### PR TITLE
refactor(shared): remove unused store writer running state

### DIFF
--- a/src/shared/store-writer-queue.ts
+++ b/src/shared/store-writer-queue.ts
@@ -13,8 +13,6 @@ type StoreWriterTask = {
 
 /** Per-store-path FIFO queue that serializes file writes within one process. */
 export type StoreWriterQueue = {
-  /** True while a drain loop owns this queue. */
-  running: boolean;
   /** Writes waiting behind the active drain. */
   pending: StoreWriterTask[];
   /** Active drain promise, reused by waiters until the current batch settles. */
@@ -70,7 +68,7 @@ function getOrCreateStoreWriterQueue(
   if (existing) {
     return existing;
   }
-  const created: StoreWriterQueue = { running: false, pending: [], drainPromise: null };
+  const created: StoreWriterQueue = { pending: [], drainPromise: null };
   queues.set(storePath, created);
   return created;
 }
@@ -84,7 +82,6 @@ async function drainStoreWriterQueue(queues: StoreWriterQueues, storePath: strin
     await queue.drainPromise;
     return;
   }
-  queue.running = true;
   queue.drainPromise = (async () => {
     try {
       while (queue.pending.length > 0) {
@@ -108,7 +105,6 @@ async function drainStoreWriterQueue(queues: StoreWriterQueues, storePath: strin
         task.resolve(result);
       }
     } finally {
-      queue.running = false;
       queue.drainPromise = null;
       if (queue.pending.length === 0) {
         queues.delete(storePath);


### PR DESCRIPTION
## What Problem This Solves

The store-writer queue carries a second “running” flag that is only written, never read. It duplicates the drain ownership already represented by `drainPromise`, leaving misleading state in a shared lifecycle owner.

## Why This Change Was Made

Remove that private field, its initializer and its two assignments. The existing drain promise remains the single owner and join handle. FIFO execution, resolution/rejection, late enqueue handling, map cleanup and explicit active-writer reentrancy are unchanged.

The separate AsyncLocalStorage active-writer flag and the history-eviction worker’s live running state remain intact. Session writer, lifecycle admission, maintenance and cleanup callers still use the same queue. Public SDK cleanup functions, package exports, SQLite schemas and persistence policy are unchanged.

## User Impact

No user-visible behavior change. This is an AI-assisted, maintainer-requested internal cleanup: **production +1/-5 (net -4), tests +0/-0, total net -4**. All existing behavioral tests remain; no shape-only test, compatibility shim or new API was added.

## Evidence

Actual local proof used Node 24.19.0 and pnpm 11.22.0 on macOS:

- Baseline: **69/69 cases passed across eight existing suites**.
- Candidate: **the same 69 named cases passed** across those eight suites.
- Configured formatter check and `git diff --check`: passed.
- Canonical changed gate: **all 28 selected checks passed**, including three full Knip unused-export scans, core and core-test typechecking, lint, import-cycle and storage-policy guards.
- One normal independent Codex precommit review: completed with **no actionable P0 findings**.

The unchanged focused command before and after the cleanup was:

```sh
OPENCLAW_VITEST_MAX_WORKERS=1 CI=true node scripts/run-vitest.mjs \
  src/shared/store-writer-queue.test.ts \
  src/config/sessions/store-writer.test.ts \
  src/sessions/session-lifecycle-admission.test.ts \
  src/config/sessions/session-history-eviction.test.ts \
  src/config/sessions/session-accessor.sqlite-maintenance-writer.test.ts \
  src/config/sessions/session-accessor.sqlite-active-events.test.ts \
  src/test-utils/session-state-cleanup.test.ts \
  src/gateway/test-helpers.server-rpc.test.ts
```

The canonical changed plan and gate were:

```sh
node scripts/check-changed.mjs --base e11c566824b100dc7a3a7989b8a0913c2c68a3bb --dry-run -- src/shared/store-writer-queue.ts
node scripts/check-changed.mjs --base e11c566824b100dc7a3a7989b8a0913c2c68a3bb -- src/shared/store-writer-queue.ts
```

The first full gate remains recorded as failed: after 15 checks passed, the external process observer failed and terminated its owned job, which exited 143 during dead-code scanning. The failed census’s exact OS cause was not saved and remains unknown. A single serialized retry passed all 28 checks with the same source, command, assertions and time budgets; no check was skipped.

Earlier evidence also retains an index ctime/checksum-only change with unchanged semantic entries and unknown actor/cause, and a patch-display comparison failure caused by full versus abbreviated blob IDs and hunk labels. A check-only format phase was mistakenly launched after that diagnostic failure; work was stopped, the exact before/after blobs were independently reconciled, and no source correction was needed. These were validation bookkeeping failures, not reproduced queue behavior bugs.

Full source/index, dependency and runtime checks passed after proof and review. Recorded reviewer processes and managed runtime paths were verified absent; ordinary Vitest/Jiti/type caches and task temporary caches were retained and disclosed.

These results bind signed commit `fb11207ca72881f945f22db5fe49590a237b4aeb`, whose committed source, exact patch, normal hook and signature were independently verified. Published-head review, hosted exact-head CI and final integration/landing remain pending. No whole-product build, live provider/channel, cross-platform proof or performance improvement is claimed.
