### PR TITLE
feat(meta): add muse-image as a first-class image-generation provider

### DIFF
--- a/extensions/meta/README.md
+++ b/extensions/meta/README.md
@@ -35,6 +35,38 @@ audio, and PDF input for these models. OpenClaw's model catalog directly represe
 text and image input only; the other upstream modalities are not model-manifest input
 values. Meta does not publish an exact maximum-output figure for these catalog rows.
 
+## Image generation (muse-image)
+
+The plugin also registers a Meta **image-generation** provider backed by the
+OpenAI-compatible `POST /v1/images/generations` endpoint (base64 WebP output).
+
+- **Provider id:** `meta`
+- **Model:** `muse-image-1.0` (text-to-image + single-reference image editing)
+- **Auth:** the same `MODEL_API_KEY` used by the text provider
+
+Select it as the image-generation model:
+
+```json5
+// ~/.openclaw/openclaw.json
+{
+  agents: {
+    defaults: {
+      imageGenerationModel: { primary: "meta/muse-image-1.0" },
+    },
+  },
+}
+```
+
+Editing works by passing a reference image to the `image_generate` tool, which
+routes to the OpenAI-compatible `POST /v1/images/edits` endpoint.
+
+> [!NOTE]
+> Meta also supports conversational multi-turn image editing through the
+> Responses API (`previous_response_id`). That is a stateful session concept
+> that does not map onto OpenClaw's stateless `image_generate` tool, so the
+> plugin exposes editing through single-reference `POST /v1/images/edits`
+> instead — which achieves the same "alter the previous image" outcome.
+
 ## Usage
 
 Install the plugin and restart Gateway:

--- a/extensions/meta/image-generation-provider.test.ts
+++ b/extensions/meta/image-generation-provider.test.ts
@@ -1,0 +1,197 @@
+// Meta tests cover the muse-image image-generation provider plugin behavior.
+import {
+  getProviderHttpMocks,
+  installProviderHttpMockCleanup,
+} from "openclaw/plugin-sdk/provider-http-test-mocks";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { buildMetaImageGenerationProvider } from "./image-generation-provider.js";
+
+const {
+  resolveApiKeyForProviderMock,
+  postJsonRequestMock,
+  postMultipartRequestMock,
+  resolveProviderHttpRequestConfigMock,
+} = getProviderHttpMocks();
+
+installProviderHttpMockCleanup();
+
+function jsonResponse(payload: unknown): Response {
+  return new Response(JSON.stringify(payload), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+// Meta returns base64 WebP payloads under data[].b64_json.
+function mockGeneratedWebpResponse() {
+  postJsonRequestMock.mockResolvedValue({
+    response: jsonResponse({
+      data: [{ b64_json: Buffer.from("webp-bytes").toString("base64") }],
+    }),
+    release: vi.fn(async () => {}),
+  });
+}
+
+function mockEditedWebpResponse() {
+  postMultipartRequestMock.mockResolvedValue({
+    response: jsonResponse({
+      data: [{ b64_json: Buffer.from("webp-bytes").toString("base64") }],
+    }),
+    release: vi.fn(async () => {}),
+  });
+}
+
+function mockObjectArg(mock: unknown, index = -1): Record<string, unknown> {
+  const calls = (mock as { mock?: { calls?: Array<Array<unknown>> } }).mock?.calls ?? [];
+  const call = index < 0 ? calls.at(index) : calls[index];
+  const [arg] = call ?? [];
+  if (!arg || typeof arg !== "object") {
+    throw new Error(`expected mock object argument ${index}`);
+  }
+  return arg as Record<string, unknown>;
+}
+
+function expectFields(value: unknown, expected: Record<string, unknown>): void {
+  if (!value || typeof value !== "object") {
+    throw new Error("expected fields object");
+  }
+  const record = value as Record<string, unknown>;
+  for (const [key, expectedValue] of Object.entries(expected)) {
+    expect(record[key], key).toEqual(expectedValue);
+  }
+}
+
+describe("meta image generation provider", () => {
+  beforeEach(() => {
+    resolveApiKeyForProviderMock.mockResolvedValue({ apiKey: "meta-key" });
+  });
+
+  it("declares the meta id and muse-image catalog surface", () => {
+    const provider = buildMetaImageGenerationProvider();
+
+    expect(provider.id).toBe("meta");
+    expect(provider.label).toBe("Meta");
+    expect(provider.defaultModel).toBe("muse-image-1.0");
+    expect(provider.models).toContain("muse-image-1.0");
+    expect(provider.capabilities.geometry?.sizes).toContain("1024x1024");
+    // muse-image supports single-reference edits via /v1/images/edits.
+    expect(provider.capabilities.edit?.enabled).toBe(true);
+    expect(provider.capabilities.edit?.maxInputImages).toBe(1);
+  });
+
+  it("defaults to the Meta base URL and posts to /images/generations", async () => {
+    mockGeneratedWebpResponse();
+
+    const provider = buildMetaImageGenerationProvider();
+    await provider.generateImage({
+      provider: "meta",
+      model: "muse-image-1.0",
+      prompt: "a single ripe banana on a white background",
+      cfg: {},
+    });
+
+    expectFields(mockObjectArg(resolveProviderHttpRequestConfigMock), {
+      baseUrl: "https://api.meta.ai/v1",
+    });
+    expect(mockObjectArg(postJsonRequestMock).url).toBe(
+      "https://api.meta.ai/v1/images/generations",
+    );
+  });
+
+  it("sends the requested model, prompt, and defaults in the generate body", async () => {
+    mockGeneratedWebpResponse();
+
+    const provider = buildMetaImageGenerationProvider();
+    await provider.generateImage({
+      provider: "meta",
+      model: "muse-image-1.0",
+      prompt: "a lighthouse",
+      cfg: {},
+    });
+
+    expectFields(mockObjectArg(postJsonRequestMock).body as Record<string, unknown>, {
+      model: "muse-image-1.0",
+      prompt: "a lighthouse",
+      n: 1,
+      size: "1024x1024",
+    });
+  });
+
+  it("honors a configured baseUrl override", async () => {
+    mockGeneratedWebpResponse();
+
+    const provider = buildMetaImageGenerationProvider();
+    await provider.generateImage({
+      provider: "meta",
+      model: "muse-image-1.0",
+      prompt: "campaign hero",
+      cfg: {
+        models: {
+          providers: {
+            meta: { baseUrl: "https://api.meta.ai/v1/", models: [] },
+          },
+        },
+      },
+    });
+
+    expect(mockObjectArg(postJsonRequestMock).url).toBe(
+      "https://api.meta.ai/v1/images/generations",
+    );
+  });
+
+  it("forwards the requested size and count", async () => {
+    mockGeneratedWebpResponse();
+
+    const provider = buildMetaImageGenerationProvider();
+    await provider.generateImage({
+      provider: "meta",
+      model: "muse-image-1.0",
+      prompt: "portrait render",
+      cfg: {},
+      size: "1024x1536",
+    });
+
+    expectFields(mockObjectArg(postJsonRequestMock).body as Record<string, unknown>, {
+      model: "muse-image-1.0",
+      prompt: "portrait render",
+      size: "1024x1536",
+    });
+  });
+
+  it("routes to the multipart /images/edits endpoint when a reference image is provided", async () => {
+    mockEditedWebpResponse();
+
+    const provider = buildMetaImageGenerationProvider();
+    await provider.generateImage({
+      provider: "meta",
+      model: "muse-image-1.0",
+      prompt: "change the cube color to blue",
+      cfg: {},
+      inputImages: [{ buffer: Buffer.from("fake-input"), mimeType: "image/webp" }],
+    });
+
+    // Edits must be multipart against /images/edits, never JSON.
+    expect(postJsonRequestMock).not.toHaveBeenCalled();
+    expect(mockObjectArg(postMultipartRequestMock).url).toBe("https://api.meta.ai/v1/images/edits");
+
+    const form = mockObjectArg(postMultipartRequestMock).body as FormData;
+    expect(form.get("model")).toBe("muse-image-1.0");
+    expect(form.get("prompt")).toBe("change the cube color to blue");
+    expect(form.getAll("image")).toHaveLength(1);
+    expect(form.get("image")).toBeInstanceOf(Blob);
+  });
+
+  it("throws a clear error when the API key is missing", async () => {
+    resolveApiKeyForProviderMock.mockResolvedValueOnce({ apiKey: "" });
+
+    const provider = buildMetaImageGenerationProvider();
+    await expect(
+      provider.generateImage({
+        provider: "meta",
+        model: "muse-image-1.0",
+        prompt: "x",
+        cfg: {},
+      }),
+    ).rejects.toThrow("Meta API key missing");
+  });
+});

--- a/extensions/meta/image-generation-provider.ts
+++ b/extensions/meta/image-generation-provider.ts
@@ -1,0 +1,107 @@
+// Meta provider module implements image-generation runtime integration.
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import {
+  createOpenAiCompatibleImageGenerationProvider,
+  imageSourceUploadFileName,
+  type ImageGenerationProvider,
+} from "openclaw/plugin-sdk/image-generation";
+import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { META_BASE_URL } from "./models.js";
+
+const PROVIDER_ID = "meta";
+const DEFAULT_SIZE = "1024x1024";
+const DEFAULT_IMAGE_MIME = "image/png";
+const DEFAULT_META_IMAGE_MODEL = "muse-image-1.0";
+
+// Meta muse-image renders at these OpenAI-style sizes (square/landscape/portrait).
+const META_IMAGE_SUPPORTED_SIZES = ["1024x1024", "1536x1024", "1024x1536"] as const;
+
+// muse-image edits take a single reference image on the OpenAI-compatible
+// /v1/images/edits endpoint. (Conversational multi-turn editing via the
+// Responses API is a session concept that does not map onto OpenClaw's
+// stateless image_generate tool, so it is intentionally not modeled here — a
+// reference-image edit achieves the same user outcome.)
+const META_MAX_INPUT_IMAGES = 1;
+
+type MetaProviderConfig = NonNullable<NonNullable<OpenClawConfig["models"]>["providers"]>[string];
+
+function resolveMetaProviderConfig(
+  cfg: OpenClawConfig | undefined,
+): MetaProviderConfig | undefined {
+  return cfg?.models?.providers?.meta;
+}
+
+function resolveConfiguredMetaBaseUrl(cfg: OpenClawConfig | undefined): string {
+  return normalizeOptionalString(resolveMetaProviderConfig(cfg)?.baseUrl) ?? META_BASE_URL;
+}
+
+/** Builds the Meta (muse-image) OpenAI-compatible image-generation provider. */
+export function buildMetaImageGenerationProvider(): ImageGenerationProvider {
+  return createOpenAiCompatibleImageGenerationProvider({
+    id: PROVIDER_ID,
+    label: "Meta",
+    defaultModel: DEFAULT_META_IMAGE_MODEL,
+    models: [DEFAULT_META_IMAGE_MODEL],
+    capabilities: {
+      generate: {
+        maxCount: 1,
+        supportsSize: true,
+        supportsAspectRatio: false,
+        supportsResolution: false,
+      },
+      // muse-image supports single-reference edits through /v1/images/edits.
+      edit: {
+        enabled: true,
+        maxCount: 1,
+        maxInputImages: META_MAX_INPUT_IMAGES,
+        supportsSize: true,
+        supportsAspectRatio: false,
+        supportsResolution: false,
+      },
+      geometry: {
+        sizes: [...META_IMAGE_SUPPORTED_SIZES],
+      },
+    },
+    defaultBaseUrl: META_BASE_URL,
+    resolveBaseUrl: ({ req }) => resolveConfiguredMetaBaseUrl(req.cfg),
+    useConfiguredRequest: true,
+    buildGenerateRequest: ({ req, model, count }) => ({
+      kind: "json",
+      body: {
+        model,
+        prompt: req.prompt,
+        n: count,
+        size: req.size ?? DEFAULT_SIZE,
+      },
+    }),
+    // Edits use the OpenAI-compatible multipart /v1/images/edits endpoint: the
+    // reference image is an uploaded file part, not a JSON field.
+    buildEditRequest: ({ req, inputImages, model, count }) => {
+      const form = new FormData();
+      form.set("model", model);
+      form.set("prompt", req.prompt);
+      form.set("n", String(count));
+      form.set("size", req.size ?? DEFAULT_SIZE);
+      for (const [index, image] of inputImages.entries()) {
+        const mimeType = normalizeOptionalString(image.mimeType) ?? DEFAULT_IMAGE_MIME;
+        form.append(
+          "image",
+          new Blob([new Uint8Array(image.buffer)], { type: mimeType }),
+          imageSourceUploadFileName({ image, index }),
+        );
+      }
+      return { kind: "multipart", form };
+    },
+    response: {
+      // Meta returns base64 WebP payloads under data[].b64_json.
+      defaultMimeType: "image/webp",
+      fileNamePrefix: "meta",
+      sniffMimeType: true,
+    },
+    missingApiKeyError: "Meta API key missing",
+    failureLabels: {
+      generate: "Meta image generation failed",
+      edit: "Meta image edit failed",
+    },
+  });
+}

--- a/extensions/meta/index.test.ts
+++ b/extensions/meta/index.test.ts
@@ -104,6 +104,22 @@ describe("meta provider", () => {
     });
   });
 
+  it("registers the Meta muse-image image-generation provider on the same entry", () => {
+    const captured = capturePluginRegistration(plugin);
+    const [imageProvider] = captured.imageGenerationProviders;
+    if (!imageProvider) {
+      throw new Error("Expected Meta image-generation provider");
+    }
+    expect(imageProvider).toMatchObject({
+      id: "meta",
+      label: "Meta",
+      defaultModel: "muse-image-1.0",
+    });
+    expect(imageProvider.models).toContain("muse-image-1.0");
+    // muse-image supports single-reference edits via /v1/images/edits.
+    expect(imageProvider.capabilities.edit?.enabled).toBe(true);
+  });
+
   it("does not wrap projected non-Responses Meta models for either stream hook", () => {
     const captured = capturePluginRegistration(plugin);
     const [provider] = captured.providers;

--- a/extensions/meta/index.ts
+++ b/extensions/meta/index.ts
@@ -1,37 +1,83 @@
 /**
  * Meta provider plugin entrypoint.
+ *
+ * Registers the Meta text model provider (Muse Spark, Responses API) and the
+ * Meta image-generation provider (muse-image) on a single plugin entry, mirroring
+ * the multi-capability shape used by the bundled OpenAI provider plugin.
  */
-import { defineSingleProviderPluginEntry } from "openclaw/plugin-sdk/provider-entry";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { definePluginEntry, type OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-entry";
+import { createProviderApiKeyAuthMethod } from "openclaw/plugin-sdk/provider-auth";
+import { buildOpenAICompatibleProviderCatalog } from "openclaw/plugin-sdk/provider-catalog-live-runtime";
 import { buildProviderReplayFamilyHooks } from "openclaw/plugin-sdk/provider-model-shared";
-import { applyMetaConfig } from "./onboard.js";
-import manifest from "./openclaw.plugin.json" with { type: "json" };
+import { buildMetaImageGenerationProvider } from "./image-generation-provider.js";
+import { applyMetaConfig, META_DEFAULT_MODEL_REF } from "./onboard.js";
 import { buildMetaProvider } from "./provider-catalog.js";
 import { wrapMetaProviderStream } from "./stream.js";
 import { resolveMetaThinkingProfile } from "./thinking.js";
 
 const PROVIDER_ID = "meta";
 
-export default defineSingleProviderPluginEntry({
+export default definePluginEntry({
   id: PROVIDER_ID,
   name: "Meta Provider",
-  description: "Meta provider plugin",
-  manifest,
-  provider: {
-    label: "Meta",
-    docsPath: "/providers/meta",
-    manifestAuth: {
-      applyConfig: applyMetaConfig,
-      noteMessage: "Meta provides Responses API inference.",
+  description: "Meta provider plugin (Muse Spark text + muse-image generation)",
+  register(api: OpenClawPluginApi) {
+    const replayFamilyHooks = buildProviderReplayFamilyHooks({ family: "openai-compatible" });
+
+    // Manifest-derived API-key auth (MODEL_API_KEY), matching the values in
+    // openclaw.plugin.json providerAuthChoices/setup.
+    const apiKeyAuth = createProviderApiKeyAuthMethod({
+      providerId: PROVIDER_ID,
+      methodId: "api-key",
+      label: "Meta API key",
+      hint: "Meta (Responses API)",
+      optionKey: "metaApiKey",
+      flagName: "--meta-api-key",
+      envVar: "MODEL_API_KEY",
+      promptMessage: "Enter Meta API key",
+      defaultModel: META_DEFAULT_MODEL_REF,
+      expectedProviders: [PROVIDER_ID],
+      applyConfig: (cfg: OpenClawConfig) => applyMetaConfig(cfg),
       noteTitle: "Meta",
-    },
-    catalog: {
-      buildProvider: buildMetaProvider,
-      buildStaticProvider: buildMetaProvider,
-      liveModelDiscovery: true,
-    },
-    ...buildProviderReplayFamilyHooks({ family: "openai-compatible" }),
-    wrapSimpleCompletionStreamFn: wrapMetaProviderStream,
-    wrapStreamFn: wrapMetaProviderStream,
-    resolveThinkingProfile: resolveMetaThinkingProfile,
+      noteMessage: "Meta provides Responses API inference.",
+      wizard: {
+        choiceId: "meta-api-key",
+        choiceLabel: "Meta API key",
+        groupId: "meta",
+        groupLabel: "Meta",
+        groupHint: "Meta (Responses API)",
+        onboardingFeatured: true,
+        methodId: "api-key",
+      },
+    });
+
+    api.registerProvider({
+      id: PROVIDER_ID,
+      label: "Meta",
+      docsPath: "/providers/meta",
+      envVars: ["MODEL_API_KEY"],
+      auth: [apiKeyAuth],
+      catalog: {
+        order: "simple",
+        run: (ctx) =>
+          buildOpenAICompatibleProviderCatalog({
+            ctx,
+            providerId: PROVIDER_ID,
+            buildProvider: buildMetaProvider,
+          }),
+      },
+      staticCatalog: {
+        order: "simple",
+        run: async () => ({ provider: buildMetaProvider() }),
+      },
+      // Provider-owned behavior preserved from the previous single-provider entry.
+      ...replayFamilyHooks,
+      wrapSimpleCompletionStreamFn: wrapMetaProviderStream,
+      wrapStreamFn: wrapMetaProviderStream,
+      resolveThinkingProfile: resolveMetaThinkingProfile,
+    });
+
+    api.registerImageGenerationProvider(buildMetaImageGenerationProvider());
   },
 });

--- a/extensions/meta/openclaw.plugin.json
+++ b/extensions/meta/openclaw.plugin.json
@@ -179,5 +179,19 @@
     "type": "object",
     "additionalProperties": false,
     "properties": {}
+  },
+  "contracts": {
+    "imageGenerationProviders": [
+      "meta"
+    ]
+  },
+  "imageGenerationProviderMetadata": {
+    "meta": {
+      "authSignals": [
+        {
+          "provider": "meta"
+        }
+      ]
+    }
   }
 }

--- a/test/vitest/vitest.extension-misc-paths.mjs
+++ b/test/vitest/vitest.extension-misc-paths.mjs
@@ -12,6 +12,7 @@ export const miscExtensionTestRoots = [
   "extensions/litellm",
   "extensions/llm-task",
   "extensions/lobster",
+  "extensions/meta",
   "extensions/opencode",
   "extensions/opencode-go",
   "extensions/openshell",


### PR DESCRIPTION
Closes #132228

## What Problem This Solves

The bundled `meta` provider ships Muse Spark text models but has no image capability, even though the Meta Model API serves muse-image on the same base URL and API key. Operators who authenticate with `MODEL_API_KEY` cannot generate or edit images through a first-class Meta path. The only workaround is pointing the `openai` image provider's `baseUrl` at `https://api.meta.ai/v1`, which takes over the OpenAI image slot, mislabels models in the catalog as `gpt-image-*`, and blocks using real OpenAI at the same time.

## Why This Change Was Made

Register a Meta image-generation provider on the existing `meta` plugin alongside the text provider, so `image_generate` can use `meta/muse-image-1.0` with the credentials already configured for Muse Spark.

- Switch `extensions/meta/index.ts` from `defineSingleProviderPluginEntry` to `definePluginEntry` (the multi-capability shape the bundled `openai` provider uses) and register the image provider via `registerImageGenerationProvider`. The text provider behavior is preserved exactly (api-key auth, live catalog, replay-family hooks, stream wrapping, thinking profile).
- Build the image provider on the shared `createOpenAiCompatibleImageGenerationProvider` factory against `POST /v1/images/generations` and `/v1/images/edits` (base64 WebP output), the same path `litellm` uses.
- Support single-reference editing. muse-image also supports conversational editing through the Responses API (`previous_response_id`), but that is a stateful session concept with no field in the stateless `image_generate` tool, so single-reference `/v1/images/edits` covers the "alter the previous image" case.
- Declare `contracts.imageGenerationProviders` and provider metadata in the manifest so the `image_generate` tool discovers it.
- `extensions/meta` was not routed by any vitest config, so its tests were not running; this adds it to the misc extension test roots.

No SQLite, config-schema, or new env-var surface is added. No CODEOWNERS-restricted paths are touched.

## User Impact

Operators using the Meta Model API can now generate and edit images through OpenClaw with the same `MODEL_API_KEY` they already use for Muse Spark:

```json5
// ~/.openclaw/openclaw.json
{ agents: { defaults: { imageGenerationModel: { primary: "meta/muse-image-1.0" } } } }
```

The `openai` image slot is left free for real OpenAI, and the catalog shows correct Meta model names.

## Evidence

AI-assisted PR (drafted with an agent; author reviewed and understands the change).

Verified live against `api.meta.ai/v1`:

- **Generate** and **single-reference edit** both return base64 WebP through `/v1/images/generations` and `/v1/images/edits`.
- End-to-end through OpenClaw's `image_generate` / `image.edit` runtime: `generate` produced a banana; `edit` took that banana as the reference and returned an apple with the same composition (pose, lighting, shadow, background), confirming the reference image conditions the result.
- Muse Spark text generation and image understanding still work unchanged.

Validation:

- `oxlint extensions/meta/` — 0 warnings, 0 errors
- tsgo typecheck (source `tsconfig.extensions.json` + `tsconfig.extensions.test.json`) — 0 errors
- 24 unit tests pass (`vitest.extension-misc.config.ts extensions/meta/`): generate body/URL, size/count forwarding, base URL override, reference-image edit routing to `/images/edits`, missing-key error, and image-provider registration on the plugin entry
- `autoreview` (Codex `gpt-5.6-sol`, high) — `patch is correct`, confidence 0.96, no accepted/actionable findings
