### PR TITLE
fix(ui): stop the history sentinel from painting skeletons over transcript rows

### DIFF
--- a/ui/src/e2e/chat-flow.history-recovery.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.history-recovery.e2e.test.ts
@@ -613,9 +613,7 @@ suite.define(() => {
           const rows = Array.from(pane?.querySelectorAll<HTMLElement>("[data-chat-row-key]") ?? []);
           samples.push({
             hiddenNotice: pane?.textContent?.includes("Showing last") ?? false,
-            loading:
-              pane?.querySelector(".chat-history-sentinel openclaw-panel-loading-skeleton") !==
-              null,
+            loading: pane?.querySelector('.chat-history-available[aria-busy="true"]') !== null,
             messageCount: pane?.state?.chatMessages?.length ?? 0,
             minOpacity: rows.reduce(
               (minimum, row) => Math.min(minimum, Number.parseFloat(getComputedStyle(row).opacity)),

--- a/ui/src/e2e/claude-sessions.e2e.test.ts
+++ b/ui/src/e2e/claude-sessions.e2e.test.ts
@@ -589,7 +589,6 @@ suite.define(() => {
     await expect
       .poll(() => gateway.getRequests("sessions.catalog.read").then((requests) => requests.length))
       .toBe(initialReadCount + 1);
-    await catalogPane.locator(".chat-history-sentinel openclaw-panel-loading-skeleton").waitFor();
     const showEarlier = catalogPane.getByRole("button", { name: "Show earlier" });
     await showEarlier.waitFor();
     expect(await showEarlier.getAttribute("aria-busy")).toBe("true");
@@ -657,9 +656,7 @@ suite.define(() => {
     await expect.poll(() => thread.evaluate((element) => element.scrollTop)).toBe(0);
     await expect.poll(() => page.getByText("older question", { exact: true }).count()).toBe(1);
     await page.clock.runFor(500);
-    expect(
-      await catalogPane.locator(".chat-history-sentinel openclaw-panel-loading-skeleton").count(),
-    ).toBe(0);
+    expect(await catalogPane.locator(".chat-history-sentinel").count()).toBe(0);
     expect(await catalogPane.getByRole("button", { name: "Show earlier" }).count()).toBe(0);
     expect(await gateway.getRequests("sessions.catalog.read")).toHaveLength(exhaustedReadCount);
     await page.close();
@@ -756,7 +753,7 @@ suite.define(() => {
           ),
         )
         .toEqual([2]);
-      await pane.locator(".chat-history-sentinel openclaw-panel-loading-skeleton").waitFor();
+      await pane.locator('.chat-history-available[aria-busy="true"]').waitFor();
       expect(await thread.evaluate((element) => element.scrollHeight <= element.clientHeight)).toBe(
         true,
       );
@@ -776,7 +773,7 @@ suite.define(() => {
           ),
         )
         .toEqual([2, 6]);
-      await pane.locator(".chat-history-sentinel openclaw-panel-loading-skeleton").waitFor();
+      await pane.locator('.chat-history-available[aria-busy="true"]').waitFor();
       expect(await thread.evaluate((element) => element.scrollHeight <= element.clientHeight)).toBe(
         true,
       );
@@ -792,7 +789,7 @@ suite.define(() => {
         .poll(() => thread.evaluate((element) => element.scrollHeight > element.clientHeight))
         .toBe(true);
       await expect
-        .poll(() => pane.locator(".chat-history-sentinel openclaw-panel-loading-skeleton").count())
+        .poll(() => pane.locator('.chat-history-available[aria-busy="true"]').count())
         .toBe(0);
       expect(await pane.locator(".chat-history-sentinel").count()).toBe(1);
       if (artifactDir) {
@@ -901,8 +898,7 @@ suite.define(() => {
     // Pin each wait past the earlier chat.history traffic so a slow runner
     // can't return a stale load-time or prior-page request.
     await gateway.waitForRequest("chat.history", { after: initialRequestCount });
-    await page.locator(".chat-history-sentinel openclaw-panel-loading-skeleton").waitFor();
-    expect(await showEarlier.getAttribute("aria-busy")).toBe("true");
+    await page.locator('.chat-history-available[aria-busy="true"]').waitFor();
     if (artifactDir) {
       await page.screenshot({
         path: path.join(artifactDir, "01-native-history-loading.png"),
@@ -914,15 +910,12 @@ suite.define(() => {
       message: "history unavailable",
       retryable: true,
     });
-    await expect
-      .poll(() => page.locator(".chat-history-sentinel openclaw-panel-loading-skeleton").count())
-      .toBe(0);
-    expect(await showEarlier.getAttribute("aria-busy")).toBe("false");
+    await expect.poll(() => showEarlier.getAttribute("aria-busy")).toBe("false");
     const failedRequestCount = (await gateway.getRequests("chat.history")).length;
     await gateway.deferNext("chat.history");
     await showEarlier.click();
     await gateway.waitForRequest("chat.history", { after: failedRequestCount });
-    await page.locator(".chat-history-sentinel openclaw-panel-loading-skeleton").waitFor();
+    await page.locator('.chat-history-available[aria-busy="true"]').waitFor();
     expect(await gateway.getRequests("chat.history")).toHaveLength(failedRequestCount + 1);
     await gateway.resolveDeferred("chat.history", {
       messages: older,
@@ -980,9 +973,6 @@ suite.define(() => {
     });
     await expect.poll(() => page.locator(".chat-history-sentinel").count()).toBe(0);
     expect(await page.getByRole("button", { name: "Show earlier" }).count()).toBe(0);
-    expect(
-      await page.locator(".chat-history-sentinel openclaw-panel-loading-skeleton").count(),
-    ).toBe(0);
     expect(await gateway.getRequests("chat.history")).toHaveLength(firstPageRequestCount + 1);
     await page.close();
   });

--- a/ui/src/pages/chat/chat-view.test.ts
+++ b/ui/src/pages/chat/chat-view.test.ts
@@ -1371,7 +1371,7 @@ describe("chat history pagination", () => {
     expect(container.querySelector(".chat-history-sentinel")).toBeNull();
   });
 
-  it("renders the auto-load sentinel and a structural skeleton while older history loads", () => {
+  it("keeps the auto-load sentinel visually empty while older history loads", () => {
     const container = renderChatView({
       historyPagination: {
         hasMore: true,
@@ -1383,12 +1383,9 @@ describe("chat history pagination", () => {
     const sentinel = requireElement(container, ".chat-history-sentinel", "history sentinel");
 
     expect(threadInner.firstElementChild).toBe(sentinel);
-    const skeleton = sentinel.querySelector("openclaw-panel-loading-skeleton");
-    expect(skeleton).not.toBeNull();
-    expect(skeleton?.getAttribute("aria-label")).toBe(t("common.loading"));
-    expect(skeleton?.getAttribute("aria-busy")).toBe("true");
-    expect(skeleton?.compact).toBe(true);
-    expect(sentinel.querySelector("button")).toBeNull();
+    // The sentinel overlays virtualized rows; content here would paint over
+    // real messages. The floating pill owns the loading affordance.
+    expect(sentinel.childElementCount).toBe(0);
   });
 
   it("loads older history from upward wheel and keyboard intent without a button", () => {

--- a/ui/src/pages/chat/chat-view.ts
+++ b/ui/src/pages/chat/chat-view.ts
@@ -334,7 +334,7 @@ export function renderChat(props: ChatProps) {
       sessionKey: props.sessionKey,
       announceTranscript: props.announceTranscript,
       loading: props.loading && !placementStartup,
-      historyLoading: props.historyPagination?.loading,
+      historySentinel: props.historyPagination !== undefined,
       messages: props.messages,
       toolMessages: props.toolMessages,
       guardianNotices: props.guardianNotices,

--- a/ui/src/pages/chat/components/chat-thread-interactions.ts
+++ b/ui/src/pages/chat/components/chat-thread-interactions.ts
@@ -68,7 +68,8 @@ export type ChatThreadProps = {
   boardProvider?: BoardProvider;
   announceTranscript?: boolean;
   loading: boolean;
-  historyLoading?: boolean;
+  /** Older-history pagination is active; render its auto-load sentinel. */
+  historySentinel?: boolean;
   messages: unknown[];
   toolMessages: unknown[];
   guardianNotices?: ChatGuardianNotice[];

--- a/ui/src/pages/chat/components/chat-thread.ts
+++ b/ui/src/pages/chat/components/chat-thread.ts
@@ -63,14 +63,6 @@ function markdownTableOwnerRef(
   return callback;
 }
 
-function renderHistorySentinel(loading: boolean) {
-  return html`
-    <div class="chat-history-sentinel">
-      ${loading ? renderPanelLoadingSkeleton("chat", t("common.loading"), true) : nothing}
-    </div>
-  `;
-}
-
 export function renderChatThread(
   props: ChatThreadProps,
   transcript: ChatTranscriptController,
@@ -85,8 +77,12 @@ function renderTranscriptShell(
   transcript: ChatTranscriptSession,
 ): TemplateResult {
   const projection = projectChatTranscript(props, transcript);
-  const historySentinel =
-    props.historyLoading === undefined ? nothing : renderHistorySentinel(props.historyLoading);
+  // The sentinel is an out-of-flow IntersectionObserver target pinned over the
+  // virtualized rows; any content here paints on top of real messages. The
+  // floating "Show earlier" pill owns the loading affordance.
+  const historySentinel = props.historySentinel
+    ? html`<div class="chat-history-sentinel"></div>`
+    : nothing;
   const transcriptContents =
     projection.showLoadingSkeleton || projection.isEmpty
       ? html`


### PR DESCRIPTION
## What Problem This Solves

Opening a session whose transcript still has earlier history to load painted ghost skeleton "chat bubbles" on top of real messages (reported from team.openclaw.ai). The three semi-transparent bubbles of the structural chat skeleton overlaid the topmost transcript rows whenever older-history pagination was in flight.

## Why This Change Was Made

Root cause: #131819 replaced the history sentinel's compact spinner with the full three-bubble `chat` panel skeleton. But the sentinel is not a layout slot — in the virtualized transcript, `.chat-virtual-sizer > .chat-history-sentinel` (`ui/src/styles/chat/layout.css`) is an absolutely-positioned `min-height: 1px`, `pointer-events: none` strip pinned over the rows at `z-index: 1`; it exists purely as the IntersectionObserver target for auto-loading older pages. Any content it renders overflows the strip and paints over real messages.

The fix makes the sentinel a visually empty observer target again and deletes the skeleton call. The loading affordance was already fully owned by the floating "Loading earlier history… / Show earlier" pill, which renders in exactly the same window (both derive from `historyPagination`), carries a spinner, and announces via `role="status"`. The thread prop is renamed `historyLoading` → `historySentinel` since presence is all it ever gated. The initial-load skeleton on an empty thread and the side-panel skeletons from #131819 are untouched; the only other overlay-mode skeleton user (`.file-view`) is correctly positioned/clipped, so the bug class was unique to the sentinel.

## User Impact

Loading a session (or scrolling up into earlier history) no longer draws ghost bubbles over the transcript. The pill remains the single, unchanged loading indicator.

## Evidence

- Before/after screenshots attached below, captured from the mocked Control UI e2e rig with a deferred `chat.history` older-page load (same state as the report).
- Regression unit test updated: the sentinel must stay empty while older history loads (`ui/src/pages/chat/chat-view.test.ts`); chat-view suite 310/310 green.
- E2E loading probes repointed from the sentinel skeleton to the pill's `aria-busy` state; `ui/src/e2e/claude-sessions.e2e.test.ts` and `ui/src/e2e/chat-flow.history-recovery.e2e.test.ts` both green (15/15).
- `pnpm check:changed` green (UI typecheck, lint, i18n verify).
- Codex autoreview on the diff: scoped-clean, "patch is correct (0.99)".
- Production LOC: +10/−19 (net −9) | Tests: +11/−20.

Provenance: introduced by #131819 (clear), merged today; the sentinel's overlay positioning predates it (`fix: stabilize virtualized chat rows`).

![before-loading-earlier](https://github.com/user-attachments/assets/29ab533d-e145-400b-b756-c35d3ffe9292)

![after-loading-earlier](https://github.com/user-attachments/assets/f0b1f07b-7808-4c09-a646-897c7458b5a3)