### PR TITLE
perf(codex): compact deferred dynamic tool discovery

### DIFF
--- a/extensions/codex/src/app-server/dynamic-tools.test.ts
+++ b/extensions/codex/src/app-server/dynamic-tools.test.ts
@@ -42,6 +42,7 @@ import {
   toCodexDynamicToolProtocolResponse,
 } from "./dynamic-tool-execution.js";
 import {
+  CODEX_TOOL_SCHEMA_LOOKUP_NAME,
   createCodexDynamicToolBridge,
   projectCodexExecutableDynamicTools,
 } from "./dynamic-tools.js";
@@ -743,7 +744,7 @@ describe("createCodexDynamicToolBridge", () => {
     });
 
     const specs = flattenSpecsWithNamespace(bridge.specs);
-    expect(bridge.specs).toHaveLength(2);
+    expect(bridge.specs).toHaveLength(3);
     expectDynamicSpec(
       specs.find((tool) => tool.name === "message"),
       { name: "message" },
@@ -757,6 +758,97 @@ describe("createCodexDynamicToolBridge", () => {
       },
     );
     expectNoNamespace(specs.find((tool) => tool.name === "message"));
+    expectNoNamespace(specs.find((tool) => tool.name === CODEX_TOOL_SCHEMA_LOOKUP_NAME));
+  });
+
+  it("publishes compact deferred discovery specs and returns exact schemas on demand", async () => {
+    const exactSchema = {
+      type: "object",
+      properties: { query: { type: "string" } },
+      required: ["query"],
+      additionalProperties: false,
+    } as const;
+    const fullDescription = `Search private records. ${"Detailed behavior. ".repeat(40)}`;
+    const bridge = createCodexDynamicToolBridge({
+      tools: [
+        createTool({
+          name: "records_search",
+          description: fullDescription,
+          displaySummary: "Search private records.",
+          parameters: exactSchema,
+        }),
+      ],
+      signal: new AbortController().signal,
+    });
+
+    const specs = flattenSpecsWithNamespace(bridge.specs);
+    const deferred = specs.find((tool) => tool.name === "records_search");
+    expect(deferred).toMatchObject({
+      description: "Search private records.",
+      deferLoading: true,
+      inputSchema: { type: "object", additionalProperties: true },
+    });
+    expect(JSON.stringify(bridge.specs)).not.toContain("Detailed behavior");
+
+    const lookup = await bridge.handleToolCall({
+      threadId: "thread-1",
+      turnId: "turn-1",
+      callId: "call-schema",
+      namespace: null,
+      tool: CODEX_TOOL_SCHEMA_LOOKUP_NAME,
+      arguments: { name: "records_search" },
+    });
+    expect(lookup.success).toBe(true);
+    const text = lookup.contentItems[0];
+    expect(text?.type).toBe("inputText");
+    expect(
+      text?.type === "inputText" && typeof text.text === "string"
+        ? JSON.parse(text.text)
+        : undefined,
+    ).toEqual({
+      name: "records_search",
+      description: fullDescription,
+      inputSchema: exactSchema,
+    });
+
+    const rejected = await bridge.handleToolCall({
+      threadId: "thread-1",
+      turnId: "turn-1",
+      callId: "call-invalid",
+      namespace: CODEX_OPENCLAW_DYNAMIC_TOOL_NAMESPACE,
+      tool: "records_search",
+      arguments: {},
+    });
+    expect(rejected.success).toBe(false);
+    expect(rejected.contentItems[0]).toMatchObject({
+      type: "inputText",
+      text: expect.stringContaining("must have required property 'query'"),
+    });
+  });
+
+  it("bounds a large deferred catalog independently of full tool schemas", () => {
+    const tools = Array.from({ length: 60 }, (_, index) =>
+      createTool({
+        name: `catalog_tool_${index}`,
+        description: `Catalog tool ${index}. ${"Verbose documentation. ".repeat(200)}`,
+        parameters: {
+          type: "object",
+          properties: Object.fromEntries(
+            Array.from({ length: 20 }, (__, propertyIndex) => [
+              `field_${propertyIndex}`,
+              { type: "string", description: "x".repeat(200) },
+            ]),
+          ),
+        },
+      }),
+    );
+    const bridge = createCodexDynamicToolBridge({
+      tools,
+      signal: new AbortController().signal,
+    });
+
+    expect(JSON.stringify(bridge.specs).length).toBeLessThan(30_000);
+    expect(specNames(bridge.specs)).toHaveLength(61);
   });
 
   it("keeps progress_card direct when searchable loading defers broad tools", () => {
@@ -830,6 +922,7 @@ describe("createCodexDynamicToolBridge", () => {
       "web_search",
       "browser",
       "computer",
+      CODEX_TOOL_SCHEMA_LOOKUP_NAME,
     ]);
     expect(forward.specs.filter((spec) => spec.type === "namespace")).toEqual([
       expect.objectContaining({
@@ -863,9 +956,13 @@ describe("createCodexDynamicToolBridge", () => {
       hookContext: { runId: "run-unavailable", onToolOutcome },
     });
 
-    expect(specNames(bridge.availableSpecs)).toEqual(["message"]);
+    expect(specNames(bridge.availableSpecs)).toEqual(["message", CODEX_TOOL_SCHEMA_LOOKUP_NAME]);
     expect(bridge.availableTools.map((tool) => tool.name)).toEqual(["message"]);
-    expect(specNames(bridge.specs)).toEqual([HEARTBEAT_RESPONSE_TOOL_NAME, "message"]);
+    expect(specNames(bridge.specs)).toEqual([
+      HEARTBEAT_RESPONSE_TOOL_NAME,
+      "message",
+      CODEX_TOOL_SCHEMA_LOOKUP_NAME,
+    ]);
 
     const result = await bridge.handleToolCall(
       {
@@ -1209,6 +1306,7 @@ describe("createCodexDynamicToolBridge", () => {
         }),
       ],
       signal: new AbortController().signal,
+      loading: "direct",
     });
 
     expect(flattenSpecsWithNamespace(bridge.availableSpecs)[0]?.inputSchema).toEqual({
@@ -1221,7 +1319,7 @@ describe("createCodexDynamicToolBridge", () => {
     });
   });
 
-  it("validates execution against the repaired schema published to Codex", async () => {
+  it("validates deferred execution against the exact repaired schema", async () => {
     const { bridge, execute, response } = await runSchemaToolCall({
       arguments: { action: "inspect" },
       callId: "call-repaired-schema",
@@ -1234,7 +1332,7 @@ describe("createCodexDynamicToolBridge", () => {
 
     expect(flattenSpecsWithNamespace(bridge.specs)[0]?.inputSchema).toEqual({
       type: "object",
-      properties: { action: { type: "string" } },
+      additionalProperties: true,
     });
     expect(bridge.telemetry.quarantinedTools).toEqual([]);
     expect(response).toEqual(expectInputText("done"));
@@ -1244,7 +1342,7 @@ describe("createCodexDynamicToolBridge", () => {
     });
   });
 
-  it("enforces the strict empty-object schema published to Codex", async () => {
+  it("enforces the strict exact schema behind a permissive deferred declaration", async () => {
     const { bridge, execute, response } = await runSchemaToolCall({
       arguments: { unexpected: true },
       callId: "call-strict-empty-schema",
@@ -1254,9 +1352,7 @@ describe("createCodexDynamicToolBridge", () => {
 
     expect(flattenSpecsWithNamespace(bridge.specs)[0]?.inputSchema).toEqual({
       type: "object",
-      properties: {},
-      required: [],
-      additionalProperties: false,
+      additionalProperties: true,
     });
     expectSchemaRejection(response, execute, 'must not have additional properties: "unexpected"');
   });
@@ -1292,8 +1388,8 @@ describe("createCodexDynamicToolBridge", () => {
       unsubscribeDiagnostics();
     }
 
-    expect(specNames(bridge.availableSpecs)).toEqual(["message"]);
-    expect(specNames(bridge.specs)).toEqual(["message"]);
+    expect(specNames(bridge.availableSpecs)).toEqual(["message", CODEX_TOOL_SCHEMA_LOOKUP_NAME]);
+    expect(specNames(bridge.specs)).toEqual(["message", CODEX_TOOL_SCHEMA_LOOKUP_NAME]);
     expect(bridge.telemetry.quarantinedTools).toEqual([
       {
         tool: "fuzzplugin_move_angles",
@@ -1436,8 +1532,12 @@ describe("createCodexDynamicToolBridge", () => {
     expect(codexDynamicToolsFingerprint(bridge.specs)).toBe(
       codexDynamicToolsFingerprint(healthyBridge.specs),
     );
-    expect(specNames(bridge.availableSpecs)).toEqual(["valid_sibling"]);
-    expect(specNames(bridge.specs).toSorted()).toEqual(["registered_sibling", "valid_sibling"]);
+    const searchableHelperNames =
+      testCase.placement === "searchable" ? [CODEX_TOOL_SCHEMA_LOOKUP_NAME] : [];
+    expect(specNames(bridge.availableSpecs)).toEqual(["valid_sibling", ...searchableHelperNames]);
+    expect(specNames(bridge.specs).toSorted()).toEqual(
+      ["registered_sibling", "valid_sibling", ...searchableHelperNames].toSorted(),
+    );
     const siblingSpec = flattenSpecsWithNamespace(bridge.availableSpecs)[0];
     if (testCase.placement === "searchable") {
       expect(siblingSpec).toMatchObject({
@@ -1585,8 +1685,8 @@ describe("createCodexDynamicToolBridge", () => {
       signal: new AbortController().signal,
     });
 
-    expect(specNames(bridge.availableSpecs)).toEqual(["message"]);
-    expect(specNames(bridge.specs)).toEqual(["message"]);
+    expect(specNames(bridge.availableSpecs)).toEqual(["message", CODEX_TOOL_SCHEMA_LOOKUP_NAME]);
+    expect(specNames(bridge.specs)).toEqual(["message", CODEX_TOOL_SCHEMA_LOOKUP_NAME]);
     expect(bridge.telemetry.quarantinedTools).toEqual([
       {
         tool: "tool[0]",
@@ -1644,8 +1744,11 @@ describe("createCodexDynamicToolBridge", () => {
       signal: new AbortController().signal,
     });
 
-    expect(specNames(registeredBridge.availableSpecs)).toEqual(["message"]);
-    expect(specNames(registeredBridge.specs)).toEqual(["message"]);
+    expect(specNames(registeredBridge.availableSpecs)).toEqual([
+      "message",
+      CODEX_TOOL_SCHEMA_LOOKUP_NAME,
+    ]);
+    expect(specNames(registeredBridge.specs)).toEqual(["message", CODEX_TOOL_SCHEMA_LOOKUP_NAME]);
   });
 
   it("can expose all dynamic tools directly for compatibility", () => {
@@ -1735,7 +1838,7 @@ describe("createCodexDynamicToolBridge", () => {
     { label: "negative", contextWindowTokens: -1, maxChars: 16_000 },
     { label: "non-finite", contextWindowTokens: Number.POSITIVE_INFINITY, maxChars: 16_000 },
     { label: "tiny", contextWindowTokens: 1, maxChars: 1 },
-    { label: "extra-large", contextWindowTokens: 200_000, maxChars: 64_000 },
+    { label: "extra-large", contextWindowTokens: 200_000, maxChars: 32_000 },
   ])(
     "preserves the canonical cap for $label contexts",
     async ({ contextWindowTokens, maxChars }) => {

--- a/extensions/codex/src/app-server/dynamic-tools.ts
+++ b/extensions/codex/src/app-server/dynamic-tools.ts
@@ -457,8 +457,17 @@ function normalizeAcceptedSessionSpawn(result: unknown): {
 
 /** Namespace attached to OpenClaw-owned dynamic tools exposed to Codex. */
 const CODEX_OPENCLAW_DYNAMIC_TOOL_NAMESPACE = "openclaw";
+export const CODEX_TOOL_SCHEMA_LOOKUP_NAME = "openclaw_tool_schema";
 const CODEX_DYNAMIC_TOOL_NAME_MAX_CHARS = 128;
 const CODEX_DYNAMIC_TOOL_NAME_PATTERN = /^[a-zA-Z0-9_-]+$/u;
+const CODEX_DEFERRED_TOOL_DESCRIPTION_MAX_CHARS = 240;
+// Keep one broad nested result from dominating the following Codex turns. The
+// converter appends an explicit rerun-with-narrower-args notice when this cap is hit.
+const CODEX_DYNAMIC_TOOL_RESULT_MAX_CHARS = 32_000;
+const CODEX_DEFERRED_TOOL_INPUT_SCHEMA = {
+  type: "object",
+  additionalProperties: true,
+} as const satisfies JsonSchemaObject & JsonValue;
 
 // Keep OpenClaw control-path tools directly callable even when Codex tool_search
 // is unavailable or resolves a connector-only universe. Developer instructions
@@ -468,6 +477,7 @@ const CODEX_DYNAMIC_TOOL_NAME_PATTERN = /^[a-zA-Z0-9_-]+$/u;
 // contract that control-path tools remain directly callable.
 const ALWAYS_DIRECT_DYNAMIC_TOOL_NAMES = new Set([
   "agents_list",
+  CODEX_TOOL_SCHEMA_LOOKUP_NAME,
   "sessions_spawn",
   "sessions_yield",
 ]);
@@ -525,7 +535,10 @@ export function createCodexDynamicToolBridge(params: {
     typeof contextWindowTokens === "number" &&
     Number.isFinite(contextWindowTokens) &&
     contextWindowTokens > 0
-      ? Math.max(1, resolveLiveToolResultMaxChars({ contextWindowTokens }))
+      ? Math.min(
+          CODEX_DYNAMIC_TOOL_RESULT_MAX_CHARS,
+          Math.max(1, resolveLiveToolResultMaxChars({ contextWindowTokens })),
+        )
       : DEFAULT_MAX_LIVE_TOOL_RESULT_CHARS;
   const availableProjection = projectCodexExecutableDynamicToolSurface(
     params.tools,
@@ -543,6 +556,9 @@ export function createCodexDynamicToolBridge(params: {
   ).filter((entry) => !quarantinedAvailableToolNames.has(entry.name));
   const toolMap = new Map(availableTools.map((entry) => [entry.name, entry]));
   const registeredToolNames = new Set(registeredSpecTools.map((entry) => entry.name));
+  const schemaLookupEnabled =
+    (params.loading ?? "searchable") === "searchable" &&
+    !registeredToolNames.has(CODEX_TOOL_SCHEMA_LOOKUP_NAME);
   const quarantinedTools = dedupeQuarantinedDynamicTools([
     ...availableProjection.quarantinedTools,
     ...registeredProjection.quarantinedTools,
@@ -599,11 +615,13 @@ export function createCodexDynamicToolBridge(params: {
       entries: availableTools,
       loading: params.loading ?? "searchable",
       directToolNames,
+      includeSchemaLookup: schemaLookupEnabled,
     }),
     specs: createCodexDynamicToolSpecs({
       entries: registeredSpecTools,
       loading: params.loading ?? "searchable",
       directToolNames,
+      includeSchemaLookup: schemaLookupEnabled,
     }),
     resultContentSourceForTool: (toolName) => toolMap.get(toolName)?.tool.resultContentSource,
     sideEffectOwnerKeyForTool: (toolName) => {
@@ -623,6 +641,51 @@ export function createCodexDynamicToolBridge(params: {
       return state?.snapshot;
     },
     handleToolCall: async (call, options) => {
+      if (schemaLookupEnabled && call.tool === CODEX_TOOL_SCHEMA_LOOKUP_NAME) {
+        const args = asNonArrayRecord(call.arguments);
+        const requestedName = normalizeOptionalString(args.name);
+        const requestedEntry = requestedName ? toolMap.get(requestedName) : undefined;
+        if (!requestedEntry) {
+          const message = requestedName
+            ? `OpenClaw tool is not available for this turn: ${requestedName}`
+            : `Invalid arguments for tool "${CODEX_TOOL_SCHEMA_LOOKUP_NAME}": name is required.`;
+          return withDynamicToolExecutionState(
+            {
+              contentItems: [{ type: "inputText", text: message }],
+              success: false,
+            },
+            {
+              executedArguments: args,
+              executionStarted: false,
+              sideEffectEvidence: false,
+            },
+          );
+        }
+        return withDynamicToolExecutionState(
+          {
+            contentItems: [
+              {
+                type: "inputText",
+                text: JSON.stringify(
+                  {
+                    name: requestedEntry.name,
+                    description: requestedEntry.description,
+                    inputSchema: requestedEntry.inputSchema,
+                  },
+                  null,
+                  2,
+                ),
+              },
+            ],
+            success: true,
+          },
+          {
+            executedArguments: args,
+            executionStarted: true,
+            sideEffectEvidence: false,
+          },
+        );
+      }
       const toolEntry = toolMap.get(call.tool);
       if (!toolEntry) {
         const executedArguments = asNonArrayRecord(call.arguments);
@@ -1097,6 +1160,7 @@ function createCodexDynamicToolSpecs(params: {
   entries: readonly ProjectedCodexDynamicTool[];
   loading: CodexDynamicToolsLoading;
   directToolNames: ReadonlySet<string>;
+  includeSchemaLookup: boolean;
 }): CodexDynamicToolSpec[] {
   const specs: CodexDynamicToolSpec[] = [];
   const namespaceTools: CodexDynamicToolFunctionSpec[] = [];
@@ -1123,13 +1187,19 @@ function createCodexDynamicToolSpecs(params: {
       specs.push(functionSpec);
       continue;
     }
-    namespaceTools.push({ ...functionSpec, deferLoading: true });
+    namespaceTools.push({
+      ...functionSpec,
+      description: compactDeferredToolDescription(entry),
+      inputSchema: CODEX_DEFERRED_TOOL_INPUT_SCHEMA,
+      deferLoading: true,
+    });
   }
   if (namespaceTools.length > 0) {
     specs.push({
       type: "namespace",
       name: CODEX_OPENCLAW_DYNAMIC_TOOL_NAMESPACE,
-      description: "",
+      description:
+        "Deferred OpenClaw tool discovery summaries. Fetch an exact contract with openclaw_tool_schema before calling when needed.",
       tools: namespaceTools,
     });
   }
@@ -1141,7 +1211,42 @@ function createCodexDynamicToolSpecs(params: {
       tools: directOnlyNamespaceTools,
     });
   }
+  if (params.includeSchemaLookup && namespaceTools.length > 0) {
+    specs.push({
+      type: "function",
+      name: CODEX_TOOL_SCHEMA_LOOKUP_NAME,
+      description:
+        "Return the complete description and exact input schema for one available deferred OpenClaw tool. Use after tool_search or ALL_TOOLS discovery before calling a tool whose arguments are unclear.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          name: {
+            type: "string",
+            description: "Exact deferred OpenClaw tool name.",
+          },
+        },
+        required: ["name"],
+        additionalProperties: false,
+      },
+    });
+  }
   return specs;
+}
+
+function compactDeferredToolDescription(entry: ProjectedCodexDynamicTool): string {
+  let summary: unknown;
+  try {
+    summary = entry.tool.displaySummary;
+  } catch {
+    summary = undefined;
+  }
+  const normalized = (typeof summary === "string" && summary.trim() ? summary : entry.description)
+    .replace(/\s+/gu, " ")
+    .trim();
+  if (normalized.length <= CODEX_DEFERRED_TOOL_DESCRIPTION_MAX_CHARS) {
+    return normalized;
+  }
+  return `${normalized.slice(0, CODEX_DEFERRED_TOOL_DESCRIPTION_MAX_CHARS - 1).trimEnd()}…`;
 }
 
 function createCodexDynamicToolFunctionSpec(params: {

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -2314,10 +2314,10 @@ describe("runCodexAppServerAttempt", () => {
     expect(registeredToolNames).toContain("message");
     expect(registeredToolNames).toContain("heartbeat_respond");
     expect(normalInstructions).not.toContain(
-      "Deferred searchable OpenClaw dynamic tools available: heartbeat_respond",
+      "1 deferred searchable OpenClaw dynamic tool is available through discovery.",
     );
     expect(heartbeatInstructions).toContain(
-      "Deferred searchable OpenClaw dynamic tools available: heartbeat_respond.",
+      "1 deferred searchable OpenClaw dynamic tool is available through discovery.",
     );
     for (const bridge of [normalBridge, heartbeatBridge, nextNormalBridge]) {
       const heartbeat = flattenSpecsWithNamespace(bridge.specs).find(
@@ -2457,7 +2457,10 @@ describe("runCodexAppServerAttempt", () => {
       registeredTools,
       registeredTools,
     );
-    expect(specNames(heartbeatBridge.availableSpecs)).toEqual(["heartbeat_respond"]);
+    expect(specNames(heartbeatBridge.availableSpecs)).toEqual([
+      "heartbeat_respond",
+      "openclaw_tool_schema",
+    ]);
     expect(specNames(heartbeatBridge.specs)).toEqual(specNames(normalBridge.specs));
     expect(specNames(nextNormalBridge.specs)).toEqual(specNames(normalBridge.specs));
   });
@@ -2609,7 +2612,12 @@ describe("runCodexAppServerAttempt", () => {
     expect(startParams?.config?.project_doc_max_bytes).toBe(131_072);
     expect(startParams?.developerInstructions?.split(agentsGuidance)).toHaveLength(2);
     expect(startParams?.config?.["tools.update_plan.enabled"]).toBe(false);
-    expect(dynamicToolNames.toSorted()).toEqual(["apply_patch", "progress_card", "read"]);
+    expect(dynamicToolNames.toSorted()).toEqual([
+      "apply_patch",
+      "openclaw_tool_schema",
+      "progress_card",
+      "read",
+    ]);
     const progressCardSpec = flattenSpecsWithNamespace(startParams?.dynamicTools ?? []).find(
       (tool) => tool.name === "progress_card",
     );

--- a/extensions/codex/src/app-server/thread-lifecycle.test.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.test.ts
@@ -1109,7 +1109,7 @@ describe("Codex app-server native code mode config", () => {
     // always-direct sessions_spawn.
     expect(instructions).toContain("Use `tool_search` when directly callable");
     expect(instructions).toContain(
-      "On code-mode-only models, use `exec` instead: filter `ALL_TOOLS` by name and description",
+      "On code-mode-only models, use `exec` instead: filter `ALL_TOOLS` by name and summary",
     );
     expect(instructions).toContain("call the matching entry through `tools`");
     expect(instructions).toContain(
@@ -1271,11 +1271,11 @@ describe("Codex app-server native code mode config", () => {
     });
 
     expect(instructions).toContain(
-      "Deferred searchable OpenClaw dynamic tools available: image_generate, music_generate.",
+      "2 deferred searchable OpenClaw dynamic tools are available through discovery.",
     );
     expect(instructions).toContain("Use `tool_search` when directly callable");
     expect(instructions).toContain(
-      "On code-mode-only models, use `exec` instead: filter `ALL_TOOLS` by name and description",
+      "On code-mode-only models, use `exec` instead: filter `ALL_TOOLS` by name and summary",
     );
     expect(instructions).toContain("call the matching entry through `tools`");
     expect(instructions).not.toContain("message,");
@@ -1331,7 +1331,7 @@ describe("Codex app-server native code mode config", () => {
 
     expect(namespaceReads).toBe(1);
     expect(instructions).toContain(
-      "Deferred searchable OpenClaw dynamic tools available: alpha_tool, skill_workshop, zeta_tool.",
+      "3 deferred searchable OpenClaw dynamic tools are available through discovery.",
     );
     expect(instructions).toContain("## Skill Workshop");
     expect(instructions).toContain("Visible source replies are not automatically delivered");

--- a/extensions/codex/src/app-server/thread-prompt.ts
+++ b/extensions/codex/src/app-server/thread-prompt.ts
@@ -13,6 +13,7 @@ import {
   isSystemAgentOnlyCodexDynamicToolAllowlist,
   shouldDisableCodexToolSearchForModel,
 } from "./dynamic-tool-profile.js";
+import { CODEX_TOOL_SCHEMA_LOOKUP_NAME } from "./dynamic-tools.js";
 import {
   CODEX_OPENCLAW_DIRECT_DYNAMIC_TOOL_NAMESPACE,
   type CodexDynamicToolSpec,
@@ -65,14 +66,12 @@ export function buildDeveloperInstructions(
     !shouldDisableCodexToolSearchForModel(params.modelId);
   const deferredToolDiscoveryGuidance =
     deferredToolNames.size > 0 || nativeDelegationAvailable
-      ? "Deferred tools may be absent from the direct tool list. Use `tool_search` when directly callable. On code-mode-only models, use `exec` instead: filter `ALL_TOOLS` by name and description, then call the matching entry through `tools`."
+      ? `Deferred tools may be absent from the direct tool list. Use \`tool_search\` when directly callable. On code-mode-only models, use \`exec\` instead: filter \`ALL_TOOLS\` by name and summary, fetch the exact contract with \`${CODEX_TOOL_SCHEMA_LOOKUP_NAME}\` when its arguments are unclear, then call the matching entry through \`tools\`.`
       : undefined;
   const sections = [
     "You are a personal agent running inside OpenClaw. OpenClaw has dynamic tools for OpenClaw-owned messaging, cron, sessions, media, gateway, and nodes.",
     deferredToolNames.size > 0
-      ? `Deferred searchable OpenClaw dynamic tools available: ${[...deferredToolNames]
-          .toSorted((left, right) => left.localeCompare(right))
-          .join(", ")}.`
+      ? `${deferredToolNames.size} deferred searchable OpenClaw dynamic ${deferredToolNames.size === 1 ? "tool is" : "tools are"} available through discovery.`
       : undefined,
     deferredToolDiscoveryGuidance,
     hasSkillWorkshop ? buildSkillWorkshopPromptSection().join("\n") : undefined,


### PR DESCRIPTION
## What Problem This Solves

Codex startup currently serializes every deferred OpenClaw dynamic tool's full description and JSON schema. A representative 63-tool session spent about 84 kB on nested OpenClaw schemas before the first user turn.

## Why This Change Was Made

Deferred tools now expose bounded discovery summaries and permissive placeholder schemas. A directly callable `openclaw_tool_schema` helper returns the exact description and schema only when needed. Direct-mode tools and runtime argument validation remain exact, and dynamic tool results are capped with explicit truncation metadata.

## User Impact

Codex sessions start with materially smaller prompts while preserving `tool_search`, `exec`/`ALL_TOOLS` discovery, exact on-demand contracts, and direct callable tools.

## Evidence

- Repository-native `check:changed` gate passed.
- Full production build passed.
- Focused Codex dynamic-tool and lifecycle regressions passed.
- Mandatory autoreview: clean, 0 actionable findings.
- Combined latest-main Gateway → Codex live E2E passed with `openai/gpt-5.6-sol`, `xhigh`.
- Representative serialized dynamic-tool payload fell from about 95,752 to 27,559 characters.
