### PR TITLE
fix: expose agent model settings in the web form

### DIFF
--- a/docs/tools/code-mode.md
+++ b/docs/tools/code-mode.md
@@ -207,9 +207,9 @@ Activation resolves from the first explicit setting in this order:
 In the Control UI, open **Settings → Agents → Agent defaults**, show **Advanced**
 settings, and find **Models** under **Agent Defaults**. Each model has a
 **Code Mode** selector beside its runtime: **Default** removes the override,
-**On** saves `true`, and **Off** saves `false`. Use **Raw** config or the CLI
-for agent-specific model overrides; the **Agent List** form does not yet
-support its constrained map schema.
+**On** saves `true`, and **Off** saves `false`. For agent-specific overrides,
+expand **Agent List**, then the agent's **Models**. Unsupported fields remain
+marked for **Raw** editing without hiding the supported settings beside them.
 
 Overrides affect the selected model on future runs, including fallback models;
 they do not enable tools on a tool-free run or change runtime selection. The

--- a/docs/tools/code-mode.md
+++ b/docs/tools/code-mode.md
@@ -208,7 +208,7 @@ In the Control UI, open **Settings → Agents → Agent defaults**, show **Advan
 settings, and find **Models** under **Agent Defaults**. Each model has a
 **Code Mode** selector beside its runtime: **Default** removes the override,
 **On** saves `true`, and **Off** saves `false`. For agent-specific overrides,
-expand **Agent List**, then the agent's **Models**. Unsupported fields remain
+expand **Agent List**, then the agent's **Agent Model Overrides**. Unsupported fields remain
 marked for **Raw** editing without hiding the supported settings beside them.
 
 Overrides affect the selected model on future runs, including fallback models;

--- a/ui/src/components/config-form-collection-draft.ts
+++ b/ui/src/components/config-form-collection-draft.ts
@@ -13,6 +13,7 @@ export type ConfigFormCollectionDraftProps = {
   identity: string;
   sourceIdentity: unknown;
   existingKeys?: readonly string[];
+  validateKey?: (key: string) => boolean;
   existingValues?: readonly unknown[];
   validateValue?: (value: unknown) => boolean;
 };
@@ -152,7 +153,10 @@ export class ConfigFormCollectionDraft extends OpenClawLightDomElement {
       return;
     }
     const key = this.draftKey.trim();
-    if (props.existingKeys && (!key || props.existingKeys.includes(key))) {
+    if (
+      props.existingKeys &&
+      (!key || props.existingKeys.includes(key) || props.validateKey?.(key) === false)
+    ) {
       this.fail("key", t("configForm.invalidString"));
       return;
     }

--- a/ui/src/components/config-form-map-integrity.browser.test.ts
+++ b/ui/src/components/config-form-map-integrity.browser.test.ts
@@ -7,6 +7,7 @@ import {
 } from "../lib/config/config-draft-model.ts";
 import { createInitialConfigState } from "../lib/config/config-state-model.ts";
 import { ConfigFormCollectionDraft } from "./config-form-collection-draft.ts";
+import type { JsonSchema } from "./config-form.shared.ts";
 import { analyzeConfigSchema, renderConfigForm } from "./config-form.ts";
 
 function expectElement<T extends Element>(element: T | null | undefined, label: string): T {
@@ -32,13 +33,35 @@ describe("config form map integrity", () => {
       });
       const config = (codeMode?: boolean) => ({
         agents: wrapScope({
-          models: { "example/model": modelSettings(codeMode), "example/other": { alias: "other" } },
+          models: {
+            "example/model.v1": modelSettings(codeMode),
+            "example/other": { alias: "other" },
+          },
+          ...(scope === "agent"
+            ? { tools: { codeMode: { enabled: "auto", maxOutputBytes: 4096 } } }
+            : {}),
         }),
         tools: { codeMode: { enabled: "auto", maxOutputBytes: 4096 } },
       });
       const modelSchema = {
         type: "object",
         properties: {
+          ...(scope === "agent"
+            ? {
+                tools: {
+                  type: "object",
+                  properties: {
+                    codeMode: {
+                      anyOf: [
+                        { type: "boolean" },
+                        { const: "auto" },
+                        { type: "object", additionalProperties: true },
+                      ],
+                    },
+                  },
+                },
+              }
+            : {}),
           models: {
             type: "object",
             additionalProperties: {
@@ -62,7 +85,13 @@ describe("config form map integrity", () => {
             properties:
               scope === "defaults"
                 ? { defaults: modelSchema }
-                : { entries: { type: "object", additionalProperties: modelSchema } },
+                : {
+                    entries: {
+                      type: "object",
+                      propertyNames: { type: "string", pattern: "^[a-z0-9_][a-z0-9_-]{0,63}$" },
+                      additionalProperties: modelSchema,
+                    },
+                  },
           },
         },
       });
@@ -94,6 +123,9 @@ describe("config form map integrity", () => {
         );
 
       renderValue();
+      if (scope === "agent") {
+        expect(container.textContent).toContain("Unsupported schema node. Use Raw mode.");
+      }
       expect(Array.from(getSelect().options, (option) => option.textContent?.trim())).toEqual([
         "Default",
         "On",
@@ -170,13 +202,11 @@ describe("config form map integrity", () => {
   });
 
   it.each([
-    ["pattern", { type: "string", pattern: "^[a-z]+$" }],
-    ["minimum length", { type: "string", minLength: 1 }],
-    ["enumeration", { enum: ["primary"] }],
     ["boolean", true],
     ["null", null],
     ["array", [{ type: "string" }]],
     ["wrong type", { type: "number" }],
+    ["unknown constraint", { type: "string", not: { const: "blocked" } }],
     ["inherited type", Object.assign(Object.create({ type: "string" }), { unknown: true })],
   ])("keeps %s property-name constraints fail-closed", (_label, propertyNames) => {
     const analysis = analyzeConfigSchema({
@@ -192,6 +222,165 @@ describe("config form map integrity", () => {
 
     expect(analysis.unsupportedPaths).toEqual(["values"]);
   });
+
+  it.each([
+    { label: "pattern", names: { type: "string", pattern: "^[a-z]+$" }, invalid: "bad/key" },
+    { label: "minimum length", names: { type: "string", minLength: 3 }, invalid: "x" },
+    { label: "enumeration", names: { enum: ["primary", "backup"] }, invalid: "other" },
+    {
+      label: "intersection",
+      names: { allOf: [{ minLength: 3 }, { pattern: "^[a-z]+$" }] },
+      invalid: "bad/key",
+    },
+  ])(
+    "rejects $label key edits even when an existing value is invalid",
+    async ({ names, invalid }) => {
+      const analysis = analyzeConfigSchema({
+        type: "object",
+        properties: {
+          values: {
+            type: "object",
+            propertyNames: names,
+            additionalProperties: { type: "string", pattern: "^[0-9]+$" },
+          },
+        },
+      });
+      expect(analysis.unsupportedPaths).toEqual([]);
+      const state = createInitialConfigState();
+      state.configSchema = analysis.schema;
+      state.configForm = { values: { primary: "invalid existing value" } };
+      const onPatch = vi.fn((path: Array<string | number>, value: unknown) =>
+        updateConfigFormValue(state, path, value),
+      );
+      const container = document.createElement("div");
+      document.body.append(container);
+      try {
+        render(
+          renderConfigForm({
+            schema: analysis.schema,
+            uiHints: {},
+            unsupportedPaths: analysis.unsupportedPaths,
+            value: state.configForm,
+            showAdvanced: true,
+            onShowAdvanced: () => {},
+            onPatch,
+          }),
+          container,
+        );
+        const keyInput = expectElement(
+          container.querySelector<HTMLInputElement>('[aria-label="Key: primary"]'),
+          "existing key",
+        );
+        keyInput.value = invalid;
+        keyInput.dispatchEvent(new Event("change", { bubbles: true }));
+        expect(keyInput.value).toBe("primary");
+        expect(onPatch).not.toHaveBeenCalled();
+
+        const draft = expectElement(
+          container.querySelector<ConfigFormCollectionDraft>(
+            "openclaw-config-form-collection-draft",
+          ),
+          "map draft",
+        );
+        expectElement(
+          Array.from(container.querySelectorAll("button")).find(
+            (button) => button.textContent?.trim() === "Add Entry",
+          ),
+          "add entry",
+        ).click();
+        await draft.updateComplete;
+        const key = expectElement(
+          draft.querySelector<HTMLInputElement>("[data-collection-draft-key]"),
+          "draft key",
+        );
+        const value = expectElement(
+          draft.querySelector<HTMLInputElement>("[data-collection-draft-value]"),
+          "draft value",
+        );
+        key.value = invalid;
+        key.dispatchEvent(new Event("input", { bubbles: true }));
+        value.value = "123";
+        value.dispatchEvent(new Event("input", { bubbles: true }));
+        await draft.updateComplete;
+        expectElement(
+          Array.from(draft.querySelectorAll("button")).find(
+            (button) => button.textContent?.trim() === "Add Entry",
+          ),
+          "commit entry",
+        ).click();
+        await draft.updateComplete;
+        expect(key.getAttribute("aria-invalid")).toBe("true");
+        expect(key.value).toBe(invalid);
+        expect(onPatch).not.toHaveBeenCalled();
+        key.value = "backup";
+        key.dispatchEvent(new Event("input", { bubbles: true }));
+        await draft.updateComplete;
+        expectElement(
+          Array.from(draft.querySelectorAll("button")).find(
+            (button) => button.textContent?.trim() === "Add Entry",
+          ),
+          "commit valid entry",
+        ).click();
+        expect(state.configForm).toEqual({
+          values: { primary: "invalid existing value", backup: "123" },
+        });
+      } finally {
+        container.remove();
+      }
+    },
+  );
+
+  it.each(["map", "array"])(
+    "keeps supported %s children editable beside Raw-only fields",
+    (kind) => {
+      const rowSchema = {
+        type: "object",
+        properties: {
+          name: { type: "string" },
+          retained: { anyOf: [{ type: "string" }, { const: false }] },
+        },
+      } satisfies JsonSchema;
+      const collection = (name: string) =>
+        kind === "map"
+          ? { "example/model.v1": { name, retained: false } }
+          : [{ name, retained: false }];
+      const analysis = analyzeConfigSchema({
+        type: "object",
+        properties: {
+          values:
+            kind === "map"
+              ? { type: "object", additionalProperties: rowSchema }
+              : { type: "array", items: rowSchema },
+        },
+      });
+      expect(analysis.unsupportedPaths).toEqual(["values.*.retained"]);
+      const state = createInitialConfigState();
+      state.configSchema = analysis.schema;
+      state.configForm = { values: collection("before") };
+      const container = document.createElement("div");
+      render(
+        renderConfigForm({
+          schema: analysis.schema,
+          uiHints: {},
+          unsupportedPaths: analysis.unsupportedPaths,
+          value: state.configForm,
+          showAdvanced: true,
+          onShowAdvanced: () => {},
+          onPatch: (path, value) => updateConfigFormValue(state, path, value),
+        }),
+        container,
+      );
+      expect(container.textContent).toContain("Unsupported schema node. Use Raw mode.");
+      expect(container.querySelector('[aria-label="Retained"]')).toBeNull();
+      const name = expectElement(
+        container.querySelector<HTMLInputElement>('[aria-label="Name"]'),
+        "supported name field",
+      );
+      name.value = "after";
+      name.dispatchEvent(new Event("input", { bubbles: true }));
+      expect(JSON.parse(serializeFormForSubmit(state))).toEqual({ values: collection("after") });
+    },
+  );
 
   it("retains unset map drafts until the collection source changes", async () => {
     const container = document.createElement("div");

--- a/ui/src/components/config-form.analyze.ts
+++ b/ui/src/components/config-form.analyze.ts
@@ -6,7 +6,12 @@ import {
   objectPropertySchema,
   requiredPropertyKeys,
 } from "./config-form.constraints.ts";
-import { pathKey, schemaType, type JsonSchema } from "./config-form.shared.ts";
+import {
+  pathKey,
+  schemaMayAcceptString,
+  schemaType,
+  type JsonSchema,
+} from "./config-form.shared.ts";
 
 export type ConfigSchemaAnalysis = {
   schema: JsonSchema | null;
@@ -142,21 +147,26 @@ function shouldNormalizeAllOfBranch(schema: JsonSchema): boolean {
 }
 
 function hasOnlySupportedConstraintKeywords(schema: JsonSchema): boolean {
-  return Object.keys(schema).every((key) => SUPPORTED_CONSTRAINT_ONLY_KEYS.has(key));
+  return hasOnlySupportedKeywords(schema, SUPPORTED_CONSTRAINT_ONLY_KEYS);
 }
 
 function hasOnlySupportedFormKeywords(schema: JsonSchema): boolean {
+  return hasOnlySupportedKeywords(schema, SUPPORTED_FORM_SCHEMA_KEYS);
+}
+
+function hasOnlySupportedKeywords(schema: JsonSchema, supported: ReadonlySet<string>): boolean {
   return Object.keys(schema).every(
     (key) =>
-      SUPPORTED_FORM_SCHEMA_KEYS.has(key) ||
-      // JSON object keys are already strings; constrained names must remain fail-closed.
+      supported.has(key) ||
+      // Key edits use the same value validator as fields. Admit its supported
+      // string constraints without hiding the whole map behind Raw mode.
       (key === "propertyNames" &&
         typeof schema.propertyNames === "object" &&
         schema.propertyNames !== null &&
         !Array.isArray(schema.propertyNames) &&
-        Object.keys(schema.propertyNames).length === 1 &&
-        Object.hasOwn(schema.propertyNames, "type") &&
-        schema.propertyNames.type === "string"),
+        schemaMayAcceptString(schema.propertyNames) &&
+        normalizeSchemaNode({ type: "string", ...schema.propertyNames }, []).unsupportedPaths
+          .length === 0),
   );
 }
 
@@ -376,8 +386,8 @@ function normalizeSchemaNode(
           compositionBranch,
         );
         normalized.additionalProperties = res.schema ?? schema.additionalProperties;
-        if (res.unsupportedPaths.length > 0) {
-          unsupported.add(pathLabel);
+        for (const unsupportedPath of res.unsupportedPaths) {
+          unsupported.add(unsupportedPath);
         }
       }
     }
@@ -435,8 +445,8 @@ function normalizeSchemaNode(
       } else {
         const res = normalizeSchemaNode(schema.items, [...path, "*"], compositionBranch);
         normalized.items = res.schema ?? schema.items;
-        if (res.unsupportedPaths.length > 0) {
-          unsupported.add(pathLabel);
+        for (const unsupportedPath of res.unsupportedPaths) {
+          unsupported.add(unsupportedPath);
         }
       }
     }

--- a/ui/src/components/config-form.constraints.test.ts
+++ b/ui/src/components/config-form.constraints.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   arrayInputConstraints,
   canApplyArrayCandidate,
+  canApplyObjectCandidate,
   configValuesEqual,
   defaultValue,
   isSupportedConfigValueValid,
@@ -17,6 +18,20 @@ import { coerceConfigFormNumberString, formatConfigFormNumber } from "./config-f
 import type { JsonSchema } from "./config-form.shared.ts";
 
 describe("config form schema constraints", () => {
+  it("rejects newly invalid keys without blocking repairs to existing invalid entries", () => {
+    const schema = {
+      type: "object",
+      propertyNames: { type: "string", pattern: "^[a-z]+$" },
+      additionalProperties: { type: "integer", minimum: 0 },
+    };
+    const current = { primary: -1 };
+    expect(canApplyObjectCandidate(schema, current, { "bad/key": -1 })).toBe(false);
+    expect(canApplyObjectCandidate(schema, current, { ...current, "bad/key": 1 })).toBe(false);
+    expect(canApplyObjectCandidate(schema, current, { ...current, backup: 1 })).toBe(true);
+    expect(canApplyObjectCandidate(schema, current, { primary: 1 })).toBe(true);
+    expect(canApplyObjectCandidate(schema, { "old/key": -1 }, { "old/key": 1 })).toBe(true);
+  });
+
   it("coerces only decimal and scientific config number spellings", () => {
     expect(coerceConfigFormNumberString("42.5", false)).toBe(42.5);
     expect(coerceConfigFormNumberString(".5e2", false)).toBe(50);

--- a/ui/src/components/config-form.constraints.ts
+++ b/ui/src/components/config-form.constraints.ts
@@ -266,11 +266,29 @@ function objectRepairIssueCount(schema: JsonSchema, value: Record<string, unknow
   return issues;
 }
 
+export function isObjectPropertyNameValid(schema: JsonSchema, key: string): boolean {
+  return collectAllOfSchemas(schema).every(
+    ({ propertyNames }) =>
+      propertyNames === undefined ||
+      propertyNames === true ||
+      (propertyNames !== false && isSupportedConfigValueValid(propertyNames, key)),
+  );
+}
+
 export function canApplyObjectCandidate(
   schema: JsonSchema,
   current: Record<string, unknown>,
   candidate: Record<string, unknown>,
 ): boolean {
+  // Repairing an unrelated invalid value must not authorize a newly invalid
+  // key. Existing keys remain editable so operators can repair their values.
+  if (
+    Object.keys(candidate).some(
+      (key) => !Object.hasOwn(current, key) && !isObjectPropertyNameValid(schema, key),
+    )
+  ) {
+    return false;
+  }
   if (isSupportedConfigValueValid(schema, candidate)) {
     return true;
   }

--- a/ui/src/components/config-form.node.collection.ts
+++ b/ui/src/components/config-form.node.collection.ts
@@ -28,6 +28,7 @@ import {
   configValuesEqual,
   defaultValue,
   isSupportedConfigValueValid,
+  isObjectPropertyNameValid,
   NO_SAFE_DEFAULT,
   objectAdditionalPropertiesSchema,
   objectPropertyKeys,
@@ -186,6 +187,7 @@ export function renderObject(
             value: objectValue,
             sourceIdentity: objectSourceIdentity,
             reservedKeys,
+            validateKey: (key) => isObjectPropertyNameValid(schema, key),
             searchCriteria: childSearchCriteria,
             onPatch: patchObjectChild,
           },
@@ -505,6 +507,7 @@ function renderMapField(
   params: ConfigNodeRenderParams & {
     value: Record<string, unknown>;
     reservedKeys: Set<string>;
+    validateKey: (key: string) => boolean;
   },
   renderNode: ConfigNodeRenderer,
 ): TemplateResult {
@@ -517,6 +520,7 @@ function renderMapField(
     unsupported,
     disabled,
     reservedKeys,
+    validateKey,
     onPatch,
     searchCriteria,
     revealSensitive,
@@ -533,6 +537,7 @@ function renderMapField(
     identity: draftId,
     sourceIdentity: params.sourceIdentity ?? value,
     existingKeys: [...new Set([...Object.keys(value), ...reservedKeys])],
+    validateKey,
   };
   const entries = Object.entries(value ?? {}).filter(([key]) => !reservedKeys.has(key));
   const visibleEntries =
@@ -590,6 +595,7 @@ function renderMapField(
           const key = event.detail.key;
           if (
             !key ||
+            !validateKey(key) ||
             Object.hasOwn(value, key) ||
             reservedKeys.has(key) ||
             onPatch(path, { ...value, [key]: event.detail.value }) === false
@@ -627,6 +633,13 @@ function renderMapField(
                           const nextKey = target.value.trim();
                           if (!nextKey || nextKey === key) {
                             target.value = key;
+                            return;
+                          }
+                          if (!validateKey(nextKey)) {
+                            target.value = key;
+                            target.setCustomValidity(t("configForm.invalidString"));
+                            target.reportValidity();
+                            target.setCustomValidity("");
                             return;
                           }
                           const nextValue = { ...value };

--- a/ui/src/components/config-form.node.collection.ts
+++ b/ui/src/components/config-form.node.collection.ts
@@ -595,7 +595,6 @@ function renderMapField(
           const key = event.detail.key;
           if (
             !key ||
-            !validateKey(key) ||
             Object.hasOwn(value, key) ||
             reservedKeys.has(key) ||
             onPatch(path, { ...value, [key]: event.detail.value }) === false
@@ -610,7 +609,6 @@ function renderMapField(
             <div class="settings-subrows">
               ${visibleEntries.map(([key, entryValue]) => {
                 const valuePath = [...path, key];
-                const fallback = jsonValue(entryValue);
                 const sensitiveState = getSensitiveRenderState({
                   path: valuePath,
                   value: entryValue,
@@ -635,28 +633,25 @@ function renderMapField(
                             target.value = key;
                             return;
                           }
-                          if (!validateKey(nextKey)) {
-                            target.value = key;
-                            target.setCustomValidity(t("configForm.invalidString"));
-                            target.reportValidity();
-                            target.setCustomValidity("");
-                            return;
-                          }
-                          const nextValue = { ...value };
                           // Renaming a key that still holds server-redacted secrets would
                           // submit the sentinel under a new key: the gateway fails closed
                           // (dead-end draft), and a delete+rename fold in one autosave
                           // window silently binds the deleted entry's old credential.
-                          if (nextKey in nextValue || containsRedactedSentinel(nextValue[key])) {
+                          const error = !validateKey(nextKey)
+                            ? t("configForm.invalidString")
+                            : containsRedactedSentinel(value[key])
+                              ? t("configForm.renameRedactedBlocked")
+                              : "";
+                          if (nextKey in value || error) {
                             target.value = key;
-                            if (!(nextKey in nextValue)) {
-                              target.setCustomValidity(t("configForm.renameRedactedBlocked"));
+                            if (error) {
+                              target.setCustomValidity(error);
                               target.reportValidity();
                               target.setCustomValidity("");
                             }
                             return;
                           }
-                          nextValue[nextKey] = nextValue[key];
+                          const nextValue = { ...value, [nextKey]: value[key] };
                           delete nextValue[key];
                           if (onPatch(path, nextValue) === false) {
                             target.value = key;
@@ -695,7 +690,7 @@ function renderMapField(
                           ariaLabel: `${key}: ${t("configForm.jsonValue")}`,
                           sourceValue: entryValue,
                           rowIdentity: params.rowIdentity,
-                          fallback,
+                          fallback: jsonValue(entryValue),
                           rows: 2,
                           sensitiveState,
                           disabled,

--- a/ui/src/components/config-form.node.ts
+++ b/ui/src/components/config-form.node.ts
@@ -33,7 +33,20 @@ export function renderNode(params: ConfigNodeRenderParams): TemplateResult | typ
   const key = pathKey(path);
   const criteria = params.searchCriteria;
 
-  if (unsupported.has(key)) {
+  if (
+    unsupported.has(key) ||
+    [...unsupported].some((pattern) => {
+      if (!pattern.includes("*")) {
+        return false;
+      }
+      const segments = pattern.split(".");
+      // Use the original segments: dynamic model/provider keys may contain dots.
+      return (
+        segments.length === path.length &&
+        segments.every((segment, index) => segment === "*" || segment === String(path[index]))
+      );
+    })
+  ) {
     return renderFieldRow({
       label,
       tags: [],

--- a/ui/src/e2e/config-form-integrity.e2e.test.ts
+++ b/ui/src/e2e/config-form-integrity.e2e.test.ts
@@ -1,6 +1,7 @@
 // Control UI tests cover schema-backed form constraints, draft recovery, and accessible names.
 import { mkdir, writeFile } from "node:fs/promises";
 import path from "node:path";
+import type { Locator } from "playwright";
 import { expect, it } from "vitest";
 import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
@@ -93,6 +94,118 @@ function configFormIntegrityMocks() {
 }
 
 suite.define(() => {
+  it("round-trips Agent List model overrides through the complete Gateway schema", async () => {
+    const { buildConfigSchemaCore } = await import("../../../src/config/schema.ts");
+    const schema = buildConfigSchemaCore();
+    const config = (codeMode?: boolean) => ({
+      agents: {
+        entries: {
+          main: {
+            name: "Form proof",
+            models: {
+              "openai/gpt-5.6-sol": {
+                alias: "coding",
+                params: { temperature: 0.5 },
+                agentRuntime: { id: "openclaw" },
+                streaming: false,
+                ...(codeMode === undefined ? {} : { codeMode }),
+              },
+            },
+            tools: { codeMode: { enabled: "auto", maxOutputBytes: 4096 } },
+          },
+        },
+      },
+      tools: { codeMode: false },
+    });
+    await suite.withPage(
+      {
+        colorScheme: "dark",
+        locale: "en-US",
+        serviceWorkers: "block",
+        viewport: { height: 1000, width: 1440 },
+      },
+      async ({ page }) => {
+        const initial = config();
+        const gateway = await installMockGateway(page, {
+          methodResponses: {
+            "config.get": {
+              appliedConfigHash: "agent-list-initial",
+              config: initial,
+              configRevisionHash: "agent-list-initial",
+              hash: "agent-list-initial",
+              issues: [],
+              raw: JSON.stringify(initial),
+              valid: true,
+            },
+            "config.schema": schema,
+          },
+        });
+        await page.goto(`${suite.server.baseUrl}settings/agents`);
+        await page
+          .getByRole("button", {
+            name: "Agent defaults Defaults every agent inherits unless overridden.",
+          })
+          .click();
+        await expect.poll(() => new URL(page.url()).pathname).toBe("/settings/ai-agents");
+        await page.goto(`${suite.server.baseUrl}settings/ai-agents?section=agents&advanced=1`);
+
+        const reveal = async (control: Locator) => {
+          await expect.poll(() => control.count()).toBe(1);
+          for (const details of await control.locator("xpath=ancestor::details").all()) {
+            if ((await details.getAttribute("open")) === null) {
+              await details.locator(":scope > summary").click();
+            }
+          }
+          await expect.poll(() => control.isVisible()).toBe(true);
+        };
+        const mode = page.locator('select[aria-label="Code Mode"]');
+        await reveal(mode);
+        expect(
+          (await mode.locator("option").allTextContents()).map((label) => label.trim()),
+        ).toEqual(["Default", "On", "Off"]);
+        expect((await mode.locator("option:checked").textContent())?.trim()).toBe("Default");
+        const rawOnly = page.locator(".settings-row").filter({
+          has: page.locator(".settings-row__title").getByText("Agent Code Mode", { exact: true }),
+        });
+        expect(await rawOnly.textContent()).toContain("Unsupported schema node. Use Raw mode.");
+        expect(await rawOnly.locator("input,select,textarea").count()).toBe(0);
+
+        const agentKey = page.locator('input[aria-label="Key: main"]').first();
+        await reveal(agentKey);
+        await agentKey.fill("bad/agent");
+        await agentKey.blur();
+        await expect.poll(() => agentKey.inputValue()).toBe("main");
+
+        for (const [label, value] of [
+          ["On", true],
+          ["Off", false],
+          ["Default", undefined],
+        ] as const) {
+          const before = (await gateway.getRequests("config.set")).length;
+          await gateway.deferNext("config.set");
+          await mode.selectOption({ label });
+          const request = await gateway.waitForRequest("config.set", { after: before });
+          const params = request.params as { raw?: string };
+          expect(JSON.parse(String(params.raw))).toEqual(config(value));
+          await gateway.resolveDeferred("config.set");
+          await expect.poll(() => mode.isEnabled()).toBe(true);
+          expect(await gateway.getRequests("config.set")).toHaveLength(before + 1);
+          await page.reload();
+          await reveal(mode);
+          expect((await mode.locator("option:checked").textContent())?.trim()).toBe(label);
+        }
+        if (captureUiProofEnabled) {
+          await mkdir(uiProofArtifactDir, { recursive: true });
+          await page.screenshot({
+            animations: "disabled",
+            fullPage: true,
+            path: path.join(uiProofArtifactDir, "04-agent-list-model-overrides.png"),
+          });
+        }
+      },
+    );
+  });
+
   it("keeps invalid drafts visible and exposes schema constraints to the browser", async () => {
     await suite.withPage(
       {

--- a/ui/src/e2e/new-session-page.durable-write-teardown.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.durable-write-teardown.e2e.test.ts
@@ -271,6 +271,7 @@ suite.define(() => {
       await expect.poll(() => message.inputValue()).toBe("main route draft");
 
       await page.getByRole("switch", { name: "Incognito" }).click();
+      await waitForCommittedNewSessionDraft(page, null, 0);
       await page.reload();
       await expect.poll(() => message.inputValue()).toBe("");
       await navigateInApp(page, "new-session", "?agent=writer");


### PR DESCRIPTION
## What Problem This Solves

Agent-specific model settings were hidden behind “Unsupported schema node. Use Raw mode.” The generic form rejected the agent map's constrained keys and then promoted one unsupported descendant to rejection of the whole map. This prevented the per-model Code Mode controls added in #132332 from being used for individual agents.

## What Changed

The schema analyzer preserves supported key constraints and isolates unsupported map/array leaves. The existing form can now edit supported siblings, including agent model Default/On/Off controls. Wildcard matching uses original path segments so dotted model IDs remain intact. Unsupported fields keep their Raw notice and retain their values.

Map mutation validation rejects newly invalid keys even while an unrelated existing value is being repaired. Rename/add controls provide key-specific feedback using the same validator. No new config option, dependency, persistence schema, provider policy, or native Codex behavior.

Production +73/-20 (net +53); tests +323/-5. Growth provides constrained-map editing, safe mutation validation, and unsupported-leaf isolation rather than a separate agent form. Documentation now names the Agent List enablement path.

## Evidence

Eight focused cases failed before the production change. All 106 owner and sibling tests passed afterward, covering constrained keys, invalid-config repairs, nested maps/arrays, composition, scalar fields, collection drafts, and redacted-value rename protection. Three full browser E2Es passed; the new case uses the complete Gateway-generated config schema, cycles Default/On/Off, checks complete saved config payloads, and reloads after every save. UI TypeScript and production build passed; independent Codex autoreview is clean.

Real isolated Gateway proof passed: Agent List now exposes Agent Model Overrides; Off persists after reload, Default removes the key, and On forces Code Mode despite agent-wide Off. Existing limits and sibling settings survive each save. Real OpenAI Luna requests returned the exact marker: applied Off used `read`, On used `exec`. The initial Off request raced autosave and used the prior config; the recorded applied-Off run began after the Gateway confirmed reload. Normal operator state was untouched.

The changed-file gate caught a renderer max-lines failure. Duplicate rename-error handling was consolidated; 25 focused rename/map regressions passed afterward. The complete changed-file gate passed. Exact-head CI passed on94075892c09e, including all14 UI E2E shards. The full local build compiled but its postbuild checker hit stale donor dependency exports; all 49 native modules passed using checkout-owned packages in the isolated runtime.

Before:
![Agent List before](https://github.com/user-attachments/assets/2c6dd2e5-ba6e-499c-b6bf-b274dad9d283)

After:
![Agent-specific model settings](https://github.com/user-attachments/assets/a1bb952f-1e02-4812-868b-ac76e4d2be48)

A separate hosted E2E exposed a pre-existing click-to-reload race in new-session draft retirement. The test now uses the already imported durable-commit helper, matching its older sibling test, before reloading. This is test synchronization only: no storage behavior change, sleep, or increased timeout.

After that synchronization fix, all 19 browser E2Es across durable draft teardown, prompt attachments, and the complete-schema config form passed. Fresh independent review and lint are clean.
