### PR TITLE
fix(presence): keep colliding profiles and raw viewers separate

### DIFF
--- a/docs/concepts/multi-user.md
+++ b/docs/concepts/multi-user.md
@@ -62,13 +62,13 @@ When the loaded session list contains fewer than two distinct owner identities a
 
 ## People cards
 
-Hover, focus, click, or tap a person in the sidebar's **Online** section to open their information card. Select **View activity** in the card to open that person's Activity page.
+Hover, focus, click, or tap a person in the sidebar's **Online** section to open their information card. For a qualified Gateway profile, select **View activity** in the card to open that person's Activity page. Unqualified viewers still have connection details and visible watched sessions, but no profile Activity link.
 
 The card shows how long the person has been continuously connected, their reported app/device context and time zone, and their last observed activity during that online period. Opening a different session, typing, and sending a new message count as activity; connection heartbeats and agent responses do not. **Not observed yet** means no qualifying activity has been recorded, not that the person is inactive. These timing facts are ephemeral and reset after the person's final connection closes or the Gateway restarts.
 
 People presence is shared with operators who have read access (`operator.read`, also implied by `operator.write` or `operator.admin`). Those readers may see other people's online and activity timing and reported time zone whether or not the person is watching a session. Node and pairing-only connections receive neither the presence inventory nor its activity-driven events. This does not change cross-reader IP visibility or provide isolation for all Gateway metadata; see [Who can see presence](/concepts/presence#who-can-see-presence).
 
-**Viewing now** and **Recent sessions** link only to sessions available in your loaded session list. Recent sessions reflect reliable ownership or creation attribution, not a complete history of the person's contributions. Session update times describe the session, not when that person last acted. Connection descriptions and time zones are client-reported hints, not verified physical locations.
+**Viewing now** and **Recent sessions** link only to sessions available in your loaded session list. Recent sessions require the same recorded profile identity on both the viewer and the owner or creator; matching raw IDs are not enough. They are not a complete history of the person's contributions. Session update times describe the session, not when that person last acted. Connection descriptions and time zones are client-reported hints, not verified physical locations.
 
 The Gateway also filters watched-session references for each recipient using `sessions.list` visibility rules, across connect snapshots, presence RPC responses, and events. Hidden or missing references are omitted without counts or placeholders; opening someone's card never borrows that person's session access.
 

--- a/docs/concepts/presence.md
+++ b/docs/concepts/presence.md
@@ -116,8 +116,17 @@ by parsed host or other beacon metadata. A stable `instanceId` helps consumers
 associate rows with the same client; it does not merge separate user WebSocket
 connections. Ephemeral control-plane clients are excluded from tracking entirely.
 
-The Control UI groups connection rows by authenticated identity when displaying
-people. The [people card](/concepts/multi-user#people-cards) keeps online duration
+The Control UI groups connection rows by their recorded identity namespace when
+displaying people. Connections with the same qualified profile identity share one
+person; unqualified connections with the same raw ID form a separate group. A raw
+ID matching a profile ID never combines their watched sessions, connection facts,
+or viewer counts. The Gateway uses the same namespace boundary for online/activity
+timing and collaborative typing counts. Overlapping tabs share timing facts only
+within their namespace; later activity stays separate if a raw tab gains profile
+qualification. Self exclusion follows the authenticated user's recorded
+qualification, using the current connection only when that user is unavailable.
+Only a displayed owner with the exact qualified profile identity is deduplicated
+from a session's live viewers. The [people card](/concepts/multi-user#people-cards) keeps online duration
 and observed activity separate from each entry's heartbeat freshness.
 
 ## TTL and bounded size

--- a/packages/gateway-protocol/src/schema/snapshot.ts
+++ b/packages/gateway-protocol/src/schema/snapshot.ts
@@ -38,7 +38,7 @@ export const PresenceEntrySchema = closedObject({
   instanceId: Type.Optional(NonEmptyString),
   user: Type.Optional(
     closedObject({
-      /** Canonical profile id when resolved, otherwise authenticated identity. Clients group presence by this. */
+      /** Canonical profile id when resolved, otherwise authenticated identity; grouping also uses identity qualification. */
       id: NonEmptyString,
       identity: Type.Optional(SessionPersonSchema.properties.identity),
       email: Type.Optional(NonEmptyString),

--- a/src/gateway/server-methods/session-typing-state.ts
+++ b/src/gateway/server-methods/session-typing-state.ts
@@ -1,6 +1,7 @@
 import { pruneMapToMaxSize } from "../../infra/map-size.js";
 import { listSystemPresence } from "../../infra/system-presence.js";
 import { resolveGlobalSingleton } from "../../shared/global-singleton.js";
+import { presenceUserKey } from "../../shared/presence-user.js";
 
 export const TYPING_THROTTLE_MS = 1_000;
 export const TYPING_PREVIEW_THROTTLE_MS = 250;
@@ -50,14 +51,11 @@ export function clearSessionTypingState(): void {
 
 export function liveViewerIdentities(sessionKeys: ReadonlySet<string>): Set<string> {
   return new Set(
-    listSystemPresence()
-      .filter(
-        (entry) =>
-          entry.user?.id &&
-          entry.watchedSessions?.some((sessionKey) => sessionKeys.has(sessionKey)),
-      )
-      .map((entry) => entry.user?.id)
-      .filter((id): id is string => Boolean(id)),
+    listSystemPresence().flatMap((entry) =>
+      entry.user?.id && entry.watchedSessions?.some((sessionKey) => sessionKeys.has(sessionKey))
+        ? [presenceUserKey(entry.user)]
+        : [],
+    ),
   );
 }
 

--- a/src/gateway/server-methods/sessions-suggestions.test-mocks.ts
+++ b/src/gateway/server-methods/sessions-suggestions.test-mocks.ts
@@ -1,4 +1,5 @@
 import { vi } from "vitest";
+import type { PresenceEntry } from "../../../packages/gateway-protocol/src/schema/snapshot.js";
 
 const mocks = vi.hoisted(() => ({
   handleChatSend: vi.fn(),
@@ -8,7 +9,7 @@ const mocks = vi.hoisted(() => ({
     | "release-unexpected"
     | "finalize"
     | undefined,
-  presence: [] as Array<{ user?: { id: string; name?: string }; watchedSessions?: string[] }>,
+  presence: [] as Array<Pick<PresenceEntry, "user" | "watchedSessions">>,
 }));
 
 vi.mock("./chat-send-handler.js", () => ({ handleChatSend: mocks.handleChatSend }));

--- a/src/gateway/server-methods/sessions-suggestions.test.ts
+++ b/src/gateway/server-methods/sessions-suggestions.test.ts
@@ -391,7 +391,12 @@ describe("session suggestion handlers", () => {
       await upsertDefaultSuggestionSession();
       const broadcast = vi.fn();
       const requestContext = context(broadcast);
-      mocks.presence = [{ user: { id: "alice" }, watchedSessions: [sessionKey] }];
+      mocks.presence = [
+        {
+          user: { id: "alice", identity: { type: "profile", id: "alice" } },
+          watchedSessions: [sessionKey],
+        },
+      ];
       const solo = await call(
         "session.typing",
         { sessionKey, sessionId: "session-main", typing: true },
@@ -401,7 +406,10 @@ describe("session suggestion handlers", () => {
       expect(solo.responses[0]?.[1]).toEqual({ ok: true, broadcast: false });
       expect(broadcast).not.toHaveBeenCalled();
 
-      mocks.presence.push({ user: { id: "owner" }, watchedSessions: [sessionKey] });
+      mocks.presence.push({
+        user: { id: "owner", identity: { type: "profile", id: "owner" } },
+        watchedSessions: [sessionKey],
+      });
       const collaborative = await call(
         "session.typing",
         { sessionKey, sessionId: "session-main", typing: true },
@@ -446,8 +454,14 @@ describe("session suggestion handlers", () => {
       );
 
       mocks.presence = [
-        { user: { id: "owner" }, watchedSessions: [sessionKey] },
-        { user: { id: "bob" }, watchedSessions: [sessionKey] },
+        {
+          user: { id: "owner", identity: { type: "profile", id: "owner" } },
+          watchedSessions: [sessionKey],
+        },
+        {
+          user: { id: "bob", identity: { type: "profile", id: "bob" } },
+          watchedSessions: [sessionKey],
+        },
       ];
       vi.setSystemTime(4_000);
       const notViewing = await call(
@@ -468,8 +482,14 @@ describe("session suggestion handlers", () => {
         },
       );
       mocks.presence = [
-        { user: { id: "shared-alice" }, watchedSessions: [sessionKey] },
-        { user: { id: "owner" }, watchedSessions: [sessionKey] },
+        {
+          user: { id: "shared-alice", identity: { type: "profile", id: "shared-alice" } },
+          watchedSessions: [sessionKey],
+        },
+        {
+          user: { id: "owner", identity: { type: "profile", id: "owner" } },
+          watchedSessions: [sessionKey],
+        },
       ];
       vi.setSystemTime(5_000);
       const sharedViewer = await call(

--- a/src/gateway/server-methods/sessions-suggestions.ts
+++ b/src/gateway/server-methods/sessions-suggestions.ts
@@ -20,6 +20,7 @@ import {
   SESSION_SUGGESTION_DISPATCH_CLAIM_TTL_MS,
   type StoredSessionSuggestion,
 } from "../../config/sessions.js";
+import { presenceUserKey } from "../../shared/presence-user.js";
 import { operatorSessionCap } from "../operator-role-policy.js";
 import { sessionObserverScopeKey } from "../session-observer-model.js";
 import { tryResolveSessionCompatibilityOwnerAgentId } from "../session-request-agent.js";
@@ -616,7 +617,11 @@ export const sessionSuggestionHandlers: GatewayRequestHandlers = {
           return false;
         }
         const liveIdentities = liveViewerIdentities(sessionKeys);
-        if (liveIdentities.size < 2 || !liveIdentities.has(actor.id)) {
+        const actorKey = presenceUserKey({
+          id: actor.id,
+          identity: { type: "profile", id: actor.id },
+        });
+        if (liveIdentities.size < 2 || !liveIdentities.has(actorKey)) {
           return false;
         }
         const event: SessionTypingEvent = {

--- a/src/gateway/server-methods/sessions-typing.test.ts
+++ b/src/gateway/server-methods/sessions-typing.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { PresenceEntry } from "../../../packages/gateway-protocol/src/schema/snapshot.js";
 import { upsertSessionEntryCore } from "../../config/sessions/session-accessor.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { closeOpenClawAgentDatabasesForTest } from "../../state/openclaw-agent-db.js";
@@ -7,15 +8,16 @@ import { sessionSuggestionHandlers } from "./sessions-suggestions.js";
 import type { GatewayClient, GatewayRequestContext, RespondFn } from "./types.js";
 
 const mocks = vi.hoisted(() => ({
-  presence: [] as Array<{
-    user?: { id: string; name?: string };
-    watchedSessions?: string[];
-  }>,
+  presence: [] as Array<Pick<PresenceEntry, "user" | "watchedSessions">>,
 }));
 
 vi.mock("../../infra/system-presence.js", () => ({
   listSystemPresence: () => mocks.presence,
 }));
+
+function profileUser(id: string): NonNullable<PresenceEntry["user"]> {
+  return { id, identity: { type: "profile", id } };
+}
 
 function client(profileId: string, connId: string): GatewayClient {
   return {
@@ -92,6 +94,59 @@ afterEach(() => {
 });
 
 describe("session typing handler", () => {
+  it.each([
+    {
+      name: "counts a same-id raw viewer separately from the profile actor",
+      presence: [{ user: profileUser("shared") }, { user: { id: "shared" } }],
+      expected: true,
+    },
+    {
+      name: "does not let a raw viewer establish profile actor membership",
+      presence: [{ user: { id: "shared" } }, { user: profileUser("other") }],
+      expected: false,
+    },
+    {
+      name: "counts multiple tabs of the profile actor once",
+      presence: [{ user: profileUser("shared") }, { user: profileUser("shared") }],
+      expected: false,
+    },
+  ])("$name", async ({ name, presence, expected }) => {
+    await withOpenClawTestState({ scenario: "minimal" }, async () => {
+      const sessionKey = `agent:main:typing-namespace-${name.replaceAll(" ", "-")}`;
+      const sessionId = "typing-namespace";
+      await upsertSessionEntryCore(
+        { agentId: "main", sessionKey },
+        {
+          sessionId,
+          updatedAt: 1,
+          createdActor: { type: "human", id: "shared" },
+          visibility: "shared",
+        },
+      );
+      mocks.presence = presence.map((entry) => ({ ...entry, watchedSessions: [sessionKey] }));
+      const broadcast = vi.fn();
+      expect(
+        await callTyping({
+          sessionKey,
+          sessionId,
+          typing: true,
+          preview: "draft preview",
+          client: client("shared", "typing-namespace-actor"),
+          context: context(broadcast),
+        }),
+      ).toEqual({ ok: true, broadcast: expected });
+      if (expected) {
+        expect(broadcast).toHaveBeenCalledExactlyOnceWith(
+          "session.typing",
+          expect.objectContaining({ actor: { type: "human", id: "shared", label: "shared" } }),
+          expect.objectContaining({ sessionKeys: [sessionKey] }),
+        );
+      } else {
+        expect(broadcast).not.toHaveBeenCalled();
+      }
+    });
+  });
+
   it("broadcasts bounded draft previews and never includes previews after typing stops", async () => {
     await withOpenClawTestState({ scenario: "minimal" }, async () => {
       vi.useFakeTimers();
@@ -107,8 +162,8 @@ describe("session typing handler", () => {
         },
       );
       mocks.presence = [
-        { user: { id: "alice" }, watchedSessions: [sessionKey] },
-        { user: { id: "owner" }, watchedSessions: [sessionKey] },
+        { user: profileUser("alice"), watchedSessions: [sessionKey] },
+        { user: profileUser("owner"), watchedSessions: [sessionKey] },
       ];
       const broadcast = vi.fn();
       const params = {
@@ -157,8 +212,8 @@ describe("session typing handler", () => {
         },
       );
       mocks.presence = [
-        { user: { id: "alice" }, watchedSessions: [sessionKey] },
-        { user: { id: "owner" }, watchedSessions: [sessionKey] },
+        { user: profileUser("alice"), watchedSessions: [sessionKey] },
+        { user: profileUser("owner"), watchedSessions: [sessionKey] },
       ];
       const broadcast = vi.fn();
       const params = {
@@ -209,8 +264,8 @@ describe("session typing handler", () => {
         },
       );
       mocks.presence = [
-        { user: { id: "alice" }, watchedSessions: ["global"] },
-        { user: { id: "owner" }, watchedSessions: ["global"] },
+        { user: profileUser("alice"), watchedSessions: ["global"] },
+        { user: profileUser("owner"), watchedSessions: ["global"] },
       ];
       const broadcast = vi.fn();
 
@@ -247,8 +302,8 @@ describe("session typing handler", () => {
         },
       );
       mocks.presence = [
-        { user: { id: "multi" }, watchedSessions: [sessionKey] },
-        { user: { id: "owner" }, watchedSessions: [sessionKey] },
+        { user: profileUser("multi"), watchedSessions: [sessionKey] },
+        { user: profileUser("owner"), watchedSessions: [sessionKey] },
       ];
       const broadcast = vi.fn();
       const requestContext = context(broadcast);
@@ -302,8 +357,8 @@ describe("session typing handler", () => {
         );
       await writeSession("session-before-reset", 1);
       mocks.presence = [
-        { user: { id: "alice" }, watchedSessions: [sessionKey] },
-        { user: { id: "owner" }, watchedSessions: [sessionKey] },
+        { user: profileUser("alice"), watchedSessions: [sessionKey] },
+        { user: profileUser("owner"), watchedSessions: [sessionKey] },
       ];
       const broadcast = vi.fn();
       const requestContext = context(broadcast);
@@ -371,8 +426,8 @@ describe("session typing handler", () => {
         visibility: "shared",
       });
       mocks.presence = [
-        { user: { id: "alice" }, watchedSessions: [sessionKey] },
-        { user: { id: "owner" }, watchedSessions: [sessionKey] },
+        { user: profileUser("alice"), watchedSessions: [sessionKey] },
+        { user: profileUser("owner"), watchedSessions: [sessionKey] },
       ];
       const broadcast = vi.fn();
       const params = {

--- a/src/gateway/server/client-presence.test.ts
+++ b/src/gateway/server/client-presence.test.ts
@@ -155,6 +155,110 @@ describe("live person presence timing", () => {
     expect(row("fresh@timing.test")?.lastActivityAt).toBeUndefined();
   });
 
+  it.each(["profile", "raw"] as const)(
+    "separates colliding presence namespaces when %s connects first",
+    async (firstNamespace) => {
+      const id = "synthetic-shared-id";
+      const profile = await connect("profile@namespace.test", id);
+      const raw = await connect(id);
+      delete raw.client.authenticatedUserProfile;
+      const [first, second] =
+        firstNamespace === "profile" ? ([profile, raw] as const) : ([raw, profile] as const);
+      const started = Date.now();
+      first.handler.setClient(first.client);
+      vi.setSystemTime(started + 1_000);
+      second.handler.setClient(second.client);
+      const profileStarted = started + (firstNamespace === "profile" ? 0 : 1_000);
+      const rawStarted = started + (firstNamespace === "raw" ? 0 : 1_000);
+      expect.soft(row("profile@namespace.test")?.onlineSince).toBe(profileStarted);
+      expect.soft(row(id)?.onlineSince).toBe(rawStarted);
+
+      vi.setSystemTime(started + 2_000);
+      expect(recordClientPresenceActivity(clients, raw.client)).toBe(true);
+      expect.soft(row("profile@namespace.test")?.lastActivityAt).toBeUndefined();
+      vi.setSystemTime(started + 3_000);
+      expect(recordClientPresenceActivity(clients, profile.client)).toBe(true);
+      expect.soft(row(id)).toMatchObject({
+        onlineSince: rawStarted,
+        lastActivityAt: started + 2_000,
+      });
+
+      vi.setSystemTime(started + 4_000);
+      const overlap = await connect("overlap@namespace.test", id);
+      overlap.handler.setClient(overlap.client);
+      profile.socket.readyState = 3;
+      profile.socket.emit("close", 1000, Buffer.alloc(0));
+      expect.soft(row("overlap@namespace.test")).toMatchObject({
+        onlineSince: profileStarted,
+        lastActivityAt: started + 3_000,
+      });
+      overlap.socket.readyState = 3;
+      overlap.socket.emit("close", 1000, Buffer.alloc(0));
+
+      vi.setSystemTime(started + 5_000);
+      const reconnected = await connect("reconnected@namespace.test", id);
+      reconnected.handler.setClient(reconnected.client);
+      expect.soft(row("reconnected@namespace.test")?.onlineSince).toBe(started + 5_000);
+      expect.soft(row("reconnected@namespace.test")?.lastActivityAt).toBeUndefined();
+      expect.soft(row(id)).toMatchObject({
+        onlineSince: rawStarted,
+        lastActivityAt: started + 2_000,
+      });
+    },
+  );
+
+  it.each(["profile", "raw"] as const)(
+    "keeps later activity separate after raw tabs qualify (%s acts first)",
+    async (firstNamespace) => {
+      const id = "qualification-shared-id";
+      const raw = await connect(id, id);
+      const qualified = await connect(id, id);
+      const profile = qualified.client.authenticatedUserProfile;
+      delete raw.client.authenticatedUserProfile;
+      delete qualified.client.authenticatedUserProfile;
+      const started = Date.now();
+      raw.handler.setClient(raw.client);
+      vi.setSystemTime(started + 1_000);
+      qualified.handler.setClient(qualified.client);
+      vi.setSystemTime(started + 2_000);
+      recordClientPresenceActivity(clients, raw.client);
+      const liveRows = (isProfile: boolean) =>
+        listSystemPresence().filter(
+          (entry) =>
+            entry.reason !== "disconnect" &&
+            entry.user?.id === id &&
+            Boolean(entry.user.identity) === isProfile,
+        );
+      expect(liveRows(false)).toHaveLength(2);
+      for (const entry of liveRows(false)) {
+        expect(entry).toMatchObject({ onlineSince: started, lastActivityAt: started + 2_000 });
+      }
+
+      qualified.client.authenticatedUserProfile = profile;
+      const [first, second] =
+        firstNamespace === "profile" ? ([qualified, raw] as const) : ([raw, qualified] as const);
+      vi.setSystemTime(started + 3_000);
+      // Activity can be the first presence operation after the profile snapshot changes.
+      recordClientPresenceActivity(clients, first.client);
+      refreshClientPresence(clients, second.client);
+      expect.soft(liveRows(firstNamespace !== "profile")[0]).toMatchObject({
+        onlineSince: started,
+        lastActivityAt: started + 2_000,
+      });
+      vi.setSystemTime(started + 4_000);
+      recordClientPresenceActivity(clients, second.client);
+      refreshClientPresence(clients, first.client);
+      expect.soft(liveRows(firstNamespace === "profile")[0]).toMatchObject({
+        onlineSince: started,
+        lastActivityAt: started + 3_000,
+      });
+      expect.soft(liveRows(firstNamespace !== "profile")[0]).toMatchObject({
+        onlineSince: started,
+        lastActivityAt: started + 4_000,
+      });
+    },
+  );
+
   it("keeps heartbeat freshness and cache eviction independent of person timing", async () => {
     const first = await connect("heartbeat@timing.test", "heartbeat-person");
     const started = Date.now();

--- a/src/gateway/server/client-presence.ts
+++ b/src/gateway/server/client-presence.ts
@@ -1,4 +1,5 @@
 import { upsertPresence } from "../../infra/system-presence.js";
+import { presenceUserKey } from "../../shared/presence-user.js";
 import { buildAuthenticatedPresenceUser } from "../authenticated-presence-user.js";
 import { WEBSOCKET_OPEN_READY_STATE } from "../server-constants.js";
 import type { GatewayClient } from "../server-methods/types.js";
@@ -9,10 +10,12 @@ function isLiveClient(client: GatewayWsClient): boolean {
 }
 
 function presenceIdentity(client: GatewayWsClient): string | undefined {
-  return (
-    client.authenticatedUserProfile?.profileId ??
-    (client.authenticatedGitHubIdentitySync ? undefined : client.authenticatedUserId)
-  );
+  const profileId = client.authenticatedUserProfile?.profileId;
+  return profileId
+    ? presenceUserKey({ id: profileId, identity: { type: "profile", id: profileId } })
+    : client.authenticatedUserId && !client.authenticatedGitHubIdentitySync
+      ? presenceUserKey({ id: client.authenticatedUserId })
+      : undefined;
 }
 
 /** Reconciles canonical identity and timing using only currently registered sockets. */
@@ -34,7 +37,7 @@ export function refreshClientPresence(
       presenceIdentity(peer) === identity &&
       (peer === client || (client.personPresence && peer.personPresence)),
   );
-  const timing = client.personPresence;
+  const timing = client.personPresence ? { ...client.personPresence } : undefined;
   for (const peer of peers) {
     if (timing && peer.personPresence) {
       timing.onlineSince = Math.min(timing.onlineSince, peer.personPresence.onlineSince);
@@ -45,10 +48,10 @@ export function refreshClientPresence(
     }
   }
   for (const peer of peers) {
-    // Nodes retain their device lifecycle. Only person sockets share the interval,
-    // including its original start after the oldest socket closes or a profile merges.
+    // Copy interval facts so later profile qualification cannot leave raw and
+    // profile sockets sharing mutable activity. Nodes retain their device lifecycle.
     if (timing && peer.personPresence) {
-      peer.personPresence = timing;
+      peer.personPresence = { ...timing };
     }
     upsertPresence(peer.presenceKey!, {
       user: buildAuthenticatedPresenceUser(peer),
@@ -73,7 +76,7 @@ export function recordClientPresenceActivity(
     ) {
       continue;
     }
-    live.personPresence.lastActivityAt = Date.now();
+    live.personPresence = { ...live.personPresence, lastActivityAt: Date.now() };
     return refreshClientPresence(clients, live);
   }
   return false;

--- a/src/gateway/server/ws-types.ts
+++ b/src/gateway/server/ws-types.ts
@@ -34,7 +34,7 @@ export type GatewayWsClient = PluginNodeCapabilityClient & {
   usesSharedGatewayAuth: boolean;
   sharedGatewaySessionGeneration?: string;
   presenceKey?: string;
-  /** Shared by overlapping identified person sockets; never owned by the presence TTL cache. */
+  /** Connection-owned timing facts, reconciled across live peers independently of the TTL cache. */
   personPresence?: { onlineSince: number; lastActivityAt?: number };
   authenticatedUserId?: string;
   /** Verified Tailscale provider identity; generic proxy identities must not infer this. */

--- a/src/shared/presence-user.ts
+++ b/src/shared/presence-user.ts
@@ -1,0 +1,8 @@
+import type { PresenceEntry } from "../../packages/gateway-protocol/src/schema/snapshot.js";
+
+/** Presence namespaces come from recorded identity, never display metadata or raw-id shape. */
+export function presenceUserKey(
+  user: Pick<NonNullable<PresenceEntry["user"]>, "id" | "identity">,
+): string {
+  return user.identity ? `profile:${user.identity.id}` : `raw:${user.id}`;
+}

--- a/ui/src/app/gateway-store.test.ts
+++ b/ui/src/app/gateway-store.test.ts
@@ -10,6 +10,7 @@ import {
   stubGatewayStoreTestGlobals,
 } from "./gateway-store.test-support.ts";
 import { loadSettings } from "./settings.ts";
+import { readPresenceEntries, resolveCurrentSelfUser } from "./user-profile.ts";
 
 const { scheduleStaleChunkReloadMock } = vi.hoisted(() => ({
   scheduleStaleChunkReloadMock: vi.fn(async () => true),
@@ -920,24 +921,49 @@ describe("createApplicationGateway connection phase", () => {
     expect(gateway.eventLog).toHaveLength(1);
   });
 
-  it("updates sender provenance when presence qualification alone changes", () => {
-    const { gateway, current } = createStore();
-    gateway.start();
-    const user = { id: "same-id", name: "Person", avatarUrl: "/api/users/same-id/avatar" };
-    current().opts.onHello?.({
-      ...HELLO,
-      snapshot: { presence: [{ instanceId: current().instanceId, user }] },
-    });
-    const identity = { type: "profile", id: user.id };
-    for (const nextUser of [{ ...user, identity }, user, { ...user, identity }]) {
-      current().opts.onEvent?.({
-        type: "event",
-        event: "presence",
-        payload: { presence: [{ instanceId: current().instanceId, user: nextUser }] },
+  it.each([false, true])(
+    "keeps refreshed self authoritative over hello (initial profile: %s)",
+    (qualified) => {
+      const { gateway, current } = createStore();
+      gateway.start();
+      const user = { id: "same-id", name: "Person", avatarUrl: "/api/users/same-id/avatar" };
+      const profile = { ...user, identity: { type: "profile" as const, id: user.id } };
+      const initialUser = qualified ? profile : user;
+      current().opts.onHello?.({
+        ...HELLO,
+        snapshot: { presence: [{ instanceId: current().instanceId, user: initialUser }] },
       });
-      expect(gateway.snapshot.selfUser).toEqual(nextUser);
-    }
-  });
+      const renderedSelf = vi.fn(() =>
+        resolveCurrentSelfUser({
+          snapshotUser: gateway.snapshot.selfUser,
+          presenceEntries: readPresenceEntries(gateway.snapshot.hello?.snapshot),
+          presenceInstanceId: current().instanceId,
+        }),
+      );
+      gateway.subscribeEvents(renderedSelf);
+      for (const nextUser of [
+        profile,
+        user,
+        {
+          ...profile,
+          id: "merged-profile",
+          identity: { type: "profile" as const, id: "merged-profile" },
+        },
+      ]) {
+        current().opts.onEvent?.({
+          type: "event",
+          event: "presence",
+          payload: { presence: [{ instanceId: current().instanceId, user: nextUser }] },
+        });
+        expect(gateway.snapshot.selfUser).toEqual(nextUser);
+        expect(renderedSelf.mock.lastCall).toBeDefined();
+        expect(renderedSelf.mock.results.at(-1)?.value).toEqual(nextUser);
+        expect(readPresenceEntries(gateway.snapshot.hello?.snapshot)?.[0]?.user).toEqual(
+          initialUser,
+        );
+      }
+    },
+  );
 
   it("projects only this browser connection's optional presence identity", () => {
     const { gateway, current } = createStore();

--- a/ui/src/app/user-profile.test.ts
+++ b/ui/src/app/user-profile.test.ts
@@ -33,13 +33,6 @@ describe("connection user profile helpers", () => {
       id: "profile-1",
       name: "Ada",
     });
-    expect(
-      resolveCurrentSelfUser({
-        snapshotUser: { id: "previous-profile", name: "Previous User" },
-        presenceEntries,
-        presenceInstanceId: "self",
-      }),
-    ).toEqual({ id: "profile-1", name: "Ada" });
   });
 
   it("reads presence payloads", () => {

--- a/ui/src/app/user-profile.ts
+++ b/ui/src/app/user-profile.ts
@@ -24,7 +24,7 @@ export function resolveSelfPresenceUser(
   return entry?.user?.id ? entry.user : null;
 }
 
-/** Prefers local profile edits for the current presence identity only. */
+/** Gateway state owns live identity updates and local profile edits; hello may be stale. */
 export function resolveCurrentSelfUser({
   snapshotUser,
   presenceEntries,
@@ -34,10 +34,5 @@ export function resolveCurrentSelfUser({
   presenceEntries?: readonly PresenceEntry[];
   presenceInstanceId?: string;
 }): AuthenticatedUser | null {
-  const presenceUser = resolveSelfPresenceUser(presenceEntries ?? [], presenceInstanceId);
-  // Gateway state folds newer presence into snapshotUser, so a matching profile is
-  // either the latest presence projection or the local profile edit it should retain.
-  return snapshotUser && (!presenceUser || snapshotUser.id === presenceUser.id)
-    ? snapshotUser
-    : presenceUser;
+  return snapshotUser ?? resolveSelfPresenceUser(presenceEntries ?? [], presenceInstanceId);
 }

--- a/ui/src/components/app-sidebar-render.ts
+++ b/ui/src/components/app-sidebar-render.ts
@@ -1,5 +1,6 @@
 import { html, nothing } from "lit";
 import { repeat } from "lit/directives/repeat.js";
+import { presenceUserKey } from "../../../src/shared/presence-user.ts";
 import type { GatewayControlUiPluginTab } from "../api/gateway.ts";
 import {
   serializeSidebarEntry,
@@ -267,7 +268,7 @@ export function renderAppSidebarOnline(host: AppSidebarRenderHost) {
   });
   const users = projectOnlinePresenceViewers(
     host.sessionData.presencePayload,
-    selfUser?.id,
+    selfUser,
     host.sessionData.presenceInstanceId,
   );
   if (users.length === 0) {
@@ -308,35 +309,32 @@ export function renderAppSidebarOnline(host: AppSidebarRenderHost) {
       ${collapsed
         ? nothing
         : html`<div class="sidebar-online__list">
-            ${repeat(
-              users,
-              (user) => user.id,
-              (user) => {
-                return html`<div class="sidebar-online__row">
-                  <button
-                    class="sidebar-online__person ${isPresenceViewerIdle(user)
-                      ? "sidebar-online__person--away"
-                      : ""}"
-                    type="button"
-                    data-online-user-id=${user.id}
-                    aria-haspopup="dialog"
-                    aria-expanded="false"
-                    aria-label=${t("presence.card.details", { name: presenceViewerLabel(user) })}
+            ${repeat(users, presenceUserKey, (user) => {
+              return html`<div class="sidebar-online__row">
+                <button
+                  class="sidebar-online__person ${isPresenceViewerIdle(user)
+                    ? "sidebar-online__person--away"
+                    : ""}"
+                  type="button"
+                  data-online-user-id=${user.id}
+                  data-online-user-key=${presenceUserKey(user)}
+                  aria-haspopup="dialog"
+                  aria-expanded="false"
+                  aria-label=${t("presence.card.details", { name: presenceViewerLabel(user) })}
+                >
+                  <openclaw-viewer-avatar
+                    .user=${user}
+                    .markAsViewer=${false}
+                    variant="footer"
+                    aria-hidden="true"
+                  ></openclaw-viewer-avatar>
+                  <span class="sidebar-online__person-name">${presenceViewerLabel(user)}</span>
+                  <span class="sidebar-online__person-action" aria-hidden="true"
+                    >${icons.chevronRight}</span
                   >
-                    <openclaw-viewer-avatar
-                      .user=${user}
-                      .markAsViewer=${false}
-                      variant="footer"
-                      aria-hidden="true"
-                    ></openclaw-viewer-avatar>
-                    <span class="sidebar-online__person-name">${presenceViewerLabel(user)}</span>
-                    <span class="sidebar-online__person-action" aria-hidden="true"
-                      >${icons.chevronRight}</span
-                    >
-                  </button>
-                </div>`;
-              },
-            )}
+                </button>
+              </div>`;
+            })}
           </div>`}
     </section>
   `;

--- a/ui/src/components/app-sidebar-session-row-render.ts
+++ b/ui/src/components/app-sidebar-session-row-render.ts
@@ -18,7 +18,7 @@ import {
   stopHoverMarqueeFromEvent,
 } from "../lib/hover-marquee.ts";
 import { handleContextMenuEvent } from "../lib/keyboard-shortcuts.ts";
-import { projectPresencePayload } from "../lib/presence-users.ts";
+import { presenceMatchesProfile, projectPresencePayload } from "../lib/presence-users.ts";
 import type { CatalogSessionKey } from "../lib/sessions/catalog-key.ts";
 import { writeSessionDragData } from "../lib/sessions/drag.ts";
 import type { SidebarSessionsGrouping } from "../lib/sessions/grouping.ts";
@@ -194,14 +194,14 @@ export function renderRecentSession(params: {
       ? session.archivedBy
       : session.owner?.actor
     : undefined;
-  const ownerId = ownerActor?.id?.trim();
-  const ownerViewing = ownerId
-    ? projectPresencePayload(
-        host.sessionData.presencePayload,
-        host.sessionDataContext?.gateway.snapshot.selfUser?.id,
-        host.sessionData.presenceInstanceId,
-      ).users.some((user) => user.id === ownerId && user.watchedSessions.includes(session.key))
-    : undefined;
+  const ownerViewing =
+    ownerActor?.identity?.type === "profile"
+      ? projectPresencePayload(host.sessionData.presencePayload).users.some(
+          (user) =>
+            presenceMatchesProfile(user, ownerActor.identity) &&
+            user.watchedSessions.includes(session.key),
+        )
+      : undefined;
   const gateway = host.sessionDataContext?.gateway;
   const channelAvatarAuth = {
     authTokens: gateway
@@ -218,7 +218,7 @@ export function renderRecentSession(params: {
         gateway.connection.password.trim()),
     ),
   };
-  const { running, leadingIndicator, trailingIndicator, renderedOwnerId } =
+  const { running, leadingIndicator, trailingIndicator, renderedOwnerIdentity } =
     renderSessionLeadingState(
       session,
       ownerActor,
@@ -369,10 +369,10 @@ export function renderRecentSession(params: {
                 : nothing}
               <openclaw-viewer-facepile
                 .presencePayload=${host.sessionData.presencePayload}
-                .selfUserId=${host.sessionDataContext?.gateway.snapshot.selfUser?.id}
+                .selfUser=${host.sessionDataContext?.gateway.snapshot.selfUser}
                 .selfInstanceId=${host.sessionData.presenceInstanceId}
                 .sessionKey=${session.key}
-                .excludeUserId=${renderedOwnerId}
+                .excludeIdentity=${renderedOwnerIdentity}
                 .maxVisible=${3}
                 variant="session"
               ></openclaw-viewer-facepile>

--- a/ui/src/components/person-activity-card.ts
+++ b/ui/src/components/person-activity-card.ts
@@ -10,7 +10,7 @@ import {
   stopHoverMarqueeFromEvent,
 } from "../lib/hover-marquee.ts";
 import { shouldHandleNavigationClick } from "../lib/navigation-click.ts";
-import type { PresenceViewer } from "../lib/presence-users.ts";
+import { presenceMatchesProfile, type PresenceViewer } from "../lib/presence-users.ts";
 import { resolveSessionDisplayName } from "../lib/session-display.ts";
 import {
   resolveSessionPreferredFace,
@@ -250,11 +250,11 @@ export function renderPersonActivityCard(input: PersonCardInput) {
   const recent = sessions.filter(
     ({ row, agentId }) =>
       !watched.has(sessionIdentity(row.key, agentId, input)) &&
-      [row.owner?.actor, row.createdActor].some(
-        (actor) => actor?.type === "human" && actor.id === user.id,
+      [row.owner?.actor, row.createdActor].some((actor) =>
+        presenceMatchesProfile(user, actor?.identity),
       ),
   );
-  const activity = personActivityLink(user.id, input.routing)!;
+  const activity = personActivityLink(user.identity?.id, input.routing);
   return html`<div class="person-activity-card">
     <header class="person-activity-card__header">
       <openclaw-viewer-avatar
@@ -293,10 +293,14 @@ export function renderPersonActivityCard(input: PersonCardInput) {
       </div>
     </dl>
     ${renderSessions(viewing, input, false)}${renderSessions(recent, input, true)}
-    <footer>
-      <a href=${activity.href} @click=${activity.open}
-        >${t("presence.card.viewActivity")}<span aria-hidden="true">${icons.chevronRight}</span></a
-      >
-    </footer>
+    ${activity
+      ? html`<footer>
+          <a href=${activity.href} @click=${activity.open}
+            >${t("presence.card.viewActivity")}<span aria-hidden="true"
+              >${icons.chevronRight}</span
+            ></a
+          >
+        </footer>`
+      : nothing}
   </div>`;
 }

--- a/ui/src/components/session-leading-indicator.ts
+++ b/ui/src/components/session-leading-indicator.ts
@@ -1,5 +1,8 @@
 import { html, nothing, type TemplateResult } from "lit";
-import type { SessionParticipant } from "../../../packages/gateway-protocol/src/schema/session-participant.js";
+import type {
+  SessionParticipant,
+  SessionParticipantIdentity,
+} from "../../../packages/gateway-protocol/src/schema/session-participant.js";
 import { t } from "../i18n/index.ts";
 import type { SidebarRecentSession } from "./app-sidebar-session-types.ts";
 import {
@@ -57,7 +60,7 @@ export function renderSessionLeadingState(
   running: boolean;
   leadingIndicator: TemplateResult | typeof nothing;
   trailingIndicator: TemplateResult | typeof nothing;
-  renderedOwnerId?: string;
+  renderedOwnerIdentity?: SessionParticipantIdentity;
 } {
   const running = sessionHasRunningWork(session);
   const trailingIndicator = session.isChild ? nothing : renderSessionState(session, false);
@@ -170,7 +173,7 @@ export function renderSessionLeadingState(
       trailingIndicator,
       // Single source for facepile dedup: only the identity actually shown in
       // the lead may be excluded, else attention/archived rows hide a viewer.
-      renderedOwnerId: ownerActor?.id,
+      renderedOwnerIdentity: ownerActor?.identity,
     };
   }
   return {

--- a/ui/src/components/sidebar-people.runtime.ts
+++ b/ui/src/components/sidebar-people.runtime.ts
@@ -1,4 +1,5 @@
 import { nothing, render } from "lit";
+import { presenceUserKey } from "../../../src/shared/presence-user.ts";
 import type { GatewayBrowserClient } from "../api/gateway.ts";
 import { selectApplicationSession } from "../app/agent-selection.ts";
 import type { ApplicationGateway } from "../app/gateway.ts";
@@ -129,7 +130,7 @@ export class SidebarPeopleRuntime {
   }
 
   private activate(row: HTMLElement, delay: number): void {
-    const id = row.querySelector<HTMLElement>("[data-online-user-id]")?.dataset.onlineUserId;
+    const id = row.querySelector<HTMLElement>("[data-online-user-key]")?.dataset.onlineUserKey;
     const trigger = row.querySelector<HTMLElement>(".sidebar-online__person");
     if (!id || !trigger || !this.host.connected) {
       return;
@@ -201,9 +202,9 @@ export class SidebarPeopleRuntime {
     });
     const user = projectOnlinePresenceViewers(
       data.presencePayload,
-      self?.id,
+      self,
       data.presenceInstanceId,
-    ).find((person) => person.id === active.id);
+    ).find((person) => presenceUserKey(person) === active.id);
     if (!user) {
       this.close();
       return;

--- a/ui/src/components/viewer-facepile.test.ts
+++ b/ui/src/components/viewer-facepile.test.ts
@@ -151,18 +151,20 @@ it.each(
     await vi.waitFor(async () => {
       await facepile.updateComplete;
       expect(facepile.querySelector("img")?.getAttribute("src")).toBe(
-        provenance === "profile" ? `/api/users/${id}/avatar` : undefined,
+        provenance !== "unqualified" ? `/api/users/${id}/avatar` : undefined,
       );
       expect(facepile.querySelector("a")?.getAttribute("href")).toBe(
-        provenance === "profile" ? `/activity?person=${id}` : undefined,
+        provenance !== "unqualified" ? `/activity?person=${id}` : undefined,
       );
       expect(facepile.querySelector(".viewer-facepile")?.getAttribute("data-viewer-count")).toBe(
-        "1",
+        provenance === "mixed" ? "2" : "1",
       );
       expect(facepile.querySelector(".viewer-avatar")?.getAttribute("aria-label")).toBe(
         "Ada Lovelace",
       );
-      expect(facepile.querySelectorAll("openclaw-viewer-avatar")).toHaveLength(1);
+      expect(facepile.querySelectorAll("openclaw-viewer-avatar")).toHaveLength(
+        provenance === "mixed" ? 2 : 1,
+      );
     });
   },
 );
@@ -208,16 +210,7 @@ it("shares an authenticated avatar blob between the same user in the roster and 
   }
 });
 
-type ViewerFacepileElement = HTMLElement & {
-  presencePayload: unknown;
-  selfUserId?: string;
-  selfInstanceId?: string;
-  sessionKey?: string;
-  excludeUserId?: string;
-  staticParticipants?: readonly SessionParticipant[];
-  maxVisible: number;
-  updateComplete: Promise<boolean>;
-};
+type ViewerFacepileElement = HTMLElementTagNameMap["openclaw-viewer-facepile"];
 
 it.each(["first", "second"])(
   "merges device presence into one non-interactive face watching %s",
@@ -274,12 +267,12 @@ it("renders ordered static participant actors without presence filtering", async
 it("excludes the session owner before choosing visible avatars and overflow", async () => {
   const facepile = document.createElement("openclaw-viewer-facepile") as ViewerFacepileElement;
   facepile.sessionKey = "agent:main:active";
-  facepile.excludeUserId = "owner";
+  facepile.excludeIdentity = { type: "profile", id: "owner" };
   facepile.maxVisible = 2;
   facepile.presencePayload = {
     presence: ["owner", "alice", "bob", "carol"].map((id) => ({
       instanceId: `${id}-instance`,
-      user: { id, name: id },
+      user: { id, identity: { type: "profile", id }, name: id },
       watchedSessions: ["agent:main:active"],
     })),
   };
@@ -311,20 +304,17 @@ it("detects only other viewers watching the requested session", () => {
       },
       {
         instanceId: "alice-instance",
-        user: { id: "alice", name: "Alice" },
+        user: { id: "alice", identity: { type: "profile", id: "alice" }, name: "Alice" },
         watchedSessions: ["agent:main:other"],
       },
     ],
   };
-  expect(hasSessionPresenceViewers(payload, "self", "self-instance", "agent:main:active")).toBe(
-    false,
-  );
-  expect(hasSessionPresenceViewers(payload, "self", "self-instance", "agent:main:other")).toBe(
-    true,
-  );
   expect(
-    hasSessionPresenceViewers(payload, "self", "self-instance", "agent:main:other", "alice"),
+    hasSessionPresenceViewers(payload, { id: "self" }, "self-instance", "agent:main:active"),
   ).toBe(false);
+  expect(
+    hasSessionPresenceViewers(payload, { id: "self" }, "self-instance", "agent:main:other"),
+  ).toBe(true);
 });
 
 it.each([
@@ -360,7 +350,7 @@ it.each([
   },
 ])("excludes authenticated self from session facepiles when $name", async (fixture) => {
   const facepile = document.createElement("openclaw-viewer-facepile") as ViewerFacepileElement;
-  facepile.selfUserId = "self";
+  facepile.selfUser = { id: "self" };
   facepile.selfInstanceId = fixture.selfInstanceId;
   facepile.sessionKey = "agent:main:active";
   facepile.presencePayload = { presence: fixture.presence };

--- a/ui/src/components/viewer-facepile.ts
+++ b/ui/src/components/viewer-facepile.ts
@@ -4,10 +4,11 @@ import type {
   SessionParticipant,
   SessionParticipantIdentity,
 } from "../../../packages/gateway-protocol/src/schema/session-participant.js";
+import type { AuthenticatedUser } from "../app/user-profile.ts";
 import { t } from "../i18n/index.ts";
 import {
   presenceViewerLabel,
-  projectPresencePayload,
+  projectPresenceViewers,
   type PresenceViewer,
 } from "../lib/presence-users.ts";
 import { OpenClawLightDomContentsElement } from "../lit/openclaw-element.ts";
@@ -23,11 +24,6 @@ import {
   type PersonActivityRouting,
 } from "./person-activity-link.ts";
 import "./tooltip.ts";
-
-function normalized(value: string | null | undefined): string | undefined {
-  const trimmed = value?.trim();
-  return trimmed ? trimmed : undefined;
-}
 
 function renderViewerAvatar(view: IdentityAvatarView) {
   const fallback = html`<span
@@ -75,10 +71,10 @@ class ViewerAvatar extends OpenClawLightDomContentsElement {
 
 class ViewerFacepile extends OpenClawLightDomContentsElement {
   @property({ attribute: false }) presencePayload: unknown;
-  @property({ attribute: false }) selfUserId?: string;
+  @property({ attribute: false }) selfUser?: AuthenticatedUser | null;
   @property({ attribute: false }) selfInstanceId?: string;
   @property({ attribute: false }) sessionKey?: string;
-  @property({ attribute: false }) excludeUserId?: string;
+  @property({ attribute: false }) excludeIdentity?: SessionParticipantIdentity;
   @property({ attribute: false }) staticParticipants?: readonly SessionParticipant[];
   /** Prepared live presence for the collapsed Online section. */
   @property({ attribute: false }) staticUsers?: readonly PresenceViewer[];
@@ -92,21 +88,13 @@ class ViewerFacepile extends OpenClawLightDomContentsElement {
   @property({ attribute: false }) personActivity?: PersonActivityRouting;
 
   override render() {
-    const projection = projectPresencePayload(
+    const viewers = projectPresenceViewers(
       this.presencePayload,
-      this.selfUserId,
+      this.selfUser,
       this.selfInstanceId,
+      this.sessionKey,
+      this.excludeIdentity,
     );
-    const sessionKey = this.sessionKey;
-    const excludeUserId = normalized(this.excludeUserId);
-    const viewers = sessionKey
-      ? projection.users.filter(
-          (user) =>
-            user.id !== projection.selfUserId &&
-            user.id !== excludeUserId &&
-            user.watchedSessions.includes(sessionKey),
-        )
-      : projection.users.filter((user) => user.id !== projection.selfUserId);
     const users = this.staticParticipants
       ? this.staticParticipants.map(({ identity, label, avatarUrl }) => ({
           identity,

--- a/ui/src/e2e/activity-session-feed.capture.e2e.test.ts
+++ b/ui/src/e2e/activity-session-feed.capture.e2e.test.ts
@@ -213,9 +213,15 @@ suite.define(() => {
         await installMockGateway(page, {
           hasMultipleSessionSharingIdentities: true,
           presenceUsers: [
-            { self: true, id: "profile-self", name: "Operator" },
+            {
+              self: true,
+              id: "profile-self",
+              identity: { type: "profile", id: "profile-self" },
+              name: "Operator",
+            },
             {
               id: "profile-alice",
+              identity: { type: "profile", id: "profile-alice" },
               name: "Alice Chen",
               email: "alice@example.test",
               host: "Alice's MacBook Pro",
@@ -227,6 +233,7 @@ suite.define(() => {
             },
             {
               id: "profile-bob",
+              identity: { type: "profile", id: "profile-bob" },
               name: "Bob Rivera",
               email: "bob@example.test",
               host: "Bob's Mac Studio",
@@ -237,12 +244,14 @@ suite.define(() => {
             },
             {
               id: "profile-carol",
+              identity: { type: "profile", id: "profile-carol" },
               name: "Carol Singh",
               lastInputSeconds: 14,
               watchedSessions: [releaseKey],
             },
             {
               id: "profile-dan",
+              identity: { type: "profile", id: "profile-dan" },
               name: "Dan Wu",
               lastInputSeconds: 70,
               watchedSessions: [designKey],

--- a/ui/src/e2e/chat-attributed-identity.e2e.test.ts
+++ b/ui/src/e2e/chat-attributed-identity.e2e.test.ts
@@ -290,7 +290,7 @@ suite.define(() => {
     await context.close();
   });
 
-  it("keeps attributed user avatars beside their bubbles through send reconciliation", async () => {
+  it("keeps refreshed self attribution through profile qualification and send reconciliation", async () => {
     const context = await suite.browser.newContext({
       viewport: { height: 900, width: 860 },
     });
@@ -298,6 +298,17 @@ suite.define(() => {
     const localSenderId = "c3e32452-0467-47e5-aafa-233cd5dae29f";
     const peerSenderId = "315ee057-302f-45b4-829d-2c5db1bfed75";
     const localAvatarUrl = `/api/users/${localSenderId}/avatar?v=7`;
+    const localUser = {
+      id: localSenderId,
+      identity: { type: "profile" as const, id: localSenderId },
+      name: "Collin Johnson",
+      avatarUrl: localAvatarUrl,
+    };
+    const peerUser = {
+      id: peerSenderId,
+      identity: { type: "profile" as const, id: peerSenderId },
+      name: "Riley Chen",
+    };
     const priorPrompt = "A prior attributed prompt.";
     const peerPrompt = "A peer attributed prompt.";
     const prompt = "A newly sent attributed prompt.";
@@ -343,11 +354,10 @@ suite.define(() => {
         {
           self: true,
           id: localSenderId,
-          identity: { type: "profile", id: localSenderId },
-          name: "Collin Johnson",
+          name: "Raw login",
           avatarUrl: localAvatarUrl,
         },
-        { id: peerSenderId, identity: { type: "profile", id: peerSenderId }, name: "Riley Chen" },
+        peerUser,
       ],
     });
 
@@ -378,6 +388,17 @@ suite.define(() => {
 
     try {
       await page.goto(controlUiSessionUrl(suite.server.baseUrl, "agent:main:main"));
+      await page.getByText(priorPrompt, { exact: true }).waitFor();
+      await captureProof(page, "self-before-qualification.png");
+      const connect = await gateway.waitForRequest("connect");
+      const { client } = connect.params as { client: { instanceId: string } };
+      await gateway.emitGatewayEvent("presence", {
+        presence: [
+          { instanceId: client.instanceId, user: localUser, ts: Date.now() },
+          { instanceId: "peer-tab", user: peerUser, ts: Date.now() },
+        ],
+      });
+      await expect(page.locator(".sidebar-identity-card")).toContainText(localUser.name);
       const before = await readUserAvatarLayout(priorPrompt);
       const peerBefore = await readUserAvatarLayout(peerPrompt);
 
@@ -387,6 +408,7 @@ suite.define(() => {
       const afterSend = await readUserAvatarLayout(prompt);
       const priorAfterSend = await readUserAvatarLayout(priorPrompt);
       const peerAfterSend = await readUserAvatarLayout(peerPrompt);
+      await captureProof(page, "self-after-qualification-send.png");
 
       const params = sendRequest.params;
       if (!params || typeof params !== "object" || !("idempotencyKey" in params)) {

--- a/ui/src/e2e/chat-header-owner-presence.capture.e2e.test.ts
+++ b/ui/src/e2e/chat-header-owner-presence.capture.e2e.test.ts
@@ -29,14 +29,21 @@ suite.define(() => {
         await installMockGateway(page, {
           hasMultipleSessionSharingIdentities: true,
           presenceUsers: [
-            { self: true, id: "profile-operator", name: "Operator" },
+            {
+              self: true,
+              id: "profile-operator",
+              identity: { type: "profile", id: "profile-operator" },
+              name: "Operator",
+            },
             {
               id: "profile-ada",
+              identity: { type: "profile", id: "profile-ada" },
               name: "Ada",
               watchedSessions: [sessionKey],
             },
             {
               id: "profile-zoe",
+              identity: { type: "profile", id: "profile-zoe" },
               name: "Zoe",
               watchedSessions: [sessionKey],
             },
@@ -46,17 +53,37 @@ suite.define(() => {
             "sessions.list": {
               count: 1,
               owners: [
-                { type: "human", id: "profile-ada", label: "Ada" },
-                { type: "human", id: "profile-zoe", label: "Zoe" },
+                {
+                  type: "human",
+                  id: "profile-ada",
+                  identity: { type: "profile", id: "profile-ada" },
+                  label: "Ada",
+                },
+                {
+                  type: "human",
+                  id: "profile-zoe",
+                  identity: { type: "profile", id: "profile-zoe" },
+                  label: "Zoe",
+                },
               ],
               defaults: { contextTokens: null, model: "gpt-5.5", modelProvider: "openai" },
               path: "",
               sessions: [
                 {
                   contextTokens: null,
-                  createdActor: { type: "human", id: "profile-ada", label: "Ada" },
+                  createdActor: {
+                    type: "human",
+                    id: "profile-ada",
+                    identity: { type: "profile", id: "profile-ada" },
+                    label: "Ada",
+                  },
                   owner: {
-                    actor: { type: "human", id: "profile-ada", label: "Ada" },
+                    actor: {
+                      type: "human",
+                      id: "profile-ada",
+                      identity: { type: "profile", id: "profile-ada" },
+                      label: "Ada",
+                    },
                   },
                   displayName: "Owner presence",
                   hasActiveRun: false,

--- a/ui/src/e2e/people-activity-card.e2e.test.ts
+++ b/ui/src/e2e/people-activity-card.e2e.test.ts
@@ -2,6 +2,7 @@ import { mkdir } from "node:fs/promises";
 import path from "node:path";
 import type { Locator, Page } from "playwright";
 import { expect, it } from "vitest";
+import { defaultControlUiFeatureMethods } from "../test-helpers/control-ui-e2e.ts";
 import {
   captureUiProofEnabled,
   chatSessionListResponse,
@@ -13,10 +14,16 @@ import {
 const suite = createChatFlowE2eSuite();
 const selected = "agent:main:card-selected";
 const watched = "agent:main:card-viewing";
-const proofDirectory = path.resolve(".artifacts/control-ui-e2e/people-activity-cards");
+const proofDirectory = path.resolve(".artifacts/control-ui-e2e/presence-namespaces");
 const recentLabel = "Review the complete cross-platform launch readiness checklist before release";
 const updatedRecentLabel = `${recentLabel} with every regional owner`;
 const focusUpdatedRecentLabel = `${updatedRecentLabel} and final approval`;
+
+const id = "synthetic-shared-id";
+const rawSession = "agent:main:raw-watch";
+const profileSession = "agent:main:profile-watch";
+const profile = { id, identity: { type: "profile" as const, id }, name: "Profile person" };
+const raw = { id, name: "Unqualified sender" };
 
 function scenario(recentSessionLabel = recentLabel) {
   const now = Date.now();
@@ -25,6 +32,7 @@ function scenario(recentSessionLabel = recentLabel) {
     presenceUsers: [
       {
         id: "alice",
+        identity: { type: "profile" as const, id: "alice" },
         name: "Alice",
         onlineSince: now - 2_700_000,
         lastActivityAt: now - 60_000,
@@ -50,7 +58,7 @@ function scenario(recentSessionLabel = recentLabel) {
           kind: "direct",
           label: recentSessionLabel,
           updatedAt: now - 120_000,
-          createdActor: { type: "human", id: "alice" },
+          createdActor: { type: "human", id: "alice", identity: { type: "profile", id: "alice" } },
         },
       ]),
     },
@@ -203,7 +211,7 @@ suite.define(() => {
           presence: [
             {
               ...current,
-              user: { id: "alice", name: "Alice" },
+              user: { id: "alice", identity: { type: "profile", id: "alice" }, name: "Alice" },
               lastInputSeconds: 600,
               ts: Date.now(),
               lastActivityAt: Date.now(),
@@ -269,9 +277,9 @@ suite.define(() => {
         expect(await person.evaluate((element) => document.activeElement === element)).toBe(true);
         await person.click();
         await card.waitFor({ state: "visible" });
-        await page.mouse.move(1100, 850);
+        await page.mouse.move(1100, 200);
         expect(await card.count()).toBe(1);
-        await page.mouse.click(1100, 850);
+        await page.mouse.click(1100, 200);
         await expect.poll(() => card.count()).toBe(0);
         await person.click();
         await card.waitFor({ state: "visible" });
@@ -338,4 +346,169 @@ suite.define(() => {
       },
     );
   });
+  it("keeps colliding people, watches, owner exclusion and open cards separate through updates", async () => {
+    await suite.withPage(
+      {
+        viewport: { width: 1280, height: 900 },
+        colorScheme: "light",
+        locale: "en-US",
+        serviceWorkers: "block",
+      },
+      async ({ page }) => {
+        const actor = { type: "human", id, identity: profile.identity, label: profile.name };
+        const sessions = chatSessionListResponse([
+          {
+            key: selected,
+            kind: "direct",
+            label: "Namespace isolation",
+            updatedAt: 3,
+            owner: { actor },
+            participantCount: 1,
+          },
+          {
+            key: profileSession,
+            kind: "direct",
+            label: "Profile watch",
+            updatedAt: 2,
+            createdActor: actor,
+          },
+          { key: rawSession, kind: "direct", label: "Raw watch", updatedAt: 1 },
+        ]);
+        const gateway = await installMockGateway(page, {
+          sessionKey: selected,
+          presenceUsers: [
+            { self: true, id: "self", identity: { type: "profile", id: "self" }, name: "Self" },
+            { ...profile, watchedSessions: [selected, profileSession] },
+            { ...raw, watchedSessions: [selected, rawSession] },
+          ],
+          methodResponses: { "sessions.list": sessions },
+        });
+        await page.goto(controlUiSessionUrl(suite.server.baseUrl, selected));
+        const profileButton = page.getByRole("button", {
+          name: "Details for Profile person",
+          exact: true,
+        });
+        await profileButton.waitFor({ state: "visible" });
+        if (captureUiProofEnabled) {
+          await mkdir(proofDirectory, { recursive: true });
+          await page.screenshot({
+            path: path.join(proofDirectory, "initial.png"),
+            animations: "disabled",
+          });
+        }
+        expect(await page.locator(".sidebar-online__person").count()).toBe(2);
+        const rawButton = page.getByRole("button", {
+          name: "Details for Unqualified sender",
+          exact: true,
+        });
+        await rawButton.click();
+        const rawCard = page.getByRole("dialog", {
+          name: "Activity for Unqualified sender",
+          exact: true,
+        });
+        await rawCard.waitFor({ state: "visible" });
+        expect(await rawCard.getByRole("link", { name: /^Raw watch(?:\s|$)/ }).count()).toBe(1);
+        expect(await rawCard.getByRole("link", { name: /^Profile watch(?:\s|$)/ }).count()).toBe(0);
+        expect(
+          await rawCard.getByRole("link", { name: "View activity", exact: true }).count(),
+        ).toBe(0);
+        const headerFaces = page.locator(".chat-pane__presence [data-viewer-id]");
+        await expect.poll(() => headerFaces.getAttribute("aria-label")).toBe(raw.name);
+        if (captureUiProofEnabled) {
+          await page.screenshot({
+            path: path.join(proofDirectory, "raw-card.png"),
+            animations: "disabled",
+          });
+        }
+        const rawLink = rawCard.getByRole("link", { name: /^Raw watch(?:\s|$)/ });
+        await rawLink.focus();
+        await gateway.emitGatewayEvent("presence", {
+          presence: [
+            { user: raw, watchedSessions: [rawSession, selected], lastInputSeconds: 600 },
+            { user: profile, watchedSessions: [profileSession, selected], lastInputSeconds: 0 },
+          ],
+        });
+        await expect
+          .poll(() => rawLink.evaluate((element) => document.activeElement === element))
+          .toBe(true);
+        await gateway.emitGatewayEvent("presence", {
+          presence: [{ user: raw, watchedSessions: [rawSession, selected] }],
+        });
+        await expect.poll(() => page.locator(".sidebar-online__person").count()).toBe(1);
+        expect(await rawLink.evaluate((element) => document.activeElement === element)).toBe(true);
+        expect(await rawCard.count()).toBe(1);
+        await gateway.emitGatewayEvent("presence", {
+          presence: [
+            { user: raw, reason: "disconnect", watchedSessions: [rawSession] },
+            { user: profile, watchedSessions: [profileSession] },
+          ],
+        });
+        await expect.poll(() => rawCard.count()).toBe(0);
+        await profileButton.click();
+        const profileCard = page.getByRole("dialog", {
+          name: "Activity for Profile person",
+          exact: true,
+        });
+        await profileCard.waitFor({ state: "visible" });
+        expect(await profileCard.getByRole("link", { name: /^Raw watch(?:\s|$)/ }).count()).toBe(0);
+        const activity = profileCard.getByRole("link", { name: "View activity", exact: true });
+        expect(await activity.getAttribute("href")).toBe(`/activity?person=${id}`);
+        if (captureUiProofEnabled) {
+          await page.screenshot({
+            path: path.join(proofDirectory, "profile-card.png"),
+            animations: "disabled",
+          });
+        }
+        expect((await gateway.getRequests("connect")).length).toBeGreaterThan(0);
+        expect((await gateway.getRequests("sessions.list")).length).toBeGreaterThan(0);
+      },
+    );
+  });
+  it.each([true, false])(
+    "keeps a same-ID peer visible and typing enabled for profile self: %s",
+    async (qualified) => {
+      await suite.withPage(
+        { viewport: { width: 1280, height: 900 }, locale: "en-US" },
+        async ({ page }) => {
+          const self = qualified ? profile : raw;
+          const peer = qualified ? raw : profile;
+          const gateway = await installMockGateway(page, {
+            sessionKey: selected,
+            featureMethods: [...defaultControlUiFeatureMethods, "session.typing"],
+            presenceUsers: [
+              { ...self, self: true, watchedSessions: [selected] },
+              { ...peer, watchedSessions: [selected] },
+            ],
+            methodResponses: {
+              "session.typing": { ok: true, broadcast: true },
+              "sessions.list": chatSessionListResponse([
+                {
+                  key: selected,
+                  kind: "direct",
+                  label: "Namespace isolation",
+                  updatedAt: 1,
+                  sessionId: "namespace-session",
+                },
+              ]),
+            },
+          });
+          await page.goto(controlUiSessionUrl(suite.server.baseUrl, selected));
+          await page
+            .getByRole("button", { name: `Details for ${peer.name}`, exact: true })
+            .waitFor({ state: "visible" });
+          expect(await page.locator(".sidebar-online__person").count()).toBe(1);
+          await expect
+            .poll(() =>
+              page.locator(".chat-pane__presence [data-viewer-id]").getAttribute("aria-label"),
+            )
+            .toBe(peer.name);
+          await page
+            .locator(".agent-chat__composer-combobox textarea")
+            .fill("A synthetic typing draft");
+          const typing = await gateway.waitForRequest("session.typing");
+          expect(typing.params).toMatchObject({ sessionKey: selected, typing: true });
+        },
+      );
+    },
+  );
 });

--- a/ui/src/lib/presence-users.test.ts
+++ b/ui/src/lib/presence-users.test.ts
@@ -1,0 +1,121 @@
+import { expect, it } from "vitest";
+import {
+  hasSessionPresenceViewers,
+  projectOnlinePresenceViewers,
+  projectPresencePayload,
+  projectPresenceViewers,
+} from "./presence-users.ts";
+
+it("isolates namespaces while merging renamed tabs and excluding disconnected facts", () => {
+  const id = "synthetic-shared-id";
+  const profile = { id, identity: { type: "profile" as const, id }, name: "Profile person" };
+  const raw = { id, name: "Unqualified sender" };
+  const presence = [
+    { instanceId: "profile-tab", user: profile, watchedSessions: ["profile-session"] },
+    { instanceId: "raw-tab", user: raw, watchedSessions: ["raw-session"] },
+    {
+      instanceId: "profile-tab-2",
+      user: { ...profile, name: "Renamed profile" },
+      watchedSessions: ["profile-extra"],
+    },
+    {
+      instanceId: "raw-tab-2",
+      user: { ...raw, name: "Updated raw" },
+      watchedSessions: ["raw-extra"],
+    },
+    { instanceId: "closed", user: raw, reason: "disconnect", watchedSessions: ["closed-session"] },
+  ];
+  const forward = projectPresencePayload({ presence });
+  expect(forward.users).toHaveLength(2);
+  expect(
+    forward.users.map(({ id: userId, identity, name, watchedSessions, entries }) => ({
+      id: userId,
+      identity,
+      name,
+      watchedSessions,
+      tabs: entries?.length,
+    })),
+  ).toEqual([
+    {
+      id,
+      identity: profile.identity,
+      name: profile.name,
+      watchedSessions: ["profile-extra", "profile-session"],
+      tabs: 2,
+    },
+    {
+      id,
+      identity: undefined,
+      name: raw.name,
+      watchedSessions: ["raw-extra", "raw-session"],
+      tabs: 2,
+    },
+  ]);
+  expect(projectPresencePayload({ presence: presence.toReversed() })).toEqual(forward);
+});
+
+it.each([true, false])(
+  "excludes only self's current namespace for an unchanged payload (profile: %s)",
+  (qualified) => {
+    const id = "synthetic-shared-id";
+    const profile = { id, identity: { type: "profile" as const, id }, name: "Same label" };
+    const raw = { id, identity: undefined, name: "Same label" };
+    const payload = {
+      presence: [
+        { instanceId: "profile-tab", user: profile, watchedSessions: ["profile-session"] },
+        { instanceId: "raw-tab", user: raw, watchedSessions: ["raw-session"] },
+      ],
+    };
+    const self = qualified ? profile : raw;
+    const other = qualified ? raw : profile;
+    const instance = qualified ? "profile-tab" : "raw-tab";
+    const otherSession = qualified ? "raw-session" : "profile-session";
+    // An unchanged payload must still exclude the current self qualification.
+    projectOnlinePresenceViewers(payload, other);
+    for (const [explicitSelf, fallbackInstance] of [
+      [self, undefined],
+      [undefined, instance],
+      [self, qualified ? "raw-tab" : "profile-tab"],
+    ] as const) {
+      const viewers = projectOnlinePresenceViewers(payload, explicitSelf, fallbackInstance);
+      expect(viewers).toHaveLength(1);
+      expect(viewers[0]?.identity).toEqual(other.identity);
+      expect(hasSessionPresenceViewers(payload, explicitSelf, fallbackInstance, otherSession)).toBe(
+        true,
+      );
+      expect(
+        hasSessionPresenceViewers(
+          payload,
+          explicitSelf,
+          fallbackInstance,
+          qualified ? "profile-session" : "raw-session",
+        ),
+      ).toBe(false);
+    }
+    expect(projectOnlinePresenceViewers(payload).map((user) => user.identity)).toEqual([
+      profile.identity,
+      undefined,
+    ]);
+  },
+);
+
+it.each([
+  { type: "profile" as const, id: "same" },
+  { type: "agent" as const, id: "same" },
+  { type: "legacy" as const, actorType: "human", source: "channel", id: "same" },
+  undefined,
+])("deduplicates only a rendered profile owner: %j", (identity) => {
+  const payload = {
+    presence: [
+      {
+        user: { id: "same", identity: { type: "profile" as const, id: "same" } },
+        watchedSessions: ["session"],
+      },
+      { user: { id: "same" }, watchedSessions: ["session"] },
+    ],
+  };
+  const viewers = projectPresenceViewers(payload, undefined, undefined, "session", identity);
+  expect(viewers.map((user) => user.identity)).toEqual(
+    identity?.type === "profile" ? [undefined] : [payload.presence[0]!.user.identity, undefined],
+  );
+});

--- a/ui/src/lib/presence-users.ts
+++ b/ui/src/lib/presence-users.ts
@@ -1,5 +1,11 @@
+import type { SessionParticipantIdentity } from "../../../packages/gateway-protocol/src/schema/session-participant.js";
+import { presenceUserKey } from "../../../src/shared/presence-user.ts";
 import type { PresenceEntry } from "../api/types.ts";
-import { readPresenceEntries } from "../app/user-profile.ts";
+import {
+  readPresenceEntries,
+  resolveSelfPresenceUser,
+  type AuthenticatedUser,
+} from "../app/user-profile.ts";
 
 export type PresenceViewer = NonNullable<PresenceEntry["user"]> & {
   watchedSessions: readonly string[];
@@ -35,39 +41,28 @@ function compareText(a: string, b: string): number {
   return a < b ? -1 : a > b ? 1 : 0;
 }
 
-function projectPresenceViewers(
-  entries: readonly PresenceEntry[],
-  authenticatedSelfUserId?: string,
-  selfInstanceId?: string,
-): { users: readonly PresenceViewer[]; selfUserId?: string } {
+function groupPresenceUsers(entries: readonly PresenceEntry[]): {
+  users: readonly PresenceViewer[];
+} {
   const grouped = new Map<string, PresenceEntry[]>();
-  let selfUserId = normalized(authenticatedSelfUserId);
   for (const entry of entries) {
     if (entry.reason === "disconnect" || !entry.user?.id) {
       continue;
     }
-    const userId = entry.user.id;
-    const existing = grouped.get(userId);
+    const key = presenceUserKey(entry.user);
+    const existing = grouped.get(key);
     if (existing) {
       existing.push(entry);
     } else {
-      grouped.set(userId, [entry]);
-    }
-    if (!selfUserId && selfInstanceId && entry.instanceId === selfInstanceId) {
-      selfUserId = userId;
+      grouped.set(key, [entry]);
     }
   }
   return {
-    selfUserId,
     users: [...grouped.entries()]
       .toSorted(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))
-      .map(([id, userEntries]) => ({
-        id,
-        // Raw-id grouping can combine qualified and unqualified connections.
-        // Carry provenance only when every connection supplies the same fact.
-        identity: userEntries.every((entry) => entry.user?.identity?.id === id)
-          ? userEntries[0]?.user?.identity
-          : undefined,
+      .map(([, userEntries]) => ({
+        id: userEntries[0]!.user!.id,
+        identity: userEntries[0]!.user!.identity,
         name: firstSorted(userEntries.map((entry) => entry.user?.name)),
         email: firstSorted(userEntries.map((entry) => entry.user?.email)),
         avatarUrl: firstSorted(userEntries.map((entry) => entry.user?.avatarUrl)),
@@ -82,31 +77,14 @@ function projectPresenceViewers(
 }
 
 let cachedPresencePayload: unknown;
-let cachedAuthenticatedSelfUserId: string | undefined;
-let cachedSelfInstanceId: string | undefined;
-let cachedPresenceProjection: ReturnType<typeof projectPresenceViewers> | undefined;
+let cachedPresenceProjection: ReturnType<typeof groupPresenceUsers> | undefined;
 
-export function projectPresencePayload(
-  value: unknown,
-  authenticatedSelfUserId?: string,
-  selfInstanceId?: string,
-) {
-  if (
-    cachedPresenceProjection &&
-    cachedPresencePayload === value &&
-    cachedAuthenticatedSelfUserId === authenticatedSelfUserId &&
-    cachedSelfInstanceId === selfInstanceId
-  ) {
+export function projectPresencePayload(value: unknown) {
+  if (cachedPresenceProjection && cachedPresencePayload === value) {
     return cachedPresenceProjection;
   }
   cachedPresencePayload = value;
-  cachedAuthenticatedSelfUserId = authenticatedSelfUserId;
-  cachedSelfInstanceId = selfInstanceId;
-  cachedPresenceProjection = projectPresenceViewers(
-    readPresenceEntries(value) ?? [],
-    authenticatedSelfUserId,
-    selfInstanceId,
-  );
+  cachedPresenceProjection = groupPresenceUsers(readPresenceEntries(value) ?? []);
   return cachedPresenceProjection;
 }
 
@@ -131,35 +109,51 @@ function comparePresenceViewers(a: PresenceViewer, b: PresenceViewer): number {
   }
   const labelA = presenceViewerLabel(a).toLowerCase();
   const labelB = presenceViewerLabel(b).toLowerCase();
-  return labelA < labelB ? -1 : labelA > labelB ? 1 : a.id < b.id ? -1 : a.id > b.id ? 1 : 0;
+  return compareText(labelA, labelB) || compareText(presenceUserKey(a), presenceUserKey(b));
+}
+
+export function presenceMatchesProfile(
+  user: PresenceViewer,
+  identity?: SessionParticipantIdentity,
+): boolean {
+  return identity?.type === "profile" && user.identity?.id === identity.id;
+}
+
+export function projectPresenceViewers(
+  value: unknown,
+  selfUser?: AuthenticatedUser | null,
+  selfInstanceId?: string,
+  sessionKey?: string,
+  excludeIdentity?: SessionParticipantIdentity,
+): readonly PresenceViewer[] {
+  const self =
+    selfUser ?? resolveSelfPresenceUser(readPresenceEntries(value) ?? [], selfInstanceId);
+  const selfKey = self ? presenceUserKey(self) : undefined;
+  return projectPresencePayload(value).users.filter(
+    (user) =>
+      presenceUserKey(user) !== selfKey &&
+      !presenceMatchesProfile(user, excludeIdentity) &&
+      (sessionKey === undefined || user.watchedSessions.includes(sessionKey)),
+  );
 }
 
 export function projectOnlinePresenceViewers(
   value: unknown,
-  authenticatedSelfUserId?: string,
+  authenticatedSelfUser?: AuthenticatedUser | null,
   selfInstanceId?: string,
 ): readonly PresenceViewer[] {
-  const projection = projectPresencePayload(value, authenticatedSelfUserId, selfInstanceId);
-  return projection.users
-    .filter((user) => user.id !== projection.selfUserId)
-    .toSorted(comparePresenceViewers);
+  return projectPresenceViewers(value, authenticatedSelfUser, selfInstanceId).toSorted(
+    comparePresenceViewers,
+  );
 }
 
 export function hasSessionPresenceViewers(
   value: unknown,
-  authenticatedSelfUserId: string | undefined,
+  selfUser: AuthenticatedUser | null | undefined,
   selfInstanceId: string | undefined,
   sessionKey: string,
-  excludeUserId?: string,
 ): boolean {
-  const projection = projectPresencePayload(value, authenticatedSelfUserId, selfInstanceId);
-  const excludedUserId = normalized(excludeUserId);
-  return projection.users.some(
-    (user) =>
-      user.id !== projection.selfUserId &&
-      user.id !== excludedUserId &&
-      user.watchedSessions.includes(sessionKey),
-  );
+  return projectPresenceViewers(value, selfUser, selfInstanceId, sessionKey).length > 0;
 }
 
 export function hasMultiplePresenceIdentities(value: unknown): boolean {

--- a/ui/src/pages/activity/session-activity-view.test.ts
+++ b/ui/src/pages/activity/session-activity-view.test.ts
@@ -209,6 +209,7 @@ describe("session activity people filter", () => {
           presenceViewers: [
             {
               id: "online",
+              identity: { type: "profile", id: "online" },
               name: "Online person",
               watchedSessions: [],
               entries: [{ instanceId: "online-device", user: { id: "online" }, ts: now }],
@@ -252,6 +253,7 @@ describe("session activity people filter", () => {
         presenceViewers: [
           {
             id: "online",
+            identity: { type: "profile", id: "online" },
             email: "online@example.test",
             watchedSessions: ["agent:main:first", "agent:main:second", "missing"],
             entries: [
@@ -321,6 +323,47 @@ describe("session activity people filter", () => {
         expect(container.querySelector("[data-activity-identity]")).toBeNull();
         expect(container.querySelector("[data-activity-session]")).toBeNull();
       }
+    },
+  );
+
+  it.each([true, false])(
+    "never joins raw presence into a profile Activity page (profile online: %s)",
+    (online) => {
+      const container = document.createElement("div");
+      document.body.append(container);
+      const input = props({
+        filters: { personId: "online", query: "", time: "7d" },
+        rows: [row("raw-watch", { id: "online" }, 10)],
+        presenceViewers: [
+          ...(online
+            ? [
+                {
+                  id: "online",
+                  identity: { type: "profile" as const, id: "online" },
+                  name: "Profile person",
+                  watchedSessions: [],
+                  entries: [{ host: "Profile device", ts: 1 }],
+                },
+              ]
+            : []),
+          {
+            id: "online",
+            name: "Raw collider",
+            watchedSessions: ["raw-watch"],
+            entries: [{ host: "Raw device", ts: 1 }],
+          },
+        ],
+      });
+      render(renderSessionActivityView(input), container);
+      const identity = container.querySelector("[data-activity-identity]")!;
+      expect(identity.querySelector("h2")?.textContent).toBe(
+        online ? "Profile person" : "Online person",
+      );
+      expect(identity.textContent).not.toContain("Raw device");
+      expect(identity.querySelector(".activity-feed__viewing-list")).toBeNull();
+      expect(
+        container.querySelectorAll(".activity-feed__people-row .activity-feed__presence-dot"),
+      ).toHaveLength(online ? 1 : 0);
     },
   );
 
@@ -405,7 +448,14 @@ describe("session activity automation grouping", () => {
       { filters: { personId: null, query: "Automation", time: "7d" as const } },
       {
         filters: { personId: "owner", query: "", time: "7d" as const },
-        presenceViewers: [{ id: "owner", name: "Owner", watchedSessions: [] }],
+        presenceViewers: [
+          {
+            id: "owner",
+            identity: { type: "profile" as const, id: "owner" },
+            name: "Owner",
+            watchedSessions: [],
+          },
+        ],
       },
     ]) {
       render(

--- a/ui/src/pages/activity/session-activity-view.ts
+++ b/ui/src/pages/activity/session-activity-view.ts
@@ -417,7 +417,11 @@ function renderIdentityHeader(
 
 export function renderSessionActivityView(props: SessionActivityViewProps) {
   const projection = projectSessionActivity(props.result);
-  const onlineById = new Map(props.presenceViewers.map((person) => [person.id, person]));
+  const onlineById = new Map(
+    props.presenceViewers.flatMap((person) =>
+      person.identity ? [[person.identity.id, person] as const] : [],
+    ),
+  );
   const identity = props.filters.personId
     ? (onlineById.get(props.filters.personId) ??
       projection.people.find((person) => person.id === props.filters.personId) ??

--- a/ui/src/pages/chat/chat-pane-header.ts
+++ b/ui/src/pages/chat/chat-pane-header.ts
@@ -17,7 +17,11 @@ import { listAssignableSessionOwners } from "../../components/session-owner-chip
 import { isCloudWorkerPlacementState } from "../../components/session-row-badges.ts";
 import { t } from "../../i18n/index.ts";
 import { isGatewayMethodAdvertised } from "../../lib/gateway-methods.ts";
-import { hasSessionPresenceViewers, projectPresencePayload } from "../../lib/presence-users.ts";
+import {
+  projectPresenceViewers,
+  presenceMatchesProfile,
+  projectPresencePayload,
+} from "../../lib/presence-users.ts";
 import { readSessionMethodAccess } from "../../lib/session-method-access.ts";
 import { collectKnownSessionGroups } from "../../lib/sessions/grouping.ts";
 import {
@@ -391,8 +395,6 @@ export abstract class ChatPaneHeader extends ChatPaneDiscussion {
       row,
     });
     const key = this.state?.sessionKey ?? "";
-    const selfId = sharingSnapshot.selfUser?.id;
-    const instanceId = sharingSnapshot.client?.instanceId;
     const result = this.state?.sessionsResult;
     const knownGroups = collectKnownSessionGroups(
       this.context.sessions?.state?.groups ?? [],
@@ -400,10 +402,19 @@ export abstract class ChatPaneHeader extends ChatPaneDiscussion {
     );
     const showOwnerChip = (result?.owners?.length ?? 0) >= 2 || (row?.participantCount ?? 0) > 0;
     const personActivity = this.personActivityRouting();
-    const renderedOwnerId = showOwnerChip ? row?.owner?.actor.id : undefined;
-    const presence = projectPresencePayload(this.presencePayload, selfId, instanceId);
-    const ownerViewing = presence.users.some(
-      (user) => user.id === renderedOwnerId && user.watchedSessions.includes(key),
+    const renderedOwnerIdentity = showOwnerChip ? row?.owner?.actor.identity : undefined;
+    const viewers = catalog
+      ? undefined
+      : projectPresenceViewers(
+          this.presencePayload,
+          sharingSnapshot.selfUser,
+          sharingSnapshot.client?.instanceId,
+          key,
+          renderedOwnerIdentity,
+        );
+    const ownerViewing = projectPresencePayload(this.presencePayload).users.some(
+      (user) =>
+        presenceMatchesProfile(user, renderedOwnerIdentity) && user.watchedSessions.includes(key),
     );
     const ownerOptions = listAssignableSessionOwners({
       facet: result?.owners,
@@ -445,21 +456,15 @@ export abstract class ChatPaneHeader extends ChatPaneDiscussion {
       backgroundTasksAction: nothing,
       sessionRailAction: nothing,
       workspaceAction: nothing,
-      presence:
-        !catalog &&
-        hasSessionPresenceViewers(this.presencePayload, selfId, instanceId, key, renderedOwnerId)
-          ? html`<openclaw-viewer-facepile
-              class="chat-pane__presence"
-              .presencePayload=${this.presencePayload}
-              .selfUserId=${selfId}
-              .selfInstanceId=${instanceId}
-              .sessionKey=${key}
-              .excludeUserId=${renderedOwnerId}
-              .maxVisible=${4}
-              .personActivity=${personActivity}
-              variant="session"
-            ></openclaw-viewer-facepile>`
-          : nothing,
+      presence: viewers?.length
+        ? html`<openclaw-viewer-facepile
+            class="chat-pane__presence"
+            .staticUsers=${viewers}
+            .maxVisible=${4}
+            .personActivity=${personActivity}
+            variant="session"
+          ></openclaw-viewer-facepile>`
+        : nothing,
       faceControl: renderBoardViewSwitch({
         hasBoard: board.hasBoard,
         face: board.face,

--- a/ui/src/pages/chat/chat-pane-render.ts
+++ b/ui/src/pages/chat/chat-pane-render.ts
@@ -220,7 +220,7 @@ export class ChatPane extends ChatPaneLayoutRender {
       isGatewayMethodAdvertised(gatewaySnapshot, "session.typing") === true &&
       hasSessionPresenceViewers(
         this.presencePayload,
-        gatewaySnapshot.selfUser?.identity?.id,
+        gatewaySnapshot.selfUser,
         gatewaySnapshot.client?.instanceId,
         state.sessionKey,
       );
@@ -244,7 +244,7 @@ export class ChatPane extends ChatPaneLayoutRender {
       });
     const selfUser = resolveCurrentSelfUser({
       snapshotUser: gatewaySnapshot.selfUser,
-      presenceEntries: readPresenceEntries(gatewaySnapshot.hello?.snapshot),
+      presenceEntries: readPresenceEntries(this.presencePayload),
       presenceInstanceId: gatewaySnapshot.client?.instanceId,
     });
     const runOutputTokens = resolveActiveRunOutputTokens({

--- a/ui/src/pages/chat/components/chat-pane-header.test.ts
+++ b/ui/src/pages/chat/components/chat-pane-header.test.ts
@@ -81,10 +81,16 @@ function mountIntegratedPresenceHeader(params: {
 }) {
   const client = { instanceId: "self-instance" } as unknown as GatewayBrowserClient;
   const { pane, state } = createTestChatPane({ client, sessions: {} as SessionCapability });
+  const actor = {
+    type: "human" as const,
+    id: "profile-ada",
+    identity: { type: "profile" as const, id: "profile-ada" },
+    label: "Ada",
+  };
   const session = row({
     key: state.sessionKey,
-    createdActor: { type: "human", id: "profile-ada", label: "Ada" },
-    owner: { actor: { type: "human", id: "profile-ada", label: "Ada" } },
+    createdActor: actor,
+    owner: { actor },
   });
   state.settings = {} as ChatPageHost["settings"];
   state.sessionsResult = {
@@ -514,6 +520,7 @@ describe("chat pane header", () => {
         { type: "human" as const, id: "profile-zoe", label: "Zoe" },
       ],
       viewers: ["profile-ada", "profile-zoe"],
+      qualified: true,
       expectedChip: true,
       expectedViewers: ["profile-zoe"],
     },
@@ -521,6 +528,7 @@ describe("chat pane header", () => {
       name: "keeps the owner when the owner chip is hidden",
       owners: [{ type: "human" as const, id: "profile-ada", label: "Ada" }],
       viewers: ["profile-ada", "profile-zoe"],
+      qualified: true,
       expectedChip: false,
       expectedViewers: ["profile-ada", "profile-zoe"],
     },
@@ -531,17 +539,33 @@ describe("chat pane header", () => {
         { type: "human" as const, id: "profile-zoe", label: "Zoe" },
       ],
       viewers: ["profile-ada"],
+      qualified: true,
       expectedChip: true,
       expectedViewers: [],
     },
-  ])("$name", async ({ owners, viewers, expectedChip, expectedViewers }) => {
+    {
+      name: "keeps a raw viewer whose ID matches the displayed profile owner",
+      owners: [
+        { type: "human" as const, id: "profile-ada", label: "Ada" },
+        { type: "human" as const, id: "profile-zoe", label: "Zoe" },
+      ],
+      viewers: ["profile-ada"],
+      qualified: false,
+      expectedChip: true,
+      expectedViewers: ["profile-ada"],
+    },
+  ])("$name", async ({ owners, viewers, qualified, expectedChip, expectedViewers }) => {
     const sessionKey = "agent:main:current";
     const { container } = mountIntegratedPresenceHeader({
       owners,
       presence: viewers.map((id) => ({
         instanceId: `${id}-instance`,
         ts: 1,
-        user: { id, name: id },
+        user: {
+          id,
+          name: id,
+          ...(qualified ? { identity: { type: "profile" as const, id } } : {}),
+        },
         watchedSessions: [sessionKey],
       })),
     });
@@ -571,7 +595,11 @@ describe("chat pane header", () => {
     const guest = {
       instanceId: "profile-zoe-instance",
       ts: 1,
-      user: { id: "profile-zoe", name: "Zoe" },
+      user: {
+        id: "profile-zoe",
+        identity: { type: "profile", id: "profile-zoe" },
+        name: "Zoe",
+      },
       watchedSessions: [sessionKey],
     } satisfies PresenceEntry;
     const mounted = mountIntegratedPresenceHeader({ owners, presence: [guest] });
@@ -583,22 +611,26 @@ describe("chat pane header", () => {
     expect(mounted.container.querySelector(".session-owner-chip--header")?.classList).toContain(
       "session-owner-chip--away",
     );
-    mounted.pane.presencePayload = {
-      presence: [
-        {
-          instanceId: "profile-ada-instance",
-          ts: 1,
-          user: { id: "profile-ada", name: "Ada" },
-          watchedSessions: [sessionKey],
-        },
-        guest,
-      ],
-    };
-    mounted.renderHeader();
-    await ownerChip?.updateComplete;
-    expect(mounted.container.querySelector(".session-owner-chip--header")?.classList).not.toContain(
-      "session-owner-chip--away",
-    );
+    for (const identity of [undefined, { type: "profile" as const, id: "profile-ada" }]) {
+      mounted.pane.presencePayload = {
+        presence: [
+          {
+            instanceId: "profile-ada-instance",
+            ts: 1,
+            user: { id: "profile-ada", identity, name: "Ada" },
+            watchedSessions: [sessionKey],
+          },
+          guest,
+        ],
+      };
+      mounted.renderHeader();
+      await ownerChip?.updateComplete;
+      expect(
+        mounted.container
+          .querySelector(".session-owner-chip--header")
+          ?.classList.contains("session-owner-chip--away"),
+      ).toBe(identity === undefined);
+    }
   });
 
   it("renders the durable session actor avatar with the header attribution semantics", async () => {

--- a/ui/src/test-helpers/app-sidebar-cases/presence.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/presence.ts
@@ -53,7 +53,7 @@ describe("AppSidebar viewer presence", () => {
         },
         {
           instanceId: "alice-instance",
-          user: { id: "alice", name: "Alice" },
+          user: { id: "alice", identity: { type: "profile" as const, id: "alice" }, name: "Alice" },
           lastInputSeconds: 600,
           ts: 1,
         },
@@ -133,7 +133,9 @@ describe("AppSidebar viewer presence", () => {
         row.createdActor = { type: "agent", id: "alice" };
       }
       if (index >= 4) {
-        row.owner = { actor: { type: "human", id: "alice" } };
+        row.owner = {
+          actor: { type: "human", id: "alice", identity: { type: "profile", id: "alice" } },
+        };
       }
     });
     sessions.publishList({ result });
@@ -150,7 +152,7 @@ describe("AppSidebar viewer presence", () => {
         platform: tab === 3 ? "iOS" : "macOS",
         mode: "webchat",
         timeZone: "Europe/Paris",
-        user: { id: "alice", name: "Alice" },
+        user: { id: "alice", identity: { type: "profile" as const, id: "alice" }, name: "Alice" },
         watchedSessions: [
           "AGENT:research:watched",
           "agent:research:watched",
@@ -207,7 +209,11 @@ describe("AppSidebar viewer presence", () => {
         ...result,
         sessions: result.sessions.map((row) => ({
           ...row,
-          createdActor: { type: "human" as const, id: "alice" },
+          createdActor: {
+            type: "human" as const,
+            id: "alice",
+            identity: { type: "profile" as const, id: "alice" },
+          },
         })),
       },
     });
@@ -216,7 +222,7 @@ describe("AppSidebar viewer presence", () => {
     const now = Date.now();
     const alice = {
       ts: now,
-      user: { id: "alice", name: "Alice" },
+      user: { id: "alice", identity: { type: "profile" as const, id: "alice" }, name: "Alice" },
       watchedSessions: ["agent:main:work"],
       onlineSince: now - 60_000,
       lastActivityAt: now - 10_000,
@@ -281,7 +287,7 @@ describe("AppSidebar viewer presence", () => {
       sidebar.connected = true;
       const person = {
         ts: Date.now(),
-        user: { id: "alice", name: "Alice" },
+        user: { id: "alice", identity: { type: "profile" as const, id: "alice" }, name: "Alice" },
         onlineSince: Date.now() - 90_000,
       };
       gateway.publishEvent("presence", {
@@ -361,7 +367,10 @@ describe("AppSidebar viewer presence", () => {
     gatewayHarness.publishEvent("presence", {
       presence: [
         { instanceId: "self-instance", user: { id: "self", name: "Self" } },
-        { instanceId: "alice-instance", user: { id: "alice", name: "Alice" } },
+        {
+          instanceId: "alice-instance",
+          user: { id: "alice", identity: { type: "profile" as const, id: "alice" }, name: "Alice" },
+        },
         { instanceId: "bob-instance", user: { id: "bob", name: "Bob" } },
         { instanceId: "carol-instance", user: { id: "carol", name: "Carol" } },
         { instanceId: "dave-instance", user: { id: "dave", name: "Dave" } },
@@ -435,12 +444,17 @@ describe("AppSidebar viewer presence", () => {
         },
         {
           instanceId: "alice-1",
-          user: { id: "alice", name: "Alice", avatarUrl: "/api/users/alice/avatar" },
+          user: {
+            id: "alice",
+            identity: { type: "profile", id: "alice" },
+            name: "Alice",
+            avatarUrl: "/api/users/alice/avatar",
+          },
           watchedSessions: ["agent:main:work"],
         },
         {
           instanceId: "alice-2",
-          user: { id: "alice", name: "Alice" },
+          user: { id: "alice", identity: { type: "profile" as const, id: "alice" }, name: "Alice" },
           watchedSessions: ["agent:main:main"],
         },
         {
@@ -536,7 +550,10 @@ describe("AppSidebar viewer presence", () => {
     gatewayHarness.publishEvent("presence", {
       presence: [
         { instanceId: "anonymous-self", watchedSessions: ["agent:main:main"] },
-        { instanceId: "alice", user: { id: "alice", name: "Alice" } },
+        {
+          instanceId: "alice",
+          user: { id: "alice", identity: { type: "profile" as const, id: "alice" }, name: "Alice" },
+        },
       ],
     });
     await sidebar.updateComplete;

--- a/ui/src/test-helpers/app-sidebar-cases/session-ownership.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/session-ownership.ts
@@ -143,6 +143,7 @@ describe("AppSidebar session ownership", () => {
           instanceId: "bob-browser",
           user: {
             id: "profile-bob",
+            identity: { type: "profile", id: "profile-bob" },
             name: "Bob",
             avatarUrl: "/api/users/profile-bob/avatar?v=99",
           },
@@ -565,7 +566,12 @@ describe("AppSidebar session ownership", () => {
       throw new Error("expected archive attribution rows");
     }
     archived.archived = true;
-    archived.archivedBy = { type: "human", id: "profile-bob", label: "Bob" };
+    archived.archivedBy = {
+      type: "human",
+      id: "profile-bob",
+      identity: { type: "profile", id: "profile-bob" },
+      label: "Bob",
+    };
     setEffectiveOwner(archived, { type: "human", id: "profile-ada", label: "Ada" });
     setEffectiveOwner(collaborator, { type: "human", id: "profile-bob", label: "Bob" });
     result.owners = [
@@ -586,8 +592,8 @@ describe("AppSidebar session ownership", () => {
     // so Bob is excluded while owner Ada must stay visible as a viewer.
     const archivedFacepile = sidebar.querySelector(
       '[data-session-key="agent:main:archived"] openclaw-viewer-facepile',
-    ) as (HTMLElement & { excludeUserId?: string }) | null;
-    expect(archivedFacepile?.excludeUserId).toBe("profile-bob");
+    ) as HTMLElementTagNameMap["openclaw-viewer-facepile"] | null;
+    expect(archivedFacepile?.excludeIdentity).toEqual(archived.archivedBy.identity);
 
     setEffectiveOwner(collaborator, { type: "human", id: "profile-ada", label: "Ada" });
     result.owners = [{ type: "human", id: "profile-ada", label: "Ada" }];
@@ -597,7 +603,7 @@ describe("AppSidebar session ownership", () => {
     expect(sidebar.querySelector("openclaw-session-owner-chip")).toBeNull();
     const soloFacepile = sidebar.querySelector(
       '[data-session-key="agent:main:archived"] openclaw-viewer-facepile',
-    ) as (HTMLElement & { excludeUserId?: string }) | null;
-    expect(soloFacepile?.excludeUserId).toBeUndefined();
+    ) as HTMLElementTagNameMap["openclaw-viewer-facepile"] | null;
+    expect(soloFacepile?.excludeIdentity).toBeUndefined();
   });
 });


### PR DESCRIPTION
Closes #132247 — ephemeral live presence merges qualified profiles with colliding unqualified IDs.

Related: #132038 — the merged transcript-provenance repair intentionally deferred this live-presence namespace collision. Transcript persistence, participant aggregation, and creator authorization remain separate.

## What Problem This Solves

Fixes an issue where operators see distinct people collapsed into one Online row or session viewer, see the wrong watched sessions or activity details, or lose another viewer when their own profile ID matches an unqualified presence ID. The same collision could mix Gateway online/activity timing and suppress typing notifications by counting two identities as one.

## Why This Change Was Made

The Gateway and Control UI now use one small recorded-namespace key instead of raw-ID equality. Same-identity tabs still aggregate, while timing facts are copied per connection so a later qualification change cannot leave different identities sharing mutable activity. The UI consumes this fact consistently for grouping, self/owner exclusion, keyed rows, card lookup, profile Activity joins, and typing presence.

The repair removes the mixed-group downgrade, duplicate raw-ID filtering, self-dependent grouping cache, and a competing self-freshness guess. Gateway-store remains the authoritative owner of current self identity, so an initial hello snapshot cannot undo a later profile update. No UUID, profile-lookup, label, or participant-membership inference is added. No SQLite/schema/config/protocol-version change is included; the protocol file has only a comment clarification.

## User Impact

A profile and an unqualified user with the same raw ID remain separate people with separate watched sessions and timing. Excluding self or a displayed profile owner leaves the other namespace visible. Multiple tabs still count once, legitimate avatars remain available, and only recorded profile identities get person Activity links and profile-owned recent-session associations. Raw viewers retain their own connection details and visible watched sessions.

## Evidence

The original synthetic reproduction was captured on main `6982495ad8fc6d709de1272dce474937cd1af2a3`, which already includes #132038: two distinct connections produced one combined viewer, profile self exclusion removed both, and the raw session incorrectly had no other viewer. Server reproduction also shared one timing object and returned one typing identity. Tests were added before production repair; **six backend cases failed** across connection order, qualification transitions, typing cardinality, and actor membership, then passed after the owner fix. UI projection, live/prepared facepile, Activity, and rendered browser controls also failed before repair.

The integrated run passed **532 tests**, including backend lifecycle/audience siblings, UI self state, sidebar, facepile, and browser flows. After the final behavior-neutral cache/header cleanup, **37 targeted tests** were rerun and passed; these overlap the earlier total and are not additive. The parent then reran the original synthetic UI and server reproductions against final source: two viewers, both namespace-specific self exclusions, refreshed self surviving stale hello, independent timing, and two typing identities passed.

The full changed-file gate passed on all **33 files**, including core/core-test/UI typechecks, scoped lint, dead-export checks, import-cycle and architecture guards. The canonical **full `pnpm build` passed**. UI startup is **345,367 gzip bytes** against the unchanged **349,025-byte** limit. Fresh isolated Codex **P0/blocker autoreview** is scoped-clean with no findings. No guard, budget, baseline, or timeout was raised.

Inspected synthetic before/after browser captures are attached below. They use the real Control UI with mocked Gateway traffic and are labeled as such, not claimed as authenticated live-Gateway proof. The [additional real isolated built-Gateway proof](https://github.com/openclaw/openclaw/pull/132250#issuecomment-5459465625) passed all 10 browser assertion groups, including genuine degraded raw-auth admission, independent timing/typing, actual multi-tab aggregation and disconnect, and self exclusion. Its source/build identity, inspected video, cleanup, and limitations are recorded in that comment. It proves the frozen candidate before conflict resolution. The namespace production patch is unchanged after the rebase; post-rebase proof and [exact-head CI 33228071671](https://github.com/openclaw/openclaw/actions/runs/33228071671) now pass on `1dc773d0a98a537e867937671a0e7e2b847db065`. The maintained proof comment records the test-only CI repair, final review, and remaining native merge mechanics.

Production: **+192/−186, net +6** across 17 files (including a comment-only protocol edit). Tests: **+730/−108, net +622**; test support: **+40/−16, net +24**; docs: **+13/−4**. The six production lines buy the explicit namespace and connection-owned timing boundary after redundant grouping/cache/filtering paths were removed.

Initial validation caught an extra E2E test-root budget violation; cases were consolidated into the existing people-card suite without changing the budget. A test-local shadowed binding and incomplete old profile/typing fixtures were repaired. A parent review also caught the stale-hello self regression, which is now protected through the Gateway-store producer and rendered send-reconciliation flow. All stated final checks pass.

<details>
<summary>Focused commands and proof scope</summary>

```bash
OPENCLAW_VITEST_MAX_WORKERS=2 node scripts/run-vitest.mjs src/gateway/server/client-presence.test.ts src/gateway/server-methods/sessions-typing.test.ts src/gateway/server-methods/sessions-suggestions.test.ts
```

```bash
OPENCLAW_VITEST_MAX_WORKERS=2 node scripts/run-vitest.mjs src/gateway/server-request-context.test.ts src/gateway/session-viewer-presence.test.ts src/gateway/server-methods/session-typing-state.test.ts src/gateway/server-methods/sessions-suggestions.visibility.test.ts src/gateway/server.auth.presence-audience.test.ts src/infra/system-presence.test.ts
```

```bash
OPENCLAW_VITEST_MAX_WORKERS=2 node scripts/run-vitest.mjs ui/src/lib/presence-users.test.ts ui/src/app/user-profile.test.ts ui/src/pages/activity/session-activity-view.test.ts ui/src/lib/session-viewer-presence.test.ts ui/src/app/gateway-store.test.ts ui/src/pages/chat/chat-pane-typing.test.ts ui/src/pages/chat/chat-pane-identity.test.ts ui/src/pages/chat/components/chat-pane-header-identity.test.ts
```

```bash
OPENCLAW_VITEST_MAX_WORKERS=2 node scripts/run-vitest.mjs ui/src/components/app-sidebar.test.ts
```

```bash
OPENCLAW_VITEST_MAX_WORKERS=2 node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-isolated.config.ts ui/src/components/viewer-facepile.test.ts
```

```bash
OPENCLAW_VITEST_MAX_WORKERS=2 node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/people-activity-card.e2e.test.ts ui/src/e2e/identity-activity-links.e2e.test.ts ui/src/e2e/chat-attributed-identity.e2e.test.ts ui/src/e2e/chat-header-owner-presence.capture.e2e.test.ts
```

```bash
OPENCLAW_VITEST_MAX_WORKERS=2 node scripts/run-vitest.mjs ui/src/lib/presence-users.test.ts ui/src/pages/chat/chat-pane-typing.test.ts
```

```bash
node scripts/check-changed.mjs -- docs/concepts/multi-user.md docs/concepts/presence.md packages/gateway-protocol/src/schema/snapshot.ts src/gateway/server-methods/session-typing-state.ts src/gateway/server-methods/sessions-suggestions.test-mocks.ts src/gateway/server-methods/sessions-suggestions.test.ts src/gateway/server-methods/sessions-suggestions.ts src/gateway/server-methods/sessions-typing.test.ts src/gateway/server/client-presence.test.ts src/gateway/server/client-presence.ts src/gateway/server/ws-types.ts src/shared/presence-user.ts ui/src/app/gateway-store.test.ts ui/src/app/user-profile.test.ts ui/src/app/user-profile.ts ui/src/components/app-sidebar-render.ts ui/src/components/app-sidebar-session-row-render.ts ui/src/components/person-activity-card.ts ui/src/components/session-leading-indicator.ts ui/src/components/sidebar-people.runtime.ts ui/src/components/viewer-facepile.test.ts ui/src/components/viewer-facepile.ts ui/src/e2e/chat-attributed-identity.e2e.test.ts ui/src/e2e/chat-header-owner-presence.capture.e2e.test.ts ui/src/e2e/people-activity-card.e2e.test.ts ui/src/lib/presence-users.test.ts ui/src/lib/presence-users.ts ui/src/pages/activity/session-activity-view.test.ts ui/src/pages/activity/session-activity-view.ts ui/src/pages/chat/chat-pane-header.ts ui/src/pages/chat/chat-pane-render.ts ui/src/test-helpers/app-sidebar-cases/presence.ts ui/src/test-helpers/app-sidebar-cases/session-ownership.ts
```

```bash
pnpm build
```

```bash
pnpm ui:build
```

No full repository test suite or external-provider run is claimed. No operator Gateway/state, saved credentials, or real conversations were used. Separate leads for degraded self-profile recovery, evicted row restoration, node retained metadata, and hello recovery scope are not silently folded into this repair.

</details>

AI-assisted implementation and verification. The root cause, owning flow, and final diff were manually reviewed.

### Synthetic Control UI before and after (mocked Gateway)

![Before: colliding synthetic identities collapse into one; mocked Gateway](https://github.com/user-attachments/assets/2de324b1-30a2-4f67-9595-fb84d9567b2f)

![After: raw viewer keeps only its own watches and no profile Activity link; mocked Gateway](https://github.com/user-attachments/assets/edc98895-bed1-4b80-b96a-a861c8ca73c5)

![After: qualified profile retains its own watches and Activity link; mocked Gateway](https://github.com/user-attachments/assets/44ca2797-8e68-4c10-bff3-ad2e53aede02)