### PR TITLE
test: advance mocked Copilot device auth polls virtually

### DIFF
--- a/extensions/github-copilot/index.test.ts
+++ b/extensions/github-copilot/index.test.ts
@@ -78,6 +78,7 @@ type GithubCopilotTestModelCatalogProvider = {
 };
 
 afterEach(async () => {
+  vi.useRealTimers();
   vi.clearAllMocks();
   vi.unstubAllGlobals();
   mocks.fetchWithSsrFGuard.mockImplementation(async (params) => ({
@@ -93,6 +94,29 @@ afterAll(() => {
   vi.doUnmock("./register.runtime.js");
   vi.resetModules();
 });
+
+async function runDeviceAuthWithFakeTimers<T>(
+  run: (openUrl: (url: string) => Promise<void>) => T | Promise<T>,
+): Promise<T> {
+  vi.useFakeTimers();
+  try {
+    let notifyDeviceCodeShown!: () => void;
+    const deviceCodeShown = new Promise<void>((resolve) => {
+      notifyDeviceCodeShown = resolve;
+    });
+    const pending = Promise.resolve(run(async () => notifyDeviceCodeShown()));
+    const openedBeforeCompletion = await Promise.race([
+      deviceCodeShown.then(() => true),
+      pending.then(() => false),
+    ]);
+    expect(openedBeforeCompletion).toBe(true);
+    // Browser handoff follows the profile, device-code, and prompt work.
+    await vi.advanceTimersByTimeAsync(1_000);
+    return await pending;
+  } finally {
+    vi.useRealTimers();
+  }
+}
 
 async function createAgentDir() {
   const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-github-copilot-test-"));
@@ -1344,20 +1368,22 @@ describe("github-copilot plugin", () => {
     });
 
     try {
-      const result = await method.run({
-        config: {},
-        env: {},
-        agentDir,
-        workspaceDir: "/tmp/workspace",
-        prompter,
-        runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
-        opts: {},
-        secretInputMode: "plaintext",
-        allowSecretRefPrompt: false,
-        isRemote: false,
-        openUrl: vi.fn(),
-        oauth: { createVpsAwareHandlers: vi.fn() },
-      } as never);
+      const result = await runDeviceAuthWithFakeTimers((openUrl) =>
+        method.run({
+          config: {},
+          env: {},
+          agentDir,
+          workspaceDir: "/tmp/workspace",
+          prompter,
+          runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
+          opts: {},
+          secretInputMode: "plaintext",
+          allowSecretRefPrompt: false,
+          isRemote: false,
+          openUrl,
+          oauth: { createVpsAwareHandlers: vi.fn() },
+        } as never),
+      );
 
       expect(prompter.confirm).toHaveBeenCalledWith({
         message: "GitHub Copilot auth already exists. Re-run login?",
@@ -1413,11 +1439,13 @@ describe("github-copilot plugin", () => {
     });
   }
 
-  async function withTty<T>(fn: () => Promise<T>): Promise<T> {
+  async function runDeviceAuthWithTty<T>(
+    fn: (openUrl: (url: string) => Promise<void>) => Promise<T>,
+  ): Promise<T> {
     const isTtyDescriptor = Object.getOwnPropertyDescriptor(process.stdin, "isTTY");
     Object.defineProperty(process.stdin, "isTTY", { configurable: true, value: true });
     try {
-      return await fn();
+      return await runDeviceAuthWithFakeTimers(fn);
     } finally {
       vi.unstubAllGlobals();
       if (isTtyDescriptor) {
@@ -1446,8 +1474,8 @@ describe("github-copilot plugin", () => {
       note: vi.fn(),
     };
 
-    const result = await withTty(
-      async () =>
+    const result = await runDeviceAuthWithTty(
+      async (openUrl) =>
         await method.run({
           config: {
             models: {
@@ -1463,7 +1491,7 @@ describe("github-copilot plugin", () => {
           secretInputMode: "plaintext",
           allowSecretRefPrompt: false,
           isRemote: false,
-          openUrl: vi.fn(),
+          openUrl,
           oauth: { createVpsAwareHandlers: vi.fn() },
         } as never),
     );
@@ -1506,8 +1534,8 @@ describe("github-copilot plugin", () => {
       note: vi.fn(),
     };
 
-    const result = await withTty(
-      async () =>
+    const result = await runDeviceAuthWithTty(
+      async (openUrl) =>
         await method.run({
           config: {},
           env: {},
@@ -1519,7 +1547,7 @@ describe("github-copilot plugin", () => {
           secretInputMode: "plaintext",
           allowSecretRefPrompt: false,
           isRemote: false,
-          openUrl: vi.fn(),
+          openUrl,
           oauth: { createVpsAwareHandlers: vi.fn() },
         } as never),
     );
@@ -1564,8 +1592,8 @@ describe("github-copilot plugin", () => {
       note: vi.fn(),
     };
 
-    const result = await withTty(
-      async () =>
+    const result = await runDeviceAuthWithTty(
+      async (openUrl) =>
         await method.run({
           config: {},
           env: { COPILOT_GITHUB_DOMAIN: "acme.ghe.com" },
@@ -1577,7 +1605,7 @@ describe("github-copilot plugin", () => {
           secretInputMode: "plaintext",
           allowSecretRefPrompt: false,
           isRemote: false,
-          openUrl: vi.fn(),
+          openUrl,
           oauth: { createVpsAwareHandlers: vi.fn() },
         } as never),
     );
@@ -1669,8 +1697,8 @@ describe("github-copilot plugin", () => {
       note: vi.fn(),
     };
 
-    const result = await withTty(
-      async () =>
+    const result = await runDeviceAuthWithTty(
+      async (openUrl) =>
         await method.run({
           config: {},
           env: { COPILOT_GITHUB_DOMAIN: "env-tenant.ghe.com" },
@@ -1682,7 +1710,7 @@ describe("github-copilot plugin", () => {
           secretInputMode: "plaintext",
           allowSecretRefPrompt: false,
           isRemote: false,
-          openUrl: vi.fn(),
+          openUrl,
           oauth: { createVpsAwareHandlers: vi.fn() },
         } as never),
     );

--- a/src/plugin-sdk/test-helpers/provider-auth-contract.ts
+++ b/src/plugin-sdk/test-helpers/provider-auth-contract.ts
@@ -314,6 +314,29 @@ export function describeGithubCopilotProviderAuthContract(
       return requireProvider(await registerProviders(githubCopilotPlugin), "github-copilot");
     }
 
+    async function runDeviceAuthWithFakeTimers<T>(
+      run: () => T | Promise<T>,
+      openUrl: (url: string) => Promise<void>,
+    ): Promise<T> {
+      vi.useFakeTimers();
+      try {
+        const deviceCodeShown = new Promise<void>((resolve) => {
+          vi.mocked(openUrl).mockImplementation(async () => resolve());
+        });
+        const pending = Promise.resolve(run());
+        const openedBeforeCompletion = await Promise.race([
+          deviceCodeShown.then(() => true),
+          pending.then(() => false),
+        ]);
+        expect(openedBeforeCompletion).toBe(true);
+        // Browser handoff follows the profile, device-code, and prompt work.
+        await vi.advanceTimersByTimeAsync(1_000);
+        return await pending;
+      } finally {
+        vi.useRealTimers();
+      }
+    }
+
     function buildCopilotSetupResponse(target: string): Response | undefined {
       if (target === "https://api.github.com/copilot_internal/user") {
         return new Response(
@@ -461,6 +484,7 @@ export function describeGithubCopilotProviderAuthContract(
     }
 
     afterEach(() => {
+      vi.useRealTimers();
       vi.unstubAllGlobals();
     });
 
@@ -469,7 +493,10 @@ export function describeGithubCopilotProviderAuthContract(
       stubGitHubDeviceFlowFetch({ accessToken: "github-device-token" });
       const ctx = buildSpyAuthContext();
 
-      const result = await provider.auth[0]?.run(ctx as never);
+      const result = await runDeviceAuthWithFakeTimers(
+        () => provider.auth[0]?.run(ctx as never),
+        ctx.openUrl,
+      );
 
       expect(result).toEqual({
         profiles: [
@@ -495,7 +522,7 @@ export function describeGithubCopilotProviderAuthContract(
       stubGitHubDeviceFlowFetch({ accessToken: "github-device-token" });
       const ctx = buildSpyAuthContext();
 
-      await provider.auth[0]?.run(ctx as never);
+      await runDeviceAuthWithFakeTimers(() => provider.auth[0]?.run(ctx as never), ctx.openUrl);
 
       expect(ctx.openUrl).toHaveBeenCalledWith("https://github.com/login/device");
       const noteCalls = (ctx.prompter.note as ReturnType<typeof vi.fn>).mock.calls;
@@ -520,7 +547,10 @@ export function describeGithubCopilotProviderAuthContract(
       const ctx = buildSpyAuthContext();
 
       try {
-        const result = await provider.auth[0]?.run(ctx as never);
+        const result = await runDeviceAuthWithFakeTimers(
+          () => provider.auth[0]?.run(ctx as never),
+          ctx.openUrl,
+        );
         expect(result?.profiles).toEqual([
           {
             profileId: "github-copilot:github",
@@ -545,7 +575,10 @@ export function describeGithubCopilotProviderAuthContract(
       stubGitHubDeviceFlowFetch({ error: "access_denied" });
       const ctx = buildSpyAuthContext();
 
-      const result = await provider.auth[0]?.run(ctx as never);
+      const result = await runDeviceAuthWithFakeTimers(
+        () => provider.auth[0]?.run(ctx as never),
+        ctx.openUrl,
+      );
 
       expect(result).toEqual({ profiles: [] });
       const noteCalls = (ctx.prompter.note as ReturnType<typeof vi.fn>).mock.calls;
@@ -559,7 +592,10 @@ export function describeGithubCopilotProviderAuthContract(
       stubGitHubDeviceFlowFetch({ error: "expired_token" });
       const ctx = buildSpyAuthContext();
 
-      const result = await provider.auth[0]?.run(ctx as never);
+      const result = await runDeviceAuthWithFakeTimers(
+        () => provider.auth[0]?.run(ctx as never),
+        ctx.openUrl,
+      );
 
       expect(result).toEqual({ profiles: [] });
       const noteCalls = (ctx.prompter.note as ReturnType<typeof vi.fn>).mock.calls;


### PR DESCRIPTION
## What Problem This Solves

Ten device-auth cases wait a real second for the initial OAuth poll even though every HTTP response is a fixture. Together, those waits add about ten seconds of test execution.

## Why This Change Was Made

Use Vitest's existing fake clock for these cases. Wait for the public browser handoff before advancing one second: profile lookup, lazy login loading, device-code parsing, and prompt work must finish first. Early completion or rejection cannot silently bypass that handoff. Restore timers in both the helper and owning cleanup hook.

All credential, configured-tenant, browser-hook, cancellation, and expiry assertions remain. Dedicated login tests continue to own polling and backoff semantics. The shared helper's change is scoped to its Copilot contract, with the OpenAI contract checked as a sibling.

## User Impact

The two affected files' test execution fell from **9.296s + 5.10s to 4.276s + 0.060s** locally. This is measured test execution, not a claim about full-suite wall time. No production, public SDK, configuration, worker-count, selection, or sharding changes. Test/support LOC +97/-33; production +0/-0.

## Evidence

- All 56 cases passed before and after. A final run passed all **77 cases** across Copilot index, provider-auth contract, device-flow login, and the sibling OpenAI provider-auth contract.
- Command: `node scripts/run-vitest.mjs extensions/github-copilot/index.test.ts extensions/github-copilot/provider-auth.contract.test.ts extensions/github-copilot/login.test.ts extensions/openai/provider-auth.contract.test.ts`.
- The repeated final run kept the affected suites at 4.247s and 0.095s. The login suite retains real owner logic with controlled response fixtures for timing, cumulative slow-down, HTTP errors, and oversized bodies.
- Independent review and fresh Codex autoreview found no actionable findings. Source inspection covered the registration/auth flow, login polling owner, shared contract and sibling cases, and installed Vitest clock semantics. Formatting and whitespace checks passed.
- No live GitHub login or external provider request was performed; this changes existing mocked tests only. Exact-head hosted CI and Linux changed-file checks must pass before landing.

Final gates: Linux changed checks passed and the one-shot Testbox was stopped. A mechanical rebase incorporates the shared gateway account-expectation correction in #132406; the Copilot patch and owner surfaces are unchanged. [Refreshed exact-head CI](https://github.com/openclaw/openclaw/actions/runs/33237993208) passed.
