### PR TITLE
docs: correct chat model selection examples

### DIFF
--- a/docs/concepts/models.md
+++ b/docs/concepts/models.md
@@ -200,7 +200,7 @@ Without a scope flag, `agents.defaults.modelSelectionScope` can opt into `"sessi
 ```text
 /model
 /model list
-/model 3
+/model Opus
 /model openai/gpt-5.4
 /model openai/gpt-5.4 -s
 /model openai/gpt-5.4 -a
@@ -210,7 +210,11 @@ Without a scope flag, `agents.defaults.modelSelectionScope` can opt into `"sessi
 /model status
 ```
 
-- `/model` and `/model list` show a compact numbered picker. `/model <#>` selects from it. Discord pickers follow the direct command behavior, including `modelSelectionScope`. Telegram callback pickers always stay session-only. `/models add` is deprecated and returns a message instead of registering models from chat.
+- In text chat, `/model` shows the current selection. `/model list` (or `/models`) browses providers; `/models <provider>` lists model refs.
+- Select with `/model <provider/model>` or `/model <alias>` (for example, `/model Opus` with the alias configured above). Numeric selections such as `/model 3` are not supported.
+- On Discord, native `/model` and `/models` without arguments open an interactive picker. Choose a provider and model, then press **Submit**. Discord pickers follow the direct command behavior, including `modelSelectionScope`.
+- On Telegram, `/model` offers a **Browse providers** button; `/model list` and `/models` open the provider menu directly. Tap a provider, then a model. Telegram callback selections always stay session-only.
+- `/models add` is deprecated and returns a message instead of registering models from chat.
 - **Current session:** `/model <model> -s` (or `--session`) changes only this session, regardless of `modelSelectionScope`. Neither configured default changes.
 - **Agent default:** Owner/admin `/model <model> -a` (or `--agent`) selects the model for this session and requests an update for `agents.entries.<agent>.model`. It creates an explicit primary for that configured agent when needed and never falls through to the shared global default.
 - **Global default:** Owner/admin `/model <model> -g` (or `--global`) changes this session and requests an update for the shared `agents.defaults.model` fallback. It does not overwrite other agents' explicit primaries or other sessions' model pins. New and existing unpinned sessions, and cron jobs that inherit this default, can use the changed model on their next run.


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users following the Models CLI page would try `/model 3` and receive “Numeric model selection is not supported in chat.” The page described a numbered chat picker even though text commands and channel-native pickers use different interactions.

Affected page: https://docs.openclaw.ai/concepts/models#model-in-chat

## Why This Change Was Made

Replace the stale numeric example with the `Opus` alias configured earlier on the page. Explain text browsing and selection by `provider/model` or configured alias, while preserving Discord’s native provider/model dropdowns plus Submit and Telegram’s provider/model callback buttons.

This is deliberately a small, single-page documentation correction. Numeric selection is not implemented, and runtime, configuration, scope policy, and operator state are unchanged. The explicit rejection and its test also exist in stable `v2026.7.1`.

## User Impact

Readers get supported commands rather than an example that fails. Discord picker selections still follow direct-command scope policy, including `modelSelectionScope`; Telegram callback selections remain session-only.

## Evidence

- Checked live `main`, then inspected the complete text directive and native Discord, Slack, and Telegram flows before editing. The documented source surfaces remain unchanged on refreshed `origin/main`.
- Text rejection: `src/auto-reply/reply/directive-handling.model-selection.ts:113-122`; existing coverage: `src/auto-reply/reply/directive-handling.model.test.ts:1460-1470`.
- Text summary/list routing: `src/auto-reply/reply/directive-handling.model.ts:354-460`; alias resolution: `src/agents/model-selection-shared.ts:738-779`.
- Discord opens the dropdown for bare native `/model` or `/models`, not `/model list`: `extensions/discord/src/monitor/native-command-model-picker-ui.ts:68-85`. Submit builds a full model-ref command: `extensions/discord/src/monitor/native-command-model-picker-interaction.ts:177-197`.
- Telegram browse/menu adapters converge on provider/model callbacks: `extensions/telegram/src/command-ui.ts:41-55,109-131`; selection explicitly disables configured-default persistence: `extensions/telegram/src/bot-handlers.callback-router.ts:653-675`.
- `pnpm docs:list` passed.
- `node scripts/check-docs-mdx.mjs docs/concepts/models.md` passed.
- `git diff --check` passed.
- **14 selected existing tests passed across three Vitest shards**, including numeric rejection, text browsing, aliases, Discord Submit, and a real-grammY Telegram callback flow against loopback HTTP:

```bash
node scripts/run-vitest.mjs src/auto-reply/reply/directive-handling.model.test.ts src/auto-reply/reply/commands-models.test.ts extensions/discord/src/monitor/native-command.model-picker.test.ts extensions/telegram/src/model-callback.loopback.integration.test.ts extensions/telegram/src/shared.test.ts --testNamePattern 'shows summary for /model|channel-specific model summaries|treats /model list as|rejects numeric /model|keeps openrouter provider/model|supports alias selections|persists auth profile overrides for alias|shows a simple providers menu|lists models for /models|requires submit and retains Gateway ownership|sends, authorizes, resolves, persists, answers, and edits|provider picker' --reporter=dot
```

The name filter intentionally skips unrelated tests; `shared.test.ts` had no matching selected case. No new tests or live-channel changes are needed for this prose-only correction. The Telegram proof is isolated loopback integration, not authenticated live-channel testing.

Production LOC: +0/-0. Tests: +0/-0. Documentation: +6/-2.

Follow-up noted separately: `docs/tools/slash-commands.md` repeats the numeric example and command-table argument; it is outside the expressly requested single-page edit.

AI-assisted.
