### PR TITLE
fix: allow off-catalog chat models under unrestricted policy

### DIFF
--- a/docs/concepts/models.md
+++ b/docs/concepts/models.md
@@ -111,6 +111,17 @@ Reauthentication preserves an existing explicit primary model, including
 
 ## "Model is not allowed" (and why replies stop)
 
+When `modelPolicy.allow` is omitted or empty, you can select an explicit
+`provider/model` even when it is absent from the finite `/model` picker catalog.
+The catalog supplies browse choices and model metadata; it is not an implicit
+allowlist. Provider availability, runtime compatibility, and authentication are
+validated independently. An unrestricted policy does not make an unknown
+provider or an unsupported runtime usable. If the policy is omitted, unmigrated
+legacy model-map restrictions described above still apply.
+
+The same policy applies to explicit `provider/model` and configured-alias hints
+after `/new` or `/reset`. Unrecognized leading text stays in the prompt.
+
 If `agents.defaults.modelPolicy.allow` is non-empty, it becomes the allowlist for `/model`, session overrides, and `--model`. Selecting a model outside that allowlist returns before any normal reply is generated. A per-agent `agents.entries.*.modelPolicy.allow` replaces the default policy for that agent.
 
 ```text

--- a/docs/plugins/sdk-migration.md
+++ b/docs/plugins/sdk-migration.md
@@ -83,6 +83,18 @@ External-plugin compatibility work follows this order:
 6. Remove only after the announced migration window, usually in a major
    release.
 
+### Model-provider result compatibility
+
+`openclaw/plugin-sdk/models-provider-runtime` preserves the `ModelsProviderData`
+construction shape and `buildModelsProviderData` return signature published in
+`v2026.7.1-2`, including typed adapters that return that shape. These contracts
+remain supported until an explicitly approved SDK-breaking boundary.
+
+Call `buildPreparedModelsProviderData` when forwarding model selections. Its
+result includes the required `modelCatalog` with
+the selected physical-route metadata. Both builders use one metadata producer;
+callers must carry prepared rows forward rather than reconstructing them from IDs.
+
 ### Memory read missing results
 
 Memory managers now return `status: "ok"` for successful excerpts and

--- a/extensions/discord/src/monitor/model-picker.state.ts
+++ b/extensions/discord/src/monitor/model-picker.state.ts
@@ -195,8 +195,8 @@ export async function loadDiscordModelPickerData(
   cfg: OpenClawConfig,
   agentId?: string,
 ): Promise<ModelsProviderData> {
-  const { buildModelsProviderData } = await loadModelsProviderRuntime();
-  return buildModelsProviderData(cfg, agentId);
+  const { buildPreparedModelsProviderData } = await loadModelsProviderRuntime();
+  return buildPreparedModelsProviderData(cfg, agentId);
 }
 
 export function buildDiscordModelPickerCustomId(params: {

--- a/extensions/discord/src/monitor/model-picker.test-utils.ts
+++ b/extensions/discord/src/monitor/model-picker.test-utils.ts
@@ -23,6 +23,5 @@ export function createModelsProviderData(
       model: entries[defaultProvider]?.[0] ?? "gpt-4o",
     },
     modelNames: new Map<string, string>(),
-    modelCatalog: [],
   };
 }

--- a/extensions/discord/src/monitor/model-picker.test-utils.ts
+++ b/extensions/discord/src/monitor/model-picker.test-utils.ts
@@ -23,5 +23,6 @@ export function createModelsProviderData(
       model: entries[defaultProvider]?.[0] ?? "gpt-4o",
     },
     modelNames: new Map<string, string>(),
+    modelCatalog: [],
   };
 }

--- a/extensions/discord/src/monitor/model-picker.test.ts
+++ b/extensions/discord/src/monitor/model-picker.test.ts
@@ -34,10 +34,10 @@ function parseDiscordModelPickerCustomId(customId: string) {
     : null;
 }
 
-const buildModelsProviderDataMock = vi.hoisted(() => vi.fn());
+const buildPreparedModelsProviderDataMock = vi.hoisted(() => vi.fn());
 
 vi.mock("openclaw/plugin-sdk/models-provider-runtime", () => ({
-  buildModelsProviderData: buildModelsProviderDataMock,
+  buildPreparedModelsProviderData: buildPreparedModelsProviderDataMock,
 }));
 
 type SerializedComponent = {
@@ -92,15 +92,15 @@ function requireValue<T>(value: T | null | undefined, message: string): T {
 }
 
 describe("loadDiscordModelPickerData", () => {
-  it("reuses buildModelsProviderData as source of truth with agent scope", async () => {
+  it("reuses buildPreparedModelsProviderData as source of truth with agent scope", async () => {
     const expected = createModelsProviderData({ openai: ["gpt-4o"] });
     const cfg = EMPTY_DISCORD_TEST_CONFIG;
-    buildModelsProviderDataMock.mockResolvedValue(expected);
+    buildPreparedModelsProviderDataMock.mockResolvedValue(expected);
 
     const result = await loadDiscordModelPickerData(cfg, "support");
 
-    expect(buildModelsProviderDataMock).toHaveBeenCalledTimes(1);
-    expect(buildModelsProviderDataMock).toHaveBeenCalledWith(cfg, "support");
+    expect(buildPreparedModelsProviderDataMock).toHaveBeenCalledTimes(1);
+    expect(buildPreparedModelsProviderDataMock).toHaveBeenCalledWith(cfg, "support");
     expect(result).toBe(expected);
   });
 });

--- a/extensions/discord/src/monitor/native-command.think-autocomplete.test.ts
+++ b/extensions/discord/src/monitor/native-command.think-autocomplete.test.ts
@@ -44,7 +44,7 @@ const resolveConfiguredBindingRouteMock = vi.hoisted(() =>
 const providerThinkingMocks = vi.hoisted(() => ({
   resolveProviderThinkingProfile: vi.fn(),
 }));
-const buildModelsProviderDataMock = vi.hoisted(() => vi.fn());
+const buildPreparedModelsProviderDataMock = vi.hoisted(() => vi.fn());
 
 type ConfiguredBindingRoute = ConfiguredBindingRouteResult;
 type ConfiguredBindingResolution = NonNullable<ConfiguredBindingRoute["bindingResolution"]>;
@@ -122,7 +122,7 @@ vi.mock("openclaw/plugin-sdk/agent-runtime", () => ({
 }));
 
 vi.mock("openclaw/plugin-sdk/models-provider-runtime", () => ({
-  buildModelsProviderData: buildModelsProviderDataMock,
+  buildPreparedModelsProviderData: buildPreparedModelsProviderDataMock,
 }));
 
 const STORE_PATH = path.join(
@@ -200,7 +200,7 @@ describe("discord native /think autocomplete", () => {
             }
           : undefined,
     );
-    buildModelsProviderDataMock.mockResolvedValue({
+    buildPreparedModelsProviderDataMock.mockResolvedValue({
       byProvider: new Map<string, Set<string>>(),
       providers: [],
       resolvedDefault: {

--- a/extensions/mattermost/runtime-api.ts
+++ b/extensions/mattermost/runtime-api.ts
@@ -38,7 +38,7 @@ export {
   resolveControlCommandGate,
   resolveStoredModelOverride,
 } from "openclaw/plugin-sdk/command-auth-native";
-export { buildModelsProviderData } from "openclaw/plugin-sdk/models-provider-runtime";
+export { buildPreparedModelsProviderData } from "openclaw/plugin-sdk/models-provider-runtime";
 export {
   GROUP_POLICY_BLOCKED_LABEL,
   resolveAllowlistProviderRuntimeGroupPolicy,

--- a/extensions/mattermost/src/mattermost/model-picker.test.ts
+++ b/extensions/mattermost/src/mattermost/model-picker.test.ts
@@ -29,6 +29,7 @@ const data = {
     model: "claude-opus-4-5",
   },
   modelNames: new Map<string, string>(),
+  modelCatalog: [],
 };
 
 describe("Mattermost model picker", () => {
@@ -202,6 +203,7 @@ describe("Mattermost model picker", () => {
           model: "gpt-5",
         },
         modelNames: new Map<string, string>(),
+        modelCatalog: [],
       };
 
       expect(

--- a/extensions/mattermost/src/mattermost/monitor-model-picker.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor-model-picker.test.ts
@@ -4,7 +4,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const mocks = vi.hoisted(() => ({
   authorize: vi.fn(),
   buildEventPlan: vi.fn(),
-  buildModelsProviderData: vi.fn(),
+  buildPreparedModelsProviderData: vi.fn(),
   deliverReply: vi.fn(),
   dispatch: vi.fn(),
   parseContext: vi.fn(),
@@ -39,7 +39,7 @@ vi.mock("./runtime-api.js", async () => {
   const actual = await vi.importActual<typeof import("./runtime-api.js")>("./runtime-api.js");
   return {
     ...actual,
-    buildModelsProviderData: mocks.buildModelsProviderData,
+    buildPreparedModelsProviderData: mocks.buildPreparedModelsProviderData,
   };
 });
 
@@ -66,7 +66,7 @@ describe("Mattermost model-picker interaction dispatch", () => {
       channelDisplay: "Lifecycle",
       roomLabel: "#lifecycle",
     });
-    mocks.buildModelsProviderData.mockResolvedValue({ providers: [{ id: "openai" }] });
+    mocks.buildPreparedModelsProviderData.mockResolvedValue({ providers: [{ id: "openai" }] });
     mocks.deliverReply.mockResolvedValue({
       outcome: "text",
       visibleReplySent: true,

--- a/extensions/mattermost/src/mattermost/monitor-model-picker.ts
+++ b/extensions/mattermost/src/mattermost/monitor-model-picker.ts
@@ -18,7 +18,7 @@ import { buildMattermostEventPlan, type MattermostEventPlan } from "./monitor-ev
 import type { MattermostMonitorContext } from "./monitor-types.js";
 import { deliverMattermostReplyPayload } from "./reply-delivery.js";
 import type { ReplyPayload } from "./runtime-api.js";
-import { buildModelsProviderData } from "./runtime-api.js";
+import { buildPreparedModelsProviderData } from "./runtime-api.js";
 import { sendMessageMattermost } from "./send.js";
 
 type RunModelPickerCommandParams = {
@@ -203,7 +203,7 @@ export function createMattermostModelPickerInteractionHandler(
       agentId: eventPlan.route.agentId,
       sessionKey: eventPlan.thread.sessionKey,
     };
-    const data = await buildModelsProviderData(cfg, eventPlan.route.agentId);
+    const data = await buildPreparedModelsProviderData(cfg, eventPlan.route.agentId);
     if (data.providers.length === 0) {
       return await updatePickerPost("No models available.");
     }

--- a/extensions/mattermost/src/mattermost/runtime-api.ts
+++ b/extensions/mattermost/src/mattermost/runtime-api.ts
@@ -16,7 +16,7 @@ export { createChannelPairingController } from "openclaw/plugin-sdk/channel-pair
 export { createChannelMessageReplyPipeline } from "openclaw/plugin-sdk/channel-outbound";
 export { logTypingFailure } from "openclaw/plugin-sdk/channel-feedback";
 export { listSkillCommandsForAgents } from "openclaw/plugin-sdk/command-auth-native";
-export { buildModelsProviderData } from "openclaw/plugin-sdk/models-provider-runtime";
+export { buildPreparedModelsProviderData } from "openclaw/plugin-sdk/models-provider-runtime";
 export { isDangerousNameMatchingEnabled } from "openclaw/plugin-sdk/dangerous-name-runtime";
 export {
   resolveAllowlistProviderRuntimeGroupPolicy,

--- a/extensions/mattermost/src/mattermost/slash-http.send-config.test.ts
+++ b/extensions/mattermost/src/mattermost/slash-http.send-config.test.ts
@@ -18,7 +18,7 @@ const mockState = vi.hoisted(() => ({
     team_id: "team-1",
   })),
   resolveCommandText: vi.fn((_trigger: string, text: string) => text),
-  buildModelsProviderData: vi.fn(async () => ({ providers: [], modelNames: new Map() })),
+  buildPreparedModelsProviderData: vi.fn(async () => ({ providers: [], modelNames: new Map() })),
   resolveMattermostModelPickerEntry: vi.fn((): { kind: string } | null => ({ kind: "summary" })),
   authorizeMattermostCommandInvocation: vi.fn(() => ({
     ok: true,
@@ -54,7 +54,7 @@ const mockState = vi.hoisted(() => ({
 
 vi.mock("./runtime-api.js", () => {
   return {
-    buildModelsProviderData: mockState.buildModelsProviderData,
+    buildPreparedModelsProviderData: mockState.buildPreparedModelsProviderData,
     createChannelMessageReplyPipeline: vi.fn(() => ({
       onModelSelected: vi.fn(),
       typingCallbacks: {},
@@ -216,7 +216,7 @@ describe("slash-http cfg threading", () => {
     mockState.readRequestBodyWithLimit.mockClear();
     mockState.parseSlashCommandPayload.mockClear();
     mockState.resolveCommandText.mockClear();
-    mockState.buildModelsProviderData.mockClear();
+    mockState.buildPreparedModelsProviderData.mockClear();
     mockState.resolveMattermostModelPickerEntry.mockClear();
     mockState.authorizeMattermostCommandInvocation.mockClear();
     mockState.createMattermostClient.mockClear();

--- a/extensions/mattermost/src/mattermost/slash-http.ts
+++ b/extensions/mattermost/src/mattermost/slash-http.ts
@@ -36,7 +36,7 @@ import {
 } from "./monitor-auth.js";
 import { deliverMattermostReplyPayload } from "./reply-delivery.js";
 import {
-  buildModelsProviderData,
+  buildPreparedModelsProviderData,
   isRequestBodyLimitError,
   logTypingFailure,
   readRequestBodyWithLimit,
@@ -787,7 +787,7 @@ async function handleSlashCommandAsync(params: {
   const to = kind === "direct" ? `user:${senderId}` : `channel:${channelId}`;
   const pickerEntry = resolveMattermostModelPickerEntry(commandText);
   if (pickerEntry) {
-    const data = await buildModelsProviderData(cfg, route.agentId);
+    const data = await buildPreparedModelsProviderData(cfg, route.agentId);
     if (data.providers.length === 0) {
       await sendMessageMattermost(`channel:${channelId}`, "No models available.", {
         cfg,

--- a/extensions/telegram/src/bot-deps.ts
+++ b/extensions/telegram/src/bot-deps.ts
@@ -17,7 +17,7 @@ import {
   recordInboundSession,
   upsertChannelPairingRequest,
 } from "openclaw/plugin-sdk/conversation-runtime";
-import { buildModelsProviderData } from "openclaw/plugin-sdk/models-provider-runtime";
+import { buildPreparedModelsProviderData } from "openclaw/plugin-sdk/models-provider-runtime";
 import { dispatchReplyWithBufferedBlockDispatcher } from "openclaw/plugin-sdk/reply-dispatch-runtime";
 import { resolveInboundLastRouteSessionKey } from "openclaw/plugin-sdk/routing";
 import { getRuntimeConfig } from "openclaw/plugin-sdk/runtime-config-snapshot";
@@ -72,7 +72,7 @@ export type TelegramBotDeps = {
   enqueueSystemEvent: typeof enqueueSystemEvent;
   dispatchReplyWithBufferedBlockDispatcher: typeof dispatchReplyWithBufferedBlockDispatcher;
   loadWebMedia?: typeof loadWebMedia;
-  buildModelsProviderData: typeof buildModelsProviderData;
+  buildModelsProviderData: typeof buildPreparedModelsProviderData;
   listSkillCommandsForAgents: typeof listSkillCommandsForAgents;
   syncTelegramMenuCommands?: typeof syncTelegramMenuCommands;
   wasSentByBot: typeof wasSentByBot;
@@ -136,7 +136,7 @@ export const defaultTelegramBotDeps: TelegramBotDeps = {
     return loadWebMedia;
   },
   get buildModelsProviderData() {
-    return buildModelsProviderData;
+    return buildPreparedModelsProviderData;
   },
   get listSkillCommandsForAgents() {
     return listSkillCommandsForAgents;

--- a/extensions/telegram/src/bot-handlers.callback-router.ts
+++ b/extensions/telegram/src/bot-handlers.callback-router.ts
@@ -637,9 +637,6 @@ async function handleTelegramModelCallback(params: {
     };
     const previousAuthProfileId = sessionEntry.authProfileOverride?.trim();
     const sessionStore = { [sessionState.sessionKey]: sessionEntry };
-    const modelCatalog = [...byProvider.entries()].flatMap(([provider, models]) =>
-      [...models].map((model) => ({ provider, id: model, name: model })),
-    );
     const currentModelRef = sessionState.model?.trim();
     const currentModelSeparator = currentModelRef?.indexOf("/") ?? -1;
     const currentProvider =
@@ -663,8 +660,7 @@ async function handleTelegramModelCallback(params: {
         defaultModel: resolvedDefault.model,
         currentProvider,
         currentModel,
-        allowedModelKeys: new Set(modelCatalog.map((entry) => `${entry.provider}/${entry.id}`)),
-        modelCatalog,
+        modelCatalog: modelData.modelCatalog,
         canPersistStickyModelSelection: false,
         request: {
           provider: selection.provider,

--- a/extensions/telegram/src/bot-message-dispatch.test-harness.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test-harness.ts
@@ -65,6 +65,7 @@ const buildModelsProviderDataHoisted = vi.hoisted(() =>
     providers: [],
     resolvedDefault: { provider: "openai", model: "gpt-test" },
     modelNames: new Map<string, string>(),
+    modelCatalog: [],
   })),
 );
 const listSkillCommandsForAgentsHoisted = vi.hoisted(() => vi.fn(() => []));
@@ -442,12 +443,6 @@ function resetTelegramDispatchTestState() {
     created: true,
   });
   enqueueSystemEvent.mockResolvedValue(undefined);
-  buildModelsProviderData.mockResolvedValue({
-    byProvider: new Map<string, Set<string>>(),
-    providers: [],
-    resolvedDefault: { provider: "openai", model: "gpt-test" },
-    modelNames: new Map<string, string>(),
-  });
   listSkillCommandsForAgents.mockReturnValue([]);
   createChannelMessageReplyPipeline.mockReturnValue({
     responsePrefix: undefined,

--- a/extensions/telegram/src/bot.create-telegram-bot.test-harness.ts
+++ b/extensions/telegram/src/bot.create-telegram-bot.test-harness.ts
@@ -254,12 +254,9 @@ function resolveDefaultModelForAgentForTest(params: { cfg: OpenClawConfig }): {
   };
 }
 
-function createModelsProviderDataFromConfig(cfg: OpenClawConfig): {
-  byProvider: Map<string, Set<string>>;
-  providers: string[];
-  resolvedDefault: { provider: string; model: string };
-  modelNames: Map<string, string>;
-} {
+function createModelsProviderDataFromConfig(
+  cfg: OpenClawConfig,
+): Awaited<ReturnType<TelegramBotDeps["buildModelsProviderData"]>> {
   const byProvider = new Map<string, Set<string>>();
   const add = (providerRaw: string | undefined, modelRaw: string | undefined) => {
     const provider = normalizeLowercaseStringOrEmptyForTest(providerRaw);
@@ -281,7 +278,15 @@ function createModelsProviderDataFromConfig(cfg: OpenClawConfig): {
   }
 
   const providers = [...byProvider.keys()].toSorted();
-  return { byProvider, providers, resolvedDefault, modelNames: new Map<string, string>() };
+  return {
+    byProvider,
+    providers,
+    resolvedDefault,
+    modelNames: new Map<string, string>(),
+    modelCatalog: [...byProvider].flatMap(([provider, models]) =>
+      [...models].map((id) => ({ provider, id, name: id, reasoning: false })),
+    ),
+  };
 }
 
 const systemEventsHoisted = vi.hoisted(() => ({

--- a/extensions/telegram/src/bot.media.e2e.test-harness.ts
+++ b/extensions/telegram/src/bot.media.e2e.test-harness.ts
@@ -255,6 +255,7 @@ export const telegramBotDepsForTest: TelegramBotDeps = {
     providers: [],
     resolvedDefault: { provider: "openai", model: "gpt-4.1" },
     modelNames: new Map<string, string>(),
+    modelCatalog: [],
   })) as TelegramBotDeps["buildModelsProviderData"],
   listSkillCommandsForAgents: vi.fn(() => []) as TelegramBotDeps["listSkillCommandsForAgents"],
   wasSentByBot: vi.fn(() => false) as TelegramBotDeps["wasSentByBot"],

--- a/extensions/telegram/src/bot.test.ts
+++ b/extensions/telegram/src/bot.test.ts
@@ -2780,6 +2780,17 @@ describe("createTelegramBot", () => {
           providers: ["anthropic", "openai"],
           resolvedDefault: { provider: defaultProvider, model: defaultModel },
           modelNames: new Map(),
+          modelCatalog: [
+            { provider: "openai", id: "gpt-4o", name: "GPT-4o", reasoning: false },
+            { provider: "openai", id: "gpt-4.1", name: "GPT-4.1", reasoning: false },
+            { provider: "openai", id: "gpt-5", name: "GPT-5", reasoning: true },
+            {
+              provider: "anthropic",
+              id: "claude-sonnet-4-5",
+              name: "Claude Sonnet",
+              reasoning: true,
+            },
+          ],
         });
 
         loadConfig.mockReturnValue(config);
@@ -2816,6 +2827,7 @@ describe("createTelegramBot", () => {
       byProvider: new Map<string, Set<string>>([["openai", new Set(["gpt-5", "gpt-4.1"])]]),
       providers: ["openai"],
       resolvedDefault: { provider: "openai", model: "gpt-5" },
+      modelCatalog: [],
       modelNames: new Map<string, string>([
         ["openai/gpt-4.1", "GPT 4.1 Bridge"],
         ["openai/gpt-5", "GPT Five Bridge"],

--- a/extensions/telegram/src/delivery-trace.test.ts
+++ b/extensions/telegram/src/delivery-trace.test.ts
@@ -183,6 +183,7 @@ function createTraceTelegramDeps(captured: CapturedDispatch): TelegramBotDeps {
       providers: [],
       resolvedDefault: { provider: "openai", model: "gpt-test" },
       modelNames: new Map<string, string>(),
+      modelCatalog: [],
     })) as unknown as TelegramBotDeps["buildModelsProviderData"],
     listSkillCommandsForAgents:
       (() => []) as unknown as TelegramBotDeps["listSkillCommandsForAgents"],

--- a/extensions/telegram/src/model-callback.loopback.integration.test.ts
+++ b/extensions/telegram/src/model-callback.loopback.integration.test.ts
@@ -6,10 +6,9 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { Bot } from "grammy";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
-import type { ModelsProviderData } from "openclaw/plugin-sdk/models-provider-runtime";
 import { listSessionEntries } from "openclaw/plugin-sdk/session-store-runtime";
 import { afterEach, describe, expect, it } from "vitest";
-import { defaultTelegramBotDeps } from "./bot-deps.js";
+import { defaultTelegramBotDeps, type TelegramBotDeps } from "./bot-deps.js";
 import type { TelegramCallbackMessageRuntime } from "./bot-handlers.callback-router-controls.js";
 import { createTelegramCallbackRouter } from "./bot-handlers.callback-router.js";
 import type { TelegramHandlerAuthorization } from "./bot-handlers.inbound-authorization.js";
@@ -143,7 +142,9 @@ describe("Telegram model callback loopback", () => {
       const bot = new Bot(TOKEN, { botInfo: telegramBotInfoForTest, client: { apiRoot } });
       const telegramDeps = {
         ...defaultTelegramBotDeps,
-        buildModelsProviderData: async (): Promise<ModelsProviderData> => {
+        buildModelsProviderData: async (): ReturnType<
+          TelegramBotDeps["buildModelsProviderData"]
+        > => {
           callbackSteps.push("catalog");
           return {
             byProvider: new Map([

--- a/extensions/telegram/src/model-callback.loopback.integration.test.ts
+++ b/extensions/telegram/src/model-callback.loopback.integration.test.ts
@@ -6,6 +6,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { Bot } from "grammy";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import type { ModelsProviderData } from "openclaw/plugin-sdk/models-provider-runtime";
 import { listSessionEntries } from "openclaw/plugin-sdk/session-store-runtime";
 import { afterEach, describe, expect, it } from "vitest";
 import { defaultTelegramBotDeps } from "./bot-deps.js";
@@ -142,7 +143,7 @@ describe("Telegram model callback loopback", () => {
       const bot = new Bot(TOKEN, { botInfo: telegramBotInfoForTest, client: { apiRoot } });
       const telegramDeps = {
         ...defaultTelegramBotDeps,
-        buildModelsProviderData: async () => {
+        buildModelsProviderData: async (): Promise<ModelsProviderData> => {
           callbackSteps.push("catalog");
           return {
             byProvider: new Map([
@@ -152,6 +153,16 @@ describe("Telegram model callback loopback", () => {
             providers: ["anthropic", PROVIDER],
             resolvedDefault: { provider: "anthropic", model: "claude-opus-4-6" },
             modelNames: new Map<string, string>(),
+            modelCatalog: [
+              {
+                provider: PROVIDER,
+                id: MODEL,
+                name: MODEL,
+                api: "ollama",
+                contextWindow: 32_768,
+                reasoning: true,
+              },
+            ],
           };
         },
         getRuntimeConfig: () => config,

--- a/extensions/telegram/src/telegram-ingress-coalescing.e2e.test.ts
+++ b/extensions/telegram/src/telegram-ingress-coalescing.e2e.test.ts
@@ -177,6 +177,7 @@ function createTelegramDeps(stateDir: string): TelegramBotDeps {
       providers: [],
       resolvedDefault: { provider: "openai", model: "gpt-test" },
       modelNames: new Map<string, string>(),
+      modelCatalog: [],
     }),
     listSkillCommandsForAgents: () => [],
     wasSentByBot: () => false,

--- a/scripts/check-plugin-sdk-exports.mts
+++ b/scripts/check-plugin-sdk-exports.mts
@@ -81,7 +81,28 @@ import { prepareHostChannelContextAdmissionEvidence } from "openclaw/plugin-sdk/
 // @ts-expect-error Plugins cannot register host evidence owners.
 import { registerChannelAdmissionEvidenceOwner } from "openclaw/plugin-sdk/channel-ingress-runtime";
 import { createPluginRuntimeStore, type PluginRuntime } from "openclaw/plugin-sdk/runtime-store";
+import type { buildModelsProviderData, buildPreparedModelsProviderData, ModelsProviderData } from "openclaw/plugin-sdk/models-provider-runtime";
+import type { buildModelsProviderData as buildCommandAuthModelsProviderData } from "openclaw/plugin-sdk/command-auth";
 import { z } from "zod";
+
+// Stable v2026.7.1-2 consumers construct these results and supply typed adapters.
+const legacyModelsData = {
+  byProvider: new Map<string, Set<string>>(),
+  providers: [],
+  resolvedDefault: { provider: "fixture-provider", model: "fixture-model" },
+  modelNames: new Map<string, string>(),
+};
+const modelsData: ModelsProviderData = legacyModelsData;
+const modelsAdapter: typeof buildModelsProviderData = async () => legacyModelsData;
+const commandAuthModelsAdapter: typeof buildCommandAuthModelsProviderData = modelsAdapter;
+void modelsData;
+void commandAuthModelsAdapter;
+declare const preparedModelsData: Awaited<ReturnType<typeof buildPreparedModelsProviderData>>;
+const preparedCatalog: { id: string; provider: string; contextWindow?: number }[] = preparedModelsData.modelCatalog;
+void preparedCatalog;
+// @ts-expect-error Prepared selections require their typed catalog metadata.
+const incompletePrepared: typeof preparedModelsData = legacyModelsData;
+void incompletePrepared;
 
 const identifierAuthentication: IdentifierAuthentication = "verified";
 const meetsMinimum: boolean = meetsIdentifierAuthentication(identifierAuthentication, "asserted");

--- a/scripts/plugin-sdk-surface-report.mts
+++ b/scripts/plugin-sdk-surface-report.mts
@@ -325,7 +325,8 @@ export function readPluginSdkSurfaceBudgets(env: NodeJS.ProcessEnv = process.env
       // +1: downstream strength mappers need canonical ordering instead of duplicate rank tables.
       // +1: focused account media-limit resolver avoids the deprecated barrel on startup.
       // +1: shared bounded HTTP rejection transport replaces plugin-local close policies.
-      4351,
+      // +1: prepared model-provider builder preserves the stable builder's return contract.
+      4352,
       env,
     ),
     publicFunctionExports: readPluginSdkSurfaceBudgetEnv(
@@ -427,7 +428,8 @@ export function readPluginSdkSurfaceBudgets(env: NodeJS.ProcessEnv = process.env
       // +1: downstream strength mappers need canonical ordering instead of duplicate rank tables.
       // +1: focused account media-limit resolver avoids the deprecated barrel on startup.
       // +1: shared bounded HTTP rejection transport replaces plugin-local close policies.
-      2587,
+      // +1: prepared model-provider builder preserves the stable builder's return contract.
+      2588,
       env,
     ),
     publicDeprecatedExports: readPluginSdkSurfaceBudgetEnv(

--- a/src/auto-reply/reply.directive.directive-behavior.prefers-alias-matches-fuzzy-selection-is-ambiguous.test.ts
+++ b/src/auto-reply/reply.directive.directive-behavior.prefers-alias-matches-fuzzy-selection-is-ambiguous.test.ts
@@ -23,6 +23,7 @@ function resolveModel(
     defaultModel: params?.defaultModel ?? "claude-opus-4-6",
     aliasIndex: params?.aliasIndex ?? emptyAliasIndex,
     allowedModelKeys: new Set(params?.allowedModelKeys ?? []),
+    cfg: { agents: { defaults: { modelPolicy: { allow: params?.allowedModelKeys ?? [] } } } },
   });
 }
 

--- a/src/auto-reply/reply/commands-models.test.ts
+++ b/src/auto-reply/reply/commands-models.test.ts
@@ -9,7 +9,7 @@ import {
   createChannelTestPluginBase,
   createTestRegistry,
 } from "../../test-utils/channel-plugins.js";
-import { buildModelsProviderData, handleModelsCommand } from "./commands-models.js";
+import { buildPreparedModelsProviderData, handleModelsCommand } from "./commands-models.js";
 import type { HandleCommandsParams } from "./commands-types.js";
 
 const modelCatalogMocks = vi.hoisted(() => ({ loadModelCatalog: vi.fn() }));
@@ -192,7 +192,7 @@ beforeAll(async () => {
   modelCatalogMocks.loadModelCatalog.mockResolvedValue([
     { provider: "anthropic", id: "claude-opus-4-5", name: "Claude Opus" },
   ]);
-  await buildModelsProviderData({
+  await buildPreparedModelsProviderData({
     agents: { defaults: { model: { primary: "anthropic/claude-opus-4-5" } } },
   } as OpenClawConfig);
 });
@@ -396,7 +396,7 @@ describe("handleModelsCommand", () => {
       },
     } as OpenClawConfig;
 
-    await buildModelsProviderData(cfg, "worker");
+    await buildPreparedModelsProviderData(cfg, "worker");
 
     expect(modelCatalogMocks.loadModelCatalog).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -436,7 +436,7 @@ describe("handleModelsCommand", () => {
       },
     ]);
 
-    const data = await buildModelsProviderData({
+    const data = await buildPreparedModelsProviderData({
       agents: { defaults: { model: { primary: "anthropic/claude-opus-4-5" } } },
     } as OpenClawConfig);
 
@@ -486,7 +486,7 @@ describe("handleModelsCommand", () => {
         selected,
       ]);
 
-      const data = await buildModelsProviderData(
+      const data = await buildPreparedModelsProviderData(
         {
           agents: { defaults: { model: { primary: "anthropic/claude-opus-4-5" } } },
         } as OpenClawConfig,
@@ -517,7 +517,7 @@ describe("handleModelsCommand", () => {
       { provider: "custom", id: "modern", name: "Modern" },
     ]);
     modelProviderAuthMocks.authenticatedProviders = new Set(["custom"]);
-    const data = await buildModelsProviderData({
+    const data = await buildPreparedModelsProviderData({
       agents: {
         defaults: {
           model: { primary: "custom/modern" },
@@ -605,7 +605,7 @@ describe("handleModelsCommand", () => {
     ]);
     modelProviderAuthMocks.authenticatedProviders = new Set(["claude-cli"]);
 
-    const data = await buildModelsProviderData({
+    const data = await buildPreparedModelsProviderData({
       agents: {
         defaults: {
           model: { primary: "anthropic/claude-opus-4-7" },
@@ -659,7 +659,7 @@ describe("handleModelsCommand", () => {
     ]);
     modelProviderAuthMocks.authenticatedProviders = new Set(["anthropic", "acme-cli"]);
 
-    const data = await buildModelsProviderData({
+    const data = await buildPreparedModelsProviderData({
       agents: {
         defaults: {
           model: { primary: "anthropic/claude-opus-4-7" },
@@ -687,7 +687,7 @@ describe("handleModelsCommand", () => {
     ]);
     modelProviderAuthMocks.authenticatedProviders = new Set(["anthropic", "claude-cli", "minimax"]);
 
-    const minimaxData = await buildModelsProviderData({
+    const minimaxData = await buildPreparedModelsProviderData({
       agents: {
         defaults: {
           model: { primary: "anthropic/claude-opus-4-7" },
@@ -745,7 +745,7 @@ describe("handleModelsCommand", () => {
   });
 
   it("labels the OpenAI default runtime choice as Codex", async () => {
-    const data = await buildModelsProviderData({
+    const data = await buildPreparedModelsProviderData({
       agents: {
         defaults: {
           model: { primary: "openai/gpt-5.5" },
@@ -766,7 +766,7 @@ describe("handleModelsCommand", () => {
   });
 
   it("keeps custom OpenAI-compatible providers on the OpenClaw default runtime choice", async () => {
-    const data = await buildModelsProviderData({
+    const data = await buildPreparedModelsProviderData({
       models: {
         providers: {
           openai: {
@@ -790,7 +790,7 @@ describe("handleModelsCommand", () => {
   });
 
   it("lets exact model runtime policy override provider runtime policy in picker choices", async () => {
-    const data = await buildModelsProviderData({
+    const data = await buildPreparedModelsProviderData({
       models: {
         providers: {
           openai: {
@@ -829,7 +829,7 @@ describe("handleModelsCommand", () => {
       { provider: "anthropic", id: "claude-sonnet-4-5", name: "Claude Sonnet" },
     ]);
 
-    const data = await buildModelsProviderData({
+    const data = await buildPreparedModelsProviderData({
       agents: {
         defaults: {
           model: { primary: "openai/gpt-5.5" },
@@ -854,7 +854,7 @@ describe("handleModelsCommand", () => {
       { provider: "anthropic", id: "claude-sonnet-4-5", name: "Claude Sonnet" },
     ]);
 
-    const data = await buildModelsProviderData({
+    const data = await buildPreparedModelsProviderData({
       agents: {
         defaults: {
           model: { primary: "openai/gpt-5.5" },
@@ -885,7 +885,7 @@ describe("handleModelsCommand", () => {
     ]);
     modelProviderAuthMocks.authenticatedProviders = new Set(["clawrouter", "openai"]);
 
-    const data = await buildModelsProviderData({
+    const data = await buildPreparedModelsProviderData({
       agents: { defaults: { modelPolicy: { allow: ["clawrouter/anthropic/*"] } } },
     } as OpenClawConfig);
 
@@ -1005,7 +1005,7 @@ describe("handleModelsCommand", () => {
       },
     } satisfies Partial<OpenClawConfig>;
 
-    const data = await buildModelsProviderData(cfg as OpenClawConfig);
+    const data = await buildPreparedModelsProviderData(cfg as OpenClawConfig);
 
     expect([...(data.byProvider.get("openai") ?? [])]).toEqual(["gpt-5.4"]);
     expect([...(data.byProvider.get("deepseek") ?? [])].toSorted()).toEqual([

--- a/src/auto-reply/reply/commands-models.test.ts
+++ b/src/auto-reply/reply/commands-models.test.ts
@@ -456,41 +456,49 @@ describe("handleModelsCommand", () => {
     );
   });
 
-  it("uses the selected route's logical model name", async () => {
-    modelProviderAuthMocks.selectedRoute = {
-      api: "openai-chatgpt-responses",
-      baseUrl: "https://chatgpt.com/backend-api/codex",
-      authRequirement: "subscription",
-      requestTransportOverrides: "none",
-    };
-    modelCatalogMocks.loadModelCatalog.mockResolvedValue([
-      {
-        provider: "openai",
-        id: "gpt-5.5",
-        name: "Platform GPT-5.5",
-        api: "openai-responses",
-        baseUrl: "https://api.openai.com/v1",
-      },
-      {
+  it.each(["default", "all"] as const)(
+    "retains selected route metadata for %s browse",
+    async (view) => {
+      modelProviderAuthMocks.selectedRoute = {
+        api: "openai-chatgpt-responses",
+        baseUrl: "https://chatgpt.com/backend-api/codex",
+        authRequirement: "subscription",
+        requestTransportOverrides: "none",
+      };
+      const selected = {
         provider: "openai",
         id: "gpt-5.5",
         name: "ChatGPT GPT-5.5",
         api: "openai-chatgpt-responses",
         baseUrl: "https://chatgpt.com/backend-api/codex",
-      },
-    ]);
+        reasoning: true,
+        contextWindow: 128_000,
+        thinkingLevelMap: { high: "high", xhigh: "xhigh" },
+      };
+      modelCatalogMocks.loadModelCatalog.mockResolvedValue([
+        {
+          ...selected,
+          name: "Platform GPT-5.5",
+          api: "openai-responses",
+          baseUrl: "https://api.openai.com/v1",
+          contextWindow: 32_000,
+        },
+        selected,
+      ]);
 
-    const data = await buildModelsProviderData(
-      {
-        agents: { defaults: { model: { primary: "anthropic/claude-opus-4-5" } } },
-      } as OpenClawConfig,
-      undefined,
-      { view: "all" },
-    );
+      const data = await buildModelsProviderData(
+        {
+          agents: { defaults: { model: { primary: "anthropic/claude-opus-4-5" } } },
+        } as OpenClawConfig,
+        undefined,
+        { view },
+      );
 
-    expect(data.byProvider.get("openai")).toEqual(new Set(["gpt-5.5"]));
-    expect(data.modelNames.get("openai/gpt-5.5")).toBe("ChatGPT GPT-5.5");
-  });
+      expect(data.byProvider.get("openai")).toEqual(new Set(["gpt-5.5"]));
+      expect(data.modelNames.get("openai/gpt-5.5")).toBe("ChatGPT GPT-5.5");
+      expect(data.modelCatalog.filter((entry) => entry.provider === "openai")).toEqual([selected]);
+    },
+  );
 
   it("shows plugin-normalized allowlist models in browse data", async () => {
     pluginMetadataMocks.getCurrent.mockReturnValue({

--- a/src/auto-reply/reply/commands-models.ts
+++ b/src/auto-reply/reply/commands-models.ts
@@ -60,8 +60,11 @@ export type ModelsProviderData = {
   providers: string[];
   resolvedDefault: { provider: string; model: string };
   modelNames: Map<string, string>;
-  modelCatalog: ModelCatalogEntry[];
   runtimeChoicesByProvider?: Map<string, ModelsRuntimeChoice[]>;
+};
+
+type PreparedModelsProviderData = ModelsProviderData & {
+  modelCatalog: ModelCatalogEntry[];
 };
 
 export type ModelsRuntimeChoice = {
@@ -153,11 +156,11 @@ function addRuntimeChoice(
   return choices;
 }
 
-export async function buildModelsProviderData(
+export async function buildPreparedModelsProviderData(
   cfg: OpenClawConfig,
   agentId?: string,
   options: { view?: "default" | "all"; workspaceDir?: string } = {},
-): Promise<ModelsProviderData> {
+): Promise<PreparedModelsProviderData> {
   const runtimeNormalization = resolveRuntimeNormalization(cfg);
   const resolvedDefault = resolveDefaultModelForAgent({
     cfg,
@@ -586,7 +589,7 @@ export async function resolveModelsCommandReply(params: {
   const argText = body.replace(/^\/models\b/i, "").trim();
   const parsed = parseModelsArgs(argText);
 
-  const { byProvider, providers, modelNames } = await buildModelsProviderData(
+  const { byProvider, providers, modelNames } = await buildPreparedModelsProviderData(
     params.cfg,
     params.agentId,
     {

--- a/src/auto-reply/reply/commands-models.ts
+++ b/src/auto-reply/reply/commands-models.ts
@@ -18,9 +18,13 @@ import {
   resolveLogicalVisibleModelCatalog,
   type ModelCatalogAuthChecker,
 } from "../../agents/model-catalog-visibility.js";
+import type { ModelCatalogEntry } from "../../agents/model-catalog.js";
 import { createProviderAuthChecker } from "../../agents/model-provider-auth.js";
 import { isRetiredModelPickerProvider } from "../../agents/model-runtime-aliases.js";
-import { modelCatalogLogicalKey } from "../../agents/model-selection-shared.js";
+import {
+  dedupeModelCatalogEntries,
+  modelCatalogLogicalKey,
+} from "../../agents/model-selection-shared.js";
 import {
   buildModelAliasIndex,
   normalizeProviderId,
@@ -56,6 +60,7 @@ export type ModelsProviderData = {
   providers: string[];
   resolvedDefault: { provider: string; model: string };
   modelNames: Map<string, string>;
+  modelCatalog: ModelCatalogEntry[];
   runtimeChoicesByProvider?: Map<string, ModelsRuntimeChoice[]>;
 };
 
@@ -398,7 +403,16 @@ export async function buildModelsProviderData(
     runtimeChoicesByProvider.set(provider, choices);
   }
 
-  return { byProvider, providers, resolvedDefault, modelNames, runtimeChoicesByProvider };
+  return {
+    byProvider,
+    providers,
+    resolvedDefault,
+    modelNames,
+    // Selection needs the prepared capabilities, with selected physical routes
+    // ahead of other inventory rows for the same logical model.
+    modelCatalog: dedupeModelCatalogEntries([...visibleCatalog, ...catalog]),
+    runtimeChoicesByProvider,
+  };
 }
 
 function formatProviderLine(params: { provider: string; count: number }): string {

--- a/src/auto-reply/reply/directive-handling.impl.ts
+++ b/src/auto-reply/reply/directive-handling.impl.ts
@@ -24,10 +24,7 @@ import {
   resolveSupportedThinkingLevel,
 } from "../thinking.js";
 import type { ReplyPayload } from "../types.js";
-import {
-  applyModelRuntimeDirective,
-  resolveModelRuntimeDirective,
-} from "./directive-handling.model-runtime.js";
+import { applyModelRuntimeDirective } from "./directive-handling.model-runtime.js";
 import { resolveModelSelectionFromDirective } from "./directive-handling.model-selection.js";
 import { maybeHandleModelDirectiveInfo } from "./directive-handling.model.js";
 import { maybeHandleUnexpectedNativeDirectiveArguments } from "./directive-handling.native.js";
@@ -54,6 +51,10 @@ import {
 } from "./directive-handling.shared.js";
 import { resolveDirectiveRuntimeContext } from "./directive-runtime-context.js";
 import type { ReasoningLevel, ThinkLevel } from "./directives.js";
+import {
+  findSelectedCatalogEntry,
+  prepareModelSelectionRuntime,
+} from "./model-runtime-normalization.js";
 import { refreshQueuedFollowupSession } from "./queue.js";
 
 /** Handles inline directives that can be acknowledged without a model turn. */
@@ -111,7 +112,7 @@ export async function handleDirectiveOnly(
   const { activeAgentId, agentDir, runtimePolicySessionKey, runtimeIsSandboxed } =
     resolveDirectiveRuntimeContext(params);
   const shouldHintDirectRuntime = directives.hasElevatedDirective && !runtimeIsSandboxed;
-  const thinkingCatalog =
+  let thinkingCatalog =
     params.thinkingCatalog && params.thinkingCatalog.length > 0
       ? params.thinkingCatalog
       : allowedModelCatalog.length > 0
@@ -153,6 +154,7 @@ export async function handleDirectiveOnly(
     allowedModelCatalog,
     provider,
     agentId: activeAgentId,
+    modelPolicy: params.modelPolicy,
   });
   if (modelResolution.errorText) {
     return rejectModelTransaction(modelResolution.errorText);
@@ -165,27 +167,50 @@ export async function handleDirectiveOnly(
 
   const resolvedProvider = modelSelection?.provider ?? provider;
   const resolvedModel = modelSelection?.model ?? model;
-  const modelRuntimeResolution = modelSelection
-    ? resolveModelRuntimeDirective({
-        rawRuntime: directives.rawModelRuntime,
-        provider: resolvedProvider,
-        cfg: params.cfg,
-        sessionEntry,
-      })
-    : ({ kind: "unchanged" } as const);
-  if (modelRuntimeResolution.kind === "invalid") {
-    return rejectModelTransaction(modelRuntimeResolution.errorText);
+  let modelRuntimeResolution: Parameters<typeof applyModelRuntimeDirective>[1] = {
+    kind: "unchanged",
+  };
+  if (modelSelection) {
+    const prepared = await prepareModelSelectionRuntime({
+      cfg: params.cfg,
+      agentId: activeAgentId,
+      provider: resolvedProvider,
+      model: resolvedModel,
+      catalog: thinkingCatalog ?? [],
+      rawRuntime: directives.rawModelRuntime,
+      sessionEntry,
+    });
+    if (prepared.status === "rejected") {
+      return rejectModelTransaction(prepared.message);
+    }
+    thinkingCatalog = prepared.catalog;
+    modelRuntimeResolution = prepared.runtime;
   }
   const prospectiveSessionEntry = { ...sessionEntry };
   applyModelRuntimeDirective(prospectiveSessionEntry, modelRuntimeResolution);
-  const thinkingRuntime = resolveEffectiveAgentRuntime({
-    cfg: params.cfg,
+  const selectedCatalogEntry = findSelectedCatalogEntry({
+    catalog: thinkingCatalog,
     provider: resolvedProvider,
-    modelId: resolvedModel,
-    agentId: activeAgentId,
-    sessionKey: runtimePolicySessionKey,
-    sessionEntry: prospectiveSessionEntry,
+    model: resolvedModel,
   });
+  const resolveThinkingRuntime = (entry: typeof sessionEntry) =>
+    resolveEffectiveAgentRuntime({
+      cfg: params.cfg,
+      provider: resolvedProvider,
+      modelId: resolvedModel,
+      modelApi: selectedCatalogEntry?.api,
+      modelBaseUrl: selectedCatalogEntry?.baseUrl,
+      agentId: activeAgentId,
+      sessionKey: runtimePolicySessionKey,
+      sessionEntry: entry,
+    });
+  const thinkingRuntime = resolveThinkingRuntime(prospectiveSessionEntry);
+  const thinkingPolicy = {
+    provider: resolvedProvider,
+    model: resolvedModel,
+    catalog: thinkingCatalog,
+    agentRuntime: thinkingRuntime,
+  };
   const fastModeState = resolveFastModeState({
     cfg: params.cfg,
     provider: resolvedProvider,
@@ -204,11 +229,8 @@ export async function handleDirectiveOnly(
     // If no argument was provided, show the current level
     if (!directives.rawThinkLevel) {
       const level = resolveSupportedThinkingLevel({
-        provider: resolvedProvider,
-        model: resolvedModel,
+        ...thinkingPolicy,
         level: currentThinkLevel ?? "off",
-        catalog: thinkingCatalog,
-        agentRuntime: thinkingRuntime,
       });
       return acknowledgeIgnoredDirective(
         {
@@ -398,11 +420,8 @@ export async function handleDirectiveOnly(
     directives.hasThinkDirective &&
     directives.thinkLevel &&
     !isThinkingLevelSupported({
-      provider: resolvedProvider,
-      model: resolvedModel,
+      ...thinkingPolicy,
       level: directives.thinkLevel,
-      catalog: thinkingCatalog,
-      agentRuntime: thinkingRuntime,
     })
   ) {
     return rejectModelTransaction(
@@ -414,21 +433,10 @@ export async function handleDirectiveOnly(
     ? directives.thinkLevel
     : ((sessionEntry?.thinkingLevel as ThinkLevel | undefined) ?? currentThinkLevel);
   const remappedUnsupportedThinkLevel =
-    !directives.hasThinkDirective &&
-    nextThinkLevel &&
-    !isThinkingLevelSupported({
-      provider: resolvedProvider,
-      model: resolvedModel,
-      level: nextThinkLevel,
-      catalog: thinkingCatalog,
-      agentRuntime: thinkingRuntime,
-    })
+    !directives.hasThinkDirective && nextThinkLevel
       ? resolveSupportedThinkingLevel({
-          provider: resolvedProvider,
-          model: resolvedModel,
+          ...thinkingPolicy,
           level: nextThinkLevel,
-          catalog: thinkingCatalog,
-          agentRuntime: thinkingRuntime,
         })
       : undefined;
   const shouldRemapUnsupportedThinkLevel =
@@ -549,14 +557,7 @@ export async function handleDirectiveOnly(
         nextThinking: {
           level: appliedSessionEntry.thinkingLevel,
           catalog: thinkingCatalog,
-          agentRuntime: resolveEffectiveAgentRuntime({
-            cfg: params.cfg,
-            provider: modelSelection.provider,
-            modelId: modelSelection.model,
-            agentId: activeAgentId,
-            sessionKey: runtimePolicySessionKey,
-            sessionEntry: appliedSessionEntry,
-          }),
+          agentRuntime: resolveThinkingRuntime(appliedSessionEntry),
         },
       });
     }
@@ -582,6 +583,7 @@ export async function handleDirectiveOnly(
       kind: "applied",
       provider: resolvedProvider,
       model: resolvedModel,
+      modelCatalog: thinkingCatalog,
     };
   }
 

--- a/src/auto-reply/reply/directive-handling.mixed-inline.test.ts
+++ b/src/auto-reply/reply/directive-handling.mixed-inline.test.ts
@@ -1,7 +1,9 @@
 // Tests mixed directives through the real reply admission and transaction boundary.
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { ModelCatalogEntry } from "../../agents/model-catalog.js";
+import { loadProviderScopedThinkingCatalog } from "../../agents/model-catalog.runtime.js";
 import type { ModelAliasIndex } from "../../agents/model-selection.js";
+import { createModelVisibilityPolicy } from "../../agents/model-visibility-policy.js";
 import { persistStickyModelSelectionBestEffort } from "../../agents/sticky-model-selection.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import type { SessionEntry } from "../../config/sessions.js";
@@ -20,6 +22,10 @@ type PersistenceResult =
   | { status: "model-selection-locked"; entry: SessionEntry }
   | { status: "lifecycle-invalidated"; error: string; entry?: SessionEntry };
 
+vi.mock("../../agents/model-catalog.runtime.js", () => ({
+  loadProviderScopedThinkingCatalog: vi.fn(async () => []),
+}));
+
 const persistenceMocks = vi.hoisted(() => ({
   persist: vi.fn<(params: { entry: SessionEntry }) => Promise<PersistenceResult>>(),
 }));
@@ -27,6 +33,7 @@ const persistenceMocks = vi.hoisted(() => ({
 vi.mock("../../agents/agent-scope.js", () => ({
   listAgentEntries: vi.fn(() => []),
   resolveAgentConfig: vi.fn(() => ({})),
+  resolveAgentModelFallbacksOverride: vi.fn(() => undefined),
   resolveAgentDir: vi.fn(() => "/tmp/agent"),
   resolveSessionAgentIds: vi.fn(() => ({ requestedAgentId: "main", sessionAgentId: "main" })),
   resolveSessionAgentId: vi.fn(() => "main"),
@@ -99,6 +106,13 @@ async function applyMixedDirectives(params: {
     provider,
     model,
     requestedRouteResolution: "resolved",
+    modelPolicy: createModelVisibilityPolicy({
+      cfg,
+      catalog: allowedModels,
+      defaultProvider: params.defaultProvider ?? provider,
+      defaultModel: params.defaultModel ?? model,
+      agentId: "main",
+    }),
     allowedModelKeys: new Set(allowedModels.map((entry) => `${entry.provider}/${entry.id}`)),
     allowedModelCatalog: allowedModels,
     policyAliasIndex: aliasIndex,
@@ -173,11 +187,109 @@ async function applyMixedDirectives(params: {
 describe("mixed inline directives", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(loadProviderScopedThinkingCatalog).mockReset().mockResolvedValue([]);
     vi.mocked(persistStickyModelSelectionBestEffort).mockReturnValue("requested");
     persistenceMocks.persist.mockImplementation(async ({ entry }) => ({
       status: "current",
       entry: { ...entry },
     }));
+  });
+
+  it("continues mixed content with the selected route's context and thinking metadata", async () => {
+    const selected: ModelCatalogEntry = {
+      provider: "fixture-route",
+      id: "reasoner",
+      name: "Reasoner",
+      api: "openai-responses",
+      contextWindow: 48_000,
+      contextTokens: 24_000,
+      reasoning: true,
+      compat: { supportedReasoningEfforts: ["low", "medium", "high", "max"] },
+    };
+    vi.mocked(loadProviderScopedThinkingCatalog).mockResolvedValueOnce([selected]);
+    const { result, sessionEntry } = await applyMixedDirectives({
+      body: "please reply /model fixture-route/reasoner -s",
+      cfg: {
+        models: {
+          providers: {
+            "fixture-route": {
+              api: "openai-responses",
+              baseUrl: "https://fixture.invalid/v1",
+              models: [],
+            },
+          },
+        },
+      },
+      allowedModels: [
+        { provider: "anthropic", id: "claude-opus-4-6", name: "Opus", reasoning: false },
+      ],
+      sessionEntry: createSessionEntry({ thinkingLevel: "max" }),
+    });
+    expect(result).toMatchObject({
+      kind: "continue",
+      provider: selected.provider,
+      model: selected.id,
+      contextTokens: 24_000,
+    });
+    expect(sessionEntry.thinkingLevel).toBe("max");
+    expect(refreshQueuedFollowupSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        nextThinking: expect.objectContaining({
+          level: "max",
+          catalog: expect.arrayContaining([selected]),
+        }),
+      }),
+    );
+  });
+
+  it.each(["", "please reply "])(
+    "rejects a restricted explicit model with prefix %j without persistence",
+    async (prefix) => {
+      const sessionEntry = createSessionEntry({ thinkingLevel: "high" });
+      const initial = { ...sessionEntry };
+      const { result } = await applyMixedDirectives({
+        body: `${prefix}/model openai/gpt-5.6-luna -s`,
+        cfg: { agents: { defaults: { modelPolicy: { allow: ["anthropic/*"] } } } },
+        sessionEntry,
+        allowedModels: [{ provider: "anthropic", id: "claude-opus-4-6", name: "Opus" }],
+      });
+      expect(result).toMatchObject({
+        kind: "reply",
+        reply: { isError: true, text: expect.stringContaining("is not allowed") },
+      });
+      expect(sessionEntry).toEqual(initial);
+      expect(persistenceMocks.persist).not.toHaveBeenCalled();
+      expect(triggerSessionPatchHook).not.toHaveBeenCalled();
+      expect(loadProviderScopedThinkingCatalog).not.toHaveBeenCalled();
+    },
+  );
+
+  describe.each(["", "please reply "])("off-catalog selection with prefix %j", (prefix) => {
+    it.each([undefined, {}, { allow: [] }])(
+      "uses policy %j independently of inventory",
+      async (modelPolicy) => {
+        const { result, sessionEntry } = await applyMixedDirectives({
+          body: `${prefix}/model openai/gpt-5.6-luna -s`,
+          cfg: { agents: { defaults: { modelPolicy } } },
+          allowedModels: [{ provider: "anthropic", id: "claude-opus-4-6", name: "Opus" }],
+          sessionEntry: createSessionEntry({ thinkingLevel: "high" }),
+        });
+        expect(result).toMatchObject(
+          prefix
+            ? { kind: "continue", provider: "openai", model: "gpt-5.6-luna" }
+            : {
+                kind: "reply",
+                reply: { text: expect.stringContaining("Model set to openai/gpt-5.6-luna") },
+              },
+        );
+        expect(sessionEntry).toMatchObject({
+          providerOverride: "openai",
+          modelOverride: "gpt-5.6-luna",
+          thinkingLevel: "high",
+        });
+        expect(persistStickyModelSelectionBestEffort).not.toHaveBeenCalled();
+      },
+    );
   });
 
   describe.each(["", "please reply "])("model scope with prefix %j", (prefix) => {

--- a/src/auto-reply/reply/directive-handling.model-selection.ts
+++ b/src/auto-reply/reply/directive-handling.model-selection.ts
@@ -1,11 +1,7 @@
 /** Resolves /model directive selections and auth profile overrides. */
 import { ensureAuthProfileStore } from "../../agents/auth-profiles.js";
-import { isModelKeyAllowedBySet } from "../../agents/model-selection-shared.js";
-import {
-  type ModelAliasIndex,
-  modelKey,
-  resolveModelRefFromString,
-} from "../../agents/model-selection.js";
+import type { ModelAliasIndex } from "../../agents/model-selection.js";
+import type { ModelVisibilityPolicy } from "../../agents/model-visibility-policy.js";
 import { resolveProviderIdForAuth } from "../../agents/provider-auth-aliases.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { resolveProfileOverride } from "./directive-handling.auth-profile.js";
@@ -54,6 +50,7 @@ export function resolveModelSelectionFromDirective(params: {
   defaultModel: string;
   aliasIndex: ModelAliasIndex;
   allowedModelKeys: Set<string>;
+  modelPolicy?: ModelVisibilityPolicy;
   allowedModelCatalog: Array<{ provider: string; id?: string; name?: string }>;
   provider: string;
   agentId?: string;
@@ -93,6 +90,7 @@ export function resolveModelSelectionFromDirective(params: {
         defaultModel: params.defaultModel,
         aliasIndex: params.aliasIndex,
         allowedModelKeys: params.allowedModelKeys,
+        modelPolicy: params.modelPolicy,
         cfg: params.cfg,
         agentId: params.agentId,
         rawRuntime: params.directives.rawModelRuntime,
@@ -108,7 +106,6 @@ export function resolveModelSelectionFromDirective(params: {
       });
   const modelRaw =
     useStoredNumericProfile && storedNumericProfile ? storedNumericProfile.modelRaw : raw;
-  let modelSelection: ModelDirectiveSelection | undefined;
 
   if (/^[0-9]+$/.test(raw)) {
     return {
@@ -121,50 +118,21 @@ export function resolveModelSelectionFromDirective(params: {
     };
   }
 
-  const explicit = resolveModelRefFromString({
-    cfg: params.cfg,
-    agentId: params.agentId,
+  const resolved = resolveModelDirectiveSelection({
     raw: modelRaw,
     defaultProvider: params.defaultProvider,
+    defaultModel: params.defaultModel,
     aliasIndex: params.aliasIndex,
+    allowedModelKeys: params.allowedModelKeys,
+    modelPolicy: params.modelPolicy,
+    cfg: params.cfg,
+    agentId: params.agentId,
+    rawRuntime: params.directives.rawModelRuntime,
   });
-  if (explicit) {
-    const explicitKey = modelKey(explicit.ref.provider, explicit.ref.model);
-    if (
-      params.allowedModelKeys.size === 0 ||
-      isModelKeyAllowedBySet(params.allowedModelKeys, explicitKey)
-    ) {
-      modelSelection = {
-        provider: explicit.ref.provider,
-        model: explicit.ref.model,
-        isDefault:
-          explicit.ref.provider === params.defaultProvider &&
-          explicit.ref.model === params.defaultModel,
-        ...(explicit.alias ? { alias: explicit.alias } : {}),
-      };
-    }
+  if (resolved.error) {
+    return { errorText: resolved.error };
   }
-
-  if (!modelSelection) {
-    const resolved = resolveModelDirectiveSelection({
-      raw: modelRaw,
-      defaultProvider: params.defaultProvider,
-      defaultModel: params.defaultModel,
-      aliasIndex: params.aliasIndex,
-      allowedModelKeys: params.allowedModelKeys,
-      cfg: params.cfg,
-      agentId: params.agentId,
-      rawRuntime: params.directives.rawModelRuntime,
-    });
-
-    if (resolved.error) {
-      return { errorText: resolved.error };
-    }
-
-    if (resolved.selection) {
-      modelSelection = resolved.selection;
-    }
-  }
+  const modelSelection = resolved.selection;
 
   let profileOverride: string | undefined;
   const rawProfile =

--- a/src/auto-reply/reply/directive-handling.model.test.ts
+++ b/src/auto-reply/reply/directive-handling.model.test.ts
@@ -564,7 +564,10 @@ function resolveModelSelectionForCommand(params: {
 }) {
   return resolveModelSelectionFromDirective({
     directives: parseInlineSessionDirectives(params.command),
-    cfg: params.cfg ?? ({ commands: { text: true } } as unknown as OpenClawConfig),
+    cfg: params.cfg ?? {
+      commands: { text: true },
+      agents: { defaults: { modelPolicy: { allow: [...params.allowedModelKeys] } } },
+    },
     agentId: params.agentId,
     agentDir: TEST_AGENT_DIR,
     defaultProvider: "anthropic",
@@ -1435,7 +1438,10 @@ describe("/model chat UX", () => {
 
   it("auto-applies closest match for typos", () => {
     const directives = parseInlineSessionDirectives("/model anthropic/claud-opus-4-5");
-    const cfg = { commands: { text: true } } as unknown as OpenClawConfig;
+    const cfg: OpenClawConfig = {
+      commands: { text: true },
+      agents: { defaults: { modelPolicy: { allow: ["anthropic/claude-opus-4-6"] } } },
+    };
 
     const resolved = resolveModelSelectionFromDirective({
       directives,
@@ -1654,17 +1660,14 @@ describe("/model chat UX", () => {
     expect(sessionEntry.authProfileOverride).toBe(OPENAI_DATE_PROFILE_ID);
   });
 
-  it.each([
-    ["openai/gpt-4o", "openai", "gpt-4o"],
-    ["codex/gpt-5.5", "codex", "gpt-5.5"],
-  ])("persists provider-compatible runtime overrides for %s", async (modelKey, provider, model) => {
+  it("persists provider-compatible runtime overrides", async () => {
     const { persisted, sessionEntry } = await persistModelDirectiveForTest({
-      command: `/model ${modelKey} --runtime codex hello`,
-      allowedModelKeys: [modelKey],
+      command: "/model openai/gpt-4o --runtime codex hello",
+      allowedModelKeys: ["openai/gpt-4o"],
     });
 
-    expect(sessionEntry.providerOverride).toBe(provider);
-    expect(sessionEntry.modelOverride).toBe(model);
+    expect(sessionEntry.providerOverride).toBe("openai");
+    expect(sessionEntry.modelOverride).toBe("gpt-4o");
     expect(sessionEntry.agentRuntimeOverride).toBe("codex");
     expect(persisted.directiveAck?.text).toContain("Runtime set to codex for this session.");
   });
@@ -1888,6 +1891,13 @@ describe("/model chat UX", () => {
   it("persists explicit auth profiles after @YYYYMMDD version suffixes in mixed-content messages", async () => {
     const { sessionEntry } = await persistModelDirectiveForTest({
       command: `/model custom/vertex-ai_claude-haiku-4-5@${OPENAI_DATE_PROFILE_ID}@work hello`,
+      cfg: {
+        models: {
+          providers: {
+            custom: { api: "openai-responses", baseUrl: "https://custom.invalid/v1", models: [] },
+          },
+        },
+      },
       profiles: {
         work: {
           type: "api_key",
@@ -2636,7 +2646,9 @@ describe("handleDirectiveOnly model persist behavior (fixes #1435)", () => {
       nextAuthProfileIdSource: "user",
       nextThinking: {
         level: undefined,
-        catalog: allowedModelCatalog,
+        catalog: expect.arrayContaining([
+          expect.objectContaining({ provider: "anthropic", id: "claude-opus-4-6" }),
+        ]),
         agentRuntime: "openclaw",
       },
     });

--- a/src/auto-reply/reply/directive-handling.params.ts
+++ b/src/auto-reply/reply/directive-handling.params.ts
@@ -3,6 +3,7 @@ import type { AgentModelPrimaryWriteTarget } from "../../agents/agent-scope.js";
 /** Parameter contracts for the canonical directive transaction handler. */
 import type { ModelCatalogEntry } from "../../agents/model-catalog.js";
 import type { ModelAliasIndex } from "../../agents/model-selection.js";
+import type { ModelVisibilityPolicy } from "../../agents/model-visibility-policy.js";
 import type { SessionEntry } from "../../config/sessions.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { MsgContext } from "../templating.js";
@@ -26,6 +27,7 @@ type HandleDirectiveOnlyCoreParams = {
   aliasIndex: ModelAliasIndex;
   policyAliasIndex?: ModelAliasIndex;
   allowedModelKeys: Set<string>;
+  modelPolicy?: ModelVisibilityPolicy;
   allowedModelCatalog: Awaited<
     ReturnType<typeof import("../../agents/prepared-model-catalog.js").loadPreparedModelCatalog>
   >;
@@ -56,7 +58,12 @@ export type HandleDirectiveOnlyParams = HandleDirectiveOnlyCoreParams & {
   /** Mixed messages consume the transaction outcome without repeating persistence. */
   persistenceState?: {
     outcome:
-      | { kind: "pending" | "applied"; provider: string; model: string }
+      | {
+          kind: "pending" | "applied";
+          provider: string;
+          model: string;
+          modelCatalog?: ModelCatalogEntry[];
+        }
       | { kind: "rejected"; errorText: string };
   };
 };

--- a/src/auto-reply/reply/get-reply-directives-apply.ts
+++ b/src/auto-reply/reply/get-reply-directives-apply.ts
@@ -186,6 +186,7 @@ export async function applyInlineDirectiveOverrides(params: {
   let { provider, model } = params;
   let { contextTokens } = params;
   const directiveModelState = {
+    modelPolicy: modelState.modelPolicy,
     allowedModelKeys: modelState.allowedModelKeys,
     allowedModelCatalog: modelState.allowedModelCatalog,
     policyAliasIndex: modelState.policyAliasIndex,
@@ -215,6 +216,7 @@ export async function applyInlineDirectiveOverrides(params: {
   });
 
   let directiveAck: ReplyPayload | undefined;
+  let selectionCatalog = modelState.allowedModelCatalog;
 
   // Fire on the reason, not the boolean: a temporarily-unavailable override
   // surfaces a notice without destroying the pin, so resetModelOverride stays false.
@@ -294,6 +296,7 @@ export async function applyInlineDirectiveOverrides(params: {
       defaultProvider,
       defaultModel,
       aliasIndex,
+      modelPolicy: modelState.modelPolicy,
       allowedModelKeys: modelState.allowedModelKeys,
       allowedModelCatalog: modelState.allowedModelCatalog,
       provider,
@@ -399,6 +402,7 @@ export async function applyInlineDirectiveOverrides(params: {
         defaultProvider,
         defaultModel,
         aliasIndex,
+        modelPolicy: modelState.modelPolicy,
         allowedModelKeys: modelState.allowedModelKeys,
         allowedModelCatalog: modelState.allowedModelCatalog,
         provider,
@@ -439,7 +443,7 @@ export async function applyInlineDirectiveOverrides(params: {
           defaultModel,
           currentProvider: provider,
           currentModel: model,
-          allowedModelKeys: modelState.allowedModelKeys,
+          modelPolicy: modelState.modelPolicy,
           modelCatalog: modelState.allowedModelCatalog,
           thinkingCatalog: modelState.allowedModelCatalog,
           canPersistStickyModelSelection,
@@ -543,9 +547,10 @@ export async function applyInlineDirectiveOverrides(params: {
       };
     }
     ({ provider, model } = persistenceState.outcome);
+    selectionCatalog = persistenceState.outcome.modelCatalog ?? selectionCatalog;
   }
 
-  const selectedCatalogEntry = modelState.allowedModelCatalog.find(
+  const selectedCatalogEntry = selectionCatalog.find(
     (entry) => modelKey(entry.provider, entry.id) === modelKey(provider, model),
   );
   contextTokens = resolveContextTokens({

--- a/src/auto-reply/reply/get-reply-directives.ts
+++ b/src/auto-reply/reply/get-reply-directives.ts
@@ -612,7 +612,7 @@ export async function resolveReplyDirectives(params: {
     !thinkingActive &&
     !thinkingExplicitlySet
   ) {
-    resolvedReasoningLevel = await modelState.resolveDefaultReasoningLevel();
+    resolvedReasoningLevel = await modelState.resolveDefaultReasoningLevel({ provider, model });
   }
   const { directiveAck, perMessageQueueMode, perMessageQueueOptions } = applyResult;
   const resolvedFastModeState = resolveFastModeState({

--- a/src/auto-reply/reply/get-reply-run-admission.ts
+++ b/src/auto-reply/reply/get-reply-run-admission.ts
@@ -109,7 +109,7 @@ export async function prepareReplyRunAdmission(context: PreparedReplyRunContext)
     const maybeLevel = normalizeThinkLevel(parts[0]);
     const thinkingCatalog = maybeLevel
       ? await traceRunPhase("reply.resolve_thinking_catalog_for_hint", () =>
-          modelState.resolveThinkingCatalog(),
+          modelState.resolveThinkingCatalog({ provider, model }),
         )
       : undefined;
     if (
@@ -224,7 +224,7 @@ export async function prepareReplyRunAdmission(context: PreparedReplyRunContext)
   const isRoomEvent = inboundEventKind === "room_event";
   if (!resolvedThinkLevel) {
     resolvedThinkLevel = await traceRunPhase("reply.resolve_default_thinking", () =>
-      modelState.resolveDefaultThinkingLevel(),
+      modelState.resolveDefaultThinkingLevel({ provider, model, agentRuntime: thinkingRuntime }),
     );
   }
   const allowedThinkingCatalog = modelState.allowedModelCatalog ?? [];
@@ -246,7 +246,7 @@ export async function prepareReplyRunAdmission(context: PreparedReplyRunContext)
     // catalog load was a 14s+ reply-blocking cost for known Codex models that
     // already publish authoritative thinking metadata.
     thinkingCatalog = await traceRunPhase("reply.resolve_thinking_catalog", () =>
-      modelState.resolveThinkingCatalog(),
+      modelState.resolveThinkingCatalog({ provider, model }),
     );
     thinkingLevelSupported = isThinkingLevelSupported({
       provider,

--- a/src/auto-reply/reply/model-runtime-normalization.ts
+++ b/src/auto-reply/reply/model-runtime-normalization.ts
@@ -1,9 +1,20 @@
 /** Prepared plugin metadata handoff for runtime model normalization. */
 import type { ModelCatalogEntry } from "../../agents/model-catalog.js";
-import { modelKey, normalizeModelRef, normalizeProviderId } from "../../agents/model-selection.js";
+import {
+  findNormalizedProviderKey,
+  modelKey,
+  normalizeModelRef,
+  normalizeProviderId,
+} from "../../agents/model-selection.js";
 import { RUNTIME_MODEL_VISIBILITY_NORMALIZATION } from "../../agents/model-visibility-policy.js";
+import type { SessionEntry } from "../../config/sessions/types.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { getCurrentPluginMetadataSnapshot } from "../../plugins/current-plugin-metadata-snapshot.js";
+import {
+  isManifestPluginAvailableForControlPlane,
+  loadManifestMetadataSnapshot,
+} from "../../plugins/manifest-contract-eligibility.js";
+import { resolveModelRuntimeDirective } from "./directive-handling.model-runtime.js";
 
 export type RuntimeModelNormalization = NonNullable<Parameters<typeof normalizeModelRef>[2]>;
 
@@ -34,6 +45,80 @@ export function findSelectedCatalogEntry(params: {
   const normalizedProvider = normalizeProviderId(params.provider);
   const selectedKey = modelKey(normalizedProvider, params.model);
   return params.catalog?.find((entry) => modelKey(entry.provider, entry.id) === selectedKey);
+}
+
+/** Provider identity comes from authored routes or prepared/plugin metadata, not model inventory. */
+export function isKnownModelSelectionProvider(params: {
+  cfg: OpenClawConfig;
+  provider: string;
+  catalog: readonly ModelCatalogEntry[];
+}): boolean {
+  const provider = normalizeProviderId(params.provider);
+  if (
+    findNormalizedProviderKey(params.cfg.models?.providers, provider) ||
+    params.catalog.some((entry) => normalizeProviderId(entry.provider) === provider)
+  ) {
+    return true;
+  }
+  const snapshot = loadManifestMetadataSnapshot({ config: params.cfg });
+  return snapshot.plugins.some(
+    (plugin) =>
+      plugin.providers.some((id) => normalizeProviderId(id) === provider) &&
+      isManifestPluginAvailableForControlPlane({ snapshot, plugin, config: params.cfg }),
+  );
+}
+
+type ModelSelectionPreparation =
+  | {
+      status: "ready";
+      catalog: ModelCatalogEntry[];
+      runtime: Exclude<ReturnType<typeof resolveModelRuntimeDirective>, { kind: "invalid" }>;
+    }
+  | { status: "rejected"; reason: "invalid-runtime" | "unknown-provider"; message: string };
+
+/** Prepare runtime and capabilities for the selected route before any session mutation. */
+export async function prepareModelSelectionRuntime(params: {
+  cfg: OpenClawConfig;
+  agentId: string;
+  provider: string;
+  model: string;
+  catalog: readonly ModelCatalogEntry[];
+  rawRuntime?: string;
+  sessionEntry?: Pick<SessionEntry, "agentRuntimeOverride">;
+}): Promise<ModelSelectionPreparation> {
+  const runtime = resolveModelRuntimeDirective(params);
+  if (runtime.kind === "invalid") {
+    return { status: "rejected", reason: "invalid-runtime", message: runtime.errorText };
+  }
+  const selected = findSelectedCatalogEntry(params);
+  if (!isKnownModelSelectionProvider(params)) {
+    return {
+      status: "rejected",
+      reason: "unknown-provider",
+      message: `Unknown provider "${params.provider}". Use /models to list providers.`,
+    };
+  }
+  if (selected?.reasoning !== undefined) {
+    return { status: "ready", runtime, catalog: [...params.catalog] };
+  }
+  // The selected route owns its capabilities. A prepared default-provider row cannot
+  // supply thinking or context metadata for an explicit cross-provider selection.
+  const { loadProviderScopedThinkingCatalog } =
+    await import("../../agents/model-catalog.runtime.js");
+  const catalog = await loadProviderScopedThinkingCatalog({
+    config: params.cfg,
+    agentId: params.agentId,
+    provider: params.provider,
+    model: params.model,
+  });
+  const resolved = findSelectedCatalogEntry({ ...params, catalog });
+  return {
+    status: "ready",
+    runtime,
+    catalog: resolved
+      ? [resolved, ...params.catalog.filter((entry) => entry !== selected)]
+      : [...params.catalog],
+  };
 }
 
 export function mergePreparedConfiguredCatalog(params: {

--- a/src/auto-reply/reply/model-selection-directive.test.ts
+++ b/src/auto-reply/reply/model-selection-directive.test.ts
@@ -4,6 +4,7 @@ import { buildModelAliasIndex } from "../../agents/model-selection.js";
 import { createModelVisibilityPolicy } from "../../agents/model-visibility-policy.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { resolveModelDirectiveSelection } from "./model-selection-directive.js";
+import { createModelSelectionState } from "./model-selection.js";
 
 function resolveDirective(params: { cfg: OpenClawConfig; raw: string; agentId?: string }) {
   const defaultProvider = "openai";
@@ -34,6 +35,89 @@ function resolveDirective(params: { cfg: OpenClawConfig; raw: string; agentId?: 
 }
 
 describe("resolveModelDirectiveSelection", () => {
+  it.each([
+    {
+      allow: ["fixture-route/namespace/*"],
+      raw: "fixture-route/namespace/reasoner",
+      agentAllow: undefined,
+      allowed: true,
+    },
+    {
+      allow: ["fixture-route/namespace/*"],
+      raw: "fixture-route/namespace-other/reasoner",
+      agentAllow: undefined,
+      allowed: false,
+    },
+    {
+      allow: ["openai/*"],
+      raw: "fixture-route/namespace/reasoner",
+      agentAllow: ["fixture-route/namespace/*"],
+      allowed: true,
+    },
+    {
+      allow: ["fixture-route/*"],
+      raw: "fixture-route/namespace/reasoner",
+      agentAllow: ["openai/*"],
+      allowed: false,
+    },
+    { allow: ["openai/*"], raw: "fixture-route/namespace/reasoner", agentAllow: [], allowed: true },
+  ])(
+    "preserves wildcard boundaries and per-agent replacement: %j",
+    ({ allow, raw, agentAllow, allowed }) => {
+      const { result } = resolveDirective({
+        cfg: {
+          agents: {
+            defaults: { modelPolicy: { allow } },
+            list: [{ id: "ops", ...(agentAllow ? { modelPolicy: { allow: agentAllow } } : {}) }],
+          },
+        },
+        raw,
+        agentId: "ops",
+      });
+      if (allowed) {
+        expect(result.selection).toMatchObject({
+          provider: "fixture-route",
+          model: "namespace/reasoner",
+        });
+      } else {
+        expect(result.selection).toBeUndefined();
+        expect(result.error).toContain("is not allowed");
+      }
+    },
+  );
+
+  it.each([undefined, {}, { allow: [] }, { allow: ["openai/*"] }])(
+    "permits an explicit uncataloged model with policy %j",
+    async (modelPolicy) => {
+      const cfg: OpenClawConfig = {
+        agents: { defaults: { model: "anthropic/claude-sonnet-4-6", modelPolicy } },
+      };
+      const entries = [{ provider: "anthropic", id: "claude-sonnet-4-6", name: "Sonnet" }];
+      const state = await createModelSelectionState({
+        cfg,
+        agentCfg: cfg.agents?.defaults,
+        defaultProvider: "anthropic",
+        defaultModel: "claude-sonnet-4-6",
+        provider: "anthropic",
+        model: "claude-sonnet-4-6",
+        hasModelDirective: true,
+        preparedModelCatalog: { entries, routeVariants: entries },
+      });
+      const result = resolveModelDirectiveSelection({
+        raw: "openai/gpt-5.6-luna",
+        defaultProvider: "anthropic",
+        defaultModel: "claude-sonnet-4-6",
+        aliasIndex: state.policyAliasIndex,
+        allowedModelKeys: state.allowedModelKeys,
+        modelPolicy: state.modelPolicy,
+        cfg,
+      });
+      expect(result).toMatchObject({
+        selection: { provider: "openai", model: "gpt-5.6-luna", isDefault: false },
+      });
+    },
+  );
+
   it("rejects a configured fallback that the explicit policy does not allow", () => {
     const { policy, result } = resolveDirective({
       cfg: {

--- a/src/auto-reply/reply/model-selection-directive.ts
+++ b/src/auto-reply/reply/model-selection-directive.ts
@@ -4,11 +4,13 @@ import { expectDefined } from "@openclaw/normalization-core";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import { modelKey } from "../../agents/model-ref-shared.js";
 import {
-  isModelKeyAllowedBySet,
   type ModelAliasIndex,
-  resolveConfiguredModelPolicyAllow,
   resolveModelRefFromString,
 } from "../../agents/model-selection-shared.js";
+import {
+  createModelVisibilityPolicy,
+  type ModelVisibilityPolicy,
+} from "../../agents/model-visibility-policy.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 export { modelKey };
 export type { ModelAliasIndex };
@@ -52,15 +54,6 @@ const FUZZY_VARIANT_TOKENS = [
   "small",
   "nano",
 ];
-
-/** Resolves an explicit model directive string into a provider/model ref. */
-export function resolveModelRefFromDirectiveString(params: {
-  raw: string;
-  defaultProvider: string;
-  aliasIndex: ModelAliasIndex;
-}): { ref: { provider: string; model: string }; alias?: string } | null {
-  return resolveModelRefFromString(params);
-}
 
 function boundedLevenshteinDistance(a: string, b: string, maxDistance: number): number | null {
   if (a === b) {
@@ -224,18 +217,28 @@ function scoreFuzzyMatch(params: {
   };
 }
 
-/** Resolves a `/model` directive into an allowlisted model selection or error. */
+/** Resolves a `/model` directive under the effective model policy. */
 export function resolveModelDirectiveSelection(params: {
   raw: string;
   defaultProvider: string;
   defaultModel: string;
   aliasIndex: ModelAliasIndex;
   allowedModelKeys: Set<string>;
+  modelPolicy?: ModelVisibilityPolicy;
   cfg?: OpenClawConfig;
   agentId?: string;
   rawRuntime?: string | undefined;
 }): { selection?: ModelDirectiveSelection; error?: string } {
   const { raw, defaultProvider, defaultModel, aliasIndex, allowedModelKeys } = params;
+  const policy =
+    params.modelPolicy ??
+    createModelVisibilityPolicy({
+      cfg: params.cfg ?? {},
+      catalog: [],
+      defaultProvider,
+      defaultModel,
+      agentId: params.agentId,
+    });
 
   const rawTrimmed = raw.trim();
   const rawLower = normalizeLowercaseStringOrEmpty(rawTrimmed);
@@ -274,7 +277,7 @@ export function resolveModelDirectiveSelection(params: {
       }
       const provider = normalizeProviderId(key.slice(0, slash));
       const model = key.slice(slash + 1);
-      if (model === "*") {
+      if (model.endsWith("*") || !policy.allowsKey(key)) {
         continue;
       }
       if (providerFilter && provider !== providerFilter) {
@@ -297,7 +300,7 @@ export function resolveModelDirectiveSelection(params: {
       }
       for (const match of aliasMatches) {
         const key = modelKey(match.provider, match.model);
-        if (!isModelKeyAllowedBySet(allowedModelKeys, key)) {
+        if (!policy.allowsKey(key)) {
           continue;
         }
         if (!candidates.some((c) => c.provider === match.provider && c.model === match.model)) {
@@ -356,7 +359,9 @@ export function resolveModelDirectiveSelection(params: {
     return { selection: buildSelection(best.provider, best.model) };
   };
 
-  const resolved = resolveModelRefFromDirectiveString({
+  const resolved = resolveModelRefFromString({
+    cfg: params.cfg,
+    agentId: params.agentId,
     raw: rawTrimmed,
     defaultProvider,
     aliasIndex,
@@ -373,15 +378,22 @@ export function resolveModelDirectiveSelection(params: {
   }
 
   const resolvedKey = modelKey(resolved.ref.provider, resolved.ref.model);
-  if (allowedModelKeys.size === 0 || isModelKeyAllowedBySet(allowedModelKeys, resolvedKey)) {
-    return {
-      selection: {
-        provider: resolved.ref.provider,
-        model: resolved.ref.model,
-        isDefault: resolved.ref.provider === defaultProvider && resolved.ref.model === defaultModel,
-        alias: resolved.alias,
-      },
-    };
+  const explicitSelection = {
+    selection: {
+      provider: resolved.ref.provider,
+      model: resolved.ref.model,
+      isDefault: resolved.ref.provider === defaultProvider && resolved.ref.model === defaultModel,
+      ...(resolved.alias ? { alias: resolved.alias } : {}),
+    },
+  };
+  const permitted = policy.allowsKey(resolvedKey);
+  // Preserve catalog hints for bare fragments, while explicit routes and aliases
+  // depend only on policy, never on finite picker membership.
+  if (
+    permitted &&
+    (rawLower.includes("/") || resolved.alias || allowedModelKeys.has(resolvedKey))
+  ) {
+    return explicitSelection;
   }
 
   // If the user specified a provider/model but the exact model isn't allowed,
@@ -402,11 +414,14 @@ export function resolveModelDirectiveSelection(params: {
     return fuzzy;
   }
 
+  if (permitted) {
+    return explicitSelection;
+  }
+
   return {
     error: formatNotAllowedError({
       modelRef: `${resolved.ref.provider}/${resolved.ref.model}`,
-      policyPath: resolveConfiguredModelPolicyAllow({ cfg: params.cfg, agentId: params.agentId })
-        .repairConfigPath,
+      policyPath: policy.allowRepairConfigPath,
       rawRuntime: params.rawRuntime,
     }),
   };

--- a/src/auto-reply/reply/model-selection.test.ts
+++ b/src/auto-reply/reply/model-selection.test.ts
@@ -6,6 +6,7 @@ import {
 } from "../../agents/context-cache.js";
 import {
   loadManifestModelCatalog,
+  loadProviderScopedThinkingCatalog,
   loadPreparedModelCatalog as loadModelCatalogLocal,
 } from "../../agents/model-catalog.runtime.js";
 import type { OpenClawConfig } from "../../config/config.js";
@@ -143,6 +144,7 @@ afterEach(() => {
   vi.mocked(loadManifestModelCatalog).mockReset();
   vi.mocked(loadManifestModelCatalog).mockReturnValue([]);
   authProfileStoreMock.reset();
+  vi.mocked(loadProviderScopedThinkingCatalog).mockReset().mockResolvedValue([]);
 });
 
 const makeConfiguredModel = (overrides: Record<string, unknown> = {}) => ({
@@ -307,7 +309,7 @@ describe("createModelSelectionState catalog loading", () => {
 
   it("hydrates runtime catalog metadata when the configured allowlist entry lacks reasoning", async () => {
     vi.mocked(loadModelCatalogLocal).mockClear();
-    vi.mocked(loadModelCatalogLocal).mockResolvedValueOnce([
+    vi.mocked(loadProviderScopedThinkingCatalog).mockResolvedValueOnce([
       { provider: "openai", id: "gpt-5.4", name: "GPT-5.4", reasoning: true },
     ]);
     const cfg = {
@@ -339,7 +341,13 @@ describe("createModelSelectionState catalog loading", () => {
     });
 
     await expect(state.resolveDefaultThinkingLevel()).resolves.toBe("medium");
-    expect(loadModelCatalogLocal).toHaveBeenCalledOnce();
+    expect(loadModelCatalogLocal).not.toHaveBeenCalled();
+    expect(loadProviderScopedThinkingCatalog).toHaveBeenCalledWith({
+      config: cfg,
+      agentId: undefined,
+      provider: "openai",
+      model: "gpt-5.4",
+    });
   });
 
   it("uses the prepared gateway owner catalog without an exact-generation reload", async () => {
@@ -2332,9 +2340,7 @@ describe("createModelSelectionState resolveDefaultReasoningLevel", () => {
   });
 
   it("returns on when catalog model has reasoning true", async () => {
-    const { loadPreparedModelCatalog: loadModelCatalogForCase } =
-      await import("../../agents/model-catalog.runtime.js");
-    vi.mocked(loadModelCatalogForCase).mockResolvedValueOnce([
+    vi.mocked(loadProviderScopedThinkingCatalog).mockResolvedValueOnce([
       { provider: "openrouter", id: "x-ai/grok-4.1-fast", name: "Grok", reasoning: true },
     ]);
     const state = await createModelSelectionState({

--- a/src/auto-reply/reply/model-selection.ts
+++ b/src/auto-reply/reply/model-selection.ts
@@ -68,6 +68,7 @@ type ModelSelectionState = {
   provider: string;
   model: string;
   requestedRouteResolution: ModelFallbackRouteResolution;
+  modelPolicy: ModelVisibilityPolicy;
   allowedModelKeys: Set<string>;
   allowedModelCatalog: ModelCatalog;
   policyAliasIndex: ModelAliasIndex;
@@ -76,11 +77,13 @@ type ModelSelectionState = {
   resetModelOverrideReason?: "disallowed" | "stale" | "temporarily-unavailable";
   modelPolicyConfigPath?: string;
   modelPolicyRepairConfigPath?: string;
-  resolveThinkingCatalog: () => Promise<ModelCatalog | undefined>;
+  resolveThinkingCatalog: (
+    selection?: ThinkingDefaultSelection,
+  ) => Promise<ModelCatalog | undefined>;
   resolveDefaultThinkingLevel: (selection?: ThinkingDefaultSelection) => Promise<ThinkLevel>;
   hasConfiguredThinkingDefault?: boolean;
   /** Default reasoning level from model capability: "on" if model has reasoning, else "off". */
-  resolveDefaultReasoningLevel: () => Promise<"on" | "off">;
+  resolveDefaultReasoningLevel: (selection?: ThinkingDefaultSelection) => Promise<"on" | "off">;
   needsModelCatalog: boolean;
   modelContextWindow?: number;
   modelContextTokens?: number;
@@ -103,6 +106,12 @@ export function createFastTestModelSelectionState(params: {
     provider: params.provider,
     model: params.model,
     requestedRouteResolution: "resolved",
+    modelPolicy: createModelVisibilityPolicy({
+      cfg: { agents: { defaults: params.agentCfg } },
+      catalog: [],
+      defaultProvider: params.provider,
+      defaultModel: params.model,
+    }),
     allowedModelKeys: new Set<string>(),
     allowedModelCatalog: [],
     policyAliasIndex: { byAlias: new Map(), byKey: new Map() },
@@ -540,7 +549,6 @@ export async function createModelSelectionState(params: {
     }
   }
 
-  let thinkingCatalog: ModelCatalog | undefined;
   let manifestModelCatalog: ModelCatalog | null = null;
   const buildThinkingCatalog = (catalog: ModelCatalog): ModelCatalog =>
     createModelVisibilityPolicy({
@@ -563,56 +571,45 @@ export async function createModelSelectionState(params: {
     logStage("manifest-catalog-loaded", `entries=${manifestModelCatalog.length}`);
     return manifestModelCatalog;
   };
-  const resolveThinkingCatalog = async () => {
-    if (thinkingCatalog) {
-      return thinkingCatalog;
+  const thinkingCatalogs = new Map<string, ModelCatalog>();
+  const resolveThinkingCatalog = async (
+    selection: ThinkingDefaultSelection = { provider, model },
+  ) => {
+    const key = modelKey(selection.provider, selection.model);
+    const cached = thinkingCatalogs.get(key);
+    if (cached) {
+      return cached.length > 0 ? cached : undefined;
     }
-    let catalogForThinking =
-      allowedModelCatalog.length > 0
-        ? allowedModelCatalog
-        : modelCatalog && modelCatalog.length > 0
-          ? buildThinkingCatalog(modelCatalog)
-          : [];
-    let selectedCatalogEntry = findSelectedCatalogEntry({
-      catalog: catalogForThinking,
-      provider,
-      model,
-    });
-    // Prefer static manifest rows before cold runtime discovery. Synthetic
-    // allowlist rows know only provider/id; manifest rows can prove reasoning
-    // support without opening the Pi auth-backed model registry.
-    if (!modelCatalog && selectedCatalogEntry?.reasoning === undefined) {
+    let catalog = allowedModelCatalog;
+    const hasReasoning = (entries: ModelCatalog) =>
+      findSelectedCatalogEntry({
+        catalog: entries,
+        provider: selection.provider,
+        model: selection.model,
+      })?.reasoning !== undefined;
+    if (!hasReasoning(catalog)) {
       const manifestCatalog = buildThinkingCatalog(await loadManifestCatalog());
-      const manifestSelectedEntry = findSelectedCatalogEntry({
-        catalog: manifestCatalog,
-        provider,
-        model,
-      });
-      if (manifestSelectedEntry?.reasoning !== undefined) {
-        catalogForThinking = manifestCatalog;
-        selectedCatalogEntry = manifestSelectedEntry;
+      if (hasReasoning(manifestCatalog)) {
+        catalog = manifestCatalog;
+      } else {
+        // Capability reads stay scoped to the actual selection, including a model
+        // chosen after this state was prepared. Never discover every provider here.
+        const { loadProviderScopedThinkingCatalog } = await loadPreparedModelCatalogRuntime();
+        const scopedCatalog = buildThinkingCatalog(
+          await loadProviderScopedThinkingCatalog({
+            config: cfg,
+            agentId: params.agentId,
+            provider: selection.provider,
+            model: selection.model,
+          }),
+        );
+        if (findSelectedCatalogEntry({ catalog: scopedCatalog, ...selection })) {
+          catalog = scopedCatalog;
+        }
       }
     }
-    const shouldHydrateRuntimeCatalog =
-      !modelCatalog && (!selectedCatalogEntry || selectedCatalogEntry.reasoning === undefined);
-    if (shouldHydrateRuntimeCatalog) {
-      modelCatalog = (await loadRuntimeCatalogSnapshot()).entries;
-      logStage("catalog-loaded-for-thinking", `entries=${modelCatalog.length}`);
-      const runtimeCatalog = buildThinkingCatalog(modelCatalog);
-      const runtimeSelectedEntry = findSelectedCatalogEntry({
-        catalog: runtimeCatalog,
-        provider,
-        model,
-      });
-      catalogForThinking =
-        runtimeSelectedEntry || !catalogForThinking || catalogForThinking.length === 0
-          ? runtimeCatalog.length > 0
-            ? runtimeCatalog
-            : allowedModelCatalog
-          : allowedModelCatalog;
-    }
-    thinkingCatalog = catalogForThinking.length > 0 ? catalogForThinking : undefined;
-    return thinkingCatalog;
+    thinkingCatalogs.set(key, catalog);
+    return catalog.length > 0 ? catalog : undefined;
   };
 
   const defaultThinkingLevels = new Map<string, ThinkLevel>();
@@ -647,7 +644,7 @@ export async function createModelSelectionState(params: {
       defaultThinkingLevels.set(cacheKey, configuredThinkingDefault);
       return configuredThinkingDefault;
     }
-    const catalogForThinking = await resolveThinkingCatalog();
+    const catalogForThinking = await resolveThinkingCatalog(selection);
     const resolved = resolveThinkingDefault({
       cfg,
       provider: selectedProvider,
@@ -660,48 +657,14 @@ export async function createModelSelectionState(params: {
     return defaultThinkingLevel;
   };
 
-  let defaultReasoningLevel: "on" | "off" | undefined;
-  const resolveDefaultReasoningLevel = async (): Promise<"on" | "off"> => {
-    if (defaultReasoningLevel) {
-      return defaultReasoningLevel;
-    }
-    let catalogForReasoning = modelCatalog ?? allowedModelCatalog;
-    let selectedReasoningEntry = findSelectedCatalogEntry({
-      catalog: catalogForReasoning,
-      provider,
-      model,
+  const resolveDefaultReasoningLevel = async (
+    selection: ThinkingDefaultSelection = { provider, model },
+  ): Promise<"on" | "off"> =>
+    resolveReasoningDefault({
+      provider: selection.provider,
+      model: selection.model,
+      catalog: await resolveThinkingCatalog(selection),
     });
-    if (!modelCatalog && selectedReasoningEntry?.reasoning === undefined) {
-      const manifestCatalog = await loadManifestCatalog();
-      const manifestReasoningCatalog =
-        hasAllowlist || hasConfiguredModels
-          ? buildThinkingCatalog(manifestCatalog)
-          : manifestCatalog;
-      const manifestSelectedEntry = findSelectedCatalogEntry({
-        catalog: manifestReasoningCatalog,
-        provider,
-        model,
-      });
-      if (manifestSelectedEntry?.reasoning !== undefined) {
-        catalogForReasoning = manifestReasoningCatalog;
-        selectedReasoningEntry = manifestSelectedEntry;
-      }
-    }
-    if (
-      (!catalogForReasoning || catalogForReasoning.length === 0) &&
-      selectedReasoningEntry?.reasoning === undefined
-    ) {
-      modelCatalog = (await loadRuntimeCatalogSnapshot()).entries;
-      logStage("catalog-loaded-for-reasoning", `entries=${modelCatalog.length}`);
-      catalogForReasoning = modelCatalog;
-    }
-    defaultReasoningLevel = resolveReasoningDefault({
-      provider,
-      model,
-      catalog: catalogForReasoning,
-    });
-    return defaultReasoningLevel;
-  };
   const selectedCatalogEntry = findSelectedCatalogEntry({
     catalog: modelCatalog ?? allowedModelCatalog,
     provider,
@@ -722,6 +685,7 @@ export async function createModelSelectionState(params: {
     provider,
     model,
     requestedRouteResolution,
+    modelPolicy: visibilityPolicy,
     allowedModelKeys,
     allowedModelCatalog,
     policyAliasIndex: visibilityPolicy.policyAliasIndex,

--- a/src/auto-reply/reply/session-reset-model.test.ts
+++ b/src/auto-reply/reply/session-reset-model.test.ts
@@ -2,8 +2,10 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
 import type { ModelCatalogEntry } from "../../agents/model-catalog.js";
+import { buildModelAliasIndex } from "../../agents/model-selection-shared.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import type { SessionEntry } from "../../config/sessions.js";
 import { loadSessionEntry, replaceSessionEntry } from "../../config/sessions/session-accessor.js";
@@ -11,6 +13,7 @@ import { clearSessionStoreCacheForTest } from "../../config/sessions/store-write
 import type { ModelAliasIndex } from "./model-selection-directive.js";
 
 const loadPreparedModelCatalog = vi.hoisted(() => vi.fn(async () => modelCatalog));
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 vi.mock("../../agents/prepared-model-catalog.js", () => ({
   loadProviderScopedThinkingCatalog: vi.fn(async () => []),
@@ -46,12 +49,13 @@ function createResetFixture(entry: Partial<SessionEntry> = {}) {
 async function applyResetFixture(params: {
   resetTriggered: boolean;
   sessionEntry?: Partial<SessionEntry>;
+  body?: string;
 }) {
   const fixture = createResetFixture(params.sessionEntry);
   await applyResetModelOverride({
     cfg: fixture.cfg,
     resetTriggered: params.resetTriggered,
-    bodyStripped: "minimax summarize",
+    bodyStripped: params.body ?? "minimax summarize",
     sessionCtx: fixture.sessionCtx,
     ctx: fixture.ctx,
     sessionEntry: fixture.sessionEntry,
@@ -66,6 +70,135 @@ async function applyResetFixture(params: {
 }
 
 describe("applyResetModelOverride", () => {
+  it.each(["initial", "persisted"])("honors the %s session model lock", async (owner) => {
+    const fixture = createResetFixture({ modelSelectionLocked: owner === "initial" });
+    const storePath = path.join(tempDirs.make("openclaw-reset-model-lock-"), "sessions.json");
+    const lockedEntry: SessionEntry = { ...fixture.sessionEntry, modelSelectionLocked: true };
+    const sessionKey = "agent:main:dm:1";
+    await replaceSessionEntry({ sessionKey, storePath }, lockedEntry);
+
+    await expect(
+      applyResetModelOverride({
+        ...fixture,
+        sessionKey,
+        storePath,
+        resetTriggered: true,
+        bodyStripped: "minimax/m2.7 summarize",
+        defaultProvider: "openai",
+        defaultModel: "gpt-4o-mini",
+        modelCatalog,
+      }),
+    ).rejects.toThrow("Model selection is locked");
+    expect(fixture.sessionEntry.modelOverride).toBeUndefined();
+    expect(loadSessionEntry({ sessionKey, storePath })).toEqual(lockedEntry);
+  });
+
+  it.each([
+    { name: "omitted", policy: undefined, allowed: true },
+    { name: "empty", policy: {}, allowed: true },
+    { name: "empty allow", policy: { allow: [] }, allowed: true },
+    { name: "restricted", policy: { allow: ["openai/*"] }, allowed: false },
+  ])("authorizes an off-catalog reset hint with $name policy", async ({ policy, allowed }) => {
+    const fixture = createResetFixture({ thinkingLevel: "high" });
+    fixture.cfg = {
+      agents: { defaults: { modelPolicy: policy } },
+      models: {
+        providers: {
+          "fixture-route": {
+            api: "openai-responses",
+            baseUrl: "https://fixture.invalid/v1",
+            models: [],
+          },
+        },
+      },
+    };
+    fixture.sessionCtx.BodyStripped = "fixture-route/reasoner summarize";
+    const initial = structuredClone(fixture.sessionEntry);
+    const result = await applyResetModelOverride({
+      ...fixture,
+      sessionKey: "agent:main:dm:1",
+      resetTriggered: true,
+      bodyStripped: fixture.sessionCtx.BodyStripped,
+      defaultProvider: "openai",
+      defaultModel: "gpt-4o-mini",
+      modelCatalog,
+    });
+
+    if (allowed) {
+      expect(result).toMatchObject({
+        selection: { provider: "fixture-route", model: "reasoner", isDefault: false },
+        cleanedBody: "summarize",
+      });
+      expect(fixture.sessionEntry).toMatchObject({
+        providerOverride: "fixture-route",
+        modelOverride: "reasoner",
+        thinkingLevel: "high",
+      });
+      expect(fixture.sessionCtx.BodyStripped).toBe("summarize");
+    } else {
+      expect(result).toEqual({});
+      expect(fixture.sessionEntry).toEqual(initial);
+      expect(fixture.sessionCtx.BodyStripped).toBe("fixture-route/reasoner summarize");
+    }
+  });
+
+  it("recognizes an exact configured alias outside the picker inventory", async () => {
+    const fixture = createResetFixture();
+    fixture.cfg = {
+      agents: {
+        defaults: {
+          modelPolicy: { allow: [] },
+          models: { "fixture-route/reasoner": { alias: "quick" } },
+        },
+      },
+      models: {
+        providers: {
+          "fixture-route": {
+            api: "openai-responses",
+            baseUrl: "https://fixture.invalid/v1",
+            models: [],
+          },
+        },
+      },
+    };
+    const result = await applyResetModelOverride({
+      ...fixture,
+      aliasIndex: buildModelAliasIndex({ cfg: fixture.cfg, defaultProvider: "openai" }),
+      sessionKey: "agent:main:dm:1",
+      resetTriggered: true,
+      bodyStripped: "quick summarize",
+      defaultProvider: "openai",
+      defaultModel: "gpt-4o-mini",
+      modelCatalog,
+    });
+    expect(result).toMatchObject({
+      selection: { provider: "fixture-route", model: "reasoner", alias: "quick" },
+      cleanedBody: "summarize",
+    });
+    expect(fixture.sessionEntry.providerOverride).toBe("fixture-route");
+  });
+
+  it.each([
+    "summarize the previous conversation",
+    "missing-provider/reasoner summarize",
+    "missing-provider reasoner summarize",
+  ])("keeps unrecognized model-hint text unchanged: %s", async (body) => {
+    const fixture = createResetFixture();
+    fixture.sessionCtx.BodyStripped = body;
+    const result = await applyResetModelOverride({
+      ...fixture,
+      resetTriggered: true,
+      bodyStripped: fixture.sessionCtx.BodyStripped,
+      defaultProvider: "openai",
+      defaultModel: "gpt-4o-mini",
+      modelCatalog,
+    });
+
+    expect(result).toEqual({});
+    expect(fixture.sessionCtx.BodyStripped).toBe(body);
+    expect(fixture.sessionEntry.modelOverride).toBeUndefined();
+  });
+
   it("loads the reset catalog for the active agent owner", async () => {
     const fixture = createResetFixture();
 
@@ -92,17 +225,21 @@ describe("applyResetModelOverride", () => {
     });
   });
 
-  it("selects a model hint while preserving the stored thinking level for validation", async () => {
-    const { sessionEntry, sessionCtx } = await applyResetFixture({
-      resetTriggered: true,
-      sessionEntry: { thinkingLevel: "ultra" },
-    });
+  it.each(["minimax summarize", "minimax m2.7 summarize", "minimax/m2.7 summarize"])(
+    "selects a model hint while preserving thinking: %s",
+    async (body) => {
+      const { sessionEntry, sessionCtx } = await applyResetFixture({
+        resetTriggered: true,
+        sessionEntry: { thinkingLevel: "ultra" },
+        body,
+      });
 
-    expect(sessionEntry.providerOverride).toBe("minimax");
-    expect(sessionEntry.modelOverride).toBe("m2.7");
-    expect(sessionEntry.thinkingLevel).toBe("ultra");
-    expect(sessionCtx.BodyStripped).toBe("summarize");
-  });
+      expect(sessionEntry.providerOverride).toBe("minimax");
+      expect(sessionEntry.modelOverride).toBe("m2.7");
+      expect(sessionEntry.thinkingLevel).toBe("ultra");
+      expect(sessionCtx.BodyStripped).toBe("summarize");
+    },
+  );
 
   it.each([
     { name: "empty catalog", catalog: [] },
@@ -119,6 +256,11 @@ describe("applyResetModelOverride", () => {
       });
       fixture.cfg.agents = {
         defaults: { model: { primary: "custom/private-model" } },
+      };
+      fixture.cfg.models = {
+        providers: {
+          custom: { api: "openai-responses", baseUrl: "https://fixture.invalid/v1", models: [] },
+        },
       };
       fixture.sessionCtx.BodyStripped = "custom/private-model summarize";
 

--- a/src/auto-reply/reply/session-reset-model.ts
+++ b/src/auto-reply/reply/session-reset-model.ts
@@ -3,10 +3,8 @@ import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { resolveAgentDir, resolveDefaultAgentId } from "../../agents/agent-scope.js";
 import type { ModelCatalogEntry } from "../../agents/model-catalog.types.js";
-import {
-  buildAllowedModelSet,
-  isModelKeyAllowedBySet,
-} from "../../agents/model-selection-shared.js";
+import { resolveModelRefFromString } from "../../agents/model-selection-shared.js";
+import { createModelVisibilityPolicy } from "../../agents/model-visibility-policy.js";
 import type { InternalSessionEntry as SessionEntry } from "../../config/sessions.js";
 import { SessionWorkStartInvalidatedError } from "../../config/sessions/lifecycle.js";
 import {
@@ -16,11 +14,12 @@ import {
 } from "../../config/sessions/session-snapshot-merge.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { applyModelOverrideWithAuthProfileCompatibility } from "../../sessions/auth-profile-preservation.js";
+import { ModelSelectionLockedError } from "../../sessions/model-overrides.js";
 import type { MsgContext, TemplateContext } from "../templating.js";
+import { isKnownModelSelectionProvider } from "./model-runtime-normalization.js";
 import {
   modelKey,
   resolveModelDirectiveSelection,
-  resolveModelRefFromDirectiveString,
   type ModelAliasIndex,
   type ModelDirectiveSelection,
 } from "./model-selection-directive.js";
@@ -31,16 +30,6 @@ type ResetModelResult = {
   selection?: ModelDirectiveSelection;
   cleanedBody?: string;
 };
-
-function splitBody(body: string) {
-  const tokens = body.split(/\s+/).filter(Boolean);
-  return {
-    tokens,
-    first: tokens[0],
-    second: tokens[1],
-    rest: tokens.slice(2),
-  };
-}
 
 async function loadResetModelCatalog(params: {
   cfg: OpenClawConfig;
@@ -56,50 +45,6 @@ async function loadResetModelCatalog(params: {
     ...(params.workspaceDir ? { workspaceDir: params.workspaceDir } : {}),
     readOnly: true,
   });
-}
-
-function buildResetAllowedModelKeys(params: {
-  cfg: OpenClawConfig;
-  catalog: ModelCatalogEntry[];
-  defaultProvider: string;
-  defaultModel?: string;
-  agentId?: string;
-}): Set<string> {
-  const allowed = buildAllowedModelSet(params);
-  const defaultModel = params.defaultModel?.trim();
-  if (allowed.allowAny && defaultModel) {
-    allowed.allowedKeys.add(modelKey(normalizeProviderId(params.defaultProvider), defaultModel));
-  }
-  return allowed.allowedKeys;
-}
-
-function buildSelectionFromExplicit(params: {
-  raw: string;
-  defaultProvider: string;
-  defaultModel: string;
-  aliasIndex: ModelAliasIndex;
-  allowedModelKeys: Set<string>;
-}): ModelDirectiveSelection | undefined {
-  const resolved = resolveModelRefFromDirectiveString({
-    raw: params.raw,
-    defaultProvider: params.defaultProvider,
-    aliasIndex: params.aliasIndex,
-  });
-  if (!resolved) {
-    return undefined;
-  }
-  const key = modelKey(resolved.ref.provider, resolved.ref.model);
-  if (params.allowedModelKeys.size > 0 && !isModelKeyAllowedBySet(params.allowedModelKeys, key)) {
-    return undefined;
-  }
-  const isDefault =
-    resolved.ref.provider === params.defaultProvider && resolved.ref.model === params.defaultModel;
-  return {
-    provider: resolved.ref.provider,
-    model: resolved.ref.model,
-    isDefault,
-    ...(resolved.alias ? { alias: resolved.alias } : undefined),
-  };
 }
 
 async function applySelectionToSession(params: {
@@ -140,9 +85,13 @@ async function applySelectionToSession(params: {
       initialEntry: initialSessionEntry,
       entry: nextSessionEntry,
       touchedFields: SESSION_MODEL_OVERRIDE_TRANSACTION_FIELDS,
+      requireModelSelectionUnlocked: true,
     });
     if (persistence.status === "lifecycle-invalidated") {
       throw new SessionWorkStartInvalidatedError(persistence.error);
+    }
+    if (persistence.status === "model-selection-locked") {
+      throw new ModelSelectionLockedError();
     }
     const persistedEntry = persistence.entry;
     appliedEntry = persistedEntry;
@@ -161,7 +110,6 @@ async function applySelectionToSession(params: {
   return selectionApplied;
 }
 
-/** Applies a model override embedded in a reset command body. */
 /** Applies a valid reset model override to session state and returns the cleaned body. */
 export async function applyResetModelOverride(params: {
   cfg: OpenClawConfig;
@@ -190,7 +138,8 @@ export async function applyResetModelOverride(params: {
     return {};
   }
 
-  const { tokens, first, second } = splitBody(rawBody);
+  const tokens = rawBody.split(/\s+/).filter(Boolean);
+  const [first, second] = tokens;
   if (!first) {
     return {};
   }
@@ -203,71 +152,72 @@ export async function applyResetModelOverride(params: {
       agentDir: params.agentDir,
       workspaceDir: params.workspaceDir,
     }));
-  const allowedModelKeys = buildResetAllowedModelKeys({
+  const modelPolicy = createModelVisibilityPolicy({
     cfg: params.cfg,
     catalog,
     defaultProvider: params.defaultProvider,
     defaultModel: params.defaultModel,
     agentId: params.agentId,
   });
-  if (allowedModelKeys.size === 0) {
-    return {};
-  }
-
-  const providers = new Set<string>();
-  for (const key of allowedModelKeys) {
-    const slash = key.indexOf("/");
-    if (slash <= 0) {
-      continue;
+  const allowedModelKeys = modelPolicy.allowedKeys;
+  const providers = new Set([...allowedModelKeys].map((key) => key.split("/", 1)[0]));
+  const resolveSelection = (raw: string, explicitRef = false) => {
+    const parsed = resolveModelRefFromString({
+      cfg: params.cfg,
+      agentId: params.agentId,
+      raw,
+      defaultProvider: params.defaultProvider,
+      aliasIndex: params.aliasIndex,
+    });
+    if (!parsed) {
+      return undefined;
     }
-    providers.add(normalizeProviderId(key.slice(0, slash)));
-  }
-
-  const resolveSelection = (raw: string) =>
-    resolveModelDirectiveSelection({
+    const exact =
+      explicitRef ||
+      parsed.alias ||
+      allowedModelKeys.has(modelKey(parsed.ref.provider, parsed.ref.model));
+    if (
+      (exact && !modelPolicy.allows(parsed.ref)) ||
+      (!exact && !providers.has(normalizeProviderId(raw)) && raw.length < 6)
+    ) {
+      return undefined;
+    }
+    const resolved = resolveModelDirectiveSelection({
       raw,
       defaultProvider: params.defaultProvider,
       defaultModel: params.defaultModel,
       aliasIndex: params.aliasIndex,
       allowedModelKeys,
+      modelPolicy,
       cfg: params.cfg,
       agentId: params.agentId,
-    });
+    }).selection;
+    // Bare text needs a finite hint match; explicit refs and configured aliases
+    // use policy independently of inventory. Neither can invent a provider.
+    return resolved &&
+      (exact || allowedModelKeys.has(modelKey(resolved.provider, resolved.model))) &&
+      isKnownModelSelectionProvider({ cfg: params.cfg, catalog, provider: resolved.provider })
+      ? resolved
+      : undefined;
+  };
 
   let selection: ModelDirectiveSelection | undefined;
   let consumed = 0;
 
   if (providers.has(normalizeProviderId(first)) && second) {
-    // Support reset bodies like `openai gpt-5.6-sol rest of prompt`.
+    // Inventory disambiguates `provider model prompt` from `provider prompt`.
+    // Uncataloged model ids remain explicit through provider/model syntax.
     const composite = `${normalizeProviderId(first)}/${second}`;
-    const resolved = resolveSelection(composite);
-    if (resolved.selection) {
-      selection = resolved.selection;
+    selection = resolveSelection(composite);
+    if (selection) {
       consumed = 2;
     }
   }
 
   if (!selection) {
-    selection = buildSelectionFromExplicit({
-      raw: first,
-      defaultProvider: params.defaultProvider,
-      defaultModel: params.defaultModel,
-      aliasIndex: params.aliasIndex,
-      allowedModelKeys,
-    });
+    selection = resolveSelection(first, first.includes("/"));
     if (selection) {
       consumed = 1;
-    }
-  }
-
-  if (!selection) {
-    const resolved = resolveSelection(first);
-    const allowFuzzy = providers.has(normalizeProviderId(first)) || first.trim().length >= 6;
-    if (allowFuzzy) {
-      selection = resolved.selection;
-      if (selection) {
-        consumed = 1;
-      }
     }
   }
 

--- a/src/model-picker/apply-session-model-selection.test.ts
+++ b/src/model-picker/apply-session-model-selection.test.ts
@@ -1,9 +1,16 @@
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../test/helpers/promise.js";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import type { ModelCatalogEntry } from "../agents/model-catalog.js";
+import { loadProviderScopedThinkingCatalog } from "../agents/model-catalog.runtime.js";
 import { replaceSessionEntry } from "../config/sessions/session-accessor.js";
 import type { SessionEntry } from "../config/sessions/types.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+
+vi.mock("../agents/model-catalog.runtime.js", () => ({
+  loadProviderScopedThinkingCatalog: vi.fn(async () => []),
+}));
 
 const effects = vi.hoisted(() => ({
   enqueueSystemEvent: vi.fn(),
@@ -79,7 +86,6 @@ function createParams(overrides: Partial<ApplySessionModelSelectionParams> = {})
     defaultModel: "claude-opus-4-6",
     currentProvider: "anthropic",
     currentModel: "claude-opus-4-6",
-    allowedModelKeys: new Set(["anthropic/claude-opus-4-6", "openai/gpt-4o"]),
     modelCatalog: catalog,
     thinkingCatalog: catalog,
     canPersistStickyModelSelection: false,
@@ -95,6 +101,7 @@ function createParams(overrides: Partial<ApplySessionModelSelectionParams> = {})
 }
 
 beforeEach(() => {
+  vi.mocked(loadProviderScopedThinkingCatalog).mockReset().mockResolvedValue([]);
   effects.enqueueSystemEvent.mockReset();
   effects.info.mockReset();
   effects.warn.mockReset();
@@ -107,6 +114,131 @@ beforeEach(() => {
 });
 
 describe("applySessionModelSelection", () => {
+  it("uses selected route metadata for context and thinking outside the prepared inventory", async () => {
+    const selected: ModelCatalogEntry = {
+      provider: "fixture-route",
+      id: "reasoner",
+      name: "Reasoner",
+      api: "openai-responses",
+      contextWindow: 48_000,
+      contextTokens: 24_000,
+      reasoning: true,
+      compat: { supportedReasoningEfforts: ["low", "medium", "high", "max"] },
+    };
+    vi.mocked(loadProviderScopedThinkingCatalog).mockResolvedValueOnce([selected]);
+    const sessionEntry = createEntry({ thinkingLevel: "max" });
+    const result = await applySessionModelSelection(
+      createParams({
+        cfg: {
+          models: {
+            providers: {
+              "fixture-route": {
+                api: "openai-responses",
+                baseUrl: "https://fixture.invalid/v1",
+                models: [],
+              },
+            },
+          },
+        },
+        sessionEntry,
+        modelCatalog: [catalog[0]!],
+        thinkingCatalog: [catalog[0]!],
+        request: {
+          provider: selected.provider,
+          model: selected.id,
+          isDefault: false,
+          runtime: { kind: "set", runtime: "openclaw" },
+        },
+      }),
+    );
+    expect(result).toMatchObject({ status: "applied", contextTokens: 24_000 });
+    expect(result).not.toHaveProperty("thinkingRemap");
+    expect(sessionEntry).toMatchObject({
+      providerOverride: selected.provider,
+      modelOverride: selected.id,
+      thinkingLevel: "max",
+    });
+    expect(loadProviderScopedThinkingCatalog).toHaveBeenCalledExactlyOnceWith(
+      expect.objectContaining({ provider: selected.provider, model: selected.id }),
+    );
+    expect(effects.refreshQueuedFollowupSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        nextThinking: expect.objectContaining({
+          level: "max",
+          catalog: expect.arrayContaining([selected]),
+        }),
+      }),
+    );
+  });
+
+  it.each([
+    {
+      provider: "missing-provider",
+      model: "reasoner",
+      runtime: { kind: "unchanged" } as const,
+      reason: "unknown-provider",
+    },
+    {
+      provider: "openai",
+      model: "gpt-5.6-luna",
+      runtime: { kind: "set", runtime: "missing-runtime" } as const,
+      reason: "invalid-runtime",
+    },
+  ])(
+    "rejects $reason without persistence under unrestricted policy",
+    async ({ provider, model, runtime, reason }) => {
+      const sessionEntry = createEntry({ thinkingLevel: "high" });
+      const initial = structuredClone(sessionEntry);
+      const result = await applySessionModelSelection(
+        createParams({
+          sessionEntry,
+          modelCatalog: [catalog[0]!],
+          thinkingCatalog: [catalog[0]!],
+          request: { provider, model, runtime, isDefault: false },
+        }),
+      );
+      expect(result).toMatchObject({ status: "rejected", reason });
+      expect(sessionEntry).toEqual(initial);
+      expect(effects.triggerSessionPatchHook).not.toHaveBeenCalled();
+      expect(effects.refreshQueuedFollowupSession).not.toHaveBeenCalled();
+      expect(loadProviderScopedThinkingCatalog).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each([undefined, {}, { allow: [] }, { allow: ["openai/*"] }])(
+    "persists an off-catalog selection under policy %j without credentials",
+    async (modelPolicy) => {
+      const sessionEntry = createEntry({ thinkingLevel: "high" });
+      const cfg: OpenClawConfig = { agents: { defaults: { modelPolicy } } };
+      const result = await applySessionModelSelection(
+        createParams({
+          cfg,
+          sessionEntry,
+          modelCatalog: [catalog[0]!],
+          thinkingCatalog: [catalog[0]!],
+          request: {
+            provider: "openai",
+            model: "gpt-5.6-luna",
+            isDefault: false,
+            runtime: { kind: "unchanged" },
+          },
+        }),
+      );
+      expect(result).toMatchObject({
+        status: "applied",
+        provider: "openai",
+        model: "gpt-5.6-luna",
+      });
+      expect(sessionEntry).toMatchObject({
+        providerOverride: "openai",
+        modelOverride: "gpt-5.6-luna",
+        modelOverrideSource: "user",
+        thinkingLevel: "high",
+      });
+      expect(effects.mutateConfigFileWithRetry).not.toHaveBeenCalled();
+    },
+  );
+
   it("applies a non-default selection, auth profile, cleanup, and side effects once", async () => {
     const sessionEntry = createEntry({
       model: "claude-opus-4-6",
@@ -482,6 +614,36 @@ describe("applySessionModelSelection", () => {
     expect(effects.triggerSessionPatchHook).not.toHaveBeenCalled();
   });
 
+  it.each([
+    {
+      name: "locked",
+      concurrent: createEntry({ modelSelectionLocked: true }),
+      outcome: { status: "rejected", reason: "locked" },
+    },
+    {
+      name: "replaced",
+      concurrent: createEntry({ sessionId: "session-2" }),
+      outcome: { status: "conflict" },
+    },
+  ])(
+    "preserves an in-memory session $name during metadata preparation",
+    async ({ concurrent, outcome }) => {
+      const metadata = createDeferred<ModelCatalogEntry[]>();
+      vi.mocked(loadProviderScopedThinkingCatalog).mockReturnValueOnce(metadata.promise);
+      const params = createParams();
+      const pending = applySessionModelSelection(params);
+      params.sessionStore[params.sessionKey] = concurrent;
+      metadata.resolve([]);
+
+      expect(await pending).toMatchObject(outcome);
+      expect(params.sessionStore[params.sessionKey]).toBe(concurrent);
+      expect(params.sessionEntry).toEqual(createEntry());
+      expect(effects.triggerSessionPatchHook).not.toHaveBeenCalled();
+      expect(effects.refreshQueuedFollowupSession).not.toHaveBeenCalled();
+      expect(effects.enqueueSystemEvent).not.toHaveBeenCalled();
+    },
+  );
+
   it("rejects when the authoritative persisted row became locked", async () => {
     const tempRoot = tempDirs.make("openclaw-model-picker-lock-");
     const storePath = path.join(tempRoot, "sessions.json");
@@ -503,11 +665,7 @@ describe("applySessionModelSelection", () => {
   it.each([
     {
       name: "allowlist",
-      overrides: { allowedModelKeys: new Set(["anthropic/claude-opus-4-6"]) },
-    },
-    {
-      name: "fresh catalog",
-      overrides: { allowedModelKeys: new Set<string>(), modelCatalog: [catalog[0]!] },
+      overrides: { cfg: { agents: { defaults: { modelPolicy: { allow: ["anthropic/*"] } } } } },
     },
   ])("rejects a model missing from the $name", async ({ overrides }) => {
     const sessionEntry = createEntry();

--- a/src/model-picker/apply-session-model-selection.ts
+++ b/src/model-picker/apply-session-model-selection.ts
@@ -1,25 +1,25 @@
-import {
-  isDefaultAgentRuntimeId,
-  normalizeOptionalAgentRuntimeId,
-} from "../agents/agent-runtime-id.js";
 import { resolveAgentDir, type AgentModelPrimaryWriteTarget } from "../agents/agent-scope.js";
 import type { ModelCatalogEntry } from "../agents/model-catalog.js";
-import { modelKey, normalizeProviderId } from "../agents/model-selection.js";
-import { resolveContextConfigProviderForRuntime } from "../agents/openai-routing.js";
+import { modelKey } from "../agents/model-selection.js";
 import {
-  resolveCompatibleAgentRuntimeForProvider,
-  resolveSessionRuntimeOverrideForProvider,
-} from "../agents/session-runtime-compat.js";
+  createModelVisibilityPolicy,
+  type ModelVisibilityPolicy,
+} from "../agents/model-visibility-policy.js";
+import { resolveContextConfigProviderForRuntime } from "../agents/openai-routing.js";
 import {
   persistStickyModelSelectionBestEffort,
   type StickyModelSelectionDispatchOutcome,
 } from "../agents/sticky-model-selection.js";
 import { resolveEffectiveAgentRuntime } from "../agents/thinking-runtime.js";
 import { applyModelRuntimeDirective } from "../auto-reply/reply/directive-handling.model-runtime.js";
+import {
+  prepareModelSelectionRuntime,
+  findSelectedCatalogEntry,
+} from "../auto-reply/reply/model-runtime-normalization.js";
 import { resolveContextTokens } from "../auto-reply/reply/model-selection-context.js";
 import { refreshQueuedFollowupSession } from "../auto-reply/reply/queue.js";
 import { persistReplySessionEntry } from "../auto-reply/reply/session-entry-persistence.js";
-import { isThinkingLevelSupported, resolveSupportedThinkingLevel } from "../auto-reply/thinking.js";
+import { resolveSupportedThinkingLevel } from "../auto-reply/thinking.js";
 import type { ThinkLevel } from "../auto-reply/thinking.shared.js";
 import { resolveSessionAuthProfileOverrideSource } from "../config/sessions/auth-profile-override-provenance.js";
 import {
@@ -58,7 +58,7 @@ export type ApplySessionModelSelectionParams = {
   defaultModel: string;
   currentProvider: string;
   currentModel: string;
-  allowedModelKeys: ReadonlySet<string>;
+  modelPolicy?: ModelVisibilityPolicy;
   modelCatalog: readonly ModelCatalogEntry[];
   thinkingCatalog?: readonly ModelCatalogEntry[];
   canPersistStickyModelSelection?: boolean;
@@ -88,15 +88,15 @@ export type ApplySessionModelSelectionResult =
     }
   | {
       status: "rejected";
-      reason: "locked" | "not-allowed" | "invalid-runtime";
+      reason: "locked" | "not-allowed" | "invalid-runtime" | "unknown-provider";
       message: string;
     }
   | { status: "conflict"; message: string };
 
-type AppliedRuntimeDirective =
-  | { kind: "unchanged" }
-  | { kind: "clear" }
-  | { kind: "set"; runtime: string };
+type AppliedRuntimeDirective = Exclude<
+  Parameters<typeof applyModelRuntimeDirective>[1],
+  { kind: "invalid" }
+>;
 
 type ApplySessionModelSelectionToEntryResult = {
   changed: boolean;
@@ -131,47 +131,6 @@ function applySessionModelSelectionToEntry(params: {
   };
 }
 
-function resolveRuntimeDirective(params: {
-  cfg: OpenClawConfig;
-  entry: SessionEntry;
-  provider: string;
-  request: SessionModelSelectionRequest["runtime"];
-}): AppliedRuntimeDirective | { kind: "invalid"; message: string } {
-  if (params.request.kind === "unchanged") {
-    const persistedRuntime = params.entry.agentRuntimeOverride?.trim();
-    if (
-      persistedRuntime &&
-      !resolveSessionRuntimeOverrideForProvider({
-        provider: params.provider,
-        entry: params.entry,
-        cfg: params.cfg,
-      })
-    ) {
-      return { kind: "clear" };
-    }
-    return params.request;
-  }
-  if (params.request.kind === "clear") {
-    return params.request;
-  }
-  const runtime = normalizeOptionalAgentRuntimeId(params.request.runtime);
-  if (isDefaultAgentRuntimeId(runtime)) {
-    return { kind: "clear" };
-  }
-  const provider = normalizeProviderId(params.provider);
-  const compatibleRuntime = resolveCompatibleAgentRuntimeForProvider({
-    provider,
-    runtime,
-    cfg: params.cfg,
-  });
-  return compatibleRuntime
-    ? { kind: "set", runtime: compatibleRuntime }
-    : {
-        kind: "invalid",
-        message: `Runtime "${params.request.runtime}" is not supported for ${provider || params.provider}.`,
-      };
-}
-
 function formatModelSwitchEvent(provider: string, model: string, alias?: string): string {
   const label = `${provider}/${model}`;
   return alias ? `Model switched to ${alias} (${label}).` : `Model switched to ${label}.`;
@@ -189,18 +148,26 @@ function rejectNotAllowed(provider: string, model: string): ApplySessionModelSel
 export async function applySessionModelSelection(
   params: ApplySessionModelSelectionParams,
 ): Promise<ApplySessionModelSelectionResult> {
+  const startingStoreEntry = params.sessionStore[params.sessionKey];
   const startingEntry = params.storePath
     ? params.sessionEntry
-    : (params.sessionStore[params.sessionKey] ?? params.sessionEntry);
+    : (startingStoreEntry ?? params.sessionEntry);
+  const initialEntry = { ...startingEntry };
   if (isModelSelectionLocked(startingEntry)) {
     return { status: "rejected", reason: "locked", message: MODEL_SELECTION_LOCKED_MESSAGE };
   }
 
   const normalizedModelKey = modelKey(params.request.provider, params.request.model);
-  if (
-    (params.allowedModelKeys.size > 0 && !params.allowedModelKeys.has(normalizedModelKey)) ||
-    !params.modelCatalog.some((entry) => modelKey(entry.provider, entry.id) === normalizedModelKey)
-  ) {
+  const policy =
+    params.modelPolicy ??
+    createModelVisibilityPolicy({
+      cfg: params.cfg,
+      catalog: [...params.modelCatalog],
+      defaultProvider: params.defaultProvider,
+      defaultModel: params.defaultModel,
+      agentId: params.agentId,
+    });
+  if (!policy.allows(params.request)) {
     return rejectNotAllowed(params.request.provider, params.request.model);
   }
   const request: SessionModelSelectionRequest = {
@@ -208,17 +175,44 @@ export async function applySessionModelSelection(
     isDefault: normalizedModelKey === modelKey(params.defaultProvider, params.defaultModel),
   };
 
-  const runtime = resolveRuntimeDirective({
+  const prepared = await prepareModelSelectionRuntime({
     cfg: params.cfg,
-    entry: startingEntry,
+    agentId: params.agentId,
+    sessionEntry: startingEntry,
     provider: request.provider,
-    request: request.runtime,
+    model: request.model,
+    catalog: params.thinkingCatalog ?? params.modelCatalog,
+    rawRuntime:
+      request.runtime.kind === "set"
+        ? request.runtime.runtime
+        : request.runtime.kind === "clear"
+          ? "default"
+          : undefined,
   });
-  if (runtime.kind === "invalid") {
-    return { status: "rejected", reason: "invalid-runtime", message: runtime.message };
+  if (prepared.status === "rejected") {
+    return prepared;
   }
-
-  const initialEntry = { ...startingEntry };
+  // Metadata preparation can yield. Memory-only sessions need the same lock and
+  // replacement fence that persisted sessions enforce in their atomic write.
+  const currentEntry = params.storePath
+    ? startingEntry
+    : (params.sessionStore[params.sessionKey] ?? params.sessionEntry);
+  if (isModelSelectionLocked(currentEntry)) {
+    return { status: "rejected", reason: "locked", message: MODEL_SELECTION_LOCKED_MESSAGE };
+  }
+  if (
+    !params.storePath &&
+    (params.sessionStore[params.sessionKey] !== startingStoreEntry ||
+      currentEntry.sessionId !== initialEntry.sessionId)
+  ) {
+    return {
+      status: "conflict",
+      message: "Model change was not applied because the session changed. Retry.",
+    };
+  }
+  const runtime = prepared.runtime;
+  const thinkingCatalog = prepared.catalog;
+  const selectedCatalogEntry = findSelectedCatalogEntry({ catalog: thinkingCatalog, ...request });
   const nextEntry = { ...startingEntry };
   const applied = applySessionModelSelectionToEntry({
     cfg: params.cfg,
@@ -229,11 +223,12 @@ export async function applySessionModelSelection(
     runtime,
     markLiveSwitchPending: params.markLiveSwitchPending,
   });
-  const thinkingCatalog = params.thinkingCatalog ?? params.modelCatalog;
   const thinkingRuntime = resolveEffectiveAgentRuntime({
     cfg: params.cfg,
     provider: request.provider,
     modelId: request.model,
+    modelApi: selectedCatalogEntry?.api,
+    modelBaseUrl: selectedCatalogEntry?.baseUrl,
     agentId: params.agentId,
     sessionKey: params.sessionKey,
     sessionEntry: nextEntry,
@@ -243,16 +238,7 @@ export async function applySessionModelSelection(
     ApplySessionModelSelectionResult,
     { status: "applied" }
   >["thinkingRemap"];
-  if (
-    currentThinkingLevel &&
-    !isThinkingLevelSupported({
-      provider: request.provider,
-      model: request.model,
-      level: currentThinkingLevel,
-      catalog: [...thinkingCatalog],
-      agentRuntime: thinkingRuntime,
-    })
-  ) {
+  if (currentThinkingLevel) {
     const remapped = resolveSupportedThinkingLevel({
       provider: request.provider,
       model: request.model,
@@ -350,6 +336,8 @@ export async function applySessionModelSelection(
           cfg: params.cfg,
           provider,
           modelId: model,
+          modelApi: selectedCatalogEntry?.api,
+          modelBaseUrl: selectedCatalogEntry?.baseUrl,
           agentId: params.agentId,
           sessionKey: params.sessionKey,
           sessionEntry: persistedEntry,
@@ -365,15 +353,14 @@ export async function applySessionModelSelection(
     });
   }
 
-  const selectedCatalogEntry = params.modelCatalog.find(
-    (entry) => modelKey(entry.provider, entry.id) === normalizedModelKey,
-  );
   const contextProvider = resolveContextConfigProviderForRuntime({
     provider,
     runtimeId: resolveEffectiveAgentRuntime({
       cfg: params.cfg,
       provider,
       modelId: model,
+      modelApi: selectedCatalogEntry?.api,
+      modelBaseUrl: selectedCatalogEntry?.baseUrl,
       agentId: params.agentId,
       sessionKey: params.sessionKey,
       sessionEntry: persistedEntry,

--- a/src/plugin-sdk/command-auth.ts
+++ b/src/plugin-sdk/command-auth.ts
@@ -99,7 +99,7 @@ export {
   buildModelsProviderData,
   formatModelsAvailableHeader,
   resolveModelsCommandReply,
-} from "../auto-reply/reply/commands-models.js";
+} from "./models-provider-runtime.js";
 export type { ModelsProviderData } from "../auto-reply/reply/commands-models.js";
 export { resolveStoredModelOverride } from "../sessions/stored-model-overrides.js";
 export type { StoredModelOverride } from "../sessions/stored-model-overrides.js";

--- a/src/plugin-sdk/models-provider-runtime.ts
+++ b/src/plugin-sdk/models-provider-runtime.ts
@@ -1,8 +1,13 @@
 /**
  * Runtime SDK subpath for building model-provider command replies.
  */
+import {
+  buildPreparedModelsProviderData,
+  type ModelsProviderData,
+} from "../auto-reply/reply/commands-models.js";
+
 export {
-  buildModelsProviderData,
+  buildPreparedModelsProviderData,
   formatModelsAvailableHeader,
   resolveModelsCommandReply,
 } from "../auto-reply/reply/commands-models.js";
@@ -10,3 +15,11 @@ export type {
   ModelsProviderData,
   ModelsRuntimeChoice,
 } from "../auto-reply/reply/commands-models.js";
+
+// v2026.7.1-2 plugins construct old-shape results and typed builder adapters.
+// Keep this signature until an explicitly approved SDK-breaking boundary.
+export function buildModelsProviderData(
+  ...args: Parameters<typeof buildPreparedModelsProviderData>
+): Promise<ModelsProviderData> {
+  return buildPreparedModelsProviderData(...args);
+}


### PR DESCRIPTION
Closes https://github.com/openclaw/openclaw/issues/132174

<details>
<summary>Additional instructions</summary>

This PR is on a maintainer-editable branch in the upstream repository.

</details>

## What Problem This Solves

Fixes an issue where users switching models in chat would receive “not allowed” when the requested model was absent from a finite prepared catalog, despite having no restrictive model policy. The same distinction affected `/new` model hints.

## Why This Change Was Made

Model permission now stays with the canonical policy through directive resolution and authoritative session mutation. Finite catalogs remain browse/fuzzy-match inventories, while provider/runtime validity and selected-route capabilities are prepared independently. Explicit restrictions, per-agent replacement, wildcard boundaries, model locks, concurrent-session fencing, and profile compatibility remain enforced.

The connected picker path now carries already-prepared physical-route metadata from browse to Telegram instead of rebuilding ID-only rows and rediscovering capabilities. Duplicate parsing, runtime checks, and thinking hydration were removed. No new config option, dependency, schema, allowlist workaround, or credential refresh was introduced. The sole compatibility wrapper preserves the demonstrated stable public SDK contract described below.

## User Impact

An omitted or empty model policy permits explicit known-provider selections outside the initial picker inventory. Unknown providers and unsupported runtimes still fail without changing the selected model. Session-only switches leave configured defaults unchanged. Telegram picker callbacks keep the selected route’s context/thinking metadata without an unnecessary cold catalog reload.

Release-note context: repairs unrestricted chat model switching and reset hints, preserves explicit policy enforcement, and avoids metadata loss in native model-picker callbacks.

## Evidence

**Before:** unchanged-production owner-boundary tests produced 13 intended failures across directive resolution (3), session mutation (4), and direct/mixed chat commands (6). Reset-policy and asynchronous lock/replacement regressions also failed before their respective repairs. The affected policy owners remained unchanged on main at `4160df04e38f14424067f6d9b1c13732a3be0181` when checked.

**After — real isolated Gateway, synthetic test data:** built CLI on an isolated local Gateway with default Anthropic, no `agents.defaults.modelPolicy` or `agents.defaults.models`, no provider credentials, and enabled OpenAI/Codex plugins. Its configured inventory contained exactly one Anthropic row and did not contain the requested OpenAI model.

| Input | Observed outcome |
| --- | --- |
| `/model openai/gpt-5.6-luna -s` | Acknowledged and persisted the exact session selection; configured default unchanged |
| Unknown-provider selection | Rejected; previous selection retained |
| Unsupported-runtime selection | Rejected; previous selection retained |
| `/model default -s` | Pin cleared; Anthropic default restored |
| `sessions.create` with the same off-inventory model | Accepted |

Configuration bytes were identical before and after the command sequence. The attached screenshot was inspected and contains only isolated synthetic-test state. **This proves selection behavior, not provider authentication or live model inference; no provider inference was attempted.** Both temporary Gateways were stopped.

**Focused tests:** 317 core/session cases passed in the grouped command below. Additional browse/Telegram proof passed 90 targeted cases, including overlapping selection-service cases: 37 browse, 35 service, 13 model-related Telegram callback, one real grammY/loopback HTTP Bot API, and four dispatch-harness cases. The 130 unrelated cases in the bot file were deliberately unselected.

```bash
node scripts/run-vitest.mjs src/model-picker/apply-session-model-selection.test.ts src/auto-reply/reply/session-reset-model.test.ts src/auto-reply/reply/directive-handling.model.test.ts src/auto-reply/reply/directive-handling.mixed-inline.test.ts src/auto-reply/reply/model-selection-directive.test.ts src/auto-reply/reply/model-selection.test.ts src/gateway/server.sessions.agent-model-catalog.test.ts
```

```bash
node scripts/run-vitest.mjs src/auto-reply/reply/commands-models.test.ts src/model-picker/apply-session-model-selection.test.ts
```

```bash
node scripts/run-vitest.mjs extensions/telegram/src/model-callback.loopback.integration.test.ts
```

```bash
node scripts/run-vitest.mjs extensions/telegram/src/bot.test.ts -t 'model|selecting the default'
```

```bash
node scripts/run-vitest.mjs src/auto-reply/reply/commands-models.test.ts extensions/telegram/src/bot-message-dispatch.pipeline-init.test.ts
```

The identical Telegram loopback scenario passed with the original service/router (1.56s test body), timed out after metadata was discarded and reloaded (259.23s body; 256.6s inside scoped catalog loading), then passed after forwarding the prepared rows (4.51s body). No catalog-loader mock, timeout increase, or new test environment override was added to hide the reload.

**Checks:** final full `pnpm build`, scoped production/test types and type-aware lint, targeted formatting, `git diff --check`, zero runtime import cycles, SDK surface check, and fresh independent Codex review passed. Review scope was P0, with no accepted findings. The broad local `check:changed` attempt was stopped during lengthy declaration preparation and is not claimed as green; final scoped checks and the complete build were run separately. Exact-head CI/landing proof will be recorded before merge.

**CI fixture correction:** the first exact-head CI run exposed two fuzzy-selection assertions whose helper supplied finite catalog keys without the restrictive policy those cases intend. The helper now declares that same allowlist in config; all assertions and production code are unchanged. The two failures reproduced locally, then all 14 cases passed across the fuzzy fixture and policy resolver suites.

```bash
node scripts/run-vitest.mjs src/auto-reply/reply.directive.directive-behavior.prefers-alias-matches-fuzzy-selection-is-ambiguous.test.ts src/auto-reply/reply/model-selection-directive.test.ts
```

**SDK compatibility repair:** accepted ClawSweeper’s finding against stable `v2026.7.1-2`. Both [`models-provider-runtime`](https://github.com/openclaw/openclaw/blob/v2026.7.1-2/src/plugin-sdk/models-provider-runtime.ts) and [`command-auth`](https://github.com/openclaw/openclaw/blob/v2026.7.1-2/src/plugin-sdk/command-auth.ts) publish the old builder spelling. The public `ModelsProviderData` construction shape and `buildModelsProviderData` return signature remain unchanged, including typed adapters returning the old shape. A thin SDK forwarding wrapper calls one canonical metadata producer. Bundled/internal callers use the additive `buildPreparedModelsProviderData`, whose inferred result requires selected physical-route metadata. Its named result type stays internal; `ModelsRuntimeChoice` and both old builder exports are preserved. Removal requires an explicitly approved SDK-breaking boundary.

The existing published-package consumer check failed TS2741 for an old literal and TS2322 for an old typed adapter before this repair. Against regenerated final declarations, both old subpath spellings pass; the new builder requires a catalog with typed model metadata. All 147 public SDK subpaths verify. The sole new public function accounts for the approved +1 export / +1 callable budget adjustment: 4352 and 2588 respectively. No other budget, baseline, ignore, or unrelated export was changed.

The compatibility repair passed 145 focused command/browse, session service, Discord, Mattermost, Telegram callback and real grammY/loopback cases, plus all 10 SDK surface-guard tests. Scoped types, type-aware lint, formatting, zero runtime import cycles, and fresh independent Codex P0 review passed. Full `pnpm build` passed in 11m34s with unchanged tracked source during that build. The subsequent edits were type-only export removal, compile-test/docs updates, and the approved guard limits; final declarations were regenerated and the public-consumer, surface, type, lint, and review checks rerun. No runtime chunks changed after the successful build.

```bash
node --import ./scripts/tsx.mjs scripts/write-plugin-sdk-entry-dts.ts
node --import ./scripts/tsx.mjs scripts/check-plugin-sdk-exports.mts
pnpm plugin-sdk:surface:check
node scripts/run-vitest.mjs test/scripts/plugin-sdk-surface-report.test.ts
```

The stored-data detector is a false positive for a format/schema change: reset calls existing `persistReplySessionEntry` with `SESSION_MODEL_OVERRIDE_TRANSACTION_FIELDS` and the model-selection lock guard. No SQLite table, schema version, migration, serialized field, or store design changed. [Review finding response](https://github.com/openclaw/openclaw/pull/132175#issuecomment-5458694991).

**Size:** production +439/-428 (**net +11**); tests/support +680/-107 (**net +573**); docs +23. The behavioral repair was net -7 production lines; preserving the demonstrated stable SDK construction/adapter contract and documenting the approved guard increment account for the growth. One metadata producer remains; no discovery or policy flow is duplicated.

AI-assisted. Documentation: https://docs.openclaw.ai/concepts/models

![Isolated synthetic chat model selection, rejection, and reset proof](https://github.com/user-attachments/assets/f6803cc5-842c-4f0e-848f-e6f588e5172e)
