### PR TITLE
fix(sessions): honor per-agent model policies and aliases

### DIFF
--- a/docs/concepts/models.md
+++ b/docs/concepts/models.md
@@ -169,6 +169,12 @@ openclaw config set agents.defaults.modelPolicy.allow '["openai/gpt-5.4","anthro
 
 ## Choose a model for a session
 
+Gateway `sessions.create` and `sessions.patch` resolve model aliases and
+`modelPolicy.allow` in the target session's agent scope. An explicit per-agent
+allowlist replaces the shared default, including `[]` to allow any model.
+Policy permission does not supply provider credentials or guarantee that the
+selected model is available to its runtime.
+
 Choose the model when you create a session whenever possible. The Control UI's
 **New Chat** composer includes the model picker for this reason: a fresh session
 gives the selected model a clean conversation boundary.

--- a/src/gateway/server.sessions.agent-model-catalog.test.ts
+++ b/src/gateway/server.sessions.agent-model-catalog.test.ts
@@ -1,9 +1,13 @@
-import { afterEach, expect, test, vi } from "vitest";
+import { afterEach, describe, expect, test, vi } from "vitest";
+import type { SessionEntry } from "../config/sessions.js";
 import { loadSessionEntry } from "../config/sessions/session-accessor.js";
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
+import type { PrepareGatewaySessionLifecycle } from "./session-lifecycle-preparation.js";
 import { writeSessionStore } from "./test-helpers.js";
+import { testState } from "./test-helpers.runtime-state.js";
 import {
   directSessionReq,
+  getGatewayConfigModule,
   sessionStoreEntry,
   setupGatewaySessionsHandlerTestHarness,
 } from "./test/server-sessions.test-helpers.js";
@@ -23,75 +27,296 @@ afterEach(() => {
   closeOpenClawStateDatabaseForTest();
 });
 
-test.each([
-  { label: "explicit agent", agentId: "work" },
-  { label: "agent-qualified session", agentId: undefined },
-])("sessions.patch loads the $label model catalog", async ({ agentId }) => {
-  const { workStorePath } = await createSelectedGlobalSessionStore();
-  const key = "agent:work:dashboard:catalog-owner-patch";
-  await writeSessionStore({
-    agentId: "work",
-    storePath: workStorePath,
-    entries: { [key]: sessionStoreEntry("work-catalog-patch") },
-  });
-  const loadGatewayModelCatalog = createAgentModelCatalogLoader();
+const mainRef = "main-provider/main-only";
+const workRef = "work-provider/work-only";
 
-  const patched = await directSessionReq<{
-    entry?: { modelOverride?: string; providerOverride?: string };
-  }>(
-    "sessions.patch",
-    {
-      key,
-      ...(agentId ? { agentId } : {}),
-      model: "work-provider/work-only",
-    },
-    { context: { loadGatewayModelCatalog } },
-  );
+type ModelSelectionCase = {
+  label: string;
+  explicitAgent?: boolean;
+  globalAllow: string[];
+  agentAllow?: string[];
+  globalAlias?: string;
+  agentAlias?: string;
+  model: string;
+  expectedModel: string;
+  denied?: boolean;
+};
 
-  expect(patched.ok, patched.error?.message).toBe(true);
-  expect(loadGatewayModelCatalog).toHaveBeenCalledWith({ agentId: "work" });
-  expect(patched.payload?.entry).toMatchObject({
-    providerOverride: "work-provider",
-    modelOverride: "work-only",
-  });
-  expect(
-    loadSessionEntry({ agentId: "work", sessionKey: key, storePath: workStorePath }),
-  ).toMatchObject({
-    providerOverride: "work-provider",
-    modelOverride: "work-only",
+function configureAgentModels(
+  scenario: Pick<
+    ModelSelectionCase,
+    "globalAllow" | "agentAllow" | "globalAlias" | "agentAlias"
+  > & { subagentModel?: string },
+) {
+  testState.agentConfig = {
+    model: { primary: "synthetic/base" },
+    modelPolicy: { allow: scenario.globalAllow },
+    models: scenario.globalAlias ? { [workRef]: { alias: scenario.globalAlias } } : {},
+  };
+  testState.agentsConfig = {
+    list: [
+      {
+        id: "main",
+        default: true,
+        modelPolicy: { allow: [mainRef] },
+        models: { [mainRef]: { alias: "agent-choice" } },
+      },
+      {
+        id: "work",
+        subagents: scenario.subagentModel ? { model: scenario.subagentModel } : undefined,
+        ...(scenario.agentAllow ? { modelPolicy: { allow: scenario.agentAllow } } : {}),
+        models: scenario.agentAlias ? { [workRef]: { alias: scenario.agentAlias } } : {},
+      },
+    ],
+  };
+}
+
+const cases: ModelSelectionCase[] = [
+  {
+    label: "loads the explicit agent model catalog",
+    explicitAgent: true,
+    globalAllow: [],
+    model: workRef,
+    expectedModel: workRef,
+  },
+  {
+    label: "loads the agent-qualified session model catalog",
+    globalAllow: [],
+    model: workRef,
+    expectedModel: workRef,
+  },
+  {
+    label: "rejects outside agent policy despite unrestricted global policy",
+    explicitAgent: true,
+    globalAllow: [],
+    agentAllow: [workRef],
+    model: mainRef,
+    expectedModel: mainRef,
+    denied: true,
+  },
+  {
+    label: "accepts an uncataloged model under explicit empty agent policy",
+    globalAllow: [mainRef],
+    agentAllow: [],
+    model: "work-provider/uncataloged",
+    expectedModel: "work-provider/uncataloged",
+  },
+  {
+    label: "accepts the agent list instead of the opposing global list",
+    explicitAgent: true,
+    globalAllow: [mainRef],
+    agentAllow: [workRef],
+    model: workRef,
+    expectedModel: workRef,
+  },
+  {
+    label: "rejects the global list when the agent list replaces it",
+    globalAllow: [mainRef],
+    agentAllow: [workRef],
+    model: mainRef,
+    expectedModel: mainRef,
+    denied: true,
+  },
+  {
+    label: "resolves an agent-only alias under the target agent policy",
+    globalAllow: [mainRef],
+    agentAllow: [workRef],
+    agentAlias: "agent-choice",
+    model: "agent-choice",
+    expectedModel: workRef,
+  },
+  {
+    label: "uses the per-agent alias override for the same model key",
+    explicitAgent: true,
+    globalAllow: [mainRef],
+    agentAllow: [workRef],
+    globalAlias: "shared-choice",
+    agentAlias: "agent-choice",
+    model: "agent-choice",
+    expectedModel: workRef,
+  },
+  {
+    label: "rejects a displaced global alias",
+    globalAllow: [workRef],
+    agentAllow: [workRef],
+    globalAlias: "shared-choice",
+    agentAlias: "agent-choice",
+    model: "shared-choice",
+    expectedModel: "synthetic/shared-choice",
+    denied: true,
+  },
+  {
+    label: "checks the resolved agent alias against agent policy",
+    globalAllow: [],
+    agentAllow: [mainRef],
+    agentAlias: "agent-choice",
+    model: "agent-choice",
+    expectedModel: workRef,
+    denied: true,
+  },
+];
+
+describe.each(["sessions.create", "sessions.patch"] as const)("%s", (method) => {
+  test.each(cases)("$label", async (scenario) => {
+    const { workStorePath } = await createSelectedGlobalSessionStore();
+    configureAgentModels(scenario);
+    const key = "agent:work:dashboard:catalog-owner";
+    const access = { agentId: "work", sessionKey: key, storePath: workStorePath };
+    if (method === "sessions.patch") {
+      await writeSessionStore({
+        agentId: "work",
+        storePath: workStorePath,
+        entries: {
+          [key]: sessionStoreEntry("work-catalog-patch", {
+            label: "Original label",
+            providerOverride: "synthetic",
+            modelOverride: "previous",
+            modelOverrideSource: "user",
+          }),
+        },
+      });
+    }
+    const before = loadSessionEntry(access);
+    const loadGatewayModelCatalog = createAgentModelCatalogLoader();
+    const result = await directSessionReq<{ entry?: SessionEntry }>(
+      method,
+      {
+        key,
+        ...(scenario.explicitAgent ? { agentId: "work" } : {}),
+        model: scenario.model,
+        label: "Updated label",
+      },
+      { context: { loadGatewayModelCatalog } },
+    );
+
+    expect(loadGatewayModelCatalog).toHaveBeenCalledWith({ agentId: "work" });
+    if (scenario.denied) {
+      expect.soft(result.ok).toBe(false);
+      expect.soft(result.error).toMatchObject({
+        code: "INVALID_REQUEST",
+        message: `model not allowed: ${scenario.expectedModel}`,
+      });
+      expect(loadSessionEntry(access)).toEqual(before);
+      return;
+    }
+    expect(result.ok, result.error?.message).toBe(true);
+    const [providerOverride, modelOverride] = scenario.expectedModel.split("/");
+    const selection = { providerOverride, modelOverride, modelOverrideSource: "user" };
+    expect(result.payload?.entry).toMatchObject(selection);
+    expect(loadSessionEntry(access)).toMatchObject({ ...selection, label: "Updated label" });
   });
 });
 
 test.each([
-  { label: "explicit agent", agentId: "work" },
-  { label: "agent-qualified session", agentId: undefined },
-])("sessions.create loads the $label model catalog", async ({ agentId }) => {
-  const { workStorePath } = await createSelectedGlobalSessionStore();
-  const key = `agent:work:dashboard:catalog-owner-create-${agentId ? "explicit" : "key"}`;
-  const loadGatewayModelCatalog = createAgentModelCatalogLoader();
+  {
+    name: "target agent alias",
+    globalAllow: [mainRef],
+    agentAllow: [workRef],
+    model: "agent-choice",
+    expected: { providerOverride: "work-provider", modelOverride: "work-only" },
+  },
+  {
+    name: "target agent denial despite unrestricted defaults",
+    globalAllow: [],
+    agentAllow: [workRef],
+    model: mainRef,
+    expected: null,
+  },
+  {
+    name: "uncataloged model under an explicit empty agent policy",
+    globalAllow: [mainRef],
+    agentAllow: [],
+    model: "work-provider/uncataloged",
+    expected: { providerOverride: "work-provider", modelOverride: "uncataloged" },
+  },
+])("prepares session lifecycle selection for $name", async (scenario) => {
+  await createSelectedGlobalSessionStore();
+  configureAgentModels({ ...scenario, agentAlias: "agent-choice" });
+  const { getRuntimeConfig } = await getGatewayConfigModule();
+  const { createGatewaySession } = await import("./session-create-service.js");
+  const prepareLifecycle = vi.fn<PrepareGatewaySessionLifecycle>(async () => ({
+    ok: true,
+    value: {},
+  }));
 
-  const created = await directSessionReq<{
-    entry?: { modelOverride?: string; providerOverride?: string };
-  }>(
-    "sessions.create",
-    {
-      key,
-      ...(agentId ? { agentId } : {}),
-      model: "work-provider/work-only",
+  const result = await createGatewaySession({
+    cfg: getRuntimeConfig(),
+    key: "agent:work:dashboard:prepared-selection",
+    agentId: "work",
+    model: scenario.model,
+    commandSource: "test",
+    prepareLifecycle,
+    loadGatewayModelCatalog: async () => [workModel],
+  });
+
+  expect(result.ok).toBe(scenario.expected !== null);
+  expect(prepareLifecycle).toHaveBeenCalledWith(
+    expect.objectContaining({ agentId: "work", titleModelSelection: scenario.expected }),
+  );
+});
+
+test.each([
+  { name: "pinned model requested by agent alias", subagent: false },
+  { name: "configured subagent default alias requested by canonical model", subagent: true },
+])("sessions.create preserves write-scoped adoption of $name", async ({ subagent }) => {
+  const { workStorePath } = await createSelectedGlobalSessionStore();
+  const otherRef = "work-provider/other";
+  configureAgentModels({
+    // The subagent request is globally allowed so only its default-alias comparison loses scope.
+    globalAllow: subagent ? [workRef, otherRef] : [mainRef],
+    agentAllow: [workRef, otherRef],
+    agentAlias: "agent-choice",
+    subagentModel: subagent ? "agent-choice" : undefined,
+  });
+  const key = `agent:work:${subagent ? "subagent" : "dashboard"}:adopt-selection`;
+  const access = { agentId: "work", sessionKey: key, storePath: workStorePath };
+  await writeSessionStore({
+    agentId: "work",
+    storePath: workStorePath,
+    entries: {
+      [key]: sessionStoreEntry("existing-selection", {
+        label: "Original label",
+        ...(subagent ? {} : { providerOverride: "work-provider", modelOverride: "work-only" }),
+      }),
     },
-    { context: { loadGatewayModelCatalog } },
+  });
+  const context = { loadGatewayModelCatalog: createAgentModelCatalogLoader() };
+  const writeClient = { connect: { scopes: ["operator.write"] } } as never;
+  const sameSelection = await directSessionReq<{ entry?: SessionEntry }>(
+    "sessions.create",
+    { key, model: subagent ? workRef : "agent-choice" },
+    { client: writeClient, context },
   );
 
-  expect(created.ok, created.error?.message).toBe(true);
-  expect(loadGatewayModelCatalog).toHaveBeenCalledWith({ agentId: "work" });
-  expect(created.payload?.entry).toMatchObject({
+  expect(sameSelection.ok, sameSelection.error?.message).toBe(true);
+  expect(loadSessionEntry(access)).toMatchObject({
+    sessionId: "existing-selection",
     providerOverride: "work-provider",
     modelOverride: "work-only",
+    modelOverrideSource: "user",
   });
-  expect(
-    loadSessionEntry({ agentId: "work", sessionKey: key, storePath: workStorePath }),
-  ).toMatchObject({
+  const beforeChange = loadSessionEntry(access);
+  const denied = await directSessionReq(
+    "sessions.create",
+    { key, model: otherRef, label: "Must not change" },
+    { client: writeClient, context },
+  );
+  expect(denied).toMatchObject({
+    ok: false,
+    error: { code: "FORBIDDEN", message: "missing scope: operator.admin" },
+  });
+  expect(loadSessionEntry(access)).toEqual(beforeChange);
+
+  const changed = await directSessionReq(
+    "sessions.create",
+    { key, model: otherRef },
+    { client: { connect: { scopes: ["operator.admin"] } } as never, context },
+  );
+  expect(changed.ok, changed.error?.message).toBe(true);
+  expect(loadSessionEntry(access)).toMatchObject({
+    sessionId: "existing-selection",
     providerOverride: "work-provider",
-    modelOverride: "work-only",
+    modelOverride: "other",
+    modelOverrideSource: "user",
   });
 });

--- a/src/gateway/session-create-service.ts
+++ b/src/gateway/session-create-service.ts
@@ -126,6 +126,7 @@ export function resolveSessionCreateModelSelection(
   // remains the sole live-catalog availability validator.
   const resolved = resolveSessionPatchModelSelection({
     cfg,
+    agentId,
     catalog: [],
     raw: model,
     defaultProvider: defaults.provider,
@@ -191,6 +192,7 @@ async function existingModelSelectionWouldChange(params: {
   const catalog = await params.loadGatewayModelCatalog();
   const resolved = resolveSessionPatchModelSelection({
     cfg: params.cfg,
+    agentId: params.agentId,
     catalog,
     raw: requestedModel,
     defaultProvider: params.defaultProvider,
@@ -209,6 +211,7 @@ async function existingModelSelectionWouldChange(params: {
   if (!normalizeOptionalString(params.existingEntry.modelOverride) && params.subagentModelHint) {
     const resolvedSubagentDefault = resolveSessionPatchModelSelection({
       cfg: params.cfg,
+      agentId: params.agentId,
       catalog,
       raw: params.subagentModelHint,
       defaultProvider: params.defaultProvider,

--- a/src/gateway/sessions-patch.test.ts
+++ b/src/gateway/sessions-patch.test.ts
@@ -1128,10 +1128,7 @@ describe("gateway sessions patch", () => {
     },
     {
       name: "accepts explicit allowlisted refs absent from bundled catalog",
-      catalog: [
-        { provider: "anthropic", id: "claude-sonnet-4-6", name: "Claude Sonnet 4.5" },
-        { provider: "openai", id: "gpt-5.4", name: "GPT-5.2" },
-      ],
+      catalog: [{ provider: "openai", id: "gpt-5.4", name: "GPT-5.2" }],
     },
   ])("$name", async ({ catalog }) => {
     const entry = expectPatchOk(
@@ -1144,25 +1141,52 @@ describe("gateway sessions patch", () => {
     expectModelSelection(entry, "anthropic", ANTHROPIC_SONNET_ID);
   });
 
-  test("supports uncataloged configured primary and session override refs", async () => {
-    const primary = "openai/o3";
-    const override = "openai/o1";
-    const entry = expectPatchOk(
-      await runPatch({
-        cfg: {
-          agents: {
-            defaults: {
-              model: { primary },
-              modelPolicy: { allow: [] },
+  test.each([false, true])(
+    "supports uncataloged refs with agent policy=%s",
+    async (agentPolicy) => {
+      const primary = "synthetic/primary";
+      const override = "synthetic/uncataloged";
+      const entry = expectPatchOk(
+        await runPatch({
+          cfg: {
+            agents: {
+              defaults: {
+                model: { primary },
+                modelPolicy: { allow: agentPolicy ? [primary] : [] },
+              },
+              entries: { main: agentPolicy ? { modelPolicy: { allow: [] } } : {} },
             },
-          },
-        } as OpenClawConfig,
-        patch: { key: MAIN_SESSION_KEY, model: override },
-        loadGatewayModelCatalog: async () => [],
-      }),
-    );
+          } as OpenClawConfig,
+          storeKey: "global",
+          patch: { key: "global", model: override },
+          loadGatewayModelCatalog: async () => [],
+        }),
+      );
 
-    expectModelSelection(entry, "openai", "o1");
+      expectModelSelection(entry, "synthetic", "uncataloged");
+      expect(entry.modelOverrideSource).toBe("user");
+    },
+  );
+
+  test("enforces the default agent policy without an explicit agent or qualified key", async () => {
+    const key = "global";
+    const existing: SessionEntry = { sessionId: "default-policy", updatedAt: 1, label: "Original" };
+    const store = { [key]: existing };
+    const result = await runPatch({
+      cfg: {
+        agents: {
+          defaults: { model: "synthetic/primary", modelPolicy: { allow: [] } },
+          entries: { main: { modelPolicy: { allow: ["synthetic/allowed"] } } },
+        },
+      },
+      store,
+      storeKey: key,
+      patch: { key, model: "synthetic/outside", label: "Changed" },
+      loadGatewayModelCatalog: loadCatalog("synthetic/allowed", "synthetic/outside"),
+    });
+
+    expectPatchError(result, "model not allowed: synthetic/outside");
+    expect(store[key]).toEqual(existing);
   });
 
   test("persists provider-qualified aliases without cross-provider collisions", async () => {

--- a/src/gateway/sessions-patch.ts
+++ b/src/gateway/sessions-patch.ts
@@ -90,6 +90,7 @@ function invalid(message: string): { ok: false; error: ErrorShape } {
 
 export function resolveSessionPatchModelSelection(params: {
   cfg: OpenClawConfig;
+  agentId: string;
   catalog: ModelCatalogEntry[];
   raw: string;
   defaultProvider: string;
@@ -101,6 +102,7 @@ export function resolveSessionPatchModelSelection(params: {
   const { model: modelWithoutProfile, profile } = splitTrailingAuthProfile(params.raw);
   const resolved = resolveAllowedModelRef({
     cfg: params.cfg,
+    agentId: params.agentId,
     catalog: params.catalog,
     raw: modelWithoutProfile,
     defaultProvider: params.defaultProvider,
@@ -619,6 +621,7 @@ export async function projectSessionsPatchEntry(params: {
       }
       const resolved = resolveSessionPatchModelSelection({
         cfg,
+        agentId: sessionAgentId,
         catalog,
         raw: trimmed,
         defaultProvider: resolvedDefault.provider,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users creating a session or changing its model through the Gateway could have the target agent's model policy and aliases ignored. A globally unrestricted policy could accept a model that the selected agent forbids; a restrictive global policy could reject a model or alias that the agent explicitly permits. An unchanged keyed-session selection could also be mistaken for an admin-only model change.

This is independent of chat `/model` unrestricted-policy handling: the Gateway already honors global `allowAny`; it was losing the target agent's scope.

## Why This Change Was Made

Keep the canonical model-policy/alias resolver and carry the already-resolved agent identity into it. `resolveSessionPatchModelSelection` now requires `agentId`, and all four callers supply it: the shared session projector, creation-title preparation, keyed-session adoption checks, and configured subagent-default comparison.

No new policy implementation, fallback, configuration, schema, dependency, or storage surface is introduced. Provider credentials, authentication compatibility, and runtime validity remain separate and unchanged. The embedded TUI and archive-preview paths inherit the shared-projector repair.

Production LOC: **+6/-0** (net +6): one required scope field and five forwarding fields, with no new control flow. Tests: **+325/-76** (net +249); documentation: **+6/-0**. Shared create/patch tables replace duplicated setup. One existing uncataloged-model fixture was corrected because it mistakenly contained the model it claimed was absent.

## User Impact

- `sessions.create` and `sessions.patch` consistently honor the target agent's allowlist and aliases.
- An explicit per-agent `allow: []` overrides a restrictive default; nonempty per-agent policies replace rather than merge with defaults.
- Denied creates leave no session row, and denied patches preserve the existing row.
- Write-scoped adoption of an unchanged agent alias or configured subagent selection remains allowed; actual model changes still require admin.

The model documentation now makes the session scope and credential/runtime boundary explicit: https://docs.openclaw.ai/concepts/models#choose-a-model-for-a-session

## Evidence

Captured failing-before regressions in two stages: **18 projector/create/patch cases failed** before scope propagation, and **5 creation-preflight cases failed** before the remaining service callers were repaired. They cover opposing default/per-agent policies, unknown-to-catalog refs under explicit empty policy, agent-only/replaced aliases, default-agent inference, lifecycle title preparation, and keyed-session adoption. They use the real policy/alias resolvers and isolated persisted session state.

After the complete repair, **285 tests passed across six files**:

```bash
node scripts/run-vitest.mjs src/gateway/server.sessions.agent-model-catalog.test.ts src/gateway/sessions-patch.test.ts src/gateway/server.sessions.patch-expected-identity.test.ts src/agents/model-selection-resolve.test.ts
```

```bash
node scripts/run-vitest.mjs src/gateway/server.sessions.create.test.ts src/agents/model-visibility-policy.test.ts
```

The complete changed gate passed, including core and test typechecks, changed-file lint/format, dead-export scans, architecture/import-cycle checks, and guards:

```bash
node scripts/check-changed.mjs -- docs/concepts/models.md src/gateway/sessions-patch.ts src/gateway/session-create-service.ts src/gateway/server.sessions.agent-model-catalog.test.ts src/gateway/sessions-patch.test.ts
```

`git diff --check` passed. Independent Codex autoreview found no P0 defects. Source/history review confirmed the affected owners still match current main and that model listing, agent execution, session status, native subagent planning, and cron retain their own agent scope.

`pnpm build` passed. **20 real WebSocket policy cases passed** on an isolated loopback Gateway, with session-state readback and a real Control UI model switch/reload. [Inspected recording, screenshots, selected verdict, and maintainer compatibility decision](https://github.com/openclaw/openclaw/pull/132205#issuecomment-5458980788). These are synthetic-model Gateway/UI proofs, not provider inference or credential validation. The session-owned Gateway is stopped; no operator Gateway or state was used.

The initial CI failure was an unrelated oversized UI type shard. [The canonical shard repair](https://github.com/openclaw/openclaw/pull/132193) landed, and this PR was rebased onto healed main with an identical patch ID and unchanged live-proof file hashes. Exact-head CI must be green before native prepare/merge.

AI-assisted implementation and review.
