### PR TITLE
fix(auto-reply): bound followup terminal drain

### DIFF
--- a/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
+++ b/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
@@ -4239,6 +4239,57 @@ describe("runReplyAgent typing (heartbeat)", () => {
   });
 
   it.each([
+    {
+      name: "releases a queued followup after the pending tool delivery idle bound",
+      elapsedMs: 30_000,
+      owned: false,
+    },
+    {
+      name: "keeps a queued followup owned until pending tool delivery settles",
+      elapsedMs: 29_999,
+      owned: true,
+    },
+  ])("$name", async ({ elapsedMs, owned }) => {
+    vi.useFakeTimers();
+    const toolResultStarted = createDeferred();
+    const toolResultReleased = createDeferred();
+    state.runEmbeddedAgentMock.mockImplementationOnce(async (params: AgentRunParams) => {
+      void params.onToolResult?.({ text: "pending tool result" });
+      return { payloads: [{ text: "followup complete" }], meta: {} };
+    });
+    const { followupRun, run } = createMinimalRun({
+      isActive: true,
+      isRunActive: () => false,
+      shouldFollowup: true,
+      resolvedQueueMode: "collect",
+      opts: {
+        forceToolResultProgress: true,
+        onToolResult: async () => {
+          toolResultStarted.resolve();
+          await toolResultReleased.promise;
+        },
+      },
+    });
+    let followup: Promise<void> | undefined;
+    try {
+      await run();
+      followup = requireScheduledFollowupRunner()(followupRun);
+      await toolResultStarted.promise;
+
+      await vi.advanceTimersByTimeAsync(elapsedMs);
+      expect(replyRunRegistry.get("main") !== undefined).toBe(owned);
+
+      toolResultReleased.resolve();
+      await followup;
+      expect(replyRunRegistry.get("main")).toBeUndefined();
+    } finally {
+      toolResultReleased.resolve();
+      await followup;
+      vi.useRealTimers();
+    }
+  });
+
+  it.each([
     { label: "empty output", payloads: [] },
     { label: "reasoning-only output", payloads: [{ text: "internal", isReasoning: true }] },
     { label: "commentary-only output", payloads: [{ text: "internal", isCommentary: true }] },

--- a/src/auto-reply/reply/followup-turn-execution.ts
+++ b/src/auto-reply/reply/followup-turn-execution.ts
@@ -1,5 +1,6 @@
 import { settleProgressVisibilityCallbackResult } from "../../channels/progress-visibility.js";
 import { loadSessionEntryReadOnly } from "../../config/sessions/session-accessor.js";
+import { logVerbose } from "../../globals.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import type { TemplateContext } from "../templating.js";
 import type { VerboseLevel } from "../thinking.js";
@@ -12,6 +13,7 @@ import { resolveTurnCommentaryProgressOwner } from "./commentary-progress-owner.
 import { requiresDurableToolResultDelivery } from "./dispatch-from-config.payloads.js";
 import type { AdmittedFollowupTurn, FollowupRunnerParams } from "./followup-turn-admission.js";
 import type { InternalGetReplyOptions } from "./get-reply.types.js";
+import { drainPendingToolTasks } from "./pending-tool-task-drain.js";
 import { hasReplyOperationExecutionStarted } from "./reply-run-registry.js";
 import { createTypingSignaler, type TypingSignaler } from "./typing-mode.js";
 
@@ -123,7 +125,7 @@ export async function executeFollowupTurn(params: {
     });
   let progressChain: Promise<void> = Promise.resolve();
   let pendingProgressTaskFailure: unknown;
-  const pendingProgressTasks = new Set<Promise<void>>();
+  const pendingWorkTasks = new Set<Promise<void>>();
   const enqueueProgress = (deliver: () => Promise<void> | void): Promise<void> => {
     const deliveryTask = progressChain.then(deliver);
     progressChain = deliveryTask.catch(() => undefined);
@@ -131,9 +133,9 @@ export async function executeFollowupTurn(params: {
       pendingProgressTaskFailure ??= error;
       throw error;
     });
-    const trackedTask = observedTask.finally(() => pendingProgressTasks.delete(trackedTask));
+    const trackedTask = observedTask.finally(() => pendingWorkTasks.delete(trackedTask));
     void trackedTask.catch(() => undefined);
-    pendingProgressTasks.add(trackedTask);
+    pendingWorkTasks.add(trackedTask);
     return progressChain;
   };
   const enqueueProgressResult = async (
@@ -287,19 +289,28 @@ export async function executeFollowupTurn(params: {
     },
   };
   let pendingToolTaskFailure: unknown;
-  const pendingToolTaskWatchers = new Set<Promise<void>>();
   const pendingToolTasks = new (class extends Set<Promise<void>> {
     override add(task: Promise<void>): this {
       const observedTask = task.catch((error: unknown) => {
         pendingToolTaskFailure ??= error;
         throw error;
       });
-      const watcher = observedTask.finally(() => pendingToolTaskWatchers.delete(watcher));
+      const watcher = observedTask.finally(() => pendingWorkTasks.delete(watcher));
       void watcher.catch(() => undefined);
-      pendingToolTaskWatchers.add(watcher);
+      pendingWorkTasks.add(watcher);
       return super.add(task);
     }
   })();
+  let pendingWorkDrain: Promise<void> | undefined;
+  const drainPendingWork = () => {
+    pendingWorkDrain ??= (async () => {
+      await drainPendingToolTasks({ tasks: pendingWorkTasks, onTimeout: logVerbose });
+      // This terminal owner gets one bounded wait. Retire the accounting handoff
+      // so timed-out tool delivery cannot start a second idle window.
+      pendingToolTasks.clear();
+    })();
+    return pendingWorkDrain;
+  };
   const sessionCtx = buildFollowupTemplateContext(turn);
   if (turn.preflightError) {
     throw turn.preflightError instanceof Error
@@ -380,17 +391,7 @@ export async function executeFollowupTurn(params: {
         ? recorder.withPendingInput(execute)
         : execute());
     } catch (error) {
-      while (
-        pendingProgressTasks.size > 0 ||
-        pendingToolTasks.size > 0 ||
-        pendingToolTaskWatchers.size > 0
-      ) {
-        await Promise.allSettled([
-          ...pendingProgressTasks,
-          ...pendingToolTasks,
-          ...pendingToolTaskWatchers,
-        ]);
-      }
+      await drainPendingWork();
       if (!hasReplyOperationExecutionStarted(turn.operation)) {
         throw error;
       }
@@ -417,20 +418,8 @@ export async function executeFollowupTurn(params: {
     pendingToolTasks,
     progress: {
       drain: async () => {
-        let firstFailure: unknown = pendingProgressTaskFailure ?? pendingToolTaskFailure;
-        while (
-          pendingProgressTasks.size > 0 ||
-          pendingToolTasks.size > 0 ||
-          pendingToolTaskWatchers.size > 0
-        ) {
-          const results = await Promise.allSettled([
-            ...pendingProgressTasks,
-            ...pendingToolTasks,
-            ...pendingToolTaskWatchers,
-          ]);
-          firstFailure ??= results.find((result) => result.status === "rejected")?.reason;
-        }
-        firstFailure ??= pendingProgressTaskFailure ?? pendingToolTaskFailure;
+        await drainPendingWork();
+        const firstFailure: unknown = pendingProgressTaskFailure ?? pendingToolTaskFailure;
         if (firstFailure !== undefined) {
           throw firstFailure instanceof Error
             ? firstFailure

--- a/src/auto-reply/reply/pending-tool-task-drain.test.ts
+++ b/src/auto-reply/reply/pending-tool-task-drain.test.ts
@@ -66,6 +66,21 @@ describe("drainPendingToolTasks", () => {
     expect(onTimeout).not.toHaveBeenCalled();
   });
 
+  it("drains tasks added after the initial snapshot", async () => {
+    const first = deferredTask();
+    const second = deferredTask();
+    const tasks = new Set([first.promise]);
+
+    const drain = drainPendingToolTasks({ tasks, idleTimeoutMs: 1_000 });
+    tasks.add(second.promise);
+    first.resolve();
+    await flushPromises();
+    expect(tasks).toEqual(new Set([second.promise]));
+
+    second.resolve();
+    await expect(drain).resolves.toEqual({ kind: "settled" });
+  });
+
   it("returns timeout when no pending task settles before the idle window", async () => {
     vi.useFakeTimers();
     const stuck = deferredTask();


### PR DESCRIPTION
## What Problem This Solves

A queued follow-up can emit a detached tool result after the model run ends. The follow-up progress drain waited on that task before it reached the existing 30-second idle bound in accounting. A hung channel callback therefore kept the reply lane and every later queued message blocked.

The earlier patch added another deadline before accounting. That could wait for 30 seconds and then let accounting wait on the same task for another 30 seconds.

## Root Cause

Follow-up execution tracked progress tasks, tool tasks, and watcher tasks in separate sets. Its terminal path drained all three without using the canonical progress-aware idle owner. Accounting then drained the tool set again.

## Fix

- Track progress and tool-result presentation in one live pending-work set.
- Drain that set once with `drainPendingToolTasks`.
- Retire the tool-task accounting handoff after terminal settlement.
- Keep the canonical idle behavior, including late task additions and timeout reset after progress.

## Evidence

Current-main red at `b14a2cae4bf69a716eea69063a45a55aa1521677`:

- The full queued runner still owned `replyRunRegistry.get("main")` after 30,000 ms.
- Blacksmith run: https://github.com/openclaw/openclaw/actions/runs/33739362975

Exact-head green at `6b8099e6df7273eaee1c39d8ff54c855c2049a90`:

- A hung tool-result callback released the queued reply owner after one 30-second idle window.
- A healthy callback remained owned at 29,999 ms and released after it settled.
- Blacksmith run: https://github.com/openclaw/openclaw/actions/runs/33740386683

```console
node scripts/run-vitest.mjs src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts -t "queued followup"
Test Files  1 passed (1)
Tests       2 passed | 170 skipped (172)
```

Focused owner tests:

```console
node scripts/run-vitest.mjs src/auto-reply/reply/followup-turn-execution.test.ts src/auto-reply/reply/pending-tool-task-drain.test.ts
Test Files  2 passed (2)
Tests       36 passed (36)
```

Production delta: 20 additions, 31 deletions, net -11 lines.

Co-authored-by: Sebastien Tardif <sebtardif@ncf.ca>
