### PR TITLE
test: advance CI watcher polling without waiting

### DIFF
--- a/test/scripts/watch-pr-ci.test.ts
+++ b/test/scripts/watch-pr-ci.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { execFile } from "node:child_process";
 import { chmodSync, readFileSync, writeFileSync } from "node:fs";
 import { delimiter, join } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import { describe, expect, it } from "vitest";
 import {
   buildFindRunArgs,
@@ -24,6 +25,27 @@ function runWatcher(ghScript: string, headSha = sha, options: string[] = []) {
     const ghPath = join(binDir, "gh");
     writeFileSync(ghPath, ghScript);
     chmodSync(ghPath, 0o755);
+    const clockPath = join(binDir, "poll-clock.mjs");
+    // Advance only polling sleep; real elapsed time still bounds GitHub child reads.
+    // NODE_OPTIONS reaches the implementation through its unmodified CLI wrapper.
+    writeFileSync(
+      clockPath,
+      `import { syncBuiltinESMExports } from "node:module";
+import timers from "node:timers/promises";
+if (process.argv[1] === ${JSON.stringify(fileURLToPath(new URL("../../scripts/watch-pr-ci.mts", import.meta.url)))}) {
+  const realNow = Date.now;
+  const realSleep = timers.setTimeout;
+  let waitedMs = 0;
+  Date.now = () => realNow() + waitedMs;
+  timers.setTimeout = async (milliseconds, value, options) => {
+    const result = await realSleep(0, value, options);
+    waitedMs += milliseconds;
+    return result;
+  };
+  syncBuiltinESMExports();
+}
+`,
+    );
     return await new Promise<{ status: number; stdout: string; stderr: string }>(
       (resolve, reject) => {
         execFile(
@@ -42,7 +64,11 @@ function runWatcher(ghScript: string, headSha = sha, options: string[] = []) {
           ],
           {
             encoding: "utf8",
-            env: { ...process.env, PATH: `${binDir}${delimiter}${process.env.PATH ?? ""}` },
+            env: {
+              ...process.env,
+              NODE_OPTIONS: `${process.env.NODE_OPTIONS ?? ""} --import=${pathToFileURL(clockPath).href}`,
+              PATH: `${binDir}${delimiter}${process.env.PATH ?? ""}`,
+            },
           },
           (error, stdout, stderr) => {
             const exitCode = error ? error.code : 0;
@@ -108,7 +134,10 @@ else if (args[1]?.startsWith(runPath + "/attempts/3/jobs?per_page=100&page=")) {
 else if (args[1]?.startsWith("repos/openclaw/openclaw/actions/jobs/")) {
   const jobIds = ${JSON.stringify(fixture.directJobs.map((job) => job.id))};
   const jobId = Number(args[1].split("/").at(-1));
-  if (fixture.delayFirstAlias && jobId === jobIds[0]) Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 2_000);
+  if (fixture.delayFirstAlias && jobId === jobIds[0]) {
+    Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 2_000);
+    fs.appendFileSync(${JSON.stringify(calls)}, JSON.stringify(["slow-alias-completed"]) + "\\n");
+  }
   value = fixture.directJobs[jobIds.indexOf(jobId)];
   if (value === undefined) throw new Error("missing direct job response");
 }
@@ -336,6 +365,7 @@ esac
         .split("\n")
         .map((line) => JSON.parse(line));
       expect(calls.filter((call) => call[1]?.includes("/actions/jobs/"))).toHaveLength(1);
+      expect(result.calls).not.toContain('"slow-alias-completed"');
     });
 
     it.each([
@@ -505,7 +535,7 @@ esac
       expect(result.calls).toContain("/attempts/3/jobs?per_page=100&page=1");
     });
 
-    // Independent rejection fixtures can overlap their real deadline waits.
+    // Independent rejection fixtures keep their own CLI process and clock state.
     // Keep successful scans and short-deadline job scans serial.
     it.concurrent.each([
       ["assigned queued job", { runner_id: 123 }],


### PR DESCRIPTION
## What Problem This Solves

The CI watcher's subprocess fixtures spend most of their time waiting through one- or five-second polling budgets, even though GitHub responses are synthetic and immediately available.

## Why This Change Was Made

Give each watcher implementation subprocess a fixture clock that advances polling sleep while retaining real elapsed time. The exact implementation-path guard leaves the real CLI wrapper and fake GitHub subprocesses on their normal clocks. Synchronous subprocess read deadlines remain real.

Strengthen the existing slow-alias test with a completion marker after its two-second blocking read. This proves the read is actually interrupted by the remaining one-second deadline; eventual TIMEOUT alone cannot distinguish an interrupted read from an overlong completed one.

## User Impact

All 124 watcher tests fell from **117.09s to 52.76s** of local execution, repeating at approximately **53.15s**. Production +0/-0; tests +33/-3. Test cases, sharding, worker count, concurrency declarations, selection, and production deadlines are unchanged.

## Evidence

- Baseline and candidate: `node scripts/run-vitest.mjs test/scripts/watch-pr-ci.test.ts` (124 passed).
- Final sibling run adds `test/scripts/plain-gh.test.ts`: all 134 passed in 53.27s of execution.
- Temporarily removing the remaining-budget cap from the real GitHub-read timeout lets the slow alias finish. The strengthened original test fails because its completion marker appears. Production bytes were restored before final validation.
- Original assertions retain request ordering, pagination, exact run/head/attempt identity, stale-proof rejection, per-poll request limits, and deadline boundary behavior.
- Complete watcher, CLI wrapper, GitHub execution seam, fixture cleanup and relevant Node timeout implementation inspected. Independent review and Codex autoreview found no actionable findings; formatting and whitespace checks passed.
- Linux changed checks and exact-head CI must pass before landing. No live GitHub responses or production service behavior are claimed by these synthetic fixtures.

Final gates: [exact-head CI](https://github.com/openclaw/openclaw/actions/runs/33238503608) and actual Linux changed checks passed. The one-shot Testbox was stopped. Latest ClawSweeper has no findings or before-merge requests.
