### PR TITLE
fix(pr): release locks after early auth failures

### DIFF
--- a/scripts/pr-lib/review.sh
+++ b/scripts/pr-lib/review.sh
@@ -17,7 +17,6 @@ review_artifacts_helper_path() {
 
 review_claim() {
   local pr="$1"
-  mark_pr_operation_side_effects_started
   # Claim logs are per-PR review state: keeping them in the PR worktree leaves the
   # shared canonical checkout with no scripts/pr-owned .local, so a stray artifact
   # there can never be mistaken for this flow's output. Claiming still works on a
@@ -315,7 +314,6 @@ review_init() {
   # caller - enter_worktree still reports the real invocation cwd.
   json=$(cd "$root" && pr_meta_json "$pr") || return 1
 
-  mark_pr_operation_side_effects_started
   enter_worktree "$pr" true || return 1
   write_pr_meta_files "$json"
   pr_url=$(printf '%s\n' "$json" | jq -r .url)

--- a/test/scripts/pr-operation-lock.test.ts
+++ b/test/scripts/pr-operation-lock.test.ts
@@ -14,6 +14,7 @@ import {
   mkdirSync,
   mkdtempSync,
   readFileSync,
+  readdirSync,
   realpathSync,
   rmSync,
   symlinkSync,
@@ -724,6 +725,9 @@ describePosix("scripts/pr per-PR operation lock", () => {
         .filter((existing) => !existing || failure !== "second")
         .map((existing) => ({ command: "review-init" as const, failure, existing })),
     ),
+    ...(["review-init", "review-claim"] as const).flatMap((command) =>
+      [false, true].map((existing) => ({ command, failure: "auth" as const, existing })),
+    ),
     ...(["review-validate-artifacts", "review-guard", "review-tests"] as const).flatMap((command) =>
       (["healthy", "first", "auth"] as const).map((failure) => ({
         command,
@@ -834,15 +838,16 @@ describePosix("scripts/pr per-PR operation lock", () => {
           writeFileSync(join(localDir, artifact), `prior ${artifact}\n`);
         }
       }
-      if (command !== "review-init") {
+      if (
+        command === "review-validate-artifacts" ||
+        command === "review-guard" ||
+        command === "review-tests"
+      ) {
         writeReviewArtifacts(worktreeDir, validReview(pullHead), { headSha: pullHead });
       }
-      const priorArtifacts =
-        command === "review-init"
-          ? []
-          : artifactNames.map(
-              (name) => [name, readFileSync(join(localDir, name), "utf8")] as const,
-            );
+      const priorArtifacts = existing
+        ? artifactNames.map((name) => [name, readFileSync(join(localDir, name), "utf8")] as const)
+        : [];
       const metadataPath = join(stateDir, "metadata.json");
       writeFileSync(
         metadataPath,
@@ -872,17 +877,24 @@ describePosix("scripts/pr per-PR operation lock", () => {
           files: [],
         }),
       );
+      const ghEventsPath = join(stateDir, "gh-events");
+      writeFileSync(ghEventsPath, "");
       const gh = writeFixtureFile(binDir, "gh", [
         "#!/usr/bin/env bash",
         "set -euo pipefail",
         'case "$*" in',
-        '  "auth token") exit 1 ;;',
+        '  "auth token") printf "token:1\\n" >> "$OPENCLAW_TEST_GH_EVENTS"; exit 1 ;;',
         '  "api graphql -f query=query { viewer { login } } --jq .data.viewer.login")',
-        '    [ "$OPENCLAW_TEST_AUTH_FAILURE" != 1 ] || exit 1',
+        '    if [ "$OPENCLAW_TEST_AUTH_FAILURE" = 1 ]; then',
+        '      printf "viewer:1\\n" >> "$OPENCLAW_TEST_GH_EVENTS"; exit 1',
+        "    fi",
+        '    printf "viewer:0\\n" >> "$OPENCLAW_TEST_GH_EVENTS"',
         '    printf "fixture-user\\n" ;;',
-        '  "pr view 42 --json headRefOid"|"pr view 42 --json number,title,state,isDraft,author,baseRefName,headRefName,headRefOid,headRepository,headRepositoryOwner,url,body,labels,assignees,changedFiles,additions,deletions,statusCheckRollup,files")',
-        '    cat "$OPENCLAW_TEST_PR_METADATA" ;;',
-        '  *) echo "unexpected fixture gh request" >&2; exit 99 ;;',
+        '  "pr view 42 --json headRefOid")',
+        '    cat "$OPENCLAW_TEST_PR_METADATA"; printf "head:0\\n" >> "$OPENCLAW_TEST_GH_EVENTS" ;;',
+        '  "pr view 42 --json number,title,state,isDraft,author,baseRefName,headRefName,headRefOid,headRepository,headRepositoryOwner,url,body,labels,assignees,changedFiles,additions,deletions,statusCheckRollup,files")',
+        '    cat "$OPENCLAW_TEST_PR_METADATA"; printf "metadata:0\\n" >> "$OPENCLAW_TEST_GH_EVENTS" ;;',
+        '  *) printf "unexpected:99\\n" >> "$OPENCLAW_TEST_GH_EVENTS"; echo "unexpected fixture gh request" >&2; exit 99 ;;',
         "esac",
       ]);
       chmodSync(gh, 0o755);
@@ -922,6 +934,7 @@ describePosix("scripts/pr per-PR operation lock", () => {
         ...env,
         OPENCLAW_GH_BIN: gh,
         OPENCLAW_TEST_PR_METADATA: metadataPath,
+        OPENCLAW_TEST_GH_EVENTS: ghEventsPath,
         OPENCLAW_TEST_REAL_GIT: realGit,
         OPENCLAW_TEST_REPO: repoDir,
         OPENCLAW_TEST_ORIGIN: originDir,
@@ -955,6 +968,40 @@ describePosix("scripts/pr per-PR operation lock", () => {
         expect.soft(git("branch", "--show-current")).toBe("main");
         expect.soft(git("write-tree")).toBe(canonicalTree);
         expect.soft(git("diff", "--exit-code")).toBe("");
+        if (failure === "auth" && (command === "review-init" || command === "review-claim")) {
+          // The exact GH trace distinguishes the intended auth failure from an
+          // unexpected fixture command that the auth diagnostic would also hide.
+          const ghEvents = readFileSync(ghEventsPath, "utf8").trim().split("\n");
+          expect
+            .soft(ghEvents, output)
+            .toEqual(
+              command === "review-init"
+                ? ["metadata:0", "head:0", "token:1", "viewer:1"]
+                : ["token:1", "viewer:1"],
+            );
+          expect.soft(controller.exitCode, output).toBe(1);
+          expect.soft(output).toContain("GitHub CLI auth is not usable");
+          expect.soft(events.filter(Boolean), output).toEqual([]);
+          expect.soft(git("rev-parse", "refs/remotes/origin/main")).toBe(cachedMain);
+          expect.soft(git("rev-parse", "refs/heads/pr-42")).toBe(cachedMain);
+          expect.soft(existsSync(worktreeDir)).toBe(existing);
+          if (existing) {
+            expect.soft(git("-C", worktreeDir, "rev-parse", "HEAD")).toBe(pullHead);
+            expect.soft(git("-C", worktreeDir, "branch", "--show-current")).toBe("temp/pr-42");
+            expect.soft(git("-C", worktreeDir, "write-tree")).toBe(canonicalTree);
+            expect.soft(git("-C", worktreeDir, "diff", "--exit-code")).toBe("");
+            expect.soft(readdirSync(localDir).sort()).toEqual([...artifactNames].sort());
+            for (const [name, contents] of priorArtifacts) {
+              expect.soft(readFileSync(join(localDir, name), "utf8"), name).toBe(contents);
+            }
+          }
+          expect.soft(refExists(repoDir, lockRef, childEnv), output).toBe(false);
+          expect.soft(output).not.toContain("Retaining the operation lock");
+          expect.soft(output).not.toContain("scripts/pr lock-recover");
+          expect.soft(output).not.toContain("wrote=.local/pr-meta.json");
+          expect.soft(output).not.toContain("review claim succeeded");
+          return;
+        }
         if (command !== "review-init") {
           const fetches = events.filter((event) => event.startsWith("fetch:"));
           expect


### PR DESCRIPTION
Related: #132152 (closed after #132274)

## What Problem This Solves

Native `review-init` and `review-claim` retained an operation lock after authentication failed, even when no fetch or protected workflow mutation occurred. The real public-wrapper regression now reproduces this in both cold and existing worktrees. This repair leaves the failed operation eligible for automatic lock release without weakening fatal authentication.

## Why This Change Was Made

Both callers entered the side-effects phase before calling the initializer. That prematurely selected the supervisor's retained-lock/recovery path. The initializer already owns a checked phase transition after authentication and before fetch or provisioning, so the repair deletes the two redundant caller markers. Successful initialization still marks the operation before protected mutations, including later claim logs/assignment and initialization artifacts.

The fatal prerequisite contract established in #132094 and operation-owned main snapshots established in #132274 are preserved. There is no supervisor, snapshot, recovery, timeout, dependency, workflow, configuration or authentication-policy change. The closed related issue is not reopened, and this follow-up does not claim the earlier repairs as its own.

## User Impact

An ordinary early authentication failure should no longer require manual lock recovery when it made no protected workflow changes. Failures after the initializer starts side effects retain the existing recovery behavior. The unchanged regression cases and required CI now pass on the repaired head. Native preparation and the separately authorized merge checks still apply; no auto-merge is enabled.

## Evidence

The diagnostic head `dc77f7ef8016a83367c2b7f059c7dac6b7941c53` ran through [ordinary PR CI](https://github.com/openclaw/openclaw/actions/runs/33233842807). The owner job `checks-node-compact-small-31` (job `99051318558`) executed merge `7bd34524eede56887dae7c1b0a604681da4c425f`, whose parents are `cddb4db86493a6df0cf680f27e55769ee21c66dc` and the diagnostic head. The complete test bytes match the reviewed diagnostic exactly.

All fourteen existing public-flow controls passed. The four new cold/warm initialization/claim cases failed only the three retained-lock/recovery assertions each: the lock remained, and retention/recovery guidance was printed. Fatal exit, the exact intended authentication trace, zero protected Git events, canonical Git state, cold worktree absence, and all six warm artifact/inventory controls reported no failures. All twenty native phase controls also passed. The complete owner job recorded 1,199 passed, 3 skipped and 4 failed tests across 67 files. Node 24.19.0, pnpm 12.0.0, Vitest 4.1.11 and runtime preparation were observed; the plan's `requiresDist: false` is not a claim that no preparation ran.

Compared with the published diagnostic head, the executed merge incorporated ten changed context files from main. Those changes were read directly: the changed native cleanup/GC/merge branches are downstream of the unchanged fatal-auth return or belong to other commands. The affected caller markers and selected authentication/phase boundary remain the same. This is bounded source binding for the reproduction, not a general certificate for unrelated cleanup or CI changes.

The complete repair is two files against the PR base: production +0/-2, tests +59/-12. All eighteen public-flow cases are unchanged since the observed baseline. Fresh structured Codex review retained all 94 whole context inputs and returned no accepted P0–P2 findings. One integrated source pass assessed the selected caller/initializer/auth/phase/cleanup/test boundary; three supplementary passes retained their context limitations. All four reports and aggregate minimum confidence 0.65 are preserved, not presented as four integrated reviews or repaired runtime proof.

The repaired head `ce49730418ac167f2ffd5f6c8ddf785aac8346ed` passed [ordinary PR CI](https://github.com/openclaw/openclaw/actions/runs/33235441300), including `openclaw/ci-gate`. The owner job `99055620399` (`checks-node-compact-small-31`) explicitly passed all eighteen public-flow cases, including the four prior auth-cleanup failures, all twenty native phase cases, and seven supervisor retention/signal controls. Its complete result was 1,203 passed and 3 skipped tests across 67 files, with zero failures; skipped jobs are not counted as behavioral proof.

Both checkout and workflow were `7a784b20ad2ef889424e51c5eaa84a00a5167df7`, with parents `89c004fc5ff1d132b70471251477179fc5d5a15e` and the repaired head. The complete two-file patch and both full source blobs match the reviewed candidate exactly. Relative to the baseline execution, all 82 other named source/context files remain identical. The four tests assert lock absence before fixture teardown while retaining fatal exit, exact intended auth traces, zero protected Git events, canonical state and warm artifacts. This is real public CLI/Git lifecycle proof with a synthetic authentication boundary, not a live authenticated GitHub outage test. Node 24.19.0, pnpm 12.0.0, Vitest 4.1.11, frozen installation and runtime preparation were observed again.

The latest same-head ClawSweeper review's two before-merge requests and its rank-up move were to complete the repaired focused cases and exact-head CI; the run above supplies both. No new code finding or mechanical repair was requested. Independent source and raw-log challenge accepted the fixed result. No local tests or merge/landing are claimed.
