### PR TITLE
fix(release): make FRV reruns write-once

### DIFF
--- a/.agents/skills/release-openclaw-ci/SKILL.md
+++ b/.agents/skills/release-openclaw-ci/SKILL.md
@@ -166,7 +166,10 @@ until their dependent enforcement changes land.
   adopts any active newer child attempt, reruns failed child jobs in parallel,
   leaves green children untouched, then reruns the parent once to restore the
   immutable plan and seal a trusted all-group manifest. It does not start a
-  second child retry while an attempt is active.
+  second child retry while an attempt is active. Each child or parent rerun
+  mutation is sent exactly once; ambiguous transport failures trigger only
+  bounded read reconciliation. The controller never repeats the mutation, and
+  provenance drift fails closed.
 - Inspect without mutation:
 
   ```bash

--- a/docs/reference/full-release-validation.md
+++ b/docs/reference/full-release-validation.md
@@ -96,6 +96,11 @@ child attempts, and writes the final all-group manifest. The manifest records
 the planned and effective attempt, accepted attempt for every logical job, and
 a digest of the composite job evidence.
 
+Each child or parent rerun mutation is sent exactly once. If GitHub returns an
+ambiguous transient error, the controller performs read-only reconciliation
+until the newer attempt becomes visible or the bounded reconciliation deadline
+expires. It never repeats the mutation, and provenance drift fails closed.
+
 The command stores no continuation ledger or local journal. GitHub run
 attempts, the immutable execution plan, Decision/Drain artifacts, and the final
 manifest are the complete state model. It never tags, publishes, changes a

--- a/scripts/frv.d.mts
+++ b/scripts/frv.d.mts
@@ -26,6 +26,7 @@ export interface FrvClient {
     runId: string,
     plan: Record<string, unknown>,
     operationDeadline?: number,
+    expectedRunAttempts?: Record<string, number>,
   ) => Promise<unknown>;
 }
 

--- a/scripts/frv.d.mts
+++ b/scripts/frv.d.mts
@@ -28,10 +28,16 @@ export interface FrvClient {
     operationDeadline?: number,
     expectedRunAttempts?: Record<string, number>,
   ) => Promise<unknown>;
+  verifySeal?: (
+    runId: string,
+    plan: Record<string, unknown>,
+    operationDeadline: number,
+    expectedRunAttempts: Record<string, number>,
+  ) => Promise<boolean>;
 }
 
 export type FrvConcreteClient = FrvClient &
-  Required<Pick<FrvClient, "rerunFailed" | "rerunParent" | "verify">>;
+  Required<Pick<FrvClient, "rerunFailed" | "rerunParent" | "verify" | "verifySeal">>;
 
 export function inspectContinuation(
   plan: Record<string, unknown>,

--- a/scripts/frv.mjs
+++ b/scripts/frv.mjs
@@ -394,11 +394,13 @@ export function createClient(repository, dependencies = {}) {
           : ["api", `repos/${repository}/${path}`],
       ));
   const mutate = dependencies.mutate ?? ((args) => execGh(args));
+  const rerun = (runId, action) =>
+    mutate(["api", "-X", "POST", `repos/${repository}/actions/runs/${runId}/${action}`]);
   const execute = dependencies.execCommand ?? execCommand;
   const attemptJobs =
     dependencies.getAttemptJobs ??
     ((runId, runAttempt) => ghAttemptJobs(repository, runId, runAttempt));
-  const client = {
+  return {
     repository,
     getAttemptJobs(runId, runAttempt) {
       return attemptJobs(runId, runAttempt);
@@ -424,13 +426,8 @@ export function createClient(repository, dependencies = {}) {
     getJobLog(jobId) {
       return apiText(`actions/jobs/${jobId}/logs`);
     },
-    async rerunFailed(runId) {
-      await mutate(["run", "rerun", runId, "--repo", repository, "--failed"]);
-    },
-    async rerunParent(runId) {
-      await mutate(["run", "rerun", runId, "--repo", repository]);
-      return runId;
-    },
+    rerunFailed: (runId) => rerun(runId, "rerun-failed-jobs"),
+    rerunParent: (runId) => rerun(runId, "rerun"),
     async verify(runId, plan, operationDeadline = createOperationDeadline()) {
       const sourceSha = plan.trustedWorkflow?.sha;
       return execute(
@@ -459,19 +456,34 @@ export function createClient(repository, dependencies = {}) {
       );
     },
   };
-  return client;
 }
 
-async function waitForTerminal(runIds, client, operationDeadline, minimumAttempts = new Map()) {
-  validateOperationDeadline(operationDeadline);
+function controllerRunAttempt(run, sourceAttempt, expectedAttempt) {
+  const runId = String(run.id);
+  const observedAttempt = positiveInteger(run.run_attempt, `${runId} run attempt`);
+  switch (true) {
+    case observedAttempt < sourceAttempt:
+      throw new Error(`rerun source ${runId} attempt regressed`);
+    case observedAttempt > expectedAttempt:
+      throw new Error(`controller-owned run ${runId} advanced past attempt ${expectedAttempt}`);
+    default:
+      return observedAttempt;
+  }
+}
+
+async function waitForTerminal(runIds, client, operationDeadline, expectedAttempts = new Map()) {
   const pollMs = configuredTimeout("OPENCLAW_FRV_POLL_MS", DEFAULT_POLL_MS);
   while (Date.now() < operationDeadline) {
     const runs = await Promise.all(runIds.map((runId) => client.getRun(runId)));
-    const ready = runs.every(
-      (run) =>
-        run.status === "completed" &&
-        Number(run.run_attempt) >= Number(minimumAttempts.get(String(run.id)) ?? 1),
-    );
+    const ready = runs.every((run) => {
+      const runId = String(run.id);
+      const expectedAttempt = expectedAttempts.get(runId);
+      if (expectedAttempt === undefined) {
+        return run.status === "completed";
+      }
+      const observedAttempt = controllerRunAttempt(run, expectedAttempt - 1, expectedAttempt);
+      return run.status === "completed" && observedAttempt === expectedAttempt;
+    });
     if (ready) {
       return runs;
     }
@@ -487,18 +499,21 @@ async function reconcileAttemptStarts(
   mutationResults,
   operationDeadline,
 ) {
-  validateOperationDeadline(operationDeadline);
-  const reconcileStartedAt = Date.now();
-  const reconcileTimeoutMs = configuredTimeout(
-    "OPENCLAW_FRV_RECONCILE_TIMEOUT_MS",
-    DEFAULT_RECONCILE_TIMEOUT_MS,
+  const reconcileDeadline = Math.min(
+    operationDeadline,
+    Date.now() +
+      configuredTimeout("OPENCLAW_FRV_RECONCILE_TIMEOUT_MS", DEFAULT_RECONCILE_TIMEOUT_MS),
   );
-  const pending = new Set(minimumAttempts.keys());
-  while (
-    pending.size > 0 &&
-    Date.now() < operationDeadline &&
-    Date.now() - reconcileStartedAt < reconcileTimeoutMs
-  ) {
+  const hardFailures = mutationResults.filter(
+    (result) =>
+      result.status === "rejected" && classifyReleaseGhTransportError(result.reason) === "hard",
+  );
+  const pending = new Set(
+    [...minimumAttempts.keys()].filter(
+      (_, index) => !hardFailures.includes(mutationResults[index]),
+    ),
+  );
+  while (pending.size > 0 && Date.now() < reconcileDeadline) {
     const runs = await Promise.all([...pending].map((runId) => client.getRun(runId)));
     for (const run of runs) {
       const runId = String(run.id);
@@ -506,52 +521,37 @@ async function reconcileAttemptStarts(
       if (JSON.stringify(runIdentity(run)) !== JSON.stringify(runIdentity(priorRun))) {
         throw new Error(`rerun source ${runId} changed during mutation reconciliation`);
       }
-      if (Number(run.run_attempt) >= minimumAttempts.get(runId)) {
+      const sourceAttempt = positiveInteger(priorRun.run_attempt, `${runId} source run attempt`);
+      const expectedAttempt = minimumAttempts.get(runId);
+      const observedAttempt = controllerRunAttempt(run, sourceAttempt, expectedAttempt);
+      if (observedAttempt === expectedAttempt) {
         pending.delete(runId);
-        continue;
-      }
-      if (
-        JSON.stringify(exactTerminalRunState(run, runId)) !==
-        JSON.stringify(exactTerminalRunState(priorRun, runId))
-      ) {
-        throw new Error(`rerun source ${runId} changed during mutation reconciliation`);
       }
     }
     if (pending.size > 0) {
-      const remainingReconcileTime = reconcileTimeoutMs - (Date.now() - reconcileStartedAt);
-      if (remainingReconcileTime < 1) {
-        break;
-      }
       await sleep(
         Math.min(
           configuredTimeout("OPENCLAW_FRV_POLL_MS", DEFAULT_POLL_MS),
           remainingOperationTime(operationDeadline),
-          remainingReconcileTime,
+          reconcileDeadline - Date.now(),
         ),
       );
     }
   }
   remainingOperationTime(operationDeadline);
   if (pending.size > 0) {
-    const failures = mutationResults
-      .map((result, index) =>
-        result.status === "rejected"
-          ? `${[...minimumAttempts.keys()][index]}: ${
-              result.reason instanceof Error ? result.reason.message : String(result.reason)
-            }`
-          : "",
-      )
-      .filter(Boolean);
     throw new Error(
-      `rerun mutation did not produce an observable newer attempt for ${[...pending].join(
-        ", ",
-      )}${failures.length > 0 ? ` (${failures.join("; ")})` : ""}`,
+      `rerun mutation did not produce an observable newer attempt for ${[...pending].join(", ")}`,
     );
+  }
+  if (hardFailures[0]) {
+    throw hardFailures[0].reason;
   }
 }
 
 function runIdentity(run) {
   return {
+    actor: String(run.actor?.login ?? ""),
     displayTitle: String(run.display_title ?? ""),
     event: String(run.event ?? ""),
     headBranch: String(run.head_branch ?? ""),
@@ -567,10 +567,8 @@ function exactTerminalRunState(run, runId) {
     ...runIdentity(run),
     conclusion: run.conclusion ?? null,
     runAttempt: positiveInteger(run.run_attempt, `${runId} run attempt`),
-    status: String(run.status ?? ""),
-    triggeringActor: String(run.triggering_actor?.login ?? ""),
   };
-  if (state.id !== runId || state.status !== "completed") {
+  if (state.id !== runId || String(run.status ?? "") !== "completed") {
     throw new Error(`rerun source ${runId} is no longer the exact terminal run`);
   }
   return state;
@@ -581,6 +579,7 @@ export async function continueFailed(plan, rootRunId, client, options = {}) {
     options.operationDeadline === undefined
       ? createOperationDeadline()
       : validateOperationDeadline(options.operationDeadline);
+  const ownedAttempts = new Map();
   await preflightContinuation(plan, rootRunId, client, client.repository ?? DEFAULT_REPOSITORY);
   let status = await inspectContinuation(plan, client);
   if (status.active.length > 0) {
@@ -624,6 +623,7 @@ export async function continueFailed(plan, rootRunId, client, options = {}) {
       mutationResults,
       operationDeadline,
     );
+    minimumAttempts.forEach((attempt, runId) => ownedAttempts.set(runId, attempt));
     await waitForTerminal(
       status.failed.map((child) => child.runId),
       client,
@@ -631,6 +631,16 @@ export async function continueFailed(plan, rootRunId, client, options = {}) {
       minimumAttempts,
     );
     status = await inspectContinuation(plan, client);
+    for (const child of status.children) {
+      const expectedAttempt = ownedAttempts.get(child.runId);
+      if (expectedAttempt !== undefined) {
+        controllerRunAttempt(
+          { id: child.runId, run_attempt: child.effectiveRunAttempt },
+          expectedAttempt,
+          expectedAttempt,
+        );
+      }
+    }
   }
   if (status.active.length > 0 || status.failed.length > 0) {
     throw new Error("failed child reruns did not produce a complete green composite");
@@ -646,11 +656,9 @@ export async function continueFailed(plan, rootRunId, client, options = {}) {
     await waitForTerminal([rootRunId], client, operationDeadline);
   }
   const completedParent = await client.getRun(rootRunId);
-  let parentReran = false;
   if (completedParent.conclusion !== "success" || childEvidenceAdvanced) {
-    const minimumAttempts = new Map([
-      [rootRunId, positiveInteger(completedParent.run_attempt, "parent run attempt") + 1],
-    ]);
+    const terminalParent = exactTerminalRunState(completedParent, rootRunId);
+    const minimumAttempts = new Map([[rootRunId, terminalParent.runAttempt + 1]]);
     remainingOperationTime(operationDeadline);
     const mutationResults = await Promise.allSettled([client.rerunParent(rootRunId)]);
     await reconcileAttemptStarts(
@@ -660,16 +668,16 @@ export async function continueFailed(plan, rootRunId, client, options = {}) {
       mutationResults,
       operationDeadline,
     );
-    parentReran = true;
+    ownedAttempts.set(rootRunId, minimumAttempts.get(rootRunId));
     await waitForTerminal([rootRunId], client, operationDeadline, minimumAttempts);
   }
-  const finalParent = await client.getRun(rootRunId);
-  if (finalParent.conclusion !== "success") {
+  if ((await client.getRun(rootRunId)).conclusion !== "success") {
     throw new Error(`final parent rerun failed: ${rootRunId}`);
   }
+  await waitForTerminal([...ownedAttempts.keys()], client, operationDeadline, ownedAttempts);
   await client.verify(rootRunId, plan, operationDeadline);
   return {
-    action: parentReran ? "reran-parent" : "verified-parent",
+    action: ownedAttempts.has(rootRunId) ? "reran-parent" : "verified-parent",
     finalRunId: rootRunId,
     status,
   };

--- a/scripts/frv.mjs
+++ b/scripts/frv.mjs
@@ -480,7 +480,13 @@ async function waitForTerminal(runIds, client, operationDeadline, minimumAttempt
   throw new Error(`timed out waiting for runs: ${runIds.join(", ")}`);
 }
 
-async function reconcileAttemptStarts(minimumAttempts, client, mutationResults, operationDeadline) {
+async function reconcileAttemptStarts(
+  minimumAttempts,
+  priorRuns,
+  client,
+  mutationResults,
+  operationDeadline,
+) {
   validateOperationDeadline(operationDeadline);
   const reconcileStartedAt = Date.now();
   const reconcileTimeoutMs = configuredTimeout(
@@ -496,8 +502,19 @@ async function reconcileAttemptStarts(minimumAttempts, client, mutationResults, 
     const runs = await Promise.all([...pending].map((runId) => client.getRun(runId)));
     for (const run of runs) {
       const runId = String(run.id);
+      const priorRun = priorRuns.get(runId);
+      if (JSON.stringify(runIdentity(run)) !== JSON.stringify(runIdentity(priorRun))) {
+        throw new Error(`rerun source ${runId} changed during mutation reconciliation`);
+      }
       if (Number(run.run_attempt) >= minimumAttempts.get(runId)) {
         pending.delete(runId);
+        continue;
+      }
+      if (
+        JSON.stringify(exactTerminalRunState(run, runId)) !==
+        JSON.stringify(exactTerminalRunState(priorRun, runId))
+      ) {
+        throw new Error(`rerun source ${runId} changed during mutation reconciliation`);
       }
     }
     if (pending.size > 0) {
@@ -533,16 +550,22 @@ async function reconcileAttemptStarts(minimumAttempts, client, mutationResults, 
   }
 }
 
-function exactTerminalRunState(run, runId) {
-  const state = {
+function runIdentity(run) {
+  return {
     displayTitle: String(run.display_title ?? ""),
-    conclusion: run.conclusion ?? null,
     event: String(run.event ?? ""),
     headBranch: String(run.head_branch ?? ""),
     headSha: String(run.head_sha ?? ""),
     id: String(run.id),
     path: String(run.path ?? ""),
     repository: String(run.repository?.full_name ?? run.repository ?? ""),
+  };
+}
+
+function exactTerminalRunState(run, runId) {
+  const state = {
+    ...runIdentity(run),
+    conclusion: run.conclusion ?? null,
     runAttempt: positiveInteger(run.run_attempt, `${runId} run attempt`),
     status: String(run.status ?? ""),
     triggeringActor: String(run.triggering_actor?.login ?? ""),
@@ -551,35 +574,6 @@ function exactTerminalRunState(run, runId) {
     throw new Error(`rerun source ${runId} is no longer the exact terminal run`);
   }
   return state;
-}
-
-async function rerunWithTransientRetry(runId, priorRun, mutation, client, operationDeadline) {
-  const prior = exactTerminalRunState(priorRun, runId);
-  for (let attempt = 1; attempt <= 2; attempt += 1) {
-    remainingOperationTime(operationDeadline);
-    try {
-      await mutation(runId);
-      return;
-    } catch (error) {
-      if (classifyReleaseGhTransportError(error) !== "transient") {
-        throw error;
-      }
-      const observedRun = await client.getRun(runId);
-      const observedAttempt = positiveInteger(observedRun.run_attempt, `${runId} run attempt`);
-      if (observedAttempt > prior.runAttempt) {
-        return;
-      }
-      const observed = exactTerminalRunState(observedRun, runId);
-      if (JSON.stringify(observed) !== JSON.stringify(prior)) {
-        throw new Error(`rerun source ${runId} changed after a rejected mutation`, {
-          cause: error,
-        });
-      }
-      if (attempt === 2) {
-        throw error;
-      }
-    }
-  }
 }
 
 export async function continueFailed(plan, rootRunId, client, options = {}) {
@@ -619,18 +613,17 @@ export async function continueFailed(plan, rootRunId, client, options = {}) {
     const minimumAttempts = new Map(
       status.failed.map((child) => [child.runId, child.effectiveRunAttempt + 1]),
     );
+    remainingOperationTime(operationDeadline);
     const mutationResults = await Promise.allSettled(
-      status.failed.map((child) =>
-        rerunWithTransientRetry(
-          child.runId,
-          priorRuns.get(child.runId),
-          client.rerunFailed.bind(client),
-          client,
-          operationDeadline,
-        ),
-      ),
+      status.failed.map((child) => client.rerunFailed(child.runId)),
     );
-    await reconcileAttemptStarts(minimumAttempts, client, mutationResults, operationDeadline);
+    await reconcileAttemptStarts(
+      minimumAttempts,
+      priorRuns,
+      client,
+      mutationResults,
+      operationDeadline,
+    );
     await waitForTerminal(
       status.failed.map((child) => child.runId),
       client,
@@ -658,16 +651,15 @@ export async function continueFailed(plan, rootRunId, client, options = {}) {
     const minimumAttempts = new Map([
       [rootRunId, positiveInteger(completedParent.run_attempt, "parent run attempt") + 1],
     ]);
-    const mutationResults = await Promise.allSettled([
-      rerunWithTransientRetry(
-        rootRunId,
-        completedParent,
-        client.rerunParent.bind(client),
-        client,
-        operationDeadline,
-      ),
-    ]);
-    await reconcileAttemptStarts(minimumAttempts, client, mutationResults, operationDeadline);
+    remainingOperationTime(operationDeadline);
+    const mutationResults = await Promise.allSettled([client.rerunParent(rootRunId)]);
+    await reconcileAttemptStarts(
+      minimumAttempts,
+      new Map([[rootRunId, completedParent]]),
+      client,
+      mutationResults,
+      operationDeadline,
+    );
     parentReran = true;
     await waitForTerminal([rootRunId], client, operationDeadline, minimumAttempts);
   }

--- a/scripts/frv.mjs
+++ b/scripts/frv.mjs
@@ -428,7 +428,7 @@ export function createClient(repository, dependencies = {}) {
     },
     rerunFailed: (runId) => rerun(runId, "rerun-failed-jobs"),
     rerunParent: (runId) => rerun(runId, "rerun"),
-    async verify(runId, plan, operationDeadline = createOperationDeadline()) {
+    async verify(runId, plan, operationDeadline, expectedRunAttempts) {
       const sourceSha = plan.trustedWorkflow?.sha;
       return execute(
         process.execPath,
@@ -448,10 +448,16 @@ export function createClient(repository, dependencies = {}) {
           sourceSha,
           "--verifier-source-file",
           "scripts/release-ci-summary.mjs",
+          ...(expectedRunAttempts === undefined
+            ? []
+            : ["--expected-run-attempts-json", JSON.stringify(expectedRunAttempts)]),
           "--json",
         ],
         {
-          timeoutMs: remainingOperationTime(operationDeadline, "FRV verification"),
+          timeoutMs: remainingOperationTime(
+            operationDeadline ?? createOperationDeadline(),
+            "FRV verification",
+          ),
         },
       );
     },
@@ -671,11 +677,32 @@ export async function continueFailed(plan, rootRunId, client, options = {}) {
     ownedAttempts.set(rootRunId, minimumAttempts.get(rootRunId));
     await waitForTerminal([rootRunId], client, operationDeadline, minimumAttempts);
   }
-  if ((await client.getRun(rootRunId)).conclusion !== "success") {
-    throw new Error(`final parent rerun failed: ${rootRunId}`);
-  }
   await waitForTerminal([...ownedAttempts.keys()], client, operationDeadline, ownedAttempts);
-  await client.verify(rootRunId, plan, operationDeadline);
+  const expectedRunAttempts = new Map(
+    status.children.map((child) => [child.runId, child.effectiveRunAttempt]),
+  );
+  // Reuse verification rereads its root and selected parent manifests too.
+  const parentRunIds = new Set([
+    rootRunId,
+    ...(plan.evidenceReuse?.requested
+      ? [plan.evidenceReuse.rootRunId, plan.evidenceReuse.selectedRunId]
+      : []),
+  ]);
+  for (const parentRunId of parentRunIds) {
+    const run = await client.getRun(parentRunId);
+    if (String(run.id) !== parentRunId) {
+      throw new Error(`verification parent run identity changed: ${parentRunId}`);
+    }
+    const terminal = parentRunId === rootRunId ? exactTerminalRunState(run, rootRunId) : undefined;
+    if (terminal && terminal.conclusion !== "success") {
+      throw new Error(`final parent rerun failed: ${rootRunId}`);
+    }
+    expectedRunAttempts.set(
+      parentRunId,
+      terminal?.runAttempt ?? positiveInteger(run.run_attempt, `${parentRunId} run attempt`),
+    );
+  }
+  await client.verify(rootRunId, plan, operationDeadline, Object.fromEntries(expectedRunAttempts));
   return {
     action: ownedAttempts.has(rootRunId) ? "reran-parent" : "verified-parent",
     finalRunId: rootRunId,

--- a/scripts/frv.mjs
+++ b/scripts/frv.mjs
@@ -128,6 +128,18 @@ function execGh(args, options = {}) {
   });
 }
 
+function verifierEvidenceNeedsRefresh(error) {
+  if (!error || typeof error !== "object" || typeof error.stdout !== "string") {
+    return false;
+  }
+  try {
+    const failure = JSON.parse(error.stdout);
+    return failure?.valid === false && failure.refreshable === true;
+  } catch {
+    return false;
+  }
+}
+
 async function sleep(milliseconds) {
   await new Promise((resolvePromise) => {
     setTimeout(resolvePromise, milliseconds);
@@ -400,6 +412,39 @@ export function createClient(repository, dependencies = {}) {
   const attemptJobs =
     dependencies.getAttemptJobs ??
     ((runId, runAttempt) => ghAttemptJobs(repository, runId, runAttempt));
+  const verify = async (runId, plan, operationDeadline, expectedRunAttempts) => {
+    const sourceSha = plan.trustedWorkflow?.sha;
+    return execute(
+      process.execPath,
+      [
+        "scripts/release-ci-summary.mjs",
+        "--validate-run",
+        runId,
+        "--repo",
+        repository,
+        "--trusted-workflow-ref",
+        plan.trustedWorkflow?.ref ?? "main",
+        "--trusted-workflow-full-ref",
+        plan.trustedWorkflow?.fullRef ?? "refs/heads/main",
+        "--trusted-workflow-sha",
+        sourceSha,
+        "--verifier-source-sha",
+        sourceSha,
+        "--verifier-source-file",
+        "scripts/release-ci-summary.mjs",
+        ...(expectedRunAttempts === undefined
+          ? []
+          : ["--expected-run-attempts-json", JSON.stringify(expectedRunAttempts)]),
+        "--json",
+      ],
+      {
+        timeoutMs: remainingOperationTime(
+          operationDeadline ?? createOperationDeadline(),
+          "FRV verification",
+        ),
+      },
+    );
+  };
   return {
     repository,
     getAttemptJobs(runId, runAttempt) {
@@ -428,38 +473,17 @@ export function createClient(repository, dependencies = {}) {
     },
     rerunFailed: (runId) => rerun(runId, "rerun-failed-jobs"),
     rerunParent: (runId) => rerun(runId, "rerun"),
-    async verify(runId, plan, operationDeadline, expectedRunAttempts) {
-      const sourceSha = plan.trustedWorkflow?.sha;
-      return execute(
-        process.execPath,
-        [
-          "scripts/release-ci-summary.mjs",
-          "--validate-run",
-          runId,
-          "--repo",
-          repository,
-          "--trusted-workflow-ref",
-          plan.trustedWorkflow?.ref ?? "main",
-          "--trusted-workflow-full-ref",
-          plan.trustedWorkflow?.fullRef ?? "refs/heads/main",
-          "--trusted-workflow-sha",
-          sourceSha,
-          "--verifier-source-sha",
-          sourceSha,
-          "--verifier-source-file",
-          "scripts/release-ci-summary.mjs",
-          ...(expectedRunAttempts === undefined
-            ? []
-            : ["--expected-run-attempts-json", JSON.stringify(expectedRunAttempts)]),
-          "--json",
-        ],
-        {
-          timeoutMs: remainingOperationTime(
-            operationDeadline ?? createOperationDeadline(),
-            "FRV verification",
-          ),
-        },
-      );
+    verify,
+    async verifySeal(runId, plan, operationDeadline, expectedRunAttempts) {
+      try {
+        await verify(runId, plan, operationDeadline, expectedRunAttempts);
+        return true;
+      } catch (error) {
+        if (verifierEvidenceNeedsRefresh(error)) {
+          return false;
+        }
+        throw error;
+      }
     },
   };
 }
@@ -535,24 +559,38 @@ async function reconcileAttemptStarts(
       }
     }
     if (pending.size > 0) {
+      const remainingReconcileTime = reconcileDeadline - Date.now();
+      if (remainingReconcileTime < 1) {
+        break;
+      }
       await sleep(
         Math.min(
           configuredTimeout("OPENCLAW_FRV_POLL_MS", DEFAULT_POLL_MS),
-          remainingOperationTime(operationDeadline),
-          reconcileDeadline - Date.now(),
+          remainingReconcileTime,
         ),
       );
     }
   }
-  remainingOperationTime(operationDeadline);
   if (pending.size > 0) {
+    const runIds = [...minimumAttempts.keys()];
+    const failures = [...pending].flatMap((runId) => {
+      const result = mutationResults[runIds.indexOf(runId)];
+      if (result?.status !== "rejected") {
+        return [];
+      }
+      const reason = result.reason instanceof Error ? result.reason.message : String(result.reason);
+      return [`${runId}: ${reason}`];
+    });
     throw new Error(
-      `rerun mutation did not produce an observable newer attempt for ${[...pending].join(", ")}`,
+      `rerun mutation did not produce an observable newer attempt for ${[...pending].join(
+        ", ",
+      )}${failures.length > 0 ? ` (${failures.join("; ")})` : ""}`,
     );
   }
   if (hardFailures[0]) {
     throw hardFailures[0].reason;
   }
+  remainingOperationTime(operationDeadline);
 }
 
 function runIdentity(run) {
@@ -578,6 +616,34 @@ function exactTerminalRunState(run, runId) {
     throw new Error(`rerun source ${runId} is no longer the exact terminal run`);
   }
   return state;
+}
+
+async function freezeVerificationAttempts(plan, rootRunId, status, client) {
+  const expectedRunAttempts = new Map(
+    status.children.map((child) => [child.runId, child.effectiveRunAttempt]),
+  );
+  // Reuse verification rereads its root and selected parent manifests too.
+  const parentRunIds = new Set([
+    rootRunId,
+    ...(plan.evidenceReuse?.requested
+      ? [plan.evidenceReuse.rootRunId, plan.evidenceReuse.selectedRunId]
+      : []),
+  ]);
+  for (const parentRunId of parentRunIds) {
+    const run = await client.getRun(parentRunId);
+    if (String(run.id) !== parentRunId) {
+      throw new Error(`verification parent run identity changed: ${parentRunId}`);
+    }
+    const terminal = parentRunId === rootRunId ? exactTerminalRunState(run, rootRunId) : undefined;
+    if (terminal && terminal.conclusion !== "success") {
+      throw new Error(`final parent rerun failed: ${rootRunId}`);
+    }
+    expectedRunAttempts.set(
+      parentRunId,
+      terminal?.runAttempt ?? positiveInteger(run.run_attempt, `${parentRunId} run attempt`),
+    );
+  }
+  return Object.fromEntries(expectedRunAttempts.entries());
 }
 
 export async function continueFailed(plan, rootRunId, client, options = {}) {
@@ -661,8 +727,31 @@ export async function continueFailed(plan, rootRunId, client, options = {}) {
   if (parent.status !== "completed") {
     await waitForTerminal([rootRunId], client, operationDeadline);
   }
-  const completedParent = await client.getRun(rootRunId);
-  if (completedParent.conclusion !== "success" || childEvidenceAdvanced) {
+  let completedParent = await client.getRun(rootRunId);
+  let verificationAttempts;
+  let parentSealed = false;
+  if (
+    completedParent.conclusion === "success" &&
+    childEvidenceAdvanced &&
+    client.verifySeal !== undefined
+  ) {
+    verificationAttempts = await freezeVerificationAttempts(plan, rootRunId, status, client);
+    parentSealed = await client.verifySeal(
+      rootRunId,
+      plan,
+      operationDeadline,
+      verificationAttempts,
+    );
+    if (!parentSealed) {
+      const verifiedParent = exactTerminalRunState(completedParent, rootRunId);
+      completedParent = await client.getRun(rootRunId);
+      const currentParent = exactTerminalRunState(completedParent, rootRunId);
+      if (JSON.stringify(currentParent) !== JSON.stringify(verifiedParent)) {
+        throw new Error(`verification parent run changed before rerun dispatch: ${rootRunId}`);
+      }
+    }
+  }
+  if (!parentSealed && (completedParent.conclusion !== "success" || childEvidenceAdvanced)) {
     const terminalParent = exactTerminalRunState(completedParent, rootRunId);
     const minimumAttempts = new Map([[rootRunId, terminalParent.runAttempt + 1]]);
     remainingOperationTime(operationDeadline);
@@ -677,32 +766,11 @@ export async function continueFailed(plan, rootRunId, client, options = {}) {
     ownedAttempts.set(rootRunId, minimumAttempts.get(rootRunId));
     await waitForTerminal([rootRunId], client, operationDeadline, minimumAttempts);
   }
-  await waitForTerminal([...ownedAttempts.keys()], client, operationDeadline, ownedAttempts);
-  const expectedRunAttempts = new Map(
-    status.children.map((child) => [child.runId, child.effectiveRunAttempt]),
-  );
-  // Reuse verification rereads its root and selected parent manifests too.
-  const parentRunIds = new Set([
-    rootRunId,
-    ...(plan.evidenceReuse?.requested
-      ? [plan.evidenceReuse.rootRunId, plan.evidenceReuse.selectedRunId]
-      : []),
-  ]);
-  for (const parentRunId of parentRunIds) {
-    const run = await client.getRun(parentRunId);
-    if (String(run.id) !== parentRunId) {
-      throw new Error(`verification parent run identity changed: ${parentRunId}`);
-    }
-    const terminal = parentRunId === rootRunId ? exactTerminalRunState(run, rootRunId) : undefined;
-    if (terminal && terminal.conclusion !== "success") {
-      throw new Error(`final parent rerun failed: ${rootRunId}`);
-    }
-    expectedRunAttempts.set(
-      parentRunId,
-      terminal?.runAttempt ?? positiveInteger(run.run_attempt, `${parentRunId} run attempt`),
-    );
+  if (!parentSealed) {
+    await waitForTerminal([...ownedAttempts.keys()], client, operationDeadline, ownedAttempts);
+    verificationAttempts = await freezeVerificationAttempts(plan, rootRunId, status, client);
+    await client.verify(rootRunId, plan, operationDeadline, verificationAttempts);
   }
-  await client.verify(rootRunId, plan, operationDeadline, Object.fromEntries(expectedRunAttempts));
   return {
     action: ownedAttempts.has(rootRunId) ? "reran-parent" : "verified-parent",
     finalRunId: rootRunId,

--- a/scripts/release-ci-summary.mjs
+++ b/scripts/release-ci-summary.mjs
@@ -133,6 +133,14 @@ const PHASED_CHILD_DISPATCHES = [
 const MAX_EXPECTED_RUN_ATTEMPTS = PHASED_CHILD_DISPATCHES.length + 2;
 const MAX_EXPECTED_RUN_ATTEMPTS_JSON_BYTES = 4 * 1024;
 
+class ReleaseEvidenceRefreshRequiredError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = "ReleaseEvidenceRefreshRequiredError";
+    this.refreshable = true;
+  }
+}
+
 const EXACT_TARGET_EVIDENCE_REUSE_POLICY = "exact-target-full-validation-v1";
 const CHANGELOG_ONLY_EVIDENCE_REUSE_POLICY = "changelog-only-release-v1";
 const EVIDENCE_REUSE_POLICIES = new Set([
@@ -1660,7 +1668,9 @@ function loadValidatedParentEvidence({
 
   const manifestEvidence = client.loadManifest(runId, parentRunAttempt, manifestPath);
   if (!manifestEvidence) {
-    throw new Error(`successful parent run is missing its release validation manifest: ${runId}`);
+    throw new ReleaseEvidenceRefreshRequiredError(
+      `successful parent run is missing its release validation manifest: ${runId}`,
+    );
   }
   const manifest = validateParentManifest(manifestEvidence.manifest, {
     runAttempt: parentRun.run_attempt,
@@ -1945,8 +1955,11 @@ function validateStrictChildRun({
   let jobs;
   let composite;
   if (plannedChild && childEvidence) {
+    if (childEvidence.effectiveRunAttempt > effectiveRunAttempt) {
+      throw new Error(`manifest child composite evidence mismatch: ${child.name}`);
+    }
     const attempts = Array.from(
-      { length: effectiveRunAttempt - plannedChild.runAttempt + 1 },
+      { length: childEvidence.effectiveRunAttempt - plannedChild.runAttempt + 1 },
       (_, index) => {
         const runAttempt = plannedChild.runAttempt + index;
         return {
@@ -1962,7 +1975,14 @@ function validateStrictChildRun({
         plannedRunAttempt: plannedChild.runAttempt,
         repository,
       },
-      run,
+      run:
+        childEvidence.effectiveRunAttempt === effectiveRunAttempt
+          ? run
+          : {
+              ...run,
+              run_attempt: childEvidence.effectiveRunAttempt,
+              triggering_actor: { login: childEvidence.triggeringActor },
+            },
     });
     const expectedEvidence = {
       ...evidence,
@@ -1972,6 +1992,11 @@ function validateStrictChildRun({
       JSON.stringify(canonicalJson(expectedEvidence))
     ) {
       throw new Error(`manifest child composite evidence mismatch: ${child.name}`);
+    }
+    if (childEvidence.effectiveRunAttempt < effectiveRunAttempt) {
+      throw new ReleaseEvidenceRefreshRequiredError(
+        `successful parent manifest predates ${child.name} attempt ${effectiveRunAttempt}`,
+      );
     }
     composite = {
       effectiveRunAttempt: evidence.effectiveRunAttempt,
@@ -2638,6 +2663,7 @@ async function main() {
     } catch (error) {
       const failure = {
         error: error instanceof Error ? error.message : String(error),
+        ...(error instanceof ReleaseEvidenceRefreshRequiredError ? { refreshable: true } : {}),
         schema: RELEASE_EVIDENCE_SCHEMA,
         valid: false,
       };

--- a/scripts/release-ci-summary.mjs
+++ b/scripts/release-ci-summary.mjs
@@ -129,6 +129,9 @@ const PHASED_CHILD_DISPATCHES = [
   LEGACY_CHILD_DISPATCHES.find((child) => child.manifestKey === "npmTelegram"),
   LEGACY_CHILD_DISPATCHES.find((child) => child.manifestKey === "productPerformance"),
 ];
+// One phased child set plus current and reused parents.
+const MAX_EXPECTED_RUN_ATTEMPTS = PHASED_CHILD_DISPATCHES.length + 2;
+const MAX_EXPECTED_RUN_ATTEMPTS_JSON_BYTES = 4 * 1024;
 
 const EXACT_TARGET_EVIDENCE_REUSE_POLICY = "exact-target-full-validation-v1";
 const CHANGELOG_ONLY_EVIDENCE_REUSE_POLICY = "changelog-only-release-v1";
@@ -597,6 +600,43 @@ function normalizeJsonObject(value, label) {
     throw new Error(`${label} is invalid`);
   }
   return value;
+}
+
+function normalizeExpectedRunAttempts(value) {
+  if (value === undefined) {
+    return undefined;
+  }
+  const entries = Object.entries(normalizeJsonObject(value, "expected run attempts"));
+  if (entries.length === 0 || entries.length > MAX_EXPECTED_RUN_ATTEMPTS) {
+    throw new Error(`expected run attempts must contain 1-${MAX_EXPECTED_RUN_ATTEMPTS} run IDs`);
+  }
+  return new Map(
+    entries.map(([runId, runAttempt]) => {
+      if (typeof runAttempt !== "number") {
+        throw new Error(`expected run ${runId} attempt must be a positive integer`);
+      }
+      return [
+        normalizeRequiredRunId(runId, "expected run ID"),
+        normalizePositiveInteger(runAttempt, `expected run ${runId} attempt`),
+      ];
+    }),
+  );
+}
+
+function consumeExpectedRunAttempt(expectedRunAttempts, runId, runAttempt, label) {
+  if (expectedRunAttempts === undefined) {
+    return;
+  }
+  const expected = expectedRunAttempts.get(runId);
+  if (expected === undefined) {
+    throw new Error(`expected run attempts omitted ${label} run ID: ${runId}`);
+  }
+  expectedRunAttempts.delete(runId);
+  if (runAttempt !== expected) {
+    throw new Error(
+      `${label} run attempt changed: ${runId} expected ${expected}, observed ${runAttempt}`,
+    );
+  }
 }
 
 function canonicalJson(value) {
@@ -1602,12 +1642,23 @@ export function createReleaseEvidenceClient(repository = DEFAULT_REPO) {
   };
 }
 
-function loadValidatedParentEvidence({ client, manifestPath, repository, runId }) {
+function loadValidatedParentEvidence({
+  client,
+  expectedRunAttempts,
+  manifestPath,
+  repository,
+  runId,
+}) {
   const parentView = client.getRunView(runId);
   const parentRun = client.getRun(runId);
+  const parentRunAttempt = normalizePositiveInteger(
+    parentRun.run_attempt,
+    `full release parent ${runId} run attempt`,
+  );
+  consumeExpectedRunAttempt(expectedRunAttempts, runId, parentRunAttempt, "parent");
   validateCompletedParentRun(parentView, parentRun, repository, runId);
 
-  const manifestEvidence = client.loadManifest(runId, parentRun.run_attempt, manifestPath);
+  const manifestEvidence = client.loadManifest(runId, parentRunAttempt, manifestPath);
   if (!manifestEvidence) {
     throw new Error(`successful parent run is missing its release validation manifest: ${runId}`);
   }
@@ -1845,12 +1896,14 @@ function validateStrictChildRun({
   releaseProfile,
   repository,
   runId,
+  expectedRunAttempts,
 }) {
   const run = client.getRun(runId);
   const effectiveRunAttempt = normalizePositiveInteger(
     run.run_attempt,
     `${child.name} run attempt`,
   );
+  consumeExpectedRunAttempt(expectedRunAttempts, runId, effectiveRunAttempt, "child");
   if (plannedChild) {
     try {
       validateReleaseChildRunProvenance(run, {
@@ -1996,6 +2049,7 @@ function validateStrictChildRun({
  *   expectedEvidencePolicy?: string,
  *   expectedEvidenceSha?: string,
  *   expectedRootRunId?: string,
+ *   expectedRunAttempts?: Record<string, number>,
  *   expectedSelectedRunId?: string,
  *   expectedTargetSha?: string,
  *   trustedWorkflowFullRef?: string,
@@ -2014,6 +2068,7 @@ export function validateReleaseRunEvidence(
     expectedEvidencePolicy,
     expectedEvidenceSha,
     expectedRootRunId,
+    expectedRunAttempts,
     expectedSelectedRunId,
     expectedTargetSha,
     trustedWorkflowFullRef,
@@ -2026,6 +2081,7 @@ export function validateReleaseRunEvidence(
 ) {
   const normalizedRepository = normalizeRepository(repository);
   const normalizedRunId = normalizeRequiredRunId(runId, "full release run ID");
+  const remainingExpectedRunAttempts = normalizeExpectedRunAttempts(expectedRunAttempts);
   const normalizedTrustedWorkflowRef = normalizeWorkflowRef(
     trustedWorkflowRef,
     "trusted workflow ref",
@@ -2039,6 +2095,7 @@ export function validateReleaseRunEvidence(
   const verifier = resolveVerifierIdentity(verifierSourceSha, verifierSourceContent);
   const currentEvidence = loadValidatedParentEvidence({
     client: evidenceClient,
+    expectedRunAttempts: remainingExpectedRunAttempts,
     manifestPath,
     repository: normalizedRepository,
     runId: normalizedRunId,
@@ -2071,6 +2128,7 @@ export function validateReleaseRunEvidence(
   if (reuse) {
     rootEvidence = loadValidatedParentEvidence({
       client: evidenceClient,
+      expectedRunAttempts: remainingExpectedRunAttempts,
       repository: normalizedRepository,
       runId: reuse.runId,
     });
@@ -2079,6 +2137,7 @@ export function validateReleaseRunEvidence(
         ? rootEvidence
         : loadValidatedParentEvidence({
             client: evidenceClient,
+            expectedRunAttempts: remainingExpectedRunAttempts,
             repository: normalizedRepository,
             runId: reuse.selectedRunId,
           });
@@ -2198,8 +2257,14 @@ export function validateReleaseRunEvidence(
       releaseProfile: rootEvidence.manifest.releaseProfile,
       repository: normalizedRepository,
       runId: childRunId,
+      expectedRunAttempts: remainingExpectedRunAttempts,
     }),
   );
+  if (remainingExpectedRunAttempts?.size) {
+    throw new Error(
+      `expected run attempts contain unvalidated run IDs: ${[...remainingExpectedRunAttempts.keys()].join(", ")}`,
+    );
+  }
 
   const current = normalizedParentTuple(
     currentEvidence,
@@ -2264,6 +2329,7 @@ function parseReleaseCiSummaryArgs(argv) {
     expectedEvidencePolicy: undefined,
     expectedEvidenceSha: undefined,
     expectedRootRunId: undefined,
+    expectedRunAttempts: undefined,
     expectedSelectedRunId: undefined,
     expectedTargetSha: undefined,
     json: false,
@@ -2305,6 +2371,20 @@ function parseReleaseCiSummaryArgs(argv) {
       options.expectedEvidenceSha = argv[++index];
     } else if (argument === "--expected-root-run-id") {
       options.expectedRootRunId = argv[++index];
+    } else if (argument === "--expected-run-attempts-json") {
+      const value = argv[++index];
+      if (!value || Buffer.byteLength(value, "utf8") > MAX_EXPECTED_RUN_ATTEMPTS_JSON_BYTES) {
+        throw new Error("--expected-run-attempts-json requires a bounded JSON object");
+      }
+      try {
+        options.expectedRunAttempts = JSON.parse(value);
+      } catch {
+        throw new Error("--expected-run-attempts-json requires a JSON object");
+      }
+      if (!options.expectedRunAttempts || Array.isArray(options.expectedRunAttempts)) {
+        throw new Error("--expected-run-attempts-json requires a JSON object");
+      }
+      normalizeExpectedRunAttempts(options.expectedRunAttempts);
     } else if (argument === "--expected-selected-run-id") {
       options.expectedSelectedRunId = argv[++index];
     } else if (argument === "--expected-changed-paths-json") {
@@ -2339,6 +2419,9 @@ function parseReleaseCiSummaryArgs(argv) {
   if (!options.validate && options.manifestPath) {
     throw new Error("--manifest requires --validate-run");
   }
+  if (!options.validate && options.expectedRunAttempts !== undefined) {
+    throw new Error("--expected-run-attempts-json requires --validate-run");
+  }
   if (options.validate && options.watch) {
     throw new Error("--watch cannot be combined with --validate-run");
   }
@@ -2356,7 +2439,7 @@ function printUsage() {
     [
       "usage: release-ci-summary.mjs <full-release-run-id>",
       "       release-ci-summary.mjs <full-release-run-id> --watch [--interval seconds]",
-      "       release-ci-summary.mjs --validate-run <id> [--repo owner/name] [--trusted-workflow-ref main --trusted-workflow-full-ref refs/heads/main] [--trusted-workflow-sha sha] [--manifest path] [--verifier-source-sha sha --verifier-source-file path] [--expected-target-sha sha --expected-evidence-sha sha --expected-evidence-policy policy --expected-root-run-id id --expected-selected-run-id id --expected-changed-paths-json json] --json",
+      "       release-ci-summary.mjs --validate-run <id> [--repo owner/name] [--trusted-workflow-ref main --trusted-workflow-full-ref refs/heads/main] [--trusted-workflow-sha sha] [--manifest path] [--verifier-source-sha sha --verifier-source-file path] [--expected-target-sha sha --expected-evidence-sha sha --expected-evidence-policy policy --expected-root-run-id id --expected-selected-run-id id --expected-changed-paths-json json] [--expected-run-attempts-json json] --json",
     ].join("\n"),
   );
 }
@@ -2537,6 +2620,7 @@ async function main() {
         expectedEvidencePolicy: options.expectedEvidencePolicy,
         expectedEvidenceSha: options.expectedEvidenceSha,
         expectedRootRunId: options.expectedRootRunId,
+        expectedRunAttempts: options.expectedRunAttempts,
         expectedSelectedRunId: options.expectedSelectedRunId,
         expectedTargetSha: options.expectedTargetSha,
         manifestPath: options.manifestPath,

--- a/test/scripts/frv.test.ts
+++ b/test/scripts/frv.test.ts
@@ -73,8 +73,13 @@ function plan(children = requiredChildren()) {
   };
 }
 
-function executionPlanArtifact() {
-  const children = requiredChildren();
+function executionPlanArtifact({
+  children = requiredChildren(),
+  evidenceReuse = { requested: false },
+}: {
+  children?: ReturnType<typeof requiredChildren>;
+  evidenceReuse?: Record<string, unknown>;
+} = {}) {
   const built = buildReleaseExecutionPlan({
     children: Object.fromEntries(
       children.map((entry) => [
@@ -88,6 +93,7 @@ function executionPlanArtifact() {
       ]),
     ),
     dockerPreflightResult: "success",
+    evidenceReuse: evidenceReuse.requested === true,
     parentRunAttempt: 1,
     parentRunId: "77",
     candidateBindingResult: "success",
@@ -109,11 +115,24 @@ function executionPlanArtifact() {
     allowUnreleasedChangelog: false,
     sharedImagePolicy: "no-push-artifact",
   });
+  const selectedKeys = new Set(children.map((entry) => entry.key));
   return buildReleaseExecutionPlanArtifact({
     attemptEvidenceVersion: 2,
     candidate: null,
-    children: built.children,
-    evidenceReuse: { requested: false },
+    children: built.children.map((entry) =>
+      selectedKeys.has(entry.key)
+        ? entry
+        : {
+            ...entry,
+            required: false,
+            result: "skipped",
+            runAttempt: null,
+            runId: "",
+            selected: false,
+            url: "",
+          },
+    ),
+    evidenceReuse,
     expected: {
       candidateRequest,
       parentRunAttempt: 1,
@@ -714,6 +733,50 @@ describe("FRV same-parent recovery", () => {
     expect(scenario.counters.verifies).toBe(0);
   });
 
+  it("freezes every selected and reused parent attempt for final verification", async () => {
+    const scenario = rerunScenario({ childSource: [1, "success"] });
+    const reusedPlan = validateReleaseExecutionPlanArtifact(
+      executionPlanArtifact({
+        children: [scenario.selected],
+        evidenceReuse: {
+          changedPaths: [],
+          evidenceSha: TARGET_SHA,
+          policy: "exact-target-full-validation-v1",
+          requested: true,
+          rootRunId: "88",
+          runUrl: `https://github.com/${REPOSITORY}/actions/runs/88`,
+          selectedRunId: "88",
+          sourceManifest: { runAttempt: 3, runId: "88", targetSha: TARGET_SHA },
+        },
+      }),
+    );
+    const getRun = scenario.client.getRun;
+    let expectedRunAttempts: Record<string, number> | undefined;
+    const client = {
+      ...scenario.client,
+      getRun: async (runId: string) => {
+        if (runId === "88") {
+          return { ...rootRun(3, "success"), id: Number(runId) };
+        }
+        return getRun(runId);
+      },
+      verify: async (
+        _runId: string,
+        _plan: Record<string, unknown>,
+        _deadline?: number,
+        attempts?: Record<string, number>,
+      ) => {
+        expectedRunAttempts = attempts;
+        return "{}";
+      },
+    };
+
+    await expect(continueFailed(reusedPlan, "77", client)).resolves.toMatchObject({
+      action: "verified-parent",
+    });
+    expect(expectedRunAttempts).toEqual({ "77": 1, "88": 3, "101": 1 });
+  });
+
   it("fails closed without another POST when provenance changes during reconciliation", async () => {
     const scenario = rerunScenario({
       childAfter: [[1, "failure", undefined, undefined, undefined, "f".repeat(40)]],
@@ -784,13 +847,18 @@ describe("FRV strict verifier", () => {
         return "{}";
       },
     });
-    await expect(client.verify("77", executionPlanArtifact(), Date.now() + 30_000)).resolves.toBe(
-      "{}",
-    );
+    await expect(
+      client.verify("77", executionPlanArtifact(), Date.now() + 30_000, {
+        "77": 2,
+        "101": 2,
+      }),
+    ).resolves.toBe("{}");
     expect(args).toEqual(
       expect.arrayContaining([
         "--validate-run",
         "77",
+        "--expected-run-attempts-json",
+        '{"77":2,"101":2}',
         "--trusted-workflow-sha",
         SHA,
         "--verifier-source-sha",

--- a/test/scripts/frv.test.ts
+++ b/test/scripts/frv.test.ts
@@ -561,6 +561,50 @@ describe("FRV same-parent recovery", () => {
     expect(parentReruns).toBe(1);
   });
 
+  it("does not rerun a parent that already seals the recovered child attempt", async () => {
+    const selected = child("normalCi", "101");
+    const childRuns = new Map([["101", { attempt: 1, conclusion: "failure" as string | null }]]);
+    const parent = { attempt: 1, conclusion: "success" as string | null };
+    const posts = { child: 0, parent: 0 };
+    let sealedChildAttempt = 1;
+    const client = {
+      ...controllerClient([selected], childRuns, parent),
+      rerunFailed: async () => {
+        posts.child += 1;
+        childRuns.set("101", { attempt: 2, conclusion: "success" });
+      },
+      rerunParent: async () => {
+        posts.parent += 1;
+        parent.attempt += 1;
+        parent.conclusion = "success";
+        sealedChildAttempt = childRuns.get("101")!.attempt;
+      },
+      verifySeal: async (
+        _runId: string,
+        _plan: Record<string, unknown>,
+        _deadline: number,
+        attempts: Record<string, number>,
+      ) => attempts["101"] === sealedChildAttempt,
+      verify: async (
+        _runId: string,
+        _plan: Record<string, unknown>,
+        _deadline?: number,
+        attempts?: Record<string, number>,
+      ) => {
+        expect(attempts?.["101"]).toBe(sealedChildAttempt);
+        return "{}";
+      },
+    };
+
+    await expect(continueFailed(plan([selected]), "77", client)).resolves.toMatchObject({
+      action: "reran-parent",
+    });
+    await expect(continueFailed(plan([selected]), "77", client)).resolves.toMatchObject({
+      action: "verified-parent",
+    });
+    expect(posts).toEqual({ child: 1, parent: 1 });
+  });
+
   it.each(["child", "parent"])("reconciles a write-once %s rerun", async (target) => {
     const transportError = Object.assign(new Error("read ECONNRESET after dispatch"), {
       code: "ECONNRESET",
@@ -605,7 +649,7 @@ describe("FRV same-parent recovery", () => {
     await withFastPolling(
       () =>
         expect(continueFailed(plan([scenario.selected]), "77", scenario.client)).rejects.toThrow(
-          "rerun mutation did not produce an observable newer attempt for 101",
+          "rerun mutation did not produce an observable newer attempt for 101 (101: HTTP 502 after dispatch)",
         ),
       "5",
     );
@@ -881,5 +925,30 @@ describe("FRV strict verifier", () => {
       "FRV verification timed out",
     );
     expect(spawns).toBe(0);
+  });
+
+  it("treats only typed verifier refresh failures as rerunnable", async () => {
+    let refreshable = true;
+    const client = createClient(REPOSITORY, {
+      execCommand: async () => {
+        throw Object.assign(new Error("verification failed"), {
+          stdout: JSON.stringify({
+            error: refreshable ? "parent evidence is stale" : "producer identity is invalid",
+            ...(refreshable ? { refreshable: true } : {}),
+            valid: false,
+          }),
+        });
+      },
+    });
+    const attempts = { "77": 2, "101": 2 };
+
+    await expect(
+      client.verifySeal("77", executionPlanArtifact(), Date.now() + 30_000, attempts),
+    ).resolves.toBe(false);
+
+    refreshable = false;
+    await expect(
+      client.verifySeal("77", executionPlanArtifact(), Date.now() + 30_000, attempts),
+    ).rejects.toThrow("verification failed");
   });
 });

--- a/test/scripts/frv.test.ts
+++ b/test/scripts/frv.test.ts
@@ -60,6 +60,7 @@ function requiredChildren() {
 
 function plan(children = requiredChildren()) {
   return {
+    attemptEvidenceVersion: 2,
     children,
     parentRunAttempt: 1,
     parentRunId: "77",
@@ -417,7 +418,7 @@ describe("FRV same-parent recovery", () => {
     expect(reruns).toBe(0);
   });
 
-  it("reruns failed children concurrently, preserves green children, then reruns the parent", async () => {
+  it("reruns current v2 failed children concurrently, preserves green children, then reruns the parent once", async () => {
     const first = child("normalCi", "101");
     const second = child("pluginPrerelease", "202");
     const green = child("releaseChecks", "303");
@@ -428,6 +429,7 @@ describe("FRV same-parent recovery", () => {
     ]);
     const parent = { attempt: 1, conclusion: "failure" as string | null };
     const events: string[] = [];
+    let parentReruns = 0;
     const client = {
       ...controllerClient([first, second, green], childRuns, parent),
       rerunFailed: async (runId: string) => {
@@ -436,6 +438,7 @@ describe("FRV same-parent recovery", () => {
         await Promise.resolve();
       },
       rerunParent: async () => {
+        parentReruns += 1;
         events.push("parent");
         parent.attempt = 2;
         parent.conclusion = "success";
@@ -451,9 +454,139 @@ describe("FRV same-parent recovery", () => {
     expect(events).not.toContain("child:303");
     expect(events.indexOf("parent")).toBeGreaterThan(events.indexOf("child:202"));
     expect(events.at(-1)).toBe("verify");
+    expect(parentReruns).toBe(1);
   });
 
-  it("reconciles an ambiguous rerun response without dispatching twice", async () => {
+  it("reconciles an accepted child POST through stale reads without dispatching twice", async () => {
+    const selected = child("normalCi", "101");
+    const parent = { attempt: 1, conclusion: "success" as string | null };
+    let dispatched = false;
+    let visibleReads = 0;
+    let reruns = 0;
+    const client = {
+      ...preflightMethods([selected], (entry) => runFor(entry, 1, "failure")),
+      getAttemptJobs: async (_runId: string, attempt: number) => [
+        job("test", attempt === 1 ? "failure" : "success"),
+      ],
+      getRun: async (runId: string) => {
+        if (runId === "77") {
+          return rootRun(parent.attempt, parent.conclusion);
+        }
+        if (!dispatched || visibleReads++ < 2) {
+          return runFor(selected, 1, "failure");
+        }
+        return runFor(selected, 2, "success");
+      },
+      repository: REPOSITORY,
+      rerunFailed: async () => {
+        reruns += 1;
+        dispatched = true;
+        throw new Error("HTTP 502 after dispatch");
+      },
+      rerunParent: async () => {
+        parent.attempt = 2;
+        parent.conclusion = "success";
+      },
+      verify: async () => "{}",
+    };
+    const previousPoll = process.env.OPENCLAW_FRV_POLL_MS;
+    process.env.OPENCLAW_FRV_POLL_MS = "1";
+    try {
+      await expect(continueFailed(plan([selected]), "77", client)).resolves.toMatchObject({
+        action: "reran-parent",
+      });
+    } finally {
+      if (previousPoll === undefined) {
+        delete process.env.OPENCLAW_FRV_POLL_MS;
+      } else {
+        process.env.OPENCLAW_FRV_POLL_MS = previousPoll;
+      }
+    }
+    expect(reruns).toBe(1);
+  });
+
+  it("fails closed when an ambiguous child POST never becomes visible", async () => {
+    const selected = child("normalCi", "101");
+    let reruns = 0;
+    const client = {
+      ...preflightMethods([selected], (entry) => runFor(entry, 1, "failure")),
+      getAttemptJobs: async () => [job("test", "failure")],
+      getRun: async (runId: string) =>
+        runId === "77" ? rootRun(1, "success") : runFor(selected, 1, "failure"),
+      repository: REPOSITORY,
+      rerunFailed: async () => {
+        reruns += 1;
+        throw new Error("HTTP 502 after dispatch");
+      },
+      rerunParent: async () => {},
+      verify: async () => "{}",
+    };
+    const previousPoll = process.env.OPENCLAW_FRV_POLL_MS;
+    const previousReconcile = process.env.OPENCLAW_FRV_RECONCILE_TIMEOUT_MS;
+    process.env.OPENCLAW_FRV_POLL_MS = "1";
+    process.env.OPENCLAW_FRV_RECONCILE_TIMEOUT_MS = "5";
+    try {
+      await expect(continueFailed(plan([selected]), "77", client)).rejects.toThrow(
+        "rerun mutation did not produce an observable newer attempt for 101",
+      );
+    } finally {
+      if (previousPoll === undefined) {
+        delete process.env.OPENCLAW_FRV_POLL_MS;
+      } else {
+        process.env.OPENCLAW_FRV_POLL_MS = previousPoll;
+      }
+      if (previousReconcile === undefined) {
+        delete process.env.OPENCLAW_FRV_RECONCILE_TIMEOUT_MS;
+      } else {
+        process.env.OPENCLAW_FRV_RECONCILE_TIMEOUT_MS = previousReconcile;
+      }
+    }
+    expect(reruns).toBe(1);
+  });
+
+  it("reconciles an accepted parent POST through stale reads without dispatching twice", async () => {
+    const selected = child("normalCi", "101");
+    let dispatched = false;
+    let visibleReads = 0;
+    let reruns = 0;
+    const client = {
+      ...preflightMethods([selected], (entry) => runFor(entry, 1, "success")),
+      getAttemptJobs: async () => [job("test")],
+      getRun: async (runId: string) => {
+        if (runId !== "77") {
+          return runFor(selected, 1, "success");
+        }
+        if (!dispatched || visibleReads++ < 2) {
+          return rootRun(1, "failure");
+        }
+        return rootRun(2, "success");
+      },
+      repository: REPOSITORY,
+      rerunFailed: async () => {},
+      rerunParent: async () => {
+        reruns += 1;
+        dispatched = true;
+        throw new Error("HTTP 502 after dispatch");
+      },
+      verify: async () => "{}",
+    };
+    const previousPoll = process.env.OPENCLAW_FRV_POLL_MS;
+    process.env.OPENCLAW_FRV_POLL_MS = "1";
+    try {
+      await expect(continueFailed(plan([selected]), "77", client)).resolves.toMatchObject({
+        action: "reran-parent",
+      });
+    } finally {
+      if (previousPoll === undefined) {
+        delete process.env.OPENCLAW_FRV_POLL_MS;
+      } else {
+        process.env.OPENCLAW_FRV_POLL_MS = previousPoll;
+      }
+    }
+    expect(reruns).toBe(1);
+  });
+
+  it("reconciles one ambiguous child response while distinct failed children rerun concurrently", async () => {
     const first = child("normalCi", "101");
     const second = child("pluginPrerelease", "202");
     const childRuns = new Map([
@@ -483,7 +616,7 @@ describe("FRV same-parent recovery", () => {
     expect(calls.toSorted()).toEqual(["101", "202"]);
   });
 
-  it("does not retry an ambiguous mutation after the source run provenance changes", async () => {
+  it("fails closed without another POST when provenance changes during reconciliation", async () => {
     const selected = child("normalCi", "101");
     let drifted = false;
     let reruns = 0;
@@ -512,7 +645,7 @@ describe("FRV same-parent recovery", () => {
     process.env.OPENCLAW_FRV_RECONCILE_TIMEOUT_MS = "5";
     try {
       await expect(continueFailed(plan([selected]), "77", client)).rejects.toThrow(
-        "rerun source 101 changed after a rejected mutation",
+        "rerun source 101 changed during mutation reconciliation",
       );
     } finally {
       if (previousPoll === undefined) {

--- a/test/scripts/frv.test.ts
+++ b/test/scripts/frv.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   continueFailed,
   createClient,
@@ -143,7 +143,12 @@ function historicalExecutionPlanArtifact() {
   return artifact;
 }
 
-function runFor(entry: ReturnType<typeof child>, attempt: number, conclusion: string | null) {
+function runFor(
+  entry: ReturnType<typeof child>,
+  attempt: number,
+  conclusion: string | null,
+  status = conclusion === null ? "in_progress" : "completed",
+) {
   return {
     actor: { login: "github-actions[bot]" },
     conclusion,
@@ -156,15 +161,20 @@ function runFor(entry: ReturnType<typeof child>, attempt: number, conclusion: st
     path: `.github/workflows/${entry.workflow}`,
     repository: { full_name: REPOSITORY },
     run_attempt: attempt,
-    status: conclusion === null ? "in_progress" : "completed",
+    status,
     triggering_actor: {
       login: attempt === entry.runAttempt ? "github-actions[bot]" : "release-operator",
     },
   };
 }
 
-function rootRun(attempt = 1, conclusion: string | null = "failure") {
+function rootRun(
+  attempt = 1,
+  conclusion: string | null = "failure",
+  status = conclusion === null ? "in_progress" : "completed",
+) {
   return {
+    actor: { login: "github-actions[bot]" },
     conclusion,
     display_title: "Full Release Validation",
     event: "workflow_dispatch",
@@ -174,7 +184,8 @@ function rootRun(attempt = 1, conclusion: string | null = "failure") {
     path: ".github/workflows/full-release-validation.yml",
     repository: { full_name: REPOSITORY },
     run_attempt: attempt,
-    status: conclusion === null ? "in_progress" : "completed",
+    status,
+    triggering_actor: { login: attempt === 1 ? "github-actions[bot]" : "release-operator" },
   };
 }
 
@@ -248,6 +259,108 @@ function controllerClient(
             childRuns.get(runId)!.conclusion,
           ),
     repository: REPOSITORY,
+  };
+}
+
+async function withFastPolling<T>(run: () => Promise<T>, reconcileTimeoutMs?: string) {
+  vi.stubEnv("OPENCLAW_FRV_POLL_MS", "1");
+  if (reconcileTimeoutMs) {
+    vi.stubEnv("OPENCLAW_FRV_RECONCILE_TIMEOUT_MS", reconcileTimeoutMs);
+  }
+  try {
+    return await run();
+  } finally {
+    vi.unstubAllEnvs();
+  }
+}
+
+type ScenarioState = [
+  attempt: unknown,
+  conclusion: string | null,
+  status?: string,
+  actor?: string,
+  triggeringActor?: string,
+  headSha?: string,
+];
+
+function rerunScenario(options: {
+  childAfter?: ScenarioState[];
+  childBefore?: ScenarioState[];
+  childError?: Error;
+  childSource?: ScenarioState;
+  parentAfter?: ScenarioState[];
+  parentBefore?: ScenarioState[];
+  parentError?: Error;
+  parentSource?: ScenarioState;
+}) {
+  const selected = child("normalCi", "101");
+  const source = {
+    child: options.childSource ?? [1, "failure"],
+    parent: options.parentSource ?? [1, "success"],
+  };
+  const after = {
+    child: options.childAfter ?? [[2, "success"]],
+    parent: options.parentAfter ?? [[2, "success"]],
+  };
+  const mutated = { child: false, parent: false };
+  const beforeReads = { child: 0, parent: 0 };
+  const counters = {
+    posts: { child: 0, parent: 0 },
+    reads: { child: 0, parent: 0 },
+    verifies: 0,
+  };
+  const stateAt = (states: ScenarioState[], index: number) =>
+    states[Math.min(index, states.length - 1)]!;
+  const makeRun = (target: "child" | "parent", state: ScenarioState) => {
+    const [attempt, conclusion, status, actor, triggeringActor, headSha] = state;
+    const validAttempt = typeof attempt === "number" && attempt > 0 ? attempt : 1;
+    const base =
+      target === "child"
+        ? runFor(selected, validAttempt, conclusion, status)
+        : rootRun(validAttempt, conclusion, status);
+    return {
+      ...base,
+      actor: { login: actor ?? base.actor.login },
+      run_attempt: attempt,
+      ...(target === "child" && triggeringActor
+        ? { triggering_actor: { login: triggeringActor } }
+        : {}),
+      ...(headSha ? { head_sha: headSha } : {}),
+    };
+  };
+  const mutate = async (target: "child" | "parent", error?: Error) => {
+    counters.posts[target] += 1;
+    mutated[target] = true;
+    if (error) {
+      throw error;
+    }
+  };
+  return {
+    counters,
+    selected,
+    client: {
+      ...preflightMethods([selected], () => makeRun("child", source.child)),
+      getAttemptJobs: async (_runId: string, attempt: number) => [
+        job("test", attempt === source.child[0] ? (source.child[1] ?? "failure") : "success"),
+      ],
+      getRun: async (runId: string) => {
+        const target = runId === "77" ? "parent" : "child";
+        const states = mutated[target]
+          ? after[target]
+          : target === "parent"
+            ? (options.parentBefore ?? [source.parent])
+            : (options.childBefore ?? [source.child]);
+        const index = mutated[target] ? counters.reads[target]++ : beforeReads[target]++;
+        return makeRun(target, stateAt(states, index));
+      },
+      repository: REPOSITORY,
+      rerunFailed: () => mutate("child", options.childError),
+      rerunParent: () => mutate("parent", options.parentError),
+      verify: async () => {
+        counters.verifies += 1;
+        return "{}";
+      },
+    },
   };
 }
 
@@ -376,46 +489,18 @@ describe("FRV same-parent recovery", () => {
   });
 
   it("adopts an already-active newer child attempt without dispatching another rerun", async () => {
-    const selected = child("normalCi", "101");
-    let childReads = 0;
-    let reruns = 0;
-    const parent = { attempt: 1, conclusion: "success" as string | null };
-    const client = {
-      ...preflightMethods([selected], (entry) => runFor(entry, 1, "failure")),
-      getAttemptJobs: async (_runId: string, attempt: number) =>
-        attempt === 1 ? [job("test", "failure")] : childReads < 2 ? [] : [job("test")],
-      getRun: async (runId: string) => {
-        if (runId === "77") {
-          return rootRun(parent.attempt, parent.conclusion);
-        }
-        childReads += 1;
-        return runFor(selected, 2, childReads < 2 ? null : "success");
-      },
-      repository: REPOSITORY,
-      rerunFailed: async () => {
-        reruns += 1;
-      },
-      rerunParent: async () => {
-        parent.attempt = 2;
-        parent.conclusion = "success";
-      },
-      verify: async () => "{}",
-    };
-    const previousPoll = process.env.OPENCLAW_FRV_POLL_MS;
-    process.env.OPENCLAW_FRV_POLL_MS = "1";
-    try {
-      await expect(continueFailed(plan([selected]), "77", client)).resolves.toMatchObject({
-        action: "reran-parent",
-        finalRunId: "77",
-      });
-    } finally {
-      if (previousPoll === undefined) {
-        delete process.env.OPENCLAW_FRV_POLL_MS;
-      } else {
-        process.env.OPENCLAW_FRV_POLL_MS = previousPoll;
-      }
-    }
-    expect(reruns).toBe(0);
+    const scenario = rerunScenario({
+      childBefore: [
+        [2, null],
+        [2, "success"],
+      ],
+    });
+    await withFastPolling(() =>
+      expect(
+        continueFailed(plan([scenario.selected]), "77", scenario.client),
+      ).resolves.toMatchObject({ action: "reran-parent", finalRunId: "77" }),
+    );
+    expect(scenario.counters.posts.child).toBe(0);
   });
 
   it("reruns current v2 failed children concurrently, preserves green children, then reruns the parent once", async () => {
@@ -457,136 +542,118 @@ describe("FRV same-parent recovery", () => {
     expect(parentReruns).toBe(1);
   });
 
-  it("reconciles an accepted child POST through stale reads without dispatching twice", async () => {
-    const selected = child("normalCi", "101");
-    const parent = { attempt: 1, conclusion: "success" as string | null };
-    let dispatched = false;
-    let visibleReads = 0;
-    let reruns = 0;
-    const client = {
-      ...preflightMethods([selected], (entry) => runFor(entry, 1, "failure")),
-      getAttemptJobs: async (_runId: string, attempt: number) => [
-        job("test", attempt === 1 ? "failure" : "success"),
+  it.each(["child", "parent"])("reconciles a write-once %s rerun", async (target) => {
+    const transportError = Object.assign(new Error("read ECONNRESET after dispatch"), {
+      code: "ECONNRESET",
+    });
+    const scenario = rerunScenario(
+      target === "child"
+        ? {
+            childAfter: [
+              [1, null, "queued"],
+              [1, null, undefined, undefined, "release-operator"],
+              [2, "success"],
+            ],
+            childError: transportError,
+          }
+        : {
+            childSource: [1, "success"],
+            parentAfter: [
+              [1, null, "queued"],
+              [1, null],
+              [2, "success"],
+            ],
+            parentError: transportError,
+            parentSource: [1, "failure"],
+          },
+    );
+    await withFastPolling(() =>
+      expect(
+        continueFailed(plan([scenario.selected]), "77", scenario.client),
+      ).resolves.toMatchObject({ action: "reran-parent" }),
+    );
+    expect(
+      target === "child" ? scenario.counters.posts.child : scenario.counters.posts.parent,
+    ).toBe(1);
+    expect(scenario.counters.verifies).toBe(1);
+  });
+
+  it("keeps the reconciliation timeout when no newer attempt appears", async () => {
+    const scenario = rerunScenario({
+      childAfter: [[1, "failure"]],
+      childError: new Error("HTTP 502 after dispatch"),
+    });
+    await withFastPolling(
+      () =>
+        expect(continueFailed(plan([scenario.selected]), "77", scenario.client)).rejects.toThrow(
+          "rerun mutation did not produce an observable newer attempt for 101",
+        ),
+      "5",
+    );
+    expect(scenario.counters.posts.child).toBe(1);
+  });
+
+  it("keeps exact-terminal parent admission before dispatch", async () => {
+    const scenario = rerunScenario({
+      childSource: [1, "success"],
+      parentBefore: [
+        [1, "failure"],
+        [2, null],
       ],
-      getRun: async (runId: string) => {
-        if (runId === "77") {
-          return rootRun(parent.attempt, parent.conclusion);
-        }
-        if (!dispatched || visibleReads++ < 2) {
-          return runFor(selected, 1, "failure");
-        }
-        return runFor(selected, 2, "success");
-      },
-      repository: REPOSITORY,
-      rerunFailed: async () => {
-        reruns += 1;
-        dispatched = true;
-        throw new Error("HTTP 502 after dispatch");
-      },
-      rerunParent: async () => {
-        parent.attempt = 2;
-        parent.conclusion = "success";
-      },
-      verify: async () => "{}",
-    };
-    const previousPoll = process.env.OPENCLAW_FRV_POLL_MS;
-    process.env.OPENCLAW_FRV_POLL_MS = "1";
-    try {
-      await expect(continueFailed(plan([selected]), "77", client)).resolves.toMatchObject({
-        action: "reran-parent",
-      });
-    } finally {
-      if (previousPoll === undefined) {
-        delete process.env.OPENCLAW_FRV_POLL_MS;
-      } else {
-        process.env.OPENCLAW_FRV_POLL_MS = previousPoll;
-      }
-    }
-    expect(reruns).toBe(1);
+      parentSource: [1, "failure"],
+    });
+    await expect(continueFailed(plan([scenario.selected]), "77", scenario.client)).rejects.toThrow(
+      "rerun source 77 is no longer the exact terminal run",
+    );
+    expect(scenario.counters.posts.parent).toBe(0);
   });
 
-  it("fails closed when an ambiguous child POST never becomes visible", async () => {
-    const selected = child("normalCi", "101");
-    let reruns = 0;
-    const client = {
-      ...preflightMethods([selected], (entry) => runFor(entry, 1, "failure")),
-      getAttemptJobs: async () => [job("test", "failure")],
-      getRun: async (runId: string) =>
-        runId === "77" ? rootRun(1, "success") : runFor(selected, 1, "failure"),
-      repository: REPOSITORY,
-      rerunFailed: async () => {
-        reruns += 1;
-        throw new Error("HTTP 502 after dispatch");
-      },
-      rerunParent: async () => {},
-      verify: async () => "{}",
-    };
-    const previousPoll = process.env.OPENCLAW_FRV_POLL_MS;
-    const previousReconcile = process.env.OPENCLAW_FRV_RECONCILE_TIMEOUT_MS;
-    process.env.OPENCLAW_FRV_POLL_MS = "1";
-    process.env.OPENCLAW_FRV_RECONCILE_TIMEOUT_MS = "5";
-    try {
-      await expect(continueFailed(plan([selected]), "77", client)).rejects.toThrow(
-        "rerun mutation did not produce an observable newer attempt for 101",
-      );
-    } finally {
-      if (previousPoll === undefined) {
-        delete process.env.OPENCLAW_FRV_POLL_MS;
-      } else {
-        process.env.OPENCLAW_FRV_POLL_MS = previousPoll;
-      }
-      if (previousReconcile === undefined) {
-        delete process.env.OPENCLAW_FRV_RECONCILE_TIMEOUT_MS;
-      } else {
-        process.env.OPENCLAW_FRV_RECONCILE_TIMEOUT_MS = previousReconcile;
-      }
-    }
-    expect(reruns).toBe(1);
+  it("binds mutation reconciliation to the original actor", async () => {
+    const scenario = rerunScenario({
+      childAfter: [[2, "success", undefined, "other-actor"]],
+    });
+    await expect(continueFailed(plan([scenario.selected]), "77", scenario.client)).rejects.toThrow(
+      "rerun source 101 changed during mutation reconciliation",
+    );
   });
 
-  it("reconciles an accepted parent POST through stale reads without dispatching twice", async () => {
-    const selected = child("normalCi", "101");
-    let dispatched = false;
-    let visibleReads = 0;
-    let reruns = 0;
-    const client = {
-      ...preflightMethods([selected], (entry) => runFor(entry, 1, "success")),
-      getAttemptJobs: async () => [job("test")],
-      getRun: async (runId: string) => {
-        if (runId !== "77") {
-          return runFor(selected, 1, "success");
-        }
-        if (!dispatched || visibleReads++ < 2) {
-          return rootRun(1, "failure");
-        }
-        return rootRun(2, "success");
-      },
-      repository: REPOSITORY,
-      rerunFailed: async () => {},
-      rerunParent: async () => {
-        reruns += 1;
-        dispatched = true;
-        throw new Error("HTTP 502 after dispatch");
-      },
-      verify: async () => "{}",
-    };
-    const previousPoll = process.env.OPENCLAW_FRV_POLL_MS;
-    process.env.OPENCLAW_FRV_POLL_MS = "1";
-    try {
-      await expect(continueFailed(plan([selected]), "77", client)).resolves.toMatchObject({
-        action: "reran-parent",
-      });
-    } finally {
-      if (previousPoll === undefined) {
-        delete process.env.OPENCLAW_FRV_POLL_MS;
-      } else {
-        process.env.OPENCLAW_FRV_POLL_MS = previousPoll;
-      }
-    }
-    expect(reruns).toBe(1);
+  it.each([
+    ["missing", 1, undefined, "101 run attempt must be a positive integer"],
+    ["zero", 1, 0, "101 run attempt must be a positive integer"],
+    ["regressed", 2, 1, "rerun source 101 attempt regressed"],
+    ["skipped", 1, 3, "controller-owned run 101 advanced past attempt 2"],
+  ])("rejects a %s child attempt", async (_label, sourceAttempt, observedAttempt, error) => {
+    const scenario = rerunScenario({
+      childAfter: [[observedAttempt, "success"]],
+      childSource: [sourceAttempt, "failure"],
+    });
+    await expect(continueFailed(plan([scenario.selected]), "77", scenario.client)).rejects.toThrow(
+      error,
+    );
   });
 
-  it("reconciles one ambiguous child response while distinct failed children rerun concurrently", async () => {
+  it.each([
+    ["child", "HTTP 403: workflow rerun forbidden"],
+    ["parent", "HTTP 422: workflow rerun rejected"],
+  ])("does not poll after a hard %s mutation failure", async (target, error) => {
+    const scenario = rerunScenario(
+      target === "child"
+        ? { childError: new Error(error) }
+        : {
+            childSource: [1, "success"],
+            parentError: new Error(error),
+            parentSource: [1, "failure"],
+          },
+    );
+    await expect(continueFailed(plan([scenario.selected]), "77", scenario.client)).rejects.toThrow(
+      error,
+    );
+    expect(
+      target === "child" ? scenario.counters.reads.child : scenario.counters.reads.parent,
+    ).toBe(0);
+  });
+
+  it("reconciles an ambiguous peer before surfacing a hard child mutation failure", async () => {
     const first = child("normalCi", "101");
     const second = child("pluginPrerelease", "202");
     const childRuns = new Map([
@@ -594,72 +661,70 @@ describe("FRV same-parent recovery", () => {
       ["202", { attempt: 1, conclusion: "failure" }],
     ]);
     const parent = { attempt: 1, conclusion: "success" as string | null };
+    const base = controllerClient([first, second], childRuns, parent);
     const calls: string[] = [];
+    let dispatched = false;
+    let hardRunReads = 0;
     const client = {
-      ...controllerClient([first, second], childRuns, parent),
+      ...base,
+      getRun: async (runId: string) => {
+        if (dispatched && runId === "202") {
+          hardRunReads += 1;
+        }
+        return base.getRun(runId);
+      },
       rerunFailed: async (runId: string) => {
+        dispatched = true;
         calls.push(runId);
-        childRuns.set(runId, { attempt: 2, conclusion: "success" });
         if (runId === "101") {
+          childRuns.set(runId, { attempt: 2, conclusion: "success" });
           throw new Error("HTTP 502 after dispatch");
         }
-      },
-      rerunParent: async () => {
-        parent.attempt = 2;
-        parent.conclusion = "success";
-      },
-      verify: async () => "{}",
-    };
-    await expect(continueFailed(plan([first, second]), "77", client)).resolves.toMatchObject({
-      action: "reran-parent",
-    });
-    expect(calls.toSorted()).toEqual(["101", "202"]);
-  });
-
-  it("fails closed without another POST when provenance changes during reconciliation", async () => {
-    const selected = child("normalCi", "101");
-    let drifted = false;
-    let reruns = 0;
-    const previousPoll = process.env.OPENCLAW_FRV_POLL_MS;
-    const previousReconcile = process.env.OPENCLAW_FRV_RECONCILE_TIMEOUT_MS;
-    const client = {
-      ...preflightMethods([selected], (entry) => runFor(entry, 1, "failure")),
-      getAttemptJobs: async () => [job("test", "failure")],
-      getRun: async (runId: string) =>
-        runId === "77"
-          ? rootRun(1, "success")
-          : {
-              ...runFor(selected, 1, "failure"),
-              head_sha: drifted ? "f".repeat(40) : SHA,
-            },
-      repository: REPOSITORY,
-      rerunFailed: async () => {
-        reruns += 1;
-        drifted = true;
-        throw new Error("HTTP 502 before dispatch");
+        throw new Error("HTTP 403: workflow rerun forbidden");
       },
       rerunParent: async () => {},
       verify: async () => "{}",
     };
-    process.env.OPENCLAW_FRV_POLL_MS = "1";
-    process.env.OPENCLAW_FRV_RECONCILE_TIMEOUT_MS = "5";
-    try {
-      await expect(continueFailed(plan([selected]), "77", client)).rejects.toThrow(
+    await expect(continueFailed(plan([first, second]), "77", client)).rejects.toThrow("HTTP 403");
+    expect(calls.toSorted()).toEqual(["101", "202"]);
+    expect(hardRunReads).toBe(0);
+  });
+
+  it.each([
+    ["child", "101"],
+    ["parent", "77"],
+  ])("rejects %s attempt advancement before verification", async (target, targetRunId) => {
+    const advancingStates = [
+      [2, null],
+      [2, "success"],
+      [3, "success"],
+    ] satisfies ScenarioState[];
+    const scenario = rerunScenario(
+      target === "child"
+        ? { childAfter: advancingStates }
+        : {
+            childSource: [1, "success"],
+            parentAfter: advancingStates,
+            parentSource: [1, "failure"],
+          },
+    );
+    await expect(continueFailed(plan([scenario.selected]), "77", scenario.client)).rejects.toThrow(
+      `controller-owned run ${targetRunId} advanced past attempt 2`,
+    );
+    expect(scenario.counters.verifies).toBe(0);
+  });
+
+  it("fails closed without another POST when provenance changes during reconciliation", async () => {
+    const scenario = rerunScenario({
+      childAfter: [[1, "failure", undefined, undefined, undefined, "f".repeat(40)]],
+      childError: new Error("HTTP 502 before dispatch"),
+    });
+    await withFastPolling(() =>
+      expect(continueFailed(plan([scenario.selected]), "77", scenario.client)).rejects.toThrow(
         "rerun source 101 changed during mutation reconciliation",
-      );
-    } finally {
-      if (previousPoll === undefined) {
-        delete process.env.OPENCLAW_FRV_POLL_MS;
-      } else {
-        process.env.OPENCLAW_FRV_POLL_MS = previousPoll;
-      }
-      if (previousReconcile === undefined) {
-        delete process.env.OPENCLAW_FRV_RECONCILE_TIMEOUT_MS;
-      } else {
-        process.env.OPENCLAW_FRV_RECONCILE_TIMEOUT_MS = previousReconcile;
-      }
-    }
-    expect(reruns).toBe(1);
+      ),
+    );
+    expect(scenario.counters.posts.child).toBe(1);
   });
 
   it("keeps dry-run recovery mutation-free", async () => {
@@ -684,6 +749,23 @@ describe("FRV same-parent recovery", () => {
       continueFailed(plan([selected]), "77", client, { dryRun: true }),
     ).resolves.toMatchObject({ action: "would-rerun" });
     expect(mutations).toBe(0);
+  });
+});
+
+describe("FRV rerun API", () => {
+  it("uses the direct failed-jobs and parent rerun endpoints", async () => {
+    const calls: string[][] = [];
+    const client = createClient(REPOSITORY, {
+      mutate: async (args: string[]) => {
+        calls.push(args);
+      },
+    });
+    await client.rerunFailed("101");
+    await client.rerunParent("77");
+    expect(calls).toEqual([
+      ["api", "-X", "POST", `repos/${REPOSITORY}/actions/runs/101/rerun-failed-jobs`],
+      ["api", "-X", "POST", `repos/${REPOSITORY}/actions/runs/77/rerun`],
+    ]);
   });
 });
 

--- a/test/scripts/pr-main-refresh.test-support.ts
+++ b/test/scripts/pr-main-refresh.test-support.ts
@@ -10,8 +10,8 @@ import {
 } from "node:fs";
 import { delimiter, join } from "node:path";
 
-// Keep the complete wrapper/lock/entry/gate owners. Only Git transport faults
-// and GitHub responses are synthetic; no functions are replaced in the wrapper.
+// Keep the complete wrapper/lock/entry/gate owners. Command resolution, Git
+// transport faults, and GitHub responses are synthetic; rg invocation is forbidden.
 export function createMainRefreshFixture(directory: string) {
   const root = realpathSync(directory);
   const canonical = join(root, "canonical");
@@ -34,7 +34,9 @@ export function createMainRefreshFixture(directory: string) {
   const realGit = spawnSync("which", ["git"], { encoding: "utf8" }).stdout.trim();
   function git(cwd: string, ...args: string[]) {
     const result = spawnSync(realGit, args, { cwd, env, encoding: "utf8" });
-    if (result.status !== 0) throw new Error(`git ${args.join(" ")}: ${result.stderr}`);
+    if (result.status !== 0) {
+      throw new Error(`git ${args.join(" ")}: ${result.stderr}`);
+    }
     return result.stdout.trim();
   }
   git(root, "init", "--bare", "-b", "main", origin);
@@ -378,9 +380,18 @@ if (jqIndex >= 0) {
   process.exit(result.status ?? 1);
 }
 console.log(JSON.stringify(value));
+    `,
+  );
+  writeFileSync(
+    join(bin, "rg"),
+    `#!/bin/sh
+echo "unexpected rg invocation in main-refresh fixture" >&2
+exit 99
 `,
   );
-  for (const command of ["git", "gh"]) chmodSync(join(bin, command), 0o755);
+  for (const command of ["git", "gh", "rg"]) {
+    chmodSync(join(bin, command), 0o755);
+  }
   env.PATH = `${bin}${delimiter}${env.PATH ?? ""}`;
   env.OPENCLAW_GH_BIN = join(bin, "gh");
   env.OPENCLAW_TESTBOX = "1";

--- a/test/scripts/release-ci-summary.test.ts
+++ b/test/scripts/release-ci-summary.test.ts
@@ -1412,8 +1412,60 @@ describe("release CI summary child correlation", () => {
       expect(() => validate(expectedRunAttempts)).toThrow(message);
     }
 
+    const staleJobs = [
+      {
+        acceptedRunAttempt: 1,
+        completedAt: firstAttemptJob.completed_at,
+        conclusion: firstAttemptJob.conclusion,
+        name: firstAttemptJob.name,
+        startedAt: firstAttemptJob.started_at,
+        status: firstAttemptJob.status,
+        url: firstAttemptJob.html_url,
+      },
+    ];
+    const staleEvidence = {
+      compositeJobsSha256: releaseCompositeJobsSha256({
+        effectiveRunAttempt: 1,
+        jobs: staleJobs,
+        plannedRunAttempt: 1,
+      }),
+      dispatchActor: "github-actions[bot]",
+      effectiveRunAttempt: 1,
+      jobs: staleJobs,
+      observedRunAttempts: [1],
+      plannedRunAttempt: 1,
+      repository: "openclaw/openclaw",
+      runId: String(fixture.childRun.id),
+      triggeringActor: "github-actions[bot]",
+    };
+    manifest.childEvidence.releaseChecks = staleEvidence;
+    expect(() => validate({ [fixture.runId]: 2, [String(fixture.childRun.id)]: 2 })).toThrowError(
+      expect.objectContaining({
+        message: "successful parent manifest predates OpenClaw Release Checks attempt 2",
+        refreshable: true,
+      }),
+    );
+
+    manifest.childEvidence.releaseChecks = releaseChecksEvidence;
+    const loadManifest = client.loadManifest.bind(client);
+    client.loadManifest = () => undefined as never;
+    expect(() => validate({ [fixture.runId]: 2, [String(fixture.childRun.id)]: 2 })).toThrowError(
+      expect.objectContaining({
+        message: `successful parent run is missing its release validation manifest: ${fixture.runId}`,
+        refreshable: true,
+      }),
+    );
+    client.loadManifest = loadManifest;
+
     releaseChecksEvidence.jobs[0]!.conclusion = "failure";
-    expect(() => validate()).toThrow("composite digest is invalid");
+    let malformedError: unknown;
+    try {
+      validate();
+    } catch (error) {
+      malformedError = error;
+    }
+    expect(malformedError).toMatchObject({ message: expect.stringContaining("digest is invalid") });
+    expect(malformedError).not.toHaveProperty("refreshable");
 
     releaseChecksEvidence.jobs[0]!.conclusion = "success";
     fixture.childRun.actor = { login: "release-operator" };

--- a/test/scripts/release-ci-summary.test.ts
+++ b/test/scripts/release-ci-summary.test.ts
@@ -870,6 +870,25 @@ describe("release CI summary child correlation", () => {
       args: ["--validate-run", "29071366025", "--verifier-source-file", "/tmp/verifier.mjs"],
       message: "requires --verifier-source-sha",
     },
+    {
+      args: ["--validate-run", "29071366025", "--expected-run-attempts-json", "[]"],
+      message: "requires a JSON object",
+    },
+    {
+      args: ["--validate-run", "29071366025", "--expected-run-attempts-json", '{"29071366025":0}'],
+      message: "must be a positive integer",
+    },
+    {
+      args: [
+        "--validate-run",
+        "29071366025",
+        "--expected-run-attempts-json",
+        JSON.stringify(
+          Object.fromEntries(Array.from({ length: 10 }, (_, index) => [index + 1, 1])),
+        ),
+      ],
+      message: "must contain 1-9 run IDs",
+    },
     { args: ["--unknown"], message: "unknown or incomplete argument" },
   ])("rejects invalid CLI arguments before GitHub access: $message", ({ args, message }) => {
     const result = spawnSync(process.execPath, [resolve(SCRIPT), ...args], {
@@ -1364,15 +1383,18 @@ describe("release CI summary child correlation", () => {
       ].join("\n");
     };
 
-    const evidence = validateReleaseRunEvidence(
-      {
-        repository: "openclaw/openclaw",
-        runId: fixture.runId,
-        verifierSourceContent: readFileSync(SCRIPT),
-        verifierSourceSha: "c".repeat(40),
-      },
-      fixture.client,
-    );
+    const validate = (expectedRunAttempts?: Record<string, number>) =>
+      validateReleaseRunEvidence(
+        {
+          expectedRunAttempts,
+          repository: "openclaw/openclaw",
+          runId: fixture.runId,
+          verifierSourceContent: readFileSync(SCRIPT),
+          verifierSourceSha: "c".repeat(40),
+        },
+        fixture.client,
+      );
+    const evidence = validate();
     expect(evidence.children).toEqual([
       expect.objectContaining({
         compositeJobsSha256: releaseChecksEvidence.compositeJobsSha256,
@@ -1381,32 +1403,21 @@ describe("release CI summary child correlation", () => {
       }),
     ]);
 
+    for (const [expectedRunAttempts, message] of [
+      [{ [fixture.runId]: 1, [String(fixture.childRun.id)]: 2 }, "parent run attempt changed"],
+      [{ [fixture.runId]: 2, [String(fixture.childRun.id)]: 1 }, "child run attempt changed"],
+      [{ [fixture.runId]: 2 }, "expected run attempts omitted"],
+      [{ [fixture.runId]: 2, [String(fixture.childRun.id)]: 2, "999": 1 }, "unvalidated run IDs"],
+    ] as const) {
+      expect(() => validate(expectedRunAttempts)).toThrow(message);
+    }
+
     releaseChecksEvidence.jobs[0]!.conclusion = "failure";
-    expect(() =>
-      validateReleaseRunEvidence(
-        {
-          repository: "openclaw/openclaw",
-          runId: fixture.runId,
-          verifierSourceContent: readFileSync(SCRIPT),
-          verifierSourceSha: "c".repeat(40),
-        },
-        fixture.client,
-      ),
-    ).toThrow("composite digest is invalid");
+    expect(() => validate()).toThrow("composite digest is invalid");
 
     releaseChecksEvidence.jobs[0]!.conclusion = "success";
     fixture.childRun.actor = { login: "release-operator" };
-    expect(() =>
-      validateReleaseRunEvidence(
-        {
-          repository: "openclaw/openclaw",
-          runId: fixture.runId,
-          verifierSourceContent: readFileSync(SCRIPT),
-          verifierSourceSha: "c".repeat(40),
-        },
-        fixture.client,
-      ),
-    ).toThrow("execution plan child dispatch tuple mismatch");
+    expect(() => validate()).toThrow("execution plan child dispatch tuple mismatch");
   });
 
   it("rejects a parent recovery that reruns a sealed child dispatch slot", () => {


### PR DESCRIPTION
Related: https://github.com/openclaw/openclaw/pull/128141
Related: https://github.com/openclaw/openclaw/pull/132289

## What Problem This Solves

Full Release Validation continuation could issue the same child or parent rerun twice when GitHub accepted the first mutation but the client observed a transient transport failure followed by a stale run-state read. A second continuation invocation could also rerun a parent whose authenticated evidence already sealed the recovered child attempts.

## Why This Change Was Made

Each child and parent rerun mutation is sent exactly once through GitHub's direct rerun endpoint. Ambiguous responses use bounded read reconciliation only. Reconciliation accepts the original attempt or its exact successor, preserves immutable run identity and actor ownership, and fails closed on timeout, provenance drift, or concurrent advancement.

The verifier now accepts the controller's frozen attempt tuple. A successful parent is reused when authenticated evidence already seals those attempts; malformed, forged, or provenance-invalid evidence remains fatal.

## User Impact

FRV continuation no longer risks duplicate workflow attempts during transient GitHub API failures or repeated operator invocations. If GitHub never exposes an accepted attempt, the operator receives a bounded error that includes the original mutation failure.

## Root Cause And Owner

The controller treated immutable workflow-run identity and GitHub's mutable current-attempt projection as one snapshot, then retried ambiguous writes. Parent refresh logic also lacked an explicit authenticated-seal check.

The owners are `scripts/frv.mjs` for mutation/reconciliation and `scripts/release-ci-summary.mjs` for evidence classification.

## Compatibility With Current Main

The branch is rebased over https://github.com/openclaw/openclaw/pull/132361, which changed release artifact readability in the same FRV files. The combined controller, release-state, artifact-contract, at-SHA, summary, and plugin-plan suites pass together.

Newer `main` commits after that rebase do not touch the eight changed FRV paths.

## Evidence

- Pre-fix live reproduction: https://github.com/openclaw/openclaw/actions/runs/33235173897 accepted one parent rerun, then exposed a stale attempt-one projection that the old exact-terminal check rejected.
- Write-once hosted proof: https://github.com/openclaw/openclaw/actions/runs/33236598699 sent exactly one `/rerun-failed-jobs` POST, injected `ECONNRESET` plus one stale read, and reconciled the same run through attempt two success with zero retries or second dispatches.
- Exact head: `f76ab070c9a8cec865a28651c6214b681fea126c`.
- Focused controller/summary suite: 110/110 tests passed.
- Combined post-#132361 FRV integration suite: 333/333 tests passed.
- Scoped oxlint, oxfmt, `git diff --check`, signed-commit verification, and Sol/high branch autoreview passed with no findings.
- Exact-head hosted CI: https://github.com/openclaw/openclaw/actions/runs/33238417737 completed successfully with 188 passed jobs, 6 intentional skips, and zero failures.
- Native review artifacts validate with `READY FOR /prepare-pr` and zero findings.

Production LOC: +349/-137 (net +212). Tests: +565/-139 (net +426). The production growth implements explicit attempt ownership, bounded reconciliation, and authenticated seal verification at the controller/verifier boundary.

## Scope

No configuration, persistence, dependency, version, release, publish, registry, or workflow-graph behavior is added. No beta or npm action is part of this PR.

Post-merge proof completed successfully:

- Landed squash: `f8c13984671834e0f270ac0e7e6cf65b0ec9dbd6`
- Broker: https://github.com/openclaw/openclaw/actions/runs/33239427306
- Fixed no-op fixture: https://github.com/openclaw/openclaw/actions/runs/33239437651 failed intentionally on attempt 1 and passed on attempt 2.
- Receipt: https://github.com/openclaw/openclaw/actions/runs/33239427306/artifacts/9710900356 binds PR 132338, the exact landed SHA, fixture attempt 2, protected `main`, and `operation: noop`.

The proof created no release candidate, package publication, tag, version change, or release promotion.
