### PR TITLE
test: reuse planner modules between admission cases

### DIFF
--- a/src/infra/state-migrations.media-persistence.test-support.ts
+++ b/src/infra/state-migrations.media-persistence.test-support.ts
@@ -1,0 +1,65 @@
+import { requireNodeSqlite } from "./node-sqlite.js";
+
+export function readDatabaseSnapshot(databasePath: string) {
+  const { DatabaseSync } = requireNodeSqlite();
+  const database = new DatabaseSync(databasePath);
+  try {
+    const version = database.prepare("PRAGMA user_version").get() as { user_version: number };
+    const rows = database
+      .prepare(
+        "SELECT session_id,seq,event_json,created_at FROM transcript_events ORDER BY session_id,seq",
+      )
+      .all() as Array<{
+      session_id: string;
+      seq: number;
+      event_json: string;
+      created_at: number;
+    }>;
+    const identities = database
+      .prepare(
+        "SELECT session_id,event_id,seq,event_type,parent_id,message_idempotency_key,created_at FROM transcript_event_identities ORDER BY session_id,seq",
+      )
+      .all();
+    const activeBranch = database
+      .prepare(
+        "SELECT session_id,active_position,event_seq,message_position FROM session_transcript_active_events ORDER BY session_id,active_position",
+      )
+      .all();
+    const windows = database
+      .prepare(
+        "SELECT session_id,session_key,created_at,updated_at,transcript_observed_at FROM session_windows ORDER BY session_id",
+      )
+      .all();
+    const generations = database
+      .prepare(
+        "SELECT session_id,generation FROM transcript_rewrite_watermarks ORDER BY session_id",
+      )
+      .all();
+    const trajectoryCount = database
+      .prepare("SELECT count(*) AS count FROM trajectory_runtime_events")
+      .get() as { count: number };
+    const trajectoryRows = database
+      .prepare(
+        "SELECT session_id,seq,run_id,event_json,created_at FROM trajectory_runtime_events ORDER BY session_id,seq",
+      )
+      .all() as Array<{
+      session_id: string;
+      seq: number;
+      run_id: string | null;
+      event_json: string;
+      created_at: number;
+    }>;
+    return {
+      activeBranch,
+      generations,
+      identities,
+      rows,
+      trajectoryCount: trajectoryCount.count,
+      trajectoryRows,
+      version,
+      windows,
+    };
+  } finally {
+    database.close();
+  }
+}

--- a/src/infra/state-migrations.media-persistence.test.ts
+++ b/src/infra/state-migrations.media-persistence.test.ts
@@ -20,6 +20,7 @@ import {
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
 import { requireNodeSqlite } from "./node-sqlite.js";
 import { migrateLegacyMediaPersistence } from "./state-migrations.media-persistence.js";
+import { readDatabaseSnapshot } from "./state-migrations.media-persistence.test-support.js";
 
 const tempDirs: string[] = [];
 const PREVIOUS_VERSION = 16;
@@ -116,70 +117,6 @@ function createLegacyDatabaseFixture(params: {
     schemaVersion,
   });
   return databasePath;
-}
-
-function readDatabaseSnapshot(databasePath: string) {
-  const { DatabaseSync } = requireNodeSqlite();
-  const database = new DatabaseSync(databasePath);
-  try {
-    const version = database.prepare("PRAGMA user_version").get() as { user_version: number };
-    const rows = database
-      .prepare(
-        "SELECT session_id,seq,event_json,created_at FROM transcript_events ORDER BY session_id,seq",
-      )
-      .all() as Array<{
-      session_id: string;
-      seq: number;
-      event_json: string;
-      created_at: number;
-    }>;
-    const identities = database
-      .prepare(
-        "SELECT session_id,event_id,seq,event_type,parent_id,message_idempotency_key,created_at FROM transcript_event_identities ORDER BY session_id,seq",
-      )
-      .all();
-    const activeBranch = database
-      .prepare(
-        "SELECT session_id,active_position,event_seq,message_position FROM session_transcript_active_events ORDER BY session_id,active_position",
-      )
-      .all();
-    const windows = database
-      .prepare(
-        "SELECT session_id,session_key,created_at,updated_at,transcript_observed_at FROM session_windows ORDER BY session_id",
-      )
-      .all();
-    const generations = database
-      .prepare(
-        "SELECT session_id,generation FROM transcript_rewrite_watermarks ORDER BY session_id",
-      )
-      .all();
-    const trajectoryCount = database
-      .prepare("SELECT count(*) AS count FROM trajectory_runtime_events")
-      .get() as { count: number };
-    const trajectoryRows = database
-      .prepare(
-        "SELECT session_id,seq,run_id,event_json,created_at FROM trajectory_runtime_events ORDER BY session_id,seq",
-      )
-      .all() as Array<{
-      session_id: string;
-      seq: number;
-      run_id: string | null;
-      event_json: string;
-      created_at: number;
-    }>;
-    return {
-      activeBranch,
-      generations,
-      identities,
-      rows,
-      trajectoryCount: trajectoryCount.count,
-      trajectoryRows,
-      version,
-      windows,
-    };
-  } finally {
-    database.close();
-  }
 }
 
 function writeArchive(filePath: string, events: FixtureEvent[], compressed: boolean): void {

--- a/test/scripts/test-projects-build-admission.test.ts
+++ b/test/scripts/test-projects-build-admission.test.ts
@@ -37,9 +37,10 @@ const e2eConfig = "test/vitest/vitest.e2e.config.ts";
 let originalArgv: string[];
 let originalExitCode: typeof process.exitCode;
 let terminal: ReturnType<typeof createDeferred<unknown>>;
+const testProjectsUrl = new URL("../../scripts/test-projects.mts", import.meta.url).href;
+let startCount = 0;
 
 beforeEach(() => {
-  vi.resetModules();
   commands.prepare.mockReset();
   commands.prepareE2e.mockReset();
   commands.reader.mockReset().mockImplementation(() => ({
@@ -287,7 +288,8 @@ syncBuiltinESMExports();\n`,
 
 async function start(args: string[]) {
   process.argv = [process.execPath, "scripts/test-projects.mts", ...args];
-  await import("../../scripts/test-projects.mts");
+  // Replay the command entry while retaining its immutable planner dependencies.
+  await import(`${testProjectsUrl}?case=${startCount++}`);
 }
 
 describe("test-projects build admission", () => {


### PR DESCRIPTION
## What Problem This Solves

Build-admission tests clear the entire module graph before every case. Replaying the command therefore reloads its planner dependencies repeatedly, adding several seconds per in-process case.

## Why This Change Was Made

Import a fresh URL for the command entry on each invocation while retaining its planner dependencies. Vite keys entry modules by their query-bearing URL. Repository inventories stay unchanged within this isolated test file; environment flags and include-file contents are read per invocation. Existing mock resets, completion waits, environment/argv cleanup, and real subprocess tests remain unchanged.

## User Impact

All 65 admission cases fell from **45.30s to 7.90s** of local execution, repeating at **6.46s**. Production +0/-0; tests +4/-2. No sharding, worker count, case ordering, concurrency, or test-selection changes.

## Evidence

- Baseline and candidate: `node scripts/run-vitest.mjs test/scripts/test-projects-build-admission.test.ts` (65 passed).
- Final run also includes `test/scripts/test-projects.test.ts`: all 386 passed in their existing order/configurations.
- Bypassing runtime preparation made four original admission assertions fail. Bypassing E2E preparation made four relevant cases fail while the explicit prebuilt case still passed. Production bytes were restored before the final full run.
- Complete admission entry, tests, prerequisite owner, relevant dependency caches and installed Vite module identity implementation inspected. Independent review and Codex autoreview through P3 found no actionable findings; formatting and whitespace checks passed.
- Linux changed checks and exact-head CI must pass before landing.

## Current-main integration

The first hosted CI run exposed a stale lint-suppression baseline after #132399 added credential-safe packaged-plugin setup errors. The existing auth-bootstrap boundary already omits raw error causes for the same reason. The expected count was corrected from one to two without adding or relaxing a production suppression. That same correction independently landed in #132394, so the final rebase drops our duplicate baseline commit and retains only the admission import change. The original lint test failed before correction, then all 69 admission/lint cases passed. Both real QA CLI auth/plugin failure tests also passed and retained their assertions that credentials appear in neither the error message nor its cause. Fresh Codex autoreview found no actionable findings.

Follow-up from the planner audit: the serial untargeted-full-suite case in `test/scripts/test-projects.test.ts` deletes two environment variables without restoring their prior values. This pre-existing cleanup issue is outside the admission-import optimization.

The exact final head passed all 390 admission, planner and lint-ratchet tests. Fresh post-rebase Codex autoreview through P3 is clean. The preceding head passed both hosted CI and Linux changed checks; final hosted CI is rerunning after the mechanical rebase. Direct installed Vite source inspection confirms query-bearing module URLs remain distinct while dependency URLs are reused. This addresses ClawSweeper's dependency-inspection gap; its exact-head CI request remains a pre-merge gate.

Shared CI integration repair: #132099 left `state-migrations.media-persistence.test.ts` above the max-lines limit. Move its existing snapshot reader verbatim into test support; all 15 migration cases, assertions, SQL queries, cleanup hooks and database-close behavior remain unchanged. All 15 cases passed before and after, focused lint passed, and fresh Codex autoreview through P3 is clean. Production and schema delta are zero; tests/support +66/-64. This repair is shared across the pending performance branches so it lands once without waiting on a known broken main check.

Final exact-head CI passed: https://github.com/openclaw/openclaw/actions/runs/33240544351. Latest ClawSweeper has no actionable findings; its remaining CI rank-up request is fulfilled. The data-model detector matched relocated test SQL only: there is no runtime/schema change.
