### PR TITLE
fix(test): roll back failed test-home acquisition

### DIFF
--- a/src/plugin-sdk/test-helpers/temp-home.ts
+++ b/src/plugin-sdk/test-helpers/temp-home.ts
@@ -3,19 +3,10 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { expectDefined } from "@openclaw/normalization-core";
-import { deleteTestEnvValue, setTestEnvValue } from "../../test-utils/env.js";
+import { captureEnv, deleteTestEnvValue, setTestEnvValue } from "../../test-utils/env.js";
 import { cleanupSessionStateForTest } from "../../test-utils/session-state-cleanup.js";
 
 type EnvValue = string | undefined | ((home: string) => string | undefined);
-
-type EnvSnapshot = {
-  home: string | undefined;
-  userProfile: string | undefined;
-  homeDrive: string | undefined;
-  homePath: string | undefined;
-  openclawHome: string | undefined;
-  stateDir: string | undefined;
-};
 
 type SharedHomeRootState = {
   rootPromise: Promise<string>;
@@ -23,51 +14,6 @@ type SharedHomeRootState = {
 };
 
 const SHARED_HOME_ROOTS = new Map<string, SharedHomeRootState>();
-
-function snapshotEnv(): EnvSnapshot {
-  return {
-    home: process.env.HOME,
-    userProfile: process.env.USERPROFILE,
-    homeDrive: process.env.HOMEDRIVE,
-    homePath: process.env.HOMEPATH,
-    openclawHome: process.env.OPENCLAW_HOME,
-    stateDir: process.env.OPENCLAW_STATE_DIR,
-  };
-}
-
-function restoreEnv(snapshot: EnvSnapshot) {
-  const restoreKey = (key: string, value: string | undefined) => {
-    if (value === undefined) {
-      deleteTestEnvValue(key);
-    } else {
-      setTestEnvValue(key, value);
-    }
-  };
-  restoreKey("HOME", snapshot.home);
-  restoreKey("USERPROFILE", snapshot.userProfile);
-  restoreKey("HOMEDRIVE", snapshot.homeDrive);
-  restoreKey("HOMEPATH", snapshot.homePath);
-  restoreKey("OPENCLAW_HOME", snapshot.openclawHome);
-  restoreKey("OPENCLAW_STATE_DIR", snapshot.stateDir);
-}
-
-function snapshotExtraEnv(keys: string[]): Record<string, string | undefined> {
-  const snapshot: Record<string, string | undefined> = {};
-  for (const key of keys) {
-    snapshot[key] = process.env[key];
-  }
-  return snapshot;
-}
-
-function restoreExtraEnv(snapshot: Record<string, string | undefined>) {
-  for (const [key, value] of Object.entries(snapshot)) {
-    if (value === undefined) {
-      deleteTestEnvValue(key);
-    } else {
-      setTestEnvValue(key, value);
-    }
-  }
-}
 
 function setTempHome(base: string) {
   setTestEnvValue("HOME", base);
@@ -97,9 +43,7 @@ async function allocateTempHomeBase(prefix: string): Promise<string> {
     SHARED_HOME_ROOTS.set(prefix, state);
   }
   const root = await state.rootPromise;
-  const base = path.join(root, `case-${state.nextCaseId++}`);
-  await fs.mkdir(base, { recursive: true });
-  return base;
+  return path.join(root, `case-${state.nextCaseId++}`);
 }
 
 export async function withTempHomeCore<T>(
@@ -111,31 +55,38 @@ export async function withTempHomeCore<T>(
     skipSessionCleanup?: boolean;
   } = {},
 ): Promise<T> {
-  const prefix = opts.prefix ?? "openclaw-test-home-";
-  const base = await allocateTempHomeBase(prefix);
-  const snapshot = snapshotEnv();
   const envKeys = Object.keys(opts.env ?? {});
   for (const key of envKeys) {
     if (key === "HOME" || key === "USERPROFILE" || key === "HOMEDRIVE" || key === "HOMEPATH") {
       throw new Error(`withTempHome: use built-in home env (got ${key})`);
     }
   }
-  const envSnapshot = snapshotExtraEnv(envKeys);
-
-  setTempHome(base);
-  await fs.mkdir(path.join(base, ".openclaw", "agents", "main", "sessions"), { recursive: true });
-  if (opts.env) {
-    for (const [key, raw] of Object.entries(opts.env)) {
-      const value = typeof raw === "function" ? raw(base) : raw;
-      if (value === undefined) {
-        deleteTestEnvValue(key);
-      } else {
-        setTestEnvValue(key, value);
+  const base = await allocateTempHomeBase(opts.prefix ?? "openclaw-test-home-");
+  const snapshot = captureEnv([
+    "HOME",
+    "USERPROFILE",
+    "HOMEDRIVE",
+    "HOMEPATH",
+    "OPENCLAW_HOME",
+    "OPENCLAW_STATE_DIR",
+    ...envKeys,
+  ]);
+  let initialized = false;
+  try {
+    await fs.mkdir(base, { recursive: true });
+    setTempHome(base);
+    await fs.mkdir(path.join(base, ".openclaw", "agents", "main", "sessions"), { recursive: true });
+    if (opts.env) {
+      for (const [key, raw] of Object.entries(opts.env)) {
+        const value = typeof raw === "function" ? raw(base) : raw;
+        if (value === undefined) {
+          deleteTestEnvValue(key);
+        } else {
+          setTestEnvValue(key, value);
+        }
       }
     }
-  }
-
-  try {
+    initialized = true;
     return await fn(base);
   } finally {
     if (!opts.skipSessionCleanup) {
@@ -143,9 +94,9 @@ export async function withTempHomeCore<T>(
         () => undefined,
       );
     }
-    restoreExtraEnv(envSnapshot);
-    restoreEnv(snapshot);
-    if (!opts.skipHomeCleanup) {
+    snapshot.restore();
+    // Retention belongs to the body; failed acquisition has no caller-owned home.
+    if (!initialized || !opts.skipHomeCleanup) {
       try {
         if (process.platform === "win32") {
           await fs.rm(base, {

--- a/src/test-utils/temp-home.test.ts
+++ b/src/test-utils/temp-home.test.ts
@@ -1,7 +1,10 @@
 // Tests temporary home directory helper setup and cleanup.
 import fs from "node:fs/promises";
+import os from "node:os";
 import path from "node:path";
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { withTempHomeCore } from "../plugin-sdk/test-helpers/temp-home.js";
+import { captureFullEnv, withEnvAsync } from "./env.js";
 import { createTempHomeEnv } from "./temp-home.js";
 
 async function expectPathMissing(targetPath: string): Promise<void> {
@@ -34,4 +37,154 @@ describe("createTempHomeEnv", () => {
     expect(process.env.OPENCLAW_STATE_DIR).toBe(previousStateDir);
     await expectPathMissing(tempHome.home);
   });
+});
+
+describe("withTempHome acquisition", () => {
+  let sandbox: string;
+  let prefix: string;
+  let snapshot: ReturnType<typeof captureFullEnv>;
+
+  beforeEach(async () => {
+    snapshot = captureFullEnv();
+    sandbox = await fs.realpath(await fs.mkdtemp(path.join(os.tmpdir(), "home-acquisition-")));
+    prefix = `${path.basename(sandbox)}-`;
+    vi.spyOn(os, "tmpdir").mockReturnValue(sandbox);
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    snapshot.restore();
+    await fs.rm(sandbox, { recursive: true, force: true });
+  });
+
+  it.each(["HOME", "USERPROFILE", "HOMEDRIVE", "HOMEPATH"])(
+    "rejects reserved %s before allocating a home",
+    async (key) => {
+      const body = vi.fn(async () => undefined);
+      await expect(withTempHomeCore(body, { prefix, env: { [key]: "invalid" } })).rejects.toThrow(
+        `withTempHome: use built-in home env (got ${key})`,
+      );
+      expect(body).not.toHaveBeenCalled();
+      expect(await fs.readdir(sandbox)).toEqual([]);
+    },
+  );
+
+  it.each([false, true])(
+    "rolls back a throwing env callback before reuse (skipHomeCleanup=%s)",
+    async (skipHomeCleanup) => {
+      const callerHome = path.join(sandbox, "caller");
+      await fs.mkdir(callerHome);
+      await fs.writeFile(path.join(callerHome, "keep"), "caller-owned");
+      await withEnvAsync(
+        {
+          OPENCLAW_HOME: callerHome,
+          OPENCLAW_STATE_DIR: path.join(callerHome, ".openclaw"),
+          ACQUISITION_ADDED: undefined,
+          ACQUISITION_CHANGED: "",
+          ACQUISITION_DELETED: "caller",
+        },
+        async () => {
+          const callerEnv = { ...process.env };
+          const failure = new Error("env acquisition failed");
+          const body = vi.fn(async () => undefined);
+          let failedHome = "";
+          await expect(
+            withTempHomeCore(body, {
+              prefix,
+              skipHomeCleanup,
+              env: {
+                ACQUISITION_ADDED: "temporary",
+                ACQUISITION_CHANGED: "temporary",
+                ACQUISITION_DELETED: undefined,
+                ACQUISITION_THROW: (home) => {
+                  failedHome = home;
+                  throw failure;
+                },
+              },
+            }),
+          ).rejects.toBe(failure);
+          expect(body).not.toHaveBeenCalled();
+          const changedKeys = [
+            ...new Set([...Object.keys(callerEnv), ...Object.keys(process.env)]),
+          ].filter((key) => callerEnv[key] !== process.env[key]);
+          expect.soft(changedKeys).toEqual([]);
+          await expectPathMissing(failedHome);
+          const root = path.dirname(failedHome);
+          expect(await fs.readdir(root)).toEqual([]);
+          const result = await withTempHomeCore(
+            async (home) => {
+              expect(home).not.toBe(failedHome);
+              expect(path.dirname(home)).toBe(root);
+              expect(process.env.HOME).toBe(home);
+              return "recovered";
+            },
+            { prefix },
+          );
+          expect(result).toBe("recovered");
+          expect(process.env.HOME).toBe(callerEnv.HOME);
+          expect(await fs.readFile(path.join(callerHome, "keep"), "utf8")).toBe("caller-owned");
+          expect(await fs.readdir(root)).toEqual([]);
+        },
+      );
+    },
+  );
+
+  it.each(["case", "sessions"])("rolls back partial %s directory creation", async (stage) => {
+    const callerEnv = { ...process.env };
+    const failure = new Error(`${stage} directory failed`);
+    const mkdir = fs.mkdir;
+    let failedHome = "";
+    const fault = vi.spyOn(fs, "mkdir").mockImplementation(async (target, options) => {
+      const result = await mkdir(target, options);
+      const targetPath = String(target);
+      const isCase = path.basename(targetPath).startsWith("case-");
+      if (
+        (stage === "case" && isCase) ||
+        (stage === "sessions" && path.basename(targetPath) === "sessions")
+      ) {
+        failedHome = isCase ? targetPath : path.resolve(targetPath, "../../../..");
+        throw failure;
+      }
+      return result;
+    });
+    const body = vi.fn(async () => undefined);
+    try {
+      await expect(withTempHomeCore(body, { prefix })).rejects.toBe(failure);
+    } finally {
+      fault.mockRestore();
+    }
+    expect(body).not.toHaveBeenCalled();
+    const changedKeys = [
+      ...new Set([...Object.keys(callerEnv), ...Object.keys(process.env)]),
+    ].filter((key) => callerEnv[key] !== process.env[key]);
+    expect.soft(changedKeys).toEqual([]);
+    await expectPathMissing(failedHome);
+  });
+
+  it.each([false, true])(
+    "preserves body-failure retention (skipHomeCleanup=%s)",
+    async (skipHomeCleanup) => {
+      const failure = new Error("body failed");
+      const callerHome = process.env.HOME;
+      let acquiredHome = "";
+      await expect(
+        withTempHomeCore(
+          async (home) => {
+            acquiredHome = home;
+            await fs.writeFile(path.join(home, "retained"), "body artifact");
+            throw failure;
+          },
+          { prefix, skipHomeCleanup, skipSessionCleanup: true },
+        ),
+      ).rejects.toBe(failure);
+      expect(process.env.HOME).toBe(callerHome);
+      if (skipHomeCleanup) {
+        expect(await fs.readFile(path.join(acquiredHome, "retained"), "utf8")).toBe(
+          "body artifact",
+        );
+      } else {
+        await expectPathMissing(acquiredHome);
+      }
+    },
+  );
 });

--- a/test/test-env.test.ts
+++ b/test/test-env.test.ts
@@ -1,5 +1,6 @@
 // Test environment tests validate shared env setup helpers.
 import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import { importFreshModule } from "openclaw/plugin-sdk/test-fixtures";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -14,7 +15,12 @@ import {
 import { closeOpenClawAgentDatabaseByPath } from "../src/state/openclaw-agent-db.js";
 import { closeOpenClawStateDatabaseByPath } from "../src/state/openclaw-state-db.js";
 import { resolveOpenClawStateSqlitePath } from "../src/state/openclaw-state-db.paths.js";
-import { deleteTestEnvValue, setTestEnvValue } from "../src/test-utils/env.js";
+import {
+  captureFullEnv,
+  deleteTestEnvValue,
+  setTestEnvValue,
+  withEnv,
+} from "../src/test-utils/env.js";
 import { cleanupTempDirs, makeTempDir } from "./helpers/temp-dir.js";
 import { installTestEnv } from "./test-env.js";
 
@@ -78,10 +84,98 @@ afterEach(() => {
     cleanupFns.pop()?.();
   }
   restoreProcessEnv();
+  vi.restoreAllMocks();
+  vi.doUnmock("node:child_process");
   cleanupTempDirs(tempDirs);
 });
 
 describe("installTestEnv", () => {
+  it.each([".openclaw", ".claude"])(
+    "rolls back live staging failure at %s before another installation",
+    (failedDirectory) => {
+      const sandbox = makeTempDir(tempDirs, "openclaw-env-acquisition-");
+      const realHome = createTempHome();
+      writeFile(
+        path.join(realHome, ".profile"),
+        [
+          "export ACQUISITION_PROFILE_ADDED=from-profile",
+          "export ACQUISITION_PROFILE_EMPTY=from-profile",
+          "export OPENCLAW_TEST_FAST=from-profile",
+        ].join("\n"),
+      );
+      const configPath = path.join(realHome, ".openclaw", "openclaw.json");
+      writeFile(configPath, "{}\n");
+      writeFile(path.join(realHome, ".claude", "settings.json"), "{}\n");
+      vi.spyOn(os, "tmpdir").mockReturnValue(sandbox);
+      const snapshot = captureFullEnv();
+      cleanupFns.push(() => snapshot.restore());
+
+      withEnv(
+        {
+          HOME: realHome,
+          USERPROFILE: realHome,
+          OPENCLAW_HOME: realHome,
+          OPENCLAW_STATE_DIR: path.join(realHome, ".openclaw"),
+          OPENCLAW_CONFIG_PATH: configPath,
+          OPENCLAW_LIVE_TEST: "1",
+          OPENCLAW_LIVE_USE_REAL_HOME: undefined,
+          OPENCLAW_LIVE_TEST_QUIET: "1",
+          OPENCLAW_TEST_FAST: "",
+          ACQUISITION_PROFILE_ADDED: undefined,
+          ACQUISITION_PROFILE_EMPTY: "",
+        },
+        () => {
+          const callerEnv = { ...process.env };
+          const failure = new Error(`staging failed at ${failedDirectory}`);
+          const mkdirSync = fs.mkdirSync;
+          let failedHome = "";
+          const fault = vi.spyOn(fs, "mkdirSync").mockImplementation((target, options) => {
+            const home = process.env.HOME;
+            if (home && home !== realHome && target === path.join(home, failedDirectory)) {
+              failedHome = home;
+              throw failure;
+            }
+            return mkdirSync(target, options);
+          });
+          try {
+            let caught: unknown;
+            try {
+              const unexpected = installTestEnv();
+              cleanupFns.push(unexpected.cleanup);
+            } catch (error) {
+              caught = error;
+            }
+            expect(caught).toBe(failure);
+          } finally {
+            fault.mockRestore();
+          }
+          expect(failedHome).not.toBe("");
+          const changedKeys = [
+            ...new Set([...Object.keys(callerEnv), ...Object.keys(process.env)]),
+          ].filter((key) => callerEnv[key] !== process.env[key]);
+          expect.soft(changedKeys).toEqual([]);
+          expect.soft(fs.existsSync(failedHome)).toBe(false);
+          expect(fs.readdirSync(sandbox)).toEqual([]);
+          expect(fs.readFileSync(configPath, "utf8")).toBe("{}\n");
+
+          const next = installTestEnv();
+          cleanupFns.push(next.cleanup);
+          expect(next.tempHome).not.toBe(failedHome);
+          expect(process.env.ACQUISITION_PROFILE_ADDED).toBe("from-profile");
+          expect(process.env.ACQUISITION_PROFILE_EMPTY).toBe("from-profile");
+          expect(
+            fs.readFileSync(path.join(next.tempHome, ".claude", "settings.json"), "utf8"),
+          ).toBe("{}\n");
+          next.cleanup();
+          expect(process.env.HOME).toBe(realHome);
+          expect(process.env.OPENCLAW_TEST_FAST).toBe("from-profile");
+          expect(process.env.ACQUISITION_PROFILE_ADDED).toBe("from-profile");
+          expect(fs.readdirSync(sandbox)).toEqual([]);
+        },
+      );
+    },
+  );
+
   it("keeps live tests on a temp HOME while copying config and auth state", () => {
     const realHome = createTempHome();
     const openClawHome = createTempHome();

--- a/test/test-env.ts
+++ b/test/test-env.ts
@@ -7,7 +7,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import JSON5 from "json5";
 import { resolveEffectiveHomeDir } from "../src/infra/home-dir.js";
-import { deleteTestEnvValue, setTestEnvValue } from "../src/test-utils/env.js";
+import { captureFullEnv, deleteTestEnvValue, setTestEnvValue } from "../src/test-utils/env.js";
 
 type RestoreEntry = { key: string; value: string | undefined };
 type InstallTestEnvOptions =
@@ -224,12 +224,7 @@ function resolveRestoreEntries(): RestoreEntry[] {
   ];
 }
 
-function createIsolatedTestHome(restore: RestoreEntry[]): {
-  cleanup: () => void;
-  tempHome: string;
-} {
-  const tempHome = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-test-home-"));
-
+function initializeIsolatedTestEnv(tempHome: string): void {
   setTestEnvValue("HOME", tempHome);
   setTestEnvValue("USERPROFILE", tempHome);
   setTestEnvValue("OPENCLAW_TEST_HOME", tempHome);
@@ -267,17 +262,6 @@ function createIsolatedTestHome(restore: RestoreEntry[]): {
   setTestEnvValue("XDG_DATA_HOME", path.join(tempHome, ".local", "share"));
   setTestEnvValue("XDG_STATE_HOME", path.join(tempHome, ".local", "state"));
   setTestEnvValue("XDG_CACHE_HOME", path.join(tempHome, ".cache"));
-
-  const cleanup = () => {
-    restoreEnv(restore);
-    try {
-      fs.rmSync(tempHome, { recursive: true, force: true });
-    } catch {
-      // ignore cleanup errors
-    }
-  };
-
-  return { cleanup, tempHome };
 }
 
 function ensureParentDir(targetPath: string): void {
@@ -487,36 +471,62 @@ export function installTestEnv(options?: InstallTestEnvOptions): {
   const allowRealHome = !hermetic && isTruthyEnvValue(process.env.OPENCLAW_LIVE_USE_REAL_HOME);
   const realHome = process.env.HOME ?? os.homedir();
   const liveEnvSnapshot = { ...process.env };
-
-  const requestedProfileLoad = options?.mode === "hermetic" ? false : options?.loadProfileEnv;
-  const shouldLoadProfileEnv = requestedProfileLoad ?? (live || allowRealHome);
-  if (shouldLoadProfileEnv) {
-    loadProfileEnv(realHome);
-  }
-
-  if (live && allowRealHome) {
-    return { cleanup: () => {}, tempHome: realHome };
-  }
-
-  const restore = resolveRestoreEntries();
-  const testEnv = createIsolatedTestHome(restore);
-
-  if (hermetic) {
-    for (const key of HERMETIC_TEST_ENV_KEYS) {
-      deleteTestEnvValue(key);
+  const rollback = captureFullEnv();
+  let tempHome: string | undefined;
+  const removeHome = () => {
+    if (!tempHome) {
+      return;
     }
-    // Keep non-isolated workers on this checkout's manifests, never a caller's
-    // staged plugin tree or a sibling worktree resolved through shared node_modules.
-    setTestEnvValue("OPENCLAW_TEST_TRUST_BUNDLED_PLUGINS_DIR", "1");
-    setTestEnvValue(
-      "OPENCLAW_BUNDLED_PLUGINS_DIR",
-      path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "extensions"),
-    );
-  } else if (live) {
-    stageLiveTestState({ env: liveEnvSnapshot, realHome, tempHome: testEnv.tempHome });
-  }
+    try {
+      fs.rmSync(tempHome, { recursive: true, force: true });
+    } catch {
+      // ignore cleanup errors
+    }
+  };
 
-  return testEnv;
+  try {
+    const requestedProfileLoad = options?.mode === "hermetic" ? false : options?.loadProfileEnv;
+    const shouldLoadProfileEnv = requestedProfileLoad ?? (live || allowRealHome);
+    if (shouldLoadProfileEnv) {
+      loadProfileEnv(realHome);
+    }
+
+    if (live && allowRealHome) {
+      return { cleanup: () => {}, tempHome: realHome };
+    }
+
+    const restore = resolveRestoreEntries();
+    tempHome = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-test-home-"));
+    initializeIsolatedTestEnv(tempHome);
+
+    if (hermetic) {
+      for (const key of HERMETIC_TEST_ENV_KEYS) {
+        deleteTestEnvValue(key);
+      }
+      // Keep non-isolated workers on this checkout's manifests, never a caller's
+      // staged plugin tree or a sibling worktree resolved through shared node_modules.
+      setTestEnvValue("OPENCLAW_TEST_TRUST_BUNDLED_PLUGINS_DIR", "1");
+      setTestEnvValue(
+        "OPENCLAW_BUNDLED_PLUGINS_DIR",
+        path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "extensions"),
+      );
+    } else if (live) {
+      stageLiveTestState({ env: liveEnvSnapshot, realHome, tempHome });
+    }
+
+    return {
+      tempHome,
+      cleanup: () => {
+        restoreEnv(restore);
+        removeHome();
+      },
+    };
+  } catch (error) {
+    // Successful live setup keeps profile additions; failed setup restores the caller exactly.
+    rollback.restore();
+    removeHome();
+    throw error;
+  }
 }
 
 export function withIsolatedTestHome(options?: InstallTestEnvOptions): {


### PR DESCRIPTION
Related: https://github.com/openclaw/openclaw/pull/132208 (parent-run temporary namespace cleanup).

## What Problem This Solves

Resolves a problem where failed test-home setup leaves temporary directories and changed process environment behind in a still-running test worker. Reserved home-key rejection, an environment callback throwing, partial directory creation, or live-test fixture staging can fail before the caller receives a cleanup handle, contaminating later tests.

## Why This Change Was Made

Acquisition rollback belongs to the helper that allocates the home and mutates the environment. `withTempHomeCore` now validates reserved keys before allocation and includes case initialization in its existing cleanup boundary, replacing duplicate environment restoration with `captureEnv`. `installTestEnv` owns allocation and failure rollback, including restoring the exact pre-profile environment.

Successful behavior remains unchanged: requested home retention applies after the test body starts, session cleanup can still be skipped, successful live-aware setup retains profile additions, and explicit real-home mode keeps its existing contract. Parent-run namespace deletion in #132208 is a distinct lifecycle fix; it cannot restore environment in a worker that continues running. This PR does not duplicate that runner work.

## User Impact

No product-runtime, configuration, schema, or operator Gateway behavior changes. Developers get isolated subsequent tests after setup failure, without deleting caller-owned directories. This is a bounded maintainer-requested internal harness repair, AI-assisted with Codex; the implementation and evidence were inspected directly.

## Evidence

Before repair, the same synthetic-fixture regressions failed at the intended boundaries: four reserved-key cases allocated directories, two throwing callback cases leaked environment/home state (including a retention request), two partial-directory cases leaked their case tree, and two staging failures leaked profile/environment/home state. The tests also prove same-process recovery and preserve caller-owned files, successful profile loading, and body-failure retention.

After a patch-identical rebase, the following command passed all 47 tests across seven files and five routed Vitest shards:

```sh
node scripts/run-vitest.mjs src/test-utils/temp-home.test.ts test/test-env.test.ts test/test-env.state-lifetime.test.ts test/setup-home-isolation.test.ts src/test-utils/env.test.ts src/test-utils/session-state-cleanup.test.ts src/agents/mcp-config-mutation.test.ts
```

Every local proof uses a fresh synthetic HOME, state/config/temp roots, separate caches, and an allowlisted child environment. The staging tests use synthetic profiles and fixtures; no operator home, real credentials, or Gateway was used. Direct native filesystem and process-environment behavior is the relevant proof for these test-support APIs; remote provider/channel proof is not applicable.

Normal commit formatting and `git diff --check` passed. Independent Codex autoreview completed scoped-clean with no findings at the helper's default P0 threshold. Rebase equivalence was verified with stable patch-id and `git range-diff`.

LOC: product runtime +0/-0; test support +81/-120 (net -39); tests +249/-2 (net +247). No generated files, dependency changes, or runner changes.

Separate follow-ups remain for sibling factory acquisition failures and rejected reusable-prefix allocation. They are intentionally outside this repair.

The full changed-file gate passed on an unchanged retry, including format, SDK, dependency, architecture, Knip, types, lint, and storage/security guards. The first full attempt hit the built-in 600-second Knip timeout; no timeout/skip setting or source was changed to pass the retry. A preliminary invocation also needed the scratch driver to include the installed corepack directory in its restricted PATH.

```sh
node scripts/check-changed.mjs -- src/plugin-sdk/test-helpers/temp-home.ts src/test-utils/temp-home.test.ts test/test-env.ts test/test-env.test.ts
```

[Exact-head CI run 33225955123](https://github.com/openclaw/openclaw/actions/runs/33225955123) passed (165 successful jobs, 18 intentionally skipped), including [openclaw/ci-gate](https://github.com/openclaw/openclaw/actions/runs/33225955123/job/99030608428). ClawSweeper found no correctness/security finding; its sole rank-up move to finish exact-head CI is satisfied.
