### PR TITLE
refactor(test): share CI checkout fixture lifecycle

### DIFF
--- a/test/scripts/ci-checkout.test-support.ts
+++ b/test/scripts/ci-checkout.test-support.ts
@@ -1,0 +1,80 @@
+import { fork } from "node:child_process";
+import { readFileSync, rmSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { expect } from "vitest";
+import { parse } from "yaml";
+import { waitForChildClose } from "../helpers/process-wait.js";
+
+type Step = { name?: string; run?: string; env?: Record<string, string | number> };
+type ProcessRecord = { pid: number; role: string; attempt: number };
+type Report = {
+  code: number | null;
+  cancelledDuringCleanup: boolean;
+  error?: string;
+  boundaries: { name: string; alive: ProcessRecord[]; sentinelAlive: boolean }[];
+  readyAttempts: number[];
+  cleanupRemaining: ProcessRecord[];
+  ownedProcesses: ProcessRecord[];
+  commands: { tool: string; cwd: string; args: string[] }[];
+  output: string;
+};
+
+export const ciCheckoutFixture = fileURLToPath(
+  new URL("./fixtures/ci-platform-checkout.mjs", import.meta.url),
+);
+const workflow = parse(readFileSync(".github/workflows/ci.yml", "utf8")) as {
+  jobs: Record<string, { steps: Step[] }>;
+};
+
+export function readCiCheckoutStep(job: string, name = "Checkout"): Step & { run: string } {
+  const step = workflow.jobs[job]?.steps.find((entry) => entry.name === name);
+  if (!step?.run) {
+    throw new Error(`Missing executable workflow step ${job}/${name}`);
+  }
+  return { ...step, run: step.run };
+}
+
+export function expectCiCheckoutCleanup(report: Report) {
+  expect(report.cleanupRemaining, "fixture cleanup left owned processes").toEqual([]);
+  expect(report.boundaries.at(-1)?.name).toBe("exit");
+  expect(
+    report.boundaries.every((entry) => entry.sentinelAlive),
+    "unrelated process killed",
+  ).toBe(true);
+  expect(
+    report.boundaries.filter((entry) => entry.alive.length > 0),
+    "Git descendants survived BEFORE deletion, reuse, consumption, or exit",
+  ).toEqual([]);
+}
+
+export async function withCiCheckoutFixture<T>(
+  root: string,
+  scenario: string,
+  inspect: (
+    report: Report,
+    result: Awaited<ReturnType<typeof waitForChildClose>>,
+    stderr: string,
+  ) => T,
+): Promise<T> {
+  const supervisor = fork(ciCheckoutFixture, ["supervise", root, scenario], {
+    detached: true,
+    execArgv: [],
+    stdio: ["ignore", "ignore", "pipe", "ipc"],
+  });
+  let stderr = "";
+  supervisor.stderr?.on("data", (data) => (stderr += String(data)));
+  const closed = waitForChildClose(supervisor, 50_000);
+  try {
+    const result = await closed;
+    const report = JSON.parse(readFileSync(path.join(root, "report.json"), "utf8")) as Report;
+    return await inspect(report, result, stderr);
+  } finally {
+    // IPC loss triggers fixture cleanup; never remove its root before joining it.
+    if (supervisor.connected) {
+      supervisor.disconnect();
+    }
+    await closed;
+    rmSync(root, { recursive: true, force: true });
+  }
+}

--- a/test/scripts/ci-linux-git.test.ts
+++ b/test/scripts/ci-linux-git.test.ts
@@ -1,33 +1,20 @@
-import { fork } from "node:child_process";
 import {
   existsSync,
   mkdirSync,
   mkdtempSync,
   readFileSync,
   realpathSync,
-  rmSync,
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
 import { expect, it } from "vitest";
-import { parse } from "yaml";
-import { waitForChildClose } from "../helpers/process-wait.js";
+import {
+  expectCiCheckoutCleanup,
+  readCiCheckoutStep,
+  withCiCheckoutFixture,
+} from "./ci-checkout.test-support.js";
 
-type Step = { name?: string; run?: string; env?: Record<string, string | number> };
-type ProcessRecord = { pid: number; role: string; attempt: number };
-type Command = { tool: string; cwd: string; args: string[] };
-type Report = {
-  code: number | null;
-  cancelledDuringCleanup: boolean;
-  error?: string;
-  boundaries: { name: string; alive: ProcessRecord[]; sentinelAlive: boolean }[];
-  readyAttempts: number[];
-  cleanupRemaining: ProcessRecord[];
-  commands: Command[];
-  output: string;
-};
 type FetchResult = number | "hang" | "cleanup-failure";
 
 const candidate = "a".repeat(40);
@@ -35,7 +22,6 @@ const harness = "b".repeat(40);
 const base = "c".repeat(40);
 const moved = "d".repeat(40);
 const merge = "e".repeat(40);
-const fixture = fileURLToPath(new URL("./fixtures/ci-platform-checkout.mjs", import.meta.url));
 const linuxIt = it.skipIf(process.platform !== "linux");
 const defaults: Record<string, string> = {
   CHECKOUT_REPO: "fixture/checkout",
@@ -67,18 +53,10 @@ const defaults: Record<string, string> = {
   RATCHET_PR_HEAD_SHA: candidate,
 };
 
-function workflowStep(job: string, name: string): Step & { run: string } {
-  const workflow = parse(readFileSync(".github/workflows/ci.yml", "utf8")) as {
-    jobs: Record<string, { steps: Step[] }>;
-  };
-  const step = workflow.jobs[job]?.steps.find((entry) => entry.name === name);
-  if (!step?.run) {
-    throw new Error(`Missing executable workflow step ${job}/${name}`);
-  }
-  return { ...step, run: step.run };
-}
-
-function stepEnvironment(step: Step, supplied: Record<string, string>) {
+function stepEnvironment(
+  step: ReturnType<typeof readCiCheckoutStep>,
+  supplied: Record<string, string>,
+) {
   const resolved = { ...defaults, ...supplied };
   for (const [key, value] of Object.entries(step.env ?? {})) {
     if (String(value).startsWith("${{")) {
@@ -128,7 +106,7 @@ async function runStep(options: {
   revisions?: Record<string, string>;
   poisonPython?: boolean;
 }) {
-  const step = workflowStep(options.job, options.step ?? "Checkout");
+  const step = readCiCheckoutStep(options.job, options.step ?? "Checkout");
   const env = stepEnvironment(step, options.env ?? {});
   const root = realpathSync(mkdtempSync(path.join(tmpdir(), "ci linux git ")));
   const workspace = path.join(root, "workspace");
@@ -171,37 +149,18 @@ async function runStep(options: {
   const readyFile = options.cancelDuringCleanup ? path.join(root, "ready-1.json") : undefined;
   let run = accelerate(step.run, readyFile);
   if (options.prepare) {
-    const prepare = workflowStep("security-fast", "Prepare Git owner");
+    const prepare = readCiCheckoutStep("security-fast", "Prepare Git owner");
     const prepareEnv = stepEnvironment(prepare, {});
     writeFileSync(path.join(root, "prepare.sh"), accelerate(prepare.run, readyFile));
     // Run the actual prepare body in its own shell: its exec must not replace the caller.
     run = `CHECKOUT_KIND=${prepareEnv.CHECKOUT_KIND} bash --noprofile --norc -eo pipefail "$TMPDIR/prepare.sh"\n${run}`;
   }
   writeFileSync(path.join(root, "checkout.sh"), run);
-  const supervisor = fork(fixture, ["supervise", root, "linux:configured"], {
-    detached: true,
-    execArgv: [],
-    stdio: ["ignore", "ignore", "pipe", "ipc"],
-  });
-  let stderr = "";
-  supervisor.stderr?.on("data", (data) => (stderr += String(data)));
-  const closed = waitForChildClose(supervisor, 50_000);
-  try {
-    const result = await closed;
-    const report = JSON.parse(readFileSync(path.join(root, "report.json"), "utf8")) as Report;
+  return withCiCheckoutFixture(root, "linux:configured", (report, result, stderr) => {
     console.log(`${options.job}/${options.step ?? "Checkout"}: ${JSON.stringify(report)}`);
     expect(result, stderr).toEqual({ code: 0, signal: null });
     expect(report.error, stderr).toBeUndefined();
-    expect(report.cleanupRemaining, "fixture cleanup left owned processes").toEqual([]);
-    expect(report.boundaries.at(-1)?.name).toBe("exit");
-    expect(
-      report.boundaries.every((entry) => entry.sentinelAlive),
-      "unrelated process killed",
-    ).toBe(true);
-    expect(
-      report.boundaries.filter((entry) => entry.alive.length > 0),
-      "Git descendants survived BEFORE deletion, reuse, consumption, or exit",
-    ).toEqual([]);
+    expectCiCheckoutCleanup(report);
     expect(readFileSync(protectedFile, "utf8")).toBe("not checkout-owned\n");
     expect(
       existsSync(path.join(root, "python-injected")),
@@ -219,13 +178,7 @@ async function runStep(options: {
         ({ tool, args }) => tool === "git" && args[0] === "checkout",
       ),
     };
-  } finally {
-    if (supervisor.connected) {
-      supervisor.disconnect();
-    }
-    await closed;
-    rmSync(root, { recursive: true, force: true });
-  }
+  });
 }
 
 const resetProfiles = [
@@ -379,11 +332,11 @@ linuxIt.each(
 );
 
 linuxIt(
-  "preflight refetches a moved exact SHA before fetching its parent metadata",
+  "preflight pins a moved exact SHA and retries only its parent metadata",
   async () => {
     const report = await runStep({
       job: "preflight",
-      fetchResults: [0, 0, 0],
+      fetchResults: [0, 0, 23, 0],
       env: { GITHUB_EVENT_NAME: "workflow_dispatch" },
       poisonPython: true,
     });
@@ -392,10 +345,11 @@ linuxIt(
       "+refs/heads/main:refs/remotes/origin/checkout",
       `+${candidate}:refs/remotes/origin/checkout`,
       candidate,
+      candidate,
     ]);
-    expect(report.fetches[2]?.args).toEqual(
-      expect.arrayContaining(["--depth=2", "--filter=blob:none"]),
-    );
+    for (const fetch of report.fetches.slice(2)) {
+      expect(fetch.args).toEqual(expect.arrayContaining(["--depth=2", "--filter=blob:none"]));
+    }
     expect(report.checkouts.map(({ args }) => args)).toEqual([
       ["checkout", "--detach", "refs/remotes/origin/checkout"],
     ]);
@@ -417,26 +371,6 @@ linuxIt(
       `+${candidate}:refs/remotes/origin/checkout`,
     ]);
     expect(report.checkouts).toEqual([]);
-  },
-  55_000,
-);
-
-linuxIt(
-  "preflight retries parent metadata without refetching the selected tree",
-  async () => {
-    const report = await runStep({ job: "preflight", fetchResults: [0, 23, 0] });
-    expect(report.code).toBe(0);
-    expect(report.fetches.map(({ args }) => args.at(-1))).toEqual([
-      `+${candidate}:refs/remotes/origin/checkout`,
-      candidate,
-      candidate,
-    ]);
-    for (const fetch of report.fetches.slice(1)) {
-      expect(fetch.args).toEqual(expect.arrayContaining(["--depth=2", "--filter=blob:none"]));
-    }
-    expect(report.checkouts.map(({ args }) => args)).toEqual([
-      ["checkout", "--detach", "refs/remotes/origin/checkout"],
-    ]);
   },
   55_000,
 );

--- a/test/scripts/ci-platform-checkout.test.ts
+++ b/test/scripts/ci-platform-checkout.test.ts
@@ -1,41 +1,15 @@
-import { fork, spawnSync } from "node:child_process";
-import { mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, realpathSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
 import { expectDefined } from "@openclaw/normalization-core";
 import { expect, it } from "vitest";
-import { parse } from "yaml";
-import { waitForChildClose } from "../helpers/process-wait.js";
-
-type ProcessRecord = { pid: number; role: string; attempt: number };
-type Boundary = { name: string; alive: ProcessRecord[]; sentinelAlive: boolean };
-type Report = {
-  code: number | null;
-  error?: string;
-  boundaries: Boundary[];
-  readyAttempts: number[];
-  cleanupRemaining: ProcessRecord[];
-  ownedProcesses: ProcessRecord[];
-  commands: { cwd: string; args: string[] }[];
-  output: string;
-};
-
-const fixture = fileURLToPath(new URL("./fixtures/ci-platform-checkout.mjs", import.meta.url));
-
-function readCheckoutRun(linux: boolean): string {
-  const workflow = parse(readFileSync(".github/workflows/ci.yml", "utf8")) as {
-    jobs: Record<string, { steps: { name?: string; run?: string }[] }>;
-  };
-  const run = workflow.jobs[linux ? "checks-fast-core" : "checks-windows"]?.steps.find(
-    (step) => step.name === "Checkout",
-  )?.run;
-  expect(run).toBeTypeOf("string");
-  if (!run) {
-    throw new Error("Missing shared platform checkout shell");
-  }
-  return run;
-}
+import {
+  ciCheckoutFixture,
+  expectCiCheckoutCleanup,
+  readCiCheckoutStep,
+  withCiCheckoutFixture,
+} from "./ci-checkout.test-support.js";
 
 // Execute both workflow policies against the same owned tree fixture. A leader's
 // exit must not authorize workspace deletion, Git reuse, or final success.
@@ -80,7 +54,7 @@ it.each([
   "preserves checkout ownership and fixture isolation (Linux=$linux, $scenario)",
   async ({ scenario, attempts, code, checkout, linux, deletions }) => {
     const setupFailure = scenario.startsWith("non-executable-");
-    const run = readCheckoutRun(linux);
+    const run = readCiCheckoutStep(linux ? "checks-fast-core" : "checks-windows").run;
 
     const root = realpathSync(mkdtempSync(path.join(tmpdir(), "ci platform checkout ")));
     const workspace = path.join(root, "workspace");
@@ -130,21 +104,12 @@ def run_git(`,
       setupFailure ? "printf 'unexpected workflow invocation\\n' >&2\nexit 99\n" : accelerated,
     );
 
-    const supervisor = fork(fixture, ["supervise", root, `${linux ? "linux:" : ""}${scenario}`], {
-      detached: true,
-      execArgv: [],
-      stdio: ["ignore", "ignore", "pipe", "ipc"],
-    });
-    let stderr = "";
-    supervisor.stderr?.on("data", (data) => (stderr += String(data)));
-    const closed = waitForChildClose(supervisor, 50_000);
-    try {
-      const result = await closed;
-      const report = JSON.parse(readFileSync(path.join(root, "report.json"), "utf8")) as Report;
+    const policyScenario = `${linux ? "linux:" : ""}${scenario}`;
+    await withCiCheckoutFixture(root, policyScenario, (report, result, stderr) => {
       // Emit evidence before assertions; it remains available even for this deliberately red test.
       console.log(`${scenario}: ${JSON.stringify(report)}`);
-      expect(report.cleanupRemaining, "fixture cleanup left owned processes").toEqual([]);
       if (setupFailure) {
+        expect(report.cleanupRemaining, "fixture cleanup left owned processes").toEqual([]);
         expect(report.error, report.output).toContain(
           "Fixture setup: mock command resolution failed",
         );
@@ -158,13 +123,7 @@ def run_git(`,
       }
       expect(result, stderr).toEqual({ code: 0, signal: null });
       expect(report.error, stderr).toBeUndefined();
-      const leaks = report.boundaries
-        .filter((entry) => entry.alive.length > 0)
-        .map(({ name, alive }) => ({ boundary: name, survivors: alive }));
-      expect(
-        leaks,
-        "Git descendants must be dead BEFORE workspace deletion, reuse or exit",
-      ).toEqual([]);
+      expectCiCheckoutCleanup(report);
       expect(report.code).toBe(code);
       expect(report.readyAttempts).toEqual(Array.from({ length: attempts }, (_, i) => i + 1));
       expect(report.boundaries.filter((entry) => entry.name.startsWith("fetch:"))).toHaveLength(
@@ -172,7 +131,6 @@ def run_git(`,
       );
       expect(report.boundaries.some((entry) => entry.name === "checkout")).toBe(checkout);
       expect(report.boundaries.filter((entry) => entry.name === "delete")).toHaveLength(deletions);
-      expect(report.boundaries.at(-1)?.name).toBe("exit");
       expect(report.output.includes("refusing reuse or retry")).toBe(
         scenario === "cleanup-failure",
       );
@@ -236,18 +194,7 @@ def run_git(`,
           "b".repeat(40),
         ]);
       }
-      expect(
-        report.boundaries.every((entry) => entry.sentinelAlive),
-        "unrelated sentinel killed",
-      ).toBe(true);
-    } finally {
-      // IPC loss also triggers cleanup if Vitest is canceled or its worker is killed.
-      if (supervisor.connected) {
-        supervisor.disconnect();
-      }
-      await closed;
-      rmSync(root, { recursive: true, force: true });
-    }
+    });
   },
   55_000,
 );
@@ -290,7 +237,7 @@ with tempfile.TemporaryDirectory(prefix="checkout-pid-reuse-") as directory:
 print("fixture lifetime contract passed")
 `,
       process.execPath,
-      fixture,
+      ciCheckoutFixture,
     ],
     { encoding: "utf8", timeout: 15_000, killSignal: "SIGKILL" },
   );
@@ -302,7 +249,7 @@ it.skipIf(process.platform === "win32")(
   "recognizes terminated POSIX groups without accepting live signal denials",
   () => {
     const owner = expectDefined(
-      readCheckoutRun(false).split("<<'PYTHON'\n")[1]?.split("\nPYTHON")[0],
+      readCiCheckoutStep("checks-windows").run.split("<<'PYTHON'\n")[1]?.split("\nPYTHON")[0],
       "checkout Python owner",
     );
     const result = spawnSync(
@@ -369,7 +316,7 @@ with subprocess.Popen([sys.executable, "-I", "-S", "-c",
 print("group contract passed")
 `,
         process.execPath,
-        fixture,
+        ciCheckoutFixture,
       ],
       { input: owner, encoding: "utf8", timeout: 15_000, killSignal: "SIGKILL" },
     );


### PR DESCRIPTION
Related: [standalone Linux Git checkout ownership repair, PR #132169](https://github.com/openclaw/openclaw/pull/132169).

## What Problem This Solves

Maintainer-requested cleanup of the checkout regression tests after the ownership repair. The Linux and platform suites duplicated the same process-launch, report, and teardown plumbing, making safety-sensitive test changes harder to keep aligned. Two preflight tests also repeated successful checkout setup and assertions.

## Why This Change Was Made

Move the shared parent-side fixture lifecycle, report shape, cleanup assertions, and immutable workflow lookup into one small test-support module. Both suites still launch the existing supervisor, emit complete reports before assertions, and disconnect/join before removing the temporary root; intentionally failed fixture setup keeps its separate failure assertions.

Combine moved-ref correction and metadata retry into one ordered preflight recovery case: event ref, exact SHA, failed metadata fetch, successful metadata retry, and exactly one checkout. Python-startup isolation and the separate push-failure/exact-SHA-mismatch cases remain.

Production workflow, fake-Git supervisor, process census, instance-lifetime tracking, clocks, deadlines, and retry/fallback rules are unchanged. The larger trusted-owner extraction is separate work, not duplicated here.

## User Impact

No user-visible behavior change. Maintainers have one place to maintain the common checkout-test lifecycle and fewer redundant test operations. Production LOC is unchanged; tests and test support are **+117/-156, net -39**, including the new 80-line helper.

## Evidence

- Native Linux: both checkout suites passed **64/64 cases** in an isolated local Node 24 Bookworm container with repository-pinned Vitest/yaml, `--init`, and `--network none`. The count decreases by one because two preflight cases became one stronger ordered case, not because a behavior was dropped.
- macOS: complete original-order platform suite passed **22/22 cases**, including non-executable mock failures, cancellation, cleanup failure, PID-instance reuse, and zombie/live-signal-denial coverage.
- Two independent negative controls disabled exact-ref correction or metadata retries in separate temporary workflow copies. Each made the combined case fail because recovery returned 1 instead of 0. No production test seam or weaker assertion was introduced.
- Targeted formatting, root-test typechecking, lint/guards, and `git diff --check` passed.
- Four independent cleanup-review lanes preceded the change; fresh precommit P0 autoreview is scoped-clean. The latest exact-head ClawSweeper review reports no findings.
- [Normal CI run 33231307425](https://github.com/openclaw/openclaw/actions/runs/33231307425) passed all **99 executed jobs** on exact head `393b6857d0e98ac85bcc944d6ce8f941e34e8cb3`, including the required gate.
- Normal PR routing skips Windows for this test-only diff, so [Windows probe 33231351902](https://github.com/openclaw/openclaw/actions/runs/33231351902/job/99044642575) separately tested the same exact target on a GitHub-hosted `windows-2025` runner. All **seven applicable checkout cases** passed; the workflow's native Scheduled Task proof and cleanup also passed. Its trusted workflow SHA is `30772d50614478e320d0368dbc716b2589a47095`, distinct from the tested target SHA. Keepalive was zero; no paid Testbox lease was provisioned.

Local commands:

```bash
node scripts/run-vitest.mjs test/scripts/ci-platform-checkout.test.ts
```

```bash
node scripts/check-changed.mjs -- test/scripts/ci-checkout.test-support.ts test/scripts/ci-linux-git.test.ts test/scripts/ci-platform-checkout.test.ts
```

```bash
git diff --check
```

AI-assisted implementation and review.
