### PR TITLE
test(gateway): verify Ultra intent across all captured requests

### DIFF
--- a/src/gateway/gateway-models.profiles.live.test.ts
+++ b/src/gateway/gateway-models.profiles.live.test.ts
@@ -24,6 +24,14 @@ import {
   saveAuthProfileStore,
 } from "../agents/auth-profiles/store.js";
 import type { AuthProfileStore } from "../agents/auth-profiles/types.js";
+import {
+  ACTIVE_EMBEDDED_RUNS,
+  ACTIVE_EMBEDDED_RUNS_BY_RUN_ID,
+} from "../agents/embedded-agent-runner/run-state.js";
+import {
+  clearActiveEmbeddedRun,
+  setActiveEmbeddedRun,
+} from "../agents/embedded-agent-runner/runs.js";
 import { collectProviderApiKeys } from "../agents/live-auth-keys.js";
 import { isModelNotFoundErrorMessage } from "../agents/live-model-errors.js";
 import {
@@ -67,9 +75,47 @@ import {
   isSessionTranscriptProjectionUnavailableError,
   SessionTranscriptProjectionUnavailableError,
 } from "../config/sessions/session-accessor.js";
+import {
+  getOwnedSessionTranscriptWriterFence,
+  withOwnedSessionTranscriptWrites,
+} from "../config/sessions/transcript-write-context.js";
 import type { ModelsConfig, ModelProviderConfig, OpenClawConfig } from "../config/types.js";
+import {
+  captureAgentRunLifecycleGeneration,
+  withAgentRunLifecycleGeneration,
+} from "../infra/agent-events.js";
+import {
+  claimAgentRunDelegatedAuthority,
+  clearAgentRunContext,
+  getAgentRunContext,
+  getAgentRunLifecycleGeneration,
+  registerAgentRunContext,
+  releaseAgentRunDelegatedAuthority,
+  validateAgentRunDelegatedAuthority,
+} from "../infra/agent-run-registry.js";
+import {
+  emitTrustedDiagnosticEvent,
+  onInternalDiagnosticEvent,
+  waitForDiagnosticEventsDrained,
+} from "../infra/diagnostic-events.js";
+import {
+  emitCoreModelRequestStartedDiagnosticEvent,
+  resolveCoreModelRequestLifecycleDiagnosticMetadata,
+} from "../infra/diagnostic-model-request.js";
+import {
+  createDiagnosticTraceContext,
+  formatDiagnosticTraceparent,
+  parseDiagnosticTraceparent,
+} from "../infra/diagnostic-trace-context.js";
+import { formatPropagatedDiagnosticTraceparent } from "../infra/diagnostic-trace-propagation.js";
 import { isTruthyEnvValue } from "../infra/env.js";
 import type { ModelRegistry } from "../llm/model-registry.js";
+import {
+  closeDiagnosticEmbeddedRunOwner,
+  createDiagnosticEmbeddedRunOwner,
+  isDiagnosticEmbeddedRunOwnerClosed,
+  type DiagnosticEmbeddedRunOwner,
+} from "../logging/diagnostic-run-activity.js";
 import { redactSecrets } from "../logging/redact.js";
 import { normalizeGooglePreviewModelId } from "../plugin-sdk/provider-model-shared.js";
 import { resolveEffectiveThinkingProfile } from "../plugins/provider-thinking.js";
@@ -1857,14 +1903,15 @@ describe("resolveGatewayLiveModelThinkingLevel", () => {
 });
 
 describe("buildLiveGatewayConfig", () => {
-  it("pins selected live gateway models to the OpenClaw runtime", () => {
+  it("pins the runtime while retaining a non-Ultra fixture default", () => {
     const cfg = buildLiveGatewayConfig({
-      cfg: {},
+      cfg: { agents: { defaults: { thinkingDefault: OPENAI_ULTRA_NORMAL_EFFORT } } },
       candidates: [createGatewayLiveTestModel("openai", "gpt-5.5")],
       liveAgentDir: GATEWAY_LIVE_CONFIG_TEST_AGENT_DIR,
       liveAgentWorkspaceDir: GATEWAY_LIVE_CONFIG_TEST_WORKSPACE,
     });
 
+    expect(cfg.agents?.defaults?.thinkingDefault).toBe("medium");
     expect(cfg.agents?.defaults?.models?.["openai/gpt-5.5"]).toEqual({
       agentRuntime: { id: "openclaw" },
     });
@@ -2997,13 +3044,13 @@ describe("gateway live model session policy", () => {
   });
 
   it("initializes explicit thinking levels without an admin-scoped session patch", () => {
-    const session = modelSession(0, "ultra");
+    const session = modelSession(0, OPENAI_ULTRA_NORMAL_EFFORT);
 
     expect(session.method).toBe("sessions.create");
     expect(session.request).toMatchObject({
       key: session.key,
       model: "openai/gpt-5.6-luna",
-      thinkingLevel: "ultra",
+      thinkingLevel: "medium",
     });
   });
 });
@@ -3590,6 +3637,12 @@ async function verifyGatewayUltraSubagentHandoff(params: {
   ).toHaveLength(1);
   run = matchingRuns[0];
   expect(run, `expected sessions_spawn child for ${params.modelKey}`).toBeDefined();
+  if (run) {
+    recordOpenAIUltraAdmission(params.client, run.runId, run.childSessionKey);
+    logProgress(
+      `[ultra] child=${JSON.stringify({ runId: run.runId, sessionKey: run.childSessionKey, requesterSessionKey: params.sessionKey, purpose: "sessions_spawn", executionStatus: run.execution.outcome?.status, deliveryStatus: run.delivery?.status })}`,
+    );
+  }
   expect(run?.execution.outcome?.status).toBe("ok");
   expect(run?.completion?.resultText).toContain(childToken);
   expect(run?.delivery?.status).toBe("delivered");
@@ -3913,6 +3966,16 @@ async function requestGatewayAgentText(params: {
   if (accepted?.status !== "accepted") {
     throw new Error(`agent status=${String(accepted?.status)}`);
   }
+  if (params.thinkingLevel === "ultra") {
+    expect(accepted.runId, "Ultra probe must retain its accepted run identity").toBe(runId);
+    expect(accepted.sessionKey, "Ultra probe must retain its accepted session").toBe(
+      params.sessionKey,
+    );
+    recordOpenAIUltraAdmission(params.client, runId, params.sessionKey);
+    logProgress(
+      `[ultra] accepted=${JSON.stringify({ runId, sessionKey: params.sessionKey, purpose: params.context })}`,
+    );
+  }
   if (params.assistantText === "optional") {
     // Tool-only turns intentionally may not append assistant text. Their
     // contract is terminal completion; the following turn proves tool state.
@@ -4004,7 +4067,32 @@ type OpenAIUltraWireObservation = {
   model?: string;
   reasoningEffort?: string;
   sessionsSpawn?: { strict?: boolean; categoryRequired: boolean };
+  requestIndex?: number;
+  traceparent?: string;
+  dispatch?: {
+    runId: string;
+    callId: string;
+    sessionId?: string;
+    sessionKey?: string;
+    isHeartbeat?: boolean;
+  } | null;
 };
+
+const OPENAI_ULTRA_WIRE_CAPTURE_LIMIT = 512;
+const OPENAI_ULTRA_NORMAL_EFFORT = "medium";
+const openAIUltraRunsByClient = new WeakMap<GatewayClient, Map<string, string>>();
+
+function recordOpenAIUltraAdmission(client: GatewayClient, runId: string, sessionKey: string) {
+  const runs = openAIUltraRunsByClient.get(client);
+  if (!runs) {
+    return;
+  }
+  expect(runs.size, "Ultra admission capture overflow").toBeLessThan(
+    OPENAI_ULTRA_WIRE_CAPTURE_LIMIT,
+  );
+  expect(runs.has(runId), "Ultra admissions must have distinct controlled identities").toBe(false);
+  runs.set(runId, sessionKey);
+}
 
 type OpenAIUltraWireCapture = {
   close: () => void;
@@ -4052,7 +4140,51 @@ function startOpenAIUltraWireCapture(upstreamBaseUrls: readonly string[]): OpenA
   const endpoints = new Set(
     upstreamBaseUrls.map((baseUrl) => `${baseUrl.replace(/\/$/u, "")}/responses`),
   );
-  const observations: OpenAIUltraWireObservation[] = [];
+  const observations: Array<
+    OpenAIUltraWireObservation & {
+      owner?: { diagnostic: DiagnosticEmbeddedRunOwner; isHeartbeat: boolean };
+    }
+  > = [];
+  const dispatches = new Map<
+    string,
+    {
+      model: string;
+      generation: object;
+      facts: NonNullable<OpenAIUltraWireObservation["dispatch"]>;
+    }
+  >();
+  let overflow = false;
+  const stopDiagnostics = onInternalDiagnosticEvent(
+    (event, metadata) => {
+      const provenance = resolveCoreModelRequestLifecycleDiagnosticMetadata(metadata);
+      if (
+        event.type !== "model.call.started" ||
+        event.provider !== "openai" ||
+        provenance?.phase !== "started"
+      ) {
+        return;
+      }
+      const traceparent = formatPropagatedDiagnosticTraceparent(event.trace);
+      if (!traceparent) {
+        return;
+      }
+      if (dispatches.size >= OPENAI_ULTRA_WIRE_CAPTURE_LIMIT) {
+        overflow = true;
+        return;
+      }
+      dispatches.set(traceparent, {
+        model: event.model,
+        generation: provenance.generation,
+        facts: {
+          runId: event.runId,
+          callId: event.callId,
+          ...(event.sessionKey ? { sessionKey: event.sessionKey } : {}),
+          ...(event.sessionId ? { sessionId: event.sessionId } : {}),
+        },
+      });
+    },
+    { include: ["model.call.started"] },
+  );
   const host = getAiTransportHost();
   // Changing baseUrl to a capture proxy changes native OpenAI schema policy.
   // The guarded client bypasses global fetch for pinned dispatchers, so observe
@@ -4068,15 +4200,74 @@ function startOpenAIUltraWireCapture(upstreamBaseUrls: readonly string[]): OpenA
         const url =
           typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
         if (endpoints.has(url) && typeof init?.body === "string") {
-          observations.push(readOpenAIUltraWireObservation(init.body));
+          if (observations.length >= OPENAI_ULTRA_WIRE_CAPTURE_LIMIT) {
+            overflow = true;
+          } else {
+            const traceparent = formatDiagnosticTraceparent(
+              parseDiagnosticTraceparent(new Headers(init.headers).get("traceparent") ?? undefined),
+            );
+            // Snapshot only the exact live writer/stream/admission intersection.
+            // Queued diagnostics may outlive cleanup or a same-id replacement.
+            const fence = getOwnedSessionTranscriptWriterFence();
+            const runId = fence?.expectedWriterRunId;
+            const handle = runId ? ACTIVE_EMBEDDED_RUNS_BY_RUN_ID.get(runId) : undefined;
+            const diagnostic = handle?.diagnosticOwner;
+            const context = runId ? getAgentRunContext(runId) : undefined;
+            const authority = context?.delegatedAuthority;
+            const ownsRequest =
+              runId &&
+              diagnostic &&
+              context &&
+              authority &&
+              diagnostic.runId === runId &&
+              ACTIVE_EMBEDDED_RUNS.get(diagnostic.sessionId) === handle &&
+              !isDiagnosticEmbeddedRunOwnerClosed(diagnostic) &&
+              handle?.isAborted?.() !== true &&
+              context.sessionId === diagnostic.sessionId &&
+              context.sessionKey === diagnostic.sessionKey &&
+              context.lifecycleGeneration === getAgentRunLifecycleGeneration() &&
+              captureAgentRunLifecycleGeneration(runId) === context.lifecycleGeneration &&
+              validateAgentRunDelegatedAuthority(authority);
+            observations.push({
+              ...readOpenAIUltraWireObservation(init.body),
+              ...(ownsRequest && typeof context.isHeartbeat === "boolean"
+                ? { owner: { diagnostic, isHeartbeat: context.isHeartbeat } }
+                : {}),
+              requestIndex: observations.length + 1,
+              ...(traceparent ? { traceparent } : {}),
+            });
+          }
         }
         return fetchModel(input, init);
       }) as typeof fetch;
     },
   });
   return {
-    observations,
+    get observations() {
+      if (overflow) {
+        throw new Error(`Ultra wire capture exceeded ${OPENAI_ULTRA_WIRE_CAPTURE_LIMIT} records`);
+      }
+      // Dispatch events arrive asynchronously. Join only exact per-call traces;
+      // same-model timing, prompt text, and inherited session scope cannot establish purpose.
+      return observations.map(({ owner, ...entry }) => {
+        const dispatch = entry.traceparent ? dispatches.get(entry.traceparent) : undefined;
+        const matchesOwner =
+          owner &&
+          dispatch &&
+          owner.diagnostic.generation === dispatch.generation &&
+          owner.diagnostic.runId === dispatch.facts.runId &&
+          owner.diagnostic.sessionId === dispatch.facts.sessionId &&
+          owner.diagnostic.sessionKey === dispatch.facts.sessionKey;
+        return Object.assign(entry, {
+          dispatch:
+            dispatch && dispatch.model === entry.model
+              ? { ...dispatch.facts, ...(matchesOwner ? { isHeartbeat: owner.isHeartbeat } : {}) }
+              : null,
+        });
+      });
+    },
     close: () => {
+      stopDiagnostics();
       configureAiTransportHost(host);
     },
   };
@@ -4105,7 +4296,289 @@ async function closeUltraWireTestServer(
   });
 }
 
+function createOpenAIUltraTestRun(purpose: string) {
+  const runId = `${purpose}-run`;
+  const sessionId = `${purpose}-session`;
+  const sessionKey = `agent:dev:${purpose}`;
+  const diagnosticOwner = createDiagnosticEmbeddedRunOwner({ runId, sessionId, sessionKey });
+  const handle = {
+    runId,
+    diagnosticOwner,
+    closeDiagnostics: () => closeDiagnosticEmbeddedRunOwner(diagnosticOwner),
+    queueMessage: async () => {},
+    isStreaming: () => true,
+    isAborted: () => false,
+    isCompacting: () => false,
+    abort: () => {},
+  };
+  registerAgentRunContext(runId, { sessionId, sessionKey, isHeartbeat: true });
+  const authority = claimAgentRunDelegatedAuthority({ runId, instanceId: randomUUID() });
+  setActiveEmbeddedRun(sessionId, handle, sessionKey);
+  return {
+    runId,
+    sessionId,
+    sessionKey,
+    handle,
+    authority,
+    close: () => {
+      clearActiveEmbeddedRun(sessionId, handle, sessionKey);
+      releaseAgentRunDelegatedAuthority(authority);
+      clearAgentRunContext(runId);
+    },
+  };
+}
+
 describe("OpenAI Ultra wire capture", () => {
+  it("checks every interleaved request against its admitted intent", async () => {
+    const endpoint = "https://api.openai.com/v1/responses";
+    const host = getAiTransportHost();
+    const transport = vi.fn<typeof fetch>().mockImplementation(async () => new Response("ok"));
+    configureAiTransportHost({ ...host, buildModelFetch: () => transport });
+    const capture = startOpenAIUltraWireCapture(["https://api.openai.com/v1"]);
+    const model = createGatewayLiveTestModel("openai", "gpt-5.6-luna");
+    const fetchModel = expectDefined(getAiTransportHost().buildModelFetch(model), "model fetch");
+    // Even a heartbeat flag on accepted probe/child admissions cannot lower Ultra.
+    const probe = createOpenAIUltraTestRun("probe");
+    const child = createOpenAIUltraTestRun("child");
+    const heartbeat = createOpenAIUltraTestRun("heartbeat");
+    const runs = [probe, child, heartbeat];
+    const ultraRuns = new Map([probe, child].map((run) => [run.runId, run.sessionKey]));
+    const send = async (run: (typeof runs)[number], effort: string, call: number) => {
+      const trace = createDiagnosticTraceContext();
+      emitCoreModelRequestStartedDiagnosticEvent(
+        {
+          runId: run.runId,
+          sessionId: run.sessionId,
+          sessionKey: run.sessionKey,
+          provider: "openai",
+          model: model.id,
+          callId: `${run.runId}:${call}`,
+          trace,
+        },
+        run.handle.diagnosticOwner.generation,
+      );
+      await withOwnedSessionTranscriptWrites(
+        {
+          sessionTarget: { expectedWriterRunId: run.runId },
+          withTranscriptWrite: async (write) => await write(),
+        },
+        async () =>
+          await fetchModel(endpoint, {
+            method: "POST",
+            headers: { traceparent: formatDiagnosticTraceparent(trace)! },
+            body: JSON.stringify({ model: model.id, reasoning: { effort } }),
+          }),
+      );
+    };
+    try {
+      await send(probe, "max", 1);
+      await send(heartbeat, "medium", 1);
+      await send(child, "max", 1);
+      await send(probe, "max", 2);
+      await send(child, "max", 2);
+      const beforeDelivery = capture.observations;
+      await waitForDiagnosticEventsDrained();
+      for (const run of runs) {
+        run.close();
+      }
+      expect(runs.every((run) => getAgentRunContext(run.runId) === undefined)).toBe(true);
+      expect(beforeDelivery.every((entry) => entry.dispatch === null)).toBe(true);
+      const observations = capture.observations;
+      expect(observations.map((entry) => entry.dispatch?.isHeartbeat)).toEqual([
+        true,
+        true,
+        true,
+        true,
+        true,
+      ]);
+      expect(transport).toHaveBeenCalledTimes(5);
+      const childContinuation = observations.with(1, {
+        ...observations[1],
+        dispatch: {
+          runId: "continuation-run",
+          callId: "continuation-call",
+          sessionKey: child.sessionKey,
+          isHeartbeat: true,
+        },
+      });
+      expect(() =>
+        assertOpenAIUltraWireEffort({
+          expectedModel: model.id,
+          observations: childContinuation,
+          ultraRuns,
+        }),
+      ).toThrow(/observed=medium request=2/);
+      expect(
+        assertOpenAIUltraWireEffort({ expectedModel: model.id, observations, ultraRuns }),
+      ).toBe(5);
+      // A lost explicit override on a medium-default fixture is a failure, as are
+      // downgrades on descendants/continuations and a heartbeat elevated to max.
+      for (const [index, entry] of observations.entries()) {
+        const wrongEfforts = index === 1 ? ["low", "max"] : ["low", "medium"];
+        for (const reasoningEffort of wrongEfforts) {
+          const changed = observations.with(index, { ...entry, reasoningEffort });
+          expect(() =>
+            assertOpenAIUltraWireEffort({
+              expectedModel: model.id,
+              observations: changed,
+              ultraRuns,
+            }),
+          ).toThrow(`request=${index + 1}`);
+        }
+      }
+      // Unattributed traffic still participates; a passing majority cannot hide it.
+      await fetchModel(endpoint, {
+        method: "POST",
+        body: JSON.stringify({ model: model.id, reasoning: { effort: "low" } }),
+      });
+      expect(() =>
+        assertOpenAIUltraWireEffort({
+          expectedModel: model.id,
+          observations: capture.observations,
+          ultraRuns,
+        }),
+      ).toThrow(/observed=low request=6 run=unknown/);
+    } finally {
+      for (const run of runs) {
+        run.close();
+      }
+      capture.close();
+      configureAiTransportHost(host);
+    }
+  });
+
+  it.each([
+    "untrusted event",
+    "missing writer",
+    "wrong event session",
+    "wrong registry session",
+    "stale stream generation",
+    "released admission",
+    "stale lifecycle",
+    "closed stream owner",
+    "aborted stream",
+  ])("cannot grant medium effort from %s attribution", async (fault) => {
+    const host = getAiTransportHost();
+    configureAiTransportHost({ ...host, buildModelFetch: () => async () => new Response("ok") });
+    const capture = startOpenAIUltraWireCapture(["https://api.openai.com/v1"]);
+    const model = createGatewayLiveTestModel("openai", "gpt-5.6-luna");
+    const fetchModel = expectDefined(getAiTransportHost().buildModelFetch(model), "model fetch");
+    const run = createOpenAIUltraTestRun("invalid-heartbeat");
+    const trace = createDiagnosticTraceContext();
+    const event = {
+      runId: run.runId,
+      sessionId: run.sessionId,
+      sessionKey: run.sessionKey,
+      provider: "openai",
+      model: model.id,
+      callId: "invalid-call",
+      trace,
+    };
+    try {
+      if (fault === "wrong event session") {
+        event.sessionId = "other-session";
+      }
+      if (fault === "wrong registry session") {
+        registerAgentRunContext(run.runId, { sessionId: "other-session" });
+      }
+      if (fault === "released admission") {
+        releaseAgentRunDelegatedAuthority(run.authority);
+      }
+      if (fault === "aborted stream") {
+        run.handle.isAborted = () => true;
+      }
+      if (fault === "closed stream owner") {
+        closeDiagnosticEmbeddedRunOwner(run.handle.diagnosticOwner);
+      }
+      if (fault === "untrusted event") {
+        emitTrustedDiagnosticEvent({ ...event, type: "model.call.started" });
+      } else {
+        emitCoreModelRequestStartedDiagnosticEvent(
+          event,
+          fault === "stale stream generation" ? {} : run.handle.diagnosticOwner.generation,
+        );
+      }
+      await withAgentRunLifecycleGeneration(
+        fault === "stale lifecycle" ? "retired-lifecycle" : getAgentRunLifecycleGeneration(),
+        () =>
+          withOwnedSessionTranscriptWrites(
+            {
+              sessionTarget: fault === "missing writer" ? {} : { expectedWriterRunId: run.runId },
+              withTranscriptWrite: async (write) => await write(),
+            },
+            async () =>
+              await fetchModel("https://api.openai.com/v1/responses", {
+                method: "POST",
+                headers: { traceparent: formatDiagnosticTraceparent(trace)! },
+                body: JSON.stringify({ model: model.id, reasoning: { effort: "medium" } }),
+              }),
+          ),
+      );
+      await waitForDiagnosticEventsDrained();
+      expect(capture.observations).toHaveLength(1);
+      expect(capture.observations[0]?.dispatch?.isHeartbeat).toBeUndefined();
+      expect(() =>
+        assertOpenAIUltraWireEffort({
+          expectedModel: model.id,
+          observations: capture.observations,
+          ultraRuns: new Map(),
+        }),
+      ).toThrow(/observed=medium request=1/);
+    } finally {
+      run.close();
+      capture.close();
+      configureAiTransportHost(host);
+    }
+  });
+
+  it("fails closed when the bounded capture fills without interrupting transport", async () => {
+    const host = getAiTransportHost();
+    const transport = vi.fn<typeof fetch>().mockImplementation(async () => new Response("ok"));
+    configureAiTransportHost({ ...host, buildModelFetch: () => transport });
+    const capture = startOpenAIUltraWireCapture(["https://api.openai.com/v1"]);
+    const model = createGatewayLiveTestModel("openai", "gpt-5.6-sol");
+    const fetchModel = expectDefined(getAiTransportHost().buildModelFetch(model), "model fetch");
+    try {
+      for (let index = 0; index <= OPENAI_ULTRA_WIRE_CAPTURE_LIMIT; index += 1) {
+        await fetchModel("https://api.openai.com/v1/responses", {
+          method: "POST",
+          body: JSON.stringify({ model: model.id, reasoning: { effort: "max" } }),
+        });
+      }
+      expect(transport).toHaveBeenCalledTimes(OPENAI_ULTRA_WIRE_CAPTURE_LIMIT + 1);
+      expect(() => capture.observations).toThrow(/Ultra wire capture exceeded/);
+    } finally {
+      capture.close();
+      configureAiTransportHost(host);
+    }
+  });
+
+  it.each(["low", undefined])(
+    "keeps the actual %s effort violation after passing requests in the aggregate preview",
+    (reasoningEffort) => {
+      const model = "gpt-5.6-sol";
+      const observations = Array.from({ length: 20 }, () => ({
+        model,
+        reasoningEffort: "max",
+      }));
+      let failure: unknown;
+      try {
+        assertOpenAIUltraWireEffort({
+          expectedModel: model,
+          observations: [...observations, { model, reasoningEffort }],
+          ultraRuns: new Map(),
+        });
+      } catch (error) {
+        failure = error;
+      }
+      expect(failure).toBeInstanceOf(Error);
+      const preview = formatFailurePreview([{ model, error: String(failure) }], 20);
+      expect(preview).toContain(`observed=${reasoningEffort ?? "missing"}`);
+      expect(preview).toContain("request=21");
+      expect(preview).not.toContain("...");
+    },
+  );
+
   it("observes the selected native endpoint without rerouting the request", async () => {
     const endpoint = "https://api.openai.com/v1/responses";
     const response = new Response("data: done\n\n", {
@@ -4142,6 +4615,8 @@ describe("OpenAI Ultra wire capture", () => {
           model: "gpt-5.6-sol",
           reasoningEffort: "max",
           sessionsSpawn: { strict: false, categoryRequired: false },
+          requestIndex: 1,
+          dispatch: null,
         },
       ]);
       await fetchModel("https://api.openai.com/v1/other", request);
@@ -4192,7 +4667,9 @@ describe("OpenAI Ultra wire capture", () => {
       const reader = expectDefined(response.body, "stream body").getReader();
       expect(new TextDecoder().decode((await reader.read()).value)).toBe("data: open\n\n");
       expect(upstreamAuthorization).toBe("Bearer test-only");
-      expect(capture.observations).toEqual([{ model: "gpt-5.6-sol", reasoningEffort: "max" }]);
+      expect(capture.observations).toEqual([
+        { model: "gpt-5.6-sol", reasoningEffort: "max", requestIndex: 1, dispatch: null },
+      ]);
       capture.close();
       expect(getAiTransportHost().buildModelFetch).toBe(host.buildModelFetch);
       expect(upstreamClosed).toBe(false);
@@ -4246,19 +4723,48 @@ function resolveOpenAIUltraUpstreamBaseUrl(params: {
 function assertOpenAIUltraWireEffort(params: {
   expectedModel: string;
   observations: OpenAIUltraWireObservation[];
+  ultraRuns: ReadonlyMap<string, string>;
 }): number {
   const matching = params.observations.filter((entry) => entry.model === params.expectedModel);
   expect(
     matching.length,
-    `expected captured OpenAI requests for ${params.expectedModel}; observations=${JSON.stringify(
-      params.observations,
-    )}`,
+    `expected captured OpenAI requests for ${params.expectedModel}; captured=${params.observations.length}`,
   ).toBeGreaterThan(0);
+  const ultraSessions = new Set(params.ultraRuns.values());
+  const expectedEffort = ({ dispatch }: OpenAIUltraWireObservation) =>
+    dispatch?.isHeartbeat === true &&
+    !params.ultraRuns.has(dispatch.runId) &&
+    !ultraSessions.has(dispatch.sessionKey ?? "")
+      ? OPENAI_ULTRA_NORMAL_EFFORT
+      : "max";
+  const heartbeats = matching.filter(
+    (entry) => expectedEffort(entry) === OPENAI_ULTRA_NORMAL_EFFORT,
+  );
+  if (heartbeats.length) {
+    logProgress(
+      `[ultra] ${params.expectedModel}: independent_heartbeats=${heartbeats.length} first=${JSON.stringify(heartbeats.slice(0, 3))}`,
+    );
+  }
+  const violations = matching.flatMap((entry, index) =>
+    entry.reasoningEffort === expectedEffort(entry)
+      ? []
+      : [
+          {
+            ...entry,
+            requestIndex: entry.requestIndex ?? index + 1,
+            expectedEffort: expectedEffort(entry),
+          },
+        ],
+  );
+  const first = violations[0];
+  if (first) {
+    logProgress(
+      `[ultra] ${params.expectedModel}: violations=${violations.length}/${matching.length} first=${JSON.stringify(violations.slice(0, 3))}`,
+    );
+  }
   expect(
-    matching.every((entry) => entry.reasoningEffort === "max"),
-    `expected Ultra to use wire effort=max for ${params.expectedModel}; observations=${JSON.stringify(
-      matching,
-    )}`,
+    matching.every((entry) => entry.reasoningEffort === expectedEffort(entry)),
+    `expected effort=${first?.expectedEffort ?? "max"} for ${params.expectedModel}; observed=${first?.reasoningEffort ?? "missing"} request=${first?.requestIndex} run=${first?.dispatch?.runId ?? "unknown"}; violations=${violations.length}/${matching.length}`,
   ).toBe(true);
   const spawnSchemas = [
     ...new Set(
@@ -4268,7 +4774,7 @@ function assertOpenAIUltraWireEffort(params: {
     ),
   ];
   logProgress(
-    `[ultra] ${params.expectedModel}: sessions_spawn wire schemas=${spawnSchemas.join(",")}`,
+    `[ultra] ${params.expectedModel}: checked=${matching.length} max=${matching.length - heartbeats.length} medium=${heartbeats.length} sessions_spawn wire schemas=${spawnSchemas.join(",")}`,
   );
   return matching.length;
 }
@@ -4932,6 +5438,17 @@ async function runGatewayModelSuite(params: GatewayModelSuiteParams) {
     const sanitizedCfg: OpenClawConfig = {
       ...params.cfg,
       auth: sanitizeAuthConfig({ cfg: params.cfg, store: isolatedStore }),
+      ...(ultraCandidates.length > 0
+        ? {
+            agents: {
+              ...params.cfg.agents,
+              defaults: {
+                ...params.cfg.agents?.defaults,
+                thinkingDefault: OPENAI_ULTRA_NORMAL_EFFORT,
+              },
+            },
+          }
+        : {}),
     };
     if (ultraCandidates.length > 0) {
       await import("../agents/ai-transport-runtime-host.js");
@@ -4985,6 +5502,9 @@ async function runGatewayModelSuite(params: GatewayModelSuiteParams) {
         }),
         `${params.label}: gateway-connect`,
       );
+      if (ultraWireCapture) {
+        openAIUltraRunsByClient.set(client, new Map());
+      }
     } catch (error) {
       const message = String(error);
       if (isGatewayLiveProbeTimeout(message)) {
@@ -5023,7 +5543,6 @@ async function runGatewayModelSuite(params: GatewayModelSuiteParams) {
       const progressLabel = `[${params.label}] ${index + 1}/${total} ${modelKey}`;
       const strictUltraProof = isOpenAIGpt56UltraTarget(model, params.thinkingLevel);
       const skippedBeforeModel = skippedCount;
-      const wireObservationStart = ultraWireCapture?.observations.length ?? 0;
       const thinkingLevel = resolveGatewayLiveModelThinkingLevel({
         model,
         requestedLevel: params.thinkingLevel,
@@ -5041,7 +5560,7 @@ async function runGatewayModelSuite(params: GatewayModelSuiteParams) {
           label: params.label,
           modelIndex: index,
           modelKey,
-          ...(strictUltraProof ? { thinkingLevel } : {}),
+          ...(strictUltraProof ? { thinkingLevel: OPENAI_ULTRA_NORMAL_EFFORT } : {}),
         });
         const sessionKey = session.key;
         if (model.provider === "anthropic" && anthropicKeys.length > 0) {
@@ -5060,7 +5579,7 @@ async function runGatewayModelSuite(params: GatewayModelSuiteParams) {
                   sessionKey,
                   expectedProvider: normalizeProviderId(model.provider),
                   expectedModelId: model.id,
-                  expectedThinkingLevel: thinkingLevel,
+                  expectedThinkingLevel: OPENAI_ULTRA_NORMAL_EFFORT,
                 });
               }
 
@@ -5463,20 +5982,6 @@ async function runGatewayModelSuite(params: GatewayModelSuiteParams) {
                   thinkingLevel,
                 });
               }
-              if (strictUltraProof) {
-                if (!ultraWireCapture) {
-                  throw new Error(`${modelKey}: missing Ultra wire capture`);
-                }
-                // Check every request made by the passing model lane, including
-                // child and tool-followup turns, so later paths cannot downgrade.
-                const capturedRequestCount = assertOpenAIUltraWireEffort({
-                  expectedModel: model.id,
-                  observations: ultraWireCapture.observations.slice(wireObservationStart),
-                });
-                logProgress(
-                  `${progressLabel}: ultra wire effort=max captured_requests=${capturedRequestCount}`,
-                );
-              }
               return "done";
             })(),
             `${progressLabel}: model`,
@@ -5685,6 +6190,28 @@ async function runGatewayModelSuite(params: GatewayModelSuiteParams) {
       }
     }
 
+    if (ultraWireCapture) {
+      // Settle all producers before one stable snapshot. Failed lanes and late
+      // same-model work must be checked too, without replacing their original failures.
+      await server.close({ reason: "live test complete" });
+      server = undefined;
+      await waitForDiagnosticEventsDrained();
+      const observations = ultraWireCapture.observations;
+      for (const model of ultraCandidates) {
+        try {
+          assertOpenAIUltraWireEffort({
+            expectedModel: model.id,
+            observations,
+            ultraRuns: expectDefined(
+              openAIUltraRunsByClient.get(client),
+              "Ultra admission receipts",
+            ),
+          });
+        } catch (error) {
+          failures.push({ model: `${model.provider}/${model.id}`, error: String(error) });
+        }
+      }
+    }
     if (failures.length > 0) {
       const preview = formatFailurePreview(failures, 20);
       throw new Error(
@@ -5701,6 +6228,9 @@ async function runGatewayModelSuite(params: GatewayModelSuiteParams) {
   } finally {
     clearRuntimeConfigSnapshot();
     client?.stop();
+    if (client) {
+      openAIUltraRunsByClient.delete(client);
+    }
     try {
       try {
         if (server) {


### PR DESCRIPTION
Related: #131758

## What Problem This Solves

Resolves a problem where the live Ultra fixture treats every request for a selected model as an Ultra probe, including independently admitted heartbeats using the normal Medium default. Its success-only observation window also misses late requests and requests from a failed model lane, while an Ultra session default can conceal a lost explicit override.

## Why This Change Was Made

Keep the existing native HTTP capture and request policy from #131758. Start the fixture and probe sessions at Medium, then require the explicit Ultra requests to override that state. Accepted probe runs, spawned children, and receipt-bound session continuations must all use Max on the wire, even if a heartbeat flag is present.

Medium is accepted only for an independently admitted heartbeat whose exact HTTP writer, active stream, live claim, lifecycle, core diagnostic generation, and trace agree. These requests are checked, not ignored. Unknown requests still require Max, capture overflow fails at 512 records, and one final snapshot after Gateway close checks every matching request, including failed lanes and late calls. The original lane failures are retained alongside capture failures.

## User Impact

No production behavior changes. Maintainers get a stronger Ultra release proof that detects a lost explicit override without misclassifying a separately owned heartbeat. This does not modify the native Codex harness tracked in #128481.

## Evidence

Current-main author base `383a293b32d97254014437430b62aaf406bc11ac`, head `ffb1bd6f9311c976281de48b333bbe65c83c26c3`, tree `0d239cd6192bf8a266b1d2601dd31892488ea60d`. Fresh restricted Codex P0 review of the complete one-file delta passed with no findings, retaining the unchanged secret scan and isolation. The local full offline file invocation reached the existing 120-second no-output watchdog before any case was reported (exit 143); that failure is retained. No assertion, retry or timeout was changed. The local full changed gate passed, including all three unused-export scans, core test types and lint. Fresh isolated Linux proof on that exact published head passed **161 offline tests with 2 live skips**, in 32.39 s, using Node 24.19.0 and pnpm 12.0.0, fresh HOME and no credential hydration. The same full-file command above ran with `CI=1`; no watchdog or limit was changed. This is current-main offline proof, separate from the original-source live receipts below. Remote coordinator heartbeat/event-upload warnings occurred but the actual command completed successfully; the complete local log retains them.

```sh
env -u OPENCLAW_LIVE_TEST -u LIVE -u OPENCLAW_LIVE_GATEWAY -u OPENCLAW_LIVE_USE_REAL_HOME OPENCLAW_VITEST_MAX_WORKERS=2 node scripts/run-vitest.mjs run --config test/vitest/vitest.live.config.ts src/gateway/gateway-models.profiles.live.test.ts
OPENCLAW_VITEST_MAX_WORKERS=2 node scripts/check-changed.mjs --base 383a293b32d97254014437430b62aaf406bc11ac -- src/gateway/gateway-models.profiles.live.test.ts
```

The complete earlier repaired-source Linux suite passed 161 offline cases (2 live skips), then 163 cases in the live run (1 optional long-context skip), in 165.09 seconds. All 46 captured requests were checked and returned HTTP 200: Sol 15, Terra 15, Luna 16, all Max; 21 accepted probes and 3 delivered children were recorded. [Final exact-source proof lease](https://github.com/openclaw/openclaw/actions/runs/33229123918) used source tree `bfa7b031d8712874405b21855d7a8c86922511e6` at `804574dd39ba9cda0a402ed49c367e0b9b4f0e33`, over a verified Linux warm environment. These are original-source receipts, not new-main live results.

A [separate earlier proof](https://github.com/openclaw/openclaw/actions/runs/33228625435) on `75384d8da936decbffc8836f34db79c141f5ed93` checked all 58 requests: 53 Max plus 5 proven Medium heartbeats. That observed heartbeat coverage is not relabeled as coverage from the final 804574d run, which contained no heartbeats. Deterministic adversarial cases cover stale/replaced/closed owners, forged diagnostic fields, trace mismatch, known probe and child ownership, session continuations, capture overflow, and preservation of existing failures.

Source evidence map: the fixture records accepted RPC and child receipts; `getOwnedSessionTranscriptWriterFence` binds the HTTP call to its admitted writer; `agent-run-registry.ts` owns current claims and lifecycle; `run-state.ts` and `runs.ts` own exact active handles; `diagnostic-run-activity.ts` freezes and retires diagnostic owners; `attempt.model-diagnostic-lifecycle.ts` stamps the request trace and call ID; core diagnostic provenance is object-bound. All these referenced owners and the fixture were unchanged from the original source base to author base `59dad71c416bcd9d649323c5f17fecdc31fd526a`.

Test audit/LOC: production **0**; one existing live fixture/test-support file **+563/-33**. The bounded observer and adversarial checks justify that test growth; there is no new production seam or general tracing framework. No model policy, timeout, retry, selector, dependency, configuration, schema, or runtime changes.

Remaining gaps: the original clipped CI offender could not be identified from that log, and the historical Terra child-delivery failure is not claimed fixed. The original full release campaign remains red. All earlier proof leases were stopped.
