### PR TITLE
fix: deliver images and PDFs to remote cloud sessions

### DIFF
--- a/docs/gateway/cloud-sessions.md
+++ b/docs/gateway/cloud-sessions.md
@@ -62,7 +62,7 @@ Suspension never interrupts work: sessions with an active turn, queued messages,
 
 Attach images and PDFs through the normal chat composer, including on later turns in an existing cloud session. The Gateway prepares image input, including rendered pages from scanned PDFs, before sending it to an OpenClaw worker. Codex receives image input through its Gateway-side app-server.
 
-Original attachments are copied into the placed session's remote workspace before execution. The turn includes the remote paths so file tools can inspect the originals without using Gateway-local filenames. Attachment transfer does not replace the remote workspace or overwrite existing work. Model credentials remain on the Gateway.
+Original attachments are copied into the placed session's remote workspace before execution. The turn includes the remote paths so file tools can inspect the originals without using Gateway-local filenames. These managed input copies stay readable on the worker but are excluded from workspace synchronization; they do not become project edits. Attachment transfer does not replace the remote workspace or overwrite existing work. Model credentials remain on the Gateway.
 
 ## What stays with the Gateway
 

--- a/docs/gateway/cloud-sessions.md
+++ b/docs/gateway/cloud-sessions.md
@@ -58,6 +58,12 @@ With warm images enabled, repeat sessions for the same repository can also avoid
 
 Suspension never interrupts work: sessions with an active turn, queued messages, or unreconciled results are skipped and re-checked on the next sweep. See the profile fields in [Cloud Workers](/gateway/cloud-workers#configuration) for costs, capture boundaries, and prerequisites.
 
+## Images and PDFs
+
+Attach images and PDFs through the normal chat composer, including on later turns in an existing cloud session. The Gateway prepares image input, including rendered pages from scanned PDFs, before sending it to an OpenClaw worker. Codex receives image input through its Gateway-side app-server.
+
+Original attachments are copied into the placed session's remote workspace before execution. The turn includes the remote paths so file tools can inspect the originals without using Gateway-local filenames. Attachment transfer does not replace the remote workspace or overwrite existing work. Model credentials remain on the Gateway.
+
 ## What stays with the Gateway
 
 Placement is disposable; the session is not. The transcript, the last-reconciled workspace files, placement history, and every provider credential live with the Gateway in all placements. A dead cloud machine or an idle suspension resolves automatically: the session remains in your sidebar, and the next message provisions a replacement — warm when an image exists, cold otherwise. An offline paired device is different by design: the placement stays active and waits for the device to reconnect, and **Continue on Gateway…** is an explicit action that can lose unsynced device files. Workspace changes made after the last reconciliation are the only loss window, and clean stops (including auto-suspension) reconcile before releasing the machine.

--- a/packages/gateway-protocol/src/schema/worker-inference.ts
+++ b/packages/gateway-protocol/src/schema/worker-inference.ts
@@ -41,7 +41,7 @@ const WorkerInferenceTextContentSchema = workerInferenceObject({
   textSignature: OptionalInferenceTextSchema,
 });
 
-const WorkerInferenceImageContentSchema = workerInferenceObject({
+export const WorkerInferenceImageContentSchema = workerInferenceObject({
   type: Type.Literal("image"),
   data: Type.String({
     minLength: 1,

--- a/src/agents/embedded-agent-runner/run/attempt-prompt-execution-prepare.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-prompt-execution-prepare.test.ts
@@ -19,7 +19,7 @@ vi.mock("./images.js", () => ({
   detectAndLoadPromptImages: hoisted.detectAndLoadPromptImages,
 }));
 
-import { prepareEmbeddedAttemptPromptExecution } from "./attempt-prompt-submit.js";
+import { prepareEmbeddedAttemptPromptExecution } from "./prompt-image-preparation.js";
 
 type PromptExecutionInput = Parameters<typeof prepareEmbeddedAttemptPromptExecution>[0];
 

--- a/src/agents/embedded-agent-runner/run/attempt-prompt-phase.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-prompt-phase.test.ts
@@ -51,8 +51,10 @@ vi.mock("./attempt-prompt-build.js", () => ({
 }));
 vi.mock("./attempt-prompt-submit.js", () => ({
   handleEmbeddedAttemptPromptError: mocks.handlePromptError,
-  prepareEmbeddedAttemptPromptExecution: mocks.preparePromptExecution,
   submitEmbeddedAttemptPrompt: mocks.submitPrompt,
+}));
+vi.mock("./prompt-image-preparation.js", () => ({
+  prepareEmbeddedAttemptPromptExecution: mocks.preparePromptExecution,
 }));
 vi.mock("./attempt-prompt-preflight.js", () => ({
   handleEmbeddedAttemptMidTurnPrecheck: mocks.handleMidTurnPrecheck,

--- a/src/agents/embedded-agent-runner/run/attempt-prompt-phase.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-prompt-phase.ts
@@ -19,7 +19,6 @@ import {
 } from "./attempt-prompt-preflight.js";
 import {
   handleEmbeddedAttemptPromptError,
-  prepareEmbeddedAttemptPromptExecution,
   submitEmbeddedAttemptPrompt,
 } from "./attempt-prompt-submit.js";
 import {
@@ -28,6 +27,7 @@ import {
 } from "./attempt-prompt-support.js";
 import { removeTrailingMidTurnPrecheckAssistantError } from "./attempt-transcript-helpers.js";
 import type { MidTurnPrecheckRequest } from "./midturn-precheck.js";
+import { prepareEmbeddedAttemptPromptExecution } from "./prompt-image-preparation.js";
 
 type PromptAssemblyInput = Parameters<typeof prepareEmbeddedAttemptPromptAssembly>[0];
 type PromptAssemblyResult = Awaited<ReturnType<typeof prepareEmbeddedAttemptPromptAssembly>>;

--- a/src/agents/embedded-agent-runner/run/attempt-prompt-submit.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-prompt-submit.ts
@@ -2,15 +2,10 @@
  * Submits or skips the prompt after build/preflight and before stream execution.
  * It may assume prompt context is assembled and admission state is published.
  */
-import { MAX_IMAGE_BYTES } from "@openclaw/media-core/constants";
 import type { StreamFn } from "openclaw/plugin-sdk/agent-core";
 import type { ImageContent } from "../../../llm/types.js";
-import { getAgentScopedMediaLocalRoots } from "../../../media/local-roots.js";
-import { readPersistedMediaFacts } from "../../../media/media-facts.js";
 import type { createTrajectoryRuntimeRecorder } from "../../../trajectory/runtime.js";
-import { resolveImageSanitizationLimits } from "../../image-sanitization.js";
 import type { AgentMessage } from "../../runtime/index.js";
-import type { SandboxContext } from "../../sandbox/types.js";
 import type { AgentSession } from "../../sessions/index.js";
 import { ackPendingAgentSteeringItems } from "../../subagents/registry/subagent-registry.js";
 import { recordAggregateTruncation } from "../prompt-cache-observability.js";
@@ -34,10 +29,8 @@ import {
   stripSessionsYieldArtifacts,
   waitForSessionsYieldAbortSettle,
 } from "./attempt-sessions-yield.js";
-import { detectAndLoadPromptImages } from "./images.js";
 import { wrapStreamFnWithMessageTransform } from "./message-transform-stream-wrapper.js";
 import { isMidTurnPrecheckSignal, type MidTurnPrecheckRequest } from "./midturn-precheck.js";
-import { readPersistedMediaImageLayout } from "./prompt-image-metadata.js";
 import type { RuntimeContextCustomMessage } from "./runtime-context-prompt.js";
 import type { EmbeddedRunAttemptParams } from "./types.js";
 
@@ -292,93 +285,5 @@ export async function handleEmbeddedAttemptPromptError(input: {
       error: input.error,
       source: "prompt",
     },
-  };
-}
-
-/** Prepares prompt-lock ownership and prompt-local images for submission. */
-type PromptExecutionAttempt = Pick<
-  EmbeddedRunAttemptParams,
-  | "config"
-  | "imageOrder"
-  | "images"
-  | "media"
-  | "model"
-  | "sessionFile"
-  | "sessionKey"
-  | "sessionTarget"
-  | "userTurnTranscriptRecorder"
->;
-type PromptImageResult = Awaited<ReturnType<typeof detectAndLoadPromptImages>>;
-
-function emptyPromptImages(): PromptImageResult {
-  return {
-    images: [],
-    imageFactIndexes: [],
-    detectedRefs: [],
-    failedMediaCount: 0,
-    loadedCount: 0,
-    skippedCount: 0,
-  };
-}
-
-export async function prepareEmbeddedAttemptPromptExecution(input: {
-  attempt: PromptExecutionAttempt;
-  /** Prepared run owner; scopes media roots without re-resolving session identity. */
-  mediaOwnerAgentId: string;
-  effectiveFsWorkspaceOnly: boolean;
-  effectiveWorkspace: string;
-  prompt: string;
-  sandbox?: SandboxContext | null;
-  skipPromptSubmission: boolean;
-  pluginHarness?: boolean;
-}): Promise<
-  PromptImageResult & {
-    imageOrder?: PromptExecutionAttempt["imageOrder"];
-    media?: PromptExecutionAttempt["media"];
-  }
-> {
-  if (input.skipPromptSubmission) {
-    return emptyPromptImages();
-  }
-
-  const { attempt } = input;
-  const persistedMessage =
-    attempt.userTurnTranscriptRecorder?.message ??
-    (await attempt.userTurnTranscriptRecorder?.resolveMessage());
-  const persistedMedia = persistedMessage ? (readPersistedMediaFacts(persistedMessage) ?? []) : [];
-
-  const result = await detectAndLoadPromptImages({
-    prompt: input.prompt,
-    workspaceDir: input.effectiveWorkspace,
-    model: attempt.model,
-    existingImages: attempt.images,
-    imageOrder: attempt.imageOrder,
-    media: persistedMedia.length > 0 ? persistedMedia : attempt.media,
-    mediaImageLayout: persistedMessage
-      ? readPersistedMediaImageLayout(persistedMessage)
-      : undefined,
-    maxBytes: MAX_IMAGE_BYTES,
-    maxDimensionPx: resolveImageSanitizationLimits(attempt.config).maxDimensionPx,
-    workspaceOnly: input.effectiveFsWorkspaceOnly,
-    localRoots: input.effectiveFsWorkspaceOnly
-      ? undefined
-      : getAgentScopedMediaLocalRoots(attempt.config ?? {}, input.mediaOwnerAgentId),
-    sandbox:
-      input.sandbox?.enabled && input.sandbox.fsBridge
-        ? { root: input.sandbox.workspaceDir, bridge: input.sandbox.fsBridge }
-        : undefined,
-  });
-  if (!input.pluginHarness) {
-    return result;
-  }
-  if (result.failedMediaCount) {
-    throw new Error(
-      `failed to hydrate ${result.failedMediaCount} structured image attachment(s) for plugin harness input`,
-    );
-  }
-  return {
-    ...result,
-    imageOrder: result.images.length ? result.images.map(() => "inline" as const) : undefined,
-    media: undefined,
   };
 }

--- a/src/agents/embedded-agent-runner/run/prompt-image-preparation.ts
+++ b/src/agents/embedded-agent-runner/run/prompt-image-preparation.ts
@@ -1,0 +1,88 @@
+import { MAX_IMAGE_BYTES } from "@openclaw/media-core/constants";
+import { getAgentScopedMediaLocalRoots } from "../../../media/local-roots.js";
+import { readPersistedMediaFacts } from "../../../media/media-facts.js";
+import { resolveImageSanitizationLimits } from "../../image-sanitization.js";
+import type { SandboxContext } from "../../sandbox/types.js";
+import { detectAndLoadPromptImages } from "./images.js";
+import type { RunEmbeddedAgentParams } from "./params.js";
+import { readPersistedMediaImageLayout } from "./prompt-image-metadata.js";
+
+type PromptExecutionAttempt = Pick<
+  RunEmbeddedAgentParams,
+  "config" | "imageOrder" | "images" | "media" | "userTurnTranscriptRecorder"
+> & { model: { input?: string[] } };
+type PromptImageResult = Awaited<ReturnType<typeof detectAndLoadPromptImages>>;
+
+function emptyPromptImages(): PromptImageResult {
+  return {
+    images: [],
+    imageFactIndexes: [],
+    detectedRefs: [],
+    failedMediaCount: 0,
+    loadedCount: 0,
+    skippedCount: 0,
+  };
+}
+
+/** Prepares ordered prompt images using the admitted media and filesystem policy. */
+export async function prepareEmbeddedAttemptPromptExecution(input: {
+  attempt: PromptExecutionAttempt;
+  /** Prepared run owner; scopes media roots without re-resolving session identity. */
+  mediaOwnerAgentId: string;
+  effectiveFsWorkspaceOnly: boolean;
+  effectiveWorkspace: string;
+  prompt: string;
+  sandbox?: SandboxContext | null;
+  skipPromptSubmission: boolean;
+  pluginHarness?: boolean;
+}): Promise<
+  PromptImageResult & {
+    imageOrder?: PromptExecutionAttempt["imageOrder"];
+    media?: PromptExecutionAttempt["media"];
+  }
+> {
+  if (input.skipPromptSubmission) {
+    return emptyPromptImages();
+  }
+
+  const { attempt } = input;
+  const persistedMessage =
+    attempt.userTurnTranscriptRecorder?.message ??
+    (await attempt.userTurnTranscriptRecorder?.resolveMessage());
+  const persistedMedia = persistedMessage ? (readPersistedMediaFacts(persistedMessage) ?? []) : [];
+
+  const result = await detectAndLoadPromptImages({
+    prompt: input.prompt,
+    workspaceDir: input.effectiveWorkspace,
+    model: attempt.model,
+    existingImages: attempt.images,
+    imageOrder: attempt.imageOrder,
+    media: persistedMedia.length > 0 ? persistedMedia : attempt.media,
+    mediaImageLayout: persistedMessage
+      ? readPersistedMediaImageLayout(persistedMessage)
+      : undefined,
+    maxBytes: MAX_IMAGE_BYTES,
+    maxDimensionPx: resolveImageSanitizationLimits(attempt.config).maxDimensionPx,
+    workspaceOnly: input.effectiveFsWorkspaceOnly,
+    localRoots: input.effectiveFsWorkspaceOnly
+      ? undefined
+      : getAgentScopedMediaLocalRoots(attempt.config ?? {}, input.mediaOwnerAgentId),
+    sandbox:
+      input.sandbox?.enabled && input.sandbox.fsBridge
+        ? { root: input.sandbox.workspaceDir, bridge: input.sandbox.fsBridge }
+        : undefined,
+  });
+  if (!input.pluginHarness) {
+    return result;
+  }
+  if (result.failedMediaCount) {
+    throw new Error(
+      `failed to hydrate ${result.failedMediaCount} structured image attachment(s) for plugin harness input`,
+    );
+  }
+  return {
+    ...result,
+    imageOrder: result.images.length ? result.images.map(() => "inline" as const) : undefined,
+    media: undefined,
+  };
+}

--- a/src/agents/embedded-agent-runner/run/run-attempt-dispatch.media.test.ts
+++ b/src/agents/embedded-agent-runner/run/run-attempt-dispatch.media.test.ts
@@ -5,7 +5,7 @@ import { describe, expect, it } from "vitest";
 import { buildInboundMediaNoteProjection } from "../../../auto-reply/media-note.js";
 import { readRuntimePromptImageFactIndexes } from "../../../media/runtime-prompt-image-provenance.js";
 import { captureEnv, setTestEnvValue } from "../../../test-utils/env.js";
-import { prepareEmbeddedAttemptPromptExecution } from "./attempt-prompt-submit.js";
+import { prepareEmbeddedAttemptPromptExecution } from "./prompt-image-preparation.js";
 
 async function preparePluginHarnessPromptImages(params: {
   runParams: Parameters<typeof prepareEmbeddedAttemptPromptExecution>[0]["attempt"];

--- a/src/agents/embedded-agent-runner/run/run-attempt-dispatch.ts
+++ b/src/agents/embedded-agent-runner/run/run-attempt-dispatch.ts
@@ -19,7 +19,6 @@ import {
 } from "../../tools/gateway-caller-context.js";
 import type { SystemAgentToolOptions } from "../../tools/system-agent-tool.js";
 import { prepareExecApprovalContinuationForAttempt } from "./attempt-exec-approval-continuation.js";
-import { prepareEmbeddedAttemptPromptExecution } from "./attempt-prompt-submit.js";
 import { applyResolvedToolPromptFinalizer } from "./attempt-prompt-support.js";
 import { resolveAttemptWorkspaceSandbox } from "./attempt-setup.js";
 import { runEmbeddedAttemptWithBackend } from "./backend.js";
@@ -29,6 +28,7 @@ import {
   EMBEDDED_RUN_LANE_TIMEOUT_GRACE_MS,
 } from "./lane-runtime.js";
 import type { RunEmbeddedAgentParams } from "./params.js";
+import { prepareEmbeddedAttemptPromptExecution } from "./prompt-image-preparation.js";
 import { resolveSkillWorkshopAttemptParams } from "./skill-workshop-attempt-params.js";
 import type { EmbeddedRunAttemptParams, EmbeddedRunAttemptTrajectoryRecorder } from "./types.js";
 

--- a/src/config/sessions/session-accessor.sqlite-transcript-store.test.ts
+++ b/src/config/sessions/session-accessor.sqlite-transcript-store.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { cleanupTempDirs, makeTempDir } from "../../../test/helpers/temp-dir.js";
+import {
+  closeOpenClawAgentDatabasesForTest,
+  openOpenClawAgentDatabase,
+  runOpenClawAgentWriteTransaction,
+} from "../../state/openclaw-agent-db.js";
+import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db.js";
+import { appendTranscriptEventInTransaction } from "./session-accessor.sqlite-transcript-store.js";
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  closeOpenClawAgentDatabasesForTest();
+  closeOpenClawStateDatabaseForTest();
+  cleanupTempDirs(tempDirs);
+});
+
+describe("SQLite transcript append", () => {
+  it("canonicalizes assistant media at the generic transcript append owner", async () => {
+    const stateDir = makeTempDir(tempDirs, "media-persistence-append-");
+    const env = { OPENCLAW_STATE_DIR: stateDir };
+    runOpenClawAgentWriteTransaction(
+      (database) => {
+        expect(
+          appendTranscriptEventInTransaction(
+            database,
+            {
+              agentId: "main",
+              env,
+              sessionId: "append-session",
+              sessionKey: "agent:main:append-session",
+            },
+            {
+              type: "message",
+              id: "event-1",
+              parentId: null,
+              timestamp: 1000,
+              message: {
+                role: "assistant",
+                content: "append",
+                MediaPaths: ["/media/a.png"],
+                MediaTypes: ["image/png"],
+              },
+            },
+          ),
+        ).toBe(true);
+      },
+      { agentId: "main", env },
+    );
+    const database = openOpenClawAgentDatabase({ agentId: "main", env });
+    const row = database.db
+      .prepare("SELECT event_json FROM transcript_events WHERE session_id = ? AND seq = 0")
+      .get("append-session") as { event_json: string };
+    const message = (JSON.parse(row.event_json) as { message: Record<string, unknown> }).message;
+    expect(message).toMatchObject({ role: "assistant", content: "append" });
+    expect(message).not.toHaveProperty("MediaPaths");
+    expect(message).not.toHaveProperty("MediaTypes");
+    expect(message["__openclaw"]).toMatchObject({
+      media: [expect.objectContaining({ path: "/media/a.png", contentType: "image/png" })],
+    });
+  });
+});

--- a/src/gateway/worker-environments/node-worker-tunnel.test.ts
+++ b/src/gateway/worker-environments/node-worker-tunnel.test.ts
@@ -506,7 +506,7 @@ describe("node worker tunnel manager", () => {
     expect(outputs).toEqual([]);
   });
 
-  it("keeps the process timeout inside the node transport deadline", async () => {
+  it("keeps node command deadlines and rechecks turn authority after discovery", async () => {
     const record = environment();
     const manifest = { version: 1 as const, baseCommit: null, entries: [] };
     const rawManifest = serializeWorkerWorkspaceManifest(manifest);
@@ -583,6 +583,27 @@ describe("node worker tunnel manager", () => {
     expect(transportTimeoutMs).toBeGreaterThan(60_000);
     expect(transportTimeoutMs).toBeLessThanOrEqual(65_000);
     expect(validationOutputs).toEqual([]);
+
+    const listCurrentNodes = nodeTransport.listCurrentNodes;
+    let current = true;
+    nodeTransport.listCurrentNodes = async () => {
+      const nodes = await listCurrentNodes();
+      current = false;
+      return nodes;
+    };
+    const sentCommands = vi.mocked(nodeTransport.invoke).mock.calls.length;
+    await expect(
+      handle.runWorkspaceCommand({
+        argv: ["slow-command"],
+        transportRetry: "never",
+        assertCurrent: () => {
+          if (!current) {
+            throw new Error("turn claim closed");
+          }
+        },
+      }),
+    ).rejects.toThrow("turn claim closed");
+    expect(nodeTransport.invoke).toHaveBeenCalledTimes(sentCommands);
   });
 
   it("preserves a typed workspace transfer cause from the node", async () => {

--- a/src/gateway/worker-environments/node-worker-tunnel.test.ts
+++ b/src/gateway/worker-environments/node-worker-tunnel.test.ts
@@ -584,14 +584,15 @@ describe("node worker tunnel manager", () => {
     expect(transportTimeoutMs).toBeLessThanOrEqual(65_000);
     expect(validationOutputs).toEqual([]);
 
-    const listCurrentNodes = nodeTransport.listCurrentNodes;
+    const listCurrentNodes = nodeTransport.listCurrentNodes.bind(nodeTransport);
     let current = true;
     nodeTransport.listCurrentNodes = async () => {
       const nodes = await listCurrentNodes();
       current = false;
       return nodes;
     };
-    const sentCommands = vi.mocked(nodeTransport.invoke).mock.calls.length;
+    const invoke = vi.spyOn(nodeTransport, "invoke");
+    const sentCommands = invoke.mock.calls.length;
     await expect(
       handle.runWorkspaceCommand({
         argv: ["slow-command"],
@@ -603,7 +604,7 @@ describe("node worker tunnel manager", () => {
         },
       }),
     ).rejects.toThrow("turn claim closed");
-    expect(nodeTransport.invoke).toHaveBeenCalledTimes(sentCommands);
+    expect(invoke).toHaveBeenCalledTimes(sentCommands);
   });
 
   it("preserves a typed workspace transfer cause from the node", async () => {

--- a/src/gateway/worker-environments/node-worker-tunnel.ts
+++ b/src/gateway/worker-environments/node-worker-tunnel.ts
@@ -188,6 +188,12 @@ export function createNodeWorkerTunnelManager(options: NodeWorkerTunnelManagerOp
     entry: NodeTunnelEntry,
     command: WorkerWorkspaceCommand & { resetWorkspace?: boolean },
   ): Promise<NodeWorkerWorkspaceExecResult> => {
+    const assertCurrent = () => {
+      if (!isEnvironmentOwner(entry)) {
+        throw new Error("node worker workspace authority closed");
+      }
+      command.assertCurrent?.();
+    };
     const commandTimeoutMs = command.timeoutMs ?? DEFAULT_COMMAND_TIMEOUT_MS;
     // Keep the subprocess deadline authoritative while allowing its terminal result to cross the
     // node transport. Equal deadlines turn an ordinary process timeout into a transport failure.
@@ -212,9 +218,7 @@ export function createNodeWorkerTunnelManager(options: NodeWorkerTunnelManagerOp
       ...(command.seed === undefined ? {} : { seed: command.seed }),
     };
     while (true) {
-      if (!isEnvironmentOwner(entry)) {
-        throw new Error("node worker workspace authority closed");
-      }
+      assertCurrent();
       const remainingMs = deadline - Date.now();
       if (remainingMs <= 0 || signal.aborted) {
         throw signal.reason ?? new Error("node worker workspace command timed out");
@@ -222,15 +226,20 @@ export function createNodeWorkerTunnelManager(options: NodeWorkerTunnelManagerOp
       let result: Awaited<ReturnType<NodeWorkerSupervisorTransport["invoke"]>>;
       try {
         const { node, transport } = await findNode(entry, signal);
+        assertCurrent();
         result = await transport.invoke({
           node,
           command: NODE_WORKER_WORKSPACE_EXEC_COMMAND,
           params: input,
           timeoutMs: remainingMs,
           signal,
-          isDispatchAuthorized: () => isEnvironmentOwner(entry),
+          isDispatchAuthorized: () => {
+            assertCurrent();
+            return true;
+          },
         });
       } catch (error) {
+        assertCurrent();
         if (
           command.transportRetry !== "idempotent" ||
           signal.aborted ||

--- a/src/gateway/worker-environments/tunnel-contract.ts
+++ b/src/gateway/worker-environments/tunnel-contract.ts
@@ -50,6 +50,8 @@ export type WorkerTunnelStopReason = "provider-destroying" | "provider-destroyed
 export type WorkerWorkspaceCommand = {
   argv: readonly string[];
   transportRetry: "idempotent" | "never";
+  /** Local owner guard revalidated after transport awaits, immediately before dispatch. */
+  assertCurrent?: () => void;
   onDispatchReady?: () => void;
   input?: string;
   timeoutMs?: number;

--- a/src/gateway/worker-environments/worker-turn-attachments.boundary.test.ts
+++ b/src/gateway/worker-environments/worker-turn-attachments.boundary.test.ts
@@ -1,0 +1,188 @@
+import { mkdir, readFile, readdir, realpath, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { saveMediaBuffer } from "../../media/store.js";
+import { runCommandWithTimeout, type SpawnResult } from "../../process/exec.js";
+import {
+  buildPersistedUserTurnMessage,
+  createUserTurnTranscriptRecorder,
+} from "../../sessions/user-turn-transcript.js";
+import { parseNodeWorkerWorkspaceExecInput } from "../../worker/node-workspace-protocol.js";
+import { createWorkerSessionPlacementGate } from "./placement-worker-gate.js";
+import type { WorkerTunnelHandle } from "./tunnel-contract.js";
+import {
+  ENVIRONMENT_ID,
+  MANIFEST_REF,
+  OWNER_EPOCH,
+  SESSION_ID,
+  SESSION_KEY,
+  attachedEnvironment,
+  cleanupWorkerTurnLauncherTest,
+  createWorkerSessionTurnPlacementProvider,
+  credential,
+  openSessionManager,
+  placements,
+  root,
+  seedActivePlacement,
+  sessionTarget,
+  setupWorkerTurnLauncherTest,
+  turn,
+  unusedEnvironments,
+} from "./worker-turn-launcher.test-support.js";
+
+describe("current attachments in an active remote placement", () => {
+  beforeEach(setupWorkerTurnLauncherTest);
+  afterEach(cleanupWorkerTurnLauncherTest);
+
+  it.each(["worker-turn", "remote-exec"] as const)(
+    "makes later image and PDF originals readable before %s inference",
+    async (executionMode) => {
+      const remote = path.join(await realpath(root), "remote");
+      await mkdir(remote);
+      await writeFile(path.join(remote, "remote-edits.txt"), "preserve me");
+      seedActivePlacement(executionMode, remote);
+      // These arrive after placement: the initial workspace snapshot cannot include them.
+      const pdf = Buffer.concat([Buffer.from("%PDF-1.7\n"), Buffer.alloc(220_000, 65)]);
+      const image = Buffer.from(
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACXBIWXMAAAsTAAALEwEAmpwYAAAADUlEQVR4nGP4////KwAJ5gPoxLp9owAAAABJRU5ErkJggg==",
+        "base64",
+      );
+      const savedPdf = await saveMediaBuffer(
+        pdf,
+        "application/pdf",
+        "inbound",
+        pdf.length,
+        "report.pdf",
+      );
+      const savedImage = await saveMediaBuffer(
+        image,
+        "image/png",
+        "inbound",
+        image.length,
+        "photo.png",
+      );
+      const media = [
+        { path: savedPdf.path, contentType: "application/pdf" },
+        { path: savedImage.path, contentType: "image/png" },
+      ];
+      const recorder = createUserTurnTranscriptRecorder({
+        message: buildPersistedUserTurnMessage({ text: "Read both attachments", media }),
+        target: { ...sessionTarget, sessionEntry: { sessionId: SESSION_ID, updatedAt: 1 } },
+      });
+      const input = {
+        ...turn(),
+        prompt: "Read both attachments",
+        media: [media[0]!],
+        userTurnTranscriptRecorder: recorder,
+      };
+      const verifyFiles = async (prompt: string) => {
+        const files: Buffer[] = [];
+        for (const entry of await readdir(remote, { recursive: true, withFileTypes: true })) {
+          if (!entry.isFile() || entry.name === "remote-edits.txt") {
+            continue;
+          }
+          const file = path.join(entry.parentPath, entry.name);
+          files.push(await readFile(file));
+          expect(prompt).toContain(
+            path.relative(remote, path.dirname(file)).split(path.sep).join("/"),
+          );
+        }
+        expect(files).toHaveLength(2);
+        expect(files.some((bytes) => bytes.equals(pdf))).toBe(true);
+        expect(files.some((bytes) => bytes.equals(image))).toBe(true);
+        expect(await readFile(path.join(remote, "remote-edits.txt"), "utf8")).toBe("preserve me");
+      };
+      const tunnel: WorkerTunnelHandle = {
+        environmentId: ENVIRONMENT_ID,
+        ownerEpoch: OWNER_EPOCH,
+        runWorkspaceCommand: vi.fn(async (command) => {
+          parseNodeWorkerWorkspaceExecInput(
+            JSON.stringify({
+              gatewayNamespace: "attachments",
+              environmentId: ENVIRONMENT_ID,
+              sessionId: SESSION_ID,
+              generation: OWNER_EPOCH,
+              argv: command.argv,
+              input: command.input,
+            }),
+          );
+          return await runCommandWithTimeout([...command.argv], {
+            cwd: remote,
+            input: command.input,
+            timeoutMs: 10_000,
+            signal: command.signal,
+          });
+        }),
+        launchTurn: vi.fn(async (request): Promise<SpawnResult> => {
+          await verifyFiles(request.plan.assignment.prompt);
+          request.onDispatchReady?.();
+          const transcriptLeafId = openSessionManager().appendMessage({
+            role: "assistant",
+            content: [{ type: "text", text: "Read both" }],
+            api: "openai-responses",
+            provider: "openai",
+            model: "gpt-test",
+            usage: {
+              input: 1,
+              output: 1,
+              cacheRead: 0,
+              cacheWrite: 0,
+              totalTokens: 2,
+              cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+            },
+            stopReason: "stop",
+            timestamp: Date.now(),
+          });
+          createWorkerSessionPlacementGate(placements).updateAckCursors({
+            claim: request.turnClaim,
+            transcriptSeq: 2,
+            liveSeq: 1,
+          });
+          return {
+            stdout: JSON.stringify({ status: "completed", transcriptLeafId, transcriptNextSeq: 3 }),
+            stderr: "",
+            code: 0,
+            signal: null,
+            killed: false,
+            termination: "exit",
+          };
+        }),
+        quiesceWorkspace: vi.fn(async () => ({
+          assertActive: async () => {},
+          resume: async () => {},
+        })),
+        reconcileWorkspace: vi.fn(async (request) => {
+          request.journal.commit(MANIFEST_REF);
+          return {
+            manifestRef: MANIFEST_REF,
+            changed: false,
+            verifyStable: async () => {},
+            verifyLocalStable: async () => {},
+          };
+        }),
+        syncWorkspace: vi.fn(),
+        stop: vi.fn(async () => {}),
+      };
+      const provider = createWorkerSessionTurnPlacementProvider({
+        placements,
+        environments: {
+          ...unusedEnvironments(),
+          get: () => attachedEnvironment(),
+          acquireTurnCredential: async () => credential(),
+          acknowledgeCredentialDelivery: () => true,
+          startTunnel: async () => tunnel,
+        },
+      });
+      await provider.executeTurn(
+        { sessionId: SESSION_ID, sessionKey: SESSION_KEY, agentId: "main", runId: input.runId },
+        input,
+        async () => {
+          await verifyFiles(input.prompt);
+          return { meta: { durationMs: 1 } };
+        },
+      );
+      expect(tunnel.syncWorkspace).not.toHaveBeenCalled();
+      expect(input.prompt).toBe("Read both attachments");
+    },
+  );
+});

--- a/src/gateway/worker-environments/worker-turn-attachments.boundary.test.ts
+++ b/src/gateway/worker-environments/worker-turn-attachments.boundary.test.ts
@@ -29,17 +29,25 @@ import {
   turn,
   unusedEnvironments,
 } from "./worker-turn-launcher.test-support.js";
+import { parseWorkerWorkspaceManifest } from "./workspace-manifest.js";
+import { applyStagedWorkerWorkspace, readActualWorkspaceManifest } from "./workspace-reconcile.js";
+import { REMOTE_WORKSPACE_MANIFEST_JS } from "./workspace-sync-scripts.js";
 
 describe("current attachments in an active remote placement", () => {
   beforeEach(setupWorkerTurnLauncherTest);
   afterEach(cleanupWorkerTurnLauncherTest);
 
   it.each(["worker-turn", "remote-exec"] as const)(
-    "makes later image and PDF originals readable before %s inference",
+    "keeps later image and PDF originals readable without reconciling them as %s output",
     async (executionMode) => {
       const remote = path.join(await realpath(root), "remote");
-      await mkdir(remote);
-      await writeFile(path.join(remote, "remote-edits.txt"), "preserve me");
+      const local = path.join(await realpath(root), "local");
+      const remoteHome = path.join(await realpath(root), "remote-home");
+      await Promise.all([mkdir(remote), mkdir(local), mkdir(remoteHome)]);
+      for (const directory of [remote, local]) {
+        await writeFile(path.join(directory, "remote-edits.txt"), "preserve me");
+      }
+      const base = await readActualWorkspaceManifest({ root: local, baseCommit: null });
       seedActivePlacement(executionMode, remote);
       // These arrive after placement: the initial workspace snapshot cannot include them.
       const pdf = Buffer.concat([Buffer.from("%PDF-1.7\n"), Buffer.alloc(220_000, 65)]);
@@ -71,10 +79,14 @@ describe("current attachments in an active remote placement", () => {
       });
       const input = {
         ...turn(),
+        workspaceDir: local,
         prompt: "Read both attachments",
         media: [media[0]!],
         userTurnTranscriptRecorder: recorder,
       };
+      const originalFiles = new Map<string, Buffer>();
+      let workerManifestPaths: string[] = [];
+      let acceptedManifestPaths: string[] = [];
       const verifyFiles = async (prompt: string) => {
         const files: Buffer[] = [];
         for (const entry of await readdir(remote, { recursive: true, withFileTypes: true })) {
@@ -82,7 +94,9 @@ describe("current attachments in an active remote placement", () => {
             continue;
           }
           const file = path.join(entry.parentPath, entry.name);
-          files.push(await readFile(file));
+          const bytes = await readFile(file);
+          files.push(bytes);
+          originalFiles.set(file, bytes);
           expect(prompt).toContain(
             path.relative(remote, path.dirname(file)).split(path.sep).join("/"),
           );
@@ -91,6 +105,8 @@ describe("current attachments in an active remote placement", () => {
         expect(files.some((bytes) => bytes.equals(pdf))).toBe(true);
         expect(files.some((bytes) => bytes.equals(image))).toBe(true);
         expect(await readFile(path.join(remote, "remote-edits.txt"), "utf8")).toBe("preserve me");
+        await writeFile(path.join(remote, "remote-edits.txt"), "worker edit");
+        await writeFile(path.join(remote, "report.txt"), "Read both attachments");
       };
       const tunnel: WorkerTunnelHandle = {
         environmentId: ENVIRONMENT_ID,
@@ -152,12 +168,34 @@ describe("current attachments in an active remote placement", () => {
           resume: async () => {},
         })),
         reconcileWorkspace: vi.fn(async (request) => {
-          request.journal.commit(MANIFEST_REF);
+          const capture = await runCommandWithTimeout(
+            [process.execPath, "-e", REMOTE_WORKSPACE_MANIFEST_JS, remote],
+            { timeoutMs: 10_000, baseEnv: { ...process.env, HOME: remoteHome } },
+          );
+          expect(capture.code, capture.stderr).toBe(0);
+          const manifestRef = capture.stdout.trim();
+          const raw = await readFile(
+            path.join(remoteHome, ".openclaw-worker", "manifests", `${manifestRef.slice(7)}.json`),
+            "utf8",
+          );
+          const current = parseWorkerWorkspaceManifest(raw, manifestRef);
+          const result = await applyStagedWorkerWorkspace({
+            root: local,
+            stagingRoot: remote,
+            baseManifestRef: MANIFEST_REF,
+            currentManifestRef: manifestRef,
+            base: base.manifest,
+            current,
+            journal: request.journal,
+          });
+          workerManifestPaths = JSON.parse(raw).entries.map(
+            (entry: { path: string }) => entry.path,
+          );
+          acceptedManifestPaths = result.manifest.entries.map((entry) => entry.path);
           return {
-            manifestRef: MANIFEST_REF,
-            changed: false,
+            ...result,
+            changed: true,
             verifyStable: async () => {},
-            verifyLocalStable: async () => {},
           };
         }),
         syncWorkspace: vi.fn(),
@@ -165,6 +203,7 @@ describe("current attachments in an active remote placement", () => {
       };
       const provider = createWorkerSessionTurnPlacementProvider({
         placements,
+        resolveWorkspacePath: async () => local,
         environments: {
           ...unusedEnvironments(),
           get: () => attachedEnvironment(),
@@ -182,6 +221,15 @@ describe("current attachments in an active remote placement", () => {
         },
       );
       expect(tunnel.syncWorkspace).not.toHaveBeenCalled();
+      expect(tunnel.reconcileWorkspace).toHaveBeenCalledOnce();
+      expect(workerManifestPaths).toEqual(["remote-edits.txt", "report.txt"]);
+      expect(acceptedManifestPaths).toEqual(["remote-edits.txt", "report.txt"]);
+      expect(await readdir(local)).toEqual(["remote-edits.txt", "report.txt"]);
+      expect(await readFile(path.join(local, "remote-edits.txt"), "utf8")).toBe("worker edit");
+      expect(await readFile(path.join(local, "report.txt"), "utf8")).toBe("Read both attachments");
+      for (const [file, bytes] of originalFiles) {
+        expect(await readFile(file)).toEqual(bytes);
+      }
       expect(input.prompt).toBe("Read both attachments");
     },
   );

--- a/src/gateway/worker-environments/worker-turn-attachments.boundary.test.ts
+++ b/src/gateway/worker-environments/worker-turn-attachments.boundary.test.ts
@@ -85,6 +85,10 @@ describe("current attachments in an active remote placement", () => {
         userTurnTranscriptRecorder: recorder,
       };
       const originalFiles = new Map<string, Buffer>();
+      const userFiles = [
+        "openclaw-inbound-project/report.txt",
+        "openclaw-inbound-12345678-1234-4234-8234-123456789ab-/report.txt",
+      ];
       let workerManifestPaths: string[] = [];
       let acceptedManifestPaths: string[] = [];
       const verifyFiles = async (prompt: string) => {
@@ -107,6 +111,10 @@ describe("current attachments in an active remote placement", () => {
         expect(await readFile(path.join(remote, "remote-edits.txt"), "utf8")).toBe("preserve me");
         await writeFile(path.join(remote, "remote-edits.txt"), "worker edit");
         await writeFile(path.join(remote, "report.txt"), "Read both attachments");
+        for (const file of userFiles) {
+          await mkdir(path.dirname(path.join(remote, file)));
+          await writeFile(path.join(remote, file), "user project output");
+        }
       };
       const tunnel: WorkerTunnelHandle = {
         environmentId: ENVIRONMENT_ID,
@@ -222,11 +230,23 @@ describe("current attachments in an active remote placement", () => {
       );
       expect(tunnel.syncWorkspace).not.toHaveBeenCalled();
       expect(tunnel.reconcileWorkspace).toHaveBeenCalledOnce();
-      expect(workerManifestPaths).toEqual(["remote-edits.txt", "report.txt"]);
-      expect(acceptedManifestPaths).toEqual(["remote-edits.txt", "report.txt"]);
-      expect(await readdir(local)).toEqual(["remote-edits.txt", "report.txt"]);
+      const expectedFiles = ["remote-edits.txt", "report.txt", ...userFiles].toSorted();
+      const expectedPaths = [
+        ...expectedFiles,
+        ...userFiles.map((file) => path.dirname(file)),
+      ].toSorted();
+      expect(workerManifestPaths).toEqual(expectedPaths);
+      expect(acceptedManifestPaths).toEqual(expectedFiles);
+      expect(
+        (await readdir(local, { recursive: true }))
+          .map((entry) => entry.split(path.sep).join("/"))
+          .toSorted(),
+      ).toEqual(expectedPaths);
       expect(await readFile(path.join(local, "remote-edits.txt"), "utf8")).toBe("worker edit");
       expect(await readFile(path.join(local, "report.txt"), "utf8")).toBe("Read both attachments");
+      for (const file of userFiles) {
+        expect(await readFile(path.join(local, file), "utf8")).toBe("user project output");
+      }
       for (const [file, bytes] of originalFiles) {
         expect(await readFile(file)).toEqual(bytes);
       }

--- a/src/gateway/worker-environments/worker-turn-attachments.test.ts
+++ b/src/gateway/worker-environments/worker-turn-attachments.test.ts
@@ -1,0 +1,172 @@
+import {
+  mkdir,
+  mkdtemp,
+  readFile,
+  readdir,
+  realpath,
+  rename,
+  rm,
+  symlink,
+  writeFile,
+} from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { saveMediaBuffer } from "../../media/store.js";
+import { runCommandWithTimeout } from "../../process/exec.js";
+import type { WorkerWorkspaceCommand } from "./tunnel-contract.js";
+import { prepareWorkerTurnAttachments } from "./worker-turn-attachments.js";
+
+describe("cloud attachment transfer confinement", () => {
+  let root: string;
+  beforeEach(async () => {
+    root = await realpath(await mkdtemp(path.join(os.tmpdir(), "cloud-attachments-")));
+    vi.stubEnv("OPENCLAW_STATE_DIR", path.join(root, "state"));
+  });
+  afterEach(async () => {
+    vi.unstubAllEnvs();
+    await rm(root, { recursive: true, force: true });
+  });
+
+  async function fixture() {
+    const remote = path.join(await realpath(root), "remote");
+    await mkdir(remote);
+    const bytes = Buffer.from("%PDF-1.7\nreal original bytes");
+    const saved = await saveMediaBuffer(
+      bytes,
+      "application/pdf",
+      "inbound",
+      bytes.length,
+      "report.pdf",
+    );
+    const execute = async (command: WorkerWorkspaceCommand) =>
+      await runCommandWithTimeout([...command.argv], {
+        cwd: remote,
+        input: command.input,
+        timeoutMs: 10_000,
+        signal: command.signal,
+      });
+    return {
+      remote,
+      bytes,
+      execute,
+      input: { timeoutMs: 5_000, media: [{ path: saved.path, contentType: "application/pdf" }] },
+    };
+  }
+
+  it("removes incomplete files after a checksum failure without changing other workspace files", async () => {
+    const { remote, execute, input } = await fixture();
+    await writeFile(path.join(remote, "keep.txt"), "remote edits");
+    const runWorkspaceCommand = vi.fn(async (command: WorkerWorkspaceCommand) =>
+      execute(
+        command.input === undefined
+          ? command
+          : { ...command, input: Buffer.from("%PDF-1.7\ncorrupt bytes here!").toString("base64") },
+      ),
+    );
+    await expect(
+      prepareWorkerTurnAttachments({
+        turn: input,
+        remoteWorkspaceDir: remote,
+        tunnel: { runWorkspaceCommand },
+        assertCurrent: () => {},
+      }),
+    ).rejects.toThrow(/checksum|invalid attachment chunk/);
+    expect(await readdir(remote)).toEqual(["keep.txt"]);
+    expect(await readFile(path.join(remote, "keep.txt"), "utf8")).toBe("remote edits");
+  });
+
+  it("rejects a replaced upload directory without following its symlink during write or cleanup", async () => {
+    const { remote, execute, input } = await fixture();
+    const outside = path.join(root, "outside");
+    await mkdir(outside);
+    await writeFile(path.join(outside, "keep.txt"), "outside");
+    let initialized = false;
+    const runWorkspaceCommand = vi.fn(async (command: WorkerWorkspaceCommand) => {
+      const result = await execute(command);
+      if (!initialized) {
+        initialized = true;
+        const [directory] = await readdir(remote);
+        await rename(path.join(remote, directory!), path.join(root, "original-upload"));
+        await symlink(outside, path.join(remote, directory!), "dir");
+      }
+      return result;
+    });
+    await expect(
+      prepareWorkerTurnAttachments({
+        turn: input,
+        remoteWorkspaceDir: remote,
+        tunnel: { runWorkspaceCommand },
+        assertCurrent: () => {},
+      }),
+    ).rejects.toThrow("attachment directory changed");
+    expect(await readdir(outside)).toEqual(["keep.txt"]);
+    expect(await readFile(path.join(outside, "keep.txt"), "utf8")).toBe("outside");
+  });
+
+  it("stops after claim loss and never uses a stale claim for cleanup", async () => {
+    const { remote, execute, input } = await fixture();
+    let current = true;
+    const runWorkspaceCommand = vi.fn(async (command: WorkerWorkspaceCommand) => {
+      const result = await execute(command);
+      current = false;
+      return result;
+    });
+    await expect(
+      prepareWorkerTurnAttachments({
+        turn: input,
+        remoteWorkspaceDir: remote,
+        tunnel: { runWorkspaceCommand },
+        assertCurrent: () => {
+          if (!current) {
+            throw new Error("lost claim");
+          }
+        },
+      }),
+    ).rejects.toThrow("lost claim");
+    expect(runWorkspaceCommand).toHaveBeenCalledOnce();
+    const [directory] = await readdir(remote);
+    expect(await readdir(path.join(remote, directory!))).toEqual([]);
+  });
+
+  it.each(["path", "url"] as const)(
+    "reports unavailable local %s attachments without reading arbitrary host files",
+    async (field) => {
+      const { remote, input } = await fixture();
+      const privatePath = path.join(root, "private.txt");
+      await writeFile(privatePath, "not an admitted attachment");
+      const runWorkspaceCommand = vi.fn();
+      await expect(
+        prepareWorkerTurnAttachments({
+          turn: { ...input, media: [{ [field]: privatePath }] },
+          remoteWorkspaceDir: remote,
+          tunnel: { runWorkspaceCommand },
+          assertCurrent: () => {},
+        }),
+      ).rejects.toThrow("attach the file again");
+      expect(runWorkspaceCommand).not.toHaveBeenCalled();
+    },
+  );
+
+  it("uses a managed original URL when the runtime path was already staged on the Gateway", async () => {
+    const { remote, input, execute, bytes } = await fixture();
+    const note = await prepareWorkerTurnAttachments({
+      turn: {
+        ...input,
+        media: [
+          {
+            path: path.join(root, "gateway-copy.pdf"),
+            url: input.media[0]!.path,
+            fileName: "original.pdf",
+          },
+        ],
+      },
+      remoteWorkspaceDir: remote,
+      tunnel: { runWorkspaceCommand: execute },
+      assertCurrent: () => {},
+    });
+    const [directory] = await readdir(remote);
+    expect(note).toContain(directory);
+    expect(await readFile(path.join(remote, directory!, "1-original.pdf"))).toEqual(bytes);
+  });
+});

--- a/src/gateway/worker-environments/worker-turn-attachments.ts
+++ b/src/gateway/worker-environments/worker-turn-attachments.ts
@@ -10,6 +10,7 @@ import { readMediaBuffer } from "../../media/store.js";
 import { resolveChatAttachmentMaxBytes } from "../chat-attachment-policy.js";
 import { MAX_PAYLOAD_BYTES } from "../server-constants.js";
 import type { WorkerWorkspaceTunnelHandle } from "./tunnel-contract.js";
+import { WORKER_ATTACHMENT_DIRECTORY_PREFIX } from "./workspace-path-exclusions.js";
 
 const MAX_TURN_ATTACHMENTS = 16;
 // Base64 expansion stays below the node workspace command's 128 KiB stdin cap.
@@ -29,7 +30,7 @@ function enter(candidate, expected) {
   if (identity(fs.statSync(".")) !== identity(before)) throw Error("attachment directory changed");
 }
 try {
-  if (!/^openclaw-inbound-[a-f0-9-]{36}$/.test(directory)) throw Error("invalid attachment directory");
+  if (!/^${WORKER_ATTACHMENT_DIRECTORY_PREFIX}[a-f0-9-]{36}$/.test(directory)) throw Error("invalid attachment directory");
   enter(workspace);
   if (operation === "init") fs.mkdirSync(directory, {mode: 0o700});
   enter(directory, directoryIdentity);
@@ -152,7 +153,7 @@ export async function prepareWorkerTurnAttachments(params: {
   if (!files.length) {
     return undefined;
   }
-  const directory = `openclaw-inbound-${randomUUID()}`;
+  const directory = `${WORKER_ATTACHMENT_DIRECTORY_PREFIX}${randomUUID()}`;
   const deadline = Date.now() + turn.timeoutMs;
   const execute = async (args: string[], input?: string, cleanup = false): Promise<string> => {
     const assertDispatchCurrent = cleanup ? assertCurrent : check;

--- a/src/gateway/worker-environments/worker-turn-attachments.ts
+++ b/src/gateway/worker-environments/worker-turn-attachments.ts
@@ -1,0 +1,219 @@
+import { createHash, randomUUID } from "node:crypto";
+import path from "node:path";
+import { isPassThroughRemoteMediaSource } from "@openclaw/media-core/media-source-url";
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
+import type { SessionPlacementTurnParams } from "../../agents/session-placement-admission.js";
+import { sanitizeUntrustedFileName } from "../../infra/fs-safe-advanced.js";
+import { readPersistedMediaFacts } from "../../media/media-facts.js";
+import { resolveInboundMediaReference } from "../../media/media-reference.js";
+import { readMediaBuffer } from "../../media/store.js";
+import { resolveChatAttachmentMaxBytes } from "../chat-attachment-policy.js";
+import { MAX_PAYLOAD_BYTES } from "../server-constants.js";
+import type { WorkerWorkspaceTunnelHandle } from "./tunnel-contract.js";
+
+const MAX_TURN_ATTACHMENTS = 16;
+// Base64 expansion stays below the node workspace command's 128 KiB stdin cap.
+const ATTACHMENT_CHUNK_BYTES = 64 * 1024;
+
+// Enter verified directories before mutation: process cwd pins the directory,
+// including when another process renames it. All following names are basenames.
+const STAGE_ATTACHMENT_SCRIPT = String.raw`
+const fs = require("node:fs");
+const crypto = require("node:crypto");
+const [workspace, directory, operation, directoryIdentity, name, offsetText, sizeText, hash, fileIdentity] = process.argv.slice(1);
+const identity = (stat) => String(stat.dev) + ":" + String(stat.ino);
+function enter(candidate, expected) {
+  const before = fs.lstatSync(candidate);
+  if (!before.isDirectory() || before.isSymbolicLink() || (expected && identity(before) !== expected)) throw Error("attachment directory changed");
+  process.chdir(candidate);
+  if (identity(fs.statSync(".")) !== identity(before)) throw Error("attachment directory changed");
+}
+try {
+  if (!/^openclaw-inbound-[a-f0-9-]{36}$/.test(directory)) throw Error("invalid attachment directory");
+  enter(workspace);
+  if (operation === "init") fs.mkdirSync(directory, {mode: 0o700});
+  enter(directory, directoryIdentity);
+  if (operation === "init") {
+    process.stdout.write(identity(fs.statSync(".")));
+  } else if (operation === "cleanup") {
+    for (const entry of fs.readdirSync(".")) fs.unlinkSync(entry);
+    enter(workspace);
+    if (identity(fs.lstatSync(directory)) !== directoryIdentity) throw Error("attachment directory changed");
+    fs.rmdirSync(directory);
+  } else {
+    if (operation !== "write" || !name || name === "." || name === ".." || /[\\/\x00]/.test(name)) throw Error("invalid attachment name");
+    const offset = Number(offsetText), size = Number(sizeText);
+    if (!Number.isSafeInteger(offset) || !Number.isSafeInteger(size) || offset < 0 || size < offset || size > ${MAX_PAYLOAD_BYTES}) throw Error("invalid attachment size");
+    const encoded = fs.readFileSync(0, "utf8");
+    if (encoded.length > ${Math.ceil(ATTACHMENT_CHUNK_BYTES / 3) * 4}) throw Error("attachment chunk exceeds limit");
+    const bytes = Buffer.from(encoded, "base64");
+    if (bytes.toString("base64") !== encoded || offset + bytes.length > size) throw Error("invalid attachment chunk");
+    const partial = "." + name + ".part";
+    if (offset > 0 && fs.lstatSync(partial).isSymbolicLink()) throw Error("attachment file changed");
+    const flags = fs.constants.O_RDWR | (fs.constants.O_NOFOLLOW || 0) | (offset === 0 ? fs.constants.O_CREAT | fs.constants.O_EXCL : 0);
+    const fd = fs.openSync(partial, flags, 0o600);
+    try {
+      const before = fs.fstatSync(fd);
+      if (!before.isFile() || before.nlink !== 1 || before.size !== offset || (offset > 0 && identity(before) !== fileIdentity)) throw Error("attachment file changed");
+      let written = 0;
+      while (written < bytes.length) {
+        const count = fs.writeSync(fd, bytes, written, bytes.length - written, offset + written);
+        if (!count) throw Error("attachment write made no progress");
+        written += count;
+      }
+      if (offset + bytes.length === size) {
+        if (fs.fstatSync(fd).size !== size || crypto.createHash("sha256").update(fs.readFileSync(fd)).digest("hex") !== hash) throw Error("attachment checksum mismatch");
+        fs.linkSync(partial, name);
+        const published = fs.lstatSync(name);
+        if (!published.isFile() || published.isSymbolicLink() || identity(published) !== identity(before)) throw Error("attachment publication changed");
+        fs.unlinkSync(partial);
+      }
+      process.stdout.write(identity(before));
+    } finally { fs.closeSync(fd); }
+  }
+} catch (error) {
+  process.stderr.write(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+}
+`;
+
+/** Transfers only admitted managed originals; workspace synchronization owns everything else. */
+export async function prepareWorkerTurnAttachments(params: {
+  turn: Pick<
+    SessionPlacementTurnParams,
+    "abortSignal" | "config" | "media" | "timeoutMs" | "userTurnTranscriptRecorder"
+  >;
+  tunnel: Pick<WorkerWorkspaceTunnelHandle, "runWorkspaceCommand">;
+  remoteWorkspaceDir: string;
+  assertCurrent: () => void;
+}): Promise<string | undefined> {
+  const { turn, tunnel, assertCurrent } = params;
+  const check = () => {
+    turn.abortSignal?.throwIfAborted();
+    assertCurrent();
+  };
+  check();
+  const recorder = turn.userTurnTranscriptRecorder;
+  const heldMessage = recorder?.message;
+  const heldFacts = heldMessage && readPersistedMediaFacts(heldMessage);
+  const message = heldFacts ? heldMessage : ((await recorder?.resolveMessage()) ?? heldMessage);
+  check();
+  // The recorder retains originals for inline images and facts already staged
+  // locally. Runtime media alone omits those images or points at a host copy.
+  const facts = (message ? readPersistedMediaFacts(message) : undefined) ?? turn.media ?? [];
+  const files: Array<{ name: string; buffer: Buffer }> = [];
+  const seen = new Set<string>();
+  let remainingBytes = MAX_PAYLOAD_BYTES;
+  const maxBytes = resolveChatAttachmentMaxBytes(turn.config ?? {});
+  for (const fact of facts) {
+    let reference: Awaited<ReturnType<typeof resolveInboundMediaReference>> = null;
+    for (const source of [fact.url, fact.path]) {
+      if (!source) {
+        continue;
+      }
+      reference = await resolveInboundMediaReference(source);
+      check();
+      if (reference) {
+        break;
+      }
+    }
+    if (!reference) {
+      if (
+        [fact.path, fact.url].some((source) => source && !isPassThroughRemoteMediaSource(source))
+      ) {
+        throw new Error(
+          "Cloud attachment original is unavailable in managed media storage; attach the file again and retry.",
+        );
+      }
+      continue;
+    }
+    if (seen.has(reference.id)) {
+      continue;
+    }
+    seen.add(reference.id);
+    if (files.length >= MAX_TURN_ATTACHMENTS) {
+      throw new Error(
+        `Cloud turns support at most ${MAX_TURN_ATTACHMENTS} original attachments; send fewer files and retry.`,
+      );
+    }
+    const saved = await readMediaBuffer(
+      reference.id,
+      "inbound",
+      Math.min(maxBytes, remainingBytes),
+    );
+    check();
+    remainingBytes -= saved.buffer.length;
+    const parsed = path.parse(
+      sanitizeUntrustedFileName(fact.fileName ?? reference.id, "attachment"),
+    );
+    const name = `${files.length + 1}-${truncateUtf16Safe(parsed.name, 48)}${truncateUtf16Safe(parsed.ext, 12)}`;
+    files.push({ name, buffer: saved.buffer });
+  }
+  if (!files.length) {
+    return undefined;
+  }
+  const directory = `openclaw-inbound-${randomUUID()}`;
+  const deadline = Date.now() + turn.timeoutMs;
+  const execute = async (args: string[], input?: string, cleanup = false): Promise<string> => {
+    const assertDispatchCurrent = cleanup ? assertCurrent : check;
+    assertDispatchCurrent();
+    const timeoutMs = cleanup ? 5_000 : Math.min(60_000, Math.max(1, deadline - Date.now()));
+    if (!cleanup && Date.now() >= deadline) {
+      throw new Error("Cloud attachment transfer timed out; retry this turn.");
+    }
+    const result = await tunnel.runWorkspaceCommand({
+      argv: ["node", "-e", STAGE_ATTACHMENT_SCRIPT, params.remoteWorkspaceDir, directory, ...args],
+      ...(input === undefined ? {} : { input }),
+      transportRetry: "never",
+      assertCurrent: assertDispatchCurrent,
+      timeoutMs,
+      ...(!cleanup && turn.abortSignal ? { signal: turn.abortSignal } : {}),
+    });
+    assertDispatchCurrent();
+    if (result.termination !== "exit" || result.code !== 0) {
+      throw new Error(
+        `Cloud attachment transfer failed: ${truncateUtf16Safe(result.stderr.trim() || "remote write failed", 512)}. Retry this turn.`,
+      );
+    }
+    return result.stdout.trim();
+  };
+  let directoryIdentity: string | undefined;
+  try {
+    directoryIdentity = await execute(["init"]);
+    if (!/^\d+:\d+$/.test(directoryIdentity)) {
+      throw new Error("Cloud attachment transfer returned an invalid directory identity.");
+    }
+    for (const file of files) {
+      const hash = createHash("sha256").update(file.buffer).digest("hex");
+      let fileIdentity = "new";
+      for (
+        let offset = 0;
+        offset === 0 || offset < file.buffer.length;
+        offset += ATTACHMENT_CHUNK_BYTES
+      ) {
+        fileIdentity = await execute(
+          [
+            "write",
+            directoryIdentity,
+            file.name,
+            String(offset),
+            String(file.buffer.length),
+            hash,
+            fileIdentity,
+          ],
+          file.buffer.subarray(offset, offset + ATTACHMENT_CHUNK_BYTES).toString("base64"),
+        );
+        if (!/^\d+:\d+$/.test(fileIdentity)) {
+          throw new Error("Cloud attachment transfer returned an invalid file identity.");
+        }
+      }
+    }
+  } catch (error) {
+    if (directoryIdentity) {
+      await execute(["cleanup", directoryIdentity], undefined, true).catch(() => undefined);
+    }
+    throw error;
+  }
+  // Only a fixed template and generated UUID enter model context, well below 2 KiB.
+  return `Current attachment originals are available in this execution workspace at ${JSON.stringify(directory + "/")}. List that directory to find the attached files by name; use these copies when earlier attachment markers refer to Gateway-local storage.`;
+}

--- a/src/gateway/worker-environments/worker-turn-attachments.ts
+++ b/src/gateway/worker-environments/worker-turn-attachments.ts
@@ -10,7 +10,10 @@ import { readMediaBuffer } from "../../media/store.js";
 import { resolveChatAttachmentMaxBytes } from "../chat-attachment-policy.js";
 import { MAX_PAYLOAD_BYTES } from "../server-constants.js";
 import type { WorkerWorkspaceTunnelHandle } from "./tunnel-contract.js";
-import { WORKER_ATTACHMENT_DIRECTORY_PREFIX } from "./workspace-path-exclusions.js";
+import {
+  WORKER_ATTACHMENT_DIRECTORY_PATTERN,
+  WORKER_ATTACHMENT_DIRECTORY_PREFIX,
+} from "./workspace-path-exclusions.js";
 
 const MAX_TURN_ATTACHMENTS = 16;
 // Base64 expansion stays below the node workspace command's 128 KiB stdin cap.
@@ -30,7 +33,7 @@ function enter(candidate, expected) {
   if (identity(fs.statSync(".")) !== identity(before)) throw Error("attachment directory changed");
 }
 try {
-  if (!/^${WORKER_ATTACHMENT_DIRECTORY_PREFIX}[a-f0-9-]{36}$/.test(directory)) throw Error("invalid attachment directory");
+  if (/^${WORKER_ATTACHMENT_DIRECTORY_PATTERN}$/.exec(directory)?.[0] !== directory) throw Error("invalid attachment directory");
   enter(workspace);
   if (operation === "init") fs.mkdirSync(directory, {mode: 0o700});
   enter(directory, directoryIdentity);

--- a/src/gateway/worker-environments/worker-turn-launcher-remote-handoff.test.ts
+++ b/src/gateway/worker-environments/worker-turn-launcher-remote-handoff.test.ts
@@ -359,6 +359,10 @@ describe("worker turn launcher remote handoff", () => {
       data: "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACXBIWXMAAAsTAAALEwEAmpwYAAAADUlEQVR4nGP4////KwAJ5gPoxLp9owAAAABJRU5ErkJggg==",
       mimeType: "image/png",
     };
+    const inlineImages = [
+      { ...image, sourceIndex: 0 },
+      { ...image, sourceIndex: 2 },
+    ];
     const savedImage = await saveMediaBuffer(
       Buffer.from(image.data, "base64"),
       "image/png",
@@ -498,7 +502,7 @@ describe("worker turn launcher remote handoff", () => {
         },
         toolsAllow: ["browser"],
         suppressNextUserMessagePersistence: true,
-        images: [image, image],
+        images: inlineImages,
         imageOrder: ["inline", "offloaded", "inline"],
         media: [{ path: imagePath, contentType: "image/png", kind: "image" }],
       },
@@ -508,7 +512,7 @@ describe("worker turn launcher remote handoff", () => {
     expect(descriptor?.assignment.prompt).toContain(
       "Inspect this workspace\n\nCurrent attachment originals",
     );
-    expect(descriptor?.assignment).toMatchObject({ images: [image, image, image] });
+    expect(descriptor?.assignment.images).toEqual([image, image, image]);
     const verifiedRuntimeIdentity = await verifyAgentRuntimeIdentityToken(
       descriptor?.assignment.agentRuntimeIdentityToken,
     );

--- a/src/gateway/worker-environments/worker-turn-launcher-remote-handoff.test.ts
+++ b/src/gateway/worker-environments/worker-turn-launcher-remote-handoff.test.ts
@@ -1,3 +1,4 @@
+import { mkdir, realpath } from "node:fs/promises";
 import path from "node:path";
 import { Value } from "typebox/value";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -11,6 +12,7 @@ import {
   type ExecutionIdentityAdmissionWork,
 } from "../../audit/execution-identity-admission.js";
 import { upsertSessionEntryCore } from "../../config/sessions/session-accessor.js";
+import { saveMediaBuffer } from "../../media/store.js";
 import { runCommandWithTimeout, type SpawnResult } from "../../process/exec.js";
 import {
   buildWorkerConnectParams,
@@ -349,7 +351,22 @@ describe("worker turn launcher remote handoff", () => {
   });
 
   it("keeps reset tool pairs valid without replaying the already-persisted current user", async () => {
-    seedActivePlacement();
+    const remote = path.join(await realpath(root), "remote");
+    await mkdir(remote);
+    seedActivePlacement("worker-turn", remote);
+    const image = {
+      type: "image" as const,
+      data: "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACXBIWXMAAAsTAAALEwEAmpwYAAAADUlEQVR4nGP4////KwAJ5gPoxLp9owAAAABJRU5ErkJggg==",
+      mimeType: "image/png",
+    };
+    const savedImage = await saveMediaBuffer(
+      Buffer.from(image.data, "base64"),
+      "image/png",
+      "inbound",
+      5_000,
+      "offloaded.png",
+    );
+    const imagePath = savedImage.path;
     const manager = openSessionManager();
     manager.appendMessage(
       makeAgentAssistantMessage({
@@ -402,7 +419,15 @@ describe("worker turn launcher remote handoff", () => {
         assertActive: vi.fn(async () => {}),
         resume: vi.fn(async () => {}),
       })),
-      runWorkspaceCommand: vi.fn(),
+      runWorkspaceCommand: vi.fn(
+        async (command) =>
+          await runCommandWithTimeout([...command.argv], {
+            cwd: remote,
+            input: command.input,
+            timeoutMs: 5_000,
+            signal: command.signal,
+          }),
+      ),
       launchTurn: vi.fn(async (request): Promise<SpawnResult> => {
         request.onDispatchReady?.();
         descriptor = completeWorkerLaunchDescriptor(structuredClone(request.plan), {
@@ -473,11 +498,17 @@ describe("worker turn launcher remote handoff", () => {
         },
         toolsAllow: ["browser"],
         suppressNextUserMessagePersistence: true,
+        images: [image, image],
+        imageOrder: ["inline", "offloaded", "inline"],
+        media: [{ path: imagePath, contentType: "image/png", kind: "image" }],
       },
       async () => ({ meta: { durationMs: 1 } }),
     );
 
-    expect(descriptor?.assignment.prompt).toBe("Inspect this workspace");
+    expect(descriptor?.assignment.prompt).toContain(
+      "Inspect this workspace\n\nCurrent attachment originals",
+    );
+    expect(descriptor?.assignment).toMatchObject({ images: [image, image, image] });
     const verifiedRuntimeIdentity = await verifyAgentRuntimeIdentityToken(
       descriptor?.assignment.agentRuntimeIdentityToken,
     );

--- a/src/gateway/worker-environments/worker-turn-launcher.test-support.ts
+++ b/src/gateway/worker-environments/worker-turn-launcher.test-support.ts
@@ -124,6 +124,7 @@ export function openSessionManager(): SessionManager {
 
 export function seedActivePlacement(
   executionMode: "worker-turn" | "remote-exec" = "worker-turn",
+  remoteWorkspaceDir = "/worker/workspace",
 ): void {
   let placement = placements.startDispatch({
     sessionId: SESSION_ID,
@@ -151,7 +152,7 @@ export function seedActivePlacement(
     to: "starting",
     expectedGeneration: placement.generation,
     patch: {
-      remoteWorkspaceDir: "/worker/workspace",
+      remoteWorkspaceDir,
       workspaceBaseManifestRef: MANIFEST_REF,
     },
   });

--- a/src/gateway/worker-environments/worker-turn-launcher.ts
+++ b/src/gateway/worker-environments/worker-turn-launcher.ts
@@ -38,6 +38,7 @@ import {
   resolvePlacementIdentity,
   waitForTurnOperation,
 } from "./worker-turn-admission.js";
+import { prepareWorkerTurnAttachments } from "./worker-turn-attachments.js";
 import {
   failHandedOffTurn,
   WorkerTurnExecutionError,
@@ -52,6 +53,7 @@ import {
   fitLaunchDescriptorWithRuntimeIdentity,
   parseRuntimeResult,
   prepareWorkerAgentRuntimeIdentity,
+  prepareWorkerTurnImages,
   windowInitialMessages,
 } from "./worker-turn-payload.js";
 import { resolveWorkerTurnTranscriptTarget } from "./worker-turn-transcript-target.js";
@@ -183,6 +185,8 @@ async function executeWorkerTurn(params: {
     model: modelRef.model,
   });
 
+  const images = await prepareWorkerTurnImages(turn, placement.agentId, params.localWorkspaceDir);
+
   const credential = await params.environments.acquireTurnCredential(params.turnClaim);
   const tunnel = await waitForTurnOperation({
     operation: params.environments.startTunnel({
@@ -192,6 +196,17 @@ async function executeWorkerTurn(params: {
     ...(turn.abortSignal ? { signal: turn.abortSignal } : {}),
     timeoutMs: turn.timeoutMs,
   });
+  const attachmentNote = await prepareWorkerTurnAttachments({
+    turn,
+    tunnel,
+    remoteWorkspaceDir: placement.remoteWorkspaceDir,
+    assertCurrent: () => {
+      if (!params.placements.validateTurnClaim(params.turnClaim)) {
+        throw new Error("Cloud attachment transfer lost its turn claim");
+      }
+    },
+  });
+  const prompt = attachmentNote ? `${turn.prompt}\n\n${attachmentNote}` : turn.prompt;
   const portalAvailable =
     Boolean(environment.nodeDeviceId) &&
     environment.sshEndpoint === null &&
@@ -238,7 +253,8 @@ async function executeWorkerTurn(params: {
           agentRuntimeIdentityToken,
           runId: turn.runId,
           turnId: randomUUID(),
-          prompt: turn.prompt,
+          prompt,
+          ...(images.length > 0 ? { images } : {}),
           suppressPromptTranscript: true,
           workspaceDir: placement.remoteWorkspaceDir,
           ...(turn.permissionMode

--- a/src/gateway/worker-environments/worker-turn-launcher.ts
+++ b/src/gateway/worker-environments/worker-turn-launcher.ts
@@ -5,7 +5,6 @@ import type { SandboxContext } from "../../agents/sandbox/types.js";
 import type {
   LocalTurnPlacementClaim,
   SessionPlacementAdmissionProvider,
-  SessionPlacementTurnParams,
 } from "../../agents/session-placement-admission.js";
 import { convertToLlm } from "../../agents/sessions/messages.js";
 import { SessionManager } from "../../agents/sessions/session-manager.js";
@@ -84,20 +83,12 @@ type WorkerTurnLauncherOptions = {
   publishAcceptedWorkspace?: (claim: WorkerSessionTurnClaim) => Promise<void>;
 };
 
-async function executeWorkerTurn(params: {
-  environments: WorkerTurnEnvironmentService;
-  onHandoff: () => void;
-  onTerminal: () => void;
-  placement: ActiveWorkerPlacement;
-  placements: WorkerSessionPlacementStore;
-  reconcileActivePlacement: (environmentId: string) => Promise<void>;
-  workspaceOperations: WorkerWorkspaceOperationCoordinator;
-  turn: SessionPlacementTurnParams;
-  turnClaim: WorkerSessionTurnClaim;
-  localWorkspaceDir: string;
-  prepareAcceptedWorkspacePublication?: (claim: WorkerSessionTurnClaim) => Promise<void>;
-  publishAcceptedWorkspace?: (claim: WorkerSessionTurnClaim) => Promise<void>;
-}) {
+async function executeWorkerTurn(
+  params: Omit<Parameters<typeof executeRemoteExecTurn>[0], "environments" | "runLocal"> & {
+    environments: WorkerTurnEnvironmentService;
+    onTerminal: () => void;
+  },
+) {
   const { placement, turn } = params;
   const modelRef = assertSupportedTurn(turn);
   const environment = params.environments.get(placement.environmentId);
@@ -615,7 +606,6 @@ export function createWorkerSessionTurnPlacementProvider(options: WorkerTurnLaun
           },
           placement,
           placements: options.placements,
-          reconcileActivePlacement: options.reconcileActivePlacement,
           localWorkspaceDir,
           ...(options.prepareAcceptedWorkspacePublication
             ? { prepareAcceptedWorkspacePublication: options.prepareAcceptedWorkspacePublication }

--- a/src/gateway/worker-environments/worker-turn-payload.ts
+++ b/src/gateway/worker-environments/worker-turn-payload.ts
@@ -33,6 +33,7 @@ import {
   type WorkerReplayMessageWindowUnavailable,
 } from "../../worker/replay-message-window.js";
 import {
+  cloneImageContent,
   toWorkerTranscriptMessage,
   type WorkerProviderReplayUnavailable,
 } from "../../worker/transcript-message.js";
@@ -76,7 +77,8 @@ export async function prepareWorkerTurnImages(
       `Cloud worker could not load ${result.failedMediaCount} image attachment(s). Resend the attachments and retry.`,
     );
   }
-  return result.images;
+  // Ingress metadata such as sourceIndex stays on the Gateway, outside the closed wire shape.
+  return result.images.map(cloneImageContent);
 }
 
 type WorkerInitialMessagePlan =

--- a/src/gateway/worker-environments/worker-turn-payload.ts
+++ b/src/gateway/worker-environments/worker-turn-payload.ts
@@ -24,6 +24,7 @@ import { resolveDefaultModelForAgent } from "../../agents/model-selection-config
 import type { AgentMessage } from "../../agents/runtime/index.js";
 import type { SessionPlacementTurnParams } from "../../agents/session-placement-admission.js";
 import { resolveEffectiveAgentRuntime } from "../../agents/thinking-runtime.js";
+import { resolveEffectiveToolFsWorkspaceOnly } from "../../agents/tool-fs-policy.js";
 import { hasNonzeroUsage, normalizeUsage } from "../../agents/usage.js";
 import { emitTrustedDiagnosticEvent, isDiagnosticsEnabled } from "../../infra/diagnostic-events.js";
 import type { WorkerLaunchPlan } from "../../worker/launch-descriptor.js";
@@ -48,6 +49,35 @@ import {
   bindWorkerTurnAdmissionContinuation,
   bindWorkerTurnExecutionIdentity,
 } from "./placement-turn-claim-events.js";
+import { WorkerTurnExecutionError } from "./worker-turn-failure.js";
+
+export async function prepareWorkerTurnImages(
+  turn: SessionPlacementTurnParams,
+  agentId: string,
+  workspaceDir: string,
+) {
+  // Managed image references belong to the Gateway filesystem. Rendered PDF
+  // pages use the same ordered image input before crossing the worker boundary.
+  const { prepareEmbeddedAttemptPromptExecution } =
+    await import("../../agents/embedded-agent-runner/run/prompt-image-preparation.js");
+  const result = await prepareEmbeddedAttemptPromptExecution({
+    attempt: {
+      ...turn,
+      model: { input: turn.modelHasVision === false ? ["text"] : ["text", "image"] },
+    },
+    mediaOwnerAgentId: agentId,
+    effectiveFsWorkspaceOnly: resolveEffectiveToolFsWorkspaceOnly({ cfg: turn.config, agentId }),
+    effectiveWorkspace: workspaceDir,
+    prompt: "",
+    skipPromptSubmission: false,
+  });
+  if (result.failedMediaCount > 0) {
+    throw new WorkerTurnExecutionError(
+      `Cloud worker could not load ${result.failedMediaCount} image attachment(s). Resend the attachments and retry.`,
+    );
+  }
+  return result.images;
+}
 
 type WorkerInitialMessagePlan =
   | { kind: "complete"; messages: WorkerTranscriptMessage[] }
@@ -321,9 +351,6 @@ export function assertSupportedTurn(params: SessionPlacementTurnParams): {
   provider: string;
   model: string;
 } {
-  if (params.images?.length || params.imageOrder?.length) {
-    throw new Error("Cloud worker turns do not yet support current-turn image input");
-  }
   if (params.clientTools?.length) {
     throw new Error("Cloud worker turns do not support client-provided tools");
   }

--- a/src/gateway/worker-environments/workspace-mutation-remote-script.ts
+++ b/src/gateway/worker-environments/workspace-mutation-remote-script.ts
@@ -1,10 +1,5 @@
 import { REMOTE_WORKSPACE_MUTATION_LOCK_JS } from "./workspace-mutation-lock-remote-script.js";
-import {
-  DERIVED_WORKSPACE_DIRECTORY_NAMES,
-  DERIVED_WORKSPACE_FILE_NAMES,
-  DERIVED_WORKSPACE_FILE_SUFFIXES,
-  isDerivedWorkspacePath,
-} from "./workspace-path-exclusions.js";
+import { WORKSPACE_PATH_EXCLUSIONS_JS } from "./workspace-path-exclusions.js";
 
 export const REMOTE_WORKSPACE_MUTATION_CONTEXT_JS = String.raw`const mutationActions = [
   "begin", "apply", "rollback", "recover", "commit", "settle", "receiver", "reset",
@@ -152,10 +147,7 @@ const action = "reset";
 ${REMOTE_WORKSPACE_MUTATION_CONTEXT_JS}
 const lockOwnerPid = process.pid;
 ${REMOTE_WORKSPACE_MUTATION_LOCK_JS}
-const DERIVED_WORKSPACE_DIRECTORY_NAMES = ${JSON.stringify(DERIVED_WORKSPACE_DIRECTORY_NAMES)};
-const DERIVED_WORKSPACE_FILE_NAMES = ${JSON.stringify(DERIVED_WORKSPACE_FILE_NAMES)};
-const DERIVED_WORKSPACE_FILE_SUFFIXES = ${JSON.stringify(DERIVED_WORKSPACE_FILE_SUFFIXES)};
-const isDerivedWorkspacePath = ${isDerivedWorkspacePath.toString()};
+${WORKSPACE_PATH_EXCLUSIONS_JS}
 function clean(directory, relativeDirectory) {
   const originalMode = fs.lstatSync(directory).mode & 0o7777;
   fs.chmodSync(directory, originalMode | 0o700);

--- a/src/gateway/worker-environments/workspace-path-exclusions.ts
+++ b/src/gateway/worker-environments/workspace-path-exclusions.ts
@@ -1,4 +1,4 @@
-export const DERIVED_WORKSPACE_DIRECTORY_NAMES = [
+const DERIVED_WORKSPACE_DIRECTORY_NAMES = [
   "__pycache__",
   ".pytest_cache",
   ".mypy_cache",
@@ -6,15 +6,17 @@ export const DERIVED_WORKSPACE_DIRECTORY_NAMES = [
   "node_modules",
 ] as const;
 
-export const DERIVED_WORKSPACE_FILE_NAMES = [".DS_Store"] as const;
-export const DERIVED_WORKSPACE_FILE_SUFFIXES = [".pyc", ".pyo"] as const;
+const DERIVED_WORKSPACE_FILE_NAMES = [".DS_Store"] as const;
+const DERIVED_WORKSPACE_FILE_SUFFIXES = [".pyc", ".pyo"] as const;
+export const WORKER_ATTACHMENT_DIRECTORY_PREFIX = "openclaw-inbound-";
 
-// Derived caches must never fence workspace reconciliation. Keep every sync,
-// manifest, divergence, apply, and recovery path on this single predicate.
+// Derived caches and runtime attachment copies are not workspace edits. Keep
+// sync, manifest, divergence, apply, and recovery on this single predicate.
 export function isDerivedWorkspacePath(relativePath: string): boolean {
   const segments = relativePath.split("/");
   return segments.some(
     (segment) =>
+      segment.startsWith(WORKER_ATTACHMENT_DIRECTORY_PREFIX) ||
       (DERIVED_WORKSPACE_DIRECTORY_NAMES as readonly string[]).includes(segment) ||
       (DERIVED_WORKSPACE_FILE_NAMES as readonly string[]).includes(segment) ||
       DERIVED_WORKSPACE_FILE_SUFFIXES.some((suffix) => segment.endsWith(suffix)),
@@ -25,4 +27,12 @@ export const DERIVED_WORKSPACE_RSYNC_EXCLUDES = [
   ...DERIVED_WORKSPACE_DIRECTORY_NAMES,
   ...DERIVED_WORKSPACE_FILE_NAMES,
   ...DERIVED_WORKSPACE_FILE_SUFFIXES.map((suffix) => `*${suffix}`),
+  `${WORKER_ATTACHMENT_DIRECTORY_PREFIX}*`,
 ] as const;
+
+export const WORKSPACE_PATH_EXCLUSIONS_JS = `
+const DERIVED_WORKSPACE_DIRECTORY_NAMES = ${JSON.stringify(DERIVED_WORKSPACE_DIRECTORY_NAMES)};
+const DERIVED_WORKSPACE_FILE_NAMES = ${JSON.stringify(DERIVED_WORKSPACE_FILE_NAMES)};
+const DERIVED_WORKSPACE_FILE_SUFFIXES = ${JSON.stringify(DERIVED_WORKSPACE_FILE_SUFFIXES)};
+const WORKER_ATTACHMENT_DIRECTORY_PREFIX = ${JSON.stringify(WORKER_ATTACHMENT_DIRECTORY_PREFIX)};
+const isDerivedWorkspacePath = ${isDerivedWorkspacePath.toString()};`;

--- a/src/gateway/worker-environments/workspace-path-exclusions.ts
+++ b/src/gateway/worker-environments/workspace-path-exclusions.ts
@@ -9,14 +9,28 @@ const DERIVED_WORKSPACE_DIRECTORY_NAMES = [
 const DERIVED_WORKSPACE_FILE_NAMES = [".DS_Store"] as const;
 const DERIVED_WORKSPACE_FILE_SUFFIXES = [".pyc", ".pyo"] as const;
 export const WORKER_ATTACHMENT_DIRECTORY_PREFIX = "openclaw-inbound-";
+const UUID_HEX = "[0-9a-f]";
+// randomUUID creates lowercase UUIDv4 names. This exact character-class pattern
+// has the same meaning in a regular expression and an rsync exclusion glob.
+export const WORKER_ATTACHMENT_DIRECTORY_PATTERN =
+  WORKER_ATTACHMENT_DIRECTORY_PREFIX +
+  [
+    UUID_HEX.repeat(8),
+    UUID_HEX.repeat(4),
+    `4${UUID_HEX.repeat(3)}`,
+    `[89ab]${UUID_HEX.repeat(3)}`,
+    UUID_HEX.repeat(12),
+  ].join("-");
+const WORKER_ATTACHMENT_DIRECTORY_RE = new RegExp(`^${WORKER_ATTACHMENT_DIRECTORY_PATTERN}$`);
 
 // Derived caches and runtime attachment copies are not workspace edits. Keep
 // sync, manifest, divergence, apply, and recovery on this single predicate.
 export function isDerivedWorkspacePath(relativePath: string): boolean {
   const segments = relativePath.split("/");
+  // "$" can match before a final newline; require the entire path segment.
   return segments.some(
     (segment) =>
-      segment.startsWith(WORKER_ATTACHMENT_DIRECTORY_PREFIX) ||
+      WORKER_ATTACHMENT_DIRECTORY_RE.exec(segment)?.[0] === segment ||
       (DERIVED_WORKSPACE_DIRECTORY_NAMES as readonly string[]).includes(segment) ||
       (DERIVED_WORKSPACE_FILE_NAMES as readonly string[]).includes(segment) ||
       DERIVED_WORKSPACE_FILE_SUFFIXES.some((suffix) => segment.endsWith(suffix)),
@@ -27,12 +41,12 @@ export const DERIVED_WORKSPACE_RSYNC_EXCLUDES = [
   ...DERIVED_WORKSPACE_DIRECTORY_NAMES,
   ...DERIVED_WORKSPACE_FILE_NAMES,
   ...DERIVED_WORKSPACE_FILE_SUFFIXES.map((suffix) => `*${suffix}`),
-  `${WORKER_ATTACHMENT_DIRECTORY_PREFIX}*`,
+  WORKER_ATTACHMENT_DIRECTORY_PATTERN,
 ] as const;
 
 export const WORKSPACE_PATH_EXCLUSIONS_JS = `
 const DERIVED_WORKSPACE_DIRECTORY_NAMES = ${JSON.stringify(DERIVED_WORKSPACE_DIRECTORY_NAMES)};
 const DERIVED_WORKSPACE_FILE_NAMES = ${JSON.stringify(DERIVED_WORKSPACE_FILE_NAMES)};
 const DERIVED_WORKSPACE_FILE_SUFFIXES = ${JSON.stringify(DERIVED_WORKSPACE_FILE_SUFFIXES)};
-const WORKER_ATTACHMENT_DIRECTORY_PREFIX = ${JSON.stringify(WORKER_ATTACHMENT_DIRECTORY_PREFIX)};
+const WORKER_ATTACHMENT_DIRECTORY_RE = ${WORKER_ATTACHMENT_DIRECTORY_RE.toString()};
 const isDerivedWorkspacePath = ${isDerivedWorkspacePath.toString()};`;

--- a/src/gateway/worker-environments/workspace-result-finalize.ts
+++ b/src/gateway/worker-environments/workspace-result-finalize.ts
@@ -16,6 +16,7 @@ import type {
 import type { WorkerEnvironmentService } from "./service.js";
 import { WorkerTunnelOwnerDisconnectedError, type WorkerTunnelHandle } from "./tunnel-contract.js";
 import { latestDurableWorkspaceConflict, waitForTurnOperation } from "./worker-turn-admission.js";
+import { prepareWorkerTurnAttachments } from "./worker-turn-attachments.js";
 import { resolveWorkerTurnTranscriptTarget } from "./worker-turn-transcript-target.js";
 import {
   formatWorkspaceConflictSummary,
@@ -315,12 +316,28 @@ export async function executeRemoteExecTurn(params: {
     timeoutMs: params.turn.timeoutMs,
   });
   const transcriptTarget = resolveWorkerTurnTranscriptTarget(params.turn);
+  const attachmentNote = await prepareWorkerTurnAttachments({
+    turn: params.turn,
+    tunnel,
+    remoteWorkspaceDir: params.placement.remoteWorkspaceDir,
+    assertCurrent: () => {
+      if (!params.placements.validateTurnClaim(params.turnClaim)) {
+        throw new Error("Cloud attachment transfer lost its turn claim");
+      }
+    },
+  });
   params.placements.markWorkspaceResultPending(params.turnClaim);
   params.onHandoff();
   let result: EmbeddedAgentRunResult | undefined;
   let executionError: unknown;
   let executionActive = true;
+  const originalPrompt = params.turn.prompt;
+  const originalTranscriptPrompt = params.turn.transcriptPrompt;
   try {
+    if (attachmentNote) {
+      params.turn.transcriptPrompt ??= originalPrompt;
+      params.turn.prompt = `${originalPrompt}\n\n${attachmentNote}`;
+    }
     result = await withPluginRuntimeGatewayRequestScope(
       {
         isWebchatConnect: () => false,
@@ -365,6 +382,8 @@ export async function executeRemoteExecTurn(params: {
     executionError = error;
   } finally {
     executionActive = false;
+    params.turn.prompt = originalPrompt;
+    params.turn.transcriptPrompt = originalTranscriptPrompt;
   }
   const workspaceConflict = await reconcileWorkspaceAfterTurn({
     placement: params.placement,

--- a/src/gateway/worker-environments/workspace-sync-inventory.test.ts
+++ b/src/gateway/worker-environments/workspace-sync-inventory.test.ts
@@ -216,8 +216,13 @@ describe("runWorkspaceInventoryCommandToFile", () => {
 
   it("omits derived artifacts from outbound Git file lists", async () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-workspace-files-"));
-    const files = [
+    const retainedFiles = [
       "src/keep.ts",
+      "openclaw-inbound-project/report.txt",
+      "nested/openclaw-inbound-12345678-1234-4234-8234-123456789ab-/report.txt",
+    ];
+    const files = [
+      ...retainedFiles,
       "__pycache__/fizzbuzz.cpython-314.pyc",
       "generated.pyc",
       "generated.pyo",
@@ -228,8 +233,8 @@ describe("runWorkspaceInventoryCommandToFile", () => {
       ".ruff_cache/state",
       "node_modules/pkg/index.js",
       ".DS_Store",
-      "openclaw-inbound-12345678-1234-1234-1234-123456789abc/report.pdf",
-      "nested/openclaw-inbound-12345678-1234-1234-1234-123456789abc/photo.png",
+      "openclaw-inbound-12345678-1234-4234-8234-123456789abc/report.pdf",
+      "nested/openclaw-inbound-12345678-1234-4234-8234-123456789abc/photo.png",
     ];
     const temporaryDirectory = path.join(root, "..", `${path.basename(root)}-transfer`);
     const initOutputPath = path.join(root, "..", `${path.basename(root)}-git-init-output`);
@@ -254,9 +259,9 @@ describe("runWorkspaceInventoryCommandToFile", () => {
         timeoutMs: 10_000,
       });
 
-      expect((await fs.readFile(outputPath, "utf8")).split("\0").filter(Boolean)).toEqual([
-        "src/keep.ts",
-      ]);
+      expect((await fs.readFile(outputPath, "utf8")).split("\0").filter(Boolean)).toEqual(
+        retainedFiles.toSorted(),
+      );
     } finally {
       await Promise.all([
         fs.rm(root, { recursive: true, force: true }),

--- a/src/gateway/worker-environments/workspace-sync-inventory.test.ts
+++ b/src/gateway/worker-environments/workspace-sync-inventory.test.ts
@@ -228,6 +228,8 @@ describe("runWorkspaceInventoryCommandToFile", () => {
       ".ruff_cache/state",
       "node_modules/pkg/index.js",
       ".DS_Store",
+      "openclaw-inbound-12345678-1234-1234-1234-123456789abc/report.pdf",
+      "nested/openclaw-inbound-12345678-1234-1234-1234-123456789abc/photo.png",
     ];
     const temporaryDirectory = path.join(root, "..", `${path.basename(root)}-transfer`);
     const initOutputPath = path.join(root, "..", `${path.basename(root)}-git-init-output`);

--- a/src/gateway/worker-environments/workspace-sync-manifest.test.ts
+++ b/src/gateway/worker-environments/workspace-sync-manifest.test.ts
@@ -659,8 +659,13 @@ process.kill = function(pid, signal) {
     const root = tempDirs.make("openclaw-manifest-derived-test-");
     const home = path.join(root, "home");
     const workspace = path.join(root, "workspace");
-    const files = [
+    const retainedFiles = [
       "keep.ts",
+      "openclaw-inbound-project/report.txt",
+      "nested/openclaw-inbound-12345678-1234-4234-8234-123456789ab-/report.txt",
+    ];
+    const files = [
+      ...retainedFiles,
       "__pycache__/fizzbuzz.cpython-314.pyc",
       "generated.pyc",
       "generated.pyo",
@@ -671,8 +676,8 @@ process.kill = function(pid, signal) {
       ".ruff_cache/state",
       "node_modules/pkg/index.js",
       ".DS_Store",
-      "openclaw-inbound-12345678-1234-1234-1234-123456789abc/report.pdf",
-      "nested/openclaw-inbound-12345678-1234-1234-1234-123456789abc/photo.png",
+      "openclaw-inbound-12345678-1234-4234-8234-123456789abc/report.pdf",
+      "nested/openclaw-inbound-12345678-1234-4234-8234-123456789abc/photo.png",
     ];
     await Promise.all([fs.mkdir(home), fs.mkdir(workspace)]);
     await Promise.all(
@@ -692,8 +697,10 @@ process.kill = function(pid, signal) {
       await fs.readFile(path.join(home, ".openclaw-worker", "manifests", `${digest}.json`), "utf8"),
     ) as { entries: Array<{ path: string }> };
     const manifestPaths = manifest.entries.map((entry) => entry.path);
-    expect(manifestPaths).toContain("keep.ts");
-    for (const excluded of files.slice(1)) {
+    for (const retained of retainedFiles) {
+      expect(manifestPaths).toContain(retained);
+    }
+    for (const excluded of files.slice(retainedFiles.length)) {
       expect(manifestPaths).not.toContain(excluded);
     }
   });

--- a/src/gateway/worker-environments/workspace-sync-manifest.test.ts
+++ b/src/gateway/worker-environments/workspace-sync-manifest.test.ts
@@ -671,6 +671,8 @@ process.kill = function(pid, signal) {
       ".ruff_cache/state",
       "node_modules/pkg/index.js",
       ".DS_Store",
+      "openclaw-inbound-12345678-1234-1234-1234-123456789abc/report.pdf",
+      "nested/openclaw-inbound-12345678-1234-1234-1234-123456789abc/photo.png",
     ];
     await Promise.all([fs.mkdir(home), fs.mkdir(workspace)]);
     await Promise.all(

--- a/src/gateway/worker-environments/workspace-sync-scripts.ts
+++ b/src/gateway/worker-environments/workspace-sync-scripts.ts
@@ -11,12 +11,7 @@ import {
   REMOTE_WORKSPACE_MANIFEST_REGISTRY_JS,
 } from "./workspace-manifest-remote-script.js";
 import { MAX_RECONCILIATION_ENTRIES } from "./workspace-manifest.js";
-import {
-  DERIVED_WORKSPACE_DIRECTORY_NAMES,
-  DERIVED_WORKSPACE_FILE_NAMES,
-  DERIVED_WORKSPACE_FILE_SUFFIXES,
-  isDerivedWorkspacePath,
-} from "./workspace-path-exclusions.js";
+import { WORKSPACE_PATH_EXCLUSIONS_JS } from "./workspace-path-exclusions.js";
 export { REMOTE_WORKSPACE_ACCEPTED_TRANSACTION_JS } from "./workspace-accepted-remote-script.js";
 export { REMOTE_GIT_WORKSPACE_RETRY_RESET_JS } from "./workspace-mutation-remote-script.js";
 export { REMOTE_WORKSPACE_SETUP_SCRIPT } from "./workspace-sync-setup-script.js";
@@ -73,10 +68,7 @@ export const REMOTE_WORKSPACE_MANIFEST_JS = String.raw`const crypto = require("n
 const childProcess = require("node:child_process");
 const fs = require("node:fs");
 const path = require("node:path");
-const DERIVED_WORKSPACE_DIRECTORY_NAMES = ${JSON.stringify(DERIVED_WORKSPACE_DIRECTORY_NAMES)};
-const DERIVED_WORKSPACE_FILE_NAMES = ${JSON.stringify(DERIVED_WORKSPACE_FILE_NAMES)};
-const DERIVED_WORKSPACE_FILE_SUFFIXES = ${JSON.stringify(DERIVED_WORKSPACE_FILE_SUFFIXES)};
-const isDerivedWorkspacePath = ${isDerivedWorkspacePath.toString()};
+${WORKSPACE_PATH_EXCLUSIONS_JS}
 const workspaceStatIdentity = ${workspaceStatIdentity.toString()};
 const MAX_RECONCILIATION_ENTRIES = ${MAX_RECONCILIATION_ENTRIES};
 const MAX_HASH_MEMO_BYTES = ${MAX_WORKSPACE_HASH_MEMO_BYTES};

--- a/src/gateway/worker-environments/workspace-sync-tunnel.test.ts
+++ b/src/gateway/worker-environments/workspace-sync-tunnel.test.ts
@@ -339,12 +339,17 @@ describe("worker tunnel manager", () => {
             throw new Error("missing test rsync destination");
           }
           const canonicalReceiverWorkspace = remoteWorkspaceDir.replace(/\/$/u, "");
-          await fs.mkdir(path.join(remoteWorkspaceDir, "node_modules"), { recursive: true });
           receiverWorkspace = canonicalReceiverWorkspace;
-          await fs.writeFile(
-            path.join(remoteWorkspaceDir, "node_modules/worker-cache"),
-            "preserve\n",
-          );
+          for (const directory of [
+            "node_modules",
+            "openclaw-inbound-12345678-1234-1234-1234-123456789abc",
+          ]) {
+            await fs.mkdir(path.join(remoteWorkspaceDir, directory), { recursive: true });
+            await fs.writeFile(
+              path.join(remoteWorkspaceDir, directory, "worker-cache"),
+              "preserve\n",
+            );
+          }
           const transferred = await runCommandWithTimeout(localArgv, options);
           if (transferred.termination !== "exit" || transferred.code !== 0) {
             throw new Error(transferred.stderr || "test rsync transfer failed");
@@ -501,6 +506,15 @@ describe("worker tunnel manager", () => {
         ).rejects.toThrow();
         await expect(
           fs.readFile(path.join(result.remoteWorkspaceDir, "node_modules/worker-cache"), "utf8"),
+        ).resolves.toBe("preserve\n");
+        await expect(
+          fs.readFile(
+            path.join(
+              result.remoteWorkspaceDir,
+              "openclaw-inbound-12345678-1234-1234-1234-123456789abc/worker-cache",
+            ),
+            "utf8",
+          ),
         ).resolves.toBe("preserve\n");
 
         const digest = result.manifestRef.slice("sha256:".length);
@@ -943,10 +957,15 @@ describe("worker tunnel manager", () => {
     // Result staging stores refs in an unborn repository for a plain workspace.
     // A later dispatch must keep using plain-mode sync until the user creates HEAD.
     await git(plainPath, "init");
-    await fs.mkdir(path.join(plainPath, "__pycache__"));
+    const attachmentDirectory = "openclaw-inbound-12345678-1234-1234-1234-123456789abc";
+    await Promise.all([
+      fs.mkdir(path.join(plainPath, "__pycache__")),
+      fs.mkdir(path.join(plainPath, attachmentDirectory)),
+    ]);
     await Promise.all([
       fs.writeFile(path.join(plainPath, "__pycache__/fizzbuzz.pyc"), "derived\n"),
       fs.writeFile(path.join(plainPath, ".mypy_cache"), "derived name file\n"),
+      fs.writeFile(path.join(plainPath, attachmentDirectory, "report.pdf"), "inbound original\n"),
     ]);
     await git(gitPath, "init");
     await git(gitPath, "config", "user.name", "Worker Sync Test");
@@ -976,6 +995,9 @@ describe("worker tunnel manager", () => {
         fs.access(path.join(plain.remoteWorkspaceDir, "__pycache__/fizzbuzz.pyc")),
       ).rejects.toThrow();
       await expect(fs.access(path.join(plain.remoteWorkspaceDir, ".mypy_cache"))).rejects.toThrow();
+      await expect(
+        fs.access(path.join(plain.remoteWorkspaceDir, attachmentDirectory)),
+      ).rejects.toThrow();
 
       await expect(
         handle.syncWorkspace({

--- a/src/gateway/worker-environments/workspace-sync-tunnel.test.ts
+++ b/src/gateway/worker-environments/workspace-sync-tunnel.test.ts
@@ -287,6 +287,18 @@ describe("worker tunnel manager", () => {
         fs.writeFile(path.join(localPath, "current.txt"), "current\n"),
         fs.writeFile(path.join(localPath, "stale.txt"), "remove before fallback\n"),
       ]);
+      const userDirectories = [
+        "openclaw-inbound-project",
+        "openclaw-inbound-12345678-1234-4234-8234-123456789ab-",
+      ];
+      for (const directory of userDirectories) {
+        await fs.mkdir(path.join(localPath, directory));
+        await fs.writeFile(path.join(localPath, directory, "current.txt"), "user project\n");
+        await fs.writeFile(
+          path.join(localPath, directory, "stale.txt"),
+          "remove before fallback\n",
+        );
+      }
       await git(localPath, "init");
       await git(localPath, "config", "user.name", "Worker Sync Test");
       await git(localPath, "config", "user.email", "worker-sync@example.invalid");
@@ -342,7 +354,7 @@ describe("worker tunnel manager", () => {
           receiverWorkspace = canonicalReceiverWorkspace;
           for (const directory of [
             "node_modules",
-            "openclaw-inbound-12345678-1234-1234-1234-123456789abc",
+            "openclaw-inbound-12345678-1234-4234-8234-123456789abc",
           ]) {
             await fs.mkdir(path.join(remoteWorkspaceDir, directory), { recursive: true });
             await fs.writeFile(
@@ -355,6 +367,9 @@ describe("worker tunnel manager", () => {
             throw new Error(transferred.stderr || "test rsync transfer failed");
           }
           await fs.rm(path.join(localPath, "stale.txt"));
+          for (const directory of userDirectories) {
+            await fs.rm(path.join(localPath, directory, "stale.txt"));
+          }
           const remoteRelative = path
             .relative(canonicalRemoteHome, remoteWorkspaceDir)
             .split(path.sep)
@@ -511,11 +526,19 @@ describe("worker tunnel manager", () => {
           fs.readFile(
             path.join(
               result.remoteWorkspaceDir,
-              "openclaw-inbound-12345678-1234-1234-1234-123456789abc/worker-cache",
+              "openclaw-inbound-12345678-1234-4234-8234-123456789abc/worker-cache",
             ),
             "utf8",
           ),
         ).resolves.toBe("preserve\n");
+        for (const directory of userDirectories) {
+          await expect(
+            fs.readFile(path.join(result.remoteWorkspaceDir, directory, "current.txt"), "utf8"),
+          ).resolves.toBe("user project\n");
+          await expect(
+            fs.access(path.join(result.remoteWorkspaceDir, directory, "stale.txt")),
+          ).rejects.toThrow();
+        }
 
         const digest = result.manifestRef.slice("sha256:".length);
         const rawManifest = await fs.readFile(
@@ -523,7 +546,10 @@ describe("worker tunnel manager", () => {
           "utf8",
         );
         const manifest = parseWorkerWorkspaceManifest(rawManifest, result.manifestRef);
-        expect(manifest.entries.map((entry) => entry.path)).toEqual(["current.txt"]);
+        expect(manifest.entries.map((entry) => entry.path)).toEqual([
+          "current.txt",
+          ...userDirectories.map((directory) => `${directory}/current.txt`).toSorted(),
+        ]);
         expect(await git(result.remoteWorkspaceDir, "rev-parse", "HEAD")).toBe(baseCommit);
         await expect(
           fs.access(path.join(result.remoteWorkspaceDir, "stale-late.txt")),
@@ -649,89 +675,51 @@ describe("worker tunnel manager", () => {
     },
   );
 
-  it("does not downgrade an operational HEAD probe failure to plain sync", async () => {
-    const { stdout: setupStdout } = workspaceSetup(
-      "/home/worker",
-      "worker:head-probe-failure",
-      "session:three",
-      3,
-    );
-    const localPath = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-worker-head-probe-"));
-    await fs.mkdir(path.join(localPath, ".git"));
-    const fake = fakeRunner((argv, options) => {
-      if (argv.includes("--show-toplevel")) {
-        return success(`${localPath}\n`);
-      }
-      if (argv.includes("--verify")) {
-        return {
-          ...success("", "HEAD probe timed out"),
-          code: null,
-          killed: true,
-          termination: "timeout",
-        };
-      }
-      if (
-        typeof options.input === "string" &&
-        options.input.includes("unsafe worker workspace directory")
-      ) {
-        return success(setupStdout);
-      }
-      return undefined;
-    });
-    const { handle } = await startConnectedTunnel(fake, "worker:head-probe-failure", 3);
+  it.each([
+    { probe: "HEAD", failedArg: "--verify", message: "HEAD probe timed out" },
+    { probe: "repository-root", failedArg: "--show-toplevel", message: "root probe timed out" },
+  ])(
+    "does not downgrade an operational $probe probe failure to plain sync",
+    async ({ failedArg, message }) => {
+      const { stdout: setupStdout } = workspaceSetup(
+        "/home/worker",
+        "worker:probe-failure",
+        "session:probe",
+        1,
+      );
+      const localPath = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-worker-probe-"));
+      await fs.mkdir(path.join(localPath, ".git"));
+      const fake = fakeRunner((argv, options) => {
+        if (argv.includes(failedArg)) {
+          return { ...success("", message), code: null, killed: true, termination: "timeout" };
+        }
+        if (argv.includes("--show-toplevel")) {
+          return success(`${localPath}\n`);
+        }
+        if (argv.includes("--verify")) {
+          return success("0123456789abcdef0123456789abcdef01234567\n");
+        }
+        if (
+          typeof options.input === "string" &&
+          options.input.includes("unsafe worker workspace directory")
+        ) {
+          return success(setupStdout);
+        }
+        return undefined;
+      });
+      const { handle } = await startConnectedTunnel(fake, "worker:probe-failure", 1);
 
-    try {
-      await expect(
-        handle.syncWorkspace({ localPath, sessionId: "session:three", generation: 3 }),
-      ).rejects.toThrow("Worker workspace sync failed: HEAD probe timed out");
-      expect(fake.runs.some((entry) => entry.argv[0] === "rsync")).toBe(false);
-    } finally {
-      await handle.stop();
-      await fs.rm(localPath, { recursive: true, force: true });
-    }
-  });
-
-  it("does not downgrade an operational repository-root probe failure to plain sync", async () => {
-    const { stdout: setupStdout } = workspaceSetup(
-      "/home/worker",
-      "worker:root-probe-failure",
-      "session:four",
-      4,
-    );
-    const localPath = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-worker-root-probe-"));
-    await fs.mkdir(path.join(localPath, ".git"));
-    const fake = fakeRunner((argv, options) => {
-      if (argv.includes("--show-toplevel")) {
-        return {
-          ...success("", "root probe timed out"),
-          code: null,
-          killed: true,
-          termination: "timeout",
-        };
+      try {
+        await expect(
+          handle.syncWorkspace({ localPath, sessionId: "session:probe", generation: 1 }),
+        ).rejects.toThrow(`Worker workspace sync failed: ${message}`);
+        expect(fake.runs.some((entry) => entry.argv[0] === "rsync")).toBe(false);
+      } finally {
+        await handle.stop();
+        await fs.rm(localPath, { recursive: true, force: true });
       }
-      if (argv.includes("--verify")) {
-        return success("0123456789abcdef0123456789abcdef01234567\n");
-      }
-      if (
-        typeof options.input === "string" &&
-        options.input.includes("unsafe worker workspace directory")
-      ) {
-        return success(setupStdout);
-      }
-      return undefined;
-    });
-    const { handle } = await startConnectedTunnel(fake, "worker:root-probe-failure", 4);
-
-    try {
-      await expect(
-        handle.syncWorkspace({ localPath, sessionId: "session:four", generation: 4 }),
-      ).rejects.toThrow("Worker workspace sync failed: root probe timed out");
-      expect(fake.runs.some((entry) => entry.argv[0] === "rsync")).toBe(false);
-    } finally {
-      await handle.stop();
-      await fs.rm(localPath, { recursive: true, force: true });
-    }
-  });
+    },
+  );
 
   it("materializes a large dirty git workspace as a credential-free commit-capable clone", async () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-worker-git-sync-"));
@@ -957,7 +945,11 @@ describe("worker tunnel manager", () => {
     // Result staging stores refs in an unborn repository for a plain workspace.
     // A later dispatch must keep using plain-mode sync until the user creates HEAD.
     await git(plainPath, "init");
-    const attachmentDirectory = "openclaw-inbound-12345678-1234-1234-1234-123456789abc";
+    const attachmentDirectory = "openclaw-inbound-12345678-1234-4234-8234-123456789abc";
+    const userDirectories = [
+      "openclaw-inbound-project",
+      "openclaw-inbound-12345678-1234-4234-8234-123456789ab-",
+    ];
     await Promise.all([
       fs.mkdir(path.join(plainPath, "__pycache__")),
       fs.mkdir(path.join(plainPath, attachmentDirectory)),
@@ -967,6 +959,10 @@ describe("worker tunnel manager", () => {
       fs.writeFile(path.join(plainPath, ".mypy_cache"), "derived name file\n"),
       fs.writeFile(path.join(plainPath, attachmentDirectory, "report.pdf"), "inbound original\n"),
     ]);
+    for (const directory of userDirectories) {
+      await fs.mkdir(path.join(plainPath, directory));
+      await fs.writeFile(path.join(plainPath, directory, "report.txt"), "user project\n");
+    }
     await git(gitPath, "init");
     await git(gitPath, "config", "user.name", "Worker Sync Test");
     await git(gitPath, "config", "user.email", "worker-sync@example.invalid");
@@ -998,6 +994,11 @@ describe("worker tunnel manager", () => {
       await expect(
         fs.access(path.join(plain.remoteWorkspaceDir, attachmentDirectory)),
       ).rejects.toThrow();
+      for (const directory of userDirectories) {
+        await expect(
+          fs.readFile(path.join(plain.remoteWorkspaceDir, directory, "report.txt"), "utf8"),
+        ).resolves.toBe("user project\n");
+      }
 
       await expect(
         handle.syncWorkspace({

--- a/src/gateway/worker-environments/workspace-sync.test.ts
+++ b/src/gateway/worker-environments/workspace-sync.test.ts
@@ -56,6 +56,38 @@ function createWorkspaceActions(
 }
 
 describe("worker workspace command transport retry", () => {
+  it.each(["never", "idempotent"] as const)(
+    "does not dispatch a %s command after its turn closes during tunnel preparation",
+    async (transportRetry) => {
+      const run = vi.fn(async () => result());
+      let current = true;
+      const actions = createWorkerWorkspaceActions({
+        bundleHash: "a".repeat(64),
+        environmentId: "worker:test",
+        ownerSignal: new AbortController().signal,
+        waitForPrepared: async () => {
+          await Promise.resolve();
+          current = false;
+          return createPreparedSsh();
+        },
+        runner: { run },
+        tasks: new Set(),
+      });
+      await expect(
+        actions.runWorkspaceCommand({
+          argv: ["printf", "stale-attachment"],
+          transportRetry,
+          assertCurrent: () => {
+            if (!current) {
+              throw new Error("turn claim closed");
+            }
+          },
+        }),
+      ).rejects.toThrow("turn claim closed");
+      expect(run).not.toHaveBeenCalled();
+    },
+  );
+
   it("runs never commands once without changing the selected port", async () => {
     // Pin the clock: the impl derives the dispatch timeout from a Date.now()
     // deadline, so real elapsed ms between admission and dispatch would turn

--- a/src/gateway/worker-environments/workspace-sync.ts
+++ b/src/gateway/worker-environments/workspace-sync.ts
@@ -156,6 +156,7 @@ export function createWorkerWorkspaceActions(
       command.signal,
     );
     signal.throwIfAborted();
+    command.assertCurrent?.();
     const remainingCommandTimeoutMs = () => Math.max(0, deadlineMs - Date.now());
     const commandOptions = (remainingTimeoutMs: number): CommandOptions => {
       const base = workerSshCommandOptions({
@@ -180,11 +181,13 @@ export function createWorkerWorkspaceActions(
     return await runWorkerSshCandidates(
       prepared,
       remainingCommandTimeoutMs(),
-      async (port, remainingTimeoutMs) =>
-        await runTask(
+      async (port, remainingTimeoutMs) => {
+        command.assertCurrent?.();
+        return await runTask(
           workerWorkspaceSshArgv(prepared, command.argv, port),
           commandOptions(remainingTimeoutMs),
-        ),
+        );
+      },
     );
   };
 

--- a/src/infra/state-migrations.media-persistence.test.ts
+++ b/src/infra/state-migrations.media-persistence.test.ts
@@ -7,7 +7,6 @@ import {
   readSessionArchiveContentSync,
   SESSION_ARCHIVE_ZSTD_SUFFIX,
 } from "../config/sessions/archive-compression.js";
-import { appendTranscriptEventInTransaction } from "../config/sessions/session-accessor.sqlite-transcript-store.js";
 import { reconcileSessionTranscriptIndexInTransaction } from "../config/sessions/session-transcript-index.js";
 import { registerOpenClawAgentDatabase } from "../state/openclaw-agent-db-registry.js";
 import {
@@ -15,7 +14,6 @@ import {
   listOpenClawRegisteredAgentDatabases,
   OPENCLAW_AGENT_SCHEMA_VERSION,
   openOpenClawAgentDatabase,
-  runOpenClawAgentWriteTransaction,
 } from "../state/openclaw-agent-db.js";
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
 import { requireNodeSqlite } from "./node-sqlite.js";
@@ -198,49 +196,6 @@ afterEach(() => {
 });
 
 describe("legacy media persistence doctor migration", () => {
-  it("canonicalizes assistant media at the generic transcript append owner", async () => {
-    const stateDir = makeTempDir(tempDirs, "media-persistence-append-");
-    const env = { OPENCLAW_STATE_DIR: stateDir };
-    runOpenClawAgentWriteTransaction(
-      (database) => {
-        expect(
-          appendTranscriptEventInTransaction(
-            database,
-            {
-              agentId: "main",
-              env,
-              sessionId: "append-session",
-              sessionKey: "agent:main:append-session",
-            },
-            createEvent({
-              id: "event-1",
-              parentId: null,
-              timestamp: 1000,
-              message: {
-                role: "assistant",
-                content: "append",
-                MediaPaths: ["/media/a.png"],
-                MediaTypes: ["image/png"],
-              },
-            }),
-          ),
-        ).toBe(true);
-      },
-      { agentId: "main", env },
-    );
-    const database = openOpenClawAgentDatabase({ agentId: "main", env });
-    const row = database.db
-      .prepare("SELECT event_json FROM transcript_events WHERE session_id = ? AND seq = 0")
-      .get("append-session") as { event_json: string };
-    const message = (JSON.parse(row.event_json) as { message: Record<string, unknown> }).message;
-    expect(message).toMatchObject({ role: "assistant", content: "append" });
-    expect(message).not.toHaveProperty("MediaPaths");
-    expect(message).not.toHaveProperty("MediaTypes");
-    expect(message["__openclaw"]).toMatchObject({
-      media: [expect.objectContaining({ path: "/media/a.png", contentType: "image/png" })],
-    });
-  });
-
   it("rewrites every active shape and trajectory snapshot, migrates mixed archives, and reruns as a no-op", async () => {
     const stateDir = makeTempDir(tempDirs, "media-persistence-migration-");
     const env = { OPENCLAW_STATE_DIR: stateDir };

--- a/src/worker/embedded-agent.runtime.ts
+++ b/src/worker/embedded-agent.runtime.ts
@@ -27,7 +27,11 @@ import { resolveToolLoopDetectionConfig } from "../agents/tool-loop-detection-co
 import { wrapToolWithGatewayCallerIdentity } from "../agents/tools/gateway-caller-context.js";
 import { DEFAULT_AGENTS_FILENAME, loadWorkspaceBootstrapFiles } from "../agents/workspace.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import type { AssistantMessage, AssistantMessageEventStreamLike } from "../llm/types.js";
+import type {
+  AssistantMessage,
+  AssistantMessageEventStreamLike,
+  ImageContent,
+} from "../llm/types.js";
 import { createWorkerBrowserToolRuntime, type WorkerBrowserRuntime } from "./browser-runtime.js";
 import { createWorkerLiveRuntime } from "./embedded-agent-live.runtime.js";
 import {
@@ -83,6 +87,7 @@ type RunWorkerEmbeddedTurnParams = {
   sessionKey: string;
   runId: string;
   prompt: string;
+  images?: ImageContent[];
   modelRef: WorkerInferenceModelRef;
   inference: WorkerEmbeddedInferenceClient;
   transcript: WorkerEmbeddedTranscriptClient;
@@ -319,7 +324,7 @@ export async function runWorkerEmbeddedTurn(params: RunWorkerEmbeddedTurnParams)
     }
     await session.agent.prompt({
       role: "user",
-      content: [{ type: "text", text: params.prompt }],
+      content: [{ type: "text", text: params.prompt }, ...(params.images ?? [])],
       timestamp: Date.now(),
     });
     await session.agent.waitForIdle();

--- a/src/worker/launch-descriptor.test.ts
+++ b/src/worker/launch-descriptor.test.ts
@@ -6,6 +6,7 @@ import {
   WORKER_RPC_SET_VERSION,
 } from "../../packages/gateway-protocol/src/schema/worker-admission.js";
 import { WORKER_INFERENCE_MAX_CONTEXT_MESSAGES } from "../../packages/gateway-protocol/src/schema/worker-inference.js";
+import { createNoisyPngBuffer } from "../../test/helpers/image-fixtures.js";
 import type { WorkerLaunchDescriptor } from "./launch-descriptor.js";
 import { buildWorkerConnectParams, parseWorkerLaunchDescriptor } from "./launch-descriptor.js";
 
@@ -62,6 +63,38 @@ describe("worker launch descriptor", () => {
       client: { id: "openclaw-worker", mode: "worker", version: "2026.7.12" },
       admission: { ...descriptor.admission, runId: descriptor.assignment.runId },
     });
+  });
+
+  it("admits current images above the transcript frame ceiling using the inference budget", () => {
+    const descriptor = launchDescriptor();
+    const images = [
+      {
+        type: "image" as const,
+        data: createNoisyPngBuffer(320, 240).toString("base64"),
+        mimeType: "image/png",
+      },
+    ];
+    descriptor.assignment.images = images;
+    descriptor.assignment.suppressPromptTranscript = true;
+    expect(images[0]?.data.length).toBeGreaterThan(WORKER_PROTOCOL_MAX_PAYLOAD_BYTES);
+
+    expect(parseWorkerLaunchDescriptor(descriptor).assignment).toMatchObject({ images });
+    for (const invalidImage of [
+      { ...images[0], data: "" },
+      { ...images[0], type: "text" },
+      { ...images[0], extra: true },
+    ]) {
+      expect(() =>
+        parseWorkerLaunchDescriptor({
+          ...descriptor,
+          assignment: { ...descriptor.assignment, images: [invalidImage] },
+        }),
+      ).toThrow("invalid worker launch descriptor");
+    }
+    descriptor.assignment.suppressPromptTranscript = false;
+    expect(() => parseWorkerLaunchDescriptor(descriptor)).toThrow(
+      "invalid worker launch descriptor",
+    );
   });
 
   it("accepts the permission context pair only when both fields are present", () => {

--- a/src/worker/launch-descriptor.ts
+++ b/src/worker/launch-descriptor.ts
@@ -1,5 +1,6 @@
 import path from "node:path";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
+import { Type } from "typebox";
 import { Value } from "typebox/value";
 import {
   GATEWAY_CLIENT_IDS,
@@ -17,6 +18,7 @@ import {
   WorkerTranscriptMessageSchema,
   type WorkerTranscriptCommitParams,
   WORKER_PROTOCOL_MAX_IDENTIFIER_LENGTH,
+  WORKER_TRANSCRIPT_MAX_CONTENT_PARTS,
 } from "../../packages/gateway-protocol/src/schema/worker-admission.js";
 import type {
   WorkerInferenceModelRef,
@@ -26,9 +28,11 @@ import {
   WORKER_INFERENCE_MAX_CONTEXT_MESSAGES,
   WorkerInferenceModelRefSchema,
   WorkerInferenceOptionsSchema,
+  WorkerInferenceImageContentSchema,
 } from "../../packages/gateway-protocol/src/schema/worker-inference.js";
 import { PROTOCOL_VERSION } from "../../packages/gateway-protocol/src/version.js";
 import type { OperationalRunInstanceRef } from "../agents/admitted-run-context.js";
+import type { ImageContent } from "../llm/types.js";
 import { isWorkerToolName, type WorkerToolAuthority } from "./tool-authority.js";
 import { isWorkerTranscriptMessageFrameSafe } from "./transcript-message.js";
 import {
@@ -37,6 +41,10 @@ import {
 } from "./worker-connection-endpoint.js";
 
 const LAUNCH_VERSION = 4;
+const WorkerPromptImagesSchema = Type.Array(WorkerInferenceImageContentSchema, {
+  minItems: 1,
+  maxItems: WORKER_TRANSCRIPT_MAX_CONTENT_PARTS - 1,
+});
 
 export type WorkerBrowserLaunchDescriptor = {
   cdpUrl: string;
@@ -56,6 +64,7 @@ type WorkerLaunchAssignment = WorkerLaunchPermissionContext & {
   runId: string;
   turnId: string;
   prompt: string;
+  images?: ImageContent[];
   suppressPromptTranscript: boolean;
   workspaceDir: string;
   modelRef: WorkerInferenceModelRef;
@@ -188,7 +197,7 @@ function parseAssignment(value: unknown): WorkerLaunchAssignment | undefined {
         "liveEvents",
         "toolAuthority",
       ],
-      ["systemPrompt", "browser", "permissionMode", "workerContainmentRoot"],
+      ["systemPrompt", "images", "browser", "permissionMode", "workerContainmentRoot"],
     )
   ) {
     return undefined;
@@ -216,6 +225,7 @@ function parseAssignment(value: unknown): WorkerLaunchAssignment | undefined {
     value.agentRuntimeIdentityToken.length > 16_384 ||
     !isIdentifier(value.turnId) ||
     typeof value.prompt !== "string" ||
+    (value.images !== undefined && !Value.Check(WorkerPromptImagesSchema, value.images)) ||
     typeof value.suppressPromptTranscript !== "boolean" ||
     !isIdentifier(value.workspaceDir) ||
     !isAbsoluteHostPath(value.workspaceDir) ||
@@ -302,7 +312,12 @@ function validateWorkerLaunchPlan(candidate: WorkerLaunchPlan): WorkerLaunchPlan
     candidate.admission.ownerEpoch < 1 ||
     !isWorkerTranscriptMessageFrameSafe({
       role: "user",
-      content: [{ type: "text", text: candidate.assignment.prompt }],
+      content: [
+        { type: "text", text: candidate.assignment.prompt },
+        ...(candidate.assignment.suppressPromptTranscript
+          ? []
+          : (candidate.assignment.images ?? [])),
+      ],
       timestamp: Number.MAX_SAFE_INTEGER,
     })
   ) {

--- a/src/worker/worker.runtime.test.ts
+++ b/src/worker/worker.runtime.test.ts
@@ -47,6 +47,7 @@ import {
   type WorkerInferenceTerminalFrame,
   type WorkerInferenceTerminalOutcome,
 } from "../../packages/gateway-protocol/src/schema/worker-inference.js";
+import { createNoisyPngBuffer, createSolidPngBuffer } from "../../test/helpers/image-fixtures.js";
 import { createDeferred, withTestTimeout } from "../../test/helpers/promise.js";
 import { createOperationalRunInstanceRef } from "../agents/admitted-run-context.js";
 import {
@@ -876,6 +877,39 @@ afterEach(async () => {
 });
 
 describe("worker runtime", () => {
+  it("sends current image and scanned PDF page content through remote inference exactly once", async () => {
+    const { gateway, launch } = await setup();
+    const images = [
+      {
+        type: "image" as const,
+        data: createNoisyPngBuffer(320, 240).toString("base64"),
+        mimeType: "image/png",
+      },
+      {
+        type: "image" as const,
+        data: createSolidPngBuffer(2, 2, { r: 0, g: 128, b: 255 }).toString("base64"),
+        mimeType: "image/png",
+      },
+    ];
+    launch.assignment.images = images;
+    launch.assignment.suppressPromptTranscript = true;
+
+    await expect(runWorkerDescriptor(launch)).resolves.toMatchObject({ status: "completed" });
+
+    expect(gateway.inferenceRequests[0]?.context.messages).toEqual([
+      {
+        role: "user",
+        content: [{ type: "text", text: launch.assignment.prompt }, ...images],
+        timestamp: expect.any(Number),
+      },
+    ]);
+    expect(
+      gateway.transcriptRequests.flatMap((request) =>
+        request.messages.map((message) => message.role),
+      ),
+    ).toEqual(["assistant"]);
+  });
+
   it("runs a full embedded turn through remote inference, live events, and transcript commits", async () => {
     const { gateway, workspaceDir, launch } = await setup();
     await writeFile(path.join(workspaceDir, "AGENTS.md"), "worker-bootstrap-marker", "utf8");

--- a/src/worker/worker.runtime.ts
+++ b/src/worker/worker.runtime.ts
@@ -222,6 +222,7 @@ export async function runWorkerDescriptor(
         sessionKey: `worker:${descriptor.admission.sessionId}`,
         runId: descriptor.assignment.runId,
         prompt: descriptor.assignment.prompt,
+        images: descriptor.assignment.images,
         suppressPromptTranscript: descriptor.assignment.suppressPromptTranscript,
         modelRef: descriptor.assignment.modelRef,
         initialMessages: descriptor.assignment.initialMessages,


### PR DESCRIPTION
## What Problem This Solves

Images and PDFs attached to an existing cloud session were not reliably available to its runtime. OpenClaw explicitly rejected current-turn images, including pages rendered from scanned PDFs. Neither OpenClaw worker turns nor Codex remote execution copied newly uploaded originals into an already-placed workspace, leaving file tools with Gateway-local references.

## What Changes

The Gateway uses canonical image preparation and projects image content through the existing bounded worker inference contract. Live testing exposed an additional mismatch: inline uploads carry Gateway-only `sourceIndex` metadata, which the closed worker payload correctly rejects. The handoff now uses the existing image-content clone instead of forwarding that metadata.

One placement-owned transfer stages admitted originals before either harness starts. It bounds files and bytes, verifies checksums, pins filesystem identities, and revalidates the current turn claim at transport dispatch. It preserves existing remote work. Managed copies remain remotely readable but stay outside workspace synchronization; one exact UUIDv4 pattern serves upload validation, manifests, reconciliation, and rsync, preserving ordinary similarly prefixed user folders.

No configuration key, dependency, SQLite schema, or protocol-version change is introduced. Provider credentials remain on the Gateway. Documentation is updated; under the release-owned changelog policy, release-note context is supplied here: repair image and PDF delivery to both cloud-session harnesses, including fresh attachments on later turns.

## Real Cloud Evidence

Validated commit: `ead13b53d18ba0deda6bb4ffa25b07eeb488cd37`. Both modes used real Hetzner `ccx33` workers and OpenAI API-key inference with `gpt-5.6-luna`. The matching private QA package passed the official strict package checker; its SHA-256 is `5e6e6267e365192e49c2a4cef6b6f122a53c55a914f8676aa08cb67191f50a6b`.

| Runtime | Post-placement batches | Verified result |
| --- | --- | --- |
| OpenClaw worker-turn | Two fresh PNG/text-PDF/scanned-PDF batches | All content codes and shape order correct; every original hash/length and remote path matched; remote execution and absent worker OpenAI key verified |
| Codex remote-exec | Two distinct PNG/text-PDF/scanned-PDF batches | Same checks passed through native remote tools and normal, exact-attempt exec-server approvals; the second batch passed after reopening and rendering its scanned PDF |

Both modes also reconciled ordinary `openclaw-inbound-project` output while excluding the exact managed UUID directories. Expected codes and hashes were not supplied in prompts. OpenClaw used explicit SSE transport; this does not establish default/WebSocket transport behavior.

Codex initially misread one character in the second scanned-PDF code. Original bytes, paths, and all isolation checks already passed; a separate reread of the actual PDF corrected the transcription and passed every strict check. The original failed verdict is preserved rather than overwritten. An earlier OpenClaw build also needed a model-authored report-path correction; the final OpenClaw run passed both rounds without correction.

Earlier attempts encountered artifact-download and broker request stalls before Codex startup. Task-only setup repaired npm 11 launcher permissions by scoping `umask 022` to the sudo install process, leaving the surrounding restrictive mask intact. No product provider timeout, authentication, or readiness policy was changed. No relay was used for provisioning or model turns. A task-local SSH relay was used only for one read-only cleanup status check; both direct and relayed checks confirmed release. Both relay listeners were stopped, and no credentials were copied or global proxy configured.

Both final cloud leases are independently confirmed released. All task Gateways and tunnels are stopped, 16 temporary QA state roots contain no remaining files, and temporary key copies and the task-only secret-tool window are removed.

## Tests and Review

[Final-head CI passed](https://github.com/openclaw/openclaw/actions/runs/33242679642) on attempt 2. All 170 non-macOS jobs passed first; both macOS jobs remained unassigned, so unfinished jobs and the aggregate gate were retried through the workflow's existing hosted `macos-15`/`macos-26` routes. No global CI settings changed.

Local proof includes 84 focused Gateway/image tests, worker image inference and launch-budget coverage, 14 inline-image handoff/descriptor checks, 37 final transfer/reconciliation/sibling tests, and 13 transcript append/migration tests. The earlier full changed-file gate passed 545 selected macOS/workspace/process tests. Final static guards, core/core-test types, formatting, typed lint, and independent Codex autoreview passed. Six extended regressions failed before the precise exclusion repair; sourceIndex reproduced the actual live descriptor error before its fix.

Broad local worker-process tests hit pre-existing timeouts under heavy host load; a redundant rerun was terminated and is not claimed as passing. An unrelated main migration-test line-cap failure was repaired by moving its existing live-append case beside the transcript owner. Nearby duplicate Git-probe fixtures were consolidated without dropping either case or its assertions.

Production: +467/-154, net +313. Tests/test support: +792/-148. Docs: +6. Growth implements the previously missing bounded cross-machine original transfer and its confinement/authority boundary. Canonical image preparation replaces the old implementation; whole-workspace resync would overwrite remote edits.

## Dependency and Current-Main Proof

The acting maintainer inspected sibling Codex directly at `rust-v0.150.1` (`0eb410ad0dd161ea323b05452f978de01cd63430`): [user-input variants](https://github.com/openai/codex/blob/rust-v0.150.1/codex-rs/protocol/src/user_input.rs), [app-server local-image loading](https://github.com/openai/codex/blob/rust-v0.150.1/codex-rs/protocol/src/models.rs#L1952), and [selected-environment file/image access](https://github.com/openai/codex/blob/rust-v0.150.1/codex-rs/core/src/tools/handlers/view_image.rs#L143). Image input belongs to app-server; native file access belongs to the selected execution environment. PDF is not a native user-input variant.

Current main was inspected at `966f7222a4056e31dd8edfeacc414458d566c90f`: its worker payload still rejects current-turn images. The final PR head merges cleanly. Overlap is limited to a separate `codeModeOverride` forwarding field, desktop documentation, and migration-test improvements. These direct checks close the review sandbox's missing-source gaps.

ClawSweeper's staging-persistence and broad-prefix findings are fixed and regression-tested. Its remaining requested live proof now covers both modes and ordinary-prefix reconciliation. Its storage heuristic does not indicate a SQLite or durable-store change; transferred originals are user attachment artifacts.

Separate follow-ups: historical managed-image replay hydration predates this current-turn repair and remains outside this proof; private-QA packaging omits a shared hashed QA chunk despite including importers. The task package restored that exact built chunk and its derived inventory before strict verification; release packaging policy is unchanged.
