### PR TITLE
fix(onboard): avoid unused plugin discovery in non-interactive setup

### DIFF
--- a/src/commands/onboard-non-interactive/local/auth-choice.test.ts
+++ b/src/commands/onboard-non-interactive/local/auth-choice.test.ts
@@ -9,12 +9,6 @@ import { applyNonInteractiveAuthChoice } from "./auth-choice.js";
 const writeWizardConfigFile = vi.hoisted(() => vi.fn(async (config: OpenClawConfig) => config));
 vi.mock("../../../wizard/setup.shared.js", () => ({ writeWizardConfigFile }));
 
-const loadManifestMetadataSnapshot = vi.hoisted(() => vi.fn(() => ({ plugins: [] })));
-vi.mock("../../../plugins/manifest-contract-eligibility.js", async (importOriginal) => ({
-  ...(await importOriginal<typeof import("../../../plugins/manifest-contract-eligibility.js")>()),
-  loadManifestMetadataSnapshot,
-}));
-
 const formatAuthChoiceChoicesForCli = vi.hoisted(() =>
   vi.fn(() => "custom-api-key|skip|demo-provider-api-key"),
 );
@@ -54,8 +48,6 @@ beforeEach(() => {
   resolveManifestProviderAuthChoices.mockReturnValue([]);
   resolveDeprecatedProviderInstallCatalogEntry.mockReset();
   resolveDeprecatedProviderInstallCatalogEntry.mockReturnValue(undefined);
-  loadManifestMetadataSnapshot.mockReset();
-  loadManifestMetadataSnapshot.mockReturnValue({ plugins: [] });
 });
 
 function createRuntime() {
@@ -276,11 +268,6 @@ describe("applyNonInteractiveAuthChoice", () => {
     expect(apiKeyParams?.envVarName).toBe("CUSTOM_API_KEY");
     expect(apiKeyParams?.agentDir).toBe(target.agentDir);
     expect(apiKeyParams?.secretInputMode).toBe("ref");
-    expect(loadManifestMetadataSnapshot).toHaveBeenCalledExactlyOnceWith({
-      config: nextConfig,
-      workspaceDir: target.workspaceDir,
-      env: process.env,
-    });
   });
 
   it("keeps a custom provider model on the configured explicit-fleet system agent", async () => {

--- a/src/commands/onboard-non-interactive/local/auth-choice.ts
+++ b/src/commands/onboard-non-interactive/local/auth-choice.ts
@@ -9,7 +9,6 @@ import { formatCliCommand } from "../../../cli/command-format.js";
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
 import type { SecretInput } from "../../../config/types.secrets.js";
 import { formatErrorMessage } from "../../../infra/errors.js";
-import { loadManifestMetadataSnapshot } from "../../../plugins/manifest-contract-eligibility.js";
 import { resolveManifestDeprecatedProviderAuthChoice } from "../../../plugins/provider-auth-choices.js";
 import { normalizeSecretInputModeInput } from "../../../plugins/provider-auth-input.js";
 import { resolveDeprecatedProviderInstallCatalogEntry } from "../../../plugins/provider-install-catalog.js";
@@ -232,11 +231,6 @@ export async function applyNonInteractiveAuthChoice(params: {
 
   if (authChoice === "custom-api-key") {
     try {
-      const manifestPlugins = loadManifestMetadataSnapshot({
-        config: nextConfig,
-        workspaceDir: params.target.workspaceDir,
-        env: process.env,
-      }).plugins;
       // Custom provider setup can be optional-key: some local endpoints do not
       // require auth, but flags and env refs still need validation if present.
       const customAuth = parseNonInteractiveCustomApiFlags({
@@ -286,7 +280,6 @@ export async function applyNonInteractiveAuthChoice(params: {
         compatibility: customAuth.compatibility,
         apiKey: customApiKeyInput,
         providerId: customAuth.providerId,
-        manifestPlugins,
         supportsImageInput: customAuth.supportsImageInput,
         target: params.target,
       });


### PR DESCRIPTION
Related: #129590
Related: #129468

## What Problem This Solves

Fixes an issue where non-interactive custom provider setup performed an unused workspace plugin manifest discovery even though that flow accepts no model alias.

## Why This Change Was Made

Remove the accidentally landed manifest snapshot import, load, and handoff from the non-interactive path. Interactive custom provider onboarding keeps the prepared workspace snapshot behavior added in #129590.

## User Impact

Non-interactive custom provider setup retains its existing static alias policy and avoids unnecessary plugin manifest discovery. Interactive alias validation is unchanged.

## Evidence

- `node scripts/run-vitest.mjs src/commands/onboard-non-interactive/local/auth-choice.test.ts src/commands/onboard-custom-config.test.ts src/commands/onboard-custom.test.ts` (78 tests passed)
- Targeted `oxfmt`, `oxlint`, and `git diff --check` passed
- Delegated `check-changed` passed on Blacksmith Testbox: https://github.com/openclaw/openclaw/actions/runs/33229722424
- Production LOC: +0/-7; tests: +0/-13

AI-assisted: yes. The diff and owner boundary were reviewed directly.
