### PR TITLE
fix(test): gateway admission E2E lacks its reply runtime

### DIFF
--- a/docs/help/testing.md
+++ b/docs/help/testing.md
@@ -1050,14 +1050,14 @@ Run full Mintlify anchor validation when you need in-page heading checks too: `p
 
 These are "real pipeline" regressions without real providers:
 
-- Gateway tool calling (mock OpenAI, real gateway + agent loop): `src/gateway/gateway.test.ts` (case: "runs a mock OpenAI tool call end-to-end via gateway agent loop")
+- Gateway agent admission (real Gateway with a mock OpenAI provider): `src/gateway/gateway.test.ts` (case: "accepts a gateway agent request over ws and returns a run id"; checks acceptance, a run ID, and an abort response).
 - Gateway wizard (WS `wizard.start`/`wizard.next`, writes config + auth enforced): `src/gateway/gateway.test.ts` (case: "runs wizard over ws and writes auth token config")
 
 ## Agent reliability evals (skills)
 
 We already have a few CI-safe tests that behave like "agent reliability evals":
 
-- Mock tool-calling through the real gateway + agent loop (`src/gateway/gateway.test.ts`).
+- Agent admission, run-ID responses, and abort requests through the real Gateway with a mock OpenAI provider (`src/gateway/gateway.test.ts`).
 - End-to-end wizard flows that validate session wiring and config effects (`src/gateway/gateway.test.ts`).
 
 What's still missing for skills (see [Skills](/tools/skills)):

--- a/src/gateway/gateway.test-support.test.ts
+++ b/src/gateway/gateway.test-support.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { withEnvAsync } from "../test-utils/env.js";
+import { removeGatewayTempHome, setupGatewayTempHome } from "./gateway.test-support.js";
+
+describe.each([undefined, "1"])("setupGatewayTempHome with prior minimal mode %s", (prior) => {
+  it.each([undefined, false, true])(
+    "restores minimal mode after minimalGateway=%s",
+    async (minimalGateway) => {
+      await withEnvAsync({ OPENCLAW_TEST_MINIMAL_GATEWAY: prior }, async () => {
+        const { envSnapshot, tempHome } = await setupGatewayTempHome({
+          prefix: "openclaw-gateway-env-",
+          minimalGateway,
+        });
+        try {
+          envSnapshot.restore();
+          // Assert the fixture's boundary before withEnvAsync or global cleanup can restore it.
+          expect(process.env.OPENCLAW_TEST_MINIMAL_GATEWAY).toBe(prior);
+        } finally {
+          await removeGatewayTempHome(tempHome);
+        }
+      });
+    },
+  );
+});

--- a/src/gateway/gateway.test-support.ts
+++ b/src/gateway/gateway.test-support.ts
@@ -18,6 +18,7 @@ export const GATEWAY_TEST_ENV_KEYS = [
   "OPENCLAW_GATEWAY_TOKEN",
   "OPENCLAW_TEST_GATEWAY_OVERRIDE_TOKEN",
   "OPENCLAW_TEST_RUNTIME_OVERRIDE_TOKEN",
+  "OPENCLAW_TEST_MINIMAL_GATEWAY",
   "OPENCLAW_SKIP_CHANNELS",
   "OPENCLAW_SKIP_GMAIL_WATCHER",
   "OPENCLAW_SKIP_CRON",
@@ -54,10 +55,7 @@ export async function removeGatewayTempHome(tempHome: string): Promise<void> {
 }
 
 export async function setupGatewayTempHome(params: { prefix: string; minimalGateway?: boolean }) {
-  const envSnapshot = captureEnv([
-    ...GATEWAY_TEST_ENV_KEYS,
-    ...(params.minimalGateway ? (["OPENCLAW_TEST_MINIMAL_GATEWAY"] as const) : []),
-  ]);
+  const envSnapshot = captureEnv([...GATEWAY_TEST_ENV_KEYS]);
 
   const tempHome = await fs.mkdtemp(path.join(os.tmpdir(), params.prefix));
   setTestEnvValue("HOME", tempHome);

--- a/src/gateway/gateway.test.ts
+++ b/src/gateway/gateway.test.ts
@@ -589,82 +589,92 @@ describe("gateway e2e", () => {
     "accepts a gateway agent request over ws and returns a run id",
     { timeout: GATEWAY_E2E_TIMEOUT_MS },
     async () => {
-      const { baseUrl: openaiBaseUrl, restore } = installOpenAiResponsesMock();
       const { envSnapshot, tempHome, workspaceDir } = await setupGatewayTempHome({
         prefix: "openclaw-gw-mock-home-",
-        minimalGateway: true,
       });
+      const { baseUrl: openaiBaseUrl, restore } = installOpenAiResponsesMock();
 
-      const token = nextGatewayId("test-token");
-      setTestEnvValue("OPENCLAW_GATEWAY_TOKEN", token);
+      try {
+        const token = nextGatewayId("test-token");
+        setTestEnvValue("OPENCLAW_GATEWAY_TOKEN", token);
 
-      const configPath = await createGatewayConfigPath(tempHome);
-      const mockProvider = buildMockOpenAiResponsesProvider(openaiBaseUrl);
+        const configPath = await createGatewayConfigPath(tempHome);
+        const mockProvider = buildMockOpenAiResponsesProvider(openaiBaseUrl);
 
-      const cfg = {
-        agents: {
-          defaults: {
-            workspace: workspaceDir,
-            model: { primary: mockProvider.modelRef },
-            models: {
-              [mockProvider.modelRef]: {
-                params: {
-                  transport: "sse",
-                  openaiWsWarmup: false,
+        const cfg = {
+          agents: {
+            defaults: {
+              workspace: workspaceDir,
+              model: { primary: mockProvider.modelRef },
+              models: {
+                [mockProvider.modelRef]: {
+                  params: {
+                    transport: "sse",
+                    openaiWsWarmup: false,
+                  },
                 },
               },
             },
+            // The request below runs sessionKey "agent:dev:mock-openai"; the
+            // gateway rejects session keys whose agent id is not declared.
+            entries: { dev: { default: true } },
           },
-          // The request below runs sessionKey "agent:dev:mock-openai"; the
-          // gateway rejects session keys whose agent id is not declared.
-          entries: { dev: { default: true } },
-        },
-        models: {
-          mode: "replace",
-          providers: {
-            [mockProvider.providerId]: mockProvider.config,
+          models: {
+            mode: "replace",
+            providers: {
+              [mockProvider.providerId]: mockProvider.config,
+            },
           },
-        },
-        gateway: { auth: { token } },
-      };
+          gateway: { auth: { token } },
+        };
 
-      const { server, client } = await startGatewayWithClient({
-        cfg,
-        configPath,
-        token,
-        clientDisplayName: "vitest-mock-openai",
-      });
+        const { server, client } = await startGatewayWithClient({
+          cfg,
+          configPath,
+          token,
+          clientDisplayName: "vitest-mock-openai",
+        });
 
-      try {
-        const sessionKey = "agent:dev:mock-openai";
+        try {
+          // Agent admission needs the reply runtime published by normal sidecar startup.
+          await server.startupSettled;
+          const sessionKey = "agent:dev:mock-openai";
 
-        const runId = nextGatewayId("run");
-        const payload = await client.request(
-          "agent",
-          {
-            sessionKey,
-            idempotencyKey: `idem-${runId}`,
-            message: "Reply with ok.",
-            deliver: false,
-          },
-          { expectFinal: false },
-        );
+          const runId = nextGatewayId("run");
+          const payload = await client.request(
+            "agent",
+            {
+              sessionKey,
+              idempotencyKey: `idem-${runId}`,
+              message: "Reply with ok.",
+              deliver: false,
+            },
+            { expectFinal: false },
+          );
 
-        expect(payload?.status).toBe("accepted");
-        expect(typeof payload?.runId).toBe("string");
+          expect(payload?.status).toBe("accepted");
+          expect(typeof payload?.runId).toBe("string");
 
-        const abortPayload = await client.request(
-          "sessions.abort",
-          { runId: payload.runId },
-          { timeoutMs: 5_000 },
-        );
-        expect(["aborted", "no-active-run"]).toContain(abortPayload?.status);
+          const abortPayload = await client.request(
+            "sessions.abort",
+            { runId: payload.runId },
+            { timeoutMs: 5_000 },
+          );
+          expect(["aborted", "no-active-run"]).toContain(abortPayload?.status);
+        } finally {
+          try {
+            await disconnectGatewayClient(client);
+          } finally {
+            await server.close({ reason: "mock openai test complete" });
+          }
+        }
       } finally {
-        await disconnectGatewayClient(client);
-        await server.close({ reason: "mock openai test complete" });
-        await removeGatewayTempHome(tempHome);
-        restore();
-        envSnapshot.restore();
+        try {
+          await removeGatewayTempHome(tempHome);
+        } finally {
+          restore();
+          envSnapshot.restore();
+        }
       }
     },
   );
@@ -915,11 +925,7 @@ module.exports = {
     "ignores env-driven plugin auto-enable in minimal gateway mode",
     { timeout: GATEWAY_E2E_TIMEOUT_MS },
     async () => {
-      const envSnapshot = captureEnv([
-        ...GATEWAY_TEST_ENV_KEYS,
-        "OPENCLAW_TEST_MINIMAL_GATEWAY",
-        "DISCORD_BOT_TOKEN",
-      ]);
+      const envSnapshot = captureEnv([...GATEWAY_TEST_ENV_KEYS, "DISCORD_BOT_TOKEN"]);
 
       const tempHome = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-minimal-gateway-home-"));
       const configPath = await createGatewayConfigPath(tempHome);

--- a/src/gateway/portals/portal-http-proxy.test.ts
+++ b/src/gateway/portals/portal-http-proxy.test.ts
@@ -9,6 +9,7 @@ import net, { type AddressInfo } from "node:net";
 import { duplexPair, type Duplex } from "node:stream";
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import { type RawData, WebSocket, WebSocketServer } from "ws";
+import { getFreePort } from "../../test-utils/ports.js";
 import type { PortalTarget } from "./portal-http-proxy.js";
 import { createGatewayPortalService, type GatewayPortalService } from "./portal-service.js";
 
@@ -760,16 +761,17 @@ describe("portal HTTP proxy", () => {
 
   it("reaches IPv6-only targets through the localhost dual-stack dial", async () => {
     // Node >=17 dev servers (Vite, Next.js) often bind ::1 only on "localhost".
+    // Probe IPv4 so localhost cannot reach the shared IPv4 fixture on the same port.
+    const v6Port = await getFreePort();
     const v6Target = createServer((req, res) => {
       res.statusCode = 200;
       res.end("v6 proxied");
     });
     await new Promise<void>((resolve, reject) => {
       v6Target.once("error", reject);
-      v6Target.listen(0, "::1", () => resolve());
+      v6Target.listen(v6Port, "::1", () => resolve());
     });
     try {
-      const v6Port = (v6Target.address() as AddressInfo).port;
       const portal = await portalService().open({ targetPort: v6Port });
       const result = await httpCall({
         port: portal.listenPort,

--- a/src/gateway/test-helpers.e2e.ts
+++ b/src/gateway/test-helpers.e2e.ts
@@ -299,6 +299,7 @@ export async function startGatewayWithClient(params: {
       port,
       client,
       server: {
+        startupSettled: startedServer.startupSettled,
         close: async (...args: Parameters<typeof startedServer.close>) => {
           try {
             await startedServer.close(...args);


### PR DESCRIPTION
Related: [original full release verification](https://github.com/openclaw/openclaw/actions/runs/33154285571) and its [repository E2E failure](https://github.com/openclaw/openclaw/actions/runs/33155289056/job/98797234459).

## What Problem This Solves

Resolves a failure in the Gateway agent-admission E2E where the first WebSocket `agent` request returns `published reply runtime missing for dev`. This is a maintainer-requested release-verification repair. The test selected deliberately minimal startup, which does not publish the runtime that real agent admission requires.

The shared temporary-home fixture also failed to restore an existing minimal-mode environment value when callers selected normal startup or omitted the option.

## Why This Change Was Made

The admission case now uses normal startup and explicitly awaits the server's existing `startupSettled` promise. The helper exposes that existing fact without imposing a global wait on transport-only tests. The common environment snapshot captures the minimal-mode key in every mode, removing the conditional capture and duplicate explicit key.

The request, declared agent, mock provider, acceptance/run-ID/abort assertions and timeout budgets are unchanged. Cleanup still closes the server if client disconnection fails and restores the fixture after startup failures. Production minimal mode, admission policy, providers, authentication and persistence are untouched. Two testing-guide lines now describe the actual admission assertions rather than an obsolete complete tool-loop claim.

## User Impact

No product runtime behavior changes. Release tests exercise the supported startup path and restore their own environment instead of leaking state into later cases. Minimal-startup smoke coverage remains intact.

## Evidence

AI-assisted implementation and review. Source/proof base: `b0cb107c8248768b4dc1899bd589f6e60c615709`.

- **Failing first:** the entire original-order Gateway file ran before edits: 10 passed/3 failed. The target failed with the exact missing-runtime error. The new environment regression, before its owner fix, failed 2/6 cases: an existing `"1"` was lost for default/false mode at the fixture's own restore boundary.
- **After:** all 13 Gateway E2E cases passed in original order; all 6 environment cases passed. Eight distinct sibling files produced 176 passes and one existing host-specific skip across 12 project/file executions. The separate three-case wizard E2E also passed. Real minimal boot, startup publication/readiness/failure/cleanup, immediate WebSocket readiness and environment siblings were included.
- **Build identity:** the first run performed the canonical runtime/declaration build after detecting an incomplete prerequisite stamp. Later E2E runs used the existing prebuilt-artifact contract only after all 11,750 built files were bound to the unchanged production source and rechecked unchanged. No manually fabricated stamp or forced minimal environment.
- **Gates:** all 20 selected checks and fresh managed Codex P0 review passed. The four test/support files remain byte-identical to that review. The only later change is two documentation accuracy lines, independently checked with docs indexing, targeted formatting, MDX validation and `git diff --check`.

Representative commands:

```bash
node scripts/run-vitest.mjs run --config test/vitest/vitest.e2e.config.ts src/gateway/gateway.test.ts
```

```bash
OPENCLAW_E2E_USE_PREBUILT_DIST=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.e2e.config.ts src/gateway/gateway.test.ts
```

```bash
node scripts/run-vitest.mjs run --config test/vitest/vitest.gateway-core.config.ts src/gateway/gateway.test-support.test.ts
```

**LOC:** production runtime +0/-0; test support +3/-4 (net −1); tests +96/-66 (net +30); docs +2/-2. Most existing-test churn is indentation under the cleanup scope. No new configuration option, dependency, schema, fallback, budget, snapshot, baseline or changelog change.

**Limits:** the original cold run also hit a runtime-token readiness timeout and an earlier `main` metadata-owner error. Those cases passed later with unchanged assertions/budgets, but their causes are not established or credited to this repair. The IPv4 alias sibling kept its existing skip because `127.0.0.2` could not be bound on the local host. This proves admission/run-ID/abort behavior, not completed model inference or a complete tool loop. It does not repair the separate native Codex delivery investigation. Full release verification remains separate and blocked; exact-head CI and native landing gates still apply.

## CI-discovered portal fixture repair

The first PR CI run [33227994619, job 99035446670](https://github.com/openclaw/openclaw/actions/runs/33227994619/job/99035446670) failed one separate IPv6 portal case (1863 other tests passed). The file keeps a shared IPv4 server alive while independently requesting an ephemeral IPv6 port. Both families can receive the same numeric port; a legitimate IPv4-first `localhost` connection then reaches the preceding SSE handler and receives its empty HTTP 404 instead of the IPv6 response.

The existing IPv6 case now obtains a free IPv4 port through the shared test helper before binding the actual target only to `::1`. No production socket, DNS, auth, timeout, assertion, or retry behavior changes. The conventional probe/close/rebind race remains; this is not a global atomic port allocator.

**Failing-first proof:** with identical temporary fault instrumentation that maps only a zero-port request to the shared IPv4 port and selects IPv4-first lookup, the original complete file had 26 passes and the intended 404/empty failure. The repaired complete file had 27 passes and recorded an actual IPv6 request returning `200` / `v6 proxied`. The instrumentation was removed. All 51 final tests passed across the portal proxy, service, HTTP listener and port-probe siblings; the pinned changed gate and fresh managed Codex P0 review passed. Independent real TCP proof confirmed the supplied HTTP socket is used without a default agent and that refused IPv4 proceeds to the IPv6 target. Node 24.19 source and installed Node 24.20 behavior were inspected.

```bash
node scripts/run-vitest.mjs src/gateway/portals/portal-http-proxy.test.ts src/gateway/portals/portal-service.test.ts src/gateway/server/http-listen.test.ts src/infra/ports-probe.test.ts --reporter=verbose
```

```bash
node scripts/check-changed.mjs --base d6d7e49d8df1e78b1584b1bf87152a4689217192 -- src/gateway/portals/portal-http-proxy.test.ts
```

The original CI log did not retain ports, DNS order or selected family, so the historical socket collision remains unproven. The controlled run proves a real fixture defect and its repair, not reconstruction of that original socket. All five existing Gateway/doc files remain unchanged. Additional delta: tests +4/-2; production +0/-0. Combined PR: tests +100/-68, test support +3/-4, docs +2/-2, production +0/-0. Owned test processes/listeners were joined or closed. New exact-head CI remains the landing gate.
