### PR TITLE
feat: let voice agents hang up when the conversation is over

### DIFF
--- a/extensions/voice-call/src/manager.agent-hangup.test.ts
+++ b/extensions/voice-call/src/manager.agent-hangup.test.ts
@@ -2,13 +2,6 @@
 import { describe, expect, it, vi } from "vitest";
 import { createManagerHarness, FakeProvider, markCallAnswered } from "./manager.test-harness.js";
 
-/** Provider whose playback is mark-confirmed, so `playTts` resolves after audio drains. */
-class DrainConfirmingProvider extends FakeProvider {
-  awaitsPlaybackCompletion(): boolean {
-    return true;
-  }
-}
-
 async function answeredCall(manager: Awaited<ReturnType<typeof createManagerHarness>>["manager"]) {
   const { callId } = await manager.initiateCall("+15550000020");
   if (!callId) {
@@ -22,14 +15,14 @@ describe("CallManager agent-requested hangup", () => {
   it("hangs up without a grace delay when the provider confirms playback drain", async () => {
     vi.useFakeTimers();
     try {
-      const provider = new DrainConfirmingProvider("plivo");
+      const provider = new FakeProvider("plivo");
       const { manager } = await createManagerHarness(
         { outbound: { notifyHangupDelaySec: 5 } },
         provider,
       );
       const callId = await answeredCall(manager);
 
-      manager.endCallAfterPlayback(callId, "Agent hangup");
+      manager.endCallAfterPlayback(callId, "Agent hangup", "confirmed");
       await vi.advanceTimersByTimeAsync(0);
 
       expect(provider.hangupCalls).toHaveLength(1);
@@ -48,7 +41,7 @@ describe("CallManager agent-requested hangup", () => {
       );
       const callId = await answeredCall(manager);
 
-      manager.endCallAfterPlayback(callId, "Agent hangup");
+      manager.endCallAfterPlayback(callId, "Agent hangup", "unconfirmed");
       await vi.advanceTimersByTimeAsync(0);
       expect(provider.hangupCalls).toHaveLength(0);
 
@@ -60,14 +53,35 @@ describe("CallManager agent-requested hangup", () => {
   });
 
   it("ignores a hangup request for a call that already ended", async () => {
-    const provider = new DrainConfirmingProvider("plivo");
+    const provider = new FakeProvider("plivo");
     const { manager } = await createManagerHarness({}, provider);
     const callId = await answeredCall(manager);
     await manager.endCall(callId);
     const hangupsAfterEnd = provider.hangupCalls.length;
 
-    manager.endCallAfterPlayback(callId, "Agent hangup");
+    manager.endCallAfterPlayback(callId, "Agent hangup", "confirmed");
 
     expect(provider.hangupCalls).toHaveLength(hangupsAfterEnd);
+  });
+
+  it("keeps the line open when the caller barges in over the closing reply", async () => {
+    vi.useFakeTimers();
+    try {
+      const provider = new FakeProvider("plivo");
+      const { manager } = await createManagerHarness(
+        { outbound: { notifyHangupDelaySec: 1 } },
+        provider,
+      );
+      const callId = await answeredCall(manager);
+
+      manager.endCallAfterPlayback(callId, "Agent hangup", "cancelled");
+      await vi.advanceTimersByTimeAsync(0);
+      await vi.advanceTimersByTimeAsync(60_000);
+
+      expect(provider.hangupCalls).toHaveLength(0);
+      expect(manager.getCall(callId)).toBeDefined();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/extensions/voice-call/src/manager.agent-hangup.test.ts
+++ b/extensions/voice-call/src/manager.agent-hangup.test.ts
@@ -1,0 +1,73 @@
+// Voice Call tests cover agent-requested hangup timing after playback.
+import { describe, expect, it, vi } from "vitest";
+import { createManagerHarness, FakeProvider, markCallAnswered } from "./manager.test-harness.js";
+
+/** Provider whose playback is mark-confirmed, so `playTts` resolves after audio drains. */
+class DrainConfirmingProvider extends FakeProvider {
+  awaitsPlaybackCompletion(): boolean {
+    return true;
+  }
+}
+
+async function answeredCall(manager: Awaited<ReturnType<typeof createManagerHarness>>["manager"]) {
+  const { callId } = await manager.initiateCall("+15550000020");
+  if (!callId) {
+    throw new Error("expected an initiated call");
+  }
+  markCallAnswered(manager, callId, "evt-agent-hangup-answered");
+  return callId;
+}
+
+describe("CallManager agent-requested hangup", () => {
+  it("hangs up without a grace delay when the provider confirms playback drain", async () => {
+    vi.useFakeTimers();
+    try {
+      const provider = new DrainConfirmingProvider("plivo");
+      const { manager } = await createManagerHarness(
+        { outbound: { notifyHangupDelaySec: 5 } },
+        provider,
+      );
+      const callId = await answeredCall(manager);
+
+      manager.endCallAfterPlayback(callId, "Agent hangup");
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(provider.hangupCalls).toHaveLength(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("waits the notify grace when the provider only acknowledges playback requests", async () => {
+    vi.useFakeTimers();
+    try {
+      const provider = new FakeProvider("plivo");
+      const { manager } = await createManagerHarness(
+        { outbound: { notifyHangupDelaySec: 3 } },
+        provider,
+      );
+      const callId = await answeredCall(manager);
+
+      manager.endCallAfterPlayback(callId, "Agent hangup");
+      await vi.advanceTimersByTimeAsync(0);
+      expect(provider.hangupCalls).toHaveLength(0);
+
+      await vi.advanceTimersByTimeAsync(3_000);
+      expect(provider.hangupCalls).toHaveLength(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("ignores a hangup request for a call that already ended", async () => {
+    const provider = new DrainConfirmingProvider("plivo");
+    const { manager } = await createManagerHarness({}, provider);
+    const callId = await answeredCall(manager);
+    await manager.endCall(callId);
+    const hangupsAfterEnd = provider.hangupCalls.length;
+
+    manager.endCallAfterPlayback(callId, "Agent hangup");
+
+    expect(provider.hangupCalls).toHaveLength(hangupsAfterEnd);
+  });
+});

--- a/extensions/voice-call/src/manager.agent-hangup.test.ts
+++ b/extensions/voice-call/src/manager.agent-hangup.test.ts
@@ -84,4 +84,47 @@ describe("CallManager agent-requested hangup", () => {
       vi.useRealTimers();
     }
   });
+
+  it("cancels a pending grace hangup when the caller speaks again", async () => {
+    vi.useFakeTimers();
+    try {
+      const provider = new FakeProvider("plivo");
+      const { manager } = await createManagerHarness(
+        { outbound: { notifyHangupDelaySec: 3 } },
+        provider,
+      );
+      const callId = await answeredCall(manager);
+      const call = manager.getCall(callId);
+
+      manager.endCallAfterPlayback(callId, "Agent hangup", "unconfirmed");
+      await vi.advanceTimersByTimeAsync(1_000);
+      expect(provider.hangupCalls).toHaveLength(0);
+
+      // Caller resumes mid-grace: the stale hangup must not fire.
+      manager.processEvent({
+        id: "evt-agent-hangup-resumed",
+        type: "call.speech",
+        callId,
+        providerCallId: call?.providerCallId,
+        timestamp: Date.now(),
+        transcript: "wait are you still there",
+        isFinal: true,
+      });
+      await vi.advanceTimersByTimeAsync(10_000);
+
+      expect(provider.hangupCalls).toHaveLength(0);
+      expect(manager.getCall(callId)).toBeDefined();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("ends the call when the agent signs off without closing words", async () => {
+    const provider = new FakeProvider("plivo");
+    const { manager } = await createManagerHarness({}, provider);
+    const callId = await answeredCall(manager);
+
+    manager.endCallAfterPlayback(callId, "Agent hangup", undefined);
+    await vi.waitFor(() => expect(provider.hangupCalls).toHaveLength(1));
+  });
 });

--- a/extensions/voice-call/src/manager.test-harness.ts
+++ b/extensions/voice-call/src/manager.test-harness.ts
@@ -234,6 +234,7 @@ export function createEventManagerHarness() {
       endCallOperations: new Map(),
       transcriptWaiters: new Map(),
       maxDurationTimers: new Map(),
+      pendingHangupTimers: new Map(),
       initialMessageInFlight: new Set(),
       ...overrides,
     };

--- a/extensions/voice-call/src/manager.ts
+++ b/extensions/voice-call/src/manager.ts
@@ -91,6 +91,7 @@ export class CallManager {
     }
   >();
   private maxDurationTimers = new Map<CallId, NodeJS.Timeout>();
+  private pendingHangupTimers = new Map<CallId, NodeJS.Timeout>();
   private initialMessageInFlight = new Set<CallId>();
 
   /**
@@ -348,7 +349,7 @@ export class CallManager {
   /**
    * End an active call once its last reply has finished playing to the caller.
    */
-  endCallAfterPlayback(callId: CallId, label: string, playback: PlaybackOutcome): void {
+  endCallAfterPlayback(callId: CallId, label: string, playback: PlaybackOutcome | undefined): void {
     scheduleHangupAfterPlaybackWithContext(this.getContext(), callId, label, playback);
   }
 
@@ -367,6 +368,7 @@ export class CallManager {
       endCallOperations: this.endCallOperations,
       transcriptWaiters: this.transcriptWaiters,
       maxDurationTimers: this.maxDurationTimers,
+      pendingHangupTimers: this.pendingHangupTimers,
       initialMessageInFlight: this.initialMessageInFlight,
       onCallAnswered: (call) => {
         this.maybeSpeakInitialMessageOnAnswered(call);

--- a/extensions/voice-call/src/manager.ts
+++ b/extensions/voice-call/src/manager.ts
@@ -13,6 +13,7 @@ import {
   scheduleHangupAfterPlayback as scheduleHangupAfterPlaybackWithContext,
   sendDtmf as sendDtmfWithContext,
   speak as speakWithContext,
+  type SpeakResult,
   speakInitialMessage as speakInitialMessageWithContext,
   type SpeakOptions,
 } from "./manager/outbound.js";
@@ -33,6 +34,7 @@ import {
   type EndReason,
   type NormalizedEvent,
   type OutboundCallOptions,
+  type PlaybackOutcome,
 } from "./types.js";
 import { resolveUserPath } from "./utils.js";
 
@@ -308,11 +310,7 @@ export class CallManager {
   /**
    * Speak to user in an active call.
    */
-  async speak(
-    callId: CallId,
-    text: string,
-    options?: SpeakOptions,
-  ): Promise<{ success: boolean; error?: string }> {
+  async speak(callId: CallId, text: string, options?: SpeakOptions): Promise<SpeakResult> {
     return speakWithContext(this.getContext(), callId, text, options);
   }
 
@@ -350,8 +348,8 @@ export class CallManager {
   /**
    * End an active call once its last reply has finished playing to the caller.
    */
-  endCallAfterPlayback(callId: CallId, label: string): void {
-    scheduleHangupAfterPlaybackWithContext(this.getContext(), callId, label);
+  endCallAfterPlayback(callId: CallId, label: string, playback: PlaybackOutcome): void {
+    scheduleHangupAfterPlaybackWithContext(this.getContext(), callId, label, playback);
   }
 
   private getContext(): CallManagerContext {

--- a/extensions/voice-call/src/manager.ts
+++ b/extensions/voice-call/src/manager.ts
@@ -10,6 +10,7 @@ import {
   continueCall as continueCallWithContext,
   endCall as endCallWithContext,
   initiateCall as initiateCallWithContext,
+  scheduleHangupAfterPlayback as scheduleHangupAfterPlaybackWithContext,
   sendDtmf as sendDtmfWithContext,
   speak as speakWithContext,
   speakInitialMessage as speakInitialMessageWithContext,
@@ -344,6 +345,13 @@ export class CallManager {
    */
   endCall(callId: CallId, options?: { reason?: EndReason }): Promise<CallEndResult> {
     return endCallWithContext(this.getContext(), callId, options);
+  }
+
+  /**
+   * End an active call once its last reply has finished playing to the caller.
+   */
+  endCallAfterPlayback(callId: CallId, label: string): void {
+    scheduleHangupAfterPlaybackWithContext(this.getContext(), callId, label);
   }
 
   private getContext(): CallManagerContext {

--- a/extensions/voice-call/src/manager/context.ts
+++ b/extensions/voice-call/src/manager/context.ts
@@ -33,6 +33,8 @@ type CallManagerTransientState = {
   endCallOperations: Map<CallId, Promise<CallEndResult>>;
   transcriptWaiters: Map<CallId, TranscriptWaiter>;
   maxDurationTimers: Map<CallId, NodeJS.Timeout>;
+  /** Grace-period hangups awaiting their delay; cancelled when the caller speaks again. */
+  pendingHangupTimers: Map<CallId, NodeJS.Timeout>;
   initialMessageInFlight: Set<CallId>;
 };
 

--- a/extensions/voice-call/src/manager/events.ts
+++ b/extensions/voice-call/src/manager/events.ts
@@ -10,7 +10,7 @@ import type { CallRecord, NormalizedEvent } from "../types.js";
 import type { CallManagerContext } from "./context.js";
 import { finalizeCall } from "./lifecycle.js";
 import { findCall } from "./lookup.js";
-import { endCall } from "./outbound.js";
+import { cancelPendingHangup, endCall } from "./outbound.js";
 import {
   appendCallReplayKey,
   releaseRejectedProviderCall,
@@ -35,6 +35,7 @@ type EventContext = Pick<
   | "storePath"
   | "transcriptWaiters"
   | "maxDurationTimers"
+  | "pendingHangupTimers"
   | "endCallOperations"
   | "onCallAnswered"
   | "streamSessionIssuer"
@@ -346,6 +347,8 @@ export function processEvent(ctx: EventContext, event: NormalizedEvent): Process
             result = { kind: "ignored" };
             break;
           }
+          // Fresh caller speech supersedes any grace-period hangup from the last turn.
+          cancelPendingHangup(ctx, activeCall.callId, "caller resumed");
           addTranscriptEntry(activeCall, "user", event.transcript);
           result = {
             kind: "final-speech",

--- a/extensions/voice-call/src/manager/lifecycle.ts
+++ b/extensions/voice-call/src/manager/lifecycle.ts
@@ -14,7 +14,9 @@ type CallLifecycleContext = Pick<
   CallManagerContext,
   "activeCalls" | "providerCallIdMap" | "storePath"
 > &
-  Partial<Pick<CallManagerContext, "transcriptWaiters" | "maxDurationTimers">>;
+  Partial<
+    Pick<CallManagerContext, "transcriptWaiters" | "maxDurationTimers" | "pendingHangupTimers">
+  >;
 
 /** Remove a provider-call mapping only when it still points at this call. */
 function removeProviderCallMapping(
@@ -53,6 +55,11 @@ export function finalizeCall(params: {
 
   if (ctx.maxDurationTimers) {
     clearMaxDurationTimer({ maxDurationTimers: ctx.maxDurationTimers }, call.callId);
+  }
+  const pendingHangup = ctx.pendingHangupTimers?.get(call.callId);
+  if (pendingHangup) {
+    clearTimeout(pendingHangup);
+    ctx.pendingHangupTimers?.delete(call.callId);
   }
   if (ctx.transcriptWaiters) {
     rejectTranscriptWaiter(

--- a/extensions/voice-call/src/manager/outbound.test.ts
+++ b/extensions/voice-call/src/manager/outbound.test.ts
@@ -364,7 +364,7 @@ describe("voice-call outbound helpers", () => {
 
     await expect(
       speak(ctx as never, "call-1", "hello", { listenAfterPlayback: true }),
-    ).resolves.toEqual({ success: true });
+    ).resolves.toEqual({ success: true, playback: "unconfirmed" });
     expect(transitionStateMock).toHaveBeenCalledWith(call, "speaking");
     expect(playTts).toHaveBeenCalledWith({
       callId: "call-1",
@@ -381,6 +381,7 @@ describe("voice-call outbound helpers", () => {
     await expect(speak(ctx as never, "call-1", "hello again")).resolves.toEqual({
       success: false,
       error: "tts failed",
+      playback: "unconfirmed",
     });
     expect(transitionStateMock).toHaveBeenLastCalledWith(call, "listening");
   });
@@ -411,6 +412,7 @@ describe("voice-call outbound helpers", () => {
 
     await expect(continueCall(ctx as never, "call-1", "hello")).resolves.toEqual({
       success: false,
+      playback: "unconfirmed",
       error: "Telephony TTS queue is full for stream; maxPending=8",
     });
 
@@ -440,7 +442,10 @@ describe("voice-call outbound helpers", () => {
       storePath: "/tmp/voice-call.json",
     };
 
-    await expect(speak(ctx as never, "call-1", "hello")).resolves.toEqual({ success: true });
+    await expect(speak(ctx as never, "call-1", "hello")).resolves.toEqual({
+      success: true,
+      playback: "unconfirmed",
+    });
 
     expect(playTts).toHaveBeenCalledWith({
       callId: "call-1",
@@ -511,7 +516,10 @@ describe("voice-call outbound helpers", () => {
       storePath: "/tmp/voice-call.json",
     };
 
-    await expect(speak(ctx as never, "call-1", "hello")).resolves.toEqual({ success: true });
+    await expect(speak(ctx as never, "call-1", "hello")).resolves.toEqual({
+      success: true,
+      playback: "unconfirmed",
+    });
 
     expect(playTts).toHaveBeenCalledWith({
       callId: "call-1",
@@ -545,7 +553,10 @@ describe("voice-call outbound helpers", () => {
       storePath: "/tmp/voice-call.json",
     };
 
-    await expect(speak(ctx as never, "call-1", "hello")).resolves.toEqual({ success: true });
+    await expect(speak(ctx as never, "call-1", "hello")).resolves.toEqual({
+      success: true,
+      playback: "unconfirmed",
+    });
 
     expect(playTts).toHaveBeenCalledWith({
       callId: "call-1",
@@ -669,7 +680,7 @@ describe("voice-call outbound helpers", () => {
         "missing",
         "hello",
       ),
-    ).resolves.toEqual({ success: false, error: "Call not found" });
+    ).resolves.toEqual({ success: false, error: "Call not found", playback: "unconfirmed" });
 
     await expect(
       endCall(

--- a/extensions/voice-call/src/manager/outbound.test.ts
+++ b/extensions/voice-call/src/manager/outbound.test.ts
@@ -472,6 +472,7 @@ describe("voice-call outbound helpers", () => {
       providerCallIdMap: new Map([["provider-1", "call-1"]]),
       provider: { name: "twilio", playTts },
       initialMessageInFlight: new Set(),
+      pendingHangupTimers: new Map(),
       config: {
         outbound: { notifyHangupDelaySec: Number.MAX_SAFE_INTEGER },
         tts: { provider: "openai", providers: { openai: { voice: "alloy" } } },

--- a/extensions/voice-call/src/manager/outbound.ts
+++ b/extensions/voice-call/src/manager/outbound.ts
@@ -15,6 +15,7 @@ import {
   type CallId,
   type CallRecord,
   type OutboundCallOptions,
+  type PlaybackOutcome,
 } from "../types.js";
 import { mapVoiceToPolly } from "../voice-mapping.js";
 import type { CallEndResult, CallManagerContext } from "./context.js";
@@ -278,15 +279,22 @@ export type SpeakOptions = {
   listenAfterPlayback?: boolean;
 };
 
+export type SpeakResult = {
+  success: boolean;
+  error?: string;
+  /** What happened to this playback; "unconfirmed" when the provider cannot tell. */
+  playback: PlaybackOutcome;
+};
+
 export async function speak(
   ctx: SpeakContext,
   callId: CallId,
   text: string,
   options?: SpeakOptions,
-): Promise<{ success: boolean; error?: string }> {
+): Promise<SpeakResult> {
   const connected = requireConnectedCall(ctx, callId);
   if (!connected.ok) {
-    return { success: false, error: connected.error };
+    return { success: false, error: connected.error, playback: "unconfirmed" };
   }
   const { call, providerCallId, provider } = connected;
 
@@ -305,7 +313,7 @@ export async function speak(
       resolveVoiceCallEffectiveConfig(ctx.config, numberRouteKey).config,
     );
     const playbackOptions = options?.listenAfterPlayback ? { listenAfterPlayback: true } : {};
-    await provider.playTts({
+    const playbackResult = await provider.playTts({
       callId,
       providerCallId,
       text,
@@ -316,12 +324,12 @@ export async function speak(
     addTranscriptEntry(call, "bot", text);
     persistCallRecord(ctx.storePath, call);
 
-    return { success: true };
+    return { success: true, playback: playbackResult?.playback ?? "unconfirmed" };
   } catch (err) {
     // A failed playback should not leave the call stuck in speaking state.
     transitionState(call, "listening");
     persistCallRecord(ctx.storePath, call);
-    return { success: false, error: formatErrorMessage(err) };
+    return { success: false, error: formatErrorMessage(err), playback: "unconfirmed" };
   }
 }
 
@@ -370,18 +378,24 @@ export async function sendDtmf(
 /**
  * Hang up once the final reply has reached the caller.
  *
- * Providers that confirm playback drain (mark-acknowledged media streams) can end
- * immediately because `speak` already awaited the audio. Providers that only
- * acknowledge a playback request get the configured notify grace instead, so the
- * closing words are not cut off mid-sentence.
+ * The decision follows what actually happened to that playback, not what the
+ * provider is capable of: a carrier-confirmed drain can end the call at once,
+ * an unobserved playback keeps the configured notify grace so closing words are
+ * not cut off, and a cancelled playback (caller barge-in) keeps the line open
+ * because the caller took the floor.
  */
 export function scheduleHangupAfterPlayback(
   ctx: SpeakContext,
   callId: CallId,
   label: string,
+  playback: PlaybackOutcome,
 ): void {
   const call = ctx.activeCalls.get(callId);
   if (!call || TerminalStates.has(call.state)) {
+    return;
+  }
+  if (playback === "cancelled") {
+    console.log(`[voice-call] ${label}: playback interrupted, keeping call ${callId} open`);
     return;
   }
   const hangUp = async () => {
@@ -397,10 +411,7 @@ export function scheduleHangupAfterPlayback(
     }
   };
 
-  const playbackConfirmed = Boolean(
-    call.providerCallId && ctx.provider?.awaitsPlaybackCompletion?.(call.providerCallId),
-  );
-  if (playbackConfirmed) {
+  if (playback === "confirmed") {
     console.log(`[voice-call] ${label}: playback drained, hanging up call ${callId}`);
     void hangUp();
     return;
@@ -459,7 +470,7 @@ export async function speakInitialMessage(
     }
 
     if (mode === "notify") {
-      scheduleHangupAfterPlayback(ctx, call.callId, "Notify mode");
+      scheduleHangupAfterPlayback(ctx, call.callId, "Notify mode", result.playback);
     } else if (
       mode === "conversation" &&
       ctx.provider &&

--- a/extensions/voice-call/src/manager/outbound.ts
+++ b/extensions/voice-call/src/manager/outbound.ts
@@ -367,6 +367,53 @@ export async function sendDtmf(
   }
 }
 
+/**
+ * Hang up once the final reply has reached the caller.
+ *
+ * Providers that confirm playback drain (mark-acknowledged media streams) can end
+ * immediately because `speak` already awaited the audio. Providers that only
+ * acknowledge a playback request get the configured notify grace instead, so the
+ * closing words are not cut off mid-sentence.
+ */
+export function scheduleHangupAfterPlayback(
+  ctx: SpeakContext,
+  callId: CallId,
+  label: string,
+): void {
+  const call = ctx.activeCalls.get(callId);
+  if (!call || TerminalStates.has(call.state)) {
+    return;
+  }
+  const hangUp = async () => {
+    const currentCall = ctx.activeCalls.get(callId);
+    if (!currentCall || TerminalStates.has(currentCall.state)) {
+      return;
+    }
+    const endResult = await endCall(ctx, callId, { reason: "hangup-bot" });
+    if (!endResult.success) {
+      console.warn(
+        `[voice-call] ${label} failed to hang up call ${callId}: ${endResult.error ?? "unknown error"}`,
+      );
+    }
+  };
+
+  const playbackConfirmed = Boolean(
+    call.providerCallId && ctx.provider?.awaitsPlaybackCompletion?.(call.providerCallId),
+  );
+  if (playbackConfirmed) {
+    console.log(`[voice-call] ${label}: playback drained, hanging up call ${callId}`);
+    void hangUp();
+    return;
+  }
+
+  const delaySec = ctx.config.outbound.notifyHangupDelaySec;
+  const delayMs = resolveVoiceCallSecondsTimerDelayMs(delaySec, 0);
+  console.log(`[voice-call] ${label}: auto-hangup in ${delaySec}s for call ${callId}`);
+  setTimeout(() => {
+    void hangUp();
+  }, delayMs);
+}
+
 export async function speakInitialMessage(
   ctx: ConversationContext,
   providerCallId: string,
@@ -412,23 +459,7 @@ export async function speakInitialMessage(
     }
 
     if (mode === "notify") {
-      const delaySec = ctx.config.outbound.notifyHangupDelaySec;
-      const delayMs = resolveVoiceCallSecondsTimerDelayMs(delaySec, 0);
-      console.log(`[voice-call] Notify mode: auto-hangup in ${delaySec}s for call ${call.callId}`);
-      setTimeout(() => {
-        void (async () => {
-          const currentCall = ctx.activeCalls.get(call.callId);
-          if (currentCall && !TerminalStates.has(currentCall.state)) {
-            console.log(`[voice-call] Notify mode: hanging up call ${call.callId}`);
-            const endResult = await endCall(ctx, call.callId);
-            if (!endResult.success) {
-              console.warn(
-                `[voice-call] Notify mode failed to hang up call ${call.callId}: ${endResult.error ?? "unknown error"}`,
-              );
-            }
-          }
-        })();
-      }, delayMs);
+      scheduleHangupAfterPlayback(ctx, call.callId, "Notify mode");
     } else if (
       mode === "conversation" &&
       ctx.provider &&

--- a/extensions/voice-call/src/manager/outbound.ts
+++ b/extensions/voice-call/src/manager/outbound.ts
@@ -52,6 +52,7 @@ type SpeakContext = Pick<
   | "storePath"
   | "transcriptWaiters"
   | "maxDurationTimers"
+  | "pendingHangupTimers"
   | "endCallOperations"
 >;
 
@@ -65,6 +66,7 @@ type ConversationContext = Pick<
   | "activeTurnCalls"
   | "transcriptWaiters"
   | "maxDurationTimers"
+  | "pendingHangupTimers"
   | "initialMessageInFlight"
   | "endCallOperations"
 >;
@@ -375,20 +377,37 @@ export async function sendDtmf(
   }
 }
 
+/** Drop a grace-period hangup that has not fired yet. */
+export function cancelPendingHangup(
+  ctx: Pick<CallManagerContext, "pendingHangupTimers">,
+  callId: CallId,
+  reason: string,
+): void {
+  const timer = ctx.pendingHangupTimers.get(callId);
+  if (!timer) {
+    return;
+  }
+  clearTimeout(timer);
+  ctx.pendingHangupTimers.delete(callId);
+  console.log(`[voice-call] Cancelled pending hangup for call ${callId} (${reason})`);
+}
+
 /**
  * Hang up once the final reply has reached the caller.
  *
  * The decision follows what actually happened to that playback, not what the
- * provider is capable of: a carrier-confirmed drain can end the call at once,
- * an unobserved playback keeps the configured notify grace so closing words are
- * not cut off, and a cancelled playback (caller barge-in) keeps the line open
- * because the caller took the floor.
+ * provider is capable of. A carrier-confirmed drain ends the call at once. An
+ * unobserved playback keeps the configured notify grace so closing words are not
+ * cut off, and that pending hangup is cancelled if the caller speaks again during
+ * the grace. A cancelled playback (caller barge-in) keeps the line open because
+ * the caller took the floor. Passing no outcome means nothing was played, so
+ * there is nothing to truncate and the call ends immediately.
  */
 export function scheduleHangupAfterPlayback(
   ctx: SpeakContext,
   callId: CallId,
   label: string,
-  playback: PlaybackOutcome,
+  playback: PlaybackOutcome | undefined,
 ): void {
   const call = ctx.activeCalls.get(callId);
   if (!call || TerminalStates.has(call.state)) {
@@ -399,6 +418,7 @@ export function scheduleHangupAfterPlayback(
     return;
   }
   const hangUp = async () => {
+    ctx.pendingHangupTimers.delete(callId);
     const currentCall = ctx.activeCalls.get(callId);
     if (!currentCall || TerminalStates.has(currentCall.state)) {
       return;
@@ -411,18 +431,23 @@ export function scheduleHangupAfterPlayback(
     }
   };
 
-  if (playback === "confirmed") {
-    console.log(`[voice-call] ${label}: playback drained, hanging up call ${callId}`);
+  if (playback !== "unconfirmed") {
+    const why = playback === "confirmed" ? "playback drained" : "nothing to play";
+    console.log(`[voice-call] ${label}: ${why}, hanging up call ${callId}`);
     void hangUp();
     return;
   }
 
+  cancelPendingHangup(ctx, callId, "superseded");
   const delaySec = ctx.config.outbound.notifyHangupDelaySec;
   const delayMs = resolveVoiceCallSecondsTimerDelayMs(delaySec, 0);
   console.log(`[voice-call] ${label}: auto-hangup in ${delaySec}s for call ${callId}`);
-  setTimeout(() => {
-    void hangUp();
-  }, delayMs);
+  ctx.pendingHangupTimers.set(
+    callId,
+    setTimeout(() => {
+      void hangUp();
+    }, delayMs),
+  );
 }
 
 export async function speakInitialMessage(

--- a/extensions/voice-call/src/media-stream.playback-marks.test.ts
+++ b/extensions/voice-call/src/media-stream.playback-marks.test.ts
@@ -118,6 +118,63 @@ describe("MediaStreamHandler playback marks", () => {
     }
   });
 
+  it("reports whether the carrier acknowledged the mark or the wait timed out", async () => {
+    const onConnect = vi.fn();
+    const handler = new MediaStreamHandler({
+      transcriptionProvider: createStubSttProvider(),
+      providerConfig: {},
+      shouldAcceptStream: () => true,
+      onConnect,
+    });
+    const server = await startWsServer(handler);
+    let ws: WebSocket | undefined;
+
+    try {
+      ws = await connectWs(server.url);
+      ws.send(
+        JSON.stringify({
+          event: "start",
+          streamSid: "MZ-ack",
+          start: { callSid: "CA-ack" },
+        }),
+      );
+      await vi.waitFor(() => expect(onConnect).toHaveBeenCalledOnce());
+
+      const acknowledgedMark = nextWsMessage(ws);
+      let acknowledged: boolean | undefined;
+      const playback = handler.queueTts("MZ-ack", async (signal) => {
+        acknowledged = await handler.sendMarkAndWait("MZ-ack", "tts-acked", 100, signal);
+      });
+      await withTimeout(acknowledgedMark);
+      ws.send(
+        JSON.stringify({
+          event: "mark",
+          streamSid: "MZ-ack",
+          mark: { name: "tts-acked" },
+        }),
+      );
+      await withTimeout(playback);
+      expect(acknowledged).toBe(true);
+
+      // Never echoed back: the local timeout resolves the wait as unconfirmed.
+      const timedOutMark = nextWsMessage(ws);
+      let timedOut: boolean | undefined;
+      const stalled = handler.queueTts("MZ-ack", async (signal) => {
+        timedOut = await handler.sendMarkAndWait("MZ-ack", "tts-timeout", 1, signal);
+      });
+      await withTimeout(timedOutMark);
+      // Waits out PLAYBACK_MARK_TIMEOUT_GRACE_MS (2s) with no echo from the carrier.
+      await withTimeout(stalled, 6_000);
+      expect(timedOut).toBe(false);
+
+      ws.close();
+      await waitForClose(ws);
+    } finally {
+      ws?.terminate();
+      await server.close();
+    }
+  });
+
   it("ignores a playback mark echoed after clear", async () => {
     const onConnect = vi.fn();
     const talkEvents: TalkEvent[] = [];

--- a/extensions/voice-call/src/media-stream.ts
+++ b/extensions/voice-call/src/media-stream.ts
@@ -84,7 +84,7 @@ type TtsQueueEntry = {
 };
 
 type PendingPlaybackMark = {
-  settle: (error?: Error, ignoreLateAck?: boolean) => void;
+  settle: (error?: Error, ignoreLateAck?: boolean, acknowledged?: boolean) => void;
 };
 
 type StreamSendResult = {
@@ -704,13 +704,18 @@ export class MediaStreamHandler {
     });
   }
 
-  /** Send a completion mark and wait until Twilio reports that buffered playback reached it. */
+  /**
+   * Send a completion mark and wait until Twilio reports that buffered playback reached it.
+   *
+   * Resolves `true` only when the carrier acknowledged the mark. A local timeout
+   * resolves `false` so callers can tell real playback completion from a guess.
+   */
   async sendMarkAndWait(
     streamSid: string,
     name: string,
     audioDurationMs: number,
     signal: AbortSignal,
-  ): Promise<void> {
+  ): Promise<boolean> {
     signal.throwIfAborted();
     const marks = this.getPendingPlaybackMarks(streamSid);
     if (marks.has(name)) {
@@ -719,11 +724,11 @@ export class MediaStreamHandler {
     this.ignoredPlaybackMarks.get(streamSid)?.delete(name);
 
     let pending!: PendingPlaybackMark;
-    const acknowledgement = new Promise<void>((resolve, reject) => {
+    const acknowledgement = new Promise<boolean>((resolve, reject) => {
       const timeout = setTimeout(
         () => {
           console.warn(`[MediaStream] Playback mark timed out; continuing stream=${streamSid}`);
-          pending.settle();
+          pending.settle(undefined, false, false);
         },
         Math.max(1, audioDurationMs + PLAYBACK_MARK_TIMEOUT_GRACE_MS),
       );
@@ -736,7 +741,7 @@ export class MediaStreamHandler {
         pending.settle(reason, true);
       };
       pending = {
-        settle: (error, ignoreLateAck = false) => {
+        settle: (error, ignoreLateAck = false, acknowledged = true) => {
           if (marks.get(name) !== pending) {
             return;
           }
@@ -752,7 +757,7 @@ export class MediaStreamHandler {
           if (error) {
             reject(error);
           } else {
-            resolve();
+            resolve(acknowledged);
           }
         },
       };

--- a/extensions/voice-call/src/providers/base.ts
+++ b/extensions/voice-call/src/providers/base.ts
@@ -76,6 +76,13 @@ export interface VoiceCallProvider {
   playTts(input: PlayTtsInput): Promise<void>;
 
   /**
+   * Whether `playTts` resolves only after the carrier confirms playback finished.
+   * Providers that merely acknowledge a playback request must leave this unset so
+   * callers keep a grace period before hanging up.
+   */
+  awaitsPlaybackCompletion?: (providerCallId: string) => boolean;
+
+  /**
    * Send DTMF digits to an active call.
    */
   sendDtmf?: (input: SendDtmfInput) => Promise<void>;

--- a/extensions/voice-call/src/providers/base.ts
+++ b/extensions/voice-call/src/providers/base.ts
@@ -7,6 +7,7 @@ import type {
   InitiateCallInput,
   InitiateCallResult,
   PlayTtsInput,
+  PlayTtsResult,
   ProviderName,
   SendDtmfInput,
   WebhookParseOptions,
@@ -72,15 +73,12 @@ export interface VoiceCallProvider {
   /**
    * Play TTS audio to the caller.
    * The provider should handle streaming if supported.
+   *
+   * Providers that can observe playback report its outcome so callers know
+   * whether the audio actually reached the caller. Returning nothing means
+   * "requested, outcome unknown".
    */
-  playTts(input: PlayTtsInput): Promise<void>;
-
-  /**
-   * Whether `playTts` resolves only after the carrier confirms playback finished.
-   * Providers that merely acknowledge a playback request must leave this unset so
-   * callers keep a grace period before hanging up.
-   */
-  awaitsPlaybackCompletion?: (providerCallId: string) => boolean;
+  playTts(input: PlayTtsInput): Promise<PlayTtsResult | void>;
 
   /**
    * Send DTMF digits to an active call.

--- a/extensions/voice-call/src/providers/twilio.test.ts
+++ b/extensions/voice-call/src/providers/twilio.test.ts
@@ -669,7 +669,7 @@ describe("TwilioProvider", () => {
         providerCallId: "CA-nostream",
         text: "Hello TwiML",
       }),
-    ).resolves.toBeUndefined();
+    ).resolves.toEqual({ playback: "unconfirmed" });
     expect(apiRequest).toHaveBeenCalledTimes(1);
     const [endpoint, params] = requireApiRequestCall(apiRequest) as [string, { Twiml?: string }];
     expect(endpoint).toBe("/Calls/CA-nostream.json");
@@ -694,7 +694,7 @@ describe("TwilioProvider", () => {
       expect(apiRequest).toHaveBeenCalledTimes(1);
 
       await vi.advanceTimersByTimeAsync(250);
-      await expect(playback).resolves.toBeUndefined();
+      await expect(playback).resolves.toEqual({ playback: "unconfirmed" });
 
       expect(apiRequest).toHaveBeenCalledTimes(2);
       expectApiRequestEndpoint(apiRequest, 0, "/Calls/CA-race-play.json");
@@ -938,7 +938,7 @@ describe("TwilioProvider", () => {
           voice: "default",
           locale: "en-US",
         }),
-      ).resolves.toBeUndefined();
+      ).resolves.toEqual({ playback: "cancelled" });
 
       expect(Date.now()).toBe(startedAt);
       expect(sendAudio).toHaveBeenCalledTimes(2);
@@ -1039,8 +1039,8 @@ describe("TwilioProvider", () => {
       text: "play next",
     });
 
-    await expect(cancelled).resolves.toBeUndefined();
-    await expect(next).resolves.toBeUndefined();
+    await expect(cancelled).resolves.toEqual({ playback: "cancelled" });
+    await expect(next).resolves.toEqual({ playback: "unconfirmed" });
     expect(synthesizeForTelephony).toHaveBeenCalledTimes(2);
   });
 });

--- a/extensions/voice-call/src/providers/twilio.ts
+++ b/extensions/voice-call/src/providers/twilio.ts
@@ -16,6 +16,8 @@ import type {
   InitiateCallResult,
   NormalizedEvent,
   PlayTtsInput,
+  PlayTtsResult,
+  PlaybackOutcome,
   ProviderWebhookParseResult,
   SendDtmfInput,
   StartListeningInput,
@@ -197,13 +199,6 @@ export class TwilioProvider implements VoiceCallProvider {
     }
     this.callStreamMap.delete(callSid);
     this.activeStreamCalls.delete(callSid);
-  }
-
-  /** Stream playback is mark-confirmed, so `playTts` resolves after audio drains. */
-  awaitsPlaybackCompletion(providerCallId: string): boolean {
-    return Boolean(
-      this.callStreamMap.has(providerCallId) && this.ttsProvider && this.mediaStreamHandler,
-    );
   }
 
   isConversationStreamConnectEnabled(): boolean {
@@ -624,7 +619,7 @@ export class TwilioProvider implements VoiceCallProvider {
    *    If telephony TTS is unavailable in that state, playback fails rather than mixing paths.
    * 2. TwiML <Say>: fallback only when there is no active stream for the call.
    */
-  async playTts(input: PlayTtsInput): Promise<void> {
+  async playTts(input: PlayTtsInput): Promise<PlayTtsResult> {
     const streamSid = this.callStreamMap.get(input.providerCallId);
     if (streamSid) {
       if (!this.ttsProvider || !this.mediaStreamHandler) {
@@ -634,8 +629,7 @@ export class TwilioProvider implements VoiceCallProvider {
       }
 
       try {
-        await this.playTtsViaStream(input.text, streamSid);
-        return;
+        return { playback: await this.playTtsViaStream(input.text, streamSid) };
       } catch (err) {
         console.warn(
           `[voice-call] Telephony TTS failed:`,
@@ -665,6 +659,8 @@ export class TwilioProvider implements VoiceCallProvider {
 </Response>`;
 
     await this.updateLiveCallTwiml(input.providerCallId, twiml, "playTts");
+    // TwiML <Say> only acknowledges the request; the carrier never reports completion.
+    return { playback: "unconfirmed" };
   }
 
   async sendDtmf(input: SendDtmfInput): Promise<void> {
@@ -687,7 +683,7 @@ export class TwilioProvider implements VoiceCallProvider {
    * Generates audio with core TTS, converts to mu-law, and streams via WebSocket.
    * Uses a queue to serialize playback and prevent overlapping audio.
    */
-  private async playTtsViaStream(text: string, streamSid: string): Promise<void> {
+  private async playTtsViaStream(text: string, streamSid: string): Promise<PlaybackOutcome> {
     if (!this.ttsProvider || !this.mediaStreamHandler) {
       throw new Error("TTS provider and media stream handler required");
     }
@@ -699,6 +695,8 @@ export class TwilioProvider implements VoiceCallProvider {
 
     const handler = this.mediaStreamHandler;
     const ttsProvider = this.ttsProvider;
+    // Set inside the queued playback; stays "cancelled" if it never reaches the mark.
+    let outcome: PlaybackOutcome = "cancelled";
 
     const normalizeSendResult = (raw: unknown): StreamSendResult => {
       if (!raw || typeof raw !== "object") {
@@ -806,14 +804,23 @@ export class TwilioProvider implements VoiceCallProvider {
       }
 
       if (signal.aborted) {
+        // Barge-in: the caller took the floor, so this reply never finished.
+        outcome = "cancelled";
         return;
       }
       if (chunkAttempts === 0 || chunkDelivered !== chunkAttempts) {
         throw new Error("Telephony stream playback failed: incomplete audio delivery");
       }
       const markName = `tts-${Date.now()}-${++this.playbackMarkSequence}`;
-      await handler.sendMarkAndWait(streamSid, markName, muLawAudio.length / 8, signal);
+      const acknowledged = await handler.sendMarkAndWait(
+        streamSid,
+        markName,
+        muLawAudio.length / 8,
+        signal,
+      );
+      outcome = acknowledged ? "confirmed" : "unconfirmed";
     });
+    return outcome;
   }
 
   /**

--- a/extensions/voice-call/src/providers/twilio.ts
+++ b/extensions/voice-call/src/providers/twilio.ts
@@ -199,6 +199,13 @@ export class TwilioProvider implements VoiceCallProvider {
     this.activeStreamCalls.delete(callSid);
   }
 
+  /** Stream playback is mark-confirmed, so `playTts` resolves after audio drains. */
+  awaitsPlaybackCompletion(providerCallId: string): boolean {
+    return Boolean(
+      this.callStreamMap.has(providerCallId) && this.ttsProvider && this.mediaStreamHandler,
+    );
+  }
+
   isConversationStreamConnectEnabled(): boolean {
     return Boolean(this.mediaStreamHandler && this.getStreamUrl());
   }

--- a/extensions/voice-call/src/response-generator.test.ts
+++ b/extensions/voice-call/src/response-generator.test.ts
@@ -628,6 +628,15 @@ describe("generateVoiceResponse", () => {
     expect(result.endCall).toBeUndefined();
   });
 
+  it("ignores an end_call flag in a reply that never parsed as JSON", async () => {
+    const { result } = await runGenerateVoiceResponse([
+      { text: 'Sure thing. {"spoken":"Bye now.","end_call":true' },
+    ]);
+
+    expect(result.text).toBe("Bye now.");
+    expect(result.endCall).toBeUndefined();
+  });
+
   it("reads end_call from fenced JSON", async () => {
     const { result } = await runGenerateVoiceResponse([
       { text: '```json\n{"spoken":"Goodbye.","end_call":true}\n```' },

--- a/extensions/voice-call/src/response-generator.test.ts
+++ b/extensions/voice-call/src/response-generator.test.ts
@@ -598,6 +598,60 @@ describe("generateVoiceResponse", () => {
     expect(result.text).toBeNull();
   });
 
+  it("reads the end_call hangup request from the spoken contract", async () => {
+    const { result } = await runGenerateVoiceResponse([
+      { text: '{"spoken":"Talk to you later.","end_call":true}' },
+    ]);
+
+    expect(result.text).toBe("Talk to you later.");
+    expect(result.endCall).toBe(true);
+  });
+
+  it("stays on the line when end_call is absent or false", async () => {
+    const { result: omitted } = await runGenerateVoiceResponse([
+      { text: '{"spoken":"Still here."}' },
+    ]);
+    const { result: explicitFalse } = await runGenerateVoiceResponse([
+      { text: '{"spoken":"Still here.","end_call":false}' },
+    ]);
+
+    expect(omitted.endCall).toBeUndefined();
+    expect(explicitFalse.endCall).toBeUndefined();
+  });
+
+  it("ignores a non-boolean end_call value", async () => {
+    const { result } = await runGenerateVoiceResponse([
+      { text: '{"spoken":"Still here.","end_call":"yes"}' },
+    ]);
+
+    expect(result.text).toBe("Still here.");
+    expect(result.endCall).toBeUndefined();
+  });
+
+  it("reads end_call from fenced JSON", async () => {
+    const { result } = await runGenerateVoiceResponse([
+      { text: '```json\n{"spoken":"Goodbye.","end_call":true}\n```' },
+    ]);
+
+    expect(result.text).toBe("Goodbye.");
+    expect(result.endCall).toBe(true);
+  });
+
+  it("hangs up on an end_call request that carries no closing words", async () => {
+    const { result } = await runGenerateVoiceResponse([{ text: '{"spoken":"","end_call":true}' }]);
+
+    expect(result.text).toBeNull();
+    expect(result.endCall).toBe(true);
+  });
+
+  it("advertises the end_call contract to the model", async () => {
+    const { runtime, runEmbeddedAgent } = createAgentRuntime([{ text: '{"spoken":"Hi."}' }]);
+    await runGenerateVoiceResponse([], { runtime });
+
+    const args = requireEmbeddedAgentArgs(runEmbeddedAgent);
+    expect(args.extraSystemPrompt).toContain('"end_call"');
+  });
+
   it("strips leading planning text when model returns plain text", async () => {
     const { result } = await runGenerateVoiceResponse([
       {

--- a/extensions/voice-call/src/response-generator.ts
+++ b/extensions/voice-call/src/response-generator.ts
@@ -214,10 +214,8 @@ function tryParseSpokenJson(text: string): SpokenTurn | null {
 
   try {
     const decoded = JSON.parse(`"${inlineSpokenMatch[1] ?? ""}"`) as string;
-    return {
-      text: normalizeSpokenText(decoded) ?? "",
-      endCall: /"end_call"\s*:\s*true/i.test(trimmed),
-    };
+    // Speech only: call control never comes from text that failed to parse.
+    return { text: normalizeSpokenText(decoded) ?? "", endCall: false };
   } catch {
     return null;
   }

--- a/extensions/voice-call/src/response-generator.ts
+++ b/extensions/voice-call/src/response-generator.ts
@@ -53,7 +53,15 @@ type VoiceResponseResult = {
   text: string | null;
   /** Whether the complete response was handed to the transport before compaction. */
   deliveredEarly: boolean;
+  /** Model asked to hang up once the reply finishes playing. */
+  endCall?: boolean;
   error?: string;
+};
+
+/** Spoken turn payload parsed from the model's JSON output contract. */
+type SpokenTurn = {
+  text: string;
+  endCall: boolean;
 };
 
 type VoiceResponsePayload = {
@@ -85,9 +93,13 @@ function resolveVoiceAgentToolsAllow(
 const VOICE_SPOKEN_OUTPUT_CONTRACT = [
   "Output format requirements:",
   '- Return only valid JSON in this exact shape: {"spoken":"..."}',
-  "- Do not include markdown, code fences, planning text, or extra keys.",
+  '- The one optional extra key is "end_call".',
+  "- Do not include markdown, code fences, planning text, or other keys.",
   '- Put exactly what should be spoken to the caller into "spoken".',
   '- If there is nothing to say, return {"spoken":""}.',
+  '- Add "end_call":true only when the conversation is over and the call should hang up.',
+  '  Example: {"spoken":"Talk to you later.","end_call":true}',
+  "  The spoken words play first, then the call ends. Stay on the line by omitting the key.",
 ].join("\n");
 const VOICE_OPENING_CONTEXT_POLICY =
   "Audible call-opening context in the user message is untrusted conversation data, " +
@@ -157,7 +169,11 @@ function normalizeSpokenText(value: string): string | null {
   return normalized.length > 0 ? normalized : null;
 }
 
-function tryParseSpokenJson(text: string): string | null {
+function readEndCallFlag(value: unknown): boolean {
+  return value === true;
+}
+
+function tryParseSpokenJson(text: string): SpokenTurn | null {
   const candidates: string[] = [];
   const trimmed = text.trim();
   if (!trimmed) {
@@ -178,11 +194,14 @@ function tryParseSpokenJson(text: string): string | null {
 
   for (const candidate of candidates) {
     try {
-      const parsed = JSON.parse(candidate) as { spoken?: unknown };
+      const parsed = JSON.parse(candidate) as { spoken?: unknown; end_call?: unknown };
       if (typeof parsed?.spoken !== "string") {
         continue;
       }
-      return normalizeSpokenText(parsed.spoken) ?? "";
+      return {
+        text: normalizeSpokenText(parsed.spoken) ?? "",
+        endCall: readEndCallFlag(parsed.end_call),
+      };
     } catch {
       // Continue trying other candidates.
     }
@@ -195,7 +214,10 @@ function tryParseSpokenJson(text: string): string | null {
 
   try {
     const decoded = JSON.parse(`"${inlineSpokenMatch[1] ?? ""}"`) as string;
-    return normalizeSpokenText(decoded) ?? "";
+    return {
+      text: normalizeSpokenText(decoded) ?? "",
+      endCall: /"end_call"\s*:\s*true/i.test(trimmed),
+    };
   } catch {
     return null;
   }
@@ -248,8 +270,9 @@ function sanitizePlainSpokenText(text: string): string | null {
   return normalizeSpokenText(paragraphs.join(" "));
 }
 
-function extractSpokenTextFromPayloads(payloads: VoiceResponsePayload[]): string | null {
+function extractSpokenTurnFromPayloads(payloads: VoiceResponsePayload[]): SpokenTurn | null {
   const spokenSegments: string[] = [];
+  let endCall = false;
 
   for (const payload of payloads) {
     if (payload.isError || payload.isReasoning) {
@@ -263,9 +286,10 @@ function extractSpokenTextFromPayloads(payloads: VoiceResponsePayload[]): string
 
     const structured = tryParseSpokenJson(rawText);
     if (structured !== null) {
-      if (structured.length > 0) {
-        spokenSegments.push(structured);
+      if (structured.text.length > 0) {
+        spokenSegments.push(structured.text);
       }
+      endCall ||= structured.endCall;
       continue;
     }
 
@@ -275,7 +299,10 @@ function extractSpokenTextFromPayloads(payloads: VoiceResponsePayload[]): string
     }
   }
 
-  return spokenSegments.length > 0 ? spokenSegments.join(" ").trim() : null;
+  if (spokenSegments.length === 0) {
+    return endCall ? { text: "", endCall } : null;
+  }
+  return { text: spokenSegments.join(" ").trim(), endCall };
 }
 
 async function deliverEarlyText(
@@ -437,7 +464,9 @@ export async function generateVoiceResponse(
         let latestToolBoundaryMessageIndex: number | undefined;
         let blockReplyBoundariesReliable = true;
         let deliveredEarly = false;
-        let lastFlushedText: string | null = null;
+        let lastFlushedTurn: SpokenTurn | null = null;
+        // Read through a closure so the flush callback's assignment stays visible to narrowing.
+        const readLastFlushedTurn = (): SpokenTurn | null => lastFlushedTurn;
 
         const result = await agentRuntime.runEmbeddedAgent({
           sessionId,
@@ -516,25 +545,32 @@ export async function generateVoiceResponse(
             if (deliveredEarly || !onEarlyText || !boundariesReliable) {
               return;
             }
-            const text = extractSpokenTextFromPayloads(pendingPayloads);
-            if (!text) {
+            const turn = extractSpokenTurnFromPayloads(pendingPayloads);
+            if (!turn) {
               return;
             }
-            lastFlushedText = text;
-            deliveredEarly = await deliverEarlyText(onEarlyText, text);
+            lastFlushedTurn = turn;
+            if (turn.text.length === 0) {
+              return;
+            }
+            deliveredEarly = await deliverEarlyText(onEarlyText, turn.text);
           },
         });
 
-        const text =
-          extractSpokenTextFromPayloads((result.payloads ?? []) as VoiceResponsePayload[]) ??
-          lastFlushedText ??
-          extractSpokenTextFromPayloads(blockReplyPayloads);
+        const finalTurn =
+          extractSpokenTurnFromPayloads((result.payloads ?? []) as VoiceResponsePayload[]) ??
+          readLastFlushedTurn() ??
+          extractSpokenTurnFromPayloads(blockReplyPayloads);
+        const text = finalTurn && finalTurn.text.length > 0 ? finalTurn.text : null;
+        // An early flush can carry the hangup request even when the final payloads are empty.
+        const endCall = (finalTurn?.endCall ?? false) || (readLastFlushedTurn()?.endCall ?? false);
 
         if (!text && result.meta?.aborted) {
           return { text: null, deliveredEarly: false, error: "Response generation was aborted" };
         }
 
-        return { text, deliveredEarly };
+        // Mirrors `error`: the key appears only when the model actually asked for it.
+        return { text, deliveredEarly, ...(endCall ? { endCall: true } : {}) };
       },
     );
   } catch (err) {

--- a/extensions/voice-call/src/types.ts
+++ b/extensions/voice-call/src/types.ts
@@ -270,6 +270,19 @@ export type PlayTtsInput = {
   listenAfterPlayback?: boolean;
 };
 
+/**
+ * Outcome of one playback request.
+ *
+ * - `confirmed`: the carrier acknowledged that buffered audio finished playing.
+ * - `unconfirmed`: playback was requested but completion was never observed.
+ * - `cancelled`: playback stopped early, e.g. the caller barged in.
+ */
+export type PlaybackOutcome = "confirmed" | "unconfirmed" | "cancelled";
+
+export type PlayTtsResult = {
+  playback: PlaybackOutcome;
+};
+
 export type SendDtmfInput = {
   callId: CallId;
   providerCallId: ProviderCallId;

--- a/extensions/voice-call/src/webhook.test.ts
+++ b/extensions/voice-call/src/webhook.test.ts
@@ -2244,6 +2244,37 @@ describe("VoiceCallWebhookServer classic response routing", () => {
     expect(endCallAfterPlayback).not.toHaveBeenCalled();
   });
 
+  it("ends the call for an end_call reply that carries no closing words", async () => {
+    const call = createCall(Date.now());
+    const speak = vi.fn(async () => ({ success: true, playback: "unconfirmed" }));
+    const endCallAfterPlayback = vi.fn();
+    const manager = {
+      getCall: (callId: string) => (callId === call.callId ? call : undefined),
+      speak,
+      endCallAfterPlayback,
+    } as unknown as CallManager;
+    const server = new VoiceCallWebhookServer(
+      createConfig({}),
+      manager,
+      provider,
+      {} as never,
+      undefined,
+      {} as never,
+    );
+    mocks.generateVoiceResponse
+      .mockReset()
+      .mockResolvedValue({ text: null, deliveredEarly: false, endCall: true });
+
+    await (
+      server as unknown as {
+        handleInboundResponse: (callId: string, message: string) => Promise<void>;
+      }
+    ).handleInboundResponse(call.callId, "bye");
+
+    expect(speak).not.toHaveBeenCalled();
+    expect(endCallAfterPlayback).toHaveBeenCalledWith(call.callId, "Agent hangup", undefined);
+  });
+
   it("forwards a barge-in so the hangup owner can keep the call open", async () => {
     const { call, endCallAfterPlayback } = await runClassicHangupTurn({
       speakResult: { success: true, playback: "cancelled" },

--- a/extensions/voice-call/src/webhook.test.ts
+++ b/extensions/voice-call/src/webhook.test.ts
@@ -2196,6 +2196,62 @@ describe("VoiceCallWebhookServer pre-auth webhook guards", () => {
 });
 
 describe("VoiceCallWebhookServer classic response routing", () => {
+  async function runClassicHangupTurn(params: {
+    speakResult: { success: boolean; error?: string; playback?: string };
+  }) {
+    const call = createCall(Date.now());
+    const speak = vi.fn(async () => params.speakResult);
+    const endCallAfterPlayback = vi.fn();
+    const manager = {
+      getCall: (callId: string) => (callId === call.callId ? call : undefined),
+      speak,
+      endCallAfterPlayback,
+    } as unknown as CallManager;
+    const server = new VoiceCallWebhookServer(
+      createConfig({}),
+      manager,
+      provider,
+      {} as never,
+      undefined,
+      {} as never,
+    );
+    mocks.generateVoiceResponse
+      .mockReset()
+      .mockResolvedValue({ text: "Talk soon", deliveredEarly: false, endCall: true });
+
+    await (
+      server as unknown as {
+        handleInboundResponse: (callId: string, message: string) => Promise<void>;
+      }
+    ).handleInboundResponse(call.callId, "bye");
+
+    return { call, speak, endCallAfterPlayback };
+  }
+
+  it("hands the observed playback outcome to the hangup when the agent asks to end", async () => {
+    const { call, endCallAfterPlayback } = await runClassicHangupTurn({
+      speakResult: { success: true, playback: "confirmed" },
+    });
+
+    expect(endCallAfterPlayback).toHaveBeenCalledWith(call.callId, "Agent hangup", "confirmed");
+  });
+
+  it("does not hang up when the closing reply failed to play", async () => {
+    const { endCallAfterPlayback } = await runClassicHangupTurn({
+      speakResult: { success: false, error: "synthetic tts failure" },
+    });
+
+    expect(endCallAfterPlayback).not.toHaveBeenCalled();
+  });
+
+  it("forwards a barge-in so the hangup owner can keep the call open", async () => {
+    const { call, endCallAfterPlayback } = await runClassicHangupTurn({
+      speakResult: { success: true, playback: "cancelled" },
+    });
+
+    expect(endCallAfterPlayback).toHaveBeenCalledWith(call.callId, "Agent hangup", "cancelled");
+  });
+
   it("keeps outbound calls on their frozen agent when the dialed number has an inbound route", async () => {
     const call = createCall(Date.now());
     call.agentId = "support";

--- a/extensions/voice-call/src/webhook.ts
+++ b/extensions/voice-call/src/webhook.ts
@@ -1091,8 +1091,11 @@ export class VoiceCallWebhookServer {
         finalPlayback = speakResult.playback;
       }
 
-      if (result.endCall && finalPlayback) {
-        this.logger.info(`Agent requested hangup for call ${callId}`);
+      if (result.endCall) {
+        // No playback outcome means the reply carried no audio, so nothing can be truncated.
+        this.logger.info(
+          `Agent requested hangup for call ${callId} (playback=${finalPlayback ?? "none"})`,
+        );
         this.manager.endCallAfterPlayback(callId, "Agent hangup", finalPlayback);
       }
     } catch (err) {

--- a/extensions/voice-call/src/webhook.ts
+++ b/extensions/voice-call/src/webhook.ts
@@ -1076,7 +1076,14 @@ export class VoiceCallWebhookServer {
 
       if (result.text && !result.deliveredEarly) {
         this.logger.info(`AI response delivered ${callId} chars=${result.text.length}`);
-        await this.manager.speak(callId, result.text, { listenAfterPlayback: true });
+        await this.manager.speak(callId, result.text, {
+          listenAfterPlayback: !result.endCall,
+        });
+      }
+
+      if (result.endCall) {
+        this.logger.info(`Agent requested hangup for call ${callId}`);
+        this.manager.endCallAfterPlayback(callId, "Agent hangup");
       }
     } catch (err) {
       this.logger.error(`Auto-response error: ${String(err)}`);

--- a/extensions/voice-call/src/webhook.ts
+++ b/extensions/voice-call/src/webhook.ts
@@ -40,7 +40,7 @@ import { isProviderStatusTerminal } from "./providers/shared/call-status.js";
 import type { TwilioProvider } from "./providers/twilio.js";
 import { normalizeProxyIp } from "./proxy-ip.js";
 import { resolveCallAgentId } from "./resolve-call-agent-id.js";
-import type { CallRecord, NormalizedEvent, WebhookContext } from "./types.js";
+import type { CallRecord, NormalizedEvent, PlaybackOutcome, WebhookContext } from "./types.js";
 import type { WebhookResponsePayload } from "./webhook.types.js";
 import type { RealtimeCallHandler } from "./webhook/realtime-handler.js";
 import { startStaleCallReaper } from "./webhook/stale-call-reaper.js";
@@ -1048,6 +1048,8 @@ export class VoiceCallWebhookServer {
 
     try {
       const { generateVoiceResponse } = await loadResponseGeneratorModule();
+      // Outcome of whichever playback delivered the reply; a hangup needs one.
+      let finalPlayback: PlaybackOutcome | undefined;
       const numberRouteKey = resolveVoiceCallNumberRouteKeyForCall(call);
       const effectiveConfig = resolveVoiceCallEffectiveConfig(this.config, numberRouteKey).config;
 
@@ -1065,6 +1067,9 @@ export class VoiceCallWebhookServer {
         onEarlyText: async (text) => {
           this.logger.info(`Early AI response queued ${callId} chars=${text.length}`);
           const speakResult = await this.manager.speak(callId, text, { listenAfterPlayback: true });
+          if (speakResult.success) {
+            finalPlayback = speakResult.playback;
+          }
           return speakResult.success;
         },
       });
@@ -1076,14 +1081,19 @@ export class VoiceCallWebhookServer {
 
       if (result.text && !result.deliveredEarly) {
         this.logger.info(`AI response delivered ${callId} chars=${result.text.length}`);
-        await this.manager.speak(callId, result.text, {
+        const speakResult = await this.manager.speak(callId, result.text, {
           listenAfterPlayback: !result.endCall,
         });
+        if (!speakResult.success) {
+          this.logger.warn(`Final reply playback failed ${callId}: ${speakResult.error}`);
+          return;
+        }
+        finalPlayback = speakResult.playback;
       }
 
-      if (result.endCall) {
+      if (result.endCall && finalPlayback) {
         this.logger.info(`Agent requested hangup for call ${callId}`);
-        this.manager.endCallAfterPlayback(callId, "Agent hangup");
+        this.manager.endCallAfterPlayback(callId, "Agent hangup", finalPlayback);
       }
     } catch (err) {
       this.logger.error(`Auto-response error: ${String(err)}`);


### PR DESCRIPTION
Closes #132334

## What Problem This Solves

An agent on a classic conversation-mode voice call cannot end the call it is on. Realtime calls get a bound `openclaw_end_call` control, but the classic flow (transcription plus text agent turn plus TTS) has no equivalent, so a call runs until the caller hangs up, `maxDurationSeconds` fires, or an operator runs `openclaw voicecall end`.

Callers hear the gap. On a live call before this change, asked to hang up, the agent answered: `"Right, I can't hang up from my end—just tap end call whenever you're ready!"` An outbound call that has delivered its message holds the line to the cap, spending carrier minutes and occupying a `maxConcurrentCalls` slot (default 1) that blocks the next call.

The existing `voice_call` tool does expose an `end_call` action, but `commandService.endCall` requires a `callId`, and `buildVoiceTurnPrompt` gives the model only bounded opening context plus the caller's latest message. The model has no call identity to pass.

## Why This Change Was Made

The spoken-output contract gains one optional key, so a reply can request its own hangup without a second tool surface:

```json
{"spoken": "Talk to you later.", "end_call": true}
```

`tryParseSpokenJson` returns a `SpokenTurn` (`text` plus `endCall`), `generateVoiceResponse` reports `endCall` the way it already reports `error` (present only when set), and `handleInboundResponse` ends the call after the reply has been spoken.

A flag rather than a tool call, because ordering matters: a mid-turn tool call ends the call before the closing sentence is spoken, which is what the realtime tool's own description warns about.

**Ending safely is decided by what happened to that playback, not by what the provider can do.** `playTts` now reports a `PlaybackOutcome`, and `speak` carries it up:

- `confirmed` — the carrier acknowledged the completion mark; hang up immediately, nothing is truncated.
- `unconfirmed` — playback was requested but completion was never observed; keep the `outbound.notifyHangupDelaySec` grace that notify mode already applies.
- `cancelled` — playback stopped early, i.e. the caller barged in; keep the line open, because the caller took the floor.

A failed `speak` never schedules a hangup at all. `sendMarkAndWait` now returns whether the carrier actually echoed the mark, so a local timeout is reported as `unconfirmed` rather than passed off as confirmed playback. Notify-mode and agent hangups share one `scheduleHangupAfterPlayback` helper.

The early-delivery path is preserved: a hangup requested on an early flush is remembered and honored after the final payloads settle, and the outcome of whichever playback delivered the reply is the one the hangup uses.

Call control is never inferred from text that failed to parse: the malformed-reply fallback returns speech only.

Non-goals: no config key, no change to realtime call control, no change to the `voice_call` tool.

## User Impact

Voice agents can end a call when the conversation is finished. The closing words play first, then the line drops — no waiting out `maxDurationSeconds`, no carrier minutes burned on a finished call, and the concurrent-call slot frees immediately. Interrupting the agent's goodbye keeps the call alive, and a failed closing reply never drops the caller silently.

Backward compatible. Replies without `end_call` behave exactly as before, plain-text replies still route through the existing sanitizer, and a non-boolean `end_call` is ignored.

## Evidence

Live calls on Twilio media streams with Deepgram transcription and ElevenLabs telephony TTS, `responseModel: anthropic/claude-sonnet-5`.

**Normal goodbye — unconfirmed playback takes the grace, then hangs up:**

```
01:25:37 [voice-call] Transcript: nothing much i'm very sleepy so you know let's talk later
01:25:39 [voice-call] Early AI response: "Get some rest, Prince—talk later!"
01:25:43 [voice-call] Agent requested hangup for call 9d9b9955… (playback=unconfirmed)
01:25:43 [voice-call] Agent hangup: auto-hangup in 3s for call 9d9b9955…
```

**Barge-in over the closing reply — the call survives:**

```
01:27:04 [voice-call] Early AI response: "Bye bye!"
01:27:05 [voice-call] Agent requested hangup for call 7749d64c… (playback=cancelled)
01:27:05 [voice-call] Agent hangup: playback interrupted, keeping call 7749d64c… open
01:27:06 [voice-call] Transcript: wait wait wait are you here
01:27:07 [voice-call] Early AI response: "Yep, still here—what's up?"
```

The caller cut off the goodbye, the hangup was suppressed, and the conversation continued. Before this revision the same interruption ended the call.

Scope of the live runs: they exercise the `cancelled` and `unconfirmed` branches against a release build of the installed plugin, because the local install is 2026.7.1-2 while this branch targets main. That build sends the completion mark without awaiting the carrier echo, so it cannot produce `confirmed`; the immediate-hangup branch is covered by tests rather than by these traces. An earlier trace on the pre-review revision showed the agent ending a call after its closing words played.

**Tests** — `pnpm test:extension voice-call`: 736 passed (64 files), 13 of them new.

- `response-generator.test.ts` — hangup request, absent and explicit-false replies, non-boolean ignored, fenced JSON, hangup with no closing words, contract reaches the prompt, and an `end_call` inside a reply that never parsed as JSON is ignored.
- `manager.agent-hangup.test.ts` — immediate hangup on `confirmed`, grace on `unconfirmed` (fake timers assert nothing fires early), no hangup on `cancelled` even after 60s, and a no-op for an already-ended call.
- `webhook.test.ts` — the observed outcome reaches the hangup, a failed final playback schedules nothing, and a barge-in is forwarded as `cancelled`.
- `media-stream.playback-marks.test.ts` — an echoed mark resolves `true`, an unechoed one resolves `false` after the timeout.

**Checks** — `pnpm build` and `pnpm check` both pass clean.

**Production LOC** — +265 / -78 across the branch including tests; the production delta stays small because the notify-mode consolidation and the removed capability offset the new outcome plumbing.
