### PR TITLE
fix(browser): restore MCP page creation through the extension relay

### DIFF
--- a/docs/tools/chrome-extension.md
+++ b/docs/tools/chrome-extension.md
@@ -136,6 +136,19 @@ The extension excludes incognito tabs, internal pages such as `chrome://` and
 `chrome-extension://`, and tabs without a usable current URL. `file://` access
 also requires Chrome's **Allow access to file URLs** setting.
 
+An agent-created tab may start at `about:blank` while a CDP client initializes
+it before navigating. The extension allows that specific initial tab, keeps it
+in the OpenClaw group, and applies the same pause and access-mode controls.
+Existing blank tabs, manually grouped blanks, and other `about:` pages remain
+unavailable. Navigating away, replacing the tab, or restarting or reconnecting
+the extension ends the initial blank admission; returning to `about:blank`
+does not restore it.
+
+If creation fails before the extension returns the target, it attempts to close
+the tab only while it still owns it. Tabs you paused, moved, or navigated during
+creation are left alone. A redirect, lost connection, or worker shutdown can
+leave a tab behind; close it manually if needed.
+
 ## Automatic setup controls
 
 Settings shows redacted relay/native bootstrap status and an **Use automatic

--- a/extensions/browser/chrome-extension/background.access-mode.test.ts
+++ b/extensions/browser/chrome-extension/background.access-mode.test.ts
@@ -876,7 +876,11 @@ describe("relay command authorization", () => {
     await vi.waitFor(() => {
       expect(harness.tabsGroup).toHaveBeenCalledWith({ tabIds: [42] });
       const frames = socket.send.mock.calls.map(([raw]) => JSON.parse(raw));
-      expect(frames).toContainEqual({ type: "result", seq: 6, result: { tabId: 42 } });
+      expect(frames).toContainEqual({
+        type: "result",
+        seq: 6,
+        result: { tabId: 42, targetId: "tab-42" },
+      });
     });
   });
 

--- a/extensions/browser/chrome-extension/background.initial-target.test.ts
+++ b/extensions/browser/chrome-extension/background.initial-target.test.ts
@@ -1,0 +1,570 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ExtensionRelayBridge } from "../src/browser/extension-relay/relay-bridge.js";
+import {
+  cleanupBackgroundHarnesses,
+  loadBackground,
+  loadRelayCommandHarness as createHarness,
+  sendRuntimeMessage,
+  TEST_RELAY_KEY,
+  REPLACEMENT_TEST_RELAY_KEY,
+} from "./background.test-harness.js";
+
+const pendingReleases = new Set<() => void>();
+function deferred<T>(fallback: T) {
+  let resolve = (_value: T) => {};
+  const promise = new Promise<T>((done) => {
+    resolve = done;
+  });
+  const pending = { promise, resolve };
+  const release = () => pending.resolve(fallback);
+  pendingReleases.add(release);
+  return {
+    promise: pending.promise,
+    resolve: (value = fallback) => {
+      pendingReleases.delete(release);
+      pending.resolve(value);
+    },
+  };
+}
+
+beforeEach(() => vi.resetModules());
+afterEach(async () => {
+  for (const release of pendingReleases) {
+    release();
+  }
+  pendingReleases.clear();
+  await cleanupBackgroundHarnesses();
+  vi.unstubAllGlobals();
+});
+
+describe.each(["all", "selected"] as const)("created initial target in %s mode", (mode) => {
+  it.each([
+    { url: "about:blank", failGrouping: false },
+    { url: "about:blank", failGrouping: true },
+    { url: "https://example.com/", failGrouping: false },
+    { url: "https://example.com/", failGrouping: true },
+  ])(
+    "handles Chrome's pending-only initial URL $url (group failure: $failGrouping)",
+    async ({ url, failGrouping }) => {
+      const harness = await createHarness(mode);
+      const create = harness.tabsCreate.getMockImplementation()!;
+      harness.tabsCreate.mockImplementation(async (params) =>
+        Object.assign(await create(params), { url: "", pendingUrl: url }),
+      );
+      const group = harness.tabsGroup.getMockImplementation()!;
+      harness.tabsGroup.mockImplementationOnce(async (params) => {
+        harness.updateTab(101, { pendingUrl: url });
+        harness.updateTab(101, { url, pendingUrl: undefined });
+        if (failGrouping) {
+          throw new Error("group failed");
+        }
+        return await group(params);
+      });
+      expect(await harness.command({ type: "createTab", url })).toMatchObject({
+        type: failGrouping ? "error" : "result",
+      });
+      if (failGrouping) {
+        expect(harness.tabsRemove).toHaveBeenCalledExactlyOnceWith(101);
+      } else {
+        expect(harness.debuggerAttach).toHaveBeenCalledExactlyOnceWith({ tabId: 101 }, "1.3");
+        expect(await harness.command({ type: "closeTab", tabId: 101 })).toMatchObject({
+          type: "result",
+        });
+      }
+    },
+  );
+  it.each([false, true])(
+    "accepts initial HTTP redirects (attach failure: %s) without reclaiming a changed destination",
+    async (failAttach) => {
+      const harness = await createHarness(mode);
+      const create = harness.tabsCreate.getMockImplementation()!;
+      harness.tabsCreate.mockImplementation(async (params) =>
+        Object.assign(await create(params), { url: "", pendingUrl: params.url }),
+      );
+      const group = harness.tabsGroup.getMockImplementation()!;
+      harness.tabsGroup.mockImplementationOnce(async (params) => {
+        harness.updateTab(101, { url: "https://example.com/redirected", pendingUrl: undefined });
+        return await group(params);
+      });
+      if (failAttach) {
+        harness.debuggerAttach.mockRejectedValueOnce(new Error("attach failed"));
+      }
+      expect(
+        await harness.command({ type: "createTab", url: "https://example.com/start" }),
+      ).toMatchObject({ type: failAttach ? "error" : "result" });
+      expect(harness.debuggerAttach).toHaveBeenCalledExactlyOnceWith({ tabId: 101 }, "1.3");
+      expect(harness.tabsRemove).not.toHaveBeenCalled();
+    },
+  );
+
+  it("accepts an initial HTTP commit observed before Chrome returns the created tab", async () => {
+    const harness = await createHarness(mode);
+    const create = harness.tabsCreate.getMockImplementation()!;
+    harness.tabsCreate.mockImplementationOnce(async (params) => {
+      const tab = await create(params);
+      harness.updateTab(tab.id, { url: params.url });
+      return tab;
+    });
+    expect(
+      await harness.command({ type: "createTab", url: "https://example.com/start" }),
+    ).toMatchObject({ type: "result" });
+    expect(harness.debuggerAttach).toHaveBeenCalledExactlyOnceWith({ tabId: 101 }, "1.3");
+  });
+
+  it("retires an unhanded blank when a lookup observes takeover before the URL event", async () => {
+    const harness = await createHarness(mode);
+    const attaching = deferred(undefined);
+    harness.debuggerAttach.mockImplementationOnce(async () => await attaching.promise);
+    const creating = harness.command({ type: "createTab", url: "about:blank" });
+    await vi.waitFor(() => expect(harness.debuggerAttach).toHaveBeenCalled());
+    const get = harness.tabsGet.getMockImplementation()!;
+    harness.tabsGet.mockImplementation(async (tabId) => ({
+      ...(await get(tabId)),
+      url: "https://example.com/user-takeover",
+    }));
+    await sendRuntimeMessage(harness, { type: "getTabAccess", tabId: 101 });
+    harness.updateTab(101, { url: "https://example.com/user-takeover" });
+    attaching.resolve();
+    expect(await creating).toMatchObject({ type: "error" });
+    expect(harness.tabsRemove).not.toHaveBeenCalled();
+  });
+
+  it("composes the real relay and background policy for blank-first CDP creation", async () => {
+    const harness = await createHarness(mode);
+    const bridge = new ExtensionRelayBridge();
+    const extension = bridge.attachExtensionSocket({
+      send: (raw) => harness.socket.receive(JSON.parse(raw)),
+      close: () => harness.socket.close(),
+    });
+    const hello = harness.frames().find((frame) => frame.type === "hello");
+    harness.socket.send.mockImplementation((raw: string) => extension.onMessage(raw));
+    extension.onMessage(JSON.stringify(hello));
+    const frames: Array<Record<string, unknown>> = [];
+    const client = bridge.attachCdpClientSocket({
+      send: (raw) => frames.push(JSON.parse(raw)),
+      close() {},
+    });
+    let id = 0;
+    const request = async (method: string, params = {}, sessionId?: string) => {
+      const requestId = ++id;
+      client.onMessage(JSON.stringify({ id: requestId, method, params, sessionId }));
+      return await vi.waitFor(() => {
+        const response = frames.find((frame) => frame.id === requestId);
+        expect(response).toBeDefined();
+        expect(response).not.toHaveProperty("error");
+        return response?.result;
+      });
+    };
+    try {
+      await request("Target.setAutoAttach", { autoAttach: true, flatten: true });
+      expect(await request("Target.createTarget", { url: "about:blank" })).toEqual({
+        targetId: "tab-101",
+      });
+      const attached = frames.find((frame) => frame.method === "Target.attachedToTarget")
+        ?.params as { sessionId: string };
+      expect(attached.sessionId).toBeTruthy();
+      await request("Page.enable", {}, attached.sessionId);
+      harness.debuggerSendCommand.mockImplementationOnce(async () => {
+        harness.updateTab(101, { url: "https://example.com/" });
+        return { frameId: "frame-101", loaderId: "next-document" };
+      });
+      await request("Page.navigate", { url: "https://example.com/" }, attached.sessionId);
+      await request("Runtime.evaluate", { expression: "document.title" }, attached.sessionId);
+      await request("Target.detachFromTarget", { sessionId: attached.sessionId });
+      expect(await request("Target.closeTarget", { targetId: "tab-101" })).toEqual({
+        success: true,
+      });
+      expect(harness.debuggerAttach).toHaveBeenCalledExactlyOnceWith({ tabId: 101 }, "1.3");
+      expect(harness.tabsRemove).toHaveBeenCalledExactlyOnceWith(101);
+    } finally {
+      client.onClose();
+      bridge.dispose();
+    }
+  });
+
+  it("attaches only its own initial blank and supports discovery, initialization, navigation, and close", async () => {
+    const harness = await createHarness(mode);
+    expect.soft(await harness.command({ type: "createTab", url: "about:blank" })).toMatchObject({
+      type: "result",
+      result: { tabId: 101, targetId: "tab-101" },
+    });
+    expect.soft(harness.debuggerAttach).toHaveBeenCalledWith({ tabId: 101 }, "1.3");
+    expect(await harness.command({ type: "attach", tabId: 101 })).toMatchObject({ type: "result" });
+    await expect(
+      sendRuntimeMessage(harness, { type: "getTabAccess", tabId: 101 }),
+    ).resolves.toMatchObject({
+      accessible: true,
+    });
+    await vi.waitFor(() =>
+      expect(harness.frames().findLast((frame) => frame.type === "tabs")?.tabs).toEqual([
+        expect.objectContaining({ tabId: 101, url: "about:blank" }),
+      ]),
+    );
+    expect(await harness.command({ type: "attach", tabId: 100 })).toMatchObject({ type: "error" });
+    expect(await harness.command({ type: "cdp", tabId: 101, method: "Page.enable" })).toMatchObject(
+      { type: "result" },
+    );
+    expect(
+      await harness.command({
+        type: "cdp",
+        tabId: 101,
+        method: "Page.navigate",
+        params: { url: "https://example.com/" },
+      }),
+    ).toMatchObject({ type: "result" });
+    harness.updateTab(101, { pendingUrl: "https://example.com/" });
+    expect(
+      await harness.command({ type: "cdp", tabId: 101, method: "Runtime.evaluate" }),
+    ).toMatchObject({ type: "result" });
+    harness.updateTab(101, { url: "https://example.com/", pendingUrl: undefined });
+    harness.debuggerEventListener?.({ tabId: 101 }, "Page.frameNavigated", {
+      frame: { url: "https://example.com/" },
+    });
+    harness.debuggerEventListener?.({ tabId: 101 }, "Page.lifecycleEvent", { name: "load" });
+    expect(
+      harness
+        .frames()
+        .filter((frame) => frame.type === "cdpEvent")
+        .map((frame) => frame.method),
+    ).toEqual(["Page.frameNavigated", "Page.lifecycleEvent"]);
+    expect(await harness.command({ type: "closeTab", tabId: 101 })).toMatchObject({
+      type: "result",
+    });
+    expect(harness.tabsRemove).toHaveBeenCalledExactlyOnceWith(101);
+    expect(await harness.tabsQuery()).toEqual([expect.objectContaining({ id: 100 })]);
+  });
+
+  it.each(["group", "name", "attach", "target lookup", "focus"])(
+    "rolls back failed %s without closing an unrelated blank",
+    async (stage) => {
+      const harness = await createHarness(mode);
+      const failure = new Error(`${stage} failed`);
+      if (stage === "group") {
+        harness.tabsGroup.mockRejectedValueOnce(failure);
+      }
+      if (stage === "name") {
+        harness.tabGroupsUpdate.mockRejectedValueOnce(failure);
+      }
+      if (stage === "attach") {
+        harness.debuggerAttach.mockRejectedValueOnce(failure);
+      }
+      if (stage === "target lookup") {
+        harness.debuggerGetTargets.mockRejectedValueOnce(failure);
+      }
+      if (stage === "focus") {
+        harness.windowsUpdate.mockRejectedValueOnce(failure);
+      }
+      expect(
+        await harness.command({ type: "createTab", url: "about:blank", focus: true }),
+      ).toMatchObject({
+        type: "error",
+        message: failure.message,
+      });
+      expect(harness.tabsRemove).toHaveBeenCalledExactlyOnceWith(101);
+      expect(await harness.tabsQuery()).toEqual([expect.objectContaining({ id: 100 })]);
+    },
+  );
+
+  it.each([
+    { url: "about:blank#manual" },
+    { url: "about:settings" },
+    { url: "chrome://settings" },
+    { url: "chrome-extension://example/popup.html" },
+    { url: "file:///tmp/private.html" },
+    { pendingUrl: "chrome://settings" },
+    { pendingUrl: "about:blank#other" },
+    { pendingUrl: "file:///tmp/private.html" },
+    { incognito: true },
+  ])("does not grant initial ownership over a restricted created tab: %j", async (properties) => {
+    const harness = await createHarness(mode);
+    const create = harness.tabsCreate.getMockImplementation()!;
+    harness.tabsCreate.mockImplementation(async (params) =>
+      Object.assign(await create(params), properties),
+    );
+    expect(await harness.command({ type: "createTab", url: "about:blank" })).toMatchObject({
+      type: "error",
+    });
+    expect(harness.debuggerAttach).not.toHaveBeenCalled();
+    expect(await harness.command({ type: "attach", tabId: 100 })).toMatchObject({ type: "error" });
+  });
+
+  it("retires initial-document provenance on navigation and does not regain it on return to blank", async () => {
+    const harness = await createHarness(mode);
+    await harness.command({ type: "createTab", url: "about:blank" });
+    harness.updateTab(101, { url: "https://example.com/" });
+    expect(
+      await harness.command({ type: "cdp", tabId: 101, method: "Runtime.evaluate" }),
+    ).toMatchObject({ type: "result" });
+    harness.updateTab(101, { url: "about:blank" });
+    expect(await harness.command({ type: "attach", tabId: 101 })).toMatchObject({ type: "error" });
+    expect(await harness.command({ type: "closeTab", tabId: 101 })).toMatchObject({
+      type: "error",
+    });
+    expect(harness.tabsRemove).not.toHaveBeenCalled();
+  });
+
+  it("fences commands and events immediately on a restricted pending destination", async () => {
+    const harness = await createHarness(mode);
+    await harness.command({ type: "createTab", url: "about:blank" });
+    const commandResult = deferred<Record<string, never>>({});
+    harness.debuggerSendCommand.mockImplementationOnce(async () => await commandResult.promise);
+    const executing = harness.command({ type: "cdp", tabId: 101, method: "Runtime.evaluate" });
+    await vi.waitFor(() => expect(harness.debuggerSendCommand).toHaveBeenCalled());
+    harness.updateTab(101, { pendingUrl: "chrome://settings" });
+    harness.debuggerEventListener?.({ tabId: 101 }, "Runtime.consoleAPICalled", {});
+    expect(harness.frames().some((frame) => frame.type === "cdpEvent")).toBe(false);
+    commandResult.resolve({});
+    expect(await executing).toMatchObject({ type: "error" });
+    expect(await harness.command({ type: "attach", tabId: 101 })).toMatchObject({ type: "error" });
+  });
+
+  it("finishes bootstrap when Chrome commits the original pending blank after handoff", async () => {
+    const harness = await createHarness(mode);
+    const create = harness.tabsCreate.getMockImplementation()!;
+    harness.tabsCreate.mockImplementation(async (params) =>
+      Object.assign(await create(params), { url: "", pendingUrl: "about:blank" }),
+    );
+    expect(await harness.command({ type: "createTab", url: "about:blank" })).toMatchObject({
+      type: "result",
+    });
+    const initialized = deferred<Record<string, never>>({});
+    harness.debuggerSendCommand.mockImplementationOnce(async () => await initialized.promise);
+    const initializing = harness.command({ type: "cdp", tabId: 101, method: "Page.enable" });
+    await vi.waitFor(() => expect(harness.debuggerSendCommand).toHaveBeenCalled());
+    harness.updateTab(101, { url: "about:blank", pendingUrl: undefined });
+    initialized.resolve();
+    expect(await initializing).toMatchObject({ type: "result" });
+    expect(await harness.command({ type: "closeTab", tabId: 101 })).toMatchObject({
+      type: "result",
+    });
+  });
+
+  it.each(["attach", "target lookup", "focus"])(
+    "does not publish or detach an owned target while %s is pending",
+    async (stage) => {
+      const harness = await createHarness(mode);
+      const attaching = deferred(undefined);
+      harness.debuggerGetTargets.mockClear();
+      if (stage === "attach") {
+        harness.debuggerAttach.mockImplementationOnce(async () => await attaching.promise);
+      }
+      if (stage === "target lookup") {
+        harness.debuggerGetTargets.mockImplementationOnce(async () => {
+          await attaching.promise;
+          return [];
+        });
+      }
+      if (stage === "focus") {
+        harness.windowsUpdate.mockImplementationOnce(async () => await attaching.promise);
+      }
+      const creating = harness.command({ type: "createTab", url: "about:blank", focus: true });
+      await vi.waitFor(() =>
+        expect(
+          stage === "focus"
+            ? harness.windowsUpdate
+            : stage === "target lookup"
+              ? harness.debuggerGetTargets
+              : harness.debuggerAttach,
+        ).toHaveBeenCalled(),
+      );
+      harness.updateTab(101, { url: "about:blank" });
+      await vi.waitFor(() =>
+        expect(harness.frames().findLast((frame) => frame.type === "tabs")?.tabs).toEqual([]),
+      );
+      expect(harness.debuggerDetach).not.toHaveBeenCalled();
+      attaching.resolve();
+      expect(await creating).toMatchObject({ type: "result" });
+    },
+  );
+
+  it("does not recapture creation authority from a late self-group event after revocation", async () => {
+    const harness = await createHarness(mode);
+    const naming = deferred(undefined);
+    harness.tabGroupsUpdate.mockImplementationOnce(async () => await naming.promise);
+    const creating = harness.command({ type: "createTab", url: "about:blank" });
+    await vi.waitFor(() => expect(harness.tabGroupsUpdate).toHaveBeenCalled());
+    await sendRuntimeMessage(harness, {
+      type: "toggleTabAccess",
+      tabId: 101,
+      accessMode: mode,
+      grant: false,
+    });
+    harness.tabGroupUpdatedListener?.({ id: 7, title: "OpenClaw" });
+    naming.resolve();
+    expect(await creating).toMatchObject({ type: "error" });
+    expect(harness.debuggerAttach).not.toHaveBeenCalled();
+    expect(harness.tabsRemove).not.toHaveBeenCalled();
+  });
+
+  it("accepts its own group naming event after the Chrome API callback during attachment", async () => {
+    const harness = await createHarness(mode);
+    harness.tabGroupsUpdate.mockResolvedValueOnce(undefined);
+    const attaching = deferred(undefined);
+    harness.debuggerAttach.mockImplementationOnce(async () => await attaching.promise);
+    const creating = harness.command({ type: "createTab", url: "about:blank" });
+    await vi.waitFor(() => expect(harness.debuggerAttach).toHaveBeenCalled());
+    harness.tabGroupUpdatedListener?.({ id: 7, title: "OpenClaw" });
+    attaching.resolve();
+    expect(await creating).toMatchObject({ type: "result" });
+    expect(harness.tabsRemove).not.toHaveBeenCalled();
+  });
+
+  it("keeps Pause/Allow or selected-group regrant coherent for the same initial document", async () => {
+    const harness = await createHarness(mode);
+    await harness.command({ type: "createTab", url: "about:blank" });
+    for (const grant of [false, true]) {
+      await expect(
+        sendRuntimeMessage(harness, {
+          type: "toggleTabAccess",
+          tabId: 101,
+          accessMode: mode,
+          grant,
+        }),
+      ).resolves.toMatchObject({ ok: true, accessible: grant });
+      expect(await harness.command({ type: "attach", tabId: 101 })).toMatchObject({
+        type: grant ? "result" : "error",
+      });
+    }
+  });
+
+  it.each(["pause", "cancel", "group", "mode", "replacement", "removal", "navigation"])(
+    "fences an in-flight creation after %s without rolling back a taken-over tab",
+    async (revocation) => {
+      const harness = await createHarness(mode);
+      const attaching = deferred(undefined);
+      harness.debuggerAttach.mockImplementationOnce(async () => await attaching.promise);
+      const creating = harness.command({ type: "createTab", url: "about:blank" });
+      await vi.waitFor(() => expect(harness.debuggerAttach).toHaveBeenCalled());
+      let mutation: Promise<unknown> | undefined;
+      switch (revocation) {
+        case "pause":
+          mutation = sendRuntimeMessage(harness, {
+            type: "toggleTabAccess",
+            tabId: 101,
+            accessMode: mode,
+            grant: false,
+          });
+          await vi.waitFor(async () =>
+            expect(
+              await sendRuntimeMessage(harness, { type: "getTabAccess", tabId: 101 }),
+            ).toMatchObject({ accessible: false }),
+          );
+          break;
+        case "cancel":
+          harness.debuggerDetachListener?.({ tabId: 101 }, "canceled_by_user");
+          break;
+        case "group":
+          harness.updateTab(101, { groupId: -1 });
+          break;
+        case "mode":
+          mutation = sendRuntimeMessage(harness, {
+            type: "setAccessMode",
+            accessMode: mode === "all" ? "selected" : "all",
+          });
+          await vi.waitFor(() =>
+            expect(harness.storageSet).toHaveBeenCalledWith({
+              accessMode: mode === "all" ? "selected" : "all",
+            }),
+          );
+          break;
+        case "replacement":
+          harness.tabsReplacedListener(102, 101);
+          harness.updateTab(102, { url: "about:blank", groupId: 7 });
+          break;
+        case "removal":
+          harness.tabsRemovedListener?.(101);
+          // Simulate a copied/reused id after the authoritative removal event.
+          harness.updateTab(101, { url: "about:blank", groupId: 7 });
+          break;
+        case "navigation":
+          harness.updateTab(101, { url: "https://example.com/user-takeover" });
+          break;
+      }
+      attaching.resolve();
+      expect(await creating).toMatchObject({ type: "error" });
+      await mutation;
+      expect(harness.tabsRemove).not.toHaveBeenCalled();
+      expect(harness.debuggerDetach).toHaveBeenCalledWith({ tabId: 101 });
+      if (revocation === "replacement") {
+        expect(await harness.command({ type: "attach", tabId: 102 })).toMatchObject({
+          type: "error",
+        });
+      }
+    },
+  );
+
+  it.each(["unpair", "connection replacement"])(
+    "does not deliver a late creation through %s",
+    async (revocation) => {
+      const harness = await createHarness(mode);
+      const attaching = deferred(undefined);
+      harness.debuggerAttach.mockImplementationOnce(async () => await attaching.promise);
+      harness.socket.receive({ type: "createTab", seq: 70, url: "about:blank" });
+      await vi.waitFor(() => expect(harness.debuggerAttach).toHaveBeenCalled());
+      const mutation = sendRuntimeMessage(
+        harness,
+        revocation === "unpair"
+          ? { type: "unpair" }
+          : {
+              type: "pair",
+              accessMode: mode,
+              pairingString: `ws://127.0.0.1:18798/extension#${REPLACEMENT_TEST_RELAY_KEY}`,
+            },
+      );
+      await vi.waitFor(() => expect(harness.socket.close).toHaveBeenCalled());
+      attaching.resolve();
+      await expect(mutation).resolves.toMatchObject({ ok: true });
+      if (revocation === "connection replacement") {
+        const replacement = harness.relaySockets.at(-1)!;
+        await harness.authenticate(replacement);
+        expect(
+          replacement.send.mock.calls
+            .map(([raw]) => JSON.parse(raw))
+            .some((frame) => frame.seq === 70),
+        ).toBe(false);
+      }
+      expect(harness.frames().some((frame) => frame.seq === 70 && frame.type === "result")).toBe(
+        false,
+      );
+    },
+  );
+
+  it("does not restore initial provenance from group snapshots after worker restart", async () => {
+    const harness = await createHarness(mode);
+    await harness.command({ type: "createTab", url: "about:blank" });
+    const initialTabs = await harness.tabsQuery();
+    await cleanupBackgroundHarnesses();
+    vi.resetModules();
+    const restarted = await loadBackground({
+      storedConfig: {
+        ...harness.storageValues,
+        relayUrl: "ws://127.0.0.1:18797/extension",
+        token: TEST_RELAY_KEY,
+        authVersion: 2,
+        accessMode: mode,
+      },
+      initialTabs,
+    });
+    await expect(
+      sendRuntimeMessage(restarted, { type: "getTabAccess", tabId: 101 }),
+    ).resolves.toMatchObject({ accessible: false, eligible: false });
+  });
+
+  it("preserves the original failure and reports failed rollback", async () => {
+    const harness = await createHarness(mode);
+    harness.tabsGroup.mockRejectedValueOnce(new Error("group failed"));
+    harness.tabsRemove.mockRejectedValueOnce(new Error("remove failed"));
+    const warning = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      expect(await harness.command({ type: "createTab", url: "about:blank" })).toMatchObject({
+        type: "error",
+        message: "group failed; cleanup failed for created tab 101; close it manually.",
+      });
+      expect(warning).toHaveBeenCalledWith(
+        "Cleanup failed for created tab 101; close it manually.",
+      );
+    } finally {
+      warning.mockRestore();
+    }
+  });
+});

--- a/extensions/browser/chrome-extension/background.js
+++ b/extensions/browser/chrome-extension/background.js
@@ -15,12 +15,11 @@ import { openAuthenticatedRelaySocket } from "./modules/relay-connection.js";
 // in all-tabs mode.
 import {
   ACCESS_MODE_SELECTED,
-  OPENCLAW_TAB_GROUP_TITLE,
   createPairingConfigStore,
   reconnectDelayMs,
   toRelayTabInfo,
 } from "./modules/relay-core.js";
-import { findOpenClawGroups, isTabSelected } from "./modules/relay-tab-groups.js";
+import { isTabSelected } from "./modules/relay-tab-groups.js";
 import { registerTabAccessEvents } from "./modules/tab-access-events.js";
 import { createTabAccessPolicy } from "./modules/tab-access.js";
 
@@ -59,7 +58,10 @@ const attachingTabs = new Map();
 let tabsSyncTimer = null;
 let accessMutationChain = Promise.resolve();
 const pairingConfigStore = createPairingConfigStore(chrome.storage.local);
-const tabAccessPolicy = createTabAccessPolicy({ isSelectedTab: isTabSelected });
+const tabAccessPolicy = createTabAccessPolicy({
+  isSelectedTab: isTabSelected,
+  getGroupColor: async () => (await getConfig()).groupColor,
+});
 const tabAccessReady = (async () => {
   const retiredState = await prepareRetiredCopilotState();
   retiredCopilotCustodyBlocked = retiredState.blocked;
@@ -149,22 +151,6 @@ function runAccessMutation(task) {
 // Tab group management (selected-mode ACL; all-mode ownership marker)
 // ---------------------------------------------------------------------------
 
-async function addTabToOpenClawGroup(tabId) {
-  const tab = await chrome.tabs.get(tabId);
-  const groups = await findOpenClawGroups();
-  const sameWindowGroup = groups.find((group) => group.windowId === tab.windowId);
-  if (sameWindowGroup) {
-    await chrome.tabs.group({ tabIds: [tabId], groupId: sameWindowGroup.id });
-    return;
-  }
-  const { groupColor } = await getConfig();
-  const groupId = await chrome.tabs.group({ tabIds: [tabId] });
-  await chrome.tabGroups.update(groupId, {
-    title: OPENCLAW_TAB_GROUP_TITLE,
-    color: groupColor,
-  });
-}
-
 async function focusWindowForTab(tab) {
   if (typeof tab.windowId === "number") {
     await chrome.windows.update(tab.windowId, { focused: true });
@@ -193,28 +179,37 @@ async function syncTabsToRelay() {
   if (retiredCopilotCustodyBlocked) {
     return;
   }
-  if (!relayWs || relayWs.readyState !== WebSocket.OPEN || relayAuthenticatedSocket !== relayWs) {
+  const socket = relayWs;
+  if (!socket || socket.readyState !== WebSocket.OPEN || relayAuthenticatedSocket !== socket) {
     return;
   }
   const accessible = await tabAccessPolicy.listAccessibleTabs();
+  if (relayWs !== socket || relayAuthenticatedSocket !== socket) {
+    return;
+  }
   const accessibleIds = new Set(accessible.map((tab) => tab.id));
   for (const tabId of attachedTabs) {
     if (!accessibleIds.has(tabId)) {
       void detachDebugger(tabId);
     }
   }
-  send({ type: "tabs", tabs: accessible.map(toRelayTabInfo) });
+  // A creation is authorized internally, but discovery must wait for handoff.
+  const tabs = accessible.filter((tab) => tabAccessPolicy.canPublishTab(tab.id));
+  send({ type: "tabs", tabs: tabs.map(toRelayTabInfo) }, socket);
 }
 
 // ---------------------------------------------------------------------------
 // chrome.debugger transport
 // ---------------------------------------------------------------------------
 
-async function attachDebugger(tabId) {
+async function attachDebugger(tabId, assertCurrent, creationEpoch) {
   await requireAutomationAllowed();
-  const accessEpoch = tabAccessPolicy.capture(tabId);
+  assertCurrent();
+  const accessEpoch = creationEpoch ?? tabAccessPolicy.capture(tabId);
   const assertAccess = async () => {
+    assertCurrent();
     await tabAccessPolicy.requireTab(tabId, accessEpoch);
+    assertCurrent();
   };
   await assertAccess();
   // Coalesce concurrent attaches for one tab. Two relay attach commands (or an
@@ -371,14 +366,15 @@ async function pauseTab(tabId) {
 // Relay connection
 // ---------------------------------------------------------------------------
 
-function send(message) {
+function send(message, socket = relayWs) {
   if (
     !retiredCopilotCustodyBlocked &&
-    relayWs &&
-    relayWs.readyState === WebSocket.OPEN &&
-    relayAuthenticatedSocket === relayWs
+    socket &&
+    relayWs === socket &&
+    socket.readyState === WebSocket.OPEN &&
+    relayAuthenticatedSocket === socket
   ) {
-    relayWs.send(JSON.stringify(message));
+    socket.send(JSON.stringify(message));
   }
 }
 
@@ -417,23 +413,26 @@ const handleRelayCommand = createRelayCommandHandler({
   send,
   attachDebugger,
   detachDebugger,
-  addTabToOpenClawGroup,
+  createTab: (message, operation) => tabAccessPolicy.createTab(message, operation),
   focusWindowForTab,
   scheduleTabsSync,
-  captureAccess: (tabId) => tabAccessPolicy.capture(tabId),
+  captureAccess: (tabId, method) => tabAccessPolicy.capture(tabId, method),
   requireAccessibleTab: (tabId, epoch) => tabAccessPolicy.requireTab(tabId, epoch),
 });
 
-async function sendHello() {
+async function sendHello(socket) {
   const accessible = await tabAccessPolicy.listAccessibleTabs();
   const uaMatch = /Chrom(?:e|ium)\/[\d.]+/.exec(navigator.userAgent);
-  send({
-    type: "hello",
-    userAgent: navigator.userAgent,
-    browserVersion: uaMatch ? uaMatch[0] : "Chrome/unknown",
-    extensionVersion: chrome.runtime.getManifest().version,
-    tabs: accessible.map(toRelayTabInfo),
-  });
+  send(
+    {
+      type: "hello",
+      userAgent: navigator.userAgent,
+      browserVersion: uaMatch ? uaMatch[0] : "Chrome/unknown",
+      extensionVersion: chrome.runtime.getManifest().version,
+      tabs: accessible.filter((tab) => tabAccessPolicy.canPublishTab(tab.id)).map(toRelayTabInfo),
+    },
+    socket,
+  );
 }
 
 async function connectRelay(isConnectionAllowed = () => true) {
@@ -486,10 +485,17 @@ async function connectRelay(isConnectionAllowed = () => true) {
         clearRelayOpeningDeadline();
         reconnectAttempt = 0;
         setBadge("on");
-        await sendHello();
+        await sendHello(socket);
       },
       onApplicationMessage: (socket, msg) => {
-        void handleRelayCommand(msg);
+        void handleRelayCommand(
+          msg,
+          () =>
+            relayWs === socket &&
+            relayAuthenticatedSocket === socket &&
+            socket.readyState === WebSocket.OPEN &&
+            connectionIsCurrent(),
+        );
       },
       onAuthenticationFailure: (socket, error) => failRelayAuthentication(socket, error),
       onClose: (socket, authenticated) => {
@@ -619,7 +625,7 @@ const handlePopupMessage = createPopupMessageHandler({
   attachingTabs,
   detachDebugger,
   removeTabFromOpenClawGroup,
-  addTabToOpenClawGroup,
+  addTabToOpenClawGroup: (tabId) => tabAccessPolicy.addTabToGroup(tabId),
   scheduleTabsSync,
   pauseTab,
 });

--- a/extensions/browser/chrome-extension/background.navigation.test.ts
+++ b/extensions/browser/chrome-extension/background.navigation.test.ts
@@ -1,0 +1,246 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  cleanupBackgroundHarnesses,
+  loadRelayCommandHarness as createHarness,
+  sendRuntimeMessage,
+  REPLACEMENT_TEST_RELAY_KEY,
+} from "./background.test-harness.js";
+
+const releases = new Set<() => void>();
+function deferred<T>(value: T) {
+  let resolve = (_value: T) => {};
+  const promise = new Promise<T>((done) => {
+    resolve = done;
+  });
+  const release = () => {
+    releases.delete(release);
+    resolve(value);
+  };
+  releases.add(release);
+  return { promise, resolve: release };
+}
+beforeEach(() => vi.resetModules());
+afterEach(async () => {
+  for (const release of releases) {
+    release();
+  }
+  await cleanupBackgroundHarnesses();
+  vi.unstubAllGlobals();
+});
+
+describe.each(["all", "selected"] as const)("navigation command authority in %s mode", (mode) => {
+  it.each(
+    ["about:blank", "https://example.com/start"].flatMap((url) =>
+      ["Page.navigate", "Page.reload", "Page.navigateToHistoryEntry"].flatMap((method) =>
+        [true, false].map((commitFirst) => ({ url, method, commitFirst })),
+      ),
+    ),
+  )(
+    "completes $method from $url (commit first: $commitFirst)",
+    async ({ url, method, commitFirst }) => {
+      const harness = await createHarness(mode);
+      expect(await harness.command({ type: "createTab", url })).toMatchObject({ type: "result" });
+      const completed = deferred({ frameId: "frame-101", loaderId: "next-document" });
+      harness.debuggerSendCommand.mockImplementationOnce(async () => await completed.promise);
+      const navigating = harness.command({
+        type: "cdp",
+        tabId: 101,
+        method,
+        params: method === "Page.navigate" ? { url: "https://example.com/next" } : { entryId: 2 },
+      });
+      await vi.waitFor(() => expect(harness.debuggerSendCommand).toHaveBeenCalled());
+      const commit = () => {
+        harness.updateTab(
+          101,
+          method === "Page.reload"
+            ? { status: "loading" }
+            : { url: "https://example.com/next", pendingUrl: undefined },
+        );
+        harness.debuggerEventListener?.({ tabId: 101 }, "Page.frameNavigated", {
+          frame: { id: "frame-101" },
+        });
+        harness.debuggerEventListener?.({ tabId: 101 }, "Page.lifecycleEvent", { name: "load" });
+      };
+      if (commitFirst) {
+        commit();
+      }
+      completed.resolve();
+      expect(await navigating).toMatchObject({
+        type: "result",
+        result: { loaderId: "next-document" },
+      });
+      if (!commitFirst) {
+        commit();
+      }
+      expect(
+        await harness.command({ type: "cdp", tabId: 101, method: "Runtime.evaluate" }),
+      ).toMatchObject({ type: "result" });
+      expect(
+        harness
+          .frames()
+          .filter((f) => f.type === "cdpEvent")
+          .map((f) => f.method),
+      ).toEqual(["Page.frameNavigated", "Page.lifecycleEvent"]);
+    },
+  );
+
+  it("retires stale page data across a reload without a URL change", async () => {
+    const harness = await createHarness(mode);
+    await harness.command({ type: "createTab", url: "https://example.com/same" });
+    const completed = deferred({});
+    harness.debuggerSendCommand.mockImplementationOnce(async () => await completed.promise);
+    const reading = harness.command({ type: "cdp", tabId: 101, method: "Runtime.evaluate" });
+    await vi.waitFor(() => expect(harness.debuggerSendCommand).toHaveBeenCalled());
+    harness.updateTab(101, { status: "loading" });
+    completed.resolve();
+    expect(await reading).toMatchObject({ type: "error" });
+  });
+
+  it.each([
+    ["Page.enable", true],
+    ["Debugger.enable", true],
+    ["Emulation.setFocusEmulationEnabled", true],
+    ["Runtime.evaluate", false],
+    ["Input.dispatchMouseEvent", false],
+    ["Page.getFrameTree", false],
+    ["Page.getResourceTree", false],
+    ["Page.createIsolatedWorld", false],
+    ["Runtime.getIsolateId", false],
+    ["Storage.getStorageKey", false],
+  ] as const)("keeps %s completion scoped correctly during a commit", async (method, succeeds) => {
+    const harness = await createHarness(mode);
+    await harness.command({ type: "createTab", url: "about:blank" });
+    const completed = deferred({});
+    harness.debuggerSendCommand.mockImplementationOnce(async () => await completed.promise);
+    const executing = harness.command({ type: "cdp", tabId: 101, method });
+    await vi.waitFor(() => expect(harness.debuggerSendCommand).toHaveBeenCalled());
+    harness.updateTab(101, { url: "https://example.com/next" });
+    completed.resolve();
+    expect(await executing).toMatchObject({ type: succeeds ? "result" : "error" });
+  });
+
+  it.each([
+    "pause",
+    "cancel",
+    "group",
+    "mode",
+    "replacement",
+    "removal",
+    "restricted",
+    "pending",
+    "file",
+    "incognito",
+  ])(
+    "rejects navigation completion after %s even if an ordinary document returns",
+    async (revocation) => {
+      const harness = await createHarness(mode);
+      await harness.command({ type: "createTab", url: "about:blank" });
+      const completed = deferred({});
+      harness.debuggerSendCommand.mockImplementationOnce(async () => await completed.promise);
+      const navigating = harness.command({
+        type: "cdp",
+        tabId: 101,
+        method: "Page.navigate",
+        params: { url: "https://example.com/next" },
+      });
+      await vi.waitFor(() => expect(harness.debuggerSendCommand).toHaveBeenCalled());
+      harness.updateTab(101, { url: "https://example.com/next" });
+      switch (revocation) {
+        case "pause":
+          await sendRuntimeMessage(harness, {
+            type: "toggleTabAccess",
+            tabId: 101,
+            accessMode: mode,
+            grant: false,
+          });
+          break;
+        case "cancel":
+          harness.debuggerDetachListener?.({ tabId: 101 }, "canceled_by_user");
+          break;
+        case "group":
+          if (mode === "all") {
+            await sendRuntimeMessage(harness, { type: "setAccessMode", accessMode: "selected" });
+          }
+          harness.updateTab(101, { groupId: -1 });
+          break;
+        case "mode":
+          await sendRuntimeMessage(harness, {
+            type: "setAccessMode",
+            accessMode: mode === "all" ? "selected" : "all",
+          });
+          break;
+        case "replacement":
+          harness.tabsReplacedListener(102, 101);
+          break;
+        case "removal":
+          harness.tabsRemovedListener?.(101);
+          break;
+        case "restricted":
+          harness.updateTab(101, { url: "chrome://settings" });
+          break;
+        case "pending":
+          harness.updateTab(101, { pendingUrl: "chrome://settings" });
+          break;
+        case "file":
+          harness.updateTab(101, { url: "file:///tmp/private.html" });
+          break;
+        case "incognito":
+          harness.updateTab(101, { incognito: true, url: "https://example.com/private" });
+          break;
+      }
+      harness.updateTab(101, {
+        url: "https://example.com/returned",
+        pendingUrl: undefined,
+        incognito: false,
+      });
+      completed.resolve();
+      expect(await navigating).toMatchObject({ type: "error" });
+      expect(harness.tabsRemove).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each(["unpair", "replacement"])(
+    "never replies to a navigation through socket %s",
+    async (revocation) => {
+      const harness = await createHarness(mode);
+      await harness.command({ type: "createTab", url: "about:blank" });
+      const completed = deferred({});
+      let returned = false;
+      harness.debuggerSendCommand.mockImplementationOnce(async () => {
+        await completed.promise;
+        returned = true;
+        return {};
+      });
+      harness.socket.receive({
+        type: "cdp",
+        seq: 70,
+        tabId: 101,
+        method: "Page.navigate",
+        params: { url: "https://example.com/next" },
+      });
+      await vi.waitFor(() => expect(harness.debuggerSendCommand).toHaveBeenCalled());
+      const mutation = sendRuntimeMessage(
+        harness,
+        revocation === "unpair"
+          ? { type: "unpair" }
+          : {
+              type: "pair",
+              accessMode: mode,
+              pairingString: `ws://127.0.0.1:18798/extension#${REPLACEMENT_TEST_RELAY_KEY}`,
+            },
+      );
+      await vi.waitFor(() => expect(harness.socket.close).toHaveBeenCalled());
+      completed.resolve();
+      await mutation;
+      await vi.waitFor(() => expect(returned).toBe(true));
+      if (revocation === "replacement") {
+        const socket = harness.relaySockets.at(-1)!;
+        await harness.authenticate(socket);
+        expect(
+          socket.send.mock.calls.map(([raw]) => JSON.parse(raw)).some((f) => f.seq === 70),
+        ).toBe(false);
+      }
+      expect(harness.frames().some((f) => f.seq === 70)).toBe(false);
+    },
+  );
+});

--- a/extensions/browser/chrome-extension/background.test-harness.ts
+++ b/extensions/browser/chrome-extension/background.test-harness.ts
@@ -8,6 +8,7 @@ import {
 } from "./background.test-support.js";
 import type { RuntimeMessageListener } from "./background.test-support.js";
 import { computeRelayAuthProof } from "./modules/relay-auth-v2-crypto.js";
+import type { BrowserTabSnapshot } from "./modules/tab-eligibility.js";
 import { relayTestKey } from "./relay-key.test-support.js";
 
 export const TEST_RELAY_KEY = relayTestKey(1);
@@ -42,6 +43,8 @@ export async function loadBackground({
   sessionConfig,
   storedConfig,
   initialTabs = [],
+  emitTabEvents = false,
+  fileAccessAllowed = false,
 }: {
   deferTabAccessInitialization?: boolean;
   deferRetiredStatePreparation?: boolean;
@@ -54,6 +57,8 @@ export async function loadBackground({
   sessionConfig?: Record<string, unknown>;
   storedConfig?: Record<string, unknown>;
   initialTabs?: Array<Record<string, unknown> & { id: number }>;
+  emitTabEvents?: boolean;
+  fileAccessAllowed?: boolean;
 } = {}) {
   const sockets: FakeWebSocket[] = [];
   let alarmListener: ((alarm: { name: string }) => void) | undefined;
@@ -68,9 +73,15 @@ export async function loadBackground({
     | undefined;
   let tabsRemovedListener: ((tabId: number) => void) | undefined;
   let tabsReplacedListener: ((addedTabId: number, removedTabId: number) => void) | undefined;
-  let tabGroupUpdatedListener: (() => void) | undefined;
+  let tabGroupUpdatedListener: ((group?: { id: number; title?: string }) => void) | undefined;
   let tabGroupRemovedListener: (() => void) | undefined;
-  let tabsUpdatedListener: ((tabId: number, changeInfo: { groupId?: number }) => void) | undefined;
+  let tabsUpdatedListener:
+    | ((
+        tabId: number,
+        changeInfo: { groupId?: number; url?: string; status?: string },
+        tab?: BrowserTabSnapshot,
+      ) => void)
+    | undefined;
   let nextStorageGet: Promise<void> | null = null;
   let nextStorageRemove: Promise<void> | null = null;
   let nextStorageSet: Promise<void> | null = null;
@@ -174,6 +185,7 @@ export async function loadBackground({
   });
   let runtimeLastError: { message?: string } | undefined;
   const chromeMock = {
+    extension: { isAllowedFileSchemeAccess: vi.fn(async () => fileAccessAllowed) },
     action: { setBadgeText, setBadgeBackgroundColor },
     alarms: {
       create: createAlarm,
@@ -316,9 +328,13 @@ export async function loadBackground({
         title: groupId === 7 ? "OpenClaw" : "Other",
         windowId: 1,
       })),
-      update: vi.fn(async () => undefined),
+      update: vi.fn(async (id: number, properties: { title: string; color?: string }) => {
+        if (emitTabEvents) {
+          tabGroupUpdatedListener?.({ id, ...properties });
+        }
+      }),
       onUpdated: {
-        addListener: vi.fn((listener: () => void) => {
+        addListener: vi.fn((listener: typeof tabGroupUpdatedListener) => {
           tabGroupUpdatedListener = listener;
         }),
       },
@@ -346,6 +362,13 @@ export async function loadBackground({
       group: vi.fn(async ({ tabIds }: { tabIds: number[] }) => {
         for (const tabId of tabIds) {
           sharedTabIds.add(tabId);
+          if (emitTabEvents) {
+            tabsUpdatedListener?.(
+              tabId,
+              { groupId: 7 },
+              { ...tabsById.get(tabId), id: tabId, groupId: 7 },
+            );
+          }
         }
         return 7;
       }),
@@ -362,6 +385,9 @@ export async function loadBackground({
       }),
       remove: vi.fn(async (tabId: number) => {
         tabsById.delete(tabId);
+        if (emitTabEvents) {
+          tabsRemovedListener?.(tabId);
+        }
       }),
       update: vi.fn(async () => undefined),
       onRemoved: {
@@ -375,11 +401,9 @@ export async function loadBackground({
         }),
       },
       onUpdated: {
-        addListener: vi.fn(
-          (listener: (tabId: number, changeInfo: { groupId?: number }) => void) => {
-            tabsUpdatedListener = listener;
-          },
-        ),
+        addListener: vi.fn((listener: typeof tabsUpdatedListener) => {
+          tabsUpdatedListener = listener;
+        }),
       },
     },
     windows: { update: vi.fn(async () => undefined) },
@@ -556,6 +580,7 @@ export async function loadBackground({
     shareTab: (tabId: number) => sharedTabIds.add(tabId),
     unshareTab: (tabId: number) => sharedTabIds.delete(tabId),
     tabGroupsQuery: chromeMock.tabGroups.query,
+    tabGroupsUpdate: chromeMock.tabGroups.update,
     tabGroupUpdatedListener,
     tabGroupRemovedListener,
     tabsCreate: chromeMock.tabs.create,
@@ -569,6 +594,18 @@ export async function loadBackground({
     tabsRemovedListener,
     tabsReplacedListener,
     windowsUpdate: chromeMock.windows.update,
+    updateTab: (tabId: number, change: Partial<BrowserTabSnapshot>) => {
+      const tab = { ...tabsById.get(tabId), ...change, id: tabId };
+      tabsById.set(tabId, tab);
+      if (typeof change.groupId === "number") {
+        if (change.groupId === 7) {
+          sharedTabIds.add(tabId);
+        } else {
+          sharedTabIds.delete(tabId);
+        }
+      }
+      tabsUpdatedListener?.(tabId, change, { ...tab, groupId: sharedTabIds.has(tabId) ? 7 : -1 });
+    },
   };
 }
 
@@ -581,4 +618,31 @@ export async function sendRuntimeMessage(
       resolve(response as Record<string, unknown>);
     });
   });
+}
+
+export async function loadRelayCommandHarness(accessMode: "all" | "selected") {
+  const harness = await loadBackground({
+    emitTabEvents: true,
+    storedConfig: {
+      relayUrl: "ws://127.0.0.1:18797/extension",
+      token: TEST_RELAY_KEY,
+      authVersion: 2,
+      accessMode,
+    },
+    initialTabs: [{ id: 100, url: "about:blank", groupId: 7 }],
+  });
+  const socket = harness.relaySockets[0]!;
+  await harness.authenticate(socket);
+  let seq = 0;
+  const frames = () => socket.send.mock.calls.map(([raw]) => JSON.parse(raw));
+  const command = async (message: Record<string, unknown>) => {
+    const id = ++seq;
+    socket.receive({ ...message, seq: id });
+    return await vi.waitFor(() => {
+      const response = frames().find((frame) => frame.seq === id);
+      expect(response).toBeDefined();
+      return response;
+    });
+  };
+  return { ...harness, socket, frames, command };
 }

--- a/extensions/browser/chrome-extension/modules/relay-command-handler.d.ts
+++ b/extensions/browser/chrome-extension/modules/relay-command-handler.d.ts
@@ -1,16 +1,16 @@
-import type { TabAccessEpoch } from "./tab-access.js";
+import type { CreatedTabOperation, TabAccessEpoch } from "./tab-access.js";
 import type { AccessibleBrowserTabSnapshot, BrowserTabSnapshot } from "./tab-eligibility.js";
 
 export function createRelayCommandHandler(params: {
   send: (message: Record<string, unknown>) => void;
-  attachDebugger: (tabId: number) => Promise<unknown>;
+  attachDebugger: CreatedTabOperation["attachDebugger"];
   detachDebugger: (tabId: number) => Promise<void>;
-  addTabToOpenClawGroup: (tabId: number) => Promise<void>;
+  createTab: (message: Record<string, unknown>, operation: CreatedTabOperation) => Promise<void>;
   focusWindowForTab: (tab: BrowserTabSnapshot) => Promise<void>;
   scheduleTabsSync: () => void;
-  captureAccess: (tabId: number) => TabAccessEpoch;
+  captureAccess: (tabId: number, method?: string) => TabAccessEpoch;
   requireAccessibleTab: (
     tabId: number,
     epoch: TabAccessEpoch,
   ) => Promise<AccessibleBrowserTabSnapshot>;
-}): (message: Record<string, unknown>) => Promise<void>;
+}): (message: Record<string, unknown>, isCurrent: () => boolean) => Promise<void>;

--- a/extensions/browser/chrome-extension/modules/relay-command-handler.js
+++ b/extensions/browser/chrome-extension/modules/relay-command-handler.js
@@ -3,29 +3,49 @@ export function createRelayCommandHandler({
   send,
   attachDebugger,
   detachDebugger,
-  addTabToOpenClawGroup,
+  createTab,
   focusWindowForTab,
   scheduleTabsSync,
   captureAccess,
   requireAccessibleTab,
 }) {
-  return async (message) => {
+  return async (message, isCurrent) => {
     const { seq } = message;
+    const assertCurrent = () => {
+      if (!isCurrent()) {
+        throw new Error("relay connection was replaced or closed");
+      }
+    };
+    const reply = (frame) => {
+      assertCurrent();
+      send(frame);
+    };
+    const requireTab = async (tabId, epoch) => {
+      assertCurrent();
+      const tab = await requireAccessibleTab(tabId, epoch);
+      assertCurrent();
+      return tab;
+    };
     try {
+      assertCurrent();
       switch (message.type) {
         case "ping":
-          send({ type: "pong" });
+          reply({ type: "pong" });
           return;
         case "attach":
-          send({ type: "result", seq, result: await attachDebugger(message.tabId) });
+          reply({
+            type: "result",
+            seq,
+            result: await attachDebugger(message.tabId, assertCurrent),
+          });
           return;
         case "detach":
           await detachDebugger(message.tabId);
-          send({ type: "result", seq, result: {} });
+          reply({ type: "result", seq, result: {} });
           return;
         case "cdp": {
-          const epoch = captureAccess(message.tabId);
-          await requireAccessibleTab(message.tabId, epoch);
+          const epoch = captureAccess(message.tabId, message.method);
+          await requireTab(message.tabId, epoch);
           const target = message.sessionId
             ? { tabId: message.tabId, sessionId: message.sessionId }
             : { tabId: message.tabId };
@@ -34,49 +54,45 @@ export function createRelayCommandHandler({
             message.method,
             message.params ?? {},
           );
-          await requireAccessibleTab(message.tabId, epoch);
-          send({ type: "result", seq, result: result ?? {} });
+          await requireTab(message.tabId, epoch);
+          reply({ type: "result", seq, result: result ?? {} });
           return;
         }
         case "createTab": {
-          const tab = await chrome.tabs.create({
-            url: message.url,
-            active: message.background !== true,
+          await createTab(message, {
+            isCurrent,
+            attachDebugger,
+            handoff: (result) => reply({ type: "result", seq, result }),
           });
-          await addTabToOpenClawGroup(tab.id);
-          if (message.focus === true) {
-            await focusWindowForTab(tab);
-          }
           scheduleTabsSync();
-          send({ type: "result", seq, result: { tabId: tab.id } });
           return;
         }
         case "closeTab": {
           const epoch = captureAccess(message.tabId);
-          await requireAccessibleTab(message.tabId, epoch);
+          await requireTab(message.tabId, epoch);
           await detachDebugger(message.tabId);
-          await requireAccessibleTab(message.tabId, epoch);
+          await requireTab(message.tabId, epoch);
           await chrome.tabs.remove(message.tabId);
-          send({ type: "result", seq, result: {} });
+          reply({ type: "result", seq, result: {} });
           return;
         }
         case "activateTab": {
           const epoch = captureAccess(message.tabId);
-          const tab = await requireAccessibleTab(message.tabId, epoch);
+          const tab = await requireTab(message.tabId, epoch);
           await chrome.tabs.update(message.tabId, { active: true });
-          await requireAccessibleTab(message.tabId, epoch);
+          await requireTab(message.tabId, epoch);
           await focusWindowForTab(tab);
-          await requireAccessibleTab(message.tabId, epoch);
-          send({ type: "result", seq, result: {} });
+          await requireTab(message.tabId, epoch);
+          reply({ type: "result", seq, result: {} });
           return;
         }
         default:
           if (typeof seq === "number") {
-            send({ type: "error", seq, message: `unknown relay command: ${message.type}` });
+            reply({ type: "error", seq, message: `unknown relay command: ${message.type}` });
           }
       }
     } catch (error) {
-      if (typeof seq === "number") {
+      if (typeof seq === "number" && isCurrent()) {
         send({
           type: "error",
           seq,

--- a/extensions/browser/chrome-extension/modules/relay-command-handler.test.ts
+++ b/extensions/browser/chrome-extension/modules/relay-command-handler.test.ts
@@ -19,13 +19,20 @@ function createHarness() {
     send,
     attachDebugger: vi.fn(),
     detachDebugger: vi.fn(async () => undefined),
-    addTabToOpenClawGroup: vi.fn(),
+    createTab: vi.fn(),
     focusWindowForTab,
     scheduleTabsSync: vi.fn(),
     captureAccess: vi.fn(() => epoch),
     requireAccessibleTab,
   });
-  return { chromeMock, epoch, focusWindowForTab, handler, requireAccessibleTab, send };
+  return {
+    chromeMock,
+    epoch,
+    focusWindowForTab,
+    handler: (message: Record<string, unknown>) => handler(message, () => true),
+    requireAccessibleTab,
+    send,
+  };
 }
 
 afterEach(() => vi.unstubAllGlobals());

--- a/extensions/browser/chrome-extension/modules/relay-tab-groups.js
+++ b/extensions/browser/chrome-extension/modules/relay-tab-groups.js
@@ -1,13 +1,5 @@
 import { OPENCLAW_TAB_GROUP_TITLE } from "./relay-core.js";
 
-export async function findOpenClawGroups() {
-  try {
-    return await chrome.tabGroups.query({ title: OPENCLAW_TAB_GROUP_TITLE });
-  } catch {
-    return [];
-  }
-}
-
 async function isOpenClawGroupId(groupId) {
   if (!Number.isInteger(groupId) || groupId < 0) {
     return false;

--- a/extensions/browser/chrome-extension/modules/tab-access-events.d.ts
+++ b/extensions/browser/chrome-extension/modules/tab-access-events.d.ts
@@ -18,13 +18,13 @@ export type TabAccessEventsChromeApi = {
     onUpdated: ChromeEvent<
       (
         tabId: number,
-        changeInfo: { groupId?: number; url?: string },
+        changeInfo: { groupId?: number; url?: string; status?: string },
         tab: BrowserTabSnapshot,
       ) => void
     >;
   };
   tabGroups: {
-    onUpdated: ChromeEvent<() => void>;
+    onUpdated: ChromeEvent<(group?: { id: number; title?: string }) => void>;
     onRemoved: ChromeEvent<() => void>;
   };
 };
@@ -36,12 +36,18 @@ export type TabAccessEventPolicy = {
   capture(tabId: number): TabAccessEpoch;
   epochIsCurrent(tabId: number, epoch: TabAccessEpoch): boolean;
   invalidateTab(tabId: number): void;
+  retireTab(tabId: number): void;
   renewTabAccess(
     tabId: number,
     attachedEpoch: TabAccessEpoch | undefined,
     tab: BrowserTabSnapshot | undefined,
   ): TabAccessEpoch | undefined;
-  invalidateAll(): void;
+  invalidateAll(group?: { id: number; title?: string }): void;
+  observeTabUpdate(
+    tabId: number,
+    change: { groupId?: number; url?: string; status?: string },
+    tab?: BrowserTabSnapshot,
+  ): boolean;
   inspectTab(tabId: number, epoch: TabAccessEpoch): Promise<{ accessible: boolean }>;
   listAccessibleTabs(): Promise<Array<{ id: number }>>;
   forgetTab(tabId: number): Promise<void>;

--- a/extensions/browser/chrome-extension/modules/tab-access-events.js
+++ b/extensions/browser/chrome-extension/modules/tab-access-events.js
@@ -62,9 +62,9 @@ export function registerTabAccessEvents({
   });
 
   chromeApi.tabs.onRemoved.addListener((tabId) => {
+    policy.retireTab(tabId);
     void (async () => {
       await accessReady;
-      policy.invalidateTab(tabId);
       attachedTabs.delete(tabId);
       attachedAccessEpochs.delete(tabId);
       scheduleTabsSync();
@@ -74,7 +74,8 @@ export function registerTabAccessEvents({
 
   chromeApi.tabs.onReplaced.addListener((addedTabId, removedTabId) => {
     const revocation = policy.beginRevocation(addedTabId);
-    policy.invalidateTab(removedTabId);
+    policy.retireTab(addedTabId);
+    policy.retireTab(removedTabId);
     attachedTabs.delete(removedTabId);
     attachedAccessEpochs.delete(removedTabId);
     scheduleTabsSync();
@@ -93,10 +94,7 @@ export function registerTabAccessEvents({
 
   chromeApi.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
     scheduleTabsSync();
-    if (
-      typeof changeInfo.url === "string" ||
-      (policy.mode === ACCESS_MODE_SELECTED && typeof changeInfo.groupId === "number")
-    ) {
+    if (policy.observeTabUpdate(tabId, changeInfo, tab)) {
       const renewed = policy.renewTabAccess(tabId, attachedAccessEpochs.get(tabId), tab);
       if (renewed && attachedTabs.has(tabId)) {
         attachedAccessEpochs.set(tabId, renewed);
@@ -126,7 +124,7 @@ export function registerTabAccessEvents({
     })();
   });
 
-  const onGroupChanged = () => {
+  const onGroupChanged = (group) => {
     const eventRevision = ++groupEventRevision;
     scheduleTabsSync();
     if (policy.mode !== ACCESS_MODE_SELECTED) {
@@ -134,7 +132,7 @@ export function registerTabAccessEvents({
     }
     // Group title/removal changes mutate the selected-mode ACL. Retire every
     // attachment epoch synchronously before any readiness or Chrome lookup.
-    policy.invalidateAll();
+    policy.invalidateAll(group);
     void accessReady.then(async () => {
       if (eventRevision !== groupEventRevision || policy.mode !== ACCESS_MODE_SELECTED) {
         return;
@@ -192,5 +190,5 @@ export function registerTabAccessEvents({
     });
   };
   chromeApi.tabGroups.onUpdated.addListener(onGroupChanged);
-  chromeApi.tabGroups.onRemoved.addListener(onGroupChanged);
+  chromeApi.tabGroups.onRemoved.addListener(() => onGroupChanged());
 }

--- a/extensions/browser/chrome-extension/modules/tab-access-events.test.ts
+++ b/extensions/browser/chrome-extension/modules/tab-access-events.test.ts
@@ -35,6 +35,14 @@ function createHarness(
   const send = vi.fn();
   const policy = {
     mode,
+    observeTabUpdate: vi.fn(
+      (_tabId: number, change: { url?: string; groupId?: number }) =>
+        typeof change.url === "string" ||
+        (mode === "selected" && typeof change.groupId === "number"),
+    ),
+    retireTab: vi.fn(() => {
+      revision += 1;
+    }),
     beginRevocation: vi.fn(() => Symbol("revocation")),
     endRevocation: vi.fn(),
     capture: vi.fn(() => ({ revision, tabRevision: 0 })),

--- a/extensions/browser/chrome-extension/modules/tab-access.d.ts
+++ b/extensions/browser/chrome-extension/modules/tab-access.d.ts
@@ -6,9 +6,22 @@ import type {
 
 export type TabAccessMode = "all" | "selected";
 
+export type CreatedTabOperation = {
+  isCurrent(): boolean;
+  attachDebugger(
+    tabId: number,
+    assertCurrent: () => void,
+    creationEpoch?: TabAccessEpoch,
+  ): Promise<{ targetId: string }>;
+  handoff(result: { tabId: number; targetId: string }): void;
+};
+
+type TabGroupSnapshot = { id: number; title?: string };
+
 export type TabAccessEpoch = Readonly<{
   revision: number;
   tabRevision: number;
+  documentRevision?: number;
 }>;
 
 export type TabAccessReason = TabEligibilityReason | "revoked" | "paused" | "not-selected" | null;
@@ -47,20 +60,32 @@ export type TabAccessPolicy = {
   endTransition(): void;
   beginRevocation(tabId: number): symbol;
   endRevocation(token: symbol): void;
-  capture(tabId: number): TabAccessEpoch;
+  capture(tabId: number, method?: string): TabAccessEpoch;
   epochIsCurrent(tabId: number, epoch: TabAccessEpoch): boolean;
   invalidateTab(tabId: number): void;
+  retireTab(tabId: number): void;
   renewTabAccess(
     tabId: number,
     attachedEpoch: TabAccessEpoch | undefined,
     tab: BrowserTabSnapshot | undefined,
   ): TabAccessEpoch | undefined;
-  invalidateAll(): void;
+  invalidateAll(group?: TabGroupSnapshot): void;
+  observeTabUpdate(
+    tabId: number,
+    change: { url?: string; groupId?: number; status?: string },
+    tab?: BrowserTabSnapshot,
+  ): boolean;
+  addTabToGroup(tabId: number): Promise<void>;
+  createTab(
+    message: { url: string; background?: boolean; focus?: boolean },
+    operation: CreatedTabOperation,
+  ): Promise<void>;
   inspectTab(tabId: number, epoch?: TabAccessEpoch): Promise<TabAccessState>;
   requireTab(tabId: number, epoch?: TabAccessEpoch): Promise<AccessibleBrowserTabSnapshot>;
   listAccessibleTabs(options?: {
     allowDuringTransition?: boolean;
   }): Promise<AccessibleBrowserTabSnapshot[]>;
+  canPublishTab(tabId: number): boolean;
   pause(tabId: number): Promise<void>;
   allow(tabId: number): Promise<void>;
   forgetTab(tabId: number): Promise<void>;
@@ -72,4 +97,5 @@ export type TabAccessPolicy = {
 export function createTabAccessPolicy(options: {
   chromeApi?: TabAccessChromeApi;
   isSelectedTab(tab: BrowserTabSnapshot): boolean | Promise<boolean>;
+  getGroupColor?(): Promise<string>;
 }): TabAccessPolicy;

--- a/extensions/browser/chrome-extension/modules/tab-access.js
+++ b/extensions/browser/chrome-extension/modules/tab-access.js
@@ -1,18 +1,54 @@
-import { ACCESS_MODE_ALL, ACCESS_MODE_SELECTED } from "./relay-core.js";
+import { ACCESS_MODE_ALL, ACCESS_MODE_SELECTED, OPENCLAW_TAB_GROUP_TITLE } from "./relay-core.js";
 import { effectiveTabUrl, tabEligibility } from "./tab-eligibility.js";
 
 const DENIED_TAB_IDS_KEY = "deniedTabIdsV1";
+// CDP navigation receipts and session configuration survive an allowed document
+// change. Page data, execution contexts, and actions still require that document.
+// These are exact protocol methods, never a caller-supplied access override.
+const TAB_SCOPED_COMMANDS = new Set([
+  "Page.navigate",
+  "Page.reload",
+  "Page.navigateToHistoryEntry",
+  "Page.enable",
+  "Page.setLifecycleEventsEnabled",
+  "Network.enable",
+  "Network.setAttachDebugStack",
+  "Runtime.enable",
+  "Runtime.runIfWaitingForDebugger",
+  "Target.setAutoAttach",
+  "Debugger.enable",
+  "Debugger.setSkipAllPauses",
+  "Debugger.setPauseOnExceptions",
+  "Debugger.setAsyncCallStackDepth",
+  "Debugger.setBlackboxPatterns",
+  "Log.enable",
+  "Log.startViolationsReport",
+  "DOM.enable",
+  "CSS.enable",
+  "Audits.enable",
+  "Performance.enable",
+  "Profiler.enable",
+  "WebMCP.enable",
+  "Emulation.setFocusEmulationEnabled",
+]);
 
 function isValidTabId(value) {
   return Number.isSafeInteger(value) && value >= 0;
+}
+
+function initialBlankDocument(tab) {
+  return tab.url === "about:blank" || (!tab.url && tab.pendingUrl === "about:blank");
 }
 
 /**
  * Owns access mode, durable browser-session pauses, and revocation epochs.
  * Every authority-bearing caller captures an epoch and checks through here.
  */
-export function createTabAccessPolicy({ chromeApi = chrome, isSelectedTab }) {
+export function createTabAccessPolicy({ chromeApi = chrome, isSelectedTab, getGroupColor }) {
   const deniedTabIds = new Set();
+  // Only createTab below mints these records. Group membership and Tab snapshots
+  // cannot recreate initial-document ownership after navigation or worker restart.
+  const createdTabs = new Map();
   const tabRevisions = new Map();
   const provenEpochs = new WeakMap();
   let fileAccessGranted = false;
@@ -42,8 +78,39 @@ export function createTabAccessPolicy({ chromeApi = chrome, isSelectedTab }) {
     }
   }
 
+  function eligibilityForTab(tab) {
+    const created = createdTabs.get(tab?.id);
+    if (created && tab.url && tab.url !== "about:blank") {
+      if (created.initialBlank && !created.handedOff) {
+        invalidateTab(tab.id);
+      }
+      created.initialBlank = false;
+      if (created.handedOff) {
+        createdTabs.delete(tab.id);
+        if (!created.isCurrent()) {
+          invalidateTab(tab.id);
+        }
+      }
+    }
+    const options = { fileAccessAllowed: fileAccessGranted };
+    const eligibility = tabEligibility(tab, options);
+    if (
+      eligibility.reason !== "restricted" ||
+      !created?.initialBlank ||
+      !created.isCurrent() ||
+      !initialBlankDocument(tab)
+    ) {
+      return eligibility;
+    }
+    // A pending ordinary destination does not replace the initial document yet.
+    // Check it independently; restricted pending URLs never inherit admission.
+    return tab.pendingUrl && tab.pendingUrl !== "about:blank"
+      ? tabEligibility({ ...tab, url: tab.pendingUrl }, options)
+      : { eligible: true, reason: null };
+  }
+
   function tabIsEligible(tab) {
-    return tabEligibility(tab, { fileAccessAllowed: fileAccessGranted }).eligible;
+    return eligibilityForTab(tab).eligible;
   }
 
   async function persistDeniedIds() {
@@ -56,12 +123,22 @@ export function createTabAccessPolicy({ chromeApi = chrome, isSelectedTab }) {
   }
 
   function invalidateTab(tabId) {
-    tabRevisions.set(tabId, (tabRevisions.get(tabId) ?? 0) + 1);
-    discoveryRevision += 1;
+    const next = ++discoveryRevision;
+    tabRevisions.set(tabId, { access: next, document: next });
   }
 
-  function capture(tabId) {
-    return { revision, tabRevision: tabRevisions.get(tabId) ?? 0 };
+  function retireTab(tabId) {
+    createdTabs.delete(tabId);
+    invalidateTab(tabId);
+  }
+
+  function capture(tabId, method) {
+    const current = tabRevisions.get(tabId);
+    return {
+      revision,
+      tabRevision: current?.access ?? 0,
+      ...(!TAB_SCOPED_COMMANDS.has(method) ? { documentRevision: current?.document ?? 0 } : {}),
+    };
   }
 
   function tabIsRevoking(tabId) {
@@ -73,14 +150,217 @@ export function createTabAccessPolicy({ chromeApi = chrome, isSelectedTab }) {
     return false;
   }
 
-  function epochIsCurrent(tabId, epoch) {
+  function epochMatches(tabId, epoch) {
     return (
       enabled &&
       !transitioning &&
       !tabIsRevoking(tabId) &&
       epoch.revision === revision &&
-      epoch.tabRevision === (tabRevisions.get(tabId) ?? 0)
+      epoch.tabRevision === (tabRevisions.get(tabId)?.access ?? 0) &&
+      (epoch.documentRevision === undefined ||
+        epoch.documentRevision === (tabRevisions.get(tabId)?.document ?? 0))
     );
+  }
+
+  function epochIsCurrent(tabId, epoch) {
+    const created = createdTabs.get(tabId);
+    return (
+      epochMatches(tabId, epoch) &&
+      (!created ||
+        (created.isCurrent() && (created.handedOff || epochMatches(tabId, created.epoch))))
+    );
+  }
+
+  function invalidateAll(group) {
+    const naming = [...createdTabs.values()].filter(
+      (created) =>
+        !created.handedOff &&
+        created.namingGroup === group?.id &&
+        group?.title === OPENCLAW_TAB_GROUP_TITLE &&
+        epochIsCurrent(created.tab.id, created.epoch),
+    );
+    revision += 1;
+    discoveryRevision += 1;
+    // Renew only the exact expected naming event of a still-current creation.
+    // An earlier pause/mode/group revocation cannot be recaptured here.
+    for (const created of naming) {
+      // Only this private creation epoch is shared with its pending attachment.
+      // Updating it also covers a naming event delivered after the API callback.
+      created.epoch.revision = revision;
+      created.namingGroup = undefined;
+    }
+  }
+
+  function observeTabUpdate(tabId, change, tab) {
+    const accessChanged =
+      typeof change.url === "string" ||
+      change.status === "loading" ||
+      (mode === ACCESS_MODE_SELECTED && typeof change.groupId === "number") ||
+      (typeof tab?.pendingUrl === "string" && !tabIsEligible(tab));
+    const created = createdTabs.get(tabId);
+    if (!created) {
+      if (mode === ACCESS_MODE_SELECTED && typeof change.groupId === "number") {
+        invalidateTab(tabId);
+      }
+      return accessChanged;
+    }
+    if (typeof change.url === "string") {
+      if (created.initialBlank && change.url === "about:blank" && tabIsEligible(tab)) {
+        // The pending initial blank can commit after handoff. This is still the
+        // creator's document; settling it must not cancel client initialization.
+        created.tab = { ...created.tab, url: tab.url, pendingUrl: tab.pendingUrl };
+        return false;
+      }
+      eligibilityForTab(tab);
+    }
+    if (!created.handedOff && typeof change.groupId === "number") {
+      if (
+        created.grouping &&
+        change.groupId >= 0 &&
+        (created.expectedGroupId === undefined || created.expectedGroupId === change.groupId) &&
+        epochIsCurrent(tabId, created.epoch) &&
+        tab?.id === tabId
+      ) {
+        created.groupId = change.groupId;
+        created.expectedGroupId = change.groupId;
+        created.grouping = false;
+        return false;
+      }
+      invalidateTab(tabId);
+    }
+    return accessChanged;
+  }
+
+  async function addTabToGroup(tabId, created) {
+    const assertCurrent = () => created?.assertCurrent();
+    const tab = await chromeApi.tabs.get(tabId);
+    assertCurrent();
+    if (created && (tab.groupId !== created.groupId || tab.windowId !== created.tab.windowId)) {
+      throw new Error(`tab ${tabId} changed during creation`);
+    }
+    const groups = await chromeApi.tabGroups
+      .query({ title: OPENCLAW_TAB_GROUP_TITLE })
+      .catch(() => []);
+    assertCurrent();
+    const group = groups.find((candidate) => candidate.windowId === tab.windowId);
+    const color = group ? undefined : await getGroupColor();
+    assertCurrent();
+    if (created) {
+      created.grouping = true;
+      created.expectedGroupId = group?.id;
+    }
+    const groupId = await chromeApi.tabs.group({
+      tabIds: [tabId],
+      ...(group ? { groupId: group.id } : {}),
+    });
+    assertCurrent();
+    if (created) {
+      if (created.expectedGroupId !== undefined && created.expectedGroupId !== groupId) {
+        throw new Error(`tab ${tabId} group changed during creation`);
+      }
+      created.groupId = groupId;
+      created.expectedGroupId = groupId;
+    }
+    if (!group) {
+      if (created) {
+        created.namingGroup = groupId;
+      }
+      await chromeApi.tabGroups.update(groupId, { title: OPENCLAW_TAB_GROUP_TITLE, color });
+      assertCurrent();
+    }
+  }
+
+  async function createTab(message, { isCurrent, attachDebugger, handoff }) {
+    const operationRevision = revision;
+    const started = discoveryRevision;
+    if (!enabled || transitioning || !isCurrent()) {
+      throw new Error("tab creation access was revoked");
+    }
+    const tab = await chromeApi.tabs.create({
+      url: message.url,
+      active: message.background !== true,
+    });
+    const created = {
+      tab,
+      // Creation owns a tab, not its first HTTP document (which may redirect).
+      epoch: { revision: operationRevision, tabRevision: tabRevisions.get(tab.id)?.access ?? 0 },
+      isCurrent,
+      initialBlank: message.url === "about:blank" && initialBlankDocument(tab),
+      handedOff: false,
+      groupId: tab.groupId,
+      grouping: false,
+      expectedGroupId: undefined,
+      namingGroup: undefined,
+      assertCurrent: () => {
+        if (createdTabs.get(tab.id) !== created || !epochIsCurrent(tab.id, created.epoch)) {
+          throw new Error(`tab ${tab.id} creation access was revoked`);
+        }
+      },
+    };
+    // A removal/replacement observed before the create callback invalidates it.
+    if (!isValidTabId(tab.id) || (tabRevisions.get(tab.id)?.access ?? 0) > started) {
+      throw new Error("created tab is no longer available");
+    }
+    createdTabs.set(tab.id, created);
+    try {
+      created.assertCurrent();
+      await addTabToGroup(tab.id, created);
+      created.assertCurrent();
+      await requireTab(tab.id, created.epoch);
+      created.assertCurrent();
+      const attached = await attachDebugger(tab.id, created.assertCurrent, created.epoch);
+      created.assertCurrent();
+      if (message.focus === true && typeof tab.windowId === "number") {
+        await chromeApi.windows.update(tab.windowId, { focused: true });
+        created.assertCurrent();
+      }
+      await requireTab(tab.id, created.epoch);
+      created.assertCurrent();
+      handoff({ tabId: tab.id, ...attached });
+      created.handedOff = true;
+    } catch (error) {
+      // Rollback belongs to the creator, before any id is handed to the relay.
+      // Never use ordinary close as a privileged bypass or close a user-revoked tab.
+      const ownsRollback = () =>
+        createdTabs.get(tab.id) === created &&
+        !deniedTabIds.has(tab.id) &&
+        epochMatches(tab.id, created.epoch);
+      try {
+        if (ownsRollback()) {
+          const current = await chromeApi.tabs.get(tab.id);
+          if (
+            ownsRollback() &&
+            current.id === tab.id &&
+            current.windowId === tab.windowId &&
+            ((created.initialBlank &&
+              initialBlankDocument(current) &&
+              (!current.pendingUrl || current.pendingUrl === "about:blank")) ||
+              (effectiveTabUrl(current) === effectiveTabUrl(created.tab) &&
+                (!current.url || current.url === effectiveTabUrl(created.tab)))) &&
+            current.groupId === created.groupId &&
+            current.incognito === tab.incognito
+          ) {
+            await chromeApi.tabs.remove(tab.id);
+          }
+        }
+      } catch {
+        console.warn(`Cleanup failed for created tab ${tab.id}; close it manually.`);
+        throw new Error(
+          `${error instanceof Error ? error.message : String(error)}; cleanup failed for created tab ${tab.id}; close it manually.`,
+          { cause: error },
+        );
+      }
+      throw error;
+    } finally {
+      if (!created.handedOff || !created.initialBlank) {
+        if (createdTabs.get(tab.id) === created) {
+          createdTabs.delete(tab.id);
+          if (!created.handedOff) {
+            invalidateTab(tab.id);
+          }
+        }
+      }
+    }
   }
 
   async function initialize(initialMode = ACCESS_MODE_SELECTED, initialEnabled = false) {
@@ -184,9 +464,17 @@ export function createTabAccessPolicy({ chromeApi = chrome, isSelectedTab }) {
       tab?.id === tabId &&
       tabIsEligible(tab) &&
       (mode === ACCESS_MODE_ALL || tab.groupId === proof.groupId);
-    // Every navigation retires in-flight commands. Only Chrome's full Tab
-    // observation can renew an already-proven attachment without losing events.
-    invalidateTab(tabId);
+    // An allowed document change retires page reads/actions, not tab authority.
+    // Only an already-proven attachment gets synchronous event renewal. Without
+    // an attachment, an eligible initial HTTP commit can precede create's callback.
+    if (!tabIsEligible(tab) || (attachedEpoch && !canRenew)) {
+      invalidateTab(tabId);
+    } else {
+      tabRevisions.set(tabId, {
+        access: tabRevisions.get(tabId)?.access ?? 0,
+        document: ++discoveryRevision,
+      });
+    }
     if (!canRenew) {
       return undefined;
     }
@@ -214,9 +502,7 @@ export function createTabAccessPolicy({ chromeApi = chrome, isSelectedTab }) {
     if (!epochIsCurrent(tabId, epoch)) {
       return { accessible: false, eligible: false, denied: false, reason: "revoked", tab };
     }
-    const eligibility = tabEligibility(tab, {
-      fileAccessAllowed: fileAccessGranted,
-    });
+    const eligibility = eligibilityForTab(tab);
     if (!eligibility.eligible) {
       return { accessible: false, eligible: false, denied: false, reason: eligibility.reason, tab };
     }
@@ -242,7 +528,8 @@ export function createTabAccessPolicy({ chromeApi = chrome, isSelectedTab }) {
       }
       if (
         current.groupId !== tab.groupId ||
-        effectiveTabUrl(current) !== effectiveTabUrl(tab) ||
+        (epoch.documentRevision !== undefined &&
+          effectiveTabUrl(current) !== effectiveTabUrl(tab)) ||
         current.incognito !== tab.incognito ||
         !currentEligible ||
         !currentSelected
@@ -354,7 +641,7 @@ export function createTabAccessPolicy({ chromeApi = chrome, isSelectedTab }) {
   }
 
   async function forgetTab(tabId) {
-    invalidateTab(tabId);
+    retireTab(tabId);
     if (!deniedTabIds.delete(tabId)) {
       return;
     }
@@ -362,8 +649,8 @@ export function createTabAccessPolicy({ chromeApi = chrome, isSelectedTab }) {
   }
 
   async function replaceTab(addedTabId, removedTabId) {
-    invalidateTab(removedTabId);
-    invalidateTab(addedTabId);
+    retireTab(removedTabId);
+    retireTab(addedTabId);
     if (!deniedTabIds.delete(removedTabId)) {
       return false;
     }
@@ -400,14 +687,16 @@ export function createTabAccessPolicy({ chromeApi = chrome, isSelectedTab }) {
     capture,
     epochIsCurrent,
     invalidateTab,
+    retireTab,
     renewTabAccess,
-    invalidateAll: () => {
-      revision += 1;
-      discoveryRevision += 1;
-    },
+    invalidateAll,
+    observeTabUpdate,
+    createTab,
+    addTabToGroup,
     inspectTab,
     requireTab,
     listAccessibleTabs,
+    canPublishTab: (tabId) => !createdTabs.has(tabId) || createdTabs.get(tabId).handedOff,
     pause,
     allow,
     forgetTab,

--- a/extensions/browser/chrome-extension/modules/tab-eligibility.d.ts
+++ b/extensions/browser/chrome-extension/modules/tab-eligibility.d.ts
@@ -2,6 +2,7 @@ export type BrowserTabSnapshot = {
   id?: number;
   url?: string;
   pendingUrl?: string;
+  status?: string;
   title?: string;
   active?: boolean;
   incognito?: boolean;

--- a/extensions/browser/src/browser/extension-relay/relay-bridge.test.ts
+++ b/extensions/browser/src/browser/extension-relay/relay-bridge.test.ts
@@ -473,6 +473,56 @@ describe("ExtensionRelayBridge", () => {
     });
   });
 
+  it.each(["active", "closed client", "replaced extension"])(
+    "binds an atomic creation reply to its current owner: %s",
+    async (lifecycle) => {
+      const bridge = new ExtensionRelayBridge();
+      try {
+        const socket = new FakeSocket();
+        const extension = bridge.attachExtensionSocket(socket);
+        sendHello(extension, []);
+        const client = new FakeSocket();
+        const cdp = bridge.attachCdpClientSocket(client);
+        cdp.onMessage(
+          JSON.stringify({ id: 1, method: "Target.createTarget", params: { url: "" } }),
+        );
+        const command = socket.frames().at(-1);
+        expect(command).toMatchObject({ type: "createTab", url: "about:blank" });
+        extension.onMessage(
+          JSON.stringify({
+            type: "result",
+            seq: command?.seq,
+            result: { tabId: 99, targetId: "created-target" },
+          }),
+        );
+        // Resolve the old promise, then replace its owner before its continuation.
+        if (lifecycle === "closed client") {
+          cdp.onClose();
+        }
+        if (lifecycle === "replaced extension") {
+          sendHello(wireExtension(bridge).handlers, []);
+        }
+        await flush();
+        expect(socket.frames().filter((frame) => frame.type === "attach")).toEqual([]);
+        if (lifecycle === "active") {
+          expect(client.frames().map((frame) => frame.method ?? frame.id)).toEqual([
+            "Target.attachedToTarget",
+            1,
+          ]);
+          expect(client.frames().at(-1)?.result).toEqual({ targetId: "created-target" });
+        } else {
+          expect(client.frames()).toEqual([]);
+          expect(bridge.accessibleTabs()).toEqual([]);
+          expect(socket.frames().filter((frame) => frame.type === "detach")).toEqual(
+            lifecycle === "closed client" ? [expect.objectContaining({ tabId: 99 })] : [],
+          );
+        }
+      } finally {
+        bridge.dispose();
+      }
+    },
+  );
+
   it.each([true, false])(
     "honors an explicit Target.createTarget focus=%s request",
     async (focus) => {

--- a/extensions/browser/src/browser/extension-relay/relay-bridge.ts
+++ b/extensions/browser/src/browser/extension-relay/relay-bridge.ts
@@ -51,8 +51,8 @@ type PendingExtensionCommand = {
 
 type TabState = {
   info: RelayTabInfo;
-  /** Set while chrome.debugger is attached: real CDP targetId + synthetic root sessionId. */
-  attached?: { targetId: string; sessionId: string };
+  /** Target identity lasts until access/extension loss; only the session ends on detach. */
+  target?: { id: string; sessionId?: string };
   attaching?: Promise<{ targetId: string; sessionId: string }>;
   /** Extension loss invalidated attachment work that auto-attach clients still expect restored. */
   restoreAttachment: boolean;
@@ -170,7 +170,9 @@ export class ExtensionRelayBridge {
     // pin both the authenticated extension owner and the exact granted tab instance.
     return () =>
       this.extension === extension && this.tabs.get(target.tabId) === target.tab
-        ? target.tab.attached?.targetId
+        ? target.tab.target?.sessionId
+          ? target.tab.target.id
+          : undefined
         : undefined;
   }
 
@@ -188,7 +190,7 @@ export class ExtensionRelayBridge {
       url: tab.info.url,
       title: tab.info.title,
       active: tab.info.active,
-      id: tab.attached?.targetId ?? `tab-${tab.info.tabId}`,
+      id: tab.target?.id ?? `tab-${tab.info.tabId}`,
       type: "page",
     }));
   }
@@ -306,9 +308,9 @@ export class ExtensionRelayBridge {
       }
       case "detached": {
         const tab = this.tabs.get(msg.tabId);
-        if (tab?.attached) {
-          this.emitDetachedFromTarget(msg.tabId, tab.attached.sessionId, tab.attached.targetId);
-          tab.attached = undefined;
+        if (tab?.target?.sessionId) {
+          this.emitDetachedFromTarget(msg.tabId, tab.target.sessionId, tab.target.id);
+          tab.target.sessionId = undefined;
         }
         break;
       }
@@ -331,12 +333,12 @@ export class ExtensionRelayBridge {
     // Retire attach work synchronously so a replacement snapshot cannot reuse
     // a rejected promise. Keep the tab list so the same ids can be re-exposed.
     for (const [tabId, tab] of this.tabs) {
-      tab.restoreAttachment ||= tab.attached !== undefined || tab.attaching !== undefined;
+      tab.restoreAttachment ||= tab.target?.sessionId !== undefined || tab.attaching !== undefined;
       tab.attaching = undefined;
-      if (tab.attached) {
-        this.emitDetachedFromTarget(tabId, tab.attached.sessionId, tab.attached.targetId);
-        tab.attached = undefined;
+      if (tab.target?.sessionId) {
+        this.emitDetachedFromTarget(tabId, tab.target.sessionId, tab.target.id);
       }
+      tab.target = undefined;
     }
     this.childSessions.clear();
   }
@@ -404,8 +406,8 @@ export class ExtensionRelayBridge {
     const shouldAutoAttach = [...this.clients].some((client) => client.autoAttach);
     for (const [tabId, tab] of this.tabs) {
       if (!nextIds.has(tabId)) {
-        if (tab.attached) {
-          this.emitDetachedFromTarget(tabId, tab.attached.sessionId, tab.attached.targetId);
+        if (tab.target?.sessionId) {
+          this.emitDetachedFromTarget(tabId, tab.target.sessionId, tab.target.id);
         }
         this.tabs.delete(tabId);
       }
@@ -430,19 +432,27 @@ export class ExtensionRelayBridge {
     }
   }
 
-  private async ensureTabAttached(tabId: number): Promise<{ targetId: string; sessionId: string }> {
+  private async ensureTabAttached(
+    tabId: number,
+    createdTargetId?: string,
+  ): Promise<{ targetId: string; sessionId: string }> {
     const tab = this.tabs.get(tabId);
     if (!tab) {
       throw new Error(`tab ${tabId} is not available to OpenClaw`);
     }
-    if (tab.attached) {
-      return tab.attached;
+    if (tab.target?.sessionId) {
+      return { targetId: tab.target.id, sessionId: tab.target.sessionId };
     }
     if (tab.attaching) {
       return await tab.attaching;
     }
+    const extension = this.extension;
     const attaching = (async () => {
-      const result = (await this.callExtension({ type: "attach", tabId })) as {
+      const result = (
+        createdTargetId
+          ? { targetId: createdTargetId }
+          : await this.callExtension({ type: "attach", tabId })
+      ) as {
         targetId?: unknown;
       } | null;
       const targetId = typeof result?.targetId === "string" ? result.targetId : `tab-${tabId}`;
@@ -452,12 +462,10 @@ export class ExtensionRelayBridge {
       // access under the same tabId while this attach was in flight, replacing
       // the TabState. Writing onto the new TabState would bind stale attach data.
       const current = this.tabs.get(tabId);
-      if (current !== tab) {
-        // Original tab vanished (or was recreated); best-effort detach the banner.
-        void this.callExtension({ type: "detach", tabId }).catch(() => {});
+      if (this.extension !== extension || current !== tab) {
         throw new Error(`tab ${tabId} closed during attach`);
       }
-      current.attached = attached;
+      current.target = { id: targetId, sessionId };
       current.restoreAttachment = false;
       return attached;
     })();
@@ -481,7 +489,7 @@ export class ExtensionRelayBridge {
       // connectOverCDP owns this as a persistent default context, but still
       // asserts that attached page events carry a non-empty context id.
       browserContextId: BROWSER_CONTEXT_ID,
-      attached: true,
+      attached: Boolean(tab.target?.sessionId),
       canAccessOpener: false,
     };
   }
@@ -495,11 +503,11 @@ export class ExtensionRelayBridge {
     if (!this.extensionConnected) {
       return { status: "unavailable", reason: "extension-disconnected" };
     }
-    if ([...this.tabs.values()].some((tab) => !tab.attached)) {
+    if ([...this.tabs.values()].some((tab) => !tab.target)) {
       return { status: "unavailable", reason: "target-identity-unresolved" };
     }
     const targetInfos = [...this.tabs.values()].map((tab) =>
-      this.targetInfoForTab(tab, tab.attached?.targetId ?? ""),
+      this.targetInfoForTab(tab, tab.target?.id ?? ""),
     );
     return { status: "available", targetInfos };
   }
@@ -560,7 +568,7 @@ export class ExtensionRelayBridge {
       this.auxiliaryTabSessions.delete(auxiliarySessionId);
     }
     // Reap this tab's child sessions (iframes/workers) by owner tabId. Callers
-    // clear tab.attached before/around this, so matching on the root sessionId
+    // clear the root session before/around this, so matching on the root sessionId
     // would miss every child and leak the childSessions map. Deleting the
     // current key during Map iteration is safe.
     for (const [childSessionId, ownerTabId] of this.childSessions) {
@@ -581,7 +589,7 @@ export class ExtensionRelayBridge {
     params: unknown,
   ): void {
     const tab = this.tabs.get(tabId);
-    const rootSessionId = tab?.attached?.sessionId;
+    const rootSessionId = tab?.target?.sessionId;
     if (!rootSessionId) {
       return;
     }
@@ -634,6 +642,9 @@ export class ExtensionRelayBridge {
     const client: CdpClientState = { socket, autoAttach: false, announcedSessions: new Set() };
     this.clients.add(client);
     const onMessage = (raw: string) => {
+      if (!this.clients.has(client)) {
+        return;
+      }
       let parsed: unknown;
       try {
         parsed = JSON.parse(raw);
@@ -681,9 +692,9 @@ export class ExtensionRelayBridge {
       return;
     }
     for (const [tabId, tab] of this.tabs) {
-      if (tab.attached) {
-        const { sessionId, targetId } = tab.attached;
-        tab.attached = undefined;
+      if (tab.target?.sessionId) {
+        const { sessionId, id: targetId } = tab.target;
+        tab.target.sessionId = undefined;
         this.emitDetachedFromTarget(tabId, sessionId, targetId);
         void this.callExtension({ type: "detach", tabId }).catch(() => {});
       }
@@ -691,6 +702,9 @@ export class ExtensionRelayBridge {
   }
 
   private respond(client: CdpClientState, request: CdpRequest, result: unknown): void {
+    if (!this.clients.has(client)) {
+      return;
+    }
     client.socket.send(
       JSON.stringify({
         id: request.id,
@@ -706,12 +720,15 @@ export class ExtensionRelayBridge {
     message: string,
     code = -32000,
   ): void {
+    if (!this.clients.has(client)) {
+      return;
+    }
     client.socket.send(toErrorPayload(request.id, request.sessionId, message, code));
   }
 
   private tabBySessionId(sessionId: string): { tabId: number; child: boolean } | null {
     for (const [tabId, tab] of this.tabs) {
-      if (tab.attached?.sessionId === sessionId) {
+      if (tab.target?.sessionId === sessionId) {
         return { tabId, child: false };
       }
     }
@@ -728,7 +745,7 @@ export class ExtensionRelayBridge {
 
   private tabByTargetId(targetId: string): { tabId: number; tab: TabState } | null {
     for (const [tabId, tab] of this.tabs) {
-      if (tab.attached?.targetId === targetId) {
+      if (tab.target?.id === targetId) {
         return { tabId, tab };
       }
     }
@@ -936,9 +953,9 @@ export class ExtensionRelayBridge {
         const route = sessionId ? this.tabBySessionId(sessionId) : null;
         if (route && !route.child) {
           const tab = this.tabs.get(route.tabId);
-          if (tab?.attached) {
-            const { sessionId: rootSession, targetId } = tab.attached;
-            tab.attached = undefined;
+          if (tab?.target?.sessionId) {
+            const { sessionId: rootSession, id: targetId } = tab.target;
+            tab.target.sessionId = undefined;
             this.emitDetachedFromTarget(route.tabId, rootSession, targetId);
             await this.callExtension({ type: "detach", tabId: route.tabId }).catch(() => {});
           }
@@ -947,10 +964,32 @@ export class ExtensionRelayBridge {
         return;
       }
       case "Target.createTarget": {
-        const url = typeof request.params?.url === "string" ? request.params.url : "about:blank";
+        const extension = this.extension;
+        const url =
+          typeof request.params?.url === "string" && request.params.url
+            ? request.params.url
+            : "about:blank";
         const createParams = resolveCreateTargetParams(request.params);
         const command = { type: "createTab", url, ...createParams } as const;
-        const created = (await this.callExtension(command)) as { tabId?: unknown } | null;
+        const created = (await this.callExtension(command)) as {
+          tabId?: unknown;
+          targetId?: unknown;
+        } | null;
+        if (this.extension !== extension) {
+          return;
+        }
+        if (!this.clients.has(client)) {
+          // The extension has already handed off; without an acknowledgement
+          // protocol we cannot reclaim the tab, but an idle relay can drop its banner.
+          if (
+            this.clients.size === 0 &&
+            typeof created?.tabId === "number" &&
+            typeof created.targetId === "string"
+          ) {
+            void this.callExtension({ type: "detach", tabId: created.tabId }).catch(() => {});
+          }
+          return;
+        }
         if (typeof created?.tabId !== "number") {
           this.respondError(client, request, "extension did not return a tabId for createTab");
           return;
@@ -962,7 +1001,16 @@ export class ExtensionRelayBridge {
             restoreAttachment: false,
           });
         }
-        const attached = await this.ensureTabAttached(tabId);
+        // Store 2.2.0 returns only tabId and still needs the separate attach.
+        // New workers own create/group/attach/rollback and return the attachment.
+        const attached = await this.ensureTabAttached(
+          tabId,
+          typeof created.targetId === "string" ? created.targetId : undefined,
+        );
+        if (this.extension !== extension || !this.clients.has(client)) {
+          this.detachAllWhenIdle();
+          return;
+        }
         // Announce before responding, mirroring Chrome's event-then-result order.
         this.announceAttachedTab(tabId, attached.targetId, attached.sessionId, {
           onlyAutoAttach: true,

--- a/extensions/browser/src/browser/extension-relay/relay-protocol.ts
+++ b/extensions/browser/src/browser/extension-relay/relay-protocol.ts
@@ -67,7 +67,7 @@ export type RelayCommandBody =
   | { type: "attach"; tabId: number }
   /** Detach chrome.debugger from a tab (access revoked or client detached). */
   | { type: "detach"; tabId: number }
-  /** Open a new tab inside the OpenClaw tab group. Result: { tabId: number }. */
+  /** Create and attach a grouped tab. Result: { tabId, targetId }; Store 2.2.0 returns tabId only. */
   | { type: "createTab"; url: string; background?: boolean; focus?: boolean }
   /** Close an accessible tab. Result: {}. */
   | { type: "closeTab"; tabId: number }


### PR DESCRIPTION
Closes #132127

AI-assisted implementation and verification.

## What Problem This Solves

Fixes an issue where users opening tabs through the OpenClaw Chrome extension with Chrome DevTools MCP received a restricted/unavailable error and accumulated grouped blank tabs. Following the real workflow through completion also exposed allowed navigation being reported as revoked and a created page failing to close after MCP detached its debugger session.

## Why This Change Was Made

The extension's existing access owner now owns creation, grouping, attachment, and guarded pre-handoff rollback. Only that operation's own initial blank receives transient provenance; ordinary blank tabs do not become eligible. Sharing revocation is recorded separately from document freshness, so permitted navigation and supported session-configuration receipts can finish without allowing stale page reads/actions across document changes.

The relay also retains a target's identity independently of its debugger session, matching MCP's detach-before-close sequence. This removes split creation/grouping paths and redundant modern-peer attachment rather than patching MCP, substituting a data URL, or bypassing access validation.

## User Impact

With updated extension code, MCP and Playwright clients can create, navigate, inspect, and close pages through the relay in both All tabs and Selected tabs. Failed pre-handoff creation cleans up the exact still-owned target. Existing/manual blanks, restricted pages and destinations, incognito, unpermitted file URLs, paused tabs, and unselected tabs remain unavailable.

No product configuration, permission, dependency, SQLite schema, or protocol-version change is introduced. Store 2.2.0's `tabId`-only reply remains supported for existing operations, but its old worker bytes do not acquire this fix; an updated worker is required. This PR does not publish a Store release or change an operator's installed extension or running services.

## Evidence

### Reproduction and regression coverage

The frozen baseline at `740f54e8ede8c54cab1b5ec8427db86d543ceedc` reproduces the original failure with the actual installed MCP executable and real Chrome APIs: one create/group, zero debugger attachments to the new tab, zero navigation, zero removal, and a grouped blank remaining after MCP exits. The same failing runtime was independently verified in installed Store 2.2.0 bytes. Ordinary-page MCP list/select/evaluate succeeded before each attempt.

Regressions were run before each repair: four initial-creation/rollback failures, fourteen navigation-ordering failures, and two detach-before-close failures. The owner/sibling suites cover **328 tests across ten files**, including both event/response orders, initial pending-only Chrome URLs, redirects, revocation during awaited work, restart/replacement, unrelated-tab preservation, and failed rollback visibility.

```bash
node scripts/run-vitest.mjs extensions/browser/chrome-extension/background.initial-target.test.ts extensions/browser/chrome-extension/background.navigation.test.ts extensions/browser/chrome-extension/background.access-mode.test.ts extensions/browser/chrome-extension/background.test.ts extensions/browser/chrome-extension/modules/tab-access.test.ts extensions/browser/chrome-extension/modules/tab-access-events.test.ts extensions/browser/chrome-extension/modules/tab-access-events.navigation.test.ts extensions/browser/chrome-extension/modules/relay-command-handler.test.ts extensions/browser/src/browser/extension-relay/relay-bridge.test.ts extensions/browser/src/browser/extension-relay/relay-protocol.test.ts
```

### Real browser behavior

Actual Chrome DevTools MCP **1.8.0** / bundled Puppeteer **25.8.0**, Chrome for Testing **151.0.7922.34**, and Playwright **1.62.1** were exercised through the real extension relay. Both access modes pass MCP new-page/navigation/evaluation/close; existing-page URL/reload/back/forward navigation; Playwright page creation/navigation/evaluation/close; direct HTTP and redirect creation; and injected failure of the single new target's debugger attachment with product cleanup. Unrelated tabs and negative access controls are preserved. A supplemental run starts All tabs without an existing OpenClaw group and also passes.

The tests use disposable profiles, isolated state/HOME, a session-owned relay and one-use local MCP handoff, and actual v2 extension authentication. No operator Gateway, shared browser/mcporter daemon, live extension settings, cookies, or credentials were used. Executing worker bodies and frozen source hashes were verified, screenshots inspected, and owned processes/endpoints/temp state cleaned up. This does not claim verification of mcporter's production discovery/handoff path.

Local frozen-source diagnostic command (runner and full traces retained locally, not committed as product artifacts):

```bash
TSX_DISABLE_CACHE=1 node --import tsx .artifacts/browser-interop-fix/live/run-candidate.mjs --implementation-complete -o .artifacts/browser-interop-fix/live/candidate-run-8
```

### Before and after

Before: Chrome's actual page inventory after the failed MCP call contains an additional blank (three instead of the two intentionally retained controls). After: the requested fixture URL appears alongside the same two blank controls; MCP then evaluates and closes the new page. Images show the visible browser state; the protocol assertions establish access checks and cleanup.

![Before: failed MCP creation leaves a third blank tab in the disposable browser](https://github.com/user-attachments/assets/7d260b17-bb30-47db-b467-5fb778a8eaba)

![After: the requested fixture page opens while the two blank controls remain](https://github.com/user-attachments/assets/c7cea5eb-6192-46eb-a07b-9a63bef7bf93)

![After: the real requested page renders through the repaired relay](https://github.com/user-attachments/assets/6403e26c-0b02-4521-bcc6-8af774b3d0fc)

### Checks and review

The full canonical `pnpm build` passes on refreshed head `eb8f8d8e22c26d2ba500ac78577877bc2c665f1f`, including the Control UI performance gate: 345,187 startup gzip bytes against a 345,947-byte enforcement limit. The first build hit the inherited UI size failure; this branch incorporated the already-landed canonical fix [#132140, keep Usage helpers out of chat startup](https://github.com/openclaw/openclaw/pull/132140), with the browser patch and all 19 changed files preserved byte-for-byte. No budget or baseline changes are part of this PR.

The complete changed-file gate passed before that refresh. Refreshed tests (328), production/test typechecks, formatting, export scans, and preceding guards passed, but both local repeats stopped before lint when SDK declaration preparation hit its existing 300-second timeout (Node 26 and Node 24; the second attempt followed the successful canonical build). This is retained as a local tooling failure, not reported as a passing local gate. No timeout or check was weakened; a separate local declaration-generation investigation is recorded.

[Exact-head CI 33223399767](https://github.com/openclaw/openclaw/actions/runs/33223399767) completed successfully. Its [check-lint job](https://github.com/openclaw/openclaw/actions/runs/33223399767/job/99022195062) actually completed extension/script lint and whole-tree formatting, alongside successful production/test types, guards, build, and tests. The declaration generator files are unchanged from current main. Native landing uses this exact-head hosted proof, plus the clean patch review and local full-build/live/regression evidence—not an override of the local timeout.

```bash
node scripts/check-changed.mjs
```

```bash
pnpm build
```

Actual structured autoreview: **Codex**, high reasoning, P0/P1 scope, with full owner modules and inspected dependency contracts supplied. The final uncommitted candidate review exited successfully with no actionable P0/P1 findings. It reviewed creator provenance, revocation/rollback, navigation epochs, target/session lifetime, and deployed-peer compatibility. The reviewer did not independently execute tests or live flows; those were run and verified separately as described above.

Requested fictional run label: `umbreon-latest`. This is a fictional label only, **not a model ID, reviewer identity, or proof that a review occurred**; the actual review engine is Codex.

### Scope, provenance, and limits

Production: **+537/-155 (net +382)**, including runtime and declarations. Tests/test support: **+961/-12 (net +949)**. Docs: **+13**. Positive production growth implements missing creator provenance/rollback and separates access/document and target/session lifetimes; the former split creator/group lookup and redundant modern attachment were removed. No baseline/suppression budget was increased.

The blank incompatibility and navigation epoch coupling were made visible by the all-tabs access change in [#120995, add all-tabs extension access](https://github.com/openclaw/openclaw/pull/120995), authored and merged by @steipete on 2026-08-09. The earlier create/attach split and target/session conflation date to the restored relay implementation in [#100619, restore the extension relay](https://github.com/openclaw/openclaw/pull/100619), authored and merged by @steipete on 2026-07-06. This is source-history attribution, not a claim that every stable package is affected.

Rollback is intentionally conservative when a target has been paused, moved, navigated elsewhere, replaced, or otherwise taken over. Lost handoff acknowledgements or process death can still leave a tab without an additional protocol guarantee; this PR does not claim distributed exactly-once creation. Post-handoff cancellation and HTTP-close compensation paths are outside this repair.
