### PR TITLE
test(discord): fix component suite initialization order

### DIFF
--- a/extensions/discord/src/send.components.test.ts
+++ b/extensions/discord/src/send.components.test.ts
@@ -88,17 +88,18 @@ function readRecordArg(
   return arg as Record<string, unknown>;
 }
 
+// Both suites consume these bindings, including when either suite runs alone or first.
+beforeAll(async () => {
+  ({ registerDiscordComponentEntries } = await import("./components-registry.js"));
+  ({
+    editDiscordComponentMessage,
+    registerBuiltDiscordComponentMessage,
+    sendDiscordComponentMessage,
+  } = await import("./send.components.js"));
+});
+
 describe("sendDiscordComponentMessage", () => {
   let registerMock: ReturnType<typeof vi.mocked<typeof registerDiscordComponentEntries>>;
-
-  beforeAll(async () => {
-    ({ registerDiscordComponentEntries } = await import("./components-registry.js"));
-    ({
-      editDiscordComponentMessage,
-      registerBuiltDiscordComponentMessage,
-      sendDiscordComponentMessage,
-    } = await import("./send.components.js"));
-  });
 
   beforeEach(() => {
     registerMock = vi.mocked(registerDiscordComponentEntries);


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where developers running the Discord component tests in shuffled order, or selecting only the classic-message suite, get 12 `sendDiscordComponentMessage is not a function` failures before the real assertions execute. This is a maintainer-requested repair of a confirmed test fixture ownership defect.

## Why This Change Was Made

The component and classic-message suites share four imported bindings, but only the component suite's `beforeAll` initialized them. Move that existing hook to file scope so initialization precedes either suite, while preserving once-per-file dynamic imports, per-test mock resets, all 21 cases, and every assertion. No new helper, test seam, forced ordering, retry, or broader mock is needed.

The classic sibling was added in #60361 (authored by @geekhuashan, merged by @steipete), while consuming the existing suite-owned bindings. Installed Vitest 4.1.11 registers `beforeAll` with the current suite and executes it before that suite's children (`@vitest/runner/dist/chunk-artifact.js:668-675,3137-3163`); moving ownership to the file directly repairs that contract.

## User Impact

No runtime or user-facing behavior changes. Developers can run either Discord component suite independently or first without losing component, classic-message, multipart HTTP, delivery-authority, or registry coverage. Production LOC: +0/-0. Tests: +10/-9 (hook relocation plus one ownership comment).

## Evidence

Before the fix on `116425e9b3044c88c20c8727360663b6ce9eeed9`, the four-file seed-17 run produced 104 passed / 12 failed; selecting only the classic suite produced 12 failed / 9 skipped. Afterward:

- Classic-only: 12 passed / 9 intentionally unselected.
- Component file, normal order and shuffled seeds 17 and 91: 21/21 passed each.
- Original four-file selection, one worker, seeds 17 and 91: 116/116 passed each, with separate filesystem module caches. The REST sibling was unchanged for both final runs.
- Focused formatting and `git diff --check` passed. Fresh Codex autoreview reported no actionable findings; independent source/lifecycle inspection agreed with file ownership.
- Changed gate passed in Blacksmith Testbox, [run 33231128728](https://github.com/openclaw/openclaw/actions/runs/33231128728), wrapper exit 0; lease stopped after success.
- Exact-head [CI run 33231228185](https://github.com/openclaw/openclaw/actions/runs/33231228185) passed for `b148c7020ea0a7e32defb5f1b4d5f2cb45b403b9`.

Commands (each run used its own `OPENCLAW_VITEST_FS_MODULE_CACHE_PATH`):

```sh
node scripts/run-vitest.mjs extensions/discord/src/send.components.test.ts --maxWorkers=1 -t 'classic message downgrade' --reporter=verbose
node scripts/run-vitest.mjs extensions/discord/src/send.components.test.ts --maxWorkers=1 --reporter=verbose
node scripts/run-vitest.mjs extensions/discord/src/send.components.test.ts --maxWorkers=1 --sequence.shuffle --sequence.seed=17 --reporter=verbose
node scripts/run-vitest.mjs extensions/discord/src/send.components.test.ts --maxWorkers=1 --sequence.shuffle --sequence.seed=91 --reporter=verbose
node scripts/run-vitest.mjs extensions/discord/src/send.components.multipart.test.ts extensions/discord/src/send.components.test.ts extensions/discord/src/outbound-payload.contract.test.ts extensions/discord/src/internal/rest.test.ts --maxWorkers=1 --sequence.shuffle --sequence.seed=17 --reporter=verbose
node scripts/run-vitest.mjs extensions/discord/src/send.components.multipart.test.ts extensions/discord/src/send.components.test.ts extensions/discord/src/outbound-payload.contract.test.ts extensions/discord/src/internal/rest.test.ts --maxWorkers=1 --sequence.shuffle --sequence.seed=91 --reporter=verbose
node scripts/check-changed.mjs -- extensions/discord/src/send.components.test.ts
```

Existing behavioral cases provide the regression proof; no duplicate meta-test or source-layout assertion was added. Real loopback HTTP remains exercised. Live authenticated Discord is not applicable to this test-only initialization change. The separately tracked REST/Undici timer-lifecycle investigation is not part of this PR.

AI-assisted with Codex.
