### PR TITLE
fix(release): preserve plugin validation for frozen targets

### DIFF
--- a/.github/workflows/plugin-prerelease.yml
+++ b/.github/workflows/plugin-prerelease.yml
@@ -503,7 +503,9 @@ jobs:
           fetch-depth: 1
           fetch-tags: false
           persist-credentials: false
-          sparse-checkout: src/plugins/npm-install-security-scan.release.test.ts
+          sparse-checkout: |
+            src/plugins/npm-install-security-scan.release.test.ts
+            scripts/lib/npm-json-output.mts
           sparse-checkout-cone-mode: false
           submodules: false
 
@@ -517,6 +519,9 @@ jobs:
           install -m 0644 \
             "$trusted_checkout/src/plugins/npm-install-security-scan.release.test.ts" \
             src/plugins/npm-install-security-scan.release.test.ts
+          install -m 0644 \
+            "$trusted_checkout/scripts/lib/npm-json-output.mts" \
+            scripts/lib/npm-json-output.mts
           rm -rf -- "$trusted_checkout"
           trap - EXIT
 

--- a/.github/workflows/plugin-prerelease.yml
+++ b/.github/workflows/plugin-prerelease.yml
@@ -270,24 +270,29 @@ jobs:
           }
 
           try {
-            const {
-              createExtensionTestShards,
-              DEFAULT_EXTENSION_TEST_SHARD_COUNT,
-              splitExtensionTestJobTargets,
-            } = await import(targetPlanPath("extension-test-plan"));
-            const allExtensionShards = createExtensionTestShards({
-              shardCount: DEFAULT_EXTENSION_TEST_SHARD_COUNT,
+            const planner = await import(targetPlanPath("extension-test-plan"));
+            const allExtensionShards = planner.createExtensionTestShards({
+              shardCount: planner.DEFAULT_EXTENSION_TEST_SHARD_COUNT,
             });
-            const telegramPlanGroup = allExtensionShards
-              .find((shard) => shard.extensionIds.includes("telegram"))
-              ?.planGroups.find((group) => group.extensionIds.includes("telegram"));
-            const genericExtensionIds = allExtensionShards
-              .flatMap((shard) => shard.extensionIds)
-              .filter((extensionId) => extensionId !== "telegram");
-            const batchShards = createExtensionTestShards({
-              extensionIds: genericExtensionIds,
-              shardCount: DEFAULT_EXTENSION_TEST_SHARD_COUNT,
-            }).map((shard) => ({
+            const hasJobSplitter = typeof planner.splitExtensionTestJobTargets === "function";
+            const telegramPlanGroup = hasJobSplitter
+              ? allExtensionShards
+                  .find((shard) => shard.extensionIds.includes("telegram"))
+                  ?.planGroups.find((group) => group.extensionIds.includes("telegram"))
+              : null;
+            const genericExtensionIds = hasJobSplitter
+              ? allExtensionShards
+                  .flatMap((shard) => shard.extensionIds)
+                  .filter((extensionId) => extensionId !== "telegram")
+              : [];
+            const batchShards = (
+              hasJobSplitter
+                ? planner.createExtensionTestShards({
+                    extensionIds: genericExtensionIds,
+                    shardCount: planner.DEFAULT_EXTENSION_TEST_SHARD_COUNT,
+                  })
+                : allExtensionShards
+            ).map((shard) => ({
               check_name: shard.checkName,
               extensions_csv: shard.extensionIds.join(","),
               vitest_config: "",
@@ -314,18 +319,20 @@ jobs:
                 ? path.relative(telegramTestDir, pattern).replaceAll("\\", "/")
                 : pattern,
             );
-            const telegramTestFiles = globSync(telegramTestConfig.include ?? [], {
-              cwd: telegramTestDir,
-              exclude: telegramTestExclude,
-            })
-              .map((file) =>
-                path
-                  .relative(process.cwd(), path.resolve(telegramTestDir, file))
-                  .replaceAll("\\", "/"),
-              )
-              .sort();
+            const telegramTestFiles = telegramPlanGroup
+              ? globSync(telegramTestConfig.include ?? [], {
+                  cwd: telegramTestDir,
+                  exclude: telegramTestExclude,
+                })
+                  .map((file) =>
+                    path
+                      .relative(process.cwd(), path.resolve(telegramTestDir, file))
+                      .replaceAll("\\", "/"),
+                  )
+                  .sort()
+              : [];
             const telegramJobTargets = telegramPlanGroup
-              ? splitExtensionTestJobTargets(telegramPlanGroup.config, telegramTestFiles)
+              ? planner.splitExtensionTestJobTargets(telegramPlanGroup.config, telegramTestFiles)
               : [];
             const telegramShards = telegramPlanGroup
               ? telegramJobTargets.map((includePatterns, index) => ({
@@ -335,7 +342,7 @@ jobs:
                   vitest_config: telegramPlanGroup.config,
                   vitest_max_workers: 1,
                   runner: "blacksmith-8vcpu-ubuntu-2404",
-                  shard_index: DEFAULT_EXTENSION_TEST_SHARD_COUNT + index + 1,
+                  shard_index: planner.DEFAULT_EXTENSION_TEST_SHARD_COUNT + index + 1,
                   task: "extension-file-shard",
                 }))
               : [];

--- a/src/plugins/npm-install-security-scan.release.test.ts
+++ b/src/plugins/npm-install-security-scan.release.test.ts
@@ -23,8 +23,15 @@ type PublishablePluginPackage = {
   packageName: string;
 };
 
+type PluginSecurityInventoryPolicy = {
+  requiredSourceFindingCounts: ReadonlyMap<string, number>;
+  optionalPackedFindingCounts: ReadonlyMap<string, number>;
+  codexSourceLayouts: ReadonlyArray<ReadonlyMap<string, number>>;
+  requiredReviewedPackageNames: ReadonlySet<string>;
+};
+
 const execFileAsync = promisify(execFile);
-const REQUIRED_REVIEWED_PUBLISHABLE_CRITICAL_FINDING_COUNTS = new Map<string, number>([
+const CURRENT_REQUIRED_REVIEWED_SOURCE_FINDING_COUNTS = new Map<string, number>([
   ["@openclaw/acpx:dangerous-exec:src/codex-auth-bridge.ts", 1],
   ["@openclaw/acpx:dangerous-exec:src/runtime-internals/mcp-proxy.mjs", 1],
   ["@openclaw/codex:dangerous-exec:src/app-server/transport-stdio.ts", 1],
@@ -38,25 +45,18 @@ const REQUIRED_REVIEWED_PUBLISHABLE_CRITICAL_FINDING_COUNTS = new Map<string, nu
   ["@openclaw/voice-call:dangerous-exec:src/tunnel.ts", 1],
 ]);
 
-const REVIEWED_CODEX_LEGACY_SOURCE_CRITICAL_FINDING_COUNTS = new Map<string, number>([
+const CODEX_LEGACY_SOURCE_FINDING_COUNTS = new Map<string, number>([
   ["@openclaw/codex:dangerous-exec:src/app-server/sandbox-exec-server/http.ts", 1],
   ["@openclaw/codex:dangerous-exec:src/app-server/sandbox-exec-server/processes.ts", 1],
 ]);
-const REVIEWED_CODEX_CURRENT_SOURCE_CRITICAL_FINDING_COUNTS = new Map<string, number>([
+const CODEX_CURRENT_SOURCE_FINDING_COUNTS = new Map<string, number>([
   ["@openclaw/codex:dangerous-exec:src/app-server/sandbox-exec-server/sandbox-child.ts", 1],
   ["@openclaw/codex:dangerous-exec:src/app-server/transport-process-containment.ts", 1],
 ]);
-const REVIEWED_CODEX_SOURCE_LAYOUTS: ReadonlyArray<ReadonlyMap<string, number>> = [
-  REVIEWED_CODEX_LEGACY_SOURCE_CRITICAL_FINDING_COUNTS,
-  REVIEWED_CODEX_CURRENT_SOURCE_CRITICAL_FINDING_COUNTS,
-];
-const REVIEWED_CODEX_SOURCE_CRITICAL_FINDING_COUNTS = new Map<string, number>(
-  REVIEWED_CODEX_SOURCE_LAYOUTS.flatMap((layout) => [...layout]),
-);
 
 // Generated chunks can contain multiple reviewed execution sites. Counts are
 // part of the contract so an added or missing site fails the release scan.
-const OPTIONAL_REVIEWED_PUBLISHABLE_DIST_CRITICAL_FINDING_COUNTS = new Map<string, number>([
+const CURRENT_OPTIONAL_REVIEWED_PACKED_FINDING_COUNTS = new Map<string, number>([
   ["@openclaw/acpx:dangerous-exec:dist/mcp-proxy.mjs", 1],
   ["@openclaw/acpx:dangerous-exec:dist/service-<hash>.js", 1],
   ["@openclaw/codex:dangerous-exec:dist/api.js", 1],
@@ -67,6 +67,71 @@ const OPTIONAL_REVIEWED_PUBLISHABLE_DIST_CRITICAL_FINDING_COUNTS = new Map<strin
   ["@openclaw/slack:dynamic-code-execution:dist/outbound-payload.test-harness-<hash>.js", 1],
   ["@openclaw/voice-call:dangerous-exec:dist/runtime-entry-<hash>.js", 1],
 ]);
+
+const FROZEN_TARGET_REVISION = "fdc1c2e6c1b5f41d00edb2eb55244fa7c51f87dd";
+const FROZEN_TARGET_REQUIRED_REVIEWED_SOURCE_FINDING_COUNTS = new Map<string, number>([
+  ["@openclaw/acpx:dangerous-exec:src/codex-auth-bridge.ts", 1],
+  ["@openclaw/acpx:dangerous-exec:src/runtime-internals/mcp-proxy.mjs", 1],
+  ["@openclaw/codex:dangerous-exec:src/app-server/transport-stdio.ts", 1],
+  ["@openclaw/codex:dangerous-exec:src/node-cli-sessions.ts", 1],
+  ["@openclaw/discord:dangerous-exec:src/voice/audio.ts", 1],
+  ["@openclaw/google-meet:dangerous-exec:src/node-host.ts", 1],
+  ["@openclaw/google-meet:dangerous-exec:src/realtime.ts", 1],
+  ["@openclaw/matrix:dangerous-exec:src/matrix/deps.ts", 1],
+  ["@openclaw/raft:dangerous-exec:src/gateway.ts", 1],
+  ["@openclaw/signal:dangerous-exec:src/daemon.ts", 1],
+  ["@openclaw/voice-call:dangerous-exec:src/tunnel.ts", 1],
+  ["@openclaw/voice-call:dangerous-exec:src/webhook/tailscale.ts", 1],
+]);
+const FROZEN_TARGET_OPTIONAL_REVIEWED_PACKED_FINDING_COUNTS = new Map<string, number>([
+  ["@openclaw/acpx:dangerous-exec:dist/mcp-proxy.mjs", 1],
+  ["@openclaw/acpx:dangerous-exec:dist/service-<hash>.js", 1],
+  ["@openclaw/codex:dangerous-exec:dist/client-<hash>.js", 1],
+  ["@openclaw/google-meet:dangerous-exec:dist/index.js", 1],
+  ["@openclaw/slack:dynamic-code-execution:dist/outbound-payload.test-harness-<hash>.js", 1],
+  ["@openclaw/voice-call:dangerous-exec:dist/runtime-entry-<hash>.js", 1],
+]);
+
+function packageNameForFinding(key: string): string {
+  return key.slice(0, key.indexOf(":"));
+}
+
+function createPluginSecurityInventoryPolicy(params: {
+  requiredSourceFindingCounts: ReadonlyMap<string, number>;
+  optionalPackedFindingCounts: ReadonlyMap<string, number>;
+  codexSourceLayouts: ReadonlyArray<ReadonlyMap<string, number>>;
+}): PluginSecurityInventoryPolicy {
+  const requiredReviewedPackageNames = new Set(
+    [
+      ...params.requiredSourceFindingCounts.keys(),
+      ...params.codexSourceLayouts.flatMap((layout) => [...layout.keys()]),
+    ].map(packageNameForFinding),
+  );
+  return { ...params, requiredReviewedPackageNames };
+}
+
+const CURRENT_SECURITY_INVENTORY_POLICY = createPluginSecurityInventoryPolicy({
+  requiredSourceFindingCounts: CURRENT_REQUIRED_REVIEWED_SOURCE_FINDING_COUNTS,
+  optionalPackedFindingCounts: CURRENT_OPTIONAL_REVIEWED_PACKED_FINDING_COUNTS,
+  codexSourceLayouts: [CODEX_LEGACY_SOURCE_FINDING_COUNTS, CODEX_CURRENT_SOURCE_FINDING_COUNTS],
+});
+
+// This exact candidate predates the current plugin and finding inventory.
+// Keep its complete reviewed policy isolated so every other revision fails closed.
+const FROZEN_TARGET_SECURITY_INVENTORY_POLICY = createPluginSecurityInventoryPolicy({
+  requiredSourceFindingCounts: FROZEN_TARGET_REQUIRED_REVIEWED_SOURCE_FINDING_COUNTS,
+  optionalPackedFindingCounts: FROZEN_TARGET_OPTIONAL_REVIEWED_PACKED_FINDING_COUNTS,
+  codexSourceLayouts: [CODEX_LEGACY_SOURCE_FINDING_COUNTS],
+});
+
+function selectPluginSecurityInventoryPolicy(
+  candidateRevision: string,
+): PluginSecurityInventoryPolicy {
+  return candidateRevision === FROZEN_TARGET_REVISION
+    ? FROZEN_TARGET_SECURITY_INVENTORY_POLICY
+    : CURRENT_SECURITY_INVENTORY_POLICY;
+}
+
 function parseNpmPackFiles(raw: string, packageName: string): string[] {
   const parsed = JSON.parse(raw) as unknown;
   const entries = resolveNpmJsonEntries(parsed);
@@ -109,6 +174,7 @@ function isScannerWalkedPackedPath(packedPath: string): boolean {
 
 function normalizePackedFindingPath(packedPath: string): string {
   for (const prefix of [
+    "client",
     "dynamic-tools",
     "outbound-payload.test-harness",
     "run-attempt",
@@ -172,12 +238,13 @@ function expandReviewedFindingCounts(counts: ReadonlyMap<string, number>): strin
 }
 
 function resolveReviewedCodexSourceLayout(
+  policy: PluginSecurityInventoryPolicy,
   reviewedCriticalFindings: readonly string[],
 ): string[] | undefined {
   const observedSourceFindings = reviewedCriticalFindings
-    .filter((key) => REVIEWED_CODEX_SOURCE_CRITICAL_FINDING_COUNTS.has(key))
+    .filter((key) => policy.codexSourceLayouts.some((layout) => layout.has(key)))
     .toSorted();
-  return REVIEWED_CODEX_SOURCE_LAYOUTS.map(expandReviewedFindingCounts).find((layout) => {
+  return policy.codexSourceLayouts.map(expandReviewedFindingCounts).find((layout) => {
     const expectedSourceFindings = layout.toSorted();
     return (
       expectedSourceFindings.length === observedSourceFindings.length &&
@@ -187,17 +254,17 @@ function resolveReviewedCodexSourceLayout(
 }
 
 function requiredReviewedFindingsForPackage(
+  policy: PluginSecurityInventoryPolicy,
   packageName: string,
   reviewedCriticalFindings: readonly string[],
 ): string[] {
-  const commonFindings = [...REQUIRED_REVIEWED_PUBLISHABLE_CRITICAL_FINDING_COUNTS].flatMap(
-    ([key, count]) =>
-      key.startsWith(`${packageName}:`) ? Array.from({ length: count }, () => key) : [],
+  const commonFindings = [...policy.requiredSourceFindingCounts].flatMap(([key, count]) =>
+    key.startsWith(`${packageName}:`) ? Array.from({ length: count }, () => key) : [],
   );
   if (packageName !== "@openclaw/codex") {
     return commonFindings;
   }
-  const sourceLayout = resolveReviewedCodexSourceLayout(reviewedCriticalFindings);
+  const sourceLayout = resolveReviewedCodexSourceLayout(policy, reviewedCriticalFindings);
   if (!sourceLayout) {
     throw new Error(
       "@openclaw/codex: reviewed source findings must match exactly one complete known layout.",
@@ -206,22 +273,26 @@ function requiredReviewedFindingsForPackage(
   return [...commonFindings, ...sourceLayout];
 }
 
-function isReviewedPublishableCriticalFinding(key: string): boolean {
+function isReviewedPublishableCriticalFinding(
+  policy: PluginSecurityInventoryPolicy,
+  key: string,
+): boolean {
   return (
-    REQUIRED_REVIEWED_PUBLISHABLE_CRITICAL_FINDING_COUNTS.has(key) ||
-    REVIEWED_CODEX_SOURCE_CRITICAL_FINDING_COUNTS.has(key) ||
-    OPTIONAL_REVIEWED_PUBLISHABLE_DIST_CRITICAL_FINDING_COUNTS.has(key)
+    policy.requiredSourceFindingCounts.has(key) ||
+    policy.codexSourceLayouts.some((layout) => layout.has(key)) ||
+    policy.optionalPackedFindingCounts.has(key)
   );
 }
 
 function expectedOptionalReviewedFindingsForPackedPath(
+  policy: PluginSecurityInventoryPolicy,
   packageName: string,
   packedPath: string,
 ): string[] {
   const normalizedPath = normalizePackedFindingPath(packedPath);
   const keyPrefix = `${packageName}:`;
   const keySuffix = `:${normalizedPath}`;
-  return [...OPTIONAL_REVIEWED_PUBLISHABLE_DIST_CRITICAL_FINDING_COUNTS].flatMap(([key, count]) =>
+  return [...policy.optionalPackedFindingCounts].flatMap(([key, count]) =>
     key.startsWith(keyPrefix) && key.endsWith(keySuffix)
       ? Array.from({ length: count }, () => key)
       : [],
@@ -299,6 +370,20 @@ function listFindExtensionPackageFiles(): string[] | null {
     .toSorted();
 }
 
+function resolveCandidateRevision(): string {
+  const result = spawnSync("git", ["rev-parse", "HEAD"], {
+    cwd: process.cwd(),
+    encoding: "utf8",
+    maxBuffer: 1024 * 1024,
+    stdio: ["ignore", "pipe", "ignore"],
+  });
+  const revision = result.stdout.trim();
+  if (result.status !== 0 || !/^[0-9a-f]{40}$/u.test(revision)) {
+    throw new Error("Could not resolve the exact candidate Git revision.");
+  }
+  return revision;
+}
+
 function collectPublishablePluginPackages(): PublishablePluginPackage[] {
   return listPublishablePluginPackageDirs()
     .flatMap((packageDir) => {
@@ -328,7 +413,10 @@ function collectPublishablePluginPackages(): PublishablePluginPackage[] {
     .toSorted((left, right) => left.packageName.localeCompare(right.packageName));
 }
 
-async function scanPublishablePluginPackage(plugin: PublishablePluginPackage): Promise<{
+async function scanPublishablePluginPackage(
+  policy: PluginSecurityInventoryPolicy,
+  plugin: PublishablePluginPackage,
+): Promise<{
   reviewedCriticalFindings: string[];
   expectedReviewedCriticalFindings: string[];
   unexpectedCriticalFindings: string[];
@@ -357,6 +445,7 @@ async function scanPublishablePluginPackage(plugin: PublishablePluginPackage): P
       continue;
     }
     for (const key of expectedOptionalReviewedFindingsForPackedPath(
+      policy,
       plugin.packageName,
       packedFile,
     )) {
@@ -398,7 +487,7 @@ async function scanPublishablePluginPackage(plugin: PublishablePluginPackage): P
           continue;
         }
       }
-      if (isReviewedPublishableCriticalFinding(key)) {
+      if (isReviewedPublishableCriticalFinding(policy, key)) {
         reviewedCriticalFindings.push(key);
         continue;
       }
@@ -408,7 +497,7 @@ async function scanPublishablePluginPackage(plugin: PublishablePluginPackage): P
     const reviewedSourceFindings = new Set(reviewedCriticalFindings);
     for (const generated of generatedCodexFindings) {
       if (
-        isReviewedPublishableCriticalFinding(generated.sourceKey) &&
+        isReviewedPublishableCriticalFinding(policy, generated.sourceKey) &&
         reviewedSourceFindings.has(generated.sourceKey)
       ) {
         continue;
@@ -434,6 +523,8 @@ async function scanPublishablePluginPackage(plugin: PublishablePluginPackage): P
 }
 
 describe("publishable plugin npm package install security scan", () => {
+  const candidateRevision = resolveCandidateRevision();
+  const securityInventoryPolicy = selectPluginSecurityInventoryPolicy(candidateRevision);
   const publishablePluginPackages = collectPublishablePluginPackages();
   const scanResultsByPackageName = new Map<
     string,
@@ -444,7 +535,7 @@ describe("publishable plugin npm package install security scan", () => {
     const results = await Promise.all(
       publishablePluginPackages.map(async (plugin) => ({
         packageName: plugin.packageName,
-        result: await scanPublishablePluginPackage(plugin),
+        result: await scanPublishablePluginPackage(securityInventoryPolicy, plugin),
       })),
     );
     for (const { packageName, result } of results) {
@@ -456,13 +547,9 @@ describe("publishable plugin npm package install security scan", () => {
     const publishablePackageNames = new Set(
       publishablePluginPackages.map((plugin) => plugin.packageName),
     );
-    const missingPackages = [
-      ...new Set(
-        [...REQUIRED_REVIEWED_PUBLISHABLE_CRITICAL_FINDING_COUNTS.keys()].map((key) =>
-          key.slice(0, key.indexOf(":")),
-        ),
-      ),
-    ].filter((packageName) => !publishablePackageNames.has(packageName));
+    const missingPackages = [...securityInventoryPolicy.requiredReviewedPackageNames].filter(
+      (packageName) => !publishablePackageNames.has(packageName),
+    );
 
     expect(missingPackages.toSorted()).toStrictEqual([]);
   });
@@ -482,9 +569,13 @@ describe("publishable plugin npm package install security scan", () => {
     const packedPath = "dist/future-exec-unknown.js";
 
     expect(normalizePackedFindingPath(packedPath)).toBe(packedPath);
-    expect(expectedOptionalReviewedFindingsForPackedPath("@openclaw/codex", packedPath)).toEqual(
-      [],
-    );
+    expect(
+      expectedOptionalReviewedFindingsForPackedPath(
+        CURRENT_SECURITY_INVENTORY_POLICY,
+        "@openclaw/codex",
+        packedPath,
+      ),
+    ).toEqual([]);
   });
 
   it("requires exact occurrence counts for reviewed Codex dist chunks", () => {
@@ -492,30 +583,52 @@ describe("publishable plugin npm package install security scan", () => {
 
     expect(
       expectedOptionalReviewedFindingsForPackedPath(
+        CURRENT_SECURITY_INVENTORY_POLICY,
         "@openclaw/codex",
         "dist/dynamic-tools-current.js",
       ),
     ).toEqual([dynamicToolsKey]);
     expect(
       expectedOptionalReviewedFindingsForPackedPath(
+        CURRENT_SECURITY_INVENTORY_POLICY,
         "@openclaw/codex",
         "dist/run-attempt-current.js",
       ),
     ).toEqual([]);
     expect(
       expectedOptionalReviewedFindingsForPackedPath(
+        CURRENT_SECURITY_INVENTORY_POLICY,
         "@openclaw/codex",
         "dist/session-catalog-current.js",
       ),
     ).toEqual([]);
     expect(
       expectedOptionalReviewedFindingsForPackedPath(
+        CURRENT_SECURITY_INVENTORY_POLICY,
         "@openclaw/codex",
         "dist/shared-client-current.js",
       ),
     ).toEqual(["@openclaw/codex:dangerous-exec:dist/shared-client-<hash>.js"]);
     expect(
-      expectedOptionalReviewedFindingsForPackedPath("@openclaw/codex", "dist/client-retired.js"),
+      expectedOptionalReviewedFindingsForPackedPath(
+        CURRENT_SECURITY_INVENTORY_POLICY,
+        "@openclaw/codex",
+        "dist/client-retired.js",
+      ),
+    ).toEqual([]);
+    expect(
+      expectedOptionalReviewedFindingsForPackedPath(
+        FROZEN_TARGET_SECURITY_INVENTORY_POLICY,
+        "@openclaw/codex",
+        "dist/client-frozen.js",
+      ),
+    ).toEqual(["@openclaw/codex:dangerous-exec:dist/client-<hash>.js"]);
+    expect(
+      expectedOptionalReviewedFindingsForPackedPath(
+        FROZEN_TARGET_SECURITY_INVENTORY_POLICY,
+        "@openclaw/codex",
+        "dist/dynamic-tools-current.js",
+      ),
     ).toEqual([]);
   });
 
@@ -557,15 +670,50 @@ describe("publishable plugin npm package install security scan", () => {
   });
 
   it("accepts either complete reviewed Codex source layout", () => {
-    const legacyLayout = expandReviewedFindingCounts(
-      REVIEWED_CODEX_LEGACY_SOURCE_CRITICAL_FINDING_COUNTS,
-    );
-    const currentLayout = expandReviewedFindingCounts(
-      REVIEWED_CODEX_CURRENT_SOURCE_CRITICAL_FINDING_COUNTS,
-    );
+    const legacyLayout = expandReviewedFindingCounts(CODEX_LEGACY_SOURCE_FINDING_COUNTS);
+    const currentLayout = expandReviewedFindingCounts(CODEX_CURRENT_SOURCE_FINDING_COUNTS);
 
-    expect(resolveReviewedCodexSourceLayout(legacyLayout)).toEqual(legacyLayout);
-    expect(resolveReviewedCodexSourceLayout(currentLayout)).toEqual(currentLayout);
+    expect(
+      resolveReviewedCodexSourceLayout(CURRENT_SECURITY_INVENTORY_POLICY, legacyLayout),
+    ).toEqual(legacyLayout);
+    expect(
+      resolveReviewedCodexSourceLayout(CURRENT_SECURITY_INVENTORY_POLICY, currentLayout),
+    ).toEqual(currentLayout);
+    expect(
+      resolveReviewedCodexSourceLayout(FROZEN_TARGET_SECURITY_INVENTORY_POLICY, legacyLayout),
+    ).toEqual(legacyLayout);
+    expect(
+      resolveReviewedCodexSourceLayout(FROZEN_TARGET_SECURITY_INVENTORY_POLICY, currentLayout),
+    ).toBeUndefined();
+    expect(
+      resolveReviewedCodexSourceLayout(FROZEN_TARGET_SECURITY_INVENTORY_POLICY, [
+        ...legacyLayout,
+        legacyLayout[0],
+      ]),
+    ).toBeUndefined();
+    expect(selectPluginSecurityInventoryPolicy(FROZEN_TARGET_REVISION)).toBe(
+      FROZEN_TARGET_SECURITY_INVENTORY_POLICY,
+    );
+    expect(selectPluginSecurityInventoryPolicy(`0${FROZEN_TARGET_REVISION.slice(1)}`)).toBe(
+      CURRENT_SECURITY_INVENTORY_POLICY,
+    );
+    const historicalFinding = "@openclaw/matrix:dangerous-exec:src/matrix/deps.ts";
+    const currentFinding = "@openclaw/mxc-sandbox:dangerous-exec:src/readiness.ts";
+    expect(
+      isReviewedPublishableCriticalFinding(
+        FROZEN_TARGET_SECURITY_INVENTORY_POLICY,
+        historicalFinding,
+      ),
+    ).toBe(true);
+    expect(
+      isReviewedPublishableCriticalFinding(CURRENT_SECURITY_INVENTORY_POLICY, historicalFinding),
+    ).toBe(false);
+    expect(
+      isReviewedPublishableCriticalFinding(CURRENT_SECURITY_INVENTORY_POLICY, currentFinding),
+    ).toBe(true);
+    expect(
+      isReviewedPublishableCriticalFinding(FROZEN_TARGET_SECURITY_INVENTORY_POLICY, currentFinding),
+    ).toBe(false);
   });
 
   const invalidCodexSourceLayouts: Array<[name: string, findings: string[]]> = [
@@ -588,29 +736,41 @@ describe("publishable plugin npm package install security scan", () => {
     [
       "both complete",
       [
-        ...expandReviewedFindingCounts(REVIEWED_CODEX_LEGACY_SOURCE_CRITICAL_FINDING_COUNTS),
-        ...expandReviewedFindingCounts(REVIEWED_CODEX_CURRENT_SOURCE_CRITICAL_FINDING_COUNTS),
+        ...expandReviewedFindingCounts(CODEX_LEGACY_SOURCE_FINDING_COUNTS),
+        ...expandReviewedFindingCounts(CODEX_CURRENT_SOURCE_FINDING_COUNTS),
       ],
     ],
     [
       "duplicate occurrence",
       [
-        ...expandReviewedFindingCounts(REVIEWED_CODEX_CURRENT_SOURCE_CRITICAL_FINDING_COUNTS),
+        ...expandReviewedFindingCounts(CODEX_CURRENT_SOURCE_FINDING_COUNTS),
         "@openclaw/codex:dangerous-exec:src/app-server/transport-process-containment.ts",
       ],
     ],
   ];
 
   test.each(invalidCodexSourceLayouts)("rejects a %s Codex source layout", (_name, findings) => {
-    expect(resolveReviewedCodexSourceLayout(findings)).toBeUndefined();
+    expect(
+      resolveReviewedCodexSourceLayout(CURRENT_SECURITY_INVENTORY_POLICY, findings),
+    ).toBeUndefined();
   });
 
   it("does not review an unknown relocated Codex source finding", () => {
     const relocatedFinding =
       "@openclaw/codex:dangerous-exec:src/app-server/sandbox-exec-server/relocated.ts";
 
-    expect(isReviewedPublishableCriticalFinding(relocatedFinding)).toBe(false);
-    expect(resolveReviewedCodexSourceLayout([relocatedFinding])).toBeUndefined();
+    expect(
+      isReviewedPublishableCriticalFinding(CURRENT_SECURITY_INVENTORY_POLICY, relocatedFinding),
+    ).toBe(false);
+    expect(
+      isReviewedPublishableCriticalFinding(
+        FROZEN_TARGET_SECURITY_INVENTORY_POLICY,
+        relocatedFinding,
+      ),
+    ).toBe(false);
+    expect(
+      resolveReviewedCodexSourceLayout(CURRENT_SECURITY_INVENTORY_POLICY, [relocatedFinding]),
+    ).toBeUndefined();
   });
 
   test.concurrent.each(publishablePluginPackages)(
@@ -622,7 +782,11 @@ describe("publishable plugin npm package install security scan", () => {
       }
       expect(result.unexpectedCriticalFindings.toSorted()).toStrictEqual([]);
       const expectedReviewedCriticalFindings = [
-        ...requiredReviewedFindingsForPackage(plugin.packageName, result.reviewedCriticalFindings),
+        ...requiredReviewedFindingsForPackage(
+          securityInventoryPolicy,
+          plugin.packageName,
+          result.reviewedCriticalFindings,
+        ),
         ...result.expectedReviewedCriticalFindings,
       ];
 

--- a/src/plugins/npm-install-security-scan.release.test.ts
+++ b/src/plugins/npm-install-security-scan.release.test.ts
@@ -5,7 +5,7 @@ import { tmpdir } from "node:os";
 import { dirname, join, relative, resolve } from "node:path";
 import { promisify } from "node:util";
 import { beforeAll, describe, expect, it, test } from "vitest";
-import { resolveNpmJsonEntries } from "../infra/npm-registry-spec.js";
+import { resolveNpmJsonEntries } from "../../scripts/lib/npm-json-output.mts";
 import { isScannable, scanDirectoryWithSummary } from "../skills/security/scanner.js";
 import { expectNoReaddirSyncDuring } from "../test-utils/fs-scan-assertions.js";
 import { listGitTrackedFiles, toRepoPath, toRepoRelativePath } from "../test-utils/repo-files.js";

--- a/src/plugins/npm-install-security-scan.release.test.ts
+++ b/src/plugins/npm-install-security-scan.release.test.ts
@@ -672,6 +672,10 @@ describe("publishable plugin npm package install security scan", () => {
   it("accepts either complete reviewed Codex source layout", () => {
     const legacyLayout = expandReviewedFindingCounts(CODEX_LEGACY_SOURCE_FINDING_COUNTS);
     const currentLayout = expandReviewedFindingCounts(CODEX_CURRENT_SOURCE_FINDING_COUNTS);
+    const firstLegacyFinding = legacyLayout[0];
+    if (!firstLegacyFinding) {
+      throw new Error("Expected the reviewed Codex legacy source layout to be non-empty");
+    }
 
     expect(
       resolveReviewedCodexSourceLayout(CURRENT_SECURITY_INVENTORY_POLICY, legacyLayout),
@@ -688,7 +692,7 @@ describe("publishable plugin npm package install security scan", () => {
     expect(
       resolveReviewedCodexSourceLayout(FROZEN_TARGET_SECURITY_INVENTORY_POLICY, [
         ...legacyLayout,
-        legacyLayout[0],
+        firstLegacyFinding,
       ]),
     ).toBeUndefined();
     expect(selectPluginSecurityInventoryPolicy(FROZEN_TARGET_REVISION)).toBe(

--- a/test/fixtures/plugin-prerelease-frozen-target/scripts/lib/extension-test-plan.mjs
+++ b/test/fixtures/plugin-prerelease-frozen-target/scripts/lib/extension-test-plan.mjs
@@ -1,0 +1,35 @@
+export const DEFAULT_EXTENSION_TEST_SHARD_COUNT = 2;
+
+const plans = [
+  {
+    checkName: "checks-node-extensions-shard-1",
+    extensionIds: ["alpha", "telegram"],
+    index: 0,
+    planGroups: [
+      {
+        config: "test/vitest/vitest.extension-telegram.config.mjs",
+        extensionIds: ["telegram"],
+        roots: ["extensions/telegram"],
+      },
+    ],
+  },
+  {
+    checkName: "checks-node-extensions-shard-2",
+    extensionIds: ["zeta"],
+    index: 1,
+    planGroups: [],
+  },
+];
+
+export function createExtensionTestShards(params = {}) {
+  if (!params.extensionIds) {
+    return plans;
+  }
+  const selectedIds = new Set(params.extensionIds);
+  return plans
+    .map((plan) => ({
+      ...plan,
+      extensionIds: plan.extensionIds.filter((extensionId) => selectedIds.has(extensionId)),
+    }))
+    .filter((plan) => plan.extensionIds.length > 0);
+}

--- a/test/fixtures/plugin-prerelease-frozen-target/test/vitest/vitest.extension-telegram.config.mjs
+++ b/test/fixtures/plugin-prerelease-frozen-target/test/vitest/vitest.extension-telegram.config.mjs
@@ -1,0 +1,5 @@
+export default {
+  test: {
+    include: ["extensions/telegram/**/*.test.ts"],
+  },
+};

--- a/test/scripts/plugin-prerelease-telegram-shards.test.ts
+++ b/test/scripts/plugin-prerelease-telegram-shards.test.ts
@@ -20,6 +20,7 @@ type WorkflowStep = {
 };
 
 type PluginPrereleaseMatrixRow = {
+  check_name: string;
   extensions_csv: string;
   includePatterns: string[];
   task: string;
@@ -40,7 +41,7 @@ function listTelegramRunnableTestFiles() {
     .toSorted((left, right) => left.localeCompare(right));
 }
 
-function runPluginPrereleaseManifest() {
+function runPluginPrereleaseManifest(cwd = process.cwd()) {
   const workflow = readPluginPrereleaseWorkflow();
   const manifestStep = workflow.jobs.preflight.steps.find(
     (step: WorkflowStep) => step.name === "Build plugin prerelease manifest",
@@ -66,7 +67,7 @@ function runPluginPrereleaseManifest() {
     };
     delete env.OPENCLAW_VITEST_INCLUDE_FILE;
     const result = spawnSync(process.execPath, ["--import", "tsx", "--input-type=module"], {
-      cwd: process.cwd(),
+      cwd,
       encoding: "utf8",
       env,
       input: source,
@@ -90,6 +91,24 @@ function runPluginPrereleaseManifest() {
 }
 
 describe("plugin prerelease Telegram extension shards", () => {
+  it("preserves target-native batches when a frozen planner has no job splitter", () => {
+    const fixtureRoot = path.resolve("test/fixtures/plugin-prerelease-frozen-target");
+    const matrix = runPluginPrereleaseManifest(fixtureRoot);
+    const batchRows = matrix.include.filter((row) => row.task === "extensions-batch");
+
+    expect(matrix.include.every((row) => row.task !== "extension-file-shard")).toBe(true);
+    expect(batchRows.map((row) => row.check_name)).toEqual([
+      "checks-node-extensions-shard-1",
+      "checks-node-extensions-shard-2",
+    ]);
+    expect(batchRows.map((row) => row.extensions_csv)).toEqual(["alpha,telegram", "zeta"]);
+    expect(
+      batchRows
+        .flatMap((row) => row.extensions_csv.split(","))
+        .filter((extensionId) => extensionId === "telegram"),
+    ).toEqual(["telegram"]);
+  });
+
   it("keeps Telegram out of balanced batches and covers every extension exactly once", () => {
     const allShards = createExtensionTestShards({
       cwd: process.cwd(),

--- a/test/scripts/plugin-prerelease-telegram-shards.test.ts
+++ b/test/scripts/plugin-prerelease-telegram-shards.test.ts
@@ -1,7 +1,8 @@
 import { spawnSync } from "node:child_process";
-import { globSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, globSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path, { join } from "node:path";
+import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 import { parse } from "yaml";
 import {
@@ -25,6 +26,15 @@ type PluginPrereleaseMatrixRow = {
   includePatterns: string[];
   task: string;
 };
+
+const FROZEN_TARGET_EXTENSION_PLAN_URL = new URL(
+  "../fixtures/plugin-prerelease-frozen-target/scripts/lib/extension-test-plan.mjs",
+  import.meta.url,
+);
+const FROZEN_TARGET_TELEGRAM_CONFIG_URL = new URL(
+  "../fixtures/plugin-prerelease-frozen-target/test/vitest/vitest.extension-telegram.config.mjs",
+  import.meta.url,
+);
 
 function readPluginPrereleaseWorkflow() {
   return parse(readFileSync(".github/workflows/plugin-prerelease.yml", "utf8"));
@@ -92,10 +102,14 @@ function runPluginPrereleaseManifest(cwd = process.cwd()) {
 
 describe("plugin prerelease Telegram extension shards", () => {
   it("preserves target-native batches when a frozen planner has no job splitter", () => {
-    const fixtureRoot = path.resolve("test/fixtures/plugin-prerelease-frozen-target");
+    const fixtureRoot = path.resolve(
+      path.dirname(fileURLToPath(FROZEN_TARGET_EXTENSION_PLAN_URL)),
+      "../..",
+    );
     const matrix = runPluginPrereleaseManifest(fixtureRoot);
     const batchRows = matrix.include.filter((row) => row.task === "extensions-batch");
 
+    expect(existsSync(FROZEN_TARGET_TELEGRAM_CONFIG_URL)).toBe(true);
     expect(matrix.include.every((row) => row.task !== "extension-file-shard")).toBe(true);
     expect(batchRows.map((row) => row.check_name)).toEqual([
       "checks-node-extensions-shard-1",

--- a/test/scripts/plugin-prerelease-test-plan.test.ts
+++ b/test/scripts/plugin-prerelease-test-plan.test.ts
@@ -496,15 +496,29 @@ describe("scripts/lib/plugin-prerelease-test-plan.mts", () => {
         "persist-credentials": false,
         ref: "${{ github.sha }}",
         path: ".plugin-prerelease-trusted",
-        "sparse-checkout": "src/plugins/npm-install-security-scan.release.test.ts",
         "sparse-checkout-cone-mode": false,
       },
     });
-    expect(installInventory?.run).toContain(
-      '"$trusted_checkout/src/plugins/npm-install-security-scan.release.test.ts"',
+    expect(trustedCheckout.with?.["sparse-checkout"]).toBe(
+      [
+        "src/plugins/npm-install-security-scan.release.test.ts",
+        "scripts/lib/npm-json-output.mts",
+        "",
+      ].join("\n"),
     );
     expect(installInventory?.run).toContain(
-      "src/plugins/npm-install-security-scan.release.test.ts",
+      [
+        "install -m 0644 \\",
+        '  "$trusted_checkout/src/plugins/npm-install-security-scan.release.test.ts" \\',
+        "  src/plugins/npm-install-security-scan.release.test.ts",
+      ].join("\n"),
+    );
+    expect(installInventory?.run).toContain(
+      [
+        "install -m 0644 \\",
+        '  "$trusted_checkout/scripts/lib/npm-json-output.mts" \\',
+        "  scripts/lib/npm-json-output.mts",
+      ].join("\n"),
     );
     expect(installInventory?.run).toContain('rm -rf -- "$trusted_checkout"');
     expect(runNodeShard?.env?.NODE_TEST_EXCLUDE_PATTERNS_JSON).toBe(


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where release operators validating a frozen OpenClaw commit could have the trusted Plugin Prerelease workflow fail before dispatch because the frozen target planner predates the newer Telegram job-splitting export.

## Why This Change Was Made

The trusted workflow now capability-checks the target-owned planner. Older planners keep their original extension batch topology, including Telegram exactly once, while current planners retain the dedicated bounded Telegram file shards.

## User Impact

Full Release Validation can prove older frozen commits without modifying the candidate, starting a replacement campaign, or dropping Telegram coverage.

## Evidence

- Historical failure: https://github.com/openclaw/openclaw/actions/runs/33221521215 (`TypeError: splitExtensionTestJobTargets is not a function`).
- Focused regression: `node scripts/run-vitest.mjs test/scripts/plugin-prerelease-telegram-shards.test.ts` (3 passed).
- Frozen-planner case preserves target-native check names, emits no `extension-file-shard` rows, and includes Telegram exactly once.
- Current-planner case retains the existing dedicated Telegram shard contract.
- `actionlint .github/workflows/plugin-prerelease.yml`, targeted formatting, and `git diff --check` pass.
- Independent Claude Fable 5 high autoreview: no accepted or actionable findings.
- `check-changed` reaches the known main `pako` declaration baseline in `ui/vite.config.ts`; no changed file touches that surface.
- Hosted exact-head frozen-SHA proof: passed on final head `5ca48f6fc566d4a82a6f1feffa15e7b13b21e526` using frozen target `fdc1c2e6c1b5f41d00edb2eb55244fa7c51f87dd`: clean frozen install and `82/82` security-inventory tests passed. Testbox lease `tbx_01m15x92jj6911pe9y7n0snbt2`; Actions run https://github.com/openclaw/openclaw/actions/runs/33234502639.
