### PR TITLE
perf(tooling): defer Discord smoke storage until live execution

### DIFF
--- a/scripts/dev/discord-acp-plain-language-smoke.ts
+++ b/scripts/dev/discord-acp-plain-language-smoke.ts
@@ -8,7 +8,6 @@ import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { promisify } from "node:util";
 import { formatErrorMessage } from "../../src/infra/errors.ts";
-import { createPluginStateKeyedStore } from "../../src/plugin-state/plugin-state-store.ts";
 import { readBoundedResponseText } from "../lib/bounded-response.mjs";
 import {
   maskIdentifier,
@@ -646,18 +645,6 @@ async function requestDiscordJson<T>(params: {
   );
 }
 
-async function readThreadBindings(stateDir: string): Promise<ThreadBindingRecord[]> {
-  const store = createPluginStateKeyedStore<ThreadBindingRecord>("discord", {
-    namespace: THREAD_BINDINGS_NAMESPACE,
-    maxEntries: THREAD_BINDINGS_MAX_ENTRIES,
-    env: { ...process.env, OPENCLAW_STATE_DIR: stateDir },
-  });
-  const entries = await store.entries();
-  return entries
-    .map((entry) => entry.value)
-    .filter((entry) => Boolean(entry?.threadId && entry?.targetSessionKey));
-}
-
 function normalizeBoundAt(record: ThreadBindingRecord): number {
   if (typeof record.boundAt === "number" && Number.isFinite(record.boundAt)) {
     return record.boundAt;
@@ -802,6 +789,14 @@ async function run(argv = process.argv.slice(2)): Promise<SuccessResult | Failur
     };
   }
 
+  // Argument-only invocations need no state runtime; initialize before any live send.
+  const { createPluginStateKeyedStore } =
+    await import("../../src/plugin-state/plugin-state-store.ts");
+  const bindingsStore = createPluginStateKeyedStore<ThreadBindingRecord>("discord", {
+    namespace: THREAD_BINDINGS_NAMESPACE,
+    maxEntries: THREAD_BINDINGS_MAX_ENTRIES,
+    env: { ...process.env, OPENCLAW_STATE_DIR: args.stateDir },
+  });
   const smokeId = `acp-smoke-${Date.now()}-${randomUUID().slice(0, 8)}`;
   const startedAt = Date.now();
   const deadline = startedAt + args.timeoutMs;
@@ -948,7 +943,9 @@ async function run(argv = process.argv.slice(2)): Promise<SuccessResult | Failur
   try {
     while (Date.now() < deadline && !winningBinding) {
       try {
-        const entries = await readThreadBindings(args.stateDir);
+        const entries = (await bindingsStore.entries())
+          .map((entry) => entry.value)
+          .filter((entry) => Boolean(entry?.threadId && entry?.targetSessionKey));
         latestCandidates = resolveCandidateBindings({
           entries,
           minBoundAt: minBindingBoundAt,


### PR DESCRIPTION
## What Problem This Solves

Discord smoke-script help and invalid-argument probes load the plugin state/database runtime before they can print an answer. That adds unnecessary startup work to the tooling-safety tests. Two such probes also stalled in unrelated CI for PR #132329; the exact cause of that stall is not proven locally.

## Why This Change Was Made

Load and prepare the binding store only after live-run arguments validate, before any send, then reuse it throughout polling. Remove the helper that recreated that same store on every poll. Argument-only invocations now avoid the storage graph entirely, while store initialization failures still happen before live work begins.

## User Impact

Faster real CLI startup and test execution, with unchanged argument handling, binding selection, store options, network behavior, and timeout budgets. No sharding or worker changes. Production/tooling LOC: +11/-14 (net -3); no test changes.

## Evidence

- Existing two real CLI cases passed before and after: 1.552s → 0.785s test execution with `node scripts/run-vitest.mjs test/scripts/dev-tooling-safety.test.ts -t 'Discord smoke args|Discord smoke usage'`.
- Direct sequential CLI probes: help 2.808s → 1.629s; unknown argument 1.767s → 1.000s, with identical status and output shape. These are local observations, not a claim that the 120s CI stall was reproduced.
- Full `test/scripts/dev-tooling-safety.test.ts`: all 60 passed, 5.252s execution, including real child cleanup and local HTTP behavior.
- Isolated end-to-end smoke with the real SQLite binding store and a fake OpenClaw CLI: one send, one read, selected the recorded ACP binding, found its ACK, returned success. No external Discord request or real message was sent; temporary state was cleaned.
- Fresh Codex autoreview, formatting and whitespace checks passed. Changed-file [Testbox33232963940](https://github.com/openclaw/openclaw/actions/runs/33232963940) passed and the lease stopped. Exact-head [CI33233076509](https://github.com/openclaw/openclaw/actions/runs/33233076509) passed. Latest ClawSweeper review has no actionable findings or rank-up moves; maintainer review complete.

Follow-up: the existing CLI probe helper does not bound child lifetime or expose partial output on a stall. Track that child-ownership repair separately; this change removes the unnecessary storage initialization without disguising the missing CI diagnosis.
