### PR TITLE
fix(ui): align Sessions tabs with page content

### DIFF
--- a/ui/src/components/sessions-hub-header.browser.test.ts
+++ b/ui/src/components/sessions-hub-header.browser.test.ts
@@ -63,44 +63,58 @@ describe.skipIf(!hasBrowserLayout)("Sessions hub header browser layout", () => {
     document.body.replaceChildren();
   });
 
-  it.each([1280, 820])(
-    "keeps the tab strip fixed without overlap at a %dpx viewport",
-    async (width) => {
-      await useViewport(width);
-      const sessions = await mount("sessions", true);
-      const sessionsTitle = sessions.querySelector<HTMLElement>(".hub-page-header__title");
-      const sessionsTabs = sessions.querySelector<HTMLElement>(".sessions-hub-tabs");
-      const sessionsActions = sessions.querySelector<HTMLElement>(".hub-page-header__actions");
-      const sessionsBody = sessions.querySelector<HTMLElement>('[data-testid="sessions-body"]');
-      const sessionsLeft = sessionsTabs?.getBoundingClientRect().left;
-      expect(sessionsLeft).toBeTypeOf("number");
-      expect(sessionsTabs?.getBoundingClientRect().width).toBeGreaterThan(0);
-      expect(sessionsActions?.childElementCount).toBe(1);
-      expect(
-        overlaps(sessionsTitle!.getBoundingClientRect(), sessionsTabs!.getBoundingClientRect()),
-      ).toBe(false);
-      expect(
-        overlaps(sessionsActions!.getBoundingClientRect(), sessionsTabs!.getBoundingClientRect()),
-      ).toBe(false);
-      expect(
-        sessionsTabs!.getBoundingClientRect().top - sessionsTitle!.getBoundingClientRect().bottom,
-      ).toBeGreaterThan(0);
-      expect(
-        Math.abs((sessionsLeft ?? 0) - sessionsTitle!.getBoundingClientRect().left),
-      ).toBeLessThanOrEqual(1);
-      expect(
-        Math.abs((sessionsLeft ?? 0) - sessionsBody!.getBoundingClientRect().left),
-      ).toBeLessThanOrEqual(1);
-      sessions.remove();
+  it.each([
+    [1280, 800],
+    [820, 800],
+    [700, 800],
+    [800, 480],
+  ])("keeps the title row and tab strip aligned at a %d×%d viewport", async (width, height) => {
+    await useViewport(width, height);
+    const sessions = await mount("sessions", true);
+    const sessionsTitle = sessions.querySelector<HTMLElement>(".hub-page-header__title");
+    const sessionsTabs = sessions.querySelector<HTMLElement>(".sessions-hub-tabs");
+    const sessionsActions = sessions.querySelector<HTMLElement>(".hub-page-header__actions");
+    const sessionsBody = sessions.querySelector<HTMLElement>('[data-testid="sessions-body"]');
+    const sessionsLeft = sessionsTabs?.getBoundingClientRect().left;
+    expect(sessionsLeft).toBeTypeOf("number");
+    expect(sessionsTabs?.getBoundingClientRect().width).toBeGreaterThan(0);
+    expect(sessionsActions?.childElementCount).toBe(1);
+    expect(
+      overlaps(sessionsTitle!.getBoundingClientRect(), sessionsTabs!.getBoundingClientRect()),
+    ).toBe(false);
+    expect(
+      overlaps(sessionsActions!.getBoundingClientRect(), sessionsTabs!.getBoundingClientRect()),
+    ).toBe(false);
+    expect(
+      sessionsTabs!.getBoundingClientRect().top - sessionsTitle!.getBoundingClientRect().bottom,
+    ).toBeGreaterThan(0);
+    expect(
+      Math.abs((sessionsLeft ?? 0) - sessionsTitle!.getBoundingClientRect().left),
+    ).toBeLessThanOrEqual(1);
+    expect(
+      Math.abs((sessionsLeft ?? 0) - sessionsBody!.getBoundingClientRect().left),
+    ).toBeLessThanOrEqual(1);
+    expect(
+      Math.abs(
+        sessionsActions!.getBoundingClientRect().right -
+          sessionsBody!.getBoundingClientRect().right,
+      ),
+    ).toBeLessThanOrEqual(1);
+    expect(
+      Math.abs(
+        sessionsActions!.getBoundingClientRect().bottom -
+          sessionsTitle!.getBoundingClientRect().bottom,
+      ),
+    ).toBeLessThanOrEqual(1);
+    sessions.remove();
 
-      const worktrees = await mount("worktrees", false);
-      const worktreesTabs = worktrees.querySelector<HTMLElement>(".sessions-hub-tabs");
-      const worktreesLeft = worktreesTabs?.getBoundingClientRect().left;
-      expect(worktreesLeft).toBeTypeOf("number");
-      expect(worktrees.querySelector(".hub-page-header__actions")?.childElementCount).toBe(0);
-      expect(Math.abs((sessionsLeft ?? 0) - (worktreesLeft ?? 0))).toBeLessThanOrEqual(1);
-    },
-  );
+    const worktrees = await mount("worktrees", false);
+    const worktreesTabs = worktrees.querySelector<HTMLElement>(".sessions-hub-tabs");
+    const worktreesLeft = worktreesTabs?.getBoundingClientRect().left;
+    expect(worktreesLeft).toBeTypeOf("number");
+    expect(worktrees.querySelector(".hub-page-header__actions")?.childElementCount).toBe(0);
+    expect(Math.abs((sessionsLeft ?? 0) - (worktreesLeft ?? 0))).toBeLessThanOrEqual(1);
+  });
 
   it("keeps session navigation and operational headers available on mobile", async () => {
     await useViewport(414, 800);

--- a/ui/src/components/sessions-hub-header.browser.test.ts
+++ b/ui/src/components/sessions-hub-header.browser.test.ts
@@ -3,6 +3,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { i18n } from "../i18n/index.ts";
 import "../styles.css";
 import { renderSessionsHubHeader } from "./sessions-hub-header.ts";
+import { renderSettingsPage } from "./settings-ui.ts";
+import { renderSettingsWorkspace } from "./settings-workspace.ts";
 
 const hasBrowserLayout = !navigator.userAgent.toLowerCase().includes("jsdom");
 
@@ -21,12 +23,19 @@ async function mount(
   container.style.maxWidth = "1120px";
   document.body.append(container);
   render(
-    renderSessionsHubHeader({
-      active,
-      title: "Sessions",
-      actions: withActions ? html`<div style="width: 240px">Agent selector</div>` : undefined,
-      onSelect,
-    }),
+    html`
+      ${renderSessionsHubHeader({
+        active,
+        title: "Sessions",
+        actions: withActions ? html`<div style="width: 240px">Agent selector</div>` : undefined,
+        onSelect,
+      })}
+      ${renderSettingsWorkspace(
+        renderSettingsPage(html`<div data-testid="sessions-body">Sessions body</div>`, {
+          wide: true,
+        }),
+      )}
+    `,
     container,
   );
   const group = container.querySelector<HTMLElement & { updateComplete: Promise<boolean> }>(
@@ -62,6 +71,7 @@ describe.skipIf(!hasBrowserLayout)("Sessions hub header browser layout", () => {
       const sessionsTitle = sessions.querySelector<HTMLElement>(".hub-page-header__title");
       const sessionsTabs = sessions.querySelector<HTMLElement>(".sessions-hub-tabs");
       const sessionsActions = sessions.querySelector<HTMLElement>(".hub-page-header__actions");
+      const sessionsBody = sessions.querySelector<HTMLElement>('[data-testid="sessions-body"]');
       const sessionsLeft = sessionsTabs?.getBoundingClientRect().left;
       expect(sessionsLeft).toBeTypeOf("number");
       expect(sessionsTabs?.getBoundingClientRect().width).toBeGreaterThan(0);
@@ -72,6 +82,15 @@ describe.skipIf(!hasBrowserLayout)("Sessions hub header browser layout", () => {
       expect(
         overlaps(sessionsActions!.getBoundingClientRect(), sessionsTabs!.getBoundingClientRect()),
       ).toBe(false);
+      expect(
+        sessionsTabs!.getBoundingClientRect().top - sessionsTitle!.getBoundingClientRect().bottom,
+      ).toBeGreaterThan(0);
+      expect(
+        Math.abs((sessionsLeft ?? 0) - sessionsTitle!.getBoundingClientRect().left),
+      ).toBeLessThanOrEqual(1);
+      expect(
+        Math.abs((sessionsLeft ?? 0) - sessionsBody!.getBoundingClientRect().left),
+      ).toBeLessThanOrEqual(1);
       sessions.remove();
 
       const worktrees = await mount("worktrees", false);
@@ -87,14 +106,19 @@ describe.skipIf(!hasBrowserLayout)("Sessions hub header browser layout", () => {
     await useViewport(414, 800);
     const onSelect = vi.fn();
     const sessions = await mount("sessions", true, onSelect);
-    const header = sessions.querySelector<HTMLElement>(".hub-page-header");
     const title = sessions.querySelector<HTMLElement>(".page-title");
     const tabs = sessions.querySelector<HTMLElement>(".sessions-hub-tabs");
     const actions = sessions.querySelector<HTMLElement>(".hub-page-header__actions");
-    expect(getComputedStyle(header!).display).toBe("grid");
+    const body = sessions.querySelector<HTMLElement>('[data-testid="sessions-body"]');
     expect(title?.getBoundingClientRect().width).toBeGreaterThan(0);
     expect(tabs?.getBoundingClientRect().width).toBeGreaterThan(0);
     expect(actions?.getBoundingClientRect().width).toBeGreaterThan(0);
+    expect(tabs!.getBoundingClientRect().top).toBeGreaterThan(
+      title!.getBoundingClientRect().bottom,
+    );
+    expect(
+      Math.abs(tabs!.getBoundingClientRect().left - body!.getBoundingClientRect().left),
+    ).toBeLessThanOrEqual(1);
 
     const worktreesTab = sessions.querySelector<HTMLElement>("#sessions-tab-worktrees");
     expect(worktreesTab?.getBoundingClientRect().width).toBeGreaterThan(0);

--- a/ui/src/components/sessions-hub-header.ts
+++ b/ui/src/components/sessions-hub-header.ts
@@ -11,15 +11,19 @@ type SessionsHubHeaderProps = {
 
 export function renderSessionsHubHeader(props: SessionsHubHeaderProps): TemplateResult {
   return html`
-    <section class="content-header content-header--page hub-page-header sessions-hub-header">
-      <div class="hub-page-header__title">
-        <div class="page-title">${props.title}</div>
-        ${props.subtitle ? html`<div class="page-subtitle">${props.subtitle}</div>` : nothing}
+    <section
+      class="content-header content-header--page hub-page-header hub-page-header--stacked sessions-hub-header"
+    >
+      <div class="hub-page-header__intro">
+        <div class="hub-page-header__title">
+          <div class="page-title">${props.title}</div>
+          ${props.subtitle ? html`<div class="page-subtitle">${props.subtitle}</div>` : nothing}
+        </div>
+        <div class="hub-page-header__actions">${props.actions ?? nothing}</div>
       </div>
       <div class="hub-page-header__tabs">
         ${renderSessionsHubTabs({ active: props.active, onSelect: props.onSelect })}
       </div>
-      <div class="hub-page-header__actions">${props.actions ?? nothing}</div>
     </section>
   `;
 }

--- a/ui/src/pages/plugins/plugins-hub-header.ts
+++ b/ui/src/pages/plugins/plugins-hub-header.ts
@@ -12,11 +12,15 @@ type PluginsHubHeaderProps = {
 
 export function renderPluginsHubHeader(props: PluginsHubHeaderProps): TemplateResult {
   return html`
-    <section class="content-header content-header--page hub-page-header plugins-hub-header">
-      <div class="hub-page-header__title">
-        <h1 class="page-title">${titleForRoute("plugins")}</h1>
-        <div class="page-subtitle">
-          ${subtitleForRoute("plugins")} ${renderLearnMoreLink(PLUGINS_DOCS_URL)}
+    <section
+      class="content-header content-header--page hub-page-header hub-page-header--stacked plugins-hub-header"
+    >
+      <div class="hub-page-header__intro">
+        <div class="hub-page-header__title">
+          <h1 class="page-title">${titleForRoute("plugins")}</h1>
+          <div class="page-subtitle">
+            ${subtitleForRoute("plugins")} ${renderLearnMoreLink(PLUGINS_DOCS_URL)}
+          </div>
         </div>
       </div>
       <div class="hub-page-header__tabs">

--- a/ui/src/styles/hub-tabs.css
+++ b/ui/src/styles/hub-tabs.css
@@ -146,3 +146,35 @@ wa-tab.hub-tab:focus-visible::part(base) {
     justify-self: center;
   }
 }
+
+.content-header.hub-page-header--stacked {
+  width: 100%;
+  max-width: 1120px;
+  margin-inline: auto;
+  padding-inline: var(--space-4);
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: var(--space-5);
+  max-height: none;
+}
+
+.hub-page-header__intro {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: var(--space-4);
+  width: 100%;
+  min-width: 0;
+}
+
+.hub-page-header--stacked + .settings-workspace {
+  margin-top: 0;
+}
+
+@media (max-width: 768px), (max-width: 932px) and (max-height: 500px) and (orientation: landscape) {
+  .content-header.hub-page-header--stacked {
+    padding-inline: var(--space-3);
+    gap: var(--space-4);
+  }
+}

--- a/ui/src/styles/hub-tabs.css
+++ b/ui/src/styles/hub-tabs.css
@@ -174,7 +174,12 @@ wa-tab.hub-tab:focus-visible::part(base) {
 
 @media (max-width: 768px), (max-width: 932px) and (max-height: 500px) and (orientation: landscape) {
   .content-header.hub-page-header--stacked {
-    padding-inline: var(--space-3);
     gap: var(--space-4);
+  }
+}
+
+@media (max-width: 640px) {
+  .content-header.hub-page-header--stacked {
+    padding-inline: var(--space-3);
   }
 }

--- a/ui/src/styles/plugins.css
+++ b/ui/src/styles/plugins.css
@@ -6,29 +6,6 @@
   margin: 0;
 }
 
-.content-header.hub-page-header.plugins-hub-header {
-  width: 100%;
-  max-width: 1120px;
-  margin-inline: auto;
-  padding-inline: var(--space-4);
-  display: flex;
-  flex-direction: column;
-  align-items: flex-start;
-  gap: var(--space-5);
-  max-height: none;
-}
-
-.plugins-hub-header + .settings-workspace {
-  /* The settings page already contributes the lower half of the tab rhythm. */
-  margin-top: 0;
-}
-
-@media (max-width: 400px) {
-  .content-header.hub-page-header.plugins-hub-header {
-    gap: var(--space-4);
-  }
-}
-
 /* ---------- toolbar ---------- */
 
 .plugins-toolbar {


### PR DESCRIPTION
## What Problem This Solves

The Sessions and Worktrees tabs sat beside the page title while the transcript controls and table used a narrower body column. That made the page hierarchy differ from the recently corrected Plugins hub and left the tab strip visibly detached from the content it controls.

## Why This Change Was Made

This follows the canonical layout established in #131239:

- stack hub tabs beneath the title row
- align the title, tabs, and body to the same 1120px content column
- keep optional header actions, such as Agent Scope, in the title row
- share the stacked-header variant with Plugins instead of duplicating page-specific CSS

The shared hub header owns this geometry. The Plugins-only structural rules are removed, while its existing appearance is preserved.

Production delta: +55/-33 (net +22). Test delta: +73/-35 (net +38). The production growth adds the reusable stacked-header owner and the title/action wrapper; it removes 23 lines of Plugins-only layout policy.

## User Impact

Sessions and Worktrees now use the same visual hierarchy as Plugins: title first, tabs directly below it, and page content aligned beneath. The layout remains aligned at desktop and mobile widths.

## Evidence

### Before / after

| Before | After |
| --- | --- |
| ![Sessions before](https://github.com/user-attachments/assets/0823b80c-8b3d-4967-8159-a5e68c08f9fc) | ![Sessions after with Agent Scope aligned at the far right](https://github.com/user-attachments/assets/5d6ac28a-fdb3-47c4-b4a8-c122cc21ae4d) |

Mobile after:

![Sessions mobile after](https://github.com/user-attachments/assets/415f01fb-fd79-4bc1-bcea-28691b1906b3)

### Geometry proof

Mocked-Gateway browser capture of the real Sessions and Worktrees routes:

- Sessions, 1440px: title x=305, tabs x=305, body x=305; tabs 20px below title
- Worktrees, 1440px: title x=305, tabs x=305, body x=305; tabs 20px below title
- Sessions, 390px: title x=16, tabs x=16, body x=16; tabs 16px below title
- The multi-agent route proof shows Agent Scope retained at the far-right edge of the title row.

The regression test failed before the implementation at 1280px because the tabs overlapped the title vertically (`-32.59px` separation), and at 820px because title and tabs differed by `311.02px` horizontally. It passes after the shared layout change.

The first shared breakpoint revision also failed at 700×800 and 800×480 because the header and wide body padding differed by 4px. The repaired responsive contract and added geometry cases now pass at both widths.

### Validation

- `pnpm --dir ui exec vitest run --config vitest.config.ts src/components/sessions-hub-header.browser.test.ts --reporter=verbose` — 5 passed (desktop, intermediate, short landscape, and mobile geometry)
- `OPENCLAW_CAPTURE_UI_PROOF=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/agent-page-scope.e2e.test.ts` — 6 passed; multi-agent Sessions proof captured
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/plugins-hub-navigation.e2e.test.ts` — 2 passed (desktop and narrow sibling proof)
- `pnpm test:changed` — 11,491 passed, 87 skipped
- `pnpm check:changed` — passed
- `pnpm ui:build` — passed, performance budgets verified
- `.agents/skills/autoreview/scripts/autoreview --mode local --stream-engine-output` — clean, no actionable findings
