### PR TITLE
fix: share fs-safe native assets across package graphs

### DIFF
--- a/scripts/lib/tsgo-core-test-shards.mts
+++ b/scripts/lib/tsgo-core-test-shards.mts
@@ -37,9 +37,14 @@ export const TSGO_CORE_TEST_SHARDS = [
   { name: "services", group: "src", config: "test/tsconfig/tsconfig.core.test.services.json" },
   { name: "other", group: "src", config: "test/tsconfig/tsconfig.core.test.other.json" },
   {
-    name: "ui-pages-e2e",
+    name: "ui-pages",
     group: "ui",
-    config: "test/tsconfig/tsconfig.core.test.ui-pages-e2e.json",
+    config: "test/tsconfig/tsconfig.core.test.ui-pages.json",
+  },
+  {
+    name: "ui-e2e",
+    group: "ui",
+    config: "test/tsconfig/tsconfig.core.test.ui-e2e.json",
   },
   { name: "ui-other", group: "ui", config: "test/tsconfig/tsconfig.core.test.ui-other.json" },
   {

--- a/scripts/lib/worker-deploy-build-plugin.mts
+++ b/scripts/lib/worker-deploy-build-plugin.mts
@@ -21,11 +21,18 @@ const UNDICI_REQUIRE_BOOTSTRAP = [
   'return requireUndici("undici") as typeof import("undici");',
 ] as const;
 const WORKER_UNDICI_IMPORT = 'import * as bundledUndici from "undici";';
+const FS_SAFE_NATIVE_DIRECTORY =
+  'const bundledNativeDirectory = fileURLToPath(new URL("../dist/native/", import.meta.url));';
+const WORKER_FS_SAFE_NATIVE_DIRECTORY =
+  'const bundledNativeDirectory = fileURLToPath(new URL("../../dist/native/", import.meta.url));';
 
 /** Composes bundled-plugin runtime and removes dependency package reads from the worker build. */
 export function createWorkerDeployBuildPlugin(rootDir = process.cwd()) {
   const playwrightRoot = fs.realpathSync(path.resolve(rootDir, "node_modules/playwright-core"));
   const coreBundlePath = fs.realpathSync(path.join(playwrightRoot, "lib/coreBundle.js"));
+  const fsSafeNativePath = fs.realpathSync(
+    path.resolve(rootDir, "node_modules/@openclaw/fs-safe/dist/native.js"),
+  );
   const browserRuntimeBridgePath = fs.realpathSync(
     path.resolve("src/worker/worker-deploy-browser-runtime.ts"),
   );
@@ -73,6 +80,12 @@ export function createWorkerDeployBuildPlugin(rootDir = process.cwd()) {
           .replace(UNDICI_REQUIRE_BOOTSTRAP[0], WORKER_UNDICI_IMPORT)
           .replace(UNDICI_REQUIRE_BOOTSTRAP[1], "")
           .replace(UNDICI_REQUIRE_BOOTSTRAP[2], "return bundledUndici;");
+      }
+      if (resolvedId === fsSafeNativePath) {
+        if (!code.includes(FS_SAFE_NATIVE_DIRECTORY)) {
+          this.error("fs-safe native asset lookup changed; update the worker deploy transform");
+        }
+        return code.replace(FS_SAFE_NATIVE_DIRECTORY, WORKER_FS_SAFE_NATIVE_DIRECTORY);
       }
       if (
         resolvedId !== coreBundlePath ||

--- a/test/scripts/tsdown-config.test.ts
+++ b/test/scripts/tsdown-config.test.ts
@@ -113,6 +113,11 @@ describe("tsdown config", () => {
         worker ? isWorkerDeployConfig : (config) => config.name === TSDOWN_UNIFIED_CONFIG_GROUP,
       );
       expect(selected).toBeDefined();
+      if (worker) {
+        expect(selected?.copy).toBeUndefined();
+      } else {
+        expect(selected?.copy).toBeDefined();
+      }
       // Deliberately not named dist: the dependency's URL is relative to the
       // emitted loader, including the worker's extra directory component.
       const bundles = await build({
@@ -126,6 +131,11 @@ describe("tsdown config", () => {
         logLevel: "silent",
       });
       try {
+        if (worker) {
+          // The runtime graph owns the package's single native tree; this
+          // isolated worker build only proves that its loader shares it.
+          fs.cpSync(nativeSource, path.join(sourceRoot, "dist/native"), { recursive: true });
+        }
         fs.writeFileSync(path.join(sourceRoot, "package.json"), '{"type":"module"}');
         fs.renameSync(sourceRoot, relocatedRoot);
         const entry = path.join(
@@ -133,10 +143,7 @@ describe("tsdown config", () => {
           worker ? "output/worker/worker.mjs" : "output/plugin-sdk/memory-core-host-engine-fs.js",
         );
         const observer = worker ? entry : path.join(relocatedRoot, "output/observer.js");
-        const nativeOutput = path.join(
-          relocatedRoot,
-          worker ? "output/dist/native" : "dist/native",
-        );
+        const nativeOutput = path.join(relocatedRoot, "dist/native");
         const probe = async (
           name: string,
           mode: string,

--- a/test/scripts/worker-deploy-build-plugin.test.ts
+++ b/test/scripts/worker-deploy-build-plugin.test.ts
@@ -64,6 +64,26 @@ describe("worker deploy build plugin", () => {
     expect(transformed).not.toContain('requireUndici("undici")');
   });
 
+  it("shares the package native fs-safe assets with the runtime build", () => {
+    const nativePath = path.resolve("node_modules/@openclaw/fs-safe/dist/native.js");
+    const source = fs.readFileSync(nativePath, "utf8");
+    const plugin = createWorkerDeployBuildPlugin();
+
+    const transformed = plugin.transform.call({ error: fail }, source, nativePath);
+
+    expect(transformed).toContain('new URL("../../dist/native/", import.meta.url)');
+    expect(transformed).not.toContain('new URL("../dist/native/", import.meta.url)');
+  });
+
+  it("fails closed when the fs-safe native lookup shape changes", () => {
+    const nativePath = path.resolve("node_modules/@openclaw/fs-safe/dist/native.js");
+    const plugin = createWorkerDeployBuildPlugin();
+
+    expect(() =>
+      plugin.transform.call({ error: fail }, "changed upstream source", nativePath),
+    ).toThrow("fs-safe native asset lookup changed");
+  });
+
   it("fails closed when the undici dispatcher bootstrap shape changes", () => {
     const dispatcherPath = path.resolve("src/infra/net/undici-dispatcher-options.ts");
     const source = fs.readFileSync(dispatcherPath, "utf8");
@@ -104,6 +124,14 @@ describe("worker deploy build plugin", () => {
     const linkedRoot = path.join(tempRoot, "node_modules", "playwright-core");
     fs.mkdirSync(path.dirname(linkedRoot), { recursive: true });
     fs.symlinkSync(sourceRoot, linkedRoot, process.platform === "win32" ? "junction" : "dir");
+    const fsSafeSourceRoot = path.resolve("node_modules/@openclaw/fs-safe");
+    const linkedFsSafeRoot = path.join(tempRoot, "node_modules", "@openclaw", "fs-safe");
+    fs.mkdirSync(path.dirname(linkedFsSafeRoot), { recursive: true });
+    fs.symlinkSync(
+      fsSafeSourceRoot,
+      linkedFsSafeRoot,
+      process.platform === "win32" ? "junction" : "dir",
+    );
     const plugin = createWorkerDeployBuildPlugin(tempRoot);
     const resolvedId = fs.realpathSync(path.join(linkedRoot, "lib/coreBundle.js"));
 

--- a/test/tsconfig/tsconfig.core.test.ui-e2e.json
+++ b/test/tsconfig/tsconfig.core.test.ui-e2e.json
@@ -1,12 +1,10 @@
 {
   "extends": "./tsconfig.core.test.shard.json",
   "compilerOptions": {
-    "tsBuildInfoFile": "../../.artifacts/tsgo-cache/core-test-ui-pages-e2e.tsbuildinfo"
+    "tsBuildInfoFile": "../../.artifacts/tsgo-cache/core-test-ui-e2e.tsbuildinfo"
   },
   "include": [
     "../../ui/src/main.ts",
-    "../../ui/src/pages/**/*.test.ts",
-    "../../ui/src/pages/**/*.test.tsx",
     "../../ui/src/e2e/**/*.test.ts",
     "../../ui/src/e2e/**/*.test.tsx"
   ]

--- a/test/tsconfig/tsconfig.core.test.ui-pages.json
+++ b/test/tsconfig/tsconfig.core.test.ui-pages.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.core.test.shard.json",
+  "compilerOptions": {
+    "tsBuildInfoFile": "../../.artifacts/tsgo-cache/core-test-ui-pages.tsbuildinfo"
+  },
+  "include": [
+    "../../ui/src/main.ts",
+    "../../ui/src/pages/**/*.test.ts",
+    "../../ui/src/pages/**/*.test.tsx"
+  ]
+}

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -171,15 +171,15 @@ function nodeBuildConfig(
   };
 }
 
-function fsSafeNativeCopy(entryDirectory: string): UserConfig["copy"] {
+function fsSafeNativeCopy(): UserConfig["copy"] {
   const packageRoot = path.dirname(
     createRequire(import.meta.url).resolve("@openclaw/fs-safe/package.json"),
   );
   return ({ outDir }) => ({
     from: path.join(packageRoot, "dist/native"),
-    // fs-safe resolves ../dist/native from its emitted loader. Preserve that
-    // layout, including the inline worker's extra directory, and every target.
-    to: path.resolve(outDir, entryDirectory, "..", "dist"),
+    // Both package graphs resolve this canonical directory, so npm ships one
+    // native tree even though their emitted loaders have different depths.
+    to: path.resolve(outDir, "..", "dist"),
   });
 }
 
@@ -188,7 +188,6 @@ function workerDeployBuildConfig(): UserConfig {
     name: TSDOWN_UNIFIED_CONFIG_GROUP,
     entry: { "worker/worker": "src/worker/worker-deploy-entry.ts" },
     outDir: "dist",
-    copy: fsSafeNativeCopy("worker"),
     dts: false,
     env,
     define: {
@@ -774,7 +773,7 @@ const configs = [
       // and bundled hooks in one graph so runtime singletons are emitted once.
       entry: unifiedDistEntries,
       deps: unifiedDeps,
-      copy: fsSafeNativeCopy("."),
+      copy: fsSafeNativeCopy(),
       plugins: [createStateSchemaInlinePlugin()],
     },
     false,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where npm packages contained two identical copies of every `fs-safe` native binary after the sealed worker gained native-mode support.

## Why This Change Was Made

The normal runtime and sealed worker are emitted at different directory depths, while `@openclaw/fs-safe` resolves native binaries relative to its emitted loader. The sealed-worker build now rewrites that dependency-owned relative lookup to the package's canonical `dist/native` directory. The runtime build remains the sole owner that copies the seven platform binaries.

The transform validates the exact upstream source shape and fails the build if that contract changes. This preserves native `off`, `auto`, and `require` behavior without symlinks, fallback paths, or duplicate package assets.

## User Impact

Installed npm packages retain native `fs-safe` support while using 16,233,360 fewer unpacked bytes (15.48 MiB).

## Evidence

- Before the fix, the package build emitted identical 16,233,360-byte trees at `dist/native` and `dist/dist/native`.
- After the fix, the full package build emits seven platform binaries only at `dist/native`; `dist/dist/native` is absent.
- The generated sealed worker resolves `../../dist/native/`, sharing the runtime-owned asset tree.
- `npm pack --dry-run --ignore-scripts --json`: 228,483,134 unpacked bytes; removing the duplicate accounts for exactly 16,233,360 bytes.
- Pre-fix regression proof: the relocated worker test failed because the canonical shared tree was absent, and the focused transform test returned no rewrite.
- `node scripts/run-vitest.mjs test/scripts/worker-deploy-build-plugin.test.ts test/scripts/tsdown-config.test.ts` — 27 tests passed.
- `NODE_OPTIONS=--max-old-space-size=8192 pnpm build:package` — passed, including CLI bootstrap and plugin SDK checks.
- Local autoreview — clean, no actionable findings.

Production/tooling delta is +12 lines. The added lines implement and fail-closed validate the dependency path transform required to preserve native-mode behavior while deleting the second asset-copy owner; no smaller dependency-supported configuration seam exists in `@openclaw/fs-safe` 0.5.6 or its current main source.
