### PR TITLE
fix(cli): accept Bun 1.4 module-miss diagnostics

### DIFF
--- a/openclaw.mjs
+++ b/openclaw.mjs
@@ -293,7 +293,9 @@ const isDirectModuleNotFoundError = (err, specifier) => {
     message.includes(`Cannot find module "${specifier}"`);
   const launcherPath = fileURLToPath(import.meta.url);
   const bunLauncherImporterMiss =
-    message.includes(` from '${launcherPath}'`) || message.includes(` from "${launcherPath}"`);
+    message.includes(` from '${launcherPath}'`) ||
+    message.includes(` from "${launcherPath}"`) ||
+    message.includes(` imported from ${launcherPath}`);
 
   const expectedUrl = new URL(specifier, import.meta.url);
   const expectedPath = fileURLToPath(expectedUrl);


### PR DESCRIPTION
## Summary

- backport the established Bun 1.4 direct-import diagnostic classifier from #129142
- preserve the existing exact-specifier and launcher-path checks, so transitive import errors still surface

## Why

The exact frozen-candidate CI proof fails both the Bun launcher regression and the built-artifact Bun smoke because Bun 1.4 reports direct imports as `imported from <launcher path>` without quotes. The candidate already contains the real-Bun regressions; this is their existing failing proof.

## Proof

- Failing frozen-candidate jobs: https://github.com/openclaw/openclaw/actions/runs/33224694066/job/99026072526 and https://github.com/openclaw/openclaw/actions/runs/33224694066/job/99026072351
- Current-main upstream fix: #129142, whose exact-head Bun launcher job passed: https://github.com/openclaw/openclaw/actions/runs/32824702686/job/97733867304
- `corepack pnpm install --frozen-lockfile`
- `node scripts/run-vitest.mjs test/openclaw-launcher.e2e.test.ts` (39 passed; the two Bun-only tests are skipped locally because Bun is unavailable)
- `git diff --check`
- autoreview clean (0.99)

Production delta: 3 additions / 1 removal in the classifier. No new config, fallback, or test seam.