### PR TITLE
fix: report Code Mode failures without false success

### DIFF
--- a/docs/tools/code-mode.md
+++ b/docs/tools/code-mode.md
@@ -68,6 +68,12 @@ commands are rejected before the QuickJS worker starts with actionable
 - `wait` resumes a suspended code-mode run when nested tool calls are still
   pending.
 
+Call `wait` only when the outer code-mode result has `status: "waiting"`, using
+its top-level `runId`. A completed cell can return a background shell operation
+with its own `sessionId` inside `value`; use the enabled process-control tool
+inside a new `exec` to poll that operation. Its `sessionId` is not a code-mode
+run ID.
+
 Code mode changes the model-facing orchestration surface only. It does not
 replace tools, plugin tools, MCP tools, auth, approval policy, channel
 behavior, or model selection.
@@ -189,6 +195,12 @@ try {
   return { status: "unavailable", error: error.message };
 }
 ```
+
+Await every tool call or handle its rejection explicitly. OpenClaw drains
+dispatched calls before completing a cell; an unhandled rejection, including
+one from an unawaited call or timer callback, fails the cell instead of silently
+reporting success. Handlers attached after a suspension still handle their
+original promises.
 
 JavaScript syntax errors, TypeScript transform errors, and tool failures proven
 to occur before execution become failed `exec` results that the model can read
@@ -934,7 +946,9 @@ type CodeModeOutput = { type: "text"; text: string } | { type: "json"; value: un
 ```
 
 Rules: output order matches guest calls. Nested tool results, cumulative guest
-output, and the final value share the `maxOutputBytes` serialized UTF-8 budget.
+output, and the final value or failure diagnostic share the `maxOutputBytes`
+serialized UTF-8 budget. Oversized errors retain their leading cause and end
+with `[error truncated]`; truncation does not turn a failure into success.
 Catalog search rejects when its callable-name array cannot fit this budget;
 narrow the query or lower `limit` and retry. For other successful results that
 exceed the budget, OpenClaw returns a bounded value

--- a/src/agents/code-mode-bridge.ts
+++ b/src/agents/code-mode-bridge.ts
@@ -10,7 +10,7 @@ import type { NodeListNode } from "../shared/node-list-types.js";
 import { resolveEligibleNodeFromList } from "../shared/node-resolve.js";
 import { resolveSafeTimeoutDelayMs } from "../utils/timer-delay.js";
 import { redactCodeModeCatalogIds, type CodeModeCatalogProjection } from "./code-mode-catalog.js";
-import { boundCodeModeValue } from "./code-mode-json.js";
+import { boundCodeModeResult, boundCodeModeValue } from "./code-mode-json.js";
 import type { CodeModeNamespaceRuntime } from "./code-mode-namespaces.js";
 import type { PendingBridgeRequest, SettledBridgeRequest } from "./code-mode-runtime.js";
 import { readCodeModeSkill } from "./code-mode-skills.js";
@@ -603,10 +603,15 @@ export async function runBridgeRequest(params: {
     const settled: SettledBridgeRequest = { id: params.request.id, ok: true, value };
     return effectReceipt ? registerToolEffectReceipt(settled, effectReceipt) : settled;
   } catch (error) {
+    const bounded = boundCodeModeResult({
+      error: redactCodeModeCatalogIds(formatErrorMessage(error), catalogProjection.bindings),
+      output: [],
+      maxOutputBytes: params.maxOutputBytes,
+    });
     const settled: SettledBridgeRequest = {
       id: params.request.id,
       ok: false,
-      error: redactCodeModeCatalogIds(formatErrorMessage(error), catalogProjection.bindings),
+      error: bounded.error,
     };
     const trustedNoStart = consumeTrustedToolNoStartError(error);
     if (trustedNoStart) {

--- a/src/agents/code-mode-controller-source.ts
+++ b/src/agents/code-mode-controller-source.ts
@@ -17,6 +17,9 @@ export const CODE_MODE_CONTROLLER_SOURCE = String.raw`
   delete globalThis.__openclawNamespaces;
   const bridgeSequences = new Map();
   const timers = new Map();
+  // Keep rejection ownership in the snapshot so a handler attached after wait
+  // can clear it; an unawaited failure must not become a successful cell.
+  const unhandledRejections = new Map();
   let nextTimerId = 0;
 
   function safe(value) {
@@ -320,6 +323,13 @@ export const CODE_MODE_CONTROLLER_SOURCE = String.raw`
     __openclawSettleBridge: { value: settle },
     __openclawSerializeCatalogHandles: { value: serializeCatalogHandles },
     __openclawTakeOutput: { value: () => output.splice(0) },
+    __openclawTrackRejection: {
+      value: (promise, reason, handled) => {
+        if (handled) unhandledRejections.delete(promise);
+        else unhandledRejections.set(promise, reason);
+      },
+    },
+    __openclawUnhandledRejection: { value: () => unhandledRejections.keys().next().value },
   });
 })();
 `;

--- a/src/agents/code-mode-execution.ts
+++ b/src/agents/code-mode-execution.ts
@@ -166,9 +166,14 @@ export async function runCodeModeExec(params: {
     });
   } catch (error) {
     const code = params.signal?.aborted ? ("aborted" as const) : codeModeFailureCode(error);
+    const bounded = boundCodeModeResult({
+      error: params.signal?.aborted ? "code mode execution aborted" : codeModeFailureMessage(error),
+      output: [],
+      maxOutputBytes: config.maxOutputBytes,
+    });
     return {
       status: "failed" as const,
-      error: params.signal?.aborted ? "code mode execution aborted" : codeModeFailureMessage(error),
+      error: bounded.error,
       code,
       failurePhase: bridgeDispatch.started
         ? ("bridge" as const)
@@ -546,10 +551,12 @@ async function settleCodeModeResult(params: {
   const bounded = boundCodeModeResult({
     output,
     ...(result.status === "completed" ? { value: result.value } : {}),
+    ...(result.status === "failed" ? { error: result.error } : {}),
     maxOutputBytes: params.config.maxOutputBytes,
   });
   const finalized = {
     ...result,
+    ...(bounded.error !== undefined ? { error: bounded.error } : {}),
     ...(result.status === "completed" ? { value: bounded.value } : {}),
     ...(result.status === "failed"
       ? {
@@ -557,7 +564,7 @@ async function settleCodeModeResult(params: {
           bridgeDispatchStarted: params.bridgeDispatch.started,
         }
       : {}),
-    output: bounded.output.slice(bounded.truncated ? 0 : deliveredOutputCount),
+    output: bounded.output.slice(bounded.outputTruncated ? 0 : deliveredOutputCount),
     replaySafe: params.replaySafe,
     telemetry: telemetry(params.runtime),
   };
@@ -702,13 +709,18 @@ export async function runWait(params: {
     if (!activeRuns.has(state.runId)) {
       cancelPendingBridgeStates(state.pending);
     }
+    const bounded = boundCodeModeResult({
+      error: codeModeFailureMessage(error),
+      output: takeUndeliveredCodeModeRunOutput(state),
+      maxOutputBytes: state.config.maxOutputBytes,
+    });
     return {
       status: "failed" as const,
-      error: codeModeFailureMessage(error),
+      error: bounded.error,
       code: codeModeFailureCode(error),
       failurePhase: "bridge" as const,
       bridgeDispatchStarted: state.bridgeDispatch.started,
-      output: takeUndeliveredCodeModeRunOutput(state),
+      output: bounded.output,
       replaySafe: state.replaySafe,
       telemetry: telemetry(state.runtime),
     };

--- a/src/agents/code-mode-headless.ts
+++ b/src/agents/code-mode-headless.ts
@@ -82,8 +82,16 @@ function headlessFailure(params: {
   error: string;
   output: unknown[];
   toolCallCount: number;
+  maxOutputBytes: number;
 }): CodeModeHeadlessResult {
-  return { status: "failed", ...params };
+  const bounded = boundCodeModeResult(params);
+  return {
+    status: "failed",
+    code: params.code,
+    toolCallCount: params.toolCallCount,
+    error: bounded.error,
+    output: bounded.output,
+  };
 }
 
 function remainingHeadlessMs(deadline: number): number {
@@ -280,6 +288,7 @@ export async function runCodeModeScriptHeadless(params: {
           error: result.error,
           output,
           toolCallCount,
+          maxOutputBytes: config.maxOutputBytes,
         });
       }
 
@@ -302,6 +311,7 @@ export async function runCodeModeScriptHeadless(params: {
           error: `code mode headless tool budget exceeded (${maxToolCalls})`,
           output,
           toolCallCount,
+          maxOutputBytes: config.maxOutputBytes,
         });
       }
 
@@ -330,6 +340,7 @@ export async function runCodeModeScriptHeadless(params: {
           error: "code mode is waiting without pending bridge requests",
           output,
           toolCallCount,
+          maxOutputBytes: config.maxOutputBytes,
         });
       }
       await awaitCodeModeDeadline({
@@ -363,6 +374,7 @@ export async function runCodeModeScriptHeadless(params: {
       error: timedOut || aborted ? error.message : codeModeFailureMessage(error),
       output,
       toolCallCount,
+      maxOutputBytes: config.maxOutputBytes,
     });
   } finally {
     cancelPendingBridgeStates(pending);

--- a/src/agents/code-mode-json.ts
+++ b/src/agents/code-mode-json.ts
@@ -67,37 +67,95 @@ function boundOutputArray(output: unknown[], maxBytes: number): unknown[] {
   return [truncationMarker(JSON.stringify(output), maxBytes - 2)];
 }
 
-/** Bound cumulative guest output and the final value under one serialized byte budget. */
-export function boundCodeModeResult(params: {
+function boundErrorString(error: string, maxBytes: number): string {
+  if (jsonUtf8Bytes(error) <= maxBytes) {
+    return error;
+  }
+  let low = 0;
+  let high = Math.min(Buffer.byteLength(error, "utf8"), maxBytes);
+  // Escaped characters cost more in JSON than in UTF-8; removing the serialized
+  // overflow from the raw prefix can erase the entire diagnostic.
+  while (low < high) {
+    const middle = Math.ceil((low + high) / 2);
+    const candidate = `${truncateUtf8Prefix(error, middle)} [error truncated]`;
+    if (jsonUtf8Bytes(candidate) <= maxBytes) {
+      low = middle;
+    } else {
+      high = middle - 1;
+    }
+  }
+  return `${truncateUtf8Prefix(error, low)} [error truncated]`;
+}
+
+type CodeModeResultInput = {
   output: unknown[];
   value?: unknown;
+  error?: string;
   maxOutputBytes: number;
-}): { output: unknown[]; value?: unknown; truncated: boolean } {
+};
+type BoundedCodeModeResult = {
+  output: unknown[];
+  value?: unknown;
+  error?: string;
+  truncated: boolean;
+  outputTruncated?: boolean;
+};
+
+/** Bound guest output, the final value, and failure text under one serialized byte budget. */
+export function boundCodeModeResult(
+  params: CodeModeResultInput & { error: string },
+): BoundedCodeModeResult & { error: string };
+export function boundCodeModeResult(params: CodeModeResultInput): BoundedCodeModeResult;
+export function boundCodeModeResult(params: CodeModeResultInput): BoundedCodeModeResult {
   const hasValue = Object.hasOwn(params, "value");
   const safeOutput = params.output.map(toCodeModeJsonSafe);
   const safeValue = hasValue ? toCodeModeJsonSafe(params.value) : undefined;
   const outputBytes = safeOutput.length > 0 ? jsonUtf8Bytes(safeOutput) : 0;
   const valueBytes = hasValue ? jsonUtf8Bytes(safeValue) : 0;
-  if (outputBytes + valueBytes <= params.maxOutputBytes) {
-    return { output: safeOutput, ...(hasValue ? { value: safeValue } : {}), truncated: false };
+  const errorBytes = params.error === undefined ? 0 : jsonUtf8Bytes(params.error);
+  const error = params.error === undefined ? {} : { error: params.error };
+  if (outputBytes + valueBytes + errorBytes <= params.maxOutputBytes) {
+    return {
+      output: safeOutput,
+      ...(hasValue ? { value: safeValue } : {}),
+      ...error,
+      truncated: false,
+    };
   }
+  // Failure text stays a string, so callers and the model retain the original
+  // cause even when output competes for space. Short channels donate their share.
+  if (error.error !== undefined) {
+    const reservedOutputBytes = Math.min(
+      outputBytes + valueBytes,
+      Math.floor(params.maxOutputBytes / 2),
+    );
+    error.error = boundErrorString(error.error, params.maxOutputBytes - reservedOutputBytes);
+  }
+  const maxOutputBytes =
+    params.maxOutputBytes - (error.error === undefined ? 0 : jsonUtf8Bytes(error.error));
   if (safeOutput.length === 0) {
     return {
       output: [],
-      ...(hasValue ? { value: boundCodeModeValue(safeValue, params.maxOutputBytes) } : {}),
+      ...(hasValue ? { value: boundCodeModeValue(safeValue, maxOutputBytes) } : {}),
+      ...error,
       truncated: true,
     };
   }
 
   // Preserve both channels when both overflow: reserve half for the final
   // value, then let short values donate their unused share to guest output.
-  const reservedValueBytes = hasValue
-    ? Math.min(valueBytes, Math.floor(params.maxOutputBytes / 2))
-    : 0;
-  const output = boundOutputArray(safeOutput, params.maxOutputBytes - reservedValueBytes);
+  const reservedValueBytes = hasValue ? Math.min(valueBytes, Math.floor(maxOutputBytes / 2)) : 0;
+  const output = boundOutputArray(safeOutput, maxOutputBytes - reservedValueBytes);
+  const outputTruncated = output !== safeOutput;
   if (!hasValue) {
-    return { output, truncated: true };
+    return { output, ...error, truncated: true, outputTruncated };
   }
-  const remainingBytes = params.maxOutputBytes - jsonUtf8Bytes(output);
-  return { output, value: boundCodeModeValue(safeValue, remainingBytes), truncated: true };
+  const remainingBytes = maxOutputBytes - jsonUtf8Bytes(output);
+  return {
+    output,
+    value: boundCodeModeValue(safeValue, remainingBytes),
+    ...error,
+    truncated: true,
+    outputTruncated,
+  };
 }

--- a/src/agents/code-mode-runtime.test.ts
+++ b/src/agents/code-mode-runtime.test.ts
@@ -59,6 +59,60 @@ describe("Code Mode output bounding", () => {
       truncated: false,
     });
   });
+
+  it("preserves failure text and output at their exact serialized byte limit", () => {
+    const output = [{ type: "text", text: "before failure" }];
+    const error = "Error: café 😀";
+    const maxOutputBytes =
+      Buffer.byteLength(JSON.stringify(output), "utf8") +
+      Buffer.byteLength(JSON.stringify(error), "utf8");
+
+    expect(boundCodeModeResult({ output, error, maxOutputBytes })).toEqual({
+      output,
+      error,
+      truncated: false,
+    });
+  });
+
+  it.each([
+    { name: "plain error", errorText: "failure ", output: [], returned: {} },
+    { name: "Unicode error", errorText: "😀 café ", output: [], returned: {} },
+    { name: "escaped error", errorText: '\\"\n\t', output: [], returned: {} },
+    {
+      name: "error and output",
+      errorText: "😀 failure ",
+      output: [{ type: "text", text: "output ".repeat(1_000) }],
+      returned: {},
+    },
+    {
+      name: "error, output, and value",
+      errorText: "😀 failure ",
+      output: [{ type: "text", text: "output ".repeat(1_000) }],
+      returned: { value: "value ".repeat(1_000) },
+    },
+  ])(
+    "bounds $name without losing the cause or splitting Unicode",
+    ({ errorText, output, returned }) => {
+      const maxOutputBytes = 1_024;
+      const bounded = boundCodeModeResult({
+        output,
+        error: `Error: ${errorText.repeat(1_000)}`,
+        ...returned,
+        maxOutputBytes,
+      });
+
+      expect(bounded.truncated).toBe(true);
+      expect(bounded.error).toMatch(/^Error: .*\[error truncated\]$/s);
+      expect(bounded.error).not.toContain("�");
+      const serializedBytes =
+        Buffer.byteLength(JSON.stringify(bounded.error), "utf8") +
+        (bounded.output.length ? Buffer.byteLength(JSON.stringify(bounded.output), "utf8") : 0) +
+        (Object.hasOwn(returned, "value")
+          ? Buffer.byteLength(JSON.stringify(bounded.value), "utf8")
+          : 0);
+      expect(serializedBytes).toBeLessThanOrEqual(maxOutputBytes);
+    },
+  );
 });
 
 describe("Code Mode master switch resolution", () => {

--- a/src/agents/code-mode.rejections.test.ts
+++ b/src/agents/code-mode.rejections.test.ts
@@ -1,0 +1,128 @@
+import { expectDefined } from "@openclaw/normalization-core";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  applyCodeModeCatalog,
+  createCodeModeTools,
+  runCodeModeScriptHeadless,
+} from "./code-mode.js";
+import {
+  createCodeModeHarness,
+  createHeadlessCodeModeHarness,
+  pluginToolWithExecute,
+  resultDetails,
+  resetCodeModeTestState,
+  runUntilCompleted,
+  testing,
+} from "./code-mode.test-support.js";
+
+describe("Code Mode promise rejection settlement", () => {
+  afterEach(resetCodeModeTestState);
+
+  it.each(["return", "throw"])(
+    "does not repeat yielded output when %s text is truncated",
+    async (action) => {
+      const { ctx } = createCodeModeHarness();
+      const config = { tools: { codeMode: { enabled: true, maxOutputBytes: 1_024 } } };
+      const tools = createCodeModeTools({ ...ctx, config, runtimeConfig: config });
+      applyCodeModeCatalog({ ...ctx, config, tools });
+      const first = resultDetails(
+        await expectDefined(tools[0], "exec").execute("yield", {
+          code: `text("already delivered"); await yield_control(); ${action} ${action === "throw" ? 'new Error("x".repeat(10000))' : '"x".repeat(10000)'};`,
+        }),
+      );
+      expect(first.status).toBe("waiting");
+      expect(first.output).toEqual([{ type: "text", text: "already delivered" }]);
+      const final = resultDetails(
+        await expectDefined(tools[1], "wait").execute("resume", { runId: first.runId }),
+      );
+      expect(final.status).toBe(action === "throw" ? "failed" : "completed");
+      expect(final.output).toEqual([]);
+    },
+  );
+
+  it.each([
+    { name: "detached promise", code: 'void Promise.reject(new Error("lost failure"));' },
+    { name: "detached tool", code: "void failing_tool({});" },
+    { name: "detached combinator", code: "void Promise.all([failing_tool({})]);" },
+    {
+      name: "rejection before snapshot",
+      code: 'void Promise.reject(new Error("lost failure")); await yield_control();',
+    },
+    {
+      name: "timer callback",
+      code: 'setTimeout(() => { throw new Error("lost failure"); }, 0);',
+    },
+  ])("reports an unhandled $name instead of success", async ({ code }) => {
+    const { ctx, config, catalogRef, tools } = createCodeModeHarness();
+    const failing = pluginToolWithExecute("failing_tool", "Fails without an outcome", async () => {
+      throw new Error("lost failure");
+    });
+    applyCodeModeCatalog({ ...ctx, config, catalogRef, tools: [...tools, failing] });
+    const result = await runUntilCompleted({
+      execTool: expectDefined(tools[0], "exec"),
+      waitTool: expectDefined(tools[1], "wait"),
+      code: `${code} return "done";`,
+    });
+    expect(result).toMatchObject({
+      status: "failed",
+      error: expect.stringContaining("lost failure"),
+    });
+    expect(testing.activeRuns.size).toBe(0);
+  });
+
+  it.each([
+    "try { await failing_tool({}); } catch {}",
+    "void failing_tool({}).catch(() => {});",
+    "await Promise.allSettled([failing_tool({})]);",
+    'const rejected = Promise.reject(new Error("handled later")); await yield_control(); await rejected.catch(() => {});',
+    'await Promise.race([Promise.resolve("winner"), failing_tool({})]);',
+  ])("preserves handled rejection semantics: %s", async (code) => {
+    const { ctx, config, catalogRef, tools } = createCodeModeHarness();
+    const failing = pluginToolWithExecute("failing_tool", "Handled failure", async () => {
+      throw new Error("handled failure");
+    });
+    applyCodeModeCatalog({ ...ctx, config, catalogRef, tools: [...tools, failing] });
+    const result = await runUntilCompleted({
+      execTool: expectDefined(tools[0], "exec"),
+      waitTool: expectDefined(tools[1], "wait"),
+      code: `${code} return "done";`,
+    });
+    expect(result).toMatchObject({ status: "completed", value: "done" });
+    expect(testing.activeRuns.size).toBe(0);
+  });
+
+  it.each(["exec", "wait", "headless"])("bounds failure diagnostics through %s", async (mode) => {
+    const error = "Error: " + '\\"\n😀'.repeat(10_000);
+    const code = `text("before failure"); ${mode === "wait" ? "await yield_control();" : ""} throw new Error(${JSON.stringify(error)});`;
+    const maxOutputBytes = 1_024;
+    let result;
+    if (mode === "headless") {
+      result = await runCodeModeScriptHeadless({
+        ctx: createHeadlessCodeModeHarness(),
+        code,
+        overrides: { maxOutputBytes },
+      });
+    } else {
+      const { ctx } = createCodeModeHarness();
+      const config = { tools: { codeMode: { enabled: true, maxOutputBytes } } };
+      const tools = createCodeModeTools({ ...ctx, config, runtimeConfig: config });
+      applyCodeModeCatalog({ ...ctx, config, tools });
+      result = await runUntilCompleted({
+        execTool: expectDefined(tools[0], "exec"),
+        waitTool: expectDefined(tools[1], "wait"),
+        code,
+      });
+    }
+    expect(result).toMatchObject({
+      status: "failed",
+      error: expect.stringContaining("[error truncated]"),
+    });
+    if (result.status !== "failed") {
+      throw new Error("expected a failed Code Mode result");
+    }
+    expect(
+      Buffer.byteLength(JSON.stringify(result.error)) +
+        Buffer.byteLength(JSON.stringify(result.output)),
+    ).toBeLessThanOrEqual(maxOutputBytes);
+  });
+});

--- a/src/agents/code-mode.ts
+++ b/src/agents/code-mode.ts
@@ -248,9 +248,13 @@ export function createCodeModeTools(ctx: CodeModeToolContext): AnyAgentTool[] {
     name: CODE_MODE_WAIT_TOOL_NAME,
     label: "wait",
     hideFromChannelProgress: true,
-    description: "Resume a suspended OpenClaw code mode run returned by exec.",
+    description:
+      'Resume only when the outer exec result has status "waiting", using its top-level runId. A completed exec may return a still-running tool operation inside value; manage that operation through its enabled tool in a new exec. Never pass a nested sessionId or process ID to wait.',
     parameters: Type.Object({
-      runId: Type.String({ description: "Code mode run id returned by exec." }),
+      runId: Type.String({
+        description:
+          'Top-level runId from an exec result with status "waiting", never a nested tool sessionId.',
+      }),
     }),
     execute: async (
       toolCallId: string,

--- a/src/agents/code-mode.worker.ts
+++ b/src/agents/code-mode.worker.ts
@@ -65,6 +65,19 @@ function buildUserSource(code: string): string {
   return `globalThis.__openclawResult = (async () => {\n${code}\n})()`;
 }
 
+function trackPromiseRejection(
+  promise: JSValueHandle,
+  reason: JSValueHandle,
+  handled: boolean,
+): void {
+  const vm = promise.vm;
+  vm.global
+    .getProp("__openclawTrackRejection")
+    .consume((track) =>
+      vm.callFunction(track, vm.undefined, promise, reason, handled ? vm.true : vm.false).dispose(),
+    );
+}
+
 function createHostRequestHandler(params: {
   vm: QuickJS;
   pendingRequests: PendingBridgeRequest[];
@@ -159,6 +172,7 @@ async function createVm(params: {
     wasm: params.wasmModule,
     memoryLimit: params.config.memoryLimitBytes,
     timezoneOffset: 0,
+    onUnhandledRejection: trackPromiseRejection,
     interruptHandler: () => {
       timedOut = deadlineReached();
       return timedOut;
@@ -208,6 +222,7 @@ async function restoreVm(params: {
     wasm: params.wasmModule,
     memoryLimit: params.config.memoryLimitBytes,
     timezoneOffset: 0,
+    onUnhandledRejection: trackPromiseRejection,
     interruptHandler: () => {
       timedOut = deadlineReached();
       return timedOut;
@@ -252,12 +267,17 @@ function boundWorkerResult(
   const bounded = boundCodeModeResult({
     output: result.output,
     ...(result.status === "completed" ? { value: result.value } : {}),
+    ...(result.status === "failed" ? { error: result.error } : {}),
     maxOutputBytes: config.maxOutputBytes,
   });
   if (result.status === "completed") {
     return { ...result, output: bounded.output, value: bounded.value };
   }
-  return { ...result, output: bounded.output };
+  return {
+    ...result,
+    output: bounded.output,
+    ...(bounded.error !== undefined ? { error: bounded.error } : {}),
+  };
 }
 
 function failedWorkerResult(
@@ -393,6 +413,12 @@ async function runVmExecution(params: {
         });
       }
       const value = await readCompletedResult(params.vm, resultHandle);
+      // Check only after all host work and microtasks settle. Catches attached
+      // after an await (including a restored snapshot) still own their errors.
+      using rejection = params.vm.global
+        .getProp("__openclawUnhandledRejection")
+        .consume((read) => params.vm.callFunction(read, params.vm.undefined));
+      await readCompletedResult(params.vm, rejection);
       return { status: "completed", value, output };
     } finally {
       resultHandle.dispose();
@@ -528,7 +554,10 @@ async function main(): Promise<CodeModeWorkerResult> {
       : error instanceof CodeModeWorkerFailure
         ? error.code
         : "internal_error";
-    return failedWorkerResult(code, timedOut ? "code mode timeout exceeded" : errorMessage(error));
+    return boundWorkerResult(
+      failedWorkerResult(code, timedOut ? "code mode timeout exceeded" : errorMessage(error)),
+      config,
+    );
   }
 }
 


### PR DESCRIPTION
Related: #128859

## What Problem This Solves

Fixes an issue where users could be told a Code Mode task succeeded even though an unawaited tool call failed. A real OpenClaw Gateway returned `CLAIMED_SUCCESS` after a missing-file read, and the model repeated that false success to the user.

Oversized failure text also bypassed the configured output budget. Separately, models could confuse a background process's `sessionId` with a Code Mode continuation, then abandon the original process after calling the wrong `wait`.

## Why This Change Was Made

The QuickJS worker now tracks unhandled promise rejections inside the guest snapshot and checks them after dispatched work and microtasks settle. Explicit catches, late catches after a yield, `allSettled`, and handled race losers still work. Borrowed QuickJS callback handles are not retained by the host.

The existing result bounder now shares its byte budget with failure text across worker, bridge, interactive, and headless paths. It preserves the leading cause and a truncation marker. Output delivery also distinguishes output truncation from final-value/error truncation, so a resumed cell does not repeat already-delivered output.

The `wait` description now requires an outer `status: "waiting"` and its top-level `runId`; nested process handles stay with their own enabled tool. This improves the selection contract without accepting invalid IDs, changing authority checks, or adding retries.

Production LOC: +154/-24 (net +130) | Tests: +182/-0 | Docs: +15/-1. Growth implements missing snapshot-owned rejection bookkeeping and applies the existing payload-budget contract at each failure boundary. No new dependency, config key, persistence format, or compatibility path.

## User Impact

Failed asynchronous work is visible as failure. Oversized diagnostics remain useful and bounded, suspension preserves handled-error semantics, and background operations are less likely to be abandoned through a mistaken continuation call. Docs describe the same contract.

This targets the OpenClaw harness. It does not change Codex Code Mode or the separate catalog-close cancellation work in #132182. The lead directly checked the QuickJS 3.5.0 callback contract and sibling Codex protocol/runtime sources before choosing the OpenClaw-specific repair: `openai/codex@0ae94fdd49`, `codex-rs/code-mode-protocol/src/description.rs:15-47` and `codex-rs/code-mode-runtime/src/session_runtime/mod.rs:76-184`.

## Evidence

- Before the repair, five rejection regressions failed. The missing-file case also reproduced through an isolated real Gateway and its Control UI.
- The full Code Mode suite passed: **773 tests in 27 files**. Core/test typechecks, changed-file lint, docs lint, and the full build passed on the initial proof base.
- **15/15 live scenarios passed** across `openai/gpt-5.6-luna`, `openai/gpt-5.6-terra`, and `openai/gpt-5.6-sol`: file composition/readback, one background-process launch and polling, yield/resume, detached failure, and oversized failure. Stored calls/results and fixture files were checked independently of the models' summaries.
- Terra recovered from one invalid process-tool argument before retrieving the original process's output; a second fresh run also completed. This is outcome proof, not a claim that every model-generated call is perfect.
- With a 1,024-byte payload budget, the old worker emitted a 100,108-byte error; the repaired worker returned 1,022 bytes of error text (1,024 with JSON quotes). Tests cover Unicode, escaping, combined channels, interactive/headless failures, and output delivery across yield.
- Fresh Codex autoreview reported no actionable findings at its configured P0-only threshold.
- Rebased cleanly onto `79bdd1b0226cbf5b9a1c857aff81e95b109ee3f9`. The only intervening Code Mode change was independent documentation clarification. Rebased tests (773/773), full build, and the complete changed-check gate passed at head `6df6ca6d2e4b136044b8e576716957b05b3e4589`. Five additional live smoke cases on that exact built head also passed: detached failure on all three OpenAI models, Terra background-process retrieval, and Sol yield/resume. Exact-head hosted [CI run 33224882191](https://github.com/openclaw/openclaw/actions/runs/33224882191) is green, including `openclaw/ci-gate`. The earlier unrelated UI shard overflow is already repaired in this base by #132193.

Live proof used an isolated state directory, an exclusive loopback port, synthetic files, and no real messaging channels. The normal operator gateway was untouched. No live MCP, external-channel, or swarm-cancellation claim is made.

AI-assisted implementation and review with Codex.

Before: a missing-file read was reported as success.

![Before: false success](https://github.com/user-attachments/assets/77a21cf3-10b5-4e88-be93-6ff9bc32b7ba)

After: the same script reports the actual failure.

![After: missing-file failure](https://github.com/user-attachments/assets/0936333f-3982-49c6-8368-10a65d241ac0)

Real Control UI recording (idle gaps shortened):

https://github.com/user-attachments/assets/314b3bf8-b001-478f-a39b-b943cf4ce4b5
