### PR TITLE
fix(qa): keep Matrix backup failure scenarios unavailable

### DIFF
--- a/extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-runtime-e2ee-room.ts
+++ b/extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-runtime-e2ee-room.ts
@@ -68,16 +68,18 @@ export function buildRoomKeyBackupUnavailableFaultRule(
   return {
     id: MATRIX_QA_ROOM_KEY_BACKUP_FAULT_RULE_ID,
     match: (request) =>
-      request.method === "GET" &&
+      (request.method === "GET" || request.method === "POST") &&
       request.path === MATRIX_QA_ROOM_KEY_BACKUP_VERSION_ENDPOINT &&
       request.bearerToken === accessToken,
-    response: () => ({
-      body: {
-        errcode: "M_NOT_FOUND",
-        error: "No current key backup",
-      },
-      status: 404,
-    }),
+    // A missing backup alone is recoverable: the SDK creates and activates one.
+    // Reject creation too so both bootstrap paths exercise an unavailable backup.
+    response: (request) =>
+      request.method === "POST"
+        ? {
+            body: { errcode: "M_UNKNOWN", error: "Room key backup creation unavailable" },
+            status: 503,
+          }
+        : { body: { errcode: "M_NOT_FOUND", error: "No current key backup" }, status: 404 },
   };
 }
 

--- a/extensions/qa-lab/src/live-transports/matrix/substrate/fault-proxy.test.ts
+++ b/extensions/qa-lab/src/live-transports/matrix/substrate/fault-proxy.test.ts
@@ -2,6 +2,7 @@
 import { createServer, request } from "node:http";
 import { gzipSync } from "node:zlib";
 import { afterEach, describe, expect, it } from "vitest";
+import { buildRoomKeyBackupUnavailableFaultRule } from "../scenarios/scenario-runtime-e2ee-room.js";
 import { startMatrixQaFaultProxy } from "./fault-proxy.js";
 
 type MatrixQaFaultProxy = Awaited<ReturnType<typeof startMatrixQaFaultProxy>>;
@@ -75,26 +76,11 @@ describe("Matrix QA fault proxy", () => {
     }
   });
 
-  it("faults matching Matrix requests and forwards everything else", async () => {
+  it("prevents backup discovery and creation only for the faulted account", async () => {
     const target = await startTargetServer();
     proxy = await startMatrixQaFaultProxy({
       targetBaseUrl: target.baseUrl,
-      rules: [
-        {
-          id: "room-key-backup-version-unavailable",
-          match: (proxyRequest) =>
-            proxyRequest.method === "GET" &&
-            proxyRequest.path === "/_matrix/client/v3/room_keys/version" &&
-            proxyRequest.bearerToken === "driver-token",
-          response: () => ({
-            body: {
-              errcode: "M_NOT_FOUND",
-              error: "No current key backup",
-            },
-            status: 404,
-          }),
-        },
-      ],
+      rules: [buildRoomKeyBackupUnavailableFaultRule("driver-token")],
     });
 
     const faulted = await fetch(`${proxy.baseUrl}/_matrix/client/v3/room_keys/version`, {
@@ -105,6 +91,20 @@ describe("Matrix QA fault proxy", () => {
       errcode: "M_NOT_FOUND",
       error: "No current key backup",
     });
+
+    const creation = await fetch(`${proxy.baseUrl}/_matrix/client/v3/room_keys/version`, {
+      headers: { authorization: "Bearer driver-token" },
+      method: "POST",
+    });
+    expect(creation.status).toBe(503);
+    await expect(creation.json()).resolves.toMatchObject({ errcode: "M_UNKNOWN" });
+
+    const otherAccount = await fetch(`${proxy.baseUrl}/_matrix/client/v3/room_keys/version`, {
+      headers: { authorization: "Bearer other-token" },
+      method: "POST",
+    });
+    expect(otherAccount.status).toBe(200);
+    await expect(otherAccount.json()).resolves.toEqual({ forwarded: true });
 
     const forwarded = await fetch(`${proxy.baseUrl}/_matrix/client/v3/sync?timeout=0`, {
       body: JSON.stringify({ ok: true }),
@@ -123,8 +123,19 @@ describe("Matrix QA fault proxy", () => {
         path: "/_matrix/client/v3/room_keys/version",
         ruleId: "room-key-backup-version-unavailable",
       },
+      {
+        method: "POST",
+        path: "/_matrix/client/v3/room_keys/version",
+        ruleId: "room-key-backup-version-unavailable",
+      },
     ]);
     expect(target.requests).toEqual([
+      {
+        authorization: "Bearer other-token",
+        body: "",
+        method: "POST",
+        url: "/_matrix/client/v3/room_keys/version",
+      },
       {
         authorization: "Bearer driver-token",
         body: '{"ok":true}',


### PR DESCRIPTION
## What Problem This Solves

Resolves false failures in full release verification's Matrix backup-failure scenarios. In [the frozen release run](https://github.com/openclaw/openclaw/actions/runs/33230752148/job/99043456912), both the direct bootstrap and encryption-setup CLI scenarios succeeded despite the fixture claiming that room-key backup was unavailable.

## Why This Change Was Made

The shared fault rule returned 404 for backup discovery but allowed backup creation. [Matrix SDK 42.2.0 activates the backup directly from the successful creation response](https://github.com/matrix-org/matrix-js-sdk/blob/v42.2.0/src/rust-crypto/backup.ts#L543), so missing discovery alone no longer establishes the intended failure.

The fixture now also returns 503 for backup creation, scoped to the same endpoint and account. The existing HTTP-boundary test uses the real shared rule instead of a copied rule, and verifies discovery failure, creation failure, unrelated-account forwarding, and unrelated-endpoint forwarding. Both real scenario callers retain their existing failure assertions and cleanup.

## User Impact

Internal release-validation repair only. No product runtime, SDK version, credentials, timeouts, skips, or security checks change. The separate Matrix streaming-retention timeout remains outside this change.

## Evidence

- Before: the new HTTP regression fails on frozen `383a293b32d97254014437430b62aaf406bc11ac` because creation returns 200 instead of 503. The original Matrix release artifact records 90 passes and three failures, including both affected bootstrap scenarios.
- After: all nine tests in `extensions/qa-lab/src/live-transports/matrix/substrate/fault-proxy.test.ts` pass. Formatting and `git diff --check` pass. Local shared dependencies are older than the release lockfile, so this is HTTP-boundary proof, not pinned-SDK integration proof.
- Fresh Linux/Docker proof passed through Blacksmith Testbox [33236849989](https://github.com/openclaw/openclaw/actions/runs/33236849989), with a frozen install, private-QA build, and only `matrix-e2ee-key-bootstrap-failure` and `matrix-e2ee-cli-encryption-setup-bootstrap-failure`, using disposable Matrix users and the mock OpenAI provider. Both scenarios passed with zero failures or skips; the log records GET 404 followed by POST 503 at backup creation. The same run passed all nine proxy tests with Vitest 4.1.11. The complete command took 7m03.845s and exited 0; its one-shot Testbox was stopped successfully. The workflow used main `bcac331e0746ef866e871cdd9c2753f65222f927` plus the two synchronized candidate files; this is candidate-file integration proof, not an exact frozen-release rerun. Blacksmith owns the command verdict, so its backing Actions run may show cancellation during successful lease cleanup.

Local targeted lint could not reach the changed files because the inherited dependency tree failed SDK declaration preparation (Google finish-reason, markdown-it types, and pi-tui exports). Shared dependencies were not modified; fresh hosted CI remains required.

Production runtime delta: zero. QA fixture: +10/-8; tests: +28/-17, replacing duplicate policy with the exercised owner. AI-assisted; independent Codex autoreview completed clean with no accepted/actionable P0 findings. The reviewer verified the SDK contract; the live result above supplies the separately observed integration proof.
