### PR TITLE
docs: correct numeric model selection guidance

### DIFF
--- a/docs/tools/slash-commands.md
+++ b/docs/tools/slash-commands.md
@@ -199,7 +199,7 @@ plugins.
     | `/elevated [on\|off\|ask\|full]` | Toggle elevated mode. Alias: `/elev` |
     | `/exec host=<auto\|sandbox\|gateway\|node> security=<deny\|allowlist\|full> ask=<off\|on-miss\|always> node=<id>` | Show or set exec defaults |
     | `/login [codex\|openai\|openai-codex]` | Pair Codex/OpenAI login from a private chat or Web UI session. Owner/admin only |
-    | `/model [name\|#\|status] [-s\|--session\|-a\|--agent\|-g\|--global]` | Show or select a model. `-s` changes only this session; owner/admin `-a` and `-g` also update configured defaults |
+    | `/model [name\|default\|list\|status] [-s\|--session\|-a\|--agent\|-g\|--global]` | Show or select a model. `-s` changes only this session; owner/admin `-a` and `-g` also update configured defaults |
     | `/models [provider] [page] [limit=<n>\|all]` | List configured/auth-available providers or models |
     | `/queue <mode>` | Manage active-run queue behavior. See [Queue](/concepts/queue) and [Queue steering](/concepts/queue-steering) |
     | `/steer <message>` | Inject guidance into the active run. Alias: `/tell`. See [Steer](/tools/steer) |
@@ -384,10 +384,13 @@ Without a flag or that optional setting, direct owner/admin `/model <model>` com
 
 The setting also accepts `"agent"` and `"global"`; it does not grant permission to write configured defaults. See [Model selection scope](/gateway/config-agents#agentsdefaultsmodelselectionscope).
 
+In text commands, select a model by `provider/model` or a configured alias.
+Numeric selections such as `/model 3` are not supported.
+
 ```text
-/model             # show model picker
-/model list        # same
-/model 3           # select by number from picker
+/model             # show current model and usage guidance
+/model list        # browse providers (same as /models)
+/models openai     # list models from a provider
 /model openai/gpt-5.4    # configured scope, or existing behavior when unset
 /model openai/gpt-5.4 -s # explicit session scope
 /model openai/gpt-5.4 -a # session + agent default update request
@@ -398,9 +401,10 @@ The setting also accepts `"agent"` and `"global"`; it does not grant permission 
 /model status      # detailed view with endpoint and API mode
 ```
 
-On Discord, `/model` and `/models` open an interactive picker with provider and
-model dropdowns. Discord follows the direct command behavior, including
-`modelSelectionScope`. Telegram callback selections always remain session-only.
+On Discord, the bare native `/model` and `/models` commands open an interactive
+picker. Choose a provider and model from the dropdowns, then select **Submit**.
+Discord follows the direct command behavior, including `modelSelectionScope`.
+Telegram model browsing uses callback buttons; selections always remain session-only.
 The picker respects `agents.defaults.modelPolicy.allow`,
 including `provider/*` entries. Without an explicit allowlist, model entries and
 aliases do not restrict selection.


### PR DESCRIPTION
Related: [#132218 — correct chat model selection examples on the models concept page](https://github.com/openclaw/openclaw/pull/132218).

## What Problem This Solves

Fixes an issue where readers of the slash-command reference would try `/model 3` and receive “Numeric model selection is not supported in chat.” The command table advertises `#`, and the examples also conflate the bare text `/model` summary with the `/model list` provider browser.

Affected page: https://docs.openclaw.ai/tools/slash-commands#model-model-selection

## Why This Change Was Made

Correct only `docs/tools/slash-commands.md`: remove the numeric-selector syntax, show provider browsing instead of a numeric selection, and explain selection by `provider/model` or configured alias. Distinguish the text summary/browser from Discord's bare native `/model` and `/models` provider/model dropdowns with **Submit** and Telegram's session-only callback buttons.

This corrects prose to match existing behavior; it does not implement numeric selection or change runtime, configuration, model policy, or scope semantics. The separate models-concept-page correction is already merged and is not part of this diff.

## User Impact

Readers get supported browsing and selection commands instead of an example that fails. Discord's native picker and scope behavior remain intact; Telegram callback selections remain session-only.

## Evidence

- Inspected the text parser, summary/browser routing, shared selection owner, directive-only and inline callers, and complete native Discord/Telegram dispatch and callback paths. A separate read-only native-path review confirmed the interactions.
- Rechecked live `main` at `b85a049da5e8cc4b96c64846a45c645258c43586`: subsequent model-policy changes retain the explicit all-digit rejection and Telegram's `canPersistStickyModelSelection: false`; Discord's bare-command picker and Submit paths are unchanged. The rejection also exists in stable `v2026.7.1`.
- Source owners: `src/auto-reply/reply/directive-handling.model-selection.ts`, `directive-handling.model.ts`, `commands-models.ts`, and `get-reply-directives-apply.ts`; native adapters: `extensions/discord/src/monitor/native-command-model-picker-ui.ts`, `native-command-model-picker-interaction.ts`, and `extensions/telegram/src/bot-handlers.callback-router.ts`.
- `pnpm docs:list` passed.
- `node scripts/check-docs-mdx.mjs docs/tools/slash-commands.md` passed.
- `git diff --check` passed.
- Exact-head [CI run 33224729454](https://github.com/openclaw/openclaw/actions/runs/33224729454) passed for `672bb7491ab2569b89f5451d58de4660ec400e8d`.
- After refreshing the branch for the current native landing wrapper, four selected existing tests passed again on exact PR head `672bb7491ab2569b89f5451d58de4660ec400e8d`: numeric-selection rejection, bare text summary, `/model list` browser alias, and the channel-specific summary. The remaining 111 tests were intentionally skipped by the name filter:

```bash
node scripts/run-vitest.mjs src/auto-reply/reply/directive-handling.model.test.ts -t 'rejects numeric /model selections with a guided error|shows summary for /model with no args|treats /model list as a models browser alias|includes the thinking level in channel-specific model summaries' --reporter=dot
```

No runtime or test files changed. Native channel interactions were source-checked, not exercised against live accounts; no operator state was used. No UI/runtime screenshot is applicable to this prose-only correction.

Production LOC: +0/-0. Tests: +0/-0. Documentation: +11/-7.

AI-assisted.
