### PR TITLE
fix(ui): prevent duplicate messages when holding Enter

### DIFF
--- a/ui/src/e2e/chat-attachment-read-lifecycle.e2e.test.ts
+++ b/ui/src/e2e/chat-attachment-read-lifecycle.e2e.test.ts
@@ -357,10 +357,14 @@ suite.define(() => {
                     .map((bubble) => readRow(bubble, "data-message-id")),
                   queued: [
                     ...active.querySelectorAll(".agent-chat__composer-shell .chat-queue__item"),
-                  ].map((row) => ({
-                    ...readRow(row, "data-chat-queue-item"),
-                    text: row.querySelector(".chat-queue__text")?.textContent?.trim(),
-                  })),
+                  ].map((row) => {
+                    const { id, visible } = readRow(row, "data-chat-queue-item");
+                    return {
+                      id,
+                      visible,
+                      text: row.querySelector(".chat-queue__text")?.textContent?.trim(),
+                    };
+                  }),
                 };
               },
               attachment ? fileName : followUpText,

--- a/ui/src/e2e/chat-attachment-read-lifecycle.e2e.test.ts
+++ b/ui/src/e2e/chat-attachment-read-lifecycle.e2e.test.ts
@@ -1,4 +1,4 @@
-import { mkdir } from "node:fs/promises";
+import { mkdir, rm } from "node:fs/promises";
 import path from "node:path";
 import type { Locator, Page } from "playwright";
 import { expect, it } from "vitest";
@@ -125,6 +125,282 @@ async function waitForCommittedAttachmentDraft(
 }
 
 suite.define(() => {
+  it.each([
+    { attachment: false, gesture: "held Enter", expectedTurns: 1 },
+    { attachment: true, gesture: "held Enter", expectedTurns: 1 },
+    { attachment: false, gesture: "released and repressed Enter", expectedTurns: 2 },
+    { attachment: true, gesture: "released and repressed Enter", expectedTurns: 2 },
+  ])(
+    "admits $expectedTurns turn(s) from $gesture during terminal history (attachment=$attachment)",
+    async ({ attachment, gesture, expectedTurns }) => {
+      await suite.withPage(
+        {
+          locale: "en-US",
+          serviceWorkers: "block",
+          viewport: { height: 900, width: 1280 },
+        },
+        async ({ page }) => {
+          const held = gesture === "held Enter";
+          const capture = held && attachment;
+          const proofDir = path.resolve(
+            process.env.OPENCLAW_UI_E2E_DIAGNOSTIC_DIR?.trim() || ".artifacts/control-ui-e2e",
+            "held-enter",
+          );
+          if (capture) {
+            await mkdir(proofDir, { recursive: true });
+            await Promise.all(
+              ["held-enter-before.png", "held-enter-after.png"].map((name) =>
+                rm(path.join(proofDir, name), { force: true }),
+              ),
+            );
+          }
+          const ready = {
+            content: [{ text: "Ready for the held Enter check.", type: "text" }],
+            role: "assistant",
+            __openclaw: { id: "held-enter-ready", seq: 1 },
+          };
+          const gateway = await installMockGateway(page, { historyMessages: [ready] });
+          const pageErrors: string[] = [];
+          page.on("pageerror", (error) => pageErrors.push(error.message));
+          await page.goto(controlUiSessionUrl(suite.server.baseUrl, "main"));
+          const pane = page.locator('openclaw-chat-pane[aria-hidden="false"]');
+          const composer = pane.locator(".agent-chat__composer-combobox textarea");
+          await pane.getByText("Ready for the held Enter check.", { exact: true }).waitFor();
+          await gateway.waitForRequest("chat.startup");
+          const initialText = "Finish the initial synthetic turn.";
+          await composer.fill(initialText);
+          await composer.press("Enter");
+          const initial = await gateway.waitForRequest("chat.send");
+          expect(initial.params).toMatchObject({
+            idempotencyKey: expect.any(String),
+            message: initialText,
+            sessionKey: "main",
+          });
+          const initialRunId = (initial.params as { idempotencyKey: string }).idempotencyKey;
+          expect(initialRunId).not.toBe("");
+          await pane.getByRole("button", { name: "Stop generating" }).waitFor();
+
+          const followUpText = attachment ? "" : "Submit this follow-up once per key press.";
+          const fileName = "held-enter.txt";
+          const fileContents = "Synthetic held Enter attachment contents.";
+          await composer.fill(followUpText);
+          if (attachment) {
+            await pane.locator(".agent-chat__file-input").setInputFiles({
+              name: fileName,
+              mimeType: "text/plain",
+              buffer: Buffer.from(fileContents),
+            });
+            await pane.locator(".chat-attachment-thumb", { hasText: fileName }).waitFor();
+          }
+          const terminalText = "The initial synthetic turn completed.";
+          const terminalMessage = {
+            content: [{ text: terminalText, type: "text" }],
+            role: "assistant",
+            __openclaw: { id: "held-enter-terminal", seq: 3 },
+          };
+          const historyMessages = [
+            ready,
+            {
+              content: [{ text: initialText, type: "text" }],
+              role: "user",
+              __openclaw: {
+                id: "held-enter-initial-user",
+                idempotencyKey: `${initialRunId}:user`,
+                seq: 2,
+              },
+            },
+            terminalMessage,
+          ];
+          await gateway.setHistoryMessages(historyMessages);
+          const historyBefore = (await gateway.getRequests("chat.history")).length;
+          await gateway.deferNext("chat.history");
+          await gateway.emitChatFinal({ runId: initialRunId, text: terminalText });
+          await pane
+            .locator(".chat-group.assistant .chat-bubble")
+            .getByText(terminalText, { exact: true })
+            .waitFor();
+          await gateway.emitGatewayEvent("session.message", {
+            activeRunIds: [],
+            clientRunId: initialRunId,
+            hasActiveRun: false,
+            message: terminalMessage,
+            messageId: "held-enter-terminal",
+            messageSeq: 3,
+            session: { activeRunIds: [], hasActiveRun: false, key: "main", status: "done" },
+            sessionKey: "main",
+          });
+          await gateway.waitForRequest("chat.history", { after: historyBefore });
+          await expect
+            .poll(() => pane.getByRole("button", { name: "Send message" }).isEnabled())
+            .toBe(true);
+          expect(await composer.inputValue()).toBe(followUpText);
+          expect(await pane.locator(".chat-attachment-thumb").count()).toBe(attachment ? 1 : 0);
+          expect(await pane.locator(".chat-queue__item").count()).toBe(0);
+          await composer.click();
+          expect(
+            await composer.evaluate((element) => ({
+              focused: document.hasFocus() && document.activeElement === element,
+              visibility: document.visibilityState,
+            })),
+          ).toEqual({ focused: true, visibility: "visible" });
+          if (capture) {
+            await pane.screenshot({ path: path.join(proofDir, "held-enter-before.png") });
+          }
+
+          const keyProof = await composer.evaluateHandle((element) => {
+            const textarea = element as HTMLTextAreaElement;
+            const events: Array<{ isTrusted: boolean; repeat: boolean }> = [];
+            const record = (event: KeyboardEvent) => {
+              if (event.key === "Enter" && events.length < 4) {
+                events.push({ isTrusted: event.isTrusted, repeat: event.repeat });
+              }
+            };
+            textarea.addEventListener("keydown", record, true);
+            return {
+              events,
+              dispose: () => textarea.removeEventListener("keydown", record, true),
+            };
+          });
+          try {
+            try {
+              await page.keyboard.down("Enter");
+              if (!held) {
+                await page.keyboard.up("Enter");
+              }
+              await page.keyboard.down("Enter");
+            } finally {
+              await page.keyboard.up("Enter");
+            }
+            const keys = await keyProof.evaluate((proof) => proof.events);
+            expect(keys).toEqual([
+              { isTrusted: true, repeat: false },
+              { isTrusted: true, repeat: held },
+            ]);
+            expect(await gateway.getRequests("chat.history")).toHaveLength(historyBefore + 1);
+            expect(await gateway.getRequests("chat.send")).toHaveLength(1);
+            expect(await composer.inputValue()).toBe(followUpText);
+            expect(await pane.locator(".chat-attachment-thumb").count()).toBe(attachment ? 1 : 0);
+
+            const sendsBefore = (await gateway.getRequests("chat.send")).length;
+            await gateway.deferNext("chat.send");
+            await gateway.resolveDeferred("chat.history", {
+              messages: historyMessages,
+              sessionId: "control-ui-e2e-session",
+              sessionInfo: {
+                activeLeafEntryId: "held-enter-terminal",
+                activeRunIds: [],
+                hasActiveRun: false,
+                key: "main",
+                status: "done",
+              },
+              thinkingLevel: null,
+            });
+            const followUp = await gateway.waitForRequest("chat.send", { after: sendsBefore });
+            expect(followUp.params).toMatchObject({
+              expectedLeafEntryId: "held-enter-terminal",
+              idempotencyKey: expect.any(String),
+              message: followUpText,
+              sessionKey: "main",
+              ...(attachment
+                ? {
+                    attachments: [
+                      {
+                        content: Buffer.from(fileContents).toString("base64"),
+                        fileName,
+                        mimeType: "text/plain",
+                        type: "file",
+                      },
+                    ],
+                  }
+                : {}),
+            });
+            const followUpRunId = (followUp.params as { idempotencyKey: string }).idempotencyKey;
+            expect(followUpRunId).not.toBe("");
+            expect(followUpRunId).not.toBe(initialRunId);
+            if (!attachment) {
+              expect(followUp.params).not.toHaveProperty("attachments");
+            }
+
+            // Both held-history continuations enqueue synchronously before their
+            // next await. Cross a committed render boundary, not a transient count=1.
+            await waitForCommittedState(
+              page,
+              () => {
+                const active = document.querySelector('openclaw-chat-pane[aria-hidden="false"]');
+                const input = active?.querySelector(".agent-chat__composer-combobox textarea");
+                return (
+                  input instanceof HTMLTextAreaElement &&
+                  input.value === "" &&
+                  active?.querySelectorAll(".chat-attachment-thumb").length === 0
+                );
+              },
+              {},
+            );
+            // The held ACK keeps the first turn in the transcript; later
+            // waiting turns remain in the composer queue. Read both together.
+            const observed = await pane.evaluate(
+              (active, followUpContent) => {
+                const readRow = (row: Element, idAttribute: string) => {
+                  const rect = row.getBoundingClientRect();
+                  return {
+                    id: row.getAttribute(idAttribute),
+                    visible:
+                      rect.height > 0 &&
+                      rect.width > 0 &&
+                      rect.bottom > 0 &&
+                      rect.top < innerHeight,
+                  };
+                };
+                return {
+                  bubbles: [...active.querySelectorAll(".chat-group.user .chat-bubble")]
+                    .filter((bubble) => bubble.textContent?.includes(followUpContent))
+                    .map((bubble) => readRow(bubble, "data-message-id")),
+                  queued: [
+                    ...active.querySelectorAll(".agent-chat__composer-shell .chat-queue__item"),
+                  ].map((row) => ({
+                    ...readRow(row, "data-chat-queue-item"),
+                    text: row.querySelector(".chat-queue__text")?.textContent?.trim(),
+                  })),
+                };
+              },
+              attachment ? fileName : followUpText,
+            );
+            console.info("held-enter admission proof", {
+              attachment,
+              gesture,
+              keys,
+              followUpRequestId: followUp.id,
+              followUpRunId,
+              observed,
+            });
+            expect(pageErrors).toEqual([]);
+            if (capture) {
+              await pane.screenshot({ path: path.join(proofDir, "held-enter-after.png") });
+            }
+            expect(observed.bubbles.map((row) => row.id)).toEqual([`msg:send:${followUpRunId}:0`]);
+            for (const rows of [observed.bubbles, observed.queued]) {
+              expect(rows.every((row) => row.visible && row.id)).toBe(true);
+              expect(new Set(rows.map((row) => row.id)).size).toBe(rows.length);
+            }
+            expect(
+              observed.queued.every(
+                (row) => row.text === (attachment ? "Image (1)" : followUpText),
+              ),
+            ).toBe(true);
+            expect(observed.bubbles.length + observed.queued.length).toBe(expectedTurns);
+            expect(await gateway.getRequests("chat.send")).toHaveLength(sendsBefore + 1);
+          } finally {
+            try {
+              await keyProof.evaluate((proof) => proof.dispose());
+            } finally {
+              await keyProof.dispose();
+            }
+          }
+        },
+      );
+    },
+  );
+
   it("restores an attachment staged offline after reload and reconnect", async () => {
     await suite.withPage(
       {

--- a/ui/src/pages/chat/chat-composer-actions.test.ts
+++ b/ui/src/pages/chat/chat-composer-actions.test.ts
@@ -21,7 +21,7 @@ afterEach(async () => {
 
 function pressComposerEnter(
   container: Element,
-  modifiers: Pick<KeyboardEventInit, "altKey" | "ctrlKey" | "metaKey" | "shiftKey"> = {},
+  modifiers: Pick<KeyboardEventInit, "altKey" | "ctrlKey" | "metaKey" | "shiftKey" | "repeat"> = {},
 ) {
   const textarea = container.querySelector<HTMLTextAreaElement>("textarea");
   if (!textarea) {
@@ -312,7 +312,7 @@ describe("renderChatComposer controls", () => {
     expect(onQueueSteer.mock.calls).toEqual([["queued-1"], ["waiting-idle-1"]]);
   });
 
-  it("steers the oldest visible-queue message when Enter is pressed on empty", () => {
+  it.each([false, true])("steers empty Enter only on a new press (repeat=%s)", (repeat) => {
     const onQueueSteer = vi.fn();
     const onSend = vi.fn();
     const { container } = renderComposer({
@@ -334,12 +334,10 @@ describe("renderChatComposer controls", () => {
         },
       ],
     });
-    const event = new KeyboardEvent("keydown", { key: "Enter", bubbles: true, cancelable: true });
-
-    container.querySelector("textarea")?.dispatchEvent(event);
+    const event = pressComposerEnter(container, { repeat });
 
     expect(event.defaultPrevented).toBe(true);
-    expect(onQueueSteer).toHaveBeenCalledWith("pending-unscoped");
+    expect(onQueueSteer.mock.calls).toEqual(repeat ? [] : [["pending-unscoped"]]);
     expect(onSend).not.toHaveBeenCalled();
   });
 
@@ -440,6 +438,10 @@ describe("renderChatComposer controls", () => {
 
         expect(onSend).toHaveBeenCalledOnce();
         expect(onSend).toHaveBeenCalledWith(alternateMode, action);
+
+        const held = pressComposerEnter(container, { ...modifiers, repeat: true });
+        expect(held.defaultPrevented).toBe(true);
+        expect(onSend).toHaveBeenCalledOnce();
       },
     );
   });
@@ -504,22 +506,30 @@ describe("renderChatComposer controls", () => {
     expect(onSend).not.toHaveBeenCalled();
   });
 
-  it("keeps Shift+modified Enter as a newline", () => {
-    const onSend = vi.fn();
-    const { container } = renderComposer({
-      canAbort: true,
-      draft: "Keep editing",
-      followUpMode: "queue",
-      onAbort: vi.fn(),
-      onSend,
-      sendShortcut: "enter",
-    });
+  it.each(["enter", "modifier-enter"] as const)(
+    "keeps newline keys, including repeats, for %s",
+    (sendShortcut) => {
+      const onSend = vi.fn();
+      const { container } = renderComposer({
+        canAbort: true,
+        draft: "Keep editing",
+        followUpMode: "queue",
+        onAbort: vi.fn(),
+        onSend,
+        sendShortcut,
+      });
 
-    const event = pressComposerEnter(container, { ctrlKey: true, shiftKey: true });
-
-    expect(event.defaultPrevented).toBe(false);
-    expect(onSend).not.toHaveBeenCalled();
-  });
+      for (const repeat of [false, true]) {
+        const event = pressComposerEnter(container, {
+          ctrlKey: sendShortcut === "enter",
+          shiftKey: sendShortcut === "enter",
+          repeat,
+        });
+        expect(event.defaultPrevented).toBe(false);
+      }
+      expect(onSend).not.toHaveBeenCalled();
+    },
+  );
 
   it.each([
     ["queue", "Queue ⏎ · Steer ⌘/Ctrl+Enter"],

--- a/ui/src/pages/chat/components/chat-composer-keydown.ts
+++ b/ui/src/pages/chat/components/chat-composer-keydown.ts
@@ -126,6 +126,11 @@ export function createComposerKeyDownHandler({
 
     const sendShortcutMatches = sendShortcut === "enter" || event.metaKey || event.ctrlKey;
     if (event.key === "Enter" && !event.shiftKey && sendShortcutMatches) {
+      // Holding send is one action, even after the draft clears into the queue.
+      if (event.repeat) {
+        event.preventDefault();
+        return;
+      }
       const attachments = props.getAttachments?.() ?? props.attachments ?? [];
       const hasComposedContent = Boolean(target.value.trim() || attachments.length);
       if (!hasComposedContent) {


### PR DESCRIPTION
Related context: #118884 — distinct deliberate chat submissions remain distinct. Queued-message presentation from #132294 is preserved.

## What Problem This Solves

Fixes duplicate Control UI chat submissions when users hold Enter while the previous turn's history refresh is pending. The ordinary Chromium baseline reproduced this for both text and a completed file-only draft.

The repair passes the same nine-case flow in both focused local Chromium proof and the normal hosted Linux CI run on the refreshed head. Exact-head CI is now green; final native landing validation remains. Auto-merge remains disabled.

## Why This Change Was Made

The composer cancels repeated keydown events only after identifying an Enter send shortcut, before sending or steering a queued message. A held shortcut stays one action; releasing and pressing again remains a distinct action. Existing IME, goal/menu navigation, Shift/newline and modified-shortcut behavior retain their earlier precedence.

The repair belongs at keyboard intent, not content deduplication or a history-loading gate: separate deliberate submissions with identical text must still be accepted. No protocol, persistence, configuration, dependency or workflow change is included.

## User Impact

Holding the send shortcut submits one text or ready attachment-only message without turning the continuing hold into an unintended Steer after the draft clears. Normal repeat typing/newlines and deliberate second submissions remain available. This behavior is verified locally and in hosted Linux CI; it is not yet landed.

## Evidence

AI-assisted. Production LOC: +5/-0 at the existing keyboard owner. The cancel-and-return branch preserves both default prevention and the distinction between sending, steering and newline input: putting the check in a match predicate would leak a newline; putting it after empty-composer steering would miss that boundary. Tests: +312/-22 across the existing attachment E2E and composer-actions files, including formatter whitespace. No new test-only production seam.

The [baseline ordinary CI run](https://github.com/openclaw/openclaw/actions/runs/33236458146) ran the normal built UI with real Chromium. Both held-Enter cases reached the intended visible-admission count and failed with two entries instead of one. Both deliberate release/repress controls and five original attachment-lifecycle cases passed. The changed-file route independently reported the same two failures and seven passes. The exact executed merge and fixture were verified against reviewed source.

All hard preconditions passed before those failures: trusted native repeat receipts, one deferred history request, the fresh first send's exact payload and history leaf, consumed composer, committed render boundary, sending-message identity, distinct visible row identities/queue copy, and no page errors. The first send ACK was held, leaving the second admission in the composer queue. The final wire-count assertion followed the failing total and did not run in the held baseline cases; no second immediate Gateway request is claimed.

The earlier [initial diagnostic run](https://github.com/openclaw/openclaw/actions/runs/33231318362) stopped at an authored strict locator before native input because the assistant bubble and accessibility announcement duplicated the terminal text. That setup error was corrected and is not counted as product reproduction. The baseline's own `no-map-spread` lint error was also fixed with equivalent explicit fields, preserving DOM reads and the oracle.

The complete repair was formatted through the normal commit hook and independently reviewed. Fresh Codex P2 review of the refreshed head found no actionable findings across three automatic evidence batches retaining the entire candidate and 73 whole supporting files. Separate batches are not one integrated model view or execution proof.

On repair commit `727b24e1a77094c451cb037097a69d9cfa6be20a`, this exact existing command ran once against the normal built UI:

```sh
node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/chat-attachment-read-lifecycle.e2e.test.ts
```

**Local result: 9 passed, no skips, 26.38 seconds, terminal exit 0.** Both held cases passed with trusted repeat false→true, one sending bubble and no queued duplicate. Both release/repress controls retained two admissions, and all five original attachment-lifecycle cases passed. The total-count and following wire-count assertions now both execute and pass. No retries, assertion weakening, timeout increases or missing-browser skips were used.

This is a **local observation**, not exact-lock/Linux CI proof: installed Vite 8.2.1 differs from target 8.2.2; TSX 4.23.12 uses its own esbuild 0.28.1 in both the installed and target lock graphs (the separate root/Vite peer is 0.28.2); Node was 24.20.0 rather than the prior CI's 24.19.0; Chromium was the existing macOS Playwright browser. No dependencies were installed or changed. The run used an empty credential-free environment, task-owned HOME/temp/cache, one worker and a deterministic mock Gateway, not an authenticated live Gateway, provider or channel.

Normal browser/server teardown and command completion succeeded; the owned temporary namespace was empty afterward, reviewed source/tool hashes and shared-cache metadata were unchanged, and task-owned dependency links were removed. The browser finished before a usable individual Chromium PID receipt was captured, so this is not a universal independently recorded process-cleanup claim. No rerun was made for that measurement limitation.

The [repair-head ordinary CI run](https://github.com/openclaw/openclaw/actions/runs/33239281501) reports success for all 14 UI E2E jobs, UI tests, lint and type checks. Retrieved unit output includes the new empty-repeat/no-Steer, modified-shortcut and newline controls passing. That run remains **failed**: `checks-node-compact-small-36` found the existing QA Lab `gateway-child-setup.ts` suppression count differed from its inventory. The exact inventory correction landed independently in #132394 (commit `2b1eee0d688a2e9163015769f7d18ed1937fa522`); no QA Lab patch or CI bypass is included here. Complete hosted browser-log retrieval encountered a corrupt cache ZIP, so the passing job status alone is not presented as a verified nine-case raw trace. The two owned commits were necessarily rebased onto canonical main `c1473eac606d6445e9f74ba2d534b5236cdd71c9`, which contains that correction. Refreshed head `5bfc3ce36ddbdcd779472222964f0d1ac509a825` preserves the complete three-file patch byte-for-byte. The rebase did not rerun pre-commit hooks; prior normal hook/formatter proof is retained with unchanged source, hooks, configuration and tool bytes. The earlier local proof remains attributed to `727b24e1`.

The [refreshed exact-head CI run](https://github.com/openclaw/openclaw/actions/runs/33241407690) completed **success** for `5bfc3ce36ddbdcd779472222964f0d1ac509a825`, including all 14 UI E2E jobs, UI tests, lint, typechecks, i18n, the repaired small-36 inventory job and `openclaw/ci-gate`. The complete targeted browser log shows **all nine attachment cases passing**, within 25 files / 84 tests passing in 211.27 seconds. Both held and both deliberate-repress cases reach their visible-count and following wire-count assertions. UI unit results show 823 files / 12,401 tests passing, with one unrelated existing memory-panel real-Chromium skip. The repeat/no-Steer, 16 modified-shortcut, newline, IME and same-Event/distinct-intent sibling controls pass.

The actual executed merge `21b8c974a792090c77a8204d99f1510caafe0f34` was inspected directly: its complete three-file patch and all 73 reviewed owners match the candidate; package/lock/workspace and CI/setup/launcher/config closure are unchanged. The normal frozen install binds target Vite 8.2.2, Playwright 1.62.1 and Vitest 4.1.11; logs record Node 24.19.0 and system Chromium. This is normal built-UI/mock-Gateway browser proof, not an authenticated live Gateway or provider run.

The attached before/after outcome frames use synthetic `held-enter.txt` data. Before repair is the failed Linux CI baseline: one sending file bubble plus a waiting composer row. After repair is the passing local run: one file bubble and no waiting row. The initial assistant's ×2 fold is harness context, not another held-input admission; the transient confetti does not obscure the asserted state. Both images were opened and inspected for sensitive content; no image editing was needed. Their differing environments are disclosed above; neither image alone proves the assertions.

The latest ClawSweeper review of this head has no actionable correctness or security finding. Its remaining exact-CI item is now resolved, the inspected fixed-state capture is provided here, and the necessary five-line default-cancellation/intent distinction is explained above. Native landing gates remain authoritative.

No issue is automatically closed. Final landing requires the ordinary native workflow after all remaining proof gates pass.

![Before repair: failed Linux CI baseline with a duplicate queued file](https://github.com/user-attachments/assets/af447846-5a87-4671-8908-6214d52d2fc7)

![After repair: passing local Chromium run on 727b with one file and no queued duplicate](https://github.com/user-attachments/assets/57112ed2-0223-45ad-ad56-85eb6e1cd363)
