### PR TITLE
fix(code-mode): cancel resumed cells when their catalog closes

### DIFF
--- a/docs/tools/code-mode.md
+++ b/docs/tools/code-mode.md
@@ -662,10 +662,17 @@ QuickJS-WASI snapshot/restore is the resume mechanism:
 Snapshots are runtime state, not user artifacts: they live only in an
 in-process map (no database or disk write), are size-limited, expire, and are
 scoped to the run and session that created them.
-Canceling the owning run or tool call, or closing its tool catalog at attempt
-teardown, immediately releases parked snapshots and cancels their pending host
-work, even if no `wait` call follows. Catalog description refreshes and client
-tool additions do not close the owner.
+One cell owner spans initial execution, suspension, and every resume. Canceling
+the owning run or current tool call, or closing its tool catalog at attempt
+teardown, cancels active workers and pending host work and releases parked
+snapshots, even if no `wait` call follows. Catalog description refreshes and
+client tool additions do not close the owner. An external operation that ignores
+cancellation may still finish, but cannot resume the closed guest, emit later
+guest output, or start another guest tool call.
+
+The process-wide limit of 64 slots applies to suspended cells and their reserved
+resume slots. A resume keeps its slot until it completes or parks again; an
+initial execution that completes without suspending does not consume a slot.
 
 `wait` fails (as a `failed` result) when:
 

--- a/extensions/copilot/src/catalog-lifetime.test-support.ts
+++ b/extensions/copilot/src/catalog-lifetime.test-support.ts
@@ -15,26 +15,29 @@ export async function createCopilotFaultPeer() {
   const sockets = new Set<Socket>();
   let socket: Socket;
   let sessionId: string;
+  let previousEventId: string | null = null;
   const send = (value: unknown) => {
     const bytes = Buffer.from(JSON.stringify(value));
     socket.write(`Content-Length: ${bytes.length}\r\n\r\n`);
     socket.write(bytes);
   };
   const emit = (type: string, data: Record<string, unknown>) => {
+    const id = randomUUID();
     send({
       jsonrpc: "2.0",
       method: "session.event",
       params: {
         sessionId,
         event: {
-          id: randomUUID(),
-          parentId: null,
+          id,
+          parentId: previousEventId,
           timestamp: new Date().toISOString(),
           type,
           data,
         },
       },
     });
+    previousEventId = id;
   };
   const handle = async (request: Request) => {
     methods.push(request.method);

--- a/extensions/copilot/src/catalog-lifetime.test-support.ts
+++ b/extensions/copilot/src/catalog-lifetime.test-support.ts
@@ -1,0 +1,141 @@
+import { randomUUID } from "node:crypto";
+import { createServer, type Socket } from "node:net";
+import { CopilotClient, RuntimeConnection } from "@github/copilot-sdk";
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
+
+type Request = { id: number; method: string; params: Record<string, unknown> };
+
+/** A loopback CLI protocol peer; the client, session, and tool dispatch are the real SDK. */
+export async function createCopilotFaultPeer() {
+  const sent = createDeferred<void>();
+  const destroying = createDeferred<void>();
+  const releaseDestroy = createDeferred<void>();
+  const replies = new Map<string, ReturnType<typeof createDeferred<Record<string, unknown>>>>();
+  const methods: string[] = [];
+  const sockets = new Set<Socket>();
+  let socket: Socket;
+  let sessionId: string;
+  const send = (value: unknown) => {
+    const bytes = Buffer.from(JSON.stringify(value));
+    socket.write(`Content-Length: ${bytes.length}\r\n\r\n`);
+    socket.write(bytes);
+  };
+  const emit = (type: string, data: Record<string, unknown>) => {
+    send({
+      jsonrpc: "2.0",
+      method: "session.event",
+      params: {
+        sessionId,
+        event: {
+          id: randomUUID(),
+          parentId: null,
+          timestamp: new Date().toISOString(),
+          type,
+          data,
+        },
+      },
+    });
+  };
+  const handle = async (request: Request) => {
+    methods.push(request.method);
+    switch (request.method) {
+      case "connect":
+        return { protocolVersion: 3 };
+      case "session.create":
+        sessionId = String(request.params.sessionId);
+        return { sessionId };
+      case "session.send":
+        emit("user.message", { content: request.params.prompt });
+        sent.resolve();
+        return { messageId: "fixture-user" };
+      case "session.tools.handlePendingToolCall":
+        replies.get(String(request.params.requestId))?.resolve(request.params);
+        return {};
+      case "session.abort":
+        return {};
+      case "session.destroy":
+        destroying.resolve();
+        await releaseDestroy.promise;
+        return {};
+      default:
+        throw new Error(`Unexpected Copilot fixture RPC: ${request.method}`);
+    }
+  };
+  const server = createServer((connected) => {
+    socket = connected;
+    sockets.add(connected);
+    connected.on("close", () => sockets.delete(connected));
+    let buffer = Buffer.alloc(0);
+    connected.on("data", (chunk) => {
+      buffer = Buffer.concat([buffer, Buffer.from(chunk)]);
+      while (true) {
+        const separator = buffer.indexOf("\r\n\r\n");
+        if (separator < 0) {
+          return;
+        }
+        const length = Number(
+          /Content-Length: (\d+)/i.exec(buffer.subarray(0, separator).toString())?.[1],
+        );
+        if (buffer.length < separator + 4 + length) {
+          return;
+        }
+        const request = JSON.parse(
+          buffer.subarray(separator + 4, separator + 4 + length).toString(),
+        ) as Request;
+        buffer = buffer.subarray(separator + 4 + length);
+        void handle(request).then(
+          (result) => send({ jsonrpc: "2.0", id: request.id, result }),
+          (error: unknown) =>
+            send({
+              jsonrpc: "2.0",
+              id: request.id,
+              error: {
+                code: -32603,
+                message: error instanceof Error ? error.message : String(error),
+              },
+            }),
+        );
+      }
+    });
+  });
+  await new Promise<void>((resolve) => {
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("Expected loopback TCP listener");
+  }
+  const client = new CopilotClient({
+    connection: RuntimeConnection.forUri(`127.0.0.1:${address.port}`),
+  });
+  return {
+    client,
+    methods,
+    sent: sent.promise,
+    destroying: destroying.promise,
+    releaseDestroy: () => releaseDestroy.resolve(),
+    emit,
+    requestTool(name: string, args: Record<string, unknown>) {
+      const requestId = randomUUID();
+      const reply = createDeferred<Record<string, unknown>>();
+      replies.set(requestId, reply);
+      emit("external_tool.requested", {
+        requestId,
+        toolCallId: requestId,
+        toolName: name,
+        arguments: args,
+      });
+      return reply.promise;
+    },
+    async close() {
+      releaseDestroy.resolve();
+      await client.stop();
+      for (const connected of sockets) {
+        connected.destroy();
+      }
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      });
+    },
+  };
+}

--- a/extensions/copilot/src/catalog-lifetime.test.ts
+++ b/extensions/copilot/src/catalog-lifetime.test.ts
@@ -3,6 +3,7 @@ import type {
   AgentHarnessAttemptParamsV2,
   AnyAgentTool,
 } from "openclaw/plugin-sdk/agent-harness-runtime";
+import { createContractToolTerminalObserver } from "openclaw/plugin-sdk/agent-runtime-test-contracts";
 import { AuthStorage, ModelRegistry } from "openclaw/plugin-sdk/agent-sessions";
 import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
 import { createAdmittedHostCapabilityTestFixture } from "openclaw/plugin-sdk/plugin-test-runtime";
@@ -55,6 +56,8 @@ it("cancels a resumed Code Mode cell during real SDK session.error cleanup befor
   };
   const sessionId = "catalog-lifetime-session";
   const sessionKey = "agent:main:catalog-lifetime";
+  const runId = "catalog-lifetime-run";
+  const providerFailure = "deterministic non-timeout provider failure";
   const target = {
     agentId: "main",
     sessionId,
@@ -90,7 +93,7 @@ it("cancels a resumed Code Mode cell during real SDK session.error cleanup befor
   const config = { tools: { codeMode: { enabled: true } } };
   const host = await createAdmittedHostCapabilityTestFixture({
     config,
-    runId: "catalog-lifetime-run",
+    runId,
     agentId: "main",
     sessionId,
     sessionKey,
@@ -125,7 +128,7 @@ it("cancels a resumed Code Mode cell during real SDK session.error cleanup befor
       sessionKey,
       sessionTarget: target,
       sessionFile: path.join(state.sessionsDir(), "catalog-lifetime.jsonl"),
-      runId: "catalog-lifetime-run",
+      runId,
       config,
       hostCapabilities: host.hostCapabilities,
       auth: { useLoggedInUser: true },
@@ -150,6 +153,7 @@ it("cancels a resumed Code Mode cell during real SDK session.error cleanup befor
       prompt: userMessage.content,
       timeoutMs: 60_000,
       abortSignal: callController.signal,
+      observeToolTerminal: createContractToolTerminalObserver(runId),
       userTurnTranscriptRecorder: recorder,
       onAgentToolResult: (event: { toolName: string; result: unknown }) => {
         observed.push(event);
@@ -175,7 +179,7 @@ it("cancels a resumed Code Mode cell during real SDK session.error cleanup befor
     host.hostCapabilities.assertActive();
     expect(nestedSignal?.aborted).toBe(false);
     peer.emit("session.error", {
-      message: "deterministic non-timeout provider failure",
+      message: providerFailure,
       errorType: "model_error",
     });
     await peer.destroying;
@@ -203,7 +207,36 @@ it("cancels a resumed Code Mode cell during real SDK session.error cleanup befor
       waitResult,
     };
     peer.releaseDestroy();
-    await attempt;
+    const attemptResult = await attempt;
+    if (!("terminal" in attemptResult)) {
+      throw new Error("Expected a canonical Copilot attempt terminal");
+    }
+    const terminal = attemptResult.terminal;
+    const failure =
+      terminal.kind === "failed" ? terminal : "failure" in terminal ? terminal.failure : undefined;
+    const attemptFacts = {
+      terminal: {
+        kind: terminal.kind,
+        source: "source" in terminal ? terminal.source : null,
+        failureSource: failure?.source ?? null,
+        errorMessage: failure?.error instanceof Error ? failure.error.message.slice(0, 512) : null,
+      },
+      lastToolError: attemptResult.lastToolError
+        ? {
+            toolName: attemptResult.lastToolError.toolName,
+            error: attemptResult.lastToolError.error?.slice(0, 512),
+            executionStarted: attemptResult.lastToolError.executionStarted,
+            mutatingAction: attemptResult.lastToolError.mutatingAction,
+          }
+        : null,
+      toolMetas: attemptResult.toolMetas.slice(0, 8).map(({ toolName, isError, meta }) => ({
+        toolName,
+        isError,
+        meta: meta?.slice(0, 512),
+      })),
+      replayMetadata: attemptResult.replayMetadata,
+      outerAborted: callController.signal.aborted,
+    };
     expect(() => host.hostCapabilities.assertActive()).toThrow(/no longer active/);
     const retainedTool = retained.at(0);
     if (!retainedTool) {
@@ -214,6 +247,7 @@ it("cancels a resumed Code Mode cell during real SDK session.error cleanup befor
       "CATALOG_LIFETIME_VERDICT",
       JSON.stringify({
         ...cleanupWindow,
+        attempt: attemptFacts,
         caller: "createCopilotAgentHarness.runAttempt",
         finalHostClosed: true,
         retainedToolRejected: true,
@@ -225,6 +259,18 @@ it("cancels a resumed Code Mode cell during real SDK session.error cleanup befor
     expect(aborts).toBe(1);
     expect(waitResult).toMatchObject({ details: { status: "failed", code: "aborted" } });
     expect(JSON.stringify(waitResult)).not.toContain("STALE AFTER CLOSE");
+    expect(attemptFacts.terminal).toEqual({
+      kind: "failed",
+      source: "prompt",
+      failureSource: "prompt",
+      errorMessage: providerFailure,
+    });
+    expect(callController.signal.aborted).toBe(false);
+    expect(attemptResult.lastToolError).toMatchObject({
+      toolName: "wait",
+      error: "code mode execution aborted",
+      executionStarted: true,
+    });
   } finally {
     gate.resolve();
     peer.releaseDestroy();

--- a/extensions/copilot/src/catalog-lifetime.test.ts
+++ b/extensions/copilot/src/catalog-lifetime.test.ts
@@ -183,6 +183,8 @@ it("cancels a resumed Code Mode cell during real SDK session.error cleanup befor
     host.hostCapabilities.assertActive();
     expect(callController.signal.aborted).toBe(false);
     expect(contextSignal?.aborted).toBe(false);
+    const abortsBeforeGateRelease = aborts;
+    const nestedAbortedBeforeGateRelease = nestedSignal?.aborted;
     gate.resolve();
     await waitReply;
     const waitResult = observed.find((event) => event.toolName === "wait")?.result;
@@ -194,6 +196,8 @@ it("cancels a resumed Code Mode cell during real SDK session.error cleanup befor
       callAborted: callController.signal.aborted,
       admissionRunId: host.admittedRunContext.operationalRunInstance.runId,
       hostActiveAtCleanup: true,
+      abortsBeforeGateRelease,
+      nestedAbortedBeforeGateRelease,
       nestedAborted: nestedSignal?.aborted,
       aborts,
       waitResult,
@@ -216,6 +220,8 @@ it("cancels a resumed Code Mode cell during real SDK session.error cleanup befor
         rpcMethods: peer.methods,
       }),
     );
+    expect(abortsBeforeGateRelease).toBe(1);
+    expect(nestedAbortedBeforeGateRelease).toBe(true);
     expect(aborts).toBe(1);
     expect(waitResult).toMatchObject({ details: { status: "failed", code: "aborted" } });
     expect(JSON.stringify(waitResult)).not.toContain("STALE AFTER CLOSE");

--- a/extensions/copilot/src/catalog-lifetime.test.ts
+++ b/extensions/copilot/src/catalog-lifetime.test.ts
@@ -1,0 +1,234 @@
+import path from "node:path";
+import type {
+  AgentHarnessAttemptParamsV2,
+  AnyAgentTool,
+} from "openclaw/plugin-sdk/agent-harness-runtime";
+import { AuthStorage, ModelRegistry } from "openclaw/plugin-sdk/agent-sessions";
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
+import { createAdmittedHostCapabilityTestFixture } from "openclaw/plugin-sdk/plugin-test-runtime";
+import { upsertSessionEntry } from "openclaw/plugin-sdk/session-store-runtime";
+import { createOpenClawTestState } from "openclaw/plugin-sdk/test-state";
+import { expect, it, vi } from "vitest";
+import { createCopilotAgentHarness } from "../harness.js";
+import { createCopilotFaultPeer } from "./catalog-lifetime.test-support.js";
+import { createCopilotClientPool } from "./runtime.js";
+import { createCopilotToolBridge } from "./tool-bridge.js";
+import * as toolBridgeModule from "./tool-bridge.js";
+
+it("cancels a resumed Code Mode cell during real SDK session.error cleanup before host closure", async () => {
+  const state = await createOpenClawTestState({ label: "copilot-catalog-lifetime" });
+  const peer = await createCopilotFaultPeer();
+  const pool = createCopilotClientPool({ sdkFactory: () => peer.client });
+  const harness = createCopilotAgentHarness({ pool });
+  const entered = createDeferred<void>();
+  const gate = createDeferred<void>();
+  const callController = new AbortController();
+  const observed: Array<{ toolName: string; result: unknown }> = [];
+  let aborts = 0;
+  let nestedSignal: AbortSignal | undefined;
+  type ToolOptions = NonNullable<
+    Parameters<
+      NonNullable<Parameters<typeof createCopilotToolBridge>[0]["createOpenClawCodingTools"]>
+    >[0]
+  >;
+  let catalog: ToolOptions["toolSearchCatalogRef"];
+  let contextSignal: AbortSignal | undefined;
+  let retained: AnyAgentTool[] = [];
+  const fixtureTool: AnyAgentTool = {
+    name: "fixture_gate",
+    label: "Fixture gate",
+    description: "Wait for the local proof gate.",
+    parameters: { type: "object", properties: {} },
+    async execute(_id, _args, signal) {
+      nestedSignal = signal;
+      signal?.addEventListener(
+        "abort",
+        () => {
+          aborts += 1;
+        },
+        { once: true },
+      );
+      entered.resolve();
+      await gate.promise;
+      return { content: [{ type: "text", text: "gate released" }], details: { released: true } };
+    },
+  };
+  const sessionId = "catalog-lifetime-session";
+  const sessionKey = "agent:main:catalog-lifetime";
+  const target = {
+    agentId: "main",
+    sessionId,
+    sessionKey,
+    storePath: path.join(state.sessionsDir(), "sessions.json"),
+  };
+  const userMessage = {
+    role: "user" as const,
+    content: "Exercise the deterministic catalog lifetime fixture.",
+    timestamp: Date.now(),
+  };
+  let persisted = false;
+  let blocked = false;
+  const recorder: NonNullable<AgentHarnessAttemptParamsV2["userTurnTranscriptRecorder"]> = {
+    message: userMessage,
+    resolveMessage: async () => userMessage,
+    markRuntimePersistencePending: () => {},
+    markRuntimePersisted: () => {
+      persisted = true;
+    },
+    markBlocked: () => {
+      blocked = true;
+    },
+    hasPersisted: () => persisted,
+    isBlocked: () => blocked,
+    hasRuntimePersistencePending: () => false,
+    getAdmissionReceipt: () => undefined,
+    waitForRuntimePersistence: async () => {},
+    persistApproved: async () => {},
+    persistBlocked: async () => {},
+    persistFallback: async () => {},
+  };
+  const config = { tools: { codeMode: { enabled: true } } };
+  const host = await createAdmittedHostCapabilityTestFixture({
+    config,
+    runId: "catalog-lifetime-run",
+    agentId: "main",
+    sessionId,
+    sessionKey,
+    workspaceDir: state.workspaceDir,
+    abortSignal: callController.signal,
+  });
+  let attempt: ReturnType<typeof harness.runAttempt> | undefined;
+  const realCreateToolBridge = createCopilotToolBridge;
+  const constructBridge = vi
+    .spyOn(toolBridgeModule, "createCopilotToolBridge")
+    .mockImplementation(async (input) => {
+      const bridge = await realCreateToolBridge({
+        ...input,
+        createOpenClawCodingTools: (options) => {
+          catalog = options?.toolSearchCatalogRef;
+          contextSignal = options?.abortSignal;
+          return [fixtureTool];
+        },
+      });
+      retained = bridge.sourceTools;
+      return bridge;
+    });
+  try {
+    await state.writeConfig(config);
+    await upsertSessionEntry({ ...target, entry: { sessionId, updatedAt: Date.now() } });
+    const authStorage = AuthStorage.inMemory();
+    const params = {
+      agentId: "main",
+      agentDir: state.agentDir(),
+      workspaceDir: state.workspaceDir,
+      sessionId,
+      sessionKey,
+      sessionTarget: target,
+      sessionFile: path.join(state.sessionsDir(), "catalog-lifetime.jsonl"),
+      runId: "catalog-lifetime-run",
+      config,
+      hostCapabilities: host.hostCapabilities,
+      auth: { useLoggedInUser: true },
+      provider: "github-copilot",
+      modelId: "auto",
+      model: {
+        api: "openai-responses",
+        provider: "github-copilot",
+        id: "auto",
+        name: "Local protocol fixture",
+        baseUrl: "http://127.0.0.1",
+        reasoning: false,
+        input: ["text"],
+        contextWindow: 128000,
+        maxTokens: 8192,
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      },
+      authStorage,
+      authProfileStore: { version: 1, profiles: {} },
+      modelRegistry: ModelRegistry.inMemory(authStorage),
+      thinkLevel: "off",
+      prompt: userMessage.content,
+      timeoutMs: 60_000,
+      abortSignal: callController.signal,
+      userTurnTranscriptRecorder: recorder,
+      onAgentToolResult: (event: { toolName: string; result: unknown }) => {
+        observed.push(event);
+      },
+    } satisfies AgentHarnessAttemptParamsV2 & { auth: { useLoggedInUser: true } };
+    attempt = harness.runAttempt(params).finally(() => {
+      host.closeHost();
+      host.closeAdmission();
+    });
+    await peer.sent;
+    const execReply = peer.requestTool("exec", {
+      code: 'await yield_control(); await fixture_gate({}); text("STALE AFTER CLOSE"); return "stale";',
+    });
+    await execReply;
+    const execResult = observed.find((event) => event.toolName === "exec")?.result as {
+      details: { status: string; runId: string };
+    };
+    expect(execResult.details.status).toBe("waiting");
+    const catalogIdentity = catalog?.current;
+    expect(catalogIdentity).toBeDefined();
+    const waitReply = peer.requestTool("wait", { runId: execResult.details.runId });
+    await entered.promise;
+    host.hostCapabilities.assertActive();
+    expect(nestedSignal?.aborted).toBe(false);
+    peer.emit("session.error", {
+      message: "deterministic non-timeout provider failure",
+      errorType: "model_error",
+    });
+    await peer.destroying;
+    expect(catalog?.current).toBeUndefined();
+    host.hostCapabilities.assertActive();
+    expect(callController.signal.aborted).toBe(false);
+    expect(contextSignal?.aborted).toBe(false);
+    gate.resolve();
+    await waitReply;
+    const waitResult = observed.find((event) => event.toolName === "wait")?.result;
+    const cleanupWindow = {
+      cellId: execResult.details.runId,
+      catalogId: catalogIdentity?.counterScope,
+      catalogClosed: catalog?.current === undefined,
+      contextAborted: contextSignal?.aborted,
+      callAborted: callController.signal.aborted,
+      admissionRunId: host.admittedRunContext.operationalRunInstance.runId,
+      hostActiveAtCleanup: true,
+      nestedAborted: nestedSignal?.aborted,
+      aborts,
+      waitResult,
+    };
+    peer.releaseDestroy();
+    await attempt;
+    expect(() => host.hostCapabilities.assertActive()).toThrow(/no longer active/);
+    const retainedTool = retained.at(0);
+    if (!retainedTool) {
+      throw new Error("Expected a retained host-bound tool");
+    }
+    await expect(retainedTool.execute("retained", {})).rejects.toThrow(/no longer active/);
+    console.log(
+      "CATALOG_LIFETIME_VERDICT",
+      JSON.stringify({
+        ...cleanupWindow,
+        caller: "createCopilotAgentHarness.runAttempt",
+        finalHostClosed: true,
+        retainedToolRejected: true,
+        rpcMethods: peer.methods,
+      }),
+    );
+    expect(aborts).toBe(1);
+    expect(waitResult).toMatchObject({ details: { status: "failed", code: "aborted" } });
+    expect(JSON.stringify(waitResult)).not.toContain("STALE AFTER CLOSE");
+  } finally {
+    gate.resolve();
+    peer.releaseDestroy();
+    await attempt;
+    host.closeHost();
+    host.closeAdmission();
+    constructBridge.mockRestore();
+    await harness.dispose?.();
+    await pool.dispose();
+    await peer.close();
+    await state.cleanup();
+  }
+});

--- a/src/agents/code-mode-execution.ts
+++ b/src/agents/code-mode-execution.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from "node:crypto";
 import {
   observeAgentRunApprovalWait,
   type AgentRunApprovalWait,
@@ -37,6 +36,7 @@ import {
   codeModeAbortedResult,
   codeModeWaitingReason,
   createCodeModeBridgeDispatchState,
+  createCodeModeRunOwner,
   createPendingBridgeStates,
   disposeCodeModeRun,
   isCodeModeBridgeRepairEligible,
@@ -47,13 +47,13 @@ import {
   reserveActiveRunSlot,
   resumingRunIds,
   settledBridgeRequestsInCompletionOrder,
-  snapshotState,
   storeSnapshotState,
   takeUndeliveredCodeModeRunOutput,
   telemetry,
   waitForPendingBridgeSettlement,
   type PendingBridgeState,
   type CodeModeBridgeDispatchState,
+  type CodeModeRunOwner,
 } from "./code-mode-state.js";
 import { normalizeCodeModeWorkerResult, runCodeModeWorker } from "./code-mode-worker.js";
 import type { AgentToolUpdateCallback } from "./runtime/index.js";
@@ -81,18 +81,6 @@ export async function runCodeModeExec(params: {
   });
   params.onRuntime?.(runtime);
   const bridgeDispatch = createCodeModeBridgeDispatchState();
-  if (params.signal?.aborted) {
-    return {
-      status: "failed" as const,
-      error: "code mode execution aborted",
-      code: "aborted" as const,
-      failurePhase: "host" as const,
-      bridgeDispatchStarted: false,
-      output: [],
-      replaySafe: params.restartSafe,
-      telemetry: telemetry(runtime),
-    };
-  }
   const deadlineMs = Date.now() + config.timeoutMs;
   const namespaceCatalog = runtime.namespaceEntries();
   const swarmEnabled = resolveSwarmConfig(
@@ -111,11 +99,13 @@ export async function runCodeModeExec(params: {
   });
   const apiFiles = createCodeModeApiFilesForRun(namespaceRuntime, swarmEnabled);
   const approvalWait = observeAgentRunApprovalWait(params.ctx);
+  const owner = createCodeModeRunOwner(params.ctx);
+  const signal = owner.bindCall(params.signal);
   try {
     const source = await awaitCodeModeDeadline({
       operation: () => prepareSource({ code: params.code, language: params.language, config }),
       remainingMs: deadlineMs - Date.now(),
-      signal: params.signal,
+      signal,
       createTimeoutError: () => new Error("interrupted"),
       createAbortError: () => new Error("code mode execution aborted"),
     });
@@ -136,10 +126,11 @@ export async function runCodeModeExec(params: {
         },
         remainingMs + CODE_MODE_WORKER_WATCHDOG_GRACE_MS,
         undefined,
-        params.signal,
+        signal,
       ),
     );
     return await settleCodeModeResult({
+      owner,
       result,
       output: result.output,
       replaySafe: params.restartSafe,
@@ -153,13 +144,13 @@ export async function runCodeModeExec(params: {
       namespaceRuntime,
       bridgeDispatch,
       approvalWait,
-      signal: params.signal,
+      signal,
       onUpdate: params.onUpdate,
     });
   } catch (error) {
-    const code = params.signal?.aborted ? ("aborted" as const) : codeModeFailureCode(error);
+    const code = signal.aborted ? ("aborted" as const) : codeModeFailureCode(error);
     const bounded = boundCodeModeResult({
-      error: params.signal?.aborted ? "code mode execution aborted" : codeModeFailureMessage(error),
+      error: signal.aborted ? "code mode execution aborted" : codeModeFailureMessage(error),
       output: [],
       maxOutputBytes: config.maxOutputBytes,
     });
@@ -179,6 +170,9 @@ export async function runCodeModeExec(params: {
     };
   } finally {
     approvalWait.dispose();
+    if (!activeRuns.has(owner.runId)) {
+      owner.close();
+    }
   }
 }
 
@@ -258,6 +252,7 @@ async function waitForPending(
 }
 
 async function settleCodeModeResult(params: {
+  owner: CodeModeRunOwner;
   result: CodeModeWorkerResult;
   output: unknown[];
   replaySafe: boolean;
@@ -271,11 +266,10 @@ async function settleCodeModeResult(params: {
   deadlineMs: number;
   deliveredOutputCount?: number;
   pending?: PendingBridgeState[];
-  activeRunId?: string;
   reservedActiveRunSlot?: boolean;
   bridgeDispatch: CodeModeBridgeDispatchState;
   approvalWait: AgentRunApprovalWait;
-  signal?: AbortSignal;
+  signal: AbortSignal;
   onUpdate?: AgentToolUpdateCallback;
 }) {
   let result = params.result;
@@ -283,7 +277,7 @@ async function settleCodeModeResult(params: {
   if (result.status === "waiting") {
     cancelPendingBridgeStatesById(pending, result.canceledRequestIds);
   }
-  const activeRunId = params.activeRunId ?? `cm_${randomUUID()}`;
+  const activeRunId = params.owner.runId;
   const output = params.output;
   let deliveredOutputCount = params.deliveredOutputCount ?? 0;
   // One exec/wait call shares a single wall-clock deadline across its initial
@@ -374,7 +368,7 @@ async function settleCodeModeResult(params: {
         // Parked rather than resumed: without a usable budget the restore alone
         // would burn the remaining deadline and fail a recoverable run.
         return storeSnapshotState({
-          runId: activeRunId,
+          owner: params.owner,
           replayId: params.codeModeReplayId,
           pending,
           replaySafe: params.replaySafe,
@@ -389,7 +383,6 @@ async function settleCodeModeResult(params: {
           output,
           deliveredOutputCount,
           bridgeDispatch: params.bridgeDispatch,
-          signal: params.signal,
         });
       }
       // Deliver the settled frontier only. Unresolved sibling promises remain
@@ -431,11 +424,11 @@ async function settleCodeModeResult(params: {
       releaseReservation?.();
     }
   }
+  if (params.signal?.aborted) {
+    cancelPendingBridgeStates(pending);
+    return abortedResult();
+  }
   if (result.status === "waiting") {
-    if (params.signal?.aborted) {
-      cancelPendingBridgeStates(pending);
-      return abortedResult();
-    }
     const pendingReplaySafe = pendingBridgeRequestsReplaySafe(
       result.pendingRequests,
       params.runtime,
@@ -456,86 +449,63 @@ async function settleCodeModeResult(params: {
         telemetry: telemetry(params.runtime),
       };
     }
-    if (pending.length > 0) {
-      let releaseReservation: (() => void) | undefined;
-      try {
-        // A resumed guest can grow its next snapshot before the shared deadline
-        // expires; validate that new payload before reserving or parking it.
-        enforceSnapshotPayloadLimits({
-          snapshotBytes: result.snapshotBytes,
-          config: params.config,
-        });
-        // Reserve before launching fresh work; transferred snapshots must
-        // obey the same process-wide active-run cap as initial suspensions.
-        if (!params.reservedActiveRunSlot) {
-          releaseReservation = reserveActiveRunSlot();
-        }
-        const pendingIds = new Set(pending.map((entry) => entry.id));
-        const newPendingRequests = result.pendingRequests.filter(
-          (request) => !pendingIds.has(request.id),
-        );
-        pending.push(
-          ...createPendingBridgeStates({
-            pendingRequests: newPendingRequests,
-            config: params.config,
-            runtime: params.runtime,
-            catalogProjection: params.catalogProjection,
-            namespaceRuntime: params.namespaceRuntime,
-            parentToolCallId: params.parentToolCallId,
-            codeModeRunId: params.codeModeReplayId,
-            remainingMs: settleDeadline() - Date.now(),
-            activeRunId,
-            ctx: params.ctx,
-            signal: params.signal,
-            onUpdate: params.onUpdate,
-            bridgeDispatch: params.bridgeDispatch,
-          }),
-        );
-        return storeSnapshotState({
-          runId: activeRunId,
-          replayId: params.codeModeReplayId,
-          pending,
-          replaySafe: params.replaySafe && pendingReplaySafe,
-          settlementMode: result.settlementMode,
-          snapshotBytes: result.snapshotBytes,
-          parentToolCallId: params.parentToolCallId,
-          ctx: params.ctx,
+    let releaseReservation: (() => void) | undefined;
+    try {
+      // A resumed guest can grow its next snapshot before the shared deadline
+      // expires; validate that new payload before reserving or parking it.
+      enforceSnapshotPayloadLimits({
+        snapshotBytes: result.snapshotBytes,
+        config: params.config,
+      });
+      // Reserve before launching fresh work; transferred snapshots must
+      // obey the same process-wide active-run cap as initial suspensions.
+      if (!params.reservedActiveRunSlot) {
+        releaseReservation = reserveActiveRunSlot();
+      }
+      const pendingIds = new Set(pending.map((entry) => entry.id));
+      const newPendingRequests = result.pendingRequests.filter(
+        (request) => !pendingIds.has(request.id),
+      );
+      pending.push(
+        ...createPendingBridgeStates({
+          pendingRequests: newPendingRequests,
           config: params.config,
           runtime: params.runtime,
           catalogProjection: params.catalogProjection,
           namespaceRuntime: params.namespaceRuntime,
-          output,
-          deliveredOutputCount,
-          bridgeDispatch: params.bridgeDispatch,
+          parentToolCallId: params.parentToolCallId,
+          codeModeRunId: params.codeModeReplayId,
+          remainingMs: settleDeadline() - Date.now(),
+          activeRunId,
+          ctx: params.ctx,
           signal: params.signal,
-        });
-      } catch (error) {
-        cancelPendingBridgeStates(pending);
-        throw error;
-      } finally {
-        releaseReservation?.();
-      }
+          onUpdate: params.onUpdate,
+          bridgeDispatch: params.bridgeDispatch,
+        }),
+      );
+      return storeSnapshotState({
+        owner: params.owner,
+        replayId: params.codeModeReplayId,
+        pending,
+        replaySafe: params.replaySafe && pendingReplaySafe,
+        settlementMode: result.settlementMode,
+        snapshotBytes: result.snapshotBytes,
+        parentToolCallId: params.parentToolCallId,
+        ctx: params.ctx,
+        config: params.config,
+        runtime: params.runtime,
+        catalogProjection: params.catalogProjection,
+        namespaceRuntime: params.namespaceRuntime,
+        output,
+        deliveredOutputCount,
+        bridgeDispatch: params.bridgeDispatch,
+      });
+    } catch (error) {
+      cancelPendingBridgeStates(pending);
+      throw error;
+    } finally {
+      releaseReservation?.();
     }
-    return snapshotState({
-      pendingRequests: result.pendingRequests,
-      snapshotBytes: result.snapshotBytes,
-      parentToolCallId: params.parentToolCallId,
-      codeModeReplayId: params.codeModeReplayId,
-      ctx: params.ctx,
-      config: params.config,
-      runtime: params.runtime,
-      catalogProjection: params.catalogProjection,
-      namespaceRuntime: params.namespaceRuntime,
-      output,
-      remainingMs: settleDeadline() - Date.now(),
-      deliveredOutputCount,
-      reservedActiveRunSlot: params.reservedActiveRunSlot,
-      replaySafe: params.replaySafe,
-      settlementMode: result.settlementMode,
-      signal: params.signal,
-      onUpdate: params.onUpdate,
-      bridgeDispatch: params.bridgeDispatch,
-    });
   }
   // Defensive cleanup covers aborts or terminal failures; successful runs have
   // already drained every dispatched call before releasing their snapshot.
@@ -598,11 +568,11 @@ export async function runWait(params: {
   // pending calls, the resume worker, and the inline settle phase.
   const deadlineMs = Date.now() + state.config.timeoutMs;
   const approvalWait = observeAgentRunApprovalWait(state.ctx);
-  // Snapshot closure wakes an observing wait even if its guest budget just expired.
-  // Transfer releases this signal; worker execution keeps its normal per-call signal.
-  const parkedSignal = params.signal
-    ? AbortSignal.any([params.signal, state.ownerSignal])
-    : state.ownerSignal;
+  const signal = state.owner.bindCall(
+    params.ctx.abortSignal && params.signal
+      ? AbortSignal.any([params.ctx.abortSignal, params.signal])
+      : (params.signal ?? params.ctx.abortSignal),
+  );
   let releaseActiveRunSlot: (() => void) | undefined;
   try {
     const ready = await waitForPending(
@@ -610,7 +580,7 @@ export async function runWait(params: {
       state.settlementMode,
       Math.max(1, deadlineMs - Date.now()),
       approvalWait,
-      parkedSignal,
+      signal,
     );
     const resumeBudgetMs = ready
       ? usableResumeBudgetMs(deadlineMs + approvalWait.pausedMs, state.config)
@@ -618,7 +588,7 @@ export async function runWait(params: {
     if (!ready || resumeBudgetMs === undefined) {
       // An aborted wait drops the suspended run: nothing will resume it, and
       // parking it would pin a process-global active-run slot until TTL expiry.
-      if (parkedSignal.aborted) {
+      if (signal.aborted) {
         disposeCodeModeRun(state.runId);
         return {
           status: "failed" as const,
@@ -669,12 +639,13 @@ export async function runWait(params: {
         },
         resumeBudgetMs + CODE_MODE_WORKER_WATCHDOG_GRACE_MS,
         undefined,
-        params.signal,
+        signal,
       ),
     );
     const output = [...state.output, ...result.output];
     const outputTruncated = boundOutputToLimit(output, state.config);
     return await settleCodeModeResult({
+      owner: state.owner,
       result,
       output,
       replaySafe: state.replaySafe,
@@ -690,26 +661,23 @@ export async function runWait(params: {
       approvalWait,
       deliveredOutputCount: outputTruncated ? 0 : state.deliveredOutputCount,
       pending,
-      activeRunId: state.runId,
       reservedActiveRunSlot: true,
-      signal: params.signal,
+      signal,
       onUpdate: params.onUpdate,
     });
   } catch (error) {
-    // After ownership leaves activeRuns, worker/limit failures must cancel
-    // every transferred loser; there is no parked snapshot left to own it.
-    if (!activeRuns.has(state.runId)) {
-      cancelPendingBridgeStates(state.pending);
-    }
+    const aborted = signal.aborted;
+    state.owner.close();
+    cancelPendingBridgeStates(state.pending);
     const bounded = boundCodeModeResult({
-      error: codeModeFailureMessage(error),
+      error: aborted ? "code mode execution aborted" : codeModeFailureMessage(error),
       output: takeUndeliveredCodeModeRunOutput(state),
       maxOutputBytes: state.config.maxOutputBytes,
     });
     return {
       status: "failed" as const,
       error: bounded.error,
-      code: codeModeFailureCode(error),
+      code: aborted ? ("aborted" as const) : codeModeFailureCode(error),
       failurePhase: "bridge" as const,
       bridgeDispatchStarted: state.bridgeDispatch.started,
       output: bounded.output,
@@ -720,6 +688,9 @@ export async function runWait(params: {
     approvalWait.dispose();
     releaseActiveRunSlot?.();
     resumingRunIds.delete(state.runId);
+    if (!activeRuns.has(state.runId)) {
+      state.owner.close();
+    }
   }
 }
 

--- a/src/agents/code-mode-headless.ts
+++ b/src/agents/code-mode-headless.ts
@@ -32,6 +32,7 @@ import {
   cancelPendingBridgeStates,
   cancelPendingBridgeStatesById,
   createCodeModeBridgeDispatchState,
+  createCodeModeRunOwner,
   createPendingBridgeStates,
   pendingBridgeStatesForSettlement,
   settledBridgeRequestsInCompletionOrder,
@@ -219,7 +220,8 @@ export async function runCodeModeScriptHeadless(params: {
     MAX_HEADLESS_TOOL_CALLS,
   );
   const deadline = performance.now() + wallClockMs;
-  const abortScope = createHeadlessAbortScope(params.signal, wallClockMs);
+  const owner = createCodeModeRunOwner(params.ctx);
+  const abortScope = createHeadlessAbortScope(owner.bindCall(params.signal), wallClockMs);
   const output: unknown[] = [];
   let pending: PendingBridgeState[] = [];
   let toolCallCount = 0;
@@ -379,5 +381,6 @@ export async function runCodeModeScriptHeadless(params: {
   } finally {
     cancelPendingBridgeStates(pending);
     abortScope.cleanup();
+    owner.close();
   }
 }

--- a/src/agents/code-mode-state.ts
+++ b/src/agents/code-mode-state.ts
@@ -8,12 +8,11 @@ import { runBridgeRequest } from "./code-mode-bridge.js";
 import type { CodeModeCatalogProjection } from "./code-mode-catalog.js";
 import { CODE_MODE_EXEC_TOOL_NAME, CODE_MODE_WAIT_TOOL_NAME } from "./code-mode-control-tools.js";
 import type { CodeModeNamespaceRuntime } from "./code-mode-namespaces.js";
-import {
-  enforceSnapshotPayloadLimits,
-  type CodeModeConfig,
-  type CodeModeSettlementMode,
-  type PendingBridgeRequest,
-  type SettledBridgeRequest,
+import type {
+  CodeModeConfig,
+  CodeModeSettlementMode,
+  PendingBridgeRequest,
+  SettledBridgeRequest,
 } from "./code-mode-runtime.js";
 import type { AgentToolUpdateCallback } from "./runtime/index.js";
 import {
@@ -57,9 +56,10 @@ type CodeModeRunState = {
   catalogProjection: CodeModeCatalogProjection;
   namespaceRuntime: CodeModeNamespaceRuntime;
   bridgeDispatch: CodeModeBridgeDispatchState;
-  ownerSignal: AbortSignal;
-  releaseOwner: () => void;
+  owner: CodeModeRunOwner;
 };
+
+export type CodeModeRunOwner = ReturnType<typeof createCodeModeRunOwner>;
 
 const MAX_ACTIVE_CODE_MODE_RUNS = 64;
 const MAX_AGENT_WAIT_SNAPSHOT_TTL_WINDOWS = 4;
@@ -67,9 +67,73 @@ const BRIDGE_CLOSED_MESSAGE = "Code Mode tool canceled, expired, or owner lost; 
 
 export const activeRuns = new Map<string, CodeModeRunState>();
 export const resumingRunIds = new Set<string>();
+const liveRunOwners = new Set<CodeModeRunOwner>();
 let activeRunReservations = 0;
 let nextPendingBridgeSettlementSequence = 0;
 let activeRunExpiryTimer: ReturnType<typeof setTimeout> | undefined;
+
+/** Catalog ownership spans worker legs and snapshots; parking never closes the cell. */
+export function createCodeModeRunOwner(ctx: ToolSearchToolContext) {
+  const runId = `cm_${randomUUID()}`;
+  const closed = new AbortController();
+  const signal = ctx.abortSignal
+    ? AbortSignal.any([closed.signal, ctx.abortSignal])
+    : closed.signal;
+  const disposers = ctx.catalogRef
+    ? (ctx.catalogRef.onDispose ??= new Set<() => void>())
+    : undefined;
+  let releaseCall = () => {};
+  const close = (reason?: unknown) => {
+    if (closed.signal.aborted) {
+      return;
+    }
+    releaseCall();
+    signal.removeEventListener("abort", onLifetimeAbort);
+    disposers?.delete(close);
+    liveRunOwners.delete(owner);
+    const parked = activeRuns.get(runId);
+    if (parked?.owner === owner) {
+      activeRuns.delete(runId);
+      cancelPendingBridgeStates(parked.pending);
+    }
+    closed.abort(reason);
+    scheduleActiveRunExpiry();
+  };
+  const onLifetimeAbort = () => close(signal.reason);
+  const owner = {
+    runId,
+    signal,
+    close,
+    bindCall(callSignal?: AbortSignal): AbortSignal {
+      releaseCall();
+      if (signal.aborted) {
+        return signal;
+      }
+      const combined = callSignal ? AbortSignal.any([signal, callSignal]) : signal;
+      const release = () => combined.removeEventListener("abort", onAbort);
+      const onAbort = () => {
+        // A completed observer cannot cancel a later wait on this same cell.
+        if (releaseCall === release) {
+          close(combined.reason);
+        }
+      };
+      releaseCall = release;
+      combined.addEventListener("abort", onAbort, { once: true });
+      if (combined.aborted) {
+        onAbort();
+      }
+      // Pending work follows the cell, not an observer replaced by a later wait.
+      return signal;
+    },
+  };
+  liveRunOwners.add(owner);
+  disposers?.add(close);
+  signal.addEventListener("abort", onLifetimeAbort, { once: true });
+  if (!ctx.catalogRef?.current || signal.aborted) {
+    close(signal.reason);
+  }
+  return owner;
+}
 
 export function createCodeModeBridgeDispatchState(): CodeModeBridgeDispatchState {
   return { started: false, operations: new Map() };
@@ -134,18 +198,15 @@ export function removeExpiredRuns(now = Date.now()): void {
 export function disposeCodeModeRun(runId: string): void {
   const state = activeRuns.get(runId);
   activeRuns.delete(runId);
-  state?.releaseOwner();
+  state?.owner.close();
   cancelPendingBridgeStates(state?.pending ?? []);
   resumingRunIds.delete(runId);
   scheduleActiveRunExpiry();
 }
 
-/** Cancel suspended bridge work before its Gateway-owned runtimes disappear. */
+/** Cancel every cell before its Gateway-owned runtimes disappear. */
 export function disposeAllCodeModeRuns(): void {
-  activeRuns.forEach((state) => {
-    state.releaseOwner();
-    cancelPendingBridgeStates(state.pending);
-  });
+  liveRunOwners.forEach((owner) => owner.close());
   activeRuns.clear();
   resumingRunIds.clear();
   scheduleActiveRunExpiry();
@@ -244,7 +305,7 @@ export function reserveActiveRunSlot(ownedRunId?: string): () => void {
       throw new ToolInputError("code mode run is unavailable or expired.");
     }
     activeRuns.delete(ownedRunId);
-    state.releaseOwner();
+    scheduleActiveRunExpiry();
   }
   // Resume transfers an existing slot without exposing a free capacity window
   // to concurrent exec calls or rejecting its own run at the global limit.
@@ -257,53 +318,6 @@ export function reserveActiveRunSlot(ownedRunId?: string): () => void {
     released = true;
     activeRunReservations = Math.max(0, activeRunReservations - 1);
   };
-}
-
-export function snapshotState(params: {
-  pendingRequests: PendingBridgeRequest[];
-  snapshotBytes: Uint8Array;
-  parentToolCallId: string;
-  codeModeReplayId: string;
-  ctx: ToolSearchToolContext;
-  config: CodeModeConfig;
-  runtime: ToolSearchRuntime;
-  catalogProjection: CodeModeCatalogProjection;
-  namespaceRuntime: CodeModeNamespaceRuntime;
-  output: unknown[];
-  remainingMs: number;
-  deliveredOutputCount?: number;
-  reservedActiveRunSlot?: boolean;
-  replaySafe: boolean;
-  settlementMode: CodeModeSettlementMode;
-  signal?: AbortSignal;
-  onUpdate?: AgentToolUpdateCallback;
-  bridgeDispatch: CodeModeBridgeDispatchState;
-}) {
-  enforceSnapshotStateLimits(params);
-  const runId = `cm_${randomUUID()}`;
-  const pending = createPendingBridgeStates({
-    ...params,
-    activeRunId: runId,
-    codeModeRunId: params.codeModeReplayId,
-  });
-  try {
-    return storeSnapshotState({
-      ...params,
-      runId,
-      replayId: params.codeModeReplayId,
-      pending,
-      replaySafe:
-        params.replaySafe &&
-        pendingBridgeRequestsReplaySafe(
-          params.pendingRequests,
-          params.runtime,
-          params.catalogProjection,
-        ),
-    });
-  } catch (error) {
-    cancelPendingBridgeStates(pending);
-    throw error;
-  }
 }
 
 export function pendingBridgeRequestsReplaySafe(
@@ -347,17 +361,6 @@ function isPendingBridgeRequestReplaySafe(
   return binding ? runtime.isReplaySafeExactId(binding.id) : false;
 }
 
-function enforceSnapshotStateLimits(params: {
-  snapshotBytes: Uint8Array;
-  config: CodeModeConfig;
-  reservedActiveRunSlot?: boolean;
-}) {
-  if (!params.reservedActiveRunSlot) {
-    enforceActiveRunLimit();
-  }
-  enforceSnapshotPayloadLimits(params);
-}
-
 export function createPendingBridgeStates(params: {
   pendingRequests: PendingBridgeRequest[];
   config: CodeModeConfig;
@@ -369,7 +372,7 @@ export function createPendingBridgeStates(params: {
   remainingMs: number;
   activeRunId?: string;
   ctx: ToolSearchToolContext;
-  signal?: AbortSignal;
+  signal: AbortSignal;
   onUpdate?: AgentToolUpdateCallback;
   bridgeDispatch: CodeModeBridgeDispatchState;
 }): PendingBridgeState[] {
@@ -377,13 +380,14 @@ export function createPendingBridgeStates(params: {
     // Bridge calls start immediately while the VM snapshot is stored. Their
     // settled values are later replayed into QuickJS by the wait tool.
     const abortController = new AbortController();
-    const signal = AbortSignal.any(
-      [params.signal, params.ctx.abortSignal, abortController.signal].filter(
-        (candidate): candidate is AbortSignal => candidate !== undefined,
-      ),
-    );
-    const target = params.catalogProjection.byCallableName.get(String(request.args[0]));
-    const yieldRunSignal = target?.name === "sessions_yield" ? params.ctx.abortSignal : undefined;
+    const signal = abortController.signal;
+    // Relay only while pending: closing a finished cell must not cancel an
+    // external operation whose result was already delivered to its guest.
+    const onAbort = () => abortController.abort(params.signal.reason);
+    params.signal.addEventListener("abort", onAbort, { once: true });
+    if (params.signal.aborted) {
+      onAbort();
+    }
     const tracksDispatch = request.method !== "sleep";
     // Discovery is read-only; replay-safe actions such as agentSpawn may still mutate.
     const recoverySafe =
@@ -407,7 +411,7 @@ export function createPendingBridgeStates(params: {
       signal,
       onUpdate: params.onUpdate,
     });
-    const completion = raceWithAbortSignal(bridgeCall, signal, yieldRunSignal).catch(
+    const completion = raceWithAbortSignal(bridgeCall, signal).catch(
       (): SettledBridgeRequest => ({
         id: request.id,
         ok: false,
@@ -417,6 +421,7 @@ export function createPendingBridgeStates(params: {
     const state: PendingBridgeState = {
       ...request,
       promise: completion.then((settled) => {
+        params.signal.removeEventListener("abort", onAbort);
         // The effect receipt owns classification; consume the predecessor marker
         // so reusing this settled object cannot preserve stale no-start authority.
         consumeTrustedToolNoStartError(settled);
@@ -452,7 +457,7 @@ export function createPendingBridgeStates(params: {
 }
 
 export function storeSnapshotState(params: {
-  runId: string;
+  owner: CodeModeRunOwner;
   replayId: string;
   pending: PendingBridgeState[];
   replaySafe: boolean;
@@ -467,16 +472,9 @@ export function storeSnapshotState(params: {
   output: unknown[];
   deliveredOutputCount?: number;
   bridgeDispatch: CodeModeBridgeDispatchState;
-  signal?: AbortSignal;
 }) {
-  const catalogRef = params.ctx.catalogRef;
-  const closed = new AbortController();
-  const ownerSignal = AbortSignal.any(
-    [params.signal, params.ctx.abortSignal, closed.signal].filter(
-      (signal): signal is AbortSignal => signal !== undefined,
-    ),
-  );
-  if (!catalogRef?.current || ownerSignal.aborted) {
+  const runId = params.owner.runId;
+  if (params.owner.signal.aborted) {
     cancelPendingBridgeStates(params.pending);
     return codeModeAbortedResult(params);
   }
@@ -494,16 +492,8 @@ export function storeSnapshotState(params: {
         params.config.snapshotTtlSeconds * MAX_AGENT_WAIT_SNAPSHOT_TTL_WINDOWS,
       )
     : undefined;
-  const disposers = (catalogRef.onDispose ??= new Set());
-  const onClose = () => {
-    // A transferred snapshot may reuse this cell id; stale observers own only
-    // the exact parked state they subscribed for, never its replacement.
-    if (activeRuns.get(params.runId) === state) {
-      disposeCodeModeRun(params.runId);
-    }
-  };
   const state: CodeModeRunState = {
-    runId: params.runId,
+    runId,
     replayId: params.replayId,
     parentToolCallId: params.parentToolCallId,
     ctx: params.ctx,
@@ -520,20 +510,13 @@ export function storeSnapshotState(params: {
     catalogProjection: params.catalogProjection,
     namespaceRuntime: params.namespaceRuntime,
     bridgeDispatch: params.bridgeDispatch,
-    ownerSignal,
-    releaseOwner: () => {
-      disposers.delete(onClose);
-      ownerSignal.removeEventListener("abort", onClose);
-      closed.abort();
-    },
+    owner: params.owner,
   };
-  activeRuns.set(params.runId, state);
-  disposers.add(onClose);
-  ownerSignal.addEventListener("abort", onClose, { once: true });
+  activeRuns.set(runId, state);
   scheduleActiveRunExpiry();
   return {
     status: "waiting" as const,
-    runId: params.runId,
+    runId,
     reason: codeModeWaitingReason(params.pending),
     pendingToolCalls: pendingToolCalls(params.pending),
     replaySafe: params.replaySafe,

--- a/src/agents/code-mode-swarm.test.ts
+++ b/src/agents/code-mode-swarm.test.ts
@@ -531,7 +531,7 @@ describe("Code Mode swarm host bridge", () => {
   it("renews expired snapshots while agentWait remains pending", () => {
     const now = 10_000;
     testing.activeRuns.set("cm-pending-agent", {
-      releaseOwner: () => undefined,
+      owner: { close: () => undefined },
       config: { ...config, snapshotTtlSeconds: 60 },
       expiresAt: now - 1,
       agentWaitRetainUntil: now + 120_000,
@@ -554,7 +554,7 @@ describe("Code Mode swarm host bridge", () => {
     const now = 10_000;
     const cancel = vi.fn();
     testing.activeRuns.set("cm-expired-agent", {
-      releaseOwner: () => undefined,
+      owner: { close: () => undefined },
       config: { ...config, snapshotTtlSeconds: 60 },
       expiresAt: now - 1,
       agentWaitRetainUntil: now - 1,

--- a/src/agents/code-mode-worker-lifecycle.test.ts
+++ b/src/agents/code-mode-worker-lifecycle.test.ts
@@ -4,8 +4,9 @@ import os from "node:os";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { BroadcastChannel, Worker } from "node:worker_threads";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, onTestFinished, vi } from "vitest";
 import { createDeferred } from "../../test/helpers/promise.js";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import * as workerUrls from "../infra/runtime-worker-url.js";
 import { createCodeModeCatalogProjection } from "./code-mode-catalog.js";
 import { createCodeModeNamespaceRuntime } from "./code-mode-namespaces.js";
@@ -76,12 +77,17 @@ describe("Code Mode worker lifecycle", () => {
   it.each(["exec", "resume"] as const)(
     "terminates a real CPU-active %s worker when its catalog closes",
     async (phase) => {
-      const dir = await mkdtemp(path.join(os.tmpdir(), "code-mode-catalog-cpu-"));
+      // Finish hooks unwind in reverse order: stop workers before restoring their
+      // loader spies and releasing the channel and files, including on setup failure.
+      const tempDirs = useAutoCleanupTempDirTracker(onTestFinished);
+      const dir = tempDirs.make("code-mode-catalog-cpu-");
       const channelName = `catalog-cpu-${phase}-${crypto.randomUUID()}`;
       const channel = new BroadcastChannel(channelName);
+      onTestFinished(() => channel.close());
       const executing = createDeferred();
       channel.addEventListener("message", () => executing.resolve(), { once: true });
       const h = createCodeModeHarness();
+      onTestFinished(() => clearToolSearchCatalog(h.ctx));
       applyCodeModeCatalog({ ...h.ctx, tools: h.tools });
       const exec = h.tools.find((tool) => tool.name === "exec");
       const wait = h.tools.find((tool) => tool.name === "wait");
@@ -128,31 +134,28 @@ describe("Code Mode worker lifecycle", () => {
       const resolveWorker = vi
         .spyOn(workerUrls, "resolveRuntimeWorkerUrl")
         .mockReturnValue(pathToFileURL(workerPath));
+      onTestFinished(() => resolveWorker.mockRestore());
       const terminate = vi.spyOn(Worker.prototype, "terminate");
+      onTestFinished(() => terminate.mockRestore());
       const execution =
         phase === "exec"
           ? exec.execute("cpu", { code: "while (true) {}" })
           : wait.execute("resume-cpu", { runId });
-      try {
-        await executing.promise;
-        clearToolSearchCatalog(h.ctx);
-        expect(resultDetails(await execution)).toMatchObject({ status: "failed", code: "aborted" });
-        expect(terminate).toHaveBeenCalledOnce();
-        const worker = terminate.mock.contexts[0];
-        if (!(worker instanceof Worker)) {
-          throw new Error("Expected a terminated real worker");
-        }
-        expect(worker.threadId).toBe(-1);
-        expect(activeRuns.size).toBe(0);
-        expect(h.catalogRef.onDispose).toBeUndefined();
-      } finally {
+      onTestFinished(async () => {
         clearToolSearchCatalog(h.ctx);
         await execution;
-        terminate.mockRestore();
-        resolveWorker.mockRestore();
-        channel.close();
-        await rm(dir, { recursive: true, force: true });
+      });
+      await executing.promise;
+      clearToolSearchCatalog(h.ctx);
+      expect(resultDetails(await execution)).toMatchObject({ status: "failed", code: "aborted" });
+      expect(terminate).toHaveBeenCalledOnce();
+      const worker = terminate.mock.contexts[0];
+      if (!(worker instanceof Worker)) {
+        throw new Error("Expected a terminated real worker");
       }
+      expect(worker.threadId).toBe(-1);
+      expect(activeRuns.size).toBe(0);
+      expect(h.catalogRef.onDispose).toBeUndefined();
     },
   );
 

--- a/src/agents/code-mode-worker-lifecycle.test.ts
+++ b/src/agents/code-mode-worker-lifecycle.test.ts
@@ -3,34 +3,33 @@ import { createRequire } from "node:module";
 import os from "node:os";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
+import { BroadcastChannel, Worker } from "node:worker_threads";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../test/helpers/promise.js";
+import * as workerUrls from "../infra/runtime-worker-url.js";
 import { createCodeModeCatalogProjection } from "./code-mode-catalog.js";
 import { createCodeModeNamespaceRuntime } from "./code-mode-namespaces.js";
 import { resolveCodeModeConfig, toToolSearchConfig } from "./code-mode-runtime.js";
 import {
   activeRuns,
   createCodeModeBridgeDispatchState,
+  createCodeModeRunOwner,
   disposeAllCodeModeRuns,
-  disposeCodeModeRun,
   reserveActiveRunSlot,
-  resumingRunIds,
   storeSnapshotState,
   type PendingBridgeState,
 } from "./code-mode-state.js";
 import { runCodeModeWorker } from "./code-mode-worker.js";
+import { applyCodeModeCatalog } from "./code-mode.js";
+import { createCodeModeHarness, resultDetails } from "./code-mode.test-support.js";
 import {
   createToolSearchCatalogRef,
+  clearToolSearchCatalog,
   registerHeadlessToolSearchCatalog,
   ToolSearchRuntime,
 } from "./tool-search.js";
 
-const EXPIRING_RUN_ID = "cm_worker_lifecycle_expiry";
-const CAPACITY_RUN_PREFIX = "cm_worker_lifecycle_capacity_";
-
-function parkExpiringRun(
-  method: "callValue" | "agentWait",
-  runId = EXPIRING_RUN_ID,
-): ReturnType<typeof vi.fn> {
+function parkExpiringRun(method: "callValue" | "agentWait") {
   const rawConfig = {
     tools: { codeMode: { enabled: true, snapshotTtlSeconds: 1 } },
   } as never;
@@ -48,8 +47,9 @@ function parkExpiringRun(
     cancel,
   };
 
+  const owner = createCodeModeRunOwner(ctx);
   storeSnapshotState({
-    runId,
+    owner,
     replayId: "cm_replay_lifecycle",
     pending: [pending],
     replaySafe: false,
@@ -64,20 +64,98 @@ function parkExpiringRun(
     output: [],
     bridgeDispatch: createCodeModeBridgeDispatchState(),
   });
-  return cancel;
+  return { cancel, runId: owner.runId };
 }
 
 afterEach(() => {
-  disposeCodeModeRun(EXPIRING_RUN_ID);
-  for (const runId of activeRuns.keys()) {
-    if (runId.startsWith(CAPACITY_RUN_PREFIX)) {
-      disposeCodeModeRun(runId);
-    }
-  }
+  disposeAllCodeModeRuns();
   vi.useRealTimers();
 });
 
 describe("Code Mode worker lifecycle", () => {
+  it.each(["exec", "resume"] as const)(
+    "terminates a real CPU-active %s worker when its catalog closes",
+    async (phase) => {
+      const dir = await mkdtemp(path.join(os.tmpdir(), "code-mode-catalog-cpu-"));
+      const channelName = `catalog-cpu-${phase}-${crypto.randomUUID()}`;
+      const channel = new BroadcastChannel(channelName);
+      const executing = createDeferred();
+      channel.addEventListener("message", () => executing.resolve(), { once: true });
+      const h = createCodeModeHarness();
+      applyCodeModeCatalog({ ...h.ctx, tools: h.tools });
+      const exec = h.tools.find((tool) => tool.name === "exec");
+      const wait = h.tools.find((tool) => tool.name === "wait");
+      if (!exec || !wait) {
+        throw new Error("Expected Code Mode control tools");
+      }
+      let runId: unknown;
+      if (phase === "resume") {
+        const parked = resultDetails(
+          await exec.execute("park-cpu", {
+            code: "await yield_control(); while (true) {}",
+          }),
+        );
+        expect(parked.status).toBe("waiting");
+        runId = parked.runId;
+      }
+      const quickJsUrl = pathToFileURL(createRequire(import.meta.url).resolve("quickjs-wasi"));
+      const workerPath = path.join(dir, "observed-worker.ts");
+      await writeFile(path.join(dir, "package.json"), '{"type":"module"}');
+      // Observe the real QuickJS interrupt callback, not merely thread startup.
+      await writeFile(
+        workerPath,
+        `
+        import { BroadcastChannel } from "node:worker_threads";
+        const channel = new BroadcastChannel(${JSON.stringify(channelName)});
+        const { QuickJS } = await import(${JSON.stringify(quickJsUrl.href)});
+        for (const method of ["create", "restore"]) {
+          const original = QuickJS[method];
+          QuickJS[method] = function (...args) {
+            const index = method === "create" ? 0 : 1;
+            const options = args[index];
+            const interrupt = options.interruptHandler;
+            let observed = false;
+            args[index] = { ...options, interruptHandler: () => {
+              if (!observed) { observed = true; channel.postMessage("executing"); }
+              return interrupt();
+            } };
+            return original.apply(this, args);
+          };
+        }
+        await import(${JSON.stringify(new URL("./code-mode.worker.ts", import.meta.url).href)});
+      `,
+      );
+      const resolveWorker = vi
+        .spyOn(workerUrls, "resolveRuntimeWorkerUrl")
+        .mockReturnValue(pathToFileURL(workerPath));
+      const terminate = vi.spyOn(Worker.prototype, "terminate");
+      const execution =
+        phase === "exec"
+          ? exec.execute("cpu", { code: "while (true) {}" })
+          : wait.execute("resume-cpu", { runId });
+      try {
+        await executing.promise;
+        clearToolSearchCatalog(h.ctx);
+        expect(resultDetails(await execution)).toMatchObject({ status: "failed", code: "aborted" });
+        expect(terminate).toHaveBeenCalledOnce();
+        const worker = terminate.mock.contexts[0];
+        if (!(worker instanceof Worker)) {
+          throw new Error("Expected a terminated real worker");
+        }
+        expect(worker.threadId).toBe(-1);
+        expect(activeRuns.size).toBe(0);
+        expect(h.catalogRef.onDispose).toBeUndefined();
+      } finally {
+        clearToolSearchCatalog(h.ctx);
+        await execution;
+        terminate.mockRestore();
+        resolveWorker.mockRestore();
+        channel.close();
+        await rm(dir, { recursive: true, force: true });
+      }
+    },
+  );
+
   it.each(
     (["exec", "resume"] as const).flatMap((kind) =>
       [1, -1].map((clockDirection) => ({ kind, clockDirection })),
@@ -158,75 +236,6 @@ describe("Code Mode worker lifecycle", () => {
       }
     },
   );
-
-  it("cancels every suspended run, releases capacity, and clears its expiry timer", () => {
-    vi.useFakeTimers({ toFake: ["Date", "setTimeout", "clearTimeout"] });
-    const firstRunId = `${CAPACITY_RUN_PREFIX}shutdown_first`;
-    const secondRunId = `${CAPACITY_RUN_PREFIX}shutdown_second`;
-    const firstCancel = parkExpiringRun("callValue", firstRunId);
-    const secondCancel = parkExpiringRun("agentWait", secondRunId);
-    const firstRun = activeRuns.get(firstRunId);
-    if (!firstRun) {
-      throw new Error("expected a parked Code Mode shutdown run");
-    }
-    resumingRunIds.add(firstRunId);
-    resumingRunIds.add(secondRunId);
-    for (let index = 0; index < 62; index += 1) {
-      const runId = `${CAPACITY_RUN_PREFIX}shutdown_${index}`;
-      activeRuns.set(runId, { ...firstRun, runId, pending: [] });
-    }
-
-    expect(activeRuns.size).toBe(64);
-    expect(() => reserveActiveRunSlot()).toThrow("too many suspended code mode runs");
-    expect(vi.getTimerCount()).toBe(1);
-
-    const clearExpiryTimer = vi.spyOn(globalThis, "clearTimeout");
-    disposeAllCodeModeRuns();
-    disposeAllCodeModeRuns();
-
-    expect(firstCancel).toHaveBeenCalledOnce();
-    expect(secondCancel).toHaveBeenCalledOnce();
-    expect(clearExpiryTimer).toHaveBeenCalledOnce();
-    expect(activeRuns.size).toBe(0);
-    expect(resumingRunIds.has(firstRunId)).toBe(false);
-    expect(resumingRunIds.has(secondRunId)).toBe(false);
-    expect(vi.getTimerCount()).toBe(0);
-    clearExpiryTimer.mockRestore();
-
-    const releaseFreedSlot = reserveActiveRunSlot();
-    releaseFreedSlot();
-  });
-
-  it("transfers a resumed run's slot atomically at the suspended-run limit", () => {
-    parkExpiringRun("callValue");
-    const ownedState = activeRuns.get(EXPIRING_RUN_ID);
-    expect(ownedState).toBeDefined();
-    if (!ownedState) {
-      throw new Error("expected a parked Code Mode run");
-    }
-    for (let index = 0; index < 63; index += 1) {
-      const runId = `${CAPACITY_RUN_PREFIX}${index}`;
-      activeRuns.set(runId, { ...ownedState, runId, pending: [] });
-    }
-
-    const release = reserveActiveRunSlot(EXPIRING_RUN_ID);
-    try {
-      expect(activeRuns.has(EXPIRING_RUN_ID)).toBe(false);
-      expect(activeRuns.size).toBe(63);
-      expect(() => reserveActiveRunSlot()).toThrow("too many suspended code mode runs");
-
-      activeRuns.set(EXPIRING_RUN_ID, ownedState);
-    } finally {
-      release();
-    }
-
-    expect(activeRuns.size).toBe(64);
-    expect(() => reserveActiveRunSlot()).toThrow("too many suspended code mode runs");
-
-    disposeCodeModeRun(`${CAPACITY_RUN_PREFIX}0`);
-    const releaseFreedSlot = reserveActiveRunSlot();
-    releaseFreedSlot();
-  });
 
   it("rejects an unavailable run without leaking a capacity reservation", () => {
     expect(() => reserveActiveRunSlot("cm_missing_lifecycle_owner")).toThrow(
@@ -354,25 +363,25 @@ describe("Code Mode worker lifecycle", () => {
 
   it("expires an idle suspended snapshot and aborts its outstanding tool", async () => {
     vi.useFakeTimers({ toFake: ["Date", "setTimeout", "clearTimeout"] });
-    const cancel = parkExpiringRun("callValue");
+    const { cancel, runId } = parkExpiringRun("callValue");
 
-    expect(activeRuns.has(EXPIRING_RUN_ID)).toBe(true);
+    expect(activeRuns.has(runId)).toBe(true);
     await vi.advanceTimersByTimeAsync(1_000);
 
-    expect(activeRuns.has(EXPIRING_RUN_ID)).toBe(false);
+    expect(activeRuns.has(runId)).toBe(false);
     expect(cancel).toHaveBeenCalledOnce();
   });
 
   it("retains an active collector only within its bounded snapshot TTL windows", async () => {
     vi.useFakeTimers({ toFake: ["Date", "setTimeout", "clearTimeout"] });
-    const cancel = parkExpiringRun("agentWait");
+    const { cancel, runId } = parkExpiringRun("agentWait");
 
     await vi.advanceTimersByTimeAsync(1_000);
-    expect(activeRuns.has(EXPIRING_RUN_ID)).toBe(true);
+    expect(activeRuns.has(runId)).toBe(true);
     expect(cancel).not.toHaveBeenCalled();
 
     await vi.advanceTimersByTimeAsync(3_000);
-    expect(activeRuns.has(EXPIRING_RUN_ID)).toBe(false);
+    expect(activeRuns.has(runId)).toBe(false);
     expect(cancel).toHaveBeenCalledOnce();
   });
 });

--- a/src/agents/code-mode.bridge.lifecycle.test.ts
+++ b/src/agents/code-mode.bridge.lifecycle.test.ts
@@ -10,6 +10,7 @@ import { upsertSessionEntryCore } from "../config/sessions/session-accessor.js";
 import { estimateTranscriptPromptTokens } from "../config/sessions/session-accessor.sqlite-parent-fork.js";
 import { projectChatDisplayMessages } from "../gateway/chat-display-projection.js";
 import { readSessionMessagesAsync } from "../gateway/session-transcript-readers.js";
+import { wrapToolWithAbortSignal } from "./agent-tools.abort.js";
 import { buildExecApprovalPendingToolResult } from "./bash-tools.exec-host-shared.js";
 import { disposeAllCodeModeRuns } from "./code-mode-state.js";
 import { createSubscribedCodeModeHarness } from "./code-mode.bridge.lifecycle.test-support.js";
@@ -29,6 +30,7 @@ import { attachInternalToolExecutionPreparer } from "./runtime/internal-hooks.js
 import { SessionManager } from "./sessions/session-manager.js";
 import { clearToolSearchCatalog } from "./tool-search.js";
 import { jsonResult } from "./tools/common.js";
+import { createSessionsYieldTool } from "./tools/sessions-yield-tool.js";
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
@@ -459,31 +461,41 @@ describe("Code Mode subscribed bridge lifecycle", () => {
     }
   });
 
-  it("preserves the initiating sessions_yield result across its run-owner handoff", async () => {
+  it("keeps direct sessions_yield handoff successful while closing sibling Code Mode cells", async () => {
     const harness = createSubscribedCodeModeHarness({ name: "yield-handoff" });
     const handoffReason = { code: "sessions_yield", turnHandoff: true } as const;
-    const target = pluginToolWithExecute(
-      "sessions_yield",
-      "Hand off the current turn",
-      async () => {
-        harness.runAbortController.abort(handoffReason);
-        return jsonResult({ status: "yielded" });
-      },
+    const onYield = vi.fn(() => harness.runAbortController.abort(handoffReason));
+    const target = wrapToolWithAbortSignal(
+      createSessionsYieldTool({
+        sessionId: harness.sessionId,
+        claimYield: () => true,
+        onYield,
+      }),
+      harness.runAbortController.signal,
     );
-    applyCodeModeCatalog({ ...harness, tools: [...harness.tools, target] });
-
+    const surface = applyCodeModeCatalog({ ...harness, tools: [...harness.tools, target] });
     try {
-      const result = resultDetails(
-        await expectDefined(harness.tools[0], "Code Mode exec test invariant").execute(
-          "code-call-yield-handoff",
-          { code: "return await sessions_yield({});" },
-        ),
+      const parked = resultDetails(
+        await harness.tools[0]!.execute("sibling-cell", {
+          code: "await yield_control(); return 'unreachable';",
+        }),
       );
-
-      expect(result).toMatchObject({ status: "completed", value: { status: "yielded" } });
-      expect(target.execute).toHaveBeenCalledOnce();
-      expect(countActiveToolExecutions(harness.runId)).toBe(0);
+      expect(parked.status).toBe("waiting");
+      expect(
+        harness.catalogRef.current?.entries.some((entry) => entry.name === "sessions_yield"),
+      ).toBe(false);
+      const direct = expectDefined(
+        surface.tools.find((tool) => tool.name === "sessions_yield"),
+        "direct handoff tool",
+      );
+      expect(resultDetails(await direct.execute("yield-handoff", {}))).toMatchObject({
+        status: "yielded",
+      });
+      expect(onYield).toHaveBeenCalledOnce();
       expect(testing.activeRuns.size).toBe(0);
+      await expect(
+        harness.tools[1]!.execute("closed-sibling", { runId: parked.runId }),
+      ).rejects.toThrow(/unavailable|expired/);
     } finally {
       harness.dispose();
     }
@@ -567,11 +579,9 @@ describe("Code Mode subscribed bridge lifecycle", () => {
           await exec.execute(
             "transfer-exec",
             {
-              code: `const timer = setTimeout(() => {}, 60_000);
-                await yield_control("first");
+              code: `await yield_control("first");
                 await yield_control("second");
                 await yield_control("third");
-                clearTimeout(timer);
                 return "done";`,
             },
             controller.signal,
@@ -590,10 +600,7 @@ describe("Code Mode subscribed bridge lifecycle", () => {
 
         for (let index = 0; index < 2; index += 1) {
           const previous = expectDefined(testing.activeRuns.get(runId), "previous snapshot");
-          const staleClose = expectDefined(
-            owner.catalogRef.onDispose?.values().next().value,
-            "parked owner subscription",
-          );
+          const previousController = controller;
           controller = new AbortController();
           result = resultDetails(
             await wait.execute(`transfer-wait-${index}`, { runId }, controller.signal),
@@ -601,11 +608,10 @@ describe("Code Mode subscribed bridge lifecycle", () => {
           expect(result).toMatchObject({ status: "waiting", runId });
           const replacement = expectDefined(testing.activeRuns.get(runId), "replacement snapshot");
           expect(replacement).not.toBe(previous);
-          staleClose();
+          previousController.abort();
           expect(testing.activeRuns.get(runId)).toBe(replacement);
-          expect(getEventListeners(previous.ownerSignal, "abort")).toHaveLength(0);
-          expect(previous.ownerSignal.aborted).toBe(true);
-          expect(getEventListeners(replacement.ownerSignal, "abort")).toHaveLength(1);
+          expect(replacement.owner).toBe(previous.owner);
+          expect(replacement.owner.signal.aborted).toBe(false);
           expect(owner.catalogRef.onDispose?.size).toBe(1);
         }
 
@@ -624,8 +630,8 @@ describe("Code Mode subscribed bridge lifecycle", () => {
         expect(testing.activeRuns.size).toBe(0);
         expect(testing.resumingRunIds.size).toBe(0);
         await Promise.all(pending.map((entry) => entry.promise));
-        expect(getEventListeners(finalState.ownerSignal, "abort")).toHaveLength(0);
-        expect(finalState.ownerSignal.aborted).toBe(true);
+        expect(getEventListeners(finalState.owner.signal, "abort")).toHaveLength(0);
+        expect(finalState.owner.signal.aborted).toBe(true);
         expect(owner.catalogRef.onDispose?.size ?? 0).toBe(0);
       } finally {
         clearToolSearchCatalog(owner);

--- a/src/agents/code-mode.bridge.lifecycle.test.ts
+++ b/src/agents/code-mode.bridge.lifecycle.test.ts
@@ -693,6 +693,7 @@ describe("Code Mode subscribed bridge lifecycle", () => {
       name: "abort-wait-deadline",
       timeoutMs: 1_500,
     });
+    const lifecycle = vi.spyOn(owner.subscription, "runToolLifecycle");
     const started = createDeferred();
     const stalled = pluginToolWithExecute("stalled", "Await cancellation", async () => {
       started.resolve();
@@ -715,8 +716,12 @@ describe("Code Mode subscribed bridge lifecycle", () => {
       expect(resultDetails(await waiting)).toMatchObject({ status: "failed", code: "aborted" });
       expect(testing.activeRuns.size).toBe(0);
       expect(testing.resumingRunIds.size).toBe(0);
+      // Abort returns before nested transcript and terminal finalization; join its owner.
+      expect(lifecycle).toHaveBeenCalledOnce();
+      await expect(lifecycle.mock.results[0]?.value).rejects.toThrow("Aborted");
       expect(countActiveToolExecutions(owner.runId)).toBe(0);
     } finally {
+      lifecycle.mockRestore();
       clearToolSearchCatalog(owner);
       owner.dispose();
       vi.useRealTimers();

--- a/src/agents/code-mode.catalog-lifetime.test.ts
+++ b/src/agents/code-mode.catalog-lifetime.test.ts
@@ -1,0 +1,273 @@
+import { afterEach, expect, it, vi } from "vitest";
+import { createDeferred } from "../../test/helpers/promise.js";
+import { applyCodeModeCatalog, runCodeModeScriptHeadless } from "./code-mode.js";
+import {
+  createCodeModeHarness,
+  createHeadlessCodeModeHarness,
+  pluginToolWithExecute,
+  resetCodeModeTestState,
+  resultDetails,
+  testing,
+} from "./code-mode.test-support.js";
+import { clearToolSearchCatalog } from "./tool-search.js";
+import { jsonResult } from "./tools/common.js";
+
+afterEach(() => {
+  resetCodeModeTestState();
+  vi.useRealTimers();
+});
+
+it.each(
+  (["exec", "wait", "headless"] as const).flatMap((phase) =>
+    [
+      { close: "catalog", honorsAbort: false },
+      { close: "catalog", honorsAbort: true },
+      { close: "context", honorsAbort: false },
+      { close: "call", honorsAbort: false },
+    ].map((params) => Object.assign({ phase }, params)),
+  ),
+)(
+  "closes $phase bridge work via $close with honorsAbort=$honorsAbort without reviving a guest",
+  async ({ phase, close, honorsAbort }) => {
+    const entered = createDeferred();
+    const release = createDeferred();
+    const finished = createDeferred();
+    const callController = new AbortController();
+    const contextController = new AbortController();
+    let aborts = 0;
+    const gate = pluginToolWithExecute(
+      "lifetime_gate",
+      "Controlled bridge work",
+      async (_id, _args, signal) => {
+        const onAbort = () => {
+          aborts += 1;
+          if (honorsAbort) {
+            release.reject(new Error("fixture observed cancellation"));
+          }
+        };
+        signal?.addEventListener("abort", onAbort, { once: true });
+        entered.resolve();
+        try {
+          await release.promise;
+          return jsonResult("late external completion");
+        } finally {
+          signal?.removeEventListener("abort", onAbort);
+          finished.resolve();
+        }
+      },
+    );
+    const after = pluginToolWithExecute("lifetime_after", "Must not execute", async () =>
+      jsonResult(true),
+    );
+    const h = createCodeModeHarness();
+    applyCodeModeCatalog({ ...h.ctx, tools: [...h.tools, gate, after] });
+    const headless =
+      phase === "headless" ? createHeadlessCodeModeHarness([gate, after]) : undefined;
+    const ctx = Object.assign(headless ?? h.ctx, { abortSignal: contextController.signal });
+    const code =
+      'try { await lifetime_gate({}); } catch {} text("STALE AFTER CLOSE"); await lifetime_after({}); await yield_control(); return "stale";';
+    let execution: Promise<unknown>;
+    let runId: unknown;
+    if (phase === "wait") {
+      const parked = resultDetails(
+        await h.tools[0]!.execute("park", { code: `await yield_control(); ${code}` }),
+      );
+      expect(parked.status).toBe("waiting");
+      runId = parked.runId;
+      execution = h.tools[1]!.execute("resume", { runId }, callController.signal).then(
+        resultDetails,
+      );
+    } else if (headless) {
+      execution = runCodeModeScriptHeadless({ ctx: headless, code, signal: callController.signal });
+    } else {
+      execution = h.tools[0]!.execute("initial", { code }, callController.signal).then(
+        resultDetails,
+      );
+    }
+    try {
+      await entered.promise;
+      if (close === "catalog") {
+        clearToolSearchCatalog(ctx);
+        clearToolSearchCatalog(ctx);
+      } else {
+        (close === "context" ? contextController : callController).abort();
+      }
+      expect(aborts).toBe(1);
+      // Cancellation must settle the cell before an uncooperative external operation finishes.
+      const result = await execution;
+      expect(result).toMatchObject({ status: "failed", code: "aborted", output: [] });
+      expect(after.execute).not.toHaveBeenCalled();
+      expect(testing.activeRuns.size).toBe(0);
+      expect(testing.resumingRunIds.size).toBe(0);
+      expect(ctx.catalogRef?.onDispose?.size ?? 0).toBe(0);
+      release.resolve();
+      await finished.promise;
+      expect(after.execute).not.toHaveBeenCalled();
+      if (runId) {
+        await expect(h.tools[1]!.execute("closed", { runId })).rejects.toThrow(
+          /unavailable|expired/,
+        );
+      }
+      const healthy = createCodeModeHarness();
+      applyCodeModeCatalog({ ...healthy.ctx, tools: healthy.tools });
+      expect(
+        resultDetails(await healthy.tools[0]!.execute("healthy", { code: "return 7;" })),
+      ).toMatchObject({ status: "completed", value: 7 });
+      expect(healthy.catalogRef.onDispose?.size ?? 0).toBe(0);
+      clearToolSearchCatalog(healthy.ctx);
+    } finally {
+      release.resolve();
+      clearToolSearchCatalog(ctx);
+      clearToolSearchCatalog(h.ctx);
+      await execution;
+    }
+  },
+);
+
+it("keeps pending work bound to the cell after a newer wait replaces its call observer", async () => {
+  const prior = new AbortController();
+  const current = new AbortController();
+  const entered = createDeferred();
+  const release = createDeferred();
+  let aborts = 0;
+  const gate = pluginToolWithExecute("gate", "Pending work", async (_id, _args, signal) => {
+    signal?.addEventListener(
+      "abort",
+      () => {
+        aborts += 1;
+      },
+      { once: true },
+    );
+    entered.resolve();
+    await release.promise;
+    return jsonResult("healthy");
+  });
+  const h = createCodeModeHarness();
+  applyCodeModeCatalog({ ...h.ctx, tools: [...h.tools, gate] });
+  let resumed: Promise<unknown> | undefined;
+  try {
+    const parked = resultDetails(
+      await h.tools[0]!.execute(
+        "initial",
+        {
+          code: "const pending = gate({}); await yield_control(); return await pending;",
+        },
+        prior.signal,
+      ),
+    );
+    expect(parked.status).toBe("waiting");
+    await entered.promise;
+    resumed = h.tools[1]!.execute("current", { runId: parked.runId }, current.signal).then(
+      resultDetails,
+    );
+    prior.abort(new Error("obsolete call observer"));
+    expect(aborts).toBe(0);
+    release.resolve();
+    expect(await resumed).toMatchObject({ status: "completed", value: "healthy" });
+    expect(gate.execute).toHaveBeenCalledOnce();
+    expect(aborts).toBe(0);
+    expect(h.catalogRef.onDispose?.size ?? 0).toBe(0);
+  } finally {
+    release.resolve();
+    await resumed;
+    clearToolSearchCatalog(h.ctx);
+  }
+});
+
+it("keeps the 64-slot limit on suspensions, including a reserved active resume, not CPU-only exec", async () => {
+  const entered = createDeferred();
+  const release = createDeferred();
+  let aborts = 0;
+  const gate = pluginToolWithExecute(
+    "capacity_gate",
+    "Hold a resumed slot",
+    async (_id, _args, signal) => {
+      signal?.addEventListener(
+        "abort",
+        () => {
+          aborts += 1;
+        },
+        { once: true },
+      );
+      entered.resolve();
+      await release.promise;
+      return jsonResult(true);
+    },
+  );
+  const owners = Array.from({ length: 64 }, () => {
+    const h = createCodeModeHarness();
+    applyCodeModeCatalog({ ...h.ctx, tools: [...h.tools, gate] });
+    return h;
+  });
+  const ids: unknown[] = [];
+  const extra = createCodeModeHarness();
+  applyCodeModeCatalog({ ...extra.ctx, tools: extra.tools });
+  let active: Promise<unknown> | undefined;
+  try {
+    // Four real VM starts at a time; no fabricated map entries or worker-count quota.
+    for (let offset = 0; offset < owners.length; offset += 4) {
+      await Promise.all(
+        owners.slice(offset, offset + 4).map(async (h, index) => {
+          const result = resultDetails(
+            await h.tools[0]!.execute(`capacity-${offset + index}`, {
+              code: "await yield_control(); await yield_control(); await capacity_gate({}); return true;",
+            }),
+          );
+          expect(result.status).toBe("waiting");
+          ids[offset + index] = result.runId;
+        }),
+      );
+    }
+    expect(new Set(ids).size).toBe(64);
+    expect(testing.activeRuns.size).toBe(64);
+    expect(
+      resultDetails(
+        await extra.tools[0]!.execute("cpu-at-capacity", {
+          code: "let n=0; for(let i=0;i<1000;i++) n+=i; return n;",
+        }),
+      ),
+    ).toMatchObject({ status: "completed", value: 499500 });
+    const rejectSuspension = async () => {
+      const result = resultDetails(
+        await extra.tools[0]!.execute("overflow", { code: "await yield_control(); return true;" }),
+      );
+      expect(result).toMatchObject({
+        status: "failed",
+        code: "invalid_input",
+        error: expect.stringContaining("too many suspended"),
+      });
+    };
+    await rejectSuspension();
+    const first = owners[0]!;
+    const repark = resultDetails(
+      await first.tools[1]!.execute("repark-at-capacity", { runId: ids[0] }),
+    );
+    expect(repark.status).toBe("waiting");
+    ids[0] = repark.runId;
+    active = first.tools[1]!.execute("active-at-capacity", { runId: ids[0] }).then(resultDetails);
+    await entered.promise;
+    expect(testing.activeRuns.size).toBe(63);
+    await rejectSuspension();
+    clearToolSearchCatalog(first.ctx);
+    expect(await active).toMatchObject({ status: "failed", code: "aborted" });
+    expect(aborts).toBe(1);
+    const healthy = resultDetails(
+      await extra.tools[0]!.execute("new-slot", {
+        code: "await yield_control(); return 'healthy';",
+      }),
+    );
+    expect(healthy.status).toBe("waiting");
+    expect(testing.activeRuns.size).toBe(64);
+    clearToolSearchCatalog(owners[1]!.ctx);
+    expect(
+      resultDetails(await extra.tools[1]!.execute("healthy-resume", { runId: healthy.runId })),
+    ).toMatchObject({ status: "completed", value: "healthy" });
+  } finally {
+    release.resolve();
+    owners.forEach((h) => clearToolSearchCatalog(h.ctx));
+    clearToolSearchCatalog(extra.ctx);
+    await active;
+  }
+  expect(testing.activeRuns.size).toBe(0);
+  expect(testing.resumingRunIds.size).toBe(0);
+});

--- a/src/agents/code-mode.wait.test.ts
+++ b/src/agents/code-mode.wait.test.ts
@@ -538,7 +538,7 @@ describe("Code Mode wait, scope, and suspended runs", () => {
     const { tools: codeModeTools } = createCodeModeHarness();
     testing.activeRuns.set("invalid-expiry-run", {
       expiresAt: 8_640_000_000_000_001,
-      releaseOwner: () => undefined,
+      owner: { close: () => undefined },
     } as never);
 
     await expect(
@@ -717,69 +717,6 @@ describe("Code Mode wait, scope, and suspended runs", () => {
 
     expect(stillWaiting.status).toBe("waiting");
     expect(stillWaiting.runId).toBe(first.runId);
-  });
-
-  it("resumes and reparks a yielding run at the suspended-run capacity limit", async () => {
-    const { config, catalogRef, tools: codeModeTools } = createCodeModeHarness();
-    applyCodeModeCatalog({
-      tools: [...codeModeTools, pluginTool("fake_noop", "Noop")],
-      config,
-      sessionId: "session-code-mode",
-      sessionKey: "agent:main:main",
-      runId: "run-code-mode",
-      catalogRef,
-    });
-
-    const first = resultDetails(
-      await expectDefined(codeModeTools[0], "Code Mode exec test invariant").execute(
-        "code-call-at-capacity",
-        {
-          code: `
-            await yield_control("first");
-            await yield_control("second");
-            return "done";
-          `,
-        },
-      ),
-    );
-    expect(first.status).toBe("waiting");
-    const firstRunId = first.runId;
-    expect(typeof firstRunId).toBe("string");
-    if (typeof firstRunId !== "string") {
-      throw new Error("expected a parked Code Mode run");
-    }
-    const parked = testing.activeRuns.get(firstRunId);
-    expect(parked).toBeDefined();
-    if (!parked) {
-      throw new Error("expected a parked Code Mode snapshot");
-    }
-
-    // Inert snapshots occupy real capacity without starting 63 extra workers.
-    for (let index = 0; index < 63; index += 1) {
-      const runId = `cm_code_mode_capacity_${index}`;
-      testing.activeRuns.set(runId, { ...parked, runId, pending: [] });
-    }
-
-    const second = resultDetails(
-      await expectDefined(codeModeTools[1], "Code Mode wait test invariant").execute(
-        "code-wait-at-capacity",
-        { runId: firstRunId },
-      ),
-    );
-
-    expect(second.status).toBe("waiting");
-    expect(second.reason).toBe("yield");
-    expect(testing.activeRuns.size).toBe(64);
-
-    const completed = resultDetails(
-      await expectDefined(codeModeTools[1], "Code Mode wait test invariant").execute(
-        "code-wait-after-capacity",
-        { runId: second.runId },
-      ),
-    );
-
-    expect(completed).toMatchObject({ status: "completed", value: "done" });
-    expect(testing.activeRuns.size).toBe(63);
   });
 
   it("reports only unsettled pending tool calls when wait times out", async () => {

--- a/src/agents/embedded-agent-runner/run/terminal-resolution.state.test.ts
+++ b/src/agents/embedded-agent-runner/run/terminal-resolution.state.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import {
+  copyAttemptDeliveryState,
+  createTerminalToolPresentationTracker,
+} from "./terminal-resolution.js";
+
+describe("terminal presentation and delivery state", () => {
+  it("carries presentation across retries until a newer tool outcome replaces it", () => {
+    const tracker = createTerminalToolPresentationTracker();
+    const firstOrdinal = tracker.allocateOrdinal();
+    tracker.observe({
+      toolCallOrdinal: firstOrdinal,
+      terminalPresentation: "Fetched https://example.com",
+    });
+
+    expect(tracker.read()).toBe("Fetched https://example.com");
+
+    const retryOrdinal = tracker.allocateOrdinal();
+    expect(tracker.read()).toBe("Fetched https://example.com");
+    tracker.observe({ toolCallOrdinal: retryOrdinal });
+    tracker.observe({
+      toolCallOrdinal: firstOrdinal,
+      terminalPresentation: "stale presentation",
+    });
+
+    expect(tracker.read()).toBeUndefined();
+  });
+
+  it("keeps only the bounded latest MCP App view identity", () => {
+    expect(
+      copyAttemptDeliveryState({
+        latestMcpAppChannelView: { viewId: "view-latest" },
+        messagingToolSentTexts: [],
+        messagingToolSentMediaUrls: [],
+        messagingToolSentTargets: [],
+      } as never).latestMcpAppChannelView,
+    ).toEqual({ viewId: "view-latest" });
+  });
+});

--- a/src/agents/embedded-agent-runner/run/terminal-resolution.test.ts
+++ b/src/agents/embedded-agent-runner/run/terminal-resolution.test.ts
@@ -1,19 +1,27 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { SILENT_REPLY_TOKEN } from "../../../auto-reply/tokens.js";
+import { classifyAgentExecResult } from "../../../commands/agent-exec.js";
 import {
   buildEmbeddedRunnerAssistant,
   makeEmbeddedRunnerAttempt,
 } from "../../test-helpers/embedded-agent-runner-e2e-fixtures.js";
+import {
+  markEmbeddedRunAuthProfileSuccess,
+  reportEmbeddedRunSuccessfulAuthBinding,
+} from "./auth-profile-success.js";
 import { createEmbeddedRunContextRecoveryState } from "./context-recovery-state.js";
 import { TRUNCATED_REPLY_NOTICE_TEXT } from "./incomplete-turn-resolution.js";
 import { resolveEmbeddedRunAttemptTerminalState } from "./terminal-outcome.js";
 import {
-  copyAttemptDeliveryState,
-  createTerminalToolPresentationTracker,
   resolveEmbeddedRunTerminal,
   resolveSettledTurnFinalizationRequest,
 } from "./terminal-resolution.js";
 import { createEmbeddedRunTerminalRetryState } from "./terminal-retry-state.js";
+
+vi.mock("./auth-profile-success.js", () => ({
+  markEmbeddedRunAuthProfileSuccess: vi.fn(),
+  reportEmbeddedRunSuccessfulAuthBinding: vi.fn(),
+}));
 
 const EMPTY_RESPONSE_RETRY_INSTRUCTION =
   "The previous attempt did not produce a user-visible answer. Continue from the current state and produce the visible answer now. Do not restart from scratch.";
@@ -118,22 +126,51 @@ async function resolveTerminalText(overrides: TerminalInputOverrides): Promise<s
 }
 
 describe("terminal resolution", () => {
-  it.each(["empty", "reasoning"])(
+  beforeEach(() => vi.clearAllMocks());
+
+  it.each(["empty", "reasoning", "cleanup", "tool warning", "partial reply", "committed delivery"])(
     "preserves a failed harness turn instead of retrying its %s output",
     async (output) => {
-      const error = new Error("Authentication failed with provider (HTTP 401)");
+      const error = new Error("Provider failed while a tool was pending");
+      const cleanupFailed = output !== "empty" && output !== "reasoning";
+      const partialText = "The first operation finished.";
       const assistant =
         output === "reasoning"
           ? buildEmbeddedRunnerAssistant({ content: [{ type: "thinking", thinking: "checking" }] })
-          : undefined;
+          : cleanupFailed
+            ? buildEmbeddedRunnerAssistant({
+                stopReason: "toolUse",
+                content: [{ type: "text", text: partialText }],
+              })
+            : undefined;
+      const payloads =
+        output === "tool warning"
+          ? [{ text: "The pending tool was cancelled.", isError: true }]
+          : output === "partial reply"
+            ? [{ text: partialText }]
+            : output === "cleanup"
+              ? undefined
+              : [];
       const attempt = makeEmbeddedRunnerAttempt({
         terminal: { kind: "failed", source: "prompt", error },
-        assistantTexts: [],
+        assistantTexts: output === "partial reply" ? [partialText] : [],
         currentAttemptAssistant: assistant,
         lastAssistant: assistant,
-        replayMetadata: { hadPotentialSideEffects: false, replaySafe: false },
+        lastToolError: cleanupFailed
+          ? { toolName: "exec", error: "Tool execution aborted" }
+          : undefined,
+        toolMetas: cleanupFailed ? [{ toolName: "exec", isError: true, replaySafe: false }] : [],
+        didSendViaMessagingTool: output === "committed delivery",
+        messagingToolSentTexts: output === "committed delivery" ? [partialText] : [],
+        replayMetadata: { hadPotentialSideEffects: cleanupFailed, replaySafe: false },
       });
-      const input = makeTerminalInput({ attempt });
+      const onSuccessfulAuthProfile = vi.fn();
+      const input = makeTerminalInput({
+        attempt,
+        payloadsWithToolMedia: payloads,
+        authProfileId: "openai:selected",
+        runParams: { onSuccessfulAuthProfile },
+      });
 
       const resolved = await resolveEmbeddedRunTerminal(input);
 
@@ -142,8 +179,70 @@ describe("terminal resolution", () => {
         result: { meta: { error: { message: error.message, fallbackSafe: false } } },
       });
       expect(input.activateInternalPrompt).not.toHaveBeenCalled();
+      expect(input.setSuppressNextUserMessagePersistence).not.toHaveBeenCalled();
+      expect(input.armPostCompactionGuard).not.toHaveBeenCalled();
+      expect(markEmbeddedRunAuthProfileSuccess).not.toHaveBeenCalled();
+      expect(reportEmbeddedRunSuccessfulAuthBinding).not.toHaveBeenCalled();
+      expect(onSuccessfulAuthProfile).not.toHaveBeenCalled();
+      expect(input.setTerminalLifecycleMeta).toHaveBeenCalledWith(
+        expect.objectContaining({ livenessState: "abandoned" }),
+      );
+      if (resolved.action === "complete") {
+        expect(classifyAgentExecResult(resolved.result).status).toBe("error");
+        expect(resolved.result.meta.executionTrace?.attempts ?? []).not.toContainEqual(
+          expect.objectContaining({ result: "success" }),
+        );
+        if (cleanupFailed) {
+          expect(resolved.result.payloads ?? []).toEqual(payloads ?? []);
+          expect(resolved.result.messagingToolSentTexts).toEqual(attempt.messagingToolSentTexts);
+        }
+      }
     },
   );
+
+  it("keeps external cancellation ahead of a failed attempt during final result construction", async () => {
+    const assistant = emptyAssistant({ stopReason: "stop" });
+    const attempt = makeEmbeddedRunnerAttempt({
+      terminal: { kind: "failed", source: "prompt", error: new Error("Late provider failure") },
+      lastToolError: { toolName: "exec", error: "Tool execution aborted" },
+      currentAttemptAssistant: assistant,
+      replayMetadata: { hadPotentialSideEffects: true, replaySafe: false },
+    });
+    const terminalState = resolveEmbeddedRunAttemptTerminalState({
+      attempt,
+      assistant,
+      abortSignal: AbortSignal.abort(),
+    });
+    const input = makeTerminalInput({ attempt, terminalState });
+    const resolved = await resolveEmbeddedRunTerminal(input);
+    expect(resolved).toMatchObject({ action: "complete", result: { meta: { aborted: true } } });
+    if (resolved.action === "complete") {
+      expect(resolved.result.meta.error).toBeUndefined();
+      expect(resolved.result.meta.livenessState).toBe("blocked");
+    }
+    expect(input.activateInternalPrompt).not.toHaveBeenCalled();
+  });
+
+  it("keeps an ordinary tool failure nonfatal when the attempt completed", async () => {
+    const text = "The operation failed; the earlier result is still available.";
+    const assistant = buildEmbeddedRunnerAssistant({ content: [{ type: "text", text }] });
+    const attempt = makeEmbeddedRunnerAttempt({
+      lastToolError: { toolName: "exec", error: "Tool failed" },
+      assistantTexts: [text],
+      currentAttemptAssistant: assistant,
+      replayMetadata: { hadPotentialSideEffects: true, replaySafe: false },
+    });
+    const resolved = await resolveEmbeddedRunTerminal(
+      makeTerminalInput({ attempt, payloadsWithToolMedia: [{ text }] }),
+    );
+    expect(resolved.action).toBe("complete");
+    if (resolved.action === "complete") {
+      expect(resolved.result.meta.error).toBeUndefined();
+      expect(classifyAgentExecResult(resolved.result).status).toBe("ok");
+      expect(resolved.result.payloads).toEqual([{ text }]);
+    }
+    expect(markEmbeddedRunAuthProfileSuccess).toHaveBeenCalledOnce();
+  });
 
   it.each(["openai:selected", undefined])(
     "reports the successful profile %s privately for command maintenance",
@@ -234,38 +333,6 @@ describe("terminal resolution", () => {
     });
     expect(text).toContain("some tool actions may have already been executed");
     expect(text).not.toContain("Couldn't sign in");
-  });
-
-  it("carries presentation across retries until a newer tool outcome replaces it", () => {
-    const tracker = createTerminalToolPresentationTracker();
-    const firstOrdinal = tracker.allocateOrdinal();
-    tracker.observe({
-      toolCallOrdinal: firstOrdinal,
-      terminalPresentation: "Fetched https://example.com",
-    });
-
-    expect(tracker.read()).toBe("Fetched https://example.com");
-
-    const retryOrdinal = tracker.allocateOrdinal();
-    expect(tracker.read()).toBe("Fetched https://example.com");
-    tracker.observe({ toolCallOrdinal: retryOrdinal });
-    tracker.observe({
-      toolCallOrdinal: firstOrdinal,
-      terminalPresentation: "stale presentation",
-    });
-
-    expect(tracker.read()).toBeUndefined();
-  });
-
-  it("keeps only the bounded latest MCP App view identity", () => {
-    expect(
-      copyAttemptDeliveryState({
-        latestMcpAppChannelView: { viewId: "view-latest" },
-        messagingToolSentTexts: [],
-        messagingToolSentMediaUrls: [],
-        messagingToolSentTargets: [],
-      } as never).latestMcpAppChannelView,
-    ).toEqual({ viewId: "view-latest" });
   });
 
   it("retries a required empty reply even when deliberate silence is enabled", async () => {

--- a/src/agents/embedded-agent-runner/run/terminal-resolution.ts
+++ b/src/agents/embedded-agent-runner/run/terminal-resolution.ts
@@ -5,7 +5,10 @@ import { freezeDiagnosticTraceContext } from "../../../infra/diagnostic-trace-co
 import { formatErrorMessage } from "../../../infra/errors.js";
 import type { AssistantMessage } from "../../../llm/types.js";
 import type { ProviderRouteOverridePresence } from "../../../plugin-sdk/provider-model-types.js";
-import { projectAgentRunAttemptTerminal } from "../../agent-run-terminal-outcome.js";
+import {
+  classifyAgentRunTerminalOutcome,
+  projectAgentRunAttemptTerminal,
+} from "../../agent-run-terminal-outcome.js";
 import type { AuthProfileFailureReason, AuthProfileStore } from "../../auth-profiles.js";
 import type { ResolvedProviderAuth } from "../../model-auth.js";
 import { log } from "../logger.js";
@@ -397,9 +400,9 @@ export async function resolveEmbeddedRunTerminal(input: {
       `reasoning-only retries exhausted: runId=${runParams.runId} sessionId=${runParams.sessionId} ` +
         `provider=${input.activeErrorContext.provider}/${input.activeErrorContext.model} attempts=${retryState.reasoningOnlyAttempts}/${input.maxReasoningOnlyRetryAttempts} — surfacing incomplete-turn error`,
     );
-    return surfaceIncompleteTurn({
+    return completeEmbeddedRun({
       ...input,
-      text: incompletePayloadText,
+      incompleteTurnText: incompletePayloadText,
       payloadCount: 0,
       incompleteTurnFallbackSafe,
       terminalToolPresentation,
@@ -431,9 +434,9 @@ export async function resolveEmbeddedRunTerminal(input: {
           ? "surfacing tool-authored terminal presentation"
           : "surfacing error to user"),
     );
-    return surfaceIncompleteTurn({
+    return completeEmbeddedRun({
       ...input,
-      text: incompleteTurnText,
+      incompleteTurnText,
       payloadCount,
       incompleteTurnFallbackSafe,
       terminalToolPresentation,
@@ -472,133 +475,103 @@ export async function resolveEmbeddedRunTerminal(input: {
   });
 }
 
-async function surfaceIncompleteTurn(
+async function completeEmbeddedRun(
   input: Parameters<typeof resolveEmbeddedRunTerminal>[0] & {
-    text: string;
     payloadCount: number;
-    incompleteTurnFallbackSafe: boolean;
+    payloadsForTerminalPath?: EmbeddedAgentRunResult["payloads"];
+    emptyAssistantReplyIsSilent?: boolean;
+    intentionalTerminalCompletion?: boolean;
+    incompleteTurnText?: string;
+    incompleteTurnFallbackSafe?: boolean;
     terminalToolPresentation?: string;
   },
 ): Promise<TerminalResolution> {
   const terminalAborted = isEmbeddedRunTerminalAbort(input.terminalState.outcome);
   const terminalTimedOut = isEmbeddedRunTerminalTimeout(input.terminalState.outcome);
-  const replayInvalid = input.resolveReplayInvalid(input.text);
-  const livenessState = resolveRunLivenessState({
-    payloadCount: input.payloadCount,
-    aborted: terminalAborted,
-    timedOut: terminalTimedOut,
-    attempt: input.attempt,
-    incompleteTurnText: input.text,
-  });
-  input.setTerminalLifecycleMeta({ replayInvalid, livenessState });
-  if (input.authProfileId) {
-    try {
-      await input.maybeMarkAuthProfileFailure({
-        profileId: input.authProfileId,
-        reason: input.assistantProfileFailureReason,
-        modelId: input.modelId,
-      });
-    } catch (error) {
-      log.warn(`terminal auth bookkeeping failed; preserving result: ${String(error)}`);
-    }
-  }
-  return {
-    action: "complete",
-    result: {
-      payloads: [
-        {
-          text: input.terminalToolPresentation
-            ? input.terminalToolPresentation.concat("\n\n", input.text)
-            : input.text,
-          isError: true,
-        },
-      ],
-      meta: {
-        durationMs: Date.now() - input.startedAtMs,
-        agentMeta: input.agentMeta,
-        aborted: terminalAborted,
-        systemPromptReport: input.attempt.systemPromptReport,
-        finalPromptText: input.attempt.finalPromptText,
-        finalAssistantVisibleText: input.finalAssistantVisibleText,
-        finalAssistantRawText: input.finalAssistantRawText,
-        replayInvalid,
-        livenessState,
-        error: {
-          kind: "incomplete_turn",
-          message:
-            input.attempt.terminal.kind === "failed"
-              ? formatErrorMessage(input.attempt.terminal.error)
-              : "Agent couldn't generate a response.",
-          fallbackSafe: input.incompleteTurnFallbackSafe,
+  // Warning suppression is presentation only: an unrecovered terminal failure
+  // must retain error metadata and must not enter successful auth/trace bookkeeping.
+  const error =
+    input.incompleteTurnText !== undefined ||
+    classifyAgentRunTerminalOutcome(input.terminalState.outcome) === "failure"
+      ? {
+          kind: "incomplete_turn" as const,
+          message: formatErrorMessage(
+            projectAgentRunAttemptTerminal(input.attempt.terminal).promptError ??
+              input.terminalState.outcome.error ??
+              "Agent couldn't generate a response.",
+          ),
+          fallbackSafe: input.incompleteTurnFallbackSafe ?? false,
           terminalPresentation: input.terminalToolPresentation !== undefined,
-        },
-        toolSummary: input.attemptToolSummary,
-        ...(input.failureSignal ? { failureSignal: input.failureSignal } : {}),
-        ...(input.terminalToolFailure ? { terminalToolFailure: input.terminalToolFailure } : {}),
-        agentHarnessResultClassification: input.attempt.agentHarnessResultClassification,
-      },
-      ...copyAttemptDeliveryState(input.attempt),
-    },
-  };
-}
-
-function completeEmbeddedRun(
-  input: Parameters<typeof resolveEmbeddedRunTerminal>[0] & {
-    payloadCount: number;
-    payloadsForTerminalPath: EmbeddedAgentRunResult["payloads"];
-    emptyAssistantReplyIsSilent: boolean;
-    intentionalTerminalCompletion: boolean;
-  },
-): TerminalResolution {
-  const terminalAborted = isEmbeddedRunTerminalAbort(input.terminalState.outcome);
-  const terminalTimedOut = isEmbeddedRunTerminalTimeout(input.terminalState.outcome);
-  log.debug(
-    `embedded run done: runId=${input.runParams.runId} sessionId=${input.runParams.sessionId} durationMs=${Date.now() - input.startedAtMs} aborted=${terminalAborted}`,
-  );
-  markEmbeddedRunAuthProfileSuccess({
-    authProfileStateMode: input.runParams.authProfileStateMode,
-    profileId: input.authProfileId,
-    profileStore: input.profileFailureStore,
-    provider: input.provider,
-    agentDir: input.runParams.agentDir,
-    runId: input.runParams.runId,
-    sessionId: input.runParams.sessionId,
-  });
-  reportEmbeddedRunSuccessfulAuthBinding({
-    profileId: input.authProfileId,
-    profileStore: input.attemptAuthProfileStore,
-    apiKeyInfo: input.apiKeyInfo,
-    attempt: input.attempt,
-    provider: input.provider,
-    agentDir: input.runParams.agentDir,
-    modelId: input.modelTransportId,
-    modelApi: input.modelTransportApi,
-    ...(input.modelTransportBaseUrl ? { modelBaseUrl: input.modelTransportBaseUrl } : {}),
-    requestTransportOverrides: input.requestTransportOverrides ?? "none",
-    config: input.runParams.config,
-    agentHarnessId: input.agentHarnessId,
-    pluginHarnessOwnsTransport: input.pluginHarnessOwnsTransport,
-    pluginHarnessOwnsAuthBootstrap: input.pluginHarnessOwnsAuthBootstrap,
-    onSuccessfulAuthBinding: input.runParams.onSuccessfulAuthBinding,
-  });
-  input.runParams.onSuccessfulAuthProfile?.(input.authProfileId);
-  const replayInvalid = input.resolveReplayInvalid(null);
+        }
+      : undefined;
+  const incompleteTurnText = input.incompleteTurnText ?? error?.message ?? null;
+  const replayInvalid = input.resolveReplayInvalid(incompleteTurnText);
   const yieldHasContinuation =
     input.attempt.yieldDetected && hasYieldContinuationEvidence(input.attempt);
-  const livenessState = input.attempt.yieldDetected
-    ? "paused"
-    : resolveRunLivenessState({
-        payloadCount: input.payloadCount,
-        aborted: terminalAborted,
-        timedOut: terminalTimedOut,
-        attempt: input.attempt,
-        incompleteTurnText: null,
-      });
-  const stopReason = input.attempt.clientToolCalls
-    ? "tool_calls"
-    : input.attempt.yieldDetected
-      ? "end_turn"
-      : (input.attemptAssistant?.stopReason as string | undefined);
+  const livenessState =
+    !error && input.attempt.yieldDetected
+      ? "paused"
+      : resolveRunLivenessState({
+          payloadCount: input.payloadCount,
+          aborted: terminalAborted,
+          timedOut: terminalTimedOut,
+          attempt: input.attempt,
+          incompleteTurnText,
+        });
+  const stopReason = error
+    ? undefined
+    : input.attempt.clientToolCalls
+      ? "tool_calls"
+      : input.attempt.yieldDetected
+        ? "end_turn"
+        : (input.attemptAssistant?.stopReason as string | undefined);
+  if (error) {
+    input.setTerminalLifecycleMeta({ replayInvalid, livenessState });
+    if (input.authProfileId) {
+      try {
+        await input.maybeMarkAuthProfileFailure({
+          profileId: input.authProfileId,
+          reason: input.assistantProfileFailureReason,
+          modelId: input.modelId,
+        });
+      } catch (bookkeepingError) {
+        log.warn(
+          `terminal auth bookkeeping failed; preserving result: ${String(bookkeepingError)}`,
+        );
+      }
+    }
+  } else {
+    log.debug(
+      `embedded run done: runId=${input.runParams.runId} sessionId=${input.runParams.sessionId} durationMs=${Date.now() - input.startedAtMs} aborted=${terminalAborted}`,
+    );
+    markEmbeddedRunAuthProfileSuccess({
+      authProfileStateMode: input.runParams.authProfileStateMode,
+      profileId: input.authProfileId,
+      profileStore: input.profileFailureStore,
+      provider: input.provider,
+      agentDir: input.runParams.agentDir,
+      runId: input.runParams.runId,
+      sessionId: input.runParams.sessionId,
+    });
+    reportEmbeddedRunSuccessfulAuthBinding({
+      profileId: input.authProfileId,
+      profileStore: input.attemptAuthProfileStore,
+      apiKeyInfo: input.apiKeyInfo,
+      attempt: input.attempt,
+      provider: input.provider,
+      agentDir: input.runParams.agentDir,
+      modelId: input.modelTransportId,
+      modelApi: input.modelTransportApi,
+      ...(input.modelTransportBaseUrl ? { modelBaseUrl: input.modelTransportBaseUrl } : {}),
+      requestTransportOverrides: input.requestTransportOverrides ?? "none",
+      config: input.runParams.config,
+      agentHarnessId: input.agentHarnessId,
+      pluginHarnessOwnsTransport: input.pluginHarnessOwnsTransport,
+      pluginHarnessOwnsAuthBootstrap: input.pluginHarnessOwnsAuthBootstrap,
+      onSuccessfulAuthBinding: input.runParams.onSuccessfulAuthBinding,
+    });
+    input.runParams.onSuccessfulAuthProfile?.(input.authProfileId);
+  }
   // The truncation notice belongs to exactly the turns this fix newly delivers:
   // a length stop whose only output is partial assistant text. A length stop that
   // also produced terminal output (tool media, a committed source reply) was
@@ -615,26 +588,40 @@ function completeEmbeddedRun(
   // Existing visible payloads already avoid the silent-park symptom. The diagnostic
   // fills only an otherwise empty yielded turn and must not duplicate visible output.
   // A length stop delivers partial text, so it is labeled instead of dropped. (#76477)
-  const terminalPayloads = input.emptyAssistantReplyIsSilent
-    ? [{ text: SILENT_REPLY_TOKEN }]
-    : input.payloadsForTerminalPath?.length
-      ? isTruncatedPartialReply
-        ? [...input.payloadsForTerminalPath, { text: TRUNCATED_REPLY_NOTICE_TEXT }]
-        : input.payloadsForTerminalPath
-      : input.attempt.yieldDetected && !yieldHasContinuation
-        ? [{ text: YIELD_DIAGNOSTIC_TEXT }]
-        : input.payloadsForTerminalPath;
-  input.setTerminalLifecycleMeta({
-    replayInvalid,
-    livenessState,
-    stopReason,
-    yielded: input.attempt.yieldDetected === true,
-  });
+  const terminalPayloads =
+    input.incompleteTurnText !== undefined
+      ? [
+          {
+            text: input.terminalToolPresentation
+              ? input.terminalToolPresentation.concat("\n\n", input.incompleteTurnText)
+              : input.incompleteTurnText,
+            isError: true,
+          },
+        ]
+      : error
+        ? input.payloadsForTerminalPath
+        : input.emptyAssistantReplyIsSilent
+          ? [{ text: SILENT_REPLY_TOKEN }]
+          : input.payloadsForTerminalPath?.length
+            ? isTruncatedPartialReply
+              ? [...input.payloadsForTerminalPath, { text: TRUNCATED_REPLY_NOTICE_TEXT }]
+              : input.payloadsForTerminalPath
+            : input.attempt.yieldDetected && !yieldHasContinuation
+              ? [{ text: YIELD_DIAGNOSTIC_TEXT }]
+              : input.payloadsForTerminalPath;
+  if (!error) {
+    input.setTerminalLifecycleMeta({
+      replayInvalid,
+      livenessState,
+      stopReason,
+      yielded: input.attempt.yieldDetected === true,
+    });
+  }
   return {
     action: "complete",
     result: {
       payloads: terminalPayloads?.length ? terminalPayloads : undefined,
-      ...(input.attempt.diagnosticTrace
+      ...(!error && input.attempt.diagnosticTrace
         ? { diagnosticTrace: freezeDiagnosticTraceContext(input.attempt.diagnosticTrace) }
         : {}),
       meta: {
@@ -648,63 +635,69 @@ function completeEmbeddedRun(
         replayInvalid,
         livenessState,
         agentHarnessResultClassification: input.attempt.agentHarnessResultClassification,
-        ...(input.attempt.yieldDetected ? { yielded: true } : {}),
-        ...(input.attempt.yieldAcknowledgment
-          ? { yieldAcknowledgment: input.attempt.yieldAcknowledgment }
-          : {}),
-        ...(input.emptyAssistantReplyIsSilent
-          ? { terminalReplyKind: "silent-empty" as const }
-          : {}),
-        ...(input.intentionalTerminalCompletion
-          ? { intentionalTerminalCompletion: "tool-batch" as const }
-          : {}),
-        stopReason,
-        pendingToolCalls: input.attempt.clientToolCalls?.map((call) => ({
-          id: randomBytes(5).toString("hex").slice(0, 9),
-          name: call.name,
-          arguments: JSON.stringify(call.params),
-        })),
-        executionTrace: {
-          winnerProvider: input.reportedModelRef.provider,
-          winnerModel: input.reportedModelRef.model,
-          attempts:
-            input.traceAttempts.length > 0 ||
-            input.attemptAssistant?.provider ||
-            input.attemptAssistant?.model
-              ? [
-                  ...input.traceAttempts,
-                  {
-                    provider: input.reportedModelRef.provider,
-                    model: input.reportedModelRef.model,
-                    result: "success",
-                    stage: "assistant",
-                  },
-                ]
-              : undefined,
-          fallbackUsed: input.traceAttempts.some(input.traceAttemptUsesFallback),
-          runner: "embedded",
-        },
-        requestShaping: {
-          ...(input.authProfileId ? { authMode: "auth-profile" } : {}),
-          ...(input.thinkLevel ? { thinking: input.thinkLevel } : {}),
-          ...(input.runParams.reasoningLevel ? { reasoning: input.runParams.reasoningLevel } : {}),
-          ...(input.runParams.verboseLevel ? { verbose: input.runParams.verboseLevel } : {}),
-          ...(input.runParams.blockReplyBreak
-            ? { blockStreaming: input.runParams.blockReplyBreak }
-            : {}),
-        },
+        ...(error
+          ? { error }
+          : {
+              ...(input.attempt.yieldDetected ? { yielded: true } : {}),
+              ...(input.attempt.yieldAcknowledgment
+                ? { yieldAcknowledgment: input.attempt.yieldAcknowledgment }
+                : {}),
+              ...(input.emptyAssistantReplyIsSilent
+                ? { terminalReplyKind: "silent-empty" as const }
+                : {}),
+              ...(input.intentionalTerminalCompletion
+                ? { intentionalTerminalCompletion: "tool-batch" as const }
+                : {}),
+              stopReason,
+              pendingToolCalls: input.attempt.clientToolCalls?.map((call) => ({
+                id: randomBytes(5).toString("hex").slice(0, 9),
+                name: call.name,
+                arguments: JSON.stringify(call.params),
+              })),
+              executionTrace: {
+                winnerProvider: input.reportedModelRef.provider,
+                winnerModel: input.reportedModelRef.model,
+                attempts:
+                  input.traceAttempts.length > 0 ||
+                  input.attemptAssistant?.provider ||
+                  input.attemptAssistant?.model
+                    ? [
+                        ...input.traceAttempts,
+                        {
+                          provider: input.reportedModelRef.provider,
+                          model: input.reportedModelRef.model,
+                          result: "success",
+                          stage: "assistant",
+                        },
+                      ]
+                    : undefined,
+                fallbackUsed: input.traceAttempts.some(input.traceAttemptUsesFallback),
+                runner: "embedded",
+              },
+              requestShaping: {
+                ...(input.authProfileId ? { authMode: "auth-profile" } : {}),
+                ...(input.thinkLevel ? { thinking: input.thinkLevel } : {}),
+                ...(input.runParams.reasoningLevel
+                  ? { reasoning: input.runParams.reasoningLevel }
+                  : {}),
+                ...(input.runParams.verboseLevel ? { verbose: input.runParams.verboseLevel } : {}),
+                ...(input.runParams.blockReplyBreak
+                  ? { blockStreaming: input.runParams.blockReplyBreak }
+                  : {}),
+              },
+              completion: {
+                ...(stopReason ? { stopReason } : {}),
+                ...(stopReason ? { finishReason: stopReason } : {}),
+                ...(stopReason?.toLowerCase().includes("refusal") ? { refusal: true } : {}),
+              },
+              contextManagement:
+                input.contextRecoveryState.autoCompactionCount > 0
+                  ? { lastTurnCompactions: input.contextRecoveryState.autoCompactionCount }
+                  : undefined,
+            }),
         toolSummary: input.attemptToolSummary,
         ...(input.failureSignal ? { failureSignal: input.failureSignal } : {}),
         ...(input.terminalToolFailure ? { terminalToolFailure: input.terminalToolFailure } : {}),
-        completion: {
-          ...(stopReason ? { stopReason } : {}),
-          ...(stopReason ? { finishReason: stopReason } : {}),
-          ...(stopReason?.toLowerCase().includes("refusal") ? { refusal: true } : {}),
-        },
-        contextManagement:
-          input.contextRecoveryState.autoCompactionCount > 0
-            ? { lastTurnCompactions: input.contextRecoveryState.autoCompactionCount }
-            : undefined,
       },
       ...copyAttemptDeliveryState(input.attempt),
     },

--- a/src/auto-reply/reply/dispatch-from-config.acp-abort.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.acp-abort.test.ts
@@ -27,7 +27,7 @@ import {
 import { buildTestCtx } from "./test-ctx.js";
 
 let dispatchReplyFromConfig: typeof import("./dispatch-from-config.js").dispatchReplyFromConfig;
-let tryDispatchAcpReplyHook: typeof import("../../plugin-sdk/acp-runtime.js").tryDispatchAcpReplyHook;
+let tryDispatchAcpReplyHook: typeof import("../../plugin-sdk/acpx.js").tryDispatchAcpReplyHook;
 let resetInboundDedupe: typeof import("./inbound-dedupe.js").resetInboundDedupe;
 let replyRunRegistry: typeof import("./reply-run-registry.js").replyRunRegistry;
 let getActiveReplyRunCount: typeof import("./reply-run-registry.js").getActiveReplyRunCount;
@@ -154,7 +154,7 @@ function createMockAcpSessionManager() {
 describe("dispatchReplyFromConfig ACP abort", () => {
   beforeAll(async () => {
     ({ dispatchReplyFromConfig } = await import("./dispatch-from-config.js"));
-    ({ tryDispatchAcpReplyHook } = await import("../../plugin-sdk/acp-runtime.js"));
+    ({ tryDispatchAcpReplyHook } = await import("../../plugin-sdk/acpx.js"));
     ({ resetInboundDedupe } = await import("./inbound-dedupe.js"));
     ({ replyRunRegistry, getActiveReplyRunCount, createReplyOperation } =
       await import("./reply-run-registry.js"));

--- a/src/auto-reply/reply/dispatch-from-config.test-harness.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test-harness.ts
@@ -77,7 +77,7 @@ export let dispatchReplyFromConfig: typeof import("./dispatch-from-config.js").d
 
 let resetInboundDedupe: typeof import("./inbound-dedupe.js").resetInboundDedupe;
 
-export let tryDispatchAcpReplyHook: typeof import("../../plugin-sdk/acp-runtime.js").tryDispatchAcpReplyHook;
+export let tryDispatchAcpReplyHook: typeof import("../../plugin-sdk/acpx.js").tryDispatchAcpReplyHook;
 
 export let createReplyOperation: typeof import("./reply-run-registry.js").createReplyOperation;
 
@@ -378,7 +378,8 @@ export const globalBeforeAll0 = async () => {
   await import("./dispatch-acp.js");
   await import("./dispatch-acp-command-bypass.js");
   ({ resetInboundDedupe } = await import("./inbound-dedupe.js"));
-  ({ tryDispatchAcpReplyHook } = await import("../../plugin-sdk/acp-runtime.js"));
+  // The broad facade imports the real manager outside this fixture's mocked dispatch boundary.
+  ({ tryDispatchAcpReplyHook } = await import("../../plugin-sdk/acpx.js"));
   ({ createReplyOperation, replyRunRegistry } = await import("./reply-run-registry.js"));
   ({ testing: replyRunTesting } = await import("./reply-run-registry.test-support.js"));
   ({ admitReplyTurn, runWithReplyOperationLifecycleAdmission } =

--- a/src/cron/trigger-script.test.ts
+++ b/src/cron/trigger-script.test.ts
@@ -2,10 +2,12 @@ import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../test/helpers/promise.js";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { wrapToolWithBeforeToolCallHook } from "../agents/agent-tools.before-tool-call.js";
 import { BEFORE_TOOL_CALL_HOOK_CONTEXT } from "../agents/before-tool-call-metadata.js";
-import type { CodeModeHeadlessResult } from "../agents/code-mode.js";
+import { runCodeModeScriptHeadless, type CodeModeHeadlessResult } from "../agents/code-mode.js";
+import { clearToolSearchCatalog } from "../agents/tool-search.js";
 import { jsonResult, type AnyAgentTool } from "../agents/tools/common.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { createCronScriptRuntime } from "./trigger-script.js";
@@ -74,6 +76,70 @@ function createCronTriggerEvaluator(deps: EvaluatorDeps) {
 }
 
 describe("cron trigger script evaluator", () => {
+  it("cancels the real headless worker and bridge when its evaluation catalog closes", async () => {
+    const entered = createDeferred();
+    const release = createDeferred();
+    const config: OpenClawConfig = {};
+    let context: HeadlessParams["ctx"] | undefined;
+    let aborts = 0;
+    const prepared = createPreparedRuntime(config);
+    const gate: AnyAgentTool = {
+      ...prepared.tools[0],
+      name: "gate",
+      label: "Gate",
+      description: "Wait for the local fixture",
+      parameters: { type: "object", properties: {} },
+      async execute(_id, _args, signal) {
+        signal?.addEventListener(
+          "abort",
+          () => {
+            aborts += 1;
+          },
+          { once: true },
+        );
+        entered.resolve();
+        await release.promise;
+        return jsonResult(true);
+      },
+    };
+    const runtime = createCronScriptRuntime({
+      config,
+      prepareRuntime: async () => ({ ...prepared, tools: [gate] }),
+      runHeadless: (params) => {
+        context = params.ctx;
+        return runCodeModeScriptHeadless(params);
+      },
+    });
+    const evaluation = runtime.evaluateTrigger({
+      jobId: "catalog-close",
+      script: 'await gate({}); text("STALE AFTER CLOSE"); return { fire: true };',
+      state: null,
+    });
+    try {
+      await entered.promise;
+      if (!context) {
+        throw new Error("Expected the real headless context");
+      }
+      expect(context.abortSignal?.aborted).toBe(false);
+      clearToolSearchCatalog(context);
+      expect(aborts).toBe(1);
+      await expect(evaluation).resolves.toMatchObject({ kind: "error", code: "aborted" });
+      expect(context.catalogRef?.onDispose).toBeUndefined();
+      release.resolve();
+      await expect(
+        runtime.evaluateTrigger({
+          jobId: "catalog-close",
+          script: "return { fire: false };",
+          state: null,
+        }),
+      ).resolves.toMatchObject({ kind: "evaluated", fire: false });
+      expect(context.catalogRef?.onDispose?.size ?? 0).toBe(0);
+    } finally {
+      release.resolve();
+      await evaluation;
+    }
+  });
+
   it.each(["trigger", "payload"] as const)(
     "does not scaffold an implicit ACP workspace during %s execution (#92015)",
     async (mode) => {

--- a/src/gateway/server-methods/chat-send-agent-dispatch.ts
+++ b/src/gateway/server-methods/chat-send-agent-dispatch.ts
@@ -10,6 +10,7 @@ import { resolveProviderIdForAuth } from "../../agents/provider-auth-aliases.js"
 import { dispatchInboundMessageWithProjectedDispatcher } from "../../auto-reply/dispatch.js";
 import type { ReplyDispatchRun } from "../../auto-reply/get-reply-options.types.js";
 import type { ReplyMessageInjectionAttempt } from "../../auto-reply/reply/reply-run-registry.js";
+import { readAgentRunTerminalOutcome } from "../../channels/turn/agent-run-terminal-outcome.js";
 import { measureDiagnosticsTimelineSpan } from "../../infra/diagnostics-timeline.js";
 import type { SkillWorkshopProposalRevisionConstraint } from "../../skills/workshop/types.js";
 import { isOperatorUiClient } from "../../utils/message-channel.js";
@@ -419,7 +420,7 @@ export function startChatDispatch(params: StartChatDispatchParams): void {
         },
       ),
     )
-    .then(async () => {
+    .then(async (dispatchResult) => {
       if (acceptedMessageInjection) {
         return;
       }
@@ -430,43 +431,44 @@ export function startChatDispatch(params: StartChatDispatchParams): void {
         async () => {
           const replyDispatchResult = replyDispatchRun?.getResult();
           const runtimeOutcome = replyDispatchResult?.terminalOutcome;
-          const runtimeClassification =
-            runtimeOutcome && classifyAgentRunTerminalOutcome(runtimeOutcome);
+          const recordedOutcome = readAgentRunTerminalOutcome(dispatchResult);
+          // ACP owns a rich terminal result; native runs record their outcome on dispatch.
+          // Delivered warnings or source replies cannot replace either authoritative result.
+          const runtimeClassification = runtimeOutcome
+            ? classifyAgentRunTerminalOutcome(runtimeOutcome)
+            : recordedOutcome === "failed"
+              ? "failure"
+              : recordedOutcome === "completed"
+                ? "success"
+                : undefined;
           const runtimeCancelled = runtimeClassification === "cancellation";
           const runtimeFailed =
             runtimeClassification === "failure" || runtimeClassification === "timeout";
           const returnedAgentErrorPayloads = replyDispatch.deliveredReplies
             .map((entryInner) => entryInner.payload)
             .filter((payload) => payload.isError);
-          const hasReturnedAgentError =
-            runtimeFailed ||
-            (!runtimeCancelled &&
-              returnedAgentErrorPayloads.length > 0 &&
-              (agentRunStarted || !isInternalTextSlashCommandTurn));
+          const hasReturnedAgentError = runtimeClassification
+            ? runtimeFailed
+            : returnedAgentErrorPayloads.length > 0 &&
+              (agentRunStarted || !isInternalTextSlashCommandTurn);
           const returnedAgentErrorMessage =
             runtimeOutcome?.error ??
             (returnedAgentErrorPayloads
               .map((payload) => payload.text?.trim())
               .filter((text): text is string => Boolean(text))
               .join(" | ") ||
-              undefined);
+              (runtimeFailed ? "agent run failed" : undefined));
           if (
-            hasReturnedAgentError &&
-            !userTurnRecorder.hasPersisted() &&
-            !userTurnRecorder.isBlocked()
-          ) {
-            await persistGatewayUserTurnTranscriptBestEffort();
-          }
-          if (
-            agentRunStarted &&
-            returnedAgentErrorPayloads.length === 0 &&
             !userTurnRecorder.hasPersisted() &&
             !userTurnRecorder.isBlocked() &&
-            userTurnRecorder.hasRuntimePersistencePending()
+            (hasReturnedAgentError ||
+              (agentRunStarted &&
+                returnedAgentErrorPayloads.length === 0 &&
+                userTurnRecorder.hasRuntimePersistencePending()))
           ) {
             await persistGatewayUserTurnTranscriptBestEffort();
           }
-          let broadcastedSourceReplyFinal = false;
+          let finalizedSourceReply = false;
           // A dispatched runtime owns its persisted turn; this owner projects
           // only settled, post-hook replies. Native runtimes project their own stream.
           if (
@@ -489,31 +491,30 @@ export function startChatDispatch(params: StartChatDispatchParams): void {
               stopReason: runtimeOutcome?.stopReason,
             });
           } else if (!context.chatRunState.hasAbortMarker(clientRunId)) {
-            broadcastedSourceReplyFinal = await finalizeChatSendSourceReplies({
+            finalizedSourceReply = await finalizeChatSendSourceReplies({
               accountId,
               context,
               deliveredReplies: replyDispatch.deliveredReplies,
               emitFirstAssistantServerTiming,
               hasReturnedAgentErrorPayloads: hasReturnedAgentError,
               session,
+              suppressFinal: runtimeFailed,
             });
           }
           const shouldBroadcastAgentError =
-            hasReturnedAgentError &&
-            !broadcastedSourceReplyFinal &&
-            !context.chatRunState.hasAbortMarker(clientRunId);
-          if (shouldBroadcastAgentError) {
-            broadcastChatError({
-              context,
-              runId: clientRunId,
-              sessionKey,
-              agentId,
-              errorMessage: returnedAgentErrorMessage,
-              errorKind: runtimeClassification === "timeout" ? "timeout" : undefined,
-              stopReason: runtimeOutcome?.stopReason,
-            });
-          }
+            hasReturnedAgentError && (runtimeFailed || !finalizedSourceReply);
           if (!context.chatRunState.hasAbortMarker(clientRunId)) {
+            if (shouldBroadcastAgentError) {
+              broadcastChatError({
+                context,
+                runId: clientRunId,
+                sessionKey,
+                agentId,
+                errorMessage: returnedAgentErrorMessage,
+                errorKind: runtimeClassification === "timeout" ? "timeout" : undefined,
+                stopReason: runtimeOutcome?.stopReason,
+              });
+            }
             const returnedAgentError = shouldBroadcastAgentError
               ? errorShape(
                   ErrorCodes.UNAVAILABLE,

--- a/src/gateway/server-methods/chat-send-source-finalization.ts
+++ b/src/gateway/server-methods/chat-send-source-finalization.ts
@@ -85,7 +85,10 @@ export function createChatSendLateReplyFinalizer(
 }
 
 async function finalizeChatSendAgentReplyPayloads(
-  params: FinalizeChatSendAgentRepliesBase & { payloads: readonly ReplyPayload[] },
+  params: FinalizeChatSendAgentRepliesBase & {
+    payloads: readonly ReplyPayload[];
+    suppressFinal?: boolean;
+  },
 ): Promise<ChatSendAgentReplyFinalization> {
   const { accountId, context, emitFirstAssistantServerTiming, session } = params;
   const { agentId, backingSessionId, cfg, clientRunId, sessionKey, sessionLoadOptions } = session;
@@ -298,16 +301,19 @@ async function finalizeChatSendAgentReplyPayloads(
     stopReason: "stop",
     usage: { input: 0, output: 0, totalTokens: 0 },
   };
-  if (hasVisibleAssistantFinalMessage(message)) {
-    emitFirstAssistantServerTiming();
+  // Failed turns retain source media/transcript finalization; chat.error carries no message.
+  if (!params.suppressFinal) {
+    if (hasVisibleAssistantFinalMessage(message)) {
+      emitFirstAssistantServerTiming();
+    }
+    broadcastChatFinal({
+      context,
+      runId: clientRunId,
+      sessionKey,
+      agentId,
+      message,
+    });
   }
-  broadcastChatFinal({
-    context,
-    runId: clientRunId,
-    sessionKey,
-    agentId,
-    message,
-  });
   return { kind: "delivered", hasSourceReplyTranscriptMirror };
 }
 
@@ -316,6 +322,7 @@ export async function finalizeChatSendSourceReplies(
   params: FinalizeChatSendAgentRepliesBase & {
     deliveredReplies: readonly DeliveredReply[];
     hasReturnedAgentErrorPayloads: boolean;
+    suppressFinal?: boolean;
   },
 ): Promise<boolean> {
   const result = await finalizeChatSendAgentReplyPayloads({
@@ -324,6 +331,7 @@ export async function finalizeChatSendSourceReplies(
     emitFirstAssistantServerTiming: params.emitFirstAssistantServerTiming,
     payloads: selectChatSendAgentReplyPayloads(params),
     session: params.session,
+    suppressFinal: params.suppressFinal,
   });
   return result.kind === "delivered" && result.hasSourceReplyTranscriptMirror;
 }

--- a/src/gateway/server-methods/chat.directive-tags.test.ts
+++ b/src/gateway/server-methods/chat.directive-tags.test.ts
@@ -32,6 +32,7 @@ import {
 } from "../../auto-reply/reply/reply-run-registry.js";
 import { testing as replyRunRegistryTesting } from "../../auto-reply/reply/reply-run-registry.test-support.js";
 import type { MsgContext } from "../../auto-reply/templating.js";
+import { recordAgentRunTerminalOutcome } from "../../channels/turn/agent-run-terminal-outcome.js";
 import {
   appendTranscriptEvent,
   appendTranscriptMessage,
@@ -61,6 +62,7 @@ import { normalizeSessionDeliveryState } from "../../utils/delivery-context.shar
 import { consumeCronCreatorAuthorityGrant } from "../cron-creator-authority-grant.js";
 import { createChatRunState } from "../server-chat-state.js";
 import { STALE_WORKER_BUILD_REASON } from "../worker-environments/admission.js";
+import { agentWaitHandler } from "./agent-wait.js";
 import { handleChatSend, handleChatSendWithRuntimeTools } from "./chat-send-handler.js";
 import type { GatewayRequestContext, RespondFn } from "./types.js";
 
@@ -4269,50 +4271,155 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
   });
 
   it.each([
-    ["after start", true],
-    ["before launch", false],
-  ] as const)("broadcasts returned agent-run error payloads $0", async (_name, agentStarted) => {
-    await createGatewayUserTurnSqliteFixture("openclaw-chat-send-agent-returned-error-");
-    const errorMessage = agentStarted
-      ? "LLM idle timeout (120s): no response from model"
-      : STALE_WORKER_BUILD_REASON;
-    mockState.triggerAgentRunStart = agentStarted;
-    mockState.dispatchedReplies = [
-      {
-        kind: "final",
-        payload: {
-          text: errorMessage,
-          isError: true,
-        },
-      },
-    ];
-    const { context, send } = createChatRequestFixture();
-    const runId = agentStarted ? "idem-agent-returned-error" : "idem-agent-rejected-before-launch";
+    ["error payload after start", true, "error", undefined],
+    ["error payload before launch", false, "error", undefined],
+    ["recorded failure with ordinary output", true, "ordinary", "failed"],
+    ["recorded failure without output", true, "empty", "failed"],
+    ["recorded failure with source reply", true, "source", "failed"],
+    ["recorded success with ordinary output", true, "ordinary", "completed"],
+    ["recorded success with a recoverable warning", true, "warning", "completed"],
+    ["recorded success with source reply plus warning", true, "source-warning", "completed"],
+  ] as const)(
+    "projects agent-run terminal: $0",
+    async (name, agentStarted, presentation, outcome) => {
+      const fixtureDir = await createGatewayUserTurnSqliteFixture(
+        "openclaw-chat-send-agent-terminal-",
+      );
+      const runId = `idem-agent-terminal-${name.replaceAll(" ", "-")}`;
+      const failed = outcome === "failed" || presentation === "error";
+      const sourceReply = presentation === "source" || presentation === "source-warning";
+      const replyText = "Partial agent reply";
+      const errorMessage =
+        presentation === "error"
+          ? agentStarted
+            ? "LLM idle timeout (120s): no response from model"
+            : STALE_WORKER_BUILD_REASON
+          : "agent run failed";
+      const mirrorIdempotencyKey = `${runId}:internal-source-reply:0`;
+      const mediaUrl = `data:image/png;base64,${TINY_PNG_BASE64}`;
+      mockState.triggerAgentRunStart = agentStarted;
+      if (outcome) {
+        await appendTestTranscriptMessage({
+          eventId: `${runId}:user`,
+          role: "user",
+          content: "please keep working",
+          now: 0,
+          parentId: null,
+        });
+        mockState.triggerUserMessagePersisted = true;
+      }
+      if (sourceReply) {
+        writeSavedPng(fixtureDir, "source-terminal.png");
+        await appendSourceReplyMirrorEntry({
+          idempotencyKey: mirrorIdempotencyKey,
+          text: replyText,
+        });
+        mockState.dispatchedReplies = [
+          createMainSourceReply({
+            idempotencyKey: mirrorIdempotencyKey,
+            text: replyText,
+            mediaUrls: [mediaUrl],
+          }),
+        ];
+      } else if (presentation === "empty") {
+        mockState.finalText = "";
+      } else if (presentation === "error") {
+        mockState.dispatchedReplies = [
+          {
+            kind: "final",
+            payload: { text: errorMessage, isError: true },
+          },
+        ];
+      } else {
+        mockState.runtimeAssistantTextsBeforeDelivery = [replyText];
+        mockState.dispatchedReplies = [{ kind: "final", payload: { text: replyText } }];
+      }
+      if (presentation === "warning" || presentation === "source-warning") {
+        mockState.dispatchedReplies.push({
+          kind: "final",
+          payload: { text: "tool warning", isError: true },
+        });
+      }
+      if (outcome) {
+        const dispatch = expectDefined(
+          dispatchInboundMessageMock.getMockImplementation(),
+          "default chat dispatch fixture",
+        );
+        dispatchInboundMessageMock.mockImplementationOnce(async (params: TestDispatchParams) =>
+          recordAgentRunTerminalOutcome(await dispatch(params), outcome),
+        );
+      }
+      const { context, send } = createChatRequestFixture();
 
-    const broadcast = await send({
-      idempotencyKey: runId,
-      message: "please keep working",
-    });
-
-    expect(broadcast).toMatchObject({
-      runId,
-      sessionKey: "agent:main:main",
-      state: "error",
-      errorMessage,
-    });
-    expect(broadcast).not.toHaveProperty("message");
-    const dedupe = context.dedupe.get(`chat:${runId}`);
-    expect(dedupe?.ok).toBe(false);
-    expect(dedupe?.payload).toMatchObject({
-      runId,
-      status: "error",
-      summary: errorMessage,
-    });
-    const userUpdate = findUserUpdate();
-    expectUserUpdateIdentity(userUpdate);
-    const assistantUpdates = findAssistantTranscriptUpdates();
-    expect(assistantUpdates).toStrictEqual([]);
-  });
+      await send({
+        idempotencyKey: runId,
+        message: "please keep working",
+        waitFor: "none",
+      });
+      // Admission already owns a dedupe entry; observe the first terminal write, not key presence.
+      await waitForAssertion(() => {
+        expect(["ok", "error"]).toContain(context.dedupe.get(`chat:${runId}`)?.payload?.status);
+      });
+      const dedupe = context.dedupe.get(`chat:${runId}`);
+      expect(dedupe?.ok).toBe(!failed);
+      expect(dedupe?.payload).toMatchObject({
+        runId,
+        status: failed ? "error" : "ok",
+        ...(failed ? { summary: errorMessage } : {}),
+      });
+      const waitRespond = vi.fn<RespondFn>();
+      await agentWaitHandler({
+        params: { runId, timeoutMs: 0 },
+        respond: waitRespond,
+        context,
+        req: {} as never,
+        client: null,
+        isWebchatConnect: () => false,
+      });
+      expect(waitRespond).toHaveBeenCalledWith(
+        true,
+        expect.objectContaining({ runId, status: failed ? "error" : "ok" }),
+      );
+      const broadcasts = context.broadcast.mock.calls
+        .filter(([event]) => event === "chat")
+        .map(([, payload]) => payload);
+      if (failed) {
+        expect(broadcasts).toEqual([
+          expect.objectContaining({
+            runId,
+            sessionKey: "agent:main:main",
+            state: "error",
+            errorMessage,
+          }),
+        ]);
+        expect(broadcasts[0]).not.toHaveProperty("message");
+      } else if (sourceReply) {
+        expect(broadcasts).toEqual([expect.objectContaining({ runId, state: "final" })]);
+        expect(extractFirstTextBlock(broadcasts[0])).toBe(replyText);
+      } else {
+        expect(broadcasts).toEqual([]);
+      }
+      const assistantEntries = await readActiveAssistantTranscriptMessages();
+      if (presentation === "error" || presentation === "empty") {
+        expect(assistantEntries).toEqual([]);
+        expect(findAssistantTranscriptUpdates()).toEqual([]);
+      } else {
+        expect(assistantEntries).toHaveLength(1);
+        expect(JSON.stringify(assistantEntries[0]?.content)).toContain(replyText);
+      }
+      if (sourceReply) {
+        expect(assistantEntries[0]?.idempotencyKey).toBe(mirrorIdempotencyKey);
+        expect(JSON.stringify(assistantEntries[0])).toContain("/api/chat/media/outgoing/");
+        expect(JSON.stringify(assistantEntries[0]?.content)).not.toContain(mediaUrl);
+        expect(fs.existsSync(mockState.transcriptPath)).toBe(false);
+      }
+      if (presentation === "error") {
+        expectUserUpdateIdentity(findUserUpdate());
+      } else {
+        expect(readPersistedUserMessages()).toHaveLength(1);
+      }
+    },
+  );
 
   it("keeps visible text on non-agent TTS final media because no model transcript exists", async () => {
     const transcriptDir = await createTranscriptFixture("openclaw-chat-send-command-tts-final-");

--- a/src/gateway/server.chat.acp-completion.test.ts
+++ b/src/gateway/server.chat.acp-completion.test.ts
@@ -108,6 +108,10 @@ describe("Gateway ACP completion ownership", () => {
       text: "rendered reply",
       transform: () => ({ text: "rendered reply" }),
     },
+    {
+      name: "successful runtime with post-hook warning",
+      transform: (payload) => ({ ...payload, isError: true }),
+    },
     { name: "post-hook suppression", suppressed: true, transform: () => null },
     { name: "live block replies", live: true },
     {


### PR DESCRIPTION
Closes #131759 — resumed Code Mode cells outlive catalog cleanup.

AI-assisted maintainer repair. **Current head `65ce5c1d903` passed [exact-head CI](https://github.com/openclaw/openclaw/actions/runs/33249428498) on attempt 1 and completed native preparation. Final uninstrumented Gateway/SDK/QuickJS/Control UI proof passed on `4436eb234925`; the rebase and 610-test current-source integration evidence are recorded below.**

## What Problem This Solves

A resumed Code Mode cell could continue executing and emit output after its owning tool catalog closed. Cancellation belonged to the parked snapshot, so transferring that snapshot into an active resume released the lifetime listener. A real Copilot SDK error-cleanup flow reproduced this while a host command was pending.

The application proof exposed a connected false-success chain. After cancellation correctly stopped the pending tool, suppressing duplicate tool-error prose could omit the failed attempt from core metadata. Once that producer was repaired, a diagnostic Gateway trace located the remaining loss: chat completion discarded the recorded dispatch outcome and wrote `ok` because the delivered payloads were ordinary text. The first public `agent.wait` returned `ok`, and the UI showed “Done” and confetti before a later error. That historical failed proof remains failed.

## Why This Change Was Made

One cell-lifetime owner retains catalog/context cancellation across execution, parking, active resume, repark and headless execution. Only the current call observer changes. Pending bridge work receives cancellation; completed operations detach so ordinary terminal cleanup cannot retroactively abort them. The snapshot-only ownership path and duplicate snapshot state are removed.

One terminal-result builder classifies canonical failure independently of warning presentation. It preserves error metadata and existing delivered-output policy without recording successful auth bookkeeping or a success trace for a failed attempt at this producer. Ordinary tool errors within successful turns remain nonfatal.

Chat completion consumes the existing recorded native dispatch outcome. Main's richer ACP completion result, synchronous ownership acknowledgment, timeout/cancellation metadata and successful transcript receipt remain authoritative when supplied. Source media/transcript finalization is retained without emitting a success final for a known failure. There is no UI workaround, new status registry, global sticky-failure flag or replay-policy exemption.

Copilot discovery registration was fixed separately by [the prepared-harness and collector repair](https://github.com/openclaw/openclaw/pull/131739); this PR has no competing Copilot production change. Main's rejection/error-budget and wait-guidance changes are preserved. The newer per-model activation change is a separate caller responsibility; its prepared config must remain alongside this lifetime repair. No new config, schema, dependency, public SDK or native Codex protocol surface is introduced.

## User Impact

Closing a catalog stops later guest work, terminates active workers and requests cancellation of pending operations. Known failed turns remain failed instead of reporting completion. Existing output/delivery policy, stale-observer protection, expiry and the 64 suspended/reserved-slot limit remain intact; this is not a new total-worker cap. Cancellation cannot roll back external effects or force a noncooperative external operation to stop.

The [Code Mode lifecycle documentation](https://docs.openclaw.ai/tools/code-mode) is updated. Across 21 files, production is **+427/-468 (net -41)**; tests/support **+1227/-280 (net +947)**; docs **+11/-4 (net +7)**. Two unchanged state tests were moved. The CPU-worker fixture also registers resource cleanup before setup can fail, preserving its runtime assertions.

## Evidence

Published candidate: `65ce5c1d903b301332ad35ac5bacb87b2d45b79a`; checked main base: `8b1e44c107982d240c70fb8b5a5dd5d7bfec6a3a`. The application recording remains bound to `4436eb23492526a224c3c6c1c6e1e27ac22b04e8` against original repair base `bd9eeaebf0836cc3ae840669d4831495953c46fe`; it is not relabeled as a recording of the rebased source.

### Uninstrumented application proof — passed

The actual entrypoint was Control UI `chat.send` → auto-reply → installed Copilot SDK → QuickJS → one real host curl request. Both variants were built normally and exercised in a real browser. The baseline rolls back **all six production owners** to the repair base while retaining candidate tests/docs and other source; it is not a full base checkout.

| Observation | Six-owner baseline | Complete candidate |
|---|---|---|
| Initial exec | Waiting/yield; no output; call count 0 | Same |
| Resumed wait after catalog closure, while SDK destroy stayed held | Completed; emitted `STALE AFTER CLOSE` | Failed / `aborted`; output `[]`; bridge dispatch started; call count 1 |
| Replay authority | Unsafe | Unsafe |
| First public outer `agent.wait` | `error` | **`error`** |
| Later public outer `agent.wait` | `error`, same terminal identity | **`error`, same terminal identity** |
| UI | Failure banner | **Failure banner and “Interrupted” accessibility announcement; no outer “Done” or confetti** |
| Candidate exact-run `chat.final` | Not the status-loss counterexample; see historical image below | **None** |
| SDK callbacks / host requests / gate effects / UI sends | 2 / 1 / 1 / 1 | 2 / 1 / 1 / 1 |
| Public history quiescence | 14.828 s | 14.725 s; existing error grace unchanged |
| Natural cleanup | Passed | Passed |

The final pair and collection exited 0. Both full builds passed (227.855 s / 234.180 s); Gateway scenarios passed (39.052 s / 39.345 s). Natural cleanup signaled **only the still-live owned Gateway**, then observed the Gateway, SDK peer, host command and ports gone before group/browser/fixture cleanup. No forced group cleanup was needed. The actual per-attempt BYOK proxy was open at session creation and closed before held disconnect, after the attempt and after cleanup. Source restoration, staged index/HEAD/refs, audited dependencies, drivers, generated output, browser, host network and all nine collection checks passed.

Provider: **Blacksmith Testbox**, lease `tbx_01m167b59qe311h53p3rd4k51j`, [application-environment workflow](https://github.com/openclaw/openclaw/actions/runs/33241354476). The owned lease is stopped/completed; its Actions workflow ended cancelled during normal lease shutdown. This is **not PR CI**. Node 24.19.0, pnpm 12.0.0, Copilot SDK 1.0.11, CLI 1.0.80 and QuickJS 3.5.0 were verified from the actual Linux installation. SDK client/session source hashes matched the directly inspected contracts.

All 34,938 versioned paths were bound to application-proof head `4436eb234925`, not the subsequent rebase. Source-tree SHA256: `574eae900637df4054c905d7218b8d480f3d735cce71910f215d846efbc10698`; final freeze: `1d0cdd8b93ac455a349c1dc60f7511648677a45f6d076e7b59978e0aa01fc61c`; Linux execution receipt: `513fd56b9f6ebc0232a2aae7d0479c5c6f0030c490e2151ed4730a2522a21878`; driver: `820b4017c16e1f0e21689e13259d877de58559fa56598a1856ab6837f79a1472`. The audited installed scope is 909 files across the named SDK/runtime/browser-tool packages, not a claim to freeze every transitive dependency.

The backend is a deterministic local protocol peer, **not an authenticated provider or uncoached model-choice evaluation**. The real application/SDK/worker/browser ran with isolated state/port, fresh HOME and a loopback-only anonymous network namespace. Actual child identity, zero capability sets, NoNewPrivs, positive loopback and IPv4/IPv6 `ENETUNREACH` controls were checked. No real provider credentials or operator services were used. The configured Blacksmith environment is credential-hydrated, not secretless; its auth/helper was not read or sourced by the proof children.

### Inspected UI evidence

All six final-run screenshots were opened at full resolution. Both recordings were inspected through 2 fps samples across their complete timelines (six contact sheets), alongside the state captures; this is not an every-frame claim. Only synthetic screenshots/video are attached—no raw logs, auth, runtime state or transcripts.

**Historical diagnostic before the chat-outcome repair:** the lifetime/core candidate already aborted the cell, but the first public wait incorrectly returned `ok` and the UI displayed “Done”/confetti. This image is diagnostic history, not final-candidate acceptance.

![Historical intermediate candidate incorrectly reports Done and confetti](https://github.com/user-attachments/assets/fa605aa5-0613-409a-9030-236e9d067074)

**Final paired baseline:** the SDK receipt proves stale guest continuation; its outer provider failure already produces an error banner. It is not the historical false-success variant above.

![Six-owner baseline with provider failure banner](https://github.com/user-attachments/assets/976f8360-0aee-424f-8bfd-c85c2cbf8ae1)

**Complete candidate, first terminal observation:** the cell is aborted and the first public wait is an error, with a real error banner instead of success presentation.

![Complete candidate displays failure without Done or confetti](https://github.com/user-attachments/assets/cbc1bb76-aef0-408a-8714-fae0465230e7)

Baseline recording:

https://github.com/user-attachments/assets/954385c1-ba3b-44ab-b04b-661901831b84

Complete candidate recording:

https://github.com/user-attachments/assets/a18fa834-217c-4d76-835e-67b8e2dd9940

### Local verification and regressions

There are passing observations for **1,259 distinct focused cases across 49 files**, including real QuickJS cancellation, real 64-cell capacity, Cron/headless, installed SDK and native/ACP/Gateway completion ownership. This is a deduplicated union across scoped runs, not one all-green invocation: earlier setup/readiness failures and unchanged passing reruns remain documented below. The complete changed-file gate passed, including five additional doctor-contract tests and selected types/lint/architecture/docs checks. The standard repo-pinned `pnpm build` passed with no ineffective dynamic imports. Only the test-resource cleanup followed that gate/build; production/package inputs remained identical, and the full 16-case lifecycle suite plus focused type-aware lint, canonical test types and formatting passed afterward. The fresh integrated isolated review of the final complete patch found no actionable P0 findings.

Matched boundary regressions failed before the status repair and passed afterward: known failures with ordinary, empty or source output; successful native turns with recoverable warnings; and successful ACP turns whose post-hook payload was marked as a warning. Rich ACP cancellation/timeout and abort ownership remain intact. An identical injected fixture-setup exception demonstrated five leaked/unrestored CPU-test resources before cleanup registration and all five released/restored afterward. Those two deliberately failing probe commands are not counted as normal passing tests.

<details>
<summary>Selected exact local proof commands (Node 26.7.0; interpreter path normalized)</summary>

```bash
node scripts/run-vitest.mjs src/gateway/server-methods/chat.directive-tags.test.ts src/gateway/server.chat.acp-completion.test.ts -t 'projects agent-run terminal|Gateway ACP completion ownership'
```

```bash
node scripts/run-vitest.mjs src/auto-reply/reply/dispatch-from-config.reply-dispatch-scope.test.ts
```

```bash
node scripts/run-vitest.mjs src/auto-reply/reply/dispatch-from-config.acp-privacy.test.ts src/auto-reply/reply/dispatch-from-config.acp-abort.test.ts
```

```bash
node scripts/run-vitest.mjs src/agents/code-mode-worker-lifecycle.test.ts
```

```bash
corepack pnpm build
```

The complete changed gate used `node scripts/check-changed.mjs --` with all 21 PR paths explicitly supplied. Its receipt records 2599.183 s and unchanged source/dependencies/HEAD. The standard build receipt records 760.864 s. Full scoped commands, individual exits, source hashes and the case-count reconciliation are preserved in the task's validation receipts.

The final remote owner command was `python3 paired-run-v4.py --execute-approved` with the exact final freeze/execution hashes above and label `paired-application-3`. It invokes `node --import ./scripts/tsx.mjs scripts/build-all.mts` for each variant, then the actual Gateway driver behind the verified namespace owner. Those task-local scripts are not product entrypoints or committed proof assets.

</details>

### CI recovery and conflict-driven rebase

[CI 33244704788](https://github.com/openclaw/openclaw/actions/runs/33244704788), the ready-event refresh [33245741475](https://github.com/openclaw/openclaw/actions/runs/33245741475), and native manual recovery [33246306944](https://github.com/openclaw/openclaw/actions/runs/33246306944) all tested the same old synthetic merge `fb60d15715e4b9c840ec06442ef75481cadfe15f`. Its media migration test exceeded the 1,000-line lint limit. The manual gate's log confirms the initial exact-head checkout followed by the same PR-merge checkout; these remain failed runs, not source-test successes.

The branch temporarily carried only the canonical append-test relocation already landed in [the cloud attachment repair](https://github.com/openclaw/openclaw/pull/132358), commit `f784160456d3b27d6c65d06f932c72fb0218acf6`. All 13 append/migration tests, focused changed checks, and its fresh isolated review passed. No assertion, runtime, package or schema byte changed. That produced head `70c6e055ff41`, whose [exact-head CI 33247711049 passed](https://github.com/openclaw/openclaw/actions/runs/33247711049).

An actual conflict subsequently arose with [main's nested-tool history repair](https://github.com/openclaw/openclaw/pull/132457). The rebase onto `8b1e44c10798` combines the adjacent imports and retains all upstream tests. `git range-diff` shows only changed import context in the lifetime commit; terminal and chat repair commits are patch-identical. The temporary append-test relocation drops out because it is already upstream. Four production owners remain byte-identical to the application proof; the other two retain main's prepared-config input and current-run/media-preparation hooks. Main's dependency updates were adopted through a successful frozen pnpm 12 install, not authored overrides. The fresh isolated review of the rebased complete patch is clean.

The first integrated rebase run passed 564 cases before one bridge assertion failed: it checked the active-tool count immediately after worker abortion, ahead of main's new asynchronous transcript/terminal finalization. The unchanged focused case failed identically twice. A five-line test-only repair captures the forwarding `runToolLifecycle` promise and awaits its `Aborted` rejection before the exact zero-count assertion, still before disposal. Immediate failed/aborted and empty-registry assertions are unchanged. No timer, polling, wider deadline or production seam was added. The repaired focused case and all 25 bridge tests pass; focused lint/format and the fresh isolated review of this delta pass. The original failure remains recorded. The fresh combined integration run then passed **610 tests across all 16 files and six Vitest shards in 321.571 s**, preserving the original execution order. It includes Gateway native/ACP/media completion, Cron/headless, the combined bridge/history suite, per-model configuration, worker/capacity, core terminal resolution, and the installed Copilot SDK boundary. Source, dependency, HEAD and temporary-directory checks all passed. The focused changed gate passed in 330.120 s, including core test types, lint, formatting and policy guards, with the comparison base pinned to `8b1e44c10798`. The published commit's source and dependency bytes exactly match that successful integration run; the commit hook made no further source changes.

### Failed attempts, limits and review follow-through

Two final-proof attempts remain failed, rather than being relabeled: the first stopped after a passing baseline because its guard incorrectly treated Git's mutable serialized index cache as source identity; the second reached the candidate's correct first error but demanded a visual Interrupted badge that the UI intentionally suppresses when an error banner is present. Git 2.52 source documentation and independent Git controls established the cache contract; the replacement guard still binds staged contents/flags and complete source bytes, while recording raw index hashes. The UI probe now requires the real visible error banner plus the existing Interrupted accessibility announcement within the original deadline. No production/UI code, timeout or application-result assertion was weakened. Both were followed by the fresh passing pair above.

Earlier local dispatch-fixture setup/readiness deadlines also failed before unchanged final runs passed. Their latency cause is not established. No speculative preload, extra mock or wider deadline was retained; the CPU-fixture cleanup is a separately reproduced defect, not an explanation for those delays.

The [ClawSweeper review](https://github.com/openclaw/openclaw/pull/132182#issuecomment-5458629902), reviewed at 2026-08-29 10:30 UTC on `70c6e055ff41`, reports no source findings and accepts the real-behavior recording. Its exact-head CI request is satisfied for that head by [CI run 33247711049](https://github.com/openclaw/openclaw/actions/runs/33247711049), completed successfully with no failed or unfinished jobs. The subsequent head `65ce5c1d903` also passed [its own exact-head CI](https://github.com/openclaw/openclaw/actions/runs/33249428498), and native preparation completed with unchanged prepared/published identity.

The external-SDK inspection gap in that review is closed by the lead's direct inspection of the actual Linux installation used for the proof: `@github/copilot-sdk@1.0.11`, `dist/session.js:449–491` handles `session.error` independently of outstanding tool work; `:543–588` dispatches the external-tool handler without awaiting it; `:668–714` awaits the tool handler and sends the pending-tool reply; `:1461–1468` awaits `session.destroy` before marking the session disconnected. The downloaded source matches the installed local source: client SHA256 `189f5560442228a159fe817dc3b1e78d5d89d9470603c3b4f81de4192bc81edb`, session SHA256 `d8f1d3e66bd931aef7a759c4073aef7fd60e14cacc2cf8b812bfe092ca63ecd1`. The held-destroy regression and application run exercise that exact ordering, rather than assuming it from the peer.

Its serialized-state heuristic points to a test-only loopback protocol fixture, not a runtime store or migration. Production remains net **-41**; test support is counted separately rather than as production. The broader prepared-registry executable-resource disposal question remains separate; the faithful peer preserves the official CLI's stdin-EOF behavior. Generic lifecycle-error grace/cancellation policy, Copilot source persistence and the remaining wait-ID/output-provenance work are not expanded here.
