### PR TITLE
test: scale container daemon regression deadlines

### DIFF
--- a/src/gateway/server-methods/send.test.ts
+++ b/src/gateway/server-methods/send.test.ts
@@ -4564,7 +4564,7 @@ describe("gateway send mirroring", () => {
       expect(mocks.deliverOutboundPayloads).toHaveBeenCalledOnce();
       expect(deliveryCall()).toMatchObject({
         to: testCase.expectedTarget,
-        accountId: testCase.accountId,
+        accountId: testCase.accountId ?? "default",
         payloads: [
           expect.objectContaining({ text: testCase.nativeDeclines ? "prepared hello" : "hello" }),
         ],

--- a/src/node-host/node-worker-supervisor.container.test.ts
+++ b/src/node-host/node-worker-supervisor.container.test.ts
@@ -3,6 +3,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import * as processExec from "../process/exec.js";
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
 import type { WorkerConnectionEndpoint } from "../worker/worker-connection-endpoint.js";
 import { NodeWorkerContainerLifecycle } from "./node-worker-container-lifecycle.js";
@@ -33,6 +34,7 @@ const endpoint: WorkerConnectionEndpoint = {
 const hostLabel = "openclaw.node-worker.host";
 const gatewayLabel = "openclaw.node-worker.gateway";
 const launchLabel = "openclaw.node-worker.launch";
+const DAEMON_TIMER_SCALE = 5;
 
 type FakeContainer = {
   id: string;
@@ -149,6 +151,36 @@ function containerFixture(
       return fs.existsSync(path.join(engineRoot, `${id}.container.json`));
     },
   };
+}
+
+function delayDaemonRevalidation(fixture: ReturnType<typeof containerFixture>, delayMs: number) {
+  fs.writeFileSync(
+    path.join(fixture.engineRoot, "info-delay-ms"),
+    String(delayMs / DAEMON_TIMER_SCALE),
+  );
+  const requestedTimeouts: number[] = [];
+  const runExec = processExec.runExec;
+  vi.spyOn(processExec, "runExec").mockImplementation((command, args, options) => {
+    if (
+      command === fixture.containerEngine.command &&
+      args.length === 3 &&
+      args[0] === "info" &&
+      args[1] === "--format" &&
+      args[2] === "{{.ID}}" &&
+      typeof options === "object" &&
+      typeof options.timeoutMs === "number"
+    ) {
+      // Scale both sides so the old five-second deadline still loses to the
+      // six-second response. Execa, process signals, and other commands stay real.
+      requestedTimeouts.push(options.timeoutMs);
+      return runExec(command, args, {
+        ...options,
+        timeoutMs: options.timeoutMs / DAEMON_TIMER_SCALE,
+      });
+    }
+    return runExec(command, args, options);
+  });
+  return requestedTimeouts;
 }
 
 async function waitForWorkerStarted(workspaceDir: string): Promise<void> {
@@ -438,12 +470,12 @@ describe("node worker supervisor container isolation", () => {
   });
 
   it(
-    "launches after a busy daemon takes six seconds to revalidate",
+    "launches when daemon revalidation outlasts the discovery timeout",
     { timeout: 15_000 },
     async () => {
       const fixture = containerFixture();
       const input = testWorkerLaunchInput(fixture.workspaceDir, "container-busy-daemon");
-      fs.writeFileSync(path.join(fixture.engineRoot, "info-delay-ms"), "6000");
+      const requestedTimeouts = delayDaemonRevalidation(fixture, 6_000);
 
       try {
         expect(await fixture.supervisor.launch(input, endpoint)).toMatchObject({
@@ -452,6 +484,7 @@ describe("node worker supervisor container isolation", () => {
         expect(await waitForTerminal(fixture.supervisor, input.launchId)).toMatchObject({
           state: "completed",
         });
+        expect(requestedTimeouts).toEqual([30_000]);
       } finally {
         await fixture.supervisor.close();
       }
@@ -464,13 +497,16 @@ describe("node worker supervisor container isolation", () => {
     async () => {
       const fixture = containerFixture();
       const input = testWorkerLaunchInput(fixture.workspaceDir, "container-unresponsive-daemon");
-      fs.writeFileSync(path.join(fixture.engineRoot, "info-delay-ms"), "35000");
+      const requestedTimeouts = delayDaemonRevalidation(fixture, 35_000);
 
       try {
         const failed = await fixture.supervisor.launch(input, endpoint);
 
         expect(failed.state).toBe("failed");
-        expect(failed.errorText).toMatch(/Command timed out after \d+ milliseconds:/u);
+        expect(requestedTimeouts).toEqual([30_000]);
+        expect(failed.errorText).toContain(
+          `Command timed out after ${30_000 / DAEMON_TIMER_SCALE} milliseconds:`,
+        );
         expect(failed.errorText).toContain("docker info --format '{{.ID}}'");
         expect(await fixture.supervisor.status(input.launchId)).toMatchObject({
           state: "failed",


### PR DESCRIPTION
## What Problem This Solves

Two container-supervisor regressions spend six and thirty seconds exercising daemon revalidation deadlines. The fake engine already controls response latency, so waiting at production scale adds wall time without strengthening the process-lifecycle coverage.

## Why This Change Was Made

Scale both the fake daemon response and its matching `runExec` deadline by five. The spy calls the original executor and matches only this fixture's `info --format {{.ID}}` command. Process creation, Execa cancellation, signal handling, error diagnostics, journal persistence, and cleanup remain real.

The healthy response retains 4.8 seconds of startup headroom. The regression remains distinguishable: the old five-second deadline becomes one second and still loses to the scaled six-second response. Both cases also assert that production requested its unchanged thirty-second budget.

## User Impact

The full twenty-case file fell from **43.06s to 14.36s** locally. No production, sharding, worker-count, selection, or configuration changes. Test/support LOC +41/-5; production +0/-0.

## Evidence

- Before and after: all twenty container cases passed. The final sibling run passed all **82 tests** across container, general supervisor, lifetime, recovery, and admission suites.
- Command: `node scripts/run-vitest.mjs src/node-host/node-worker-supervisor.container.test.ts src/node-host/node-worker-supervisor.test.ts src/node-host/node-worker-supervisor.lifetime.test.ts src/node-host/node-worker-supervisor.recovery.test.ts src/node-host/node-worker-supervisor.admission.test.ts`.
- Negative probe: restoring the old five-second production revalidation deadline made the healthy-daemon case fail its original running-state assertion (received failed). Original production bytes were restored before the final passing run.
- The unresponsive-daemon case still exercises a real subprocess timeout and checks its six-second diagnostic and durable failed state.
- Independent source review and fresh Codex autoreview passed. Execa's installed timeout/kill contract and the engine, lifecycle, supervisor, launch transport, and executor owners were inspected directly.
- This is isolated real-process proof with a fake container executable, not a live Docker-daemon claim. Linux changed-file checks and exact-head hosted CI must pass before landing.

## CI Integration Repair

The first CI run exposed two stale gateway-send assertions when this PR was merged with main's account-resolution change from #132226. The tested merge was `1e92368db1959543a7d8fafdbb86ed7ff1fcf23f`, combining this PR's old head with `c3ff7f98d58e`. Those requests omit account selection; canonical local delivery now correctly receives the plugin's resolved `default` account.

After rebasing onto current main, the same two failures reproduced locally. The existing table now expects the resolved default at the delivery boundary while preserving omitted-account inputs and the explicit `secondary` case. No production behavior changes. All **185 tests** then passed across container supervision, the complete gateway-send suite, account routing, and core send. Fresh Codex reviews passed for the container branch and assertion correction. The refreshed exact-head CI and changed-file gates must pass before landing.

Refreshed gates passed: [exact-head CI](https://github.com/openclaw/openclaw/actions/runs/33237264277), [Linux changed-file checks](https://github.com/openclaw/openclaw/actions/runs/33237235949) (wrapper exit 0; Testbox stopped). No ClawSweeper review comment or rank-up moves were present at the final pre-landing read.
