### PR TITLE
fix(memory-wiki): publish dashboard snapshots

### DIFF
--- a/docs/plugins/memory-wiki.md
+++ b/docs/plugins/memory-wiki.md
@@ -313,6 +313,9 @@ gateway methods (`wiki.overview`, `wiki.get`, `wiki.importInsights`); inline
 page previews use `wiki.get`, the same lookup agents reach through the
 `wiki_get` tool.
 
+Each dashboard keeps at most the newest 2,500 cards in its compiled snapshot.
+When a vault exceeds that bound, the UI shows the returned and total item counts.
+
 Dashboard requests never scan raw vault pages or wait for a full vault compile.
 During automatic recovery, the UI reports that the dashboards are rebuilding;
 reload the tab shortly. When

--- a/docs/plugins/memory-wiki.md
+++ b/docs/plugins/memory-wiki.md
@@ -313,6 +313,12 @@ gateway methods (`wiki.overview`, `wiki.get`, `wiki.importInsights`); inline
 page previews use `wiki.get`, the same lookup agents reach through the
 `wiki_get` tool.
 
+Dashboard requests never scan raw vault pages or wait for a full vault compile.
+During automatic recovery, the UI reports that the dashboards are rebuilding;
+reload the tab shortly. When
+`ingest.autoCompile` is `false`, a source change or older cache reports that a
+compile is required instead. Run `openclaw wiki compile`, then reload the tab.
+
 ## Prompt and context behavior
 
 When `context.includeCompiledDigestPrompt` is enabled, memory prompt sections
@@ -393,6 +399,7 @@ Key toggles:
 | `bridge.followMemoryEvents`                | default `true`                                 | include event logs in bridge mode                                             |
 | `unsafeLocal.allowPrivateMemoryCoreAccess` | default `false`                                | required to run `unsafe-local` imports                                        |
 | `unsafeLocal.paths`                        | default `[]`                                   | explicit local paths to import in `unsafe-local` mode                         |
+| `ingest.autoCompile`                       | default `true`                                 | rebuild compiled output after imported sources change                         |
 | `search.backend`                           | `shared` (default), `local`                    |                                                                               |
 | `search.corpus`                            | `wiki` (default), `memory`, `all`              |                                                                               |
 | `context.includeCompiledDigestPrompt`      | default `false`                                | append the selected agent's compact digest snapshot to memory prompt sections |

--- a/extensions/memory-wiki/index.test.ts
+++ b/extensions/memory-wiki/index.test.ts
@@ -19,6 +19,8 @@ import {
   loadMemoryWikiVaultIdentity,
   resolveMemoryWikiVaultSourceGeneration,
 } from "./src/log.js";
+import { withMemoryWikiVaultMutation } from "./src/mutation-coordinator.js";
+import { waitForMemoryWikiImportedSourceSyncs } from "./src/source-sync.js";
 import { createMemoryWikiTestHarness } from "./src/test-helpers.js";
 
 const toolMocks = vi.hoisted(() => {
@@ -286,6 +288,60 @@ describe("memory-wiki plugin", () => {
 
     await expect(publication).rejects.toThrow("cache owner retired before publication");
     expect(commitPublication).not.toHaveBeenCalled();
+    await expect(loadMemoryWikiCompiledCache(config)).resolves.toBeNull();
+  });
+
+  it("closes queued dashboard source sync before it can activate a vault", async () => {
+    const rootDir = await createTempDir("memory-wiki-index-stop-sync-");
+    const { api, registerGatewayMethod, registerService } = createPluginApi();
+    api.pluginConfig = { vault: { path: rootDir } };
+    plugin.register(api);
+    const config = resolveMemoryWikiConfig(api.pluginConfig);
+    const service = registerService.mock.calls[0]?.[0];
+    await service?.start?.();
+
+    const mutationEntered = deferred();
+    const releaseMutation = deferred();
+    const mutation = withMemoryWikiVaultMutation(rootDir, async () => {
+      mutationEntered.resolve();
+      await releaseMutation.promise;
+    });
+    await mutationEntered.promise;
+    const handler = registerGatewayMethod.mock.calls.find(
+      ([method]) => method === "wiki.importInsights",
+    )?.[1];
+    if (!handler) {
+      throw new Error("Expected wiki.importInsights gateway handler");
+    }
+    await handler({ params: {}, respond: vi.fn() });
+    await vi.waitFor(async () => {
+      const drainState = await Promise.race([
+        waitForMemoryWikiImportedSourceSyncs().then(() => "settled" as const),
+        new Promise<"pending">((resolve) => {
+          setImmediate(() => resolve("pending"));
+        }),
+      ]);
+      expect(drainState).toBe("pending");
+    });
+
+    const stop = service?.stop?.();
+    releaseMutation.resolve();
+    await mutation;
+    await stop;
+
+    const snapshot = emptyCompiledSnapshot();
+    await expect(
+      writeMemoryWikiCompiledCache(
+        config,
+        snapshot,
+        resolveMemoryWikiCompiledCacheGeneration(snapshot),
+        createMemoryWikiCompiledCachePublicationId(),
+        null,
+        async () => {},
+        async () => {},
+        () => loadMemoryWikiValidatedVaultIdentity(rootDir),
+      ),
+    ).rejects.toThrow("vault is not active");
     await expect(loadMemoryWikiCompiledCache(config)).resolves.toBeNull();
   });
 

--- a/extensions/memory-wiki/index.test.ts
+++ b/extensions/memory-wiki/index.test.ts
@@ -41,6 +41,33 @@ vi.mock("./src/tool.js", () => toolMocks);
 
 const { createPluginApi, createTempDir } = createMemoryWikiTestHarness();
 
+function emptyCompiledSnapshot(): MemoryWikiCompiledCacheSnapshot {
+  return {
+    digest: { claimCount: 0, contradictionCount: 0, pages: [] },
+    claims: [],
+    dashboards: {
+      importInsights: { sourceType: "chatgpt", totalItems: 0, totalClusters: 0, clusters: [] },
+      overview: {
+        totalItems: 0,
+        totalPages: 0,
+        pageCounts: { synthesis: 0, entity: 0, concept: 0, source: 0, report: 0 },
+        totalClaims: 0,
+        totalQuestions: 0,
+        totalContradictions: 0,
+        clusters: [],
+      },
+    },
+  };
+}
+
+function deferred() {
+  let resolve!: () => void;
+  const promise = new Promise<void>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
 describe("memory-wiki plugin", () => {
   it("registers prompt supplement, gateway methods, tools, and wiki cli surface", () => {
     const {
@@ -217,6 +244,51 @@ describe("memory-wiki plugin", () => {
     });
   });
 
+  it("fences cache publication when the plugin service stops", async () => {
+    const rootDir = await createTempDir("memory-wiki-index-stop-fence-");
+    await fs.mkdir(path.join(rootDir, ".openclaw-wiki"), { recursive: true });
+    await fs.writeFile(path.join(rootDir, ".openclaw-wiki", "log.jsonl"), "", "utf8");
+    const { api, registerService } = createPluginApi();
+    api.pluginConfig = { vault: { path: rootDir } };
+    plugin.register(api);
+    const config = resolveMemoryWikiConfig(api.pluginConfig);
+    const service = registerService.mock.calls[0]?.[0];
+    await service?.start?.();
+    const identity = await loadMemoryWikiVaultIdentity(rootDir);
+    if (!identity.vaultGeneration) {
+      throw new Error("Expected an active Memory Wiki vault generation");
+    }
+    const snapshot = emptyCompiledSnapshot();
+    const validationEntered = deferred();
+    const releaseValidation = deferred();
+    const commitPublication = vi.fn();
+    const publicationId = createMemoryWikiCompiledCachePublicationId();
+    const publication = writeMemoryWikiCompiledCache(
+      config,
+      snapshot,
+      resolveMemoryWikiCompiledCacheGeneration(snapshot),
+      publicationId,
+      null,
+      async () => {
+        validationEntered.resolve();
+        await releaseValidation.promise;
+      },
+      commitPublication,
+      async () => ({
+        vaultGeneration: identity.vaultGeneration,
+        compiledCachePublicationId: publicationId,
+      }),
+    );
+    await validationEntered.promise;
+
+    await service?.stop?.();
+    releaseValidation.resolve();
+
+    await expect(publication).rejects.toThrow("cache owner retired before publication");
+    expect(commitPublication).not.toHaveBeenCalled();
+    await expect(loadMemoryWikiCompiledCache(config)).resolves.toBeNull();
+  });
+
   it("clears active owners before a fallible lifecycle identity refresh", async () => {
     const rootDir = await createTempDir("memory-wiki-index-refresh-failure-");
     const { api, registerService } = createPluginApi();
@@ -228,22 +300,7 @@ describe("memory-wiki plugin", () => {
     const service = registerService.mock.calls[0]?.[0];
     await service?.start?.();
 
-    const snapshot: MemoryWikiCompiledCacheSnapshot = {
-      digest: { claimCount: 0, contradictionCount: 0, pages: [] },
-      claims: [],
-      dashboards: {
-        importInsights: { sourceType: "chatgpt", totalItems: 0, totalClusters: 0, clusters: [] },
-        overview: {
-          totalItems: 0,
-          totalPages: 0,
-          pageCounts: { synthesis: 0, entity: 0, concept: 0, source: 0, report: 0 },
-          totalClaims: 0,
-          totalQuestions: 0,
-          totalContradictions: 0,
-          clusters: [],
-        },
-      },
-    };
+    const snapshot = emptyCompiledSnapshot();
     const publicationId = createMemoryWikiCompiledCachePublicationId();
     const reservationId = createMemoryWikiCompiledCachePublicationId();
     const parentPublicationId = (await loadMemoryWikiVaultIdentity(rootDir))

--- a/extensions/memory-wiki/index.test.ts
+++ b/extensions/memory-wiki/index.test.ts
@@ -298,59 +298,61 @@ describe("memory-wiki plugin", () => {
     await expect(loadMemoryWikiCompiledCache(config)).resolves.toBeNull();
   });
 
-  it("closes queued dashboard source sync before it can activate a vault", async () => {
-    const rootDir = await createTempDir("memory-wiki-index-stop-sync-");
-    const { api, registerGatewayMethod, registerService } = createPluginApi();
-    api.pluginConfig = { vault: { path: rootDir } };
-    plugin.register(api);
-    const config = resolveMemoryWikiConfig(api.pluginConfig);
-    const service = registerService.mock.calls[0]?.[0];
-    await service?.start?.();
+  it.each(["wiki.importInsights", "wiki.compile"])(
+    "closes queued %s source sync before it can activate a vault",
+    async (method) => {
+      const rootDir = await createTempDir("memory-wiki-index-stop-sync-");
+      const { api, registerGatewayMethod, registerService } = createPluginApi();
+      api.pluginConfig = { vault: { path: rootDir } };
+      plugin.register(api);
+      const config = resolveMemoryWikiConfig(api.pluginConfig);
+      const service = registerService.mock.calls[0]?.[0];
+      await service?.start?.();
 
-    const mutationEntered = deferred();
-    const releaseMutation = deferred();
-    const mutation = withMemoryWikiVaultMutation(rootDir, async () => {
-      mutationEntered.resolve();
-      await releaseMutation.promise;
-    });
-    await mutationEntered.promise;
-    const handler = registerGatewayMethod.mock.calls.find(
-      ([method]) => method === "wiki.importInsights",
-    )?.[1];
-    if (!handler) {
-      throw new Error("Expected wiki.importInsights gateway handler");
-    }
-    await handler({ params: {}, respond: vi.fn() });
-    await vi.waitFor(async () => {
-      const drainState = await Promise.race([
-        waitForMemoryWikiImportedSourceSyncs().then(() => "settled" as const),
-        new Promise<"pending">((resolve) => {
-          setImmediate(() => resolve("pending"));
-        }),
-      ]);
-      expect(drainState).toBe("pending");
-    });
+      const mutationEntered = deferred();
+      const releaseMutation = deferred();
+      const mutation = withMemoryWikiVaultMutation(rootDir, async () => {
+        mutationEntered.resolve();
+        await releaseMutation.promise;
+      });
+      await mutationEntered.promise;
+      const handler = registerGatewayMethod.mock.calls.find(([name]) => name === method)?.[1];
+      if (!handler) {
+        throw new Error(`Expected ${method} gateway handler`);
+      }
+      const request = handler({ params: {}, respond: vi.fn() });
+      await vi.waitFor(async () => {
+        const drainState = await Promise.race([
+          waitForMemoryWikiImportedSourceSyncs().then(() => "settled" as const),
+          new Promise<"pending">((resolve) => {
+            setImmediate(() => resolve("pending"));
+          }),
+        ]);
+        expect(drainState).toBe("pending");
+      });
 
-    const stop = service?.stop?.();
-    releaseMutation.resolve();
-    await mutation;
-    await stop;
+      const stop = service?.stop?.();
+      releaseMutation.resolve();
+      await mutation;
+      await request;
+      await stop;
 
-    const snapshot = emptyCompiledSnapshot();
-    await expect(
-      writeMemoryWikiCompiledCache(
-        config,
-        snapshot,
-        resolveMemoryWikiCompiledCacheGeneration(snapshot),
-        createMemoryWikiCompiledCachePublicationId(),
-        null,
-        async () => {},
-        async () => {},
-        () => loadMemoryWikiValidatedVaultIdentity(rootDir),
-      ),
-    ).rejects.toThrow("vault is not active");
-    await expect(loadMemoryWikiCompiledCache(config)).resolves.toBeNull();
-  });
+      const snapshot = emptyCompiledSnapshot();
+      await expect(
+        writeMemoryWikiCompiledCache(
+          config,
+          snapshot,
+          resolveMemoryWikiCompiledCacheGeneration(snapshot),
+          createMemoryWikiCompiledCachePublicationId(),
+          null,
+          async () => {},
+          async () => {},
+          () => loadMemoryWikiValidatedVaultIdentity(rootDir),
+        ),
+      ).rejects.toThrow("vault is not active");
+      await expect(loadMemoryWikiCompiledCache(config)).resolves.toBeNull();
+    },
+  );
 
   it("clears active owners before a fallible lifecycle identity refresh", async () => {
     const rootDir = await createTempDir("memory-wiki-index-refresh-failure-");

--- a/extensions/memory-wiki/index.test.ts
+++ b/extensions/memory-wiki/index.test.ts
@@ -231,6 +231,18 @@ describe("memory-wiki plugin", () => {
     const snapshot: MemoryWikiCompiledCacheSnapshot = {
       digest: { claimCount: 0, contradictionCount: 0, pages: [] },
       claims: [],
+      dashboards: {
+        importInsights: { sourceType: "chatgpt", totalItems: 0, totalClusters: 0, clusters: [] },
+        overview: {
+          totalItems: 0,
+          totalPages: 0,
+          pageCounts: { synthesis: 0, entity: 0, concept: 0, source: 0, report: 0 },
+          totalClaims: 0,
+          totalQuestions: 0,
+          totalContradictions: 0,
+          clusters: [],
+        },
+      },
     };
     const publicationId = createMemoryWikiCompiledCachePublicationId();
     const reservationId = createMemoryWikiCompiledCachePublicationId();

--- a/extensions/memory-wiki/index.test.ts
+++ b/extensions/memory-wiki/index.test.ts
@@ -48,7 +48,13 @@ function emptyCompiledSnapshot(): MemoryWikiCompiledCacheSnapshot {
     digest: { claimCount: 0, contradictionCount: 0, pages: [] },
     claims: [],
     dashboards: {
-      importInsights: { sourceType: "chatgpt", totalItems: 0, totalClusters: 0, clusters: [] },
+      importInsights: {
+        sourceType: "chatgpt",
+        totalItems: 0,
+        totalClusters: 0,
+        clusters: [],
+        truncated: false,
+      },
       overview: {
         totalItems: 0,
         totalPages: 0,
@@ -57,6 +63,7 @@ function emptyCompiledSnapshot(): MemoryWikiCompiledCacheSnapshot {
         totalQuestions: 0,
         totalContradictions: 0,
         clusters: [],
+        truncated: false,
       },
     },
   };

--- a/extensions/memory-wiki/index.ts
+++ b/extensions/memory-wiki/index.ts
@@ -110,34 +110,38 @@ export default definePluginEntry({
       },
     });
     configureMemoryWikiCompiledCacheStore(compiledCacheStore);
+    let sourceSyncAbortController: AbortController | undefined;
     api.registerService({
       id: "memory-wiki-compiled-cache-owner-cleanup",
       async start() {
-        const appConfig = getAppConfig();
-        const activeConfigs =
-          config.vault.scope === "global"
-            ? [resolveConfig(undefined, appConfig)]
-            : resolveMemoryWikiConfiguredAgentIds(appConfig).map((agentId) =>
-                resolveConfig(agentId, appConfig),
-              );
-        // Clear every previously trusted owner before fallible vault reads. A failed
-        // lifecycle refresh must leave prompt preparation closed, not stale-but-active.
-        deactivateMemoryWikiCompiledCacheOwnersExcept(new Set());
-        const preparedOwners: Array<{
-          config: ReturnType<MemoryWikiConfigResolver>;
-          identity: {
-            vaultGeneration: string;
-            compiledCachePublicationId: string | null;
-          };
-        }> = [];
-        for (const activeConfig of activeConfigs) {
-          const identity = await loadConfiguredVaultIdentity(activeConfig.vault.path);
-          if (identity) {
-            preparedOwners.push({ config: activeConfig, identity });
-          }
-        }
-        const activeOwnerIds = new Set<string>();
+        sourceSyncAbortController?.abort();
+        const abortController = new AbortController();
+        sourceSyncAbortController = abortController;
         try {
+          const appConfig = getAppConfig();
+          const activeConfigs =
+            config.vault.scope === "global"
+              ? [resolveConfig(undefined, appConfig)]
+              : resolveMemoryWikiConfiguredAgentIds(appConfig).map((agentId) =>
+                  resolveConfig(agentId, appConfig),
+                );
+          // Clear every previously trusted owner before fallible vault reads. A failed
+          // lifecycle refresh must leave prompt preparation closed, not stale-but-active.
+          deactivateMemoryWikiCompiledCacheOwnersExcept(new Set());
+          const preparedOwners: Array<{
+            config: ReturnType<MemoryWikiConfigResolver>;
+            identity: {
+              vaultGeneration: string;
+              compiledCachePublicationId: string | null;
+            };
+          }> = [];
+          for (const activeConfig of activeConfigs) {
+            const identity = await loadConfiguredVaultIdentity(activeConfig.vault.path);
+            if (identity) {
+              preparedOwners.push({ config: activeConfig, identity });
+            }
+          }
+          const activeOwnerIds = new Set<string>();
           for (const { config: activeConfig, identity } of preparedOwners) {
             activateMemoryWikiCompiledCacheOwner(
               activeConfig,
@@ -149,16 +153,23 @@ export default definePluginEntry({
             );
             activeOwnerIds.add(resolveMemoryWikiCompiledCacheOwnerId(activeConfig));
           }
+          deactivateMemoryWikiCompiledCacheOwnersExcept(activeOwnerIds);
+          await compiledCacheStore.deleteOwnersExcept(activeOwnerIds);
         } catch (error) {
+          abortController.abort();
+          if (sourceSyncAbortController === abortController) {
+            sourceSyncAbortController = undefined;
+          }
           deactivateMemoryWikiCompiledCacheOwnersExcept(new Set());
           throw error;
         }
-        deactivateMemoryWikiCompiledCacheOwnersExcept(activeOwnerIds);
-        await compiledCacheStore.deleteOwnersExcept(activeOwnerIds);
       },
       async stop() {
+        sourceSyncAbortController?.abort();
+        sourceSyncAbortController = undefined;
         deactivateMemoryWikiCompiledCacheOwnersExcept(new Set());
         await waitForMemoryWikiImportedSourceSyncs();
+        deactivateMemoryWikiCompiledCacheOwnersExcept(new Set());
       },
     });
 
@@ -171,6 +182,7 @@ export default definePluginEntry({
       appConfig: api.config,
       getAppConfig,
       resolveConfig,
+      resolveSourceSyncSignal: () => sourceSyncAbortController?.signal,
     });
     api.registerTool(
       (ctx) => {

--- a/extensions/memory-wiki/index.ts
+++ b/extensions/memory-wiki/index.ts
@@ -36,6 +36,7 @@ import {
   configureMemoryWikiSourceSyncStateStore,
   createMemoryWikiSourceSyncStateStore,
 } from "./src/source-sync-state.js";
+import { waitForMemoryWikiImportedSourceSyncs } from "./src/source-sync.js";
 import {
   createWikiApplyTool,
   createWikiGetTool,
@@ -154,6 +155,9 @@ export default definePluginEntry({
         }
         deactivateMemoryWikiCompiledCacheOwnersExcept(activeOwnerIds);
         await compiledCacheStore.deleteOwnersExcept(activeOwnerIds);
+      },
+      async stop() {
+        await waitForMemoryWikiImportedSourceSyncs();
       },
     });
 

--- a/extensions/memory-wiki/index.ts
+++ b/extensions/memory-wiki/index.ts
@@ -96,7 +96,11 @@ export default definePluginEntry({
         // Context-free tool discovery cannot safely choose one agent's vault.
         return null;
       }
-      return { appConfig, config: resolveConfig(agentId, appConfig) };
+      return {
+        appConfig,
+        config: resolveConfig(agentId, appConfig),
+        ...(sourceSyncAbortController ? { signal: sourceSyncAbortController.signal } : {}),
+      };
     };
     configureMemoryWikiSourceSyncStateStore(
       createMemoryWikiSourceSyncStateStore(api.runtime.state.openKeyedStore),
@@ -190,6 +194,7 @@ export default definePluginEntry({
         return resolved
           ? createWikiStatusTool(resolved.config, resolved.appConfig, {
               agentId: resolved.config.agentId ?? ctx.agentId,
+              ...(resolved.signal ? { signal: resolved.signal } : {}),
             })
           : null;
       },
@@ -198,14 +203,18 @@ export default definePluginEntry({
     api.registerTool(
       (ctx) => {
         const resolved = resolveToolContext(ctx.agentId);
-        return resolved ? createWikiLintTool(resolved.config, resolved.appConfig) : null;
+        return resolved
+          ? createWikiLintTool(resolved.config, resolved.appConfig, resolved.signal)
+          : null;
       },
       { name: "wiki_lint" },
     );
     api.registerTool(
       (ctx) => {
         const resolved = resolveToolContext(ctx.agentId);
-        return resolved ? createWikiApplyTool(resolved.config, resolved.appConfig) : null;
+        return resolved
+          ? createWikiApplyTool(resolved.config, resolved.appConfig, resolved.signal)
+          : null;
       },
       { name: "wiki_apply" },
     );
@@ -220,6 +229,7 @@ export default definePluginEntry({
           agentSessionKey: ctx.sessionKey,
           sandboxed: ctx.sandboxed,
           conversationRecall: ctx.conversationRecall,
+          ...(resolved.signal ? { signal: resolved.signal } : {}),
         });
       },
       { name: "wiki_search" },
@@ -235,6 +245,7 @@ export default definePluginEntry({
           agentSessionKey: ctx.sessionKey,
           sandboxed: ctx.sandboxed,
           conversationRecall: ctx.conversationRecall,
+          ...(resolved.signal ? { signal: resolved.signal } : {}),
         });
       },
       { name: "wiki_get" },

--- a/extensions/memory-wiki/index.ts
+++ b/extensions/memory-wiki/index.ts
@@ -157,6 +157,7 @@ export default definePluginEntry({
         await compiledCacheStore.deleteOwnersExcept(activeOwnerIds);
       },
       async stop() {
+        deactivateMemoryWikiCompiledCacheOwnersExcept(new Set());
         await waitForMemoryWikiImportedSourceSyncs();
       },
     });

--- a/extensions/memory-wiki/src/apply.ts
+++ b/extensions/memory-wiki/src/apply.ts
@@ -365,8 +365,13 @@ async function applyUpdateMetadataMutation(params: {
 async function applyMemoryWikiMutationUnlocked(params: {
   config: ResolvedMemoryWikiConfig;
   mutation: ApplyMemoryWikiMutation;
+  signal?: AbortSignal;
 }): Promise<ApplyMemoryWikiMutationResult> {
-  await initializeMemoryWikiVault(params.config);
+  await initializeMemoryWikiVault(
+    params.config,
+    params.signal ? { signal: params.signal } : undefined,
+  );
+  params.signal?.throwIfAborted();
   const result =
     params.mutation.op === "create_synthesis"
       ? await applyCreateSynthesisMutation({
@@ -377,7 +382,11 @@ async function applyMemoryWikiMutationUnlocked(params: {
           config: params.config,
           mutation: params.mutation,
         });
-  const compile = await compileMemoryWikiVault(params.config);
+  params.signal?.throwIfAborted();
+  const compile = await compileMemoryWikiVault(
+    params.config,
+    params.signal ? { signal: params.signal } : undefined,
+  );
   return {
     changed: result.changed,
     operation: params.mutation.op,
@@ -390,6 +399,7 @@ async function applyMemoryWikiMutationUnlocked(params: {
 export async function applyMemoryWikiMutation(params: {
   config: ResolvedMemoryWikiConfig;
   mutation: ApplyMemoryWikiMutation;
+  signal?: AbortSignal;
 }): Promise<ApplyMemoryWikiMutationResult> {
   return await withMemoryWikiVaultMutation(params.config.vault.path, () =>
     applyMemoryWikiMutationUnlocked(params),

--- a/extensions/memory-wiki/src/bridge.test.ts
+++ b/extensions/memory-wiki/src/bridge.test.ts
@@ -7,7 +7,7 @@ import {
   type MemoryPluginPublicArtifact,
   registerMemoryCapability,
 } from "openclaw/plugin-sdk/memory-host-core";
-import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../api.js";
 import { syncMemoryWikiBridgeSources } from "./bridge.js";
 import { createMemoryWikiTestHarness } from "./test-helpers.js";
@@ -30,6 +30,7 @@ describe("syncMemoryWikiBridgeSources", () => {
   });
 
   afterEach(() => {
+    vi.restoreAllMocks();
     clearMemoryPluginState();
   });
 
@@ -133,12 +134,18 @@ describe("syncMemoryWikiBridgeSources", () => {
     expect(memoryPage).toContain("sourceType: memory-bridge");
     expect(memoryPage).toContain("## Bridge Source");
 
+    const readFile = vi.spyOn(fs, "readFile");
     const second = await syncMemoryWikiBridgeSources({ config, appConfig });
 
     expect(second.importedCount).toBe(0);
     expect(second.updatedCount).toBe(0);
     expect(second.skippedCount).toBe(3);
     expect(second.removedCount).toBe(0);
+    expect(
+      readFile.mock.calls.some(
+        ([filePath]) => typeof filePath === "string" && filePath.startsWith(vaultDir),
+      ),
+    ).toBe(false);
 
     const logLines = (await fs.readFile(path.join(vaultDir, ".openclaw-wiki", "log.jsonl"), "utf8"))
       .trim()

--- a/extensions/memory-wiki/src/bridge.ts
+++ b/extensions/memory-wiki/src/bridge.ts
@@ -253,6 +253,7 @@ async function writeBridgeSourcePage(params: {
 export async function syncMemoryWikiBridgeSources(params: {
   config: ResolvedMemoryWikiConfig;
   appConfig?: OpenClawConfig;
+  signal?: AbortSignal;
 }): Promise<BridgeMemoryWikiResult> {
   resolveMemoryWikiVaultAgentId(params.config);
   if (
@@ -287,7 +288,15 @@ export async function syncMemoryWikiBridgeSources(params: {
   );
   const state = await readMemoryWikiSourceSyncState(params.config.vault.path);
   let initializePromise: ReturnType<typeof initializeMemoryWikiVault> | undefined;
-  const prepareWrite = () => (initializePromise ??= initializeMemoryWikiVault(params.config));
+  const prepareWrite = async () => {
+    params.signal?.throwIfAborted();
+    const result = await (initializePromise ??= initializeMemoryWikiVault(
+      params.config,
+      params.signal ? { signal: params.signal } : undefined,
+    ));
+    params.signal?.throwIfAborted();
+    return result;
+  };
   assertMemoryWikiSourceSyncStateCapacity({
     state,
     group: "bridge",

--- a/extensions/memory-wiki/src/bridge.ts
+++ b/extensions/memory-wiki/src/bridge.ts
@@ -180,6 +180,7 @@ async function writeBridgeSourcePage(params: {
   sourceUpdatedAtMs: number;
   sourceSize: number;
   state: Awaited<ReturnType<typeof readMemoryWikiSourceSyncState>>;
+  prepareWrite: () => Promise<unknown>;
 }): Promise<{ pagePath: string; changed: boolean; created: boolean }> {
   const { pageId, pagePath } = resolveBridgePagePath({
     workspaceDir: params.artifact.workspaceDir,
@@ -206,6 +207,7 @@ async function writeBridgeSourcePage(params: {
     pagePath,
     group: "bridge",
     state: params.state,
+    prepareWrite: params.prepareWrite,
     buildRendered: (raw, updatedAt) => {
       const contentLanguage =
         params.artifact.artifactType === "memory-events" ? "json" : "markdown";
@@ -253,7 +255,6 @@ export async function syncMemoryWikiBridgeSources(params: {
   appConfig?: OpenClawConfig;
 }): Promise<BridgeMemoryWikiResult> {
   resolveMemoryWikiVaultAgentId(params.config);
-  await initializeMemoryWikiVault(params.config);
   if (
     params.config.vaultMode !== "bridge" ||
     !params.config.bridge.enabled ||
@@ -285,6 +286,8 @@ export async function syncMemoryWikiBridgeSources(params: {
     publicArtifacts,
   );
   const state = await readMemoryWikiSourceSyncState(params.config.vault.path);
+  let initializePromise: ReturnType<typeof initializeMemoryWikiVault> | undefined;
+  const prepareWrite = () => (initializePromise ??= initializeMemoryWikiVault(params.config));
   assertMemoryWikiSourceSyncStateCapacity({
     state,
     group: "bridge",
@@ -306,6 +309,7 @@ export async function syncMemoryWikiBridgeSources(params: {
         sourceUpdatedAtMs: stats.mtimeMs,
         sourceSize: stats.size,
         state,
+        prepareWrite,
       }),
     );
   }
@@ -320,6 +324,7 @@ export async function syncMemoryWikiBridgeSources(params: {
         group: "bridge",
         activeKeys,
         state,
+        prepareWrite,
       })
     : 0;
   await writeMemoryWikiSourceSyncState(params.config.vault.path, state);

--- a/extensions/memory-wiki/src/compile.test.ts
+++ b/extensions/memory-wiki/src/compile.test.ts
@@ -4,7 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { compileMemoryWikiVault, refreshMemoryWikiIndexesAfterImport } from "./compile.js";
-import { loadMemoryWikiCompiledCache } from "./compiled-cache.js";
+import { loadMemoryWikiCompiledCache, readMemoryWikiDashboardState } from "./compiled-cache.js";
 import { renderWikiMarkdown, WIKI_RAW_SOURCE_MARKER } from "./markdown.js";
 import { writeMemoryWikiSourceSyncState } from "./source-sync-state.js";
 import { createMemoryWikiTestHarness } from "./test-helpers.js";
@@ -115,7 +115,7 @@ describe("compileMemoryWikiVault", () => {
     expect(claims.map((claim) => claim.text)).toContain("Alpha is the canonical source page.");
   });
 
-  it("refreshes only the compiled cache after changed imports when auto-compile is disabled", async () => {
+  it("keeps changed imports compile-required when auto-compile is disabled", async () => {
     const { rootDir, config } = await createVault({
       rootDir: nextCaseRoot(),
       config: {
@@ -135,28 +135,24 @@ describe("compileMemoryWikiVault", () => {
         body: `# Cache only\n\n## Auto Digest\n- First user line: ${value}\n`,
       });
     await fs.writeFile(sourcePath, renderSource("before"), "utf8");
+    await compileMemoryWikiVault(config);
+    const snapshotBefore = await loadMemoryWikiCompiledCache(config);
     const indexBefore = await fs.readFile(path.join(rootDir, "index.md"), "utf8");
 
-    const first = await refreshMemoryWikiIndexesAfterImport({
-      config,
-      syncResult: { importedCount: 1, updatedCount: 0, removedCount: 0 },
-    });
-    const firstSnapshot = await loadMemoryWikiCompiledCache(config);
-
     await fs.writeFile(sourcePath, renderSource("after"), "utf8");
-    const second = await refreshMemoryWikiIndexesAfterImport({
+    const refresh = await refreshMemoryWikiIndexesAfterImport({
       config,
       syncResult: { importedCount: 0, updatedCount: 1, removedCount: 0 },
     });
-    const secondSnapshot = await loadMemoryWikiCompiledCache(config);
+    const snapshotAfter = await loadMemoryWikiCompiledCache(config);
 
-    expect(first).toMatchObject({ refreshed: false, reason: "auto-compile-disabled" });
-    expect(first.compile?.updatedFiles).toEqual([]);
-    expect(JSON.stringify(firstSnapshot?.dashboards)).toContain("before");
-    expect(second).toMatchObject({ refreshed: false, reason: "auto-compile-disabled" });
-    expect(second.compile?.updatedFiles).toEqual([]);
-    expect(JSON.stringify(secondSnapshot?.dashboards)).toContain("after");
-    expect(JSON.stringify(secondSnapshot?.dashboards)).not.toContain("before");
+    expect(refresh).toMatchObject({ refreshed: false, reason: "auto-compile-disabled" });
+    expect(JSON.stringify(snapshotBefore?.dashboards)).toContain("before");
+    expect(snapshotAfter).toEqual(snapshotBefore);
+    expect(JSON.stringify(snapshotAfter?.dashboards)).not.toContain("after");
+    await expect(readMemoryWikiDashboardState(config)).resolves.toEqual({
+      state: "compile-required",
+    });
     await expect(fs.readFile(path.join(rootDir, "index.md"), "utf8")).resolves.toBe(indexBefore);
   });
 

--- a/extensions/memory-wiki/src/compile.test.ts
+++ b/extensions/memory-wiki/src/compile.test.ts
@@ -4,10 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { compileMemoryWikiVault, refreshMemoryWikiIndexesAfterImport } from "./compile.js";
-import {
-  invalidateMemoryWikiCompiledCache,
-  loadMemoryWikiCompiledCache,
-} from "./compiled-cache.js";
+import { loadMemoryWikiCompiledCache } from "./compiled-cache.js";
 import { renderWikiMarkdown, WIKI_RAW_SOURCE_MARKER } from "./markdown.js";
 import { writeMemoryWikiSourceSyncState } from "./source-sync-state.js";
 import { createMemoryWikiTestHarness } from "./test-helpers.js";
@@ -118,8 +115,8 @@ describe("compileMemoryWikiVault", () => {
     expect(claims.map((claim) => claim.text)).toContain("Alpha is the canonical source page.");
   });
 
-  it("rebuilds a missing compiled cache when import auto-compile is disabled", async () => {
-    const { config } = await createVault({
+  it("refreshes only the compiled cache after changed imports when auto-compile is disabled", async () => {
+    const { rootDir, config } = await createVault({
       rootDir: nextCaseRoot(),
       config: {
         ingest: { autoCompile: false },
@@ -127,17 +124,40 @@ describe("compileMemoryWikiVault", () => {
       },
       initialize: true,
     });
-    await compileMemoryWikiVault(config);
-    await invalidateMemoryWikiCompiledCache(config);
+    const sourcePath = path.join(rootDir, "sources", "cache-only.md");
+    const renderSource = (value: string) =>
+      renderWikiMarkdown({
+        frontmatter: {
+          pageType: "source",
+          sourceType: "chatgpt-export",
+          title: "Cache only",
+        },
+        body: `# Cache only\n\n## Auto Digest\n- First user line: ${value}\n`,
+      });
+    await fs.writeFile(sourcePath, renderSource("before"), "utf8");
+    const indexBefore = await fs.readFile(path.join(rootDir, "index.md"), "utf8");
 
-    const result = await refreshMemoryWikiIndexesAfterImport({
+    const first = await refreshMemoryWikiIndexesAfterImport({
       config,
-      syncResult: { importedCount: 0, updatedCount: 0, removedCount: 0 },
+      syncResult: { importedCount: 1, updatedCount: 0, removedCount: 0 },
     });
+    const firstSnapshot = await loadMemoryWikiCompiledCache(config);
 
-    expect(result.reason).toBe("missing-compiled-cache");
-    expect(result.refreshed).toBe(true);
-    await expect(loadMemoryWikiCompiledCache(config)).resolves.not.toBeNull();
+    await fs.writeFile(sourcePath, renderSource("after"), "utf8");
+    const second = await refreshMemoryWikiIndexesAfterImport({
+      config,
+      syncResult: { importedCount: 0, updatedCount: 1, removedCount: 0 },
+    });
+    const secondSnapshot = await loadMemoryWikiCompiledCache(config);
+
+    expect(first).toMatchObject({ refreshed: false, reason: "auto-compile-disabled" });
+    expect(first.compile?.updatedFiles).toEqual([]);
+    expect(JSON.stringify(firstSnapshot?.dashboards)).toContain("before");
+    expect(second).toMatchObject({ refreshed: false, reason: "auto-compile-disabled" });
+    expect(second.compile?.updatedFiles).toEqual([]);
+    expect(JSON.stringify(secondSnapshot?.dashboards)).toContain("after");
+    expect(JSON.stringify(secondSnapshot?.dashboards)).not.toContain("before");
+    await expect(fs.readFile(path.join(rootDir, "index.md"), "utf8")).resolves.toBe(indexBefore);
   });
 
   it("preserves source page bytes while rebuilding derived artifacts", async () => {

--- a/extensions/memory-wiki/src/compile.test.ts
+++ b/extensions/memory-wiki/src/compile.test.ts
@@ -415,7 +415,7 @@ describe("compileMemoryWikiVault", () => {
     ).resolves.toContain("[Alpha Synthesis](alpha-synthesis.md)");
   });
 
-  it("bounds concurrent page reads while compiling", async () => {
+  it("bounds concurrent page reads and stops the queue after abort", async () => {
     const { rootDir, config } = await createVault({
       rootDir: nextCaseRoot(),
       initialize: true,
@@ -437,6 +437,8 @@ describe("compileMemoryWikiVault", () => {
     }
 
     const originalReadFile = fs.readFile.bind(fs);
+    const abortController = new AbortController();
+    let pageReads = 0;
     let activePageReads = 0;
     let maxActivePageReads = 0;
     const readFileSpy = vi
@@ -451,7 +453,11 @@ describe("compileMemoryWikiVault", () => {
         }
 
         activePageReads += 1;
+        pageReads += 1;
         maxActivePageReads = Math.max(maxActivePageReads, activePageReads);
+        if (pageReads === 16) {
+          abortController.abort();
+        }
         try {
           await Promise.resolve();
           return await originalReadFile(...args);
@@ -461,12 +467,14 @@ describe("compileMemoryWikiVault", () => {
       });
 
     try {
-      await compileMemoryWikiVault(config);
+      await expect(
+        compileMemoryWikiVault(config, { signal: abortController.signal }),
+      ).rejects.toThrow();
     } finally {
       readFileSpy.mockRestore();
     }
 
-    expect(maxActivePageReads).toBeGreaterThan(0);
+    expect(pageReads).toBe(16);
     expect(maxActivePageReads).toBeLessThanOrEqual(16);
   });
 

--- a/extensions/memory-wiki/src/compile.test.ts
+++ b/extensions/memory-wiki/src/compile.test.ts
@@ -160,6 +160,35 @@ describe("compileMemoryWikiVault", () => {
     await expect(fs.readFile(path.join(rootDir, "index.md"), "utf8")).resolves.toBe(indexBefore);
   });
 
+  it("serves an unchanged compiled cache without reading the vault", async () => {
+    const { rootDir, config } = await createVault({
+      rootDir: nextCaseRoot(),
+      initialize: true,
+    });
+    await fs.writeFile(
+      path.join(rootDir, "sources", "stable.md"),
+      renderWikiMarkdown({
+        frontmatter: {
+          pageType: "source",
+          sourceType: "chatgpt-export",
+          title: "Stable",
+        },
+        body: "# Stable\n\n## Auto Digest\n- First user line: cached\n",
+      }),
+      "utf8",
+    );
+    await compileMemoryWikiVault(config);
+    const readFile = vi.spyOn(fs, "readFile");
+
+    const result = await refreshMemoryWikiIndexesAfterImport({
+      config,
+      syncResult: { importedCount: 0, updatedCount: 0, removedCount: 0 },
+    });
+
+    expect(result).toMatchObject({ refreshed: false, reason: "no-import-changes" });
+    expect(readFile).not.toHaveBeenCalled();
+  });
+
   it("preserves source page bytes while rebuilding derived artifacts", async () => {
     const { rootDir, config } = await createVault({
       rootDir: nextCaseRoot(),

--- a/extensions/memory-wiki/src/compile.test.ts
+++ b/extensions/memory-wiki/src/compile.test.ts
@@ -3,8 +3,11 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
-import { compileMemoryWikiVault } from "./compile.js";
-import { loadMemoryWikiCompiledCache } from "./compiled-cache.js";
+import { compileMemoryWikiVault, refreshMemoryWikiIndexesAfterImport } from "./compile.js";
+import {
+  invalidateMemoryWikiCompiledCache,
+  loadMemoryWikiCompiledCache,
+} from "./compiled-cache.js";
 import { renderWikiMarkdown, WIKI_RAW_SOURCE_MARKER } from "./markdown.js";
 import { writeMemoryWikiSourceSyncState } from "./source-sync-state.js";
 import { createMemoryWikiTestHarness } from "./test-helpers.js";
@@ -113,6 +116,28 @@ describe("compileMemoryWikiVault", () => {
       "Alpha is the canonical source page.",
     ]);
     expect(claims.map((claim) => claim.text)).toContain("Alpha is the canonical source page.");
+  });
+
+  it("rebuilds a missing compiled cache when import auto-compile is disabled", async () => {
+    const { config } = await createVault({
+      rootDir: nextCaseRoot(),
+      config: {
+        ingest: { autoCompile: false },
+        render: { createBacklinks: false, createDashboards: false },
+      },
+      initialize: true,
+    });
+    await compileMemoryWikiVault(config);
+    await invalidateMemoryWikiCompiledCache(config);
+
+    const result = await refreshMemoryWikiIndexesAfterImport({
+      config,
+      syncResult: { importedCount: 0, updatedCount: 0, removedCount: 0 },
+    });
+
+    expect(result.reason).toBe("missing-compiled-cache");
+    expect(result.refreshed).toBe(true);
+    await expect(loadMemoryWikiCompiledCache(config)).resolves.not.toBeNull();
   });
 
   it("preserves source page bytes while rebuilding derived artifacts", async () => {

--- a/extensions/memory-wiki/src/compile.ts
+++ b/extensions/memory-wiki/src/compile.ts
@@ -391,6 +391,7 @@ export type RefreshMemoryWikiIndexesResult = {
 
 type CompileMemoryWikiOptions = {
   sourcePageWrites?: "update" | "preserve";
+  signal?: AbortSignal;
 };
 
 function yieldToEventLoop(): Promise<void> {
@@ -1265,10 +1266,14 @@ async function compileMemoryWikiVaultUnlocked(
   options?: CompileMemoryWikiOptions,
 ): Promise<CompileMemoryWikiResult> {
   if (options?.sourcePageWrites === "preserve") {
-    await activateExistingMemoryWikiVault(config);
+    await activateExistingMemoryWikiVault(config, options.signal);
   } else {
-    await initializeMemoryWikiVault(config);
+    await initializeMemoryWikiVault(
+      config,
+      options?.signal ? { signal: options.signal } : undefined,
+    );
   }
+  options?.signal?.throwIfAborted();
   const rootDir = config.vault.path;
   const compiledInputIdentity = await loadMemoryWikiVaultIdentity(rootDir);
   if (!compiledInputIdentity.vaultGeneration) {
@@ -1355,6 +1360,7 @@ async function compileMemoryWikiVaultUnlocked(
 
   // Persist an immutable candidate, then commit its causal publication. A stale
   // compiler cannot overwrite the accepted row or activate before validation.
+  options?.signal?.throwIfAborted();
   await writeMemoryWikiCompiledCache(
     config,
     compiledSnapshot,
@@ -1362,6 +1368,7 @@ async function compileMemoryWikiVaultUnlocked(
     compiledCachePublicationId,
     compiledInputIdentity.compiledCachePublicationId,
     async () => {
+      options?.signal?.throwIfAborted();
       const currentIdentity = await loadMemoryWikiVaultIdentity(rootDir);
       if (
         currentIdentity.vaultGeneration !== compiledInputIdentity.vaultGeneration ||
@@ -1393,8 +1400,10 @@ async function compileMemoryWikiVaultUnlocked(
       ) {
         throw new Error("Memory Wiki vault changed while its compiled cache was being verified.");
       }
+      options?.signal?.throwIfAborted();
     },
     async () => {
+      options?.signal?.throwIfAborted();
       if (!compiledCacheSourceGeneration) {
         throw new Error("Memory Wiki compiled cache source generation is missing.");
       }
@@ -1408,6 +1417,7 @@ async function compileMemoryWikiVaultUnlocked(
           compiledCacheSourceGeneration,
         },
       });
+      options?.signal?.throwIfAborted();
     },
     () => loadMemoryWikiValidatedVaultIdentity(rootDir),
   );
@@ -1435,12 +1445,16 @@ export async function compileMemoryWikiVault(
   options?: CompileMemoryWikiOptions,
 ): Promise<CompileMemoryWikiResult> {
   try {
+    options?.signal?.throwIfAborted();
     return await withMemoryWikiVaultMutation(config.vault.path, () => {
+      options?.signal?.throwIfAborted();
       setMemoryWikiDashboardState(config, { state: "rebuilding" });
       return compileMemoryWikiVaultUnlocked(config, options);
     });
   } catch (error) {
-    setMemoryWikiDashboardState(config, { state: "failed" });
+    if (!options?.signal?.aborted) {
+      setMemoryWikiDashboardState(config, { state: "failed" });
+    }
     throw error;
   }
 }
@@ -1465,12 +1479,15 @@ async function hasMissingWikiIndexes(rootDir: string): Promise<boolean> {
 export async function refreshMemoryWikiIndexesAfterImport(params: {
   config: ResolvedMemoryWikiConfig;
   syncResult: { importedCount: number; updatedCount: number; removedCount: number };
+  signal?: AbortSignal;
 }): Promise<RefreshMemoryWikiIndexesResult> {
+  params.signal?.throwIfAborted();
   const importChanged =
     params.syncResult.importedCount > 0 ||
     params.syncResult.updatedCount > 0 ||
     params.syncResult.removedCount > 0;
   const dashboardState = await readMemoryWikiDashboardState(params.config);
+  params.signal?.throwIfAborted();
   const dashboardNeedsCompile = dashboardState.state !== "ready";
   if (!params.config.ingest.autoCompile) {
     if (importChanged || dashboardNeedsCompile) {
@@ -1480,11 +1497,15 @@ export async function refreshMemoryWikiIndexesAfterImport(params: {
   }
 
   const missingIndexes = await hasMissingWikiIndexes(params.config.vault.path);
+  params.signal?.throwIfAborted();
   if (!importChanged && !missingIndexes && !dashboardNeedsCompile) {
     return { refreshed: false, reason: "no-import-changes" };
   }
 
-  const compile = await compileMemoryWikiVault(params.config);
+  const compile = await compileMemoryWikiVault(
+    params.config,
+    params.signal ? { signal: params.signal } : undefined,
+  );
   return {
     refreshed: true,
     reason: importChanged

--- a/extensions/memory-wiki/src/compile.ts
+++ b/extensions/memory-wiki/src/compile.ts
@@ -30,8 +30,9 @@ import {
 } from "./claim-health.js";
 import {
   createMemoryWikiCompiledCachePublicationId,
-  loadMemoryWikiCompiledCache,
+  readMemoryWikiDashboardState,
   resolveMemoryWikiCompiledCacheGeneration,
+  setMemoryWikiDashboardState,
   writeMemoryWikiCompiledCache,
   type MemoryWikiCompiledCacheSnapshot,
   type MemoryWikiImportInsightItem,
@@ -390,8 +391,13 @@ export type RefreshMemoryWikiIndexesResult = {
 
 type CompileMemoryWikiOptions = {
   sourcePageWrites?: "update" | "preserve";
-  derivedPageWrites?: "update" | "preserve";
 };
+
+function yieldToEventLoop(): Promise<void> {
+  return new Promise((resolve) => {
+    setImmediate(resolve);
+  });
+}
 
 async function collectMarkdownFiles(rootDir: string, relativeDir: string): Promise<string[]> {
   const entries = await walkMemoryWikiDirectory(rootDir, relativeDir);
@@ -419,6 +425,9 @@ async function readPageSummaries(rootDir: string): Promise<{
         () => fs.readFile(absolutePath, "utf8"),
         `read wiki page ${absolutePath}`,
       );
+      // Large imported pages are parsed off the request path, but the compiler
+      // still yields between pages so background recovery cannot starve Gateway ticks.
+      await yieldToEventLoop();
       const scan = scanWikiPageSummary({ absolutePath, relativePath, raw });
       if (scan.status !== "valid") {
         return { scan, importInsight: null, overviewItem: null };
@@ -1149,13 +1158,9 @@ function sortClaims(page: WikiPageSummary): WikiClaim[] {
   });
 }
 
-type CompleteMemoryWikiCompiledCacheSnapshot = MemoryWikiCompiledCacheSnapshot & {
-  dashboards: NonNullable<MemoryWikiCompiledCacheSnapshot["dashboards"]>;
-};
-
 function buildCompiledCacheSnapshot(
   scan: Awaited<ReturnType<typeof readPageSummaries>>,
-): CompleteMemoryWikiCompiledCacheSnapshot {
+): MemoryWikiCompiledCacheSnapshot {
   const pagesInput = scan.pages;
   const pages = [...pagesInput]
     .toSorted((left, right) => left.relativePath.localeCompare(right.relativePath))
@@ -1300,15 +1305,12 @@ async function compileMemoryWikiVaultUnlocked(
     scan = await readPageSummaries(rootDir);
     pages = scan.pages;
   }
-  const dashboardUpdatedFiles =
-    options?.derivedPageWrites === "preserve"
-      ? []
-      : await refreshDashboardPages({
-          config,
-          managedImportedSourcePagePaths,
-          rootDir,
-          pages,
-        });
+  const dashboardUpdatedFiles = await refreshDashboardPages({
+    config,
+    managedImportedSourcePagePaths,
+    rootDir,
+    pages,
+  });
   updatedFiles.push(...dashboardUpdatedFiles);
   if (dashboardUpdatedFiles.length > 0) {
     scan = await readPageSummaries(rootDir);
@@ -1320,36 +1322,34 @@ async function compileMemoryWikiVaultUnlocked(
   const compiledCachePublicationId = createMemoryWikiCompiledCachePublicationId();
   let compiledCacheSourceGeneration: string | undefined;
 
-  if (options?.derivedPageWrites !== "preserve") {
-    const rootIndexPath = path.join(rootDir, "index.md");
+  const rootIndexPath = path.join(rootDir, "index.md");
+  if (
+    await writeManagedMarkdownFile({
+      rootDir,
+      relativePath: "index.md",
+      title: "Wiki Index",
+      startMarker: "<!-- openclaw:wiki:index:start -->",
+      endMarker: "<!-- openclaw:wiki:index:end -->",
+      body: buildRootIndexBody({ config, pages, counts }),
+    })
+  ) {
+    updatedFiles.push(rootIndexPath);
+  }
+
+  for (const group of COMPILE_PAGE_GROUPS) {
+    const relativePath = path.join(group.dir, "index.md").replace(/\\/g, "/");
+    const filePath = path.join(rootDir, relativePath);
     if (
       await writeManagedMarkdownFile({
         rootDir,
-        relativePath: "index.md",
-        title: "Wiki Index",
-        startMarker: "<!-- openclaw:wiki:index:start -->",
-        endMarker: "<!-- openclaw:wiki:index:end -->",
-        body: buildRootIndexBody({ config, pages, counts }),
+        relativePath,
+        title: group.heading,
+        startMarker: `<!-- openclaw:wiki:${group.dir}:index:start -->`,
+        endMarker: `<!-- openclaw:wiki:${group.dir}:index:end -->`,
+        body: buildDirectoryIndexBody({ config, pages, group }),
       })
     ) {
-      updatedFiles.push(rootIndexPath);
-    }
-
-    for (const group of COMPILE_PAGE_GROUPS) {
-      const relativePath = path.join(group.dir, "index.md").replace(/\\/g, "/");
-      const filePath = path.join(rootDir, relativePath);
-      if (
-        await writeManagedMarkdownFile({
-          rootDir,
-          relativePath,
-          title: group.heading,
-          startMarker: `<!-- openclaw:wiki:${group.dir}:index:start -->`,
-          endMarker: `<!-- openclaw:wiki:${group.dir}:index:end -->`,
-          body: buildDirectoryIndexBody({ config, pages, group }),
-        })
-      ) {
-        updatedFiles.push(filePath);
-      }
+      updatedFiles.push(filePath);
     }
   }
 
@@ -1434,9 +1434,15 @@ export async function compileMemoryWikiVault(
   config: ResolvedMemoryWikiConfig,
   options?: CompileMemoryWikiOptions,
 ): Promise<CompileMemoryWikiResult> {
-  return await withMemoryWikiVaultMutation(config.vault.path, () =>
-    compileMemoryWikiVaultUnlocked(config, options),
-  );
+  try {
+    return await withMemoryWikiVaultMutation(config.vault.path, () => {
+      setMemoryWikiDashboardState(config, { state: "rebuilding" });
+      return compileMemoryWikiVaultUnlocked(config, options);
+    });
+  } catch (error) {
+    setMemoryWikiDashboardState(config, { state: "failed" });
+    throw error;
+  }
 }
 
 async function hasMissingWikiIndexes(rootDir: string): Promise<boolean> {
@@ -1464,36 +1470,20 @@ export async function refreshMemoryWikiIndexesAfterImport(params: {
     params.syncResult.importedCount > 0 ||
     params.syncResult.updatedCount > 0 ||
     params.syncResult.removedCount > 0;
-  const compiledCache = await loadMemoryWikiCompiledCache(params.config);
-  const missingCompiledCache = !compiledCache?.dashboards;
+  const dashboardState = await readMemoryWikiDashboardState(params.config);
+  const dashboardNeedsCompile = dashboardState.state !== "ready";
   if (!params.config.ingest.autoCompile) {
-    if (!importChanged && !missingCompiledCache) {
-      return {
-        refreshed: false,
-        reason: "auto-compile-disabled",
-      };
+    if (importChanged || dashboardNeedsCompile) {
+      setMemoryWikiDashboardState(params.config, { state: "compile-required" });
     }
-    await initializeMemoryWikiVault(params.config);
-    // This mode disables generated index writes, not the dashboard snapshot
-    // that read RPCs need after source sync or a cache-format upgrade.
-    const compile = await compileMemoryWikiVault(params.config, {
-      sourcePageWrites: "preserve",
-      derivedPageWrites: "preserve",
-    });
-    return {
-      refreshed: false,
-      reason: "auto-compile-disabled",
-      compile,
-    };
+    return { refreshed: false, reason: "auto-compile-disabled" };
   }
+
   const missingIndexes = await hasMissingWikiIndexes(params.config.vault.path);
-  if (!importChanged && !missingIndexes && !missingCompiledCache) {
-    return {
-      refreshed: false,
-      reason: "no-import-changes",
-    };
+  if (!importChanged && !missingIndexes && !dashboardNeedsCompile) {
+    return { refreshed: false, reason: "no-import-changes" };
   }
-  await initializeMemoryWikiVault(params.config);
+
   const compile = await compileMemoryWikiVault(params.config);
   return {
     refreshed: true,

--- a/extensions/memory-wiki/src/compile.ts
+++ b/extensions/memory-wiki/src/compile.ts
@@ -1460,7 +1460,6 @@ export async function refreshMemoryWikiIndexesAfterImport(params: {
   config: ResolvedMemoryWikiConfig;
   syncResult: { importedCount: number; updatedCount: number; removedCount: number };
 }): Promise<RefreshMemoryWikiIndexesResult> {
-  await initializeMemoryWikiVault(params.config);
   const importChanged =
     params.syncResult.importedCount > 0 ||
     params.syncResult.updatedCount > 0 ||
@@ -1474,6 +1473,7 @@ export async function refreshMemoryWikiIndexesAfterImport(params: {
         reason: "auto-compile-disabled",
       };
     }
+    await initializeMemoryWikiVault(params.config);
     // This mode disables generated index writes, not the dashboard snapshot
     // that read RPCs need after source sync or a cache-format upgrade.
     const compile = await compileMemoryWikiVault(params.config, {
@@ -1493,6 +1493,7 @@ export async function refreshMemoryWikiIndexesAfterImport(params: {
       reason: "no-import-changes",
     };
   }
+  await initializeMemoryWikiVault(params.config);
   const compile = await compileMemoryWikiVault(params.config);
   return {
     refreshed: true,

--- a/extensions/memory-wiki/src/compile.ts
+++ b/extensions/memory-wiki/src/compile.ts
@@ -388,6 +388,11 @@ export type RefreshMemoryWikiIndexesResult = {
   compile?: CompileMemoryWikiResult;
 };
 
+type CompileMemoryWikiOptions = {
+  sourcePageWrites?: "update" | "preserve";
+  derivedPageWrites?: "update" | "preserve";
+};
+
 async function collectMarkdownFiles(rootDir: string, relativeDir: string): Promise<string[]> {
   const entries = await walkMemoryWikiDirectory(rootDir, relativeDir);
   return entries
@@ -1144,9 +1149,13 @@ function sortClaims(page: WikiPageSummary): WikiClaim[] {
   });
 }
 
+type CompleteMemoryWikiCompiledCacheSnapshot = MemoryWikiCompiledCacheSnapshot & {
+  dashboards: NonNullable<MemoryWikiCompiledCacheSnapshot["dashboards"]>;
+};
+
 function buildCompiledCacheSnapshot(
   scan: Awaited<ReturnType<typeof readPageSummaries>>,
-): MemoryWikiCompiledCacheSnapshot {
+): CompleteMemoryWikiCompiledCacheSnapshot {
   const pagesInput = scan.pages;
   const pages = [...pagesInput]
     .toSorted((left, right) => left.relativePath.localeCompare(right.relativePath))
@@ -1248,7 +1257,7 @@ function buildCompiledCacheSnapshot(
 
 async function compileMemoryWikiVaultUnlocked(
   config: ResolvedMemoryWikiConfig,
-  options?: { sourcePageWrites?: "update" | "preserve" },
+  options?: CompileMemoryWikiOptions,
 ): Promise<CompileMemoryWikiResult> {
   if (options?.sourcePageWrites === "preserve") {
     await activateExistingMemoryWikiVault(config);
@@ -1291,12 +1300,15 @@ async function compileMemoryWikiVaultUnlocked(
     scan = await readPageSummaries(rootDir);
     pages = scan.pages;
   }
-  const dashboardUpdatedFiles = await refreshDashboardPages({
-    config,
-    managedImportedSourcePagePaths,
-    rootDir,
-    pages,
-  });
+  const dashboardUpdatedFiles =
+    options?.derivedPageWrites === "preserve"
+      ? []
+      : await refreshDashboardPages({
+          config,
+          managedImportedSourcePagePaths,
+          rootDir,
+          pages,
+        });
   updatedFiles.push(...dashboardUpdatedFiles);
   if (dashboardUpdatedFiles.length > 0) {
     scan = await readPageSummaries(rootDir);
@@ -1308,34 +1320,36 @@ async function compileMemoryWikiVaultUnlocked(
   const compiledCachePublicationId = createMemoryWikiCompiledCachePublicationId();
   let compiledCacheSourceGeneration: string | undefined;
 
-  const rootIndexPath = path.join(rootDir, "index.md");
-  if (
-    await writeManagedMarkdownFile({
-      rootDir,
-      relativePath: "index.md",
-      title: "Wiki Index",
-      startMarker: "<!-- openclaw:wiki:index:start -->",
-      endMarker: "<!-- openclaw:wiki:index:end -->",
-      body: buildRootIndexBody({ config, pages, counts }),
-    })
-  ) {
-    updatedFiles.push(rootIndexPath);
-  }
-
-  for (const group of COMPILE_PAGE_GROUPS) {
-    const relativePath = path.join(group.dir, "index.md").replace(/\\/g, "/");
-    const filePath = path.join(rootDir, relativePath);
+  if (options?.derivedPageWrites !== "preserve") {
+    const rootIndexPath = path.join(rootDir, "index.md");
     if (
       await writeManagedMarkdownFile({
         rootDir,
-        relativePath,
-        title: group.heading,
-        startMarker: `<!-- openclaw:wiki:${group.dir}:index:start -->`,
-        endMarker: `<!-- openclaw:wiki:${group.dir}:index:end -->`,
-        body: buildDirectoryIndexBody({ config, pages, group }),
+        relativePath: "index.md",
+        title: "Wiki Index",
+        startMarker: "<!-- openclaw:wiki:index:start -->",
+        endMarker: "<!-- openclaw:wiki:index:end -->",
+        body: buildRootIndexBody({ config, pages, counts }),
       })
     ) {
-      updatedFiles.push(filePath);
+      updatedFiles.push(rootIndexPath);
+    }
+
+    for (const group of COMPILE_PAGE_GROUPS) {
+      const relativePath = path.join(group.dir, "index.md").replace(/\\/g, "/");
+      const filePath = path.join(rootDir, relativePath);
+      if (
+        await writeManagedMarkdownFile({
+          rootDir,
+          relativePath,
+          title: group.heading,
+          startMarker: `<!-- openclaw:wiki:${group.dir}:index:start -->`,
+          endMarker: `<!-- openclaw:wiki:${group.dir}:index:end -->`,
+          body: buildDirectoryIndexBody({ config, pages, group }),
+        })
+      ) {
+        updatedFiles.push(filePath);
+      }
     }
   }
 
@@ -1418,7 +1432,7 @@ async function compileMemoryWikiVaultUnlocked(
 
 export async function compileMemoryWikiVault(
   config: ResolvedMemoryWikiConfig,
-  options?: { sourcePageWrites?: "update" | "preserve" },
+  options?: CompileMemoryWikiOptions,
 ): Promise<CompileMemoryWikiResult> {
   return await withMemoryWikiVaultMutation(config.vault.path, () =>
     compileMemoryWikiVaultUnlocked(config, options),
@@ -1447,17 +1461,31 @@ export async function refreshMemoryWikiIndexesAfterImport(params: {
   syncResult: { importedCount: number; updatedCount: number; removedCount: number };
 }): Promise<RefreshMemoryWikiIndexesResult> {
   await initializeMemoryWikiVault(params.config);
-  const missingCompiledCache = (await loadMemoryWikiCompiledCache(params.config)) === null;
-  if (!params.config.ingest.autoCompile && !missingCompiledCache) {
-    return {
-      refreshed: false,
-      reason: "auto-compile-disabled",
-    };
-  }
   const importChanged =
     params.syncResult.importedCount > 0 ||
     params.syncResult.updatedCount > 0 ||
     params.syncResult.removedCount > 0;
+  const compiledCache = await loadMemoryWikiCompiledCache(params.config);
+  const missingCompiledCache = !compiledCache?.dashboards;
+  if (!params.config.ingest.autoCompile) {
+    if (!importChanged && !missingCompiledCache) {
+      return {
+        refreshed: false,
+        reason: "auto-compile-disabled",
+      };
+    }
+    // This mode disables generated index writes, not the dashboard snapshot
+    // that read RPCs need after source sync or a cache-format upgrade.
+    const compile = await compileMemoryWikiVault(params.config, {
+      sourcePageWrites: "preserve",
+      derivedPageWrites: "preserve",
+    });
+    return {
+      refreshed: false,
+      reason: "auto-compile-disabled",
+      compile,
+    };
+  }
   const missingIndexes = await hasMissingWikiIndexes(params.config.vault.path);
   if (!importChanged && !missingIndexes && !missingCompiledCache) {
     return {

--- a/extensions/memory-wiki/src/compile.ts
+++ b/extensions/memory-wiki/src/compile.ts
@@ -34,12 +34,13 @@ import {
   resolveMemoryWikiCompiledCacheGeneration,
   writeMemoryWikiCompiledCache,
   type MemoryWikiCompiledCacheSnapshot,
+  type MemoryWikiImportInsightItem,
+  type MemoryWikiOverviewItem,
 } from "./compiled-cache.js";
 import type { ResolvedMemoryWikiConfig } from "./config.js";
 import {
   buildMemoryWikiImportInsights,
   projectMemoryWikiImportInsight,
-  type MemoryWikiImportInsightItem,
 } from "./import-insights.js";
 import {
   appendMemoryWikiLog,
@@ -65,11 +66,7 @@ import {
 import { withMemoryWikiVaultMutation } from "./mutation-coordinator.js";
 import { readMemoryWikiSourceSyncState } from "./source-sync-state.js";
 import { activateExistingMemoryWikiVault, initializeMemoryWikiVault } from "./vault.js";
-import {
-  buildMemoryWikiOverview,
-  projectMemoryWikiOverviewItem,
-  type MemoryWikiOverviewItem,
-} from "./wiki-overview.js";
+import { buildMemoryWikiOverview, projectMemoryWikiOverviewItem } from "./wiki-overview.js";
 
 const COMPILE_PAGE_GROUPS: Array<{ kind: WikiPageKind; dir: string; heading: string }> = [
   { kind: "source", dir: "sources", heading: "Sources" },
@@ -1450,7 +1447,8 @@ export async function refreshMemoryWikiIndexesAfterImport(params: {
   syncResult: { importedCount: number; updatedCount: number; removedCount: number };
 }): Promise<RefreshMemoryWikiIndexesResult> {
   await initializeMemoryWikiVault(params.config);
-  if (!params.config.ingest.autoCompile) {
+  const missingCompiledCache = (await loadMemoryWikiCompiledCache(params.config)) === null;
+  if (!params.config.ingest.autoCompile && !missingCompiledCache) {
     return {
       refreshed: false,
       reason: "auto-compile-disabled",
@@ -1461,7 +1459,6 @@ export async function refreshMemoryWikiIndexesAfterImport(params: {
     params.syncResult.updatedCount > 0 ||
     params.syncResult.removedCount > 0;
   const missingIndexes = await hasMissingWikiIndexes(params.config.vault.path);
-  const missingCompiledCache = (await loadMemoryWikiCompiledCache(params.config)) === null;
   if (!importChanged && !missingIndexes && !missingCompiledCache) {
     return {
       refreshed: false,

--- a/extensions/memory-wiki/src/compile.ts
+++ b/extensions/memory-wiki/src/compile.ts
@@ -409,7 +409,10 @@ async function collectMarkdownFiles(rootDir: string, relativeDir: string): Promi
     .toSorted((left, right) => left.localeCompare(right));
 }
 
-async function readPageSummaries(rootDir: string): Promise<{
+async function readPageSummaries(
+  rootDir: string,
+  signal?: AbortSignal,
+): Promise<{
   pages: WikiPageSummary[];
   frontmatterErrors: WikiPageFrontmatterError[];
   importInsights: MemoryWikiImportInsightItem[];
@@ -418,17 +421,21 @@ async function readPageSummaries(rootDir: string): Promise<{
   const filePaths = (
     await Promise.all(COMPILE_PAGE_GROUPS.map((group) => collectMarkdownFiles(rootDir, group.dir)))
   ).flat();
+  signal?.throwIfAborted();
 
   const readResult = await runTasksWithConcurrency({
     tasks: filePaths.map((relativePath) => async () => {
+      signal?.throwIfAborted();
       const absolutePath = path.join(rootDir, relativePath);
       const raw = await retryTransientMemoryRead(
         () => fs.readFile(absolutePath, "utf8"),
         `read wiki page ${absolutePath}`,
       );
+      signal?.throwIfAborted();
       // Large imported pages are parsed off the request path, but the compiler
       // still yields between pages so background recovery cannot starve Gateway ticks.
       await yieldToEventLoop();
+      signal?.throwIfAborted();
       const scan = scanWikiPageSummary({ absolutePath, relativePath, raw });
       if (scan.status !== "valid") {
         return { scan, importInsight: null, overviewItem: null };
@@ -446,6 +453,7 @@ async function readPageSummaries(rootDir: string): Promise<{
   if (readResult.hasError) {
     throw readResult.firstError;
   }
+  signal?.throwIfAborted();
 
   return {
     pages: readResult.results
@@ -892,6 +900,7 @@ function buildRelatedBlockBody(params: {
 async function refreshPageRelatedBlocks(params: {
   config: ResolvedMemoryWikiConfig;
   pages: WikiPageSummary[];
+  signal?: AbortSignal;
 }): Promise<string[]> {
   if (!params.config.render.createBacklinks) {
     return [];
@@ -899,10 +908,12 @@ async function refreshPageRelatedBlocks(params: {
   const root = await fsRoot(params.config.vault.path);
   const updatedFiles: string[] = [];
   for (const page of params.pages) {
+    params.signal?.throwIfAborted();
     if (page.kind === "report") {
       continue;
     }
     const original = await root.readText(page.relativePath);
+    params.signal?.throwIfAborted();
     if (original.trim().length === 0) {
       continue;
     }
@@ -923,6 +934,7 @@ async function refreshPageRelatedBlocks(params: {
       continue;
     }
     await root.write(page.relativePath, updated);
+    params.signal?.throwIfAborted();
     updatedFiles.push(page.absolutePath);
   }
   return updatedFiles;
@@ -957,9 +969,12 @@ async function writeManagedMarkdownFile(params: {
   startMarker: string;
   endMarker: string;
   body: string;
+  signal?: AbortSignal;
 }): Promise<boolean> {
+  params.signal?.throwIfAborted();
   const root = await fsRoot(params.rootDir);
   const original = await root.readText(params.relativePath).catch(() => `# ${params.title}\n`);
+  params.signal?.throwIfAborted();
   // Generated indexes bypass page discovery. Parse existing content here so
   // managed-block updates cannot rewrite malformed frontmatter.
   parseWikiMarkdown(original);
@@ -975,6 +990,7 @@ async function writeManagedMarkdownFile(params: {
     return false;
   }
   await root.write(params.relativePath, rendered);
+  params.signal?.throwIfAborted();
   return true;
 }
 
@@ -1062,6 +1078,7 @@ async function refreshDashboardPages(params: {
   managedImportedSourcePagePaths: Set<string>;
   rootDir: string;
   pages: WikiPageSummary[];
+  signal?: AbortSignal;
 }): Promise<string[]> {
   if (!params.config.render.createDashboards) {
     return [];
@@ -1069,6 +1086,7 @@ async function refreshDashboardPages(params: {
   const now = new Date();
   const updatedFiles: string[] = [];
   for (const definition of DASHBOARD_PAGES) {
+    params.signal?.throwIfAborted();
     if (
       await writeDashboardPage({
         config: params.config,
@@ -1081,6 +1099,7 @@ async function refreshDashboardPages(params: {
     ) {
       updatedFiles.push(path.join(params.rootDir, definition.relativePath));
     }
+    params.signal?.throwIfAborted();
   }
   return updatedFiles;
 }
@@ -1300,14 +1319,18 @@ async function compileMemoryWikiVaultUnlocked(
   const managedImportedSourcePagePaths = new Set(
     Object.values(sourceSyncState.entries).map((entry) => entry.pagePath.split(path.sep).join("/")),
   );
-  let scan = await readPageSummaries(rootDir);
+  let scan = await readPageSummaries(rootDir, options?.signal);
   let pages = scan.pages;
   const updatedFiles =
     options?.sourcePageWrites === "preserve"
       ? []
-      : await refreshPageRelatedBlocks({ config, pages });
+      : await refreshPageRelatedBlocks({
+          config,
+          pages,
+          ...(options?.signal ? { signal: options.signal } : {}),
+        });
   if (updatedFiles.length > 0) {
-    scan = await readPageSummaries(rootDir);
+    scan = await readPageSummaries(rootDir, options?.signal);
     pages = scan.pages;
   }
   const dashboardUpdatedFiles = await refreshDashboardPages({
@@ -1315,10 +1338,11 @@ async function compileMemoryWikiVaultUnlocked(
     managedImportedSourcePagePaths,
     rootDir,
     pages,
+    ...(options?.signal ? { signal: options.signal } : {}),
   });
   updatedFiles.push(...dashboardUpdatedFiles);
   if (dashboardUpdatedFiles.length > 0) {
-    scan = await readPageSummaries(rootDir);
+    scan = await readPageSummaries(rootDir, options?.signal);
     pages = scan.pages;
   }
   const compiledSnapshot = buildCompiledCacheSnapshot(scan);
@@ -1336,6 +1360,7 @@ async function compileMemoryWikiVaultUnlocked(
       startMarker: "<!-- openclaw:wiki:index:start -->",
       endMarker: "<!-- openclaw:wiki:index:end -->",
       body: buildRootIndexBody({ config, pages, counts }),
+      ...(options?.signal ? { signal: options.signal } : {}),
     })
   ) {
     updatedFiles.push(rootIndexPath);
@@ -1352,6 +1377,7 @@ async function compileMemoryWikiVaultUnlocked(
         startMarker: `<!-- openclaw:wiki:${group.dir}:index:start -->`,
         endMarker: `<!-- openclaw:wiki:${group.dir}:index:end -->`,
         body: buildDirectoryIndexBody({ config, pages, group }),
+        ...(options?.signal ? { signal: options.signal } : {}),
       })
     ) {
       updatedFiles.push(filePath);
@@ -1379,7 +1405,7 @@ async function compileMemoryWikiVaultUnlocked(
         throw new Error("Memory Wiki vault changed while its compiled cache was being built.");
       }
       const sourceGenerationBeforeScan = await resolveMemoryWikiVaultSourceGeneration(rootDir);
-      const verifiedScan = await readPageSummaries(rootDir);
+      const verifiedScan = await readPageSummaries(rootDir, options?.signal);
       const verifiedGeneration = resolveMemoryWikiCompiledCacheGeneration(
         buildCompiledCacheSnapshot(verifiedScan),
       );

--- a/extensions/memory-wiki/src/compile.ts
+++ b/extensions/memory-wiki/src/compile.ts
@@ -30,11 +30,17 @@ import {
 } from "./claim-health.js";
 import {
   createMemoryWikiCompiledCachePublicationId,
+  loadMemoryWikiCompiledCache,
   resolveMemoryWikiCompiledCacheGeneration,
   writeMemoryWikiCompiledCache,
   type MemoryWikiCompiledCacheSnapshot,
 } from "./compiled-cache.js";
 import type { ResolvedMemoryWikiConfig } from "./config.js";
+import {
+  buildMemoryWikiImportInsights,
+  projectMemoryWikiImportInsight,
+  type MemoryWikiImportInsightItem,
+} from "./import-insights.js";
 import {
   appendMemoryWikiLog,
   loadMemoryWikiValidatedVaultIdentity,
@@ -59,6 +65,11 @@ import {
 import { withMemoryWikiVaultMutation } from "./mutation-coordinator.js";
 import { readMemoryWikiSourceSyncState } from "./source-sync-state.js";
 import { activateExistingMemoryWikiVault, initializeMemoryWikiVault } from "./vault.js";
+import {
+  buildMemoryWikiOverview,
+  projectMemoryWikiOverviewItem,
+  type MemoryWikiOverviewItem,
+} from "./wiki-overview.js";
 
 const COMPILE_PAGE_GROUPS: Array<{ kind: WikiPageKind; dir: string; heading: string }> = [
   { kind: "source", dir: "sources", heading: "Sources" },
@@ -371,7 +382,12 @@ export type CompileMemoryWikiResult = {
 
 export type RefreshMemoryWikiIndexesResult = {
   refreshed: boolean;
-  reason: "auto-compile-disabled" | "no-import-changes" | "missing-indexes" | "import-changed";
+  reason:
+    | "auto-compile-disabled"
+    | "no-import-changes"
+    | "missing-indexes"
+    | "missing-compiled-cache"
+    | "import-changed";
   compile?: CompileMemoryWikiResult;
 };
 
@@ -387,6 +403,8 @@ async function collectMarkdownFiles(rootDir: string, relativeDir: string): Promi
 async function readPageSummaries(rootDir: string): Promise<{
   pages: WikiPageSummary[];
   frontmatterErrors: WikiPageFrontmatterError[];
+  importInsights: MemoryWikiImportInsightItem[];
+  overviewItems: MemoryWikiOverviewItem[];
 }> {
   const filePaths = (
     await Promise.all(COMPILE_PAGE_GROUPS.map((group) => collectMarkdownFiles(rootDir, group.dir)))
@@ -399,7 +417,16 @@ async function readPageSummaries(rootDir: string): Promise<{
         () => fs.readFile(absolutePath, "utf8"),
         `read wiki page ${absolutePath}`,
       );
-      return scanWikiPageSummary({ absolutePath, relativePath, raw });
+      const scan = scanWikiPageSummary({ absolutePath, relativePath, raw });
+      if (scan.status !== "valid") {
+        return { scan, importInsight: null, overviewItem: null };
+      }
+      const parsed = parseWikiMarkdown(raw);
+      return {
+        scan,
+        importInsight: projectMemoryWikiImportInsight(scan.page, parsed),
+        overviewItem: projectMemoryWikiOverviewItem(scan.page, parsed.body),
+      };
     }),
     limit: READ_PAGE_SUMMARIES_CONCURRENCY,
     errorMode: "stop",
@@ -410,21 +437,17 @@ async function readPageSummaries(rootDir: string): Promise<{
 
   return {
     pages: readResult.results
-      .flatMap((result) => (result.status === "valid" ? [result.page] : []))
+      .flatMap(({ scan }) => (scan.status === "valid" ? [scan.page] : []))
       .toSorted((left, right) => left.title.localeCompare(right.title)),
-    frontmatterErrors: readResult.results.flatMap((result) =>
-      result.status === "invalid-frontmatter" ? [result.error] : [],
+    frontmatterErrors: readResult.results.flatMap(({ scan }) =>
+      scan.status === "invalid-frontmatter" ? [scan.error] : [],
     ),
-  };
-}
-
-function buildPageCounts(pages: WikiPageSummary[]): Record<WikiPageKind, number> {
-  return {
-    entity: pages.filter((page) => page.kind === "entity").length,
-    concept: pages.filter((page) => page.kind === "concept").length,
-    source: pages.filter((page) => page.kind === "source").length,
-    synthesis: pages.filter((page) => page.kind === "synthesis").length,
-    report: pages.filter((page) => page.kind === "report").length,
+    importInsights: readResult.results.flatMap(({ importInsight }) =>
+      importInsight ? [importInsight] : [],
+    ),
+    overviewItems: readResult.results.flatMap(({ overviewItem }) =>
+      overviewItem ? [overviewItem] : [],
+    ),
   };
 }
 
@@ -1125,8 +1148,9 @@ function sortClaims(page: WikiPageSummary): WikiClaim[] {
 }
 
 function buildCompiledCacheSnapshot(
-  pagesInput: WikiPageSummary[],
+  scan: Awaited<ReturnType<typeof readPageSummaries>>,
 ): MemoryWikiCompiledCacheSnapshot {
+  const pagesInput = scan.pages;
   const pages = [...pagesInput]
     .toSorted((left, right) => left.relativePath.localeCompare(right.relativePath))
     .map((page) => {
@@ -1218,6 +1242,10 @@ function buildCompiledCacheSnapshot(
       pages,
     },
     claims,
+    dashboards: {
+      importInsights: buildMemoryWikiImportInsights(scan.importInsights),
+      overview: buildMemoryWikiOverview(scan.pages, scan.overviewItems),
+    },
   };
 }
 
@@ -1277,8 +1305,8 @@ async function compileMemoryWikiVaultUnlocked(
     scan = await readPageSummaries(rootDir);
     pages = scan.pages;
   }
-  const counts = buildPageCounts(pages);
-  const compiledSnapshot = buildCompiledCacheSnapshot(pages);
+  const compiledSnapshot = buildCompiledCacheSnapshot(scan);
+  const counts = compiledSnapshot.dashboards.overview.pageCounts;
   const compiledCacheGeneration = resolveMemoryWikiCompiledCacheGeneration(compiledSnapshot);
   const compiledCachePublicationId = createMemoryWikiCompiledCachePublicationId();
   let compiledCacheSourceGeneration: string | undefined;
@@ -1335,7 +1363,7 @@ async function compileMemoryWikiVaultUnlocked(
       const sourceGenerationBeforeScan = await resolveMemoryWikiVaultSourceGeneration(rootDir);
       const verifiedScan = await readPageSummaries(rootDir);
       const verifiedGeneration = resolveMemoryWikiCompiledCacheGeneration(
-        buildCompiledCacheSnapshot(verifiedScan.pages),
+        buildCompiledCacheSnapshot(verifiedScan),
       );
       const sourceGenerationAfterScan = await resolveMemoryWikiVaultSourceGeneration(rootDir);
       if (
@@ -1433,7 +1461,8 @@ export async function refreshMemoryWikiIndexesAfterImport(params: {
     params.syncResult.updatedCount > 0 ||
     params.syncResult.removedCount > 0;
   const missingIndexes = await hasMissingWikiIndexes(params.config.vault.path);
-  if (!importChanged && !missingIndexes) {
+  const missingCompiledCache = (await loadMemoryWikiCompiledCache(params.config)) === null;
+  if (!importChanged && !missingIndexes && !missingCompiledCache) {
     return {
       refreshed: false,
       reason: "no-import-changes",
@@ -1442,7 +1471,11 @@ export async function refreshMemoryWikiIndexesAfterImport(params: {
   const compile = await compileMemoryWikiVault(params.config);
   return {
     refreshed: true,
-    reason: missingIndexes && !importChanged ? "missing-indexes" : "import-changed",
+    reason: importChanged
+      ? "import-changed"
+      : missingIndexes
+        ? "missing-indexes"
+        : "missing-compiled-cache",
     compile,
   };
 }

--- a/extensions/memory-wiki/src/compiled-cache.integration.test.ts
+++ b/extensions/memory-wiki/src/compiled-cache.integration.test.ts
@@ -103,6 +103,18 @@ function snapshot(text: string): MemoryWikiCompiledCacheSnapshot {
         text,
       },
     ],
+    dashboards: {
+      importInsights: { sourceType: "chatgpt", totalItems: 0, totalClusters: 0, clusters: [] },
+      overview: {
+        totalItems: 0,
+        totalPages: 0,
+        pageCounts: { synthesis: 0, entity: 0, concept: 0, source: 0, report: 0 },
+        totalClaims: 0,
+        totalQuestions: 0,
+        totalContradictions: 0,
+        clusters: [],
+      },
+    },
   };
 }
 

--- a/extensions/memory-wiki/src/compiled-cache.integration.test.ts
+++ b/extensions/memory-wiki/src/compiled-cache.integration.test.ts
@@ -110,7 +110,13 @@ function snapshot(text: string): MemoryWikiCompiledCacheSnapshot {
       },
     ],
     dashboards: {
-      importInsights: { sourceType: "chatgpt", totalItems: 0, totalClusters: 0, clusters: [] },
+      importInsights: {
+        sourceType: "chatgpt",
+        totalItems: 0,
+        totalClusters: 0,
+        clusters: [],
+        truncated: false,
+      },
       overview: {
         totalItems: 0,
         totalPages: 0,
@@ -119,6 +125,7 @@ function snapshot(text: string): MemoryWikiCompiledCacheSnapshot {
         totalQuestions: 0,
         totalContradictions: 0,
         clusters: [],
+        truncated: false,
       },
     },
   };

--- a/extensions/memory-wiki/src/compiled-cache.integration.test.ts
+++ b/extensions/memory-wiki/src/compiled-cache.integration.test.ts
@@ -226,6 +226,16 @@ describe("Memory Wiki compiled cache lifecycle", () => {
     );
   });
 
+  it("replaces a loaded snapshot when a newer publication commits", async () => {
+    const { config } = await createPersistentVault({ initialize: true });
+    await publishSnapshot(config, snapshot("before"));
+    expect((await loadMemoryWikiCompiledCache(config))?.claims[0]?.text).toBe("before");
+
+    await publishSnapshot(config, snapshot("after"));
+
+    expect((await loadMemoryWikiCompiledCache(config))?.claims[0]?.text).toBe("after");
+  });
+
   it("ignores legacy files and rebuilds only on compile", async () => {
     const { rootDir, config } = await createPersistentVault({
       initialize: true,
@@ -574,6 +584,9 @@ describe("Memory Wiki compiled cache lifecycle", () => {
     );
     configureMemoryWikiCompiledCacheStore(store);
     await publishSnapshot(config, snapshot("recoverable"));
+    configureMemoryWikiCompiledCacheStore(undefined);
+    configureMemoryWikiCompiledCacheStore(store);
+    await activateVault(config);
     failNextRead = true;
 
     await expect(loadMemoryWikiCompiledCache(config)).resolves.toBeNull();

--- a/extensions/memory-wiki/src/compiled-cache.integration.test.ts
+++ b/extensions/memory-wiki/src/compiled-cache.integration.test.ts
@@ -18,6 +18,7 @@ import {
   createMemoryWikiCompiledCacheStore,
   deactivateMemoryWikiCompiledCacheOwnersExcept,
   loadMemoryWikiCompiledCache,
+  readMemoryWikiDashboardState,
   MEMORY_WIKI_DASHBOARD_ITEM_LIMIT,
   reconcileMemoryWikiCompiledCacheOwner,
   resolveMemoryWikiCompiledCacheGeneration,
@@ -108,6 +109,18 @@ function snapshot(text: string): MemoryWikiCompiledCacheSnapshot {
         text,
       },
     ],
+    dashboards: {
+      importInsights: { sourceType: "chatgpt", totalItems: 0, totalClusters: 0, clusters: [] },
+      overview: {
+        totalItems: 0,
+        totalPages: 0,
+        pageCounts: { synthesis: 0, entity: 0, concept: 0, source: 0, report: 0 },
+        totalClaims: 0,
+        totalQuestions: 0,
+        totalContradictions: 0,
+        clusters: [],
+      },
+    },
   };
 }
 
@@ -217,17 +230,6 @@ describe("Memory Wiki compiled cache lifecycle", () => {
     await expect(preparePrompt(config)).resolves.toContain(
       "Alpha uses PostgreSQL for production writes.",
     );
-  });
-
-  it("keeps a version-2 prompt digest readable before dashboard cache refresh", async () => {
-    const { config } = await createPersistentVault({
-      initialize: true,
-      config: { context: { includeCompiledDigestPrompt: true } },
-    });
-    await publishSnapshot(config, snapshot("version-2 prompt claim"));
-
-    await expect(preparePrompt(config)).resolves.toContain("version-2 prompt claim");
-    expect((await loadMemoryWikiCompiledCache(config))?.dashboards).toBeUndefined();
   });
 
   it("bounds dashboard projections below the compiled-cache entry limit", () => {
@@ -627,7 +629,7 @@ describe("Memory Wiki compiled cache lifecycle", () => {
     expect(readFile).not.toHaveBeenCalled();
   });
 
-  it("treats transient SQLite read failures as a recoverable cache miss", async () => {
+  it("reports transient SQLite read failures as failed dashboard state", async () => {
     const { config } = await createPersistentVault({ initialize: true });
     const errors: unknown[] = [];
     let failNextRead = false;
@@ -654,7 +656,9 @@ describe("Memory Wiki compiled cache lifecycle", () => {
     await activateVault(config);
     failNextRead = true;
 
-    await expect(loadMemoryWikiCompiledCache(config)).resolves.toBeNull();
+    await expect(readMemoryWikiDashboardState(config)).resolves.toMatchObject({
+      state: "failed",
+    });
     expect(errors).toHaveLength(1);
     expect((await loadMemoryWikiCompiledCache(config))?.claims[0]?.text).toBe("recoverable");
   });

--- a/extensions/memory-wiki/src/compiled-cache.integration.test.ts
+++ b/extensions/memory-wiki/src/compiled-cache.integration.test.ts
@@ -18,13 +18,17 @@ import {
   createMemoryWikiCompiledCacheStore,
   deactivateMemoryWikiCompiledCacheOwnersExcept,
   loadMemoryWikiCompiledCache,
+  MEMORY_WIKI_DASHBOARD_ITEM_LIMIT,
   reconcileMemoryWikiCompiledCacheOwner,
   resolveMemoryWikiCompiledCacheGeneration,
   resolveMemoryWikiCompiledCacheOwnerId,
   writeMemoryWikiCompiledCache,
   type MemoryWikiCompiledCacheSnapshot,
+  type MemoryWikiImportInsightItem,
+  type MemoryWikiOverviewItem,
 } from "./compiled-cache.js";
 import { resolveMemoryWikiAgentConfig, resolveMemoryWikiConfig } from "./config.js";
+import { buildMemoryWikiImportInsights } from "./import-insights.js";
 import {
   appendMemoryWikiLog,
   loadMemoryWikiValidatedVaultIdentity,
@@ -36,6 +40,7 @@ import { createWikiPromptSectionPreparer } from "./prompt-section.js";
 import { getMemoryWikiPage } from "./query.js";
 import { createMemoryWikiTestHarness } from "./test-helpers.js";
 import { initializeMemoryWikiVault } from "./vault.js";
+import { buildMemoryWikiOverview } from "./wiki-overview.js";
 
 const { createTempDir, createVault } = createMemoryWikiTestHarness();
 let blobStateDir = "";
@@ -103,18 +108,6 @@ function snapshot(text: string): MemoryWikiCompiledCacheSnapshot {
         text,
       },
     ],
-    dashboards: {
-      importInsights: { sourceType: "chatgpt", totalItems: 0, totalClusters: 0, clusters: [] },
-      overview: {
-        totalItems: 0,
-        totalPages: 0,
-        pageCounts: { synthesis: 0, entity: 0, concept: 0, source: 0, report: 0 },
-        totalClaims: 0,
-        totalQuestions: 0,
-        totalContradictions: 0,
-        clusters: [],
-      },
-    },
   };
 }
 
@@ -224,6 +217,78 @@ describe("Memory Wiki compiled cache lifecycle", () => {
     await expect(preparePrompt(config)).resolves.toContain(
       "Alpha uses PostgreSQL for production writes.",
     );
+  });
+
+  it("keeps a version-2 prompt digest readable before dashboard cache refresh", async () => {
+    const { config } = await createPersistentVault({
+      initialize: true,
+      config: { context: { includeCompiledDigestPrompt: true } },
+    });
+    await publishSnapshot(config, snapshot("version-2 prompt claim"));
+
+    await expect(preparePrompt(config)).resolves.toContain("version-2 prompt claim");
+    expect((await loadMemoryWikiCompiledCache(config))?.dashboards).toBeUndefined();
+  });
+
+  it("bounds dashboard projections below the compiled-cache entry limit", () => {
+    const oversized = "x".repeat(10_000);
+    const importItem: MemoryWikiImportInsightItem = {
+      pagePath: "sources/oversized.md",
+      title: oversized,
+      riskLevel: "low",
+      riskReasons: Array(16).fill(oversized),
+      labels: Array(16).fill(oversized),
+      topicKey: oversized,
+      topicLabel: oversized,
+      digestStatus: "available",
+      activeBranchMessages: 1,
+      userMessageCount: 1,
+      assistantMessageCount: 1,
+      firstUserLine: oversized,
+      lastUserLine: oversized,
+      assistantOpener: oversized,
+      summary: oversized,
+      candidateSignals: Array(8).fill(oversized),
+      correctionSignals: Array(8).fill(oversized),
+      preferenceSignals: Array(16).fill(oversized),
+      createdAt: oversized,
+      updatedAt: oversized,
+    };
+    const overviewItem: MemoryWikiOverviewItem = {
+      pagePath: "concepts/oversized.md",
+      title: oversized,
+      kind: "concept",
+      id: oversized,
+      updatedAt: oversized,
+      sourceType: oversized,
+      claimCount: 3,
+      questionCount: 3,
+      contradictionCount: 3,
+      claims: Array(6).fill(oversized),
+      questions: Array(6).fill(oversized),
+      contradictions: Array(6).fill(oversized),
+      snippet: oversized,
+    };
+    const count = MEMORY_WIKI_DASHBOARD_ITEM_LIMIT + 1;
+    const dashboards = {
+      importInsights: buildMemoryWikiImportInsights(
+        Array.from({ length: count }, (_, index) => ({
+          ...importItem,
+          pagePath: `sources/oversized-${index}.md`,
+        })),
+      ),
+      overview: buildMemoryWikiOverview(
+        [],
+        Array.from({ length: count }, (_, index) => ({
+          ...overviewItem,
+          pagePath: `concepts/oversized-${index}.md`,
+        })),
+      ),
+    };
+
+    expect(dashboards.importInsights).toMatchObject({ totalItems: count, truncated: true });
+    expect(dashboards.overview).toMatchObject({ totalItems: count, truncated: true });
+    expect(Buffer.byteLength(JSON.stringify(dashboards))).toBeLessThan(32 * 1024 * 1024);
   });
 
   it("replaces a loaded snapshot when a newer publication commits", async () => {

--- a/extensions/memory-wiki/src/compiled-cache.ts
+++ b/extensions/memory-wiki/src/compiled-cache.ts
@@ -16,7 +16,7 @@ const COMPILED_CACHE_NAMESPACE = "compiled-cache";
 const COMPILED_CACHE_MAX_ENTRIES = 256;
 const COMPILED_CACHE_MAX_BYTES_PER_ENTRY = 100 * 1024 * 1024;
 const COMPILED_CACHE_MAX_BYTES = 512 * 1024 * 1024;
-const COMPILED_CACHE_VERSION = 2;
+const COMPILED_CACHE_VERSION = 3;
 export const MEMORY_WIKI_DASHBOARD_ITEM_LIMIT = 2_500;
 
 export type MemoryWikiCompiledDigestClaim = {
@@ -158,11 +158,37 @@ export type MemoryWikiCompiledCacheSnapshot = {
     pages: MemoryWikiCompiledDigestPage[];
   };
   claims: MemoryWikiCompiledClaim[];
-  dashboards?: {
+  dashboards: {
     importInsights: MemoryWikiImportInsightsStatus;
     overview: MemoryWikiOverviewStatus;
   };
 };
+
+type MemoryWikiCompiledDashboards = MemoryWikiCompiledCacheSnapshot["dashboards"];
+
+export type MemoryWikiDashboardState =
+  | { state: "ready"; dashboards: MemoryWikiCompiledDashboards }
+  | { state: "rebuilding" }
+  | { state: "compile-required" }
+  | { state: "failed" };
+
+type MemoryWikiDashboardPendingState = Exclude<MemoryWikiDashboardState, { state: "ready" }>;
+const DASHBOARD_UNAVAILABLE_MESSAGES: Record<MemoryWikiDashboardPendingState["state"], string> = {
+  rebuilding: "Memory Wiki dashboards are rebuilding. Retry shortly.",
+  "compile-required":
+    'Memory Wiki dashboards need a compiled snapshot. Run "openclaw wiki compile", then reload.',
+  failed: 'Memory Wiki dashboard rebuild failed. Run "openclaw wiki compile", then reload.',
+};
+
+export class MemoryWikiDashboardUnavailableError extends Error {
+  constructor(
+    readonly state: MemoryWikiDashboardPendingState["state"],
+    message: string,
+  ) {
+    super(message);
+    this.name = "MemoryWikiDashboardUnavailableError";
+  }
+}
 
 type CompiledCacheMetadata = {
   version: typeof COMPILED_CACHE_VERSION;
@@ -204,6 +230,10 @@ type MemoryWikiCompiledCacheStore = {
 
 let configuredStore: MemoryWikiCompiledCacheStore | undefined;
 const activeVaults = new Map<string, ActiveVault>();
+const dashboardStates = new Map<
+  string,
+  { ownerId: string; state: MemoryWikiDashboardPendingState }
+>();
 
 export function resolveMemoryWikiCompiledCacheOwnerId(config: ResolvedMemoryWikiConfig): string {
   if (config.vault.scope === "global") {
@@ -222,6 +252,10 @@ function ownerKeyPrefix(ownerId: string): string {
 
 function publicationKey(ownerId: string, publicationId: string): string {
   return `${ownerKeyPrefix(ownerId)}${createHash("sha256").update(publicationId).digest("hex")}`;
+}
+
+function dashboardStateKey(config: ResolvedMemoryWikiConfig): string {
+  return `${resolveMemoryWikiCompiledCacheOwnerId(config)}\0${path.resolve(config.vault.path)}`;
 }
 
 function isMetadata(value: CompiledCacheMetadata | undefined): value is CompiledCacheMetadata {
@@ -272,6 +306,21 @@ export function deactivateMemoryWikiCompiledCacheOwnersExcept(ownerIds: Readonly
       activeVaults.delete(ownerId);
     }
   }
+  for (const [key, entry] of dashboardStates) {
+    if (!ownerIds.has(entry.ownerId)) {
+      dashboardStates.delete(key);
+    }
+  }
+}
+
+export function setMemoryWikiDashboardState(
+  config: ResolvedMemoryWikiConfig,
+  state: MemoryWikiDashboardPendingState,
+): void {
+  dashboardStates.set(dashboardStateKey(config), {
+    ownerId: resolveMemoryWikiCompiledCacheOwnerId(config),
+    state,
+  });
 }
 
 function resolveActiveVault(config: ResolvedMemoryWikiConfig): ActiveVault | null {
@@ -299,14 +348,14 @@ function parseSnapshot(
       typeof parsed.digest !== "object" ||
       !Array.isArray(parsed.digest.pages) ||
       !Array.isArray(parsed.claims) ||
-      (parsed.dashboards !== undefined &&
-        (typeof parsed.dashboards !== "object" ||
-          !parsed.dashboards.importInsights ||
-          typeof parsed.dashboards.importInsights !== "object" ||
-          !Array.isArray(parsed.dashboards.importInsights.clusters) ||
-          !parsed.dashboards.overview ||
-          typeof parsed.dashboards.overview !== "object" ||
-          !Array.isArray(parsed.dashboards.overview.clusters)))
+      !parsed.dashboards ||
+      typeof parsed.dashboards !== "object" ||
+      !parsed.dashboards.importInsights ||
+      typeof parsed.dashboards.importInsights !== "object" ||
+      !Array.isArray(parsed.dashboards.importInsights.clusters) ||
+      !parsed.dashboards.overview ||
+      typeof parsed.dashboards.overview !== "object" ||
+      !Array.isArray(parsed.dashboards.overview.clusters)
     ) {
       return null;
     }
@@ -360,7 +409,7 @@ export function createMemoryWikiCompiledCacheStore(
       const key = publicationKey(ownerId, activeVault.compiledCachePublicationId);
       const entry = await store.lookup(key).catch((error: unknown) => {
         options.onReadError?.(error);
-        return undefined;
+        throw error;
       });
       if (!entry) {
         return null;
@@ -487,6 +536,7 @@ export function configureMemoryWikiCompiledCacheStore(
   configuredStore = store;
   if (!store) {
     activeVaults.clear();
+    dashboardStates.clear();
   }
 }
 
@@ -503,11 +553,43 @@ export async function loadMemoryWikiCompiledCache(
   return await requireConfiguredStore().read(config);
 }
 
+export async function readMemoryWikiDashboardState(
+  config: ResolvedMemoryWikiConfig,
+): Promise<MemoryWikiDashboardState> {
+  const pending = dashboardStates.get(dashboardStateKey(config));
+  if (pending) {
+    return pending.state;
+  }
+  try {
+    const snapshot = await loadMemoryWikiCompiledCache(config);
+    if (snapshot) {
+      return { state: "ready", dashboards: snapshot.dashboards };
+    }
+  } catch {
+    return { state: "failed" };
+  }
+  return config.ingest.autoCompile ? { state: "rebuilding" } : { state: "compile-required" };
+}
+
+export async function loadMemoryWikiCompiledDashboards(
+  config: ResolvedMemoryWikiConfig,
+): Promise<MemoryWikiCompiledDashboards> {
+  const status = await readMemoryWikiDashboardState(config);
+  if (status.state === "ready") {
+    return status.dashboards;
+  }
+  throw new MemoryWikiDashboardUnavailableError(
+    status.state,
+    DASHBOARD_UNAVAILABLE_MESSAGES[status.state],
+  );
+}
+
 export async function invalidateMemoryWikiCompiledCache(
   config: ResolvedMemoryWikiConfig,
 ): Promise<void> {
   await requireConfiguredStore().delete(config);
   activeVaults.delete(resolveMemoryWikiCompiledCacheOwnerId(config));
+  dashboardStates.delete(dashboardStateKey(config));
 }
 
 export async function reconcileMemoryWikiCompiledCacheOwner(
@@ -577,4 +659,5 @@ export async function writeMemoryWikiCompiledCache(
     reconciled: true,
     snapshot,
   });
+  dashboardStates.delete(dashboardStateKey(config));
 }

--- a/extensions/memory-wiki/src/compiled-cache.ts
+++ b/extensions/memory-wiki/src/compiled-cache.ts
@@ -16,7 +16,8 @@ const COMPILED_CACHE_NAMESPACE = "compiled-cache";
 const COMPILED_CACHE_MAX_ENTRIES = 256;
 const COMPILED_CACHE_MAX_BYTES_PER_ENTRY = 100 * 1024 * 1024;
 const COMPILED_CACHE_MAX_BYTES = 512 * 1024 * 1024;
-const COMPILED_CACHE_VERSION = 3;
+const COMPILED_CACHE_VERSION = 2;
+export const MEMORY_WIKI_DASHBOARD_ITEM_LIMIT = 2_500;
 
 export type MemoryWikiCompiledDigestClaim = {
   id?: string;
@@ -91,7 +92,7 @@ export type MemoryWikiImportInsightItem = {
   updatedAt?: string;
 };
 
-type MemoryWikiImportInsightCluster = {
+export type MemoryWikiImportInsightCluster = {
   key: string;
   label: string;
   itemCount: number;
@@ -107,6 +108,7 @@ export type MemoryWikiImportInsightsStatus = {
   totalItems: number;
   totalClusters: number;
   clusters: MemoryWikiImportInsightCluster[];
+  truncated?: boolean;
 };
 
 export type MemoryWikiOverviewItem = {
@@ -125,7 +127,7 @@ export type MemoryWikiOverviewItem = {
   snippet?: string;
 };
 
-type MemoryWikiOverviewCluster = {
+export type MemoryWikiOverviewCluster = {
   key: WikiPageKind;
   label: string;
   itemCount: number;
@@ -146,6 +148,7 @@ export type MemoryWikiOverviewStatus = {
   totalQuestions: number;
   totalContradictions: number;
   clusters: MemoryWikiOverviewCluster[];
+  truncated?: boolean;
 };
 
 export type MemoryWikiCompiledCacheSnapshot = {
@@ -155,7 +158,7 @@ export type MemoryWikiCompiledCacheSnapshot = {
     pages: MemoryWikiCompiledDigestPage[];
   };
   claims: MemoryWikiCompiledClaim[];
-  dashboards: {
+  dashboards?: {
     importInsights: MemoryWikiImportInsightsStatus;
     overview: MemoryWikiOverviewStatus;
   };
@@ -296,14 +299,14 @@ function parseSnapshot(
       typeof parsed.digest !== "object" ||
       !Array.isArray(parsed.digest.pages) ||
       !Array.isArray(parsed.claims) ||
-      !parsed.dashboards ||
-      typeof parsed.dashboards !== "object" ||
-      !parsed.dashboards.importInsights ||
-      typeof parsed.dashboards.importInsights !== "object" ||
-      !Array.isArray(parsed.dashboards.importInsights.clusters) ||
-      !parsed.dashboards.overview ||
-      typeof parsed.dashboards.overview !== "object" ||
-      !Array.isArray(parsed.dashboards.overview.clusters)
+      (parsed.dashboards !== undefined &&
+        (typeof parsed.dashboards !== "object" ||
+          !parsed.dashboards.importInsights ||
+          typeof parsed.dashboards.importInsights !== "object" ||
+          !Array.isArray(parsed.dashboards.importInsights.clusters) ||
+          !parsed.dashboards.overview ||
+          typeof parsed.dashboards.overview !== "object" ||
+          !Array.isArray(parsed.dashboards.overview.clusters)))
     ) {
       return null;
     }

--- a/extensions/memory-wiki/src/compiled-cache.ts
+++ b/extensions/memory-wiki/src/compiled-cache.ts
@@ -623,6 +623,10 @@ export async function writeMemoryWikiCompiledCache(
     await store.deletePublication(config, publicationId);
     throw error;
   }
+  if (resolveActiveVault(config) !== activeVault) {
+    await store.deletePublication(config, publicationId);
+    throw new Error("Memory Wiki cache owner retired before publication.");
+  }
   try {
     await commitPublication();
   } catch (error) {
@@ -645,13 +649,16 @@ export async function writeMemoryWikiCompiledCache(
     }
     throw new Error("Memory Wiki vault changed while its compiled cache was being published.");
   }
+  if (resolveActiveVault(config) !== activeVault) {
+    await store.deletePublication(config, publicationId);
+    throw new Error("Memory Wiki cache owner retired during publication.");
+  }
   if (parentPublicationId) {
     await store.deletePublication(config, parentPublicationId);
   }
-  // The publication is durable. A concurrent lifecycle refresh owns in-memory
-  // activation; retaining this row lets its next refresh reconcile safely.
   if (resolveActiveVault(config) !== activeVault) {
-    return;
+    await store.deletePublication(config, publicationId);
+    throw new Error("Memory Wiki cache owner retired while replacing its predecessor.");
   }
   activeVaults.set(resolveMemoryWikiCompiledCacheOwnerId(config), {
     ...activeVault,

--- a/extensions/memory-wiki/src/compiled-cache.ts
+++ b/extensions/memory-wiki/src/compiled-cache.ts
@@ -108,7 +108,7 @@ export type MemoryWikiImportInsightsStatus = {
   totalItems: number;
   totalClusters: number;
   clusters: MemoryWikiImportInsightCluster[];
-  truncated?: boolean;
+  truncated: boolean;
 };
 
 export type MemoryWikiOverviewItem = {
@@ -148,7 +148,7 @@ export type MemoryWikiOverviewStatus = {
   totalQuestions: number;
   totalContradictions: number;
   clusters: MemoryWikiOverviewCluster[];
-  truncated?: boolean;
+  truncated: boolean;
 };
 
 export type MemoryWikiCompiledCacheSnapshot = {
@@ -352,9 +352,11 @@ function parseSnapshot(
       typeof parsed.dashboards !== "object" ||
       !parsed.dashboards.importInsights ||
       typeof parsed.dashboards.importInsights !== "object" ||
+      typeof parsed.dashboards.importInsights.truncated !== "boolean" ||
       !Array.isArray(parsed.dashboards.importInsights.clusters) ||
       !parsed.dashboards.overview ||
       typeof parsed.dashboards.overview !== "object" ||
+      typeof parsed.dashboards.overview.truncated !== "boolean" ||
       !Array.isArray(parsed.dashboards.overview.clusters)
     ) {
       return null;

--- a/extensions/memory-wiki/src/compiled-cache.ts
+++ b/extensions/memory-wiki/src/compiled-cache.ts
@@ -5,9 +5,7 @@ import { gunzipSync, gzipSync } from "node:zlib";
 import type { PluginBlobStore } from "openclaw/plugin-sdk/plugin-state-runtime";
 import type { WikiFreshnessLevel } from "./claim-health.js";
 import type { ResolvedMemoryWikiConfig } from "./config.js";
-import type { MemoryWikiImportInsightsStatus } from "./import-insights.js";
 import type { WikiPageKind, WikiPageSummary, WikiRelationship } from "./markdown.js";
-import type { MemoryWikiOverviewStatus } from "./wiki-overview.js";
 
 export const LEGACY_MEMORY_WIKI_COMPILED_CACHE_PATHS = [
   ".openclaw-wiki/cache/agent-digest.json",
@@ -68,6 +66,86 @@ export type MemoryWikiCompiledClaim = {
   privacyTiers?: string[];
   freshnessLevel?: string;
   lastTouchedAt?: string;
+};
+
+export type MemoryWikiImportInsightItem = {
+  pagePath: string;
+  title: string;
+  riskLevel: "low" | "medium" | "high" | "unknown";
+  riskReasons: string[];
+  labels: string[];
+  topicKey: string;
+  topicLabel: string;
+  digestStatus: "available" | "withheld";
+  activeBranchMessages: number;
+  userMessageCount: number;
+  assistantMessageCount: number;
+  firstUserLine?: string;
+  lastUserLine?: string;
+  assistantOpener?: string;
+  summary: string;
+  candidateSignals: string[];
+  correctionSignals: string[];
+  preferenceSignals: string[];
+  createdAt?: string;
+  updatedAt?: string;
+};
+
+type MemoryWikiImportInsightCluster = {
+  key: string;
+  label: string;
+  itemCount: number;
+  highRiskCount: number;
+  withheldCount: number;
+  preferenceSignalCount: number;
+  updatedAt?: string;
+  items: MemoryWikiImportInsightItem[];
+};
+
+export type MemoryWikiImportInsightsStatus = {
+  sourceType: "chatgpt";
+  totalItems: number;
+  totalClusters: number;
+  clusters: MemoryWikiImportInsightCluster[];
+};
+
+export type MemoryWikiOverviewItem = {
+  pagePath: string;
+  title: string;
+  kind: WikiPageKind;
+  id?: string;
+  updatedAt?: string;
+  sourceType?: string;
+  claimCount: number;
+  questionCount: number;
+  contradictionCount: number;
+  claims: string[];
+  questions: string[];
+  contradictions: string[];
+  snippet?: string;
+};
+
+type MemoryWikiOverviewCluster = {
+  key: WikiPageKind;
+  label: string;
+  itemCount: number;
+  claimCount: number;
+  questionCount: number;
+  contradictionCount: number;
+  updatedAt?: string;
+  items: MemoryWikiOverviewItem[];
+};
+
+export type MemoryWikiOverviewPageCounts = Record<WikiPageKind, number>;
+
+export type MemoryWikiOverviewStatus = {
+  totalItems: number;
+  totalPages: number;
+  pageCounts: MemoryWikiOverviewPageCounts;
+  totalClaims: number;
+  totalQuestions: number;
+  totalContradictions: number;
+  clusters: MemoryWikiOverviewCluster[];
 };
 
 export type MemoryWikiCompiledCacheSnapshot = {
@@ -494,5 +572,6 @@ export async function writeMemoryWikiCompiledCache(
     ...activeVault,
     compiledCachePublicationId: publicationId,
     reconciled: true,
+    snapshot,
   });
 }

--- a/extensions/memory-wiki/src/compiled-cache.ts
+++ b/extensions/memory-wiki/src/compiled-cache.ts
@@ -5,7 +5,9 @@ import { gunzipSync, gzipSync } from "node:zlib";
 import type { PluginBlobStore } from "openclaw/plugin-sdk/plugin-state-runtime";
 import type { WikiFreshnessLevel } from "./claim-health.js";
 import type { ResolvedMemoryWikiConfig } from "./config.js";
+import type { MemoryWikiImportInsightsStatus } from "./import-insights.js";
 import type { WikiPageKind, WikiPageSummary, WikiRelationship } from "./markdown.js";
+import type { MemoryWikiOverviewStatus } from "./wiki-overview.js";
 
 export const LEGACY_MEMORY_WIKI_COMPILED_CACHE_PATHS = [
   ".openclaw-wiki/cache/agent-digest.json",
@@ -16,7 +18,7 @@ const COMPILED_CACHE_NAMESPACE = "compiled-cache";
 const COMPILED_CACHE_MAX_ENTRIES = 256;
 const COMPILED_CACHE_MAX_BYTES_PER_ENTRY = 100 * 1024 * 1024;
 const COMPILED_CACHE_MAX_BYTES = 512 * 1024 * 1024;
-const COMPILED_CACHE_VERSION = 2;
+const COMPILED_CACHE_VERSION = 3;
 
 export type MemoryWikiCompiledDigestClaim = {
   id?: string;
@@ -75,6 +77,10 @@ export type MemoryWikiCompiledCacheSnapshot = {
     pages: MemoryWikiCompiledDigestPage[];
   };
   claims: MemoryWikiCompiledClaim[];
+  dashboards: {
+    importInsights: MemoryWikiImportInsightsStatus;
+    overview: MemoryWikiOverviewStatus;
+  };
 };
 
 type CompiledCacheMetadata = {
@@ -92,6 +98,7 @@ type ActiveVault = {
   vaultGeneration: string;
   compiledCachePublicationId?: string;
   reconciled: boolean;
+  snapshot?: MemoryWikiCompiledCacheSnapshot;
 };
 
 type MemoryWikiCompiledCacheStore = {
@@ -152,17 +159,30 @@ export function activateMemoryWikiCompiledCacheOwner(
   config: ResolvedMemoryWikiConfig,
   vaultGeneration: string,
   compiledCachePublicationId?: string | null,
-): void {
+): boolean {
   const normalizedVaultGeneration = vaultGeneration.trim();
   if (!normalizedVaultGeneration) {
     throw new Error("Memory Wiki vault generation must not be empty.");
   }
-  activeVaults.set(resolveMemoryWikiCompiledCacheOwnerId(config), {
-    path: path.resolve(config.vault.path),
+  const ownerId = resolveMemoryWikiCompiledCacheOwnerId(config);
+  const vaultPath = path.resolve(config.vault.path);
+  const publicationId = compiledCachePublicationId?.trim() || undefined;
+  const active = activeVaults.get(ownerId);
+  if (
+    active?.reconciled &&
+    active.path === vaultPath &&
+    active.vaultGeneration === normalizedVaultGeneration &&
+    active.compiledCachePublicationId === publicationId
+  ) {
+    return false;
+  }
+  activeVaults.set(ownerId, {
+    path: vaultPath,
     vaultGeneration: normalizedVaultGeneration,
-    compiledCachePublicationId: compiledCachePublicationId?.trim() || undefined,
+    compiledCachePublicationId: publicationId,
     reconciled: false,
   });
+  return true;
 }
 
 export function deactivateMemoryWikiCompiledCacheOwnersExcept(ownerIds: ReadonlySet<string>): void {
@@ -197,7 +217,15 @@ function parseSnapshot(
       !parsed.digest ||
       typeof parsed.digest !== "object" ||
       !Array.isArray(parsed.digest.pages) ||
-      !Array.isArray(parsed.claims)
+      !Array.isArray(parsed.claims) ||
+      !parsed.dashboards ||
+      typeof parsed.dashboards !== "object" ||
+      !parsed.dashboards.importInsights ||
+      typeof parsed.dashboards.importInsights !== "object" ||
+      !Array.isArray(parsed.dashboards.importInsights.clusters) ||
+      !parsed.dashboards.overview ||
+      typeof parsed.dashboards.overview !== "object" ||
+      !Array.isArray(parsed.dashboards.overview.clusters)
     ) {
       return null;
     }
@@ -245,6 +273,9 @@ export function createMemoryWikiCompiledCacheStore(
       if (!activeVault?.reconciled || !activeVault.compiledCachePublicationId) {
         return null;
       }
+      if (activeVault.snapshot) {
+        return activeVault.snapshot;
+      }
       const key = publicationKey(ownerId, activeVault.compiledCachePublicationId);
       const entry = await store.lookup(key).catch((error: unknown) => {
         options.onReadError?.(error);
@@ -276,6 +307,7 @@ export function createMemoryWikiCompiledCacheStore(
       if (resolveActiveVault(config) !== activeVault) {
         return null;
       }
+      activeVault.snapshot = snapshot;
       return snapshot;
     },
 
@@ -394,6 +426,7 @@ export async function invalidateMemoryWikiCompiledCache(
   config: ResolvedMemoryWikiConfig,
 ): Promise<void> {
   await requireConfiguredStore().delete(config);
+  activeVaults.delete(resolveMemoryWikiCompiledCacheOwnerId(config));
 }
 
 export async function reconcileMemoryWikiCompiledCacheOwner(

--- a/extensions/memory-wiki/src/gateway.test.ts
+++ b/extensions/memory-wiki/src/gateway.test.ts
@@ -2,6 +2,7 @@
 import path from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { applyMemoryWikiMutation, normalizeMemoryWikiMutationInput } from "./apply.js";
+import { MemoryWikiDashboardUnavailableError } from "./compiled-cache.js";
 import { registerMemoryWikiGatewayMethods } from "./gateway.js";
 import { listMemoryWikiImportInsights } from "./import-insights.js";
 import { listMemoryWikiImportRuns } from "./import-runs.js";
@@ -102,6 +103,14 @@ function readRespondError(respond: { mock: { calls: Array<Array<unknown>> } }): 
   expect(call?.[0]).toBe(false);
   expect(call?.[1]).toBeUndefined();
   return call?.[2];
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
 }
 
 const VAULT_BACKED_GATEWAY_CASES = [
@@ -302,7 +311,10 @@ describe("memory-wiki gateway methods", () => {
       respond,
     });
 
-    expect(syncMemoryWikiImportedSources).toHaveBeenCalledWith({ config, appConfig: undefined });
+    expect(syncMemoryWikiImportedSources).toHaveBeenCalledWith({
+      config,
+      appConfig: undefined,
+    });
     expect(resolveMemoryWikiStatus).toHaveBeenCalledWith(config, {
       appConfig: undefined,
     });
@@ -329,7 +341,10 @@ describe("memory-wiki gateway methods", () => {
 
     await handler({ params: { agentId: "marketing" }, respond: vi.fn() });
 
-    expect(syncMemoryWikiImportedSources).toHaveBeenCalledWith({ config, appConfig });
+    expect(syncMemoryWikiImportedSources).toHaveBeenCalledWith({
+      config,
+      appConfig,
+    });
     expect(resolveMemoryWikiStatus).toHaveBeenCalledWith(config, { appConfig });
   });
 
@@ -506,7 +521,10 @@ describe("memory-wiki gateway methods", () => {
       respond,
     });
 
-    expect(syncMemoryWikiImportedSources).toHaveBeenCalledWith({ config, appConfig: undefined });
+    expect(syncMemoryWikiImportedSources).toHaveBeenCalledWith({
+      config,
+      appConfig: undefined,
+    });
     expect(listMemoryWikiImportInsights).toHaveBeenCalledWith(config);
     expect(readRespondPayload(respond)).toEqual({
       sourceType: "chatgpt",
@@ -539,6 +557,71 @@ describe("memory-wiki gateway methods", () => {
       ],
     });
   });
+
+  it.each(["wiki.importInsights", "wiki.overview"])(
+    "%s responds without waiting for source sync",
+    async (method) => {
+      const { config } = await createVault({ prefix: "memory-wiki-gateway-background-" });
+      const { api, registerGatewayMethod } = createPluginApi();
+      const syncGate = deferred<Awaited<ReturnType<typeof syncMemoryWikiImportedSources>>>();
+      vi.mocked(syncMemoryWikiImportedSources).mockReturnValueOnce(syncGate.promise);
+
+      registerMemoryWikiGatewayMethods({ api, config });
+      const handler = findGatewayHandler(registerGatewayMethod, method);
+      if (!handler) {
+        throw new Error(`${method} handler missing`);
+      }
+      const respond = vi.fn();
+
+      await handler({ params: {}, respond });
+
+      expect(respond).toHaveBeenCalledOnce();
+      syncGate.resolve({
+        importedCount: 0,
+        updatedCount: 0,
+        skippedCount: 0,
+        removedCount: 0,
+        artifactCount: 0,
+        workspaces: 0,
+        pagePaths: [],
+        indexesRefreshed: false,
+        indexUpdatedFiles: [],
+        indexRefreshReason: "no-import-changes",
+      });
+      await syncGate.promise;
+    },
+  );
+
+  it.each([
+    ["rebuilding", "UNAVAILABLE", true, 500],
+    ["compile-required", "INVALID_REQUEST", undefined, undefined],
+    ["failed", "UNAVAILABLE", undefined, undefined],
+  ] as const)(
+    "returns explicit %s dashboard availability",
+    async (state, code, retryable, retryAfterMs) => {
+      const { config } = await createVault({ prefix: "memory-wiki-gateway-state-" });
+      const { api, registerGatewayMethod } = createPluginApi();
+      vi.mocked(listMemoryWikiImportInsights).mockRejectedValueOnce(
+        new MemoryWikiDashboardUnavailableError(state, `dashboard ${state}`),
+      );
+
+      registerMemoryWikiGatewayMethods({ api, config });
+      const handler = findGatewayHandler(registerGatewayMethod, "wiki.importInsights");
+      if (!handler) {
+        throw new Error("wiki.importInsights handler missing");
+      }
+      const respond = vi.fn();
+
+      await handler({ params: {}, respond });
+
+      expect(readRespondError(respond)).toEqual({
+        code,
+        message: `dashboard ${state}`,
+        details: { state },
+        ...(retryable ? { retryable, retryAfterMs } : {}),
+      });
+    },
+  );
 
   it("returns the wiki overview over the gateway", async () => {
     const { config } = await createVault({ prefix: "memory-wiki-gateway-" });
@@ -593,7 +676,10 @@ describe("memory-wiki gateway methods", () => {
       respond,
     });
 
-    expect(syncMemoryWikiImportedSources).toHaveBeenCalledWith({ config, appConfig: undefined });
+    expect(syncMemoryWikiImportedSources).toHaveBeenCalledWith({
+      config,
+      appConfig: undefined,
+    });
     expect(listMemoryWikiOverview).toHaveBeenCalledWith(config);
     expect(readRespondPayload(respond)).toEqual({
       totalItems: 1,

--- a/extensions/memory-wiki/src/gateway.test.ts
+++ b/extensions/memory-wiki/src/gateway.test.ts
@@ -2,6 +2,7 @@
 import path from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { applyMemoryWikiMutation, normalizeMemoryWikiMutationInput } from "./apply.js";
+import { compileMemoryWikiVault } from "./compile.js";
 import { MemoryWikiDashboardUnavailableError } from "./compiled-cache.js";
 import { registerMemoryWikiGatewayMethods } from "./gateway.js";
 import { listMemoryWikiImportInsights } from "./import-insights.js";
@@ -324,6 +325,31 @@ describe("memory-wiki gateway methods", () => {
       vaultMode: "isolated",
       vaultExists: true,
     });
+  });
+
+  it("binds manual compilation to the active service generation", async () => {
+    const { config } = await createVault({ prefix: "memory-wiki-gateway-compile-signal-" });
+    const { api, registerGatewayMethod } = createPluginApi();
+    const signal = new AbortController().signal;
+
+    registerMemoryWikiGatewayMethods({
+      api,
+      config,
+      resolveSourceSyncSignal: () => signal,
+    });
+    const handler = findGatewayHandler(registerGatewayMethod, "wiki.compile");
+    if (!handler) {
+      throw new Error("wiki.compile handler missing");
+    }
+
+    await handler({ params: {}, respond: vi.fn() });
+
+    expect(syncMemoryWikiImportedSources).toHaveBeenCalledWith({
+      config,
+      appConfig: undefined,
+      signal,
+    });
+    expect(compileMemoryWikiVault).toHaveBeenCalledWith(config, { signal });
   });
 
   it("keeps global vault requests on the shared base config", async () => {

--- a/extensions/memory-wiki/src/gateway.ts
+++ b/extensions/memory-wiki/src/gateway.ts
@@ -102,8 +102,13 @@ function respondError(respond: GatewayRespond, error: unknown) {
 async function syncImportedSourcesIfNeeded(
   config: ResolvedMemoryWikiConfig,
   appConfig?: OpenClawConfig,
+  signal?: AbortSignal,
 ) {
-  await syncMemoryWikiImportedSources({ config, appConfig });
+  await syncMemoryWikiImportedSources({
+    config,
+    appConfig,
+    ...(signal ? { signal } : {}),
+  });
 }
 
 export function registerMemoryWikiGatewayMethods(params: {
@@ -146,7 +151,15 @@ export function registerMemoryWikiGatewayMethods(params: {
     }
     return params.appConfig;
   };
+  const resolveSourceSyncSignal = () => {
+    const signal = params.resolveSourceSyncSignal?.();
+    if (params.resolveSourceSyncSignal && !signal) {
+      throw new Error("Memory Wiki service is not active.");
+    }
+    return signal;
+  };
   const resolveRequestContext = (requestParams: Record<string, unknown>) => {
+    const signal = resolveSourceSyncSignal();
     const appConfig = getAppConfig();
     const requestedAgentId = readStringParam(requestParams, "agentId");
     const config = params.resolveConfig
@@ -160,7 +173,7 @@ export function registerMemoryWikiGatewayMethods(params: {
       config.agentId ??
       requestedAgentId ??
       (appConfig ? resolveDefaultAgentId(appConfig) : undefined);
-    return { agentId, appConfig, config };
+    return { agentId, appConfig, config, signal };
   };
 
   const assertOfficialObsidianCliSupported = (config: ResolvedMemoryWikiConfig) => {
@@ -175,8 +188,8 @@ export function registerMemoryWikiGatewayMethods(params: {
     "wiki.status",
     async ({ params: requestParams, respond }) => {
       try {
-        const { appConfig, config } = resolveRequestContext(requestParams);
-        await syncImportedSourcesIfNeeded(config, appConfig);
+        const { appConfig, config, signal } = resolveRequestContext(requestParams);
+        await syncImportedSourcesIfNeeded(config, appConfig, signal);
         respond(
           true,
           await resolveMemoryWikiStatus(config, {
@@ -239,8 +252,8 @@ export function registerMemoryWikiGatewayMethods(params: {
     "wiki.init",
     async ({ params: requestParams, respond }) => {
       try {
-        const { config } = resolveRequestContext(requestParams);
-        respond(true, await initializeMemoryWikiVault(config));
+        const { config, signal } = resolveRequestContext(requestParams);
+        respond(true, await initializeMemoryWikiVault(config, signal ? { signal } : undefined));
       } catch (error) {
         respondError(respond, error);
       }
@@ -252,8 +265,8 @@ export function registerMemoryWikiGatewayMethods(params: {
     "wiki.doctor",
     async ({ params: requestParams, respond }) => {
       try {
-        const { appConfig, config } = resolveRequestContext(requestParams);
-        await syncImportedSourcesIfNeeded(config, appConfig);
+        const { appConfig, config, signal } = resolveRequestContext(requestParams);
+        await syncImportedSourcesIfNeeded(config, appConfig, signal);
         const status = await resolveMemoryWikiStatus(config, {
           appConfig,
         });
@@ -269,9 +282,9 @@ export function registerMemoryWikiGatewayMethods(params: {
     "wiki.compile",
     async ({ params: requestParams, respond }) => {
       try {
-        const { appConfig, config } = resolveRequestContext(requestParams);
-        await syncImportedSourcesIfNeeded(config, appConfig);
-        respond(true, await compileMemoryWikiVault(config));
+        const { appConfig, config, signal } = resolveRequestContext(requestParams);
+        await syncImportedSourcesIfNeeded(config, appConfig, signal);
+        respond(true, await compileMemoryWikiVault(config, signal ? { signal } : undefined));
       } catch (error) {
         respondError(respond, error);
       }
@@ -283,7 +296,7 @@ export function registerMemoryWikiGatewayMethods(params: {
     "wiki.ingest",
     async ({ params: requestParams, respond }) => {
       try {
-        const { config } = resolveRequestContext(requestParams);
+        const { config, signal } = resolveRequestContext(requestParams);
         const inputPath = readStringParam(requestParams, "inputPath", { required: true });
         const title = readStringParam(requestParams, "title");
         respond(
@@ -292,6 +305,7 @@ export function registerMemoryWikiGatewayMethods(params: {
             config,
             inputPath,
             ...(title ? { title } : {}),
+            ...(signal ? { signal } : {}),
           }),
         );
       } catch (error) {
@@ -305,9 +319,9 @@ export function registerMemoryWikiGatewayMethods(params: {
     "wiki.lint",
     async ({ params: requestParams, respond }) => {
       try {
-        const { appConfig, config } = resolveRequestContext(requestParams);
-        await syncImportedSourcesIfNeeded(config, appConfig);
-        respond(true, await lintMemoryWikiVault(config));
+        const { appConfig, config, signal } = resolveRequestContext(requestParams);
+        await syncImportedSourcesIfNeeded(config, appConfig, signal);
+        respond(true, await lintMemoryWikiVault(config, signal ? { signal } : undefined));
       } catch (error) {
         respondError(respond, error);
       }
@@ -319,12 +333,13 @@ export function registerMemoryWikiGatewayMethods(params: {
     "wiki.bridge.import",
     async ({ params: requestParams, respond }) => {
       try {
-        const { appConfig, config } = resolveRequestContext(requestParams);
+        const { appConfig, config, signal } = resolveRequestContext(requestParams);
         respond(
           true,
           await syncMemoryWikiImportedSources({
             config: { ...config, vaultMode: "bridge" },
             appConfig,
+            ...(signal ? { signal } : {}),
           }),
         );
       } catch (error) {
@@ -338,7 +353,7 @@ export function registerMemoryWikiGatewayMethods(params: {
     "wiki.unsafeLocal.import",
     async ({ params: requestParams, respond }) => {
       try {
-        const { appConfig, config } = resolveRequestContext(requestParams);
+        const { appConfig, config, signal } = resolveRequestContext(requestParams);
         if (config.vault.scope === "agent") {
           throw new Error("Unsafe-local import does not support memory-wiki vault.scope=agent.");
         }
@@ -347,6 +362,7 @@ export function registerMemoryWikiGatewayMethods(params: {
           await syncMemoryWikiImportedSources({
             config: { ...config, vaultMode: "unsafe-local" },
             appConfig,
+            ...(signal ? { signal } : {}),
           }),
         );
       } catch (error) {
@@ -360,8 +376,8 @@ export function registerMemoryWikiGatewayMethods(params: {
     "wiki.search",
     async ({ params: requestParams, respond }) => {
       try {
-        const { agentId, appConfig, config } = resolveRequestContext(requestParams);
-        await syncImportedSourcesIfNeeded(config, appConfig);
+        const { agentId, appConfig, config, signal } = resolveRequestContext(requestParams);
+        await syncImportedSourcesIfNeeded(config, appConfig, signal);
         const query = readStringParam(requestParams, "query", { required: true });
         const maxResults = readPositiveIntegerParam(requestParams, "maxResults");
         const searchBackend = readEnumParam(requestParams, "backend", WIKI_SEARCH_BACKENDS);
@@ -391,13 +407,14 @@ export function registerMemoryWikiGatewayMethods(params: {
     "wiki.apply",
     async ({ params: requestParams, respond }) => {
       try {
-        const { appConfig, config } = resolveRequestContext(requestParams);
-        await syncImportedSourcesIfNeeded(config, appConfig);
+        const { appConfig, config, signal } = resolveRequestContext(requestParams);
+        await syncImportedSourcesIfNeeded(config, appConfig, signal);
         respond(
           true,
           await applyMemoryWikiMutation({
             config,
             mutation: normalizeMemoryWikiMutationInput(requestParams),
+            ...(signal ? { signal } : {}),
           }),
         );
       } catch (error) {
@@ -411,8 +428,8 @@ export function registerMemoryWikiGatewayMethods(params: {
     "wiki.get",
     async ({ params: requestParams, respond }) => {
       try {
-        const { agentId, appConfig, config } = resolveRequestContext(requestParams);
-        await syncImportedSourcesIfNeeded(config, appConfig);
+        const { agentId, appConfig, config, signal } = resolveRequestContext(requestParams);
+        await syncImportedSourcesIfNeeded(config, appConfig, signal);
         const lookup = readStringParam(requestParams, "lookup", { required: true });
         const fromLine = readPositiveIntegerParam(requestParams, "fromLine");
         const lineCount = readPositiveIntegerParam(requestParams, "lineCount");

--- a/extensions/memory-wiki/src/gateway.ts
+++ b/extensions/memory-wiki/src/gateway.ts
@@ -112,6 +112,7 @@ export function registerMemoryWikiGatewayMethods(params: {
   appConfig?: OpenClawConfig;
   getAppConfig?: () => OpenClawConfig | undefined;
   resolveConfig?: (agentId?: string, appConfig?: OpenClawConfig) => ResolvedMemoryWikiConfig;
+  resolveSourceSyncSignal?: () => AbortSignal | undefined;
 }) {
   const { api, config: baseConfig } = params;
 
@@ -119,7 +120,18 @@ export function registerMemoryWikiGatewayMethods(params: {
     config: ResolvedMemoryWikiConfig,
     appConfig?: OpenClawConfig,
   ) => {
-    void syncMemoryWikiImportedSources({ config, appConfig }).catch((error: unknown) => {
+    const signal = params.resolveSourceSyncSignal?.();
+    if (params.resolveSourceSyncSignal && !signal) {
+      return;
+    }
+    void syncMemoryWikiImportedSources({
+      config,
+      appConfig,
+      ...(signal ? { signal } : {}),
+    }).catch((error: unknown) => {
+      if (signal?.aborted) {
+        return;
+      }
       setMemoryWikiDashboardState(config, { state: "failed" });
       api.logger.warn(`memory-wiki: background source sync failed: ${formatErrorMessage(error)}`);
     });

--- a/extensions/memory-wiki/src/gateway.ts
+++ b/extensions/memory-wiki/src/gateway.ts
@@ -1,10 +1,15 @@
 // Memory Wiki plugin module implements gateway behavior.
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
+import { ErrorCodes, errorShape } from "openclaw/plugin-sdk/gateway-runtime";
 import { resolveDefaultAgentId } from "openclaw/plugin-sdk/memory-host-core";
 import { readPositiveIntegerParam } from "openclaw/plugin-sdk/param-readers";
 import type { OpenClawConfig, OpenClawPluginApi } from "../api.js";
 import { applyMemoryWikiMutation, normalizeMemoryWikiMutationInput } from "./apply.js";
 import { compileMemoryWikiVault } from "./compile.js";
+import {
+  MemoryWikiDashboardUnavailableError,
+  setMemoryWikiDashboardState,
+} from "./compiled-cache.js";
 import {
   resolveMemoryWikiAgentConfig,
   WIKI_SEARCH_BACKENDS,
@@ -74,6 +79,22 @@ function readEnumParam<T extends string>(
 }
 
 function respondError(respond: GatewayRespond, error: unknown) {
+  if (error instanceof MemoryWikiDashboardUnavailableError) {
+    const retryable = error.state === "rebuilding";
+    respond(
+      false,
+      undefined,
+      errorShape(
+        error.state === "compile-required" ? ErrorCodes.INVALID_REQUEST : ErrorCodes.UNAVAILABLE,
+        error.message,
+        {
+          details: { state: error.state },
+          ...(retryable ? { retryable: true, retryAfterMs: 500 } : {}),
+        },
+      ),
+    );
+    return;
+  }
   const message = formatErrorMessage(error);
   respond(false, undefined, { code: "internal_error", message });
 }
@@ -93,6 +114,16 @@ export function registerMemoryWikiGatewayMethods(params: {
   resolveConfig?: (agentId?: string, appConfig?: OpenClawConfig) => ResolvedMemoryWikiConfig;
 }) {
   const { api, config: baseConfig } = params;
+
+  const syncImportedSourcesInBackground = (
+    config: ResolvedMemoryWikiConfig,
+    appConfig?: OpenClawConfig,
+  ) => {
+    void syncMemoryWikiImportedSources({ config, appConfig }).catch((error: unknown) => {
+      setMemoryWikiDashboardState(config, { state: "failed" });
+      api.logger.warn(`memory-wiki: background source sync failed: ${formatErrorMessage(error)}`);
+    });
+  };
 
   const getAppConfig = () => {
     if (params.getAppConfig) {
@@ -166,7 +197,7 @@ export function registerMemoryWikiGatewayMethods(params: {
     async ({ params: requestParams, respond }) => {
       try {
         const { appConfig, config } = resolveRequestContext(requestParams);
-        await syncImportedSourcesIfNeeded(config, appConfig);
+        syncImportedSourcesInBackground(config, appConfig);
         respond(true, await listMemoryWikiImportInsights(config));
       } catch (error) {
         respondError(respond, error);
@@ -183,7 +214,7 @@ export function registerMemoryWikiGatewayMethods(params: {
     async ({ params: requestParams, respond }) => {
       try {
         const { appConfig, config } = resolveRequestContext(requestParams);
-        await syncImportedSourcesIfNeeded(config, appConfig);
+        syncImportedSourcesInBackground(config, appConfig);
         respond(true, await listMemoryWikiOverview(config));
       } catch (error) {
         respondError(respond, error);

--- a/extensions/memory-wiki/src/import-insights.test.ts
+++ b/extensions/memory-wiki/src/import-insights.test.ts
@@ -2,6 +2,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
+import { compileMemoryWikiVault } from "./compile.js";
 import { listMemoryWikiImportInsights } from "./import-insights.js";
 import { renderWikiMarkdown } from "./markdown.js";
 import { createMemoryWikiTestHarness } from "./test-helpers.js";
@@ -30,6 +31,7 @@ describe("listMemoryWikiImportInsights", () => {
   it("clusters ChatGPT import pages by topic and extracts digest fields", async () => {
     const { rootDir, config } = await createVault({
       prefix: "memory-wiki-import-insights-",
+      config: { render: { createBacklinks: false, createDashboards: false } },
       initialize: true,
     });
     await fs.mkdir(path.join(rootDir, "sources"), { recursive: true });
@@ -109,6 +111,12 @@ describe("listMemoryWikiImportInsights", () => {
       "utf8",
     );
 
+    await compileMemoryWikiVault(config);
+    await Promise.all([
+      fs.unlink(path.join(rootDir, "sources", "chatgpt-travel.md")),
+      fs.unlink(path.join(rootDir, "sources", "chatgpt-health.md")),
+    ]);
+
     const result = await listMemoryWikiImportInsights(config);
 
     expect(result.sourceType).toBe("chatgpt");
@@ -161,6 +169,7 @@ describe("listMemoryWikiImportInsights", () => {
   it("truncates import insight summaries without leaving lone surrogates", async () => {
     const { rootDir, config } = await createVault({
       prefix: "memory-wiki-import-insights-surrogate-",
+      config: { render: { createBacklinks: false, createDashboards: false } },
       initialize: true,
     });
     await fs.mkdir(path.join(rootDir, "sources"), { recursive: true });
@@ -202,6 +211,8 @@ describe("listMemoryWikiImportInsights", () => {
       }),
       "utf8",
     );
+
+    await compileMemoryWikiVault(config);
 
     const result = await listMemoryWikiImportInsights(config);
 

--- a/extensions/memory-wiki/src/import-insights.ts
+++ b/extensions/memory-wiki/src/import-insights.ts
@@ -2,7 +2,7 @@ import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runti
 import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 // Memory Wiki plugin module implements import insights behavior.
 import {
-  loadMemoryWikiCompiledCache,
+  loadMemoryWikiCompiledDashboards,
   MEMORY_WIKI_DASHBOARD_ITEM_LIMIT,
   type MemoryWikiImportInsightCluster,
   type MemoryWikiImportInsightItem,
@@ -290,11 +290,7 @@ function capImportInsightItem(item: MemoryWikiImportInsightItem): MemoryWikiImpo
 export async function listMemoryWikiImportInsights(
   config: ResolvedMemoryWikiConfig,
 ): Promise<MemoryWikiImportInsightsStatus> {
-  const snapshot = await loadMemoryWikiCompiledCache(config);
-  if (!snapshot?.dashboards) {
-    throw new Error('Memory Wiki has no compiled dashboard snapshot. Run "openclaw wiki compile".');
-  }
-  return snapshot.dashboards.importInsights;
+  return (await loadMemoryWikiCompiledDashboards(config)).importInsights;
 }
 
 export function projectMemoryWikiImportInsight(

--- a/extensions/memory-wiki/src/import-insights.ts
+++ b/extensions/memory-wiki/src/import-insights.ts
@@ -3,6 +3,8 @@ import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 // Memory Wiki plugin module implements import insights behavior.
 import {
   loadMemoryWikiCompiledCache,
+  MEMORY_WIKI_DASHBOARD_ITEM_LIMIT,
+  type MemoryWikiImportInsightCluster,
   type MemoryWikiImportInsightItem,
   type MemoryWikiImportInsightsStatus,
 } from "./compiled-cache.js";
@@ -259,11 +261,37 @@ function compareItemsByUpdated(
   return left.title.localeCompare(right.title);
 }
 
+function capStrings(values: string[], maxItems: number, maxChars: number): string[] {
+  return values.slice(0, maxItems).map((value) => shortenSentence(value, maxChars));
+}
+
+function capImportInsightItem(item: MemoryWikiImportInsightItem): MemoryWikiImportInsightItem {
+  return {
+    ...item,
+    title: shortenSentence(item.title, 240),
+    riskReasons: capStrings(item.riskReasons, 8, 120),
+    labels: capStrings(item.labels, 8, 120),
+    topicKey: shortenSentence(item.topicKey, 120),
+    topicLabel: shortenSentence(item.topicLabel, 120),
+    ...(item.firstUserLine ? { firstUserLine: shortenSentence(item.firstUserLine, 240) } : {}),
+    ...(item.lastUserLine ? { lastUserLine: shortenSentence(item.lastUserLine, 240) } : {}),
+    ...(item.assistantOpener
+      ? { assistantOpener: shortenSentence(item.assistantOpener, 240) }
+      : {}),
+    summary: shortenSentence(item.summary, 180),
+    candidateSignals: capStrings(item.candidateSignals, 4, 240),
+    correctionSignals: capStrings(item.correctionSignals, 2, 160),
+    preferenceSignals: capStrings(item.preferenceSignals, 8, 240),
+    ...(item.createdAt ? { createdAt: shortenSentence(item.createdAt, 64) } : {}),
+    ...(item.updatedAt ? { updatedAt: shortenSentence(item.updatedAt, 64) } : {}),
+  };
+}
+
 export async function listMemoryWikiImportInsights(
   config: ResolvedMemoryWikiConfig,
 ): Promise<MemoryWikiImportInsightsStatus> {
   const snapshot = await loadMemoryWikiCompiledCache(config);
-  if (!snapshot) {
+  if (!snapshot?.dashboards) {
     throw new Error('Memory Wiki has no compiled dashboard snapshot. Run "openclaw wiki compile".');
   }
   return snapshot.dashboards.importInsights;
@@ -344,7 +372,8 @@ export function projectMemoryWikiImportInsight(
 export function buildMemoryWikiImportInsights(
   input: MemoryWikiImportInsightItem[],
 ): MemoryWikiImportInsightsStatus {
-  const items = [...input].toSorted(compareItemsByUpdated);
+  const allItems = input.map(capImportInsightItem).toSorted(compareItemsByUpdated);
+  const items = allItems.slice(0, MEMORY_WIKI_DASHBOARD_ITEM_LIMIT);
 
   const clustersByKey = new Map<string, MemoryWikiImportInsightItem[]>();
   for (const item of items) {
@@ -389,8 +418,9 @@ export function buildMemoryWikiImportInsights(
 
   return {
     sourceType: "chatgpt",
-    totalItems: items.length,
-    totalClusters: clusters.length,
+    totalItems: allItems.length,
+    totalClusters: new Set(allItems.map((item) => item.topicKey)).size,
     clusters,
+    truncated: items.length < allItems.length,
   };
 }

--- a/extensions/memory-wiki/src/import-insights.ts
+++ b/extensions/memory-wiki/src/import-insights.ts
@@ -1,50 +1,13 @@
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 // Memory Wiki plugin module implements import insights behavior.
-import { loadMemoryWikiCompiledCache } from "./compiled-cache.js";
+import {
+  loadMemoryWikiCompiledCache,
+  type MemoryWikiImportInsightItem,
+  type MemoryWikiImportInsightsStatus,
+} from "./compiled-cache.js";
 import type { ResolvedMemoryWikiConfig } from "./config.js";
 import type { WikiPageSummary } from "./markdown.js";
-
-export type MemoryWikiImportInsightItem = {
-  pagePath: string;
-  title: string;
-  riskLevel: "low" | "medium" | "high" | "unknown";
-  riskReasons: string[];
-  labels: string[];
-  topicKey: string;
-  topicLabel: string;
-  digestStatus: "available" | "withheld";
-  activeBranchMessages: number;
-  userMessageCount: number;
-  assistantMessageCount: number;
-  firstUserLine?: string;
-  lastUserLine?: string;
-  assistantOpener?: string;
-  summary: string;
-  candidateSignals: string[];
-  correctionSignals: string[];
-  preferenceSignals: string[];
-  createdAt?: string;
-  updatedAt?: string;
-};
-
-type MemoryWikiImportInsightCluster = {
-  key: string;
-  label: string;
-  itemCount: number;
-  highRiskCount: number;
-  withheldCount: number;
-  preferenceSignalCount: number;
-  updatedAt?: string;
-  items: MemoryWikiImportInsightItem[];
-};
-
-export type MemoryWikiImportInsightsStatus = {
-  sourceType: "chatgpt";
-  totalItems: number;
-  totalClusters: number;
-  clusters: MemoryWikiImportInsightCluster[];
-};
 
 function normalizeStringArray(value: unknown): string[] {
   if (!Array.isArray(value)) {

--- a/extensions/memory-wiki/src/import-insights.ts
+++ b/extensions/memory-wiki/src/import-insights.ts
@@ -1,11 +1,11 @@
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 // Memory Wiki plugin module implements import insights behavior.
+import { loadMemoryWikiCompiledCache } from "./compiled-cache.js";
 import type { ResolvedMemoryWikiConfig } from "./config.js";
-import { parseWikiMarkdown } from "./markdown.js";
-import { readQueryableWikiPages } from "./query.js";
+import type { WikiPageSummary } from "./markdown.js";
 
-type MemoryWikiImportInsightItem = {
+export type MemoryWikiImportInsightItem = {
   pagePath: string;
   title: string;
   riskLevel: "low" | "medium" | "high" | "unknown";
@@ -39,7 +39,7 @@ type MemoryWikiImportInsightCluster = {
   items: MemoryWikiImportInsightItem[];
 };
 
-type MemoryWikiImportInsightsStatus = {
+export type MemoryWikiImportInsightsStatus = {
   sourceType: "chatgpt";
   totalItems: number;
   totalClusters: number;
@@ -299,89 +299,89 @@ function compareItemsByUpdated(
 export async function listMemoryWikiImportInsights(
   config: ResolvedMemoryWikiConfig,
 ): Promise<MemoryWikiImportInsightsStatus> {
-  const pages = await readQueryableWikiPages(config.vault.path);
-  const items = pages
-    .flatMap((page) => {
-      if (page.pageType !== "source") {
-        return [];
-      }
-      const parsed = parseWikiMarkdown(page.raw);
-      if (parsed.frontmatter.sourceType !== "chatgpt-export") {
-        return [];
-      }
-      const labels = normalizeStringArray(parsed.frontmatter.labels);
-      const topic = resolveTopic(labels);
-      const triageLines = extractHeadingSection(parsed.body, "Auto Triage");
-      const digestLines = extractHeadingSection(parsed.body, "Auto Digest");
-      const transcriptTurns = parseTranscriptTurns(parsed.body);
-      const digestStatus = digestLines.some((line) =>
-        line.toLowerCase().includes("withheld from durable-candidate generation"),
-      )
-        ? "withheld"
-        : "available";
-      const exposeImportContent = shouldExposeImportContent(digestStatus);
-      const userTurns = transcriptTurns.filter((turn) => turn.role === "user");
-      const assistantTurns = transcriptTurns.filter((turn) => turn.role === "assistant");
-      const assistantOpener = exposeImportContent
-        ? firstParagraph(assistantTurns[0]?.text ?? "")
-        : undefined;
-      const correctionSignals = exposeImportContent
-        ? extractCorrectionSignals(transcriptTurns)
-        : [];
-      const preferenceSignals = exposeImportContent ? extractPreferenceSignals(digestLines) : [];
-      const candidateSignals = exposeImportContent
-        ? deriveCandidateSignals({
-            preferenceSignals,
-            correctionSignals,
-          })
-        : [];
-      const firstUserLine = exposeImportContent
-        ? extractDigestField(digestLines, "First user line")
-        : undefined;
-      const lastUserLine = exposeImportContent
-        ? extractDigestField(digestLines, "Last user line")
-        : undefined;
-      const createdAt = normalizeOptionalString(parsed.frontmatter.createdAt);
-      const updatedAt = normalizeOptionalString(parsed.frontmatter.updatedAt);
-      return [
-        {
-          pagePath: page.relativePath,
-          title: page.title.replace(/^ChatGPT Export:\s*/i, ""),
-          riskLevel: normalizeRiskLevel(parsed.frontmatter.riskLevel),
-          riskReasons: normalizeStringArray(parsed.frontmatter.riskReasons),
-          labels,
-          topicKey: topic.key,
-          topicLabel: topic.label,
-          digestStatus,
-          activeBranchMessages: extractIntegerField(triageLines, "Active-branch messages"),
-          userMessageCount: Math.max(
-            extractIntegerField(digestLines, "User messages"),
-            userTurns.length,
-          ),
-          assistantMessageCount: Math.max(
-            extractIntegerField(digestLines, "Assistant messages"),
-            assistantTurns.length,
-          ),
-          ...(firstUserLine ? { firstUserLine } : {}),
-          ...(lastUserLine ? { lastUserLine } : {}),
-          ...(assistantOpener ? { assistantOpener } : {}),
-          summary: deriveSummary({
-            title: page.title.replace(/^ChatGPT Export:\s*/i, ""),
-            digestStatus,
-            ...(assistantOpener ? { assistantOpener } : {}),
-            ...(firstUserLine ? { firstUserLine } : {}),
-            riskReasons: normalizeStringArray(parsed.frontmatter.riskReasons),
-            topicLabel: topic.label,
-          }),
-          candidateSignals,
-          correctionSignals,
-          preferenceSignals,
-          ...(createdAt ? { createdAt } : {}),
-          ...(updatedAt ? { updatedAt } : {}),
-        } satisfies MemoryWikiImportInsightItem,
-      ];
-    })
-    .toSorted(compareItemsByUpdated);
+  const snapshot = await loadMemoryWikiCompiledCache(config);
+  if (!snapshot) {
+    throw new Error('Memory Wiki has no compiled dashboard snapshot. Run "openclaw wiki compile".');
+  }
+  return snapshot.dashboards.importInsights;
+}
+
+export function projectMemoryWikiImportInsight(
+  page: WikiPageSummary,
+  parsed: { frontmatter: Record<string, unknown>; body: string },
+): MemoryWikiImportInsightItem | null {
+  if (page.pageType !== "source" || parsed.frontmatter.sourceType !== "chatgpt-export") {
+    return null;
+  }
+  const labels = normalizeStringArray(parsed.frontmatter.labels);
+  const topic = resolveTopic(labels);
+  const triageLines = extractHeadingSection(parsed.body, "Auto Triage");
+  const digestLines = extractHeadingSection(parsed.body, "Auto Digest");
+  const transcriptTurns = parseTranscriptTurns(parsed.body);
+  const digestStatus = digestLines.some((line) =>
+    line.toLowerCase().includes("withheld from durable-candidate generation"),
+  )
+    ? "withheld"
+    : "available";
+  const exposeImportContent = shouldExposeImportContent(digestStatus);
+  const userTurns = transcriptTurns.filter((turn) => turn.role === "user");
+  const assistantTurns = transcriptTurns.filter((turn) => turn.role === "assistant");
+  const assistantOpener = exposeImportContent
+    ? firstParagraph(assistantTurns[0]?.text ?? "")
+    : undefined;
+  const correctionSignals = exposeImportContent ? extractCorrectionSignals(transcriptTurns) : [];
+  const preferenceSignals = exposeImportContent ? extractPreferenceSignals(digestLines) : [];
+  const candidateSignals = exposeImportContent
+    ? deriveCandidateSignals({ preferenceSignals, correctionSignals })
+    : [];
+  const firstUserLine = exposeImportContent
+    ? extractDigestField(digestLines, "First user line")
+    : undefined;
+  const lastUserLine = exposeImportContent
+    ? extractDigestField(digestLines, "Last user line")
+    : undefined;
+  const createdAt = normalizeOptionalString(parsed.frontmatter.createdAt);
+  const updatedAt = normalizeOptionalString(parsed.frontmatter.updatedAt);
+  const title = page.title.replace(/^ChatGPT Export:\s*/i, "");
+  const riskReasons = normalizeStringArray(parsed.frontmatter.riskReasons);
+  return {
+    pagePath: page.relativePath,
+    title,
+    riskLevel: normalizeRiskLevel(parsed.frontmatter.riskLevel),
+    riskReasons,
+    labels,
+    topicKey: topic.key,
+    topicLabel: topic.label,
+    digestStatus,
+    activeBranchMessages: extractIntegerField(triageLines, "Active-branch messages"),
+    userMessageCount: Math.max(extractIntegerField(digestLines, "User messages"), userTurns.length),
+    assistantMessageCount: Math.max(
+      extractIntegerField(digestLines, "Assistant messages"),
+      assistantTurns.length,
+    ),
+    ...(firstUserLine ? { firstUserLine } : {}),
+    ...(lastUserLine ? { lastUserLine } : {}),
+    ...(assistantOpener ? { assistantOpener } : {}),
+    summary: deriveSummary({
+      title,
+      digestStatus,
+      ...(assistantOpener ? { assistantOpener } : {}),
+      ...(firstUserLine ? { firstUserLine } : {}),
+      riskReasons,
+      topicLabel: topic.label,
+    }),
+    candidateSignals,
+    correctionSignals,
+    preferenceSignals,
+    ...(createdAt ? { createdAt } : {}),
+    ...(updatedAt ? { updatedAt } : {}),
+  };
+}
+
+export function buildMemoryWikiImportInsights(
+  input: MemoryWikiImportInsightItem[],
+): MemoryWikiImportInsightsStatus {
+  const items = [...input].toSorted(compareItemsByUpdated);
 
   const clustersByKey = new Map<string, MemoryWikiImportInsightItem[]>();
   for (const item of items) {

--- a/extensions/memory-wiki/src/ingest.ts
+++ b/extensions/memory-wiki/src/ingest.ts
@@ -70,10 +70,16 @@ async function ingestMemoryWikiSourceUnlocked(params: {
   inputPath: string;
   title?: string;
   nowMs?: number;
+  signal?: AbortSignal;
 }): Promise<IngestMemoryWikiSourceResult> {
-  await initializeMemoryWikiVault(params.config, { nowMs: params.nowMs });
+  await initializeMemoryWikiVault(params.config, {
+    ...(params.nowMs !== undefined ? { nowMs: params.nowMs } : {}),
+    ...(params.signal ? { signal: params.signal } : {}),
+  });
+  params.signal?.throwIfAborted();
   const sourcePath = path.resolve(params.inputPath);
   const buffer = await fs.readFile(sourcePath);
+  params.signal?.throwIfAborted();
   const content = assertUtf8Text(buffer, sourcePath);
   const title = resolveSourceTitle(sourcePath, params.title);
   const slug = slugifyWikiSegment(title);
@@ -115,11 +121,13 @@ async function ingestMemoryWikiSourceUnlocked(params: {
   });
 
   const existing = created ? "" : await readExistingSourcePage(pagePath);
+  params.signal?.throwIfAborted();
   await fs.writeFile(
     pagePath,
     existing ? preserveHumanNotesBlock(markdown, existing) : markdown,
     "utf8",
   );
+  params.signal?.throwIfAborted();
   await appendMemoryWikiLog(params.config.vault.path, {
     type: "ingest",
     timestamp,
@@ -131,7 +139,11 @@ async function ingestMemoryWikiSourceUnlocked(params: {
       created,
     },
   });
-  const compile = await compileMemoryWikiVault(params.config);
+  params.signal?.throwIfAborted();
+  const compile = await compileMemoryWikiVault(
+    params.config,
+    params.signal ? { signal: params.signal } : undefined,
+  );
 
   return {
     sourcePath,
@@ -149,6 +161,7 @@ export async function ingestMemoryWikiSource(params: {
   inputPath: string;
   title?: string;
   nowMs?: number;
+  signal?: AbortSignal;
 }): Promise<IngestMemoryWikiSourceResult> {
   // Ingest read-modify-writes the source page and recompiles the vault; hold
   // the vault mutation lock across the whole span so it cannot interleave

--- a/extensions/memory-wiki/src/lint.ts
+++ b/extensions/memory-wiki/src/lint.ts
@@ -517,8 +517,13 @@ async function writeLintReport(rootDir: string, issues: MemoryWikiLintIssue[]): 
 
 export async function lintMemoryWikiVault(
   config: ResolvedMemoryWikiConfig,
+  options: { signal?: AbortSignal } = {},
 ): Promise<LintMemoryWikiResult> {
-  const compileResult = await compileMemoryWikiVault(config);
+  const compileResult = await compileMemoryWikiVault(
+    config,
+    options.signal ? { signal: options.signal } : undefined,
+  );
+  options.signal?.throwIfAborted();
   const sourceSyncState = await readMemoryWikiSourceSyncState(config.vault.path);
   const managedImportedSourcePagePaths = new Set(
     Object.values(sourceSyncState.entries).map((entry) => entry.pagePath.split(path.sep).join("/")),
@@ -537,6 +542,7 @@ export async function lintMemoryWikiVault(
   ].toSorted((left, right) => left.path.localeCompare(right.path));
   const issuesByCategory = buildIssuesByCategory(issues);
   const reportPath = await writeLintReport(config.vault.path, issues);
+  options.signal?.throwIfAborted();
 
   await appendMemoryWikiLog(config.vault.path, {
     type: "lint",

--- a/extensions/memory-wiki/src/prompt-section.test.ts
+++ b/extensions/memory-wiki/src/prompt-section.test.ts
@@ -94,6 +94,18 @@ async function seedCompiledDigest(params: {
       })),
     },
     claims: [],
+    dashboards: {
+      importInsights: { sourceType: "chatgpt", totalItems: 0, totalClusters: 0, clusters: [] },
+      overview: {
+        totalItems: 0,
+        totalPages: 0,
+        pageCounts: { synthesis: 0, entity: 0, concept: 0, source: 0, report: 0 },
+        totalClaims: 0,
+        totalQuestions: 0,
+        totalContradictions: 0,
+        clusters: [],
+      },
+    },
   };
   const publicationId = createMemoryWikiCompiledCachePublicationId();
   const reservationId = createMemoryWikiCompiledCachePublicationId();

--- a/extensions/memory-wiki/src/prompt-section.test.ts
+++ b/extensions/memory-wiki/src/prompt-section.test.ts
@@ -95,7 +95,13 @@ async function seedCompiledDigest(params: {
     },
     claims: [],
     dashboards: {
-      importInsights: { sourceType: "chatgpt", totalItems: 0, totalClusters: 0, clusters: [] },
+      importInsights: {
+        sourceType: "chatgpt",
+        totalItems: 0,
+        totalClusters: 0,
+        clusters: [],
+        truncated: false,
+      },
       overview: {
         totalItems: 0,
         totalPages: 0,
@@ -104,6 +110,7 @@ async function seedCompiledDigest(params: {
         totalQuestions: 0,
         totalContradictions: 0,
         clusters: [],
+        truncated: false,
       },
     },
   };

--- a/extensions/memory-wiki/src/source-page-shared.ts
+++ b/extensions/memory-wiki/src/source-page-shared.ts
@@ -43,6 +43,7 @@ export async function writeImportedSourcePage(params: {
   pagePath: string;
   group: MemoryWikiImportedSourceGroup;
   state: ImportedSourceState;
+  prepareWrite?: () => Promise<unknown>;
   buildRendered: (raw: string, updatedAt: string) => string;
 }): Promise<{ pagePath: string; changed: boolean; created: boolean }> {
   const shouldSkip = await shouldSkipImportedSourceWrite({
@@ -59,6 +60,9 @@ export async function writeImportedSourcePage(params: {
     return { pagePath: params.pagePath, changed: false, created: false };
   }
 
+  // Source metadata checks stay outside vault activation. This boundary keeps
+  // unchanged import polls from validating and rereading every retained page.
+  await params.prepareWrite?.();
   const vault = await fsRoot(params.vaultRoot);
   const pageStat = await vault.stat(params.pagePath).catch((error: unknown) => {
     if (

--- a/extensions/memory-wiki/src/source-sync-state.ts
+++ b/extensions/memory-wiki/src/source-sync-state.ts
@@ -435,6 +435,7 @@ export async function pruneImportedSourceEntries(params: {
   group: MemoryWikiImportedSourceGroup;
   activeKeys: Set<string>;
   state: MemoryWikiImportedSourceState;
+  prepareWrite?: () => Promise<unknown>;
 }): Promise<number> {
   let removedCount = 0;
   let vault: Awaited<ReturnType<typeof fsRoot>> | undefined;
@@ -442,6 +443,9 @@ export async function pruneImportedSourceEntries(params: {
     if (entry.group !== params.group || params.activeKeys.has(syncKey)) {
       continue;
     }
+    // Pruning is the first vault mutation when every active source was unchanged.
+    // Activate here so no-change polls keep using the process snapshot.
+    await params.prepareWrite?.();
     try {
       vault ??= await fsRoot(params.vaultRoot);
     } catch (error) {

--- a/extensions/memory-wiki/src/source-sync.ts
+++ b/extensions/memory-wiki/src/source-sync.ts
@@ -21,11 +21,13 @@ export type MemoryWikiImportedSourceSyncResult = BridgeMemoryWikiResult & {
 type SyncMemoryWikiImportedSourcesParams = {
   config: ResolvedMemoryWikiConfig;
   appConfig?: OpenClawConfig;
+  signal?: AbortSignal;
 };
 
 type ActiveImportedSourceSync = {
   requestKey: string;
   appConfig?: OpenClawConfig;
+  signal?: AbortSignal;
   promise: Promise<MemoryWikiImportedSourceSyncResult>;
 };
 
@@ -47,11 +49,14 @@ function resolveImportedSourceSyncRequestKey(
 async function syncMemoryWikiImportedSourcesOnce(
   params: SyncMemoryWikiImportedSourcesParams,
 ): Promise<MemoryWikiImportedSourceSyncResult> {
+  params.signal?.throwIfAborted();
   let syncResult: BridgeMemoryWikiResult;
   if (params.config.vaultMode === "bridge") {
     syncResult = await syncMemoryWikiBridgeSources(params);
   } else if (params.config.vaultMode === "unsafe-local") {
-    syncResult = await syncMemoryWikiUnsafeLocalSources(params.config);
+    syncResult = params.signal
+      ? await syncMemoryWikiUnsafeLocalSources(params.config, { signal: params.signal })
+      : await syncMemoryWikiUnsafeLocalSources(params.config);
   } else {
     syncResult = {
       importedCount: 0,
@@ -63,9 +68,11 @@ async function syncMemoryWikiImportedSourcesOnce(
       pagePaths: [],
     };
   }
+  params.signal?.throwIfAborted();
   const refreshResult = await refreshMemoryWikiIndexesAfterImport({
     config: params.config,
     syncResult,
+    ...(params.signal ? { signal: params.signal } : {}),
   });
   return {
     ...syncResult,
@@ -82,7 +89,10 @@ export async function syncMemoryWikiImportedSources(
   const requestKey = resolveImportedSourceSyncRequestKey(params, vaultKey);
   const active = activeImportedSourceSyncs.get(vaultKey) ?? [];
   const matching = active.find(
-    (entry) => entry.requestKey === requestKey && entry.appConfig === params.appConfig,
+    (entry) =>
+      entry.requestKey === requestKey &&
+      entry.appConfig === params.appConfig &&
+      entry.signal === params.signal,
   );
   if (matching) {
     return await matching.promise;
@@ -90,12 +100,14 @@ export async function syncMemoryWikiImportedSources(
 
   // Equivalent polls share the whole source-and-index flight. Different
   // snapshots still queue on the common vault transaction boundary.
-  const promise = withMemoryWikiVaultMutation(params.config.vault.path, () =>
-    syncMemoryWikiImportedSourcesOnce(params),
-  );
+  const promise = withMemoryWikiVaultMutation(params.config.vault.path, () => {
+    params.signal?.throwIfAborted();
+    return syncMemoryWikiImportedSourcesOnce(params);
+  });
   const entry: ActiveImportedSourceSync = {
     requestKey,
     ...(params.appConfig ? { appConfig: params.appConfig } : {}),
+    ...(params.signal ? { signal: params.signal } : {}),
     promise,
   };
   active.push(entry);

--- a/extensions/memory-wiki/src/source-sync.ts
+++ b/extensions/memory-wiki/src/source-sync.ts
@@ -113,3 +113,11 @@ export async function syncMemoryWikiImportedSources(
     }
   }
 }
+
+export async function waitForMemoryWikiImportedSourceSyncs(): Promise<void> {
+  await Promise.allSettled(
+    [...activeImportedSourceSyncs.values()].flatMap((entries) =>
+      entries.map((entry) => entry.promise),
+    ),
+  );
+}

--- a/extensions/memory-wiki/src/tool.ts
+++ b/extensions/memory-wiki/src/tool.ts
@@ -106,8 +106,13 @@ const WikiApplySchema = Type.Object(
 async function syncImportedSourcesIfNeeded(
   config: ResolvedMemoryWikiConfig,
   appConfig?: OpenClawConfig,
+  signal?: AbortSignal,
 ) {
-  await syncMemoryWikiImportedSources({ config, appConfig });
+  await syncMemoryWikiImportedSources({
+    config,
+    appConfig,
+    ...(signal ? { signal } : {}),
+  });
 }
 
 type WikiToolMemoryContext = {
@@ -115,6 +120,7 @@ type WikiToolMemoryContext = {
   agentSessionKey?: string;
   sandboxed?: boolean;
   conversationRecall?: OpenClawPluginToolContext["conversationRecall"];
+  signal?: AbortSignal;
 };
 
 export function createWikiStatusTool(
@@ -129,7 +135,7 @@ export function createWikiStatusTool(
       "Inspect the current memory wiki vault mode, health, and Obsidian CLI availability.",
     parameters: WikiStatusSchema,
     execute: async () => {
-      await syncImportedSourcesIfNeeded(config, appConfig);
+      await syncImportedSourcesIfNeeded(config, appConfig, memoryContext.signal);
       const status = await resolveMemoryWikiStatus(config, {
         appConfig,
         callerAgentId: memoryContext.agentId,
@@ -161,7 +167,7 @@ export function createWikiSearchTool(
         corpus?: ResolvedMemoryWikiConfig["search"]["corpus"];
         mode?: (typeof WIKI_SEARCH_MODES)[number];
       };
-      await syncImportedSourcesIfNeeded(config, appConfig);
+      await syncImportedSourcesIfNeeded(config, appConfig, memoryContext.signal);
       const results = await searchMemoryWiki({
         config,
         appConfig,
@@ -195,6 +201,7 @@ export function createWikiSearchTool(
 export function createWikiLintTool(
   config: ResolvedMemoryWikiConfig,
   appConfig?: OpenClawConfig,
+  signal?: AbortSignal,
 ): AnyAgentTool {
   return {
     name: "wiki_lint",
@@ -203,8 +210,8 @@ export function createWikiLintTool(
       "Lint the wiki vault and surface structural issues, provenance gaps, contradictions, and open questions.",
     parameters: WikiLintSchema,
     execute: async () => {
-      await syncImportedSourcesIfNeeded(config, appConfig);
-      const result = await lintMemoryWikiVault(config);
+      await syncImportedSourcesIfNeeded(config, appConfig, signal);
+      const result = await lintMemoryWikiVault(config, signal ? { signal } : undefined);
       const contradictions = result.issuesByCategory.contradictions.length;
       const openQuestions = result.issuesByCategory["open-questions"].length;
       const provenance = result.issuesByCategory.provenance.length;
@@ -237,6 +244,7 @@ export function createWikiLintTool(
 export function createWikiApplyTool(
   config: ResolvedMemoryWikiConfig,
   appConfig?: OpenClawConfig,
+  signal?: AbortSignal,
 ): AnyAgentTool {
   return {
     name: "wiki_apply",
@@ -246,8 +254,12 @@ export function createWikiApplyTool(
     parameters: WikiApplySchema,
     execute: async (_toolCallId, rawParams) => {
       const mutation = normalizeMemoryWikiMutationInput(rawParams);
-      await syncImportedSourcesIfNeeded(config, appConfig);
-      const result = await applyMemoryWikiMutation({ config, mutation });
+      await syncImportedSourcesIfNeeded(config, appConfig, signal);
+      const result = await applyMemoryWikiMutation({
+        config,
+        mutation,
+        ...(signal ? { signal } : {}),
+      });
       const action = result.changed ? "Updated" : "No changes for";
       const compileSummary =
         result.compile.updatedFiles.length > 0
@@ -292,7 +304,7 @@ export function createWikiGetTool(
           details: { found: false },
         };
       }
-      await syncImportedSourcesIfNeeded(config, appConfig);
+      await syncImportedSourcesIfNeeded(config, appConfig, memoryContext.signal);
       const result = await getMemoryWikiPage({
         config,
         appConfig,

--- a/extensions/memory-wiki/src/unsafe-local.test.ts
+++ b/extensions/memory-wiki/src/unsafe-local.test.ts
@@ -2,7 +2,7 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import { createMemoryWikiTestHarness } from "./test-helpers.js";
 import { syncMemoryWikiUnsafeLocalSources } from "./unsafe-local.js";
 
@@ -21,6 +21,10 @@ describe("syncMemoryWikiUnsafeLocalSources", () => {
       return;
     }
     await fs.rm(fixtureRoot, { recursive: true, force: true });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
   });
 
   function nextCaseRoot(name: string): string {
@@ -66,12 +70,18 @@ describe("syncMemoryWikiUnsafeLocalSources", () => {
     expect(page).toContain("sourceType: memory-unsafe-local");
     expect(page).toContain("provenanceMode: unsafe-local");
 
+    const readFile = vi.spyOn(fs, "readFile");
     const second = await syncMemoryWikiUnsafeLocalSources(config);
 
     expect(second.importedCount).toBe(0);
     expect(second.updatedCount).toBe(0);
     expect(second.skippedCount).toBe(3);
     expect(second.removedCount).toBe(0);
+    expect(
+      readFile.mock.calls.some(
+        ([filePath]) => typeof filePath === "string" && filePath.startsWith(vaultDir),
+      ),
+    ).toBe(false);
   });
 
   it.each([

--- a/extensions/memory-wiki/src/unsafe-local.ts
+++ b/extensions/memory-wiki/src/unsafe-local.ts
@@ -146,6 +146,7 @@ async function writeUnsafeLocalSourcePage(params: {
   sourceUpdatedAtMs: number;
   sourceSize: number;
   state: Awaited<ReturnType<typeof readMemoryWikiSourceSyncState>>;
+  prepareWrite: () => Promise<unknown>;
 }): Promise<{ pagePath: string; changed: boolean; created: boolean }> {
   const { pageId, pagePath } = resolveUnsafeLocalPagePath({
     configuredPath: params.artifact.configuredPath,
@@ -170,6 +171,7 @@ async function writeUnsafeLocalSourcePage(params: {
     pagePath,
     group: "unsafe-local",
     state: params.state,
+    prepareWrite: params.prepareWrite,
     buildRendered: (raw, updatedAt) =>
       renderWikiMarkdown({
         frontmatter: {
@@ -207,7 +209,6 @@ async function writeUnsafeLocalSourcePage(params: {
 export async function syncMemoryWikiUnsafeLocalSources(
   config: ResolvedMemoryWikiConfig,
 ): Promise<BridgeMemoryWikiResult> {
-  await initializeMemoryWikiVault(config);
   if (
     config.vaultMode !== "unsafe-local" ||
     !config.unsafeLocal.allowPrivateMemoryCoreAccess ||
@@ -228,6 +229,8 @@ export async function syncMemoryWikiUnsafeLocalSources(
     config.unsafeLocal.paths,
   );
   const state = await readMemoryWikiSourceSyncState(config.vault.path);
+  let initializePromise: ReturnType<typeof initializeMemoryWikiVault> | undefined;
+  const prepareWrite = () => (initializePromise ??= initializeMemoryWikiVault(config));
   const activeKeys = new Set<string>();
   for (const [syncKey, entry] of Object.entries(state.entries)) {
     if (
@@ -256,6 +259,7 @@ export async function syncMemoryWikiUnsafeLocalSources(
         sourceUpdatedAtMs: stats.mtimeMs,
         sourceSize: stats.size,
         state,
+        prepareWrite,
       });
     }),
     limit: UNSAFE_LOCAL_SYNC_CONCURRENCY,
@@ -268,6 +272,7 @@ export async function syncMemoryWikiUnsafeLocalSources(
     group: "unsafe-local",
     activeKeys,
     state,
+    prepareWrite,
   });
   await writeMemoryWikiSourceSyncState(config.vault.path, state);
   const importedCount = results.filter((result) => result.changed && result.created).length;

--- a/extensions/memory-wiki/src/unsafe-local.ts
+++ b/extensions/memory-wiki/src/unsafe-local.ts
@@ -208,6 +208,7 @@ async function writeUnsafeLocalSourcePage(params: {
 
 export async function syncMemoryWikiUnsafeLocalSources(
   config: ResolvedMemoryWikiConfig,
+  options: { signal?: AbortSignal } = {},
 ): Promise<BridgeMemoryWikiResult> {
   if (
     config.vaultMode !== "unsafe-local" ||
@@ -230,7 +231,15 @@ export async function syncMemoryWikiUnsafeLocalSources(
   );
   const state = await readMemoryWikiSourceSyncState(config.vault.path);
   let initializePromise: ReturnType<typeof initializeMemoryWikiVault> | undefined;
-  const prepareWrite = () => (initializePromise ??= initializeMemoryWikiVault(config));
+  const prepareWrite = async () => {
+    options.signal?.throwIfAborted();
+    const result = await (initializePromise ??= initializeMemoryWikiVault(
+      config,
+      options.signal ? { signal: options.signal } : undefined,
+    ));
+    options.signal?.throwIfAborted();
+    return result;
+  };
   const activeKeys = new Set<string>();
   for (const [syncKey, entry] of Object.entries(state.entries)) {
     if (

--- a/extensions/memory-wiki/src/vault.ts
+++ b/extensions/memory-wiki/src/vault.ts
@@ -175,12 +175,16 @@ export async function activateExistingMemoryWikiVault(
   if (!identity.vaultGeneration) {
     throw new Error(`Memory Wiki vault generation is missing: ${rootDir}`);
   }
-  activateMemoryWikiCompiledCacheOwner(
+  const needsReconcile = activateMemoryWikiCompiledCacheOwner(
     config,
     identity.vaultGeneration,
     identity.compiledCachePublicationId,
   );
-  await reconcileMemoryWikiCompiledCacheOwner(config, () =>
-    loadMemoryWikiValidatedVaultIdentity(rootDir),
-  );
+  // Repeated request setup must retain the loaded publication. Reconciliation
+  // runs again only when its path, generation, or publication identity changes.
+  if (needsReconcile) {
+    await reconcileMemoryWikiCompiledCacheOwner(config, () =>
+      loadMemoryWikiValidatedVaultIdentity(rootDir),
+    );
+  }
 }

--- a/extensions/memory-wiki/src/vault.ts
+++ b/extensions/memory-wiki/src/vault.ts
@@ -106,8 +106,9 @@ async function writeFileIfMissing(
 
 export async function initializeMemoryWikiVault(
   config: ResolvedMemoryWikiConfig,
-  options?: { nowMs?: number },
+  options?: { nowMs?: number; signal?: AbortSignal },
 ): Promise<InitializeMemoryWikiVaultResult> {
+  options?.signal?.throwIfAborted();
   const rootDir = config.vault.path;
   const createdDirectories: string[] = [];
   const createdFiles: string[] = [];
@@ -157,7 +158,8 @@ export async function initializeMemoryWikiVault(
     });
   }
   await ensureMemoryWikiVaultGeneration(rootDir);
-  await activateExistingMemoryWikiVault(config);
+  options?.signal?.throwIfAborted();
+  await activateExistingMemoryWikiVault(config, options?.signal);
 
   return {
     rootDir,
@@ -169,12 +171,15 @@ export async function initializeMemoryWikiVault(
 
 export async function activateExistingMemoryWikiVault(
   config: ResolvedMemoryWikiConfig,
+  signal?: AbortSignal,
 ): Promise<void> {
+  signal?.throwIfAborted();
   const rootDir = config.vault.path;
   const identity = await loadMemoryWikiValidatedVaultIdentity(rootDir);
   if (!identity.vaultGeneration) {
     throw new Error(`Memory Wiki vault generation is missing: ${rootDir}`);
   }
+  signal?.throwIfAborted();
   const needsReconcile = activateMemoryWikiCompiledCacheOwner(
     config,
     identity.vaultGeneration,
@@ -187,4 +192,5 @@ export async function activateExistingMemoryWikiVault(
       loadMemoryWikiValidatedVaultIdentity(rootDir),
     );
   }
+  signal?.throwIfAborted();
 }

--- a/extensions/memory-wiki/src/wiki-overview.test.ts
+++ b/extensions/memory-wiki/src/wiki-overview.test.ts
@@ -2,6 +2,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
+import { compileMemoryWikiVault } from "./compile.js";
 import { renderWikiMarkdown } from "./markdown.js";
 import { createMemoryWikiTestHarness } from "./test-helpers.js";
 import { listMemoryWikiOverview } from "./wiki-overview.js";
@@ -12,6 +13,7 @@ describe("listMemoryWikiOverview", () => {
   it("groups wiki pages by kind and surfaces claims, questions, and contradictions", async () => {
     const { rootDir, config } = await createVault({
       prefix: "memory-wiki-overview-",
+      config: { render: { createBacklinks: false, createDashboards: false } },
       initialize: true,
     });
 
@@ -72,6 +74,13 @@ describe("listMemoryWikiOverview", () => {
       }),
       "utf8",
     );
+
+    await compileMemoryWikiVault(config);
+    await Promise.all([
+      fs.unlink(path.join(rootDir, "syntheses", "travel-system.md")),
+      fs.unlink(path.join(rootDir, "sources", "raw-chat.md")),
+      fs.unlink(path.join(rootDir, "entities", "mariano.md")),
+    ]);
 
     const result = await listMemoryWikiOverview(config);
 

--- a/extensions/memory-wiki/src/wiki-overview.ts
+++ b/extensions/memory-wiki/src/wiki-overview.ts
@@ -1,7 +1,10 @@
 // Memory Wiki plugin module implements the memory wiki overview.
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import {
   loadMemoryWikiCompiledCache,
+  MEMORY_WIKI_DASHBOARD_ITEM_LIMIT,
+  type MemoryWikiOverviewCluster,
   type MemoryWikiOverviewItem,
   type MemoryWikiOverviewPageCounts,
   type MemoryWikiOverviewStatus,
@@ -26,6 +29,24 @@ const EMPTY_OVERVIEW_PAGE_COUNTS: MemoryWikiOverviewPageCounts = {
   source: 0,
   report: 0,
 };
+
+function capOverviewText(value: string, maxChars = 240): string {
+  return truncateUtf16Safe(value.replace(/\s+/g, " ").trim(), maxChars);
+}
+
+function capOverviewItem(item: MemoryWikiOverviewItem): MemoryWikiOverviewItem {
+  return {
+    ...item,
+    title: capOverviewText(item.title, 240),
+    ...(item.id ? { id: capOverviewText(item.id, 240) } : {}),
+    ...(item.updatedAt ? { updatedAt: capOverviewText(item.updatedAt, 64) } : {}),
+    ...(item.sourceType ? { sourceType: capOverviewText(item.sourceType, 120) } : {}),
+    claims: item.claims.slice(0, 3).map((value) => capOverviewText(value)),
+    questions: item.questions.slice(0, 3).map((value) => capOverviewText(value)),
+    contradictions: item.contradictions.slice(0, 3).map((value) => capOverviewText(value)),
+    ...(item.snippet ? { snippet: capOverviewText(item.snippet, 700) } : {}),
+  };
+}
 
 function extractSnippet(body: string): string | undefined {
   for (const rawLine of body.split(/\r?\n/)) {
@@ -61,7 +82,7 @@ export async function listMemoryWikiOverview(
   config: ResolvedMemoryWikiConfig,
 ): Promise<MemoryWikiOverviewStatus> {
   const snapshot = await loadMemoryWikiCompiledCache(config);
-  if (!snapshot) {
+  if (!snapshot?.dashboards) {
     throw new Error('Memory Wiki has no compiled dashboard snapshot. Run "openclaw wiki compile".');
   }
   return snapshot.dashboards.overview;
@@ -105,7 +126,8 @@ export function buildMemoryWikiOverview(
   const totalClaims = pages.reduce((sum, page) => sum + page.claims.length, 0);
   const totalQuestions = pages.reduce((sum, page) => sum + page.questions.length, 0);
   const totalContradictions = pages.reduce((sum, page) => sum + page.contradictions.length, 0);
-  const items = projectedItems
+  const allItems = projectedItems
+    .map(capOverviewItem)
     .filter(
       (item) =>
         PRIMARY_OVERVIEW_KINDS.has(item.kind) ||
@@ -114,6 +136,7 @@ export function buildMemoryWikiOverview(
         item.contradictionCount > 0,
     )
     .toSorted(compareOverviewItems);
+  const items = allItems.slice(0, MEMORY_WIKI_DASHBOARD_ITEM_LIMIT);
 
   const clusters = OVERVIEW_KIND_ORDER.map((kind) => {
     const clusterItems = items.filter((item) => item.kind === kind);
@@ -135,12 +158,13 @@ export function buildMemoryWikiOverview(
   }).filter((entry): entry is MemoryWikiOverviewCluster => entry !== null);
 
   return {
-    totalItems: items.length,
+    totalItems: allItems.length,
     totalPages: pages.length,
     pageCounts,
     totalClaims,
     totalQuestions,
     totalContradictions,
     clusters,
+    truncated: items.length < allItems.length,
   };
 }

--- a/extensions/memory-wiki/src/wiki-overview.ts
+++ b/extensions/memory-wiki/src/wiki-overview.ts
@@ -1,6 +1,11 @@
 // Memory Wiki plugin module implements the memory wiki overview.
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
-import { loadMemoryWikiCompiledCache } from "./compiled-cache.js";
+import {
+  loadMemoryWikiCompiledCache,
+  type MemoryWikiOverviewItem,
+  type MemoryWikiOverviewPageCounts,
+  type MemoryWikiOverviewStatus,
+} from "./compiled-cache.js";
 import type { ResolvedMemoryWikiConfig } from "./config.js";
 import type { WikiPageKind, WikiPageSummary } from "./markdown.js";
 
@@ -12,45 +17,6 @@ const OVERVIEW_KIND_LABELS: Record<WikiPageKind, string> = {
   concept: "Concepts",
   source: "Sources",
   report: "Reports",
-};
-
-export type MemoryWikiOverviewItem = {
-  pagePath: string;
-  title: string;
-  kind: WikiPageKind;
-  id?: string;
-  updatedAt?: string;
-  sourceType?: string;
-  claimCount: number;
-  questionCount: number;
-  contradictionCount: number;
-  claims: string[];
-  questions: string[];
-  contradictions: string[];
-  snippet?: string;
-};
-
-type MemoryWikiOverviewCluster = {
-  key: WikiPageKind;
-  label: string;
-  itemCount: number;
-  claimCount: number;
-  questionCount: number;
-  contradictionCount: number;
-  updatedAt?: string;
-  items: MemoryWikiOverviewItem[];
-};
-
-type MemoryWikiOverviewPageCounts = Record<WikiPageKind, number>;
-
-export type MemoryWikiOverviewStatus = {
-  totalItems: number;
-  totalPages: number;
-  pageCounts: MemoryWikiOverviewPageCounts;
-  totalClaims: number;
-  totalQuestions: number;
-  totalContradictions: number;
-  clusters: MemoryWikiOverviewCluster[];
 };
 
 const EMPTY_OVERVIEW_PAGE_COUNTS: MemoryWikiOverviewPageCounts = {

--- a/extensions/memory-wiki/src/wiki-overview.ts
+++ b/extensions/memory-wiki/src/wiki-overview.ts
@@ -2,7 +2,7 @@
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import {
-  loadMemoryWikiCompiledCache,
+  loadMemoryWikiCompiledDashboards,
   MEMORY_WIKI_DASHBOARD_ITEM_LIMIT,
   type MemoryWikiOverviewCluster,
   type MemoryWikiOverviewItem,
@@ -81,11 +81,7 @@ function compareOverviewItems(left: MemoryWikiOverviewItem, right: MemoryWikiOve
 export async function listMemoryWikiOverview(
   config: ResolvedMemoryWikiConfig,
 ): Promise<MemoryWikiOverviewStatus> {
-  const snapshot = await loadMemoryWikiCompiledCache(config);
-  if (!snapshot?.dashboards) {
-    throw new Error('Memory Wiki has no compiled dashboard snapshot. Run "openclaw wiki compile".');
-  }
-  return snapshot.dashboards.overview;
+  return (await loadMemoryWikiCompiledDashboards(config)).overview;
 }
 
 export function projectMemoryWikiOverviewItem(

--- a/extensions/memory-wiki/src/wiki-overview.ts
+++ b/extensions/memory-wiki/src/wiki-overview.ts
@@ -1,8 +1,8 @@
 // Memory Wiki plugin module implements the memory wiki overview.
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { loadMemoryWikiCompiledCache } from "./compiled-cache.js";
 import type { ResolvedMemoryWikiConfig } from "./config.js";
-import { parseWikiMarkdown, type WikiPageKind } from "./markdown.js";
-import { readQueryableWikiPages } from "./query.js";
+import type { WikiPageKind, WikiPageSummary } from "./markdown.js";
 
 const OVERVIEW_KIND_ORDER: WikiPageKind[] = ["synthesis", "entity", "concept", "source", "report"];
 const PRIMARY_OVERVIEW_KINDS = new Set<WikiPageKind>(["synthesis", "entity", "concept"]);
@@ -14,7 +14,7 @@ const OVERVIEW_KIND_LABELS: Record<WikiPageKind, string> = {
   report: "Reports",
 };
 
-type MemoryWikiOverviewItem = {
+export type MemoryWikiOverviewItem = {
   pagePath: string;
   title: string;
   kind: WikiPageKind;
@@ -43,7 +43,7 @@ type MemoryWikiOverviewCluster = {
 
 type MemoryWikiOverviewPageCounts = Record<WikiPageKind, number>;
 
-type MemoryWikiOverviewStatus = {
+export type MemoryWikiOverviewStatus = {
   totalItems: number;
   totalPages: number;
   pageCounts: MemoryWikiOverviewPageCounts;
@@ -53,15 +53,13 @@ type MemoryWikiOverviewStatus = {
   clusters: MemoryWikiOverviewCluster[];
 };
 
-function createEmptyOverviewPageCounts(): MemoryWikiOverviewPageCounts {
-  return {
-    synthesis: 0,
-    entity: 0,
-    concept: 0,
-    source: 0,
-    report: 0,
-  };
-}
+const EMPTY_OVERVIEW_PAGE_COUNTS: MemoryWikiOverviewPageCounts = {
+  synthesis: 0,
+  entity: 0,
+  concept: 0,
+  source: 0,
+  report: 0,
+};
 
 function extractSnippet(body: string): string | undefined {
   for (const rawLine of body.split(/\r?\n/)) {
@@ -96,35 +94,52 @@ function compareOverviewItems(left: MemoryWikiOverviewItem, right: MemoryWikiOve
 export async function listMemoryWikiOverview(
   config: ResolvedMemoryWikiConfig,
 ): Promise<MemoryWikiOverviewStatus> {
-  const pages = await readQueryableWikiPages(config.vault.path);
-  const pageCounts = pages.reduce<MemoryWikiOverviewPageCounts>((counts, page) => {
-    counts[page.kind] += 1;
-    return counts;
-  }, createEmptyOverviewPageCounts());
+  const snapshot = await loadMemoryWikiCompiledCache(config);
+  if (!snapshot) {
+    throw new Error('Memory Wiki has no compiled dashboard snapshot. Run "openclaw wiki compile".');
+  }
+  return snapshot.dashboards.overview;
+}
+
+export function projectMemoryWikiOverviewItem(
+  page: WikiPageSummary,
+  body: string,
+): MemoryWikiOverviewItem {
+  const updatedAt = normalizeOptionalString(page.updatedAt);
+  const sourceType = normalizeOptionalString(page.sourceType);
+  const snippet = extractSnippet(body);
+  return Object.assign(
+    { pagePath: page.relativePath, title: page.title, kind: page.kind },
+    page.id ? { id: page.id } : {},
+    updatedAt ? { updatedAt } : {},
+    sourceType ? { sourceType } : {},
+    {
+      claimCount: page.claims.length,
+      questionCount: page.questions.length,
+      contradictionCount: page.contradictions.length,
+      claims: page.claims.map((claim) => claim.text).slice(0, 3),
+      questions: page.questions.slice(0, 3),
+      contradictions: page.contradictions.slice(0, 3),
+    },
+    snippet ? { snippet } : {},
+  );
+}
+
+export function buildMemoryWikiOverview(
+  pages: WikiPageSummary[],
+  projectedItems: MemoryWikiOverviewItem[],
+): MemoryWikiOverviewStatus {
+  const pageCounts = pages.reduce<MemoryWikiOverviewPageCounts>(
+    (counts, page) => {
+      counts[page.kind] += 1;
+      return counts;
+    },
+    { ...EMPTY_OVERVIEW_PAGE_COUNTS },
+  );
   const totalClaims = pages.reduce((sum, page) => sum + page.claims.length, 0);
   const totalQuestions = pages.reduce((sum, page) => sum + page.questions.length, 0);
   const totalContradictions = pages.reduce((sum, page) => sum + page.contradictions.length, 0);
-  const items = pages
-    .map((page) => {
-      const parsed = parseWikiMarkdown(page.raw);
-      const updatedAt = normalizeOptionalString(page.updatedAt);
-      const sourceType = normalizeOptionalString(page.sourceType);
-      return Object.assign(
-        { pagePath: page.relativePath, title: page.title, kind: page.kind },
-        page.id ? { id: page.id } : {},
-        updatedAt ? { updatedAt } : {},
-        sourceType ? { sourceType } : {},
-        {
-          claimCount: page.claims.length,
-          questionCount: page.questions.length,
-          contradictionCount: page.contradictions.length,
-          claims: page.claims.map((claim) => claim.text).slice(0, 3),
-          questions: page.questions.slice(0, 3),
-          contradictions: page.contradictions.slice(0, 3),
-        },
-        extractSnippet(parsed.body) ? { snippet: extractSnippet(parsed.body) } : {},
-      ) satisfies MemoryWikiOverviewItem;
-    })
+  const items = projectedItems
     .filter(
       (item) =>
         PRIMARY_OVERVIEW_KINDS.has(item.kind) ||

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -4751,6 +4751,7 @@ export const en: TranslationMap = {
       pageNotFound: "No wiki page found for {lookup}.",
       previewTruncated: "Showing the first chunk of this page.",
       previewTruncatedWithTotal: "Showing the first chunk of this page ({count} total lines).",
+      boundedResults: "Showing the newest {returned} of {total} items.",
       importedClusterSummary: "Imported chats clustered around {label}.",
       withheldDigestOne: "{count} digest was withheld pending review.",
       withheldDigests: "{count} digests were withheld pending review.",

--- a/ui/src/pages/agents/memory/dreaming.test.ts
+++ b/ui/src/pages/agents/memory/dreaming.test.ts
@@ -586,6 +586,7 @@ describe("dreaming controller", () => {
       sourceType: "chatgpt",
       totalItems: 1,
       totalClusters: 1,
+      truncated: false,
       clusters: [],
     };
     state.wikiImportInsightsError = "unknown method: wiki.importInsights";
@@ -617,6 +618,7 @@ describe("dreaming controller", () => {
       sourceType: "chatgpt",
       totalItems: 1,
       totalClusters: 1,
+      truncated: false,
       clusters: [],
     };
     state.wikiImportInsightsError = "unknown method: wiki.importInsights";
@@ -794,6 +796,7 @@ describe("dreaming controller", () => {
     state.wikiOverview = {
       totalItems: 1,
       totalPages: 1,
+      truncated: false,
       pageCounts: {
         synthesis: 1,
         entity: 0,
@@ -834,6 +837,7 @@ describe("dreaming controller", () => {
     state.wikiOverview = {
       totalItems: 1,
       totalPages: 1,
+      truncated: false,
       pageCounts: {
         synthesis: 1,
         entity: 0,

--- a/ui/src/pages/agents/memory/dreaming.ts
+++ b/ui/src/pages/agents/memory/dreaming.ts
@@ -63,6 +63,7 @@ export type WikiImportInsights = {
   totalItems: number;
   totalClusters: number;
   clusters: WikiImportInsightCluster[];
+  truncated: boolean;
 };
 
 type WikiOverviewItem = {
@@ -102,6 +103,7 @@ export type WikiOverview = {
   totalQuestions: number;
   totalContradictions: number;
   clusters: WikiOverviewCluster[];
+  truncated: boolean;
 };
 
 type DreamingResourceKey = "dreamingStatus" | "dreamDiary" | "wikiImportInsights" | "wikiOverview";

--- a/ui/src/pages/agents/memory/view-bounded-results.test.ts
+++ b/ui/src/pages/agents/memory/view-bounded-results.test.ts
@@ -1,0 +1,145 @@
+/* @vitest-environment jsdom */
+
+import { render } from "lit";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  fullDreamingViewAccess,
+  installDreamingViewTestTranslations,
+} from "./view.test-helpers.ts";
+import { createDreamingViewState, renderDreaming } from "./view.ts";
+
+type DreamingProps = Parameters<typeof renderDreaming>[0];
+
+let restoreTranslations = () => {};
+
+beforeAll(() => {
+  restoreTranslations = installDreamingViewTestTranslations();
+});
+
+afterAll(() => {
+  restoreTranslations();
+});
+
+function buildBoundedDashboardProps(tab: "insights" | "wiki"): DreamingProps {
+  const viewState = createDreamingViewState();
+  viewState.activeSubTab = "diary";
+  viewState.activeDiarySubTab = tab;
+  return {
+    access: fullDreamingViewAccess,
+    viewState,
+    active: true,
+    selectedAgentId: "main",
+    shortTermCount: 0,
+    promotedCount: 0,
+    shortTermEntries: [],
+    promotedEntries: [],
+    dreamingOf: null,
+    nextCycle: null,
+    timezone: null,
+    statusError: null,
+    modeSaving: false,
+    dreamDiaryLoading: false,
+    dreamDiaryActionLoading: false,
+    dreamDiaryActionMessage: null,
+    dreamDiaryActionArchivePath: null,
+    dreamDiaryError: null,
+    dreamDiaryContent: null,
+    memoryWikiEnabled: true,
+    wikiImportInsightsLoading: false,
+    wikiImportInsightsError: null,
+    wikiImportInsights:
+      tab === "insights"
+        ? {
+            sourceType: "chatgpt",
+            totalItems: 2_501,
+            totalClusters: 1,
+            truncated: true,
+            clusters: [
+              {
+                key: "topic/example",
+                label: "Example",
+                itemCount: 2_500,
+                highRiskCount: 0,
+                withheldCount: 0,
+                preferenceSignalCount: 0,
+                items: Array.from({ length: 2_500 }, (_, index) => ({
+                  pagePath: `sources/import-${index}.md`,
+                  title: `Imported chat ${index}`,
+                  riskLevel: "low" as const,
+                  riskReasons: [],
+                  labels: [],
+                  topicKey: "topic/example",
+                  topicLabel: "Example",
+                  digestStatus: "available" as const,
+                  activeBranchMessages: 1,
+                  userMessageCount: 1,
+                  assistantMessageCount: 1,
+                  summary: "Imported summary",
+                  candidateSignals: [],
+                  correctionSignals: [],
+                  preferenceSignals: [],
+                })),
+              },
+            ],
+          }
+        : null,
+    wikiOverviewLoading: false,
+    wikiOverviewError: null,
+    wikiOverview:
+      tab === "wiki"
+        ? {
+            totalItems: 2_501,
+            totalPages: 2_501,
+            pageCounts: { synthesis: 2_501, entity: 0, concept: 0, source: 0, report: 0 },
+            totalClaims: 0,
+            totalQuestions: 0,
+            totalContradictions: 0,
+            truncated: true,
+            clusters: [
+              {
+                key: "synthesis",
+                label: "Syntheses",
+                itemCount: 2_500,
+                claimCount: 0,
+                questionCount: 0,
+                contradictionCount: 0,
+                items: Array.from({ length: 2_500 }, (_, index) => ({
+                  pagePath: `syntheses/page-${index}.md`,
+                  title: `Memory page ${index}`,
+                  kind: "synthesis" as const,
+                  claimCount: 0,
+                  questionCount: 0,
+                  contradictionCount: 0,
+                  claims: [],
+                  questions: [],
+                  contradictions: [],
+                })),
+              },
+            ],
+          }
+        : null,
+    onRefreshDiary: () => {},
+    onRefreshImports: () => {},
+    onRefreshWikiOverview: () => {},
+    onOpenConfig: () => {},
+    onOpenWikiPage: async () => null,
+    onBackfillDiary: () => {},
+    onCopyDreamingArchivePath: () => {},
+    onDedupeDreamDiary: () => {},
+    onResetDiary: () => {},
+    onResetGroundedShortTerm: () => {},
+    onRepairDreamingArtifacts: () => {},
+    onViewStateChange: () => {},
+  };
+}
+
+describe("bounded Memory Wiki dashboard results", () => {
+  it.each(["insights", "wiki"] as const)("discloses returned and total %s item counts", (tab) => {
+    const container = document.createElement("div");
+    render(renderDreaming(buildBoundedDashboardProps(tab)), container);
+
+    expect(container.querySelector(".dreams-diary__bounded-result")?.textContent?.trim()).toBe(
+      "Showing the newest 2,500 of 2,501 items.",
+    );
+  });
+});

--- a/ui/src/pages/agents/memory/view.test-helpers.ts
+++ b/ui/src/pages/agents/memory/view.test-helpers.ts
@@ -1,3 +1,6 @@
+import { i18n } from "../../../i18n/index.ts";
+import type { TranslationMap } from "../../../i18n/lib/types.ts";
+import { en } from "../../../i18n/locales/en.ts";
 import type { renderDreaming } from "./view.ts";
 
 export const fullDreamingViewAccess: Parameters<typeof renderDreaming>[0]["access"] = {
@@ -8,3 +11,74 @@ export const fullDreamingViewAccess: Parameters<typeof renderDreaming>[0]["acces
   canResetGroundedShortTerm: true,
   canRepairDreamingArtifacts: true,
 };
+
+const asTranslationMap = (value: string | TranslationMap | undefined): TranslationMap =>
+  value && typeof value === "object" ? value : {};
+
+export function installDreamingViewTestTranslations(): () => void {
+  const dreaming = asTranslationMap(en.dreaming);
+  const wiki = asTranslationMap(dreaming.wiki);
+  i18n.registerTranslation("en", {
+    ...en,
+    dreaming: {
+      ...dreaming,
+      wiki: {
+        ...wiki,
+        pageTypes: {
+          entity: "entity",
+          concept: "concept",
+          source: "source",
+          synthesis: "synthesis",
+          report: "report",
+        },
+        pageGroups: {
+          sources: "Sources",
+          syntheses: "Syntheses",
+          reports: "Reports",
+          entities: "Entities",
+          concepts: "Concepts",
+        },
+        counts: {
+          pageOne: "{count} page",
+          pages: "{count} pages",
+          claimRowOne: "{count} claim row",
+          claimRows: "{count} claim rows",
+          openQuestionOne: "{count} open question",
+          openQuestions: "{count} open questions",
+          contradictionOne: "{count} contradiction",
+          contradictions: "{count} contradictions",
+          chats: "{count} chats",
+          sensitive: "{count} sensitive",
+          signals: "{count} signals",
+          messages: "{count} messages",
+          userMessages: "{count} user",
+          assistantMessages: "{count} assistant",
+        },
+        pageGroupSummary: "{label} · {count}",
+        noPagesYet: "No pages yet",
+        sectionPageSummary: "{label}: {count}",
+        questionCountOnPages: "{questionCount} on {pageCount}",
+        risk: {
+          needsReview: "needs review",
+          low: "low risk",
+          medium: "medium risk",
+          high: "high risk",
+          unknown: "unknown risk",
+        },
+        pageNotFound: "No wiki page found for {lookup}.",
+        previewTruncated: "Showing the first chunk of this page.",
+        previewTruncatedWithTotal: "Showing the first chunk of this page ({count} total lines).",
+        importedClusterSummary: "Imported chats clustered around {label}.",
+        withheldDigestOne: "{count} digest was withheld pending review.",
+        withheldDigests: "{count} digests were withheld pending review.",
+        details: "Details",
+        hideDetails: "Hide details",
+        vault: "Vault",
+        fullVaultBreakdown: "Full vault breakdown: {breakdown}.",
+        selectedSection: "Selected section: {summary}.",
+        latestUpdate: "Latest update {date}.",
+      },
+    },
+  });
+  return () => i18n.registerTranslation("en", en);
+}

--- a/ui/src/pages/agents/memory/view.test.ts
+++ b/ui/src/pages/agents/memory/view.test.ts
@@ -2,102 +2,27 @@
 
 import { expectDefined } from "@openclaw/normalization-core";
 import { render } from "lit";
-import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
-import { i18n } from "../../../i18n/index.ts";
-import type { TranslationMap } from "../../../i18n/lib/types.ts";
-import { en } from "../../../i18n/locales/en.ts";
-import { fullDreamingViewAccess } from "./view.test-helpers.ts";
+import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  fullDreamingViewAccess,
+  installDreamingViewTestTranslations,
+} from "./view.test-helpers.ts";
 import { createDreamingViewState, renderDreaming, type DreamingViewState } from "./view.ts";
 
 type DreamingProps = Parameters<typeof renderDreaming>[0];
 
 let viewState = createDreamingViewState();
-let restoreTranslations = () => {};
+const restoreTranslations = installDreamingViewTestTranslations();
 
-const asTranslationMap = (value: string | TranslationMap | undefined): TranslationMap =>
-  value && typeof value === "object" ? value : {};
-
-beforeAll(() => {
-  const dreaming = asTranslationMap(en.dreaming);
-  const wiki = asTranslationMap(dreaming.wiki);
-  i18n.registerTranslation("en", {
-    ...en,
-    dreaming: {
-      ...dreaming,
-      wiki: {
-        ...wiki,
-        pageTypes: {
-          entity: "entity",
-          concept: "concept",
-          source: "source",
-          synthesis: "synthesis",
-          report: "report",
-        },
-        pageGroups: {
-          sources: "Sources",
-          syntheses: "Syntheses",
-          reports: "Reports",
-          entities: "Entities",
-          concepts: "Concepts",
-        },
-        counts: {
-          pageOne: "{count} page",
-          pages: "{count} pages",
-          claimRowOne: "{count} claim row",
-          claimRows: "{count} claim rows",
-          openQuestionOne: "{count} open question",
-          openQuestions: "{count} open questions",
-          contradictionOne: "{count} contradiction",
-          contradictions: "{count} contradictions",
-          chats: "{count} chats",
-          sensitive: "{count} sensitive",
-          signals: "{count} signals",
-          messages: "{count} messages",
-          userMessages: "{count} user",
-          assistantMessages: "{count} assistant",
-        },
-        pageGroupSummary: "{label} · {count}",
-        noPagesYet: "No pages yet",
-        sectionPageSummary: "{label}: {count}",
-        questionCountOnPages: "{questionCount} on {pageCount}",
-        risk: {
-          needsReview: "needs review",
-          low: "low risk",
-          medium: "medium risk",
-          high: "high risk",
-          unknown: "unknown risk",
-        },
-        pageNotFound: "No wiki page found for {lookup}.",
-        previewTruncated: "Showing the first chunk of this page.",
-        previewTruncatedWithTotal: "Showing the first chunk of this page ({count} total lines).",
-        importedClusterSummary: "Imported chats clustered around {label}.",
-        withheldDigestOne: "{count} digest was withheld pending review.",
-        withheldDigests: "{count} digests were withheld pending review.",
-        details: "Details",
-        hideDetails: "Hide details",
-        vault: "Vault",
-        fullVaultBreakdown: "Full vault breakdown: {breakdown}.",
-        selectedSection: "Selected section: {summary}.",
-        latestUpdate: "Latest update {date}.",
-      },
-    },
-  });
-  restoreTranslations = () => i18n.registerTranslation("en", en);
-});
-
-afterAll(() => {
-  restoreTranslations();
-});
+afterAll(() => restoreTranslations());
 
 const setDreamSubTab = (tab: DreamingViewState["activeSubTab"]) => (viewState.activeSubTab = tab);
 
-function setDreamDiarySubTab(tab: DreamingViewState["activeDiarySubTab"]) {
-  viewState.activeDiarySubTab = tab;
-}
+const setDreamDiarySubTab = (tab: DreamingViewState["activeDiarySubTab"]) =>
+  (viewState.activeDiarySubTab = tab);
 
-function setDreamAdvancedWaitingSort(sort: DreamingViewState["advancedWaitingSort"]) {
-  viewState.advancedWaitingSort = sort;
-}
+const setDreamAdvancedWaitingSort = (sort: DreamingViewState["advancedWaitingSort"]) =>
+  (viewState.advancedWaitingSort = sort);
 
 function buildProps(overrides?: Partial<DreamingProps>): DreamingProps {
   const props: DreamingProps = {
@@ -164,6 +89,7 @@ function buildProps(overrides?: Partial<DreamingProps>): DreamingProps {
       sourceType: "chatgpt",
       totalItems: 2,
       totalClusters: 2,
+      truncated: false,
       clusters: [
         {
           key: "topic/travel",
@@ -232,6 +158,7 @@ function buildProps(overrides?: Partial<DreamingProps>): DreamingProps {
     wikiOverview: {
       totalItems: 1,
       totalPages: 2,
+      truncated: false,
       pageCounts: {
         synthesis: 1,
         entity: 0,
@@ -612,6 +539,7 @@ describe("dreaming view", () => {
       wikiOverview: {
         totalItems: 1,
         totalPages: 1,
+        truncated: false,
         pageCounts: {
           synthesis: 0,
           entity: 0,
@@ -859,6 +787,7 @@ describe("dreaming view", () => {
       const firstCluster = expectDefined(wikiOverview.clusters[0], "first memory wiki cluster");
       props.wikiOverview = {
         ...wikiOverview,
+        truncated: false,
         clusters: [
           ...wikiOverview.clusters,
           { ...firstCluster, key: "concept", label: "Concepts" },

--- a/ui/src/pages/agents/memory/view.ts
+++ b/ui/src/pages/agents/memory/view.ts
@@ -8,7 +8,7 @@ import { lobsterPetSeed } from "../../../components/lobster-pet-contract.ts";
 import { createLobsterPetLook, renderLobsterSvg } from "../../../components/lobster-pet-look.ts";
 import { toSanitizedMarkdownHtml } from "../../../components/markdown.ts";
 import "../../../components/modal-dialog.ts";
-import { t } from "../../../i18n/index.ts";
+import { i18n, t } from "../../../i18n/index.ts";
 import { formatUiError } from "../../../lib/format-error.ts";
 import "../../../styles/dreams.css";
 import type { DreamingEntry, WikiImportInsights, WikiOverview } from "./dreaming.ts";
@@ -1149,12 +1149,19 @@ function renderDiaryNavigation(props: DreamingProps, labels: string[], selectedP
 }
 
 function renderWikiClusterSection<
-  Cluster extends { key: string; label: string; items: { pagePath: string }[] },
+  Cluster extends {
+    key: string;
+    label: string;
+    itemCount: number;
+    items: { pagePath: string }[];
+  },
 >(
   props: DreamingProps,
   params: {
     kind: "imports" | "wiki";
     clusters: Cluster[];
+    totalItems: number;
+    truncated: boolean;
     loading: boolean;
     loadingKey: string;
     emptyKey: string;
@@ -1186,6 +1193,7 @@ function renderWikiClusterSection<
       ? "selected imported insight cluster"
       : "selected memory overview cluster",
   );
+  const returnedItems = clusters.reduce((total, entry) => total + entry.itemCount, 0);
   return {
     navigation: renderDiaryNavigation(
       props,
@@ -1196,6 +1204,14 @@ function renderWikiClusterSection<
       <article class="dreams-diary__entry" key="${params.kind}-${cluster.key}">
         <div class="dreams-diary__accent"></div>
         <div class="dreams-diary__date">${params.date(cluster)}</div>
+        ${params.truncated
+          ? html`<p class="dreams-diary__para dreams-diary__bounded-result">
+              ${t("dreaming.wiki.boundedResults", {
+                returned: returnedItems.toLocaleString(i18n.getLocale()),
+                total: params.totalItems.toLocaleString(i18n.getLocale()),
+              })}
+            </p>`
+          : nothing}
         <div class="dreams-diary__prose">${params.prose(cluster)}</div>
         <div class="dreams-diary__insights">${cluster.items.map(params.renderItem)}</div>
       </article>
@@ -1207,6 +1223,8 @@ function renderDiaryImportsSection(props: DreamingProps) {
   return renderWikiClusterSection(props, {
     kind: "imports",
     clusters: props.wikiImportInsights?.clusters ?? [],
+    totalItems: props.wikiImportInsights?.totalItems ?? 0,
+    truncated: props.wikiImportInsights?.truncated ?? false,
     loading: props.wikiImportInsightsLoading,
     loadingKey: "dreaming.wiki.loadingInsights",
     emptyKey: "dreaming.wiki.noInsights",
@@ -1248,6 +1266,8 @@ function renderWikiOverviewSection(props: DreamingProps) {
   return renderWikiClusterSection(props, {
     kind: "wiki",
     clusters: overview?.clusters ?? [],
+    totalItems: overview?.totalItems ?? 0,
+    truncated: overview?.truncated ?? false,
     loading: props.wikiOverviewLoading,
     loadingKey: "dreaming.wiki.loadingWiki",
     emptyKey: "dreaming.wiki.emptyWiki",


### PR DESCRIPTION
Fixes #132077

## What Problem This Solves

The Memory Wiki dashboard RPCs read and parsed every Markdown page on each Control UI request. A 229 MB vault made both dashboard calls take about 166 seconds and blocked the operator flow.

## Why This Change Was Made

The compiled-cache publication now owns the Imported Insights and Memory Wiki overview projections.

- Compile builds both bounded projections during its existing page scan.
- Cache version 3 has one required dashboard shape; older rebuildable cache rows are rejected.
- Dashboard RPCs start source sync in the background and never wait for a vault compile.
- Recovery returns explicit `rebuilding`, `compile-required`, or `failed` states through structured Gateway errors.
- `ingest.autoCompile: false` never triggers a hidden compile; the UI tells the operator to run `openclaw wiki compile`.
- Background compile yields between large page parses so Gateway health traffic remains responsive.
- Plugin shutdown retires cache owners before waiting for source sync, so a late compile cannot publish after lifecycle closure.
- The service-generation abort signal reaches every Gateway and tool compile producer, page scan, and derived-write unit.
- Both bounded dashboard results carry a required truncation flag; the UI shows returned and total item counts when the 2,500-item cap applies.

Ready dashboard response payloads are unchanged.

## User Impact

Memory Wiki dashboards remain responsive on large vaults. Upgrades show a short rebuilding result and then use the new publication. Changed imports publish in the background. Operators who disable automatic compile keep that setting and receive a clear manual recovery command. A dashboard that reaches the item cap now states exactly how many items are shown and how many exist.

## Evidence

The same built Control UI and isolated Gateway flow ran with 3,700 valid Markdown pages totaling 229,400,000 bytes, including 2,300 ChatGPT pages and a unique sentinel.

| Case | Initial dashboard result | Final result | Publications | Concurrent health |
| --- | --- | --- | ---: | --- |
| Current main `8cd61f02bf48` | ready after 166,149/166,347 ms | contract failed | n/a | 2,281/2,281 passed; p95 101 ms; max 655 ms |
| Head `fd44319486d4`, warm | ready in 230/231 ms | ready | 0 | 10/10 passed; max 585 ms |
| Head, version-2 upgrade | rebuilding in 136/137 ms | ready in 72/72 ms | 1 | 630/630 passed; p95 31 ms; max 285 ms |
| Head, changed import | prior snapshot in 206/206 ms | refreshed in 78/78 ms | 1 | 926/926 passed; p95 37 ms; max 555 ms |
| Head, changed import with auto-compile off | prior snapshot in 221/220 ms | compile-required in 38/38 ms | 0 | 28/28 passed; p95 269 ms; max 586 ms |

The upgrade and changed-import runs retained the sentinel and correct page counts. The changed-import run proved the new sentinel after publication. The disabled-auto-compile run recorded zero compile and publication events. All proof-owned Gateways, browsers, ports, and state were cleaned up.

A separate 2,501-item, 229.4 MB run returned 2,500 items with `truncated: true` from both real Gateway methods. Imported Insights answered in 230 ms and Memory Wiki in 238 ms. Both built Control UI tabs showed `Showing the newest 2,500 of 2,501 items.` Concurrent health passed 72/72.

A separate SIGTERM probe reached an active large-vault scan in three fresh runs and produced zero later publications. Gateway-wide drains prevented isolating the Memory Wiki abort latency and restart state, so that extra timing probe remains unverified. The owner-boundary regressions independently prove that queued manual compile stops before activation and an active scan stops at its 16 in-flight work units.

### Control UI proof

![Version-2 cache returns rebuilding](https://github.com/user-attachments/assets/119aefcc-8c0a-45bb-967e-db13e3462a0b)

![Recovered version-3 dashboard](https://github.com/user-attachments/assets/425d3347-7f9b-40cd-933e-0739edb352c7)

![Auto-compile disabled returns compile-required](https://github.com/user-attachments/assets/5ef1e9dc-e824-463c-a8c2-5dd57416de42)

![Imported Insights discloses bounded results](https://github.com/user-attachments/assets/c722edc7-40c6-480f-8199-50dea07bfd7c)

![Memory Wiki discloses bounded results](https://github.com/user-attachments/assets/c7086840-ac86-4982-bbdd-08bd43f526f1)

### Validation

- The dashboard request-boundary regression failed on pre-fix `812840adf85f` because neither handler responded while source sync remained unresolved.
- The queued dashboard-sync lifecycle regression failed on pre-fix `4baa0dabe749` because stopped work reactivated the vault owner, then passed on the repaired head.
- The queued manual-compile and active-scan regressions failed on pre-fix `a77e3fbf637b`, then passed on the repaired head.
- `node scripts/run-vitest.mjs` passed 205 focused Memory Wiki and Control UI tests across 12 owner and sibling files on exact head `fd44319486d4`; the two bounded-result tests rendered 2,500 real cards per view.
- Live `main` `5b532a78ee1f` has no Memory Wiki or Control UI memory-owner change after the exact `8cd61f02bf48` red run.
- Exact-head production and test type checks, Oxlint, dependency and boundary guards, dead-export checks, database-first checks, and import-cycle checks passed.
- Exact-head `pnpm build` passed, including the served Control UI bundle.
- Docs MDX, internal links, and formatting checks passed.

### Line Count

- Production: +848/-337, net +511.
- Tests and test support: +736/-103, net +633.
- Docs: +10/-0.

The production growth adds bounded dashboard projections plus the cache-owned availability state, required truncation contract, visible disclosure, and one service-generation fence across every compile path. The absorbing refactor moved both projections into the existing compiler, uses the platform `AbortController` for lifecycle closure, removed the request-time raw readers, removed the optional version-2 dashboard shape, removed the hidden `autoCompile: false` compile path, and removed the temporary derived-write mode. The UI test split also removes the touched file's max-lines violation without a suppression.
