### PR TITLE
fix(process): settle disconnected workers after pipe closure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Worker shutdown:** release completed worker capacity promptly after IPC disconnect and closed pipes, avoiding unnecessary shutdown escalation when Node omits its child close event.
 - **Control UI tool progress:** keep error-shaped partial output running until the tool returns its result, with consistent status in collapsed rows, expanded cards, and side-panel details.
 
 - MCP Apps: let standalone operations finish across catalog refreshes within per-request server budgets, propagate App cancellation without cancelling shared catalog work, and reload restored history views without replaying interrupted operations. Thanks @tzy-17. (#119388)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,7 +69,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Worker shutdown:** release completed worker capacity promptly after IPC disconnect and closed pipes, avoiding unnecessary shutdown escalation when Node omits its child close event.
 - **Control UI tool progress:** keep error-shaped partial output running until the tool returns its result, with consistent status in collapsed rows, expanded cards, and side-panel details.
 
 - MCP Apps: let standalone operations finish across catalog refreshes within per-request server budgets, propagate App cancellation without cancelling shared catalog work, and reload restored history views without replaying interrupted operations. Thanks @tzy-17. (#119388)

--- a/src/infra/state-migrations.media-persistence.test-support.ts
+++ b/src/infra/state-migrations.media-persistence.test-support.ts
@@ -1,0 +1,65 @@
+import { requireNodeSqlite } from "./node-sqlite.js";
+
+export function readDatabaseSnapshot(databasePath: string) {
+  const { DatabaseSync } = requireNodeSqlite();
+  const database = new DatabaseSync(databasePath);
+  try {
+    const version = database.prepare("PRAGMA user_version").get() as { user_version: number };
+    const rows = database
+      .prepare(
+        "SELECT session_id,seq,event_json,created_at FROM transcript_events ORDER BY session_id,seq",
+      )
+      .all() as Array<{
+      session_id: string;
+      seq: number;
+      event_json: string;
+      created_at: number;
+    }>;
+    const identities = database
+      .prepare(
+        "SELECT session_id,event_id,seq,event_type,parent_id,message_idempotency_key,created_at FROM transcript_event_identities ORDER BY session_id,seq",
+      )
+      .all();
+    const activeBranch = database
+      .prepare(
+        "SELECT session_id,active_position,event_seq,message_position FROM session_transcript_active_events ORDER BY session_id,active_position",
+      )
+      .all();
+    const windows = database
+      .prepare(
+        "SELECT session_id,session_key,created_at,updated_at,transcript_observed_at FROM session_windows ORDER BY session_id",
+      )
+      .all();
+    const generations = database
+      .prepare(
+        "SELECT session_id,generation FROM transcript_rewrite_watermarks ORDER BY session_id",
+      )
+      .all();
+    const trajectoryCount = database
+      .prepare("SELECT count(*) AS count FROM trajectory_runtime_events")
+      .get() as { count: number };
+    const trajectoryRows = database
+      .prepare(
+        "SELECT session_id,seq,run_id,event_json,created_at FROM trajectory_runtime_events ORDER BY session_id,seq",
+      )
+      .all() as Array<{
+      session_id: string;
+      seq: number;
+      run_id: string | null;
+      event_json: string;
+      created_at: number;
+    }>;
+    return {
+      activeBranch,
+      generations,
+      identities,
+      rows,
+      trajectoryCount: trajectoryCount.count,
+      trajectoryRows,
+      version,
+      windows,
+    };
+  } finally {
+    database.close();
+  }
+}

--- a/src/infra/state-migrations.media-persistence.test.ts
+++ b/src/infra/state-migrations.media-persistence.test.ts
@@ -20,6 +20,7 @@ import {
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
 import { requireNodeSqlite } from "./node-sqlite.js";
 import { migrateLegacyMediaPersistence } from "./state-migrations.media-persistence.js";
+import { readDatabaseSnapshot } from "./state-migrations.media-persistence.test-support.js";
 
 const tempDirs: string[] = [];
 const PREVIOUS_VERSION = 16;
@@ -116,70 +117,6 @@ function createLegacyDatabaseFixture(params: {
     schemaVersion,
   });
   return databasePath;
-}
-
-function readDatabaseSnapshot(databasePath: string) {
-  const { DatabaseSync } = requireNodeSqlite();
-  const database = new DatabaseSync(databasePath);
-  try {
-    const version = database.prepare("PRAGMA user_version").get() as { user_version: number };
-    const rows = database
-      .prepare(
-        "SELECT session_id,seq,event_json,created_at FROM transcript_events ORDER BY session_id,seq",
-      )
-      .all() as Array<{
-      session_id: string;
-      seq: number;
-      event_json: string;
-      created_at: number;
-    }>;
-    const identities = database
-      .prepare(
-        "SELECT session_id,event_id,seq,event_type,parent_id,message_idempotency_key,created_at FROM transcript_event_identities ORDER BY session_id,seq",
-      )
-      .all();
-    const activeBranch = database
-      .prepare(
-        "SELECT session_id,active_position,event_seq,message_position FROM session_transcript_active_events ORDER BY session_id,active_position",
-      )
-      .all();
-    const windows = database
-      .prepare(
-        "SELECT session_id,session_key,created_at,updated_at,transcript_observed_at FROM session_windows ORDER BY session_id",
-      )
-      .all();
-    const generations = database
-      .prepare(
-        "SELECT session_id,generation FROM transcript_rewrite_watermarks ORDER BY session_id",
-      )
-      .all();
-    const trajectoryCount = database
-      .prepare("SELECT count(*) AS count FROM trajectory_runtime_events")
-      .get() as { count: number };
-    const trajectoryRows = database
-      .prepare(
-        "SELECT session_id,seq,run_id,event_json,created_at FROM trajectory_runtime_events ORDER BY session_id,seq",
-      )
-      .all() as Array<{
-      session_id: string;
-      seq: number;
-      run_id: string | null;
-      event_json: string;
-      created_at: number;
-    }>;
-    return {
-      activeBranch,
-      generations,
-      identities,
-      rows,
-      trajectoryCount: trajectoryCount.count,
-      trajectoryRows,
-      version,
-      windows,
-    };
-  } finally {
-    database.close();
-  }
 }
 
 function writeArchive(filePath: string, events: FixtureEvent[], compressed: boolean): void {

--- a/src/node-host/node-worker-supervisor.test-support.ts
+++ b/src/node-host/node-worker-supervisor.test-support.ts
@@ -157,7 +157,6 @@ if (mode === "admission-rearm") {
 } else if (mode === "quiet-fail") {
   exitWorker(7);
 } else if (mode === "secret-fail") {
-  await new Promise((resolve) => setTimeout(resolve, 500));
   const credential = descriptor.admission.credential;
   const escaped = JSON.stringify(credential).slice(1, -1);
   process.stderr.write(
@@ -176,7 +175,6 @@ if (mode === "admission-rearm") {
   process.stderr.write("x".repeat(5000) + representation + "y".repeat(suffixBytes));
   exitWorker(7);
 } else if (mode === "secret-success") {
-  await new Promise((resolve) => setTimeout(resolve, 500));
   const credential = descriptor.admission.credential;
   finish(descriptor, {
     ...completedResult,

--- a/src/node-host/node-worker-supervisor.test.ts
+++ b/src/node-host/node-worker-supervisor.test.ts
@@ -8,6 +8,7 @@ import { NODE_WORKER_CAPACITY_EXHAUSTED_ERROR_CODE } from "../infra/node-command
 import { NODE_WORKER_CAPACITY_MAX } from "../infra/node-runner-inventory.js";
 import { registerSecretValueForRedaction } from "../logging/secret-redaction-registry.js";
 import { resetSecretRedactionRegistryForTest } from "../logging/secret-redaction-registry.test-support.js";
+import * as processTree from "../process/kill-tree.js";
 import {
   closeOpenClawStateDatabaseForTest,
   openOpenClawStateDatabase,
@@ -623,10 +624,21 @@ describe("node worker supervisor", () => {
   });
 
   it("does not open or signal a child after markRunning observes its terminal receipt", async () => {
-    const { supervisor, workspaceDir } = fixture();
+    const capacities: Array<{ total: number; available: number }> = [];
+    const { supervisor, workspaceDir, env } = fixture({
+      capacity: 1,
+      onCapacityChanged: (capacity) => capacities.push(capacity),
+    });
     const input = launchInput(workspaceDir, "fast-terminal-launch", "fast-terminal");
+    const captureSpawn = vi.spyOn(childProcess.ChildProcess.prototype, "emit");
+    const signalTree = vi.spyOn(processTree, "signalProcessTree");
+    let child: ChildProcess | undefined;
     vi.spyOn(NodeWorkerLaunchStore.prototype, "markRunning").mockImplementation(
       function (this: NodeWorkerLaunchStore, params) {
+        child = captureSpawn.mock.contexts.find(
+          (context): context is ChildProcess =>
+            context instanceof childProcess.ChildProcess && context.pid === params.worker.pid,
+        );
         return this.finish({
           launchId: params.launchId,
           planHash: params.planHash,
@@ -638,15 +650,25 @@ describe("node worker supervisor", () => {
       },
     );
 
-    expect(await supervisor.launch(input, TEST_WORKER_ENDPOINT)).toMatchObject({
-      state: "completed",
-    });
-    const marker = path.join(workspaceDir, "fast-terminal-marker");
-    await new Promise((resolve) => {
-      setTimeout(resolve, 150);
-    });
-    expect(fs.existsSync(marker)).toBe(false);
-    await supervisor.close();
+    try {
+      expect(await supervisor.launch(input, TEST_WORKER_ENDPOINT)).toMatchObject({
+        state: "completed",
+      });
+      // Capacity returns only after the real child exit and adapter settlement.
+      await vi.waitFor(() => expect(capacities.at(-1)).toEqual({ total: 1, available: 1 }), {
+        timeout: 5_000,
+      });
+      expect(child?.exitCode).toBe(0);
+      expect(child?.signalCode).toBeNull();
+      expect(child?.stdout?.closed).toBe(true);
+      expect(child?.stderr?.closed).toBe(true);
+      expect(fs.existsSync(path.join(workspaceDir, "fast-terminal-marker"))).toBe(false);
+      expect(new NodeWorkerLaunchStore({ env }).get(input.launchId)?.state).toBe("completed");
+      await supervisor.close();
+      expect(signalTree).not.toHaveBeenCalled();
+    } finally {
+      await supervisor.close();
+    }
   });
 
   it("records a gated child that exits before journal readiness as terminal", async () => {
@@ -682,6 +704,7 @@ describe("node worker supervisor", () => {
     const input = launchInput(workspaceDir, "blocked-cancel", "wait");
     const sibling = launchInput(workspaceDir, "unrelated-worker", "wait");
     const captureSpawn = vi.spyOn(childProcess.ChildProcess.prototype, "emit");
+    const signalTree = vi.spyOn(processTree, "signalProcessTree");
     let heldWrite: { data: unknown; callback?: (error?: Error | null) => void } | undefined;
     let restoreWrite: (() => void) | undefined;
     let cancellation: ReturnType<NodeWorkerSupervisor["cancel"]> | undefined;
@@ -704,17 +727,29 @@ describe("node worker supervisor", () => {
         return false;
       });
       restoreWrite = () => write.mockRestore();
+      vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
       cancellation = supervisor.cancel(testNodeWorkerLaunchIdentity(input)).then((receipt) => {
         cancelled = receipt;
         return receipt;
       });
-      await vi.waitFor(() => {
-        expect(heldWrite?.data).toBe(
-          `${JSON.stringify({ type: "cancel", turnId: input.launchId })}\n`,
-        );
-        expect(heldWrite?.callback).toEqual(expect.any(Function));
-      });
+      await vi.advanceTimersByTimeAsync(0);
+      expect(heldWrite?.data).toBe(
+        `${JSON.stringify({ type: "cancel", turnId: input.launchId })}\n`,
+      );
+      expect(heldWrite?.callback).toEqual(expect.any(Function));
 
+      await vi.advanceTimersByTimeAsync(4_999);
+      expect(signalTree).not.toHaveBeenCalled();
+      expect(cancelled).toBeUndefined();
+      expect(new NodeWorkerLaunchStore({ env }).get(input.launchId)?.state).toBe("running");
+      expect(inspectNodeWorkerProcessIdentity(running.worker!)).toBe("live");
+      expect(inspectNodeWorkerProcessIdentity(unrelated.worker!)).toBe("live");
+      expect(capacities.at(-1)).toEqual({ total: 2, available: 0 });
+
+      // Fire only the blocked-write deadline. Restore real timers before its
+      // rejection continuation schedules process termination and escalation.
+      vi.advanceTimersByTime(1);
+      vi.useRealTimers();
       await vi.waitFor(
         () => {
           expect(cancelled).toMatchObject({ state: "cancelled", worker: running.worker });
@@ -733,6 +768,7 @@ describe("node worker supervisor", () => {
         ),
       ).resolves.toMatchObject({ state: "running" });
     } finally {
+      vi.useRealTimers();
       captureSpawn.mockRestore();
       restoreWrite?.();
       // Release the injected write even on the pre-fix failure, so cleanup cannot inherit its hang.

--- a/src/node-host/node-worker-supervisor.test.ts
+++ b/src/node-host/node-worker-supervisor.test.ts
@@ -6,7 +6,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { NODE_WORKER_CAPACITY_EXHAUSTED_ERROR_CODE } from "../infra/node-commands.js";
 import { NODE_WORKER_CAPACITY_MAX } from "../infra/node-runner-inventory.js";
-import { registerSecretValueForRedaction } from "../logging/secret-redaction-registry.js";
+import * as secretRegistry from "../logging/secret-redaction-registry.js";
 import { resetSecretRedactionRegistryForTest } from "../logging/secret-redaction-registry.test-support.js";
 import * as processTree from "../process/kill-tree.js";
 import {
@@ -54,6 +54,19 @@ function launchInput(workspaceDir: string, launchId: string, prompt = "success")
   input.descriptor.admission.environmentId = `environment-${launchId}`;
   input.descriptor.admission.sessionId = `session-${launchId}`;
   return input;
+}
+
+function evictWorkerCredentialsOnRegistration() {
+  const { registerSecretValueForRedaction } = secretRegistry;
+  // Both launch paths register before sending a turn. Evict every registration so a
+  // later launch cannot restore the global secret and hide a missing worker scrubber.
+  return vi.spyOn(secretRegistry, "registerSecretValueForRedaction").mockImplementation((value) => {
+    registerSecretValueForRedaction(value);
+    for (let index = 0; index < 600; index += 1) {
+      registerSecretValueForRedaction(`eviction-secret-${index}`);
+    }
+    expect(secretRegistry.isSecretValueRegisteredForRedaction(value)).toBe(false);
+  });
 }
 
 describe("node worker supervisor", () => {
@@ -532,12 +545,12 @@ describe("node worker supervisor", () => {
     const failureInput = launchInput(workspaceDir, "failure-launch", "secret-fail");
     const overflowInput = launchInput(workspaceDir, "overflow-launch", "overflow");
 
+    const registrations = evictWorkerCredentialsOnRegistration();
     await supervisor.launch(successInput, TEST_WORKER_ENDPOINT);
     await supervisor.launch(failureInput, TEST_WORKER_ENDPOINT);
     await supervisor.launch(overflowInput, TEST_WORKER_ENDPOINT);
-    for (let index = 0; index < 600; index += 1) {
-      registerSecretValueForRedaction(`eviction-secret-${index}`);
-    }
+    expect(registrations).toHaveBeenCalledTimes(3);
+    expect(registrations).toHaveBeenCalledWith(TEST_WORKER_CREDENTIAL);
     const success = await waitForTerminal(supervisor, successInput.launchId);
     const failure = await waitForTerminal(supervisor, failureInput.launchId);
     const overflow = await waitForTerminal(supervisor, overflowInput.launchId);
@@ -596,12 +609,11 @@ describe("node worker supervisor", () => {
     try {
       const original = await supervisor.launch(first, TEST_WORKER_ENDPOINT);
       await waitForTerminal(supervisor, first.launchId);
+      const registrations = evictWorkerCredentialsOnRegistration();
       expect(await supervisor.launch(second, TEST_WORKER_ENDPOINT)).toMatchObject({
         worker: original.worker,
       });
-      for (let index = 0; index < 600; index += 1) {
-        registerSecretValueForRedaction(`rotated-eviction-secret-${index}`);
-      }
+      expect(registrations).toHaveBeenCalledWith(second.descriptor.admission.credential);
       const completed = await waitForTerminal(supervisor, second.launchId);
       expect(JSON.parse(completed.resultJson ?? "null")).toEqual({
         status: "completed",
@@ -609,6 +621,7 @@ describe("node worker supervisor", () => {
         transcriptNextSeq: 2,
       });
 
+      registrations.mockRestore();
       await supervisor.launch(last, TEST_WORKER_ENDPOINT);
       const failed = await waitForTerminal(supervisor, last.launchId);
       expect(failed).toMatchObject({

--- a/src/process/supervisor/adapters/child.test-support.ts
+++ b/src/process/supervisor/adapters/child.test-support.ts
@@ -1,0 +1,105 @@
+import type { ChildProcess } from "node:child_process";
+import { EventEmitter } from "node:events";
+import { mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { PassThrough } from "node:stream";
+import { vi, type Mock } from "vitest";
+
+export function createStubChild(pid = 1234) {
+  const child = new EventEmitter() as ChildProcess;
+  child.stdin = new PassThrough() as ChildProcess["stdin"];
+  child.stdout = new PassThrough() as ChildProcess["stdout"];
+  child.stderr = new PassThrough() as ChildProcess["stderr"];
+  Object.defineProperty(child, "stdio", {
+    value: [child.stdin, child.stdout, child.stderr],
+    configurable: true,
+  });
+  Object.defineProperty(child, "pid", { value: pid, configurable: true });
+  Object.defineProperty(child, "killed", { value: false, configurable: true, writable: true });
+  Object.defineProperty(child, "exitCode", { value: null, configurable: true, writable: true });
+  Object.defineProperty(child, "signalCode", { value: null, configurable: true, writable: true });
+  Object.defineProperty(child, "channel", { value: {}, configurable: true });
+  Object.defineProperty(child, "connected", { value: true, configurable: true, writable: true });
+  const killMock = vi.fn(() => true);
+  const sendMock = vi.fn((_message: unknown, ...args: unknown[]) => {
+    const callback = args.findLast((value) => typeof value === "function") as
+      | ((error: Error | null) => void)
+      | undefined;
+    callback?.(null);
+    return true;
+  });
+  const disconnectMock = vi.fn(() => {
+    Object.defineProperty(child, "connected", { value: false, configurable: true, writable: true });
+    child.emit("disconnect");
+  });
+  child.kill = killMock as ChildProcess["kill"];
+  child.send = sendMock as ChildProcess["send"];
+  child.disconnect = disconnectMock as ChildProcess["disconnect"];
+  const emitClose = (code: number | null, signal: NodeJS.Signals | null = null) => {
+    child.emit("close", code, signal);
+  };
+  const emitExit = (code: number | null, signal: NodeJS.Signals | null = null) => {
+    Object.defineProperty(child, "exitCode", { value: code, configurable: true, writable: true });
+    Object.defineProperty(child, "signalCode", {
+      value: signal,
+      configurable: true,
+      writable: true,
+    });
+    child.emit("exit", code, signal);
+  };
+  return { child, disconnectMock, killMock, sendMock, emitClose, emitExit };
+}
+
+type SpawnWithFallbackParams = {
+  argv?: string[];
+  options?: {
+    detached?: boolean;
+    env?: NodeJS.ProcessEnv | Record<string, string>;
+    stdio?: string[];
+    windowsHide?: boolean;
+    windowsVerbatimArguments?: boolean;
+  };
+  fallbacks?: Array<{ options?: { detached?: boolean } }>;
+};
+
+export function firstSpawnWithFallbackParams(mock: Mock): SpawnWithFallbackParams {
+  const [call] = mock.mock.calls;
+  if (!call) {
+    throw new Error("expected spawnWithFallback call");
+  }
+  const [params] = call;
+  if (typeof params !== "object" || params === null || Array.isArray(params)) {
+    throw new Error("expected spawnWithFallback params to be an object");
+  }
+  return params;
+}
+
+export function firstMockArg(
+  mock: { mock: { calls: readonly unknown[][] } },
+  label: string,
+): unknown {
+  const [call] = mock.mock.calls;
+  if (!call) {
+    throw new Error(`expected ${label} call`);
+  }
+  return call[0];
+}
+
+export async function createWindowsNpmShim(params: {
+  binDir: string;
+  command: string;
+  packagePath: string[];
+}) {
+  const { binDir } = params;
+  const entrypoint = path.join(binDir, "node_modules", ...params.packagePath);
+  await mkdir(path.dirname(entrypoint), { recursive: true });
+  await writeFile(entrypoint, "", "utf8");
+  const relativeEntrypoint = path.relative(binDir, entrypoint).replaceAll(path.sep, "\\");
+  const shimHead =
+    "@ECHO off\r\nGOTO start\r\n:find_dp0\r\nSET dp0=%~dp0\r\nEXIT /b\r\n:start\r\nSETLOCAL\r\nCALL :find_dp0\r\n";
+  const shimCommand = entrypoint.endsWith(".exe")
+    ? `"%dp0%\\${relativeEntrypoint}" %*\r\n`
+    : `IF EXIST "%dp0%\\node.exe" (\r\n  SET "_prog=%dp0%\\node.exe"\r\n) ELSE (\r\n  SET "_prog=node"\r\n)\r\nendLocal & goto #_undefined_# 2>NUL || title %COMSPEC% & "%_prog%" "%dp0%\\${relativeEntrypoint}" %*\r\n`;
+  await writeFile(path.join(binDir, `${params.command}.cmd`), `${shimHead}${shimCommand}`, "utf8");
+  return { binDir, entrypoint };
+}

--- a/src/process/supervisor/adapters/child.test.ts
+++ b/src/process/supervisor/adapters/child.test.ts
@@ -1,12 +1,16 @@
 // Child adapter tests cover adapting child processes to supervisor runs.
-import type { ChildProcess } from "node:child_process";
-import { EventEmitter } from "node:events";
 import fs from "node:fs";
-import { mkdir, writeFile } from "node:fs/promises";
+import { writeFile } from "node:fs/promises";
 import path from "node:path";
 import { PassThrough, Writable } from "node:stream";
 import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../../../test/helpers/temp-dir.js";
+import {
+  createStubChild,
+  createWindowsNpmShim,
+  firstMockArg,
+  firstSpawnWithFallbackParams,
+} from "./child.test-support.js";
 import {
   expectRealExitWinsOverSigkillFallback,
   expectWaitStaysPendingUntilSigkillFallback,
@@ -52,51 +56,6 @@ let createChildAdapter: typeof import("./child.js").createChildAdapter;
 let getWindowsInstallRoots: typeof import("../../../infra/windows-install-roots.js").getWindowsInstallRoots;
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
-function createStubChild(pid = 1234) {
-  const child = new EventEmitter() as ChildProcess;
-  child.stdin = new PassThrough() as ChildProcess["stdin"];
-  child.stdout = new PassThrough() as ChildProcess["stdout"];
-  child.stderr = new PassThrough() as ChildProcess["stderr"];
-  Object.defineProperty(child, "stdio", {
-    value: [child.stdin, child.stdout, child.stderr],
-    configurable: true,
-  });
-  Object.defineProperty(child, "pid", { value: pid, configurable: true });
-  Object.defineProperty(child, "killed", { value: false, configurable: true, writable: true });
-  Object.defineProperty(child, "exitCode", { value: null, configurable: true, writable: true });
-  Object.defineProperty(child, "signalCode", { value: null, configurable: true, writable: true });
-  Object.defineProperty(child, "channel", { value: {}, configurable: true });
-  Object.defineProperty(child, "connected", { value: true, configurable: true, writable: true });
-  const killMock = vi.fn(() => true);
-  const sendMock = vi.fn((_message: unknown, ...args: unknown[]) => {
-    const callback = args.findLast((value) => typeof value === "function") as
-      | ((error: Error | null) => void)
-      | undefined;
-    callback?.(null);
-    return true;
-  });
-  const disconnectMock = vi.fn(() => {
-    Object.defineProperty(child, "connected", { value: false, configurable: true, writable: true });
-    child.emit("disconnect");
-  });
-  child.kill = killMock as ChildProcess["kill"];
-  child.send = sendMock as ChildProcess["send"];
-  child.disconnect = disconnectMock as ChildProcess["disconnect"];
-  const emitClose = (code: number | null, signal: NodeJS.Signals | null = null) => {
-    child.emit("close", code, signal);
-  };
-  const emitExit = (code: number | null, signal: NodeJS.Signals | null = null) => {
-    Object.defineProperty(child, "exitCode", { value: code, configurable: true, writable: true });
-    Object.defineProperty(child, "signalCode", {
-      value: signal,
-      configurable: true,
-      writable: true,
-    });
-    child.emit("exit", code, signal);
-  };
-  return { child, disconnectMock, killMock, sendMock, emitClose, emitExit };
-}
-
 async function createAdapterHarness(params?: {
   pid?: number;
   argv?: string[];
@@ -113,38 +72,6 @@ async function createAdapterHarness(params?: {
     stdinMode: "pipe-open",
   });
   return { adapter, killMock };
-}
-
-type SpawnWithFallbackParams = {
-  argv?: string[];
-  options?: {
-    detached?: boolean;
-    env?: NodeJS.ProcessEnv | Record<string, string>;
-    stdio?: string[];
-    windowsHide?: boolean;
-    windowsVerbatimArguments?: boolean;
-  };
-  fallbacks?: Array<{ options?: { detached?: boolean } }>;
-};
-
-function firstSpawnWithFallbackParams(): SpawnWithFallbackParams {
-  const [call] = spawnWithFallbackMock.mock.calls;
-  if (!call) {
-    throw new Error("expected spawnWithFallback call");
-  }
-  const [params] = call;
-  if (typeof params !== "object" || params === null || Array.isArray(params)) {
-    throw new Error("expected spawnWithFallback params to be an object");
-  }
-  return params;
-}
-
-function firstMockArg(mock: { mock: { calls: readonly unknown[][] } }, label: string): unknown {
-  const [call] = mock.mock.calls;
-  if (!call) {
-    throw new Error(`expected ${label} call`);
-  }
-  return call[0];
 }
 
 function expectedTrustedCmdExe(): string {
@@ -209,29 +136,10 @@ describe("createChildAdapter", () => {
     vi.useRealTimers();
   });
 
-  const createWindowsNpmShim = async (params: { command: string; packagePath: string[] }) => {
-    const binDir = tempDirs.make("openclaw-child-shim-");
-    const entrypoint = path.join(binDir, "node_modules", ...params.packagePath);
-    await mkdir(path.dirname(entrypoint), { recursive: true });
-    await writeFile(entrypoint, "", "utf8");
-    const relativeEntrypoint = path.relative(binDir, entrypoint).replaceAll(path.sep, "\\");
-    const shimHead =
-      "@ECHO off\r\nGOTO start\r\n:find_dp0\r\nSET dp0=%~dp0\r\nEXIT /b\r\n:start\r\nSETLOCAL\r\nCALL :find_dp0\r\n";
-    const shimCommand = entrypoint.endsWith(".exe")
-      ? `"%dp0%\\${relativeEntrypoint}" %*\r\n`
-      : `IF EXIST "%dp0%\\node.exe" (\r\n  SET "_prog=%dp0%\\node.exe"\r\n) ELSE (\r\n  SET "_prog=node"\r\n)\r\nendLocal & goto #_undefined_# 2>NUL || title %COMSPEC% & "%_prog%" "%dp0%\\${relativeEntrypoint}" %*\r\n`;
-    await writeFile(
-      path.join(binDir, `${params.command}.cmd`),
-      `${shimHead}${shimCommand}`,
-      "utf8",
-    );
-    return { binDir, entrypoint };
-  };
-
   it("uses process-tree kill for default SIGKILL", async () => {
     const { adapter, killMock } = await createAdapterHarness({ pid: 4321 });
 
-    const spawnArgs = firstSpawnWithFallbackParams();
+    const spawnArgs = firstSpawnWithFallbackParams(spawnWithFallbackMock);
     // On Windows, detached defaults to false (headless Scheduled Task compat);
     // on POSIX, detached is true with a no-detach fallback.
     if (process.platform === "win32") {
@@ -267,9 +175,10 @@ describe("createChildAdapter", () => {
       input: "{}",
     });
 
-    expect(firstSpawnWithFallbackParams().options?.detached).toBe(process.platform !== "win32");
-    expect(firstSpawnWithFallbackParams().fallbacks).toEqual([]);
-    expect(firstSpawnWithFallbackParams().options?.stdio).toEqual(["pipe", "pipe", "pipe", "ipc"]);
+    const spawnArgs = firstSpawnWithFallbackParams(spawnWithFallbackMock);
+    expect(spawnArgs.options?.detached).toBe(process.platform !== "win32");
+    expect(spawnArgs.fallbacks).toEqual([]);
+    expect(spawnArgs.options?.stdio).toEqual(["pipe", "pipe", "pipe", "ipc"]);
 
     await adapter.openStartGate?.();
     expect(sendMock).toHaveBeenCalledWith(
@@ -292,7 +201,11 @@ describe("createChildAdapter", () => {
       const { child, disconnectMock, emitExit, killMock } = createStubChild();
       // Node marks connected false before a queued IPC disconnect has completed.
       disconnectMock.mockImplementation(() => {
-        child.connected = false;
+        Object.defineProperty(child, "connected", {
+          value: false,
+          configurable: true,
+          writable: true,
+        });
       });
       spawnWithFallbackMock.mockResolvedValue({ child, usedFallback: false });
       const adapter = await createChildAdapter({
@@ -556,7 +469,7 @@ describe("createChildAdapter", () => {
       },
     });
 
-    expect(firstSpawnWithFallbackParams().options?.stdio).toEqual([
+    expect(firstSpawnWithFallbackParams(spawnWithFallbackMock).options?.stdio).toEqual([
       "pipe",
       "pipe",
       "pipe",
@@ -615,7 +528,9 @@ describe("createChildAdapter", () => {
       },
     });
 
-    expect(firstSpawnWithFallbackParams().options?.stdio?.[3]).toBe("overlapped");
+    expect(firstSpawnWithFallbackParams(spawnWithFallbackMock).options?.stdio?.[3]).toBe(
+      "overlapped",
+    );
   });
 
   it("passes detached:false to signalProcessTree when spawn fell back to no-detach (#71662 follow-up)", async () => {
@@ -719,7 +634,7 @@ describe("createChildAdapter", () => {
       argv: ["node", "-e", "setTimeout(() => {}, 1000)"],
     });
 
-    const spawnArgs = firstSpawnWithFallbackParams();
+    const spawnArgs = firstSpawnWithFallbackParams(spawnWithFallbackMock);
     expect(spawnArgs.options?.stdio?.[0]).toBe("inherit");
     expect(adapter.stdin).toBeUndefined();
   });
@@ -972,7 +887,7 @@ describe("createChildAdapter", () => {
 
     await createAdapterHarness({ pid: 7777 });
 
-    const spawnArgs = firstSpawnWithFallbackParams();
+    const spawnArgs = firstSpawnWithFallbackParams(spawnWithFallbackMock);
     expect(spawnArgs.options?.detached).toBe(false);
     expect(spawnArgs.fallbacks ?? []).toStrictEqual([]);
     expect(createServiceChildRelayAdapterMock).not.toHaveBeenCalled();
@@ -986,7 +901,7 @@ describe("createChildAdapter", () => {
       argv: ["node", "-e", "process.exit(0)"],
     });
 
-    const spawnArgs = firstSpawnWithFallbackParams();
+    const spawnArgs = firstSpawnWithFallbackParams(spawnWithFallbackMock);
     expect(spawnArgs.argv).toEqual(["node", "-e", "process.exit(0)"]);
     expect(spawnArgs.options?.env).toBeUndefined();
   });
@@ -1000,7 +915,7 @@ describe("createChildAdapter", () => {
       env: { PATH: "", PATHEXT: ".EXE;.CMD;.BAT" },
     });
 
-    const spawnArgs = firstSpawnWithFallbackParams();
+    const spawnArgs = firstSpawnWithFallbackParams(spawnWithFallbackMock);
     expect(spawnArgs.argv).toEqual([
       expectedTrustedCmdExe(),
       "/d",
@@ -1017,6 +932,7 @@ describe("createChildAdapter", () => {
   it("unwraps Gemini's npm shim and preserves prompt argv on Windows", async () => {
     setPlatform("win32");
     const { binDir, entrypoint } = await createWindowsNpmShim({
+      binDir: tempDirs.make("openclaw-child-shim-"),
       command: "gemini",
       packagePath: ["@google", "gemini-cli", "bundle", "gemini.js"],
     });
@@ -1030,7 +946,7 @@ describe("createChildAdapter", () => {
       env: { PATH: binDir, PATHEXT: ".EXE;.CMD;.BAT" },
     });
 
-    const spawnArgs = firstSpawnWithFallbackParams();
+    const spawnArgs = firstSpawnWithFallbackParams(spawnWithFallbackMock);
     expect(spawnArgs.argv?.[0]?.toLowerCase()).toBe(nodePath.toLowerCase());
     expect(spawnArgs.argv?.slice(1)).toEqual([entrypoint, "--prompt", prompt]);
     expect(spawnArgs.options?.windowsVerbatimArguments).toBeUndefined();
@@ -1040,6 +956,7 @@ describe("createChildAdapter", () => {
   it("unwraps Claude's npm shim to its native executable on Windows", async () => {
     setPlatform("win32");
     const { binDir, entrypoint } = await createWindowsNpmShim({
+      binDir: tempDirs.make("openclaw-child-shim-"),
       command: "claude",
       packagePath: ["@anthropic-ai", "claude-code", "bin", "claude.exe"],
     });
@@ -1050,7 +967,7 @@ describe("createChildAdapter", () => {
       env: { PATH: binDir, PATHEXT: ".EXE;.CMD;.BAT" },
     });
 
-    const spawnArgs = firstSpawnWithFallbackParams();
+    const spawnArgs = firstSpawnWithFallbackParams(spawnWithFallbackMock);
     expect(spawnArgs.argv).toEqual([entrypoint, "--version"]);
     expect(spawnArgs.options?.windowsVerbatimArguments).toBeUndefined();
     expect(spawnArgs.fallbacks).toStrictEqual([]);
@@ -1090,7 +1007,7 @@ describe("createChildAdapter", () => {
       }
     }
 
-    const spawnArgs = firstSpawnWithFallbackParams();
+    const spawnArgs = firstSpawnWithFallbackParams(spawnWithFallbackMock);
     expect(spawnArgs.argv?.slice(0, 4)).toEqual([
       "/bin/sh",
       "-c",
@@ -1123,7 +1040,7 @@ describe("createChildAdapter", () => {
       restoreLinuxShell();
     }
 
-    const spawnArgs = firstSpawnWithFallbackParams();
+    const spawnArgs = firstSpawnWithFallbackParams(spawnWithFallbackMock);
     expect(spawnArgs.argv).toEqual(["/usr/bin/node", "-e", "process.exit(0)"]);
     expect(spawnArgs.options?.env).toEqual({ HOME: "/worker-home", PATH: "/usr/bin" });
   });
@@ -1135,7 +1052,7 @@ describe("createChildAdapter", () => {
       env: { FOO: "bar", COUNT: "12", DROP_ME: undefined },
     });
 
-    const spawnArgs = firstSpawnWithFallbackParams();
+    const spawnArgs = firstSpawnWithFallbackParams(spawnWithFallbackMock);
     expect(spawnArgs.options?.env).toEqual({ FOO: "bar", COUNT: "12" });
   });
 

--- a/src/process/supervisor/adapters/child.test.ts
+++ b/src/process/supervisor/adapters/child.test.ts
@@ -280,6 +280,128 @@ describe("createChildAdapter", () => {
     expect(disconnectMock).toHaveBeenCalledOnce();
   });
 
+  it.each([
+    { order: "disconnect first", events: ["disconnect", "exit", "stdout", "stderr"] },
+    { order: "disconnect last", events: ["stdout", "stderr", "exit", "disconnect"] },
+    { order: "exit last", events: ["disconnect", "stdout", "stderr", "exit"] },
+  ] as const)(
+    "settles owned POSIX workers after all resources close ($order)",
+    async ({ events }) => {
+      vi.useFakeTimers();
+      setPlatform("darwin");
+      const { child, disconnectMock, emitExit, killMock } = createStubChild();
+      // Node marks connected false before a queued IPC disconnect has completed.
+      disconnectMock.mockImplementation(() => {
+        child.connected = false;
+      });
+      spawnWithFallbackMock.mockResolvedValue({ child, usedFallback: false });
+      const adapter = await createChildAdapter({
+        argv: ["node", "worker"],
+        ownedWorker: true,
+        stdinMode: "pipe-open",
+      });
+      const settled = vi.fn();
+      const wait = adapter.wait();
+      void wait.then(settled);
+
+      try {
+        adapter.closeStartGate?.();
+        await vi.advanceTimersByTimeAsync(0);
+        expect(settled).not.toHaveBeenCalled();
+        for (const [index, event] of events.entries()) {
+          if (event === "exit") {
+            emitExit(7);
+          } else if (event === "disconnect") {
+            child.emit("disconnect");
+          } else {
+            child[event]?.emit("end");
+            await vi.advanceTimersByTimeAsync(0);
+            expect(settled).not.toHaveBeenCalled();
+            child[event]?.emit("close");
+          }
+          await vi.advanceTimersByTimeAsync(0);
+          if (index < events.length - 1) {
+            expect(settled).not.toHaveBeenCalled();
+          }
+        }
+        expect(settled).toHaveBeenCalledExactlyOnceWith({ code: 7, signal: null });
+        await expect(wait).resolves.toEqual({ code: 7, signal: null });
+        expect(signalProcessTreeMock).not.toHaveBeenCalled();
+        expect(killMock).not.toHaveBeenCalled();
+      } finally {
+        adapter.dispose();
+      }
+    },
+  );
+
+  it("keeps ordinary POSIX child waits bound to close after exit and pipe closure", async () => {
+    vi.useFakeTimers();
+    setPlatform("darwin");
+    const { child, emitClose, emitExit } = createStubChild();
+    spawnWithFallbackMock.mockResolvedValue({ child, usedFallback: false });
+    const adapter = await createChildAdapter({ argv: ["node", "-e", "process.exit(0)"] });
+    const settled = vi.fn();
+    const wait = adapter.wait();
+    void wait.then(settled);
+
+    try {
+      emitExit(0);
+      child.stdout?.emit("close");
+      child.stderr?.emit("close");
+      child.emit("disconnect");
+      await vi.advanceTimersByTimeAsync(0);
+      expect(settled).not.toHaveBeenCalled();
+      emitClose(0);
+      await expect(wait).resolves.toEqual({ code: 0, signal: null });
+    } finally {
+      adapter.dispose();
+    }
+  });
+
+  it("waits for an owned worker's secret descriptor to close after delivery", async () => {
+    vi.useFakeTimers();
+    setPlatform("darwin");
+    const { child, emitExit } = createStubChild();
+    const secretStream = new Writable({
+      autoDestroy: false,
+      write(_chunk, _encoding, callback) {
+        callback();
+      },
+    });
+    Object.defineProperty(child, "stdio", {
+      value: [child.stdin, child.stdout, child.stderr, secretStream, null],
+      configurable: true,
+    });
+    spawnWithFallbackMock.mockResolvedValue({ child, usedFallback: false });
+    const transient = Buffer.from("synthetic-secret");
+    const adapter = await createChildAdapter({
+      argv: ["node", "worker"],
+      ownedWorker: true,
+      secretInput: { fd: 3, createData: () => transient },
+    });
+    const settled = vi.fn();
+    const wait = adapter.wait();
+    void wait.then(settled);
+
+    try {
+      expect(secretStream.writableFinished).toBe(true);
+      expect(transient.equals(Buffer.alloc(transient.length))).toBe(true);
+      adapter.closeStartGate?.();
+      emitExit(0);
+      child.stdout?.emit("close");
+      child.stderr?.emit("close");
+      await vi.advanceTimersByTimeAsync(0);
+      expect(settled).not.toHaveBeenCalled();
+      secretStream.destroy();
+      await vi.advanceTimersByTimeAsync(0);
+      expect(settled).toHaveBeenCalledExactlyOnceWith({ code: 0, signal: null });
+      await expect(wait).resolves.toEqual({ code: 0, signal: null });
+    } finally {
+      secretStream.destroy();
+      adapter.dispose();
+    }
+  });
+
   it("keeps ordinary children supervised through repeated operational errors", async () => {
     const { child, emitClose, emitExit } = createStubChild(7865);
     spawnWithFallbackMock.mockResolvedValue({ child, usedFallback: false });
@@ -742,36 +864,41 @@ describe("createChildAdapter", () => {
     expect(settled).toHaveBeenCalledWith({ code: null, signal: "SIGKILL" });
   });
 
-  it("blocks drained Windows streams until tree-kill completion", async () => {
-    vi.useFakeTimers();
-    setPlatform("win32");
-    let resolveTreeKill: (() => void) | undefined;
-    signalProcessTreeMock.mockImplementationOnce(
-      (_pid: number, _signal: string, opts?: { onComplete?: () => void }) => {
-        resolveTreeKill = opts?.onComplete;
-      },
-    );
+  it.each([false, true])(
+    "blocks drained Windows streams until tree-kill completion (ownedWorker=%s)",
+    async (ownedWorker) => {
+      vi.useFakeTimers();
+      setPlatform("win32");
+      let resolveTreeKill: (() => void) | undefined;
+      signalProcessTreeMock.mockImplementationOnce(
+        (_pid: number, _signal: string, opts?: { onComplete?: () => void }) => {
+          resolveTreeKill = opts?.onComplete;
+        },
+      );
 
-    const stub = createStubChild(9755);
-    spawnWithFallbackMock.mockResolvedValue({ child: stub.child, usedFallback: false });
-    const adapter = await createChildAdapter({
-      argv: ["node", "-e", "setInterval(() => {}, 1000)"],
-      stdinMode: "pipe-closed",
-    });
-    const settled = vi.fn();
-    void adapter.wait().then(settled);
+      const stub = createStubChild(9755);
+      spawnWithFallbackMock.mockResolvedValue({ child: stub.child, usedFallback: false });
+      const adapter = await createChildAdapter({
+        argv: ["node", "-e", "setInterval(() => {}, 1000)"],
+        stdinMode: "pipe-closed",
+        ...(ownedWorker ? { ownedWorker: true } : {}),
+      });
+      const settled = vi.fn();
+      void adapter.wait().then(settled);
 
-    adapter.kill("SIGKILL");
-    stub.emitExit(null, "SIGKILL");
-    stub.child.stdout?.emit("end");
-    stub.child.stderr?.emit("end");
-    await Promise.resolve();
-    expect(settled).not.toHaveBeenCalled();
+      adapter.kill("SIGKILL");
+      adapter.closeStartGate?.();
+      stub.emitExit(null, "SIGKILL");
+      stub.child.stdout?.emit("end");
+      stub.child.stderr?.emit("end");
+      await Promise.resolve();
+      expect(settled).not.toHaveBeenCalled();
 
-    resolveTreeKill?.();
-    await vi.advanceTimersByTimeAsync(0);
-    expect(settled).toHaveBeenCalledWith({ code: null, signal: "SIGKILL" });
-  });
+      resolveTreeKill?.();
+      await vi.advanceTimersByTimeAsync(0);
+      expect(settled).toHaveBeenCalledWith({ code: null, signal: "SIGKILL" });
+    },
+  );
 
   it("preserves descendant output after ordinary Windows child exit", async () => {
     vi.useFakeTimers();

--- a/src/process/supervisor/adapters/child.ts
+++ b/src/process/supervisor/adapters/child.ts
@@ -237,6 +237,8 @@ export async function createChildAdapter(params: ChildAdapterInput): Promise<Wor
   let childCloseState: { code: number | null; signal: NodeJS.Signals | null } | null = null;
   let stdoutDrained = child.stdout == null;
   let stderrDrained = child.stderr == null;
+  let workerIpcDisconnected = false;
+  let openWorkerStdio = 0;
 
   const clearForceKillWaitFallback = () => {
     if (!forceKillWaitFallbackTimer) {
@@ -318,9 +320,9 @@ export async function createChildAdapter(params: ChildAdapterInput): Promise<Wor
   const isWindowsHardKillSettlementBlocked = () =>
     process.platform === "win32" && hardKillRequested && !windowsTreeKillCompleted;
 
-  const maybeSettleAfterWindowsExit = () => {
+  const maybeSettleAfterExit = () => {
     if (
-      process.platform !== "win32" ||
+      (process.platform !== "win32" && (!workerIpcDisconnected || openWorkerStdio > 0)) ||
       isWindowsHardKillSettlementBlocked() ||
       childExitState == null ||
       !stdoutDrained ||
@@ -331,21 +333,40 @@ export async function createChildAdapter(params: ChildAdapterInput): Promise<Wor
     settleWait(resolveObservedExitState(childExitState));
   };
 
+  if (params.ownedWorker) {
+    // Parent-initiated IPC disconnect can suppress Node's child close event.
+    // Preserve its exit-and-closed-pipes boundary, including secret descriptors.
+    child.once("disconnect", () => {
+      workerIpcDisconnected = true;
+      maybeSettleAfterExit();
+    });
+    for (const stream of child.stdio.slice(1)) {
+      if (!stream || stream.closed) {
+        continue;
+      }
+      openWorkerStdio += 1;
+      stream.once("close", () => {
+        openWorkerStdio -= 1;
+        maybeSettleAfterExit();
+      });
+    }
+  }
+
   child.stdout?.once("end", () => {
     stdoutDrained = true;
-    maybeSettleAfterWindowsExit();
+    maybeSettleAfterExit();
   });
   child.stdout?.once("close", () => {
     stdoutDrained = true;
-    maybeSettleAfterWindowsExit();
+    maybeSettleAfterExit();
   });
   child.stderr?.once("end", () => {
     stderrDrained = true;
-    maybeSettleAfterWindowsExit();
+    maybeSettleAfterExit();
   });
   child.stderr?.once("close", () => {
     stderrDrained = true;
-    maybeSettleAfterWindowsExit();
+    maybeSettleAfterExit();
   });
 
   // Worker IPC failures close authority; ordinary post-spawn errors are nonterminal.
@@ -353,7 +374,7 @@ export async function createChildAdapter(params: ChildAdapterInput): Promise<Wor
   child.once("exit", (code, signal) => {
     childExitState = { code, signal };
     scheduleForcedWindowsCloseSettlement();
-    maybeSettleAfterWindowsExit();
+    maybeSettleAfterExit();
   });
   child.once("close", (code, signal) => {
     childCloseState = { code, signal };
@@ -408,7 +429,7 @@ export async function createChildAdapter(params: ChildAdapterInput): Promise<Wor
             settleWait(resolveObservedExitState(childCloseState));
             return;
           }
-          maybeSettleAfterWindowsExit();
+          maybeSettleAfterExit();
           scheduleForcedWindowsCloseSettlement();
         });
       } else {


### PR DESCRIPTION
## What Problem This Solves

An owned worker can exit successfully and close its output pipes after the parent disconnects IPC, yet Node never emits the child `close` event. The process adapter then retains completion and capacity until shutdown spends one second escalating and four more seconds in its fallback. Profiling an existing real-process supervisor test exposed this production lifecycle gap.

## Why This Change Was Made

Let the existing exit-settlement owner complete a disconnected owned worker after observing process exit and closure of every non-stdin pipe, including an extra secret descriptor. Require the actual IPC `disconnect` event: `connected === false` can precede queued IPC completion. Keep ordinary POSIX children on their existing `close` boundary and retain Windows tree-kill completion ordering.

The real supervisor case now observes capacity release and physical exit instead of sleeping before cleanup. It checks closed output pipes, the retained physical launch receipt, the absent execution marker, and that shutdown never signals the process tree.

The adjacent blocked-cancellation test advances only its five-second write deadline. It checks that no signal, state transition or capacity release occurs at 4,999 ms, then restores real timers synchronously before termination continuations run. Real child termination, sibling isolation, capacity reuse and escalation remain exercised.

## User Impact

Owned workers release completion promptly after their resources close instead of waiting for unnecessary escalation. The existing terminal-before-start case fell from about **5.28s to 152ms**; blocked cancellation fell from **5.16s to 145ms**.

Production +29/-8 (net +21): the added state records actual IPC disconnection and pipe closure in their owning adapter; it adds no timeout, fallback, configuration, protocol or storage policy. Final tests/support net +198, including moved fixture code; no changelog edit because release generation owns it. No sharding, worker count, concurrency or test-selection changes.

## Evidence

- Before the fix, instrumentation observed IPC disconnect at 144ms and exit0 plus both outputs closed at 170ms, but no child close; shutdown completed at 5,308ms after escalation/fallback.
- New owned-worker ordering/secret-pipe assertions fail on the original adapter. The revised real process test also fails its capacity observation on the original adapter.
- Initial 159 tests passed across child adapter, service lifecycle, node worker supervisor, container, admission, lifetime, recovery, and turn-store suites.
- Moving only the cancellation deadline by -1ms fails the no-signal assertion; +1ms fails the bounded cancellation-completion assertion. Original production bytes were restored before final proof.
- Installed Node26.5.0 internal child-process source was inspected: explicit parent disconnect can omit the IPC close credit. The repair uses only public events and pipe state, not Node private fields.
- Independent lifecycle reviews and Codex autoreview through P3 found no actionable findings. Formatting and whitespace checks passed. Final Linux changed checks and exact-head CI passed before landing.

Physical process completion and turn completion remain distinct. The existing turn-store policy intentionally interrupts an unfinished turn when its physical owner is completed; this PR does not change that policy.

Additional real-entry proof: the production `runWorkerProcess` managed IPC entry was launched in an isolated HOME/state directory with no provider credentials or Gateway assignment. After its ready handoff, parent IPC disconnect produced exit0/no signal and settled the production adapter in 11ms, with no stdout or stderr. No fake worker implementation or Gateway request was used for this probe.

Final CI corrections: the new disconnect stub now uses the existing `Object.defineProperty` pattern for Node's readonly `connected` type. Reusable fixture construction and mock readers moved to a test-support module to keep the original test file within its lint limit; all cases, assertions, hoisted mocks and module resets stay in the same test file. All 159 tests passed again after extraction. The ClawSweeper request to remove the release-owned changelog edit is addressed here; the user-impact paragraph supplies release context. The final branch also incorporates the independently landed QA lint-baseline correction from main.

Shared CI integration repair: #132099 left `state-migrations.media-persistence.test.ts` above the max-lines limit. Move its existing snapshot reader verbatim into test support; all 15 migration cases, assertions, SQL queries, cleanup hooks and database-close behavior remain unchanged. All 15 cases passed before and after, focused lint passed, and fresh Codex autoreview through P3 is clean. Production and schema delta are zero; tests/support +66/-64. This repair is shared across the pending performance branches so it lands once without waiting on a known broken main check.

Final execution cleanup: replace two 500ms worker-fixture sleeps with synchronous, real registry eviction at the existing credential-registration boundary. All three fresh launches remain covered; reused-worker output still runs through the real child. The two cases fell from 1.66s to 596ms, repeating at 671ms in the full run. Disabling the dedicated scrubber fails both original output assertions; disabling reused-turn scrubber rotation fails its original redacted-result assertion. Production bytes were restored, then all 339 adapter, worker, output, registry-redaction and lifecycle tests passed. Codex autoreview through P3 found no actionable findings. This adds only +20/-9 test/support lines.

Final landing evidence for `81fda09b70c24ea2905998e543766f2adcd65ac6`: [hosted CI](https://github.com/openclaw/openclaw/actions/runs/33240780280) passed, including Linux and Windows process checks. The separate [Linux changed-file gate](https://github.com/openclaw/openclaw/actions/runs/33240802270) completed with exit 0 and its one-shot Testbox stopped. A fresh production worker-entry probe on Node 26.7.0 returned exit 0/no signal, no stdout/stderr, and 12ms from parent IPC disconnect to adapter settlement.

The latest exact-head ClawSweeper review (07:32 UTC) reports no actionable defects. Its rank-up request to finish lifecycle checks is fulfilled. Its upstream-source evidence gap is covered by direct inspection of the installed Node 26.5.0 internal child-process source: IPC contributes a close credit, explicit parent disconnect emits disconnect after queued messages drain, and the close event depends on the credit count; the observed trace demonstrates the missing close event. The adapter still uses only public events. The review's data-model detector matched extracted test snapshot helpers; there is no runtime SQL, schema or serialization change. The shared media helper repair has now landed separately in #132444.
