### PR TITLE
fix(compaction): preserve headroom for local chat follow-up turns

### DIFF
--- a/docs/providers/ollama.md
+++ b/docs/providers/ollama.md
@@ -965,14 +965,20 @@ For full setup and behavior, see [Ollama Web Search](/tools/ollama-search).
     Per-model `contextWindow` declares native window metadata, and per-model
     `contextTokens` caps active input. Provider-level `maxTokens` remains an
     output-token default; a model entry can override it. Native
-    `/api/chat` requests leave `options.num_ctx` unset unless you set
-    `params.num_ctx` explicitly, so Ollama applies its own model,
-    `OLLAMA_CONTEXT_LENGTH`, or VRAM-based default; invalid, zero, negative,
-    or non-finite `params.num_ctx` values are ignored. After upgrading an older
-    configuration, run `openclaw doctor --fix`, then set `params.num_ctx`
-    explicitly when you need to force native request context. The
+    `/api/chat` requests set `options.num_ctx` from a positive `params.num_ctx`
+    first, then from the effective model `contextTokens` when present. Local
+    discovery normally caps `contextTokens` at 32,768 (or the model's smaller
+    native window), so OpenClaw can override a smaller Modelfile context even
+    without an explicit `params.num_ctx`. Invalid, zero, negative, or non-finite
+    `params.num_ctx` values are ignored. Only when neither value is available
+    does Ollama choose its own model, Modelfile, `OLLAMA_CONTEXT_LENGTH`, or
+    VRAM-based default; the native adapter does not fall back directly to the
+    advertised `contextWindow`. After upgrading an older configuration, run
+    `openclaw doctor --fix`. Use `params.num_ctx` to override the native request
+    context explicitly. The
     OpenAI-compatible adapter still injects `options.num_ctx` by default from
-    `params.num_ctx` or the matching model entry's `contextWindow`; disable with
+    `params.num_ctx`, then the matching model entry's `contextTokens` or
+    `contextWindow`; disable with
     `injectNumCtxForOpenAICompat: false` if the upstream rejects `options`.
 
     Native model entries also accept common Ollama runtime options under
@@ -1301,8 +1307,8 @@ For full setup and behavior, see [Ollama Web Search](/tools/ollama-search).
 
   <Accordion title="Large-context model is too slow or runs out of memory">
     Many models advertise contexts larger than your hardware can run
-    comfortably. Native Ollama uses its own runtime default unless
-    `params.num_ctx` is set. Cap both OpenClaw's budget and Ollama's request
+    comfortably. Native requests forward the effective `contextTokens` unless
+    `params.num_ctx` overrides it. Cap both OpenClaw's budget and Ollama's request
     context for predictable first-token latency:
 
     ```json5

--- a/docs/reference/session-management-compaction.md
+++ b/docs/reference/session-management-compaction.md
@@ -217,7 +217,7 @@ The built-in OpenClaw runtime has three scheduling paths:
 
    One provider shape is terminal rather than compaction-recoverable. When the refusal states a single request larger than the provider's entire token limit - Groq answers an oversized request with an HTTP 413 naming TPM and stating `Limit <n>, Requested <m>` - no bucket state can admit it. Compaction budgets against the model's context window rather than that per-request ceiling, and its own summarization request is refused by the same ceiling, so it can only spend further calls that cannot succeed. OpenClaw surfaces the reset guidance immediately instead of compacting, adopting a successor transcript, or retrying. Ordinary TPM throttling, which states a requested size within the limit, stays a rate limit and keeps its normal backoff.
 
-2. **Usage-based maintenance**: normal replies check projected usage before their turn; successful direct commands, including `agent --local` and Gateway agent RPC runs, check after the completed turn is persisted and any pending final reply is protected. Both use the active model budget and shared maintenance headroom. Disabling memory flush does not disable this compaction. Direct-command maintenance respects `compaction.enabled: false` and skips a second compaction when the completed run already compacted.
+2. **Usage-based maintenance**: normal replies check projected usage before their turn; successful direct commands, including `agent --local` and Gateway agent RPC runs, check after the completed turn is persisted and any pending final reply is protected. Both block on projected usage at or above the active model window minus the selected compaction reserve, subject to an applicable server compaction threshold floor. The memory-flush soft margin does not lower this blocking threshold. Disabling memory flush does not disable this compaction. Direct-command maintenance respects `compaction.enabled: false` and skips a second compaction when the completed run already compacted.
 3. **Session-internal threshold maintenance**: default-mode sessions can also compact when actual context usage exceeds the model window minus the session reserve. Safeguard mode disables this competing session-internal path and leaves proactive scheduling to the maintenance owner above.
 
 The persisted `contextBudgetStatus` is a pre-prompt pressure estimate, not an execution command. Completed direct commands, normal replies, and queued follow-up replies record it when the runtime supplies one. `/status` can show this estimate, marked with `~` and `est`, when fresh token usage is unavailable. Compaction and session resets invalidate old estimates; a completed run without a diagnostic clears the previous one unless that run preserves the session's model state (for example, a heartbeat). Its `route` and `shouldCompact` fields can report pressure while the provider attempt is still admitted. Use completed compaction counts and transcript entries to verify that compaction actually happened.
@@ -291,6 +291,14 @@ Config (`agents.defaults.compaction.memoryFlush`), full reference at [/gateway/c
 | `model`                     | unset            | exact provider/model override for the flush turn only, for example `ollama/qwen3:8b`                                                                   |
 | `softThresholdTokens`       | `4000`           | gap below the compaction threshold that triggers a flush                                                                                               |
 | `forceFlushTranscriptBytes` | unset (disabled) | force a flush once active transcript history reaches this estimated byte size (or string like `"2mb"`), even if token counters are stale; `0` disables |
+
+For a 32,768-token window, a 20,000-token reserve and a 4,000-token soft margin,
+early flushing starts at 8,768 projected tokens. Blocking token compaction starts
+at 12,768, or later if an applicable server threshold is higher. Between those
+thresholds, flushing can run without blocking the next user turn on compaction.
+The selected memory provider owns the reserve and flush margin; without a flush
+plan, maintenance still uses the effective compaction reserve. Nonpositive
+thresholds suppress token triggers. Transcript byte guards remain independent.
 
 Notes:
 

--- a/src/agents/agent-hooks/compaction-safeguard.test.ts
+++ b/src/agents/agent-hooks/compaction-safeguard.test.ts
@@ -1,7 +1,12 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import type { AgentMessage, StreamFn } from "openclaw/plugin-sdk/agent-core";
+import {
+  prepareCompaction,
+  type AgentMessage,
+  type SessionTreeEntry,
+  type StreamFn,
+} from "openclaw/plugin-sdk/agent-core";
 import type { ExtensionAPI, ExtensionContext } from "openclaw/plugin-sdk/agent-sessions";
 import { createAssistantMessageEventStream, type Model } from "openclaw/plugin-sdk/llm";
 /** Tests compaction safeguard summaries, quality audit, providers, and runtime settings. */
@@ -2751,59 +2756,221 @@ describe("compaction-safeguard recent-turn preservation", () => {
     expect(consumeCompactionSafeguardCancelReason(sessionManager)).toBeNull();
   });
 
-  it("retries a split-turn summary that revives a completed request", async () => {
-    mockSummarizeInStages.mockReset();
-    const latestAsk = "combine the provider boxes into one completed artifact";
-    const identifier = "/tmp/pr130620/live/marker";
-    const structuredSummary = (pendingAsk: string) =>
-      [
+  it.each([true, false])(
+    "retries a split-turn summary that revives a completed request (corrected=%s)",
+    async (corrected) => {
+      mockSummarizeInStages.mockReset();
+      const latestAsk = "combine the provider boxes into one completed artifact";
+      const identifier = "/tmp/pr130620/live/marker";
+      const structuredSummary = (pendingAsk: string) =>
+        [
+          "## Decisions",
+          `${latestAsk} was completed.`,
+          "## Open TODOs",
+          "None.",
+          "## Constraints/Rules",
+          "Preserve exact identifiers.",
+          "## Pending user asks",
+          pendingAsk,
+          "## Exact identifiers",
+          identifier,
+        ].join("\n");
+      mockSummarizeInStages
+        .mockResolvedValueOnce(summaryResult(structuredSummary(latestAsk)))
+        .mockResolvedValueOnce(summaryResult(structuredSummary(corrected ? "None." : latestAsk)));
+
+      const sessionManager = stubSessionManager();
+      setCompactionSafeguardRuntime(sessionManager, {
+        model: createAnthropicModelFixture(),
+        qualityGuardEnabled: true,
+        qualityGuardMaxRetries: 1,
+      });
+      const messages: AgentMessage[] = [
+        { role: "user", content: `${latestAsk} and preserve ${identifier}`, timestamp: 1 },
+        castAgentMessage({
+          role: "assistant",
+          content: [{ type: "text", text: "The requested artifact is complete." }],
+          stopReason: "stop",
+          usage: { input: 7_039, output: 34, totalTokens: 7_073 },
+          timestamp: 2,
+        }),
+      ];
+      const entries: SessionTreeEntry[] = messages.map((message, index) => ({
+        type: "message",
+        id: `entry-${index}`,
+        parentId: index ? `entry-${index - 1}` : null,
+        timestamp: new Date(index + 1).toISOString(),
+        message,
+      }));
+      const prepared = prepareCompaction(entries, {
+        enabled: true,
+        reserveTokens: 4_000,
+        keepRecentTokens: 0,
+      });
+      if (!prepared.ok || !prepared.value) {
+        throw new Error("expected a prepared split turn");
+      }
+      expect(prepared.value).toMatchObject({
+        firstKeptEntryId: "entry-1",
+        turnPrefixMessages: [messages[0]],
+        splitTurnCompleted: true,
+      });
+      const retainedTerminal = structuredClone(entries[1]);
+      const event = {
+        preparation: prepared.value,
+        customInstructions: "",
+        signal: new AbortController().signal,
+      };
+
+      const { result } = await runCompactionScenario({ sessionManager, event, apiKey: "test-key" });
+
+      expect(mockSummarizeInStages).toHaveBeenCalledTimes(2);
+      if (corrected) {
+        const finalSummary = expectCompactionResult(result).summary;
+        expect(finalSummary).not.toContain(`## Pending user asks\n${latestAsk}`);
+        expect(finalSummary).toContain("## Pending user asks\nNone.");
+      } else {
+        expect(result).toEqual({ cancel: true });
+        expect(consumeCompactionSafeguardCancelReason(sessionManager)).toContain(
+          "failed quality checks",
+        );
+      }
+      expect(entries[1]).toEqual(retainedTerminal);
+      for (const [call] of mockSummarizeInStages.mock.calls) {
+        expect(call.messages).toEqual([messages[0]]);
+        expect(call.customInstructions).toContain(
+          "The split turn is completed; its terminal response is retained outside this prefix.",
+        );
+      }
+      const retry = requireRecord(mockCallArg(mockSummarizeInStages, 1));
+      expect(retry.customInstructions).toContain("completed_latest_user_ask_marked_pending");
+    },
+  );
+
+  it.each([
+    { prefixRole: "user", stopReason: "toolUse", completed: false },
+    { prefixRole: "user", stopReason: "error", completed: false },
+    { prefixRole: "user", stopReason: "aborted", completed: false },
+    { prefixRole: "custom", stopReason: "stop", completed: true },
+    { prefixRole: "bashExecution", stopReason: "stop", completed: true },
+  ] as const)(
+    "binds $prefixRole/$stopReason completion in initial and corrective generation",
+    async ({ prefixRole, stopReason, completed }) => {
+      mockSummarizeInStages.mockReset();
+      const historyAsk = "report the deployment status";
+      const splitAsk = "inspect the service configuration";
+      const latestAsk = prefixRole === "user" ? splitAsk : historyAsk;
+      const assistant = (text: string, reason: string) =>
+        castAgentMessage({
+          role: "assistant",
+          content: [{ type: "text", text }],
+          stopReason: reason,
+          timestamp: 2,
+          usage: { input: 7_039, output: 34, totalTokens: 7_073 },
+        });
+      const prefix: AgentMessage =
+        prefixRole === "user"
+          ? { role: "user", content: splitAsk, timestamp: 3 }
+          : prefixRole === "custom"
+            ? {
+                role: "custom",
+                customType: "maintenance",
+                content: "maintenance event",
+                display: false,
+                timestamp: 3,
+              }
+            : {
+                role: "bashExecution",
+                command: "true",
+                output: "",
+                exitCode: 0,
+                cancelled: false,
+                truncated: false,
+                timestamp: 3,
+              };
+      const messages: AgentMessage[] = [
+        { role: "user", content: historyAsk, timestamp: 1 },
+        assistant("Deployment is complete.", "stop"),
+        prefix,
+        assistant("Retained suffix.", stopReason),
+      ];
+      const entries: SessionTreeEntry[] = messages.map((message, index) => ({
+        type: "message",
+        id: `entry-${index}`,
+        parentId: index ? `entry-${index - 1}` : null,
+        timestamp: new Date(index + 1).toISOString(),
+        message,
+      }));
+      const prepared = prepareCompaction(entries, {
+        enabled: true,
+        reserveTokens: 4_000,
+        keepRecentTokens: 0,
+      });
+      if (!prepared.ok || !prepared.value) {
+        throw new Error("expected a prepared split turn");
+      }
+      expect(prepared.value).toMatchObject({
+        firstKeptEntryId: "entry-3",
+        isSplitTurn: true,
+        splitTurnCompleted: false,
+      });
+      const validSummary = [
         "## Decisions",
-        `${latestAsk} was completed.`,
+        completed ? `${latestAsk} is completed.` : "Continue the current work.",
         "## Open TODOs",
         "None.",
         "## Constraints/Rules",
-        "Preserve exact identifiers.",
+        "Preserve context.",
         "## Pending user asks",
-        pendingAsk,
+        completed ? "None." : latestAsk,
         "## Exact identifiers",
-        identifier,
+        "None.",
       ].join("\n");
-    mockSummarizeInStages
-      .mockResolvedValueOnce(summaryResult(structuredSummary(latestAsk)))
-      .mockResolvedValueOnce(summaryResult(structuredSummary("None.")));
-
-    const sessionManager = stubSessionManager();
-    setCompactionSafeguardRuntime(sessionManager, {
-      model: createAnthropicModelFixture(),
-      qualityGuardEnabled: true,
-      qualityGuardMaxRetries: 1,
-    });
-    const event = {
-      preparation: {
-        messagesToSummarize: [] as AgentMessage[],
-        turnPrefixMessages: [
-          { role: "user", content: `${latestAsk} and preserve ${identifier}`, timestamp: 1 },
-        ] as AgentMessage[],
-        splitTurnCompleted: true,
-        firstKeptEntryId: "entry-1",
-        tokensBefore: 90_000,
-        fileOps: { read: [], edited: [], written: [] },
-        settings: { reserveTokens: 4_000 },
-        isSplitTurn: true,
-      },
-      customInstructions: "",
-      signal: new AbortController().signal,
-    };
-
-    const { result } = await runCompactionScenario({ sessionManager, event, apiKey: "test-key" });
-
-    const finalSummary = expectCompactionResult(result).summary;
-    expect(mockSummarizeInStages).toHaveBeenCalledTimes(2);
-    expect(finalSummary).not.toContain(`## Pending user asks\n${latestAsk}`);
-    expect(finalSummary).toContain("## Pending user asks\nNone.");
-    const retry = requireRecord(mockCallArg(mockSummarizeInStages, 1));
-    expect(retry.customInstructions).toContain("completed_latest_user_ask_marked_pending");
-  });
+      let historyCalls = 0;
+      mockSummarizeInStages.mockImplementation(async ({ messages: summaryMessages }) => {
+        if (
+          summaryMessages.some(
+            (message) => message.role === "user" && message.content === historyAsk,
+          )
+        ) {
+          return ++historyCalls === 1 ? "invalid first attempt" : validSummary;
+        }
+        return validSummary;
+      });
+      const sessionManager = stubSessionManager();
+      setCompactionSafeguardRuntime(sessionManager, {
+        model: createAnthropicModelFixture(),
+        recentTurnsPreserve: 0,
+        qualityGuardEnabled: true,
+        qualityGuardMaxRetries: 1,
+      });
+      const { result } = await runCompactionScenario({
+        sessionManager,
+        event: {
+          preparation: prepared.value,
+          customInstructions: "",
+          signal: new AbortController().signal,
+        },
+        apiKey: "test-key",
+      });
+      expectCompactionResult(result);
+      const prefixCalls = mockSummarizeInStages.mock.calls
+        .map(([call]) => call)
+        .filter((call) => call.messages[0]?.role === prefixRole && call.messages.length === 1);
+      expect(prefixCalls).toHaveLength(2);
+      for (const call of prefixCalls) {
+        if (prefixRole === "user") {
+          expect(call.customInstructions).toContain("The split turn is not completed.");
+        } else {
+          expect(call.customInstructions).not.toContain("The split turn is ");
+        }
+        expect(call.messages).toEqual([prefix]);
+      }
+      expect(mockAuditSummaryQuality).toHaveBeenLastCalledWith(
+        expect.objectContaining({ latestAsk, latestAskCompleted: completed }),
+      );
+    },
+  );
 
   it("audits all-preserved fallback output against pre-partition source facts", async () => {
     mockSummarizeInStages.mockReset();

--- a/src/agents/agent-hooks/compaction-safeguard.ts
+++ b/src/agents/agent-hooks/compaction-safeguard.ts
@@ -1237,10 +1237,20 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
       }
 
       const oracleMessages = [...messagesToSummarize, ...turnPrefixMessages];
-      const latestUserTurn = extractLatestUserTurn(oracleMessages);
+      const splitUserTurn = preparation.isSplitTurn
+        ? extractLatestUserTurn(turnPrefixMessages)
+        : null;
+      const latestUserTurn = splitUserTurn ?? extractLatestUserTurn(messagesToSummarize);
       const latestUserAsk = latestUserTurn?.ask ?? null;
+      // Preparation sees the retained suffix. Bind that fact only to its user-bearing cut turn,
+      // not an older history ask when the split starts at a custom or bash message.
       const latestUserAskCompleted =
-        preparation.splitTurnCompleted ?? latestUserTurn?.completed ?? false;
+        (splitUserTurn ? preparation.splitTurnCompleted : undefined) ??
+        latestUserTurn?.completed ??
+        false;
+      const splitCompletionInstruction = splitUserTurn
+        ? `The split turn is ${latestUserAskCompleted ? "completed; its terminal response is retained outside this prefix" : "not completed"}. Preserve this status; do not infer it from the prefix alone.\n\n`
+        : "";
       const identifiers = extractOpaqueIdentifiers(
         oracleMessages.slice(-10).map(extractMessageText).filter(Boolean).join("\n"),
       );
@@ -1307,7 +1317,7 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
               ...llmSummaryParams,
               messages: turnPrefixMessages,
               maxChunkTokens,
-              customInstructions: `${TURN_PREFIX_INSTRUCTIONS}\n\nAdditional requirements:\n\n${currentInstructions}`,
+              customInstructions: `${TURN_PREFIX_INSTRUCTIONS}\n\n${splitCompletionInstruction}Additional requirements:\n\n${currentInstructions}`,
               previousSummary: undefined,
             });
             splitTurnSectionLocal = formatGeneratedSplitTurnSection(prefixSummary, () => {

--- a/src/agents/embedded-agent-runner/compact.abort-signal.test.ts
+++ b/src/agents/embedded-agent-runner/compact.abort-signal.test.ts
@@ -1,5 +1,15 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { closeOpenClawAgentDatabasesForTest } from "../../state/openclaw-agent-db.js";
+
+const tempDirs = useAutoCleanupTempDirTracker((cleanup) =>
+  afterEach(() => {
+    closeOpenClawAgentDatabasesForTest();
+    cleanup();
+  }),
+);
 
 vi.mock("../model-fallback-candidates.js", () => ({
   resolveModelCandidateChain: (params: { provider: string; model: string }) => [
@@ -66,18 +76,21 @@ import { compactEmbeddedAgentSessionDirectOnce } from "./direct-compaction.js";
 const runMock = vi.mocked(runWithModelFallback);
 const compactOnceMock = vi.mocked(compactEmbeddedAgentSessionDirectOnce);
 
-const baseParams = {
-  sessionId: "test-session",
-  sessionKey: "agent:main:test-session",
-  sessionFile: "agent:main:test-session",
-  sessionTarget: {
-    agentId: "main",
+function baseParams() {
+  const workspaceDir = tempDirs.make("openclaw-compact-abort-");
+  return {
     sessionId: "test-session",
     sessionKey: "agent:main:test-session",
-    storePath: "/tmp/sessions.json",
-  },
-  workspaceDir: "/tmp",
-};
+    sessionFile: "agent:main:test-session",
+    sessionTarget: {
+      agentId: "main",
+      sessionId: "test-session",
+      sessionKey: "agent:main:test-session",
+      storePath: join(workspaceDir, "sessions.json"),
+    },
+    workspaceDir,
+  };
+}
 
 function configWithFallbacks(fallbacks: string[]): OpenClawConfig {
   return {
@@ -102,7 +115,7 @@ describe("compactEmbeddedAgentSessionDirect abortSignal threading", () => {
     const controller = new AbortController();
 
     await compactEmbeddedAgentSessionDirect({
-      ...baseParams,
+      ...baseParams(),
       config: configWithFallbacks(["anthropic/claude-haiku-4-5", "openai/gpt-4.1-mini"]),
       provider: "anthropic",
       model: "claude-sonnet-4-6",
@@ -116,7 +129,7 @@ describe("compactEmbeddedAgentSessionDirect abortSignal threading", () => {
 
   it("passes undefined when no abortSignal is set (back-compat)", async () => {
     await compactEmbeddedAgentSessionDirect({
-      ...baseParams,
+      ...baseParams(),
       config: configWithFallbacks(["anthropic/claude-haiku-4-5"]),
       provider: "anthropic",
       model: "claude-sonnet-4-6",
@@ -132,7 +145,7 @@ describe("compactEmbeddedAgentSessionDirect abortSignal threading", () => {
     { source: "auto" as const, expected: undefined },
   ])("forwards only $source auth profiles as user locks", async ({ source, expected }) => {
     await compactEmbeddedAgentSessionDirect({
-      ...baseParams,
+      ...baseParams(),
       config: configWithFallbacks(["anthropic/claude-haiku-4-5"]),
       provider: "anthropic",
       model: "claude-sonnet-4-6",
@@ -145,7 +158,7 @@ describe("compactEmbeddedAgentSessionDirect abortSignal threading", () => {
 
   it("preserves a user auth pin across BytePlus compaction fallback aliases", async () => {
     await compactEmbeddedAgentSessionDirect({
-      ...baseParams,
+      ...baseParams(),
       config: configWithFallbacks(["byteplus-plan/ark-code-latest"]),
       provider: "byteplus",
       model: "dola-seed-2-1-turbo-260628",

--- a/src/agents/embedded-agent-runner/compact.hooks.harness.ts
+++ b/src/agents/embedded-agent-runner/compact.hooks.harness.ts
@@ -1,6 +1,7 @@
 /**
  * Test harness mocks for embedded-agent compaction hook coverage.
  */
+import { join } from "node:path";
 import { vi, type Mock } from "vitest";
 import type { CompactResult } from "../../context-engine/types.js";
 import type { PluginMetadataSnapshot } from "../../plugins/plugin-metadata-snapshot.js";
@@ -109,7 +110,8 @@ export const resolveSessionAgentIdsMock = vi.fn(() => ({
 export const resolveAgentConfigMock = vi.fn(
   (_config?: unknown, _agentId?: string): unknown => undefined,
 );
-export const resolveDefaultAgentDirMock = vi.fn(() => "/tmp/agents/main/agent");
+let fixtureWorkspaceDir: string;
+export const resolveDefaultAgentDirMock = vi.fn<() => string>();
 export const estimateTokensMock = vi.fn((_message?: unknown) => 10);
 export const resolveAgentHarnessPolicyMock = vi.fn(() => ({ runtime: "openclaw" }));
 function createSelectedAgentHarnessMock(params: {
@@ -577,7 +579,8 @@ export function resetCompactSessionStateMocks(): void {
   resolveSkillsPromptMock.mockReturnValue(undefined);
 }
 
-export function resetCompactHooksHarnessMocks(): void {
+export function resetCompactHooksHarnessMocks(workspaceDir: string): void {
+  fixtureWorkspaceDir = workspaceDir;
   runCliAgentMock.mockClear();
   resolveCliBackendConfigMock.mockReset();
   resolveCliBackendConfigMock.mockReturnValue(null);
@@ -591,7 +594,7 @@ export function resetCompactHooksHarnessMocks(): void {
 
   acquireAgentRunPreparedModelRuntimeMock.mockClear();
   resolveDefaultAgentDirMock.mockReset();
-  resolveDefaultAgentDirMock.mockReturnValue("/tmp/agents/main/agent");
+  resolveDefaultAgentDirMock.mockReturnValue(join(workspaceDir, "agents/main/agent"));
   getCurrentPluginMetadataSnapshotMock.mockReset();
   getCurrentPluginMetadataSnapshotMock.mockReturnValue(emptyPluginMetadataSnapshot);
 
@@ -668,7 +671,6 @@ export async function loadCompactHooksHarness(): Promise<{
   onSessionTranscriptUpdate: typeof import("../../sessions/transcript-events.js").onSessionTranscriptUpdate;
   onInternalSessionTranscriptUpdate: typeof import("../../sessions/transcript-events.js").onInternalSessionTranscriptUpdate;
 }> {
-  resetCompactHooksHarnessMocks();
   vi.resetModules();
 
   vi.doMock("./server-endpoint-compaction.js", () => ({
@@ -1016,9 +1018,11 @@ export async function loadCompactHooksHarness(): Promise<{
   vi.doMock("../agent-scope.js", () => ({
     listAgentEntries: vi.fn(() => []),
     resolveAgentConfig: resolveAgentConfigMock,
-    resolveAgentDir: vi.fn((_cfg: unknown, agentId: string) => `/tmp/agents/${agentId}/agent`),
+    resolveAgentDir: vi.fn((_cfg: unknown, agentId: string) =>
+      join(fixtureWorkspaceDir, "agents", agentId, "agent"),
+    ),
     resolveAgentModelFallbacksOverride: vi.fn(() => undefined),
-    resolveAgentWorkspaceDir: vi.fn(() => "/tmp"),
+    resolveAgentWorkspaceDir: vi.fn(() => fixtureWorkspaceDir),
     resolveDefaultAgentDir: resolveDefaultAgentDirMock,
     resolveDefaultAgentId: vi.fn(() => "main"),
     resolveAgentIdFromSessionKey: vi.fn(

--- a/src/agents/embedded-agent-runner/compact.hooks.test.ts
+++ b/src/agents/embedded-agent-runner/compact.hooks.test.ts
@@ -83,12 +83,18 @@ let onInternalSessionTranscriptUpdate: typeof import("../../sessions/transcript-
 let diagnosticEvents: typeof import("../../infra/diagnostic-events.js");
 let diagnosticRunActivity: typeof import("../../logging/diagnostic-run-activity.js");
 
-const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+// Target resolution still reads real SQLite metadata even when compaction is mocked.
+const tempDirs = useAutoCleanupTempDirTracker((cleanup) =>
+  afterEach(() => {
+    closeOpenClawAgentDatabasesForTest();
+    cleanup();
+  }),
+);
 
 const TEST_SESSION_ID = "session-1";
 const TEST_SESSION_KEY = "agent:main:session-1";
-const TEST_SESSION_FILE = "/tmp/session.jsonl";
-const TEST_WORKSPACE_DIR = "/tmp";
+let TEST_SESSION_FILE: string;
+let TEST_WORKSPACE_DIR: string;
 const TEST_CUSTOM_INSTRUCTIONS = "focus on decisions";
 type SessionHookEvent = {
   type?: string;
@@ -228,7 +234,7 @@ function wrappedCompactionArgs(overrides: Record<string, unknown> = {}) {
       agentId: "main",
       sessionId: TEST_SESSION_ID,
       sessionKey: TEST_SESSION_KEY,
-      storePath: "/tmp/sessions.json",
+      storePath: join(TEST_WORKSPACE_DIR, "sessions.json"),
     },
     workspaceDir: TEST_WORKSPACE_DIR,
     customInstructions: TEST_CUSTOM_INSTRUCTIONS,
@@ -330,7 +336,9 @@ beforeAll(async () => {
 });
 
 beforeEach(() => {
-  resetCompactHooksHarnessMocks();
+  TEST_WORKSPACE_DIR = tempDirs.make("openclaw-compact-hooks-");
+  TEST_SESSION_FILE = join(TEST_WORKSPACE_DIR, "session.jsonl");
+  resetCompactHooksHarnessMocks(TEST_WORKSPACE_DIR);
 });
 
 describe("compactEmbeddedAgentSessionDirect hooks", () => {
@@ -543,7 +551,7 @@ describe("compactEmbeddedAgentSessionDirect hooks", () => {
     const result = await compactEmbeddedAgentSessionDirect({
       sessionId: "session-1",
       sessionFile: TEST_SESSION_KEY,
-      workspaceDir: "/tmp/workspace",
+      workspaceDir: join(TEST_WORKSPACE_DIR, "workspace"),
       provider: "openai",
       model: "gpt-5.5",
       agentHarnessId: "codex",
@@ -876,11 +884,11 @@ describe("compactEmbeddedAgentSessionDirect hooks", () => {
       sessionId: "session-1",
       sessionKey: TEST_SESSION_KEY,
       sessionFile: TEST_SESSION_KEY,
-      workspaceDir: "/tmp/workspace",
+      workspaceDir: join(TEST_WORKSPACE_DIR, "workspace"),
     });
 
     expect(acquireAgentRunPreparedModelRuntimeMock).toHaveBeenCalledWith(
-      expect.objectContaining({ config: {}, workspaceDir: "/tmp/workspace" }),
+      expect.objectContaining({ config: {}, workspaceDir: join(TEST_WORKSPACE_DIR, "workspace") }),
     );
   });
 
@@ -907,7 +915,7 @@ describe("compactEmbeddedAgentSessionDirect hooks", () => {
           agentId: "marie-clawndo",
           sessionId: TEST_SESSION_ID,
           sessionKey: "agent:marie-clawndo:dashboard:session-1",
-          storePath: "/tmp/sessions.json",
+          storePath: join(TEST_WORKSPACE_DIR, "sessions.json"),
         },
       }),
     );
@@ -932,14 +940,14 @@ describe("compactEmbeddedAgentSessionDirect hooks", () => {
       sessionId: "session-1",
       sessionKey: TEST_SESSION_KEY,
       sessionFile: TEST_SESSION_KEY,
-      workspaceDir: "/tmp/workspace",
+      workspaceDir: join(TEST_WORKSPACE_DIR, "workspace"),
       allowGatewaySubagentBinding: true,
     });
 
     expect(acquireAgentRunPreparedModelRuntimeMock).toHaveBeenCalledWith(
       expect.objectContaining({
         config: {},
-        workspaceDir: "/tmp/workspace",
+        workspaceDir: join(TEST_WORKSPACE_DIR, "workspace"),
         allowGatewaySubagentBinding: true,
       }),
     );
@@ -951,14 +959,14 @@ describe("compactEmbeddedAgentSessionDirect hooks", () => {
       sessionKey: "agent:main:main",
       sandboxSessionKey: "agent:main:telegram:default:direct:12345",
       sessionFile: TEST_SESSION_KEY,
-      workspaceDir: "/tmp/workspace",
+      workspaceDir: join(TEST_WORKSPACE_DIR, "workspace"),
     });
 
     expect(resolveSandboxContextMock).toHaveBeenCalledWith(
       expect.objectContaining({
         config: {},
         sessionKey: "agent:main:telegram:default:direct:12345",
-        workspaceDir: "/tmp/workspace",
+        workspaceDir: join(TEST_WORKSPACE_DIR, "workspace"),
       }),
     );
   });
@@ -968,7 +976,7 @@ describe("compactEmbeddedAgentSessionDirect hooks", () => {
       sessionId: "session-1",
       sessionKey: "agent:main:subagent:worker",
       sessionFile: TEST_SESSION_KEY,
-      workspaceDir: "/tmp/workspace",
+      workspaceDir: join(TEST_WORKSPACE_DIR, "workspace"),
     });
 
     expect(listRegisteredPluginAgentPromptGuidanceMock).toHaveBeenCalledWith({
@@ -988,7 +996,7 @@ describe("compactEmbeddedAgentSessionDirect hooks", () => {
       sessionId: "session-1",
       sessionKey: "agent:codex:acp:worker",
       sessionFile: TEST_SESSION_KEY,
-      workspaceDir: "/tmp/workspace",
+      workspaceDir: join(TEST_WORKSPACE_DIR, "workspace"),
     });
 
     expect(listRegisteredPluginAgentPromptGuidanceMock).toHaveBeenCalledWith({
@@ -1016,7 +1024,7 @@ describe("compactEmbeddedAgentSessionDirect hooks", () => {
       sessionId: "session-1",
       sessionKey: "agent:marketing-agent:session-1",
       sessionFile: TEST_SESSION_KEY,
-      workspaceDir: "/tmp/workspace",
+      workspaceDir: join(TEST_WORKSPACE_DIR, "workspace"),
       config: {
         agents: {
           list: [{ id: "marketing-agent", identity: { name: "Campaign Navigator" } }],
@@ -1045,7 +1053,7 @@ describe("compactEmbeddedAgentSessionDirect hooks", () => {
       sessionId: "session-1",
       sessionKey: "agent:main:session-1",
       sessionFile: TEST_SESSION_KEY,
-      workspaceDir: "/tmp/workspace",
+      workspaceDir: join(TEST_WORKSPACE_DIR, "workspace"),
     });
 
     const createdSession = (await createAgentSessionMock.mock.results[0]?.value) as {
@@ -1166,8 +1174,8 @@ describe("compactEmbeddedAgentSessionDirect hooks", () => {
       modelId: "gpt-5.4",
       thinkLevel: "off",
       sessionAgentId: "main",
-      effectiveWorkspace: "/tmp/workspace",
-      agentDir: "/tmp/workspace",
+      effectiveWorkspace: join(TEST_WORKSPACE_DIR, "workspace"),
+      agentDir: join(TEST_WORKSPACE_DIR, "workspace"),
       runtimePlan: {
         auth: { forwardedAuthProfileId: "openai:profile-1" },
         transport: { resolveExtraParams: vi.fn(() => undefined) },
@@ -1186,13 +1194,13 @@ describe("compactEmbeddedAgentSessionDirect hooks", () => {
       undefined,
       "off",
       "main",
-      "/tmp/workspace",
+      join(TEST_WORKSPACE_DIR, "workspace"),
       expectRecordFields(mockCallArg(applyExtraParamsToAgentMock, 0, 8), {
         provider: "openai",
         id: "fake",
         api: "responses",
       }),
-      "/tmp/workspace",
+      join(TEST_WORKSPACE_DIR, "workspace"),
       undefined,
       expectRecordFields(mockCallArg(applyExtraParamsToAgentMock, 0, 11), {
         nativeWebSearchPolicyContext: {
@@ -1234,8 +1242,8 @@ describe("compactEmbeddedAgentSessionDirect hooks", () => {
       modelId: "gpt-5.6-sol",
       thinkLevel: "ultra",
       sessionAgentId: "main",
-      effectiveWorkspace: "/tmp/workspace",
-      agentDir: "/tmp/workspace",
+      effectiveWorkspace: join(TEST_WORKSPACE_DIR, "workspace"),
+      agentDir: join(TEST_WORKSPACE_DIR, "workspace"),
       runtimePlan: {
         auth: {},
         transport: { resolveExtraParams },
@@ -1253,9 +1261,9 @@ describe("compactEmbeddedAgentSessionDirect hooks", () => {
       undefined,
       "max",
       "main",
-      "/tmp/workspace",
+      join(TEST_WORKSPACE_DIR, "workspace"),
       expect.anything(),
-      "/tmp/workspace",
+      join(TEST_WORKSPACE_DIR, "workspace"),
       undefined,
       expect.anything(),
     );
@@ -1266,7 +1274,7 @@ describe("compactEmbeddedAgentSessionDirect hooks", () => {
       sessionId: "session-1",
       sessionKey: TEST_SESSION_KEY,
       sessionFile: TEST_SESSION_KEY,
-      workspaceDir: "/tmp/workspace",
+      workspaceDir: join(TEST_WORKSPACE_DIR, "workspace"),
       senderId: "sender-1",
       senderName: "Alice",
       senderUsername: "alice_u",
@@ -1289,20 +1297,23 @@ describe("compactEmbeddedAgentSessionDirect hooks", () => {
     async ({ execMode, permissionMode }) => {
       await compactEmbeddedAgentSessionDirect(
         wrappedCompactionArgs({
-          workspaceDir: "/tmp/workspace",
+          workspaceDir: join(TEST_WORKSPACE_DIR, "workspace"),
           permissionMode: "full",
-          sessionRoot: "/tmp/workspace",
+          sessionRoot: join(TEST_WORKSPACE_DIR, "workspace"),
           execOverrides: { mode: execMode },
           sessionEntry: {
             sessionId: "session-1",
             permissionMode: "full",
-            sessionRoot: "/tmp/workspace",
+            sessionRoot: join(TEST_WORKSPACE_DIR, "workspace"),
           },
         }),
       );
 
       const toolOptions = expectRecordFields(mockCallArg(createOpenClawCodingToolsMock), {
-        sessionPermissionPolicy: { mode: permissionMode, root: "/tmp/workspace" },
+        sessionPermissionPolicy: {
+          mode: permissionMode,
+          root: join(TEST_WORKSPACE_DIR, "workspace"),
+        },
       });
       expect(toolOptions.exec).toEqual(expect.objectContaining({ mode: execMode }));
     },
@@ -1330,7 +1341,7 @@ describe("compactEmbeddedAgentSessionDirect hooks", () => {
     const toolName = "profiled_plugin_tool";
     const metadataSnapshot = {
       ...getCurrentPluginMetadataSnapshotMock(),
-      workspaceDir: "/tmp/workspace",
+      workspaceDir: join(TEST_WORKSPACE_DIR, "workspace"),
       plugins: [
         {
           id: "profiled-plugin",
@@ -1340,9 +1351,9 @@ describe("compactEmbeddedAgentSessionDirect hooks", () => {
           skills: [],
           hooks: [],
           origin: "workspace",
-          rootDir: "/tmp/workspace/profiled-plugin",
-          source: "/tmp/workspace/profiled-plugin/index.js",
-          manifestPath: "/tmp/workspace/profiled-plugin/openclaw.plugin.json",
+          rootDir: join(TEST_WORKSPACE_DIR, "workspace/profiled-plugin"),
+          source: join(TEST_WORKSPACE_DIR, "workspace/profiled-plugin/index.js"),
+          manifestPath: join(TEST_WORKSPACE_DIR, "workspace/profiled-plugin/openclaw.plugin.json"),
           contracts: { tools: [toolName] },
           toolMetadata: { [toolName]: { profiles: ["coding"] } },
         } satisfies PluginManifestRecord,
@@ -1350,9 +1361,9 @@ describe("compactEmbeddedAgentSessionDirect hooks", () => {
     };
     const preparedModelRuntime = {
       agentId: "main",
-      agentDir: "/tmp/agents/main/agent",
+      agentDir: join(TEST_WORKSPACE_DIR, "agents/main/agent"),
       config: { tools: { profile: "coding" } },
-      workspaceDir: "/tmp/workspace",
+      workspaceDir: join(TEST_WORKSPACE_DIR, "workspace"),
       metadataSnapshot,
       configuredRuntimeModels: [],
       inlineProviderModels: [],
@@ -1376,7 +1387,7 @@ describe("compactEmbeddedAgentSessionDirect hooks", () => {
       sessionId: "session-1",
       sessionKey: TEST_SESSION_KEY,
       sessionFile: TEST_SESSION_KEY,
-      workspaceDir: "/tmp/workspace",
+      workspaceDir: join(TEST_WORKSPACE_DIR, "workspace"),
       config: { tools: { profile: "coding" } },
     });
 
@@ -1411,7 +1422,7 @@ describe("compactEmbeddedAgentSessionDirect hooks", () => {
         sessionId: "session-1",
         sessionKey: TEST_SESSION_KEY,
         sessionFile: TEST_SESSION_KEY,
-        workspaceDir: "/tmp/workspace",
+        workspaceDir: join(TEST_WORKSPACE_DIR, "workspace"),
       });
 
       expectRecordFields(mockCallArg(createOpenClawCodingToolsMock), { modelHasVision });
@@ -1423,18 +1434,18 @@ describe("compactEmbeddedAgentSessionDirect hooks", () => {
       sessionId: "session-1",
       sessionKey: TEST_SESSION_KEY,
       sessionFile: TEST_SESSION_KEY,
-      workspaceDir: "/tmp/workspace",
-      cwd: "/tmp/task-repo",
+      workspaceDir: join(TEST_WORKSPACE_DIR, "workspace"),
+      cwd: join(TEST_WORKSPACE_DIR, "task-repo"),
     });
 
     expectRecordFields(mockCallArg(createOpenClawCodingToolsMock), {
-      cwd: "/tmp/task-repo",
-      workspaceDir: "/tmp/workspace",
-      spawnWorkspaceDir: "/tmp/workspace",
+      cwd: join(TEST_WORKSPACE_DIR, "task-repo"),
+      workspaceDir: join(TEST_WORKSPACE_DIR, "workspace"),
+      spawnWorkspaceDir: join(TEST_WORKSPACE_DIR, "workspace"),
     });
     expectRecordFields(mockCallArg(createPreparedEmbeddedAgentSettingsManagerMock), {
-      cwd: "/tmp/task-repo",
-      agentDir: "/tmp/agents/main/agent",
+      cwd: join(TEST_WORKSPACE_DIR, "task-repo"),
+      agentDir: join(TEST_WORKSPACE_DIR, "agents/main/agent"),
     });
   });
 
@@ -1443,7 +1454,7 @@ describe("compactEmbeddedAgentSessionDirect hooks", () => {
       sessionId: "session-1",
       sessionKey: TEST_SESSION_KEY,
       sessionFile: TEST_SESSION_KEY,
-      workspaceDir: "/tmp/workspace",
+      workspaceDir: join(TEST_WORKSPACE_DIR, "workspace"),
       contextTokenBudget: 64_000,
     });
 
@@ -1466,7 +1477,7 @@ describe("compactEmbeddedAgentSessionDirect hooks", () => {
       sessionId: "session-1",
       sessionKey: TEST_SESSION_KEY,
       sessionFile: TEST_SESSION_KEY,
-      workspaceDir: "/tmp/workspace",
+      workspaceDir: join(TEST_WORKSPACE_DIR, "workspace"),
     });
     const firstCache = expectRecordFields(
       mockCallArg(createOpenClawCodingToolsMock),
@@ -1477,7 +1488,7 @@ describe("compactEmbeddedAgentSessionDirect hooks", () => {
       sessionId: "session-2",
       sessionKey: TEST_SESSION_KEY,
       sessionFile: TEST_SESSION_KEY,
-      workspaceDir: "/tmp/workspace",
+      workspaceDir: join(TEST_WORKSPACE_DIR, "workspace"),
     });
     const secondCache = expectRecordFields(
       mockCallArg(createOpenClawCodingToolsMock, 1),
@@ -1496,7 +1507,7 @@ describe("compactEmbeddedAgentSessionDirect hooks", () => {
       sessionId: "session-1",
       sessionKey: TEST_SESSION_KEY,
       sessionFile: TEST_SESSION_KEY,
-      workspaceDir: "/tmp/workspace",
+      workspaceDir: join(TEST_WORKSPACE_DIR, "workspace"),
     });
 
     expect(createOpenClawCodingToolsMock).not.toHaveBeenCalled();
@@ -1534,7 +1545,7 @@ describe("compactEmbeddedAgentSessionDirect hooks", () => {
       sessionId: "session-1",
       sessionKey: "agent:main:session-1",
       sessionFile: TEST_SESSION_KEY,
-      workspaceDir: "/tmp/workspace",
+      workspaceDir: join(TEST_WORKSPACE_DIR, "workspace"),
       runId: "run-tool-schema-quarantine",
     });
 
@@ -1552,7 +1563,7 @@ describe("compactEmbeddedAgentSessionDirect hooks", () => {
       sessionId: "session-1",
       sessionKey: TEST_SESSION_KEY,
       sessionFile: TEST_SESSION_KEY,
-      workspaceDir: "/tmp/workspace",
+      workspaceDir: join(TEST_WORKSPACE_DIR, "workspace"),
       contextTokenBudget: 64_000,
     });
 
@@ -1580,7 +1591,7 @@ describe("compactEmbeddedAgentSessionDirect hooks", () => {
       sessionId: "session-1",
       sessionKey: TEST_SESSION_KEY,
       sessionFile: TEST_SESSION_KEY,
-      workspaceDir: "/tmp/workspace",
+      workspaceDir: join(TEST_WORKSPACE_DIR, "workspace"),
       provider: "openai",
       model: "gpt-primary",
       trigger: "overflow",
@@ -1719,7 +1730,7 @@ describe("compactEmbeddedAgentSessionDirect hooks", () => {
       sessionId: "session-1",
       sessionKey: TEST_SESSION_KEY,
       sessionFile: TEST_SESSION_KEY,
-      workspaceDir: "/tmp/workspace",
+      workspaceDir: join(TEST_WORKSPACE_DIR, "workspace"),
       provider: "openai",
       model: "gpt-primary",
       agentHarnessId: "openclaw",
@@ -1763,7 +1774,7 @@ describe("compactEmbeddedAgentSessionDirect hooks", () => {
       sessionId: "session-1",
       sessionKey: TEST_SESSION_KEY,
       sessionFile: TEST_SESSION_KEY,
-      workspaceDir: "/tmp/workspace",
+      workspaceDir: join(TEST_WORKSPACE_DIR, "workspace"),
       provider: "openai",
       model: "gpt-5.6-sol",
       thinkLevel: "ultra" as const,
@@ -1831,7 +1842,7 @@ describe("compactEmbeddedAgentSessionDirect hooks", () => {
       sessionId: "session-1",
       sessionKey: TEST_SESSION_KEY,
       sessionFile: TEST_SESSION_KEY,
-      workspaceDir: "/tmp/workspace",
+      workspaceDir: join(TEST_WORKSPACE_DIR, "workspace"),
       provider: "openai",
       model: "gpt-5.5",
       authProfileId: "openai:default",
@@ -1941,7 +1952,7 @@ describe("compactEmbeddedAgentSessionDirect hooks", () => {
       sessionId: "session-1",
       sessionKey: TEST_SESSION_KEY,
       sessionFile: TEST_SESSION_KEY,
-      workspaceDir: "/tmp/workspace",
+      workspaceDir: join(TEST_WORKSPACE_DIR, "workspace"),
       provider: "openai",
       model: "gpt-5.5",
       agentHarnessId: "codex",
@@ -2000,7 +2011,7 @@ describe("compactEmbeddedAgentSessionDirect hooks", () => {
       sessionId: "session-1",
       sessionKey: TEST_SESSION_KEY,
       sessionFile: TEST_SESSION_KEY,
-      workspaceDir: "/tmp/workspace",
+      workspaceDir: join(TEST_WORKSPACE_DIR, "workspace"),
       config: {
         models: {
           providers: {
@@ -2038,7 +2049,7 @@ describe("compactEmbeddedAgentSessionDirect hooks", () => {
       sessionId: "session-1",
       sessionKey: TEST_SESSION_KEY,
       sessionFile: TEST_SESSION_KEY,
-      workspaceDir: "/tmp/workspace",
+      workspaceDir: join(TEST_WORKSPACE_DIR, "workspace"),
       provider: "openai",
       model: "gpt-5.5",
       runtimeAuthPlan: {
@@ -2075,7 +2086,7 @@ describe("compactEmbeddedAgentSessionDirect hooks", () => {
       sessionId: "session-1",
       sessionKey: TEST_SESSION_KEY,
       sessionFile: TEST_SESSION_KEY,
-      workspaceDir: "/tmp/workspace",
+      workspaceDir: join(TEST_WORKSPACE_DIR, "workspace"),
       provider: "openai",
       model: "gpt-5.5",
       agentHarnessId: "codex",
@@ -2157,7 +2168,7 @@ describe("compactEmbeddedAgentSessionDirect hooks", () => {
       sessionId: "session-1",
       sessionKey: TEST_SESSION_KEY,
       sessionFile: TEST_SESSION_KEY,
-      workspaceDir: "/tmp/workspace",
+      workspaceDir: join(TEST_WORKSPACE_DIR, "workspace"),
       provider: "openai",
       model: "gpt-5.5",
       authProfileId: "openai:work",
@@ -2233,7 +2244,7 @@ describe("compactEmbeddedAgentSessionDirect hooks", () => {
       sessionId: "session-1",
       sessionKey: TEST_SESSION_KEY,
       sessionFile: TEST_SESSION_KEY,
-      workspaceDir: "/tmp/workspace",
+      workspaceDir: join(TEST_WORKSPACE_DIR, "workspace"),
       provider: "openai",
       model: "gpt-primary",
       config: config as never,
@@ -2269,7 +2280,7 @@ describe("compactEmbeddedAgentSessionDirect hooks", () => {
       sessionId: "session-1",
       sessionKey: TEST_SESSION_KEY,
       sessionFile: TEST_SESSION_KEY,
-      workspaceDir: "/tmp/workspace",
+      workspaceDir: join(TEST_WORKSPACE_DIR, "workspace"),
       provider: "openai",
       model: "gpt-primary",
       config: {
@@ -2309,7 +2320,7 @@ describe("compactEmbeddedAgentSessionDirect hooks", () => {
       sessionId: "session-1",
       sessionKey: TEST_SESSION_KEY,
       sessionFile: TEST_SESSION_KEY,
-      workspaceDir: "/tmp/workspace",
+      workspaceDir: join(TEST_WORKSPACE_DIR, "workspace"),
       provider: "openai",
       model: "gpt-primary",
       config: {
@@ -2399,7 +2410,7 @@ describe("compactEmbeddedAgentSessionDirect hooks", () => {
       sessionId: "session-1",
       sessionKey: "agent:main:session-1",
       sessionAgentId: "main",
-      workspaceDir: "/tmp",
+      workspaceDir: TEST_WORKSPACE_DIR,
       metrics: beforeMetrics,
     });
 
@@ -2429,7 +2440,7 @@ describe("compactEmbeddedAgentSessionDirect hooks", () => {
       sessionId: "session-1",
       sessionKey: "agent:main:session-1",
       sessionAgentId: "main",
-      workspaceDir: "/tmp",
+      workspaceDir: TEST_WORKSPACE_DIR,
       metrics: beforeMetrics,
       onHookMessages,
     });
@@ -2439,7 +2450,7 @@ describe("compactEmbeddedAgentSessionDirect hooks", () => {
       sessionAgentId: "main",
       hookSessionKey: hookState.hookSessionKey,
       missingSessionKey: hookState.missingSessionKey,
-      workspaceDir: "/tmp",
+      workspaceDir: TEST_WORKSPACE_DIR,
       messageCountAfter: 1,
       tokensAfter: 10,
       compactedCount: 1,
@@ -2810,8 +2821,8 @@ describe("compactEmbeddedAgentSessionDirect hooks", () => {
         headers: { Authorization: "Bearer ollama-cloud" },
       } as never,
       config: undefined,
-      agentDir: "/tmp",
-      effectiveWorkspace: "/tmp",
+      agentDir: TEST_WORKSPACE_DIR,
+      effectiveWorkspace: TEST_WORKSPACE_DIR,
       apiRegistry: {} as never,
     });
 
@@ -2821,8 +2832,8 @@ describe("compactEmbeddedAgentSessionDirect hooks", () => {
       unknown
     >;
     expectRecordFields(streamRegistration, {
-      agentDir: "/tmp",
-      workspaceDir: "/tmp",
+      agentDir: TEST_WORKSPACE_DIR,
+      workspaceDir: TEST_WORKSPACE_DIR,
     });
     expectRecordFields(streamRegistration.model, {
       provider: "ollama",
@@ -2933,7 +2944,7 @@ describe("compactEmbeddedAgentSession hooks (ownsCompaction engine)", () => {
   });
 
   it("resolves the durable session key before invoking an owning context engine", async () => {
-    const dir = await mkdtemp(join(tmpdir(), "openclaw-compaction-session-key-"));
+    const dir = await realpath(await mkdtemp(join(tmpdir(), "openclaw-compaction-session-key-")));
     const storePath = join(dir, "sessions.json");
     const sessionId = "9d6c8436-7cb2-4bd5-a302-e33305bfc8c4";
     const sessionKey = "agent:main:telegram:direct:reporter";
@@ -3011,7 +3022,7 @@ describe("compactEmbeddedAgentSession hooks (ownsCompaction engine)", () => {
           agentId: "marie-clawndo",
           sessionId: TEST_SESSION_ID,
           sessionKey: "agent:marie-clawndo:dashboard:session-1",
-          storePath: "/tmp/sessions.json",
+          storePath: join(TEST_WORKSPACE_DIR, "sessions.json"),
         },
       }),
     );
@@ -3291,7 +3302,7 @@ describe("compactEmbeddedAgentSession hooks (ownsCompaction engine)", () => {
     } as never);
 
     const result = await compactEmbeddedAgentSession(
-      wrappedCompactionArgs({ cwd: "/tmp/task-repo" }),
+      wrappedCompactionArgs({ cwd: join(TEST_WORKSPACE_DIR, "task-repo") }),
     );
 
     expect(result.ok).toBe(true);
@@ -3359,7 +3370,7 @@ describe("compactEmbeddedAgentSession hooks (ownsCompaction engine)", () => {
     } as never);
 
     const result = await compactEmbeddedAgentSession(
-      wrappedCompactionArgs({ cwd: "/tmp/task-repo" }),
+      wrappedCompactionArgs({ cwd: join(TEST_WORKSPACE_DIR, "task-repo") }),
     );
 
     expect(result.ok).toBe(true);
@@ -3371,7 +3382,7 @@ describe("compactEmbeddedAgentSession hooks (ownsCompaction engine)", () => {
       sessionFile: TEST_SESSION_KEY,
     });
     expect(runtimeContext?.workspaceDir).toBe(TEST_WORKSPACE_DIR);
-    expect(runtimeContext?.cwd).toBe("/tmp/task-repo");
+    expect(runtimeContext?.cwd).toBe(join(TEST_WORKSPACE_DIR, "task-repo"));
     expect(runtimeContext?.rewriteTranscriptEntries).toBeTypeOf("function");
   });
 
@@ -3797,7 +3808,9 @@ describe("compactEmbeddedAgentSession hooks (ownsCompaction engine)", () => {
   });
 
   it("routes a queued manual CLI session to backend-owned compaction", async () => {
-    const agentDir = await mkdtemp(join(tmpdir(), "openclaw-native-compaction-queued-"));
+    const agentDir = await realpath(
+      await mkdtemp(join(tmpdir(), "openclaw-native-compaction-queued-")),
+    );
     try {
       resolveCliBackendConfigMock.mockReturnValue({
         id: "claude-cli",
@@ -3844,7 +3857,9 @@ describe("compactEmbeddedAgentSession hooks (ownsCompaction engine)", () => {
   });
 
   it("normalizes an omitted manual target before native harness compaction", async () => {
-    const agentDir = await mkdtemp(join(tmpdir(), "openclaw-native-compaction-target-"));
+    const agentDir = await realpath(
+      await mkdtemp(join(tmpdir(), "openclaw-native-compaction-target-")),
+    );
     try {
       resolveAgentHarnessPolicyMock.mockReturnValue({
         runtime: "codex",
@@ -4728,7 +4743,9 @@ describe("compactEmbeddedAgentSession hooks (ownsCompaction engine)", () => {
   });
 
   it("runs native manual compaction before generic model auth preparation", async () => {
-    const agentDir = await mkdtemp(join(tmpdir(), "openclaw-native-compaction-authless-"));
+    const agentDir = await realpath(
+      await mkdtemp(join(tmpdir(), "openclaw-native-compaction-authless-")),
+    );
     try {
       resolveCliBackendConfigMock.mockReturnValue({
         id: "claude-cli",
@@ -5182,7 +5199,7 @@ describe("compactEmbeddedAgentSession hooks (ownsCompaction engine)", () => {
     {
       identity: "session key",
       activeSessionKey: TEST_SESSION_KEY,
-      activeSessionFile: "/tmp/other-session.jsonl",
+      activeSessionFile: "other-session.jsonl",
     },
     {
       identity: "session file",
@@ -5191,6 +5208,10 @@ describe("compactEmbeddedAgentSession hooks (ownsCompaction engine)", () => {
     },
   ])("rejects manual compaction matching an active $identity", async (active) => {
     const activeSessionId = "other-session";
+    const activeSessionFile =
+      active.activeSessionFile === TEST_SESSION_KEY
+        ? TEST_SESSION_KEY
+        : join(TEST_WORKSPACE_DIR, active.activeSessionFile);
     const existingHandle = {
       kind: "embedded" as const,
       queueMessage: async () => {},
@@ -5202,7 +5223,7 @@ describe("compactEmbeddedAgentSession hooks (ownsCompaction engine)", () => {
       activeSessionId,
       existingHandle,
       active.activeSessionKey,
-      active.activeSessionFile,
+      activeSessionFile,
     );
     try {
       await expect(
@@ -5220,7 +5241,7 @@ describe("compactEmbeddedAgentSession hooks (ownsCompaction engine)", () => {
         activeSessionId,
         existingHandle,
         active.activeSessionKey,
-        active.activeSessionFile,
+        activeSessionFile,
       );
     }
   });
@@ -5294,7 +5315,7 @@ describe("compactEmbeddedAgentSession hooks (ownsCompaction engine)", () => {
       rewrittenEntries: 0,
     }));
     const delegatedSessionId = "delegated-session";
-    const storePath = "/tmp/custom-active-sessions.json";
+    const storePath = join(TEST_WORKSPACE_DIR, "custom-active-sessions.json");
     resolveContextEngineMock.mockResolvedValue({
       info: { ownsCompaction: false },
       compact: contextEngineCompactMock,
@@ -5332,11 +5353,12 @@ describe("compactEmbeddedAgentSession hooks (ownsCompaction engine)", () => {
   });
 
   it.each([
-    ["session key", "agent:main:other", "/tmp/active-sessions.json"],
-    ["store path", TEST_SESSION_KEY, "/tmp/other-sessions.json"],
+    ["session key", "agent:main:other", "active-sessions.json"],
+    ["store path", TEST_SESSION_KEY, "other-sessions.json"],
   ])(
     "rejects a structured successor outside the active %s",
-    async (_label, sessionKey, storePath) => {
+    async (_label, sessionKey, storeName) => {
+      const storePath = join(TEST_WORKSPACE_DIR, storeName);
       resolveContextEngineMock.mockResolvedValue({
         info: { ownsCompaction: false },
         compact: contextEngineCompactMock,
@@ -5361,7 +5383,7 @@ describe("compactEmbeddedAgentSession hooks (ownsCompaction engine)", () => {
               agentId: "main",
               sessionId: TEST_SESSION_ID,
               sessionKey: TEST_SESSION_KEY,
-              storePath: "/tmp/active-sessions.json",
+              storePath: join(TEST_WORKSPACE_DIR, "active-sessions.json"),
             },
           }),
         ),
@@ -5372,7 +5394,7 @@ describe("compactEmbeddedAgentSession hooks (ownsCompaction engine)", () => {
   it("rejects a deprecated session-key successor outside the active binding", async () => {
     const delegatedSessionId = "delegated-key-session";
     const delegatedSessionKey = "agent:main:delegated-key-session";
-    const dir = await mkdtemp(join(tmpdir(), "openclaw-compaction-successor-"));
+    const dir = await realpath(await mkdtemp(join(tmpdir(), "openclaw-compaction-successor-")));
     const storePath = join(dir, "sessions.json");
     resolveContextEngineMock.mockResolvedValue({
       info: { ownsCompaction: false },
@@ -5414,7 +5436,9 @@ describe("compactEmbeddedAgentSession hooks (ownsCompaction engine)", () => {
   });
 
   it("rejects a deprecated session-key successor with a mismatched stored id", async () => {
-    const dir = await mkdtemp(join(tmpdir(), "openclaw-compaction-successor-mismatch-"));
+    const dir = await realpath(
+      await mkdtemp(join(tmpdir(), "openclaw-compaction-successor-mismatch-")),
+    );
     const storePath = join(dir, "sessions.json");
     const delegatedSessionKey = "agent:main:delegated-key-mismatch";
     resolveContextEngineMock.mockResolvedValue({
@@ -5460,7 +5484,7 @@ describe("compactEmbeddedAgentSession hooks (ownsCompaction engine)", () => {
       rewrittenEntries: 0,
     }));
     const delegatedSessionId = "delegated-marker-session";
-    const storePath = "/tmp/sessions.json";
+    const storePath = join(TEST_WORKSPACE_DIR, "sessions.json");
     const marker = `sqlite:main:${delegatedSessionId}:${storePath}`;
     resolveContextEngineMock.mockResolvedValue({
       info: { ownsCompaction: false },
@@ -5497,7 +5521,7 @@ describe("compactEmbeddedAgentSession hooks (ownsCompaction engine)", () => {
       ok: true,
       compacted: true,
       result: {
-        sessionFile: "sqlite:main:marker-session:/tmp/sessions.json",
+        sessionFile: `sqlite:main:marker-session:${join(TEST_WORKSPACE_DIR, "sessions.json")}`,
         sessionId: TEST_SESSION_ID,
       },
     } as never);
@@ -5514,7 +5538,9 @@ describe("compactEmbeddedAgentSession hooks (ownsCompaction engine)", () => {
       rewrittenEntries: 0,
     }));
     const delegatedSessionId = "delegated-marker-session";
-    const dir = await mkdtemp(join(tmpdir(), "openclaw-compaction-marker-successor-"));
+    const dir = await realpath(
+      await mkdtemp(join(tmpdir(), "openclaw-compaction-marker-successor-")),
+    );
     const storePath = join(dir, "sessions.json");
     const marker = `sqlite:main:${delegatedSessionId}:${storePath}`;
     resolveContextEngineMock.mockResolvedValue({
@@ -5576,7 +5602,7 @@ describe("compactEmbeddedAgentSession hooks (ownsCompaction engine)", () => {
           agentId: "main",
           sessionId: "target-session",
           sessionKey: TEST_SESSION_KEY,
-          storePath: "/tmp/sessions.json",
+          storePath: join(TEST_WORKSPACE_DIR, "sessions.json"),
         },
       },
     } as never);
@@ -5595,7 +5621,7 @@ describe("compactEmbeddedAgentSession hooks (ownsCompaction engine)", () => {
           agentId: "other",
           sessionId: "other-session",
           sessionKey: "agent:other:main",
-          storePath: "/tmp/other-sessions.json",
+          storePath: join(TEST_WORKSPACE_DIR, "other-sessions.json"),
         },
       }),
     );

--- a/src/agents/embedded-agent-runner/compact.native-cli.test.ts
+++ b/src/agents/embedded-agent-runner/compact.native-cli.test.ts
@@ -1,7 +1,11 @@
+import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
 import type { CliBackendPlugin } from "../../plugins/cli-backend.types.js";
 import type { PreparedAgentRunAdmission } from "../admitted-run-context.js";
 import { testing as cliBackendsTesting } from "../cli-backends.test-support.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 const { runCliAgentMock } = vi.hoisted(() => ({
   runCliAgentMock: vi.fn(async (_params: { preparedRunAdmission?: PreparedAgentRunAdmission }) => ({
@@ -48,6 +52,7 @@ function registerBackend(overrides: Partial<CliBackendPlugin> = {}) {
 }
 
 function compactParams(overrides: Record<string, unknown> = {}) {
+  const dir = tempDirs.make("openclaw-compact-native-cli-");
   const cliSessionBinding = {
     sessionId: "native-session",
     authProfileId: "anthropic:subscription",
@@ -60,12 +65,12 @@ function compactParams(overrides: Record<string, unknown> = {}) {
       agentId: "main",
       sessionId: "openclaw-session",
       sessionKey: "agent:main:main",
-      storePath: "/tmp/openclaw.sqlite",
+      storePath: join(dir, "openclaw.sqlite"),
     },
     sessionFile: "agent:main:main",
     agentId: "main",
-    workspaceDir: "/tmp/workspace",
-    agentDir: "/tmp/agent",
+    workspaceDir: join(dir, "workspace"),
+    agentDir: join(dir, "agent"),
     config: {},
     provider: "anthropic",
     model: "opus",

--- a/src/auto-reply/reply/agent-runner-memory.test.ts
+++ b/src/auto-reply/reply/agent-runner-memory.test.ts
@@ -546,6 +546,28 @@ describe("runMemoryFlushIfNeeded", () => {
     expect(resolver).toHaveBeenCalledWith(expect.objectContaining({ contextWindowTokens: 32_000 }));
   });
 
+  it.each([
+    [8_767, false, false],
+    [8_768, true, false],
+    [12_767, true, false],
+    [12_768, true, true],
+  ] as const)(
+    "separates early flush and blocking compaction at %i tokens",
+    async (totalTokens, flushExpected, compactionExpected) => {
+      const entry = createFlushSessionEntry({ totalTokens, compactionCount: 0 });
+      const storePath = path.join(rootDir, "sessions.json");
+      await writeTestSessionStore(storePath, "main", entry);
+      const overrides = { modelContextTokens: 32_768, promptForEstimate: "", storePath };
+      const first = await runDefaultMemoryFlush(entry, overrides);
+      expect(first.outcome).toBe(flushExpected ? "completed" : "skipped");
+      const second = await runDefaultMemoryFlush(first.sessionEntry ?? entry, overrides);
+      expect(second.outcome).toBe("skipped");
+      expect(runEmbeddedAgentMock).toHaveBeenCalledTimes(flushExpected ? 1 : 0);
+      await runDefaultPreflight(first.sessionEntry ?? entry, overrides);
+      expect(compactEmbeddedAgentSessionMock).toHaveBeenCalledTimes(compactionExpected ? 1 : 0);
+    },
+  );
+
   it("runs exactly one auto-reply memory flush turn, rotates, and persists metadata", async () => {
     const followupRun = createTestFollowupRun({
       authProfileId: "anthropic:work",
@@ -1906,32 +1928,64 @@ describe("runMemoryFlushIfNeeded", () => {
   );
   it.each([
     {
-      label: "below threshold",
-      totalTokens: 897_999,
+      label: "below the 32K threshold",
+      totalTokens: 12_767,
       shouldCompact: false,
       requestedRuntime: "openclaw",
+      contextWindowTokens: 32_768,
+    },
+    {
+      label: "at the 32K threshold",
+      totalTokens: 12_768,
+      shouldCompact: true,
+      requestedRuntime: "openclaw",
+      contextWindowTokens: 32_768,
+    },
+    {
+      label: "below the capped 8K threshold",
+      totalTokens: 3_999,
+      shouldCompact: false,
+      requestedRuntime: "openclaw",
+      contextWindowTokens: 8_000,
+    },
+    {
+      label: "at the capped 8K threshold",
+      totalTokens: 4_000,
+      shouldCompact: true,
+      requestedRuntime: "openclaw",
+      contextWindowTokens: 8_000,
+    },
+    {
+      label: "below threshold",
+      totalTokens: 901_999,
+      shouldCompact: false,
+      requestedRuntime: "openclaw",
+      contextWindowTokens: 922_000,
     },
     {
       label: "at threshold",
-      totalTokens: 898_000,
+      totalTokens: 902_000,
       shouldCompact: true,
       requestedRuntime: "openclaw",
+      contextWindowTokens: 922_000,
     },
     {
       label: "reported pressure",
       totalTokens: 904_869,
       shouldCompact: true,
       requestedRuntime: "openclaw",
+      contextWindowTokens: 922_000,
     },
     {
       label: "reported pressure after a runtime fallback",
       totalTokens: 904_869,
       shouldCompact: true,
       requestedRuntime: "codex",
+      contextWindowTokens: 922_000,
     },
   ] as const)(
     "applies session compaction at $label with memory flush disabled",
-    async ({ totalTokens, shouldCompact, requestedRuntime }) => {
+    async ({ totalTokens, shouldCompact, requestedRuntime, contextWindowTokens }) => {
       // A disabled memory plugin supplies no flush plan; compaction still owns its budget.
       registerMemoryFlushPlanResolverForTest(() => null);
       const sessionEntry = createFlushSessionEntry({
@@ -1977,7 +2031,7 @@ describe("runMemoryFlushIfNeeded", () => {
           agentDir: rootDir,
         }),
         defaultModel: "openai/gpt-5.6-luna",
-        modelContextTokens: 922_000,
+        modelContextTokens: contextWindowTokens,
         promptForEstimate: "",
         authorize,
         ...(requestedRuntime === "codex" ? { agentHarnessId: "openclaw" } : {}),
@@ -1992,7 +2046,7 @@ describe("runMemoryFlushIfNeeded", () => {
       if (shouldCompact) {
         expect(requireCompactEmbeddedAgentSessionCall()).toMatchObject({
           agentHarnessId: "openclaw",
-          contextTokenBudget: 922_000,
+          contextTokenBudget: contextWindowTokens,
           currentTokenCount: totalTokens,
           force: true,
           forcePreflight: true,
@@ -2416,7 +2470,7 @@ describe("runMemoryFlushIfNeeded", () => {
     const sessionEntry: SessionEntry = {
       sessionId: "session",
       updatedAt: Date.now(),
-      totalTokens: 70_000,
+      totalTokens: 72_000,
       totalTokensFresh: true,
       totalTokensVersion: 1,
     };
@@ -2426,7 +2480,7 @@ describe("runMemoryFlushIfNeeded", () => {
     });
 
     expect(requireCompactEmbeddedAgentSessionCall().currentTokenCount).toBeGreaterThanOrEqual(
-      80_000,
+      82_000,
     );
   });
 
@@ -2906,7 +2960,7 @@ describe("runMemoryFlushIfNeeded", () => {
 
   it.each([
     ["below", 20_000, false],
-    ["above", 70_000, true],
+    ["above", 72_000, true],
   ])(
     "uses a provider usage anchor older than the scan window when pressure is %s threshold",
     async (_label, providerPromptTokens, shouldCompact) => {
@@ -3098,7 +3152,7 @@ describe("runMemoryFlushIfNeeded", () => {
           message: {
             role: "assistant",
             content: "small answer",
-            usage: { input: 86_000, output: 2_000 },
+            usage: { input: 90_000, output: 2_000 },
           },
         },
         {
@@ -3128,7 +3182,7 @@ describe("runMemoryFlushIfNeeded", () => {
     });
 
     const compactCall = requireCompactEmbeddedAgentSessionCall();
-    expect(compactCall.currentTokenCount).toBeGreaterThanOrEqual(96_000);
+    expect(compactCall.currentTokenCount).toBeGreaterThanOrEqual(100_000);
   });
 
   it("does not count bytes from a large latest usage record as post-usage tail pressure", async () => {

--- a/src/auto-reply/reply/agent-runner-memory.test.ts
+++ b/src/auto-reply/reply/agent-runner-memory.test.ts
@@ -547,13 +547,26 @@ describe("runMemoryFlushIfNeeded", () => {
   });
 
   it.each([
-    [8_767, false, false],
-    [8_768, true, false],
-    [12_767, true, false],
-    [12_768, true, true],
+    ["default", 8_767, false, false],
+    ["default", 8_768, true, false],
+    ["default", 12_767, true, false],
+    ["default", 12_768, true, true],
+    ["custom", 18_767, false, false],
+    ["custom", 18_768, true, false],
+    ["custom", 20_767, true, false],
+    ["custom", 20_768, true, true],
   ] as const)(
-    "separates early flush and blocking compaction at %i tokens",
-    async (totalTokens, flushExpected, compactionExpected) => {
+    "separates early flush and blocking compaction for %s plan at %i tokens",
+    async (plan, totalTokens, flushExpected, compactionExpected) => {
+      if (plan === "custom") {
+        registerMemoryCapability("third-party-memory", {
+          flushPlanResolver: () =>
+            createModifiedMemoryFlushPlan({
+              reserveTokensFloor: 12_000,
+              softThresholdTokens: 2_000,
+            }),
+        });
+      }
       const entry = createFlushSessionEntry({ totalTokens, compactionCount: 0 });
       const storePath = path.join(rootDir, "sessions.json");
       await writeTestSessionStore(storePath, "main", entry);

--- a/src/auto-reply/reply/agent-runner-memory.ts
+++ b/src/auto-reply/reply/agent-runner-memory.ts
@@ -72,7 +72,7 @@ import {
   hasAlreadyFlushedForCurrentCompaction,
   resolveMaxActiveTranscriptBytes,
   resolveMemoryFlushContextWindowTokens,
-  resolveMemoryFlushThreshold,
+  resolveCompactionThreshold,
   resolveResponsesServerCompactionThreshold,
   shouldRunMemoryFlush,
   shouldRunPreflightCompaction,
@@ -813,9 +813,6 @@ export async function runSessionCompactionIfNeeded(params: {
       contextTokenBudget: contextWindowTokens,
       reserveTokens: 20_000,
     });
-  const softThresholdTokens =
-    memoryFlushPlan?.softThresholdTokens ??
-    Math.min(4_000, Math.floor((contextWindowTokens - reserveTokensFloor) / 2));
   const freshPersistedTokens = resolveFreshSessionTotalTokens(entry);
   const promptTokenEstimate = estimatePromptTokensForMemoryFlush(
     params.promptForEstimate ?? params.followupRun.prompt,
@@ -825,10 +822,9 @@ export async function runSessionCompactionIfNeeded(params: {
     provider: params.followupRun.run.provider,
     modelId: params.followupRun.run.model ?? params.defaultModel,
   });
-  const threshold = resolveMemoryFlushThreshold({
+  const threshold = resolveCompactionThreshold({
     contextWindowTokens,
     reserveTokensFloor,
-    softThresholdTokens,
     minimumThresholdTokens: responsesServerCompactionThreshold,
   });
   const freshNeedsOutputRead =
@@ -924,10 +920,7 @@ export async function runSessionCompactionIfNeeded(params: {
   const shouldCompactByTokens = shouldRunPreflightCompaction({
     entry,
     tokenCount: tokenCountForCompaction,
-    contextWindowTokens,
-    reserveTokensFloor,
-    softThresholdTokens,
-    minimumThresholdTokens: responsesServerCompactionThreshold,
+    threshold,
   });
   const shouldCompact = shouldCompactByTokens || shouldCompactByTranscriptBytes;
   if (!shouldCompact) {
@@ -1220,11 +1213,14 @@ export async function runMemoryFlushIfNeeded(params: {
       : undefined;
   const hasFreshPersistedPromptTokens = resolveFreshSessionTotalTokens(entry) !== undefined;
 
-  const flushThreshold = resolveMemoryFlushThreshold({
-    contextWindowTokens,
-    reserveTokensFloor: memoryFlushPlan.reserveTokensFloor,
-    softThresholdTokens: memoryFlushPlan.softThresholdTokens,
-  });
+  // The soft margin belongs only to early flushing, leaving room before blocking compaction.
+  const flushThreshold = Math.max(
+    0,
+    resolveCompactionThreshold({
+      contextWindowTokens,
+      reserveTokensFloor: memoryFlushPlan.reserveTokensFloor,
+    }) - Math.max(0, Math.floor(memoryFlushPlan.softThresholdTokens)),
+  );
 
   // When totals are stale/unknown, derive prompt + last output from transcript so memory
   // flush can still be evaluated against projected next-input size.
@@ -1357,9 +1353,7 @@ export async function runMemoryFlushIfNeeded(params: {
     shouldRunMemoryFlush({
       entry,
       tokenCount: tokenCountForFlush,
-      contextWindowTokens,
-      reserveTokensFloor: memoryFlushPlan.reserveTokensFloor,
-      softThresholdTokens: memoryFlushPlan.softThresholdTokens,
+      threshold: flushThreshold,
     }) ||
     (shouldForceFlushByTranscriptSize &&
       entry != null &&

--- a/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
+++ b/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
@@ -20,6 +20,7 @@ import { clearRuntimeConfigSnapshot } from "../../config/config.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import type { SessionEntry } from "../../config/sessions.js";
 import { loadSessionEntry, replaceSessionEntry } from "../../config/sessions/session-accessor.js";
+import { replaceTranscriptEvents } from "../../config/sessions/session-accessor.sqlite-transcript-write.js";
 import {
   onAgentEvent as subscribeAgentEvent,
   type AgentEventPayload,
@@ -590,6 +591,118 @@ describe("runReplyAgent auto-compaction token update", () => {
 
     expect(compactState.compactEmbeddedAgentSessionMock).toHaveBeenCalledTimes(1);
     expectReplyText(result, "⚠️ Gateway is restarting. Please wait a few seconds and try again.");
+  });
+
+  it("executes the next user turn in the default 32K early-flush interval without compaction", async () => {
+    const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-early-flush-"));
+    const storePath = path.join(tmp, "sessions.json");
+    const sessionKey = "agent:main:main";
+    const scope = { agentId: "main", sessionId: "session", sessionKey, storePath };
+    const sessionEntry: SessionEntry = {
+      sessionId: "session",
+      updatedAt: Date.now(),
+      totalTokens: 10_920,
+      totalTokensFresh: true,
+      totalTokensVersion: 1,
+      compactionCount: 0,
+    };
+    const prompt = "What is two plus two? Answer in one short sentence without tools.";
+    registerMemoryFlushPlanResolverForTest(({ cfg, contextWindowTokens }) => {
+      expect(cfg?.models?.providers?.anthropic?.models).toMatchObject([
+        { id: "claude-opus-4-6", contextTokens: 32_768 },
+      ]);
+      expect(contextWindowTokens).toBe(32_768);
+      return {
+        softThresholdTokens: 4_000,
+        reserveTokensFloor: 20_000,
+        forceFlushTranscriptBytes: 1_000_000_000,
+        prompt: "Pre-compaction memory flush.",
+        systemPrompt: "Write durable memory, then reply NO_REPLY.",
+        relativePath: "memory/active.md",
+      };
+    });
+    // The usage counters are from bounded QA metadata. This assembled prompt and
+    // transcript are synthetic; their estimates are not an observed second-turn budget.
+    const terminalEvent = (input: number, output: number) => ({
+      type: "message",
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "NO_REPLY" }],
+        stopReason: "stop",
+        usage: { input, output, totalTokens: input + output },
+      },
+    });
+    runEmbeddedAgentMock.mockImplementation(
+      async (params: { trigger?: string; prompt?: string }) => {
+        if (params.trigger === "memory") {
+          await replaceTranscriptEvents(scope, [terminalEvent(7_039, 34)]);
+          return {
+            payloads: [],
+            meta: { agentMeta: { lastCallUsage: { input: 7_039, output: 34 } } },
+          };
+        }
+        expect(params.prompt).toContain(prompt);
+        return { payloads: [{ text: "Two plus two is four." }], meta: {} };
+      },
+    );
+    try {
+      await replaceSessionEntry(scope, sessionEntry);
+      await replaceTranscriptEvents(scope, [terminalEvent(10_920, 10)]);
+      // Store preparation can populate the shared test config snapshot.
+      clearRuntimeConfigSnapshot();
+      const result = await createBaseRun({
+        followup: { prompt },
+        run: {
+          agentId: "main",
+          agentDir: path.join(tmp, "agent"),
+          sessionKey,
+          sessionFile: path.join(tmp, "session.jsonl"),
+          workspaceDir: tmp,
+          model: "claude-opus-4-6",
+          config: {
+            models: {
+              providers: {
+                anthropic: {
+                  baseUrl: "https://example.test",
+                  models: [
+                    {
+                      id: "claude-opus-4-6",
+                      name: "Test model",
+                      contextTokens: 32_768,
+                      reasoning: false,
+                      input: ["text"],
+                      maxTokens: 8_192,
+                      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                    },
+                  ],
+                },
+              },
+            },
+          },
+        },
+        reply: {
+          commandBody: prompt,
+          sessionEntry,
+          sessionStore: { [sessionKey]: sessionEntry },
+          sessionKey,
+          storePath,
+        },
+      }).run();
+
+      expect(compactState.compactEmbeddedAgentSessionMock).not.toHaveBeenCalled();
+      expect(runtimeErrorMock).not.toHaveBeenCalled();
+      expect(runEmbeddedAgentMock.mock.calls.map(([params]) => params.trigger)).toEqual([
+        "memory",
+        "user",
+      ]);
+      expectReplyText(result, "Two plus two is four.");
+      expect(loadSessionEntry(scope)?.memoryFlush).toMatchObject({
+        kind: "succeeded",
+        compactionCount: 0,
+      });
+    } finally {
+      await fs.rm(tmp, { recursive: true, force: true });
+    }
   });
 
   it.each([

--- a/src/auto-reply/reply/memory-flush.ts
+++ b/src/auto-reply/reply/memory-flush.ts
@@ -42,21 +42,15 @@ function resolvePositiveTokenCount(value: number | undefined): number | undefine
     : undefined;
 }
 
-/** Resolves the maintenance threshold owned by the selected memory provider. */
-export function resolveMemoryFlushThreshold(params: {
+/** Resolves the blocking threshold using the selected reserve and server floor. */
+export function resolveCompactionThreshold(params: {
   contextWindowTokens: number;
   reserveTokensFloor: number;
-  softThresholdTokens: number;
   minimumThresholdTokens?: number;
 }): number {
   const contextWindow = Math.max(1, Math.floor(params.contextWindowTokens));
   const reserveTokens = Math.max(0, Math.floor(params.reserveTokensFloor));
-  const softThreshold = Math.max(0, Math.floor(params.softThresholdTokens));
-  return Math.max(
-    0,
-    contextWindow - reserveTokens - softThreshold,
-    Math.floor(params.minimumThresholdTokens ?? 0),
-  );
+  return Math.max(0, contextWindow - reserveTokens, Math.floor(params.minimumThresholdTokens ?? 0));
 }
 
 export function resolveResponsesServerCompactionThreshold(params: {
@@ -119,15 +113,12 @@ export function resolveResponsesServerCompactionThreshold(params: {
   ).threshold;
 }
 
-function resolveMemoryFlushGateState<
+function resolveMaintenanceGateState<
   TEntry extends Pick<SessionEntry, "totalTokens" | "totalTokensFresh" | "totalTokensVersion">,
 >(params: {
   entry?: TEntry;
   tokenCount?: number;
-  contextWindowTokens: number;
-  reserveTokensFloor: number;
-  softThresholdTokens: number;
-  minimumThresholdTokens?: number;
+  threshold: number;
 }): { entry: TEntry; totalTokens: number; threshold: number } | null {
   if (!params.entry) {
     return null;
@@ -139,7 +130,7 @@ function resolveMemoryFlushGateState<
     return null;
   }
 
-  const threshold = resolveMemoryFlushThreshold(params);
+  const threshold = params.threshold;
   return threshold > 0 ? { entry: params.entry, totalTokens, threshold } : null;
 }
 
@@ -154,11 +145,9 @@ export function shouldRunMemoryFlush(params: {
    * SessionEntry.totalTokens (which may be stale/unknown).
    */
   tokenCount?: number;
-  contextWindowTokens: number;
-  reserveTokensFloor: number;
-  softThresholdTokens: number;
+  threshold: number;
 }): boolean {
-  const state = resolveMemoryFlushGateState(params);
+  const state = resolveMaintenanceGateState(params);
   if (!state || state.totalTokens < state.threshold) {
     return false;
   }
@@ -178,12 +167,9 @@ export function shouldRunPreflightCompaction(params: {
    * of any cached SessionEntry total.
    */
   tokenCount?: number;
-  contextWindowTokens: number;
-  reserveTokensFloor: number;
-  softThresholdTokens: number;
-  minimumThresholdTokens?: number;
+  threshold: number;
 }): boolean {
-  const state = resolveMemoryFlushGateState(params);
+  const state = resolveMaintenanceGateState(params);
   return Boolean(state && state.totalTokens >= state.threshold);
 }
 

--- a/src/auto-reply/reply/reply-state.test.ts
+++ b/src/auto-reply/reply/reply-state.test.ts
@@ -25,7 +25,7 @@ import {
 import {
   hasAlreadyFlushedForCurrentCompaction,
   resolveMemoryFlushContextWindowTokens,
-  resolveMemoryFlushThreshold,
+  resolveCompactionThreshold,
   shouldRunMemoryFlush,
   shouldRunPreflightCompaction,
 } from "./memory-flush.js";
@@ -271,9 +271,7 @@ describe("shouldRunMemoryFlush", () => {
     expect(
       shouldRunMemoryFlush({
         entry: { totalTokens: 0, totalTokensFresh: true, totalTokensVersion: 1 },
-        contextWindowTokens: 16_000,
-        reserveTokensFloor: 20_000,
-        softThresholdTokens: 4_000,
+        threshold: 0,
       }),
     ).toBe(false);
   });
@@ -282,67 +280,48 @@ describe("shouldRunMemoryFlush", () => {
     expect(
       shouldRunMemoryFlush({
         entry: undefined,
-        contextWindowTokens: 16_000,
-        reserveTokensFloor: 1_000,
-        softThresholdTokens: 4_000,
+        threshold: 11_000,
       }),
     ).toBe(false);
   });
 
-  it("preserves thresholds supplied by external memory providers", () => {
-    expect(
-      resolveMemoryFlushThreshold({
-        contextWindowTokens: 100,
-        reserveTokensFloor: 10,
-        softThresholdTokens: 80,
-      }),
-    ).toBe(10);
-
-    const disabled = {
-      entry: { totalTokens: 8_000, totalTokensFresh: true, totalTokensVersion: 1 as const },
-      contextWindowTokens: 32_000,
-      reserveTokensFloor: 50_000,
-      softThresholdTokens: 4_000,
-    };
-    expect(shouldRunMemoryFlush(disabled)).toBe(false);
-    expect(shouldRunPreflightCompaction(disabled)).toBe(false);
-  });
+  it.each([
+    [8_000, 4_000, 4_000],
+    [16_000, 8_000, 8_000],
+    [24_000, 16_000, 8_000],
+    [32_768, 20_000, 12_768],
+    [128_000, 20_000, 108_000],
+    [200_000, 20_000, 180_000],
+    [32_000, 50_000, 0],
+  ])(
+    "honors the selected reserve in a %i-token window",
+    (contextWindowTokens, reserveTokensFloor, expected) => {
+      const threshold = resolveCompactionThreshold({ contextWindowTokens, reserveTokensFloor });
+      expect(threshold).toBe(expected);
+      for (const tokenCount of [expected - 1, expected, expected + 1]) {
+        expect(
+          shouldRunPreflightCompaction({
+            entry: { totalTokens: tokenCount, totalTokensFresh: true, totalTokensVersion: 1 },
+            threshold,
+          }),
+        ).toBe(expected > 0 && tokenCount >= expected);
+      }
+    },
+  );
 
   it.each([
-    [8_000, 4_000, 2_000, 2_000],
-    [16_000, 8_000, 4_000, 4_000],
-    [24_000, 16_000, 4_000, 4_000],
-    [32_000, 20_000, 4_000, 8_000],
-    [128_000, 20_000, 4_000, 104_000],
-    [200_000, 20_000, 4_000, 176_000],
+    [12_000, 12_768],
+    [16_000, 16_000],
   ])(
-    "preserves a usable %i-token model window with provider-owned maintenance budgets",
-    (contextWindowTokens, reserveTokensFloor, softThresholdTokens, threshold) => {
-      const params = {
-        contextWindowTokens,
-        reserveTokensFloor,
-        softThresholdTokens,
-      };
-
-      expect(resolveMemoryFlushThreshold(params)).toBe(threshold);
+    "honors a server floor of %i without lowering the local threshold",
+    (minimumThresholdTokens, expected) => {
       expect(
-        shouldRunMemoryFlush({
-          ...params,
-          entry: { totalTokens: threshold, totalTokensFresh: true, totalTokensVersion: 1 },
+        resolveCompactionThreshold({
+          contextWindowTokens: 32_768,
+          reserveTokensFloor: 20_000,
+          minimumThresholdTokens,
         }),
-      ).toBe(true);
-      expect(
-        shouldRunPreflightCompaction({
-          ...params,
-          entry: { totalTokens: threshold - 1, totalTokensFresh: true, totalTokensVersion: 1 },
-        }),
-      ).toBe(false);
-      expect(
-        shouldRunPreflightCompaction({
-          ...params,
-          entry: { totalTokens: threshold, totalTokensFresh: true, totalTokensVersion: 1 },
-        }),
-      ).toBe(true);
+      ).toBe(expected);
     },
   );
 
@@ -350,9 +329,7 @@ describe("shouldRunMemoryFlush", () => {
     expect(
       shouldRunMemoryFlush({
         entry: { totalTokens: 10_000, totalTokensFresh: true, totalTokensVersion: 1 },
-        contextWindowTokens: 100_000,
-        reserveTokensFloor: 20_000,
-        softThresholdTokens: 10_000,
+        threshold: 70_000,
       }),
     ).toBe(false);
   });
@@ -361,9 +338,7 @@ describe("shouldRunMemoryFlush", () => {
     expect(
       shouldRunMemoryFlush({
         entry: { totalTokens: 85, totalTokensFresh: true, totalTokensVersion: 1 },
-        contextWindowTokens: 100,
-        reserveTokensFloor: 10,
-        softThresholdTokens: 5,
+        threshold: 85,
       }),
     ).toBe(true);
   });
@@ -372,15 +347,13 @@ describe("shouldRunMemoryFlush", () => {
     expect(
       shouldRunMemoryFlush({
         entry: {
-          totalTokens: 90_000,
+          totalTokens: 96_000,
           totalTokensFresh: true,
           totalTokensVersion: 1,
           compactionCount: 2,
           memoryFlush: { kind: "succeeded", compactionCount: 2 },
         },
-        contextWindowTokens: 100_000,
-        reserveTokensFloor: 5_000,
-        softThresholdTokens: 2_000,
+        threshold: 93_000,
       }),
     ).toBe(false);
   });
@@ -394,18 +367,14 @@ describe("shouldRunMemoryFlush", () => {
           totalTokensVersion: 1,
           compactionCount: 1,
         },
-        contextWindowTokens: 100_000,
-        reserveTokensFloor: 5_000,
-        softThresholdTokens: 2_000,
+        threshold: 93_000,
       }),
     ).toBe(true);
   });
 
   it("runs on consecutive compaction cycles when flush records the pre-increment count", () => {
     const params = {
-      contextWindowTokens: 100_000,
-      reserveTokensFloor: 5_000,
-      softThresholdTokens: 2_000,
+      threshold: 93_000,
     };
 
     for (const entry of [
@@ -438,9 +407,7 @@ describe("shouldRunMemoryFlush", () => {
     expect(
       shouldRunMemoryFlush({
         entry: { totalTokens: 96_000, totalTokensFresh: false, compactionCount: 1 },
-        contextWindowTokens: 100_000,
-        reserveTokensFloor: 5_000,
-        softThresholdTokens: 2_000,
+        threshold: 93_000,
       }),
     ).toBe(false);
   });
@@ -451,9 +418,7 @@ describe("shouldRunPreflightCompaction", () => {
     expect(
       shouldRunPreflightCompaction({
         entry: { totalTokens: 96_000, totalTokensFresh: false },
-        contextWindowTokens: 100_000,
-        reserveTokensFloor: 5_000,
-        softThresholdTokens: 2_000,
+        threshold: 93_000,
       }),
     ).toBe(false);
   });
@@ -463,9 +428,7 @@ describe("shouldRunPreflightCompaction", () => {
       shouldRunPreflightCompaction({
         entry: { totalTokens: 10, totalTokensFresh: false },
         tokenCount: 93_000,
-        contextWindowTokens: 100_000,
-        reserveTokensFloor: 5_000,
-        softThresholdTokens: 2_000,
+        threshold: 93_000,
       }),
     ).toBe(true);
   });


### PR DESCRIPTION
Closes #131762 — local 32K chat fails its second turn at the compaction safeguard.

Related: #131757 — desktop activation/restart handoff repair, now merged. Builds on merged #132010 — preserve conversation after optional memory-flush exhaustion; that repair is not duplicated here.

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where users of a newly configured local 32K model could receive a compaction error instead of the second short chat reply. The real Tauri/Linux reproduction completed its first request, restarted the Gateway and app, then rejected the next request during required maintenance despite an effective 32,768-token model context.

Two connected ownership defects made that path unnecessarily fragile: blocking compaction reused the early-memory-flush margin, and split-prefix summarization did not receive the completion fact already available to preparation and required by the summary safeguard. The rejected live summary itself was not captured, so this does **not** claim a proven lexical false positive or that every model reproduces the failure.

## Why This Change Was Made

Resolve the blocking threshold once from the model window, selected reserve, and applicable server floor; apply the soft margin only to early flushing. For the observed 32,768-token window with 20,000 reserve and 4,000 soft margin, flushing begins at **8,768**, while blocking token compaction begins at **12,768**. No setting or default value is added or increased.

The existing preparation-owned split-turn completion fact now reaches both initial and corrective summary generation, retention, and final audit. It is bound to the actual user-bearing split, not a different older ask when a custom/bash boundary has no user. The retained terminal suffix is not copied, quality checks remain enforced, and repeated invalid summaries still cancel before history replacement.

The real storage-boundary tests also exposed formerly shared temporary SQLite locators. Those fixtures and their direct/native siblings now allocate canonical owned roots and close database handles before cleanup. This repairs the test producer rather than mocking away real target resolution or modifying an unowned database.

## User Impact

A successful early memory flush no longer forces otherwise premature blocking compaction; normal chat can continue in the intended headroom interval. Legitimate compaction has the completion evidence it needs without resurrecting an already completed request. Fresh/stale usage accounting, the larger persisted-versus-transcript projection, once-per-cycle flushing, byte-pressure guards, required-compaction failures, manual/overflow paths, authorization, cancellation, and native-runtime ownership remain intact.

This composes with the already-merged exhaustion-continuity repair: optional maintenance exhaustion does not reset conversation history. The coordinator still performs required compaction before admitting the user turn and surfaces required-compaction failure normally. No SQLite schema/store, persistent-state semantics, protocol version, dependency, new public configuration/environment option, inference timeout, or context-window increase is introduced.

## Evidence

### Final refreshed-head checkpoint

Published head: `459ea0cdf397b1b4f228cb1ee5cd75e58d5744b5`. The mechanical rebase `e6fbc922540c00fd9b3288243a1985ec3a19d780` onto main `ea1a547437ce3fc76802345bf4213c143fb77dab` has the same stable patch ID as the original main integration. The final commit adds only the custom-plan test cases below; all three production owners still match the original live-tested candidate.

The previous hosted run failed only because the merged UI-pages/E2E typecheck shard exceeded its unchanged 720-root cap. The exact-coverage split landed independently in [#132193 — share fs-safe native assets across package graphs](https://github.com/openclaw/openclaw/pull/132193), so this refresh includes that fix rather than duplicating it or weakening the cap. **Final-head hosted CI completed successfully**, including [the required `openclaw/ci-gate`](https://github.com/openclaw/openclaw/actions/runs/33226815982/job/99032923046). Fresh live rollup verification found no failed or pending checks. Native artifact validation, mandatory hosted preparation, and the pinned squash merge completed successfully. Landed as [85cefd02525a](https://github.com/openclaw/openclaw/commit/85cefd02525aa63531f73d000a8cd3f8b568676e); [native merge receipt](https://github.com/openclaw/openclaw/pull/132190#issuecomment-5459659902). The linked issue is closed. No release was published.

The refreshed integration passed **926 unique tests across 19 files**. Its first run hit the unchanged agent-command import hook's 180-second timeout under heavy host contention: 349 tests in earlier shards and 29 controls passed, while 24 cases were skipped by that failed hook. After the static gate completed, the failed shard and remaining suites passed **577 tests** with the existing one-worker setting and unchanged timeout, mocks, and assertions. The 29 controls are not double-counted. The full changed gate passed on the refreshed implementation, including all Knip scans, the corrected graph-coverage guard, all 15 core-test type graphs, lint, formatting, and storage/cycle guards.

[ClawSweeper's reviewed-head feedback](https://github.com/openclaw/openclaw/pull/132190#issuecomment-5458763500) has no correctness/security finding and asks for positive non-default flush-plan coverage. The existing table now also selects an external memory provider with reserve **12,000** and soft margin **2,000**: flush at **18,768**, required compaction at **20,768**. Against the exact pre-fix production owners, the two interval cases failed for an unwanted compaction call and the two boundary controls passed. Repaired production was restored byte-for-byte; the full **98-test** maintenance suite, matching type graph, canonical lint, formatting, and a fresh isolated P0 review then passed. This adds four unique cases, bringing final covered scope to **930 unique tests**, not a sum of repeated runs.

```bash
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/agents/agent-command.embedded-maintenance.test.ts src/agents/run-session-target.test.ts src/agents/embedded-agent-runner/compact.hooks.test.ts src/agents/embedded-agent-runner/compact.abort-signal.test.ts src/agents/embedded-agent-runner/compact.native-cli.test.ts src/agents/agent-hooks/compaction-safeguard.test.ts src/agents/sessions/agent-session-loop-correctness.test.ts extensions/memory-core/src/flush-plan.test.ts extensions/ollama/src/stream-runtime.test.ts --reporter=dot
```

```bash
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/auto-reply/reply/agent-runner-memory.test.ts --reporter=dot
```

```bash
node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.messaging.json --incremental
```

```bash
node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/auto-reply/reply/agent-runner-memory.test.ts
```

The custom-plan change deliberately restores the existing field contract: `softThresholdTokens` says to run memory flush *within that many tokens of the compaction threshold* (`src/config/types.agent-defaults.ts:441`); it is not a second subtraction from required compaction. No migration is needed: no schema, stored metadata, vector/embedding record, or retained-field change occurs. The review's `docs:list` failure was confined to its read-only Corepack environment; local docs discovery and MDX checks were completed. Its remaining exact-head/rank-up confirmation will be recorded before native merge.

### Real native Linux behavior

The [original failure and candidate proof](https://github.com/openclaw/openclaw/issues/131762#issuecomment-5456490825) use an actual Debian ARM64 Docker desktop with systemd, Tauri/WebKitGTK, and Ollama 0.33.1—not a mocked browser or provider. The original reviewed candidate is [d5be515ec32](https://github.com/openclaw/openclaw/commit/d5be515ec32e0df9f07c414d99a19a9afece5f78), preserved on its source branch. This main integration has byte-identical production owners; its docs/test conflict resolutions preserve newer main's request-ceiling, configured-agent identity, and plugin-metadata changes.

The candidate completed default-main first chat, Gateway/app restart, second and third replies, manual `/compact`, and post-compaction recall. Observed early flush projection was **11,061 ≥ 8,768**; subsequent preflight was **11,037 < 12,768**. The smaller **7,159** housekeeping prompt did not replace the larger normal-chat accounting. Manual compaction succeeded on its first attempt in **12,470 ms**, leaving two messages / approximately 288 tokens; the subsequent reply recalled both arithmetic answers.

| Before | After restart |
| --- | --- |
| ![Second request fails at required compaction](https://github.com/user-attachments/assets/1bd152d0-1adb-42cf-b37c-b657bcb09b42) | ![Second short request succeeds after restart](https://github.com/user-attachments/assets/b240b472-1512-4e4e-a4b1-bf75ddd00e21) |

![Recall after successful manual compaction](https://github.com/user-attachments/assets/9f9a819c-d29f-4089-a6c2-ab339568a0a5)

Inspected accelerated replay (12×):

https://github.com/user-attachments/assets/686b7219-ac54-48f0-8146-b769ca96a456

All published captures were inspected and contain synthetic QA conversation, not credentials or operator data. No live state was edited to manufacture the outcome, and no context, timeout, quality-guard, or retry policy was weakened.

### Regression-first and integrated proof

Before production edits, these regressions failed for the intended reasons; both pass after repair:

```bash
node scripts/run-vitest.mjs src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts -t 'default 32K early-flush interval' --reporter=dot
```

```bash
node scripts/run-vitest.mjs src/agents/agent-hooks/compaction-safeguard.test.ts -t 'retries a split-turn summary that revives a completed request' --reporter=dot
```

The first observed an unwanted compactor call after successful early flushing; the second prepared a real split with its terminal response retained outside the prefix and observed missing completion evidence in the initial summarizer call. Both initial/corrective requests are now covered, alongside valid correction versus repeated-invalid-summary cancellation.

Integrated head `917738e14367cdca40ac51d1c1277349d2c94ceb` on main `6e6a0e59fde0034a2705eca34cbd1b7c6ca0ff3a`: **924 unique tests, 19 files, 10 shards passed**, including the merged continuity coordinator's real-SQLite exhaustion/no-reset test. The original eight-file execution order separately passed **687 tests**. These are complementary proofs: the existing exhaustion case is byte-forced at low token pressure, while the 32K interval regression uses successful flushing; no single combined token-interval-exhaustion test is claimed.

```bash
node scripts/run-vitest.mjs src/auto-reply/reply/agent-runner-memory.test.ts src/agents/agent-hooks/compaction-safeguard.test.ts src/auto-reply/reply/followup-turn-admission.test.ts src/agents/agent-command.embedded-maintenance.test.ts src/agents/embedded-agent-runner/compact.hooks.test.ts packages/agent-core/src/harness/compaction/compaction.test.ts extensions/memory-core/src/flush-plan.test.ts extensions/ollama/src/stream-runtime.test.ts src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts src/auto-reply/reply/memory-flush.test.ts src/auto-reply/reply/reply-state.test.ts src/auto-reply/reply/agent-runner-memory.preflight-stale-tokens.test.ts src/agents/sessions/agent-session-loop-correctness.test.ts src/agents/embedded-agent-runner/compact.abort-signal.test.ts src/agents/embedded-agent-runner/compact.native-cli.test.ts src/agents/run-session-target.test.ts src/config/sessions/session-sqlite-target.ownership.test.ts test/helpers/temp-dir.test.ts src/auto-reply/reply/agent-runner-direct-runtime-config.test.ts --reporter=dot
```

Full explicit changed-file gate passed with the exact integrity-pinned pnpm 11.22.0, including production/full-tree/script Knip scans, core and all 14 core-test type graphs, type-aware lint, formatting, schema/storage guards, and import-cycle checks:

```bash
node scripts/check-changed.mjs --base 6e6a0e59fde0034a2705eca34cbd1b7c6ca0ff3a -- docs/providers/ollama.md docs/reference/session-management-compaction.md src/agents/agent-hooks/compaction-safeguard.test.ts src/agents/agent-hooks/compaction-safeguard.ts src/agents/embedded-agent-runner/compact.abort-signal.test.ts src/agents/embedded-agent-runner/compact.hooks.harness.ts src/agents/embedded-agent-runner/compact.hooks.test.ts src/agents/embedded-agent-runner/compact.native-cli.test.ts src/auto-reply/reply/agent-runner-memory.test.ts src/auto-reply/reply/agent-runner-memory.ts src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts src/auto-reply/reply/memory-flush.ts src/auto-reply/reply/reply-state.test.ts
```

Both changed docs passed MDX validation. A fresh isolated Codex autoreview of the integrated staged patch returned no P0 findings; that is not represented as an all-severity review. The initial gate correctly failed because its pinned package-manager executable was missing; the exact pinned manager was restored in a private Corepack cache, without dependency reconciliation or `node_modules` edits, before the complete successful rerun.

### Ownership, dependencies, and size

The shared maintenance caller neighborhood includes ordinary replies, queued follow-ups, and direct commands. Coverage preserves CLI/heartbeat/native skips, Codex's host byte fuse without host token ownership, server floors, small/no-plan budgets, stale projections, cancellation, durable ownership, and terminal failures. Real session coverage verifies cancellation before compaction append/history replacement.

Directly inspected the pinned Codex source at [90854393966](https://github.com/openai/codex/commit/90854393966b21e9ebfd21b122334eb09a20c93d): [`context_window.rs`](https://github.com/openai/codex/blob/90854393966b21e9ebfd21b122334eb09a20c93d/codex-rs/core/src/session/context_window.rs#L23), [`turn.rs`](https://github.com/openai/codex/blob/90854393966b21e9ebfd21b122334eb09a20c93d/codex-rs/core/src/session/turn.rs#L413), and [`thread_processor.rs`](https://github.com/openai/codex/blob/90854393966b21e9ebfd21b122334eb09a20c93d/codex-rs/app-server/src/request_processors/thread_processor.rs#L2312). Native pressure/compaction remains Codex-owned; OpenClaw's flush margin is not part of that compact request.

[Ollama v0.33.1 source](https://github.com/ollama/ollama/blob/v0.33.1/server/routes.go#L118-L174) applies request options after model options. OpenClaw's existing native precedence is explicit `params.num_ctx`, then effective `contextTokens`, otherwise Ollama chooses. The live runner actually used **32,768**, despite its Modelfile's 16,384. The corrected [Ollama docs](https://docs.openclaw.ai/providers/ollama) and [compaction reference](https://docs.openclaw.ai/reference/session-management-compaction) reflect those contracts; provider transport itself is unchanged.

**Production +35/−45 (net −10); tests/support +613/−255 (net +358); docs +24/−10 (net +14), 13 files.** The bounded completion instruction adds at most 146 UTF-16 units; removing duplicate threshold policy and hard-path soft-margin plumbing more than offsets it. No new production test seam, generation path, compatibility reader, or fallback is added.

Provenance: early-margin reuse originated in [#49479 — stale-usage preflight compaction](https://github.com/openclaw/openclaw/pull/49479), authored by @jared596 and merged by @jalehman on March 25, 2026. [#85160 — surface native compaction failures](https://github.com/openclaw/openclaw/pull/85160), authored/merged by @joshavant on May 22, removed the stale-only gate and made required failures consequential for fresh usage. [#130072 — model-aware maintenance budgets](https://github.com/openclaw/openclaw/pull/130072), authored/merged by @steipete on August 26, correctly capped reserve policy and carried the reuse forward; it did not introduce it. This is source-history attribution, not proof that a specific predecessor produced the uncaptured live summary.

### Explicit limits

The live proof belongs to preserved candidate `d5be515ec32`; the integrated main patch is verified by production-byte equivalence, conflict inspection, and the expanded tests/gates, not mislabeled as a second live deployment. Restart was in the original reproduction, not proven necessary. The separate fresh no-restart child-session pair was interrupted and is not counted; the completed default-main run includes a third turn without another restart. Small CPU-only models can still be slow or generate invalid summaries; real safeguard failures remain visible. No fresh subscription OAuth enrollment or operator Gateway/state mutation was performed.
