### PR TITLE
fix(talk): remove scheduler sensitivity from relay startup proof

### DIFF
--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/RealtimeTalkRelaySessionTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/RealtimeTalkRelaySessionTests.swift
@@ -250,7 +250,6 @@ private final class TestRealtimeTalkAudioCapture: RealtimeTalkAudioCapturing {
     private(set) var startCount = 0
     private(set) var stopCount = 0
     private var onFailure: (@MainActor (String) -> Void)?
-    private let started = RealtimeRelayTestSignal<Void>()
 
     func start(
         targetSampleRate: Double,
@@ -260,7 +259,6 @@ private final class TestRealtimeTalkAudioCapture: RealtimeTalkAudioCapturing {
         self.isStarted = true
         self.startCount += 1
         self.onFailure = onFailure
-        self.started.send(())
     }
 
     func stop() {
@@ -271,10 +269,6 @@ private final class TestRealtimeTalkAudioCapture: RealtimeTalkAudioCapturing {
 
     func fail(_ message: String) {
         self.onFailure?(message)
-    }
-
-    func waitUntilStarted() async throws {
-        _ = try await self.started.next("audio capture to start")
     }
 }
 
@@ -1581,9 +1575,16 @@ extension RealtimeTalkRelaySessionTests {
         #expect(!audioCapture.isStarted)
     }
 
-    @Test func `pre-ready event stream end promptly fails startup and closes created session once`() async throws {
+    @Test(arguments: [true, false])
+    func `pre-ready event stream end fails startup and closes created session once`(
+        processedBeforeRegistration: Bool) async throws
+    {
         let requests = RealtimeRelayStartupRequestLog()
         let eventChannel = AsyncStream<EventFrame>.makeStream()
+        let issueObserved = AsyncStream.makeStream(of: Void.self, bufferingPolicy: .bufferingNewest(1))
+        let startupCompleted = RealtimeRelayTestSignal<Result<Void, any Error>>()
+        let audioCapture = TestRealtimeTalkAudioCapture()
+        var endedEventStream = false
         let result = TalkSessionCreateResult(
             sessionid: "talk-session",
             mode: AnyCodable("realtime"),
@@ -1599,8 +1600,19 @@ extension RealtimeTalkRelaySessionTests {
                     return resultData
                 }
                 return Data("{\"ok\":true}".utf8)
+            },
+            isCurrent: { @MainActor () async -> Bool in
+                guard audioCapture.isStarted, !endedEventStream else { return true }
+                endedEventStream = true
+                eventChannel.continuation.finish()
+                // Suspending here lets the pump save the issue before waiter registration.
+                // Otherwise this MainActor segment registers the waiter before the pump can run.
+                if processedBeforeRegistration {
+                    var iterator = issueObserved.stream.makeAsyncIterator()
+                    _ = await iterator.next()
+                }
+                return true
             })
-        let audioCapture = TestRealtimeTalkAudioCapture()
         var issues: [RealtimeTalkRelayIssue] = []
         let session = RealtimeTalkRelaySession(
             transport: transport,
@@ -1608,26 +1620,55 @@ extension RealtimeTalkRelaySessionTests {
             audioCapture: audioCapture,
             pcmPlayer: UnusedPCMStreamingAudioPlayer(),
             onStatus: { _ in },
-            onIssue: { issues.append($0) },
+            onIssue: {
+                issues.append($0)
+                issueObserved.continuation.yield(())
+            },
             onSpeakingChanged: { _ in })
-        let start = Task { @MainActor in try await session.start() }
-        try await audioCapture.waitUntilStarted()
-
-        let disconnectedAt = ContinuousClock.now
-        eventChannel.continuation.finish()
-        do {
-            try await start.value
-            Issue.record("Expected the pre-ready event stream end to throw")
-        } catch {
-            #expect(error.localizedDescription == "Realtime connection ended before it became ready.")
+        let start = Task { @MainActor in
+            do {
+                try await session.start()
+                startupCompleted.send(.success(()))
+            } catch {
+                startupCompleted.send(.failure(error))
+            }
         }
+        defer {
+            issueObserved.continuation.finish()
+            eventChannel.continuation.finish()
+            session.stop()
+            start.cancel()
+        }
+        do {
+            let startupResult = try await startupCompleted.next("relay startup completion after event stream end")
+            await start.value
+            switch startupResult {
+            case .success:
+                Issue.record("Expected the pre-ready event stream end to throw")
+            case let .failure(error):
+                let startupError = error as NSError
+                #expect(startupError.domain == "RealtimeTalkRelay")
+                #expect(startupError.code == 6)
+                #expect(startupError.localizedDescription == "Realtime connection ended before it became ready.")
+            }
 
-        #expect(disconnectedAt.duration(to: .now) < .seconds(1))
-        #expect(issues.map(\.phase) == ["connect"])
-        let recorded = await requests.snapshot()
-        #expect(recorded.map(\.method) == ["talk.session.create", "talk.session.close"])
-        #expect(recorded.last?.params?["sessionId"]?.stringValue == "relay-1")
-        #expect(!audioCapture.isStarted)
+            #expect(issues.map(\.phase) == ["connect"])
+            let recorded = await requests.snapshot()
+            #expect(recorded.map(\.method) == ["talk.session.create", "talk.session.close"])
+            #expect(recorded.last?.params?["sessionId"]?.stringValue == "relay-1")
+            #expect(audioCapture.startCount == 1)
+            #expect(!audioCapture.isStarted)
+        } catch {
+            issueObserved.continuation.finish()
+            eventChannel.continuation.finish()
+            session.stop()
+            start.cancel()
+            await start.value
+            if audioCapture.startCount > 0 {
+                try? await requests.waitForRequestCount(2)
+            }
+            throw error
+        }
     }
 
     @Test func `event stream ending during relay creation closes the late relay`() async throws {


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where the shared Apple realtime Talk relay suite reports a startup-disconnect failure under scheduler or close-request delay even though the exact disconnect error, once-only relay close, session ID, and stopped capture are all correct.

This is an explicitly maintainer-requested, AI-assisted test repair. A disposable macOS 26.6.2 / Swift 6.4 run reported one failure among 1497 tests: the one-second elapsed-time assertion. The reported 22.196 seconds was the **whole test duration**, not the measured disconnect interval. The same owner and test remained on current `main` when this repair was prepared.

## Why This Change Was Made

The stopwatch includes actor scheduling, final route validation, and the awaited close request. Capture having started also does not establish that the readiness waiter has been registered. Replacing one arbitrary timing budget with another would retain the flawed proof.

The parameterized test instead uses the existing explicitly MainActor-isolated async transport callback to force both causal orderings: the stream-end issue is observed before waiter registration, or startup registers its waiter before the event handler can run. It retains the exact error and cleanup assertions, adds NSError domain/code and capture-start checks, separates watchdog failure from the expected startup error, and joins the owned startup task on failure. The obsolete capture-start notification helper is removed.

Production LOC: **+0/-0**. Tests and test support: **+65/-24**. No production hooks, timeout increases, forced serialization, dependency changes, or TLS/native-CI changes.

Provenance: the stopwatch was introduced in the [shared Apple relay lifecycle change](https://github.com/openclaw/openclaw/pull/127232), authored and merged by @vincentkoc ([057ed79f96e0](https://github.com/openclaw/openclaw/commit/057ed79f96e0c13b74b6b7432514b97ff0b73bce)). This repairs its test proof, not the relay's disconnect behavior.

## User Impact

No runtime behavior changes. Maintainers get scheduler-independent regression coverage for both startup-failure paths without weakening the existing error or cleanup contract. The existing 12-second readiness timeout and 30-second test-signal watchdog are unchanged.

## Evidence

Proof ran in an audited **macOS 27.0 / Apple Swift 6.4** sandbox, with operator-home/storage access, Keychain/preferences/TCC services, and test network access denied. Synthetic allow/deny controls and a negative audit control verified the sandbox before tests. No installed app or Gateway was operated.

- Original and repaired relay suites: **40 tests passed**, with parallel execution retained.
- Repaired parameterized test: five additional runs passed both values (**10 case executions**).
- Controlled 1.1-second close-request delay: the old test failed **only** its stopwatch, measuring **1.237007834 seconds**; both repaired cases passed the same delay.
- Remove only stream-end `startupIssue = issue`: only the pre-registration case fails, observing the wrong readiness-timeout error and a duplicate connect issue.
- Remove only stream-end `finishStartupWait(.failed(issue))`: only the registered-waiter case fails through the unchanged watchdog; cleanup completes and the test process exits normally with failure.
- Restore the real owner and exact candidate: all **40 relay tests passed** again; source hashes match the reviewed candidate.
- Repository-configured SwiftFormat and `git diff --check` passed. Fresh pre-commit Codex autoreview was scoped-clean at its default P0 priority, with no accepted/actionable findings.

The baseline and initial candidate were built as the complete shared package. Mutation rebuilds selected the same relay test source in a task-owned archived manifest to avoid re-emitting unrelated tests; no repository manifest or production dependency was changed. Test execution used SwiftPM's actual macOS `swiftpm-testing-helper` and the already-built bundle, with default parallelism unchanged. The native build engine and explicit SDK/framework/Swift-overlay paths were confined to this isolated proof, not a CI/backend change.

Proof limitation: this local evidence is **not** a rerun of the full 1497-test macOS 26.6.2 suite. Exact-head hosted CI is required before landing. An extra strict SwiftLint run found the already-oversized test file (2045 nonblank/noncomment lines before, 2086 after; 1500-line warning threshold); this file is outside that config's ordinary app-source selection, and a separate suite-splitting follow-up was recorded rather than adding a suppression.

Source contracts checked: [Swift executor switching](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0338-clarify-execution-non-actor-async.md#detailed-design), [async function reabstraction](https://github.com/swiftlang/swift/blob/406ff0c69495254ef471997f3a3b5bb4735f0485/lib/SILGen/SILGenPoly.cpp#L5634-L5799), and [checked-continuation registration/resumption](https://github.com/swiftlang/swift/blob/406ff0c69495254ef471997f3a3b5bb4735f0485/stdlib/public/Concurrency/CheckedContinuation.swift#L257-L310).
