### PR TITLE
test(ollama): advance stalled preflight deadline virtually

### DIFF
--- a/extensions/ollama/src/provider-models.preflight-timeout.test.ts
+++ b/extensions/ollama/src/provider-models.preflight-timeout.test.ts
@@ -7,10 +7,12 @@ const TAGS_TIMEOUT_MS = 5000;
 
 describe("fetchOllamaModels preflight timeout", () => {
   afterEach(() => {
+    vi.useRealTimers();
     vi.unstubAllEnvs();
   });
 
   it("aborts at the configured deadline when preflight lookup stalls", async () => {
+    vi.useFakeTimers();
     vi.stubEnv("OPENCLAW_PROXY_ACTIVE", "0");
     let lookupCalls = 0;
     const stalledLookup: LookupFn = (() => {
@@ -20,15 +22,17 @@ describe("fetchOllamaModels preflight timeout", () => {
     const fetchSpy = vi.fn(async () => new Response("should not run"));
 
     const started = Date.now();
-    const result = await fetchOllamaModels("https://ollama.example.com", undefined, {
+    // Capture settlement time so advancing the clock cannot hide an early timeout.
+    const pending = fetchOllamaModels("https://ollama.example.com", undefined, {
       fetchImpl: fetchSpy,
       lookupFn: stalledLookup,
-    });
-    const elapsedMs = Date.now() - started;
+    }).then((result) => ({ result, elapsedMs: Date.now() - started }));
+    await vi.waitFor(() => expect(lookupCalls).toBeGreaterThan(0));
+    await vi.advanceTimersByTimeAsync(TAGS_TIMEOUT_MS);
+    const { result, elapsedMs } = await pending;
 
     expect(result).toEqual({ reachable: false, models: [] });
     // Preflight ran and never handed off to the socket.
-    expect(lookupCalls).toBeGreaterThan(0);
     expect(fetchSpy).not.toHaveBeenCalled();
     // Bounded by the guard-owned deadline, not left to hang.
     expect(elapsedMs).toBeGreaterThanOrEqual(TAGS_TIMEOUT_MS - 500);


### PR DESCRIPTION
## What Problem This Solves

The stalled DNS-preflight test spends five seconds waiting for the production discovery deadline, even though it deliberately never opens a socket.

## Why This Change Was Made

Use a test clock only for the stalled-lookup case, wait until the real guarded-fetch preflight enters the existing lookup fixture, then advance the unchanged five-second deadline. Capture elapsed time when the request settles so an incorrectly early timeout still fails the original lower-bound assertion. Restore real timers before the successful-lookup sibling.

The real guard, DNS cancellation, default timeout, result assertions, no-fetch assertion, and both elapsed-time bounds remain. No production code changes.

## User Impact

The two preflight tests execute in **0.245s instead of 5.078s** locally. No sharding, worker, selection, production timeout, configuration or dependency changes. Production LOC +0/-0; tests +8/-4.

## Evidence

- Before/after focused and sibling runs passed; the final preflight, provider-model and stream run passed **88 tests across three files**. Command: `node scripts/run-vitest.mjs extensions/ollama/src/provider-models.preflight-timeout.test.ts extensions/ollama/src/provider-models.test.ts extensions/ollama/src/stream.test.ts`.
- Removing the production timeout leaves the existing stalled lookup unresolved and fails a bounded negative probe. Shortening it incorrectly to one second fails the retained lower bound with `expected 1000 to be greater than or equal to 4500`. Production bytes were restored before the final passing run. The negative probes used a two-second runner timeout only to bound deliberate broken-code experiments; no runner timeout changed in this PR.
- Read the model-discovery owner, guarded-fetch deadline owner and abortable DNS-preflight implementation. Independent source review and fresh Codex autoreview found no actionable findings. Formatting and whitespace checks passed.
- Changed-file Linux `check:changed` passed (delegated Testbox exit 0 and stopped; [runner record](https://github.com/openclaw/openclaw/actions/runs/33234847124)). [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/33234880896) passed at `57ad58d4d8d11bbc44d04b1ef4c7c6c785d5ac60`.

The adjacent six-second real stream fixture is intentionally unchanged. History in #127669 shows its five-second idle allowance was chosen to remove load-sensitive timing; reducing that allowance would risk bringing the flake back. This PR speeds the socket-free preflight case without reducing that scheduling tolerance.
