### PR TITLE
test(tooling): accelerate paired compiler cleanup clocks

### DIFF
--- a/test/scripts/run-tsgo.test.ts
+++ b/test/scripts/run-tsgo.test.ts
@@ -295,6 +295,28 @@ describe.skipIf(process.platform === "win32")("run-tsgo watchdog", () => {
     }
   }
 
+  function withSupervisorClock(cwd: string, env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+    const preloadPath = path.join(cwd, "supervisor-clock.mjs");
+    // Scale both cleanup owners so an outer cutoff that races inner reaping still fails.
+    // Compiler/watchdog timers, readiness checks, and OS signals retain real time.
+    fs.writeFileSync(
+      preloadPath,
+      `if (process.argv[1] === ${JSON.stringify(path.resolve("scripts/run-tsgo.mts"))}) {
+  const realNow = Date.now.bind(Date);
+  const startedAt = realNow();
+  Date.now = () => startedAt + (realNow() - startedAt) * 5;
+} else if (process.argv[1] === ${JSON.stringify(path.resolve("scripts/run-tsgo.mjs"))}) {
+  const realSetTimeout = globalThis.setTimeout;
+  globalThis.setTimeout = (callback, delay, ...args) =>
+    realSetTimeout(callback, delay / 5, ...args);
+}\n`,
+    );
+    return {
+      ...env,
+      NODE_OPTIONS: `${env.NODE_OPTIONS ?? ""} --import=${pathToFileURL(preloadPath).href}`,
+    };
+  }
+
   function runFakeTsgo(
     cwd: string,
     timeoutMs: string | undefined,
@@ -308,8 +330,10 @@ describe.skipIf(process.platform === "win32")("run-tsgo watchdog", () => {
         {
           cwd,
           encoding: "utf8",
-          env:
+          env: withSupervisorClock(
+            cwd,
             timeoutMs === undefined ? baseEnv : { ...baseEnv, OPENCLAW_TSGO_TIMEOUT_MS: timeoutMs },
+          ),
           // spawnSync blocks this thread, so vitest's own per-test budget can never
           // fire; a regression here would hang the worker instead of failing.
           timeout: 25_000,
@@ -451,14 +475,15 @@ child.once("message", () => process.exit(0));
 import childProcess from "node:child_process";
 import fs from "node:fs";
 import { syncBuiltinESMExports } from "node:module";
+import { performance } from "node:perf_hooks";
 const spawn = childProcess.spawn;
 childProcess.spawn = (...args) => {
   const child = spawn(...args);
   if (args[0] === ${JSON.stringify(path.join(cwd, "node_modules/.bin/tsgo"))}) {
     const pidFile = ${JSON.stringify(pidFile)};
-    const deadline = Date.now() + 10_000;
+    const deadline = performance.now() + 10_000;
     while (!fs.existsSync(pidFile) || Number(fs.readFileSync(pidFile, "utf8")) !== child.pid) {
-      if (Date.now() >= deadline) throw new Error("compiler readiness timed out");
+      if (performance.now() >= deadline) throw new Error("compiler readiness timed out");
       Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 5);
     }
     process.kill(process.pid, "SIGTERM");
@@ -474,10 +499,10 @@ syncBuiltinESMExports();
         {
           cwd,
           stdio: ["ignore", "ignore", "pipe"],
-          env: {
+          env: withSupervisorClock(cwd, {
             ...process.env,
             NODE_OPTIONS: `${process.env.NODE_OPTIONS ?? ""}${phase === "spawn" ? ` --import=${pathToFileURL(preloadPath).href}` : ""}`,
-          },
+          }),
         },
       );
       const stderr = createBoundedChildOutput();


### PR DESCRIPTION
## What Problem This Solves

The compiler watchdog tests spend most of their execution waiting through production cleanup grace periods. Their contract is real signal forwarding, orderly escalation, descendant cleanup, and correct terminal status.

## Why This Change Was Made

A fixture preload accelerates the inner supervisor's grace/drain clock and the outer wrapper's signal cutoff by the same factor. It is gated by each exact entrypoint, so compiler processes, the real watchdog timer, readiness deadlines, and the test harness keep real clocks. Keeping both cleanup owners on the same scale preserves the ordering regression this suite protects.

Every existing case, assertion, process group, signal, PID-death check, completing-compiler sleep, and timeout budget remains. No production seam or runtime change is added.

## User Impact

The same 23 tests execute in **10.661s instead of 23.328s** locally (about 54% less). No sharding, workers, or test selection changes. Production LOC +0/-0; tests +30/-5.

## Evidence

- Before/after: `node scripts/run-vitest.mjs test/scripts/run-tsgo.test.ts --reporter=default --reporter=json --outputFile=<report>` — 23 passed both times.
- Sibling proof: `node scripts/run-vitest.mjs test/scripts/run-tsgo.test.ts test/scripts/managed-child-process.test.ts` — 66 passed.
- Mutation proof: temporarily removed the real outer wrapper's longer `forceKillDelayMs` override. The accelerated wrapper-SIGTERM case failed with unexpected SIGKILL/exit 137. Restored production bytes and reran the full suite successfully. The optimization still detects the original nested-cleanup regression.
- Independent source review caught an inner-only clock proposal that weakened the outer/inner relationship; the paired-clock version addresses that finding. Fresh Codex autoreview, formatting, and whitespace checks passed.
- Changed-file [Linux checks33232793662](https://github.com/openclaw/openclaw/actions/runs/33232793662) passed and the Testbox lease stopped. Exact-head [CI33233018695](https://github.com/openclaw/openclaw/actions/runs/33233018695) passed on attempt2 at the unchanged commit. The existing watchdog cases are POSIX-only; no new skips were introduced.

CI investigation: the first hosted run failed the unrelated live-updater standalone-checkout CLI case in a different job from this test. Its assertion reported status1 but omitted the CLI's stdout JSON diagnostic. The unchanged focused case passed locally; the failed hosted jobs passed on one retry, with the same commit. No compiler fixture preload can affect that separate job.

Named follow-up: include stdout JSON in the live-updater CLI status assertion's failure message, so any recurrence exposes the actual error without weakening its status or payload checks. A transient managed Git child cleanup issue is only a hypothesis, not a confirmed diagnosis.
