### PR TITLE
test: skip Node startup for uninstrumented Git queries

### DIFF
--- a/src/infra/state-migrations.media-persistence.test-support.ts
+++ b/src/infra/state-migrations.media-persistence.test-support.ts
@@ -1,0 +1,65 @@
+import { requireNodeSqlite } from "./node-sqlite.js";
+
+export function readDatabaseSnapshot(databasePath: string) {
+  const { DatabaseSync } = requireNodeSqlite();
+  const database = new DatabaseSync(databasePath);
+  try {
+    const version = database.prepare("PRAGMA user_version").get() as { user_version: number };
+    const rows = database
+      .prepare(
+        "SELECT session_id,seq,event_json,created_at FROM transcript_events ORDER BY session_id,seq",
+      )
+      .all() as Array<{
+      session_id: string;
+      seq: number;
+      event_json: string;
+      created_at: number;
+    }>;
+    const identities = database
+      .prepare(
+        "SELECT session_id,event_id,seq,event_type,parent_id,message_idempotency_key,created_at FROM transcript_event_identities ORDER BY session_id,seq",
+      )
+      .all();
+    const activeBranch = database
+      .prepare(
+        "SELECT session_id,active_position,event_seq,message_position FROM session_transcript_active_events ORDER BY session_id,active_position",
+      )
+      .all();
+    const windows = database
+      .prepare(
+        "SELECT session_id,session_key,created_at,updated_at,transcript_observed_at FROM session_windows ORDER BY session_id",
+      )
+      .all();
+    const generations = database
+      .prepare(
+        "SELECT session_id,generation FROM transcript_rewrite_watermarks ORDER BY session_id",
+      )
+      .all();
+    const trajectoryCount = database
+      .prepare("SELECT count(*) AS count FROM trajectory_runtime_events")
+      .get() as { count: number };
+    const trajectoryRows = database
+      .prepare(
+        "SELECT session_id,seq,run_id,event_json,created_at FROM trajectory_runtime_events ORDER BY session_id,seq",
+      )
+      .all() as Array<{
+      session_id: string;
+      seq: number;
+      run_id: string | null;
+      event_json: string;
+      created_at: number;
+    }>;
+    return {
+      activeBranch,
+      generations,
+      identities,
+      rows,
+      trajectoryCount: trajectoryCount.count,
+      trajectoryRows,
+      version,
+      windows,
+    };
+  } finally {
+    database.close();
+  }
+}

--- a/src/infra/state-migrations.media-persistence.test.ts
+++ b/src/infra/state-migrations.media-persistence.test.ts
@@ -20,6 +20,7 @@ import {
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
 import { requireNodeSqlite } from "./node-sqlite.js";
 import { migrateLegacyMediaPersistence } from "./state-migrations.media-persistence.js";
+import { readDatabaseSnapshot } from "./state-migrations.media-persistence.test-support.js";
 
 const tempDirs: string[] = [];
 const PREVIOUS_VERSION = 16;
@@ -116,70 +117,6 @@ function createLegacyDatabaseFixture(params: {
     schemaVersion,
   });
   return databasePath;
-}
-
-function readDatabaseSnapshot(databasePath: string) {
-  const { DatabaseSync } = requireNodeSqlite();
-  const database = new DatabaseSync(databasePath);
-  try {
-    const version = database.prepare("PRAGMA user_version").get() as { user_version: number };
-    const rows = database
-      .prepare(
-        "SELECT session_id,seq,event_json,created_at FROM transcript_events ORDER BY session_id,seq",
-      )
-      .all() as Array<{
-      session_id: string;
-      seq: number;
-      event_json: string;
-      created_at: number;
-    }>;
-    const identities = database
-      .prepare(
-        "SELECT session_id,event_id,seq,event_type,parent_id,message_idempotency_key,created_at FROM transcript_event_identities ORDER BY session_id,seq",
-      )
-      .all();
-    const activeBranch = database
-      .prepare(
-        "SELECT session_id,active_position,event_seq,message_position FROM session_transcript_active_events ORDER BY session_id,active_position",
-      )
-      .all();
-    const windows = database
-      .prepare(
-        "SELECT session_id,session_key,created_at,updated_at,transcript_observed_at FROM session_windows ORDER BY session_id",
-      )
-      .all();
-    const generations = database
-      .prepare(
-        "SELECT session_id,generation FROM transcript_rewrite_watermarks ORDER BY session_id",
-      )
-      .all();
-    const trajectoryCount = database
-      .prepare("SELECT count(*) AS count FROM trajectory_runtime_events")
-      .get() as { count: number };
-    const trajectoryRows = database
-      .prepare(
-        "SELECT session_id,seq,run_id,event_json,created_at FROM trajectory_runtime_events ORDER BY session_id,seq",
-      )
-      .all() as Array<{
-      session_id: string;
-      seq: number;
-      run_id: string | null;
-      event_json: string;
-      created_at: number;
-    }>;
-    return {
-      activeBranch,
-      generations,
-      identities,
-      rows,
-      trajectoryCount: trajectoryCount.count,
-      trajectoryRows,
-      version,
-      windows,
-    };
-  } finally {
-    database.close();
-  }
 }
 
 function writeArchive(filePath: string, events: FixtureEvent[], compressed: boolean): void {

--- a/test/scripts/pr-main-refresh.test-support.ts
+++ b/test/scripts/pr-main-refresh.test-support.ts
@@ -10,6 +10,10 @@ import {
 } from "node:fs";
 import { delimiter, join } from "node:path";
 
+function shellQuote(value: string): string {
+  return `'${value.replace(/'/gu, `'\\''`)}'`;
+}
+
 // Keep the complete wrapper/lock/entry/gate owners. Command resolution, Git
 // transport faults, and GitHub responses are synthetic; rg invocation is forbidden.
 export function createMainRefreshFixture(directory: string) {
@@ -219,8 +223,9 @@ function runGit(args, input) {
   return result.stdout.trim();
 }
 `;
+  const instrumentedGit = join(bin, "git-instrumented.mjs");
   writeFileSync(
-    join(bin, "git"),
+    instrumentedGit,
     prelude +
       `
 const mainFetch = args.includes('fetch') && args.some(arg =>
@@ -270,6 +275,20 @@ if (mainFetch && result.status === 0) {
   });
 }
 process.exit(result.status ?? 1);
+`,
+  );
+  // Scan every argument like the Node shim, including values after -C/-c prefixes.
+  // Unobserved queries can execute real Git directly without starting another Node process.
+  writeFileSync(
+    join(bin, "git"),
+    `#!/bin/sh
+for arg in "$@"; do
+  case "$arg" in
+    fetch|merge-base|diff|checkout|update-ref|push)
+      exec ${shellQuote(process.execPath)} ${shellQuote(instrumentedGit)} "$@" ;;
+  esac
+done
+exec ${shellQuote(realGit)} "$@"
 `,
   );
   writeFileSync(


### PR DESCRIPTION
## What Problem This Solves

The native PR refresh fixture launches Node before every Git invocation, including ordinary queries that the fixture neither observes nor modifies. Real wrapper execution makes many such calls, so process startup dominates part of this suite.

## Why This Change Was Made

Put a small POSIX dispatcher in front of the unchanged instrumented Git implementation. Fetch, merge-base, diff, checkout, update-ref, and push still run through the original Node shim. Other calls execute the same real Git directly.

The dispatcher scans every argument, preserving the existing shim's matching behavior with global options and operand values. Executable paths are shell-quoted and arguments retain their original boundaries. No wrapper functions or Git operations are mocked away.

## User Impact

The full 36-case suite fell from **160.31s to 142.44s (137.35s on repeat)** locally. Production +0/-0; test support +20/-1. No sharding, worker count, test selection, runtime, or configuration changes.

## Evidence

- All 36 cases passed before and after: `node scripts/run-vitest.mjs test/scripts/pr-main-refresh.test.ts`.
- Real wrapper/Git proof retains supervised prepare and merge, exact-head stamps, private main snapshots, moved refs, failed authentication/fetch, interrupted fetch process groups, exact-owner lock recovery, and leased branch cleanup. GitHub responses and injected transport faults remain synthetic.
- Independent all-priorities review and fresh Codex autoreview found no actionable findings. The complete fixture, tests, wrapper, worktree refresh, operation locks, and process-group supervisor were inspected.
- Formatting and whitespace checks passed. Linux changed-file checks passed with wrapper exit 0 and its Testbox stopped: https://github.com/openclaw/openclaw/actions/runs/33237028871. Exact-head hosted CI must pass before landing.

Final integration: rebased onto current main, retaining #132338's command-resolution and forbidden-rg safeguards. All 36 tests passed again in the native PR worktree; fresh conflict-resolution Codex autoreview through P3 found no actionable findings. That native run used a different installed Node version and is not part of the before/after timing comparison. The first native rerun exposed an incomplete dependency directory, corrected by linking the canonical dependency tree without reinstalling it. Refreshed exact-head CI must pass before landing.

Shared CI integration repair: #132099 left `state-migrations.media-persistence.test.ts` above the max-lines limit. Move its existing snapshot reader verbatim into test support; all 15 migration cases, assertions, SQL queries, cleanup hooks and database-close behavior remain unchanged. All 15 cases passed before and after, focused lint passed, and fresh Codex autoreview through P3 is clean. Production and schema delta are zero; tests/support +66/-64. This repair is shared across the pending performance branches so it lands once without waiting on a known broken main check.

Final exact-head CI passed: https://github.com/openclaw/openclaw/actions/runs/33240565866. The recent ClawSweeper rank-up request is addressed: the rebase preserves the rg tripwire and the reconciled 36-case suite passed. A newer review is queued; it is not used as proof or a substitute for the completed maintainer review.
