### PR TITLE
fix(ci): prevent Swift release checks restoring incompatible builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4047,10 +4047,11 @@ jobs:
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: apps/macos/.build
-          # Exact hits are immutable; exclude pre-native products from both restore paths.
-          key: ${{ runner.os }}-swift-build-v4-native-tests-${{ steps.swift-toolchain.outputs.key }}-${{ hashFiles('apps/macos/Package.swift', 'apps/macos/Package.resolved', 'apps/macos/Sources/**', 'apps/macos/Tests/**', 'apps/shared/OpenClawKit/Package.swift', 'apps/shared/OpenClawKit/Sources/**', 'apps/swabble/Package.swift', 'apps/swabble/Sources/**') }}
+          # SwiftPM retains old dependency traits while resolving cached checkouts.
+          # Reuse compiled products across source edits only within the same package graph.
+          key: ${{ runner.os }}-swift-build-v5-graph-${{ steps.swift-toolchain.outputs.key }}-${{ hashFiles('apps/macos/Package*.swift', 'apps/macos/Package.resolved', 'apps/shared/**/Package*.swift', 'apps/shared/**/Package.resolved', 'apps/swabble/Package*.swift', 'apps/swabble/Package.resolved') }}-${{ hashFiles('apps/macos/Sources/**', 'apps/macos/Tests/**', 'apps/shared/**/Sources/**', 'apps/swabble/Sources/**') }}
           restore-keys: |
-            ${{ runner.os }}-swift-build-v4-native-tests-${{ steps.swift-toolchain.outputs.key }}-
+            ${{ runner.os }}-swift-build-v5-graph-${{ steps.swift-toolchain.outputs.key }}-${{ hashFiles('apps/macos/Package*.swift', 'apps/macos/Package.resolved', 'apps/shared/**/Package*.swift', 'apps/shared/**/Package.resolved', 'apps/swabble/Package*.swift', 'apps/swabble/Package.resolved') }}-
 
       - name: Validate Swift build cache
         id: validate-swift-build-cache

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -6634,7 +6634,8 @@ exit 1
       (step: WorkflowStep) => step.id === "swift-build-cache",
     );
     const nativeCachePrefix =
-      "${{ runner.os }}-swift-build-v4-native-tests-${{ steps.swift-toolchain.outputs.key }}-";
+      "${{ runner.os }}-swift-build-v5-graph-${{ steps.swift-toolchain.outputs.key }}-" +
+      "${{ hashFiles('apps/macos/Package*.swift', 'apps/macos/Package.resolved', 'apps/shared/**/Package*.swift', 'apps/shared/**/Package.resolved', 'apps/swabble/Package*.swift', 'apps/swabble/Package.resolved') }}-";
 
     expect(buildCache.with).toMatchObject({
       key: expect.stringContaining(nativeCachePrefix),


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where full release verification fails during the macOS Swift build after restoring compiled products from a different dependency graph. The frozen candidate's source does not enable the trait reported by SwiftPM, so rerunning the unchanged candidate can keep failing on the same incompatible cache.

Observed failure: [CI run 33230753064, macos-swift](https://github.com/openclaw/openclaw/actions/runs/33230753064/job/99043170473) restored a 1.36 GB build cache, then rejected `SubprocessSpan` after resolving `swift-subprocess` 1.0.0, whose declared traits are `SubprocessFoundation` and `default`.

## Why This Change Was Made

SwiftPM 6.3.3 loads cached dependency manifests before updating checkouts. Its enabled-trait map is additive, so an old dependency's default traits can survive resolution and fail validation against the newly selected version. The workflow's toolchain-only fallback allowed that incompatible build state to enter the job.

`git blame` attributes the current v4 prefix to [de7a0c0 / #131866](https://github.com/openclaw/openclaw/pull/131866), merged by @steipete on 2026-08-28. That change correctly separated native test products but retained the prior v3 toolchain-only fallback from [c1eee1a / #98818](https://github.com/openclaw/openclaw/commit/c1eee1a41a8d578582d43fbbd37c7f8cd4005971). The precise earlier introduction of the broad fallback and any historical automerge trigger were not established; this patch repairs the current restore boundary without reverting either recovery or native-test work.

Bind both exact and fallback build-cache keys to package manifests and resolved pins, while keeping a separate source fingerprint for incremental reuse within the same graph. Include every local dependency root: the macOS package, shared OpenClawKit and OpenClawMLXTTSProtocol packages, and swabble. This also includes the previously omitted MLX protocol sources in the exact key. The existing workflow guard now requires the graph-bound restore prefix.

Repository-download caching, Swift test execution, clean OpenClawKit test scratch space, test coverage, and runner fanout stay unchanged. iOS uses its existing uncached xcodebuild path. Retrying package resolution or deleting compiled products on every source edit would leave the producer boundary wrong or lose useful incremental reuse.

## User Impact

No application behavior changes. Release maintainers avoid restoring incompatible Swift build state while preserving cache reuse for ordinary source edits. The new namespace requires one initial cold build per package graph and toolchain.

This is an internal CI fix: runtime production LOC delta is zero; workflow delta is +1 line and test delta is +1 line.

## Evidence

- **Author-reported native before/after reproduction:** Apple Swift 6.3.3 (`swiftlang-6.3.3.1.3`) on arm64 macOS, using the installed Command Line Tools toolchain. A local Git dependency's 1.0.0 release enabled `LegacyTrait` by default; its 2.0.0 release replaced that with `CurrentTrait`. Building 1.0.0 passed. Updating the consumer to 2.0.0 with the same scratch directory failed with the same retired-trait error as CI. Building that unchanged 2.0.0 graph in a separate scratch directory passed. No network dependency downloads were needed for this fixture.
- **Dependency source checked:** SwiftPM `swift-6.3.3-RELEASE` [resolution loads current manifests](https://github.com/swiftlang/swift-package-manager/blob/swift-6.3.3-RELEASE/Sources/Workspace/Workspace%2BDependencies.swift#L532), [updates checkouts and reloads manifests](https://github.com/swiftlang/swift-package-manager/blob/swift-6.3.3-RELEASE/Sources/Workspace/Workspace%2BDependencies.swift#L632), [validates accumulated traits](https://github.com/swiftlang/swift-package-manager/blob/swift-6.3.3-RELEASE/Sources/Workspace/Workspace%2BTraits.swift#L37), and [keeps the enabled-trait map additive](https://github.com/swiftlang/swift-package-manager/blob/swift-6.3.3-RELEASE/Sources/PackageModel/EnabledTrait.swift#L138).
- **Regression check:** `node scripts/run-vitest.mjs test/scripts/ci-workflow-guards.test.ts -t 'uses native macOS Swift tests and preserves the first failure'` failed against the old workflow and passed against this patch: 1 passed, 165 skipped. Existing serial/parallel test execution and first-failure behavior remain covered by that case.
- **Static checks:** Oxfmt and `git diff --check` passed. Actionlint workflow validation passed with shellcheck disabled; full actionlint output was byte-identical to the baseline's existing shellcheck informational findings outside this change.
- **Independent review:** Codex autoreview completed with no actionable findings at the repository's default P0 threshold.

**Hosted follow-up (2026-08-29):** [CI run 33236415081, attempt 1](https://github.com/openclaw/openclaw/actions/runs/33236415081) is terminal. Workflow and target both equal `f00654c2761cbffdf586e06e881447c064bc69f6`, dispatched from `codex/frv-swift-graph-cache` with empty `target_ref`, `release_gate=false`, and cache restoration enabled.

The [macos-swift job 99058212472](https://github.com/openclaw/openclaw/actions/runs/33236415081/job/99058212472) **passed** on an assigned `macos-26` runner with Xcode 26.6 / Swift 6.3.3: release build, 1,496 OpenClawKit tests, 1,888 macOS SwiftTesting tests, three XCTest tests, and the health-render test. SwiftPM download caching restored successfully. The compiled `.build` lookup tried only the new toolchain-and-graph-scoped v5 exact/fallback keys and missed; no incompatible v4 entry was selected. This is real cache-enabled selection/build/test proof, not a warm `.build` hit or cache-save proof.

**The full run failed**, despite Swift, macOS Node, and iOS success. [native-i18n](https://github.com/openclaw/openclaw/actions/runs/33236415081/job/99058212477) passed source verification but failed generated locale parity; main already carries locale repair `270c0b3c094`. [checks-node-core-tooling-5](https://github.com/openclaw/openclaw/actions/runs/33236415081/job/99058213394) failed release fixtures, including `Missing required command(s): rg`. The existing [PR #132376, release fixture execution contracts](https://github.com/openclaw/openclaw/pull/132376), owns that prerequisite and remains in flight. No duplicate repair, assertion weakening, or bypass is included here.

Fresh native-worktree proof on this exact head: `scripts/pr review-tests 132357 test/scripts/ci-workflow-guards.test.ts` passed (164 tests, two intentional platform skips). The focused graph-cache guard failed against the prior workflow, then passed the unchanged candidate (one passed, 165 filtered). Oxfmt, `git diff --check`, and installed Actionlint 1.7.12 with ShellCheck available passed. Fresh isolated Codex autoreview was clean at the default P0 scope; its actual output was inspected. Native review artifacts validate, with readiness still marked **NEEDS WORK** for prerequisite refresh and final-head CI.

The latest [ClawSweeper review](https://github.com/openclaw/openclaw/pull/132357#issuecomment-5460373425) requests MLX exact-hit timestamp normalization as a P3 improvement. The timestamp block omits those inputs identically before and after this PR; this possible existing cache-performance follow-up is deferred from the approved graph-safety patch pending maintainer scope judgment. Completed hosted Swift and direct pinned upstream-source verification address its other proof requests. No warm-hit performance claim is made.

The original native transition fixture remains author-reported proof. Independent temporary probes timed out during Git I/O before behavior assertions and are not proof. After #132376 lands, the authorized mechanical refresh must preserve this two-file patch and receive fresh exact-head CI plus cache-enabled Swift proof. No prepare or merge has been performed.
