### PR TITLE
fix(ui): let chat widgets use the height they report

### DIFF
--- a/ui/src/e2e/chat-widget-autosize.e2e.test.ts
+++ b/ui/src/e2e/chat-widget-autosize.e2e.test.ts
@@ -1,0 +1,84 @@
+// Chat widgets size to their content: the in-frame reporter drives the host
+// frame, so a tall document must not end up scrolling inside its own row.
+import { expect, it } from "vitest";
+import { buildWidgetDocument } from "../../../src/canvas/wrap.js";
+import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
+import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
+
+const suite = createControlUiE2eSuite({
+  name: "Control UI chat widget autosizing",
+  startServerBeforeBrowser: true,
+});
+
+const documentId = "widget-autosize-proof";
+const documentPath = `/__openclaw__/canvas/documents/${documentId}/index.html`;
+// Taller than any viewport this suite uses, so a frame that fits the content
+// can only come from the reported height rather than from the layout box.
+const rowCount = 90;
+const rowHeight = 28;
+
+suite.define(() => {
+  it("fits a widget taller than the previous frame ceiling", async () => {
+    await suite.withPage({ viewport: { width: 1280, height: 800 } }, async ({ page }) => {
+      await page.route(`**${documentPath}`, async (route) => {
+        await route.fulfill({
+          contentType: "text/html; charset=utf-8",
+          body: buildWidgetDocument(
+            "Autosize proof",
+            `<div style="display:grid">${Array.from(
+              { length: rowCount },
+              (_, index) =>
+                `<div style="height:${rowHeight}px;line-height:${rowHeight}px">Row ${index + 1}</div>`,
+            ).join("")}</div>`,
+          ),
+        });
+      });
+      await installMockGateway(page, {
+        historyMessages: [
+          {
+            role: "assistant",
+            content: [
+              {
+                type: "toolCall",
+                id: "autosize-widget",
+                name: "canvas_render",
+                arguments: { title: "Autosize proof" },
+              },
+              {
+                type: "tool_result",
+                id: "autosize-widget",
+                name: "canvas_render",
+                text: JSON.stringify({
+                  kind: "canvas",
+                  view: {
+                    backend: "canvas",
+                    id: documentId,
+                    url: documentPath,
+                    title: "Autosize proof",
+                  },
+                  presentation: { target: "assistant_message" },
+                }),
+              },
+            ],
+            timestamp: 100,
+          },
+        ],
+      });
+      await page.goto(`${suite.server.baseUrl}chat`);
+      const frame = page.locator(".chat-tool-card__preview-frame");
+      await frame.waitFor();
+      const contentHeight = rowCount * rowHeight;
+      await expect
+        .poll(async () => Math.round((await frame.boundingBox())?.height ?? 0))
+        .toBeGreaterThanOrEqual(contentHeight);
+      // The document is fully laid out inside the frame, so nothing is hidden
+      // behind a nested scrollbar the transcript cannot reach. The frame is
+      // sandboxed and cross-origin, so measure from inside it.
+      const overflow = await frame
+        .contentFrame()
+        .locator("body")
+        .evaluate((body) => body.scrollHeight - window.innerHeight);
+      expect(overflow).toBeLessThanOrEqual(0);
+    });
+  });
+});

--- a/ui/src/pages/chat/components/widget-card.test.ts
+++ b/ui/src/pages/chat/components/widget-card.test.ts
@@ -58,6 +58,37 @@ describe("widget-card", () => {
     expect(host.querySelector("iframe")?.getAttribute("src")).toContain("/__openclaw__/cap/three/");
   });
 
+  it("fits a tall widget instead of scrolling it inside the frame", () => {
+    const host = document.createElement("div");
+    document.body.append(host);
+    render(
+      renderToolPreview(
+        {
+          kind: "canvas",
+          surface: "assistant_message",
+          render: "url",
+          viewId: "cv_tall_widget",
+          url: "/__openclaw__/canvas/documents/cv_tall_widget/index.html",
+          sandbox: "scripts",
+        } as const,
+        "chat_message",
+        { canvasPluginSurfaceUrl: "https://canvas.test/__openclaw__/cap/one" },
+      ),
+      host,
+    );
+    const frame = host.querySelector<HTMLIFrameElement>("iframe");
+    frame?.dispatchEvent(new Event("load"));
+    window.dispatchEvent(
+      new MessageEvent("message", {
+        data: { type: "openclaw:widget-size", height: 3000 },
+        source: frame?.contentWindow,
+      }),
+    );
+    expect(frame?.style.height).toBe("3000px");
+    expect(frame?.style.minHeight).toBe("3000px");
+    host.remove();
+  });
+
   it("keeps a short reported frame height across a capability rotation", () => {
     const preview = {
       kind: "canvas",

--- a/ui/src/pages/chat/components/widget-card.ts
+++ b/ui/src/pages/chat/components/widget-card.ts
@@ -142,7 +142,11 @@ const WIDGET_PROMPT_MESSAGE_TYPE = "openclaw:widget-prompt";
 const WIDGET_PROMPT_HOST_READY_MESSAGE_TYPE = "openclaw:widget-prompt-host-ready";
 const WIDGET_CHAT_HOST_MESSAGE_TYPE = "openclaw:widget-chat-host";
 const WIDGET_FRAME_MIN_HEIGHT = 48;
-const WIDGET_FRAME_MAX_HEIGHT = 1200;
+// The ceiling is an abuse bound, not a layout preference: a widget that reports
+// a runaway size cannot blow up the transcript, but ordinary tall widgets must
+// fit their content here — a frame shorter than its document scrolls inside the
+// row, which hides content behind a nested scrollbar the transcript cannot see.
+const WIDGET_FRAME_MAX_HEIGHT = 8000;
 // Preview frames render inside lit shadow roots, so a document query cannot
 // find them; frames register themselves on load and are dropped once detached.
 const widgetFrameRegistry = new Set<HTMLIFrameElement>();


### PR DESCRIPTION
## What Problem This Solves

Chat widgets already autosize: every hosted widget document carries a size reporter (`src/canvas/wrap.ts`) that measures its body and posts `openclaw:widget-size`, and the transcript applies that height to the frame. The host then clamped every reported height to 1200px, so any taller widget was left scrolling **inside** its own frame — content hidden behind a nested scrollbar the transcript cannot reach, with rows visibly cut at the top and bottom of the card.

## Why This Change Was Made

The ceiling is an abuse bound — it stops a runaway or hostile reporter from blowing up the transcript — not a layout preference. 1200px is well inside the range ordinary widgets reach (a six-panel hardware table is ~1900px), so the bound was silently truncating legitimate content. Raised to 8000px, with the intent stated at the constant so the next reader does not mistake it for a design height. The 420px CSS floor stays as the pre-report placeholder; a report still overrides it in both directions, so short widgets keep collapsing to 48px.

## User Impact

A tall widget now takes the height it needs and you scroll the transcript through it, the same as a long message. No config, no migration. Widgets under 1200px are unaffected.

## Evidence

Production delta is net zero (one constant plus its comment); the rest is test.

Measured on a real Chromium transcript with the real in-frame reporter, content height 1916px:

| | frame height | widget content | reachable |
|---|---|---|---|
| before | 1200 | 1916 | 716px hidden behind an inner scrollbar |
| after | 1916 | 1916 | all of it |

Before — the widget is cut mid-panel and the last two panels are unreachable:

![before](https://github.com/user-attachments/assets/b0add8d0-79bc-4c3e-9f22-88e030206840)

After — the final panel ends cleanly inside the transcript:

![after](https://github.com/user-attachments/assets/0e840339-1ceb-4772-8475-411f2118e350)

Regression coverage, both proven to fail against the old 1200px ceiling and pass with the fix:

- `ui/src/e2e/chat-widget-autosize.e2e.test.ts` — real browser, real widget document, asserts the frame fits the content and the document does not overflow its own frame.
- `ui/src/pages/chat/components/widget-card.test.ts` — the host applies a 3000px report to both `height` and `min-height`.

Local: `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/chat-widget-autosize.e2e.test.ts` (1 passed), `node scripts/run-vitest.mjs ui/src/pages/chat/components/widget-card.test.ts` (9 passed), `node scripts/check-changed.mjs` (green), autoreview clean.
