### PR TITLE
fix(macos): show Peekaboo snapshot failure diagnostics

### DIFF
--- a/docs/platforms/mac/dev-setup.md
+++ b/docs/platforms/mac/dev-setup.md
@@ -92,6 +92,15 @@ and defaults mutations; it does not isolate the process from the host.
 
 ## Troubleshooting
 
+### Build fails while freezing Peekaboo sources
+
+If packaging stops at `Freezing authenticated Peekaboo sources in a read-only snapshot`,
+check the `hdiutil` error on stderr. Routine image creation and attachment output stays
+quiet, but failures such as `hdiutil: attach failed - Permission denied` are preserved.
+Check the temporary location selected by `TMPDIR` and its filesystem or mount permissions
+before retrying. This step runs before signing; source verification and the read-only
+snapshot remain required.
+
 ### Build fails: toolchain or SDK mismatch
 
 The macOS app build expects the latest macOS SDK and the Swift 6.3 toolchain

--- a/scripts/package-mac-app.sh
+++ b/scripts/package-mac-app.sh
@@ -463,13 +463,14 @@ create_verified_peekaboo_snapshot() {
   PEEKABOO_SNAPSHOT_IMAGE="$PEEKABOO_SNAPSHOT_ROOT/Peekaboo.dmg"
   PEEKABOO_SNAPSHOT_MOUNT="$PEEKABOO_SNAPSHOT_ROOT/mount"
   mkdir "$PEEKABOO_SNAPSHOT_MOUNT"
-  hdiutil create -quiet -fs APFS -format UDRO \
+  # -quiet suppresses failure stderr too; discard only routine stdout.
+  hdiutil create -fs APFS -format UDRO \
     -srcfolder "$source_checkout" \
     -volname OpenClawPeekabooSnapshot \
-    "$PEEKABOO_SNAPSHOT_IMAGE"
-  hdiutil attach -quiet -readonly -nobrowse \
+    "$PEEKABOO_SNAPSHOT_IMAGE" >/dev/null
+  hdiutil attach -readonly -nobrowse \
     -mountpoint "$PEEKABOO_SNAPSHOT_MOUNT" \
-    "$PEEKABOO_SNAPSHOT_IMAGE"
+    "$PEEKABOO_SNAPSHOT_IMAGE" >/dev/null
   snapshot_commit="$(compiled_peekaboo_commit "$PEEKABOO_SNAPSHOT_MOUNT" "$expected")" || return 1
   [[ "$snapshot_commit" == "$source_commit" ]] || return 1
 }

--- a/test/scripts/package-mac-app.test.ts
+++ b/test/scripts/package-mac-app.test.ts
@@ -1580,13 +1580,133 @@ describe("package-mac-app plist stamping", () => {
     expect(script.indexOf(resolveCall)).toBeLessThan(script.indexOf(buildCall));
   });
 
+  it.each([
+    { operation: "create", exitCode: 1, reason: "No such file or directory" },
+    { operation: "attach", exitCode: 73, reason: "Permission denied" },
+    { operation: "none", exitCode: 0, reason: "" },
+  ])(
+    "preserves Peekaboo snapshot diagnostics and cleanup: $operation",
+    ({ operation, exitCode, reason }) => {
+      const root = tempDirs.make("openclaw-peekaboo-snapshot-fixture-");
+      const buildPath = path.join(root, "build with spaces");
+      const checkout = path.join(buildPath, "checkouts", "Peekaboo");
+      const scratch = path.join(root, "temporary snapshots");
+      const unrelated = path.join(scratch, "unrelated-snapshot", "marker");
+      const operationsPath = path.join(root, "operations");
+      const expectedCommit = "b".repeat(40);
+      mkdirSync(checkout, { recursive: true });
+      mkdirSync(path.dirname(unrelated), { recursive: true });
+      writeFileSync(path.join(checkout, "source"), "source preserved\n");
+      writeFileSync(unrelated, "unrelated snapshot preserved\n");
+      const hdiutil = path.join(root, "hdiutil");
+      writeFileSync(
+        hdiutil,
+        `#!/bin/bash
+        set -euo pipefail
+        printf '%s\\n' "$1" >> "$operations"
+        printf '%s\\0' "$@" > "$fixture_root/$1.args"
+        if [[ "$1" == create ]]; then
+          image="\${@: -1}"
+          printf '%s' "\${image%/*}" > "$fixture_root/snapshot-root"
+          : > "$image"
+        fi
+        for arg in "$@"; do
+          if [[ "$arg" == -quiet ]]; then
+            exec 1>&- 2>&-
+          fi
+        done
+        if [[ "$1" == ${JSON.stringify(operation)} ]]; then
+          printf 'hdiutil: %s failed - %s\\n' "$1" ${JSON.stringify(reason)} >&2 || true
+          exit ${exitCode}
+        fi
+        if [[ "$1" == detach && ${JSON.stringify(operation)} != none ]]; then
+          exit 1
+        fi
+        printf 'hdiutil: %s completed\\n' "$1" || true
+        exit 0
+        `,
+      );
+      chmodSync(hdiutil, 0o755);
+
+      const result = runHelper(
+        `
+      set -euo pipefail
+      export fixture_root=${JSON.stringify(root)}
+      export operations=${JSON.stringify(operationsPath)}
+      export PATH=${JSON.stringify(`${root}:/usr/bin:/bin`)}
+      TMPDIR=${JSON.stringify(scratch)}
+      ${getSwiftPackageResolutionBlock()}
+      compiled_peekaboo_commit() {
+        printf 'verify:%s:%s\\n' "$1" "$2" >> "$operations"
+        printf '%s' "$2"
+      }
+      rm() {
+        printf 'remove:%s\\n' "$*" >> "$operations"
+        command rm "$@"
+      }
+      create_verified_peekaboo_snapshot ${JSON.stringify(buildPath)} ${JSON.stringify(expectedCommit)}
+      printf 'snapshot-ready\\n' >> "$operations"
+      `,
+        "/bin/bash",
+      );
+
+      const snapshotRoot = readFileSync(path.join(root, "snapshot-root"), "utf8");
+      const image = path.join(snapshotRoot, "Peekaboo.dmg");
+      const mount = path.join(snapshotRoot, "mount");
+      const expectedOperations = [`verify:${checkout}:${expectedCommit}`, "create"];
+      if (operation !== "create") {
+        expectedOperations.push("attach");
+      }
+      if (operation === "none") {
+        expectedOperations.push(`verify:${mount}:${expectedCommit}`, "snapshot-ready");
+      }
+      expectedOperations.push("detach", `remove:-rf ${snapshotRoot}`);
+      expect(result.status).toBe(exitCode);
+      expect(readFileSync(operationsPath, "utf8").trim().split("\n")).toEqual(expectedOperations);
+      expect(existsSync(snapshotRoot)).toBe(false);
+      expect(readFileSync(path.join(checkout, "source"), "utf8")).toBe("source preserved\n");
+      expect(readFileSync(unrelated, "utf8")).toBe("unrelated snapshot preserved\n");
+      const readArgs = (command: string) =>
+        readFileSync(path.join(root, `${command}.args`), "utf8")
+          .split("\0")
+          .slice(0, -1)
+          .filter((arg) => arg !== "-quiet");
+      expect(readArgs("create")).toEqual([
+        "create",
+        "-fs",
+        "APFS",
+        "-format",
+        "UDRO",
+        "-srcfolder",
+        checkout,
+        "-volname",
+        "OpenClawPeekabooSnapshot",
+        image,
+      ]);
+      if (operation !== "create") {
+        expect(readArgs("attach")).toEqual([
+          "attach",
+          "-readonly",
+          "-nobrowse",
+          "-mountpoint",
+          mount,
+          image,
+        ]);
+      }
+      expect(readArgs("detach")).toEqual(["detach", mount]);
+      expect(result.stdout).toBe("");
+      expect(result.stderr).toBe(
+        operation === "none" ? "" : `hdiutil: ${operation} failed - ${reason}\n`,
+      );
+    },
+  );
+
   it("stamps only the clean Peekaboo source that SwiftPM actually compiled", () => {
     const verifier = getCompiledPeekabooHelperBlock();
     expect(verifier).toContain('"core.commitGraph=false"');
     expect(verifier).toContain('"--no-replace-objects"');
     expect(verifier).toContain('"fsck", "--full", "--strict"');
     expect(verifier).toContain('"cat-file", object_type');
-    expect(readFileSync(scriptPath, "utf8")).toContain("hdiutil attach -quiet -readonly -nobrowse");
     expect(readFileSync(scriptPath, "utf8")).toContain(
       'swift package --scratch-path "$build_path" edit Peekaboo --path "$PEEKABOO_SNAPSHOT_MOUNT"',
     );


### PR DESCRIPTION
Closes #132325

Related: https://github.com/openclaw/openclaw/pull/131757 (desktop onboarding persistence; this is a separate packaging-diagnostics follow-up).

<details>
<summary>Additional instructions</summary>

Maintainers can edit this same-repository branch.

</details>

## What Problem This Solves

Fixes an issue where developers packaging the macOS app would see an unexplained exit immediately after `Freezing authenticated Peekaboo sources in a read-only snapshot` when image creation or attachment failed. The reported attachment failure was `Permission denied`, but the packager hid that diagnostic.

## Why This Change Was Made

Apple's `hdiutil` documents that `-quiet` closes both stdout and stderr. The snapshot owner now redirects only routine stdout for create and attach, preserving native failure messages and exit codes without adding wrappers, retries, temporary logs, or fallback paths.

Source verification before and after the snapshot, APFS UDRO creation, `-readonly -nobrowse` attachment, signing, and EXIT cleanup ownership are unchanged. Host permissions, global mount policy, and signing refactors are explicitly out of scope. The source-snapshot implementation originated in https://github.com/openclaw/openclaw/pull/124564 (Peekaboo elevation cutovers); this change keeps that boundary intact.

## User Impact

Developers get the native image-creation or attachment error on stderr instead of a silent failure. Successful snapshot operations stay quiet. The macOS developer guide now explains where to find the diagnostic and which temporary-directory permissions to inspect; it does not recommend bypassing verification or the read-only snapshot.

Release-note context: macOS packaging now preserves Peekaboo snapshot failure diagnostics without adding routine successful output.

## Evidence

- Before editing production, the new bounded fixture failed both create/attach diagnostic assertions because stderr was empty. Its success case passed. After the fix, it preserves exact exit codes 1 and 73, rejects progress beyond the failing operation, exercises the actual EXIT cleanup, preserves unrelated/source files, and verifies the unchanged image/mount arguments and quiet success.
- `node scripts/run-vitest.mjs test/scripts/package-mac-app.test.ts`: 59 passed. Existing real-Git cases continue to protect source authentication.
- `node scripts/check-changed.mjs -- scripts/package-mac-app.sh test/scripts/package-mac-app.test.ts docs/platforms/mac/dev-setup.md`: passed formatting, test-root typechecking, script lint, guards, and the selected macOS suite (548 tests in 15 files). The pre-existing elevation-host lifecycle cases made this gate slow; none failed.
- `/bin/bash -n scripts/package-mac-app.sh` and `git diff --check`: passed. The new fixture uses macOS Bash 3.2.
- Native macOS 26.6.2 proof ran the actual snapshot function with Apple's `hdiutil` and a test-owned Git checkout. Before: real create/attach missing-path failures exited 1 with empty stderr. After: both still exited 1 and exposed their native `No such file or directory` stderr. The success path authenticated the mounted APFS UDRO source, rejected a write with `EROFS`, produced empty stdout/stderr, and left no owned mounts or temporary snapshot roots.
- Independent Codex autoreview: the initial and fresh pre-commit passes both passed at the default P0 scope with no accepted/actionable findings.

Proof limits: the full app was not rebuilt or signed, and the original external-volume mount restriction was not re-created. Live proof targeted the changed snapshot function; the permission-denial diagnostic and non-1 status are covered deterministically by the fixture. This is a shell diagnostic change, not a UI change or artifact-content change.

Production/tooling LOC: +5/-4 (net +1 explanatory comment). Tests: +121/-1 (net +120). Docs: +9/-0. No new production helper, configuration option, dependency, or compatibility path.

AI-assisted; the owner flow, tests, native dependency contract, and resulting diff were inspected directly. No agent transcript is included.


## Scope restoration and current-main validation

The PR retains only its original three files: `scripts/package-mac-app.sh`, `test/scripts/package-mac-app.test.ts`, and `docs/platforms/mac/dev-setup.md`. Refreshed head `91c27cba55a00394cd2fc6e942f7a081e48aafdc` is based on main `c3e9712a497d70f97838e0a25ef55a252edbf27d`; its entire binary diff is byte-identical to the reviewed diagnostics patch (SHA256 `026e12d8fe7fdba95aa87dd5d5313b322de0fbdfa476625160fa57ef812136bc`). The subsequent QA consolidation from `85f737a0744fc49466da034068aa932efbe5bdb3` was removed from this PR and preserved in a task-owned local backup ref with its proof artifacts. That QA proof is superseded and is not evidence for a QA change in this final diff.

Main independently addressed the previous selected blockers: [#132394](https://github.com/openclaw/openclaw/pull/132394), commit `2b1eee0d688a2e9163015769f7d18ed1937fa522`, recorded the second QA suppression; [#132444](https://github.com/openclaw/openclaw/pull/132444), commit `9d79bf3f8c5f18f7c35d028d57402f5085659640`, repaired the media-test max-lines failure. By the time of the refresh, [#125618](https://github.com/openclaw/openclaw/pull/125618), commit `562aead90137aa0c92bc5f03a9000afac4127cc7`, had also independently consolidated QA bootstrap error handling and reconciled the inventory back to one. All of that main state is inherited unchanged. This PR changes neither QA implementation nor suppression policy/inventory.

Fresh pre-commit validation on this base: `node scripts/run-vitest.mjs test/scripts/package-mac-app.test.ts test/scripts/lint-suppressions.test.ts` passed all 63 tests (59 packaging + 4 inventory). Bash syntax, diff checks, targeted formatting, root-test typechecking, and targeted lint passed. Fresh isolated Codex autoreview of the final uncommitted three-file delta passed at the default P0 scope; credential scanning and the restricted review sandbox were retained. The original 548-test changed-path run and native before/after evidence remain applicable to this identical diagnostics patch; they were not rerun as a new full-suite claim.

ClawSweeper finding/rank-up disposition: the proposed QA allowlist reduction is superseded by removal of the QA patch and inheritance of canonical main. The fresh inventory test verifies that integration. No inventory edit is being added here. Exact new-head CI remains the readiness gate; failed runs on old heads, including [33240976209](https://github.com/openclaw/openclaw/actions/runs/33240976209), are retained as historical failures, not claimed green.

The Swift-cache companion [#132357](https://github.com/openclaw/openclaw/pull/132357) is merged as `dc9405e9b2d37bb94d3ac0a0958a48f917959dc5` and included in the base. Its cache-enabled hosted Swift proof passed 3,387 tests; late cache-mtime polish remains separate. [#132376](https://github.com/openclaw/openclaw/pull/132376) remains independently owned; its earlier ripgrep fixture issue is not substituted for an observed failure in this head's selected gates.

The exact leased push and live three-file PR diff are verified. Native review artifacts were reinitialized and validated for this head, with the superseded QA artifacts archived.

## Final landing and CI retry

Landed through the native squash-merge flow at [e6efad25278fcd1d65b0310e4c53673b0650f72c](https://github.com/openclaw/openclaw/commit/e6efad25278fcd1d65b0310e4c53673b0650f72c) on 2026-08-29 at 10:18:08 UTC. [Issue #132325](https://github.com/openclaw/openclaw/issues/132325) closed automatically at 10:18:09 UTC. The [native completion receipt](https://github.com/openclaw/openclaw/pull/132335#issuecomment-5461757728) records the exact prepared head and landed commit. The native outcome is complete; no bypass or uncertain dispatch retry occurred.

Freshly fetched main contains the exact approved three-file patch, including both stdout-only snapshot calls. The landed diff SHA256 is `026e12d8fe7fdba95aa87dd5d5313b322de0fbdfa476625160fa57ef812136bc`: 135 additions / 5 removals total, production tooling +5/-4 (one explanatory comment), tests +121/-1, docs +9/-0. Source authentication, readonly/nobrowse, failure status and cleanup remain unchanged. The existing 59-packager-test and native before/after evidence applies to the identical landed patch.

The approved head remains `91c27cba55a00394cd2fc6e942f7a081e48aafdc`, with the unchanged three-file diagnostics diff. [Normal CI 33242291870, attempt 1](https://github.com/openclaw/openclaw/actions/runs/33242291870/attempts/1) was cancelled only after fresh attempt-specific job pages confirmed 101 successful jobs, 15 intentional skips, and one remaining unassigned, zero-step MacNode job. Swift had already succeeded at 09:05 UTC; it was not still waiting for a runner. Cancellation is not a passing result.

After terminal cancellation, `gh run rerun 33242291870 --failed` started [attempt 2](https://github.com/openclaw/openclaw/actions/runs/33242291870/attempts/2) on the same head. The existing workflow routes retries to hosted runners. [MacNode 99086149869](https://github.com/openclaw/openclaw/actions/runs/33242291870/job/99086149869) passed all 548 cases across seven shards on GitHub-hosted `macos-15`. Successful source results, including Swift, were retained. Attempt 2 completed successfully at 10:15:47 UTC with 103 successful jobs and 15 intentional skips. Its [openclaw/ci-gate](https://github.com/openclaw/openclaw/actions/runs/33242291870/job/99087172084) succeeded on the exact approved head from GitHub Actions (integration 15368). No unrelated workflow or repository/global setting was changed.

The separate [exact-head hosted fallback 33242699076/1](https://github.com/openclaw/openclaw/actions/runs/33242699076) remains successful and untouched: 190 jobs passed, four intentional skips, 548 macOS TypeScript cases, and 3,387 Swift Testing cases plus three XCTest cases and the health fixture. Its [GitHub Actions CI gate](https://github.com/openclaw/openclaw/actions/runs/33242699076/job/99077461203) succeeded on this exact head. Cache restore was enabled; the graph-bound build cache missed, so this is not a warm-build-cache-hit claim.

Native prepare already passed without a head change or push. The earlier native merge operation exhausted its advisory watch on attempt 1, then stopped at the PR/main stability check before recording intent or sending a merge request. The outcome ref and merge-output file were absent; all owned tools had stopped before recovery of the exact emitted lock. The first authorized pre-intent retry completed successfully through the native wrapper. It passed the normal CI watch immediately, verified the required gate, preserved stable observation, and issued one pinned squash merge. No rebase or source commit was needed; main drift remained advisory.

The latest [ClawSweeper review](https://github.com/openclaw/openclaw/pull/132335#issuecomment-5460219574), at 08:53 UTC on this exact head, has no code or security findings and requests a fresh exact-head server/mergeability check. The maintainer has approved this diagnostics scope; normal CI was green and GitHub state was `MERGEABLE/CLEAN` at admission. Live main rules required only the successful GitHub Actions CI gate and no independent approval. The native merge completed successfully. The one net production line is the explanatory stderr-contract comment. Original signing/external-volume proof limits remain unchanged.
