### PR TITLE
fix(codex): keep tool lifecycle out of channel progress

### DIFF
--- a/extensions/codex/src/app-server/event-projector-events.ts
+++ b/extensions/codex/src/app-server/event-projector-events.ts
@@ -122,6 +122,8 @@ export function projectNormalizedToolItem(params: {
         stream: "tool",
         data: {
           phase: params.phase,
+          // Codex tool lifecycle is private telemetry; channels render authored progress only.
+          hideFromChannelProgress: true,
           name,
           itemId: item.id,
           toolCallId: item.id,

--- a/extensions/codex/src/app-server/event-projector-tool-progress.ts
+++ b/extensions/codex/src/app-server/event-projector-tool-progress.ts
@@ -453,6 +453,10 @@ export class CodexToolProgressProjection {
     if (params.finalOutput) {
       this.resultOutputItemIds.add(params.itemId);
     }
+    // Channel drafts consume structured events; this legacy formatted callback must stay private.
+    if (this.params.messageChannel || this.params.messageProvider) {
+      return;
+    }
     try {
       void Promise.resolve(
         this.params.onToolResult?.({

--- a/extensions/codex/src/app-server/event-projector.dynamic-tools.test.ts
+++ b/extensions/codex/src/app-server/event-projector.dynamic-tools.test.ts
@@ -264,11 +264,15 @@ describe("CodexAppServerEventProjector dynamic tool projection", () => {
     });
   });
 
-  it("emits verbose summaries for transcript-recorded dynamic tool calls", async () => {
+  it.each([
+    ["non-channel", undefined, 1],
+    ["channel", "telegram", 0],
+  ] as const)("handles transcript tool summaries for %s runs", async (_, messageChannel, calls) => {
     const onAgentEvent = vi.fn();
     const onToolResult = vi.fn();
     const projector = await createProjector({
       ...(await createParams()),
+      ...(messageChannel ? { messageChannel } : {}),
       verboseLevel: "on",
       onAgentEvent,
       onToolResult,
@@ -279,15 +283,28 @@ describe("CodexAppServerEventProjector dynamic tool projection", () => {
       tool: "browser",
       arguments: { action: "open", url: "http://127.0.0.1:3000" },
     });
+    projector.recordDynamicToolResult({
+      callId: "call-browser-1",
+      tool: "browser",
+      success: true,
+      contentItems: [{ type: "inputText", text: "opened" }],
+    });
 
     const toolEvents = onAgentEvent.mock.calls.filter(([event]) => {
       const record = requireRecord(event, "agent event");
       return record.stream === "tool";
     });
     expect(toolEvents).toHaveLength(0);
-    expect(onToolResult).toHaveBeenCalledTimes(1);
-    const payload = mockCallArg(onToolResult, 0, 0, "onToolResult") as { text?: string };
-    expect(payload.text).toContain("Browser");
+    expect(onToolResult).toHaveBeenCalledTimes(calls);
+    if (calls > 0) {
+      const payload = mockCallArg(onToolResult, 0, 0, "onToolResult") as { text?: string };
+      expect(payload.text).toContain("Browser");
+    }
+    const messages = projector.buildResult(buildEmptyToolTelemetry()).messagesSnapshot;
+    expect(requireRecord(messages[2], "tool result")).toMatchObject({
+      role: "toolResult",
+      toolCallId: "call-browser-1",
+    });
   });
 
   it("does not replay transcript summaries when only tool output is enabled", async () => {

--- a/extensions/codex/src/app-server/event-projector.native-finalization.test.ts
+++ b/extensions/codex/src/app-server/event-projector.native-finalization.test.ts
@@ -366,6 +366,7 @@ describe("CodexAppServerEventProjector native tool finalization", () => {
       itemId: "cmd-snapshot",
       name: "bash",
     }).data;
+    expect(toolStart.hideFromChannelProgress).toBe(true);
     expect(toolStart.args).toEqual({ command: "pnpm test extensions/codex", cwd: "/workspace" });
     const toolResult = findAgentEvent(onAgentEvent, {
       stream: "tool",
@@ -373,6 +374,7 @@ describe("CodexAppServerEventProjector native tool finalization", () => {
       itemId: "cmd-snapshot",
       name: "bash",
     }).data;
+    expect(toolResult.hideFromChannelProgress).toBe(true);
     expect(toolResult.status).toBe("completed");
     expect(toolResult.isError).toBe(false);
     expect(onToolResult).toHaveBeenCalledWith({

--- a/extensions/codex/src/app-server/event-projector.replay-safety.test.ts
+++ b/extensions/codex/src/app-server/event-projector.replay-safety.test.ts
@@ -261,7 +261,11 @@ describe("CodexAppServerEventProjector replay safety and progress projection", (
         itemId: "mcp-command-1",
         name: "server.exec",
       }).data,
-    ).toMatchObject({ commandBearing: true, isError: false });
+    ).toMatchObject({
+      commandBearing: true,
+      hideFromChannelProgress: true,
+      isError: false,
+    });
   });
 
   it("treats native collaboration calls as side-effect evidence", async () => {

--- a/extensions/codex/src/app-server/run-attempt-server-requests.ts
+++ b/extensions/codex/src/app-server/run-attempt-server-requests.ts
@@ -198,6 +198,8 @@ export function createCodexAttemptServerRequestController(
           stream: "tool",
           data: {
             phase: "start",
+            // OpenClaw tool execution stays observable without becoming public channel content.
+            hideFromChannelProgress: true,
             name: call.tool,
             toolCallId: call.callId,
             ...(toolMeta ? { meta: toolMeta } : {}),
@@ -304,6 +306,7 @@ export function createCodexAttemptServerRequestController(
             stream: "tool",
             data: {
               phase: "result",
+              hideFromChannelProgress: true,
               name: call.tool,
               toolCallId: call.callId,
               ...(toolMeta ? { meta: toolMeta } : {}),

--- a/extensions/codex/src/app-server/run-attempt.dynamic-tools.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.dynamic-tools.test.ts
@@ -242,6 +242,7 @@ describe("runCodexAppServerAttempt dynamic tools", () => {
       data?: {
         args?: Record<string, unknown>;
         commandBearing?: boolean;
+        hideFromChannelProgress?: boolean;
         isError?: boolean;
         name?: string;
         phase?: string;
@@ -261,6 +262,7 @@ describe("runCodexAppServerAttempt dynamic tools", () => {
     expect(startEvent?.data?.toolCallId).toBe("call-1");
     expect(startEvent?.data?.args?.action).toBe("search");
     expect(startEvent?.data?.commandBearing).toBe(true);
+    expect(startEvent?.data?.hideFromChannelProgress).toBe(true);
     expect(startEvent?.data?.args?.token).toBe("plain-…2345");
     expect(startEvent?.data?.args?.text).toBe("hello");
     const resultEvent = agentEvents.find(
@@ -271,6 +273,7 @@ describe("runCodexAppServerAttempt dynamic tools", () => {
     );
     expect(resultEvent?.data?.name).toBe("lookup");
     expect(resultEvent?.data?.commandBearing).toBe(true);
+    expect(resultEvent?.data?.hideFromChannelProgress).toBe(true);
     expect(resultEvent?.data?.toolCallId).toBe("call-1");
     expect(resultEvent?.data?.isError).toBe(true);
     expect(resultEvent?.data?.result).not.toHaveProperty("success");

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -1797,6 +1797,7 @@ describe("runCodexAppServerAttempt", () => {
       stream: "tool",
       data: {
         phase: "start",
+        hideFromChannelProgress: true,
         name: "python",
         toolCallId: "call-1",
         args: { code: "print('hi')" },
@@ -1806,6 +1807,7 @@ describe("runCodexAppServerAttempt", () => {
       stream: "tool",
       data: {
         phase: "result",
+        hideFromChannelProgress: true,
         name: "python",
         toolCallId: "call-1",
         isError: true,


### PR DESCRIPTION
Fixes #132034

## Problem

Codex-backed channel turns exposed native command, MCP, and OpenClaw dynamic-tool lifecycle labels in public Telegram and Discord progress drafts. These rows are execution telemetry, not assistant-authored progress.

## Root cause

Codex published the same lifecycle through two public-progress paths. Its structured native and dynamic tool events omitted the existing channel-privacy marker. Its legacy formatted `onToolResult` callback also bypassed structured event filtering during channel runs.

## Fix

- Mark native command, MCP, and dynamic-tool events as hidden from channel progress at their Codex producer boundaries.
- Keep the legacy formatted callback available for non-channel verbose consumers, but suppress it for channel-originated runs.
- Keep transcript, trajectory, diagnostics, authored commentary, and final delivery unchanged.

## Codex contract proof

The acting maintainer directly inspected OpenAI Codex at `0ae94fdd49b05ee7faa4d984d06a68492cb32b54`. The upstream source confirms that app-server owns typed command, MCP, and dynamic-tool lifecycle facts. OpenClaw owns whether those facts become channel presentation.

- [`protocol/common.rs`](https://github.com/openai/codex/blob/0ae94fdd49b05ee7faa4d984d06a68492cb32b54/codex-rs/app-server-protocol/src/protocol/common.rs#L1681-L1719) defines command approval, MCP elicitation, and the client-executed `item/tool/call` request.
- [`protocol/v2/item.rs`](https://github.com/openai/codex/blob/0ae94fdd49b05ee7faa4d984d06a68492cb32b54/codex-rs/app-server-protocol/src/protocol/v2/item.rs#L230-L341) defines distinct `AgentMessage`, `CommandExecution`, and `McpToolCall` item variants.
- [`thread_shell_command.rs`](https://github.com/openai/codex/blob/0ae94fdd49b05ee7faa4d984d06a68492cb32b54/codex-rs/app-server/tests/suite/v2/thread_shell_command.rs#L574-L630) observes command start, completion, and output as app-server notifications.
- [`dynamic_tools.rs`](https://github.com/openai/codex/blob/0ae94fdd49b05ee7faa4d984d06a68492cb32b54/codex-rs/app-server/tests/suite/v2/dynamic_tools.rs#L964-L1002) observes dynamic tool start and completion as app-server notifications.

## Validation

- Focused Codex projector and dynamic-tool tests: 58 passed.
- Formatting, targeted Oxlint, conflict markers, max-lines ratchet, assertion-safety ratchet, and `git diff --check`: passed.
- Production delta: +9 lines. Test delta: +28 lines. The production growth is the three privacy markers plus one channel-boundary guard and its invariant comments.
- Hosted CI owns full typecheck and build validation.

## Live proof

The same real Telegram Test Server direct-message scenario ran against current main and this exact head with a real Codex-backed turn, the live OpenAI Developer Docs MCP server, Bash, authored commentary, and final message delivery.

- Main `e6696bea2c826e4ad0b009292a652459626d513f`: the progress draft kept authored commentary, then exposed both the MCP search label and `Bash`; the final reply remained visible.
- Head `60d26ba6a8390d5285c6c0603cc25ba0589c3051` reuses the patch-identical runtime proof from `128984ee739ec6928c058f63acb7d7c98b30032a`: the progress draft showed only authored commentary; no MCP or Bash label appeared; the final reply remained visible. The only later change updates an exact event expectation found by CI.
- Anti-cheat: the retained private trajectory records completed MCP and Bash call/result pairs, final message delivery, and a successful session end.
