### PR TITLE
fix(gateway): native subagent delivery stays pending after completion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,8 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Gateway/subagents: keep plugin completion turns bound to the owning Gateway runtime so successful native subagents can finish delivery without losing the published reply runtime.
+
 - **Control UI tool progress:** keep error-shaped partial output running until the tool returns its result, with consistent status in collapsed rows, expanded cards, and side-panel details.
 
 - MCP Apps: let standalone operations finish across catalog refreshes within per-request server budgets, propagate App cancellation without cancelling shared catalog work, and reload restored history views without replaying interrupted operations. Thanks @tzy-17. (#119388)

--- a/src/agents/subagents/announce/subagent-announce-delivery.runtime.test.ts
+++ b/src/agents/subagents/announce/subagent-announce-delivery.runtime.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import { createInternalAgentTurnFacade } from "../../../gateway/agent-turn/internal-facade.js";
 import { WRITE_SCOPE } from "../../../gateway/method-scopes.js";
 import { createGatewayMethodRegistry } from "../../../gateway/methods/registry.js";
 import type {
@@ -10,7 +11,7 @@ import { withPluginRuntimeGatewayContextResolver } from "../../../plugins/runtim
 import { dispatchSubagentAnnounceAgent } from "./subagent-announce-delivery.runtime.js";
 
 function createContext(handlers: GatewayRequestHandlers): GatewayRequestContext {
-  return {
+  const context = {
     deps: {},
     getRuntimeConfig: () => ({}),
     getGatewayMethodRegistry: () => createRegistry(handlers),
@@ -22,6 +23,13 @@ function createContext(handlers: GatewayRequestHandlers): GatewayRequestContext 
     chatQueuedTurns: new Map(),
     dedupe: new Map(),
   } as unknown as GatewayRequestContext;
+  context.createAgentTurnFacade = (principal) =>
+    createInternalAgentTurnFacade({
+      ...principal,
+      getContext: () => context,
+      getMethodRegistry: () => createRegistry(handlers),
+    });
+  return context;
 }
 
 function createRegistry(handlers: GatewayRequestHandlers) {

--- a/src/gateway/agent-turn/internal-facade.ts
+++ b/src/gateway/agent-turn/internal-facade.ts
@@ -21,36 +21,17 @@ import type { GatewayRequestOptions } from "../server-methods/types.js";
 import { validateGatewayMethodParams } from "../server-methods/validation.js";
 import { prepareAgentRequestPreflight } from "./agent-request-preflight.js";
 import { createAgentTurnService } from "./agent-turn-service.js";
+import type {
+  InternalAgentTurnDispatchOptions,
+  InternalAgentTurnFacade,
+  InternalAgentTurnPrincipalOptions,
+} from "./internal-facade.types.js";
 import { captureAgentTurnPrincipal, resolveAgentTurnRunObserver } from "./principal.js";
 import type { AgentTurnIo } from "./types.js";
 
-type InternalAgentTurnFacadeOptions = {
-  // Authorization can await; the lifecycle owner must still be current before dispatch.
-  assertContextCurrent?: () => void;
-  client: NonNullable<GatewayRequestOptions["client"]>;
+type InternalAgentTurnFacadeOptions = InternalAgentTurnPrincipalOptions & {
   getContext: () => GatewayRequestOptions["context"];
   getMethodRegistry?: () => GatewayMethodRegistry;
-  isWebchatConnect?: GatewayRequestOptions["isWebchatConnect"];
-};
-
-export type InternalAgentTurnPrincipalOptions = Omit<
-  InternalAgentTurnFacadeOptions,
-  "getContext" | "getMethodRegistry"
->;
-
-export type InternalAgentTurnFacadeFactory = (
-  principal: InternalAgentTurnPrincipalOptions,
-) =>
-  | ReturnType<typeof createInternalAgentTurnFacade>
-  | Promise<ReturnType<typeof createInternalAgentTurnFacade>>;
-
-type InternalAgentTurnDispatchOptions = {
-  expectFinal?: boolean;
-  onAccepted?: (payload: unknown) => void;
-  onExecutionStarted?: () => void;
-  onSignalAbort?: () => Promise<void> | void;
-  signal?: AbortSignal;
-  timeoutMs?: number;
 };
 
 function throwEnvelopeRejection(method: string, error: ErrorShape): never {
@@ -61,7 +42,9 @@ function throwEnvelopeRejection(method: string, error: ErrorShape): never {
 }
 
 /** Typed, frame-free access to agent turns owned by the running Gateway instance. */
-export function createInternalAgentTurnFacade(options: InternalAgentTurnFacadeOptions) {
+export function createInternalAgentTurnFacade(
+  options: InternalAgentTurnFacadeOptions,
+): InternalAgentTurnFacade {
   const isWebchatConnect = options.isWebchatConnect ?? (() => false);
   const getMethodRegistry = options.getMethodRegistry ?? createRequestGatewayMethodRegistry;
 

--- a/src/gateway/agent-turn/internal-facade.ts
+++ b/src/gateway/agent-turn/internal-facade.ts
@@ -33,6 +33,17 @@ type InternalAgentTurnFacadeOptions = {
   isWebchatConnect?: GatewayRequestOptions["isWebchatConnect"];
 };
 
+export type InternalAgentTurnPrincipalOptions = Omit<
+  InternalAgentTurnFacadeOptions,
+  "getContext" | "getMethodRegistry"
+>;
+
+export type InternalAgentTurnFacadeFactory = (
+  principal: InternalAgentTurnPrincipalOptions,
+) =>
+  | ReturnType<typeof createInternalAgentTurnFacade>
+  | Promise<ReturnType<typeof createInternalAgentTurnFacade>>;
+
 type InternalAgentTurnDispatchOptions = {
   expectFinal?: boolean;
   onAccepted?: (payload: unknown) => void;
@@ -60,6 +71,7 @@ export function createInternalAgentTurnFacade(options: InternalAgentTurnFacadeOp
   ): Promise<GatewayMethodDispatchResponse> => {
     const method = "agent";
     throwIfGatewayDispatchAborted(method, dispatchOptions.signal);
+    options.assertContextCurrent?.();
     const context = options.getContext();
     const methodRegistry = getMethodRegistry();
     const authorization = await authorizeGatewayRequestPreDispatch({
@@ -221,6 +233,7 @@ export function createInternalAgentTurnFacade(options: InternalAgentTurnFacadeOp
   ): Promise<T> => {
     const method = "agent.wait";
     throwIfGatewayDispatchAborted(method, signal);
+    options.assertContextCurrent?.();
     const context = options.getContext();
     const methodRegistry = getMethodRegistry();
     const authorization = await authorizeGatewayRequestPreDispatch({

--- a/src/gateway/agent-turn/internal-facade.types.ts
+++ b/src/gateway/agent-turn/internal-facade.types.ts
@@ -1,0 +1,42 @@
+import type { AgentWaitParams } from "../../../packages/gateway-protocol/src/index.js";
+import type { ConnectParams } from "../../../packages/gateway-protocol/src/schema/frames.js";
+import type { GatewayMethodDispatchResponse } from "../server-in-process-dispatch.types.js";
+import type { AgentRunRequest } from "../server-methods/agent-request-types.js";
+import type { GatewayClient } from "../server-methods/client-types.js";
+
+export type InternalAgentTurnPrincipalOptions = {
+  // Authorization can await; the lifecycle owner must still be current before dispatch.
+  assertContextCurrent?: () => void;
+  client: GatewayClient;
+  isWebchatConnect?: (params: ConnectParams | null | undefined) => boolean;
+};
+
+export type InternalAgentTurnDispatchOptions = {
+  expectFinal?: boolean;
+  onAccepted?: (payload: unknown) => void;
+  onExecutionStarted?: () => void;
+  onSignalAbort?: () => Promise<void> | void;
+  signal?: AbortSignal;
+  timeoutMs?: number;
+};
+
+export type InternalAgentTurnFacade = {
+  dispatch: <T = unknown>(
+    request: AgentRunRequest,
+    options?: InternalAgentTurnDispatchOptions | number,
+  ) => Promise<T>;
+  dispatchRaw: (
+    request: AgentRunRequest,
+    options?: InternalAgentTurnDispatchOptions,
+  ) => Promise<GatewayMethodDispatchResponse>;
+  wait: <T = unknown>(
+    params: AgentWaitParams,
+    timeoutMs?: number,
+    signal?: AbortSignal,
+    onSignalAbort?: () => Promise<void> | void,
+  ) => Promise<T>;
+};
+
+export type InternalAgentTurnFacadeFactory = (
+  principal: InternalAgentTurnPrincipalOptions,
+) => InternalAgentTurnFacade | Promise<InternalAgentTurnFacade>;

--- a/src/gateway/local-request-context.test.ts
+++ b/src/gateway/local-request-context.test.ts
@@ -14,7 +14,16 @@ import { loadCronStore, resolveCronJobsStorePath, saveCronStore } from "../cron/
 import { getPluginRuntimeGatewayRequestScope } from "../plugins/runtime/gateway-request-scope.js";
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
 import { withLocalGatewayRequestScope } from "./local-request-context.js";
-import { dispatchGatewayMethodInProcessRaw } from "./server-plugins.js";
+import {
+  dispatchGatewayMethodInProcess,
+  dispatchGatewayMethodInProcessRaw,
+} from "./server-plugins.js";
+
+const createAgentTurnService = vi.hoisted(() =>
+  vi.fn<typeof import("./agent-turn/agent-turn-service.js").createAgentTurnService>(),
+);
+
+vi.mock("./agent-turn/agent-turn-service.js", () => ({ createAgentTurnService }));
 
 type PublishedOwnerSnapshot = Awaited<
   ReturnType<typeof preparedModelCatalog.loadPublishedPreparedModelCatalogOwnerSnapshot>
@@ -48,6 +57,36 @@ describe("local gateway request context", () => {
   it("lets embedded local runs dispatch gateway methods in-process", () => {
     expect(response.ok).toBe(true);
     expect(response.payload).toMatchObject({ agentId: "main" });
+  });
+
+  it("binds typed agent turns to the embedded context", async () => {
+    await withLocalGatewayRequestScope(
+      { deps: {} as CliDeps, getRuntimeConfig: () => ({}) },
+      async () => {
+        const context = getPluginRuntimeGatewayRequestScope()?.context;
+        if (!context) {
+          throw new Error("expected local gateway request context");
+        }
+        const payload = { runId: "local-turn", status: "accepted" };
+        createAgentTurnService.mockReturnValue({
+          startTurn: async ({ io }) => io.emitAcceptance([true, payload, undefined]),
+          waitForTurn: vi.fn(),
+          abortTurn: vi.fn(),
+        });
+
+        await expect(
+          dispatchGatewayMethodInProcess(
+            "agent",
+            { message: "local turn", idempotencyKey: "local-turn" },
+            { forceSyntheticClient: true, operatorRoleActor: { kind: "system" } },
+          ),
+        ).resolves.toEqual(payload);
+        expect(createAgentTurnService).toHaveBeenCalledWith(
+          expect.objectContaining({ context }),
+          expect.any(Function),
+        );
+      },
+    );
   });
 
   it("defaults local model catalog snapshot reads to read-only", async () => {

--- a/src/gateway/local-request-context.ts
+++ b/src/gateway/local-request-context.ts
@@ -88,7 +88,7 @@ function createLocalGatewayRequestContext(
         getConfig: params.getRuntimeConfig,
       }),
   });
-  return {
+  const context: GatewayRequestContext = {
     deps: params.deps,
     configRevisionProjector: loadGatewayConfigRevisionProjector({ env: process.env }),
     cron,
@@ -168,6 +168,12 @@ function createLocalGatewayRequestContext(
     broadcastVoiceWakeRoutingChanged: () => {},
     unavailableGatewayMethods: new Set(),
   };
+  context.createAgentTurnFacade = async (principal) => {
+    const { createInternalAgentTurnFacade } =
+      await import("./agent-turn/internal-facade.runtime.js");
+    return createInternalAgentTurnFacade({ ...principal, getContext: () => context });
+  };
+  return context;
 }
 
 /** Runs code inside a local gateway request scope unless an outer scope already exists. */

--- a/src/gateway/server-in-process-dispatch.ts
+++ b/src/gateway/server-in-process-dispatch.ts
@@ -4,14 +4,10 @@ import type { ErrorShape } from "../../packages/gateway-protocol/src/schema/fram
 import { createAbortError } from "../infra/abort-signal.js";
 import { resolveSafeTimeoutDelayMs } from "../utils/timer-delay.js";
 import type { GatewayMethodRegistry } from "./methods/registry.js";
+import type { GatewayMethodDispatchResponse } from "./server-in-process-dispatch.types.js";
 import type { GatewayRequestOptions } from "./server-methods/types.js";
 
-export type GatewayMethodDispatchResponse = {
-  ok: boolean;
-  payload?: unknown;
-  error?: ErrorShape;
-  meta?: Record<string, unknown>;
-};
+export type { GatewayMethodDispatchResponse } from "./server-in-process-dispatch.types.js";
 
 type InProcessGatewayDispatchOptions = {
   client: GatewayRequestOptions["client"];

--- a/src/gateway/server-in-process-dispatch.types.ts
+++ b/src/gateway/server-in-process-dispatch.types.ts
@@ -1,0 +1,8 @@
+import type { ErrorShape } from "../../packages/gateway-protocol/src/schema/frames.js";
+
+export type GatewayMethodDispatchResponse = {
+  ok: boolean;
+  payload?: unknown;
+  error?: ErrorShape;
+  meta?: Record<string, unknown>;
+};

--- a/src/gateway/server-instance-runtime.test.ts
+++ b/src/gateway/server-instance-runtime.test.ts
@@ -128,9 +128,18 @@ describe("createGatewayInstanceRuntime", () => {
     ).rejects.toThrow("cwd must be absolute");
     expect(rawAgent).not.toHaveBeenCalled();
 
+    const retainedFacade = await runtime.createAgentTurnFacade({
+      client: createSyntheticPluginRuntimeClient({ scopes: [WRITE_SCOPE] }),
+    });
     runtime.close();
     expect(getGatewayRecoveryRuntime()).toBeUndefined();
     await expect(runtime.recovery.waitForAgent({ runId: "run-1" })).rejects.toThrow(
+      "Gateway instance dispatch unavailable",
+    );
+    await expect(
+      retainedFacade.dispatch({ message: "stale completion", idempotencyKey: "closed-host" }),
+    ).rejects.toThrow("Gateway instance dispatch unavailable");
+    await expect(retainedFacade.wait({ runId: "run-1" })).rejects.toThrow(
       "Gateway instance dispatch unavailable",
     );
   });

--- a/src/gateway/server-instance-runtime.ts
+++ b/src/gateway/server-instance-runtime.ts
@@ -13,10 +13,8 @@ import type {
 import { createApprovalNativeRouteCoordinator } from "../infra/approval-native-route-coordinator.js";
 import type { ChannelApprovalKind } from "../infra/approval-types.js";
 import { createLazyRuntimeModule } from "../shared/lazy-runtime.js";
-import {
-  createInternalAgentTurnFacade,
-  type InternalAgentTurnPrincipalOptions,
-} from "./agent-turn/internal-facade.js";
+import { createInternalAgentTurnFacade } from "./agent-turn/internal-facade.js";
+import type { InternalAgentTurnPrincipalOptions } from "./agent-turn/internal-facade.types.js";
 import { APPROVALS_SCOPE, WRITE_SCOPE } from "./method-scopes.js";
 import type { GatewayMethodRegistry } from "./methods/registry.js";
 import { dispatchGatewayRequestInProcess } from "./server-in-process-dispatch.js";

--- a/src/gateway/server-instance-runtime.ts
+++ b/src/gateway/server-instance-runtime.ts
@@ -13,7 +13,10 @@ import type {
 import { createApprovalNativeRouteCoordinator } from "../infra/approval-native-route-coordinator.js";
 import type { ChannelApprovalKind } from "../infra/approval-types.js";
 import { createLazyRuntimeModule } from "../shared/lazy-runtime.js";
-import { createInternalAgentTurnFacade } from "./agent-turn/internal-facade.js";
+import {
+  createInternalAgentTurnFacade,
+  type InternalAgentTurnPrincipalOptions,
+} from "./agent-turn/internal-facade.js";
 import { APPROVALS_SCOPE, WRITE_SCOPE } from "./method-scopes.js";
 import type { GatewayMethodRegistry } from "./methods/registry.js";
 import { dispatchGatewayRequestInProcess } from "./server-in-process-dispatch.js";
@@ -62,6 +65,19 @@ export function createGatewayInstanceRuntime(
     }
   };
 
+  const createAgentTurnFacade = (principal: InternalAgentTurnPrincipalOptions) => {
+    const assertContextCurrent = () => {
+      assertDispatchAvailable("agent turn");
+      principal.assertContextCurrent?.();
+    };
+    return createInternalAgentTurnFacade({
+      ...principal,
+      assertContextCurrent,
+      getContext: options.getContext,
+      getMethodRegistry: options.getMethodRegistry,
+    });
+  };
+
   const dispatch = async <T>(params: {
     allowedMethods: ReadonlySet<string>;
     client: ReturnType<typeof createSyntheticPluginRuntimeClient>;
@@ -86,10 +102,8 @@ export function createGatewayInstanceRuntime(
     operatorRoleActor: { kind: "system" },
     scopes: [WRITE_SCOPE],
   });
-  const recoveryAgentTurns = createInternalAgentTurnFacade({
+  const recoveryAgentTurns = createAgentTurnFacade({
     client: recoveryClient,
-    getContext: options.getContext,
-    getMethodRegistry: options.getMethodRegistry,
   });
   const recoveryControlMethods = new Set(["chat.abort"]);
   const approvalClient = createSyntheticPluginRuntimeClient({
@@ -132,7 +146,7 @@ export function createGatewayInstanceRuntime(
         dispatchOptions.syntheticScopes,
       );
       const agentTurns = needsDedicatedPrincipal
-        ? createInternalAgentTurnFacade({
+        ? createAgentTurnFacade({
             client: createSyntheticPluginRuntimeClient({
               operatorRoleActor: { kind: "system" },
               allowModelOverride:
@@ -144,8 +158,6 @@ export function createGatewayInstanceRuntime(
               delegatedToolPolicyHandoffId,
               scopes: dispatchOptions.scopes ?? dispatchOptions.syntheticScopes,
             }),
-            getContext: options.getContext,
-            getMethodRegistry: options.getMethodRegistry,
           })
         : recoveryAgentTurns;
       try {
@@ -222,6 +234,7 @@ export function createGatewayInstanceRuntime(
   };
 
   return {
+    createAgentTurnFacade,
     approvalEvents: {
       publishRequested: (kind, request) =>
         publish(

--- a/src/gateway/server-instance-runtime.types.ts
+++ b/src/gateway/server-instance-runtime.types.ts
@@ -2,7 +2,7 @@ import type { AgentWaitParams } from "../../packages/gateway-protocol/src/index.
 import type { SubagentCompletionToolHandoffRegistration } from "../agents/subagents/announce/subagent-announce-handoff.js";
 import type { GatewayNativeApprovalRuntime } from "../infra/approval-gateway-runtime.types.js";
 import type { ChannelApprovalKind } from "../infra/approval-types.js";
-import type { InternalAgentTurnFacadeFactory } from "./agent-turn/internal-facade.js";
+import type { InternalAgentTurnFacadeFactory } from "./agent-turn/internal-facade.types.js";
 import type { AgentRunRequest } from "./server-methods/agent-request-types.js";
 
 export type GatewayInstanceAgentDispatchOptions = {

--- a/src/gateway/server-instance-runtime.types.ts
+++ b/src/gateway/server-instance-runtime.types.ts
@@ -2,6 +2,7 @@ import type { AgentWaitParams } from "../../packages/gateway-protocol/src/index.
 import type { SubagentCompletionToolHandoffRegistration } from "../agents/subagents/announce/subagent-announce-handoff.js";
 import type { GatewayNativeApprovalRuntime } from "../infra/approval-gateway-runtime.types.js";
 import type { ChannelApprovalKind } from "../infra/approval-types.js";
+import type { InternalAgentTurnFacadeFactory } from "./agent-turn/internal-facade.js";
 import type { AgentRunRequest } from "./server-methods/agent-request-types.js";
 
 export type GatewayInstanceAgentDispatchOptions = {
@@ -52,6 +53,7 @@ export type GatewayRecoveryRuntime = {
 };
 
 export type GatewayInstanceRuntime = {
+  createAgentTurnFacade: InternalAgentTurnFacadeFactory;
   approvalEvents: GatewayApprovalEventPublisher;
   nativeApprovals: GatewayNativeApprovalRuntime;
   recovery: GatewayRecoveryRuntime;

--- a/src/gateway/server-kernel-request-runtime.ts
+++ b/src/gateway/server-kernel-request-runtime.ts
@@ -258,6 +258,7 @@ export async function prepareGatewayKernelRequestRuntime(params: {
     gatewayInstanceRuntime.isAvailable() ? gatewayRequestContext : undefined;
   gatewayRequestContext.approvalEvents = gatewayInstanceRuntime.approvalEvents;
   gatewayRequestContext.recoveryRuntime = gatewayInstanceRuntime.recovery;
+  gatewayRequestContext.createAgentTurnFacade = gatewayInstanceRuntime.createAgentTurnFacade;
   return { ...runtime, chatMetadataLifecycle, gatewayRequestContext, gatewayInstanceRuntime };
 }
 

--- a/src/gateway/server-methods/client-types.ts
+++ b/src/gateway/server-methods/client-types.ts
@@ -1,0 +1,88 @@
+import type { ConnectParams } from "../../../packages/gateway-protocol/src/schema/frames.js";
+import type { TranscriptSenderIdentity } from "../../chat/sender-identity.js";
+import type { PluginSubagentRequesterContext } from "../../plugins/runtime/subagent-requester-context.js";
+import type { RuntimePluginToolGrant } from "../../plugins/runtime/tool-grant.js";
+import type { AgentRuntimeIdentity } from "../agent-runtime-identity-token.js";
+import type { AuthenticatedGitHubIdentitySync } from "../github-user-identity.js";
+import type { GatewayOperatorRoleActor } from "../operator-role-actor.js";
+import type { PluginNodeCapabilitySurface } from "../plugin-node-capability.js";
+import type { TrustedSessionCreation } from "./session-creation-provenance.js";
+
+/** Trusted in-process spawn control plane that already owns this run's task row.
+    Gateway CLI tracking only covers runs nobody else records, so a marked run
+    must never get a second row. */
+export type GatewayAgentRunTaskOwner = "plugin_subagent" | "native_subagent";
+
+/** Caller identity captured by a built-in agent tool before trusted in-process dispatch. */
+export type TrustedAgentToolCaller = Readonly<{
+  agentId: string;
+  sessionKey: string;
+}>;
+
+/** Closure-bound streaming hooks attached only to trusted plugin-owned synthetic clients. */
+export type GatewayNodeInvokeStream = {
+  onProgress: (chunk: string) => void;
+  onDispatchReady: (invokeId: string) => void;
+  idleTimeoutMs?: number;
+  isRuntimeCurrent: () => boolean;
+};
+
+/** Per-connection client metadata captured after the gateway handshake. */
+export type GatewayClient = {
+  connect: ConnectParams;
+  connId?: string;
+  presenceKey?: string;
+  clientIp?: string;
+  /** Client id verified against the server-approved device pairing record. */
+  pairedClientId?: string;
+  authenticatedUserId?: string;
+  /** Verified Tailscale provider identity; generic proxy identities must not infer this. */
+  authenticatedUserIsTailscaleProvider?: boolean;
+  authenticatedGitHubIdentitySync?: AuthenticatedGitHubIdentitySync;
+  authenticatedUserProfile?: {
+    profileId: string;
+    displayName: string | null;
+    avatarRevision?: string;
+    hasAvatar: boolean;
+    updatedAt: number;
+  };
+  pluginSurfaceUrls?: Record<string, string>;
+  pluginNodeCapabilitySurfaces?: Record<string, PluginNodeCapabilitySurface>;
+  pluginNodeCapabilities?: Record<string, { capability: string; expiresAtMs: number }>;
+  isDeviceTokenAuth?: boolean;
+  internal?: {
+    /** Handshake-attested direct-local transport; never accepted from wire params. */
+    isLocalClient?: true;
+    /** Marks the server-constructed client used by trusted in-process dispatch. */
+    syntheticClient?: true;
+    /** Host-owned role authority retained separately from an autonomous run principal. */
+    operatorRoleActor?: GatewayOperatorRoleActor;
+    /** Overrides persisted sender attribution without changing the authorizing client identity. */
+    senderAttribution?: { id: string; name?: string; identity?: TranscriptSenderIdentity };
+    /** Trusted session creation provenance; never accepted from Gateway wire params. */
+    sessionCreation?: TrustedSessionCreation;
+    /** Trusted built-in agent tool caller; never accepted from Gateway wire params. */
+    agentToolCaller?: TrustedAgentToolCaller;
+    allowModelOverride?: boolean;
+    approvalRuntime?: boolean;
+    cronRunContinuation?: boolean;
+    agentRuntimeIdentity?: AgentRuntimeIdentity;
+    pluginRuntimeOwnerId?: string;
+    /** Host-attested session provenance for a trusted official plugin node invocation. */
+    nodeInvokeApprovalSessionKey?: string;
+    /** Plugin-owned in-process invoke hooks; never accepted from Gateway wire params. */
+    nodeInvokeStream?: GatewayNodeInvokeStream;
+    agentRunTracking?: GatewayAgentRunTaskOwner;
+    /** Host-captured requester lineage for opt-in plugin subagent completion delivery. */
+    pluginSubagentRequester?: PluginSubagentRequesterContext;
+    /** Host-owned exact media set for a scoped automatic recovery delivery. */
+    internalDeliveryMediaUrls?: string[];
+    internalDeliverySuppressText?: boolean;
+    /** Plugin-owned tools authorized for this internal subagent run. */
+    runtimePluginToolGrant?: RuntimePluginToolGrant;
+    /** Host-owned exact tool cap for a tracked plugin subagent run. */
+    pluginSubagentToolsAllow?: string[];
+    /** Opaque in-process subagent-completion capability; never accepted from wire params. */
+    delegatedToolPolicyHandoffId?: string;
+  };
+};

--- a/src/gateway/server-methods/shared-types.ts
+++ b/src/gateway/server-methods/shared-types.ts
@@ -30,6 +30,7 @@ import type {
   AgentRuntimeIdentity,
   AgentRuntimeApprovalAuthorityValidator,
 } from "../agent-runtime-identity-token.js";
+import type { InternalAgentTurnFacadeFactory } from "../agent-turn/internal-facade.js";
 import type { ChatAbortControllerEntry } from "../chat-abort.js";
 import type { GatewayHotReloadStatus } from "../config-reload-status.types.js";
 import type { GatewayConfigRevisionProjector } from "../config-revision-token.js";
@@ -301,6 +302,8 @@ type GatewayKernelContext = {
   /** Instance-local native approval subscribers; never derived from a network client. */
   approvalEvents?: GatewayApprovalEventPublisher;
   recoveryRuntime?: GatewayRecoveryRuntime;
+  /** Uses the lifecycle owner's module graph for plugin and detached agent turns. */
+  createAgentTurnFacade?: InternalAgentTurnFacadeFactory;
   enforceSharedGatewayAuthGenerationForConfigWrite?: (nextConfig: OpenClawConfig) => void;
   nodeRegistry: NodeRegistry;
   agentRunSeq: Map<string, number>;

--- a/src/gateway/server-methods/shared-types.ts
+++ b/src/gateway/server-methods/shared-types.ts
@@ -12,7 +12,6 @@ import type {
   RequestFrame,
 } from "../../../packages/gateway-protocol/src/schema/frames.js";
 import type { ModelCatalogEntry } from "../../agents/model-catalog.types.js";
-import type { TranscriptSenderIdentity } from "../../chat/sender-identity.js";
 import type { CliDeps } from "../../cli/deps.types.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type {
@@ -21,27 +20,20 @@ import type {
 } from "../../infra/plugin-approvals.js";
 import type { SystemAgentApprovalRequestPayload } from "../../infra/system-agent-approvals.js";
 import type { createSubsystemLogger } from "../../logging/subsystem.js";
-import type { PluginSubagentRequesterContext } from "../../plugins/runtime/subagent-requester-context.js";
-import type { RuntimePluginToolGrant } from "../../plugins/runtime/tool-grant.js";
 import type { PluginRuntimeCore } from "../../plugins/runtime/types-core.js";
 import type { SystemAgentOperation } from "../../system-agent/operation-types.js";
 import type { WizardSession } from "../../wizard/session.js";
-import type {
-  AgentRuntimeIdentity,
-  AgentRuntimeApprovalAuthorityValidator,
-} from "../agent-runtime-identity-token.js";
-import type { InternalAgentTurnFacadeFactory } from "../agent-turn/internal-facade.js";
+import type { AgentRuntimeApprovalAuthorityValidator } from "../agent-runtime-identity-token.js";
+import type { InternalAgentTurnFacadeFactory } from "../agent-turn/internal-facade.types.js";
 import type { ChatAbortControllerEntry } from "../chat-abort.js";
 import type { GatewayHotReloadStatus } from "../config-reload-status.types.js";
 import type { GatewayConfigRevisionProjector } from "../config-revision-token.js";
 import type { ScopeUpgradeCoordinator } from "../device-scope-upgrade.js";
 import type { ExecApprovalManager, ExecApprovalRecord } from "../exec-approval-manager.js";
-import type { AuthenticatedGitHubIdentitySync } from "../github-user-identity.js";
 import type { HealthSummary } from "../health/types.js";
 import type { GatewayMethodRegistryView } from "../methods/descriptor.js";
 import type { NodeRegistry } from "../node-registry.js";
 import type { GatewayOperatorRoleActor } from "../operator-role-actor.js";
-import type { PluginNodeCapabilitySurface } from "../plugin-node-capability.js";
 import type { GatewayPortalService } from "../portals/portal-service.js";
 import type { QuestionManager } from "../question-manager.js";
 import type { GatewayBroadcastFn, GatewayBroadcastToConnIdsFn } from "../server-broadcast-types.js";
@@ -76,94 +68,22 @@ import type {
   ChatStartupProjectionReadParams,
   ChatStartupProjectionResult,
 } from "./chat-startup-projection-contract.js";
-import type { TrustedSessionCreation } from "./session-creation-provenance.js";
+import type { GatewayClient } from "./client-types.js";
 
 /**
  * Shared gateway request types used by every server-method module.
  */
 type SubsystemLogger = ReturnType<typeof createSubsystemLogger>;
 
-/** Trusted in-process spawn control plane that already owns this run's task row.
-    Gateway CLI tracking only covers runs nobody else records, so a marked run
-    must never get a second row. */
-export type GatewayAgentRunTaskOwner = "plugin_subagent" | "native_subagent";
+export type {
+  GatewayAgentRunTaskOwner,
+  GatewayClient,
+  GatewayNodeInvokeStream,
+  TrustedAgentToolCaller,
+} from "./client-types.js";
 
 /** Host-minted role authority; leaf contract re-exported for method handlers. */
 export type { GatewayOperatorRoleActor };
-
-/** Caller identity captured by a built-in agent tool before trusted in-process dispatch. */
-export type TrustedAgentToolCaller = Readonly<{
-  agentId: string;
-  sessionKey: string;
-}>;
-
-/** Closure-bound streaming hooks attached only to trusted plugin-owned synthetic clients. */
-export type GatewayNodeInvokeStream = {
-  onProgress: (chunk: string) => void;
-  onDispatchReady: (invokeId: string) => void;
-  idleTimeoutMs?: number;
-  isRuntimeCurrent: () => boolean;
-};
-
-/** Per-connection client metadata captured after the gateway handshake. */
-export type GatewayClient = {
-  connect: ConnectParams;
-  connId?: string;
-  presenceKey?: string;
-  clientIp?: string;
-  /** Client id verified against the server-approved device pairing record. */
-  pairedClientId?: string;
-  authenticatedUserId?: string;
-  /** Verified Tailscale provider identity; generic proxy identities must not infer this. */
-  authenticatedUserIsTailscaleProvider?: boolean;
-  authenticatedGitHubIdentitySync?: AuthenticatedGitHubIdentitySync;
-  authenticatedUserProfile?: {
-    profileId: string;
-    displayName: string | null;
-    avatarRevision?: string;
-    hasAvatar: boolean;
-    updatedAt: number;
-  };
-  pluginSurfaceUrls?: Record<string, string>;
-  pluginNodeCapabilitySurfaces?: Record<string, PluginNodeCapabilitySurface>;
-  pluginNodeCapabilities?: Record<string, { capability: string; expiresAtMs: number }>;
-  isDeviceTokenAuth?: boolean;
-  internal?: {
-    /** Handshake-attested direct-local transport; never accepted from wire params. */
-    isLocalClient?: true;
-    /** Marks the server-constructed client used by trusted in-process dispatch. */
-    syntheticClient?: true;
-    /** Host-owned role authority retained separately from an autonomous run principal. */
-    operatorRoleActor?: GatewayOperatorRoleActor;
-    /** Overrides persisted sender attribution without changing the authorizing client identity. */
-    senderAttribution?: { id: string; name?: string; identity?: TranscriptSenderIdentity };
-    /** Trusted session creation provenance; never accepted from Gateway wire params. */
-    sessionCreation?: TrustedSessionCreation;
-    /** Trusted built-in agent tool caller; never accepted from Gateway wire params. */
-    agentToolCaller?: TrustedAgentToolCaller;
-    allowModelOverride?: boolean;
-    approvalRuntime?: boolean;
-    cronRunContinuation?: boolean;
-    agentRuntimeIdentity?: AgentRuntimeIdentity;
-    pluginRuntimeOwnerId?: string;
-    /** Host-attested session provenance for a trusted official plugin node invocation. */
-    nodeInvokeApprovalSessionKey?: string;
-    /** Plugin-owned in-process invoke hooks; never accepted from Gateway wire params. */
-    nodeInvokeStream?: GatewayNodeInvokeStream;
-    agentRunTracking?: GatewayAgentRunTaskOwner;
-    /** Host-captured requester lineage for opt-in plugin subagent completion delivery. */
-    pluginSubagentRequester?: PluginSubagentRequesterContext;
-    /** Host-owned exact media set for a scoped automatic recovery delivery. */
-    internalDeliveryMediaUrls?: string[];
-    internalDeliverySuppressText?: boolean;
-    /** Plugin-owned tools authorized for this internal subagent run. */
-    runtimePluginToolGrant?: RuntimePluginToolGrant;
-    /** Host-owned exact tool cap for a tracked plugin subagent run. */
-    pluginSubagentToolsAllow?: string[];
-    /** Opaque in-process subagent-completion capability; never accepted from wire params. */
-    delegatedToolPolicyHandoffId?: string;
-  };
-};
 
 /** Callback used by method handlers to emit one protocol response frame. */
 export type RespondFn = (

--- a/src/gateway/server-plugin-in-process-dispatch.authorization.test.ts
+++ b/src/gateway/server-plugin-in-process-dispatch.authorization.test.ts
@@ -10,6 +10,7 @@ import { upsertSessionEntryCore } from "../config/sessions/session-accessor.js";
 import { withPluginRuntimeGatewayRequestScope } from "../plugins/runtime/gateway-request-scope.js";
 import { createDeferredCore } from "../shared/deferred.js";
 import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
+import { createInternalAgentTurnFacade } from "./agent-turn/internal-facade.js";
 import { createGatewayMethodRegistry } from "./methods/registry.js";
 import { resolveNodeInvokeRuntimeAuthorityError } from "./server-methods/nodes.invoke-authority.js";
 import type {
@@ -33,11 +34,20 @@ vi.mock("./agent-turn/agent-turn-service.js", () => ({
 }));
 
 function createContext(): GatewayRequestContext {
-  return {
+  const context = {
     dedupe: new Map(),
     getRuntimeConfig: () => ({}),
     logGateway: { error: vi.fn(), warn: vi.fn() },
   } as unknown as GatewayRequestContext;
+  context.createAgentTurnFacade = (principal) =>
+    createInternalAgentTurnFacade({
+      ...principal,
+      getContext: () => context,
+      ...(context.getGatewayMethodRegistry
+        ? { getMethodRegistry: context.getGatewayMethodRegistry }
+        : {}),
+    });
+  return context;
 }
 
 function createOperatorClient(params: {
@@ -114,6 +124,66 @@ describe("typed in-process agent authorization", () => {
     startTurn.mockReset();
     waitForTurn.mockReset();
   });
+
+  it.each([
+    ["agent", { message: "owned turn", idempotencyKey: "host-owned" }],
+    ["agent.wait", { runId: "host-owned" }],
+  ] as const)(
+    "uses the captured host factory for %s and refuses an ownerless context",
+    async (method, params) => {
+      const client = createOperatorClient({ profileId: "owner", scopes: ["operator.write"] });
+      const context = createContext();
+      const createFacade = vi.fn(context.createAgentTurnFacade!);
+      context.createAgentTurnFacade = createFacade;
+      const result = { runId: "host-owned", status: "ok" };
+      startTurn.mockImplementation(async ({ io }) => io.emitAcceptance([true, result, undefined]));
+      waitForTurn.mockResolvedValue(result);
+
+      await expect(dispatchScopedMethod({ client, context, method, params })).resolves.toEqual(
+        result,
+      );
+      expect(createFacade).toHaveBeenCalledOnce();
+      expect(createFacade.mock.calls[0]?.[0].client).toBe(client);
+
+      delete context.createAgentTurnFacade;
+      await expect(dispatchScopedMethod({ client, context, method, params })).rejects.toThrow(
+        "Gateway instance agent turn facade unavailable",
+      );
+    },
+  );
+
+  it.each([
+    ["agent", { message: "retired turn", idempotencyKey: "retired-host" }],
+    ["agent.wait", { runId: "retired-host" }],
+  ] as const)(
+    "revalidates the captured host after awaiting its %s factory",
+    async (method, params) => {
+      const context = createContext();
+      let current = context;
+      const entered = createDeferredCore();
+      const release = createDeferredCore();
+      const createFacade = context.createAgentTurnFacade!;
+      context.createAgentTurnFacade = async (principal) => {
+        entered.resolve();
+        await release.promise;
+        return createFacade(principal);
+      };
+
+      const pending = dispatchGatewayMethodInProcess(method, params, {
+        forceSyntheticClient: true,
+        operatorRoleActor: { kind: "system" },
+        resolveGatewayContext: () => current,
+      });
+      const rejected = expect(pending).rejects.toThrow("current gateway instance binding");
+      await entered.promise;
+      current = createContext();
+      release.resolve();
+
+      await rejected;
+      expect(startTurn).not.toHaveBeenCalled();
+      expect(waitForTurn).not.toHaveBeenCalled();
+    },
+  );
 
   it("preserves verified operator identity and never widens a synthetic tool caller's scopes", async () => {
     const owner = createOperatorClient({

--- a/src/gateway/server-plugin-in-process-dispatch.ts
+++ b/src/gateway/server-plugin-in-process-dispatch.ts
@@ -5,7 +5,6 @@ import { getActivePluginRegistry } from "../plugins/runtime.js";
 import { getPluginRuntimeGatewayRequestScope } from "../plugins/runtime/gateway-request-scope.js";
 import type { PluginSubagentRequesterContext } from "../plugins/runtime/subagent-requester-context.js";
 import type { RuntimePluginToolGrant } from "../plugins/runtime/tool-grant.js";
-import { createLazyRuntimeModule } from "../shared/lazy-runtime.js";
 import { readInProcessAgentRuntimeIdentity } from "./in-process-agent-runtime-identity.js";
 import { ADMIN_SCOPE, WRITE_SCOPE } from "./operator-scopes.js";
 import {
@@ -32,10 +31,6 @@ import {
   cancelSubagentCompletionToolHandoff,
   registerSubagentCompletionToolHandoff,
 } from "./subagent-completion-tool-handoff.js";
-
-const loadInternalAgentTurnFacade = createLazyRuntimeModule(
-  () => import("./agent-turn/internal-facade.runtime.js"),
-);
 
 type OperatorToolGatewayAuthority = {
   authenticatedUserProfile: NonNullable<
@@ -339,17 +334,15 @@ export async function dispatchGatewayMethodInProcess<T>(
 ): Promise<T> {
   if (method === "agent" || method === "agent.wait") {
     return await withInProcessGatewayDispatch(method, options, async (resolved) => {
-      const { createInternalAgentTurnFacade } = await loadInternalAgentTurnFacade();
-      const facade = createInternalAgentTurnFacade({
+      const createAgentTurnFacade = resolved.context.createAgentTurnFacade;
+      if (!createAgentTurnFacade) {
+        throw new Error(`Gateway instance agent turn facade unavailable for ${method}`);
+      }
+      // Plugins may load through another source/bundle graph. Only the captured host can
+      // create turns against its published runtime; a local import creates a second owner.
+      const facade = await createAgentTurnFacade({
         assertContextCurrent: resolved.assertContextCurrent,
         client: resolved.client,
-        getContext: () => {
-          resolved.assertContextCurrent();
-          return resolved.context;
-        },
-        ...(resolved.context.getGatewayMethodRegistry
-          ? { getMethodRegistry: resolved.context.getGatewayMethodRegistry }
-          : {}),
         isWebchatConnect: resolved.isWebchatConnect,
       });
       return method === "agent"

--- a/src/gateway/server-plugins.subagent-ended-hook.test.ts
+++ b/src/gateway/server-plugins.subagent-ended-hook.test.ts
@@ -24,15 +24,6 @@ const internalAgentTurnFacade = vi.hoisted(() => ({
 vi.mock("./server-methods.js", () => ({
   handleGatewayRequest,
 }));
-vi.mock("./agent-turn/internal-facade.runtime.js", () => ({
-  createInternalAgentTurnFacade: (options: InternalAgentTurnFacadeOptions) => {
-    internalAgentTurnFacade.create(options);
-    return {
-      dispatch: internalAgentTurnFacade.dispatch,
-      wait: internalAgentTurnFacade.wait,
-    };
-  },
-}));
 
 type ServerPluginsModule = typeof import("./server-plugins.js") & {
   clearFallbackGatewayContext: () => void;
@@ -52,6 +43,13 @@ function createTestContext(label: string, cfg: OpenClawConfig): GatewayRequestCo
   return {
     label,
     getRuntimeConfig: () => cfg,
+    createAgentTurnFacade: (options: InternalAgentTurnFacadeOptions) => {
+      internalAgentTurnFacade.create(options);
+      return {
+        dispatch: internalAgentTurnFacade.dispatch,
+        wait: internalAgentTurnFacade.wait,
+      };
+    },
   } as unknown as GatewayRequestContext;
 }
 

--- a/src/gateway/server-plugins.test.ts
+++ b/src/gateway/server-plugins.test.ts
@@ -20,6 +20,7 @@ import { setActiveDegradedPlugins } from "../plugins/runtime-degraded-state.js";
 import type { PluginRuntimeGatewayRequestScope } from "../plugins/runtime/gateway-request-scope.test-fixtures.js";
 import type { PluginRuntime } from "../plugins/runtime/types.js";
 import { withEnv } from "../test-utils/env.js";
+import { createInternalAgentTurnFacade } from "./agent-turn/internal-facade.js";
 import type { GatewayRequestContext, GatewayRequestOptions } from "./server-methods/types.js";
 import { createSyntheticPluginRuntimeClient } from "./server-plugin-runtime-client.js";
 
@@ -276,7 +277,13 @@ function createTestLog() {
 }
 
 function createTestContext(label: string): GatewayRequestContext {
-  return { label } as unknown as GatewayRequestContext;
+  return bindTestAgentTurns({ label } as unknown as GatewayRequestContext);
+}
+
+function bindTestAgentTurns(context: GatewayRequestContext): GatewayRequestContext {
+  context.createAgentTurnFacade ??= (principal) =>
+    createInternalAgentTurnFacade({ ...principal, getContext: () => context });
+  return context;
 }
 
 const requireRecord = createRequireRecord("record", "expected-label-object-capitalized");
@@ -368,6 +375,7 @@ async function loadTestModules() {
       resolveTestGatewayContext = () => undefined;
     },
     setFallbackGatewayContext: (context) => {
+      bindTestAgentTurns(context);
       resolveTestGatewayContext = () => context;
       return () => {
         if (resolveTestGatewayContext() === context) {
@@ -376,9 +384,13 @@ async function loadTestModules() {
       };
     },
     setFallbackGatewayContextResolver: (resolve) => {
-      resolveTestGatewayContext = resolve;
+      const boundResolve = () => {
+        const context = resolve();
+        return context ? bindTestAgentTurns(context) : undefined;
+      };
+      resolveTestGatewayContext = boundResolve;
       return () => {
-        if (resolveTestGatewayContext === resolve) {
+        if (resolveTestGatewayContext === boundResolve) {
           resolveTestGatewayContext = () => undefined;
         }
       };


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where native subagents completed successfully but their completion delivery stayed pending during release verification. The recorded delivery error was `published reply runtime missing for dev`, even though the running Gateway had already published its runtime.

## Why This Change Was Made

The plugin dispatcher could create typed agent admission from a separate module-loader graph. The captured Gateway context was valid, but that graph did not own the Gateway's published runtime. The Gateway instance now supplies the typed facade factory through its context; embedded local runs explicitly bind their own factory. Recovery uses the same instance-owned factory.

The consumer-side construction was introduced in #121715 (authored and merged by @steipete on 2026-08-11); its later caller-context guards are retained.

The old consumer-side facade import is removed. Caller identity, scopes, request validation, session visibility, and context checks before and after awaited authorization are preserved. Retained facades reject once their instance closes; an absent host factory fails closed instead of creating another runtime owner.

Production LOC: +196/-130 (net +66), including unchanged client/response contract moves. The growth declares an explicit lifecycle-owner factory and leaf method contract without coupling shared context types to an implementation module. Duplicate consumer imports and recovery getters are removed. Test LOC: +151/-15. No config, SQLite schema, protocol, provider-routing, or native receipt-parser changes.

## User Impact

Completion turns use the same published runtime as their owning Gateway, so plugin-delivered native subagent results can complete delivery while preserving the original caller and lifecycle boundaries.

## Evidence

- The original release failure was captured before Gateway teardown; native child completion and the parent response both succeeded while delivery remained pending. See [release checks](https://github.com/openclaw/openclaw/actions/runs/33230752148).
- Both new factory-selection regressions fail against the original dispatcher because it never invokes the captured host factory. They pass with this repair, alongside missing-owner, asynchronous context replacement, closed-facade, authorization, visibility, and embedded-context coverage.
- Focused Gateway suites passed. Core TypeScript, both Gateway test TypeScript shards, changed-file lint, runtime-sidecar loader checks, and the import-cycle check passed.
- Independent Codex review reported no actionable P0 findings; the release coordinator also reviewed the complete production path and tests.
- Full `pnpm build` passed on runtime commit `1be15b8c05d4d8d1ef9f01f4363e0fba2c5dbd4e`, including declarations, SDK exports, CLI bootstrap checks, and UI performance budgets (19m 16.7s). The subsequent leaf type extraction passes the full architecture gate and core/Gateway type checks; normalized emitted JavaScript is identical for every changed existing module. A fresh independent review found no actionable P0 findings.
- The [real Luna Max Codex lane passed](https://github.com/openclaw/openclaw/actions/runs/33238320438/job/99063712107) on combined source `90c5191b442e81fe94f1349ba1683dd500272c6c`, using frozen tooling `383a293b32d97254014437430b62aaf406bc11ac`. The unchanged native-subagent probe received both result markers, completed its announcement turn, and passed the delivered-task assertion; Guardian and session-deletion probes also passed.
- The same focused group failed in Sol and Terra before the subagent probe because session selection still returned `max` instead of `ultra`. That remaining #132389 issue is separate; this PR does not claim the entire group passed. The first PR CI also caught a static type cycle, now repaired by moving exact client/response and facade contracts to leaf modules.

The full PR matrix also caught three detached-announcement fixtures that had not bound the host factory; their original lifecycle and delivery assertions now pass. The #132399 lint-suppression guard drift was reproduced failing at count one and passing at count two. That same correction has since reached main, so it is no longer part of this diff. The latest clean rebase onto `0120daca2b49c29c92037c84a1286833ef524a90` keeps the production and remaining fixture bytes unchanged and incorporates the landed media-test line-count repair; focused lint passes.

Codex dependency contract checked directly at `rust-v0.150.1`: `codex-rs/core/src/tools/handlers/multi_agents/wait.rs` (completed wait results) and `codex-rs/app-server-protocol/src/protocol/v2/item.rs` (completed collaboration items).

## Review Follow-up

The latest ClawSweeper review accepts the instance-owned repair and the corrected announcement fixtures. Its remaining changelog rank-up suggestion is intentionally skipped: this maintainer-directed release-verification repair explicitly includes the release note. The positive production delta is the typed lifecycle factory and exact leaf contracts described above; no additional parallel facade was added. The reviewer could not open the cited run because of its network restriction; the real Luna delivery proof remains linked above, and all production bytes are unchanged through both mechanical refreshes.
