### PR TITLE
fix: preserve complete output in release QA probes

### DIFF
--- a/test/e2e/qa-lab/runtime/openai-compatible-chat-tools.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/openai-compatible-chat-tools.e2e.test.ts
@@ -1,23 +1,16 @@
 // OpenAI-compatible chat tools tests cover QA Lab HTTP tool-call evidence.
-import { spawn, spawnSync } from "node:child_process";
+import { spawnSync } from "node:child_process";
 import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { createServer, type Server } from "node:http";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { beforeAll, describe, expect, it } from "vitest";
-import { createBoundedChildOutput } from "../../../helpers/bounded-child-output.js";
+import { runNodeScript } from "../../../helpers/run-node-script.js";
 import { cleanupTempDirs, makeTempDir } from "../../../helpers/temp-dir.js";
 
 const clientPath = path.resolve("scripts/e2e/lib/openai-chat-tools/client.mjs");
 const dockerRunnerPath = path.resolve("scripts/e2e/openai-chat-tools-docker.sh");
 const writeConfigPath = path.resolve("scripts/e2e/lib/openai-chat-tools/write-config.mjs");
-
-interface ClientResult {
-  error?: Error;
-  status: number | null;
-  stderr: string;
-  stdout: string;
-}
 
 async function listen(server: Server): Promise<number> {
   await new Promise<void>((resolve, reject) => {
@@ -34,52 +27,19 @@ async function listen(server: Server): Promise<number> {
   return address.port;
 }
 
-function runClient(
-  port: number | string,
-  env: Record<string, string> = {},
-  timeout = 5_000,
-): Promise<ClientResult> {
-  return new Promise((resolve) => {
-    const child = spawn(process.execPath, [clientPath], {
-      env: {
-        ...process.env,
-        MODEL_REF: "openai/gpt-5.4-mini",
-        OPENCLAW_GATEWAY_TOKEN: "test-token",
-        OPENCLAW_OPENAI_CHAT_TOOLS_TIMEOUT_SECONDS: "1",
-        PORT: String(port),
-        ...env,
-      },
-      stdio: ["ignore", "pipe", "pipe"],
-    });
-    const stdout = createBoundedChildOutput();
-    const stderr = createBoundedChildOutput();
-    let timedOut = false;
-    child.stdout.setEncoding("utf8");
-    child.stderr.setEncoding("utf8");
-    child.stdout.on("data", (chunk) => {
-      stdout.append(chunk);
-    });
-    child.stderr.on("data", (chunk) => {
-      stderr.append(chunk);
-    });
-    const timer = setTimeout(() => {
-      timedOut = true;
-      child.kill("SIGKILL");
-    }, timeout);
-    child.on("error", (error) => {
-      clearTimeout(timer);
-      resolve({ error, status: null, stderr: stderr.text(), stdout: stdout.text() });
-    });
-    child.on("exit", (status) => {
-      clearTimeout(timer);
-      resolve({
-        error: timedOut ? new Error(`client timed out after ${timeout}ms`) : undefined,
-        status,
-        stderr: stderr.text(),
-        stdout: stdout.text(),
-      });
-    });
-  });
+function runClient(port: number | string, env: Record<string, string> = {}, timeout = 5_000) {
+  return runNodeScript(
+    clientPath,
+    {
+      ...process.env,
+      MODEL_REF: "openai/gpt-5.4-mini",
+      OPENCLAW_GATEWAY_TOKEN: "test-token",
+      OPENCLAW_OPENAI_CHAT_TOOLS_TIMEOUT_SECONDS: "1",
+      PORT: String(port),
+      ...env,
+    },
+    timeout,
+  );
 }
 
 function runWriteConfig(root: string, env: Record<string, string> = {}) {
@@ -138,7 +98,7 @@ describe("scripts/e2e/lib/openai-chat-tools/client.mjs", () => {
   let bodyReadTimeoutProbe: {
     elapsedMs: number;
     responseClosed: boolean;
-    result: ClientResult;
+    result: Awaited<ReturnType<typeof runClient>>;
   };
 
   beforeAll(async () => {

--- a/test/e2e/qa-lab/runtime/openwebui-probe.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/openwebui-probe.e2e.test.ts
@@ -1,21 +1,13 @@
 // OpenWebUI probe tests cover QA Lab OpenAI-compatible API evidence.
-import { spawn } from "node:child_process";
 import { readFileSync } from "node:fs";
 import { createServer, type IncomingMessage, type Server as HttpServer } from "node:http";
 import { createServer as createTcpServer, type Server as TcpServer, type Socket } from "node:net";
 import path from "node:path";
 import { MAX_TIMER_TIMEOUT_MS } from "@openclaw/normalization-core/number-coercion";
 import { describe, expect, it } from "vitest";
-import { createBoundedChildOutput } from "../../../helpers/bounded-child-output.js";
+import { runNodeScript } from "../../../helpers/run-node-script.js";
 
 const probePath = path.resolve("scripts/e2e/openwebui-probe.mjs");
-
-interface ProbeResult {
-  error?: Error;
-  status: number | null;
-  stderr: string;
-  stdout: string;
-}
 
 async function listen(server: HttpServer | TcpServer): Promise<string> {
   await new Promise<void>((resolve, reject) => {
@@ -33,52 +25,23 @@ async function listen(server: HttpServer | TcpServer): Promise<string> {
 }
 
 function runProbe(baseUrl: string, env: Record<string, string> = {}, timeout = 3_000) {
-  return new Promise<ProbeResult>((resolve) => {
-    const child = spawn(process.execPath, [probePath], {
-      env: {
-        ...process.env,
-        OPENWEBUI_ADMIN_EMAIL: "openwebui-e2e@example.com",
-        OPENWEBUI_ADMIN_PASSWORD: "test-password",
-        OPENWEBUI_BASE_URL: baseUrl,
-        OPENWEBUI_CONTROL_TIMEOUT_MS: "250",
-        OPENWEBUI_EXPECTED_NONCE: "nonce-123",
-        OPENWEBUI_MODEL_ATTEMPTS: "1",
-        OPENWEBUI_MODEL_RETRY_MS: "0",
-        OPENWEBUI_PROMPT: "reply with nonce-123",
-        OPENWEBUI_SMOKE_MODE: "models",
-        ...env,
-      },
-      stdio: ["ignore", "pipe", "pipe"],
-    });
-    const stdout = createBoundedChildOutput();
-    const stderr = createBoundedChildOutput();
-    let timedOut = false;
-    child.stdout.setEncoding("utf8");
-    child.stderr.setEncoding("utf8");
-    child.stdout.on("data", (chunk) => {
-      stdout.append(chunk);
-    });
-    child.stderr.on("data", (chunk) => {
-      stderr.append(chunk);
-    });
-    const timer = setTimeout(() => {
-      timedOut = true;
-      child.kill("SIGKILL");
-    }, timeout);
-    child.on("error", (error) => {
-      clearTimeout(timer);
-      resolve({ error, status: null, stderr: stderr.text(), stdout: stdout.text() });
-    });
-    child.on("exit", (status) => {
-      clearTimeout(timer);
-      resolve({
-        error: timedOut ? new Error(`probe timed out after ${timeout}ms`) : undefined,
-        status,
-        stderr: stderr.text(),
-        stdout: stdout.text(),
-      });
-    });
-  });
+  return runNodeScript(
+    probePath,
+    {
+      ...process.env,
+      OPENWEBUI_ADMIN_EMAIL: "openwebui-e2e@example.com",
+      OPENWEBUI_ADMIN_PASSWORD: "test-password",
+      OPENWEBUI_BASE_URL: baseUrl,
+      OPENWEBUI_CONTROL_TIMEOUT_MS: "250",
+      OPENWEBUI_EXPECTED_NONCE: "nonce-123",
+      OPENWEBUI_MODEL_ATTEMPTS: "1",
+      OPENWEBUI_MODEL_RETRY_MS: "0",
+      OPENWEBUI_PROMPT: "reply with nonce-123",
+      OPENWEBUI_SMOKE_MODE: "models",
+      ...env,
+    },
+    timeout,
+  );
 }
 
 async function readRequestBody(request: IncomingMessage): Promise<string> {

--- a/test/helpers/run-node-script.test.ts
+++ b/test/helpers/run-node-script.test.ts
@@ -1,0 +1,32 @@
+import { writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { afterEach, expect, it } from "vitest";
+import { runNodeScript } from "./run-node-script.js";
+import { useAutoCleanupTempDirTracker } from "./temp-dir.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+it("captures inherited output written after the script exits", async () => {
+  const script = join(tempDirs.make("openclaw-node-script-output-"), "parent.mjs");
+  writeFileSync(
+    script,
+    `import { spawn } from "node:child_process";
+const child = spawn(process.execPath, ["-e", \`
+process.on("disconnect", () => {
+  process.stdout.write("drained stdout\\\\n");
+  process.stderr.write("drained stderr\\\\n");
+});
+process.send("ready");
+\`], { stdio: ["ignore", "inherit", "inherit", "ipc"] });
+child.once("message", () => process.exit(17));
+`,
+  );
+
+  const result = await runNodeScript(script, process.env, 5_000);
+  expect(result).toEqual({
+    error: undefined,
+    status: 17,
+    stdout: "drained stdout\n",
+    stderr: "drained stderr\n",
+  });
+});

--- a/test/helpers/run-node-script.ts
+++ b/test/helpers/run-node-script.ts
@@ -1,0 +1,26 @@
+import { runManagedCommand } from "../../scripts/lib/managed-child-process.mts";
+import { createBoundedChildOutput } from "./bounded-child-output.js";
+
+export async function runNodeScript(scriptPath: string, env: NodeJS.ProcessEnv, timeoutMs: number) {
+  const stdout = createBoundedChildOutput();
+  const stderr = createBoundedChildOutput();
+  let status: number | null = null;
+  let error: unknown;
+  try {
+    status = await runManagedCommand({
+      bin: process.execPath,
+      args: [scriptPath],
+      env,
+      timeoutMs,
+      shell: false,
+      stdio: ["ignore", "pipe", "pipe"],
+      onReady(child) {
+        child.stdout!.on("data", stdout.append);
+        child.stderr!.on("data", stderr.append);
+      },
+    });
+  } catch (cause) {
+    error = cause;
+  }
+  return { error, status, stderr: stderr.text(), stdout: stdout.text() };
+}


### PR DESCRIPTION
## What Problem This Solves

Resolves intermittent full release QA failures where a completed probe reported empty stderr or incomplete stdout even though its child process had written the expected evidence. The same output capture race existed in the OpenAI-compatible chat tools and OpenWebUI probe tests.

## Why This Change Was Made

The two test helpers completed on the Node child `exit` event, before its inherited output pipes were necessarily closed. Both now use one small bounded-output adapter over the existing managed process owner, which completes on `close` and owns timeout and process-tree cleanup. This removes the duplicate spawn/listener/timer loops without changing the callers' deadlines or assertions.

## User Impact

No product behavior changes. Release QA retains complete subprocess evidence and avoids false failures caused by reading output too early. Production LOC: unchanged. Test/support LOC: +92/-111, net -19.

## Evidence

A real child/grandchild regression uses IPC disconnect to write stdout and stderr after the parent exits. Before the fix, it returned status 17 with both streams empty; after the fix, it preserves status 17 and both complete outputs. Node documents this lifecycle distinction in its [child process close contract](https://nodejs.org/api/child_process.html#event-close).

The new regression, bounded UTF-8 output tests, and both complete probe suites passed: 38 tests total. The script-only E2E suites used their existing `OPENCLAW_E2E_SKIP_BUILD=1` fixture-owned build exemption. Formatting and diff checks passed; independent Codex autoreview reported no findings at its default P0 scope.

The root test typecheck is not green in this checkout: it reports 18 dependency/type errors outside the changed files. A before/after comparison against unchanged base `09be104e941c1b791fa4ceac71f0e801fd9370ac` produced byte-identical diagnostics. Dependencies were left untouched; exact-head CI must provide the clean dependency proof.
