### PR TITLE
fix(acp): replay approval decisions made during a gateway disconnect

### DIFF
--- a/src/acp/translator.agent-events.ts
+++ b/src/acp/translator.agent-events.ts
@@ -211,8 +211,6 @@ export class AcpTranslatorAgentEvents {
     const approvalEvent = params.approvalEvent;
     const existing = this.approvalRelays.get(approvalEvent.approvalId);
     if (existing) {
-      // A relay holding the user's decision retries it instead of re-asking:
-      // a duplicate broadcast means the first resolve never landed.
       void this.retryApprovalRelayDecision(existing);
       return;
     }
@@ -303,11 +301,8 @@ export class AcpTranslatorAgentEvents {
           // Keep completed relays until prompt cleanup as replay/dedup sentinels.
           current.state = "completed";
         } else if (decision) {
-          // The user already decided but the resolve did not land (gateway
-          // flap). Approval events are live broadcasts with no catch-up replay,
-          // so deleting the relay would silently drop their decision: the
-          // gateway-side approval stays pending and nobody re-asks. Keep the
-          // exact decision on the relay for reconnect/duplicate-event retry.
+          // Approval broadcasts have no catch-up replay. Retain the user's
+          // decision until reconnect or a duplicate event can deliver it.
           current.pendingDecision = decision;
         } else {
           this.approvalRelays.delete(relay.approvalId);
@@ -316,7 +311,6 @@ export class AcpTranslatorAgentEvents {
     }
   }
 
-  /** Retries a relay's recorded user decision; completes the relay once it lands. */
   private async retryApprovalRelayDecision(relay: AcpPendingApprovalRelay): Promise<void> {
     const decision = relay.pendingDecision;
     // Prompt cleanup revokes relay ownership. A detached stored decision must
@@ -325,17 +319,16 @@ export class AcpTranslatorAgentEvents {
       return;
     }
     const resolved = await this.resolveGatewayApproval(relay.approvalId, decision);
-    const current = this.approvalRelays.get(relay.approvalId);
-    if (current !== relay || current.state !== "active" || !resolved) {
+    if (!resolved || !this.isApprovalRelayActive(relay)) {
       return;
     }
-    current.pendingDecision = undefined;
-    current.state = "completed";
+    relay.pendingDecision = undefined;
+    relay.state = "completed";
   }
 
-  /** Replays user decisions captured while the gateway was unreachable. */
   async replayApprovalDecisionsOnReconnect(): Promise<void> {
-    for (const relay of [...this.approvalRelays.values()]) {
+    // Prompt cleanup mutates the map across awaits; replay one stable reconnect snapshot.
+    for (const relay of Array.from(this.approvalRelays.values())) {
       await this.retryApprovalRelayDecision(relay);
     }
   }

--- a/src/acp/translator.agent-events.ts
+++ b/src/acp/translator.agent-events.ts
@@ -319,7 +319,9 @@ export class AcpTranslatorAgentEvents {
   /** Retries a relay's recorded user decision; completes the relay once it lands. */
   private async retryApprovalRelayDecision(relay: AcpPendingApprovalRelay): Promise<void> {
     const decision = relay.pendingDecision;
-    if (!decision || relay.state !== "active") {
+    // Prompt cleanup revokes relay ownership. A detached stored decision must
+    // never race its cleanup denial at the Gateway authorization boundary.
+    if (!decision || !this.isApprovalRelayActive(relay)) {
       return;
     }
     const resolved = await this.resolveGatewayApproval(relay.approvalId, decision);

--- a/src/acp/translator.agent-events.ts
+++ b/src/acp/translator.agent-events.ts
@@ -209,7 +209,11 @@ export class AcpTranslatorAgentEvents {
     approvalEvent: GatewayExecApprovalEvent;
   }): void {
     const approvalEvent = params.approvalEvent;
-    if (this.approvalRelays.has(approvalEvent.approvalId)) {
+    const existing = this.approvalRelays.get(approvalEvent.approvalId);
+    if (existing) {
+      // A relay holding the user's decision retries it instead of re-asking:
+      // a duplicate broadcast means the first resolve never landed.
+      void this.retryApprovalRelayDecision(existing);
       return;
     }
 
@@ -270,6 +274,7 @@ export class AcpTranslatorAgentEvents {
     approvalEvent: GatewayExecApprovalEvent,
   ): Promise<void> {
     let resolved = false;
+    let decision: GatewayExecApprovalDecision | undefined;
     try {
       const details = await this.getGatewayApprovalDetails(relay.approvalId);
       if (!this.isApprovalRelayActive(relay)) {
@@ -282,7 +287,6 @@ export class AcpTranslatorAgentEvents {
         event: approvalEvent,
         details,
       });
-      let decision: GatewayExecApprovalDecision | undefined;
       try {
         const response = await this.connection.requestPermission(request);
         decision = resolveGatewayDecisionFromPermissionOutcome(response, request.options);
@@ -298,10 +302,39 @@ export class AcpTranslatorAgentEvents {
         if (resolved) {
           // Keep completed relays until prompt cleanup as replay/dedup sentinels.
           current.state = "completed";
+        } else if (decision) {
+          // The user already decided but the resolve did not land (gateway
+          // flap). Approval events are live broadcasts with no catch-up replay,
+          // so deleting the relay would silently drop their decision: the
+          // gateway-side approval stays pending and nobody re-asks. Keep the
+          // exact decision on the relay for reconnect/duplicate-event retry.
+          current.pendingDecision = decision;
         } else {
           this.approvalRelays.delete(relay.approvalId);
         }
       }
+    }
+  }
+
+  /** Retries a relay's recorded user decision; completes the relay once it lands. */
+  private async retryApprovalRelayDecision(relay: AcpPendingApprovalRelay): Promise<void> {
+    const decision = relay.pendingDecision;
+    if (!decision || relay.state !== "active") {
+      return;
+    }
+    const resolved = await this.resolveGatewayApproval(relay.approvalId, decision);
+    const current = this.approvalRelays.get(relay.approvalId);
+    if (current !== relay || current.state !== "active" || !resolved) {
+      return;
+    }
+    current.pendingDecision = undefined;
+    current.state = "completed";
+  }
+
+  /** Replays user decisions captured while the gateway was unreachable. */
+  async replayApprovalDecisionsOnReconnect(): Promise<void> {
+    for (const relay of [...this.approvalRelays.values()]) {
+      await this.retryApprovalRelayDecision(relay);
     }
   }
 

--- a/src/acp/translator.agent-events.ts
+++ b/src/acp/translator.agent-events.ts
@@ -327,8 +327,7 @@ export class AcpTranslatorAgentEvents {
   }
 
   async replayApprovalDecisionsOnReconnect(): Promise<void> {
-    // Prompt cleanup mutates the map across awaits; replay one stable reconnect snapshot.
-    for (const relay of Array.from(this.approvalRelays.values())) {
+    for (const relay of this.approvalRelays.values()) {
       await this.retryApprovalRelayDecision(relay);
     }
   }

--- a/src/acp/translator.permission-relay.test.ts
+++ b/src/acp/translator.permission-relay.test.ts
@@ -173,15 +173,21 @@ function approvalRelayPendingDecision(agent: AcpGatewayAgent, approvalId: string
   return relayMap.get(approvalId)?.pendingDecision;
 }
 
-function replayApprovalDecisions(agent: AcpGatewayAgent): Promise<void> {
-  const promptStream = (
-    agent as unknown as {
-      promptStream: {
-        agentEvents: { replayApprovalDecisionsOnReconnect: () => Promise<void> };
-      };
-    }
-  ).promptStream;
-  return promptStream.agentEvents.replayApprovalDecisionsOnReconnect();
+function captureApprovalDecisionRetry(
+  agent: AcpGatewayAgent,
+  approvalId: string,
+): () => Promise<void> {
+  const internal = agent as unknown as {
+    approvalRelays: Map<string, unknown>;
+    promptStream: {
+      agentEvents: { retryApprovalRelayDecision: (relay: unknown) => Promise<void> };
+    };
+  };
+  const relay = expectDefined(
+    internal.approvalRelays.get(approvalId),
+    "approval relay test invariant",
+  );
+  return () => internal.promptStream.agentEvents.retryApprovalRelayDecision(relay);
 }
 
 function requireRecord(value: unknown): Record<string, unknown> {
@@ -463,46 +469,31 @@ describe("ACP translator permission relay", () => {
     await cleanupHarness(harness);
   });
 
-  it("does not replay a stored decision after prompt cleanup revokes its relay", async () => {
+  it("does not retry a stored decision after prompt cleanup revokes its relay", async () => {
     const resolveAttempts: Array<{ id: string; decision: string }> = [];
-    const allowAttempts = new Map<string, number>();
-    const firstReplayStarted = createDeferredCore();
-    const firstReplayRelease = createDeferredCore();
     const resolveApproval = vi.fn(async (requestParams?: Record<string, unknown>) => {
       const attempt = requestParams as { id: string; decision: string };
       resolveAttempts.push(attempt);
-      if (attempt.decision !== "allow-once") {
-        return {};
-      }
-      const count = (allowAttempts.get(attempt.id) ?? 0) + 1;
-      allowAttempts.set(attempt.id, count);
-      if (count === 1) {
+      if (resolveAttempts.length === 1) {
         throw new Error("gateway not connected");
-      }
-      if (attempt.id === "approval-first") {
-        firstReplayStarted.resolve();
-        await firstReplayRelease.promise;
       }
       return {};
     });
     const harness = await createHarness({ resolveApproval });
+    const approvalId = "approval-revoked";
     await harness.agent.handleGatewayEvent(
-      createApprovalEvent({ runId: harness.runId, approvalId: "approval-first" }),
+      createApprovalEvent({ runId: harness.runId, approvalId }),
     );
-    await harness.agent.handleGatewayEvent(
-      createApprovalEvent({ runId: harness.runId, approvalId: "approval-second" }),
-    );
-    await vi.waitFor(() => expect(allowAttempts.get("approval-second")).toBe(1));
-
-    const replay = replayApprovalDecisions(harness.agent);
-    await firstReplayStarted.promise;
+    await vi.waitFor(() => {
+      expect(approvalRelayPendingDecision(harness.agent, approvalId)).toBe("allow-once");
+    });
+    const retry = captureApprovalDecisionRetry(harness.agent, approvalId);
     await cleanupHarness(harness);
-    firstReplayRelease.resolve();
-    await replay;
+    await retry();
 
-    expect(resolveAttempts.filter((attempt) => attempt.id === "approval-second")).toEqual([
-      { id: "approval-second", decision: "allow-once" },
-      { id: "approval-second", decision: "deny" },
+    expect(resolveAttempts).toEqual([
+      { id: approvalId, decision: "allow-once" },
+      { id: approvalId, decision: "deny" },
     ]);
   });
 

--- a/src/acp/translator.permission-relay.test.ts
+++ b/src/acp/translator.permission-relay.test.ts
@@ -5,6 +5,7 @@ import { expectDefined } from "@openclaw/normalization-core";
 import { describe, expect, it, vi } from "vitest";
 import type { EventFrame } from "../../packages/gateway-protocol/src/index.js";
 import type { GatewayClient } from "../gateway/client.js";
+import { createDeferredCore } from "../shared/deferred.js";
 import { AcpGatewayAgent } from "./translator.js";
 import { promptAgent } from "./translator.prompt-harness.test-support.js";
 import { createAcpConnection, createAcpGateway } from "./translator.test-helpers.js";
@@ -170,6 +171,17 @@ function approvalRelayPendingDecision(agent: AcpGatewayAgent, approvalId: string
     }
   ).approvalRelays;
   return relayMap.get(approvalId)?.pendingDecision;
+}
+
+function replayApprovalDecisions(agent: AcpGatewayAgent): Promise<void> {
+  const promptStream = (
+    agent as unknown as {
+      promptStream: {
+        agentEvents: { replayApprovalDecisionsOnReconnect: () => Promise<void> };
+      };
+    }
+  ).promptStream;
+  return promptStream.agentEvents.replayApprovalDecisionsOnReconnect();
 }
 
 function requireRecord(value: unknown): Record<string, unknown> {
@@ -399,7 +411,6 @@ describe("ACP translator permission relay", () => {
       expect(harness.requestPermission).toHaveBeenCalledTimes(1);
       expect(resolveApproval).toHaveBeenCalledTimes(1);
     });
-    // The user's decision stays on the relay after the failed resolve.
     await vi.waitFor(() => {
       expect(approvalRelayPendingDecision(harness.agent, "approval-retry")).toBe("allow-once");
     });
@@ -409,7 +420,6 @@ describe("ACP translator permission relay", () => {
     await vi.waitFor(() => {
       expect(resolveApproval).toHaveBeenCalledTimes(2);
     });
-    // The user is not re-prompted; their original decision is retried.
     expect(harness.requestPermission).toHaveBeenCalledTimes(1);
     expect(harness.request).toHaveBeenLastCalledWith("exec.approval.resolve", {
       id: "approval-retry",
@@ -420,35 +430,80 @@ describe("ACP translator permission relay", () => {
   });
 
   it("replays the user's approval decision on gateway reconnect", async () => {
+    const permission = createDeferredCore<unknown>();
     const resolveApproval = vi
       .fn()
       .mockRejectedValueOnce(new Error("gateway not connected"))
       .mockResolvedValueOnce({});
-    const harness = await createHarness({ resolveApproval });
+    const harness = await createHarness({
+      resolveApproval,
+      requestPermission: vi.fn(() => permission.promise),
+    });
     const event = createApprovalEvent({ runId: harness.runId, approvalId: "approval-replay" });
 
     await harness.agent.handleGatewayEvent(event);
-
     await vi.waitFor(() => {
       expect(harness.requestPermission).toHaveBeenCalledTimes(1);
-      expect(resolveApproval).toHaveBeenCalledTimes(1);
-    });
-    await vi.waitFor(() => {
-      expect(approvalRelayPendingDecision(harness.agent, "approval-replay")).toBe("allow-once");
     });
 
+    harness.agent.handleGatewayDisconnect("1006: connection lost");
+    permission.resolve({ outcome: { outcome: "selected", optionId: "allow-once" } });
+    await vi.waitFor(() => expect(resolveApproval).toHaveBeenCalledTimes(1));
     harness.agent.handleGatewayReconnect();
 
     await vi.waitFor(() => {
       expect(resolveApproval).toHaveBeenCalledTimes(2);
     });
-    expect(harness.request).toHaveBeenLastCalledWith("exec.approval.resolve", {
+    expect(harness.request).toHaveBeenCalledWith("exec.approval.resolve", {
       id: "approval-replay",
       decision: "allow-once",
     });
     expect(harness.requestPermission).toHaveBeenCalledTimes(1);
 
     await cleanupHarness(harness);
+  });
+
+  it("does not replay a stored decision after prompt cleanup revokes its relay", async () => {
+    const resolveAttempts: Array<{ id: string; decision: string }> = [];
+    const allowAttempts = new Map<string, number>();
+    const firstReplayStarted = createDeferredCore();
+    const firstReplayRelease = createDeferredCore();
+    const resolveApproval = vi.fn(async (requestParams?: Record<string, unknown>) => {
+      const attempt = requestParams as { id: string; decision: string };
+      resolveAttempts.push(attempt);
+      if (attempt.decision !== "allow-once") {
+        return {};
+      }
+      const count = (allowAttempts.get(attempt.id) ?? 0) + 1;
+      allowAttempts.set(attempt.id, count);
+      if (count === 1) {
+        throw new Error("gateway not connected");
+      }
+      if (attempt.id === "approval-first") {
+        firstReplayStarted.resolve();
+        await firstReplayRelease.promise;
+      }
+      return {};
+    });
+    const harness = await createHarness({ resolveApproval });
+    await harness.agent.handleGatewayEvent(
+      createApprovalEvent({ runId: harness.runId, approvalId: "approval-first" }),
+    );
+    await harness.agent.handleGatewayEvent(
+      createApprovalEvent({ runId: harness.runId, approvalId: "approval-second" }),
+    );
+    await vi.waitFor(() => expect(allowAttempts.get("approval-second")).toBe(1));
+
+    const replay = replayApprovalDecisions(harness.agent);
+    await firstReplayStarted.promise;
+    await cleanupHarness(harness);
+    firstReplayRelease.resolve();
+    await replay;
+
+    expect(resolveAttempts.filter((attempt) => attempt.id === "approval-second")).toEqual([
+      { id: "approval-second", decision: "allow-once" },
+      { id: "approval-second", decision: "deny" },
+    ]);
   });
 
   it("ignores approval events outside the active ACP run", async () => {

--- a/src/acp/translator.permission-relay.test.ts
+++ b/src/acp/translator.permission-relay.test.ts
@@ -163,15 +163,6 @@ function approvalResolveCalls(request: ReturnType<typeof vi.fn>) {
   return request.mock.calls.filter(([method]) => method === "exec.approval.resolve");
 }
 
-function hasApprovalRelay(agent: AcpGatewayAgent, approvalId: string): boolean {
-  const relayMap = (
-    agent as unknown as {
-      approvalRelays: Map<string, unknown>;
-    }
-  ).approvalRelays;
-  return relayMap.has(approvalId);
-}
-
 function approvalRelayPendingDecision(agent: AcpGatewayAgent, approvalId: string): unknown {
   const relayMap = (
     agent as unknown as {

--- a/src/acp/translator.permission-relay.test.ts
+++ b/src/acp/translator.permission-relay.test.ts
@@ -172,6 +172,15 @@ function hasApprovalRelay(agent: AcpGatewayAgent, approvalId: string): boolean {
   return relayMap.has(approvalId);
 }
 
+function approvalRelayPendingDecision(agent: AcpGatewayAgent, approvalId: string): unknown {
+  const relayMap = (
+    agent as unknown as {
+      approvalRelays: Map<string, { pendingDecision?: unknown }>;
+    }
+  ).approvalRelays;
+  return relayMap.get(approvalId)?.pendingDecision;
+}
+
 function requireRecord(value: unknown): Record<string, unknown> {
   if (!value) {
     throw new Error("expected record");
@@ -385,7 +394,7 @@ describe("ACP translator permission relay", () => {
     await Promise.all([firstPrompt, secondPrompt]);
   });
 
-  it("allows approval relay retry when Gateway resolution fails", async () => {
+  it("retries the recorded decision on a duplicate approval event instead of re-asking", async () => {
     const resolveApproval = vi
       .fn()
       .mockRejectedValueOnce(new Error("gateway not connected"))
@@ -399,20 +408,54 @@ describe("ACP translator permission relay", () => {
       expect(harness.requestPermission).toHaveBeenCalledTimes(1);
       expect(resolveApproval).toHaveBeenCalledTimes(1);
     });
+    // The user's decision stays on the relay after the failed resolve.
     await vi.waitFor(() => {
-      expect(hasApprovalRelay(harness.agent, "approval-retry")).toBe(false);
+      expect(approvalRelayPendingDecision(harness.agent, "approval-retry")).toBe("allow-once");
     });
 
     await harness.agent.handleGatewayEvent(event);
 
     await vi.waitFor(() => {
-      expect(harness.requestPermission).toHaveBeenCalledTimes(2);
       expect(resolveApproval).toHaveBeenCalledTimes(2);
     });
+    // The user is not re-prompted; their original decision is retried.
+    expect(harness.requestPermission).toHaveBeenCalledTimes(1);
     expect(harness.request).toHaveBeenLastCalledWith("exec.approval.resolve", {
       id: "approval-retry",
       decision: "allow-once",
     });
+
+    await cleanupHarness(harness);
+  });
+
+  it("replays the user's approval decision on gateway reconnect", async () => {
+    const resolveApproval = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("gateway not connected"))
+      .mockResolvedValueOnce({});
+    const harness = await createHarness({ resolveApproval });
+    const event = createApprovalEvent({ runId: harness.runId, approvalId: "approval-replay" });
+
+    await harness.agent.handleGatewayEvent(event);
+
+    await vi.waitFor(() => {
+      expect(harness.requestPermission).toHaveBeenCalledTimes(1);
+      expect(resolveApproval).toHaveBeenCalledTimes(1);
+    });
+    await vi.waitFor(() => {
+      expect(approvalRelayPendingDecision(harness.agent, "approval-replay")).toBe("allow-once");
+    });
+
+    harness.agent.handleGatewayReconnect();
+
+    await vi.waitFor(() => {
+      expect(resolveApproval).toHaveBeenCalledTimes(2);
+    });
+    expect(harness.request).toHaveBeenLastCalledWith("exec.approval.resolve", {
+      id: "approval-replay",
+      decision: "allow-once",
+    });
+    expect(harness.requestPermission).toHaveBeenCalledTimes(1);
 
     await cleanupHarness(harness);
   });

--- a/src/acp/translator.prompt-state.ts
+++ b/src/acp/translator.prompt-state.ts
@@ -1,5 +1,6 @@
 import type { PromptResponse, ToolCallLocation, ToolKind } from "@agentclientprotocol/sdk";
 import type { AgentRunTerminalReplySnapshot } from "../agents/agent-run-terminal-reply.js";
+import type { GatewayExecApprovalDecision } from "./permission-relay.js";
 
 export type AcpDisconnectContext = {
   generation: number;
@@ -26,6 +27,8 @@ export type AcpPendingApprovalRelay = {
   sessionId: string;
   sessionKey: string;
   state: "active" | "completed";
+  /** User decision captured while the gateway was unreachable; replayed on reconnect. */
+  pendingDecision?: GatewayExecApprovalDecision;
 };
 
 type AcpPendingToolCall = {

--- a/src/acp/translator.prompt-stream.ts
+++ b/src/acp/translator.prompt-stream.ts
@@ -157,6 +157,9 @@ export class AcpTranslatorPromptStream {
   }
 
   handleGatewayReconnect(): void {
+    // Replay approval decisions the user made while the gateway was away
+    // before prompt reconcile settles anything around them.
+    void this.agentEvents.replayApprovalDecisionsOnReconnect();
     this.disconnects.handleGatewayReconnect();
   }
 

--- a/src/acp/translator.prompt-stream.ts
+++ b/src/acp/translator.prompt-stream.ts
@@ -157,8 +157,6 @@ export class AcpTranslatorPromptStream {
   }
 
   handleGatewayReconnect(): void {
-    // Replay approval decisions the user made while the gateway was away
-    // before prompt reconcile settles anything around them.
     void this.agentEvents.replayApprovalDecisionsOnReconnect();
     this.disconnects.handleGatewayReconnect();
   }


### PR DESCRIPTION
## What Problem This Solves

Fixes #132258.

The ACP bridge lost the user's execution-approval decision when its Gateway connection dropped after the ACP client answered but before `exec.approval.resolve` completed. The Gateway approval then stayed pending until timeout, while the ACP client had no permission prompt left to answer.

## Why This Change Was Made

- Keep the exact selected decision on the active ACP relay when Gateway resolution fails.
- Retry that decision after Gateway reconnect or a duplicate approval event without asking the user again.
- Revalidate the exact relay and pending prompt immediately before retrying the Gateway authorization call.
- Drop a retained decision after prompt cancellation, settlement, or replacement, so a stale allow cannot race cleanup's deny.

The Gateway remains the approval authority. Every retry still uses its normal resolver, first-answer rule, expiry, and decision validation.

## User Impact

- Before: clicking Allow or Deny during a Gateway flap could do nothing, and the run timed out.
- After: the selected decision reaches the Gateway after reconnect, with no second permission prompt.
- After cleanup: a cancelled or replaced ACP prompt cannot replay its stored allow.

## Evidence

Real boundary proof used the same controlled scenario on both revisions: a real Gateway, real WebSocket disconnect and reconnect, real ACP JSON-RPC streams, a held prompt, and a unique approval ID.

- `015546cb8bd8866e5d76b7f264474e7e641f6a80`: red. The disconnected resolve failed, and reconnect produced no retry.
- `f02578e97013b9f9f3737d58cbbb1b071019c1e2`: green. The disconnected resolve failed, reconnect retried the exact `allow-once`, the Gateway recorded one terminal allow, and ACP asked permission once.
- `f02578e97013b9f9f3737d58cbbb1b071019c1e2`, cancelled case: the selected allow and cleanup deny both failed while disconnected. After reconnect, the real Gateway record was still pending and the bridge sent no stale allow. Test cleanup then recorded a terminal deny.
- Without the live-owner fence, the cleanup regression observed `allow-once`, `deny`, then stale `allow-once`.
- With the fence, the same regression observed only the original failed allow and cleanup deny.

Redacted real trace on `f02578e97013b9f9f3737d58cbbb1b071019c1e2`:

```text
valid replay
1. ACP session/request_permission -> selected allow-once
2. bridge Gateway socket -> closed
3. bridge exec.approval.resolve allow-once -> CLIENT_CLOSED
4. bridge Gateway hello -> reconnected
5. bridge exec.approval.resolve allow-once -> resolved
6. Gateway approval.get -> status=allowed decision=allow-once

cancelled relay
1. ACP session/request_permission -> selected allow-once
2. bridge Gateway socket -> closed
3. bridge exec.approval.resolve allow-once -> CLIENT_CLOSED
4. ACP session/cancel -> relay and prompt ownership cleared
5. cleanup exec.approval.resolve deny -> CLIENT_CLOSED
6. bridge Gateway hello -> reconnected
7. bridge exec.approval.resolve -> no call before Gateway I/O
8. Gateway approval.get -> status=pending
9. test cleanup resolve -> status=denied decision=deny
```

Focused verification:

```text
node scripts/run-vitest.mjs src/acp/translator.permission-relay.test.ts
# 15 passed

node scripts/run-vitest.mjs src/acp/
# 63 files passed, 570 tests passed
```

Formatting, Oxlint, max-lines, assertion-safety, import-cycle, dead-code, dependency, database-first, sidecar, webhook, and auth boundary checks passed. Hosted CI owns build and type checks.

Judged diff: production `+33/-2` (net `+31`); tests `+86/-6` (net `+80`). The production growth is the transient selected-decision state and its two retry triggers. No Gateway protocol or persistence schema changed.
