### PR TITLE
docs: reconcile session history sanitization guarantees

### DIFF
--- a/docs/concepts/session-tool.md
+++ b/docs/concepts/session-tool.md
@@ -51,19 +51,15 @@ Gateway sharing operations are outside this run-audit boundary.
 
 `sessions_history` fetches the conversation transcript for a specific session. By default, tool results are excluded; pass `includeTools: true` to see them. Use `limit` for the newest bounded tail. Pass `offset: 0` when you need pagination metadata, then pass returned `nextOffset` values to page backward through older OpenClaw transcript windows without reading raw transcript files. Explicit offset pages do not merge external CLI fallback imports; use the default newest-tail view (no `offset`) when you need that merged display history.
 
-The returned view is intentionally bounded and safety-filtered:
+The returned view is intentionally bounded and redacted:
 
-- assistant text is normalized before recall:
-  - thinking tags are stripped
-  - `<relevant-memories>` / `<relevant_memories>` scaffolding blocks are stripped
-  - plain-text tool-call XML payload blocks such as `<tool_call>...</tool_call>`, `<function_call>...</function_call>`, `<tool_calls>...</tool_calls>`, and `<function_calls>...</function_calls>` are stripped, including truncated payloads that never close cleanly
-  - downgraded tool-call/result scaffolding such as `[Tool Call: ...]`, `[Tool Result ...]`, and `[Historical context ...]` is stripped
-  - leaked model control tokens such as `<|assistant|>`, other ASCII `<|...|>` tokens, and full-width `<｜...｜>` variants are stripped
-  - malformed MiniMax tool-call XML such as `<invoke ...>` / `</minimax:tool_call>` is stripped
-- credential/token-like text is redacted before it is returned
-- long text blocks are truncated
-- very large histories can drop older rows or replace an oversized row with `[sessions_history omitted: message too large]`
+- credential/token-like text is redacted even when general-purpose log redaction is disabled
+- thinking signatures, reasoning replay payloads, and inline image data are omitted
+- long text blocks are truncated to 4000 characters, with a truncation marker appended
+- returned messages are capped at 80 KB; older rows can be dropped or an oversized row replaced with `[sessions_history omitted: message too large]`
 - the tool reports summary flags such as `truncated`, `droppedMessages`, `contentTruncated`, `contentRedacted`, `bytes`, and pagination metadata
+
+This is structured history, not the plain-text rendering used by [`/subagents log`](/tools/subagents#slash-command). `sessions_history` does not apply that command's assistant prose sanitizer: reasoning tags, `<relevant-memories>` / `<relevant_memories>` scaffolding, plain-text tool-call XML (including malformed MiniMax XML), downgraded tool markers, and model control tokens can remain in returned message text. `includeTools` controls tool-result messages, not those embedded text forms.
 
 Use the returned **session key** (like `"main"`) with `sessions_history`, `sessions_send`, and `session_status`. Use the durable `sessionId` only as the lifecycle identity described above.
 

--- a/docs/tools/subagents.md
+++ b/docs/tools/subagents.md
@@ -614,9 +614,9 @@ transcript from within an agent turn:
 
 - Redacts credential/token-like text even when general-purpose log redaction is disabled.
 - Truncates long text blocks (4000 chars per block) and drops thinking signatures, reasoning replay payloads, and inline image data.
-- Enforces an 80 KB response cap; oversized rows are replaced with `[sessions_history omitted: message too large]`.
+- Caps returned messages at 80 KB; older rows can be dropped or an oversized row replaced with `[sessions_history omitted: message too large]`.
 - Use `nextOffset` when present to page backward through older transcript windows.
-- `sessions_history` does **not** strip reasoning tags, `<relevant-memories>` scaffolding, or tool-call XML from message text — it returns structured content blocks close to the raw transcript shape, just redacted and size-bounded. `/subagents log` applies the heavier prose sanitizer (strips reasoning tags, memory scaffolding, and tool-call XML) because it renders plain chat lines instead of structured blocks.
+- Returns structured history rather than `/subagents log`'s plain chat lines. Reasoning tags, `<relevant-memories>` / `<relevant_memories>` scaffolding, and tool-call XML can remain in message text: `sessions_history` does not apply the log command's assistant prose sanitizer. See [Session tools](/concepts/session-tool#listing-and-reading-sessions) for the recall guarantees.
 - Raw on-disk transcript inspection is the fallback when you need the full byte-for-byte transcript.
 
 ## Tool policy
@@ -636,8 +636,8 @@ depth. Leaf sub-agents (default depth-1 behavior, and always at depth 2)
 additionally lose `subagents`, `sessions_list`, `sessions_history`, and
 `sessions_spawn`, so sub-agent communication stays on the announce chain.
 
-`sessions_history` remains a bounded, sanitized recall view here too — it
-is not a raw transcript dump.
+`sessions_history` remains a bounded, redacted recall view here too — it
+is neither a raw transcript dump nor a prose-only rendering.
 
 When `maxSpawnDepth >= 2`, depth-1 orchestrator sub-agents additionally
 receive `sessions_spawn`, `subagents`, `sessions_list`, and


### PR DESCRIPTION
## What Problem This Solves

Resolves a documentation contradiction for users inspecting another session: the session-tools page said `sessions_history` strips reasoning tags, relevant-memory scaffolding, and tool-call XML, while the subagents page said it does not. The latter also called the view "sanitized," leaving the actual guarantee ambiguous.

## Why This Change Was Made

The current tool reads the Gateway's structured `chat.history` projection, filters tool-result messages, and applies credential redaction and output bounds. It does not use the assistant prose sanitizer called by `/subagents log`. This change corrects the stale session-tools prose and makes the same distinction explicit on the subagents page; it does not change runtime behavior or session-fork behavior.

The July 5 documentation rewrite (`f7d7148cf047`) changed the subagents explanation without updating the contradictory concepts-page claim. The shared sanitizer's `history` profile belongs to assistant text extraction, not automatically to the `sessions_history` tool.

## User Impact

Readers can distinguish bounded, redacted structured recall from a prose-only log and from an unfiltered transcript. Reasoning tags, memory scaffolding, plain-text tool-call XML, downgraded markers, and model control tokens can remain in recalled message text. The docs retain forced credential redaction, 4,000-character text truncation, the 80 KB returned-message cap, metadata/image-payload omission, and pagination guarantees. They also clarify that `includeTools` controls tool-result messages rather than embedded markup.

No runtime, configuration, storage, API, or test behavior changes. English source docs only; translations remain owned by the docs publishing pipeline. AI-assisted.

## Evidence

- Inspected the complete history tool, Gateway display projection/sanitization, canonical assistant-visible sanitizer, `/subagents log` callers, relevant existing tests, and local Git history. A fresh `origin/main` comparison showed no drift in the affected docs or these runtime owners.
- `pnpm docs:list` — passed.
- `node scripts/check-docs-mdx.mjs docs/concepts/session-tool.md docs/tools/subagents.md` — passed for both files.
- `git diff --check` — passed.
- A temporary in-process probe through the real Gateway display projection, `createSessionsHistoryTool`, and `/subagents log` text extraction passed 95 assertions: 10 markup classes in both string and structured-block messages, metadata omission, redaction with general log redaction disabled, text/byte bounds, the oversized-row placeholder, and tool-result filtering. The Gateway response was injected; this is not live-Gateway proof.
- The existing shared assistant-visible sanitizer suite passed all 124 tests. The combined command was `node scripts/run-vitest.mjs src/agents/tools/sessions-history-tool.test.ts src/agents/openclaw-tools.sessions.test.ts src/auto-reply/reply/commands-subagents.test.ts src/shared/text/assistant-visible-text.test.ts`.
- Validation limitation: that combined run initially hit missing Zod dependency files. `pnpm install` repaired them without tracked dependency changes. Retried combined and tool-only Vitest runs then stalled during collection/import and were stopped with process cleanup verified. No passing result is claimed for those tool/subagent suites; the local loading stall is recorded as a separate follow-up. No live provider or channel test is needed for this prose-only change.

Production LOC: +0/-0. Tests: +0/-0. Documentation: +12/-16.
