### PR TITLE
fix(fireworks): prevent unsupported images reaching GLM 5.2 Fast

### DIFF
--- a/docs/providers/fireworks.md
+++ b/docs/providers/fireworks.md
@@ -78,7 +78,7 @@ openclaw onboard --non-interactive \
 
 | Model ref                                              | Name           | Input        | Context | Max output | Thinking     |
 | ------------------------------------------------------ | -------------- | ------------ | ------- | ---------- | ------------ |
-| `fireworks/accounts/fireworks/routers/glm-5p2-fast`    | GLM 5.2 Fast   | text + image | 256,000 | 256,000    | On (default) |
+| `fireworks/accounts/fireworks/routers/glm-5p2-fast`    | GLM 5.2 Fast   | text         | 256,000 | 256,000    | On (default) |
 | `fireworks/accounts/fireworks/models/kimi-k2p6`        | Kimi K2.6      | text + image | 262,144 | 262,144    | Forced off   |
 | `fireworks/accounts/fireworks/routers/kimi-k2p6-turbo` | Kimi K2.6 Fast | text + image | 262,144 | 256,000    | Forced off   |
 
@@ -88,7 +88,7 @@ openclaw onboard --non-interactive \
 
 ## Custom Fireworks model ids
 
-OpenClaw accepts any Fireworks model or router id at runtime. Use the exact id shown by Fireworks and prefix it with `fireworks/`. Dynamic resolution clones the Fire Pass template (text + image input and the OpenAI-compatible API) and disables thinking automatically when the id matches the Kimi pattern. GLM dynamic ids are marked text-only unless you configure a custom model entry with image input.
+OpenClaw accepts any Fireworks model or router id at runtime. Use the exact id shown by Fireworks and prefix it with `fireworks/`. Dynamic resolution uses the Fire Pass template's OpenAI-compatible API and marks GLM ids as text-only; other dynamic ids advertise text + image input. Thinking is disabled automatically when the id matches the Kimi pattern. For a model with different capabilities, configure a custom model entry with its supported input types.
 
 ```json5
 {

--- a/extensions/fireworks/index.test.ts
+++ b/extensions/fireworks/index.test.ts
@@ -29,7 +29,7 @@ function createFireworksDefaultRuntimeModel(params: { reasoning: boolean }): Pro
     api: "openai-completions",
     baseUrl: FIREWORKS_BASE_URL,
     reasoning: params.reasoning,
-    input: ["text", "image"],
+    input: ["text"],
     cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
     contextWindow: FIREWORKS_DEFAULT_CONTEXT_WINDOW,
     maxTokens: FIREWORKS_DEFAULT_MAX_TOKENS,
@@ -73,7 +73,7 @@ describe("fireworks provider plugin", () => {
     ]);
     expect(models[0]?.name).toBe("GLM 5.2 Fast");
     expect(models[0]?.reasoning).toBe(true);
-    expect(models[0]?.input).toEqual(["text", "image"]);
+    expect(models[0]?.input).toEqual(["text"]);
     expect(models[0]?.contextWindow).toBe(FIREWORKS_DEFAULT_CONTEXT_WINDOW);
     expect(models[0]?.maxTokens).toBe(FIREWORKS_DEFAULT_MAX_TOKENS);
     expect(models[0]?.cost).toEqual({

--- a/extensions/fireworks/openclaw.plugin.json
+++ b/extensions/fireworks/openclaw.plugin.json
@@ -40,7 +40,7 @@
             "id": "accounts/fireworks/routers/glm-5p2-fast",
             "name": "GLM 5.2 Fast",
             "reasoning": true,
-            "input": ["text", "image"],
+            "input": ["text"],
             "contextWindow": 256000,
             "maxTokens": 256000,
             "cost": {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users sending images to Fireworks GLM 5.2 Fast receive HTTP 400 because OpenClaw advertises image input for this text-only model.

## Why This Change Was Made

Correct the provider-owned catalog entry and matching docs. The catalog is the authoritative capability source; no downstream exception or provider-specific runtime guard is needed. Kimi retains vision support.

## User Impact

GLM 5.2 Fast is accurately listed as text-only, so capability selection no longer sends unsupported images. Existing text and tool calls continue to work. No configuration, schema, or public API changes.

## Evidence

The full model E2E sweep reproduced Fireworks rejecting GLM image input after successful text/tool turns. Fireworks documents the underlying GLM model as text-only: https://fireworks.ai/models/fireworks/glm-5p2; the Fast router is described at https://fireworks.ai/blog/glm-5p2-fast.

Blacksmith Testbox proof: https://github.com/openclaw/openclaw/actions/runs/33233092299.

- Negative control using the original manifest at `9e2168d9cf761129faf1c600165dab296a1ca186` fails the capability assertion; the corrected manifest passes all 9 Fireworks index/onboarding tests.
- Live Gateway GLM text/read/exec turns succeed. Kimi text/read/exec and image-nonce recognition also succeed. The selected gateway suite reports 150 passed and one unrelated OpenAI long-context test skipped.
- Source-performance build and formatting passed. Independent Codex autoreview reported no actionable findings at its default P0 threshold.

Production metadata: +1/-1 lines; tests: +2/-2; docs: +2/-2. The erroneous capability was introduced in `d5dcc3fb19e`; the fix stays at that catalog owner. Release context: Fireworks GLM 5.2 Fast should be described as text-only.
