### PR TITLE
fix(release): preserve canonical candidate requests

### DIFF
--- a/scripts/full-release-candidate-reuse.mjs
+++ b/scripts/full-release-candidate-reuse.mjs
@@ -3,7 +3,6 @@ import { spawnSync } from "node:child_process";
 import { appendFileSync, readFileSync } from "node:fs";
 import { pathToFileURL } from "node:url";
 import {
-  buildFullReleaseCandidateRequest,
   canonicalFullReleaseCandidateRequestJson,
   candidateRequestSha256,
   fullReleaseCandidateArtifactName,
@@ -192,9 +191,7 @@ function output(name, value) {
 
 async function discover(args) {
   const contract = requestContract(
-    buildFullReleaseCandidateRequest(
-      readJson(option(args, "--request-input"), "candidate request input"),
-    ),
+    readJson(option(args, "--request-input"), "candidate request input"),
   );
   const expectedRequestSha256 = optionalOption(args, "--expected-request-sha256");
   if (expectedRequestSha256 !== undefined && expectedRequestSha256 !== contract.requestSha256) {

--- a/test/scripts/full-release-candidate-reuse.test.ts
+++ b/test/scripts/full-release-candidate-reuse.test.ts
@@ -24,6 +24,7 @@ import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
 const NOW = Date.parse("2026-08-28T12:00:00Z");
 const EXPIRES_AT = "2026-09-04T12:00:00Z";
 const REPOSITORY = "openclaw/openclaw";
+const CONTRACT_SCRIPT = resolve("scripts/full-release-candidate-contract.mjs");
 const SCRIPT = resolve("scripts/full-release-candidate-reuse.mjs");
 const WORKFLOW_PATH = ".github/workflows/full-release-validation.yml";
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
@@ -344,6 +345,94 @@ describe("trusted full release candidate selection", () => {
 });
 
 describe("full release candidate discovery CLI", () => {
+  it("preserves canonical request arrays when checking the expected digest", () => {
+    const root = tempDirs.make("full-release-candidate-canonical-");
+    const bin = join(root, "bin");
+    const rawInputPath = join(root, "raw-request-input.json");
+    const requestPath = join(root, "request.json");
+    const outputPath = join(root, "github-output");
+    const callLogPath = join(root, "gh-calls");
+    mkdirSync(bin);
+    const ghPath = join(bin, "gh");
+    writeFileSync(
+      ghPath,
+      `#!/bin/sh
+printf '%s\n' "$*" >> "$FAKE_GH_CALL_LOG"
+printf '%s\n' '{"artifacts":[]}'
+`,
+    );
+    chmodSync(ghPath, 0o755);
+    writeFileSync(
+      rawInputPath,
+      JSON.stringify(
+        fullReleaseCandidateRequestInput({
+          upgradeSurvivorBaselines: "openclaw@latest",
+          upgradeSurvivorScenarios: "base",
+        }),
+      ),
+    );
+    const contractResult = spawnSync(
+      process.execPath,
+      [CONTRACT_SCRIPT, "request", "--input", rawInputPath, "--output", requestPath],
+      { encoding: "utf8", timeout: 10_000 },
+    );
+    expect(contractResult.status, contractResult.stderr).toBe(0);
+    const contract = JSON.parse(contractResult.stdout) as {
+      requestJson: string;
+      requestSha256: string;
+    };
+    const requestBeforeDiscovery = readFileSync(requestPath, "utf8");
+    const request = JSON.parse(requestBeforeDiscovery) as {
+      upgradeSurvivorBaselines: string[];
+      upgradeSurvivorScenarios: string[];
+    };
+    expect(request.upgradeSurvivorBaselines).toEqual(["openclaw@latest"]);
+    expect(request.upgradeSurvivorScenarios).toEqual(["base"]);
+
+    const result = spawnSync(
+      process.execPath,
+      [
+        SCRIPT,
+        "discover",
+        "--request-input",
+        requestPath,
+        "--expected-request-sha256",
+        contract.requestSha256,
+      ],
+      {
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          FAKE_GH_CALL_LOG: callLogPath,
+          GH_TOKEN: "test-token",
+          GITHUB_OUTPUT: outputPath,
+          PATH: `${bin}:${process.env.PATH}`,
+        },
+        timeout: 10_000,
+      },
+    );
+    expect(result.status, result.stderr).toBe(0);
+    const outputs = Object.fromEntries(
+      readFileSync(outputPath, "utf8")
+        .trim()
+        .split("\n")
+        .map((line) => {
+          const separator = line.indexOf("=");
+          return [line.slice(0, separator), line.slice(separator + 1)];
+        }),
+    );
+    expect(outputs).toMatchObject({
+      request_json: contract.requestJson,
+      request_sha256: contract.requestSha256,
+      reused: "false",
+      state: "miss",
+    });
+    expect(readFileSync(requestPath, "utf8")).toBe(requestBeforeDiscovery);
+    expect(readFileSync(callLogPath, "utf8").trim()).toBe(
+      `api repos/${REPOSITORY}/actions/artifacts?name=full-release-candidate-v2-${contract.requestSha256}&per_page=100&page=1`,
+    );
+  });
+
   it("marks exhausted transient reads unavailable instead of permitting preparation", () => {
     const root = tempDirs.make("full-release-candidate-discovery-");
     const bin = join(root, "bin");
@@ -364,7 +453,7 @@ exit 1
 `,
     );
     chmodSync(ghPath, 0o755);
-    writeFileSync(inputPath, JSON.stringify(fullReleaseCandidateRequestInput()));
+    writeFileSync(inputPath, JSON.stringify(fullReleaseCandidateManifestFixture().request));
     const result = spawnSync(process.execPath, [SCRIPT, "discover", "--request-input", inputPath], {
       encoding: "utf8",
       env: {
@@ -405,7 +494,7 @@ cat "$FAKE_GH_PAYLOAD"
 `,
     );
     chmodSync(ghPath, 0o755);
-    writeFileSync(inputPath, JSON.stringify(fullReleaseCandidateRequestInput()));
+    writeFileSync(inputPath, JSON.stringify(fullReleaseCandidateManifestFixture().request));
     writeFileSync(
       payloadPath,
       JSON.stringify({ artifacts: Array.from({ length: 100 }, () => ({})) }),
@@ -482,7 +571,7 @@ esac
         },
       });
     });
-    writeFileSync(inputPath, JSON.stringify(fullReleaseCandidateRequestInput()));
+    writeFileSync(inputPath, JSON.stringify(fullReleaseCandidateManifestFixture().request));
     writeFileSync(artifactListingPath, JSON.stringify({ artifacts }));
     const result = spawnSync(process.execPath, [SCRIPT, "discover", "--request-input", inputPath], {
       encoding: "utf8",
@@ -550,7 +639,7 @@ esac
     );
     chmodSync(ghPath, 0o755);
     const { archive, manifest, metadata } = await fixture();
-    writeFileSync(inputPath, JSON.stringify(fullReleaseCandidateRequestInput()));
+    writeFileSync(inputPath, JSON.stringify(fullReleaseCandidateManifestFixture().request));
     writeFileSync(archivePath, archive);
     writeFileSync(artifactListingPath, JSON.stringify({ artifacts: [metadata] }));
     writeFileSync(workflowRunPath, JSON.stringify(workflowRun()));


### PR DESCRIPTION
## What Problem This Solves

Full Release Validation passed a canonical candidate request into candidate discovery. Discovery rebuilt that canonical object as raw CLI input, dropping array-valued survivor policy and changing the request digest before acquisition could start.

Run https://github.com/openclaw/openclaw/actions/runs/33228807189 reproduced the failure in `Acquire full release candidate / Find trusted release candidate`.

## Why This Change Was Made

Discovery now validates and digests the canonical request directly. It no longer routes canonical JSON through the raw-input builder.

The subprocess regression generates canonical JSON with nonempty baseline and scenario arrays through the real contract CLI, passes its exact digest into discovery, and verifies the unchanged request identity plus the digest-qualified artifact lookup.

## User Impact

Fresh Full Release Validation runs can acquire or prepare the exact requested candidate instead of failing before selected-lane execution with a false digest mismatch.

## Scope

- Production/tooling: +1/-4
- Tests: +93/-4
- No workflow, dependency, configuration, publication, tag, registry, or compatibility change

## Evidence

- Pre-fix regression: failed with `full release candidate request digest does not match the expected request digest`.
- Post-fix reuse suite: 28 tests passed.
- Contract suite: 52 tests passed.
- Formatting and `git diff --check`: passed.
- Changed-surface gate: all preceding guards passed; root test typecheck stopped on the unrelated current-main `pako` declaration baseline in `ui/vite.config.ts`.
- Autoreview: clean, no accepted P0/P1 findings.
- Fresh Full Release Validation: pending after merge and subject to the six-hour controller throttle.
