### PR TITLE
test(reply): remove wall-clock wait from hung dispatch regression

### DIFF
--- a/src/auto-reply/reply/dispatch-from-config.base.test-utils.ts
+++ b/src/auto-reply/reply/dispatch-from-config.base.test-utils.ts
@@ -1079,19 +1079,25 @@ describe("dispatchReplyFromConfig", () => {
   it("bounds Slack bypass lease cleanup when dispatcher idle never settles", async () => {
     const { activeOperation, createCtx, sessionId, sessionKey } = createActiveSlackThread("U4");
     const dispatcher = createDispatcher();
+    const replyResolver = vi.fn(async () => undefined);
     dispatcher.waitForIdle = vi.fn(async () => await new Promise<void>(() => {}));
     dispatcher.resolveFollowupAdmissionBarrierTimeoutPolicy = () => ({
       maxTimeoutMs: 25,
       shouldExtend: () => false,
     });
 
+    vi.useFakeTimers();
     try {
-      const result = await dispatchReplyFromConfig({
+      const dispatch = dispatchReplyFromConfig({
         ctx: createCtx({ BodyForAgent: "hung delivery barrier" }),
         cfg: emptyConfig,
         dispatcher,
-        replyResolver: async () => undefined,
+        replyResolver,
       });
+      await vi.waitFor(() => expect(replyResolver).toHaveBeenCalled());
+      // Advance settlement only; the cleanup assertion must still reject an overlong lease.
+      await vi.advanceTimersByTimeAsync(30_000);
+      const result = await dispatch;
 
       // An unsettled custom dispatcher has no receipt, so the turn cannot claim delivery.
       expect(result.queuedFinal).toBe(false);
@@ -1106,6 +1112,7 @@ describe("dispatchReplyFromConfig", () => {
       );
     } finally {
       activeOperation.complete();
+      vi.useRealTimers();
     }
   });
 


### PR DESCRIPTION
## What Problem This Solves

The hung-dispatcher regression test spends thirty seconds waiting for the real settlement deadline on every run. Its dispatcher deliberately never settles; the elapsed wall time adds no transport coverage.

## Why This Change Was Made

Use virtual time only in this case, wait until reply resolution has begun, then advance the unchanged thirty-second settlement deadline. Keep the separate 500ms lease-cleanup assertion and restore real timers in `finally`.

Draining every timer would hide an overlong cleanup lease. The bounded advance preserves that distinction and leaves production admission, settlement, and lease ownership unchanged.

## User Impact

The existing case takes **0.168s instead of 30.155s** locally. No production, sharding, worker-count, selection, configuration, or runtime timeout changes. Test/support LOC +9/-2; production +0/-0.

## Evidence

- Baseline: all 128 dispatch tests passed; the affected case took 30.155s. Final run: all **218 tests across dispatch, lifecycle, and turn-ledger suites passed**, with the affected case at 0.168s.
- Command: `node scripts/run-vitest.mjs src/auto-reply/reply/dispatch-from-config.test.ts src/auto-reply/reply/dispatch-from-config.turn-ledger.test.ts src/auto-reply/reply/dispatch-from-config.lifecycle.test.ts`.
- Negative probes removed the ledger deadline, removed bounded lease settlement, and substituted an excessive cleanup deadline; each failed. Temporary broken-code runs used a short runner timeout to bound hangs. No runner timeout is changed in this PR; original production and fixture bytes were restored before the final passing run.
- Independent review caught the drain-all-timers coverage issue; the final bounded implementation addresses it. Fresh Codex autoreview and formatting passed. Installed Vitest timer semantics and the real lifecycle/ledger owners were inspected directly.
- Linux changed-file checks passed (wrapper exit 0, Testbox stopped): https://github.com/openclaw/openclaw/actions/runs/33236302122. Exact-head CI passed: https://github.com/openclaw/openclaw/actions/runs/33236357774.
- Latest ClawSweeper review found no actionable findings and requested normal exact-head CI; that request is satisfied.
