### PR TITLE
refactor(tests): speed up browser relay response waits

### DIFF
--- a/extensions/browser/chrome-extension/background.test-harness.ts
+++ b/extensions/browser/chrome-extension/background.test-harness.ts
@@ -638,7 +638,7 @@ export async function loadRelayCommandHarness(accessMode: "all" | "selected") {
   const command = async (message: Record<string, unknown>) => {
     const id = ++seq;
     socket.receive({ ...message, seq: id });
-    return await vi.waitFor(() => {
+    return await waitForBackgroundState(() => {
       const response = frames().find((frame) => frame.seq === id);
       expect(response).toBeDefined();
       return response;


### PR DESCRIPTION
## What Problem This Solves

The newly added browser relay lifecycle suites spend about 14 extra seconds waiting for command responses that are already ready. This slows the browser plugin test lane without exercising additional behavior. Related: #132232.

## Why This Change Was Made

Reuse the harness's existing `waitForBackgroundState` for correlated relay responses. The real relay queues frames through a Promise chain, so the initial synchronous assertion misses; plain `vi.waitFor` then waits for its default 50ms polling interval. The existing helper polls at 1ms with the same default 1000ms timeout and the exact same assertion/result matching. No production code, fixture ownership, module isolation, race control, cleanup, test case, or assertion changes.

## User Impact

No product behavior changes. Developers get the same 158 browser relay lifecycle checks in roughly half the scoped wall time. Production LOC: +0/-0. Test support: +1/-1 (net zero).

## Evidence

Measured on one dedicated Blacksmith Testbox at `9b1c4bb3589d7608651dca8603e8937157ac7c44`, using the repository's `pnpm test` routing, one Vitest worker, two excluded A/B warmups, then eight order-balanced AB/BA pairs. Every sample passed the exact same 158 named cases in two files. All eight pairs favored the candidate: median paired saving **14.46s / 47.55%**; median GNU wall **30.22s → 15.815s**. This is a scoped two-file result, not a claim about total CI duration.

[Owned Testbox workflow](https://github.com/openclaw/openclaw/actions/runs/33236899266). Completion is proven by successful wrapper exit/timing records; lease shutdown can cancel the enclosing workflow. All raw logs, JSON results, import breakdowns, GNU time files, per-case durations, and process samples were retained; archive SHA-256: `347f97dd728d6ddc0de9b1aff64c28e24b7b0dda269b1ef1b33c9b05048b6ff6`.

Each invocation used a distinct `OPENCLAW_VITEST_FS_MODULE_CACHE_PATH`, `OPENCLAW_VITEST_IMPORT_DURATIONS=1`, `OPENCLAW_VITEST_PRINT_IMPORT_BREAKDOWN=1`, and `/usr/bin/time -v`:

```sh
pnpm test extensions/browser/chrome-extension/background.initial-target.test.ts extensions/browser/chrome-extension/background.navigation.test.ts --maxWorkers=1 --reporter=verbose --reporter=json --outputFile=<sample>.json
```

A = unchanged baseline, B = candidate. Times are seconds; RSS is KiB. Runner PID counts are sampled every 50ms, not application fixture counts.

| Sample | Wall | Vitest | Bodies | Import | RSS | User CPU | System CPU | CPU % | Peak PIDs |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| pair-1-A | 30.27 | 26.65 | 22.957 | 2.980 | 834780 | 9.13 | 0.87 | 33% | 6 |
| pair-1-B | 15.63 | 12.14 | 8.682 | 2.800 | 873940 | 8.57 | 0.78 | 59% | 6 |
| pair-2-B | 15.77 | 12.21 | 8.673 | 2.820 | 865396 | 8.80 | 0.72 | 60% | 7 |
| pair-2-A | 30.17 | 26.46 | 22.979 | 2.800 | 815764 | 9.03 | 0.78 | 32% | 6 |
| pair-3-A | 30.08 | 26.62 | 23.037 | 2.960 | 871876 | 8.97 | 0.83 | 32% | 6 |
| pair-3-B | 15.86 | 12.34 | 8.714 | 2.930 | 867416 | 8.81 | 0.85 | 60% | 6 |
| pair-4-B | 15.72 | 12.20 | 8.703 | 2.790 | 862404 | 8.65 | 0.81 | 60% | 6 |
| pair-4-A | 30.42 | 26.74 | 23.147 | 2.910 | 835956 | 9.53 | 0.73 | 33% | 6 |
| pair-5-A | 30.80 | 27.23 | 23.260 | 3.270 | 854440 | 9.47 | 1.10 | 34% | 6 |
| pair-5-B | 16.21 | 12.55 | 8.787 | 3.010 | 845496 | 9.35 | 0.78 | 62% | 7 |
| pair-6-B | 16.44 | 12.64 | 8.752 | 3.100 | 854636 | 9.45 | 0.84 | 62% | 7 |
| pair-6-A | 30.63 | 27.00 | 23.171 | 3.090 | 842312 | 9.54 | 0.86 | 33% | 6 |
| pair-7-A | 30.11 | 26.57 | 23.117 | 2.780 | 863052 | 9.06 | 0.76 | 32% | 6 |
| pair-7-B | 16.11 | 12.58 | 8.755 | 3.130 | 839676 | 9.11 | 0.89 | 62% | 7 |
| pair-8-B | 15.63 | 12.15 | 8.677 | 2.790 | 863920 | 8.53 | 0.75 | 59% | 6 |
| pair-8-A | 30.15 | 26.67 | 23.078 | 2.900 | 841240 | 9.09 | 0.78 | 32% | 6 |

Median test-body time fell from 23.097s to 8.708s; imports stayed near 2.9s. Median RSS rose modestly from 841,776 to 863,162 KiB (about 2.5%); this is a wall-time improvement, not a memory-saving claim. These two suites retain their existing fake Chrome/WebSocket adapters and real background/crypto/relay policy: zero real browser, server, database, or application subprocess fixtures in either variant. No sampled runner descendant survived completion. Temporary roots contained only the task-owned Node compile cache, removed with the Testbox.

Coverage and reversible fault proof:

- Removed `Page.navigate` from the production `TAB_SCOPED_COMMANDS` set temporarily. A and B both failed the same six intended assertions: four commit-first navigation cases and two real relay/background composition cases. Both had 152 passes / 6 failures. The owner and harness were restored byte-for-byte after fault testing.
- Candidate: **317/317 tests in nine files** passed normally and with shuffled seeds **7301** and **9287**. Scope includes both changed callers, existing background/access-mode suites, relay-command-handler, tab-access, tab-access-events/navigation, and relay-bridge tests.
- Temporary diagnostic socket census: all **164** observed fake sockets closed; 158/158 tests passed. Diagnostic instrumentation was removed exactly. Existing root/DB cleanup and deferred lifecycle controls are unchanged.
- Source/dependency audit checked complete callers, background/relay/tab-authority owners and sibling flows, fresh history, scoped CI routing, and installed Vitest's immediate-check/50ms-interval/1000ms-timeout implementation. Module resets remain necessary for service-worker state and were retained.
- Test-audit and deslop: no duplicate cases, new seam, weaker assertion, or avoidable machinery. Fresh isolated Codex autoreview: no accepted/actionable findings.

Complete changed gate passed on the owned Testbox (494.923s): both extension type checks, type-aware lint, doctor contract tests, dead-export scans, formatting, ratchets, plugin/dependency/database/media/sidecar/cycle guards. Targeted local formatting/lint and `git diff --check` also passed. Exact-head hosted CI will be verified before native landing. No changelog, dependency, baseline, snapshot, package, schema, protocol, or release changes.
