### PR TITLE
test(setup): give recommendation fixtures a canonical agent roster

### DIFF
--- a/src/system-agent/inference-route.test.ts
+++ b/src/system-agent/inference-route.test.ts
@@ -42,18 +42,32 @@ afterEach(() => {
 });
 
 describe("resolveSystemAgentConfiguredRouteFromConfig", () => {
-  it("admits the reserved execution agent for a dev-shaped roster", async () => {
-    const route = await resolveSystemAgentConfiguredRouteFromConfig(devConfig());
+  it.each([
+    { label: "main", agentIds: ["main"], owner: "main" },
+    { label: "non-main", agentIds: ["dev"], owner: "dev" },
+    { label: "multi-agent", agentIds: ["main", "dev"], owner: "dev" },
+  ])(
+    "admits the route owner and reserved agent for a $label roster",
+    async ({ agentIds, owner }) => {
+      const config = devConfig();
+      config.agents = {
+        ...config.agents,
+        entries: Object.fromEntries(agentIds.map((id) => [id, {}])),
+      };
+      const route = await resolveSystemAgentConfiguredRouteFromConfig(config, owner);
 
-    expect(route).not.toBeNull();
-    expect(() =>
-      resolveRunWorkspaceDir({
-        workspaceDir: "/tmp/x",
-        agentId: SYSTEM_AGENT_ID,
-        config: route!.runConfig,
-      }),
-    ).not.toThrow();
-  });
+      expect(route?.agentId).toBe(owner);
+      for (const agentId of [owner, SYSTEM_AGENT_ID]) {
+        expect(
+          resolveRunWorkspaceDir({
+            workspaceDir: "/tmp/x",
+            agentId,
+            config: route!.runConfig,
+          }).agentId,
+        ).toBe(agentId);
+      }
+    },
+  );
 
   it("keeps implicit harness selection fallible while forcing explicit policy", async () => {
     const supports = vi.fn((ctx: { modelProvider?: { requestTransportOverrides?: string } }) =>

--- a/src/system-agent/setup-app-recommendations.live.test.ts
+++ b/src/system-agent/setup-app-recommendations.live.test.ts
@@ -1,8 +1,10 @@
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { describe, expect, it } from "vitest";
+import { resolveRunWorkspaceDir } from "../agents/workspace-run.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { redactToolPayloadText } from "../logging/redact.js";
 import type { RuntimeEnv } from "../runtime.js";
+import { resolveSystemAgentConfiguredRouteFromConfig } from "./inference-route.js";
 import { getSetupAppRecommendations } from "./setup-app-recommendations.js";
 import {
   completeSetupInferenceConfig,
@@ -38,6 +40,8 @@ const config: OpenClawConfig = {
     },
   },
   agents: {
+    // Config-injected inference bypasses load-time roster materialization.
+    entries: { main: {} },
     defaults: {
       model: { primary: `openai/${modelId}` },
       models: {
@@ -55,6 +59,20 @@ const runtime: RuntimeEnv = {
   error: () => undefined,
   exit: () => undefined,
 };
+
+describe("setup app recommendations fixture", () => {
+  it("admits the selected inference owner without provider credentials", async () => {
+    const route = await resolveSystemAgentConfiguredRouteFromConfig(config);
+    expect(route).not.toBeNull();
+    expect(
+      resolveRunWorkspaceDir({
+        workspaceDir: undefined,
+        agentId: route!.agentId,
+        config: route!.runConfig,
+      }).agentId,
+    ).toBe("main");
+  });
+});
 
 describeLive("setup app recommendations live", () => {
   it("uses real ClawHub search and OpenAI while rejecting substring traps", async () => {


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where the setup recommendation live fixture supplies a model-only raw configuration without the canonical agent roster, so the probe fails at owner admission before testing recommendation quality.

Related: #131780 (staged setup configurations without runtime rosters). This test-only repair does not claim to resolve that issue's separate production adapter concern.

## Why This Change Was Made

Give the raw live fixture its explicit `main` roster entry and exercise that ownership before inference. Extend the existing route table for main, a sole named agent, and an explicit owner in a multi-agent roster, while verifying the reserved system agent is added without discarding the authored roster. Runtime admission and config migration stay unchanged.

## User Impact

No production change. The setup live test can reach real inference and ClawHub recommendation traps instead of stopping at an invalid fixture. Experience replay and its diagnostics are explicitly excluded.

## Evidence

Original-source live proof completed both cases in 72.61 seconds with the default public Luna model, actual inference and ClawHub calls, fresh HOME, and substring false-positive traps. Earlier focused sibling/route proof and complete changed gates passed on that frozen source. Those receipts are not relabeled as new-main proof.

Current-main base `383a293b32d97254014437430b62aaf406bc11ac`, head `53ba43e800d2bec5e1033ded1eb2d85d3b7eb986`, tree `4707fef51f0a02ac7d265809a640d4d0e65a073e`: all 44 route/legacy-roster/workspace sibling tests passed. The live file with live execution disabled passed its offline fixture test and skipped its one live case. Full changed-file gates passed, including all three unused-export scans, core test types and lint. Fresh restricted Codex P0 review of the complete nonempty delta found no findings with the unchanged secret scan and isolation. Its first review engine invocation failed without a verdict; one bounded retry completed.

```sh
OPENCLAW_VITEST_MAX_WORKERS=2 node scripts/run-vitest.mjs src/system-agent/inference-route.test.ts src/config/legacy.roster.test.ts src/agents/workspace-run.test.ts
env -u OPENCLAW_LIVE_TEST -u LIVE OPENCLAW_VITEST_MAX_WORKERS=2 node scripts/run-vitest.mjs run --config test/vitest/vitest.live.config.ts src/system-agent/setup-app-recommendations.live.test.ts
OPENCLAW_VITEST_MAX_WORKERS=2 node scripts/check-changed.mjs --base 383a293b32d97254014437430b62aaf406bc11ac -- src/system-agent/inference-route.test.ts src/system-agent/setup-app-recommendations.live.test.ts
```

Source evidence: `setup-app-recommendations.ts` invokes `completeSetupInference`; `setup-inference-verify.ts` and `setup-inference-plan.ts` preserve the selected route; `inference-route.ts` carries the authored roster into the system-agent projection. `src/agents/workspace-run.ts` requires the canonical roster and selected owner. The persisted-config producer `legacy.roster.ts` materializes implicit main where appropriate; raw tests bypass that producer and must provide valid runtime input.

Test audit: protect real owner admission before an expensive live call and preserve selection across roster shapes; extend the existing fixture/table, with no new production seam. Production delta **0**; tests **+43/-11** across exactly two files. No experience-replay, config, schema, dependency, or changelog changes.
