### PR TITLE
fix(test): clean isolated homes across managed test runners

### DIFF
--- a/docs/reference/test.md
+++ b/docs/reference/test.md
@@ -132,13 +132,21 @@ allowing artifact stamps or downstream checks to proceed. Windows retains normal
 joined-launcher completion because strict group verification is unsupported there.
 This does not detect descendants that deliberately leave the managed groups.
 
-On POSIX hosts, the Vitest wrapper gives each invocation an owned temporary
-namespace through `TMPDIR`, `TMP`, and `TEMP`. Fallback SQLite state stays available
-across shared-worker files and module resets, then the wrapper removes the namespace
-after its child process group has stopped, including failed test runs. Explicit state
-and artifact paths outside that namespace are unchanged. Windows and raw invocations
-outside the wrapper are unchanged; interrupted wrappers or unverified process-group
-teardown can retain their temporary files. The wrapper never sweeps old PID directories.
+On POSIX hosts, `run-vitest` (including project shards), plugin batches, `test-live`
+(including live shards), `run-vitest-profile`, and the TUI PTY watcher give each
+Vitest invocation an owned temporary namespace through `TMPDIR`, `TMP`, and `TEMP`.
+The namespace contains isolated homes, their JIT caches, SDK/shared-home allocation
+roots, and fallback SQLite state; its lifetime spans shared-worker files and module
+resets. The parent removes
+only that namespace after its child process group has stopped and output pipes
+have closed, including passing and failing runs, child crashes, caught `SIGINT`/`SIGTERM`
+signals, and watchdog termination where supported. Explicit state, profile output,
+and mirror artifacts outside the namespace remain untouched. Failed or unverified
+group joins retain the namespace and report the exact path for manual recovery.
+Windows and raw external invocations retain their existing behavior. Forced parent
+or supervisor death (such as `SIGKILL`) can prevent cleanup; descendants that
+intentionally escape the owned group can recreate removed paths. The wrappers do
+not sweep old directories or infer ownership from names, ages, or PIDs.
 
 - `src/test-utils/openclaw-test-state.ts`: use from Vitest when a test needs an isolated `HOME`, `OPENCLAW_STATE_DIR`, `OPENCLAW_CONFIG_PATH`, config fixture, workspace, agent dir, or auth-profile store.
 - `pnpm test:env-mutations:report`: non-blocking report of tests/harnesses that mutate `HOME`, `OPENCLAW_STATE_DIR`, `OPENCLAW_CONFIG_PATH`, `OPENCLAW_WORKSPACE_DIR`, or related env keys directly. Use it to find migration candidates for the shared test-state helper.

--- a/scripts/dev/tui-pty-test-watch.ts
+++ b/scripts/dev/tui-pty-test-watch.ts
@@ -1,11 +1,11 @@
 // Tui Pty Test Watch script supports OpenClaw repository automation.
-import { spawn } from "node:child_process";
 import { mkdir, open, writeFile } from "node:fs/promises";
 import { createRequire } from "node:module";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { terminateManagedChild } from "../lib/managed-child-process.mts";
 import { sleep as delay } from "../lib/sleep.mjs";
+import { spawnOwnedVitestProcess } from "../lib/vitest-process.mts";
 
 type Options = {
   altScreen: boolean;
@@ -244,9 +244,9 @@ async function main(): Promise<void> {
   const useAltScreen = shouldUseAltScreen(options);
   await createMirrorFile(options.mirrorPath);
 
-  const child = spawn(
-    process.execPath,
-    [
+  const { child, completion } = spawnOwnedVitestProcess({
+    command: process.execPath,
+    args: [
       "--no-maglev",
       resolveVitestCliEntry(),
       "run",
@@ -256,9 +256,8 @@ async function main(): Promise<void> {
       "--reporter=dot",
       ...options.vitestArgs,
     ],
-    {
+    options: {
       cwd: process.cwd(),
-      detached: process.platform !== "win32",
       env: {
         ...process.env,
         OPENCLAW_TUI_PTY_MIRROR_PATH: options.mirrorPath,
@@ -270,7 +269,7 @@ async function main(): Promise<void> {
       },
       stdio: ["ignore", "pipe", "pipe"],
     },
-  );
+  });
 
   let childStdout: Buffer = Buffer.alloc(0);
   let childStderr: Buffer = Buffer.alloc(0);
@@ -387,15 +386,18 @@ async function main(): Promise<void> {
     childStderr = appendBufferTail(childStderr, chunk);
   });
 
-  type ChildExit = { code: number | null; signal: NodeJS.Signals | null };
-  let childExit: ChildExit | null = null;
-  const childFinished = new Promise<ChildExit>((resolve) => {
-    child.once("exit", (code, signal) => {
-      childExit = { code, signal };
+  let childFinished = false;
+  // Keep escalation and mirror reads alive until descendants and output have joined.
+  // Capture rejection now so polling cannot leave a spawn/join failure unhandled.
+  const childOutcome = completion
+    .then(
+      (result) => ({ result }),
+      (error: unknown) => ({ error }),
+    )
+    .finally(() => {
+      childFinished = true;
       childStopper.cancel();
-      resolve(childExit);
     });
-  });
 
   const parentSignals: NodeJS.Signals[] = ["SIGINT", "SIGTERM", "SIGHUP"];
   for (const signal of parentSignals) {
@@ -404,7 +406,7 @@ async function main(): Promise<void> {
 
   try {
     for (;;) {
-      if (childExit) {
+      if (childFinished) {
         break;
       }
       const result = await readNewMirrorData(options.mirrorPath, mirrorOffset);
@@ -419,9 +421,10 @@ async function main(): Promise<void> {
 
     mirrorOffset = await drainNewMirrorData(options.mirrorPath, mirrorOffset, writeMirrorChunk);
   } finally {
-    if (!childExit) {
+    if (!childFinished) {
       stopChild();
     }
+    await childOutcome;
     for (const signal of parentSignals) {
       process.off(signal, stopChild);
     }
@@ -433,9 +436,11 @@ async function main(): Promise<void> {
     restoreScreen();
   }
 
-  if (!childExit) {
-    childExit = await childFinished;
+  const outcome = await childOutcome;
+  if ("error" in outcome) {
+    throw outcome.error;
   }
+  const childExit = outcome.result;
 
   if (childStdout.byteLength > 0) {
     process.stdout.write(childStdout);

--- a/scripts/lib/vitest-batch-runner.mts
+++ b/scripts/lib/vitest-batch-runner.mts
@@ -1,12 +1,9 @@
 // Runs grouped Vitest batches through the repo pnpm wrapper.
 import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
-import { spawnPnpmRunner } from "../pnpm-runner.mts";
-import {
-  createVitestProcessCompletion,
-  installVitestProcessGroupCleanup,
-  shouldUseDetachedVitestProcessGroup,
-} from "../vitest-process-group.mts";
+import { createPnpmRunnerSpawnSpec } from "../pnpm-runner.mts";
+import { installVitestProcessGroupCleanup } from "../vitest-process-group.mts";
+import { spawnOwnedVitestProcess } from "./vitest-process.mts";
 
 export type VitestBatchRunParams = {
   args: string[];
@@ -25,14 +22,14 @@ const repoRoot = path.resolve(scriptDir, "../..");
 export async function runVitestBatch(params: VitestBatchRunParams): Promise<number> {
   return await new Promise<number>((resolve, reject) => {
     let forwardedSignal: NodeJS.Signals | undefined;
-    const detached = shouldUseDetachedVitestProcessGroup();
-    const child = spawnPnpmRunner({
-      cwd: repoRoot,
-      detached,
-      env: params.env,
-      pnpmArgs: buildVitestBatchPnpmArgs(params),
-      stdio: "inherit",
-    });
+    const { child, completion } = spawnOwnedVitestProcess(
+      createPnpmRunnerSpawnSpec({
+        cwd: repoRoot,
+        env: params.env,
+        pnpmArgs: buildVitestBatchPnpmArgs(params),
+        stdio: "inherit",
+      }),
+    );
     const teardownChildCleanup = installVitestProcessGroupCleanup({
       child,
       forceSignal: "SIGKILL",
@@ -41,11 +38,7 @@ export async function runVitestBatch(params: VitestBatchRunParams): Promise<numb
         forwardedSignal ??= signal;
       },
     });
-    const completion = createVitestProcessCompletion({ child, detached }).finally(
-      teardownChildCleanup,
-    );
-
-    completion.then((result) => {
+    completion.finally(teardownChildCleanup).then((result) => {
       const { code, signal } = result;
       if (forwardedSignal) {
         process.kill(process.pid, forwardedSignal);

--- a/scripts/lib/vitest-process.mts
+++ b/scripts/lib/vitest-process.mts
@@ -1,0 +1,55 @@
+import { spawn, type SpawnOptions } from "node:child_process";
+import fs from "node:fs";
+import { tmpdir } from "node:os";
+import { createTempDirTracker } from "../../test/helpers/temp-dir.ts";
+import {
+  createVitestProcessCompletion,
+  shouldUseDetachedVitestProcessGroup,
+} from "../vitest-process-group.mts";
+
+/** Own temporary files until the Vitest child, its group, and its pipes have joined. */
+export function spawnOwnedVitestProcess(spec: {
+  command: string;
+  args: string[];
+  options: SpawnOptions;
+}) {
+  const tempDirs = createTempDirTracker();
+  const detached = spec.options.detached ?? shouldUseDetachedVitestProcessGroup();
+  let options = { ...spec.options, detached };
+  let tempRoot: string | undefined;
+  // Windows has no verified group join. Keep its existing temporary-file behavior.
+  if (detached && shouldUseDetachedVitestProcessGroup()) {
+    const env = options.env ?? process.env;
+    tempRoot = tempDirs.make(
+      "oc-vt-",
+      fs.realpathSync(env.TMPDIR || env.TMP || env.TEMP || tmpdir()),
+    );
+    options = { ...options, env: { ...env, TMPDIR: tempRoot, TMP: tempRoot, TEMP: tempRoot } };
+  }
+  let child;
+  try {
+    child = spawn(spec.command, spec.args, options);
+  } catch (error) {
+    tempDirs.cleanup();
+    throw error;
+  }
+  const completion = createVitestProcessCompletion({ child, detached }).then(
+    (result) => {
+      tempDirs.cleanup();
+      return result;
+    },
+    (error: unknown) => {
+      // No PID means spawn failed; otherwise unverified writers still own the files.
+      if (!child.pid) {
+        tempDirs.cleanup();
+      } else if (tempRoot) {
+        throw new Error(
+          `[vitest] retained temporary namespace ${tempRoot}; child/group completion was not verified. Stop the remaining writers before removing this exact directory.`,
+          { cause: error },
+        );
+      }
+      throw error;
+    },
+  );
+  return { child, completion };
+}

--- a/scripts/run-vitest-profile.mts
+++ b/scripts/run-vitest-profile.mts
@@ -1,11 +1,13 @@
 // Profiles Vitest main or runner processes and writes CPU/heap artifacts.
-import { spawnSync, type SpawnSyncOptions } from "node:child_process";
+import type { SpawnOptions } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { formatErrorMessage } from "./lib/error-format.mts";
+import { spawnOwnedVitestProcess } from "./lib/vitest-process.mts";
 import { createPnpmRunnerSpawnSpec } from "./pnpm-runner.mts";
+import { installVitestProcessGroupCleanup } from "./vitest-process-group.mts";
 
 function readOutputDirValue(argv: string[], index: number): string {
   const value = argv[index + 1];
@@ -58,7 +60,7 @@ type VitestProfileOptions = Pick<ReturnType<typeof parseArgs>, "mode" | "outputD
 type VitestProfileSpawnSpec = {
   args: string[];
   command: string;
-  options: SpawnSyncOptions;
+  options: SpawnOptions;
 };
 
 /**
@@ -141,11 +143,11 @@ export function buildVitestProfileSpawnSpec(
     options: {
       env: process.env,
       stdio: "inherit",
-    } satisfies SpawnSyncOptions,
+    } satisfies SpawnOptions,
   };
 }
 
-function main() {
+async function main() {
   const parsed = parseArgs(process.argv.slice(2));
   const outputDir = resolveVitestProfileDir(parsed);
   fs.mkdirSync(outputDir, { recursive: true });
@@ -159,12 +161,22 @@ function main() {
   console.log(`[run-vitest-profile] writing ${parsed.mode} profiles to ${outputDir}`);
 
   const spawnSpec = buildVitestProfileSpawnSpec(plan);
-  const result = spawnSync(spawnSpec.command, spawnSpec.args, spawnSpec.options);
-
-  if (result.error) {
-    throw result.error;
+  const { child, completion } = spawnOwnedVitestProcess(spawnSpec);
+  let forwardedSignal: NodeJS.Signals | undefined;
+  const teardown = installVitestProcessGroupCleanup({
+    child,
+    forceSignal: "SIGKILL",
+    forceSignalDelayMs: 100,
+    onSignal: (signal) => {
+      forwardedSignal ??= signal;
+    },
+  });
+  const result = await completion.finally(teardown);
+  if (forwardedSignal) {
+    process.kill(process.pid, forwardedSignal);
+    return;
   }
-  process.exit(result.status ?? 1);
+  process.exitCode = result.code ?? 1;
 }
 
 const isMain =
@@ -174,7 +186,7 @@ const isMain =
 
 if (isMain) {
   try {
-    main();
+    await main();
   } catch (error) {
     console.error(formatErrorMessage(error));
     process.exit(1);

--- a/scripts/run-vitest.mts
+++ b/scripts/run-vitest.mts
@@ -1,11 +1,9 @@
 // Runs Vitest through repo project selection, local scheduling policy, output
 // watchdogs, and process-group cleanup.
-import { spawn, type ChildProcess } from "node:child_process";
 import fs from "node:fs";
 import { createRequire } from "node:module";
-import { constants as osConstants, tmpdir } from "node:os";
+import { constants as osConstants } from "node:os";
 import path from "node:path";
-import { createTempDirTracker } from "../test/helpers/temp-dir.ts";
 import {
   agentVitestProjectOwners,
   embeddedAgentVitestProjectOwners,
@@ -25,14 +23,14 @@ import {
   prepareVitestRuntime,
 } from "./lib/vitest-build-prerequisites.mts";
 import { resolveVitestProcessEnv } from "./lib/vitest-process-env.mts";
+import { spawnOwnedVitestProcess } from "./lib/vitest-process.mts";
 import {
   createVitestUnhandledErrorDetector,
   stripVitestAnsi,
   writeVitestUnhandledErrorSummary,
 } from "./lib/vitest-unhandled-errors.mts";
-import { spawnPnpmRunner, type PnpmRunnerParams } from "./pnpm-runner.mts";
+import { createPnpmRunnerSpawnSpec, type PnpmRunnerParams } from "./pnpm-runner.mts";
 import {
-  createVitestProcessCompletion,
   forwardSignalToVitestProcessGroup,
   installVitestProcessGroupCleanup,
   shouldUseDetachedVitestProcessGroup,
@@ -1049,23 +1047,6 @@ export function resolveImplicitVitestArgs(argv: string[], cwd = process.cwd()): 
   return argv;
 }
 
-function spawnVitestProcess({
-  pnpmArgs,
-  spawnParams,
-}: {
-  pnpmArgs: string[];
-  spawnParams: PnpmRunnerParams;
-}): ChildProcess {
-  const directNodeArgs = resolveDirectNodeVitestArgs(pnpmArgs);
-  if (directNodeArgs) {
-    return spawn(process.execPath, directNodeArgs, spawnParams);
-  }
-  return spawnPnpmRunner({
-    pnpmArgs,
-    ...spawnParams,
-  });
-}
-
 /**
  * Installs the no-output watchdog for long-running Vitest children.
  */
@@ -1264,28 +1245,12 @@ export function spawnWatchedVitestProcess({
 }) {
   let forwardedSignal: NodeSignal | null = null;
   let diagnosticsCompletion: Promise<void> | null = null;
-  const tempDirs = createTempDirTracker();
-  let childSpawnParams = spawnParams;
-  // The POSIX completion contract joins all workers before deleting SQLite files.
-  // Own a fresh namespace outside worker module resets, never ambient PID directories.
-  if (spawnParams.detached && shouldUseDetachedVitestProcessGroup()) {
-    const childEnv = spawnParams.env ?? process.env;
-    const tempRoot = tempDirs.make(
-      "oc-vt-",
-      fs.realpathSync(childEnv.TMPDIR || childEnv.TMP || childEnv.TEMP || tmpdir()),
-    );
-    childSpawnParams = {
-      ...spawnParams,
-      env: { ...childEnv, TMPDIR: tempRoot, TMP: tempRoot, TEMP: tempRoot },
-    };
-  }
-  let child: ChildProcess;
-  try {
-    child = spawnVitestProcess({ pnpmArgs, spawnParams: childSpawnParams });
-  } catch (error) {
-    tempDirs.cleanup();
-    throw error;
-  }
+  const directNodeArgs = resolveDirectNodeVitestArgs(pnpmArgs);
+  const { child, completion: childCompletion } = spawnOwnedVitestProcess(
+    directNodeArgs
+      ? { command: process.execPath, args: directNodeArgs, options: spawnParams }
+      : createPnpmRunnerSpawnSpec({ pnpmArgs, ...spawnParams }),
+  );
   const teardownChildCleanup = installVitestProcessGroupCleanup({
     child,
     forceSignal: "SIGKILL",
@@ -1335,28 +1300,14 @@ export function spawnWatchedVitestProcess({
     teardownChildCleanup();
     teardownNoOutputWatchdog();
   };
-  const completion = Promise.all([
-    createVitestProcessCompletion({
-      child,
-      detached: spawnParams.detached === true,
-    }),
-    forwardedOutput,
-  ])
+  const completion = Promise.all([childCompletion, forwardedOutput])
     .then(async ([{ code, signal }]) => {
       await diagnosticsCompletion;
-      tempDirs.cleanup();
       const result = unhandledErrors.finish();
       if (result) {
         writeVitestUnhandledErrorSummary(result, env);
       }
       return { code, signal: normalizeNodeSignal(signal) };
-    })
-    .catch((error: unknown) => {
-      // A failed spawn owns no handles. A failed group join may still own them.
-      if (!child.pid) {
-        tempDirs.cleanup();
-      }
-      throw error;
     })
     .finally(teardown);
 

--- a/scripts/test-live.mts
+++ b/scripts/test-live.mts
@@ -1,9 +1,9 @@
 // Runs the full live Vitest suite with live-test env and heartbeat output.
 import { terminateManagedChild } from "./lib/managed-child-process.mts";
-import { spawnPnpmRunner } from "./pnpm-runner.mts";
+import { spawnOwnedVitestProcess } from "./lib/vitest-process.mts";
+import { createPnpmRunnerSpawnSpec, type PnpmRunnerParams } from "./pnpm-runner.mts";
 import { resolveVitestNoOutputTimeoutMs } from "./run-vitest.mts";
 import {
-  createVitestProcessCompletion,
   installVitestProcessGroupCleanup,
   shouldUseDetachedVitestProcessGroup,
 } from "./vitest-process-group.mts";
@@ -136,7 +136,7 @@ export function buildTestLiveSpawnParams(env: NodeJS.ProcessEnv, platform = proc
     detached: shouldUseDetachedVitestProcessGroup(platform),
     env,
     stdio: ["inherit", "pipe", "pipe"],
-  } satisfies Pick<Parameters<typeof spawnPnpmRunner>[0], "detached" | "env" | "stdio">;
+  } satisfies Pick<PnpmRunnerParams, "detached" | "env" | "stdio">;
 }
 
 /**
@@ -158,10 +158,12 @@ export function main(argv = process.argv.slice(2), baseEnv = process.env) {
   let timedOut = false;
 
   const spawnParams = buildTestLiveSpawnParams(env);
-  const child = spawnPnpmRunner({
-    pnpmArgs: buildTestLivePnpmArgs(args),
-    ...spawnParams,
-  });
+  const { child, completion } = spawnOwnedVitestProcess(
+    createPnpmRunnerSpawnSpec({
+      pnpmArgs: buildTestLivePnpmArgs(args),
+      ...spawnParams,
+    }),
+  );
   let forwardedSignal: NodeJS.Signals | null = null;
   const teardownChildCleanup = installVitestProcessGroupCleanup({
     child,
@@ -219,33 +221,31 @@ export function main(argv = process.argv.slice(2), baseEnv = process.env) {
   );
   heartbeat.unref?.();
 
-  createVitestProcessCompletion({ child, detached: spawnParams.detached })
-    .finally(teardown)
-    .then(
-      ({ code, signal }) => {
-        if (forwardedSignal) {
-          process.kill(process.pid, forwardedSignal);
-          return;
-        }
-        if (timedOut) {
-          process.exit(1);
-          return;
-        }
-        if (signal) {
-          process.stderr.write(`[test:live] vitest exited via signal=${signal}\n`);
-          process.kill(process.pid, signal);
-          return;
-        }
-        if ((code ?? 1) !== 0) {
-          process.stderr.write(`[test:live] vitest exited code=${code ?? 1}\n`);
-        }
-        process.exit(code ?? 1);
-      },
-      (error: unknown) => {
-        console.error(error);
+  completion.finally(teardown).then(
+    ({ code, signal }) => {
+      if (forwardedSignal) {
+        process.kill(process.pid, forwardedSignal);
+        return;
+      }
+      if (timedOut) {
         process.exit(1);
-      },
-    );
+        return;
+      }
+      if (signal) {
+        process.stderr.write(`[test:live] vitest exited via signal=${signal}\n`);
+        process.kill(process.pid, signal);
+        return;
+      }
+      if ((code ?? 1) !== 0) {
+        process.stderr.write(`[test:live] vitest exited code=${code ?? 1}\n`);
+      }
+      process.exit(code ?? 1);
+    },
+    (error: unknown) => {
+      console.error(error);
+      process.exit(1);
+    },
+  );
 }
 
 if (import.meta.main) {

--- a/test/scripts/run-vitest-state-cleanup.test.ts
+++ b/test/scripts/run-vitest-state-cleanup.test.ts
@@ -3,7 +3,8 @@ import fs from "node:fs";
 import path from "node:path";
 import { DatabaseSync } from "node:sqlite";
 import { promisify } from "node:util";
-import { afterEach, expect, it } from "vitest";
+import { afterEach, expect, it, vi } from "vitest";
+import { spawnOwnedVitestProcess } from "../../scripts/lib/vitest-process.mts";
 import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
 
 const execFileAsync = promisify(execFile);
@@ -12,18 +13,23 @@ const repoRoot = path.resolve(import.meta.dirname, "../..");
 const posixIt = process.platform === "win32" ? it.skip : it;
 
 posixIt.each([
-  { pool: "threads", failRun: false },
-  { pool: "threads", failRun: true },
-  { pool: "forks", failRun: false },
-  { pool: "forks", failRun: true },
+  { route: "main", pool: "threads", failRun: false },
+  { route: "main", pool: "threads", failRun: true },
+  { route: "main", pool: "forks", failRun: false },
+  { route: "main", pool: "forks", failRun: true },
+  ...["batch", "live", "profile-main", "profile-runner", "pty"].flatMap((route) => [
+    { route, pool: "threads", failRun: false },
+    { route, pool: "forks", failRun: true },
+  ]),
 ])(
-  "cleans fallback SQLite after $pool completion (failed run: $failRun)",
-  async ({ pool, failRun }) => {
+  "$route cleans its namespace after $pool completion (failed run: $failRun)",
+  async ({ route, pool, failRun }) => {
     const root = tempDirs.make("oc-vt-state-");
     const tmp = path.join(root, "tmp");
     const home = path.join(root, "home");
     fs.mkdirSync(tmp);
     fs.mkdirSync(home);
+    fs.writeFileSync(path.join(root, "package.json"), '{"private":true,"type":"module"}');
     fs.symlinkSync(
       path.join(repoRoot, "node_modules"),
       path.join(root, "node_modules"),
@@ -39,11 +45,45 @@ posixIt.each([
     const receiptPath = path.join(root, "receipt.json");
     const databaseModule = JSON.stringify(path.join(repoRoot, "src/state/openclaw-state-db.ts"));
     const setupModule = path.join(repoRoot, "test/setup.ts");
+    const testRoot = path.join(root, "src/tui");
+    const configRoot = path.join(root, "test/vitest");
+    fs.mkdirSync(testRoot, { recursive: true });
+    fs.mkdirSync(configRoot, { recursive: true });
+    fs.writeFileSync(path.join(root, "tiny.ts"), "export const answer: number = 42;");
     fs.writeFileSync(
-      path.join(root, "01-open.test.ts"),
+      path.join(root, "resources.ts"),
+      `
+import fs from "node:fs";
+import path from "node:path";
+import { createJiti } from "jiti";
+import { expect } from "vitest";
+import { withTempHomeCore } from ${JSON.stringify(path.join(repoRoot, "src/plugin-sdk/test-helpers/temp-home.ts"))};
+import { createTempHomeEnv } from ${JSON.stringify(path.join(repoRoot, "src/test-utils/temp-home.ts"))};
+export async function allocateResources() {
+  const home = process.env.HOME;
+  const cache = path.join(process.env.XDG_CACHE_HOME, "openclaw/jiti/fixture");
+  const jiti = createJiti(import.meta.url, { fsCache: cache, moduleCache: false, tryNative: false });
+  expect((await jiti.import(${JSON.stringify(path.join(root, "tiny.ts"))})).answer).toBe(42);
+  expect(fs.readdirSync(cache).length).toBeGreaterThan(0);
+  let sdkHome;
+  await withTempHomeCore(async (base) => { sdkHome = base; }, { skipSessionCleanup: true });
+  expect(fs.existsSync(sdkHome)).toBe(false);
+  const shared = await createTempHomeEnv("oc-shared-home-");
+  await shared.restore();
+  expect(fs.existsSync(shared.home)).toBe(false);
+  const roots = [path.dirname(sdkHome), path.dirname(shared.home)];
+  for (const root of roots) expect(fs.readdirSync(root)).toEqual([]);
+  return { home, cache, roots };
+}
+`,
+    );
+    fs.writeFileSync(
+      path.join(testRoot, "tui-pty-harness.e2e.test.ts"),
       `import fs from "node:fs";
 import { expect, it } from "vitest";
 import { openOpenClawStateDatabase, closeOpenClawStateDatabaseForTest } from ${databaseModule};
+import { allocateResources } from "../../resources.ts";
+const resources = await allocateResources();
 it("opens actual fallback SQLite and retains it until the worker finishes", () => {
   const first = openOpenClawStateDatabase();
   expect(first.db.prepare("SELECT count(*) AS count FROM sqlite_schema").get().count).toBeGreaterThan(0);
@@ -51,32 +91,38 @@ it("opens actual fallback SQLite and retains it until the worker finishes", () =
   expect(first.db.isOpen).toBe(false);
   const reopened = openOpenClawStateDatabase();
   const explicit = openOpenClawStateDatabase({ env: { OPENCLAW_STATE_DIR: ${JSON.stringify(path.dirname(path.dirname(explicitPath)))} } });
-  globalThis[Symbol.for("openclaw.stateLeakFixture")] = { reopened, explicit, pid: process.pid };
+  globalThis[Symbol.for("openclaw.stateLeakFixture")] = { reopened, explicit, resources, pid: process.pid };
   fs.writeFileSync(${JSON.stringify(receiptPath)}, JSON.stringify({ path: reopened.path }));
 });
 `,
     );
     fs.writeFileSync(
-      path.join(root, "02-reset.test.ts"),
+      path.join(testRoot, "tui-pty-local.e2e.test.ts"),
       `import fs from "node:fs";
 import { expect, it, vi } from "vitest";
-it("keeps the same worker namespace alive across files and module resets", async () => {
-  const previous = globalThis[Symbol.for("openclaw.stateLeakFixture")];
+const previous = globalThis[Symbol.for("openclaw.stateLeakFixture")];
+vi.resetModules();
+const { openOpenClawStateDatabase } = await import(${databaseModule});
+const { allocateResources } = await import("../../resources.ts");
+const resources = await allocateResources();
+it("keeps the same worker namespace alive across files and module resets", () => {
   expect(process.pid).toBe(previous.pid);
   expect(previous.reopened.db.isOpen).toBe(true);
   expect(previous.explicit.db.isOpen).toBe(true);
-  vi.resetModules();
-  const { openOpenClawStateDatabase } = await import(${databaseModule});
   const current = openOpenClawStateDatabase();
   expect(current.path).toBe(previous.reopened.path);
   expect(current.db.prepare("SELECT count(*) AS count FROM sqlite_schema").get().count).toBeGreaterThan(0);
   expect(fs.existsSync(current.path)).toBe(true);
-  fs.writeFileSync(${JSON.stringify(receiptPath)}, JSON.stringify({ path: current.path, resetVerified: true }));
+  expect(resources.home).toBe(previous.resources.home);
+  expect(resources.roots).not.toEqual(previous.resources.roots);
+  fs.writeFileSync(${JSON.stringify(receiptPath)}, JSON.stringify({ path: current.path, resetVerified: true, resources: [previous.resources, resources] }));
+  if (process.env.OPENCLAW_TUI_PTY_MIRROR_PATH) fs.appendFileSync(process.env.OPENCLAW_TUI_PTY_MIRROR_PATH, "namespace fixture frame\\n");
   ${failRun ? 'expect.fail("intentional failure after SQLite allocation");' : ""}
 });
 `,
     );
-    const configPath = path.join(root, "vitest.config.ts");
+    const configName = route === "live" ? "live" : route === "pty" ? "tui-pty" : "unit";
+    const configPath = path.join(configRoot, `vitest.${configName}.config.ts`);
     fs.writeFileSync(
       configPath,
       `import { sharedVitestConfig } from ${JSON.stringify(path.join(repoRoot, "test/vitest/vitest.shared.config.ts"))};
@@ -86,8 +132,10 @@ class AlphabeticalSequencer extends BaseSequencer {
 }
 export default {
   resolve: sharedVitestConfig.resolve,
+  plugins: sharedVitestConfig.plugins,
   cacheDir: ${JSON.stringify(path.join(root, ".vite"))},
   test: {
+    include: ["src/tui/*.e2e.test.ts"],
     pool: ${JSON.stringify(pool)}, isolate: false, fileParallelism: false, maxWorkers: 1,
     sequence: { sequencer: AlphabeticalSequencer },
     runner: ${JSON.stringify(path.join(repoRoot, "test/non-isolated-runner.ts"))},
@@ -96,26 +144,67 @@ export default {
 };
 `,
     );
-    const env: NodeJS.ProcessEnv = { ...process.env };
-    for (const key of Object.keys(env)) {
-      if (key.startsWith("VITEST") || key.startsWith("OPENCLAW_") || key === "LIVE") {
-        delete env[key];
-      }
-    }
-    Object.assign(env, { HOME: home, USERPROFILE: home, TMPDIR: tmp, TMP: tmp, TEMP: tmp });
+    const env: NodeJS.ProcessEnv = {
+      PATH: process.env.PATH,
+      HOME: home,
+      USERPROFILE: home,
+      TMPDIR: tmp,
+      TMP: tmp,
+      TEMP: tmp,
+      XDG_CONFIG_HOME: path.join(home, "config"),
+      XDG_CACHE_HOME: path.join(home, "cache"),
+      XDG_DATA_HOME: path.join(home, "data"),
+      XDG_STATE_HOME: path.join(home, "state"),
+      LIVE: "0",
+      OPENCLAW_LIVE_TEST: "0",
+      OPENCLAW_LIVE_GATEWAY: "0",
+      CI: "1",
+      PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN: "false",
+      pnpm_config_verify_deps_before_run: "false",
+    };
+    const vitestArgs = ["--root", root, "--configLoader", "native"];
+    const profileDir = path.join(root, "profiles");
+    const mirrorPath = path.join(root, "mirror.ansi");
+    const batchEntry = path.join(root, "batch.mts");
+    fs.writeFileSync(
+      batchEntry,
+      `import { runVitestBatch } from ${JSON.stringify(path.join(repoRoot, "scripts/lib/vitest-batch-runner.mts"))};
+process.exitCode = await runVitestBatch({ config: ${JSON.stringify(configPath)}, args: ${JSON.stringify(vitestArgs)}, targets: [], env: process.env });`,
+    );
+    const args =
+      route === "main"
+        ? [
+            path.join(repoRoot, "scripts/run-vitest.mjs"),
+            "run",
+            "--config",
+            configPath,
+            ...vitestArgs,
+          ]
+        : route === "batch"
+          ? [batchEntry]
+          : route === "live"
+            ? [path.join(repoRoot, "scripts/test-live.mts"), "--", ...vitestArgs]
+            : route === "pty"
+              ? [
+                  path.join(repoRoot, "scripts/dev/tui-pty-test-watch.ts"),
+                  "--mode",
+                  "all",
+                  "--no-alt-screen",
+                  "--mirror-path",
+                  mirrorPath,
+                  "--",
+                  ...vitestArgs,
+                ]
+              : [
+                  path.join(repoRoot, "scripts/run-vitest-profile.mts"),
+                  route === "profile-main" ? "main" : "runner",
+                  "--output-dir",
+                  profileDir,
+                  "--",
+                  ...vitestArgs,
+                ];
     try {
-      const result = await execFileAsync(
-        process.execPath,
-        [
-          path.join(repoRoot, "scripts/run-vitest.mjs"),
-          "run",
-          "--root",
-          root,
-          "--config",
-          configPath,
-        ],
-        { cwd: repoRoot, env },
-      ).then(
+      const result = await execFileAsync(process.execPath, args, { cwd: root, env }).then(
         ({ stdout, stderr }) => ({ code: 0, output: stdout + stderr }),
         (error: { code: number; stdout: string; stderr: string }) => ({
           code: error.code,
@@ -123,11 +212,26 @@ export default {
         }),
       );
       expect(result.code, result.output).toBe(failRun ? 1 : 0);
+      if (failRun) expect(result.output).toContain("intentional failure after SQLite allocation");
       const receipt = JSON.parse(fs.readFileSync(receiptPath, "utf8")) as {
         path: string;
         resetVerified: boolean;
+        resources: Array<{ home: string; cache: string; roots: string[] }>;
       };
       expect(receipt.resetVerified).toBe(true);
+      for (const resource of receipt.resources) {
+        for (const owned of [resource.home, resource.cache, ...resource.roots]) {
+          expect(fs.existsSync(owned), owned).toBe(false);
+        }
+      }
+      if (route.startsWith("profile-")) {
+        const artifacts = fs.readdirSync(profileDir);
+        expect(artifacts.some((file) => file.endsWith(".cpuprofile"))).toBe(true);
+        if (route === "profile-runner")
+          expect(artifacts.some((file) => file.endsWith(".heapprofile"))).toBe(true);
+      }
+      if (route === "pty")
+        expect(fs.readFileSync(mirrorPath, "utf8")).toContain("namespace fixture frame");
       expect(fs.existsSync(path.dirname(path.dirname(receipt.path)))).toBe(false);
       expect(sibling.prepare("PRAGMA quick_check").get()).toEqual({ quick_check: "ok" });
       expect(fs.existsSync(siblingRoot)).toBe(true);
@@ -141,6 +245,61 @@ export default {
       }
     } finally {
       sibling.close();
+    }
+  },
+);
+
+posixIt("removes only its namespace when spawning fails before acquiring a PID", async () => {
+  const root = tempDirs.make("oc-vt-spawn-");
+  const sentinel = path.join(root, "caller");
+  fs.writeFileSync(sentinel, "keep");
+  const options = { env: { TMPDIR: root }, stdio: "ignore" as const };
+  expect(() => spawnOwnedVitestProcess({ command: "", args: [], options })).toThrow();
+  const { child, completion } = spawnOwnedVitestProcess({
+    command: process.execPath,
+    args: [],
+    options: { ...options, cwd: path.join(root, "missing") },
+  });
+  await expect(completion).rejects.toMatchObject({ code: "ENOENT" });
+  expect(child.pid).toBeUndefined();
+  expect(fs.readdirSync(root)).toEqual(["caller"]);
+  expect(fs.readFileSync(sentinel, "utf8")).toBe("keep");
+});
+
+posixIt(
+  "retains the exact namespace with recovery guidance when group verification fails",
+  async () => {
+    const root = tempDirs.make("oc-vt-unverified-");
+    const receipt = path.join(root, "namespace");
+    const { child, completion } = spawnOwnedVitestProcess({
+      command: process.execPath,
+      args: [
+        "-e",
+        `require("node:fs").writeFileSync(${JSON.stringify(receipt)}, require("node:os").tmpdir())`,
+      ],
+      options: { env: { TMPDIR: root }, stdio: "ignore" },
+    });
+    const closed = new Promise<void>((resolve) => child.once("close", () => resolve()));
+    const nativeKill = process.kill.bind(process);
+    const failure = Object.assign(new Error("injected group probe failure"), { code: "EIO" });
+    const kill = vi.spyOn(process, "kill").mockImplementation((pid, signal) => {
+      if (pid === -child.pid! && signal === 0) throw failure;
+      return nativeKill(pid, signal);
+    });
+    try {
+      await expect(completion).rejects.toMatchObject({
+        message: expect.stringContaining(
+          "Stop the remaining writers before removing this exact directory",
+        ),
+        cause: failure,
+      });
+      await closed;
+      const namespace = fs.readFileSync(receipt, "utf8");
+      expect(path.dirname(namespace)).toBe(root);
+      expect(fs.existsSync(namespace)).toBe(true);
+    } finally {
+      kill.mockRestore();
+      await closed;
     }
   },
 );

--- a/test/scripts/test-live.test.ts
+++ b/test/scripts/test-live.test.ts
@@ -1,6 +1,6 @@
 // Test Live tests cover test live script behavior.
 import { spawn, spawnSync } from "node:child_process";
-import { chmodSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { createInterface } from "node:readline";
@@ -83,45 +83,49 @@ describe("scripts/test-live", () => {
     });
   });
 
-  posixIt("signals the live pnpm child when the wrapper is terminated", async ({ signal }) => {
-    const root = mkdtempSync(join(tmpdir(), "openclaw-test-live-signal-"));
-    const fakePnpmPath = join(root, "pnpm");
-    const signaledPath = join(root, "signaled");
+  posixIt.for(["SIGINT", "SIGTERM"] as const)(
+    "signals the live pnpm child on %s and removes its joined namespace",
+    async (stopSignal, { signal }) => {
+      const root = mkdtempSync(join(tmpdir(), "openclaw-test-live-signal-"));
+      const fakePnpmPath = join(root, "pnpm");
+      const signaledPath = join(root, "signaled");
 
-    writeFakePnpm(fakePnpmPath);
-    const runner = spawn(
-      process.execPath,
-      ["--import", "tsx", "scripts/test-live.mts", "--", "fake.live.test.ts"],
-      {
-        env: {
-          ...process.env,
-          OPENCLAW_FAKE_PNPM_SIGNALED_PATH: signaledPath,
-          npm_execpath: fakePnpmPath,
+      writeFakePnpm(fakePnpmPath);
+      const runner = spawn(
+        process.execPath,
+        ["--import", "tsx", "scripts/test-live.mts", "--", "fake.live.test.ts"],
+        {
+          env: {
+            ...process.env,
+            OPENCLAW_FAKE_PNPM_SIGNALED_PATH: signaledPath,
+            npm_execpath: fakePnpmPath,
+          },
+          stdio: ["ignore", "pipe", "ignore"],
         },
-        stdio: ["ignore", "pipe", "ignore"],
-      },
-    );
-    let childPid = 0;
-    let descendantPid = 0;
+      );
+      let childPid = 0;
+      let descendantPid = 0;
 
-    try {
-      ({ childPid, descendantPid } = await waitForFixtureReady(runner, signal));
+      try {
+        ({ childPid, descendantPid } = await waitForFixtureReady(runner, signal));
 
-      expect(runner.pid).toBeGreaterThan(0);
-      const completion = waitForClose(runner);
-      process.kill(runner.pid!, "SIGTERM");
-      const result = await completion;
+        expect(runner.pid).toBeGreaterThan(0);
+        const completion = waitForClose(runner);
+        process.kill(runner.pid!, stopSignal);
+        const result = await completion;
 
-      expect(result).toEqual({ code: null, signal: "SIGTERM" });
-      await waitFor(() => fileExists(signaledPath), 5_000);
-      expect(readFileSync(signaledPath, "utf8")).toBe("SIGTERM");
-      await waitFor(() => !isProcessAlive(childPid), 5_000);
-      await waitFor(() => !isProcessAlive(descendantPid), 5_000);
-    } finally {
-      await stopFixture(runner, [childPid, descendantPid]);
-      rmSync(root, { force: true, recursive: true });
-    }
-  });
+        expect(result).toEqual({ code: null, signal: stopSignal });
+        await waitFor(() => fileExists(signaledPath), 5_000);
+        expect(readFileSync(signaledPath, "utf8")).toBe(stopSignal);
+        await waitFor(() => !isProcessAlive(childPid), 5_000);
+        await waitFor(() => !isProcessAlive(descendantPid), 5_000);
+        expect(existsSync(readFileSync(join(root, "namespace"), "utf8"))).toBe(false);
+      } finally {
+        await stopFixture(runner, [childPid, descendantPid]);
+        rmSync(root, { force: true, recursive: true });
+      }
+    },
+  );
 
   posixIt("kills the live pnpm process group after the no-output timeout", async ({ signal }) => {
     const root = mkdtempSync(join(tmpdir(), "openclaw-test-live-timeout-"));
@@ -175,6 +179,7 @@ describe("scripts/test-live", () => {
       expect(Buffer.concat(stderr).toString("utf8")).toContain("[test:live] still running");
       await waitFor(() => !isProcessAlive(childPid), 5_000);
       await waitFor(() => !isProcessAlive(descendantPid), 5_000);
+      expect(existsSync(readFileSync(join(root, "namespace"), "utf8"))).toBe(false);
     } finally {
       await stopFixture(runner, [childPid, descendantPid]);
       rmSync(root, { force: true, recursive: true });
@@ -221,8 +226,11 @@ function writeFakePnpm(filePath: string): void {
       "#!/usr/bin/env node",
       'const { spawn } = require("node:child_process");',
       'const fs = require("node:fs");',
-      'process.on("SIGTERM", () => {',
-      '  fs.writeFileSync(process.env.OPENCLAW_FAKE_PNPM_SIGNALED_PATH, "SIGTERM");',
+      'const tmp = require("node:os").tmpdir();',
+      'fs.writeFileSync(require("node:path").join(__dirname, "namespace"), tmp);',
+      'fs.writeFileSync(require("node:path").join(tmp, "owned-marker"), "owned");',
+      'for (const signal of ["SIGINT", "SIGTERM"]) process.on(signal, () => {',
+      "  fs.writeFileSync(process.env.OPENCLAW_FAKE_PNPM_SIGNALED_PATH, signal);",
       "  process.exit(0);",
       "});",
       "const child = spawn(process.execPath, [",


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where running OpenClaw's plugin-batch, live-test, profiling, or TUI PTY test launchers could leave isolated test homes and their generated JIT caches behind even when the tests passed. Repeated runs could accumulate abandoned directories and consume substantial disk space.

The main test runner already owned a temporary namespace, but the other launchers bypassed that owner. Worker `process.once("exit")` hooks are not a reliable cleanup boundary: ordinary Vitest thread termination and fork shutdown can complete without delivering those hooks. SDK helpers also leave empty shared allocation roots after removing their individual case directories; that is a separate retention mechanism covered by the enclosing run namespace.

## Why This Change Was Made

Extract the existing namespace lifecycle into one shared spawn/completion owner and use it across the main runner, plugin batches, live tests, both profiler modes, and the PTY watcher. Each POSIX invocation receives a unique temporary namespace through `TMPDIR`, `TMP`, and `TEMP`. Only that exact namespace is removed, and only after the child process group and output pipes have joined. Failed or unverified group completion retains the directory and reports its exact path for recovery.

This is an owner-boundary repair rather than a cache sweep. It removes duplicated/bypassing launch paths and PTY leader-exit-only completion without changing production JIT caching, worker defaults, dependencies, configuration, or SQLite schemas. The profiler now joins asynchronously while retaining its original profiling target and artifact destination. Existing heartbeat, output, and Ctrl-C escalation policies remain with their respective launchers.

## User Impact

Developers using the maintained POSIX test runners no longer accumulate these run-owned homes, JIT caches, and shared helper roots after the covered completion and shutdown paths. Explicit caller-owned state and artifacts outside the namespace—including SQLite files, CPU/heap profiles, and PTY mirrors—remain untouched. No existing abandoned homes are swept or removed by this change.

Windows and raw external Vitest invocations retain their existing behavior. Forced supervisor death, such as `SIGKILL`, can prevent final cleanup. Descendants that deliberately escape the managed process group remain outside the cleanup guarantee and can recreate removed paths. These limits are documented rather than hidden behind global age-based deletion.

## Evidence

- Before changing the lifecycle owner, the real-wrapper regression passed for the main runner and failed for all five bypass routes: plugin batch, live, main profiler, worker profiler, and PTY. Each failure observed its recorded isolated home still present after a successful child run.
- After the repair, the combined focused run passed **393 tests across 7 files**. The namespace fixture covers threads and forks, passing and failing runs, ordered non-isolated files, module resets, actual Jiti-generated files, SDK/shared-home roots, a concurrently open caller-owned sibling SQLite database, and explicit state outside the namespace. It also verifies retained profile and mirror artifacts, failed spawn cleanup, and safe retention when process-group verification fails.
- A fresh-process shutdown matrix passed **18 cases** covering forwarded signals, child/worker crashes, watchdogs, and late writers that remain in the owned process group. Every case verified its owned PIDs/groups had stopped and recorded homes were removed. A separate escaped-descendant probe established the documented limitation; it is not treated as proof about the cause of any historical disk backlog.
- Re-running the original passing-run reproduction produced the same successful exit, but changed the recorded home from retained before the fix to absent afterward, with all owned writers confirmed gone.

Focused command:

```bash
node scripts/run-vitest.mjs test/scripts/run-vitest-state-cleanup.test.ts test/scripts/test-live.test.ts test/scripts/test-extension.test.ts test/scripts/run-vitest-profile.test.ts test/scripts/vitest-process-group.test.ts test/scripts/run-vitest.test.ts test/scripts/dev-tooling-safety.test.ts -- --maxWorkers=1
```

Changed-file checks passed, including formatting, script erasability, script/root-test typechecks, targeted lint, and classified guards. `git diff --check` passed. Fresh independent Codex autoreview completed scoped-clean at the default P0 threshold, with no accepted/actionable P0 findings; lower-priority issues were outside that review threshold. [Exact-head hosted CI run 33221394051](https://github.com/openclaw/openclaw/actions/runs/33221394051) passed for `1698aaa157bec8b6e8d63695cad8b38fe36aad27`, including `openclaw/ci-gate`. Native review artifacts validated, the designated lead approved landing, and native prepare/merge completed successfully as [208f55154278](https://github.com/openclaw/openclaw/commit/208f551542784d77678ce3920cbb098eeda66964). The [CI recovery note](https://github.com/openclaw/openclaw/pull/132208#issuecomment-5458906858) records the earlier unrelated shard-bound failure and patch-identical rebase onto its main-tree fix.

Size: product runtime **0 lines changed**; scripts/tooling **+155/-139 (net +16)**; tests and embedded fixture support **+239/-72 (net +167)**; documentation **+15/-7**. Moved lifecycle code contributes no net growth. The remaining tooling growth supplies joined profiler/PTY completion and actionable retention diagnostics while keeping launcher policy separate.

AI-assisted implementation and review. No screenshots are applicable: this changes test-process resource ownership, not a product UI.
