### PR TITLE
fix(usage): cap session-cost busy refresh wait

### DIFF
--- a/src/infra/session-cost-usage-direct-refresh.test.ts
+++ b/src/infra/session-cost-usage-direct-refresh.test.ts
@@ -1,0 +1,51 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { withEnvAsync } from "../test-utils/env.js";
+import { refreshCostUsageCacheForAgent } from "./session-cost-usage-aggregation.js";
+import { loadSessionCostSummary } from "./session-cost-usage-reporting.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+vi.mock("./session-cost-usage-aggregation.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./session-cost-usage-aggregation.js")>();
+  return {
+    ...actual,
+    refreshCostUsageCacheForAgent: vi.fn(async () => "busy" as const),
+  };
+});
+
+describe("loadSessionCostSummary direct refresh wait", () => {
+  it("stops polling a busy refresh lock after the wait budget", async () => {
+    const root = tempDirs.make("openclaw-usage-busy-");
+    const sessionFile = path.join(root, "transcript.jsonl");
+    await fs.writeFile(
+      sessionFile,
+      `${JSON.stringify({ message: { role: "user", content: "hi", timestamp: Date.now() } })}\n`,
+    );
+
+    const startedAt = Date.now();
+    let waitPhase: "start" | "expired" = "start";
+    const now = vi
+      .spyOn(Date, "now")
+      .mockImplementation(() => (waitPhase === "start" ? startedAt : startedAt + 5_000));
+    vi.mocked(refreshCostUsageCacheForAgent).mockImplementation(async () => {
+      waitPhase = "expired";
+      return "busy";
+    });
+
+    try {
+      await withEnvAsync({ OPENCLAW_STATE_DIR: root }, async () => {
+        await expect(
+          loadSessionCostSummary({
+            agentId: "main",
+            sessionFile,
+          }).then((summary) => summary ?? "empty"),
+        ).resolves.toBe("empty");
+      });
+    } finally {
+      now.mockRestore();
+    }
+  });
+});

--- a/src/infra/session-cost-usage-reporting.ts
+++ b/src/infra/session-cost-usage-reporting.ts
@@ -43,6 +43,7 @@ import type {
 } from "./session-cost-usage.types.js";
 
 const USAGE_COST_DIRECT_REFRESH_RETRY_MS = 25;
+const USAGE_COST_DIRECT_REFRESH_MAX_WAIT_MS = 5_000;
 
 /**
  * Scan all transcript files to discover sessions not in the session store.
@@ -165,6 +166,7 @@ export async function loadSessionCostSummary(params: {
   }
   const agentDir = resolveUsageCostAgentDir(params.config, params.agentId);
   const databasePath = resolveUsageCostCacheDatabasePath(params.agentId);
+  const refreshWaitStartedAt = Date.now();
   while (
     (await refreshCostUsageCacheForAgent({
       config: params.config,
@@ -174,6 +176,9 @@ export async function loadSessionCostSummary(params: {
       sessionFiles: [sessionFile],
     })) === "busy"
   ) {
+    if (Date.now() - refreshWaitStartedAt >= USAGE_COST_DIRECT_REFRESH_MAX_WAIT_MS) {
+      break;
+    }
     // Direct detail callers require the requested session, unlike background
     // summary refreshes. Wait for the agent-wide writer to release, then retry.
     await new Promise<void>((resolve) => {


### PR DESCRIPTION
## What Problem This Solves

`loadSessionCostSummary` (used by `/usage` and session-cost detail) retries every 25ms while the agent-wide usage refresh lock is `busy`. Stale-PID steal already exists, but a live writer that is stuck or just slow can hold `/usage` open with no deadline. Background refresh already backs off to a 5s max. Direct detail callers had no cap.

## Evidence

Live `tsx` on tip [`7b487b2f4b2b`](https://github.com/openclaw/openclaw/commit/7b487b2f4b2b6586d9c767a6bbafffe5e41cb02f) acquired the real SQLite refresh lock, then called production `loadSessionCostSummary` with no wait-budget override. The shipped internal 5s deadline returned a null summary when no rollup existed, and the cached rollup after a prior refresh. The lock stayed held in both cases.

```console
$ node -v && uname -srm
v26.8.2
Darwin 25.6.0 arm64

$ cd /private/tmp/oc-132396
$ PROOF_TIP=$(git rev-parse HEAD) pnpm exec tsx proof-132396.mts
tip=7b487b2f4b2b6586d9c767a6bbafffe5e41cb02f
cwd=/private/tmp/oc-132396
stateDir=/var/folders/7_/3g02szlx2h3_4pdqp0knlw740000gn/T/oc-132396-proof-t5ND6I
databasePath=/var/folders/7_/3g02szlx2h3_4pdqp0knlw740000gn/T/oc-132396-proof-t5ND6I/agents/main/agent/openclaw-agent.sqlite
parent_pid=60232
override=none shipped_deadline_ms=5000
shipped_const=const USAGE_COST_DIRECT_REFRESH_MAX_WAIT_MS = 5_000;
CASE null: hold real SQLite refresh lock, then load with no prior rollup
null: lock_acquired pid=60232 running=true
{"case":"null","elapsed_ms":5107,"summary":null,"lock_still_held":true}
seed cache via production refresh while lock is free
seed_refresh=refreshed
CASE cached: hold real SQLite refresh lock, then load existing rollup
cached: lock_acquired pid=60232 running=true
{"case":"cached","elapsed_ms":5022,"summary":{"totalTokens":12,"totalCost":0.012,"lastActivity":1769940000000},"lock_still_held":true}
DONE both production 5s busy waits returned
```

## Real behavior proof

Behavior addressed: Direct session-cost refresh waits for a busy lock for at most the internal 5s deadline, then returns a fresh cached summary or null instead of polling forever.
Real environment tested: macOS Darwin 25.6.0 arm64, Node v26.8.2, worktree /private/tmp/oc-132396 on tip 7b487b2f4b2b. Proof acquired the real SQLite refresh lock, then called production loadSessionCostSummary with no override.
Exact steps or command run after this patch: cd /private/tmp/oc-132396 && PROOF_TIP=$(git rev-parse HEAD) pnpm exec tsx proof-132396.mts
Evidence after fix: terminal output copied below.

```console
override=none shipped_deadline_ms=5000
shipped_const=const USAGE_COST_DIRECT_REFRESH_MAX_WAIT_MS = 5_000;
{"case":"null","elapsed_ms":5107,"summary":null,"lock_still_held":true}
{"case":"cached","elapsed_ms":5022,"summary":{"totalTokens":12,"totalCost":0.012,"lastActivity":1769940000000},"lock_still_held":true}
```

Observed result after fix: With the real refresh lock held, the public loader returned null after 5107ms, then the cached 12-token summary after 5022ms. Both waits used the shipped 5s constant. The lock was still held after each return.
What was not tested: Multi-process gateway `/usage` against a long-running writer on a large transcript corpus.

## Summary

Public path: `/usage` and session-cost commands via `loadSessionCostSummary`.
Related: open #103961 reclaims leaked same-process locks. This PR caps the wait when another live holder exists.
Introduced in [`71e8f6a925f9`](https://github.com/openclaw/openclaw/commit/71e8f6a925f9) (2026-07-25, Peter Steinberger).
No CHANGELOG (repo auto-generates).
