### PR TITLE
fix(test): release acquired state when wrapper setup fails

### DIFF
--- a/test/helpers/auth-wizard.test.ts
+++ b/test/helpers/auth-wizard.test.ts
@@ -1,0 +1,105 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { describe, expect, it, vi } from "vitest";
+import {
+  closeOpenClawAgentDatabaseByPath,
+  openOpenClawAgentDatabase,
+} from "../../src/state/openclaw-agent-db.js";
+import {
+  closeOpenClawStateDatabaseByPath,
+  openOpenClawStateDatabase,
+} from "../../src/state/openclaw-state-db.js";
+import { captureFullEnv, withEnvAsync } from "../../src/test-utils/env.js";
+import { setupAuthTestEnv } from "./auth-wizard.js";
+
+describe("setupAuthTestEnv", () => {
+  it.each([
+    { name: "default", agentSubdir: undefined },
+    { name: "custom", agentSubdir: "custom-agent" },
+  ])("owns the $name agent directory until cleanup", async ({ agentSubdir }) => {
+    const previousEnv = { ...process.env };
+    const snapshot = captureFullEnv();
+    const fixture = await setupAuthTestEnv("auth-wrapper-success-", { agentSubdir });
+    try {
+      expect(fixture.agentDir).toBe(path.join(fixture.stateDir, agentSubdir ?? "agent"));
+      expect((await fs.stat(fixture.agentDir)).isDirectory()).toBe(true);
+      expect(process.env.OPENCLAW_AGENT_DIR).toBe(fixture.agentDir);
+      expect(process.env.OPENCLAW_STATE_DIR).toBe(fixture.stateDir);
+      expect(process.env.OPENCLAW_CONFIG_PATH).toBe(path.join(fixture.stateDir, "openclaw.json"));
+      expect(process.env.HOME).toBe(previousEnv.HOME);
+      await fixture.cleanup();
+      expect(process.env).toEqual(previousEnv);
+      await expect(fs.stat(path.dirname(fixture.stateDir))).rejects.toMatchObject({
+        code: "ENOENT",
+      });
+    } finally {
+      try {
+        await fixture.cleanup();
+      } finally {
+        snapshot.restore();
+      }
+    }
+  });
+
+  it.each(["absent", "set"])(
+    "releases state after agent mkdir fails with agent override %s",
+    async (prior) => {
+      await withEnvAsync(
+        {
+          OPENCLAW_AGENT_DIR:
+            prior === "set" ? path.join(process.env.HOME!, "prior-agent") : undefined,
+        },
+        async () => {
+          const previousEnv = { ...process.env };
+          const snapshot = captureFullEnv();
+          const failure = new Error("agent mkdir failed");
+          let root: string | undefined;
+          let shared: ReturnType<typeof openOpenClawStateDatabase> | undefined;
+          let agent: ReturnType<typeof openOpenClawAgentDatabase> | undefined;
+          const mkdir = fs.mkdir;
+          const mkdirSpy = vi.spyOn(fs, "mkdir").mockImplementation(async (...args) => {
+            if (
+              typeof args[0] === "string" &&
+              args[0] === process.env.OPENCLAW_AGENT_DIR &&
+              path.basename(args[0]) === "faulting-agent"
+            ) {
+              const stateDir = path.dirname(args[0]);
+              root = path.dirname(stateDir);
+              expect((await fs.stat(stateDir)).isDirectory()).toBe(true);
+              const env = { ...process.env, OPENCLAW_STATE_DIR: stateDir };
+              shared = openOpenClawStateDatabase({ env });
+              agent = openOpenClawAgentDatabase({ agentId: "main", env });
+              throw failure;
+            }
+            return mkdir(...args);
+          });
+          try {
+            await expect(
+              setupAuthTestEnv("auth-wrapper-failure-", { agentSubdir: "faulting-agent" }),
+            ).rejects.toBe(failure);
+            expect.soft(process.env).toEqual(previousEnv);
+            expect.soft(shared?.db.isOpen).toBe(false);
+            expect.soft(agent?.db.isOpen).toBe(false);
+            expect(root).toBeDefined();
+            await expect(fs.stat(root!)).rejects.toMatchObject({ code: "ENOENT" });
+          } finally {
+            mkdirSpy.mockRestore();
+            try {
+              if (agent) {
+                closeOpenClawAgentDatabaseByPath(agent.path);
+              }
+              if (shared) {
+                closeOpenClawStateDatabaseByPath(shared.path);
+              }
+            } finally {
+              snapshot.restore();
+              if (root) {
+                await fs.rm(root, { recursive: true, force: true });
+              }
+            }
+          }
+        },
+      );
+    },
+  );
+});

--- a/test/helpers/auth-wizard.ts
+++ b/test/helpers/auth-wizard.ts
@@ -44,10 +44,16 @@ export async function setupAuthTestEnv(
 ): Promise<AuthTestEnv> {
   clearRuntimeAuthProfileStoreSnapshots();
   const state = await createOpenClawTestState({ prefix, layout: "state-only" });
-  const agentDir = path.join(state.stateDir, options?.agentSubdir ?? "agent");
-  process.env.OPENCLAW_AGENT_DIR = agentDir;
-  await fs.mkdir(agentDir, { recursive: true });
-  return { stateDir: state.stateDir, agentDir, cleanup: state.cleanup };
+  try {
+    const agentDir = path.join(state.stateDir, options?.agentSubdir ?? "agent");
+    process.env.OPENCLAW_AGENT_DIR = agentDir;
+    await fs.mkdir(agentDir, { recursive: true });
+    return { stateDir: state.stateDir, agentDir, cleanup: state.cleanup };
+  } catch (error) {
+    // Ownership has not reached the caller, so release the acquired state here.
+    await state.cleanup();
+    throw error;
+  }
 }
 
 type AuthTestLifecycle = {

--- a/test/helpers/openclaw-test-instance.acquisition.test.ts
+++ b/test/helpers/openclaw-test-instance.acquisition.test.ts
@@ -1,0 +1,83 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { describe, expect, it, vi } from "vitest";
+import { captureFullEnv } from "../../src/test-utils/env.js";
+import { createOpenClawTestInstance } from "./openclaw-test-instance.js";
+
+describe("createOpenClawTestInstance acquisition", () => {
+  it.each(["merge", "serialization", "write"] as const)(
+    "releases acquired state when initial config %s fails",
+    async (stage) => {
+      const previousEnv = { ...process.env };
+      const snapshot = captureFullEnv();
+      const failure = new Error(`config ${stage} failed`);
+      let root: string | undefined;
+      let writeFailure: unknown;
+      const mkdtemp = fs.mkdtemp;
+      const allocationSpy = vi.spyOn(fs, "mkdtemp").mockImplementation(async (...args) => {
+        const allocated = await mkdtemp(...args);
+        if (args[0].endsWith("instance-wrapper-failure-")) {
+          root = await fs.realpath(allocated);
+        }
+        return allocated;
+      });
+      const writeFile = fs.writeFile;
+      const writeSpy = vi.spyOn(fs, "writeFile").mockImplementation(async (...args) => {
+        if (
+          stage === "write" &&
+          root &&
+          args[0] === path.join(root, "home", ".openclaw", "openclaw.json")
+        ) {
+          // A directory at the config path makes the real filesystem write reject.
+          await fs.mkdir(args[0]);
+          try {
+            await writeFile(...args);
+          } catch (error) {
+            writeFailure = error;
+            throw error;
+          }
+          return;
+        }
+        return writeFile(...args);
+      });
+      const failConfig = () => {
+        expect(root).toBeDefined();
+        throw failure;
+      };
+      const config =
+        stage === "merge"
+          ? {
+              get gateway() {
+                return failConfig();
+              },
+            }
+          : stage === "serialization"
+            ? { toJSON: failConfig }
+            : {};
+      try {
+        const rejected = await createOpenClawTestInstance({
+          name: "acquisition-failure",
+          port: 12345,
+          state: { prefix: "instance-wrapper-failure-" },
+          config,
+        }).catch((error: unknown) => error);
+        if (stage === "write") {
+          expect(writeFailure).toMatchObject({ code: "EISDIR" });
+          expect(rejected).toBe(writeFailure);
+        } else {
+          expect(rejected).toBe(failure);
+        }
+        expect(process.env).toEqual(previousEnv);
+        expect(root).toBeDefined();
+        await expect(fs.stat(root!)).rejects.toMatchObject({ code: "ENOENT" });
+      } finally {
+        allocationSpy.mockRestore();
+        writeSpy.mockRestore();
+        snapshot.restore();
+        if (root) {
+          await fs.rm(root, { recursive: true, force: true });
+        }
+      }
+    },
+  );
+});

--- a/test/helpers/openclaw-test-instance.ts
+++ b/test/helpers/openclaw-test-instance.ts
@@ -456,19 +456,25 @@ export async function createOpenClawTestInstance(
     applyEnv: false,
     env: options.env,
   });
-  await state.writeConfig(
-    mergeConfig(
-      {
-        gateway: {
-          port,
-          auth: { mode: "token", token: gatewayToken },
-          controlUi: { enabled: false },
+  try {
+    await state.writeConfig(
+      mergeConfig(
+        {
+          gateway: {
+            port,
+            auth: { mode: "token", token: gatewayToken },
+            controlUi: { enabled: false },
+          },
+          hooks: { enabled: true, token: hookToken, path: "/hooks" },
         },
-        hooks: { enabled: true, token: hookToken, path: "/hooks" },
-      },
-      options.config,
-    ),
-  );
+        options.config,
+      ),
+    );
+  } catch (error) {
+    // Config staging can fail before the instance exposes its cleanup handle.
+    await state.cleanup();
+    throw error;
+  }
 
   const stdout = createBoundedStringLog();
   const stderr = createBoundedStringLog();


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where auth-wizard and process-instance test setup could leak an acquired fixture when wrapper setup failed before returning its cleanup handle. An agent-directory mkdir failure left the auth fixture root, environment overrides, and open fixture database handles behind. Initial instance-config merge, serialization, or filesystem-write failures left the instance root behind.

Related: https://github.com/openclaw/openclaw/pull/132257 (merged test-home acquisition rollback) and https://github.com/openclaw/openclaw/pull/132282 (independent factory-allocation cleanup). This PR repairs the caller-owned interval after the state factory returns; it does not duplicate or close either companion repair.

## Why This Change Was Made

Each wrapper now catches failures in its own staging, awaits the existing `state.cleanup()`, and rethrows the original error. The factory has already handed ownership to the wrapper, while downstream callers do not yet have a handle, so neither can release this state instead.

The canonical cleanup sequence is unchanged: drain session work, close scoped auth readers and agent databases before shared state, restore the environment, then remove the owned root. Successful auth-fixture lifetime and the entire successful instance lifecycle remain unchanged. No new abstraction, teardown sequence, fallback, or runtime seam is introduced.

## User Impact

No product-user-visible change. Developers get isolated failed test setup without leaked roots, environment overrides, or fixture database handles. No changelog, UI capture, live provider, or operator Gateway proof is applicable to this test-support-only change.

Product runtime LOC: **0**. Test support: **+28/-16 (net +12)**. Tests: **+188/-0**. The six net support lines per wrapper establish the missing ownership boundary using the existing cleanup owner. No dependency, configuration/environment option, protocol, or SQLite/schema changes.

AI-assisted with Codex. The maintainer reviewed the ownership boundary; a fresh independent scoped autoreview reported no accepted/actionable findings in its selected priority scope (P0). That review inspected tests but did not run them; the separate executed proof follows.

## Evidence

Before the source fixes, these exact child commands exercised the two new suites:

```sh
node scripts/run-vitest.mjs test/helpers/auth-wizard.test.ts test/helpers/openclaw-test-instance.acquisition.test.ts
```

**Before:** 5 intended failures and 2 successful auth-lifetime cases passed. Both prior-agent-env variants leaked on mkdir rejection; merge, serialization, and real `EISDIR` config-write failures leaked roots. **After:** all 7 passed. Tests use real state acquisition and cleanup, inspect environment restoration/database openness/root removal/error identity, and do not mock the state factory or cleanup.

The published candidate was rebased once onto `31baa67f98743ac5adb4c01f2e7fe0a94d3a3f66`, including the merged test-home rollback. All four approved file hashes remained unchanged. On candidate `baa00511d9b1a51b7344b9bc49cc6a3d3ff118d2`, macOS Node 24.20.0 ran:

```sh
node scripts/run-vitest.mjs test/helpers/auth-wizard.test.ts test/helpers/openclaw-test-instance.acquisition.test.ts test/helpers/openclaw-test-instance.test.ts src/test-utils/openclaw-test-state.test.ts src/test-utils/env.test.ts src/test-utils/session-state-cleanup.test.ts --maxWorkers=1 --no-file-parallelism --no-isolate
```

**55/55 passed** across 6 files and 4 serial Vitest shards; wrapper output: `[test] passed 4 Vitest shards in 58.47s`, exit 0. This includes all 7 new cases, the unchanged 26-case instance suite, and all 22 shared state/env/session cleanup cases. All 28 recorded synthetic fixture process instances exited; the exact owned temporary root was removed.

```sh
node scripts/check-changed.mjs -- test/helpers/auth-wizard.ts test/helpers/auth-wizard.test.ts test/helpers/openclaw-test-instance.ts test/helpers/openclaw-test-instance.acquisition.test.ts
```

**Passed, exit 0:** changed formatting, test-root typecheck, scripts lint (0 warnings / 0 errors), and selected repository guards. The temp-creation inventory emitted a warning for the acquisition test’s real-mkdtemp spy; the spy observes the factory allocation and the test has exact-root cleanup in `finally`. `git diff --check` also passed.

All local test/check commands run through a launcher with a literal credential-free environment: fresh synthetic HOME/state/config/TMP/XDG roots and a fixed Node/system PATH. No ambient credentials, operator paths, live provider, or actual OpenClaw Gateway are inherited or started. The existing lifecycle suite starts synthetic fixture children only. Proof artifacts and raw logs remain local; no inaccessible artifact links are presented as public evidence.

Caveats: an earlier Node 24 combined run passed 54/55 because the unchanged `SIGKILLs a TERM-resistant gateway group before releasing state` case missed its 500ms startup deadline; its single-case rerun passed unchanged, and the candidate's full 55-case run above passed without a retry. Startup-clock coupling remains a separate follow-up; no timeout or assertion was weakened. Earlier Node 26 proof also passed 55/55. Supplemental core lint passed both new suites and the instance wrapper, but whole-file auth-wrapper lint reports the pre-existing `unicorn/no-array-reverse` in unchanged lifecycle cleanup (`cleanups.splice(0).reverse()`, also present on the candidate base). The required changed gate is reported separately, not as a claim that this supplemental baseline lint is green. Local Windows/Linux, full-suite, and live-product execution were not performed; attached exact-head CI is separate evidence.

Exact-head GitHub CI: [run 33230748235, attempt 1](https://github.com/openclaw/openclaw/actions/runs/33230748235) completed **success** for `baa00511d9b1a51b7344b9bc49cc6a3d3ff118d2` (100 successful jobs, 17 skipped). The [openclaw/ci-gate](https://github.com/openclaw/openclaw/actions/runs/33230748235/job/99043790177) passed, and the exact-head watcher exited 0 with `GREEN`, zero pending checks. This records CI evidence only; independent review and the maintainer landing decision remain separate.
