### PR TITLE
fix(doctor): preserve config when service repair is refused

### DIFF
--- a/docs/gateway/doctor.md
+++ b/docs/gateway/doctor.md
@@ -23,7 +23,7 @@ openclaw doctor
     openclaw doctor --yes
     ```
 
-    Accept defaults without prompting (including restart/service/sandbox repair steps when applicable).
+    Accept default non-service repairs without prompting. Gateway service definition rewrites still require interactive confirmation.
 
   </Tab>
   <Tab title="--fix">
@@ -31,7 +31,7 @@ openclaw doctor
     openclaw doctor --fix
     ```
 
-    Apply recommended repairs without prompting (`--repair` is an alias).
+    Apply recommended non-service repairs without prompting (`--repair` is an alias). Gateway service definition rewrites still require interactive confirmation.
 
   </Tab>
   <Tab title="--lint">

--- a/docs/gateway/doctor.md
+++ b/docs/gateway/doctor.md
@@ -606,12 +606,13 @@ That stages grounded durable candidates into the short-term dreaming store while
     Notes:
 
     - `openclaw doctor` prompts before rewriting supervisor config.
-    - `openclaw doctor --yes` accepts the default repair prompts.
-    - `openclaw doctor --fix` applies recommended fixes without prompts (`--repair` is an alias).
+    - `openclaw doctor --yes` accepts default non-service repair prompts; service definition rewrites still require interactive confirmation.
+    - `openclaw doctor --fix` applies recommended non-service fixes without prompts (`--repair` is an alias). Outside update repair mode, headless runs report service drift without rewriting the definition.
     - `openclaw doctor --fix --force` can overwrite the managed supervisor config; operator-owned systemd drop-ins remain unchanged.
     - `OPENCLAW_SERVICE_REPAIR_POLICY=external` keeps doctor read-only for gateway service lifecycle. It still reports service health and runs non-service repairs, but skips service install/start/restart/bootstrap, supervisor config rewrites, and legacy service cleanup because an external supervisor owns that lifecycle.
     - On macOS, a same-label system LaunchDaemon blocks user LaunchAgent install, start, restart, and bootstrap repair. Doctor reports the system owner and stops service recovery; `--force` does not bypass this ownership boundary. See [Existing system LaunchDaemons](/gateway#existing-system-launchdaemons).
     - On Linux, doctor does not rewrite command/entrypoint metadata while the matching systemd gateway unit is active. If a stopped unit's command or working directory is overridden by an operator-owned systemd drop-in, inspect it with `systemctl --user cat <unit>.service`, then update or remove the drop-in; rewriting the managed base cannot change the effective launcher. `Environment=` drop-ins remain supported. Doctor also ignores inactive non-legacy extra gateway-like units during the duplicate-service scan so companion service files do not create cleanup noise.
+    - On Linux, doctor checks authority over the installed and planned service files before persisting a recovered gateway token. If that check blocks service repair, the repair leaves config and token unchanged and reports how to restore inspection access or involve the deployment owner; `--force` cannot bypass it. Unrelated Doctor config repairs are unaffected.
     - If token auth requires a token and `gateway.auth.token` is SecretRef-managed, doctor service install/repair validates the SecretRef but does not persist resolved plaintext token values into supervisor service environment metadata.
     - Doctor detects managed `.env`/SecretRef-backed service environment values that older LaunchAgent, systemd, or Windows Scheduled Task installs embedded inline and rewrites the service metadata so those values load from the runtime source instead of the supervisor definition.
     - Doctor detects when the service command still pins an old `--port` after `gateway.port` changes and rewrites the service metadata to the current port.

--- a/src/commands/doctor-gateway-services.authority.test.ts
+++ b/src/commands/doctor-gateway-services.authority.test.ts
@@ -1,0 +1,425 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { isDeepStrictEqual } from "node:util";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../config/config.js";
+import { isDefaultInstallIdentity } from "../config/paths.js";
+import * as gatewayService from "../daemon/service.js";
+import {
+  buildSystemdManagerPropertyOutput,
+  buildSystemdUnitPropertyOutput,
+} from "../daemon/service.test-helpers.js";
+import { buildSystemdUnit } from "../daemon/systemd-unit.js";
+import type { RuntimeEnv } from "../runtime.js";
+import { withEnvAsync } from "../test-utils/env.js";
+import {
+  createOpenClawTestState,
+  type OpenClawTestState,
+} from "../test-utils/openclaw-test-state.js";
+import type { DoctorPrompter } from "./doctor-prompter.js";
+
+const edges = vi.hoisted(() => ({
+  command: vi.fn<typeof import("../process/exec.js").runCommandWithTimeout>(),
+  runtimeProbe: vi.fn<typeof import("../process/exec.js").runExec>(),
+  note: vi.fn<(message: string, title?: string) => void>(),
+}));
+
+vi.mock("../process/exec.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../process/exec.js")>()),
+  runCommandWithTimeout: edges.command,
+  runExec: edges.runtimeProbe,
+}));
+vi.mock("../../packages/terminal-core/src/note.js", () => ({ note: edges.note }));
+
+import { maybeRepairGatewayServiceConfig } from "./doctor-gateway-services.js";
+
+const refusals = [
+  { scenario: "sealed", kind: "sealed", reason: "sealed-mount", guidance: "deployment owner" },
+  {
+    scenario: "unsafe",
+    kind: "unknown",
+    reason: "unsafe-permissions",
+    guidance: "chmod go-w",
+  },
+  {
+    scenario: "uninspectable",
+    kind: "unknown",
+    reason: "inspection-failed",
+    guidance: "native service-manager availability",
+  },
+] as const;
+type Scenario = (typeof refusals)[number]["scenario"] | "writable" | "rejected";
+
+// All tokens are synthetic. Assertions report equality booleans, never token bytes.
+const embeddedToken = "doctor-fixture-embedded-token";
+const existingToken = "doctor-fixture-config-token";
+const inspectionCanary = "doctor-fixture-private-inspection-detail";
+
+describe.skipIf(process.platform === "win32")("Doctor native repair authority ordering", () => {
+  let state: OpenClawTestState | undefined;
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    vi.clearAllMocks();
+    await state?.cleanup();
+    state = undefined;
+  });
+
+  async function runRepair(
+    scenario: Scenario,
+    {
+      tokenPresent = false,
+      update = false,
+      blockedTarget,
+    }: { tokenPresent?: boolean; update?: boolean; blockedTarget?: "installed" | "planned" } = {},
+  ) {
+    state = await createOpenClawTestState({ prefix: "doctor-authority-" });
+    const { root, home, stateDir, configPath } = state;
+    const installedStateDir = blockedTarget ? path.join(root, "installed-state") : stateDir;
+    const unitPath = path.join(home, ".config/systemd/user/openclaw-gateway.service");
+    const environmentPath = path.join(stateDir, "gateway.systemd.env");
+    const installedEnvironmentPath = path.join(installedStateDir, "gateway.systemd.env");
+    const wrapperPath = path.join(root, "openclaw-fixture");
+    const systemUnits = path.join(root, "system-units");
+    await fs.mkdir(installedStateDir, { recursive: true, mode: 0o700 });
+    await fs.mkdir(path.dirname(unitPath), { recursive: true, mode: 0o755 });
+    await fs.mkdir(systemUnits, { mode: 0o755 });
+    await fs.writeFile(wrapperPath, "#!/bin/sh\nexit 99\n", { mode: 0o700 });
+    const cfg: OpenClawConfig = {
+      gateway: {
+        mode: "local",
+        auth: { mode: "token", ...(tokenPresent ? { token: existingToken } : {}) },
+      },
+      plugins: { enabled: false },
+    };
+    const originalConfig = `${JSON.stringify(cfg, null, 2)}\n`;
+    const programArguments = [wrapperPath, "gateway", "--port", "18789"];
+    const environment = {
+      HOME: home,
+      OPENCLAW_STATE_DIR: installedStateDir,
+      OPENCLAW_CONFIG_PATH: configPath,
+      OPENCLAW_WRAPPER: wrapperPath,
+      OPENCLAW_GATEWAY_TOKEN: embeddedToken,
+      PATH: "/usr/local/bin:/usr/bin:/bin",
+    };
+    const originalUnit = buildSystemdUnit({ programArguments, environment });
+    const originalEnvironment = "OPERATOR_FIXTURE=unchanged\n";
+    await fs.writeFile(configPath, originalConfig, { mode: 0o600 });
+    await fs.writeFile(unitPath, originalUnit, { mode: 0o644 });
+    await fs.writeFile(environmentPath, originalEnvironment, { mode: 0o600 });
+    if (blockedTarget) {
+      await fs.writeFile(installedEnvironmentPath, originalEnvironment, { mode: 0o600 });
+    }
+
+    // Model one synthetic OS account; the real install-identity guard still runs.
+    vi.spyOn(process, "platform", "get").mockReturnValue("linux");
+    vi.spyOn(os, "homedir").mockReturnValue(home);
+    vi.spyOn(os, "userInfo").mockReturnValue({
+      homedir: home,
+      username: "doctor-fixture",
+      uid: process.geteuid!(),
+      gid: process.getegid!(),
+      shell: "/bin/sh",
+    });
+    const readFile = fs.readFile.bind(fs);
+    vi.spyOn(fs, "readFile").mockImplementation(async (...args) => {
+      if (typeof args[0] === "string" && args[0].startsWith("/proc/self/fdinfo/")) {
+        return "mnt_id:\t1\n";
+      }
+      if (args[0] === "/proc/self/mountinfo") {
+        return `1 0 0:1 / / ${scenario === "sealed" ? "ro" : "rw"} - tmpfs tmpfs rw\n`;
+      }
+      return readFile(...args);
+    });
+    if (scenario === "unsafe") {
+      const unsafePath = blockedTarget
+        ? blockedTarget === "installed"
+          ? installedEnvironmentPath
+          : environmentPath
+        : unitPath;
+      await fs.chmod(unsafePath, 0o666);
+    } else if (scenario === "uninspectable") {
+      const lstat = fs.lstat.bind(fs);
+      vi.spyOn(fs, "lstat").mockImplementation(async (...args) => {
+        if (args[0] === unitPath) {
+          throw Object.assign(new Error(inspectionCanary), { code: "EACCES" });
+        }
+        return lstat(...args);
+      });
+    }
+
+    const events: string[] = [];
+    const nativeActions: string[] = [];
+    const unexpectedProcesses: string[] = [];
+    const rename = fs.rename.bind(fs);
+    vi.spyOn(fs, "rename").mockImplementation(async (source, destination) => {
+      await rename(source, destination);
+      if (destination === configPath) {
+        events.push("config-published");
+      } else if (
+        [unitPath, `${unitPath}.bak`, environmentPath, installedEnvironmentPath].includes(
+          String(destination),
+        )
+      ) {
+        events.push("service-published");
+      }
+    });
+    edges.runtimeProbe.mockImplementation(async (_file, args) => {
+      if (args[0] !== "-e" || !args[1]?.includes("sqliteVersion")) {
+        unexpectedProcesses.push("unexpected runtime process");
+        throw new Error("Unexpected fixture runtime process");
+      }
+      return {
+        stdout: JSON.stringify({ nodeVersion: "24.15.0", sqliteVersion: "3.51.3" }),
+        stderr: "",
+      };
+    });
+    edges.command.mockImplementation(async (argv) => {
+      const [binary, ...args] = argv;
+      let stdout: string;
+      let code = 0;
+      if (binary === "busctl") {
+        stdout = args.includes("LoadUnit")
+          ? JSON.stringify({ type: "o", data: ["/org/freedesktop/systemd1/unit/fixture"] })
+          : args.includes("org.freedesktop.systemd1.Unit")
+            ? buildSystemdUnitPropertyOutput({ fragmentPath: unitPath })
+            : buildSystemdManagerPropertyOutput({
+                programArguments,
+                environment: Object.entries(environment).map(([key, value]) => `${key}=${value}`),
+              });
+      } else if (binary === "systemctl" && args.includes("--property=LoadState")) {
+        stdout = "not-found\n";
+      } else if (binary === "systemctl" && args.includes("--property=UnitPath")) {
+        stdout = `${systemUnits}\n`;
+      } else if (binary === "systemctl" && args.includes("show")) {
+        stdout =
+          "After=network-online.target\nWants=network-online.target\nRestartUSec=5s\nKillMode=control-group\n";
+      } else if (binary === "systemctl" && args.includes("status")) {
+        stdout = "running\n";
+      } else if (binary === "systemctl" && args.includes("is-active")) {
+        stdout = "inactive\n";
+        code = 3;
+      } else if (
+        binary === "systemctl" &&
+        args.some((arg) => ["daemon-reload", "enable", "restart"].includes(arg))
+      ) {
+        nativeActions.push(
+          args.find((arg) => ["daemon-reload", "enable", "restart"].includes(arg))!,
+        );
+        stdout = "";
+      } else {
+        unexpectedProcesses.push(argv.join(" "));
+        throw new Error("Unexpected fixture process");
+      }
+      return { stdout, stderr: "", code, signal: null, killed: false, termination: "exit" };
+    });
+    const errors: string[] = [];
+    const runtime: RuntimeEnv = {
+      log: vi.fn(),
+      error: (...args) => {
+        const message = args.map(String).join(" ");
+        errors.push(message);
+        if (message.includes("SERVICE_DEFINITION_")) {
+          events.push("repair-refused");
+        }
+      },
+      exit: vi.fn(),
+    };
+    const prompter: DoctorPrompter = {
+      confirm: async () => true,
+      confirmAutoFix: async () => true,
+      confirmAggressiveAutoFix: async () => true,
+      confirmRuntimeRepair: async () => true,
+      select: async (_params, fallback) => fallback,
+      shouldRepair: true,
+      shouldForce: update,
+      repairMode: {
+        shouldRepair: true,
+        shouldForce: update,
+        canPrompt: !update,
+        nonInteractive: update,
+        updateInProgress: update,
+      },
+    };
+    return withEnvAsync(
+      {
+        HOME: home,
+        USERPROFILE: home,
+        OPENCLAW_HOME: undefined,
+        OPENCLAW_STATE_DIR: stateDir,
+        OPENCLAW_CONFIG_PATH: configPath,
+        OPENCLAW_PROFILE: undefined,
+        OPENCLAW_SYSTEMD_UNIT: undefined,
+        OPENCLAW_SERVICE_KIND: undefined,
+        OPENCLAW_NIX_MODE: undefined,
+        OPENCLAW_SUPERVISOR_MODE: undefined,
+        OPENCLAW_SERVICE_REPAIR_POLICY: undefined,
+        OPENCLAW_GATEWAY_TOKEN: undefined,
+        OPENCLAW_GATEWAY_PASSWORD: undefined,
+        OPENCLAW_GATEWAY_PORT: undefined,
+        OPENCLAW_WRAPPER: wrapperPath,
+        OPENCLAW_UPDATE_IN_PROGRESS: update ? "1" : undefined,
+        OPENCLAW_UPDATE_PARENT_ALLOWS_GATEWAY_SERVICE_REPAIR: update ? "1" : undefined,
+      },
+      async () => {
+        expect(isDefaultInstallIdentity()).toBe(true);
+        const service = gatewayService.resolveGatewayService();
+        const capability = await service.readDefinitionMutationCapability!({
+          env: process.env,
+          environment,
+        });
+        const plannedCapability = blockedTarget
+          ? await service.readDefinitionMutationCapability!({
+              env: process.env,
+              environment: { ...environment, OPENCLAW_STATE_DIR: stateDir },
+            })
+          : undefined;
+        if (scenario === "rejected") {
+          // Native filesystem failures return a capability; also exercise an adapter rejection.
+          vi.spyOn(gatewayService, "resolveGatewayService").mockReturnValue({
+            ...service,
+            readDefinitionMutationCapability: async () => {
+              throw new Error(inspectionCanary);
+            },
+          });
+        }
+        const result = await maybeRepairGatewayServiceConfig(cfg, "local", runtime, prompter);
+        const configBytes = await fs.readFile(configPath, "utf8");
+        const persisted: OpenClawConfig = JSON.parse(configBytes);
+        const diagnostics = [...edges.note.mock.calls.map(([message]) => message), ...errors].join(
+          "\n",
+        );
+        const observations = {
+          capability,
+          plannedCapability,
+          events,
+          configBytesPreserved: configBytes === originalConfig,
+          configTokenPreserved: persisted.gateway?.auth?.token === cfg.gateway?.auth?.token,
+          embeddedTokenPersisted: persisted.gateway?.auth?.token === embeddedToken,
+          returnedTokenPreserved: result.gateway?.auth?.token === cfg.gateway?.auth?.token,
+          returnedConfigPreserved: isDeepStrictEqual(result, JSON.parse(originalConfig)),
+          unitBytesPreserved: (await fs.readFile(unitPath, "utf8")) === originalUnit,
+          environmentBytesPreserved:
+            (await fs.readFile(environmentPath, "utf8")) === originalEnvironment,
+          installedEnvironmentBytesPreserved:
+            (await fs.readFile(installedEnvironmentPath, "utf8")) === originalEnvironment,
+          unitDirectoryEntries: await fs.readdir(path.dirname(unitPath)),
+          nativeActions,
+        };
+        expect(unexpectedProcesses).toEqual([]);
+        expect(diagnostics.includes(embeddedToken)).toBe(false);
+        expect(diagnostics.includes(existingToken)).toBe(false);
+        expect(diagnostics.includes(inspectionCanary)).toBe(false);
+        return { observations, diagnostics, errors };
+      },
+    );
+  }
+
+  it.each(
+    refusals.flatMap(({ scenario, kind, reason, guidance }) =>
+      [false, true].map((tokenPresent) => ({ scenario, kind, reason, guidance, tokenPresent })),
+    ),
+  )(
+    "preserves config and service when $scenario repair is refused (existing token=$tokenPresent)",
+    async ({ scenario, kind, reason, guidance, tokenPresent }) => {
+      const { observations, diagnostics } = await runRepair(scenario, { tokenPresent });
+      expect(observations.capability).toMatchObject({ kind, reason });
+      expect(diagnostics).toContain(`SERVICE_DEFINITION_${kind.toUpperCase()}: [${reason}]`);
+      expect(diagnostics).toContain(guidance);
+      expect(observations.unitBytesPreserved).toBe(true);
+      expect(observations.environmentBytesPreserved).toBe(true);
+      expect(observations.installedEnvironmentBytesPreserved).toBe(true);
+      expect(observations.unitDirectoryEntries).toEqual(["openclaw-gateway.service"]);
+      expect(observations.nativeActions).toEqual([]);
+      expect(observations.events).not.toContain("service-published");
+      expect
+        .soft(observations.configTokenPreserved, "refused repair must preserve the config token")
+        .toBe(true);
+      expect
+        .soft(observations.configBytesPreserved, "refused repair must preserve config bytes")
+        .toBe(true);
+      expect
+        .soft(observations.returnedTokenPreserved, "refused repair must return the original token")
+        .toBe(true);
+      expect(observations.returnedConfigPreserved).toBe(true);
+    },
+  );
+
+  it.each(refusals)(
+    "preserves config and service when $scenario update staging is refused",
+    async ({ scenario, kind, reason }) => {
+      const { observations, diagnostics } = await runRepair(scenario, { update: true });
+      expect(observations.capability).toMatchObject({ kind, reason });
+      expect(diagnostics).toContain(`SERVICE_DEFINITION_${kind.toUpperCase()}: [${reason}]`);
+      expect(observations.configBytesPreserved).toBe(true);
+      expect(observations.configTokenPreserved).toBe(true);
+      expect(observations.returnedConfigPreserved).toBe(true);
+      expect(observations.unitBytesPreserved).toBe(true);
+      expect(observations.environmentBytesPreserved).toBe(true);
+      expect(observations.unitDirectoryEntries).toEqual(["openclaw-gateway.service"]);
+      expect(observations.events).not.toContain("service-published");
+      expect(observations.nativeActions).toEqual([]);
+    },
+  );
+
+  it.each(["installed", "planned"] as const)(
+    "preserves both generated environments when only the %s target is protected",
+    async (blockedTarget) => {
+      const { observations, diagnostics } = await runRepair("unsafe", { blockedTarget });
+      const denied = { kind: "unknown", reason: "unsafe-permissions" };
+      expect(observations.capability).toMatchObject(
+        blockedTarget === "installed" ? denied : { kind: "writable" },
+      );
+      expect(observations.plannedCapability).toMatchObject(
+        blockedTarget === "planned" ? denied : { kind: "writable" },
+      );
+      expect(diagnostics).toContain("SERVICE_DEFINITION_UNKNOWN: [unsafe-permissions]");
+      expect(diagnostics).toContain("chmod go-w");
+      expect(observations).toMatchObject({
+        configBytesPreserved: true,
+        configTokenPreserved: true,
+        returnedConfigPreserved: true,
+        unitBytesPreserved: true,
+        environmentBytesPreserved: true,
+        installedEnvironmentBytesPreserved: true,
+        unitDirectoryEntries: ["openclaw-gateway.service"],
+        nativeActions: [],
+      });
+      expect(observations.events).not.toContain("service-published");
+    },
+  );
+
+  it("redacts a rejected capability inspection and leaves the repair untouched", async () => {
+    const { observations, diagnostics } = await runRepair("rejected");
+    expect(diagnostics).toContain("SERVICE_DEFINITION_UNKNOWN: [inspection-failed]");
+    expect(diagnostics).toContain("native service-manager availability");
+    expect(observations).toMatchObject({
+      configBytesPreserved: true,
+      configTokenPreserved: true,
+      returnedConfigPreserved: true,
+      unitBytesPreserved: true,
+      environmentBytesPreserved: true,
+      installedEnvironmentBytesPreserved: true,
+      unitDirectoryEntries: ["openclaw-gateway.service"],
+      nativeActions: [],
+    });
+    expect(observations.events).not.toContain("service-published");
+  });
+
+  it("preserves authentication while publishing an authorized service repair", async () => {
+    const { observations, errors } = await runRepair("writable");
+    expect(observations.capability).toEqual({ kind: "writable" });
+    expect(errors).toEqual([]);
+    expect(observations.embeddedTokenPersisted).toBe(true);
+    expect(observations.unitBytesPreserved).toBe(false);
+    expect(observations.events.indexOf("config-published")).toBeLessThan(
+      observations.events.indexOf("service-published"),
+    );
+    expect(observations.nativeActions).toEqual(["daemon-reload", "enable", "restart"]);
+    expect(observations.unitDirectoryEntries).toEqual([
+      "openclaw-gateway.service",
+      "openclaw-gateway.service.bak",
+    ]);
+  });
+});

--- a/src/commands/doctor-gateway-services.ts
+++ b/src/commands/doctor-gateway-services.ts
@@ -27,6 +27,7 @@ import {
   readEmbeddedGatewayToken,
   SERVICE_AUDIT_CODES,
 } from "../daemon/service-audit.js";
+import { mergeGatewayServiceEnv } from "../daemon/service-env-merge.js";
 import { SERVICE_PROXY_ENV_KEYS } from "../daemon/service-env.js";
 import { summarizeGatewayServiceLayout } from "../daemon/service-layout.js";
 import {
@@ -35,6 +36,7 @@ import {
 } from "../daemon/service-managed-env.js";
 import type { GatewayServiceRuntime } from "../daemon/service-runtime.js";
 import {
+  assertServiceDefinitionWritable,
   hasGatewayServiceEnvironmentOverride,
   hasGatewayServiceLauncherOverride,
   resolveManagedGatewayServiceCommand,
@@ -773,6 +775,24 @@ export async function maybeRepairGatewayServiceConfig(
         "Gateway service config",
       );
     }
+    return cfg;
+  }
+  try {
+    // Installed and planned environments can select different state files. Check
+    // both before token persistence; native publication still revalidates under locks.
+    for (const environment of [
+      mergeGatewayServiceEnv(serviceInstallEnv, command),
+      expectedRuntimePlan.environment,
+    ]) {
+      const capability = await service
+        .readDefinitionMutationCapability?.({ env: serviceInstallEnv, environment })
+        .catch(() => ({ kind: "unknown", reason: "inspection-failed" }) as const);
+      if (capability) {
+        assertServiceDefinitionWritable(capability);
+      }
+    }
+  } catch (err) {
+    runtime.error(`Gateway service repair blocked: ${String(err)}`);
     return cfg;
   }
   const serviceEmbeddedToken = readEmbeddedGatewayToken(managedDefinition);


### PR DESCRIPTION
Closes #132371 — Doctor persists a recovered token before refusing service repair.

<details>
<summary>Additional instructions</summary>

This maintainer branch is in `openclaw/openclaw` and is available for maintainer edits.

</details>

## What Problem This Solves

Fixes an issue where users repairing their gateway service would get a changed config/token even when a sealed, unsafe, or uninspectable service definition caused the repair to be refused. Doctor could persist a recovered embedded token before the native service owner reached its mutation-authority check.

## Why This Change Was Made

Doctor now checks the existing native mutation capability for both the installed effective environment and the planned environment, after eligibility and confirmation but before recovered-token persistence. A refusal returns the original config through the canonical service-definition diagnostic; rejected inspections become `unknown` / `inspection-failed` without exposing the rejected error.

Native service publication still revalidates authority under its existing locks. No native guard is changed or removed, and confirmation, external ownership, update staging, Windows repair behavior, and SecretRef handling remain in their existing owners. The documentation also corrects the adjacent `--yes` / `--fix` confirmation description.

## User Impact

When the preflight refuses service repair, that repair leaves config, token, and service files unchanged and reports the existing remediation guidance. Authorized repair still preserves authentication before service publication; unrelated Doctor config repairs are unaffected. `--force` does not bypass native authority.

Production LOC: **+20/-0**. These lines supply the missing check at Doctor's config-publication boundary using the existing capability and diagnostics; they introduce no new authority policy or test-only production seam. Tests: **+425/-0**; docs: **+5/-4**. There are no schema, configuration-option, dependency, native-guard, or timeout changes.

## Evidence

The pre-fix source was `31baa67f98743ac5adb4c01f2e7fe0a94d3a3f66`. The original reproduction had three intended failures and seven passing controls; the expanded reproduction had six intended failures and seven passing controls. Production was not edited before these reproductions. The final patch passes all 13 regression/control cases.

The fixture uses real Doctor, config writing, and native service ownership/publication against temporary on-disk files. Injected OS edges model Linux/systemd on macOS 27.0. Coverage includes sealed mounts, unsafe permissions, inspection failures, missing/existing tokens, update staging, distinct installed/planned environment files, rejected-inspection redaction, and authorized publication ordering. No live systemd instance, real mounted read-only filesystem, operator config, or operator service was modified; live OS behavior and stable-release reachability are not claimed. Real service-manager mutation was outside the authorized proof scope.

Focused local proof passed, with **596 unique cases** overall (13 new plus 583 existing):

```sh
node scripts/run-vitest.mjs src/commands/doctor-gateway-services.authority.test.ts
# 13 passed

node scripts/run-vitest.mjs src/cli/daemon-cli/install.integration.test.ts src/cli/daemon-cli/install.test.ts src/cli/daemon-cli/start-repair.test.ts src/commands/doctor-gateway-daemon-flow.test.ts src/commands/doctor-gateway-services.authority.test.ts src/commands/doctor-gateway-services.test.ts src/commands/doctor-service-repair-policy.test.ts src/daemon/systemd-definition-mutation.test.ts src/daemon/systemd.test.ts
# 535 passed

node scripts/run-vitest.mjs src/commands/doctor-gateway-services.authority.test.ts src/daemon/systemd-definition-mutation.creation.test.ts src/daemon/service.test.ts
# 74 passed, including 13 repeated cases

node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core.tsbuildinfo
node scripts/run-tsgo.mjs -b test/tsconfig/tsconfig.core.test.commands.json --builders 1
node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/commands/doctor-gateway-services.authority.test.ts src/commands/doctor-gateway-services.ts
git diff --check
```

Targeted formatting also passed. A final Codex autoreview of the frozen three-file diff was scoped-clean at P0, with no findings; this is not a claim of an unrestricted all-severity review.

The full local changed gate **did not pass**:

```sh
node scripts/check-changed.mjs -- src/commands/doctor-gateway-services.ts src/commands/doctor-gateway-services.authority.test.ts docs/gateway/doctor.md
```

Its earlier formatting/guard stages passed, then the production Knip dead-export scan hit its unchanged 600-second timeout on a saturated host. No guard was skipped and no timeout was raised. The previous exact-head hosted CI run succeeded, including the dependency/dead-export, lint, type, build, and required gate lanes. This covers the hosted dead-export check; the local timeout remains an incomplete local result. The final documentation-only head also passed its exact-head hosted CI; see the final landing checkpoint below.

AI-assisted with Codex. The maintainer has approved landing through normal native gates; no bypass is authorized.

Publication checkpoint: rebased cleanly onto `293c433a10bcd4727b11505caa1c8a995618a18f`; that publication head was `b48f2f12c67cafa0290b71a466931923ef893ed0`. At that checkpoint all three reviewed file fingerprints were unchanged, and `git range-diff` reports a patch-identical commit. The focused authority command above was rerun on that head: **13 passed** (136.61 seconds including the wrapper).

The PR was opened as a draft, verified `MERGEABLE`, then marked ready. [CI run 33234840184](https://github.com/openclaw/openclaw/actions/runs/33234840184) completed **successfully** through `pull_request` on `b48f2f12c67cafa0290b71a466931923ef893ed0`, including the required `openclaw/ci-gate` and applicable hosted checks/build.

Documentation follow-up: [the accepted ClawSweeper P2 finding](https://github.com/openclaw/openclaw/pull/132375#issuecomment-5460471731) is addressed by exactly two quick-start summary replacements in `docs/gateway/doctor.md`. The `--yes` and `--fix` summaries now match the supervisor notes: non-service repairs can run without prompts; Gateway service definition rewrites still require interactive confirmation. This agrees with `src/commands/doctor-prompter.ts:93`.

Current head: `d88dae9d875136031ae9386b9ed6a01a632dfba8`. Production and test file fingerprints remain unchanged; no code tests or review engines were rerun for this docs-only follow-up. `pnpm docs:list`, `node_modules/.bin/oxfmt --check docs/gateway/doctor.md`, and `git diff --check` passed; the normal commit hook also passed. Exact-head CI is now complete and successful, as recorded below. No schema or persistence redesign is introduced. The prior headless-docs correction and current-head CI rank-up moves are both complete; the maintainer approved normal native landing.


Final landing checkpoint: [CI 33235654731](https://github.com/openclaw/openclaw/actions/runs/33235654731) completed **successfully** via `pull_request` at `d88dae9d875136031ae9386b9ed6a01a632dfba8`, including [build-artifacts 99056195327](https://github.com/openclaw/openclaw/actions/runs/33235654731/job/99056195327), [check-dependencies 99056195388](https://github.com/openclaw/openclaw/actions/runs/33235654731/job/99056195388), and [required openclaw/ci-gate 99056857937](https://github.com/openclaw/openclaw/actions/runs/33235654731/job/99056857937). No failing, cancelled, or timed-out rollup checks were observed. The [current ClawSweeper review](https://github.com/openclaw/openclaw/pull/132375#issuecomment-5460471731), reviewed 2026-08-29T05:21:14.985Z on this head, has no actionable correctness/security findings and confirms the headless-docs finding is resolved. Both rank-up moves are complete. The maintainer approved this frozen head for normal native preparation and merge.

The full local changed gate remains incomplete because of the unchanged 600-second Knip timeout; successful hosted dependency proof does not relabel that local run as passing. The 596 unique local cases remain the previously recorded runs, with no new code-test execution claimed for the two-line docs follow-up or landing mechanics. Proof remains synthetic temporary-file Doctor/config/native-publication coverage with mocked OS edges, not live Linux/systemd or a real read-only mount. Native locks, publication revalidation, ownership, confirmation, Windows and SecretRef controls remain intact. There are no schema, configuration-option, dependency, timeout, or native-guard changes.
