### PR TITLE
test(deepgram): advance real protocol fixture waits

### DIFF
--- a/extensions/deepgram/realtime-transcription-provider.test.ts
+++ b/extensions/deepgram/realtime-transcription-provider.test.ts
@@ -357,6 +357,7 @@ describe("buildDeepgramRealtimeTranscriptionProvider", () => {
   });
 
   it("does not infer silence from a gap between provisional results", async () => {
+    vi.useFakeTimers();
     let socket: WebSocket | undefined;
     const server = await createDeepgramRealtimeServer({
       onRequest: () => undefined,
@@ -375,9 +376,7 @@ describe("buildDeepgramRealtimeTranscriptionProvider", () => {
 
     await session.connect();
     await vi.waitFor(() => expect(onPartial).toHaveBeenCalledWith("still speaking"));
-    await new Promise<void>((resolve) => {
-      setTimeout(resolve, 350);
-    });
+    await vi.advanceTimersByTimeAsync(350);
     expect(onTranscript).not.toHaveBeenCalled();
 
     sendResult(socket!, { text: "continuous speech", isFinal: true, speechFinal: true });
@@ -386,6 +385,7 @@ describe("buildDeepgramRealtimeTranscriptionProvider", () => {
   });
 
   it("does not merge an interrupted turn into a reconnected provider stream", async () => {
+    vi.useFakeTimers();
     let connectionCount = 0;
     const server = await createDeepgramRealtimeServer({
       onRequest: () => undefined,
@@ -406,6 +406,9 @@ describe("buildDeepgramRealtimeTranscriptionProvider", () => {
     });
 
     await session.connect();
+    // Observe the real socket close before advancing the provider's retry delay.
+    await vi.waitFor(() => expect(session.isConnected()).toBe(false));
+    await vi.advanceTimersByTimeAsync(1000);
     await vi.waitFor(() => expect(onTranscript).toHaveBeenCalledWith("new"), {
       timeout: 3000,
     });
@@ -415,6 +418,7 @@ describe("buildDeepgramRealtimeTranscriptionProvider", () => {
   });
 
   it("preserves finalized speech as a separate turn when the provider reconnects", async () => {
+    vi.useFakeTimers();
     let connectionCount = 0;
     const server = await createDeepgramRealtimeServer({
       onRequest: () => undefined,
@@ -435,6 +439,8 @@ describe("buildDeepgramRealtimeTranscriptionProvider", () => {
     });
 
     await session.connect();
+    await vi.waitFor(() => expect(session.isConnected()).toBe(false));
+    await vi.advanceTimersByTimeAsync(1000);
     await vi.waitFor(() => expect(onTranscript).toHaveBeenCalledTimes(2), {
       timeout: 3000,
     });


### PR DESCRIPTION
## What Problem This Solves

The Deepgram realtime protocol suite spends over two seconds waiting for production retry delays and a provisional-speech gap. These cases need to exercise elapsed time without occupying wall time.

## Why This Change Was Made

Install the test clock before the three timed flows begin, then advance the existing waits. Reconnect tests first observe the public disconnected state after the real socket closes. The loopback HTTP/WebSocket server, provider, reconnect path, transcript callbacks, cases and assertions all remain real and unchanged.

## User Impact

All 18 protocol cases run in **0.535s instead of 2.659s** locally. No production, sharding, worker, test-selection or configuration changes. Production LOC +0/-0; tests +9/-3.

## Evidence

- Before/after: `node scripts/run-vitest.mjs extensions/deepgram/realtime-transcription-provider.test.ts` — 18 passed each run, 2.659s → 0.535s execution.
- Siblings: `node scripts/run-vitest.mjs extensions/deepgram src/realtime-transcription/websocket-session.test.ts` — 54 passed across three files; repeated protocol execution 0.469s.
- Mutation proof: temporarily reintroduced premature provisional-text flushing and dropped finalized text on reconnect. Both relevant accelerated tests failed on their original transcript assertions. Restored production bytes, then the full sibling run passed. Installing the clock before receipt preserves detection of timers armed by incoming provisional results.
- Reviewed production provider/core socket lifecycle, retry implementation, and installed WebSocket timer behavior. Fresh Codex autoreview, formatting and whitespace checks passed.
- Changed-file [Linux checks33233330233](https://github.com/openclaw/openclaw/actions/runs/33233330233) passed; Testbox stopped. Exact-head [CI33233335507](https://github.com/openclaw/openclaw/actions/runs/33233335507) passed. No external Deepgram call was made; all protocol proof uses the existing loopback server.
