### PR TITLE
fix(ci): pin Periphery for native dead-code gates

### DIFF
--- a/.github/workflows/ios-periphery.yml
+++ b/.github/workflows/ios-periphery.yml
@@ -62,6 +62,7 @@ jobs:
               "config/swiftlint.yml",
               "scripts/check-swift-tools.sh",
               "scripts/format-swift.sh",
+              "scripts/install-periphery.sh",
               "scripts/install-swift-tools.sh",
               "scripts/ios-write-swift-filelist.mjs",
               "scripts/ios-write-swift-filelist.mts",
@@ -112,8 +113,9 @@ jobs:
 
       - name: Install iOS Swift tooling
         run: |
-          brew update
-          brew install periphery
+          periphery_dir="$RUNNER_TEMP/openclaw-periphery"
+          ./scripts/install-periphery.sh "$periphery_dir"
+          echo "$periphery_dir" >> "$GITHUB_PATH"
           swift_tools_dir="$RUNNER_TEMP/openclaw-swift-tools"
           # Homebrew's xcodegen bottle can arrive corrupted on runner images;
           # use the repo's pinned, checksummed release installer like ci.yml.

--- a/.github/workflows/macos-periphery.yml
+++ b/.github/workflows/macos-periphery.yml
@@ -57,6 +57,7 @@ jobs:
               ".github/workflows/macos-periphery.yml",
               ".github/workflows/ios-periphery-comment.yml",
               "apps/macos/.periphery.yml",
+              "scripts/install-periphery.sh",
             ], { ignoreReturnCode: true, silent: true });
             if (result.exitCode !== 0 && result.exitCode !== 1) {
               throw new Error(`git diff failed with exit code ${result.exitCode}`);
@@ -103,8 +104,9 @@ jobs:
 
       - name: Install Periphery
         run: |
-          brew update
-          brew install periphery
+          periphery_dir="$RUNNER_TEMP/openclaw-periphery"
+          ./scripts/install-periphery.sh "$periphery_dir"
+          echo "$periphery_dir" >> "$GITHUB_PATH"
 
       - name: Run Periphery
         run: |

--- a/.github/workflows/shared-openclawkit-periphery.yml
+++ b/.github/workflows/shared-openclawkit-periphery.yml
@@ -57,6 +57,7 @@ jobs:
               "apps/macos/",
               "apps/shared/OpenClawKit/",
               ".github/workflows/shared-openclawkit-periphery.yml",
+              "scripts/install-periphery.sh",
               "scripts/periphery-intersection.mjs",
               "scripts/ios-configure-signing.sh",
               "scripts/ios-write-swift-filelist.mjs",
@@ -109,8 +110,9 @@ jobs:
 
       - name: Install iOS scan tooling
         run: |
-          brew update
-          brew install periphery
+          periphery_dir="$RUNNER_TEMP/openclaw-periphery"
+          ./scripts/install-periphery.sh "$periphery_dir"
+          echo "$periphery_dir" >> "$GITHUB_PATH"
           swift_tools_dir="$RUNNER_TEMP/openclaw-swift-tools"
           # Homebrew's xcodegen bottle can arrive corrupted on runner images;
           # use the repo's pinned, checksummed release installer like ci.yml.
@@ -199,8 +201,9 @@ jobs:
 
       - name: Install Periphery
         run: |
-          brew update
-          brew install periphery
+          periphery_dir="$RUNNER_TEMP/openclaw-periphery"
+          ./scripts/install-periphery.sh "$periphery_dir"
+          echo "$periphery_dir" >> "$GITHUB_PATH"
 
       - name: Scan shared kit
         run: |

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -70,6 +70,10 @@ registrations for unrelated pull requests.
 
 Standalone Periphery workflows enforce zero dead-code findings for the iOS and macOS apps. The shared OpenClawKit workflow scans both consumers in parallel and reports a declaration only when Periphery emits the same Swift USR from both builds. Its generated `OpenClawProtocol/GatewayModels.swift` schema contract is retained as generator-owned code rather than treated as app-local dead code.
 
+All four scans use `scripts/install-periphery.sh` to install the checksum-pinned Periphery 3.8.0 OSS release, including its adjacent `libIndexStore.dylib`, in a dedicated runner-temporary directory. The installer rejects download, checksum, and version failures without falling back to Homebrew. Installer changes select all three native workflows.
+
+[Upstream archived the OSS project](https://github.com/peripheryapp/periphery/commit/56a0eb6fb97b785c8fbc1044ccbc7b5d9f06ebec). The pin is a maintainer-owned bridge for the workflows' Xcode 26.6 toolchain, not a claim of ongoing upstream support. Native CI maintainers must revalidate both app scans and both shared consumers before changing Xcode, the pinned release, or the analyzer; retain the zero-findings policy and exact-USR intersection rather than adding a baseline or a weaker fallback.
+
 ## Fail-fast order
 
 1. `preflight` decides which lanes exist at all. The `docs-scope` and `changed-scope` logic are steps inside this job, not standalone jobs. Canonical `main` starts immediately in one of two parity slots; each slot admits one complete run and coalesces later pushes into its newest pending tip. On Node-relevant canonical `main` pushes and same-repository pull requests, preflight is the sole exact dependency-cache writer; downstream jobs wait for it, then restore the immutable archive or fall back to the ordinary pnpm-store cache on a miss.

--- a/scripts/install-periphery.sh
+++ b/scripts/install-periphery.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+temp_dir=""
+cleanup() {
+  local exit_code="$?"
+  if [[ -n "$temp_dir" ]]; then
+    rm -rf "$temp_dir"
+  fi
+  if [[ "$exit_code" -ne 0 ]]; then
+    printf '[install-periphery] FAILED (exit %s)\n' "$exit_code" >&2
+  fi
+}
+trap cleanup EXIT
+
+if [[ "$#" -ne 1 ]]; then
+  echo "usage: $0 <install-directory>" >&2
+  exit 2
+fi
+
+# The archived OSS release stays pinned until native CI validates an owner-approved successor.
+readonly periphery_version="3.8.0"
+readonly periphery_checksum="07d4e286e31dd79164df39097e0b59f533c94badbe18158464a455ea88a166d7"
+
+install_dir="$1"
+temp_dir="$(mktemp -d)"
+archive="$temp_dir/periphery.zip"
+extract_dir="$temp_dir/extract"
+
+curl --fail --location --silent --show-error \
+  --connect-timeout 10 --max-time 120 \
+  --retry 3 --retry-max-time 120 \
+  --output "$archive" \
+  "https://github.com/peripheryapp/periphery/releases/download/$periphery_version/periphery-$periphery_version.zip"
+if [[ "$(shasum -a 256 "$archive" | awk '{print $1}')" != "$periphery_checksum" ]]; then
+  echo "periphery archive checksum mismatch" >&2
+  exit 1
+fi
+
+mkdir -p "$install_dir" "$extract_dir"
+unzip -q "$archive" -d "$extract_dir"
+
+# The signed release resolves libIndexStore through @loader_path, beside the executable.
+install -m 0755 "$extract_dir/periphery" "$install_dir/periphery"
+install -m 0644 "$extract_dir/libIndexStore.dylib" "$install_dir/libIndexStore.dylib"
+install -m 0644 "$extract_dir/LICENSE.md" "$install_dir/LICENSE.md"
+
+installed_version="$("$install_dir/periphery" version)"
+if [[ "$installed_version" != "$periphery_version" ]]; then
+  echo "error: expected Periphery $periphery_version, got $installed_version" >&2
+  exit 1
+fi
+printf 'Periphery %s\n' "$installed_version"

--- a/test/scripts/install-native-tools.test.ts
+++ b/test/scripts/install-native-tools.test.ts
@@ -1,5 +1,5 @@
 import { spawnSync } from "node:child_process";
-import { chmodSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
@@ -15,7 +15,68 @@ const installers = [
     script: "scripts/install-swift-tools.sh",
     url: "https://github.com/nicklockwood/SwiftFormat/releases/download/0.62.1/swiftformat.zip",
   },
+  {
+    script: "scripts/install-periphery.sh",
+    url: "https://github.com/peripheryapp/periphery/releases/download/3.8.0/periphery-3.8.0.zip",
+  },
 ] as const;
+
+function writeExecutable(filePath: string, lines: string[]): void {
+  writeFileSync(filePath, ["#!/usr/bin/env bash", "set -euo pipefail", ...lines, ""].join("\n"), {
+    mode: 0o755,
+  });
+}
+
+function makePeripheryFixture(version = "3.8.0") {
+  const root = tempDirs.make("openclaw-periphery-installer-");
+  const binDir = path.join(root, "bin");
+  const bundleDir = path.join(root, "bundle");
+  const installDir = path.join(root, "install directory");
+  const archive = path.join(root, "periphery.zip");
+  const callsPath = path.join(root, "periphery-calls.txt");
+  mkdirSync(binDir);
+  mkdirSync(bundleDir);
+  writeExecutable(path.join(bundleDir, "periphery"), [
+    'printf "%s\\n" "$0" "$@" >>"$OPENCLAW_TEST_PERIPHERY_CALLS"',
+    '[[ "$#" -eq 1 && "$1" == "version" ]]',
+    '[[ -f "$(dirname "$0")/libIndexStore.dylib" ]]',
+    'printf "%s\\n" "$OPENCLAW_TEST_PERIPHERY_VERSION"',
+  ]);
+  writeFileSync(path.join(bundleDir, "libIndexStore.dylib"), "fixture index store\n");
+  writeFileSync(path.join(bundleDir, "LICENSE.md"), "fixture license\n");
+  const zip = spawnSync("zip", ["-q", archive, "periphery", "libIndexStore.dylib", "LICENSE.md"], {
+    cwd: bundleDir,
+    encoding: "utf8",
+  });
+  expect(zip.status, zip.stderr).toBe(0);
+  writeExecutable(path.join(binDir, "curl"), [
+    'while [[ "$#" -gt 0 ]]; do',
+    '  case "$1" in',
+    '    --output|-o) cp "$OPENCLAW_TEST_PERIPHERY_ARCHIVE" "$2"; exit 0 ;;',
+    "  esac",
+    "  shift",
+    "done",
+    "exit 64",
+  ]);
+  return {
+    binDir,
+    installDir,
+    callsPath,
+    run: () =>
+      spawnSync("bash", ["scripts/install-periphery.sh", installDir], {
+        cwd: process.cwd(),
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          OPENCLAW_TEST_PERIPHERY_ARCHIVE: archive,
+          OPENCLAW_TEST_PERIPHERY_CALLS: callsPath,
+          OPENCLAW_TEST_PERIPHERY_VERSION: version,
+          PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ""}`,
+          TMPDIR: root,
+        },
+      }),
+  };
+}
 
 function expectOption(args: string[], option: string, value: string): void {
   const index = args.indexOf(option);
@@ -30,16 +91,7 @@ describe.runIf(process.platform !== "win32")("native tool installers", () => {
     const argsPath = path.join(root, "curl-args.txt");
     const curlPath = path.join(binDir, "curl");
     mkdirSync(binDir);
-    writeFileSync(
-      curlPath,
-      [
-        "#!/usr/bin/env bash",
-        'printf "%s\\n" "$@" >"$OPENCLAW_TEST_CURL_ARGS_PATH"',
-        "exit 28",
-        "",
-      ].join("\n"),
-    );
-    chmodSync(curlPath, 0o755);
+    writeExecutable(curlPath, ['printf "%s\\n" "$@" >"$OPENCLAW_TEST_CURL_ARGS_PATH"', "exit 28"]);
 
     const result = spawnSync("bash", [script, path.join(root, "install")], {
       cwd: process.cwd(),
@@ -59,4 +111,49 @@ describe.runIf(process.platform !== "win32")("native tool installers", () => {
     expectOption(args, "--retry-max-time", "120");
     expect(args).toContain(url);
   });
+
+  it("rejects a Periphery archive with the wrong digest before extraction or execution", () => {
+    const fixture = makePeripheryFixture();
+    const unzipCalls = path.join(fixture.binDir, "unzip-calls.txt");
+    writeExecutable(path.join(fixture.binDir, "unzip"), [
+      'printf "%s\\n" "$@" >"$(dirname "$0")/unzip-calls.txt"',
+      "exit 99",
+    ]);
+
+    // This ZIP is extractable, but its real SHA-256 is not the pinned release digest.
+    const result = fixture.run();
+    expect(result.status, `${result.stdout}\n${result.stderr}`).toBeGreaterThan(0);
+    expect(result.stderr).toContain("checksum mismatch");
+    expect(existsSync(unzipCalls)).toBe(false);
+    expect(existsSync(fixture.callsPath)).toBe(false);
+    expect(existsSync(path.join(fixture.installDir, "periphery"))).toBe(false);
+  });
+
+  it.each([
+    { version: "3.8.0", exitCode: 0 },
+    { version: "3.8.1", exitCode: 1 },
+  ])(
+    "installs the complete Periphery bundle and verifies version $version",
+    ({ version, exitCode }) => {
+      const fixture = makePeripheryFixture(version);
+      // Substitute only the digest boundary; extraction, installation, and execution stay real.
+      writeExecutable(path.join(fixture.binDir, "shasum"), [
+        '[[ "$#" -eq 3 && "$1" == "-a" && "$2" == "256" ]]',
+        'cmp "$3" "$OPENCLAW_TEST_PERIPHERY_ARCHIVE"',
+        'printf "%s  %s\\n" "07d4e286e31dd79164df39097e0b59f533c94badbe18158464a455ea88a166d7" "$3"',
+      ]);
+
+      const result = fixture.run();
+      expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(exitCode);
+      expect(readFileSync(path.join(fixture.installDir, "libIndexStore.dylib"), "utf8")).toBe(
+        "fixture index store\n",
+      );
+      expect(readFileSync(path.join(fixture.installDir, "LICENSE.md"), "utf8")).toBe(
+        "fixture license\n",
+      );
+      expect(readFileSync(fixture.callsPath, "utf8")).toBe(
+        `${path.join(fixture.installDir, "periphery")}\nversion\n`,
+      );
+    },
+  );
 });

--- a/test/scripts/periphery-scope-workflows.test.ts
+++ b/test/scripts/periphery-scope-workflows.test.ts
@@ -155,6 +155,9 @@ describe("Periphery scope workflows", () => {
     "selects only $name scope changes",
     async ({ path: workflowPath, scopedPath }) => {
       await expect(runScope(workflowPath, { files: [scopedPath] })).resolves.toBe("true");
+      await expect(
+        runScope(workflowPath, { files: ["scripts/install-periphery.sh"] }),
+      ).resolves.toBe("true");
       await expect(runScope(workflowPath, { files: ["docs/index.md"] })).resolves.toBe("false");
       await expect(runScope(workflowPath, { draft: true, files: [scopedPath] })).resolves.toBe(
         "false",


### PR DESCRIPTION
## What Problem This Solves

Resolves a reproducibility and maintenance problem in the native dead-code gates: their four consumers install whatever Homebrew currently supplies for Periphery even though the OSS upstream is archived. Homebrew currently supplies 3.8.0, marks it deprecated for `repo_archived`, and schedules disablement for 2027-08-12. This is not a claim that current installation or native scans have already stopped working.

The maintainer requested this focused installer change, native proof, and landing after evaluating maintained OSS alternatives. It is separate from the seven-day dependency refresh; no package manifests, lockfiles, baselines, or analyzer configuration change.

## Why This Change Was Made

Keep the existing Periphery 3.8.0 analyzer and the complete zero-findings contract. A single bounded, checksum-pinned release installer replaces all four floating Homebrew installations. It preserves the signed release's adjacent `libIndexStore.dylib` and license in a dedicated runner-temporary directory, verifies the installed version, and has no Homebrew or analyzer fallback. Installer-only changes select all three standalone native workflows.

This is the maintainer-approved Xcode 26.6 bridge, not an upstream maintenance claim. The native CI maintainers own revalidation before changing the toolchain, pin, or analyzer. No maintained OSS successor examined preserved the current whole-project analysis and JSON Swift-USR contract: the preservation fork currently republishes identical release bytes, while SwiftLint and Deadwood expose different detection/output contracts.

The new installer is an intentional supply-chain boundary, reused by four consumers; a new generic downloader framework or installing Periphery in every unrelated Swift-tooling job would be a larger change. Application/runtime source is unchanged. The existing scan, report, artifact, and failure step objects were compared before and after and are identical, including the shared consumers' intentional non-strict scans followed by exact-USR intersection.

Upstream evidence: [archive announcement](https://github.com/peripheryapp/periphery/commit/56a0eb6fb97b785c8fbc1044ccbc7b5d9f06ebec), [3.8.0 release](https://github.com/peripheryapp/periphery/releases/tag/3.8.0), and [runtime-library bundling contract](https://github.com/peripheryapp/periphery/blob/a2db299196ae774cd644c79fa6b1f67556d78de8/.mise/tasks/release#L84-L121). The pinned ZIP SHA-256 was independently downloaded and matched to GitHub's asset digest.

## User Impact

No application behavior change. Native contributors retain the same zero-findings gates, while CI installs a fixed OSS release rather than relying on a deprecated floating formula. Missing or corrupt downloads, wrong versions, and incomplete bundles fail instead of weakening the analysis.

## Evidence

Completed local proof:

- `node scripts/run-vitest.mjs test/scripts/install-native-tools.test.ts test/scripts/periphery-scope-workflows.test.ts test/scripts/periphery-intersection.test.ts test/scripts/ios-periphery-comment-workflow.test.ts` — 45 tests passed.
- `node scripts/run-vitest.mjs test/scripts/ci-workflow-guards.test.ts test/scripts/test-projects.test.ts -t 'pins Swift 6.3 workflow jobs|routes Periphery workflow edits'` — both selected guards passed; unrelated cases were intentionally not selected.
- `node --import tsx scripts/check-workflows.mts` — passed, including workflow security and composite-action interpolation checks.
- Real network installation through `scripts/install-periphery.sh <owned-temporary-directory>` — installed version 3.8.0; both executable and adjacent dylib passed code-signature verification.
- Replayed the original and candidate workflow scope scripts with an installer-only change: all three changed from `should-scan=false` to `should-scan=true`. Existing test-owner resolution selects the installer and scope regression files without a new routing table.
- Compared the scan, report, artifact, and failure step objects before and after — identical. `git diff --check` passed.

- `node scripts/check-changed.mjs -- scripts/install-periphery.sh .github/workflows/ios-periphery.yml .github/workflows/macos-periphery.yml .github/workflows/shared-openclawkit-periphery.yml docs/ci.md test/scripts/install-native-tools.test.ts test/scripts/periphery-scope-workflows.test.ts` — passed the classified formatting, test-root typecheck, script lint, and guard plan.
- Fresh isolated Codex autoreview of the complete uncommitted patch — scoped-clean, no accepted/actionable findings through P2.

Application/runtime production LOC: **+0/-0**. CI/tooling: **+69/-8 (net +61)** for one verified-release installation boundary and four consumers. Tests: **+111/-11**. Docs: **+4/-0**. No generated, baseline, lockfile, or snapshot changes.

Exact-head hosted proof on `1f5d519e3e81094cdacb4bde34b53f7a18573f68`:

- [CI](https://github.com/openclaw/openclaw/actions/runs/33233197239) and [Workflow Sanity](https://github.com/openclaw/openclaw/actions/runs/33233162962) passed.
- [iOS Periphery](https://github.com/openclaw/openclaw/actions/runs/33233197282) and [macOS Periphery](https://github.com/openclaw/openclaw/actions/runs/33233197285) each actually ran under Xcode 26.6 / Swift 6.3.3, logged installed `Periphery 3.8.0`, and produced empty findings, scan status 0, and `should-fail=0`.
- [Shared OpenClawKit Periphery](https://github.com/openclaw/openclaw/actions/runs/33233197229) completed both Xcode 26.6 consumers with scan status 0. Raw findings were 216 for iOS and 227 for macOS; the exact-USR intersection was empty.

All producer reports, the shared intersection, and toolchain/installer log lines were downloaded and inspected. These are candidate-installer runs, not the historical Homebrew evidence. The macOS runners queued before starting; no native test retry, baseline change, or weakened assertion was needed.

Review follow-through: the [fresh ClawSweeper review](https://github.com/openclaw/openclaw/pull/132344#issuecomment-5460316564) found no code defects. Its native-validation risks and sole Rank-up move are addressed by the runs above. Its isolated DNS failure prevented its own upstream fetch; the lead independently read the exact release/source contracts and downloaded/verified the official ZIP before these real native runs. No code change or re-review request was needed.

The host has only Xcode 27 beta / Swift 6.4. The real installed binary passed an isolated clean/unused-declaration smoke with the legacy native SwiftPM build system explicitly selected: clean source produced `[]` and exit 0; one unused function produced its Swift USR and exit 1. The default Xcode 27 SwiftPM path remains incompatible with 3.8.0's expected index-store layout; this PR does not change or mask that next-toolchain limitation, and the local smoke is not presented as Xcode 26.6 CI parity.

AI-assisted with Codex. No app screenshots are required: no app or user-visible interaction code changes.
