### PR TITLE
fix(test): release inventory fixture times out under filesystem load

### DIFF
--- a/test/scripts/release-plan-producer.test.ts
+++ b/test/scripts/release-plan-producer.test.ts
@@ -13,11 +13,12 @@ import {
   writeFileSync,
 } from "node:fs";
 import { createRequire } from "node:module";
-import { dirname, join, resolve } from "node:path";
+import { dirname, join, relative, resolve } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { parse } from "yaml";
 import { collectClawHubPublishablePluginPackages } from "../../scripts/lib/plugin-clawhub-release.ts";
 import { collectPublishablePluginPackages } from "../../scripts/lib/plugin-npm-release.ts";
+import { collectExtensionPackageJsonCandidates } from "../../scripts/lib/plugin-publication-candidates.ts";
 import {
   canonicalReleasePlanLockJson,
   createReleasePlanLock,
@@ -1172,10 +1173,37 @@ mutateModule.syncBuiltinESMExports();
       encoding: "utf8",
     }).trim();
     execFileSync("git", ["clone", "-q", "--shared", "--no-checkout", resolve("."), root]);
+    const candidates = collectExtensionPackageJsonCandidates();
+    const pluginMetadataPaths = candidates.flatMap(({ packageDir, readmeText }) => [
+      `${packageDir}/package.json`,
+      ...(readmeText === undefined ? [] : [`${packageDir}/README.md`]),
+    ]);
+    // Preserve the exact candidate commit without materializing runtime trees for fixture cleanup.
+    execFileSync("git", ["sparse-checkout", "set", "--no-cone", "--stdin"], {
+      cwd: root,
+      input: [
+        ".github/workflows/",
+        "packages/*/package.json",
+        ...pluginMetadataPaths,
+        ...TOOLING_CLOSURE,
+        ...TOOLING_ROOT_FILES,
+      ]
+        .map((path) => `/${path}`)
+        .join("\n"),
+    });
     execFileSync("git", ["checkout", "-q", "--detach", candidateSha], { cwd: root });
     copyToolingClosure(root);
     const toolingSha = commit(root, "tooling overlay", { allowEmpty: true });
     execFileSync("git", ["update-ref", "refs/heads/main", toolingSha], { cwd: root });
+    expect(candidateSha).not.toBe(toolingSha);
+    expect(existsSync(join(root, "src"))).toBe(false);
+    expect(collectExtensionPackageJsonCandidates(root)).toEqual(candidates);
+    expect(
+      readdirSync(join(root, "extensions"), { recursive: true, withFileTypes: true })
+        .filter((entry) => entry.isFile())
+        .map((entry) => relative(root, join(entry.parentPath, entry.name)).replaceAll("\\", "/"))
+        .toSorted(),
+    ).toEqual(pluginMetadataPaths.toSorted());
 
     const plan = produceReleasePlan({
       repoRoot: root,


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where release validation could time out while setting up and deleting the full-repository fixture for the current publisher-inventory test. During the August 28 validation, the test hit its 120-second deadline and the cleanup hook hit its 180-second deadline. Process samples showed Git checkout followed by recursive filesystem deletion, not a producer runtime or ancestry failure.

Related: #132029 (bounded release-tooling ancestry verification, retained unchanged here).

## Why This Change Was Made

The producer already reads exact Git objects and extracts a bounded manifest/README snapshot. Its test fixture now configures a sparse checkout before materialization, using the canonical plugin candidate collector and existing tooling closure rather than checking out every source file.

The fixture retains the exact original candidate SHA, a genuinely separate tooling commit, the complete Git object/index tree, every candidate manifest and existing README (including nonpublishable candidates), and real workflow policy. New assertions protect the metadata-only working-file boundary and complete candidate preservation. All original inventory and trust/attestation assertions remain intact; no production code, timeout, cleanup policy, dependency, or test-only production seam changed.

## User Impact

No runtime behavior change. Release-validation developers avoid unnecessary full-source checkout and cleanup while retaining the exact 93 npm / 89 ClawHub publisher-inventory checks.

Production/tooling LOC: +0/-0. Tests: +29/-1 (net +28), one file. AI-assisted, maintainer-requested repair.

## Evidence

Before/after proof on macOS with Node 24.20.0 and Git 2.55.0:

| Metric | Before | After |
| --- | ---: | ---: |
| Materialized source files | 34,895 | 382 |
| Targeted command wall time | 200.70s | 57.51s |
| Inventory test duration | 183.138s | 24.628s |
| CPU system time | 33.86s | 7.42s |
| Maximum RSS | 449,331,200 bytes | 248,037,376 bytes |

Host load varied, so timing is observed rather than a controlled speedup. The stable improvement is the bounded file set: 149 plugin manifests, 101 READMEs, workspace manifests, workflow files, and the tooling closure instead of the full checkout. The new no-runtime-tree assertion failed against the old setup (`expected true to be false`) and passed with the repair.

Equivalent targeted command before and after:

```bash
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs test/scripts/release-plan-producer.test.ts --maxWorkers=1 --reporter=verbose -t 'matches the exact current publisher inventory'
```

Full connected proof passed: **213 tests across six files**, with no skipped tests. This includes all 43 producer tests, full trust/attestation cases, identity and lock contracts, validation intents, and both publisher suites. The repaired inventory case took 8.261s in this run. An independent final targeted rerun also passed (4.923s test duration).

```bash
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs test/scripts/release-plan-producer.test.ts test/scripts/release-plan-contract.test.ts test/scripts/release-tooling-identity.test.ts test/scripts/release-validation-intent.test.ts test/plugin-npm-release.test.ts test/plugin-clawhub-release.test.ts --maxWorkers=1 --reporter=verbose
```

Formatting, direct changed-test lint, root test typechecking, scripts lint, and independent autoreview passed. The initial changed gate found an unrelated UI typecheck shard overflow (724 roots against 720), reproduced on unchanged source. After rebasing onto the canonical shard split from #132193, the complete changed gate passed without changing its limits.

Rebased validation on `414c1450ec84eef08cc89c84b01ef2e7d3f61d91` (base `48f43ac39dac3d60bd8c13071413f65f9c5c098d`), with Node 24.20.0:

```bash
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs test/scripts/release-plan-producer.test.ts --maxWorkers=1 --reporter=verbose
node scripts/check-changed.mjs -- test/scripts/release-plan-producer.test.ts
```

All 43 producer tests passed in normal order, with no skips; the inventory case took 5.219s. The changed-file gate passed all formatting, boundary, root test typecheck, and scripts lint stages. The reviewed patch is byte-identical after rebase, and the connected producer/collector owners are unchanged. Hosted CI [run 33223483908](https://github.com/openclaw/openclaw/actions/runs/33223483908), attempt 1, passed on this exact head. The canonical PR CI watcher completed with `GREEN`.

No release publication, version, tag, workflow dispatch, runtime, or operator-state changes are part of this PR. This is real local Git/filesystem fixture proof, not a claim of release-wide validation or live registry publication. A product build is unnecessary for this test-only change.
