### PR TITLE
test(agents): use normal startup in announce live fixture

### DIFF
--- a/src/agents/subagents/announce/subagent-announce.live.test.ts
+++ b/src/agents/subagents/announce/subagent-announce.live.test.ts
@@ -13,11 +13,12 @@ import { startGatewayServer, type GatewayServer } from "../../../gateway/server.
 import { extractPayloadText } from "../../../gateway/test-helpers.agent-results.js";
 import { onAgentEvent, type AgentEventPayload } from "../../../infra/agent-events.js";
 import { isTruthyEnvValue } from "../../../infra/env.js";
-import { clearPluginMetadataLifecycleCaches } from "../../../plugins/plugin-metadata-lifecycle.js";
+import { resetPluginRuntimeStateForTest } from "../../../plugins/runtime.js";
 import {
   createOpenClawTestState,
   type OpenClawTestState,
 } from "../../../test-utils/openclaw-test-state.js";
+import { getFreePort } from "../../../test-utils/ports.js";
 import { GATEWAY_CLIENT_MODES, GATEWAY_CLIENT_NAMES } from "../../../utils/message-channel.js";
 import { isLiveTestEnabled, readLiveTestConfig } from "../../live-test-helpers.js";
 import {
@@ -260,7 +261,7 @@ describeLive("subagent announce live", () => {
     await server?.close({ reason: "subagent announce live test done" }).catch(() => undefined);
     await state?.cleanup().catch(() => undefined);
     clearRuntimeConfigSnapshot();
-    clearPluginMetadataLifecycleCaches();
+    resetPluginRuntimeStateForTest();
     client = undefined;
     server = undefined;
     state = undefined;
@@ -268,9 +269,9 @@ describeLive("subagent announce live", () => {
 
   it(
     "keeps issue 82913 busy-parent completion announce pending until transcript delivery",
-    async () => {
+    async ({ skip }) => {
       if (!isTruthyEnvValue(process.env.OPENCLAW_SUBAGENT_ISSUE_82913_REPRO)) {
-        console.warn(
+        skip(
           "[issue-82913] skip: set OPENCLAW_SUBAGENT_ISSUE_82913_REPRO=1 to run this focused repro",
         );
         return;
@@ -279,7 +280,7 @@ describeLive("subagent announce live", () => {
       requireLiveSubagentAuth(modelConfig);
 
       const token = `subagent-82913-${randomUUID()}`;
-      const port = 30_000 + Math.floor(Math.random() * 10_000);
+      const port = await getFreePort();
       const modelKey = modelConfig.modelKey;
       const nonce = randomBytes(3).toString("hex").toUpperCase();
       const childToken = `ISSUE_82913_CHILD_${nonce}`;
@@ -294,7 +295,8 @@ describeLive("subagent announce live", () => {
           OPENCLAW_SKIP_CRON: "1",
           OPENCLAW_SKIP_BROWSER_CONTROL_SERVER: "1",
           OPENCLAW_SKIP_CANVAS_HOST: "1",
-          OPENCLAW_TEST_MINIMAL_GATEWAY: "1",
+          // Agent admission needs the reply runtime published by normal startup.
+          OPENCLAW_TEST_MINIMAL_GATEWAY: "0",
           OPENCLAW_DISABLE_BUNDLED_PLUGINS: undefined,
           OPENCLAW_BUNDLED_PLUGINS_DIR: path.resolve("extensions"),
           OPENCLAW_TEST_TRUST_BUNDLED_PLUGINS_DIR: "1",
@@ -309,7 +311,7 @@ describeLive("subagent announce live", () => {
         }),
       );
       clearRuntimeConfigSnapshot();
-      clearPluginMetadataLifecycleCaches();
+      resetPluginRuntimeStateForTest();
 
       server = await startGatewayServer(port, {
         bind: "loopback",
@@ -413,7 +415,7 @@ describeLive("subagent announce live", () => {
       requireLiveSubagentAuth(modelConfig);
 
       const token = `subagent-live-${randomUUID()}`;
-      const port = 30_000 + Math.floor(Math.random() * 10_000);
+      const port = await getFreePort();
       const modelKey = modelConfig.modelKey;
       const nonce = randomBytes(3).toString("hex").toUpperCase();
       const childToken = `CHILD_STEERED_${nonce}`;
@@ -487,7 +489,7 @@ describeLive("subagent announce live", () => {
           OPENCLAW_SKIP_CRON: "1",
           OPENCLAW_SKIP_BROWSER_CONTROL_SERVER: "1",
           OPENCLAW_SKIP_CANVAS_HOST: "1",
-          OPENCLAW_TEST_MINIMAL_GATEWAY: "1",
+          OPENCLAW_TEST_MINIMAL_GATEWAY: "0",
           OPENCLAW_DISABLE_BUNDLED_PLUGINS: undefined,
           OPENCLAW_BUNDLED_PLUGINS_DIR: path.resolve("extensions"),
           OPENCLAW_TEST_TRUST_BUNDLED_PLUGINS_DIR: "1",
@@ -501,7 +503,7 @@ describeLive("subagent announce live", () => {
         }),
       );
       clearRuntimeConfigSnapshot();
-      clearPluginMetadataLifecycleCaches();
+      resetPluginRuntimeStateForTest();
 
       server = await startGatewayServer(port, {
         bind: "loopback",
@@ -657,10 +659,10 @@ describeLive("subagent announce live", () => {
 
   it(
     "runs parallel isolated Gemini subagents with tool-heavy schemas",
-    async () => {
+    async ({ skip }) => {
       const modelConfig = resolveLiveSubagentModelConfig();
       if (!modelConfig.modelKey.startsWith("google/")) {
-        console.warn(
+        skip(
           "[subagent-stress] skip: set OPENCLAW_LIVE_SUBAGENT_E2E_MODEL=google/gemini-3.1-pro-preview",
         );
         return;
@@ -668,7 +670,7 @@ describeLive("subagent announce live", () => {
       requireLiveSubagentAuth(modelConfig);
 
       const token = `subagent-stress-${randomUUID()}`;
-      const port = 30_000 + Math.floor(Math.random() * 10_000);
+      const port = await getFreePort();
       const nonce = randomBytes(3).toString("hex").toUpperCase();
       const sessionKey = `agent:main:live-subagent-stress-${nonce.toLowerCase()}`;
       const childTokens = [1, 2, 3].map((index) => `GEMINI_STRESS_${nonce}_${index}`);
@@ -682,7 +684,7 @@ describeLive("subagent announce live", () => {
           OPENCLAW_SKIP_CRON: "1",
           OPENCLAW_SKIP_BROWSER_CONTROL_SERVER: "1",
           OPENCLAW_SKIP_CANVAS_HOST: "1",
-          OPENCLAW_TEST_MINIMAL_GATEWAY: "1",
+          OPENCLAW_TEST_MINIMAL_GATEWAY: "0",
           OPENCLAW_DISABLE_BUNDLED_PLUGINS: undefined,
           OPENCLAW_BUNDLED_PLUGINS_DIR: path.resolve("extensions"),
           OPENCLAW_TEST_TRUST_BUNDLED_PLUGINS_DIR: "1",
@@ -717,7 +719,7 @@ describeLive("subagent announce live", () => {
         }),
       );
       clearRuntimeConfigSnapshot();
-      clearPluginMetadataLifecycleCaches();
+      resetPluginRuntimeStateForTest();
 
       server = await startGatewayServer(port, {
         bind: "loopback",


### PR DESCRIPTION
Related: #132277

## What Problem This Solves

The live subagent announce fixture retains synthetic channel registry state from global test setup, which can send its handshake into unrelated bundled account inspection. Once the handshake reaches agent work, its deliberately minimal Gateway lacks the prepared runtime that the scenario requires.

## Why This Change Was Made

Reset plugin runtime through the canonical test owner and use normal Gateway startup for the three announce scenarios. Reuse the existing free-port helper and report the two optional scenarios as actual Vitest skips rather than false passes. The original parent/active-child steering, completion and in-process continuation assertions remain unchanged; no diagnostic scaffolding is included.

The initially included agent-RPC fixture delta has been removed because #132277 already landed the equivalent repair, including startup-settled waiting, environment restoration and stronger cleanup. This PR now changes only `src/agents/subagents/announce/subagent-announce.live.test.ts`. It preserves every current-main addition from that repair and does not change minimal startup globally.

## User Impact

No production behavior changes. The announce fixture uses the startup and registry ownership needed for real agent work, and optional scenarios are honestly reported as skipped. This does not fix the independent native source/Jiti publication split or the separate closing-transport hello defect tracked in #132359.

## Evidence

The original announce reproduction repeatedly closed after a delayed hello before sending its initial request. Source/CPU tracing tied the delay to inherited synthetic channel plugins entering real bundled account inspection. A canonical registry reset repaired initial send, which then exposed missing prepared runtime under minimal startup. Normal startup completed the original live flow.

[Final reduced announce proof](https://github.com/openclaw/openclaw/actions/runs/33229517620) passed the full parent/active-child steer/completion/in-process continuation case with public Luna and recorded two actual optional skips. All 34,738 tracked files, modes and symlink targets matched tree `461d5dbd803e08bb20d0fe3399bfbead16031ca0` before and after. The announce delta is exactly the compact `bd2264498112625d32586520474c0991be6121c4` change; earlier diagnostic stacks are excluded. This is original-source live evidence, not new-main inference proof.

Author base `383a293b32d97254014437430b62aaf406bc11ac`: the complete changed gate and fresh restricted Codex review passed for the original two-file patch. The first review engine invocation failed without a verdict; one bounded retry completed. A new complete restricted review of the final one-file branch passed after deduplication with no actionable findings, retaining the unchanged secret scan and isolation (6,531-byte nonempty review bundle). No production/runtime owner was changed by narrowing the PR.

Retained failures from the superseded agent-RPC delta: local minimal-startup siblings timed out at their original 120-second and 90-second budgets, and the selected RPC case timed out at 90 seconds after its canonical build completed. A fresh secretless Linux attempt at old head `468f691f370b30eb6b983242fca877efba1a5014` was intentionally stopped during the cold build after the main repair was discovered; the command exited 255 and produced no test verdict. These are not announce failures or green proof. Its lease was released. The existing #132277 repair has independently verified exact-head CI [33230159889](https://github.com/openclaw/openclaw/actions/runs/33230159889) at `abe754973f187f04f3e8500fe5b8d76e6325f622`, merged as `59478e6bde59f8bcdfdc37894e2bff4e8a81a7db`; its proof is not relabeled as this PR's test run.

Source evidence map: `test/setup-openclaw-runtime.ts` seeds the synthetic plugin registry; `server-startup-plugins.ts` inherits it only for minimal test startup. `resetPluginRuntimeStateForTest` clears registry and metadata through the existing test owner. Normal `server-startup-finish.ts` / `server-startup-post-attach.ts` startup publishes the prepared model runtime before real agent work. The Vitest 4.1.11 `context.skip` / `failTask` contract records the two optional cases as skipped. Complete fixture, startup/reset owners, announce coordinator/delivery/dispatch paths and dependency contract were read. Current-main announce fixture bytes are unchanged from the original patch base.

```sh
OPENCLAW_VITEST_MAX_WORKERS=2 node scripts/check-changed.mjs --base 383a293b32d97254014437430b62aaf406bc11ac -- src/gateway/gateway.test.ts src/agents/subagents/announce/subagent-announce.live.test.ts
```

That completed gate covered the original superset; the final delta keeps only the unchanged announce file. Production delta **0**; one existing live test **+17/-15**. No runtime publication, model, config, schema, dependency, timeout, retry or changelog changes. The original full release campaign remains red.


## Current main refresh

Refreshed to `24e12d4403571582d61e9c33c15efa9849f23ef6`; published head `b3831a5efe6fa9d88db032dd4db87887a17bd519` preserves the exact approved announce postimage and **+17/-15 test-only** scope. The old CI failure was the QA bootstrap suppression inventory, already repaired on main by `2b1eee0d688a2e9163015769f7d18ed1937fa522` (#132394). No QA implementation or baseline change is included here.

Fresh restricted, nonempty Codex review reported no actionable findings. The complete one-file changed gate passed, including canonical unused-code checks, core graph checks, all core test type graphs and lint. Focused current-main proof passed all 118 startup cases and all 4 suppression-guard cases. Registry sibling tests had 7 passes and 2 failures at their unchanged 500 ms first-cleanup signal deadline; the identical command on clean main reproduced the same two failures. Named follow-up: the runtime-registry cleanup fixture's initial dynamic-import startup is coupled to that deadline. No timeout or assertion was weakened.

The original live result above remains tied to its original source; it is not a new-head live rerun. Fresh exact-head CI is required before native preparation.
