### PR TITLE
fix(bug): telegram session remains running ~15 minutes after successful terminal delivery on beta.3

### DIFF
--- a/src/gateway/server-chat.agent-events.test.ts
+++ b/src/gateway/server-chat.agent-events.test.ts
@@ -4894,6 +4894,33 @@ describe("agent event handler", () => {
     expect(persistGatewaySessionLifecycleEventMock).toHaveBeenCalledTimes(persisted);
   });
 
+  it("preserves an owner claim in the terminal persistence handoff", () => {
+    const runId = "claimed-terminal-handoff";
+    const claimId = claimAgentRunContext(
+      runId,
+      { sessionKey: "session-claimed-terminal" },
+      { exclusive: true, trackOwner: true },
+    )!;
+    const { handler } = createHarness({
+      resolveSessionKeyForRun: () => "session-claimed-terminal",
+    });
+    let event: Parameters<typeof handler>[0] | undefined;
+    const stop = onAgentRuntimeEvent((received) => {
+      event = received;
+    });
+    emitAgentEventForOwner({ runId, stream: "lifecycle", data: { phase: "end" } }, claimId);
+    stop();
+
+    handler(expectDefined(event, "claimed terminal event"));
+
+    expect(persistGatewaySessionLifecycleEventMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: expect.objectContaining({ contextClaimId: claimId }),
+      }),
+    );
+    releaseAgentRunContext(runId, claimId);
+  });
+
   it("mirrors commentary-phase assistant events only to exact session message subscribers", () => {
     const {
       broadcast,

--- a/src/gateway/server-chat.ts
+++ b/src/gateway/server-chat.ts
@@ -715,6 +715,7 @@ export function createAgentEventHandler({
     if (isSupersededRestartRecoveryEvent) {
       return;
     }
+    let terminalPersistence: Promise<void> | undefined;
 
     if (
       !replyDispatchOwnsCompletion &&
@@ -788,7 +789,9 @@ export function createAgentEventHandler({
       if (suppressRestartRecoveryProjection && chatLink) {
         chatRunState.registry.remove(evt.runId, clientRunId, sessionKey);
       }
-      clearRunContextForEvent(evt);
+      if (!evt.contextClaimId) {
+        clearRunContextForEvent(evt);
+      }
       agentRunSeq.delete(evt.runId);
       agentRunSeq.delete(clientRunId);
     }
@@ -801,6 +804,7 @@ export function createAgentEventHandler({
           agentId: sessionAgentId,
           event: {
             ...evt,
+            ...(evt.contextClaimId ? { contextClaimId: evt.contextClaimId } : {}),
             ...(eventRunId !== evt.runId ? { clientRunId: eventRunId } : {}),
             ...(evt.lifecycleGeneration ? { lifecycleGeneration: evt.lifecycleGeneration } : {}),
             ...(evt.mainSessionRestartRecovery === true
@@ -808,6 +812,7 @@ export function createAgentEventHandler({
               : {}),
           },
         });
+        terminalPersistence = persistence;
         trackTrackedRunTerminalPersistence?.({
           runId: evt.runId,
           clientRunId,
@@ -871,6 +876,16 @@ export function createAgentEventHandler({
           sessionKey,
           persisted: false,
         });
+      }
+    }
+    if (!replyDispatchOwnsCompletion && evt.contextClaimId) {
+      // The queued write's commit guard requires this exact claim to stay active.
+      // Abort or replacement can still revoke it before the write settles.
+      if (terminalPersistence) {
+        const clearOwnedRunContext = () => clearRunContextForEvent(evt);
+        void terminalPersistence.then(clearOwnedRunContext, clearOwnedRunContext);
+      } else {
+        clearRunContextForEvent(evt);
       }
     }
   };

--- a/src/gateway/server-runtime-subscriptions.test.ts
+++ b/src/gateway/server-runtime-subscriptions.test.ts
@@ -13,9 +13,15 @@ import { tryFinishCronTaskRunWithoutHistory } from "../cron/service/task-runs.js
 import {
   emitAgentAuditEvent,
   emitAgentEvent,
+  emitAgentEventForOwner,
   getAgentEventLifecycleGeneration,
   resetAgentEventsForTest,
 } from "../infra/agent-events.js";
+import {
+  claimAgentRunContext,
+  getAgentRunContextOwnerStatus as ownerStatus,
+  releaseAgentRunContext,
+} from "../infra/agent-run-registry.js";
 import type { SubsystemLogger } from "../logging/subsystem.js";
 import { emitSessionLifecycleEvent } from "../sessions/session-lifecycle-events.js";
 import {
@@ -41,7 +47,6 @@ import {
   createSessionEventSubscriberRegistry,
   createSessionMessageSubscriberRegistry,
 } from "./server-chat-state.js";
-import type { AgentEventHandlerOptions } from "./server-chat.js";
 import type { TaskEventPayload } from "./server-methods/task-summary.js";
 import { TerminalSessionManager } from "./terminal/session-manager.js";
 import {
@@ -84,6 +89,8 @@ const auditTestState = vi.hoisted(() => ({
 }));
 const agentEventHandlerMocks = vi.hoisted(() => ({
   create: vi.fn(),
+  persistLifecycle: vi.fn(async () => {}),
+  resolveSessionKey: vi.fn(() => "agent:main:main"),
 }));
 const transcriptBroadcastMocks = vi.hoisted(() => ({
   useActualHandler: false,
@@ -129,8 +136,12 @@ vi.mock("./server-chat.js", () => ({
   createAgentEventHandler: (...args: unknown[]) => agentEventHandlerMocks.create(...args),
 }));
 
+vi.mock("./session-lifecycle-state.js", () => ({
+  persistGatewaySessionLifecycleEvent: agentEventHandlerMocks.persistLifecycle,
+}));
+
 vi.mock("./server-session-key.js", () => ({
-  resolveSessionKeyForRun: () => "agent:main:main",
+  resolveSessionKeyForRun: agentEventHandlerMocks.resolveSessionKey,
 }));
 
 vi.mock("./session-transcript-readers.js", async (importOriginal) => {
@@ -173,13 +184,6 @@ function readTaskUpserts(broadcast: Mock<SubscriptionParams["broadcast"]>) {
     return taskEvent.action === "upserted" ? [taskEvent] : [];
   });
 }
-
-type LifecycleOwnerCallbacks = Required<
-  Pick<
-    AgentEventHandlerOptions,
-    "clearTrackedActiveRun" | "settleTrackedTerminal" | "trackTrackedRunTerminalPersistence"
-  >
->;
 type LifecycleTransition = { state: string; lifecycle?: ReturnType<typeof readLifecycleState> };
 
 function readLifecycleState(entry: ChatAbortControllerEntry) {
@@ -208,24 +212,6 @@ function lifecycleState(
     projectSessionTerminalPersistence,
     projectSessionTerminalPersisted,
     registrationCleanupRequested,
-  };
-}
-
-function requireLifecycleOwnerCallbacks(): LifecycleOwnerCallbacks {
-  const options = agentEventHandlerMocks.create.mock.calls[0]?.[0] as
-    | AgentEventHandlerOptions
-    | undefined;
-  if (
-    !options?.clearTrackedActiveRun ||
-    !options.settleTrackedTerminal ||
-    !options.trackTrackedRunTerminalPersistence
-  ) {
-    throw new Error("expected lifecycle owner callbacks");
-  }
-  return {
-    clearTrackedActiveRun: options.clearTrackedActiveRun,
-    settleTrackedTerminal: options.settleTrackedTerminal,
-    trackTrackedRunTerminalPersistence: options.trackTrackedRunTerminalPersistence,
   };
 }
 
@@ -264,6 +250,8 @@ describe("startGatewayEventSubscriptions", () => {
     transcriptBroadcastMocks.useActualHandler = false;
     transcriptBroadcastMocks.readMessageById.mockReset();
     runtimeConfigState.value = {};
+    agentEventHandlerMocks.persistLifecycle.mockReset().mockResolvedValue(undefined);
+    agentEventHandlerMocks.resolveSessionKey.mockClear();
     agentEventHandlerMocks.create.mockReset().mockImplementation(() => {
       throw new Error("server-chat lazy load failure");
     });
@@ -354,19 +342,47 @@ describe("startGatewayEventSubscriptions", () => {
   });
 
   it("logs lazy agent event handler failures", async () => {
+    const runId = "run-claimed-terminal";
+    const lifecycleGeneration = getAgentEventLifecycleGeneration();
+    const claimId = claimAgentRunContext(
+      runId,
+      {
+        lifecycleGeneration,
+        sessionId: "session-1",
+      },
+      { exclusive: true, ownsContext: true, trackOwner: true },
+    );
+    if (!claimId) {
+      throw new Error("expected terminal event claim");
+    }
+    agentEventHandlerMocks.persistLifecycle.mockRejectedValue(new Error("terminal write rejected"));
     unsubs = startGatewayEventSubscriptions(createParams());
 
-    emitAgentEvent({
-      runId: "run-1",
-      stream: "lifecycle",
-      data: { phase: "start", startedAt: 1_000 },
-    });
+    emitAgentEventForOwner(
+      {
+        runId,
+        sessionId: "session-1",
+        stream: "lifecycle",
+        data: { phase: "end", startedAt: 1_000, endedAt: 2_000 },
+      },
+      claimId,
+    );
 
-    await waitForFast(() => expect(warn).toHaveBeenCalledTimes(1));
+    await waitForFast(() => expect(warn).toHaveBeenCalledTimes(2));
+    expect(agentEventHandlerMocks.persistLifecycle).toHaveBeenCalledWith(
+      expect.objectContaining({ assertCommitAllowed: expect.any(Function) }),
+    );
+    expect(agentEventHandlerMocks.resolveSessionKey).toHaveBeenCalledWith(runId, undefined);
     expect(warn).toHaveBeenCalledWith(
       "Agent event dispatch failed",
-      expect.objectContaining({ runId: "run-1", stream: "lifecycle" }),
+      expect.objectContaining({ runId, stream: "lifecycle" }),
     );
+    expect(warn).toHaveBeenCalledWith(
+      "Terminal session persistence failed",
+      expect.objectContaining({ runId }),
+    );
+    expect(ownerStatus(runId, claimId, lifecycleGeneration)).toBe("clear-requested");
+    releaseAgentRunContext(runId, claimId);
   });
 
   it("disposes a loaded agent event handler on unsubscribe", async () => {
@@ -452,7 +468,23 @@ describe("startGatewayEventSubscriptions", () => {
     });
     transitions.push({ state: "Start-normalized", lifecycle: readLifecycleState(entry) });
     await waitForFast(() => expect(agentEventHandlerMocks.create).toHaveBeenCalledOnce());
-    const callbacks = requireLifecycleOwnerCallbacks();
+
+    emitAgentEvent({
+      runId,
+      lifecycleGeneration,
+      stream: "lifecycle",
+      data: { phase: "error", error: "retryable provider failure", endedAt: 2_000 },
+    });
+    emitAgentEvent({
+      runId,
+      lifecycleGeneration,
+      stream: "lifecycle",
+      data: { phase: "start", startedAt: 2_500 },
+    });
+    expect(agentEventHandlerMocks.persistLifecycle).not.toHaveBeenCalled();
+
+    const terminalPersistence = createDeferred();
+    agentEventHandlerMocks.persistLifecycle.mockReturnValue(terminalPersistence.promise);
 
     emitAgentEvent({
       runId,
@@ -460,25 +492,10 @@ describe("startGatewayEventSubscriptions", () => {
       stream: "lifecycle",
       data: { phase: "end", endedAt: 3_000 },
     });
-    transitions.push({ state: "Terminal-observed", lifecycle: readLifecycleState(entry) });
-
-    callbacks.clearTrackedActiveRun({ runId, clientRunId: runId, sessionKey });
-    transitions.push({ state: "Projection-cleared", lifecycle: readLifecycleState(entry) });
-
-    const terminalPersistence = createDeferred();
-    callbacks.trackTrackedRunTerminalPersistence({
-      runId,
-      clientRunId: runId,
-      sessionKey,
-      sessionId: entry.sessionId,
-      observedAt: 3_001,
-      persistence: terminalPersistence.promise,
-    });
     transitions.push({ state: "Persisting", lifecycle: readLifecycleState(entry) });
 
     terminalPersistence.resolve();
-    await terminalPersistence.promise;
-    callbacks.settleTrackedTerminal({ runId, clientRunId: runId, sessionKey });
+    await waitForFast(() => expect(entry.projectSessionTerminalPersisted).toBe(true));
     transitions.push({ state: "Persisted", lifecycle: readLifecycleState(entry) });
 
     registration.cleanup();
@@ -487,11 +504,6 @@ describe("startGatewayEventSubscriptions", () => {
     expect(transitions).toEqual([
       { state: "Registered", lifecycle: lifecycleState(true) },
       { state: "Start-normalized", lifecycle: lifecycleState(true, false) },
-      { state: "Terminal-observed", lifecycle: lifecycleState(true, true, 3_000) },
-      {
-        state: "Projection-cleared",
-        lifecycle: lifecycleState(false, true, 3_000, undefined, false),
-      },
       {
         state: "Persisting",
         lifecycle: lifecycleState(false, true, 3_000, terminalPersistence.promise, false),
@@ -560,7 +572,8 @@ describe("startGatewayEventSubscriptions", () => {
       data: { phase: "start", startedAt: 1_000 },
     });
     await waitForFast(() => expect(agentEventHandlerMocks.create).toHaveBeenCalledOnce());
-    const callbacks = requireLifecycleOwnerCallbacks();
+    const terminalPersistence = createDeferred();
+    agentEventHandlerMocks.persistLifecycle.mockReturnValue(terminalPersistence.promise);
 
     expect(
       abortChatRunById(
@@ -581,20 +594,6 @@ describe("startGatewayEventSubscriptions", () => {
       projectSessionTerminalPending: true,
       projectSessionTerminalObservedAt: expect.any(Number),
       registrationCleanupRequested: true,
-    });
-
-    callbacks.clearTrackedActiveRun({ runId, clientRunId: runId, sessionKey });
-    const terminalPersistence = createDeferred();
-    callbacks.trackTrackedRunTerminalPersistence({
-      runId,
-      clientRunId: runId,
-      sessionKey,
-      sessionId: entry.sessionId,
-      observedAt: entry.projectSessionTerminalObservedAt ?? 0,
-      persistence: terminalPersistence.promise,
-    });
-    void terminalPersistence.promise.then(() => {
-      callbacks.settleTrackedTerminal({ runId, clientRunId: runId, sessionKey });
     });
 
     await Promise.resolve();

--- a/src/gateway/server-runtime-subscriptions.ts
+++ b/src/gateway/server-runtime-subscriptions.ts
@@ -15,8 +15,12 @@ import {
   configureChannelAdmissionEvidenceCollection,
 } from "../channels/message-access/admission-evidence.js";
 import { getRuntimeConfig } from "../config/io.js";
-import { onAgentAuditEvent, onAgentRuntimeEvent } from "../infra/agent-events.js";
-import { clearAgentRunContext } from "../infra/agent-run-registry.js";
+import {
+  type AgentEventRuntimePayload,
+  onAgentAuditEvent,
+  onAgentRuntimeEvent,
+} from "../infra/agent-events.js";
+import { clearAgentRunContext, getAgentRunContext } from "../infra/agent-run-registry.js";
 import { onTrustedToolExecutionEvent } from "../infra/diagnostic-events.js";
 import { onHeartbeatEvent } from "../infra/heartbeat-events.js";
 import type { SubsystemLogger } from "../logging/subsystem.js";
@@ -43,6 +47,7 @@ import { resolveVisibleActiveSessionRunState } from "./server-methods/session-ac
 import { mapTaskSummary, type TaskEventPayload } from "./server-methods/task-summary.js";
 import { defaultSessionCompanionContextReader } from "./session-companion-context.js";
 import { createSessionCompanion } from "./session-companion.js";
+import { createSessionLifecyclePersistenceOwner } from "./session-lifecycle-persistence-owner.js";
 import { createSessionObserver } from "./session-observer.js";
 import { tryResolveSessionCompatibilityOwnerAgentId } from "./session-request-agent.js";
 import { resolveTaskRequesterSessionTarget } from "./task-session-access.js";
@@ -54,12 +59,15 @@ function dispatchEventHandler<TEvent>(params: {
   log: SubsystemLogger;
   failureMessage: string;
   context: Record<string, unknown>;
+  onFailure?: () => void;
 }) {
-  void params
+  return params
     .loadHandler()
     .then((handler) => handler(params.event))
+    .then(() => undefined)
     .catch((error: unknown) => {
       params.log.warn(params.failureMessage, { ...params.context, error });
+      params.onFailure?.();
     });
 }
 
@@ -140,10 +148,96 @@ export function startGatewayEventSubscriptions(params: {
     auditEnabled && auditMessageMode !== "off"
       ? onTrustedMessageAuditEvent(auditRecorder.recordMessage)
       : undefined;
+  const sessionLifecyclePersistence = createSessionLifecyclePersistenceOwner();
+  const agentEventDispatches = new Set<Promise<void>>();
+  const trackedRunIds = (runId: string, clientRunId: string) =>
+    runId === clientRunId ? [runId] : [runId, clientRunId];
+  const clearTrackedActiveRun = (run: { runId: string; clientRunId: string }) => {
+    for (const candidateRunId of trackedRunIds(run.runId, run.clientRunId)) {
+      const entry = params.chatAbortControllers.get(candidateRunId);
+      if (!entry) {
+        continue;
+      }
+      entry.projectSessionActive = false;
+      entry.projectSessionTerminalPersisted = false;
+      markChatAbortTerminalPersistenceError(entry, undefined);
+      queueMicrotask(() => {
+        const current = params.chatAbortControllers.get(candidateRunId);
+        if (
+          current === entry &&
+          entry.registrationCleanupRequested === true &&
+          !entry.projectSessionTerminalPersistence
+        ) {
+          removeChatAbortControllerEntry(params.chatAbortControllers, candidateRunId, entry);
+        }
+      });
+    }
+  };
+  const settleTrackedTerminal = (run: {
+    runId: string;
+    clientRunId: string;
+    persisted?: boolean;
+  }) => {
+    const persisted = run.persisted ?? true;
+    for (const candidateRunId of trackedRunIds(run.runId, run.clientRunId)) {
+      const entry = params.chatAbortControllers.get(candidateRunId);
+      if (!entry) {
+        continue;
+      }
+      if (persisted) {
+        params.restartRecoveryCandidates.delete(candidateRunId);
+        markChatAbortTerminalPersistenceError(entry, undefined);
+      }
+      entry.projectSessionTerminalPending = false;
+      entry.projectSessionTerminalPersistence = undefined;
+      entry.projectSessionTerminalPersisted = persisted;
+      if (entry.registrationCleanupRequested === true) {
+        removeChatAbortControllerEntry(params.chatAbortControllers, candidateRunId, entry);
+      }
+    }
+  };
+  const trackTrackedRunTerminalPersistence = (run: {
+    runId: string;
+    clientRunId: string;
+    sessionId?: string;
+    observedAt: number;
+    persistence: Promise<void>;
+  }) => {
+    let tracked = false;
+    for (const candidateRunId of trackedRunIds(run.runId, run.clientRunId)) {
+      const entry = params.chatAbortControllers.get(candidateRunId);
+      if (!entry) {
+        continue;
+      }
+      tracked = true;
+      entry.projectSessionTerminalPersistence = run.persistence;
+      void run.persistence.catch((error: unknown) => {
+        markChatAbortTerminalPersistenceError(entry, error);
+      });
+      const lifecycleGeneration = entry.lifecycleGeneration?.trim();
+      const sessionKey = entry.sessionKey.trim();
+      const sessionId = run.sessionId?.trim() || entry.sessionId.trim();
+      if (entry.controlUiVisible !== false && lifecycleGeneration && sessionKey && sessionId) {
+        void run.persistence.catch(() => {
+          params.restartRecoveryCandidates.set(candidateRunId, {
+            runId: candidateRunId,
+            lifecycleGeneration,
+            sessionKey,
+            sessionId,
+            observedAt: run.observedAt,
+          });
+        });
+      }
+    }
+    return tracked;
+  };
+  const getSessionKeyModule = createLazyPromise(() => import("./server-session-key.js"), {
+    cacheRejections: true,
+  });
   const agentEventHandlerLoader = createLazyPromiseLoader(
     () => {
       // Lazy-load heavy chat modules only after the first agent event reaches the gateway.
-      return Promise.all([import("./server-chat.js"), import("./server-session-key.js")]).then(
+      return Promise.all([import("./server-chat.js"), getSessionKeyModule()]).then(
         ([{ createAgentEventHandler }, { resolveSessionKeyForRun }]) =>
           createAgentEventHandler({
             broadcast: params.broadcast,
@@ -156,6 +250,7 @@ export function startGatewayEventSubscriptions(params: {
             toolEventRecipients: params.toolEventRecipients,
             sessionEventSubscribers: params.sessionEventSubscribers,
             sessionMessageSubscribers: params.sessionMessageSubscribers,
+            persistGatewaySessionLifecycleEventForEvent: sessionLifecyclePersistence.persist,
             updateRunToolErrorSummary: ({ runId, clientRunId, summary }) => {
               for (const candidateRunId of new Set([runId, clientRunId])) {
                 const entry = params.chatAbortControllers.get(candidateRunId);
@@ -164,92 +259,9 @@ export function startGatewayEventSubscriptions(params: {
                 }
               }
             },
-            clearTrackedActiveRun: ({ runId, clientRunId }) => {
-              const candidateRunIds = runId === clientRunId ? [runId] : [runId, clientRunId];
-              for (const candidateRunId of candidateRunIds) {
-                const entry = params.chatAbortControllers.get(candidateRunId);
-                // Chat abort entries can hold the requested key while chat run
-                // state holds the canonical key; the run ids are the scoped match.
-                if (entry) {
-                  entry.projectSessionActive = false;
-                  entry.projectSessionTerminalPersisted = false;
-                  markChatAbortTerminalPersistenceError(entry, undefined);
-                  queueMicrotask(() => {
-                    const current = params.chatAbortControllers.get(candidateRunId);
-                    if (
-                      current === entry &&
-                      entry.registrationCleanupRequested === true &&
-                      !entry.projectSessionTerminalPersistence
-                    ) {
-                      removeChatAbortControllerEntry(
-                        params.chatAbortControllers,
-                        candidateRunId,
-                        entry,
-                      );
-                    }
-                  });
-                }
-              }
-            },
-            settleTrackedTerminal: ({ runId, clientRunId, persisted = true }) => {
-              const candidateRunIds = runId === clientRunId ? [runId] : [runId, clientRunId];
-              for (const candidateRunId of candidateRunIds) {
-                const entry = params.chatAbortControllers.get(candidateRunId);
-                if (entry) {
-                  if (persisted) {
-                    params.restartRecoveryCandidates.delete(candidateRunId);
-                    markChatAbortTerminalPersistenceError(entry, undefined);
-                  }
-                  entry.projectSessionTerminalPending = false;
-                  entry.projectSessionTerminalPersistence = undefined;
-                  entry.projectSessionTerminalPersisted = persisted;
-                  if (entry.registrationCleanupRequested === true) {
-                    removeChatAbortControllerEntry(
-                      params.chatAbortControllers,
-                      candidateRunId,
-                      entry,
-                    );
-                  }
-                }
-              }
-            },
-            trackTrackedRunTerminalPersistence: ({
-              runId,
-              clientRunId,
-              sessionId: terminalSessionId,
-              observedAt,
-              persistence,
-            }) => {
-              const candidateRunIds = runId === clientRunId ? [runId] : [runId, clientRunId];
-              for (const candidateRunId of candidateRunIds) {
-                const entry = params.chatAbortControllers.get(candidateRunId);
-                if (entry) {
-                  entry.projectSessionTerminalPersistence = persistence;
-                  void persistence.catch((error: unknown) => {
-                    markChatAbortTerminalPersistenceError(entry, error);
-                  });
-                  const lifecycleGeneration = entry.lifecycleGeneration?.trim();
-                  const sessionKey = entry.sessionKey.trim();
-                  const sessionId = terminalSessionId?.trim() || entry.sessionId.trim();
-                  if (
-                    entry.controlUiVisible !== false &&
-                    lifecycleGeneration &&
-                    sessionKey &&
-                    sessionId
-                  ) {
-                    void persistence.catch(() => {
-                      params.restartRecoveryCandidates.set(candidateRunId, {
-                        runId: candidateRunId,
-                        lifecycleGeneration,
-                        sessionKey,
-                        sessionId,
-                        observedAt,
-                      });
-                    });
-                  }
-                }
-              }
-            },
+            clearTrackedActiveRun,
+            settleTrackedTerminal,
+            trackTrackedRunTerminalPersistence,
             isChatSendRunActive: (runId) => {
               const entry = params.chatAbortControllers.get(runId);
               return entry !== undefined && entry.kind !== "agent";
@@ -308,6 +320,8 @@ export function startGatewayEventSubscriptions(params: {
   };
 
   const unsubscribeAgentEvents = onAgentRuntimeEvent((evt) => {
+    let failedDispatchCleanup: (() => void) | undefined;
+    let terminalPreparation: Promise<void> | undefined;
     sessionObserver.handleEvent(evt);
     if (auditEnabled) {
       auditRecorder.record(evt);
@@ -322,6 +336,10 @@ export function startGatewayEventSubscriptions(params: {
         : params.chatRunState.registry.peek(evt.runId);
       const clientRunId = chatLink?.clientRunId ?? evt.runId;
       const candidateRunIds = evt.runId === clientRunId ? [evt.runId] : [evt.runId, clientRunId];
+      const observedAt =
+        typeof evt.data.endedAt === "number" && Number.isFinite(evt.data.endedAt)
+          ? evt.data.endedAt
+          : evt.ts;
       for (const candidateRunId of candidateRunIds) {
         const entry = params.chatAbortControllers.get(candidateRunId);
         const eventLifecycleGeneration = evt.lifecycleGeneration?.trim();
@@ -332,10 +350,93 @@ export function startGatewayEventSubscriptions(params: {
             entry.lifecycleGeneration === eventLifecycleGeneration)
         ) {
           entry.projectSessionTerminalPending = true;
-          entry.projectSessionTerminalObservedAt =
-            typeof evt.data.endedAt === "number" && Number.isFinite(evt.data.endedAt)
-              ? evt.data.endedAt
-              : evt.ts;
+          entry.projectSessionTerminalObservedAt = observedAt;
+        }
+      }
+      const trackedEntry = candidateRunIds
+        .map((candidateRunId) => params.chatAbortControllers.get(candidateRunId))
+        .find((entry) => entry !== undefined);
+      const runContext = getAgentRunContext(evt.runId);
+      const sessionAgentId = trackedEntry?.agentId ?? evt.agentId ?? runContext?.agentId;
+      const knownSessionKey =
+        evt.deliverySessionKey ??
+        evt.sessionKey ??
+        trackedEntry?.sessionKey ??
+        runContext?.sessionKey;
+      const eventLifecycleGeneration = evt.lifecycleGeneration?.trim();
+      const terminalAuthority =
+        evt.contextClaimId && eventLifecycleGeneration
+          ? {
+              claimId: evt.contextClaimId,
+              lifecycleGeneration: eventLifecycleGeneration,
+              runId: evt.runId,
+            }
+          : undefined;
+      const trackedOwnerIsCurrent =
+        !trackedEntry ||
+        !eventLifecycleGeneration ||
+        !trackedEntry.lifecycleGeneration ||
+        trackedEntry.lifecycleGeneration === eventLifecycleGeneration;
+      const claimIsComplete = !evt.contextClaimId || terminalAuthority !== undefined;
+      const canPersistTerminal =
+        lifecyclePhase === "end" &&
+        evt.projectSessionLifecycle !== false &&
+        trackedOwnerIsCurrent &&
+        claimIsComplete;
+      const prepareTerminalPersistence = (sessionKey: string) => {
+        const persistence = sessionLifecyclePersistence.observe({
+          sessionKey,
+          ...(sessionAgentId ? { agentId: sessionAgentId } : {}),
+          event: evt,
+          ...(terminalAuthority ? { authority: terminalAuthority } : {}),
+          ...(clientRunId !== evt.runId ? { clientRunId } : {}),
+        });
+        if (terminalAuthority) {
+          // A failed lazy handler cannot consume the prepared write and release
+          // its claim. Persistence settlement becomes that cleanup boundary.
+          const clearTerminalAuthority = () =>
+            clearAgentRunContext(
+              terminalAuthority.runId,
+              terminalAuthority.lifecycleGeneration,
+              terminalAuthority.claimId,
+            );
+          failedDispatchCleanup = () => {
+            void persistence.then(clearTerminalAuthority, clearTerminalAuthority);
+          };
+        }
+        clearTrackedActiveRun({ runId: evt.runId, clientRunId });
+        const tracked = trackTrackedRunTerminalPersistence({
+          runId: evt.runId,
+          clientRunId,
+          sessionId: evt.sessionId,
+          observedAt,
+          persistence,
+        });
+        if (!tracked) {
+          void persistence.catch((error: unknown) => {
+            params.log.warn("Terminal session persistence failed", { runId: evt.runId, error });
+          });
+        }
+        void persistence.then(
+          () => settleTrackedTerminal({ runId: evt.runId, clientRunId }),
+          () => settleTrackedTerminal({ runId: evt.runId, clientRunId, persisted: false }),
+        );
+      };
+      if (canPersistTerminal) {
+        if (knownSessionKey) {
+          prepareTerminalPersistence(knownSessionKey);
+        } else {
+          // Context cleanup can precede a terminal event. Resolve its persisted
+          // run mapping before the lazy chat handler consumes the same event.
+          terminalPreparation = getSessionKeyModule().then(({ resolveSessionKeyForRun }) => {
+            const sessionKey = resolveSessionKeyForRun(
+              evt.runId,
+              sessionAgentId ? { agentId: sessionAgentId } : undefined,
+            );
+            if (sessionKey) {
+              prepareTerminalPersistence(sessionKey);
+            }
+          });
         }
       }
     } else if (lifecyclePhase === "start") {
@@ -358,13 +459,19 @@ export function startGatewayEventSubscriptions(params: {
         }
       }
     }
-    dispatchEventHandler({
-      loadHandler: getAgentEventHandler,
+    const dispatchPreparation = terminalPreparation;
+    const dispatch = dispatchEventHandler<AgentEventRuntimePayload>({
+      loadHandler: dispatchPreparation
+        ? () => dispatchPreparation.then(() => getAgentEventHandler())
+        : getAgentEventHandler,
       event: evt,
       log: params.log,
       failureMessage: "Agent event dispatch failed",
       context: { runId: evt.runId, stream: evt.stream },
+      onFailure: () => failedDispatchCleanup?.(),
     });
+    agentEventDispatches.add(dispatch);
+    void dispatch.then(() => agentEventDispatches.delete(dispatch));
   });
   const agentUnsub = async () => {
     unsubscribeAgentEvents();
@@ -379,10 +486,14 @@ export function startGatewayEventSubscriptions(params: {
     clearChannelAdmissionDecisionSink();
     clearMessageActionDecisionSink();
     clearRuntimeActionDecisionSink();
+    // A missing-key terminal can still be resolving its persisted run mapping.
+    // Join dispatch first so handler consumption precedes persistence drain.
+    await Promise.allSettled(agentEventDispatches);
     await agentEventHandlerLoader
       .peek()
       ?.then((handler) => handler.dispose())
       .catch(() => undefined);
+    await sessionLifecyclePersistence.drain();
     await auditRecorder.stop();
   };
 
@@ -391,7 +502,7 @@ export function startGatewayEventSubscriptions(params: {
   });
 
   const transcriptUnsub = onInternalSessionTranscriptUpdate((evt) => {
-    dispatchEventHandler({
+    void dispatchEventHandler({
       loadHandler: getTranscriptUpdateHandler,
       event: evt,
       log: params.log,
@@ -408,7 +519,7 @@ export function startGatewayEventSubscriptions(params: {
     );
   });
   const unsubscribeLifecycle = onSessionLifecycleEvent((evt) => {
-    dispatchEventHandler({
+    void dispatchEventHandler({
       loadHandler: getLifecycleEventHandler,
       event: evt,
       log: params.log,

--- a/src/gateway/session-lifecycle-persistence-owner.test.ts
+++ b/src/gateway/session-lifecycle-persistence-owner.test.ts
@@ -1,0 +1,246 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../test/helpers/promise.js";
+
+const persistLifecycle = vi.hoisted(() => vi.fn());
+const ownerStatus = vi.hoisted(() => vi.fn());
+
+vi.mock("./session-lifecycle-state.js", () => ({
+  persistGatewaySessionLifecycleEvent: persistLifecycle,
+}));
+vi.mock("../infra/agent-run-registry.js", () => ({
+  getAgentRunContextOwnerStatus: ownerStatus,
+}));
+
+import { createSessionLifecyclePersistenceOwner } from "./session-lifecycle-persistence-owner.js";
+
+type PersistenceParams = Parameters<
+  typeof import("./session-lifecycle-state.js").persistGatewaySessionLifecycleEvent
+>[0];
+
+const terminal = {
+  sessionKey: "agent:main:main",
+  event: {
+    runId: "run-1",
+    seq: 2,
+    stream: "lifecycle",
+    lifecycleGeneration: "generation-1",
+    sessionId: "session-1",
+    ts: 2_000,
+    data: { phase: "end", startedAt: 1_000, endedAt: 2_000 },
+  },
+};
+
+describe("session lifecycle persistence owner", () => {
+  beforeEach(() => {
+    persistLifecycle.mockReset();
+    ownerStatus.mockReset().mockReturnValue("active");
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("starts one terminal write before the chat handler consumes it", async () => {
+    persistLifecycle.mockResolvedValue(undefined);
+    const owner = createSessionLifecyclePersistenceOwner();
+
+    const prepared = owner.observe(terminal);
+    const consumed = owner.persist(terminal);
+
+    expect(consumed).toBe(prepared);
+    expect(persistLifecycle).toHaveBeenCalledOnce();
+    await consumed;
+    await owner.drain();
+  });
+
+  it("distinguishes reused run ids by their exact owner claim", async () => {
+    persistLifecycle.mockResolvedValue(undefined);
+    const owner = createSessionLifecyclePersistenceOwner();
+    const first = {
+      ...terminal,
+      event: { ...terminal.event, contextClaimId: "claim-1" },
+    };
+    const successor = {
+      ...terminal,
+      event: { ...terminal.event, contextClaimId: "claim-2" },
+    };
+
+    const firstPrepared = owner.observe(first);
+    const successorPrepared = owner.observe(successor);
+
+    expect(successorPrepared).not.toBe(firstPrepared);
+    expect(persistLifecycle).toHaveBeenCalledTimes(2);
+    expect(owner.persist(successor)).toBe(successorPrepared);
+    await Promise.all([firstPrepared, successorPrepared]);
+    await owner.drain();
+  });
+
+  it("preserves private restart-recovery metadata for the durable write", async () => {
+    persistLifecycle.mockResolvedValue(undefined);
+    const event = {
+      runId: "run-recovery",
+      seq: 2,
+      stream: "lifecycle",
+      sessionId: "session-recovery",
+      ts: 2_000,
+      data: { phase: "end", startedAt: 1_000, endedAt: 2_000 },
+    } as typeof terminal.event & { mainSessionRestartRecovery?: true };
+    Object.defineProperties(event, {
+      lifecycleGeneration: { value: "generation-recovery", enumerable: false },
+      mainSessionRestartRecovery: { value: true, enumerable: false },
+    });
+    const owner = createSessionLifecyclePersistenceOwner();
+
+    await owner.observe({ sessionKey: terminal.sessionKey, event });
+
+    expect(persistLifecycle).toHaveBeenCalledWith({
+      sessionKey: terminal.sessionKey,
+      event: expect.objectContaining({
+        lifecycleGeneration: "generation-recovery",
+        mainSessionRestartRecovery: true,
+      }),
+    });
+    await owner.drain();
+  });
+
+  it("persists a keyed error after the chat retry grace expires", async () => {
+    persistLifecycle.mockResolvedValue(undefined);
+    const owner = createSessionLifecyclePersistenceOwner();
+    const error = {
+      ...terminal,
+      event: {
+        ...terminal.event,
+        data: { phase: "error", error: "fallback exhausted", endedAt: 2_000 },
+      },
+    };
+
+    await owner.persist(error);
+
+    expect(persistLifecycle).toHaveBeenCalledOnce();
+    expect(persistLifecycle).toHaveBeenCalledWith(error);
+  });
+
+  it("keeps terminal writes alive until shutdown drains them", async () => {
+    const deferred = createDeferred();
+    persistLifecycle.mockReturnValue(deferred.promise);
+    const owner = createSessionLifecyclePersistenceOwner();
+    void owner.observe(terminal);
+
+    let drained = false;
+    const drain = owner.drain().then(() => {
+      drained = true;
+    });
+    await Promise.resolve();
+    expect(drained).toBe(false);
+
+    deferred.resolve();
+    await drain;
+    expect(drained).toBe(true);
+  });
+
+  it("keeps a pending write available after its lookup grace expires", async () => {
+    vi.useFakeTimers();
+    const deferred = createDeferred();
+    persistLifecycle.mockReturnValue(deferred.promise);
+    const owner = createSessionLifecyclePersistenceOwner();
+    const prepared = owner.observe(terminal);
+    await vi.advanceTimersByTimeAsync(60_000);
+
+    const consumed = owner.persist(terminal);
+
+    expect(consumed).toBe(prepared);
+    deferred.resolve();
+    await consumed;
+    await owner.drain();
+  });
+
+  it("keeps a prepared write available while shutdown drain waits", async () => {
+    const deferred = createDeferred();
+    persistLifecycle.mockReturnValue(deferred.promise);
+    const owner = createSessionLifecyclePersistenceOwner();
+    const prepared = owner.observe(terminal);
+    const draining = owner.drain();
+    await Promise.resolve();
+
+    const consumed = owner.persist(terminal);
+
+    expect(consumed).toBe(prepared);
+    deferred.resolve();
+    await Promise.all([consumed, draining]);
+  });
+
+  it("rejects a terminal write when its exact claim retires before commit", async () => {
+    const beforeCommit = createDeferred();
+    const commitReached = createDeferred();
+    let sessionStatus = "running";
+    persistLifecycle.mockImplementation(async (params: PersistenceParams) => {
+      commitReached.resolve();
+      await beforeCommit.promise;
+      params.assertCommitAllowed?.();
+      sessionStatus = "done";
+    });
+    const owner = createSessionLifecyclePersistenceOwner();
+    const persistence = owner.observe({
+      ...terminal,
+      authority: {
+        claimId: "claim-1",
+        lifecycleGeneration: "generation-1",
+        runId: "run-1",
+      },
+    });
+    await commitReached.promise;
+
+    ownerStatus.mockReturnValue(undefined);
+    beforeCommit.resolve();
+
+    await expect(persistence).rejects.toMatchObject({
+      name: "AbortError",
+      code: "ERR_STALE_GATEWAY_LIFECYCLE",
+    });
+    expect(sessionStatus).toBe("running");
+  });
+
+  it("rejects a deferred error when its exact claim retires before commit", async () => {
+    const beforeCommit = createDeferred();
+    const commitReached = createDeferred();
+    let sessionStatus = "running";
+    persistLifecycle.mockImplementation(async (params: PersistenceParams) => {
+      commitReached.resolve();
+      await beforeCommit.promise;
+      params.assertCommitAllowed?.();
+      sessionStatus = "failed";
+    });
+    const owner = createSessionLifecyclePersistenceOwner();
+    const persistence = owner.persist({
+      ...terminal,
+      event: {
+        ...terminal.event,
+        contextClaimId: "claim-error",
+        data: { phase: "error", error: "fallback exhausted", endedAt: 2_000 },
+      },
+    });
+    await commitReached.promise;
+
+    ownerStatus.mockReturnValue(undefined);
+    beforeCommit.resolve();
+
+    await expect(persistence).rejects.toMatchObject({
+      name: "AbortError",
+      code: "ERR_STALE_GATEWAY_LIFECYCLE",
+    });
+    expect(sessionStatus).toBe("running");
+  });
+
+  it("does not restart a terminal write after its prepared promise expires", async () => {
+    vi.useFakeTimers();
+    persistLifecycle.mockResolvedValue(undefined);
+    const owner = createSessionLifecyclePersistenceOwner();
+    await owner.observe(terminal);
+    await vi.advanceTimersByTimeAsync(60_000);
+
+    await expect(owner.persist(terminal)).rejects.toMatchObject({
+      code: "ERR_STALE_GATEWAY_LIFECYCLE",
+    });
+    expect(persistLifecycle).toHaveBeenCalledOnce();
+  });
+});

--- a/src/gateway/session-lifecycle-persistence-owner.ts
+++ b/src/gateway/session-lifecycle-persistence-owner.ts
@@ -1,0 +1,173 @@
+import { AGENT_RUN_TERMINAL_RETRY_GRACE_MS } from "../agents/agent-run-terminal-outcome.js";
+import type { AgentEventRuntimePayload } from "../infra/agent-events.js";
+import { createAgentRunStaleLifecycleError } from "../infra/agent-lifecycle-error.js";
+import { getAgentRunContextOwnerStatus } from "../infra/agent-run-registry.js";
+import { persistGatewaySessionLifecycleEvent } from "./session-lifecycle-state.js";
+
+type LifecyclePersistenceParams = Parameters<typeof persistGatewaySessionLifecycleEvent>[0];
+type TerminalPersistenceAuthority = {
+  claimId: string;
+  lifecycleGeneration: string;
+  runId: string;
+};
+type ObservedTerminalPersistenceParams = Omit<
+  LifecyclePersistenceParams,
+  "assertCommitAllowed" | "event"
+> & {
+  authority?: TerminalPersistenceAuthority;
+  clientRunId?: string;
+  event: AgentEventRuntimePayload;
+};
+type PreparedPersistence = {
+  expired: boolean;
+  promise: Promise<void>;
+  settled: boolean;
+  timer: ReturnType<typeof setTimeout>;
+};
+
+function assertTerminalAuthority(authority: TerminalPersistenceAuthority): void {
+  if (
+    getAgentRunContextOwnerStatus(
+      authority.runId,
+      authority.claimId,
+      authority.lifecycleGeneration,
+    ) !== "active"
+  ) {
+    throw createAgentRunStaleLifecycleError();
+  }
+}
+
+function terminalEventAuthority(
+  event: LifecyclePersistenceParams["event"],
+): TerminalPersistenceAuthority | undefined {
+  return event.contextClaimId && event.lifecycleGeneration && event.runId
+    ? {
+        claimId: event.contextClaimId,
+        lifecycleGeneration: event.lifecycleGeneration,
+        runId: event.runId,
+      }
+    : undefined;
+}
+
+function terminalEventKey(event: {
+  contextClaimId?: string;
+  lifecycleGeneration?: string;
+  runId?: string;
+  seq?: number;
+}): string | undefined {
+  if (!event.runId || event.seq === undefined) {
+    return undefined;
+  }
+  return `${event.contextClaimId ?? ""}\0${event.lifecycleGeneration ?? ""}\0${event.runId}\0${event.seq}`;
+}
+
+/** Owns each lifecycle end write before optional chat presentation code runs. */
+export function createSessionLifecyclePersistenceOwner() {
+  const prepared = new Map<string, PreparedPersistence>();
+  const inFlight = new Set<Promise<void>>();
+
+  const observe = (params: ObservedTerminalPersistenceParams) => {
+    const key = terminalEventKey(params.event);
+    const existing = key ? prepared.get(key)?.promise : undefined;
+    if (existing) {
+      return existing;
+    }
+    const authority = params.authority;
+    const promise = persistGatewaySessionLifecycleEvent({
+      sessionKey: params.sessionKey,
+      ...(params.agentId ? { agentId: params.agentId } : {}),
+      event: {
+        ...params.event,
+        ...(params.event.lifecycleGeneration
+          ? { lifecycleGeneration: params.event.lifecycleGeneration }
+          : {}),
+        ...(params.event.mainSessionRestartRecovery === true
+          ? { mainSessionRestartRecovery: true as const }
+          : {}),
+        ...(params.clientRunId ? { clientRunId: params.clientRunId } : {}),
+      },
+      ...(authority
+        ? {
+            assertCommitAllowed: () => assertTerminalAuthority(authority),
+          }
+        : {}),
+    });
+    inFlight.add(promise);
+    let entry: PreparedPersistence | undefined;
+    const settle = () => {
+      inFlight.delete(promise);
+      if (!entry) {
+        return;
+      }
+      entry.settled = true;
+      if (entry.expired && key && prepared.get(key) === entry) {
+        prepared.delete(key);
+      }
+    };
+    void promise.then(settle, settle);
+    if (key) {
+      // Expiry bounds settled promises only. A queued write stays reachable so
+      // delayed handler cleanup cannot revoke its claim before commit.
+      const preparedEntry: PreparedPersistence = {
+        expired: false,
+        promise,
+        settled: false,
+        timer: setTimeout(() => {
+          if (prepared.get(key) !== preparedEntry) {
+            return;
+          }
+          preparedEntry.expired = true;
+          if (preparedEntry.settled) {
+            prepared.delete(key);
+          }
+        }, AGENT_RUN_TERMINAL_RETRY_GRACE_MS),
+      };
+      entry = preparedEntry;
+      preparedEntry.timer.unref?.();
+      prepared.set(key, preparedEntry);
+    }
+    return promise;
+  };
+
+  const take = (event: LifecyclePersistenceParams["event"]) => {
+    const key = terminalEventKey(event);
+    if (!key) {
+      return undefined;
+    }
+    const entry = prepared.get(key);
+    if (!entry) {
+      return undefined;
+    }
+    clearTimeout(entry.timer);
+    prepared.delete(key);
+    return entry.promise;
+  };
+
+  return {
+    observe,
+    persist: (params: LifecyclePersistenceParams) => {
+      const preparedPersistence = take(params.event);
+      if (preparedPersistence) {
+        return preparedPersistence;
+      }
+      const phase = params.event.data?.phase;
+      if (phase === "end" && terminalEventKey(params.event)) {
+        // Every admitted lifecycle end is prepared by observe(). A missing
+        // promise means its exact owner expired or shutdown retired it.
+        return Promise.reject(createAgentRunStaleLifecycleError());
+      }
+      const authority = terminalEventAuthority(params.event);
+      return persistGatewaySessionLifecycleEvent({
+        ...params,
+        ...(authority ? { assertCommitAllowed: () => assertTerminalAuthority(authority) } : {}),
+      });
+    },
+    async drain(): Promise<void> {
+      await Promise.allSettled(inFlight);
+      for (const entry of prepared.values()) {
+        clearTimeout(entry.timer);
+      }
+      prepared.clear();
+    },
+  };
+}

--- a/src/gateway/session-lifecycle-state.persistence.test.ts
+++ b/src/gateway/session-lifecycle-state.persistence.test.ts
@@ -1,18 +1,53 @@
 import path from "node:path";
 import { expect, it, vi } from "vitest";
+import { createDeferred } from "../../test/helpers/promise.js";
 import { createTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { createAgentLifecycleTerminalBackstop } from "../auto-reply/reply/agent-lifecycle-terminal.js";
-import { loadSessionEntry, replaceSessionEntry } from "../config/sessions/session-accessor.js";
+import {
+  loadSessionEntry,
+  patchSessionEntryCore,
+  replaceSessionEntry,
+} from "../config/sessions/session-accessor.js";
 import {
   emitAgentEvent,
+  emitAgentEventForOwner,
   getAgentEventLifecycleGeneration,
   onAgentEvent,
 } from "../infra/agent-events.js";
+import {
+  claimAgentRunContext,
+  getAgentRunContextOwnerStatus,
+  releaseAgentRunContext,
+} from "../infra/agent-run-registry.js";
+import type { SubsystemLogger } from "../logging/subsystem.js";
 import { closeOpenClawAgentDatabasesForTest } from "../state/openclaw-agent-db.js";
+import {
+  createChatRunState,
+  createSessionEventSubscriberRegistry,
+  createSessionMessageSubscriberRegistry,
+} from "./server-chat-state.js";
+import { startGatewayEventSubscriptions } from "./server-runtime-subscriptions.js";
 import { persistGatewaySessionLifecycleEvent } from "./session-lifecycle-state.js";
 
 const routing = vi.hoisted(() => ({ loadSessionEntry: vi.fn() }));
-vi.mock("./session-utils.js", () => ({ loadSessionEntry: routing.loadSessionEntry }));
+vi.mock("./session-utils.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./session-utils.js")>()),
+  loadSessionEntry: routing.loadSessionEntry,
+}));
+
+const persistenceTestWarnings = vi.fn();
+const silentLog: SubsystemLogger = {
+  subsystem: "gateway-lifecycle-persistence-test",
+  isEnabled: () => false,
+  trace: vi.fn(),
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: persistenceTestWarnings,
+  error: vi.fn(),
+  fatal: vi.fn(),
+  raw: vi.fn(),
+  child: () => silentLog,
+};
 
 it("persists current-run timing after pre-start failure and clears it on the next run", async () => {
   const tempDirs = createTempDirTracker();
@@ -98,6 +133,109 @@ it("persists current-run timing after pre-start failure and clears it on the nex
     unsubscribe();
     await persistence;
     clock.mockRestore();
+    routing.loadSessionEntry.mockReset();
+    closeOpenClawAgentDatabasesForTest();
+    tempDirs.cleanup();
+  }
+});
+
+it("keeps an owner claim active until its queued terminal write commits", async () => {
+  const tempDirs = createTempDirTracker();
+  const target = {
+    storePath: path.join(tempDirs.make("openclaw-owner-terminal-"), "sessions.json"),
+    sessionKey: "agent:main:worker-terminal",
+  };
+  const runId = "worker-terminal-run";
+  const sessionId = "worker-terminal-session";
+  const lifecycleGeneration = getAgentEventLifecycleGeneration();
+  const writerStarted = createDeferred();
+  const releaseWriter = createDeferred();
+  let claimId: string | undefined;
+  let subscriptions: ReturnType<typeof startGatewayEventSubscriptions> | undefined;
+  let heldWriter: Promise<unknown> | undefined;
+  persistenceTestWarnings.mockReset();
+  routing.loadSessionEntry.mockImplementation(() => ({
+    ...target,
+    canonicalKey: target.sessionKey,
+    entry: loadSessionEntry(target),
+  }));
+  try {
+    await replaceSessionEntry(target, {
+      lifecycleRunId: runId,
+      sessionId,
+      startedAt: 1_000,
+      status: "running",
+      updatedAt: 1_000,
+    });
+    heldWriter = patchSessionEntryCore(target, async () => {
+      writerStarted.resolve();
+      await releaseWriter.promise;
+      return null;
+    });
+    await writerStarted.promise;
+    claimId = claimAgentRunContext(
+      runId,
+      { lifecycleGeneration, sessionId, sessionKey: target.sessionKey },
+      { exclusive: true, ownsContext: true, trackOwner: true },
+    );
+    if (!claimId) {
+      throw new Error("expected worker terminal claim");
+    }
+    const terminalClaimId = claimId;
+    const chatRunState = createChatRunState();
+    const markFinal = vi.spyOn(chatRunState.toolEventRecipients, "markFinal");
+    const agentRunSeq = new Map<string, number>();
+    subscriptions = startGatewayEventSubscriptions({
+      log: silentLog,
+      broadcast: vi.fn(),
+      broadcastToConnIds: vi.fn(),
+      nodeSendToSession: vi.fn(),
+      agentRunSeq,
+      chatRunState,
+      toolEventRecipients: chatRunState.toolEventRecipients,
+      sessionEventSubscribers: createSessionEventSubscriberRegistry(),
+      sessionMessageSubscribers: createSessionMessageSubscriberRegistry(),
+      chatAbortControllers: new Map(),
+      restartRecoveryCandidates: new Map(),
+      terminalSessions: { closeTaskSessions: vi.fn() },
+    });
+
+    emitAgentEventForOwner(
+      {
+        runId,
+        sessionId,
+        sessionKey: target.sessionKey,
+        stream: "lifecycle",
+        data: { phase: "end", startedAt: 1_000, endedAt: 2_000 },
+      },
+      claimId,
+    );
+    await vi.waitFor(
+      () =>
+        expect(
+          markFinal.mock.calls.length + persistenceTestWarnings.mock.calls.length,
+        ).toBeGreaterThan(0),
+      { timeout: 10_000 },
+    );
+    expect(persistenceTestWarnings).not.toHaveBeenCalled();
+    expect(markFinal).toHaveBeenCalledWith(runId);
+
+    expect(getAgentRunContextOwnerStatus(runId, terminalClaimId, lifecycleGeneration)).toBe(
+      "active",
+    );
+    releaseWriter.resolve();
+    await heldWriter;
+    await vi.waitFor(() => expect(loadSessionEntry(target)?.status).toBe("done"));
+    await vi.waitFor(() =>
+      expect(getAgentRunContextOwnerStatus(runId, terminalClaimId, lifecycleGeneration)).toBe(
+        "clear-requested",
+      ),
+    );
+  } finally {
+    releaseWriter.resolve();
+    await heldWriter;
+    await subscriptions?.agentUnsub();
+    releaseAgentRunContext(runId, claimId);
     routing.loadSessionEntry.mockReset();
     closeOpenClawAgentDatabasesForTest();
     tempDirs.cleanup();

--- a/src/gateway/session-lifecycle-state.test.ts
+++ b/src/gateway/session-lifecycle-state.test.ts
@@ -17,7 +17,7 @@ const loggerMocks = vi.hoisted(() => ({
 }));
 
 vi.mock("../config/sessions/session-accessor.js", () => ({
-  updateSessionEntry: persistenceMocks.updateSessionEntry,
+  patchSessionEntryCore: persistenceMocks.updateSessionEntry,
 }));
 
 vi.mock("./session-utils.js", () => ({
@@ -34,7 +34,7 @@ import {
 } from "./session-lifecycle-state.js";
 
 type UpdateSessionEntry =
-  typeof import("../config/sessions/session-accessor.js").updateSessionEntry;
+  typeof import("../config/sessions/session-accessor.js").patchSessionEntryCore;
 type LifecycleEvent = Parameters<typeof persistGatewaySessionLifecycleEvent>[0]["event"];
 
 const exactCronSessionKey = "agent:main:cron:job-1:run:cron-run-1";
@@ -70,7 +70,9 @@ async function persistExactCronLifecycle(options: {
     .mockReset()
     .mockImplementation(async (...args: Parameters<UpdateSessionEntry>) => {
       const [, update] = args;
-      const patch = await update(structuredClone(currentEntry));
+      const patch = await update(structuredClone(currentEntry), {
+        existingEntry: structuredClone(currentEntry),
+      });
       if (patch) {
         currentEntry = { ...currentEntry, ...patch };
       }
@@ -99,7 +101,9 @@ async function persistLifecycle(entry: SessionEntry, event: LifecycleEvent): Pro
     .mockReset()
     .mockImplementation(async (...args: Parameters<UpdateSessionEntry>) => {
       const [, update] = args;
-      const patch = await update(structuredClone(currentEntry));
+      const patch = await update(structuredClone(currentEntry), {
+        existingEntry: structuredClone(currentEntry),
+      });
       if (patch) {
         currentEntry = { ...currentEntry, ...patch };
       }
@@ -815,5 +819,50 @@ describe("session lifecycle state", () => {
     expect(persistenceMocks.updateSessionEntry.mock.calls[0]?.[2]).toMatchObject({
       requireWriteSuccess: true,
     });
+  });
+
+  it("checks terminal authority before committing the session patch", async () => {
+    const entry: SessionEntry = {
+      sessionId: "terminal-authority-session",
+      updatedAt: 1_000,
+      startedAt: 1_000,
+      status: "running",
+      lifecycleRunId: "terminal-authority-run",
+    };
+    let storedEntry = structuredClone(entry);
+    persistenceMocks.loadSessionEntry.mockReturnValue({
+      storePath: "/tmp/sessions.json",
+      canonicalKey: "agent:main:terminal-authority",
+      entry,
+    });
+    persistenceMocks.updateSessionEntry.mockImplementation(
+      async (...args: Parameters<UpdateSessionEntry>) => {
+        const [, update, options] = args;
+        const patch = await update(structuredClone(storedEntry), {
+          existingEntry: structuredClone(storedEntry),
+        });
+        options?.assertCommitAllowed?.();
+        if (patch) {
+          storedEntry = { ...storedEntry, ...patch };
+        }
+        return storedEntry;
+      },
+    );
+
+    await expect(
+      persistGatewaySessionLifecycleEvent({
+        sessionKey: "agent:main:terminal-authority",
+        event: {
+          runId: "terminal-authority-run",
+          sessionId: entry.sessionId,
+          ts: 2_000,
+          data: { phase: "end", startedAt: 1_000, endedAt: 2_000 },
+        },
+        assertCommitAllowed: () => {
+          throw new Error("terminal authority retired");
+        },
+      }),
+    ).rejects.toThrow("terminal authority retired");
+    expect(storedEntry.status).toBe("running");
   });
 });

--- a/src/gateway/session-lifecycle-state.test.ts
+++ b/src/gateway/session-lifecycle-state.test.ts
@@ -245,6 +245,32 @@ describe("session lifecycle state", () => {
     expect(completed.lifecycleRunId).toBeUndefined();
   });
 
+  it("does not reopen a terminal row when its same-run start persistence arrives late", async () => {
+    const completed = await persistLifecycle(
+      {
+        sessionId: "session-id",
+        updatedAt: 2_000,
+        status: "done",
+        startedAt: 1_000,
+        endedAt: 2_000,
+        runtimeMs: 1_000,
+        lastRunId: "run-a",
+      },
+      {
+        ts: 2_100,
+        sessionId: "session-id",
+        runId: "run-a",
+        data: { phase: "start", startedAt: 1_000 },
+      },
+    );
+
+    expect(completed).toMatchObject({
+      status: "done",
+      endedAt: 2_000,
+      lastRunId: "run-a",
+    });
+  });
+
   it("keeps provider lifecycle ownership while recording the client terminal run", async () => {
     const started = await persistLifecycle(
       { sessionId: "session-id", updatedAt: 900 },

--- a/src/gateway/session-lifecycle-state.ts
+++ b/src/gateway/session-lifecycle-state.ts
@@ -15,7 +15,7 @@ import {
   projectMainSessionRecoveryLifecycle,
 } from "../agents/main-session-recovery/main-session-recovery-lifecycle.js";
 import type { InternalSessionEntry as SessionEntry } from "../config/sessions.js";
-import { updateSessionEntry } from "../config/sessions/session-accessor.js";
+import { patchSessionEntryCore } from "../config/sessions/session-accessor.js";
 import { getAgentEventLifecycleGeneration, type AgentEventPayload } from "../infra/agent-events.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { parseCronRunScopeSuffix } from "../sessions/session-key-utils.js";
@@ -27,6 +27,7 @@ const restartRecoveryLog = createSubsystemLogger("main-session-restart-recovery"
 type LifecyclePhase = "start" | "end" | "error";
 
 type LifecycleEventLike = Pick<AgentEventPayload, "ts" | "sessionId"> & {
+  contextClaimId?: string;
   runId?: string;
   clientRunId?: string;
   lifecycleGeneration?: string;
@@ -338,6 +339,7 @@ export async function persistGatewaySessionLifecycleEvent(params: {
   sessionKey: string;
   agentId?: string;
   event: LifecycleEventLike;
+  assertCommitAllowed?: () => void;
 }): Promise<void> {
   const phase = resolveLifecyclePhase(params.event);
   if (!phase) {
@@ -358,7 +360,7 @@ export async function persistGatewaySessionLifecycleEvent(params: {
 
   const exactCronRun = parseCronRunScopeSuffix(sessionEntry.canonicalKey).runId !== undefined;
   let terminalRecovery: { runId: string; outcome: AgentRunTerminalOutcome } | undefined;
-  const persisted = await updateSessionEntry(
+  const persisted = await patchSessionEntryCore(
     {
       storePath: sessionEntry.storePath,
       sessionKey: sessionEntry.canonicalKey,
@@ -411,6 +413,7 @@ export async function persistGatewaySessionLifecycleEvent(params: {
       skipMaintenance: true,
       takeCacheOwnership: true,
       requireWriteSuccess: true,
+      ...(params.assertCommitAllowed ? { assertCommitAllowed: params.assertCommitAllowed } : {}),
     },
   );
   if (persisted && terminalRecovery) {

--- a/src/gateway/session-lifecycle-state.ts
+++ b/src/gateway/session-lifecycle-state.ts
@@ -388,6 +388,20 @@ export async function persistGatewaySessionLifecycleEvent(params: {
       ) {
         return null;
       }
+      const eventRunId = normalizeLifecycleRunId(params.event.runId);
+      const eventClientRunId = normalizeLifecycleRunId(params.event.clientRunId);
+      const terminalRunId = normalizeLifecycleRunId(entry.lastRunId);
+      if (
+        phase === "start" &&
+        entry.status !== "running" &&
+        terminalRunId !== undefined &&
+        (eventRunId === terminalRunId || eventClientRunId === terminalRunId)
+      ) {
+        // A delayed start from a terminalized run must not reopen the row after
+        // its end write commits; lifecycle events are delivered in order, but
+        // their async persistence can settle out of order.
+        return null;
+      }
       const patch = derivePersistedSessionLifecyclePatch({
         entry,
         event: params.event,


### PR DESCRIPTION
Related: #131561

## What Problem This Solves

A Telegram reply could finish successfully while `openclaw sessions` kept the session as `running` after the lazy terminal chat handler failed.

## Why This Change Was Made

The durable terminal write started inside optional chat presentation code. Some channel runs also have no Gateway abort-controller registration, so a controller-bound maintenance retry could not cover the failing path.

The synchronous agent-event subscriber now starts the canonical session lifecycle write as soon as it accepts a lifecycle `end`. The lazy chat handler consumes that same prepared promise, and Gateway shutdown drains any write that is still active. Claim-bound events carry their exact claim to the SQLite commit edge and fail closed if that claim retires.

Lifecycle `error` remains on the existing 15-second retry grace so a fallback can restart with the same run ID without being marked failed. The prepared write also copies the private lifecycle generation and main-session restart-recovery marker that object spread cannot retain.

For owner-scoped worker events, normal terminal cleanup now waits for the prepared SQLite write to settle. An abort, replacement, or Gateway lifecycle rotation can still revoke the claim before commit; successful completion no longer revokes its own write.

A prepared write that is still queued remains available after the lookup grace expires. Gateway shutdown also lets an already-started handler consume its prepared write before the persistence owner drains and clears settled entries.

If live context is already gone, the subscriber uses the existing lazy persisted run-to-session lookup before it dispatches the chat handler. Shutdown joins that pending dispatch preparation before it drains terminal writes.

Owner-scoped prepared writes also include the exact claim ID in their private lookup key. A successor that reuses a released run ID and reset event sequence cannot consume the previous run instance's promise.

Deferred owner-scoped `error` writes derive the same exact claim from the private event after the retry grace. Their SQLite commit is rejected if abort, replacement, or lifecycle rotation revoked that claim while the write waited.

## User Impact

Completed Telegram sessions now become `done` even when the lazy chat handler fails. Retryable provider errors remain active while a same-run fallback starts.

## Evidence

- Telegram Test Server red/green: the same direct-message scenario delivered `OPENCLAW_E2E_OK`, completed one model request, and injected the same lazy terminal-handler failure on both revisions.
- Exact main `5d3bd15130a2` still reported the durable session as `running` at the 70-second checkpoint.
- Exact pushed head `4ddf3f3d626` reported the durable session as `done` through the same injected handler failure.
- The retry regression proved that `error` does not write before a same-run `start`, the final `end` writes once, and a fallback-exhausted error still persists after the grace.
- The restart-recovery regression proved that non-enumerable lifecycle generation and recovery provenance reach the durable writer.
- The revoked-claim regression delayed commit, retired the exact claim, rejected with `ERR_STALE_GATEWAY_LIFECYCLE`, and left the session state unchanged.
- The queued-write integration held SQLite busy, drove an owner-scoped terminal through the real Gateway subscriber and loaded chat handler, kept its claim active through commit, stored `done`, then requested cleanup.
- Delayed-consumption regressions proved that a queued prepared promise remains available after grace expiry and while shutdown drain waits.
- The subscriber regression removed event and live-context session keys, resolved the persisted run mapping, and still started the claim-fenced write before the injected handler failure.
- The run-instance regressions reused a run ID and reset sequence under a new claim, then proved preparation and handler consumption selected the successor promise.
- The deferred-error regression held the write before commit, revoked its exact claim, observed `ERR_STALE_GATEWAY_LIFECYCLE`, and left the session status unchanged.
- `node scripts/run-vitest.mjs src/gateway/session-lifecycle-persistence-owner.test.ts src/gateway/server-runtime-subscriptions.test.ts src/gateway/session-lifecycle-state.test.ts src/gateway/session-lifecycle-state.persistence.test.ts src/gateway/chat-abort.test.ts src/gateway/server-close.test.ts src/gateway/server-active-work.test.ts src/gateway/server-methods/session-active-runs.test.ts src/gateway/server-chat.agent-events.test.ts src/gateway/worker-environments/live-events.test.ts src/gateway/server-session-key.test.ts src/gateway/server-import-boundary.test.ts` — 422 tests passed.
- Focused format, Oxlint, max-lines, assertion-safety, dead-export, database-first, runtime-sidecar, coercion-helper, import-cycle, and diff checks passed.
- Judged line delta: production +302; tests +460. The production growth creates one claim-fenced terminal persistence owner, exact run-instance lookup, bounded settled-promise retention, persisted-key fallback, shutdown draining, and claim cleanup ordered after durable settlement; the subscriber deletes its old callback-only wiring.
