### PR TITLE
fix(ci): retain Docker timeout evidence without blind retries

### DIFF
--- a/scripts/e2e/codex-npm-plugin-live-docker.sh
+++ b/scripts/e2e/codex-npm-plugin-live-docker.sh
@@ -68,6 +68,9 @@ else
   FOLLOWTHROUGH_PROGRESS_FINAL_MODE="legacy"
 fi
 run_log=""
+# Signal traps inherit the harness function's log redirection. Reserve the original stdout
+# so EXIT cleanup cannot print the failure tail back into the log it is reading.
+exec 3>&1
 
 cleanup() {
   local cleanup_status="$?"
@@ -78,9 +81,8 @@ cleanup() {
     docker_e2e_cleanup_package_tgz "$PACKAGE_TGZ"
   fi
   if [ -n "${run_log:-}" ]; then
-    # Harness signal handlers exit before the outer failure branch can print.
     if [ "$cleanup_status" -ne 0 ]; then
-      docker_e2e_print_log "$run_log" || true
+      docker_e2e_print_log "$run_log" >&3 || true
     fi
     rm -f "$run_log"
   fi

--- a/scripts/e2e/codex-npm-plugin-live-docker.sh
+++ b/scripts/e2e/codex-npm-plugin-live-docker.sh
@@ -70,6 +70,7 @@ fi
 run_log=""
 
 cleanup() {
+  local cleanup_status="$?"
   if [ -n "${CODEX_PLUGIN_PACK_DIR:-}" ]; then
     rm -rf "$CODEX_PLUGIN_PACK_DIR"
   fi
@@ -77,8 +78,13 @@ cleanup() {
     docker_e2e_cleanup_package_tgz "$PACKAGE_TGZ"
   fi
   if [ -n "${run_log:-}" ]; then
+    # Harness signal handlers exit before the outer failure branch can print.
+    if [ "$cleanup_status" -ne 0 ]; then
+      docker_e2e_print_log "$run_log" || true
+    fi
     rm -f "$run_log"
   fi
+  return "$cleanup_status"
 }
 trap cleanup EXIT
 
@@ -542,7 +548,6 @@ node scripts/e2e/lib/codex-npm-plugin-live/assertions.mjs assert-agent-error "$p
 
 echo "Codex npm plugin live Docker E2E passed"
 EOF
-  docker_e2e_print_log "$run_log"
   exit 1
 fi
 

--- a/scripts/lib/docker-e2e-logs.sh
+++ b/scripts/lib/docker-e2e-logs.sh
@@ -143,6 +143,9 @@ run_logged_print_heartbeat() {
       terminate_heartbeat_command
       wait "$command_pid" 2>/dev/null || true
     fi
+    if [ "$cleanup_status" -ne 0 ]; then
+      docker_e2e_print_log "$log_file" || true
+    fi
     rm -f "$log_file"
     restore_heartbeat_traps
     if [ "$cleanup_status" -ge 128 ]; then

--- a/scripts/test-docker-all.mts
+++ b/scripts/test-docker-all.mts
@@ -1397,9 +1397,8 @@ async function runLane(
     if (result.status === 0 || attempt >= maxAttempts) {
       break;
     }
-    const retryable =
-      result.timedOut || (await laneLogMatchesRetryPattern(logFile, lane.retryPatterns));
-    if (!retryable) {
+    // An exhausted lane deadline alone does not diagnose a transient failure.
+    if (!(await laneLogMatchesRetryPattern(logFile, lane.retryPatterns))) {
       break;
     }
   }

--- a/test/scripts/docker-all-harness.test.ts
+++ b/test/scripts/docker-all-harness.test.ts
@@ -222,6 +222,64 @@ function runFixture(
 }
 
 describe("Docker scheduler trusted harness execution", () => {
+  posixIt.each([
+    { failure: "timeout", attempts: 1, passed: false },
+    { failure: "deterministic failure", attempts: 1, passed: false },
+    { failure: "rate limited", attempts: 2, passed: true },
+  ])("retries only diagnosed transient failures: $failure", ({ failure, attempts, passed }) => {
+    const fixture = setupFixture("split");
+    const catalog = path.join(fixture.harness, "scripts/lib/docker-e2e-scenarios.mts");
+    // Keep the real scheduler and catalog policy, with a short fixture-only deadline.
+    writeFileSync(
+      catalog,
+      readFileSync(catalog, "utf8").replace(
+        "const LIVE_PROFILE_TIMEOUT_MS = 30 * 60 * 1000;",
+        "const LIVE_PROFILE_TIMEOUT_MS = 1_000;",
+      ),
+    );
+    const attemptLog = path.join(fixture.root, "attempts");
+    const command = path.join(fixture.root, "live-attempt.cjs");
+    writeFileSync(
+      command,
+      `const fs = require("node:fs");
+const attemptLog = ${JSON.stringify(attemptLog)};
+fs.appendFileSync(attemptLog, "attempt\\n");
+const attempt = fs.readFileSync(attemptLog, "utf8").trim().split("\\n").length;
+if (${JSON.stringify(failure)} === "timeout") {
+  setInterval(() => {}, 1000);
+} else if (attempt === 1) {
+  console.error(${JSON.stringify(failure)});
+  process.exitCode = 1;
+}
+`,
+    );
+    writeFileSync(
+      path.join(fixture.harness, "scripts/test-live-models-docker.sh"),
+      `#!/usr/bin/env bash\nexec ${quote(process.execPath)} ${quote(command)}\n`,
+    );
+    const { result, logDir } = runFixture(
+      fixture,
+      "split",
+      ["live-models", "gateway-concurrency"],
+      {
+        env: {
+          OPENCLAW_DOCKER_ALL_LIVE_RETRIES: "1",
+          OPENCLAW_DOCKER_ALL_FAIL_FAST: "0",
+          OPENCLAW_DOCKER_ALL_PARALLELISM: "1",
+        },
+      },
+    );
+    expect(result.status, result.stdout + result.stderr).toBe(passed ? 0 : 1);
+    expect(readFileSync(attemptLog, "utf8").trim().split("\n")).toHaveLength(attempts);
+    const summary = JSON.parse(readFileSync(path.join(logDir, "summary.json"), "utf8"));
+    const live = summary.lanes.find((lane: { name: string }) => lane.name === "live-models");
+    expect(live.attempts).toHaveLength(attempts);
+    expect(live.timedOut).toBe(failure === "timeout");
+    expect(
+      summary.lanes.find((lane: { name: string }) => lane.name === "gateway-concurrency").status,
+    ).toBe(0);
+  });
+
   posixIt.each(["split", "override", "local"] as const)(
     "executes current scripts with the frozen candidate in %s mode",
     (mode) => {

--- a/test/scripts/docker-e2e-observability.test.ts
+++ b/test/scripts/docker-e2e-observability.test.ts
@@ -1,6 +1,6 @@
 // Docker E2E Observability tests cover docker e2e observability script behavior.
 import { spawnSync } from "node:child_process";
-import { readFileSync, writeFileSync } from "node:fs";
+import { existsSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
@@ -34,6 +34,68 @@ function runSuccessTail(scriptPath: string) {
 }
 
 describe("Docker E2E observability", () => {
+  it("prints the bounded heartbeat log before signal cleanup", () => {
+    const tempDir = tempDirs.make("openclaw-heartbeat-signal-log-");
+    const result = spawnSync(
+      "bash",
+      [
+        "-c",
+        `
+set -euo pipefail
+source scripts/lib/docker-e2e-logs.sh
+run_logged_print_heartbeat signal-proof 30 bash -c 'printf "old log head%0256drecent failure tail\\n" 0; kill -TERM "$PPID"'
+`,
+      ],
+      {
+        encoding: "utf8",
+        timeout: 5_000,
+        env: { ...process.env, TMPDIR: tempDir, OPENCLAW_DOCKER_E2E_LOG_PRINT_BYTES: "64" },
+      },
+    );
+    expect(result.status, result.stderr).toBe(143);
+    expect(result.stdout).not.toContain("old log head");
+    expect(result.stdout.match(/recent failure tail/g)).toHaveLength(1);
+    expect(result.stdout).toContain("showing last 64");
+    expect(readdirSync(tempDir)).toEqual([]);
+  });
+
+  it.each([0, 1, 143])("preserves Codex run diagnostics on exit %i", (status) => {
+    const tempDir = tempDirs.make("openclaw-codex-run-cleanup-");
+    const log = path.join(tempDir, "run.log");
+    writeFileSync(log, `old log head${"x".repeat(256)}recent failure tail\n`);
+    const script = readFileSync("scripts/e2e/codex-npm-plugin-live-docker.sh", "utf8");
+    const cleanup = script.slice(
+      script.indexOf("cleanup() {"),
+      script.indexOf("trap cleanup EXIT"),
+    );
+    const result = spawnSync(
+      "bash",
+      [
+        "-c",
+        [
+          "set -euo pipefail",
+          "source scripts/lib/docker-e2e-logs.sh",
+          `run_log=${JSON.stringify(log)}`,
+          "OPENCLAW_DOCKER_E2E_LOG_PRINT_BYTES=64",
+          cleanup,
+          "trap cleanup EXIT",
+          // The Docker harness exits from its signal handler before the outer failure branch.
+          status === 143 ? "trap 'exit 143' TERM; kill -TERM $$" : `exit ${status}`,
+        ].join("\n"),
+      ],
+      { encoding: "utf8" },
+    );
+    expect(result.status, result.stderr).toBe(status);
+    expect(existsSync(log)).toBe(false);
+    expect(result.stdout).not.toContain("old log head");
+    if (status === 0) {
+      expect(result.stdout).toBe("");
+    } else {
+      expect(result.stdout.match(/recent failure tail/g)).toHaveLength(1);
+      expect(result.stdout).toContain("showing last 64");
+    }
+  });
+
   it("feeds the cron CLI Docker proof body through container stdin", () => {
     const script = readFileSync("scripts/e2e/cron-cli-docker.sh", "utf8");
 

--- a/test/scripts/docker-e2e-observability.test.ts
+++ b/test/scripts/docker-e2e-observability.test.ts
@@ -1,6 +1,6 @@
 // Docker E2E Observability tests cover docker e2e observability script behavior.
 import { spawnSync } from "node:child_process";
-import { existsSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
+import { readdirSync, readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
@@ -59,42 +59,96 @@ run_logged_print_heartbeat signal-proof 30 bash -c 'printf "old log head%0256dre
     expect(readdirSync(tempDir)).toEqual([]);
   });
 
-  it.each([0, 1, 143])("preserves Codex run diagnostics on exit %i", (status) => {
-    const tempDir = tempDirs.make("openclaw-codex-run-cleanup-");
-    const log = path.join(tempDir, "run.log");
-    writeFileSync(log, `old log head${"x".repeat(256)}recent failure tail\n`);
-    const script = readFileSync("scripts/e2e/codex-npm-plugin-live-docker.sh", "utf8");
-    const cleanup = script.slice(
-      script.indexOf("cleanup() {"),
-      script.indexOf("trap cleanup EXIT"),
-    );
-    const result = spawnSync(
-      "bash",
-      [
-        "-c",
+  it.each([
+    [0, "", true],
+    [1, "", true],
+    [143, "TERM", false],
+    [143, "TERM", true],
+    [130, "INT", false],
+    [129, "HUP", false],
+  ] as const)(
+    "preserves redirected Codex run diagnostics on exit %i (%s, long=%s)",
+    (status, signal, long) => {
+      const tempDir = tempDirs.make("openclaw-codex-run-cleanup-");
+      const script = readFileSync("scripts/e2e/codex-npm-plugin-live-docker.sh", "utf8");
+      const cleanupSetup = script.slice(
+        script.indexOf('run_log=""'),
+        script.indexOf("trap cleanup EXIT") + "trap cleanup EXIT".length,
+      );
+      const result = spawnSync(
+        "bash",
         [
-          "set -euo pipefail",
-          "source scripts/lib/docker-e2e-logs.sh",
-          `run_log=${JSON.stringify(log)}`,
-          "OPENCLAW_DOCKER_E2E_LOG_PRINT_BYTES=64",
-          cleanup,
-          "trap cleanup EXIT",
-          // The Docker harness exits from its signal handler before the outer failure branch.
-          status === 143 ? "trap 'exit 143' TERM; kill -TERM $$" : `exit ${status}`,
-        ].join("\n"),
-      ],
-      { encoding: "utf8" },
-    );
-    expect(result.status, result.stderr).toBe(status);
-    expect(existsSync(log)).toBe(false);
-    expect(result.stdout).not.toContain("old log head");
-    if (status === 0) {
-      expect(result.stdout).toBe("");
-    } else {
-      expect(result.stdout.match(/recent failure tail/g)).toHaveLength(1);
-      expect(result.stdout).toContain("showing last 64");
-    }
-  });
+          "-c",
+          `
+set -Eeuo pipefail
+# Bound the pre-fix self-copy if EXIT cleanup still writes into its input log.
+ulimit -f 8
+source scripts/lib/docker-e2e-package.sh
+proof_status="$1"
+proof_signal="$2"
+proof_long="$3"
+docker_e2e_docker_cmd() {
+  printf '%s\\n' "$*" >>"$TMPDIR/docker-cleanup"
+}
+docker_e2e_docker_run_cmd() {
+  while [ "$#" -gt 0 ]; do
+    if [ "$1" = --cidfile ]; then
+      printf 'proof-container\\n' >"$2"
+      break
+    fi
+    shift
+  done
+  cat >"$TMPDIR/container-stdin"
+  if [ "$proof_long" = true ]; then
+    printf 'old log head%0256d' 0
+  fi
+  printf 'recent failure tail\\n'
+  if [ -n "$proof_signal" ]; then
+    kill -"$proof_signal" "$$"
+  else
+    return "$proof_status"
+  fi
+}
+${cleanupSetup}
+run_log="$TMPDIR/run.log"
+# Use the actual harness: its signal trap exits inside this function redirection.
+if ! docker_e2e_run_with_harness image-name bash -s >"$run_log" 2>&1 <<'SH'; then
+container stdin proof
+SH
+  exit 1
+fi
+`,
+          "bash",
+          String(status),
+          signal,
+          String(long),
+        ],
+        {
+          encoding: "utf8",
+          timeout: 5_000,
+          killSignal: "SIGKILL",
+          env: { ...process.env, TMPDIR: tempDir, OPENCLAW_DOCKER_E2E_LOG_PRINT_BYTES: "64" },
+        },
+      );
+      expect(result.status, JSON.stringify({ stderr: result.stderr, signal: result.signal })).toBe(
+        status,
+      );
+      expect(readFileSync(path.join(tempDir, "container-stdin"), "utf8")).toBe(
+        "container stdin proof\n",
+      );
+      expect(readFileSync(path.join(tempDir, "docker-cleanup"), "utf8")).toBe(
+        "rm -f proof-container\n",
+      );
+      expect(readdirSync(tempDir).sort()).toEqual(["container-stdin", "docker-cleanup"]);
+      expect(result.stdout).not.toContain("old log head");
+      if (status === 0) {
+        expect(result.stdout).toBe("");
+      } else {
+        expect(result.stdout.match(/recent failure tail/g)).toHaveLength(1);
+        expect(result.stdout.includes("showing last 64")).toBe(long);
+      }
+    },
+  );
 
   it("feeds the cron CLI Docker proof body through container stdin", () => {
     const script = readFileSync("scripts/e2e/cron-cli-docker.sh", "utf8");


### PR DESCRIPTION
## What Problem This Solves

Resolves a release-verification failure mode where an undiagnosed live Docker timeout consumed the remaining job budget on an automatic retry while its useful container log had already been deleted.

In [the observed package/update OpenAI job](https://github.com/openclaw/openclaw/actions/runs/33231321931/job/99044967154), the live npm plugin lane exhausted its 30-minute deadline, restarted automatically, and hit the 45-minute job limit before typed onboarding could start. The retained log did not contain the inner container failure evidence.

## Why This Change Was Made

The Docker harness exits from its signal handler before the caller's ordinary failure-print branch. The live plugin script now prints its existing bounded failure tail from the cleanup owner before deleting the temporary log, preserving the signal exit status. The shared heartbeat logger repairs the same signal-cleanup loss. Successful output behavior is unchanged.

The scheduler now requires a recognized transient failure pattern for a retry. An exhausted lane deadline alone no longer starts another full attempt. Existing rate-limit, capacity, and network-error retry patterns remain; failed and timed-out attempts still fail validation. No lane, scenario, assertion, or deadline is removed or expanded.

## User Impact

No product behavior changes. Maintainers retain failure diagnostics and avoid spending another lane budget on an unexplained timeout. Production/tooling LOC: +13/-4, net +9, needed to emit bounded evidence at its cleanup owner. Tests: +175/-1.

The underlying live npm plugin stall is still unknown. This change does not claim to fix it or to make the observed release candidate pass; one narrow live rerun with retained diagnostics is the next proof.

## Evidence

Before the fix, the real scheduler fixture ran two opaque timeout attempts, and both the live-script and shared-heartbeat cleanup regressions lost their failure tail. After the fix:

- The scheduler runs one opaque timeout attempt, still retries a recognized rate limit, does not retry a deterministic failure, and runs the other selected lane with failure draining enabled.
- Regular failure and signal 143 preserve the bounded log tail exactly once and remove temporary logs; successful cleanup remains quiet.
- All 20 scheduler/observability tests and 15 existing logging/heartbeat sibling tests pass. Shell syntax, targeted scheduler lint, formatting, and diff checks pass.
- Independent Codex autoreview reports no findings at its default P0 scope.

The root test typecheck reports 18 dependency/type errors outside the changed files. Unchanged base `09be104e941c1b791fa4ceac71f0e801fd9370ac` and patched code produce byte-identical diagnostics with the existing dependencies. Exact-head CI still needs to establish clean dependency proof.


Pre-landing review caught an execution-order gap in the first regression: the Docker harness signal trap exits while the harness function still owns its stdout redirection. EXIT cleanup could therefore copy the run log into itself instead of emitting diagnostics. The correction reserves original stdout before capture, matching the existing upgrade-survivor script pattern, and emits cleanup diagnostics through that descriptor. The replacement regression sources the real Docker harness, preserves function-level capture and heredoc stdin, and stubs only Docker. Before the correction, all four signal cases failed; afterward, the scheduler and observability suite passes 20 tests, 15 logging/container/stdin siblings pass, and all 11 observability cases also pass under Bash 3. Success remains quiet, the tail appears once, container/log cleanup completes, and signal exit codes remain 129/130/143. No new configuration or retry was added. The actual live plugin stall remains unknown pending the targeted replay after this diagnostics change lands.
