### PR TITLE
test: select workspace mode for worker wire permission proof

### DIFF
--- a/test/e2e/qa-lab/runtime/node-worker-launch-wire.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/node-worker-launch-wire.e2e.test.ts
@@ -151,13 +151,16 @@ describe("node worker launch wire", () => {
           key: SESSION_KEY,
           agentId: "qa",
           worktree: true,
+          // Worktree creation alone inherits tool policy; this probe needs explicit containment.
+          permissionMode: "workspace",
           worktreeName: "node-worker-launch-wire",
           worktreeBaseRef: "main",
           cwd: published.source,
         });
         const created = (await gateway.call("sessions.describe", { key: SESSION_KEY })) as {
-          session?: { execCwd?: string; spawnedCwd?: string };
+          session?: { execCwd?: string; spawnedCwd?: string; permissionMode?: string };
         };
+        expect(created.session?.permissionMode).toBe("workspace");
         const localWorkspaceDir = created.session?.execCwd ?? created.session?.spawnedCwd;
         expect(localWorkspaceDir).toBeTruthy();
         await fs.writeFile(
@@ -261,6 +264,15 @@ describe("node worker launch wire", () => {
           "device result\n",
         );
 
+        for (const marker of [
+          "worker-permission-in-root.txt",
+          "../worker-permission-outside.txt",
+          "worker-exec-escaped.txt",
+        ]) {
+          await expect(fs.access(path.resolve(remoteWorkspaceDir, marker))).rejects.toMatchObject({
+            code: "ENOENT",
+          });
+        }
         const permissionRunId = `node-worker-permission-${Date.now()}`;
         await expect(
           operator.request<{ runId?: string; status?: string }>("chat.send", {


### PR DESCRIPTION
## What Problem This Solves

Fixes a stale worker wire-test setup that expected workspace containment without selecting a permission mode. Since #131547, creating a worktree intentionally pins the directory while inheriting configured tool/exec policy; it does not select workspace mode.

## Why This Change Was Made

Select the existing `workspace` mode in the fixture's session creation, verify the persisted mode, and assert all three effect markers are absent before probing. Keep the original allowed-write, outside-write denial, exec approval-required outcome, transcript, reconciliation, legacy negotiation, 36 load turns and restart-audit assertions unchanged. Preserve current main's separately repaired Gateway cleanup owner.

The fix belongs to test setup. Reintroducing the worktree-only production default would contradict the documented permission contract. No production/default/containment/approval/authority changes are made.

## User Impact

No product behavior change. The real wire scenario once again tests the explicitly selected workspace policy it claims to exercise.

## Evidence

The unmodified fixture failed on fresh Linux at the outside-marker absence assertion. Separate temporary instrumentation of the actual prepared-tool execution path showed new marker effects under an absent mode and denial under explicit workspace mode, with the same live placement generation/owner epoch/turn claim. That instrumentation was removed. This explains the fresh reproduction; it does not identify the historical CI marker creator or claim general worker security completeness.

The original final uninstrumented full wire scenario and 141 owner/sibling cases passed. The current-main port passed its complete original wire scenario again (39.793s), a full private-QA build (3m51.7s), and the full changed-files gate in [clean Linux environment33226469125](https://github.com/openclaw/openclaw/actions/runs/33226469125). Node24.19.0/pnpm12.0.0, canonical frozen install; command8m10.534s/exit0. Exact full tracked tree `a5dd4b860b3a5c8349813be6287b743e3cfbb6ca` matched before/after; the Testbox was stopped. The environment Actions run may be cancelled by lease cleanup; the wrapper receipt records command success.

Fresh isolated complete-delta Codex review found no actionable P0 findings. [Exact headbe409 CI33227133928](https://github.com/openclaw/openclaw/actions/runs/33227133928) is green; native landing gates are next. AI-assisted. This is local synthetic-provider/isolated Gateway proof, not an authenticated provider session or full release matrix.

Production LOC:0. Test LOC:+13/-1 (net+12). Existing documented input only; no new test-only production seam, config field, schema/protocol, dependency or permission policy.
