### PR TITLE
fix(gateway): suppress hello from closing client transports

### DIFF
--- a/packages/gateway-client/src/client.handshake.test.ts
+++ b/packages/gateway-client/src/client.handshake.test.ts
@@ -2,8 +2,11 @@
 import http from "node:http";
 import net from "node:net";
 import type { AddressInfo } from "node:net";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { WebSocketServer, type WebSocket } from "ws";
+import { createDeferred } from "../../../test/helpers/promise.js";
 import { GatewayClient } from "./client.js";
+import { rawDataToString } from "./websocket-data.js";
 
 describe("GatewayClient websocket opening handshakeTimeout", () => {
   const servers: net.Server[] = [];
@@ -38,6 +41,78 @@ describe("GatewayClient websocket opening handshakeTimeout", () => {
     });
     return (server.address() as AddressInfo).port;
   }
+
+  it("keeps a hello received during WebSocket closing in the pre-hello failure path", async () => {
+    const server = http.createServer();
+    const wss = new WebSocketServer({ server });
+    const port = await listen(server);
+    const onHelloOk = vi.fn();
+    const onConnectError = vi.fn();
+    const onClose = vi.fn();
+    let peer: WebSocket;
+    let markerReceived = false;
+    const closed = createDeferred();
+    const client = new GatewayClient({
+      url: `ws://127.0.0.1:${port}`,
+      deviceIdentity: null,
+      onHelloOk,
+      onConnectError,
+      onClose: (...args) => {
+        onClose(...args);
+        closed.resolve();
+      },
+      onEvent: (event) => {
+        if (event.event === "late-hello-marker") {
+          markerReceived = true;
+          peer.resume();
+        }
+      },
+    });
+    clients.push(client);
+    wss.on("connection", (socket) => {
+      peer = socket;
+      socket.send(
+        JSON.stringify({
+          type: "event",
+          event: "connect.challenge",
+          payload: { nonce: "synthetic-nonce", ts: Date.now() },
+        }),
+      );
+      socket.once("message", (raw) => {
+        const frame = JSON.parse(rawDataToString(raw)) as { id: string };
+        // Hold the peer's close reply until the real client has received both
+        // frames. updateNodeManifest starts closing through the public API.
+        socket.pause();
+        client.updateNodeManifest({ caps: [], commands: [] });
+        socket.send(
+          JSON.stringify({ type: "res", id: frame.id, ok: true, payload: { type: "hello-ok" } }),
+        );
+        socket.send(JSON.stringify({ type: "event", event: "late-hello-marker" }));
+      });
+    });
+    try {
+      client.start();
+      await closed.promise;
+      expect(markerReceived).toBe(true);
+      expect(onHelloOk).not.toHaveBeenCalled();
+      expect(onConnectError).toHaveBeenCalledExactlyOnceWith(
+        new Error("gateway closed (1012): node manifest changed"),
+      );
+      expect(onClose).toHaveBeenCalledExactlyOnceWith(
+        1012,
+        "node manifest changed",
+        expect.objectContaining({ phase: "pre-hello", connectRequestSent: true }),
+      );
+    } finally {
+      await client.stopAndWait();
+      for (const socket of wss.clients) {
+        socket.terminate();
+      }
+      await new Promise<void>((resolve) => {
+        wss.close(() => resolve());
+      });
+    }
+  });
 
   it("fails when a peer accepts TCP but never completes the websocket upgrade", async () => {
     // Accept TCP but never complete the websocket upgrade so missing

--- a/packages/gateway-client/src/protocol-client.handshake.test.ts
+++ b/packages/gateway-client/src/protocol-client.handshake.test.ts
@@ -1,3 +1,4 @@
+import assert from "node:assert/strict";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { GatewayProtocolClient, type GatewayProtocolSocketHandlers } from "./protocol-client.js";
 import { DEFAULT_PREAUTH_HANDSHAKE_TIMEOUT_MS } from "./timeouts.js";
@@ -10,8 +11,13 @@ type HandshakeConnection = {
 
 function createHandshakeClient(
   buildConnectPlan: () => Record<string, never> | Promise<Record<string, never>> = () => ({}),
+  delayClose = false,
 ) {
   const connections: HandshakeConnection[] = [];
+  const onHello = vi.fn();
+  const onConnectHello = vi.fn();
+  const onClose = vi.fn();
+  const onTiming = vi.fn();
   let nextRequestId = 0;
   const client = new GatewayProtocolClient<Record<string, never>>({
     createSocket: (handlers) => {
@@ -19,7 +25,9 @@ function createHandshakeClient(
       const send = vi.fn<(data: string) => void>();
       const close = vi.fn<(code?: number, reason?: string) => void>((code, reason) => {
         open = false;
-        handlers.close(code ?? 1000, reason ?? "");
+        if (!delayClose) {
+          handlers.close(code ?? 1000, reason ?? "");
+        }
       });
       connections.push({ handlers, send, close });
       return { isOpen: () => open, send, close };
@@ -28,10 +36,14 @@ function createHandshakeClient(
     buildConnectPlan,
     buildConnectParams: (plan) => plan,
     resolveClose: () => ({ retry: true, notify: true }),
+    onHello,
+    onConnectHello,
+    onClose,
+    onTiming,
     handshake: { mode: "require-challenge", timeoutMs: 100 },
     reconnect: { initialMs: 10, multiplier: 2, maxMs: 100 },
   });
-  return { client, connections };
+  return { client, connections, onHello, onConnectHello, onClose, onTiming };
 }
 
 function receiveConnectChallenge(connection: HandshakeConnection, ts = 1_800_000_000_000): void {
@@ -45,8 +57,121 @@ function receiveConnectChallenge(connection: HandshakeConnection, ts = 1_800_000
   );
 }
 
+function receiveHello(connection: HandshakeConnection): void {
+  const sent = connection.send.mock.calls[0];
+  assert(sent);
+  const request = JSON.parse(sent[0]) as { id: string };
+  connection.handlers.message(
+    JSON.stringify({ type: "res", id: request.id, ok: true, payload: { type: "hello-ok" } }),
+  );
+}
+
 describe("GatewayProtocolClient connect handshake", () => {
   afterEach(() => vi.useRealTimers());
+
+  it.each(["before response", "before publication"])(
+    "rejects hello when the connect deadline closes the transport %s",
+    async (closingOrder) => {
+      vi.useFakeTimers();
+      const { client, connections, onHello, onConnectHello, onClose, onTiming } =
+        createHandshakeClient(undefined, true);
+      try {
+        client.start();
+        const first = connections[0];
+        assert(first);
+        first.close(1012, "restart");
+        first.handlers.close(1012, "restart");
+        await vi.advanceTimersByTimeAsync(10);
+        const connection = connections[1];
+        assert(connection);
+        receiveConnectChallenge(connection);
+        const pending = client.request("status").catch((error: unknown) => error);
+
+        if (closingOrder === "before publication") {
+          receiveHello(connection);
+        }
+        // Advance synchronously so an already-resolved response publishes only
+        // after the deadline has moved the transport into its closing window.
+        vi.advanceTimersByTime(DEFAULT_PREAUTH_HANDSHAKE_TIMEOUT_MS);
+        expect(connection.close).toHaveBeenCalledExactlyOnceWith(4000, "connect timeout");
+        if (closingOrder === "before response") {
+          receiveHello(connection);
+        }
+        await vi.advanceTimersByTimeAsync(0);
+
+        expect(client.connected).toBe(false);
+        expect(client.connecting).toBe(true);
+        expect(onHello).not.toHaveBeenCalled();
+        expect(onConnectHello).not.toHaveBeenCalled();
+        expect(onTiming.mock.calls.some(([timing]) => timing.phase === "hello")).toBe(false);
+        expect(onClose).toHaveBeenCalledTimes(1);
+        expect(client.hasPendingRequests).toBe(true);
+        const onSent = vi.fn();
+        await expect(client.request("status", undefined, { onSent })).rejects.toThrow(
+          "gateway not connected",
+        );
+        expect(onSent).not.toHaveBeenCalled();
+
+        connection.handlers.close(4000, "connect timeout");
+        await expect(pending).resolves.toEqual(new Error("gateway closed (4000): connect timeout"));
+        expect(client.hasPendingRequests).toBe(false);
+        expect(onClose).toHaveBeenLastCalledWith(
+          expect.objectContaining({ helloReceived: false, connectRequestSent: true }),
+          { retry: true, notify: true },
+        );
+        // An unusable hello must not reset the second retry's exponential delay.
+        await vi.advanceTimersByTimeAsync(10);
+        expect(connections).toHaveLength(2);
+        await vi.advanceTimersByTimeAsync(10);
+        const replacement = connections[2];
+        assert(replacement);
+        receiveConnectChallenge(replacement);
+        receiveHello(replacement);
+        await vi.advanceTimersByTimeAsync(0);
+        expect(onHello).toHaveBeenCalledExactlyOnceWith({ type: "hello-ok" });
+        expect(onConnectHello).toHaveBeenCalledOnce();
+        expect(client.connecting).toBe(false);
+        expect(client.connected).toBe(true);
+        await vi.advanceTimersByTimeAsync(DEFAULT_PREAUTH_HANDSHAKE_TIMEOUT_MS);
+        expect(replacement.close).not.toHaveBeenCalled();
+        replacement.close(1012, "restart");
+        replacement.handlers.close(1012, "restart");
+        await vi.advanceTimersByTimeAsync(10);
+        expect(connections).toHaveLength(4);
+      } finally {
+        client.stop();
+      }
+    },
+  );
+
+  it.each([false, true])("suppresses a resolved hello after stop (restart=%s)", async (restart) => {
+    vi.useFakeTimers();
+    const { client, connections, onHello, onConnectHello } = createHandshakeClient();
+    try {
+      client.start();
+      const connection = connections[0];
+      assert(connection);
+      receiveConnectChallenge(connection);
+      receiveHello(connection);
+      client.stop();
+      if (restart) {
+        client.start();
+      }
+      await vi.advanceTimersByTimeAsync(0);
+      expect(onHello).not.toHaveBeenCalled();
+      expect(onConnectHello).not.toHaveBeenCalled();
+      if (restart) {
+        const replacement = connections[1];
+        assert(replacement);
+        receiveConnectChallenge(replacement);
+        receiveHello(replacement);
+        await vi.advanceTimersByTimeAsync(0);
+        expect(onHello).toHaveBeenCalledOnce();
+      }
+    } finally {
+      client.stop();
+    }
+  });
 
   it("reconnects when an open Gateway never responds to connect", async () => {
     vi.useFakeTimers();

--- a/packages/gateway-client/src/protocol-client.ts
+++ b/packages/gateway-client/src/protocol-client.ts
@@ -340,7 +340,9 @@ export class GatewayProtocolClient<TPlan> {
     this.connectRequestSent = true;
     void this.request<HelloOk>("connect", this.opts.buildConnectParams(plan))
       .then((hello) => {
-        if (!this.isActive(socket, generation)) {
+        // Closing transports remain current until their close callback runs;
+        // a late response must not publish readiness or reset reconnect backoff.
+        if (!this.isActive(socket, generation) || !socket.isOpen()) {
           return;
         }
         this.helloReceived = true;

--- a/ui/src/api/gateway.node.test.ts
+++ b/ui/src/api/gateway.node.test.ts
@@ -481,6 +481,59 @@ describe("GatewayBrowserClient", () => {
     vi.restoreAllMocks();
   });
 
+  it("does not publish hello when a response observer closes the browser socket", async () => {
+    useNodeFakeTimers();
+    const onHello = vi.fn();
+    const onClose = vi.fn();
+    const onConnectTiming = vi.fn();
+    const client = new GatewayBrowserClient({
+      url: DEFAULT_GATEWAY_URL,
+      onHello,
+      onClose,
+      onConnectTiming,
+      onRequestTiming: ({ method }) => {
+        if (method === "connect") {
+          client.forceReconnect("response observer closed");
+        }
+      },
+    });
+    try {
+      const { ws, connectFrame } = await startConnect(client);
+      ws.emitMessage({
+        type: "res",
+        id: connectFrame.id,
+        ok: true,
+        payload: {
+          type: "hello-ok",
+          auth: { role: "operator", deviceToken: "late-device-token", scopes: [] },
+        },
+      });
+      await vi.advanceTimersByTimeAsync(0);
+      expect(ws.lastClose).toEqual({ code: 4000, reason: "response observer closed" });
+      expect(onHello).not.toHaveBeenCalled();
+      expect(onClose).not.toHaveBeenCalled();
+      expect(loadDeviceAuthToken({ deviceId: "device-1", role: "operator" })?.token).toBe(
+        STORED_CRED,
+      );
+      expect(connectTimingPayloads(onConnectTiming).some(({ phase }) => phase === "hello")).toBe(
+        false,
+      );
+      ws.emitClose(4000, "response observer closed");
+      expect(onClose).toHaveBeenCalledWith(
+        expect.objectContaining({
+          code: 4000,
+          reason: "response observer closed",
+          willRetry: true,
+        }),
+      );
+      expect(connectTimingPayloads(onConnectTiming).at(-1)?.phase).toBe("failed");
+      await vi.advanceTimersByTimeAsync(800);
+      expect(getLatestWebSocket()).not.toBe(ws);
+    } finally {
+      client.stop();
+    }
+  });
+
   it("requests full control ui operator scopes with explicit shared auth", async () => {
     const client = new GatewayBrowserClient({
       url: "ws://127.0.0.1:18789",


### PR DESCRIPTION
Closes #132359

## What Problem This Solves

A Gateway client can publish a successful hello after its current WebSocket has started closing. Callers then receive readiness for a transport that rejects requests. The late success also resets reconnect backoff, changes pre-hello close reporting, and can perform hello-side device-token bookkeeping.

## Why This Change Was Made

Require the current transport to remain open when the shared protocol owner publishes hello. The existing generation/current-socket check alone is insufficient: a closing socket intentionally stays current until its close callback owns error reporting, pending-request cleanup, and reconnection. The repair reuses the existing `socket.isOpen()` predicate at that publication boundary and leaves `isActive`, timers, retry policy, authentication and the wire protocol unchanged.

The existing handshake fixtures cover both deadline orderings, stop/replacement, pending-request cleanup and retained exponential backoff. A real Node TCP/ws case starts closing through `updateNodeManifest` and holds only the peer's close reply until the client receives the delayed response. The browser case closes through the existing response observer after a response is admitted, before its promise continuation publishes hello. It does not simulate a late native browser message that the WebSockets standard would discard.

## User Impact

Closing attempts no longer report readiness or overwrite hello-side state. They retain the visible pre-hello failure and their existing reconnect delay; the next valid connection can publish hello and complete requests normally. No new configuration, persistence, dependency, API, protocol version, retry, timeout or fallback is introduced. The documented `onHelloOk` readiness contract remains unchanged.

## Evidence

Author base `cddb4db86493a6df0cf680f27e55769ee21c66dc`. Before editing, the unchanged 15-second deadline reproduction failed with `connected=false, helloCount=1`; a separate real TCP/ws reproduction published hello for the closing first connection and classified its close as post-hello. Both independently reproduced on current main, not only on the original repair branch.

On that author base, both original source reproductions now pass: the closing attempt publishes no hello, remains pre-hello for visible error/close reporting, and the replacement real WebSocket completes a status RPC. The three focused files passed 86 tests; five separate transport/request/sequence/reconnect siblings passed 70 tests, for 156 distinct current-main cases across eight files. A mistyped additional test path was rejected before execution and then corrected to the actual sibling files; no failed test was retried to green. The canonical package build passed and emitted 19 JavaScript/declaration files. Both built-entry probes passed: actual Node TCP/ws close/recovery/status, and the browser-safe entry with an injected transport and unchanged 15-second deadline. Fresh restricted Codex review of the full nonempty four-file delta passed with no actionable findings, retaining the original secret scan and isolation. The full changed gate passed, including all three unused-export scans, production/core-test typechecking, lint, i18n validation, import-cycle checks and the final store/auth guards. No native-browser or full-Gateway live proof is claimed.

```sh
OPENCLAW_VITEST_MAX_WORKERS=2 node scripts/run-vitest.mjs packages/gateway-client/src/protocol-client.handshake.test.ts packages/gateway-client/src/client.handshake.test.ts ui/src/api/gateway.node.test.ts
OPENCLAW_VITEST_MAX_WORKERS=2 node scripts/check-changed.mjs --base cddb4db86493a6df0cf680f27e55769ee21c66dc -- packages/gateway-client/src/protocol-client.ts packages/gateway-client/src/protocol-client.handshake.test.ts packages/gateway-client/src/client.handshake.test.ts ui/src/api/gateway.node.test.ts
pnpm --dir packages/gateway-client build
```

Original exact-source repair `d5d1210932f2b9d5ed59036f79079286124bcc5f` also passed 489 sibling cases before a test-only type correction, then 100 focused cases including that final correction, the full 29-check changed gate, a fresh restricted review, and the canonical standalone package build plus built Node/browser-entry probes. These overlapping counts are not additive and are not relabeled new-main proof. The original source build emitted 19 JavaScript/declaration files. Its Node probe used real TCP/ws and verified replacement-connection status recovery; its browser-entry probe used an injected transport, not a native browser process.

Source evidence map: Node `GatewayClient` and the Control UI browser adapter call the shared `GatewayProtocolClient`; pending-response settlement enters the hello continuation, which owns readiness/backoff/timing before the adapters perform hello-side state updates. `src/gateway/client.ts` injects host dependencies without changing that state machine. `ui/src/app/gateway-store.ts` projects `onHello` into connected application state. Close remains current until its authoritative callback retires the socket and pending requests. Complete affected modules, callers, siblings and dependency contracts were read. Installed [ws 8.21.3](https://github.com/websockets/ws/blob/8.21.3/lib/websocket.js) enters CLOSING synchronously but can deliver buffered messages before the final close event; the [browser standard](https://websockets.spec.whatwg.org/#feedback-from-the-protocol) instead drops incoming message tasks unless OPEN. The browser regression follows the valid already-admitted-response ordering.

Shipped-history limit: stable `v2026.7.1` predates the shared protocol module and clears its challenge timer when sending connect; its package client likewise publishes success without rechecking transport-open state. The current 15-second deadline reproduction is not claimed for that older implementation, and the shallow path history does not establish introduction attribution.

Test audit/LOC: production **+3/-1**, net **+2 comment lines and zero executable-line growth**; tests **+256/-3** in three existing files. One existing condition absorbs the repair; no new helper, path or general observer is added. The two comment lines explain why current-socket identity is not transport readiness.

This does not fix the separate announce fixture's runtime-discovery stall, missing prepared runtime, native source/Jiti publication split or the full release campaign. No new release, native Control UI proof, credential access or full Gateway/announce live-flow result is claimed here.


## Current main refresh

Rebased onto `24e12d4403571582d61e9c33c15efa9849f23ef6` as `71b3799bbd1f62601624e3a858508a68c89cf976`; all four approved file postimages are byte-identical to the prior PR head. Main already contains the canonical QA guard inventory repair (#132394), so this PR adds no QA or baseline changes.

Fresh current-head proof passed **159 distinct cases** across the eight focused/sibling files and rebuilt all 19 package JavaScript/declaration files. The built Node entry again exercised actual TCP/ws closing, pre-hello failure, replacement hello and a successful status request. The built browser entry's injected-transport probe again retained the unchanged 15-second deadline and observed `connected=false, helloCount=0`; no native browser or Control UI video proof is claimed. A fresh restricted review of the complete nonempty four-file patch reported no actionable findings. Production remains +3/-1 (zero executable growth, two explanatory comment lines); tests +256/-3.
