### PR TITLE
test: bind release assertions to explicit version contexts

### DIFF
--- a/src/auto-reply/reply/commands-plugins.install.test.ts
+++ b/src/auto-reply/reply/commands-plugins.install.test.ts
@@ -10,6 +10,15 @@ import { createCommandWorkspaceHarness } from "./commands-filesystem.test-suppor
 import { handlePluginsCommand } from "./commands-plugins.js";
 import { buildPluginsCommandParams } from "./commands.test-harness.js";
 
+// Default-selector assertions describe a stable build; beta cases set their own identity.
+const coreVersion = vi.hoisted(() => ({ value: "2026.8.1" }));
+vi.mock("../../version.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../version.js")>()),
+  get VERSION() {
+    return coreVersion.value;
+  },
+}));
+
 const {
   installPluginFromNpmPackArchiveMock,
   installPluginFromNpmSpecMock,
@@ -61,6 +70,18 @@ vi.mock("../../plugins/install-persistence.js", async (importOriginal) => ({
 }));
 
 const workspaceHarness = createCommandWorkspaceHarness("openclaw-command-plugins-install-");
+
+function mockNpmPluginInstall(pluginId: string, packageName: string, version = "1.0.0"): void {
+  installPluginFromNpmSpecMock.mockResolvedValue({
+    ok: true,
+    pluginId,
+    targetDir: `/tmp/${pluginId}`,
+    version,
+    extensions: ["index.js"],
+    npmResolution: { name: packageName, version, resolvedSpec: `${packageName}@${version}` },
+  });
+  persistPluginInstallMock.mockResolvedValue({});
+}
 
 function buildPluginsParams(
   commandBodyNormalized: string,
@@ -126,6 +147,7 @@ function expectNonClawHubChatInstallRejected(
 
 describe("handleCommands /plugins install", () => {
   afterEach(async () => {
+    coreVersion.value = "2026.8.1";
     installPluginFromNpmPackArchiveMock.mockReset();
     installPluginFromNpmSpecMock.mockReset();
     installPluginFromPathMock.mockReset();
@@ -167,19 +189,7 @@ describe("handleCommands /plugins install", () => {
         },
       },
     };
-    installPluginFromNpmSpecMock.mockResolvedValue({
-      ok: true,
-      pluginId: "policy-plugin",
-      targetDir: "/tmp/policy-plugin",
-      version: "1.0.0",
-      extensions: ["index.js"],
-      npmResolution: {
-        name: "@acme/policy-plugin",
-        version: "1.0.0",
-        resolvedSpec: "@acme/policy-plugin@1.0.0",
-      },
-    });
-    persistPluginInstallMock.mockResolvedValue({});
+    mockNpmPluginInstall("policy-plugin", "@acme/policy-plugin");
 
     await withTempHome("openclaw-command-plugins-home-", async (home) => {
       await fs.writeFile(
@@ -222,7 +232,11 @@ describe("handleCommands /plugins install", () => {
     });
   });
 
-  it("allows npm packages matched by the official catalog", async () => {
+  it.each([
+    { version: "2026.8.1", installSpec: "@openclaw/brave-plugin" },
+    { version: "2026.8.1-beta.4", installSpec: "@openclaw/brave-plugin@beta" },
+  ])("allows official catalog npm installs on core $version", async ({ version, installSpec }) => {
+    coreVersion.value = version;
     const policyConfig: OpenClawConfig = {
       commands: { text: true, plugins: true },
       plugins: { enabled: true },
@@ -237,19 +251,7 @@ describe("handleCommands /plugins install", () => {
         },
       },
     };
-    installPluginFromNpmSpecMock.mockResolvedValue({
-      ok: true,
-      pluginId: "brave",
-      targetDir: "/tmp/brave",
-      version: "1.0.0",
-      extensions: ["index.js"],
-      npmResolution: {
-        name: "@openclaw/brave-plugin",
-        version: "1.0.0",
-        resolvedSpec: "@openclaw/brave-plugin@1.0.0",
-      },
-    });
-    persistPluginInstallMock.mockResolvedValue({});
+    mockNpmPluginInstall("brave", "@openclaw/brave-plugin");
 
     await withTempHome("openclaw-command-plugins-home-", async (home) => {
       await fs.writeFile(
@@ -267,7 +269,7 @@ describe("handleCommands /plugins install", () => {
 
       expect(result?.reply?.text).toContain('Installed plugin "brave"');
       expectObjectFields(mockFirstObjectArg(installPluginFromNpmSpecMock), {
-        spec: "@openclaw/brave-plugin",
+        spec: installSpec,
         config: {
           ...policyConfig,
           agents: { entries: { main: {} } },
@@ -284,20 +286,12 @@ describe("handleCommands /plugins install", () => {
     });
   });
 
-  it("allows npm packages matched by a bundled plugin manifest", async () => {
-    installPluginFromNpmSpecMock.mockResolvedValue({
-      ok: true,
-      pluginId: "discord",
-      targetDir: "/tmp/discord",
-      version: "1.0.0",
-      extensions: ["index.js"],
-      npmResolution: {
-        name: "@openclaw/discord",
-        version: "1.0.0",
-        resolvedSpec: "@openclaw/discord@1.0.0",
-      },
-    });
-    persistPluginInstallMock.mockResolvedValue({});
+  it.each([
+    { version: "2026.8.1", installSpec: "@openclaw/discord" },
+    { version: "2026.8.1-beta.4", installSpec: "@openclaw/discord@beta" },
+  ])("allows bundled-manifest npm installs on core $version", async ({ version, installSpec }) => {
+    coreVersion.value = version;
+    mockNpmPluginInstall("discord", "@openclaw/discord");
 
     await withTempHome("openclaw-command-plugins-home-", async () => {
       const workspaceDir = await workspaceHarness.createWorkspace();
@@ -310,7 +304,7 @@ describe("handleCommands /plugins install", () => {
 
       expect(result?.reply?.text).toContain('Installed plugin "discord"');
       expectObjectFields(mockFirstObjectArg(installPluginFromNpmSpecMock), {
-        spec: "@openclaw/discord",
+        spec: installSpec,
         expectedPluginId: "discord",
         trustedSourceLinkedOfficialInstall: true,
       });
@@ -346,19 +340,7 @@ describe("handleCommands /plugins install", () => {
   });
 
   it("allows plugin ids matched by the official catalog", async () => {
-    installPluginFromNpmSpecMock.mockResolvedValue({
-      ok: true,
-      pluginId: "wecom-openclaw-plugin",
-      targetDir: "/tmp/wecom-openclaw-plugin",
-      version: "2026.7.2",
-      extensions: ["index.js"],
-      npmResolution: {
-        name: "@wecom/wecom-openclaw-plugin",
-        version: "2026.7.2",
-        resolvedSpec: "@wecom/wecom-openclaw-plugin@2026.7.2",
-      },
-    });
-    persistPluginInstallMock.mockResolvedValue({});
+    mockNpmPluginInstall("wecom-openclaw-plugin", "@wecom/wecom-openclaw-plugin", "2026.7.2");
 
     await withTempHome("openclaw-command-plugins-home-", async () => {
       const workspaceDir = await workspaceHarness.createWorkspace();
@@ -1043,46 +1025,41 @@ describe("handleCommands /plugins install", () => {
     });
   });
 
-  it("allows catalog npm package chat installs with alternate selectors", async () => {
-    installPluginFromNpmSpecMock.mockResolvedValue({
-      ok: true,
-      pluginId: "wecom-openclaw-plugin",
-      targetDir: "/tmp/wecom-openclaw-plugin",
-      version: "2026.7.2",
-      extensions: ["index.js"],
-      npmResolution: {
-        name: "@wecom/wecom-openclaw-plugin",
-        version: "2026.7.2",
-        resolvedSpec: "@wecom/wecom-openclaw-plugin@2026.7.2",
-      },
-    });
-    persistPluginInstallMock.mockResolvedValue({});
+  it.each([
+    { version: "2026.8.1", installSpec: "@wecom/wecom-openclaw-plugin@latest" },
+    { version: "2026.8.1-beta.4", installSpec: "@wecom/wecom-openclaw-plugin@beta" },
+  ])(
+    "allows catalog npm @latest chat installs on core $version",
+    async ({ version, installSpec }) => {
+      coreVersion.value = version;
+      mockNpmPluginInstall("wecom-openclaw-plugin", "@wecom/wecom-openclaw-plugin", "2026.7.2");
 
-    await withTempHome("openclaw-command-plugins-home-", async () => {
-      const workspaceDir = await workspaceHarness.createWorkspace();
-      const params = buildPluginsParams(
-        "/plugins install @wecom/wecom-openclaw-plugin@latest --accept-capabilities",
-        workspaceDir,
-      );
-      const result = await handlePluginsCommand(params, true);
-      if (result === null) {
-        throw new Error("expected plugin install result");
-      }
-      expect(result.reply?.text).toContain('Installed plugin "wecom-openclaw-plugin"');
-      expectObjectFields(mockFirstObjectArg(installPluginFromNpmSpecMock), {
-        spec: "@wecom/wecom-openclaw-plugin@latest",
-        expectedPluginId: "wecom-openclaw-plugin",
-        expectedIntegrity: undefined,
-        trustedSourceLinkedOfficialInstall: true,
+      await withTempHome("openclaw-command-plugins-home-", async () => {
+        const workspaceDir = await workspaceHarness.createWorkspace();
+        const params = buildPluginsParams(
+          "/plugins install @wecom/wecom-openclaw-plugin@latest --accept-capabilities",
+          workspaceDir,
+        );
+        const result = await handlePluginsCommand(params, true);
+        if (result === null) {
+          throw new Error("expected plugin install result");
+        }
+        expect(result.reply?.text).toContain('Installed plugin "wecom-openclaw-plugin"');
+        expectObjectFields(mockFirstObjectArg(installPluginFromNpmSpecMock), {
+          spec: installSpec,
+          expectedPluginId: "wecom-openclaw-plugin",
+          expectedIntegrity: undefined,
+          trustedSourceLinkedOfficialInstall: true,
+        });
+        expectPersistedInstall("wecom-openclaw-plugin", {
+          source: "npm",
+          spec: "@wecom/wecom-openclaw-plugin@latest",
+          installPath: "/tmp/wecom-openclaw-plugin",
+          version: "2026.7.2",
+          resolvedName: "@wecom/wecom-openclaw-plugin",
+          resolvedVersion: "2026.7.2",
+        });
       });
-      expectPersistedInstall("wecom-openclaw-plugin", {
-        source: "npm",
-        spec: "@wecom/wecom-openclaw-plugin@latest",
-        installPath: "/tmp/wecom-openclaw-plugin",
-        version: "2026.7.2",
-        resolvedName: "@wecom/wecom-openclaw-plugin",
-        resolvedVersion: "2026.7.2",
-      });
-    });
-  });
+    },
+  );
 });

--- a/src/cli/plugins-cli.install.test.ts
+++ b/src/cli/plugins-cli.install.test.ts
@@ -46,6 +46,15 @@ import {
   writePersistedInstalledPluginIndexInstallRecordsWithLeaseMock,
 } from "./plugins-cli-test-helpers.js";
 
+// Default-selector assertions describe a stable build; beta cases set their own identity.
+const coreVersion = vi.hoisted(() => ({ value: "2026.8.1" }));
+vi.mock("../version.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../version.js")>()),
+  get VERSION() {
+    return coreVersion.value;
+  },
+}));
+
 const CLI_STATE_ROOT = "/tmp/openclaw-state";
 const ORIGINAL_OPENCLAW_STATE_DIR = process.env.OPENCLAW_STATE_DIR;
 const ORIGINAL_OPENCLAW_NIX_MODE = process.env.OPENCLAW_NIX_MODE;
@@ -624,6 +633,7 @@ describe("plugins cli install", () => {
   });
 
   afterEach(() => {
+    coreVersion.value = "2026.8.1";
     if (ORIGINAL_OPENCLAW_STATE_DIR === undefined) {
       delete process.env.OPENCLAW_STATE_DIR;
     } else {
@@ -1971,16 +1981,22 @@ describe("plugins cli install", () => {
     expect(configWriteMock).toHaveBeenCalledWith(enabledCfg);
   });
 
-  it.each([
-    { label: "plugin id", arg: "brave" },
-    { label: "npm package name", arg: "@openclaw/brave-plugin" },
-  ])(
-    "installs the beta artifact for an official plugin on a beta gateway by $label",
-    async ({ arg }) => {
+  it.each(
+    [
+      { version: "2026.8.1", channel: "beta" },
+      { version: "2026.8.1-beta.4", channel: undefined },
+      { version: "2026.8.1-beta.4", channel: "stable" },
+    ].flatMap(({ version, channel }) =>
+      ["brave", "@openclaw/brave-plugin"].map((arg) => ({ version, channel, arg })),
+    ),
+  )(
+    "installs beta for $arg on core $version with channel $channel",
+    async ({ version, channel, arg }) => {
+      coreVersion.value = version;
       primeSuccessfulPluginPersistence("brave");
       pluginCliConfigMock.mockReturnValue({
         ...createEmptyPluginConfig(),
-        update: { channel: "beta" },
+        ...(channel ? { update: { channel } } : {}),
       } as OpenClawConfig);
       findBundledPluginSourceMock.mockReturnValue(undefined);
       installPluginFromNpmSpecMock.mockResolvedValue(createNpmPluginInstallResult("brave"));
@@ -2020,6 +2036,7 @@ describe("plugins cli install", () => {
   });
 
   it("passes third-party external catalog integrity with catalog install trust", async () => {
+    coreVersion.value = "2026.8.1-beta.4";
     primeSuccessfulPluginPersistence("wecom-openclaw-plugin");
     findBundledPluginSourceMock.mockReturnValue(undefined);
     installPluginFromNpmSpecMock.mockResolvedValue(
@@ -2262,28 +2279,37 @@ describe("plugins cli install", () => {
     expect(runtimeLogsContain("npm:@openclaw/discord@2026.5.20")).toBe(true);
   });
 
-  it("marks catalog npm package installs with alternate selectors as trusted", async () => {
-    primeSuccessfulPluginPersistence("wecom-openclaw-plugin");
-    findBundledPluginSourceMock.mockReturnValue(undefined);
-    installPluginFromNpmSpecMock.mockResolvedValue(
-      createNpmPluginInstallResult("wecom-openclaw-plugin"),
-    );
+  it.each([
+    { version: "2026.8.1", selector: "latest", installSelector: "latest" },
+    { version: "2026.8.1-beta.4", selector: "latest", installSelector: "beta" },
+    { version: "2026.8.1-beta.4", selector: "next", installSelector: "next" },
+    { version: "2026.8.1-beta.4", selector: "2026.6.1", installSelector: "2026.6.1" },
+  ])(
+    "trusts catalog npm @$selector on core $version",
+    async ({ version, selector, installSelector }) => {
+      coreVersion.value = version;
+      primeSuccessfulPluginPersistence("wecom-openclaw-plugin");
+      findBundledPluginSourceMock.mockReturnValue(undefined);
+      installPluginFromNpmSpecMock.mockResolvedValue(
+        createNpmPluginInstallResult("wecom-openclaw-plugin"),
+      );
 
-    await runCapabilityAcceptedPluginsInstallCommand([
-      "plugins",
-      "install",
-      "@wecom/wecom-openclaw-plugin@latest",
-    ]);
+      await runCapabilityAcceptedPluginsInstallCommand([
+        "plugins",
+        "install",
+        `@wecom/wecom-openclaw-plugin@${selector}`,
+      ]);
 
-    // Alternate selectors stay trusted by catalog package name, but must not
-    // inherit catalog integrity unless the install spec matches exactly.
-    expect(npmInstallCall().spec).toBe("@wecom/wecom-openclaw-plugin@latest");
-    expect(npmInstallCall().expectedPluginId).toBe("wecom-openclaw-plugin");
-    expect(npmInstallCall().trustedSourceLinkedOfficialInstall).toBe(true);
-    expect(npmInstallCall().expectedIntegrity).toBeUndefined();
-    expect(runtimeLogsContain("outside ClawHub review")).toBe(false);
-    expect(installPluginFromClawHubMock).not.toHaveBeenCalled();
-  });
+      // Alternate selectors stay trusted by catalog package name, but must not
+      // inherit catalog integrity unless the install spec matches exactly.
+      expect(npmInstallCall().spec).toBe(`@wecom/wecom-openclaw-plugin@${installSelector}`);
+      expect(npmInstallCall().expectedPluginId).toBe("wecom-openclaw-plugin");
+      expect(npmInstallCall().trustedSourceLinkedOfficialInstall).toBe(true);
+      expect(npmInstallCall().expectedIntegrity).toBeUndefined();
+      expect(runtimeLogsContain("outside ClawHub review")).toBe(false);
+      expect(installPluginFromClawHubMock).not.toHaveBeenCalled();
+    },
+  );
 
   it("passes the active profile extensions dir to npm installs", async () => {
     const extensionsDir = useProfileExtensionsDir();

--- a/src/commands/onboarding-plugin-install.test.ts
+++ b/src/commands/onboarding-plugin-install.test.ts
@@ -1,24 +1,24 @@
 // Onboarding plugin install tests cover install sources, trust checks, and install records.
 import fs from "node:fs/promises";
 import path from "node:path";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { PluginInstallRecord as PersistedPluginInstallRecord } from "../config/types.plugins.js";
-import { resolveRegistryUpdateChannel } from "../infra/update-channels.js";
 import type { PluginEnableResult } from "../plugins/enable.js";
-import { resolveNpmInstallSpecsForUpdateChannel } from "../plugins/install-channel-specs.js";
 import type { PluginInstallArtifactConsentHandler } from "../plugins/install-types.js";
 import { createColdPluginFixture } from "../plugins/test-helpers/cold-plugin-fixtures.js";
 import { withTestDir } from "../test-helpers/temp-dir.js";
 import { VERSION } from "../version.js";
 import { WizardNavigationError } from "../wizard/prompts.js";
 
-function expectedNpmInstallSpec(spec: string): string {
-  return resolveNpmInstallSpecsForUpdateChannel({
-    spec,
-    updateChannel: resolveRegistryUpdateChannel({ currentVersion: VERSION }),
-  }).installSpec;
-}
+// Stable setup is the default fixture, independent of the checkout's release version.
+const coreVersion = vi.hoisted(() => ({ value: "2026.8.1" }));
+vi.mock("../version.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../version.js")>()),
+  get VERSION() {
+    return coreVersion.value;
+  },
+}));
 
 const resolveBundledInstallPlanForCatalogEntry = vi.hoisted(() =>
   vi.fn<(...args: unknown[]) => unknown>(() => undefined),
@@ -198,14 +198,19 @@ type PluginInstallRecord = Partial<PersistedPluginInstallRecord> & { pluginId?: 
 describe("ensureOnboardingPluginInstalled", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    delete process.env.OPENCLAW_ALLOW_PLUGIN_INSTALL_OVERRIDES;
-    delete process.env.OPENCLAW_PLUGIN_INSTALL_OVERRIDES;
+    vi.stubEnv("OPENCLAW_ALLOW_PLUGIN_INSTALL_OVERRIDES", undefined);
+    vi.stubEnv("OPENCLAW_PLUGIN_INSTALL_OVERRIDES", undefined);
     withTimeout.mockImplementation(async <T>(promise: Promise<T>) => await promise);
     prepareManagedPluginArtifactConsentHandler.mockResolvedValue({
       onBeforePluginArtifactCommit: async () => {},
       applyAcceptedSurface: (_pluginId, record) => record,
     });
     invalidatePluginRuntimeDiscoveryAfterConfigMutation.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    coreVersion.value = "2026.8.1";
+    vi.unstubAllEnvs();
   });
 
   it.each([
@@ -896,6 +901,7 @@ describe("ensureOnboardingPluginInstalled", () => {
   });
 
   it("installs trusted official plugins at the exact extended-stable core version", async () => {
+    coreVersion.value = "2026.7.33";
     installPluginFromNpmSpec.mockResolvedValueOnce({
       ok: true,
       pluginId: "discord",
@@ -977,46 +983,58 @@ describe("ensureOnboardingPluginInstalled", () => {
     );
   });
 
-  it("keeps version-bound official runtime plugins aligned with the stable core version", async () => {
-    installPluginFromNpmSpec.mockResolvedValueOnce({
-      ok: true,
-      pluginId: "codex",
-      targetDir: "/tmp/codex",
-      version: VERSION,
-      npmResolution: {
-        name: "@openclaw/codex",
-        version: VERSION,
-        resolvedSpec: `@openclaw/codex@${VERSION}`,
-      },
-    });
-
-    await ensureOnboardingPluginInstalled({
-      cfg: { update: { channel: "stable" } },
-      entry: {
+  it.each([
+    { version: "2026.8.1", channel: undefined, installVersion: "2026.8.1" },
+    { version: "2026.8.1", channel: "stable", installVersion: "2026.8.1" },
+    { version: "2026.8.1-2", channel: "stable", installVersion: "2026.8.1" },
+    { version: "2026.7.33-1", channel: "extended-stable", installVersion: "2026.7.33" },
+    { version: "2026.8.1", channel: "beta", installVersion: "beta" },
+    { version: "2026.8.1-beta.4", channel: undefined, installVersion: "beta" },
+    { version: "2026.8.1-beta.4", channel: "stable", installVersion: "beta" },
+  ] as const)(
+    "aligns version-bound plugins on core $version with channel $channel",
+    async ({ version, channel, installVersion }) => {
+      coreVersion.value = version;
+      installPluginFromNpmSpec.mockResolvedValueOnce({
+        ok: true,
         pluginId: "codex",
-        label: "Codex",
-        install: { npmSpec: "@openclaw/codex" },
-        trustedSourceLinkedOfficialInstall: true,
-        versionBoundToOpenClaw: true,
-      },
-      prompter: {
-        select: vi.fn(async () => "npm"),
-        progress: vi.fn(() => ({ update: vi.fn(), stop: vi.fn() })),
-      } as never,
-      runtime: {} as never,
-      promptInstall: false,
-    });
+        targetDir: "/tmp/codex",
+        version: VERSION,
+        npmResolution: {
+          name: "@openclaw/codex",
+          version: VERSION,
+          resolvedSpec: `@openclaw/codex@${VERSION}`,
+        },
+      });
 
-    const [npmCall] = readFirstMockCall(installPluginFromNpmSpec, "installPluginFromNpmSpec") as [
-      NpmSpecInstallCall,
-    ];
-    expect(npmCall.spec).toBe(`@openclaw/codex@${VERSION}`);
-    const [, recordUpdate] = readFirstMockCall(recordPluginInstall, "recordPluginInstall") as [
-      OpenClawConfig,
-      PluginInstallRecord,
-    ];
-    expect(recordUpdate.spec).toBe("@openclaw/codex");
-  });
+      await ensureOnboardingPluginInstalled({
+        cfg: channel ? { update: { channel } } : {},
+        entry: {
+          pluginId: "codex",
+          label: "Codex",
+          install: { npmSpec: "@openclaw/codex" },
+          trustedSourceLinkedOfficialInstall: true,
+          versionBoundToOpenClaw: true,
+        },
+        prompter: {
+          select: vi.fn(async () => "npm"),
+          progress: vi.fn(() => ({ update: vi.fn(), stop: vi.fn() })),
+        } as never,
+        runtime: {} as never,
+        promptInstall: false,
+      });
+
+      const [npmCall] = readFirstMockCall(installPluginFromNpmSpec, "installPluginFromNpmSpec") as [
+        NpmSpecInstallCall,
+      ];
+      expect(npmCall.spec).toBe(`@openclaw/codex@${installVersion}`);
+      const [, recordUpdate] = readFirstMockCall(recordPluginInstall, "recordPluginInstall") as [
+        OpenClawConfig,
+        PluginInstallRecord,
+      ];
+      expect(recordUpdate.spec).toBe("@openclaw/codex");
+    },
+  );
 
   it("logs npm install warnings once while shortening the progress label", async () => {
     const warning =
@@ -1175,7 +1193,7 @@ describe("ensureOnboardingPluginInstalled", () => {
     });
 
     expect(captured?.options).toEqual([
-      { value: "npm", label: `Download from npm (${expectedNpmInstallSpec("@demo/plugin")})` },
+      { value: "npm", label: "Download from npm (@demo/plugin)" },
       { value: "skip", label: "Skip for now" },
     ]);
     expect(captured?.initialValue).toBe("npm");

--- a/test/scripts/package-source-preflight.test.ts
+++ b/test/scripts/package-source-preflight.test.ts
@@ -1,4 +1,4 @@
-import { spawnSync } from "node:child_process";
+import { execFileSync, spawnSync } from "node:child_process";
 import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -325,16 +325,19 @@ function runReleaseInputCapture(params: {
 }
 
 describe("package source preflight", () => {
-  it("accepts aligned source manifests and the explicitly allowed Unreleased section", () => {
-    expect(
-      validatePackageSource({
-        aiManifestContent: aiManifest(),
-        allowUnreleasedChangelog: true,
-        changelogContent: changelog,
-        rootManifestContent: rootManifest(),
-      }),
-    ).toBe("2026.8.1");
-  });
+  it.each(["2026.8.1", "2026.8.1-beta.4", "2026.9.1"])(
+    "accepts aligned %s source manifests with Unreleased notes",
+    (version) => {
+      expect(
+        validatePackageSource({
+          aiManifestContent: aiManifest({ version }),
+          allowUnreleasedChangelog: true,
+          changelogContent: changelog,
+          rootManifestContent: rootManifest({ version }),
+        }),
+      ).toBe(version);
+    },
+  );
 
   it("uses canonical package changelog validation", () => {
     expect(() =>
@@ -438,16 +441,20 @@ describe("package source preflight", () => {
   });
 
   it("validates the current source ref without modifying the checkout", () => {
+    const committedManifest = JSON.parse(
+      execFileSync("git", ["show", "HEAD:package.json"], { encoding: "utf8" }),
+    ) as { version: string };
+    const workingManifest = JSON.parse(readFileSync("package.json", "utf8")) as { version: string };
     expect(
       validatePackageSourceRef("HEAD", {
         allowUnreleasedChangelog: true,
       }),
-    ).toBe("2026.8.1");
+    ).toBe(committedManifest.version);
     expect(
       validatePackageSourceDir(process.cwd(), {
         allowUnreleasedChangelog: true,
       }),
-    ).toBe("2026.8.1");
+    ).toBe(workingManifest.version);
   });
 
   it("normalizes release-check package mode and guards the source resolver", () => {


### PR DESCRIPTION
## What Problem This Solves

Resolves release verification failures where stable-only test expectations accidentally depended on the checkout's current version. Beta builds correctly select beta plugin packages, but the CLI, chat and onboarding fixtures still expected stable selectors. The package preflight fixture also hardcoded one version while asking Git to validate the actual source ref.

## Why This Change Was Made

Make each selector fixture's version context explicit, exercise stable and beta cases at the existing entry points, and compare source-ref and working-tree validation with their respective manifests. Consolidate repeated mocked install results without changing product selection or consent policy.

The original five-file release repair was adapted to current main: #132135 replaced the automatic-upgrade repair owner and its new startup-repair test already uses `VERSION`. That obsolete hunk is omitted here; the remaining four files preserve main's release-phase and candidate-artifact fixture changes.

## User Impact

No product behavior changes. Release verification tests now distinguish their intended stable/beta contracts from the version of the checkout running them. No package version, selector, dependency, configuration, workflow policy, assertion budget or publication changes.

## Evidence

The original beta-context failures were reproduced before repair. The retained release proof passed 308 affected tests and broader owner/sibling coverage. The initial five-file main port passed all 308 tests and the full changed-files gate in [clean Linux environment33224560502](https://github.com/openclaw/openclaw/actions/runs/33224560502).

The final four-file port on `ddf5b5a5882c44335e168f2a7a874c803663a4a6` passed 314 tests: all four affected suites (303 cases), plus all11 cases in main's replacement startup-repair suite. Formatting and diff checks passed; exact full tracked tree `a17aa857354d32c9a9b45b2b1322319094b013da` matched before/after. [Final clean Linux environment33226402690](https://github.com/openclaw/openclaw/actions/runs/33226402690), Node24.19.0/pnpm12.0.0, canonical frozen install; command1m53.104s/exit0. Both Testboxes were stopped. The wrapper receipt is the command result; stopping the lease may mark its environment Actions run cancelled.

Fresh isolated complete-delta Codex autoreview found no actionable P0 findings. [Exact head417ce856 CI33226728664](https://github.com/openclaw/openclaw/actions/runs/33226728664) is green; native landing gates are next. AI-assisted. Full release verification remains separate.

Production LOC:0. Tests:+213/-185 (net+28). No test-only production seam; existing stable selector assertions remain and beta cases extend the same tables.
