### PR TITLE
fix(test): prove gateway retry and drain ordering

### DIFF
--- a/test/helpers/openclaw-test-instance.test.ts
+++ b/test/helpers/openclaw-test-instance.test.ts
@@ -1,5 +1,5 @@
 // OpenClaw test instance tests cover spawned test instance lifecycle.
-import { EventEmitter } from "node:events";
+import { EventEmitter, once } from "node:events";
 import fs from "node:fs/promises";
 import { createServer } from "node:http";
 import { tmpdir } from "node:os";
@@ -9,7 +9,7 @@ import { setTimeout as delay } from "node:timers/promises";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createOpenClawTestInstance, testing } from "./openclaw-test-instance.js";
 import { isProcessAlive } from "./process-wait.js";
-import { createDeferred } from "./promise.js";
+import { createDeferred, withTestTimeout } from "./promise.js";
 
 const MIGRATION_CONVERGENCE_REFUSAL =
   "OpenClaw plugin migration inputs changed during startup convergence;";
@@ -189,7 +189,11 @@ const kind = (process.env.OPENCLAW_FAKE_GATEWAY_SEQUENCE || "ready").split(",")[
 process.stdout.write("fake gateway attempt " + attempt + "\\n");
 const refusal = ${JSON.stringify(MIGRATION_CONVERGENCE_REFUSAL)};
 if (kind === "refuse") { process.stderr.write(refusal + " fixture\\n"); process.exit(1); }
-if (kind === "late-refuse") { const delayed = spawn(process.execPath, ["-e", 'setTimeout(() => process.stderr.write(process.argv[1]), 50)', refusal + " delayed fixture\\n"], { stdio: ["ignore", "ignore", "inherit"] }); recordFixtureProcess(delayed.pid); process.exit(1); }
+if (kind === "late-refuse") {
+  const delayed = spawn(process.execPath, ["-e", 'require("node:http").get(process.argv[1] + "/wait", (response) => { response.resume(); response.on("end", () => process.stderr.write(process.argv[2], () => process.exit(0))); });', controlUrl, refusal + " delayed fixture\\n"], { stdio: ["ignore", "ignore", "inherit"] });
+  recordFixtureProcess(delayed.pid);
+  process.exit(1);
+}
 if (kind === "resist-after-exit") {
   const resistant = spawn(process.execPath, ["-e", 'const fs = require("node:fs");fs.writeFileSync(process.argv[1], String(process.pid));process.on("SIGTERM", () => fs.appendFileSync(process.argv[2], "SIGTERM"));process.send("ready");setInterval(() => {}, 1_000);', tracePath + ".resistant-pid", tracePath + ".signals"], { stdio: ["ignore", "ignore", "inherit", "ipc"] });
   await new Promise((resolve) => resistant.once("message", resolve));
@@ -394,8 +398,41 @@ describe("openclaw test instance", () => {
   it.each(["refuse", "late-refuse"])(
     "restarts one %s refusal with identical launch state and owns the ready child",
     async (refusalAction) => {
-      const { instance, readAttempts } = await createFakeGateway(`${refusalAction},ready`);
-      await instance.startGateway();
+      const control = refusalAction === "late-refuse" ? await createGatewayControl() : undefined;
+      const { instance, readAttempts } = await createFakeGateway(
+        `${refusalAction},ready`,
+        1_000,
+        1_500,
+        control,
+      );
+      const exited = createDeferred<{ code: number | null; signal: NodeJS.Signals | null }>();
+      if (control) {
+        control.observers.onLaunch = () => {
+          if (control.launches.length !== 1) return;
+          const leader = instance.child;
+          if (!leader) {
+            exited.reject(new Error("fixture launched without a process owner"));
+            return;
+          }
+          leader.once("exit", (code, signal) => exited.resolve({ code, signal }));
+        };
+      }
+      const startup = trackOperation(instance.startGateway());
+      try {
+        if (control) {
+          expect(await Promise.race([exited.promise, startup])).toEqual({ code: 1, signal: null });
+          await Promise.race([control.reached, startup]);
+          expect(instance.child?.stderr.closed).toBe(false);
+          expect(instance.logs()).not.toContain(MIGRATION_CONVERGENCE_REFUSAL);
+          // /launch installs the exit observer before the leader proceeds. Only
+          // release its waiting stderr writer after that native exit, never a timer.
+          await control.release();
+        }
+        await startup;
+      } finally {
+        control?.unblock();
+        await Promise.allSettled([startup]);
+      }
       const attempts = await readAttempts();
       expect(attempts).toHaveLength(2);
       expect(attempts[0]?.pid).not.toBe(attempts[1]?.pid);
@@ -511,35 +548,63 @@ describe("openclaw test instance", () => {
   it.runIf(process.platform !== "win32")(
     "reaps terminal children with inherited stdio before starting a new gateway",
     async () => {
+      const stopTimeoutMs = 100;
       const { instance, readAttempts, tracePath } = await createFakeGateway(
         "terminal-drain,ready",
         300,
-        100,
+        stopTimeoutMs,
       );
 
-      const startupError = await instance.startGateway().catch((error: unknown) => error);
-      expect(startupError).toBeInstanceOf(Error);
-      expect((startupError as Error).message).toContain(
-        "gateway exited before readiness (code=7 signal=null)",
-      );
-      expect((startupError as Error).message).toContain("terminal startup failure");
-      expect(instance.child?.exitCode).toBe(7);
-      expect(instance.child?.stderr.closed).toBe(false);
-      const firstAttempt = (await readAttempts())[0];
-      const drainingPid = Number(await fs.readFile(`${tracePath}.draining-pid`, "utf8"));
-      expect(isProcessAlive(drainingPid)).toBe(true);
+      const startup = trackOperation(instance.startGateway());
+      try {
+        const startupError = await startup.catch((error: unknown) => error);
+        expect(startupError).toBeInstanceOf(Error);
+        expect((startupError as Error).message).toContain(
+          "gateway exited before readiness (code=7 signal=null)",
+        );
+        expect((startupError as Error).message).toContain("terminal startup failure");
+        const firstChild = instance.child;
+        expect(firstChild?.exitCode).toBe(7);
+        expect(firstChild?.stderr.closed).toBe(false);
+        if (!firstChild) throw new Error("terminal fixture lost its process owner");
+        const firstAttempt = (await readAttempts())[0];
+        const drainingPid = Number(await fs.readFile(`${tracePath}.draining-pid`, "utf8"));
+        expect(isProcessAlive(drainingPid)).toBe(true);
 
-      await fs.writeFile(`${tracePath}.draining-release`, "");
-      await instance.startGateway();
+        // Keep the inherited pipe held through a complete failed restart: eventual
+        // replacement after release alone cannot prove that stale ownership blocked it.
+        await expect(trackOperation(instance.startGateway())).rejects.toThrow(
+          new Error(`gateway process did not close before stop deadline\n${instance.logs()}`),
+        );
+        expect(instance.child).toBe(firstChild);
+        expect(firstChild.stderr.closed).toBe(false);
+        expect(isProcessAlive(drainingPid)).toBe(true);
+        expect(await readAttempts()).toHaveLength(1);
 
-      const attempts = await readAttempts();
-      expect(attempts).toHaveLength(2);
-      expect(attempts[1]?.pid).not.toBe(firstAttempt?.pid);
-      expect(instance.child?.pid).toBe(attempts[1]?.pid);
-      await instance.stopGateway();
-      expect(instance.child).toBeUndefined();
-      expect(isProcessAlive(attempts[1]?.pid as number)).toBe(false);
-      await expect.poll(() => isProcessAlive(drainingPid), { timeout: 500 }).toBe(false);
+        // Register before release, but charge only post-release drain to the stop budget.
+        const closed = trackOperation(once(firstChild, "close"));
+        await fs.writeFile(`${tracePath}.draining-release`, "");
+        await withTestTimeout(
+          closed,
+          stopTimeoutMs * 2,
+          "terminal fixture did not close after release",
+        );
+        expect(firstChild.stdout.closed).toBe(true);
+        expect(firstChild.stderr.closed).toBe(true);
+        await trackOperation(instance.startGateway());
+
+        const attempts = await readAttempts();
+        expect(attempts).toHaveLength(2);
+        expect(attempts[1]?.pid).not.toBe(firstAttempt?.pid);
+        expect(instance.child?.pid).toBe(attempts[1]?.pid);
+        await instance.stopGateway();
+        expect(instance.child).toBeUndefined();
+        expect(isProcessAlive(attempts[1]?.pid as number)).toBe(false);
+        await expect.poll(() => isProcessAlive(drainingPid), { timeout: 500 }).toBe(false);
+      } finally {
+        await fs.writeFile(`${tracePath}.draining-release`, "");
+        await Promise.allSettled([startup]);
+      }
     },
   );
 


### PR DESCRIPTION
Related: [#120089 — shared Gateway migration retry](https://github.com/openclaw/openclaw/pull/120089), [#131890 — Gateway readiness and lifecycle cleanup](https://github.com/openclaw/openclaw/pull/131890).

<details>
<summary>Additional instructions</summary>

Maintainer-owned branch; maintainers can update the branch. AI-assisted, explicitly maintainer-requested test repair.

</details>

## What Problem This Solves

Resolves a problem where the shared Gateway lifecycle tests could pass without proving the event ordering they claim to protect. The delayed-refusal case assumed a descendant's 50 ms timer would run after the leader exited, while the terminal-drain case released its inherited pipe before asking the helper to restart. Controlled negative tests demonstrated that those assertion flows could miss early stderr classification and skipped stale-owner cleanup.

## Why This Change Was Made

The delayed writer now waits on the existing loopback control and is released only after the test observes the leader's native exit. The test also verifies that stderr remains open and the refusal has not arrived before release, then retains the original real-readiness, identical-launch-state and replacement-ownership assertions.

The terminal case now attempts a restart while the old pipe is deliberately held, requires the existing stop-deadline error and retained owner, and verifies that no second attempt was recorded. It then releases the holder, observes native closure and completes the original successful replacement/stop proof. Listener registration precedes release, but filesystem setup is outside the close-observation clock. This case uses its existing attempt trace rather than adding an HTTP launch round-trip inside its 300 ms startup budget.

All existing startup/stop values and original assertions remain. The shared instance helper and managed-child implementation are unchanged. Automatic startup-failure cleanup is not replaced by explicit-stop coverage.

## User Impact

No production Gateway, configuration, dependency or public API change. Maintainers get stronger real-process regression coverage for late startup diagnostics and retained child ownership. The separate TERM-resistant case and its fixture, refusal-drain case, and intervening-stop case remain byte-identical.

This is an ordering/coverage repair, not a claim to eliminate every scheduler-sensitive startup under the existing short deadlines.

## Evidence

**Real subprocess and loopback HTTP proof:** full 26-test file, original declaration order, one worker, no file parallelism and no isolation. Every run used fresh synthetic HOME/state/config/TMP/XDG, a literal credential-free environment and the existing external PID registry. These are real Node children, inherited pipes and process-group signals—not mocked ChildProcess objects. No operator Gateway, live credentials, provider or channel was used.

```bash
node scripts/run-vitest.mjs test/helpers/openclaw-test-instance.test.ts --maxWorkers=1 --no-file-parallelism --no-isolate
```

- Node 24.20.0: **26 passed**, 46.196 s runner wall time.
- Node 26.7.0: first final-source run **25 passed / 1 failed** at the previously observed replacement-readiness timeout; one bounded unchanged-source recheck **26 passed**, 58.932 s. The held-owner rejection and closure checks had already completed before that timeout. The failure is retained as evidence of remaining startup timing sensitivity, not hidden by the recheck.
- The unchanged TERM-resistant test passed in these final-source full-file runs.

**Regression controls:** controlled schedules retaining the old assertions passed against artifact-only helper copies that classified stderr before draining or skipped stale-owner stop. With the final assertions, both deliberately broken variants fail for the intended reason: the late refusal loses its retry (209 ms, code-1 exit—not timeout), and the blocked terminal restart incorrectly resolves instead of rejecting (497 ms—not timeout). The other 24 cases were unselected in this focused mutation run; it is not counted as a full-file pass. The tracked helper was never mutated and the temporary test import was restored exactly.

**Cleanup:** all post-run recorded PID checks were absent; all synthetic roots were removed after verification. No global/manual kill was needed. Recorded-PID absence is the precise claim; child-side receipts are not a complete OS-spawn ledger.

**Static checks and review:** focused oxfmt, `git diff --check`, and the complete changed gate passed, including root test typechecking and scripts lint.

```bash
node scripts/check-changed.mjs -- test/helpers/openclaw-test-instance.test.ts
```

Codex autoreview of the final uncommitted candidate and owner evidence completed scoped-clean at its default P0 threshold. Manual owner/caller/callee/history review and direct Node 24/26 exit/close and synchronous-receipt contract inspection also completed.

Production/shared-owner LOC: **0**. Tests: **+92/-27 (net +65)**, including existing assertions moved into failure-safe `try/finally` blocks. No build/package or authenticated product Gateway proof is claimed for this test-only change.
