### PR TITLE
fix(imessage): avoid unnecessary startup work in Doctor

### DIFF
--- a/extensions/imessage/doctor-contract-api.test.ts
+++ b/extensions/imessage/doctor-contract-api.test.ts
@@ -1,12 +1,31 @@
 // Imessage tests cover doctor contract api plugin behavior.
 import { expectDefined } from "@openclaw/normalization-core";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { legacyConfigRules, normalizeCompatibilityConfig } from "./doctor-contract-api.js";
 
 function imessageConfig(entry: Record<string, unknown>): OpenClawConfig {
   return { channels: { imessage: entry } } as never;
 }
+
+describe("imessage doctor control plane", () => {
+  afterEach(() => {
+    vi.doUnmock("./src/state-migrations.js");
+    vi.resetModules();
+  });
+
+  it("repairs config without loading state migration implementation", async () => {
+    vi.resetModules();
+    vi.doMock("./src/state-migrations.js", () => {
+      throw new Error("config repair must not load state migration implementation");
+    });
+    const doctor = await import("./doctor-contract-api.js");
+    const result = doctor.normalizeCompatibilityConfig({
+      cfg: imessageConfig({ chunkMode: "newline" }),
+    });
+    expect(result.config.channels?.imessage).toEqual({ streaming: { chunkMode: "newline" } });
+  });
+});
 
 describe("imessage streaming legacy config rules", () => {
   const rootRule = legacyConfigRules.find(

--- a/extensions/imessage/doctor-contract-api.ts
+++ b/extensions/imessage/doctor-contract-api.ts
@@ -9,7 +9,6 @@ import {
   definePluginDoctorMigrationFromPlans,
 } from "openclaw/plugin-sdk/runtime-doctor-migrations";
 import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
-import { detectIMessageLegacyStateMigrations } from "./src/state-migrations.js";
 
 // Disabled `channels.imessage.catchup` blocks are retired. Enabled blocks stay
 // as a compatibility contract: older configs that opted into replay still get
@@ -111,6 +110,11 @@ export const stateMigrations = [
   definePluginDoctorMigrationFromPlans({
     id: "imessage-legacy-state",
     label: "iMessage legacy state",
-    resolvePlans: detectIMessageLegacyStateMigrations,
+    // Config repair enumerates this artifact too; load the detector only when
+    // detection or migration resolves plans.
+    resolvePlans: async (params) => {
+      const { detectIMessageLegacyStateMigrations } = await import("./src/state-migrations.js");
+      return detectIMessageLegacyStateMigrations(params);
+    },
   }),
 ];

--- a/extensions/imessage/src/accounts.ts
+++ b/extensions/imessage/src/accounts.ts
@@ -2,10 +2,12 @@ import { statSync } from "node:fs";
 import path from "node:path";
 import { createAccountListHelpers } from "openclaw/plugin-sdk/account-helpers";
 import { DEFAULT_ACCOUNT_ID } from "openclaw/plugin-sdk/account-id";
-import { normalizeAccountId, type OpenClawConfig } from "openclaw/plugin-sdk/account-resolution";
-// Imessage plugin module implements accounts behavior.
+import {
+  normalizeAccountId,
+  resolveAccountEntry,
+  type OpenClawConfig,
+} from "openclaw/plugin-sdk/account-resolution";
 import { expectDefined } from "openclaw/plugin-sdk/expect-runtime";
-import { resolveAccountEntry } from "openclaw/plugin-sdk/routing";
 import {
   asOptionalRecord,
   normalizeOptionalString,

--- a/extensions/imessage/src/monitor-reply-cache.ts
+++ b/extensions/imessage/src/monitor-reply-cache.ts
@@ -1,5 +1,3 @@
-// Imessage plugin module implements monitor reply cache behavior.
-import { createHash } from "node:crypto";
 import type { PluginStateSyncKeyedStore } from "openclaw/plugin-sdk/plugin-state-runtime";
 import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
@@ -9,15 +7,18 @@ import {
   type IMessageChatContext,
 } from "./chat-context.js";
 import { getIMessageRuntime } from "./runtime.js";
+import {
+  IMESSAGE_REPLY_CACHE_NAMESPACE,
+  IMESSAGE_REPLY_CACHE_MAX_ENTRIES,
+  IMESSAGE_REPLY_CACHE_COUNTER_NAMESPACE,
+  IMESSAGE_REPLY_CACHE_COUNTER_MAX_ENTRIES,
+  IMESSAGE_REPLY_CACHE_COUNTER_KEY,
+  IMESSAGE_REPLY_CACHE_TTL_MS,
+  resolveIMessageReplyCacheEntryKey,
+} from "./state-contract.js";
 
 export type { IMessageChatContext } from "./chat-context.js";
 
-export const IMESSAGE_REPLY_CACHE_NAMESPACE = "imessage.reply-cache";
-export const IMESSAGE_REPLY_CACHE_MAX_ENTRIES = 2000;
-export const IMESSAGE_REPLY_CACHE_COUNTER_NAMESPACE = "imessage.reply-cache-counter";
-export const IMESSAGE_REPLY_CACHE_COUNTER_MAX_ENTRIES = 1;
-export const IMESSAGE_REPLY_CACHE_COUNTER_KEY = "short-id-counter";
-const REPLY_CACHE_TTL_MS = 6 * 60 * 60 * 1000;
 /** Recency window for the "react to the latest message" fallback. */
 const LATEST_FALLBACK_MS = 10 * 60 * 1000;
 let persistenceFailureLogged = false;
@@ -60,10 +61,6 @@ const imessageShortIdToUuid = new Map<string, string>();
 const imessageUuidToShortId = new Map<string, string>();
 let imessageShortIdCounter = 0;
 
-export function resolveIMessageReplyCacheEntryKey(messageId: string): string {
-  return createHash("sha256").update(messageId, "utf8").digest("hex").slice(0, 32);
-}
-
 function openReplyCacheStore(): IMessageReplyCacheStore {
   return getIMessageRuntime().state.openSyncKeyedStore<IMessageReplyCacheEntry>({
     namespace: IMESSAGE_REPLY_CACHE_NAMESPACE,
@@ -79,7 +76,7 @@ function openReplyCacheCounterStore(): PluginStateSyncKeyedStore<IMessageReplyCa
 }
 
 function remainingTtlMs(timestamp: number): number | undefined {
-  const remaining = REPLY_CACHE_TTL_MS - Math.max(0, Date.now() - timestamp);
+  const remaining = IMESSAGE_REPLY_CACHE_TTL_MS - Math.max(0, Date.now() - timestamp);
   return remaining > 0 ? remaining : undefined;
 }
 
@@ -89,7 +86,7 @@ function hydrateFromStoreOnce(): void {
     return;
   }
   hydrated = true;
-  const cutoff = Date.now() - REPLY_CACHE_TTL_MS;
+  const cutoff = Date.now() - IMESSAGE_REPLY_CACHE_TTL_MS;
   let entries: IMessageReplyCacheEntry[];
   try {
     const counter = openReplyCacheCounterStore().lookup(IMESSAGE_REPLY_CACHE_COUNTER_KEY);
@@ -198,7 +195,7 @@ export function rememberIMessageReplyCache(
   imessageReplyCacheByMessageId.delete(messageId);
   imessageReplyCacheByMessageId.set(messageId, fullEntry);
 
-  const cutoff = Date.now() - REPLY_CACHE_TTL_MS;
+  const cutoff = Date.now() - IMESSAGE_REPLY_CACHE_TTL_MS;
   let evicted = false;
   const deletedMessageIds: string[] = [];
   for (const [key, value] of imessageReplyCacheByMessageId) {
@@ -446,7 +443,7 @@ export function resolveIMessageCachedResourceBinding(
   if (!entry) {
     return "unknown";
   }
-  if (Date.now() - entry.timestamp > REPLY_CACHE_TTL_MS) {
+  if (Date.now() - entry.timestamp > IMESSAGE_REPLY_CACHE_TTL_MS) {
     return "unknown";
   }
   if (entry.accountId !== ctx.accountId) {

--- a/extensions/imessage/src/monitor/catchup-bridge.test-support.ts
+++ b/extensions/imessage/src/monitor/catchup-bridge.test-support.ts
@@ -1,15 +1,15 @@
 // Imessage test support covers catchup bridge plugin behavior.
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { getIMessageRuntime } from "../runtime.js";
-import { installIMessageStateRuntimeForTest } from "../test-support/runtime.js";
-import { runIMessageCatchup } from "./catchup-bridge.js";
 import {
   IMESSAGE_CATCHUP_CURSOR_MAX_ENTRIES,
   IMESSAGE_CATCHUP_CURSOR_NAMESPACE,
-  resolveCatchupConfig,
   resolveIMessageCatchupCursorKey,
   type IMessageCatchupCursor,
-} from "./catchup.js";
+} from "../state-contract.js";
+import { installIMessageStateRuntimeForTest } from "../test-support/runtime.js";
+import { runIMessageCatchup } from "./catchup-bridge.js";
+import { resolveCatchupConfig } from "./catchup.js";
 import type { IMessagePayload } from "./types.js";
 
 type RpcCall = {

--- a/extensions/imessage/src/monitor/catchup.test-support.ts
+++ b/extensions/imessage/src/monitor/catchup.test-support.ts
@@ -1,18 +1,20 @@
 // Imessage tests cover catchup plugin behavior.
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { getIMessageRuntime } from "../runtime.js";
-import { installIMessageStateRuntimeForTest } from "../test-support/runtime.js";
 import {
-  advanceIMessageCatchupCursor,
   capFailureRetriesMap,
   IMESSAGE_CATCHUP_CURSOR_MAX_ENTRIES,
   IMESSAGE_CATCHUP_CURSOR_NAMESPACE,
+  resolveIMessageCatchupCursorKey,
+  type IMessageCatchupCursor,
+} from "../state-contract.js";
+import { installIMessageStateRuntimeForTest } from "../test-support/runtime.js";
+import {
+  advanceIMessageCatchupCursor,
   performIMessageCatchup,
   resolveCatchupConfig,
-  resolveIMessageCatchupCursorKey,
   type CatchupDispatchFn,
   type CatchupFetchFn,
-  type IMessageCatchupCursor,
   type IMessageCatchupRow,
 } from "./catchup.js";
 

--- a/extensions/imessage/src/monitor/catchup.ts
+++ b/extensions/imessage/src/monitor/catchup.ts
@@ -1,9 +1,14 @@
-// Imessage plugin module implements catchup behavior.
-import { createHash } from "node:crypto";
 import { KeyedAsyncQueue } from "openclaw/plugin-sdk/keyed-async-queue";
 import { resolveIntegerOption } from "openclaw/plugin-sdk/number-runtime";
 import type { PluginStateSyncKeyedStore } from "openclaw/plugin-sdk/plugin-state-runtime";
 import { getIMessageRuntime } from "../runtime.js";
+import {
+  IMESSAGE_CATCHUP_CURSOR_NAMESPACE,
+  IMESSAGE_CATCHUP_CURSOR_MAX_ENTRIES,
+  resolveIMessageCatchupCursorKey,
+  capFailureRetriesMap,
+  type IMessageCatchupCursor,
+} from "../state-contract.js";
 
 // iMessage inbound catchup. When the gateway is offline (crash, restart, mac
 // sleep, machine off), `imsg watch` resumes from current state and ignores
@@ -24,13 +29,6 @@ const MAX_PER_RUN_LIMIT = 500;
 const DEFAULT_FIRST_RUN_LOOKBACK_MINUTES = 30;
 const DEFAULT_MAX_FAILURE_RETRIES = 10;
 const MAX_MAX_FAILURE_RETRIES = 1_000;
-// Defense-in-depth bound on the retry map. The cursor is one plugin-state
-// value, so keep the retry payload well below the 64KB store limit.
-const MAX_FAILURE_RETRY_MAP_SIZE = 512;
-const MAX_FAILURE_RETRY_MAP_JSON_BYTES = 48_000;
-const textEncoder = new TextEncoder();
-export const IMESSAGE_CATCHUP_CURSOR_NAMESPACE = "imessage.catchup-cursors";
-export const IMESSAGE_CATCHUP_CURSOR_MAX_ENTRIES = 256;
 const cursorWriteQueue = new KeyedAsyncQueue();
 
 type IMessageCatchupConfig = {
@@ -39,28 +37,6 @@ type IMessageCatchupConfig = {
   perRunLimit?: number;
   firstRunLookbackMinutes?: number;
   maxFailureRetries?: number;
-};
-
-export type IMessageCatchupCursor = {
-  /** Timestamp (ms since epoch) of the highest-watermark message we processed. */
-  lastSeenMs: number;
-  /** ROWID of the highest-watermark processed message. Monotonic in chat.db. */
-  lastSeenRowid: number;
-  /** UTC ms timestamp of the most recent cursor write. */
-  updatedAt: number;
-  /**
-   * Per-GUID failure counter, preserved across runs. Two states:
-   * - `1 <= count < maxFailureRetries`: the GUID is still retrying and
-   *   continues to hold the cursor back.
-   * - `count >= maxFailureRetries`: catchup has given up on the GUID. The
-   *   message is skipped on sight (no dispatch attempt) and the cursor no
-   *   longer waits on it. Entry stays in the map until the cursor naturally
-   *   advances past the message's timestamp.
-   *
-   * A successful dispatch removes the entry. Optional on the persisted shape
-   * so older cursor files without this field load cleanly.
-   */
-  failureRetries?: Record<string, number>;
 };
 
 export type IMessageCatchupRow = {
@@ -96,10 +72,6 @@ export type IMessageCatchupSummary = {
   windowStartMs: number;
   windowEndMs: number;
 };
-
-export function resolveIMessageCatchupCursorKey(accountId: string): string {
-  return createHash("sha256").update(accountId, "utf8").digest("hex").slice(0, 32);
-}
 
 function openCatchupCursorStore(): PluginStateSyncKeyedStore<IMessageCatchupCursor> {
   return getIMessageRuntime().state.openSyncKeyedStore<IMessageCatchupCursor>({
@@ -207,35 +179,6 @@ async function saveIMessageCatchupCursor(
     }
     return cursor;
   });
-}
-
-/**
- * Bound the retry map so a pathological storm of unique failing GUIDs
- * cannot grow the cursor file without limit. Keeps the `maxSize` entries
- * with the highest counts (closest to give-up) when over the bound.
- */
-export function capFailureRetriesMap(
-  map: Record<string, number>,
-  maxSize: number = MAX_FAILURE_RETRY_MAP_SIZE,
-  maxBytes: number = MAX_FAILURE_RETRY_MAP_JSON_BYTES,
-): Record<string, number> {
-  const entries = Object.entries(map);
-  if (entries.length <= maxSize && textEncoder.encode(JSON.stringify(map)).byteLength <= maxBytes) {
-    return map;
-  }
-  // Sort by count desc; stable tiebreak on guid string so the retained set
-  // is deterministic across runs (important for cursor-file diffing during
-  // debugging).
-  entries.sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]));
-  const capped: Record<string, number> = {};
-  for (const [guid, count] of entries.slice(0, maxSize)) {
-    capped[guid] = count;
-    if (textEncoder.encode(JSON.stringify(capped)).byteLength > maxBytes) {
-      delete capped[guid];
-      break;
-    }
-  }
-  return capped;
 }
 
 export type ResolvedCatchupConfig = {

--- a/extensions/imessage/src/monitor/echo-cache.ts
+++ b/extensions/imessage/src/monitor/echo-cache.ts
@@ -1,7 +1,8 @@
 import type { MediaPlaceholderTextFact } from "openclaw/plugin-sdk/channel-inbound";
+import { resolveIMessageEchoMediaKey } from "../state-contract.js";
 // Imessage plugin module implements echo cache behavior.
 import { stripLeadingEchoTextCorruptionMarkers } from "./echo-text-corruption.js";
-import { hasPersistedIMessageEcho, resolveIMessageEchoMediaKey } from "./persisted-echo-cache.js";
+import { hasPersistedIMessageEcho } from "./persisted-echo-cache.js";
 
 type SentMessageLookup = {
   text?: string;

--- a/extensions/imessage/src/monitor/monitor-provider.echo-cache.test-support.ts
+++ b/extensions/imessage/src/monitor/monitor-provider.echo-cache.test-support.ts
@@ -1,19 +1,18 @@
 // Imessage test support covers monitor provider.echo cache plugin behavior.
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  IMESSAGE_SENT_ECHOES_MAX_ENTRIES,
+  IMESSAGE_SENT_ECHOES_NAMESPACE,
+  IMESSAGE_SENT_ECHOES_TTL_MS,
+  resolveIMessageSentEchoEntryKey,
+} from "../state-contract.js";
+import {
   createIMessagePluginStateSyncStoreForTest,
   installIMessageFailingStateRuntimeForTest,
   installIMessageStateRuntimeForTest,
 } from "../test-support/runtime.js";
 import { createSentMessageCache } from "./echo-cache.js";
-import {
-  IMESSAGE_SENT_ECHOES_MAX_ENTRIES,
-  IMESSAGE_SENT_ECHOES_NAMESPACE,
-  IMESSAGE_SENT_ECHOES_TTL_MS,
-  hasPersistedIMessageEcho,
-  rememberPersistedIMessageEcho,
-  resolveIMessageSentEchoEntryKey,
-} from "./persisted-echo-cache.js";
+import { hasPersistedIMessageEcho, rememberPersistedIMessageEcho } from "./persisted-echo-cache.js";
 
 describe("iMessage sent-message echo cache", () => {
   beforeEach(() => {

--- a/extensions/imessage/src/monitor/persisted-echo-cache.ts
+++ b/extensions/imessage/src/monitor/persisted-echo-cache.ts
@@ -1,30 +1,16 @@
-// Imessage plugin module implements persisted echo cache behavior.
-import { createHash } from "node:crypto";
 import type { MediaPlaceholderTextFact } from "openclaw/plugin-sdk/channel-inbound";
 import type { PluginStateSyncKeyedStore } from "openclaw/plugin-sdk/plugin-state-runtime";
 import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
 import { getIMessageRuntime } from "../runtime.js";
+import {
+  IMESSAGE_SENT_ECHOES_TTL_MS,
+  IMESSAGE_SENT_ECHOES_NAMESPACE,
+  IMESSAGE_SENT_ECHOES_MAX_ENTRIES,
+  resolveIMessageSentEchoEntryKey,
+  resolveIMessageEchoMediaKey,
+  type PersistedEchoEntry,
+} from "../state-contract.js";
 import { stripLeadingEchoTextCorruptionMarkers } from "./echo-text-corruption.js";
-
-type PersistedEchoEntry = {
-  scope: string;
-  text?: string;
-  media?: MediaPlaceholderTextFact;
-  messageId?: string;
-  timestamp: number;
-  expiresAt?: number;
-  pending?: true;
-};
-
-// 12h comfortably outlives the inbound replay guard window
-// (IMESSAGE_INBOUND_DEDUPE_TTL_MS) so an own-outbound row that imsg re-emits
-// after a bridge reconnect is still recognized as the agent's own echo rather
-// than re-ingested as an external send. A shorter window would let own rows
-// fall out of the dedupe set before a reconnect burst replays the messages
-// around them.
-export const IMESSAGE_SENT_ECHOES_TTL_MS = 12 * 60 * 60 * 1000;
-export const IMESSAGE_SENT_ECHOES_NAMESPACE = "imessage.sent-echoes";
-export const IMESSAGE_SENT_ECHOES_MAX_ENTRIES = 256;
 
 type PersistedEchoStore = PluginStateSyncKeyedStore<PersistedEchoEntry>;
 
@@ -56,33 +42,6 @@ function reportFailure(scope: string, err: unknown): void {
   }
   persistenceFailureLogged = true;
   logVerbose(`imessage echo-cache: ${scope} disabled after first failure: ${String(err)}`);
-}
-
-export function resolveIMessageSentEchoEntryKey(entry: PersistedEchoEntry): string {
-  return createHash("sha256")
-    .update(
-      JSON.stringify([
-        entry.scope,
-        entry.text ?? "",
-        resolveIMessageEchoMediaKey(entry.media) ?? "",
-        entry.messageId ?? "",
-        entry.timestamp,
-      ]),
-    )
-    .digest("hex")
-    .slice(0, 32);
-}
-
-export function resolveIMessageEchoMediaKey(
-  media: MediaPlaceholderTextFact | null | undefined,
-): string | undefined {
-  const contentType = media?.contentType?.trim().toLowerCase() || undefined;
-  const kind = media?.kind && media.kind !== "unknown" ? media.kind : undefined;
-  if (kind) {
-    return `kind:${kind}`;
-  }
-  const normalizedContentType = contentType?.split(";", 1)[0]?.trim();
-  return normalizedContentType ? `mime:${normalizedContentType}` : undefined;
 }
 
 function normalizeMedia(

--- a/extensions/imessage/src/state-contract.ts
+++ b/extensions/imessage/src/state-contract.ts
@@ -1,0 +1,125 @@
+// Pure state contracts shared by doctor migrations and the live iMessage caches.
+// Keep runtime/store imports out: detecting legacy state must not initialize the channel.
+import { createHash } from "node:crypto";
+import type { MediaPlaceholderTextFact } from "openclaw/plugin-sdk/channel-inbound";
+
+export const IMESSAGE_REPLY_CACHE_NAMESPACE = "imessage.reply-cache";
+export const IMESSAGE_REPLY_CACHE_MAX_ENTRIES = 2000;
+export const IMESSAGE_REPLY_CACHE_COUNTER_NAMESPACE = "imessage.reply-cache-counter";
+export const IMESSAGE_REPLY_CACHE_COUNTER_MAX_ENTRIES = 1;
+export const IMESSAGE_REPLY_CACHE_COUNTER_KEY = "short-id-counter";
+export const IMESSAGE_REPLY_CACHE_TTL_MS = 6 * 60 * 60 * 1000;
+
+export function resolveIMessageReplyCacheEntryKey(messageId: string): string {
+  return createHash("sha256").update(messageId, "utf8").digest("hex").slice(0, 32);
+}
+
+// Defense-in-depth bound on the retry map. The cursor is one plugin-state
+// value, so keep the retry payload well below the 1 MiB facade limit.
+const MAX_FAILURE_RETRY_MAP_SIZE = 512;
+const MAX_FAILURE_RETRY_MAP_JSON_BYTES = 48_000;
+const textEncoder = new TextEncoder();
+export const IMESSAGE_CATCHUP_CURSOR_NAMESPACE = "imessage.catchup-cursors";
+export const IMESSAGE_CATCHUP_CURSOR_MAX_ENTRIES = 256;
+
+export type IMessageCatchupCursor = {
+  /** Timestamp (ms since epoch) of the highest-watermark message we processed. */
+  lastSeenMs: number;
+  /** ROWID of the highest-watermark processed message. Monotonic in chat.db. */
+  lastSeenRowid: number;
+  /** UTC ms timestamp of the most recent cursor write. */
+  updatedAt: number;
+  /**
+   * Per-GUID failure counter, preserved across runs. Two states:
+   * - `1 <= count < maxFailureRetries`: the GUID is still retrying and
+   *   continues to hold the cursor back.
+   * - `count >= maxFailureRetries`: catchup has given up on the GUID. The
+   *   message is skipped on sight (no dispatch attempt) and the cursor no
+   *   longer waits on it. Entry stays in the map until the cursor naturally
+   *   advances past the message's timestamp.
+   *
+   * A successful dispatch removes the entry. Optional on the persisted shape
+   * so older cursor values without this field load cleanly.
+   */
+  failureRetries?: Record<string, number>;
+};
+
+export function resolveIMessageCatchupCursorKey(accountId: string): string {
+  return createHash("sha256").update(accountId, "utf8").digest("hex").slice(0, 32);
+}
+
+/**
+ * Bound the retry map so a pathological storm of unique failing GUIDs
+ * cannot grow the cursor value without limit. Keeps the `maxSize` entries
+ * with the highest counts (closest to give-up) when over the bound.
+ */
+export function capFailureRetriesMap(
+  map: Record<string, number>,
+  maxSize: number = MAX_FAILURE_RETRY_MAP_SIZE,
+  maxBytes: number = MAX_FAILURE_RETRY_MAP_JSON_BYTES,
+): Record<string, number> {
+  const entries = Object.entries(map);
+  if (entries.length <= maxSize && textEncoder.encode(JSON.stringify(map)).byteLength <= maxBytes) {
+    return map;
+  }
+  // Sort by count desc; stable tiebreak on guid string so the retained set
+  // is deterministic across runs (important for cursor-value diffing during
+  // debugging).
+  entries.sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]));
+  const capped: Record<string, number> = {};
+  for (const [guid, count] of entries.slice(0, maxSize)) {
+    capped[guid] = count;
+    if (textEncoder.encode(JSON.stringify(capped)).byteLength > maxBytes) {
+      delete capped[guid];
+      break;
+    }
+  }
+  return capped;
+}
+
+export type PersistedEchoEntry = {
+  scope: string;
+  text?: string;
+  media?: MediaPlaceholderTextFact;
+  messageId?: string;
+  timestamp: number;
+  expiresAt?: number;
+  pending?: true;
+};
+
+// 12h comfortably outlives the inbound replay guard window
+// (IMESSAGE_INBOUND_DEDUPE_TTL_MS) so an own-outbound row that imsg re-emits
+// after a bridge reconnect is still recognized as the agent's own echo rather
+// than re-ingested as an external send. A shorter window would let own rows
+// fall out of the dedupe set before a reconnect burst replays the messages
+// around them.
+export const IMESSAGE_SENT_ECHOES_TTL_MS = 12 * 60 * 60 * 1000;
+export const IMESSAGE_SENT_ECHOES_NAMESPACE = "imessage.sent-echoes";
+export const IMESSAGE_SENT_ECHOES_MAX_ENTRIES = 256;
+
+export function resolveIMessageSentEchoEntryKey(entry: PersistedEchoEntry): string {
+  return createHash("sha256")
+    .update(
+      JSON.stringify([
+        entry.scope,
+        entry.text ?? "",
+        resolveIMessageEchoMediaKey(entry.media) ?? "",
+        entry.messageId ?? "",
+        entry.timestamp,
+      ]),
+    )
+    .digest("hex")
+    .slice(0, 32);
+}
+
+export function resolveIMessageEchoMediaKey(
+  media: MediaPlaceholderTextFact | null | undefined,
+): string | undefined {
+  const contentType = media?.contentType?.trim().toLowerCase() || undefined;
+  const kind = media?.kind && media.kind !== "unknown" ? media.kind : undefined;
+  if (kind) {
+    return `kind:${kind}`;
+  }
+  const normalizedContentType = contentType?.split(";", 1)[0]?.trim();
+  return normalizedContentType ? `mime:${normalizedContentType}` : undefined;
+}

--- a/extensions/imessage/src/state-migrations.test.ts
+++ b/extensions/imessage/src/state-migrations.test.ts
@@ -2,15 +2,20 @@
 import { createHash } from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
+import {
+  closeOpenClawStateDatabaseForTest,
+  createPluginStateKeyedStoreForTests,
+  resetPluginStateStoreForTests,
+} from "openclaw/plugin-sdk/plugin-state-test-runtime";
 import { buildLegacyMigrationPreview } from "openclaw/plugin-sdk/runtime-doctor-migrations";
 import {
   resolvePreferredOpenClawTmpDir,
   tempWorkspaceSync,
   type TempWorkspaceSync,
 } from "openclaw/plugin-sdk/temp-path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { stateMigrations } from "../doctor-contract-api.js";
-import { resolveIMessageCatchupCursorKey } from "./monitor/catchup.js";
+import { resolveIMessageCatchupCursorKey } from "./state-contract.js";
 import { detectIMessageLegacyStateMigrations } from "./state-migrations.js";
 
 describe("detectIMessageLegacyStateMigrations", () => {
@@ -24,8 +29,56 @@ describe("detectIMessageLegacyStateMigrations", () => {
   });
 
   afterEach(() => {
+    closeOpenClawStateDatabaseForTest();
+    resetPluginStateStoreForTests();
     stateWorkspace.cleanup();
+    vi.doUnmock("./runtime.js");
+    vi.doUnmock("openclaw/plugin-sdk/routing");
+    vi.resetModules();
   });
+
+  it.each(["runtime", "routing"])(
+    "detects absent and unconfigured legacy state without loading %s",
+    async (boundary) => {
+      vi.resetModules();
+      if (boundary === "runtime") {
+        vi.doMock("./runtime.js", () => {
+          throw new Error("doctor detection must not materialize channel runtime");
+        });
+      } else {
+        vi.doMock("openclaw/plugin-sdk/routing", () => {
+          throw new Error("account lookup must not materialize message routing");
+        });
+      }
+      const { detectIMessageLegacyStateMigrations: detect } = await import("./state-migrations.js");
+      const params = { cfg: {}, env: {}, stateDir: stateWorkspace.dir };
+      expect(await detect(params)).toEqual([]);
+      expect(fs.readdirSync(stateWorkspace.dir)).toEqual([]);
+      const imsgDir = path.join(stateWorkspace.dir, "imessage");
+      fs.mkdirSync(imsgDir);
+      fs.writeFileSync(
+        path.join(imsgDir, "reply-cache.jsonl"),
+        JSON.stringify({
+          accountId: "default",
+          messageId: "legacy",
+          shortId: "7",
+          timestamp: Date.now(),
+        }),
+      );
+      const plans = await detect(params);
+      expect(plans.map((plan) => plan.label)).toEqual([
+        "iMessage reply short-id counter",
+        "iMessage reply short-id cache",
+      ]);
+      const counter = plans[0];
+      if (counter?.kind !== "plugin-state-import") {
+        throw new Error("expected counter import");
+      }
+      expect(await counter.readEntries()).toEqual([
+        { key: "short-id-counter", value: { counter: 7 } },
+      ]);
+    },
+  );
 
   function legacyCatchupFilename(accountId: string): string {
     return `${accountId}__${createHash("sha256").update(accountId, "utf8").digest("hex").slice(0, 12)}.json`;
@@ -191,6 +244,46 @@ describe("detectIMessageLegacyStateMigrations", () => {
         incomingValue: { counter: 1 },
       }),
     ).toBe(false);
+
+    const migration = stateMigrations[0];
+    if (!migration) {
+      throw new Error("expected iMessage migration");
+    }
+    const env = { OPENCLAW_STATE_DIR: stateDir };
+    const input = {
+      config: {},
+      env,
+      stateDir,
+      oauthDir: path.join(stateDir, "credentials"),
+      context: {
+        openPluginStateKeyedStore: <T>(
+          options: Parameters<typeof createPluginStateKeyedStoreForTests>[1],
+        ) => createPluginStateKeyedStoreForTests<T>("imessage", { ...options, env }),
+      },
+    };
+    const migrated = await migration.migrateLegacyState(input);
+    expect(migrated.warnings).toEqual([]);
+    expect(migrated.changes.length).toBeGreaterThan(0);
+    for (const plan of plans) {
+      if (plan.kind !== "plugin-state-import") {
+        throw new Error("expected plugin-state import");
+      }
+      const entries = await createPluginStateKeyedStoreForTests("imessage", {
+        namespace: plan.namespace,
+        maxEntries: plan.maxEntries,
+        env,
+      }).entries();
+      expect(entries).toHaveLength(1);
+      if (plan.label === "iMessage reply short-id counter") {
+        expect(entries[0]?.value).toEqual({ counter: 1 });
+      }
+      if (plan.cleanupSource === "rename") {
+        expect(fs.existsSync(plan.sourcePath)).toBe(false);
+        expect(fs.existsSync(`${plan.sourcePath}.migrated`)).toBe(true);
+      }
+    }
+    expect(await migration.detectLegacyState(input)).toBeNull();
+    expect(await migration.migrateLegacyState(input)).toEqual({ changes: [], warnings: [] });
   });
 
   it("leaves unreadable reply-cache sidecars for a later migration attempt", async () => {

--- a/extensions/imessage/src/state-migrations.ts
+++ b/extensions/imessage/src/state-migrations.ts
@@ -14,25 +14,22 @@ import {
 } from "./accounts.js";
 import {
   IMESSAGE_REPLY_CACHE_MAX_ENTRIES,
+  IMESSAGE_REPLY_CACHE_TTL_MS,
   IMESSAGE_REPLY_CACHE_COUNTER_KEY,
   IMESSAGE_REPLY_CACHE_COUNTER_MAX_ENTRIES,
   IMESSAGE_REPLY_CACHE_COUNTER_NAMESPACE,
   IMESSAGE_REPLY_CACHE_NAMESPACE,
   resolveIMessageReplyCacheEntryKey,
-} from "./monitor-reply-cache.js";
-import {
   capFailureRetriesMap,
   IMESSAGE_CATCHUP_CURSOR_MAX_ENTRIES,
   IMESSAGE_CATCHUP_CURSOR_NAMESPACE,
   resolveIMessageCatchupCursorKey,
   type IMessageCatchupCursor,
-} from "./monitor/catchup.js";
-import {
   IMESSAGE_SENT_ECHOES_MAX_ENTRIES,
   IMESSAGE_SENT_ECHOES_NAMESPACE,
   IMESSAGE_SENT_ECHOES_TTL_MS,
   resolveIMessageSentEchoEntryKey,
-} from "./monitor/persisted-echo-cache.js";
+} from "./state-contract.js";
 
 type ReplyCacheEntry = {
   accountId: string;
@@ -51,8 +48,6 @@ type SentEchoEntry = {
   messageId?: string;
   timestamp: number;
 };
-
-const REPLY_CACHE_TTL_MS = 6 * 60 * 60 * 1000;
 
 function resolveMigrationStateDir(params: { env: NodeJS.ProcessEnv; stateDir?: string }): string {
   return params.stateDir ?? resolveStateDir(params.env);
@@ -169,7 +164,7 @@ function listReplyCacheEntries(sourcePath: string): Array<{
     if (!entry) {
       continue;
     }
-    const ttlMs = remainingTtlMs(entry.timestamp, REPLY_CACHE_TTL_MS);
+    const ttlMs = remainingTtlMs(entry.timestamp, IMESSAGE_REPLY_CACHE_TTL_MS);
     if (!ttlMs) {
       continue;
     }


### PR DESCRIPTION
Related: [the generic CLI startup preparation repair](https://github.com/openclaw/openclaw/pull/131503). This is the independent iMessage import-boundary follow-up; Browser CLI and native relay changes are not included.

## What Problem This Solves

Fixes unnecessary startup work for operators running configuration repair or Doctor with the iMessage plugin installed. Those control-plane checks could load the live channel and message-routing dependency graph even when no channel execution was requested.

## Why This Change Was Made

Keep the existing state definitions in one lightweight, plugin-owned module shared by migration planning and the live caches. Load the migration detector only when the existing Doctor adapter resolves plans, and use the existing narrow account-resolution SDK export instead of the message-routing barrel.

This removes the eager detector/runtime/routing edges and the duplicate reply-cache TTL without introducing another cache, SDK surface, compatibility wrapper, or migration path. The existing adapter still owns detection and migration execution. Storage namespaces, capacities, TTLs, hash keys, serialized values, retry ordering, replacement rules, source archival and idempotence are unchanged. There are no schema, configuration, dependency, permission or protocol changes.

The eager Doctor import is traceable to [the legacy-state migration unification](https://github.com/openclaw/openclaw/pull/120716), authored and merged by @steipete on August 9, 2026. This preserves that canonical adapter rather than reverting its ownership model. The narrow account-resolution export is already present in the host's 2026.8.1 beta SDK.

## User Impact

Configuration repair and state detection avoid unrelated channel initialization work. Existing iMessage reply mappings, catchup cursors and sent-message echo state keep the same behavior. This is an import-boundary repair, not a five-second startup guarantee or a change to sending, receiving, native permissions, or account selection.

## Evidence

AI-assisted; implementation and independent Codex review were inspected against the real owner and SDK contracts.

- Baseline: 386 owner tests passed. The three new import-denial cases then failed on the old eager detector, live runtime and routing edges, before production changes.
- After extraction: the same three cases passed; the complete owner selection passed 389 tests across six files. This includes the real migration adapter writing canonical keyed-store rows, archiving synthetic legacy files, and repeated detection/migration.
- Doctor registry/load-path and post-startup-repair persistence siblings: 45 tests passed across three files.
- The full changed-file gate passed extension and test types, lint, formatting, five Doctor declaration/import-closure cases, dead-export checks, dependency/SDK guards and import-cycle checks. No timeouts, assertions or gates were weakened.
- Fresh isolated pre-commit review: scoped-clean at P0, with no findings.
- Fresh full `pnpm build` passed on `19e77d0aca15ee9b6cfee3d7751ca0b9e071806a`: all 15 phases completed, with no ineffective dynamic imports.
- Canonical host packaging, normal lifecycle-enabled npm installation, external iMessage runtime build and local package, then real installed `plugins install npm-pack:... --force --accept-capabilities` and `plugins inspect imessage --json` all passed in isolated state. Installed bytes matched 10,073 host dist files and all 2,135 plugin files.
- Native Node execution of the actual installed built Doctor artifact passed 104 assertions: config normalization, non-creating absent-state checks, four canonical SQLite rows, remaining TTLs, counter sequence 42→42→73, cursor rowid sequence 42→42→99, eight byte-verified archives, and three repeated null-detection/empty-migration runs. The driver used the real installed host executor and read-only SQLite inspection, not workspace aliases or a mocked executor.
- [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/33238419076) passed on `19e77d0aca15ee9b6cfee3d7751ca0b9e071806a`: 41 successful jobs, 18 intentionally skipped, and the required `openclaw/ci-gate` successful. No CI rerun was needed.

Artifact identities: host tarball SHA-256 `0a89d644bb3f0de1e209521b1923c4e63910f320d3e51475051075283b840b2c`; iMessage tarball SHA-256 `8987c28522122c138f71efee473eddbb047b65a1d555e82341a2fcb22be1ce13`. Installed Doctor entry SHA-256 `1dfe5ad94caebf87e936b801202aebd3482c640f947a61ed919216df52dba477`. Build ID: `2026.8.1-19e77d0aca15-2026-08-29T06-10-11.492Z`.

All canonical build/package/install commands passed. A local proof-output filename collision overwrote the first detailed functional receipt, so the same successful proof was rerun once with distinct receipt names and entirely fresh synthetic state; the retained run passed all 104 assertions. No product changes, deadline extensions or skipped checks were used. The source tree and staged Git entries remained unchanged throughout artifact proof.

Owner tests:

```bash
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs extensions/imessage/doctor-contract-api.test.ts extensions/imessage/src/state-migrations.test.ts extensions/imessage/src/accounts.test.ts extensions/imessage/src/monitor-reply-cache.test.ts extensions/imessage/src/monitor.behavior.test.ts extensions/imessage/src/monitor/cache-lifecycle.test.ts
```

Sibling tests:

```bash
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/plugins/doctor-contract-registry.state-migrations.test.ts src/plugins/doctor-contract-registry.load-paths.test.ts src/commands/doctor-config-preflight.plugin-persistence.test.ts
```

Production LOC: **+169/-143 (net +26)**. Tests/support: **+132/-19 (net +113)**. Most of the 125-line state-contract module is relocated code. The remaining production growth is the shared imports/types and lazy detector handoff; the extraction already removes the old definitions and duplicate TTL. No unrelated deletion is included to manufacture a net-neutral count.

Proof boundaries: all state is synthetic. No operator Gateway, Messages, `imsg`, native registrations, credentials, or Chrome state is touched. iMessage has `bundledDist: false`, so the root/Browser artifact is not counted as external iMessage package proof. The existing unreadable-source test proves failed plan reading, not full failed-executor source retention.
