### PR TITLE
fix(daemon): explain unsafe service publication failures

### DIFF
--- a/docs/cli/gateway.md
+++ b/docs/cli/gateway.md
@@ -154,7 +154,28 @@ Named profiles must also use the native service identity derived from `OPENCLAW_
 
 On Linux, `openclaw gateway install --force` refuses a sealed systemd service
 definition, or one whose write authority cannot be verified, before changing
-configuration, authentication tokens, or service files. Ask the privileged deployment owner to repair or replace the definition.
+configuration, authentication tokens, or service files. The error keeps its
+`SERVICE_DEFINITION_SEALED` or `SERVICE_DEFINITION_UNKNOWN` prefix and adds a
+reason tag and next action, without printing private paths, config, environment values,
+or underlying inspection errors.
+
+For `[unsafe-permissions]`, inspect the named artifact category locally. The
+service directory is `~/.config/systemd/user`; on a fresh install, its nearest
+existing ancestor may be `~/.config`. The service state directory belongs to the
+selected profile. Check directory metadata, not file contents:
+
+```bash
+ls -ld ~/.config ~/.config/systemd ~/.config/systemd/user
+```
+
+Missing directories are normal on a fresh install. After confirming the affected
+path is yours and is not intentionally shared, remove group/other write access
+with `chmod go-w <path>` and retry the same command. Mode `0700` is appropriate
+for private directories. Do not recursively chmod, take ownership of system
+paths, or use `sudo`/`--force` to bypass the check. Foreign-owned files and sealed
+mounts require the deployment owner; inspection failures require restoring
+filesystem or native service-manager access first.
+
 Type-wide `service.d` defaults are inspected as shared read-only inputs and do
 not require write access. Root-owned selected units and unit-specific drop-ins
 remain protected.

--- a/src/cli/daemon-cli/install.integration.test.ts
+++ b/src/cli/daemon-cli/install.integration.test.ts
@@ -17,7 +17,8 @@ import { makeTempWorkspace } from "../../test-helpers/workspace.js";
 import { captureEnv } from "../../test-utils/env.js";
 import { createCliRuntimeCapture } from "../test-runtime-capture.js";
 
-const { runtimeLogs, defaultRuntime, resetRuntimeCapture } = createCliRuntimeCapture();
+const { runtimeLogs, runtimeErrors, defaultRuntime, resetRuntimeCapture } =
+  createCliRuntimeCapture();
 const busctl = vi.hoisted(() =>
   vi.fn<typeof import("../../daemon/systemd-exec.js").execBusctlUser>(),
 );
@@ -179,6 +180,69 @@ describe("runDaemonInstall integration", () => {
     expect(joined).toContain("SecretRef is configured but unresolved");
     expect(joined).toContain("MISSING_GATEWAY_TOKEN");
   });
+
+  it.each([true, false])(
+    "explains unsafe publication permissions and recovers without bypassing SecretRefs (json=%s)",
+    async (json) => {
+      const fixture = await fs.realpath(
+        await fs.mkdtemp(path.join(tempHome, "private-path-canary-")),
+      );
+      const ancestor = path.join(fixture, ".config");
+      const config = {
+        gateway: {
+          auth: {
+            mode: "token",
+            token: { source: "env", provider: "default", id: "MISSING_GATEWAY_TOKEN" },
+          },
+        },
+      };
+      await fs.mkdir(ancestor);
+      await fs.chmod(ancestor, 0o777);
+      await fs.writeFile(configPath, JSON.stringify(config));
+      clearConfigCache();
+      busctl.mockResolvedValue({
+        code: 1,
+        termination: "exit",
+        stdout: "",
+        stderr: "Call failed: Unit openclaw-gateway.service not found.",
+      });
+      const env = { ...process.env, HOME: fixture, OPENCLAW_SYSTEMD_UNIT: "openclaw-gateway" };
+      serviceMock.readCommand.mockImplementation((_env, options) =>
+        readSystemdServiceExecStart(env, options),
+      );
+      serviceMock.readDefinitionMutationCapability.mockImplementation(() =>
+        readSystemdDefinitionMutationCapability(env),
+      );
+      const before = await snapshotConfig();
+      try {
+        await expect(runDaemonInstall({ json, force: true })).rejects.toThrow("__exit__:1");
+        expect(await snapshotConfig()).toEqual(before);
+        expect(await fs.readdir(ancestor)).toEqual([]);
+        expect(serviceMock.install).not.toHaveBeenCalled();
+        const output = [...runtimeLogs, ...runtimeErrors].join("\n");
+        expect(output).toContain("SERVICE_DEFINITION_UNKNOWN");
+        expect(output).toContain("unsafe-permissions");
+        expect(output).toContain("service directory");
+        expect(output).toContain("group/world-writable");
+        expect(output).toContain("chmod go-w");
+        expect(output).not.toContain("private-path-canary");
+        expect(output).not.toContain("MISSING_GATEWAY_TOKEN");
+
+        await fs.chmod(ancestor, 0o700);
+        resetRuntimeCapture();
+        await expect(runDaemonInstall({ json, force: true })).rejects.toThrow("__exit__:1");
+        const recovered = [...runtimeLogs, ...runtimeErrors].join("\n");
+        expect(recovered).not.toContain("SERVICE_DEFINITION_UNKNOWN");
+        expect(recovered).toContain("SecretRef is configured but unresolved");
+        expect((await readJson(configPath)).gateway).toEqual({ ...config.gateway, mode: "local" });
+        expect(await fs.readdir(ancestor)).toEqual([]);
+        expect(serviceMock.install).not.toHaveBeenCalled();
+      } finally {
+        await fs.chmod(ancestor, 0o700);
+        await fs.rm(fixture, { recursive: true, force: true });
+      }
+    },
+  );
 
   it.each(["fragment", "drop-in"])(
     "blocks a root-owned manager %s before config or token writes",
@@ -349,19 +413,19 @@ describe("runDaemonInstall integration", () => {
   it.each([
     {
       name: "gateway.mode is missing",
-      capability: { kind: "sealed" as const, detail: "unit definition is owned by root" },
+      capability: { kind: "sealed" as const, reason: "foreign-owner" as const },
       config: { gateway: { auth: { mode: "token", token: "existing-token" } } },
       marker: "SERVICE_DEFINITION_SEALED",
     },
     {
       name: "the gateway token is missing",
-      capability: { kind: "sealed" as const, detail: "unit definition is owned by root" },
+      capability: { kind: "sealed" as const, reason: "foreign-owner" as const },
       config: { gateway: { mode: "local", auth: { mode: "token" } } },
       marker: "SERVICE_DEFINITION_SEALED",
     },
     {
       name: "gateway.mode is missing and definition authority is unknown",
-      capability: { kind: "unknown" as const, detail: "unit definition cannot be inspected" },
+      capability: { kind: "unknown" as const, reason: "inspection-failed" as const },
       config: { gateway: { auth: { mode: "token" } } },
       marker: "SERVICE_DEFINITION_UNKNOWN",
     },
@@ -370,7 +434,7 @@ describe("runDaemonInstall integration", () => {
     async ({ capability, config, marker }) => {
       await fs.writeFile(configPath, JSON.stringify(config, null, 2));
       clearConfigCache();
-      serviceMock.readDefinitionMutationCapability.mockResolvedValueOnce(capability as never);
+      serviceMock.readDefinitionMutationCapability.mockResolvedValueOnce(capability);
       const before = await snapshotConfig();
 
       await expect(runDaemonInstall({ json: true, force: true })).rejects.toThrow("__exit__:1");
@@ -437,8 +501,8 @@ describe("runDaemonInstall integration", () => {
     serviceMock.isLoaded.mockResolvedValue(true);
     serviceMock.readDefinitionMutationCapability.mockResolvedValue({
       kind: "sealed",
-      detail: "unit definition is owned by root",
-    } as never);
+      reason: "foreign-owner",
+    });
     serviceMock.readCommand.mockResolvedValue(await createInstalledServiceCommand());
 
     await runDaemonInstall({ json: true });
@@ -462,8 +526,8 @@ describe("runDaemonInstall integration", () => {
     } as never);
     serviceMock.readDefinitionMutationCapability.mockResolvedValueOnce({
       kind: "sealed",
-      detail: "unit definition is owned by root",
-    } as never);
+      reason: "foreign-owner",
+    });
     const before = await snapshotConfig();
 
     await expect(runDaemonInstall({ json: true })).rejects.toThrow("__exit__:1");
@@ -482,11 +546,10 @@ describe("runDaemonInstall integration", () => {
       programArguments: ["openclaw", "gateway", "run"],
       environment: { OPENCLAW_STATE_DIR: effectiveStateDir },
     } as never);
-    serviceMock.readDefinitionMutationCapability.mockImplementationOnce(
-      async (args) =>
-        (args?.environment?.OPENCLAW_STATE_DIR === effectiveStateDir
-          ? { kind: "sealed", detail: "effective state is owned by root" }
-          : { kind: "writable" }) as never,
+    serviceMock.readDefinitionMutationCapability.mockImplementationOnce(async (args) =>
+      args?.environment?.OPENCLAW_STATE_DIR === effectiveStateDir
+        ? { kind: "sealed", reason: "foreign-owner" }
+        : { kind: "writable" },
     );
     const before = await snapshotConfig();
 
@@ -522,6 +585,7 @@ describe("runDaemonInstall integration", () => {
     } else {
       serviceMock.readDefinitionMutationCapability.mockResolvedValueOnce({
         kind,
+        reason: kind === "sealed" ? "foreign-owner" : "inspection-failed",
         detail: secret,
       } as never);
     }

--- a/src/cli/daemon-cli/install.ts
+++ b/src/cli/daemon-cli/install.ts
@@ -199,12 +199,9 @@ export async function runDaemonInstall(opts: DaemonInstallOptions) {
       for (const environment of [effectiveServiceEnv, installEnv]) {
         const capability = await service
           .readDefinitionMutationCapability?.({ env: process.env, environment })
-          .catch(() => ({ kind: "unknown" as const, detail: "" }));
-        if (capability && capability.kind !== "writable") {
-          assertServiceDefinitionWritable({
-            kind: capability.kind,
-            detail: "Service definition cannot be safely modified.",
-          });
+          .catch(() => ({ kind: "unknown", reason: "inspection-failed" }) as const);
+        if (capability) {
+          assertServiceDefinitionWritable(capability);
         }
       }
       return true;

--- a/src/cli/daemon-cli/start-repair.test.ts
+++ b/src/cli/daemon-cli/start-repair.test.ts
@@ -146,14 +146,36 @@ describe("repairLoadedGatewayServiceForStart", () => {
     vi.unstubAllEnvs();
   });
 
-  it.each(["sealed", "unknown"] as const)(
-    "denies definition repair before config or token work when authority is %s",
-    async (kind) => {
+  it.each([
+    {
+      kind: "sealed",
+      reason: "foreign-owner",
+      artifact: "service-file",
+      guidance: "deployment owner",
+    },
+    {
+      kind: "unknown",
+      reason: "unsafe-permissions",
+      artifact: "service-directory",
+      guidance: "chmod go-w",
+    },
+    {
+      kind: "unknown",
+      reason: "inspection-failed",
+      artifact: "service-file",
+      guidance: "Inspect service definition access",
+    },
+  ] as const)(
+    "explains $reason without exposing raw details or doing config/token work",
+    async ({ guidance, ...capability }) => {
       const install = vi.fn();
       const service = {
         install,
         isLoaded: vi.fn(async () => true),
-        readDefinitionMutationCapability: vi.fn(async () => ({ kind, detail: "protected" })),
+        readDefinitionMutationCapability: vi.fn(async () => ({
+          ...capability,
+          detail: "repair-inspection-secret-canary",
+        })),
       };
       const state: GatewayServiceState = {
         installed: true,
@@ -165,15 +187,22 @@ describe("repairLoadedGatewayServiceForStart", () => {
           environment: { HOME: "/home/openclaw" },
         },
       };
-      await expect(
-        repairLoadedGatewayServiceForStart({
-          service,
-          state,
-          issues: [{ code: "missing-program", message: "missing" }],
-          json: true,
-          stdout: process.stdout,
-        }),
-      ).rejects.toThrow(`SERVICE_DEFINITION_${kind.toUpperCase()}`);
+      const params = {
+        service,
+        state,
+        issues: [{ code: "missing-program" as const, message: "missing" }],
+        json: true,
+        stdout: process.stdout,
+      };
+      for (const action of ["start", "restart"] as const) {
+        const repair =
+          action === "restart"
+            ? repairLoadedGatewayServiceForStart({ ...params, action })
+            : repairLoadedGatewayServiceForStart(params);
+        await expect(repair).rejects.toThrow(`SERVICE_DEFINITION_${capability.kind.toUpperCase()}`);
+        await expect(repair).rejects.toThrow(guidance);
+        await expect(repair).rejects.not.toThrow("secret-canary");
+      }
       expect(readConfigFileSnapshotForWriteMock).not.toHaveBeenCalled();
       expect(resolveGatewayInstallTokenMock).not.toHaveBeenCalled();
       expect(install).not.toHaveBeenCalled();

--- a/src/cli/daemon-cli/start-repair.ts
+++ b/src/cli/daemon-cli/start-repair.ts
@@ -153,12 +153,9 @@ export async function repairLoadedGatewayServiceForStart(
   // Repair can persist a generated token; check definition authority before planning it.
   const capability = await params.service
     .readDefinitionMutationCapability?.({ env: process.env, environment: params.state.env })
-    .catch(() => ({ kind: "unknown" as const, detail: "" }));
-  if (capability && capability.kind !== "writable") {
-    assertServiceDefinitionWritable({
-      kind: capability.kind,
-      detail: "Service definition cannot be safely modified.",
-    });
+    .catch(() => ({ kind: "unknown", reason: "inspection-failed" }) as const);
+  if (capability) {
+    assertServiceDefinitionWritable(capability);
   }
   if (
     hasGatewayServiceLauncherOverride(params.state.command) ||

--- a/src/cli/update-cli/update-command-service.integration.test.ts
+++ b/src/cli/update-cli/update-command-service.integration.test.ts
@@ -200,7 +200,7 @@ beforeEach(async () => {
   });
   mocks.handoff.mockReturnValue({ ok: true, value: Promise.resolve(true) });
   mocks.events = [];
-  mocks.capability.mockResolvedValue({ kind: "sealed", detail: "operator-owned definition" });
+  mocks.capability.mockResolvedValue({ kind: "sealed", reason: "foreign-owner" });
   mocks.command.mockResolvedValue({
     programArguments: [
       process.execPath,
@@ -288,7 +288,9 @@ describe("preserved update activation with real version guards", () => {
         environment: { HOME: root, MANAGED_VALUE: "revalidated" },
       });
       mocks.capability.mockResolvedValue(
-        late ? { kind: "writable" } : { kind: denial, detail: "owner denial" },
+        late
+          ? { kind: "writable" }
+          : { kind: denial, reason: denial === "sealed" ? "foreign-owner" : "inspection-failed" },
       );
       const before = await maybeStopManagedServiceBeforeMutableUpdate({
         updateInstallKind: mode === "git" ? "git" : "package",
@@ -300,7 +302,10 @@ describe("preserved update activation with real version guards", () => {
       const repair = vi.spyOn(startRepair, "repairLoadedGatewayServiceForStart");
       mocks.child.mockImplementation(async (args) => {
         if (args.includes("install")) {
-          mocks.capability.mockResolvedValue({ kind: denial, detail: "late owner denial" });
+          mocks.capability.mockResolvedValue({
+            kind: denial,
+            reason: denial === "sealed" ? "foreign-owner" : "inspection-failed",
+          });
           if (outcome === "uninspectable") {
             mocks.command.mockRejectedValue(new Error("manager inspection failed"));
           } else if (outcome === "foreign") {
@@ -762,7 +767,7 @@ describe("preserved update activation with real version guards", () => {
     "fresh restart keeps the preserved launcher even when authority is %s",
     async (kind) => {
       mocks.capability.mockResolvedValue(
-        kind === "sealed" ? { kind, detail: "operator-owned definition" } : { kind },
+        kind === "sealed" ? { kind, reason: "foreign-owner" } : { kind },
       );
       await expect(runDaemonRestart({ json: true, preserveDefinition: true })).resolves.toBe(true);
       expect(mocks.restart).toHaveBeenCalledOnce();

--- a/src/daemon/service-types.ts
+++ b/src/daemon/service-types.ts
@@ -93,20 +93,58 @@ export type GatewayServiceLoadState =
   | { status: "not-loaded" }
   | { status: "unknown"; detail: string };
 
+const SERVICE_DEFINITION_ARTIFACTS = {
+  "service-directory":
+    "service directory (~/.config/systemd/user) or its nearest existing ancestor",
+  "state-directory": "service state directory or its nearest existing ancestor",
+  "definition-directory": "loaded service definition directory",
+  "service-file": "service file",
+} as const;
+
+const SERVICE_DEFINITION_REASONS = {
+  "unsafe-permissions":
+    "is group/world-writable. Inspect ownership and permissions locally. If the path is yours and not intentionally shared, remove group/other write access with chmod go-w <path>, then retry. Use 0700 for private directories; ask the deployment owner about shared paths. Do not use recursive chmod or sudo to bypass this check.",
+  "invalid-artifact":
+    "has an unexpected file type. Inspect the service directories and files locally; have their owner repair the layout before retrying. Changing permissions alone will not repair it.",
+  symlink:
+    "is a symbolic link. Ask the deployment owner to replace the managed file through the deployment process; OpenClaw will not rewrite the link or its target.",
+  "foreign-owner":
+    "belongs to another account. Ask the privileged deployment owner to repair or replace it; do not take ownership or use --force to bypass this check.",
+  "sealed-mount":
+    "cannot be replaced on its mount. Ask the deployment owner to update the mounted artifact or deployment; chmod and --force cannot make it replaceable.",
+  "system-owned":
+    "is owned by a system service. Ask the privileged deployment owner to update it; do not create a competing user service.",
+  "system-ownership-unverified":
+    "has unverifiable system-service ownership. Restore system service-manager and filesystem inspection access from the service account, then retry; do not create a competing user service.",
+  "inspection-failed":
+    "cannot be safely inspected. Inspect service definition access and native service-manager availability from the service account, then retry. Do not share config or environment contents.",
+} as const;
+
+export type ServiceDefinitionMutationArtifact = keyof typeof SERVICE_DEFINITION_ARTIFACTS;
 export type ServiceDefinitionMutationCapability =
   | { kind: "writable" }
-  | { kind: "sealed" | "unknown"; detail: string };
+  | {
+      kind: "sealed" | "unknown";
+      reason: keyof typeof SERVICE_DEFINITION_REASONS;
+      artifact?: ServiceDefinitionMutationArtifact;
+    };
 
 export function assertServiceDefinitionWritable(capability: ServiceDefinitionMutationCapability) {
-  if (capability.kind !== "writable") {
-    const guidance =
-      capability.kind === "sealed"
-        ? "Ask the privileged deployment owner."
-        : "Inspect service definition access.";
-    throw new Error(
-      `SERVICE_DEFINITION_${capability.kind.toUpperCase()}: ${capability.detail} ${guidance}`,
-    );
+  if (capability.kind === "writable") {
+    return;
   }
+  // Only allowlisted facts reach callers: paths, native errors, and extra fields can contain secrets.
+  const reason = Object.hasOwn(SERVICE_DEFINITION_REASONS, capability.reason)
+    ? capability.reason
+    : "inspection-failed";
+  const artifact =
+    capability.artifact && Object.hasOwn(SERVICE_DEFINITION_ARTIFACTS, capability.artifact)
+      ? SERVICE_DEFINITION_ARTIFACTS[capability.artifact]
+      : "service definition";
+  // Update recovery recognizes these prefixes to preserve a protected definition.
+  const code =
+    capability.kind === "sealed" ? "SERVICE_DEFINITION_SEALED" : "SERVICE_DEFINITION_UNKNOWN";
+  throw new Error(`${code}: [${reason}] The ${artifact} ${SERVICE_DEFINITION_REASONS[reason]}`);
 }
 
 export type GatewayServiceCommandSnapshot = {

--- a/src/daemon/service.test.ts
+++ b/src/daemon/service.test.ts
@@ -209,7 +209,7 @@ describe("readGatewayServiceState", () => {
         if (capabilityFails) {
           throw new Error("capability unavailable");
         }
-        return { kind: "sealed", detail: "deployment owned" };
+        return { kind: "sealed", reason: "foreign-owner" };
       });
       const service = createService({
         hasInstalledDefinition,
@@ -241,8 +241,8 @@ describe("readGatewayServiceState", () => {
         });
         expect(state.definitionMutationCapability).toEqual(
           capabilityFails
-            ? { kind: "unknown", detail: "Cannot inspect service definition." }
-            : { kind: "sealed", detail: "deployment owned" },
+            ? { kind: "unknown", reason: "inspection-failed" }
+            : { kind: "sealed", reason: "foreign-owner" },
         );
       } else {
         expect(readDefinitionMutationCapability).not.toHaveBeenCalled();

--- a/src/daemon/service.ts
+++ b/src/daemon/service.ts
@@ -222,7 +222,7 @@ export async function readGatewayServiceState(
     args.requireEffective
       ? service
           .readDefinitionMutationCapability?.({ env: baseEnv, environment: env, timeoutMs })
-          .catch(() => ({ kind: "unknown" as const, detail: "Cannot inspect service definition." }))
+          .catch(() => ({ kind: "unknown", reason: "inspection-failed" }) as const)
       : undefined,
   ]);
   return {

--- a/src/daemon/systemd-definition-mutation.test.ts
+++ b/src/daemon/systemd-definition-mutation.test.ts
@@ -741,42 +741,53 @@ describe.skipIf(process.platform === "win32")("systemd definition mutation owner
     expect(await fs.readFile(unitPath, "utf8")).toBe("original definition");
   });
 
-  it.each(["file symlink", "unsafe mode", "uninspectable", "missing", "directory"])(
-    "rejects a manager definition with %s without publication",
-    async (kind) => {
-      const directory = path.join(root, "operator");
-      const target = path.join(directory, "operator.conf");
-      await fs.mkdir(directory);
-      await fs.writeFile(target, "[Service]\nEnvironment=TOKEN=protected-secret-canary\n");
-      let extra = target;
-      if (kind === "file symlink") {
-        extra = path.join(root, "linked.conf");
-        await fs.symlink(target, extra);
-      } else if (kind === "unsafe mode") {
-        await fs.chmod(target, 0o666);
-      } else if (kind === "missing") {
-        extra = path.join(directory, "missing.conf");
-      } else if (kind === "directory") {
-        extra = stateDir;
-      } else {
-        const lstat = fs.lstat.bind(fs);
-        vi.spyOn(fs, "lstat").mockImplementation(async (...args) => {
-          if (args[0] === extra) {
-            throw Object.assign(new Error("inspection-secret-canary"), { code: "EACCES" });
-          }
-          return lstat(...args);
-        });
-      }
-      managerDefinition(extra);
-      const capability = await readSystemdDefinitionMutationCapability(env);
-      expect(capability).toMatchObject({ kind: "unknown" });
-      expect(JSON.stringify(capability)).not.toContain("secret-canary");
-      await expect(stage()).rejects.toThrow("SERVICE_DEFINITION_UNKNOWN");
-      expect(await fs.readFile(target, "utf8")).toContain("protected-secret-canary");
-      expect(await fs.readdir(path.dirname(unitPath))).toEqual([]);
-      expect(await fs.readdir(stateDir)).toEqual([]);
-    },
-  );
+  it.each([
+    "file symlink",
+    "group-writable",
+    "world-writable",
+    "uninspectable",
+    "missing",
+    "directory",
+  ])("rejects a manager definition with %s without publication", async (kind) => {
+    const directory = path.join(root, "operator");
+    const target = path.join(directory, "operator.conf");
+    await fs.mkdir(directory);
+    await fs.writeFile(target, "[Service]\nEnvironment=TOKEN=protected-secret-canary\n");
+    let extra = target;
+    if (kind === "file symlink") {
+      extra = path.join(root, "linked.conf");
+      await fs.symlink(target, extra);
+    } else if (kind === "group-writable" || kind === "world-writable") {
+      await fs.chmod(target, kind === "group-writable" ? 0o660 : 0o606);
+    } else if (kind === "missing") {
+      extra = path.join(directory, "missing.conf");
+    } else if (kind === "directory") {
+      extra = stateDir;
+    } else {
+      const lstat = fs.lstat.bind(fs);
+      vi.spyOn(fs, "lstat").mockImplementation(async (...args) => {
+        if (args[0] === extra) {
+          throw Object.assign(new Error("inspection-secret-canary"), { code: "EACCES" });
+        }
+        return lstat(...args);
+      });
+    }
+    managerDefinition(extra);
+    const capability = await readSystemdDefinitionMutationCapability(env);
+    const reason =
+      kind === "file symlink"
+        ? "symlink"
+        : kind === "group-writable" || kind === "world-writable"
+          ? "unsafe-permissions"
+          : "inspection-failed";
+    expect(capability).toMatchObject({ kind: "unknown", reason });
+    expect(JSON.stringify(capability)).not.toContain(root);
+    expect(JSON.stringify(capability)).not.toContain("secret-canary");
+    await expect(stage()).rejects.toThrow(`SERVICE_DEFINITION_UNKNOWN: [${reason}]`);
+    expect(await fs.readFile(target, "utf8")).toContain("protected-secret-canary");
+    expect(await fs.readdir(path.dirname(unitPath))).toEqual([]);
+    expect(await fs.readdir(stateDir)).toEqual([]);
+  });
 
   it("accepts the ownership owner's proven absence on a fresh non-systemd install", async () => {
     await expect(readSystemdDefinitionMutationCapability(env)).resolves.toEqual({
@@ -843,13 +854,12 @@ describe.skipIf(process.platform === "win32")("systemd definition mutation owner
     await fs.writeFile(target, "operator-secret-canary\n");
     await fs.symlink(target, file);
 
-    await expect(readSystemdDefinitionMutationCapability(env)).resolves.toMatchObject({
+    await expect(readSystemdDefinitionMutationCapability(env)).resolves.toEqual({
       kind: "unknown",
-      detail: `Refusing to rewrite symlinked managed systemd file: ${file}`,
+      reason: "symlink",
+      artifact: "service-file",
     });
-    await expect(stage()).rejects.toThrow(
-      `SERVICE_DEFINITION_UNKNOWN: Refusing to rewrite symlinked managed systemd file: ${file}`,
-    );
+    await expect(stage()).rejects.toThrow("SERVICE_DEFINITION_UNKNOWN: [symlink]");
     expect(await fs.readlink(file)).toBe(target);
     expect(await fs.readFile(target, "utf8")).toBe("operator-secret-canary\n");
     if (fresh) {

--- a/src/daemon/systemd-definition-mutation.ts
+++ b/src/daemon/systemd-definition-mutation.ts
@@ -12,6 +12,7 @@ import { canonicalPathFromExistingAncestor, findExistingAncestor } from "../infr
 import {
   assertServiceDefinitionWritable,
   type GatewayServiceEnv,
+  type ServiceDefinitionMutationArtifact,
   type ServiceDefinitionMutationCapability,
 } from "./service-types.js";
 import {
@@ -91,7 +92,7 @@ async function inspect(env: GatewayServiceEnv, environment: GatewayServiceEnv, t
     shared,
     sourcePath,
   });
-  let inspected = "the selected service";
+  let artifact: ServiceDefinitionMutationArtifact | undefined;
   try {
     const command = await readSystemdServiceExecStart(env, {
       requireEffective: true,
@@ -118,7 +119,15 @@ async function inspect(env: GatewayServiceEnv, environment: GatewayServiceEnv, t
     for (const file of artifacts) {
       const directory = parents.has(file) && !definitions.has(file);
       const required = definitions.has(file) || definitionParents.has(file);
-      inspected = directory && !required ? ((await findExistingAncestor(file)) ?? file) : file;
+      artifact = !directory
+        ? "service-file"
+        : file === path.dirname(unit)
+          ? "service-directory"
+          : file === path.dirname(generated)
+            ? "state-directory"
+            : "definition-directory";
+      const inspected =
+        directory && !required ? ((await findExistingAncestor(file)) ?? file) : file;
       const stat = await fs.lstat(inspected).catch((error: unknown) => {
         if (required || !hasErrnoCode(error, "ENOENT")) {
           throw error;
@@ -130,34 +139,28 @@ async function inspect(env: GatewayServiceEnv, environment: GatewayServiceEnv, t
       }
       // systemd retains lexical directory aliases; fingerprint both alias and target.
       if (!directory && stat.isSymbolicLink()) {
-        return result({
-          kind: "unknown",
-          detail: `Refusing to rewrite symlinked managed systemd file: ${file}`,
-        });
+        return result({ kind: "unknown", reason: "symlink", artifact });
       }
       const actual = directory && stat.isSymbolicLink() ? await fs.stat(inspected) : stat;
       if (!shared.has(file) && actual.uid !== process.geteuid?.()) {
-        return result({
-          kind: "sealed",
-          detail: `Service artifact ${inspected} belongs to another account.`,
-        });
+        return result({ kind: "sealed", reason: "foreign-owner", artifact });
       }
-      if ((directory && !actual.isDirectory()) || actual.mode & 0o022) {
-        throw new Error("unsafe service publication artifact");
+      if (directory && !actual.isDirectory()) {
+        return result({ kind: "unknown", reason: "invalid-artifact", artifact });
+      }
+      if (actual.mode & 0o022) {
+        return result({ kind: "unknown", reason: "unsafe-permissions", artifact });
       }
       if (directory) {
         await fs.access(inspected, constants.W_OK | constants.X_OK);
         fingerprint.set(file, `${inspected}:${identity(stat)}:${identity(actual)}`);
         continue;
       }
-      const artifact = await readStableFile(file, stat, !shared.has(file));
-      if ("sealed" in artifact) {
-        return result({
-          kind: "sealed",
-          detail: `Service artifact ${file} cannot be replaced on its mount.`,
-        });
+      const snapshot = await readStableFile(file, stat, !shared.has(file));
+      if ("sealed" in snapshot) {
+        return result({ kind: "sealed", reason: "sealed-mount", artifact });
       }
-      const { contents } = artifact;
+      const { contents } = snapshot;
       fingerprint.set(file, identity(stat, contents));
       if (targets.has(file)) {
         snapshots.set(file, { contents, mode: stat.mode & 0o777 });
@@ -165,10 +168,7 @@ async function inspect(env: GatewayServiceEnv, environment: GatewayServiceEnv, t
     }
     return result({ kind: "writable" });
   } catch {
-    return result({
-      kind: "unknown",
-      detail: `Cannot safely rewrite managed systemd artifact ${inspected}.`,
-    });
+    return result({ kind: "unknown", reason: "inspection-failed", artifact });
   }
 }
 
@@ -187,13 +187,11 @@ export async function readSystemdDefinitionMutationCapability(
         deadlineAt === undefined ? undefined : Math.max(1, deadlineAt - Date.now()),
       );
     } catch (error) {
-      return {
-        kind:
-          isSystemSystemdOwnershipError(error) && error.ownership.status !== "unverifiable"
-            ? "sealed"
-            : "unknown",
-        detail: `System service ${name} requires its privileged deployment owner.`,
-      };
+      const owned =
+        isSystemSystemdOwnershipError(error) && error.ownership.status !== "unverifiable";
+      return owned
+        ? { kind: "sealed", reason: "system-owned" }
+        : { kind: "unknown", reason: "system-ownership-unverified" };
     }
   }
   return (await inspect(env, options?.environment ?? env, options?.timeoutMs)).capability;

--- a/src/daemon/systemd-system.test.ts
+++ b/src/daemon/systemd-system.test.ts
@@ -129,7 +129,7 @@ describe("system systemd ownership", () => {
 
       expect(capability).toEqual({
         kind,
-        detail: `System service ${unitName} requires its privileged deployment owner.`,
+        reason: kind === "sealed" ? "system-owned" : "system-ownership-unverified",
       });
       expect(JSON.stringify(capability)).not.toContain("manager-secret-canary");
       // Denial permits only system ownership probes, never user-manager or artifact reads.


### PR DESCRIPTION
Closes #132278 — unsafe service-directory permissions are hidden behind a generic installation error.

<details>
<summary>Additional instructions</summary>

This is a same-repository branch; maintainers can push fixes directly.

</details>

## What Problem This Solves

Fixes an issue where users installing a managed Gateway would receive only `SERVICE_DEFINITION_UNKNOWN` when an account-owned service-publication directory or existing ancestor was group/world-writable. The guard correctly refused the operation, but the CLI hid the reason needed to repair the directory. Start/restart repair discarded the same information.

## Why This Change Was Made

The publication owner now returns closed reason codes and redacted artifact categories, and the shared assertion renders allowlisted explanations and next actions. This removes free-form detail from the contract and the duplicate CLI detail-replacement paths without forwarding private paths, config/environment contents, or native errors. Existing `SERVICE_DEFINITION_SEALED:` / `SERVICE_DEFINITION_UNKNOWN:` prefixes remain unchanged because definition-preserving update recovery recognizes them.

Authority classification, owner checks, mode checks, mount/symlink protection, publication locking, and pre-config/token ordering are unchanged. There is no parser/import change, new option, dependency change, persistence/schema change, timeout increase, or guard bypass.

Production LOC: **+82/-52 (net +30)**. Tests: **+184/-76 (net +108)**. The production growth is the bounded diagnostic vocabulary and shared recovery renderer; the owner and CLI paths otherwise shrink. Documentation: +22/-1.

## User Impact

Operators can distinguish unsafe permissions from foreign ownership, a sealed mount, a symlink, unexpected file types, or failed inspection. For unsafe permissions, the message identifies the artifact category, explains how to inspect ownership/mode locally, and permits repair guidance only for an owned, nonshared path. It does not recommend recursive chmod, taking ownership, or bypassing the check with `sudo`/`--force`.

The recovery steps are documented in [Gateway install identity](https://docs.openclaw.ai/cli/gateway#install-identity). This is an AI-assisted, maintainer-requested diagnostics follow-up.

## Evidence

### Behavior regression and sibling coverage

The new JSON and text regression cases fail on the pre-fix source because the permission reason and next action are absent, then pass with this change. All **269 tests in six files** passed, covering failure/recovery, config/token non-mutation, unsafe mode bits, foreign ownership, symlinks, mounts, publication races/rollback, safe directory creation, start/restart repair, and definition-preserving update activation (including the macOS sibling).

```bash
node scripts/run-vitest.mjs src/cli/daemon-cli/install.integration.test.ts src/cli/daemon-cli/start-repair.test.ts src/daemon/systemd-definition-mutation.test.ts src/daemon/systemd-definition-mutation.creation.test.ts src/daemon/service.test.ts src/cli/update-cli/update-command-service.integration.test.ts
```

```bash
node scripts/check-changed.mjs
```

```bash
pnpm docs:check-mdx
```

```bash
pnpm docs:check-links
```

All commands passed; the changed gate included core/test typechecks, scoped lint, dead exports, import cycles, and applicable guards. Docs: 6,975 internal links checked, zero broken links. Fresh Codex autoreview completed at the configured P0 threshold with no accepted/actionable findings.

### CI-discovered sibling assertion correction

The [initial PR CI run](https://github.com/openclaw/openclaw/actions/runs/33228290091) caught five system-scope ownership cases that still expected the retired raw `detail` field. Those assertions now require the exact typed `system-owned` / `system-ownership-unverified` reasons; the secret-canary and no-user-inspection assertions remain intact. This was a test-only correction, not a change to authority behavior.

The expanded local run passed **1,302 tests across 39 files, with 5 platform skips**, including the full daemon suite and CLI recovery siblings:

```bash
node scripts/run-vitest.mjs src/daemon src/cli/daemon-cli/install.integration.test.ts src/cli/daemon-cli/start-repair.test.ts src/cli/update-cli/update-command-service.integration.test.ts
```

Targeted lint passed, and fresh Codex autoreview of the complete PR candidate was scoped-clean at the configured P0 threshold. Production inputs are unchanged from the native proof below. Exact-head CI is rerun for the corrected head.

### Native Linux before/after proof

Provider: **Blacksmith Testbox**, lease `tbx_01m15hv19h0qzkts4w70y1dqne`, [run 33226287496](https://github.com/openclaw/openclaw/actions/runs/33226287496). This used the real disposable OS account/home, native systemd user manager, an allowlisted process environment, and a fresh named profile—not service-manager shims.

The initial prerequisite probe lacked the non-login-shell user-bus environment; correcting only that proof setup made the native query work. No manager/service was started to bypass it. The candidate was rebuilt with `pnpm build`; hashes of 14 scoped owner/dependency inputs matched the local candidate before and after the build. The fingerprint was `16f1947ff2f6f0b298c235d8cac3c53479899994fc6044f64eb94a1fcdc046ec`; the Testbox mirror's synthetic Git SHA is not used as candidate identity.

```bash
node openclaw.mjs --profile <fresh-proof-profile> gateway install --force --json
```

Sanitized observed result:

```json
{
  "before": { "typedPermissionReason": false, "safeNextAction": false },
  "afterAt0777": {
    "reason": "unsafe-permissions",
    "artifact": "service-directory",
    "safeNextAction": true,
    "noPrivatePathInDiagnostic": true,
    "blockedBeforeConfigOrServiceWrites": true,
    "cliExitCode": 1
  },
  "sameInvocationAfter0700": {
    "authorityBlockCleared": true,
    "expectedUnresolvedSyntheticSecretRefReached": true,
    "persistedGatewayModeLocal": true,
    "secretRefPreserved": true,
    "noServiceArtifacts": true,
    "cliExitCode": 1
  },
  "proofPassed": true,
  "ownedProfileRemoved": true,
  "originalDirectoryModeRestored": true,
  "testboxStopped": true
}
```

The recovered CLI still exits `1` intentionally: recovery means reaching the genuine unresolved-SecretRef rejection, not creating a service. Testbox wrapper exit was `0`; the linked long-running hydration Actions job is `cancelled` because the owned lease was explicitly stopped after proof. It is behavior evidence, not the PR's CI gate. Exact-head PR CI is tracked separately.
