### PR TITLE
fix: plugin checks skip inherited config changes

### DIFF
--- a/scripts/check-extension-package-tsc-boundary.mts
+++ b/scripts/check-extension-package-tsc-boundary.mts
@@ -21,6 +21,7 @@ import {
   resolveTimerTimeoutMs,
 } from "../packages/normalization-core/src/number-coercion.ts";
 import { toErrorObject } from "./lib/error-format.mts";
+import { EXTENSION_BOUNDARY_CONFIG_INPUTS } from "./lib/extension-package-boundary-inputs.mts";
 import { parsePositiveInt } from "./lib/numeric-options.mjs";
 import { resolveRepoRoot } from "./lib/repo-root.mjs";
 import {
@@ -400,6 +401,14 @@ function collectOldestMtime(paths: string[]) {
   return Number.isFinite(oldestMtimeMs) ? oldestMtimeMs : null;
 }
 
+function collectSharedNewestInputMtime(rootDir: string) {
+  return Math.max(
+    ...[...EXTENSION_BOUNDARY_CONFIG_INPUTS, "dist/plugin-sdk", "packages/plugin-sdk/dist"].map(
+      (input) => collectNewestMtime(resolve(rootDir, input), { skipDistDirectories: false }),
+    ),
+  );
+}
+
 /**
  * Checks whether an extension boundary compile canary is still fresh.
  */
@@ -410,15 +419,7 @@ export function isBoundaryCompileFresh(extensionId: string, params: CompileFresh
     params.extensionNewestInputMtimeMs ??
     collectNewestMtime(extensionRoot, { includeFile: isRelevantCompileInput });
   const sharedNewestInputMtimeMs =
-    params.sharedNewestInputMtimeMs ??
-    Math.max(
-      collectNewestMtime(resolve(rootDir, "dist/plugin-sdk"), {
-        skipDistDirectories: false,
-      }),
-      collectNewestMtime(resolve(rootDir, "packages/plugin-sdk/dist"), {
-        skipDistDirectories: false,
-      }),
-    );
+    params.sharedNewestInputMtimeMs ?? collectSharedNewestInputMtime(rootDir);
   const newestInputMtimeMs = Math.max(extensionNewestInputMtimeMs, sharedNewestInputMtimeMs);
   const oldestOutputMtimeMs = collectOldestMtime([
     resolveBoundaryTsStampPath(extensionId, rootDir),
@@ -910,14 +911,7 @@ async function runCompileCheck(extensionIds: string[]) {
   const prepElapsedMs = Date.now() - prepStartedAt;
   const concurrency = resolveCompileConcurrency();
   const verboseFreshLogs = process.env.OPENCLAW_EXTENSION_BOUNDARY_VERBOSE_FRESH === "1";
-  const sharedNewestInputMtimeMs = Math.max(
-    collectNewestMtime(resolve(repoRoot, "dist/plugin-sdk"), {
-      skipDistDirectories: false,
-    }),
-    collectNewestMtime(resolve(repoRoot, "packages/plugin-sdk/dist"), {
-      skipDistDirectories: false,
-    }),
-  );
+  const sharedNewestInputMtimeMs = collectSharedNewestInputMtime(repoRoot);
   process.stdout.write(`compile concurrency ${concurrency}\n`);
   const compileStartedAt = Date.now();
   let skippedCompileCount = 0;

--- a/scripts/lib/extension-package-boundary-inputs.mts
+++ b/scripts/lib/extension-package-boundary-inputs.mts
@@ -1,0 +1,6 @@
+// Fixed inheritance chain for plugins opting into package-boundary compilation.
+export const EXTENSION_BOUNDARY_CONFIG_INPUTS = [
+  "tsconfig.json",
+  "extensions/tsconfig.package-boundary.base.json",
+  "extensions/tsconfig.package-boundary.paths.json",
+] as const;

--- a/scripts/prepare-extension-package-boundary-artifacts.mts
+++ b/scripts/prepare-extension-package-boundary-artifacts.mts
@@ -11,6 +11,7 @@ import {
   resolveTimerTimeoutMs,
 } from "../packages/normalization-core/src/number-coercion.ts";
 import { acquireExtensionPackageBoundaryArtifactLockSync } from "./lib/extension-package-boundary-artifact-lock.mts";
+import { EXTENSION_BOUNDARY_CONFIG_INPUTS } from "./lib/extension-package-boundary-inputs.mts";
 import {
   ensureRepoToolNodeModulesLink,
   isLocalCheckEnabled,
@@ -371,6 +372,7 @@ const PACKAGE_DTS_REQUIRED_OUTPUTS = [
   "packages/plugin-sdk/dist/src/plugin-sdk/video-generation.d.ts",
 ];
 const QA_CHANNEL_DTS_INPUTS = [
+  ...EXTENSION_BOUNDARY_CONFIG_INPUTS,
   "extensions/qa-channel/api.ts",
   "extensions/qa-channel/runtime-api.ts",
   "extensions/qa-channel/test-api.ts",
@@ -380,6 +382,7 @@ const QA_CHANNEL_DTS_INPUTS = [
 const QA_CHANNEL_DTS_STAMP = "dist/plugin-sdk/extensions/qa-channel/.boundary-dts.stamp";
 const QA_CHANNEL_DTS_REQUIRED_OUTPUTS = ["dist/plugin-sdk/extensions/qa-channel/api.d.ts"];
 const MEMORY_CORE_DTS_INPUTS = [
+  ...EXTENSION_BOUNDARY_CONFIG_INPUTS,
   "extensions/memory-core/api.ts",
   "extensions/memory-core/src",
   "extensions/memory-core/tsconfig.json",
@@ -387,6 +390,7 @@ const MEMORY_CORE_DTS_INPUTS = [
 const MEMORY_CORE_DTS_STAMP = "dist/plugin-sdk/extensions/memory-core/.boundary-dts.stamp";
 const MEMORY_CORE_DTS_REQUIRED_OUTPUTS = ["dist/plugin-sdk/extensions/memory-core/api.d.ts"];
 const MATRIX_DTS_INPUTS = [
+  ...EXTENSION_BOUNDARY_CONFIG_INPUTS,
   "extensions/matrix/test-api.ts",
   "extensions/matrix/src",
   "extensions/matrix/tsconfig.json",
@@ -394,6 +398,7 @@ const MATRIX_DTS_INPUTS = [
 const MATRIX_DTS_STAMP = "dist/plugin-sdk/extensions/matrix/.boundary-dts.stamp";
 const MATRIX_DTS_REQUIRED_OUTPUTS = ["dist/plugin-sdk/extensions/matrix/test-api.d.ts"];
 const DISCORD_DTS_INPUTS = [
+  ...EXTENSION_BOUNDARY_CONFIG_INPUTS,
   "extensions/discord/api.ts",
   "extensions/discord/src/api.ts",
   "extensions/discord/tsconfig.json",
@@ -401,16 +406,22 @@ const DISCORD_DTS_INPUTS = [
 const DISCORD_DTS_STAMP = "dist/plugin-sdk/extensions/discord/.boundary-dts.stamp";
 const DISCORD_DTS_REQUIRED_OUTPUTS = ["dist/plugin-sdk/extensions/discord/api.d.ts"];
 const SLACK_DTS_INPUTS = [
+  ...EXTENSION_BOUNDARY_CONFIG_INPUTS,
   "extensions/slack/api.ts",
   "extensions/slack/src/client.ts",
   "extensions/slack/tsconfig.json",
 ];
 const SLACK_DTS_STAMP = "dist/plugin-sdk/extensions/slack/.boundary-dts.stamp";
 const SLACK_DTS_REQUIRED_OUTPUTS = ["dist/plugin-sdk/extensions/slack/api.d.ts"];
-const TELEGRAM_DTS_INPUTS = ["extensions/telegram/api.ts", "extensions/telegram/tsconfig.json"];
+const TELEGRAM_DTS_INPUTS = [
+  ...EXTENSION_BOUNDARY_CONFIG_INPUTS,
+  "extensions/telegram/api.ts",
+  "extensions/telegram/tsconfig.json",
+];
 const TELEGRAM_DTS_STAMP = "dist/plugin-sdk/extensions/telegram/.boundary-dts.stamp";
 const TELEGRAM_DTS_REQUIRED_OUTPUTS = ["dist/plugin-sdk/extensions/telegram/api.d.ts"];
 const WHATSAPP_DTS_INPUTS = [
+  ...EXTENSION_BOUNDARY_CONFIG_INPUTS,
   "extensions/whatsapp/api.ts",
   "extensions/whatsapp/src/qa-driver.runtime.ts",
   "extensions/whatsapp/tsconfig.json",
@@ -555,6 +566,7 @@ const EXTENSION_BOUNDARY_NON_TYPE_INPUTS = [
   "packages/plugin-sdk/tsconfig.json",
   "scripts/check-extension-package-tsc-boundary.mts",
   "scripts/prepare-extension-package-boundary-artifacts.mts",
+  "scripts/lib/extension-package-boundary-inputs.mts",
   "scripts/write-plugin-sdk-entry-dts.ts",
   "scripts/lib/plugin-sdk-entrypoints.json",
   "scripts/lib/plugin-sdk-entries.mts",

--- a/test/scripts/check-extension-package-tsc-boundary.test.ts
+++ b/test/scripts/check-extension-package-tsc-boundary.test.ts
@@ -1,5 +1,5 @@
 // Check Extension Package Tsc Boundary tests cover check extension package tsc boundary script behavior.
-import { spawn } from "node:child_process";
+import { spawn, spawnSync } from "node:child_process";
 import { EventEmitter } from "node:events";
 import fs from "node:fs";
 import os from "node:os";
@@ -264,54 +264,115 @@ describe("check-extension-package-tsc-boundary", () => {
     ).toBe(["slowest plugin compiles:", "- slow: 900ms", "- medium: 250ms", ""].join("\n"));
   });
 
-  it("treats a plugin compile as fresh only when its outputs are newer than plugin and shared sdk inputs", () => {
+  it.each([
+    "extensions/demo/index.ts",
+    "extensions/demo/tsconfig.json",
+    "extensions/demo/package.json",
+    "dist/plugin-sdk/core.d.ts",
+    "packages/plugin-sdk/dist/src/plugin-sdk/core.d.ts",
+    "tsconfig.json",
+    "extensions/tsconfig.package-boundary.base.json",
+    "extensions/tsconfig.package-boundary.paths.json",
+  ])("invalidates a warm compile after %s changes", (input) => {
     const { rootDir, extensionRoot } = createTempExtensionRoot();
-    const extensionSourcePath = path.join(extensionRoot, "index.ts");
-    const extensionTsconfigPath = path.join(extensionRoot, "tsconfig.json");
+    const inputPath = path.join(rootDir, input);
     const stampPath = path.join(extensionRoot, "dist", ".boundary-tsc.stamp");
-    const rootSdkTypePath = path.join(rootDir, "dist", "plugin-sdk", "core.d.ts");
-    const packageSdkTypePath = path.join(
-      rootDir,
-      "packages",
-      "plugin-sdk",
-      "dist",
-      "src",
-      "plugin-sdk",
-      "core.d.ts",
-    );
-
-    fs.mkdirSync(path.dirname(extensionSourcePath), { recursive: true });
+    fs.mkdirSync(path.dirname(inputPath), { recursive: true });
     fs.mkdirSync(path.dirname(stampPath), { recursive: true });
-    fs.mkdirSync(path.dirname(rootSdkTypePath), { recursive: true });
-    fs.mkdirSync(path.dirname(packageSdkTypePath), { recursive: true });
-
-    fs.writeFileSync(extensionSourcePath, "export const demo = 1;\n", "utf8");
-    fs.writeFileSync(
-      extensionTsconfigPath,
-      '{ "extends": "../tsconfig.package-boundary.base.json" }\n',
-      "utf8",
-    );
-    fs.writeFileSync(stampPath, "ok\n", "utf8");
-    fs.writeFileSync(rootSdkTypePath, "export {};\n", "utf8");
-    fs.writeFileSync(packageSdkTypePath, "export {};\n", "utf8");
-
-    fs.utimesSync(extensionSourcePath, new Date(1_000), new Date(1_000));
-    fs.utimesSync(extensionTsconfigPath, new Date(1_000), new Date(1_000));
-    fs.utimesSync(rootSdkTypePath, new Date(500), new Date(500));
-    fs.utimesSync(packageSdkTypePath, new Date(2_000), new Date(2_000));
-    fs.utimesSync(stampPath, new Date(3_000), new Date(3_000));
+    fs.writeFileSync(inputPath, input.endsWith(".json") ? "{}\n" : "export {};\n");
+    fs.writeFileSync(stampPath, "ok\n");
+    fs.utimesSync(inputPath, new Date(1_000), new Date(1_000));
+    fs.utimesSync(stampPath, new Date(2_000), new Date(2_000));
 
     expect(isBoundaryCompileFresh("demo", { rootDir })).toBe(true);
-
-    fs.utimesSync(rootSdkTypePath, new Date(500), new Date(500));
-    fs.utimesSync(packageSdkTypePath, new Date(500), new Date(500));
-
-    expect(isBoundaryCompileFresh("demo", { rootDir })).toBe(true);
-
-    fs.utimesSync(rootSdkTypePath, new Date(4_000), new Date(4_000));
-
+    fs.utimesSync(inputPath, new Date(3_000), new Date(3_000));
     expect(isBoundaryCompileFresh("demo", { rootDir })).toBe(false);
+
+    fs.utimesSync(stampPath, new Date(4_000), new Date(4_000));
+    expect(isBoundaryCompileFresh("demo", { rootDir })).toBe(true);
   });
+
+  it("reruns the real compiler after an inherited paths change in the CLI", () => {
+    const fixture = createTempExtensionRoot();
+    const rootDir = fs.realpathSync(fixture.rootDir);
+    const write = (relativePath: string, contents: string) => {
+      const filePath = path.join(rootDir, relativePath);
+      fs.mkdirSync(path.dirname(filePath), { recursive: true });
+      fs.writeFileSync(filePath, contents);
+      fs.utimesSync(filePath, new Date(1_000), new Date(1_000));
+    };
+    write("package.json", '{"type":"module"}\n');
+    write("tsconfig.json", '{"compilerOptions":{"module":"NodeNext","strict":true,"types":[]}}\n');
+    const pathsConfig = "extensions/tsconfig.package-boundary.paths.json";
+    const config = {
+      extends: "../tsconfig.json",
+      compilerOptions: {
+        paths: { "openclaw/plugin-sdk/*": ["../dist/plugin-sdk/*.d.ts"] },
+      },
+    };
+    write(pathsConfig, JSON.stringify(config));
+    write(
+      "extensions/tsconfig.package-boundary.base.json",
+      '{"extends":"./tsconfig.package-boundary.paths.json","compilerOptions":{"rootDir":"${configDir}"}}\n',
+    );
+    write(
+      "extensions/demo/tsconfig.json",
+      '{"extends":"../tsconfig.package-boundary.base.json","include":["index.ts"]}\n',
+    );
+    write("dist/plugin-sdk/core.d.ts", "export type DemoContract = { ok: boolean };\n");
+    write(
+      "extensions/demo/index.ts",
+      'import type { DemoContract } from "openclaw/plugin-sdk/core";\nexport const demo: DemoContract = { ok: true };\n',
+    );
+    // Hold the already-prepared declaration boundary fixed; the CLI's compile
+    // scheduling, incremental compiler, and successful stamp writer stay real.
+    write("scripts/prepare-extension-package-boundary-artifacts.mts", "export {};\n");
+    fs.symlinkSync(
+      path.resolve("node_modules"),
+      path.join(rootDir, "node_modules"),
+      process.platform === "win32" ? "junction" : "dir",
+    );
+    const scriptPath = path.resolve("scripts/check-extension-package-tsc-boundary.mts");
+    const rootModule = `export const resolveRepoRoot = () => ${JSON.stringify(rootDir)};`;
+    write(
+      "root-hook.mjs",
+      `import { registerHooks } from "node:module";
+registerHooks({ resolve(specifier, context, nextResolve) {
+  if (context.parentURL === ${JSON.stringify(pathToFileURL(scriptPath).href)} && specifier === "./lib/repo-root.mjs") {
+    return { url: ${JSON.stringify(`data:text/javascript,${encodeURIComponent(rootModule)}`)}, shortCircuit: true };
+  }
+  return nextResolve(specifier, context);
+}});\n`,
+    );
+    const run = () =>
+      spawnSync(
+        process.execPath,
+        ["--import", path.join(rootDir, "root-hook.mjs"), scriptPath, "--mode=compile"],
+        { encoding: "utf8", timeout: 20_000 },
+      );
+    const cold = run();
+    expect(cold.error, cold.stderr).toBeUndefined();
+    expect(cold.status, cold.stdout + cold.stderr).toBe(0);
+    expect(cold.stdout).toContain("compiled plugins: 1");
+
+    const stampPath = path.join(rootDir, "extensions/demo/dist/.boundary-tsc.stamp");
+    const stamp = fs.readFileSync(stampPath, "utf8");
+    fs.utimesSync(stampPath, new Date(2_000), new Date(2_000));
+    const warm = run();
+    expect(warm.status, warm.stdout + warm.stderr).toBe(0);
+    expect(warm.stdout).toContain("skipped plugins: 1");
+    expect(warm.stdout).toContain("compiled plugins: 0");
+
+    config.compilerOptions.paths["openclaw/plugin-sdk/*"] = ["../missing-sdk/*.d.ts"];
+    write(pathsConfig, JSON.stringify(config));
+    fs.utimesSync(path.join(rootDir, pathsConfig), new Date(3_000), new Date(3_000));
+    const changed = run();
+    expect(changed.error, changed.stderr).toBeUndefined();
+    expect(changed.status, changed.stdout + changed.stderr).toBe(1);
+    expect(changed.stderr).toContain("TS2307");
+    expect(fs.readFileSync(stampPath, "utf8")).toBe(stamp);
+    expect(fs.statSync(stampPath).mtimeMs).toBe(2_000);
+  }, 30_000);
 
   it("accepts cached input mtimes for freshness checks", () => {
     const { rootDir, extensionRoot } = createTempExtensionRoot();
@@ -517,11 +578,17 @@ describe("check-extension-package-tsc-boundary", () => {
         "setInterval(() => {}, 1000);",
       ].join("");
 
+      const parent = spawn(process.execPath, ["--eval", parentScript], {
+        detached: true,
+        stdio: ["ignore", "pipe", "pipe"],
+      });
       try {
-        const failurePromise = runNodeStepAsync("hung-step-group", ["--eval", parentScript], 100, {
-          spawnImpl(command: string, args: string[], options: unknown) {
-            return spawn(command, args, options as Parameters<typeof spawn>[2]);
-          },
+        // Give the timeout owner a ready process group: its 100 ms deadline must
+        // test cleanup, not race cold child startup under a loaded test runner.
+        childPid = await waitForPidFile(childPidPath, 2_000);
+        expect(isProcessAlive(childPid)).toBe(true);
+        const failure = await runNodeStepAsync("hung-step-group", ["--eval", parentScript], 100, {
+          spawnImpl: () => parent,
         }).then(
           () => {
             throw new Error("expected hung-step-group to time out");
@@ -529,13 +596,13 @@ describe("check-extension-package-tsc-boundary", () => {
           (error: unknown) => error,
         );
 
-        childPid = await waitForPidFile(childPidPath, 2_000);
-        expect(isProcessAlive(childPid)).toBe(true);
-
-        const failure = await failurePromise;
         expect(failure).toBeInstanceOf(Error);
+        expect(failure).toMatchObject({ kind: "timeout" });
         await waitForDead(childPid, 2_000);
       } finally {
+        if (parent.pid && isProcessAlive(parent.pid)) {
+          process.kill(-parent.pid, "SIGKILL");
+        }
         if (childPid && isProcessAlive(childPid)) {
           process.kill(childPid, "SIGKILL");
         }

--- a/test/scripts/prepare-extension-package-boundary-artifacts.test.ts
+++ b/test/scripts/prepare-extension-package-boundary-artifacts.test.ts
@@ -1,10 +1,10 @@
 // Prepare Extension Package Boundary Artifacts tests cover prepare extension package boundary artifacts script behavior.
-import { spawn } from "node:child_process";
+import { spawn, spawnSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { setTimeout as delay } from "node:timers/promises";
-import { pathToFileURL } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import { MAX_TIMER_TIMEOUT_MS } from "@openclaw/normalization-core/number-coercion";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
@@ -13,6 +13,7 @@ import {
 } from "../../scripts/lib/plugin-sdk-entries.mjs";
 import {
   computeArtifactInputsDigest,
+  computeExtensionBoundaryInputsFingerprint,
   createPrefixedOutputWriter,
   derivePluginSdkTypeInputsFromBuildInfo,
   isArtifactSetFresh,
@@ -27,6 +28,147 @@ import {
 import { makeTempDir } from "../helpers/temp-dir.js";
 
 const tempRoots = new Set<string>();
+const inheritedConfigs = [
+  "tsconfig.json",
+  "extensions/tsconfig.package-boundary.base.json",
+  "extensions/tsconfig.package-boundary.paths.json",
+];
+
+function createPrepSchedulingFixture() {
+  const rootDir = makeTempDir(tempRoots, "openclaw-boundary-scheduling-");
+  const pluginIds = [
+    "qa-channel",
+    "memory-core",
+    "matrix",
+    "discord",
+    "slack",
+    "telegram",
+    "whatsapp",
+  ];
+  const pluginConfigs = pluginIds.map((id) => `extensions/${id}/tsconfig.json`);
+  const write = (relativePath: string, contents = "{}\n", mtimeMs = 1_000) => {
+    const filePath = path.join(rootDir, relativePath);
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    fs.writeFileSync(filePath, contents);
+    fs.utimesSync(filePath, new Date(mtimeMs), new Date(mtimeMs));
+  };
+  const outputs = new Set([
+    ...resolveBoundaryEntryShimRequiredOutputs({ OPENCLAW_BUILD_PRIVATE_QA: "1" }),
+    "dist/plugin-sdk/.tsbuildinfo",
+    "dist/plugin-sdk/.boundary-dts.stamp",
+    "dist/plugin-sdk/.boundary-entry-shims.stamp",
+    "packages/plugin-sdk/dist/.tsbuildinfo",
+    "packages/plugin-sdk/dist/.boundary-dts.stamp",
+  ]);
+  // Seed declaration-shaped outputs from source paths, not a copied required-output inventory.
+  const collectPackageOutputs = (directory: string) => {
+    for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+      if (["node_modules", "dist"].includes(entry.name)) continue;
+      const entryPath = path.join(directory, entry.name);
+      if (entry.isDirectory()) collectPackageOutputs(entryPath);
+      else if (entry.name.endsWith(".ts")) {
+        const relative = path.relative(process.cwd(), entryPath).replaceAll("\\", "/");
+        for (const prefix of ["dist/plugin-sdk", "packages/plugin-sdk/dist"]) {
+          outputs.add(`${prefix}/${relative.replace(/\.ts$/u, ".d.ts")}`);
+        }
+      }
+    }
+  };
+  const sdkConfig = JSON.parse(fs.readFileSync("tsconfig.plugin-sdk.dts.json", "utf8")) as {
+    include: string[];
+  };
+  for (const include of sdkConfig.include.filter((input) => input.startsWith("packages/"))) {
+    collectPackageOutputs(path.resolve(include.replace(/\/\*\*.*$/u, "")));
+  }
+  for (const id of pluginIds) {
+    for (const output of ["api.d.ts", "test-api.d.ts", ".boundary-dts.stamp"]) {
+      outputs.add(`dist/plugin-sdk/extensions/${id}/${output}`);
+    }
+  }
+  for (const output of outputs) write(output, "{}\n", 2_000);
+  for (const config of [
+    ...inheritedConfigs,
+    "tsconfig.plugin-sdk.dts.json",
+    "packages/plugin-sdk/tsconfig.json",
+  ])
+    write(config);
+  for (const config of pluginConfigs) write(config, "{}\n", 3_000);
+  write("tsconfig.json", "{}\n", 3_000);
+  write("packages/acp-core/package.json");
+  fs.mkdirSync(path.join(rootDir, "packages/ai/src"), { recursive: true });
+  // Keep lane selection, filesystem freshness, and stamp writes in the real prep owner.
+  const managedCommandUrl = pathToFileURL(
+    path.resolve("scripts/lib/managed-child-process.mts"),
+  ).href;
+  write(
+    "command-recorder.mjs",
+    `
+    import fs from 'node:fs';
+    import path from 'node:path';
+    export { createManagedCommandInvocation, signalExitCode } from ${JSON.stringify(managedCommandUrl)};
+    export async function runManagedCommand({ args, cwd }) {
+    const project = args.includes('-p') ? args[args.indexOf('-p') + 1] : 'entry-shims';
+    fs.appendFileSync(path.join(cwd, 'steps.log'), project + '\\n');
+    if (args.includes('-p')) {
+      const buildInfo = args.includes('--tsBuildInfoFile')
+        ? args[args.indexOf('--tsBuildInfoFile') + 1]
+        : project === 'tsconfig.plugin-sdk.dts.json'
+          ? 'dist/plugin-sdk/.tsbuildinfo' : 'packages/plugin-sdk/dist/.tsbuildinfo';
+      fs.mkdirSync(path.dirname(path.join(cwd, buildInfo)), { recursive: true });
+      fs.writeFileSync(path.join(cwd, buildInfo), '{}\\n');
+    }
+    return 0;
+    }
+  `,
+  );
+  const scriptUrl = pathToFileURL(
+    path.resolve("scripts/prepare-extension-package-boundary-artifacts.mts"),
+  ).href;
+  const rootModule = `export const resolveRepoRoot = () => ${JSON.stringify(rootDir)};`;
+  write(
+    "root-hook.mjs",
+    `
+    import { registerHooks } from 'node:module';
+    registerHooks({ resolve(specifier, context, nextResolve) {
+      if (context.parentURL === ${JSON.stringify(scriptUrl)}) {
+        if (specifier === './lib/repo-root.mjs') {
+          return { url: ${JSON.stringify(`data:text/javascript,${encodeURIComponent(rootModule)}`)}, shortCircuit: true };
+        }
+        if (specifier === './lib/managed-child-process.mts') {
+          return { url: ${JSON.stringify(pathToFileURL(path.join(rootDir, "command-recorder.mjs")).href)}, shortCircuit: true };
+        }
+      }
+      return nextResolve(specifier, context);
+    }});
+  `,
+  );
+  const run = () => {
+    write("steps.log", "");
+    const result = spawnSync(
+      process.execPath,
+      ["--import", path.join(rootDir, "root-hook.mjs"), fileURLToPath(scriptUrl)],
+      {
+        cwd: process.cwd(),
+        encoding: "utf8",
+        timeout: 20_000,
+      },
+    );
+    expect(result.error, result.stderr).toBeUndefined();
+    expect(result.status, result.stdout + result.stderr).toBe(0);
+    return fs
+      .readFileSync(path.join(rootDir, "steps.log"), "utf8")
+      .trim()
+      .split("\n")
+      .filter(Boolean)
+      .toSorted();
+  };
+  const resetOutputMtimes = () => {
+    for (const output of outputs) {
+      fs.utimesSync(path.join(rootDir, output), new Date(2_000), new Date(2_000));
+    }
+  };
+  return { rootDir, pluginIds, pluginConfigs, write, run, resetOutputMtimes };
+}
 
 afterEach(() => {
   for (const rootDir of tempRoots) {
@@ -91,6 +233,60 @@ async function waitForProcessExit(
 }
 
 describe("prepare-extension-package-boundary-artifacts", () => {
+  it.each(inheritedConfigs)(
+    "tracks %s in declaration scheduling and successful hash stamps",
+    (config) => {
+      const fixture = createPrepSchedulingFixture();
+      const { rootDir, pluginIds, pluginConfigs, write, run, resetOutputMtimes } = fixture;
+      const allSteps = [
+        ...pluginConfigs,
+        "tsconfig.plugin-sdk.dts.json",
+        "packages/plugin-sdk/tsconfig.json",
+        "entry-shims",
+      ];
+      expect(run()).toEqual(allSteps.toSorted());
+      for (const ownConfig of ["tsconfig.json", ...pluginConfigs]) write(ownConfig);
+      resetOutputMtimes();
+      expect(run()).toEqual([]);
+
+      // Re-stamping identical bytes must use the real lane hash and repair its mtimes.
+      write(config, "{}\n", 3_000);
+      expect(run()).toEqual([]);
+      for (const id of pluginIds) {
+        expect
+          .soft(
+            fs.statSync(path.join(rootDir, `dist/plugin-sdk/extensions/${id}/.boundary-dts.stamp`))
+              .mtimeMs,
+            id,
+          )
+          .toBeGreaterThan(3_000);
+      }
+
+      resetOutputMtimes();
+      write(config, '{"compilerOptions":{"strict":true}}\n', 4_000);
+      const expectedSteps = config === "tsconfig.json" ? allSteps : pluginConfigs;
+      expect(run()).toEqual(expectedSteps.toSorted());
+      expect(run()).toEqual([]);
+    },
+    30_000,
+  );
+
+  it.each([...inheritedConfigs, "scripts/lib/extension-package-boundary-inputs.mts"])(
+    "fingerprints byte changes in %s",
+    (input) => {
+      const rootDir = makeTempDir(tempRoots, "openclaw-boundary-fingerprint-");
+      const buildInfo = path.join(rootDir, "dist/plugin-sdk/.tsbuildinfo");
+      const inputPath = path.join(rootDir, input);
+      fs.mkdirSync(path.dirname(buildInfo), { recursive: true });
+      fs.mkdirSync(path.dirname(inputPath), { recursive: true });
+      fs.writeFileSync(buildInfo, "{}");
+      fs.writeFileSync(inputPath, "{}\n");
+      const before = computeExtensionBoundaryInputsFingerprint(rootDir);
+      fs.appendFileSync(inputPath, "\n");
+      expect(computeExtensionBoundaryInputsFingerprint(rootDir)).not.toBe(before);
+    },
+  );
+
   it("derives the historical SDK cache misses from TypeScript build inputs", () => {
     const rootDir = makeTempDir(tempRoots, "openclaw-plugin-sdk-inputs-");
     const buildInfoPath = path.join(rootDir, "dist", "plugin-sdk", ".tsbuildinfo");


### PR DESCRIPTION
Closes #132345

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Resolves a problem where developers rerunning a warm plugin package-boundary check could receive a successful result without recompiling after an inherited TypeScript config changed. A paths edit that makes an SDK import invalid could therefore remain hidden behind the last successful stamp.

Discovered during follow-up to https://github.com/openclaw/openclaw/pull/132212 (Browser native bootstrap repair). The omission predates that PR; this link is discovery context, not attribution.

## Why This Change Was Made

The freshness owner tracked plugin-local inputs and prepared SDK declarations but omitted the root, boundary-base, and boundary-paths configs that the compiler inherits. One shared input list now feeds both the compile freshness scan and all seven plugin declaration freshness/hash stamps; the duplicated shared-mtime scans are replaced by one private helper, also used for once-per-run precomputation.

Root/package SDK declarations remain independent of boundary-only configs. The hosted content fingerprint already covers the whole plugins tree and now also fingerprints the new shared owner module. No extra cache, config option, schema, protocol, dependency, or package artifact shape is introduced.

Production/tooling: **+30/-18 (net +12)**; tests: **+314/-51**. The small net growth establishes one shared input owner across compile and declaration preparation while removing duplicated scans; a compile-only guard would leave declaration stamps stale. The adjacent process-timeout test now waits for a real child to be ready before starting its unchanged 100 ms cleanup deadline, removing a startup race without increasing the timeout.

## User Impact

Developers and CI get a fresh check after an inherited compiler config changes, and compiler failures remain visible without replacing the last successful stamp. Unchanged warm inputs still skip work. This is build tooling only; no runtime/operator-state or released-user behavior change is claimed.

## Evidence

The retained real-compiler CLI regression demonstrates the original failure in order: cold compile succeeds, unchanged warm run skips, inherited paths change, original owner falsely skips again with exit 0. After the repair, the same sequence exits 1 with TS2307 and preserves the successful stamp bytes and mtime.

```sh
node scripts/run-vitest.mjs test/scripts/check-extension-package-tsc-boundary.test.ts test/scripts/prepare-extension-package-boundary-artifacts.test.ts
node scripts/check-changed.mjs -- scripts/check-extension-package-tsc-boundary.mts scripts/lib/extension-package-boundary-inputs.mts scripts/prepare-extension-package-boundary-artifacts.mts test/scripts/check-extension-package-tsc-boundary.test.ts test/scripts/prepare-extension-package-boundary-artifacts.test.ts
git diff --check
```

All **54 tests passed across two shards**. Changed checks passed formatting, script erasability, scripts/test-root tsgo, targeted lint, and guards. Coverage includes all three inherited configs, all seven declaration lanes, identical-content restamping, changed-content rebuild scheduling, root/package SDK isolation, and hosted fingerprint invalidation. Fresh Codex autoreview of the identical patch was scoped-clean with no P0 findings; no source changes followed that review.

Proof boundaries: the CLI fixture holds already-prepared declarations fixed while exercising the real scheduler, incremental compiler, and successful-stamp writer. Declaration tests exercise real scheduling, filesystem freshness, and stamp writing with compiler command recording; they are not real declaration compilation.

The full local command below hit the existing **420000 ms SDK-preparation timeout on both original and repaired code**, at 423577 ms and 420358 ms respectively, before any of the 123 plugin compiles. Child trees and locks were cleaned. No timeout was raised. These local attempts remain historical limitations; the successful exact-head hosted run below supplies the real SDK-preparation and all-plugin proof.

```sh
node --import ./scripts/tsx.mjs scripts/check-extension-package-tsc-boundary.mts --mode=compile
```

The affected main files were unchanged at 9fe38caf4672e1285ff6a453ec6f00ed05919a04; no equivalent repair was already present. No full build was run because release/package artifact shape is unchanged.

Exact-head [CI run 33233267742, attempt 1](https://github.com/openclaw/openclaw/actions/runs/33233267742) passed for `47a118ccb67c7734b4f5dd4e54b5aa42bda5ad1f`, including the Actions-owned `openclaw/ci-gate`. [Boundary job 99049752759](https://github.com/openclaw/openclaw/actions/runs/33233267742/job/99049752759) ran both real commands:

```sh
node --import ./scripts/tsx.mjs scripts/check-extension-package-tsc-boundary.mts --mode=compile
node --import ./scripts/tsx.mjs scripts/check-extension-package-tsc-boundary.mts --mode=canary
```

Compilation passed for **all 123 plugins** after real SDK preparation: prep 141398 ms, compile 13573 ms, total 155029 ms. The canary passed for **one plugin**: canary 335 ms, total 339 ms. This closes the broad-proof gap; the focused fixture boundaries described above remain accurate.

Maintainer landing review is complete. The [latest ClawSweeper review and Rank-up moves](https://github.com/openclaw/openclaw/pull/132346#issuecomment-5460311041) were read in full: no correctness or security findings. The net +12 tooling lines are explicitly accepted for the sole canonical three-config/seven-lane input owner after duplicate scan removal. Exact-head CI is green; no actionable code findings remain.

AI-assisted with Codex. The owner flow and regression coverage were inspected and verified; no raw agent transcript is included.


**Native merge status:** preparation and exact-head CI passed, but GitHub rejected the merge request with `Base branch was modified. Review and try the merge again.` The PR remains open. Native read-only reconciliation reports `prior dispatch unresolved (state=OPEN, phase=intent)` and forbids another merge dispatch until operator reconciliation. No outcome record was cleared, no gate was bypassed, and no source changes were made.
