### PR TITLE
refactor(channels): remove duplicate setup return assertions

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -431,7 +431,6 @@ extensions/discord/src/send.shared.ts	4
 extensions/discord/src/send.webhook.ts	1
 extensions/discord/src/setup-account-state.ts	1
 extensions/discord/src/setup-core.ts	1
-extensions/discord/src/shared.ts	1
 extensions/discord/src/status-issues.ts	1
 extensions/discord/src/target-parsing.ts	1
 extensions/discord/src/token.ts	2
@@ -1210,7 +1209,6 @@ extensions/slack/src/security-audit.ts	6
 extensions/slack/src/send.ts	6
 extensions/slack/src/setup-core.ts	7
 extensions/slack/src/setup-surface.ts	1
-extensions/slack/src/shared.ts	1
 extensions/slack/src/streaming.ts	3
 extensions/slack/src/target-parsing.ts	1
 extensions/sms/src/accounts.ts	1

--- a/extensions/discord/src/shared.ts
+++ b/extensions/discord/src/shared.ts
@@ -174,21 +174,5 @@ export function createDiscordPluginBase(params: {
       collectUnsupportedSecretRefConfigCandidates,
       collectRuntimeConfigAssignments,
     },
-  } as Pick<
-    ChannelPlugin<ResolvedDiscordAccount>,
-    | "id"
-    | "meta"
-    | "setupWizard"
-    | "capabilities"
-    | "commands"
-    | "doctor"
-    | "streaming"
-    | "reload"
-    | "configSchema"
-    | "config"
-    | "setupContract"
-    | "messaging"
-    | "security"
-    | "secrets"
-  >;
+  };
 }

--- a/extensions/slack/src/shared.ts
+++ b/extensions/slack/src/shared.ts
@@ -88,21 +88,5 @@ export function createSlackPluginBase(params: {
       secretTargetRegistryEntries,
       collectRuntimeConfigAssignments,
     },
-  } as Pick<
-    ChannelPlugin<ResolvedSlackAccount>,
-    | "id"
-    | "meta"
-    | "setupWizard"
-    | "capabilities"
-    | "commands"
-    | "doctor"
-    | "agentPrompt"
-    | "streaming"
-    | "reload"
-    | "configSchema"
-    | "config"
-    | "setupContract"
-    | "security"
-    | "secrets"
-  >;
+  };
 }


### PR DESCRIPTION
## What Problem This Solves

AI-assisted cleanup, independently reviewed with Codex.

The Discord and Slack setup-base factories repeat their complete explicit return types in trailing type assertions. Those assertions add no API contract and bypass contextual checking of the returned objects.

## Why This Change Was Made

Keep each existing function return annotation as the single type owner and remove only its identical trailing assertion. The returned object expressions, imports, plugin metadata, account selection and caller overlays stay unchanged. The assertion-safety ratchet requires removing the corresponding two count-one debt rows; it is shrink-only metadata, not a new waiver.

Production: +2/-34, net -32 lines. Ratchet metadata: -2 lines. Tests: unchanged. Whole diff: -34 lines. Signal and iMessage's distinct partial-configuration assertions and existing public compatibility contracts are untouched.

## User Impact

No intended runtime, config, authentication, security or public API change. This is internal type-checking cleanup, not a provider behavior fix. No new abstraction, dependency, test seam or changelog entry.

## Evidence

The same four existing Discord/Slack setup and shared-owner suites passed all 41 cases on the baseline and candidate. The final normal changed gate passed all 26 selected checks, including production/test type checks, lint, import/dependency checks and assertion-safety ratchets. The first changed-gate failure correctly demanded the two removed debt rows; that failure is retained, not waived.

The canonical plugin package pipeline completed on both sides: 21 Discord and 18 Slack entry routes. All 167 emitted files matched exactly in path, bytes and mode. That builder sets `dts: false`; both declaration inventories were empty, so this is not emitted-declaration parity. Existing explicit source return types and the normal type gates establish the type boundary. No whole-host Discord bundle, authenticated channel/API or live operator behavior is claimed; this patch removes erased TypeScript assertions only.

One normal Codex P0 precommit review completed with no findings. Source, dependency, build, runtime and child-process custody passed. Earlier raw-index and generated Jiti-cache audit failures remain preserved: the index difference was classified as stat-cache-only with actor/cause unknown, and exactly 118 generated cache entries were matched to their source transforms without allowing changes to the 97,971 installed entries.

Signed source commit: `f2eb2545a300d1f5528d8208171405342ab8a551`. All 34,728 physical source files, committed blobs, the exact three-file patch, index, normal hooks and signature were independently verified after the local commit. Earlier pre-stage runtime-environment and observer failures remain preserved; no hook, timeout or identity guard was bypassed.

Current-main composition is tracked separately at `bb51e903325f6c7d0c8609805040df920e0c4908`. The two production beforeimages and 47 of 51 reviewed context files are unchanged since the previously inspected `fa57231562dac2b4f038cead2ef9f5e9cad58bde`. The context differences are unrelated assertion-debt reductions, documentation-template lint commands, and QA Lab's Crabline dependency update to 0.1.19 with its specific release-age exception. Both removed Setup debt rows and the Discord/Slack package importers are unchanged. The earlier base-to-main public-model wording and Discord attachment changes remain separate from this type-only edit. This is immutable source-composition evidence, not a rebased build, new dependency installation or current-main runtime proof. That earlier composition observation remains historical; final current-main composition and native landing are still pending.

## Published-head verification

A separate normal committed-head Codex P0 review completed with no findings on `f2eb2545a300d1f5528d8208171405342ab8a551`. Its full source, index, dependencies, package outputs and runtime checks passed, and owned review processes and temporary homes were verified absent.

[Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/33221401743) completed successfully, including the required `openclaw/ci-gate`. The completed [ClawSweeper review](https://github.com/openclaw/openclaw/pull/132213#issuecomment-5458957309) requests ordinary maintainer review and exact-head CI rather than source repair; both are now complete. Its generic stored-data notice does not identify a changed migration: this diff removes only erased return assertions and their two ratchet rows, with no schema, persistence or runtime expression change.

Native current-main reconciliation, preparation and merge are separate remaining steps. No merged state or cleanup credit is claimed here.

## Final native source reconciliation

The normal metadata sequence completed at the same exact reviewed head. Private launcher main was `a86b427ca8ee077b4653a2a18615696f5586b151`; canonical metadata fetches observed `d53f57c3d25059244376b5a799b89b8756b240ea`. Both production beforeimages, all 51 selected contexts, and all 15 launcher components are identical between those two main observations. Relative to the earlier `831ac903e4921371a9b5d577e4178f29a5762556` snapshot, the four selected differences are unrelated assertion-debt reductions, visitor-access packaging, platform test-list additions, acpx 0.13.2, and a Vitest task-update reporter throttle patch. The relevant type contracts and package builders are unchanged. This is source reconciliation, not a new patched-runtime or live-channel test. Native preparation and merge results remain separate until actually completed.
