### PR TITLE
test: avoid real CI dispatch indexing backoff

### DIFF
--- a/test/scripts/pr-ci-dispatch.test.ts
+++ b/test/scripts/pr-ci-dispatch.test.ts
@@ -30,6 +30,7 @@ function createFakeGh() {
   const realGh = join(tempDir, "real-gh");
   const calls = join(tempDir, "calls.log");
   const dispatched = join(tempDir, "dispatched");
+  const pollingPreload = join(tempDir, "immediate-poll.mjs");
   mkdirSync(binDir);
   const fakeGhScript = `#!/usr/bin/env bash
 set -euo pipefail
@@ -68,7 +69,14 @@ esac
   writeFileSync(realGh, fakeGhScript);
   chmodSync(pathGh, 0o755);
   chmodSync(realGh, 0o755);
-  return { binDir, calls, dispatched, realGh };
+  // The GitHub fixture is synchronous; keep poll scheduling without real backoff waits.
+  writeFileSync(
+    pollingPreload,
+    `const realSetTimeout = globalThis.setTimeout;
+globalThis.setTimeout = (callback, _delay, ...args) => realSetTimeout(callback, 0, ...args);
+`,
+  );
+  return { binDir, calls, dispatched, pollingPreload, realGh };
 }
 
 function runDispatch(
@@ -143,6 +151,8 @@ function runDispatch(
   return spawnSync(
     process.execPath,
     [
+      "--import",
+      fakeGh.pollingPreload,
       dispatchScript,
       "12345",
       "contributor/fix-hosted-gates",


### PR DESCRIPTION
## What Problem This Solves

Two PR-dispatch rejection cases each wait through nine real 1.5-second indexing delays even though their fake GitHub responses are immediately available.

## Why This Change Was Made

Preload an immediate but asynchronous timer only in the dispatch CLI subprocess. Every polling attempt, real CLI invocation, fake GitHub subprocess, authentication-forwarding check, remote-head check, and proof-identity assertion remains intact. The preload is passed directly with `--import`, so it is not inherited by child processes through `NODE_OPTIONS`.

## User Impact

The eight dispatch cases fell from **28.10s to 1.13s** of local test execution. Production +0/-0; tests +11/-1. No sharding, worker count, concurrency, test selection, or production retry-policy changes.

## Evidence

- Eight cases passed before and after: `node scripts/run-vitest.mjs test/scripts/pr-ci-dispatch.test.ts`.
- Final run with `test/scripts/plain-gh.test.ts`: all 18 passed in 1.16s.
- Loosening the real owner's exact run-title comparison to a generic prefix made both original title-rejection assertions fail. Production bytes were restored before final validation.
- Complete dispatch owner, GitHub execution seam, protected proof contract and relevant history inspected. Independent review and Codex autoreview through P3 found no actionable findings; formatting and whitespace checks passed.
- Linux changed checks and exact-head CI must pass before landing.

## Follow-up

The existing `scripts/pr` help still advertises caller-supplied proof-handle flags even though the dispatch parser intentionally rejects them. Correct that stale help separately; this fixture change does not modify the wrapper's public command surface.

Final gates: [exact-head CI](https://github.com/openclaw/openclaw/actions/runs/33238745548) and actual Linux changed checks passed; the one-shot Testbox was stopped. ClawSweeper identified no code defect. Its pending-CI request is satisfied, and comments were freshly re-read before landing.
