### PR TITLE
test(github-copilot): accelerate real transport deadlines

### DIFF
--- a/extensions/github-copilot/embeddings.transport.test.ts
+++ b/extensions/github-copilot/embeddings.transport.test.ts
@@ -1,10 +1,12 @@
 // Exercise discovery and embeddings over real sockets, including request
 // cancellation and redaction without relying on fetch or SSRF mocks.
+import { channel } from "node:diagnostics_channel";
 import fs from "node:fs";
 import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
 import type { AddressInfo } from "node:net";
 import os from "node:os";
 import path from "node:path";
+import type { DiagnosticsChannel } from "undici";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const resolveFirstGithubTokenMock = vi.hoisted(() => vi.fn());
@@ -132,6 +134,7 @@ describe("githubCopilotMemoryEmbeddingProviderAdapter real transport", () => {
   it.each(["headers", "trickling body"])(
     "aborts model discovery with stalled %s within its operation deadline",
     async (phase) => {
+      let bodyReceived = false;
       let connectionClosed = false;
       const server = await startCopilotServer({
         models: (response) => {
@@ -147,18 +150,44 @@ describe("githubCopilotMemoryEmbeddingProviderAdapter real transport", () => {
           });
         },
       });
+      const bodyChannel = channel("undici:request:bodyChunkReceived");
+      const onBody = (message: unknown) => {
+        const { request } = message as DiagnosticsChannel.RequestBodyChunkReceivedMessage;
+        if (String(request.origin) === server.baseUrl && request.path === "/models") {
+          bodyReceived = true;
+        }
+      };
+      bodyChannel.subscribe(onBody);
+      const realSetTimeout = globalThis.setTimeout;
+      // Scale long deadlines together, leaving Undici's retained sub-second
+      // timer pump and the real body trickle untouched across later requests.
+      const timeoutSpy = vi
+        .spyOn(globalThis, "setTimeout")
+        .mockImplementation((callback, delay, ...args) =>
+          realSetTimeout(
+            callback,
+            delay !== undefined && delay >= 1_000 ? Math.ceil(delay / 10) : delay,
+            ...args,
+          ),
+        );
       const startedAt = performance.now();
 
-      await expect(
-        githubCopilotMemoryEmbeddingProviderAdapter.create({
-          ...defaultCreateOptions(),
-          remote: { baseUrl: server.baseUrl, apiKey: "copilot-test-only" },
-        }),
-      ).rejects.toThrow("request timed out");
+      try {
+        await expect(
+          githubCopilotMemoryEmbeddingProviderAdapter.create({
+            ...defaultCreateOptions(),
+            remote: { baseUrl: server.baseUrl, apiKey: "copilot-test-only" },
+          }),
+        ).rejects.toThrow("request timed out");
 
-      expect(performance.now() - startedAt).toBeLessThan(15_000);
-      await vi.waitFor(() => expect(connectionClosed).toBe(true));
-      expect(server.requests).toEqual([{ method: "GET", url: "/models" }]);
+        expect(performance.now() - startedAt).toBeLessThan(1_500);
+        expect(bodyReceived).toBe(phase === "trickling body");
+        await vi.waitFor(() => expect(connectionClosed).toBe(true));
+        expect(server.requests).toEqual([{ method: "GET", url: "/models" }]);
+      } finally {
+        bodyChannel.unsubscribe(onBody);
+        timeoutSpy.mockRestore();
+      }
     },
     20_000,
   );


### PR DESCRIPTION
## What Problem This Solves

Two real HTTP transport tests each spend ten seconds waiting for the model-discovery operation deadline. They need to prove cancellation before headers and throughout a trickling body, but do not need to occupy twenty seconds of wall time.

## Why This Change Was Made

Scale long `setTimeout` delays together by ten within those two cases. This includes both the production deadline and the fixture's later successful-response sentinel, so a missing or excessively long deadline still fails. Short timers and the real 100ms body trickle are unchanged. Undici retains and refreshes its sub-second timer pump across requests; leaving that pump untouched avoids contaminating later transport cases.

Observe Undici's documented received-body diagnostics for the exact local endpoint, proving the streaming case received actual bytes before cancellation. Restore the timer spy and diagnostic subscription in `finally`. Keep the real HTTP server, provider, fetch, SSRF guard, cancellation, socket-close assertions, request assertions, and all seven cases. The elapsed-time bound scales proportionally; test-runner timeout budgets are unchanged.

## User Impact

Focused transport execution falls from **20.171s to 2.213s**, repeated at **2.142s** with siblings. No production, sharding, worker-count, test-selection, dependency, or configuration changes. Production LOC +0/-0; tests +38/-9.

## Evidence

- Before/after: `node scripts/run-vitest.mjs extensions/github-copilot/embeddings.transport.test.ts` — all seven cases passed each time.
- Siblings: the transport, embeddings, models, guarded-response release, and fetch-timeout files passed **121 tests across five files**. The remaining five real transport cases run after the accelerated cases, exercising subsequent requests with normal timers.
- Three deliberate mutations were tested and restored byte-for-byte: removing the owner timeout failed both cases; extending it past the successful-response sentinel failed both; clearing the timeout after headers failed the trickling-body case. Each failed because discovery incorrectly resolved instead of rejecting, not because the harness hung. The full sibling run passed after restoring production code.
- Read the entire transport test, embeddings owner, timeout owner, guarded-fetch path, and installed Undici timer/diagnostics implementation. This retains the full-body deadline regression introduced in #102886.
- Independent source review and fresh Codex autoreview found no actionable findings. Formatting and whitespace checks passed. Changed-file [Linux checks33234219834](https://github.com/openclaw/openclaw/actions/runs/33234219834) passed with no warnings or errors, and the Testbox lease was stopped. Exact-head [CI33234275164](https://github.com/openclaw/openclaw/actions/runs/33234275164) is green, including changed-plugin tests and type checks.

No real credentials or external Copilot requests were used; all network proof is loopback HTTP. The scaled deadline leaves 500ms of scheduling headroom in the elapsed assertion; hosted CI confirmed that execution path before merge.
