### PR TITLE
fix(auto-reply): surface allowlist pairing-store read errors

### DIFF
--- a/src/auto-reply/reply/commands-allowlist.test.ts
+++ b/src/auto-reply/reply/commands-allowlist.test.ts
@@ -343,9 +343,21 @@ describe("handleAllowlistCommand", () => {
 
     expect(result?.shouldContinue).toBe(false);
     expect(result?.reply?.text).toContain(
-      "Paired allowFrom (store): unavailable (store read failed)",
+      "Paired allowFrom (store): unavailable (read failed). Retry this command; if it still fails, run openclaw doctor.",
     );
-    expect(result?.reply?.text).not.toContain("Paired allowFrom (store): 123");
+  });
+
+  it("omits the pairing-store line when the store is empty", async () => {
+    const cfg = {
+      commands: { text: true },
+      channels: { telegram: { allowFrom: ["123"] } },
+    } as OpenClawConfig;
+    const result = await handleAllowlistCommand(
+      buildAllowlistParams("/allowlist list dm", cfg),
+      true,
+    );
+
+    expect(result?.reply?.text).not.toContain("Paired allowFrom (store):");
   });
 
   it("adds allowlist entries to config and pairing stores", async () => {

--- a/src/auto-reply/reply/commands-allowlist.test.ts
+++ b/src/auto-reply/reply/commands-allowlist.test.ts
@@ -329,6 +329,25 @@ describe("handleAllowlistCommand", () => {
     expect(result?.reply?.text).toContain("Paired allowFrom (store): 456");
   });
 
+  it("surfaces pairing-store read failures instead of an empty store list", async () => {
+    readChannelAllowFromStoreMock.mockRejectedValueOnce(new Error("pairing db locked"));
+
+    const cfg = {
+      commands: { text: true },
+      channels: { telegram: { allowFrom: ["123"] } },
+    } as OpenClawConfig;
+    const result = await handleAllowlistCommand(
+      buildAllowlistParams("/allowlist list dm", cfg),
+      true,
+    );
+
+    expect(result?.shouldContinue).toBe(false);
+    expect(result?.reply?.text).toContain(
+      "Paired allowFrom (store): unavailable (store read failed)",
+    );
+    expect(result?.reply?.text).not.toContain("Paired allowFrom (store): 123");
+  });
+
   it("adds allowlist entries to config and pairing stores", async () => {
     const cases = [
       {

--- a/src/auto-reply/reply/commands-allowlist.ts
+++ b/src/auto-reply/reply/commands-allowlist.ts
@@ -380,7 +380,9 @@ export const handleAllowlistCommand: CommandHandler = async (params, allowTextCo
       lines.push(`DM allowFrom (config): ${formatEntryList(dmDisplay, resolvedDm)}`);
     }
     if (supportsStore && storeReadFailed) {
-      lines.push("Paired allowFrom (store): unavailable (store read failed)");
+      lines.push(
+        "Paired allowFrom (store): unavailable (read failed). Retry this command; if it still fails, run openclaw doctor.",
+      );
     } else if (supportsStore && storeAllowFrom.length > 0) {
       lines.push(`Paired allowFrom (store): ${formatEntryList(normalizeValues(storeAllowFrom))}`);
     }

--- a/src/auto-reply/reply/commands-allowlist.ts
+++ b/src/auto-reply/reply/commands-allowlist.ts
@@ -315,9 +315,15 @@ export const handleAllowlistCommand: CommandHandler = async (params, allowTextCo
     if (!plugin?.allowlist?.readConfig && !supportsStore) {
       return commandReply(`⚠️ ${channelId} does not expose allowlist configuration.`);
     }
-    const storeAllowFrom = supportsStore
-      ? await readChannelAllowFromStore(channelId, process.env, accountId).catch(() => [])
-      : [];
+    let storeAllowFrom: string[] = [];
+    let storeReadFailed = false;
+    if (supportsStore) {
+      try {
+        storeAllowFrom = await readChannelAllowFromStore(channelId, process.env, accountId);
+      } catch {
+        storeReadFailed = true;
+      }
+    }
     const configState = await readAllowlistConfig({
       cfg: params.cfg,
       channelId,
@@ -373,7 +379,9 @@ export const handleAllowlistCommand: CommandHandler = async (params, allowTextCo
     if (showDm) {
       lines.push(`DM allowFrom (config): ${formatEntryList(dmDisplay, resolvedDm)}`);
     }
-    if (supportsStore && storeAllowFrom.length > 0) {
+    if (supportsStore && storeReadFailed) {
+      lines.push("Paired allowFrom (store): unavailable (store read failed)");
+    } else if (supportsStore && storeAllowFrom.length > 0) {
       lines.push(`Paired allowFrom (store): ${formatEntryList(normalizeValues(storeAllowFrom))}`);
     }
     if (showGroup) {

--- a/src/gateway/gateway-allowlist-store-read-failure.e2e.test.ts
+++ b/src/gateway/gateway-allowlist-store-read-failure.e2e.test.ts
@@ -1,0 +1,159 @@
+import { randomUUID } from "node:crypto";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { afterEach, describe, expect, it } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { clearConfigCache, clearRuntimeConfigSnapshot } from "../config/config.js";
+import { clearSessionStoreCacheForTest } from "../config/sessions/store-writer-state.js";
+import { extractFirstTextBlock } from "../shared/chat-message-content.js";
+import { captureEnv, setTestEnvValue } from "../test-utils/env.js";
+import { disconnectGatewayClient, startGatewayWithClient } from "./test-helpers.e2e.js";
+
+const ENV_KEYS = [
+  "HOME",
+  "OPENCLAW_STATE_DIR",
+  "OPENCLAW_CONFIG_PATH",
+  "OPENCLAW_SKIP_CHANNELS",
+  "OPENCLAW_SKIP_GMAIL_WATCHER",
+  "OPENCLAW_SKIP_CRON",
+  "OPENCLAW_SKIP_CANVAS_HOST",
+  "OPENCLAW_SKIP_BROWSER_CONTROL_SERVER",
+  "OPENCLAW_SKIP_PROVIDERS",
+  "OPENCLAW_BUNDLED_PLUGINS_DIR",
+  "OPENCLAW_TEST_TRUST_BUNDLED_PLUGINS_DIR",
+] as const;
+
+type ChatFinalPayload = {
+  runId?: string;
+  state?: string;
+  message?: unknown;
+};
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+describe("Gateway allowlist command", () => {
+  it("surfaces a pairing-store read failure through chat.send", { timeout: 90_000 }, async () => {
+    const envSnapshot = captureEnv([...ENV_KEYS]);
+    // The native method needs its receiver when restored and called from the fault wrapper.
+    // oxlint-disable-next-line typescript/unbound-method
+    const originalPrepare = DatabaseSync.prototype.prepare;
+    let faultArmed = false;
+    let faultObserved = false;
+    let gateway: Awaited<ReturnType<typeof startGatewayWithClient>> | undefined;
+    let finalTimeout: ReturnType<typeof setTimeout> | undefined;
+
+    try {
+      const home = tempDirs.make("openclaw-allowlist-gateway-");
+      const stateDir = path.join(home, ".openclaw");
+      const configPath = path.join(stateDir, "openclaw.json");
+      const workspaceDir = path.join(home, "workspace");
+      await Promise.all([
+        fs.mkdir(stateDir, { recursive: true }),
+        fs.mkdir(workspaceDir, { recursive: true }),
+      ]);
+      for (const [key, value] of Object.entries({
+        HOME: home,
+        OPENCLAW_STATE_DIR: stateDir,
+        OPENCLAW_CONFIG_PATH: configPath,
+        OPENCLAW_SKIP_CHANNELS: "1",
+        OPENCLAW_SKIP_GMAIL_WATCHER: "1",
+        OPENCLAW_SKIP_CRON: "1",
+        OPENCLAW_SKIP_CANVAS_HOST: "1",
+        OPENCLAW_SKIP_BROWSER_CONTROL_SERVER: "1",
+        OPENCLAW_SKIP_PROVIDERS: "1",
+        OPENCLAW_BUNDLED_PLUGINS_DIR: path.join(process.cwd(), "extensions"),
+        OPENCLAW_TEST_TRUST_BUNDLED_PLUGINS_DIR: "1",
+      })) {
+        setTestEnvValue(key, value);
+      }
+
+      const runId = randomUUID();
+      let resolveFinal: ((payload: ChatFinalPayload) => void) | undefined;
+      const final = new Promise<ChatFinalPayload>((resolve) => {
+        resolveFinal = resolve;
+      });
+      gateway = await startGatewayWithClient({
+        cfg: {
+          agents: {
+            defaults: { workspace: workspaceDir, skipBootstrap: true },
+            entries: { main: { default: true } },
+          },
+          channels: {
+            telegram: {
+              enabled: true,
+              botToken: "test-token",
+              dmPolicy: "allowlist",
+              allowFrom: ["123"],
+            },
+          },
+          commands: { text: true },
+          gateway: { auth: { mode: "token", token: "allowlist-gateway-token" } },
+          plugins: {
+            enabled: true,
+            allow: ["telegram"],
+            entries: { telegram: { enabled: true } },
+          },
+        },
+        configPath,
+        token: "allowlist-gateway-token",
+        clientDisplayName: "allowlist-store-read-failure",
+        onEvent: (event) => {
+          if (event.event !== "chat" || !event.payload || typeof event.payload !== "object") {
+            return;
+          }
+          const payload = event.payload as ChatFinalPayload;
+          if (payload.runId === runId && payload.state === "final") {
+            resolveFinal?.(payload);
+          }
+        },
+      });
+
+      DatabaseSync.prototype.prepare = function prepareWithAllowlistReadFailure(sql) {
+        if (
+          faultArmed &&
+          sql.includes("channel_pairing_allow_entries") &&
+          (new Error().stack ?? "").includes("commands-allowlist")
+        ) {
+          faultArmed = false;
+          faultObserved = true;
+          throw new Error("injected pairing-store read failure");
+        }
+        return originalPrepare.call(this, sql);
+      };
+      faultArmed = true;
+
+      await gateway.client.request("chat.send", {
+        sessionKey: "agent:main:main",
+        message: "/allowlist list dm channel=telegram",
+        deliver: false,
+        idempotencyKey: runId,
+      });
+      const timeout = new Promise<never>((_resolve, reject) => {
+        finalTimeout = setTimeout(
+          () => reject(new Error("timed out waiting for allowlist command reply")),
+          30_000,
+        );
+      });
+      const payload = await Promise.race([final, timeout]);
+
+      expect(faultObserved).toBe(true);
+      expect(extractFirstTextBlock(payload.message)).toContain(
+        "Paired allowFrom (store): unavailable (read failed). Retry this command; if it still fails, run openclaw doctor.",
+      );
+    } finally {
+      if (finalTimeout) {
+        clearTimeout(finalTimeout);
+      }
+      DatabaseSync.prototype.prepare = originalPrepare;
+      if (gateway) {
+        await disconnectGatewayClient(gateway.client).catch(() => undefined);
+        await gateway.server.close().catch(() => undefined);
+      }
+      envSnapshot.restore();
+      clearRuntimeConfigSnapshot();
+      clearConfigCache();
+      clearSessionStoreCacheForTest();
+    }
+  });
+});


### PR DESCRIPTION
## What Problem This Solves

`/allowlist list` treated a pairing-store read failure as an empty list. Operators saw normal config output with no store status, so a failed read looked identical to a successful empty store.

## Root cause

The shared allowlist command caught every `readChannelAllowFromStore` rejection and replaced it with `[]`. The renderer then printed a store line only for non-empty arrays.

The suppression shipped in direct commit `555b2578a8cc6e1b93f717496935ead97bfbed8b`. Commit `bce643a0bd145d3e9cb55400af33bd1b85baeb02` later added account-scoped arguments and carried the existing catch forward.

## Fix

The command now keeps empty and failed store reads distinct. It preserves useful config output and adds an actionable warning:

`Paired allowFrom (store): unavailable (read failed). Retry this command; if it still fails, run openclaw doctor.`

This shared boundary covers every pairing-enabled channel without changing storage, authorization, or channel-specific policy.

## Evidence

### Live Telegram proof

Telegram Test Server direct message: `/allowlist list dm`.

- Current main `590ee376ad0cee24ed157b401da1b0dbe58a90b7`: an injected failure on the allowlist command's real `channel_pairing_allow_entries` query produced normal config output with no store status.
- Anti-cheat probe: a successful empty store produced the same current-main reply.
- Repaired head `307004e6011c5457993113682b70fd70dcfa68ea`: the same query failure preserved config output and added the retry and doctor guidance.
- Both command turns stayed on the native path with zero provider requests.

### Validation

- Focused regression test: 20 passed.
- Gateway product-path E2E: passed through the real `chat.send` WebSocket route.
- Current-main regression check: 1 intended failure, 19 passed.
- Focused Oxlint and Oxfmt: passed.
- Conflict-marker, max-line, and assertion-safety ratchets: passed.
- `git diff --check`: passed.

Production: `+14/-4` (net `+10`). Tests: `+190/-0`.

The production growth represents the distinct failure outcome and the operator recovery text. No store, configuration, or protocol contract changed.
