### PR TITLE
fix(ci): keep isolated QA dependencies independent of pnpm store

### DIFF
--- a/.github/workflows/openclaw-release-telegram-qa.yml
+++ b/.github/workflows/openclaw-release-telegram-qa.yml
@@ -326,6 +326,8 @@ jobs:
           set -euo pipefail
           candidate_home="${RUNNER_TEMP}/openclaw-telegram-candidate-home"
           mkdir -p "$candidate_home"
+          # Native pnpm reads this policy from env; the config flag also covers older targets.
+          # Copies keep the candidate independent of the external package store.
           env -i \
             CI=true \
             COREPACK_HOME="${candidate_home}/.cache/corepack" \
@@ -333,6 +335,7 @@ jobs:
             LANG=C.UTF-8 \
             NPM_CONFIG_USERCONFIG=/dev/null \
             PATH="$PATH" \
+            PNPM_CONFIG_PACKAGE_IMPORT_METHOD=copy \
             RUNNER_TEMP="$RUNNER_TEMP" \
             pnpm install \
               --store-dir "$RUNNER_TEMP/openclaw-telegram-candidate-pnpm-store" \

--- a/.github/workflows/qa-profile-evidence.yml
+++ b/.github/workflows/qa-profile-evidence.yml
@@ -387,6 +387,7 @@ jobs:
           set -euo pipefail
           selected_home="${RUNNER_TEMP}/openclaw-qa-selected-home"
           mkdir -p "$selected_home"
+          # Native pnpm reads this policy from env; the config flag also covers older targets.
           env -i \
             CI=true \
             COREPACK_HOME="${selected_home}/.cache/corepack" \
@@ -394,6 +395,7 @@ jobs:
             LANG=C.UTF-8 \
             NPM_CONFIG_USERCONFIG=/dev/null \
             PATH="$PATH" \
+            PNPM_CONFIG_PACKAGE_IMPORT_METHOD=copy \
             RUNNER_TEMP="$RUNNER_TEMP" \
             pnpm install \
               --store-dir "$RUNNER_TEMP/openclaw-qa-selected-pnpm-store" \
@@ -556,6 +558,7 @@ jobs:
             LANG=C.UTF-8 \
             NPM_CONFIG_USERCONFIG=/dev/null \
             PATH="$PATH" \
+            PNPM_CONFIG_PACKAGE_IMPORT_METHOD=copy \
             RUNNER_TEMP="$RUNNER_TEMP" \
             pnpm install \
               --store-dir "$RUNNER_TEMP/openclaw-qa-selected-pnpm-store" \
@@ -861,6 +864,7 @@ jobs:
             LANG=C.UTF-8 \
             NPM_CONFIG_USERCONFIG=/dev/null \
             PATH="$PATH" \
+            PNPM_CONFIG_PACKAGE_IMPORT_METHOD=copy \
             RUNNER_TEMP="$RUNNER_TEMP" \
             pnpm install \
               --store-dir "$RUNNER_TEMP/openclaw-qa-selected-pnpm-store" \

--- a/test/scripts/qa-candidate-install-workflows.test.ts
+++ b/test/scripts/qa-candidate-install-workflows.test.ts
@@ -1,0 +1,55 @@
+import { spawnSync } from "node:child_process";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { afterEach, expect, it } from "vitest";
+import { parse } from "yaml";
+import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+it.each([
+  ["openclaw-release-telegram-qa", "build_candidate"],
+  ["qa-profile-evidence", "plan_qa_profile"],
+  ["qa-profile-evidence", "run_qa_profile_shard"],
+  ["qa-profile-evidence", "aggregate_qa_profile"],
+])("%s/%s installs an isolated copy of its dependencies", (workflowName, jobName) => {
+  const workflow = parse(readFileSync(`.github/workflows/${workflowName}.yml`, "utf8")) as {
+    jobs: Record<string, { steps: Array<{ name?: string; run?: string }> }>;
+  };
+  const install = workflow.jobs[jobName]?.steps.find((step) =>
+    /^Install (candidate|selected) dependencies/u.test(step.name ?? ""),
+  );
+  expect(install?.run).toBeTruthy();
+
+  const root = tempDirs.make("qa-candidate-install-");
+  const bin = join(root, "bin");
+  mkdirSync(bin);
+  writeFileSync(
+    join(bin, "pnpm"),
+    `#!/usr/bin/env node
+process.stdout.write(JSON.stringify({
+  importMethod: process.env.PNPM_CONFIG_PACKAGE_IMPORT_METHOD,
+  githubToken: process.env.GH_TOKEN,
+  args: process.argv.slice(2),
+}));
+`,
+    { mode: 0o755 },
+  );
+  const result = spawnSync("bash", ["-c", install!.run!], {
+    cwd: root,
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      GH_TOKEN: "test-runner-token",
+      PATH: `${bin}:${process.env.PATH}`,
+      PNPM_CONFIG_PACKAGE_IMPORT_METHOD: "hardlink",
+      RUNNER_TEMP: root,
+    },
+    timeout: 10_000,
+  });
+  expect(result.status, result.stderr).toBe(0);
+  expect(JSON.parse(result.stdout)).toEqual({
+    importMethod: "copy",
+    args: expect.arrayContaining(["install", "--frozen-lockfile"]),
+  });
+});


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where full release verification cannot archive the Telegram candidate after its dependency install. The archive guard correctly rejects package files hard-linked to an external pnpm store. The same ineffective copy setting is used by three QA profile jobs.

Observed in [full release verification](https://github.com/openclaw/openclaw/actions/runs/33230733150) at `383a293b32d97254014437430b62aaf406bc11ac`, with the exact failure in [Telegram candidate archive](https://github.com/openclaw/openclaw/actions/runs/33230795945/job/99043176377).

## Why This Change Was Made

Native pnpm 12 accepts but ignores the old `--config.package-import-method=copy` flag. Its [CLI override contract](https://github.com/pnpm/pnpm/blob/v12.0.0/pnpm/crates/cli/src/config_overrides.rs) does not implement that setting; its [environment overlay](https://github.com/pnpm/pnpm/blob/v12.0.0/pnpm/crates/config/src/env_overlay.rs) does. Set `PNPM_CONFIG_PACKAGE_IMPORT_METHOD=copy` inside each sanitized install environment, following the existing setup-node-env action. Retain the old flag because trusted workflows also install older frozen candidates.

The archive checks, credential isolation, frozen lockfile and test coverage remain intact. This fixes the dependency producer; it does not strip hard links or loosen the archive consumer. The pnpm 12 migration in #131043 exposed the gap (authored and merged by @steipete).

## User Impact

No product behavior changes. Release and QA operators can construct independent candidate trees with pnpm 12.

## Evidence

- All four new cases fail against the unchanged workflows and pass with the fix. They execute the actual install steps and verify the copy policy survives `env -i`, an inherited conflicting value is overridden, and a runner token is absent.
- Focused install/workflow/archive suites: 56 passed, 3 existing skips. External-hard-link rejection remains covered.
- `check:workflows` passed; formatting and independent Codex review passed.
- Real Linux install/archive proof with pinned pnpm 12: external-store hard-link case has link count 2 and fails the unchanged guard; copy case has link count 1 and passes. [Blacksmith Testbox run](https://github.com/openclaw/openclaw/actions/runs/33232034048), lease `tbx_01m15sq90jy53fj83zjn9ks5ca`, delegated command exit 0; lease stopped. Earlier tiny-fixture attempts lacked their own package-manager pin and were not accepted as pnpm 12 proof.
- Product runtime LOC: 0. Workflow configuration: +7. Tests: +55.

Full release verification is still blocked on independent failures being investigated separately; this PR does not claim a green full run.
