### PR TITLE
fix(codex): explicitly selected hidden models fail bounded turns

### DIFF
--- a/docs/plugins/codex-harness-reference.md
+++ b/docs/plugins/codex-harness-reference.md
@@ -785,6 +785,13 @@ points `appServer.command` at a different Codex binary. Availability can also
 be account-scoped. Use `/codex models` on a running gateway to see the live
 catalog for that harness and account.
 
+Automatic discovery and hosted-search model selection use visible picker entries.
+Bounded turns with an explicit model selection, including image understanding,
+structured extraction, isolated completion, and settled-turn finalization, also
+look up hidden entries returned by `model/list`. The model must still be listed
+and support the required input modalities. Listing does not prove account
+entitlement.
+
 Native discovery reads `model/list` and `account/read` from the same scoped
 app-server client. An API-key account remains API-key authentication; model
 listing does not imply a ChatGPT transport or endpoint. Picker readiness is

--- a/extensions/codex/src/app-server/bounded-turn.test.ts
+++ b/extensions/codex/src/app-server/bounded-turn.test.ts
@@ -1,3 +1,4 @@
+import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { describe, expect, it, vi } from "vitest";
 import { runBoundedCodexAppServerTurn } from "./bounded-turn.js";
 import { createFakeCodexAppServerClient } from "./codex-app-server.test-fixtures.js";
@@ -5,28 +6,29 @@ import type { JsonValue } from "./protocol.js";
 import type { CodexAppServerClientFactory } from "./shared-client.js";
 import { CODEX_APP_SERVER_VERSION } from "./version.js";
 
-function modelList(model = "gpt-5.4", id = model) {
+function codexModel(model = "gpt-5.4", id = model) {
   return {
-    data: [
-      {
-        id,
-        model,
-        displayName: "GPT-5.4",
-        description: "test model",
-        hidden: false,
-        isDefault: true,
-        inputModalities: ["text"],
-        supportedReasoningEfforts: [],
-        defaultReasoningEffort: "low",
-        supportsPersonality: false,
-        additionalSpeedTiers: [],
-      },
-    ],
-    nextCursor: null,
+    id,
+    model,
+    upgrade: null,
+    upgradeInfo: null,
+    availabilityNux: null,
+    displayName: id,
+    description: "test model",
+    hidden: false,
+    isDefault: true,
+    inputModalities: ["text"],
+    supportedReasoningEfforts: [{ reasoningEffort: "low", description: "fast" }],
+    defaultReasoningEffort: "low",
+    supportsPersonality: false,
+    multiAgentVersion: null,
+    additionalSpeedTiers: [],
+    serviceTiers: [],
+    defaultServiceTier: null,
   };
 }
 
-function threadStartResult() {
+function threadStartResult(model: string) {
   return {
     thread: {
       id: "thread-finalizer",
@@ -46,7 +48,7 @@ function threadStartResult() {
       name: null,
       turns: [],
     },
-    model: "gpt-5.4",
+    model,
     modelProvider: "openai",
     cwd: "/tmp/finalizer",
     approvalPolicy: "on-request",
@@ -107,15 +109,18 @@ function createClientFactory(
     assistantDelta?: string;
     emptyAnswer?: boolean;
     completeTurn?: boolean;
-    model?: string;
-    modelId?: string;
+    models?: ReturnType<typeof codexModel>[];
   } = {},
 ) {
   const methods: string[] = [];
-  const fixture = createFakeCodexAppServerClient(async (method: string, _params?: unknown) => {
+  const fixture = createFakeCodexAppServerClient(async (method: string, params?: unknown) => {
     methods.push(method);
     if (method === "model/list") {
-      return modelList(options.model, options.modelId);
+      const includeHidden = isRecord(params) && params.includeHidden === true;
+      return {
+        data: (options.models ?? [codexModel()]).filter((model) => includeHidden || !model.hidden),
+        nextCursor: null,
+      };
     }
     if (method === "config/read") {
       return {
@@ -126,8 +131,8 @@ function createClientFactory(
     if (method === "configRequirements/read") {
       return { requirements: null };
     }
-    if (method === "thread/start") {
-      return threadStartResult();
+    if (method === "thread/start" && isRecord(params) && typeof params.model === "string") {
+      return threadStartResult(params.model);
     }
     if (method === "mcpServerStatus/list") {
       return {
@@ -581,15 +586,26 @@ describe("runBoundedCodexAppServerTurn settled finalization isolation", () => {
     );
   });
 
-  it("uses the execution model for required logical model ids", async () => {
+  it.each([
+    { label: "visible catalog ID", id: "gpt-5.6-sol", hidden: false, requested: "gpt-5.6-sol" },
+    { label: "hidden catalog ID", id: "umbreon-latest", hidden: true, requested: "umbreon-latest" },
+    {
+      label: "hidden execution ID",
+      id: "umbreon-latest",
+      hidden: true,
+      requested: "codex-execution-model",
+    },
+  ])("uses the execution model for a required $label", async ({ id, hidden, requested }) => {
     const fake = createClientFactory({
-      model: "codex-execution-model",
-      modelId: "gpt-5.6-sol",
+      models: [
+        { ...codexModel("codex-execution-model", id), hidden, isDefault: !hidden },
+        { ...codexModel(), isDefault: hidden },
+      ],
     });
 
     await expect(
       runBoundedCodexAppServerTurn({
-        model: { mode: "required", id: "gpt-5.6-sol" },
+        model: { mode: "required", id: requested },
         timeoutMs: 5_000,
         options: { clientFactory: fake.factory },
         taskLabel: "isolated completion",
@@ -598,12 +614,61 @@ describe("runBoundedCodexAppServerTurn settled finalization isolation", () => {
         requiredModalities: ["text"],
         isolation: "configured-transport",
       }),
-    ).resolves.toMatchObject({ model: "gpt-5.6-sol" });
+    ).resolves.toMatchObject({ model: id, text: "The message was sent successfully." });
 
     const threadStart = fake.request.mock.calls.find(([method]) => method === "thread/start")?.[1];
     const turnStart = fake.request.mock.calls.find(([method]) => method === "turn/start")?.[1];
     expect(threadStart).toMatchObject({ model: "codex-execution-model" });
     expect(turnStart).toMatchObject({ model: "codex-execution-model" });
+  });
+
+  it("keeps hidden models out of live-default selection", async () => {
+    const fake = createClientFactory({
+      models: [
+        { ...codexModel("umbreon-latest"), hidden: true, isDefault: false },
+        { ...codexModel("image-only-default"), inputModalities: ["image"] },
+        { ...codexModel("visible-execution-model", "visible-model"), isDefault: false },
+      ],
+    });
+
+    await expect(
+      runBoundedCodexAppServerTurn({
+        model: { mode: "live-default" },
+        timeoutMs: 5_000,
+        options: { clientFactory: fake.factory },
+        taskLabel: "hosted search",
+        developerInstructions: "Search only.",
+        input: [{ type: "text", text: "Find the answer.", text_elements: [] }],
+        requiredModalities: ["text"],
+        isolation: "private-stdio",
+      }),
+    ).resolves.toMatchObject({
+      model: "visible-model",
+      text: "The message was sent successfully.",
+    });
+
+    const threadStart = fake.request.mock.calls.find(([method]) => method === "thread/start")?.[1];
+    const turnStart = fake.request.mock.calls.find(([method]) => method === "turn/start")?.[1];
+    expect(threadStart).toMatchObject({ model: "visible-execution-model" });
+    expect(turnStart).toMatchObject({ model: "visible-execution-model" });
+  });
+
+  it("rejects a missing required model before starting a thread", async () => {
+    const fake = createClientFactory();
+
+    await expect(
+      runBoundedCodexAppServerTurn({
+        model: { mode: "required", id: "missing-model" },
+        timeoutMs: 5_000,
+        options: { clientFactory: fake.factory },
+        taskLabel: "isolated completion",
+        developerInstructions: "Answer only.",
+        input: [{ type: "text", text: "Name this conversation.", text_elements: [] }],
+        requiredModalities: ["text"],
+        isolation: "configured-transport",
+      }),
+    ).rejects.toThrow("Codex app-server model not found: missing-model");
+    expect(fake.methods).toEqual(["model/list"]);
   });
 
   it("attests ring-zero and injects frozen history before starting the final turn", async () => {

--- a/extensions/codex/src/app-server/bounded-turn.ts
+++ b/extensions/codex/src/app-server/bounded-turn.ts
@@ -472,7 +472,7 @@ async function resolveCodexBoundedTurnModel(params: {
 }): Promise<{ catalogId: string; runtimeModelId: string }> {
   const result = await params.client.request<unknown>(
     "model/list",
-    { limit: null, cursor: null, includeHidden: false },
+    { limit: null, cursor: null, includeHidden: params.selection.mode === "required" },
     { timeoutMs: Math.min(params.timeoutMs, 5_000), signal: params.signal },
   );
   const listed = readModelListResult(result).models;


### PR DESCRIPTION
Closes #132187 — explicit hidden Codex models fail bounded turns.

<details>
<summary>Additional instructions</summary>

Maintainers can update this same-repository branch.

</details>

## What Problem This Solves

Fixes an issue where explicitly selecting a Codex model hidden from the default picker caused bounded image understanding, structured extraction, isolated completion, and settled-turn finalization to fail with `model not found` before inference.

The model could be present in the native catalog; OpenClaw was applying the picker's visibility filter to an explicit model lookup.

## Why This Change Was Made

The shared bounded-turn owner now requests hidden catalog entries only for an explicit `required` model selection. Automatic hosted-search selection still uses visible entries. Missing-model errors, input-modality checks, authentication, and tool isolation are unchanged.

The regression fixture `umbreon-latest` exercises hidden catalog and execution IDs through thread creation, turn start, and completion. The fake app-server now honors the actual `includeHidden` request, so the tests reproduce the upstream contract rather than always returning every row. A sibling case keeps hidden models out of automatic selection.

Direct sibling-source inspection covered both bundled Codex [`rust-v0.150.1`](https://github.com/openai/codex/blob/90854393966b21e9ebfd21b122334eb09a20c93d/codex-rs/app-server/src/models.rs#L13-L24) and the latest fetched upstream revision [`2008d27e98d7`](https://github.com/openai/codex/blob/2008d27e98d7b46170d2d464b36dbf97008611b8/codex-rs/app-server-protocol/src/protocol/v2/model.rs#L53-L63). The visibility contract is unchanged. The unconditional filter originated in [#93446 — Codex hosted web search](https://github.com/openclaw/openclaw/pull/93446) (`1e0062b44a5`, author and merger @fuller-stack-dev).

## User Impact

Explicitly selected hidden models can proceed through bounded turns when the native catalog contains the model and its input modalities match. This does not expose hidden entries in ordinary automatic selection, add a model, grant entitlement, or change provider credentials. The Codex reference documentation now explains the distinction.

## Evidence

- Before the fix, the two new hidden-ID cases failed with `Codex app-server model not found`; the automatic-selection case passed.
- After the fix, `node scripts/run-vitest.mjs extensions/codex/src/app-server/bounded-turn.test.ts extensions/codex/media-understanding-provider.test.ts extensions/codex/src/app-server/isolated-completion.test.ts extensions/codex/src/app-server/settled-turn-finalizer.test.ts extensions/codex/src/web-search-provider.test.ts` — 62 tests passed across 5 files.
- Real-process before/after proof used the actual OpenClaw bounded-turn owner, installed Codex `0.150.1`, a fresh isolated home, a synthetic model catalog, and a loopback Responses fixture. Original code failed with the same model-not-found error; fixed code completed both an explicit hidden-model turn and an automatic visible-model turn. Outbound model IDs matched the selections, and no Authorization header was sent. This is real app-server integration proof, not live model inference or an entitlement claim.
- `node scripts/check-changed.mjs -- docs/plugins/codex-harness-reference.md extensions/codex/src/app-server/bounded-turn.ts extensions/codex/src/app-server/bounded-turn.test.ts` — formatting, production/test typechecks, lint, and selected boundary/guard checks passed.
- Fresh Codex autoreview — no accepted/actionable P0 findings.
- `git diff --check` — passed.
- Production LOC: +1/-1 (net 0). Tests: +95/-30 (net +65). Docs: +7/-0.

AI-assisted. No dependency, configuration, manifest model-list, or schema changes. No screenshot evidence is claimed: the changed boundary is native model lookup, and the real-process proof covers it directly.
