### PR TITLE
feat(hovercard): show PR co-authors as a facepile

### DIFF
--- a/src/gateway/control-ui-contract.ts
+++ b/src/gateway/control-ui-contract.ts
@@ -14,9 +14,22 @@ export const CONTROL_UI_SESSION_PULL_REQUESTS_CHANGED_EVENT =
 export const CONTROL_UI_SESSION_PULL_REQUESTS_MAX_KEYS = 200;
 
 /** Public GitHub metadata rendered by Control UI link hover cards. */
+/**
+ * One co-author resolved from a `Co-authored-by` trailer. Only trailers using
+ * GitHub's `<id>+<login>@users.noreply.github.com` form resolve, because the id
+ * yields both the login and the avatar without a per-person API lookup.
+ */
+type ControlUiGitHubPreviewCoAuthor = {
+  login: string;
+  avatarDataUrl?: string;
+};
+
 export type ControlUiGitHubPreview = {
   additions?: number;
   avatarDataUrl?: string;
+  /** Bounded to the faces the card renders; `coAuthorCount` carries the true total. */
+  coAuthors?: ControlUiGitHubPreviewCoAuthor[];
+  coAuthorCount?: number;
   changedFiles?: number;
   closedAt?: string;
   comments?: number;

--- a/src/gateway/control-ui-github-preview.test.ts
+++ b/src/gateway/control-ui-github-preview.test.ts
@@ -13,7 +13,8 @@ import {
   parseControlUiGitHubPreviewTarget,
 } from "./control-ui-github-preview.js";
 
-function githubJson(body: Record<string, unknown>, status = 200): Response {
+// List endpoints such as /pulls/{n}/commits return arrays, not objects.
+function githubJson(body: unknown, status = 200): Response {
   return new Response(JSON.stringify(body), {
     status,
     headers: { "Content-Type": "application/json" },
@@ -134,14 +135,18 @@ describe("loadControlUiGitHubPreview", () => {
   });
 
   it("normalizes public metadata and embeds a bounded GitHub avatar", async () => {
-    const fetchMock = vi
-      .fn<typeof fetch>()
-      .mockResolvedValueOnce(githubJson(previewPayload()))
-      .mockResolvedValueOnce(
-        new Response(new Uint8Array([137, 80, 78, 71]), {
+    const fetchMock = vi.fn<typeof fetch>().mockImplementation(async (input) => {
+      const url = requestUrl(input);
+      if (url.includes("/commits")) {
+        return githubJson([]);
+      }
+      if (url.includes("avatars.githubusercontent.com")) {
+        return new Response(new Uint8Array([137, 80, 78, 71]), {
           headers: { "Content-Type": "image/png" },
-        }),
-      );
+        });
+      }
+      return githubJson(previewPayload());
+    });
     const target = { kind: "pull" as const, number: 99816, owner: "openclaw", repo: "openclaw" };
 
     const first = await loadControlUiGitHubPreview(target, fetchMock);
@@ -160,11 +165,16 @@ describe("loadControlUiGitHubPreview", () => {
       repo: "openclaw",
     });
     expect(second).toEqual(first);
-    expect(fetchMock).toHaveBeenCalledTimes(2);
+    // Item, avatar, and the single commits page that carries co-author trailers.
+    expect(fetchMock).toHaveBeenCalledTimes(3);
     expect(fetchMock.mock.calls[0]?.[0]).toBe(
       "https://api.github.com/repos/openclaw/openclaw/pulls/99816",
     );
-    const avatarRequest = fetchMock.mock.calls[1]?.[0];
+    const avatarRequest = fetchMock.mock.calls
+      .map(([input]) => input)
+      .find((input) => {
+        return input instanceof URL && input.href.includes("avatars.githubusercontent.com");
+      });
     expect(avatarRequest).toBeInstanceOf(URL);
     expect(avatarRequest instanceof URL ? avatarRequest.href : "").toContain(
       "avatars.githubusercontent.com/u/58493",
@@ -172,6 +182,98 @@ describe("loadControlUiGitHubPreview", () => {
     expect(avatarRequest instanceof URL ? avatarRequest.hash : "").toBe("");
     expect(avatarRequest instanceof URL ? avatarRequest.search : "").toBe("?s=64");
     expect(avatarRequest instanceof URL ? avatarRequest.searchParams.get("s") : null).toBe("64");
+  });
+
+  it("resolves co-authors from noreply trailers without a lookup per person", async () => {
+    const commits = [
+      {
+        commit: {
+          message: "feat: one\n\nCo-authored-by: Ada King <20+ada@users.noreply.github.com>",
+        },
+      },
+      // Repeat plus a different case: the same person must fold into one face.
+      { commit: { message: "fix: two\n\nCo-authored-by: ada <20+ADA@users.noreply.github.com>" } },
+      {
+        commit: { message: "fix: three\n\nCo-authored-by: Mira <7+mira@users.noreply.github.com>" },
+      },
+      // The PR author is not their own co-author.
+      {
+        commit: {
+          message:
+            "fix: four\n\nCo-authored-by: steipete <58493+steipete@users.noreply.github.com>",
+        },
+      },
+      // A plain address carries no account id, so it cannot resolve to a face.
+      { commit: { message: "fix: five\n\nCo-authored-by: Someone <someone@example.com>" } },
+    ];
+    const fetchMock = vi.fn<typeof fetch>().mockImplementation(async (input) => {
+      const url = requestUrl(input);
+      if (url.includes("/commits")) {
+        return githubJson(commits);
+      }
+      if (url.includes("avatars.githubusercontent.com")) {
+        return new Response(new Uint8Array([137, 80, 78, 71]), {
+          headers: { "Content-Type": "image/png" },
+        });
+      }
+      return githubJson(previewPayload());
+    });
+
+    const preview = await loadControlUiGitHubPreview(
+      { kind: "pull", number: 88101, owner: "openclaw", repo: "openclaw" },
+      fetchMock,
+    );
+
+    expect(preview.coAuthorCount).toBe(2);
+    expect(preview.coAuthors).toEqual([
+      { login: "ada", avatarDataUrl: "data:image/png;base64,iVBORw==" },
+      { login: "mira", avatarDataUrl: "data:image/png;base64,iVBORw==" },
+    ]);
+    // The account id in the trailer is the avatar, so no per-person API lookup.
+    const avatarUrls = fetchMock.mock.calls
+      .map(([input]) => requestUrl(input))
+      .filter((url) => url.includes("avatars.githubusercontent.com"));
+    expect(avatarUrls).toEqual([
+      "https://avatars.githubusercontent.com/u/58493?s=64",
+      // Co-author avatars go through the same bounded ?s=64 normalization.
+      "https://avatars.githubusercontent.com/u/20?s=64",
+      "https://avatars.githubusercontent.com/u/7?s=64",
+    ]);
+  });
+
+  it("keeps the card when the commits page fails and omits co-authors for issues", async () => {
+    const fetchMock = vi.fn<typeof fetch>().mockImplementation(async (input) => {
+      const url = requestUrl(input);
+      if (url.includes("/commits")) {
+        return githubJson({ message: "rate limited" }, 403);
+      }
+      if (url.includes("avatars.githubusercontent.com")) {
+        return new Response(new Uint8Array([137, 80, 78, 71]), {
+          headers: { "Content-Type": "image/png" },
+        });
+      }
+      return githubJson(previewPayload());
+    });
+
+    const pull = await loadControlUiGitHubPreview(
+      { kind: "pull", number: 88102, owner: "openclaw", repo: "openclaw" },
+      fetchMock,
+    );
+
+    expect(pull.login).toBe("steipete");
+    expect(pull.coAuthors).toBeUndefined();
+    expect(pull.coAuthorCount).toBeUndefined();
+
+    fetchMock.mockClear();
+    await loadControlUiGitHubPreview(
+      { kind: "issue", number: 88103, owner: "openclaw", repo: "openclaw" },
+      fetchMock,
+    );
+
+    // Issues have no commits, so they must not spend the extra request at all.
+    expect(
+      fetchMock.mock.calls.filter(([input]) => requestUrl(input).includes("/commits")),
+    ).toHaveLength(0);
   });
 
   it("does not reuse cached previews after the GitHub credential scope changes", async () => {
@@ -327,16 +429,17 @@ describe("loadControlUiGitHubPreview", () => {
 
   it("retries stale optional authentication anonymously for public previews", async () => {
     vi.stubEnv("GH_TOKEN", "stale-github-token");
-    const fetchMock = vi
-      .fn<typeof fetch>()
-      .mockResolvedValueOnce(githubJson({ message: "Bad credentials" }, 401))
-      .mockResolvedValueOnce(
-        githubJson(
-          previewPayload({
-            user: { login: "octocat" },
-          }),
-        ),
-      );
+    let itemCalls = 0;
+    const fetchMock = vi.fn<typeof fetch>().mockImplementation(async (input) => {
+      const url = requestUrl(input);
+      if (url.includes("/commits")) {
+        return githubJson([]);
+      }
+      itemCalls += 1;
+      return itemCalls === 1
+        ? githubJson({ message: "Bad credentials" }, 401)
+        : githubJson(previewPayload({ user: { login: "octocat" } }));
+    });
 
     const preview = await loadControlUiGitHubPreview(
       { kind: "pull", number: 70012, owner: "openclaw", repo: "openclaw" },
@@ -344,7 +447,7 @@ describe("loadControlUiGitHubPreview", () => {
     );
 
     expect(preview.login).toBe("octocat");
-    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(itemCalls).toBe(2);
     expect(fetchMock.mock.calls[0]?.[1]?.headers).toHaveProperty(
       "Authorization",
       "Bearer stale-github-token",

--- a/src/gateway/control-ui-github-preview.test.ts
+++ b/src/gateway/control-ui-github-preview.test.ts
@@ -520,6 +520,53 @@ describe("loadControlUiGitHubPreview", () => {
     expect(redirectResponse.bodyUsed).toBe(true);
   });
 
+  it("re-checks visibility when the commits request is redirected into another repository", async () => {
+    vi.stubEnv("GH_TOKEN", "github-test-token");
+    const visibilityChecks: string[] = [];
+    const fetchMock = vi.fn<typeof fetch>().mockImplementation(async (input) => {
+      const url = requestUrl(input);
+      if (url.endsWith("/repos/openclaw/openclaw")) {
+        visibilityChecks.push(url);
+        return githubJson({ private: false });
+      }
+      if (url.endsWith("/repos/openclaw/secret")) {
+        visibilityChecks.push(url);
+        // The token can read it; the Control UI viewer must not.
+        return githubJson({ private: true });
+      }
+      if (url.includes("/commits")) {
+        return new Response("moved", {
+          status: 301,
+          headers: {
+            Location: "https://api.github.com/repos/openclaw/secret/pulls/88201/commits",
+          },
+        });
+      }
+      if (url.includes("avatars.githubusercontent.com")) {
+        return new Response(new Uint8Array([137, 80, 78, 71]), {
+          headers: { "Content-Type": "image/png" },
+        });
+      }
+      return githubJson(previewPayload());
+    });
+
+    const preview = await loadControlUiGitHubPreview(
+      { kind: "pull", number: 88201, owner: "openclaw", repo: "openclaw" },
+      fetchMock,
+    );
+
+    // The card still renders; only the co-author decoration is withheld.
+    expect(preview.login).toBe("steipete");
+    expect(preview.coAuthors).toBeUndefined();
+    // The redirect target was visibility-checked, and its commits were never fetched.
+    expect(visibilityChecks).toContain("https://api.github.com/repos/openclaw/secret");
+    expect(
+      fetchMock.mock.calls.filter(([input]) =>
+        requestUrl(input).startsWith("https://api.github.com/repos/openclaw/secret/pulls"),
+      ),
+    ).toHaveLength(0);
+  });
+
   it("stops private and missing repositories before fetching item metadata", async () => {
     vi.stubEnv("GH_TOKEN", "github-test-token");
     const fetchMock = vi

--- a/src/gateway/control-ui-github-preview.ts
+++ b/src/gateway/control-ui-github-preview.ts
@@ -19,6 +19,15 @@ import {
 
 const GITHUB_AVATAR_HOST = "avatars.githubusercontent.com";
 const GITHUB_AVATAR_MAX_BYTES = 256 * 1024;
+// One commits page bounds the extra request; the card only renders three faces,
+// so deeper paging would spend quota on people it can never show.
+const GITHUB_COMMITS_PAGE_SIZE = 100;
+const GITHUB_COMMITS_MAX_BYTES = 1024 * 1024;
+const CO_AUTHOR_FACE_LIMIT = 3;
+// GitHub's noreply form is the only trailer that yields a login and an avatar
+// without a lookup per person: `<accountId>+<login>@users.noreply.github.com`.
+const CO_AUTHOR_TRAILER =
+  /^co-authored-by:\s*[^<]*<(?<id>\d{1,12})\+(?<login>[a-z\d](?:[a-z\d-]{0,38}))@users\.noreply\.github\.com>\s*$/gimu;
 const AUTHENTICATED_SUCCESS_CACHE_MS = 5 * 60_000;
 const ANONYMOUS_SUCCESS_CACHE_MS = 60 * 60_000;
 const FAILURE_CACHE_MS = 30_000;
@@ -79,6 +88,12 @@ export function parseControlUiGitHubPreviewTarget(
     return null;
   }
   return { kind, number, owner, repo };
+}
+
+function commitsApiUrl(target: ControlUiGitHubPreviewTarget): string {
+  const owner = encodeURIComponent(target.owner);
+  const repo = encodeURIComponent(target.repo);
+  return `${GITHUB_API_ORIGIN}/repos/${owner}/${repo}/pulls/${target.number}/commits?per_page=${GITHUB_COMMITS_PAGE_SIZE}`;
 }
 
 function previewApiUrl(target: ControlUiGitHubPreviewTarget): string {
@@ -205,6 +220,68 @@ function safeAvatarUrl(raw: string | undefined): URL | null {
   }
 }
 
+/**
+ * Distinct co-author logins from a PR's commit trailers, author excluded, in
+ * first-seen order. Returns the true total alongside the bounded face list so
+ * the card can render "+N" without another request.
+ */
+async function fetchCoAuthors(
+  target: ControlUiGitHubPreviewTarget,
+  authorLogin: string,
+  fetchImpl: typeof fetch,
+  token: string | undefined,
+): Promise<{ coAuthors: { login: string; avatarDataUrl?: string }[]; coAuthorCount: number }> {
+  const empty = { coAuthors: [], coAuthorCount: 0 };
+  let commits: unknown;
+  try {
+    const response = await fetchGitHubApi(commitsApiUrl(target), fetchImpl, token);
+    if (!response.ok) {
+      await discardResponse(response);
+      return empty;
+    }
+    commits = JSON.parse(
+      (await readBoundedResponse(response, GITHUB_COMMITS_MAX_BYTES)).toString("utf8"),
+    );
+  } catch {
+    // Co-authors are decoration on an already-useful card, so a failed or
+    // oversized commits page degrades to no faces instead of failing the card.
+    return empty;
+  }
+  if (!Array.isArray(commits)) {
+    return empty;
+  }
+  const byLogin = new Map<string, { login: string; accountId: string }>();
+  for (const entry of commits) {
+    const commit = isRecord(entry) && isRecord(entry.commit) ? entry.commit : undefined;
+    const message = commit ? readOptionalGitHubString(commit, "message") : undefined;
+    if (!message) {
+      continue;
+    }
+    for (const match of message.matchAll(CO_AUTHOR_TRAILER)) {
+      const login = match.groups?.login;
+      const accountId = match.groups?.id;
+      if (!login || !accountId || login.toLowerCase() === authorLogin.toLowerCase()) {
+        continue;
+      }
+      const key = login.toLowerCase();
+      if (!byLogin.has(key)) {
+        byLogin.set(key, { login, accountId });
+      }
+    }
+  }
+  const faces = [...byLogin.values()].slice(0, CO_AUTHOR_FACE_LIMIT);
+  const coAuthors = await Promise.all(
+    faces.map(async (face) => {
+      const avatarDataUrl = await fetchAvatarDataUrl(
+        `https://${GITHUB_AVATAR_HOST}/u/${face.accountId}`,
+        fetchImpl,
+      );
+      return avatarDataUrl ? { login: face.login, avatarDataUrl } : { login: face.login };
+    }),
+  );
+  return { coAuthors, coAuthorCount: byLogin.size };
+}
+
 async function fetchAvatarDataUrl(
   rawUrl: string | undefined,
   fetchImpl: typeof fetch,
@@ -266,8 +343,21 @@ async function fetchPreview(
     await assertPublicRepositoryUrl(previewRepositoryApiUrl(target, parsed), fetchImpl, token);
   }
   const { preview, avatarUrl } = parseGitHubResponse(target, parsed);
-  const avatarDataUrl = await fetchAvatarDataUrl(avatarUrl, fetchImpl);
-  return avatarDataUrl ? { ...preview, avatarDataUrl } : preview;
+  // Both extra fetches run only after the public-repository assertions above,
+  // so neither can widen what this token is allowed to read.
+  const [avatarDataUrl, coAuthorFacts] = await Promise.all([
+    fetchAvatarDataUrl(avatarUrl, fetchImpl),
+    target.kind === "pull"
+      ? fetchCoAuthors(target, preview.login, fetchImpl, token)
+      : Promise.resolve({ coAuthors: [], coAuthorCount: 0 }),
+  ]);
+  return {
+    ...preview,
+    ...(avatarDataUrl ? { avatarDataUrl } : {}),
+    ...(coAuthorFacts.coAuthorCount > 0
+      ? { coAuthors: coAuthorFacts.coAuthors, coAuthorCount: coAuthorFacts.coAuthorCount }
+      : {}),
+  };
 }
 
 function cacheKey(target: ControlUiGitHubPreviewTarget, credentialScope: string): string {

--- a/src/gateway/control-ui-github-preview.ts
+++ b/src/gateway/control-ui-github-preview.ts
@@ -127,24 +127,26 @@ async function assertPublicRepositoryUrl(
 function redirectedRepositoryApiUrl(target: ControlUiGitHubPreviewTarget, url: URL): string | null {
   const segments = url.pathname.split("/").filter(Boolean);
   const collection = target.kind === "pull" ? "pulls" : "issues";
+  // The commits request redirects to the same item path plus one known suffix.
+  const itemSegments = segments.at(-1) === "commits" ? segments.slice(0, -1) : segments;
   if (
-    segments.length === 5 &&
-    segments[0] === "repos" &&
-    segments[1] &&
-    segments[2] &&
-    segments[3] === collection &&
-    /^\d+$/u.test(segments[4] ?? "")
+    itemSegments.length === 5 &&
+    itemSegments[0] === "repos" &&
+    itemSegments[1] &&
+    itemSegments[2] &&
+    itemSegments[3] === collection &&
+    /^\d+$/u.test(itemSegments[4] ?? "")
   ) {
-    return `${GITHUB_API_ORIGIN}/repos/${segments[1]}/${segments[2]}`;
+    return `${GITHUB_API_ORIGIN}/repos/${itemSegments[1]}/${itemSegments[2]}`;
   }
   if (
-    segments.length === 4 &&
-    segments[0] === "repositories" &&
-    /^\d+$/u.test(segments[1] ?? "") &&
-    segments[2] === collection &&
-    /^\d+$/u.test(segments[3] ?? "")
+    itemSegments.length === 4 &&
+    itemSegments[0] === "repositories" &&
+    /^\d+$/u.test(itemSegments[1] ?? "") &&
+    itemSegments[2] === collection &&
+    /^\d+$/u.test(itemSegments[3] ?? "")
   ) {
-    return `${GITHUB_API_ORIGIN}/repositories/${segments[1]}`;
+    return `${GITHUB_API_ORIGIN}/repositories/${itemSegments[1]}`;
   }
   return null;
 }
@@ -230,11 +232,12 @@ async function fetchCoAuthors(
   authorLogin: string,
   fetchImpl: typeof fetch,
   token: string | undefined,
+  beforeRedirect: ((url: URL) => Promise<void>) | undefined,
 ): Promise<{ coAuthors: { login: string; avatarDataUrl?: string }[]; coAuthorCount: number }> {
   const empty = { coAuthors: [], coAuthorCount: 0 };
   let commits: unknown;
   try {
-    const response = await fetchGitHubApi(commitsApiUrl(target), fetchImpl, token);
+    const response = await fetchGitHubApi(commitsApiUrl(target), fetchImpl, token, beforeRedirect);
     if (!response.ok) {
       await discardResponse(response);
       return empty;
@@ -320,21 +323,19 @@ async function fetchPreview(
   if (token) {
     await assertPublicRepositoryUrl(repositoryApiUrl(target), fetchImpl, token);
   }
+  // Every credentialed fetch below shares this guard: a rename or transfer can
+  // redirect into a repository the token can read but the viewer may not see.
+  const beforeRedirect = token
+    ? async (url: URL) => {
+        const repositoryUrl = redirectedRepositoryApiUrl(target, url);
+        if (!repositoryUrl) {
+          throw new ControlUiGitHubError(502, "GitHub item returned an unsafe redirect");
+        }
+        await assertPublicRepositoryUrl(repositoryUrl, fetchImpl, token);
+      }
+    : undefined;
   const parsed = await readGitHubJsonResponse(
-    await fetchGitHubApi(
-      previewApiUrl(target),
-      fetchImpl,
-      token,
-      token
-        ? async (url) => {
-            const repositoryUrl = redirectedRepositoryApiUrl(target, url);
-            if (!repositoryUrl) {
-              throw new ControlUiGitHubError(502, "GitHub item returned an unsafe redirect");
-            }
-            await assertPublicRepositoryUrl(repositoryUrl, fetchImpl, token);
-          }
-        : undefined,
-    ),
+    await fetchGitHubApi(previewApiUrl(target), fetchImpl, token, beforeRedirect),
   );
   if (!isRecord(parsed)) {
     throw new ControlUiGitHubError(502, "GitHub response was not an object");
@@ -348,7 +349,7 @@ async function fetchPreview(
   const [avatarDataUrl, coAuthorFacts] = await Promise.all([
     fetchAvatarDataUrl(avatarUrl, fetchImpl),
     target.kind === "pull"
-      ? fetchCoAuthors(target, preview.login, fetchImpl, token)
+      ? fetchCoAuthors(target, preview.login, fetchImpl, token, beforeRedirect)
       : Promise.resolve({ coAuthors: [], coAuthorCount: 0 }),
   ]);
   return {

--- a/ui/src/components/github-link-hovercard.runtime.ts
+++ b/ui/src/components/github-link-hovercard.runtime.ts
@@ -163,12 +163,16 @@ function appendCoAuthors(author: HTMLElement, preview: GitHubPreview): void {
   }
   const stack = document.createElement("span");
   stack.className = "github-link-hovercard__coauthors";
+  let faces = 0;
   for (const coAuthor of coAuthors) {
     if (coAuthor.avatarDataUrl) {
       stack.append(coAuthorAvatarElement(coAuthor.avatarDataUrl));
+      faces += 1;
     }
   }
-  const hidden = Math.max(0, total - coAuthors.length);
+  // Counted from rendered faces, not fetched people: avatar inlining is optional,
+  // and a co-author with no face must fall into "+N" rather than disappear.
+  const hidden = Math.max(0, total - faces);
   if (hidden > 0) {
     const more = document.createElement("span");
     more.className = "github-link-hovercard__coauthors-more";

--- a/ui/src/components/github-link-hovercard.runtime.ts
+++ b/ui/src/components/github-link-hovercard.runtime.ts
@@ -50,6 +50,25 @@ function safeAvatarDataUrl(value: unknown): string | undefined {
     : undefined;
 }
 
+/** Gateway data is untrusted here: keep only well-formed logins and inlined avatars. */
+function parseCoAuthors(value: unknown): { login: string; avatarDataUrl?: string }[] | undefined {
+  if (!Array.isArray(value)) {
+    return undefined;
+  }
+  const parsed = value.flatMap((entry) => {
+    if (!isRecord(entry)) {
+      return [];
+    }
+    const login = readNonBlankString(entry.login);
+    if (!login) {
+      return [];
+    }
+    const avatarDataUrl = safeAvatarDataUrl(entry.avatarDataUrl);
+    return [avatarDataUrl ? { login, avatarDataUrl } : { login }];
+  });
+  return parsed.length > 0 ? parsed : undefined;
+}
+
 function parsePreviewResponse(target: GitHubLinkTarget, value: unknown): GitHubPreview {
   if (!isRecord(value)) {
     throw new Error("GitHub response was not an object");
@@ -70,6 +89,8 @@ function parsePreviewResponse(target: GitHubLinkTarget, value: unknown): GitHubP
     avatarDataUrl: safeAvatarDataUrl(value.avatarDataUrl),
     changedFiles: asFiniteNumber(value.changedFiles),
     closedAt: readNonBlankString(value.closedAt),
+    coAuthorCount: asFiniteNumber(value.coAuthorCount),
+    coAuthors: parseCoAuthors(value.coAuthors),
     comments: asFiniteNumber(value.comments),
     createdAt: requiredString(value, "createdAt"),
     deletions: asFiniteNumber(value.deletions),
@@ -118,6 +139,49 @@ function appendTextElement(
   element.textContent = text;
   parent.append(element);
   return element;
+}
+
+function coAuthorAvatarElement(dataUrl: string): HTMLImageElement {
+  const avatar = document.createElement("img");
+  avatar.className = "github-link-hovercard__avatar";
+  avatar.alt = "";
+  avatar.decoding = "async";
+  avatar.referrerPolicy = "no-referrer";
+  avatar.src = dataUrl;
+  return avatar;
+}
+
+/**
+ * Overlapping faces after the author, plus "+N" for anyone past the fetched
+ * three. Names live in the title so the row never competes with the metrics.
+ */
+function appendCoAuthors(author: HTMLElement, preview: GitHubPreview): void {
+  const coAuthors = preview.coAuthors ?? [];
+  const total = preview.coAuthorCount ?? coAuthors.length;
+  if (coAuthors.length === 0) {
+    return;
+  }
+  const stack = document.createElement("span");
+  stack.className = "github-link-hovercard__coauthors";
+  for (const coAuthor of coAuthors) {
+    if (coAuthor.avatarDataUrl) {
+      stack.append(coAuthorAvatarElement(coAuthor.avatarDataUrl));
+    }
+  }
+  const hidden = Math.max(0, total - coAuthors.length);
+  if (hidden > 0) {
+    const more = document.createElement("span");
+    more.className = "github-link-hovercard__coauthors-more";
+    more.textContent = `+${hidden}`;
+    stack.append(more);
+  }
+  if (stack.childElementCount === 0) {
+    return;
+  }
+  stack.title = t("githubPreview.coAuthors", {
+    logins: coAuthors.map((coAuthor) => coAuthor.login).join(", "),
+  });
+  author.after(stack);
 }
 
 function appendMetric(parent: HTMLElement, className: string, text: string): void {
@@ -199,14 +263,9 @@ function renderPreview(card: HTMLDivElement, preview: GitHubPreview): void {
     preview.login,
   );
   if (preview.avatarDataUrl) {
-    const avatar = document.createElement("img");
-    avatar.className = "github-link-hovercard__avatar";
-    avatar.alt = "";
-    avatar.decoding = "async";
-    avatar.referrerPolicy = "no-referrer";
-    avatar.src = preview.avatarDataUrl;
-    author.prepend(avatar);
+    author.prepend(coAuthorAvatarElement(preview.avatarDataUrl));
   }
+  appendCoAuthors(author, preview);
 
   const metrics = document.createElement("span");
   metrics.className = "github-link-hovercard__metrics";

--- a/ui/src/components/github-link-hovercard.runtime.ts
+++ b/ui/src/components/github-link-hovercard.runtime.ts
@@ -153,7 +153,8 @@ function coAuthorAvatarElement(dataUrl: string): HTMLImageElement {
 
 /**
  * Overlapping faces after the author, plus "+N" for anyone past the fetched
- * three. Names live in the title so the row never competes with the metrics.
+ * three. The group is one labelled image: names reach assistive tech through
+ * its accessible name instead of competing with the metrics for row width.
  */
 function appendCoAuthors(author: HTMLElement, preview: GitHubPreview): void {
   const coAuthors = preview.coAuthors ?? [];
@@ -182,9 +183,14 @@ function appendCoAuthors(author: HTMLElement, preview: GitHubPreview): void {
   if (stack.childElementCount === 0) {
     return;
   }
-  stack.title = t("githubPreview.coAuthors", {
+  // The faces are decorative images, so the group carries the only accessible
+  // name; a title alone is never announced.
+  const label = t("githubPreview.coAuthors", {
     logins: coAuthors.map((coAuthor) => coAuthor.login).join(", "),
   });
+  stack.title = label;
+  stack.role = "img";
+  stack.ariaLabel = label;
   author.after(stack);
 }
 

--- a/ui/src/components/github-link-hovercard.test.ts
+++ b/ui/src/components/github-link-hovercard.test.ts
@@ -97,6 +97,73 @@ describe("openclaw-github-link-hovercard-provider", () => {
     vi.restoreAllMocks();
   });
 
+  it("stacks co-author faces after the author and counts the rest", async () => {
+    const avatar =
+      "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAusB9WlY9Z8AAAAASUVORK5CYII=";
+    const request = vi.fn().mockResolvedValue({
+      additions: 71,
+      avatarDataUrl: avatar,
+      changedFiles: 8,
+      coAuthorCount: 5,
+      coAuthors: [
+        { login: "steipete", avatarDataUrl: avatar },
+        { login: "ada", avatarDataUrl: avatar },
+        { login: "mira", avatarDataUrl: avatar },
+      ],
+      createdAt: "2026-07-04T05:03:47Z",
+      deletions: 109,
+      kind: "pull",
+      login: "roboclaw-bot",
+      mergedAt: "2026-07-04T09:53:52Z",
+      number: 131440,
+      owner: "OpenClaw",
+      repo: "OpenClaw",
+      state: "closed",
+      title: "fix(ui): open people cards from one row",
+      updatedAt: "2026-07-05T09:55:00Z",
+    });
+    const { anchor, provider } = createLink(
+      "https://github.com/openclaw/openclaw/pull/131440",
+      "#131440",
+    );
+    provider.client = { request } as unknown as GatewayBrowserClient;
+
+    await hover(anchor);
+
+    const stack = document.querySelector<HTMLElement>(".github-link-hovercard__coauthors");
+    expect(stack?.querySelectorAll("img")).toHaveLength(3);
+    // Two co-authors beyond the three fetched faces.
+    expect(stack?.querySelector(".github-link-hovercard__coauthors-more")?.textContent).toBe("+2");
+    expect(stack?.getAttribute("title")).toBe("Co-authored by steipete, ada, mira");
+    // The stack sits after the author, never inside the metrics.
+    expect(stack?.previousElementSibling?.classList.contains("github-link-hovercard__author")).toBe(
+      true,
+    );
+  });
+
+  it("omits the co-author stack when a pull request has none", async () => {
+    const request = vi.fn().mockResolvedValue({
+      createdAt: "2026-07-04T05:03:47Z",
+      kind: "pull",
+      login: "roboclaw-bot",
+      number: 131441,
+      owner: "OpenClaw",
+      repo: "OpenClaw",
+      state: "open",
+      title: "fix(ui): one row",
+      updatedAt: "2026-07-05T09:55:00Z",
+    });
+    const { anchor, provider } = createLink(
+      "https://github.com/openclaw/openclaw/pull/131441",
+      "#131441",
+    );
+    provider.client = { request } as unknown as GatewayBrowserClient;
+
+    await hover(anchor);
+
+    expect(document.querySelector(".github-link-hovercard__coauthors")).toBeNull();
+  });
+
   it("renders and caches pull request details without changing the link", async () => {
     const request = vi.fn().mockResolvedValue({
       additions: 101,

--- a/ui/src/components/github-link-hovercard.test.ts
+++ b/ui/src/components/github-link-hovercard.test.ts
@@ -135,6 +135,10 @@ describe("openclaw-github-link-hovercard-provider", () => {
     // Two co-authors beyond the three fetched faces.
     expect(stack?.querySelector(".github-link-hovercard__coauthors-more")?.textContent).toBe("+2");
     expect(stack?.getAttribute("title")).toBe("Co-authored by steipete, ada, mira");
+    // Faces are decorative; the group is the only thing assistive tech can read.
+    expect(stack?.getAttribute("role")).toBe("img");
+    expect(stack?.getAttribute("aria-label")).toBe("Co-authored by steipete, ada, mira");
+    expect([...(stack?.querySelectorAll("img") ?? [])].every((img) => img.alt === "")).toBe(true);
     // The stack sits after the author, never inside the metrics.
     expect(stack?.previousElementSibling?.classList.contains("github-link-hovercard__author")).toBe(
       true,

--- a/ui/src/components/github-link-hovercard.test.ts
+++ b/ui/src/components/github-link-hovercard.test.ts
@@ -141,6 +141,41 @@ describe("openclaw-github-link-hovercard-provider", () => {
     );
   });
 
+  it("counts a co-author whose avatar failed to inline into the overflow", async () => {
+    const avatar =
+      "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAusB9WlY9Z8AAAAASUVORK5CYII=";
+    const request = vi.fn().mockResolvedValue({
+      createdAt: "2026-07-04T05:03:47Z",
+      coAuthorCount: 5,
+      coAuthors: [
+        { login: "steipete", avatarDataUrl: avatar },
+        { login: "ada", avatarDataUrl: avatar },
+        // Avatar inlining is optional and can fail for one person.
+        { login: "mira" },
+      ],
+      kind: "pull",
+      login: "roboclaw-bot",
+      number: 131442,
+      owner: "OpenClaw",
+      repo: "OpenClaw",
+      state: "open",
+      title: "fix(ui): one row",
+      updatedAt: "2026-07-05T09:55:00Z",
+    });
+    const { anchor, provider } = createLink(
+      "https://github.com/openclaw/openclaw/pull/131442",
+      "#131442",
+    );
+    provider.client = { request } as unknown as GatewayBrowserClient;
+
+    await hover(anchor);
+
+    const stack = document.querySelector<HTMLElement>(".github-link-hovercard__coauthors");
+    expect(stack?.querySelectorAll("img")).toHaveLength(2);
+    // Two faces plus "+3" accounts for all five; "+2" would drop the faceless one.
+    expect(stack?.querySelector(".github-link-hovercard__coauthors-more")?.textContent).toBe("+3");
+  });
+
   it("omits the co-author stack when a pull request has none", async () => {
     const request = vi.fn().mockResolvedValue({
       createdAt: "2026-07-04T05:03:47Z",

--- a/ui/src/e2e/github-link-hovercard.e2e.test.ts
+++ b/ui/src/e2e/github-link-hovercard.e2e.test.ts
@@ -50,6 +50,24 @@ async function captureArtifact(page: Page, name: string): Promise<void> {
 
 const pullPreviewResponse = {
   additions: 101,
+  coAuthorCount: 5,
+  coAuthors: [
+    {
+      login: "roboclaw-bot",
+      avatarDataUrl:
+        "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAusB9WlY9Z8AAAAASUVORK5CYII=",
+    },
+    {
+      login: "ada",
+      avatarDataUrl:
+        "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAusB9WlY9Z8AAAAASUVORK5CYII=",
+    },
+    {
+      login: "mira",
+      avatarDataUrl:
+        "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAusB9WlY9Z8AAAAASUVORK5CYII=",
+    },
+  ],
   avatarDataUrl:
     "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAusB9WlY9Z8AAAAASUVORK5CYII=",
   changedFiles: 3,
@@ -330,6 +348,11 @@ describeControlUiE2e("GitHub link hover cards", () => {
     await page.mouse.move(cardBox!.x + cardBox!.width / 2, cardBox!.y + 4);
     await page.mouse.move(cardBox!.x + cardBox!.width / 2, cardBox!.y + cardBox!.height / 2);
     expect(await card.count()).toBe(1);
+    const faces = card.locator(".github-link-hovercard__coauthors img");
+    await expect.poll(() => faces.count()).toBe(3);
+    await expect
+      .poll(() => card.locator(".github-link-hovercard__coauthors-more").textContent())
+      .toBe("+2");
     await captureArtifact(page, "github-hovercard-pointer-open");
 
     // Staying on the card holds it open regardless of elapsed time, mirroring

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -188,6 +188,7 @@ export const en: TranslationMap = {
     },
   },
   githubPreview: {
+    coAuthors: "Co-authored by {logins}",
     loading: "Loading GitHub details…",
     unavailable: "GitHub preview unavailable",
     states: {

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -1344,6 +1344,30 @@ openclaw-session-progress-hovercard-provider {
   align-items: center;
 }
 
+.github-link-hovercard__coauthors {
+  display: inline-flex;
+  align-items: center;
+  flex: 0 0 auto;
+  margin-left: 6px;
+}
+
+/* Overlap reads as one group; the ring keeps faces separable against the card. */
+.github-link-hovercard__coauthors .github-link-hovercard__avatar {
+  width: 21px;
+  height: 21px;
+  box-shadow: 0 0 0 2px var(--surface-1);
+}
+
+.github-link-hovercard__coauthors .github-link-hovercard__avatar + .github-link-hovercard__avatar {
+  margin-left: -7px;
+}
+
+.github-link-hovercard__coauthors-more {
+  margin-left: 5px;
+  color: var(--text-muted);
+  font-size: 12px;
+}
+
 .github-link-hovercard__author {
   min-width: 0;
   gap: 8px;

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -1364,7 +1364,7 @@ openclaw-session-progress-hovercard-provider {
 
 .github-link-hovercard__coauthors-more {
   margin-left: 5px;
-  color: var(--text-muted);
+  color: var(--muted);
   font-size: 12px;
 }
 


### PR DESCRIPTION
## What Problem This Solves

GitHub link hovercards name only the pull request author, so a co-authored PR reads as solo work. On a Gateway where sessions routinely produce `Co-authored-by` trailers, the card was actively misleading about who did the work.

## Why This Change Was Made

Co-authors now render as overlapping faces immediately after the author, with `+N` for anyone past the three the card fetches. That was chosen over a second line or inline names because the hovercard is fixed-width and appears under the cursor: a second line makes card height depend on data, and inline logins compete with the metrics and truncate after about two names.

The interesting part is the data. Co-authors live in commit trailers, which normally means a lookup per person to turn an email into a login and avatar. GitHub's noreply form carries both: `<accountId>+<login>@users.noreply.github.com`. So one commits page yields the login directly, and the account id yields the avatar URL on the already-allowlisted `avatars.githubusercontent.com` host, which then goes through the existing server-side inlining instead of being hotlinked from the viewer's browser.

That keeps the whole feature at **one extra request per pull preview**, and it works anonymously. A GraphQL `commit.authors` query would also resolve trailers — and would additionally resolve non-noreply addresses — but GraphQL requires a token, and this preview path deliberately works without one. The tradeoff taken here is that a co-author who commits under a plain email address does not get a face; that is a deliberate accepted gap, not an oversight.

Bounds and failure behavior:

- Issues never make the request; only pulls have commits.
- One commits page (`per_page=100`), 1 MB response cap, three faces fetched, true total reported separately so `+N` needs no second request.
- The trailer pattern is anchored per line and bounded (12-digit id, 39-character login).
- Co-authors are decoration on an already-useful card, so a failed, rate-limited, malformed, or oversized commits page degrades to no faces rather than failing the preview.
- Both extra fetches run only after the existing public-repository assertions, so the token's read scope is unchanged.

## User Impact

Hovering a co-authored PR link shows who worked on it. Solo PRs render exactly as before. Names are in the stack's `title` so the row never competes with the diff metrics.

Production delta is +150 lines across four files; the rest is tests.

## Evidence

![Co-author facepile between the author and the metrics](https://github.com/user-attachments/assets/cb850aea-118d-4dbc-8f0c-7e706fe87fb8)

Captured from the real Control UI in Chromium via the mocked-gateway E2E lane (`ui/src/e2e/github-link-hovercard.e2e.test.ts`). The faces are blank circles because the fixture avatar is a 1×1 white PNG; the layout, overlap, and `+2` overflow are real.

- `node scripts/run-vitest.mjs src/gateway/control-ui-github-preview.test.ts` — 20 passed, including trailer resolution (dedupe across commits, case-insensitive, PR author excluded, plain-email trailer ignored), the assertion that avatars come from the trailer's account id with no per-person API lookup, and degradation when the commits page 403s.
- `node scripts/run-vitest.mjs ui/src/components/github-link-hovercard.test.ts` — 17 passed, including face count, `+N`, the title, stack placement after the author, and no stack when a PR has none.
- `node scripts/run-vitest.mjs ui/src/e2e/github-link-hovercard.e2e.test.ts` — 4 passed, asserting three faces and `+2` in a real browser.
- `node scripts/check-changed.mjs` — exit 0.
- Codex autoreview — no accepted or actionable findings.

Two gate failures were fixed rather than annotated: the assertion-SAFETY ratchet flagged two type assertions, both of which turned out to be unnecessary and were removed (narrowing through the existing `isRecord` guard, and dropping a redundant `as unknown` on a `JSON.parse` assigned to an `unknown`), and `no-base-to-string` flagged a `String(input)` that the file's own `requestUrl` helper already handled.
