### PR TITLE
fix(build): reject native declaration compiler failures

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,7 @@ overrides:
   typebox: 1.3.16
   tar: 7.5.22
   tough-cookie: 6.0.2
+  tsdown>rolldown-plugin-dts: 0.28.2
   zca-js@2.1.2>tough-cookie: 5.1.2
   yauzl: 3.4.0
   protobufjs: 8.7.2
@@ -8598,13 +8599,13 @@ packages:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
 
-  rolldown-plugin-dts@0.27.14:
-    resolution: {integrity: sha512-ZvuDDwoIpRK9RPxDXratCpklFO9QZZWndf/sd0VBFb4LEj0jj07UcHK9OCh7V4XiFz2Z89ziyBC2K6tJiDjrbw==}
-    engines: {node: ^22.18.0 || >=24.11.0}
+  rolldown-plugin-dts@0.28.2:
+    resolution: {integrity: sha512-U0Ng45ZaESZ7rJtQtgCWkJYCpMgH42yIj3xv9HGAsh/dJ8XBhjI4lcqh4NOWx8+CAxoY2HWg8VYINML2yE9A5A==}
+    engines: {node: ^22.18.0 || ^24.11.0 || >=26.0.0}
     peerDependencies:
       '@typescript/native-preview': '*'
       '@volar/typescript': ~2.4.0
-      rolldown: ^1.0.0
+      rolldown: ^1.2.0
       typescript: ^5.0.0 || ^6.0.0 || ~7.0.0
       vue-tsc: ~3.2.0 || ~3.3.0
     peerDependenciesMeta:
@@ -16192,7 +16193,7 @@ snapshots:
 
   reusify@1.1.0: {}
 
-  rolldown-plugin-dts@0.27.14(@typescript/native-preview@7.0.0-dev.20260707.2)(rolldown@1.2.0)(typescript@6.0.3):
+  rolldown-plugin-dts@0.28.2(@typescript/native-preview@7.0.0-dev.20260707.2)(rolldown@1.2.0)(typescript@6.0.3):
     dependencies:
       dts-resolver: 3.0.0
       get-tsconfig: 5.0.0-beta.5
@@ -16799,7 +16800,7 @@ snapshots:
       obug: 2.1.4
       picomatch: 4.0.5
       rolldown: 1.2.0
-      rolldown-plugin-dts: 0.27.14(@typescript/native-preview@7.0.0-dev.20260707.2)(rolldown@1.2.0)(typescript@6.0.3)
+      rolldown-plugin-dts: 0.28.2(@typescript/native-preview@7.0.0-dev.20260707.2)(rolldown@1.2.0)(typescript@6.0.3)
       tinyexec: 1.2.4
       tinyglobby: 0.2.17
       tree-kill: 1.2.2

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -157,6 +157,7 @@ overrides:
   typebox: 1.3.16
   tar: 7.5.22
   tough-cookie: 6.0.2
+  "tsdown>rolldown-plugin-dts": 0.28.2
   "zca-js@2.1.2>tough-cookie": 5.1.2
   yauzl: 3.4.0
   protobufjs: 8.7.2

--- a/scripts/generate-npm-package-lock.mts
+++ b/scripts/generate-npm-package-lock.mts
@@ -92,14 +92,13 @@ function normalizeOverrides(overrides: unknown): OverrideMap {
       const parentSelector = key.slice(0, scopedSeparator).trim();
       const dependencyName = key.slice(scopedSeparator + 1).trim();
       if (parentSelector && dependencyName) {
-        const current = normalized[parentSelector];
-        const nested = isRecord(current) ? current : {};
-        nested[dependencyName] = normalizeOverrideValue(value);
-        normalized[parentSelector] = nested;
+        mergeOverrideEntry(normalized, parentSelector, {
+          [dependencyName]: normalizeOverrideValue(value),
+        });
         continue;
       }
     }
-    normalized[key] = normalizeOverrideValue(value);
+    mergeOverrideEntry(normalized, key, normalizeOverrideValue(value));
   }
   return normalized;
 }
@@ -425,35 +424,26 @@ function mergeOverrideEntry(merged: OverrideMap, name: string, spec: unknown): v
     merged[name] = spec;
     return;
   }
-  if (isRecord(current) && isRecord(spec)) {
-    for (const [nestedName, nestedSpec] of Object.entries(spec)) {
-      mergeOverrideEntry(current, nestedName, nestedSpec);
-    }
-    return;
-  }
-  if (
-    typeof current === "string" &&
-    isRecord(spec) &&
-    typeof spec["."] === "string" &&
-    exactOverrideVersionsMatch(current, spec["."])
-  ) {
-    const mergedEntry = { ".": preferredExactOverrideRootSpec(current, spec["."]) };
-    merged[name] = mergedEntry;
-    for (const [nestedName, nestedSpec] of Object.entries(spec)) {
-      if (nestedName === ".") {
-        continue;
+  if (isRecord(current) || isRecord(spec)) {
+    // npm's scalar shorthand constrains the package itself, not its children.
+    // Promote it to "." so either input order retains both policies.
+    const currentObject = typeof current === "string" ? { ".": current } : current;
+    const incomingObject = typeof spec === "string" ? { ".": spec } : spec;
+    if (isRecord(currentObject) && isRecord(incomingObject)) {
+      merged[name] = currentObject;
+      for (const [nestedName, nestedSpec] of Object.entries(incomingObject)) {
+        mergeOverrideEntry(currentObject, nestedName, nestedSpec);
       }
-      mergeOverrideEntry(mergedEntry, nestedName, nestedSpec);
+      return;
     }
-    return;
   }
   if (
-    isRecord(current) &&
+    name === "." &&
+    typeof current === "string" &&
     typeof spec === "string" &&
-    typeof current["."] === "string" &&
-    exactOverrideVersionsMatch(current["."], spec)
+    exactOverrideVersionsMatch(current, spec)
   ) {
-    current["."] = preferredExactOverrideRootSpec(current["."], spec);
+    merged[name] = preferredExactOverrideRootSpec(current, spec);
     return;
   }
   if (JSON.stringify(current) !== JSON.stringify(spec)) {

--- a/test/package-manager-config.test.ts
+++ b/test/package-manager-config.test.ts
@@ -109,6 +109,42 @@ describe("package manager build policy", () => {
     });
   });
 
+  it.each(
+    (
+      [
+        ["package", "workspace"],
+        ["package", "lock"],
+        ["workspace", "lock"],
+      ] as const
+    ).flatMap(([first, second]) =>
+      [false, true].flatMap((childrenFirst) =>
+        ["1.2.3", "npm:@scope/parent@1.2.3"].map((rootSpec) => ({
+          first,
+          second,
+          childrenFirst,
+          rootSpec,
+        })),
+      ),
+    ),
+  )(
+    "retains child policy and $rootSpec across sources $first/$second (childrenFirst=$childrenFirst)",
+    ({ first, second, childrenFirst, rootSpec }) => {
+      const sources: Record<"package" | "workspace" | "lock", Record<string, unknown>> = {
+        package: {},
+        workspace: {},
+        lock: {},
+      };
+      const children = { parent: { child: "2.0.0" } };
+      const self = { parent: rootSpec };
+      sources[first] = childrenFirst ? children : self;
+      sources[second] = childrenFirst ? self : children;
+
+      expect(mergeOverrides(sources.package, sources.workspace, sources.lock)).toEqual({
+        parent: { ".": rootSpec, child: "2.0.0" },
+      });
+    },
+  );
+
   it("preserves npm alias pins when merging nested lock-derived pins", () => {
     expect(
       mergeOverrides(
@@ -139,18 +175,21 @@ describe("package manager build policy", () => {
     });
   });
 
-  it("rejects non-exact root pins when merging nested pins", () => {
+  it.each([
+    ["^1.0.0", "~1.0.0"],
+    ["1.0.0", "2.0.0"],
+  ])("rejects conflicting root pins %s and %s when merging nested pins", (left, right) => {
     expect(() =>
       mergeOverrides(
-        { "floating-package": "^1.0.0" },
-        { "floating-package": { ".": "~1.0.0", child: "2.0.0" } },
+        { "floating-package": left },
+        { "floating-package": { ".": right, child: "2.0.0" } },
         {},
       ),
     ).toThrow(/conflicts with pnpm lock policy/u);
     expect(() =>
       mergeOverrides(
-        { "floating-package": { ".": "^1.0.0", child: "2.0.0" } },
-        { "floating-package": "~1.0.0" },
+        { "floating-package": { ".": left, child: "2.0.0" } },
+        { "floating-package": right },
         {},
       ),
     ).toThrow(/conflicts with pnpm lock policy/u);

--- a/test/scripts/generate-npm-package-lock.test.ts
+++ b/test/scripts/generate-npm-package-lock.test.ts
@@ -103,6 +103,22 @@ describe("generate-npm-package-lock", () => {
     });
   });
 
+  it.each([false, true])(
+    "retains parent and child overrides during normalization (childrenFirst=%s)",
+    (childrenFirst) => {
+      const entries = [
+        ["parent", "1.2.3"],
+        ["parent>child", "2.0.0"],
+        ["parent>sibling", "3.0.0"],
+      ];
+      expect(
+        normalizeOverrides(Object.fromEntries(childrenFirst ? entries.toReversed() : entries)),
+      ).toEqual({
+        parent: { ".": "1.2.3", child: "2.0.0", sibling: "3.0.0" },
+      });
+    },
+  );
+
   it("rejects short flag package selectors before resolving npm-lock targets", () => {
     expect(() => resolvePackageDirs(["--package-dir", "-h"])).toThrow(
       "--package-dir requires a package directory.",

--- a/test/scripts/tsdown-build.test.ts
+++ b/test/scripts/tsdown-build.test.ts
@@ -2254,6 +2254,69 @@ describe("runTsdownBuildInvocation", () => {
     expect(output.chunks.join("")).toContain("stdout-ok");
   });
 
+  it("preserves successful declarations when the native compiler fails", async () => {
+    const rootDir = fs.realpathSync(createTempDir("openclaw-tsdown-native-dts-"));
+    const sourcePath = path.join(rootDir, "index.ts");
+    const declarationPath = path.join(rootDir, "dist", "index.d.ts");
+    fs.writeFileSync(path.join(rootDir, "package.json"), '{"type":"module"}\n');
+    fs.writeFileSync(
+      path.join(rootDir, "tsconfig.json"),
+      JSON.stringify({
+        compilerOptions: {
+          target: "ESNext",
+          module: "ESNext",
+          moduleResolution: "Bundler",
+          declaration: true,
+          emitDeclarationOnly: true,
+          noCheck: true,
+          noEmitOnError: false,
+          rootDir,
+        },
+        files: [sourcePath],
+      }),
+    );
+    const buildOptions = {
+      clean: false,
+      config: false,
+      cwd: rootDir,
+      entry: [sourcePath],
+      fixedExtension: false,
+      format: "esm",
+      logLevel: "error",
+      outDir: path.join(rootDir, "dist"),
+      platform: "node",
+      report: false,
+      tsconfig: path.join(rootDir, "tsconfig.json"),
+    };
+    const script = [
+      'import { build } from "tsdown";',
+      'const nativePackage = import.meta.resolve("@typescript/native-preview/package.json");',
+      'const { default: getExePath } = await import(new URL("lib/getExePath.js", nativePackage).href);',
+      `await build({ ...${JSON.stringify(buildOptions)}, dts: { generator: "tsgo", emitDtsOnly: true, tsgo: { path: getExePath() } } });`,
+    ].join("\n");
+    const output = createWriteSink();
+    // Keep compiler scratch output inside the fixture even when compilation rejects.
+    const env = { ...process.env, TMPDIR: rootDir, TEMP: rootDir, TMP: rootDir };
+    const invocation = {
+      command: process.execPath,
+      args: ["--input-type=module", "-e", script],
+      options: { stdio: ["ignore", "pipe", "pipe"], shell: false, env },
+    };
+    const runOptions = { stdout: output.sink, stderr: output.sink };
+
+    fs.writeFileSync(sourcePath, 'export const broken = "healthy";\n');
+    const healthy = await runTsdownBuildInvocation(invocation, runOptions);
+    expect(healthy.status, healthy.captured).toBe(0);
+    const declarations = fs.readFileSync(declarationPath, "utf8");
+    expect(declarations).toContain('"healthy"');
+
+    fs.writeFileSync(sourcePath, "export const broken = ;\n");
+    const failed = await runTsdownBuildInvocation(invocation, runOptions);
+    expect(failed.captured).toContain("TS1109");
+    expect(failed.status, failed.captured).toBeGreaterThan(0);
+    expect(fs.readFileSync(declarationPath, "utf8")).toBe(declarations);
+  });
+
   it("rejects malformed OPENCLAW_TSDOWN_TIMEOUT_MS values", async () => {
     const invocation = {
       command: process.execPath,


### PR DESCRIPTION
Related upstream fix: [reject failed native compiler processes](https://github.com/sxzz/rolldown-plugin-dts/pull/282).

<details>
<summary>Additional instructions</summary>

Maintainers with repository push access can update this same-repository branch.

</details>

## What Problem This Solves

Fixes an issue where developers using native TypeScript declaration generation could get a successful build and overwritten declaration output even though the compiler reported a syntax error. With `noEmitOnError: false`, the compiler can emit partial declarations while returning exit code 2; the old plugin incorrectly accepted that output. Compiler termination by signal had the same false-success behavior.

## Why This Change Was Made

Use the published owner fix in `rolldown-plugin-dts` 0.28.2 rather than adding a compiler-error workaround to OpenClaw. The override is limited to `tsdown>rolldown-plugin-dts` because the current tsdown 0.22.14 dependency range (`^0.27.13`) cannot select the fixed release normally. No other dependency versions change.

CI exposed a latent npm-lock projection bug: the independent parent version pin and scoped child override were treated as conflicting. The same PR normalizes both into npm's canonical `"."` self-pin representation and uses one merge path, preserving children, alias constraints, and rejection of genuine conflicts. This is a generic owner repair, not a package-specific exception.

Version 0.28.2 was published on **August 12, 2026 at 19:07 UTC**, more than seven days before selection. Version 0.28.3 was newly published on August 28 and was deliberately not selected. Remove this override once tsdown's normal dependency range includes a fixed release.

## User Impact

Native declaration compiler failures now fail the enclosing build instead of passing partial SDK type artifacts onward to packaging. The regression verifies that an existing good declaration is preserved when output cleaning is disabled. Successful declaration generation remains supported; running Gateway behavior is unchanged.

Compatibility note: the new build-tool package declares Node 22.18+, Node 24.11+, and Node 26+ support, excluding Node 25. OpenClaw's runtime engine declaration is unchanged; source-build validation here covers Node 24 and 26. The separate upstream temporary-directory leak on failed compilation remains outside this build-tool fix; no unpublished patch is included.

## Evidence

A real-process regression was added at the existing `runTsdownBuildInvocation` boundary. It builds healthy declarations through the public tsdown API, introduces `export const broken = ;`, and asserts the compiler diagnostic, nonzero build status, and unchanged previous declarations. The test fails with the original dependency and passes with the override.

| Real tsdown flow | 0.27.14 | 0.28.2 |
| --- | --- | --- |
| Healthy native declaration build | Exit 0 | Exit 0 |
| Malformed TypeScript (`TS1109`) | Exit 0, incorrect | Exit 1 |
| Existing declarations after malformed input | Overwritten | Preserved byte-for-byte |
| Task-owned compiler terminated by `SIGTERM` | Exit 0, incorrect | Exit 1 with signal diagnostic |
| Existing declarations after signal | Overwritten | Preserved byte-for-byte |

The native compiler itself returned **2** and emitted a partial declaration in both syntax-error probes. The installed 0.28.2 package was compared byte-for-byte with the integrity-verified npm artifact.

**Pre-rebase validation:** the following results were collected on the approved patch based on `0924fd9a0c401464d6257ca59a160d1b292f5441`, before branch synchronization. They are not exact-head build results for the rebased PR:

```bash
pnpm test test/scripts/tsdown-build.test.ts
```

All **157 tests passed on Node 24.20.0 and Node 26.7.0**.

```bash
pnpm build
```

Both the baseline and upgraded full builds passed, including SDK generation, the 147-public-subpath consumer/declaration-graph check, plugin builds, and UI build checks.

```bash
pnpm tsgo:test:root
```

```bash
pnpm tsgo:scripts
```

Focused lint/formatting, dependency pin/patch/root-ownership checks, and `git diff --check` also passed. Those local checks did not run full-repository Vitest, the all-lane changed gate, cross-OS runs, or live provider/channel tests.

**Earlier publication validation (not the current head):** head `68bb307533cd0295f7cc165f5c8dbb0dab3a3e72` was based on `b4833bf0eff0f99bda1adab7d3c1b821a23a75e0`. Its complete build-wrapper and declaration-source suites passed **161 tests** on Node 26.7.0. A first run concurrent with typechecking and lint hit the existing process-group SIGTERM test's two-second child-startup wait; one unchanged rerun after the other checks finished passed. No timeout, assertion, source, or test was changed. The declaration-source suite covered main's `eager`/`tsconfigRaw` caller, transitive type-only imports, and preservation on discovery failure. The earlier full builds above remain pre-rebase evidence; no controlled speedup or output-byte-equivalence claim is made for the full build.

### CI follow-up: npm override projection

[The first CI run](https://github.com/openclaw/openclaw/actions/runs/33221323524) tested merge `7f3295e5add7d666443e51be456cf4adc66f410e` based on `a49da4208bc85b6af5b82e87cf495f38de9a042b`. `check-npm-lock`, `checks-node-compact-small-29` (package-manager policy), and `checks-node-compact-small-35` (portable plugin staging) all failed with the same `package.json overrides.tsdown conflicts with pnpm lock policy for tsdown` exception. The repair belongs to the shared override merge owner; its consumers and validators are unchanged.

The added normalization/merge regressions fail before the repair. Before integration, the repair passed **94/94 npm locks**, **63 focused policy/generator/runner tests**, the native compiler regression, and the exact portable-staging case. Real npm fixtures covered ordinary and aliased parent packages; genuine conflicting direct dependency pins still produced `EOVERRIDE`. Intentional scoped version forks remain allowed.

The independent UI guard failure (`724 > 720`) in that old merge tree was already fixed by [the shared native-assets and UI shard split change](https://github.com/openclaw/openclaw/pull/132193), commit `249c248285b03eacc1fdcb9153bc47c6c3a2ec20`. This branch now incorporates that landed fix through its base. No UI patch, cap increase, baseline change, or skipped gate was added by this PR.

### Integrated-head local proof

Head **`d2355a8aba090008814eaf5c239490a216fba907`** contains two task commits, rebased onto pinned main **`ad6739064efa23cdc9666eb05208a6e5cf0658cf`**. Both rebased without conflicts; `git range-diff` shows both patches unchanged and the frozen npm-repair source hashes still match. The landed UI fix is an ancestor. Validation used Node **26.7.0** and repository-pinned pnpm **11.22.0**, with Vitest serialized separately from type/lint work.

```bash
pnpm install --frozen-lockfile --ignore-scripts --prefer-offline
```

```bash
pnpm lint:tmp:tsgo-core-boundary
```

```bash
node scripts/run-tsgo-core-test-shards.mjs ui
```

```bash
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs test/scripts/tsgo-core-test-shards.test.ts test/package-manager-config.test.ts test/scripts/generate-npm-package-lock.test.ts test/scripts/npm-runner.test.ts test/scripts/root-package-overrides.test.ts
```

```bash
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs test/plugin-npm-package-manifest.test.ts --testNamePattern 'stages portable bundled dependencies without polluting pack output'
```

```bash
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs test/scripts/tsdown-build.test.ts --testNamePattern 'preserves successful declarations when the native compiler fails'
```

```bash
pnpm deps:npm-lock:check
```

```bash
pnpm tsgo:scripts
```

```bash
pnpm tsgo:test:root
```

```bash
node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.scripts.json scripts/generate-npm-package-lock.mts
```

```bash
node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json test/package-manager-config.test.ts test/scripts/generate-npm-package-lock.test.ts test/scripts/tsdown-build.test.ts
```

```bash
node_modules/.bin/oxfmt --check --no-error-on-unmatched-pattern pnpm-lock.yaml pnpm-workspace.yaml scripts/generate-npm-package-lock.mts test/package-manager-config.test.ts test/scripts/generate-npm-package-lock.test.ts test/scripts/tsdown-build.test.ts
```

```bash
pnpm check:script-erasability
```

```bash
pnpm deps:pins:check
```

```bash
pnpm deps:patches:check
```

```bash
pnpm deps:root-ownership:check
```

```bash
git diff --check ad6739064efa23cdc9666eb05208a6e5cf0658cf...HEAD
```

All 17 commands passed. Fresh proof covers **94/94 npm locks**, **71 focused npm/shard tests**, the exact portable-staging case (**1 passed, 14 deliberately filtered out**), and the native declaration compiler failure regression (**1 passed, 156 deliberately filtered out**). The formerly failing boundary guard, every UI type graph selected by the canonical wrapper, source/test types, scoped lint/formatting, script erasability, dependency pin/patch/root-ownership guards, and whitespace checks passed. No integrated test required a retry. The frozen install passed all **1,626** supply-chain entries and preserved plugin **0.28.2**. Formatting checked five matched files; generated lockfile formatting remains pnpm-owned.

These are fresh integrated checks, not a new full build or full-repository test run. The full builds and complete build-wrapper suites described earlier are historical proof and are not relabeled as current-head results. The fresh GitHub CI result below validates the published head; the old immutable run was not rerun against a different base.

### Fresh pull-request CI

[CI run 33225040194](https://github.com/openclaw/openclaw/actions/runs/33225040194), attempt **1**, completed **successfully** for head `d2355a8aba090008814eaf5c239490a216fba907`: **168 successful jobs, 16 workflow-skipped jobs, no failures**. Its recorded base is `52e43a4a4feec44d4b14ac14eccce68095ef2b82`. The verified merge commit `299c587baf5e709917938764d09c759e983be8aa` has exactly that base and PR head as parents and contains the already-landed UI fix `249c248285b03eacc1fdcb9153bc47c6c3a2ec20`.

| Repaired check / aggregate | Result | Job |
| --- | --- | --- |
| `check-npm-lock` | Passed | [99026998061](https://github.com/openclaw/openclaw/actions/runs/33225040194/job/99026998061) |
| `checks-node-compact-small-29` | Passed | [99027000064](https://github.com/openclaw/openclaw/actions/runs/33225040194/job/99027000064) |
| `checks-node-compact-small-35` | Passed | [99027000021](https://github.com/openclaw/openclaw/actions/runs/33225040194/job/99027000021) |
| `check-guards` | Passed | [99026998056](https://github.com/openclaw/openclaw/actions/runs/33225040194/job/99026998056) |
| `openclaw/ci-gate` | Passed | [99028139937](https://github.com/openclaw/openclaw/actions/runs/33225040194/job/99028139937) |

All five core test-type stripes also passed. The canonical watcher completed with exit **0**; no CI rerun was needed.

```bash
node scripts/watch-pr-ci.mjs 132210 d2355a8aba090008814eaf5c239490a216fba907 --after 33221323524 --attach-timeout 180 --timeout 1020 --interval 120 --completion ci-run
```

The PR remains open and ready for review; it has not been merged.

Independent Codex autoreview reported no accepted/actionable findings at its default P0 threshold for both the original override and the npm projection repair. Production runtime LOC: **+0/-0**; npm tooling: **+18/-28** (net **−10**); dependency configuration: **+1/-0**; regression tests: **+123/-5**; generated lockfile: **+7/-6**.

AI-assisted implementation and verification.

### Node 25 proof and maintainer disposition

[The pre-merge maintainer decision and Node 25.9.0 proof](https://github.com/openclaw/openclaw/pull/132210#issuecomment-5459596881) supplement the Node 24/26 evidence above. Healthy native declarations pass; malformed-source and SIGTERM failures exit nonzero and preserve prior declarations. The approved 0.28.2 selection and OpenClaw runtime engines remain unchanged. Upstream engine metadata still excludes Node 25, and strict-engine Node 25 installs are not claimed supported. The linked decision explicitly dispositions the ClawSweeper rank-up request.
