### PR TITLE
fix(codex): avoid duplicate workspace instructions

### DIFF
--- a/extensions/codex/src/app-server/attempt-context.ts
+++ b/extensions/codex/src/app-server/attempt-context.ts
@@ -26,7 +26,6 @@ import type {
 } from "openclaw/plugin-sdk/session-transcript-runtime";
 import { readNonBlankString as readNonEmptyString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import type { EmbeddedRunAttemptResult } from "./attempt-terminal.js";
-import { isMessageOnlyCodexSourceReply } from "./dynamic-tool-profile.js";
 import type { CodexDynamicToolFunctionSpec, CodexDynamicToolSpec, JsonValue } from "./protocol.js";
 import { flattenCodexDynamicToolFunctions, isJsonObject } from "./protocol.js";
 import type { CodexAppServerThreadBinding } from "./session-binding.js";
@@ -246,16 +245,9 @@ export async function buildCodexWorkspaceBootstrapContext(params: {
       memoryWorkspaceDir: params.effectiveWorkspace,
     });
     const injectOpenClawContext = shouldInjectCodexOpenClawPromptContext(params.params);
-    const restrictedProjectDocNeedsOpenClawCarrier =
-      params.params.pluginHarnessToolPolicyRestricted === true &&
-      !params.params.disableTools &&
-      !isMessageOnlyCodexSourceReply(params.params) &&
-      params.params.bootstrapContextMode !== "lightweight";
     const threadDeveloperInstructionFiles =
-      injectOpenClawContext &&
-      !params.ringZeroActive &&
-      (inheritsAgentWorkspace || restrictedProjectDocNeedsOpenClawCarrier)
-        ? selectCodexWorkspaceAgentProjectInstructionFiles(contextFiles, params.resolvedWorkspace)
+      injectOpenClawContext && !params.ringZeroActive
+        ? selectCodexWorkspaceAgentProjectInstructionFiles(contextFiles, promptWorkspace)
         : [];
     const turnScopedDeveloperInstructionFiles = injectOpenClawContext
       ? selectCodexWorkspaceTurnScopedDeveloperInstructionFiles(contextFiles)
@@ -716,7 +708,7 @@ function renderCodexWorkspaceBootstrapPromptContext(
     return undefined;
   }
   const lines = [
-    "OpenClaw loaded these user-editable workspace files for the current turn. Codex loads project-local AGENTS.md natively. When execution uses another folder, OpenClaw supplies the agent workspace AGENTS.md as thread-level developer instructions. SOUL.md, IDENTITY.md, and USER.md remain turn-scoped collaboration instructions. Those files are not repeated here.",
+    "OpenClaw loaded these user-editable workspace files for the current turn. OpenClaw supplies the agent workspace AGENTS.md once as thread-level developer instructions; when execution uses another folder, Codex may additionally load that distinct project's AGENTS.md natively. SOUL.md, IDENTITY.md, and USER.md remain turn-scoped collaboration instructions. Those files are not repeated here.",
     "",
     "# Project Context",
     "",

--- a/extensions/codex/src/app-server/attempt-startup.ts
+++ b/extensions/codex/src/app-server/attempt-startup.ts
@@ -163,6 +163,7 @@ export async function startCodexAttemptThread(params: {
   webSearchAllowed: boolean;
   developerInstructions: string | undefined;
   agentWorkspaceDeveloperInstructions?: string;
+  projectDocsHandledByOpenClaw?: boolean;
   finalConfigPatch?: Parameters<typeof startOrResumeThread>[0]["finalConfigPatch"];
   buildFinalConfigPatch?: Parameters<typeof startOrResumeThread>[0]["buildFinalConfigPatch"];
   nativeHookRelayGeneration?: string;
@@ -474,6 +475,7 @@ export async function startCodexAttemptThread(params: {
                 appServer: pluginAppServer,
                 developerInstructions: params.developerInstructions,
                 agentWorkspaceDeveloperInstructions: params.agentWorkspaceDeveloperInstructions,
+                projectDocsHandledByOpenClaw: params.projectDocsHandledByOpenClaw,
                 config: threadConfig,
                 shellEnvironment: params.shellEnvironment,
                 disableLoginShell: params.disableLoginShell,

--- a/extensions/codex/src/app-server/run-attempt-start.ts
+++ b/extensions/codex/src/app-server/run-attempt-start.ts
@@ -119,6 +119,9 @@ export async function startCodexAttemptRuntime(resources: CodexAttemptResources)
       webSearchAllowed: toolState.webSearchAllowed,
       developerInstructions,
       agentWorkspaceDeveloperInstructions: context.agentWorkspaceDeveloperInstructions,
+      projectDocsHandledByOpenClaw:
+        !context.workspaceBootstrapContext.inheritsAgentWorkspace &&
+        Boolean(context.agentWorkspaceDeveloperInstructions),
       buildFinalConfigPatch: buildNativeHookRelayFinalConfigPatch,
       nativeHookRelayRequired:
         connection.options.nativeHookRelay?.enabled !== false &&

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -432,7 +432,12 @@ async function buildCodexTurnContextForTest(
     memoryToolNames,
     ringZeroActive: false,
   });
-  const threadDeveloperInstructions = testing.buildDeveloperInstructions(params, { dynamicTools });
+  const threadDeveloperInstructions = [
+    testing.buildDeveloperInstructions(params, { dynamicTools }),
+    workspaceBootstrapContext.threadDeveloperInstructions,
+  ]
+    .filter((section): section is string => Boolean(section?.trim()))
+    .join("\n\n");
   const openClawPromptContext = buildCodexOpenClawPromptContext({
     params,
     workspacePromptContext: workspaceBootstrapContext.promptContext,
@@ -2606,7 +2611,7 @@ describe("runCodexAppServerAttempt", () => {
     );
 
     expect(startParams?.environments).toEqual([]);
-    expect(startParams?.config?.project_doc_max_bytes).toBe(131_072);
+    expect(startParams?.config?.project_doc_max_bytes).toBe(0);
     expect(startParams?.developerInstructions?.split(agentsGuidance)).toHaveLength(2);
     expect(startParams?.config?.["tools.update_plan.enabled"]).toBe(false);
     expect(dynamicToolNames.toSorted()).toEqual(["apply_patch", "progress_card", "read"]);
@@ -3947,7 +3952,7 @@ describe("runCodexAppServerAttempt", () => {
     expect(secondInputText).toContain("continue from there");
   });
 
-  it("routes AGENTS.md natively and MEMORY.md through tools", async () => {
+  it("routes AGENTS.md once through developer instructions and MEMORY.md through tools", async () => {
     const { sessionFile, workspaceDir } = createRunPaths();
     const agentsGuidance = "Follow AGENTS guidance.";
     const soulGuidance = "Soul voice goes here.";
@@ -3981,7 +3986,7 @@ describe("runCodexAppServerAttempt", () => {
     expect(threadDeveloperInstructions).not.toContain(userProfile);
     expect(threadDeveloperInstructions).not.toContain(memorySummary);
     expect(threadDeveloperInstructions).not.toContain("Codex loads AGENTS.md natively");
-    expect(threadDeveloperInstructions).not.toContain(agentsGuidance);
+    expect(threadDeveloperInstructions).toContain(agentsGuidance);
     expect(collaborationInstructions).toContain("# Collaboration Mode: Default");
     expect(collaborationInstructions).toContain("request_user_input availability");
     expect(collaborationInstructions).toContain("OpenClaw Agent Soul");
@@ -4047,9 +4052,8 @@ describe("runCodexAppServerAttempt", () => {
     });
     expect(fileStats.get("AGENTS.md")).toMatchObject({
       rawChars: agentsGuidance.length,
-      injectionStatus: "native_unverified",
-      injectedChars: null,
-      truncated: null,
+      injectedChars: agentsGuidance.length,
+      truncated: false,
     });
   });
   it("adds memory recall guidance when dated memory notes exist without root MEMORY.md", async () => {
@@ -4129,11 +4133,12 @@ describe("runCodexAppServerAttempt", () => {
     const result = await run;
     const threadStart = harness.requests.find((request) => request.method === "thread/start");
     const threadStartParams = threadStart?.params as {
-      config?: { instructions?: string };
+      config?: { instructions?: string; project_doc_max_bytes?: number };
       developerInstructions?: string;
     };
     expect(threadStartParams.config?.instructions).toBeUndefined();
-    expect(threadStartParams.developerInstructions).not.toContain(agentsGuidance);
+    expect(threadStartParams.developerInstructions?.split(agentsGuidance)).toHaveLength(2);
+    expect(threadStartParams.config?.project_doc_max_bytes).toBe(0);
     expect(threadStartParams.developerInstructions).not.toContain(soulGuidance);
     expect(threadStartParams.developerInstructions).not.toContain(identityGuidance);
     expect(threadStartParams.developerInstructions).not.toContain(userProfile);
@@ -4193,6 +4198,10 @@ describe("runCodexAppServerAttempt", () => {
     expect(threadInstructions).toContain(path.join(agentWorkspaceDir, "AGENTS.md"));
     expect(threadInstructions).toContain(agentsGuidance);
     expect(threadInstructions).not.toContain(soulGuidance);
+    expect(
+      (threadStart.params as { config?: { project_doc_max_bytes?: number } }).config
+        ?.project_doc_max_bytes,
+    ).toBe(131_072);
 
     const turnStart = harness.requests.find((request) => request.method === "turn/start");
     if (!turnStart) {

--- a/extensions/codex/src/app-server/thread-lifecycle-io.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle-io.ts
@@ -186,6 +186,7 @@ export async function resumeExistingCodexThread(
         restrictedToolSurfaceInheritedMcpServerNames,
         shellEnvironment: params.shellEnvironment,
         disableLoginShell: params.disableLoginShell,
+        projectDocsHandledByOpenClaw: params.projectDocsHandledByOpenClaw,
       }),
     );
     const requestModelProvider =
@@ -475,6 +476,7 @@ export async function startFreshCodexThread(
       restrictedToolSurfaceInheritedMcpServerNames,
       shellEnvironment: params.shellEnvironment,
       disableLoginShell: params.disableLoginShell,
+      projectDocsHandledByOpenClaw: params.projectDocsHandledByOpenClaw,
     }),
   );
   const requestModelProvider =

--- a/extensions/codex/src/app-server/thread-lifecycle-run.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle-run.ts
@@ -205,6 +205,7 @@ export async function startOrResumeThread(
         restrictedToolSurfaceInheritedMcpServerNames,
         shellEnvironment: params.shellEnvironment,
         disableLoginShell: params.disableLoginShell,
+        projectDocsHandledByOpenClaw: params.projectDocsHandledByOpenClaw,
         environmentSelection: params.environmentSelection,
         provisionalAppIds: pluginThreadConfig?.provisionalAppIds,
         signal: params.signal,

--- a/extensions/codex/src/app-server/thread-lifecycle-types.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle-types.ts
@@ -70,6 +70,8 @@ export type CodexStartOrResumeThreadParams = {
   appServer: CodexAppServerRuntimeOptions;
   developerInstructions?: string;
   agentWorkspaceDeveloperInstructions?: string;
+  /** OpenClaw already supplied the execution workspace AGENTS.md exactly once. */
+  projectDocsHandledByOpenClaw?: boolean;
   config?: JsonObject;
   shellEnvironment?: Readonly<Record<string, string>>;
   disableLoginShell?: boolean;

--- a/extensions/codex/src/app-server/thread-lifecycle.test.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.test.ts
@@ -457,6 +457,21 @@ describe("Codex ring-zero thread config", () => {
     });
     expect(disabled.config?.project_doc_max_bytes).toBe(0);
   });
+
+  it("disables native project documents when OpenClaw already supplied them", () => {
+    const params = createAttemptParams({ provider: "openai" });
+    const start = buildThreadStartParams(params, {
+      appServer: createAppServerOptions() as never,
+      cwd: "/repo",
+      dynamicTools: [],
+      hostSystemAgentActive: false,
+      nativeCodeModeEnabled: false,
+      projectDocsHandledByOpenClaw: true,
+      config: { project_doc_max_bytes: 64_000 },
+    });
+
+    expect(start.config?.project_doc_max_bytes).toBe(0);
+  });
 });
 
 describe("Codex delegation capability", () => {

--- a/extensions/codex/src/app-server/thread-requests.ts
+++ b/extensions/codex/src/app-server/thread-requests.ts
@@ -59,9 +59,7 @@ const CODEX_CODE_MODE_DISABLED_THREAD_CONFIG: JsonObject = {
   "features.code_mode_only": false,
 };
 
-const CODEX_NO_PROJECT_DOCS_CONFIG: JsonObject = {
-  project_doc_max_bytes: 0,
-};
+const CODEX_NO_PROJECT_DOCS_CONFIG: JsonObject = { project_doc_max_bytes: 0 };
 
 const CODEX_TOOL_SEARCH_UNSUPPORTED_THREAD_CONFIG: JsonObject = {
   "features.multi_agent": false,
@@ -171,6 +169,7 @@ export function buildThreadStartParams(
     restrictedToolSurfaceInheritedMcpServerNames?: readonly string[];
     shellEnvironment?: Readonly<Record<string, string>>;
     disableLoginShell?: boolean;
+    projectDocsHandledByOpenClaw?: boolean;
   },
 ): CodexThreadStartParams {
   const ringZeroActive =
@@ -219,6 +218,7 @@ export function buildThreadStartParams(
         options.restrictedToolSurfaceInheritedMcpServerNames,
       shellEnvironment: options.shellEnvironment,
       disableLoginShell: options.disableLoginShell,
+      projectDocsHandledByOpenClaw: options.projectDocsHandledByOpenClaw,
     }),
     ...resolveCodexThreadEnvironmentSelection(options),
     developerInstructions:
@@ -254,6 +254,7 @@ export function buildThreadResumeParams(
     restrictedToolSurfaceInheritedMcpServerNames?: readonly string[];
     shellEnvironment?: Readonly<Record<string, string>>;
     disableLoginShell?: boolean;
+    projectDocsHandledByOpenClaw?: boolean;
     preserveNativeModel?: boolean;
   },
 ): CodexThreadResumeParams {
@@ -314,6 +315,7 @@ export function buildThreadResumeParams(
         options.restrictedToolSurfaceInheritedMcpServerNames,
       shellEnvironment: options.shellEnvironment,
       disableLoginShell: options.disableLoginShell,
+      projectDocsHandledByOpenClaw: options.projectDocsHandledByOpenClaw,
     }),
     developerInstructions:
       options.developerInstructions ??
@@ -424,6 +426,7 @@ export function buildCodexRuntimeThreadConfigForRun(
     restrictedToolSurfaceInheritedMcpServerNames?: readonly string[];
     shellEnvironment?: Readonly<Record<string, string>>;
     disableLoginShell?: boolean;
+    projectDocsHandledByOpenClaw?: boolean;
   } = {},
 ): JsonObject {
   const ringZeroActive =
@@ -435,7 +438,8 @@ export function buildCodexRuntimeThreadConfigForRun(
   const restrictedTurnDisablesProjectDocs =
     ringZeroActive ||
     messageOnlySourceReply ||
-    (params.pluginHarnessToolPolicyRestricted && params.disableTools);
+    (params.pluginHarnessToolPolicyRestricted && params.disableTools) ||
+    options.projectDocsHandledByOpenClaw === true;
   const configMcpServers = config?.mcp_servers;
   if (restrictedToolSurface && configMcpServers !== undefined && !isJsonObject(configMcpServers)) {
     throw new Error("Codex restricted tool surface received invalid thread mcp_servers config");

--- a/extensions/codex/src/app-server/thread-supervision.ts
+++ b/extensions/codex/src/app-server/thread-supervision.ts
@@ -65,6 +65,7 @@ type PendingSupervisionMaterializationParams = {
   dynamicTools: CodexDynamicToolSpec[];
   appServer: CodexAppServerRuntimeOptions;
   developerInstructions?: string;
+  projectDocsHandledByOpenClaw?: boolean;
   config?: JsonObject;
   shellEnvironment?: Readonly<Record<string, string>>;
   disableLoginShell?: boolean;
@@ -231,6 +232,7 @@ export async function materializePendingSupervisionBranch(
         params.restrictedToolSurfaceInheritedMcpServerNames,
       shellEnvironment: params.shellEnvironment,
       disableLoginShell: params.disableLoginShell,
+      projectDocsHandledByOpenClaw: params.projectDocsHandledByOpenClaw,
     });
     assertExactSupervisionModelSelection(startParams, {
       model: nativeModel,


### PR DESCRIPTION
## What Problem This Solves

When OpenClaw supplies the authoritative workspace `AGENTS.md` to Codex, Codex can independently discover and inject the same project document again.

## Why This Change Was Made

The lifecycle now tracks when OpenClaw has supplied workspace instructions and sets Codex's `project_doc_max_bytes` to zero only for that same workspace. External execution directories retain native Codex project-document discovery.

## User Impact

Workspace instructions appear exactly once without weakening instruction handling for external repositories, restricted turns, or resumed threads.

## Evidence

- Repository-native `check:changed` gate passed.
- Full production build passed.
- Focused attempt-context, thread-lifecycle, and run-attempt regressions passed.
- Mandatory autoreview: clean, 0 actionable findings.
- Combined latest-main Gateway → Codex live E2E passed with `openai/gpt-5.6-sol`, `xhigh`.
