### PR TITLE
fix(codex): honor thinking off on supported Platform routes

### DIFF
--- a/docs/tools/thinking.md
+++ b/docs/tools/thinking.md
@@ -30,7 +30,7 @@ title: "Thinking levels"
   - Direct DeepSeek V4 models expose `/think xhigh|max`; both map to DeepSeek `reasoning_effort: "max"` while lower non-off levels map to `high`.
   - OpenRouter-routed DeepSeek V4 models expose `/think xhigh` and send OpenRouter-supported `reasoning.effort` values instead of DeepSeek-native top-level `reasoning_effort`. Lower non-off levels map to `high`, and stored `max` overrides fall back to `xhigh`.
   - Ollama thinking-capable models expose `/think low|medium|high|max`. Verified full-effort Ollama Cloud families such as GLM 5.2 and DeepSeek V4 send each matching native `think` effort, including `max`; other models and local Ollama keep the compatible `high` mapping for `/think max`.
-  - OpenAI GPT models map `/think` through model-specific Responses API effort support. `/think off` sends `reasoning.effort: "none"` only when the target model supports it; otherwise OpenClaw omits the disabled reasoning payload instead of sending an unsupported value.
+  - OpenAI GPT models map `/think` through the selected model and auth route's effort support. On supported OpenAI Platform/API-key routes, `/think off` sends explicit `reasoning.effort: "none"`, including when using the Codex runtime. Subscription routes that do not support `none` retain the provider or native runtime's default reasoning behavior; `off` does not guarantee zero reasoning there. Supervised native Codex threads keep their own thinking settings.
   - GPT-5.6 Sol and Terra expose native `/think ultra` through the Codex runtime. GPT-5.6 Luna exposes levels through `max` because its Codex catalog does not advertise Ultra.
   - The embedded OpenClaw runtime exposes logical `/think ultra` for GPT-5.6 Sol, Terra, and Luna. It sends provider max effort and adds run-scoped proactive sub-agent orchestration guidance.
   - Custom OpenAI-compatible catalog entries can opt into `/think xhigh` by setting `models.providers.<provider>.models[].compat.supportedReasoningEfforts` to include `"xhigh"`. This uses the same compat metadata that maps outbound OpenAI reasoning effort payloads, so menus, session validation, agent CLI, and `llm-task` agree with transport behavior.
@@ -52,7 +52,7 @@ title: "Thinking levels"
 
 - Send a message that is **only** the directive (whitespace allowed), e.g. `/think:medium` or `/t high`.
 - That sticks for the current session (per-sender by default). Use `/think default` to clear the session override and inherit the configured/provider default; aliases include `inherit`, `clear`, `reset`, and `unpin`.
-- `/think off` stores an explicit off override. It disables thinking until you change or clear the session override.
+- `/think off` stores an explicit off override until you change or clear it. Whether the upstream model can disable thinking depends on the selected provider and auth route.
 - Confirmation reply is sent (`Thinking level set to high.` / `Thinking disabled.`). If the level is invalid (e.g. `/thinking big`), the command is rejected with a hint and the session state is left unchanged.
 - Send `/think` (or `/think:`) with no argument to see the current thinking level.
 

--- a/extensions/codex/src/app-server/reasoning-effort.ts
+++ b/extensions/codex/src/app-server/reasoning-effort.ts
@@ -9,21 +9,12 @@ const CODEX_REASONING_EFFORTS = [
   "max",
   "ultra",
 ] as const;
-export type CodexReasoningEffort = (typeof CODEX_REASONING_EFFORTS)[number];
+type CodexEnabledReasoningEffort = (typeof CODEX_REASONING_EFFORTS)[number];
+export type CodexReasoningEffort = CodexEnabledReasoningEffort | "none";
 
 const LEGACY_PRO_REASONING_EFFORTS = ["medium", "high", "xhigh"] as const;
 const LEGACY_PRO_MODEL_ID_RE = /^gpt-5\.[45]-pro$/u;
 const MODERN_GPT_5_MODEL_ID_RE = /^gpt-5\.(?:[3-9]|[1-9]\d)(?:$|-)/u;
-
-function normalizeCodexReasoningEfforts(
-  efforts: readonly string[] | null | undefined,
-): CodexReasoningEffort[] {
-  if (!efforts) {
-    return [];
-  }
-  const supported = new Set(efforts.map((effort) => effort.trim().toLowerCase()));
-  return CODEX_REASONING_EFFORTS.filter((effort) => supported.has(effort));
-}
 
 /** Read reasoning metadata after the Codex app-server route has been selected. */
 export function readCodexSupportedReasoningEfforts(compat: unknown): string[] | undefined {
@@ -38,10 +29,13 @@ export function readCodexSupportedReasoningEfforts(compat: unknown): string[] | 
 }
 
 function resolveSupportedReasoningEffort(params: {
-  requested: CodexReasoningEffort;
+  requested: CodexEnabledReasoningEffort;
   supportedReasoningEfforts: readonly string[];
-}): CodexReasoningEffort | undefined {
-  const supported = normalizeCodexReasoningEfforts(params.supportedReasoningEfforts);
+}): CodexEnabledReasoningEffort | undefined {
+  const declared = new Set(
+    params.supportedReasoningEfforts.map((effort) => effort.trim().toLowerCase()),
+  );
+  const supported = CODEX_REASONING_EFFORTS.filter((effort) => declared.has(effort));
   if (supported.includes(params.requested)) {
     return params.requested;
   }
@@ -62,7 +56,10 @@ export function resolveCodexAppServerReasoningEffort(params: {
   modelId: string;
   supportedReasoningEfforts?: readonly string[];
 }): CodexReasoningEffort | null {
-  if (params.thinkLevel === "off" || params.thinkLevel === "adaptive") {
+  if (params.thinkLevel === "off") {
+    return params.supportedReasoningEfforts?.includes("none") ? "none" : null;
+  }
+  if (params.thinkLevel === "adaptive") {
     return null;
   }
   if (params.supportedReasoningEfforts) {

--- a/extensions/codex/src/app-server/run-attempt.reasoning-effort.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.reasoning-effort.test.ts
@@ -1,9 +1,9 @@
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
 import type { ModelCompatConfig } from "openclaw/plugin-sdk/provider-model-types";
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 import {
   createStartedThreadHarness,
   createTestParams,
-  fastWait,
   runCodexAppServerAttempt,
   setupRunAttemptTestHooks,
   threadStartResult,
@@ -29,12 +29,15 @@ describe("Codex reasoning effort across completed turns", () => {
     "changes high to off on the same thread with $metadata metadata",
     async ({ metadata, supported, expectedOff }) => {
       let turnCount = 0;
+      let turnStarted = createDeferred<void>();
       const harness = createStartedThreadHarness(async (method) => {
         if (method === "thread/resume") {
           return threadStartResult();
         }
         if (method === "turn/start") {
-          return turnStartResult(`turn-${++turnCount}`);
+          const result = turnStartResult(`turn-${++turnCount}`);
+          turnStarted.resolve();
+          return result;
         }
         return undefined;
       });
@@ -58,12 +61,14 @@ describe("Codex reasoning effort across completed turns", () => {
       };
 
       for (const [index, thinkLevel] of (["high", "off"] as const).entries()) {
+        turnStarted = createDeferred<void>();
         const run = runCodexAppServerAttempt({
           ...params,
           thinkLevel,
           runId: `run-${index + 1}`,
         });
-        await vi.waitFor(() => expect(turnCount).toBe(index + 1), fastWait);
+        await Promise.race([turnStarted.promise, run]);
+        expect(turnCount).toBe(index + 1);
         await harness.completeTurn({ threadId: "thread-1", turnId: `turn-${index + 1}` });
         await run;
       }

--- a/extensions/codex/src/app-server/run-attempt.reasoning-effort.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.reasoning-effort.test.ts
@@ -1,0 +1,87 @@
+import type { ModelCompatConfig } from "openclaw/plugin-sdk/provider-model-types";
+import { describe, expect, it, vi } from "vitest";
+import {
+  createStartedThreadHarness,
+  createTestParams,
+  fastWait,
+  runCodexAppServerAttempt,
+  setupRunAttemptTestHooks,
+  threadStartResult,
+  turnStartResult,
+} from "./run-attempt-test-harness.js";
+
+setupRunAttemptTestHooks();
+
+describe("Codex reasoning effort across completed turns", () => {
+  it.each([
+    {
+      metadata: "Platform",
+      supported: ["none", "low", "medium", "high", "xhigh", "max"],
+      expectedOff: "none",
+    },
+    {
+      metadata: "subscription",
+      supported: ["low", "medium", "high", "xhigh", "max"],
+      expectedOff: null,
+    },
+    { metadata: "unknown", supported: undefined, expectedOff: null },
+  ] as const)(
+    "changes high to off on the same thread with $metadata metadata",
+    async ({ metadata, supported, expectedOff }) => {
+      let turnCount = 0;
+      const harness = createStartedThreadHarness(async (method) => {
+        if (method === "thread/resume") {
+          return threadStartResult();
+        }
+        if (method === "turn/start") {
+          return turnStartResult(`turn-${++turnCount}`);
+        }
+        return undefined;
+      });
+      const params = createTestParams();
+      const compat: ModelCompatConfig = {
+        supportsTools: false,
+        ...(supported ? { supportedReasoningEfforts: [...supported] } : {}),
+      };
+      params.provider = "openai";
+      params.modelId = "gpt-5.6-luna";
+      params.model = {
+        ...params.model,
+        provider: "openai",
+        id: params.modelId,
+        api: metadata === "subscription" ? "openai-chatgpt-responses" : "openai-responses",
+        baseUrl:
+          metadata === "subscription"
+            ? "https://chatgpt.com/backend-api/codex"
+            : "https://api.openai.com/v1",
+        compat,
+      };
+
+      for (const [index, thinkLevel] of (["high", "off"] as const).entries()) {
+        const run = runCodexAppServerAttempt({
+          ...params,
+          thinkLevel,
+          runId: `run-${index + 1}`,
+        });
+        await vi.waitFor(() => expect(turnCount).toBe(index + 1), fastWait);
+        await harness.completeTurn({ threadId: "thread-1", turnId: `turn-${index + 1}` });
+        await run;
+      }
+
+      expect(harness.requests.filter(({ method }) => method === "thread/start")).toHaveLength(1);
+      const turnRequests = harness.requests.filter(({ method }) => method === "turn/start");
+      expect(turnRequests.map(({ params: request }) => request)).toMatchObject([
+        {
+          threadId: "thread-1",
+          effort: "high",
+          collaborationMode: { settings: { reasoning_effort: "high" } },
+        },
+        {
+          threadId: "thread-1",
+          effort: expectedOff,
+          collaborationMode: { settings: { reasoning_effort: expectedOff } },
+        },
+      ]);
+    },
+  );
+});

--- a/extensions/codex/src/app-server/side-question.test.ts
+++ b/extensions/codex/src/app-server/side-question.test.ts
@@ -16,6 +16,7 @@ import {
   createMockPluginRegistry,
   loadWebFetchToolFactoryForTest,
 } from "openclaw/plugin-sdk/plugin-test-runtime";
+import type { ModelCompatConfig } from "openclaw/plugin-sdk/provider-model-types";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   codexTestTurnIds,
@@ -29,7 +30,7 @@ import {
   createCodexTestBindingStore,
   type CodexAppServerBindingStore,
 } from "./session-binding.test-helpers.js";
-import { createClientHarness } from "./test-support.js";
+import { createClientHarness, createCodexTestModel } from "./test-support.js";
 
 const readCodexAppServerBindingMock = vi.fn();
 const isCodexAppServerNativeAuthProfileMock = vi.fn();
@@ -1000,6 +1001,64 @@ describe("runCodexAppServerSideQuestion", () => {
     expect(replacementClient.requests).toHaveLength(1);
   });
 
+  it.each([
+    {
+      metadata: "Platform",
+      supported: ["none", "low", "medium", "high", "xhigh", "max"],
+      expected: "none",
+    },
+    {
+      metadata: "subscription",
+      supported: ["low", "medium", "high", "xhigh", "max"],
+      expected: null,
+    },
+    { metadata: "unknown", supported: undefined, expected: null },
+  ] as const)(
+    "sends off with $metadata metadata to the side-question request boundary",
+    async ({ metadata, supported, expected }) => {
+      const client = createFakeClient();
+      getSharedCodexAppServerClientMock.mockResolvedValue(client);
+      const compat: ModelCompatConfig | undefined = supported
+        ? { supportedReasoningEfforts: [...supported] }
+        : undefined;
+      const params = sideParams({
+        model: "gpt-5.6-luna",
+        resolvedThinkLevel: "off",
+        runtimeModel: {
+          ...createCodexTestModel(),
+          id: "gpt-5.6-luna",
+          api: metadata === "subscription" ? "openai-chatgpt-responses" : "openai-responses",
+          baseUrl:
+            metadata === "subscription"
+              ? "https://chatgpt.com/backend-api/codex"
+              : "https://api.openai.com/v1",
+          compat,
+        },
+      });
+      if (metadata !== "subscription") {
+        params.preparedRuntimeAuth = platformPreparedRuntimeAuth("platform-test-key");
+        params.authProfileId = undefined;
+        params.authProfileIdSource = undefined;
+        isCodexAppServerNativeAuthProfileMock.mockReturnValue(false);
+      }
+      params.preparedRuntimeAuth.plan.modelRoute!.modelId = params.model;
+
+      await expect(runCodexAppServerSideQuestion(params)).resolves.toEqual({
+        text: "Side answer.",
+      });
+
+      const turnStartCall = client.request.mock.calls.find(([method]) => method === "turn/start");
+      expect(turnStartCall?.[1]).toMatchObject({
+        threadId: "side-thread",
+        model: "gpt-5.6-luna",
+        effort: expected,
+        collaborationMode: {
+          settings: { model: "gpt-5.6-luna", reasoning_effort: expected },
+        },
+      });
+    },
+  );
+
   it("rejects a Platform plan before binding OAuth can fill missing prepared auth", async () => {
     await expect(
       runCodexAppServerSideQuestion(
@@ -1137,8 +1196,9 @@ describe("runCodexAppServerSideQuestion", () => {
           runtimeModel: {
             id: "claude-opus-4-6",
             provider: "anthropic",
-            compat: { supportsTools: false },
+            compat: { supportsTools: false, supportedReasoningEfforts: ["none", "high"] },
           } as never,
+          resolvedThinkLevel: "off",
           authProfileId: "openai:outer",
         }),
         { pluginConfig: { supervision: { enabled: true } } },

--- a/extensions/codex/src/app-server/thread-lifecycle.test.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.test.ts
@@ -3,7 +3,10 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import type { EmbeddedRunAttemptParamsV2 as EmbeddedRunAttemptParams } from "openclaw/plugin-sdk/agent-harness-runtime";
-import { GPT5_BEHAVIOR_CONTRACT as CODEX_GPT5_BEHAVIOR_CONTRACT } from "openclaw/plugin-sdk/provider-model-shared";
+import {
+  GPT5_BEHAVIOR_CONTRACT as CODEX_GPT5_BEHAVIOR_CONTRACT,
+  type ModelCompatConfig,
+} from "openclaw/plugin-sdk/provider-model-shared";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { codexCatalogHomeId } from "../session-catalog-home-id.js";
 import { resolveCodexAppServerHomeDir } from "./auth-start-options.js";
@@ -1716,7 +1719,12 @@ describe("Codex app-server native code mode config", () => {
 
   it("does not overwrite native supervised turn settings", () => {
     const params = createAttemptParams({ provider: "anthropic" });
-    params.thinkLevel = "high";
+    params.thinkLevel = "off";
+    const compat: ModelCompatConfig = { supportedReasoningEfforts: ["none", "high"] };
+    params.model = {
+      ...createCodexTestModel("anthropic"),
+      compat,
+    };
     const request = buildTurnStartParams(params, {
       threadId: "thread-supervised",
       cwd: "/repo",
@@ -5309,6 +5317,8 @@ describe("resolveReasoningEffort (#71946)", () => {
     { requested: "max", supported: maxEfforts, expected: "max" },
     { requested: "ultra", supported: maxEfforts, expected: "max" },
     { requested: "ultra", supported: ultraEfforts, expected: "ultra" },
+    { requested: "high", supported: ["none", "max"], expected: "max" },
+    { requested: "high", supported: ["none"], expected: null },
   ] as const)(
     "maps $requested to $expected using provider-supported efforts",
     ({ requested, supported, expected }) => {
@@ -5328,6 +5338,9 @@ describe("resolveReasoningEffort (#71946)", () => {
   it("omits non-effort think levels", () => {
     expect(resolveReasoningEffort("off", "catalog-model", ultraEfforts)).toBeNull();
     expect(resolveReasoningEffort("adaptive", "catalog-model", ultraEfforts)).toBeNull();
+    expect(
+      resolveReasoningEffort("adaptive", "catalog-model", ["none", ...ultraEfforts]),
+    ).toBeNull();
   });
 });
 

--- a/src/agents/embedded-agent-runner/run/runtime-preparation.thinking.test.ts
+++ b/src/agents/embedded-agent-runner/run/runtime-preparation.thinking.test.ts
@@ -1,0 +1,254 @@
+import { mkdtemp, realpath, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { buildOpenAIProvider } from "../../../../extensions/openai/api.js";
+import type { OpenClawConfig } from "../../../config/types.openclaw.js";
+import { setCurrentPluginMetadataSnapshot } from "../../../plugins/current-plugin-metadata.test-support.js";
+import { loadPluginManifest } from "../../../plugins/manifest.js";
+import { clearPluginMetadataLifecycleCaches } from "../../../plugins/plugin-metadata-lifecycle.js";
+import { createPluginMetadataSnapshotFixture } from "../../../plugins/plugin-metadata.test-support.js";
+import { createEmptyPluginRegistry } from "../../../plugins/registry-empty.js";
+import {
+  resetPluginRuntimeStateForTest,
+  setActivePluginRegistry,
+} from "../../../plugins/runtime.js";
+import { createTestAdmittedRunContext } from "../../admitted-run-context.test-support.js";
+import type { AuthProfileStore } from "../../auth-profiles.js";
+import type { ResolvedProviderAuth } from "../../model-auth.js";
+import { prepareModelRunCapabilities } from "../../model-catalog-lookup.js";
+import type { ModelCatalogEntry } from "../../model-catalog.types.js";
+import type { PreparedModelRuntimeSnapshot } from "../../prepared-model-runtime.js";
+import { createEmptyAgentDiscoveryStores } from "../model.js";
+import { resolveBundledStaticCatalogModel } from "../model.static-catalog.js";
+import { prepareEmbeddedRunRuntime } from "./runtime-preparation.js";
+
+const fixtures = vi.hoisted((): { authStore: AuthProfileStore } => ({
+  authStore: { version: 1, profiles: {} },
+}));
+
+// Credential acquisition and native process installation are outside this network-free
+// composition. Route planning, model resolution, auth commit, and the overlay remain real.
+vi.mock("../../model-auth.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../model-auth.js")>()),
+  ensureAuthProfileStore: () => fixtures.authStore,
+  ensureAuthProfileStoreWithoutExternalProfiles: () => fixtures.authStore,
+  getApiKeyForModelCore: async ({
+    profileId,
+  }: {
+    profileId: string;
+  }): Promise<ResolvedProviderAuth> => ({
+    apiKey: "fixture-key",
+    mode: "api-key",
+    source: "fixture",
+    profileId,
+  }),
+}));
+vi.mock("../../auth-profiles.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../auth-profiles.js")>()),
+  ensureAuthProfileStore: () => fixtures.authStore,
+}));
+vi.mock("openclaw/plugin-sdk/provider-auth-runtime", () => ({
+  resolveApiKeyForProvider: async () => ({ mode: "token", apiKey: "fixture-token" }),
+  resolveProviderAuthProfileMetadata: () => ({}),
+}));
+vi.mock("openclaw/plugin-sdk/provider-catalog-live-runtime", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("openclaw/plugin-sdk/provider-catalog-live-runtime")>()),
+  getCachedLiveProviderModelRows: async () => [
+    {
+      slug: "gpt-5.6-luna",
+      supported_reasoning_levels: ["none", "low", "medium", "high", "xhigh", "max", "ultra"],
+    },
+  ],
+}));
+vi.mock("../../harness/runtime-plugin.js", () => ({
+  ensureSelectedAgentHarnessPlugin: async () => undefined,
+}));
+vi.mock("../../harness/selection.js", () => {
+  const harness = {
+    id: "codex",
+    label: "Codex fixture",
+    authBootstrap: "harness",
+    supports: () => ({ supported: true }),
+    runAttempt: vi.fn(),
+  };
+  return {
+    selectAgentHarness: () => harness,
+    selectAgentHarnessForPreparedModelProviders: () => harness,
+  };
+});
+
+const MODEL_ID = "gpt-5.6-luna";
+const PLATFORM = "https://api.openai.com/v1";
+const SUBSCRIPTION = "https://chatgpt.com/backend-api/codex";
+
+describe("selected route thinking metadata at runtime preparation", () => {
+  let root: string;
+  let preparedModelRuntime: PreparedModelRuntimeSnapshot;
+  let platformModel: NonNullable<ReturnType<typeof resolveBundledStaticCatalogModel>>;
+  const provider = buildOpenAIProvider();
+
+  beforeEach(async () => {
+    root = await realpath(await mkdtemp(path.join(tmpdir(), "openclaw-effort-route-")));
+    const pluginDir = path.resolve("extensions/openai");
+    const loaded = loadPluginManifest(pluginDir);
+    if (!loaded.ok) {
+      throw new Error(loaded.error);
+    }
+    const metadataSnapshot = createPluginMetadataSnapshotFixture({
+      plugins: [{ ...loaded.manifest, origin: "bundled", rootDir: pluginDir }],
+    });
+    const pluginRegistry = createEmptyPluginRegistry();
+    pluginRegistry.providers.push({ pluginId: "openai", source: pluginDir, provider });
+    const config: OpenClawConfig = {};
+    setCurrentPluginMetadataSnapshot(metadataSnapshot, { config, workspaceDir: root });
+    setActivePluginRegistry(pluginRegistry, "effort-route", "default", root);
+    const model = resolveBundledStaticCatalogModel({
+      provider: "openai",
+      modelId: MODEL_ID,
+      cfg: config,
+      env: {},
+      metadataSnapshot,
+      includeRuntimeDiscovery: true,
+    });
+    if (!model) {
+      throw new Error("missing Platform catalog fixture");
+    }
+    platformModel = model;
+    preparedModelRuntime = {
+      agentDir: path.join(root, "agent"),
+      workspaceDir: root,
+      activeProjectKeys: [],
+      config,
+      authModes: {},
+      metadataSnapshot,
+      pluginRegistry,
+      allowGatewaySubagentBinding: false,
+      modelCatalog: { entries: [], routeVariants: [] },
+      configuredRuntimeModels: [],
+      inlineProviderModels: [],
+      createStores: createEmptyAgentDiscoveryStores,
+    };
+    fixtures.authStore = {
+      version: 1,
+      profiles: {
+        "openai:platform": { type: "api_key", provider: "openai", key: "fixture-key" },
+        "openai:subscription": { type: "token", provider: "openai", token: "fixture-token" },
+      },
+    };
+  });
+
+  afterEach(async () => {
+    setCurrentPluginMetadataSnapshot(undefined);
+    resetPluginRuntimeStateForTest();
+    clearPluginMetadataLifecycleCaches();
+    vi.unstubAllEnvs();
+    vi.unstubAllGlobals();
+    await rm(root, { recursive: true, force: true });
+  });
+
+  it.each([
+    { route: "platform", capability: "absent" },
+    { route: "platform", capability: "platform" },
+    { route: "platform", capability: "subscription" },
+    { route: "subscription", capability: "absent" },
+    { route: "subscription", capability: "platform" },
+    { route: "subscription", capability: "subscription" },
+  ] as const)(
+    "preserves $route disablement with $capability prepared capability",
+    async ({ route, capability }) => {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(() => {
+          throw new Error("unexpected network request");
+        }),
+      );
+      const catalog = await provider.catalog!.run({
+        config: {},
+        env: {},
+        resolveProviderAuth: () => ({ apiKey: "fixture-token", mode: "token", source: "profile" }),
+        resolveProviderApiKey: () => ({ apiKey: undefined }),
+      });
+      if (!catalog || !("providers" in catalog)) {
+        throw new Error("missing subscription catalog fixture");
+      }
+      const subscriptionRow = catalog.providers.openai?.models.find(
+        (model) => model.id === MODEL_ID,
+      );
+      if (!subscriptionRow) {
+        throw new Error("missing subscription model fixture");
+      }
+      const subscriptionModel = { ...subscriptionRow, provider: "openai" };
+      expect(subscriptionModel.thinkingLevelMap?.off).toBeNull();
+      expect(subscriptionModel.compat?.supportedReasoningEfforts).not.toContain("none");
+      const capabilityModel = capability === "platform" ? platformModel : subscriptionModel;
+      const capabilityApi =
+        capability === "platform" ? "openai-responses" : "openai-chatgpt-responses";
+      expect(capabilityModel.api).toBe(capabilityApi);
+      const capabilityEntry = {
+        ...capabilityModel,
+        api: capabilityApi,
+      } satisfies ModelCatalogEntry;
+      const modelThinkingCapability =
+        capability === "absent"
+          ? undefined
+          : prepareModelRunCapabilities([[capabilityEntry], []], ["openai", MODEL_ID, "codex"])
+              .modelThinkingCapability;
+      const runId = `effort-${route}-${capability}`;
+      const runtime = await prepareEmbeddedRunRuntime({
+        runParams: {
+          runId,
+          admittedRunContext: createTestAdmittedRunContext(runId),
+          sessionId: "effort-session",
+          sessionKey: "agent:main:effort-session",
+          agentId: "main",
+          prompt: "Reply briefly.",
+          workspaceDir: root,
+          timeoutMs: 5_000,
+          config: preparedModelRuntime.config,
+          authProfileId: `openai:${route}`,
+          authProfileIdSource: "user",
+          thinkLevel: "off",
+          modelThinkingCapability,
+        },
+        provider: "openai",
+        modelId: MODEL_ID,
+        agentDir: preparedModelRuntime.agentDir,
+        workspaceDir: root,
+        globalLane: "test",
+        hookRunner: undefined,
+        hookContext: { sessionId: "effort-session", workspaceDir: root },
+        markStartupStage: () => {},
+        notifyExecutionPhase: () => {},
+        fallbackConfigured: false,
+        preparedModelRuntime,
+      });
+      try {
+        const { effectiveModel, activePreparedAuthPlan } = runtime.snapshot();
+        expect(activePreparedAuthPlan.modelRoute?.authRequirement).toBe(
+          route === "platform" ? "api-key" : "subscription",
+        );
+        expect(effectiveModel.baseUrl).toBe(route === "platform" ? PLATFORM : SUBSCRIPTION);
+        expect(effectiveModel.thinkingLevelMap?.off).toBe(route === "platform" ? "none" : null);
+        const efforts = effectiveModel.compat?.supportedReasoningEfforts ?? [];
+        if (modelThinkingCapability) {
+          expect(modelThinkingCapability.route).toBeUndefined();
+          expect(efforts).toEqual(
+            expect.arrayContaining(
+              modelThinkingCapability.compat.supportedReasoningEfforts?.filter(
+                (effort) => effort !== "none",
+              ) ?? [],
+            ),
+          );
+        }
+        if (route === "platform") {
+          expect(efforts).toContain("none");
+        } else {
+          expect(efforts).not.toContain("none");
+        }
+      } finally {
+        runtime.stopRuntimeAuthRefreshTimer();
+      }
+    },
+  );
+});

--- a/src/agents/embedded-agent-runner/run/runtime-preparation.thinking.test.ts
+++ b/src/agents/embedded-agent-runner/run/runtime-preparation.thinking.test.ts
@@ -2,8 +2,8 @@ import { mkdtemp, realpath, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { buildOpenAIProvider } from "../../../../extensions/openai/api.js";
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
+import { loadBundledPluginPublicSurface } from "../../../plugin-sdk/test-helpers/public-surface-loader.js";
 import { setCurrentPluginMetadataSnapshot } from "../../../plugins/current-plugin-metadata.test-support.js";
 import { loadPluginManifest } from "../../../plugins/manifest.js";
 import { clearPluginMetadataLifecycleCaches } from "../../../plugins/plugin-metadata-lifecycle.js";
@@ -13,6 +13,7 @@ import {
   resetPluginRuntimeStateForTest,
   setActivePluginRegistry,
 } from "../../../plugins/runtime.js";
+import type { ProviderPlugin } from "../../../plugins/types.js";
 import { createTestAdmittedRunContext } from "../../admitted-run-context.test-support.js";
 import type { AuthProfileStore } from "../../auth-profiles.js";
 import type { ResolvedProviderAuth } from "../../model-auth.js";
@@ -86,9 +87,13 @@ describe("selected route thinking metadata at runtime preparation", () => {
   let root: string;
   let preparedModelRuntime: PreparedModelRuntimeSnapshot;
   let platformModel: NonNullable<ReturnType<typeof resolveBundledStaticCatalogModel>>;
-  const provider = buildOpenAIProvider();
+  let provider: ProviderPlugin;
 
   beforeEach(async () => {
+    const { buildOpenAIProvider } = await loadBundledPluginPublicSurface<{
+      buildOpenAIProvider: () => ProviderPlugin;
+    }>({ pluginId: "openai", artifactBasename: "api.js" });
+    provider = buildOpenAIProvider();
     root = await realpath(await mkdtemp(path.join(tmpdir(), "openclaw-effort-route-")));
     const pluginDir = path.resolve("extensions/openai");
     const loaded = loadPluginManifest(pluginDir);

--- a/src/agents/embedded-agent-runner/run/runtime-preparation.thinking.test.ts
+++ b/src/agents/embedded-agent-runner/run/runtime-preparation.thinking.test.ts
@@ -121,6 +121,7 @@ describe("selected route thinking metadata at runtime preparation", () => {
     }
     platformModel = model;
     preparedModelRuntime = {
+      catalogOwner: undefined,
       agentDir: path.join(root, "agent"),
       workspaceDir: root,
       activeProjectKeys: [],

--- a/src/agents/model-catalog-lookup.thinking.test.ts
+++ b/src/agents/model-catalog-lookup.thinking.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+import { resolvePreparedModelThinkingCompat } from "./model-catalog-lookup.js";
+
+describe("prepared thinking disablement ownership", () => {
+  it.each([
+    {
+      name: "retains route disablement while replacing enabled tiers",
+      selected: ["none", "low"],
+      prepared: ["max", "ultra"],
+      expected: ["none", "max", "ultra"],
+    },
+    {
+      name: "does not grant disablement to an unknown route",
+      selected: undefined,
+      prepared: ["none", "max", "ultra"],
+      expected: ["max", "ultra"],
+    },
+    {
+      name: "does not grant disablement from nullable route metadata",
+      selected: null,
+      prepared: ["none", "max"],
+      expected: ["max"],
+    },
+    {
+      name: "retains route disablement when enabled tiers are unknown",
+      selected: ["none", "low"],
+      prepared: null,
+      expected: ["none"],
+    },
+    {
+      name: "preserves nullable unknown metadata",
+      selected: undefined,
+      prepared: null,
+      expected: null,
+    },
+    {
+      name: "leaves an absent effort overlay absent",
+      selected: ["none", "high"],
+      prepared: undefined,
+      expected: undefined,
+    },
+    {
+      name: "accepts disablement from the exact physical route",
+      selected: undefined,
+      prepared: ["none", "high"],
+      expected: ["none", "high"],
+      routeBound: true,
+    },
+    {
+      name: "accepts nullable metadata from the exact physical route",
+      selected: ["none", "high"],
+      prepared: null,
+      expected: null,
+      routeBound: true,
+    },
+  ])("$name", ({ selected, prepared, expected, routeBound }) => {
+    const route = { api: "openai-responses", baseUrl: "https://reasoning.example/v1" } as const;
+    const model = {
+      provider: "reasoning-provider",
+      id: "reasoning-model",
+      ...route,
+      compat: { supportedReasoningEfforts: selected },
+    };
+    const result = resolvePreparedModelThinkingCompat({
+      model,
+      agentRuntime: "native-harness",
+      capability: {
+        provider: model.provider,
+        modelId: model.id,
+        agentRuntime: "native-harness",
+        ...(routeBound ? { route } : {}),
+        compat: { thinkingFormat: "openai", supportedReasoningEfforts: prepared },
+      },
+    });
+
+    expect(result).toEqual({ thinkingFormat: "openai", supportedReasoningEfforts: expected });
+  });
+});

--- a/src/agents/model-catalog-lookup.ts
+++ b/src/agents/model-catalog-lookup.ts
@@ -79,7 +79,9 @@ function prepareModelThinkingCapability(params: {
 /** Resolves prepared thinking metadata only for the exact final model route and harness. */
 export function resolvePreparedModelThinkingCompat(params: {
   capability?: PreparedModelThinkingCapability;
-  model: Pick<Model, "provider" | "id" | "api" | "baseUrl">;
+  model: Pick<Model, "provider" | "id" | "api" | "baseUrl"> & {
+    compat?: Model["compat"] | ModelThinkingCompat;
+  };
   agentRuntime: string;
 }): ModelThinkingCompat | undefined {
   const capability = params.capability;
@@ -88,12 +90,29 @@ export function resolvePreparedModelThinkingCompat(params: {
   }
   const runtimeModelId = canonicalizeProviderModelId(capability.provider, params.model.id);
   const preparedModelId = canonicalizeProviderModelId(capability.provider, capability.modelId);
-  return normalizeProviderId(params.model.provider) === capability.provider &&
-    runtimeModelId === preparedModelId &&
-    normalizeLowercaseStringOrEmpty(params.agentRuntime) === capability.agentRuntime &&
-    (!capability.route || modelTransportRoutesMatch(params.model, capability.route))
-    ? capability.compat
-    : undefined;
+  if (
+    normalizeProviderId(params.model.provider) !== capability.provider ||
+    runtimeModelId !== preparedModelId ||
+    normalizeLowercaseStringOrEmpty(params.agentRuntime) !== capability.agentRuntime ||
+    (capability.route && !modelTransportRoutesMatch(params.model, capability.route))
+  ) {
+    return undefined;
+  }
+  const { compat, route } = capability;
+  const efforts = compat.supportedReasoningEfforts;
+  if (route || efforts === undefined) {
+    return compat;
+  }
+  // "none" disables reasoning; it is not an enabled effort tier. Harness-wide
+  // tiers may cross auth routes, but only the selected route can allow "none".
+  const routeEfforts = projectModelThinkingCompat(params.model.compat)?.supportedReasoningEfforts;
+  const enabledEfforts = efforts?.filter((effort) => effort !== "none");
+  return {
+    ...compat,
+    supportedReasoningEfforts: routeEfforts?.includes("none")
+      ? ["none", ...(enabledEfforts ?? [])]
+      : (enabledEfforts ?? efforts),
+  };
 }
 
 /** Projects the prepared capabilities needed by one selected run candidate. */

--- a/test/vitest/vitest.extension-codex-app-server-attempt-extra.config.ts
+++ b/test/vitest/vitest.extension-codex-app-server-attempt-extra.config.ts
@@ -16,6 +16,7 @@ export function createExtensionCodexAppServerAttemptExtraVitestConfig(
       "extensions/codex/src/app-server/run-attempt.native-hook-relay.test.ts",
       "extensions/codex/src/app-server/run-attempt.native-hook-relay-retention.test.ts",
       "extensions/codex/src/app-server/run-attempt.notification-burst.test.ts",
+      "extensions/codex/src/app-server/run-attempt.reasoning-effort.test.ts",
       "extensions/codex/src/app-server/run-attempt-runtime.authority.test.ts",
       "extensions/codex/src/app-server/run-attempt.steering.test.ts",
       "extensions/codex/src/app-server/run-attempt.turn-watches.test.ts",


### PR DESCRIPTION
Closes #132253

<details>
<summary>Additional instructions</summary>

This is a same-repository maintainer-editable branch. AI-assisted implementation and independent Codex review; no agent transcript is included.

</details>

## What Problem This Solves

Fixes an issue where users disabling thinking would still get native-default reasoning when running a supported OpenAI Platform model through Codex. This also affects Codex side questions. On an isolated live `gpt-5.6-luna` thread, high followed by off sent `high` followed by `medium`, rather than explicitly disabling reasoning.

## Why This Change Was Made

Disabled reasoning belongs to the selected physical route, while enabled effort tiers can be supplied by the native harness. Preserve that distinction at the existing prepared-metadata merge, then make the shared Codex mapper send `none` only when supported. Both normal turn fields and side-question fields already share that mapper; no second request path is added.

Native Max/Ultra overlays, subscription/no-none behavior, unknown metadata, adaptive behavior, and native-owned supervision remain intact. `none` stays outside enabled-effort ranking. The redundant normalization helper is absorbed into its sole caller.

Production LOC: **+38/-22 (net +16)**. Tests: **+507/-4 (net +503)**. Test-support registration: +1/-0. Docs: +2/-2. The growth is the ownership split between physical-route disablement and harness-enabled tiers, not a provider/model-name special case. A mapper-only change misses erased Platform metadata and can grant disablement to subscription routes; unioning whole lists or binding every native tier to one auth route breaks the complementary contract.

The harness-scoped enabled-tier carry was deliberately introduced in [the Max/Ultra capability repair](https://github.com/openclaw/openclaw/commit/efc33f882e9bb7aea950651e7445f39017149d82). This fix preserves it. The existing off/null conversion is longstanding; the shallow checkout's blame boundary does not establish its original introduction.

## User Impact

On Platform routes that advertise disabled reasoning, off now sends explicit `reasoning.effort: "none"`, including after a high-effort turn on the same native thread. Routes without this capability retain their previous behavior rather than receiving an unsupported value. No new configuration, migration, dependency, schema, or public API is introduced. The [thinking documentation](https://docs.openclaw.ai/tools/thinking) now explains the route-dependent meaning of off.

This is separate from hidden-model lookup work.

## Evidence

### Authenticated before/after

Real Codex app-server **0.150.1**, isolated HOME/CODEX_HOME and empty workspace, ephemeral native auth, harmless fixed prompt. A local recorder forwarded unchanged native bodies to the official Platform Responses API and retained only effort/status/token counters. No operator Gateway or native thread store was modified; temporary credentials/processes were cleaned up.

Before, on one `gpt-5.6-luna` thread:

| Requested case | App-server effort | API request/response effort | Observed reasoning tokens |
| --- | --- | --- | ---: |
| high | high | high | 0 |
| off | null | medium | 8 |
| explicit-none control | none | none | 0 |

After the repair, the real Platform manifest and observed native model/list efforts were composed through the production metadata owner and `buildTurnStartParams`. The generated requests were submitted to the real app-server, replacing only the disposable thread id and cwd:

| Requested case on one thread | Both app-server effort fields | API request/response effort | Observed reasoning tokens |
| --- | --- | --- | ---: |
| high | high | high | 0 |
| off | none | none | 0 |
| adaptive | null | medium | 0 |

All turns completed with HTTP 200. Token counts are observations, not a promise for every inference. Native model/list omitted `none`; the selected Platform route advertised and accepted it. This is native app-server/API proof, not a Control UI or channel recording; the change does not alter rendering or Gateway session lifecycle.

### Regression and dependency proof

Before production edits, the six-case real auth-route/model-preparation matrix failed in both cross-route directions. Completed same-thread high-to-off and side-question request tests each failed with null instead of none in both fields. The repair also has generic metadata-edge controls and verifies that enabled effort never falls back to none.

Initial post-fix proof: **288 focused tests passed** across the metadata owner, real route composition, completed native attempts, side questions, lifecycle mapping/supervision, direct AI sibling, and unchanged model-resolution consistency. Core/plugin production and test typechecks, scoped type-aware lint, formatting, and architecture/ownership guards passed. An extensible-runtime-versus-closed-catalog fixture type mismatch was corrected with explicit native API validation and a typed catalog entry, without a cast or production seam.

Bundled Codex rust-v0.150.1 source was personally inspected at `90854393966b21e9ebfd21b122334eb09a20c93d`: [explicit None enum](https://github.com/openai/codex/blob/90854393966b21e9ebfd21b122334eb09a20c93d/codex-rs/protocol/src/openai_models.rs#L50-L145), [turn precedence](https://github.com/openai/codex/blob/90854393966b21e9ebfd21b122334eb09a20c93d/codex-rs/app-server-protocol/src/protocol/v2/turn.rs#L134-L155), [settings replacement](https://github.com/openai/codex/blob/90854393966b21e9ebfd21b122334eb09a20c93d/codex-rs/core/src/session/thread_settings.rs#L36-L79), and [client fallback](https://github.com/openai/codex/blob/90854393966b21e9ebfd21b122334eb09a20c93d/codex-rs/core/src/client.rs#L851-L868). The same contract was checked in upstream `c2abf869d539a6326a6e5a125dfdb8a5dc488ab4`, with no changes to those contract owners through `0ae94fdd49b05ee7faa4d984d06a68492cb32b54`.

### Integrated-head validation

Initial integrated local proof: `270d17ddd24984610f7e0fbad30802b226362aa7`, integrated onto main `831e2de0a367cb9ad74f59eddb49dc92371b2cec`. The rebase was conflict-free and patch-identical. The bundled Codex version and the production owners/callers used by the authenticated proof did not change.

Passed on the integrated patch:

```sh
node scripts/check-changed.mjs -- docs/tools/thinking.md extensions/codex/src/app-server/reasoning-effort.ts extensions/codex/src/app-server/side-question.test.ts extensions/codex/src/app-server/thread-lifecycle.test.ts extensions/codex/src/app-server/run-attempt.reasoning-effort.test.ts src/agents/model-catalog-lookup.ts src/agents/model-catalog-lookup.thinking.test.ts src/agents/embedded-agent-runner/run/runtime-preparation.thinking.test.ts
node scripts/run-vitest.mjs src/agents/model-catalog-lookup.thinking.test.ts src/agents/embedded-agent-runner/run/runtime-preparation.thinking.test.ts extensions/codex/src/app-server/run-attempt.reasoning-effort.test.ts extensions/codex/src/app-server/side-question.test.ts extensions/codex/src/app-server/thread-lifecycle.test.ts packages/ai/src/providers/openai-reasoning-effort.test.ts
node scripts/run-vitest.mjs src/agents/embedded-agent-runner/model-resolution-consistency.test.ts
node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run/runtime-preparation.thinking.test.ts
node --import ./scripts/tsx.mjs scripts/check-tsgo-core-boundary.mts
pnpm build
pnpm docs:list
git diff --check 831e2de0a367cb9ad74f59eddb49dc92371b2cec...HEAD
```

The focused runs passed 279 + 9 tests; the composition rerun passed all 6 cases after the fixture-only correction described below. The final full changed gate passed, including core/plugin production and test types, scoped lint, formatting, import cycles, unused exports, and ownership guards. The build passed, including plugin distributions and Control UI artifact/performance checks; it emitted dependency eval/timing warnings, with no ineffective dynamic-import warning.

The first integrated changed gate exposed a core TypeScript graph violation in the new composition test's static plugin import. The fixture now uses the existing public-surface loader and the `ProviderPlugin` contract, as its model-resolution sibling does. This preserves the real provider and all assertions without an exemption, mock, or production seam. The failing graph guard, composition tests, and full gate passed afterward. Production remains +38/-22; the fixture correction adds five net test lines.

Independent Codex autoreview of the complete original eight-file patch and a fresh isolated review of the fixture correction both reported no accepted/actionable findings at the default P0 threshold. No production code changed after the authenticated after-proof. No operator state or live credentials were accessed during publication validation.

The old-base whole-checkout gate encountered the pre-existing 724/720 UI shard overflow. Current main's [canonical shard split](https://github.com/openclaw/openclaw/commit/249c248285b03eacc1fdcb9153bc47c6c3a2ec20) is integrated before publication; no UI shard configuration change is part of this PR.

### CI integration corrections

Current head: `3411bd413339b8c00169e96be98972b3856a595d`, based on main `bf94ec5e7e5fc316327017ee497b382c6d954f0a`.

[Initial exact-head CI](https://github.com/openclaw/openclaw/actions/runs/33227768697) found two test integration issues: main had added required snapshot `catalogOwner` metadata while local proof ran, and the new completed-turn test needed registration in the explicit Codex attempt shard. The fixture now declares its known-unbound owner, and the existing shard includes the regression. No baseline or assertion was weakened.

A loaded-host rerun then exposed a five-second polling deadline in the new test's startup driver. It now observes a deferred signal from the exact `turn/start` callback, races early run completion, and preserves the same turn-count, effort, and completed-thread assertions without increasing a timeout. The canonical SDK deferred helper keeps the test within the repository's TypeScript target.

Passed for these test-only corrections:

```sh
node scripts/check-changed.mjs -- src/agents/embedded-agent-runner/run/runtime-preparation.thinking.test.ts test/vitest/vitest.extension-codex-app-server-attempt-extra.config.ts
node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.agents-other.json
node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.extensions.test.json
node scripts/run-oxlint.mjs --tsconfig test/tsconfig/tsconfig.extensions.test.json extensions/codex/src/app-server/run-attempt.reasoning-effort.test.ts
node scripts/run-vitest.mjs extensions/codex/src/app-server/run-attempt.reasoning-effort.test.ts
```

The ownership-audit file passed 23 tests and composition passed all 6 cases in the combined repair run; its completed-turn file initially hit the startup polling issue above. The final separate completed-turn invocation passed all 3 cases. Fresh isolated Codex autoreview of the complete test corrections reported no actionable findings at default P0.

The original full eight-path changed gate and `pnpm build` results above remain the production proof; the incremental gate and focused type/lint checks cover the later test-only edits. The second integration did not change the bundled Codex pin or the affected production owners/callers. Exact-head CI completed successfully at `3411bd413339b8c00169e96be98972b3856a595d`: [CI run 33229199414](https://github.com/openclaw/openclaw/actions/runs/33229199414), 167 successful and 17 intentionally skipped jobs. The required [openclaw/ci-gate job 99039690899](https://github.com/openclaw/openclaw/actions/runs/33229199414/job/99039690899) passed. The repository watcher exited 0 with GREEN; all PR checks were terminal (194 success, 44 skipped, 1 neutral). Native main/PR guards and review artifact validation passed for this exact head. Lead verification and a fresh whole-branch independent Codex review at the configured P0 threshold then completed. Native prepare and merge both succeeded without changing the reviewed head. Landed as [19640ebf009204b6c06d41ff1776d15337609f93](https://github.com/openclaw/openclaw/commit/19640ebf009204b6c06d41ff1776d15337609f93); issue #132253 closed automatically. All nine landed files match the reviewed head byte for byte.
