### PR TITLE
fix(deps): update tar security patch for extended stable

### DIFF
--- a/extensions/llama-cpp/npm-shrinkwrap.json
+++ b/extensions/llama-cpp/npm-shrinkwrap.json
@@ -1639,9 +1639,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.20",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.20.tgz",
-      "integrity": "sha512-9FcyK4PA6+WbzlTM9WhQm6vB5W7cP7dUiPsv1g7YDwEQnQ1CGpK3MGlKk/ITVWMk05kHZuBhmVhiv8LZoy/PFQ==",
+      "version": "7.5.22",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.22.tgz",
+      "integrity": "sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA==",
       "license": "BlueOak-1.0.0",
       "optional": true,
       "dependencies": {

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -53,7 +53,7 @@
         "qrcode": "1.5.4",
         "quickjs-wasi": "3.0.0",
         "rastermill": "0.3.1",
-        "tar": "7.5.20",
+        "tar": "7.5.22",
         "tree-sitter-bash": "0.25.1",
         "tslog": "4.10.2",
         "typebox": "1.1.39",
@@ -3171,9 +3171,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.20",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.20.tgz",
-      "integrity": "sha512-9FcyK4PA6+WbzlTM9WhQm6vB5W7cP7dUiPsv1g7YDwEQnQ1CGpK3MGlKk/ITVWMk05kHZuBhmVhiv8LZoy/PFQ==",
+      "version": "7.5.22",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.22.tgz",
+      "integrity": "sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -1994,7 +1994,7 @@
     "qrcode": "1.5.4",
     "quickjs-wasi": "3.0.0",
     "rastermill": "0.3.1",
-    "tar": "7.5.20",
+    "tar": "7.5.22",
     "tree-sitter-bash": "0.25.1",
     "tslog": "4.10.2",
     "typebox": "1.1.39",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,7 +30,7 @@ overrides:
   qs: 6.15.2
   node-domexception: npm:@nolyfill/domexception@1.0.28
   typebox: 1.1.39
-  tar: 7.5.20
+  tar: 7.5.22
   tough-cookie: 4.1.3
   yauzl: 3.2.1
   protobufjs: 7.6.5
@@ -175,8 +175,8 @@ importers:
         specifier: 0.3.1
         version: 0.3.1
       tar:
-        specifier: 7.5.20
-        version: 7.5.20
+        specifier: 7.5.22
+        version: 7.5.22
       tree-sitter-bash:
         specifier: 0.25.1
         version: 0.25.1
@@ -7312,8 +7312,8 @@ packages:
   tar-stream@3.2.0:
     resolution: {integrity: sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg==}
 
-  tar@7.5.20:
-    resolution: {integrity: sha512-9FcyK4PA6+WbzlTM9WhQm6vB5W7cP7dUiPsv1g7YDwEQnQ1CGpK3MGlKk/ITVWMk05kHZuBhmVhiv8LZoy/PFQ==}
+  tar@7.5.22:
+    resolution: {integrity: sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA==}
     engines: {node: '>=18'}
 
   teex@1.0.1:
@@ -9229,7 +9229,7 @@ snapshots:
   '@openclaw/fs-safe@0.3.0':
     optionalDependencies:
       jszip: 3.10.1
-      tar: 7.5.20
+      tar: 7.5.22
 
   '@openclaw/proxyline@0.3.3(undici@8.9.0)':
     dependencies:
@@ -10982,7 +10982,7 @@ snapshots:
       node-api-headers: 1.9.0
       rc: 1.2.8
       semver: 7.8.2
-      tar: 7.5.20
+      tar: 7.5.22
       url-join: 4.0.1
       which: 6.0.1
       yargs: 17.7.2
@@ -13853,7 +13853,7 @@ snapshots:
       - bare-buffer
       - react-native-b4a
 
-  tar@7.5.20:
+  tar@7.5.22:
     dependencies:
       '@isaacs/fs-minipass': 4.0.1
       chownr: 3.0.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -121,7 +121,7 @@ overrides:
   qs: 6.15.2
   node-domexception: "npm:@nolyfill/domexception@1.0.28"
   typebox: 1.1.39
-  tar: 7.5.20
+  tar: 7.5.22
   tough-cookie: 4.1.3
   yauzl: 3.2.1
   protobufjs: 7.6.5


### PR DESCRIPTION
## Summary

- update the direct `tar` runtime dependency and authoritative workspace override from 7.5.20 to 7.5.22
- regenerate the pnpm lockfile plus the root and `llama-cpp` npm shrinkwraps that resolve this dependency

## Why

The exact frozen-candidate CI proof for #127002 is blocked by the production-dependency audit on `tar@7.5.20`. The candidate uses `tar` for archive handling; this patch preserves its existing 7.x API and Node >=18 contract while adopting the upstream patch release that bounds the affected archive-filter recursion.

## Proof

- Exact failing candidate run: https://github.com/openclaw/openclaw/actions/runs/33224694066/job/99025887747
- `corepack pnpm install --lockfile-only`
- `corepack pnpm deps:shrinkwrap:check`
- `node scripts/run-vitest.mjs test/scripts/pnpm-audit-prod.test.ts` (20 passed)
- `node scripts/run-vitest.mjs test/scripts/generate-npm-shrinkwrap.test.ts` (23 passed)
- `node scripts/pre-commit/pnpm-audit-prod.mjs --audit-level=high` (no high-or-higher production advisories)
- `corepack pnpm exec oxfmt --check package.json pnpm-workspace.yaml pnpm-lock.yaml`
- `git diff --check`
- autoreview clean (0.99)

Production delta: direct dependency, workspace override, and resolved metadata only; 17 additions / 17 removals across the five required graph artifacts. No product source changes.