### PR TITLE
chore(e2e): repair lifecycle and ClawHub release fixtures

### DIFF
--- a/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
+++ b/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
@@ -265,34 +265,41 @@ vi.mock("../../channels/plugins/index.js", async (importOriginal) => ({
   getChannelPlugin: (channel: unknown) => state.getChannelPluginMock(channel),
 }));
 
-vi.mock("../../agents/embedded-agent-runner/runs.js", () => ({
-  formatEmbeddedAgentQueueFailureSummary: () => "test queue rejection",
-  queueEmbeddedAgentMessageWithOutcomeAsync: async (
-    sessionId: string,
-    prompt: string,
-    options: unknown,
-  ) => {
-    const result = state.queueEmbeddedAgentMessageMock(sessionId, prompt, options);
-    if (typeof result === "object") {
-      return result;
-    }
-    return result
-      ? {
-          queued: true,
-          sessionId,
-          target: "embedded_run",
-          gatewayHealth: "live",
-          enqueuedAtMs: Date.now(),
-        }
-      : {
-          queued: false,
-          sessionId,
-          reason: "no_active_run",
-          target: "none",
-          gatewayHealth: "live",
-        };
-  },
-}));
+vi.mock("../../agents/embedded-agent-runner/runs.js", async (importOriginal) => {
+  const { clearActiveEmbeddedRun, setActiveEmbeddedRun } =
+    await importOriginal<typeof import("../../agents/embedded-agent-runner/runs.js")>();
+  return {
+    // Queue admission is controlled here; logical-turn registration and retirement stay real.
+    clearActiveEmbeddedRun,
+    setActiveEmbeddedRun,
+    formatEmbeddedAgentQueueFailureSummary: () => "test queue rejection",
+    queueEmbeddedAgentMessageWithOutcomeAsync: async (
+      sessionId: string,
+      prompt: string,
+      options: unknown,
+    ) => {
+      const result = state.queueEmbeddedAgentMessageMock(sessionId, prompt, options);
+      if (typeof result === "object") {
+        return result;
+      }
+      return result
+        ? {
+            queued: true,
+            sessionId,
+            target: "embedded_run",
+            gatewayHealth: "live",
+            enqueuedAtMs: Date.now(),
+          }
+        : {
+            queued: false,
+            sessionId,
+            reason: "no_active_run",
+            target: "none",
+            gatewayHealth: "live",
+          };
+    },
+  };
+});
 
 vi.mock("../../gateway/mcp-app-channel-action.js", () => ({
   materializeMcpAppChannelPresentation: (params: unknown) =>

--- a/src/cli/plugins-cli.clawhub-install.e2e.test.ts
+++ b/src/cli/plugins-cli.clawhub-install.e2e.test.ts
@@ -8,6 +8,7 @@ import path from "node:path";
 import JSZip from "jszip";
 import { afterEach, describe, expect, it } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import type { ClawHubPackageSecurityResponse } from "../infra/clawhub-packages.js";
 import { loadInstalledPluginIndexInstallRecords } from "../plugins/installed-plugin-index-records.js";
 
 const PACKAGE_NAME = "@openclaw/telemetry-demo";
@@ -151,6 +152,8 @@ async function startClawHubServer(options: TestServerOptions = {}) {
             family: "code-plugin",
           },
           release: { version: PACKAGE_VERSION },
+          overview: "Synthetic plugin fixture with no registered tools or services.",
+          securityAuditUrl: `${registry}/plugins/${PACKAGE_NAME}/security-audit?version=${PACKAGE_VERSION}`,
           trust: {
             scanStatus: "clean",
             moderationState: null,
@@ -159,7 +162,7 @@ async function startClawHubServer(options: TestServerOptions = {}) {
             pending: false,
             stale: false,
           },
-        }),
+        } satisfies ClawHubPackageSecurityResponse),
       );
       return;
     }
@@ -191,9 +194,10 @@ async function startClawHubServer(options: TestServerOptions = {}) {
   await new Promise<void>((resolve) => {
     server.listen(0, "127.0.0.1", resolve);
   });
+  const registry = `http://127.0.0.1:${(server.address() as AddressInfo).port}`;
 
   return {
-    registry: `http://127.0.0.1:${(server.address() as AddressInfo).port}`,
+    registry,
     requestLog,
     telemetryBodies,
     close: async () => {
@@ -333,7 +337,7 @@ describe("openclaw plugins install ClawHub E2E", () => {
     30_000,
   );
 
-  it("does not report success when plugin installation fails", async () => {
+  it("rejects a corrupt archive without persisting or reporting a successful install", async () => {
     const testServer = await startClawHubServer({ artifactSha256: "0".repeat(64) });
     const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-plugin-telemetry-fail-"));
     try {
@@ -343,6 +347,8 @@ describe("openclaw plugins install ClawHub E2E", () => {
       );
 
       expect(result.status).not.toBe(0);
+      expect(`${result.stdout}\n${result.stderr}`).toContain("ClawHub archive integrity mismatch");
+      expect(testServer.requestLog).toContain(`GET ${PACKAGE_API_PATH}/download`);
       expect(testServer.telemetryBodies).toEqual([]);
       await expect(readPersistedInstallRecord(stateDir)).resolves.toBeUndefined();
     } finally {


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where release E2E fixtures fail before exercising their intended lifecycle and package-integrity boundaries. The reply-run fixture omits newly required lifecycle exports, and the ClawHub fixture returns an incomplete security response. Its former corruption assertion accepts any nonzero exit, including failure before downloading the archive.

Related: #126566 (deferred CLI run ownership) and #131233 (required ClawHub audit information). The telemetry fixture from the same investigation is already superseded by #132222 (accurate automated-environment telemetry inspection), so it is deliberately excluded here.

## Why This Change Was Made

Keep controlled queue admission in the existing reply fixture, while importing the real registration/retirement functions used by the deferred owner. Complete the typed ClawHub security response and require the corrupt-archive case to reach download and the digest error before asserting no persisted install or success telemetry. No production path is changed or weakened.

## User Impact

No runtime behavior change. Maintainers regain meaningful release-fixture coverage without disabling lifecycle cleanup or weakening ClawHub validation. This is explicitly requested test maintenance; there is no changelog change.

## Evidence

The original frozen-source reproduction had 116 failures in the 158-case reply fixture and two failures in the five-case ClawHub fixture. The strengthened corruption assertion also failed against the old response because download was never reached. On that repaired source, all 158 reply cases and five ClawHub cases passed, including the residual final-text cases, repeat installation, persisted records, and telemetry HTTP 503 handling. These earlier receipts are retained as original-source evidence, not new-main proof.

Current-main base: `59dad71c416bcd9d649323c5f17fecdc31fd526a`. Ported only the two fixture hunks, preserving the newer main test title. Current local commands:

```sh
OPENCLAW_VITEST_MAX_WORKERS=2 OPENCLAW_E2E_WORKERS=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.e2e.config.ts src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts src/cli/plugins-cli.clawhub-install.e2e.test.ts
OPENCLAW_VITEST_MAX_WORKERS=2 node scripts/check-changed.mjs --base 59dad71c416bcd9d649323c5f17fecdc31fd526a -- src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts src/cli/plugins-cli.clawhub-install.e2e.test.ts
```

The full changed-file gate passed, including all three unused-export scans. The two-file focused invocation did not report cases locally: after its canonical cold build completed, the unchanged 300-second no-output watchdog terminated it (exit 143). One diagnostic rerun reused that exact prepared dist and enabled the existing verbose output switch; it reached the same pre-case watchdog. Both failures are retained. A sampled child showed filesystem work and event-loop waiting, which does not establish an assertion result.

The unchanged two-file patch was rebased cleanly onto `383a293b32d97254014437430b62aaf406bc11ac`; its affected runtime owners are unchanged from the original author base. Current head: `19033bf1c58ac51cd20d48d535759301fa619175`, tree `5367bd557afe5da5e0bbb84b8faec8444bc7fed0`. Fresh isolated Linux proof on that exact head passed **163/163 tests in both files** (502.57 s), using Node 24.19.0, pnpm 12.0.0, the unchanged canonical bootstrap and a fresh HOME without credential hydration. The canonical build completed before the tests. The command was `CI=1 OPENCLAW_E2E_WORKERS=1 OPENCLAW_VITEST_MAX_WORKERS=2 node scripts/run-vitest.mjs run --config test/vitest/vitest.e2e.config.ts src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts src/cli/plugins-cli.clawhub-install.e2e.test.ts`. No watchdog, assertion, or execution-order limit was relaxed. The isolated lease was stopped and read back as released. The latest ClawSweeper review requested this exact-head two-file result before marking ready; that rank-up move and its associated proof gap are now satisfied.

Fresh full nonempty-delta Codex autoreview passed at P0 with no findings; the helper's existing secret scan and restricted review isolation were retained. Test audit: both changes repair existing boundary coverage; no duplicate cases or test-only production seams were added. Production delta: **0**. Test delta: **+44/-31**.

Source evidence: `agent-runner-execution.ts` completes the deferred lifecycle owner in `finally`; `deferred-lifecycle-owner.ts` uses `runs.ts` registration/retirement; the command runner shares that owner. ClawHub flows from `plugins-install-command.ts` through managed installation to `plugins/clawhub.ts`, whose trust parser requires the audit fields before archive download and digest validation; success telemetry is emitted only after installation succeeds. Existing direct lifecycle, registry, parser, and installer tests cover those sibling boundaries.

Known gaps: the separate unchanged execution shard's three failures / 119 passes and the original full-suite unexpected worker exit remain unresolved. This PR does not repair either, the native source/Jiti publication split, or make the full release campaign green.
