### PR TITLE
fix(agents): retain prepared catalog ownership through refresh

### DIFF
--- a/src/agents/embedded-agent-runner/model.forward-compat.errors-and-overrides.test.ts
+++ b/src/agents/embedded-agent-runner/model.forward-compat.errors-and-overrides.test.ts
@@ -93,6 +93,7 @@ vi.mock("../prepared-model-runtime.js", async () => {
   }) => {
     const config = input.config ?? {};
     return {
+      catalogOwner: undefined,
       agentDir: input.agentDir,
       ...(input.workspaceDir ? { workspaceDir: input.workspaceDir } : {}),
       activeProjectKeys: [],

--- a/src/agents/embedded-agent-runner/model.generation-scope.test-support.ts
+++ b/src/agents/embedded-agent-runner/model.generation-scope.test-support.ts
@@ -107,6 +107,7 @@ export function createModelGenerationFixture(params: {
       return { authStorage, modelRegistry: ModelRegistry.inMemory(authStorage) };
     });
   const preparedModelRuntime = {
+    catalogOwner: undefined,
     agentDir: "/tmp/openclaw-model-generation-agent",
     workspaceDir: GENERATION_WORKSPACE_DIR,
     activeProjectKeys: [],

--- a/src/agents/embedded-agent-runner/model.test.ts
+++ b/src/agents/embedded-agent-runner/model.test.ts
@@ -194,6 +194,7 @@ vi.mock("../prepared-model-runtime.js", async () => {
       Object.assign(modelRegistry, { fork: () => modelRegistry });
     }
     const snapshot = {
+      catalogOwner: undefined,
       agentDir: input.agentDir,
       ...(workspaceDir ? { workspaceDir } : {}),
       activeProjectKeys: [],
@@ -1077,6 +1078,7 @@ describe("resolveModel", () => {
       models: [{ id: "deepseek-v4-pro", name: "Configured DeepSeek" }],
     });
     const preparedModelRuntime = {
+      catalogOwner: undefined,
       agentDir: "/tmp/agent",
       activeProjectKeys: [],
       allowGatewaySubagentBinding: false,
@@ -1118,6 +1120,7 @@ describe("resolveModel", () => {
     );
 
     const preparedModelRuntime = {
+      catalogOwner: undefined,
       agentDir: "/tmp/agent",
       activeProjectKeys: [],
       allowGatewaySubagentBinding: false,
@@ -1155,6 +1158,7 @@ describe("resolveModel", () => {
   it("resolves opt-in provider static catalog rows while skipping agent discovery", async () => {
     const metadataSnapshot = createPluginMetadataSnapshotFixture();
     const preparedModelRuntime = {
+      catalogOwner: undefined,
       agentDir: "/tmp/agent",
       activeProjectKeys: [],
       allowGatewaySubagentBinding: false,

--- a/src/agents/openclaw-tools.browser-plugin.integration.test.ts
+++ b/src/agents/openclaw-tools.browser-plugin.integration.test.ts
@@ -499,6 +499,7 @@ describe("createOpenClawTools browser plugin integration", () => {
         config,
         workspaceDir: "/tmp",
         preparedModelRuntime: {
+          catalogOwner: undefined,
           agentDir: "/tmp/agent",
           workspaceDir: "/tmp",
           activeProjectKeys: [],

--- a/src/agents/prepared-model-catalog-owner.ts
+++ b/src/agents/prepared-model-catalog-owner.ts
@@ -1,10 +1,11 @@
 import { normalizeAgentId } from "../routing/session-key.js";
-import { listAgentIds, resolveAgentDir, resolveAgentWorkspaceDir } from "./agent-scope.js";
+import { listAgentIds, resolveAgentDir, resolveAgentWorkspaceDir } from "./agent-scope-config.js";
 import type {
   PublishedModelCatalogOwnerCandidate,
   ResolvedPublishedModelCatalogOwner,
 } from "./prepared-model-catalog.types.js";
 import { getPreparedModelRuntimeAuthStore } from "./prepared-model-runtime-auth.js";
+import type { PreparedModelRuntimeInput } from "./prepared-model-runtime.types.js";
 
 class PublishedModelCatalogOwnerResolutionError extends Error {
   constructor(message: string) {
@@ -13,31 +14,40 @@ class PublishedModelCatalogOwnerResolutionError extends Error {
   }
 }
 
-export function resolvePublishedModelCatalogOwner(
-  snapshot: PublishedModelCatalogOwnerCandidate,
-): ResolvedPublishedModelCatalogOwner {
-  const configuredAgentIds = listAgentIds(snapshot.config);
-  const directoryAgentIds = configuredAgentIds.filter(
-    (candidate) => resolveAgentDir(snapshot.config, candidate) === snapshot.agentDir,
-  );
-  const agentId = snapshot.agentId
+export function preparePublishedModelCatalogOwnerIdentity(
+  input: PreparedModelRuntimeInput,
+): PublishedModelCatalogOwnerCandidate["catalogOwner"] {
+  const env = input.env ?? process.env;
+  const configuredAgentIds = listAgentIds(input.config);
+  const directoryAgentIds = input.agentId
+    ? []
+    : configuredAgentIds.filter(
+        (candidate) => resolveAgentDir(input.config, candidate, env) === input.agentDir,
+      );
+  const agentId = input.agentId
     ? configuredAgentIds.find(
-        (candidate) => normalizeAgentId(candidate) === normalizeAgentId(snapshot.agentId),
+        (candidate) => normalizeAgentId(candidate) === normalizeAgentId(input.agentId),
       )
     : directoryAgentIds.length === 1
       ? directoryAgentIds[0]
       : undefined;
-  if (!agentId || resolveAgentDir(snapshot.config, agentId) !== snapshot.agentDir) {
+  if (!agentId || resolveAgentDir(input.config, agentId, env) !== input.agentDir) {
+    return undefined;
+  }
+  const workspaceDir = input.workspaceDir ?? resolveAgentWorkspaceDir(input.config, agentId, env);
+  return workspaceDir ? Object.freeze({ agentId, workspaceDir }) : undefined;
+}
+
+export function resolvePublishedModelCatalogOwner(
+  snapshot: PublishedModelCatalogOwnerCandidate,
+): ResolvedPublishedModelCatalogOwner {
+  const { catalogOwner } = snapshot;
+  if (!catalogOwner) {
     throw new PublishedModelCatalogOwnerResolutionError(
       `published model catalog owner did not identify one configured agent (${snapshot.agentDir})`,
     );
   }
-  const workspaceDir = snapshot.workspaceDir ?? resolveAgentWorkspaceDir(snapshot.config, agentId);
-  if (!workspaceDir) {
-    throw new PublishedModelCatalogOwnerResolutionError(
-      `published model catalog owner did not identify a workspace (${agentId})`,
-    );
-  }
+  const { agentId, workspaceDir } = catalogOwner;
   const authStore = snapshot.authStore ?? getPreparedModelRuntimeAuthStore(snapshot);
   if (!authStore) {
     throw new PublishedModelCatalogOwnerResolutionError(
@@ -45,6 +55,7 @@ export function resolvePublishedModelCatalogOwner(
     );
   }
   return Object.freeze({
+    catalogOwner,
     agentId,
     agentDir: snapshot.agentDir,
     workspaceDir,

--- a/src/agents/prepared-model-catalog-worker.integration.test.ts
+++ b/src/agents/prepared-model-catalog-worker.integration.test.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { buildModelsListResult } from "../gateway/server-methods/models-list-result.js";
@@ -12,6 +12,8 @@ import {
 } from "../gateway/server-model-catalog.js";
 import { loadPluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.js";
 import { closeOpenClawAgentDatabasesForTest } from "../state/openclaw-agent-db.js";
+import { unregisterResolvedAgentDir } from "./agent-dir-registry.js";
+import { resolveAgentDir, resolveAgentWorkspaceDir } from "./agent-scope-config.js";
 import { OPENAI_CODEX_DEFAULT_PROFILE_ID } from "./auth-profiles/constants.js";
 import { getRuntimeExternalCliProfileIds } from "./auth-profiles/runtime-external-profile-references.js";
 import {
@@ -24,10 +26,29 @@ import {
   PLUGIN_MODEL_CATALOG_GENERATED_BY,
   replacePersistedPluginModelCatalogs,
 } from "./plugin-model-catalog.js";
+import { preparePublishedModelCatalogOwnerIdentity } from "./prepared-model-catalog-owner.js";
 import {
   createPreparedModelCatalogWorker,
   createPreparedModelCatalogWorkerInput,
 } from "./prepared-model-catalog-worker.js";
+import {
+  PROVIDER_ID,
+  HARNESS_ID,
+  SHARED_AUTH_PROVIDER_ID,
+  PLUGIN_ID,
+  PROFILE_ID,
+  MATERIALIZED_SECRET,
+  UNRELATED_SECRET,
+  REF_ONLY_API_PROVIDER_ID,
+  REF_ONLY_API_ENV,
+  REF_ONLY_TOKEN_PROVIDER_ID,
+  REF_ONLY_TOKEN_ENV,
+  DURABLE_AUTH_PROVIDER_ID,
+  DURABLE_AUTH_KEY,
+  EXTERNAL_AUTH_PROFILE_ID,
+  EXTERNAL_AUTH_PATH_ENV,
+  writeFixturePlugin,
+} from "./prepared-model-catalog-worker.test-support.js";
 import {
   getPreparedModelFullCatalogAuth,
   getPreparedModelRuntimeAuthStore,
@@ -42,27 +63,8 @@ import {
 } from "./prepared-model-runtime.js";
 import { resetPreparedModelRuntimeSnapshotsForTest } from "./prepared-model-runtime.test-support.js";
 import { AuthStorage } from "./sessions/auth-storage.js";
-import {
-  markPluginMetadataSnapshotProvided,
-  writeSyntheticAuthDiscoveryFixture,
-} from "./test-helpers/prepared-model-catalog-worker-fixture.js";
+import { markPluginMetadataSnapshotProvided } from "./test-helpers/prepared-model-catalog-worker-fixture.js";
 
-const PROVIDER_ID = "worker-catalog-fixture";
-const HARNESS_ID = "worker-catalog-fixture-harness";
-const UNRELATED_SYNTHETIC_AUTH_ID = `${PROVIDER_ID}-unrelated-harness`;
-const SHARED_AUTH_PROVIDER_ID = `${PROVIDER_ID}-shared-auth`;
-const PLUGIN_ID = "worker-catalog-fixture";
-const PROFILE_ID = `${SHARED_AUTH_PROVIDER_ID}:named`;
-const MATERIALIZED_SECRET = "materialized-worker-secret-not-real";
-const UNRELATED_SECRET = "unrelated-worker-secret-not-real";
-const REF_ONLY_API_PROVIDER_ID = `${PROVIDER_ID}-ref-api`;
-const REF_ONLY_API_ENV = "OPENCLAW_WORKER_REF_ONLY_API_KEY";
-const REF_ONLY_TOKEN_PROVIDER_ID = `${PROVIDER_ID}-ref-token`;
-const REF_ONLY_TOKEN_ENV = "OPENCLAW_WORKER_REF_ONLY_TOKEN";
-const DURABLE_AUTH_PROVIDER_ID = `${PROVIDER_ID}-durable-auth`;
-const DURABLE_AUTH_KEY = "post-startup-durable-key-not-real";
-const EXTERNAL_AUTH_PROFILE_ID = `${PROVIDER_ID}:external`;
-const EXTERNAL_AUTH_PATH_ENV = "OPENCLAW_WORKER_EXTERNAL_AUTH_PATH";
 const tempDirs = useAutoCleanupTempDirTracker((cleanup) => {
   afterEach(() => {
     resetPreparedModelRuntimeSnapshotsForTest();
@@ -94,138 +96,6 @@ function writeCodexAuth(codexHome: string, marker: string): void {
   );
   const future = new Date(Date.now() + 2_000);
   fs.utimesSync(authPath, future, future);
-}
-
-function writeFixturePlugin(params: {
-  root: string;
-  spinMs: number;
-  pluginVersion?: string;
-}): string {
-  const pluginDir = path.join(params.root, "plugin");
-  fs.mkdirSync(pluginDir, { recursive: true });
-  const pluginFile = path.join(pluginDir, "index.cjs");
-  writeSyntheticAuthDiscoveryFixture({
-    root: params.root,
-    pluginDir,
-    harnessId: HARNESS_ID,
-    unrelatedId: UNRELATED_SYNTHETIC_AUTH_ID,
-  });
-  fs.writeFileSync(
-    pluginFile,
-    `const fs = require("node:fs");
-module.exports = {
-  id: ${JSON.stringify(PLUGIN_ID)},
-  register(api) {
-    api.registerAgentHarness({
-      id: ${JSON.stringify(HARNESS_ID)},
-      label: "Worker catalog fixture harness",
-      supports: () => ({ supported: true }),
-      runAttempt: async () => ({ ok: false, error: "unused" }),
-      loadModelCatalog: async () => [{
-        provider: ${JSON.stringify(PROVIDER_ID)},
-        id: "account-scoped-model",
-        name: "Account scoped model",
-        api: "openai-completions",
-        baseUrl: "https://worker-catalog.invalid/v1",
-      }],
-    });
-    api.registerProvider({
-      id: ${JSON.stringify(PROVIDER_ID)},
-      label: "Worker catalog fixture",
-      auth: [],
-      resolveExternalAuthProfiles() {
-        const credentialPath = process.env[${JSON.stringify(EXTERNAL_AUTH_PATH_ENV)}];
-        if (!credentialPath || !fs.existsSync(credentialPath)) {
-          return [];
-        }
-        const credentialMarker = fs.readFileSync(credentialPath, "utf8").trim();
-        return [{
-          profileId: ${JSON.stringify(EXTERNAL_AUTH_PROFILE_ID)},
-          credential: {
-            type: "oauth",
-            provider: ${JSON.stringify(PROVIDER_ID)},
-            access: ${JSON.stringify(params.pluginVersion ?? "v1")} + ":" + credentialMarker,
-            refresh: "refresh-" + credentialMarker + "-not-real",
-            expires: Date.now() + 60_000,
-          },
-        }];
-      },
-      catalog: {
-        run(context) {
-          const refOnlyApi = context.resolveProviderApiKey(${JSON.stringify(REF_ONLY_API_PROVIDER_ID)}).apiKey;
-          const refOnlyToken = context.resolveProviderApiKey(${JSON.stringify(REF_ONLY_TOKEN_PROVIDER_ID)}).apiKey;
-          const durableAuth = context.resolveProviderApiKey(${JSON.stringify(DURABLE_AUTH_PROVIDER_ID)}).apiKey;
-          const hasRefOnlyApi = refOnlyApi === ${JSON.stringify(REF_ONLY_API_ENV)} || refOnlyApi === process.env[${JSON.stringify(REF_ONLY_API_ENV)}];
-          const hasRefOnlyToken = refOnlyToken === ${JSON.stringify(REF_ONLY_TOKEN_ENV)} || refOnlyToken === process.env[${JSON.stringify(REF_ONLY_TOKEN_ENV)}];
-          return { provider: {
-            baseUrl: "https://worker-catalog.invalid/v1",
-            api: "openai-completions",
-            models: [
-              { id: "sqlite-model", name: "SQLite model" },
-              {
-                id: ${JSON.stringify(`plugin-generation-${params.pluginVersion ?? "v1"}`)},
-                name: "Plugin generation proof",
-              },
-              {
-                id: \`ref-proof-api-\${hasRefOnlyApi}-token-\${hasRefOnlyToken}\`,
-                name: "Ref-only worker proof",
-              },
-              ...(durableAuth === ${JSON.stringify(DURABLE_AUTH_KEY)}
-                ? [{ id: "post-startup-auth-model", name: "Post-startup auth model" }]
-                : []),
-            ],
-          } };
-        },
-      },
-      async augmentModelCatalog(context) {
-        const marker = process.env.OPENCLAW_WORKER_CATALOG_MARKER;
-        const invocation = fs.existsSync(marker)
-          ? fs.readFileSync(marker, "utf8").split("start\\n").length
-          : 1;
-        fs.appendFileSync(process.env.OPENCLAW_WORKER_CATALOG_MARKER, "start\\n");
-        const barrier = marker + ".hold";
-        if (fs.existsSync(barrier)) {
-          await new Promise((resolve) => {
-            const watcher = fs.watch(require("node:path").dirname(barrier), () => {
-              if (!fs.existsSync(barrier)) { watcher.close(); resolve(); }
-            });
-            if (!fs.existsSync(barrier)) { watcher.close(); resolve(); }
-          });
-        }
-        const until = Date.now() + ${params.spinMs};
-        while (Date.now() < until) {}
-        const hasSqlite = context.entries.some((entry) =>
-          entry.provider === ${JSON.stringify(PROVIDER_ID)} && entry.id === "sqlite-model");
-        const hasShared = context.resolveProviderApiKey(${JSON.stringify(SHARED_AUTH_PROVIDER_ID)}).apiKey === ${JSON.stringify(MATERIALIZED_SECRET)};
-        const hasUnrelated = context.resolveProviderApiKey("unrelated-provider").apiKey === ${JSON.stringify(UNRELATED_SECRET)};
-        fs.appendFileSync(process.env.OPENCLAW_WORKER_CATALOG_MARKER, "done\\n");
-        return [{
-          provider: ${JSON.stringify(PROVIDER_ID)},
-          id: \`proof-refresh-\${invocation}-sqlite-\${hasSqlite}-shared-\${hasShared}-unrelated-\${hasUnrelated}\`,
-          name: "Worker boundary proof",
-        }];
-      },
-    });
-  },
-};
-`,
-    "utf8",
-  );
-  fs.writeFileSync(
-    path.join(pluginDir, "openclaw.plugin.json"),
-    JSON.stringify({
-      id: PLUGIN_ID,
-      providers: [PROVIDER_ID],
-      cliBackends: [HARNESS_ID, UNRELATED_SYNTHETIC_AUTH_ID],
-      syntheticAuthRefs: [HARNESS_ID, UNRELATED_SYNTHETIC_AUTH_ID],
-      providerCatalogEntry: "./provider-discovery.cjs",
-      configSchema: { type: "object", additionalProperties: false, properties: {} },
-      contracts: { externalAuthProviders: [PROVIDER_ID] },
-      modelCatalog: { discovery: { [PROVIDER_ID]: "runtime" }, runtimeAugment: true },
-    }),
-    "utf8",
-  );
-  return pluginFile;
 }
 
 function createCatalogFixture(
@@ -332,6 +202,14 @@ async function createStaticSnapshot(
 ) {
   const fixture = createCatalogFixture(spinMs, envOverride, options);
   const { agentDir, workspaceDir, config, env, root } = fixture;
+  const input = {
+    agentId: "main",
+    agentDir,
+    inheritedAuthDir: agentDir,
+    workspaceDir,
+    config,
+    env,
+  };
   let current = true;
   const loadedMetadataSnapshot = options?.metadataWorkspace
     ? loadPluginMetadataSnapshot({
@@ -350,13 +228,14 @@ async function createStaticSnapshot(
       ? markPluginMetadataSnapshotProvided(loadedMetadataSnapshot)
       : loadedMetadataSnapshot;
   const build = await startSerializedSnapshotBuild(
-    { agentId: "main", agentDir, inheritedAuthDir: agentDir, workspaceDir, config, env },
+    {
+      input,
+      catalogOwner: preparePublishedModelCatalogOwnerIdentity(input),
+      isGenerationCurrent: () => current,
+    },
     new Map(),
     30_000,
     "static",
-    () => current,
-    false,
-    undefined,
     providedMetadataSnapshot,
   ).pending;
   return {
@@ -381,6 +260,87 @@ async function waitForMarker(marker: string): Promise<void> {
 }
 
 describe("prepared model catalog worker boundary", () => {
+  beforeEach(() => {
+    vi.stubEnv("CODEX_HOME", tempDirs.make("openclaw-worker-empty-codex-"));
+  });
+
+  it("preserves prepared catalog ownership across ambient environment changes", async () => {
+    const homeA = tempDirs.make("openclaw-catalog-owner-home-a-");
+    const homeB = tempDirs.make("openclaw-catalog-owner-home-b-");
+    const codexHome = tempDirs.make("openclaw-catalog-owner-empty-codex-");
+    vi.stubEnv("HOME", homeA);
+    vi.stubEnv("OPENCLAW_HOME", homeA);
+    vi.stubEnv("CODEX_HOME", codexHome);
+    const fixture = createCatalogFixture(0);
+    vi.stubEnv("OPENCLAW_STATE_DIR", fixture.env.OPENCLAW_STATE_DIR);
+    const config = {
+      ...fixture.config,
+      agents: { ...fixture.config.agents, entries: { main: {} } },
+    } satisfies OpenClawConfig;
+    const agentDir = resolveAgentDir(config, "main", fixture.env);
+    const workspaceDir = resolveAgentWorkspaceDir(config, "main", fixture.env);
+    expect(agentDir).toBe(fixture.agentDir);
+    const input = {
+      agentId: "main",
+      agentDir,
+      inheritedAuthDir: agentDir,
+      config,
+      env: fixture.env,
+    };
+    let current = true;
+    const build = startSerializedSnapshotBuild(
+      {
+        input,
+        catalogOwner: preparePublishedModelCatalogOwnerIdentity(input),
+        isGenerationCurrent: () => current,
+      },
+      new Map(),
+      30_000,
+      "static",
+    );
+    let snapshot: Awaited<typeof build.pending>["snapshot"] | undefined;
+    let driftedAgentDir: string | undefined;
+    try {
+      snapshot = (await build.pending).snapshot;
+      const modelCatalog = await snapshot.loadFullModelCatalog!();
+      expect(modelCatalog.entries).toContainEqual(
+        expect.objectContaining({ provider: PROVIDER_ID, id: "plugin-generation-v1" }),
+      );
+      const auth = getPreparedModelFullCatalogAuth(modelCatalog)!;
+      const candidate = { ...snapshot, ...auth, modelCatalog };
+      const project = () =>
+        loadPreparedGatewayModelCatalogSnapshot({
+          getConfig: () => config,
+          loadPublishedPreparedModelCatalogOwnerSnapshot: async () => candidate,
+        });
+      const expectedOwner = { agentId: "main", agentDir, workspaceDir, catalogComplete: true };
+      await expect(project()).resolves.toMatchObject(expectedOwner);
+
+      vi.stubEnv("HOME", homeB);
+      vi.stubEnv("OPENCLAW_HOME", homeB);
+      vi.stubEnv("OPENCLAW_STATE_DIR", path.join(homeB, "state"));
+      driftedAgentDir = resolveAgentDir(config, "main");
+      expect(driftedAgentDir).not.toBe(agentDir);
+      expect(resolveAgentWorkspaceDir(config, "main")).not.toBe(workspaceDir);
+      await expect(project()).resolves.toMatchObject(expectedOwner);
+    } finally {
+      current = false;
+      await build.completion;
+      if (snapshot) {
+        // Requesting after retirement also closes the fixture worker immediately.
+        await Promise.allSettled([loadPreparedModelRuntimeAuth(snapshot, { providerIds: [] })]);
+      }
+      resetPreparedModelRuntimeSnapshotsForTest();
+      clearRuntimeAuthProfileStoreSnapshots();
+      closeOpenClawAgentDatabasesForTest();
+      unregisterResolvedAgentDir({ agentId: "main", agentDir, env: fixture.env });
+      if (driftedAgentDir) {
+        unregisterResolvedAgentDir({ agentId: "main", agentDir: driftedAgentDir });
+      }
+      vi.unstubAllEnvs();
+    }
+  });
+
   it("keeps an unaffected configured worker live across a scoped sibling reload", async () => {
     const fixture = createCatalogFixture(0);
     // Configured publication reads the process environment; keep both the parent and worker

--- a/src/agents/prepared-model-catalog-worker.test-support.ts
+++ b/src/agents/prepared-model-catalog-worker.test-support.ts
@@ -1,0 +1,152 @@
+import fs from "node:fs";
+import path from "node:path";
+import { writeSyntheticAuthDiscoveryFixture } from "./test-helpers/prepared-model-catalog-worker-fixture.js";
+
+export const PROVIDER_ID = "worker-catalog-fixture";
+export const HARNESS_ID = "worker-catalog-fixture-harness";
+const UNRELATED_SYNTHETIC_AUTH_ID = `${PROVIDER_ID}-unrelated-harness`;
+export const SHARED_AUTH_PROVIDER_ID = `${PROVIDER_ID}-shared-auth`;
+export const PLUGIN_ID = "worker-catalog-fixture";
+export const PROFILE_ID = `${SHARED_AUTH_PROVIDER_ID}:named`;
+export const MATERIALIZED_SECRET = "materialized-worker-secret-not-real";
+export const UNRELATED_SECRET = "unrelated-worker-secret-not-real";
+export const REF_ONLY_API_PROVIDER_ID = `${PROVIDER_ID}-ref-api`;
+export const REF_ONLY_API_ENV = "OPENCLAW_WORKER_REF_ONLY_API_KEY";
+export const REF_ONLY_TOKEN_PROVIDER_ID = `${PROVIDER_ID}-ref-token`;
+export const REF_ONLY_TOKEN_ENV = "OPENCLAW_WORKER_REF_ONLY_TOKEN";
+export const DURABLE_AUTH_PROVIDER_ID = `${PROVIDER_ID}-durable-auth`;
+export const DURABLE_AUTH_KEY = "post-startup-durable-key-not-real";
+export const EXTERNAL_AUTH_PROFILE_ID = `${PROVIDER_ID}:external`;
+export const EXTERNAL_AUTH_PATH_ENV = "OPENCLAW_WORKER_EXTERNAL_AUTH_PATH";
+
+export function writeFixturePlugin(params: {
+  root: string;
+  spinMs: number;
+  pluginVersion?: string;
+}): string {
+  const pluginDir = path.join(params.root, "plugin");
+  fs.mkdirSync(pluginDir, { recursive: true });
+  const pluginFile = path.join(pluginDir, "index.cjs");
+  writeSyntheticAuthDiscoveryFixture({
+    root: params.root,
+    pluginDir,
+    harnessId: HARNESS_ID,
+    unrelatedId: UNRELATED_SYNTHETIC_AUTH_ID,
+  });
+  fs.writeFileSync(
+    pluginFile,
+    `const fs = require("node:fs");
+module.exports = {
+  id: ${JSON.stringify(PLUGIN_ID)},
+  register(api) {
+    api.registerAgentHarness({
+      id: ${JSON.stringify(HARNESS_ID)},
+      label: "Worker catalog fixture harness",
+      supports: () => ({ supported: true }),
+      runAttempt: async () => ({ ok: false, error: "unused" }),
+      loadModelCatalog: async () => [{
+        provider: ${JSON.stringify(PROVIDER_ID)},
+        id: "account-scoped-model",
+        name: "Account scoped model",
+        api: "openai-completions",
+        baseUrl: "https://worker-catalog.invalid/v1",
+      }],
+    });
+    api.registerProvider({
+      id: ${JSON.stringify(PROVIDER_ID)},
+      label: "Worker catalog fixture",
+      auth: [],
+      resolveExternalAuthProfiles() {
+        const credentialPath = process.env[${JSON.stringify(EXTERNAL_AUTH_PATH_ENV)}];
+        if (!credentialPath || !fs.existsSync(credentialPath)) {
+          return [];
+        }
+        const credentialMarker = fs.readFileSync(credentialPath, "utf8").trim();
+        return [{
+          profileId: ${JSON.stringify(EXTERNAL_AUTH_PROFILE_ID)},
+          credential: {
+            type: "oauth",
+            provider: ${JSON.stringify(PROVIDER_ID)},
+            access: ${JSON.stringify(params.pluginVersion ?? "v1")} + ":" + credentialMarker,
+            refresh: "refresh-" + credentialMarker + "-not-real",
+            expires: Date.now() + 60_000,
+          },
+        }];
+      },
+      catalog: {
+        run(context) {
+          const refOnlyApi = context.resolveProviderApiKey(${JSON.stringify(REF_ONLY_API_PROVIDER_ID)}).apiKey;
+          const refOnlyToken = context.resolveProviderApiKey(${JSON.stringify(REF_ONLY_TOKEN_PROVIDER_ID)}).apiKey;
+          const durableAuth = context.resolveProviderApiKey(${JSON.stringify(DURABLE_AUTH_PROVIDER_ID)}).apiKey;
+          const hasRefOnlyApi = refOnlyApi === ${JSON.stringify(REF_ONLY_API_ENV)} || refOnlyApi === process.env[${JSON.stringify(REF_ONLY_API_ENV)}];
+          const hasRefOnlyToken = refOnlyToken === ${JSON.stringify(REF_ONLY_TOKEN_ENV)} || refOnlyToken === process.env[${JSON.stringify(REF_ONLY_TOKEN_ENV)}];
+          return { provider: {
+            baseUrl: "https://worker-catalog.invalid/v1",
+            api: "openai-completions",
+            models: [
+              { id: "sqlite-model", name: "SQLite model" },
+              {
+                id: ${JSON.stringify(`plugin-generation-${params.pluginVersion ?? "v1"}`)},
+                name: "Plugin generation proof",
+              },
+              {
+                id: \`ref-proof-api-\${hasRefOnlyApi}-token-\${hasRefOnlyToken}\`,
+                name: "Ref-only worker proof",
+              },
+              ...(durableAuth === ${JSON.stringify(DURABLE_AUTH_KEY)}
+                ? [{ id: "post-startup-auth-model", name: "Post-startup auth model" }]
+                : []),
+            ],
+          } };
+        },
+      },
+      async augmentModelCatalog(context) {
+        const marker = process.env.OPENCLAW_WORKER_CATALOG_MARKER;
+        const invocation = fs.existsSync(marker)
+          ? fs.readFileSync(marker, "utf8").split("start\\n").length
+          : 1;
+        fs.appendFileSync(process.env.OPENCLAW_WORKER_CATALOG_MARKER, "start\\n");
+        const barrier = marker + ".hold";
+        if (fs.existsSync(barrier)) {
+          await new Promise((resolve) => {
+            const watcher = fs.watch(require("node:path").dirname(barrier), () => {
+              if (!fs.existsSync(barrier)) { watcher.close(); resolve(); }
+            });
+            if (!fs.existsSync(barrier)) { watcher.close(); resolve(); }
+          });
+        }
+        const until = Date.now() + ${params.spinMs};
+        while (Date.now() < until) {}
+        const hasSqlite = context.entries.some((entry) =>
+          entry.provider === ${JSON.stringify(PROVIDER_ID)} && entry.id === "sqlite-model");
+        const hasShared = context.resolveProviderApiKey(${JSON.stringify(SHARED_AUTH_PROVIDER_ID)}).apiKey === ${JSON.stringify(MATERIALIZED_SECRET)};
+        const hasUnrelated = context.resolveProviderApiKey("unrelated-provider").apiKey === ${JSON.stringify(UNRELATED_SECRET)};
+        fs.appendFileSync(process.env.OPENCLAW_WORKER_CATALOG_MARKER, "done\\n");
+        return [{
+          provider: ${JSON.stringify(PROVIDER_ID)},
+          id: \`proof-refresh-\${invocation}-sqlite-\${hasSqlite}-shared-\${hasShared}-unrelated-\${hasUnrelated}\`,
+          name: "Worker boundary proof",
+        }];
+      },
+    });
+  },
+};
+`,
+    "utf8",
+  );
+  fs.writeFileSync(
+    path.join(pluginDir, "openclaw.plugin.json"),
+    JSON.stringify({
+      id: PLUGIN_ID,
+      providers: [PROVIDER_ID],
+      cliBackends: [HARNESS_ID, UNRELATED_SYNTHETIC_AUTH_ID],
+      syntheticAuthRefs: [HARNESS_ID, UNRELATED_SYNTHETIC_AUTH_ID],
+      providerCatalogEntry: "./provider-discovery.cjs",
+      configSchema: { type: "object", additionalProperties: false, properties: {} },
+      contracts: { externalAuthProviders: [PROVIDER_ID] },
+      modelCatalog: { discovery: { [PROVIDER_ID]: "runtime" }, runtimeAugment: true },
+    }),
+    "utf8",
+  );
+  return pluginFile;
+}

--- a/src/agents/prepared-model-catalog.test.ts
+++ b/src/agents/prepared-model-catalog.test.ts
@@ -20,9 +20,14 @@ vi.mock("../config/config.js", () => ({
 
 vi.mock("./agent-scope.js", () => ({
   listAgentIds: () => mocks.agentIds,
-  resolveAgentDir: (_config: object, agentId: string) =>
-    mocks.agentDirs.get(agentId) ?? "/tmp/prepared-model-catalog-agent",
-  resolveAgentWorkspaceDir: () => "/tmp/prepared-model-catalog-workspace",
+  resolveAgentDir: (_config: object, agentId: string, env?: NodeJS.ProcessEnv) =>
+    env?.OPENCLAW_STATE_DIR
+      ? `${env.OPENCLAW_STATE_DIR}/${agentId}`
+      : (mocks.agentDirs.get(agentId) ?? "/tmp/prepared-model-catalog-agent"),
+  resolveAgentWorkspaceDir: (_config: object, agentId: string, env?: NodeJS.ProcessEnv) =>
+    env?.OPENCLAW_STATE_DIR
+      ? `${env.OPENCLAW_STATE_DIR}/workspace-${agentId}`
+      : "/tmp/prepared-model-catalog-workspace",
   resolveAmbientOwnerAgentId: () => "main",
   resolveDefaultAgentDir: () => "/tmp/prepared-model-catalog-agent",
   resolveDefaultAgentId: () => "main",
@@ -77,6 +82,7 @@ import { PreparedModelRuntimeOwnerNotPublishedError } from "./prepared-model-run
 
 const fullSnapshot = {
   config: mocks.config,
+  catalogOwner: { agentId: "main", workspaceDir: "/tmp/prepared-model-catalog-workspace" },
   authModes: {},
   authStore: { version: 1, profiles: {} },
   metadataSnapshot: { index: { plugins: [] }, plugins: [] },
@@ -102,6 +108,28 @@ describe("prepared model catalog access", () => {
     mocks.prepareScopedCatalog.mockReset();
     mocks.isFullCatalog.mockReset();
     mocks.releaseSnapshot.mockReset();
+  });
+
+  it("uses the requested environment for directory selection and workspace activation", async () => {
+    mocks.agentIds = ["main", "worker"];
+    const env = { OPENCLAW_STATE_DIR: "/tmp/selected-catalog-state" };
+    mocks.prepareSnapshot.mockRejectedValue(new PreparedModelRuntimeOwnerNotPublishedError());
+    mocks.loadSnapshot.mockResolvedValue(readOnlySnapshot);
+
+    await expect(
+      loadPreparedModelCatalogSnapshot({
+        agentDir: "/tmp/selected-catalog-state/worker",
+        readOnly: true,
+        env,
+      }),
+    ).resolves.toEqual(readOnlySnapshot.modelCatalog);
+    expect(mocks.loadSnapshot).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agentId: "worker",
+        workspaceDir: "/tmp/selected-catalog-state/workspace-worker",
+        env,
+      }),
+    );
   });
 
   it("does not return a full nonblocking generation from another config", () => {
@@ -302,6 +330,7 @@ describe("prepared model catalog access", () => {
     await expect(
       loadResolvedPublishedModelCatalogOwner({ agentId: "MAIN", readOnly: true }),
     ).resolves.toEqual({
+      catalogOwner: fullSnapshot.catalogOwner,
       agentId: "main",
       agentDir: "/tmp/prepared-model-catalog-agent",
       workspaceDir: "/tmp/prepared-model-catalog-workspace",
@@ -320,6 +349,7 @@ describe("prepared model catalog access", () => {
     const committedSnapshot = {
       ...fullSnapshot,
       agentDir: "/tmp/shared-agent-dir",
+      catalogOwner: undefined,
       config: { agents: { list: [{ id: "main", default: true }, { id: "worker" }] } },
     };
     mocks.prepareSnapshot.mockResolvedValue(committedSnapshot);

--- a/src/agents/prepared-model-catalog.ts
+++ b/src/agents/prepared-model-catalog.ts
@@ -123,16 +123,17 @@ function resolveInputs(params: LoadPreparedModelCatalogParams = {}): {
   const agentDir =
     params.agentDir ?? resolveAgentDir(config, explicitOrDefaultAgentId as string, params.env);
   const matchingAgentIds =
-    params.agentDir === undefined
+    explicitOrDefaultAgentId !== undefined
       ? []
       : listAgentIds(config).filter(
-          (candidateAgentId) => resolveAgentDir(config, candidateAgentId) === agentDir,
+          (candidateAgentId) => resolveAgentDir(config, candidateAgentId, params.env) === agentDir,
         );
   const agentId =
     explicitOrDefaultAgentId ?? (matchingAgentIds.length === 1 ? matchingAgentIds[0] : undefined);
   const explicitWorkspaceDir = params.workspaceDir === undefined ? undefined : params.workspaceDir;
   const activationWorkspaceDir =
-    explicitWorkspaceDir ?? (agentId ? resolveAgentWorkspaceDir(config, agentId) : undefined);
+    explicitWorkspaceDir ??
+    (agentId ? resolveAgentWorkspaceDir(config, agentId, params.env) : undefined);
   const full: PreparedModelRuntimeInput = {
     ...(agentId ? { agentId } : {}),
     agentDir,

--- a/src/agents/prepared-model-catalog.types.ts
+++ b/src/agents/prepared-model-catalog.types.ts
@@ -5,6 +5,8 @@ import type { AuthProfileStore } from "./auth-profiles/types.js";
 import type { ModelCatalogSnapshot } from "./model-catalog.types.js";
 
 export type PublishedModelCatalogOwnerCandidate = Readonly<{
+  /** Captured during preparation; undefined is a known-unbound runtime. */
+  catalogOwner: Readonly<{ agentId: string; workspaceDir: string }> | undefined;
   agentId?: string;
   agentDir: string;
   workspaceDir?: string;
@@ -16,6 +18,7 @@ export type PublishedModelCatalogOwnerCandidate = Readonly<{
 }>;
 
 export type ResolvedPublishedModelCatalogOwner = Readonly<{
+  catalogOwner: NonNullable<PublishedModelCatalogOwnerCandidate["catalogOwner"]>;
   agentId: string;
   agentDir: string;
   workspaceDir: string;

--- a/src/agents/prepared-model-runtime-config-stamp.test.ts
+++ b/src/agents/prepared-model-runtime-config-stamp.test.ts
@@ -6,6 +6,7 @@ import {
 } from "./prepared-model-runtime.test-harness.js";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createDeferred } from "../../test/helpers/promise.js";
+import { resolvePublishedModelCatalogOwner } from "./prepared-model-catalog-owner.js";
 import {
   getPreparedModelRuntimeAuthMaterializations,
   getPreparedModelRuntimeAuthStore,
@@ -52,6 +53,7 @@ describe("prepared model runtime config stamps", () => {
     setPreparedModelRuntimeAuthMaterializations(existingReader, materializations);
     const authStore = getPreparedModelRuntimeAuthStore(existingReader);
     const loadedAuth = await loadPreparedModelRuntimeAuth(existingReader, { providerIds: [] });
+    mocks.configuredAgentDirs.set("default", "/tmp/later-agent");
 
     advancePreparedModelRuntimeConfig(nextConfig);
 
@@ -59,6 +61,11 @@ describe("prepared model runtime config stamps", () => {
     expect(advanced).not.toBe(existingReader);
     expect(advanced.config).toBe(nextConfig);
     expect(existingReader.config).toBe(initialConfig);
+    expect(resolvePublishedModelCatalogOwner(advanced)).toMatchObject({
+      agentId: "default",
+      workspaceDir: "/tmp/unused-workspace",
+      config: nextConfig,
+    });
     expect(getPreparedModelRuntimeAuthStore(advanced)).toBe(authStore);
     expect(getPreparedModelRuntimeAuthMaterializations(advanced)).toBe(materializations);
     await expect(loadPreparedModelRuntimeAuth(advanced, { providerIds: [] })).resolves.toEqual(
@@ -175,17 +182,21 @@ describe("prepared model runtime config stamps", () => {
 
     mocks.mutationListener?.({ affectsInheritedStores: true });
     await vi.waitFor(() => expect(finishAuthRefresh).toBeDefined());
+    mocks.configuredAgentDirs.set("default", "/tmp/later-agent");
     advancePreparedModelRuntimeConfig(nextConfig);
     finishAuthRefresh?.();
 
-    await expect(
-      prepareModelRuntimeSnapshot({
-        agentId: "default",
-        agentDir: "/tmp/unused-agent",
-        inheritedAuthDir: "/tmp/unused-agent",
-        config: nextConfig,
-      }),
-    ).resolves.toMatchObject({ config: nextConfig });
+    const snapshot = await prepareModelRuntimeSnapshot({
+      agentId: "default",
+      agentDir: "/tmp/unused-agent",
+      inheritedAuthDir: "/tmp/unused-agent",
+      config: nextConfig,
+    });
+    expect(resolvePublishedModelCatalogOwner(snapshot)).toMatchObject({
+      agentId: "default",
+      workspaceDir: "/tmp/unused-workspace",
+      config: nextConfig,
+    });
     expect(mocks.ensureOpenClawModelsJson).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/agents/prepared-model-runtime-materializations.test.ts
+++ b/src/agents/prepared-model-runtime-materializations.test.ts
@@ -16,6 +16,7 @@ function createOwner(params: {
   needsRefresh?: boolean;
 }): PreparedModelRuntimeOwner {
   const snapshot = {
+    catalogOwner: undefined,
     agentId: params.agentId,
     agentDir: params.agentDir,
     config: {},
@@ -29,6 +30,7 @@ function createOwner(params: {
     createStores: () => ({ authStorage: { getAll: () => ({}) }, modelRegistry: {} }),
   } as unknown as PreparedModelRuntimeSnapshot;
   return {
+    catalogOwner: undefined,
     input: { agentId: params.agentId, agentDir: params.agentDir, config: {} },
     environmentFingerprint: "test-env",
     catalogMode: "static",

--- a/src/agents/prepared-model-runtime.build.ts
+++ b/src/agents/prepared-model-runtime.build.ts
@@ -56,9 +56,16 @@ type PreparedModelRuntimeCatalogAccess = Readonly<{
   loadFullModelCatalog: (options?: { refresh?: boolean }) => Promise<ModelCatalogSnapshot>;
   loadAuth: (scope: PreparedModelRuntimeAuthScope) => Promise<PreparedModelRuntimeAuth>;
 }>;
-type PreparedModelRuntimeBuildGuards =
-  | ReadonlyMap<PreparedModelRuntimeInput, () => boolean>
-  | (() => boolean);
+export type PreparedModelRuntimeBuildCandidate = Readonly<{
+  input: PreparedModelRuntimeInput;
+  catalogOwner: PreparedModelRuntimeSnapshot["catalogOwner"];
+  pluginGeneration?: PreparedModelRuntimePluginGeneration;
+  prepareInboundPluginRegistry?: boolean;
+  isGenerationCurrent?: () => boolean;
+  isBuildCurrent?: () => boolean;
+  /** Shared publication guards run before workspace preparation; registration guards do not. */
+  isPreparationCurrent?: () => boolean;
+}>;
 
 export type PreparedModelRuntimeBuildResult = Readonly<{
   snapshot: PreparedModelRuntimeSnapshot;
@@ -101,9 +108,8 @@ function runSerializedPreparedModelRuntimeTask<T>(params: {
 
 function assertPreparedModelRuntimeInputCurrent(
   input: PreparedModelRuntimeInput,
-  guards: PreparedModelRuntimeBuildGuards,
+  isCurrent: (() => boolean) | undefined,
 ): void {
-  const isCurrent = typeof guards === "function" ? guards : guards.get(input);
   if (isCurrent && !isCurrent()) {
     throw new PreparedModelRuntimePublicationSupersededError(
       `prepared model runtime publication was superseded for ${input.agentDir}`,
@@ -111,12 +117,11 @@ function assertPreparedModelRuntimeInputCurrent(
   }
 }
 
-function assertPreparedModelRuntimeInputsCurrent(
-  inputs: readonly PreparedModelRuntimeInput[],
-  guards: PreparedModelRuntimeBuildGuards,
+function assertPreparedModelRuntimeCandidatesCurrent(
+  candidates: readonly PreparedModelRuntimeBuildCandidate[],
 ): void {
-  for (const input of inputs) {
-    assertPreparedModelRuntimeInputCurrent(input, guards);
+  for (const candidate of candidates) {
+    assertPreparedModelRuntimeInputCurrent(candidate.input, candidate.isBuildCurrent);
   }
 }
 
@@ -228,6 +233,7 @@ function createFullModelCatalogAccess(params: {
 }
 
 function createSnapshot(
+  catalogOwner: PreparedModelRuntimeSnapshot["catalogOwner"],
   agentFacts: PreparedModelRuntimeAgentFacts,
   pluginGeneration: PreparedModelRuntimePluginGeneration,
   catalogFacts: PreparedModelRuntimeCatalogFacts,
@@ -245,6 +251,7 @@ function createSnapshot(
     return { authStorage, modelRegistry: templateModelRegistry.fork(authStorage) };
   };
   const snapshot: PreparedModelRuntimeSnapshot = Object.freeze({
+    catalogOwner,
     ...(input.agentId ? { agentId: input.agentId } : {}),
     agentDir: input.agentDir,
     activeProjectKeys: [],
@@ -274,53 +281,46 @@ function createSnapshot(
 }
 
 async function buildSnapshotBatch(
-  inputs: readonly PreparedModelRuntimeInput[],
+  candidates: readonly PreparedModelRuntimeBuildCandidate[],
   catalogMode: PreparedModelRuntimeCatalogMode,
   agentBuildCompletions: Map<string, Promise<void>>,
-  generationGuards: ReadonlyMap<PreparedModelRuntimeInput, () => boolean>,
-  buildGuards: PreparedModelRuntimeBuildGuards,
-  inboundPluginRegistryInputs: ReadonlySet<PreparedModelRuntimeInput>,
-  reusablePluginGenerations: ReadonlyMap<
-    PreparedModelRuntimeInput,
-    PreparedModelRuntimePluginGeneration
-  >,
   pluginMetadataSnapshot?: PreparedModelRuntimePluginGeneration["pluginMetadataSnapshot"],
   onBuildStats?: (stats: PreparedModelRuntimeBuildStats) => void,
 ): Promise<PreparedModelRuntimeBuildResult[]> {
-  const freshGroups = new Map<string, PreparedModelRuntimeInput[]>();
+  const freshGroups = new Map<string, PreparedModelRuntimeBuildCandidate[]>();
   const reusableGroups = new Map<
     PreparedModelRuntimePluginGeneration,
-    PreparedModelRuntimeInput[]
+    PreparedModelRuntimeBuildCandidate[]
   >();
-  for (const input of inputs) {
-    const reusablePluginGeneration = reusablePluginGenerations.get(input);
+  for (const candidate of candidates) {
+    const { input, pluginGeneration: reusablePluginGeneration } = candidate;
     if (reusablePluginGeneration) {
       const group = reusableGroups.get(reusablePluginGeneration);
       if (group) {
-        group.push(input);
+        group.push(candidate);
       } else {
-        reusableGroups.set(reusablePluginGeneration, [input]);
+        reusableGroups.set(reusablePluginGeneration, [candidate]);
       }
       continue;
     }
-    const ownerKind = inboundPluginRegistryInputs.has(input) ? "configured" : "dynamic";
+    const ownerKind = candidate.prepareInboundPluginRegistry ? "configured" : "dynamic";
     const key = `${ownerKind}\0${preparedModelRuntimeWorkspaceFactsKey(input)}`;
     const group = freshGroups.get(key);
     if (group) {
-      group.push(input);
+      group.push(candidate);
     } else {
-      freshGroups.set(key, [input]);
+      freshGroups.set(key, [candidate]);
     }
   }
   const groups: Array<{
-    groupInputs: PreparedModelRuntimeInput[];
+    groupCandidates: PreparedModelRuntimeBuildCandidate[];
     pluginGeneration?: PreparedModelRuntimePluginGeneration;
   }> = [
-    ...[...reusableGroups].map(([pluginGeneration, groupInputs]) => ({
-      groupInputs,
+    ...[...reusableGroups].map(([pluginGeneration, groupCandidates]) => ({
+      groupCandidates,
       pluginGeneration,
     })),
-    ...[...freshGroups.values()].map((groupInputs) => ({ groupInputs })),
+    ...[...freshGroups.values()].map((groupCandidates) => ({ groupCandidates })),
   ];
   const preparedInputs = new Map<PreparedModelRuntimeInput, PreparedModelRuntimeAgentFacts>();
   const pluginGenerations = new Map<
@@ -337,24 +337,24 @@ async function buildSnapshotBatch(
   const workspaceFactsStartedAt = performance.now();
   // Workspace plugin loading and static hooks are intentionally sequential. Large parallel
   // workspace fanout recreates the CPU/RSS spike this generation boundary is meant to contain.
-  for (const { groupInputs, pluginGeneration } of groups) {
-    if (typeof buildGuards === "function") {
-      assertPreparedModelRuntimeInputsCurrent(groupInputs, buildGuards);
+  for (const { groupCandidates, pluginGeneration } of groups) {
+    for (const candidate of groupCandidates) {
+      assertPreparedModelRuntimeInputCurrent(candidate.input, candidate.isPreparationCurrent);
     }
-    const prepareInboundPluginRegistry = groupInputs.some((input) =>
-      inboundPluginRegistryInputs.has(input),
+    const prepareInboundPluginRegistry = groupCandidates.some(
+      (candidate) => candidate.prepareInboundPluginRegistry,
     );
     const preferBuiltPluginArtifacts =
       pluginGeneration?.preferBuiltPluginArtifacts ?? prepareInboundPluginRegistry;
     const prepared = await prepareWorkspaceBuildGroup(
-      groupInputs,
+      groupCandidates.map(({ input }) => input),
       catalogMode,
       { preferBuiltPluginArtifacts },
       prepareInboundPluginRegistry ? loadInboundPluginRegistry : undefined,
       pluginGeneration,
       pluginMetadataSnapshot,
     );
-    assertPreparedModelRuntimeInputsCurrent(groupInputs, buildGuards);
+    assertPreparedModelRuntimeCandidatesCurrent(groupCandidates);
     runtimePluginMs += prepared.buildStats.runtimePluginMs;
     pluginMetadataMs += prepared.buildStats.pluginMetadataMs;
     staticProviderCatalogMs += prepared.buildStats.staticProviderCatalogMs;
@@ -370,13 +370,14 @@ async function buildSnapshotBatch(
   const catalogSourceStartedAt = performance.now();
   const catalogSources = new Map<PreparedModelRuntimeInput, PreparedModelRuntimeCatalogSource>();
   if (catalogMode === "live") {
-    const sourceInputsByAgentDir = new Map<string, PreparedModelRuntimeInput[]>();
-    for (const input of inputs) {
-      const group = sourceInputsByAgentDir.get(input.agentDir);
+    const sourceCandidatesByAgentDir = new Map<string, PreparedModelRuntimeBuildCandidate[]>();
+    for (const candidate of candidates) {
+      const { input } = candidate;
+      const group = sourceCandidatesByAgentDir.get(input.agentDir);
       if (group) {
-        group.push(input);
+        group.push(candidate);
       } else {
-        sourceInputsByAgentDir.set(input.agentDir, [input]);
+        sourceCandidatesByAgentDir.set(input.agentDir, [candidate]);
       }
     }
     const sourceErrors: unknown[] = [];
@@ -386,10 +387,11 @@ async function buildSnapshotBatch(
       onTaskError: (error) => {
         sourceErrors.push(error);
       },
-      tasks: [...sourceInputsByAgentDir.values()].map((sourceInputs) => async () => {
+      tasks: [...sourceCandidatesByAgentDir.values()].map((sourceCandidates) => async () => {
         // Generated catalogs are agent-directory owned. Preserve write serialization within one
         // directory while allowing bounded progress across distinct agents.
-        for (const input of sourceInputs) {
+        for (const candidate of sourceCandidates) {
+          const { input } = candidate;
           const prepared = preparedInputs.get(input);
           const pluginGeneration = pluginGenerations.get(input);
           if (!prepared) {
@@ -402,13 +404,13 @@ async function buildSnapshotBatch(
           }
           // A replacement waits for this batch's completion. Stop the stale batch before another
           // same-directory write so a superseded generation cannot overwrite catalog state.
-          assertPreparedModelRuntimeInputCurrent(input, buildGuards);
+          assertPreparedModelRuntimeInputCurrent(input, candidate.isBuildCurrent);
           const catalogSource = await prepareAgentCatalogSource(
             prepared,
             pluginGeneration,
             catalogMode,
           );
-          assertPreparedModelRuntimeInputCurrent(input, buildGuards);
+          assertPreparedModelRuntimeInputCurrent(input, candidate.isBuildCurrent);
           catalogSources.set(input, catalogSource);
         }
       }),
@@ -430,7 +432,8 @@ async function buildSnapshotBatch(
   if (catalogMode === "live") {
     // Explicit live owners still request the complete inventory. Keep those builds sequential
     // instead of multiplying heap and GC pressure when a command names several agents.
-    for (const input of inputs) {
+    for (const candidate of candidates) {
+      const { input } = candidate;
       const agentFacts = preparedInputs.get(input);
       const pluginGeneration = pluginGenerations.get(input);
       if (!agentFacts || !pluginGeneration) {
@@ -440,23 +443,23 @@ async function buildSnapshotBatch(
       if (!catalogSource) {
         throw new Error(`prepared model runtime catalog source missing for ${input.agentDir}`);
       }
-      assertPreparedModelRuntimeInputCurrent(input, buildGuards);
+      assertPreparedModelRuntimeInputCurrent(input, candidate.isBuildCurrent);
       preparedCatalogs.set(
         input,
         await prepareFullCatalogFacts(agentFacts, pluginGeneration, catalogMode, catalogSource),
       );
-      assertPreparedModelRuntimeInputCurrent(input, buildGuards);
+      assertPreparedModelRuntimeInputCurrent(input, candidate.isBuildCurrent);
       runtimeRegistryCount += 1;
     }
   } else {
-    for (const { groupInputs } of groups) {
-      assertPreparedModelRuntimeInputsCurrent(groupInputs, buildGuards);
-      const pluginGeneration = pluginGenerations.get(groupInputs[0]!);
+    for (const { groupCandidates } of groups) {
+      assertPreparedModelRuntimeCandidatesCurrent(groupCandidates);
+      const pluginGeneration = pluginGenerations.get(groupCandidates[0]!.input);
       if (!pluginGeneration) {
         throw new Error("prepared model runtime plugin generation is missing");
       }
       const batch = prepareConfiguredRuntimeFactsBatch({
-        agentFacts: groupInputs.map((input) => {
+        agentFacts: groupCandidates.map(({ input }) => {
           const agentFacts = preparedInputs.get(input);
           if (!agentFacts) {
             throw new Error(`prepared model runtime facts missing for ${input.agentDir}`);
@@ -469,7 +472,7 @@ async function buildSnapshotBatch(
       for (const [input, catalogFacts] of batch.catalogs) {
         preparedCatalogs.set(input, catalogFacts);
       }
-      assertPreparedModelRuntimeInputsCurrent(groupInputs, buildGuards);
+      assertPreparedModelRuntimeCandidatesCurrent(groupCandidates);
     }
   }
   const registryMs = performance.now() - registryStartedAt;
@@ -486,7 +489,7 @@ async function buildSnapshotBatch(
     0,
   );
   onBuildStats?.({
-    agentCount: inputs.length,
+    agentCount: candidates.length,
     workspaceGroupCount: groups.length,
     configuredFactsGroupCount: groups.length,
     catalogSourceCount:
@@ -498,7 +501,7 @@ async function buildSnapshotBatch(
         fingerprintPreparedRuntimeFacts(agentFacts.credentials),
       ),
     ).size,
-    catalogGroupCount: catalogMode === "live" ? inputs.length : 0,
+    catalogGroupCount: catalogMode === "live" ? candidates.length : 0,
     runtimeRegistryCount,
     configuredRuntimeModelCount,
     generatedCatalogPluginCount,
@@ -515,8 +518,9 @@ async function buildSnapshotBatch(
     sourceConcurrencyLimit: MAX_CONCURRENT_MODEL_RUNTIME_AGENT_SOURCE_BUILDS,
     fullCatalogConcurrencyLimit: MAX_CONCURRENT_FULL_MODEL_CATALOG_BUILDS,
   });
-  assertPreparedModelRuntimeInputsCurrent(inputs, buildGuards);
-  return inputs.map((input) => {
+  assertPreparedModelRuntimeCandidatesCurrent(candidates);
+  return candidates.map((candidate) => {
+    const { input } = candidate;
     const agentFacts = preparedInputs.get(input);
     const pluginGeneration = pluginGenerations.get(input);
     const catalogFacts = preparedCatalogs.get(input);
@@ -525,6 +529,7 @@ async function buildSnapshotBatch(
     }
     return {
       snapshot: createSnapshot(
+        candidate.catalogOwner,
         agentFacts,
         pluginGeneration,
         catalogFacts,
@@ -532,7 +537,7 @@ async function buildSnapshotBatch(
           agentFacts,
           pluginGeneration,
           agentBuildCompletions,
-          isCurrent: generationGuards.get(input) ?? (() => false),
+          isCurrent: candidate.isGenerationCurrent ?? (() => false),
         }),
       ),
       pluginGeneration,
@@ -541,24 +546,17 @@ async function buildSnapshotBatch(
 }
 
 export function startSerializedSnapshotBuildBatch(
-  inputs: readonly PreparedModelRuntimeInput[],
+  candidates: readonly PreparedModelRuntimeBuildCandidate[],
   agentBuildCompletions: Map<string, Promise<void>>,
   buildTimeoutMs: number,
   catalogMode: PreparedModelRuntimeCatalogMode = "live",
   onBuildStats?: (stats: PreparedModelRuntimeBuildStats) => void,
-  generationGuards: ReadonlyMap<PreparedModelRuntimeInput, () => boolean> = new Map(),
-  buildGuards: PreparedModelRuntimeBuildGuards = generationGuards,
-  inboundPluginRegistryInputs: ReadonlySet<PreparedModelRuntimeInput> = new Set(),
-  reusablePluginGenerations: ReadonlyMap<
-    PreparedModelRuntimeInput,
-    PreparedModelRuntimePluginGeneration
-  > = new Map(),
   pluginMetadataSnapshot?: PreparedModelRuntimePluginGeneration["pluginMetadataSnapshot"],
 ): {
   pending: Promise<PreparedModelRuntimeBuildResult[]>;
   completion: Promise<void>;
 } {
-  const agentDirs = [...new Set(inputs.map((input) => input.agentDir))];
+  const agentDirs = [...new Set(candidates.map(({ input }) => input.agentDir))];
   const previousBuildCompletions = [
     ...new Set(
       agentDirs
@@ -574,13 +572,9 @@ export function startSerializedSnapshotBuildBatch(
     }
     return {
       actualBuild: buildSnapshotBatch(
-        inputs,
+        candidates,
         catalogMode,
         agentBuildCompletions,
-        generationGuards,
-        buildGuards,
-        inboundPluginRegistryInputs,
-        reusablePluginGenerations,
         pluginMetadataSnapshot,
         onBuildStats,
       ),
@@ -614,28 +608,29 @@ export function startSerializedSnapshotBuildBatch(
 }
 
 export function startSerializedSnapshotBuild(
-  input: PreparedModelRuntimeInput,
+  candidate: PreparedModelRuntimeBuildCandidate,
   agentBuildCompletions: Map<string, Promise<void>>,
   buildTimeoutMs: number,
   catalogMode: PreparedModelRuntimeCatalogMode = "live",
-  generationGuard: () => boolean = () => true,
-  prepareInboundPluginRegistry = false,
-  reusablePluginGeneration?: PreparedModelRuntimePluginGeneration,
   pluginMetadataSnapshot?: PreparedModelRuntimePluginGeneration["pluginMetadataSnapshot"],
 ): {
   pending: Promise<PreparedModelRuntimeBuildResult>;
   completion: Promise<void>;
 } {
+  // Direct builds are current by default; batch callbacks require explicit generation authority.
+  const isGenerationCurrent = candidate.isGenerationCurrent ?? (() => true);
   const build = startSerializedSnapshotBuildBatch(
-    [input],
+    [
+      {
+        ...candidate,
+        isGenerationCurrent,
+        isBuildCurrent: candidate.isBuildCurrent ?? isGenerationCurrent,
+      },
+    ],
     agentBuildCompletions,
     buildTimeoutMs,
     catalogMode,
     undefined,
-    new Map([[input, generationGuard]]),
-    undefined,
-    prepareInboundPluginRegistry ? new Set([input]) : undefined,
-    reusablePluginGeneration ? new Map([[input, reusablePluginGeneration]]) : undefined,
     pluginMetadataSnapshot,
   );
   return {

--- a/src/agents/prepared-model-runtime.catalog-owner.test.ts
+++ b/src/agents/prepared-model-runtime.catalog-owner.test.ts
@@ -174,6 +174,29 @@ describe("prepared catalog owner lifecycle", () => {
 });
 
 describe("prepared build candidate lifetime", () => {
+  it("allows a direct serialized build without a lifecycle generation guard", async () => {
+    const input = {
+      config: {},
+      agentDir: "/tmp/direct-prepared-model-runtime-build",
+      readOnly: true,
+    };
+    const build = startSerializedSnapshotBuild(
+      { input, catalogOwner: preparePublishedModelCatalogOwnerIdentity(input) },
+      new Map(),
+      1_000,
+      "static",
+    );
+
+    await expect(build.pending).resolves.toMatchObject({
+      snapshot: {
+        agentDir: input.agentDir,
+        config: input.config,
+      },
+      pluginGeneration: expect.any(Object),
+    });
+    await expect(build.completion).resolves.toBeUndefined();
+  });
+
   it.each([
     {
       name: "single default",

--- a/src/agents/prepared-model-runtime.catalog-owner.test.ts
+++ b/src/agents/prepared-model-runtime.catalog-owner.test.ts
@@ -1,0 +1,268 @@
+// Preserve module setup before modules that consume it.
+// oxfmt-ignore
+import {
+  getPreparedModelRuntimeMocks,
+  resetPreparedModelRuntimeHarness,
+} from "./prepared-model-runtime.test-harness.js";
+import { beforeEach, describe, expect, it } from "vitest";
+import { createDeferred } from "../../test/helpers/promise.js";
+import {
+  preparePublishedModelCatalogOwnerIdentity,
+  resolvePublishedModelCatalogOwner,
+} from "./prepared-model-catalog-owner.js";
+import {
+  startSerializedSnapshotBuild,
+  startSerializedSnapshotBuildBatch,
+} from "./prepared-model-runtime.build.js";
+import {
+  loadPublishedGatewayReplyDispatchRuntime,
+  prepareModelRuntimeSnapshot,
+  publishPreparedModelRuntimeSnapshot,
+  refreshPreparedModelRuntimeSnapshots,
+  registerPreparedModelRuntimePublicationListener,
+} from "./prepared-model-runtime.js";
+
+const mocks = getPreparedModelRuntimeMocks();
+
+beforeEach(() => resetPreparedModelRuntimeHarness());
+
+describe("prepared catalog owner lifecycle", () => {
+  it.each([false, true])(
+    "retains the current preparation across adopted auth (previous snapshot: %s)",
+    async (previousSnapshot) => {
+      mocks.configuredAgentIds = ["alpha"];
+      const agentDir = "/tmp/configured-alpha";
+      if (previousSnapshot) {
+        mocks.configuredWorkspaces.set("alpha", "/tmp/old-workspace");
+        await refreshPreparedModelRuntimeSnapshots({}, { gatewayLifecycle: true });
+      }
+      const workspaceDir = "/tmp/fresh-workspace";
+      mocks.configuredWorkspaces.set("alpha", workspaceDir);
+      const config = { plugins: {} };
+      const source = createDeferred<{ agentDir: string; wrote: false }>();
+      const auth = createDeferred<{ agentDir: string; wrote: false }>();
+      const started = createDeferred();
+      const authStarted = createDeferred();
+      mocks.ensureOpenClawModelsJson
+        .mockImplementationOnce(async () => {
+          started.resolve();
+          return await source.promise;
+        })
+        .mockImplementationOnce(async () => {
+          authStarted.resolve();
+          return await auth.promise;
+        });
+      const phases: string[] = [];
+      const unregister = registerPreparedModelRuntimePublicationListener(({ phase }) =>
+        phases.push(phase),
+      );
+      const publication = refreshPreparedModelRuntimeSnapshots(config, { gatewayLifecycle: true });
+      let published = false;
+      void publication.then(
+        () => {
+          published = true;
+        },
+        () => undefined,
+      );
+      let dispatch: ReturnType<typeof loadPublishedGatewayReplyDispatchRuntime> | undefined;
+      let dispatched = false;
+      try {
+        await started.promise;
+        dispatch = loadPublishedGatewayReplyDispatchRuntime({ agentId: "alpha" });
+        void dispatch.then(
+          () => {
+            dispatched = true;
+          },
+          () => undefined,
+        );
+        // Any later inference is now wrong, including an auth build with no completed snapshot.
+        mocks.configuredAgentDirs.set("alpha", "/tmp/later-agent");
+        mocks.configuredWorkspaces.set("alpha", "/tmp/later-workspace");
+        mocks.mutationListener!({ agentDir, affectsInheritedStores: false });
+        source.resolve({ agentDir, wrote: false });
+        await authStarted.promise;
+        expect(published).toBe(false);
+        expect(dispatched).toBe(false);
+        expect(phases).not.toContain("published");
+        auth.resolve({ agentDir, wrote: false });
+        await publication;
+        await expect(dispatch).resolves.toMatchObject({
+          agentId: "alpha",
+          agentDir,
+          workspaceDir,
+          config,
+        });
+        const snapshot = await prepareModelRuntimeSnapshot({ agentId: "alpha", agentDir, config });
+        expect(resolvePublishedModelCatalogOwner(snapshot)).toMatchObject({
+          agentId: "alpha",
+          workspaceDir,
+        });
+        expect(phases.filter((phase) => phase === "published")).toHaveLength(1);
+        expect(phases).not.toContain("failed");
+      } finally {
+        source.resolve({ agentDir, wrote: false });
+        auth.resolve({ agentDir, wrote: false });
+        await Promise.allSettled([publication, dispatch]);
+        unregister();
+      }
+    },
+  );
+
+  it("refreshes a newer beta preparation instead of the completed alpha snapshot", async () => {
+    const agentDir = "/tmp/rebound-catalog-agent";
+    const workspaceDir = "/tmp/rebound-catalog-workspace";
+    const input = { agentDir, inheritedAuthDir: agentDir, workspaceDir, config: {} };
+    mocks.configuredAgentIds = ["alpha"];
+    mocks.configuredAgentDirs.set("alpha", agentDir);
+    const alpha = await publishPreparedModelRuntimeSnapshot(input);
+    expect(resolvePublishedModelCatalogOwner(alpha)).toMatchObject({ agentId: "alpha" });
+    mocks.configuredAgentIds = ["beta"];
+    mocks.configuredAgentDirs.set("beta", agentDir);
+    const freshInput = { ...input, config: { plugins: {} } };
+    const source = createDeferred<{ agentDir: string; wrote: false }>();
+    const started = createDeferred();
+    mocks.ensureOpenClawModelsJson.mockImplementationOnce(async () => {
+      started.resolve();
+      return await source.promise;
+    });
+    const fresh = publishPreparedModelRuntimeSnapshot(freshInput, { force: true });
+    void fresh.catch(() => undefined);
+    let refreshed: Promise<Awaited<ReturnType<typeof prepareModelRuntimeSnapshot>>> | undefined;
+    try {
+      await started.promise;
+      expect(resolvePublishedModelCatalogOwner(alpha)).toMatchObject({ agentId: "alpha" });
+      // The beta fact must already exist; neither the old snapshot nor ambient inference can supply it.
+      mocks.configuredAgentIds = ["gamma"];
+      mocks.configuredAgentDirs.set("gamma", agentDir);
+      mocks.mutationListener!({ agentDir, affectsInheritedStores: false });
+      refreshed = prepareModelRuntimeSnapshot(freshInput);
+      void refreshed.catch(() => undefined);
+      source.resolve({ agentDir, wrote: false });
+      await expect(fresh).rejects.toThrow("superseded");
+      const snapshot = await refreshed;
+      expect(snapshot.agentId).toBeUndefined();
+      expect(resolvePublishedModelCatalogOwner(snapshot)).toMatchObject({
+        agentId: "beta",
+        workspaceDir,
+      });
+    } finally {
+      source.resolve({ agentDir, wrote: false });
+      await Promise.allSettled([fresh, refreshed]);
+    }
+  });
+
+  it("retains known-unbound identity across auth refresh while runtime reads stay usable", async () => {
+    const input = { config: {}, agentDir: "/tmp/unbound-catalog-agent", readOnly: true };
+    mocks.configuredAgentIds = ["alpha"];
+    const first = await publishPreparedModelRuntimeSnapshot(input);
+    expect(() => resolvePublishedModelCatalogOwner(first)).toThrow(
+      "did not identify one configured agent",
+    );
+    mocks.configuredAgentDirs.set("alpha", input.agentDir);
+    expect(preparePublishedModelCatalogOwnerIdentity(input)).toMatchObject({ agentId: "alpha" });
+    mocks.mutationListener!({ agentDir: input.agentDir, affectsInheritedStores: false });
+    const refreshed = await prepareModelRuntimeSnapshot(input);
+    expect(refreshed.createStores().authStorage.getAll()).toMatchObject({
+      custom: { type: "api_key" },
+    });
+    expect(refreshed.workspaceDir).toBeUndefined();
+    expect(() => resolvePublishedModelCatalogOwner(refreshed)).toThrow(
+      "did not identify one configured agent",
+    );
+    expect(mocks.ensureOpenClawModelsJson).not.toHaveBeenCalled();
+  });
+});
+
+describe("prepared build candidate lifetime", () => {
+  it.each([
+    {
+      name: "single default",
+      single: true,
+      generation: undefined,
+      build: undefined,
+      allowed: true,
+      callbacks: true,
+    },
+    {
+      name: "batch default",
+      single: false,
+      generation: undefined,
+      build: undefined,
+      allowed: true,
+      callbacks: false,
+    },
+    {
+      name: "batch build-only",
+      single: false,
+      generation: undefined,
+      build: true,
+      allowed: true,
+      callbacks: false,
+    },
+    {
+      name: "batch missing build predicate",
+      single: false,
+      generation: false,
+      build: undefined,
+      allowed: true,
+      callbacks: false,
+    },
+    {
+      name: "batch inherited generation predicate",
+      single: false,
+      generation: false,
+      build: false,
+      allowed: false,
+      callbacks: false,
+    },
+  ])("preserves $name semantics", async ({ single, generation, build, allowed, callbacks }) => {
+    const input = { config: {}, agentDir: "/tmp/candidate-lifetime", readOnly: true };
+    const candidate = {
+      input,
+      catalogOwner: preparePublishedModelCatalogOwnerIdentity(input),
+      ...(generation === undefined ? {} : { isGenerationCurrent: () => generation }),
+      ...(build === undefined ? {} : { isBuildCurrent: () => build }),
+    };
+    const started = single
+      ? startSerializedSnapshotBuild(candidate, new Map(), 1_000, "static")
+      : startSerializedSnapshotBuildBatch([candidate], new Map(), 1_000, "static");
+    try {
+      if (!allowed) {
+        await expect(started.pending).rejects.toThrow("superseded");
+      } else {
+        const result = await started.pending;
+        const { snapshot } = Array.isArray(result) ? result[0]! : result;
+        if (callbacks) {
+          await expect(snapshot.loadFullModelCatalog!()).resolves.toMatchObject({ entries: [] });
+        } else {
+          await expect(snapshot.loadFullModelCatalog!()).rejects.toThrow("superseded");
+        }
+      }
+      expect(mocks.prepareStaticCatalog).toHaveBeenCalledOnce();
+    } finally {
+      await started.completion;
+    }
+  });
+
+  it.each(["before", "after"] as const)(
+    "checks supersession %s workspace preparation",
+    async (checkpoint) => {
+      const input = { config: {}, agentDir: "/tmp/candidate-checkpoint", readOnly: true };
+      const candidate = {
+        input,
+        catalogOwner: preparePublishedModelCatalogOwnerIdentity(input),
+        isGenerationCurrent: () => false,
+        isBuildCurrent: () => false,
+        ...(checkpoint === "before" ? { isPreparationCurrent: () => false } : {}),
+      };
+      const build = startSerializedSnapshotBuildBatch([candidate], new Map(), 1_000, "static");
+      try {
+        await expect(build.pending).rejects.toThrow("superseded");
+        expect(mocks.prepareStaticCatalog).toHaveBeenCalledTimes(checkpoint === "before" ? 0 : 1);
+        expect(mocks.discoverModels).not.toHaveBeenCalled();
+      } finally {
+        await build.completion;
+      }
+    },
+  );
+});

--- a/src/agents/prepared-model-runtime.owner.ts
+++ b/src/agents/prepared-model-runtime.owner.ts
@@ -15,6 +15,7 @@ import { resolveSelectedAgentHarnessRuntime } from "./harness/runtime-plugin-loa
 import { resolveLegacyInheritedAuthDir } from "./legacy-inherited-auth-dir.js";
 import { resolveModelCandidateChain } from "./model-fallback-candidates.js";
 import { resolveDefaultModelForAgent } from "./model-selection-config.js";
+import { preparePublishedModelCatalogOwnerIdentity } from "./prepared-model-catalog-owner.js";
 import { copyPreparedModelRuntimeAuthBindings } from "./prepared-model-runtime-auth.js";
 import {
   startSerializedSnapshotBuild,
@@ -48,19 +49,21 @@ export type {
   PreparedModelRuntimeStores,
 } from "./prepared-model-runtime.types.js";
 
-export function createPreparedModelRuntimeOwner(
+export function prepareModelRuntimeOwner(
   input: PreparedModelRuntimeInput,
   provenance: PreparedModelRuntimeOwner["provenance"],
   catalogMode: PreparedModelRuntimeCatalogMode = "live",
+  existing?: PreparedModelRuntimeOwner,
 ): PreparedModelRuntimeOwner {
-  return {
+  // Preparation precedes async discovery: auth may supersede the first build, or a new
+  // preparation whose previous snapshot is still attached. Neither snapshot owns these facts.
+  return Object.assign(existing ?? { generation: 0, needsRefresh: true }, {
     input,
+    catalogOwner: preparePublishedModelCatalogOwnerIdentity(input),
     environmentFingerprint: effectiveEnvironmentFingerprint(input),
     catalogMode,
     provenance,
-    generation: 0,
-    needsRefresh: true,
-  };
+  });
 }
 
 export class PreparedModelRuntimeOwnerRetention {
@@ -288,7 +291,7 @@ function environmentFingerprint(env: NodeJS.ProcessEnv | undefined): string | un
   return env ? hashRuntimeConfigValue(env) : undefined;
 }
 
-export function effectiveEnvironmentFingerprint(input: PreparedModelRuntimeInput): string {
+function effectiveEnvironmentFingerprint(input: PreparedModelRuntimeInput): string {
   return hashRuntimeConfigValue(input.env ?? process.env);
 }
 
@@ -444,8 +447,8 @@ export async function publishPreparedModelRuntimeOwnerBatch(params: {
   reusePluginGenerations?: boolean;
   pluginMetadataSnapshot?: PreparedModelRuntimePluginGeneration["pluginMetadataSnapshot"];
 }): Promise<void> {
-  const candidates = params.entries.map(({ owner, input }) => {
-    owner.input = input;
+  const candidates = params.entries.map(({ owner }) => {
+    const input = owner.input;
     owner.environmentFingerprint = effectiveEnvironmentFingerprint(input);
     owner.generation += 1;
     owner.needsRefresh = true;
@@ -460,17 +463,23 @@ export async function publishPreparedModelRuntimeOwnerBatch(params: {
     // Persistent catalog/auth callbacks must retire only with this exact registered generation.
     const isGenerationCurrent = () =>
       owner.generation === generation && params.owners.get(key) === owner;
+    const isCurrent = () => (params.isPublicationCurrent?.() ?? true) && isGenerationCurrent();
     return {
       catalogMode: owner.catalogMode,
       input,
+      catalogOwner: owner.catalogOwner,
+      pluginGeneration: owner.pendingPluginGeneration,
+      prepareInboundPluginRegistry: owner.provenance === "configured",
       isGenerationCurrent,
+      isBuildCurrent: params.isBuildCurrent ?? isCurrent,
+      isPreparationCurrent: params.isBuildCurrent,
       isEligible: () =>
         (params.isPublicationCurrent?.() ?? true) &&
         owner.generation === generation &&
         (registered
           ? params.owners.get(key) === owner
           : params.registerEntriesAfterBuildStart === true),
-      isCurrent: () => (params.isPublicationCurrent?.() ?? true) && isGenerationCurrent(),
+      isCurrent,
       key,
       generation,
       markRegistered: () => {
@@ -509,30 +518,11 @@ export async function publishPreparedModelRuntimeOwnerBatch(params: {
               continue;
             }
             const build = startSerializedSnapshotBuildBatch(
-              currentGroup.map(({ input }) => input),
+              currentGroup,
               params.agentBuildCompletions,
               params.buildTimeoutMs,
               catalogMode,
               params.onBuildStats,
-              new Map(
-                currentGroup.map((candidate) => [candidate.input, candidate.isGenerationCurrent]),
-              ),
-              params.isBuildCurrent ??
-                new Map(currentGroup.map((candidate) => [candidate.input, candidate.isCurrent])),
-              new Set(
-                currentGroup
-                  .filter((candidate) => candidate.owner.provenance === "configured")
-                  .map((candidate) => candidate.input),
-              ),
-              params.reusePluginGenerations
-                ? new Map(
-                    currentGroup.flatMap((candidate) =>
-                      candidate.owner.pluginGeneration
-                        ? [[candidate.input, candidate.owner.pluginGeneration] as const]
-                        : [],
-                    ),
-                  )
-                : undefined,
               params.pluginMetadataSnapshot,
             );
             for (const candidate of currentGroup) {
@@ -621,11 +611,7 @@ export async function publishModelRuntimeSnapshot(
   pluginMetadataSnapshot?: PreparedModelRuntimePluginGeneration["pluginMetadataSnapshot"],
 ): Promise<PreparedModelRuntimeSnapshot> {
   const key = ownerKey(input);
-  const owner = existing ?? createPreparedModelRuntimeOwner(input, provenance, catalogMode);
-  owner.input = input;
-  owner.environmentFingerprint = effectiveEnvironmentFingerprint(input);
-  owner.catalogMode = catalogMode;
-  owner.provenance = provenance;
+  const owner = prepareModelRuntimeOwner(input, provenance, catalogMode, existing);
   owner.generation += 1;
   owner.needsRefresh = true;
   owner.refreshError = undefined;
@@ -633,13 +619,16 @@ export async function publishModelRuntimeSnapshot(
   owner.pendingPluginGeneration = reusablePluginGeneration;
   const generation = owner.generation;
   const build = startSerializedSnapshotBuild(
-    input,
+    {
+      input,
+      catalogOwner: owner.catalogOwner,
+      isGenerationCurrent: () => owner.generation === generation && owners.get(key) === owner,
+      prepareInboundPluginRegistry: provenance === "configured",
+      pluginGeneration: reusablePluginGeneration,
+    },
     agentBuildCompletions,
     buildTimeoutMs,
     catalogMode,
-    () => owner.generation === generation && owners.get(key) === owner,
-    provenance === "configured",
-    reusablePluginGeneration,
     pluginMetadataSnapshot,
   );
   owner.buildCompletion = build.completion;

--- a/src/agents/prepared-model-runtime.startup-static.test.ts
+++ b/src/agents/prepared-model-runtime.startup-static.test.ts
@@ -156,7 +156,7 @@ vi.mock("./legacy-inherited-auth-dir.js", () => ({
   resolveLegacyInheritedAuthDir: () => "/tmp/prepared-static-agent",
 }));
 
-vi.mock("./agent-scope.js", () => ({
+const agentScopeMocks = vi.hoisted(() => ({
   listAgentEntries: (config: { agents?: { list?: unknown[] } }) => config.agents?.list ?? [],
   listAgentIds: () => ["default"],
   resolveAgentDir: () => "/tmp/prepared-static-agent",
@@ -173,6 +173,14 @@ vi.mock("./agent-scope.js", () => ({
     defaultAgentId: "default",
     sessionAgentId: agentId ?? "default",
   }),
+}));
+
+vi.mock("./agent-scope.js", () => agentScopeMocks);
+vi.mock("./agent-scope-config.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./agent-scope-config.js")>()),
+  listAgentIds: agentScopeMocks.listAgentIds,
+  resolveAgentDir: agentScopeMocks.resolveAgentDir,
+  resolveAgentWorkspaceDir: agentScopeMocks.resolveAgentWorkspaceDir,
 }));
 
 vi.mock("./auth-profiles/runtime-snapshots.js", () => ({

--- a/src/agents/prepared-model-runtime.test-harness.ts
+++ b/src/agents/prepared-model-runtime.test-harness.ts
@@ -173,7 +173,7 @@ vi.mock("../plugins/synthetic-auth.runtime.js", () => ({
     preparedModelRuntimeMocks.runtimeSyntheticAuthProviderRefs,
 }));
 
-vi.mock("./agent-scope.js", () => ({
+const agentScopeMocks = vi.hoisted(() => ({
   listAgentEntries: (config: { agents?: { list?: unknown[] } }) => config.agents?.list ?? [],
   listAgentIds: () => {
     if (preparedModelRuntimeMocks.configuredAgentIdsError) {
@@ -201,6 +201,14 @@ vi.mock("./agent-scope.js", () => ({
     defaultAgentId: "default",
     sessionAgentId: agentId ?? "default",
   }),
+}));
+
+vi.mock("./agent-scope.js", () => agentScopeMocks);
+vi.mock("./agent-scope-config.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./agent-scope-config.js")>()),
+  listAgentIds: agentScopeMocks.listAgentIds,
+  resolveAgentDir: agentScopeMocks.resolveAgentDir,
+  resolveAgentWorkspaceDir: agentScopeMocks.resolveAgentWorkspaceDir,
 }));
 
 vi.mock("./legacy-inherited-auth-dir.js", () => ({

--- a/src/agents/prepared-model-runtime.test.ts
+++ b/src/agents/prepared-model-runtime.test.ts
@@ -9,6 +9,7 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { createEmptyPluginRegistry } from "../plugins/registry-empty.js";
 import { requireActivePluginRegistry } from "../plugins/runtime.js";
 import { getPluginRuntimeLoadContext } from "../plugins/runtime/load-context.js";
+import { preparePublishedModelCatalogOwnerIdentity } from "./prepared-model-catalog-owner.js";
 import { getPreparedModelRuntimeAuthStore } from "./prepared-model-runtime-auth.js";
 import { startSerializedSnapshotBuild } from "./prepared-model-runtime.build.js";
 import { prepareWorkspacePluginRegistries } from "./prepared-model-runtime.inbound-registry.js";
@@ -38,7 +39,12 @@ describe("prepared model runtime snapshots", () => {
       agentDir: "/tmp/direct-prepared-model-runtime-build",
       readOnly: true,
     };
-    const build = startSerializedSnapshotBuild(input, new Map(), 1_000, "static");
+    const build = startSerializedSnapshotBuild(
+      { input, catalogOwner: preparePublishedModelCatalogOwnerIdentity(input) },
+      new Map(),
+      1_000,
+      "static",
+    );
 
     await expect(build.pending).resolves.toMatchObject({
       snapshot: {

--- a/src/agents/prepared-model-runtime.test.ts
+++ b/src/agents/prepared-model-runtime.test.ts
@@ -9,9 +9,7 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { createEmptyPluginRegistry } from "../plugins/registry-empty.js";
 import { requireActivePluginRegistry } from "../plugins/runtime.js";
 import { getPluginRuntimeLoadContext } from "../plugins/runtime/load-context.js";
-import { preparePublishedModelCatalogOwnerIdentity } from "./prepared-model-catalog-owner.js";
 import { getPreparedModelRuntimeAuthStore } from "./prepared-model-runtime-auth.js";
-import { startSerializedSnapshotBuild } from "./prepared-model-runtime.build.js";
 import { prepareWorkspacePluginRegistries } from "./prepared-model-runtime.inbound-registry.js";
 import {
   acquireAgentRunPreparedModelRuntime,
@@ -31,29 +29,6 @@ const mocks = getPreparedModelRuntimeMocks();
 describe("prepared model runtime snapshots", () => {
   beforeEach(() => {
     resetPreparedModelRuntimeHarness();
-  });
-
-  it("allows a direct serialized build without a lifecycle generation guard", async () => {
-    const input = {
-      config: {},
-      agentDir: "/tmp/direct-prepared-model-runtime-build",
-      readOnly: true,
-    };
-    const build = startSerializedSnapshotBuild(
-      { input, catalogOwner: preparePublishedModelCatalogOwnerIdentity(input) },
-      new Map(),
-      1_000,
-      "static",
-    );
-
-    await expect(build.pending).resolves.toMatchObject({
-      snapshot: {
-        agentDir: input.agentDir,
-        config: input.config,
-      },
-      pluginGeneration: expect.any(Object),
-    });
-    await expect(build.completion).resolves.toBeUndefined();
   });
 
   it("materializes Claude CLI thinking capabilities on the prepared logical row", async () => {

--- a/src/agents/prepared-model-runtime.ts
+++ b/src/agents/prepared-model-runtime.ts
@@ -18,9 +18,8 @@ import {
   PreparedModelRuntimeOwnerRetention,
   PreparedModelRuntimePublicationSupersededError,
   advancePreparedModelRuntimeOwnerConfig,
-  createPreparedModelRuntimeOwner,
+  prepareModelRuntimeOwner,
   createPreparedModelRuntimeReplacement,
-  effectiveEnvironmentFingerprint,
   hasSameLifecycleInput,
   normalizeOptionalDir,
   normalizePreparedModelRuntimeInput,
@@ -460,14 +459,12 @@ async function refreshPreparedModelRuntimeSnapshotsNow(
   const candidates = entries.map(({ owner: existing, input }) => {
     // Dynamic and standalone owners have different lifetime contracts. A configured publication
     // must replace them so an older lease release cannot remove the committed generation.
-    const owner =
-      existing?.provenance === "configured"
-        ? existing
-        : createPreparedModelRuntimeOwner(input, "configured", catalogMode);
-    owner.input = input;
-    owner.environmentFingerprint = effectiveEnvironmentFingerprint(input);
-    owner.catalogMode = catalogMode;
-    owner.provenance = "configured";
+    const owner = prepareModelRuntimeOwner(
+      input,
+      "configured",
+      catalogMode,
+      existing?.provenance === "configured" ? existing : undefined,
+    );
     return { input, owner };
   });
   await publishPreparedModelRuntimeOwnerBatch({

--- a/src/agents/prepared-model-runtime.types.ts
+++ b/src/agents/prepared-model-runtime.types.ts
@@ -9,6 +9,7 @@ import type { PreparedAgentCredentialModes } from "./agent-auth-credential-modes
 import type { InlineModelEntry } from "./embedded-agent-runner/model.inline-provider.js";
 import type { AgentHarnessPluginSelection } from "./harness/runtime-plugin-load-plan.js";
 import type { ModelCatalogEntry, ModelCatalogSnapshot } from "./model-catalog.types.js";
+import type { PublishedModelCatalogOwnerCandidate } from "./prepared-model-catalog.types.js";
 import type { PreparedConfiguredRuntimeModel } from "./prepared-model-runtime.configured.js";
 import type { AuthStorage } from "./sessions/auth-storage.js";
 import type { ModelRegistry } from "./sessions/model-registry.js";
@@ -31,6 +32,7 @@ export type PreparedModelRuntimePluginGeneration = Readonly<{
 }>;
 
 export type PreparedModelRuntimeSnapshot = Readonly<{
+  catalogOwner: PublishedModelCatalogOwnerCandidate["catalogOwner"];
   agentId?: string;
   agentDir: string;
   inheritedAuthDir?: string;
@@ -147,6 +149,7 @@ export type PreparedModelRuntimeBuildStats = Readonly<{
 
 export type PreparedModelRuntimeOwner = {
   input: PreparedModelRuntimeInput;
+  catalogOwner: PublishedModelCatalogOwnerCandidate["catalogOwner"];
   environmentFingerprint: string;
   catalogMode: PreparedModelRuntimeCatalogMode;
   provenance: "configured" | "standalone" | "explicit" | "run" | "ephemeral";

--- a/src/agents/test-helpers/embedded-agent-runner-e2e-mocks.ts
+++ b/src/agents/test-helpers/embedded-agent-runner-e2e-mocks.ts
@@ -77,6 +77,7 @@ function createEmptyPreparedModelRuntimeSnapshot(
   input: PreparedModelRuntimeInput,
 ): PreparedModelRuntimeSnapshot {
   return {
+    catalogOwner: undefined,
     ...(input.agentId !== undefined ? { agentId: input.agentId } : {}),
     agentDir: input.agentDir,
     ...(input.inheritedAuthDir !== undefined ? { inheritedAuthDir: input.inheritedAuthDir } : {}),

--- a/src/gateway/local-request-context.test.ts
+++ b/src/gateway/local-request-context.test.ts
@@ -67,6 +67,7 @@ describe("local gateway request context", () => {
       .spyOn(preparedModelCatalog, "loadPublishedPreparedModelCatalogOwnerSnapshot")
       .mockResolvedValue(
         asPublishedOwner({
+          catalogOwner: { agentId: "worker", workspaceDir: "/tmp/local-model-catalog-workspace" },
           agentId: "worker",
           agentDir: "/tmp/local-model-catalog-agent",
           workspaceDir: "/tmp/local-model-catalog-workspace",
@@ -120,6 +121,7 @@ describe("local gateway request context", () => {
       api: "openai-completions" as const,
     };
     const candidate = {
+      catalogOwner: { agentId: "main", workspaceDir: "/tmp/local-model-auth-workspace" },
       agentId: "main",
       agentDir: "/tmp/local-model-auth-agent",
       workspaceDir: "/tmp/local-model-auth-workspace",
@@ -202,6 +204,7 @@ describe("local gateway request context", () => {
       },
     } as OpenClawConfig;
     const candidate = {
+      catalogOwner: { agentId: "main", workspaceDir: "/tmp/local-model-timeout-workspace" },
       agentId: "main",
       agentDir: "/tmp/local-model-timeout-agent",
       workspaceDir: "/tmp/local-model-timeout-workspace",

--- a/src/gateway/server-methods/chat-metadata-runtime.test.ts
+++ b/src/gateway/server-methods/chat-metadata-runtime.test.ts
@@ -34,6 +34,7 @@ function createOwner(
     ),
   };
   const owner: PreparedModelRuntimeSnapshot = {
+    catalogOwner: { agentId: "main", workspaceDir: `/tmp/${id}/workspace` },
     agentId: "main",
     agentDir: `/tmp/${id}/agent`,
     workspaceDir: `/tmp/${id}/workspace`,

--- a/src/gateway/server-model-catalog.test.ts
+++ b/src/gateway/server-model-catalog.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it, vi } from "vitest";
 import type { ModelCatalogSnapshot } from "../agents/model-catalog.types.js";
+import {
+  preparePublishedModelCatalogOwnerIdentity,
+  resolvePublishedModelCatalogOwner,
+} from "../agents/prepared-model-catalog-owner.js";
 import type { PublishedModelCatalogOwnerCandidate } from "../agents/prepared-model-catalog.types.js";
 import { setPreparedModelRuntimeAuthLoader } from "../agents/prepared-model-runtime-auth.js";
 import { PreparedModelRuntimePublicationSupersededError } from "../agents/prepared-model-runtime.errors.js";
@@ -44,6 +48,11 @@ function ownerSnapshot(
   agentId?: string,
 ): PublishedModelCatalogOwnerCandidate {
   return {
+    catalogOwner: preparePublishedModelCatalogOwnerIdentity({
+      config,
+      agentId,
+      agentDir: "/tmp/gateway-agent",
+    }),
     ...(agentId ? { agentId } : {}),
     agentDir: "/tmp/gateway-agent",
     config,
@@ -55,6 +64,98 @@ function ownerSnapshot(
 }
 
 describe("gateway prepared model catalog", () => {
+  it("keeps raw pre-roster input distinct from an explicitly empty roster", () => {
+    const input = {
+      config: {},
+      agentDir: "/tmp/raw-catalog-state/agents/main/agent",
+      env: { OPENCLAW_STATE_DIR: "/tmp/raw-catalog-state", OPENCLAW_HOME: "/tmp/raw-catalog-home" },
+    };
+    expect(preparePublishedModelCatalogOwnerIdentity(input)).toMatchObject({ agentId: "main" });
+    expect(
+      preparePublishedModelCatalogOwnerIdentity({ ...input, config: { agents: { entries: {} } } }),
+    ).toBeUndefined();
+  });
+
+  it.each([
+    { name: "wrong directory", agentId: "main", agentDir: "/tmp/wrong-agent", bound: false },
+    {
+      name: "unknown explicit id",
+      agentId: "missing",
+      agentDir: "/tmp/gateway-agent",
+      bound: false,
+    },
+    {
+      name: "explicit empty roster",
+      agentId: "main",
+      agentDir: "/tmp/gateway-agent",
+      empty: true,
+      bound: false,
+    },
+    {
+      name: "shared directory without id",
+      agentDir: "/tmp/gateway-agent",
+      shared: true,
+      bound: false,
+    },
+    {
+      name: "explicit shared-directory id",
+      agentId: "WORKER",
+      agentDir: "/tmp/gateway-agent",
+      shared: true,
+      bound: true,
+    },
+    { name: "unique directory without id", agentDir: "/tmp/gateway-agent", bound: true },
+  ])(
+    "preserves prepared binding validation: $name",
+    async ({ agentId, agentDir, empty, shared, bound }) => {
+      const config = ownerConfig();
+      if (empty) {
+        config.agents = { entries: {} };
+      } else if (shared) {
+        config.agents!.list!.push({ id: "worker", agentDir, workspace: "/tmp/worker-workspace" });
+      }
+      const input = { config, agentId, agentDir };
+      const candidate = {
+        ...ownerSnapshot(config),
+        ...input,
+        catalogOwner: preparePublishedModelCatalogOwnerIdentity(input),
+      };
+      const project = loadGatewayModelCatalogSnapshot({
+        getConfig: () => config,
+        loadPublishedPreparedModelCatalogOwnerSnapshot: async () => candidate,
+      });
+      if (!bound) {
+        await expect(project).rejects.toMatchObject({
+          name: "PublishedModelCatalogOwnerResolutionError",
+        });
+        return;
+      }
+      const expected = {
+        agentId: shared ? "worker" : "main",
+        workspaceDir: shared ? "/tmp/worker-workspace" : "/tmp/gateway-workspace",
+      };
+      await expect(project).resolves.toMatchObject(expected);
+      const resolved = resolvePublishedModelCatalogOwner(candidate);
+      expect(
+        resolvePublishedModelCatalogOwner({
+          ...resolved,
+          catalogOwner: { ...resolved.catalogOwner },
+        }),
+      ).toEqual(resolved);
+    },
+  );
+
+  it("rejects a bound catalog without prepared auth", async () => {
+    const config = ownerConfig();
+    const candidate = { ...ownerSnapshot(config), authStore: undefined };
+    await expect(
+      loadGatewayModelCatalogSnapshot({
+        getConfig: () => config,
+        loadPublishedPreparedModelCatalogOwnerSnapshot: async () => candidate,
+      }),
+    ).rejects.toThrow("missing prepared auth state");
+  });
+
   it("reads the published read-only generation directly", async () => {
     const config = ownerConfig();
     const loadPublishedPreparedModelCatalogOwnerSnapshot = vi.fn(async () => ownerSnapshot(config));

--- a/src/gateway/worker-environments/inference-runtime.test.ts
+++ b/src/gateway/worker-environments/inference-runtime.test.ts
@@ -208,6 +208,7 @@ function setup(
     prepareWorkspace?: string;
   } = {};
   const preparedModelRuntime = {
+    catalogOwner: undefined,
     agentDir: "/gateway-agent",
     activeProjectKeys: [],
     allowGatewaySubagentBinding: true,


### PR DESCRIPTION
Closes #132156
Related: #131931 (preserve native auth across catalog refresh); its fixture improvements are retained.

## What Problem This Solves

Fixes an issue where a valid prepared model catalog became unavailable to its Gateway projection after the ambient home/state environment changed. The full catalog and authentication had already been prepared, but a later projection tried to rediscover their agent/workspace ownership in the new environment.

## Why This Change Was Made

Capture the frozen agent/workspace identity at lifecycle preparation, before asynchronous discovery, and carry that fact through each build candidate and published snapshot. Auth-only refresh preserves the current preparation—not an absent or older completed snapshot. A fresh configured preparation can establish a new identity; a known-unbound runtime remains explicitly unbound.

The consumer now reads the prepared fact while still requiring prepared authentication. Raw execution identity, optional runtime workspace, private auth bindings, model-neutral config stamps, generation/registration fences, deadlines, serialization and sibling retry behavior remain intact. Parallel builder maps/sets and duplicate ownership inference are absorbed into the existing owner/candidate flow. No environment snapshot, fallback reader, new authority token, configuration option, schema, dependency, or public model change.

## User Impact

Prepared catalogs retain their correct ownership across environment changes and auth refreshes, including auth supersession before the first snapshot is published. Standalone unbound runtime reads remain usable; invalid or ambiguous ownership is not silently rebound to another agent.

## Evidence

AI-assisted implementation and review. The main-based patch starts at `b0cb107c8248768b4dc1899bd589f6e60c615709`; the explicit rebase excluded the unrelated Workshop ancestry at `df5bcf7caab919224d6686b29b991fc86f5023fa`.

**Failing first:** the real-worker regression fully loaded a synthetic catalog under environment A, successfully projected it, and verified actual canonical directory/workspace resolver drift under B. The second projection then failed with `PublishedModelCatalogOwnerResolutionError` on unchanged production code. This was not an import, setup, or timeout failure.

**Reconciled behavior:** a 595-test batch in 30 files passed, followed by all **19 real-worker cases with no exclusions**. The worker suite covers environment drift before sibling reload, metadata ordering, auth/materialization, selected native auth versus unrelated synthetic providers, cache sharing, supersession, ref-only profiles, and both synthetic Codex-login file hydration cases. The latter use isolated temporary auth files and disable keychain prompting; no real login or provider credentials were used.

**Lifecycle coverage:** first publication superseded by auth without a snapshot; fresh preparation while an older snapshot remains; alpha→beta ownership while later inference would identify gamma; known-unbound ownership across auth; missing auth; config stamps and metadata copies; single/batch missing/default guard distinctions; shared pre-workspace versus registered-owner checks; serialization, timeout and sibling retry controls.

**Final source binding:** the first changed gate found the existing runtime suite at 1003 effective lines against its unchanged 1000-line cap. One already-reviewed serialized-build test was moved unchanged into the existing candidate-lifetime suite, using the same harness/reset, and its two unused imports were removed. Both affected suites then passed all 49 tests, followed by the complete final changed gate and explicit-base ratchets. No case, assertion, timeout, suppression or baseline was weakened. The other tests and all seven production files remained byte-identical. This is 614 distinct cases covered with the affected 49 rerun after the move, not a claim of a second full 614-case run.

**Build and gates:** the full canonical build passed all nine unified steps, external plugin builds, CLI bootstrap, 147 public SDK subpaths and UI budgets. All 11,984 final dist files still match that successful build; only the two test source files moved afterward. Production/core-test types, lint, formatting, dead exports, storage/schema guards, import cycles and other selected guards passed. The already-pinned Vitest patch was installed through frozen dependency reconciliation and verified from the actual installed code.

Representative commands:

```bash
node scripts/run-vitest.mjs src/agents/prepared-model-catalog-worker.integration.test.ts
```

```bash
node scripts/run-vitest.mjs src/agents/prepared-model-runtime.test.ts src/agents/prepared-model-runtime.catalog-owner.test.ts
```

```bash
node --import ./scripts/tsx.mjs scripts/build-all.mts
```

The complete 25-file `node scripts/check-changed.mjs -- <changed paths>` gate passed; max-lines and assertion ratchets were also checked against the explicit selected base rather than a moving `origin/main`.

Fresh managed Codex P0 review passed with no actionable findings. All seven production files match the reviewed bytes; the only later change is the unchanged test relocation, with the affected suites and final gate rerun. The new main native-auth discovery fixture contract, provided-metadata distinction, and selected-versus-sibling assertions were preserved during reconciliation.

**LOC:** production +150/-151 (**net −1**); tests +583/-188 (net +395); test support +163/-1 (net +162), including the mechanical fixture-writer extraction. No changelog, lockfile, generated snapshot or baseline edit.

**Limits:** this is real catalog-worker/Gateway-projection proof with synthetic providers, not authenticated model inference or a browser capture. The reported trigger is an internal same-process environment transition; there is no supported browser operation that changes an existing server's process environment, so a UI before/after reproduction was not produced. Earlier sibling timing failures remain documented and are not assigned a cause merely because the final ordered/full worker runs passed. This repair is not claimed to explain the separate native-delivery inactive-runtime error or historical trajectory exit.

Exact-head hosted CI and native landing gates remain required. [The original full release verification](https://github.com/openclaw/openclaw/actions/runs/33154285571) is investigation context only and remains separate from this PR's scoped proof. No release, tag, version bump or package publication is included.
