### PR TITLE
test(imap): shorten protocol fixture reconnect backoff

### DIFF
--- a/extensions/imap/src/watcher.test.ts
+++ b/extensions/imap/src/watcher.test.ts
@@ -192,6 +192,8 @@ async function startWatcher(
     state,
     context,
     authenticator,
+    // Exercise real reconnects without waiting through production backoff intervals.
+    reconnectBaseMs: 5,
   });
   activeWatchers.push(watcher);
   watcher.start();


### PR DESCRIPTION
## What Problem This Solves

The IMAP protocol suite spends seconds idling through production reconnect backoff on every run, although its assertions exercise delivery, cursor recovery, admission ordering, and authentication exhaustion rather than elapsed backoff time. This is part of a maintainer-requested test execution performance sweep; sharding is explicitly unchanged.

## Why This Change Was Made

Pass the watcher's existing `reconnectBaseMs` option from the shared test fixture. All connections still use the scripted loopback IMAP server and real ImapFlow client. The production default, exponential backoff implementation, polling intervals, and all 18 protocol cases and assertions remain unchanged. The admission-ordering test still holds admission across later mailbox polls.

## User Impact

No product behavior changes. Developers get faster execution of the same protocol coverage. Production LOC: +0/-0. Tests: +2/-0. No sharding, worker, dependency, timeout-budget, or test-selection changes.

## Evidence

- Same local Node 26.5.0 checkout and command before/after: `node scripts/run-vitest.mjs extensions/imap/src/watcher.test.ts --reporter=default --reporter=json --outputFile=<report>`.
- All 18 tests passed before and after. Vitest test execution: **8.742s before → 1.423s after (83.7% reduction)**. Cold import/transform changes are excluded from this comparison.
- Full sibling suite: `node scripts/run-vitest.mjs extensions/imap --reporter=default --reporter=json --outputFile=<report>` — **45 tests passed across 4 files**, watcher execution 1.602s.
- Fresh Codex autoreview: no accepted/actionable findings.
- Formatting, targeted lint, and whitespace checks passed.
- `node scripts/check-changed.mjs -- extensions/imap/src/watcher.test.ts` passed on Blacksmith Testbox (exit 0; lease stopped), including extension test typechecking, lint, and repository guards: [run 33231331311](https://github.com/openclaw/openclaw/actions/runs/33231331311). Hosted PR CI must pass on the exact head before landing.
