### PR TITLE
fix: package inventory is skipped for symlinked source paths

### DIFF
--- a/scripts/write-package-dist-inventory.ts
+++ b/scripts/write-package-dist-inventory.ts
@@ -1,13 +1,11 @@
 #!/usr/bin/env -S node --import tsx
 // Write Package Dist Inventory script supports OpenClaw repository automation.
 
-import { pathToFileURL } from "node:url";
+import { fileURLToPath } from "node:url";
+import { isMainModule } from "../src/infra/is-main.ts";
 import { writePackageDistInventoryForPublish } from "./lib/package-dist-inventory.ts";
 
-async function writeCurrentPackageDistInventory(): Promise<void> {
+// Match argv only; PM2 hints must not turn an import into a package write.
+if (isMainModule({ currentFile: fileURLToPath(import.meta.url), env: {} })) {
   await writePackageDistInventoryForPublish(process.cwd());
-}
-
-if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {
-  await writeCurrentPackageDistInventory();
 }

--- a/test/scripts/write-package-dist-inventory.test.ts
+++ b/test/scripts/write-package-dist-inventory.test.ts
@@ -1,0 +1,101 @@
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import { createRequire } from "node:module";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { describe, expect, it } from "vitest";
+import {
+  PACKAGE_DIST_INVENTORY_RELATIVE_PATH,
+  PACKAGE_INSTALL_GUARD_RELATIVE_PATH,
+} from "../../scripts/lib/package-dist-inventory-contract.mts";
+import { withTempDirSync } from "../../src/test-helpers/temp-dir.js";
+
+const repoRoot = fs.realpathSync(fileURLToPath(new URL("../..", import.meta.url)));
+const writerPath = path.join(repoRoot, "scripts/write-package-dist-inventory.ts");
+const loaderUrl = pathToFileURL(createRequire(import.meta.url).resolve("tsx")).href;
+
+function withPackageFixture(run: (packageRoot: string) => void) {
+  withTempDirSync({ prefix: "openclaw-path-alias-inventory-" }, (packageRoot) => {
+    fs.mkdirSync(path.join(packageRoot, "dist"));
+    fs.writeFileSync(path.join(packageRoot, "package.json"), '{"type":"module"}\n');
+    fs.writeFileSync(path.join(packageRoot, "dist/entry.js"), "export {};\n");
+    run(packageRoot);
+  });
+}
+
+function runNode(packageRoot: string, args: string[]) {
+  const result = spawnSync(process.execPath, ["--import", loaderUrl, ...args], {
+    cwd: packageRoot,
+    encoding: "utf8",
+    timeout: 30_000,
+    env: {
+      ...process.env,
+      // The tiny cwd fixture still uses the real source closure's workspace aliases.
+      TSX_TSCONFIG_PATH: path.join(repoRoot, "tsconfig.json"),
+      TSX_DISABLE_CACHE: "1",
+      pm_exec_path: writerPath,
+    },
+  });
+  expect(result.error).toBeUndefined();
+  expect(result.status, result.stderr).toBe(0);
+}
+
+describe("write-package-dist-inventory direct entry", () => {
+  it.each(["canonical", "directory alias"])("writes both artifacts via %s", (entry) => {
+    withPackageFixture((packageRoot) => {
+      let scriptPath = writerPath;
+      if (entry === "directory alias") {
+        const sourceAlias = path.join(packageRoot, "source-alias");
+        fs.symlinkSync(repoRoot, sourceAlias, process.platform === "win32" ? "junction" : "dir");
+        scriptPath = path.join(sourceAlias, "scripts/write-package-dist-inventory.ts");
+      }
+
+      runNode(packageRoot, [scriptPath]);
+
+      expect(
+        JSON.parse(
+          fs.readFileSync(path.join(packageRoot, PACKAGE_DIST_INVENTORY_RELATIVE_PATH), "utf8"),
+        ),
+      ).toEqual(["dist/entry.js"]);
+      expect(
+        fs.readFileSync(path.join(packageRoot, PACKAGE_INSTALL_GUARD_RELATIVE_PATH), "utf8"),
+      ).toBe("OpenClaw package preinstall has not completed.\n");
+      expect(fs.readdirSync(path.join(packageRoot, "dist")).sort()).toEqual(
+        [
+          "entry.js",
+          path.basename(PACKAGE_DIST_INVENTORY_RELATIVE_PATH),
+          path.basename(PACKAGE_INSTALL_GUARD_RELATIVE_PATH),
+        ].sort(),
+      );
+    });
+  });
+
+  describe.each([false, true])("import with existing artifacts=%s", (seeded) => {
+    it.each(["no argv", "same basename"])("stays inert with %s and PM2 hints", (entry) => {
+      withPackageFixture((packageRoot) => {
+        const expected: Record<string, string> = { "entry.js": "export {};\n" };
+        if (seeded) {
+          expected[path.basename(PACKAGE_DIST_INVENTORY_RELATIVE_PATH)] = '["dist/previous.js"]\n';
+          expected[path.basename(PACKAGE_INSTALL_GUARD_RELATIVE_PATH)] = "existing guard\n";
+          for (const [name, content] of Object.entries(expected)) {
+            fs.writeFileSync(path.join(packageRoot, "dist", name), content);
+          }
+        }
+        const importSource = `await import(${JSON.stringify(pathToFileURL(writerPath).href)});\n`;
+        const importerPath = path.join(packageRoot, path.basename(writerPath));
+        fs.writeFileSync(importerPath, importSource);
+        runNode(
+          packageRoot,
+          entry === "no argv" ? ["--input-type=module", "--eval", importSource] : [importerPath],
+        );
+
+        const actual = Object.fromEntries(
+          fs
+            .readdirSync(path.join(packageRoot, "dist"))
+            .map((name) => [name, fs.readFileSync(path.join(packageRoot, "dist", name), "utf8")]),
+        );
+        expect(actual).toEqual(expected);
+      });
+    });
+  });
+});


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where packaging OpenClaw from a symlinked source directory would silently skip inventory generation and produce a tarball rejected for missing the postinstall inventory and pending-install guard. This includes macOS temporary-directory aliases.

## Why This Change Was Made

The writer now matches its direct entrypoint by filesystem identity through the existing realpath-aware helper rather than comparing URL spellings. It deliberately keeps argv-only activation, so importing the module remains inert even with an inherited PM2 execution hint. The package wrapper and frozen-source ownership are unchanged; no downstream path normalization or retry was added.

## User Impact

Canonical and symlinked source paths now both generate the package inventory and install guard. There are no version, dependency, package-budget, configuration, or application-runtime changes.

## Evidence

- Real pre-fix subprocess reproduction: the canonical entrypoint exited 0 and wrote both markers; the same entrypoint through a temporary directory symlink exited 0 and wrote neither. After the repair, both paths write the expected inventory and guard.
- New regression suite ran against the old writer: five cases passed and the aliased-entry case failed on the missing inventory. The six fixed cases cover canonical/aliased execution and inert imports with absent argv, an unrelated same-basename entrypoint, misleading PM2 hints, and absent or seeded artifacts.
- On this PR head, `node scripts/run-vitest.mjs test/scripts/write-package-dist-inventory.test.ts src/infra/is-main.test.ts src/infra/package-dist-inventory.test.ts test/scripts/direct-run-entrypoints.test.ts` passed all **66 tests**.
- On this PR head, `node scripts/check-changed.mjs -- scripts/write-package-dist-inventory.ts test/scripts/write-package-dist-inventory.test.ts` passed formatting, types, lint, and selected guards. A transient pnpm launcher failure occurred before any checks ran; the same pinned pnpm version resolved on retry, with no dependency changes.
- Fresh isolated Codex autoreview: no accepted/actionable findings. `git diff --check` passed.
- Full `pnpm build` passed on head `b3313d50d6d37946a12d90ba7f57a6495dc86cb3` (34m 12s on the shared local host; no ineffective-dynamic-import warning).
- The real canonical package wrapper ran against that build with a temporary symlink supplied as `--source-dir`, using `--skip-build --allow-unreleased-changelog` and an npm pack receipt. It generated `dist/postinstall-inventory.json` and `dist/openclaw-install-guard`, then passed strict inventory parity, tar modes, bundled workspace dependency, and dist import graph validation. The inventory contains **10,038 entries**.
- The finished tarball is **203,885,815 bytes unpacked (194.4 MiB)**, below the **unchanged 213,909,504-byte (204 MiB) cap**; `collectPackUnpackedSizeErrors` returned `[]`. SHA-256: `11086e9b6a495305aa277697b833cdb8685954236c4d3ef697522f0975a750f6`. The earlier task-base artifact exceeded the cap (232.1 MiB); it is superseded by this passing exact-head rebuild/replay, not by a raised limit.
- Exact-head [CI run 33225111808](https://github.com/openclaw/openclaw/actions/runs/33225111808) passed. The latest [ClawSweeper review](https://github.com/openclaw/openclaw/pull/132252#issuecomment-5459388732) reports no actionable findings; its remaining next step is normal exact-head validation and maintainer merge handling.

Production/tooling LOC: **+4/-6 (net -2)**. Tests: **+101**. The redundant one-use async wrapper was removed.

AI-assisted with Codex.
