### PR TITLE
fix(exec): automation exec-approval denials no longer point at the TUI

### DIFF
--- a/docs/tools/exec-approvals.md
+++ b/docs/tools/exec-approvals.md
@@ -440,8 +440,10 @@ Each allowlist entry supports:
 ## Standing grants for automations
 
 Approvals raised by gateway-host automation (cron) runs are delivered only to
-connected approval surfaces (Control UI, TUI, macOS app) — never to chat
-channels, which would repeat a card on every occurrence. While a reviewer
+connected exec approval clients: the Control UI, the macOS/iOS/Android apps,
+and API clients that declare the `approvals` or `exec-approvals` capability.
+The TUI does not render exec approval cards, and chat channels never receive
+automation approvals, which would repeat a card on every occurrence. While a reviewer
 surface is connected, the scheduled run waits for the decision like an
 interactive run; automations are single-flight, so at most one card per job
 is pending at a time. With no approval surface connected, the request is

--- a/src/agents/bash-tools.exec-approval-request.ts
+++ b/src/agents/bash-tools.exec-approval-request.ts
@@ -343,9 +343,10 @@ async function buildHostApprovalDecisionParams(
     runId: params.runId,
     toolCallId: params.toolCallId,
     requireDeliveryRoute: params.requireDeliveryRoute,
-    // Gateway-host cron cards go only to connected approval clients (Control
-    // UI/TUI); allow-always there mints a standing grant that ends the
-    // recurrence. With no client connected, the request still registers and
+    // Gateway-host cron cards go only to connected exec approval clients
+    // (Control UI, macOS/iOS/Android apps, `approvals`/`exec-approvals` cap
+    // holders — not the TUI); allow-always there mints a standing grant that
+    // ends the recurrence. With no client connected, the request still registers and
     // expires no-route into the headless denial (#128031). Node-host cron has
     // no grant mint/consume path yet, so it keeps the fully suppressed
     // headless policy instead of raising cards whose allow-always could not

--- a/src/agents/bash-tools.exec-host-shared.test.ts
+++ b/src/agents/bash-tools.exec-host-shared.test.ts
@@ -12,6 +12,7 @@ import {
 } from "./bash-tools.exec-approval-followup-state.js";
 import {
   buildExecApprovalPendingToolResult,
+  buildHeadlessExecApprovalDeniedMessage,
   createExecApprovalRequestRoute,
   resolveExecApprovalWaitOutcome,
   resolveExecHostApprovalContext,
@@ -766,5 +767,37 @@ describe("buildExecApprovalPendingToolResult", () => {
     expect(text).not.toContain("/approve");
     expect(text).not.toContain("Pending command:");
     expect(text).not.toContain("Approver DMs were sent");
+  });
+});
+
+describe("buildHeadlessExecApprovalDeniedMessage", () => {
+  it("points gateway automation runs at card-capable approval clients, not the TUI", () => {
+    const text = buildHeadlessExecApprovalDeniedMessage({
+      trigger: "cron",
+      host: "gateway",
+      security: "allowlist",
+      ask: "on-miss",
+      askFallback: "deny",
+    });
+
+    expect(text).toContain("Automation runs cannot wait for interactive exec approval");
+    expect(text).toContain("Control UI or a macOS/iOS/Android app");
+    expect(text).toContain("standing grant");
+    expect(text).not.toContain("TUI,");
+    expect(text).not.toContain("terminal UI");
+  });
+
+  it("offers the interactive rerun surfaces for non-automation headless runs", () => {
+    const text = buildHeadlessExecApprovalDeniedMessage({
+      host: "node",
+      security: "allowlist",
+      ask: "on-miss",
+      askFallback: "deny",
+    });
+
+    expect(text).toContain("Headless runs cannot wait for interactive exec approval");
+    expect(text).toContain("rerun interactively");
+    expect(text).toContain("Control UI, TUI, or a chat channel with exec approvals");
+    expect(text).not.toContain("standing grant");
   });
 });

--- a/src/agents/bash-tools.exec-host-shared.ts
+++ b/src/agents/bash-tools.exec-host-shared.ts
@@ -508,6 +508,13 @@ export function buildHeadlessExecApprovalDeniedMessage(params: {
   askFallback: ExecApprovalsResolved["agent"]["askFallback"];
 }): string {
   const runLabel = params.trigger === "cron" ? "Automation runs" : "Headless runs";
+  // The TUI and chat channels never receive automation approval cards
+  // (server-request-context canDeliverApprovals), so only name surfaces that
+  // can actually answer this run's approval.
+  const approvalSurfaceFix =
+    params.trigger === "cron" && params.host === "gateway"
+      ? "- keep the Control UI or a macOS/iOS/Android app connected and answer the next run's approval card; Allow Always mints a standing grant"
+      : "- rerun interactively and approve when prompted (Control UI, TUI, or a chat channel with exec approvals)";
   return [
     `exec denied: ${runLabel} cannot wait for interactive exec approval.`,
     `Effective host exec policy: security=${params.security} ask=${params.ask} askFallback=${params.askFallback}`,
@@ -515,7 +522,7 @@ export function buildHeadlessExecApprovalDeniedMessage(params: {
     "Fix one of these:",
     '- align both files to security="full" and ask="off" for trusted local automation',
     "- keep allowlist mode and add an explicit allowlist entry for this command",
-    "- enable Web UI, terminal UI, or chat exec approvals and rerun interactively",
+    approvalSurfaceFix,
     'Tip: run "openclaw doctor" and "openclaw approvals get --gateway" to inspect the effective policy.',
   ].join("\n");
 }

--- a/src/commands/doctor-security.ts
+++ b/src/commands/doctor-security.ts
@@ -170,7 +170,7 @@ function collectExecPolicyConflictWarnings(cfg: OpenClawConfig): SecurityAuditFi
         `Config: ${configParts.join(", ")}`,
         `Host: ${hostParts.join(", ")}`,
         `Effective host exec stays security="${snapshot.security.effective}" ask="${snapshot.ask.effective}" because the stricter side wins.`,
-        "Headless runs like isolated cron cannot answer approval prompts; align both files or enable Web UI, terminal UI, or chat exec approvals.",
+        "Headless runs like isolated cron cannot answer approval prompts; align both files, or keep the Control UI or a macOS/iOS/Android app connected so gateway automation runs can raise approval cards.",
         `Inspect with: ${formatCliCommand("openclaw approvals get --gateway")}`,
       ].join("\n"),
     });


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators whose automation (cron) exec was denied were told to "enable Web UI, terminal UI, or chat exec approvals" — advice that does not work. Gateway automation approval cards are delivered only to connected exec approval clients (Control UI, the macOS/iOS/Android apps, and clients declaring the `approvals`/`exec-approvals` gateway cap). The TUI qualifies only for plugin approvals, so an operator who attached a TUI after reading the message still saw "Automation runs cannot wait for interactive exec approval" (verified live on main 869cf47b8da). The docs section "Standing grants for automations" made the same wrong claim ("Control UI, TUI, macOS app"), and so did the doctor `exec_policy_conflict` hint and the #128031 delivery comment.

## Why This Change Was Made

Deny-message guidance must name surfaces that can actually answer the approval (never-dead-end doctrine). The authority is `canDeliverApprovals` in `src/gateway/server-request-context.ts`: for `exec`, TUI is not in the client set and declares no `exec-approvals` cap (`src/tui/gateway-chat.ts` declares `AGENT_KIND, PLUGIN_APPROVALS, TASK_SUGGESTIONS, TOOL_EVENTS`). The TUI *is* a working exec approval surface for interactive sessions — it forwards `/approve` through `chat.send` into the auto-reply fast-approve path — so the fix branches the copy instead of deleting "TUI" everywhere: gateway automation denials point at card-capable clients plus the Allow Always standing grant; other headless denials keep the interactive-rerun advice where the TUI legitimately works. Implementing exec-card rendering in the TUI would be a separate product decision; the corrected docs now state the TUI does not render these cards.

## User Impact

- Automation exec denials now tell operators the fix that works: keep the Control UI or a macOS/iOS/Android app connected and answer the next run's approval card (Allow Always mints a standing grant).
- Non-automation headless denials keep accurate interactive-rerun advice (Control UI, TUI, or a chat channel with exec approvals).
- `openclaw doctor` exec-policy-conflict remediation and https://docs.openclaw.ai/tools/exec-approvals#standing-grants-for-automations no longer name the TUI as an automation approval surface.

## Evidence

- Delivery authority: `EXEC_APPROVAL_CLIENT_IDS` = macOS/iOS/Android apps, `ALL_APPROVAL_CLIENT_IDS` = Control UI, TUI only in `PLUGIN_APPROVAL_CLIENT_IDS` (`src/gateway/server-request-context.ts:125-163`); cron cards use `deliverToApprovalClientsOnly` (`src/agents/bash-tools.exec-approval-request.ts`).
- Interactive TUI path: unknown slash commands forward to the gateway (`src/tui/tui-command-handlers.ts` `handleCommand` → `sendMessage`), `chat.send` dispatches through `dispatchInboundMessageWithProjectedDispatcher`, and `/approve` resolves in `src/auto-reply/reply/fast-approve.ts` — so "rerun interactively" advice keeps naming the TUI.
- Two new tests pin both deny-message variants (`src/agents/bash-tools.exec-host-shared.test.ts`); file passes 36/36, `src/commands/doctor-security.test.ts` passes 33/33, `check-changed` plan green.
- Codex autoreview (uncommitted diff): scoped-clean, no accepted/actionable findings, verdict "patch is correct (0.99)".
- Production LOC: +12/-5 (net +7: two-way message branch + delivery-invariant comment); Tests: +33/-0; Docs: +5/-2.

Copy note: the interactive-context "Approve it from the Web UI or terminal UI" strings in six channel plugins were deliberately left unchanged — that copy targets interactive sessions where the `/approve` chat flow works.
