### PR TITLE
test(onepassword): reuse immutable fixtures and compile resolver once

### DIFF
--- a/extensions/onepassword/src/op-client.test.ts
+++ b/extensions/onepassword/src/op-client.test.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { OnePasswordError } from "./errors.js";
 import { OpClient } from "./op-client.js";
 import { createTrustedNodeFixture } from "./trusted-node.test-support.js";
@@ -14,9 +14,23 @@ describe("OpClient", () => {
   let root = "";
   let opBin = "";
   let interpreter = "";
+  let interpreterRoot: string | undefined;
   let tokenFile = "";
   const fixtureAuth = ["fixture", "auth"].join("-");
   const rightFixture = ["right", "fixture"].join("-");
+
+  beforeAll(async () => {
+    // Only the immutable interpreter is shared; executable and token trust stay per-test.
+    // openclaw-temp-dir: allow plugin tests cannot import the core-only tracker.
+    interpreterRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-onepassword-node-"));
+    interpreter = createTrustedNodeFixture(interpreterRoot);
+  });
+
+  afterAll(async () => {
+    if (interpreterRoot) {
+      await fs.rm(interpreterRoot, { recursive: true, force: true });
+    }
+  });
 
   beforeEach(async () => {
     // openclaw-temp-dir: allow plugin tests cannot import the core-only tracker.
@@ -24,7 +38,6 @@ describe("OpClient", () => {
     tempDirs.push(root);
     opBin = path.join(root, process.platform === "win32" ? "op.exe" : "op");
     tokenFile = path.join(root, "service-account-token");
-    interpreter = createTrustedNodeFixture(root);
     await fs.writeFile(opBin, `#!${interpreter}\nprocess.exit(0);\n`, { mode: 0o700 });
     await fs.writeFile(tokenFile, `  ${fixtureAuth}\n`, { mode: 0o600 });
   });

--- a/extensions/onepassword/src/secret-ref-resolver.test.ts
+++ b/extensions/onepassword/src/secret-ref-resolver.test.ts
@@ -2,14 +2,16 @@ import { spawn } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { fileURLToPath, pathToFileURL } from "node:url";
+import { fileURLToPath } from "node:url";
 import { DEFAULT_SECRET_FILE_MAX_BYTES } from "openclaw/plugin-sdk/secret-file-runtime";
 import {
   resolvePreferredOpenClawTmpDir,
   tempWorkspaceSync,
   type TempWorkspaceSync,
 } from "openclaw/plugin-sdk/temp-path";
+import { build } from "tsdown";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { createStateSchemaInlinePlugin } from "../../../scripts/lib/state-schema-inline-plugin.mjs";
 import { encodeOnePasswordSecretId } from "../onepassword-secret-id.js";
 import { createTrustedNodeFixture } from "./trusted-node.test-support.js";
 
@@ -23,11 +25,7 @@ const sourceStaticAssetPaths = [
 ];
 const manifestPath = fileURLToPath(new URL("../openclaw.plugin.json", import.meta.url));
 const packagePath = fileURLToPath(new URL("../package.json", import.meta.url));
-const tsxCliPath = fileURLToPath(import.meta.resolve("tsx/cli"));
 const rootTsconfigPath = path.resolve("tsconfig.json");
-const secretRefRuntimeSourceUrl = pathToFileURL(
-  path.resolve("src/plugin-sdk/secret-ref-runtime.ts"),
-).href;
 // The manifest test reads the production source; the timeout-only staged executable needs a
 // shorter deadline to prove cleanup without sleeping for the production seven seconds.
 const TEST_OP_READ_TIMEOUT_MS = process.platform === "win32" ? 5_000 : 1_500;
@@ -41,28 +39,14 @@ let stagedResolverRoot: string | undefined;
 let trustedNodeRoot: string | undefined;
 let trustedNodePath: string | undefined;
 
-beforeAll(() => {
+beforeAll(async () => {
   const tempRoot = path.join(process.cwd(), ".tmp");
   fs.mkdirSync(tempRoot, { recursive: true });
   stagedResolverRoot = fs.mkdtempSync(path.join(tempRoot, "onepassword-resolver-"));
   for (const sourcePath of sourceStaticAssetPaths) {
     const stagedPath = path.join(stagedResolverRoot, path.basename(sourcePath));
-    if (sourcePath.endsWith("onepassword-op-path.js")) {
-      fs.writeFileSync(
-        stagedPath,
-        fs
-          .readFileSync(sourcePath, "utf8")
-          .replace(
-            '"openclaw/plugin-sdk/secret-ref-runtime"',
-            JSON.stringify(secretRefRuntimeSourceUrl),
-          ),
-      );
-      continue;
-    }
     fs.copyFileSync(sourcePath, stagedPath);
   }
-  // Keep the relative static assets together, but resolve the real SDK from source so this
-  // focused test does not depend on a parallel build producing dist/plugin-sdk first.
   resolverPath = path.join(stagedResolverRoot, path.basename(sourceResolverPath));
   const resolverSource = fs.readFileSync(sourceResolverPath, "utf8");
   const timeoutResolverSource = resolverSource.replace(
@@ -74,6 +58,25 @@ beforeAll(() => {
   }
   timeoutResolverPath = path.join(stagedResolverRoot, "onepassword-timeout-resolver.js");
   fs.writeFileSync(timeoutResolverPath, timeoutResolverSource);
+  // Build the real SDK once; each request still gets a fresh process and real op execution.
+  // Keep native dependencies external and use the production schema-asset transform.
+  const compiledRoot = path.join(stagedResolverRoot, "compiled");
+  await build({
+    config: false,
+    entry: [resolverPath, timeoutResolverPath],
+    outDir: compiledRoot,
+    tsconfig: rootTsconfigPath,
+    format: "esm",
+    outExtensions: () => ({ js: ".js" }),
+    dts: false,
+    deps: {
+      neverBundle: true,
+      alwaysBundle: [/^openclaw\//, /^@openclaw\/(?!fs-safe(?:\/|$))/],
+    },
+    plugins: [createStateSchemaInlinePlugin()],
+  });
+  resolverPath = path.join(compiledRoot, path.basename(resolverPath));
+  timeoutResolverPath = path.join(compiledRoot, path.basename(timeoutResolverPath));
   // The fake op paths remain per-test; only their trusted Node interpreter is shared.
   // Re-copying the runtime does not strengthen path-ownership coverage.
   trustedNodeRoot = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-1password-node-"));
@@ -150,21 +153,17 @@ function runResolver(params: {
     );
   }
   return new Promise((resolve, reject) => {
-    const child = spawn(
-      process.execPath,
-      [tsxCliPath, "--tsconfig", rootTsconfigPath, params.resolverExecutablePath ?? resolverPath],
-      {
-        ...(params.cwd ? { cwd: params.cwd } : {}),
-        stdio: ["pipe", "pipe", "pipe"],
-        env: {
-          ...process.env,
-          OP_SERVICE_ACCOUNT_TOKEN: "",
-          CLAW_1PASSWORD_OP: "",
-          OPENCLAW_STATE_DIR: stateDir,
-          ...params.env,
-        },
+    const child = spawn(process.execPath, [params.resolverExecutablePath ?? resolverPath], {
+      ...(params.cwd ? { cwd: params.cwd } : {}),
+      stdio: ["pipe", "pipe", "pipe"],
+      env: {
+        ...process.env,
+        OP_SERVICE_ACCOUNT_TOKEN: "",
+        CLAW_1PASSWORD_OP: "",
+        OPENCLAW_STATE_DIR: stateDir,
+        ...params.env,
       },
-    );
+    });
     let stdout = "";
     let stderr = "";
     child.stdout.setEncoding("utf8");
@@ -892,7 +891,6 @@ while true; do sleep 1; done
       // Windows verifies the executable owner and ACL chain through OS tooling before op starts.
       // Keep the synchronization bound above that preflight without weakening the kill deadline.
       await Promise.race([
-        // Source-mode loading now includes the shared process runtime before op starts.
         waitForPath(descendantReady, process.platform === "win32" ? 15_000 : 10_000),
         resultPromise.then((result) => {
           throw new Error(


### PR DESCRIPTION
## What Problem This Solves

The 1Password plugin tests repeatedly copy the same Node interpreter and start a TypeScript loader over the same large SDK graph for each resolver request. That setup dominates execution time without adding isolation to the executable/token security fixtures.

## Why This Change Was Made

The client suite now shares only its immutable trusted interpreter, matching the resolver suite's existing ownership pattern. Fake op executables, token files, and trust roots remain per case.

The resolver suite builds its normal and shortened-timeout fixtures once with the existing tsdown dependency, then launches fresh plain-Node processes. It compiles the real public SDK from source, keeps installed dependencies (including native fs-safe and Execa) external, and reuses the production schema-asset transform. This removes the custom SDK import rewrite and repeated loader startup without mocking resolver, filesystem trust, process runner, or cleanup behavior.

## User Impact

Faster execution of the same plugin coverage. No production, configuration, dependency, sharding, worker, test-selection, or timeout-budget changes. Production LOC: +0/-0. Tests: +48/-37 (net +11).

## Evidence

- Same local Node 26.5.0 checkout, before/after client + op-path command: all 26 passed; client execution **22.846s → 2.711s**. The immutable fixture no longer incurs one full interpreter copy per case.
- Full resolver suite before/after: **22 passed, 1 existing Windows-only skip** on macOS; execution including suite setup **73.082s → 18.040s**. Both runs used `node scripts/run-vitest.mjs extensions/onepassword/src/secret-ref-resolver.test.ts --reporter=default --reporter=json --outputFile=<report>`.
- Full plugin suite after both changes: `node scripts/run-vitest.mjs extensions/onepassword` — **111 passed, 1 existing skip across 9 files**, total Vitest duration 18.65s. All inherited-output, output-limit, timeout, descendant cleanup, concurrency, token symlink/hardlink, profile, and executable trust assertions remain unchanged.
- Inspected emitted code: real trusted-path and buffered process implementations present, fs-safe and Execa imports external, canonical schema bytes inlined, no unresolved public SDK/workspace imports. Build itself takes under one second locally.
- Fresh Codex autoreview clean for both changes; formatting and whitespace checks passed. Changed-file Linux checks passed on Blacksmith Testbox (exit 0; lease stopped): [run 33232330394](https://github.com/openclaw/openclaw/actions/runs/33232330394). Exact-head CI must pass before landing. Windows-specific resolver behavior was not run locally.
