### PR TITLE
perf(agents): bound session discovery results

### DIFF
--- a/src/agents/tools/sessions-history-tool.ts
+++ b/src/agents/tools/sessions-history-tool.ts
@@ -86,7 +86,10 @@ const SessionsHistoryOutputSchema = Type.Union([
   ),
 ]);
 
-const SESSIONS_HISTORY_MAX_BYTES = 80 * 1024;
+// History reads remain loss-aware and pageable (`truncated`, `hasMore`,
+// `nextOffset`), so a caller can explicitly continue without one response
+// consuming most of the next model prompt.
+const SESSIONS_HISTORY_MAX_BYTES = 32 * 1024;
 const SESSIONS_HISTORY_TEXT_MAX_CHARS = 4000;
 type GatewayCaller = AgentToolGatewayRequestCaller;
 type ChatHistoryPaginationMetadata = {

--- a/src/agents/tools/sessions-search-tool.ts
+++ b/src/agents/tools/sessions-search-tool.ts
@@ -46,7 +46,9 @@ const SESSIONS_SEARCH_MAX_LIMIT = 25;
 const SESSIONS_SEARCH_MAX_SESSION_KEYS = 200;
 // Bounds FTS token expansion on the synchronous gateway path while leaving ample query context.
 const SESSIONS_SEARCH_MAX_QUERY_CHARS = 4096;
-const SESSIONS_SEARCH_MAX_BYTES = 32 * 1024;
+// Search is a discovery surface: return enough candidates to refine the query,
+// while using the explicit `truncated` flag instead of flooding the model history.
+const SESSIONS_SEARCH_MAX_BYTES = 12 * 1024;
 const SESSIONS_SEARCH_SNIPPET_MAX_CHARS = 300;
 const SESSIONS_SEARCH_INDEXING_WARNING =
   "Transcript indexing is in progress; results may be incomplete. Retry sessions_search shortly.";


### PR DESCRIPTION
## What Problem This Solves

Broad session search and history calls can add large result blobs to every later model turn even though both tools support explicit pagination and truncation signaling.

## Why This Change Was Made

The existing safe response bounds are tightened from 32 KiB to 12 KiB for search and from 80 KiB to 32 KiB for history. Existing continuation metadata, anchored-history behavior, and explicit truncation flags are preserved.

## User Impact

Tool-heavy sessions accumulate less prompt history while callers can still request exact subsequent pages.

## Evidence

- Repository-native `check:changed` gate passed.
- Full production build passed.
- Session search/history regression suites passed, including byte caps and pagination.
- Mandatory autoreview: clean, 0 actionable findings.
- Combined latest-main Gateway → Codex live E2E passed with `openai/gpt-5.6-sol`, `xhigh`.
