### PR TITLE
fix: avoid cold SecretRef validation stalls in daemon install

### DIFF
--- a/extensions/googlechat/secret-contract-api.test.ts
+++ b/extensions/googlechat/secret-contract-api.test.ts
@@ -1,0 +1,64 @@
+import { runDirectImportSmoke } from "openclaw/plugin-sdk/test-fixtures";
+import { describe, expect, it } from "vitest";
+
+describe("googlechat secret contract import boundary", () => {
+  it("exposes service-account targets without loading secret setup or resolution", async () => {
+    const stdout = await runDirectImportSmoke(`
+import { realpathSync } from "node:fs";
+import { registerHooks } from "node:module";
+import { pathToFileURL } from "node:url";
+const entryUrl = pathToFileURL(realpathSync("./extensions/googlechat/secret-contract-api.ts")).href;
+const watchedUrls = new Map([
+  [entryUrl, "entry"],
+  [pathToFileURL(realpathSync("./src/secrets/plugin-setup-plan.ts")).href, "setup"],
+  [pathToFileURL(realpathSync("./src/secrets/resolve.ts")).href, "resolver"],
+]);
+const observed = { entry: false, setup: false, resolver: false };
+const hooks = registerHooks({
+  load(url, context, nextLoad) {
+    // Loader query parameters do not change which filesystem owner is loaded.
+    const canonicalUrl = new URL(url);
+    canonicalUrl.search = "";
+    canonicalUrl.hash = "";
+    const owner = watchedUrls.get(canonicalUrl.href);
+    if (owner) observed[owner] = true;
+    return nextLoad(url, context);
+  },
+});
+try {
+  const contract = await import(entryUrl);
+  process.stdout.write(JSON.stringify({
+    observed,
+    collectorCallable: typeof contract.collectRuntimeConfigAssignments === "function",
+    targets: contract.secretTargetRegistryEntries.map(
+      ({ pathPattern, secretShape, expectedResolvedValue }) =>
+        ({ pathPattern, secretShape, expectedResolvedValue }),
+    ),
+  }));
+} finally {
+  hooks.deregister();
+}
+`);
+    const result = JSON.parse(stdout);
+    expect(result.observed.entry).toBe(true);
+    expect(result.collectorCallable).toBe(true);
+    expect(result.targets).toEqual(
+      expect.arrayContaining([
+        {
+          pathPattern: "channels.googlechat.serviceAccount",
+          secretShape: "secret_input",
+          expectedResolvedValue: "string-or-object",
+        },
+        {
+          pathPattern: "channels.googlechat.accounts.*.serviceAccount",
+          secretShape: "secret_input",
+          expectedResolvedValue: "string-or-object",
+        },
+      ]),
+    );
+    expect(
+      result.observed,
+      "Google Chat metadata must not load secret setup or resolver owners",
+    ).toEqual({ entry: true, setup: false, resolver: false });
+  }, 45_000);
+});

--- a/extensions/googlechat/src/secret-contract.ts
+++ b/extensions/googlechat/src/secret-contract.ts
@@ -1,4 +1,4 @@
-// Googlechat plugin module implements secret contract behavior.
+// Secret-target discovery must not load provider setup or resolution runtimes.
 import { normalizeAccountId } from "openclaw/plugin-sdk/account-id";
 import {
   createChannelSecretTargetRegistryEntries,
@@ -10,7 +10,7 @@ import {
   type ResolverContext,
   type SecretDefaults,
 } from "openclaw/plugin-sdk/channel-secret-basic-runtime";
-import { coerceSecretRef } from "openclaw/plugin-sdk/secret-ref-runtime";
+import { coerceSecretRef } from "openclaw/plugin-sdk/secret-input";
 
 type GoogleChatAccountLike = {
   serviceAccount?: unknown;

--- a/extensions/matrix/src/matrix/account-config.ts
+++ b/extensions/matrix/src/matrix/account-config.ts
@@ -5,7 +5,7 @@ import {
   resolveMergedAccountConfig,
   resolveNormalizedAccountEntry,
 } from "openclaw/plugin-sdk/account-resolution-runtime";
-import { hasConfiguredSecretInput } from "openclaw/plugin-sdk/secret-input-runtime";
+import { hasConfiguredSecretInput } from "openclaw/plugin-sdk/secret-input";
 import type { CoreConfig, MatrixAccountConfig, MatrixConfig } from "../types.js";
 
 type MatrixRoomEntries = Record<string, NonNullable<MatrixConfig["groups"]>[string]>;

--- a/extensions/matrix/src/matrix/accounts.ts
+++ b/extensions/matrix/src/matrix/accounts.ts
@@ -1,6 +1,6 @@
 // Matrix plugin module implements accounts behavior.
 import { DEFAULT_ACCOUNT_ID, normalizeAccountId } from "openclaw/plugin-sdk/account-id";
-import { hasConfiguredSecretInput } from "openclaw/plugin-sdk/secret-input-runtime";
+import { hasConfiguredSecretInput } from "openclaw/plugin-sdk/secret-input";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import {
   resolveConfiguredMatrixAccountIds,

--- a/extensions/matrix/src/matrix/client/config.ts
+++ b/extensions/matrix/src/matrix/client/config.ts
@@ -13,7 +13,7 @@ import { sleepWithAbort } from "openclaw/plugin-sdk/runtime-env";
 import {
   coerceSecretRef,
   normalizeResolvedSecretInputString,
-} from "openclaw/plugin-sdk/secret-input-runtime";
+} from "openclaw/plugin-sdk/secret-input";
 import type { PinnedDispatcherPolicy } from "openclaw/plugin-sdk/ssrf-dispatcher";
 import {
   isPrivateNetworkOptInEnabled,

--- a/extensions/matrix/src/matrix/config-update.import.test.ts
+++ b/extensions/matrix/src/matrix/config-update.import.test.ts
@@ -1,0 +1,58 @@
+import { runDirectImportSmoke } from "openclaw/plugin-sdk/test-fixtures";
+import { describe, expect, it } from "vitest";
+
+describe("matrix config update import boundary", () => {
+  it("updates secret inputs without loading secret setup or resolution", async () => {
+    const stdout = await runDirectImportSmoke(`
+import { realpathSync } from "node:fs";
+import { registerHooks } from "node:module";
+import { pathToFileURL } from "node:url";
+const entryUrl = pathToFileURL(realpathSync("./extensions/matrix/src/matrix/config-update.ts")).href;
+const watchedUrls = new Map([
+  [entryUrl, "entry"],
+  [pathToFileURL(realpathSync("./src/secrets/plugin-setup-plan.ts")).href, "setup"],
+  [pathToFileURL(realpathSync("./src/secrets/resolve.ts")).href, "resolver"],
+]);
+const observed = { entry: false, setup: false, resolver: false };
+const hooks = registerHooks({
+  load(url, context, nextLoad) {
+    // Loader query parameters do not change which filesystem owner is loaded.
+    const canonicalUrl = new URL(url);
+    canonicalUrl.search = "";
+    canonicalUrl.hash = "";
+    const owner = watchedUrls.get(canonicalUrl.href);
+    if (owner) observed[owner] = true;
+    return nextLoad(url, context);
+  },
+});
+try {
+  const { updateMatrixAccountConfig } = await import(entryUrl);
+  const ref = { source: "env", provider: "default", id: "MATRIX_IMPORT_TEST_TOKEN" };
+  const updated = updateMatrixAccountConfig({}, "default", {
+    accessToken: ref,
+    password: "  synthetic-password  ",
+  });
+  const { hasExplicitMatrixAccountConfig } = await import("./extensions/matrix/src/matrix/account-config.ts");
+  process.stdout.write(JSON.stringify({
+    observed,
+    account: updated.channels.matrix,
+    explicitAccount: hasExplicitMatrixAccountConfig({ channels: { matrix: { accessToken: ref } } }, "default"),
+  }));
+} finally {
+  hooks.deregister();
+}
+`);
+    const result = JSON.parse(stdout);
+    expect(result.observed.entry).toBe(true);
+    expect(result.account).toEqual({
+      enabled: true,
+      accessToken: { source: "env", provider: "default", id: "MATRIX_IMPORT_TEST_TOKEN" },
+      password: "synthetic-password",
+    });
+    expect(result.explicitAccount).toBe(true);
+    expect(
+      result.observed,
+      "Matrix config updates must not load secret setup or resolver owners",
+    ).toEqual({ entry: true, setup: false, resolver: false });
+  }, 45_000);
+});

--- a/extensions/matrix/src/matrix/config-update.ts
+++ b/extensions/matrix/src/matrix/config-update.ts
@@ -1,8 +1,7 @@
 // Matrix helper module supports config update behavior.
 import { DEFAULT_ACCOUNT_ID, normalizeAccountId } from "openclaw/plugin-sdk/account-id";
 import { resolveOptionalIntegerOption } from "openclaw/plugin-sdk/number-runtime";
-import { coerceSecretRef } from "openclaw/plugin-sdk/secret-ref-runtime";
-import { normalizeSecretInputString } from "openclaw/plugin-sdk/setup";
+import { coerceSecretRef, normalizeSecretInputString } from "openclaw/plugin-sdk/secret-input";
 import type { CoreConfig, MatrixConfig } from "../types.js";
 import { findMatrixAccountConfig } from "./account-config.js";
 import {


### PR DESCRIPTION
Closes #132142 (cold daemon-install SecretRef validation loads heavy runtime for channel metadata).

<details>
<summary>Additional instructions</summary>

Keep **Allow edits from maintainers** enabled. This is a same-repository maintainer branch.

</details>

## What Problem This Solves

Resolves a problem where cold source-mode daemon-install validation spends most of its existing 120-second test budget importing credential setup/resolution code before reporting an unresolved gateway token. On the pinned baseline, the unchanged first integration case reported **103.124 seconds** even though token resolution itself took **1.3 milliseconds**.

The case deliberately omits `gateway.mode`: the installer persists the default mode before token rejection, and that write must run strict validation against the exact plugin target registry, including disabled configured plugins. That valid path exposed the expensive metadata import; it is not a reason to skip validation.

## Why This Change Was Made

Google Chat's public secret contract requested only `coerceSecretRef` from the broad `secret-ref-runtime` SDK. That imports setup-plan machinery and credential resolution, pulling a large host graph through Jiti while core only needs channel secret-target metadata. The existing `openclaw/plugin-sdk/secret-input` export provides the **same canonical helper implementations** without those runtime owners.

Use that narrow export in Google Chat and the connected parser-only Matrix config/account/client paths. Matrix's actual asynchronous credential resolver remains behind its existing lazy `config-secret-input.runtime.ts` boundary. Vault and 1Password's real setup-CLI consumers remain unchanged. No new SDK surface, helper, dependency, cache, fallback, config, schema, protocol, timeout, mock, or validation policy is introduced.

Best-fix judgment: repair the plugin's import boundary, not the installer order or strict-registry owner. Rejecting the token earlier, supplying mode in the fixture, filtering disabled targets, warming the first case, or raising its timeout would conceal the measured owner failure.

## User Impact

Cold source validation and parser-only plugin configuration avoid unnecessary setup/resolver loading. Existing SecretRef parsing, account recognition, credential precedence, and fail-closed installation behavior are preserved. This is **source-test cold-module evidence**, not a claim that an installed native-JavaScript daemon becomes nine times faster.

Production LOC: **+6/-7 (net -1)**. Tests: **+122/-0**. Two fresh-process, real-ESM import tests protect the metadata/config boundary; they use the existing smoke helper and a pass-through Node module-load observer, not mocked providers or replacement modules.

## Evidence

AI-assisted implementation and investigation. Fresh isolated Codex autoreview of the complete seven-file patch: **scoped-clean at the default P0 priority, no accepted findings**. No private routing identifiers or transcripts are included.

### Regression-first and functional proof

Both new tests were run against unchanged production first. Functional and entry-observation assertions passed, then the intended boundary assertion failed with `setup: true, resolver: true`. After the import repair, both observed `setup: false, resolver: false` and passed. The observer returns `nextLoad` unchanged and asserts that it saw the entry, so a nonfunctioning observer cannot falsely prove absence. Node's `registerHooks` exists since 22.15, below the supported Node floor; local proof used Node 24.20.0.

**119 tests across eight files passed:** Google Chat's public contract and collector; Matrix config updates, account recognition, client config and lazy asynchronous auth wiring; and all **18** strict/runtime validation-policy tests. This includes rejection of impossible provider/source bindings on disabled configured plugin targets.

```bash
node scripts/run-vitest.mjs extensions/googlechat/secret-contract-api.test.ts extensions/googlechat/src/secret-contract.test.ts extensions/matrix/src/matrix/config-update.import.test.ts extensions/matrix/src/matrix/config-update.test.ts extensions/matrix/src/matrix/accounts.test.ts extensions/matrix/src/matrix/client/config.test.ts extensions/matrix/src/matrix/client.test.ts src/config/validation.policy.test.ts
```

### Matched cold source comparison

Same pinned source baseline `151fbaad45adac60d6a684e8680551173d8f38a0`, before versus after only this patch. The original three-file selection, original fixture/mocks, eight-worker ceiling, three observed worker threads, non-isolated scheduler, and **120000-ms case timeout** were unchanged:

```bash
OPENCLAW_VITEST_MAX_WORKERS=8 node scripts/run-vitest.mjs src/cli/update-cli/update-command-lease.test.ts src/cli/update-cli/update-command-service.integration.test.ts src/cli/daemon-cli/install.integration.test.ts
```

An external in-memory observer measured nested owner phases without recording configs, environments, arguments, or secrets. Fresh Vite/results and filesystem transform caches plus the unchanged canonical per-worker test-home cache lifecycle were used. No shared cache pruning or deliberate prewarming. Effective Jiti cache hit counts and OS page-cache/host activity were not controlled. The build ran only after this pair, preserving the source-artifact route.

| Measurement | Before | After |
|---|---:|---:|
| Vitest-reported first case | 103.124 s | 11.455 s |
| First callback | 103.089 s | 11.339 s |
| Initial snapshot | 1.022 s | 1.401 s |
| Default-mode write | 101.929 s | 9.907 s |
| First strict validation | 101.553 s | 9.621 s |
| Google Chat artifact load, nested above | 96.684 s | 0.709 s |
| Google Chat artifact worker CPU | 30.552 s | 0.206 s |
| Reread | 126.7 ms | 11.0 ms |
| Token resolution | 1.300 ms | 1.284 ms |
| Global runtime afterEach | 24.7 ms | 98.7 ms |
| Actual contract artifact loads | 20 | 20 |
| CLI cases | 125 passed | 125 passed |

Nested spans must not be summed. Whole-command wall time was almost unchanged (242.28 s versus 240.16 s) because other selected suites still determine the tail. Transform/import aggregates are not CPU-contention evidence. The original historical 146278-ms timeout was not reproduced; the bottleneck already exists on the supplied pre-cleanup base. This PR does not blame the sealed-service cleanup or assert a cause for that historical timeout.

### Build, gates, and operator-visible proof

[ClawSweeper reviewed this exact head](https://github.com/openclaw/openclaw/pull/132206#issuecomment-5459031483) and found no actionable code or security findings. Its single Rank-up move is satisfied by the verified exact-head built-CLI Testbox receipt below. The maintainer-approved import-only solution now has the required behavior proof and green CI; native prepare/merge guards remain mandatory.

Initial hosted CI run [33220998855](https://github.com/openclaw/openclaw/actions/runs/33220998855) failed the shared UI test-root guard in GitHub's PR merge snapshot (`ui-pages-e2e`: 724 roots against the unchanged 720 limit), which also failed the aggregate CI gate. The branch itself had exactly 720 roots; this was an integration-snapshot failure. This patch changes no UI test roots. The split landed in #132193 (`249c248285b03eacc1fdcb9153bc47c6c3a2ec20`); #132207 closed as its duplicate. The branch was rebased onto that specific fix to repair the failed gate, retaining byte-identical import changes. The new head is `8f0087d59da3ad91492c46c8a76de19ee5b94562`; exact-head CI passed in run [33221626408](https://github.com/openclaw/openclaw/actions/runs/33221626408), including `openclaw/ci-gate` (GitHub Actions check 99017402152). The previously failing boundary command also passed locally in 30.225 seconds. The newly bound remote CLI receipt below also passed. No red check will be bypassed.

Hosted CI and independently verified real built-CLI proof are green for the exact PR head. The unchanged import patch was first committed at `479451746c05f7a98f8162db55d546b92af88cae` on pinned base `9684f8f51228cdd35b768066d9e2389296788da6`, then mechanically rebased for the concrete hosted CI failure described above. Its patch bytes still match the reviewed staged patch.

On the pre-CI-repair candidate `479451746c05f7a98f8162db55d546b92af88cae`, Node 24.20.0 `pnpm build` passed in 429.428 seconds, including SDK exports and UI validation, with zero ineffective-dynamic-import warnings. UI startup gzip was 345404 B against the base's 345947 B enforcement limit. This repair changes no budget or baseline files. The prior full build's 347427 B versus 347037 B failure was resolved by acquiring the already-landed UI fix in #132124.

The focused command above passed all 119 tests across eight files again (30.995 seconds). The actual changed check, `node scripts/check-changed.mjs -- extensions/googlechat/secret-contract-api.test.ts extensions/googlechat/src/secret-contract.ts extensions/matrix/src/matrix/account-config.ts extensions/matrix/src/matrix/accounts.ts extensions/matrix/src/matrix/client/config.ts extensions/matrix/src/matrix/config-update.import.test.ts extensions/matrix/src/matrix/config-update.ts`, passed in 588.861 seconds. Before commit, the initial staged changed gate exited 1 during extension lint (826.538 seconds); its filtered receipt omitted the exact diagnostic. An unchanged seven-file lint rerun passed (254.282 seconds), followed by a complete staged changed-gate retry (592.233 seconds). Later runs put Node 24 first in child PATH; the initial cause remains unproven and is not attributed to runtime selection.

Two real `node openclaw.mjs --profile <unique-profile> gateway install --json` attempts used new temporary homes/state, a strict allowlisted child environment, and the exact synthetic missing-env fixture with `gateway.mode` omitted. Both proved their unique GUI/system service labels and definitions absent before and after, preserved the SecretRef, and created no service environment. Both exited 1 before mode persistence and before the unresolved-SecretRef reason. The diagnostic attempt identified the deliberate native-service identity guard: relocated HOME/state cannot manage a host service. `src/config/paths.ts:155` checks the real OS account home; `src/infra/gateway-supervision.ts:55` rejects the temporary identity; the integration harness explicitly replaces `isDefaultInstallIdentity` at `src/cli/daemon-cli/install.integration.test.ts:57`. This is not successful live proof of the repaired path. No operator-home retry or guard bypass was attempted. The local result establishes the isolation guard, not successful SecretRef-path proof; the successful disposable Testbox follow-up used its actual isolated OS account home.

### Real built-CLI receipt

Real CLI proof now passes on exact head `8f0087d59da3ad91492c46c8a76de19ee5b94562` in **Blacksmith Testbox** `tbx_01m15cx4hp95v16z5pakqw4dms` ([run](https://github.com/openclaw/openclaw/actions/runs/33222059190)), Linux / Node 24.19.0. A full `pnpm build` passed in 234.010 s. From a neutral working directory, the resulting official `openclaw.mjs` launcher ran `--profile <fresh-profile> gateway install --json` with the original synthetic unresolved-env SecretRef fixture and no gateway mode. The CLI exited **1 as expected** (harness exit **0**) in 2.234 s, persisted mode `local`, reported the unresolved SecretRef, preserved the reference, and created no unit, drop-in, or service environment. The native unit was absent before and after, default-profile metadata was unchanged, and the owned profile was removed. This is behavior proof, not a packaged-latency benchmark.

The VM image initially supplied a world-writable (`0777`) config-directory ancestor. The installer correctly rejected write authority there, before token validation. Making that account-owned directory private (`0700`) inside the disposable VM satisfied the existing guard; no production code, timeout, assertion, mock, or guard was changed. The final CLI run used no observer/preload. Both session-owned Testboxes are stopped; the final lease's `completed` state was verified separately. No operator service or home was touched.

Exact-head [CI run 33221626408](https://github.com/openclaw/openclaw/actions/runs/33221626408) is completed/success and was independently rechecked by the parent. Proceed through native review/prepare/merge only while this head remains exact and all current review/native gates pass.

Separate follow-ups remain outside this patch: direct-import smoke failure diagnostics and Matrix synchronous default-alias validation parity. The exact-head remote receipt and CI have now been independently verified, and ClawSweeper's receipt request is addressed. Native landing guards still apply.

Provenance boundary: the broad import predates the supplied pre-cleanup base. Local history is shallow at `e357203be5721f55434e7fc9891268e5c6afdd38`; that boundary is not proof that its author introduced this import. No unsupported author or cleanup-regression attribution is made.
