### PR TITLE
perf: trim unused Mistral APIs from standalone worker

### DIFF
--- a/packages/ai/src/providers/mistral-http-client.contract.test.ts
+++ b/packages/ai/src/providers/mistral-http-client.contract.test.ts
@@ -1,8 +1,19 @@
-import { HTTPClient, Mistral } from "@mistralai/mistralai";
+import { Mistral } from "@mistralai/mistralai";
+import { HTTPClient } from "@mistralai/mistralai/lib/http";
+import { Chat } from "@mistralai/mistralai/sdk/chat";
 import { describe, expect, it, vi } from "vitest";
 
 describe("Mistral HTTPClient contract", () => {
-  it("routes chat.stream responses through the injected HTTPClient hooks", async () => {
+  it.each([
+    {
+      name: "root client",
+      createChat: (options: ConstructorParameters<typeof Chat>[0]) => new Mistral(options).chat,
+    },
+    {
+      name: "chat subclient",
+      createChat: (options: ConstructorParameters<typeof Chat>[0]) => new Chat(options),
+    },
+  ])("routes $name responses through the injected HTTPClient hooks", async ({ createChat }) => {
     const response = new Response("data: [DONE]\n\n", {
       status: 200,
       headers: { "content-type": "text/event-stream" },
@@ -11,13 +22,13 @@ describe("Mistral HTTPClient contract", () => {
     const onResponse = vi.fn();
     const httpClient = new HTTPClient({ fetcher });
     httpClient.addHook("response", onResponse);
-    const mistral = new Mistral({
+    const chat = createChat({
       apiKey: "test-key",
       serverURL: "https://mistral.invalid",
       httpClient,
     });
 
-    const stream = await mistral.chat.stream({
+    const stream = await chat.stream({
       model: "mistral-test",
       messages: [{ role: "user", content: "hello" }],
     });

--- a/packages/ai/src/providers/mistral.test.ts
+++ b/packages/ai/src/providers/mistral.test.ts
@@ -23,12 +23,9 @@ vi.mock("node:crypto", async () => {
   };
 });
 
-vi.mock("@mistralai/mistralai", async () => {
-  const actual =
-    await vi.importActual<typeof import("@mistralai/mistralai")>("@mistralai/mistralai");
+vi.mock("@mistralai/mistralai/sdk/chat", () => {
   return {
-    ...actual,
-    Mistral: class MockMistral {
+    Chat: class MockMistralChat {
       private readonly config: unknown;
 
       constructor(config: unknown) {
@@ -36,29 +33,27 @@ vi.mock("@mistralai/mistralai", async () => {
         mistralMockState.configs.push(config);
       }
 
-      chat = {
-        stream: vi.fn(async (payload: unknown, requestOptions: unknown) => {
-          mistralMockState.payloads.push(payload);
-          mistralMockState.requestOptions.push(requestOptions);
-          if (mistralMockState.requestThroughHttpClient) {
-            const httpClient = (
-              this.config as {
-                httpClient?: { request(request: Request): Promise<Response> };
-              }
-            ).httpClient;
-            const response = await httpClient?.request(new Request("https://api.mistral.ai/chat"));
-            if (response && !response.ok) {
-              throw Object.assign(new Error(`Mistral HTTP ${response.status}`), {
-                statusCode: response.status,
-              });
+      stream = vi.fn(async (payload: unknown, requestOptions: unknown) => {
+        mistralMockState.payloads.push(payload);
+        mistralMockState.requestOptions.push(requestOptions);
+        if (mistralMockState.requestThroughHttpClient) {
+          const httpClient = (
+            this.config as {
+              httpClient?: { request(request: Request): Promise<Response> };
             }
+          ).httpClient;
+          const response = await httpClient?.request(new Request("https://api.mistral.ai/chat"));
+          if (response && !response.ok) {
+            throw Object.assign(new Error(`Mistral HTTP ${response.status}`), {
+              statusCode: response.status,
+            });
           }
-          if (mistralMockState.streamResult !== undefined) {
-            return mistralMockState.streamResult;
-          }
-          throw mistralMockState.streamError;
-        }),
-      };
+        }
+        if (mistralMockState.streamResult !== undefined) {
+          return mistralMockState.streamResult;
+        }
+        throw mistralMockState.streamError;
+      });
     },
   };
 });

--- a/packages/ai/src/providers/mistral.ts
+++ b/packages/ai/src/providers/mistral.ts
@@ -1,6 +1,6 @@
 // Mistral provider adapts Mistral streams and tool calls to the runtime.
 import { randomUUID } from "node:crypto";
-import { HTTPClient, Mistral, type Fetcher } from "@mistralai/mistralai";
+import { HTTPClient, type Fetcher } from "@mistralai/mistralai/lib/http";
 import type {
   ChatCompletionStreamRequest,
   ChatCompletionStreamRequestMessage,
@@ -8,6 +8,7 @@ import type {
   ContentChunk,
   FunctionTool,
 } from "@mistralai/mistralai/models/components";
+import { Chat } from "@mistralai/mistralai/sdk/chat";
 import { getEnvApiKey } from "../env-api-keys.js";
 import { getAiTransportHost } from "../host.js";
 import { calculateCost, clampThinkingLevel } from "../model-utils.js";
@@ -160,13 +161,12 @@ export const streamMistral: StreamFunction<"mistral-conversations", MistralOptio
           reportedResponse = response;
         }
       });
+      // Use the public chat subclient so standalone bundles omit unrelated Mistral APIs.
       // Intentionally per-request: avoids shared SDK mutable state across concurrent consumers.
-      const mistral = new Mistral({
+      const chat = new Chat({
         apiKey,
         serverURL: model.baseUrl,
-        // Bound the streamed Mistral response body at 16 MiB so a hostile or
-        // malfunctioning endpoint cannot exhaust memory. The HTTPClient is the
-        // SDK's public fetch and response-hook boundary for every chat.stream attempt.
+        // Keep bounded fetch and response hooks on every streaming attempt.
         httpClient,
       });
 
@@ -186,7 +186,7 @@ export const streamMistral: StreamFunction<"mistral-conversations", MistralOptio
       if (resolveMistralPromptCacheKey(options) && options?.sessionId) {
         headers["x-affinity"] ||= options.sessionId;
       }
-      const mistralStream = await mistral.chat.stream(payload, {
+      const mistralStream = await chat.stream(payload, {
         headers,
         signal: options?.signal,
       });


### PR DESCRIPTION
## What Problem This Solves

Standalone worker deployments and the npm package retain Mistral SDK APIs that OpenClaw's chat adapter never calls. The worker bundles its entire dependency closure into one deployable file, so using the all-API SDK client keeps unrelated agents, audio, batch, files, models, OCR, and workflow client code reachable.

## Why This Change Was Made

Use the installed SDK's public `Chat` subclient and `lib/http` entrypoint instead of constructing the all-API `Mistral` client. In `@mistralai/mistralai@2.5.0`, `Mistral.chat` itself constructs this same `Chat` class with the same options. Both inherit `ClientSDK`, including SDK hooks and the injected HTTP client. This removes the unused graph at the importing provider rather than excluding modules or changing the worker deployment contract.

No dependency versions, manifests, lockfiles, minification settings, package budgets, provider features, or worker capabilities change. Production LOC is unchanged (6 added / 6 removed); tests net +6, including a table-driven real-SDK HTTPClient contract for both client entrypoints. AI-assisted.

## User Impact

Smaller standalone worker transfers and npm package payload, with unchanged Mistral streaming, tool calls, cancellation, bounded response reads, guarded host fetch, and response hooks. No setup or configuration changes.

## Evidence

Same-base measurements at `cce893e90057ec7ef2954db429968c5a30f66dad`, rebuilding the AI workspace before each canonical-config standalone worker build:

| Artifact | Before | After | Reduction |
| --- | ---: | ---: | ---: |
| `dist/worker/worker.mjs` | 47,144,525 bytes | 46,231,674 bytes | **912,851 bytes (0.87 MiB, 1.94%)** |

- Before worker SHA-256: `61c2359e982d5c208a4130df570ab4b18ae329e317376435546c083e5c91924f`
- After worker SHA-256: `f69e268d41b6c45f079b947b52d689ee67f2e994668f183c0143eaa56fd4ddce`
- `OPENCLAW_VITEST_MAX_WORKERS=2 node scripts/run-vitest.mjs packages/ai/src/providers/mistral.test.ts packages/ai/src/providers/mistral-http-client.contract.test.ts packages/ai/src/providers/mistral.bounded-stream.test.ts`: **55 passed before and after**, including installed-SDK real HTTP/SSE terminal, cancellation, and tool-argument boundaries.
- Direct dependency inspection: SDK export map; `esm/sdk/sdk.js:40-43`; `esm/sdk/chat.js:49-50`; `esm/lib/sdks.js:28-50`; `esm/hooks/hooks.js:12-31`; `esm/hooks/registration.js:9-21`; `esm/funcs/chatStream.js:23-95`.

- Authenticated `packages/ai/src/providers/mistral.live.test.ts` through `scripts/run-vitest.mjs run --config test/vitest/vitest.live.config.ts`, with a fresh temporary home/state and the existing test credential: **1 passed**, real Mistral streaming and usage parsing. An initial default-harness attempt stopped in auth staging on unrelated old local database state before making a provider request; isolated proof passed without changing operator state.

- Compiled-worker managed-process probe: **before and after passed**. It runs the standalone file as a child with isolated home/state and a protocol-level test Gateway; exercises background exec, the next managed turn, process poll/kill, transcript commits, tool allowlisting, and terminal fencing. The first baseline attempt timed out under the concurrent full-build/check load; its bounded rerun and the candidate both passed without timeout/assertion changes.
- Fresh isolated Codex autoreview: **clean, no accepted/actionable findings**.

- `node scripts/check-changed.mjs -- packages/ai/src/providers/mistral.ts packages/ai/src/providers/mistral.test.ts packages/ai/src/providers/mistral-http-client.contract.test.ts`: **passed**, including core/test typechecks, focused lint, dead-export scan, and import-cycle checks.
- Clean Linux canonical packaging via `node scripts/crabbox-wrapper.mjs run --timing-json -- node scripts/package-openclaw-for-docker.mjs --allow-unreleased-changelog --output-dir .artifacts/mistral-package-proof --pack-json .artifacts/mistral-package-proof/pack.json`: **passed**, full build plus strict tarball integrity checks. The separate unpacked-size budget check is not part of that wrapper and remains to be measured. Provider `blacksmith-testbox`, lease `tbx_01m15vr398x6a2x8rm31zwdcwr`, [run 33233437487](https://github.com/openclaw/openclaw/actions/runs/33233437487), wrapper `exitCode: 0`; one-shot lease stopped after success. The backing Actions run may show cancellation from lease cleanup, not a failed proof.

- `pnpm build`: **passed locally**, including all declarations, plugin SDK exports, CLI bootstrap checks, runtime assets, and Control UI.

### Canonical package measurement

A second clean Linux run checked the changed-file SHA-256 values against source commit `7dad7721f8f48a58f448c9f7aa28bb1b8fff7f42`, rebuilt and packed the synced tree, verified the strict archive contract, and evaluated the final npm receipt with `collectPackUnpackedSizeErrors`:

- Packed archive: **61,531,029 bytes**.
- Unpacked package: **203,321,140 bytes**, below the unchanged **213,909,504-byte (204 MiB)** limit by **10,588,364 bytes**.
- Packed worker: **46,231,674 bytes**, matching the local candidate exactly.
- Files: **11,289**; budget errors: **none**.
- Tarball SHA-256: `cb1953c0c3230ef28061e5b157f858fc350e53a8bb09ed4b6ceb3cba601cbcce`.
- Provider `blacksmith-testbox`, lease `tbx_01m15wzrxn75m3k1m5e0wzvwfv`, [run 33234309369](https://github.com/openclaw/openclaw/actions/runs/33234309369), wrapper `exitCode: 0`; lease stopped. The Testbox Git metadata remained its hydration head `1cbac29f2b40c7651cc1bd2142743dc953589748`; the tested source was the synced local tree, with changed-file hashes checked explicitly.

The first measurement-only launcher omitted the repository TypeScript loader and failed to resolve a workspace package before building. Adding the standard `--import ./scripts/tsx.mjs` loader fixed the diagnostic invocation; no production code changed. These are PR-candidate package bytes, not yet a measurement of merged main.

### Landing status

Merged through the official native workflow as `e1a38de321a804955909a77fad394c001ba2c53e` on 2026-08-29. Exact-head CI and a fresh independent review passed; ClawSweeper's requested SDK contract was rerun and both cases passed. The earlier workspace blocker was resolved by regenerating the native repository and review artifacts wholly inside the allowed directory, with separate Git metadata and unchanged gates. `review-validate-artifacts`, `OPENCLAW_TESTBOX=1 prepare-run`, and `merge-run` all passed. [Native merge confirmation](https://github.com/openclaw/openclaw/pull/132368#issuecomment-5460707367).

### Post-merge measurement

Fresh canonical clean Linux build of main `f5ff15cb568efc85ff479198cb9062a0512a4d69`, containing merge `e1a38de321a804955909a77fad394c001ba2c53e`. Synced source and remote Git HEAD match; changed-file hashes were checked. Strict archive integrity passed.

| Merged-main artifact | Bytes |
| --- | ---: |
| Worker | **46,258,629** |
| Compressed package | **61,562,813** |
| Unpacked package | **203,454,343** |
| Headroom under the original 204 MiB ceiling | **10,455,161** |

Provider `blacksmith-testbox`, lease `tbx_01m162048wy7cm42v7c7wv3yhf`, [run 33237670009](https://github.com/openclaw/openclaw/actions/runs/33237670009), exit 0; lease stopped. Tarball SHA-256: `62dfc1c0a5759f996eedfa84021a07874c78a932c35fc46004dae34309bfe69e`.

Budget clarification: the helper defaults to 235 MiB on current main and already did at this PR's base; this PR never changes the budget file. To enforce the original requested ceiling, both candidate and merged receipt sizes were explicitly rechecked with `collectPackUnpackedSizeErrors(..., { budgetBytes: 204 * 1024 * 1024 })`; both returned `[]`. The result does not rely on the larger default.

The matched-base saving remains **912,851 bytes**. The merged-main worker is 26,955 bytes larger than the candidate because other main changes landed between the two builds; do not attribute that intervening growth to this patch.
