### PR TITLE
refactor(tests): remove redundant coverage and fixtures

### DIFF
--- a/apps/macos/Tests/OpenClawIPCTests/OnboardingViewSmokeTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/OnboardingViewSmokeTests.swift
@@ -122,23 +122,6 @@ struct OnboardingViewSmokeTests {
             requiresCLIInstall: false) == [0, 1, 9])
     }
 
-    @Test func `fresh local setup installs CLI before inference setup`() {
-        let order = OnboardingView.pageOrder(
-            for: .local,
-            requiresCLIInstall: true)
-
-        #expect(order.firstIndex(of: 2) == 2)
-        #expect(order.firstIndex(of: 3) == 3)
-    }
-
-    @Test func `configured local setup skips CLI install page`() {
-        let order = OnboardingView.pageOrder(
-            for: .local,
-            requiresCLIInstall: false)
-
-        #expect(!order.contains(2))
-    }
-
     @Test func `CLI install activates only a local gateway`() {
         #expect(!OnboardingView.shouldActivateLocalGateway(afterCLIInstallFor: .remote))
         #expect(OnboardingView.shouldActivateLocalGateway(afterCLIInstallFor: .local))

--- a/extensions/codex/src/app-server/thread-lifecycle.test.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.test.ts
@@ -2392,26 +2392,23 @@ describe("Codex app-server turn params", () => {
 });
 
 describe("Codex app-server model provider selection", () => {
-  it.each(["openai", "openai"])(
-    "omits public %s modelProvider when forwarding native Codex auth on thread/start",
-    (provider) => {
-      const request = buildThreadStartParams(
-        createAttemptParams({
-          provider,
-          authProfileId: "work",
-          runtimeExternalProfileIds: ["work"],
-        }),
-        {
-          cwd: "/repo",
-          dynamicTools: [],
-          appServer: createAppServerOptions() as never,
-          developerInstructions: "test instructions",
-        },
-      );
+  it("omits public openai modelProvider when forwarding native Codex auth on thread/start", () => {
+    const request = buildThreadStartParams(
+      createAttemptParams({
+        provider: "openai",
+        authProfileId: "work",
+        runtimeExternalProfileIds: ["work"],
+      }),
+      {
+        cwd: "/repo",
+        dynamicTools: [],
+        appServer: createAppServerOptions() as never,
+        developerInstructions: "test instructions",
+      },
+    );
 
-      expect(request).not.toHaveProperty("modelProvider");
-    },
-  );
+    expect(request).not.toHaveProperty("modelProvider");
+  });
 
   it("uses the bound native Codex auth profile when deciding thread/resume modelProvider", () => {
     const request = buildThreadResumeParams(

--- a/extensions/oc-path/src/oc-path/tests/scenarios/sentinel-guard.test.ts
+++ b/extensions/oc-path/src/oc-path/tests/scenarios/sentinel-guard.test.ts
@@ -34,13 +34,6 @@ describe("sentinel-guard", () => {
     );
   });
 
-  it("round-trip echoes pre-existing sentinel; strict mode rejects", () => {
-    const raw = "## Section\n\n- token: __OPENCLAW_REDACTED__\n";
-    const { ast } = parseMd(raw);
-    expect(emitMd(ast)).toBe(raw);
-    expect(() => emitMd(ast, { acceptPreExistingSentinel: false })).toThrow(OcEmitSentinelError);
-  });
-
   it("round-trip emit allows sentinel-free content", () => {
     const raw = "## Section\n\n- token: redacted-but-not-sentinel\n";
     const { ast } = parseMd(raw);

--- a/extensions/signal/src/client-container.test.ts
+++ b/extensions/signal/src/client-container.test.ts
@@ -1588,19 +1588,6 @@ describe("containerRestRequest edge cases", () => {
     expect(result.items[0]?.id).toBe(0);
     expect(result.items[49_999]?.id).toBe(49_999);
   });
-
-  it("returns undefined for an empty success body via the bounded reader", async () => {
-    // The bounded reader must preserve the existing empty-body -> undefined contract
-    // (no spurious JSON.parse("") throw) so well-behaved 200/empty responses are unchanged.
-    mockFetch.mockResolvedValue({
-      ok: true,
-      status: 200,
-      ...bodyStream(""),
-    });
-
-    const result = await containerRestRequest("/v1/about", { baseUrl: "http://localhost:8080" });
-    expect(result).toBeUndefined();
-  });
 });
 
 describe("streamContainerEvents", () => {

--- a/extensions/zalouser/src/text-styles-blocks.test.ts
+++ b/extensions/zalouser/src/text-styles-blocks.test.ts
@@ -67,11 +67,7 @@ describe("parseZalouserTextStyles blocks", () => {
     {
       name: "four-column bullet child becomes a nested native list",
       input: "- parent\n    - child",
-      before: {
-        text: `parent\n${"\u00A0".repeat(4)}- child`,
-        styles: [{ start: 0, len: 6, st: TextStyle.UnorderedList }],
-      },
-      after: {
+      expected: {
         text: "parent\nchild",
         styles: [
           { start: 0, len: 6, st: TextStyle.UnorderedList },
@@ -83,14 +79,7 @@ describe("parseZalouserTextStyles blocks", () => {
     {
       name: "ordered child gains parser-owned nesting",
       input: "1. parent\n   1. child",
-      before: {
-        text: "parent\nchild",
-        styles: [
-          { start: 0, len: 6, st: TextStyle.OrderedList },
-          { start: 7, len: 5, st: TextStyle.OrderedList },
-        ],
-      },
-      after: {
+      expected: {
         text: "parent\nchild",
         styles: [
           { start: 0, len: 6, st: TextStyle.OrderedList },
@@ -102,11 +91,7 @@ describe("parseZalouserTextStyles blocks", () => {
     {
       name: "wide ordered parent owns its bullet child",
       input: "10. parent\n    - child",
-      before: {
-        text: `parent\n${"\u00A0".repeat(4)}- child`,
-        styles: [{ start: 0, len: 6, st: TextStyle.OrderedList }],
-      },
-      after: {
+      expected: {
         text: "parent\nchild",
         styles: [
           { start: 0, len: 6, st: TextStyle.OrderedList },
@@ -118,11 +103,7 @@ describe("parseZalouserTextStyles blocks", () => {
     {
       name: "lazy continuation remains owned by one native item",
       input: "- parent\n  continuation",
-      before: {
-        text: "parent\n  continuation",
-        styles: [{ start: 0, len: 6, st: TextStyle.UnorderedList }],
-      },
-      after: {
+      expected: {
         text: "parent\ncontinuation",
         styles: [{ start: 0, len: 19, st: TextStyle.UnorderedList }],
       },
@@ -130,14 +111,7 @@ describe("parseZalouserTextStyles blocks", () => {
     {
       name: "loose continuation remains inside its native item",
       input: "- first\n\n  continuation\n- next",
-      before: {
-        text: "first\n\n  continuation\nnext",
-        styles: [
-          { start: 0, len: 5, st: TextStyle.UnorderedList },
-          { start: 22, len: 4, st: TextStyle.UnorderedList },
-        ],
-      },
-      after: {
+      expected: {
         text: "first\n\ncontinuation\nnext",
         styles: [
           { start: 0, len: 19, st: TextStyle.UnorderedList },
@@ -148,11 +122,7 @@ describe("parseZalouserTextStyles blocks", () => {
     {
       name: "nested task child keeps checkbox fallback without a native bullet",
       input: "- parent\n  - [ ] child",
-      before: {
-        text: "parent\n- [ ] child",
-        styles: [{ start: 0, len: 6, st: TextStyle.UnorderedList }],
-      },
-      after: {
+      expected: {
         text: "parent\n[ ] child",
         styles: [
           { start: 0, len: 6, st: TextStyle.UnorderedList },
@@ -160,9 +130,8 @@ describe("parseZalouserTextStyles blocks", () => {
         ],
       },
     },
-  ])("documents CommonMark list before and after: $name", ({ input, before, after }) => {
-    expect(before).not.toEqual(after);
-    expect(parseZalouserTextStyles(input)).toEqual(after);
+  ])("renders CommonMark lists: $name", ({ input, expected }) => {
+    expect(parseZalouserTextStyles(input)).toEqual(expected);
   });
 
   it("keeps a top-level four-space list-looking line as indented code", () => {

--- a/extensions/zalouser/src/text-styles.test.ts
+++ b/extensions/zalouser/src/text-styles.test.ts
@@ -35,8 +35,7 @@ describe("parseZalouserTextStyles", () => {
     {
       name: "resolves ambiguous triple-marker nesting with CommonMark precedence",
       input: "***foo** bar*",
-      before: { text: "***foo** bar*", styles: [] },
-      after: {
+      expected: {
         text: "foo bar",
         styles: [
           { start: 0, len: 7, st: TextStyle.Italic },
@@ -47,14 +46,10 @@ describe("parseZalouserTextStyles", () => {
     {
       name: "uses Unicode-aware underscore flanking inside words",
       input: "привет_мир_снова",
-      before: {
-        text: "приветмирснова",
-        styles: [{ start: 6, len: 3, st: TextStyle.Italic }],
-      },
-      after: { text: "привет_мир_снова", styles: [] },
+      expected: { text: "привет_мир_снова", styles: [] },
     },
-  ])("documents before and after: $name", ({ input, after }) => {
-    expect(parseZalouserTextStyles(input)).toEqual(after);
+  ])("$name", ({ input, expected }) => {
+    expect(parseZalouserTextStyles(input)).toEqual(expected);
   });
 
   it("keeps inline code and plain math markers literal", () => {

--- a/packages/ai/src/providers/openai-reasoning-effort.test.ts
+++ b/packages/ai/src/providers/openai-reasoning-effort.test.ts
@@ -28,10 +28,8 @@ describe("OpenAI reasoning effort support", () => {
     expect(resolveOpenAIReasoningEffortForModel({ model: luna, effort: "off" })).toBe("none");
   });
 
-  it.each([
-    { provider: "openai", id: "gpt-5.5" },
-    { provider: "openai", id: "gpt-5.5" },
-  ])("preserves xhigh for $provider/$id", (model) => {
+  it("preserves xhigh for openai/gpt-5.5", () => {
+    const model = { provider: "openai", id: "gpt-5.5" };
     expect(resolveOpenAISupportedReasoningEfforts(model)).toContain("xhigh");
     expect(resolveOpenAIReasoningEffortForModel({ model, effort: "xhigh" })).toBe("xhigh");
   });

--- a/scripts/audit-seams.mts
+++ b/scripts/audit-seams.mts
@@ -53,7 +53,7 @@ const testRoot = path.join(repoRoot, "test");
 const workspacePackagePaths = ["ui/package.json"];
 const MAX_SCAN_BYTES = 2 * 1024 * 1024;
 const compareStrings = (left: string, right: string) => left.localeCompare(right);
-export const HELP_TEXT = `Usage: node --import tsx scripts/audit-seams.mts [--help]
+const HELP_TEXT = `Usage: node --import tsx scripts/audit-seams.mts [--help]
 
 Audit repo seam inventory and emit JSON to stdout.
 

--- a/scripts/check-memory-fd-repro.mts
+++ b/scripts/check-memory-fd-repro.mts
@@ -488,7 +488,7 @@ function sampleFds({ label, pid, workspaceRealPath }: FdSampleOptions) {
 /**
  * Reports whether a spawned child has already exited.
  */
-export function hasChildExited(child: ChildExitState) {
+function hasChildExited(child: ChildExitState) {
   return child.exitCode !== null || child.signalCode !== null;
 }
 

--- a/src/agents/harness/selection.test.ts
+++ b/src/agents/harness/selection.test.ts
@@ -1195,15 +1195,6 @@ describe("runAgentHarnessAttempt", () => {
     expect(agentRunAttempt).not.toHaveBeenCalled();
   });
 
-  it("auto-selects a supporting plugin harness by default", async () => {
-    registerFailingCodexHarness();
-
-    await expect(runAgentHarnessAttempt(createAttemptParams())).rejects.toThrow(
-      "codex startup failed",
-    );
-    expect(agentRunAttempt).not.toHaveBeenCalled();
-  });
-
   it("projects deferred route support into the final attempt selection", async () => {
     const supports = vi.fn((ctx: Parameters<AgentHarness["supports"]>[0]) =>
       ctx.modelProvider?.preparedAuth?.source === "harness" &&
@@ -1308,21 +1299,18 @@ describe("runAgentHarnessAttempt", () => {
     expect(agentRunAttempt).not.toHaveBeenCalled();
   });
 
-  it.each(["openai", "openai"])(
-    "does not override forced Codex harness support rejection for %s",
-    (provider) => {
-      registerFailingCodexHarness();
+  it("does not override forced Codex harness support rejection for openai", () => {
+    registerFailingCodexHarness();
 
-      expect(() =>
-        selectAgentHarness({
-          provider,
-          modelId: "gpt-5.4",
-          agentHarnessRuntimeOverride: "codex",
-        }),
-      ).toThrow(`Requested agent harness "codex" does not support ${provider}/gpt-5.4`);
-      expect(agentRunAttempt).not.toHaveBeenCalled();
-    },
-  );
+    expect(() =>
+      selectAgentHarness({
+        provider: "openai",
+        modelId: "gpt-5.4",
+        agentHarnessRuntimeOverride: "codex",
+      }),
+    ).toThrow('Requested agent harness "codex" does not support openai/gpt-5.4');
+    expect(agentRunAttempt).not.toHaveBeenCalled();
+  });
 
   it("uses the Codex harness by default for OpenAI agent model runs", async () => {
     registerSuccessfulCodexHarness();

--- a/src/auto-reply/reply/agent-runner-runtime-selection.test.ts
+++ b/src/auto-reply/reply/agent-runner-runtime-selection.test.ts
@@ -48,18 +48,6 @@ describe("resolveSessionRuntimeOverrideForProvider", () => {
     ).toBeUndefined();
   });
 
-  it("keeps a locked harness pin ahead of a conflicting runtime override", () => {
-    expect(
-      resolveSessionRuntimeOverrideForProvider({
-        provider: "anthropic",
-        entry: {
-          agentHarnessId: "codex",
-          agentRuntimeOverride: "claude-cli",
-          modelSelectionLocked: true,
-        },
-      }),
-    ).toBe("codex");
-  });
   it("keeps CLI runtime pins only when the runtime serves the selected provider", () => {
     cliBackendsTesting.setDepsForTest({
       resolveRuntimeCliBackends: () => [],

--- a/src/image-generation/live-test-helpers.test.ts
+++ b/src/image-generation/live-test-helpers.test.ts
@@ -4,7 +4,6 @@ import type { OpenClawConfig } from "../config/config.js";
 import {
   parseCaseFilter,
   parseImageProviderFilter,
-  redactLiveApiKey,
   resolveConfiguredLiveImageModels,
   resolveLiveImageAuthStore,
 } from "./live-test-helpers.js";
@@ -71,12 +70,5 @@ describe("image-generation live-test helpers", () => {
         hasLiveKeys: false,
       }),
     ).toBeUndefined();
-  });
-
-  it("redacts live API keys for diagnostics", () => {
-    expect(redactLiveApiKey(undefined)).toBe("none");
-    expect(redactLiveApiKey("   ")).toBe("none");
-    expect(redactLiveApiKey("synthetic-12")).toBe("<redacted>");
-    expect(redactLiveApiKey("synthetic-credential-value")).toBe("<redacted>");
   });
 });

--- a/src/image-generation/live-test-helpers.ts
+++ b/src/image-generation/live-test-helpers.ts
@@ -4,12 +4,11 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import {
   parseLiveCsvFilter,
   parseProviderModelMap,
-  redactLiveApiKey,
   resolveConfiguredLiveProviderModels,
   resolveLiveAuthStore,
 } from "../media-generation/live-test-helpers.js";
 
-export { parseProviderModelMap, redactLiveApiKey };
+export { parseProviderModelMap };
 
 // Default provider/model matrix for image live tests. Provider env filters can
 // override these without changing test source.

--- a/src/infra/exec-wrapper-resolution.test.ts
+++ b/src/infra/exec-wrapper-resolution.test.ts
@@ -279,10 +279,6 @@ describe("unwrapKnownDispatchWrapperInvocation", () => {
       expected: { kind: "blocked", wrapper: "arch" },
     },
     {
-      argv: ["arch", "-arch", "bogus", "bash", "-lc", "echo hi"],
-      expected: { kind: "blocked", wrapper: "arch" },
-    },
-    {
       argv: ["xcrun", "--sdk", "macosx", "bash", "-lc", "echo hi"],
       expected: { kind: "blocked", wrapper: "xcrun" },
     },

--- a/src/infra/state-migrations.media-persistence.test-support.ts
+++ b/src/infra/state-migrations.media-persistence.test-support.ts
@@ -1,0 +1,65 @@
+import { requireNodeSqlite } from "./node-sqlite.js";
+
+export function readDatabaseSnapshot(databasePath: string) {
+  const { DatabaseSync } = requireNodeSqlite();
+  const database = new DatabaseSync(databasePath);
+  try {
+    const version = database.prepare("PRAGMA user_version").get() as { user_version: number };
+    const rows = database
+      .prepare(
+        "SELECT session_id,seq,event_json,created_at FROM transcript_events ORDER BY session_id,seq",
+      )
+      .all() as Array<{
+      session_id: string;
+      seq: number;
+      event_json: string;
+      created_at: number;
+    }>;
+    const identities = database
+      .prepare(
+        "SELECT session_id,event_id,seq,event_type,parent_id,message_idempotency_key,created_at FROM transcript_event_identities ORDER BY session_id,seq",
+      )
+      .all();
+    const activeBranch = database
+      .prepare(
+        "SELECT session_id,active_position,event_seq,message_position FROM session_transcript_active_events ORDER BY session_id,active_position",
+      )
+      .all();
+    const windows = database
+      .prepare(
+        "SELECT session_id,session_key,created_at,updated_at,transcript_observed_at FROM session_windows ORDER BY session_id",
+      )
+      .all();
+    const generations = database
+      .prepare(
+        "SELECT session_id,generation FROM transcript_rewrite_watermarks ORDER BY session_id",
+      )
+      .all();
+    const trajectoryCount = database
+      .prepare("SELECT count(*) AS count FROM trajectory_runtime_events")
+      .get() as { count: number };
+    const trajectoryRows = database
+      .prepare(
+        "SELECT session_id,seq,run_id,event_json,created_at FROM trajectory_runtime_events ORDER BY session_id,seq",
+      )
+      .all() as Array<{
+      session_id: string;
+      seq: number;
+      run_id: string | null;
+      event_json: string;
+      created_at: number;
+    }>;
+    return {
+      activeBranch,
+      generations,
+      identities,
+      rows,
+      trajectoryCount: trajectoryCount.count,
+      trajectoryRows,
+      version,
+      windows,
+    };
+  } finally {
+    database.close();
+  }
+}

--- a/src/infra/state-migrations.media-persistence.test.ts
+++ b/src/infra/state-migrations.media-persistence.test.ts
@@ -20,6 +20,7 @@ import {
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
 import { requireNodeSqlite } from "./node-sqlite.js";
 import { migrateLegacyMediaPersistence } from "./state-migrations.media-persistence.js";
+import { readDatabaseSnapshot } from "./state-migrations.media-persistence.test-support.js";
 
 const tempDirs: string[] = [];
 const PREVIOUS_VERSION = 16;
@@ -116,70 +117,6 @@ function createLegacyDatabaseFixture(params: {
     schemaVersion,
   });
   return databasePath;
-}
-
-function readDatabaseSnapshot(databasePath: string) {
-  const { DatabaseSync } = requireNodeSqlite();
-  const database = new DatabaseSync(databasePath);
-  try {
-    const version = database.prepare("PRAGMA user_version").get() as { user_version: number };
-    const rows = database
-      .prepare(
-        "SELECT session_id,seq,event_json,created_at FROM transcript_events ORDER BY session_id,seq",
-      )
-      .all() as Array<{
-      session_id: string;
-      seq: number;
-      event_json: string;
-      created_at: number;
-    }>;
-    const identities = database
-      .prepare(
-        "SELECT session_id,event_id,seq,event_type,parent_id,message_idempotency_key,created_at FROM transcript_event_identities ORDER BY session_id,seq",
-      )
-      .all();
-    const activeBranch = database
-      .prepare(
-        "SELECT session_id,active_position,event_seq,message_position FROM session_transcript_active_events ORDER BY session_id,active_position",
-      )
-      .all();
-    const windows = database
-      .prepare(
-        "SELECT session_id,session_key,created_at,updated_at,transcript_observed_at FROM session_windows ORDER BY session_id",
-      )
-      .all();
-    const generations = database
-      .prepare(
-        "SELECT session_id,generation FROM transcript_rewrite_watermarks ORDER BY session_id",
-      )
-      .all();
-    const trajectoryCount = database
-      .prepare("SELECT count(*) AS count FROM trajectory_runtime_events")
-      .get() as { count: number };
-    const trajectoryRows = database
-      .prepare(
-        "SELECT session_id,seq,run_id,event_json,created_at FROM trajectory_runtime_events ORDER BY session_id,seq",
-      )
-      .all() as Array<{
-      session_id: string;
-      seq: number;
-      run_id: string | null;
-      event_json: string;
-      created_at: number;
-    }>;
-    return {
-      activeBranch,
-      generations,
-      identities,
-      rows,
-      trajectoryCount: trajectoryCount.count,
-      trajectoryRows,
-      version,
-      windows,
-    };
-  } finally {
-    database.close();
-  }
 }
 
 function writeArchive(filePath: string, events: FixtureEvent[], compressed: boolean): void {

--- a/src/media-generation/live-test-helpers.test.ts
+++ b/src/media-generation/live-test-helpers.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from "vitest";
+import { redactLiveApiKey } from "./live-test-helpers.js";
+
+describe("media-generation live-test helpers", () => {
+  it("redacts live API keys for diagnostics", () => {
+    expect(redactLiveApiKey(undefined)).toBe("none");
+    expect(redactLiveApiKey("   ")).toBe("none");
+    expect(redactLiveApiKey("synthetic-12")).toBe("<redacted>");
+    expect(redactLiveApiKey("synthetic-credential-value")).toBe("<redacted>");
+  });
+});

--- a/src/plugins/channel-plugin-ids.test.ts
+++ b/src/plugins/channel-plugin-ids.test.ts
@@ -1538,7 +1538,7 @@ describe("resolveGatewayStartupPluginIdsFromRegistry", () => {
     });
   });
 
-  it("does not ambient-start source-discovered external plugins from onStartup alone", () => {
+  it("does not ambient-start external startup or hook-capability plugins", () => {
     expectStartupPluginIds({
       config: createStartupConfig({
         noConfiguredChannels: true,
@@ -1616,14 +1616,6 @@ describe("resolveGatewayStartupPluginIdsFromRegistry", () => {
   });
 
   it("loads startup-lazy bundled plugins only when their activation config is present", () => {
-    expectStartupPluginIds({
-      config: createStartupConfig({
-        noConfiguredChannels: true,
-        memorySlot: "none",
-      }),
-      expected: ["browser"],
-    });
-
     expectStartupPluginIds({
       config: {
         channels: {},
@@ -1766,16 +1758,6 @@ describe("resolveGatewayStartupPluginIdsFromRegistry", () => {
         memorySlot: "none",
       }),
       expected: ["external-hook-capability"],
-    });
-  });
-
-  it("does not ambient-load hook-capability plugins at startup", () => {
-    expectStartupPluginIds({
-      config: createStartupConfig({
-        noConfiguredChannels: true,
-        memorySlot: "none",
-      }),
-      expected: ["browser"],
     });
   });
 

--- a/src/video-generation/live-test-helpers.test.ts
+++ b/src/video-generation/live-test-helpers.test.ts
@@ -6,7 +6,6 @@ import {
   canRunBufferBackedVideoToVideoLiveLane,
   parseVideoProviderFilter,
   parseProviderModelMap,
-  redactLiveApiKey,
   resolveConfiguredLiveVideoModels,
   resolveLiveVideoAuthStore,
   resolveLiveVideoResolution,
@@ -87,13 +86,6 @@ describe("video-generation live-test helpers", () => {
         hasLiveKeys: false,
       }),
     ).toBeUndefined();
-  });
-
-  it("redacts live API keys for diagnostics", () => {
-    expect(redactLiveApiKey(undefined)).toBe("none");
-    expect(redactLiveApiKey("   ")).toBe("none");
-    expect(redactLiveApiKey("synthetic-12")).toBe("<redacted>");
-    expect(redactLiveApiKey("synthetic-credential-value")).toBe("<redacted>");
   });
 
   it("runs buffer-backed video-to-video only for supported providers/models", () => {

--- a/src/video-generation/live-test-helpers.ts
+++ b/src/video-generation/live-test-helpers.ts
@@ -4,12 +4,11 @@ import type { OpenClawConfig } from "../config/types.js";
 import {
   parseLiveCsvFilter,
   parseProviderModelMap,
-  redactLiveApiKey,
   resolveConfiguredLiveProviderModels,
   resolveLiveAuthStore,
 } from "../media-generation/live-test-helpers.js";
 
-export { parseProviderModelMap, redactLiveApiKey };
+export { parseProviderModelMap };
 
 // Default provider/model matrix for video live tests. Env/config filters can
 // override this without editing the live test source.

--- a/test/scripts/audit-seams.test.ts
+++ b/test/scripts/audit-seams.test.ts
@@ -1,10 +1,6 @@
 // Audit Seams tests cover audit seams script behavior.
 import { describe, expect, it } from "vitest";
-import {
-  HELP_TEXT,
-  describeSeamKinds,
-  determineSeamTestStatus,
-} from "../../scripts/audit-seams.mts";
+import { describeSeamKinds, determineSeamTestStatus } from "../../scripts/audit-seams.mts";
 
 describe("audit-seams cron seam classification", () => {
   it("detects cron agent handoff and outbound delivery boundaries", () => {
@@ -134,7 +130,7 @@ describe("audit-seams subagent seam classification", () => {
   });
 });
 
-describe("audit-seams status/help", () => {
+describe("audit-seams status", () => {
   it("keeps cron seam statuses conservative when nearby tests exist", () => {
     expect(
       determineSeamTestStatus(
@@ -164,12 +160,5 @@ describe("audit-seams status/help", () => {
       reason:
         "Nearby tests exist (best match: direct-import), but this inventory does not prove cross-layer seam coverage end to end.",
     });
-  });
-
-  it("documents cron and subagent seam coverage in help text", () => {
-    expect(HELP_TEXT).toContain("cron orchestration seams");
-    expect(HELP_TEXT).toContain("subagent seams");
-    expect(HELP_TEXT).toContain("announce delivery");
-    expect(HELP_TEXT).toContain("parent streaming");
   });
 });

--- a/test/scripts/check-memory-fd-repro.test.ts
+++ b/test/scripts/check-memory-fd-repro.test.ts
@@ -10,7 +10,6 @@ import {
   GATEWAY_READY_OUTPUT_MAX_CHARS,
   MEMORY_SEARCH_PROBE_QUERY,
   classifyMemorySearchInvokeResponse,
-  hasChildExited,
   invokeMemorySearch,
   parseArgs,
   stopGatewayWithRuntime,
@@ -263,34 +262,22 @@ describe("check-memory-fd-repro", () => {
     });
   });
 
-  it("treats signaled gateway children as exited", () => {
-    expect(hasChildExited({ exitCode: null, signalCode: "SIGTERM" })).toBe(true);
-    expect(hasChildExited({ exitCode: 0, signalCode: null })).toBe(true);
-    expect(hasChildExited({ exitCode: null, signalCode: null })).toBe(false);
-  });
-
-  it("fails gateway readiness immediately after signal exits", async () => {
+  it.each([
+    { exitCode: null, signalCode: "SIGTERM" },
+    { exitCode: 0, signalCode: null },
+  ])("rejects readiness and skips signaling for an exited child (%j)", async (exitState) => {
     const child = {
-      exitCode: null,
-      signalCode: "SIGTERM",
+      ...exitState,
+      kill: vi.fn(),
       stderr: new EventEmitter(),
       stdout: new EventEmitter(),
-    };
-
-    await expect(
-      waitForGatewayReady({ child, port: 9, logPath: "gateway.log", timeoutMs: 10_000 }),
-    ).rejects.toThrow("gateway exited before ready");
-  });
-
-  it("does not signal already exited children during gateway cleanup", async () => {
-    const child = {
-      exitCode: null,
-      kill: vi.fn(),
-      signalCode: "SIGTERM",
     };
     const findGatewayPidFn = vi.fn(() => null);
     const killProcess = vi.fn();
 
+    await expect(
+      waitForGatewayReady({ child, port: 9, logPath: "gateway.log", timeoutMs: 10_000 }),
+    ).rejects.toThrow("gateway exited before ready");
     await expect(
       stopGatewayWithRuntime({ child, findGatewayPidFn, killProcess, port: 9 }),
     ).resolves.toBeUndefined();

--- a/test/scripts/telegram-e2e-userbot-skill.test.ts
+++ b/test/scripts/telegram-e2e-userbot-skill.test.ts
@@ -18,10 +18,6 @@ function requireSuccess(command: string, args: string[]) {
 }
 
 describe("repository Telegram E2E skill", () => {
-  it("replaces the obsolete Telegram Crabbox recorder skill", () => {
-    expect(fs.existsSync(".agents/skills/telegram-crabbox-e2e-proof")).toBe(false);
-  });
-
   it("registers its UI metadata through the skill interface", () => {
     const descriptor = parse(
       fs.readFileSync(".agents/skills/telegram-e2e-userbot/agents/openai.yaml", "utf8"),

--- a/ui/src/lib/channels/index.test.ts
+++ b/ui/src/lib/channels/index.test.ts
@@ -309,29 +309,6 @@ describe("channels controller WhatsApp logout", () => {
     expect(channels.state.whatsappBusy).toBe(false);
     channels.dispose();
   });
-
-  it("reports a Gateway failure without discarding login state", async () => {
-    const request = vi.fn(async (method: string) => {
-      if (method === "channels.logout") {
-        throw new Error("credential cleanup failed");
-      }
-      return createChannelsSnapshot("refreshed");
-    });
-    const channels = createChannelCapability({
-      snapshot: { client: { request }, phase: "connected" },
-      subscribe: () => () => undefined,
-    } as never);
-    channels.state.whatsappLoginQrDataUrl = "data:image/png;base64,current-qr";
-    channels.state.whatsappLoginConnected = true;
-
-    await channels.logoutWhatsApp();
-
-    expect(channels.state.whatsappLoginMessage).toBe("credential cleanup failed");
-    expect(channels.state.whatsappLoginQrDataUrl).toBe("data:image/png;base64,current-qr");
-    expect(channels.state.whatsappLoginConnected).toBe(true);
-    expect(request.mock.calls.filter(([method]) => method === "channels.status")).toHaveLength(0);
-    channels.dispose();
-  });
 });
 
 describe("channels controller WhatsApp mutation failures", () => {
@@ -342,22 +319,25 @@ describe("channels controller WhatsApp mutation failures", () => {
       invoke: (channels: ReturnType<typeof createChannelCapability>) =>
         channels.startWhatsApp(false),
       preservesQr: false,
+      connected: null,
     },
     {
       operation: "scan wait",
       method: "web.login.wait",
       invoke: (channels: ReturnType<typeof createChannelCapability>) => channels.waitWhatsApp(),
       preservesQr: true,
+      connected: null,
     },
     {
       operation: "logout",
       method: "channels.logout",
       invoke: (channels: ReturnType<typeof createChannelCapability>) => channels.logoutWhatsApp(),
       preservesQr: true,
+      connected: true,
     },
   ])(
     "publishes a rejected $operation without probing channel status",
-    async ({ method, invoke, preservesQr }) => {
+    async ({ method, invoke, preservesQr, connected }) => {
       const request = vi.fn(async (requestedMethod: string) => {
         if (requestedMethod === method) {
           throw new Error("WhatsApp request rejected");
@@ -384,6 +364,7 @@ describe("channels controller WhatsApp mutation failures", () => {
       expect(channels.state.whatsappLoginQrDataUrl).toBe(
         preservesQr ? "data:image/png;base64,current-qr" : null,
       );
+      expect(channels.state.whatsappLoginConnected).toBe(connected);
       channels.dispose();
     },
   );


### PR DESCRIPTION
Merged as `d8306367e04e993c4c624d69daae7b78dcf02dee`. The landed cleanup is 22 files, net -178 lines: main independently absorbed the byte-identical snapshot-helper extraction in #132444 before this PR merged. Both the full recovery CI and final PR CI attempt passed.

## What Problem This Solves

The test suite contains identical cases, duplicate table rows, obsolete before/after fixtures, and assertions that compare fixtures without exercising behavior. This maintainer-requested cleanup removes that noise while preserving distinct behavior and failure coverage.

## Why This Change Was Made

Consolidate repeated assertions at their owning boundary: credential redaction is tested once in the shared media helper; child exit states are exercised through readiness and cleanup; WhatsApp failure cases retain connection-state assertions in the existing operation table. Remove only proven duplicates elsewhere, keeping security, package, platform, timing, and provider contracts.

Reviewed branch delta: 24 files, net -176 lines. Non-test tooling/support: +4/-6; tests and test fixtures: +135/-309, including a pure helper move. The only non-test edits remove unused test-only exports; no runtime behavior changes. The original cleanup's stable patch ID remains unchanged.

Hosted CI also found that main's new large-timestamp regression (#132099) pushed the media migration suite to 1,034 counted lines. Move its existing database snapshot reader unchanged into adjacent test-support. Every test body, SQL query, ordering, return field, type, and cleanup behavior is preserved; no limit increase or regression removal.

## User Impact

No user-visible behavior changes. Maintainers get less redundant coverage with the same protected outcomes. No configuration, persistent-store schema, dependency, or public SDK contract changes.

## Evidence

- Final head `0a67062312f8bfca2fc0687daae4cf7aa8a02e63`: 1,136 focused tests passed in 24 files across 14 routed Vitest shards (64.32 seconds).
- Final-head migration/inventory proof: 41 tests in 9 files / 3 shards passed (42.96 seconds), including main's new large-timestamp regression. The snapshot helper and all remaining test bytes were compared directly before/after.
- The exact max-lines rule fails on main's merged source before extraction (1,034 lines) and passes after. All 20 selected extraction checks passed, including the core test typecheck, dead-export checks, ratchets, formatting and lint; full-config focused lint passed again after rebase.
- Inherited fixture fix: all 82 main-refresh/wrapper/review tests passed on the unchanged fixture/wrapper sources; an isolated PATH without host rg also passed.
- Patch-identical cleanup proof: 545 macOS CI tests in 15 files / 7 shards, plus 29 native onboarding tests with `swift test --package-path apps/macos --build-system native --filter OnboardingViewSmokeTests`.
- All 39 original selected `check-changed` commands passed across the main run and environment-corrected retries. Local dependency links and pinned SwiftLint were corrected without source workarounds. This does not claim one uninterrupted gate invocation passed.
- Fresh Codex autoreview found no actionable findings at its default P0 threshold. Mechanical rebases preserve the reviewed cleanup and helper extraction.
- Final duplicate-row scan covered 11,802 TypeScript test files and 11,737 literal tables, with no remaining exact duplicate rows. Pattern scans identify candidates; this does not claim every test received full manual review.

Direct upstream Codex contract inspection used commit `2181224dad147a9ed37e698b66487aba54acdb65`: `codex-rs/app-server/src/request_processors/thread_processor.rs:1604-1622` forwards optional `model_provider`, while `codex-rs/core/src/config/mod.rs:3713-3715` retains the configured/default provider. Retained tests cover provider omission and startup-error propagation. No Codex protocol behavior changed.

## CI Recovery

Four existing base issues surfaced during hosted proof and were independently repaired on main while this PR was being validated:

- #132406 repaired stale Gateway send-account expectations exposed by the first run. We reproduced both failures and verified all 128 Gateway tests plus 37 account-routing/delivery tests. The stale expectation followed #132226 (`c3ff7f98d58e`, authored and merged by @steipete). Remote delegation still preserves omitted account inputs.
- #132357 repaired Swift build-cache reuse across incompatible dependency graphs. The failed runner restored v4 state containing a removed SubprocessSpan trait. The branch inherits package-graph-specific v5 cache keys.
- #132338 supplied the missing `rg` command prerequisite in the PR-main-refresh fixture introduced by #132274 (`e7a7127c9127`, authored and merged by @steipete). An isolated PATH reproduction failed before and passes with the inherited fix. Production prerequisite enforcement remains unchanged.
- #132394 corrected the lint-suppression inventory after #132399 added a second QA credential-redaction boundary. The old inventory reproduced 1 failure/3 passes; the correction passed 100 lint/QA boundary tests (one pre-existing skip), all 14 changed checks, and fresh review. The production suppressions remain necessary because raw candidate CLI errors can carry credentials.

These repairs are inherited from main, not additional changes in this PR. Redundant local corrections were dropped when the overlaps caused actual conflicts. The final GitHub merge ref was verified to include the exact current head before dispatch.

Exact-head hosted CI: [run 33240802628](https://github.com/openclaw/openclaw/actions/runs/33240802628), completed successfully on the final head, including `openclaw/ci-gate`. Repository-native recovery uses the existing GitHub-hosted route after a Blacksmith macOS job remained unassigned. No global runner configuration changed. Authenticated live-provider/channel proof is not applicable to this internal test cleanup.

The duplicate PR run had remained queued on an unassigned macOS runner. Cancelling it after the successful recovery run published a failed PR-specific aggregate, which the native wrapper correctly refused. Rerunning only the cancelled macOS lane used the workflow's built-in GitHub-hosted retry route; [PR CI attempt 2](https://github.com/openclaw/openclaw/actions/runs/33240780648/attempts/2) and its required gate then passed. Native prepare and merge completed without a gate bypass.

Tooling follow-up: the native merge advisory watcher should recognize accepted exact-head recovery runs while preserving direct required-check authority. No workflow or merge-tool changes are included here.
