### PR TITLE
fix(github): classify new skills before Barnacle close

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -304,16 +304,6 @@
           - "docs/**"
           - ".agents/skills/update-team-server/**"
 
-"r: skill":
-  - changed-files:
-      - any-glob-to-any-file:
-          - "custodian-skills/**"
-          - "skills/**"
-          - "src/skills/**"
-          - "docs/tools/custodian-skills.md"
-          - "docs/tools/skills-config.md"
-          - "docs/tools/skills.md"
-
 "cli":
   - changed-files:
       - any-glob-to-any-file:

--- a/scripts/github/barnacle-auto-response.mjs
+++ b/scripts/github/barnacle-auto-response.mjs
@@ -10,13 +10,14 @@ import {
 } from "./real-behavior-proof-policy.mjs";
 
 const activePrLimit = 20;
+const skillCloseLabel = "r: skill";
 
 const thirdPartyExtensionMessage =
   "Please publish this as a third-party plugin on [ClawHub](https://clawhub.ai) instead of adding it to the core repo. Docs: https://docs.openclaw.ai/plugin and https://docs.openclaw.ai/clawhub";
 
 const rules = [
   {
-    label: "r: skill",
+    label: skillCloseLabel,
     close: true,
     message:
       "Thanks for the contribution! New skills should be published on [ClawHub](https://clawhub.ai) for everyone to use. We’re keeping the core lean on skills, so I’m closing this out.",
@@ -79,7 +80,7 @@ const rules = [
 
 /** @type {Record<string, { color: string; description: string }>} */
 export const managedLabelSpecs = {
-  "r: skill": {
+  [skillCloseLabel]: {
     color: "5319E7",
     description: "Auto-close: skills should be published on ClawHub, not added to core.",
   },
@@ -222,7 +223,7 @@ const maintainerAuthorLabel = "maintainer";
 const privilegedAuthorAssociations = new Set(["OWNER", "MEMBER", "COLLABORATOR"]);
 const privilegedRepositoryRoles = new Set(["admin", "maintain", "write"]);
 const candidateLabelValues = Object.values(candidateLabels);
-const structuralContextLabelValues = [NEEDS_PR_CONTEXT_LABEL];
+const structuralContextLabelValues = [NEEDS_PR_CONTEXT_LABEL, skillCloseLabel];
 const noisyPrMessage =
   "Closing this PR because it looks dirty (too many unrelated or unexpected changes). This usually happens when a branch picks up unrelated commits or a merge went sideways. Please recreate the PR from a clean branch.";
 
@@ -550,6 +551,13 @@ export function classifyPullRequestCandidateLabels(pullRequest, files) {
     labelsToAdd.push(candidateLabels.externalPluginCandidate);
   }
 
+  const addsBundledSkill = files.some(
+    (file) => file.status === "added" && /^skills\/[^/]+\/SKILL\.md$/i.test(file.filename),
+  );
+  if (addsBundledSkill) {
+    labelsToAdd.push(skillCloseLabel);
+  }
+
   const surfaces = new Set(filenames.flatMap(surfacesForFile));
   if (surfaces.size >= 4 && !clearDesignContext) {
     labelsToAdd.push(candidateLabels.dirtyCandidate);
@@ -783,8 +791,15 @@ async function applyPullRequestCandidateLabels(github, context, core, pullReques
     },
     files,
   );
+  const preserveSkillCloseLabel =
+    context.payload.action === "labeled" &&
+    context.payload.label?.name === skillCloseLabel &&
+    !isAutomationActor(context);
   const staleContextLabels = structuralContextLabelValues.filter(
-    (label) => labelSet.has(label) && !candidateLabelsToApply.includes(label),
+    (label) =>
+      (!preserveSkillCloseLabel || label !== skillCloseLabel) &&
+      labelSet.has(label) &&
+      !candidateLabelsToApply.includes(label),
   );
   await removeLabels(github, context, pullRequest.number, staleContextLabels, labelSet);
   await addMissingLabels(
@@ -1018,6 +1033,7 @@ export async function runBarnacleAutoResponse({ github, context, core = console 
   }
 
   const isLabelEvent = context.payload.action === "labeled";
+  const eventLabel = context.payload.label?.name ?? "";
   const isPrCandidateEvent =
     pullRequest &&
     ["opened", "edited", "synchronize", "reopened", "labeled", "unlabeled"].includes(
@@ -1086,6 +1102,13 @@ export async function runBarnacleAutoResponse({ github, context, core = console 
     }
 
     await applyPullRequestCandidateLabels(github, context, core, pullRequest, labelSet);
+
+    if (isLabelEvent && eventLabel === skillCloseLabel && isAutomationActor(context)) {
+      core.info(
+        `Skipping duplicate PR auto-response for automation-applied ${skillCloseLabel} on #${pullRequest.number}.`,
+      );
+      return;
+    }
 
     if (labelSet.has(dirtyLabel)) {
       await github.rest.issues.createComment({

--- a/scripts/github/barnacle-auto-response.mjs
+++ b/scripts/github/barnacle-auto-response.mjs
@@ -552,7 +552,7 @@ export function classifyPullRequestCandidateLabels(pullRequest, files) {
   }
 
   const addsBundledSkill = files.some(
-    (file) => file.status === "added" && /^skills\/[^/]+\/SKILL\.md$/i.test(file.filename),
+    (file) => file.status === "added" && /^skills\/(?:[^/]+\/)+SKILL\.md$/i.test(file.filename),
   );
   if (addsBundledSkill) {
     labelsToAdd.push(skillCloseLabel);

--- a/test/scripts/barnacle-auto-response.test.ts
+++ b/test/scripts/barnacle-auto-response.test.ts
@@ -295,11 +295,16 @@ describe("barnacle-auto-response", () => {
       ).not.toContain("r: skill");
     }
 
-    expect(
-      classifyPullRequestCandidateLabels(pr("Add weather helper skill"), [
-        file("skills/weather-helper/SKILL.md", "added"),
-      ]),
-    ).toContain("r: skill");
+    for (const filename of [
+      "skills/weather-helper/SKILL.md",
+      "skills/group/weather-helper/SKILL.md",
+    ]) {
+      expect(
+        classifyPullRequestCandidateLabels(pr("Add weather helper skill"), [
+          file(filename, "added"),
+        ]),
+      ).toContain("r: skill");
+    }
   });
 
   it("removes a stale automated skill close label from a core test-only PR", async () => {

--- a/test/scripts/barnacle-auto-response.test.ts
+++ b/test/scripts/barnacle-auto-response.test.ts
@@ -282,6 +282,111 @@ describe("barnacle-auto-response", () => {
     ]);
   });
 
+  it("classifies only an added bundled skill for the ClawHub close", () => {
+    for (const filename of [
+      "src/skills/loading/plugin-skills.test.ts",
+      "src/skills/workspace.ts",
+      "skills/weather/SKILL.md",
+    ]) {
+      expect(
+        classifyPullRequestCandidateLabels(pr("Fix linked skill behavior", "Fixes #127931"), [
+          file(filename),
+        ]),
+      ).not.toContain("r: skill");
+    }
+
+    expect(
+      classifyPullRequestCandidateLabels(pr("Add weather helper skill"), [
+        file("skills/weather-helper/SKILL.md", "added"),
+      ]),
+    ).toContain("r: skill");
+  });
+
+  it("removes a stale automated skill close label from a core test-only PR", async () => {
+    const { calls, github } = barnacleGithub([file("src/skills/loading/plugin-skills.test.ts")]);
+
+    await runBarnacleAutoResponse({
+      github,
+      context: barnacleContext(
+        {
+          title: "Fix Windows symlink typing",
+          body: "Fixes #127931",
+        },
+        ["r: skill"],
+        {
+          action: "labeled",
+          label: { name: "r: skill" },
+          sender: { login: "openclaw-barnacle[bot]", type: "Bot" },
+        },
+      ),
+      core: {
+        info: () => undefined,
+      },
+    });
+
+    expect(calls.removeLabel).toContainEqual(expectedRemoveLabel(123, "r: skill"));
+    expect(calls.createComment).toStrictEqual([]);
+    expect(calls.update).toStrictEqual([]);
+  });
+
+  it("closes a newly added bundled skill deterministically", async () => {
+    const { calls, github } = barnacleGithub([file("skills/weather-helper/SKILL.md", "added")]);
+
+    await runBarnacleAutoResponse({
+      github,
+      context: barnacleContext({ title: "Add weather helper skill" }),
+      core: {
+        info: () => undefined,
+      },
+    });
+
+    expect(calls.addLabels.flatMap((call) => call.labels)).toContain("r: skill");
+    expect(calls.createComment).toHaveLength(1);
+    expect(calls.createComment[0]?.body).toContain("ClawHub");
+    expect(calls.update).toStrictEqual([expectedIssueUpdate(123, "closed")]);
+  });
+
+  it("does not duplicate the close for its own skill label event", async () => {
+    const { calls, github } = barnacleGithub([file("skills/weather-helper/SKILL.md", "added")]);
+
+    await runBarnacleAutoResponse({
+      github,
+      context: barnacleContext({}, ["r: skill"], {
+        action: "labeled",
+        label: { name: "r: skill" },
+        sender: { login: "openclaw-barnacle[bot]", type: "Bot" },
+      }),
+      core: {
+        info: () => undefined,
+      },
+    });
+
+    expect(calls.createComment).toStrictEqual([]);
+    expect(calls.update).toStrictEqual([]);
+  });
+
+  it("honors a maintainer-applied skill close label", async () => {
+    const { calls, github } = barnacleGithub([file("src/skills/workspace.ts")], {
+      maintainerLogins: ["maintainer"],
+    });
+
+    await runBarnacleAutoResponse({
+      github,
+      context: barnacleContext({}, ["r: skill"], {
+        action: "labeled",
+        label: { name: "r: skill" },
+        sender: { login: "maintainer", type: "User" },
+      }),
+      core: {
+        info: () => undefined,
+      },
+    });
+
+    expect(calls.removeLabel).not.toContainEqual(expectedRemoveLabel(123, "r: skill"));
+    expect(calls.createComment).toHaveLength(1);
+    expect(calls.update).toStrictEqual([expectedIssueUpdate(123, "closed")]);
+  });
+
   it("uses the latest case-insensitive context sections after template boilerplate", () => {
     const body = [
       blankTemplateBody,


### PR DESCRIPTION
## What Problem This Solves

Barnacle treated the path-routing label `r: skill` as proof that a pull request added a new distributable skill. Because the labeler applied it to every change under `src/skills/**`, core bug fixes and test-only changes were closed with the ClawHub message. This affected #127941, #127946, and #132199 while addressing #127931.

## Why This Change Was Made

- Removes the destructive `r: skill` rule from the generic path labeler.
- Derives `r: skill` inside Barnacle only when the diff adds `skills/<slug>/SKILL.md`.
- Revalidates and removes stale automated `r: skill` labels from PRs that do not add a bundled skill.
- Preserves an explicitly applied human `r: skill` close and avoids duplicate responses to Barnacle's own label event.

## User Impact

Test-only and core implementation changes under `src/skills/**` remain open for normal review. Genuine new bundled skills still receive the existing ClawHub close response. No separate Barnacle deployment is required: the workflow executes the script from the default-branch revision.

## Evidence

- Pre-fix regression run: the new tests fail against `origin/main` for stale-label removal and deterministic new-skill classification.
- `node scripts/run-vitest.mjs run test/scripts/barnacle-auto-response.test.ts test/scripts/labeler-extension-coverage.test.ts` — 49 passed.
- `node scripts/run-vitest.mjs run test/scripts/ci-workflow-guards.test.ts -t "isolates auto-response per item and ignores ClawSweeper PR label feedback"` — passed.
- `pnpm lint:scripts` — passed (0 warnings/errors).
- `check:changed` completed all checks through the root test typecheck; that check is blocked by the shared checkout's stale dependency install (`pako` declaration missing), unrelated to this diff.

Fixes the Barnacle classification defect reported against #127931.
