### PR TITLE
perf(codex): compact skill discovery catalog

### DIFF
--- a/extensions/codex/src/app-server/attempt-context.test.ts
+++ b/extensions/codex/src/app-server/attempt-context.test.ts
@@ -16,6 +16,7 @@ import {
   buildCodexWatchedSessionsContext,
   buildCodexWorkspaceBootstrapContext,
   buildCodexSystemPromptReport,
+  compactCodexSkillsPrompt,
   readContextEngineThreadBootstrapProjection,
   readMirroredSessionHistoryMessages,
   resolveContextEngineBootstrapProjectionDecision,
@@ -29,6 +30,33 @@ afterEach(() => {
 });
 
 describe("Codex app-server attempt context", () => {
+  it("compacts skill discovery metadata while preserving every exact skill name", () => {
+    const prompt = [
+      "The following skills are available.",
+      "<available_skills>",
+      "  <skill>",
+      "    <name>weather</name>",
+      `    <description>${"Forecast weather & travel conditions. ".repeat(10)}</description>`,
+      "    <location>/very/long/private/workspace/skills/weather/SKILL.md</location>",
+      "  </skill>",
+      "  <skill>",
+      "    <name>github</name>",
+      "    <description>Inspect &quot;GitHub&quot; repositories.</description>",
+      "    <location>/very/long/private/workspace/skills/github/SKILL.md</location>",
+      "  </skill>",
+      "</available_skills>",
+    ].join("\n");
+
+    const compact = compactCodexSkillsPrompt(prompt);
+    expect(compact.length).toBeLessThan(prompt.length);
+    expect(compact).toContain("<name>weather</name>");
+    expect(compact).toContain("<name>github</name>");
+    expect(compact).toContain("skills.read");
+    expect(compact).toContain("&quot;GitHub&quot;");
+    expect(compact).not.toContain("<location>");
+    expect(compact).not.toContain("/very/long/private/workspace");
+  });
+
   it("treats missing mirrored session history as empty without hook warning", async () => {
     const warn = vi.spyOn(embeddedAgentLog, "warn").mockImplementation(() => undefined);
     const dir = await fs.mkdtemp(path.join(os.tmpdir(), "codex-attempt-context-history-"));

--- a/extensions/codex/src/app-server/attempt-context.ts
+++ b/extensions/codex/src/app-server/attempt-context.ts
@@ -49,6 +49,7 @@ const CODEX_WORKSPACE_DEVELOPER_CONTEXT_BASENAMES = new Set(
 );
 const CODEX_MEMORY_CONTEXT_BASENAME = "memory.md";
 const CODEX_MEMORY_TOOL_NAMES = new Set(["memory_search", "memory_get"]);
+const CODEX_SKILL_DISCOVERY_DESCRIPTION_MAX_CHARS = 120;
 const CODEX_BOOTSTRAP_CONTEXT_ORDER = new Map<string, number>([
   ["soul.md", 10],
   ["identity.md", 20],
@@ -612,9 +613,86 @@ export function renderCodexSkillsCollaborationInstructions(params: {
   if (!shouldInjectCodexOpenClawPromptContext(params.attempt)) {
     return undefined;
   }
-  return params.skillsPrompt?.trim()
-    ? ["## OpenClaw Skills", "", params.skillsPrompt.trim()].join("\n")
-    : undefined;
+  const catalog = compactCodexSkillsPrompt(params.skillsPrompt);
+  return catalog ? ["## OpenClaw Skills", "", catalog].join("\n") : undefined;
+}
+
+/**
+ * Codex Code Mode receives the exact skill sources separately, so the model
+ * prompt only needs bounded discovery metadata. Explicit `skills.read(name)`
+ * calls still return the complete selected SKILL.md.
+ */
+export function compactCodexSkillsPrompt(skillsPrompt: string | undefined): string {
+  const prompt = skillsPrompt?.trim();
+  if (!prompt) {
+    return "";
+  }
+  const catalogMatch = /<available_skills>([\s\S]*?)<\/available_skills>/iu.exec(prompt);
+  if (!catalogMatch) {
+    return prompt;
+  }
+  const blocks = Array.from(catalogMatch[1]?.matchAll(/<skill>([\s\S]*?)<\/skill>/giu) ?? []);
+  if (blocks.length === 0) {
+    return prompt;
+  }
+  const entries: Array<{ name: string; description?: string }> = [];
+  for (const blockMatch of blocks) {
+    const block = blockMatch[1] ?? "";
+    const name = /<name>([\s\S]*?)<\/name>/iu.exec(block)?.[1]?.trim();
+    if (!name) {
+      return prompt;
+    }
+    const rawDescription = /<description>([\s\S]*?)<\/description>/iu.exec(block)?.[1];
+    const description = rawDescription
+      ? truncateCodexSkillDescription(decodeCodexSkillXml(rawDescription))
+      : undefined;
+    entries.push({ name, ...(description ? { description } : {}) });
+  }
+  const lines = [
+    "Compact skill discovery catalog. Match by name and summary.",
+    'On a clear match, use `skills.read("<name>")` inside `exec` to load the complete skill before acting. Several matches: read the most specific. No match: read none.',
+    "",
+    "<available_skills>",
+  ];
+  for (const entry of entries) {
+    lines.push("  <skill>", `    <name>${entry.name}</name>`);
+    if (entry.description) {
+      lines.push(`    <description>${encodeCodexSkillXml(entry.description)}</description>`);
+    }
+    lines.push("  </skill>");
+  }
+  lines.push("</available_skills>");
+  return lines.join("\n");
+}
+
+function truncateCodexSkillDescription(description: string): string {
+  const normalized = description.replace(/\s+/gu, " ").trim();
+  const characters = Array.from(normalized);
+  if (characters.length <= CODEX_SKILL_DISCOVERY_DESCRIPTION_MAX_CHARS) {
+    return normalized;
+  }
+  return `${characters
+    .slice(0, CODEX_SKILL_DISCOVERY_DESCRIPTION_MAX_CHARS - 1)
+    .join("")
+    .trimEnd()}…`;
+}
+
+function decodeCodexSkillXml(value: string): string {
+  return value
+    .replace(/&lt;/gu, "<")
+    .replace(/&gt;/gu, ">")
+    .replace(/&quot;/gu, '"')
+    .replace(/&apos;/gu, "'")
+    .replace(/&amp;/gu, "&");
+}
+
+function encodeCodexSkillXml(value: string): string {
+  return value
+    .replace(/&/gu, "&amp;")
+    .replace(/</gu, "&lt;")
+    .replace(/>/gu, "&gt;")
+    .replace(/"/gu, "&quot;")
+    .replace(/'/gu, "&apos;");
 }
 
 /**

--- a/extensions/codex/src/app-server/run-attempt-prompt.ts
+++ b/extensions/codex/src/app-server/run-attempt-prompt.ts
@@ -7,6 +7,7 @@ import {
 } from "openclaw/plugin-sdk/agent-harness-runtime";
 import {
   buildCodexSystemPromptReport,
+  compactCodexSkillsPrompt,
   prependCodexOpenClawPromptContext,
   readContextEngineThreadBootstrapProjection,
   resolveCodexDeliveryHintPreservedInputRange,
@@ -492,7 +493,9 @@ export async function prepareCodexAttemptPrompt(context: CodexAttemptContext) {
     workspaceDir: effectiveWorkspace,
     developerInstructions: buildRenderedCodexDeveloperInstructions(),
     workspaceBootstrapContext,
-    skillsPrompt: skillsCollaborationInstructions ? (params.skillsSnapshot?.prompt ?? "") : "",
+    skillsPrompt: skillsCollaborationInstructions
+      ? compactCodexSkillsPrompt(params.skillsSnapshot?.prompt)
+      : "",
     tools: toolBridge.availableSpecs,
   });
   return {

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -1746,9 +1746,11 @@ describe("runCodexAppServerAttempt", () => {
     expect(trajectoryEvents.find((event) => event.type === "prompt.submitted")?.data?.prompt).toBe(
       inputText,
     );
-    expect(result.systemPromptReport?.skills.promptChars).toBe(params.skillsSnapshot.prompt.length);
+    expect(result.systemPromptReport?.skills.promptChars).toBeLessThan(
+      params.skillsSnapshot.prompt.length + 300,
+    );
     expect(result.systemPromptReport?.skills.entries).toEqual([
-      { name: "demo", blockChars: "<skill><name>demo</name></skill>".length },
+      expect.objectContaining({ name: "demo" }),
     ]);
   });
 


### PR DESCRIPTION
## What Problem This Solves

Codex receives every available skill's full location and unbounded discovery description at startup, even though the exact skill is read only after selection.

## Why This Change Was Made

The startup catalog preserves every exact skill name, bounds summaries to 120 characters, omits locations, and explicitly requires `skills.read("<name>")` before acting. Malformed catalogs fall back unchanged.

## User Impact

Users with many skills get smaller startup prompts without losing discoverability or exact skill instructions.

## Evidence

- Repository-native `check:changed` gate passed.
- Full production build passed.
- Focused attempt-context and run-attempt regressions passed.
- Mandatory autoreview: clean, 0 actionable findings.
- Combined latest-main Gateway → Codex live E2E passed with `openai/gpt-5.6-sol`, `xhigh`.
- Representative 52-skill catalog fell from about 17,229 to 10,885 characters while preserving all names.
