### PR TITLE
fix(browser): worker targets no longer crash the gateway

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -86,7 +86,6 @@ extensions/browser/src/browser/playwright-core.runtime.ts	2
 extensions/browser/src/browser/pw-download-capture.ts	1
 extensions/browser/src/browser/pw-role-snapshot.ts	1
 extensions/browser/src/browser/pw-session-actions.ts	2
-extensions/browser/src/browser/pw-session-cdp-transport.ts	1
 extensions/browser/src/browser/pw-session-navigation.ts	1
 extensions/browser/src/browser/pw-session.page-cdp.ts	4
 extensions/browser/src/browser/pw-tools-core.interactions.actions.ts	2

--- a/extensions/browser/src/browser/pw-session-cdp-transport.test-support.ts
+++ b/extensions/browser/src/browser/pw-session-cdp-transport.test-support.ts
@@ -1,0 +1,12 @@
+import { chromium } from "playwright-core";
+
+/** Test transport that preserves the existing Playwright connection spies. */
+export function connectOverCdpTransport(
+  connectionUrl: string,
+  opts: { timeout: number; headers: Record<string, string> },
+) {
+  return chromium.connectOverCDP(connectionUrl, {
+    timeout: opts.timeout,
+    headers: opts.headers,
+  });
+}

--- a/extensions/browser/src/browser/pw-session-cdp-transport.ts
+++ b/extensions/browser/src/browser/pw-session-cdp-transport.ts
@@ -1,21 +1,49 @@
 import type { lookup as dnsLookupCb } from "node:dns";
+import { asOptionalRecord, readStringField } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { rawDataToString } from "openclaw/plugin-sdk/webhook-ingress";
 import type { Browser, ConnectOverCDPTransport } from "playwright-core";
 import WebSocket from "ws";
 import { formatErrorMessage } from "../infra/errors.js";
-import { openCdpWebSocket } from "./cdp.helpers.js";
+import { isWebSocketUrl, openCdpWebSocket } from "./cdp.helpers.js";
 import { getPlaywrightCore } from "./playwright-core.runtime.js";
 type CdpSocketLookup = typeof dnsLookupCb;
+// Playwright allocates positive command IDs and reserves -9999 for Browser.close.
+// Keep transport-owned replies below that range so Playwright never consumes them.
+const FIRST_INTERNAL_COMMAND_ID = -10_000;
 
-export async function connectOverCdpPinnedTransport(
+// Playwright exempts only the browser target before requiring browserContextId.
+// Release every other contextless target here or its assertion exits the Gateway.
+function contextlessTargetSession(message: Record<string, unknown>): string | undefined {
+  if (readStringField(message, "method") !== "Target.attachedToTarget") {
+    return undefined;
+  }
+  const params = asOptionalRecord(message.params);
+  const targetInfo = asOptionalRecord(params?.targetInfo);
+  if (
+    readStringField(targetInfo, "type") === "browser" ||
+    readStringField(targetInfo, "browserContextId")
+  ) {
+    return undefined;
+  }
+  return readStringField(params, "sessionId");
+}
+
+export async function connectOverCdpTransport(
   connectionUrl: string,
   opts: {
     timeout: number;
     headers: Record<string, string>;
-    lookup: CdpSocketLookup;
+    lookup?: CdpSocketLookup;
+    resolveWebSocketUrl?: () => Promise<string | undefined>;
   },
 ): Promise<Browser> {
-  const ws = openCdpWebSocket(connectionUrl, {
+  const resolvedConnectionUrl = isWebSocketUrl(connectionUrl)
+    ? connectionUrl
+    : await opts.resolveWebSocketUrl?.();
+  if (!resolvedConnectionUrl) {
+    throw new Error("CDP endpoint did not expose a usable WebSocket URL.");
+  }
+  const ws = openCdpWebSocket(resolvedConnectionUrl, {
     headers: opts.headers,
     handshakeTimeoutMs: opts.timeout,
     lookup: opts.lookup,
@@ -33,6 +61,8 @@ export async function connectOverCdpPinnedTransport(
     let pendingCloseReason: string | undefined;
     let transportClosed = false;
     let transportCloseScheduled = false;
+    let nextInternalCommandId = FIRST_INTERNAL_COMMAND_ID;
+    const pendingContextlessTargetResumes = new Map<number, string>();
     const notifyTransportClosed = (reason: string) => {
       if (transportClosed) {
         return;
@@ -63,6 +93,28 @@ export async function connectOverCdpPinnedTransport(
         }
       }, 100);
       terminateTimer.unref?.();
+    };
+    const sendInternalCommand = (
+      method: string,
+      params: Record<string, unknown> | undefined,
+      sessionId?: string,
+    ): number => {
+      const id = nextInternalCommandId--;
+      ws.send(
+        JSON.stringify({
+          id,
+          method,
+          ...(params ? { params } : {}),
+          sessionId,
+        }),
+      );
+      return id;
+    };
+    const releaseContextlessTarget = (sessionId: string) => {
+      // Chrome dispatches session and root commands independently. Wait for the
+      // resume response before detach so the hidden target cannot stay paused.
+      const resumeId = sendInternalCommand("Runtime.runIfWaitingForDebugger", undefined, sessionId);
+      pendingContextlessTargetResumes.set(resumeId, sessionId);
     };
     const scheduleMessage = (message: object) => {
       setImmediate(() => {
@@ -116,7 +168,25 @@ export async function connectOverCdpPinnedTransport(
     };
     ws.on("message", (raw) => {
       try {
-        const parsed = JSON.parse(rawDataToString(raw)) as object;
+        const parsed = asOptionalRecord(JSON.parse(rawDataToString(raw)));
+        if (!parsed) {
+          closeTransportSocket();
+          return;
+        }
+        const id = parsed.id;
+        if (typeof id === "number" && id <= FIRST_INTERNAL_COMMAND_ID) {
+          const targetSessionId = pendingContextlessTargetResumes.get(id);
+          if (targetSessionId) {
+            pendingContextlessTargetResumes.delete(id);
+            sendInternalCommand("Target.detachFromTarget", { sessionId: targetSessionId });
+          }
+          return;
+        }
+        const contextlessSessionId = contextlessTargetSession(parsed);
+        if (contextlessSessionId) {
+          releaseContextlessTarget(contextlessSessionId);
+          return;
+        }
         scheduleMessage(parsed);
       } catch {
         closeTransportSocket();

--- a/extensions/browser/src/browser/pw-session-connection.ts
+++ b/extensions/browser/src/browser/pw-session-connection.ts
@@ -15,8 +15,7 @@ import {
 } from "./cdp.helpers.js";
 import { getChromeWebSocketEndpoint } from "./chrome.js";
 import { BrowserTabNotFoundError } from "./errors.js";
-import { getPlaywrightCore } from "./playwright-core.runtime.js";
-import { connectOverCdpPinnedTransport } from "./pw-session-cdp-transport.js";
+import { connectOverCdpTransport } from "./pw-session-cdp-transport.js";
 import {
   blockedPageRefsByCdpUrl,
   blockedTargetsByCdpUrl,
@@ -420,16 +419,21 @@ export async function connectBrowser(
           return null;
         });
         const hasUrlCredentials = stripCdpUrlCredentials(normalized) !== normalized;
-        if (!resolvedEndpoint && hasUrlCredentials && !isWebSocketUrl(normalized)) {
-          // Playwright preserves explicit headers across HTTP discovery redirects.
-          // Keep credentialed discovery in OpenClaw's guarded fetch path instead.
-          throw new Error("Authenticated CDP HTTP endpoint did not expose a usable WebSocket URL.");
-        }
-        if (!resolvedEndpoint && ssrfPolicy && !isWebSocketUrl(normalized)) {
+        const configuredIsWebSocket = isWebSocketUrl(normalized);
+        if (!resolvedEndpoint && !configuredIsWebSocket) {
+          if (hasUrlCredentials) {
+            // Playwright preserves explicit headers across HTTP discovery redirects.
+            // Keep credentialed discovery in OpenClaw's guarded fetch path instead.
+            throw new Error(
+              "Authenticated CDP HTTP endpoint did not expose a usable WebSocket URL.",
+            );
+          }
           const detail = endpointDiscoveryError
             ? ` Reason: ${redactCdpErrorText(formatErrorMessage(endpointDiscoveryError))}`
             : "";
-          throw new Error(`Guarded CDP endpoint did not expose a usable WebSocket URL.${detail}`);
+          if (ssrfPolicy) {
+            throw new Error(`Guarded CDP endpoint did not expose a usable WebSocket URL.${detail}`);
+          }
         }
         const normalizedCdpHostname = new URL(normalized).hostname;
         const needsPinnedDependencyConnect =
@@ -441,19 +445,17 @@ export async function connectBrowser(
         const connectEndpoint = async (target: string, lookup?: CdpEndpointPin["lookup"]) => {
           const headers = getHeadersWithAuth(target);
           const connectionUrl = stripCdpUrlCredentials(target);
+          const resolveWebSocketUrl = isWebSocketUrl(connectionUrl)
+            ? undefined
+            : async () => (await getChromeWebSocketEndpoint(connectionUrl, timeout))?.url;
           // Keep both loopback bypasses active until the Playwright handshake settles.
           return await withManagedProxyForCdpUrl(connectionUrl, () =>
             withNoProxyForCdpUrl(connectionUrl, async () => {
-              if (lookup) {
-                return await connectOverCdpPinnedTransport(connectionUrl, {
-                  timeout,
-                  headers,
-                  lookup,
-                });
-              }
-              return await getPlaywrightCore().chromium.connectOverCDP(connectionUrl, {
+              return await connectOverCdpTransport(connectionUrl, {
                 timeout,
                 headers,
+                lookup,
+                resolveWebSocketUrl,
               });
             }),
           );
@@ -462,7 +464,7 @@ export async function connectBrowser(
         try {
           browser = await connectEndpoint(endpointUrl, endpointLookup);
         } catch (err) {
-          if (!isWebSocketUrl(normalized) || endpointUrl === normalized) {
+          if (!configuredIsWebSocket || endpointUrl === normalized) {
             throw err;
           }
           browser = await connectEndpoint(normalized, configuredPin?.lookup);

--- a/extensions/browser/src/browser/pw-session.connection.test-support.ts
+++ b/extensions/browser/src/browser/pw-session.connection.test-support.ts
@@ -14,6 +14,11 @@ vi.mock("openclaw/plugin-sdk/ssrf-runtime-internal", () => ({
   registerManagedProxyBrowserCdpBypass: registerManagedProxyBrowserCdpBypassMock,
 }));
 
+vi.mock(
+  "./pw-session-cdp-transport.js",
+  () => import("./pw-session-cdp-transport.test-support.js"),
+);
+
 export type BrowserMockBundle = {
   browser: import("playwright-core").Browser;
   browserClose: ReturnType<typeof vi.fn>;

--- a/extensions/browser/src/browser/pw-session.create-page.navigation-guard.test.ts
+++ b/extensions/browser/src/browser/pw-session.create-page.navigation-guard.test.ts
@@ -25,6 +25,11 @@ const {
 const connectOverCdpSpy = vi.spyOn(chromium, "connectOverCDP");
 const getChromeWebSocketEndpointSpy = vi.spyOn(chromeModule, "getChromeWebSocketEndpoint");
 
+vi.mock(
+  "./pw-session-cdp-transport.js",
+  () => import("./pw-session-cdp-transport.test-support.js"),
+);
+
 const PROXY_ENV_KEYS = [
   "ALL_PROXY",
   "all_proxy",

--- a/extensions/browser/src/browser/pw-session.get-page-for-targetid.test.ts
+++ b/extensions/browser/src/browser/pw-session.get-page-for-targetid.test.ts
@@ -16,6 +16,11 @@ const {
 const connectOverCdpSpy = vi.spyOn(chromium, "connectOverCDP");
 const getChromeWebSocketEndpointSpy = vi.spyOn(chromeModule, "getChromeWebSocketEndpoint");
 
+vi.mock(
+  "./pw-session-cdp-transport.js",
+  () => import("./pw-session-cdp-transport.test-support.js"),
+);
+
 type MockPageSpec = {
   targetId?: string;
   url?: string;

--- a/extensions/browser/src/browser/pw-session.pinned-transport.test.ts
+++ b/extensions/browser/src/browser/pw-session.pinned-transport.test.ts
@@ -1,4 +1,4 @@
-// Browser tests cover pinned Playwright CDP transport behavior.
+// Browser tests cover managed Playwright CDP transport behavior.
 import { createServer } from "node:http";
 import { rawDataToString } from "openclaw/plugin-sdk/webhook-ingress";
 import { chromium } from "playwright-core";
@@ -78,7 +78,143 @@ afterEach(async () => {
   await closePlaywrightBrowserConnection().catch(() => {});
 });
 
-describe("pw-session pinned Playwright transport", () => {
+describe("pw-session Playwright CDP transport", () => {
+  it("keeps HTTP fallback managed while releasing contextless non-browser targets", async () => {
+    const server = new WebSocketServer({ port: 0, host: "127.0.0.1" });
+    await new Promise<void>((resolve) => {
+      server.once("listening", () => resolve());
+    });
+    const port = (server.address() as { port: number }).port;
+    const cdpUrl = `http://127.0.0.1:${port}`;
+    const transportUrl = `ws://127.0.0.1:${port}/devtools/browser/test`;
+    const serverSocket = new Promise<import("ws").WebSocket>((resolve) => {
+      server.on("connection", (socket) => resolve(socket));
+    });
+    const commands: Array<{ id: number; method: string; params?: unknown; sessionId?: string }> =
+      [];
+    const resumeCommands: Array<{ id: number; sessionId?: string }> = [];
+    server.on("connection", (socket) => {
+      socket.addEventListener("message", (event) => {
+        const command = JSON.parse(
+          webSocketMessageToString(event.data),
+        ) as (typeof commands)[number];
+        commands.push(command);
+        if (command.method === "Runtime.runIfWaitingForDebugger") {
+          resumeCommands.push(command);
+          return;
+        }
+        socket.send(JSON.stringify({ id: command.id, result: {} }));
+      });
+    });
+    getChromeWebSocketEndpointSpy
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({ url: transportUrl });
+    const browser = makeBrowser("A", "https://example.com");
+    connectOverCdpSpy.mockImplementationOnce((async (transportArg: unknown) => {
+      expect(typeof transportArg).not.toBe("string");
+      const transport = transportArg as import("playwright-core").ConnectOverCDPTransport;
+      const delivered: object[] = [];
+      // oxlint-disable-next-line unicorn/prefer-add-event-listener -- Playwright's ConnectOverCDPTransport contract uses an onmessage property.
+      transport.onmessage = (message) => delivered.push(message);
+      const socket = await serverSocket;
+      const contextlessTargetTypes = [
+        "worker",
+        "shared_worker",
+        "service_worker",
+        "worklet",
+        "shared_storage_worklet",
+        "auction_worklet",
+        "other",
+        "page",
+      ];
+      for (const [index, type] of contextlessTargetTypes.entries()) {
+        socket.send(
+          JSON.stringify({
+            method: "Target.attachedToTarget",
+            params: {
+              sessionId: `contextless-session-${index}`,
+              targetInfo: { targetId: `contextless-target-${index}`, type },
+              waitingForDebugger: true,
+            },
+          }),
+        );
+      }
+      const forwardedTargetInfos = [
+        { type: "browser" },
+        { type: "page", browserContextId: "default-context" },
+        { type: "other", browserContextId: "default-context" },
+        { type: "service_worker", browserContextId: "default-context" },
+      ];
+      const forwardedTargets = forwardedTargetInfos.map((targetInfo, index) => ({
+        method: "Target.attachedToTarget",
+        params: {
+          sessionId: `forwarded-session-${index}`,
+          targetInfo: { targetId: `forwarded-target-${index}`, ...targetInfo },
+          waitingForDebugger: true,
+        },
+      }));
+      for (const event of forwardedTargets) {
+        socket.send(JSON.stringify(event));
+      }
+
+      await vi.waitFor(() => {
+        expect(commands).toHaveLength(contextlessTargetTypes.length);
+      });
+      expect(commands).toEqual(
+        contextlessTargetTypes.map((_type, index) =>
+          expect.objectContaining({
+            id: expect.any(Number),
+            method: "Runtime.runIfWaitingForDebugger",
+            sessionId: `contextless-session-${index}`,
+          }),
+        ),
+      );
+      const firstResume = resumeCommands[0];
+      if (!firstResume) {
+        throw new Error("missing first contextless-target resume command");
+      }
+      socket.send(JSON.stringify({ id: firstResume.id, result: {} }));
+      await vi.waitFor(() => {
+        expect(commands).toHaveLength(contextlessTargetTypes.length + 1);
+      });
+      expect(commands.at(-1)).toEqual(
+        expect.objectContaining({
+          method: "Target.detachFromTarget",
+          params: { sessionId: "contextless-session-0" },
+        }),
+      );
+      for (const command of resumeCommands.slice(1)) {
+        socket.send(JSON.stringify({ id: command.id, result: {} }));
+      }
+      await vi.waitFor(() => {
+        expect(commands).toHaveLength(contextlessTargetTypes.length * 2);
+      });
+      expect(commands.slice(contextlessTargetTypes.length + 1)).toEqual(
+        contextlessTargetTypes.slice(1).map((_type, index) =>
+          expect.objectContaining({
+            method: "Target.detachFromTarget",
+            params: { sessionId: `contextless-session-${index + 1}` },
+          }),
+        ),
+      );
+      await vi.waitFor(() => {
+        expect(delivered).toEqual(forwardedTargets);
+      });
+      transport.close();
+      return browser.browser;
+    }) as never);
+
+    try {
+      await expect(listPagesViaPlaywright({ cdpUrl })).resolves.toEqual([
+        expect.objectContaining({ targetId: "A" }),
+      ]);
+    } finally {
+      await new Promise<void>((resolve) => {
+        server.close(() => resolve());
+      });
+    }
+  });
+
   it("connects guarded Playwright CDP through the pinned WebSocket transport", async () => {
     const server = new WebSocketServer({ port: 0, host: "127.0.0.1" });
     await new Promise<void>((resolve) => {

--- a/extensions/browser/src/browser/pw-session.termination-cdp-ssrf.test.ts
+++ b/extensions/browser/src/browser/pw-session.termination-cdp-ssrf.test.ts
@@ -49,6 +49,11 @@ vi.mock("ws", () => {
   return { default: MockWebSocket };
 });
 
+vi.mock(
+  "./pw-session-cdp-transport.js",
+  () => import("./pw-session-cdp-transport.test-support.js"),
+);
+
 const connectOverCdpSpy = vi.spyOn(chromium, "connectOverCDP");
 const getChromeWebSocketEndpointSpy = vi.spyOn(chromeModule, "getChromeWebSocketEndpoint");
 


### PR DESCRIPTION
Closes #131892

## What Problem This Solves

An attached Chrome profile could terminate the Gateway when Chrome reported a target without a browser context ID.

## Root Cause

OpenClaw forwarded every `Target.attachedToTarget` event to Playwright. Playwright 1.62.1 exempts only the browser target before requiring `browserContextId`. A contextless service worker, shared worker, worklet, page, or other target therefore reached a Playwright assertion. That rejection reached the Gateway fatal boundary and exited the process.

The managed Chrome DevTools Protocol transport is the owner because it sees the target event before Playwright and already owns the socket lifecycle.

## Fix

- Route both WebSocket and HTTP-discovered Chrome connections through one managed transport.
- Resume every attached non-browser target without a context, wait for Chrome's resume response, then detach that exact session.
- Keep transport-owned command responses out of Playwright's message stream.
- Preserve guarded endpoint discovery, endpoint retry, authentication headers, and server-side request forgery protections.

## User Impact

Operators can keep an attached Chrome profile open on sites that start background workers without one target terminating the Gateway and every active browser session.

## Evidence

- Live red on `dc17d248cc62ac2ba6d754787c1fe99edf1d396f`: real Chrome produced two service workers without context IDs. The first Browser action reached Playwright's `targetInfo` assertion, and the Gateway exited with code 1.
- Current `main` `f9b3bcccdba3dc159c6484c30f56974b90a6d938` leaves both Browser owner modules unchanged from that live-red revision.
- Live green on `72eded7f1c020cb9546616c88701312639dd1efc`: real Chrome produced 16 rewritten worker attachments, including 12 service workers and four shared workers. The transport sent 16 resume commands, observed all 16 responses, sent 16 detach commands, and never detached early. Four Browser actions passed through the Gateway, and the Gateway stayed alive.
- Final head `fde9ae43230410ebc47e5030bc1813a7b804313a` has the same tree as the proven head, rebased onto `f9b3bccc`, with obsolete intermediate commit bytes removed. The Browser owner files did not change. The final tree passes 115/115 focused Browser tests.
- The installed Playwright 1.62.1 source starts Chrome DevTools Protocol command IDs at 1 and increments them. It reserves `-9999` for `Browser.close`. OpenClaw starts transport-owned IDs at `-10000` and decrements them. The exact-head Chrome trace recorded Playwright IDs 1 through 106, transport IDs `-10000` through `-10031`, and no overlap.
- The owner-boundary regression fails on the previous head because contextless `other` and page-shaped targets are forwarded. It passes on the repaired head and verifies those targets are withheld before Playwright.
- Exact-head changed-scope gates passed before the tree-identical refresh: production and test type checks, Oxlint, Oxfmt, assertion safety, coercion rules, plugin boundaries, dead exports, and zero runtime import cycles.

## Shape And Size

- One closed transport shape now covers direct WebSocket endpoints and HTTP-discovered endpoints.
- One predicate mirrors Playwright's context rule for every target type instead of maintaining a worker-name list.
- The native Playwright HTTP bypass is removed.
- Production delta: +72 lines.
- Test and test-support delta: +168 lines.
- Baseline delta: -1 line.
- The production growth adds the protocol state needed to isolate internal replies and enforce response-before-detach ordering. No parallel fallback or duplicate connection path remains.

AI-assisted repair. I inspected the complete owner path, callers, sibling transports, Playwright source and types, current-main history, overlaps, tests, CI, and live Chrome behavior.
