### PR TITLE
fix(release): ignore skipped attempt-evidence jobs

### DIFF
--- a/scripts/full-release-validation-policy.mjs
+++ b/scripts/full-release-validation-policy.mjs
@@ -368,6 +368,11 @@ export function composeReleaseAttemptJobs(attempts, expected = {}) {
     const names = new Set();
     for (const rawJob of attempt.jobs) {
       const job = normalizedAttemptJob(rawJob, expectedAttempt);
+      // Completed skipped jobs never executed, so they cannot contribute attempt
+      // evidence. Drop them before identity checks because placeholders may collide.
+      if (job.status === "completed" && job.conclusion === "skipped") {
+        continue;
+      }
       if (names.has(job.name)) {
         throw new Error(
           `release child attempt ${expectedAttempt} contains duplicate job identity: ${job.name}`,

--- a/test/scripts/full-release-validation-state.test.ts
+++ b/test/scripts/full-release-validation-state.test.ts
@@ -630,6 +630,41 @@ describe("release child attempt composition", () => {
     ]);
   });
 
+  it("ignores terminal skipped jobs before duplicate identity checks", () => {
+    const matrixPlaceholder = job("matrix.check_name", "skipped");
+    const skippedJob = job("disabled-check", "skipped");
+    const result = composeReleaseAttemptJobs(
+      [
+        {
+          jobs: [
+            matrixPlaceholder,
+            matrixPlaceholder,
+            skippedJob,
+            skippedJob,
+            job("test", "success"),
+          ],
+          runAttempt: 1,
+        },
+      ],
+      { effectiveRunAttempt: 1, plannedRunAttempt: 1 },
+    );
+    expect(result.jobs).toEqual([
+      expect.objectContaining({ acceptedRunAttempt: 1, conclusion: "success", name: "test" }),
+    ]);
+  });
+
+  it.each([
+    ["nonterminal", { ...job("matrix.check_name", "skipped"), status: "queued" }],
+    ["nonskipped", job("disabled-check", "success")],
+  ])("still rejects duplicate %s jobs", (_label, retainedJob) => {
+    expect(() =>
+      composeReleaseAttemptJobs([{ jobs: [retainedJob, retainedJob], runAttempt: 1 }], {
+        effectiveRunAttempt: 1,
+        plannedRunAttempt: 1,
+      }),
+    ).toThrow("duplicate job identity");
+  });
+
   it("rejects duplicate logical jobs and gapped attempts", () => {
     expect(() =>
       composeReleaseAttemptJobs(


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Full Release Validation could reject valid child-attempt evidence when GitHub returned multiple terminal skipped matrix placeholders with the same display name.

## Why This Change Was Made

Attempt composition now normalizes each job and excludes only jobs that are both `completed` and `skipped` before logical identity validation. Those jobs never executed and cannot contribute attempt evidence; all retained jobs still use the existing strict duplicate rejection.

## User Impact

Release operators can collect and seal valid retry evidence without false duplicate-job failures from GitHub's skipped matrix placeholders. Real duplicate job identities remain fail-closed.

## Evidence

- Live GitHub Actions attempt `33230019958` returned three separate jobs named `matrix.check_name`, all with `status=completed` and `conclusion=skipped`.
- Owner decision: accepted for this FRV reliability program; `completed/skipped` jobs are non-executed records and do not belong in digest-bound attempt evidence.
- Pre-fix reproduction failed with `release child attempt 1 contains duplicate job identity: matrix.check_name`.
- Focused composition suite: 6 passed, 154 skipped.
- Full owner test file: 160 passed.
- `pnpm format:check --no-error-on-unmatched-pattern -- scripts/full-release-validation-policy.mjs test/scripts/full-release-validation-state.test.ts`: passed.
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.scripts.json scripts/full-release-validation-policy.mjs`: passed.
- `node scripts/check-changed.mjs -- ...`: all preceding gates passed; `tsgo:test:root` reached the known main baseline missing `pako` declaration at `ui/vite.config.ts:9`.
- Claude Fable 5 autoreview at the rebased head: no accepted or actionable P0/P1 findings.

Production/tooling LOC: +5/-0. Tests: +35/-0.

AI-assisted: yes.
