### PR TITLE
fix: keep full release verification evidence readable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2326,7 +2326,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: read
-    name: ${{ matrix.check_name }}
+    name: ${{ matrix.check_name || 'checks-fast-core' }}
     needs: [preflight]
     if: needs.preflight.outputs.run_checks_fast_core == 'true'
     runs-on: ${{ (vars.OPENCLAW_CI_RUNNER_BACKEND == 'github' || vars.OPENCLAW_CI_RUNNER_BACKEND == 'hybrid') && 'ubuntu-24.04' || github.event_name == 'workflow_dispatch' && 'ubuntu-24.04' || (github.repository == 'openclaw/openclaw' && (github.event_name != 'pull_request' || contains(fromJSON('["OWNER","MEMBER","COLLABORATOR","CONTRIBUTOR"]'), github.event.pull_request.author_association)) && (matrix.runner || 'blacksmith-4vcpu-ubuntu-2404') || 'ubuntu-24.04') }}
@@ -2778,7 +2778,7 @@ jobs:
   checks-node-core-test-nondist-shard:
     permissions:
       contents: read
-    name: ${{ matrix.check_name }}
+    name: ${{ matrix.check_name || 'checks-node-core-test-nondist-shard' }}
     needs: [preflight]
     if: needs.preflight.outputs.run_checks_node_core_nondist == 'true'
     runs-on: ${{ vars.OPENCLAW_CI_RUNNER_BACKEND == 'github' && 'ubuntu-24.04' || (vars.OPENCLAW_CI_RUNNER_BACKEND == 'hybrid' && github.run_attempt > 1) && 'ubuntu-24.04' || github.event_name == 'workflow_dispatch' && 'ubuntu-24.04' || (github.repository == 'openclaw/openclaw' && (github.event_name != 'pull_request' || contains(fromJSON('["OWNER","MEMBER","COLLABORATOR","CONTRIBUTOR"]'), github.event.pull_request.author_association)) && (matrix.runner || 'blacksmith-4vcpu-ubuntu-2404') || 'ubuntu-24.04') }}
@@ -2939,7 +2939,7 @@ jobs:
   check-shard:
     permissions:
       contents: read
-    name: ${{ matrix.check_name }}
+    name: ${{ matrix.check_name || 'check-shard' }}
     needs: [preflight]
     if: ${{ !cancelled() && always() && needs.preflight.outputs.run_check == 'true' }}
     runs-on: ${{ vars.OPENCLAW_CI_RUNNER_BACKEND == 'github' && 'ubuntu-24.04' || (vars.OPENCLAW_CI_RUNNER_BACKEND == 'hybrid' && github.repository == 'openclaw/openclaw' && github.event_name == 'workflow_dispatch' && !inputs.release_gate && startsWith(inputs.dispatch_id, 'full-release-validation-') && inputs.target_context_ref != '' && needs.preflight.outputs.frozen_target == 'true' && matrix.task == 'lint') && (matrix.runner || 'blacksmith-4vcpu-ubuntu-2404') || (vars.OPENCLAW_CI_RUNNER_BACKEND == 'hybrid' && (github.event_name == 'workflow_dispatch' || github.run_attempt > 1 || (matrix.task != 'lint' && matrix.task != 'test-types' && matrix.task != 'dependencies'))) && 'ubuntu-24.04' || (github.event_name == 'workflow_dispatch' && inputs.release_gate) && 'ubuntu-24.04' || (github.repository == 'openclaw/openclaw' && (github.event_name != 'pull_request' || contains(fromJSON('["OWNER","MEMBER","COLLABORATOR","CONTRIBUTOR"]'), github.event.pull_request.author_association)) && (matrix.runner || 'blacksmith-4vcpu-ubuntu-2404') || 'ubuntu-24.04') }}
@@ -3388,7 +3388,7 @@ jobs:
   check-additional-shard:
     permissions:
       contents: read
-    name: ${{ matrix.check_name }}
+    name: ${{ matrix.check_name || 'check-additional-shard' }}
     needs: [preflight]
     if: ${{ !cancelled() && always() && needs.preflight.outputs.run_check_additional == 'true' }}
     runs-on: ${{ vars.OPENCLAW_CI_RUNNER_BACKEND == 'github' && 'ubuntu-24.04' || (vars.OPENCLAW_CI_RUNNER_BACKEND == 'hybrid' && (github.run_attempt > 1 || (matrix.group != 'extension-package-boundary' && matrix.group != 'runtime-topology-architecture' && matrix.group != 'plugin-sdk-api-diff'))) && 'ubuntu-24.04' || github.event_name == 'workflow_dispatch' && 'ubuntu-24.04' || (github.repository == 'openclaw/openclaw' && (github.event_name != 'pull_request' || contains(fromJSON('["OWNER","MEMBER","COLLABORATOR","CONTRIBUTOR"]'), github.event.pull_request.author_association)) && (matrix.runner || 'blacksmith-4vcpu-ubuntu-2404') || 'ubuntu-24.04') }}
@@ -3799,7 +3799,7 @@ jobs:
   checks-windows:
     permissions:
       contents: read
-    name: ${{ matrix.check_name }}
+    name: ${{ matrix.check_name || 'checks-windows' }}
     needs: [preflight]
     if: needs.preflight.outputs.run_checks_windows == 'true'
     runs-on: ${{ vars.OPENCLAW_CI_RUNNER_BACKEND == 'github' && 'windows-2025' || (vars.OPENCLAW_CI_RUNNER_BACKEND == 'hybrid' && github.run_attempt > 1) && 'windows-2025' || github.event_name == 'workflow_dispatch' && 'windows-2025' || (github.repository == 'openclaw/openclaw' && (github.event_name != 'pull_request' || contains(fromJSON('["OWNER","MEMBER","COLLABORATOR","CONTRIBUTOR"]'), github.event.pull_request.author_association)) && 'blacksmith-8vcpu-windows-2025' || 'windows-2025') }}
@@ -3918,7 +3918,7 @@ jobs:
   macos-node:
     permissions:
       contents: read
-    name: ${{ matrix.check_name }}
+    name: ${{ matrix.check_name || 'macos-node' }}
     needs: [preflight]
     if: ${{ !cancelled() && always() && needs.preflight.outputs.run_macos_node == 'true' }}
     runs-on: ${{ vars.OPENCLAW_CI_RUNNER_BACKEND == 'github' && 'macos-15' || (github.event_name == 'workflow_dispatch' || github.run_attempt > 1) && 'macos-15' || (github.repository == 'openclaw/openclaw' && (github.event_name != 'pull_request' || contains(fromJSON('["OWNER","MEMBER","COLLABORATOR","CONTRIBUTOR"]'), github.event.pull_request.author_association)) && 'blacksmith-6vcpu-macos-15' || 'macos-15') }}
@@ -4632,7 +4632,7 @@ jobs:
   android:
     permissions:
       contents: read
-    name: ${{ matrix.check_name }}
+    name: ${{ matrix.check_name || 'android' }}
     needs: [preflight]
     if: needs.preflight.outputs.run_android_job == 'true'
     runs-on: ${{ vars.OPENCLAW_CI_RUNNER_BACKEND == 'github' && 'ubuntu-24.04' || (vars.OPENCLAW_CI_RUNNER_BACKEND == 'hybrid' && github.run_attempt > 1) && 'ubuntu-24.04' || github.event_name == 'workflow_dispatch' && 'ubuntu-24.04' || (github.repository == 'openclaw/openclaw' && (github.event_name != 'pull_request' || contains(fromJSON('["OWNER","MEMBER","COLLABORATOR","CONTRIBUTOR"]'), github.event.pull_request.author_association)) && 'blacksmith-8vcpu-ubuntu-2404' || 'ubuntu-24.04') }}

--- a/.github/workflows/full-release-validation.yml
+++ b/.github/workflows/full-release-validation.yml
@@ -1853,7 +1853,7 @@ jobs:
           if [[ "$EVIDENCE_REUSE" == "true" ]]; then
             # Inherit the evidence manifest (profile, soak, child runs) so future
             # reuse lookups and evidence consumers keep resolving the chain root.
-            jq \
+            jq -c \
               --arg runId "$GITHUB_RUN_ID" \
               --arg runAttempt "$GITHUB_RUN_ATTEMPT" \
               --arg workflowRef "$GITHUB_REF_NAME" \
@@ -1898,7 +1898,7 @@ jobs:
               }' <<< "$EVIDENCE_MANIFEST" > "${manifest_dir}/full-release-validation-manifest.json"
             exit 0
           fi
-          jq -n \
+          jq -cn \
             --arg workflowName "Full Release Validation" \
             --arg runId "$GITHUB_RUN_ID" \
             --arg runAttempt "$GITHUB_RUN_ATTEMPT" \

--- a/.github/workflows/plugin-prerelease.yml
+++ b/.github/workflows/plugin-prerelease.yml
@@ -432,7 +432,8 @@ jobs:
   plugin-prerelease-static-shard:
     permissions:
       contents: read
-    name: ${{ matrix.check_name }}
+    # Job-level skips happen before matrix expansion; retain a unique owner name.
+    name: ${{ matrix.check_name || 'plugin-prerelease-static-shard' }}
     needs: [preflight]
     if: needs.preflight.outputs.run_plugin_prerelease_static == 'true'
     runs-on: ${{ github.event_name == 'workflow_dispatch' && 'ubuntu-24.04' || 'blacksmith-8vcpu-ubuntu-2404' }}
@@ -469,7 +470,7 @@ jobs:
   plugin-prerelease-node-shard:
     permissions:
       contents: read
-    name: ${{ matrix.check_name }}
+    name: ${{ matrix.check_name || 'plugin-prerelease-node-shard' }}
     needs: [preflight]
     if: needs.preflight.outputs.run_plugin_prerelease_node == 'true'
     runs-on: ${{ github.event_name == 'workflow_dispatch' && 'ubuntu-24.04' || (matrix.runner || 'ubuntu-24.04') }}
@@ -579,7 +580,7 @@ jobs:
   plugin-prerelease-extension-shard:
     permissions:
       contents: read
-    name: ${{ matrix.check_name }}
+    name: ${{ matrix.check_name || 'plugin-prerelease-extension-shard' }}
     needs: [preflight]
     if: needs.preflight.outputs.run_plugin_prerelease_extensions == 'true'
     runs-on: ${{ github.event_name == 'workflow_dispatch' && 'ubuntu-24.04' || matrix.runner }}

--- a/scripts/frv.mjs
+++ b/scripts/frv.mjs
@@ -10,6 +10,7 @@ import {
   classifyReleaseGhTransportError,
   composeReleaseChildAttemptEvidence,
   isReleaseGhArtifactMissingError,
+  MAX_RELEASE_ARTIFACT_BYTES,
   releaseChildSpec,
   terminalPolicyPass,
   validateReleaseChildDispatchBinding,
@@ -193,7 +194,7 @@ async function downloadExecutionPlan(repository, runId) {
     }
     const path = join(directory, PLAN_FILENAME);
     const size = statSync(path, { throwIfNoEntry: false })?.size ?? 0;
-    if (size < 1 || size > 128 * 1024) {
+    if (size < 1 || size > MAX_RELEASE_ARTIFACT_BYTES) {
       throw new Error("immutable execution plan artifact is missing or oversized");
     }
     return JSON.parse(readFileSync(path, "utf8"));

--- a/scripts/full-release-validation-at-sha.mts
+++ b/scripts/full-release-validation-at-sha.mts
@@ -15,6 +15,7 @@ import {
   classifyReleaseGhTransportError,
   formatReleaseStateOutcome,
   isReleaseGhArtifactMissingError,
+  MAX_RELEASE_ARTIFACT_BYTES,
   validateReleaseStateArtifact,
 } from "./full-release-validation-policy.mjs";
 import { execGhRead } from "./lib/plain-gh.mjs";
@@ -32,7 +33,6 @@ export const FULL_RELEASE_WAIT_TIMEOUT_MINUTES = 720;
 export const FULL_RELEASE_GITHUB_POLL_INTERVAL_MS = 15 * 60_000;
 const FULL_RELEASE_RUN_DISCOVERY_ATTEMPTS = 2;
 const RELEASE_DECISION_FILE = "full-release-decision.json";
-const MAX_RELEASE_DECISION_BYTES = 128 * 1024;
 const GH_READ_OPTIONS = {
   encoding: "utf8",
   killSignal: "SIGKILL",
@@ -663,7 +663,7 @@ export function tryReadReleaseDecision(
         `Release Decision artifact ${artifactName} omitted ${RELEASE_DECISION_FILE}.`,
       );
     }
-    if (statSync(decisionPath).size > MAX_RELEASE_DECISION_BYTES) {
+    if (statSync(decisionPath).size > MAX_RELEASE_ARTIFACT_BYTES) {
       throw new Error(`Release Decision artifact ${artifactName} exceeds the size limit.`);
     }
     return validateReleaseDecisionPayload(JSON.parse(readFileSync(decisionPath, "utf8")), {

--- a/scripts/full-release-validation-policy.d.mts
+++ b/scripts/full-release-validation-policy.d.mts
@@ -1,3 +1,6 @@
+export const MAX_RELEASE_ARTIFACT_BYTES: number;
+export function serializeReleaseArtifact(payload: unknown): string;
+
 export interface ReleaseRecord {
   [key: string]: unknown;
 }

--- a/scripts/full-release-validation-policy.mjs
+++ b/scripts/full-release-validation-policy.mjs
@@ -4,6 +4,18 @@ import {
   validateFullReleaseCandidateRequest,
 } from "./full-release-candidate-contract.mjs";
 
+// Full profiles carry over 500 job records. Keep complete evidence under one
+// shared wire budget instead of letting producers exceed smaller reader limits.
+export const MAX_RELEASE_ARTIFACT_BYTES = 1024 * 1024;
+
+export function serializeReleaseArtifact(payload) {
+  const json = `${JSON.stringify(payload)}\n`;
+  if (Buffer.byteLength(json, "utf8") > MAX_RELEASE_ARTIFACT_BYTES) {
+    throw new Error("release artifact exceeds the size limit");
+  }
+  return json;
+}
+
 const SUCCESSFUL_JOB_CONCLUSIONS = new Set(["neutral", "skipped", "success"]);
 const MAX_REPORTED_ISSUES = 25;
 const MAX_SUMMARY_ISSUES = 5;

--- a/scripts/full-release-validation-state.mjs
+++ b/scripts/full-release-validation-state.mjs
@@ -6,6 +6,7 @@ import {
   mkdirSync,
   readFileSync,
   readdirSync,
+  statSync,
   writeFileSync,
 } from "node:fs";
 import { dirname, join } from "node:path";
@@ -23,6 +24,8 @@ import {
   composeReleaseChildAttemptEvidence,
   formatReleaseStateOutcome,
   releasePlanGateFailures,
+  MAX_RELEASE_ARTIFACT_BYTES,
+  serializeReleaseArtifact,
   selectReleaseStateArtifacts,
   validateReleaseChildRunProvenance,
   validateReleaseExecutionPlanArtifact,
@@ -420,8 +423,9 @@ async function validateReuse(plan, planInputs, signal) {
 }
 
 function writeArtifact(path, payload) {
+  const json = serializeReleaseArtifact(payload);
   mkdirSync(dirname(path), { recursive: true });
-  writeFileSync(path, `${JSON.stringify(payload, null, 2)}\n`);
+  writeFileSync(path, json);
 }
 
 function writeResult(path, payload) {
@@ -483,6 +487,9 @@ async function cancelAffectedChildren(children, blockers, cancelledRunIds, signa
 
 function readArtifact(path, label) {
   try {
+    if (statSync(path).size > MAX_RELEASE_ARTIFACT_BYTES) {
+      throw new Error("release artifact exceeds the size limit");
+    }
     return JSON.parse(readFileSync(path, "utf8"));
   } catch (error) {
     throw new Error(
@@ -1031,6 +1038,7 @@ async function validateManifestMode() {
   ) {
     throw new Error("release validation manifest differs from the immutable execution plan");
   }
+  writeArtifact(manifestPath, rawManifest);
 }
 
 function selectMode() {

--- a/scripts/release-ci-summary.mjs
+++ b/scripts/release-ci-summary.mjs
@@ -17,6 +17,7 @@ import {
   composeReleaseChildAttemptEvidence,
   formatReleaseStateOutcome,
   isReleaseGhArtifactMissingError,
+  MAX_RELEASE_ARTIFACT_BYTES,
   releaseCompositeJobsSha256,
   terminalPolicyPass,
   validateReleaseChildDispatchBinding,
@@ -36,11 +37,8 @@ const RELEASE_EVIDENCE_SCRIPT = "scripts/release-ci-summary.mjs";
 const RELEASE_EVIDENCE_FILE = fileURLToPath(import.meta.url);
 const RELEASE_EVIDENCE_REPO_ROOT = resolve(dirname(RELEASE_EVIDENCE_FILE), "..");
 const MANIFEST_ARTIFACT_ENTRY = "full-release-validation-manifest.json";
-const MAX_MANIFEST_ARTIFACT_ZIP_BYTES = 256 * 1024;
-const MAX_MANIFEST_JSON_BYTES = 128 * 1024;
 const MAX_MANIFEST_ENTRY_LIST_BYTES = 8 * 1024;
-const MAX_RELEASE_STATE_BYTES = 128 * 1024;
-const MAX_EXECUTION_PLAN_BYTES = 128 * 1024;
+const MAX_MANIFEST_ARTIFACT_ZIP_BYTES = MAX_RELEASE_ARTIFACT_BYTES + MAX_MANIFEST_ENTRY_LIST_BYTES;
 // Release evidence lookups run during full release validation, so keep enough
 // headroom for GitHub latency while preventing one stalled read from consuming
 // the workflow budget.
@@ -292,7 +290,7 @@ function tryDownloadExecutionPlan(runId, repository = DEFAULT_REPO) {
     if (!statSync(path, { throwIfNoEntry: false })) {
       throw new Error(`release execution plan artifact ${artifactName} omitted its manifest`);
     }
-    if (statSync(path).size > MAX_EXECUTION_PLAN_BYTES) {
+    if (statSync(path).size > MAX_RELEASE_ARTIFACT_BYTES) {
       throw new Error(`release execution plan artifact ${artifactName} exceeds the size limit`);
     }
     return JSON.parse(readFileSync(path, "utf8"));
@@ -1456,13 +1454,13 @@ export function readManifestArtifactArchive(archivePath, expectedDigest) {
   let manifestBytes;
   try {
     manifestBytes = execFileSync("unzip", ["-p", archivePath, MANIFEST_ARTIFACT_ENTRY], {
-      maxBuffer: MAX_MANIFEST_JSON_BYTES + 1,
+      maxBuffer: MAX_RELEASE_ARTIFACT_BYTES + 1,
       stdio: ["ignore", "pipe", "pipe"],
     });
   } catch {
     throw new Error("release validation manifest artifact entry could not be read safely");
   }
-  if (manifestBytes.byteLength < 1 || manifestBytes.byteLength > MAX_MANIFEST_JSON_BYTES) {
+  if (manifestBytes.byteLength < 1 || manifestBytes.byteLength > MAX_RELEASE_ARTIFACT_BYTES) {
     throw new Error("release validation manifest artifact entry size is invalid");
   }
   return JSON.parse(manifestBytes.toString("utf8"));
@@ -2427,7 +2425,7 @@ export function tryReadReleaseDecisionArtifact(
     if (!statSync(path, { throwIfNoEntry: false })) {
       throw new Error(`release decision artifact ${artifactName} omitted its manifest`);
     }
-    if (statSync(path).size > MAX_RELEASE_STATE_BYTES) {
+    if (statSync(path).size > MAX_RELEASE_ARTIFACT_BYTES) {
       throw new Error(`release decision artifact ${artifactName} exceeds the size limit`);
     }
     return validateReleaseStateArtifact(

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -3445,7 +3445,7 @@ NODE
     );
     expect(source.match(/check_name: "android-build-play"/gu)).toHaveLength(1);
     expect(source).toContain('task: useCompatibleAndroidCi ? "build-play-compat" : "build-play"');
-    expect(androidJob.name).toBe("${{ matrix.check_name }}");
+    expect(androidJob.name).toBe("${{ matrix.check_name || 'android' }}");
     expect(androidJob["runs-on"]).toBe(
       "${{ vars.OPENCLAW_CI_RUNNER_BACKEND == 'github' && 'ubuntu-24.04' || (vars.OPENCLAW_CI_RUNNER_BACKEND == 'hybrid' && github.run_attempt > 1) && 'ubuntu-24.04' || github.event_name == 'workflow_dispatch' && 'ubuntu-24.04' || (github.repository == 'openclaw/openclaw' && (github.event_name != 'pull_request' || contains(fromJSON('[\"OWNER\",\"MEMBER\",\"COLLABORATOR\",\"CONTRIBUTOR\"]'), github.event.pull_request.author_association)) && 'blacksmith-8vcpu-ubuntu-2404' || 'ubuntu-24.04') }}",
     );

--- a/test/scripts/full-release-artifact-contract.test.ts
+++ b/test/scripts/full-release-artifact-contract.test.ts
@@ -1,0 +1,173 @@
+import { readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { parse } from "yaml";
+import { tryReadReleaseDecision } from "../../scripts/full-release-validation-at-sha.mts";
+import {
+  buildReleaseStateArtifact,
+  composeReleaseAttemptJobs,
+  MAX_RELEASE_ARTIFACT_BYTES,
+  serializeReleaseArtifact,
+} from "../../scripts/full-release-validation-policy.mjs";
+import { tryReadReleaseDecisionArtifact } from "../../scripts/release-ci-summary.mjs";
+
+const SHA = "a".repeat(40);
+
+function fullMatrixDecision() {
+  // Observed full-profile fanout from parent 33230733150, including both phases.
+  const counts = {
+    normalCi: 186,
+    pluginPrereleaseIndependent: 38,
+    pluginPrereleaseCandidate: 44,
+    releaseChecksIndependent: 130,
+    releaseChecksCandidate: 121,
+    productPerformance: 7,
+  };
+  const children = Object.entries(counts).map(([key, count], childIndex) => {
+    const runId = String(1000 + childIndex);
+    const composite = composeReleaseAttemptJobs(
+      [
+        {
+          runAttempt: 1,
+          jobs: Array.from({ length: count }, (_, index) => ({
+            name: `${key} / Docker and repository validation shard ${index}`,
+            status: "completed",
+            conclusion: "success",
+            started_at: "2026-08-29T03:25:00Z",
+            completed_at: "2026-08-29T03:26:00Z",
+            html_url: `https://github.com/openclaw/openclaw/actions/runs/${runId}/job/${index + 1}`,
+          })),
+        },
+      ],
+      { plannedRunAttempt: 1, effectiveRunAttempt: 1 },
+    );
+    return {
+      key,
+      runId,
+      selected: true,
+      runAttempt: 1,
+      plannedRunAttempt: 1,
+      compositeJobsSha256: composite.sha256,
+      jobs: composite.jobs,
+      observedRunAttempts: [1],
+      status: "completed",
+      conclusion: "success",
+      dispatchActor: "github-actions[bot]",
+      triggeringActor: "github-actions[bot]",
+      displayTitle: key,
+      repository: "openclaw/openclaw",
+      errors: [],
+      workflow: `${key}.yml`,
+      workflowRef: "main",
+      workflowSha: SHA,
+      url: `https://github.com/openclaw/openclaw/actions/runs/${runId}`,
+      createdAt: "2026-08-29T03:25:00Z",
+      updatedAt: "2026-08-29T03:26:00Z",
+    };
+  });
+  return buildReleaseStateArtifact({
+    children,
+    decision: { activeRunIds: [], blockers: [], errors: [], state: "passed" },
+    executionPlan: { parentRunAttempt: 1, sha256: "b".repeat(64) },
+    expected: {
+      parentRunAttempt: 1,
+      parentRunId: "123",
+      workflowRef: "main",
+      workflowSha: SHA,
+      targetSha: SHA,
+    },
+    mode: "decision",
+    releaseProfile: "full",
+    rerunGroup: "all",
+  });
+}
+
+describe("full release artifact contract", () => {
+  it("compacts the full matrix without dropping job evidence and bounds UTF-8 bytes", () => {
+    const payload = fullMatrixDecision();
+    const compact = serializeReleaseArtifact(payload);
+    expect(JSON.parse(compact)).toEqual(payload);
+    expect(Buffer.byteLength(compact)).toBeGreaterThan(128 * 1024);
+    expect(Buffer.byteLength(compact)).toBeLessThan(MAX_RELEASE_ARTIFACT_BYTES);
+    expect(compact.split("\n")).toHaveLength(2);
+
+    const value = "x".repeat(
+      MAX_RELEASE_ARTIFACT_BYTES - Buffer.byteLength(serializeReleaseArtifact({ value: "" })),
+    );
+    expect(Buffer.byteLength(serializeReleaseArtifact({ value }))).toBe(MAX_RELEASE_ARTIFACT_BYTES);
+    expect(() => serializeReleaseArtifact({ value: `${value}é` })).toThrow("size limit");
+  });
+
+  it.each(["ci.yml", "plugin-prerelease.yml"])(
+    "keeps skipped matrix job names distinct in %s without renaming expanded checks",
+    (file) => {
+      const workflow = parse(readFileSync(`.github/workflows/${file}`, "utf8"));
+      const shards = Object.entries(workflow.jobs).filter(([, raw]) =>
+        String((raw as { name?: string }).name).includes("matrix.check_name"),
+      );
+      expect(shards.length).toBeGreaterThan(1);
+      for (const [id, raw] of shards) {
+        expect((raw as { name: string }).name).toBe(`\${{ matrix.check_name || '${id}' }}`);
+      }
+    },
+  );
+
+  it.each(["dispatch helper", "summary watcher"])(
+    "%s reads every job in the full release matrix",
+    (reader) => {
+      const payload = fullMatrixDecision();
+      const serialized = JSON.stringify(payload, null, 2);
+      expect(Buffer.byteLength(serialized)).toBeGreaterThan(128 * 1024);
+      const download = (args: string[]) => {
+        writeFileSync(
+          join(args[args.indexOf("--dir") + 1]!, "full-release-decision.json"),
+          serialized,
+        );
+      };
+      const result =
+        reader === "dispatch helper"
+          ? tryReadReleaseDecision("123", 1, SHA, (_command, args) => {
+              download(args);
+              return { error: undefined, signal: null, status: 0, stderr: "", stdout: "" };
+            })
+          : tryReadReleaseDecisionArtifact(
+              { attempt: 1, headSha: SHA },
+              "123",
+              "openclaw/openclaw",
+              (args) => {
+                download(args);
+                return "";
+              },
+            );
+      expect(result).toEqual(payload);
+    },
+  );
+
+  it.each(["dispatch helper", "summary watcher"])(
+    "%s rejects oversized evidence before parsing it",
+    (reader) => {
+      const download = (args: string[]) => {
+        writeFileSync(
+          join(args[args.indexOf("--dir") + 1]!, "full-release-decision.json"),
+          " ".repeat(MAX_RELEASE_ARTIFACT_BYTES + 1),
+        );
+      };
+      expect(() =>
+        reader === "dispatch helper"
+          ? tryReadReleaseDecision("123", 1, SHA, (_command, args) => {
+              download(args);
+              return { error: undefined, signal: null, status: 0, stderr: "", stdout: "" };
+            })
+          : tryReadReleaseDecisionArtifact(
+              { attempt: 1, headSha: SHA },
+              "123",
+              "openclaw/openclaw",
+              (args) => {
+                download(args);
+                return "";
+              },
+            ),
+      ).toThrow("size limit");
+    },
+  );
+});

--- a/test/scripts/plugin-prerelease-test-plan.test.ts
+++ b/test/scripts/plugin-prerelease-test-plan.test.ts
@@ -603,7 +603,7 @@ describe("scripts/lib/plugin-prerelease-test-plan.mts", () => {
     expect(buildDistStep.env).toEqual({ NODE_OPTIONS: "--max-old-space-size=8192" });
     expect(staticShard).toEqual({
       if: "needs.preflight.outputs.run_plugin_prerelease_static == 'true'",
-      name: "${{ matrix.check_name }}",
+      name: "${{ matrix.check_name || 'plugin-prerelease-static-shard' }}",
       needs: ["preflight"],
       permissions: {
         contents: "read",

--- a/test/scripts/release-ci-summary.test.ts
+++ b/test/scripts/release-ci-summary.test.ts
@@ -10,6 +10,7 @@ import { buildFullReleaseCandidateRequest } from "../../scripts/full-release-can
 import {
   buildReleaseExecutionPlanArtifact,
   composeReleaseAttemptJobs,
+  MAX_RELEASE_ARTIFACT_BYTES,
   releaseCompositeJobsSha256,
 } from "../../scripts/full-release-validation-policy.mjs";
 import {
@@ -1059,7 +1060,7 @@ describe("release CI summary child correlation", () => {
       const root = mkdtempSync(join(tmpdir(), "release-manifest-artifact-"));
       try {
         const archivePath = join(root, "manifest.zip");
-        const manifest = { runAttempt: 1, runId: "29071366025" };
+        const manifest = { runAttempt: 1, runId: "29071366025", evidence: "x".repeat(128 * 1024) };
         const archive = makeStoredZip({
           [MANIFEST_ARTIFACT_ENTRY]: JSON.stringify(manifest),
         });
@@ -1079,14 +1080,14 @@ describe("release CI summary child correlation", () => {
         ).toThrow(`must contain only ${MANIFEST_ARTIFACT_ENTRY}`);
 
         const oversizedManifestArchive = makeStoredZip({
-          [MANIFEST_ARTIFACT_ENTRY]: "x".repeat(128 * 1024 + 1),
+          [MANIFEST_ARTIFACT_ENTRY]: "x".repeat(MAX_RELEASE_ARTIFACT_BYTES + 1),
         });
         writeFileSync(archivePath, oversizedManifestArchive);
         expect(() =>
           readManifestArtifactArchive(archivePath, artifactDigest(oversizedManifestArchive)),
         ).toThrow("artifact entry size is invalid");
 
-        const oversizedArchive = Buffer.alloc(256 * 1024 + 1);
+        const oversizedArchive = Buffer.alloc(MAX_RELEASE_ARTIFACT_BYTES + 8 * 1024 + 1);
         writeFileSync(archivePath, oversizedArchive);
         expect(() =>
           readManifestArtifactArchive(archivePath, artifactDigest(oversizedArchive)),


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

This PR uses a branch in `openclaw/openclaw`. GitHub reports `maintainerCanModify: false`, and an explicit request to enable it was rejected; the setting is not claimed enabled.

</details>

## What Problem This Solves

Resolves a problem where maintainers running Full Release Validation could lose readable release evidence and stop the diagnostic drain while child workflows were still active.

In [full release run 33230733150](https://github.com/openclaw/openclaw/actions/runs/33230733150), the Release Decision correctly reported real test failures, but its 167,314-byte artifact exceeded the operator readers' 128 KiB limit. The drain then stopped on three distinct skipped jobs in [plugin candidate run 33231320953](https://github.com/openclaw/openclaw/actions/runs/33231320953) that GitHub named identically: `matrix.check_name`.

## Why This Change Was Made

GitHub evaluates job conditions before matrix expansion. Candidate-only execution therefore skips the three independent plugin matrices before their display names resolve. Give those jobs and the seven matching ordinary CI matrix owners unique job-id fallbacks while preserving expanded check names. Keep the collector's strict duplicate detection and logical rerun identity unchanged; dropping skipped jobs or substituting per-attempt job IDs would weaken the evidence contract.

Move artifact serialization and the byte budget into the shared release policy. Producers emit compact JSON and readers enforce the same explicit 1 MiB limit. Manifest archives still require their digest, a single expected entry, and bounded compressed and uncompressed reads. All job metadata, attempt composition, provenance, and fail-closed behavior remain intact.

Production LOC: +47/-24 (net +23). Tests: +179/-5 (net +174). The production growth supplies one shared serializer and enforces its boundary at producers; existing independent reader limits are removed.

## User Impact

Maintainers can read complete full-profile evidence and continue collecting child diagnostics without these reporting failures. Product behavior and release test coverage do not change.

The original frozen run remains invalid: this change cannot retroactively repair its ambiguous job records. It must not be treated as successful or silently normalized. A fresh run with the corrected workflow producer is required.

## Evidence

The observed full profile had 526 jobs across six children:

| Child | Jobs |
| --- | ---: |
| Ordinary CI | 186 |
| Plugin independent | 38 |
| Plugin candidate | 44 |
| Release Checks independent | 130 |
| Release Checks candidate | 121 |
| Product performance | 7 |

The saved partial Decision contained 362 jobs: 167,314 bytes pretty-printed and 117,033 bytes compact. The saved Drain contained 381 jobs: 176,239 bytes pretty-printed and 123,234 bytes compact. Round-tripping each through the repaired serializer and validator preserved every field and job. A complete 526-job regression fixture still exceeds 128 KiB even when compact, so compaction alone is insufficient. The 1 MiB limit is an explicit conservative budget based on this measurement, not a claim about a universal maximum number of workflow jobs.

Before the fix, the new regression failed on both skipped-matrix name checks and both Decision readers. After the fix, six complete FRV suites passed 310 tests, and the affected existing Android workflow assertion passed separately (311 total). Coverage includes full-matrix evidence through both readers, exact UTF-8 boundary acceptance, oversized rejection, archive limits, and existing attempt/provenance/reuse checks.

```sh
node scripts/run-vitest.mjs test/scripts/full-release-artifact-contract.test.ts test/scripts/full-release-validation-state.test.ts test/scripts/full-release-validation-at-sha.test.ts test/scripts/release-ci-summary.test.ts test/scripts/frv.test.ts test/scripts/plugin-prerelease-test-plan.test.ts
node scripts/run-vitest.mjs test/scripts/ci-workflow-guards.test.ts -t 'covers Android app variants, lint, and benchmark compilation'
```

Actionlint on the three workflows, scoped script lint, formatting, and `git diff --check` passed. Independent Codex autoreview completed without actionable findings at its configured P0 threshold.

Both script and root-test type checks were attempted; the reused local dependency installation produced errors in untouched markdown-it, Crabline, Pi TUI, Google, and pako consumers. Neither check reported a changed-file diagnostic, but they are not claimed green. An initial whole CI-guard-file run was interrupted after unrelated auto-merge fixtures consumed several minutes; the affected assertion and complete FRV owner suites above subsequently passed.

**Pending before landing:** exact-head hosted/native proof and a fresh workflow execution demonstrating distinct skipped matrix names. No hosted post-fix result is claimed here. The latest ClawSweeper findings and Rank-up moves must be addressed or explicitly dispositioned before merge.
