### PR TITLE
fix(release): distinguish Anthropic validation jobs

### DIFF
--- a/.github/workflows/openclaw-live-and-e2e-checks-reusable.yml
+++ b/.github/workflows/openclaw-live-and-e2e-checks-reusable.yml
@@ -4333,7 +4333,7 @@ jobs:
             profiles: stable
           - suite_id: live-gateway-anthropic-docker-full
             suite_group: live-gateway-anthropic-docker
-            label: Docker live gateway Anthropic
+            label: Docker live gateway Anthropic (full advisory)
             command: OPENCLAW_LIVE_GATEWAY_THINKING=low OPENCLAW_LIVE_GATEWAY_PROVIDERS=anthropic OPENCLAW_LIVE_GATEWAY_MODELS=anthropic/claude-sonnet-4-6,anthropic/claude-haiku-4-5 OPENCLAW_LIVE_GATEWAY_MAX_MODELS=2 OPENCLAW_LIVE_GATEWAY_STEP_TIMEOUT_MS=90000 OPENCLAW_LIVE_GATEWAY_MODEL_TIMEOUT_MS=600000 OPENCLAW_LIVE_DOCKER_REPO_ROOT="$GITHUB_WORKSPACE" timeout --foreground --kill-after=30s 35m bash .release-harness/scripts/test-live-gateway-models-docker.sh
             timeout_minutes: 40
             profile_env_only: false

--- a/test/scripts/release-workflow-matrix-plan.test.ts
+++ b/test/scripts/release-workflow-matrix-plan.test.ts
@@ -29,6 +29,7 @@ type MatrixEntry = {
   advisory?: boolean;
   chunk_id?: string;
   id?: string;
+  label?: string;
   profiles?: string;
   providers?: string;
   suite_group?: string;
@@ -289,6 +290,7 @@ describe("scripts/plan-release-workflow-matrix.mjs", () => {
       .filter((entry: MatrixEntry) => entry.suite_group === "live-gateway-anthropic-docker")
       .map((entry: MatrixEntry) => ({
         advisory: entry.advisory,
+        label: entry.label,
         profiles: entry.profiles,
         suiteId: entry.suite_id,
       }));
@@ -296,11 +298,13 @@ describe("scripts/plan-release-workflow-matrix.mjs", () => {
     expect(anthropicEntries).toEqual([
       {
         advisory: undefined,
+        label: "Docker live gateway Anthropic",
         profiles: "stable",
         suiteId: "live-gateway-anthropic-docker",
       },
       {
         advisory: true,
+        label: "Docker live gateway Anthropic (full advisory)",
         profiles: "full",
         suiteId: "live-gateway-anthropic-docker-full",
       },


### PR DESCRIPTION
## Summary

- give the full-profile advisory Anthropic Docker lane a distinct displayed job identity
- lock the stable and full Anthropic labels into the release workflow matrix test

## Root cause

Full release validation run 33213053022 failed closed while collecting release-check evidence because two successful matrix jobs shared the exact name `Docker live gateway Anthropic`. The immutable collector correctly rejects duplicate job identities.

The release workflow matrix owns the identity. The stable blocking lane and full advisory lane already have distinct suite IDs and behavior, but reused one display label.

## Verification

- regression test failed against the old duplicate label
- `node scripts/run-vitest.mjs test/scripts/release-workflow-matrix-plan.test.ts` (12 passed)
- `git diff --check`
- `pnpm check:workflows` reached its Python tool bootstrap but the configured index does not provide pinned `pre-commit==4.6.2`; CI will run the canonical workflow check

Production LOC: +1/-1 workflow configuration (net 0). Tests: +4/-0.

No product behavior, provider selection, blocking/advisory policy, or commands change.
