### PR TITLE
fix(cli): reject unsupported inherited --dry-run on update status

### DIFF
--- a/src/cli/update-cli.option-collisions.test.ts
+++ b/src/cli/update-cli.option-collisions.test.ts
@@ -152,6 +152,7 @@ describe("update cli option collisions", () => {
     { name: "repair", handler: updateFinalizeCommand },
     { name: "finalize", handler: updateFinalizeCommand },
     { name: "wizard", handler: updateWizardCommand },
+    { name: "status", handler: updateStatusCommand },
   ])("rejects parent --dry-run before running update $name", async ({ name, handler }) => {
     await runRegisteredCli({
       register: registerUpdateCli as (program: Command) => void,

--- a/src/cli/update-cli.ts
+++ b/src/cli/update-cli.ts
@@ -60,17 +60,23 @@ type CommanderUpdateOptions = Record<string, unknown> & {
   yes?: boolean;
 };
 
-function rejectUnsupportedInheritedUpdateDryRun(command: Command): boolean {
-  if (!inheritOptionFromParent<boolean>(command, "dryRun")) {
-    return false;
-  }
-
-  handleUpdateCommandError(
-    new Error(
-      `--dry-run is not supported for \`openclaw update ${command.name()}\`. Run \`openclaw update --dry-run\` instead.`,
-    ),
-  );
-  return true;
+// Every update leaf must reject the parent-only dry-run flag before owner work starts.
+// Keeping that policy in the shared action wrapper prevents a new leaf from silently ignoring it.
+function createUpdateLeafAction(
+  action: (opts: Record<string, unknown>, command: Command) => Promise<void>,
+) {
+  return async (opts: Record<string, unknown>, command: Command) => {
+    try {
+      if (inheritOptionFromParent<boolean>(command, "dryRun")) {
+        throw new Error(
+          `--dry-run is not supported for \`openclaw update ${command.name()}\`. Run \`openclaw update --dry-run\` instead.`,
+        );
+      }
+      await action(opts, command);
+    } catch (err) {
+      handleUpdateCommandError(err);
+    }
+  };
 }
 
 function registerUpdateFinalizationCommand(update: Command, name: string, hidden: boolean) {
@@ -100,12 +106,8 @@ function registerUpdateFinalizationCommand(update: Command, name: string, hidden
           "Docs:",
         )} ${formatDocsLink("/cli/update", "docs.openclaw.ai/cli/update")}`,
     )
-    .action(async (opts, actionCommand) => {
-      try {
-        if (rejectUnsupportedInheritedUpdateDryRun(actionCommand)) {
-          return;
-        }
-
+    .action(
+      createUpdateLeafAction(async (opts, actionCommand) => {
         await updateFinalizeCommand({
           json: Boolean(opts.json) || inheritedUpdateJson(actionCommand),
           channel:
@@ -119,10 +121,8 @@ function registerUpdateFinalizationCommand(update: Command, name: string, hidden
           restart: false,
           deferCompletionCache: hidden && process.env[POST_CORE_UPDATE_ENV]?.trim() === "1",
         });
-      } catch (err) {
-        handleUpdateCommandError(err);
-      }
-    });
+      }),
+    );
 }
 
 /** Attach the update command group to the root CLI. */
@@ -221,22 +221,16 @@ ${theme.muted("Docs:")} ${formatDocsLink("/cli/update", "docs.openclaw.ai/cli/up
       "after",
       `\n${theme.muted("Docs:")} ${formatDocsLink("/cli/update", "docs.openclaw.ai/cli/update")}\n`,
     )
-    .action(async (opts, command) => {
-      try {
-        if (rejectUnsupportedInheritedUpdateDryRun(command)) {
-          return;
-        }
-
+    .action(
+      createUpdateLeafAction(async (opts, command) => {
         await updateWizardCommand({
           timeout: inheritedUpdateTimeout(opts, command),
           acceptCapabilities:
             Boolean(opts.acceptCapabilities) ||
             Boolean(inheritOptionFromParent<boolean>(command, "acceptCapabilities")),
         });
-      } catch (err) {
-        handleUpdateCommandError(err);
-      }
-    });
+      }),
+    );
 
   update
     .command("status")
@@ -256,18 +250,12 @@ ${theme.muted("Docs:")} ${formatDocsLink("/cli/update", "docs.openclaw.ai/cli/up
           "Docs:",
         )} ${formatDocsLink("/cli/update", "docs.openclaw.ai/cli/update")}`,
     )
-    .action(async (opts, command) => {
-      try {
-        if (rejectUnsupportedInheritedUpdateDryRun(command)) {
-          return;
-        }
-
+    .action(
+      createUpdateLeafAction(async (opts, command) => {
         await updateStatusCommand({
           json: Boolean(opts.json) || inheritedUpdateJson(command),
           timeout: inheritedUpdateTimeout(opts, command),
         });
-      } catch (err) {
-        handleUpdateCommandError(err);
-      }
-    });
+      }),
+    );
 }

--- a/src/cli/update-cli.ts
+++ b/src/cli/update-cli.ts
@@ -258,6 +258,10 @@ ${theme.muted("Docs:")} ${formatDocsLink("/cli/update", "docs.openclaw.ai/cli/up
     )
     .action(async (opts, command) => {
       try {
+        if (rejectUnsupportedInheritedUpdateDryRun(command)) {
+          return;
+        }
+
         await updateStatusCommand({
           json: Boolean(opts.json) || inheritedUpdateJson(command),
           timeout: inheritedUpdateTimeout(opts, command),


### PR DESCRIPTION
## What Problem This Solves

`openclaw update --dry-run status` accepted the parent-only `--dry-run` option, ran the live update-status check, and exited 0. The command silently ignored the requested preview mode.

## Root cause

The update parser uses Commander positional options. A parent option placed before a leaf stays on the parent command. The update leaves repeated their inherited-option guard in separate action handlers, and the `status` handler omitted it.

The public CLI contract defines `--dry-run` for `openclaw update`. The `update status` leaf supports only `--json` and `--timeout`.

## Fix

- Route all four update leaves through one shared action wrapper.
- Reject inherited `--dry-run` before `repair`, hidden `finalize`, `wizard`, or `status` owner work starts.
- Add `status` to the existing real-parser table that enumerates every update leaf.
- Preserve the parent `openclaw update --dry-run` behavior.

Production code is 8 lines smaller than current main. Regression coverage adds one table row.

## Evidence

Exact current main `5e135e3ab809c54357d60ab963609c63d7891733`:

```text
$ node --import tsx src/entry.ts update --dry-run status
OpenClaw update status
Git      git · @ 5e135e3a
$ echo $?
0
```

Exact repaired head `5c5c9582fa7a6d844f0530a58f09e2f400b597f1`, using the identical command:

```text
--dry-run is not supported for `openclaw update status`. Run `openclaw update --dry-run` instead.
$ echo $?
1
```

The pre-fix real-parser regression failed because `updateStatusCommand` ran once. The repaired table passes all 25 cases and confirms that no update leaf handler runs for the inherited unsupported option.

## Verification

- `node scripts/run-vitest.mjs src/cli/update-cli.option-collisions.test.ts src/cli/command-options.test.ts src/cli/update-cli.test.ts` — 316 passed.
- Targeted Oxlint, Oxfmt, conflict-marker, max-lines, assertion-safety, and `git diff --check` checks passed.
- Commander 15 documents and implements positional parent options before subcommands: [`Readme.md`](https://github.com/tj/commander.js/blob/v15.0.0/Readme.md#L984-L998), [`lib/command.js`](https://github.com/tj/commander.js/blob/v15.0.0/lib/command.js#L845-L853).
- The separate Codex CLI update route does not participate in this OpenClaw parser path: [`openai/codex` CLI declaration](https://github.com/openai/codex/blob/5fc7840cf6d085a7a7b3438d69a2beb934a2a5f4/codex-rs/cli/src/main.rs#L99-L172), [`Update` dispatch](https://github.com/openai/codex/blob/5fc7840cf6d085a7a7b3438d69a2beb934a2a5f4/codex-rs/cli/src/main.rs#L1579-L1586).

Fixes #132192
