### PR TITLE
fix(acp): surface the abort cause carried on aborted chat events

### DIFF
--- a/src/acp/translator.abort-cause.e2e.test.ts
+++ b/src/acp/translator.abort-cause.e2e.test.ts
@@ -1,0 +1,277 @@
+import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
+import { createServer, type Server, type ServerResponse } from "node:http";
+import { Readable, Writable } from "node:stream";
+import { setTimeout as delay } from "node:timers/promises";
+import {
+  ClientSideConnection,
+  PROTOCOL_VERSION,
+  ndJsonStream,
+  type SessionNotification,
+} from "@agentclientprotocol/sdk";
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
+import { describe, expect, it } from "vitest";
+import {
+  createOpenClawTestInstance,
+  type OpenClawTestInstance,
+} from "../../test/helpers/openclaw-test-instance.js";
+import { GatewayClient } from "../gateway/client.js";
+
+const ABORT_CAUSE = "session_status tool validation failed: invalid arguments";
+
+function writeToolCall(response: ServerResponse): void {
+  const call = {
+    type: "function_call",
+    id: "fc_abort_cause",
+    call_id: "call_abort_cause",
+    name: "session_status",
+    arguments: JSON.stringify({ changesSince: "not-a-number" }),
+  };
+  const events = [
+    {
+      type: "response.output_item.added",
+      output_index: 0,
+      item: { ...call, arguments: "" },
+    },
+    {
+      type: "response.function_call_arguments.delta",
+      item_id: call.id,
+      output_index: 0,
+      delta: call.arguments,
+    },
+    { type: "response.output_item.done", output_index: 0, item: call },
+    {
+      type: "response.completed",
+      response: {
+        id: "resp_abort_cause",
+        status: "completed",
+        output: [call],
+        usage: { input_tokens: 20, output_tokens: 10, total_tokens: 30 },
+      },
+    },
+  ];
+  response.writeHead(200, {
+    "content-type": "text/event-stream",
+    "cache-control": "no-store",
+    connection: "keep-alive",
+  });
+  response.end(
+    `${events.map((event) => `data: ${JSON.stringify(event)}\n\n`).join("")}data: [DONE]\n\n`,
+  );
+}
+
+async function listen(server: Server): Promise<number> {
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("mock provider did not bind a loopback port");
+  }
+  return address.port;
+}
+
+async function connectOperator(instance: OpenClawTestInstance): Promise<GatewayClient> {
+  return await new Promise<GatewayClient>((resolve, reject) => {
+    let settled = false;
+    const client = new GatewayClient({
+      url: instance.url,
+      token: instance.gatewayToken,
+      clientName: "cli",
+      clientDisplayName: "ACP abort-cause test operator",
+      clientVersion: "test",
+      mode: "cli",
+      role: "operator",
+      scopes: ["operator.write", "operator.admin"],
+      deviceIdentity: null,
+      env: instance.env,
+      sharedStateMode: "read-only",
+      onHelloOk: () => {
+        settled = true;
+        resolve(client);
+      },
+      onConnectError: reject,
+      onClose: (code, reason) => {
+        if (!settled) {
+          reject(new Error(`operator connection closed: ${code} ${reason}`));
+        }
+      },
+    });
+    client.start();
+  });
+}
+
+async function stopChild(child: ChildProcessWithoutNullStreams | undefined): Promise<void> {
+  if (!child || child.exitCode !== null || child.signalCode !== null) {
+    return;
+  }
+  child.stdin.end();
+  const exited = await Promise.race([
+    new Promise<boolean>((resolve) => {
+      child.once("exit", () => resolve(true));
+    }),
+    delay(2_000).then(() => false),
+  ]);
+  if (!exited && child.exitCode === null && child.signalCode === null) {
+    child.kill("SIGKILL");
+  }
+}
+
+describe("openclaw acp abort causes", () => {
+  it(
+    "shows the carried tool-validation cause before cancelled settlement",
+    { timeout: 120_000 },
+    async () => {
+      let instance: OpenClawTestInstance | undefined;
+      let operator: GatewayClient | undefined;
+      let acpProcess: ChildProcessWithoutNullStreams | undefined;
+      const stalledResponses = new Set<ServerResponse>();
+      let providerRequestCount = 0;
+      let failedToolUpdate = false;
+      const provider = createServer((request, response) => {
+        void (async () => {
+          const chunks: Buffer[] = [];
+          for await (const chunk of request) {
+            chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+          }
+          if (request.method !== "POST" || request.url !== "/v1/responses") {
+            response.writeHead(404).end();
+            return;
+          }
+          providerRequestCount += 1;
+          const body: unknown = JSON.parse(Buffer.concat(chunks).toString("utf8"));
+          const tools = isRecord(body) && Array.isArray(body.tools) ? body.tools : [];
+          if (!tools.some((tool) => isRecord(tool) && tool.name === "session_status")) {
+            throw new Error("session_status tool missing from provider request");
+          }
+          if (providerRequestCount > 1) {
+            stalledResponses.add(response);
+            request.once("close", () => stalledResponses.delete(response));
+            return;
+          }
+          writeToolCall(response);
+        })().catch((error: unknown) => response.writeHead(500).end(String(error)));
+      });
+
+      try {
+        const providerPort = await listen(provider);
+        instance = await createOpenClawTestInstance({
+          name: "acp-abort-cause",
+          config: {
+            agents: {
+              defaults: {
+                workspace: process.cwd(),
+                skipBootstrap: true,
+                model: { primary: "mock-openai/gpt-acp-abort-cause" },
+                models: {
+                  "mock-openai/gpt-acp-abort-cause": {
+                    params: { transport: "sse", openaiWsWarmup: false },
+                  },
+                },
+              },
+            },
+            models: {
+              mode: "replace",
+              providers: {
+                "mock-openai": {
+                  baseUrl: `http://127.0.0.1:${providerPort}/v1`,
+                  apiKey: "test",
+                  api: "openai-responses",
+                  models: [
+                    {
+                      id: "gpt-acp-abort-cause",
+                      name: "gpt-acp-abort-cause",
+                      api: "openai-responses",
+                      reasoning: false,
+                      input: ["text"],
+                      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                      contextWindow: 128_000,
+                      maxTokens: 4096,
+                    },
+                  ],
+                },
+              },
+            },
+            plugins: { slots: { memory: "none" } },
+          },
+          env: {
+            OPENCLAW_TEST_MINIMAL_GATEWAY: "0",
+            OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1",
+          },
+        });
+        await instance.startGateway();
+        operator = await connectOperator(instance);
+
+        const entrypoint = await instance.entrypoint();
+        acpProcess = spawn(
+          process.execPath,
+          [...entrypoint, "acp", "--url", instance.url, "--token", instance.gatewayToken],
+          { cwd: process.cwd(), env: instance.env, stdio: ["pipe", "pipe", "pipe"] },
+        );
+        const timeline: string[] = [];
+        // SAFETY: Node and DOM ReadableStream types describe the same runtime object here.
+        const output = Readable.toWeb(acpProcess.stdout) as Parameters<typeof ndJsonStream>[1];
+        const stream = ndJsonStream(Writable.toWeb(acpProcess.stdin), output);
+        const client = new ClientSideConnection(
+          () => ({
+            sessionUpdate: async (notification: SessionNotification) => {
+              const update = notification.update;
+              if (
+                update.sessionUpdate === "agent_message_chunk" &&
+                update.content.type === "text"
+              ) {
+                timeline.push(update.content.text);
+              }
+              if (update.sessionUpdate === "tool_call_update" && update.status === "failed") {
+                failedToolUpdate = true;
+              }
+            },
+            requestPermission: async () => ({ outcome: { outcome: "cancelled" } }),
+          }),
+          stream,
+        );
+        await client.initialize({
+          protocolVersion: PROTOCOL_VERSION,
+          clientCapabilities: { fs: { readTextFile: true, writeTextFile: true }, terminal: true },
+          clientInfo: { name: "openclaw-acp-abort-cause-test", version: "1.0.0" },
+        });
+        const sessionKey = `agent:main:acp-abort-cause-${process.pid}`;
+        const session = await client.newSession({
+          cwd: process.cwd(),
+          mcpServers: [],
+          _meta: { sessionKey },
+        });
+        const prompt = client.prompt({
+          sessionId: session.sessionId,
+          prompt: [{ type: "text", text: "Call session_status now." }],
+        });
+
+        await expect
+          .poll(() => ({ failedToolUpdate, providerRequestCount }), {
+            timeout: 30_000,
+            interval: 25,
+          })
+          .toEqual({ failedToolUpdate: true, providerRequestCount: 2 });
+        await expect(operator.request("chat.abort", { sessionKey })).resolves.toMatchObject({
+          aborted: true,
+        });
+        const result = await prompt;
+        timeline.push(result.stopReason);
+
+        expect(timeline).toContain(`[OpenClaw interruption] ${ABORT_CAUSE}`);
+        expect(timeline.at(-1)).toBe("cancelled");
+      } finally {
+        for (const response of stalledResponses) {
+          response.destroy();
+        }
+        await stopChild(acpProcess);
+        await operator?.stopAndWait({ timeoutMs: 1_000 }).catch(() => operator?.stop());
+        await instance?.cleanup();
+        provider.closeAllConnections();
+        await new Promise<void>((resolve) => {
+          provider.close(() => resolve());
+        });
+      }
+    },
+  );
+});

--- a/src/acp/translator.prompt-harness.test-support.ts
+++ b/src/acp/translator.prompt-harness.test-support.ts
@@ -11,6 +11,7 @@ type PendingPromptHarness = {
   agent: AcpGatewayAgent;
   promptPromise: ReturnType<AcpGatewayAgent["prompt"]>;
   runId: string;
+  sessionUpdate: ReturnType<typeof vi.fn>;
 };
 
 // Shared prompt harness used by translator cancellation and lifecycle tests.
@@ -31,7 +32,8 @@ export function createSessionAgentHarness(
     sessionKey,
     cwd: options.cwd ?? "/tmp",
   });
-  const agent = new AcpGatewayAgent(createAcpConnection(), createAcpGateway(request), {
+  const connection = createAcpConnection();
+  const agent = new AcpGatewayAgent(connection, createAcpGateway(request), {
     sessionStore,
   });
 
@@ -40,6 +42,7 @@ export function createSessionAgentHarness(
     sessionId,
     sessionKey,
     sessionStore,
+    sessionUpdate: connection.__sessionUpdateMock,
   };
 }
 
@@ -77,7 +80,7 @@ export async function createPendingPromptHarness(): Promise<PendingPromptHarness
     return {};
   }) as GatewayClient["request"];
 
-  const { agent, sessionId } = createSessionAgentHarness(request);
+  const { agent, sessionId, sessionUpdate } = createSessionAgentHarness(request);
   const promptPromise = promptAgent(agent, sessionId);
 
   await vi.waitFor(() => {
@@ -88,6 +91,7 @@ export async function createPendingPromptHarness(): Promise<PendingPromptHarness
     agent,
     promptPromise,
     runId: runId!,
+    sessionUpdate,
   };
 }
 

--- a/src/acp/translator.prompt-harness.test-support.ts
+++ b/src/acp/translator.prompt-harness.test-support.ts
@@ -42,7 +42,7 @@ export function createSessionAgentHarness(
     sessionId,
     sessionKey,
     sessionStore,
-    sessionUpdate: connection.__sessionUpdateMock,
+    sessionUpdate: connection["__sessionUpdateMock"],
   };
 }
 

--- a/src/acp/translator.prompt-stream.ts
+++ b/src/acp/translator.prompt-stream.ts
@@ -518,7 +518,8 @@ export class AcpTranslatorPromptStream {
       return;
     }
     if (state === "aborted") {
-      const errorMessage = payload.errorMessage as string | undefined;
+      const errorMessage =
+        typeof payload.errorMessage === "string" ? payload.errorMessage : undefined;
       if (errorMessage?.trim()) {
         // The Gateway attaches the abort cause (e.g. tool validation failure)
         // to the event; surface it or the IDE shows a bare "cancelled" for a

--- a/src/acp/translator.prompt-stream.ts
+++ b/src/acp/translator.prompt-stream.ts
@@ -518,19 +518,26 @@ export class AcpTranslatorPromptStream {
       return;
     }
     if (state === "aborted") {
+      // Claim before the first await so a stalled or rejected interruption
+      // delivery cannot strand the prompt (same shape as settleRecoveredPrompt).
+      if (!this.claimPendingPrompt(pending)) {
+        return;
+      }
       const errorMessage =
-        typeof payload.errorMessage === "string" ? payload.errorMessage : undefined;
-      if (errorMessage?.trim()) {
+        typeof payload.errorMessage === "string" ? payload.errorMessage.trim() : undefined;
+      if (errorMessage) {
         // The Gateway attaches the abort cause (e.g. tool validation failure)
         // to the event; surface it or the IDE shows a bare "cancelled" for a
-        // run that actually died from an error.
+        // run that actually died from an error. Nonblocking: the notice is
+        // best-effort and must not hold terminal settlement hostage.
         await this.emitPromptChunk(
           pending,
           "agent_message_chunk",
-          `[OpenClaw interruption] ${errorMessage.trim()}`,
+          `[OpenClaw interruption] ${errorMessage}`,
+          false,
         );
       }
-      await this.finishPrompt(pending.sessionId, pending, "cancelled");
+      await this.finishPrompt(pending.sessionId, pending, "cancelled", { claimed: true });
       return;
     }
     if (state === "error") {

--- a/src/acp/translator.prompt-stream.ts
+++ b/src/acp/translator.prompt-stream.ts
@@ -518,6 +518,17 @@ export class AcpTranslatorPromptStream {
       return;
     }
     if (state === "aborted") {
+      const errorMessage = payload.errorMessage as string | undefined;
+      if (errorMessage?.trim()) {
+        // The Gateway attaches the abort cause (e.g. tool validation failure)
+        // to the event; surface it or the IDE shows a bare "cancelled" for a
+        // run that actually died from an error.
+        await this.emitPromptChunk(
+          pending,
+          "agent_message_chunk",
+          `[OpenClaw interruption] ${errorMessage.trim()}`,
+        );
+      }
       await this.finishPrompt(pending.sessionId, pending, "cancelled");
       return;
     }

--- a/src/acp/translator.prompt-stream.ts
+++ b/src/acp/translator.prompt-stream.ts
@@ -518,26 +518,9 @@ export class AcpTranslatorPromptStream {
       return;
     }
     if (state === "aborted") {
-      // Claim before the first await so a stalled or rejected interruption
-      // delivery cannot strand the prompt (same shape as settleRecoveredPrompt).
-      if (!this.claimPendingPrompt(pending)) {
-        return;
-      }
-      const errorMessage =
-        typeof payload.errorMessage === "string" ? payload.errorMessage.trim() : undefined;
-      if (errorMessage) {
-        // The Gateway attaches the abort cause (e.g. tool validation failure)
-        // to the event; surface it or the IDE shows a bare "cancelled" for a
-        // run that actually died from an error. Nonblocking: the notice is
-        // best-effort and must not hold terminal settlement hostage.
-        await this.emitPromptChunk(
-          pending,
-          "agent_message_chunk",
-          `[OpenClaw interruption] ${errorMessage}`,
-          false,
-        );
-      }
-      await this.finishPrompt(pending.sessionId, pending, "cancelled", { claimed: true });
+      const interruption =
+        typeof payload.errorMessage === "string" ? payload.errorMessage : undefined;
+      await this.finishPrompt(pending.sessionId, pending, "cancelled", { interruption });
       return;
     }
     if (state === "error") {
@@ -592,10 +575,19 @@ export class AcpTranslatorPromptStream {
     sessionId: string,
     pending: AcpPendingPrompt,
     stopReason: StopReason,
-    options: { claimed?: boolean } = {},
+    options: { claimed?: boolean; interruption?: string } = {},
   ): Promise<void> {
     if (!options.claimed && !this.claimPendingPrompt(pending)) {
       return;
+    }
+    if (options.interruption) {
+      // Persist the visible reason before settlement without waiting for client delivery.
+      await this.emitPromptChunk(
+        pending,
+        "agent_message_chunk",
+        `[OpenClaw interruption] ${options.interruption}`,
+        false,
+      );
     }
     const promptKey = this.pendingPromptKey(sessionId, pending.idempotencyKey);
     this.settlingPromptKeys.add(promptKey);

--- a/src/acp/translator.stop-reason.test.ts
+++ b/src/acp/translator.stop-reason.test.ts
@@ -144,7 +144,14 @@ describe("acp translator stop reason mapping", () => {
     await expect(promptPromise).resolves.toEqual({ stopReason: "cancelled" });
   });
 
-  it("aborted state with errorMessage surfaces the cause before resolving as cancelled", async () => {
+  async function createAbortedPromptHarness(
+    sessionUpdateImpl: (params: unknown) => Promise<void>,
+  ): Promise<{
+    agent: AcpGatewayAgent;
+    promptPromise: Promise<unknown>;
+    sessionUpdate: ReturnType<typeof vi.fn>;
+    getRunId: () => string | undefined;
+  }> {
     let runId: string | undefined;
     const request = vi.fn(async (method: string, params?: Record<string, unknown>) => {
       if (method === "chat.send") {
@@ -154,9 +161,7 @@ describe("acp translator stop reason mapping", () => {
       return {};
     }) as GatewayClient["request"];
     const connection = createAcpConnection();
-    const sessionUpdate = vi.fn(
-      async (_params: Parameters<typeof connection.sessionUpdate>[0]) => {},
-    );
+    const sessionUpdate = vi.fn(sessionUpdateImpl);
     connection.sessionUpdate = sessionUpdate as typeof connection.sessionUpdate;
     const sessionStore = createInMemorySessionStore();
     sessionStore.createSession({
@@ -169,8 +174,11 @@ describe("acp translator stop reason mapping", () => {
     await vi.waitFor(() => {
       expect(runId).toBeDefined();
     });
+    return { agent, promptPromise, sessionUpdate, getRunId: () => runId };
+  }
 
-    await agent.handleGatewayEvent(
+  function sendAbortWithCause(agent: AcpGatewayAgent, runId: string | undefined): Promise<void> {
+    return agent.handleGatewayEvent(
       createChatEvent({
         runId,
         sessionKey: "agent:main:main",
@@ -179,6 +187,14 @@ describe("acp translator stop reason mapping", () => {
         errorMessage: "Tool validation failed: command contains unsupported flag",
       }),
     );
+  }
+
+  it("aborted state with errorMessage surfaces the cause before resolving as cancelled", async () => {
+    const { agent, promptPromise, sessionUpdate, getRunId } = await createAbortedPromptHarness(
+      async () => {},
+    );
+
+    await sendAbortWithCause(agent, getRunId());
 
     await expect(promptPromise).resolves.toEqual({ stopReason: "cancelled" });
     const chunkTexts = sessionUpdate.mock.calls
@@ -195,6 +211,16 @@ describe("acp translator stop reason mapping", () => {
     expect(chunkTexts).toContain(
       "[OpenClaw interruption] Tool validation failed: command contains unsupported flag",
     );
+  });
+
+  it("resolves as cancelled when the interruption notice delivery rejects", async () => {
+    const { agent, promptPromise, getRunId } = await createAbortedPromptHarness(async () => {
+      throw new Error("client gone");
+    });
+
+    await sendAbortWithCause(agent, getRunId());
+
+    await expect(promptPromise).resolves.toEqual({ stopReason: "cancelled" });
   });
 
   it("reconciles provisional ACP session keys to canonical Gateway keys by run id", async () => {

--- a/src/acp/translator.stop-reason.test.ts
+++ b/src/acp/translator.stop-reason.test.ts
@@ -154,6 +154,10 @@ describe("acp translator stop reason mapping", () => {
       return {};
     }) as GatewayClient["request"];
     const connection = createAcpConnection();
+    const sessionUpdate = vi.fn(
+      async (_params: Parameters<typeof connection.sessionUpdate>[0]) => {},
+    );
+    connection.sessionUpdate = sessionUpdate as typeof connection.sessionUpdate;
     const sessionStore = createInMemorySessionStore();
     sessionStore.createSession({
       sessionId: "session-1",
@@ -177,7 +181,7 @@ describe("acp translator stop reason mapping", () => {
     );
 
     await expect(promptPromise).resolves.toEqual({ stopReason: "cancelled" });
-    const chunkTexts = connection.__sessionUpdateMock.mock.calls
+    const chunkTexts = sessionUpdate.mock.calls
       .map(
         ([params]) =>
           (

--- a/src/acp/translator.stop-reason.test.ts
+++ b/src/acp/translator.stop-reason.test.ts
@@ -144,6 +144,55 @@ describe("acp translator stop reason mapping", () => {
     await expect(promptPromise).resolves.toEqual({ stopReason: "cancelled" });
   });
 
+  it("aborted state with errorMessage surfaces the cause before resolving as cancelled", async () => {
+    let runId: string | undefined;
+    const request = vi.fn(async (method: string, params?: Record<string, unknown>) => {
+      if (method === "chat.send") {
+        runId = params?.idempotencyKey as string | undefined;
+        return new Promise<never>(() => {});
+      }
+      return {};
+    }) as GatewayClient["request"];
+    const connection = createAcpConnection();
+    const sessionStore = createInMemorySessionStore();
+    sessionStore.createSession({
+      sessionId: "session-1",
+      sessionKey: "agent:main:main",
+      cwd: "/tmp",
+    });
+    const agent = new AcpGatewayAgent(connection, createAcpGateway(request), { sessionStore });
+    const promptPromise = promptAgent(agent, "session-1");
+    await vi.waitFor(() => {
+      expect(runId).toBeDefined();
+    });
+
+    await agent.handleGatewayEvent(
+      createChatEvent({
+        runId,
+        sessionKey: "agent:main:main",
+        seq: 1,
+        state: "aborted",
+        errorMessage: "Tool validation failed: command contains unsupported flag",
+      }),
+    );
+
+    await expect(promptPromise).resolves.toEqual({ stopReason: "cancelled" });
+    const chunkTexts = connection.__sessionUpdateMock.mock.calls
+      .map(
+        ([params]) =>
+          (
+            params as {
+              update?: { sessionUpdate?: string; content?: { text?: string } };
+            }
+          ).update,
+      )
+      .filter((update) => update?.sessionUpdate === "agent_message_chunk")
+      .map((update) => update?.content?.text);
+    expect(chunkTexts).toContain(
+      "[OpenClaw interruption] Tool validation failed: command contains unsupported flag",
+    );
+  });
+
   it("reconciles provisional ACP session keys to canonical Gateway keys by run id", async () => {
     const sentRunIds: string[] = [];
     const request = vi.fn(async (method: string, params?: Record<string, unknown>) => {

--- a/src/acp/translator.stop-reason.test.ts
+++ b/src/acp/translator.stop-reason.test.ts
@@ -144,40 +144,7 @@ describe("acp translator stop reason mapping", () => {
     await expect(promptPromise).resolves.toEqual({ stopReason: "cancelled" });
   });
 
-  async function createAbortedPromptHarness(
-    sessionUpdateImpl: (params: unknown) => Promise<void>,
-  ): Promise<{
-    agent: AcpGatewayAgent;
-    promptPromise: Promise<unknown>;
-    sessionUpdate: ReturnType<typeof vi.fn>;
-    getRunId: () => string | undefined;
-  }> {
-    let runId: string | undefined;
-    const request = vi.fn(async (method: string, params?: Record<string, unknown>) => {
-      if (method === "chat.send") {
-        runId = params?.idempotencyKey as string | undefined;
-        return new Promise<never>(() => {});
-      }
-      return {};
-    }) as GatewayClient["request"];
-    const connection = createAcpConnection();
-    const sessionUpdate = vi.fn(sessionUpdateImpl);
-    connection.sessionUpdate = sessionUpdate as typeof connection.sessionUpdate;
-    const sessionStore = createInMemorySessionStore();
-    sessionStore.createSession({
-      sessionId: "session-1",
-      sessionKey: "agent:main:main",
-      cwd: "/tmp",
-    });
-    const agent = new AcpGatewayAgent(connection, createAcpGateway(request), { sessionStore });
-    const promptPromise = promptAgent(agent, "session-1");
-    await vi.waitFor(() => {
-      expect(runId).toBeDefined();
-    });
-    return { agent, promptPromise, sessionUpdate, getRunId: () => runId };
-  }
-
-  function sendAbortWithCause(agent: AcpGatewayAgent, runId: string | undefined): Promise<void> {
+  function sendAbortWithCause(agent: AcpGatewayAgent, runId: string): Promise<void> {
     return agent.handleGatewayEvent(
       createChatEvent({
         runId,
@@ -190,35 +157,32 @@ describe("acp translator stop reason mapping", () => {
   }
 
   it("aborted state with errorMessage surfaces the cause before resolving as cancelled", async () => {
-    const { agent, promptPromise, sessionUpdate, getRunId } = await createAbortedPromptHarness(
-      async () => {},
-    );
+    const { agent, promptPromise, runId, sessionUpdate } = await createPendingPromptHarness();
+    const settlement = observeSettlement(promptPromise);
 
-    await sendAbortWithCause(agent, getRunId());
+    await sendAbortWithCause(agent, runId);
 
     await expect(promptPromise).resolves.toEqual({ stopReason: "cancelled" });
-    const chunkTexts = sessionUpdate.mock.calls
-      .map(
-        ([params]) =>
-          (
-            params as {
-              update?: { sessionUpdate?: string; content?: { text?: string } };
-            }
-          ).update,
-      )
-      .filter((update) => update?.sessionUpdate === "agent_message_chunk")
-      .map((update) => update?.content?.text);
-    expect(chunkTexts).toContain(
-      "[OpenClaw interruption] Tool validation failed: command contains unsupported flag",
+    expect(sessionUpdate).toHaveBeenCalledWith({
+      sessionId: "session-1",
+      update: {
+        sessionUpdate: "agent_message_chunk",
+        content: {
+          type: "text",
+          text: "[OpenClaw interruption] Tool validation failed: command contains unsupported flag",
+        },
+      },
+    });
+    expect(sessionUpdate.mock.invocationCallOrder[0]).toBeLessThan(
+      settlement.mock.invocationCallOrder[0] ?? Number.POSITIVE_INFINITY,
     );
   });
 
   it("resolves as cancelled when the interruption notice delivery rejects", async () => {
-    const { agent, promptPromise, getRunId } = await createAbortedPromptHarness(async () => {
-      throw new Error("client gone");
-    });
+    const { agent, promptPromise, runId, sessionUpdate } = await createPendingPromptHarness();
+    sessionUpdate.mockRejectedValueOnce(new Error("client gone"));
 
-    await sendAbortWithCause(agent, getRunId());
+    await sendAbortWithCause(agent, runId);
 
     await expect(promptPromise).resolves.toEqual({ stopReason: "cancelled" });
   });


### PR DESCRIPTION
## What Problem This Solves

Fixes #132262.

The Gateway includes a safe `errorMessage` on an aborted chat event after a tool validation failure. The ACP bridge discarded that field and returned only `cancelled`, so IDE users could not see why the run stopped.

## Root Cause

The ACP aborted-event branch called `finishPrompt` without forwarding the interruption. The Gateway producer and protocol already carried the bounded cause.

## Fix

- Pass the carried abort cause into `finishPrompt`.
- Let `finishPrompt` claim the pending prompt before any asynchronous work.
- Record the interruption before terminal settlement without waiting for ACP client delivery.
- Keep ordinary aborts without a cause byte-identical: they still settle as `cancelled` with no interruption chunk.
- Reuse the shared pending-prompt harness for focused order and rejected-delivery regressions.

## Evidence

Current `main` at `590ee376ad0cee24ed157b401da1b0dbe58a90b7` reproduced the bug through a built Gateway, built `openclaw acp`, ACP SDK client, mock OpenAI Responses provider, invalid `session_status` call, and external `chat.abort`:

```text
stopReason: cancelled
messages: []
surfaced: false
```

The source tree retained in `182ddae3770fff7e86c17de9fb795634330f53e2` produced:

```text
stopReason: cancelled
messages: ["[OpenClaw interruption] session_status tool validation failed: invalid arguments"]
surfaced: true
```

The varied prompt anti-cheat run produced the same correct terminal sequence.

Focused validation:

- Pre-fix regression: 1 failed, 21 passed.
- Fixed stop-reason, delivery, and cancellation suites: 47 passed.
- Built `openclaw acp` process E2E: 1 passed.
- Oxfmt: passed for all changed files.
- Full build: passed in an isolated Linux container.

## Size

- Production: +13/-2, net +11. The growth adds the missing visible abort outcome at the existing terminal owner.
- Tests and test support: +326/-2, net +324. The added E2E keeps the Gateway-to-CLI-to-ACP-client product path repeatable in CI.
