### PR TITLE
fix(codex): force bounded settlement when a terminal turn notification stalls

### DIFF
--- a/extensions/codex/src/app-server/attempt-timeouts.ts
+++ b/extensions/codex/src/app-server/attempt-timeouts.ts
@@ -22,6 +22,9 @@ const CODEX_TURN_TERMINAL_IDLE_TIMEOUT_MS = 30 * 60_000;
 // Terminal receipt must still reach settlement; force a bounded abort if the
 // handler tail stalls, or the session can remain active forever.
 export const TURN_TERMINAL_SETTLEMENT_IDLE_TIMEOUT_MS = 2 * 60_000;
+// Aborted/timed-out completions still join queued projection work; this grace
+// bounds a blocked handler tail so finalization cannot hang forever.
+export const TURN_FINALIZE_DRAIN_ABORT_GRACE_MS = 5_000;
 
 type CodexAppServerStartupErrorReason = "aborted" | "timed_out";
 

--- a/extensions/codex/src/app-server/attempt-timeouts.ts
+++ b/extensions/codex/src/app-server/attempt-timeouts.ts
@@ -19,6 +19,9 @@ const CODEX_POST_TOOL_RAW_ASSISTANT_COMPLETION_IDLE_TIMEOUT_MS = 5 * 60_000;
 export const CODEX_POST_REASONING_REPLY_IDLE_TIMEOUT_MS = 5 * 60_000;
 /** Long terminal idle watch for app-server turns that never send completion. */
 const CODEX_TURN_TERMINAL_IDLE_TIMEOUT_MS = 30 * 60_000;
+// Terminal receipt must still reach settlement; force a bounded abort if the
+// handler tail stalls, or the session can remain active forever.
+export const TURN_TERMINAL_SETTLEMENT_IDLE_TIMEOUT_MS = 2 * 60_000;
 
 type CodexAppServerStartupErrorReason = "aborted" | "timed_out";
 

--- a/extensions/codex/src/app-server/attempt-turn-watches.test.ts
+++ b/extensions/codex/src/app-server/attempt-turn-watches.test.ts
@@ -177,6 +177,103 @@ describe("Codex app-server attempt turn watches", () => {
     expect(harness.abortController.signal.aborted).toBe(false);
   });
 
+  it.each([
+    { terminalTimeoutMs: 30 * 60_000, settlementTimeoutMs: 2 * 60_000 },
+    { terminalTimeoutMs: 10, settlementTimeoutMs: 10 },
+  ])(
+    "aborts unsettled terminal delivery within $settlementTimeoutMs ms (terminal budget $terminalTimeoutMs)",
+    ({ terminalTimeoutMs, settlementTimeoutMs }) => {
+      const harness = createController({ turnTerminalIdleTimeoutMs: terminalTimeoutMs });
+      harness.controller.armTerminalIdleWatch();
+      harness.controller.touchActivity("turn:start", { arm: true });
+      vi.advanceTimersByTime(5);
+
+      harness.terminalQueued = true;
+      harness.controller.noteNotificationReceived("turn/completed");
+      vi.advanceTimersByTime(settlementTimeoutMs - 1);
+      expect(harness.timeouts).toEqual([]);
+
+      vi.advanceTimersByTime(1);
+      expect(harness.timeouts).toMatchObject([
+        {
+          kind: "terminal",
+          idleMs: settlementTimeoutMs,
+          timeoutMs: settlementTimeoutMs,
+          details: { terminalTurnNotificationQueued: true },
+        },
+      ]);
+      expect(harness.abortController.signal.reason).toBe("turn_terminal_idle_timeout");
+    },
+  );
+
+  it.each(["activeRequests", "activeFinalizationHooks"] as const)(
+    "defers queued terminal settlement while %s owns the quiet window",
+    (counter) => {
+      const harness = createController({ turnTerminalIdleTimeoutMs: 3 * 60_000 });
+      harness.controller.armTerminalIdleWatch();
+      harness[counter] = 1;
+      harness.terminalQueued = true;
+      harness.controller.noteNotificationReceived("turn/completed");
+      vi.advanceTimersByTime(2 * 60_000 + 1);
+
+      expect(harness.timeouts).toEqual([]);
+      expect(harness.abortController.signal.aborted).toBe(false);
+
+      harness[counter] = 0;
+      harness.controller.touchActivity(`${counter}:settled`);
+      vi.advanceTimersByTime(2 * 60_000 - 1);
+      expect(harness.timeouts).toEqual([]);
+
+      vi.advanceTimersByTime(1);
+      expect(harness.timeouts).toMatchObject([
+        {
+          kind: "terminal",
+          idleMs: 2 * 60_000,
+          timeoutMs: 2 * 60_000,
+          details: { terminalTurnNotificationQueued: true },
+        },
+      ]);
+      expect(harness.abortController.signal.reason).toBe("turn_terminal_idle_timeout");
+    },
+  );
+
+  it("does not abort terminal delivery that completes within the settlement window", () => {
+    const isCompleted = vi.fn(() => false);
+    const harness = createController({ isCompleted });
+    harness.controller.armTerminalIdleWatch();
+    harness.terminalQueued = true;
+    harness.controller.noteNotificationReceived("turn/completed");
+    vi.advanceTimersByTime(9);
+
+    isCompleted.mockReturnValue(true);
+    vi.advanceTimersByTime(20);
+
+    expect(harness.timeouts).toEqual([]);
+    expect(harness.abortController.signal.aborted).toBe(false);
+  });
+
+  it("aborts at the absolute idle budget when a queued terminal hook never settles", () => {
+    const harness = createController({ turnTerminalIdleTimeoutMs: 10 });
+    harness.controller.armTerminalIdleWatch();
+    harness.activeFinalizationHooks = 1;
+    harness.terminalQueued = true;
+    harness.controller.noteNotificationReceived("turn/completed");
+    vi.advanceTimersByTime(9);
+    expect(harness.timeouts).toEqual([]);
+
+    vi.advanceTimersByTime(1);
+
+    expect(harness.timeouts).toMatchObject([
+      {
+        kind: "terminal",
+        idleMs: 10,
+        timeoutMs: 10,
+        details: { terminalTurnNotificationQueued: true },
+      },
+    ]);
+    expect(harness.abortController.signal.reason).toBe("turn_terminal_idle_timeout");
+  });
+
   it("keeps terminal idle gated while an app-server request is in flight", () => {
     const harness = createController();
     harness.activeRequests = 1;
@@ -188,30 +285,38 @@ describe("Codex app-server attempt turn watches", () => {
     expect(harness.abortController.signal.aborted).toBe(false);
   });
 
-  it("fires terminal idle after the in-flight request settles and silence resumes", () => {
-    const harness = createController();
-    harness.activeRequests = 1;
+  it.each(["before", "after"])(
+    "defers pre-terminal silence when a request starts %s watch arming until its response",
+    (requestStarts) => {
+      const timeoutMs = 30 * 60_000;
+      const harness = createController({ turnTerminalIdleTimeoutMs: timeoutMs });
+      harness.activeRequests = requestStarts === "before" ? 1 : 0;
+      harness.controller.armTerminalIdleWatch();
+      harness.activeRequests = 1;
 
-    harness.controller.armTerminalIdleWatch();
-    vi.advanceTimersByTime(10);
-    expect(harness.timeouts).toEqual([]);
+      vi.advanceTimersByTime(3 * timeoutMs);
+      expect(harness.timeouts).toEqual([]);
+      expect(harness.abortController.signal.aborted).toBe(false);
 
-    harness.activeRequests = 0;
-    harness.controller.touchActivity("request:item/tool/call:response");
-    vi.advanceTimersByTime(9);
-    expect(harness.timeouts).toEqual([]);
+      harness.activeRequests = 0;
+      harness.controller.touchActivity("request:item/tool/call:response");
+      vi.advanceTimersByTime(timeoutMs - 1);
+      expect(harness.timeouts).toEqual([]);
+      expect(harness.abortController.signal.aborted).toBe(false);
 
-    vi.advanceTimersByTime(1);
-    expect(harness.timeouts).toMatchObject([
-      {
-        kind: "terminal",
-        idleMs: 10,
-        timeoutMs: 10,
-        lastActivityReason: "request:item/tool/call:response",
-      },
-    ]);
-    expect(harness.abortController.signal.reason).toBe("turn_terminal_idle_timeout");
-  });
+      vi.advanceTimersByTime(1);
+      expect(harness.timeouts).toMatchObject([
+        {
+          kind: "terminal",
+          idleMs: timeoutMs,
+          timeoutMs,
+          lastActivityReason: "request:item/tool/call:response",
+          details: { terminalTurnNotificationQueued: false },
+        },
+      ]);
+      expect(harness.abortController.signal.reason).toBe("turn_terminal_idle_timeout");
+    },
+  );
 
   it("keeps completion idle gated while a request is in flight", () => {
     const harness = createController();

--- a/extensions/codex/src/app-server/attempt-turn-watches.ts
+++ b/extensions/codex/src/app-server/attempt-turn-watches.ts
@@ -4,6 +4,7 @@
  */
 import { embeddedAgentLog } from "openclaw/plugin-sdk/agent-harness-runtime";
 import { resolveTimerTimeoutMs } from "openclaw/plugin-sdk/number-runtime";
+import { TURN_TERMINAL_SETTLEMENT_IDLE_TIMEOUT_MS } from "./attempt-timeouts.js";
 
 type Timer = ReturnType<typeof setTimeout>;
 type WatchTimerKind = "completion" | "assistant" | "attempt" | "terminal";
@@ -159,13 +160,26 @@ export function createCodexAttemptTurnWatchController(params: {
     );
   }
 
+  const terminalWorkIsActive = () =>
+    params.getActiveAppServerTurnRequests() > 0 ||
+    (params.isTerminalTurnNotificationQueued() && params.getActiveFinalizationHookCount() > 0);
+  // Physical-client backstop: requests own quiet windows via their own timeouts;
+  // responses touch activity and rearm. After terminal receipt, even stuck counters
+  // must respect the absolute silence budget, or a blocked tail leaves the session active.
+  const terminalIdleTimeoutMs = () =>
+    params.isTerminalTurnNotificationQueued() && !terminalWorkIsActive()
+      ? Math.min(TURN_TERMINAL_SETTLEMENT_IDLE_TIMEOUT_MS, turnTerminalIdleTimeoutMs)
+      : turnTerminalIdleTimeoutMs;
+
   function scheduleTerminalIdleWatch() {
     scheduleWatch(
       "terminal",
       fireTerminalIdleTimeout,
       completionLastActivityAt,
-      turnTerminalIdleTimeoutMs,
-      terminalIdleWatchArmed && params.getActiveAppServerTurnRequests() === 0,
+      terminalIdleTimeoutMs(),
+      terminalIdleWatchArmed &&
+        (params.isTerminalTurnNotificationQueued() ||
+          params.getActiveAppServerTurnRequests() === 0),
     );
   }
 
@@ -342,32 +356,28 @@ export function createCodexAttemptTurnWatchController(params: {
   }
 
   function fireTerminalIdleTimeout() {
-    // Physical-client liveness backstop. A terminal timeout retires the shared
-    // client, so it must only measure silence the client owns: while a
-    // server->client request is pending (approval/elicitation/tool call) the
-    // app-server legitimately says nothing until we respond. The response path
-    // touches activity when the request settles, so a wedged client is still
-    // caught within one terminal window after our response.
-    if (
-      params.isCompleted() ||
-      params.isTerminalTurnNotificationQueued() ||
-      params.signal.aborted ||
-      !terminalIdleWatchArmed ||
-      params.getActiveAppServerTurnRequests() > 0
-    ) {
+    if (params.isCompleted() || params.signal.aborted || !terminalIdleWatchArmed) {
       return;
     }
+    if (!params.isTerminalTurnNotificationQueued() && params.getActiveAppServerTurnRequests() > 0) {
+      scheduleTerminalIdleWatch();
+      return;
+    }
+    const timeoutMs = terminalIdleTimeoutMs();
     const idleMs = Math.max(0, Date.now() - completionLastActivityAt);
-    if (idleMs < turnTerminalIdleTimeoutMs) {
+    if (idleMs < timeoutMs) {
       scheduleTerminalIdleWatch();
       return;
     }
     reportTimeout({
       kind: "terminal" as const,
       idleMs,
-      timeoutMs: turnTerminalIdleTimeoutMs,
+      timeoutMs,
       lastActivityReason: completionLastActivityReason,
-      details: completionLastActivityDetails,
+      details: {
+        ...completionLastActivityDetails,
+        terminalTurnNotificationQueued: params.isTerminalTurnNotificationQueued(),
+      },
     });
   }
 
@@ -453,6 +463,10 @@ export function createCodexAttemptTurnWatchController(params: {
       }
       if (options?.attemptProgress) {
         recordAttemptProgress(completionLastActivityReason, options);
+      }
+      // Receipt precedes the handler tail; arm the shorter settlement watch now.
+      if (params.isTerminalTurnNotificationQueued()) {
+        scheduleTerminalIdleWatch();
       }
     },
     extendAttemptIdleWatch: (timeoutMs: number) => {

--- a/extensions/codex/src/app-server/run-attempt-finalize.ts
+++ b/extensions/codex/src/app-server/run-attempt-finalize.ts
@@ -1,9 +1,11 @@
+import { addAbortListener } from "node:events";
 import {
   buildEmbeddedForegroundPromptContext,
   embeddedAgentLog,
   formatErrorMessage,
   runAgentHarnessLlmOutputHook,
 } from "openclaw/plugin-sdk/agent-harness-runtime";
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
 import { classifyCodexModelCallFailureKind } from "./attempt-diagnostics.js";
 import {
   buildCodexAppServerPromptTimeoutOutcome,
@@ -94,8 +96,15 @@ export async function finalizeCodexAttempt(
   } = activeTurn;
   await completion;
   await state.abortCleanup;
-  // Include projection work already queued when timeout completion wins.
-  await drainNotificationQueue();
+  // Normal completion joins projection work; Stop must also escape a blocked
+  // handler while the interrupted route is still reserved.
+  const aborted = createDeferred<void>();
+  const abortListener = addAbortListener(runAbortController.signal, () => aborted.resolve());
+  try {
+    await Promise.race([drainNotificationQueue(), aborted.promise]);
+  } finally {
+    abortListener[Symbol.dispose]();
+  }
   const hasQuiescentCompletedAssistant =
     activeProjector.hasCompletedTerminalAssistantText() &&
     state.activeAppServerTurnRequests === 0 &&

--- a/extensions/codex/src/app-server/run-attempt-finalize.ts
+++ b/extensions/codex/src/app-server/run-attempt-finalize.ts
@@ -14,6 +14,7 @@ import {
   resolveCodexAppServerReplayBlockedReason,
 } from "./attempt-results.js";
 import { attemptTerminal, type EmbeddedRunAttemptResult } from "./attempt-terminal.js";
+import { TURN_FINALIZE_DRAIN_ABORT_GRACE_MS } from "./attempt-timeouts.js";
 import { buildCodexContinuityCalibration } from "./context-engine-projection.js";
 import { flattenCodexDynamicToolFunctions } from "./protocol.js";
 import { readCodexRateLimitsRevision, readRecentCodexRateLimits } from "./rate-limit-cache.js";
@@ -96,14 +97,23 @@ export async function finalizeCodexAttempt(
   } = activeTurn;
   await completion;
   await state.abortCleanup;
-  // Normal completion joins projection work; Stop must also escape a blocked
-  // handler while the interrupted route is still reserved.
-  const aborted = createDeferred<void>();
-  const abortListener = addAbortListener(runAbortController.signal, () => aborted.resolve());
+  // Timeout and Stop still join queued projections within the abort grace;
+  // normal completion awaits the full drain.
+  const drain = drainNotificationQueue();
+  const abortGraceElapsed = createDeferred<void>();
+  let abortGraceTimer: ReturnType<typeof setTimeout> | undefined;
+  const abortListener = addAbortListener(runAbortController.signal, () => {
+    abortGraceTimer = setTimeout(
+      () => abortGraceElapsed.resolve(),
+      TURN_FINALIZE_DRAIN_ABORT_GRACE_MS,
+    );
+    abortGraceTimer.unref?.();
+  });
   try {
-    await Promise.race([drainNotificationQueue(), aborted.promise]);
+    await Promise.race([drain, abortGraceElapsed.promise]);
   } finally {
     abortListener[Symbol.dispose]();
+    clearTimeout(abortGraceTimer);
   }
   const hasQuiescentCompletedAssistant =
     activeProjector.hasCompletedTerminalAssistantText() &&

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -38,7 +38,7 @@ import {
   prependCodexOpenClawPromptContext,
 } from "./attempt-context.js";
 import { readAttemptTerminal } from "./attempt-terminal.test-helper.js";
-import { withCodexStartupTimeout } from "./attempt-timeouts.js";
+import { TURN_FINALIZE_DRAIN_ABORT_GRACE_MS, withCodexStartupTimeout } from "./attempt-timeouts.js";
 import { prepareCodexAppServerAuthBinding } from "./auth-binding.js";
 import { resolveCodexAppServerFallbackApiKeyCacheKey } from "./auth-bridge.js";
 import {
@@ -5334,6 +5334,7 @@ describe("runCodexAppServerAttempt", () => {
           abortController.abort("cancelled");
         }
         await vi.advanceTimersByTimeAsync(2 * 60_000);
+        await vi.advanceTimersByTimeAsync(TURN_FINALIZE_DRAIN_ABORT_GRACE_MS + 1);
         vi.useRealTimers();
         await vi.waitFor(() => expect(settled).toHaveBeenCalledOnce(), { timeout: 1_000 });
         const result = await run;

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { createOpenClawCodingTools } from "openclaw/plugin-sdk/agent-harness";
 import {
   embeddedAgentLog,
+  resolveActiveEmbeddedRunSessionId,
   type EmbeddedRunAttemptParamsV2 as EmbeddedRunAttemptParams,
 } from "openclaw/plugin-sdk/agent-harness-runtime";
 import { replaceRuntimeAuthProfileStoreSnapshots } from "openclaw/plugin-sdk/agent-runtime";
@@ -13,6 +14,7 @@ import {
   waitForDiagnosticEventsDrained,
   type DiagnosticEventPayload,
 } from "openclaw/plugin-sdk/diagnostic-runtime";
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
 import { initializeGlobalHookRunner, registerInternalHook } from "openclaw/plugin-sdk/hook-runtime";
 import { registerMemoryCapability } from "openclaw/plugin-sdk/memory-core-host-runtime-core";
 import { MESSAGE_TOOL_DELIVERY_HINTS } from "openclaw/plugin-sdk/message-tool-delivery-hints";
@@ -5295,6 +5297,64 @@ describe("runCodexAppServerAttempt", () => {
     const result = await runCodexAppServerAttempt(createRunParams());
     expect(readAttemptTerminal(result)).toMatchObject({ aborted: false, timedOut: false });
   });
+  it.each(["terminal timeout", "user stop"] as const)(
+    "clears an active run with blocked terminal delivery after %s",
+    async (termination) => {
+      const harness = createStartedThreadHarness();
+      harness.client.close = () => harness.close();
+      const abortController = new AbortController();
+      const blocked = createDeferred<void>();
+      const onPartialReply = vi.fn(() => blocked.promise);
+      const params = createRunParams();
+      params.abortSignal = abortController.signal;
+      params.onPartialReply = onPartialReply;
+      const run = runCodexAppServerAttempt(params, { turnTerminalIdleTimeoutMs: 30 * 60_000 });
+      const settled = vi.fn();
+      void run.then(settled);
+      try {
+        await vi.waitFor(() => {
+          expect(resolveActiveEmbeddedRunSessionId(params.sessionKey!)).toBe(params.sessionId);
+        }, fastWait);
+        await harness.notify(
+          itemNotification("item/started", {
+            id: "msg-1",
+            type: "agentMessage",
+            phase: "final_answer",
+            text: "",
+          }),
+        );
+        void harness.notify({
+          method: "item/agentMessage/delta",
+          params: { threadId: "thread-1", turnId: "turn-1", itemId: "msg-1", delta: "hello" },
+        });
+        await vi.waitFor(() => expect(onPartialReply).toHaveBeenCalledOnce(), fastWait);
+        vi.useFakeTimers();
+        void harness.completeTurn({ threadId: "thread-1", turnId: "turn-1" });
+        if (termination === "user stop") {
+          abortController.abort("cancelled");
+        }
+        await vi.advanceTimersByTimeAsync(2 * 60_000);
+        vi.useRealTimers();
+        await vi.waitFor(() => expect(settled).toHaveBeenCalledOnce(), { timeout: 1_000 });
+        const result = await run;
+        expect(readAttemptTerminal(result)).toMatchObject({
+          aborted: true,
+          timedOut: termination === "terminal timeout",
+        });
+        if (termination === "terminal timeout") {
+          expect(result.codexAppServerFailure?.turnWatchTimeoutKind).toBe("terminal");
+        }
+        expect(resolveActiveEmbeddedRunSessionId(params.sessionKey!)).toBeUndefined();
+      } finally {
+        // Release only for test cleanup; the run must settle while this callback is still blocked.
+        blocked.resolve();
+        vi.useRealTimers();
+        abortController.abort("test_cleanup");
+        await vi.waitFor(() => expect(settled).toHaveBeenCalledOnce(), fastWait);
+      }
+    },
+  );
+
   it("does not fail when a buffered terminal notification is followed by client close", async () => {
     let resolveBufferedTerminal!: () => void;
     const bufferedTerminal = new Promise<void>((resolve) => {

--- a/extensions/codex/src/app-server/run-attempt.turn-watches.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.turn-watches.test.ts
@@ -5,6 +5,7 @@ import {
   embeddedAgentLog,
   invokeNativeHookRelay,
   nativeHookRelayTesting,
+  resolveActiveEmbeddedRunSessionId,
 } from "openclaw/plugin-sdk/agent-harness-runtime";
 import {
   onInternalDiagnosticEvent,
@@ -17,6 +18,10 @@ import * as approvalBridge from "./approval-bridge.js";
 import { buildCodexAppServerPromptTimeoutOutcome } from "./attempt-results.js";
 import type { EmbeddedRunAttemptResult } from "./attempt-terminal.js";
 import { readAttemptTerminal } from "./attempt-terminal.test-helper.js";
+import {
+  TURN_FINALIZE_DRAIN_ABORT_GRACE_MS,
+  TURN_TERMINAL_SETTLEMENT_IDLE_TIMEOUT_MS,
+} from "./attempt-timeouts.js";
 import { createCodexAttemptTurnWatchController } from "./attempt-turn-watches.js";
 import * as authBridge from "./auth-bridge.js";
 import { createCodexDynamicToolBridge } from "./dynamic-tools.js";
@@ -2792,6 +2797,74 @@ describe("runCodexAppServerAttempt turn watches", () => {
       promptError: null,
       assistantTexts: ["Done."],
     });
+  });
+
+  it("settles blocked terminal delivery within the short window after a queued hook completes", async () => {
+    const harness = createStartedThreadHarness();
+    harness.client.close = () => harness.close();
+    const abortController = new AbortController();
+    const projection = createDeferred<void>();
+    const blockedReply = createDeferred<void>();
+    const onReasoningStream = vi.fn(() => projection.promise);
+    const onPartialReply = vi.fn(() => blockedReply.promise);
+    const params = makeTestParams({
+      timeoutMs: 60 * 60_000,
+      abortSignal: abortController.signal,
+      onReasoningStream,
+      onPartialReply,
+    });
+    const settled = vi.fn();
+    const run = runCodexAppServerAttempt(params, { turnTerminalIdleTimeoutMs: 30 * 60_000 });
+    void run.then(settled);
+    try {
+      await harness.waitForMethod("turn/start");
+      await harness.notify(
+        itemNotification("item/started", {
+          id: "msg-final-1",
+          type: "agentMessage",
+          phase: "final_answer",
+          text: "",
+        }),
+      );
+      await harness.notify(finalizationHookNotification("hook/started", "running"));
+      void harness.notify({
+        method: "item/reasoning/textDelta",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          itemId: "reasoning-1",
+          delta: "thinking",
+        },
+      });
+      await vi.waitFor(() => expect(onReasoningStream).toHaveBeenCalledOnce(), fastWait);
+
+      vi.useFakeTimers();
+      const completedHook = harness.notify(
+        finalizationHookNotification("hook/completed", "completed"),
+      );
+      void harness.notify(makeAgentMessageDelta({ itemId: "msg-final-1", delta: "Done." }));
+      // Receipt sees the unsettled hook; its completion is still behind the first projection.
+      void harness.completeTurn({ threadId: "thread-1", turnId: "turn-1" });
+      projection.resolve();
+      await vi.waitFor(() => expect(onPartialReply).toHaveBeenCalledOnce(), fastWait);
+      await completedHook;
+      expect(settled).not.toHaveBeenCalled();
+
+      await vi.advanceTimersByTimeAsync(TURN_TERMINAL_SETTLEMENT_IDLE_TIMEOUT_MS);
+      await vi.advanceTimersByTimeAsync(TURN_FINALIZE_DRAIN_ABORT_GRACE_MS + 1);
+      vi.useRealTimers();
+      await vi.waitFor(() => expect(settled).toHaveBeenCalledOnce(), fastWait);
+      const result = await run;
+      expect(readAttemptTerminal(result)).toMatchObject({ aborted: true, timedOut: true });
+      expect(result.codexAppServerFailure?.turnWatchTimeoutKind).toBe("terminal");
+      expect(resolveActiveEmbeddedRunSessionId(params.sessionKey!)).toBeUndefined();
+    } finally {
+      projection.resolve();
+      blockedReply.resolve();
+      vi.useRealTimers();
+      abortController.abort("test_cleanup");
+      await vi.waitFor(() => expect(settled).toHaveBeenCalledOnce(), fastWait);
+    }
   });
 
   it("rearms recovery after queued assistant projection outlives the receive-time watch", async () => {

--- a/extensions/codex/src/app-server/run-attempt.turn-watches.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.turn-watches.test.ts
@@ -10,6 +10,7 @@ import {
   onInternalDiagnosticEvent,
   type DiagnosticEventPayload,
 } from "openclaw/plugin-sdk/diagnostic-runtime";
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
 import * as mediaStore from "openclaw/plugin-sdk/media-store";
 import { describe, expect, it, vi } from "vitest";
 import * as approvalBridge from "./approval-bridge.js";
@@ -517,6 +518,48 @@ describe("runCodexAppServerAttempt turn watches", () => {
       replayInvalid: true,
       livenessState: "abandoned",
     });
+  });
+
+  it("joins queued image projection when timeout aborts the turn", async () => {
+    const harness = createStartedThreadHarness();
+    const projection = createDeferred<void>();
+    const mediaPath = path.join(tempDir, "queued-image.png");
+    const saveMedia = vi.spyOn(mediaStore, "saveMediaBuffer").mockImplementation(async () => {
+      await projection.promise;
+      return { id: "queued-image", path: mediaPath, size: 1, contentType: "image/png" };
+    });
+    const settled = vi.fn();
+    const run = runCodexAppServerAttempt(makeTestParams({ timeoutMs: 60_000 }), {
+      turnCompletionIdleTimeoutMs: 1_000,
+      turnTerminalIdleTimeoutMs: 60_000,
+    });
+    void run.then(settled);
+    try {
+      await harness.waitForMethod("turn/start");
+      vi.useFakeTimers();
+      void harness.notify(
+        rawItemCompleted({
+          id: "queued-image",
+          type: "image_generation_call",
+          status: "generating",
+          result: tinyPngBase64,
+        }),
+      );
+      await vi.waitFor(() => expect(saveMedia).toHaveBeenCalledOnce(), fastWait);
+      await vi.advanceTimersByTimeAsync(1_000);
+      await harness.waitForMethod("thread/unsubscribe");
+      await vi.advanceTimersByTimeAsync(1);
+
+      projection.resolve();
+      vi.useRealTimers();
+      await vi.waitFor(() => expect(settled).toHaveBeenCalledOnce(), fastWait);
+      const result = await run;
+      expect(readAttemptTerminal(result).timedOut).toBe(true);
+      expect(result.toolMediaUrls).toEqual([mediaPath]);
+    } finally {
+      projection.resolve();
+      vi.useRealTimers();
+    }
   });
 
   it("marks executed dynamic-tool completion-idle timeouts as replay-invalid", async () => {
@@ -2490,7 +2533,7 @@ describe("runCodexAppServerAttempt turn watches", () => {
     });
   });
 
-  it("does not idle-timeout when terminal completion queues behind projection", async () => {
+  it("does not idle-timeout when terminal completion queues behind projection within the settlement window", async () => {
     const harness = createStartedThreadHarness();
     const params = makeTestParams({ timeoutMs: 120 });
     const turnStartProgressEvents: DiagnosticEventPayload[] = [];
@@ -2515,7 +2558,10 @@ describe("runCodexAppServerAttempt turn watches", () => {
     let settled = false;
     const run = runCodexAppServerAttempt(params, {
       turnCompletionIdleTimeoutMs: 5,
-      turnTerminalIdleTimeoutMs: 5,
+      // A queued terminal now settles within a bounded window instead of
+      // waiting forever; keep that window far beyond this test's drain time so
+      // it still proves a briefly blocked projection is not aborted early.
+      turnTerminalIdleTimeoutMs: 60_000,
     }).finally(() => {
       settled = true;
     });

--- a/extensions/codex/src/app-server/turn-router.test.ts
+++ b/extensions/codex/src/app-server/turn-router.test.ts
@@ -320,7 +320,7 @@ describe("CodexAppServerTurnRouter", () => {
     ]);
   });
 
-  it("records receipt synchronously and drains accepted work after release", async () => {
+  it("records receipt synchronously and drains accepted work before release", async () => {
     const harness = createHarness();
     const events: string[] = [];
     let finishFirst!: () => void;
@@ -356,7 +356,6 @@ describe("CodexAppServerTurnRouter", () => {
       "item/started:start",
     ]);
 
-    route.release();
     finishFirst();
     await route.drain();
     expect(events).toEqual([
@@ -367,21 +366,16 @@ describe("CodexAppServerTurnRouter", () => {
       "item/completed:start",
       "item/completed:end",
     ]);
+    route.release();
   });
 
-  it("releases routing waiters without waiting for an async notification", async () => {
+  it("drain resolves after release while a handler is blocked and routing waiters are pending", async () => {
+    vi.useFakeTimers();
     const harness = createHarness();
-    let notificationStarted!: () => void;
-    const started = new Promise<void>((resolve) => {
-      notificationStarted = resolve;
-    });
-    const neverFinishes = new Promise<void>(() => {});
+    const handler = vi.fn(() => new Promise<void>(() => {}));
     const route = getCodexAppServerTurnRouter(harness.client).reserveThread({
       threadId: "thread-release-tail",
-      onNotification: async () => {
-        notificationStarted();
-        await neverFinishes;
-      },
+      onNotification: handler,
       onRequest: () => ({ decision: "accept" }),
     });
     route.armTurn();
@@ -398,12 +392,22 @@ describe("CodexAppServerTurnRouter", () => {
         itemId: "item-1",
       },
     });
-    const binding = route.bindTurn("turn-release-tail");
-    await started;
+    const binding = expect(route.bindTurn("turn-release-tail")).rejects.toThrow(
+      "thread route is released",
+    );
+    await vi.advanceTimersByTimeAsync(0);
+    expect(handler).toHaveBeenCalledOnce();
+    const result = Promise.race([
+      Promise.all([route.drain(), binding]).then(() => "drained"),
+      new Promise<string>((resolve) => {
+        setTimeout(() => resolve("still blocked"), 1);
+      }),
+    ]);
 
     route.release();
+    await vi.advanceTimersByTimeAsync(1);
 
-    await expect(binding).rejects.toThrow("thread route is released");
+    expect(await result).toBe("drained");
     expect(await waitForResponse(harness, "request-release-tail")).toEqual({
       id: "request-release-tail",
       result: { decision: "decline" },

--- a/extensions/codex/src/app-server/turn-router.ts
+++ b/extensions/codex/src/app-server/turn-router.ts
@@ -565,7 +565,8 @@ class ClientTurnRouter implements CodexAppServerTurnRouter {
   }
 
   private async drainNotifications(route: Route): Promise<void> {
-    await route.notificationTail;
+    // A released route cannot promise that accepted handlers finish processing.
+    await Promise.race([route.notificationTail, route.ended.promise]);
   }
 
   private release(route: Route, error = new Error("codex app-server thread route is released")) {

--- a/extensions/qa-lab/src/gateway-kill-restart-send.e2e.test.ts
+++ b/extensions/qa-lab/src/gateway-kill-restart-send.e2e.test.ts
@@ -1,0 +1,174 @@
+import path from "node:path";
+import { buildAgentSessionKey } from "openclaw/plugin-sdk/routing";
+import { afterEach, describe, expect, it } from "vitest";
+import { startQaBusServer } from "./bus-server.js";
+import { createQaBusState } from "./bus-state.js";
+import { createQaGatewayChild } from "./gateway-child.js";
+import { isQaPosixProcessGroupAlive, signalQaPosixProcessGroup } from "./posix-process-group.js";
+import { QA_REPEATED_REQUEST_QUEUED_REPLY_MARKER } from "./providers/mock-openai/mock-openai-contracts.js";
+import { startQaMockOpenAiServer } from "./providers/mock-openai/server.js";
+import { createQaChannelTransport } from "./qa-channel-transport.js";
+import { waitForQaTransportCondition } from "./qa-transport.js";
+import {
+  readRawQaSessionStore,
+  readSessionTranscriptSummary,
+} from "./suite-runtime-agent-session.js";
+
+const repoRoot = path.resolve(import.meta.dirname, "../../..");
+
+describe.skipIf(process.platform === "win32")("gateway hard-kill recovery", () => {
+  const cleanups: Array<() => Promise<void>> = [];
+  afterEach(async () => {
+    const errors: unknown[] = [];
+    for (const cleanup of cleanups.splice(0).toReversed()) {
+      try {
+        await cleanup();
+      } catch (error) {
+        errors.push(error);
+      }
+    }
+    if (errors.length) {
+      throw new AggregateError(errors, "hard-kill recovery test cleanup failed");
+    }
+  });
+
+  it("reconciles an orphaned run and replies to a new inbound send after SIGKILL", async () => {
+    const state = createQaBusState();
+    const transport = createQaChannelTransport(state);
+    const bus = await startQaBusServer({ state });
+    cleanups.push(() => bus.stop());
+    const mock = await startQaMockOpenAiServer();
+    cleanups.push(() => mock.stop());
+    const owner = createQaGatewayChild();
+    cleanups.push(async () => {
+      expect((await owner.stop()).errors).toEqual([]);
+    });
+    const gateway = await owner.start({
+      repoRoot,
+      providerBaseUrl: `${mock.baseUrl}/v1`,
+      providerMode: "mock-openai",
+      forcedRuntime: "openclaw",
+      transport,
+      transportBaseUrl: bus.baseUrl,
+      controlUiEnabled: false,
+      mutateConfig: (cfg) => ({
+        ...cfg,
+        plugins: {
+          ...cfg.plugins,
+          slots: { ...cfg.plugins?.slots, memory: "none" },
+          entries: {
+            ...cfg.plugins?.entries,
+            acpx: { enabled: false },
+            "memory-core": { enabled: false },
+          },
+        },
+        tools: {
+          ...cfg.tools,
+          alsoAllow: ["qa_restart_wait", "qa_restart_unsafe_probe"],
+          // Suspend the 30-second tool so the model's wait is pending at SIGKILL.
+          codeMode: { enabled: true, timeoutMs: 10_000 },
+        },
+      }),
+    });
+    const conversation = { id: "kill-restart-send", kind: "direct" as const };
+    const sessionKey = buildAgentSessionKey({
+      agentId: "qa",
+      channel: "qa-channel",
+      accountId: transport.accountId,
+      peer: { kind: "direct", id: `dm:${conversation.id}` },
+      dmScope: gateway.cfg.session?.dmScope,
+      identityLinks: gateway.cfg.session?.identityLinks,
+    });
+    try {
+      await transport.waitReady({ gateway });
+      await transport.sendInbound({
+        accountId: transport.accountId,
+        conversation,
+        senderId: conversation.id,
+        text: "Code Mode restart wait QA check. Original prompt marker: KILL-RESTART-PROMPT.",
+      });
+      const pending = await transport.waitForCondition(
+        async () => {
+          const entry = (await readRawQaSessionStore({ gateway }))[sessionKey];
+          if (entry?.status !== "running") {
+            return undefined;
+          }
+          const transcript = await readSessionTranscriptSummary({ gateway }, sessionKey);
+          return (transcript.assistantToolCallCounts.wait ?? 0) >
+            (transcript.completedToolCallCounts.wait ?? 0)
+            ? { entry, transcript }
+            : undefined;
+        },
+        120_000,
+        25,
+      );
+      const pid = gateway.pid;
+      expect(pid).not.toBeNull();
+      // Kill the owned process group so no gateway or descendant can drain.
+      expect(signalQaPosixProcessGroup(pid!, "SIGKILL")).toBeUndefined();
+      await waitForQaTransportCondition(
+        () => (!isQaPosixProcessGroupAlive(pid!) ? true : undefined),
+        30_000,
+        25,
+      );
+      await gateway.restartAfterStateMutation(async () => {
+        const orphan = (await readRawQaSessionStore({ gateway }))[sessionKey];
+        expect(orphan).toMatchObject({ sessionId: pending.entry.sessionId, status: "running" });
+        expect(orphan?.abortedLastRun).not.toBe(true);
+      });
+      expect(gateway.pid).not.toBe(pid);
+      await transport.waitReady({ gateway });
+      await transport.waitForCondition(
+        async () => {
+          if (!gateway.logs().includes("dispatching restart-safe recovery")) {
+            return undefined;
+          }
+          const transcript = await readSessionTranscriptSummary({ gateway }, sessionKey);
+          return transcript.eventCursor > pending.transcript.eventCursor ? true : undefined;
+        },
+        120_000,
+        25,
+      );
+      expect(gateway.logs()).toContain("marked 1 startup-orphaned main session(s)");
+
+      const sinceIndex = state
+        .getSnapshot()
+        .messages.filter((message) => message.direction === "outbound").length;
+      const second = await transport.sendInbound({
+        accountId: transport.accountId,
+        conversation,
+        senderId: conversation.id,
+        // This current-turn fixture takes precedence over the restart prompt in history.
+        text: "repeated request queued reply gateway qa check",
+      });
+      const reply = await transport.waitForOutbound({
+        conversation,
+        sinceIndex,
+        textIncludes: QA_REPEATED_REQUEST_QUEUED_REPLY_MARKER,
+        timeoutMs: 180_000,
+      });
+      expect(reply.replyToId).toBe(second.id);
+      expect(reply.accountId).toBe(transport.accountId);
+      const settled = await transport.waitForCondition(
+        async () => {
+          const entry = (await readRawQaSessionStore({ gateway }))[sessionKey];
+          return entry?.status === "done" ? entry : undefined;
+        },
+        30_000,
+        25,
+      );
+      expect(settled.sessionId).toBe(pending.entry.sessionId);
+    } catch (error) {
+      const diagnostics = await Promise.allSettled([
+        readRawQaSessionStore({ gateway }),
+        readSessionTranscriptSummary({ gateway }, sessionKey, { allowEmpty: true }),
+      ]);
+      throw new Error(
+        `${String(error)}\nsessions=${JSON.stringify(diagnostics)}\nbus=${JSON.stringify(state.getSnapshot())}\ngateway=${gateway.logs()}`,
+        { cause: error },
+      );
+    }
+    // Nominal runtime is ~130s; heavily loaded hosts stretch child boots and
+    // waits severalfold, so the budget leaves real headroom before flaking.
+  }, 600_000);
+});


### PR DESCRIPTION
## What Problem This Solves

After a gateway process is hard-killed mid Codex-harness run and restarted, the recovery resume turn could become permanently active: the session kept reporting a run active, and every new chat send queued behind the phantom indefinitely (the Control UI parks sends as waiting-idle with no timer-based retry; the gateway followup queue only drains when the owning reply operation clears). Observed live on an isolated dev gateway on main a86b427ca8e with the signature log `[agent/embedded] codex app-server notification ignored for inactive turn` repeating while the session stayed busy forever. This violates two root invariants: active turn claims do not survive gateway restart, and every action ends in a visible outcome.

Root cause (verified by direct code reading, all paths under `extensions/codex/src/app-server/`): the attempt sets `terminalTurnNotificationQueued` the moment a terminal turn notification is received (`run-attempt-notification-controller.ts`), before its handler runs. That flag permanently disarmed both the completion idle watch and the 30-minute terminal backstop (`attempt-turn-watches.ts` early-returned without rescheduling) and disabled route-close aborts (`run-attempt-route.ts`). Notifications process on one serialized tail, and `completeTurn()` only runs when that tail reaches the terminal handler - so any earlier never-settling handler left `await completion` pending forever, `clearActiveEmbeddedRun` never ran, and no watchdog could fire. Finalization had the same class of unbounded join: `drainNotificationQueue()` awaited the same blocked tail unconditionally, so even an explicit Stop could hang there. Post-restart this is easy to hit: a hard-killed run leaves the codex rollout with `TurnStarted` and no terminal record, which projects the dead turn as `inProgress` on resume (verified in sibling codex source: `codex-rs/app-server-protocol/src/protocol/thread_history_projection.rs:26`, checked at `openai/codex@0ae94fdd49`), producing exactly the observed stale-turn warnings after the resumed attempt binds its new turn.

## Why This Change Was Made

The producer of the unbounded state is the codex attempt watch controller, so the repair lands there rather than compensating in the send/queue consumers:

- `attempt-turn-watches.ts`: the terminal idle watch stays armed after terminal receipt and forces settlement through the existing abort -> completeTurn path within a 2-minute settlement window (`TURN_TERMINAL_SETTLEMENT_IDLE_TIMEOUT_MS`). Pending server->client requests and active finalization hooks defer it, but never past the existing 30-minute absolute silence budget - the receipt-side hook counter only decrements inside the (possibly blocked) handler tail, so a stuck counter must not defer forever. The pre-existing contract that a pending request suppresses the terminal backstop entirely is preserved for the ordinary (non-terminal-queued) path.
- `turn-router.ts`: `drain()` resolves when the route is released - a released route cannot promise complete processing.
- `run-attempt-finalize.ts`: the drain join also settles when the run abort signal fires, so Stop escapes a blocked handler while the route is still reserved.

Once the run settles, the existing chat terminal events wake the Control UI outbox drain and the followup queue, and queued sends dispatch - no consumer-side changes needed.

## User Impact

A gateway crash or kill mid-run can no longer leave a session permanently busy with new messages silently queued forever. Worst case, a wedged resumed turn settles as the existing "Codex stopped before confirming the turn was complete" timeout outcome within the settlement window, and queued sends then dispatch. Named tradeoff: a turn whose post-terminal processing is legitimately silent for longer than the settlement window is force-settled; active requests/hooks defer the window, so this requires minutes of true silence.

## Evidence

- Failing-first regression tests (all red pre-fix with fast assertion failures, green post-fix):
  - `attempt-turn-watches.test.ts`: settlement fires within the window; defers for pending requests/hooks and re-arms after they settle; absolute-budget fire when a hook counter is stuck behind a blocked tail; no fire when completion wins; non-queued pending-request deferral preserved (this last one red against an intermediate draft that dropped it).
  - `turn-router.test.ts`: `drain()` resolves after release while a handler is blocked (red pre-fix: "still blocked").
  - `run-attempt.test.ts`: timeout and user Stop clear the active embedded run despite a blocked notification callback.
- Real-gateway boundary e2e (`extensions/qa-lab/src/gateway-kill-restart-send.e2e.test.ts`, new): SIGKILL the gateway's process group mid-run (wait tool pending, no drain/marking - asserted `status: "running"` with `abortedLastRun` unset), restart against the same state dir, assert the startup orphan scan marks the session and restart-safe recovery dispatches, then a NEW inbound send must produce a reply and the session settles to done. Passed locally in 131s nominal / 363s under heavy host load (mock-openai provider; per repo policy the mock-gateway harness covers the changed channel-visible path).
- Suites on the rebased head: `attempt-turn-watches.test.ts` + `turn-router.test.ts` + `run-attempt.test.ts` = 217 passed, composing cleanly with #107721's abort-cleanup join in `run-attempt-finalize.ts`. `node scripts/check-changed.mjs` exit 0. Codex autoreview (gpt-5.6-sol, high): scoped-clean, verdict correct (0.98).
- Production LOC +48/-21 (net +27), tests +370/-29: growth is the settlement-window constant plus the bounded joins; the invariant cannot be expressed by deleting code here.

Follow-ups (named, out of scope): (1) #131527's attempt-budget refresh lets a start-then-wedge recovery loop refresh its budget - with bounded settlement each attempt now terminates visibly, but a cycle cap may still be worth considering; (2) cold-resume takeover stalls: thread/resume projects a dead turn as inProgress forever, so each resumed attempt waits the full 30s native-turn takeover window before proceeding - interrupting/reconciling the orphaned native turn at first observation would remove the stall; (3) a SIGKILLed gateway orphans the detached codex app-server child (stdio transport spawns detached); nothing reaps it on the next boot.
