### PR TITLE
fix(gateway): prevent reply reservations leaking between tests

### DIFF
--- a/src/gateway/test-helpers.mocks.test.ts
+++ b/src/gateway/test-helpers.mocks.test.ts
@@ -1,0 +1,99 @@
+// Exercise the shared Gateway mock wiring with real reply dispatchers.
+import "./test-helpers.mocks.js";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../test/helpers/promise.js";
+import type { dispatchInboundMessage } from "../auto-reply/dispatch.js";
+import { getTotalPendingReplies } from "../auto-reply/reply/dispatcher-registry.js";
+import { dispatchInboundMessageMock } from "./test-helpers.runtime-state.js";
+
+const { dispatchInboundMessageWithProjectedDispatcher } = await import("../auto-reply/dispatch.js");
+
+describe("Gateway projected-dispatch mock ownership", () => {
+  afterEach(() => {
+    dispatchInboundMessageMock.mockReset();
+  });
+
+  it.each(["fulfill", "reject"] as const)(
+    "releases a no-reply reservation when mocked dispatches %s",
+    async (outcome) => {
+      const pendingBefore = getTotalPendingReplies();
+      const result = { queuedFinal: false, counts: { tool: 0, block: 0, final: 0 } };
+      const error = new Error("mocked dispatch failed");
+      const deliver = vi.fn(async () => {});
+      dispatchInboundMessageMock.mockImplementationOnce(async () => {
+        if (outcome === "reject") {
+          throw error;
+        }
+        return result;
+      });
+
+      const dispatch = dispatchInboundMessageWithProjectedDispatcher({
+        ctx: { Body: "hello", Surface: "webchat" },
+        cfg: {},
+        dispatcherOptions: { deliver },
+      });
+      if (outcome === "reject") {
+        await expect(dispatch).rejects.toBe(error);
+      } else {
+        await expect(dispatch).resolves.toBe(result);
+      }
+      expect(deliver).not.toHaveBeenCalled();
+      expect(getTotalPendingReplies()).toBe(pendingBefore);
+    },
+  );
+
+  it.each(["fulfill", "reject"] as const)(
+    "drains queued delivery before mocked dispatches %s",
+    async (outcome) => {
+      const pendingBefore = getTotalPendingReplies();
+      const deliveryStarted = createDeferred();
+      const releaseDelivery = createDeferred();
+      const deliverySettled = createDeferred();
+      const result = { queuedFinal: true, counts: { tool: 0, block: 0, final: 1 } };
+      const error = new Error("mocked dispatch failed after enqueue");
+      dispatchInboundMessageMock.mockImplementationOnce(async (params: unknown) => {
+        const { dispatcher } = params as Parameters<typeof dispatchInboundMessage>[0];
+        dispatcher.sendFinalReply({ text: "queued reply" });
+        if (outcome === "reject") {
+          throw error;
+        }
+        return result;
+      });
+      const dispatch = dispatchInboundMessageWithProjectedDispatcher({
+        ctx: { Body: "hello", Surface: "webchat" },
+        cfg: {},
+        dispatcherOptions: {
+          deliver: async () => {
+            deliveryStarted.resolve();
+            await releaseDelivery.promise;
+          },
+          onDeliverySettled: () => deliverySettled.resolve(),
+        },
+      });
+      let dispatchSettled = false;
+      const completion = Promise.allSettled([dispatch]).then((results) => {
+        dispatchSettled = true;
+        return results;
+      });
+      try {
+        await deliveryStarted.promise;
+        // Give a prematurely returned dispatch promise a turn to settle while delivery is held.
+        await new Promise<void>((resolve) => {
+          setImmediate(resolve);
+        });
+        expect(dispatchSettled).toBe(false);
+        expect(getTotalPendingReplies()).toBeGreaterThan(pendingBefore);
+      } finally {
+        releaseDelivery.resolve();
+        await completion;
+        await deliverySettled.promise;
+      }
+      expect(await completion).toEqual([
+        outcome === "reject"
+          ? { status: "rejected", reason: error }
+          : { status: "fulfilled", value: result },
+      ]);
+      expect(getTotalPendingReplies()).toBe(pendingBefore);
+    },
+  );
+});

--- a/src/gateway/test-helpers.mocks.ts
+++ b/src/gateway/test-helpers.mocks.ts
@@ -2,6 +2,7 @@
 // Centralizes Vitest mock wiring for agent, channel, plugin, and runtime seams.
 import path from "node:path";
 import { vi } from "vitest";
+import { withReplyDispatcher } from "../auto-reply/dispatch-dispatcher.js";
 import { createReplyDispatcher } from "../auto-reply/reply/reply-dispatcher.js";
 import { getTestPluginRegistry } from "./test-helpers.plugin-registry.js";
 import {
@@ -86,10 +87,16 @@ function createDispatchInboundMessageMockExports(
       }
       const [params] = args;
       const { dispatcherOptions, ...dispatchParams } = params;
-      return gatewayTestHoisted.dispatchInboundMessage({
-        ...dispatchParams,
-        dispatcher: createReplyDispatcher(dispatcherOptions),
-      }) as ReturnType<typeof actual.dispatchInboundMessageWithProjectedDispatcher>;
+      const dispatcher = createReplyDispatcher(dispatcherOptions);
+      // The override bypasses dispatchInboundMessage's dispatcher lifecycle ownership.
+      return withReplyDispatcher({
+        dispatcher,
+        run: () =>
+          gatewayTestHoisted.dispatchInboundMessage({
+            ...dispatchParams,
+            dispatcher,
+          }) as ReturnType<typeof actual.dispatchInboundMessageWithProjectedDispatcher>,
+      });
     },
   };
 }


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

This same-repository branch is editable by maintainers.

</details>

## What Problem This Solves

Resolves a problem where Gateway tests using the shared projected-dispatch override could finish while leaving a real reply-dispatcher reservation registered, or could resolve/reject before their queued delivery settled. Existing Gateway assertions could pass despite that ownership leak.

This is a maintainer-requested repair of the shared mock, independent of the previously investigated Gateway root-work-count and settled-event failures. It does not claim to fix or explain either of those failures.

## Why This Change Was Made

The shared override created a real dispatcher but bypassed the lifecycle owner in normal inbound dispatch. It now uses the existing `withReplyDispatcher` helper at the producer, so completion and delivery settlement happen in `finally` on both fulfillment and rejection. No-override delegation remains unchanged.

Per-test `markComplete` calls, registry resets, consumer guards, and timeout/assertion changes were rejected because they would leave the shared producer's ownership contract broken. No production exports, runtime seams, dependencies, or configuration were added.

Provenance: the shared override was added in [#114351 — honor outbound hooks in Control UI chat replies](https://github.com/openclaw/openclaw/pull/114351), authored and merged by @joshavant, in commit [`a4c4f905ff7`](https://github.com/openclaw/openclaw/commit/a4c4f905ff7b5a7a65114c5225ddc563c7014fb7). [#118531 — settle reply dispatchers after failed chat sends](https://github.com/openclaw/openclaw/pull/118531) repaired the same omission in the separately owned directive-tags mock, not this shared helper.

## User Impact

No shipped runtime behavior changes. Gateway test fixtures now model the real dispatcher's lifecycle instead of leaking pending reply reservations or finishing before delivery. Four boundary regressions exercise the actual shared mock wiring with real dispatchers.

Production LOC: **+0/-0**. Test support: **+11/-4 (net +7)**. Tests: **+99/-0**. AI-assisted; reviewed and verified by the maintainer session.

## Evidence

All four new regressions failed before the repair for the intended reason, then passed: no-reply fulfillment and actual dispatch rejection left reservations pending; queued-delivery fulfillment and rejection settled the dispatch promise while delivery was still held. Return/error identity is preserved. The fixture-table callback `throw` is not mistaken for dispatch rejection—both original fixture dispatches return, and actual rejection is covered separately.

The original 66-case server-chat file was run in its original order with temporary observation-only registration tracking. It retained exact tracked-object and pending-closure identities and inspected actual current Set membership, rather than inferring membership from unregister counts. In this fresh run, the two fixture cases were observed to leave reservations registered; the later target went from pending `2 → 3 → 2` before repair to `0 → 1 → 0` afterward. All 35 observed post-fix dispatchers ended pending=0, absent from the Set, with one normal unregister call. Earlier reservations removed by nested server closes were distinguished from normal completion. This does not retroactively identify reservations from an earlier uninstrumented diagnostic or establish causation for the separate original failures.

Temporary instrumentation was removed; the original server-chat test file has no final diff. Local proof covered **297 distinct cases**, with additional before/after and final reruns:

```bash
node scripts/run-vitest.mjs src/gateway/test-helpers.mocks.test.ts --reporter=verbose
```

4/4 passed, including a final rerun after a lint-only promise-executor block-body correction.

```bash
node scripts/run-vitest.mjs src/gateway/server.chat.gateway-server-chat.test.ts --reporter=verbose
```

66/66 passed before and after with diagnostics, then 66/66 passed without diagnostics.

```bash
node scripts/run-vitest.mjs src/gateway/server-methods/chat.directive-tags.test.ts --reporter=verbose
```

203/203 passed.

```bash
node scripts/run-vitest.mjs src/auto-reply/dispatch.test.ts --reporter=verbose
```

24/24 passed.

The changed-check plan passed its preceding guards, core typecheck, and all core test-type shards, then found one `no-promise-executor-return` lint error in the new test. That was corrected without changing timing or assertions; the exact failed lint step and all eight remaining canonical guards passed on rerun. Formatting and `git diff --check` passed. Fresh isolated Codex autoreview of the final patch was scoped-clean at its configured P0 threshold.

Local before/after evidence was captured on `5d8ef653cd7198797983a957cd7b850f9880a8e9` plus this patch; the affected dispatcher owners and original server-chat file were unchanged at the refreshed main snapshot `027df17725c`. No operator Gateway, live state, or external channel was used: this is a test-support repair, not a user-facing runtime change. Hosted exact-head CI and native prepare/merge gates remain required before landing.
