### PR TITLE
fix(cli): accurately preview suppressed telemetry requests

### DIFF
--- a/docs/gateway/telemetry.md
+++ b/docs/gateway/telemetry.md
@@ -43,8 +43,10 @@ document.
 The output shows whether feature statistics are enabled, why they are enabled
 or disabled, the request endpoint, and the last successful check. When feature
 statistics are enabled, it prints the exact JSON payload the next request would
-send. When they are disabled, it shows the update-only request and its
-`User-Agent` header instead.
+send. When only feature statistics are disabled, it shows the update-only request
+and its `User-Agent` header instead. When automation or update-check policy
+disables all requests, it shows `Request: none` with the reason (`request: null`
+in JSON).
 
 ## Daily update check
 

--- a/src/cli/telemetry-cli.test.ts
+++ b/src/cli/telemetry-cli.test.ts
@@ -100,59 +100,50 @@ describe("telemetry cli", () => {
     expect(mocks.defaultRuntime.log).not.toHaveBeenCalled();
   });
 
-  it("reports a null JSON request when update checks are disabled", async () => {
+  it.each([
+    { reason: "never-asked", label: "consent has not been requested", method: "GET" },
+    { reason: "config-disabled", label: "disabled in configuration", method: "GET" },
+    { reason: "do-not-track", label: "disabled by DO_NOT_TRACK", method: "GET" },
+    { reason: "update-disabled", label: "update checks are disabled", method: null },
+    {
+      reason: "automated-environment",
+      label: "disabled in an automated environment (CI is set)",
+      method: null,
+    },
+  ])("reports the same request in JSON and text for $reason", async ({ reason, label, method }) => {
+    const endpoint = "https://telemetry.openclaw.ai/api/latest-version";
+    const userAgent = "openclaw/2026.8.2 (darwin; node/26.0.1; arm64; gateway)";
     mocks.resolveTelemetryStatus.mockReturnValue({
       enabled: false,
-      reason: "update-disabled",
-      endpoint: "https://telemetry.openclaw.ai/api/latest-version",
+      reason,
+      endpoint,
     });
 
     await runTelemetryCli(["show", "--json"]);
 
     expect(mocks.defaultRuntime.writeJson).toHaveBeenCalledExactlyOnceWith(
-      expect.objectContaining({
+      {
         featureStatsEnabled: false,
-        reason: "update-disabled",
+        reason,
+        endpoint,
         lastPingAt: null,
-        request: null,
-      }),
+        request: method ? { method, userAgent } : null,
+      },
       0,
     );
     expect(mocks.defaultRuntime.log).not.toHaveBeenCalled();
-  });
-
-  it("shows only the update request headers when feature statistics are disabled", async () => {
-    mocks.resolveTelemetryStatus.mockReturnValue({
-      enabled: false,
-      reason: "do-not-track",
-      endpoint: "https://telemetry.openclaw.ai/api/latest-version",
-    });
-
     await runTelemetryCli(["show"]);
 
     expect(mocks.buildTelemetryPayload).not.toHaveBeenCalled();
-    expect(mocks.runtimeLogs).toContain("Feature stats: disabled");
-    expect(mocks.runtimeLogs).toContain("Reason: disabled by DO_NOT_TRACK");
-    expect(mocks.runtimeLogs).toContain("Last ping: never");
-    expect(mocks.runtimeLogs).toContain(
-      "Request: GET https://telemetry.openclaw.ai/api/latest-version",
-    );
-    expect(mocks.runtimeLogs).toContain(
-      "User-Agent: openclaw/2026.8.2 (darwin; node/26.0.1; arm64; gateway)",
-    );
-  });
-
-  it("reports that no request is sent when update checks are disabled", async () => {
-    mocks.resolveTelemetryStatus.mockReturnValue({
-      enabled: false,
-      reason: "update-disabled",
-      endpoint: "https://telemetry.openclaw.ai/api/latest-version",
-    });
-
-    await runTelemetryCli(["show"]);
-
-    expect(mocks.buildTelemetryPayload).not.toHaveBeenCalled();
-    expect(mocks.runtimeLogs).toContain("Request: none (update checks are disabled)");
+    expect(mocks.runtimeLogs).toEqual([
+      "Feature stats: disabled",
+      `Reason: ${label}`,
+      `Endpoint: ${endpoint}`,
+      "Last ping: never",
+      ...(method
+        ? [`Request: ${method} ${endpoint}`, `User-Agent: ${userAgent}`]
+        : [`Request: none (${label})`]),
+    ]);
   });
 
   it.each([

--- a/src/cli/telemetry-cli.ts
+++ b/src/cli/telemetry-cli.ts
@@ -20,11 +20,16 @@ const TELEMETRY_REASON_LABELS = {
 async function showTelemetry(options: { json?: boolean }): Promise<void> {
   const config = getRuntimeConfig({ skipPluginValidation: true });
   const telemetry = resolveTelemetryStatus(config);
-  const userAgent = buildTelemetryUserAgent("gateway");
-  const requestSent = telemetry.reason !== "update-disabled";
-  const payload = telemetry.enabled
-    ? buildTelemetryPayload(config, { surface: "gateway" })
-    : undefined;
+  const request =
+    telemetry.reason === "update-disabled" || telemetry.reason === "automated-environment"
+      ? null
+      : {
+          method: telemetry.enabled ? "POST" : "GET",
+          userAgent: buildTelemetryUserAgent("gateway"),
+          ...(telemetry.enabled
+            ? { payload: buildTelemetryPayload(config, { surface: "gateway" }) }
+            : {}),
+        };
 
   if (options.json) {
     defaultRuntime.writeJson(
@@ -33,13 +38,7 @@ async function showTelemetry(options: { json?: boolean }): Promise<void> {
         reason: telemetry.reason,
         endpoint: telemetry.endpoint,
         lastPingAt: telemetry.lastPingAt ? new Date(telemetry.lastPingAt).toISOString() : null,
-        request: requestSent
-          ? {
-              method: telemetry.enabled ? "POST" : "GET",
-              userAgent,
-              ...(payload ? { payload } : {}),
-            }
-          : null,
+        request,
       },
       0,
     );
@@ -52,15 +51,15 @@ async function showTelemetry(options: { json?: boolean }): Promise<void> {
   defaultRuntime.log(
     `Last ping: ${telemetry.lastPingAt ? new Date(telemetry.lastPingAt).toISOString() : "never"}`,
   );
-  if (telemetry.reason === "update-disabled") {
-    defaultRuntime.log("Request: none (update checks are disabled)");
+  if (!request) {
+    defaultRuntime.log(`Request: none (${TELEMETRY_REASON_LABELS[telemetry.reason]})`);
     return;
   }
-  defaultRuntime.log(`Request: ${telemetry.enabled ? "POST" : "GET"} ${telemetry.endpoint}`);
-  defaultRuntime.log(`User-Agent: ${userAgent}`);
-  if (payload) {
+  defaultRuntime.log(`Request: ${request.method} ${telemetry.endpoint}`);
+  defaultRuntime.log(`User-Agent: ${request.userAgent}`);
+  if (request.payload) {
     defaultRuntime.log("Payload:");
-    defaultRuntime.log(JSON.stringify(payload));
+    defaultRuntime.log(JSON.stringify(request.payload));
   }
 }
 

--- a/test/cli-json-stdout.e2e.test.ts
+++ b/test/cli-json-stdout.e2e.test.ts
@@ -597,47 +597,102 @@ describe("cli json stdout contract", () => {
     );
   });
 
-  it.each([
-    { name: "piped stdout", tty: false },
-    { name: "dual TTYs", tty: true },
-  ])("writes successful telemetry show JSON to clean $name", async ({ tty }) => {
-    await withTempHome(
-      async (tempHome) => {
-        const ttyPreload = Buffer.from(
-          [
-            'Object.defineProperty(process.stdout, "isTTY", { value: true, configurable: true });',
-            'Object.defineProperty(process.stderr, "isTTY", { value: true, configurable: true });',
-          ].join("\n"),
-        ).toString("base64");
-        const result = runBuiltCli(tempHome, ["telemetry", "show", "--json"], {
-          OPENCLAW_CONFIG_PATH: path.join(tempHome, "missing-openclaw.json"),
-          OPENCLAW_STATE_DIR: path.join(tempHome, "isolated-state"),
-          ...(tty
-            ? {
-                NODE_OPTIONS: `--import=data:text/javascript;base64,${ttyPreload}`,
-                FORCE_COLOR: "1",
-              }
-            : {}),
-        });
-
-        expect(result.status, result.stderr).toBe(0);
-        expect(result.stdout, result.stderr).not.toMatch(/[\u001B\u0007]/u);
-        const payload = JSON.parse(result.stdout);
-        expect(payload).toEqual({
-          featureStatsEnabled: false,
-          reason: "never-asked",
-          endpoint: "https://telemetry.openclaw.ai/api/latest-version",
-          lastPingAt: null,
-          request: {
-            method: "GET",
-            userAgent: expect.stringMatching(/^openclaw\/[^ ]+ \(.+; gateway\)$/u),
-          },
-        });
-        expect(result.stdout).toBe(`${JSON.stringify(payload)}\n`);
-        expect(result.stderr).not.toContain('"featureStatsEnabled"');
+  describe.each([
+    { context: "ordinary fresh home", env: {}, reason: "never-asked" },
+    { context: "automated fresh home", env: { CI: "1" }, reason: "automated-environment" },
+    {
+      context: "automation with an explicit endpoint",
+      env: {
+        CI: "1",
+        OPENCLAW_TELEMETRY_ENDPOINT: "https://telemetry.example.invalid/api/latest-version",
       },
-      { prefix: "openclaw-telemetry-json-success-e2e-" },
-    );
+      reason: "never-asked",
+    },
+  ])("telemetry inspection in $context", ({ env, reason }) => {
+    it.each([
+      { name: "piped stdout", tty: false, format: "JSON" },
+      { name: "stubbed dual TTYs", tty: true, format: "JSON" },
+      { name: "piped stdout", tty: false, format: "text" },
+      { name: "stubbed dual TTYs", tty: true, format: "text" },
+    ])("writes successful telemetry show $format to $name", async ({ tty, format }) => {
+      await withTempHome(
+        async (tempHome) => {
+          const preload = Buffer.from(
+            [
+              'import net from "node:net";',
+              'const denyNetwork = () => { throw new Error("TELEMETRY_NETWORK_FORBIDDEN"); };',
+              "net.Socket.prototype.connect = denyNetwork;",
+              "globalThis.fetch = async () => denyNetwork();",
+              ...(tty
+                ? [
+                    'Object.defineProperty(process.stdout, "isTTY", { value: true, configurable: true });',
+                    'Object.defineProperty(process.stderr, "isTTY", { value: true, configurable: true });',
+                  ]
+                : []),
+            ].join("\n"),
+          ).toString("base64");
+          // CI and the endpoint are named inputs, independent of the test runner's environment.
+          const result = runBuiltCli(
+            tempHome,
+            ["telemetry", "show", ...(format === "JSON" ? ["--json"] : [])],
+            {
+              ...env,
+              NODE_OPTIONS: `--import=data:text/javascript;base64,${preload}`,
+              OPENCLAW_CONFIG_PATH: path.join(tempHome, "missing-openclaw.json"),
+              OPENCLAW_STATE_DIR: path.join(tempHome, "isolated-state"),
+              ...(tty ? { FORCE_COLOR: "1" } : {}),
+            },
+            { inheritEnvironment: false },
+          );
+
+          expect(result.status, result.stderr).toBe(0);
+          const endpoint =
+            env.OPENCLAW_TELEMETRY_ENDPOINT ?? "https://telemetry.openclaw.ai/api/latest-version";
+          if (format === "JSON") {
+            expect(result.stdout, result.stderr).not.toMatch(/[\u001B\u0007]/u);
+            const payload = JSON.parse(result.stdout);
+            expect(payload).toEqual({
+              featureStatsEnabled: false,
+              reason,
+              endpoint,
+              lastPingAt: null,
+              request:
+                reason === "automated-environment"
+                  ? null
+                  : {
+                      method: "GET",
+                      userAgent: expect.stringMatching(/^openclaw\/[^ ]+ \(.+; gateway\)$/u),
+                    },
+            });
+            expect(result.stdout).toBe(`${JSON.stringify(payload)}\n`);
+          } else {
+            // Human TTY output includes the startup banner before the inspection report.
+            const report = result.stdout.slice(result.stdout.indexOf("Feature stats:"));
+            const lines = report.trimEnd().split("\n");
+            expect(lines).toEqual([
+              "Feature stats: disabled",
+              `Reason: ${reason === "automated-environment" ? "disabled in an automated environment (CI is set)" : "consent has not been requested"}`,
+              `Endpoint: ${endpoint}`,
+              "Last ping: never",
+              ...(reason === "automated-environment"
+                ? ["Request: none (disabled in an automated environment (CI is set))"]
+                : [
+                    `Request: GET ${endpoint}`,
+                    expect.stringMatching(/^User-Agent: openclaw\/[^ ]+ \(.+; gateway\)$/u),
+                  ]),
+            ]);
+          }
+          if (tty && format === "text") {
+            expect(result.stdout).toContain("OpenClaw");
+            expect(result.stderr).toContain("\u001B[?25h");
+            expect(result.stderr).not.toContain("TELEMETRY_NETWORK_FORBIDDEN");
+          } else {
+            expect(result.stderr).toBe("");
+          }
+        },
+        { prefix: "openclaw-telemetry-json-success-e2e-" },
+      );
+    });
   });
 
   it.each([


### PR DESCRIPTION
Closes #132211
Related: #129155 (the merged automation-suppression policy).

The shared UI test-type shard blocker is resolved on main by [the canonical split included in the native-asset repair](https://github.com/openclaw/openclaw/pull/132193), merge `249c248285b03eacc1fdcb9153bc47c6c3a2ec20`. Its shard registry and replacement UI configs match the independently tested split, and its required CI passed. This PR is now proceeding through exact-head CI and native landing gates; no cap or telemetry policy changes are part of this patch.

## What Problem This Solves

Fixes an issue where operators using `openclaw telemetry show` in CI would see a GET request described even though the sender suppresses all requests in that environment. The inspection output contradicted its own `automated-environment` reason and the [documented automation behavior](https://docs.openclaw.ai/gateway/telemetry#automated-environments).

The release-E2E stdout fixtures also inherited the runner's CI setting while always expecting `never-asked`, causing two failures despite clean JSON and a successful CLI exit.

## Why This Change Was Made

Build one nullable request projection from the existing canonical telemetry status and use it for both JSON and human-readable output. This removes the duplicated request decisions that omitted automation suppression.

The sender is unchanged. Ordinary update-only GET, consented POST, DO_NOT_TRACK, explicit endpoint behavior, update disabling, endpoint, User-Agent, and last-ping semantics remain intact. No new configuration, environment variable, dependency, schema, fallback, exported helper, or collection policy.

## User Impact

Inspection now reports `request: null` / `Request: none` when policy suppresses all requests. Disabling only feature statistics still shows the update-only GET. No additional data is collected or sent, and no existing privacy control is weakened.

## Evidence

AI-assisted implementation and review. Source base: `b0cb107c8248768b4dc1899bd589f6e60c615709`. The CLI and sender baseline blobs were independently checked unchanged at main snapshot `6f6b6491fd499ca9ac996c658cbbab8929999bbe`.

**Failing-first proof:** before the production edit, four subprocess cases failed specifically on the incorrect CI request description: JSON and text, each with ordinary pipes and stubbed TTY properties. The matching CLI unit case failed as well. The original two release-E2E reason mismatches were separately reproduced under CI and passed outside CI.

**After proof:** the 12 focused subprocess cases passed, as did nine CLI unit cases and 101 sender/update-startup tests. Direct dist-backed CLI captures verified 44 after outputs across 11 contexts with zero observed network attempts and task-owned home/state cleanup. The actual public CLI is used; the TTY cases stub `isTTY` on pipes and are not real PTYs.

The installed Vitest runner initially lagged the already-pinned dependency patch. After a frozen dependency reconciliation, the parent directly verified the installed patch and reran **113 unit/sibling/installed-runner regression tests plus all 12 focused E2E cases**, all passing with unchanged source. The three runner regressions exercise actual trailing task updates at 99/100/101 ms.

Canonical focused commands (Node 24.20.0):

```bash
node scripts/run-vitest.mjs src/cli/telemetry-cli.test.ts src/infra/telemetry.test.ts src/infra/update-startup.test.ts test/scripts/vitest-runner-task-updates.test.ts
```

```bash
CI=1 OPENCLAW_E2E_USE_PREBUILT_DIST=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.e2e.config.ts test/cli-json-stdout.e2e.test.ts -t 'writes successful telemetry show'
```

The full build and changed-file gate passed on the unchanged production patch. The changed gate includes types, lint, formatting, boundary/patch guards, and import cycles. Managed Codex P0 review passed with no findings. Production is **+17/-18 (net −1)**; tests **+124/-78 (net +46)**; docs **+4/-2**.

**Retained limitations and failures:** the broader stdout file passed 261 tests with one explicitly excluded update-status case that performs a Git fetch, before the final dependency reconciliation. Its first default-reporter attempt ended at the wrapper's existing 300-second silence bound; the verbose original-order attempt passed. That historical timeout remains unexplained, not relabeled as fixed by telemetry or by the dependency refresh. Earlier overstrict human-TTY assertions and an artifact-verifier stderr expectation were corrected and their failed runs retained. No test deadlines or assertions were weakened to accept the product behavior.

This is local CLI and sender-contract proof, not a live telemetry-service call, real PTY, cross-OS result, or full release-verification pass. [The original full run](https://github.com/openclaw/openclaw/actions/runs/33154285571) remains separate and blocked. No release, tag, version bump, or package publication is part of this PR.
