### PR TITLE
test: overlap native fs-safe probes within asset phases

### DIFF
--- a/test/scripts/tsdown-config.test.ts
+++ b/test/scripts/tsdown-config.test.ts
@@ -1,5 +1,5 @@
 // Tsdown config tests protect package artifact build contracts.
-import { spawnSync } from "node:child_process";
+import { execFile } from "node:child_process";
 import { createHash } from "node:crypto";
 import fs from "node:fs";
 import { createRequire } from "node:module";
@@ -137,7 +137,7 @@ describe("tsdown config", () => {
           relocatedRoot,
           worker ? "output/dist/native" : "dist/native",
         );
-        const probe = (
+        const probe = async (
           name: string,
           mode: string,
           outcome: string,
@@ -145,51 +145,74 @@ describe("tsdown config", () => {
         ) => {
           const rootDir = path.join(relocatedRoot, name);
           fs.mkdirSync(rootDir);
-          const result = spawnSync(
-            process.execPath,
-            [
-              "--input-type=module",
-              "--eval",
-              FS_SAFE_CALLER_PROBE,
-              entry,
-              observer,
-              rootDir,
-              mode,
-              outcome,
-            ],
-            {
-              cwd: relocatedRoot,
-              encoding: "utf8",
-              timeout: 30_000,
-              env: {
-                PATH: process.env.PATH,
-                SystemRoot: process.env.SystemRoot,
-                WINDIR: process.env.WINDIR,
-                HOME: temporaryRoot,
-                USERPROFILE: temporaryRoot,
-                TMPDIR: temporaryRoot,
-                TMP: temporaryRoot,
-                TEMP: temporaryRoot,
-                ...override,
+          const result = await new Promise<{
+            error: Error | null;
+            status: number | null;
+            stdout: string;
+            stderr: string;
+          }>((resolve) => {
+            const child = execFile(
+              process.execPath,
+              [
+                "--input-type=module",
+                "--eval",
+                FS_SAFE_CALLER_PROBE,
+                entry,
+                observer,
+                rootDir,
+                mode,
+                outcome,
+              ],
+              {
+                cwd: relocatedRoot,
+                encoding: "utf8",
+                timeout: 30_000,
+                env: {
+                  PATH: process.env.PATH,
+                  SystemRoot: process.env.SystemRoot,
+                  WINDIR: process.env.WINDIR,
+                  HOME: temporaryRoot,
+                  USERPROFILE: temporaryRoot,
+                  TMPDIR: temporaryRoot,
+                  TMP: temporaryRoot,
+                  TEMP: temporaryRoot,
+                  ...override,
+                },
               },
-            },
-          );
-          expect(result.error, name).toBeUndefined();
+              (error, stdout, stderr) => resolve({ error, status: child.exitCode, stdout, stderr }),
+            );
+          });
+          expect(result.error, name).toBeNull();
           expect(result.status, `${name}\n${result.stdout}\n${result.stderr}`).toBe(0);
         };
-        for (const key of ["FS_SAFE_NATIVE_MODE", "OPENCLAW_FS_SAFE_NATIVE_MODE"]) {
-          probe(key, "require", "native", { [key]: "require" });
-        }
-        probe("shared-config", "configured", "native");
-        probe("default", "off", "fallback");
+        const joinProbes = async (probes: Promise<void>[]) => {
+          // Every child must close before assets are removed or bundles disposed,
+          // including when a sibling probe fails.
+          const results = await Promise.allSettled(probes);
+          const failures = results.flatMap((result) =>
+            result.status === "rejected" ? [result.reason] : [],
+          );
+          if (failures.length) {
+            throw new AggregateError(failures, "Native fs-safe probes failed");
+          }
+        };
+        await joinProbes([
+          ...["FS_SAFE_NATIVE_MODE", "OPENCLAW_FS_SAFE_NATIVE_MODE"].map((key) =>
+            probe(key, "require", "native", { [key]: "require" }),
+          ),
+          probe("shared-config", "configured", "native"),
+          probe("default", "off", "fallback"),
+        ]);
         const assets = nativeAssetInventory(nativeSource);
         expect(assets).toHaveLength(7);
         expect(nativeAssetInventory(nativeOutput)).toEqual(assets);
         fs.rmSync(nativeOutput, { recursive: true });
-        probe("missing", "require", "missing", { FS_SAFE_NATIVE_MODE: "require" });
-        for (const mode of ["off", "auto"]) {
-          probe(mode, mode, "fallback", { FS_SAFE_NATIVE_MODE: mode });
-        }
+        await joinProbes([
+          probe("missing", "require", "missing", { FS_SAFE_NATIVE_MODE: "require" }),
+          ...["off", "auto"].map((mode) =>
+            probe(mode, mode, "fallback", { FS_SAFE_NATIVE_MODE: mode }),
+          ),
+        ]);
       } finally {
         for (const bundle of bundles) {
           await bundle[Symbol.asyncDispose]();


### PR DESCRIPTION
## What Problem This Solves

The relocated native fs-safe artifact tests wait for fourteen independent Node probes in sequence. This adds avoidable wall time to the tooling suite even though each probe has its own data directory and process-local native loader/configuration state.

## Why This Change Was Made

Run the four probes with native assets present concurrently, wait for every child to finish, then verify and remove the assets before running the three missing-asset probes concurrently. Keep the runtime and worker builds serial, along with bundle disposal and the rest of the file. `Promise.allSettled` keeps a failing child from releasing the shared built artifact while its siblings still use it; aggregate failures retain individual probe labels.

All seventeen test registrations, fourteen real Node processes, seven native asset hashes, both environment aliases, shared configuration, default fallback, and missing-native require/off/auto outcomes remain. No production, workflow, runner configuration, dependency, or public behavior changes.

## User Impact

Developers get faster tooling tests with the same real build/relocation/native-process coverage. No end-user behavior changes.

## Evidence

Measured on one dedicated Blacksmith Testbox, one Vitest worker, separate module cache per invocation, import diagnostics and `/usr/bin/time -v`. Each set excludes A/B warmups and uses eight balanced AB/BA pairs. The initial full-file set was noisy, so a separate confirmation set was recorded without dropping any initial samples.

| Scope | Median wall A -> B | Saving | Favorable pairs | Vitest A -> B | Test body A -> B | Import A -> B |
| --- | --- | --- | --- | --- | --- | --- |
| Full file, initial | 5.331 -> 5.052 s | 5.22% | 5/8 | 1.335 -> 1.019 s | 0.960 -> 0.631 s | 0.138 -> 0.140 s |
| Full file, confirmation | 4.908 -> 4.742 s | 3.37% | 8/8 | 1.195 -> 1.010 s | 0.850 -> 0.647 s | 0.128 -> 0.131 s |
| Native table | 4.892 -> 4.529 s | 7.42% | 8/8 | 0.984 -> 0.707 s | 0.621 -> 0.348 s | 0.137 -> 0.131 s |

Confirmation full-file GNU-time median max RSS: 527,686 -> 542,968 KiB; user CPU 4.975 -> 5.015 s; system CPU 0.495 -> 0.545 s. Sampled descendant peak rises 7 -> 10 and tree RSS peak 901,612 -> 1,040,112 KiB. This trades a bounded peak of four short-lived probes for lower wall time; it is not a CPU or memory reduction. Full-file timing, not filtered timing, determines retention.

The real owner fault tests changed the runtime and worker native-copy destinations independently. Each fault failed exactly its corresponding relocated target, with named native-probe failures, while the sibling target passed. Exact owner bytes were restored; full-file shuffles at seeds 17 and 91 and local seed 37 passed all 17 tests. Observation-only instrumentation counted fourteen distinct child PIDs and fourteen distinct roots, peak four probes, four completions before each native asset deletion, then three missing-asset probes. All children and roots were gone after completion.

[Blacksmith proof workflow](https://github.com/openclaw/openclaw/actions/runs/33216360107). Baseline source: `a79e6517be830ad930fc9be36d5cc7536f86089c`. The test runs real tsdown output and the installed native fs-safe binding; no mocked process, native binding, copied validator, or in-process probe substitution.

Canonical test command (with per-run cache/import/resource instrumentation around it):

```sh
node scripts/run-vitest.mjs test/scripts/tsdown-config.test.ts --maxWorkers=1 --reporter=verbose
```

Test-audit and deslop: no test cases removed or added, no new mocks or test-only production seams. Production LOC +0/-0; test LOC +63/-40 (net +23), for asynchronous process completion and phase-owned failure joining. No incidental coverage removed.

<details>
<summary>All measured whole-file wall pairs (seconds; no samples omitted)</summary>

| Set | Pair | Order | A | B | A - B |
| --- | --- | --- | --- | --- | --- |
| Initial | 1 | AB | 4.962 | 5.105 | -0.143 |
| Initial | 2 | BA | 5.470 | 5.014 | +0.456 |
| Initial | 3 | AB | 5.139 | 5.162 | -0.022 |
| Initial | 4 | BA | 5.642 | 5.090 | +0.552 |
| Initial | 5 | BA | 5.330 | 5.367 | -0.037 |
| Initial | 6 | AB | 5.332 | 4.592 | +0.739 |
| Initial | 7 | BA | 5.451 | 4.587 | +0.864 |
| Initial | 8 | AB | 5.105 | 4.791 | +0.314 |
| Confirmation | 1 | AB | 4.797 | 4.508 | +0.288 |
| Confirmation | 2 | BA | 4.807 | 4.495 | +0.312 |
| Confirmation | 3 | AB | 4.893 | 4.722 | +0.170 |
| Confirmation | 4 | BA | 5.062 | 4.764 | +0.298 |
| Confirmation | 5 | BA | 4.759 | 4.577 | +0.182 |
| Confirmation | 6 | AB | 4.923 | 4.762 | +0.160 |
| Confirmation | 7 | BA | 5.364 | 4.910 | +0.454 |
| Confirmation | 8 | AB | 5.285 | 5.126 | +0.159 |

</details>

Complete changed gate passed on the same Testbox (root test types, tooling lint, formatting, dependency and boundary guards). Fresh Codex autoreview reported no actionable findings.
