### PR TITLE
fix(ui): Desktop does not follow the chat session machine

### DIFF
--- a/docs/gateway/cloud-sessions.md
+++ b/docs/gateway/cloud-sessions.md
@@ -43,7 +43,7 @@ See [Cloud Workers](/gateway/cloud-workers) for profiles, requirements, dispatch
 
 ## Viewing the session desktop
 
-Open **Desktop** from a session to view its execution machine. Cloud sessions select their worker desktop; sessions on paired devices select that device. The pop-out window keeps the session in its link and resolves the current machine when opened. When placement changes, the embedded viewer disconnects from the previous machine. A stopped cloud session does not switch the viewer to the Gateway desktop.
+Open **Desktop** from a session to view its execution machine. Cloud sessions select their worker desktop; sessions on paired devices select that device. The pop-out window keeps the session in its link. Both viewers follow placement changes and disconnect from the previous machine when the session moves or stops. A stopped cloud session does not switch either viewer to the Gateway desktop.
 
 The machine must already support desktop viewing. For cloud workers, enable the [Cloud Worker Desktop lab and desktop profile setting](/gateway/cloud-workers#desktop-interactive). Opening Desktop starts in view-only mode and does not change the machine's permissions or the agent's tool policy. The global Desktop command in the command palette still opens the machine picker, including on chat pages.
 

--- a/docs/gateway/cloud-sessions.md
+++ b/docs/gateway/cloud-sessions.md
@@ -45,7 +45,7 @@ See [Cloud Workers](/gateway/cloud-workers) for profiles, requirements, dispatch
 
 Open **Desktop** from a session to view its execution machine. Cloud sessions select their worker desktop; sessions on paired devices select that device. The pop-out window keeps the session in its link and resolves the current machine when opened. When placement changes, the embedded viewer disconnects from the previous machine. A stopped cloud session does not switch the viewer to the Gateway desktop.
 
-The machine must already support desktop viewing. For cloud workers, enable the [Cloud Worker Desktop lab and desktop profile setting](/gateway/cloud-workers#desktop-interactive). Opening Desktop starts in view-only mode and does not change the machine's permissions or the agent's tool policy. Standalone Desktop still offers the machine picker.
+The machine must already support desktop viewing. For cloud workers, enable the [Cloud Worker Desktop lab and desktop profile setting](/gateway/cloud-workers#desktop-interactive). Opening Desktop starts in view-only mode and does not change the machine's permissions or the agent's tool policy. The global Desktop command in the command palette still opens the machine picker, including on chat pages.
 
 ## Automatic load balancing across devices
 

--- a/docs/gateway/cloud-sessions.md
+++ b/docs/gateway/cloud-sessions.md
@@ -41,6 +41,12 @@ Configure a profile under `cloudWorkers.profiles` and the bundled Crabbox plugin
 
 See [Cloud Workers](/gateway/cloud-workers) for profiles, requirements, dispatching, moving sessions between destinations, and the security model.
 
+## Viewing the session desktop
+
+Open **Desktop** from a session to view its execution machine. Cloud sessions select their worker desktop; sessions on paired devices select that device. The pop-out window keeps the session in its link and resolves the current machine when opened. When placement changes, the embedded viewer disconnects from the previous machine. A stopped cloud session does not switch the viewer to the Gateway desktop.
+
+The machine must already support desktop viewing. For cloud workers, enable the [Cloud Worker Desktop lab and desktop profile setting](/gateway/cloud-workers#desktop-interactive). Opening Desktop starts in view-only mode and does not change the machine's permissions or the agent's tool policy. Standalone Desktop still offers the machine picker.
+
 ## Automatic load balancing across devices
 
 You do not have to pick a device. Choosing **Auto** (least-busy device) in the Place picker — or dispatching with `autoDevice: true` — selects a paired session host automatically and retries up to three ranked hosts if provisioning fails before a machine is allocated. OpenClaw `worker-turn` placements rank hosts by most free worker slots, breaking ties by device ID; Codex `remote-exec` placements do not consume worker slots, so eligible hosts are ranked by device ID alone. When no host qualifies, the error says exactly why: no session hosts paired, all disconnected, or all at capacity.

--- a/ui/src/app/app-root.ts
+++ b/ui/src/app/app-root.ts
@@ -509,8 +509,8 @@ export class OpenClawApp extends OpenClawLightDomElement {
           .client=${gatewayConnected ? gatewaySnapshot.client : null}
           .available=${desktopAvailable}
           .documentMode=${true}
-          .documentSource=${source}
-          .documentSession=${session}
+          .requestedSource=${source}
+          .sessionKey=${session}
           .documentControl=${focusTarget.control}
           .onDocumentClose=${() => this.closeDocument(context.basePath)}
         ></openclaw-desktop-panel>

--- a/ui/src/components/desktop/desktop-document-inventory.ts
+++ b/ui/src/components/desktop/desktop-document-inventory.ts
@@ -1,31 +1,21 @@
 import type { EnvironmentSummary } from "@openclaw/gateway-protocol";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
-import type { GatewaySessionRow } from "../../api/types.ts";
-import { resolveDesktopDocumentTarget } from "./desktop-source.ts";
+import { resolveDesktopDocumentSessionTarget } from "./desktop-session-controller.ts";
 
 export async function resolveDesktopDocumentInventoryTarget(options: {
   client: Pick<GatewayBrowserClient, "request"> | null;
   source: string | null;
   sessionKey: string | null;
   environments: readonly Pick<EnvironmentSummary, "id">[];
+  resolvedSessionTarget?: string | null;
 }): Promise<string | null> {
-  let session: GatewaySessionRow | undefined;
-  if (options.source === null && options.sessionKey !== null) {
-    // `sessions.describe` is the exact-key lookup; a paged list cannot rule out a later match.
-    try {
-      session =
-        (
-          await options.client?.request<{ session?: GatewaySessionRow | null }>(
-            "sessions.describe",
-            { key: options.sessionKey },
-          )
-        )?.session ?? undefined;
-    } catch {}
-  }
-  const requestedSource = resolveDesktopDocumentTarget(
-    { source: options.source, session: options.sessionKey },
-    session,
-  );
+  const requestedSource =
+    options.source ??
+    (options.resolvedSessionTarget !== undefined
+      ? options.resolvedSessionTarget
+      : options.sessionKey !== null
+        ? await resolveDesktopDocumentSessionTarget(options.client, options.sessionKey)
+        : null);
   return requestedSource !== null &&
     options.environments.some((environment) => environment.id === requestedSource)
     ? requestedSource

--- a/ui/src/components/desktop/desktop-focus-window.ts
+++ b/ui/src/components/desktop/desktop-focus-window.ts
@@ -1,14 +1,6 @@
 import { buildControlUiFocusPath } from "@openclaw/session-url-contract";
 import { openExternalUrlSafe } from "../../lib/open-external-url.ts";
 
-export function desktopFocusPath(
-  basePath: string,
-  source?: string | null,
-  control = false,
-): string {
-  return buildControlUiFocusPath({ kind: "desktop", source, control }, basePath);
-}
-
 export function openDesktopFocus(basePath: string, source?: string | null, control = false): void {
-  openExternalUrlSafe(desktopFocusPath(basePath, source, control));
+  openExternalUrlSafe(buildControlUiFocusPath({ kind: "desktop", source, control }, basePath));
 }

--- a/ui/src/components/desktop/desktop-panel.test.ts
+++ b/ui/src/components/desktop/desktop-panel.test.ts
@@ -2,13 +2,14 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createDeferred } from "../../../../test/helpers/promise.js";
-import type { GatewayBrowserClient } from "../../api/gateway.ts";
+import type { GatewayBrowserClient, GatewayEventListener } from "../../api/gateway.ts";
 import { createStorageMock } from "../../test-helpers/storage.ts";
 import { waitForFast } from "../../test-helpers/wait-for.ts";
 import "./desktop-panel.ts";
 
 type DesktopPanelElement = HTMLElement & {
   available: boolean;
+  documentMode: boolean;
   client: GatewayBrowserClient | null;
   desktopClientFactory: () => {
     connect(options: { onConnect: () => void }): Promise<{ disconnect(): void }>;
@@ -122,6 +123,103 @@ describe("embedded desktop panel presentation", () => {
     expect(disconnect).toHaveBeenCalledTimes(2);
     expect(connect).toHaveBeenCalledTimes(2);
     expect(request.mock.calls.some(([method]) => method === "sessions.describe")).toBe(false);
+  });
+
+  it("keeps focused session updates current across control changes and overlapping lookups", async () => {
+    const sessionKey = "agent:main:focused";
+    const active = {
+      key: sessionKey,
+      kind: "direct",
+      placement: { state: "active", environmentId: desktopEnvironment.id },
+    };
+    const reclaimed = { ...active, placement: { state: "reclaimed" } };
+    let sessionRead: Promise<unknown> | undefined;
+    let listener: GatewayEventListener = () => {
+      throw new Error("expected a focused session listener");
+    };
+    const unsubscribe = vi.fn();
+    const request = vi.fn(async (method: string, params?: { control?: boolean }) => {
+      if (method === "environments.list") {
+        return { environments: [desktopEnvironment] };
+      }
+      if (method === "sessions.describe") {
+        return sessionRead ?? { session: active };
+      }
+      return {
+        transport: "rfb",
+        wsPath: "/desktop/observe?token=focused",
+        expiresAtMs: 60_000,
+        control: params?.control ?? false,
+      };
+    });
+    const disconnect = vi.fn();
+    const connect = vi.fn(async (options: { onConnect: () => void }) => {
+      options.onConnect();
+      return { disconnect };
+    });
+    const panel = createPanel();
+    panel.client = {
+      gatewayUrl: "ws://gateway.test",
+      request,
+      addEventListener: (next: GatewayEventListener) => {
+        listener = next;
+        return unsubscribe;
+      },
+    } as unknown as GatewayBrowserClient;
+    panel.available = true;
+    panel.documentMode = true;
+    panel.sessionKey = sessionKey;
+    panel.desktopClientFactory = () => ({ connect });
+    document.body.append(panel);
+    await waitForFast(() => expect(connect).toHaveBeenCalledOnce());
+    const descriptions = () =>
+      request.mock.calls.filter(([method]) => method === "sessions.describe");
+    const changed = (key = sessionKey) =>
+      listener({ type: "event", event: "sessions.changed", payload: { sessionKey: key } });
+
+    changed("agent:main:unrelated");
+    await settleTasks();
+    expect(descriptions()).toHaveLength(1);
+    changed();
+    await waitForFast(() => expect(descriptions()).toHaveLength(2));
+    await settleTasks();
+    expect(disconnect).not.toHaveBeenCalled();
+
+    const pending = createDeferred<unknown>();
+    sessionRead = pending.promise;
+    changed();
+    await waitForFast(() => expect(descriptions()).toHaveLength(3));
+    const control = panel.renderRoot.querySelector<HTMLButtonElement>(
+      'button[aria-label="Take control"]',
+    );
+    if (!control) {
+      throw new Error("expected focused Desktop control button");
+    }
+    control.click();
+    await waitForFast(() => expect(connect).toHaveBeenCalledTimes(2));
+    pending.resolve({ session: reclaimed });
+    await waitForFast(() =>
+      expect(panel.renderRoot.querySelector(".desktop-picker")).not.toBeNull(),
+    );
+    expect(disconnect).toHaveBeenCalledTimes(2);
+
+    sessionRead = undefined;
+    changed();
+    await waitForFast(() => expect(connect).toHaveBeenCalledTimes(3));
+    const stale = createDeferred<unknown>();
+    sessionRead = stale.promise;
+    changed();
+    await waitForFast(() => expect(descriptions()).toHaveLength(5));
+    sessionRead = Promise.resolve({ session: reclaimed });
+    changed();
+    await waitForFast(() =>
+      expect(panel.renderRoot.querySelector(".desktop-picker")).not.toBeNull(),
+    );
+    stale.resolve({ session: active });
+    await settleTasks();
+    expect(connect).toHaveBeenCalledTimes(3);
+    panel.remove();
+    expect(unsubscribe).toHaveBeenCalledOnce();
   });
 
   it("keeps a hidden embedded mount dormant even when the standalone dock was open", async () => {

--- a/ui/src/components/desktop/desktop-panel.test.ts
+++ b/ui/src/components/desktop/desktop-panel.test.ts
@@ -102,7 +102,7 @@ describe("embedded desktop panel presentation", () => {
       control: false,
     });
 
-    const nextInventory = createDeferred<void>();
+    const nextInventory = createDeferred();
     refresh = nextInventory.promise;
     panel.requestedSource = replacement.id;
     await panel.updateComplete;

--- a/ui/src/components/desktop/desktop-panel.test.ts
+++ b/ui/src/components/desktop/desktop-panel.test.ts
@@ -1,6 +1,7 @@
 /* @vitest-environment jsdom */
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../../../test/helpers/promise.js";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import { createStorageMock } from "../../test-helpers/storage.ts";
 import { waitForFast } from "../../test-helpers/wait-for.ts";
@@ -15,6 +16,8 @@ type DesktopPanelElement = HTMLElement & {
   embedded: boolean;
   handleToggleRequest(event: Event): void;
   presented: boolean;
+  requestedSource: string | null;
+  sessionKey: string | null;
   renderRoot: DocumentFragment;
   updateComplete: Promise<unknown>;
 };
@@ -61,6 +64,64 @@ describe("embedded desktop panel presentation", () => {
   afterEach(() => {
     document.body.replaceChildren();
     vi.unstubAllGlobals();
+  });
+
+  it("follows the session desktop and retires its connection before resolving a new placement", async () => {
+    const replacement = { ...desktopEnvironment, id: "worker-desktop-2" };
+    let refresh: Promise<void> | undefined;
+    const request = vi.fn(async (method: string) => {
+      if (method === "environments.list") {
+        await refresh;
+        return { environments: [desktopEnvironment, replacement] };
+      }
+      return {
+        transport: "rfb",
+        wsPath: "/desktop/observe?token=session",
+        expiresAtMs: 60_000,
+        control: false,
+      };
+    });
+    const disconnect = vi.fn();
+    const connect = vi.fn(async (options: { onConnect: () => void }) => {
+      options.onConnect();
+      return { disconnect };
+    });
+    const panel = createPanel();
+    panel.client = { gatewayUrl: "ws://gateway.test", request } as unknown as GatewayBrowserClient;
+    panel.available = true;
+    panel.embedded = true;
+    panel.presented = true;
+    panel.sessionKey = "agent:main:cloud";
+    panel.requestedSource = desktopEnvironment.id;
+    panel.desktopClientFactory = () => ({ connect });
+    document.body.append(panel);
+
+    await waitForFast(() => expect(connect).toHaveBeenCalledOnce());
+    expect(request).toHaveBeenCalledWith("desktop.observe", {
+      source: { kind: "environment", environmentId: desktopEnvironment.id },
+      control: false,
+    });
+
+    const nextInventory = createDeferred<void>();
+    refresh = nextInventory.promise;
+    panel.requestedSource = replacement.id;
+    await panel.updateComplete;
+    expect(disconnect).toHaveBeenCalledOnce();
+    expect(connect).toHaveBeenCalledOnce();
+    nextInventory.resolve();
+    refresh = undefined;
+    await waitForFast(() => expect(connect).toHaveBeenCalledTimes(2));
+    expect(request).toHaveBeenLastCalledWith("desktop.observe", {
+      source: { kind: "environment", environmentId: replacement.id },
+      control: false,
+    });
+
+    panel.requestedSource = null;
+    await panel.updateComplete;
+    await settleTasks();
+    expect(disconnect).toHaveBeenCalledTimes(2);
+    expect(connect).toHaveBeenCalledTimes(2);
+    expect(request.mock.calls.some(([method]) => method === "sessions.describe")).toBe(false);
   });
 
   it("keeps a hidden embedded mount dormant even when the standalone dock was open", async () => {

--- a/ui/src/components/desktop/desktop-panel.ts
+++ b/ui/src/components/desktop/desktop-panel.ts
@@ -83,7 +83,7 @@ class OpenClawDesktopPanel extends OpenClawLitElement {
   private operationId = 0;
   private launchOperationId = 0;
   private controlTakeoverRecoveryUsed = false;
-  private requestedSourceResolved = false;
+  private sourceSelection: "pending" | "resolved" | "picker" = "pending";
   private readonly mobileKeyboard = new DesktopMobileKeyboard({
     connection: () => this.connection,
     controlling: () => this.controlling,
@@ -151,7 +151,7 @@ class OpenClawDesktopPanel extends OpenClawLitElement {
     if ((this.documentMode || this.embedded) && presentationChanged) {
       // Release input and invalidate pending work before resolving a different session or machine.
       this.returnToPicker();
-      this.requestedSourceResolved = false;
+      this.sourceSelection = "pending";
       if (this.available && (!this.embedded || (this.presented && this.refreshOnPresentation))) {
         void this.refreshEnvironments();
       }
@@ -188,6 +188,9 @@ class OpenClawDesktopPanel extends OpenClawLitElement {
       if (detail?.environmentId) {
         void this.connectRequestedEnvironment(detail.environmentId);
       } else {
+        this.returnToPicker();
+        // An untargeted shell command opens the picker, overriding this presentation's session default.
+        this.sourceSelection = "picker";
         void this.refreshEnvironments();
       }
       return;
@@ -282,10 +285,10 @@ class OpenClawDesktopPanel extends OpenClawLitElement {
   }
 
   private async resolveRequestedSource(operationId: number): Promise<void> {
-    if (this.requestedSourceResolved || operationId !== this.operationId) {
+    if (this.sourceSelection !== "pending" || operationId !== this.operationId) {
       return;
     }
-    this.requestedSourceResolved = true;
+    this.sourceSelection = "resolved";
     const requestedSource = await resolveDesktopDocumentInventoryTarget({
       client: this.client,
       source: this.requestedSource,
@@ -308,7 +311,7 @@ class OpenClawDesktopPanel extends OpenClawLitElement {
 
   private async connectRequestedEnvironment(environmentId: string): Promise<void> {
     this.returnToPicker();
-    this.requestedSourceResolved = true;
+    this.sourceSelection = "resolved";
     this.environmentId = environmentId;
     this.state = "connecting";
     const operationId = this.operationId;
@@ -601,8 +604,10 @@ class OpenClawDesktopPanel extends OpenClawLitElement {
       reason: this.disconnectedReason,
       onRetry: () => {
         if (this.state === "inventory-error" && (this.documentMode || !this.environmentId)) {
-          this.requestedSourceResolved = false;
-          this.state = "connecting";
+          if (this.sourceSelection !== "picker") {
+            this.sourceSelection = "pending";
+          }
+          this.state = "picker";
           void this.refreshEnvironments();
           return;
         }

--- a/ui/src/components/desktop/desktop-panel.ts
+++ b/ui/src/components/desktop/desktop-panel.ts
@@ -39,6 +39,7 @@ import {
   renderDesktopPanelHeader,
   renderDesktopPicker,
 } from "./desktop-panel-view.ts";
+import { DesktopSessionController } from "./desktop-session-controller.ts";
 import { desktopSourceForEnvironment } from "./desktop-source.ts";
 
 /** `<openclaw-desktop-panel>` — dockable RFB access to Gateway desktop sources. */
@@ -84,6 +85,15 @@ class OpenClawDesktopPanel extends OpenClawLitElement {
   private launchOperationId = 0;
   private controlTakeoverRecoveryUsed = false;
   private sourceSelection: "pending" | "resolved" | "picker" = "pending";
+  private readonly sessionSource = new DesktopSessionController(
+    this,
+    () => this.environmentId,
+    (target) => {
+      this.returnToPicker();
+      this.sourceSelection = "pending";
+      void this.refreshEnvironments(undefined, target);
+    },
+  );
   private readonly mobileKeyboard = new DesktopMobileKeyboard({
     connection: () => this.connection,
     controlling: () => this.controlling,
@@ -222,6 +232,7 @@ class OpenClawDesktopPanel extends OpenClawLitElement {
   }
 
   private returnToPicker(): void {
+    this.sessionSource.invalidate();
     this.disconnectConnection();
     this.clearLaunchState();
     this.state = "picker";
@@ -249,7 +260,10 @@ class OpenClawDesktopPanel extends OpenClawLitElement {
     this.launchErrorText = null;
   }
 
-  private async refreshEnvironments(expectedOperationId?: number): Promise<boolean> {
+  private async refreshEnvironments(
+    expectedOperationId?: number,
+    resolvedSessionTarget?: string | null,
+  ): Promise<boolean> {
     const client = this.client;
     if (!client || !this.available || (this.embedded && !this.presented)) {
       return false;
@@ -279,12 +293,15 @@ class OpenClawDesktopPanel extends OpenClawLitElement {
       }
     }
     if (refreshed) {
-      await this.resolveRequestedSource(operationId);
+      await this.resolveRequestedSource(operationId, resolvedSessionTarget);
     }
     return refreshed;
   }
 
-  private async resolveRequestedSource(operationId: number): Promise<void> {
+  private async resolveRequestedSource(
+    operationId: number,
+    resolvedSessionTarget?: string | null,
+  ): Promise<void> {
     if (this.sourceSelection !== "pending" || operationId !== this.operationId) {
       return;
     }
@@ -295,6 +312,7 @@ class OpenClawDesktopPanel extends OpenClawLitElement {
       // Embedded presenters already receive the chat owner's current placement; do not rediscover it.
       sessionKey: this.documentMode ? this.sessionKey : null,
       environments: this.environments,
+      resolvedSessionTarget,
     });
     if (operationId !== this.operationId) {
       return;

--- a/ui/src/components/desktop/desktop-panel.ts
+++ b/ui/src/components/desktop/desktop-panel.ts
@@ -47,8 +47,8 @@ class OpenClawDesktopPanel extends OpenClawLitElement {
   @property({ type: Boolean }) available = false;
   @property({ type: Boolean }) suppressed = false;
   @property({ type: Boolean }) documentMode = false;
-  @property({ attribute: false }) documentSource: string | null = null;
-  @property({ attribute: false }) documentSession: string | null = null;
+  @property({ attribute: false }) requestedSource: string | null = null;
+  @property({ attribute: false }) sessionKey: string | null = null;
   @property({ type: Boolean }) documentControl = false;
   @property({ attribute: false }) basePath = "";
   /** Hosted by the chat side panel, which owns visibility and geometry. */
@@ -83,7 +83,7 @@ class OpenClawDesktopPanel extends OpenClawLitElement {
   private operationId = 0;
   private launchOperationId = 0;
   private controlTakeoverRecoveryUsed = false;
-  private documentSourceResolved = false;
+  private requestedSourceResolved = false;
   private readonly mobileKeyboard = new DesktopMobileKeyboard({
     connection: () => this.connection,
     controlling: () => this.controlling,
@@ -139,27 +139,20 @@ class OpenClawDesktopPanel extends OpenClawLitElement {
         void this.refreshEnvironments();
       }
     }
-    if (changed.has("documentSource") || changed.has("documentSession")) {
-      this.documentSourceResolved = false;
-    }
     const gatewayAvailabilityChanged = changed.has("client") || changed.has("available");
-    const embeddedPresentationChanged =
-      this.embedded && (changed.has("embedded") || changed.has("presented"));
-    const documentPresentationChanged =
+    const presentationChanged =
+      gatewayAvailabilityChanged ||
+      changed.has("embedded") ||
+      changed.has("presented") ||
       changed.has("documentMode") ||
-      changed.has("documentSource") ||
-      changed.has("documentSession") ||
+      changed.has("requestedSource") ||
+      changed.has("sessionKey") ||
       changed.has("documentControl");
-    if (this.documentMode && (gatewayAvailabilityChanged || documentPresentationChanged)) {
-      if (!this.available) {
-        this.documentSourceResolved = false;
-        this.returnToPicker();
-      } else {
-        void this.refreshEnvironments();
-      }
-    } else if (this.embedded && (embeddedPresentationChanged || gatewayAvailabilityChanged)) {
+    if ((this.documentMode || this.embedded) && presentationChanged) {
+      // Release input and invalidate pending work before resolving a different session or machine.
       this.returnToPicker();
-      if (this.presented && this.available && this.client && this.refreshOnPresentation) {
+      this.requestedSourceResolved = false;
+      if (this.available && (!this.embedded || (this.presented && this.refreshOnPresentation))) {
         void this.refreshEnvironments();
       }
     } else if (gatewayAvailabilityChanged) {
@@ -272,10 +265,8 @@ class OpenClawDesktopPanel extends OpenClawLitElement {
     } catch (error) {
       if (operationId === this.operationId) {
         this.errorText = t("desktop.errors.listFailed", { error: formatUiError(error) });
-        if (this.documentMode && (this.documentSource !== null || this.documentSession !== null)) {
-          // A session key only names a machine once the inventory loads, so it stays out of
-          // `environmentId`; document-mode retry refreshes the inventory rather than reconnecting.
-          this.environmentId = this.documentSource;
+        if (this.requestedSource !== null || this.sessionKey !== null) {
+          // Keep an explicit target through retry; an unresolved session has no environment yet.
           this.state = "inventory-error";
         }
       }
@@ -285,27 +276,28 @@ class OpenClawDesktopPanel extends OpenClawLitElement {
       }
     }
     if (refreshed) {
-      await this.resolveDocumentSource(operationId);
+      await this.resolveRequestedSource(operationId);
     }
     return refreshed;
   }
 
-  private async resolveDocumentSource(operationId: number): Promise<void> {
-    if (!this.documentMode || this.documentSourceResolved || operationId !== this.operationId) {
+  private async resolveRequestedSource(operationId: number): Promise<void> {
+    if (this.requestedSourceResolved || operationId !== this.operationId) {
       return;
     }
-    this.documentSourceResolved = true;
+    this.requestedSourceResolved = true;
     const requestedSource = await resolveDesktopDocumentInventoryTarget({
       client: this.client,
-      source: this.documentSource,
-      sessionKey: this.documentSession,
+      source: this.requestedSource,
+      // Embedded presenters already receive the chat owner's current placement; do not rediscover it.
+      sessionKey: this.documentMode ? this.sessionKey : null,
       environments: this.environments,
     });
     if (operationId !== this.operationId) {
       return;
     }
     if (requestedSource === null) {
-      if (this.documentSource !== null || this.documentSession !== null) {
+      if (this.requestedSource !== null || this.sessionKey !== null) {
         this.state = "picker";
         this.noticeText = t("desktop.sourceUnavailable");
       }
@@ -316,6 +308,7 @@ class OpenClawDesktopPanel extends OpenClawLitElement {
 
   private async connectRequestedEnvironment(environmentId: string): Promise<void> {
     this.returnToPicker();
+    this.requestedSourceResolved = true;
     this.environmentId = environmentId;
     this.state = "connecting";
     const operationId = this.operationId;
@@ -607,8 +600,8 @@ class OpenClawDesktopPanel extends OpenClawLitElement {
       inventoryError: this.state === "inventory-error",
       reason: this.disconnectedReason,
       onRetry: () => {
-        if (this.state === "inventory-error" && this.documentMode) {
-          this.documentSourceResolved = false;
+        if (this.state === "inventory-error" && (this.documentMode || !this.environmentId)) {
+          this.requestedSourceResolved = false;
           this.state = "connecting";
           void this.refreshEnvironments();
           return;

--- a/ui/src/components/desktop/desktop-session-controller.ts
+++ b/ui/src/components/desktop/desktop-session-controller.ts
@@ -1,0 +1,89 @@
+import type { ReactiveControllerHost } from "lit";
+import type { GatewayBrowserClient } from "../../api/gateway.ts";
+import type { GatewaySessionRow } from "../../api/types.ts";
+import { readSessionChangedEvent } from "../../lib/sessions/reconcile.ts";
+import { areUiSessionKeysEquivalent } from "../../lib/sessions/session-key.ts";
+import { SubscriptionsController } from "../../lit/subscriptions-controller.ts";
+import { resolveChatPaneDesktopTarget } from "../../pages/chat/chat-pane-placement.ts";
+
+// Keep the chat placement dependency in this lazily loaded desktop owner, outside the boot chunk.
+export async function resolveDesktopDocumentSessionTarget(
+  client: Pick<GatewayBrowserClient, "request"> | null,
+  sessionKey: string,
+): Promise<string | null> {
+  let session: GatewaySessionRow | undefined;
+  // `sessions.describe` is the exact-key lookup; a paged list cannot rule out a later match.
+  try {
+    session =
+      (
+        await client?.request<{ session?: GatewaySessionRow | null }>("sessions.describe", {
+          key: sessionKey,
+        })
+      )?.session ?? undefined;
+  } catch {}
+  return resolveChatPaneDesktopTarget(session);
+}
+
+type DesktopSessionHost = ReactiveControllerHost & {
+  isConnected: boolean;
+  client: GatewayBrowserClient | null;
+  available: boolean;
+  documentMode: boolean;
+  requestedSource: string | null;
+  sessionKey: string | null;
+};
+
+export class DesktopSessionController {
+  private refreshId = 0;
+
+  constructor(
+    private readonly host: DesktopSessionHost,
+    private readonly currentTarget: () => string | null,
+    private readonly onTargetChange: (target: string | null) => void,
+  ) {
+    new SubscriptionsController(host).effect(
+      () =>
+        host.documentMode &&
+        host.available &&
+        host.sessionKey !== null &&
+        host.requestedSource === null
+          ? host.client
+          : null,
+      (client) =>
+        client.addEventListener((event) => {
+          const changed =
+            event.event === "sessions.changed" ? readSessionChangedEvent(event.payload) : null;
+          if (changed && areUiSessionKeysEquivalent(changed.key, host.sessionKey)) {
+            void this.refresh();
+          }
+        }),
+    );
+  }
+
+  invalidate(): void {
+    this.refreshId += 1;
+  }
+
+  private async refresh(): Promise<void> {
+    const { client, sessionKey } = this.host;
+    if (!client || !sessionKey) {
+      return;
+    }
+    const refreshId = ++this.refreshId;
+    const target = await resolveDesktopDocumentSessionTarget(client, sessionKey);
+    if (
+      refreshId !== this.refreshId ||
+      !this.host.isConnected ||
+      client !== this.host.client ||
+      sessionKey !== this.host.sessionKey ||
+      !this.host.documentMode ||
+      !this.host.available ||
+      this.host.requestedSource !== null ||
+      (target !== null && target === this.currentTarget())
+    ) {
+      return;
+    }
+    // Session events omit placement. Resolve it before comparing; unchanged updates keep live input.
+    this.onTargetChange(target);
+  }
+}

--- a/ui/src/components/desktop/desktop-source.ts
+++ b/ui/src/components/desktop/desktop-source.ts
@@ -1,6 +1,4 @@
 import type { DesktopSource, EnvironmentSummary } from "@openclaw/gateway-protocol";
-import type { GatewaySessionRow } from "../../api/types.ts";
-import { resolveChatPaneDesktopTarget } from "../../pages/chat/chat-pane-placement.ts";
 
 export function desktopSourceForEnvironment(
   environment: Pick<EnvironmentSummary, "id">,
@@ -12,15 +10,4 @@ export function desktopSourceForEnvironment(
     return { kind: "node", nodeId: environment.id.slice("node:".length) };
   }
   return { kind: "environment", environmentId: environment.id };
-}
-
-/**
- * Lives beside the lazily loaded panel rather than in the route module: the chat placement
- * owner pulls the chat page's dependency tree, which must stay out of the startup chunk.
- */
-export function resolveDesktopDocumentTarget(
-  options: { source: string | null; session: string | null },
-  session: GatewaySessionRow | undefined,
-): string | null {
-  return options.source ?? (options.session ? resolveChatPaneDesktopTarget(session) : null);
 }

--- a/ui/src/e2e/chat-rail-columns.e2e.test.ts
+++ b/ui/src/e2e/chat-rail-columns.e2e.test.ts
@@ -51,6 +51,13 @@ function scenario(): ControlUiMockGatewayScenario {
       "browser.request": {
         cases: [{ match: { method: "GET", path: "/tabs" }, response: { running: true, tabs: [] } }],
       },
+      "desktop.observe": {
+        transport: "rfb",
+        wsPath: "/desktop/observe?token=rail-tabs",
+        expiresAtMs: 60_000,
+        control: false,
+        auth: "vnc-password",
+      },
       "environments.list": {
         environments: [{ id: "gateway", type: "local", status: "available", desktop: true }],
       },
@@ -458,7 +465,9 @@ suite.define(() => {
           await sidePanel(page).locator('[data-panel-slot="companion"]:not([hidden])').waitFor();
           await openFromPlus(page, "Desktop");
           await sidePanel(page).locator('[data-panel-slot="desktop"]:not([hidden])').waitFor();
-          await sidePanel(page).getByText("Desktop sources", { exact: true }).waitFor();
+          const desktopObserve = await gateway.waitForRequest("desktop.observe");
+          expect(desktopObserve.params).toEqual({ source: { kind: "host" }, control: false });
+          await sidePanel(page).getByLabel("VNC password", { exact: true }).waitFor();
           await captureRichPanel(page, `rails-tabs-desktop-${themeMode}`);
           expect(await tabLabels(page)).toEqual([
             "Files",

--- a/ui/src/e2e/chat-side-panel.test-support.ts
+++ b/ui/src/e2e/chat-side-panel.test-support.ts
@@ -56,16 +56,13 @@ export async function activateChatHeaderPanelAction(page: Page, label: string): 
     }
   }
   await action.waitFor({ state: "visible" });
-  const afterHide = menu.locator("wa-dropdown").evaluate(
-    (dropdown) =>
-      new Promise<void>((resolve) => {
-        dropdown.addEventListener("wa-after-hide", () => resolve(), { once: true });
-      }),
-  );
   await action.click();
-  await afterHide;
   await page.waitForFunction(() => {
     const dropdown = document.querySelector("openclaw-chat-header-session-menu wa-dropdown");
-    return !dropdown || Reflect.get(dropdown, "open") !== true;
+    // Web Awesome clears `open` before its hide animation; reopening while the popup is active
+    // skips showMenu setup and can let the previous close hide the newly opened submenu.
+    const popup = dropdown?.shadowRoot?.querySelector("wa-popup");
+    return (!dropdown || Reflect.get(dropdown, "open") !== true) && !popup?.active;
   });
+  await action.waitFor({ state: "hidden" });
 }

--- a/ui/src/e2e/desktop-document-mode.e2e.test.ts
+++ b/ui/src/e2e/desktop-document-mode.e2e.test.ts
@@ -342,6 +342,32 @@ suite.define(() => {
         control: false,
       });
       await panel.locator("[data-test-remote-desktop='true']").waitFor();
+      await gateway.setMethodResponse("sessions.describe", {
+        session: {
+          key: sessionKey,
+          kind: "direct",
+          updatedAt: 2,
+          ...scenario.session,
+          placement: { state: "reclaimed" },
+        },
+      });
+      await gateway.setMethodResponse("environments.list", {
+        environments: [gatewayEnvironment, { ...scenario.environment, desktop: true }],
+      });
+      await gateway.emitGatewayEvent("sessions.changed", { sessionKey, reason: "reclaim" });
+      await panel.getByText("Desktop sources", { exact: true }).waitFor();
+      expect(await panel.locator("[data-test-remote-desktop='true']").count()).toBe(0);
+      expect(await gateway.getRequests("desktop.observe")).toHaveLength(1);
+
+      await gateway.setMethodResponse("sessions.describe", {
+        session: { key: sessionKey, kind: "direct", updatedAt: 3, ...scenario.session },
+      });
+      await gateway.emitGatewayEvent("sessions.changed", { sessionKey, reason: "placement" });
+      await panel.locator("[data-test-remote-desktop='true']").waitFor();
+      expect((await gateway.getRequests("desktop.observe")).at(-1)?.params).toEqual({
+        source: scenario.source,
+        control: false,
+      });
       await mkdir(artifactDirectory, { recursive: true });
       await page.screenshot({
         path: path.join(

--- a/ui/src/e2e/desktop-document-mode.e2e.test.ts
+++ b/ui/src/e2e/desktop-document-mode.e2e.test.ts
@@ -1,7 +1,13 @@
 import { mkdir } from "node:fs/promises";
 import path from "node:path";
 import { expect, it } from "vitest";
+import { waitForControlUiGatewayReady } from "../test-helpers/control-ui-e2e-readiness.ts";
 import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
+import { chatSessionListResponse } from "./chat-flow.test-support.ts";
+import {
+  activateChatHeaderPanelAction,
+  openChatSidePanelType,
+} from "./chat-side-panel.test-support.ts";
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
 const suite = createControlUiE2eSuite({
@@ -122,6 +128,107 @@ async function openDesktopDocument(
 }
 
 suite.define(() => {
+  it.each(["active", "starting", "offline"])(
+    "opens the %s chat session desktop and keeps its pop-out bound to the session",
+    async (initialState) => {
+      await suite.withPage({ serviceWorkers: "block" }, async ({ page }) => {
+        const sessionKey = "agent:main:cloud-desktop";
+        const session = {
+          key: sessionKey,
+          kind: "direct",
+          label: "Cloud desktop session",
+          updatedAt: 1,
+          placement: {
+            state: initialState === "offline" ? "active" : initialState,
+            environmentId: "worker-cloud",
+            ...(initialState === "offline"
+              ? { runner: { kind: "device", status: "offline", deviceId: "workstation" } }
+              : {}),
+          },
+        };
+        const gateway = await installMockGateway(page, {
+          sessionKey,
+          deferredMethods: ["environments.list"],
+          featureMethods: ["desktop.observe", "environments.list"],
+          methodResponses: {
+            "sessions.list": chatSessionListResponse([session]),
+            "desktop.observe": {
+              transport: "rfb",
+              wsPath: "/desktop/observe?token=chat-session",
+              expiresAtMs: 60_000,
+              control: false,
+            },
+          },
+        });
+        await page.goto(`${suite.server.baseUrl}chat`);
+        await waitForControlUiGatewayReady(page);
+        if (initialState !== "active") {
+          await openChatSidePanelType(page, "Desktop");
+        } else {
+          await activateChatHeaderPanelAction(page, "Desktop");
+        }
+        const panel = page.locator("openclaw-desktop-panel");
+        await panel.waitFor({ state: "attached" });
+        await gateway.waitForRequest("environments.list");
+        await installDesktopClientFake(panel);
+        const inventory = {
+          environments: [
+            gatewayEnvironment,
+            {
+              id: initialState === "offline" ? "node:workstation" : "worker-cloud",
+              type: initialState === "offline" ? "node" : "worker",
+              status: "available",
+              desktop: true,
+            },
+          ],
+        };
+        await gateway.resolveDeferred(
+          "environments.list",
+          initialState === "active" ? inventory : { environments: [gatewayEnvironment] },
+        );
+        if (initialState !== "active") {
+          await panel.getByText("Desktop sources", { exact: true }).waitFor();
+          expect(await gateway.getRequests("desktop.observe")).toHaveLength(0);
+          await gateway.setMethodResponse("environments.list", inventory);
+          await gateway.setMethodResponse(
+            "sessions.list",
+            chatSessionListResponse([
+              {
+                ...session,
+                placement: {
+                  ...session.placement,
+                  state: "active",
+                  ...(session.placement.runner
+                    ? { runner: { ...session.placement.runner, status: "available" } }
+                    : {}),
+                },
+              },
+            ]),
+          );
+          await gateway.emitGatewayEvent("sessions.changed", { sessionKey });
+        }
+
+        const observed = await gateway.waitForRequest("desktop.observe");
+        expect(observed.params).toEqual({
+          source:
+            initialState === "offline"
+              ? { kind: "node", nodeId: "workstation" }
+              : { kind: "environment", environmentId: "worker-cloud" },
+          control: false,
+        });
+        await panel.locator("[data-test-remote-desktop='true']").waitFor();
+        const popout = page.getByRole("link", { name: "Open desktop in new window" });
+        expect(await popout.getAttribute("href")).toBe(
+          `/focus/desktop/session/${encodeURIComponent(sessionKey)}`,
+        );
+        await mkdir(artifactDirectory, { recursive: true });
+        await page.screenshot({
+          path: path.join(artifactDirectory, `chat-session-${initialState}-connected.png`),
+        });
+      });
+    },
+  );
+
   it("returns from an unavailable focused desktop", async () => {
     await suite.withPage({ serviceWorkers: "block" }, async ({ page }) => {
       await installMockGateway(page);
@@ -181,7 +288,32 @@ suite.define(() => {
     });
   });
 
-  it("resolves a session to its observable machine and auto-connects", async () => {
+  it.each([
+    {
+      name: "execution node",
+      session: { execNode: "workstation" },
+      environment: { id: "node:workstation", type: "node" },
+      source: { kind: "node", nodeId: "workstation" },
+    },
+    {
+      name: "paired device placement",
+      session: {
+        placement: {
+          state: "active",
+          environmentId: "worker-device",
+          runner: { kind: "device", deviceId: "workstation", status: "available" },
+        },
+      },
+      environment: { id: "node:workstation", type: "node" },
+      source: { kind: "node", nodeId: "workstation" },
+    },
+    {
+      name: "cloud placement",
+      session: { placement: { state: "active", environmentId: "worker-cloud" } },
+      environment: { id: "worker-cloud", type: "worker" },
+      source: { kind: "environment", environmentId: "worker-cloud" },
+    },
+  ])("resolves a $name session to its observable machine and auto-connects", async (scenario) => {
     await suite.withPage({ serviceWorkers: "block" }, async ({ page }) => {
       const sessionKey = "agent:main:mobile-session";
       const { gateway, panel } = await openDesktopDocument(
@@ -190,8 +322,7 @@ suite.define(() => {
         [
           gatewayEnvironment,
           {
-            id: "node:workstation",
-            type: "node",
+            ...scenario.environment,
             status: "available",
             desktop: true,
           },
@@ -201,19 +332,22 @@ suite.define(() => {
           key: sessionKey,
           kind: "direct",
           updatedAt: 1,
-          execNode: "workstation",
+          ...scenario.session,
         },
       );
 
       const request = await gateway.waitForRequest("desktop.observe");
       expect(request.params).toEqual({
-        source: { kind: "node", nodeId: "workstation" },
+        source: scenario.source,
         control: false,
       });
       await panel.locator("[data-test-remote-desktop='true']").waitFor();
       await mkdir(artifactDirectory, { recursive: true });
       await page.screenshot({
-        path: path.join(artifactDirectory, "session-connected-390x844.png"),
+        path: path.join(
+          artifactDirectory,
+          `session-${scenario.name.replaceAll(" ", "-")}-390x844.png`,
+        ),
         fullPage: false,
       });
     });
@@ -237,14 +371,25 @@ suite.define(() => {
     });
   });
 
-  it("falls back to the picker with a notice for an unknown session", async () => {
+  it.each([
+    { name: "unknown", session: null },
+    {
+      name: "reclaimed cloud",
+      session: {
+        key: "agent:main:missing",
+        kind: "direct",
+        updatedAt: 1,
+        placement: { state: "reclaimed", environmentId: "worker-stopped" },
+      },
+    },
+  ])("falls back to the picker with a notice for a $name session", async ({ session }) => {
     await suite.withPage({ serviceWorkers: "block" }, async ({ page }) => {
       const { gateway, panel } = await openDesktopDocument(
         page,
         "focus/desktop/session/agent%3Amain%3Amissing",
         [gatewayEnvironment],
         undefined,
-        null,
+        session,
       );
 
       await panel

--- a/ui/src/e2e/desktop-panel.e2e.test.ts
+++ b/ui/src/e2e/desktop-panel.e2e.test.ts
@@ -1,6 +1,7 @@
 import { expect, it } from "vitest";
 import { waitForControlUiGatewayReady } from "../test-helpers/control-ui-e2e-readiness.ts";
 import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
+import { activateChatHeaderPanelAction } from "./chat-side-panel.test-support.ts";
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 import { installDesktopClientFake, installScriptedRfbServer } from "./desktop-rfb-test-support.ts";
 
@@ -21,7 +22,10 @@ function sessionsList(placement: "local" | "active") {
         key: "main",
         kind: "direct",
         label: "Main",
-        placement: { state: placement },
+        placement: {
+          state: placement,
+          ...(placement === "active" ? { environmentId: "worker-desktop-1" } : {}),
+        },
         updatedAt: Date.now(),
       },
     ],
@@ -93,27 +97,69 @@ suite.define(() => {
     }
   });
 
-  it("keeps the desktop command and panel available without a cloud session", async () => {
-    await suite.withPage({ serviceWorkers: "block" }, async ({ page }) => {
-      const gateway = await installMockGateway(page, {
-        featureMethods: ["environments.list", "desktop.observe"],
-        methodResponses: {
-          "sessions.list": sessionsList("local"),
-          "environments.list": { environments: [] },
-        },
-      });
-      await page.goto(`${suite.server.baseUrl}chat`);
-      await openPalette(page);
-      expect(await page.getByRole("option", { name: "Desktop", exact: true }).count()).toBe(1);
+  it.each(["local", "active"] as const)(
+    "opens the global desktop picker on a %s chat session",
+    async (placement) => {
+      await suite.withPage({ serviceWorkers: "block" }, async ({ page }) => {
+        const inventory = {
+          environments: [
+            { id: "gateway", type: "local", status: "available", desktop: true },
+            workerDesktopEnvironment,
+          ],
+        };
+        const gateway = await installMockGateway(page, {
+          featureMethods: ["environments.list", "desktop.observe"],
+          methodResponses: {
+            "sessions.list": sessionsList(placement),
+            "environments.list": inventory,
+            "desktop.observe": {
+              transport: "rfb",
+              wsPath: "/desktop/observe?token=palette-session",
+              expiresAtMs: 60_000,
+              control: false,
+              auth: "vnc-password",
+            },
+          },
+        });
+        await page.goto(`${suite.server.baseUrl}chat`);
+        await openPalette(page);
+        expect(await page.getByRole("option", { name: "Desktop", exact: true }).count()).toBe(1);
 
-      await page.getByRole("option", { name: "Desktop", exact: true }).click();
-      const panel = page.locator("openclaw-desktop-panel");
-      await panel.locator("section[aria-label='Desktop']").waitFor();
-      await panel.getByText("Desktop sources", { exact: true }).waitFor();
-      await gateway.waitForRequest("environments.list");
-      expect(await gateway.getRequests("desktop.observe")).toHaveLength(0);
-    });
-  });
+        await page.getByRole("option", { name: "Desktop", exact: true }).click();
+        const panel = page.locator("openclaw-desktop-panel");
+        await panel.locator("section[aria-label='Desktop']").waitFor();
+        await panel.getByText("Desktop sources", { exact: true }).waitFor();
+        await gateway.waitForRequest("environments.list");
+        expect(await gateway.getRequests("desktop.observe")).toHaveLength(0);
+
+        await activateChatHeaderPanelAction(page, "Desktop");
+        await activateChatHeaderPanelAction(page, "Desktop");
+        await panel.getByLabel("VNC password", { exact: true }).waitFor();
+        const observation = await gateway.waitForRequest("desktop.observe");
+        expect(observation.params).toEqual({
+          source:
+            placement === "local"
+              ? { kind: "host" }
+              : { kind: "environment", environmentId: "worker-desktop-1" },
+          control: false,
+        });
+
+        await gateway.setMethodResponse("environments.list", {
+          __mockError: {
+            code: "UNAVAILABLE",
+            message: "desktop inventory temporarily unavailable",
+          },
+        });
+        await openPalette(page);
+        await page.getByRole("option", { name: "Desktop", exact: true }).click();
+        await panel.getByRole("alert").filter({ hasText: "inventory" }).waitFor();
+        await gateway.setMethodResponse("environments.list", inventory);
+        await panel.getByRole("button", { name: "Retry", exact: true }).click();
+        await panel.getByText("Desktop sources", { exact: true }).waitFor();
+        expect(await gateway.getRequests("desktop.observe")).toHaveLength(1);
+      });
+    },
+  );
 
   it("refreshes direct-target inventory before observing the exact worker", async () => {
     await suite.withPage({ serviceWorkers: "block" }, async ({ page }) => {

--- a/ui/src/e2e/desktop-panel.e2e.test.ts
+++ b/ui/src/e2e/desktop-panel.e2e.test.ts
@@ -53,7 +53,7 @@ async function openPalette(page: import("playwright").Page) {
 }
 
 async function openDesktopPanel(page: import("playwright").Page) {
-  await page.goto(`${suite.server.baseUrl}chat`);
+  await page.goto(`${suite.server.baseUrl}activity`);
   await openPalette(page);
   await page.getByRole("option", { name: "Desktop", exact: true }).click();
   const panel = page.locator("openclaw-desktop-panel");
@@ -191,10 +191,17 @@ suite.define(() => {
 
   it("shows direct-target inventory failure without observing or falling back", async () => {
     await suite.withPage({ serviceWorkers: "block" }, async ({ page }) => {
+      const sessions = sessionsList("active");
+      const [session] = sessions.sessions;
       const gateway = await installMockGateway(page, {
         featureMethods: ["desktop.observe", "environments.list"],
         methodResponses: {
-          "sessions.list": sessionsList("active"),
+          "sessions.list": {
+            ...sessions,
+            sessions: [
+              { ...session, placement: { state: "active", environmentId: "other-worker" } },
+            ],
+          },
           "environments.list": {
             __mockError: {
               code: "UNAVAILABLE",
@@ -289,7 +296,7 @@ suite.define(() => {
     });
   });
 
-  it("opens the selected desktop source in a focused window", async () => {
+  it("opens the standalone desktop picker in a focused window", async () => {
     await suite.withPage({ serviceWorkers: "block" }, async ({ page }) => {
       await installMockGateway(page, {
         featureMethods: ["environments.list", "desktop.observe"],
@@ -299,9 +306,10 @@ suite.define(() => {
         },
       });
       await openDesktopPanel(page);
-      const popupPromise = page.waitForEvent("popup");
-      await page.getByRole("link", { name: "Open desktop in new window", exact: true }).click();
-      const popup = await popupPromise;
+      const [popup] = await Promise.all([
+        page.waitForEvent("popup"),
+        page.getByRole("button", { name: "Open desktop in new window", exact: true }).click(),
+      ]);
       await popup.waitForLoadState("domcontentloaded");
       expect(new URL(popup.url()).pathname).toBe("/focus/desktop");
       await popup.close();

--- a/ui/src/pages/chat/chat-pane-embedded-panels.ts
+++ b/ui/src/pages/chat/chat-pane-embedded-panels.ts
@@ -1,8 +1,8 @@
+import { buildControlUiFocusPath } from "@openclaw/session-url-contract";
 import { html, nothing, type TemplateResult } from "lit";
 import type { SessionObserverDigest } from "../../../../packages/gateway-protocol/src/schema/sessions.js";
 import type { ControlUiSessionPullRequest } from "../../../../src/gateway/control-ui-contract.js";
 import type { BrowserTabSelection } from "../../components/browser/browser-target.ts";
-import { desktopFocusPath } from "../../components/desktop/desktop-focus-window.ts";
 import { icons } from "../../components/icons.ts";
 import {
   renderPanelLoadingSkeleton,
@@ -38,6 +38,7 @@ type SidebarPanelDefinitionParams = {
   desktopPresented: boolean;
   desktopRefreshOnPresentation: boolean;
   desktopAvailable: boolean;
+  desktopSource: string | null;
   hasBoard: boolean;
   chat: TemplateResult;
   workspace: TemplateResult | typeof nothing;
@@ -95,7 +96,9 @@ export function sidebarPanelDefinitions(
   const terminalAvailable = state?.terminalAvailable === true;
   const browserAvailable = state?.browserPanelAvailable === true;
   const desktopAvailable = params?.desktopAvailable === true;
-  const desktopFocusHref = state ? desktopFocusPath(state.basePath) : null;
+  const desktopFocusHref = state
+    ? buildControlUiFocusPath({ kind: "desktop", session: state.sessionKey }, state.basePath)
+    : null;
   const definePanel = (
     slot: SidebarSlotId,
     textKey: SidebarPanelTextKey,
@@ -166,6 +169,8 @@ export function sidebarPanelDefinitions(
           .available=${desktopAvailable}
           .presented=${params?.desktopPresented ?? false}
           .refreshOnPresentation=${params?.desktopRefreshOnPresentation ?? true}
+          .requestedSource=${params?.desktopSource ?? null}
+          .sessionKey=${state.sessionKey}
         ></openclaw-desktop-panel>`
       : null;
   const discussion = params?.discussion

--- a/ui/src/pages/chat/chat-pane-layout-render.ts
+++ b/ui/src/pages/chat/chat-pane-layout-render.ts
@@ -10,6 +10,7 @@ import {
   sidebarPanelDefinitions,
   sidebarPanelTemplates,
 } from "./chat-pane-embedded-panels.ts";
+import { resolveChatPaneDesktopTarget } from "./chat-pane-placement.ts";
 import type { ResolvedBoardView } from "./chat-pane-shared.ts";
 import { renderSidebarRegion, sidebarRegionCallbacks } from "./chat-pane-sidebar-layout.ts";
 import type { ChatPageHost } from "./chat-state-host.ts";
@@ -108,6 +109,7 @@ export abstract class ChatPaneLayoutRender extends ChatPaneBrowserAnnotationRend
       desktopPresented,
       desktopRefreshOnPresentation,
       desktopAvailable,
+      desktopSource: resolveChatPaneDesktopTarget(selectedSession),
       hasBoard: board.hasBoard,
       chat,
       workspace: renderSessionWorkspaceRail(sessionWorkspace, { embedded: true }),

--- a/ui/src/pages/chat/chat-pane-placement.ts
+++ b/ui/src/pages/chat/chat-pane-placement.ts
@@ -2,7 +2,6 @@ import { normalizeOptionalString } from "@openclaw/normalization-core/string-coe
 import type { GatewaySessionRow } from "../../api/types.ts";
 import type { ApplicationGatewaySnapshot } from "../../app/context.ts";
 import { resolveCloudWorkerStopAction } from "../../components/cloud-worker-stop.ts";
-import { isCloudWorkerPlacementState } from "../../components/session-row-badges.ts";
 import { t } from "../../i18n/index.ts";
 import { registerSessionPlacementEnglish } from "../../i18n/locales/en-session-placement.ts";
 import { readSessionMethodAccess } from "../../lib/session-method-access.ts";
@@ -16,10 +15,16 @@ export function resolveChatPaneDesktopTarget(
     return null;
   }
   const placement = session.placement;
-  if (isCloudWorkerPlacementState(placement?.state)) {
-    return "environmentId" in placement
-      ? (normalizeOptionalString(placement.environmentId) ?? null)
-      : null;
+  if (placement && placement.state !== "local") {
+    // Wait for the active owner; starting or reclaimed sessions do not own a desktop yet.
+    if (placement.state !== "active") {
+      return null;
+    }
+    if (placement.runner?.kind === "device") {
+      const nodeId = normalizeOptionalString(placement.runner.deviceId);
+      return placement.runner.status === "available" && nodeId ? `node:${nodeId}` : null;
+    }
+    return normalizeOptionalString(placement.environmentId) ?? null;
   }
   const execNode = normalizeOptionalString(session.execNode);
   return execNode ? `node:${execNode}` : "gateway";

--- a/ui/src/pages/chat/chat-pane-terminal.test.ts
+++ b/ui/src/pages/chat/chat-pane-terminal.test.ts
@@ -233,17 +233,6 @@ describe("chat pane terminal action", () => {
           name: "node",
           session: { ...localSession, execNode: "  paired-node  " },
         },
-        {
-          name: "reclaimed",
-          session: {
-            ...localSession,
-            execNode: " reclaimed-node ",
-            placement: {
-              state: "reclaimed",
-              environmentId: "former-worker",
-            } as GatewaySessionRow["placement"],
-          },
-        },
       ];
       for (const testCase of targetCases) {
         renderDesktopHeader(testCase.session);
@@ -257,13 +246,18 @@ describe("chat pane terminal action", () => {
         onToggleDesktop.mockClear();
       }
 
-      renderDesktopHeader({
-        ...localSession,
-        execNode: "must-not-fall-back",
-        placement: { state: "requested" } as GatewaySessionRow["placement"],
-      });
-      expect(container.querySelector('[aria-label="Toggle desktop panel"]')).toBeNull();
-      expect(panelActionIds()).not.toContain("desktop");
+      for (const placement of [
+        { state: "requested" },
+        { state: "reclaimed", environmentId: "former-worker" },
+      ]) {
+        renderDesktopHeader({
+          ...localSession,
+          execNode: "must-not-fall-back",
+          placement: placement as GatewaySessionRow["placement"],
+        });
+        expect(container.querySelector('[aria-label="Toggle desktop panel"]')).toBeNull();
+        expect(panelActionIds()).not.toContain("desktop");
+      }
 
       renderDesktopHeader(undefined);
       expect(container.querySelector('[aria-label="Toggle desktop panel"]')).toBeNull();


### PR DESCRIPTION
Closes #132239

## What Problem This Solves

Opening Desktop from a chat session showed the generic picker instead of that session's machine. Paired-device popouts could not resolve their node, stopped cloud sessions could select the Gateway desktop, and a panel opened before readiness stayed stuck. Live verification also found that an already-open popout retained its old paired desktop after the worker was stopped.

## Why This Change Was Made

Chat already owns the current session projection, so it now passes that target into the existing Desktop panel. Session popouts retain the session key and use the existing exact-session lookup. Their focused-session controller follows the existing session event stream, resolves current placement, and retires the old connection only when its target changes. The panel owns RFB/input cleanup and rejects stale observations. A separate lookup revision prevents a control-mode change or an older response from hiding a reclaim.

Only active, available placement owners produce an automatic target. Paired placements map to their actual node; cloud placements map to their environment. Provisioning, offline, and stopped remote placements do not fall through to the Gateway. The global command-palette Desktop action still opens the generic picker, including on chat routes and after inventory-error retry. Explicit source requests retain precedence.

This reuses the placement resolver, session subscriptions, inventory filter, and shared panel lifecycle. It removes the obsolete focus wrapper and document-target wrapper. It adds no configuration, storage, protocol, permission, or CUA enablement change.

## User Impact

The session header opens the right machine, an early-open panel attaches when that machine becomes available, and both embedded and focused viewers follow placement changes and stops. View-only remains the default; existing credential, control, retry, and standalone picker behavior remains available.

## Evidence

Pre-fix failing browser reproductions cover automatic embedded selection, paired-device mapping, reclaimed placement, readiness recovery, the global picker, and open-popout retirement for execution-node/device/cloud sessions. Component tests cover immediate connection release, delayed inventory, stale observations, control changes during lookup, overlapping session lookups, and listener cleanup.

The focused repair passed 36 combined document/panel/rail browser cases before mechanical extraction; the final extracted source passed all 16 document browser cases and 5 component cases. The final browser run exited 0 after green results with a fork-termination warning during harness shutdown. Canonical targeted typed lint, formatting, diff checks, and fresh independent Codex autoreview passed. CI run 33231110312 exposed a newer-main test-helper race: it waited for `dropdown.open = false` before Web Awesome had finished hiding its popup. Both new palette cases failed with that helper locally. The test-only correction waits for popup inactivity and submenu disappearance, preserving the removal of the unreliable event Promise. All 52 cases across its seven consumer suites then passed, followed by both palette cases again after a lint-only boolean simplification. Final targeted typed lint passed and isolated autoreview was clean. Full hosted CI: [run 33232123771](https://github.com/openclaw/openclaw/actions/runs/33232123771) **passed** on final head `9a8bed79c9b43768afce75e3ade66f2396447607`, including the required `openclaw/ci-gate`..

Local broad typechecking uses a shared installation with unrelated stale Google SDK, markdown-it, and pi-tui types; it is not claimed as green. Exact-head hosted CI owns the complete dependency/type/lint verification.

### Actual cloud and paired-device proof

Actual UI-created cloud and paired-device sessions ran real model turns against an isolated Gateway and real AWS desktop. With UI `b799acdeb6ec418d78bedbe90cda25f32971e764` and backend `9e89c990445d3cdb0e718f02792c31907588a0a9`, the global palette made zero observations; session-header Desktop and its popout observed the same cloud environment, and the paired session observed its actual node instead of its worker environment. The cloud desktop accepted a synthetic marker through VNC control and launched Chromium. Normal UI stop/reclaim left the embedded viewer unavailable.

Final head `9a8bed79c9b43768afce75e3ade66f2396447607` changes only a browser test helper after the live-tested production commit; production source is identical. The additional popout-lifecycle proof used the exact frozen source committed as **`97fcfa93ef181ba35d1a136e8f6b945719b48ab3`**, built as `cloud-cua-focused-lifecycle`, with the same backend **`9e89c990445d3cdb0e718f02792c31907588a0a9`**. This is explicitly a candidate UI/custom-root test against that prepared backend, not a claim that both processes ran the final source tree. The bundle was built before committing, so its footer retained base `b799acdeb6`; its asset-manifest SHA-256 is `af5fe5c53ef7a05ac4b5d8d854bf1562b2362fcd175a7cd3be3a7b6d595242ca`.

A fresh paired-only desktop session produced the real reply “Focused desktop lifecycle proof ready.” Opening Desktop from the session header and its real popout created two successful view-only node observations. Both showed the same foreground synthetic marker. Renaming the session through the UI kept both canvases connected and the observation count at two. Then **Runs on device → Stop device worker → Confirm** returned a reclaimed placement: both the embedded canvas and the already-open popout disappeared and showed unavailable, while the paired node remained available in inventory. The observation count stayed at two: no fallback or unintended reconnection.

Real cloud desktop, same session in the focused window:

![Real cloud desktop](https://github.com/user-attachments/assets/a379ecaa-7eeb-4d25-a348-5b67ca9824df)

Final focused paired desktop before stopping its worker:

![Real focused session desktop before stop](https://github.com/user-attachments/assets/904e33a9-325e-4bbf-85ea-a96e40cf9561)

The **same already-open popout** after stop, with the underlying node still available:

![Open popout retires the stopped session desktop](https://github.com/user-attachments/assets/5613ec4e-2335-44f1-93d1-2d24f4a8ca66)

The embedded viewer after the same stop:

![Embedded viewer retires the stopped session desktop](https://github.com/user-attachments/assets/0dfb65f4-8bcf-49c8-8953-ef3c35dcf304)

All captures were inspected before upload and contain only the isolated task's synthetic UI/desktop. Both proof runs were cleaned up: no task leases or checkpoints remain; the final Gateway, tunnel, browser context, and harness are stopped. No operator settings or unrelated resources were changed.

### Before and after (browser fixtures)

These two images use a synthetic browser fixture; they are not the live VNC evidence above.

Before — session Desktop stops at the generic picker:

![Before: generic desktop picker](https://github.com/user-attachments/assets/5125744d-dffd-43f0-97b9-725e74c458f9)

After — session Desktop resolves its machine automatically:

![After: session desktop connected](https://github.com/user-attachments/assets/19bb7432-f296-4c6c-a14a-eb2544044892)

## Scope and Review

Production +171/-85 (net +86); tests/test-support +447/-63 (net +384); docs +6/-0. The production increase adds the missing event-driven focused-session lifecycle, including exact lookup, stale-response fencing, and subscription cleanup. The owner extraction keeps the panel under its file-size limit; obsolete wrappers are deleted instead of retaining another path. No new configuration/default surface.

ClawSweeper's earlier picker finding is fixed. Its live cloud/paired-device rank-up move is addressed by the observed proof above; the focused lifecycle discovered during that proof is included in this repair. The latest ClawSweeper review (03:37 UTC, `97fcfa93ef1`) found no source defect and requested the CI failure/current-base verification be resolved. The shared-helper race is fixed, all affected production files were compared with main `56c2083fbdd`, and final exact-head CI is green; no rank-up move is skipped.

Provenance: #122992 added direct session targeting. The tabbed-side-panel change #123874 removed that handoff; author @vyctorbrzezowski, merger @fuller-stack-dev, merged 2026-08-16. This is a main regression after the latest stable v2026.7.1-2. Current repair author: @steipete. Release-note context: session Desktop and its popout follow the active cloud worker, paired device, or local execution node, retire stopped owners, and preserve the global picker.
