### PR TITLE
fix(ci): keep slow startup from failing cancellation tests

### DIFF
--- a/test/scripts/ci-platform-checkout.test.ts
+++ b/test/scripts/ci-platform-checkout.test.ts
@@ -16,6 +16,7 @@ type Report = {
   boundaries: Boundary[];
   readyAttempts: number[];
   cleanupRemaining: ProcessRecord[];
+  ownedProcesses: ProcessRecord[];
   commands: { cwd: string; args: string[] }[];
   output: string;
 };
@@ -84,6 +85,10 @@ it.each([
     const root = realpathSync(mkdtempSync(path.join(tmpdir(), "ci platform checkout ")));
     const workspace = path.join(root, "workspace");
     mkdirSync(workspace);
+    if (scenario.startsWith("cancel-")) {
+      // Inject slow startup before fetch, beyond the former cancellation readiness deadline.
+      writeFileSync(path.join(root, "fixture-config.json"), JSON.stringify({ initDelayMs: 4_100 }));
+    }
     if (linux) {
       writeFileSync(path.join(workspace, ".previous-checkout"), "stale\n");
     }
@@ -171,6 +176,23 @@ def run_git(`,
       expect(report.output.includes("refusing reuse or retry")).toBe(
         scenario === "cleanup-failure",
       );
+      if (scenario.startsWith("cancel-")) {
+        const alive = report.ownedProcesses.filter((entry) => entry.attempt === 1);
+        expect(alive.map((entry) => entry.role).toSorted()).toEqual([
+          "child",
+          "grandchild",
+          "parent",
+        ]);
+        const owner = expectDefined(
+          report.ownedProcesses.find((entry) => entry.role === "shell"),
+          "workflow owner",
+        );
+        expect(owner.pid).toBeGreaterThan(1);
+        const signal = scenario.slice("cancel-".length);
+        expect(report.output).toContain(
+          `cancellation: ${JSON.stringify({ signal, owner: owner.pid, alive })}\n`,
+        );
+      }
       if (code === 0) {
         const fetches = report.commands.filter(({ args }) => args.includes("fetch"));
         const candidateFetch = expectDefined(fetches[0], "candidate fetch");

--- a/test/scripts/fixtures/ci-platform-checkout.mjs
+++ b/test/scripts/fixtures/ci-platform-checkout.mjs
@@ -27,9 +27,11 @@ function record(pid, role, attempt = 0) {
 }
 
 function records() {
+  // Keep producer observations and shutdown reports in the same order.
   return fs
     .readdirSync(recordsDir)
     .filter((file) => file.endsWith(".json"))
+    .toSorted()
     .map((file) => JSON.parse(fs.readFileSync(path.join(recordsDir, file), "utf8")));
 }
 

--- a/test/scripts/fixtures/ci-platform-checkout.mjs
+++ b/test/scripts/fixtures/ci-platform-checkout.mjs
@@ -157,6 +157,10 @@ async function command() {
   const operation = args.shift();
   if (operation === "init") {
     boundary("init");
+    const config = path.join(root, "fixture-config.json");
+    if (fs.existsSync(config)) {
+      await delay(JSON.parse(fs.readFileSync(config, "utf8")).initDelayMs);
+    }
     fs.mkdirSync(insideWorkspace(args[0]), { recursive: true });
     if (linux && cwd === workspace) {
       if (fs.readdirSync(workspace).length !== 0) {
@@ -172,6 +176,26 @@ async function command() {
     record(process.pid, "parent", attempt);
     launch("child", attempt);
     await until(() => fs.existsSync(path.join(root, `ready-${attempt}.json`)), "tree readiness");
+    if (scenario.startsWith("cancel-")) {
+      const owned = records();
+      const alive = owned.filter((entry) => entry.attempt === attempt && isPidAlive(entry.pid));
+      if (
+        !["parent", "child", "grandchild"].every((role) =>
+          alive.some((entry) => entry.role === role),
+        )
+      ) {
+        throw new Error("Cancellation tree is no longer alive");
+      }
+      const owner = owned.find((entry) => entry.role === "shell");
+      // Both shells exec their replacements. Validate the current Python parent,
+      // never an orphan's new parent or the Git group, before sending cancellation.
+      if (!owner || owner.pid <= 1 || process.ppid !== owner.pid) {
+        throw new Error("Cancellation owner is no longer the registered workflow parent");
+      }
+      const signal = scenario.slice("cancel-".length);
+      fs.writeSync(1, `cancellation: ${JSON.stringify({ signal, owner: owner.pid, alive })}\n`);
+      process.kill(owner.pid, signal);
+    }
     if (scenario === "early-leader-exit") {
       process.exit(0);
     }
@@ -402,11 +426,6 @@ async function supervise() {
       record(shell.pid, "shell");
     }
     const exited = once(shell, "exit");
-    if (scenario.startsWith("cancel-")) {
-      await until(() => fs.existsSync(path.join(root, "ready-1.json")), "cancellation readiness");
-      // exec replaces Bash on POSIX: this is the owner, not the Git group.
-      shell.kill(scenario.slice("cancel-".length));
-    }
     const [code] = await exited;
     report.code = code;
     boundary("exit");

--- a/test/scripts/fixtures/ci-platform-checkout.mjs
+++ b/test/scripts/fixtures/ci-platform-checkout.mjs
@@ -179,8 +179,8 @@ async function command() {
     launch("child", attempt);
     await until(() => fs.existsSync(path.join(root, `ready-${attempt}.json`)), "tree readiness");
     if (scenario.startsWith("cancel-")) {
-      const owned = records();
-      const alive = owned.filter((entry) => entry.attempt === attempt && isPidAlive(entry.pid));
+      const owned = liveRecords();
+      const alive = owned.filter((entry) => entry.attempt === attempt);
       if (
         !["parent", "child", "grandchild"].every((role) =>
           alive.some((entry) => entry.role === role),
@@ -221,7 +221,7 @@ async function command() {
     }
     // Expire the two-second fetch budget only after the full tree is ready.
     // Immutable ticks avoid replacing a clock file held open by Windows readers.
-    // Cancellation scenarios instead wait for the supervisor's actual signal.
+    // Cancellation scenarios signal from the ready fetch without advancing this clock.
     if (!scenario.startsWith("cancel-")) {
       publish(`fetch-tick-${attempt}.json`, attempt);
     }


### PR DESCRIPTION
Related: #132105 (shared checkout process ownership fixture).
Integrated with #132204 (the separately landed fetch-clock and macOS terminated-group cleanup repair, which closed #132184 and #132194).

<details>
<summary>Additional instructions</summary>

Maintainer-requested, AI-assisted repair on an editable main-repository branch.

</details>

## What Problem This Solves

Resolves a problem where the CI checkout ownership tests fail with `Timed out waiting for cancellation readiness` during slow process startup, before the intended cancellation is sent. Platform-policy SIGTERM and SIGHUP failures were observed in an original-order 20-case run concurrent with changed checks, with empty boundary and final cleanup survivor lists.

This cancellation-startup defect is distinct from the fetch-clock recovery race and terminated-group cleanup work that landed separately in #132204. It does not retroactively attribute the original uninstrumented `PermissionError` incident.

## Why This Change Was Made

The supervisor's four-second cancellation wait started immediately after shell launch, so Python and Git init/config/remote startup consumed the budget before the fetch tree existed. The fake fetch already owns tree readiness. After the grandchild publishes readiness, it now takes one canonical `liveRecords()` snapshot, verifies that parent, child, and grandchild are active, checks its current parent against the registered positive workflow-owner PID, records the observation synchronously, and signals that owner. The redundant supervisor wait is removed.

Both bootstrap shells use `exec`, preserving the registered PID. Cancellation still targets the workflow's Python owner, never the Git group directly. The record list is explicitly sorted at its shared producer, retaining the exact observation assertion without relying on directory enumeration order. No additional production workflow change, deadline increase, new supervisor, OS gate, or test-only production hook is added.

When #132204 landed during native preparation, merging was held despite the earlier green CI. The repair was rebased onto its exact commit `ad6739064efa23cdc9666eb05208a6e5cf0658cf`, and cancellation was aligned with its new canonical live-process census instead of retaining a separate PID-existence filter. Main's clock, census, POSIX contract test, and production owner remain unchanged. The stale clock comment was corrected to identify the ready fetch as the cancellation producer.

## User Impact

No product-runtime or operator-configuration change from this PR. Maintainers can exercise cancellation after slow checkout setup without an unrelated startup stopwatch failing the fixture. Existing cleanup, fixture, join, test, and orphan ceilings remain unchanged.

Relative to the integrated main base: production **+0/-0**; tests **+22/-0**; fixture support **+27/-6**; combined test/support net **+43**.

## Evidence

The existing cancellation cases inject a 4,100 ms fake Git-init delay, before fetch starts. All original twenty cases and assertions stay in their original order. The current file additionally retains main's appended POSIX process-state contract.

**Final integrated proof, macOS / Node 24.20.0:**

- Exact-base fixture plus only the init-delay fault: **17 passed / 4 failed** out of 21. Exactly the four original cancellation cases failed with cancellation-readiness timeout, null owner exit code, and empty readiness. The additional POSIX contract passed.
- Final combined repair: **21/21 passed in 126.21 s**, including the original twenty and the unchanged POSIX contract. Cancellation results were **143/130/129/143**.
- Every one of the forty matrix reports across these red/green runs had empty active-boundary and final cleanup survivor lists; every sentinel remained alive. No retry or unrelated PID/cleanup failure was needed.
- Changed checks passed, including formatting, root test types, scoped lint, and classified guards. The production workflow is byte-identical to the integrated base.

```bash
node scripts/run-vitest.mjs test/scripts/ci-platform-checkout.test.ts --reporter=verbose
```

```bash
node scripts/check-changed.mjs -- test/scripts/ci-platform-checkout.test.ts test/scripts/fixtures/ci-platform-checkout.mjs
```

`git diff --check` passed. Fresh isolated Codex autoreview covered the full integrated PR candidate against the new main base and returned scoped-clean at P0; no broader-priority automated review is claimed.

**Earlier independent proof:** before companion integration, the original startup fault produced 16 passes / four intended failures, followed by 20/20 passing runs on Node 24 and 26. A temporary logical-clock composition also passed all twenty concurrently with changed checks. For ClawSweeper's ordering follow-up, deliberately reversing enumeration only in the supervisor produced four exact-log failures before canonicalization, then 20/20 with the sort and fault retained and 20/20 after removing the fault. This is injected normalization proof, not naturally observed macOS enumeration instability: inspected Node 24 POSIX libuv already sorts names internally. The fixture now explicitly owns that ordering.

**CI history:** [run 33220860121](https://github.com/openclaw/openclaw/actions/runs/33220860121) failed only the unrelated UI compiler-shard overflow (724 roots versus the unchanged 720 bound) and its aggregate gate. Main's [#132193 shard split](https://github.com/openclaw/openclaw/pull/132193) resolved it; no UI config or bound was changed here. [Run 33222509910](https://github.com/openclaw/openclaw/actions/runs/33222509910) subsequently passed on the pre-integration head. That older green run is not substituted for the integrated head `9a4ba8366d7906cdcbc879f8163a2b3d6613b6e4`. [Exact-head CI run 33224945084](https://github.com/openclaw/openclaw/actions/runs/33224945084) completed **SUCCESS** on that head (attempt 1), including the required [openclaw/ci-gate](https://github.com/openclaw/openclaw/actions/runs/33224945084/job/99027786146). The maintainer has approved the integrated source; fresh native prepare/merge gates and the final check for new actionable review findings still apply.

[Review dispositions and pre-land evidence](https://github.com/openclaw/openclaw/pull/132203#issuecomment-5459112527) are maintained in one comment. ClawSweeper's ordering finding and rank-up are addressed. Local proof is macOS; native Linux/Windows evidence is distinguished from local execution. Screenshots are not applicable to this test-only change.

Provenance: the original launch-time cancellation wait came from `050e2883b4b02503547982fa88154c5eb501edcb` via #132105, authored and merged by @steipete on 2026-08-28. This PR leaves the current production owner unchanged.
