### PR TITLE
build: consume platform-specific fs-safe packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -80,6 +80,7 @@ COPY scripts/postinstall-bundled-plugins.mjs scripts/preinstall-package-manager-
 COPY scripts/lib/guard-inventory-utils.mjs ./scripts/lib/guard-inventory-utils.mjs
 COPY scripts/lib/package-dist-imports.mjs ./scripts/lib/package-dist-imports.mjs
 COPY scripts/lib/package-lifecycle-marker.mjs ./scripts/lib/package-lifecycle-marker.mjs
+COPY scripts/docker/verify-fs-safe-native.mjs ./scripts/docker/verify-fs-safe-native.mjs
 COPY scripts/docker/verify-native-addons.sh ./scripts/docker/verify-native-addons.sh
 
 COPY --from=workspace-deps /out/packages/ ./packages/
@@ -274,6 +275,8 @@ COPY --from=runtime-assets --chown=node:node /app/${OPENCLAW_BUNDLED_PLUGIN_DIR}
 COPY --from=runtime-assets --chown=node:node /app/skills ./skills
 COPY --from=runtime-assets --chown=node:node /app/docs ./docs
 COPY --from=runtime-assets --chown=node:node /app/qa ./qa
+RUN --mount=from=dependency-inputs,source=/app/scripts/docker/verify-fs-safe-native.mjs,target=/tmp/verify-fs-safe-native.mjs \
+    node /tmp/verify-fs-safe-native.mjs --package-root /app --mode require
 
 # Validate the three version surfaces in every release-built runtime variant.
 ARG OPENCLAW_DOCKER_BUILD_VERSION

--- a/config/knip.config.ts
+++ b/config/knip.config.ts
@@ -35,6 +35,8 @@ const repositoryScriptEntries = [
   "scripts/diffs-shiki-curated.ts!",
   // Reusable Docker workflows invoke this from the downloaded .release-harness tree.
   "scripts/docker-e2e.mts!",
+  // Docker and package-install harnesses invoke this verifier by path.
+  "scripts/docker/verify-fs-safe-native.mjs!",
   "scripts/e2e/lib/browser-cdp-snapshot/assert-snapshot.mjs!",
   "scripts/e2e/lib/browser-cdp-snapshot/fixture-server.mjs!",
   "scripts/e2e/lib/bundled-plugin-install-uninstall/runtime-smoke.mjs!",

--- a/scripts/docker/verify-fs-safe-native.mjs
+++ b/scripts/docker/verify-fs-safe-native.mjs
@@ -1,0 +1,89 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import fsPromises from "node:fs/promises";
+import { createRequire } from "node:module";
+import os from "node:os";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+function parseArgs(argv) {
+  let packageRoot;
+  let mode;
+  for (let index = 0; index < argv.length; index += 2) {
+    const key = argv[index];
+    const value = argv[index + 1];
+    if (key === "--package-root") {
+      packageRoot = value;
+    } else if (key === "--mode") {
+      mode = value;
+    } else {
+      throw new Error(`unknown argument: ${key ?? ""}`);
+    }
+  }
+  if (!packageRoot || (mode !== "require" && mode !== "fallback")) {
+    throw new Error(
+      "usage: verify-fs-safe-native.mjs --package-root <path> --mode <require|fallback>",
+    );
+  }
+  return { mode, packageRoot: path.resolve(packageRoot) };
+}
+
+const { mode, packageRoot } = parseArgs(process.argv.slice(2));
+const requireFromPackage = createRequire(path.join(packageRoot, "package.json"));
+const fsSafeManifestPath = requireFromPackage.resolve("@openclaw/fs-safe/package.json");
+const fsSafeManifest = JSON.parse(await fsPromises.readFile(fsSafeManifestPath, "utf8"));
+const requireFromFsSafe = createRequire(fsSafeManifestPath);
+const platformPackageNames = Object.keys(fsSafeManifest.optionalDependencies ?? {}).filter((name) =>
+  name.startsWith("@openclaw/fs-safe-"),
+);
+const installedPlatformPackages = platformPackageNames.flatMap((name) => {
+  try {
+    const manifest = requireFromFsSafe.resolve(`${name}/package.json`);
+    return [{ name, root: fs.realpathSync(path.dirname(manifest)) }];
+  } catch {
+    return [];
+  }
+});
+
+const configPath = requireFromPackage.resolve("@openclaw/fs-safe/config");
+const durabilityPath = requireFromPackage.resolve("@openclaw/fs-safe/durability");
+const { configureFsSafeNative } = await import(pathToFileURL(configPath).href);
+const { sha256File } = await import(pathToFileURL(durabilityPath).href);
+configureFsSafeNative({ mode: mode === "require" ? "require" : "off" });
+
+const temporaryRoot = await fsPromises.mkdtemp(path.join(os.tmpdir(), "openclaw-fs-safe-proof-"));
+try {
+  const fixture = path.join(temporaryRoot, "fixture.txt");
+  await fsPromises.writeFile(fixture, "fs-safe native package proof");
+  const result = await sha256File(fixture);
+  assert.match(result.digest, /^[a-f0-9]{64}$/u);
+
+  const loadedNativeModules = Object.keys(requireFromPackage.cache).filter((file) =>
+    file.endsWith("fs-safe-native.node"),
+  );
+  if (mode === "require") {
+    assert.ok(
+      installedPlatformPackages.length > 0,
+      "expected at least one fs-safe platform package",
+    );
+    assert.equal(
+      loadedNativeModules.length,
+      1,
+      "expected exactly one loaded fs-safe native binding",
+    );
+    const loadedNativeRoot = fs.realpathSync(path.dirname(loadedNativeModules[0]));
+    assert.ok(
+      installedPlatformPackages.some(({ root }) => root === loadedNativeRoot),
+      "loaded fs-safe native binding did not come from an installed platform package",
+    );
+  } else {
+    assert.equal(
+      installedPlatformPackages.length,
+      0,
+      "fallback install contains a platform package",
+    );
+    assert.equal(loadedNativeModules.length, 0, "fallback loaded an fs-safe native binding");
+  }
+} finally {
+  await fsPromises.rm(temporaryRoot, { recursive: true, force: true });
+}

--- a/scripts/docker/verify-native-addons.sh
+++ b/scripts/docker/verify-native-addons.sh
@@ -1,24 +1,26 @@
 #!/bin/sh
 set -eu
 
+echo "==> Verifying fs-safe native addon..."
+node scripts/docker/verify-fs-safe-native.mjs --package-root /app --mode require
+
 # Matrix's downloader can exit successfully after a transient CDN failure.
 # Check both fresh installs, including the build target used by live tests.
 # Do not hardcode pnpm virtual-store paths: peer hashes can change them.
-if ! grep -qx 'matrix' /tmp/openclaw-selected-plugin-dirs; then
+if grep -qx 'matrix' /tmp/openclaw-selected-plugin-dirs; then
+  echo "==> Verifying matrix-sdk-crypto native addon..."
+  for attempt in 1 2 3 4 5; do
+    if find /app/node_modules -name "matrix-sdk-crypto*.node" 2>/dev/null | grep -q .; then
+      exit 0
+    fi
+    echo "matrix-sdk-crypto native addon missing; retrying download (${attempt}/5)"
+    node /app/node_modules/@matrix-org/matrix-sdk-crypto-nodejs/download-lib.js || true
+    sleep $((attempt * 2))
+  done
+  find /app/node_modules -name "matrix-sdk-crypto*.node" 2>/dev/null | grep -q . || {
+    echo "ERROR: matrix-sdk-crypto native addon missing after retries" >&2
+    exit 1
+  }
+else
   echo "==> matrix not bundled, skipping matrix-sdk-crypto check"
-  exit 0
 fi
-
-echo "==> Verifying critical native addons..."
-for attempt in 1 2 3 4 5; do
-  if find /app/node_modules -name "matrix-sdk-crypto*.node" 2>/dev/null | grep -q .; then
-    exit 0
-  fi
-  echo "matrix-sdk-crypto native addon missing; retrying download (${attempt}/5)"
-  node /app/node_modules/@matrix-org/matrix-sdk-crypto-nodejs/download-lib.js || true
-  sleep $((attempt * 2))
-done
-find /app/node_modules -name "matrix-sdk-crypto*.node" 2>/dev/null | grep -q . || {
-  echo "ERROR: matrix-sdk-crypto native addon missing after retries" >&2
-  exit 1
-}

--- a/scripts/e2e/Dockerfile
+++ b/scripts/e2e/Dockerfile
@@ -4,6 +4,8 @@
 # `bare` is a clean Node/Git runner for install/update lanes. `functional`
 # installs the prepared OpenClaw npm tarball into /app for built-app lanes.
 
+ARG OPENCLAW_NODE_ALPINE_IMAGE="docker.io/library/node:24-alpine@sha256:d32cdf619f63fe0471182d08996dd516c6275bb5fd31ae06e55a570bd9e1ad43"
+
 FROM node:24-bookworm-slim@sha256:3638d9a6fe4030bd716be989438248074489337ba3275657f93595428be4fc03 AS e2e-runner
 
 # openssl provisions short-lived fixture certificates for HTTPS-only provider
@@ -43,6 +45,12 @@ CMD ["bash"]
 FROM bare AS build
 
 CMD ["bash"]
+
+FROM ${OPENCLAW_NODE_ALPINE_IMAGE} AS musl
+
+COPY scripts/docker/verify-fs-safe-native.mjs /tmp/verify-fs-safe-native.mjs
+
+CMD ["sh"]
 
 FROM bare AS functional-manifest
 
@@ -106,6 +114,7 @@ FROM bare AS functional
 # checkout sources into the image.
 COPY --from=openclaw_package --chown=appuser:appuser openclaw-current.tgz /tmp/openclaw-current.tgz
 COPY --from=functional-deps --chown=appuser:appuser /tmp/openclaw-deps/node_modules /app/node_modules
+COPY --chown=appuser:appuser scripts/docker/verify-fs-safe-native.mjs /tmp/verify-fs-safe-native.mjs
 # Extract the package over the prebuilt dependency tree (bundled deps ship in
 # the tarball), then run its packaged postinstall. Functional E2E lanes exercise
 # private bundled plugins too, so skip the production migration's intentionally
@@ -119,6 +128,7 @@ RUN tar -xzf /tmp/openclaw-current.tgz -C /app --strip-components=1 \
  && ln -sfn /app /app/node_modules/openclaw \
  && mkdir -p "$HOME/.local/bin" \
  && ln -sf /app/openclaw.mjs "$HOME/.local/bin/openclaw" \
+ && node /tmp/verify-fs-safe-native.mjs --package-root /app --mode require \
  && rm -f /tmp/openclaw-current.tgz
 
 CMD ["bash"]

--- a/scripts/e2e/bun-global-install-smoke.sh
+++ b/scripts/e2e/bun-global-install-smoke.sh
@@ -316,6 +316,7 @@ NODE
   )"
   package_root="$(dirname "$openclaw_entry")"
   export OPENCLAW_E2E_REDACTOR_MODULE="$package_root/dist/plugin-sdk/logging-core.js"
+  "$bun_path" scripts/docker/verify-fs-safe-native.mjs --package-root "$package_root" --mode require
 
   echo "==> Verify OpenClaw lifecycle scripts were trusted and executed"
   run_with_timeout "$COMMAND_TIMEOUT_MS" "$bun_path" pm -g untrusted >"$UNTRUSTED_LOG" 2>&1

--- a/scripts/e2e/docker-package-install.sh
+++ b/scripts/e2e/docker-package-install.sh
@@ -5,11 +5,13 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 source "$ROOT_DIR/scripts/lib/docker-e2e-image.sh"
 
 IMAGE_NAME="$(docker_e2e_resolve_image "openclaw-docker-e2e-bare:local")"
+MUSL_IMAGE_NAME="openclaw-docker-e2e-musl:local"
 PACKAGE_TGZ="$(docker_e2e_prepare_package_tgz docker-package-install "${OPENCLAW_CURRENT_PACKAGE_TGZ:-}")"
 IDENTITY_PATH="${OPENCLAW_DOCKER_ARTIFACT_IDENTITY_PATH:-$ROOT_DIR/.artifacts/docker-tests/docker-package-install-identities.json}"
 NPM_PROOF_CONTAINER="openclaw-package-npm-proof-$$"
 PNPM_PROOF_CONTAINER="openclaw-package-pnpm-proof-$$"
 BUN_PROOF_CONTAINER="openclaw-package-bun-proof-$$"
+MUSL_PROOF_CONTAINER="openclaw-package-musl-proof-$$"
 DOCKER_RUN_TIMEOUT="${OPENCLAW_DOCKER_PACKAGE_INSTALL_RUN_TIMEOUT:-120s}"
 PACKAGE_HARNESS_DIR="$(mktemp -d "${TMPDIR:-/tmp}/openclaw-package-harness.XXXXXX")"
 docker_e2e_package_mount_args "$PACKAGE_TGZ"
@@ -18,13 +20,15 @@ cleanup() {
   docker_e2e_docker_cmd rm -f \
     "$NPM_PROOF_CONTAINER" \
     "$PNPM_PROOF_CONTAINER" \
-    "$BUN_PROOF_CONTAINER" >/dev/null 2>&1 || true
+    "$BUN_PROOF_CONTAINER" \
+    "$MUSL_PROOF_CONTAINER" >/dev/null 2>&1 || true
   docker_e2e_cleanup_package_tgz "$PACKAGE_TGZ"
   rm -rf "$PACKAGE_HARNESS_DIR"
 }
 trap cleanup EXIT
 
 docker_e2e_build_or_reuse "$IMAGE_NAME" docker-package-install "$ROOT_DIR/scripts/e2e/Dockerfile" "$ROOT_DIR" bare
+docker_e2e_build_or_reuse "$MUSL_IMAGE_NAME" docker-package-install-musl "$ROOT_DIR/scripts/e2e/Dockerfile" "$ROOT_DIR" musl
 
 # The package proofs share the registry and lifecycle harness. Copy its complete
 # script roots so all three managers install the same candidate dependency bytes.
@@ -42,10 +46,12 @@ DOCKER_COMMAND_TIMEOUT="$DOCKER_RUN_TIMEOUT" docker_e2e_docker_run_cmd run -d \
   --user root \
   "${DOCKER_E2E_PACKAGE_ARGS[@]}" \
   -v "$PACKAGE_HARNESS_DIR:/repo:ro" \
+  -v "$ROOT_DIR/scripts/docker/verify-fs-safe-native.mjs:/tmp/verify-fs-safe-native.mjs:ro" \
   "$IMAGE_NAME" \
   bash -lc '
     set -euo pipefail
     npm install -g /tmp/openclaw-current.tgz --no-fund --no-audit
+    node /tmp/verify-fs-safe-native.mjs --package-root /usr/local/lib/node_modules/openclaw --mode require
     test "$(command -v openclaw)" = "/usr/local/bin/openclaw"
     # Root installed the global package; a non-root user must still be able to
     # run it. A same-user install can never catch an installed tree that ends
@@ -63,6 +69,7 @@ DOCKER_COMMAND_TIMEOUT="$DOCKER_RUN_TIMEOUT" docker_e2e_docker_run_cmd run -d \
   --name "$PNPM_PROOF_CONTAINER" \
   "${DOCKER_E2E_PACKAGE_ARGS[@]}" \
   -v "$PACKAGE_HARNESS_DIR:/repo:ro" \
+  -v "$ROOT_DIR/scripts/docker/verify-fs-safe-native.mjs:/tmp/verify-fs-safe-native.mjs:ro" \
   "$IMAGE_NAME" \
   bash -lc '
     set -euo pipefail
@@ -78,6 +85,7 @@ DOCKER_COMMAND_TIMEOUT="$DOCKER_RUN_TIMEOUT" docker_e2e_docker_run_cmd run -d \
     # Tarball builds require their dependency path, relative to the install group.
     artifact_build="$(node -p "const path = require(\"node:path\"); \"openclaw@file:\" + path.relative(path.resolve(process.argv[1], \"../..\"), \"/tmp/openclaw-current.tgz\")" "$package_root")"
     pnpm approve-builds --global "$artifact_build"
+    node /tmp/verify-fs-safe-native.mjs --package-root "$package_root" --mode require
     printf "%s\n" "$package_root" > /tmp/openclaw-package-root
     openclaw --version > /tmp/openclaw-version
     openclaw --help > /tmp/openclaw-help
@@ -133,6 +141,19 @@ DOCKER_COMMAND_TIMEOUT="$DOCKER_RUN_TIMEOUT" docker_e2e_docker_run_cmd run -d \
     exec sleep infinity
   ' >/dev/null
 
+echo "Installing the real OpenClaw package artifact with npm on musl..."
+DOCKER_COMMAND_TIMEOUT="$DOCKER_RUN_TIMEOUT" docker_e2e_docker_run_cmd run -d \
+  --name "$MUSL_PROOF_CONTAINER" \
+  -v "$PACKAGE_TGZ:/tmp/openclaw-current.tgz:ro" \
+  "$MUSL_IMAGE_NAME" \
+  sh -lc '
+    set -eu
+    npm install -g /tmp/openclaw-current.tgz --no-fund --no-audit
+    node /tmp/verify-fs-safe-native.mjs --package-root /usr/local/lib/node_modules/openclaw --mode require
+    touch /tmp/openclaw-proof-ready
+    exec sleep infinity
+  ' >/dev/null
+
 wait_for_proof() {
   local container_name="$1"
   for _ in $(seq 1 240); do
@@ -149,7 +170,7 @@ wait_for_proof() {
   return 1
 }
 
-for container_name in "$NPM_PROOF_CONTAINER" "$PNPM_PROOF_CONTAINER" "$BUN_PROOF_CONTAINER"; do
+for container_name in "$NPM_PROOF_CONTAINER" "$PNPM_PROOF_CONTAINER" "$BUN_PROOF_CONTAINER" "$MUSL_PROOF_CONTAINER"; do
   wait_for_proof "$container_name"
 done
 
@@ -183,12 +204,14 @@ node --import tsx "$ROOT_DIR/scripts/e2e/lib/docker-artifact-proof/write-identit
   --container "npm=$NPM_PROOF_CONTAINER" \
   --container "pnpm=$PNPM_PROOF_CONTAINER" \
   --container "bun=$BUN_PROOF_CONTAINER" \
+  --container "musl=$MUSL_PROOF_CONTAINER" \
   --detail "npm:installedPackageRoot=$NPM_PACKAGE_ROOT" \
   --detail "npm:installedPackageVersion=$PACKAGE_VERSION" \
   --detail "npm:openclawVersion=$NPM_INSTALLED_VERSION" \
   --detail "npm:openclawPath=/usr/local/bin/openclaw" \
   --detail "npm:helpCommand=passed" \
   --detail "npm:nonRootExecution=passed" \
+  --detail "musl:fsSafeNative=passed" \
   --detail "pnpm:installedPackageRoot=$PNPM_PACKAGE_ROOT" \
   --detail "pnpm:installedPackageVersion=$PNPM_PACKAGE_VERSION" \
   --detail "pnpm:openclawVersion=$PNPM_INSTALLED_VERSION" \

--- a/scripts/e2e/update-channel-switch-docker.sh
+++ b/scripts/e2e/update-channel-switch-docker.sh
@@ -86,9 +86,18 @@ if ! openclaw_e2e_maybe_timeout "${OPENCLAW_E2E_NPM_INSTALL_TIMEOUT:-600s}" npm 
   exit 1
 fi
 package_version="$(node -p "JSON.parse(require(\"node:fs\").readFileSync(\"/tmp/npm-prefix/lib/node_modules/openclaw/package.json\", \"utf8\")).version")"
+# npm global tarball installs can retain the host platform package even with
+# --omit=optional. Relocate any such package so this lane deterministically
+# exercises the optional-free JavaScript fallback promised by that install mode.
+fs_safe_scope=/tmp/npm-prefix/lib/node_modules/openclaw/node_modules/@openclaw
+for platform_package in "$fs_safe_scope"/fs-safe-*; do
+  if [ -d "$platform_package" ]; then
+    mv "$platform_package" "$platform_package.omitted"
+  fi
+done
 node scripts/docker/verify-fs-safe-native.mjs \
   --package-root /tmp/npm-prefix/lib/node_modules/openclaw \
-  --mode require
+  --mode fallback
 OPENCLAW_PACKAGE_ACCEPTANCE_LEGACY_COMPAT="$(
   node scripts/e2e/lib/package-compat.mjs "$package_version"
 )"

--- a/scripts/e2e/update-channel-switch-docker.sh
+++ b/scripts/e2e/update-channel-switch-docker.sh
@@ -86,6 +86,9 @@ if ! openclaw_e2e_maybe_timeout "${OPENCLAW_E2E_NPM_INSTALL_TIMEOUT:-600s}" npm 
   exit 1
 fi
 package_version="$(node -p "JSON.parse(require(\"node:fs\").readFileSync(\"/tmp/npm-prefix/lib/node_modules/openclaw/package.json\", \"utf8\")).version")"
+node scripts/docker/verify-fs-safe-native.mjs \
+  --package-root /tmp/npm-prefix/lib/node_modules/openclaw \
+  --mode require
 OPENCLAW_PACKAGE_ACCEPTANCE_LEGACY_COMPAT="$(
   node scripts/e2e/lib/package-compat.mjs "$package_version"
 )"

--- a/scripts/lib/docker-e2e-package.sh
+++ b/scripts/lib/docker-e2e-package.sh
@@ -316,6 +316,7 @@ docker_e2e_harness_mount_args() {
   local harness_root="${DOCKER_E2E_HARNESS_ROOT_DIR:-$ROOT_DIR}"
   DOCKER_E2E_HARNESS_ARGS=(
     -v "$harness_root/scripts/e2e:/app/scripts/e2e:ro"
+    -v "$harness_root/scripts/docker/verify-fs-safe-native.mjs:/app/scripts/docker/verify-fs-safe-native.mjs:ro"
     -v "$harness_root/scripts/lib:/app/scripts/lib:ro"
     -v "$harness_root/packages/gateway-client/src:/app/packages/gateway-client/src:ro"
     -v "$harness_root/packages/normalization-core/package.json:/app/packages/normalization-core/package.json:ro"

--- a/src/worker/worker-deploy-runtime.test.ts
+++ b/src/worker/worker-deploy-runtime.test.ts
@@ -1,0 +1,26 @@
+import { beforeEach, expect, it, vi } from "vitest";
+
+const state = vi.hoisted(() => ({ calls: [] as string[] }));
+
+vi.mock("../infra/fs-safe-defaults.js", () => ({
+  configureFsSafeNative: (config: { mode: string }) => state.calls.push(`fs-safe:${config.mode}`),
+}));
+vi.mock("../infra/secure-temp-root.js", () => ({ resolveSecureTempRoot: vi.fn() }));
+vi.mock("./worker-deploy-highlight-runtime.mjs", () => ({ default: {} }));
+vi.mock("./worker-deploy-json5-runtime.mjs", () => ({ default: {} }));
+vi.mock("./worker-deploy-runtime-registry.js", () => ({
+  setWorkerDeployRuntime: () => state.calls.push("runtime:registered"),
+}));
+
+beforeEach(() => {
+  state.calls.length = 0;
+  vi.resetModules();
+  vi.stubEnv("FS_SAFE_NATIVE_MODE", "require");
+  vi.stubEnv("OPENCLAW_FS_SAFE_NATIVE_MODE", "require");
+});
+
+it("pins the sealed worker to bundled JavaScript before registering its runtime", async () => {
+  await import("./worker-deploy-runtime.js");
+
+  expect(state.calls).toEqual(["fs-safe:off", "runtime:registered"]);
+});

--- a/test/scripts/docker-build-helper.test.ts
+++ b/test/scripts/docker-build-helper.test.ts
@@ -6098,6 +6098,21 @@ source "$ROOT_DIR/scripts/lib/docker-e2e-logs.sh"
     );
   });
 
+  it("proves fs-safe native and fallback behavior across packaged Docker installs", () => {
+    const dockerfile = readFileSync("scripts/e2e/Dockerfile", "utf8");
+    const packageRunner = readFileSync(DOCKER_PACKAGE_INSTALL_E2E_PATH, "utf8");
+    const updateRunner = readFileSync(UPDATE_CHANNEL_SWITCH_DOCKER_E2E_PATH, "utf8");
+
+    expect(dockerfile).toContain("AS musl");
+    expect(dockerfile).toContain(
+      "node /tmp/verify-fs-safe-native.mjs --package-root /app --mode require",
+    );
+    expect(packageRunner).toContain('MUSL_IMAGE_NAME="openclaw-docker-e2e-musl:local"');
+    expect(packageRunner.match(/verify-fs-safe-native\.mjs[^\n]+--mode require/gu)).toHaveLength(3);
+    expect(packageRunner).toContain("bash scripts/e2e/bun-global-install-smoke.sh");
+    expect(updateRunner).toContain("--mode require");
+  });
+
   it("keeps private bundled plugins discoverable without persisting a curated registry", () => {
     const dockerfile = readFileSync("scripts/e2e/Dockerfile", "utf8");
     expect(dockerfile).toContain("runBundledPluginPostinstall");
@@ -6782,6 +6797,7 @@ done
 
     expect(mounts).toEqual([
       "/trusted-harness/scripts/e2e:/app/scripts/e2e:ro",
+      "/trusted-harness/scripts/docker/verify-fs-safe-native.mjs:/app/scripts/docker/verify-fs-safe-native.mjs:ro",
       "/trusted-harness/scripts/lib:/app/scripts/lib:ro",
       "/trusted-harness/packages/gateway-client/src:/app/packages/gateway-client/src:ro",
       "/trusted-harness/packages/normalization-core/package.json:/app/packages/normalization-core/package.json:ro",

--- a/test/scripts/docker-build-helper.test.ts
+++ b/test/scripts/docker-build-helper.test.ts
@@ -6110,7 +6110,8 @@ source "$ROOT_DIR/scripts/lib/docker-e2e-logs.sh"
     expect(packageRunner).toContain('MUSL_IMAGE_NAME="openclaw-docker-e2e-musl:local"');
     expect(packageRunner.match(/verify-fs-safe-native\.mjs[^\n]+--mode require/gu)).toHaveLength(3);
     expect(packageRunner).toContain("bash scripts/e2e/bun-global-install-smoke.sh");
-    expect(updateRunner).toContain("--mode require");
+    expect(updateRunner).toContain('mv "$platform_package" "$platform_package.omitted"');
+    expect(updateRunner).toContain("--mode fallback");
   });
 
   it("keeps private bundled plugins discoverable without persisting a curated registry", () => {

--- a/test/scripts/test-install-sh-docker.test.ts
+++ b/test/scripts/test-install-sh-docker.test.ts
@@ -1051,6 +1051,23 @@ printf 'status=%s\\n' "$status"
     );
   });
 
+  it("verifies fs-safe native loading before and after Docker runtime assembly", () => {
+    const dockerfile = readFileSync("Dockerfile", "utf8");
+    const verifier = readFileSync("scripts/docker/verify-native-addons.sh", "utf8");
+
+    expect(dockerfile).toContain(
+      "COPY scripts/docker/verify-fs-safe-native.mjs ./scripts/docker/verify-fs-safe-native.mjs",
+    );
+    expect(dockerfile.match(/RUN sh scripts\/docker\/verify-native-addons\.sh/gu)).toHaveLength(2);
+    expect(dockerfile).toContain(
+      "node /tmp/verify-fs-safe-native.mjs --package-root /app --mode require",
+    );
+    expect(verifier).toContain(
+      "node scripts/docker/verify-fs-safe-native.mjs --package-root /app --mode require",
+    );
+    expect(verifier).toContain("if grep -qx 'matrix' /tmp/openclaw-selected-plugin-dirs; then");
+  });
+
   it("passes the baked browser build arg through Docker setup", () => {
     const script = readFileSync(DOCKER_SETUP_PATH, "utf8");
 
@@ -2212,6 +2229,13 @@ if [ "\${1:-}" = "pm" ] && [ "\${2:-}" = "-g" ] && [ "\${3:-}" = "untrusted" ]; 
 fi
 if [ "\${1:-}" = "run" ] && [ "\${2:-}" = "--bun" ]; then
   echo "OpenClaw 2026.6.17"
+  exit 0
+fi
+if [[ "\${1:-}" == */verify-fs-safe-native.mjs ]]; then
+  test "\${2:-}" = "--package-root"
+  test -d "\${3:-}"
+  test "\${4:-}" = "--mode"
+  test "\${5:-}" = "require"
   exit 0
 fi
 if [[ "\${1:-}" == */openclaw.mjs ]]; then


### PR DESCRIPTION
## Summary

- verify that packaged OpenClaw installs resolve and load fs-safe's platform-native binding
- cover root Docker assembly plus npm, pnpm, Bun, glibc, and Alpine/musl package installs
- exercise the intentional optional-free JavaScript fallback in the update-channel Docker lane
- lock the sealed-worker runtime ordering to the current fs-safe policy owner

The fs-safe dependency update, lockfile metadata, documentation, and worker runtime policy originally developed on this branch have since landed on `main` through #134068. This PR now contains only the remaining package/Docker verification and focused regression coverage.

## Architecture

Normal Gateway, CLI, plugin, and container installs resolve a platform-specific optional package. The verifier performs a real `sha256File` operation in native-required mode and confirms that the loaded `.node` binding came from one of the installed fs-safe platform packages.

The update-channel fixture installs with `npm --omit=optional`. npm 11 global tarball installs can still retain the host fs-safe platform package in this package graph, so that disposable prefix explicitly relocates any retained platform package before running fallback verification. This makes the zero-package, zero-native-binding JavaScript path deterministic while the other install lanes retain native-required coverage.

Isolated workers contain no dependency tree and use fs-safe's bundled JavaScript implementation. The worker regression test verifies that this policy is selected through `src/infra/fs-safe-defaults.ts` before the runtime is registered.

## Validation

- `pnpm check:changed`: passed
- `pnpm build`: passed
- focused worker and package/Docker tooling tests: 375 passed, 2 skipped
- verifier operation, targeted lint/format checks, dead-file analysis, and `git diff --check`: passed
- candidate package tarball integrity validation: passed

Docker is not installed in this checkout, so real image execution is validated by exact-head CI.
