### PR TITLE
fix(release): prove landed FRV controller commits

### DIFF
--- a/.agents/skills/release-openclaw-ci/SKILL.md
+++ b/.agents/skills/release-openclaw-ci/SKILL.md
@@ -84,6 +84,11 @@ Use this with `$release-openclaw-maintainer` and `$openclaw-testing` when a rele
   publication.
 - Post-merge controller proof must use the reviewed landed SHA on protected
   `main` through the non-release `FRV Proof Broker` and `FRV Proof Fixture`.
+  Dispatch the broker with the merged pull request number and exact landed
+  commit. The broker must require that pull request's merge commit to match the
+  landed commit, prove the landed commit is identical to or an ancestor of its
+  trusted workflow SHA, and repeat authority, merge, and ancestry checks
+  immediately before rerunning the fixture.
   Require the exact fixed no-op fixture run to advance from its intentional
   attempt-one failure to an attempt-two pass. The broker must emit its receipt
   without creating a release candidate, release artifact, publication,

--- a/.github/workflows/frv-proof-broker.yml
+++ b/.github/workflows/frv-proof-broker.yml
@@ -5,11 +5,11 @@ on:
   workflow_dispatch:
     inputs:
       pr_number:
-        description: Open OpenClaw pull request containing the FRV recovery candidate
+        description: Merged OpenClaw pull request containing the FRV recovery controller
         required: true
         type: string
-      head_sha:
-        description: Exact lowercase 40-character pull request head SHA
+      landed_sha:
+        description: Exact lowercase 40-character commit landed on main
         required: true
         type: string
 permissions: {}

--- a/docs/reference/full-release-validation.md
+++ b/docs/reference/full-release-validation.md
@@ -134,8 +134,14 @@ creates or updates repository refs itself.
 Use the non-release `FRV Proof Broker` and `FRV Proof Fixture` workflows only
 after the reviewed SHA lands on protected `main`. The fixture contains one
 fixed no-op job that intentionally fails on attempt one and passes on attempt
-two. The broker validates the exact maintainer, pull request head, protected
+two. The broker validates the exact maintainer, merged pull request, protected
 main SHA, fixture workflow, and run tuple before rerunning only that failed job.
+Supply the merged pull request number and its exact landed commit. The broker
+requires the pull request to be merged into `main`, requires its recorded merge
+commit to equal that landed commit, and requires the landed commit to be
+identical to or an ancestor of the trusted broker workflow SHA. It repeats the
+maintainer, merged pull request, and ancestry checks immediately before the
+fixture rerun.
 
 Accept the hosted mutation proof only when the exact fixture run advances to
 attempt two and passes. The broker emits a receipt and must create no release

--- a/scripts/frv-proof-broker.d.mts
+++ b/scripts/frv-proof-broker.d.mts
@@ -1,7 +1,7 @@
 export type BrokerContext = {
   actor: string;
   correlation: string;
-  headSha: string;
+  landedSha: string;
   prNumber: number;
   repository: "openclaw/openclaw";
   runId: number;
@@ -27,7 +27,7 @@ export type ProofReceipt = {
   correlation: string;
   fixtureRunAttempt: 2;
   fixtureRunId: number;
-  headSha: string;
+  landedSha: string;
   operation: "noop";
   prNumber: number;
   repository: "openclaw/openclaw";

--- a/scripts/frv-proof-broker.mjs
+++ b/scripts/frv-proof-broker.mjs
@@ -2,6 +2,7 @@
 import { appendFileSync, readFileSync, writeFileSync } from "node:fs";
 import { pathToFileURL } from "node:url";
 import { isRecord } from "./lib/record-shared.mjs";
+import { validateForwardAncestry } from "./pr-lib/crabbox-gate-contract.mjs";
 
 const REPOSITORY = "openclaw/openclaw";
 const BROKER_WORKFLOW = ".github/workflows/frv-proof-broker.yml";
@@ -77,19 +78,19 @@ export function validateBrokerRequest(event, env) {
     "GITHUB_RUN_ATTEMPT",
   );
 
-  assertExactKeys(event.inputs, ["head_sha", "pr_number"], "workflow inputs");
+  assertExactKeys(event.inputs, ["landed_sha", "pr_number"], "workflow inputs");
   const inputs = event.inputs;
   const prNumber = requiredPositiveInteger(inputs.pr_number, "pr_number");
-  const headSha = requiredString(inputs.head_sha, "head_sha");
-  if (!SHA_PATTERN.test(headSha)) {
-    throw new Error("head_sha must be exactly 40 lowercase hex characters");
+  const landedSha = requiredString(inputs.landed_sha, "landed_sha");
+  if (!SHA_PATTERN.test(landedSha)) {
+    throw new Error("landed_sha must be exactly 40 lowercase hex characters");
   }
   const correlation = `frv-proof-${runId}-${runAttempt}`;
 
   return {
     actor,
     correlation,
-    headSha,
+    landedSha,
     prNumber,
     repository: REPOSITORY,
     runId,
@@ -117,14 +118,17 @@ function validateActorPermission(value, actor) {
 
 function validatePullRequest(value, context) {
   const pull = record(value, "pull request");
-  if (pull.number !== context.prNumber || pull.state !== "open") {
-    throw new Error("proof target must be the requested open pull request");
+  if (
+    pull.number !== context.prNumber ||
+    pull.state !== "closed" ||
+    pull.merged !== true ||
+    typeof pull.merged_at !== "string" ||
+    pull.merged_at.length === 0
+  ) {
+    throw new Error("proof target must be the requested merged pull request");
   }
-  if (nestedRecord(pull, "head", "pull request").sha !== context.headSha) {
-    throw new Error("pull request head SHA does not match the requested exact head");
-  }
-  if (nestedRecord(pull, "head", "pull request").repo?.full_name !== context.repository) {
-    throw new Error("pull request head must belong to the trusted repository");
+  if (pull.merge_commit_sha !== context.landedSha) {
+    throw new Error("pull request merge commit does not match the requested landed SHA");
   }
   if (nestedRecord(pull, "base", "pull request").ref !== "main") {
     throw new Error("pull request base must be main");
@@ -132,6 +136,14 @@ function validatePullRequest(value, context) {
   if (nestedRecord(pull, "base", "pull request").repo?.full_name !== context.repository) {
     throw new Error("pull request base repository does not match");
   }
+}
+
+function validateLandedAncestry(value, context) {
+  validateForwardAncestry(
+    value,
+    { baseSha: context.landedSha, headSha: context.workflowSha },
+    "landed controller ancestry",
+  );
 }
 
 function validateFixtureWorkflow(value) {
@@ -261,6 +273,10 @@ async function validateMutationAuthority(api, context) {
     context.actor,
   );
   validatePullRequest(await api.request("GET", `/pulls/${context.prNumber}`), context);
+  validateLandedAncestry(
+    await api.request("GET", `/compare/${context.landedSha}...${context.workflowSha}`),
+    context,
+  );
 }
 
 async function validateFixturePrerequisite(api) {
@@ -294,7 +310,7 @@ export async function runProofBroker({ api, env, event, sleep = setTimeoutPromis
     correlation: context.correlation,
     fixtureRunAttempt: 2,
     fixtureRunId,
-    headSha: context.headSha,
+    landedSha: context.landedSha,
     operation: FIXTURE_OPERATION,
     prNumber: context.prNumber,
     repository: context.repository,
@@ -357,7 +373,7 @@ async function main() {
         "## FRV failed-job rerun proof",
         "",
         `- Pull request: #${receipt.prNumber}`,
-        `- Exact head: \`${receipt.headSha}\``,
+        `- Landed controller: \`${receipt.landedSha}\``,
         `- Trusted broker SHA: \`${receipt.workflowSha}\``,
         `- Fixture run: \`${receipt.fixtureRunId}\`, attempt \`2\``,
         "- Fixed operation: `noop`",

--- a/test/scripts/frv-proof-broker.test.ts
+++ b/test/scripts/frv-proof-broker.test.ts
@@ -9,7 +9,8 @@ import {
 } from "../../scripts/frv-proof-broker.mjs";
 
 const workflowSha = "a".repeat(40);
-const headSha = "b".repeat(40);
+const landedSha = "b".repeat(40);
+const pullHeadSha = "c".repeat(40);
 const repository = "openclaw/openclaw";
 
 type BrokerWorkflow = {
@@ -52,7 +53,7 @@ function brokerEnv(overrides: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv {
 function brokerEvent(overrides: Record<string, unknown> = {}) {
   return {
     inputs: {
-      head_sha: headSha,
+      landed_sha: landedSha,
       pr_number: "128141",
       ...overrides,
     },
@@ -78,15 +79,30 @@ function fixtureRun(overrides: Record<string, unknown> = {}) {
 function pullRequest(overrides: Record<string, unknown> = {}) {
   return {
     base: { ref: "main", repo: { full_name: repository } },
-    head: { sha: headSha, repo: { full_name: repository } },
+    head: { sha: pullHeadSha, repo: { full_name: repository } },
+    merge_commit_sha: landedSha,
+    merged: true,
+    merged_at: "2026-08-28T11:35:11Z",
     number: 128141,
-    state: "open",
+    state: "closed",
+    ...overrides,
+  };
+}
+
+function landedAncestry(overrides: Record<string, unknown> = {}) {
+  return {
+    ahead_by: 1,
+    base_commit: { sha: landedSha },
+    behind_by: 0,
+    merge_base_commit: { sha: landedSha },
+    status: "ahead",
     ...overrides,
   };
 }
 
 function successfulApi(
   options: {
+    ancestries?: Array<Record<string, unknown>>;
     initialRun?: Record<string, unknown>;
     mainShas?: string[];
     permissions?: string[];
@@ -99,6 +115,7 @@ function successfulApi(
   let permissionRead = 0;
   let pullRead = 0;
   let mainRead = 0;
+  let ancestryRead = 0;
   const initialRun = options.initialRun ?? fixtureRun();
   const rerun =
     options.rerun ??
@@ -118,6 +135,11 @@ function successfulApi(
         const pull = options.pulls?.[pullRead] ?? pullRequest();
         pullRead += 1;
         return pull;
+      }
+      if (method === "GET" && path === `/compare/${landedSha}...${workflowSha}`) {
+        const ancestry = options.ancestries?.[ancestryRead] ?? landedAncestry();
+        ancestryRead += 1;
+        return ancestry;
       }
       if (method === "GET" && path === "/actions/workflows/frv-proof-fixture.yml") {
         return {
@@ -158,7 +180,7 @@ describe("FRV proof broker request validation", () => {
     const parsed = validateBrokerRequest(brokerEvent(), brokerEnv());
     expect(parsed).toMatchObject({
       correlation: "frv-proof-12345-1",
-      headSha,
+      landedSha,
       prNumber: 128141,
       workflowSha,
     });
@@ -179,7 +201,7 @@ describe("FRV proof broker request validation", () => {
 
   it("rejects malformed PR and SHA inputs", () => {
     expect(() => validateBrokerRequest(brokerEvent({ pr_number: "0" }), brokerEnv())).toThrow();
-    expect(() => validateBrokerRequest(brokerEvent({ head_sha: "ABC" }), brokerEnv())).toThrow();
+    expect(() => validateBrokerRequest(brokerEvent({ landed_sha: "ABC" }), brokerEnv())).toThrow();
     expect(() =>
       validateBrokerRequest(brokerEvent(), brokerEnv({ GITHUB_RUN_ATTEMPT: "0" })),
     ).toThrow(/GITHUB_RUN_ATTEMPT/u);
@@ -203,7 +225,7 @@ describe("FRV proof fixture identity", () => {
 
   it.each([
     ["repository", { repository: { full_name: "attacker/fork" } }],
-    ["SHA", { head_sha: headSha }],
+    ["SHA", { head_sha: landedSha }],
     ["workflow", { path: ".github/workflows/full-release-validation.yml" }],
     ["run", { id: 778 }],
     ["attempt", { run_attempt: 2 }],
@@ -227,6 +249,7 @@ describe("FRV proof broker mutation boundary", () => {
       "/actions/workflows/frv-proof-fixture.yml",
       "/collaborators/maintainer/permission",
       "/pulls/128141",
+      `/compare/${landedSha}...${workflowSha}`,
       "/git/ref/heads/main",
     ]);
   });
@@ -242,6 +265,7 @@ describe("FRV proof broker mutation boundary", () => {
     expect(receipt).toMatchObject({
       fixtureRunAttempt: 2,
       fixtureRunId: 777,
+      landedSha,
       operation: "noop",
       sourceRef: "refs/heads/main",
     });
@@ -262,13 +286,23 @@ describe("FRV proof broker mutation boundary", () => {
     ]);
   });
 
-  it("rejects a mismatched PR head before any mutation", async () => {
+  it.each([
+    ["open", { merged: false, merged_at: null, state: "open" }, /merged pull request/u],
+    ["unmerged", { merged: false, merged_at: null }, /merged pull request/u],
+    [
+      "wrong base",
+      { base: { ref: "release/2026.9.1", repo: { full_name: repository } } },
+      /base must be main/u,
+    ],
+    [
+      "wrong base repository",
+      { base: { ref: "main", repo: { full_name: "attacker/fork" } } },
+      /base repository/u,
+    ],
+    ["wrong merge SHA", { merge_commit_sha: "c".repeat(40) }, /merge commit/u],
+  ])("rejects a %s PR before any mutation", async (_label, overrides, message) => {
     const { api, calls } = successfulApi({
-      pulls: [
-        pullRequest({
-          head: { sha: "c".repeat(40), repo: { full_name: repository } },
-        }),
-      ],
+      pulls: [pullRequest(overrides)],
     });
     await expect(
       runProofBroker({
@@ -277,8 +311,83 @@ describe("FRV proof broker mutation boundary", () => {
         event: brokerEvent(),
         sleep: async () => {},
       }),
-    ).rejects.toThrow(/head SHA/u);
+    ).rejects.toThrow(message);
     expect(calls.some((call) => call.method !== "GET")).toBe(false);
+  });
+
+  it("binds a squash-merged PR to its landed commit instead of its former head", async () => {
+    const { api } = successfulApi();
+    const receipt = await runProofBroker({
+      api,
+      env: brokerEnv(),
+      event: brokerEvent(),
+      sleep: async () => {},
+    });
+    expect(pullHeadSha).not.toBe(landedSha);
+    expect(receipt.landedSha).toBe(landedSha);
+  });
+
+  it.each([
+    [
+      "non-ancestor",
+      {
+        ahead_by: 0,
+        base_commit: { sha: landedSha },
+        behind_by: 1,
+        merge_base_commit: { sha: "c".repeat(40) },
+        status: "behind",
+      },
+    ],
+    [
+      "wrong base",
+      {
+        base_commit: { sha: "c".repeat(40) },
+        merge_base_commit: { sha: "c".repeat(40) },
+      },
+    ],
+  ])("rejects %s landed ancestry before any mutation", async (_label, ancestry) => {
+    const { api, calls } = successfulApi({ ancestries: [landedAncestry(ancestry)] });
+    await expect(
+      runProofBroker({
+        api,
+        env: brokerEnv(),
+        event: brokerEvent(),
+        sleep: async () => {},
+      }),
+    ).rejects.toThrow(/landed controller ancestry/u);
+    expect(calls.some((call) => call.method !== "GET")).toBe(false);
+  });
+
+  it("accepts a landed SHA identical to the trusted workflow SHA", async () => {
+    const identicalSha = workflowSha;
+    const { api } = successfulApi({
+      pulls: [
+        pullRequest({ merge_commit_sha: identicalSha }),
+        pullRequest({ merge_commit_sha: identicalSha }),
+      ],
+    });
+    let ancestryReads = 0;
+    await runProofBroker({
+      api: {
+        request: async (method, path, body) => {
+          if (method === "GET" && path === `/compare/${identicalSha}...${workflowSha}`) {
+            ancestryReads += 1;
+            return {
+              ahead_by: 0,
+              base_commit: { sha: identicalSha },
+              behind_by: 0,
+              merge_base_commit: { sha: identicalSha },
+              status: "identical",
+            };
+          }
+          return api.request(method, path, body);
+        },
+      },
+      env: brokerEnv(),
+      event: brokerEvent({ landed_sha: identicalSha }),
+      sleep: async () => {},
+    });
+    expect(ancestryReads).toBe(2);
   });
 
   it("rejects a moved main immediately before dispatch", async () => {
@@ -338,12 +447,12 @@ describe("FRV proof broker mutation boundary", () => {
     ]);
   });
 
-  it("rejects a replaced PR head before rerunning", async () => {
+  it("revalidates the merged PR immediately before rerunning", async () => {
     const { api, calls } = successfulApi({
       pulls: [
         pullRequest(),
         pullRequest({
-          head: { sha: "c".repeat(40), repo: { full_name: repository } },
+          merge_commit_sha: "c".repeat(40),
         }),
       ],
     });
@@ -354,7 +463,30 @@ describe("FRV proof broker mutation boundary", () => {
         event: brokerEvent(),
         sleep: async () => {},
       }),
-    ).rejects.toThrow(/head SHA/u);
+    ).rejects.toThrow(/merge commit/u);
+    expect(calls.some((call) => call.path.endsWith("/rerun-failed-jobs"))).toBe(false);
+  });
+
+  it("revalidates landed ancestry immediately before rerunning", async () => {
+    const { api, calls } = successfulApi({
+      ancestries: [
+        landedAncestry(),
+        landedAncestry({
+          ahead_by: 0,
+          behind_by: 1,
+          merge_base_commit: { sha: "c".repeat(40) },
+          status: "behind",
+        }),
+      ],
+    });
+    await expect(
+      runProofBroker({
+        api,
+        env: brokerEnv(),
+        event: brokerEvent(),
+        sleep: async () => {},
+      }),
+    ).rejects.toThrow(/landed controller ancestry/u);
     expect(calls.some((call) => call.path.endsWith("/rerun-failed-jobs"))).toBe(false);
   });
 
@@ -411,9 +543,9 @@ describe("FRV proof workflows", () => {
   const broker = parseYaml(brokerSource) as BrokerWorkflow;
   const fixture = parseYaml(fixtureSource) as FixtureWorkflow;
 
-  it("exposes only PR number and exact head as broker inputs", () => {
+  it("exposes only PR number and exact landed commit as broker inputs", () => {
     expect(Object.keys(broker.on.workflow_dispatch.inputs).toSorted()).toEqual([
-      "head_sha",
+      "landed_sha",
       "pr_number",
     ]);
     expect(broker.concurrency).toEqual({
@@ -436,7 +568,7 @@ describe("FRV proof workflows", () => {
       "persist-credentials": false,
       ref: "${{ github.workflow_sha }}",
     });
-    expect(brokerSource).not.toContain("inputs.head_sha }}");
+    expect(brokerSource).not.toContain("inputs.landed_sha }}");
     expect(brokerSource).not.toContain("pull/");
     expect(brokerSource).not.toContain("contents: write");
   });


### PR DESCRIPTION
Related: #128141

## What Problem This Solves

Resolves a problem where release operators could not run the required post-merge FRV controller proof because the proof broker accepted only an open pull request head. Once the controller landed, that authorization target no longer existed.

## Why This Change Was Made

The broker now accepts the exact landed commit for a merged pull request. Before either fixture mutation, it requires the PR to be merged into `openclaw/openclaw` `main`, requires GitHub's recorded merge commit to match the supplied landed commit, and proves that commit is identical to or an ancestor of the trusted broker workflow SHA.

The broker still checks out only trusted `main` code, uses the fixed tokenless no-op fixture, and has no repository-ref, release, candidate, package, or publication path.

## User Impact

Release operators can run the documented non-release proof after an FRV controller PR is merged, including squash-merged PRs whose landed commit differs from the former PR head.

## Evidence

- `node --import tsx scripts/run-vitest.mjs run --config test/vitest/vitest.tooling.config.ts test/scripts/frv-proof-broker.test.ts test/scripts/check-workflows.test.ts --reporter=dot`
  - 43 tests passed.
- `actionlint .github/workflows/frv-proof-broker.yml`
- `uvx --from zizmor==1.29.0 zizmor .github/workflows/frv-proof-broker.yml`
  - no findings; one existing suppression.
- `python3 scripts/check-composite-action-input-interpolation.py`
- `node scripts/check-no-conflict-markers.mjs`
- `pnpm docs:check-mdx`
- `pnpm docs:check-links`
  - 6,975 internal links checked; none broken.
- `pnpm docs:check-i18n-glossary`
- Targeted Oxlint, script erasability, formatting, and `git diff --check` passed.
- TruffleHog branch scan: 0 verified and 0 unverified secrets.
- Read-only GitHub API checks confirmed merged PR #128141 exposes its squash result through `merge_commit_sha` and that the landed commit is an ancestor of current `main`.

Known validation gaps:

- `pnpm check:workflows` cannot reach its checks because `scripts/check-workflows.mts` falls back to the unavailable `pre-commit==4.6.2`. The touched workflow passed direct `actionlint`, `zizmor`, and repository workflow guard checks.
- `pnpm tsgo:scripts` is blocked by existing sparse-worktree omissions under `ui/config` plus the existing `pako` declaration gap; no changed-file error was reported before those checkout-wide failures.
- Fresh branch autoreview completed with Claude Fable 5/high and reported no accepted or actionable findings.
- Per scope, no proof broker or release workflow was dispatched.
