### PR TITLE
fix(e2e): retain readable plugin update handoff evidence

### DIFF
--- a/scripts/e2e/lib/plugin-update/consent-scenario.mjs
+++ b/scripts/e2e/lib/plugin-update/consent-scenario.mjs
@@ -8,6 +8,7 @@ import os from "node:os";
 import path from "node:path";
 import { setTimeout as delay } from "node:timers/promises";
 import { fixtureCapabilityConsentArgs } from "../package-compat.mjs";
+import { observePostCoreCommand } from "./process-observer.mjs";
 
 export async function runConsentScenario(entry, coreTarball) {
   assert(entry && coreTarball, "expected installed entry and canonical core tarball");
@@ -51,39 +52,6 @@ export async function runConsentScenario(entry, coreTarball) {
     );
   }
 
-  // Inspect only this command's descendants and the existing post-core marker.
-  // process.title overwrites Linux argv, so retain argv before that mutation.
-  function descendants(pid, seen = new Map()) {
-    try {
-      const children = fs
-        .readFileSync(`/proc/${pid}/task/${pid}/children`, "utf8")
-        .trim()
-        .split(/\s+/)
-        .filter(Boolean);
-      for (const child of children) {
-        const argv = fs.readFileSync(`/proc/${child}/cmdline`, "utf8").split("\0").filter(Boolean);
-        const postCore =
-          (argv.includes("update") || argv[0] === "openclaw-update") &&
-          fs
-            .readFileSync(`/proc/${child}/environ`, "utf8")
-            .split("\0")
-            .includes("OPENCLAW_UPDATE_POST_CORE=1");
-        const previous = seen.get(child);
-        seen.set(child, {
-          pid: child,
-          argv: previous?.argv.includes("update") ? previous.argv : argv,
-          postCore: previous?.postCore || postCore,
-        });
-        descendants(child, seen);
-      }
-    } catch (error) {
-      if (error.code !== "ENOENT" && error.code !== "ESRCH" && error.code !== "EACCES") {
-        throw error;
-      }
-    }
-    return seen;
-  }
-
   async function cli(label, args, { allowFailure = false } = {}) {
     const stdout = path.join(root, `${label}.stdout`);
     const stderr = path.join(root, `${label}.stderr`);
@@ -102,13 +70,11 @@ export async function runConsentScenario(entry, coreTarball) {
       ],
       { stdio: ["ignore", out, err] },
     );
-    const observed = new Map();
-    const observer = setInterval(() => descendants(child.pid, observed), 20);
     let code;
+    let children;
     try {
-      [code] = await once(child, "exit");
+      ({ code, children } = await observePostCoreCommand(child, label));
     } finally {
-      clearInterval(observer);
       fs.closeSync(out);
       fs.closeSync(err);
     }
@@ -129,14 +95,14 @@ export async function runConsentScenario(entry, coreTarball) {
       code,
       stdout,
       stderr,
-      children: [...observed.values()].filter(
+      children: children.filter(
         (descendant) => descendant.argv.includes("update") || descendant.postCore,
       ),
       ...(result ? { result } : {}),
     });
     fs.writeFileSync(path.join(root, "runs.json"), JSON.stringify(runs, null, 2));
     console.log(JSON.stringify({ event: "consent-command", ...runs.at(-1) }));
-    return { code, output, diagnostic, children: [...observed.values()] };
+    return { code, output, diagnostic, children };
   }
 
   async function stopRegistry() {

--- a/scripts/e2e/lib/plugin-update/process-observer.mjs
+++ b/scripts/e2e/lib/plugin-update/process-observer.mjs
@@ -1,0 +1,61 @@
+import { once } from "node:events";
+import fs from "node:fs";
+
+function readProc(file) {
+  try {
+    return fs.readFileSync(file, "utf8");
+  } catch (error) {
+    // Descendants can exit or deny ptrace access to environ. Neither is evidence
+    // of a post-core handoff; keep scanning other descendants.
+    if (["ENOENT", "ESRCH", "EACCES", "EPERM"].includes(error.code)) {
+      return null;
+    }
+    throw error;
+  }
+}
+
+function descendants(pid, seen) {
+  const children = readProc(`/proc/${pid}/task/${pid}/children`);
+  for (const child of children?.trim().split(/\s+/).filter(Boolean) ?? []) {
+    const argv = readProc(`/proc/${child}/cmdline`)?.split("\0").filter(Boolean);
+    const postCore = argv
+      ? (argv.includes("update") || argv[0] === "openclaw-update") &&
+        (readProc(`/proc/${child}/environ`)?.split("\0").includes("OPENCLAW_UPDATE_POST_CORE=1") ??
+          null)
+      : null;
+    const previous = seen.get(child);
+    seen.set(child, {
+      pid: child,
+      // process.title overwrites Linux argv; retain previously observed arguments.
+      argv: previous?.argv.includes("update") ? previous.argv : (argv ?? previous?.argv ?? []),
+      postCore: previous?.postCore === true || postCore,
+    });
+    descendants(child, seen);
+  }
+}
+
+export async function observePostCoreCommand(child, label) {
+  const observed = new Map();
+  let observationError;
+  const observer = setInterval(() => {
+    try {
+      descendants(child.pid, observed);
+    } catch (error) {
+      observationError = error;
+      clearInterval(observer);
+    }
+  }, 20);
+  try {
+    // The command runner still owns its timeout/cleanup. Join it before surfacing
+    // observer failures so a timer cannot strand a running command or registry.
+    const [code, signal] = await once(child, "exit");
+    if (observationError) {
+      throw new Error(`${label} observation failed after command exit ${code} (${signal})`, {
+        cause: observationError,
+      });
+    }
+    return { code, children: [...observed.values()] };
+  } finally {
+    clearInterval(observer);
+  }
+}

--- a/test/scripts/plugin-update-process-observer.test.ts
+++ b/test/scripts/plugin-update-process-observer.test.ts
@@ -1,0 +1,122 @@
+import { EventEmitter } from "node:events";
+import fs from "node:fs";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { observePostCoreCommand } from "../../scripts/e2e/lib/plugin-update/process-observer.mjs";
+
+const argv = "node\0entry.js\0update\0--json\0";
+const marker = "OPENCLAW_UPDATE_POST_CORE=1\0";
+const procError = (code: string) => Object.assign(new Error(`proc read: ${code}`), { code });
+
+describe("plugin update command observation", () => {
+  let files: Map<string, string | Error>;
+  let child: EventEmitter & { pid: number };
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    child = Object.assign(new EventEmitter(), { pid: 10 });
+    files = new Map([
+      ["/proc/10/task/10/children", "11 12"],
+      ["/proc/11/cmdline", argv],
+      ["/proc/11/environ", marker],
+      ["/proc/11/task/11/children", ""],
+      ["/proc/12/cmdline", argv],
+      ["/proc/12/environ", marker],
+      ["/proc/12/task/12/children", ""],
+    ]);
+    const readFile = fs.readFileSync;
+    vi.spyOn(fs, "readFileSync").mockImplementation((file, options) => {
+      if (!String(file).startsWith("/proc/")) {
+        return readFile(file, options);
+      }
+      const value = files.get(String(file));
+      if (value instanceof Error) {
+        throw value;
+      }
+      if (value === undefined) {
+        throw procError("ENOENT");
+      }
+      return value;
+    });
+  });
+
+  afterEach(() => {
+    const timers = vi.getTimerCount();
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+    expect(timers).toBe(0);
+  });
+
+  it.each(["EACCES", "EPERM", "ENOENT", "ESRCH"])(
+    "%s leaves evidence unknown and keeps scanning readable siblings and grandchildren",
+    async (code) => {
+      files.set("/proc/11/environ", procError(code));
+      files.set("/proc/11/task/11/children", "13");
+      files.set("/proc/13/cmdline", argv);
+      files.set("/proc/13/environ", marker);
+      const outcome = observePostCoreCommand(child, "update");
+      await vi.advanceTimersByTimeAsync(20);
+      child.emit("exit", 0, null);
+      const result = await outcome;
+      expect(result.code).toBe(0);
+      expect(result.children).toEqual([
+        { pid: "11", argv: argv.split("\0").filter(Boolean), postCore: null },
+        { pid: "13", argv: argv.split("\0").filter(Boolean), postCore: true },
+        { pid: "12", argv: argv.split("\0").filter(Boolean), postCore: true },
+      ]);
+    },
+  );
+
+  it.each(["cmdline", "environ", "task/11/children"])(
+    "does not manufacture positive handoff evidence when %s is inaccessible",
+    async (file) => {
+      files.set("/proc/10/task/10/children", "11");
+      files.set("/proc/11/environ", "OPENCLAW_UPDATE_POST_CORE=0\0");
+      files.set(`/proc/11/${file}`, procError("EACCES"));
+      const outcome = observePostCoreCommand(child, "update");
+      await vi.advanceTimersByTimeAsync(20);
+      child.emit("exit", 0, null);
+      expect((await outcome).children.some((entry) => entry.postCore)).toBe(false);
+    },
+  );
+
+  it("retains positive evidence and argv after process.title changes and the process exits", async () => {
+    const outcome = observePostCoreCommand(child, "update");
+    await vi.advanceTimersByTimeAsync(20);
+    files.set("/proc/11/cmdline", "openclaw-update\0");
+    files.set("/proc/11/environ", procError("EACCES"));
+    files.set("/proc/12/cmdline", procError("ESRCH"));
+    await vi.advanceTimersByTimeAsync(20);
+    files.set("/proc/10/task/10/children", "");
+    await vi.advanceTimersByTimeAsync(20);
+    child.emit("exit", 7, null);
+    const result = await outcome;
+    expect(result.code).toBe(7);
+    expect(result.children).toEqual(
+      ["11", "12"].map((pid) => ({ pid, argv: argv.split("\0").filter(Boolean), postCore: true })),
+    );
+  });
+
+  it("joins unexpected observer failure with command exit instead of throwing from the timer", async () => {
+    const failure = procError("EIO");
+    files.set("/proc/11/environ", failure);
+    const outcome = observePostCoreCommand(child, "update-denied");
+    const rejected = expect(outcome).rejects.toMatchObject({
+      message: "update-denied observation failed after command exit 7 (null)",
+      cause: failure,
+    });
+    await vi.advanceTimersByTimeAsync(20);
+    expect(child.listenerCount("exit")).toBe(1);
+    child.emit("exit", 7, null);
+    await rejected;
+    expect(child.listenerCount("exit")).toBe(0);
+  });
+
+  it("cleans up observation when command spawning fails", async () => {
+    const failure = procError("ENOENT");
+    const outcome = observePostCoreCommand(child, "update");
+    const rejected = expect(outcome).rejects.toBe(failure);
+    child.emit("error", failure);
+    await rejected;
+    expect(child.listenerCount("exit")).toBe(0);
+  });
+});


### PR DESCRIPTION
## What Problem This Solves

Resolves remaining false failures in the plugin-update package test's positive post-core handoff observation. Main's #132214 already catches `EACCES`, but its catch exits the entire descendant traversal: an inaccessible first child hides readable siblings and grandchildren. Unexpected read errors also escape a timer instead of joining the command's cleanup lifecycle.

## Why This Change Was Made

Move observation into one scenario-owned helper. Treat disappearing or inaccessible individual procfs reads as unknown evidence, continue scanning readable descendants, and retain previously observed positive evidence. Join unexpected observer errors with command exit and always clear the timer. The shell runner still owns timeout/cleanup; both positive fresh-child assertions and the complete consent sequence remain unchanged.

Linux `environ` access uses `PTRACE_MODE_READ_FSCREDS`, not ancestry alone. Direct Linux source inspection and a real owned non-dumpable descendant reproduce inaccessible environment evidence. Unknown reads never count as a positive post-core handoff. Reading only the CLI result would not prove a fresh process, so that weaker substitute is not used.

## User Impact

No product behavior changes. Package verification retains real positive-process evidence without letting one unreadable descendant suppress independent evidence or strand cleanup.

## Evidence

Against current main `ddf5b5a5882c44335e168f2a7a874c803663a4a6`, the exact old traversal failed the new EACCES sibling/grandchild regression (observed `[]` instead of readable descendants). The fixed helper passed all45 focused/unchanged-sibling/package-compat cases and the full changed-files gate in [clean Linux environment33226636684](https://github.com/openclaw/openclaw/actions/runs/33226636684). Canonical frozen dependencies, Node24.19.0/pnpm12.0.0, command2m40.463s/exit0; full tracked tree `b5fe3a86afafd86cc7057719cf401f75ecc143fb` matched before/after, lease stopped.

All three final files are byte-identical to the separately reviewed and fully Docker-tested repair. That complete unchanged package lane passed on native ARM64 Linux Docker29.4.0/Node24.19.0 using the exact failed CI package from [run33213053022](https://github.com/openclaw/openclaw/actions/runs/33213053022), artifact9702691101, SHA256 `2a4782ed15f473bb5e5a4494328735e177c816bedc4028726e43e3cebff0aed9`: all14 ordered commands, six runtime snapshots, both positively observed fresh children, denied widening preservation, missing-payload denial/recovery and unchanged-plugin sibling. No acceptance, timeout or assertion weakening. This retained Docker proof is not relabeled as a new-main Docker run.

Failed environment attempts remain failures: remote source synchronization, an earlier repack's timeout, and AMD64 emulation's timeout did not prove the full lane. The successful full lane is native ARM64; no native AMD64 full-lane claim. All owned containers and leases are closed.

Fresh complete-delta isolated Codex P0 review found no actionable P0 findings. [Exact head14a3 CI33227153111](https://github.com/openclaw/openclaw/actions/runs/33227153111) is green; native landing gates are next. AI-assisted. Full release verification remains separate.

Production LOC:0. E2E support:+66/-39 (net+27, including the moved traversal); regression tests:+122. No product configuration, dependency, schema, protocol, store or consent-policy changes. A separate diagnostic-log redactor-discovery limitation is recorded with the shared harness owner; this patch does not change that helper.
