### PR TITLE
feat(ui): show node worker-slot utilization as segmented pips in the placement picker and Devices settings

### DIFF
--- a/scripts/capture-where-chip-auto-proof.mts
+++ b/scripts/capture-where-chip-auto-proof.mts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
-// Captures Where-chip placement proof: the open picker with the Auto row and
-// its least-busy subtitle, and the collapsed chip after selecting Auto.
+// Captures placement, inventory, and context-meter proof in both themes.
+import assert from "node:assert/strict";
 import { mkdir } from "node:fs/promises";
 import path from "node:path";
 import { chromium } from "playwright";
@@ -11,8 +11,9 @@ import {
   startControlUiE2eServer,
 } from "../ui/src/test-helpers/control-ui-e2e.ts";
 
-const label = process.argv[2] ?? "after";
-const outputDir = path.resolve(".artifacts/control-ui-e2e/where-chip-auto-proof");
+const captureLabel = process.argv[2] ?? "after";
+const outputDir = path.resolve(process.argv[3] ?? "/tmp/node-slot-pips-proof");
+const remoteExec = process.argv[4] === "remote-exec";
 await mkdir(outputDir, { recursive: true });
 const executablePath = resolvePlaywrightChromiumExecutablePath(chromium.executablePath());
 if (!canRunPlaywrightChromium(executablePath)) {
@@ -20,42 +21,145 @@ if (!canRunPlaywrightChromium(executablePath)) {
 }
 const server = await startControlUiE2eServer(undefined, { source: true });
 const browser = await chromium.launch({ executablePath });
-const context = await browser.newContext({
-  colorScheme: "dark",
-  viewport: { width: 1280, height: 800 },
-});
-const page = await context.newPage();
-page.setDefaultTimeout(30_000);
+const environments = [
+  { id: "idle", label: "Idle runner", workerSlots: { total: 8, available: 8 } },
+  { id: "partial", label: "Busy runner", workerSlots: { total: 8, available: 5 } },
+  { id: "full", label: "Full runner", workerSlots: { total: 8, available: 0 } },
+  { id: "offline", label: "Offline runner", workerSlots: { total: 8, available: 2 } },
+  { id: "large", label: "Large runner", workerSlots: { total: 13, available: 6 } },
+  { id: "exec", label: "Terminal runner" },
+].map(({ id, label, workerSlots }) => ({
+  id: `node:${id}`,
+  label,
+  workerSlots,
+  type: "node",
+  status: id === "offline" ? "unavailable" : "available",
+  sessionHost: true,
+  platform: "linux",
+  capabilities: ["codex.exec-server"],
+  invocableCommands: ["codex.exec-server.stdio.v1"],
+}));
 try {
-  await installMockGateway(page, {
-    methodResponses: {
-      "environments.list": {
-        environments: [
-          {
-            id: "node:studio",
-            type: "node",
-            label: "steipete-studio-sf",
-            status: "available",
-            sessionHost: true,
-            workerSlots: { total: 50, available: 50 },
-          },
-        ],
-        profiles: [],
+  for (const mode of ["dark", "light"] as const) {
+    const context = await browser.newContext({
+      colorScheme: mode,
+      locale: "en-US",
+      viewport: { width: 1280, height: 900 },
+    });
+    const page = await context.newPage();
+    page.setDefaultTimeout(30_000);
+    const config = { ui: { prefs: { theme: "claw", themeMode: mode } } };
+    await installMockGateway(page, {
+      ...(remoteExec
+        ? {
+            agentModel: "openai/gpt-5.6-sol",
+            models: [
+              {
+                available: true,
+                id: "gpt-5.6-sol",
+                name: "GPT-5.6 Sol",
+                provider: "openai",
+                agentRuntime: {
+                  id: "codex",
+                  devicePlacementSupported: true,
+                  source: "model",
+                  devicePlacement: {
+                    requiredNodeCommands: ["codex.exec-server.stdio.v1"],
+                    consumesWorkerSlot: false,
+                  },
+                },
+              },
+            ],
+          }
+        : {}),
+      methodResponses: {
+        "config.get": { config, hash: "capacity-proof", valid: true, issues: [] },
+        "environments.list": {
+          environments,
+          profiles: [],
+        },
+        "node.list": {
+          nodes: environments.map((entry) => ({
+            nodeId: entry.id.slice(5),
+            displayName: entry.label,
+            platform: entry.platform,
+            paired: true,
+            connected: entry.status === "available",
+            approvalState: "approved",
+            caps: entry.capabilities,
+            commands: entry.invocableCommands,
+            workerSlots: entry.workerSlots,
+          })),
+        },
+        "sessions.list": {
+          count: 4,
+          ts: 0,
+          path: "",
+          defaults: {},
+          sessions: [
+            { label: "Context OK", totalTokens: 40_000 },
+            { label: "Context warning", totalTokens: 140_000 },
+            { label: "Context danger", totalTokens: 180_000 },
+            { label: "Context approximate", totalTokens: 180_000, totalTokensFresh: false },
+          ].map(({ label, totalTokens, totalTokensFresh }, index) => ({
+            label,
+            totalTokens,
+            totalTokensFresh,
+            key: `agent:main:context-${index}`,
+            kind: "direct",
+            updatedAt: 0,
+            contextTokens: 200_000,
+            hasActiveRun: false,
+          })),
+        },
       },
-    },
-  });
-  await page.goto(`${server.baseUrl}new`);
-  const chip = page.getByText("Local", { exact: true }).first();
-  await chip.waitFor();
-  await page.waitForTimeout(600);
-  await chip.click();
-  await page.waitForSelector('[data-value="auto-device"]');
-  await page.waitForTimeout(300);
-  await page.screenshot({ path: path.join(outputDir, `${label}-menu.png`) });
-  await page.locator('[data-value="auto-device"]').click();
-  await page.waitForTimeout(500);
-  await page.screenshot({ path: path.join(outputDir, `${label}-selected.png`) });
-  console.log("SHOT_OK", label);
+    });
+    await page.goto(`${server.baseUrl}new`);
+    const chip = page.getByText("Local", { exact: true }).first();
+    await chip.waitFor();
+    await page.waitForFunction(
+      (themeMode) => document.documentElement.dataset.themeMode === themeMode,
+      mode,
+    );
+    await page.evaluate(() => document.fonts.ready);
+    await chip.click();
+    await page.waitForSelector('[data-value="auto-device"]');
+    await page.locator('[data-value="device:exec"]').waitFor();
+    if (remoteExec) {
+      assert.equal(await page.locator('[data-value="device:full"]').isEnabled(), true);
+      assert.equal(await page.locator('[data-value="device:exec"]').isEnabled(), true);
+    }
+    await page.screenshot({
+      path: path.join(outputDir, `${captureLabel}-${mode}-menu.png`),
+      animations: "disabled",
+    });
+    await page.locator('[data-value="auto-device"]').click();
+    await page.locator('#new-session-where-trigger[data-auto-device="true"]').waitFor();
+    if (remoteExec) {
+      await page.locator("#new-session-where-trigger").click();
+      await page.locator('[data-value="device:full"]').click();
+      await page.locator('#new-session-where-trigger[data-device-id="full"]').waitFor();
+      console.log("SHOT_OK", captureLabel, mode, outputDir);
+      await context.close();
+      continue;
+    }
+    await page.goto(`${server.baseUrl}settings/devices`);
+    await page.getByText("Terminal runner", { exact: true }).waitFor();
+    await page.screenshot({
+      path: path.join(outputDir, `${captureLabel}-${mode}-devices.png`),
+      animations: "disabled",
+    });
+    await page.goto(`${server.baseUrl}sessions`);
+    await page.locator(".session-context-meter").first().waitFor();
+    assert.equal(await page.locator(".session-context-meter").count(), 4);
+    await page.evaluate(() => document.fonts.ready);
+    await page.locator(".data-table-container").screenshot({
+      path: path.join(outputDir, `${captureLabel}-${mode}-sessions.png`),
+      animations: "disabled",
+    });
+    console.log("SHOT_OK", captureLabel, mode, outputDir);
+    await context.close();
+  }
 } finally {
   await browser.close();
   await server.close();

--- a/test/scripts/lint-suppressions.test.ts
+++ b/test/scripts/lint-suppressions.test.ts
@@ -199,7 +199,7 @@ describe("production lint suppressions", () => {
         "extensions/matrix/src/onboarding.test-harness.ts|typescript/no-unnecessary-type-parameters|1",
         // Oxlint 1.78 checks AggregateError cause options at the wrong argument position.
         "extensions/qa-lab/src/gateway-child-lifecycle.ts|preserve-caught-error|1",
-        "extensions/qa-lab/src/gateway-child-setup.ts|preserve-caught-error|1",
+        "extensions/qa-lab/src/gateway-child-setup.ts|preserve-caught-error|2",
         "extensions/slack/src/monitor/provider-support.ts|typescript/no-unnecessary-type-parameters|1",
         "src/agents/agent-bundle-mcp-runtime.ts|unicorn/prefer-add-event-listener|1",
         "src/agents/agent-tools.abort.ts|typescript/prefer-promise-reject-errors|1",

--- a/ui/src/components/capacity-meter.test.ts
+++ b/ui/src/components/capacity-meter.test.ts
@@ -1,0 +1,123 @@
+/* @vitest-environment jsdom */
+import { nothing, render } from "lit";
+import { describe, expect, it } from "vitest";
+import { workerCapacityPresentation } from "./worker-capacity.ts";
+
+function renderCapacity(params: Parameters<typeof workerCapacityPresentation>[0]) {
+  const container = document.createElement("div");
+  const capacity = workerCapacityPresentation(params);
+  render(capacity?.meter ?? nothing, container);
+  return container;
+}
+
+describe("worker capacity meter", () => {
+  it.each([
+    {
+      name: "idle",
+      available: 8,
+      unavailable: false,
+      filled: 0,
+      tone: "accent",
+      label: "0 of 8 slots busy",
+    },
+    {
+      name: "partially occupied",
+      available: 5,
+      unavailable: false,
+      filled: 3,
+      tone: "accent",
+      label: "3 of 8 slots busy",
+    },
+    {
+      name: "at capacity",
+      available: 0,
+      unavailable: false,
+      filled: 8,
+      tone: "warn",
+      label: "8 of 8 slots busy",
+    },
+    {
+      name: "offline with a last-known metric",
+      available: 5,
+      unavailable: true,
+      filled: 0,
+      tone: "stale",
+      label: "Slot utilization unavailable",
+    },
+    {
+      name: "ineligible and saturated",
+      available: 0,
+      unavailable: true,
+      filled: 0,
+      tone: "stale",
+      label: "Slot utilization unavailable",
+    },
+  ])(
+    "renders $name without reversing free and busy",
+    ({ available, unavailable, filled, tone, label }) => {
+      const container = renderCapacity({ workerSlots: { total: 8, available }, unavailable });
+      const meter = container.querySelector('[role="img"]');
+      expect(meter?.getAttribute("aria-label")).toBe(label);
+      expect(meter?.classList.contains(`session-context-meter--${tone}`)).toBe(true);
+      expect(container.querySelectorAll(".capacity-meter-pips__pip")).toHaveLength(8);
+      expect(container.querySelectorAll(".capacity-meter-pips__pip--filled")).toHaveLength(filled);
+    },
+  );
+
+  it.each([
+    { total: 12, unavailable: false, pips: 12, width: undefined, tone: "accent" },
+    { total: 13, unavailable: false, pips: 0, width: "100%", tone: "warn" },
+    { total: 1024, unavailable: false, pips: 0, width: "50%", tone: "accent" },
+    { total: 13, unavailable: true, pips: 0, width: "0%", tone: "stale" },
+  ])(
+    "bounds glyphs for $total slots (unavailable=$unavailable)",
+    ({ total, unavailable, pips, width, tone }) => {
+      const available = total === 13 ? 0 : total / 2;
+      const container = renderCapacity({ workerSlots: { total, available }, unavailable });
+      expect(container.querySelectorAll(".capacity-meter-pips__pip")).toHaveLength(pips);
+      expect(
+        container.querySelector<HTMLElement>(".session-context-meter__fill")?.style.width,
+      ).toBe(width);
+      expect(
+        container
+          .querySelector('[role="img"]')
+          ?.classList.contains(`session-context-meter--${tone}`),
+      ).toBe(true);
+      expect(container.querySelector('[role="img"]')?.getAttribute("aria-label")).toBe(
+        unavailable
+          ? "Slot utilization unavailable"
+          : `${total - available} of ${total} slots busy`,
+      );
+    },
+  );
+
+  it.each([
+    { capabilities: ["codex.exec-server"], unavailable: false },
+    { capabilities: ["codex.exec-server.stdio.v1"], unavailable: false },
+    { commands: ["codex.exec-server.stdio.v1"], unavailable: false },
+    { capabilities: ["codex.exec-server"], unavailable: true },
+  ])("shows a terminal affordance for a slot-less exec host: %j", (params) => {
+    const container = renderCapacity(params);
+    expect(container.querySelector('[role="img"]')?.getAttribute("aria-label")).toBe("Codex exec");
+    expect(container.textContent).toContain("Codex exec");
+    expect(container.querySelector("svg")).not.toBeNull();
+    expect(container.querySelector(".capacity-meter-pips, .session-context-meter")).toBeNull();
+  });
+
+  it("prefers slots on dual hosts and renders nothing for an unmetered ordinary device", () => {
+    const dualHost = renderCapacity({
+      workerSlots: { total: 8, available: 5 },
+      capabilities: ["codex.exec-server"],
+      unavailable: false,
+    });
+    expect(dualHost.querySelector('[role="img"]')?.getAttribute("aria-label")).toBe(
+      "3 of 8 slots busy",
+    );
+    expect(dualHost.textContent).not.toContain("Codex exec");
+    for (const unavailable of [false, true]) {
+      const unmetered = renderCapacity({ capabilities: ["camera"], unavailable });
+      expect(unmetered.querySelector('[role="img"]')).toBeNull();
+      expect(unmetered.textContent).toBe("");
+    }
+  });
+});

--- a/ui/src/components/capacity-meter.ts
+++ b/ui/src/components/capacity-meter.ts
@@ -1,0 +1,45 @@
+import { html } from "lit";
+import "../styles/capacity-meter.css";
+
+type CapacityMeterOptions = {
+  label: string;
+  tone: "ok" | "stale" | "warn" | "danger" | "accent";
+} & (
+  | { mode: "continuous"; percent: number }
+  | { mode: "discrete"; total: number; used: number | null }
+);
+
+/** Shared sessions micro-meter; integer capacities use pips up to twelve slots. */
+export function renderCapacityMeter(options: CapacityMeterOptions) {
+  if (options.mode === "discrete" && options.total <= 12) {
+    return html`<span
+      class="capacity-meter-pips session-context-meter--${options.tone}"
+      role="img"
+      aria-label=${options.label}
+    >
+      ${Array.from(
+        { length: options.total },
+        (_, index) => html`
+          <span
+            class="capacity-meter-pips__pip ${options.used !== null && index < options.used
+              ? "capacity-meter-pips__pip--filled"
+              : ""}"
+          ></span>
+        `,
+      )}
+    </span>`;
+  }
+  const percent =
+    options.mode === "continuous"
+      ? options.percent
+      : options.used === null
+        ? 0
+        : (options.used / options.total) * 100;
+  return html`<span
+    class="session-context-meter session-context-meter--${options.tone}"
+    role="img"
+    aria-label=${options.label}
+  >
+    <span class="session-context-meter__fill" style=${`width: ${percent}%`}></span>
+  </span>`;
+}

--- a/ui/src/components/worker-capacity.ts
+++ b/ui/src/components/worker-capacity.ts
@@ -1,0 +1,45 @@
+import { html } from "lit";
+import { t } from "../i18n/index.ts";
+import { renderCapacityMeter } from "./capacity-meter.ts";
+import { icons } from "./icons.ts";
+
+/** Presentation only: the caller owns connectivity and placement eligibility. */
+export function workerCapacityPresentation(params: {
+  workerSlots?: { available: number; total: number };
+  capabilities?: readonly string[];
+  commands?: readonly string[];
+  unavailable: boolean;
+}) {
+  const slots = params.workerSlots;
+  if (slots) {
+    const used = params.unavailable ? null : slots.total - slots.available;
+    const label =
+      used === null
+        ? t("capacityMeter.unavailable")
+        : t("capacityMeter.workerSlots", {
+            used: String(used),
+            total: String(slots.total),
+          });
+    const tone = params.unavailable ? "stale" : slots.available === 0 ? "warn" : "accent";
+    return {
+      label,
+      meter: renderCapacityMeter({ mode: "discrete", total: slots.total, used, tone, label }),
+    };
+  }
+  // Environments advertise capabilities/commands together; node inventory keeps them separate.
+  const execHost =
+    params.capabilities?.some(
+      (capability) =>
+        capability === "codex.exec-server" || capability === "codex.exec-server.stdio.v1",
+    ) || params.commands?.includes("codex.exec-server.stdio.v1");
+  if (!execHost) {
+    return undefined;
+  }
+  const label = t("capacityMeter.execHost");
+  return {
+    label,
+    meter: html`<span class="capacity-meter-exec" role="img" aria-label=${label}>
+      <span aria-hidden="true">${icons.terminal}</span>${label}
+    </span>`,
+  };
+}

--- a/ui/src/components/worker-capacity.ts
+++ b/ui/src/components/worker-capacity.ts
@@ -23,6 +23,9 @@ export function workerCapacityPresentation(params: {
     const tone = params.unavailable ? "stale" : slots.available === 0 ? "warn" : "accent";
     return {
       label,
+      // Row titles carry countable facts only; an unavailable node's title
+      // belongs to its disabled reason, not the meter's alt text.
+      title: used === null ? undefined : label,
       meter: renderCapacityMeter({ mode: "discrete", total: slots.total, used, tone, label }),
     };
   }
@@ -38,6 +41,7 @@ export function workerCapacityPresentation(params: {
   const label = t("capacityMeter.execHost");
   return {
     label,
+    title: label,
     meter: html`<span class="capacity-meter-exec" role="img" aria-label=${label}>
       <span aria-hidden="true">${icons.terminal}</span>${label}
     </span>`,

--- a/ui/src/e2e/new-session-page.environment-metadata.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.environment-metadata.e2e.test.ts
@@ -244,7 +244,10 @@ suite.define(() => {
       expect(await row("alpha-device").isEnabled()).toBe(true);
       await expect
         .poll(() => row("alpha-device").locator(".new-session-page__menu-fact").allTextContents())
-        .toEqual(["Worker slots 2/4", "macOS", "Camera", "Screen capture"]);
+        .toEqual(["macOS", "Camera", "Screen capture"]);
+      await expect
+        .poll(() => row("alpha-device").locator(".capacity-meter-pips").getAttribute("aria-label"))
+        .toBe("2 of 4 slots busy");
       expect(await row("alpha-device").locator(".session-menu__sub").textContent()).toBe(
         "alpha-de",
       );
@@ -253,10 +256,10 @@ suite.define(() => {
       expect(await row("saturated").isDisabled()).toBe(true);
       await expect
         .poll(() => row("saturated").locator(".new-session-page__menu-fact").allTextContents())
-        .toEqual([
-          "Worker slots 0/2",
-          "No worker slots are available. Wait for a slot or pick another device.",
-        ]);
+        .toEqual(["No worker slots are available. Wait for a slot or pick another device."]);
+      await expect
+        .poll(() => row("saturated").locator(".capacity-meter-pips").getAttribute("aria-label"))
+        .toBe("Slot utilization unavailable");
       expect(await row("missing-capacity").isDisabled()).toBe(true);
       expect(await row("offline").isDisabled()).toBe(true);
       expect(await row("disabled").isDisabled()).toBe(true);

--- a/ui/src/e2e/new-session-page.places-live.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.places-live.e2e.test.ts
@@ -281,10 +281,11 @@ suite.define(() => {
       await expect.poll(() => runner.isDisabled()).toBe(true);
       await expect
         .poll(() => runner.locator(".new-session-page__menu-fact").allTextContents())
-        .toEqual([
-          "Worker slots 0/2",
-          "No worker slots are available. Wait for a slot or pick another device.",
-        ]);
+        .toEqual(["No worker slots are available. Wait for a slot or pick another device."]);
+      // A disabled row keeps a muted meter with no utilization claim.
+      await expect
+        .poll(() => runner.locator(".capacity-meter-pips").getAttribute("aria-label"))
+        .toBe("Slot utilization unavailable");
       expect(await gateway.getRequests("node.list")).toHaveLength(0);
     } finally {
       await context.close();

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -3,6 +3,11 @@ import type { TranslationMap } from "../lib/types.ts";
 import * as agentEn from "./en-agents.ts";
 
 export const en: TranslationMap = {
+  capacityMeter: {
+    workerSlots: "{used} of {total} slots busy",
+    unavailable: "Slot utilization unavailable",
+    execHost: "Codex exec",
+  },
   common: {
     health: "Health",
     ok: "OK",
@@ -732,7 +737,6 @@ export const en: TranslationMap = {
       versionDriftTitle:
         "Device {nodeVersion}; Gateway {gatewayVersion}. Update the older component to align the fleet.",
       workerVersion: "Worker {version}",
-      workerSlots: "Worker slots {available}/{total}",
       workerMissing: "worker missing",
       workerMissingTitle:
         "The Gateway-managed worker bundle is missing. Start a new session on this device to reinstall it.",
@@ -904,7 +908,6 @@ export const en: TranslationMap = {
     deviceCapacityUnavailable:
       "Worker capacity is unavailable. Restart the device session host and try again.",
     deviceNoSlots: "No worker slots are available. Wait for a slot or pick another device.",
-    workerSlots: "Worker slots {available}/{total}",
     nodeUpdateRequired:
       "Update required: run {updateCommand}, then reconnect. For a headless node, run {restartCommand}.",
     capabilityCamera: "Camera",

--- a/ui/src/pages/devices/view-inventory.ts
+++ b/ui/src/pages/devices/view-inventory.ts
@@ -8,6 +8,7 @@ import {
   renderSettingsSection,
   renderSettingsStatus,
 } from "../../components/settings-ui.ts";
+import { workerCapacityPresentation } from "../../components/worker-capacity.ts";
 import { t } from "../../i18n/index.ts";
 import { formatList, formatRelativeTimestamp, formatTimeAgo } from "../../lib/format.ts";
 import type { DeviceTokenSummary, InventoryRemovalRequest } from "../../lib/nodes/index.ts";
@@ -237,14 +238,6 @@ function entryMetaLine(entry: DeviceInventoryEntry): string {
   if (entry.node?.workerBundle?.status === "installed") {
     parts.push(t("devices.inventory.workerVersion", { version: entry.node.workerBundle.version }));
   }
-  if (entry.node?.workerSlots) {
-    parts.push(
-      t("devices.inventory.workerSlots", {
-        available: String(entry.node.workerSlots.available),
-        total: String(entry.node.workerSlots.total),
-      }),
-    );
-  }
   if (entry.connected && entry.presence?.lastInputSeconds != null) {
     parts.push(formatInputRecency(entry.presence.lastInputSeconds));
   } else if (!entry.connected && entry.lastSeenAtMs) {
@@ -309,6 +302,12 @@ function renderEntryDetails(entry: DeviceInventoryEntry, props: DevicesProps) {
 }
 
 function renderInventoryEntry(entry: DeviceInventoryEntry, props: DevicesProps) {
+  const capacity = workerCapacityPresentation({
+    workerSlots: entry.node?.workerSlots,
+    capabilities: entry.node?.caps,
+    commands: entry.node?.commands,
+    unavailable: entry.node?.connected !== true || !isApprovedNodeEntry(entry),
+  });
   const pendingRequestId =
     entry.node?.approvalState === "pending-approval" ||
     entry.node?.approvalState === "pending-reapproval"
@@ -319,7 +318,7 @@ function renderInventoryEntry(entry: DeviceInventoryEntry, props: DevicesProps) 
       ? nothing
       : renderSettingsStatus({ kind: "muted", label: t("devices.inventory.offline") });
   return html`
-    <div class="settings-row device-entry">
+    <div class="settings-row device-entry" title=${capacity?.label ?? nothing}>
       ${renderDeviceTile(deviceIcon(entry))}
       <div class="settings-row__text">
         <span class="settings-row__title">${entry.name}</span>
@@ -327,7 +326,8 @@ function renderInventoryEntry(entry: DeviceInventoryEntry, props: DevicesProps) 
         ${renderEntryDetails(entry, props)}
       </div>
       <div class="settings-row__control">
-        ${connectionStatus} ${entryWarnStatuses(entry, props.gatewayVersion)}
+        ${capacity?.meter ?? nothing} ${connectionStatus}
+        ${entryWarnStatuses(entry, props.gatewayVersion)}
         ${pendingRequestId
           ? html`
               <button

--- a/ui/src/pages/devices/view-inventory.ts
+++ b/ui/src/pages/devices/view-inventory.ts
@@ -318,7 +318,7 @@ function renderInventoryEntry(entry: DeviceInventoryEntry, props: DevicesProps) 
       ? nothing
       : renderSettingsStatus({ kind: "muted", label: t("devices.inventory.offline") });
   return html`
-    <div class="settings-row device-entry" title=${capacity?.label ?? nothing}>
+    <div class="settings-row device-entry" title=${capacity?.title ?? nothing}>
       ${renderDeviceTile(deviceIcon(entry))}
       <div class="settings-row__text">
         <span class="settings-row__title">${entry.name}</span>

--- a/ui/src/pages/devices/view.devices.test.ts
+++ b/ui/src/pages/devices/view.devices.test.ts
@@ -401,8 +401,12 @@ describe("devices inventory rendering", () => {
     expect(installed?.querySelector(".settings-row__desc")?.textContent).toContain(
       "Worker 2026.8.9",
     );
-    expect(installed?.querySelector(".settings-row__desc")?.textContent).toContain(
-      "Worker slots 1/2",
+    expect(installed?.querySelector('[role="img"]')?.getAttribute("aria-label")).toBe(
+      "1 of 2 slots busy",
+    );
+    expect(installed?.getAttribute("title")).toBe("1 of 2 slots busy");
+    expect(installed?.querySelector(".settings-row__desc")?.textContent).not.toContain(
+      "Worker slots",
     );
     expect(installed ? statusesByText(installed, "connected") : []).toHaveLength(0);
     expect(installed ? statusesByText(installed, "worker missing") : []).toHaveLength(0);
@@ -553,6 +557,7 @@ describe("devices inventory rendering", () => {
           platform: "Windows 11",
           connected: false,
           paired: true,
+          workerSlots: { total: 8, available: 0 },
         },
       ],
     });
@@ -560,9 +565,34 @@ describe("devices inventory rendering", () => {
     const row = getSettingsRow(section, "Mixed-role Windows");
 
     expect(section.textContent).toContain("1 of 1 connected");
+    expect(row.querySelector('[role="img"]')?.getAttribute("aria-label")).toBe(
+      "Slot utilization unavailable",
+    );
+    expect(row.querySelectorAll(".capacity-meter-pips__pip--filled")).toHaveLength(0);
     expect(
       Array.from(row.querySelectorAll(".settings-status"), (status) => status.textContent?.trim()),
     ).toEqual(["offline", "manual wake required"]);
+  });
+
+  it.each([
+    { caps: ["codex.exec-server"], commands: [] },
+    { caps: [], commands: ["codex.exec-server.stdio.v1"] },
+  ])("preserves the slot-less exec affordance through node inventory: %j", ({ caps, commands }) => {
+    const container = renderDevicesContainer({
+      nodes: [
+        {
+          nodeId: "exec",
+          displayName: "Exec host",
+          connected: true,
+          paired: true,
+          caps,
+          commands,
+        },
+      ],
+    });
+    const row = getSettingsRow(getInventorySection(container), "Exec host");
+    expect(row.querySelector('[role="img"]')?.getAttribute("aria-label")).toBe("Codex exec");
+    expect(row.querySelector(".capacity-meter-pips, .session-context-meter")).toBeNull();
   });
 
   it("shows token rows with rotate and revoke inside entry details", () => {

--- a/ui/src/pages/new-session/cloud-target.ts
+++ b/ui/src/pages/new-session/cloud-target.ts
@@ -1,4 +1,4 @@
-import { html, nothing } from "lit";
+import { html, nothing, type TemplateResult } from "lit";
 import type { EnvironmentsListResult } from "../../../../packages/gateway-protocol/src/index.js";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import { icons } from "../../components/icons.ts";
@@ -22,6 +22,7 @@ type SessionMenuItemOptions = {
   icon?: unknown;
   sub?: string;
   facts?: readonly string[];
+  meter?: TemplateResult;
   checked: boolean;
   disabled?: boolean;
   title?: string;
@@ -45,11 +46,16 @@ export function renderSessionMenuItem(params: SessionMenuItemOptions, submitting
         ? html`<span class="session-menu__icon" aria-hidden="true">${params.icon}</span>`
         : nothing}
       <span class="session-menu__text">${params.label}</span>
-      ${params.facts?.length
-        ? html`<span class="new-session-page__menu-facts">
-            ${params.facts.map(
-              (fact) => html`<span class="new-session-page__menu-fact">${fact}</span>`,
-            )}
+      ${params.facts?.length || params.meter
+        ? html`<span class="new-session-page__menu-meta">
+            ${params.facts?.length
+              ? html`<span class="new-session-page__menu-facts">
+                  ${params.facts.map(
+                    (fact) => html`<span class="new-session-page__menu-fact">${fact}</span>`,
+                  )}
+                </span>`
+              : nothing}
+            ${params.meter ?? nothing}
           </span>`
         : nothing}
       ${params.sub ? html`<span class="session-menu__sub">${params.sub}</span>` : nothing}

--- a/ui/src/pages/new-session/device-placement.test.ts
+++ b/ui/src/pages/new-session/device-placement.test.ts
@@ -31,7 +31,7 @@ describe("device placement projection", () => {
       environment: node({}),
       selectable: true,
       reason: undefined,
-      facts: ["Worker slots 1/2", "macOS", "Camera"],
+      facts: ["macOS", "Camera"],
     },
     {
       name: "saturated host",
@@ -39,7 +39,6 @@ describe("device placement projection", () => {
       selectable: false,
       reason: "No worker slots are available. Wait for a slot or pick another device.",
       facts: [
-        "Worker slots 0/2",
         "No worker slots are available. Wait for a slot or pick another device.",
         "macOS",
         "Camera",
@@ -88,13 +87,12 @@ describe("device placement projection", () => {
         "Update required: run openclaw update, then reconnect. For a headless node, run openclaw node restart.",
       facts: [
         "Update required: run openclaw update, then reconnect. For a headless node, run openclaw node restart.",
-        "Worker slots 1/2",
         "macOS",
         "Camera",
       ],
     },
   ])("projects $name with one canonical eligibility decision", (testCase) => {
-    expect(projectDevicePlacements([testCase.environment])).toEqual([
+    expect(projectDevicePlacements([testCase.environment])).toMatchObject([
       {
         deviceId: "runner",
         label: "Build runner",

--- a/ui/src/pages/new-session/device-placement.ts
+++ b/ui/src/pages/new-session/device-placement.ts
@@ -1,16 +1,18 @@
 import { t } from "../../i18n/index.ts";
 import type { DraftEnvironment } from "./discovery.ts";
-import { environmentMenuFacts } from "./place-facts.ts";
+import { environmentMenuFacts, MAX_PLACE_MENU_FACTS } from "./place-facts.ts";
 import { disambiguate } from "./place-labels.ts";
 
-export type DevicePlacementOption = Readonly<{
-  deviceId: string;
-  label: string;
-  subtitle?: string;
-  facts: readonly string[];
-  selectable: boolean;
-  disabledReason?: string;
-}>;
+export type DevicePlacementOption = Readonly<
+  {
+    deviceId: string;
+    label: string;
+    subtitle?: string;
+    facts: readonly string[];
+    selectable: boolean;
+    disabledReason?: string;
+  } & Pick<DraftEnvironment, "workerSlots" | "capabilities" | "invocableCommands">
+>;
 
 export type DevicePlacementRequirement = Readonly<{
   requiredNodeCommands: readonly string[];
@@ -75,17 +77,21 @@ export function projectDevicePlacements(
       });
       const priorityFacts =
         (environment.issues?.length ?? 0) > 0 || environment.status !== "available" ? 1 : 0;
-      const slotFacts = environment.workerSlots ? 1 : 0;
-      const insertion = priorityFacts + slotFacts;
       const visibleFacts =
         disabledReason && !facts.includes(disabledReason)
-          ? [...facts.slice(0, insertion), disabledReason, ...facts.slice(insertion)].slice(0, 4)
+          ? [...facts.slice(0, priorityFacts), disabledReason, ...facts.slice(priorityFacts)].slice(
+              0,
+              MAX_PLACE_MENU_FACTS,
+            )
           : facts;
       return [
         {
           deviceId,
           label: environment.label ?? deviceId,
           facts: placementDisabledReason ? [placementDisabledReason] : visibleFacts,
+          workerSlots: environment.workerSlots,
+          capabilities: environment.capabilities,
+          invocableCommands: environment.invocableCommands,
           selectable: disabledReason === undefined,
           ...(disabledReason ? { disabledReason } : {}),
         },

--- a/ui/src/pages/new-session/place-facts.ts
+++ b/ui/src/pages/new-session/place-facts.ts
@@ -3,7 +3,7 @@ import { formatDurationCompact, formatRelativeTimestamp } from "../../lib/format
 import { prettifyPlatform } from "../../lib/platform-label.ts";
 import type { DraftEnvironment } from "./discovery.ts";
 
-const MAX_PLACE_MENU_FACTS = 4;
+export const MAX_PLACE_MENU_FACTS = 4;
 const CAPABILITY_FACT_KEYS = {
   camera: "newSession.capabilityCamera",
   location: "newSession.capabilityLocation",
@@ -55,14 +55,6 @@ export function environmentMenuFacts(
       })
     : lifecycle;
   const facts = priorityFact ? [priorityFact] : [];
-  if (environment?.workerSlots) {
-    facts.push(
-      t("newSession.workerSlots", {
-        available: String(environment.workerSlots.available),
-        total: String(environment.workerSlots.total),
-      }),
-    );
-  }
   if (environment?.platform) {
     facts.push(prettifyPlatform(environment.platform));
   }

--- a/ui/src/pages/new-session/where-chip.test.ts
+++ b/ui/src/pages/new-session/where-chip.test.ts
@@ -166,9 +166,8 @@ describe("Where chip", () => {
     const device = container.querySelector<HTMLButtonElement>('[data-value="device:macbook"]');
     expect(device?.disabled).toBe(true);
     expect(device?.textContent).toContain("This runtime does not support paired devices");
-    expect(device?.title).toBe(
-      "This runtime does not support paired devices · Slot utilization unavailable",
-    );
+    // The disabled reason owns the title; the meter's no-claim alt text stays on its aria-label.
+    expect(device?.title).toBe("This runtime does not support paired devices");
   });
 
   it("omits the devices section entirely when no devices are paired", () => {

--- a/ui/src/pages/new-session/where-chip.test.ts
+++ b/ui/src/pages/new-session/where-chip.test.ts
@@ -64,7 +64,7 @@ function renderPicker(isAdmin: boolean, autoPlacementMode?: "least-busy" | "elig
 }
 
 describe("Where chip", () => {
-  it("projects the selected device label and exact capacity facts", () => {
+  it("keeps capacity structured and exposes busy slots without an ambiguous visible fraction", () => {
     const state = resolveWhereChip({
       environments: [
         {
@@ -83,7 +83,14 @@ describe("Where chip", () => {
 
     expect(state.kind).toBe("device");
     expect(state.label).toBe("Build runner");
-    expect(state.devices[0]?.facts).toEqual(["Worker slots 1/2"]);
+    const row = renderPicker(false).querySelector('[data-value="device:runner"]');
+    expect(row?.querySelector('[role="img"]')?.getAttribute("aria-label")).toBe(
+      "1 of 2 slots busy",
+    );
+    expect(row?.getAttribute("title")).toBe("1 of 2 slots busy");
+    expect(row?.textContent).not.toContain("Worker slots");
+    expect(state.devices[0]?.workerSlots).toEqual({ total: 2, available: 1 });
+    expect(state.devices[0]?.facts).toEqual([]);
   });
 
   it("renders devices for writers while cloud and Connect remain admin-only", () => {
@@ -159,7 +166,9 @@ describe("Where chip", () => {
     const device = container.querySelector<HTMLButtonElement>('[data-value="device:macbook"]');
     expect(device?.disabled).toBe(true);
     expect(device?.textContent).toContain("This runtime does not support paired devices");
-    expect(device?.title).toBe("This runtime does not support paired devices");
+    expect(device?.title).toBe(
+      "This runtime does not support paired devices · Slot utilization unavailable",
+    );
   });
 
   it("omits the devices section entirely when no devices are paired", () => {
@@ -271,6 +280,20 @@ describe("Where chip", () => {
       workerSlots: { total: 1, available: 0 },
       invocableCommands: ["codex.exec-server.stdio.v1"],
       disabled: false,
+      label: "1 of 1 slots busy",
+      tone: "warn",
+    },
+    {
+      name: "shows slot-less remote execution without a capacity claim",
+      devicePlacement: {
+        requiredNodeCommands: ["codex.exec-server.stdio.v1"],
+        consumesWorkerSlot: false,
+      },
+      workerSlots: undefined,
+      invocableCommands: ["codex.exec-server.stdio.v1"],
+      disabled: false,
+      label: "Codex exec",
+      tone: undefined,
     },
     {
       name: "keeps worker execution capacity-gated",
@@ -279,6 +302,8 @@ describe("Where chip", () => {
       invocableCommands: [],
       disabled: true,
       reason: /worker slots/i,
+      label: "Slot utilization unavailable",
+      tone: "stale",
     },
     {
       name: "disables a declared remote command that the Gateway has not enabled",
@@ -290,10 +315,12 @@ describe("Where chip", () => {
       invocableCommands: [],
       disabled: true,
       reason: /enable|approv/i,
+      label: "Slot utilization unavailable",
+      tone: "stale",
     },
   ])(
     "$name in the New Session picker",
-    ({ devicePlacement, workerSlots, invocableCommands, disabled, reason }) => {
+    ({ devicePlacement, workerSlots, invocableCommands, disabled, reason, label, tone }) => {
       const state = resolveWhereChip({
         environments: [
           {
@@ -339,6 +366,11 @@ describe("Where chip", () => {
 
       const device = container.querySelector<HTMLButtonElement>('[data-value="device:runner"]');
       expect(device?.disabled).toBe(disabled);
+      const meter = device?.querySelector('[role="img"]');
+      expect(meter?.getAttribute("aria-label")).toBe(label);
+      if (tone) {
+        expect(meter?.classList.contains(`session-context-meter--${tone}`)).toBe(true);
+      }
       if (reason) {
         expect(device?.title).toMatch(reason);
       }

--- a/ui/src/pages/new-session/where-chip.ts
+++ b/ui/src/pages/new-session/where-chip.ts
@@ -1,5 +1,6 @@
 import { html, nothing } from "lit";
 import { icons } from "../../components/icons.ts";
+import { workerCapacityPresentation } from "../../components/worker-capacity.ts";
 import { t } from "../../i18n/index.ts";
 import {
   renderCloudProfileMenuItems,
@@ -211,6 +212,12 @@ export function renderWhereChip(params: {
                 params.submitting,
               )}
               ${params.state.devices.map((device) => {
+                const capacity = workerCapacityPresentation({
+                  workerSlots: device.workerSlots,
+                  capabilities: device.capabilities,
+                  commands: device.invocableCommands,
+                  unavailable: !device.selectable,
+                });
                 return renderSessionMenuItem(
                   {
                     value: `device:${device.deviceId}`,
@@ -218,9 +225,12 @@ export function renderWhereChip(params: {
                     sub: device.subtitle,
                     icon: icons.monitor,
                     facts: device.facts,
+                    meter: capacity?.meter,
                     checked: params.deviceId === device.deviceId,
                     disabled: !device.selectable,
-                    title: device.disabledReason,
+                    title:
+                      [device.disabledReason, capacity?.label].filter(Boolean).join(" · ") ||
+                      undefined,
                     onSelect: () => params.onSelectDevice(device.deviceId),
                   },
                   params.submitting,

--- a/ui/src/pages/new-session/where-chip.ts
+++ b/ui/src/pages/new-session/where-chip.ts
@@ -229,7 +229,7 @@ export function renderWhereChip(params: {
                     checked: params.deviceId === device.deviceId,
                     disabled: !device.selectable,
                     title:
-                      [device.disabledReason, capacity?.label].filter(Boolean).join(" · ") ||
+                      [device.disabledReason, capacity?.title].filter(Boolean).join(" · ") ||
                       undefined,
                     onSelect: () => params.onSelectDevice(device.deviceId),
                   },

--- a/ui/src/pages/sessions/view.browser.test.ts
+++ b/ui/src/pages/sessions/view.browser.test.ts
@@ -32,6 +32,7 @@ function readUiCss(): string {
     "ui/src/styles/settings-controls.css",
     "ui/src/styles/settings.css",
     "ui/src/styles/sessions.css",
+    "ui/src/styles/capacity-meter.css",
   ];
   return files.map((file) => readStyleSheet(file)).join("\n");
 }

--- a/ui/src/pages/sessions/view.test.ts
+++ b/ui/src/pages/sessions/view.test.ts
@@ -1817,34 +1817,49 @@ describe("sessions view", () => {
     expect(facts[1]?.classList.contains("sessions-heading-fact--active")).toBe(true);
   });
 
-  it("renders a context meter with usage tone on the tokens cell", async () => {
-    const container = document.createElement("div");
-    render(
-      renderSessions(
-        buildProps(
-          buildResult({
-            key: "agent:main:main",
-            kind: "direct",
-            updatedAt: Date.now(),
-            totalTokens: 180_000,
-            contextTokens: 200_000,
-          }),
+  it.each([
+    { total: 128_000, percent: 64, tone: "ok", value: "128k" },
+    { total: 130_000, percent: 65, tone: "warn", value: "130k" },
+    { total: 168_000, percent: 84, tone: "warn", value: "168k" },
+    { total: 170_000, percent: 85, tone: "danger", value: "170k" },
+    { total: 180_000, percent: 90, tone: "danger", value: "180k" },
+    { total: 220_000, percent: 100, tone: "danger", value: "220k" },
+  ])(
+    "preserves context usage, tooltip, and $tone tone at $percent%",
+    async ({ total, percent, tone, value }) => {
+      const container = document.createElement("div");
+      render(
+        renderSessions(
+          buildProps(
+            buildResult({
+              key: "agent:main:main",
+              kind: "direct",
+              updatedAt: Date.now(),
+              totalTokens: total,
+              contextTokens: 200_000,
+            }),
+          ),
         ),
-      ),
-      container,
-    );
-    await Promise.resolve();
+        container,
+      );
+      await Promise.resolve();
 
-    const meter = container.querySelector(".session-context-meter");
-    expect(meter?.classList.contains("session-context-meter--danger")).toBe(true);
-    expect(meter?.getAttribute("aria-label")).toBe(
-      "90% of context used (180,000 / 200,000 tokens)",
-    );
-    expect(container.querySelector<HTMLElement>(".session-context-meter__fill")?.style.width).toBe(
-      "90%",
-    );
-    expect(container.querySelector(".session-token-cell")?.textContent?.trim()).toBe("180k / 200k");
-  });
+      const meter = container.querySelector(".session-context-meter");
+      const label = `${percent}% of context used (${total.toLocaleString()} / 200,000 tokens)`;
+      expect(meter?.classList.contains(`session-context-meter--${tone}`)).toBe(true);
+      expect(meter?.getAttribute("role")).toBe("img");
+      expect(meter?.getAttribute("aria-label")).toBe(label);
+      expect(
+        container.querySelector(".session-token-cell")?.querySelector("openclaw-tooltip")?.content,
+      ).toBe(label);
+      expect(
+        container.querySelector<HTMLElement>(".session-context-meter__fill")?.style.width,
+      ).toBe(`${percent}%`);
+      expect(container.querySelector(".session-token-cell")?.textContent?.trim()).toBe(
+        `${value} / 200k`,
+      );
+    },
+  );
 
   it("keeps stale token snapshots out of the warning tones", async () => {
     const container = document.createElement("div");

--- a/ui/src/pages/sessions/view.ts
+++ b/ui/src/pages/sessions/view.ts
@@ -16,6 +16,7 @@ import type {
   SessionCompactionCheckpoint,
   SessionsListResult,
 } from "../../api/types.ts";
+import { renderCapacityMeter } from "../../components/capacity-meter.ts";
 import { icons } from "../../components/icons.ts";
 import "../../components/tooltip.ts";
 import "../../components/web-awesome.ts";
@@ -335,13 +336,7 @@ function renderTokensCell(row: GatewaySessionRow) {
         <span class="session-tokens__value"
           >${totalLabel} / ${formatCompactTokenCount(context)}</span
         >
-        <span
-          class="session-context-meter session-context-meter--${tone}"
-          role="img"
-          aria-label=${title}
-        >
-          <span class="session-context-meter__fill" style=${`width: ${percent}%`}></span>
-        </span>
+        ${renderCapacityMeter({ mode: "continuous", percent, tone, label: title })}
       </div>
     </openclaw-tooltip>
   `;

--- a/ui/src/styles/capacity-meter.css
+++ b/ui/src/styles/capacity-meter.css
@@ -1,0 +1,71 @@
+/* Extracted from the sessions context meter; keep its dimensions and tones. */
+.session-context-meter {
+  display: block;
+  width: 84px;
+  height: 3px;
+  overflow: hidden;
+  background: var(--bg-hover);
+  border-radius: var(--radius-full);
+}
+
+.session-context-meter__fill {
+  display: block;
+  height: 100%;
+  background: currentColor;
+  border-radius: inherit;
+}
+
+.session-context-meter--ok {
+  color: var(--ok);
+}
+
+/* Stale token snapshots keep a neutral meter; they must not read as danger. */
+.session-context-meter--stale {
+  color: var(--muted);
+}
+
+.session-context-meter--warn {
+  color: var(--warn);
+}
+
+.session-context-meter--danger {
+  color: var(--danger);
+}
+
+.session-context-meter--accent {
+  color: var(--accent);
+}
+
+.capacity-meter-pips {
+  display: inline-flex;
+  flex: 0 0 auto;
+  align-items: center;
+  gap: 2px;
+}
+
+.capacity-meter-pips__pip {
+  width: 5px;
+  height: 8px;
+  border-radius: 2px;
+  background: color-mix(in srgb, var(--muted) 25%, transparent);
+}
+
+.capacity-meter-pips__pip--filled {
+  background: currentColor;
+}
+
+.capacity-meter-exec {
+  display: inline-flex;
+  flex: 0 0 auto;
+  align-items: center;
+  gap: 4px;
+  color: var(--muted);
+  font-size: var(--control-ui-text-xs);
+  white-space: nowrap;
+}
+
+.capacity-meter-exec svg {
+  display: block;
+  width: 12px;
+  height: 12px;
+}

--- a/ui/src/styles/new-session.css
+++ b/ui/src/styles/new-session.css
@@ -703,13 +703,25 @@ wa-popover.new-session-page__picker-popover
   color: var(--muted);
 }
 
-.new-session-page__menu-facts {
+.new-session-page__menu-meta {
   display: inline-flex;
   flex: 0 1 auto;
-  gap: 3px;
+  align-items: center;
+  gap: 8px;
   min-width: 0;
   max-width: 62%;
   overflow: hidden;
+}
+
+.new-session-page__menu-facts {
+  display: inline-flex;
+  gap: 3px;
+  min-width: 0;
+  overflow: hidden;
+}
+
+.new-session-page__menu-meta > .session-context-meter {
+  flex: 0 0 84px;
 }
 
 .new-session-page__menu-fact {

--- a/ui/src/styles/sessions.css
+++ b/ui/src/styles/sessions.css
@@ -713,40 +713,6 @@
   white-space: nowrap;
 }
 
-/* Context meter: totalTokens vs the model context window. */
-.session-context-meter {
-  display: block;
-  width: 84px;
-  height: 3px;
-  overflow: hidden;
-  background: var(--bg-hover);
-  border-radius: var(--radius-full);
-}
-
-.session-context-meter__fill {
-  display: block;
-  height: 100%;
-  background: currentColor;
-  border-radius: inherit;
-}
-
-.session-context-meter--ok {
-  color: var(--ok);
-}
-
-/* Stale token snapshots keep a neutral meter; they must not read as danger. */
-.session-context-meter--stale {
-  color: var(--muted);
-}
-
-.session-context-meter--warn {
-  color: var(--warn);
-}
-
-.session-context-meter--danger {
-  color: var(--danger);
-}
-
 /* Actions cell: details disclosure + row tools */
 .session-actions-col {
   width: 76px;


### PR DESCRIPTION
## What Problem This Solves

Fixes a picker and Settings label that reads as the opposite of its meaning.
Both the session placement picker and Settings → Devices show node capacity as
`Worker slots {available}/{total}` — so a fully **idle** 8-slot node renders
`Worker slots 8/8`, which nearly everyone reads as "8 of 8 used, full". A node
under load reads *better* as it gets worse. Operators picking a placement
target get the busyness signal inverted at exactly the moment it matters.

## Why This Change Was Made

Replace the string with a glanceable segmented meter, built by **extracting the
sessions page's existing context meter** into a shared `capacity-meter`
component rather than adding a fourth hand-rolled bar (sessions, provider
usage, and swarm progress each have private copies today; the latter two are
noted as follow-up candidates — different semantics, deliberately untouched).

- One pip per slot, filled = in use, accent tone; warning tone when at
  capacity; continuous micro-bar above 12 slots (`nodeHost.workerRuns.capacity`
  allows up to 1024, so per-slot pips cannot be assumed).
- Five first-class states: idle, partial, at capacity, offline (muted, no
  utilization claim), and slot-less Codex exec hosts — which get a terminal
  glyph + "Codex exec" instead of a lying empty meter, since `remote-exec`
  consumes no slots.
- At-capacity nuance preserved, not "fixed": for embedded worker-turn sessions
  the Gateway already rejects full nodes (row stays disabled with its existing
  reason); for Codex sessions the same node stays selectable with warn pips.
  No dispatch/selector behavior changed.
- Menu rows gain one optional `meter` slot; slot numbers stay structured from
  node inventory instead of being flattened into a translated string in
  `place-facts.ts`. Exact numbers survive in row `title` and `aria-label`
  ("3 of 8 slots busy"). Sessions page migrates to the shared component with
  byte-identical rendering.

Presentation only — no wire or protocol changes.

## User Impact

Operators see at a glance how busy each node is before placing a session, in
both the picker and Settings → Devices. Idle no longer masquerades as full.
Screen-reader users get "N of M slots busy" instead of an ambiguous fraction.

## Evidence

Captured with the repo harness (`pnpm ui:proof:where-chip`), every image
inspected; sessions before/after PNGs are **byte-identical** in both themes
(`cmp` verified), proving the extraction changed nothing there.

Picker (dark, embedded runtime) — partial/disabled-full/idle/micro-bar/offline/exec states:

![picker dark](https://github.com/user-attachments/assets/e81a16cd-00f5-4525-b441-e266870ed8b8)

Picker with a Codex-runtime session — full node selectable, warn pips:

![picker remote](https://github.com/user-attachments/assets/fa3ad09c-ac2f-4ffa-9512-f0ec1f4180f8)

Settings → Devices (light):

![devices light](https://github.com/user-attachments/assets/4dd02ecc-891a-448e-aeaf-b5b191198eb0)

Tests: 176 passed across nine files (component states, pips↔bar threshold,
tone selection, both consumer pages, inventory parsing); `pnpm check:changed`
green (tsgo lanes, oxlint, import cycles); fresh Codex autoreview clean
(0.99, no actionable findings); focused suites re-run green on the rebased
head.

Size: production +151 / tests +199 / proof tooling +104 — feature growth
partly offset by deleting the sessions page's private meter (34 CSS lines +
inline markup); both old `workerSlots` i18n strings retired.
