### PR TITLE
fix: keep session thinking controls aligned with their model owner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,7 @@ Docs: https://docs.openclaw.ai
 
 - **WebChat attachments:** keep managed `MEDIA:` directives out of the first assistant transcript event while attachments are prepared, preserving raw transcript references, user text, and attachment failure warnings.
 
+- **Session controls:** preserve native Ultra thinking levels advertised by the model catalog when the provider plugin is inactive.
 - **Control UI tool progress:** keep error-shaped partial output running until the tool returns its result, with consistent status in collapsed rows, expanded cards, and side-panel details.
 
 - MCP Apps: let standalone operations finish across catalog refreshes within per-request server budgets, propagate App cancellation without cancelling shared catalog work, and reload restored history views without replaying interrupted operations. Thanks @tzy-17. (#119388)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,7 +76,6 @@ Docs: https://docs.openclaw.ai
 
 - **WebChat attachments:** keep managed `MEDIA:` directives out of the first assistant transcript event while attachments are prepared, preserving raw transcript references, user text, and attachment failure warnings.
 
-- **Session controls:** preserve native Ultra thinking levels advertised by the model catalog when the provider plugin is inactive.
 - **Control UI tool progress:** keep error-shaped partial output running until the tool returns its result, with consistent status in collapsed rows, expanded cards, and side-panel details.
 
 - MCP Apps: let standalone operations finish across catalog refreshes within per-request server budgets, propagate App cancellation without cancelling shared catalog work, and reload restored history views without replaying interrupted operations. Thanks @tzy-17. (#119388)
@@ -100,6 +99,7 @@ Docs: https://docs.openclaw.ai
 - **Plugin setup diagnostics:** stop treating metadata-only provider setup descriptors as missing runtime registrations while retaining undeclared runtime and CLI drift warnings. Fixes #125506. Thanks @shakkernerd.
 - **Onboarding model browsing:** keep preferred-provider model discovery scoped to the selected provider, preserve route variants, and avoid loading unrelated provider setup surfaces. Fixes #125363. Thanks @shakkernerd.
 - **Codex subagent fan-out:** settle successful terminal yields immediately and preserve requester ownership so completed children reliably resume their parent.
+- **Session controls:** keep thinking levels aligned with the selected agent's prepared model and provider policy, including native Ultra.
 - **Control UI session companion:** load bounded visible session context before answering, keep unavailable questions retryable, and prevent private companion reference wrappers from appearing as answers. Fixes #120746. Thanks @shakkernerd.
 - **Telegram live locations:** expose initial, moving, and stopped live-location updates through the channel-neutral `message_received` hook without starting agent turns for edits.
 - **Telegram send acceptance:** keep accepted-message bookkeeping failures out of transport fallback and chunk rejection handling, preventing duplicate replies or continued sends after an accepted delivery fails to record; preserve inline buttons when native rich quotes fall back to ordinary replies. (#130643)

--- a/src/agents/model-thinking-default-core.ts
+++ b/src/agents/model-thinking-default-core.ts
@@ -13,6 +13,7 @@ import {
   type ThinkLevel,
 } from "../auto-reply/thinking.shared.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import type { ProviderThinkingPolicySource } from "../plugins/provider-thinking.types.js";
 import type { ModelCatalogEntry } from "./model-catalog.types.js";
 import { legacyModelKey, modelKey, normalizeProviderId } from "./model-ref-shared.js";
 import { normalizeModelSelection } from "./model-selection-resolve.js";
@@ -62,7 +63,7 @@ export function resolveConfiguredThinkingDefaultCore(params: {
 
 export function resolveThinkingDefaultCore(
   params: ThinkingDefaultParams & {
-    providerPolicySource?: "active" | "active-or-bundled";
+    providerPolicySource?: ProviderThinkingPolicySource;
   },
 ): ThinkLevel {
   const normalizedProvider = normalizeProviderId(params.provider);

--- a/src/auto-reply/thinking.ts
+++ b/src/auto-reply/thinking.ts
@@ -6,7 +6,10 @@ import {
 } from "@openclaw/normalization-core/string-coerce";
 import { resolveClaudeThinkingProfile } from "../plugins/provider-claude-thinking.js";
 import { resolveEffectiveThinkingProfile } from "../plugins/provider-thinking.js";
-import type { ProviderThinkingProfile } from "../plugins/provider-thinking.types.js";
+import type {
+  ProviderThinkingPolicySource,
+  ProviderThinkingProfile,
+} from "../plugins/provider-thinking.types.js";
 import {
   BASE_THINKING_LEVELS,
   normalizeThinkLevel,
@@ -212,7 +215,7 @@ export function resolveThinkingProfile(params: {
   catalog?: ThinkingCatalogEntry[];
   agentRuntime?: string | null;
   configuredReasoning?: boolean;
-  providerPolicySource?: "active" | "active-or-bundled";
+  providerPolicySource?: ProviderThinkingPolicySource;
 }): ResolvedThinkingProfile {
   const context = resolveThinkingPolicyContext(params);
   if (!context.normalizedProvider) {
@@ -232,11 +235,15 @@ export function resolveThinkingProfile(params: {
     context: providerContext,
   };
   const providerProfile =
-    params.providerPolicySource === "active"
+    typeof params.providerPolicySource === "object"
       ? resolveEffectiveThinkingProfile(providerProfileParams, {
-          allowPublicArtifactFallback: false,
+          registry: params.providerPolicySource,
         })
-      : resolveEffectiveThinkingProfile(providerProfileParams);
+      : params.providerPolicySource === "active"
+        ? resolveEffectiveThinkingProfile(providerProfileParams, {
+            allowPublicArtifactFallback: false,
+          })
+        : resolveEffectiveThinkingProfile(providerProfileParams);
   // Any anthropic-messages catalog row routes through the canonical Claude
   // resolver: Claude families get the proper profile (incl. xhigh/adaptive/max);
   // non-Claude models on the anthropic-messages transport collapse to the Claude
@@ -401,7 +408,7 @@ export function resolveSupportedThinkingLevel(params: {
   catalog?: ThinkingCatalogEntry[];
   agentRuntime?: string | null;
   configuredReasoning?: boolean;
-  providerPolicySource?: "active" | "active-or-bundled";
+  providerPolicySource?: ProviderThinkingPolicySource;
 }): ThinkLevel {
   const profile = resolveThinkingProfile({
     provider: params.provider,

--- a/src/auto-reply/thinking.ts
+++ b/src/auto-reply/thinking.ts
@@ -190,8 +190,9 @@ function appendCatalogAdvancedThinkingLevels(
   for (const effort of compat?.supportedReasoningEfforts ?? []) {
     const level = normalizeThinkLevel(effort);
     if (
-      (level === "adaptive" || level === "xhigh" || level === "max") &&
-      (level === "adaptive" || thinkingLevelMap?.[level] !== null)
+      level === "ultra" ||
+      ((level === "adaptive" || level === "xhigh" || level === "max") &&
+        (level === "adaptive" || thinkingLevelMap?.[level] !== null))
     ) {
       appendProfileLevel(profile, level);
       supportsMax ||= level === "max";

--- a/src/gateway/gateway-codex-harness.live.test.ts
+++ b/src/gateway/gateway-codex-harness.live.test.ts
@@ -272,7 +272,7 @@ function resolveCodexHarnessExpectedRequestEffort(modelId: string): string | nul
   const configured = process.env.OPENCLAW_LIVE_CODEX_HARNESS_EXPECTED_EFFORT;
   if (configured?.trim()) {
     const expected = resolveCodexHarnessThinkingLevel(configured);
-    return expected === "off" ? null : expected === "ultra" ? "max" : expected;
+    return expected === "off" ? null : expected;
   }
   const supported = CODEX_HARNESS_SUPPORTED_EFFORTS.get(modelId);
   if (!supported) {
@@ -281,8 +281,8 @@ function resolveCodexHarnessExpectedRequestEffort(modelId: string): string | nul
   if (CODEX_HARNESS_THINKING === "off") {
     return null;
   }
-  // Codex preserves Ultra in config but intentionally sends Max to the model.
-  // Compare the request-facing lifecycle event to that wire contract.
+  // The lifecycle event records turn/start effort before Codex maps Ultra to Max
+  // for its downstream model request; Ultra still controls native collaboration.
   const candidates =
     CODEX_HARNESS_THINKING === "ultra"
       ? supported
@@ -297,7 +297,7 @@ function resolveCodexHarnessExpectedRequestEffort(modelId: string): string | nul
     ) ??
     candidates.at(-1) ??
     null;
-  return configuredEffort === "ultra" ? "max" : configuredEffort;
+  return configuredEffort;
 }
 
 function logCodexLiveStep(step: string, details?: Record<string, unknown>): void {

--- a/src/gateway/server-methods/optional-model-catalog.test.ts
+++ b/src/gateway/server-methods/optional-model-catalog.test.ts
@@ -6,14 +6,15 @@ describe("readPreparedServerMethodModelCatalog", () => {
   it("reads published startup facts without starting catalog discovery", async () => {
     const entries = [{ id: "work-only", name: "Work Model", provider: "work-provider" }];
     const loadGatewayModelCatalog = vi.fn();
-    const readPreparedGatewayModelCatalog = vi.fn(async () => entries);
+    const prepared = { entries };
+    const readPreparedGatewayModelCatalog = vi.fn(async () => prepared);
     const context = {
       loadGatewayModelCatalog,
       readPreparedGatewayModelCatalog,
     } as unknown as GatewayRequestContext;
 
     await expect(readPreparedServerMethodModelCatalog(context, { agentId: "work" })).resolves.toBe(
-      entries,
+      prepared,
     );
 
     expect(readPreparedGatewayModelCatalog).toHaveBeenCalledWith({ agentId: "work" });

--- a/src/gateway/server-methods/optional-model-catalog.ts
+++ b/src/gateway/server-methods/optional-model-catalog.ts
@@ -1,11 +1,11 @@
-import type { ModelCatalogEntry } from "../../agents/model-catalog.types.js";
+import type { PreparedGatewayModelCatalog } from "../server-model-catalog.types.js";
 import type { GatewayRequestContext } from "./types.js";
 
 /** Reads already-published startup facts without starting provider discovery on an RPC hot path. */
 export async function readPreparedServerMethodModelCatalog(
   context: GatewayRequestContext,
   options?: { agentId?: string },
-): Promise<ModelCatalogEntry[] | undefined> {
+): Promise<PreparedGatewayModelCatalog | undefined> {
   try {
     return context.readPreparedGatewayModelCatalog
       ? await context.readPreparedGatewayModelCatalog(options)

--- a/src/gateway/server-methods/sessions-list-cache.ts
+++ b/src/gateway/server-methods/sessions-list-cache.ts
@@ -1,5 +1,4 @@
 import type { SessionsListParams } from "../../../packages/gateway-protocol/src/index.js";
-import type { ModelCatalogEntry } from "../../agents/model-catalog.types.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { readAgentRunIndexVersion } from "../../infra/agent-run-registry.js";
 import {
@@ -49,10 +48,10 @@ type SessionListState = {
 
 const SESSIONS_LIST_COMPLETED_CACHE_LIMIT = 64;
 const sessionListsByContext = new WeakMap<GatewayRequestContext, SessionListState>();
-const modelCatalogRevisions = new WeakMap<readonly ModelCatalogEntry[], number>();
+const modelCatalogRevisions = new WeakMap<object, number>();
 let nextModelCatalogRevision = 1;
 
-function readModelCatalogRevision(modelCatalog: readonly ModelCatalogEntry[] | undefined): number {
+function readModelCatalogRevision(modelCatalog: object | undefined): number {
   if (!modelCatalog) {
     return 0;
   }
@@ -67,8 +66,8 @@ function readModelCatalogRevision(modelCatalog: readonly ModelCatalogEntry[] | u
 
 /**
  * Serializes the per-agent catalog revision set so the cache fence advances
- * when any row owner's catalog changes. The revision identity of each distinct
- * catalog array is monotonic; the string join is stable per sorted agent set.
+ * when any row owner's entries or provider policy changes. A new read wrapper
+ * alone does not invalidate the cache; the prepared facts retain stable identity.
  */
 function readSessionListModelCatalogFence(
   modelCatalog: SessionListModelCatalog | undefined,
@@ -78,7 +77,10 @@ function readSessionListModelCatalogFence(
   }
   return [...modelCatalog.entries()]
     .toSorted(([left], [right]) => left.localeCompare(right))
-    .map(([agentId, entries]) => `${agentId}:${readModelCatalogRevision(entries)}`)
+    .map(
+      ([agentId, catalog]) =>
+        `${agentId}:${readModelCatalogRevision(catalog?.entries)}:${readModelCatalogRevision(catalog?.pluginRegistry)}`,
+    )
     .join(",");
 }
 

--- a/src/gateway/server-methods/sessions-read-cache.test.ts
+++ b/src/gateway/server-methods/sessions-read-cache.test.ts
@@ -295,7 +295,7 @@ describe("sessions.list single-flight", () => {
       let catalog = startupCatalog;
       const context = {
         ...requestContext(config),
-        readPreparedGatewayModelCatalog: vi.fn(async () => catalog),
+        readPreparedGatewayModelCatalog: vi.fn(async () => ({ entries: catalog })),
       };
       const client = identifiedClient("owner@example.com");
       const request = { archived: "all" as const, limit: 100 };

--- a/src/gateway/server-methods/sessions-read-catalog-scope.test.ts
+++ b/src/gateway/server-methods/sessions-read-catalog-scope.test.ts
@@ -1,5 +1,4 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { resolveThinkingProfile as resolveOpenAIThinkingProfile } from "../../../extensions/openai/provider-policy-api.js";
 import type {
   AgentsListResult,
   SessionsListParams,
@@ -12,6 +11,7 @@ import { upsertSessionEntryCore } from "../../config/sessions/session-accessor.j
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { resetAgentEventsForTest } from "../../infra/agent-events.js";
 import { createPluginMetadataSnapshotFixture } from "../../plugins/plugin-metadata.test-support.js";
+import { resolveProviderPolicySurface } from "../../plugins/provider-public-artifacts.js";
 import type { ProviderThinkingProfile } from "../../plugins/provider-thinking.types.js";
 import { createEmptyPluginRegistry } from "../../plugins/registry-empty.js";
 import type { PluginRegistry } from "../../plugins/registry-types.js";
@@ -206,7 +206,10 @@ describe("sessions.list catalog scoping", () => {
           config,
           agentId: "main",
           entries,
-          pluginRegistry: thinkingRegistry("openai", resolveOpenAIThinkingProfile),
+          pluginRegistry: thinkingRegistry(
+            "openai",
+            resolveProviderPolicySurface("openai")!.resolveThinkingProfile!,
+          ),
         });
         // The Gateway startup registry need not contain the model-selected provider.
         setActivePluginRegistry(createEmptyPluginRegistry());

--- a/src/gateway/server-methods/sessions-read-catalog-scope.test.ts
+++ b/src/gateway/server-methods/sessions-read-catalog-scope.test.ts
@@ -255,13 +255,13 @@ describe("sessions.list catalog scoping", () => {
       });
       const mainRegistry = thinkingRegistry("dynamic-router", () => profile("ultra"));
       const workRegistry = thinkingRegistry("dynamic-router", () => profile("low"));
-      let completed: ModelCatalogSnapshot | undefined;
+      const completed: { catalog?: ModelCatalogSnapshot } = {};
       const mainOwner = preparedOwner({
         config,
         agentId: "main",
         entries,
         pluginRegistry: mainRegistry,
-        readFullModelCatalog: () => completed,
+        readFullModelCatalog: () => completed.catalog,
       });
       const owners = new Map([
         ["main", mainOwner],
@@ -314,7 +314,7 @@ describe("sessions.list catalog scoping", () => {
         "low",
       ]);
 
-      completed = { entries: [{ ...entries[0]!, reasoning: false }], routeVariants: [] };
+      completed.catalog = { entries: [{ ...entries[0]!, reasoning: false }], routeVariants: [] };
       const promoted = await listSessions(request);
       expect(promoted).not.toBe(replaced);
       expect(promoted.sessions.find((row) => row.agentId === "main")?.thinkingOptions).toEqual([

--- a/src/gateway/server-methods/sessions-read-catalog-scope.test.ts
+++ b/src/gateway/server-methods/sessions-read-catalog-scope.test.ts
@@ -1,11 +1,25 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import type { SessionsListParams } from "../../../packages/gateway-protocol/src/index.js";
-import type { ModelCatalogEntry } from "../../agents/model-catalog.types.js";
+import { resolveThinkingProfile as resolveOpenAIThinkingProfile } from "../../../extensions/openai/provider-policy-api.js";
+import type {
+  AgentsListResult,
+  SessionsListParams,
+} from "../../../packages/gateway-protocol/src/index.js";
+import { resolveAgentDir, resolveAgentWorkspaceDir } from "../../agents/agent-scope-config.js";
+import type { ModelCatalogEntry, ModelCatalogSnapshot } from "../../agents/model-catalog.types.js";
+import * as preparedRuntime from "../../agents/prepared-model-runtime.js";
+import type { PreparedModelRuntimeSnapshot } from "../../agents/prepared-model-runtime.types.js";
 import { upsertSessionEntryCore } from "../../config/sessions/session-accessor.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { resetAgentEventsForTest } from "../../infra/agent-events.js";
+import { createPluginMetadataSnapshotFixture } from "../../plugins/plugin-metadata.test-support.js";
+import type { ProviderThinkingProfile } from "../../plugins/provider-thinking.types.js";
+import { createEmptyPluginRegistry } from "../../plugins/registry-empty.js";
+import type { PluginRegistry } from "../../plugins/registry-types.js";
+import { resetPluginRuntimeStateForTest, setActivePluginRegistry } from "../../plugins/runtime.js";
 import { withOpenClawTestState } from "../../test-utils/openclaw-test-state.js";
-import type { GatewaySessionRow } from "../session-utils.types.js";
+import { readPreparedGatewayModelCatalog } from "../server-model-catalog.js";
+import type { GatewaySessionRow, GatewaySessionsDefaults } from "../session-utils.types.js";
+import { agentsHandlers } from "./agents.js";
 import type { GatewayClient, GatewayRequestContext, RespondFn } from "./types.js";
 
 const { sessionReadHandlers } = await import("./sessions-read.js");
@@ -54,6 +68,7 @@ async function listSessions(params: {
   expect(responses[0]?.[0]).toBe(true);
   return responses[0]?.[1] as {
     count: number;
+    defaults: GatewaySessionsDefaults;
     nextOffset: number | null;
     sessions: GatewaySessionRow[];
     totalCount: number;
@@ -85,16 +100,227 @@ async function seedSessions(): Promise<OpenClawConfig> {
   return config;
 }
 
+function thinkingRegistry(
+  providerId: string,
+  resolveThinkingProfile: NonNullable<
+    PluginRegistry["providers"][number]["provider"]["resolveThinkingProfile"]
+  >,
+): PluginRegistry {
+  const registry = createEmptyPluginRegistry();
+  registry.providers.push({
+    pluginId: providerId,
+    source: "test",
+    provider: { id: providerId, label: providerId, auth: [], resolveThinkingProfile },
+  });
+  return registry;
+}
+
+function preparedOwner(params: {
+  config: OpenClawConfig;
+  agentId: string;
+  entries: ModelCatalogEntry[];
+  pluginRegistry: PluginRegistry;
+  readFullModelCatalog?: () => ModelCatalogSnapshot | undefined;
+}): PreparedModelRuntimeSnapshot {
+  const workspaceDir = resolveAgentWorkspaceDir(params.config, params.agentId);
+  return {
+    catalogOwner: { agentId: params.agentId, workspaceDir },
+    agentId: params.agentId,
+    agentDir: resolveAgentDir(params.config, params.agentId),
+    workspaceDir,
+    config: params.config,
+    activeProjectKeys: [],
+    authModes: {},
+    metadataSnapshot: createPluginMetadataSnapshotFixture(),
+    pluginRegistry: params.pluginRegistry,
+    allowGatewaySubagentBinding: false,
+    modelCatalog: { entries: params.entries, routeVariants: [] },
+    readFullModelCatalog: params.readFullModelCatalog,
+    loadFullModelCatalog: vi.fn(() => {
+      throw new Error("session listing must not start full catalog discovery");
+    }),
+    configuredRuntimeModels: [],
+    inlineProviderModels: [],
+    createStores: () => {
+      throw new Error("session listing must not create execution stores");
+    },
+  };
+}
+
+function publishedCatalogContext(
+  config: OpenClawConfig,
+  owners: ReadonlyMap<string, PreparedModelRuntimeSnapshot>,
+): GatewayRequestContext {
+  vi.spyOn(preparedRuntime, "getPreparedModelRuntimeSnapshot").mockImplementation((input) =>
+    input.agentId ? owners.get(input.agentId) : undefined,
+  );
+  return {
+    ...requestContext(config),
+    readPreparedGatewayModelCatalog: (options) =>
+      readPreparedGatewayModelCatalog({ ...options, getConfig: () => config }),
+  };
+}
+
 beforeEach(() => {
   resetAgentEventsForTest();
 });
 
 afterEach(() => {
   resetAgentEventsForTest();
+  resetPluginRuntimeStateForTest();
   vi.restoreAllMocks();
 });
 
 describe("sessions.list catalog scoping", () => {
+  it.each([
+    { model: "gpt-5.6-sol", runtime: "codex", level: "ultra" },
+    { model: "gpt-5.6-terra", runtime: "codex", level: "ultra" },
+    { model: "gpt-5.6-luna", runtime: "codex", level: "max" },
+    { model: "gpt-5.6-luna", runtime: "openclaw", level: "ultra" },
+  ] as const)(
+    "projects $model/$runtime from its prepared provider owner",
+    async ({ model, runtime, level }) => {
+      await withOpenClawTestState({ scenario: "minimal" }, async () => {
+        const config = await seedSessions();
+        config.agents!.defaults = {
+          model: { primary: `openai/${model}` },
+          models: { [`openai/${model}`]: { agentRuntime: { id: runtime } } },
+        };
+        await upsertSessionEntryCore(
+          { agentId: "main", sessionKey: "agent:main:active" },
+          { thinkingLevel: level },
+        );
+        const entries: ModelCatalogEntry[] = [
+          {
+            provider: "openai",
+            id: model,
+            name: model,
+            api: "openai-responses",
+            reasoning: true,
+            compat: {
+              supportedReasoningEfforts: ["none", "low", "medium", "high", "xhigh", "max"],
+            },
+          },
+        ];
+        const owner = preparedOwner({
+          config,
+          agentId: "main",
+          entries,
+          pluginRegistry: thinkingRegistry("openai", resolveOpenAIThinkingProfile),
+        });
+        // The Gateway startup registry need not contain the model-selected provider.
+        setActivePluginRegistry(createEmptyPluginRegistry());
+        const context = publishedCatalogContext(config, new Map([["main", owner]]));
+
+        const result = await listSessions({
+          client: identifiedClient("owner@example.com"),
+          context,
+          request: { agentId: "main", archived: "all" },
+        });
+
+        expect(result.sessions[0]).toMatchObject({ thinkingLevel: level });
+        expect(result.sessions[0]?.thinkingOptions).toContain(level);
+        expect(result.defaults.thinkingOptions).toContain(level);
+        if (level === "max") {
+          expect(result.sessions[0]?.thinkingOptions).not.toContain("ultra");
+          expect(result.defaults.thinkingOptions).not.toContain("ultra");
+        }
+        expect(owner.loadFullModelCatalog).not.toHaveBeenCalled();
+      });
+    },
+  );
+
+  it("keeps identical catalogs owner-scoped across registry replacement and full catalog completion", async () => {
+    await withOpenClawTestState({ scenario: "minimal" }, async () => {
+      const config = await seedSessions();
+      config.agents!.defaults = {
+        model: { primary: "dynamic-router/reasoner" },
+        models: { "dynamic-router/reasoner": { agentRuntime: { id: "codex" } } },
+      };
+      const entries: ModelCatalogEntry[] = [
+        {
+          provider: "dynamic-router",
+          id: "reasoner",
+          name: "Reasoner",
+          reasoning: true,
+          compat: { supportedReasoningEfforts: ["low", "high", "max"] },
+        },
+      ];
+      const profile = (level: "low" | "ultra"): ProviderThinkingProfile => ({
+        levels: [{ id: "off" }, { id: level }],
+        defaultLevel: level,
+      });
+      const mainRegistry = thinkingRegistry("dynamic-router", () => profile("ultra"));
+      const workRegistry = thinkingRegistry("dynamic-router", () => profile("low"));
+      let completed: ModelCatalogSnapshot | undefined;
+      const mainOwner = preparedOwner({
+        config,
+        agentId: "main",
+        entries,
+        pluginRegistry: mainRegistry,
+        readFullModelCatalog: () => completed,
+      });
+      const owners = new Map([
+        ["main", mainOwner],
+        ["work", preparedOwner({ config, agentId: "work", entries, pluginRegistry: workRegistry })],
+      ]);
+      setActivePluginRegistry(mainRegistry);
+      const context = publishedCatalogContext(config, owners);
+      const request = {
+        client: identifiedClient("owner@example.com"),
+        context,
+        request: { archived: "all" as const },
+      };
+      const first = await listSessions(request);
+      expect(first.sessions.find((row) => row.agentId === "main")?.thinkingOptions).toEqual([
+        "off",
+        "ultra",
+      ]);
+      expect(first.sessions.find((row) => row.agentId === "work")?.thinkingOptions).toEqual([
+        "off",
+        "low",
+      ]);
+      expect(await listSessions(request)).toBe(first);
+      const rosterResponse = vi.fn();
+      await agentsHandlers["agents.list"]?.({
+        params: {},
+        client: request.client,
+        context,
+        respond: rosterResponse,
+      } as never);
+      expect(rosterResponse.mock.calls[0]?.[0]).toBe(true);
+      const roster = rosterResponse.mock.calls[0]?.[1] as AgentsListResult;
+      expect(roster.agents.find((row) => row.id === "main")?.thinkingOptions).toEqual([
+        "off",
+        "ultra",
+      ]);
+      expect(roster.agents.find((row) => row.id === "work")?.thinkingOptions).toEqual([
+        "off",
+        "low",
+      ]);
+
+      // An empty replacement is authoritative even while the global registry still offers Ultra.
+      owners.set("main", { ...mainOwner, pluginRegistry: createEmptyPluginRegistry() });
+      const replaced = await listSessions(request);
+      expect(replaced).not.toBe(first);
+      expect(
+        replaced.sessions.find((row) => row.agentId === "main")?.thinkingOptions,
+      ).not.toContain("ultra");
+      expect(replaced.sessions.find((row) => row.agentId === "work")?.thinkingOptions).toEqual([
+        "off",
+        "low",
+      ]);
+
+      completed = { entries: [{ ...entries[0]!, reasoning: false }], routeVariants: [] };
+      const promoted = await listSessions(request);
+      expect(promoted).not.toBe(replaced);
+      expect(promoted.sessions.find((row) => row.agentId === "main")?.thinkingOptions).toEqual([
+        "off",
+      ]);
+      expect(mainOwner.loadFullModelCatalog).not.toHaveBeenCalled();
+    });
+  });
+
   it("keeps unscoped listings owner-scoped when agents have distinct completed catalogs", async () => {
     await withOpenClawTestState({ scenario: "minimal" }, async () => {
       const config = await seedSessions();
@@ -122,9 +348,9 @@ describe("sessions.list catalog scoping", () => {
       ];
       const context = {
         ...requestContext(config),
-        readPreparedGatewayModelCatalog: vi.fn(async (options?: { agentId?: string }) =>
-          options?.agentId === "work" ? workCatalog : mainCatalog,
-        ),
+        readPreparedGatewayModelCatalog: vi.fn(async (options?: { agentId?: string }) => ({
+          entries: options?.agentId === "work" ? workCatalog : mainCatalog,
+        })),
       };
       const client = identifiedClient("owner@example.com");
       const request = { archived: "all" as const, limit: 100 };
@@ -167,7 +393,7 @@ describe("sessions.list catalog scoping", () => {
       ];
       const context = {
         ...requestContext(config),
-        readPreparedGatewayModelCatalog: vi.fn(async () => mainCatalog),
+        readPreparedGatewayModelCatalog: vi.fn(async () => ({ entries: mainCatalog })),
       };
       const client = identifiedClient("owner@example.com");
 

--- a/src/gateway/server-methods/sessions-read.test.ts
+++ b/src/gateway/server-methods/sessions-read.test.ts
@@ -64,7 +64,7 @@ async function listAgentsViaRpc(
     context: {
       getRuntimeConfig,
       loadGatewayModelCatalog: async () => [],
-      readPreparedGatewayModelCatalog: async () => [],
+      readPreparedGatewayModelCatalog: async () => ({ entries: [] }),
       ...catalogContext,
     } as unknown as GatewayRequestContext,
     client: includeSystem
@@ -96,14 +96,16 @@ async function setAgentsConfig(agentsConfig: Record<string, unknown> | undefined
 test("agents.list includes system rows only when negotiated", async () => {
   fs.mkdirSync(path.join(requireStateDir(), "agents", "openclaw"), { recursive: true });
   testState.agentConfig = { model: { primary: "local/shared-reasoner" } };
-  const readPreparedGatewayModelCatalog = vi.fn(async () => [
-    {
-      id: "shared-reasoner",
-      name: "Shared Reasoner",
-      provider: "local",
-      reasoning: false,
-    },
-  ]);
+  const readPreparedGatewayModelCatalog = vi.fn(async () => ({
+    entries: [
+      {
+        id: "shared-reasoner",
+        name: "Shared Reasoner",
+        provider: "local",
+        reasoning: false,
+      },
+    ],
+  }));
 
   expect(await listAgentIdsViaRpc(false, { readPreparedGatewayModelCatalog })).toEqual(["main"]);
   const result = await listAgentsViaRpc(true, { readPreparedGatewayModelCatalog });
@@ -121,7 +123,7 @@ test("agents.list includes system rows only when negotiated", async () => {
 
 test("agents.list reads published model facts without starting provider discovery", async () => {
   const loadGatewayModelCatalog = vi.fn(async () => []);
-  const readPreparedGatewayModelCatalog = vi.fn(async () => []);
+  const readPreparedGatewayModelCatalog = vi.fn(async () => ({ entries: [] }));
 
   await expect(
     listAgentIdsViaRpc(false, {
@@ -167,14 +169,16 @@ test.each([
       if (!options?.agentId || options.agentId === unavailableAgentId) {
         return undefined;
       }
-      return [
-        {
-          id: "shared-reasoner",
-          name: "Shared Reasoner",
-          provider: "local",
-          reasoning: options.agentId === "work",
-        },
-      ];
+      return {
+        entries: [
+          {
+            id: "shared-reasoner",
+            name: "Shared Reasoner",
+            provider: "local",
+            reasoning: options.agentId === "work",
+          },
+        ],
+      };
     });
 
     const result = await listAgentsViaRpc(false, { readPreparedGatewayModelCatalog });

--- a/src/gateway/server-methods/sessions-sharing.test.ts
+++ b/src/gateway/server-methods/sessions-sharing.test.ts
@@ -592,7 +592,7 @@ describe("session sharing handlers", () => {
                 visibility: "draft",
               }));
               invalidateSessionSharingSnapshot(sessionKey);
-              return [];
+              return { entries: [] };
             },
           } as unknown as GatewayRequestContext,
           respond: (...response: Parameters<RespondFn>) => responses.push(response),
@@ -668,7 +668,7 @@ describe("session sharing handlers", () => {
               visibility: "draft",
             }));
             invalidateSessionSharingSnapshot(hiddenKey);
-            return [];
+            return { entries: [] };
           },
         } as unknown as GatewayRequestContext,
         respond: (...response: Parameters<RespondFn>) => responses.push(response),

--- a/src/gateway/server-methods/shared-types.ts
+++ b/src/gateway/server-methods/shared-types.ts
@@ -47,7 +47,10 @@ import type {
   GatewayApprovalEventPublisher,
   GatewayRecoveryRuntime,
 } from "../server-instance-runtime.types.js";
-import type { GatewayModelCatalogSnapshot } from "../server-model-catalog.types.js";
+import type {
+  GatewayModelCatalogSnapshot,
+  PreparedGatewayModelCatalog,
+} from "../server-model-catalog.types.js";
 import type { DedupeEntry } from "../server-shared.js";
 import type { GatewayEventLoopHealth } from "../server/event-loop-health.js";
 import type { SessionObserverService } from "../session-observer-contract.js";
@@ -209,7 +212,7 @@ type GatewayKernelContext = {
     agentId?: string;
     agentDir?: string;
     workspaceDir?: string;
-  }) => Promise<ModelCatalogEntry[] | undefined>;
+  }) => Promise<PreparedGatewayModelCatalog | undefined>;
   readChatMetadata: (params: ChatMetadataReadParams) => Promise<ChatMetadataResult>;
   readChatStartupProjection?: (
     params: ChatStartupProjectionReadParams,

--- a/src/gateway/server-model-catalog.ts
+++ b/src/gateway/server-model-catalog.ts
@@ -13,7 +13,10 @@ import { isPreparedModelCatalogFull } from "../agents/prepared-model-runtime.ful
 // Gateway catalog reads use the atomic prepared runtime generation.
 import { getRuntimeConfig } from "../config/io.js";
 import type { PreparedGatewayModelCatalogSnapshot } from "./server-model-catalog-auth.js";
-import type { GatewayModelCatalogSnapshot } from "./server-model-catalog.types.js";
+import type {
+  GatewayModelCatalogSnapshot,
+  PreparedGatewayModelCatalog,
+} from "./server-model-catalog.types.js";
 
 export type GatewayModelChoice = import("../agents/model-catalog.js").ModelCatalogEntry;
 export type { GatewayModelCatalogSnapshot } from "./server-model-catalog.types.js";
@@ -170,17 +173,24 @@ export async function loadGatewayModelCatalog(
 /** Reads the newest completed published catalog without starting provider discovery. */
 export async function readPreparedGatewayModelCatalog(
   params?: LoadGatewayModelCatalogParams,
-): Promise<GatewayModelChoice[] | undefined> {
-  const { getAvailablePreparedModelCatalogSnapshot } =
+): Promise<PreparedGatewayModelCatalog | undefined> {
+  const { getPreparedModelCatalogOwnerSnapshot } =
     await import("../agents/prepared-model-catalog.js");
   const config = (params?.getConfig ?? getRuntimeConfig)();
-  return getAvailablePreparedModelCatalogSnapshot({
+  const owner = getPreparedModelCatalogOwnerSnapshot({
     ...(params?.agentId ? { agentId: params.agentId } : {}),
     ...(params?.agentDir ? { agentDir: params.agentDir } : {}),
     config,
     readOnly: true,
     ...(params?.workspaceDir ? { workspaceDir: params.workspaceDir } : {}),
-  })?.entries;
+  });
+  if (!owner) {
+    return undefined;
+  }
+  return {
+    entries: (owner.readFullModelCatalog?.() ?? owner.modelCatalog).entries,
+    pluginRegistry: owner.pluginRegistry,
+  };
 }
 
 /** Reads the published owner generation without activating full catalog discovery. */

--- a/src/gateway/server-model-catalog.types.ts
+++ b/src/gateway/server-model-catalog.types.ts
@@ -1,5 +1,12 @@
-import type { ModelCatalogSnapshot } from "../agents/model-catalog.types.js";
+import type { ModelCatalogEntry, ModelCatalogSnapshot } from "../agents/model-catalog.types.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import type { ProviderThinkingRegistry } from "../plugins/provider-thinking.types.js";
+
+/** Catalog entries and policy come from the same completed prepared generation. */
+export type PreparedGatewayModelCatalog = {
+  entries: ModelCatalogEntry[];
+  pluginRegistry?: ProviderThinkingRegistry;
+};
 
 export type GatewayModelCatalogSnapshot = ModelCatalogSnapshot & {
   agentId: string;

--- a/src/gateway/server.sessions.archive-lifecycle.test.ts
+++ b/src/gateway/server.sessions.archive-lifecycle.test.ts
@@ -206,7 +206,7 @@ async function archiveLifecycleRequestContext(
     getSessionEventSubscriberConnIds: () => new Set<string>(),
     getRuntimeConfig,
     loadGatewayModelCatalog,
-    readPreparedGatewayModelCatalog: loadGatewayModelCatalog,
+    readPreparedGatewayModelCatalog: async () => ({ entries: await loadGatewayModelCatalog() }),
     ...overrides,
   } as unknown as GatewayRequestContext;
 }

--- a/src/gateway/server.sessions.list-changed.test.ts
+++ b/src/gateway/server.sessions.list-changed.test.ts
@@ -146,7 +146,7 @@ async function invokeSessionsList({
     isWebchatConnect: () => false,
     context: {
       getRuntimeConfig,
-      readPreparedGatewayModelCatalog: async () => [],
+      readPreparedGatewayModelCatalog: async () => ({ entries: [] }),
       ...context,
     } as never,
   });
@@ -417,14 +417,16 @@ test("sessions.list uses the gateway model catalog for effective thinking defaul
   const { respond } = await invokeSessionsList({
     requestId: "req-sessions-list-thinking-default",
     context: {
-      readPreparedGatewayModelCatalog: async () => [
-        {
-          provider: "test-provider",
-          id: "reasoner",
-          name: "Reasoner",
-          reasoning: true,
-        },
-      ],
+      readPreparedGatewayModelCatalog: async () => ({
+        entries: [
+          {
+            provider: "test-provider",
+            id: "reasoner",
+            name: "Reasoner",
+            reasoning: true,
+          },
+        ],
+      }),
     },
   });
 

--- a/src/gateway/server.sessions.thinking-e2e.test.ts
+++ b/src/gateway/server.sessions.thinking-e2e.test.ts
@@ -10,6 +10,7 @@
 import { expectDefined } from "@openclaw/normalization-core";
 import { expect, test, vi } from "vitest";
 import { formatThinkingLevels } from "../auto-reply/thinking.js";
+import type { GatewayRequestContext } from "./server-methods/types.js";
 import { testState, writeSessionStore } from "./test-helpers.js";
 import {
   directSessionReq,
@@ -97,15 +98,7 @@ async function listMainSessionWithThinking(params: {
   agentRuntime?: "codex" | "openclaw";
   selectedByOverride?: boolean;
   thinkingLevel?: string;
-  readPreparedGatewayModelCatalog?: () => Promise<
-    Array<{
-      provider: string;
-      id: string;
-      name: string;
-      reasoning: boolean;
-      compat?: { supportedReasoningEfforts?: string[] };
-    }>
-  >;
+  readPreparedGatewayModelCatalog?: GatewayRequestContext["readPreparedGatewayModelCatalog"];
 }) {
   await createSessionStoreDir();
   testState.agentConfig = {
@@ -148,7 +141,8 @@ async function listMainSessionWithThinking(params: {
     isWebchatConnect: () => false,
     context: {
       getRuntimeConfig,
-      readPreparedGatewayModelCatalog: params.readPreparedGatewayModelCatalog ?? (async () => []),
+      readPreparedGatewayModelCatalog:
+        params.readPreparedGatewayModelCatalog ?? (async () => ({ entries: [] })),
     } as never,
   });
 
@@ -165,17 +159,19 @@ test("e2e #76482: session with different model gets its own thinking levels thro
     primaryModel: "openai/gpt-5.5",
     sessionModelProvider: "test-extended",
     sessionModel: "extended-reasoner",
-    readPreparedGatewayModelCatalog: async () => [
-      // Provide a catalog with xhigh support — simulates what a real gateway
-      // resolves for models like DeepSeek V4 Pro
-      {
-        provider: "test-extended",
-        id: "extended-reasoner",
-        name: "Extended Reasoner",
-        reasoning: true,
-        compat: { supportedReasoningEfforts: ["xhigh"] },
-      },
-    ],
+    readPreparedGatewayModelCatalog: async () => ({
+      entries: [
+        // Provide a catalog with xhigh support — simulates what a real gateway
+        // resolves for models like DeepSeek V4 Pro
+        {
+          provider: "test-extended",
+          id: "extended-reasoner",
+          name: "Extended Reasoner",
+          reasoning: true,
+          compat: { supportedReasoningEfforts: ["xhigh"] },
+        },
+      ],
+    }),
   });
 
   // Gateway includes thinkingOptions for lightweight rows (needed by Control UI)
@@ -251,7 +247,7 @@ test("session rows keep the selected Codex Sol model when runtime metadata conta
     sessionModel: "gpt-5.6",
     agentRuntime: "codex",
     selectedByOverride: false,
-    readPreparedGatewayModelCatalog: loadSolCatalog,
+    readPreparedGatewayModelCatalog: async () => ({ entries: await loadSolCatalog() }),
   });
 
   expect(session).toMatchObject({
@@ -286,15 +282,17 @@ test("unsupported generic stored levels clamp through the current profile", asyn
     sessionModel: "reasoner",
     agentRuntime: "codex",
     thinkingLevel: "ultra",
-    readPreparedGatewayModelCatalog: async () => [
-      {
-        provider: "test-generic",
-        id: "reasoner",
-        name: "Generic Reasoner",
-        reasoning: true,
-        compat: { supportedReasoningEfforts: ["max"] },
-      },
-    ],
+    readPreparedGatewayModelCatalog: async () => ({
+      entries: [
+        {
+          provider: "test-generic",
+          id: "reasoner",
+          name: "Generic Reasoner",
+          reasoning: true,
+          compat: { supportedReasoningEfforts: ["max"] },
+        },
+      ],
+    }),
   });
 
   expect(session?.thinkingOptions).not.toContain("ultra");

--- a/src/gateway/session-utils-list.ts
+++ b/src/gateway/session-utils-list.ts
@@ -537,7 +537,7 @@ function buildSessionsListResult(params: {
   // the requested agent when scoped, otherwise the legacy compatibility agent.
   // Legacy plain-array catalogs (direct listSessionsFromStore callers) pass through
   // unchanged; per-agent maps resolve by the same identity.
-  const defaultsCatalog =
+  const preparedDefaultsCatalog =
     params.modelCatalog instanceof Map
       ? params.modelCatalog.get(
           params.agentId
@@ -546,7 +546,9 @@ function buildSessionsListResult(params: {
                 tryResolveLegacyCompatibilityAgentId(params.cfg) ?? LEGACY_IMPLICIT_AGENT_ID,
               ),
         )
-      : params.modelCatalog;
+      : undefined;
+  const defaultsCatalog =
+    params.modelCatalog instanceof Map ? preparedDefaultsCatalog?.entries : params.modelCatalog;
   return {
     ts: list.now,
     path: list.storePath,
@@ -568,6 +570,7 @@ function buildSessionsListResult(params: {
     defaults: getSessionDefaults(params.cfg, defaultsCatalog, {
       ...(params.agentId ? { agentId: params.agentId } : {}),
       allowPluginNormalization: false,
+      providerPolicySource: preparedDefaultsCatalog?.pluginRegistry,
     }),
     sessions,
   };

--- a/src/gateway/session-utils-model.ts
+++ b/src/gateway/session-utils-model.ts
@@ -96,7 +96,9 @@ function resolveGatewaySessionThinkingLevel(params: {
   // projections must not reinterpret an already-validated level without it.
   if (
     !catalogEntry ||
-    (params.providerPolicySource === "active" && catalogEntry.reasoning === undefined)
+    (params.providerPolicySource !== undefined &&
+      params.providerPolicySource !== "active-or-bundled" &&
+      catalogEntry.reasoning === undefined)
   ) {
     return params.level;
   }
@@ -126,9 +128,12 @@ function resolveGatewaySessionThinkingDefault(params: {
     ? resolveAgentConfig(params.cfg, params.agentId)?.thinkingDefault
     : undefined;
   const resolveDefault =
-    params.providerPolicySource === "active"
+    params.providerPolicySource !== undefined && params.providerPolicySource !== "active-or-bundled"
       ? (defaultParams: Parameters<typeof resolveThinkingDefault>[0]) =>
-          resolveThinkingDefaultCore({ ...defaultParams, providerPolicySource: "active" })
+          resolveThinkingDefaultCore({
+            ...defaultParams,
+            providerPolicySource: params.providerPolicySource,
+          })
       : resolveThinkingDefault;
   const defaultLevel =
     agentThinkingDefault ??
@@ -182,7 +187,9 @@ export function resolveGatewayModelThinkingProfile(params: {
       sessionKey: params.sessionKey,
     });
   const thinkingPolicyProvider = params.thinkingPolicyProvider ?? params.provider;
-  const key = `${normalizeAgentId(params.agentId)}\0${agentRuntime}\0${normalizeLowercaseStringOrEmpty(thinkingPolicyProvider)}\0${String(params.configuredReasoning)}\0${params.providerPolicySource ?? "active-or-bundled"}\0${createSessionRowModelCacheKey(
+  const policySource =
+    typeof params.providerPolicySource === "object" ? "prepared" : params.providerPolicySource;
+  const key = `${normalizeAgentId(params.agentId)}\0${agentRuntime}\0${normalizeLowercaseStringOrEmpty(thinkingPolicyProvider)}\0${String(params.configuredReasoning)}\0${policySource ?? "active-or-bundled"}\0${createSessionRowModelCacheKey(
     params.provider,
     params.model,
   )}`;
@@ -355,7 +362,12 @@ export function getSessionDefaults(
     provider: resolved.provider,
     model: resolved.model,
     agentId,
-    modelCatalog: modelCatalog ?? (options?.providerPolicySource === "active" ? [] : undefined),
+    modelCatalog:
+      modelCatalog ??
+      (options?.providerPolicySource !== undefined &&
+      options.providerPolicySource !== "active-or-bundled"
+        ? []
+        : undefined),
     sessionKey,
     providerPolicySource: options?.providerPolicySource,
   });

--- a/src/gateway/session-utils-row.ts
+++ b/src/gateway/session-utils-row.ts
@@ -351,12 +351,12 @@ export function buildGatewaySessionRow(params: {
 
   const thinkingProvider = rowModelProvider ?? DEFAULT_PROVIDER;
   const thinkingModel = rowModel ?? DEFAULT_MODEL;
-  // A per-agent catalog map keeps unscoped listings owner-scoped: each row uses
-  // its own agent's completed catalog instead of a shared default-agent catalog.
+  // Entries and provider policy must stay bound to the same prepared agent owner;
+  // the Gateway startup registry can contain a different set of plugins.
+  const preparedCatalog =
+    params.modelCatalog instanceof Map ? params.modelCatalog.get(sessionAgentId) : undefined;
   const rowModelCatalog =
-    params.modelCatalog instanceof Map
-      ? params.modelCatalog.get(sessionAgentId)
-      : params.modelCatalog;
+    params.modelCatalog instanceof Map ? preparedCatalog?.entries : params.modelCatalog;
   // Event/list rows must not rediscover plugin-backed configured catalog metadata.
   // Lightweight projections may use an already-active provider policy, but must
   // not fall through to public artifacts that reload the manifest registry.
@@ -370,7 +370,7 @@ export function buildGatewaySessionRow(params: {
     entry,
     modelCatalog: thinkingModelCatalog,
     rowContext,
-    providerPolicySource: lightweight ? "active" : undefined,
+    providerPolicySource: preparedCatalog?.pluginRegistry ?? (lightweight ? "active" : undefined),
   });
   const catalogEntry =
     rowModelCatalog && rowModelProvider && rowModel

--- a/src/gateway/session-utils-store.ts
+++ b/src/gateway/session-utils-store.ts
@@ -39,7 +39,7 @@ import {
   resolveGatewaySessionStoreTarget,
   resolveGatewaySessionStoreTargetWithStore,
 } from "./session-utils-store-lookup.js";
-import type { GatewayAgentRow } from "./session-utils.types.js";
+import type { GatewayAgentRow, SessionListModelCatalog } from "./session-utils.types.js";
 import { projectWorkerPlacementAgentRuntime } from "./worker-environments/placement-session-runtime.js";
 
 /**
@@ -304,7 +304,7 @@ export function listAgentsForGateway(
   cfg: OpenClawConfig,
   modelCatalog?: ModelCatalogEntry[],
   options?: {
-    modelCatalogByAgentId?: ReadonlyMap<string, ModelCatalogEntry[] | undefined>;
+    modelCatalogByAgentId?: SessionListModelCatalog;
     includeSystem?: boolean;
   },
 ): {
@@ -357,9 +357,17 @@ export function listAgentsForGateway(
         acpRuntime: false,
       }),
     );
-    const agentModelCatalog = options?.modelCatalogByAgentId?.has(id)
-      ? options.modelCatalogByAgentId.get(id)
-      : (modelCatalog ?? options?.modelCatalogByAgentId?.get(basic.defaultId));
+    const hasAgentCatalog = options?.modelCatalogByAgentId?.has(id);
+    // Unconfigured system rows inherit the default catalog; keep its provider
+    // policy attached. A configured owner with no catalog must not inherit it.
+    const preparedCatalog = hasAgentCatalog
+      ? options?.modelCatalogByAgentId?.get(id)
+      : modelCatalog
+        ? undefined
+        : options?.modelCatalogByAgentId?.get(basic.defaultId);
+    const agentModelCatalog = hasAgentCatalog
+      ? preparedCatalog?.entries
+      : (modelCatalog ?? preparedCatalog?.entries);
     const thinkingProfile = resolveGatewayModelThinkingProfile({
       cfg,
       agentId: id,
@@ -367,6 +375,7 @@ export function listAgentsForGateway(
       model: resolvedModel.model,
       modelCatalog: agentModelCatalog,
       sessionKey,
+      providerPolicySource: preparedCatalog?.pluginRegistry,
     });
     const workspace = resolveAgentWorkspaceDir(cfg, id);
     // Must mirror the sessions.create worktree preflight: subdirectory workspaces inside a

--- a/src/gateway/session-utils.test.ts
+++ b/src/gateway/session-utils.test.ts
@@ -1348,7 +1348,10 @@ describe("gateway session utils", () => {
         },
       },
     } as OpenClawConfig;
-    const row = (entry: SessionEntry, catalog?: { reasoning?: boolean }) =>
+    const row = (
+      entry: SessionEntry,
+      catalog?: { reasoning?: boolean; compat?: { supportedReasoningEfforts: string[] } },
+    ) =>
       buildGatewaySessionRow({
         cfg,
         storePath: "",
@@ -1374,6 +1377,16 @@ describe("gateway session utils", () => {
     expect(row(stored).thinkingLevel).toBe("ultra");
     expect(row(stored, {}).thinkingLevel).toBe("ultra");
     expect(row(stored, { reasoning: true }).thinkingLevel).toBe("high");
+    expect(
+      row(stored, { reasoning: true, compat: { supportedReasoningEfforts: ["max"] } })
+        .thinkingLevel,
+    ).toBe("max");
+    const nativeUltra = row(stored, {
+      reasoning: true,
+      compat: { supportedReasoningEfforts: ["max", "ultra"] },
+    });
+    expect(nativeUltra.thinkingLevel).toBe("ultra");
+    expect(nativeUltra.thinkingLevels).toContainEqual({ id: "ultra", label: "ultra" });
   });
 
   test("strips retired thinking provenance from Gateway patch results", async () => {

--- a/src/gateway/session-utils.test.ts
+++ b/src/gateway/session-utils.test.ts
@@ -3960,8 +3960,8 @@ describe("gateway session utils", () => {
 
     const result = listAgentsForGateway(cfg, disabledCatalog, {
       modelCatalogByAgentId: new Map([
-        ["main", disabledCatalog],
-        ["work", enabledCatalog],
+        ["main", { entries: disabledCatalog }],
+        ["work", { entries: enabledCatalog }],
         ["missing", undefined],
       ]),
     });

--- a/src/gateway/session-utils.types.ts
+++ b/src/gateway/session-utils.types.ts
@@ -16,7 +16,6 @@ import type {
 import type { QueueMode } from "../../packages/gateway-protocol/src/schema/logs-chat.js";
 import type { SessionParticipant } from "../../packages/gateway-protocol/src/schema/session-participant.js";
 import type { SessionObserverDigest } from "../../packages/gateway-protocol/src/schema/sessions.js";
-import type { ModelCatalogEntry } from "../agents/model-catalog.js";
 import type { ChatType } from "../channels/chat-type.js";
 import type {
   SessionCompactionCheckpoint,
@@ -36,6 +35,7 @@ import type {
   SessionsPatchResultBase,
 } from "../shared/session-types.js";
 import type { DeliveryContext } from "../utils/delivery-context.types.js";
+import type { PreparedGatewayModelCatalog } from "./server-model-catalog.types.js";
 
 // Shared Gateway session response contracts. Server methods, UI adapters, and
 // tests import these types so list/patch/preview payloads evolve together.
@@ -241,7 +241,7 @@ export type SessionsListResult = SessionsListResultBase<GatewaySessionsDefaults,
  * carry exactly one agent's catalog; unscoped listings carry one per configured
  * agent so row projections stay owner-scoped.
  */
-export type SessionListModelCatalog = ReadonlyMap<string, ModelCatalogEntry[] | undefined>;
+export type SessionListModelCatalog = ReadonlyMap<string, PreparedGatewayModelCatalog | undefined>;
 
 export type SessionsPatchResult = SessionsPatchResultBase<SessionEntry> & {
   entry: SessionEntry;

--- a/src/gateway/test/server-sessions.test-helpers.ts
+++ b/src/gateway/test/server-sessions.test-helpers.ts
@@ -719,7 +719,7 @@ export async function directSessionReq<TPayload = unknown>(
       dedupe: new Map(),
       getSessionEventSubscriberConnIds: () => new Set<string>(),
       loadGatewayModelCatalog,
-      readPreparedGatewayModelCatalog: loadGatewayModelCatalog,
+      readPreparedGatewayModelCatalog: async () => ({ entries: await loadGatewayModelCatalog() }),
       getRuntimeConfig,
       ...opts?.context,
     } as never,

--- a/src/plugins/provider-thinking-active.ts
+++ b/src/plugins/provider-thinking-active.ts
@@ -1,26 +1,13 @@
-// Reads provider thinking policy from the active runtime registry only.
+// Reads provider thinking policy from a prepared or active runtime registry.
 import { matchesProviderPluginRef } from "./provider-registry-shared.js";
 import type {
   ProviderDefaultThinkingPolicyContext,
-  ProviderThinkingProfile,
+  ProviderThinkingRegistry,
 } from "./provider-thinking.types.js";
 import { PLUGIN_REGISTRY_STATE } from "./runtime-state-key.js";
 
-type ActiveThinkingProvider = {
-  id: string;
-  aliases?: string[];
-  hookAliases?: string[];
-  resolveThinkingProfile?: (
-    ctx: ProviderDefaultThinkingPolicyContext,
-  ) => ProviderThinkingProfile | null | undefined;
-};
-
 type ActiveThinkingRegistryState = {
-  activeRegistry?: {
-    providers?: Array<{
-      provider: ActiveThinkingProvider;
-    }>;
-  } | null;
+  activeRegistry?: ProviderThinkingRegistry | null;
 };
 
 type ThinkingHookParams<TContext> = {
@@ -28,19 +15,22 @@ type ThinkingHookParams<TContext> = {
   context: TContext;
 };
 
-function resolveActiveThinkingProvider(providerId: string): ActiveThinkingProvider | undefined {
+function resolveActiveThinkingProvider(providerId: string, registry?: ProviderThinkingRegistry) {
   const state = (
     globalThis as typeof globalThis & {
       [PLUGIN_REGISTRY_STATE]?: ActiveThinkingRegistryState;
     }
   )[PLUGIN_REGISTRY_STATE];
-  return state?.activeRegistry?.providers?.find((entry) =>
+  return (registry ?? state?.activeRegistry)?.providers?.find((entry) =>
     matchesProviderPluginRef(entry.provider, providerId),
   )?.provider;
 }
 
 export function resolveActiveProviderThinkingProfile(
   params: ThinkingHookParams<ProviderDefaultThinkingPolicyContext>,
+  registry?: ProviderThinkingRegistry,
 ) {
-  return resolveActiveThinkingProvider(params.provider)?.resolveThinkingProfile?.(params.context);
+  return resolveActiveThinkingProvider(params.provider, registry)?.resolveThinkingProfile?.(
+    params.context,
+  );
 }

--- a/src/plugins/provider-thinking.ts
+++ b/src/plugins/provider-thinking.ts
@@ -2,7 +2,10 @@
 import { getCurrentPluginMetadataSnapshot } from "./current-plugin-metadata-snapshot.js";
 import { resolveProviderPolicySurface } from "./provider-public-artifacts.js";
 import { resolveActiveProviderThinkingProfile } from "./provider-thinking-active.js";
-import type { ProviderDefaultThinkingPolicyContext } from "./provider-thinking.types.js";
+import type {
+  ProviderDefaultThinkingPolicyContext,
+  ProviderThinkingRegistry,
+} from "./provider-thinking.types.js";
 
 function resolveProviderPublicPolicySurface(providerId: string) {
   const metadataSnapshot = getCurrentPluginMetadataSnapshot({
@@ -22,13 +25,14 @@ type ThinkingHookParams<TContext> = {
 /** Resolves a provider thinking profile from active plugins or bundled policy surface. */
 export function resolveEffectiveThinkingProfile(
   params: ThinkingHookParams<ProviderDefaultThinkingPolicyContext>,
-  options?: { allowPublicArtifactFallback?: boolean },
+  options?: { allowPublicArtifactFallback?: boolean; registry?: ProviderThinkingRegistry },
 ) {
-  const activeProfile = resolveActiveProviderThinkingProfile(params);
+  const activeProfile = resolveActiveProviderThinkingProfile(params, options?.registry);
   if (activeProfile !== undefined) {
     return activeProfile;
   }
-  if (options?.allowPublicArtifactFallback === false) {
+  // A captured owner is authoritative even when its registry has no matching hook.
+  if (options?.registry || options?.allowPublicArtifactFallback === false) {
     return undefined;
   }
   return resolveProviderPublicPolicySurface(params.provider)?.resolveThinkingProfile?.(

--- a/src/plugins/provider-thinking.types.ts
+++ b/src/plugins/provider-thinking.types.ts
@@ -72,3 +72,22 @@ export type ProviderThinkingProfile = {
    */
   preserveWhenCatalogReasoningFalse?: boolean;
 };
+
+/** Prepared provider policy ownership, without the broader Gateway registry contract. */
+export type ProviderThinkingRegistry = {
+  providers: ReadonlyArray<{
+    provider: {
+      id: string;
+      aliases?: string[];
+      hookAliases?: string[];
+      resolveThinkingProfile?: (
+        context: ProviderDefaultThinkingPolicyContext,
+      ) => ProviderThinkingProfile | null | undefined;
+    };
+  }>;
+};
+
+export type ProviderThinkingPolicySource =
+  | "active"
+  | "active-or-bundled"
+  | ProviderThinkingRegistry;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where session controls display Max after accepting Ultra for a native model. Agent lists and session defaults can also show another agent's provider policy when their prepared catalogs contain the same model.

## Why This Change Was Made

The lightweight session reader discarded the provider registry attached to the prepared model owner. It then resolved thinking controls against the Gateway startup registry, which can contain different plugins. The live diagnostic confirmed that the stored selection remained Ultra while the rendered row changed to Max.

The reader now carries catalog entries and their prepared provider registry together. Session rows, defaults, and agent lists use that captured policy; completed response caching tracks both entry and registry identity. An explicitly empty prepared registry remains authoritative. Existing system-agent inheritance keeps the catalog and policy paired, and reads do not start provider discovery.

The original generic catalog repair remains: explicitly advertised native Ultra is preserved without requiring an active provider plugin. There are no new configuration options, persistence changes, discovery passes, or global caches.

## User Impact

Thinking controls stay aligned with the selected agent and runtime, including native Ultra for supported models and Max for native models whose policy stops there. Existing lightweight listing and system-agent behavior remain intact.

## Evidence

- The original [full verification](https://github.com/openclaw/openclaw/actions/runs/33230733150) remains failed; this PR repairs one of its confirmed product failures.
- A bounded [live diagnostic](https://github.com/openclaw/openclaw/actions/runs/33240631707) captured persisted Ultra, rendered Max, and distinct prepared-provider versus Gateway startup registries.
- Before the owner repair, the new real-reader-to-session-handler regressions fail for Sol and Terra (Max versus Ultra) and for cross-agent policy isolation. The same tests pass afterward.
- 496 tests passed across 15 files, covering session rows, defaults, agent lists, registry replacement with unchanged entries, completed catalog promotion, generic thinking, provider policy, and the unchanged system-agent inheritance assertion.
- Mandatory Codex autoreview reported no actionable P0 findings. Independent source review confirmed that the reader uses only completed prepared facts and adds no runtime import cycle.
- The owner-binding change is production +133/-66 (net +67), carrying one existing owner across the read boundary and its cache; tests/support +305/-74. The small initial catalog repair is retained separately.
- [CI](https://github.com/openclaw/openclaw/actions/runs/33244595273) passed for the reviewed d6db83fdb9d1ec172c585c177a01c798bb84c9a0 head. The fresh [native live replay](https://github.com/openclaw/openclaw/actions/runs/33244661283) passed all three cases: Sol Ultra (257s), Terra Ultra (230s), and Luna Max (236s). Each retained strict succeeded/delivered/child-token assertions, guardian checks, session deletion, and clean shutdown. Sol/Terra also passed native child ownership rejection; Luna does not enter that conditional branch.
- The complete changed-file gate passed with a fresh frozen dependency installation, including typed lint, core and core-test types, boundary guards, and zero runtime import cycles.

## Review decisions and upstream contract

The latest ClawSweeper review was read, including its rank-up moves. The acting maintainer directly inspected the installed harness version's upstream Codex source, tag `rust-v0.150.1`: [ReasoningEffort](https://github.com/openai/codex/blob/rust-v0.150.1/codex-rs/protocol/src/openai_models.rs#L50) retains and serializes Ultra, [reasoning_effort_for_request](https://github.com/openai/codex/blob/rust-v0.150.1/codex-rs/core/src/client.rs#L179) maps Ultra to Max only when building the model request (called at line 859), and [native collaboration](https://github.com/openai/codex/blob/rust-v0.150.1/codex-rs/core/src/session/multi_agents.rs#L167) selects proactive behavior from Ultra. OpenClaw's `run-attempt-turn-request.ts:131` emits its lifecycle event from `turnStartParams` before invoking `turn/start`. The corrected test therefore checks Ultra at that lifecycle boundary; it does not change the downstream model request or weaken an assertion. The final real replay confirms this exact contract with Codex CLI 0.150.1.

The prepared registry is intentionally authoritative, including an empty registry. Falling through to another registry would recreate the demonstrated cross-agent ownership leak; no provider discovery is started by these read paths. The decision applies to an in-process prepared fact, not persisted configuration or a serialized data model. There are no schema, migration, or protocol changes. Existing catalog-only callers retain their behavior.

The changelog rank-up is intentionally skipped for this explicitly requested maintainer release-verification closeout: the user's standing instruction requires a changelog note for user-visible repairs. The native supported maintainer exception is used; this does not change repository policy.

## Required main refresh

Main added an overlapping changelog note, requiring a mechanical rebase to `44063ed60d2cf36fb8ca9900bd3ac772938bc6f2` on `8e673fc7f829ca891b1fe7e52b5cb4f677e3819a`. Both release notes are preserved. All production files and 25 of 26 non-changelog changed files are byte-identical to the preceding head; the five-commit range diff changes only changelog context.

The remaining test file also contains the independently landed #132499 fixture conversion to the built Gateway. Its public task status `completed` is the canonical projection of internal `succeeded`; delivered status and the exact child token remain required. Because that upstream fixture changed, fresh [CI](https://github.com/openclaw/openclaw/actions/runs/33246282109) and the same three [native live cases](https://github.com/openclaw/openclaw/actions/runs/33246386838) passed against 44063ed. Sol took 72.84s, Terra 51.17s, and Luna 69.30s; strict task delivery, lifecycle effort, guardians, session deletion, and managed cleanup all passed. The earlier live result remains explicitly bound to d6db83f. Fresh mandatory Codex autoreview of the rebased branch reported no actionable P0 findings.

## Final landing evidence

The final head is e7d3c063b7faa1260429cf2bee4b4441fe23089f, rebased after the related Media and Grok fixes landed. [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/33247426947) passed. The five code/test patches are unchanged from the live-proven 44063ed head. Of the 26 non-changelog changed files, 25 remain byte-identical; the complete session-list cache file also incorporates three independent upstream worker-inventory fence lines, inspected directly. The changelog note now sits beside the related Codex entry to avoid repeated conflicts with new notes at the top. Fresh mandatory Codex autoreview found no actionable P0 issues.

The latest exact-head ClawSweeper review and its rank-up moves were read. The prepared-owner decision and direct tagged upstream Codex check above remain applicable; the changelog removal is explicitly skipped under the documented maintainer closeout exception and the user's user-visible repair requirement. No persistence or schema change exists. Fresh full release verification will follow all repair landings; the original failed parent remains failed.
