### PR TITLE
ci: avoid redundant full release preparation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2858,14 +2858,15 @@ jobs:
 
       # A few real-CLI E2E tests need a current dist tree. Build it before
       # Vitest starts so the shard's worker processes cannot consume the
-      # cgroup memory that the build admission check must reserve.
+      # cgroup memory that the build admission check must reserve. Reuse the
+      # CI artifact profile: these runtime readers do not need global declarations.
       - name: Build Node test runtime
         if: matrix.pretest_build_mode != null
         env:
           NODE_OPTIONS: --max-old-space-size=8192
           OPENCLAW_BUILD_PRIVATE_QA: ${{ matrix.pretest_build_mode == 'private-qa' && '1' || '0' }}
           VITEST: "1"
-        run: pnpm build
+        run: pnpm build:ci-artifacts
 
       - name: Run Node test shard
         env:

--- a/.github/workflows/openclaw-live-and-e2e-checks-reusable.yml
+++ b/.github/workflows/openclaw-live-and-e2e-checks-reusable.yml
@@ -606,7 +606,11 @@ jobs:
       - name: Checkout workflow repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          # Ref trust needs every branch and tag, but no historical file blobs.
           fetch-depth: 0
+          filter: blob:none
+          sparse-checkout: package.json
+          sparse-checkout-cone-mode: false
 
       - name: Validate selected ref
         id: validate

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -93,6 +93,12 @@ Use `pnpm ci:timings`, `pnpm ci:timings:recent`, or `node scripts/ci-run-timings
 
 Run the timing helper locally; there is no in-workflow timing-summary job (a permanently disabled one was removed once the local helper became the tool everyone actually used). For build timing, check the `build-artifacts` job's `Build dist` step: `pnpm build:ci-artifacts` prints `[build-all] phase timings:` and includes `ui:build`; the job also uploads the `startup-memory` artifact.
 
+Node test shards that need a built CLI use the same `build:ci-artifacts` profile
+before starting Vitest. It builds the runtime, Control UI, and scoped plugin SDK
+declarations without repeating global declaration emission in each shard.
+Private QA shards retain their private runtime build selection. Release package
+builds still generate the full declarations.
+
 Local `pnpm build:ci-artifacts` uses the same memory admission as full and package
 builds. The orchestrator passes the resolved heap budget to every child process,
 including the SDK declaration writer, so local builds do not depend on CI's
@@ -484,6 +490,11 @@ with soak or explicit focused groups. Stable-publish maps to
 See [Full release validation](/reference/full-release-validation) for the
 stage matrix, exact workflow job names, profile differences, artifacts, and
 focused rerun handles.
+
+The live/E2E selected-ref validator fetches the complete commit and ref history
+with a sparse checkout. Ancestry and release-ref checks remain unchanged, while
+historical file contents stay out of this metadata-only job. Build and test jobs
+check out their own complete source trees.
 
 `OpenClaw Release Publish` is the manual mutating release workflow. Dispatch
 regular beta and stable publishes from trusted `main` after the release tag

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -8886,7 +8886,7 @@ printf '%s\n' "\${CURL_SUCCESS_IP:-203.0.113.7}"
         OPENCLAW_BUILD_PRIVATE_QA: "${{ matrix.pretest_build_mode == 'private-qa' && '1' || '0' }}",
         VITEST: "1",
       },
-      run: "pnpm build",
+      run: "pnpm build:ci-artifacts",
     });
     expect(nodeTestJob.steps.indexOf(buildRuntimeStep)).toBeLessThan(
       nodeTestJob.steps.indexOf(runStep),

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -9048,6 +9048,7 @@ esac
 
   it("keeps release history checks blobless", () => {
     const fullHistoryCheckouts: Array<[string, string, string]> = [
+      [LIVE_E2E_WORKFLOW, "validate_selected_ref", "Checkout workflow repository"],
       [RELEASE_PUBLISH_WORKFLOW, "resolve_release_target", "Checkout release tag"],
       [
         RELEASE_CHECKS_WORKFLOW,
@@ -9078,6 +9079,7 @@ esac
     }
 
     const metadataOnlyCheckouts: Array<[string, string, string]> = [
+      [LIVE_E2E_WORKFLOW, "validate_selected_ref", "Checkout workflow repository"],
       [RELEASE_PUBLISH_WORKFLOW, "resolve_release_target", "Checkout release tag"],
       [
         RELEASE_CHECKS_WORKFLOW,


### PR DESCRIPTION
## What Problem This Solves

Full Release Validation repeats expensive preparation that its consumers do not need. Three Node runtime shards emit global declarations before their actual tests, and the shared live/E2E ref validator downloads historical file contents just to inspect Git ancestry.

## Why This Change Was Made

Use the existing `build:ci-artifacts` profile before runtime-dependent Node shards. It retains runtime artifacts, Control UI, scoped SDK declarations and checks, build identity, private-QA selection, and the build-before-workers memory boundary. Canonical release package builds remain unchanged.

Apply the existing blobless, metadata-only checkout pattern to the live/E2E selected-ref validator. It still fetches every branch/tag and the complete commit graph; the trust predicates and all downstream source checkouts are unchanged. No new cache, dependency, runner, concurrency setting, or release input is introduced.

## User Impact

Less redundant preparation during full CI and release validation. No product behavior or test coverage changes. This is a maintainer-requested, AI-assisted CI optimization.

## Evidence

In [CI run 33213920863](https://github.com/openclaw/openclaw/actions/runs/33213920863), the runtime-shard full build took 7m39s, including 6m15s in global declaration emission. The same run's existing CI artifact build took 2m05s. The three affected current shards are `core-tooling-6`, `agentic-gateway-core-1`, and `agentic-gateway-core-3`; this suggests approximately 5m34s less preparation per shard, not an asserted end-to-end release saving.

In [successful full validation 33161859499](https://github.com/openclaw/openclaw/actions/runs/33161859499), selected-ref checkout took 156s in shared candidate preparation. Its [Plugin Prerelease child](https://github.com/openclaw/openclaw/actions/runs/33162966927) repeated the checkout in 154s.

Validation:

- Four focused workflow/build-profile/test-plan contract checks passed using `node scripts/run-vitest.mjs` with the changed contract names.
- `node --import tsx scripts/check-workflows.mts` passed, including zizmor.
- Changed-file formatting and `git diff --check` passed.
- Pinned actions/checkout source inspected: `git-source-provider.ts` retains full-history refspecs with `blob:none`; `ref-helper.ts` includes every branch and tag; `git-command-manager.ts` applies noncone sparse patterns before checkout.
- The broader local changed gate reached test-root typechecking, then failed on stale shared dependencies (for example installed `pi-tui` 0.82.1 / `markdown-it` 14.3.0 versus this branch's 0.84.2 / 15.0.0). The shared install was not reconciled; clean pinned hosted CI must pass before landing.
- Independent autoreview, exact-head CI, and hosted metadata-checkout timing are recorded in the landing follow-up.

Tooling/workflow delta: +5 net lines. Tests: +2 net lines, extending existing contract assertions. Documentation: +11 lines. Product runtime code: unchanged.

Named follow-ups from the parallel investigation: profile Windows npm fetch versus extraction time before changing its real baseline/install/update proof; verify the freshly rotated macOS build cache warms before changing its clean-build safeguards. Candidate declaration parallelism remains unchanged because its serialization protects measured memory limits.
