### PR TITLE
test: avoid doctor fixture fallthrough waits

### DIFF
--- a/test/scripts/docker-build-helper.test.ts
+++ b/test/scripts/docker-build-helper.test.ts
@@ -3375,14 +3375,15 @@ fi
         openclaw: `#!/usr/bin/env bash
 set -euo pipefail
 printf '%s %s\n' "$OPENCLAW_CONFIG_PATH" "$*" >>"$CAPTURE_DIR/openclaw-calls"
-if [ "$FAILURE_STAGE" = doctor ] && [ "\${1:-}" = doctor ]; then
-  exit 41
+if [ "\${1:-}" = doctor ]; then
+  [ "$FAILURE_STAGE" != doctor ] || exit 41
+  exit 0
 fi
 if [ "\${1:-}" = gateway ] && [ "\${2:-}" = install ]; then
   [ "$FAILURE_STAGE" != install ] || exit 44
   exit 0
 fi
-sleep 30
+exec sleep 30
 `,
       });
 


### PR DESCRIPTION
## What Problem This Solves

The upgrade-survivor recovery fixture accidentally runs its 30-second gateway sleep after a successful `doctor` command. Three later failure cases each pay that delay before reaching the behavior under test.

## Why This Change Was Made

Return explicitly from the fake doctor for both success and failure, and use `exec sleep 30` only for the long-running gateway stand-in. The existing cleanup can then kill and reap the actual sleeper by its owned PID. The production preparation and config-parking functions remain unchanged.

## User Impact

All 247 Docker helper cases fell from **114.13s to 24.38s** of local test execution, repeating at **24.34s**. Production +0/-0; tests +4/-3. No sharding, worker count, selection, timeout policy, or runtime changes.

## Evidence

- `node scripts/run-vitest.mjs test/scripts/docker-build-helper.test.ts`: 247 passed before and after.
- Final run with `test/scripts/upgrade-survivor-config-parking.test.ts`: all 253 passed.
- Temporarily removing the real owner's final authored-config restoration made all four existing recovery cases fail their original byte-restoration assertion. Production bytes were restored before the final passing run.
- Original failure statuses 41/42/43/44, canonical config path, snapshot removal, and real shell/process cleanup remain covered. These tests exercise recovery orchestration with a fake CLI, not live gateway readiness.
- Independent review and Codex autoreview found no actionable findings; formatting and whitespace checks passed. Linux changed checks and exact-head CI must pass before landing.

Final gates: [exact-head CI](https://github.com/openclaw/openclaw/actions/runs/33238339551) and actual Linux changed checks passed. The one-shot Testbox was stopped. Latest ClawSweeper has no findings; its request for normal CI and maintainer landing is satisfied.
