### PR TITLE
test(skills): use platform-safe symlink type in workspace-load fixtures

### DIFF
--- a/src/skills/loading/plugin-skills.test.ts
+++ b/src/skills/loading/plugin-skills.test.ts
@@ -57,6 +57,7 @@ let resolvePluginSkillRoots: typeof import("./plugin-skills.js").resolvePluginSk
 let resolvePluginSkillRootsFromMetadata: typeof import("./plugin-skills.js").resolvePluginSkillRootsFromMetadata;
 
 const tempDirs = createTrackedTempDirs();
+const directorySymlinkType = process.platform === "win32" ? "junction" : "dir";
 
 async function expectPathMissing(targetPath: string): Promise<void> {
   try {
@@ -472,11 +473,7 @@ describe("resolvePluginSkillRoots", () => {
     const { workspaceDir, pluginRoot, outsideSkills } = await setupPluginOutsideSkills();
     const linkPath = path.join(pluginRoot, "skills-link");
     await fs.mkdir(outsideSkills, { recursive: true });
-    await fs.symlink(
-      outsideSkills,
-      linkPath,
-      process.platform === "win32" ? ("junction" as const) : ("dir" as const),
-    );
+    await fs.symlink(outsideSkills, linkPath, directorySymlinkType);
 
     hoisted.loadPluginManifestRegistryForInstalledIndex.mockReturnValue(
       createSinglePluginRegistry({
@@ -505,7 +502,7 @@ describe("resolvePluginSkillRoots", () => {
     const staleRoot = await tempDirs.make("stale-plugin-skills-");
     const staleSkill = path.join(staleRoot, "stale-skill");
     await fs.mkdir(staleSkill, { recursive: true });
-    fsSync.symlinkSync(staleSkill, path.join(pluginSkillsDir, "stale-skill"), "dir");
+    fsSync.symlinkSync(staleSkill, path.join(pluginSkillsDir, "stale-skill"), directorySymlinkType);
 
     hoisted.loadPluginManifestRegistryForInstalledIndex.mockReturnValue({
       diagnostics: [],
@@ -527,7 +524,7 @@ describe("resolvePluginSkillRoots", () => {
     const staleRoot = await tempDirs.make("stale-plugin-skills-");
     const staleSkill = path.join(staleRoot, "stale-skill");
     await fs.mkdir(staleSkill, { recursive: true });
-    fsSync.symlinkSync(staleSkill, path.join(pluginSkillsDir, "stale-skill"), "dir");
+    fsSync.symlinkSync(staleSkill, path.join(pluginSkillsDir, "stale-skill"), directorySymlinkType);
 
     const roots = resolvePluginSkillRoots({
       workspaceDir: undefined,
@@ -735,7 +732,7 @@ describe("publishPluginSkills", () => {
     const dir1 = await writeSkillDir(skillParent1, "my-skill", "old");
     const dir2 = await writeSkillDir(skillParent2, "my-skill", "new");
 
-    fsSync.symlinkSync(dir1, path.join(managedDir, "my-skill"), "dir");
+    fsSync.symlinkSync(dir1, path.join(managedDir, "my-skill"), directorySymlinkType);
 
     publishPluginSkills([dir2], { pluginSkillsDir: managedDir });
 
@@ -751,7 +748,7 @@ describe("publishPluginSkills", () => {
     const currentDir = await writeSkillDir(currentParent, "my-skill", "new");
     const linkPath = path.join(managedDir, "my-skill");
 
-    fsSync.symlinkSync(staleDir, linkPath, "dir");
+    fsSync.symlinkSync(staleDir, linkPath, directorySymlinkType);
     await fs.rm(staleParent, { recursive: true, force: true });
 
     publishPluginSkills([currentDir], { pluginSkillsDir: managedDir });
@@ -782,7 +779,7 @@ describe("publishPluginSkills", () => {
     const dir = await writeSkillDir(skillParent, "current-skill");
     const staleDir = await writeSkillDir(skillParent, "stale-skill");
 
-    fsSync.symlinkSync(staleDir, path.join(managedDir, "stale-skill"), "dir");
+    fsSync.symlinkSync(staleDir, path.join(managedDir, "stale-skill"), directorySymlinkType);
 
     publishPluginSkills([dir], { pluginSkillsDir: managedDir });
 
@@ -814,7 +811,7 @@ describe("publishPluginSkills", () => {
     const nonexistentDir = path.join(skillParent, "nonexistent");
 
     // Create a symlink to a nonexistent directory.
-    fsSync.symlinkSync(nonexistentDir, path.join(managedDir, "broken-skill"), "dir");
+    fsSync.symlinkSync(nonexistentDir, path.join(managedDir, "broken-skill"), directorySymlinkType);
 
     publishPluginSkills([dir], { pluginSkillsDir: managedDir });
 

--- a/src/skills/loading/workspace-skill-snapshot.test.ts
+++ b/src/skills/loading/workspace-skill-snapshot.test.ts
@@ -22,6 +22,7 @@ vi.mock("./plugin-skills.js", () => ({
 }));
 
 const fixtureSuite = createFixtureSuite("openclaw-skills-snapshot-suite-");
+const directorySymlinkType = process.platform === "win32" ? "junction" : "dir";
 let truncationWorkspaceTemplateDir = "";
 let tempHome: TempHomeEnv | null = null;
 let skillsHomeEnv: SkillsHomeEnvSnapshot | null = null;
@@ -335,7 +336,11 @@ describe("buildSkillSnapshot", () => {
       description: "Personal compatibility skill",
     });
     await fs.mkdir(path.join(home, ".agents"), { recursive: true });
-    await fs.symlink(compatibilitySkillsDir, path.join(home, ".agents", "skills"), "dir");
+    await fs.symlink(
+      compatibilitySkillsDir,
+      path.join(home, ".agents", "skills"),
+      directorySymlinkType,
+    );
     const buildHomeSnapshot = () =>
       buildSkillSnapshot(workspaceDir, {
         managedSkillsDir: path.join(workspaceDir, ".managed"),


### PR DESCRIPTION
## What this fixes

Directory-link fixtures in the plugin-skill and compatibility-snapshot tests used Windows symbolic links. Non-elevated Windows runners without Developer Mode reject those links with `EPERM`, even though production publishes these directory links as junctions.

Use a single platform-specific fixture type in each affected suite: `junction` on Windows and `dir` elsewhere. This covers all seven plugin-skill fixtures plus the sibling compatibility-snapshot fixture.

## Evidence

Non-elevated Windows 11 VM, exact pre-fix parent:

- 7 failures with `EPERM: operation not permitted, symlink`
- failures included `plugin-skills.test.ts` and `workspace-skill-snapshot.test.ts`

Same VM and checkout with this patch overlaid:

- 2 test files passed
- 46 tests passed, 1 intentional platform skip

Current PR head on macOS:

- 2 test files passed
- 47 tests passed

## Scope

Test fixtures only. Production code, runtime behavior, dependencies, and configuration are unchanged.
