### PR TITLE
refactor(ci): share weighted contract test sharding

### DIFF
--- a/scripts/lib/channel-contract-test-plan.mts
+++ b/scripts/lib/channel-contract-test-plan.mts
@@ -1,6 +1,7 @@
 // Builds balanced Vitest shard plans for channel plugin contract tests.
 import { relative } from "node:path";
 import { listTrackedTestFiles } from "./list-test-files.mts";
+import { assignWeightedTestFiles } from "./weighted-test-shards.mts";
 
 function listContractTestFiles(rootDir = "src/channels/plugins/contracts") {
   return listTrackedTestFiles(rootDir);
@@ -42,16 +43,6 @@ export function createChannelContractTestShards() {
     includePatterns: new Array<string>(),
     weight: 0,
   }));
-  const pushBalanced = (file: string) => {
-    const target = groups.toSorted(
-      (a, b) => a.weight - b.weight || a.checkName.localeCompare(b.checkName),
-    )[0];
-    if (!target) {
-      throw new Error("channel contract shard groups must not be empty");
-    }
-    target.includePatterns.push(file);
-    target.weight += resolveContractFileWeight(file);
-  };
 
   const coreFiles = new Array<string>();
   const registryFiles = new Array<string>();
@@ -63,16 +54,8 @@ export function createChannelContractTestShards() {
     ).push(file);
   }
 
-  const byDescendingWeight = (left: string, right: string) => {
-    const delta = resolveContractFileWeight(right) - resolveContractFileWeight(left);
-    return delta === 0 ? left.localeCompare(right) : delta;
-  };
-  for (const file of registryFiles.toSorted(byDescendingWeight)) {
-    pushBalanced(file);
-  }
-  for (const file of coreFiles.toSorted(byDescendingWeight)) {
-    pushBalanced(file);
-  }
+  assignWeightedTestFiles(groups, registryFiles, resolveContractFileWeight);
+  assignWeightedTestFiles(groups, coreFiles, resolveContractFileWeight);
 
   return groups.map(({ checkName, includePatterns }) => ({
     checkName,

--- a/scripts/lib/plugin-contract-test-plan.mts
+++ b/scripts/lib/plugin-contract-test-plan.mts
@@ -1,5 +1,6 @@
 // Builds balanced Vitest shard plans for plugin contract tests.
 import { listTrackedTestFiles } from "./list-test-files.mts";
+import { assignWeightedTestFiles } from "./weighted-test-shards.mts";
 
 function listContractTestFiles(rootDir = "src/plugins/contracts") {
   return listTrackedTestFiles(rootDir);
@@ -33,34 +34,16 @@ function resolveContractFileWeight(file: string) {
 /** Create balanced plugin contract test shards for CI check planning. */
 export function createPluginContractTestShards() {
   const suffixes = ["a", "b"];
-  const groups: Record<string, string[]> = Object.fromEntries(
-    suffixes.map((suffix) => [`checks-fast-contracts-plugins-${suffix}`, []]),
-  );
-  const groupKeys = suffixes.map((suffix) => `checks-fast-contracts-plugins-${suffix}`);
-  const weights: Record<string, number> = Object.fromEntries(groupKeys.map((key) => [key, 0]));
+  const groups = suffixes.map((suffix) => ({
+    checkName: `checks-fast-contracts-plugins-${suffix}`,
+    includePatterns: new Array<string>(),
+    weight: 0,
+  }));
 
-  const pushBalanced = (file: string) => {
-    const target = groupKeys.toSorted(
-      (a, b) => (weights[a] ?? 0) - (weights[b] ?? 0) || a.localeCompare(b),
-    )[0];
-    if (!target || !groups[target] || weights[target] === undefined) {
-      throw new Error("plugin contract shard groups must not be empty");
-    }
-    groups[target].push(file);
-    weights[target] += resolveContractFileWeight(file);
-  };
+  assignWeightedTestFiles(groups, listContractTestFiles(), resolveContractFileWeight);
 
-  const byDescendingWeight = (left: string, right: string) => {
-    const delta = resolveContractFileWeight(right) - resolveContractFileWeight(left);
-    return delta === 0 ? left.localeCompare(right) : delta;
-  };
-
-  for (const file of listContractTestFiles().toSorted(byDescendingWeight)) {
-    pushBalanced(file);
-  }
-
-  return Object.entries(groups)
-    .map(([checkName, includePatterns]) => ({
+  return groups
+    .map(({ checkName, includePatterns }) => ({
       checkName,
       includePatterns,
       runtime: "node",

--- a/scripts/lib/weighted-test-shards.mts
+++ b/scripts/lib/weighted-test-shards.mts
@@ -1,0 +1,30 @@
+type WeightedTestShard = {
+  checkName: string;
+  includePatterns: string[];
+  weight: number;
+};
+
+export function assignWeightedTestFiles(
+  shards: WeightedTestShard[],
+  files: readonly string[],
+  resolveWeight: (file: string) => number,
+) {
+  if (shards.length === 0) {
+    throw new Error("weighted test shards must not be empty");
+  }
+
+  const weightedFiles = files
+    .map((file) => ({ file, weight: resolveWeight(file) }))
+    .toSorted((left, right) => right.weight - left.weight || left.file.localeCompare(right.file));
+
+  for (const { file, weight } of weightedFiles) {
+    // Stable ties keep generated CI plans byte-identical across hosts and repeated runs.
+    const target = shards.reduce((lightest, candidate) => {
+      const delta =
+        candidate.weight - lightest.weight || candidate.checkName.localeCompare(lightest.checkName);
+      return delta < 0 ? candidate : lightest;
+    });
+    target.includePatterns.push(file);
+    target.weight += weight;
+  }
+}

--- a/test/scripts/weighted-test-shards.test.ts
+++ b/test/scripts/weighted-test-shards.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import { assignWeightedTestFiles } from "../../scripts/lib/weighted-test-shards.mts";
+
+describe("assignWeightedTestFiles", () => {
+  it("balances deterministic ties across repeated assignment batches", () => {
+    const shards = [
+      { checkName: "check-b", includePatterns: new Array<string>(), weight: 0 },
+      { checkName: "check-a", includePatterns: new Array<string>(), weight: 0 },
+    ];
+    const weights = new Map([
+      ["a-heavy.test.ts", 5],
+      ["b-heavy.test.ts", 5],
+      ["z-light.test.ts", 1],
+      ["c-medium.test.ts", 4],
+      ["d-medium.test.ts", 4],
+    ]);
+    const resolveWeight = (file: string) => weights.get(file) ?? 0;
+
+    assignWeightedTestFiles(
+      shards,
+      ["z-light.test.ts", "b-heavy.test.ts", "a-heavy.test.ts"],
+      resolveWeight,
+    );
+    assignWeightedTestFiles(shards, ["d-medium.test.ts", "c-medium.test.ts"], resolveWeight);
+
+    expect(shards).toEqual([
+      {
+        checkName: "check-b",
+        includePatterns: ["b-heavy.test.ts", "c-medium.test.ts"],
+        weight: 9,
+      },
+      {
+        checkName: "check-a",
+        includePatterns: ["a-heavy.test.ts", "z-light.test.ts", "d-medium.test.ts"],
+        weight: 10,
+      },
+    ]);
+  });
+
+  it("rejects an empty shard list", () => {
+    expect(() => assignWeightedTestFiles([], ["contract.test.ts"], () => 1)).toThrow(
+      "weighted test shards must not be empty",
+    );
+  });
+});


### PR DESCRIPTION
## What Problem This Solves

The channel and plugin contract-test planners independently implemented the same weighted shard assignment policy. Keeping those copies in sync made CI plan determinism easier to regress when either planner changed.

## Why This Change Was Made

This moves the shared deterministic assignment into one scripts-internal helper while preserving each planner's discovery, weighting, batch order, check names, and output shape. It adds no package, SDK, config, protocol, or runtime seam.

## User Impact

No user-visible behavior changes. CI contract-test plans remain byte-identical while their balancing policy now has one owner.

## Evidence

- Focused Vitest proof: 11 tests passed across the helper and both planner suites.
- Before/after planner JSON SHA-256: `53490522859ff219d39b26fb0315a40f4fbc91cc8e597112dacb5496be48e849`.
- Crabbox clean-machine proof: Blacksmith Testbox `tbx_01m15smj30xf14zchac71e00wz` passed on exact head `53eaf2c443c7c634359ee1783a5ff549644f426f` ([run](https://github.com/openclaw/openclaw/actions/runs/33231968436)).
- Native prepare build and check gates passed. Its remote full-suite run hit unrelated Testbox filesystem assumptions: mode assertions observed `0664`/`0775` under `umask=0002`, plus a temporary-directory cleanup `EACCES` ([run](https://github.com/openclaw/openclaw/actions/runs/33232671223)).
- Fresh latest `main` at `6b5d9f7db976e5b3e2266a2511fc3f071d0d5632` reproduced the same three mode assertion failures under Testbox `umask=0002` ([run](https://github.com/openclaw/openclaw/actions/runs/33233839649)).
- Structured autoreview: clean on the rebased exact head.
- Independent review: 20,000 equivalence trials passed; no findings.
- Tooling LOC: `+42/-46` (net `-4`); tests: `+45`.

AI-assisted: yes. The final diff, behavior, and proof were independently reviewed.
