### PR TITLE
fix(qa): restore in-flight restart verification

### DIFF
--- a/extensions/qa-lab/src/providers/mock-openai/server.test.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/server.test.ts
@@ -1,5 +1,7 @@
 import { once } from "node:events";
+import { runInNewContext } from "node:vm";
 // Qa Lab tests cover server plugin behavior.
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
 import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
 import { afterEach, describe, expect, it } from "vitest";
 import { WebSocket } from "ws";
@@ -6921,8 +6923,31 @@ Update and merge these partial structured summaries.`,
       expect(execArgs).toMatchObject({ language: "javascript", restartSafe: true });
       expect(execArgs.code).toContain("qa_restart_wait");
       expect(execArgs.code).toContain('catalog.search("qa_restart_wait")');
-      expect(execArgs.code).toContain("await target({})");
       expect(execArgs.code).toContain(`CHECKPOINT-${checkpoint}`);
+
+      const started = createDeferred<void>();
+      const released = createDeferred<void>();
+      let yielded = false;
+      const target = Object.assign(
+        () => {
+          started.resolve();
+          return released.promise;
+        },
+        { toolName: "qa_restart_wait" },
+      );
+      const execution = runInNewContext(`(async () => { ${String(execArgs.code)} })()`, {
+        catalog: { search: async () => [target] },
+        yield_control: () => {
+          yielded = true;
+        },
+      }) as Promise<unknown>;
+      try {
+        await started.promise;
+        expect(yielded).toBe(true);
+      } finally {
+        released.resolve();
+        await expect(execution).resolves.toBe(`CHECKPOINT-${checkpoint}`);
+      }
 
       const runId = `restart-checkpoint-${checkpoint}`;
       input.push(

--- a/extensions/qa-lab/src/providers/mock-openai/server.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/server.ts
@@ -968,7 +968,9 @@ async function buildResponsesPayload(
             `// ${QA_CODE_MODE_TARGET_MARKER}${encodedTarget}`,
             'const target = (await catalog.search("qa_restart_wait")).find((tool) => tool.toolName === "qa_restart_wait");',
             'if (!target) throw new Error("qa_restart_wait unavailable");',
-            "await target({});",
+            // Bridge calls drain inside exec; explicitly yield while this hold is pending.
+            // The restart scenario must interrupt a real wait call, not a timing guess.
+            'await Promise.all([target({}), yield_control("restart checkpoint")]);',
             `return "CHECKPOINT-${nextCheckpoint}";`,
           ].join("\n"),
         });


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where full release verification timed out before the first restart in `gateway-restart-inflight-run`, leaving the intended restart recovery behavior untested.

## Why This Change Was Made

The mock provider's generated Code Mode cell awaited a 30-second bridge tool directly. Code Mode drains ordinary bridge awaits within the 60-second exec deadline, so the cell completed without leaving the unfinished `wait` that the scenario requires.

Make the mock provider explicitly yield while its checkpoint tool remains pending. The existing checkpoint test now executes the generated JavaScript and proves it yields before the pending tool resolves, for all three checkpoints. No runtime changes, retries, timeout increases, or weaker scenario assertions.

## User Impact

Release verification can exercise the intended three-restart recovery flow again. There is no public runtime, configuration, persistence schema, or dependency change. The fixture has no executable line-count growth; two invariant comments are added. Tests add 25 net lines.

## Evidence

- Original failure: [release checks job](https://github.com/openclaw/openclaw/actions/runs/33230752148/job/99043149152) on `383a293b32d97254014437430b62aaf406bc11ac`.
- The new regression assertion fails against the original fixture (`yielded` is false) and passes with this change.
- All 291 tests passed across the mock provider and two scenario catalog suites. The checkpoint test passed again after test-only typing/lint corrections.
- The unchanged `gateway-restart-inflight-run` scenario passed through a freshly built private QA CLI and isolated Gateway with a mock provider: three restarts, three execs, three waits, three recovery dispatches, three retained policies, exactly one final delivery, zero resend notices, and no unsafe visible output.
- Extension and extension-test typechecks, targeted lint, formatting, and the changed-file architecture guards passed. Independent Codex autoreview reported no P0 findings.
- Inspected the pinned Codex yield contract directly in [`globals.rs`](https://github.com/openai/codex/blob/rust-v0.150.1/codex-rs/code-mode-runtime/src/runtime/globals.rs#L28), [`callbacks.rs`](https://github.com/openai/codex/blob/rust-v0.150.1/codex-rs/code-mode-runtime/src/runtime/callbacks.rs#L324), and [`cell_actor/mod.rs`](https://github.com/openai/codex/blob/rust-v0.150.1/codex-rs/code-mode-runtime/src/cell_actor/mod.rs#L371). This patch changes only the OpenClaw mock fixture.
