### PR TITLE
fix(matrix): accept env SecretRefs with shared default aliases

### DIFF
--- a/docs/channels/matrix.md
+++ b/docs/channels/matrix.md
@@ -67,6 +67,8 @@ Password-based (token is cached after first login):
 }
 ```
 
+Token and password SecretRefs follow the shared [source-specific provider-alias rules](/gateway/secrets#provider-config), including for named accounts. An explicit matching `env` provider still enforces its allowlist; an empty allowlist denies all variables.
+
 ### Auto-join
 
 `channels.matrix.autoJoin` defaults to `"off"`: the bot will not appear in new rooms or DMs from fresh invites until you join manually. OpenClaw cannot tell at invite time whether an invite is a DM or a group, so every invite goes through `autoJoin` first; `dm.policy` only applies later, after the bot has joined and the room is classified.

--- a/docs/plugins/sdk-subpaths.md
+++ b/docs/plugins/sdk-subpaths.md
@@ -224,7 +224,7 @@ usage endpoint failed or returned no usable usage data.
     | `plugin-sdk/ssrf-policy` | Host allowlist and private-network SSRF policy helpers |
     | `plugin-sdk/ssrf-dispatcher` | Private-local after July 2026; Narrow pinned-dispatcher helpers without the broad infra runtime surface |
     | `plugin-sdk/ssrf-runtime` | Pinned-dispatcher, SSRF-guarded fetch, `SsrFBlockedError` and `GuardedFetchRedirectError`, SSRF policy helpers, and loopback/private host classification |
-    | `plugin-sdk/secret-input` | Secret input parsing helpers |
+    | `plugin-sdk/secret-input` | Secret input parsing helpers and `isBuiltInDefaultSecretProviderRef(config, ref)`, which returns true when the built-in `env` or `store` provider owns its source's selected default alias, and false for a same-source explicit provider entry |
     | `plugin-sdk/secret-input-runtime` | Secret input normalization, SecretRef coercion, and configured secret resolution helpers |
     | `plugin-sdk/secret-ref-readonly` | Closed available/missing/blocked resolution and provider-policy checks for read-only env SecretRefs |
     | `plugin-sdk/webhook-ingress` | Webhook request/target helpers and raw websocket/body coercion |

--- a/extensions/matrix/src/matrix/client/config.test.ts
+++ b/extensions/matrix/src/matrix/client/config.test.ts
@@ -1,6 +1,6 @@
 import type { LookupFn } from "openclaw/plugin-sdk/ssrf-runtime";
 // Matrix tests cover config plugin behavior.
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { getMatrixScopedEnvVarNames } from "../../env-vars.js";
 import { installMatrixTestRuntime } from "../../test-runtime.js";
 import type { CoreConfig } from "../../types.js";
@@ -30,6 +30,36 @@ function resolveDefaultMatrixAuthContext(
 beforeEach(() => {
   installMatrixTestRuntime();
 });
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+function createEnvSecretRefConfig(params: {
+  field: "accessToken" | "password";
+  accountId?: string;
+  provider?: string;
+  secrets?: CoreConfig["secrets"];
+}): CoreConfig {
+  const account = {
+    homeserver: "https://matrix.example.org",
+    userId: "@bot:example.org",
+    [params.field]: {
+      source: "env",
+      provider: params.provider ?? "default",
+      id: "MATRIX_TEST_SECRET",
+    },
+  };
+  return {
+    channels: {
+      matrix:
+        params.accountId && params.accountId !== "default"
+          ? { accounts: { [params.accountId]: account } }
+          : account,
+    },
+    secrets: params.secrets,
+  };
+}
 
 describe("Matrix auth/config live surfaces", () => {
   it("prefers config over env", () => {
@@ -104,76 +134,42 @@ describe("Matrix auth/config live surfaces", () => {
     expect(resolved.initialSyncLimit).toBeUndefined();
   });
 
-  it("resolves accessToken SecretRef against the provided env", () => {
-    const cfg = {
-      channels: {
-        matrix: {
-          homeserver: "https://cfg.example.org",
-          accessToken: { source: "env", provider: "default", id: "MATRIX_ACCESS_TOKEN" },
+  it.each([
+    ["default", "accessToken", "default", undefined],
+    ["default", "password", "default", undefined],
+    ["ops", "accessToken", "default", undefined],
+    ["ops", "password", "default", undefined],
+    ["default", "accessToken", "default", "file"],
+    ["default", "password", "default", "exec"],
+    ["ops", "accessToken", "default", "store"],
+    ["ops", "password", "default", "file"],
+    ["default", "accessToken", "shared", "exec"],
+    ["default", "password", "shared", "store"],
+    ["ops", "accessToken", "shared", "file"],
+    ["ops", "password", "shared", "exec"],
+  ] as const)(
+    "resolves %s %s from supplied env with alias %s and declaration %s",
+    (accountId, field, provider, declaredSource) => {
+      const declarations = {
+        file: { source: "file", path: "/unused/matrix-secret.json" },
+        exec: { source: "exec", command: "/unused/matrix-secret-command" },
+        store: { source: "store" },
+      } as const;
+      const cfg = createEnvSecretRefConfig({
+        accountId,
+        field,
+        provider,
+        secrets: {
+          defaults: provider === "shared" ? { env: "shared" } : undefined,
+          providers: declaredSource ? { [provider]: declarations[declaredSource] } : undefined,
         },
-      },
-      secrets: {
-        defaults: {
-          env: "default",
-        },
-      },
-    } as CoreConfig;
-    const env = {
-      MATRIX_ACCESS_TOKEN: "env-token",
-    } as NodeJS.ProcessEnv;
+      });
+      const env = { MATRIX_TEST_SECRET: " supplied-secret " };
 
-    const resolved = resolveDefaultMatrixAuthContext(cfg, env).resolved;
-    expect(resolved.accessToken).toBe("env-token");
-  });
-
-  it("resolves password SecretRef against the provided env", () => {
-    const cfg = {
-      channels: {
-        matrix: {
-          homeserver: "https://cfg.example.org",
-          userId: "@cfg:example.org",
-          password: { source: "env", provider: "default", id: "MATRIX_PASSWORD" },
-        },
-      },
-      secrets: {
-        defaults: {
-          env: "default",
-        },
-      },
-    } as CoreConfig;
-    const env = {
-      MATRIX_PASSWORD: "env-pass",
-    } as NodeJS.ProcessEnv;
-
-    const resolved = resolveDefaultMatrixAuthContext(cfg, env).resolved;
-    expect(resolved.password).toBe("env-pass");
-  });
-
-  it("resolves account accessToken SecretRef against the provided env", () => {
-    const cfg = {
-      channels: {
-        matrix: {
-          accounts: {
-            ops: {
-              homeserver: "https://ops.example.org",
-              accessToken: { source: "env", provider: "default", id: "MATRIX_OPS_ACCESS_TOKEN" },
-            },
-          },
-        },
-      },
-      secrets: {
-        defaults: {
-          env: "default",
-        },
-      },
-    } as CoreConfig;
-    const env = {
-      MATRIX_OPS_ACCESS_TOKEN: "ops-token",
-    } as NodeJS.ProcessEnv;
-
-    const resolved = resolveMatrixConfigForAccount(cfg, "ops", env);
-    expect(resolved.accessToken).toBe("ops-token");
-  });
+      const resolved = resolveMatrixAuthContext({ cfg, accountId, env }).resolved;
+      expect(resolved[field]).toBe("supplied-secret");
+    },
+  );
 
   it("does not resolve account password SecretRefs when scoped token auth is configured", () => {
     const cfg = {
@@ -187,11 +183,7 @@ describe("Matrix auth/config live surfaces", () => {
           },
         },
       },
-      secrets: {
-        defaults: {
-          env: "default",
-        },
-      },
+      secrets: { providers: { default: { source: "env", allowlist: [] } } },
     } as CoreConfig;
     const env = {
       MATRIX_OPS_ACCESS_TOKEN: "ops-token",
@@ -202,50 +194,80 @@ describe("Matrix auth/config live surfaces", () => {
     expect(resolved.password).toBeUndefined();
   });
 
-  it("keeps unresolved accessToken SecretRef errors when env fallback is missing", () => {
-    const cfg = {
-      channels: {
-        matrix: {
-          homeserver: "https://cfg.example.org",
-          accessToken: { source: "env", provider: "default", id: "MATRIX_ACCESS_TOKEN" },
-        },
-      },
-      secrets: {
-        defaults: {
-          env: "default",
-        },
-      },
-    } as CoreConfig;
+  it.each([
+    ["accessToken", undefined],
+    ["accessToken", "   "],
+    ["password", undefined],
+    ["password", "   "],
+  ] as const)("rejects %s SecretRefs with missing/blank env value %j", (field, value) => {
+    vi.stubEnv("MATRIX_ACCESS_TOKEN", "ambient-token");
+    vi.stubEnv("MATRIX_PASSWORD", "ambient-password");
+    vi.stubEnv("MATRIX_TEST_SECRET", "ambient-secret");
+    const cfg = createEnvSecretRefConfig({ field });
+    const env = {
+      MATRIX_TEST_SECRET: value,
+      ...(field === "accessToken" ? { MATRIX_ACCESS_TOKEN: "fallback-token" } : {}),
+    };
 
-    expect(() => resolveDefaultMatrixAuthContext(cfg, {} as NodeJS.ProcessEnv)).toThrow(
-      /channels\.matrix\.accessToken: unresolved SecretRef "env:default:MATRIX_ACCESS_TOKEN"/i,
+    expect(() => resolveDefaultMatrixAuthContext(cfg, env)).toThrow(
+      `channels.matrix.${field}: unresolved SecretRef "env:default:MATRIX_TEST_SECRET"`,
     );
   });
 
-  it("does not bypass env provider allowlists during startup fallback", () => {
-    const cfg = {
-      channels: {
-        matrix: {
-          homeserver: "https://cfg.example.org",
-          accessToken: { source: "env", provider: "matrix-env", id: "MATRIX_ACCESS_TOKEN" },
+  it.each([
+    ["accessToken", "default", undefined, true],
+    ["password", "shared", ["MATRIX_TEST_SECRET"], true],
+    ["accessToken", "default", ["OTHER_MATRIX_SECRET"], false],
+    ["password", "shared", ["OTHER_MATRIX_SECRET"], false],
+    ["accessToken", "default", [], false],
+    ["password", "shared", [], false],
+  ] as const)(
+    "honors explicit env policy for %s at %s with allowlist %j (allowed: %s)",
+    (field, provider, allowlist, allowed) => {
+      const cfg = createEnvSecretRefConfig({
+        field,
+        provider,
+        secrets: {
+          defaults: { env: provider },
+          providers: { [provider]: { source: "env", allowlist: allowlist && [...allowlist] } },
         },
-      },
-      secrets: {
-        providers: {
-          "matrix-env": {
-            source: "env",
-            allowlist: ["OTHER_MATRIX_ACCESS_TOKEN"],
-          },
-        },
-      },
-    } as CoreConfig;
+      });
+      const resolve = () =>
+        resolveDefaultMatrixAuthContext(cfg, { MATRIX_TEST_SECRET: "env-secret" });
 
-    expect(() =>
-      resolveDefaultMatrixAuthContext(cfg, {
-        MATRIX_ACCESS_TOKEN: "env-token",
-      } as NodeJS.ProcessEnv),
-    ).toThrow(/not allowlisted in secrets\.providers\.matrix-env\.allowlist/i);
-  });
+      if (allowed) {
+        expect(resolve().resolved[field]).toBe("env-secret");
+      } else {
+        expect(resolve).toThrow(`not allowlisted in secrets.providers.${provider}.allowlist`);
+      }
+    },
+  );
+
+  it.each([
+    ["other", { source: "file", path: "/unused/matrix-secret.json" }, undefined],
+    ["other", undefined, undefined],
+    ["default", undefined, "shared"],
+  ] as const)(
+    "rejects non-default alias %s with declaration %j and env default %s",
+    (provider, declaration, envDefault) => {
+      const cfg = createEnvSecretRefConfig({
+        field: "accessToken",
+        provider,
+        secrets: {
+          defaults: { env: envDefault },
+          providers: declaration ? { [provider]: declaration } : undefined,
+        },
+      });
+
+      expect(() =>
+        resolveDefaultMatrixAuthContext(cfg, { MATRIX_TEST_SECRET: "env-secret" }),
+      ).toThrow(
+        declaration
+          ? `Secret provider "${provider}" has source "file" but ref requests "env".`
+          : `Secret provider "${provider}" is not configured (ref: env:${provider}:MATRIX_TEST_SECRET).`,
+      );
+    },
+  );
 
   it("leaves non-env SecretRef access tokens unresolved", () => {
     const cfg = {
@@ -556,35 +578,39 @@ describe("Matrix auth/config live surfaces", () => {
     ).toThrow(/Matrix account id "!!!" is invalid/i);
   });
 
-  it("rejects explicitly selected disabled accounts before resolving their secrets", () => {
-    const cfg = {
-      channels: {
-        matrix: {
-          homeserver: "https://legacy.example.org",
-          accessToken: "legacy-token",
-          accounts: {
-            disabled: {
-              enabled: false,
-              homeserver: "https://disabled.example.org",
-              accessToken: {
-                source: "env",
-                provider: "default",
-                id: "MATRIX_DISABLED_ACCESS_TOKEN",
+  it.each(["channel", "account"])(
+    "rejects a disabled %s before resolving secrets",
+    (disabledScope) => {
+      const cfg = {
+        channels: {
+          matrix: {
+            enabled: disabledScope !== "channel",
+            homeserver: "https://legacy.example.org",
+            accessToken: "legacy-token",
+            accounts: {
+              disabled: {
+                enabled: disabledScope !== "account",
+                homeserver: "https://disabled.example.org",
+                accessToken: {
+                  source: "env",
+                  provider: "default",
+                  id: "MATRIX_DISABLED_ACCESS_TOKEN",
+                },
               },
             },
           },
         },
-      },
-    } as CoreConfig;
+      } as CoreConfig;
 
-    expect(() =>
-      resolveMatrixAuthContext({
-        cfg,
-        env: {} as NodeJS.ProcessEnv,
-        accountId: "disabled",
-      }),
-    ).toThrow(/Matrix account "disabled" is disabled/i);
-  });
+      expect(() =>
+        resolveMatrixAuthContext({
+          cfg,
+          env: {} as NodeJS.ProcessEnv,
+          accountId: "disabled",
+        }),
+      ).toThrow(/Matrix account "disabled" is disabled/i);
+    },
+  );
 
   it("allows explicit non-default account ids backed only by scoped env vars", () => {
     const cfg = {

--- a/extensions/matrix/src/matrix/client/config.ts
+++ b/extensions/matrix/src/matrix/client/config.ts
@@ -12,6 +12,7 @@ import { retryAsync } from "openclaw/plugin-sdk/retry-runtime";
 import { sleepWithAbort } from "openclaw/plugin-sdk/runtime-env";
 import {
   coerceSecretRef,
+  isBuiltInDefaultSecretProviderRef,
   normalizeResolvedSecretInputString,
 } from "openclaw/plugin-sdk/secret-input";
 import type { PinnedDispatcherPolicy } from "openclaw/plugin-sdk/ssrf-dispatcher";
@@ -149,20 +150,18 @@ function readMatrixEnvSecretRef(params: {
   env: NodeJS.ProcessEnv;
 }): string | undefined {
   const provider = params.cfg.secrets?.providers?.[params.ref.provider];
-  if (provider) {
-    if (provider.source !== "env") {
-      throw new Error(
-        `Secret provider "${params.ref.provider}" has source "${provider.source}" but ref requests "env".`,
-      );
-    }
+  // Canonical source-specific aliases keep sync and async secret resolution aligned.
+  if (provider?.source === "env") {
     if (provider.allowlist && !provider.allowlist.includes(params.ref.id)) {
       throw new Error(
         `Environment variable "${params.ref.id}" is not allowlisted in secrets.providers.${params.ref.provider}.allowlist.`,
       );
     }
-  } else if (params.ref.provider !== (params.cfg.secrets?.defaults?.env?.trim() || "default")) {
+  } else if (!isBuiltInDefaultSecretProviderRef(params.cfg, params.ref)) {
     throw new Error(
-      `Secret provider "${params.ref.provider}" is not configured (ref: env:${params.ref.provider}:${params.ref.id}).`,
+      provider
+        ? `Secret provider "${params.ref.provider}" has source "${provider.source}" but ref requests "env".`
+        : `Secret provider "${params.ref.provider}" is not configured (ref: env:${params.ref.provider}:${params.ref.id}).`,
     );
   }
   return params.env[params.ref.id]?.trim() || undefined;

--- a/scripts/plugin-sdk-surface-report.mts
+++ b/scripts/plugin-sdk-surface-report.mts
@@ -326,7 +326,8 @@ export function readPluginSdkSurfaceBudgets(env: NodeJS.ProcessEnv = process.env
       // +1: focused account media-limit resolver avoids the deprecated barrel on startup.
       // +1: shared bounded HTTP rejection transport replaces plugin-local close policies.
       // +1: prepared model-provider builder preserves the stable builder's return contract.
-      4352,
+      // +1: canonical SecretRef default-alias predicate for plugin binding parity.
+      4353,
       env,
     ),
     publicFunctionExports: readPluginSdkSurfaceBudgetEnv(
@@ -429,7 +430,8 @@ export function readPluginSdkSurfaceBudgets(env: NodeJS.ProcessEnv = process.env
       // +1: focused account media-limit resolver avoids the deprecated barrel on startup.
       // +1: shared bounded HTTP rejection transport replaces plugin-local close policies.
       // +1: prepared model-provider builder preserves the stable builder's return contract.
-      2588,
+      // +1: canonical SecretRef default-alias predicate for plugin binding parity.
+      2589,
       env,
     ),
     publicDeprecatedExports: readPluginSdkSurfaceBudgetEnv(

--- a/src/plugin-sdk/secret-input.ts
+++ b/src/plugin-sdk/secret-input.ts
@@ -8,7 +8,7 @@ import {
   normalizeResolvedSecretInputString,
   normalizeSecretInputString,
 } from "../config/types.secrets.js";
-import { isValidSecretRef } from "../secrets/ref-contract.js";
+import { isBuiltInDefaultSecretProviderRef, isValidSecretRef } from "../secrets/ref-contract.js";
 import { normalizeSecretInput } from "../utils/normalize-secret-input.js";
 import { buildSecretInputSchema, registerSensitiveConfigSchema } from "./secret-input-schema.js";
 
@@ -22,6 +22,7 @@ export {
   registerSensitiveConfigSchema,
   coerceSecretRef,
   hasConfiguredSecretInput,
+  isBuiltInDefaultSecretProviderRef,
   isSecretRef,
   isValidSecretRef,
   resolveSecretInputString,


### PR DESCRIPTION
Closes https://github.com/openclaw/openclaw/issues/132323 (Matrix env SecretRefs rejected when a source-specific default provider alias is shared).

<details>
<summary>Additional instructions</summary>

Maintainer edits are enabled; this is a branch in the canonical repository.

</details>

## What Problem This Solves

Fixes an issue where Matrix operators would receive a provider-source mismatch for a valid token or password env SecretRef when its source-specific default alias also names a file, exec, or store provider declaration. Both default and named accounts are affected.

## Why This Change Was Made

Matrix retained a local blanket source check after the canonical resolver adopted source-specific default aliases. The reader now consumes the existing canonical predicate through the existing public `secret-input` SDK instead of maintaining a second alias policy.

Matching explicit env providers still enforce their allowlists, including empty deny-all lists. Undeclared/non-default invalid bindings, missing-value failures, supplied-env lookup, inactive-password suppression, and disabled channel/account gates are preserved. Non-env credential resolution remains on its existing asynchronous path; core validation, activation, configuration, and persistence semantics are unchanged.

The one-public-export/one-callable SDK budget allowance was explicitly approved by the maintainer. There is no new SDK subpath, configuration option, dependency, or private bypass. This repair is separate from daemon-install import-only performance work and the remaining sibling-channel/read-only-helper parity follow-up.

## User Impact

Supported Matrix env SecretRefs now honor the same [source-specific provider-alias rules](https://docs.openclaw.ai/gateway/secrets#provider-config) as canonical resolution, without requiring operators to rename aliases or relax allowlists. Matrix and SDK documentation describe the shared contract.

Release-note context: fixes Matrix token/password configuration failures when a valid env default alias is shared with another provider source, for default and named accounts. No migration or operator action is required for already-valid bindings.

## Evidence

All credential proof uses synthetic values and isolated HOME/state/config paths. No operator services or real Matrix credentials were used.

- Before: all 60 existing Matrix config/auth tests passed, then eight added alias-collision cases failed with the intended source-mismatch error.
- After: both Matrix suites pass all 81 tests. The focused canonical/config/activation/SDK/Matrix selection passes 163 tests.
- An independent fresh Node 24 process compared Matrix resolution with the real canonical `resolveSecretRefString` across 576 cases: 80 accepted, 496 rejected, zero mismatches. Disabled channel/account controls rejected before any referenced environment read.
- The built public SDK export was exercised with native Node, confirming accepted default-alias shadowing, explicit env-provider precedence, and non-default rejection.
- SDK-budget tests: 10 passed; doctor declaration/closure guards: five passed.
- Full local build passed with zero `INEFFECTIVE_DYNAMIC_IMPORT` warnings. Complete changed-file checks passed after the explicitly approved one-export budget allowance; the initial budget failure was not bypassed.
- Changed documentation MDX, formatting, and `git diff --check` passed.
- Fresh pre-commit Codex autoreview of the complete six-file patch: scoped-clean at P0, no accepted/actionable findings.

Real operator-flow proof used the built `matrix devices list --account probe --json` command against an owned synthetic loopback Matrix server. The valid alias collision exited 0, made exactly one authenticated synthetic device-list request, and returned the expected current device. An immediately resumed debugger breakpoint observed the repaired reader four times, including the initial CLI account-context path; no functions or variables were replaced. Separate uninstrumented non-default-mismatch and deny-all-env controls exited 1 with the expected diagnostics and zero Matrix requests. The declared file-provider path was absent and OS-denied.

```bash
node openclaw.mjs matrix devices list --account probe --json
```

```json
{
  "kind": "built-cli-loopback-matrix",
  "result": "PASS",
  "defaultAliasCollision": { "exitCode": 0, "matrixRequests": 1, "syntheticAuthorizationMatched": true, "readerBreakpointHits": 4, "expectedCurrentDeviceReturned": true },
  "nonDefaultMismatch": { "exitCode": 1, "matrixRequests": 0, "expectedDiagnostic": true },
  "explicitEnvDenyAll": { "exitCode": 1, "matrixRequests": 0, "expectedDiagnostic": true },
  "isolatedState": true,
  "externalMatrixApiCalls": false,
  "credentialPrinted": false,
  "ownedServicesAndStateCleanedUp": true
}
```

Early sandbox/instrumentation setup attempts and coverage/debugger-control timeouts were not counted as passes. Successful probes retained the same 60-second cap; no production timeout, retry, or gate was changed. This is real CLI/runtime proof against a synthetic HTTP fixture, not authenticated external Matrix, Gateway-monitor, E2EE, or message-delivery proof. The pre-fix comparison is supplied by the eight boundary regression failures above.

Exact local commands:

```bash
node scripts/run-vitest.mjs extensions/matrix/src/matrix/client/config.test.ts extensions/matrix/src/matrix/client.test.ts src/config/validation.policy.test.ts src/secrets/ref-contract.test.ts src/secrets/resolve.test.ts src/secrets/resolve-store.test.ts src/secrets/runtime-matrix-shadowing.test.ts src/secrets/runtime-matrix-top-level.test.ts src/plugin-sdk/secret-ref-readonly.test.ts
```

```bash
node scripts/run-vitest.mjs test/scripts/plugin-sdk-surface-report.test.ts
```

```bash
pnpm build
```

```bash
node scripts/check-changed.mjs -- extensions/matrix/src/matrix/client/config.ts extensions/matrix/src/matrix/client/config.test.ts src/plugin-sdk/secret-input.ts docs/channels/matrix.md docs/plugins/sdk-subpaths.md scripts/plugin-sdk-surface-report.mts
```

```bash
node scripts/check-docs-mdx.mjs docs/channels/matrix.md docs/plugins/sdk-subpaths.md
```

Runtime production LOC: +9/-9 (net 0). Tooling: +4/-2, with net growth limited to two comments recording the approved SDK allowance. Tests: +167/-141 (net +26 after consolidation). Docs: +3/-1.

AI-assisted implementation and independent Codex review. Hosted exact-head CI and final landing evidence will be recorded before merge.
