### PR TITLE
docs(plugins): correct bundled override precedence

### DIFF
--- a/docs/plugins/architecture.md
+++ b/docs/plugins/architecture.md
@@ -433,7 +433,11 @@ Use allowlists and explicit install/load paths for non-bundled plugins. Treat wo
 For bundled workspace package names, keep the plugin id anchored in the npm name: `@openclaw/<id>` by default, or an approved typed suffix such as `-provider`, `-plugin`, `-speech`, `-sandbox`, or `-media-understanding` when the package intentionally exposes a narrower plugin role.
 
 <Note>
-**Trust note:** `plugins.allow` trusts **plugin ids**, not source provenance. A workspace plugin with the same id as a bundled plugin intentionally shadows the bundled copy when that workspace plugin is enabled/allowlisted. This is normal and useful for local development, patch testing, and hotfixes. Bundled-plugin trust is resolved from the source snapshot — the manifest and code on disk at load time — rather than from install metadata. A corrupted or substituted install record cannot silently widen a bundled plugin's trust surface beyond what the actual source claims.
+**Trust note:** `plugins.allow` permits **plugin ids** to load; it does not verify source provenance or choose which same-id copy loads. An auto-discovered workspace plugin does not shadow a bundled plugin merely because that id is enabled or allowlisted.
+
+For intentional local overrides, use `plugins.load.paths` to select the plugin path. Tracked global installs can also override ordinary bundled copies, while bundled plugins from `OPENCLAW_DEV_SOURCE_ROOT` retain priority over tracked globals. See [Discovery precedence](/plugins/manifest#discovery-precedence-duplicate-plugin-ids) for the full order.
+
+Bundled-plugin trust is resolved from the source snapshot — the manifest and code on disk at load time — rather than from install metadata. A corrupted or substituted install record cannot silently widen a bundled plugin's trust surface beyond what the actual source claims.
 </Note>
 
 ## Export boundary

--- a/docs/plugins/manifest.md
+++ b/docs/plugins/manifest.md
@@ -1409,22 +1409,22 @@ Use `env.allOf` when every listed variable is required and `env.anyOf` when any 
 
 ## Discovery precedence (duplicate plugin ids)
 
-OpenClaw discovers plugins from three roots, checked in this order: bundled plugins shipped with OpenClaw, the global install root (`~/.openclaw/extensions`), and the current workspace root (`<workspace>/.openclaw/extensions`), plus any explicit `plugins.load.paths` entries.
+OpenClaw discovers plugins from explicit `plugins.load.paths` entries, the current workspace root (`<workspace>/.openclaw/extensions`), bundled plugins shipped with OpenClaw, and global install locations (`~/.openclaw/extensions` plus tracked install paths). Discovery order alone does not determine which copy loads.
 
-If two discoveries share the same `id`, only the **highest-precedence** manifest is kept; lower-precedence duplicates are dropped instead of loading beside it. Precedence, highest to lowest:
+If two distinct plugin roots share the same `id`, only the **highest-precedence** manifest is kept; lower-precedence duplicates are dropped instead of loading beside it. Precedence, highest to lowest:
 
-1. **Config-selected** — a path explicitly pinned in `plugins.entries.<id>`
-2. **Global install matching a tracked install record** — a plugin installed via `openclaw plugin install`/`openclaw plugin update` that OpenClaw's install tracking recognizes for that same id, even when the id also belongs to a bundled plugin
-3. **Bundled** — plugins shipped with OpenClaw
-4. **Workspace** — plugins discovered relative to the current workspace
-5. Any other discovered candidate
+1. **Config-selected** — a path explicitly selected in `plugins.load.paths`
+2. **Development-source bundled** — a bundled plugin inside the checkout selected by `OPENCLAW_DEV_SOURCE_ROOT`
+3. **Global install matching a tracked install record** — an installed global candidate whose path matches its install record, managed by `openclaw plugins install`/`openclaw plugins update`
+4. **Bundled** — other plugins shipped with OpenClaw
+5. **Workspace** — plugins discovered relative to the current workspace
+6. **Untracked global** — other plugins discovered in the global root
 
 Implications:
 
-- A forked or stale copy of a bundled plugin sitting untracked in the workspace or global root will not shadow the bundled build.
-- To override a bundled plugin, either run `openclaw plugin install` for that id so the tracked global install outranks the bundled copy, or pin a specific path via `plugins.entries.<id>` so it wins by config-selected precedence.
-- Duplicate drops are logged so Doctor and startup diagnostics can point at the discarded copy.
-- Config-selected duplicate overrides are worded as explicit overrides in diagnostics, but still warn so stale forks and accidental shadows stay visible.
+- An auto-discovered workspace or untracked global copy will not shadow a bundled plugin, even when its id is enabled or allowlisted. `plugins.allow` and `plugins.entries.<id>.enabled` control load permission, not source selection.
+- To override a bundled plugin intentionally, select its path via `plugins.load.paths`. A tracked global install can also override an ordinary bundled copy, but not a development-source bundled copy.
+- Duplicate warnings identify the discarded copy and selected source, with config-selected winners labeled as explicit overrides. Intentional tracked-install overrides of ordinary bundled copies do not emit duplicate warnings.
 
 ## JSON Schema requirements
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators following the plugin internals documentation would expect an enabled or allowlisted workspace plugin to replace a bundled plugin with the same id. Current manifest selection and loading keep the bundled copy ahead of an auto-discovered workspace copy; enablement does not change that source selection.

The related manifest reference also named the wrong config field for selecting an override path and used singular `openclaw plugin` commands.

## Why This Change Was Made

Correct the public trust note and its linked duplicate-precedence reference to match the existing canonical discovery → manifest selection → activation → loading flow. Document explicit `plugins.load.paths` selection, matching tracked global installs, ordinary bundled precedence, and the separate `OPENCLAW_DEV_SOURCE_ROOT` bundled priority. Clarify the intentional tracked-install duplicate-warning exception.

This is documentation only. It does not change runtime policy, configuration schema, plugin trust/capability gates, or the separate developer-plugin trust design.

The stale note was added in [3cf06f793957](https://github.com/openclaw/openclaw/commit/3cf06f7939578541120712947a7d6b30561b4477), before [8d44b16b7cc7](https://github.com/openclaw/openclaw/commit/8d44b16b7cc7705dc878ef7cc9fbcba6dcb9e179) reserved bundled duplicates. Source inspection of stable tag `v2026.7.1-2` confirms the documented ranking is shipped behavior rather than a new policy.

## User Impact

Operators can distinguish permission to load a plugin id from selection of its source, and use `plugins.load.paths` for intentional local overrides instead of relying on workspace enablement. The six-tier precedence list preserves both tracked-install overrides and development-source priority.

Public references: [Plugin internals](https://docs.openclaw.ai/plugins/architecture#execution-model) and [Discovery precedence](https://docs.openclaw.ai/plugins/manifest#discovery-precedence-duplicate-plugin-ids).

## Evidence

- Personally inspected discovery, manifest ranking, installed-index/snapshot propagation, shared loader discovery, runtime and CLI loaders, activation, and the focused existing tests. The two ranking owners are `src/plugins/manifest-registry.ts` and `src/plugins/loader-provenance.ts`.
- Verified the affected documentation and runtime owner files have no drift against freshly fetched `origin/main` before publication.
- Focused existing behavior proof: **10 tests passed across 3 files**, including the enabled/allowlisted workspace duplicate, configured-path override, tracked global override, development-source priority, and discovery-order cases:

```bash
node scripts/run-vitest.mjs src/plugins/loader.test.ts src/plugins/manifest-registry.test.ts src/plugins/discovery.test.ts -t 'resolves duplicate plugin ids by source precedence|handles workspace-discovered plugins according to trust and precedence|keeps only the higher-precedence plugin|lets config-loaded plugins replace bundled duplicates|explicit installed globals overriding bundled plugins|prefers dev source bundled plugins|installed global is discovered before bundled|discovers global and workspace extensions|preserves configured load-path order|discovers bundled and global plugins for each workspace-specific scan'
```

```bash
pnpm check:docs
```

The complete docs suite passed: formatting, Markdown and template lint, MDX, i18n glossary, internal links (0 broken), and config examples (1,208 validated).

```bash
git diff --check
```

Documentation LOC: +16/-12 across two files. Production LOC: +0/-0. Tests/test support: +0/-0. Existing tests already cover the behavior; no runtime regression test or live Gateway change is needed for this prose correction. No operator config or services were changed.

AI-assisted documentation correction; source and validation results reviewed by the maintainer session.
