### PR TITLE
fix(installer): pin NodeSource RPM repository

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -2304,10 +2304,10 @@ install_node() {
             run_required_step "Downloading NodeSource setup script" download_validated_script "$setup_url" "$tmp"
             if is_root; then
                 run_required_step "Configuring NodeSource repository" bash "$tmp"
-                run_required_step "Installing Node.js" dnf install -y -q nodejs
+                run_required_step "Installing Node.js" dnf install -y -q --disablerepo='*' --enablerepo=nodesource-nodejs nodejs
             else
                 run_required_step "Configuring NodeSource repository" sudo bash "$tmp"
-                run_required_step "Installing Node.js" sudo dnf install -y -q nodejs
+                run_required_step "Installing Node.js" sudo dnf install -y -q --disablerepo='*' --enablerepo=nodesource-nodejs nodejs
             fi
         elif command -v yum &> /dev/null; then
             local tmp setup_url
@@ -2316,10 +2316,10 @@ install_node() {
             run_required_step "Downloading NodeSource setup script" download_validated_script "$setup_url" "$tmp"
             if is_root; then
                 run_required_step "Configuring NodeSource repository" bash "$tmp"
-                run_required_step "Installing Node.js" yum install -y -q nodejs
+                run_required_step "Installing Node.js" yum install -y -q --disablerepo='*' --enablerepo=nodesource-nodejs nodejs
             else
                 run_required_step "Configuring NodeSource repository" sudo bash "$tmp"
-                run_required_step "Installing Node.js" sudo yum install -y -q nodejs
+                run_required_step "Installing Node.js" sudo yum install -y -q --disablerepo='*' --enablerepo=nodesource-nodejs nodejs
             fi
         else
             ui_error "Could not detect package manager"

--- a/test/scripts/install-sh.test.ts
+++ b/test/scripts/install-sh.test.ts
@@ -269,6 +269,46 @@ describe("install.sh", () => {
     },
   );
 
+  it.each(["dnf", "yum"])(
+    "pins Node.js installation to the configured NodeSource %s repository",
+    (packageManager) => {
+      for (const rootMode of ["root", "sudo"]) {
+        const result = runInstallShell(`
+          set -euo pipefail
+          source "${SCRIPT_PATH}"
+          OS=linux
+          PACKAGE_MANAGER=${JSON.stringify(packageManager)}
+          ROOT_MODE=${JSON.stringify(rootMode)}
+          require_sudo() { :; }
+          install_build_tools_linux() { return 0; }
+          is_root() { [[ "$ROOT_MODE" == "root" ]]; }
+          is_arch_linux() { return 1; }
+          is_alpine_linux() { return 1; }
+          command() {
+            if [[ "\${1:-}" == "-v" ]]; then
+              case "\${2:-}" in
+                pacman|apk|apt-get) return 1 ;;
+                dnf|yum) [[ "$PACKAGE_MANAGER" == "$2" ]]; return ;;
+              esac
+            fi
+            builtin command "$@"
+          }
+          download_validated_script() { :; }
+          ui_info() { :; }
+          run_required_step() { printf 'step:%s|%s\\n' "$1" "\${*:2}"; }
+          finish_linux_node_install() { :; }
+          install_node
+        `);
+
+        const sudoPrefix = rootMode === "sudo" ? "sudo " : "";
+        expect(result.status, result.stderr || result.stdout).toBe(0);
+        expect(result.stdout).toContain(
+          `step:Installing Node.js|${sudoPrefix}${packageManager} install -y -q --disablerepo=* --enablerepo=nodesource-nodejs nodejs`,
+        );
+      }
+    },
+  );
+
   it("runs apt-get through noninteractive wrappers", () => {
     expect(script).toContain("apt_get()");
     expect(script).toContain('DEBIAN_FRONTEND="${DEBIAN_FRONTEND:-noninteractive}"');


### PR DESCRIPTION
## What Problem This Solves

On RPM-based Linux systems, enabling NodeSource and then running an unrestricted `dnf` or `yum` install can select a prerelease Node.js package from another enabled repository. That can leave a fresh OpenClaw install on an unsupported runtime.

## Why This Change Was Made

Restrict the Node.js package transaction to the repository configured by the validated NodeSource setup script. The root and sudo paths now use `--disablerepo='*' --enablerepo=nodesource-nodejs` for both `dnf` and `yum`.

The regression test exercises all four package-manager and privilege-mode combinations at the installer command boundary.

## User Impact

Fresh installs on Fedora/RHEL-family systems consistently install Node.js from the intended NodeSource LTS repository instead of an unrelated prerelease repository.

## Evidence

- `node scripts/run-vitest.mjs run test/scripts/install-sh.test.ts` (167 passed)
- `bash -n scripts/install.sh`
- `pnpm format:check --no-error-on-unmatched-pattern -- scripts/install.sh test/scripts/install-sh.test.ts`
- `pnpm lint:scripts`
- `node scripts/check-changed.mjs --dry-run -- scripts/install.sh test/scripts/install-sh.test.ts`
- Autoreview: no accepted/actionable findings
- Exact-head Fedora 44 root transaction: [Website Installer Sync job](https://github.com/openclaw/openclaw/actions/runs/33229093762/job/99038501223) configured NodeSource, resolved the restricted repository transaction, installed Node.js `v24.20.0`, and completed OpenClaw installation
- Exact-head Fedora 44 non-root transaction: [Website Installer Sync job](https://github.com/openclaw/openclaw/actions/runs/33229093762/job/99038501313) completed the same NodeSource transaction through the sudo path and verified user-local OpenClaw installation

`pnpm tsgo:test:root` was also attempted, but the sparse GWT profile excludes unrelated Android, UI, and QA modules referenced by the root test config. Exact-head hosted CI remains the authoritative broad gate.

AI-assisted: yes.
