### PR TITLE
fix(discord): prevent REST fixture timers leaking into later tests

### DIFF
--- a/extensions/discord/src/internal/rest.test.ts
+++ b/extensions/discord/src/internal/rest.test.ts
@@ -881,7 +881,8 @@ describe("RequestClient", () => {
         expect(req.headers["content-type"]).toMatch(/^multipart\/form-data; boundary=/);
         req.resume();
         req.on("end", () => {
-          res.writeHead(200, { "Content-Type": "application/json" });
+          // Retire the native fetch socket before a later test installs fake timers.
+          res.writeHead(200, { "Content-Type": "application/json", Connection: "close" });
           res.end(JSON.stringify({ id: "msg" }));
         });
       });

--- a/extensions/discord/src/send.test-harness.ts
+++ b/extensions/discord/src/send.test-harness.ts
@@ -78,8 +78,10 @@ export async function createDiscordLoopbackRest(options?: {
         path: request.url,
       };
       requests.push(received);
+      // server.close() does not await the fetch client's deferred keep-alive timer.
       response.writeHead(options?.status?.(received) ?? 200, {
         "Content-Type": "application/json",
+        Connection: "close",
       });
       response.end(
         JSON.stringify(


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where Discord REST tests fail in shuffled order after a real multipart HTTP request. With seed 37, the same-bucket no-polling test observes two timers after advancing 20ms, although only its active request deadline should remain. The original four-file run reproduces 115 passed / 1 failed on current main.

## Why This Change Was Made

The extra timer is native Undici's 3,000ms HTTP/1 keep-alive parser timeout, created by a deferred client-resume callback after the preceding fixture's `server.close()` resolves. Closing the server does not own that peer-client continuation.

Both short-lived Discord loopback response owners now send `Connection: close`. Native Undici destroys the completed response's socket before scheduling an idle-client resume. This retains native fetch, its default dispatcher and multipart serialization, while keeping the existing awaited server cleanup. The proxy multipart fixture already uses the same response contract.

## User Impact

No production behavior changes. Discord HTTP fixtures no longer contaminate subsequent fake-timer tests. All fetch counts, exact timer counts, payload assertions, test ordering, fake-timer scope, timeouts and runner isolation remain unchanged. Production LOC: +0/-0; tests and test support: +4/-1.

## Evidence

AI-assisted maintainer-requested repair.

- Baseline `116425e9b3044c88c20c8727360663b6ce9eeed9`: original four-file seed 37 command fails only `rest.test.ts:288`, expected 1 timer and received 2. The earlier fetch-count and initial timer-count assertions pass.
- Temporary instrumentation traced the first timer to `RequestClient.executeRequest` (15,000ms) and the extra timer to native Undici `Parser.setTimeout -> resumeH1 -> Immediate.Client[kResume]` (3,000ms, `onParserTimeout`). Instrumentation is removed from the patch.
- Direct native-source inspection confirms `onMessageComplete` queues that resume only for a persistent connection; a nonpersistent response destroys the socket synchronously. A standalone real-HTTP probe reproduced post-server-close timer creation on Node 26.7.0 / Undici 8.9.0 and Node 24.20.0 / Undici 7.29.0, and confirmed its absence with the close header.
- Fixed original four-file command: 116/116 in normal order; 116/116 with shuffled seed 37 twice on Node 26; 116/116 with seed 37 on Node 24. The existing no-polling test is the failing-before/passing-after regression; no duplicate test or broader fake-timer scope was added.
- All five additional loopback-caller/proxy test files pass: 279/279 tests (durable forum batches, native-command replies, basic channel sends, messaging actions, proxy multipart uploads).
- Scoped formatting and `git diff --check` pass. Full changed-gate CI parity passed on Blacksmith Testbox (lease stopped/completed): https://github.com/openclaw/openclaw/actions/runs/33231271199.
- Exact-head [CI run 33231431958](https://github.com/openclaw/openclaw/actions/runs/33231431958) passed at `e7724d2ffb01d82d6ea63ae446f41f82a25a4ef1`; rebase-sanity seed 37 also passed 116/116.
- Fresh Codex autoreview: clean, no accepted/actionable findings.

Canonical regression command:

```sh
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs \
  extensions/discord/src/send.components.multipart.test.ts \
  extensions/discord/src/send.components.test.ts \
  extensions/discord/src/outbound-payload.contract.test.ts \
  extensions/discord/src/internal/rest.test.ts \
  --maxWorkers=1 --sequence.shuffle --sequence.seed=37
```

Each local run used a distinct filesystem module-cache directory. The separate component suite initialization defect was repaired in #132307; this patch does not include or depend on that change for seed 37.
