### PR TITLE
test(release): keep candidate expectations channel-aware

### DIFF
--- a/src/cli/plugins-cli.install.test.ts
+++ b/src/cli/plugins-cli.install.test.ts
@@ -6,6 +6,8 @@ import { installedPluginRoot } from "openclaw/plugin-sdk/test-fixtures";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
 import { hashConfigIncludeRaw } from "../config/includes.js";
+import { resolveRegistryUpdateChannel } from "../infra/update-channels.js";
+import { resolveNpmInstallSpecsForUpdateChannel } from "../plugins/install-channel-specs.js";
 import { recordPluginManifestInstallOwner } from "../plugins/manifest-install-owner.js";
 import {
   listOfficialExternalPluginCatalogEntries,
@@ -14,6 +16,7 @@ import {
 } from "../plugins/official-external-plugin-catalog.js";
 import { createColdPluginFixture } from "../plugins/test-helpers/cold-plugin-fixtures.js";
 import { withTempDir } from "../test-utils/temp-dir.js";
+import { VERSION } from "../version.js";
 import {
   applyExclusiveSlotSelectionMock,
   buildPluginSnapshotReportMock,
@@ -61,6 +64,13 @@ const ORIGINAL_OPENCLAW_NIX_MODE = process.env.OPENCLAW_NIX_MODE;
 const ORIGINAL_STDIN_TTY = Object.getOwnPropertyDescriptor(process.stdin, "isTTY");
 const ORIGINAL_STDOUT_TTY = Object.getOwnPropertyDescriptor(process.stdout, "isTTY");
 const PROFILE_STATE_ROOT = "/tmp/openclaw-ledger-profile";
+
+function expectedNpmInstallSpec(spec: string): string {
+  return resolveNpmInstallSpecsForUpdateChannel({
+    spec,
+    updateChannel: resolveRegistryUpdateChannel({ currentVersion: VERSION }),
+  }).installSpec;
+}
 
 const OFFICIAL_EXTERNAL_NPM_INSTALLS_WITHOUT_INTEGRITY = listOfficialExternalPluginCatalogEntries()
   .map((entry) => {
@@ -2069,7 +2079,7 @@ describe("plugins cli install", () => {
             lookup: { kind: "pluginId", value: pluginId },
           });
           expect(installPluginFromClawHubMock).not.toHaveBeenCalled();
-          expect(npmInstallCall().spec).toBe(npmSpec);
+          expect(npmInstallCall().spec).toBe(expectedNpmInstallSpec(npmSpec));
           expect(npmInstallCall().expectedPluginId).toBe(pluginId);
           expect(npmInstallCall().trustedSourceLinkedOfficialInstall).toBe(true);
           expect(npmInstallCall().expectedIntegrity).toBeUndefined();

--- a/src/cli/plugins-cli.install.test.ts
+++ b/src/cli/plugins-cli.install.test.ts
@@ -6,8 +6,6 @@ import { installedPluginRoot } from "openclaw/plugin-sdk/test-fixtures";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
 import { hashConfigIncludeRaw } from "../config/includes.js";
-import { resolveRegistryUpdateChannel } from "../infra/update-channels.js";
-import { resolveNpmInstallSpecsForUpdateChannel } from "../plugins/install-channel-specs.js";
 import { recordPluginManifestInstallOwner } from "../plugins/manifest-install-owner.js";
 import {
   listOfficialExternalPluginCatalogEntries,
@@ -66,10 +64,7 @@ const ORIGINAL_STDOUT_TTY = Object.getOwnPropertyDescriptor(process.stdout, "isT
 const PROFILE_STATE_ROOT = "/tmp/openclaw-ledger-profile";
 
 function expectedNpmInstallSpec(spec: string): string {
-  return resolveNpmInstallSpecsForUpdateChannel({
-    spec,
-    updateChannel: resolveRegistryUpdateChannel({ currentVersion: VERSION }),
-  }).installSpec;
+  return VERSION.includes("-beta.") ? `${spec.replace(/@latest$/, "")}@beta` : spec;
 }
 
 const OFFICIAL_EXTERNAL_NPM_INSTALLS_WITHOUT_INTEGRITY = listOfficialExternalPluginCatalogEntries()
@@ -2063,9 +2058,16 @@ describe("plugins cli install", () => {
     expect(npmInstallCall().trustedSourceLinkedOfficialInstall).toBe(true);
   });
 
-  it.each(OFFICIAL_EXTERNAL_NPM_INSTALLS_WITHOUT_INTEGRITY)(
-    "keeps official external npm installs trusted without integrity for $pluginId",
-    async ({ pluginId, npmSpec }) => {
+  it.each([
+    ...OFFICIAL_EXTERNAL_NPM_INSTALLS_WITHOUT_INTEGRITY.map((entry) => ({
+      ...entry,
+      version: "2026.8.1",
+    })),
+    { ...OFFICIAL_EXTERNAL_NPM_INSTALLS_WITHOUT_INTEGRITY[0]!, version: "2026.8.1-beta.4" },
+  ])(
+    "keeps official external npm installs trusted without integrity for $pluginId on $version",
+    async ({ pluginId, npmSpec, version }) => {
+      coreVersion.value = version;
       await withTempDir("openclaw-official-plugin-install-", async (cwd) => {
         const cwdSpy = vi.spyOn(process, "cwd").mockReturnValue(cwd);
         try {


### PR DESCRIPTION
## Summary

- derive official plugin install expectations from the candidate release channel
- compare package-source and config-writer metadata with the candidate version
- keep stable-main behavior unchanged while allowing beta candidate validation

## Root cause

Full Release Validation rewrites the candidate to a prerelease version. Five tests instead hard-coded stable package metadata or bare stable plugin specs, so the beta candidate correctly selected `@beta` and stamped its beta version while the tests expected stable values.

## Evidence

Failed candidate jobs: [agentic CLI](https://github.com/openclaw/openclaw/actions/runs/33213125649/job/98991080464), [onboarding](https://github.com/openclaw/openclaw/actions/runs/33213125649/job/98991080465), [chat plugin commands](https://github.com/openclaw/openclaw/actions/runs/33213125649/job/98991083969), [core fast](https://github.com/openclaw/openclaw/actions/runs/33213125649/job/98991080490), and [tooling](https://github.com/openclaw/openclaw/actions/runs/33213125649/job/98991080453).

Focused proof on stable main: 5 files, 118+ tests passed across unit-fast, tooling, CLI, commands, and auto-reply projects. The failing beta candidate provides the pre-fix regression proof.

## LOC

- production: 0
- tests: +30 / -8
