### PR TITLE
fix(a2a): bound outbound JSON response bodies

### DIFF
--- a/extensions/a2a/src/outbound.test.ts
+++ b/extensions/a2a/src/outbound.test.ts
@@ -260,7 +260,7 @@ describe("A2A outbound channel delivery", () => {
       url: "https://hermes.example/a2a/v1",
     });
     const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
-      new Response(`{\"reflected\":\"${outboundToken}\"`, {
+      new Response(`{"reflected":"${outboundToken}"`, {
         headers: { "content-type": "application/json" },
       }),
     );

--- a/extensions/a2a/src/outbound.test.ts
+++ b/extensions/a2a/src/outbound.test.ts
@@ -251,4 +251,32 @@ describe("A2A outbound channel delivery", () => {
     );
     expect(fetchMock).toHaveBeenCalledOnce();
   });
+
+  it("does not retain reflected outbound credentials in malformed responses", async () => {
+    const outboundToken = "outbound-secret-token";
+    const cfg = createA2aOutboundConfig({
+      token: "inbound-token",
+      outboundToken,
+      url: "https://hermes.example/a2a/v1",
+    });
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(`{\"reflected\":\"${outboundToken}\"`, {
+        headers: { "content-type": "application/json" },
+      }),
+    );
+
+    const failure = await sendA2aChannelText({ cfg, to: "hermes", text: "hello" }).catch(
+      (error: unknown) => error,
+    );
+
+    expect(failure).toBeInstanceOf(Error);
+    if (!(failure instanceof Error)) {
+      throw new Error("expected malformed peer response to reject");
+    }
+    expect(failure.message).toBe("peer hermes A2A response: malformed JSON response");
+    expect(failure.message).not.toContain(outboundToken);
+    expect(String(failure.cause)).not.toContain(outboundToken);
+    expect(failure.cause).toBeUndefined();
+    expect(fetchMock).toHaveBeenCalledOnce();
+  });
 });

--- a/extensions/a2a/src/outbound.test.ts
+++ b/extensions/a2a/src/outbound.test.ts
@@ -225,11 +225,30 @@ describe("A2A outbound channel delivery", () => {
       "invalid A2A JSON-RPC response",
     );
     await expect(sendA2aChannelText({ cfg, to: "hermes", text: "hello" })).rejects.toThrow(
-      SyntaxError,
+      "peer hermes A2A response: malformed JSON response",
     );
     await expect(sendA2aChannelText({ cfg, to: "hermes", text: "hello" })).rejects.toThrow(
       "A2A response without a result",
     );
     expect(fetchMock).toHaveBeenCalledTimes(4);
+  });
+
+  it("bounds oversized peer JSON responses before parsing", async () => {
+    const cfg = createA2aOutboundConfig({
+      token: "inbound-token",
+      url: "https://hermes.example/a2a/v1",
+    });
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      createA2aJsonResponse({
+        jsonrpc: "2.0",
+        result: { task: { id: "remote-task-1" } },
+        padding: "x".repeat(16 * 1024 * 1024),
+      }),
+    );
+
+    await expect(sendA2aChannelText({ cfg, to: "hermes", text: "hello" })).rejects.toThrow(
+      "peer hermes A2A response: JSON response exceeds 16777216 bytes",
+    );
+    expect(fetchMock).toHaveBeenCalledOnce();
   });
 });

--- a/extensions/a2a/src/outbound.ts
+++ b/extensions/a2a/src/outbound.ts
@@ -98,7 +98,9 @@ export async function sendA2aChannelText(
       }
 
       const parsed = A2aOutboundResponseSchema.safeParse(
-        await readProviderJsonResponse(response, `peer ${peerName} A2A response`),
+        await readProviderJsonResponse(response, `peer ${peerName} A2A response`, {
+          requestHeaders: headers,
+        }),
       );
       if (!parsed.success) {
         throw new Error(`peer ${peerName} returned an invalid A2A JSON-RPC response`);

--- a/extensions/a2a/src/outbound.ts
+++ b/extensions/a2a/src/outbound.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "node:crypto";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { readProviderJsonResponse } from "openclaw/plugin-sdk/provider-http";
 import {
   fetchWithSsrFGuard,
   ssrfPolicyFromHttpBaseUrlAllowedOrigin,
@@ -96,7 +97,9 @@ export async function sendA2aChannelText(
         );
       }
 
-      const parsed = A2aOutboundResponseSchema.safeParse(await response.json());
+      const parsed = A2aOutboundResponseSchema.safeParse(
+        await readProviderJsonResponse(response, `peer ${peerName} A2A response`),
+      );
       if (!parsed.success) {
         throw new Error(`peer ${peerName} returned an invalid A2A JSON-RPC response`);
       }


### PR DESCRIPTION
## What Problem This Solves

An A2A peer controls its successful HTTP response body. The outbound channel parsed that body with `Response.json()`, so it could buffer and accept JSON larger than OpenClaw's shared 16 MiB response limit.

## Root cause

`sendA2aChannelText` used the Server-Side Request Forgery guard for the request, but bypassed OpenClaw's bounded reader when it consumed the successful response.

## Fix

- Read successful peer JSON through the public Plugin SDK `readProviderJsonResponse` helper.
- Pass the active request headers so malformed reflected data cannot survive in parser causes.
- Keep A2A schema validation and the one-time legacy method retry unchanged.

## Evidence

The same production send path called a real loopback A2A peer at both revisions.

| Scenario | Exact main `aace96c6720e` | Exact head `9592e1cd6fdd` |
| --- | --- | --- |
| Valid 1,048,653-byte JSON | Accepted as `normal-control-task` | Accepted as `normal-control-task` |
| Valid 17,825,873-byte JSON | Accepted as `oversized-boundary-task` | Rejected at the 16,777,216-byte shared limit |
| Malformed JSON reflecting the outbound credential | Rejected | Rejected with the bounded-reader error and no retained credential or cause |

The peer recorded `SendMessage` for every probe, which proves the real A2A request reached the loopback server.

## Tests

- The two regression cases fail against exact pre-fix production for the intended reasons.
- `extensions/a2a/src/outbound.test.ts`: 8 passed.
- Scoped format, lint, max-lines, assertion-safety, test-temp, and plugin doctor-contract checks passed.
- Hosted CI owns type checking because this Falc0n host does not run OpenClaw type checks.

AI-assisted: built with Codex.
