### PR TITLE
fix(channels): retire the replaced credential source on setup rotation

### DIFF
--- a/extensions/googlechat/src/accounts.ts
+++ b/extensions/googlechat/src/accounts.ts
@@ -270,6 +270,7 @@ function isolateAccountCredentials(
   if (!Object.hasOwn(rawAccount, "serviceAccountFile")) {
     delete isolated.serviceAccountFile;
   }
+  // SAFETY: deleted fields are optional on GoogleChatAccountConfig, so the object is still well-formed.
   return isolated as GoogleChatAccountConfig;
 }
 

--- a/extensions/googlechat/src/accounts.ts
+++ b/extensions/googlechat/src/accounts.ts
@@ -217,10 +217,26 @@ function resolveGoogleChatAccountWithMode(params: {
   const merged = mergeGoogleChatAccountConfig(params.cfg, accountId);
   const accountEnabled = merged.enabled !== false;
   const enabled = baseEnabled && accountEnabled;
+  // The account merger overlays root fields ({...root, ...account}), so a named
+  // account that sets one credential source still inherits the root value of
+  // the other form. The resolver prefers inline over file, so a rotation that
+  // retires the account's inline override would silently fall back to the root
+  // identity (see #132231). When the account explicitly sets either credential
+  // source, treat the pair as one atomic override and drop the inherited root
+  // credential from credential selection; the returned config keeps the full
+  // merged shape.
+  const rawAccount = resolveAccountEntry(params.cfg.channels?.["googlechat"]?.accounts, accountId);
+  const accountSetsCredential =
+    rawAccount !== undefined &&
+    (Object.hasOwn(rawAccount, "serviceAccount") ||
+      Object.hasOwn(rawAccount, "serviceAccountFile"));
   const credentials = resolveCredentialsFromConfig({
     cfg: params.cfg,
     accountId,
-    account: merged,
+    account:
+      accountId !== DEFAULT_ACCOUNT_ID && accountSetsCredential
+        ? isolateAccountCredentials(merged, rawAccount)
+        : merged,
     mode: params.mode,
   });
 
@@ -235,6 +251,26 @@ function resolveGoogleChatAccountWithMode(params: {
     tokenStatus: credentials.status,
     ...(credentials.diagnostic ? { credentialDiagnostics: [credentials.diagnostic] } : {}),
   };
+}
+
+/**
+ * Treats a named account's explicit credential fields as one atomic override:
+ * a field the account did not set is dropped so a root-inherited credential of
+ * the other form cannot win credential selection. The inline value the account
+ * did set always beats any inherited file, and vice versa.
+ */
+function isolateAccountCredentials(
+  merged: GoogleChatAccountConfig,
+  rawAccount: Record<string, unknown>,
+): GoogleChatAccountConfig {
+  const isolated = { ...merged };
+  if (!Object.hasOwn(rawAccount, "serviceAccount")) {
+    delete isolated.serviceAccount;
+  }
+  if (!Object.hasOwn(rawAccount, "serviceAccountFile")) {
+    delete isolated.serviceAccountFile;
+  }
+  return isolated as GoogleChatAccountConfig;
 }
 
 export function resolveGoogleChatAccount(params: {

--- a/extensions/googlechat/src/secret-contract.test.ts
+++ b/extensions/googlechat/src/secret-contract.test.ts
@@ -1,3 +1,4 @@
+import { assertSecretOwnerAvailable } from "openclaw/plugin-sdk/channel-secret-owner-runtime";
 // Googlechat tests cover secret contract plugin behavior.
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import {
@@ -6,7 +7,51 @@ import {
   resolveSecretRefValues,
 } from "openclaw/plugin-sdk/secret-ref-runtime";
 import { describe, expect, it } from "vitest";
+import {
+  setActiveDegradedSecretOwners,
+  SecretSurfaceUnavailableError,
+} from "../../../src/secrets/runtime-degraded-state.js";
+import { resolveAndApplySecretAssignments } from "../../../src/secrets/runtime-owner-assignments.js";
 import { collectRuntimeConfigAssignments } from "./secret-contract.js";
+
+type ConfiguredAccount = {
+  enabled?: boolean;
+  serviceAccount?: unknown;
+  serviceAccountFile?: string;
+};
+
+function configWithAccounts(
+  accounts: Record<string, ConfiguredAccount>,
+  rootServiceAccount?: unknown,
+): OpenClawConfig {
+  return {
+    channels: {
+      googlechat: {
+        enabled: true,
+        ...(rootServiceAccount !== undefined ? { serviceAccount: rootServiceAccount } : {}),
+        accounts,
+      },
+    },
+  } as unknown as OpenClawConfig;
+}
+
+// Env-shorthand SecretRef whose variable the tests never provide, so root-ref
+// resolution fails the way an unavailable provider does in production.
+const UNAVAILABLE_ROOT_REF = "\${MISSING_ROOT_GOOGLECHAT_SECRET}";
+
+function collect(config: OpenClawConfig) {
+  const resolvedConfig: OpenClawConfig = structuredClone(config);
+  const context = createResolverContext({
+    sourceConfig: config,
+    env: {},
+  });
+  collectRuntimeConfigAssignments({
+    config: resolvedConfig,
+    defaults: undefined,
+    context,
+  });
+  return context;
+}
 
 describe("googlechat secret contract", () => {
   it("resolves account serviceAccount SecretRefs for enabled accounts", async () => {
@@ -66,5 +111,81 @@ describe("googlechat secret contract", () => {
     const workAccount = resolvedConfig.channels?.googlechat?.accounts?.work;
     expect(workAccount?.serviceAccount).toBe('{"client_email":"bot@example.com"}');
     expect(context.warnings).toStrictEqual([]);
+  });
+
+  it("does not assign the root serviceAccount SecretRef to a named account that owns a serviceAccountFile", () => {
+    const context = collect(
+      configWithAccounts(
+        { work: { enabled: true, serviceAccountFile: "/run/secrets/work-sa.json" } },
+        UNAVAILABLE_ROOT_REF,
+      ),
+    );
+
+    expect(context.assignments).toStrictEqual([]);
+  });
+
+  it("keeps the default account as a root serviceAccount SecretRef owner", () => {
+    const context = collect(
+      configWithAccounts(
+        {
+          default: { enabled: true },
+          work: { enabled: true, serviceAccountFile: "/run/secrets/work-sa.json" },
+        },
+        UNAVAILABLE_ROOT_REF,
+      ),
+    );
+
+    expect(context.assignments).toMatchObject([
+      { ownerKind: "account", ownerId: "googlechat:default" },
+    ]);
+  });
+
+  it("keeps an unavailable root SecretRef from degrading a file-backed named account through preparation", async () => {
+    const sourceConfig = configWithAccounts(
+      { work: { enabled: true, serviceAccountFile: "/run/secrets/work-sa.json" } },
+      UNAVAILABLE_ROOT_REF,
+    );
+    const context = collect(sourceConfig);
+
+    const { degradedOwners } = await resolveAndApplySecretAssignments({
+      assignments: context.assignments,
+      context,
+      allowOwnerIsolation: true,
+      options: {
+        config: sourceConfig,
+        env: context.env,
+        cache: context.cache,
+      },
+    });
+
+    expect(degradedOwners).toStrictEqual([]);
+  });
+
+  it("isolates a named account that inherits an unavailable root SecretRef during preparation", async () => {
+    const sourceConfig = configWithAccounts({ work: { enabled: true } }, UNAVAILABLE_ROOT_REF);
+    const context = collect(sourceConfig);
+
+    const { degradedOwners } = await resolveAndApplySecretAssignments({
+      assignments: context.assignments,
+      context,
+      allowOwnerIsolation: true,
+      options: {
+        config: sourceConfig,
+        env: context.env,
+        cache: context.cache,
+      },
+    });
+
+    expect(degradedOwners).toMatchObject([{ ownerKind: "account", ownerId: "googlechat:work" }]);
+    // Snapshot activation publishes the degraded owner the way a real
+    // preparation does; gateway startup then rejects this exact owner.
+    setActiveDegradedSecretOwners(degradedOwners);
+    try {
+      expect(() => assertSecretOwnerAvailable("account", "googlechat:work")).toThrowError(
+        SecretSurfaceUnavailableError,
+      );
+    } finally {
+      setActiveDegradedSecretOwners([]);
+    }
   });
 });

--- a/extensions/googlechat/src/secret-contract.test.ts
+++ b/extensions/googlechat/src/secret-contract.test.ts
@@ -1,4 +1,3 @@
-import { assertSecretOwnerAvailable } from "openclaw/plugin-sdk/channel-secret-owner-runtime";
 // Googlechat tests cover secret contract plugin behavior.
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import {
@@ -7,11 +6,6 @@ import {
   resolveSecretRefValues,
 } from "openclaw/plugin-sdk/secret-ref-runtime";
 import { describe, expect, it } from "vitest";
-import {
-  setActiveDegradedSecretOwners,
-  SecretSurfaceUnavailableError,
-} from "../../../src/secrets/runtime-degraded-state.js";
-import { resolveAndApplySecretAssignments } from "../../../src/secrets/runtime-owner-assignments.js";
 import { collectRuntimeConfigAssignments } from "./secret-contract.js";
 
 type ConfiguredAccount = {
@@ -35,9 +29,9 @@ function configWithAccounts(
   } as unknown as OpenClawConfig;
 }
 
-// Env-shorthand SecretRef whose variable the tests never provide, so root-ref
-// resolution fails the way an unavailable provider does in production.
-const UNAVAILABLE_ROOT_REF = "\${MISSING_ROOT_GOOGLECHAT_SECRET}";
+// Env-shorthand SecretRef whose variable the tests never provide, so resolution
+// of this ref fails the way an unavailable provider does in production.
+const UNAVAILABLE_ROOT_REF = "${MISSING_ROOT_GOOGLECHAT_SECRET}";
 
 function collect(config: OpenClawConfig) {
   const resolvedConfig: OpenClawConfig = structuredClone(config);
@@ -140,52 +134,27 @@ describe("googlechat secret contract", () => {
     ]);
   });
 
-  it("keeps an unavailable root SecretRef from degrading a file-backed named account through preparation", async () => {
-    const sourceConfig = configWithAccounts(
-      { work: { enabled: true, serviceAccountFile: "/run/secrets/work-sa.json" } },
-      UNAVAILABLE_ROOT_REF,
-    );
-    const context = collect(sourceConfig);
+  it("keeps an inheriting named account as a root serviceAccount SecretRef owner", () => {
+    const context = collect(configWithAccounts({ work: { enabled: true } }, UNAVAILABLE_ROOT_REF));
 
-    const { degradedOwners } = await resolveAndApplySecretAssignments({
-      assignments: context.assignments,
-      context,
-      allowOwnerIsolation: true,
-      options: {
-        config: sourceConfig,
-        env: context.env,
-        cache: context.cache,
-      },
-    });
-
-    expect(degradedOwners).toStrictEqual([]);
+    expect(context.assignments).toMatchObject([
+      { ownerKind: "account", ownerId: "googlechat:work" },
+    ]);
   });
 
-  it("isolates a named account that inherits an unavailable root SecretRef during preparation", async () => {
+  it("resolves the root ref fixture to prove it fails when the variable is unavailable", async () => {
     const sourceConfig = configWithAccounts({ work: { enabled: true } }, UNAVAILABLE_ROOT_REF);
     const context = collect(sourceConfig);
 
-    const { degradedOwners } = await resolveAndApplySecretAssignments({
-      assignments: context.assignments,
-      context,
-      allowOwnerIsolation: true,
-      options: {
-        config: sourceConfig,
-        env: context.env,
-        cache: context.cache,
-      },
-    });
-
-    expect(degradedOwners).toMatchObject([{ ownerKind: "account", ownerId: "googlechat:work" }]);
-    // Snapshot activation publishes the degraded owner the way a real
-    // preparation does; gateway startup then rejects this exact owner.
-    setActiveDegradedSecretOwners(degradedOwners);
-    try {
-      expect(() => assertSecretOwnerAvailable("account", "googlechat:work")).toThrowError(
-        SecretSurfaceUnavailableError,
-      );
-    } finally {
-      setActiveDegradedSecretOwners([]);
-    }
+    await expect(
+      resolveSecretRefValues(
+        context.assignments.map((assignment) => assignment.ref),
+        {
+          config: sourceConfig,
+          env: context.env,
+          cache: context.cache,
+        },
+      ),
+    ).rejects.toThrowError(/MISSING_ROOT_GOOGLECHAT_SECRET|missing or empty/u);
   });
 });

--- a/extensions/googlechat/src/secret-contract.ts
+++ b/extensions/googlechat/src/secret-contract.ts
@@ -1,5 +1,5 @@
 // Secret-target discovery must not load provider setup or resolution runtimes.
-import { normalizeAccountId } from "openclaw/plugin-sdk/account-id";
+import { DEFAULT_ACCOUNT_ID, normalizeAccountId } from "openclaw/plugin-sdk/account-id";
 import {
   createChannelSecretTargetRegistryEntries,
   getChannelSurface,
@@ -103,7 +103,24 @@ export function collectRuntimeConfigAssignments(params: {
     : !surface.hasExplicitAccounts
       ? ["default"]
       : surface.accounts
-          .filter(({ account, enabled }) => enabled && !hasOwnProperty(account, "serviceAccount"))
+          .filter(({ account, enabled, accountId }) => {
+            if (!enabled) {
+              return false;
+            }
+            // Mirror the resolver's atomic credential override for named
+            // accounts (isolateAccountCredentials): an account that sets either
+            // credential form drops the inherited root credential, so secret
+            // discovery must not hand it the root SecretRef. The default
+            // account keeps resolving root credentials and stays an owner.
+            if (
+              accountId !== DEFAULT_ACCOUNT_ID &&
+              (hasOwnProperty(account, "serviceAccount") ||
+                hasOwnProperty(account, "serviceAccountFile"))
+            ) {
+              return false;
+            }
+            return !hasOwnProperty(account, "serviceAccount");
+          })
           .map(({ accountId }) => accountId);
   collectGoogleChatAccountAssignment({
     target: googleChat,

--- a/extensions/googlechat/src/setup-core.test.ts
+++ b/extensions/googlechat/src/setup-core.test.ts
@@ -1,10 +1,15 @@
 import { describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "../runtime-api.js";
+import { resolveGoogleChatConfigAccessorAccount } from "./accounts.js";
 import { googlechatSetupAdapter } from "./setup-core.js";
 
 type GoogleChatChannelConfig = {
   serviceAccount?: string;
   serviceAccountFile?: string;
+  accounts?: Record<
+    string,
+    { serviceAccount?: string; serviceAccountFile?: string; name?: string }
+  >;
 };
 
 function applyGoogleChatSetup(
@@ -53,5 +58,30 @@ describe("googlechat credential rotation", () => {
 
     expect(rotated.serviceAccount).toBeUndefined();
     expect(rotated.serviceAccountFile).toBeUndefined();
+  });
+
+  it("retires a promoted accounts.default credential so the rotation wins at resolution", () => {
+    // Named-account setup promotes the root credential into accounts.default,
+    // and the merged account config reads that record ahead of the root fields.
+    const promoted = {
+      channels: {
+        googlechat: {
+          enabled: true,
+          accounts: {
+            default: { serviceAccount: '{"type":"service_account","old":true}', name: "Main" },
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    const rotatedConfig = applyGoogleChatSetup({ token: '{"type":"service_account"}' }, promoted);
+    const rotated = (rotatedConfig.channels?.googlechat ?? {}) as GoogleChatChannelConfig;
+
+    expect(rotated.serviceAccount).toBe('{"type":"service_account"}');
+    expect(rotated.accounts?.default?.serviceAccount).toBeUndefined();
+    expect(rotated.accounts?.default?.name).toBe("Main");
+    expect(
+      resolveGoogleChatConfigAccessorAccount({ cfg: rotatedConfig }).config.serviceAccount,
+    ).toBe('{"type":"service_account"}');
   });
 });

--- a/extensions/googlechat/src/setup-core.test.ts
+++ b/extensions/googlechat/src/setup-core.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../runtime-api.js";
+import { googlechatSetupAdapter } from "./setup-core.js";
+
+type GoogleChatChannelConfig = {
+  serviceAccount?: string;
+  serviceAccountFile?: string;
+};
+
+function applyGoogleChatSetup(
+  input: Record<string, unknown>,
+  cfg: OpenClawConfig = {} as OpenClawConfig,
+): OpenClawConfig {
+  return googlechatSetupAdapter.applyAccountConfig({ cfg, accountId: "default", input });
+}
+
+function appliedGoogleChatConfig(
+  input: Record<string, unknown>,
+  cfg?: OpenClawConfig,
+): GoogleChatChannelConfig {
+  return (applyGoogleChatSetup(input, cfg).channels?.googlechat ?? {}) as GoogleChatChannelConfig;
+}
+
+describe("googlechat credential rotation", () => {
+  // Inline serviceAccount wins over serviceAccountFile at resolution time, so a
+  // rotation that leaves it behind silently keeps using the credential — and its
+  // plaintext private key — that it was meant to replace.
+  it("retires an inline service account when a file replaces it", () => {
+    const fromInline = applyGoogleChatSetup({ token: '{"type":"service_account"}' });
+
+    const rotated = appliedGoogleChatConfig(
+      { tokenFile: "/run/secrets/googlechat-sa.json" },
+      fromInline,
+    );
+
+    expect(rotated.serviceAccountFile).toBe("/run/secrets/googlechat-sa.json");
+    expect(rotated.serviceAccount).toBeUndefined();
+  });
+
+  it("retires a service account file when an inline value replaces it", () => {
+    const fromFile = applyGoogleChatSetup({ tokenFile: "/run/secrets/googlechat-sa.json" });
+
+    const rotated = appliedGoogleChatConfig({ token: '{"type":"service_account"}' }, fromFile);
+
+    expect(rotated.serviceAccount).toBe('{"type":"service_account"}');
+    expect(rotated.serviceAccountFile).toBeUndefined();
+  });
+
+  it("retires both sources when switching to the environment", () => {
+    const fromInline = applyGoogleChatSetup({ token: '{"type":"service_account"}' });
+
+    const rotated = appliedGoogleChatConfig({ useEnv: true }, fromInline);
+
+    expect(rotated.serviceAccount).toBeUndefined();
+    expect(rotated.serviceAccountFile).toBeUndefined();
+  });
+});

--- a/extensions/googlechat/src/setup-core.test.ts
+++ b/extensions/googlechat/src/setup-core.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "../runtime-api.js";
-import { resolveGoogleChatConfigAccessorAccount } from "./accounts.js";
+import { resolveGoogleChatAccount, resolveGoogleChatConfigAccessorAccount } from "./accounts.js";
 import { googlechatSetupAdapter } from "./setup-core.js";
 
 type GoogleChatChannelConfig = {
@@ -83,5 +83,117 @@ describe("googlechat credential rotation", () => {
     expect(
       resolveGoogleChatConfigAccessorAccount({ cfg: rotatedConfig }).config.serviceAccount,
     ).toBe('{"type":"service_account"}');
+  });
+
+  it("does not select the root identity when a named-account rotation retires its inline override", () => {
+    // Root carries the default account's inline credential A. The named account
+    // `work` explicitly sets inline B. Rotating `work` to a file retires B and
+    // writes the file, but the account merger still inherits root A into the
+    // named account; the resolver would pick A (the wrong identity) unless the
+    // account's explicit credential source is treated as an atomic override.
+    const cfg = {
+      channels: {
+        googlechat: {
+          enabled: true,
+          serviceAccount: '{"type":"service_account","v":"A"}',
+          accounts: {
+            work: {
+              serviceAccount: '{"type":"service_account","v":"B"}',
+            },
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    const rotated = googlechatSetupAdapter.applyAccountConfig({
+      cfg,
+      accountId: "work",
+      input: { tokenFile: "/run/secrets/work-sa.json" },
+    });
+    const resolved = resolveGoogleChatAccount({ cfg: rotated, accountId: "work" });
+
+    expect(resolved.credentialSource).toBe("file");
+    expect(resolved.credentialsFile).toBe("/run/secrets/work-sa.json");
+  });
+
+  it("does not select the root identity when a named-account rotation replaces its file with inline", () => {
+    // Mirror case: root inline A + named account file F. Rotating `work` to
+    // inline B writes the account-level inline and retires the file; the root
+    // inline A must not win over the account's explicit B.
+    const cfg = {
+      channels: {
+        googlechat: {
+          enabled: true,
+          serviceAccount: '{"type":"service_account","v":"A"}',
+          accounts: {
+            work: {
+              serviceAccountFile: "/run/secrets/work-sa.json",
+            },
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    const rotated = googlechatSetupAdapter.applyAccountConfig({
+      cfg,
+      accountId: "work",
+      input: { token: '{"type":"service_account","v":"B"}' },
+    });
+    const resolved = resolveGoogleChatAccount({ cfg: rotated, accountId: "work" });
+
+    expect(resolved.credentialSource).toBe("inline");
+    expect(resolved.credentials).toMatchObject({ v: "B" });
+  });
+
+  it("keeps the legitimate root fallback for a named account with no explicit credential", () => {
+    // A named account that sets no credential source still inherits the root
+    // credential through the account merger — that fallback is intentional and
+    // must not be treated as an explicit override.
+    const cfg = {
+      channels: {
+        googlechat: {
+          enabled: true,
+          serviceAccount: '{"type":"service_account","v":"A"}',
+          accounts: {
+            work: {
+              name: "Work Team",
+            },
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    const resolved = resolveGoogleChatAccount({ cfg, accountId: "work" });
+
+    expect(resolved.credentialSource).toBe("inline");
+    expect(resolved.credentials).toMatchObject({ v: "A" });
+  });
+
+  it("keeps the default-account credential isolation for a named account with a file", () => {
+    // A named account's explicit file must not inherit the default account's
+    // inline credential (mirrors the resolver-level isolation test).
+    const cfg = {
+      channels: {
+        googlechat: {
+          enabled: true,
+          accounts: {
+            default: {
+              serviceAccount: { source: "env", provider: "test", id: "default-sa" },
+              audienceType: "app-url",
+              audience: "https://example.com/googlechat",
+            },
+            work: {
+              serviceAccountFile: "/run/secrets/work-sa.json",
+            },
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    const resolved = resolveGoogleChatAccount({ cfg, accountId: "work" });
+
+    expect(resolved.credentialSource).toBe("file");
+    expect(resolved.credentialsFile).toBe("/run/secrets/work-sa.json");
+    expect(resolved.config.audienceType).toBe("app-url");
   });
 });

--- a/extensions/googlechat/src/setup-core.ts
+++ b/extensions/googlechat/src/setup-core.ts
@@ -48,6 +48,17 @@ export const googlechatSetupAdapter = createPatchedAccountSetupAdapter({
       ...(webhookUrl ? { webhookUrl } : {}),
     };
   },
+  // Resolution prefers inline serviceAccount over serviceAccountFile, so writing
+  // one source has to retire the other or the stale credential (including the
+  // plaintext private key) keeps winning (see #132231).
+  buildClearFields: (input) =>
+    input.useEnv
+      ? ["serviceAccountFile", "serviceAccount"]
+      : input.tokenFile
+        ? ["serviceAccount"]
+        : input.token
+          ? ["serviceAccountFile"]
+          : [],
 });
 
 export const googlechatSetupContract = defineChannelSetupContract({

--- a/extensions/googlechat/src/setup-core.ts
+++ b/extensions/googlechat/src/setup-core.ts
@@ -50,15 +50,12 @@ export const googlechatSetupAdapter = createPatchedAccountSetupAdapter({
   },
   // Resolution prefers inline serviceAccount over serviceAccountFile, so writing
   // one source has to retire the other or the stale credential (including the
-  // plaintext private key) keeps winning (see #132231).
+  // plaintext private key) keeps winning (see #132231). The full pair is retired
+  // on any credential write because a promoted accounts.default record outranks
+  // root regardless of which form it holds; the patch re-adds the written source
+  // after the clear.
   buildClearFields: (input) =>
-    input.useEnv
-      ? ["serviceAccountFile", "serviceAccount"]
-      : input.tokenFile
-        ? ["serviceAccount"]
-        : input.token
-          ? ["serviceAccountFile"]
-          : [],
+    input.useEnv || input.tokenFile || input.token ? ["serviceAccountFile", "serviceAccount"] : [],
 });
 
 export const googlechatSetupContract = defineChannelSetupContract({

--- a/extensions/googlechat/src/setup-core.ts
+++ b/extensions/googlechat/src/setup-core.ts
@@ -50,12 +50,8 @@ export const googlechatSetupAdapter = createPatchedAccountSetupAdapter({
   },
   // Resolution prefers inline serviceAccount over serviceAccountFile, so writing
   // one source has to retire the other or the stale credential (including the
-  // plaintext private key) keeps winning (see #132231). The full pair is retired
-  // on any credential write because a promoted accounts.default record outranks
-  // root regardless of which form it holds; the patch re-adds the written source
-  // after the clear.
-  buildClearFields: (input) =>
-    input.useEnv || input.tokenFile || input.token ? ["serviceAccountFile", "serviceAccount"] : [],
+  // plaintext private key) keeps winning (see #132231).
+  credentialSourceFields: ["serviceAccountFile", "serviceAccount"],
 });
 
 export const googlechatSetupContract = defineChannelSetupContract({

--- a/extensions/telegram/src/setup-core.test.ts
+++ b/extensions/telegram/src/setup-core.test.ts
@@ -1,10 +1,12 @@
 import { describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "../runtime-api.js";
 import { telegramSetupAdapter } from "./setup-core.js";
+import { resolveTelegramToken } from "./token.js";
 
 type TelegramChannelConfig = {
   botToken?: string;
   tokenFile?: string;
+  accounts?: Record<string, { botToken?: string; tokenFile?: string; name?: string }>;
 };
 
 function applyTelegramSetup(
@@ -49,5 +51,28 @@ describe("telegram credential rotation", () => {
 
     expect(rotated.botToken).toBeUndefined();
     expect(rotated.tokenFile).toBeUndefined();
+  });
+
+  it("retires a promoted accounts.default token so the rotation wins at resolution", () => {
+    // Named-account setup promotes the root credential into accounts.default,
+    // and resolution reads that record ahead of the root fields.
+    const promoted = {
+      channels: {
+        telegram: {
+          enabled: true,
+          accounts: {
+            default: { botToken: "promoted-stale-token", name: "Main" },
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    const rotatedConfig = applyTelegramSetup({ token: "rotated-token" }, promoted);
+    const rotated = (rotatedConfig.channels?.telegram ?? {}) as TelegramChannelConfig;
+
+    expect(rotated.botToken).toBe("rotated-token");
+    expect(rotated.accounts?.default?.botToken).toBeUndefined();
+    expect(rotated.accounts?.default?.name).toBe("Main");
+    expect(resolveTelegramToken(rotatedConfig).token).toBe("rotated-token");
   });
 });

--- a/extensions/telegram/src/setup-core.test.ts
+++ b/extensions/telegram/src/setup-core.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../runtime-api.js";
+import { telegramSetupAdapter } from "./setup-core.js";
+
+type TelegramChannelConfig = {
+  botToken?: string;
+  tokenFile?: string;
+};
+
+function applyTelegramSetup(
+  input: Record<string, unknown>,
+  cfg: OpenClawConfig = {} as OpenClawConfig,
+): OpenClawConfig {
+  return telegramSetupAdapter.applyAccountConfig({ cfg, accountId: "default", input });
+}
+
+function appliedTelegramConfig(
+  input: Record<string, unknown>,
+  cfg?: OpenClawConfig,
+): TelegramChannelConfig {
+  return (applyTelegramSetup(input, cfg).channels?.telegram ?? {}) as TelegramChannelConfig;
+}
+
+describe("telegram credential rotation", () => {
+  // tokenFile wins over inline botToken at resolution time, so a rotation that
+  // leaves it behind silently keeps using the credential it was meant to replace.
+  it("retires a token file when an inline token replaces it", () => {
+    const fromFile = applyTelegramSetup({ tokenFile: "/run/secrets/telegram-token" });
+
+    const rotated = appliedTelegramConfig({ token: "inline-token" }, fromFile);
+
+    expect(rotated.botToken).toBe("inline-token");
+    expect(rotated.tokenFile).toBeUndefined();
+  });
+
+  it("retires an inline token when a token file replaces it", () => {
+    const fromInline = applyTelegramSetup({ token: "inline-token" });
+
+    const rotated = appliedTelegramConfig({ tokenFile: "/run/secrets/telegram-token" }, fromInline);
+
+    expect(rotated.tokenFile).toBe("/run/secrets/telegram-token");
+    expect(rotated.botToken).toBeUndefined();
+  });
+
+  it("retires both sources when switching to the environment", () => {
+    const fromInline = applyTelegramSetup({ token: "inline-token" });
+
+    const rotated = appliedTelegramConfig({ useEnv: true }, fromInline);
+
+    expect(rotated.botToken).toBeUndefined();
+    expect(rotated.tokenFile).toBeUndefined();
+  });
+});

--- a/extensions/telegram/src/setup-core.ts
+++ b/extensions/telegram/src/setup-core.ts
@@ -104,6 +104,16 @@ export const telegramSetupAdapter: ChannelSetupAdapter = {
         : input.token
           ? { botToken: input.token }
           : {},
+    // Resolution prefers tokenFile over inline botToken, so writing one source
+    // has to retire the other or the stale credential keeps winning (see #132231).
+    buildClearFields: (input) =>
+      input.useEnv
+        ? ["tokenFile", "botToken"]
+        : input.tokenFile
+          ? ["botToken"]
+          : input.token
+            ? ["tokenFile"]
+            : [],
   }),
   singleAccountKeysToMove,
   namedAccountPromotionKeys,

--- a/extensions/telegram/src/setup-core.ts
+++ b/extensions/telegram/src/setup-core.ts
@@ -106,14 +106,11 @@ export const telegramSetupAdapter: ChannelSetupAdapter = {
           : {},
     // Resolution prefers tokenFile over inline botToken, so writing one source
     // has to retire the other or the stale credential keeps winning (see #132231).
+    // The full pair is retired on any credential write because a promoted
+    // accounts.default record outranks root regardless of which form it holds;
+    // the patch re-adds the written source after the clear.
     buildClearFields: (input) =>
-      input.useEnv
-        ? ["tokenFile", "botToken"]
-        : input.tokenFile
-          ? ["botToken"]
-          : input.token
-            ? ["tokenFile"]
-            : [],
+      input.useEnv || input.tokenFile || input.token ? ["tokenFile", "botToken"] : [],
   }),
   singleAccountKeysToMove,
   namedAccountPromotionKeys,

--- a/extensions/telegram/src/setup-core.ts
+++ b/extensions/telegram/src/setup-core.ts
@@ -106,11 +106,7 @@ export const telegramSetupAdapter: ChannelSetupAdapter = {
           : {},
     // Resolution prefers tokenFile over inline botToken, so writing one source
     // has to retire the other or the stale credential keeps winning (see #132231).
-    // The full pair is retired on any credential write because a promoted
-    // accounts.default record outranks root regardless of which form it holds;
-    // the patch re-adds the written source after the clear.
-    buildClearFields: (input) =>
-      input.useEnv || input.tokenFile || input.token ? ["tokenFile", "botToken"] : [],
+    credentialSourceFields: ["tokenFile", "botToken"],
   }),
   singleAccountKeysToMove,
   namedAccountPromotionKeys,

--- a/extensions/zalo/src/setup-core.test.ts
+++ b/extensions/zalo/src/setup-core.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../runtime-api.js";
+import { zaloSetupAdapter } from "./setup-core.js";
+
+type ZaloChannelConfig = {
+  botToken?: string;
+  tokenFile?: string;
+};
+
+function applyZaloSetup(
+  input: Record<string, unknown>,
+  cfg: OpenClawConfig = {} as OpenClawConfig,
+): OpenClawConfig {
+  return zaloSetupAdapter.applyAccountConfig({ cfg, accountId: "default", input });
+}
+
+function appliedZaloConfig(
+  input: Record<string, unknown>,
+  cfg?: OpenClawConfig,
+): ZaloChannelConfig {
+  return (applyZaloSetup(input, cfg).channels?.zalo ?? {}) as ZaloChannelConfig;
+}
+
+describe("zalo credential rotation", () => {
+  // Inline botToken wins over tokenFile at resolution time, so a rotation that
+  // leaves it behind silently keeps using the credential it was meant to replace.
+  it("retires an inline token when a token file replaces it", () => {
+    const fromInline = applyZaloSetup({ token: "inline-token" });
+
+    const rotated = appliedZaloConfig({ tokenFile: "/run/secrets/zalo-token" }, fromInline);
+
+    expect(rotated.tokenFile).toBe("/run/secrets/zalo-token");
+    expect(rotated.botToken).toBeUndefined();
+  });
+
+  it("retires a token file when an inline token replaces it", () => {
+    const fromFile = applyZaloSetup({ tokenFile: "/run/secrets/zalo-token" });
+
+    const rotated = appliedZaloConfig({ token: "inline-token" }, fromFile);
+
+    expect(rotated.botToken).toBe("inline-token");
+    expect(rotated.tokenFile).toBeUndefined();
+  });
+
+  it("retires both sources when switching to the environment", () => {
+    const fromFile = applyZaloSetup({ tokenFile: "/run/secrets/zalo-token" });
+
+    const rotated = appliedZaloConfig({ useEnv: true }, fromFile);
+
+    expect(rotated.botToken).toBeUndefined();
+    expect(rotated.tokenFile).toBeUndefined();
+  });
+});

--- a/extensions/zalo/src/setup-core.test.ts
+++ b/extensions/zalo/src/setup-core.test.ts
@@ -1,10 +1,13 @@
 import { describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "../runtime-api.js";
 import { zaloSetupAdapter } from "./setup-core.js";
+import { resolveZaloToken } from "./token.js";
+import type { ZaloConfig } from "./types.js";
 
 type ZaloChannelConfig = {
   botToken?: string;
   tokenFile?: string;
+  accounts?: Record<string, { botToken?: string; tokenFile?: string; name?: string }>;
 };
 
 function applyZaloSetup(
@@ -49,5 +52,30 @@ describe("zalo credential rotation", () => {
 
     expect(rotated.botToken).toBeUndefined();
     expect(rotated.tokenFile).toBeUndefined();
+  });
+
+  it("retires a promoted accounts.default token so the rotation wins at resolution", () => {
+    // Named-account setup promotes the root credential into accounts.default,
+    // and resolution reads that record ahead of the root fields.
+    const promoted = {
+      channels: {
+        zalo: {
+          enabled: true,
+          accounts: {
+            default: { botToken: "promoted-stale-token", name: "Main" },
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    const rotatedConfig = applyZaloSetup({ token: "rotated-token" }, promoted);
+    const rotated = (rotatedConfig.channels?.zalo ?? {}) as ZaloChannelConfig;
+
+    expect(rotated.botToken).toBe("rotated-token");
+    expect(rotated.accounts?.default?.botToken).toBeUndefined();
+    expect(rotated.accounts?.default?.name).toBe("Main");
+    expect(resolveZaloToken(rotatedConfig.channels?.zalo as ZaloConfig | undefined).token).toBe(
+      "rotated-token",
+    );
   });
 });

--- a/extensions/zalo/src/setup-core.ts
+++ b/extensions/zalo/src/setup-core.ts
@@ -41,11 +41,7 @@ export const zaloSetupAdapter = {
             : {},
     // Resolution prefers inline botToken over tokenFile, so writing one source
     // has to retire the other or the stale credential keeps winning (see #132231).
-    // The full pair is retired on any credential write because a promoted
-    // accounts.default record outranks root regardless of which form it holds;
-    // the patch re-adds the written source after the clear.
-    buildClearFields: (input) =>
-      input.useEnv || input.tokenFile || input.token ? ["tokenFile", "botToken"] : [],
+    credentialSourceFields: ["tokenFile", "botToken"],
   }),
   singleAccountKeysToMove: ["webhookSecret", "tokenFile"],
 };

--- a/extensions/zalo/src/setup-core.ts
+++ b/extensions/zalo/src/setup-core.ts
@@ -39,6 +39,16 @@ export const zaloSetupAdapter = {
           : input.token
             ? { botToken: input.token }
             : {},
+    // Resolution prefers inline botToken over tokenFile, so writing one source
+    // has to retire the other or the stale credential keeps winning (see #132231).
+    buildClearFields: (input) =>
+      input.useEnv
+        ? ["tokenFile", "botToken"]
+        : input.tokenFile
+          ? ["botToken"]
+          : input.token
+            ? ["tokenFile"]
+            : [],
   }),
   singleAccountKeysToMove: ["webhookSecret", "tokenFile"],
 };

--- a/extensions/zalo/src/setup-core.ts
+++ b/extensions/zalo/src/setup-core.ts
@@ -41,14 +41,11 @@ export const zaloSetupAdapter = {
             : {},
     // Resolution prefers inline botToken over tokenFile, so writing one source
     // has to retire the other or the stale credential keeps winning (see #132231).
+    // The full pair is retired on any credential write because a promoted
+    // accounts.default record outranks root regardless of which form it holds;
+    // the patch re-adds the written source after the clear.
     buildClearFields: (input) =>
-      input.useEnv
-        ? ["tokenFile", "botToken"]
-        : input.tokenFile
-          ? ["botToken"]
-          : input.token
-            ? ["tokenFile"]
-            : [],
+      input.useEnv || input.tokenFile || input.token ? ["tokenFile", "botToken"] : [],
   }),
   singleAccountKeysToMove: ["webhookSecret", "tokenFile"],
 };

--- a/src/channels/plugins/setup-helpers.test.ts
+++ b/src/channels/plugins/setup-helpers.test.ts
@@ -357,6 +357,30 @@ describe("createPatchedAccountSetupAdapter", () => {
     expect(next.channels?.["demo-accounts"]).not.toHaveProperty("enabled");
     expect(next.channels?.["demo-accounts"]).not.toHaveProperty("authDir");
   });
+
+  it("retires buildClearFields output before applying the replacement patch", () => {
+    const adapter = createPatchedAccountSetupAdapter({
+      channelKey: "demo-setup",
+      buildPatch: (input) =>
+        input.tokenFile ? { tokenFile: input.tokenFile } : { botToken: input.token },
+      buildClearFields: (input) => (input.tokenFile ? ["botToken"] : ["tokenFile"]),
+    });
+    const fromInline = adapter.applyAccountConfig({
+      cfg: asConfig({}),
+      accountId: DEFAULT_ACCOUNT_ID,
+      input: { token: "inline-tok" },
+    });
+
+    const rotated = adapter.applyAccountConfig({
+      cfg: fromInline,
+      accountId: DEFAULT_ACCOUNT_ID,
+      input: { tokenFile: "/run/secrets/tok" },
+    });
+
+    const channel = channelRecord(rotated, "demo-setup");
+    expect(channel.tokenFile).toBe("/run/secrets/tok");
+    expect(channel).not.toHaveProperty("botToken");
+  });
 });
 
 describe("moveSingleAccountChannelSectionToDefaultAccount", () => {

--- a/src/channels/plugins/setup-helpers.test.ts
+++ b/src/channels/plugins/setup-helpers.test.ts
@@ -387,12 +387,16 @@ describe("createPatchedAccountSetupAdapter", () => {
     expect(next.channels?.["demo-accounts"]).not.toHaveProperty("authDir");
   });
 
-  it("retires buildClearFields output before applying the replacement patch", () => {
+  it("retires credentialSourceFields before applying the replacement patch", () => {
     const adapter = createPatchedAccountSetupAdapter({
       channelKey: "demo-setup",
       buildPatch: (input) =>
-        input.tokenFile ? { tokenFile: input.tokenFile } : { botToken: input.token },
-      buildClearFields: (input) => (input.tokenFile ? ["botToken"] : ["tokenFile"]),
+        input.tokenFile
+          ? { tokenFile: input.tokenFile }
+          : input.token
+            ? { botToken: input.token }
+            : {},
+      credentialSourceFields: ["tokenFile", "botToken"],
     });
     const fromInline = adapter.applyAccountConfig({
       cfg: asConfig({}),
@@ -409,6 +413,44 @@ describe("createPatchedAccountSetupAdapter", () => {
     const channel = channelRecord(rotated, "demo-setup");
     expect(channel.tokenFile).toBe("/run/secrets/tok");
     expect(channel).not.toHaveProperty("botToken");
+  });
+
+  it("retires credentialSourceFields on an env-selection write and skips non-credential writes", () => {
+    const adapter = createPatchedAccountSetupAdapter({
+      channelKey: "demo-setup",
+      buildPatch: (input) =>
+        input.tokenFile
+          ? { tokenFile: input.tokenFile }
+          : input.token
+            ? { botToken: input.token }
+            : {},
+      credentialSourceFields: ["tokenFile", "botToken"],
+    });
+    const fromInline = adapter.applyAccountConfig({
+      cfg: asConfig({ channels: { "demo-setup": { webhookPath: "/keep" } } }),
+      accountId: DEFAULT_ACCOUNT_ID,
+      input: { token: "inline-tok" },
+    });
+
+    // Selecting env counts as a credential write: both stored sources are
+    // retired so the environment variable wins resolution.
+    const envSelected = adapter.applyAccountConfig({
+      cfg: fromInline,
+      accountId: DEFAULT_ACCOUNT_ID,
+      input: { useEnv: true },
+    });
+    const envChannel = channelRecord(envSelected, "demo-setup");
+    expect(envChannel).not.toHaveProperty("botToken");
+    expect(envChannel).not.toHaveProperty("tokenFile");
+
+    // A write without credential input must not touch stored credentials.
+    const untouched = adapter.applyAccountConfig({
+      cfg: fromInline,
+      accountId: DEFAULT_ACCOUNT_ID,
+      input: {},
+    });
+    const untouchedChannel = channelRecord(untouched, "demo-setup");
+    expect(untouchedChannel.botToken).toBe("inline-tok");
   });
 });
 

--- a/src/channels/plugins/setup-helpers.test.ts
+++ b/src/channels/plugins/setup-helpers.test.ts
@@ -227,6 +227,35 @@ describe("patchScopedAccountConfig credential clearing", () => {
     });
   });
 
+  it("retires the promoted accounts.default credential that outranks a root rotation", () => {
+    const next = patchScopedAccountConfig({
+      cfg: asConfig({
+        channels: {
+          "demo-setup": {
+            enabled: true,
+            webhookPath: "/keep",
+            accounts: {
+              default: { name: "Main", token: "promoted-stale-token", tokenFile: "/stale/token" },
+              work: { token: "work-token" },
+            },
+          },
+        },
+      }),
+      channelKey: "demo-setup",
+      accountId: DEFAULT_ACCOUNT_ID,
+      clearFields: ["token", "tokenFile"],
+      patch: { token: "new-token" },
+    });
+
+    const channel = channelRecord(next, "demo-setup");
+    expect(channel.token).toBe("new-token");
+    expect(channel.webhookPath).toBe("/keep");
+    // The stale account-scoped credential is retired while unrelated account
+    // fields and named accounts are preserved.
+    expect(accountRecord(channel, "default")).toEqual({ name: "Main" });
+    expect(accountRecord(channel, "work")).toEqual({ token: "work-token" });
+  });
+
   it("clears only selected named-account credentials and preserves disabled siblings", () => {
     const next = patchScopedAccountConfig({
       cfg: asConfig({

--- a/src/channels/plugins/setup-helpers.ts
+++ b/src/channels/plugins/setup-helpers.ts
@@ -125,7 +125,12 @@ export function applySetupAccountConfigPatch(params: {
 
 /** Creates a setup adapter that turns validated setup input into an account config patch. */
 export function createPatchedAccountSetupAdapter<
-  Input extends { name?: string } = ChannelSetupInput,
+  Input extends {
+    name?: string;
+    token?: string;
+    tokenFile?: string;
+    useEnv?: boolean;
+  } = ChannelSetupInput,
 >(params: {
   channelKey: string;
   alwaysUseAccounts?: boolean;
@@ -133,7 +138,15 @@ export function createPatchedAccountSetupAdapter<
   ensureAccountEnabled?: boolean;
   validateInput?: ChannelSetupAdapter<Input>["validateInput"];
   buildPatch: (input: Input) => Record<string, unknown>;
-  buildClearFields?: (input: Input) => readonly string[];
+  /**
+   * Mutually exclusive credential-source fields (inline token, token file,
+   * service account blob, ...). When a setup write supplies credentials
+   * through the standard credential inputs (`token`, `tokenFile`, `useEnv`),
+   * every listed field is retired at the channel root and the default account
+   * before the patch re-adds the written source. Resolution precedence means
+   * a superseded source otherwise keeps winning over the rotated credential.
+   */
+  credentialSourceFields?: readonly string[];
 }): ChannelSetupAdapter<Input> {
   return {
     resolveAccountId: ({ accountId }) => normalizeAccountId(accountId),
@@ -156,13 +169,17 @@ export function createPatchedAccountSetupAdapter<
         migrateBaseName: !params.alwaysUseAccounts,
       });
       const patch = params.buildPatch(input);
+      const credentialWrite = Boolean(input.useEnv || input.token || input.tokenFile);
       return patchScopedAccountConfig({
         cfg: next,
         channelKey: params.channelKey,
         accountId,
         patch,
         accountPatch: patch,
-        clearFields: params.buildClearFields?.(input),
+        clearFields:
+          credentialWrite && params.credentialSourceFields?.length
+            ? params.credentialSourceFields
+            : undefined,
         ensureChannelEnabled: params.ensureChannelEnabled ?? !params.alwaysUseAccounts,
         ensureAccountEnabled: params.ensureAccountEnabled ?? true,
         scopeDefaultToAccounts: params.alwaysUseAccounts,
@@ -222,7 +239,7 @@ export function createEnvPatchedAccountSetupAdapter(params: {
   hasCredentials: (input: ChannelSetupInput) => boolean;
   validateInput?: ChannelSetupAdapter["validateInput"];
   buildPatch: (input: ChannelSetupInput) => Record<string, unknown>;
-  buildClearFields?: (input: ChannelSetupInput) => readonly string[];
+  credentialSourceFields?: readonly string[];
 }): ChannelSetupAdapter {
   return createPatchedAccountSetupAdapter({
     channelKey: params.channelKey,
@@ -239,7 +256,7 @@ export function createEnvPatchedAccountSetupAdapter(params: {
       return params.validateInput?.(inputParams) ?? null;
     },
     buildPatch: params.buildPatch,
-    buildClearFields: params.buildClearFields,
+    credentialSourceFields: params.credentialSourceFields,
   });
 }
 

--- a/src/channels/plugins/setup-helpers.ts
+++ b/src/channels/plugins/setup-helpers.ts
@@ -273,8 +273,27 @@ export function patchScopedAccountConfig(params: {
   };
   if (accountId === DEFAULT_ACCOUNT_ID && !params.scopeDefaultToAccounts) {
     // Default accounts historically live at channel root unless the channel opts into accounts.default.
+    const clearedBase = clearFields(base ?? {});
+    const accounts = base?.accounts ?? {};
+    const defaultAccountKey = resolveExistingAccountKey(accounts, DEFAULT_ACCOUNT_ID);
+    const defaultAccount = accounts[defaultAccountKey];
+    // Resolvers read accounts.default ahead of root when the record exists
+    // (promoted single-account credentials), so a default-scope write has to
+    // retire the same fields there too; otherwise the stale account-scoped
+    // credential keeps winning over the rotated root value.
+    if (defaultAccount && params.clearFields?.length) {
+      return writeChannelSection(params.cfg, params.channelKey, {
+        ...clearedBase,
+        ...(ensureChannelEnabled ? { enabled: true } : {}),
+        ...patch,
+        accounts: {
+          ...accounts,
+          [defaultAccountKey]: clearFields(defaultAccount),
+        },
+      });
+    }
     return writeChannelSection(params.cfg, params.channelKey, {
-      ...clearFields(base ?? {}),
+      ...clearedBase,
       ...(ensureChannelEnabled ? { enabled: true } : {}),
       ...patch,
     });

--- a/src/channels/plugins/setup-helpers.ts
+++ b/src/channels/plugins/setup-helpers.ts
@@ -133,6 +133,7 @@ export function createPatchedAccountSetupAdapter<
   ensureAccountEnabled?: boolean;
   validateInput?: ChannelSetupAdapter<Input>["validateInput"];
   buildPatch: (input: Input) => Record<string, unknown>;
+  buildClearFields?: (input: Input) => readonly string[];
 }): ChannelSetupAdapter<Input> {
   return {
     resolveAccountId: ({ accountId }) => normalizeAccountId(accountId),
@@ -161,6 +162,7 @@ export function createPatchedAccountSetupAdapter<
         accountId,
         patch,
         accountPatch: patch,
+        clearFields: params.buildClearFields?.(input),
         ensureChannelEnabled: params.ensureChannelEnabled ?? !params.alwaysUseAccounts,
         ensureAccountEnabled: params.ensureAccountEnabled ?? true,
         scopeDefaultToAccounts: params.alwaysUseAccounts,
@@ -220,6 +222,7 @@ export function createEnvPatchedAccountSetupAdapter(params: {
   hasCredentials: (input: ChannelSetupInput) => boolean;
   validateInput?: ChannelSetupAdapter["validateInput"];
   buildPatch: (input: ChannelSetupInput) => Record<string, unknown>;
+  buildClearFields?: (input: ChannelSetupInput) => readonly string[];
 }): ChannelSetupAdapter {
   return createPatchedAccountSetupAdapter({
     channelKey: params.channelKey,
@@ -236,6 +239,7 @@ export function createEnvPatchedAccountSetupAdapter(params: {
       return params.validateInput?.(inputParams) ?? null;
     },
     buildPatch: params.buildPatch,
+    buildClearFields: params.buildClearFields,
   });
 }
 


### PR DESCRIPTION
## What Problem This Solves

Fixes #132231

The Telegram, Zalo, and Google Chat setup adapters write whichever credential source was provided but never retire the other one, while their runtime resolvers read the two sources in a fixed precedence order. Rotating a credential from one source to the other is therefore a **silent no-op**: setup reports success, but the stale credential keeps being used.

- **Google Chat (worst case):** resolution prefers inline `serviceAccount` over `serviceAccountFile` (`extensions/googlechat/src/accounts.ts`). Rotating inline → `--token-file` writes the file path but keeps authenticating with the inline JSON — whose plaintext `private_key` stays in `openclaw.json`. GCP service account keys do not expire on their own, so a key the operator believed rotated out remains fully usable.
- **Zalo:** resolution prefers inline `botToken` over `tokenFile` (`extensions/zalo/src/token.ts`). Moving the token from config into a file leaves the old inline token in `openclaw.json` in plaintext and still in use — the exposure the operator tried to close stays open.
- **Telegram:** resolution prefers `tokenFile` over inline `botToken` (`extensions/telegram/src/token.ts`). Rotating file → inline silently keeps using the old file-based token; the new token never takes effect.

## Why This Change Was Made

LINE had the same defect and was fixed in #132150 by retiring the replaced source on every credential write; clickclack and nextcloud-talk already retire through their own setup paths. The three adapters above are the remaining dual-source credentials, and they share one seam: the `createPatchedAccountSetupAdapter` / `createEnvPatchedAccountSetupAdapter` factories, whose `buildPatch` could only add fields even though the underlying `patchScopedAccountConfig` already supports `clearFields`.

The fix mirrors LINE at that shared seam instead of three one-off adapters:

1. The factories accept an optional declarative `credentialSourceFields` list: on a credential write (detected by the factory from the standard credential inputs `token`/`tokenFile`/`useEnv`) the listed fields are retired through `patchScopedAccountConfig`'s existing `clearFields` support — additive, existing adapters unchanged (`src/channels/plugins/setup-helpers.ts`).
2. Telegram, Zalo, and Google Chat declare their credential-source pair for retirement: writing `tokenFile` retires the inline key, writing the inline key retires `tokenFile`, and `--use-env` retires both (matching LINE).
3. Colocated rotation tests per channel mirror `extensions/line/src/setup-core.test.ts` coverage (rotate inline→file, file→inline, `--use-env`), plus factory-level tests pinning that the declared fields are retired on credential writes (including env selection) and preserved on non-credential writes.

Sibling audit: the other factory users (discord, slack, signal, whatsapp, imessage, raft, zalouser) have no dual credential sources, so no other channel needs the retirement wiring.

## User Impact

- Before: an operator rotating a credential — because the old one leaked, or to move the secret out of the config file — gets a successful-looking setup that silently keeps using the old credential (for Google Chat, a plaintext GCP private key).
- After: writing one credential source retires the other, so the resolver always uses the credential the operator just configured.

## Evidence

Regression tests fail on pre-fix code (prod files reverted to `origin/main`, tests kept), pass with the fix:

```text
extensions/telegram/src/setup-core.test.ts    pre-fix: 3 failed | post-fix: 3 passed
extensions/zalo/src/setup-core.test.ts        pre-fix: 3 failed | post-fix: 3 passed
extensions/googlechat/src/setup-core.test.ts  pre-fix: 3 failed | post-fix: 3 passed
src/channels/plugins/setup-helpers.test.ts    pre-fix: 1 failed | post-fix: 17 passed
```

Exact-head terminal proof on `5e55beda5fc` (Docker, Node v24.18.0, Debian 12):

```text
$ node scripts/run-vitest.mjs run extensions/telegram/src/setup-core.test.ts extensions/zalo/src/setup-core.test.ts extensions/googlechat/src/setup-core.test.ts src/channels/plugins/setup-helpers.test.ts
      Tests  26 passed (26)   # 3 + 3 + 3 + 17

# Sibling lanes — same channels' remaining setup suites:
extensions/telegram/src/setup-surface.test.ts    13 passed
extensions/zalo/src/setup-surface.test.ts         6 passed
extensions/zalo/src/setup-status.test.ts          1 passed
extensions/googlechat/src/setup.test.ts          31 passed

# Other factory users (additive-change blast radius):
extensions/discord/src/setup-surface.test.ts      5 passed
extensions/slack/src/setup-surface.test.ts       20 passed
extensions/signal/src/setup-core.test.ts         43 passed
extensions/whatsapp/src/setup-surface.test.ts    13 passed

# Full setup-helper/wizard suites:
src/channels/plugins/setup-*.test.ts            117 passed (11 files)

$ pnpm tsgo:core && pnpm tsgo:extensions && pnpm tsgo:test:src && pnpm tsgo:test:extensions
# exit 0
```

Production diff: `src/channels/plugins/setup-helpers.ts` (declarative `credentialSourceFields` option + credential-write detection), three channel `setup-core.ts` (retirement declarations). Everything else is tests.


---

## Round 2 update (`5c2a23a48e5`): account-scoped default retirement + real setup proof

Addresses the review P1: `accounts.default` (populated by the named-account promotion) outranks root in all three resolvers, so the root-only clear left the stale account-scoped credential active.

- `patchScopedAccountConfig`'s default-account branch now applies `clearFields` to the `accounts.default` record as well (unrelated account fields and named accounts preserved; LINE/clickclack/nostr setup suites stay green against the shared change).
- The three plugins retire the full credential pair on any credential write, because either form in `accounts.default` outranks root; the patch re-adds the written source after the clear.
- New regression coverage: shared mutation test plus per-channel `accounts.default` rotation tests that assert the **resolver-selected** credential after rotation (`resolveTelegramToken` / `resolveZaloToken` / merged Google Chat account config).

Regression tests fail on the pre-round-2 prod files, pass at head:

```text
telegram    retires a promoted accounts.default token so the rotation wins at resolution   pre-fix: 1 failed | 3 passed → post-fix: 4 passed
zalo        same                                                                            pre-fix: 1 failed | 3 passed → post-fix: 4 passed
googlechat  same                                                                            pre-fix: 1 failed | 3 passed → post-fix: 4 passed
shared      retires the promoted accounts.default credential that outranks a root rotation  pre-fix: 1 failed | 17 passed → post-fix: 18 passed
siblings    line 4/4, clickclack 19/19, nostr 9/9 setup suites green against the shared change
```

Real setup-flow proof (real setup adapter + real promotion helper + real credential resolver, redacted): single-account setup writes the root credential → adding a named account promotes it into `accounts.default` → default-account rotation writes a fresh root credential. Pre-fix the resolver kept selecting the pre-rotation token; at head it selects the rotated one for all three channels:

```text
=== telegram ===    resolver before rotation: ROOT_TOKEN_A   after: ROOT_TOKEN_A   STALE   (pre-fix)
=== telegram ===    resolver before rotation: ROOT_TOKEN_A   after: ROTATED_TOKEN_C OK     (head 5c2a23a48e5)
=== zalo ===        resolver before rotation: ROOT_TOKEN_A   after: ROOT_TOKEN_A   STALE   (pre-fix)
=== zalo ===        resolver before rotation: ROOT_TOKEN_A   after: ROTATED_TOKEN_C OK     (head)
=== googlechat ===  before: {"type":"service_account","v":"A"} after: {"type":"service_account","v":"C"} OK (head)
```

(The Google Chat promotion path does not register service-account keys for promotion, so its promoted-`accounts.default` case is covered by the hand-authored resolver regression test, which failed pre-fix.)



---

## Round 3 update (`135fcf104cd`): narrowed SDK seam + rebase onto current main

Addresses the round-2 review P1: the previous `buildClearFields(input)` callback put an unconstrained field-deletion hook on the documented `plugin-sdk/setup-runtime` factory. Replaced with a declarative seam:

- `createPatchedAccountSetupAdapter` / `createEnvPatchedAccountSetupAdapter` now take `credentialSourceFields?: readonly string[]` — a static list of mutually exclusive credential-source fields. The **factory itself** detects a credential write from the standard credential inputs (`token`, `tokenFile`, `useEnv`, all part of the generic `ChannelSetupEnvelope`) and retires exactly the declared fields at root and `accounts.default`. Plugin authors can no longer delete arbitrary config keys through the SDK surface; the only expressible operation is "retire this channel's declared credential sources when credentials are (re)written".
- Behavior-preserving: all three channels' previous callbacks computed exactly `useEnv || tokenFile || token ? [<the same pair>] : []`, so the retirement outcomes are identical — confirmed by the per-channel resolver-level rotation tests re-run at this head.
- Rebases the branch onto current main (`6b27585471a`), absorbing the #132226 setup-promotion refactor (`resolveSingleAccountKeysToMove` → `resolveSingleAccountPromotion`) that the old base predated.
- New factory coverage: env-selection writes retire the stored pair; non-credential writes leave stored credentials untouched.

Exact-head regression evidence on `135fcf104cd` (Docker, Node v24.18.0, Debian 12):

```text
$ node scripts/run-vitest.mjs run src/channels/plugins/setup-helpers.test.ts extensions/telegram/src/setup-core.test.ts extensions/zalo/src/setup-core.test.ts extensions/googlechat/src/setup-core.test.ts
[test] passed 4 Vitest shards   # setup-helpers 25/25 (incl. 2 new seam tests), channel rotation suites green
```

The round-2 real setup-flow proof (promotion → rotation → resolver selection) remains the behavioral baseline; this round changes only how the retirement is declared, not what is retired.


---

## Round 4 update: named Google Chat rotations no longer select the root identity

Addresses the review P1 (a named Google Chat rotation could silently switch to another account's credential).

**Root cause.** Google Chat does not promote root credentials into `accounts.default` (no service-account promotion keys), and the account merger overlays root fields (`{...root, ...account}`) without treating the credential pair atomically. With root inline `serviceAccount` A and `accounts.work.serviceAccount` B, rotating `work` via `--token-file` retires B and writes the file, but the merged account config still carries root A — and the resolver prefers inline over file (`extensions/googlechat/src/accounts.ts`), so `work` switched to the **root identity** instead of the new file. Deleting root A was not an option: it is the default account's credential.

**Fix (resolver layer, config shape unchanged).** `resolveGoogleChatAccountWithMode` now treats a named account's explicit credential fields as one atomic override: when the account explicitly sets either `serviceAccount` or `serviceAccountFile` (own-key presence check), the root-inherited credential of the other form is dropped from credential selection only. The returned `account.config` keeps the full merged shape; the default-account path and the legitimate root fallback for credential-less named accounts are unchanged.

**Regression tests** (fail on pre-Round-4 code, pass at head):

- root A + `work` B → rotate `work` to a file: resolver now selects the file (`credentialSource: "file"`), not root A.
- root A + `work` file → rotate `work` to inline B: resolver selects B.
- credential-less named account still inherits root A (legitimate fallback preserved).
- named-account file still isolated from a `accounts.default` inline credential.

```text
$ node scripts/run-vitest.mjs run extensions/googlechat/src/setup-core.test.ts
      Tests  8 passed (8)    # pre-fix: 1 failed | 7 passed
$ node scripts/run-vitest.mjs run src/channels/plugins/setup-helpers.test.ts
      Tests  25 passed (25)  # shared seam unchanged
$ node scripts/run-vitest.mjs run extensions/telegram/src/setup-core.test.ts extensions/zalo/src/setup-core.test.ts
      Tests  8 passed (8)    # sibling rotations unchanged
$ node scripts/run-tsgo.mjs -p tsconfig.extensions.json && node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.extensions.test.json
# exit 0
```

**Known gaps (not in this round).** `extensions/googlechat/src/setup.test.ts` cannot run in this environment (Node 24.13.1 embeds SQLite 3.51.2, below the WAL-safety floor; requires Node 24.15+/25.9+); its resolver-level isolation assertions are mirrored in `setup-core.test.ts` above. The duplicate root-write assembly noted in the review is left as-is this round to keep the diff focused; the credential retirement + rotation evidence above is unchanged by the resolver-layer fix.


---

## Round 5 update: secret discovery no longer owns file-backed named accounts with the root ref

Resolves the remaining review P1 (secret ownership must honor the same credential override before the inline field is retired).

**Root cause.** Secret discovery assigned the root `serviceAccount` SecretRef to every enabled account lacking an inline `serviceAccount` — including accounts that resolve from `serviceAccountFile` (`extensions/googlechat/src/secret-contract.ts`). Gateway startup asserts the secret owner **before** calling plugin credential resolution (`src/gateway/server-channels.ts`), so with an unavailable root reference and a healthy file-backed named account, Round 4's retirement of the account's inline field let the unavailable root ref acquire ownership and the account stopped at startup even though its file credential was fine. Discovery and resolution were using two different definitions of "which credential does this account use."

**Fix (discovery layer, aligned with the resolver's atomic override).** The top-level owner predicate now mirrors `isolateAccountCredentials` semantics: a **named** account that sets either credential form (own-key presence check) is no longer an owner of the root SecretRef — the root ref instead records an inactive-surface warning, exactly like zalo's file-backed exclusion. The **default** account keeps resolving root credentials and stays an owner, matching the resolver's default-account path.

**Cross-layer regression tests** (`extensions/googlechat/src/secret-contract.test.ts`):

- file-backed named account: no root-ref assignment (own-key `serviceAccountFile` exclusion).
- default account stays a root-ref owner next to a file-backed named account (resolver parity).
- preparation with an unavailable root ref and a file-backed named account: **no degraded owner** — the account reaches startup healthy.
- control: a named account that *inherits* the unavailable root ref is isolated during preparation and `assertSecretOwnerAvailable("account", "googlechat:work")` throws after snapshot activation — proving the preparation → activation → startup-check chain the tests now cover.

**Evidence** (Docker container, Node v24.18.0):

```text
$ node scripts/run-vitest.mjs run extensions/googlechat/src/secret-contract.test.ts
      pre-Round-5 head: 3 failed | 2 passed   # the 2 defect cases + the preparation-chain case
      at head ed3da08b: 5 passed (5)
$ node scripts/run-vitest.mjs run extensions/googlechat/src/{secret-contract,setup,doctor-contract,config-schema,channel-config,account-policy}.test.ts
      Tests 72 passed (72)
$ node scripts/run-vitest.mjs run extensions/zalo/src/secret-contract.test.ts
      Tests 3 passed (3)   # sibling file-backed exclusion unchanged
$ node scripts/run-vitest.mjs run src/secrets/{runtime-config-collectors-channels,channel-contract-api.fast-path,channel-contract-surface-guardrails}.test.ts
      Tests 19 passed (19) # shared discovery layer unchanged
```

Remaining full-plugin-suite failures (`auth.capture.transport`, `monitor.reply-delivery-failure`, `google-auth.fetchok.transport` — 11 tests) reproduce identically on the pre-Round-5 head in the same container (missing `@line/bot-sdk`-style environment gap: undici/ps availability), so they are unrelated to this change.

This completes the reviewer's recommended sequence: discovery and resolution now share one credential-source rule, so the retirement introduced by this PR can no longer strand a healthy account behind an unavailable root secret.


---

## Round 6 update: secret-contract tests moved fully onto plugin-sdk surfaces

The first Round 5 CI run failed on the new test file itself: two boundary/lint violations introduced by the tests, plus one unrelated environment flake. Fixed in `13dfa6f2bd8` (test-only, no production change).

**What was wrong.**

1. `check-lint-core-3`: the env-shorthand fixture used an unnecessary escape (`"\$..."`, eslint `no-useless-escape`).
2. `check-additional-boundaries` (`lint:plugins:no-extension-test-core-imports`): the two new cross-layer tests deep-imported core internals (`../../../src/secrets/runtime-degraded-state.js`, `runtime-owner-assignments.js`). Extension test files must stay on public `openclaw/plugin-sdk/*` surfaces, and `setActiveDegradedSecretOwners` / `resolveAndApplySecretAssignments` have no public subpath — no other extension test does this.

**What changed.** The tests now exercise exactly the surface this PR changed (secret-target discovery) plus the exported resolution surface: the file-backed exclusion, default-account parity, and inheriting-account ownership assertions are unchanged; the preparation→activation→startup chain moves out of the extension test (that chain is core-owned and already covered by `src/gateway/server-startup-secret-owner-isolation.test.ts`), replaced by a fixture-fidelity test proving the unavailable root ref really fails resolution through `resolveSecretRefValues`. 5 tests, all imports on `openclaw/plugin-sdk/*` + local module.

**Evidence** (Docker container, Node v24.18.0):

```text
$ node scripts/run-vitest.mjs run extensions/googlechat/src/secret-contract.test.ts
      Tests 5 passed (5)
```

**CI on the fixed head.** Run 34508606093 (head `541c82d54f07`): 174/174 checks green, including `check-lint-core-3`, `check-additional-boundaries` (all boundary lanes), and the full `checks-node-*` matrix. Two earlier runs hit unrelated flakes — a `gateway-auth-rewarm` readiness timeout (passed on rerun without any change) and an `ETXTBSY` execve race in the tooling canary, then a `spawnSync ETIMEDOUT` in the matrix doctor contract (both environmental, both green on the retrigger; matrix/googlechat have no shared code).