### PR TITLE
fix(ui): show final replies after interim output

### DIFF
--- a/ui/src/e2e/dashboard-final-reply-recovery.e2e.test.ts
+++ b/ui/src/e2e/dashboard-final-reply-recovery.e2e.test.ts
@@ -17,7 +17,7 @@ function dashboardPath(): string {
 }
 
 suite.define(() => {
-  it("projects a durable reply when the dashboard terminal event has no message", async () => {
+  it("projects a distinct durable reply after interim text and a message-less terminal", async () => {
     const recordProof = process.env.OPENCLAW_UI_E2E_RECORD === "1";
     if (recordProof) {
       await mkdir(proofDir, { recursive: true });
@@ -63,6 +63,9 @@ suite.define(() => {
     try {
       await page.goto(new URL(dashboardPath(), suite.server.baseUrl).href);
       const prompt = "Why did Done appear without my reply?";
+      const interimText = "Checking the dashboard state.";
+      const updatedInterimText = "Still checking the dashboard state.";
+      const partialFinalText = "Drafting the durable dashboard reply.";
       const finalText = "The durable dashboard reply is visible after Done.";
       const composer = page.locator(".agent-chat__composer-combobox textarea");
       await composer.fill(prompt);
@@ -72,7 +75,36 @@ suite.define(() => {
       const runId = typeof params.idempotencyKey === "string" ? params.idempotencyKey : "";
       expect(runId).not.toBe("");
 
-      const persistedHistory = [
+      await gateway.emitGatewayEvent("chat", {
+        runId,
+        sessionKey,
+        seq: 1,
+        state: "delta",
+        deltaText: interimText,
+        message: {
+          role: "assistant",
+          phase: "commentary",
+          content: [{ type: "text", text: interimText }],
+          timestamp: 1,
+        },
+      });
+      await page.locator(".chat-thread-inner", { hasText: interimText }).waitFor();
+      await gateway.emitGatewayEvent("chat", {
+        runId,
+        sessionKey,
+        seq: 2,
+        state: "delta",
+        deltaText: partialFinalText,
+        message: {
+          role: "assistant",
+          phase: "final_answer",
+          content: [{ type: "text", text: partialFinalText }],
+          timestamp: 2,
+        },
+      });
+      await page.locator(".chat-thread-inner", { hasText: partialFinalText }).waitFor();
+
+      const persistedInterimHistory = [
         {
           role: "user",
           content: [{ type: "text", text: prompt }],
@@ -81,10 +113,31 @@ suite.define(() => {
         },
         {
           role: "assistant",
+          phase: "commentary",
+          // A stale snapshot can contain newer commentary with producer key
+          // order and metadata changes; it is still not the terminal reply.
+          content: [
+            { text: updatedInterimText, type: "text", cache_control: { type: "ephemeral" } },
+          ],
+          timestamp: 2,
+          __openclaw: { id: "dashboard-interim", runId, seq: 2 },
+        },
+        {
+          role: "assistant",
+          phase: "final_answer",
+          content: [{ text: partialFinalText, type: "text", cache_control: { type: "ephemeral" } }],
+          timestamp: 3,
+          __openclaw: { id: "dashboard-partial-final", runId, seq: 3 },
+        },
+      ];
+      const persistedHistory = [
+        ...persistedInterimHistory,
+        {
+          role: "assistant",
           content: [{ type: "text", text: finalText }],
           stopReason: "stop",
-          timestamp: 2,
-          __openclaw: { id: "dashboard-final", runId, seq: 2 },
+          timestamp: 4,
+          __openclaw: { id: "dashboard-final", runId, seq: 4 },
         },
       ];
       const historyCount = (await gateway.getRequests("chat.history")).length;
@@ -97,12 +150,12 @@ suite.define(() => {
 
       const staleRequest = await gateway.waitForRequest("chat.history", { after: historyCount });
       expect(staleRequest.params).toMatchObject({ sessionKey, limit: 100 });
-      // The real Gateway can publish the terminal event before the durable row
-      // is visible to chat.history. The first recovery snapshot is therefore
-      // stale; a bounded retry must pick up the later commit without reconnect.
+      // The first authoritative snapshot can promote the same interim text to
+      // a durable row before the distinct terminal reply is committed. That
+      // identity change is not a recovered final; retry until new content lands.
       await gateway.setHistoryMessages(persistedHistory);
       await gateway.resolveDeferred("chat.history", {
-        messages: [],
+        messages: persistedInterimHistory,
         sessionId: "control-ui-e2e-session",
         thinkingLevel: null,
       });

--- a/ui/src/e2e/dashboard-final-reply-recovery.e2e.test.ts
+++ b/ui/src/e2e/dashboard-final-reply-recovery.e2e.test.ts
@@ -66,6 +66,7 @@ suite.define(() => {
       const interimText = "Checking the dashboard state.";
       const updatedInterimText = "Still checking the dashboard state.";
       const partialFinalText = "Drafting the durable dashboard reply.";
+      const stalePartialFinalText = "Drafting more of the durable dashboard reply.";
       const finalText = "The durable dashboard reply is visible after Done.";
       const composer = page.locator(".agent-chat__composer-combobox textarea");
       await composer.fill(prompt);
@@ -125,7 +126,13 @@ suite.define(() => {
         {
           role: "assistant",
           phase: "final_answer",
-          content: [{ text: partialFinalText, type: "text", cache_control: { type: "ephemeral" } }],
+          content: [
+            {
+              text: stalePartialFinalText,
+              type: "text",
+              cache_control: { type: "ephemeral" },
+            },
+          ],
           timestamp: 3,
           __openclaw: { id: "dashboard-partial-final", runId, seq: 3 },
         },

--- a/ui/src/pages/chat/chat-state-events.ts
+++ b/ui/src/pages/chat/chat-state-events.ts
@@ -1,10 +1,5 @@
-import { readSessionMessageIdentity } from "@openclaw/gateway-client/browser";
 import { asNullableRecord } from "@openclaw/normalization-core/record-coerce";
 import type { SessionObserverDigest } from "../../../../packages/gateway-protocol/src/schema/sessions.js";
-import {
-  isToolCallContentType,
-  isToolResultContentType,
-} from "../../../../src/chat/tool-content.js";
 import type { GatewayEventFrame } from "../../api/gateway.ts";
 import { fireFirstReplyConfetti } from "../../components/confetti.ts";
 import { isGitHubPullRequestLink } from "../../components/github-link-target.ts";
@@ -45,8 +40,6 @@ import { refreshCurrentChatSessionList } from "./chat-session.ts";
 import type { ChatPageHost } from "./chat-state-host.ts";
 import { requestChatPageUpdate } from "./chat-state-render.ts";
 import { resolveChatAgentId, selectedChatSessionRow } from "./chat-state-route.ts";
-import { transcriptRunId } from "./chat-thread-run-identity.ts";
-import { safeNormalizeMessage } from "./chat-turn-boundary.ts";
 import { handleBackgroundTasksEvent } from "./components/chat-background-tasks.ts";
 import {
   refreshSessionWorkspace,
@@ -70,10 +63,12 @@ import {
 import { applySessionMessagePayload } from "./session-message-apply.ts";
 import { isSidebarSlotVisible } from "./sidebar-layout.ts";
 import { rememberAuthoritativeTerminal } from "./terminal-message-identity.ts";
+import { readTerminalReplyRecoveryState } from "./terminal-reply-recovery.ts";
 import { handleAgentEvent, handleSessionOperationEvent } from "./tool-stream.ts";
 
 const BRANCH_TOPOLOGY_REASONS = new Set(["rewind", "branch-switch", "fork", "reset", "new"]);
 const MISSING_TERMINAL_HISTORY_RETRY_DELAYS_MS = [100, 400, 1_500, 3_000] as const;
+const MAX_REMEMBERED_TERMINAL_RECOVERY_CLAIMS = 64;
 type ChatPanePresentation = () => boolean;
 
 function sessionMessageMatchesChat(
@@ -230,34 +225,6 @@ function replayPendingSessionMessageReload(
   return true;
 }
 
-function hasRecoveredTerminalReply(state: ChatPageHost, runId: string): boolean {
-  const scope = readChatSessionProjectionScope(state);
-  const projection = getChatSessionProjection(state, state.chatMessages, scope);
-  const message =
-    projection.runs[runId]?.message ??
-    projection.messages.findLast(
-      (candidate) =>
-        readSessionMessageIdentity(candidate)?.role === "assistant" &&
-        transcriptRunId(candidate) === runId,
-    );
-  const text = extractText(message);
-  if (
-    typeof text === "string" &&
-    text.trim().length > 0 &&
-    !isHiddenAssistantStreamText(text) &&
-    !shouldHideAssistantChatMessage(message)
-  ) {
-    return true;
-  }
-  if (shouldHideAssistantChatMessage(message)) {
-    return false;
-  }
-  return (safeNormalizeMessage(message)?.content ?? []).some((block) => {
-    const type = block.type;
-    return type !== "text" && !isToolCallContentType(type) && !isToolResultContentType(type);
-  });
-}
-
 type TerminalRecoveryOwnership = {
   sessionKey: string;
   agentId: string;
@@ -265,7 +232,71 @@ type TerminalRecoveryOwnership = {
   client: ChatPageHost["client"];
   connectionEpoch: number;
   runLifecycleGeneration: number;
+  initialTerminalReplySignatures: ReadonlySet<string>;
 };
+
+const terminalRecoveryClaimsByPane = new WeakMap<object, Map<string, ChatPageHost["client"]>>();
+
+function createTerminalRecoveryOwnership(
+  state: ChatPageHost,
+  payload: ChatEventPayload,
+): TerminalRecoveryOwnership | null {
+  const runId = payload.runId;
+  if (!runId) {
+    return null;
+  }
+  return {
+    sessionKey: payload.sessionKey,
+    agentId: resolveChatAgentId(state),
+    runId,
+    client: state.client,
+    connectionEpoch: state.connectionEpoch,
+    runLifecycleGeneration: state.chatRunLifecycleGeneration ?? 0,
+    initialTerminalReplySignatures: readTerminalReplyRecoveryState(state, runId)
+      .terminalReplySignatures,
+  };
+}
+
+function claimTerminalRecovery(state: ChatPageHost, ownership: TerminalRecoveryOwnership): boolean {
+  let claims = terminalRecoveryClaimsByPane.get(state);
+  if (!claims) {
+    claims = new Map();
+    terminalRecoveryClaimsByPane.set(state, claims);
+  }
+  const key = [
+    ownership.connectionEpoch,
+    ownership.runLifecycleGeneration,
+    ownership.agentId,
+    ownership.sessionKey,
+    ownership.runId,
+  ].join("\0");
+  if (claims.has(key) && claims.get(key) === ownership.client) {
+    return false;
+  }
+  claims.delete(key);
+  claims.set(key, ownership.client);
+  while (claims.size > MAX_REMEMBERED_TERMINAL_RECOVERY_CLAIMS) {
+    const oldest = claims.keys().next().value;
+    if (typeof oldest !== "string") {
+      break;
+    }
+    claims.delete(oldest);
+  }
+  return true;
+}
+
+function hasRecoveredTerminalReply(
+  state: ChatPageHost,
+  ownership: TerminalRecoveryOwnership,
+): boolean {
+  const recovery = readTerminalReplyRecoveryState(state, ownership.runId);
+  return (
+    recovery.acceptedFinal ||
+    [...recovery.terminalReplySignatures].some(
+      (signature) => !ownership.initialTerminalReplySignatures.has(signature),
+    )
+  );
+}
 
 function terminalRecoveryStillOwned(
   state: ChatPageHost,
@@ -279,28 +310,15 @@ function terminalRecoveryStillOwned(
     resolveChatAgentId(state) === ownership.agentId &&
     (state.chatRunId === null || state.chatRunId === ownership.runId) &&
     (state.chatRunLifecycleGeneration ?? 0) === ownership.runLifecycleGeneration &&
-    !hasRecoveredTerminalReply(state, ownership.runId)
+    !hasRecoveredTerminalReply(state, ownership)
   );
 }
 
 async function recoverMissingTerminalReply(
   state: ChatPageHost,
-  payload: ChatEventPayload,
+  ownership: TerminalRecoveryOwnership,
   presentation: ChatPanePresentation,
 ): Promise<void> {
-  const sessionKey = payload.sessionKey;
-  const runId = payload.runId;
-  if (!runId) {
-    return;
-  }
-  const ownership: TerminalRecoveryOwnership = {
-    sessionKey,
-    agentId: resolveChatAgentId(state),
-    runId,
-    client: state.client,
-    connectionEpoch: state.connectionEpoch,
-    runLifecycleGeneration: state.chatRunLifecycleGeneration ?? 0,
-  };
   for (let attempt = 0; ; attempt += 1) {
     if (!terminalRecoveryStillOwned(state, ownership)) {
       return;
@@ -547,10 +565,6 @@ export function handlePageGatewayEvent(
         ? payload.runId
         : null;
     const recoveryScope = recoveryRunId ? readChatSessionProjectionScope(state) : null;
-    const projectedRunBeforeEvent =
-      recoveryRunId && recoveryScope
-        ? getChatSessionProjection(state, state.chatMessages, recoveryScope).runs[recoveryRunId]
-        : undefined;
     if (
       payload?.state === "delta" &&
       typeof payload.runId === "string" &&
@@ -605,17 +619,26 @@ export function handlePageGatewayEvent(
     const shouldRecoverMissingTerminal = Boolean(
       recoveryRunId &&
       recoveryScope &&
-      (projectedRunBeforeEvent === undefined || projectedRunBeforeEvent.status === "streaming") &&
       getChatSessionProjection(state, state.chatMessages, recoveryScope).runs[recoveryRunId]
         ?.status === "completed",
     );
-    if (shouldRecoverMissingTerminal && payload) {
+    const recoveryOwnership =
+      shouldRecoverMissingTerminal && payload
+        ? createTerminalRecoveryOwnership(state, payload)
+        : null;
+    const recoveryClaimed = recoveryOwnership
+      ? claimTerminalRecovery(state, recoveryOwnership)
+      : false;
+    if (recoveryOwnership && recoveryClaimed) {
       state.pendingSessionMessageReloadSessionKey = null;
-      // Only the first owned completion can recover history. Replayed, yielded,
-      // or background-run terminals must not repeat I/O or disturb the foreground pane.
+      // The first owned message-less terminal recovers history even when an
+      // earlier snapshot already marked the run complete. Replays, yielded, or
+      // background-run terminals must not repeat I/O or disturb the foreground pane.
       // Persistence can trail the terminal event, so retry bounded authoritative
       // snapshots until the completed run's reply becomes visible.
-      void recoverMissingTerminalReply(state, payload, isPresented).catch(() => undefined);
+      void recoverMissingTerminalReply(state, recoveryOwnership, isPresented).catch(
+        () => undefined,
+      );
     } else {
       replayPendingSessionMessageReload(state, payload, isPresented);
     }

--- a/ui/src/pages/chat/chat-state.test.ts
+++ b/ui/src/pages/chat/chat-state.test.ts
@@ -844,6 +844,54 @@ describe("canonical session message recovery", () => {
     },
   );
 
+  it("recovers once when history completed the run before its message-less terminal arrives", async () => {
+    const runId = "run-completed-by-history-before-terminal";
+    const prompt = {
+      role: "user",
+      content: [{ type: "text", text: "Finish after the tool call" }],
+      __openclaw: { id: "prompt-1", idempotencyKey: `${runId}:user`, seq: 1 },
+    };
+    const persistedReply = {
+      role: "assistant",
+      content: [{ type: "text", text: "The durable final arrived after the snapshot." }],
+      stopReason: "stop",
+      __openclaw: { id: "reply-1", runId, seq: 2 },
+    };
+    const request = vi.fn().mockResolvedValue({
+      messages: [prompt, persistedReply],
+      sessionId: "selected-session",
+      sessionInfo: {
+        key: "agent:main:main",
+        kind: "direct",
+        updatedAt: 2,
+        hasActiveRun: false,
+        activeRunIds: [],
+        status: "done",
+      },
+    });
+    const { state } = createSessionEventState({
+      chatMessages: [prompt],
+      chatHistoryPagination: { hasMore: false },
+      chatRunId: runId,
+      client: { request } as unknown as GatewayBrowserClient,
+    });
+    reduceChatSessionProjection(state, { type: "runTerminal", runId, status: "completed" });
+
+    const terminalEvent = {
+      type: "event",
+      event: "chat",
+      payload: { sessionKey: state.sessionKey, runId, state: "final" },
+    } satisfies Parameters<typeof handlePageGatewayEvent>[1];
+    handlePageGatewayEvent(state, terminalEvent);
+
+    await vi.waitFor(() => expect(request).toHaveBeenCalledTimes(1));
+    await vi.waitFor(() => expect(state.chatMessages).toContainEqual(persistedReply));
+
+    request.mockClear();
+    handlePageGatewayEvent(state, terminalEvent);
+    expect(request).not.toHaveBeenCalled();
+  });
+
   it("stops terminal recovery after a media-only reply becomes durable", async () => {
     vi.useFakeTimers();
     try {
@@ -889,6 +937,60 @@ describe("canonical session message recovery", () => {
       await vi.advanceTimersByTimeAsync(5_000);
       expect(request).toHaveBeenCalledTimes(1);
       expect(state.chatMessages).toContainEqual(persistedReply);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("bounds terminal recovery when no durable reply appears", async () => {
+    vi.useFakeTimers();
+    try {
+      const runId = "run-without-durable-reply";
+      const prompt = {
+        role: "user",
+        content: [{ type: "text", text: "Finish without persisting a reply" }],
+        __openclaw: { id: "prompt-1", idempotencyKey: `${runId}:user`, seq: 1 },
+      };
+      const request = vi.fn().mockResolvedValue({
+        messages: [prompt],
+        sessionId: "selected-session",
+        sessionInfo: {
+          key: "agent:main:main",
+          kind: "direct",
+          updatedAt: 2,
+          hasActiveRun: false,
+          activeRunIds: [],
+          status: "done",
+        },
+      });
+      const { state } = createSessionEventState({
+        chatMessages: [prompt],
+        chatHistoryPagination: { hasMore: false },
+        chatRunId: runId,
+        client: { request } as unknown as GatewayBrowserClient,
+      });
+
+      handlePageGatewayEvent(state, {
+        type: "event",
+        event: "chat",
+        payload: { sessionKey: state.sessionKey, runId, state: "final" },
+      });
+
+      await vi.advanceTimersByTimeAsync(5_000);
+      expect(request).toHaveBeenCalledTimes(5);
+      await vi.advanceTimersByTimeAsync(60_000);
+      expect(request).toHaveBeenCalledTimes(5);
+      expect(renderedTranscript(state)).toEqual([
+        { role: "user", text: "Finish without persisting a reply" },
+      ]);
+
+      handlePageGatewayEvent(state, {
+        type: "event",
+        event: "chat",
+        payload: { sessionKey: state.sessionKey, runId, state: "final" },
+      });
+      await vi.advanceTimersByTimeAsync(5_000);
+      expect(request).toHaveBeenCalledTimes(5);
     } finally {
       vi.useRealTimers();
     }
@@ -1122,6 +1224,7 @@ describe("canonical session message recovery", () => {
       const persistedReply = {
         role: "assistant",
         content: [{ type: "text", text: "The current reply is now durable." }],
+        stopReason: "stop",
         __openclaw: { id: "current-reply", runId, seq: 3 },
       };
       const sessionInfo = {

--- a/ui/src/pages/chat/terminal-reply-recovery.ts
+++ b/ui/src/pages/chat/terminal-reply-recovery.ts
@@ -23,9 +23,7 @@ function terminalReplyDisplaySignature(message: unknown): string | null {
   const metadata = asNullableRecord(record?.["__openclaw"]);
   if (
     phase === "commentary" ||
-    (phase !== "final_answer" &&
-      (!stopReason || stopReason === "tooluse") &&
-      metadata?.runTerminal !== true)
+    ((!stopReason || stopReason === "tooluse") && metadata?.runTerminal !== true)
   ) {
     return null;
   }

--- a/ui/src/pages/chat/terminal-reply-recovery.ts
+++ b/ui/src/pages/chat/terminal-reply-recovery.ts
@@ -1,0 +1,82 @@
+import { readSessionMessageIdentity } from "@openclaw/gateway-client/browser";
+import { asNullableRecord } from "@openclaw/normalization-core/record-coerce";
+import {
+  isToolCallContentType,
+  isToolResultContentType,
+} from "../../../../src/chat/tool-content.js";
+import { resolveAssistantMessagePhase } from "../../../../src/shared/chat-message-content.js";
+import { extractText } from "../../lib/chat/message-extract.ts";
+import { isHiddenAssistantStreamText, shouldHideAssistantChatMessage } from "./chat-history.ts";
+import type { ChatPageHost } from "./chat-state-host.ts";
+import { transcriptRunId } from "./chat-thread-run-identity.ts";
+import { safeNormalizeMessage } from "./chat-turn-boundary.ts";
+import { getChatSessionProjection, readChatSessionProjectionScope } from "./history-merge.ts";
+
+function terminalReplyDisplaySignature(message: unknown): string | null {
+  if (shouldHideAssistantChatMessage(message)) {
+    return null;
+  }
+  const record = asNullableRecord(message);
+  const phase = resolveAssistantMessagePhase(message);
+  const stopReason =
+    typeof record?.stopReason === "string" ? record.stopReason.trim().toLowerCase() : "";
+  const metadata = asNullableRecord(record?.["__openclaw"]);
+  if (
+    phase === "commentary" ||
+    (phase !== "final_answer" &&
+      (!stopReason || stopReason === "tooluse") &&
+      metadata?.runTerminal !== true)
+  ) {
+    return null;
+  }
+  const text = extractText(message);
+  if (typeof text === "string" && isHiddenAssistantStreamText(text)) {
+    return null;
+  }
+  const content = (safeNormalizeMessage(message)?.content ?? []).filter((block) => {
+    if (block.type === "text") {
+      return typeof block.text === "string" && block.text.trim().length > 0;
+    }
+    return !isToolCallContentType(block.type) && !isToolResultContentType(block.type);
+  });
+  if (content.length === 0) {
+    return null;
+  }
+  try {
+    return JSON.stringify(content) ?? null;
+  } catch {
+    return null;
+  }
+}
+
+export function readTerminalReplyRecoveryState(
+  state: ChatPageHost,
+  runId: string,
+): {
+  acceptedFinal: boolean;
+  terminalReplySignatures: ReadonlySet<string>;
+} {
+  const scope = readChatSessionProjectionScope(state);
+  const projection = getChatSessionProjection(state, state.chatMessages, scope);
+  const run = projection.runs[runId];
+  const candidates: unknown[] = run?.message === undefined ? [] : [run.message];
+  for (const message of projection.messages) {
+    if (
+      readSessionMessageIdentity(message)?.role === "assistant" &&
+      transcriptRunId(message) === runId
+    ) {
+      candidates.push(message);
+    }
+  }
+  const terminalReplySignatures = new Set<string>();
+  for (const message of candidates) {
+    const signature = terminalReplyDisplaySignature(message);
+    if (signature) {
+      terminalReplySignatures.add(signature);
+    }
+  }
+  return {
+    acceptedFinal: (run?.acceptedFinalMessageIdentities?.length ?? 0) > 0,
+    terminalReplySignatures,
+  };
+}


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Control UI users could see a turn finish after interim text and tool activity without seeing the agent's final reply. Reloading the page revealed the reply because it was already present in durable history.

## Why This Change Was Made

The terminal recovery path treated any visible assistant content from the run as proof that the final reply had been recovered. It also required the terminal event itself to move the projected run from streaming to completed. Those assumptions fail when retained commentary is visible or a pre-terminal history response has already marked the run complete.

This change gives the first owned message-less terminal one bounded recovery claim per pane, connection, lifecycle, agent, session, run, and client. Recovery stops only after the UI accepts a live final or authoritative history adds new terminal-semantic content. Commentary and tool-only rows do not count as terminal replies.

Production LOC: +162/-59, net +103. Tests: +171/-8. The production growth records the missing recovery ownership fact and centralizes terminal-semantic classification; removing either restores the replay or interim-as-final failure.

## User Impact

The final answer now appears without a reload when a Gateway terminal event omits its message after interim output or tool activity. Duplicate terminal events still do not repeat recovery work, and reconnect, replacement-run, session, agent, and client ownership fences remain intact.

## Evidence

### Real Gateway and browser proof

The same deterministic source Gateway fixture emitted interim text, one harmless read-only tool, and a distinct final answer. A WebSocket proxy removed only the live final content so the final could be recovered solely from a post-terminal `chat.history` response.

- Unmodified base `64f9e1302eda8e99479099a111ec9bb00601928b`: final absent before reload; `historyRequestsAfterTerminal: 0`.
- Patched candidate: one final before reload, one final after reload, `historyRequestsAfterTerminal: 1`, and `pageErrors: []`.
- Source-blind behavior validation passed the same observable contract.
- [Red and green recordings, screenshots, checksums, and the exact fixture result](https://github.com/openclaw/openclaw/pull/132197#issuecomment-5458775070) are attached in the evidence comment.

A review-discovered adjacent ordering was also reproduced before correction: history could expose a newer `final_answer` partial before the durable final. The original candidate stopped on that changed text. The corrected candidate continued polling until terminal evidence arrived, with the same five-attempt bound and ownership fences. The exact browser E2E and a source-blind contract both passed.

Subsequent `main` movement was inspected for impact. It did not touch terminal recovery, accepted-final ownership, chat event routing, or this fixture. Gateway ACP completion changes were checked directly and preserve the terminal-evidence contract used here.

### Focused gates

- `chat-state.test.ts`: 97/97
- `dashboard-final-reply-recovery.e2e.test.ts`: 1/1 for both the original retained-interim ordering and the newer-stale-partial ordering
- `pnpm tsgo:ui`
- `pnpm ui:build`
- oxfmt, oxlint, max-lines check, and `git diff --check`
- final exact-head autoreview: clean, correctness 0.98, no accepted or actionable findings

### Dependency contract

Direct Codex source inspection confirms that output-text deltas and `response.completed` are separate events. The UI therefore cannot use earlier visible delta/commentary text as proof that terminal content arrived:

- [`codex-rs/codex-api/src/sse/responses.rs:263-278`](https://github.com/openai/codex/blob/cdc1d592df7f066c141025cc8ae80bb3202580b6/codex-rs/codex-api/src/sse/responses.rs#L263-L278)
- [`codex-rs/codex-api/src/sse/responses.rs:358-366`](https://github.com/openai/codex/blob/cdc1d592df7f066c141025cc8ae80bb3202580b6/codex-rs/codex-api/src/sse/responses.rs#L358-L366)
- [`codex-rs/docs/protocol_v1.md:35-45`](https://github.com/openai/codex/blob/cdc1d592df7f066c141025cc8ae80bb3202580b6/codex-rs/docs/protocol_v1.md#L35-L45)

### Provenance

The transition-only recovery gate came from #130417, authored and merged by @fuller-stack-dev on 2026-08-26. The broad visible-content terminal check came from #131174, authored by @roboclaw-bot and merged by @fuller-stack-dev on 2026-08-28. Their interaction made this ordering reachable; neither prior fix covered retained interim content plus a pre-terminal completed history projection.
