### PR TITLE
refactor(tests): deduplicate max-lines ratchet fixtures

### DIFF
--- a/test/scripts/check-max-lines-ratchet.test.ts
+++ b/test/scripts/check-max-lines-ratchet.test.ts
@@ -10,8 +10,9 @@ import {
   isGovernedSourcePath,
   main,
 } from "../../scripts/check-max-lines-ratchet.mts";
+import { createTempDirTracker } from "../helpers/temp-dir.js";
 
-const tempDirs: string[] = [];
+const tempDirs = createTempDirTracker();
 const nestedGitEnvKeys = [
   "GIT_ALTERNATE_OBJECT_DIRECTORIES",
   "GIT_COMMON_DIR",
@@ -44,11 +45,21 @@ function git(cwd: string, args: string[]): void {
   execFileSync("git", args, { cwd, env, stdio: "ignore" });
 }
 
+function commitFixture(root: string, message = "base"): void {
+  for (const args of [
+    ["init"],
+    ["config", "user.email", "test@example.com"],
+    ["config", "user.name", "Test"],
+    ["add", "."],
+    ["commit", "-m", message],
+  ]) {
+    git(root, args);
+  }
+}
+
 afterEach(() => {
   vi.restoreAllMocks();
-  for (const dir of tempDirs.splice(0)) {
-    fs.rmSync(dir, { force: true, recursive: true });
-  }
+  tempDirs.cleanup();
 });
 
 describe("check-max-lines-ratchet", () => {
@@ -91,8 +102,7 @@ describe("check-max-lines-ratchet", () => {
   });
 
   it("rejects baseline growth even when the new suppression is listed", () => {
-    const root = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-max-lines-"));
-    tempDirs.push(root);
+    const root = tempDirs.make("openclaw-max-lines-", os.tmpdir());
     fs.mkdirSync(path.join(root, "config"), { recursive: true });
     fs.mkdirSync(path.join(root, "src"), { recursive: true });
     fs.writeFileSync(path.join(root, "config/max-lines-baseline.txt"), "src/a.ts\n");
@@ -100,15 +110,7 @@ describe("check-max-lines-ratchet", () => {
       path.join(root, "src/a.ts"),
       "/* oxlint-disable max-lines -- TODO: split. */\n",
     );
-    for (const args of [
-      ["init"],
-      ["config", "user.email", "test@example.com"],
-      ["config", "user.name", "Test"],
-      ["add", "."],
-      ["commit", "-m", "base"],
-    ]) {
-      git(root, args);
-    }
+    commitFixture(root);
 
     fs.writeFileSync(path.join(root, "config/max-lines-baseline.txt"), "src/a.ts\nsrc/b.ts\n");
     fs.writeFileSync(
@@ -122,21 +124,12 @@ describe("check-max-lines-ratchet", () => {
   });
 
   it("rejects replacing an explicit max-lines suppression with an all-rule disable", () => {
-    const root = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-max-lines-all-rule-"));
-    tempDirs.push(root);
+    const root = tempDirs.make("openclaw-max-lines-all-rule-", os.tmpdir());
     fs.mkdirSync(path.join(root, "config"), { recursive: true });
     fs.mkdirSync(path.join(root, "src"), { recursive: true });
     fs.writeFileSync(path.join(root, "config/max-lines-baseline.txt"), "src/a.ts\n");
     fs.writeFileSync(path.join(root, "src/a.ts"), "/* oxlint-disable max-lines */\n");
-    for (const args of [
-      ["init"],
-      ["config", "user.email", "test@example.com"],
-      ["config", "user.name", "Test"],
-      ["add", "."],
-      ["commit", "-m", "base"],
-    ]) {
-      git(root, args);
-    }
+    commitFixture(root);
 
     fs.writeFileSync(path.join(root, "src/a.ts"), "/* oxlint-disable */\n");
     vi.spyOn(console, "error").mockImplementation(() => {});
@@ -145,21 +138,12 @@ describe("check-max-lines-ratchet", () => {
   });
 
   it("rejects a new all-rule disable without baseline growth", () => {
-    const root = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-max-lines-all-rule-new-"));
-    tempDirs.push(root);
+    const root = tempDirs.make("openclaw-max-lines-all-rule-new-", os.tmpdir());
     fs.mkdirSync(path.join(root, "config"), { recursive: true });
     fs.mkdirSync(path.join(root, "src"), { recursive: true });
     fs.writeFileSync(path.join(root, "config/max-lines-baseline.txt"), "");
     fs.writeFileSync(path.join(root, "src/a.ts"), "export const a = 1;\n");
-    for (const args of [
-      ["init"],
-      ["config", "user.email", "test@example.com"],
-      ["config", "user.name", "Test"],
-      ["add", "."],
-      ["commit", "-m", "base"],
-    ]) {
-      git(root, args);
-    }
+    commitFixture(root);
 
     fs.writeFileSync(path.join(root, "src/a.ts"), "/* oxlint-disable */\n");
     vi.spyOn(console, "error").mockImplementation(() => {});
@@ -168,8 +152,7 @@ describe("check-max-lines-ratchet", () => {
   });
 
   it("transfers grandfathered debt across a verified rename", () => {
-    const root = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-max-lines-rename-"));
-    tempDirs.push(root);
+    const root = tempDirs.make("openclaw-max-lines-rename-", os.tmpdir());
     fs.mkdirSync(path.join(root, "config"), { recursive: true });
     fs.mkdirSync(path.join(root, "src"), { recursive: true });
     fs.writeFileSync(path.join(root, "config/max-lines-baseline.txt"), "src/a.ts\n");
@@ -177,15 +160,7 @@ describe("check-max-lines-ratchet", () => {
       path.join(root, "src/a.ts"),
       "export const a = 1;\n/* oxlint-disable max-lines -- TODO: split. */\n",
     );
-    for (const args of [
-      ["init"],
-      ["config", "user.email", "test@example.com"],
-      ["config", "user.name", "Test"],
-      ["add", "."],
-      ["commit", "-m", "base"],
-    ]) {
-      git(root, args);
-    }
+    commitFixture(root);
     git(root, ["update-ref", "refs/remotes/origin/main", "HEAD"]);
 
     git(root, ["mv", "src/a.ts", "src/b.ts"]);
@@ -195,21 +170,12 @@ describe("check-max-lines-ratchet", () => {
   });
 
   it("defaults worktree comparisons to origin/main", () => {
-    const root = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-max-lines-default-base-"));
-    tempDirs.push(root);
+    const root = tempDirs.make("openclaw-max-lines-default-base-", os.tmpdir());
     fs.mkdirSync(path.join(root, "config"), { recursive: true });
     fs.mkdirSync(path.join(root, "src"), { recursive: true });
     fs.writeFileSync(path.join(root, "config/max-lines-baseline.txt"), "src/a.ts\n");
     fs.writeFileSync(path.join(root, "src/a.ts"), "/* oxlint-disable max-lines */\n");
-    for (const args of [
-      ["init"],
-      ["config", "user.email", "test@example.com"],
-      ["config", "user.name", "Test"],
-      ["add", "."],
-      ["commit", "-m", "base"],
-    ]) {
-      git(root, args);
-    }
+    commitFixture(root);
     git(root, ["update-ref", "refs/remotes/origin/main", "HEAD"]);
 
     fs.writeFileSync(path.join(root, "config/max-lines-baseline.txt"), "src/a.ts\nsrc/b.ts\n");
@@ -222,23 +188,14 @@ describe("check-max-lines-ratchet", () => {
   });
 
   it("compares an explicit moving base at the branch fork", () => {
-    const root = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-max-lines-diverged-"));
-    tempDirs.push(root);
+    const root = tempDirs.make("openclaw-max-lines-diverged-", os.tmpdir());
     fs.mkdirSync(path.join(root, "config"), { recursive: true });
     fs.mkdirSync(path.join(root, "src"), { recursive: true });
     fs.writeFileSync(path.join(root, "config/max-lines-baseline.txt"), "src/a.ts\nsrc/b.ts\n");
     fs.writeFileSync(path.join(root, "src/a.ts"), "/* oxlint-disable max-lines */\n");
     fs.writeFileSync(path.join(root, "src/b.ts"), "/* oxlint-disable max-lines */\n");
-    for (const args of [
-      ["init"],
-      ["config", "user.email", "test@example.com"],
-      ["config", "user.name", "Test"],
-      ["add", "."],
-      ["commit", "-m", "base"],
-      ["branch", "release"],
-    ]) {
-      git(root, args);
-    }
+    commitFixture(root);
+    git(root, ["branch", "release"]);
 
     fs.writeFileSync(path.join(root, "config/max-lines-baseline.txt"), "src/a.ts\n");
     fs.writeFileSync(path.join(root, "src/b.ts"), "export const b = 1;\n");
@@ -251,22 +208,13 @@ describe("check-max-lines-ratchet", () => {
   });
 
   it("falls back to main when no merge base is available", () => {
-    const root = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-max-lines-disconnected-"));
-    tempDirs.push(root);
+    const root = tempDirs.make("openclaw-max-lines-disconnected-", os.tmpdir());
     fs.mkdirSync(path.join(root, "config"), { recursive: true });
     fs.mkdirSync(path.join(root, "src"), { recursive: true });
     fs.writeFileSync(path.join(root, "config/max-lines-baseline.txt"), "src/a.ts\n");
     fs.writeFileSync(path.join(root, "src/a.ts"), "/* oxlint-disable max-lines */\n");
-    for (const args of [
-      ["init"],
-      ["config", "user.email", "test@example.com"],
-      ["config", "user.name", "Test"],
-      ["add", "."],
-      ["commit", "-m", "release"],
-      ["branch", "-m", "release"],
-    ]) {
-      git(root, args);
-    }
+    commitFixture(root, "release");
+    git(root, ["branch", "-m", "release"]);
     git(root, ["checkout", "--orphan", "main"]);
     fs.writeFileSync(path.join(root, "config/max-lines-baseline.txt"), "");
     fs.writeFileSync(path.join(root, "src/a.ts"), "export const a = 1;\n");
@@ -279,21 +227,12 @@ describe("check-max-lines-ratchet", () => {
   });
 
   it("checks staged content instead of unstaged worktree edits", () => {
-    const root = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-max-lines-staged-"));
-    tempDirs.push(root);
+    const root = tempDirs.make("openclaw-max-lines-staged-", os.tmpdir());
     fs.mkdirSync(path.join(root, "config"), { recursive: true });
     fs.mkdirSync(path.join(root, "src"), { recursive: true });
     fs.writeFileSync(path.join(root, "config/max-lines-baseline.txt"), "");
     fs.writeFileSync(path.join(root, "src/a.ts"), "export const a = 1;\n");
-    for (const args of [
-      ["init"],
-      ["config", "user.email", "test@example.com"],
-      ["config", "user.name", "Test"],
-      ["add", "."],
-      ["commit", "-m", "base"],
-    ]) {
-      git(root, args);
-    }
+    commitFixture(root);
 
     fs.writeFileSync(path.join(root, "config/max-lines-baseline.txt"), "src/a.ts\n");
     fs.writeFileSync(path.join(root, "src/a.ts"), "/* oxlint-disable */\n");
@@ -306,8 +245,7 @@ describe("check-max-lines-ratchet", () => {
   });
 
   it.skipIf(process.platform === "win32")("keeps staged filenames NUL-framed", () => {
-    const root = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-max-lines-nul-"));
-    tempDirs.push(root);
+    const root = tempDirs.make("openclaw-max-lines-nul-", os.tmpdir());
     fs.mkdirSync(path.join(root, "src"), { recursive: true });
     git(root, ["init"]);
     const filePath = "src/newline\nname.ts";
@@ -318,21 +256,12 @@ describe("check-max-lines-ratchet", () => {
   });
 
   it("checks untracked sources and tolerates unstaged deletions", () => {
-    const root = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-max-lines-worktree-"));
-    tempDirs.push(root);
+    const root = tempDirs.make("openclaw-max-lines-worktree-", os.tmpdir());
     fs.mkdirSync(path.join(root, "config"), { recursive: true });
     fs.mkdirSync(path.join(root, "src"), { recursive: true });
     fs.writeFileSync(path.join(root, "config/max-lines-baseline.txt"), "");
     fs.writeFileSync(path.join(root, "src/deleted.ts"), "export const deleted = true;\n");
-    for (const args of [
-      ["init"],
-      ["config", "user.email", "test@example.com"],
-      ["config", "user.name", "Test"],
-      ["add", "."],
-      ["commit", "-m", "base"],
-    ]) {
-      git(root, args);
-    }
+    commitFixture(root);
     git(root, ["update-ref", "refs/remotes/origin/main", "HEAD"]);
     fs.rmSync(path.join(root, "src/deleted.ts"));
     expect(main(root)).toBe(0);


### PR DESCRIPTION
## What Problem This Solves

The max-lines ratchet tests repeat the same temporary-repository setup and directory bookkeeping across independent cases. That duplication makes fixture maintenance harder without adding behavioral coverage.

## Why This Change Was Made

Reuse the existing temporary-directory tracker and consolidate nine identical, ordered Git initialization/configuration/commit sequences in a private fixture helper. All 12 original cases and assertions remain. The NUL-framed filename case remains init-only; divergent histories, staged versus unstaged content, commit messages, and the mock-restoration-before-cleanup order are preserved.

The tracker receives an explicit system temporary root to preserve its original spelling. Its existing cleanup policy includes bounded filesystem removal retries and retains tracked directories if cleanup throws; this is adoption of the canonical fixture lifecycle, not a claim of identical exceptional cleanup timing. No production code, shared helper, public API, test retry, test timeout, or assertion is changed.

## User Impact

No user-visible behavior change. This is an AI-assisted, maintainer-requested test-fixture cleanup: production +0/-0; tests +36/-107, net -71 lines. The meaningful ratchet checks remain independent.

## Evidence

Actual local proof on macOS used Node 24.19.0, the repository-pinned pnpm 12.0.0 through normal Corepack resolution, and the same canonical five-suite command before and after:

```sh
OPENCLAW_VITEST_MAX_WORKERS=2 node scripts/run-vitest.mjs \
  test/scripts/check-max-lines-ratchet.test.ts \
  test/helpers/temp-dir.test.ts \
  test/scripts/shrink-ratchet.test.ts \
  test/scripts/check-assertion-safety-ratchet.test.ts \
  test/scripts/check-env-var-count.test.ts \
  --reporter=verbose
```

Baseline and candidate each passed all 60 cases across five files, with the complete named-case multiset preserved, including embedded-newline names and duplicate titles. There were no skips on this macOS host; the existing Windows-only filename-case skip remains unchanged.

Scoped formatting and `git diff --check` passed. The full canonical changed gate passed all 14 selected commands, including root test typechecking, script lint, temporary-directory ownership reporting, and the relevant repository guards:

```sh
node scripts/check-changed.mjs --dry-run \
  --base 59dad71c416bcd9d649323c5f17fecdc31fd526a \
  -- test/scripts/check-max-lines-ratchet.test.ts
node scripts/check-changed.mjs --timed \
  --base 59dad71c416bcd9d649323c5f17fecdc31fd526a \
  -- test/scripts/check-max-lines-ratchet.test.ts
```

One normal independent Codex precommit review completed with no actionable P0 findings. The ordinary commit hook ran and preserved the reviewed afterimage; signed commit `4cba0a3f472554205bc24ac4609f8160de37bb1d` has the exact one-file diff above.

The first candidate preflight was refused before tests because its raw Git index bytes differed from the prior observation. The old raw bytes were not archived, so historical cause, actor, and exact field delta remain unknown. A complete index/flag/source audit established the intended state; a separately admitted candidate run then passed, without resetting the index or replaying installation/baseline tests. Original diagnostic failures remain retained, including a case-log parser correction for multiline names and a review-packet correction that relabeled unchanged lockfile/CI-guide context accurately. None required a product or assertion change.

Full tracked-source, semantic-index/flags, dependency, output, and current-runtime checks passed around review and commit; known processes and isolated review homes were verified absent. Normal Vitest cache creation/result updates were retained and disclosed.

Hosted exact-head CI, any published-head review, current-main integration, and native landing remain pending. No product build, live external API, Linux/Windows execution, performance improvement, or landed cleanup credit is claimed.

## Subsequent Proof Update — 2026-08-29

This update supersedes only the pending proof statuses above; the original evidence and limitations are retained verbatim.

[CI run 33234787464](https://github.com/openclaw/openclaw/actions/runs/33234787464), attempt 1 for exact head `4cba0a3f472554205bc24ac4609f8160de37bb1d`, completed successfully with 100 successful jobs and 18 skipped jobs. The canonical exact-head CI watcher exited 0. Its raw rollup reported `FAILURE`, zero pending and 53 superseded checks before `GREEN`; this is not a claim that every raw check across earlier runs passed.

Actual hosted logs contain the same 60 named passing cases as both local runs, including multiline names and duplicate titles: [core-tooling-1](https://github.com/openclaw/openclaw/actions/runs/33234787464/job/99053811202) has 12 max-lines and 6 temporary-directory helper cases; [core-tooling-3](https://github.com/openclaw/openclaw/actions/runs/33234787464/job/99053811232) has 20 environment-variable and 5 assertion-safety cases; [core-tooling-6](https://github.com/openclaw/openclaw/actions/runs/33234787464/job/99053811171) has 17 shrink cases. Each owning group ended with exit 0. No skipped case is counted as a pass.

Those jobs checked out merge ref `8d3792e4b58488bdc1728945cafad26741aa540f`, combining this head with base `293c433a10bcd4727b11505caa1c8a995618a18f`. A separate read-only comparison against main checkpoint `015546cb8bd8866e5d76b7f264474e7e641f6a80` found the owned test beforeimage unchanged and no relevant fixture/selector conflict in the inspected current-main deltas. The complete object-map composition predicts a one-file change on that checkpoint; it is not a performed merge or new local/hosted execution on `015546...`.

One normal independent Codex published-head review completed with no actionable P0 findings. Its actual process closure and source/index/dependency/output/runtime checks passed. The [ClawSweeper review](https://github.com/openclaw/openclaw/pull/132372#issuecomment-5460457496) on this head had no findings; its outstanding CI verification is now backed by the exact-head run and named-case audit above. No redundant review request or comment was needed.

Native integration, final live mergeability and landing remain separate gates. No Windows execution, live external API, performance improvement, or landed cleanup credit is claimed by this update.

