### PR TITLE
fix(plugin-sdk): registration leaves private declaration aliases stale

### DIFF
--- a/docs/plugins/sdk-subpaths.md
+++ b/docs/plugins/sdk-subpaths.md
@@ -23,6 +23,14 @@ inventory of every internal runtime helper. Four files define the boundary:
 - `scripts/lib/plugin-sdk-entries.mts`: derived public/private export metadata,
   supported bundled facades, and plugin-owned public surfaces.
 
+After changing the entrypoint inventories, run `pnpm plugin-sdk:sync-exports`,
+then `pnpm plugin-sdk:check-exports`. The same registration command maintains
+package exports and private workspace declaration aliases in
+`extensions/tsconfig.package-boundary.paths.json` and `extensions/xai/tsconfig.json`.
+It preserves unrelated mappings and XAI's intentional private-alias omissions.
+These local declaration aliases do not add types to JavaScript-only published
+SDK exports; test-only entries remain unexported.
+
 Maintainers audit the public export count with `pnpm plugin-sdk:surface` and
 the compatibility queue with `pnpm plugins:boundary-report:summary`.
 

--- a/scripts/check-changed.mts
+++ b/scripts/check-changed.mts
@@ -97,7 +97,7 @@ const DOCTOR_CONTRACT_OWNER_TEST_PATH_RE =
 const SQLITE_SESSION_SCHEMA_BASELINE_PATH_RE =
   /^(?:src\/state\/openclaw-agent-schema\.sql|scripts\/(?:generate-sqlite-session-schema-baseline\.ts|lib\/sqlite-session-schema-baseline\.ts)|test\/scripts\/sqlite-session-schema-baseline\.test\.ts|docs\/\.generated\/sqlite-session-transcript-schema-baseline\.sha256)$/u;
 const PLUGIN_SDK_SURFACE_PATH_RE =
-  /^(?:package\.json$|src\/plugin-sdk\/|packages\/plugin-sdk\/|scripts\/(?:plugin-sdk-surface-report\.mts|sync-plugin-sdk-exports\.mts|lib\/plugin-sdk-(?:declaration-budget\.mts|deprecated-barrel-subpaths\.json|deprecated-public-subpaths\.json|entries\.mts|entrypoints\.json|private-local-only-subpaths\.json)))/u;
+  /^(?:package\.json$|src\/plugin-sdk\/|packages\/plugin-sdk\/|extensions\/(?:tsconfig\.package-boundary\.paths\.json|xai\/tsconfig\.json)$|scripts\/(?:plugin-sdk-surface-report\.mts|sync-plugin-sdk-exports\.mts|lib\/plugin-sdk-(?:declaration-budget\.mts|deprecated-barrel-subpaths\.json|deprecated-public-subpaths\.json|entries\.mts|entrypoints\.json|private-local-only-subpaths\.json)))/u;
 const DEPRECATION_HYGIENE_PATH_RE =
   /^(?:package\.json$|src\/|extensions\/|packages\/|scripts\/(?:check-deprecated-api-usage\.mts$|plugin-boundary-report\.ts$|lib\/plugin-sdk))/u;
 const WRAPPER_SHADOWING_PATH_RE =

--- a/scripts/sync-plugin-sdk-exports.mts
+++ b/scripts/sync-plugin-sdk-exports.mts
@@ -1,15 +1,31 @@
 #!/usr/bin/env node
 
 // Regenerates package.json plugin-sdk export entries from the canonical entry list
-// and keeps the workspace facade package (@openclaw/plugin-sdk) exports aligned
-// with its src facade files.
+// and keeps workspace facade exports and private declaration aliases aligned.
 import fs from "node:fs";
 import path from "node:path";
-import { buildPluginSdkPackageExports, pluginSdkEntrypoints } from "./lib/plugin-sdk-entries.mts";
+import {
+  buildPluginSdkPackageExports,
+  pluginSdkEntrypoints,
+  privateLocalOnlyPluginSdkEntrypoints,
+} from "./lib/plugin-sdk-entries.mts";
 
 const checkOnly = process.argv.includes("--check");
 const repoRoot = process.cwd();
 let failed = false;
+
+function writeOrCheckJson(relativePath: string, value: unknown) {
+  if (checkOnly) {
+    console.error(`${relativePath} out of sync. Run \`pnpm plugin-sdk:sync-exports\`.`);
+    failed = true;
+    return;
+  }
+  fs.writeFileSync(
+    path.join(repoRoot, relativePath),
+    `${JSON.stringify(value, null, 2)}\n`,
+    "utf8",
+  );
+}
 
 function syncRootPackageExports() {
   const packageJsonPath = path.join(repoRoot, "package.json");
@@ -43,13 +59,8 @@ function syncRootPackageExports() {
   if (JSON.stringify(currentExports) === JSON.stringify(nextExports)) {
     return;
   }
-  if (checkOnly) {
-    console.error("plugin-sdk exports out of sync. Run `pnpm plugin-sdk:sync-exports`.");
-    failed = true;
-    return;
-  }
   packageJson.exports = nextExports;
-  fs.writeFileSync(packageJsonPath, `${JSON.stringify(packageJson, null, 2)}\n`, "utf8");
+  writeOrCheckJson("package.json", packageJson);
 }
 
 // The workspace facade package mirrors a subset of plugin SDK entrypoints for
@@ -107,16 +118,49 @@ function syncFacadePackageExports(facadeSubpaths: string[]) {
         console.error(`packages/plugin-sdk src facade ${key} is missing from exports.`);
       }
     }
-    console.error("packages/plugin-sdk exports out of sync. Run `pnpm plugin-sdk:sync-exports`.");
-    failed = true;
-    return;
   }
   facadePackageJson.exports = nextExports;
-  fs.writeFileSync(
-    facadePackageJsonPath,
-    `${JSON.stringify(facadePackageJson, null, 2)}\n`,
-    "utf8",
+  writeOrCheckJson("packages/plugin-sdk/package.json", facadePackageJson);
+}
+
+function syncPrivateDeclarationAliases(
+  relativePath: string,
+  prefix: string,
+  omitted: readonly string[] = [],
+) {
+  const config: { compilerOptions: { paths: Record<string, string[]> } } = JSON.parse(
+    fs.readFileSync(path.join(repoRoot, relativePath), "utf8"),
   );
+  const currentPaths = config.compilerOptions.paths;
+  const nextPaths = { ...currentPaths };
+  const privateEntries = new Set(privateLocalOnlyPluginSdkEntrypoints);
+  const declarationRoot = `${prefix}packages/plugin-sdk/dist/src/plugin-sdk/`;
+  for (const [key, targets] of Object.entries(currentPaths)) {
+    const entry = /^openclaw\/plugin-sdk\/([^/*]+)$/u.exec(key)?.[1];
+    // Only canonical generated targets identify retired private aliases. Custom
+    // targets, public overrides, QA bridges and wildcard mappings stay owner-managed.
+    if (
+      entry &&
+      !privateEntries.has(entry) &&
+      targets.length === 1 &&
+      targets[0] === `${declarationRoot}${entry}.d.ts`
+    ) {
+      delete nextPaths[key];
+    }
+  }
+  for (const entry of privateEntries) {
+    const key = `openclaw/plugin-sdk/${entry}`;
+    if (omitted.includes(entry)) {
+      delete nextPaths[key];
+    } else {
+      nextPaths[key] = [`${declarationRoot}${entry}.d.ts`];
+    }
+  }
+  if (JSON.stringify(currentPaths) === JSON.stringify(nextPaths)) {
+    return;
+  }
+  config.compilerOptions.paths = nextPaths;
+  writeOrCheckJson(relativePath, config);
 }
 
 const facadeSubpaths = collectFacadeSubpaths();
@@ -125,6 +169,13 @@ if (facadeSubpaths === null) {
 }
 syncRootPackageExports();
 syncFacadePackageExports(facadeSubpaths);
+syncPrivateDeclarationAliases("extensions/tsconfig.package-boundary.paths.json", "../");
+// XAI's independent package boundary contract intentionally excludes these two
+// private aliases; its remaining custom paths are not registration projections.
+syncPrivateDeclarationAliases("extensions/xai/tsconfig.json", "../../", [
+  "channel-secret-owner-runtime",
+  "channel-secret-tts-runtime",
+]);
 if (failed) {
   process.exit(1);
 }

--- a/test/scripts/changed-lanes.test.ts
+++ b/test/scripts/changed-lanes.test.ts
@@ -1822,22 +1822,22 @@ describe("scripts/changed-lanes", () => {
     }
   });
 
-  it("runs Plugin SDK export and surface checks for direct SDK changes", () => {
-    expect(
-      shouldRunPluginSdkSurfaceChecks([
-        "src/plugin-sdk/core.ts",
-        "scripts/plugin-sdk-surface-report.mts",
-        "scripts/sync-plugin-sdk-exports.mts",
-        "scripts/lib/plugin-sdk-entries.mts",
-        "scripts/lib/plugin-sdk-entrypoints.json",
-        "package.json",
-      ]),
-    ).toBe(true);
+  it.each([
+    "src/plugin-sdk/core.ts",
+    "scripts/plugin-sdk-surface-report.mts",
+    "scripts/sync-plugin-sdk-exports.mts",
+    "scripts/lib/plugin-sdk-entries.mts",
+    "scripts/lib/plugin-sdk-entrypoints.json",
+    "extensions/tsconfig.package-boundary.paths.json",
+    "extensions/xai/tsconfig.json",
+  ])("runs Plugin SDK export and surface checks for %s", (changedPath) => {
+    expect(shouldRunPluginSdkSurfaceChecks([changedPath])).toBe(true);
+    expect(shouldRunPluginSdkSurfaceChecks(["package.json"])).toBe(true);
     expect(shouldRunPluginSdkSurfaceChecks(["src/config/sessions/session-accessor.ts"])).toBe(
       false,
     );
 
-    const result = detectChangedLanes(["src/plugin-sdk/core.ts"]);
+    const result = detectChangedLanes([changedPath]);
     const plan = createChangedCheckPlan(result);
 
     expect(plan.commands).toContainEqual({

--- a/test/scripts/sync-plugin-sdk-exports.test.ts
+++ b/test/scripts/sync-plugin-sdk-exports.test.ts
@@ -1,0 +1,254 @@
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
+
+const repoRoot = path.resolve(import.meta.dirname, "../..");
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+const declarationConfigs = [
+  { file: "extensions/tsconfig.package-boundary.paths.json", prefix: "../" },
+  { file: "extensions/xai/tsconfig.json", prefix: "../../" },
+] as const;
+const outputFiles = [
+  "package.json",
+  "packages/plugin-sdk/package.json",
+  ...declarationConfigs.map(({ file }) => file),
+];
+const entryList = "scripts/lib/plugin-sdk-entrypoints.json";
+const privateList = "scripts/lib/plugin-sdk-private-local-only-subpaths.json";
+
+function writeJson(root: string, file: string, value: unknown) {
+  fs.mkdirSync(path.dirname(path.join(root, file)), { recursive: true });
+  fs.writeFileSync(path.join(root, file), `${JSON.stringify(value, null, 2)}\n`);
+}
+
+function readConfig(
+  root: string,
+  file: string,
+): {
+  compilerOptions: { paths: Record<string, string[]> };
+} {
+  return JSON.parse(fs.readFileSync(path.join(root, file), "utf8"));
+}
+
+function readOutputs(root: string) {
+  return outputFiles.map((file) => fs.readFileSync(path.join(root, file), "utf8"));
+}
+
+function readPackageExports(root: string): Record<string, unknown> {
+  return JSON.parse(fs.readFileSync(path.join(root, "package.json"), "utf8")).exports;
+}
+
+function createFixture(inventory?: { entries: string[]; privateEntries: string[] }) {
+  const root = tempDirs.make("openclaw-sdk-registration-");
+  for (const file of [
+    "scripts/sync-plugin-sdk-exports.mts",
+    "scripts/lib/plugin-sdk-entries.mts",
+    entryList,
+    privateList,
+    "scripts/lib/plugin-sdk-deprecated-barrel-subpaths.json",
+    "scripts/lib/plugin-sdk-deprecated-public-subpaths.json",
+    ...outputFiles,
+  ]) {
+    fs.mkdirSync(path.dirname(path.join(root, file)), { recursive: true });
+    fs.copyFileSync(path.join(repoRoot, file), path.join(root, file));
+  }
+  fs.mkdirSync(path.join(root, "packages/plugin-sdk/src"), { recursive: true });
+  if (inventory) {
+    writeJson(root, entryList, inventory.entries);
+    writeJson(root, privateList, inventory.privateEntries);
+    writeJson(root, "package.json", { type: "module", exports: { ".": "./index.js" } });
+    writeJson(root, "packages/plugin-sdk/package.json", { exports: {} });
+    for (const { file, prefix } of declarationConfigs) {
+      writeJson(root, file, {
+        extends: "./base.json",
+        compilerOptions: {
+          strict: true,
+          paths: {
+            "openclaw/plugin-sdk/*": [`${prefix}dist/plugin-sdk/*.d.ts`],
+            "openclaw/plugin-sdk/custom": [
+              `${prefix}packages/plugin-sdk/dist/src/plugin-sdk/custom.d.ts`,
+              "./override.d.ts",
+            ],
+          },
+        },
+        include: ["z.ts", "a.ts"],
+      });
+    }
+  } else {
+    // Registration reads facade names, not their implementation or dependencies.
+    for (const file of fs.readdirSync(path.join(repoRoot, "packages/plugin-sdk/src"))) {
+      if (file.endsWith(".ts")) {
+        fs.writeFileSync(path.join(root, "packages/plugin-sdk/src", file), "");
+      }
+    }
+  }
+  return root;
+}
+
+function runSync(root: string, ...args: string[]) {
+  return spawnSync(
+    process.execPath,
+    [
+      "--import",
+      path.join(repoRoot, "scripts/tsx.mjs"),
+      path.join(root, "scripts/sync-plugin-sdk-exports.mts"),
+      ...args,
+    ],
+    { cwd: root, encoding: "utf8" },
+  );
+}
+
+describe("plugin SDK registration CLI", () => {
+  it.each(declarationConfigs)("checks $file independently without writing", ({ file }) => {
+    const root = createFixture();
+    const config = readConfig(root, file);
+    delete config.compilerOptions.paths["openclaw/plugin-sdk/browser-cdp"];
+    writeJson(root, file, config);
+    const before = readOutputs(root);
+
+    const result = runSync(root, "--check");
+
+    expect(readOutputs(root)).toEqual(before);
+    expect(result.status, result.stderr).toBe(1);
+    expect(result.stderr).toContain(file);
+    expect(result.stderr).toContain("pnpm plugin-sdk:sync-exports");
+    expect(result.stdout).not.toContain("synced");
+    for (const other of outputFiles.filter((output) => output !== file)) {
+      expect(result.stderr).not.toContain(other);
+    }
+  });
+
+  it("repairs both declaration maps while preserving all existing custom mappings and fields", () => {
+    const root = createFixture();
+    const original = readOutputs(root);
+    const shared = readConfig(root, declarationConfigs[0].file);
+    delete shared.compilerOptions.paths["openclaw/plugin-sdk/browser-cdp"];
+    writeJson(root, declarationConfigs[0].file, shared);
+    const xai = readConfig(root, declarationConfigs[1].file);
+    xai.compilerOptions.paths["openclaw/plugin-sdk/browser-cdp"] = ["./wrong.d.ts"];
+    for (const entry of ["channel-secret-owner-runtime", "channel-secret-tts-runtime"]) {
+      xai.compilerOptions.paths[`openclaw/plugin-sdk/${entry}`] = ["./wrong.d.ts"];
+    }
+    writeJson(root, declarationConfigs[1].file, xai);
+
+    const result = runSync(root);
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(readOutputs(root).map((text) => JSON.parse(text))).toEqual(
+      original.map((text) => JSON.parse(text)),
+    );
+    const sharedKeys = Object.keys(
+      readConfig(root, declarationConfigs[0].file).compilerOptions.paths,
+    );
+    expect(sharedKeys).toEqual([
+      ...Object.keys(shared.compilerOptions.paths),
+      "openclaw/plugin-sdk/browser-cdp",
+    ]);
+    const synced = readOutputs(root);
+    expect(runSync(root, "--check").status).toBe(0);
+    expect(runSync(root).status).toBe(0);
+    expect(readOutputs(root)).toEqual(synced);
+  });
+
+  it("registers private workspace types without publishing them or test-only exports", () => {
+    const root = createFixture({
+      entries: ["public-entry", "private-entry", "test-fixtures"],
+      privateEntries: ["private-entry", "test-fixtures", "qa-lab"],
+    });
+    const result = runSync(root);
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(readPackageExports(root)).toEqual({
+      ".": "./index.js",
+      "./plugin-sdk/public-entry": {
+        types: "./dist/plugin-sdk/public-entry.d.ts",
+        default: "./dist/plugin-sdk/public-entry.js",
+      },
+      "./plugin-sdk/private-entry": { default: "./dist/plugin-sdk/private-entry.js" },
+    });
+    for (const { file, prefix } of declarationConfigs) {
+      expect(readConfig(root, file).compilerOptions.paths).toEqual({
+        "openclaw/plugin-sdk/*": [`${prefix}dist/plugin-sdk/*.d.ts`],
+        "openclaw/plugin-sdk/custom": [
+          `${prefix}packages/plugin-sdk/dist/src/plugin-sdk/custom.d.ts`,
+          "./override.d.ts",
+        ],
+        "openclaw/plugin-sdk/private-entry": [
+          `${prefix}packages/plugin-sdk/dist/src/plugin-sdk/private-entry.d.ts`,
+        ],
+        "openclaw/plugin-sdk/test-fixtures": [
+          `${prefix}packages/plugin-sdk/dist/src/plugin-sdk/test-fixtures.d.ts`,
+        ],
+      });
+    }
+  });
+
+  it.each(["removed", "public"])(
+    "prunes generated aliases when a private entry becomes %s",
+    (kind) => {
+      const root = createFixture({
+        entries: kind === "public" ? ["former-private"] : [],
+        privateEntries: [],
+      });
+      for (const { file, prefix } of declarationConfigs) {
+        const config = readConfig(root, file);
+        config.compilerOptions.paths["openclaw/plugin-sdk/former-private"] = [
+          `${prefix}packages/plugin-sdk/dist/src/plugin-sdk/former-private.d.ts`,
+        ];
+        writeJson(root, file, config);
+      }
+
+      const result = runSync(root);
+
+      expect(result.status, result.stderr).toBe(0);
+      for (const { file, prefix } of declarationConfigs) {
+        expect(readConfig(root, file).compilerOptions.paths).toEqual({
+          "openclaw/plugin-sdk/*": [`${prefix}dist/plugin-sdk/*.d.ts`],
+          "openclaw/plugin-sdk/custom": [
+            `${prefix}packages/plugin-sdk/dist/src/plugin-sdk/custom.d.ts`,
+            "./override.d.ts",
+          ],
+        });
+      }
+      const exports = readPackageExports(root);
+      expect(exports["./plugin-sdk/former-private"]).toEqual(
+        kind === "public"
+          ? {
+              types: "./dist/plugin-sdk/former-private.d.ts",
+              default: "./dist/plugin-sdk/former-private.js",
+            }
+          : undefined,
+      );
+      writeJson(root, entryList, ["former-private"]);
+      writeJson(root, privateList, ["former-private"]);
+      expect(runSync(root).status).toBe(0);
+      for (const { file, prefix } of declarationConfigs) {
+        expect(
+          readConfig(root, file).compilerOptions.paths["openclaw/plugin-sdk/former-private"],
+        ).toEqual([`${prefix}packages/plugin-sdk/dist/src/plugin-sdk/former-private.d.ts`]);
+      }
+      expect(readPackageExports(root)["./plugin-sdk/former-private"]).toEqual({
+        default: "./dist/plugin-sdk/former-private.js",
+      });
+    },
+  );
+
+  it.each([{ args: [] }, { args: ["--check"] }])(
+    "rejects stale facade files before any writes ($args)",
+    ({ args }) => {
+      const root = createFixture({ entries: ["private-entry"], privateEntries: ["private-entry"] });
+      fs.writeFileSync(path.join(root, "packages/plugin-sdk/src/stale.ts"), "");
+      const before = readOutputs(root);
+
+      const result = runSync(root, ...args);
+
+      expect(result.status).toBe(1);
+      expect(result.stderr).toContain(
+        "packages/plugin-sdk/src/stale.ts does not match any plugin SDK entrypoint",
+      );
+      expect(readOutputs(root)).toEqual(before);
+    },
+  );
+});


### PR DESCRIPTION
Related: [Browser native bootstrap repair and the SDK declaration omission found during landing](https://github.com/openclaw/openclaw/pull/132212).

<details>
<summary>Additional instructions</summary>

Maintainers can edit this same-repository branch.

</details>

## What Problem This Solves

Resolves a problem where maintainers registering a private SDK entrypoint could run the registration command successfully, including its check mode, while leaving the workspace declaration aliases incomplete. The independent package-boundary contract then failed later in CI.

This surfaced while landing the Browser native bootstrap repair: registering `browser-cdp` and synchronizing exports did not update `extensions/tsconfig.package-boundary.paths.json` or `extensions/xai/tsconfig.json`. That PR repaired the six missing mapping lines; this follow-up repairs the registration workflow that omitted them.

## Why This Change Was Made

The existing `scripts/sync-plugin-sdk-exports.mts` now reconciles private workspace declaration aliases from the same derived entrypoint inventory it already uses for package exports. Its write and check modes cover both maintained declaration configs. Retired or reclassified aliases are removed only when their key and target match the canonical generated private-declaration shape.

XAI keeps its two intentional private-alias omissions, all other omissions and overrides, and its existing ordered fallback targets. Public aliases, custom package bridges, and unregistered QA mappings remain owner-managed. No second generator, duplicated registration inventory, or test-only production API is introduced. The independent SDK boundary contracts remain unchanged. Config-only edits now select the existing export check through the canonical changed-check owner.

## User Impact

Developer workflow only: one registration command keeps package exports and private declaration aliases aligned, and check mode reports either declaration config when it is stale without writing files.

Private workspace declarations do not become a typed public SDK. Private production exports remain JavaScript-only; test-only entries remain unexported. With the current inventory, synchronization leaves both package manifests and both declaration configs byte-identical. No dependencies, baselines, runtime behavior, or operator state change.

## Evidence

The real CLI was exercised against disposable filesystem fixtures, not mocked projection helpers. Before the repair, check mode exited zero with both `browser-cdp` aliases missing and write mode left them missing. After the repair, check mode exits one without changing bytes, write mode restores the aliases while preserving the other mappings, and subsequent check/write runs succeed idempotently.

- Six CLI regression cases and two independently selected declaration-config routing cases failed on the pre-fix production code for the intended omission.
- Final focused selection: 239 tests passed — eight registration CLI cases, 184 changed-lane cases, and all 47 current SDK contracts. The CLI tests cover private/public/test-only classification, registration, removal/reclassification, both declaration outputs, XAI preservation, idempotence, and stale-facade rejection before writes.
- The complete selected changed-check gate passed, including formatting, SDK export/surface checks, core/plugin/script/test typechecks, lint, and import-cycle checks. Its first run found unchecked-index errors in the new test fixture; those were corrected by recording tuple cardinality and reading the package manifest directly, without non-null assertions or suppressions. The focused tests/typecheck and full gate passed afterward.
- Full build passed. Its unmodified package-consumer guard verified all 147 public SDK subpaths using package resolution without test aliases. No ineffective-dynamic-import diagnostic.
- After building, the real TypeScript resolver selected the generated workspace `browser-cdp` declaration bridge through both Browser and XAI configs; Node package resolution selected the real JavaScript artifact, with no published `types` condition added.
- Fresh isolated Codex autoreview of the complete final local patch, including the corrected fixture typing, reported no P0 findings. This is a P0-scoped review, not an all-severity certification.

Exact local commands:

```bash
node scripts/run-vitest.mjs test/scripts/sync-plugin-sdk-exports.test.ts test/scripts/changed-lanes.test.ts src/plugins/contracts/extension-package-project-boundaries.test.ts src/plugins/contracts/plugin-sdk-subpaths.test.ts src/plugins/contracts/plugin-sdk-package-contract-guardrails.test.ts
```

```bash
node scripts/check-changed.mjs -- docs/plugins/sdk-subpaths.md scripts/check-changed.mts scripts/sync-plugin-sdk-exports.mts test/scripts/changed-lanes.test.ts test/scripts/sync-plugin-sdk-exports.test.ts
```

```bash
pnpm build
```

```bash
pnpm plugin-sdk:sync-exports
```

```bash
pnpm plugin-sdk:check-exports
```

Runtime code: **unchanged**. Tooling: **+68/-17, net +51**. Tests: **+266/-12, net +254**. Docs: **+8/-0**. Tooling growth supplies the missing two-output reconciliation while sharing existing check/write handling; it does not add another policy or generation layer.

Separate follow-ups: inherited shared-config compile freshness, and declaration-graph/stamp ownership after mixed-artifact replay. This PR changes neither declaration generation nor cache/stamp ownership; the passing build and resolution probes do not claim coverage of those separate execution orders.

Pre-merge review follow-through: [exact-head CI run 33231325986](https://github.com/openclaw/openclaw/actions/runs/33231325986) and its CI gate passed; native prepare passed without changing or rebasing the head. [ClawSweeper's review](https://github.com/openclaw/openclaw/pull/132311#issuecomment-5460094548) found no correctness or security defect. Its CI, positive-tooling-LOC, and explicit maintainer acceptance items are satisfied by that run, the final changed-check proof and ownership justification above, and the prior explicit landing approval for this exact patch. Its serialized-state flag refers to existing checked-in build config maps, not runtime persistence: no schema, migration, or operator state is changed. All four outputs remain byte-identical. No independent GitHub approval rule is enforced and no bypass is used.

AI-assisted implementation and verification.
