### PR TITLE
fix(codex): stop cancelled compaction and close stalled progress

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -193,7 +193,6 @@ extensions/codex/src/app-server/event-projector-reasoning.ts	1
 extensions/codex/src/app-server/event-projector-tool-items.ts	1
 extensions/codex/src/app-server/event-projector-tool-transcript.ts	4
 extensions/codex/src/app-server/event-projector-values.ts	2
-extensions/codex/src/app-server/event-projector.ts	1
 extensions/codex/src/app-server/explicit-skill-input.ts	1
 extensions/codex/src/app-server/image-payload-sanitizer.ts	3
 extensions/codex/src/app-server/managed-binary.ts	2

--- a/docs/plugins/codex-harness.md
+++ b/docs/plugins/codex-harness.md
@@ -496,6 +496,13 @@ public OpenAI summarizer. If the native Codex thread binding is missing or
 stale, the command fails closed instead of silently switching compaction
 backends.
 
+Cancellation before the compact request is written prevents new native
+compaction. If the request may already have been written, OpenClaw keeps the
+native completion fence until the turn ends or the unconfirmed thread is
+retired. Unfinished compaction progress closes on terminal status or local
+teardown with an unsuccessful end event. This closeout does not increment
+successful compaction counts or undo an already recorded completion.
+
 ### Direct API long context
 
 Codex subscription and direct OpenAI API traffic are separate contracts. The

--- a/extensions/codex/src/app-server/client.test.ts
+++ b/extensions/codex/src/app-server/client.test.ts
@@ -274,7 +274,10 @@ describe("CodexAppServerClient", () => {
     });
     controller.abort();
 
-    await expect(request).rejects.toThrow("model/list aborted");
+    await expect(request).rejects.toMatchObject({
+      message: "model/list aborted",
+      mayHaveWritten: false,
+    });
     await vi.advanceTimersByTimeAsync(1_000);
     expect(harness.writes).toHaveLength(1);
   });

--- a/extensions/codex/src/app-server/compact.test.ts
+++ b/extensions/codex/src/app-server/compact.test.ts
@@ -13,8 +13,10 @@ import {
   retainCodexAppServerLiveThread,
 } from "./client-runtime.js";
 import { CodexAppServerRpcError, type CodexAppServerClient } from "./client.js";
+import { threadStartResult } from "./codex-app-server.test-fixtures.js";
 import { maybeCompactCodexAppServerSession as maybeCompactCodexAppServerSessionImpl } from "./compact.js";
 import { resolveCodexSupervisionAppServerRuntimeOptions } from "./config.js";
+import * as compactionActivity from "./context-compaction-activity.js";
 import { buildCodexAppServerConnectionFingerprint } from "./plugin-app-cache-key.js";
 import type { CodexServerNotification } from "./protocol.js";
 import { createSandboxContext } from "./sandbox-exec-server.test-helpers.js";
@@ -29,6 +31,7 @@ import {
   writeCodexAppServerBinding,
 } from "./session-binding.test-helpers.js";
 import type { CodexAppServerClientFactory } from "./shared-client.js";
+import { createClientHarness } from "./test-support.js";
 import { CODEX_APP_SERVER_VERSION } from "./version.js";
 
 let tempDir: string;
@@ -220,7 +223,7 @@ describe("maybeCompactCodexAppServerSession", () => {
       await startCompaction(sessionFile, { currentTokenCount: 123 }),
     );
 
-    expect(fake.request).toHaveBeenCalledWith("thread/compact/start", { threadId: "thread-1" });
+    expect(fake.request).toHaveBeenCalledWith("thread/compact/start", { threadId: "thread-1" }, {});
     expect(fake.client["addNotificationHandler"]).toHaveBeenCalledTimes(1);
     expect(result.ok).toBe(true);
     expect(result.compacted).toBe(true);
@@ -306,7 +309,11 @@ describe("maybeCompactCodexAppServerSession", () => {
     const sessionFile = await writeTestBinding();
     const pending = startCompaction(sessionFile);
     await vi.waitFor(() => {
-      expect(fake.request).toHaveBeenCalledWith("thread/compact/start", { threadId: "thread-1" });
+      expect(fake.request).toHaveBeenCalledWith(
+        "thread/compact/start",
+        { threadId: "thread-1" },
+        {},
+      );
     });
 
     await fake.client.request("thread/resume", { threadId: "thread-2", excludeTurns: true });
@@ -333,7 +340,11 @@ describe("maybeCompactCodexAppServerSession", () => {
     const sessionFile = await writeTestBinding({ clientId: "client-before-compaction" });
     const pending = startCompaction(sessionFile);
     await vi.waitFor(() => {
-      expect(fake.request).toHaveBeenCalledWith("thread/compact/start", { threadId: "thread-1" });
+      expect(fake.request).toHaveBeenCalledWith(
+        "thread/compact/start",
+        { threadId: "thread-1" },
+        {},
+      );
     });
 
     seedCodexTestBinding(sessionFile, {
@@ -694,6 +705,228 @@ describe("maybeCompactCodexAppServerSession", () => {
       expect.objectContaining({ release: expect.any(Function) }),
     );
   });
+
+  it.each(["resume", "projection", "overload"] as const)(
+    "cancels native admission during %s without retiring an untouched thread",
+    async (cancelAt) => {
+      const harness = createClientHarness();
+      const abortController = new AbortController();
+      ensureCodexAppServerClientRuntime(harness.client, { agentDir: tempDir });
+      if (cancelAt !== "resume") {
+        await retainCodexAppServerLiveThread(harness.client, "thread-1");
+      }
+      const projection = {
+        schemaVersion: 1 as const,
+        mode: "thread_bootstrap" as const,
+        epoch: "epoch-1",
+        fingerprint: "fingerprint-1",
+      };
+      const sessionFile = await writeTestBinding({
+        contextEngine: {
+          schemaVersion: 1,
+          engineId: "lossless-claw",
+          policyFingerprint: "policy-1",
+          projection,
+        },
+      });
+      const run = maybeCompactCodexAppServerSession(
+        {
+          sessionId: "session-1",
+          sessionKey: "agent:main:session-1",
+          sessionFile,
+          workspaceDir: tempDir,
+          trigger: "manual",
+          abortSignal: abortController.signal,
+        },
+        {
+          clientFactory: async () => harness.client,
+          nativeCompletionTimeoutMs: 1_000,
+          nativeInterruptGraceMs: 100,
+          bindingStore: {
+            ...testCodexAppServerBindingStore,
+            mutate: async (...args) => {
+              const result = await testCodexAppServerBindingStore.mutate(...args);
+              if (cancelAt === "projection" && args[1].kind === "patch") {
+                abortController.abort();
+              }
+              return result;
+            },
+          },
+        },
+      );
+      try {
+        if (cancelAt === "resume") {
+          const resume = JSON.parse(await harness.waitForWrite(0));
+          expect(resume.method).toBe("thread/resume");
+          harness.send({ id: resume.id, result: threadStartResult("thread-1", tempDir) });
+          // The response has settled the physical request; cancel before its
+          // asynchronous subscription acquisition returns to compaction.
+          queueMicrotask(() => abortController.abort());
+          const release = JSON.parse(await harness.waitForWrite(1));
+          expect(release.method).toBe("thread/unsubscribe");
+          harness.send({ id: release.id, result: {} });
+        } else if (cancelAt === "overload") {
+          const request = JSON.parse(await harness.waitForWrite(0));
+          expect(request.method).toBe("thread/compact/start");
+          harness.send({
+            id: request.id,
+            error: { code: -32_001, message: "Server overloaded; retry later." },
+          });
+          abortController.abort();
+        }
+        await expect(run).resolves.toMatchObject({ ok: false, compacted: false });
+        expect(harness.writes.map((line) => JSON.parse(line).method)).toEqual(
+          cancelAt === "resume"
+            ? ["thread/resume", "thread/unsubscribe"]
+            : cancelAt === "overload"
+              ? ["thread/compact/start"]
+              : [],
+        );
+        expect(harness.client.getCloseError()).toBeUndefined();
+        expect((await readCodexAppServerBinding(sessionFile))?.contextEngine?.projection).toEqual(
+          projection,
+        );
+        if (cancelAt !== "resume") {
+          await expect(
+            consumeCodexAppServerLiveThread(harness.client, "thread-1"),
+          ).resolves.toEqual(expect.objectContaining({ release: expect.any(Function) }));
+        }
+      } finally {
+        harness.client.close();
+        await run.catch(() => undefined);
+      }
+    },
+  );
+
+  it.each(["completed", "interrupted"] as const)(
+    "holds a cancelled written compact request until native terminal state: %s",
+    async (terminalStatus) => {
+      const harness = createClientHarness();
+      const abortController = new AbortController();
+      const persistActivity = vi.spyOn(compactionActivity, "persistCodexContextCompactionActivity");
+      ensureCodexAppServerClientRuntime(harness.client, { agentDir: tempDir });
+      await retainCodexAppServerLiveThread(
+        harness.client,
+        "thread-1",
+        undefined,
+        "config-thread-1",
+        "priority",
+      );
+      const sessionFile = await writeTestBinding();
+      let settled = false;
+      const run = maybeCompactCodexAppServerSession(
+        {
+          sessionId: "session-1",
+          sessionKey: "agent:main:session-1",
+          sessionFile,
+          workspaceDir: tempDir,
+          trigger: "manual",
+          abortSignal: abortController.signal,
+          currentTokenCount: 456,
+        },
+        { clientFactory: async () => harness.client },
+      ).finally(() => {
+        settled = true;
+      });
+      try {
+        const request = JSON.parse(await harness.waitForWrite(0));
+        expect(request.method).toBe("thread/compact/start");
+        harness.send({
+          method: "turn/started",
+          params: { threadId: "thread-1", turn: { id: "compact-turn", status: "inProgress" } },
+        });
+        const itemParams = {
+          threadId: "thread-1",
+          turnId: "compact-turn",
+          item: { id: "compact-item", type: "contextCompaction" },
+        };
+        harness.send({ method: "item/started", params: itemParams });
+        // Do not acknowledge compact/start: cancellation now leaves a written
+        // request whose native lifetime must still be owned by the completion watch.
+        abortController.abort();
+        const interrupt = JSON.parse(await harness.waitForWrite(1));
+        expect(interrupt).toMatchObject({
+          method: "turn/interrupt",
+          params: { threadId: "thread-1", turnId: "compact-turn" },
+        });
+        if (terminalStatus === "interrupted") {
+          harness.send({ id: interrupt.id, result: {} });
+        }
+        await flushAsyncTasks();
+        expect(settled).toBe(false);
+        expect(harness.client.getCloseError()).toBeUndefined();
+        expect(persistActivity).not.toHaveBeenCalled();
+        if (terminalStatus === "completed") {
+          harness.send({
+            method: "thread/tokenUsage/updated",
+            params: {
+              threadId: "thread-1",
+              turnId: "compact-turn",
+              tokenUsage: { last: { totalTokens: 123 } },
+            },
+          });
+          harness.send({ method: "item/completed", params: itemParams });
+        }
+        harness.send({
+          method: "turn/completed",
+          params: { threadId: "thread-1", turn: { id: "compact-turn", status: terminalStatus } },
+        });
+        // Native completion can beat cancellation even when the compact ACK arrives last.
+        harness.send({ id: request.id, result: {} });
+        if (terminalStatus === "completed") {
+          harness.send({
+            id: interrupt.id,
+            error: { code: -32_600, message: "no active turn to interrupt" },
+          });
+        }
+        await flushAsyncTasks();
+        // Answer cleanup if requested so a retention regression fails on outcome, not timeout.
+        if (harness.writes[2]) {
+          const release = JSON.parse(harness.writes[2]);
+          expect(release.method).toBe("thread/unsubscribe");
+          harness.send({ id: release.id, result: {} });
+        }
+        const result = requireCompactResult(await run);
+        expect(result).toMatchObject({
+          ok: terminalStatus === "completed",
+          compacted: terminalStatus === "completed",
+        });
+        expect(harness.client.getCloseError()).toBeUndefined();
+        if (terminalStatus === "completed") {
+          expect(result.result).toMatchObject({
+            tokensBefore: 456,
+            tokensAfter: 123,
+            details: { pending: false, completed: true },
+          });
+          expect(persistActivity).toHaveBeenCalledOnce();
+          expect(persistActivity).toHaveBeenCalledWith(
+            expect.objectContaining({
+              threadId: "thread-1",
+              turnId: "compact-turn",
+              itemId: "compact-item",
+            }),
+          );
+          expect(harness.writes).toHaveLength(2);
+          await expect(
+            consumeCodexAppServerLiveThread(harness.client, "thread-1", "config-thread-1"),
+          ).resolves.toMatchObject({
+            configFingerprint: "config-thread-1",
+            serviceTier: "priority",
+          });
+        } else {
+          expect(persistActivity).not.toHaveBeenCalled();
+          expect(harness.writes).toHaveLength(3);
+          await expect(
+            consumeCodexAppServerLiveThread(harness.client, "thread-1"),
+          ).resolves.toBeUndefined();
+        }
+      } finally {
+        harness.client.close();
+        await run.catch(() => undefined);
+        persistActivity.mockRestore();
+      }
+    },
+  );
 
   it("records the required-preflight origin on native app-server compaction requests", async () => {
     const fake = createFakeCodexClient({ retainedThreadId: null });
@@ -1213,7 +1446,11 @@ describe("maybeCompactCodexAppServerSession", () => {
       settled = true;
     });
     await vi.waitFor(() => {
-      expect(fake.request).toHaveBeenCalledWith("thread/compact/start", { threadId: "thread-1" });
+      expect(fake.request).toHaveBeenCalledWith(
+        "thread/compact/start",
+        { threadId: "thread-1" },
+        {},
+      );
     });
     await flushAsyncTasks();
     expect(settled).toBe(false);
@@ -1915,7 +2152,7 @@ describe("maybeCompactCodexAppServerSession", () => {
       await startCompaction(sessionFile, { currentTokenCount: 456 }),
     );
 
-    expect(fake.request).toHaveBeenCalledWith("thread/compact/start", { threadId: "thread-1" });
+    expect(fake.request).toHaveBeenCalledWith("thread/compact/start", { threadId: "thread-1" }, {});
     const preservedBinding = await readCodexAppServerBinding(sessionFile);
     expect(preservedBinding?.threadId).toBe("thread-1");
     expect(preservedBinding?.authProfileId).toBe("openai:work");
@@ -2053,7 +2290,7 @@ describe("maybeCompactCodexAppServerSession", () => {
       },
     });
 
-    expect(fake.request).toHaveBeenCalledWith("thread/compact/start", { threadId: "thread-1" });
+    expect(fake.request).toHaveBeenCalledWith("thread/compact/start", { threadId: "thread-1" }, {});
     expect(warn).toHaveBeenCalledWith(
       "ignoring OpenClaw compaction overrides for Codex app-server compaction; Codex uses native server-side compaction",
       {
@@ -2104,7 +2341,7 @@ describe("maybeCompactCodexAppServerSession", () => {
       },
     });
 
-    expect(fake.request).toHaveBeenCalledWith("thread/compact/start", { threadId: "thread-1" });
+    expect(fake.request).toHaveBeenCalledWith("thread/compact/start", { threadId: "thread-1" }, {});
     expect(warn).toHaveBeenCalledWith(
       "ignoring OpenClaw compaction overrides for Codex app-server compaction; Codex uses native server-side compaction",
       {
@@ -2186,7 +2423,7 @@ describe("maybeCompactCodexAppServerSession", () => {
       }),
     );
 
-    expect(fake.request).toHaveBeenCalledWith("thread/compact/start", { threadId: "thread-1" });
+    expect(fake.request).toHaveBeenCalledWith("thread/compact/start", { threadId: "thread-1" }, {});
     expect(fake.request.mock.calls.map(([method]) => method)).toEqual([
       "thread/resume",
       "thread/compact/start",

--- a/extensions/codex/src/app-server/compact.ts
+++ b/extensions/codex/src/app-server/compact.ts
@@ -31,7 +31,12 @@ import {
   retainCodexAppServerLiveThread,
   type CodexAppServerLiveThreadOwnership,
 } from "./client-runtime.js";
-import { CodexAppServerRpcError, type CodexAppServerClient } from "./client.js";
+import {
+  CodexAppServerRpcError,
+  isCodexAppServerIndeterminateRequestCancellationError,
+  isCodexAppServerPrewriteRequestCancellationError,
+  type CodexAppServerClient,
+} from "./client.js";
 import { persistCodexContextCompactionActivity } from "./context-compaction-activity.js";
 import { readCodexThreadContextSnapshot } from "./event-projector-usage.js";
 import {
@@ -549,8 +554,7 @@ async function compactCodexNativeThread(
         });
         let releaseThreadSubscription: (() => Promise<void>) | undefined;
         let retainedThreadOwnership: CodexAppServerLiveThreadOwnership | undefined;
-        let compactionSucceeded = false;
-        let compactionRequestDefinitelyRejected = false;
+        let canRetainThreadOwnership = true;
         let tokensAfter: number | undefined;
         const releaseCompactionThread = async (threadId: string) => {
           if (
@@ -692,6 +696,7 @@ async function compactCodexNativeThread(
                 )
               : undefined;
             await acquireThreadSubscription(guardedRequestTimeoutMs);
+            params.abortSignal?.throwIfAborted();
             await clearContextEngineProjectionBeforeNativeCompaction({
               sessionId: params.sessionId,
               bindingStore: options.bindingStore,
@@ -699,47 +704,54 @@ async function compactCodexNativeThread(
               binding,
             });
             try {
+              canRetainThreadOwnership = false;
               completionWatch.beginRequest();
-              if (guardedRequestTimeoutMs === undefined) {
-                await client.request("thread/compact/start", { threadId: binding.threadId });
-              } else {
-                await client.request(
-                  "thread/compact/start",
-                  { threadId: binding.threadId },
-                  { timeoutMs: guardedRequestTimeoutMs },
-                );
-              }
+              await client.request(
+                "thread/compact/start",
+                { threadId: binding.threadId },
+                { timeoutMs: guardedRequestTimeoutMs, signal: params.abortSignal },
+              );
               return { started: true as const, accepted: true as const };
             } catch (error) {
-              if (error instanceof CodexAppServerRpcError) {
-                // A server rejection proves native history was untouched; an
-                // ambiguous transport failure must never restore stale context.
+              const rejected =
+                error instanceof CodexAppServerRpcError ||
+                isCodexAppServerPrewriteRequestCancellationError(error);
+              if (rejected) {
+                // Rejection or cancellation before write leaves history untouched.
+                // A written request must keep its fence and cleared projection.
+                canRetainThreadOwnership = !isCodexThreadNotFoundError(error);
+                completionWatch.confirmRequestRejected();
                 await options.bindingStore.mutate(bindingIdentity, {
                   kind: "set",
                   binding,
                 });
-                compactionRequestDefinitelyRejected = !isCodexThreadNotFoundError(error);
               }
               // Retirement can acquire this same generation lease.
-              return { started: true as const, accepted: false as const, error };
+              return { started: true as const, accepted: false as const, rejected, error };
             }
           });
           if (!guardedResult.started) {
             return guardedResult.result;
           }
           if (!guardedResult.accepted) {
-            if (guardedResult.error instanceof CodexAppServerRpcError) {
-              completionWatch.confirmRequestRejected();
-            } else {
+            if (guardedResult.rejected) {
+              throw guardedResult.error;
+            }
+            if (
+              !params.abortSignal?.aborted ||
+              !isCodexAppServerIndeterminateRequestCancellationError(guardedResult.error)
+            ) {
               // Transport errors after the write leave the server-side start
               // ambiguous. Retire or detach the thread before releasing its fence.
               await completionWatch.retireUnconfirmedRequest(
                 `codex app-server compaction start was unconfirmed: ${coerceErrorMessage(guardedResult.error)}`,
               );
+              throw guardedResult.error;
             }
-            throw guardedResult.error;
+            // Cancellation after write leaves native completion authoritative,
+            // including when completion wins before the compact ACK arrives.
           }
-          embeddedAgentLog.info("started codex app-server compaction", {
+          embeddedAgentLog.info("waiting for codex app-server compaction completion", {
             sessionId: params.sessionId,
             threadId: binding.threadId,
           });
@@ -764,7 +776,7 @@ async function compactCodexNativeThread(
             sessionId: params.sessionId,
             threadId: binding.threadId,
           });
-          compactionSucceeded = true;
+          canRetainThreadOwnership = true;
         } catch (error) {
           if (isCodexThreadNotFoundError(error)) {
             return failedCodexThreadBindingCompactionResult(params, {
@@ -787,10 +799,7 @@ async function compactCodexNativeThread(
         } finally {
           completionWatch.cancel();
           try {
-            if (
-              (compactionSucceeded || compactionRequestDefinitelyRejected) &&
-              retainedThreadOwnership
-            ) {
+            if (canRetainThreadOwnership && retainedThreadOwnership) {
               const ownership = retainedThreadOwnership;
               const currentBinding = await options.bindingStore.read(bindingIdentity);
               // Reset uses this same generation lease; without it compaction

--- a/extensions/codex/src/app-server/event-projector-result.ts
+++ b/extensions/codex/src/app-server/event-projector-result.ts
@@ -47,6 +47,7 @@ type CodexAttemptResultInput = {
   contextTokens: number | undefined;
   contextTokensSource: EmbeddedRunAttemptResult["contextTokensSource"];
   completedCompactionCount: number;
+  observedItemCount: number;
   activeItemCount: number;
   completedItemCount: number;
   guardianReviewCount: number;
@@ -230,7 +231,7 @@ export function buildCodexAttemptResult(
       replaySafe: !hadPotentialSideEffects,
     },
     itemLifecycle: {
-      startedCount: input.activeItemCount + input.completedItemCount,
+      startedCount: input.observedItemCount,
       completedCount: input.completedItemCount,
       activeCount: input.activeItemCount,
     },

--- a/extensions/codex/src/app-server/event-projector-values.ts
+++ b/extensions/codex/src/app-server/event-projector-values.ts
@@ -39,11 +39,6 @@ export function readNonNegativeInteger(record: JsonObject, key: string): number 
   return value !== undefined && Number.isInteger(value) && value >= 0 ? value : undefined;
 }
 
-export function readCodexErrorNotificationMessage(record: JsonObject): string | undefined {
-  const error = record.error;
-  return isJsonObject(error) ? readStringField(error, "message") : undefined;
-}
-
 export function readHookOutputEntries(
   value: JsonValue | undefined,
 ): Array<{ kind?: string; text: string }> {

--- a/extensions/codex/src/app-server/event-projector.replay-safety.test.ts
+++ b/extensions/codex/src/app-server/event-projector.replay-safety.test.ts
@@ -23,6 +23,46 @@ import {
 registerCodexEventProjectorTestLifecycle();
 
 describe("CodexAppServerEventProjector replay safety and progress projection", () => {
+  it.each(["item/started", "item/completed", "turn/completed"] as const)(
+    "counts each item once across repeated %s observations and snapshots",
+    async (method) => {
+      const projector = await createProjector();
+      const item = {
+        type: "commandExecution",
+        id: "cmd-observed",
+        command: "pwd",
+        cwd: "/workspace",
+        processId: null,
+        source: "agent",
+        status: "completed",
+        commandActions: [],
+        aggregatedOutput: "/workspace",
+        exitCode: 0,
+        durationMs: 1,
+      };
+      const notification =
+        method === "turn/completed"
+          ? turnCompleted([item])
+          : forCurrentTurn(method, {
+              item: { ...item, status: method === "item/started" ? "inProgress" : "completed" },
+            });
+      await projector.handleNotification(notification);
+      await projector.handleNotification(notification);
+      expect(projector.buildResult(buildEmptyToolTelemetry()).itemLifecycle).toEqual({
+        startedCount: 1,
+        completedCount: method === "item/started" ? 0 : 1,
+        activeCount: method === "item/started" ? 1 : 0,
+      });
+
+      await projector.handleNotification(turnCompleted([item, item]));
+      expect(projector.buildResult(buildEmptyToolTelemetry()).itemLifecycle).toEqual({
+        startedCount: 1,
+        completedCount: 1,
+        activeCount: 0,
+      });
+    },
+  );
+
   it("clears a prior terminal presentation after a native tool completes", async () => {
     let terminalPresentation: string | undefined = "stale web fetch";
     const projector = await createProjector({

--- a/extensions/codex/src/app-server/event-projector.terminal-errors.test.ts
+++ b/extensions/codex/src/app-server/event-projector.terminal-errors.test.ts
@@ -223,85 +223,93 @@ describe("CodexAppServerEventProjector terminal errors", () => {
     },
   );
 
-  it("keeps an active native compaction failure scoped through the failed turn", async () => {
-    const onAgentEvent = vi.fn();
-    const onContextCompacted = vi.fn();
-    const projector = await createProjector(
-      { ...(await createParams()), onAgentEvent },
-      { onContextCompacted },
-    );
-
-    await projector.handleNotification(
-      forCurrentTurn("item/started", {
-        item: { type: "contextCompaction", id: "compact-failed" },
-      }),
-    );
-    await projector.handleNotification(
-      appServerError({
-        message: "remote compaction failed",
-        willRetry: false,
-        codexErrorInfo: "other",
-      }),
-    );
-
-    expect(readAttemptTerminal(projector.buildResult(buildEmptyToolTelemetry()))).toMatchObject({
-      promptError: "remote compaction failed",
-      promptErrorSource: "compaction",
-    });
-    expect(projector.settledTurnFailureFinalizationAllowed).toBe(true);
-
-    await projector.handleNotification(
-      forCurrentTurn("turn/completed", {
-        turn: {
-          id: TURN_ID,
-          status: "failed",
-          error: { message: "remote compaction failed", codexErrorInfo: "other" },
-          items: [],
+  it.each([
+    { status: "failed", codexErrorInfo: "other", recoverable: true },
+    { status: "failed", codexErrorInfo: "unauthorized", recoverable: false },
+    { status: "failed", codexErrorInfo: "usageLimitExceeded", recoverable: false },
+    { status: "interrupted", codexErrorInfo: undefined, recoverable: false },
+  ] as const)(
+    "closes active native compaction for $status/$codexErrorInfo without widening recovery",
+    async ({ status, codexErrorInfo, recoverable }) => {
+      const onAgentEvent = vi.fn();
+      const onContextCompacted = vi.fn();
+      const projector = await createProjector(
+        { ...(await createParams()), onAgentEvent },
+        { onContextCompacted },
+      );
+      const compaction = { item: { type: "contextCompaction", id: "compact-failed" } };
+      await projector.handleNotification(forCurrentTurn("item/started", compaction));
+      if (codexErrorInfo) {
+        await projector.handleNotification(
+          appServerError({ message: "remote compaction failed", willRetry: false, codexErrorInfo }),
+        );
+        expect(readAttemptTerminal(projector.buildResult(buildEmptyToolTelemetry()))).toMatchObject(
+          {
+            promptErrorSource: recoverable ? "compaction" : "prompt",
+          },
+        );
+      }
+      await projector.handleNotification(
+        forCurrentTurn("turn/completed", {
+          turn: {
+            id: TURN_ID,
+            status,
+            error: codexErrorInfo ? { message: "remote compaction failed", codexErrorInfo } : null,
+            items: [],
+          },
+        }),
+      );
+      expect(projector.buildResult(buildEmptyToolTelemetry()).itemLifecycle).toEqual({
+        startedCount: 1,
+        completedCount: 0,
+        activeCount: 0,
+      });
+      expect(projector.buildResult(buildEmptyToolTelemetry()).compactionCount).toBeUndefined();
+      // A late native completion must not report a second outcome after
+      // the enclosing turn has already closed its unfinished compaction.
+      await projector.handleNotification(forCurrentTurn("item/completed", compaction));
+      const result = projector.buildResult(buildEmptyToolTelemetry());
+      expect(projector.settledTurnFailureFinalizationAllowed).toBe(recoverable);
+      expect(readAttemptTerminal(result).promptErrorSource).toBe(
+        codexErrorInfo ? (recoverable ? "compaction" : "prompt") : null,
+      );
+      expect(projector.isCompacting()).toBe(false);
+      expect(result.itemLifecycle).toEqual({ startedCount: 1, completedCount: 1, activeCount: 0 });
+      expect(result.compactionCount).toBeUndefined();
+      expect(onContextCompacted).not.toHaveBeenCalled();
+      expect(
+        onAgentEvent.mock.calls
+          .map(([event]) => event)
+          .filter((event) => event.stream === "compaction"),
+      ).toEqual([
+        {
+          stream: "compaction",
+          data: {
+            phase: "start",
+            backend: "codex-app-server",
+            threadId: THREAD_ID,
+            turnId: TURN_ID,
+            itemId: "compact-failed",
+          },
         },
-      }),
-    );
-
-    const result = projector.buildResult(buildEmptyToolTelemetry());
-    expect(readAttemptTerminal(result)).toMatchObject({
-      promptError: "remote compaction failed",
-      promptErrorSource: "compaction",
-    });
-    expect(projector.settledTurnFailureFinalizationAllowed).toBe(true);
-    expect(projector.isCompacting()).toBe(false);
-    expect(result.itemLifecycle).toEqual({ startedCount: 0, completedCount: 0, activeCount: 0 });
-    expect(result.compactionCount).toBeUndefined();
-    expect(onContextCompacted).not.toHaveBeenCalled();
-    expect(
-      onAgentEvent.mock.calls
-        .map(([event]) => event)
-        .filter((event) => event.stream === "compaction"),
-    ).toEqual([
-      {
-        stream: "compaction",
-        data: {
-          phase: "start",
-          backend: "codex-app-server",
-          threadId: THREAD_ID,
-          turnId: TURN_ID,
-          itemId: "compact-failed",
+        {
+          stream: "compaction",
+          data: {
+            phase: "end",
+            backend: "codex-app-server",
+            completed: false,
+            threadId: THREAD_ID,
+            turnId: TURN_ID,
+            itemId: "compact-failed",
+          },
         },
-      },
-      {
-        stream: "compaction",
-        data: {
-          phase: "end",
-          backend: "codex-app-server",
-          completed: false,
-          threadId: THREAD_ID,
-          turnId: TURN_ID,
-          itemId: "compact-failed",
-        },
-      },
-    ]);
-  });
+      ]);
+    },
+  );
 
   it("keeps other errors prompt-scoped after native compaction completes", async () => {
-    const projector = await createProjector();
+    const onAgentEvent = vi.fn();
+    const projector = await createProjector({ ...(await createParams()), onAgentEvent });
     const compaction = { item: { type: "contextCompaction", id: "compact-completed" } };
 
     await projector.handleNotification(forCurrentTurn("item/started", compaction));
@@ -319,6 +327,16 @@ describe("CodexAppServerEventProjector terminal errors", () => {
       promptErrorSource: "prompt",
     });
     expect(projector.settledTurnFailureFinalizationAllowed).toBe(false);
+    await projector.handleNotification(turnWithStatus("interrupted"));
+    expect(projector.buildResult(buildEmptyToolTelemetry()).compactionCount).toBe(1);
+    expect(
+      onAgentEvent.mock.calls
+        .map(([event]) => event)
+        .filter((event) => event.stream === "compaction"),
+    ).toEqual([
+      expect.objectContaining({ data: expect.objectContaining({ phase: "start" }) }),
+      expect.objectContaining({ data: expect.objectContaining({ phase: "end", completed: true }) }),
+    ]);
   });
 
   it("uses Codex rate-limit resets for usage-limit app-server errors", async () => {

--- a/extensions/codex/src/app-server/event-projector.ts
+++ b/extensions/codex/src/app-server/event-projector.ts
@@ -35,11 +35,7 @@ import {
   normalizeCodexThreadTokenUsage,
   projectCodexThreadUsageUpdate,
 } from "./event-projector-usage.js";
-import {
-  readCodexErrorNotificationMessage,
-  readItem,
-  readItemString,
-} from "./event-projector-values.js";
+import { readItem, readItemString } from "./event-projector-values.js";
 import type { CodexNativePreToolUseFailure } from "./native-hook-relay.js";
 import {
   isCodexNotificationForTurn,
@@ -67,6 +63,8 @@ export class CodexAppServerEventProjector {
   private readonly asyncDeliveryProjection: CodexAsyncDeliveryProjection;
   private readonly assistantProjection: CodexAssistantProjection;
   private readonly reasoningProjection: CodexReasoningProjection;
+  // Observed identities survive local teardown of unfinished items.
+  private readonly observedItemIds = new Set<string>();
   private readonly activeItemIds = new Set<string>();
   private readonly completedItemIds = new Set<string>();
   private readonly activeCompactionItemIds = new Set<string>();
@@ -250,7 +248,10 @@ export class CodexAppServerEventProjector {
       return;
     }
     if (notification.method === "hook/started" || notification.method === "hook/completed") {
-      if (!this.isHookNotificationForCurrentThread(params)) {
+      // Thread-level hooks carry a null turn id.
+      const threadId = readString(params, "threadId");
+      const turnId = params.turnId;
+      if (threadId !== this.threadId || (turnId !== this.turnId && turnId !== null)) {
         return;
       }
     } else if (
@@ -364,7 +365,7 @@ export class CodexAppServerEventProjector {
         const compactionFailure = codexErrorInfo === "other" && this.isCompacting();
         this.settledTurnFailureFinalizationAllowed =
           codexErrorInfo === "serverOverloaded" || compactionFailure;
-        this.promptError = this.formatCodexErrorMessage(params) ?? "codex app-server error";
+        this.promptError = this.formatCodexErrorMessage(params.error) ?? "codex app-server error";
         this.promptErrorSource = compactionFailure ? "compaction" : "prompt";
         break;
       }
@@ -408,6 +409,7 @@ export class CodexAppServerEventProjector {
       contextTokens: this.contextTokens,
       contextTokensSource: this.contextTokensSource,
       completedCompactionCount: this.completedCompactionCount,
+      observedItemCount: this.observedItemIds.size,
       activeItemCount: this.activeItemIds.size,
       completedItemCount: this.completedItemIds.size,
       guardianReviewCount: this.eventProjection.guardianReviewCount,
@@ -468,11 +470,22 @@ export class CodexAppServerEventProjector {
     return this.activeCompactionItemIds.size > 0;
   }
 
+  closeActiveCompactions(): void {
+    // Native interruption can omit item/completed. Close only projector activity;
+    // the controller's separate active-item set still gates recovery.
+    for (const itemId of this.activeCompactionItemIds) {
+      this.activeItemIds.delete(itemId);
+      this.activeCompactionItemIds.delete(itemId);
+      this.eventProjection.emitCompactionEnd(itemId, false);
+    }
+  }
+
   private async handleItemStarted(params: JsonObject): Promise<void> {
     const item = readItem(params.item);
     const itemId = item?.id ?? readString(params, "itemId");
     this.assistantProjection.recordItemStarted(item, itemId);
     if (itemId) {
+      this.observedItemIds.add(itemId);
       this.activeItemIds.add(itemId);
     }
     this.recordNativeToolOutcome(item);
@@ -521,6 +534,7 @@ export class CodexAppServerEventProjector {
     this.clearTerminalPresentationForNativeItem(item);
     const itemId = item?.id ?? readString(params, "itemId");
     if (itemId) {
+      this.observedItemIds.add(itemId);
       this.activeItemIds.delete(itemId);
       this.completedItemIds.add(itemId);
     }
@@ -537,8 +551,11 @@ export class CodexAppServerEventProjector {
     }
     this.reasoningProjection.recordItem(item);
     await this.generatedMediaProjection.recordNative(item);
-    if (item?.type === "contextCompaction" && itemId) {
-      this.activeCompactionItemIds.delete(itemId);
+    if (
+      item?.type === "contextCompaction" &&
+      itemId &&
+      this.activeCompactionItemIds.delete(itemId)
+    ) {
       this.completedCompactionCount += 1;
       await this.options.onContextCompacted?.();
       await runAgentHarnessAfterCompactionHook({
@@ -599,26 +616,10 @@ export class CodexAppServerEventProjector {
       this.responseCompletions.clear();
     }
     if (turn.status === "failed") {
-      const usageLimitMessage = formatCodexUsageLimitErrorMessage({
-        message: turn.error?.message,
-        codexErrorInfo: turn.error?.codexErrorInfo as JsonValue | null | undefined,
-        rateLimits: this.options.readRecentRateLimits?.(),
-      });
-      this.promptError = usageLimitMessage
-        ? createCodexUsageLimitPromptError(usageLimitMessage)
-        : (turn.error?.message ?? "codex app-server turn failed");
+      this.promptError = this.formatCodexErrorMessage(turn.error) ?? "codex app-server turn failed";
       this.promptErrorSource = compactionFailure ? "compaction" : "prompt";
     }
-    if (compactionFailure) {
-      // Codex omits item/completed on failure, so the terminal turn must close
-      // every active structural compaction for state and stream consumers.
-      const failedCompactionItemIds = [...this.activeCompactionItemIds];
-      for (const itemId of failedCompactionItemIds) {
-        this.activeItemIds.delete(itemId);
-        this.activeCompactionItemIds.delete(itemId);
-        this.eventProjection.emitCompactionEnd(itemId, false);
-      }
-    }
+    this.closeActiveCompactions();
     const turnItems = turn.items ?? [];
     // Upstream terminal summaries contain only the last assistant item. Keep
     // earlier unsettled deliveries at their producer instead of inferring them.
@@ -663,7 +664,6 @@ export class CodexAppServerEventProjector {
       await this.asyncDeliveryProjection.deliver(delivery);
     }
     this.assistantProjection.finalizeAnswerCandidate(turn);
-    this.activeCompactionItemIds.clear();
     await this.reasoningProjection.maybeEndReasoning();
   }
 
@@ -676,6 +676,7 @@ export class CodexAppServerEventProjector {
     ) {
       return;
     }
+    this.observedItemIds.add(item.id);
     const wasStarted = this.activeItemIds.has(item.id);
     if (!wasStarted) {
       this.eventProjection.emitStandardItemEvent({ phase: "start", item });
@@ -724,27 +725,20 @@ export class CodexAppServerEventProjector {
     });
   }
 
-  private formatCodexErrorMessage(params: JsonObject): string | Error | undefined {
-    const error = isJsonObject(params.error) ? params.error : undefined;
+  private formatCodexErrorMessage(value: unknown): string | Error | undefined {
+    const error = isJsonObject(value) ? value : undefined;
+    const message = error ? readString(error, "message") : undefined;
     const usageLimitMessage = formatCodexUsageLimitErrorMessage({
-      message: error ? readString(error, "message") : undefined,
+      message,
       codexErrorInfo: error?.codexErrorInfo,
       rateLimits: this.options.readRecentRateLimits?.(),
     });
-    return usageLimitMessage
-      ? createCodexUsageLimitPromptError(usageLimitMessage)
-      : readCodexErrorNotificationMessage(params);
+    return usageLimitMessage ? createCodexUsageLimitPromptError(usageLimitMessage) : message;
   }
 
   private emitAgentEvent(
     event: Parameters<NonNullable<EmbeddedRunAttemptParams["onAgentEvent"]>>[0],
   ): void {
     emitCodexAgentEvent(this.params, event);
-  }
-
-  private isHookNotificationForCurrentThread(params: JsonObject): boolean {
-    const threadId = readString(params, "threadId");
-    const turnId = params.turnId;
-    return threadId === this.threadId && (turnId === this.turnId || turnId === null);
   }
 }

--- a/extensions/codex/src/app-server/run-attempt-cleanup.ts
+++ b/extensions/codex/src/app-server/run-attempt-cleanup.ts
@@ -161,6 +161,7 @@ export async function cleanupCodexAttempt(
       await Promise.allSettled(cleanups.map(async (cleanup) => await cleanup(cleanupReason)));
     });
     await runCleanupStep("codex-route-release", releaseCurrentRoute);
+    activeTurn.activeProjector.closeActiveCompactions();
     await runCleanupStep("codex-transcript-checkpoint", () =>
       activeTurn.activeProjector.transcriptCheckpoint.flush(true),
     );

--- a/extensions/codex/src/app-server/run-attempt-finalize.ts
+++ b/extensions/codex/src/app-server/run-attempt-finalize.ts
@@ -95,6 +95,7 @@ export async function finalizeCodexAttempt(
   await completion;
   // Include projection work already queued when timeout completion wins.
   await drainNotificationQueue();
+  activeProjector.closeActiveCompactions();
   const hasQuiescentCompletedAssistant =
     activeProjector.hasCompletedTerminalAssistantText() &&
     state.activeAppServerTurnRequests === 0 &&

--- a/extensions/codex/src/app-server/run-attempt.turn-watches.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.turn-watches.test.ts
@@ -18,6 +18,7 @@ import type { EmbeddedRunAttemptResult } from "./attempt-terminal.js";
 import { readAttemptTerminal } from "./attempt-terminal.test-helper.js";
 import { createCodexAttemptTurnWatchController } from "./attempt-turn-watches.js";
 import * as authBridge from "./auth-bridge.js";
+import { CodexAppServerRpcError } from "./client.js";
 import { createCodexDynamicToolBridge } from "./dynamic-tools.js";
 import * as elicitationBridge from "./elicitation-bridge.js";
 import { CodexAppServerEventProjector } from "./event-projector.js";
@@ -25,6 +26,7 @@ import { nativeHookRelayUnregisterQueue } from "./native-hook-relay-state.js";
 import type { CodexServerNotification, JsonObject } from "./protocol.js";
 import { itemNotification, rawItemCompleted, turnCompleted } from "./protocol.test-helpers.js";
 import { readRecentCodexRateLimits } from "./rate-limit-cache.js";
+import * as attemptFinalization from "./run-attempt-finalize.js";
 import {
   createParams,
   createTestParams,
@@ -781,6 +783,155 @@ describe("runCodexAppServerAttempt turn watches", () => {
       },
     });
     expect(result.promptTimeoutOutcome).toBeUndefined();
+  });
+
+  it.each(["cancel", "timeout", "timeout-with-terminal", "client-close"] as const)(
+    "closes active compaction during local %s finalization",
+    async (termination) => {
+      const abortController = new AbortController();
+      const onAgentEvent = vi.fn();
+      const harness = createStartedThreadHarness(async (method) => {
+        if (method === "turn/interrupt" && termination === "timeout-with-terminal") {
+          await harness.notify(turnCompleted({ id: "turn-1", status: "interrupted", items: [] }));
+        }
+        return undefined;
+      });
+      const params = makeTestParams({
+        timeoutMs: termination.startsWith("timeout") ? 200 : 5_000,
+        abortSignal: abortController.signal,
+        onAgentEvent,
+      });
+      const run = runCodexAppServerAttempt(params);
+      await harness.waitForMethod("turn/start");
+      await harness.notify(
+        itemNotification("item/started", { type: "contextCompaction", id: "compact-local" }),
+      );
+      await vi.waitFor(
+        () =>
+          expect(onAgentEvent).toHaveBeenCalledWith(
+            expect.objectContaining({
+              stream: "compaction",
+              data: expect.objectContaining({ phase: "start" }),
+            }),
+          ),
+        fastWait,
+      );
+      if (termination === "cancel") {
+        abortController.abort();
+      } else if (termination === "client-close") {
+        harness.close();
+      }
+      const result = await run;
+      expect(readAttemptTerminal(result)).toMatchObject({
+        aborted: termination !== "client-close",
+        timedOut: termination.startsWith("timeout"),
+      });
+      if (termination !== "cancel") {
+        expect(result.codexAppServerFailure).toMatchObject({
+          kind:
+            termination === "client-close"
+              ? "client_closed_before_turn_completed"
+              : "turn_completion_idle_timeout",
+          replaySafe: false,
+          replayBlockedReason: "active_item",
+        });
+      }
+      expect(result.compactionCount).toBeUndefined();
+      expect(result.itemLifecycle).toEqual({ startedCount: 1, completedCount: 0, activeCount: 0 });
+      expect(result.settledTurnFinalizationContext).toBeUndefined();
+      expect(
+        onAgentEvent.mock.calls
+          .map(([event]) => event)
+          .filter((event) => event.stream === "compaction"),
+      ).toEqual([
+        expect.objectContaining({
+          data: expect.objectContaining({ phase: "start", itemId: "compact-local" }),
+        }),
+        expect.objectContaining({
+          data: expect.objectContaining({
+            phase: "end",
+            itemId: "compact-local",
+            completed: false,
+          }),
+        }),
+      ]);
+    },
+  );
+
+  it("closes unfinished compaction in cleanup when finalization fails after local cancellation", async () => {
+    const abortController = new AbortController();
+    const onAgentEvent = vi.fn();
+    const finalizationError = new Error("finalization failed after local completion");
+    let readResult: (() => EmbeddedRunAttemptResult) | undefined;
+    vi.spyOn(attemptFinalization, "finalizeCodexAttempt").mockImplementationOnce(
+      async (resources, turnRuntime, _lifecycle, notifications, _requestRuntime, activeTurn) => {
+        await turnRuntime.completion;
+        await notifications.drainNotificationQueue();
+        // Fail only after the real cancellation owner has confirmed termination.
+        // Neither native terminal projection nor normal finalization closes this item.
+        expect(turnRuntime.state.completed).toBe(true);
+        expect(activeTurn.activeProjector.isCompacting()).toBe(true);
+        readResult = () =>
+          activeTurn.activeProjector.buildResult(
+            resources.prompt.context.attemptTools.toolBridge.telemetry,
+          );
+        throw finalizationError;
+      },
+    );
+    const harness = createStartedThreadHarness(async (method) => {
+      if (method === "turn/interrupt") {
+        // Codex's exact already-terminal response also covers a lost terminal notification.
+        throw new CodexAppServerRpcError(
+          { code: -32_600, message: "no active turn to interrupt" },
+          method,
+        );
+      }
+      return undefined;
+    });
+    const params = makeTestParams({ abortSignal: abortController.signal, onAgentEvent });
+    const run = runCodexAppServerAttempt(params, { nativeHookRelay: { enabled: true } });
+    await harness.waitForMethod("turn/start");
+    const startRequest = harness.requests.find((request) => request.method === "thread/start");
+    const relayId = extractRelayIdFromThreadRequest(startRequest?.params);
+    await harness.notify(
+      itemNotification("item/started", { type: "contextCompaction", id: "compact-cleanup" }),
+    );
+    expect(onAgentEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        stream: "compaction",
+        data: expect.objectContaining({ phase: "start", itemId: "compact-cleanup" }),
+      }),
+    );
+    abortController.abort();
+    await expect(run).rejects.toBe(finalizationError);
+
+    expect(readResult?.().compactionCount).toBeUndefined();
+    expect(readResult?.().itemLifecycle).toEqual({
+      startedCount: 1,
+      completedCount: 0,
+      activeCount: 0,
+    });
+    expect(
+      onAgentEvent.mock.calls
+        .map(([event]) => event)
+        .filter((event) => event.stream === "compaction"),
+    ).toEqual([
+      expect.objectContaining({
+        data: expect.objectContaining({ phase: "start", itemId: "compact-cleanup" }),
+      }),
+      expect.objectContaining({
+        data: expect.objectContaining({
+          phase: "end",
+          itemId: "compact-cleanup",
+          completed: false,
+        }),
+      }),
+    ]);
+    expect(harness.requests.filter(({ method }) => method === "thread/unsubscribe")).toEqual([
+      { method: "thread/unsubscribe", params: { threadId: "thread-1" } },
+    ]);
+    expect(nativeHookRelayTesting.getNativeHookRelayRegistrationForTests(relayId)).toBeUndefined();
+    expect(queueActiveRunMessageForTest(params.sessionId, "after cleanup")).toBe(false);
   });
 
   it("unsubscribes and closes the app-server client when the active turn goes idle past the attempt timeout", async () => {


### PR DESCRIPTION
**Draft — not ready to merge.** The native runtime repair passes its focused regression suite and build, but authenticated changed-path cancellation/follow-up proof remains blocked by the isolated Gateway startup constraint described below. No live compaction PASS is claimed.

Closes #132177 — native compaction could still be submitted after cancellation.
Closes #132178 — interrupted native compaction could leave its progress stream open.

## What Problem This Solves

Fixes an issue where users cancelling Codex-backed work could still start a new native compaction, or leave the conversation showing compaction progress after the turn had already stopped. The admission race also occurred when cancellation arrived during the app-server's overload retry delay.

## Why This Change Was Made

Native request admission and native completion are different facts. The bridge passes cancellation through the existing client, positively distinguishes cancellation before a write from an indeterminate written request, and keeps the latter's completion/retirement fence. If native completion wins before a cancelled local acknowledgement, the completed compaction remains successful.

The projector has one idempotent unfinished-compaction closeout, called by native terminal handling, local finalization, and exceptional cleanup. It records observed item identities independently of active/completed state: closing progress must not make already-observed native work look safe to replay after a disconnect or timeout. This replaces failure-only closeout, silent set clearing, and the lossy derivation of observed work from current activity. Nearby duplicated error formatting and an obsolete single-use reader are removed; the assertion-safety baseline is reduced by exactly the one eliminated assertion.

## User Impact

Cancellation before submission prevents new native compaction. Interrupted progress closes once without claiming a successful compaction, while already-observed successful completion remains successful. Disconnect/timeout recovery keeps its existing replay barrier even after the progress indicator closes.

Native Codex still owns native history and compaction. No API-key/OAuth selection, provider payload, public configuration, protocol, dependency, or SQLite schema changes are included. Broader durable bookkeeping for already-applied history effects is not claimed fixed here.

## Evidence

**Before/after regressions:** the initial repair had 12 intended pre-fix failures with 211 controls passing. Independent checks caught and repaired two unpublished draft regressions: completion winning a cancelled acknowledgement, and progress closeout erasing replay evidence. The latter reproduced through the real run-attempt test harness: client loss and timeout incorrectly returned `replaySafe: true`; after repair they retain `replayBlockedReason: "active_item"`, with lifecycle counts `started=1, completed=0, active=0` and one unsuccessful compaction end.

The fixture-corrected replay before-run had **9 intended failures / 3 passing controls**. The identical focused selection then passed **12/12**. An initial exploratory run also caught two incomplete new command-item fixtures; those were corrected to the actual protocol shape before counting regression evidence.

```bash
node scripts/run-vitest.mjs extensions/codex/src/app-server/run-attempt.turn-watches.test.ts extensions/codex/src/app-server/event-projector.terminal-errors.test.ts extensions/codex/src/app-server/event-projector.replay-safety.test.ts -t 'closes active compaction during local|closes unfinished compaction|closes active native compaction|counts each item once' --maxWorkers=1
```

**Broader proof:** 469 tests passed across 22 files, including all projector suites, complete turn-watch integration coverage, replay-result/watch-controller tests, and manual compaction. Earlier client/admission and lifecycle suites also passed; their totals overlap and are not added to this count.

```bash
node scripts/run-vitest.mjs extensions/codex/src/app-server/run-attempt.turn-watches.test.ts extensions/codex/src/app-server/event-projector*.test.ts extensions/codex/src/app-server/attempt-results.test.ts extensions/codex/src/app-server/attempt-turn-watches.test.ts extensions/codex/src/app-server/compact.test.ts --maxWorkers=1
```

**Build and static gates:** the final runtime candidate's normal local build passed, as did the Linux private-QA build on [Blacksmith Testbox run 33228210872](https://github.com/openclaw/openclaw/actions/runs/33228210872), lease `tbx_01m15mdpacyzycmmxma0gxehhd`. The wrapper's successful build result is the build evidence; the lease workflow's later stop status is not a test result. The six production files were independently hash-checked against the tested/reviewed candidate. After the required one-row assertion-baseline shrink, the final changed gate passed formatting, both extension typecheck programs, all preceding guards, five doctor-contract guard tests, and the dead-export scans. It failed before extension lint started: `plugin-sdk boundary root shims timed out after 300000ms`. One normal retry of that exact lint command hit the same preparation timeout. No timeout increase or preparation skip was used; extension lint remains unproven. The remaining canonical steps passed separately: script lint (including Docker E2E boundary and raw HTTP/2 guards), database-first legacy-store guard, media-download helper guard, runtime-sidecar loader guard, and import-cycle check (zero cycles). The aggregate changed command is still not reported as passing. Diagnosis located the repeated timeout during active declaration publication and found a zero-byte generated bridge with the success stamp unchanged; that publication-safety issue is tracked separately. Those partial generated artifacts are not treated as valid lint proof. Draft CI skips the runtime gate, so no exact-head CI pass is claimed.

```bash
pnpm build
```

```bash
node scripts/check-changed.mjs -- config/assertion-safety-baseline.txt docs/plugins/codex-harness.md extensions/codex/src/app-server/client.test.ts extensions/codex/src/app-server/compact.test.ts extensions/codex/src/app-server/compact.ts extensions/codex/src/app-server/event-projector-result.ts extensions/codex/src/app-server/event-projector-values.ts extensions/codex/src/app-server/event-projector.replay-safety.test.ts extensions/codex/src/app-server/event-projector.terminal-errors.test.ts extensions/codex/src/app-server/event-projector.ts extensions/codex/src/app-server/run-attempt-cleanup.ts extensions/codex/src/app-server/run-attempt-finalize.ts extensions/codex/src/app-server/run-attempt.turn-watches.test.ts
```

**Independent review:** isolated Codex autoreview of the complete corrected runtime candidate and pinned native contracts returned no actionable P0 findings. This is P0-scoped review, not an all-severity or reviewer-run test claim. The only subsequent repository edit is the required shrink-only assertion-baseline row removal.

**Native contract:** inspected Codex `rust-v0.150.1`, commit `90854393966b21e9ebfd21b122334eb09a20c93d`, directly. The app-server rejects transport overload before enqueue; interrupt acknowledgement is separate from terminal state; compaction installs its history effect before emitting completion. Sources: [transport admission](https://github.com/openai/codex/blob/90854393966b21e9ebfd21b122334eb09a20c93d/codex-rs/app-server-transport/src/transport/mod.rs#L219-L258), [compaction submission](https://github.com/openai/codex/blob/90854393966b21e9ebfd21b122334eb09a20c93d/codex-rs/app-server/src/request_processors/thread_processor.rs#L2312-L2324), [turn interruption](https://github.com/openai/codex/blob/90854393966b21e9ebfd21b122334eb09a20c93d/codex-rs/app-server/src/request_processors/turn_processor.rs#L1496-L1540), and [history installation/completion](https://github.com/openai/codex/blob/90854393966b21e9ebfd21b122334eb09a20c93d/codex-rs/core/src/compact_remote.rs#L268-L308). Published Linux native binary provenance matched version 0.150.1; it was not patched or upgraded.

**Live-proof blocker — still open:** two authenticated attempts stopped during setup/startup before any compaction assertion. The QA seeder first hit Node's symlink restriction; switching to the normal built Gateway CLI with an owned synthetic workspace removed that unnecessary operation without broadening permissions. The Gateway then exited before `/readyz`. Two keyless diagnostic starts and an independent same-permissions probe identified the required state coordinator: `src/infra/state-database-coordinator.ts:33` chooses `/tmp`, and `src/state/openclaw-state-ownership.ts:179` does not override it. The actual failure is `ERR_ACCESS_DENIED` while canonicalizing `/tmp`, before the coordinator can use `/tmp/openclaw-state-locks-<uid>` outside the proof's task-owned filesystem grants. This is a limitation of that proof environment, not evidence of a new compaction failure or a general Gateway startup regression.

The final keyless preflight correctly reports **INCOMPLETE: LINUX_COORDINATOR_OUTSIDE_TASK_ROOT**, not READY or PASS. Configuration validates with zero warnings. Diagnostics observed no native activity beyond observer readiness and sent no messages. Owned process groups disappeared, ports closed, task state/auth/logs were removed, and the Testbox lease was stopped. No permission widening, production coordination change, fake event/history, or favorable-race retry was used. Native cancellation and same-thread follow-up still need an actual passing run before this draft is promoted; there is no before/after rendered UI proof.

**Provenance:** local blame for both affected paths reaches the checkout's shallow history boundary. The original introducing commit is not established; that boundary commit is not attributed as the regression.

**Current-main comparison:** checked `45a1e3c8b8d279eeb2d8bee16b1e8301ac03edab`. The native admission/projector owners and pinned dependency are unchanged from this candidate's base. The independently landed native tool-process cleanup repair in commit `cde3458c842e71f851d6d3e887aaf41a60c2ea9a` adds abort-cleanup joins to finalization/cleanup; it does not provide compaction closeout or preserve observed-item counts. Combined-head CI and live proof remain required before landing.

Production is **+74/−73, net +1**; tests **+533/−84, net +449**; docs **+7**; assertion-baseline bookkeeping **−1**. The remaining production line pays for the explicit admission/lifecycle/observed-work ownership after removing duplicated error formatting and the obsolete reader. No compatibility path, production test seam, extra retry, or timeout increase is added.

AI-assisted repair. Documentation: https://docs.openclaw.ai/plugins/codex-harness
