### PR TITLE
fix(qa): recognize process groups reaped during cleanup

### DIFF
--- a/extensions/qa-lab/src/gateway-child-lifecycle.test.ts
+++ b/extensions/qa-lab/src/gateway-child-lifecycle.test.ts
@@ -3,7 +3,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createQaGatewayChild } from "./gateway-child.js";
-import { isQaPosixProcessGroupAlive } from "./posix-process-group.js";
+import { isQaPosixProcessGroupAlive, signalQaPosixProcessGroup } from "./posix-process-group.js";
 import { createTempDirHarness } from "./temp-dir.test-helper.js";
 
 const boundary = vi.hoisted(() => ({ create: vi.fn() }));
@@ -23,15 +23,17 @@ const groups: number[] = [];
 afterEach(async () => {
   vi.restoreAllMocks();
   boundary.create.mockReset();
-  for (const owner of owners.splice(0)) {
+  for (const owner of owners) {
     await owner.stop();
   }
-  for (const group of groups.splice(0)) {
+  for (const group of groups) {
     if (isQaPosixProcessGroupAlive(group)) {
-      process.kill(-group, "SIGKILL");
+      expect(signalQaPosixProcessGroup(group, "SIGKILL")).toBeUndefined();
     }
     await vi.waitFor(() => expect(isQaPosixProcessGroupAlive(group)).toBe(false));
   }
+  owners.length = 0;
+  groups.length = 0;
   await dirs.cleanup();
 });
 

--- a/extensions/qa-lab/src/gateway-startup-lease.integration.test.ts
+++ b/extensions/qa-lab/src/gateway-startup-lease.integration.test.ts
@@ -7,7 +7,7 @@ import { fileURLToPath } from "node:url";
 import { describe, expect, it, vi } from "vitest";
 import { createQaBusState } from "./bus-state.js";
 import type { QaLabServerHandle } from "./lab-server.types.js";
-import { isQaPosixProcessGroupAlive } from "./posix-process-group.js";
+import { isQaPosixProcessGroupAlive, signalQaPosixProcessGroup } from "./posix-process-group.js";
 import type { QaTransportAdapterFactory } from "./qa-transport-registry.js";
 import { runQaFlowSuiteStandard } from "./suite-run-standard.js";
 import type { QaSuiteResolvedRunContext } from "./suite-types.js";
@@ -320,11 +320,9 @@ async function reproduce(denyGroupSignals: boolean) {
       const identity = readIdentity(root);
       if (identity && alive(-identity.pgid)) {
         record("diagnostic-force-kill", snapshot());
-        realKill(-identity.pgid, "SIGKILL");
+        expect(signalQaPosixProcessGroup(identity.pgid, "SIGKILL")).toBeUndefined();
       }
       const deadline = Date.now() + 5_000;
-      // Retain the settled observation: a later Linux probe may see no /proc
-      // members during reaping and conservatively report an unknown group alive.
       cleaned = snapshot();
       while (cleaned.groupAlive && Date.now() < deadline) {
         await sleep(25);

--- a/extensions/qa-lab/src/posix-process-group.test.ts
+++ b/extensions/qa-lab/src/posix-process-group.test.ts
@@ -1,6 +1,20 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { isQaPosixProcessGroupAlive, signalQaPosixProcessGroup } from "./posix-process-group.js";
+import {
+  inspectLinuxProcessGroup,
+  isQaPosixProcessGroupAlive,
+  signalQaPosixProcessGroup,
+} from "./posix-process-group.js";
 import { inspectLinuxProcessGroupStats } from "./posix-process-stat.js";
+
+const procFs = vi.hoisted(() => ({ readFileSync: vi.fn(), readdirSync: vi.fn() }));
+vi.mock("node:fs", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs")>();
+  return {
+    ...actual,
+    readFileSync: procFs.readFileSync.mockImplementation(actual.readFileSync),
+    readdirSync: procFs.readdirSync.mockImplementation(actual.readdirSync),
+  };
+});
 
 afterEach(() => {
   vi.restoreAllMocks();
@@ -47,6 +61,50 @@ describe("POSIX process group inspection", () => {
     expect(inspection.diagnostics).toMatch(/\.\.\.$/u);
   });
 
+  it.each(["ENOENT", "ESRCH", "EACCES"])(
+    "distinguishes a vanished /proc member from unreadable state (%s)",
+    (code) => {
+      vi.spyOn(process, "platform", "get").mockReturnValue("linux");
+      procFs.readdirSync.mockReturnValueOnce([
+        { name: "123", isDirectory: () => true },
+        { name: "999", isDirectory: () => true },
+      ]);
+      procFs.readFileSync
+        .mockReturnValueOnce("123 (leader) Z 1 123 123 0 -1 0")
+        .mockImplementationOnce(() => {
+          throw Object.assign(new Error("stat read failed"), { code });
+        });
+
+      const inspection = inspectLinuxProcessGroup(123);
+      if (code === "EACCES") {
+        expect(inspection).toBeNull();
+      } else {
+        expect(inspection?.alive).toBe(false);
+      }
+    },
+  );
+
+  it.each(["empty", "unavailable"])(
+    "confirms a group reaped during an %s Linux snapshot is stopped",
+    (snapshot) => {
+      vi.spyOn(process, "platform", "get").mockReturnValue("linux");
+      let reaped = false;
+      vi.spyOn(process, "kill").mockImplementation(() => {
+        if (reaped) {
+          throw Object.assign(new Error("group reaped"), { code: "ESRCH" });
+        }
+        return true;
+      });
+
+      expect(
+        isQaPosixProcessGroupAlive(123, () => {
+          reaped = true;
+          return snapshot === "empty" ? inspectLinuxProcessGroupStats(123, []) : null;
+        }),
+      ).toBe(false);
+    },
+  );
+
   it("fails closed when the Linux member snapshot is unavailable", () => {
     const platform = vi.spyOn(process, "platform", "get").mockReturnValue("linux");
     const processKill = vi.spyOn(process, "kill").mockImplementation(() => true);
@@ -86,5 +144,15 @@ describe("POSIX process group inspection", () => {
     expect(isQaPosixProcessGroupAlive(123)).toBe(false);
     expect(signalQaPosixProcessGroup(123, "SIGTERM")).toBeUndefined();
     expect(processKill).not.toHaveBeenCalledWith(123, expect.anything());
+  });
+
+  it.each(["ESRCH", "EPERM"])("preserves the group signal contract on %s", (code) => {
+    const failure = Object.assign(new Error("group signal failed"), { code });
+    const processKill = vi.spyOn(process, "kill").mockImplementation(() => {
+      throw failure;
+    });
+
+    expect(signalQaPosixProcessGroup(123, "SIGKILL")).toBe(code === "ESRCH" ? undefined : failure);
+    expect(processKill.mock.calls).toEqual([[-123, "SIGKILL"]]);
   });
 });

--- a/extensions/qa-lab/src/posix-process-group.ts
+++ b/extensions/qa-lab/src/posix-process-group.ts
@@ -27,7 +27,8 @@ export function inspectLinuxProcessGroup(
     try {
       stats.push(readFileSync(path.join("/proc", entry.name, "stat"), "utf8"));
     } catch (error) {
-      if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+      // Exit can race either opening stat (ENOENT) or reading its open fd (ESRCH).
+      if (!["ENOENT", "ESRCH"].includes((error as NodeJS.ErrnoException).code ?? "")) {
         return null;
       }
     }
@@ -41,13 +42,15 @@ export function isQaPosixProcessGroupAlive(
 ) {
   try {
     process.kill(-processGroupId, 0);
+    // Reaping can remove the last zombie between kill(0) and /proc. Resolve an
+    // inconclusive snapshot with a fresh existence probe, never the stale one.
+    return (
+      process.platform !== "linux" ||
+      (inspectLinuxProcessGroupFn(processGroupId)?.alive ?? process.kill(-processGroupId, 0))
+    );
   } catch (error) {
     return (error as NodeJS.ErrnoException).code !== "ESRCH";
   }
-  if (process.platform !== "linux") {
-    return true;
-  }
-  return inspectLinuxProcessGroupFn(processGroupId)?.alive ?? true;
 }
 
 export function signalQaPosixProcessGroup(


### PR DESCRIPTION
Related: #131643, #131740. Unblocks the QA lifecycle checks on #129276 and #132090.

## What Problem This Solves

Resolves a problem where Linux QA cleanup can report an already-stopped process group as alive, or throw `ESRCH` after checking it. This interrupted the extension QA gate before the doctor and Gateway repairs could land.

## Why This Change Was Made

The shared POSIX group owner previously reused a successful `kill(0)` observation after `/proc` inspection. Reaping the last zombie between those observations leaves an empty snapshot, which was converted back to `alive=true`. The owner now makes a fresh kernel existence probe when that snapshot is inconclusive, and treats `/proc` `ESRCH` as an exited member alongside `ENOENT`.

The two real-process fixtures use the existing idempotent group-signal helper and retain their tracking until termination is confirmed. Live descendants, permission errors, failed replacement ownership, and retry-stop semantics remain protected. No retries, larger timeouts, assertion weakening, new settings, dependencies, or lifecycle policy changes.

## User Impact

QA shutdown and CLI/scenario settlement recognize groups that actually disappeared during reaping. This is an internal QA reliability repair, with no operator Gateway or user configuration change.

Production: +8/-5, net +3; those three net lines explain the kernel race, while executable LOC is net-neutral. Tests: +77/-9. The stale liveness default and raw fixture signal calls are replaced at their existing owners.

## Evidence

Tested source is commit `c48f6ae017240b7b0ac550428292038d618195ab`, based on `b4833bf0eff0f99bda1adab7d3c1b821a23a75e0`. All four committed file hashes match the reviewed and Linux-tested bytes.

- Real Linux reaping probe: a supervised `setsid` child is held as a zombie with `waitid(WNOWAIT)`, then reaped through a FIFO handshake between the first kernel probe and `/proc` inspection. Before: `result=true`, empty members, final `ESRCH`. After: `result=false`, final `ESRCH`; supervisor joined exit 0 and fixture files removed.
- Pre-fix regression run: three intended failures, ten passing controls. Final owner/sibling run: 129 tests across seven files passed.
- Complete original extension QA config, two workers: 220 files / 3046 tests passed. Three additional complete lifetime-file runs passed 10/10 each.
- Clean Linux Node 24.19.0 Testbox proof: [run 33221598080](https://github.com/openclaw/openclaw/actions/runs/33221598080), uninterrupted command exit 0. Source/package/workspace/lock hashes matched before and after, with no tracked deletions. Both proof leases were stopped; the final command receipt, not the hosting lease's cancellation state, records success.
- Full changed gate passed: owner contract tests, production/test types, lint, dead exports, applicable guards, and zero runtime import cycles. Fresh isolated complete-delta Codex P0 review found no actionable P0 findings; this is not an all-priority review claim.

Complete CI-parity shard command:

```sh
CI=1 OPENCLAW_VITEST_MAX_WORKERS=2 OPENCLAW_TESTBOX=1 \
OPENCLAW_TESTBOX_REMOTE_RUN=1 \
OPENCLAW_NODE_TEST_CONFIGS_JSON='["test/vitest/vitest.extension-qa.config.ts"]' \
OPENCLAW_VITEST_SHARD_NAME=changed-extensions-config-38 \
node --import tsx scripts/ci-run-node-test-shard.mts
```

The original CI logs did not capture kernel state: their exact scheduling is inferred from the matching deterministic real-kernel reproduction. The unchanged full baseline passed, so it is not presented as a natural full-shard red reproduction. Original failures: [doctor cleanup ESRCH](https://github.com/openclaw/openclaw/actions/runs/33216229782/job/99000579621) and [Gateway all-dead assertion](https://github.com/openclaw/openclaw/actions/runs/33214533465/job/98999527149).

Direct source audit covered the group/stat owner, Gateway process/lifetime/startup cleanup, CLI settlement and sibling lifecycle tests. The behavior follows the [Linux process-group signal contract](https://man7.org/linux/man-pages/man2/kill.2.html), [exited `/proc` handle contract](https://docs.kernel.org/filesystems/proc.html), and [Node 24.19.0 `process.kill` implementation](https://github.com/nodejs/node/blob/v24.19.0/lib/internal/process/per_thread.js#L235-L260). Consumer-only retries or weakening failed-replacement retention would leave the shared owner defect intact.

Provenance: the stale default is from #120010, authored by @vincentkoc and merged by @RomneyDa on August 8; the new lifetime coverage in #131740 made it visible. This repair preserves that coverage and its ownership invariant. AI-assisted implementation and review.
