### PR TITLE
fix(hovercard): restore link styling on session PR rows

### DIFF
--- a/ui/src/e2e/session-progress-hovercard.e2e.test.ts
+++ b/ui/src/e2e/session-progress-hovercard.e2e.test.ts
@@ -335,9 +335,14 @@ suite.define(() => {
           .poll(() => card.locator(".session-progress-card__heading").textContent())
           .toContain("1/3");
         await expect.poll(() => card.locator(".session-hovercard__pr-row").count()).toBe(4);
+        const prRow = card.locator(".session-hovercard__pr-row").first();
         await expect
-          .poll(() => card.locator(".session-hovercard__pr-author").first().textContent())
+          .poll(() => prRow.locator(".session-hovercard__pr-author").textContent())
           .toBe("steipete");
+        // The row is an anchor: a dropped text-decoration reset is invisible to jsdom.
+        await expect
+          .poll(() => prRow.evaluate((node) => getComputedStyle(node).textDecorationLine))
+          .toBe("none");
         await captureProof(page, "sidebar-row-hovercard-maximum.png");
         await expect
           .poll(() => card.locator(".session-hovercard__identity-row").textContent())

--- a/ui/src/styles/chat/progress-card.css
+++ b/ui/src/styles/chat/progress-card.css
@@ -250,6 +250,9 @@
   align-items: center;
   column-gap: var(--space-2);
   min-width: 0;
+  /* The row is an anchor: without these it falls back to default link styling. */
+  color: var(--muted);
+  text-decoration: none;
   font-family: var(--mono);
   font-size: var(--control-ui-text-xs);
   font-variant-numeric: tabular-nums;


### PR DESCRIPTION
## What Problem This Solves

Every pull-request row in the session hovercard renders underlined on current main. The rows are anchors, and [#132107](https://github.com/openclaw/openclaw/pull/132107) — mine — split the shared `.session-hovercard__pr-row, .session-hovercard__branch-row` rule to give PR rows their own four-column grid. The split carried over the layout declarations but dropped `color: var(--muted)` and `text-decoration: none`, so the rows fell back to default link styling.

## Why This Change Was Made

Both declarations are restored on `.session-hovercard__pr-row`, with a comment naming why they exist: the row is an `<a>`, and without them it reverts to browser link defaults.

The more useful half is the test. This is invisible to the component suite because jsdom applies no stylesheet, which is exactly why the regression shipped past a green `session-hovercard.test.ts` and past screenshots I had reviewed. The mocked-gateway E2E now asserts the computed `text-decoration-line` on a real PR row in Chromium. Reverting the two CSS lines fails it with `expected 'underline' to be 'none'`.

## User Impact

PR rows in the session hovercard return to muted, undecorated text; the diff-stat colors and the author login are unaffected. No behavior or API change.

## Evidence

![Fixed: session hovercard PR rows with no underline](https://github.com/user-attachments/assets/57032b99-0b28-43a0-a1aa-91f5d458d626)

Captured from the real Control UI in Chromium via the mocked-gateway E2E lane (`ui/src/e2e/session-progress-hovercard.e2e.test.ts`, `OPENCLAW_CAPTURE_UI_PROOF=1`). Compare against the underlined rows in [#132107](https://github.com/openclaw/openclaw/pull/132107)'s evidence, which is where the regression is visible.

- `node scripts/run-vitest.mjs ui/src/e2e/session-progress-hovercard.e2e.test.ts` — 8 passed.
- Same test with the two CSS lines removed — fails with `expected 'underline' to be 'none'`, confirming it covers the regression rather than the fix.
- `node scripts/check-changed.mjs` — exit 0.
- Codex autoreview — no accepted or actionable findings.
