### PR TITLE
test: remove redundant Control UI setup and waiting

### DIFF
--- a/ui/src/e2e/agent-selection-persistence.e2e.test.ts
+++ b/ui/src/e2e/agent-selection-persistence.e2e.test.ts
@@ -178,13 +178,11 @@ suite.define(() => {
       const reopened = await openPage(context);
       const reopenedPage = reopened.page;
       await reopened.gateway.waitForRequest("chat.startup");
-      await reopenedPage.waitForTimeout(1_500);
-      await screenshot(reopenedPage, "03-reopened-agent.png");
-
       await waitForControlUiRoute(reopenedPage, {
         pathname: "/chat/openclaw",
         routeId: "chat",
       });
+      await screenshot(reopenedPage, "03-reopened-agent.png");
       await expect.poll(() => hasOpenClawStartup(reopened.gateway)).toBe(true);
       await expect.poll(() => selectedAgentName(reopenedPage)).toBe("OpenClaw");
       await expect

--- a/ui/src/e2e/lobster-pet-dismiss-menu-overflow.e2e.test.ts
+++ b/ui/src/e2e/lobster-pet-dismiss-menu-overflow.e2e.test.ts
@@ -3,8 +3,8 @@
 // Linux run matches what a macOS "Always show scrollbars" operator sees.
 import { mkdir } from "node:fs/promises";
 import path from "node:path";
-import type { BrowserContext, Page } from "playwright";
-import { beforeEach, expect, it } from "vitest";
+import type { BrowserContextOptions, Page } from "playwright";
+import { expect, it } from "vitest";
 import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
@@ -30,9 +30,6 @@ const artifactDir = path.resolve(
   ".artifacts/control-ui-e2e/lobster-dismiss-menu-overflow",
 );
 
-let context: BrowserContext;
-let page: Page;
-
 /** Shared setup for a fresh page: mock gateway, load, and park the clock so
  *  the pet's own timers don't fire mid-assertion. Reused across the default
  *  1280x900 context and the per-test contexts below (compact/edge/theme). */
@@ -43,6 +40,17 @@ async function loadControlUiPage(currentPage: Page) {
   await currentPage.waitForFunction(() => Boolean(customElements.get("openclaw-lobster-pet")));
   const loadedAt = await currentPage.evaluate(() => Date.now());
   await currentPage.clock.pauseAt(loadedAt + 1_000);
+}
+
+async function withDismissMenuPage(
+  options: BrowserContextOptions,
+  run: (page: Page) => Promise<void>,
+) {
+  await suite.withPage({ viewport: { width: 1280, height: 900 }, ...options }, async ({ page }) => {
+    await loadControlUiPage(page);
+    await mkdir(artifactDir, { recursive: true });
+    await run(page);
+  });
 }
 
 /** Mounts the pet inside the real sidebar footer ledge so production CSS
@@ -163,136 +171,39 @@ async function useOversizedDismissLabels(currentPage: Page) {
 }
 
 suite.define(() => {
-  beforeEach(async () => {
-    context = await suite.newBrowserContext({ viewport: { width: 1280, height: 900 } });
-    page = await context.newPage();
-    await loadControlUiPage(page);
-    await mkdir(artifactDir, { recursive: true });
-  });
+  it("does not scroll its two dismissal items in the real sidebar footer", () =>
+    withDismissMenuPage({}, async (page) => {
+      await mountPetInRealFooter(page, 42);
+      const sprite = page.locator(".lobster-pet");
+      await sprite.waitFor();
 
-  it("does not scroll its two dismissal items in the real sidebar footer", async () => {
-    await mountPetInRealFooter(page, 42);
-    const sprite = page.locator(".lobster-pet");
-    await sprite.waitFor();
+      await sprite.click({ button: "right" });
+      await page.locator("wa-dropdown.lobster-pet-dismiss-menu").waitFor();
+      await page.getByText("Dismiss and don't show again", { exact: true }).waitFor();
 
-    await sprite.click({ button: "right" });
-    await page.locator("wa-dropdown.lobster-pet-dismiss-menu").waitFor();
-    await page.getByText("Dismiss and don't show again", { exact: true }).waitFor();
+      const measurement = await measureDismissMenu(page);
+      await page.screenshot({ path: path.join(artifactDir, "real-footer-context.png") });
 
-    const measurement = await measureDismissMenu(page);
-    await page.screenshot({ path: path.join(artifactDir, "real-footer-context.png") });
-
-    // Asserting on the whole measurement so a regression prints the anchor
-    // position and resolved max-height that explain it.
-    expect(measurement).toMatchObject({
-      overflowPx: 0,
-      popupIsTopLayer: true,
-      hasOuterMenuSurface: false,
-    });
-  });
+      // Asserting on the whole measurement so a regression prints the anchor
+      // position and resolved max-height that explain it.
+      expect(measurement).toMatchObject({
+        overflowPx: 0,
+        popupIsTopLayer: true,
+        hasOuterMenuSurface: false,
+      });
+    }));
 
   // Control: the identical menu content, anchored away from the bottom edge.
   // Isolates the anchor position as the cause rather than the menu's content.
-  it("has room for the same two items when the ledge is not at the viewport edge", async () => {
-    await mountPetInRealFooter(page, 42);
-    await page.evaluate(() => {
-      const footer = document.querySelector<HTMLElement>(".sidebar-shell__footer");
-      if (footer) {
-        footer.style.transform = "translateY(-400px)";
-      }
-    });
-    const sprite = page.locator(".lobster-pet");
-    await sprite.waitFor();
-
-    await sprite.click({ button: "right" });
-    await page.locator("wa-dropdown.lobster-pet-dismiss-menu").waitFor();
-
-    const measurement = await measureDismissMenu(page);
-    await page.screenshot({ path: path.join(artifactDir, "control-away-from-edge.png") });
-
-    expect(measurement).toMatchObject({ overflowPx: 0 });
-  });
-
-  it("keeps both items fully visible under long labels and an enlarged type scale", async () => {
-    await mountPetInRealFooter(page, 42);
-    const sprite = page.locator(".lobster-pet");
-    await sprite.waitFor();
-
-    await sprite.click({ button: "right" });
-    await page.locator("wa-dropdown.lobster-pet-dismiss-menu").waitFor();
-    await page.getByText("Dismiss and don't show again", { exact: true }).waitFor();
-    const baseline = await measureDismissMenu(page);
-
-    await useOversizedDismissLabels(page);
-
-    // Web Awesome's popup tracks anchor/floating element size with a
-    // ResizeObserver, so the label swap above reflows the popup
-    // asynchronously; poll for settlement instead of asserting immediately
-    // after the DOM write.
-    await expect
-      .poll(async () => (await measureDismissMenu(page)).overflowPx, {
-        message: "menu did not settle",
-      })
-      .toBe(0);
-    const measurement = await measureDismissMenu(page);
-    await page.screenshot({ path: path.join(artifactDir, "long-labels-enlarged-scale.png") });
-
-    // Guards against --control-ui-text-scale/the label injection silently
-    // no-opping: the rendered label font-size and its unclamped box height
-    // must both actually grow, or this test would pass without exercising
-    // the real type-scale token (the row's own height can't tell a real
-    // increase from a no-op — see firstItemLabelHeightPx above).
-    expect(measurement.firstItemFontSizePx).not.toBeNull();
-    expect(measurement.firstItemFontSizePx).toBeGreaterThan(baseline.firstItemFontSizePx ?? 0);
-    expect(measurement.firstItemLabelHeightPx).not.toBeNull();
-    expect(measurement.firstItemLabelHeightPx).toBeGreaterThan(
-      baseline.firstItemLabelHeightPx ?? 0,
-    );
-  });
-
-  it("keeps the popup within the viewport at a compact footer-edge viewport height", async () => {
-    await suite.withPage(
-      { viewport: { width: 1280, height: 420 } },
-      async ({ page: shortPage }) => {
-        await loadControlUiPage(shortPage);
-        await mountPetInRealFooter(shortPage, 42);
-        const sprite = shortPage.locator(".lobster-pet");
-        await sprite.waitFor();
-
-        await sprite.click({ button: "right" });
-        await shortPage.locator("wa-dropdown.lobster-pet-dismiss-menu").waitFor();
-        await shortPage.getByText("Dismiss and don't show again", { exact: true }).waitFor();
-
-        const measurement = await measureDismissMenu(shortPage);
-        await shortPage.screenshot({ path: path.join(artifactDir, "compact-viewport-height.png") });
-
-        // At this height even the "top" placement may run short, so Web
-        // Awesome's own vertical auto-size may still shrink the menu in place
-        // (an accepted last-resort fallback). What must hold regardless is
-        // that the popup itself never renders outside the viewport.
-        expect(measurement.menuTop).toBeGreaterThanOrEqual(0);
-        expect(measurement.menuBottom).toBeLessThanOrEqual(measurement.viewportHeight);
-      },
-    );
-  });
-
-  for (const edge of ["left", "right"] as const) {
-    it(`keeps the popup within the viewport when the footer sits near the ${edge} edge`, async () => {
+  it("has room for the same two items when the ledge is not at the viewport edge", () =>
+    withDismissMenuPage({}, async (page) => {
       await mountPetInRealFooter(page, 42);
-      // Slide the footer so the sprite's click point lands 12px from the
-      // named edge, computed from its live layout rather than a guessed
-      // translate distance, so the sprite stays actionable for Playwright.
-      await page.evaluate((direction) => {
+      await page.evaluate(() => {
         const footer = document.querySelector<HTMLElement>(".sidebar-shell__footer");
-        const sprite = document.querySelector<HTMLElement>(".lobster-pet");
-        if (!footer || !sprite) {
-          throw new Error("footer or sprite not found");
+        if (footer) {
+          footer.style.transform = "translateY(-400px)";
         }
-        const rect = sprite.getBoundingClientRect();
-        const targetCenterX = direction === "left" ? 12 : window.innerWidth - 12;
-        const dx = targetCenterX - (rect.left + rect.width / 2);
-        footer.style.transform = `translateX(${dx}px)`;
-      }, edge);
+      });
       const sprite = page.locator(".lobster-pet");
       await sprite.waitFor();
 
@@ -300,18 +211,107 @@ suite.define(() => {
       await page.locator("wa-dropdown.lobster-pet-dismiss-menu").waitFor();
 
       const measurement = await measureDismissMenu(page);
-      await page.screenshot({ path: path.join(artifactDir, `edge-${edge}.png`) });
+      await page.screenshot({ path: path.join(artifactDir, "control-away-from-edge.png") });
 
-      expect(measurement.menuLeft).toBeGreaterThanOrEqual(0);
-      expect(measurement.menuRight).toBeLessThanOrEqual(measurement.viewportWidth);
+      expect(measurement).toMatchObject({ overflowPx: 0 });
+    }));
+
+  it("keeps both items fully visible under long labels and an enlarged type scale", () =>
+    withDismissMenuPage({}, async (page) => {
+      await mountPetInRealFooter(page, 42);
+      const sprite = page.locator(".lobster-pet");
+      await sprite.waitFor();
+
+      await sprite.click({ button: "right" });
+      await page.locator("wa-dropdown.lobster-pet-dismiss-menu").waitFor();
+      await page.getByText("Dismiss and don't show again", { exact: true }).waitFor();
+      const baseline = await measureDismissMenu(page);
+
+      await useOversizedDismissLabels(page);
+
+      // Web Awesome's popup tracks anchor/floating element size with a
+      // ResizeObserver, so the label swap above reflows the popup
+      // asynchronously; poll for settlement instead of asserting immediately
+      // after the DOM write.
+      await expect
+        .poll(async () => (await measureDismissMenu(page)).overflowPx, {
+          message: "menu did not settle",
+        })
+        .toBe(0);
+      const measurement = await measureDismissMenu(page);
+      await page.screenshot({ path: path.join(artifactDir, "long-labels-enlarged-scale.png") });
+
+      // Guards against --control-ui-text-scale/the label injection silently
+      // no-opping: the rendered label font-size and its unclamped box height
+      // must both actually grow, or this test would pass without exercising
+      // the real type-scale token (the row's own height can't tell a real
+      // increase from a no-op — see firstItemLabelHeightPx above).
+      expect(measurement.firstItemFontSizePx).not.toBeNull();
+      expect(measurement.firstItemFontSizePx).toBeGreaterThan(baseline.firstItemFontSizePx ?? 0);
+      expect(measurement.firstItemLabelHeightPx).not.toBeNull();
+      expect(measurement.firstItemLabelHeightPx).toBeGreaterThan(
+        baseline.firstItemLabelHeightPx ?? 0,
+      );
+    }));
+
+  it("keeps the popup within the viewport at a compact footer-edge viewport height", async () => {
+    await withDismissMenuPage({ viewport: { width: 1280, height: 420 } }, async (shortPage) => {
+      await mountPetInRealFooter(shortPage, 42);
+      const sprite = shortPage.locator(".lobster-pet");
+      await sprite.waitFor();
+
+      await sprite.click({ button: "right" });
+      await shortPage.locator("wa-dropdown.lobster-pet-dismiss-menu").waitFor();
+      await shortPage.getByText("Dismiss and don't show again", { exact: true }).waitFor();
+
+      const measurement = await measureDismissMenu(shortPage);
+      await shortPage.screenshot({ path: path.join(artifactDir, "compact-viewport-height.png") });
+
+      // At this height even the "top" placement may run short, so Web
+      // Awesome's own vertical auto-size may still shrink the menu in place
+      // (an accepted last-resort fallback). What must hold regardless is
+      // that the popup itself never renders outside the viewport.
+      expect(measurement.menuTop).toBeGreaterThanOrEqual(0);
+      expect(measurement.menuBottom).toBeLessThanOrEqual(measurement.viewportHeight);
     });
+  });
+
+  for (const edge of ["left", "right"] as const) {
+    it(`keeps the popup within the viewport when the footer sits near the ${edge} edge`, () =>
+      withDismissMenuPage({}, async (page) => {
+        await mountPetInRealFooter(page, 42);
+        // Slide the footer so the sprite's click point lands 12px from the
+        // named edge, computed from its live layout rather than a guessed
+        // translate distance, so the sprite stays actionable for Playwright.
+        await page.evaluate((direction) => {
+          const footer = document.querySelector<HTMLElement>(".sidebar-shell__footer");
+          const sprite = document.querySelector<HTMLElement>(".lobster-pet");
+          if (!footer || !sprite) {
+            throw new Error("footer or sprite not found");
+          }
+          const rect = sprite.getBoundingClientRect();
+          const targetCenterX = direction === "left" ? 12 : window.innerWidth - 12;
+          const dx = targetCenterX - (rect.left + rect.width / 2);
+          footer.style.transform = `translateX(${dx}px)`;
+        }, edge);
+        const sprite = page.locator(".lobster-pet");
+        await sprite.waitFor();
+
+        await sprite.click({ button: "right" });
+        await page.locator("wa-dropdown.lobster-pet-dismiss-menu").waitFor();
+
+        const measurement = await measureDismissMenu(page);
+        await page.screenshot({ path: path.join(artifactDir, `edge-${edge}.png`) });
+
+        expect(measurement.menuLeft).toBeGreaterThanOrEqual(0);
+        expect(measurement.menuRight).toBeLessThanOrEqual(measurement.viewportWidth);
+      }));
   }
 
   it("does not scroll its two dismissal items under a dark color scheme", async () => {
-    await suite.withPage(
+    await withDismissMenuPage(
       { viewport: { width: 1280, height: 900 }, colorScheme: "dark" },
-      async ({ page: darkPage }) => {
-        await loadControlUiPage(darkPage);
+      async (darkPage) => {
         await mountPetInRealFooter(darkPage, 42);
         const sprite = darkPage.locator(".lobster-pet");
         await sprite.waitFor();


### PR DESCRIPTION
## What Problem This Solves

The lobster-menu suite creates nine browser contexts for seven cases: its compact and dark cases get an unused default page before creating their actual page. Default contexts also remain open until the suite ends. Separately, the agent-selection restart case sleeps 1.5 seconds immediately before an existing route-readiness check.

## Why This Change Was Made

Use the existing `suite.withPage` lifecycle for each menu case, with one fresh context and guaranteed per-case cleanup. Preserve viewport and theme overrides, browser-clock setup, geometry and font-growth assertions, and every screenshot.

For agent selection, wait for the committed route before optional screenshot capture. The existing checks still require the correct startup request, sidebar selection, and visible heading after reopening the canonical global session.

## User Impact

The eight cases fell from **9.25s of test execution to 6.63s**, repeating at **7.32s**. Production +0/-0; tests +133/-135, mostly indentation from the lifecycle wrapper. No test removal, sharding, worker-count, selection, runtime, or configuration changes.

## Evidence

- All eight cases passed before, after, and on repeat in real Chromium against the built UI and mocked Gateway.
- Command: `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/lobster-pet-dismiss-menu-overflow.e2e.test.ts ui/src/e2e/agent-selection-persistence.e2e.test.ts`.
- Negative probe: disabling saved-agent restoration at the shared settings reader made the restart case fail its retained route assertion: expected `/chat/openclaw`, observed settled `/chat/dummy`. The original 60-second route budget was retained for this probe. Production bytes were restored before final validation.
- Independent source review and fresh Codex autoreview found no actionable findings. Inspection covered the browser fixture lifecycle, route readiness, persisted settings, initial routing, and the alternate shell-navigation restoration path. That alternate path explains why disabling only one routing consumer is not a valid lost-persistence mutation.
- Linux changed-file checks and exact-head hosted CI must pass before landing. No user-facing UI behavior changes or live Gateway claim.

Final gates: [exact-head CI](https://github.com/openclaw/openclaw/actions/runs/33237719855) and actual Linux changed checks passed. The one-shot Testbox was stopped after success. No ClawSweeper review comment was present at the final read.
