### PR TITLE
fix(qa): packaged gateway fails when plugins need preparation

### DIFF
--- a/extensions/qa-lab/src/gateway-child-setup.ts
+++ b/extensions/qa-lab/src/gateway-child-setup.ts
@@ -48,7 +48,7 @@ import { seedQaAgentWorkspace } from "./qa-agent-workspace.js";
 import { buildQaGatewayConfig, type QaThinkingLevel } from "./qa-gateway-config.js";
 import type { QaTransportAdapter } from "./qa-transport.js";
 import type { RuntimeId } from "./runtime-parity.js";
-const QA_PACKAGE_AUTH_FAILURE_MAX_CHARS = 2_048;
+const QA_PACKAGE_BOOTSTRAP_FAILURE_MAX_CHARS = 2_048;
 export type QaGatewayChildStateMutationContext = {
   configPath: string;
   runtimeEnv: NodeJS.ProcessEnv;
@@ -143,7 +143,7 @@ async function stageQaPackagedMockAuthProfiles(params: {
       const details = sliceUtf16Safe(
         redactQaGatewayDebugText(errorMessage),
         0,
-        QA_PACKAGE_AUTH_FAILURE_MAX_CHARS,
+        QA_PACKAGE_BOOTSTRAP_FAILURE_MAX_CHARS,
       );
       // oxlint-disable-next-line preserve-caught-error -- Candidate CLI errors can contain the submitted API key; only the redacted message crosses this boundary.
       throw new Error(`installed package mock auth bootstrap failed for ${provider}: ${details}`);
@@ -424,6 +424,39 @@ export async function prepareQaGatewayChild(
             throw new Error("installed package mock auth bootstrap mutated canonical config");
           }
           packagedMockAuthStaged = true;
+        }
+        if (usesPackagedCandidate && gatewayCommand) {
+          try {
+            // The separate onboarding smoke cannot prepare this child's state.
+            // Converge every freshly written config; a new-port retry can otherwise
+            // restore plugin entries the candidate removed before verify-only startup.
+            const command = {
+              executablePath: gatewayCommand.executablePath,
+              argsPrefix: gatewayCommand.argsPrefix ?? [],
+              cwd: gatewayCwd,
+              env,
+            };
+            // Published candidates such as 2026.7.1-2 predate capability consent.
+            const help = await runQaGatewayCliCommand({
+              ...command,
+              args: ["update", "repair", "--help"],
+            });
+            const consentArgs = help.includes("--accept-capabilities")
+              ? ["--accept-capabilities"]
+              : [];
+            await runQaGatewayCliCommand({
+              ...command,
+              args: ["update", "repair", ...consentArgs, "--yes", "--no-restart", "--json"],
+            });
+          } catch (error) {
+            const details = sliceUtf16Safe(
+              redactQaGatewayDebugText(toErrorObject(error, "plugin setup failed").message),
+              0,
+              QA_PACKAGE_BOOTSTRAP_FAILURE_MAX_CHARS,
+            );
+            // oxlint-disable-next-line preserve-caught-error -- Candidate output can include credentials; retain only the bounded redacted diagnostic.
+            throw new Error(`installed package plugin setup failed: ${details}`);
+          }
         }
       }
       if (!env) {

--- a/extensions/qa-lab/src/gateway-child.test.ts
+++ b/extensions/qa-lab/src/gateway-child.test.ts
@@ -1685,7 +1685,9 @@ describe("buildQaRuntimeEnv", () => {
       })
       .catch((caught: unknown) => caught);
     expect(error).toBeInstanceOf(Error);
-    if (!(error instanceof Error)) throw new Error("expected package plugin setup error");
+    if (!(error instanceof Error)) {
+      throw new Error("expected package plugin setup error");
+    }
     expect(error.message).toContain("installed package plugin setup failed: OpenClaw CLI exited 8");
     expect(error.message).not.toContain("fixture-plugin-secret");
     expect(String(error.cause)).not.toContain("fixture-plugin-secret");

--- a/extensions/qa-lab/src/gateway-child.test.ts
+++ b/extensions/qa-lab/src/gateway-child.test.ts
@@ -6,6 +6,7 @@ import os from "node:os";
 import path from "node:path";
 import { Writable } from "node:stream";
 import { pathToFileURL } from "node:url";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { toErrorObject } from "openclaw/plugin-sdk/error-runtime";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
@@ -204,6 +205,27 @@ if (args[0] === "models") {
   fs.writeFileSync(configPath, JSON.stringify(config));
   process.exit(0);
 }
+if (args[0] === "update") {
+  if (args.includes("--help")) {
+    process.stdout.write(process.env.QA_LEGACY_PLUGIN_SETUP === "1" ? "Options: --yes" : "Options: --accept-capabilities --yes");
+    process.exit(0);
+  }
+  if (process.env.QA_LEGACY_PLUGIN_SETUP === "1" && args.includes("--accept-capabilities")) {
+    process.stderr.write("unknown option --accept-capabilities");
+    process.exit(2);
+  }
+  record({ kind: "plugins", args, authDbPath, configPath, stateDir });
+  if (process.env.QA_FAIL_PLUGIN_SETUP === "1") {
+    process.stderr.write("plugin fixture rejected: Authorization: Bearer fixture-plugin-secret");
+    process.exit(8);
+  }
+  const config = JSON.parse(fs.readFileSync(configPath, "utf8"));
+  delete config.plugins.entries["qa-lab"];
+  config.plugins.allow = config.plugins.allow.filter((id) => id !== "qa-lab");
+  fs.writeFileSync(configPath, JSON.stringify(config));
+  process.stdout.write(JSON.stringify({ status: "ok", mode: "finalize", restart: false }));
+  process.exit(0);
+}
 const config = JSON.parse(fs.readFileSync(configPath, "utf8"));
 record({
   kind: "gateway",
@@ -213,8 +235,18 @@ record({
   configPath,
   authProfileIds: Object.keys(config.auth?.profiles ?? {}),
   fixtureProfiles: config.fixtureProfiles,
+  sourcePluginConfigured: Boolean(config.plugins?.entries?.["qa-lab"]),
+  configPort: config.gateway.port,
   stateDir,
 });
+const gatewayAttempts = fs.readFileSync(recordPath, "utf8").trim().split("\\n")
+  .map((line) => JSON.parse(line)).filter((entry) => entry.kind === "gateway").length;
+if (gatewayAttempts === 1 && process.env.QA_STARTUP_RETRY) {
+  process.stderr.write(process.env.QA_STARTUP_RETRY === "migration"
+    ? "OpenClaw plugin migration inputs changed during startup convergence; refusing readiness."
+    : "listen EADDRINUSE: address already in use");
+  process.exit(18);
+}
 process.stderr.write("fixture gateway exit");
 process.exit(17);
 `,
@@ -1487,16 +1519,159 @@ describe("buildQaRuntimeEnv", () => {
     }
   });
 
-  it("lets an explicit packaged command own mock auth state before gateway spawn", async () => {
-    const fixtureRoot = await tempDirs.makeTempDir("qa-packaged-auth-");
+  it.each([false, true])(
+    "lets an explicit packaged command own mock auth and plugins before gateway spawn (legacy=%s)",
+    async (legacy) => {
+      const fixtureRoot = await tempDirs.makeTempDir("qa-packaged-auth-");
+      const tempParentDir = path.join(fixtureRoot, "gateway-temp");
+      const recordPath = path.join(fixtureRoot, "commands.jsonl");
+      const fixturePath = await writePackagedGatewayFixture(fixtureRoot);
+      await mkdir(tempParentDir);
+
+      const owner = ownGateway();
+      await expect(
+        owner.start({
+          repoRoot: process.cwd(),
+          command: {
+            executablePath: process.execPath,
+            argsPrefix: [fixturePath],
+            tempParentDir,
+            usePackagedPlugins: true,
+          },
+          providerMode: "mock-openai",
+          transportBaseUrl: "http://127.0.0.1:43123",
+          runtimeEnvPatch: {
+            QA_RECORD_PATH: recordPath,
+            QA_LEGACY_PLUGIN_SETUP: legacy ? "1" : "0",
+          },
+        }),
+      ).rejects.toThrow("fixture gateway exit");
+      await expect(owner.stop()).resolves.toMatchObject({ errors: [] });
+
+      const records = await readJsonLines(recordPath);
+      const authRecords = records.filter((record) => record.kind === "auth");
+      expect(authRecords).toHaveLength(2);
+      expect(authRecords.map((record) => record.args)).toEqual([
+        [
+          "models",
+          "auth",
+          "--agent",
+          "qa",
+          "paste-api-key",
+          "--provider",
+          "openai",
+          "--profile-id",
+          "qa-mock-openai",
+        ],
+        [
+          "models",
+          "auth",
+          "--agent",
+          "qa",
+          "paste-api-key",
+          "--provider",
+          "anthropic",
+          "--profile-id",
+          "qa-mock-anthropic",
+        ],
+      ]);
+      for (const record of authRecords) {
+        expect(record.stdin).toMatch(/^sk-qa-mock-[a-f0-9]{32}\n$/u);
+        expect(record.env).toMatchObject({
+          OPENCLAW_CLI: "1",
+        });
+        expect(record.configMode).toBe(0o600);
+        expect(record.configRegular).toBe(true);
+        expect(record.configSymlink).toBe(false);
+      }
+      expect(authRecords.map((record) => record.dbExists)).toEqual([false, true]);
+      const authConfigPaths = authRecords.map((record) => String(record.configPath));
+      expect(new Set(authConfigPaths).size).toBe(1);
+      expect(authConfigPaths[0]).toBe(
+        path.join(String(authRecords[0]?.stateDir), "qa-auth-bootstrap", "openclaw.json"),
+      );
+      expect(records.at(-1)).toMatchObject({
+        kind: "gateway",
+        authProfileIds: ["qa-mock-openai", "qa-mock-anthropic"],
+        dbExists: true,
+      });
+      expect(records.at(-1)?.configPath).not.toBe(authConfigPaths[0]);
+      expect(records.at(-1)?.fixtureProfiles).toBeUndefined();
+      expect(records.map((record) => record.kind)).toEqual(["auth", "auth", "plugins", "gateway"]);
+      expect(records[2]).toMatchObject({
+        args: [
+          "update",
+          "repair",
+          ...(legacy ? [] : ["--accept-capabilities"]),
+          "--yes",
+          "--no-restart",
+          "--json",
+        ],
+        configPath: records.at(-1)?.configPath,
+        stateDir: records.at(-1)?.stateDir,
+      });
+      expect(new Set(records.map((record) => record.authDbPath)).size).toBe(1);
+    },
+  );
+
+  it.each([
+    { retry: "bind", configBuilds: 2 },
+    { retry: "migration", configBuilds: 1 },
+  ])(
+    "preserves packaged config repair across $retry startup retries",
+    async ({ retry, configBuilds }) => {
+      const fixtureRoot = await tempDirs.makeTempDir("qa-packaged-retry-");
+      const tempParentDir = path.join(fixtureRoot, "gateway-temp");
+      const recordPath = path.join(fixtureRoot, "commands.jsonl");
+      const fixturePath = await writePackagedGatewayFixture(fixtureRoot);
+      await mkdir(tempParentDir);
+      const mutateConfig = vi.fn((cfg: OpenClawConfig) => cfg);
+      const owner = ownGateway();
+      await expect(
+        owner.start({
+          repoRoot: process.cwd(),
+          command: {
+            executablePath: process.execPath,
+            argsPrefix: [fixturePath],
+            tempParentDir,
+            usePackagedPlugins: true,
+          },
+          providerMode: "mock-openai",
+          transportBaseUrl: "http://127.0.0.1:43123",
+          runtimeEnvPatch: { QA_RECORD_PATH: recordPath, QA_STARTUP_RETRY: retry },
+          mutateConfig,
+        }),
+      ).rejects.toThrow("fixture gateway exit");
+      const records = await readJsonLines(recordPath);
+      const gateways = records.filter((record) => record.kind === "gateway");
+      expect(gateways).toHaveLength(2);
+      expect(gateways.map((record) => record.sourcePluginConfigured)).toEqual([false, false]);
+      expect(records.filter((record) => record.kind === "plugins")).toHaveLength(configBuilds);
+      expect(mutateConfig).toHaveBeenCalledTimes(configBuilds);
+      expect(records.filter((record) => record.kind === "auth")).toHaveLength(2);
+      expect(new Set(records.map((record) => record.stateDir)).size).toBe(1);
+      for (const gateway of gateways) {
+        expect(gateway.args).toContainEqual(String(gateway.configPort));
+        expect(gateway).toMatchObject({
+          dbExists: true,
+          authProfileIds: ["qa-mock-openai", "qa-mock-anthropic"],
+        });
+      }
+      if (retry === "migration") {
+        expect(gateways[1]?.configPort).toBe(gateways[0]?.configPort);
+      }
+    },
+  );
+
+  it("blocks packaged gateway spawn when candidate plugin setup fails", async () => {
+    const fixtureRoot = await tempDirs.makeTempDir("qa-packaged-plugins-fail-");
     const tempParentDir = path.join(fixtureRoot, "gateway-temp");
     const recordPath = path.join(fixtureRoot, "commands.jsonl");
     const fixturePath = await writePackagedGatewayFixture(fixtureRoot);
     await mkdir(tempParentDir);
-
     const owner = ownGateway();
-    await expect(
-      owner.start({
+    const error = await owner
+      .start({
         repoRoot: process.cwd(),
         command: {
           executablePath: process.execPath,
@@ -1506,61 +1681,16 @@ describe("buildQaRuntimeEnv", () => {
         },
         providerMode: "mock-openai",
         transportBaseUrl: "http://127.0.0.1:43123",
-        runtimeEnvPatch: { QA_RECORD_PATH: recordPath },
-      }),
-    ).rejects.toThrow("fixture gateway exit");
-    await expect(owner.stop()).resolves.toMatchObject({ errors: [] });
-
+        runtimeEnvPatch: { QA_RECORD_PATH: recordPath, QA_FAIL_PLUGIN_SETUP: "1" },
+      })
+      .catch((caught: unknown) => caught);
+    expect(error).toBeInstanceOf(Error);
+    if (!(error instanceof Error)) throw new Error("expected package plugin setup error");
+    expect(error.message).toContain("installed package plugin setup failed: OpenClaw CLI exited 8");
+    expect(error.message).not.toContain("fixture-plugin-secret");
+    expect(String(error.cause)).not.toContain("fixture-plugin-secret");
     const records = await readJsonLines(recordPath);
-    const authRecords = records.filter((record) => record.kind === "auth");
-    expect(authRecords).toHaveLength(2);
-    expect(authRecords.map((record) => record.args)).toEqual([
-      [
-        "models",
-        "auth",
-        "--agent",
-        "qa",
-        "paste-api-key",
-        "--provider",
-        "openai",
-        "--profile-id",
-        "qa-mock-openai",
-      ],
-      [
-        "models",
-        "auth",
-        "--agent",
-        "qa",
-        "paste-api-key",
-        "--provider",
-        "anthropic",
-        "--profile-id",
-        "qa-mock-anthropic",
-      ],
-    ]);
-    for (const record of authRecords) {
-      expect(record.stdin).toMatch(/^sk-qa-mock-[a-f0-9]{32}\n$/u);
-      expect(record.env).toMatchObject({
-        OPENCLAW_CLI: "1",
-      });
-      expect(record.configMode).toBe(0o600);
-      expect(record.configRegular).toBe(true);
-      expect(record.configSymlink).toBe(false);
-    }
-    expect(authRecords.map((record) => record.dbExists)).toEqual([false, true]);
-    const authConfigPaths = authRecords.map((record) => String(record.configPath));
-    expect(new Set(authConfigPaths).size).toBe(1);
-    expect(authConfigPaths[0]).toBe(
-      path.join(String(authRecords[0]?.stateDir), "qa-auth-bootstrap", "openclaw.json"),
-    );
-    expect(records.at(-1)).toMatchObject({
-      kind: "gateway",
-      authProfileIds: ["qa-mock-openai", "qa-mock-anthropic"],
-      dbExists: true,
-    });
-    expect(records.at(-1)?.configPath).not.toBe(authConfigPaths[0]);
-    expect(records.at(-1)?.fixtureProfiles).toBeUndefined();
-    expect(new Set(records.map((record) => record.authDbPath)).size).toBe(1);
+    expect(records.map((record) => record.kind)).toEqual(["auth", "auth", "plugins"]);
   });
 
   it("blocks packaged gateway spawn when candidate auth bootstrap fails", async () => {

--- a/extensions/qa-lab/src/gateway-startup-lease.integration.test.ts
+++ b/extensions/qa-lab/src/gateway-startup-lease.integration.test.ts
@@ -33,6 +33,15 @@ if (command === "models") {
   record("auth-cli-completed");
   process.exit(0);
 }
+if (command === "update" && leaderText === "repair") {
+  if (process.argv.includes("--help")) {
+    process.stdout.write("Options: --accept-capabilities --yes --no-restart --json");
+  } else {
+    record("plugin-repair-completed");
+    process.stdout.write(JSON.stringify({ status: "ok" }));
+  }
+  process.exit(0);
+}
 if (command === "descendant") {
   process.on("SIGTERM", () => {});
   setTimeout(() => { record("descendant-failsafe-exit"); process.exit(0); }, 30_000);
@@ -397,6 +406,13 @@ describe.skipIf(process.platform === "win32")(
       async ({ denyGroupSignals }) => {
         const result = await reproduce(denyGroupSignals);
         expect(result.scenarioCalls).toBe(0);
+        const repaired = result.events.findIndex(
+          (event) => event.kind === "plugin-repair-completed",
+        );
+        expect(repaired).toBeGreaterThan(-1);
+        expect(result.events.findIndex((event) => event.kind === "gateway-start")).toBeGreaterThan(
+          repaired,
+        );
         expect(result.events.filter((event) => event.kind === "gateway-start")).toHaveLength(1);
         expect(result.events.find((event) => event.kind === "leader-exit")).toMatchObject({
           exitCode: 17,


### PR DESCRIPTION
## What Problem This Solves

Package Telegram acceptance installs the release tarball successfully, but its first QA gateway fails before any Telegram message is sent. The shared QA config enables the external ACP plugin, while every scenario starts with fresh isolated state that has no installed artifact or recorded capability consent. The separate onboarding smoke uses a different home and cannot prepare that state.

Observed in the full release validation of `383a293b32d97254014437430b62aaf406bc11ac`: [package Telegram job](https://github.com/openclaw/openclaw/actions/runs/33231321931/job/99045022957).

## Why This Change Was Made

Before launching an explicitly packaged QA child, run the candidate's own `update repair --yes --no-restart --json` after its mock-auth bootstrap, adding `--accept-capabilities` when the candidate advertises it in help. Published `2026.7.1-2` exposes repair but predates that flag; the same repair path remains usable for it. The candidate installs configured plugin artifacts and records this fixture's consent in the child's state. Gateway startup retains its normal verify-only behavior. A failed setup blocks startup and exposes a bounded, redacted diagnostic.

No source plugin is substituted for a package artifact, no consent record is copied from another home, and no runtime verification check is removed. Preparation follows each freshly written config. Bind-collision and RPC startup retries rebuild config and run repair again; a migration-convergence restart preserves the existing config and does not repeat preparation. This prevents a fresh retry from restoring plugin entries the candidate removed.

## User Impact

Packaged QA can reach its gateway using the selected release artifact and isolated scenario state. Product install/update behavior, release artifacts, configuration options, schemas, and dependencies are unchanged.

## Evidence

- The startup regressions fail on the original implementation: no plugin setup occurs, and a rejected setup does not prevent gateway launch. The published CLI compatibility case also rejected an unconditional capability-consent flag in the initial draft.
- A process-level retry regression exposed a once-per-child preparation bug in the draft: after a bind collision, the next launch restored the source-only QA Lab entry. The migration-convergence sibling already preserved it. The final owner flow repairs each new config while reusing repaired config for migration restarts.
- The initial 90 tests in `extensions/qa-lab/src/gateway-child.test.ts` pass with the fix on Linux. The final compatibility- and retry-aware file passes locally: 92 passed, one existing platform-dependent case skipped (93 total).
- A clean Linux install used the unchanged full-release package and plugin-registry artifacts from parent run `33230733150`, verifying archive hashes and the registry manifest before use. The original gateway reproduced the missing-consent failure; candidate-owned repair succeeded without restarting a service. Selected model and auth settings and configured product-plugin options remained intact. The candidate removed the unavailable source-only QA Lab entry and normalized empty plugin config objects.
- The actual patched `createQaGatewayChild().start()` completed fresh-state auth bootstrap, plugin preparation, HTTP readiness, and `config.get` RPC against that same package. [Testbox workflow](https://github.com/openclaw/openclaw/actions/runs/33233235099); lease stopped after proof. This proves package startup, not a Telegram round trip; the focused hosted package-Telegram lane must supply transport proof.
- Fresh independent Codex autoreview of the final compatibility- and retry-aware patch reported no actionable findings at its default P0 threshold. Formatting and diff checks pass. The complete changed-file gate passed all earlier guards, including doctor contracts and dead exports, then failed extension typechecking against the shared stale local dependencies: installed Crabline 0.1.11 versus required 0.1.19, CUA driver 0.19.3 versus required 0.21.0, and missing IMAP/geolocation dependencies. No error identifies either changed file. Focused lint also stops before linting while preparing SDK declaration artifacts against those stale dependencies. A clean CI install must supply final type/lint proof; the shared dependency tree was not modified.

Production/test-support delta: +35/-2 (net +33) in the QA child owner. Tests: +207/-59 (net +148, including modern/legacy and real subprocess retry and lease-lifetime coverage). The added owner step performs the missing isolated package preparation; it does not add a production test seam or an alternate plugin installer.


### CI follow-up

The first exact-head CI run caught a second disposable packaged CLI fixture that rejected the new repair command, so its lease-lifetime tests never reached gateway startup. The fixture now accepts candidate repair and records its completion before gateway launch; its real descendant-process shutdown, heartbeat, and lease-release assertions remain intact. The same follow-up fixes the lint-required braces in the setup-failure assertion. No production code changed.

After that correction, the gateway-child, gateway-child-lifecycle, and gateway-startup-lease integration files passed together: **104 passed, one existing platform skip (105 total)**. A fresh independent Codex review of the test-only follow-up found no actionable P0 issues. Exact-head hosted [CI run 33238064531](https://github.com/openclaw/openclaw/actions/runs/33238064531) passed on `83b8fa24f08ba062c954b5da46491c3a01bc72df`, including the changed-extension tests and lint that failed on the first run. The clean hosted checks resolve the local stale-dependency type/lint proof gap. The latest ClawSweeper review covers this same head and reports no actionable correctness findings.
