### PR TITLE
test(ui): avoid repeated browser probes and feedback waits

### DIFF
--- a/test/vitest/vitest.ui-e2e.global-setup.ts
+++ b/test/vitest/vitest.ui-e2e.global-setup.ts
@@ -10,13 +10,16 @@ import { createTempDirTracker } from "../helpers/temp-dir.ts";
 
 declare module "vitest" {
   export interface ProvidedContext {
+    controlUiE2eChromium: { executablePath: string; available: boolean };
     controlUiE2eServerBaseUrl: string | null;
   }
 }
 
 export default async function setup(project: TestProject) {
   const executablePath = resolvePlaywrightChromiumExecutablePath(chromium.executablePath());
-  if (!canRunPlaywrightChromium(executablePath)) {
+  const available = canRunPlaywrightChromium(executablePath);
+  project.provide("controlUiE2eChromium", { executablePath, available });
+  if (!available) {
     project.provide("controlUiE2eServerBaseUrl", null);
     // No-op teardown keeps both paths value-returning for Vitest's setup contract.
     return () => {};

--- a/ui/src/e2e/chat-flow.clipboard.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.clipboard.e2e.test.ts
@@ -112,6 +112,7 @@ suite.define(() => {
           : {}),
       });
       const page = await context.newPage();
+      await page.clock.install();
       await installDeniedClipboard(page);
       const text = "Deployment update is ready for review.";
       const gateway = await installMockGateway(page, {
@@ -202,6 +203,7 @@ suite.define(() => {
         } else {
           await expect.poll(() => hasAccessibleName("Copied!")).toBe(true);
           expect(await button.isDisabled()).toBe(false);
+          await page.clock.fastForward(1_500);
           await expect
             .poll(() => hasAccessibleName(surface === "agent-id" ? "Copy ID" : "Copy"))
             .toBe(true);
@@ -418,6 +420,7 @@ suite.define(() => {
       viewport: { height: 900, width: 1280 },
     });
     const page = await context.newPage();
+    await page.clock.install();
     await installDeniedClipboard(page);
     const code = "const answer = 42;";
     const gateway = await installMockGateway(page, {
@@ -460,6 +463,7 @@ suite.define(() => {
         });
       }
 
+      await page.clock.fastForward(2_000);
       await expect.poll(() => button.getAttribute("aria-label")).toBe("Copy code");
       await expect.poll(() => button.getAttribute("class")).not.toContain("copy-failed");
     } finally {
@@ -476,6 +480,7 @@ suite.define(() => {
         viewport: { height: 900, width },
       });
       const page = await context.newPage();
+      await page.clock.install();
       await installDeniedClipboard(page);
       await installMockGateway(page, {
         historyMessages: [
@@ -509,6 +514,7 @@ suite.define(() => {
           legacyAttempts: 1,
           value: "Copy this complete message.",
         });
+        await page.clock.fastForward(2_000);
         await feedback.waitFor({ state: "hidden" });
         await expect.poll(() => copy.getAttribute("aria-label")).toBe("Copy as markdown");
       } finally {

--- a/ui/src/e2e/control-ui-e2e-suite.test-support.ts
+++ b/ui/src/e2e/control-ui-e2e-suite.test-support.ts
@@ -1,12 +1,16 @@
 import { chromium, type Browser, type BrowserContext, type Locator, type Page } from "playwright";
-import { afterAll, afterEach, beforeAll, describe, expect } from "vitest";
+import { afterAll, afterEach, beforeAll, describe, expect, inject } from "vitest";
 import {
-  canRunPlaywrightChromium,
   controlUiE2eWaitTimeoutMs,
-  resolvePlaywrightChromiumExecutablePath,
   startControlUiE2eServer,
   type ControlUiE2eServer,
 } from "../test-helpers/control-ui-e2e.ts";
+
+declare module "vitest" {
+  export interface ProvidedContext {
+    controlUiE2eChromium: { executablePath: string; available: boolean };
+  }
+}
 
 type ControlUiE2eSuiteOptions = {
   browserLaunchOptions?: Omit<NonNullable<Parameters<typeof chromium.launch>[0]>, "executablePath">;
@@ -83,8 +87,9 @@ export async function holdModuleResponse(page: Page, module: RegExp) {
 }
 
 export function createControlUiE2eSuite(options: ControlUiE2eSuiteOptions): ControlUiE2eSuite {
-  const chromiumExecutablePath = resolvePlaywrightChromiumExecutablePath(chromium.executablePath());
-  const chromiumAvailable = canRunPlaywrightChromium(chromiumExecutablePath);
+  // Global setup already checked the executable; keep that result across isolated files.
+  const { executablePath: chromiumExecutablePath, available: chromiumAvailable } =
+    inject("controlUiE2eChromium");
   const allowMissingChromium = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM === "1";
   const describeControlUiE2e =
     chromiumAvailable || !allowMissingChromium ? describe : describe.skip;


### PR DESCRIPTION
## What Problem This Solves

The Control UI browser tests repeatedly rediscover Chromium and wait in real time for clipboard feedback to reset. This spends execution time without exercising additional behavior.

## Why This Change Was Made

The global setup now supplies its already-validated Chromium path and availability to the shared E2E suite. Each file keeps its own browser, and each case keeps its own context. This removes two redundant Chromium probes per shared-suite file (215 callers) while preserving explicit executable overrides, system fallback, and missing-browser failure/explicit-skip behavior.

Clipboard cases use Playwright's clock only to advance the existing 1.5s/2s feedback timers after asserting the visible success or failure state. Every case and assertion remains; the clipboard API, rendering, clicks, layout checks, and feedback reset still run in Chromium.

## User Impact

Faster execution of unchanged browser coverage. No production behavior, sharding, workers, test selection, or timeout-budget changes. Production LOC: +0/-0; tests/support: +20/-6.

## Evidence

- Same local checkout/Node 26.5.0, full clipboard suite: warm baseline **20 passed, 37.572s** test execution; candidate **20 passed, 27.152s**. A sibling run repeated clipboard at **27.560s** and passed all **23** clipboard + chat-message-actions cases. The initial cold baseline was 61.108s and is excluded from the improvement claim.
- Actual browser runs exercised the global-setup injection, clipboard success/failure, message copying, width stability, and feedback reset. Commands: `node scripts/run-vitest.mjs ui/src/e2e/chat-flow.clipboard.e2e.test.ts` and the same command with `ui/src/e2e/chat-message-actions.e2e.test.ts`.
- Missing executable smoke: explicit allow-missing flag preserves the existing skip; without it the run fails with the expected absent-executable diagnostic.
- Existing Chromium resolver unit tests: 2 passed. UI E2E test typecheck passed with `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.ui-e2e.json`.
- Fresh Codex autoreview and formatting/whitespace checks passed. Changed-file checks passed on Blacksmith Testbox (exit 0; lease stopped), including test types, lint, and guards: [run 33231931899](https://github.com/openclaw/openclaw/actions/runs/33231931899). Exact-head [CI33232146216](https://github.com/openclaw/openclaw/actions/runs/33232146216) is green on attempt2, including all14 browser lanes and the real-gateway browser lane. Initial unrelated Discord smoke CLI timeouts were inspected; the targeted failed-job retry passed without changing this head. The eager smoke-script dependency graph is separately improved in #132342.
