### PR TITLE
fix(macos): allow dragging the OpenClaw panel header

### DIFF
--- a/docs/platforms/macos.md
+++ b/docs/platforms/macos.md
@@ -92,6 +92,8 @@ In the macOS app's embedded dashboard, clicking an external web link opens it in
 
 The titlebar controls follow the app sidebar: while it is expanded, back/forward sit at its right edge next to the sidebar toggle; while it is collapsed, they make way for a search button (opens the command palette) and a new-session button.
 
+Drag the empty header space or title in the docked OpenClaw chat panel to move the app window. Its dock-position and close buttons remain clickable.
+
 Right-click an external link to choose **Open in Sidebar**, **Open in Default Browser**, or **Copy Link**. Modified clicks and user-activated new-window links from the dashboard continue to open in the default browser; new-window links inside the sidebar open as new sidebar tabs. Regular browser-hosted Control UI pages keep the browser's normal link and context-menu behavior.
 
 ## Import browser logins

--- a/ui/src/components/custodian/custodian-panel.test.ts
+++ b/ui/src/components/custodian/custodian-panel.test.ts
@@ -128,6 +128,53 @@ describe("custodian panel", () => {
     expect(panel.custodianPanelOpen).toBe(false);
   });
 
+  it.each(["right", "bottom"])("drags only passive header chrome when docked %s", async (dock) => {
+    const { panel } = await mountPanel();
+    panel.suppressed = false;
+    await panel.updateComplete;
+    window.dispatchEvent(
+      new CustomEvent(CUSTODIAN_PANEL_TOGGLE_EVENT, { detail: { open: true, dock } }),
+    );
+    await panel.updateComplete;
+
+    const postMessage = vi.fn();
+    vi.stubGlobal("webkit", { messageHandlers: { openclawWindowDrag: { postMessage } } });
+    const cases = [
+      [".cp-header", true],
+      [".cp-title", true],
+      [".cp-actions", true],
+      [".cp-actions button:first-child", false],
+      [".cp-actions button:first-child svg", false],
+      [".cp-actions button:last-child", false],
+      [".cp-actions button:last-child svg", false],
+      ["openclaw-custodian-surface", false],
+    ] as const;
+    for (const [selector, draggable] of cases) {
+      postMessage.mockClear();
+      const target = panel.querySelector(selector);
+      expect(target, selector).not.toBeNull();
+      const event = new MouseEvent("mousedown", {
+        bubbles: true,
+        cancelable: true,
+        composed: true,
+        button: 0,
+      });
+      target!.dispatchEvent(event);
+      expect(postMessage, selector).toHaveBeenCalledTimes(draggable ? 1 : 0);
+      if (draggable) {
+        expect(postMessage).toHaveBeenCalledWith({ type: "window-drag" });
+      }
+      expect(event.defaultPrevented, selector).toBe(draggable);
+    }
+
+    panel.querySelector<HTMLButtonElement>(".cp-actions button:first-child")!.click();
+    await panel.updateComplete;
+    expect(panel.querySelector(`.cp--${dock === "right" ? "bottom" : "right"}`)).not.toBeNull();
+    panel.querySelector<HTMLButtonElement>(".cp-actions button:last-child")!.click();
+    await panel.updateComplete;
+    expect(panel.custodianPanelOpen).toBe(false);
+  });
+
   it("ignores toggle requests while unavailable", async () => {
     const { panel } = await mountPanel();
     panel.available = false;

--- a/ui/src/components/custodian/custodian-panel.ts
+++ b/ui/src/components/custodian/custodian-panel.ts
@@ -2,6 +2,7 @@ import { asNullableRecord } from "@openclaw/normalization-core/record-coerce";
 import { html, nothing, type PropertyValues } from "lit";
 import { property } from "lit/decorators.js";
 import "../openclaw-mascot.ts";
+import { beginNativeWindowDrag } from "../../app/native-window-drag.ts";
 import { t } from "../../i18n/index.ts";
 import { OpenClawLightDomElement } from "../../lit/openclaw-element.ts";
 import {
@@ -159,7 +160,7 @@ export class OpenClawCustodianPanel extends OpenClawLightDomElement {
     return html`
       <section class="cp cp--${dock}" style=${style} aria-label=${t("custodian.panel.title")}>
         ${this.dockLayout.renderResizer("cp", t("custodian.panel.resize"))}
-        <header class="rail-header cp-header">
+        <header class="rail-header cp-header" @mousedown=${beginNativeWindowDrag}>
           <div class="cp-title">
             <openclaw-mascot
               .mood=${this.store.sending ? "thinking" : "idle"}


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users could not drag the macOS dashboard window from the unused header space in the docked OpenClaw chat panel. The affected area is the top-right strip beside the OpenClaw title, not the chat transcript beneath it.

Closes #132287

## Why This Change Was Made

The panel header omitted the existing native window-drag event binding. Reuse the same handler as the chat-pane header and macOS titlebar controls instead of expanding the native hit-test overlay, which could cover interactive controls.

The existing bridge keeps AppKit in charge of the gesture and excludes interactive descendants, including button icons. This change adds no new drag implementation, compatibility path, dependency, setting, or native API.

## User Impact

Users can move the app window by dragging the panel's empty header space or title in either right or bottom docking. Dock-position and close controls remain clickable; the conversation remains a normal selection/scrolling surface. Browser-hosted dashboards retain their existing mouse behavior when the native bridge is absent.

## Evidence

- The new rendered-panel regression failed before the fix in both dock positions: the header emitted zero drag messages instead of one.
- After the fix, all 66 focused panel, native-drag, and sibling chat-header tests pass. The regression checks the empty header/title/action gaps, both buttons and their SVG icons, and conversation content; it also checks that docking and closing still work.
- `node scripts/run-vitest.mjs ui/src/components/custodian/custodian-panel.test.ts ui/src/app/native-window-drag.test.ts ui/src/pages/chat/components/chat-pane-header.test.ts`
- `node scripts/check-changed.mjs -- ui/src/components/custodian/custodian-panel.ts ui/src/components/custodian/custodian-panel.test.ts docs/platforms/macos.md` passed formatting, typechecks, lint, and selected guards.
- `pnpm ui:build` passed, including finalized sidecar and Control UI performance checks.
- `git diff --check` passed.
- [Exact-head CI run 33229169387](https://github.com/openclaw/openclaw/actions/runs/33229169387) passed for `a013c17caaca73cb38c37dedaccf19142ba0e23e`, including `openclaw/ci-gate`.
- Fresh Codex autoreview completed with exit 0 and no findings at the configured P0-only threshold. Lower-priority findings were outside that review's scope.

### Native visual-proof limitation

Real post-fix window displacement and before/after native screenshots remain unverified. We restored and booted an existing pristine macOS QA VM, with shared folders/profile/app/clipboard/cloud/drive integration disabled for the attempt. The guest stopped at its password-protected login screen; Parallels Tools could not open a guest command session. No QA guest-login credential was available in the approved non-interactive credential store. Graceful shutdown timed out, so the task-owned test guest was force-stopped, restored to its original QA snapshot, and verified stopped afterward.

We did not reset guest credentials, access an unapproved credential vault, alter or restart the operator's live app/Gateway, or substitute a generated image, standalone WKWebView harness, or mocked bridge for actual native window-movement proof. The configured remote proof backend is Linux and cannot exercise AppKit.

The deterministic evidence above covers the omitted binding and control exclusions. Existing native code already handles this same drag message for other headers, including drag versus double-click zoom. This PR only attaches that established handler to the omitted panel header.

Production LOC: +2/-1 (net +1: one import plus the missing event binding). Tests: +47/-0. Documentation: +2/-0. No old path needs removal: the fix connects the omitted header to the existing canonical flow.

AI-assisted. No agent transcript or private screenshot content is included.
