### PR TITLE
fix(ui): reduce sidebar title movement on hover

### DIFF
--- a/ui/src/e2e/chat-flow.sidebar-presentation.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.sidebar-presentation.e2e.test.ts
@@ -342,18 +342,19 @@ suite.define(() => {
     const busyKey = "agent:main:busy-session";
     const plainKey = "agent:main:plain-session";
     const longKey = "agent:main:long-title-session";
+    const unreadKey = "agent:main:unread-session";
     const homeKey = "agent:main:main";
     await installMockGateway(page, {
       featureMethods: [...defaultControlUiFeatureMethods, "board.get"],
       methodResponses: {
         "board.get": {
-          cases: [homeKey, busyKey, plainKey, longKey].map((sessionKey) => ({
+          cases: [homeKey, busyKey, plainKey, longKey, unreadKey].map((sessionKey) => ({
             match: { sessionKey },
             response: {
               sessionKey,
               revision: 1,
               tabs:
-                sessionKey === homeKey || sessionKey === busyKey
+                sessionKey === homeKey || sessionKey === busyKey || sessionKey === unreadKey
                   ? [{ tabId: "overview", title: "Overview", position: 0, chatDock: "right" }]
                   : [],
               widgets: [],
@@ -361,6 +362,14 @@ suite.define(() => {
           })),
         },
         "sessions.list": chatSessionListResponse([
+          {
+            key: unreadKey,
+            kind: "direct",
+            label: "Movies and recommendations for the weekend",
+            icon: "🎬",
+            updatedAt: 3,
+            unread: true,
+          },
           {
             key: busyKey,
             kind: "direct",
@@ -608,6 +617,38 @@ suite.define(() => {
       const intrinsicAtomWidth = longLayout.atoms.reduce((sum, width) => sum + width, 0);
       expect(intrinsicAtomWidth).toBeGreaterThan(0);
       expect(longLayout.endcapWidth).toBeGreaterThanOrEqual(intrinsicAtomWidth);
+
+      const unreadRow = page.locator(`.sidebar-recent-session[data-session-key="${unreadKey}"]`);
+      const unreadDot = unreadRow.locator(".session-unread-dot");
+      const unreadTitle = unreadRow.locator(".sidebar-recent-session__name");
+      await unreadDot.waitFor({ state: "visible" });
+      const restingWidth = await unreadTitle.evaluate((element) => element.clientWidth);
+      await unreadRow.hover();
+      if (captureUiProofEnabled) {
+        await shellNav.screenshot({
+          animations: "disabled",
+          path: path.join(sessionSecondRowProofDir, "03-unread-hover.png"),
+        });
+      }
+      await unreadDot.waitFor({ state: "hidden" });
+      const hoverWidth = await unreadTitle.evaluate((element) => element.clientWidth);
+      const actionReserve = await unreadRow.evaluate((element) =>
+        Number.parseFloat(
+          getComputedStyle(element).getPropertyValue("--session-row-actions-reserve"),
+        ),
+      );
+      // Collapsing the unread track gives its width back to the title; merely
+      // making the dot transparent would still squeeze the text by the full reserve.
+      expect(restingWidth - hoverWidth).toBeLessThan(actionReserve);
+      await unreadRow
+        .getByRole("img", { name: "Dashboard available" })
+        .waitFor({ state: "visible" });
+      await page.mouse.move(900, 400);
+      await unreadDot.waitFor({ state: "visible" });
+      await unreadRow.locator("[data-session-menu]").focus();
+      await unreadDot.waitFor({ state: "hidden" });
+      await sidebarResizer.focus();
+      await unreadDot.waitFor({ state: "visible" });
 
       await busyRow.hover();
       await expect

--- a/ui/src/e2e/session-management.trailing-state.e2e.test.ts
+++ b/ui/src/e2e/session-management.trailing-state.e2e.test.ts
@@ -252,7 +252,7 @@ suite.define(() => {
     }
   });
 
-  it("keeps the trailing unread dot on one axis with and without a pull-request icon", async () => {
+  it("aligns trailing unread dots and trades unread/PR icons for hover actions", async () => {
     const plainKey = "agent:main:unread-plain";
     const pullRequestKey = "agent:main:unread-pr";
     const context = await suite.browser.newContext({
@@ -261,6 +261,9 @@ suite.define(() => {
       viewport: { height: 900, width: 1280 },
     });
     const page = await context.newPage();
+    await page.addInitScript(() => {
+      localStorage.setItem("openclaw:sidebar:sessions:show-preview", "false");
+    });
     const gateway = await installMockGateway(page, {
       featureMethods: ["chat.metadata", "chat.startup", SESSION_PULL_REQUESTS_SUBSCRIBE_METHOD],
       methodResponses: {
@@ -342,6 +345,23 @@ suite.define(() => {
         await dotInsetFromRowRight(plainRow),
         0,
       );
+      const pullRequestIcon = pullRequestRow.locator("[data-pull-request-state='merged']");
+      const unreadDot = pullRequestRow.locator(".session-unread-dot");
+      const trailingState = pullRequestRow.locator(".session-row-state");
+      await captureUiProof(page, "sidebar-pr-before-hover.png");
+      await pullRequestRow.hover();
+      await captureUiProof(page, "sidebar-pr-hover.png");
+      await pullRequestIcon.waitFor({ state: "hidden" });
+      await unreadDot.waitFor({ state: "hidden" });
+      await trailingState.waitFor({ state: "hidden" });
+      await page.mouse.move(0, 0);
+      await pullRequestIcon.waitFor({ state: "visible" });
+      await unreadDot.waitFor({ state: "visible" });
+      await pullRequestRow.getByRole("button", { name: "Open session menu" }).focus();
+      await trailingState.waitFor({ state: "hidden" });
+      await codingToggle.focus();
+      await pullRequestIcon.waitFor({ state: "visible" });
+      await unreadDot.waitFor({ state: "visible" });
     } finally {
       await context.close();
     }

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -2116,6 +2116,18 @@ openclaw-settings-save-indicator:empty {
   padding-right: var(--session-row-actions-reserve);
 }
 
+/* Trade unread/PR tracks for action space, keeping active state and second-line
+   metadata visible. Collapse empty containers too so their gaps cannot squeeze the title. */
+.sidebar-recent-session--single-line:not(.sidebar-recent-session--child):is(:hover, :focus-within)
+  :is(
+    .session-unread-dot,
+    .session-row-badge--pull-request,
+    .session-row-aside:has(> .session-row-state > .session-unread-dot:only-child),
+    .session-row-badges:has(> openclaw-tooltip:only-child > .session-row-badge--pull-request)
+  ) {
+  display: none;
+}
+
 .nav-collapse-toggle__icon {
   display: flex;
   align-items: center;


### PR DESCRIPTION
Closes #132401

## What Problem This Solves

Resolves a problem where hovering or keyboard-focusing a single-line sidebar session squeezed its title more than necessary: the unread and pull-request icons kept consuming space while pin/menu actions appeared.

## Why This Change Was Made

Temporarily collapse unread/PR icons and their otherwise-empty layout containers at the existing sidebar hover/focus boundary. Reuse the canonical badge renderer and CSS; no new JavaScript state, dependency, or setting.

## User Impact

Single-line session titles keep more room when actions appear. Icons return afterward without marking the session read. Running/attention indicators, other badges, two-line rows, and child rows retain their existing behavior.

## Evidence

- Focused browser suites: 11 assertions/tests passed across `chat-flow.sidebar-presentation.e2e.test.ts` and `session-management.trailing-state.e2e.test.ts` on the refreshed branch. Command: `OPENCLAW_CAPTURE_UI_PROOF=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/chat-flow.sidebar-presentation.e2e.test.ts ui/src/e2e/session-management.trailing-state.e2e.test.ts`.
- Covers hover and keyboard focus, restoration afterward, reclaimed title width, unread/PR coexistence, active-state preservation, touch actions, and two-line geometry.
- Original implementation reproduced the failure before adding the CSS rule. Current-main refresh removes the retired PR-icon selector and uses the canonical shared PR badge.
- Production LOC: +12/-0 CSS. Tests: +64/-3. Growth implements the requested presentation capability at the existing layout owner; no new runtime state or event handlers.
- Standalone live-flow attempt: an isolated loopback Gateway was started with a temporary state directory, no ambient channels, and no provider credentials. Its normal UI gates conversation creation at **Connect a verified AI model**, so live session-row proof could not proceed. The screenshots below are inspected Chromium screenshots of the real Control UI with a **mocked Gateway**, not live provider/Gateway proof.
- Production UI build passed: `node scripts/ui.js build`. Branch and rebase-adaptation autoreview passes both returned no accepted/actionable findings.
- One refreshed full browser run passed all 11 tests but hit the wrapper no-output watchdog during synchronous temporary-directory deletion (exit 137). A process sample identified filesystem cleanup, not a running test. The two changed scenarios then passed with exit 0 under the normal limits: the same command plus `-t 'keeps session titles on the first line|aligns trailing unread dots'`. The changed-check run initially hit stale local dependencies (`@types/jsdom` missing); `pnpm install --frozen-lockfile` repaired the install without source changes. The remaining core/UI types, targeted oxlint, and stylelint commands then passed. Exact-head CI also passed: https://github.com/openclaw/openclaw/actions/runs/33237186869.

### Resting row

![Unread and PR icons at rest](https://github.com/user-attachments/assets/3e3a92cd-5e08-4442-8a46-a98a7df1598c)

### Hovered row

![Unread and PR icons collapse beside the hover actions](https://github.com/user-attachments/assets/f557efa2-0170-496c-95b9-9198fe46f5cd)

AI-assisted. Requested and reviewed as a small Control UI presentation improvement; no configuration, protocol, provider, persistence, or security-boundary changes.
