### PR TITLE
fix(compaction): restore fallback after safeguard provider failures

### DIFF
--- a/docs/concepts/compaction.md
+++ b/docs/concepts/compaction.md
@@ -90,7 +90,7 @@ Configure compaction under `agents.defaults.compaction` in your `openclaw.json`.
 
 ### Using a different model
 
-By default, compaction uses the agent's primary model. Set `agents.defaults.compaction.model` to delegate summarization to a more capable or specialized model. The override accepts a `provider/model-id` string or a bare alias configured under `agents.defaults.models`:
+The built-in OpenClaw runtime starts compaction with the active session model. Set `agents.defaults.compaction.model` to select a different summarization model. The override accepts a `provider/model-id` string or a bare alias configured under `agents.defaults.models`:
 
 ```json
 {
@@ -121,6 +121,8 @@ This works with local models too, for example a second Ollama model dedicated to
 ```
 
 When unset, compaction starts with the active session model. If summarization fails with a model-fallback-eligible provider error, OpenClaw retries that compaction attempt through the session's existing model fallback chain. The fallback choice is temporary and is not written back to session state. An explicit `agents.defaults.compaction.model` override remains exact and does not inherit the session fallback chain.
+
+In safeguard mode, provider timeouts and rate limits from built-in summarization remain eligible for that chain. Caller cancellation and failed safeguard quality checks do not trigger a model switch.
 
 ### Identifier preservation
 

--- a/extensions/reef/src/channel.test.ts
+++ b/extensions/reef/src/channel.test.ts
@@ -249,7 +249,10 @@ describe("Reef gateway account ownership", () => {
       }),
     );
     setReefRuntime(runtime);
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("Unexpected Reef relay request"));
     vi.spyOn(ReefTransportClient.prototype, "listFriends").mockResolvedValue({ friendships: [] });
+    // Startup reconciliation polls REST before the mocked inbox loop starts.
+    vi.spyOn(ReefTransportClient.prototype, "pull").mockResolvedValue({ entries: [], cursor: 0 });
     vi.spyOn(ReefInboxConnection.prototype, "start").mockImplementation(() => {
       const drain = createDeferred<void>();
       inboxDrains.push(drain);
@@ -265,12 +268,15 @@ describe("Reef gateway account ownership", () => {
       drain.resolve();
     }
     await Promise.allSettled(accountTasks.splice(0));
+    // Count only: failed assertions must not dump signed request headers.
+    const relayRequests = vi.mocked(fetch).mock.calls.length;
     vi.restoreAllMocks();
     vi.unstubAllEnvs();
     activeReefSlot.clearRuntime();
     reefRuntimeSlot.clearRuntime();
     resetPluginStateStoreForTests();
     fs.rmSync(stateDir, { recursive: true, force: true });
+    expect(relayRequests).toBe(0);
   });
 
   function startAccount() {

--- a/src/agents/agent-hooks/compaction-safeguard-runtime.ts
+++ b/src/agents/agent-hooks/compaction-safeguard-runtime.ts
@@ -3,6 +3,8 @@ import type { AgentCompactionIdentifierPolicy } from "../../config/types.agent-d
 import type { Model } from "../../llm/types.js";
 import { createSessionManagerRuntimeRegistry } from "./session-manager-runtime-registry.js";
 
+export type CompactionSafeguardCancellation = { reason: string; error?: unknown };
+
 /** Runtime knobs consumed by the compaction safeguard extension. */
 type CompactionSafeguardRuntimeValue = {
   maxHistoryShare?: number;
@@ -27,12 +29,8 @@ type CompactionSafeguardRuntimeValue = {
    * `summarize()` is called instead of the built-in `summarizeInStages()`.
    */
   provider?: string;
-  /**
-   * Pending human-readable cancel reason from the current safeguard compaction
-   * attempt. OpenClaw consumes this to replace the upstream generic
-   * "Compaction cancelled" message.
-   */
-  cancelReason?: string;
+  /** Hook cancellation hides provider errors behind AgentSession's generic error. */
+  cancellation?: CompactionSafeguardCancellation;
 };
 
 const registry = createSessionManagerRuntimeRegistry<CompactionSafeguardRuntimeValue>();
@@ -41,36 +39,33 @@ export const setCompactionSafeguardRuntime = registry.set;
 
 export const getCompactionSafeguardRuntime = registry.get;
 
-/** Stores a human-readable compaction cancel reason on the session runtime state. */
-export function setCompactionSafeguardCancelReason(
+/** Records cancellation atomically; intentional declines carry no provider error. */
+export function setCompactionSafeguardCancellation(
   sessionManager: unknown,
   reason: string | undefined,
+  error?: unknown,
 ): void {
   const current = getCompactionSafeguardRuntime(sessionManager);
   const trimmed = reason?.trim();
-
   if (!current && !trimmed) {
     return;
   }
   const next = { ...current };
   if (trimmed) {
-    next.cancelReason = trimmed;
+    next.cancellation = { reason: trimmed, ...(error !== undefined ? { error } : {}) };
   } else {
-    delete next.cancelReason;
+    delete next.cancellation;
   }
-  setCompactionSafeguardRuntime(sessionManager, next);
+  setCompactionSafeguardRuntime(sessionManager, Object.keys(next).length > 0 ? next : null);
 }
 
-/** Reads and clears the pending compaction cancel reason for one session manager. */
-export function consumeCompactionSafeguardCancelReason(sessionManager: unknown): string | null {
-  const current = getCompactionSafeguardRuntime(sessionManager);
-  const reason = current?.cancelReason?.trim();
-  if (!reason) {
-    return null;
+/** Consumes this attempt's cancellation without clearing session configuration. */
+export function consumeCompactionSafeguardCancellation(
+  sessionManager: unknown,
+): CompactionSafeguardCancellation | null {
+  const cancellation = getCompactionSafeguardRuntime(sessionManager)?.cancellation;
+  if (cancellation) {
+    setCompactionSafeguardCancellation(sessionManager, undefined);
   }
-
-  const next = { ...current };
-  delete next.cancelReason;
-  setCompactionSafeguardRuntime(sessionManager, Object.keys(next).length > 0 ? next : null);
-  return reason;
+  return cancellation ?? null;
 }

--- a/src/agents/agent-hooks/compaction-safeguard.test.ts
+++ b/src/agents/agent-hooks/compaction-safeguard.test.ts
@@ -25,9 +25,9 @@ import { jsonResult } from "../tools/common.js";
 import { MAX_WORKSPACE_BOOTSTRAP_FILE_BYTES } from "../workspace-bootstrap-read.js";
 import * as compactionQualityModule from "./compaction-safeguard-quality.js";
 import {
-  consumeCompactionSafeguardCancelReason,
+  consumeCompactionSafeguardCancellation,
   getCompactionSafeguardRuntime,
-  setCompactionSafeguardCancelReason,
+  setCompactionSafeguardCancellation,
   setCompactionSafeguardRuntime,
 } from "./compaction-safeguard-runtime.js";
 import compactionSafeguardExtension from "./compaction-safeguard.js";
@@ -889,22 +889,38 @@ describe("compaction-safeguard runtime registry", () => {
     });
   });
 
-  it("consumes cancel reasons without dropping other runtime fields", () => {
+  it("consumes cancellation provenance once without dropping other runtime fields", () => {
     const sm = {};
+    const error = Object.assign(new Error("provider unavailable"), { status: 503 });
     setCompactionSafeguardRuntime(sm, { maxHistoryShare: 0.6 });
-    setCompactionSafeguardCancelReason(sm, "no API key");
+    setCompactionSafeguardCancellation(sm, "summarization failed", error);
 
-    expect(consumeCompactionSafeguardCancelReason(sm)).toBe("no API key");
-    expect(consumeCompactionSafeguardCancelReason(sm)).toBeNull();
+    expect(consumeCompactionSafeguardCancellation(sm)).toEqual({
+      reason: "summarization failed",
+      error: expect.objectContaining({ message: "provider unavailable", status: 503 }),
+    });
+    expect(consumeCompactionSafeguardCancellation(sm)).toBeNull();
     expect(getCompactionSafeguardRuntime(sm)).toEqual({ maxHistoryShare: 0.6 });
   });
 
-  it("clears cancel reason when set to undefined", () => {
+  it("replaces provider failure provenance with an intentional decline atomically", () => {
     const sm = {};
-    setCompactionSafeguardCancelReason(sm, "temporary reason");
-    expect(consumeCompactionSafeguardCancelReason(sm)).toBe("temporary reason");
-    setCompactionSafeguardCancelReason(sm, undefined);
-    expect(consumeCompactionSafeguardCancelReason(sm)).toBeNull();
+    setCompactionSafeguardCancellation(sm, "summary failed", new Error("request timed out"));
+    setCompactionSafeguardCancellation(sm, "quality guard declined");
+
+    expect(consumeCompactionSafeguardCancellation(sm)).toEqual({
+      reason: "quality guard declined",
+    });
+    expect(getCompactionSafeguardRuntime(sm)).toBeNull();
+  });
+
+  it("clears the pending cancellation and its error before another attempt", () => {
+    const sm = {};
+    setCompactionSafeguardCancellation(sm, "summary failed", new Error("request timed out"));
+    setCompactionSafeguardCancellation(sm, undefined);
+
+    expect(consumeCompactionSafeguardCancellation(sm)).toBeNull();
+    expect(getCompactionSafeguardRuntime(sm)).toBeNull();
   });
 
   it("wires oversized safeguard runtime values when config validation is bypassed", () => {
@@ -1756,7 +1772,7 @@ describe("compaction-safeguard recent-turn preservation", () => {
     expect(result).not.toHaveProperty("compaction");
     expect(mockSummarizeInStages).toHaveBeenCalledTimes(1);
     expect(messagesToSummarize).toStrictEqual(transcriptBefore);
-    expect(consumeCompactionSafeguardCancelReason(sessionManager)).toBe(
+    expect(consumeCompactionSafeguardCancellation(sessionManager)?.reason).toBe(
       "Compaction safeguard could not summarize the session: " +
         "Failed to summarize dropped messages. | dropped prefix unavailable",
     );
@@ -1877,7 +1893,7 @@ describe("compaction-safeguard recent-turn preservation", () => {
 
     await expect(compactionHandler(event, mockContext)).rejects.toBe(abortError);
     expect(mockSummarizeInStages).toHaveBeenCalledTimes(1);
-    expect(consumeCompactionSafeguardCancelReason(sessionManager)).toBeNull();
+    expect(consumeCompactionSafeguardCancellation(sessionManager)).toBeNull();
     expect(messagesToSummarize).toStrictEqual(transcriptBefore);
   });
 
@@ -2091,7 +2107,7 @@ describe("compaction-safeguard recent-turn preservation", () => {
     expect(result).toEqual({ cancel: true });
     expect(result).not.toHaveProperty("compaction");
     expect(event.preparation.messagesToSummarize).toStrictEqual(transcriptBefore);
-    expect(consumeCompactionSafeguardCancelReason(sessionManager)).toContain(
+    expect(consumeCompactionSafeguardCancellation(sessionManager)?.reason).toContain(
       "Cannot convert undefined or null to object",
     );
   });
@@ -2250,7 +2266,7 @@ describe("compaction-safeguard recent-turn preservation", () => {
     expect(summary).toContain(`## Pending user asks\n${latestAsk}`);
     expect(summary).toContain(`## Exact identifiers\n${identifier}`);
     expect(mockSummarizeInStages).toHaveBeenCalledTimes(1);
-    expect(consumeCompactionSafeguardCancelReason(sessionManager)).toBeNull();
+    expect(consumeCompactionSafeguardCancellation(sessionManager)).toBeNull();
   });
 
   it("restores source identifiers omitted by an oversized generated summary", async () => {
@@ -2293,7 +2309,7 @@ describe("compaction-safeguard recent-turn preservation", () => {
     expect(summary.length).toBeLessThanOrEqual(MAX_COMPACTION_SUMMARY_CHARS);
     expect(summary).toContain(`## Exact identifiers\nNone.\n${identifier}`);
     expect(mockSummarizeInStages).toHaveBeenCalledTimes(1);
-    expect(consumeCompactionSafeguardCancelReason(sessionManager)).toBeNull();
+    expect(consumeCompactionSafeguardCancellation(sessionManager)).toBeNull();
   });
 
   it("keeps real sections when a re-distilled identifier list outgrows the budget", async () => {
@@ -2352,7 +2368,7 @@ describe("compaction-safeguard recent-turn preservation", () => {
     expect(identifiersSection.length).toBeLessThanOrEqual(
       MAX_COMPACTION_SUMMARY_CHARS * 0.25 + 200,
     );
-    expect(consumeCompactionSafeguardCancelReason(sessionManager)).toBeNull();
+    expect(consumeCompactionSafeguardCancellation(sessionManager)).toBeNull();
   });
 
   it("keeps surplus budget out of the protected sections when trimming", () => {
@@ -2436,7 +2452,7 @@ describe("compaction-safeguard recent-turn preservation", () => {
     expect(identifiersSection.length).toBeLessThanOrEqual(
       MAX_COMPACTION_SUMMARY_CHARS * 0.25 + 200,
     );
-    expect(consumeCompactionSafeguardCancelReason(sessionManager)).toBeNull();
+    expect(consumeCompactionSafeguardCancellation(sessionManager)).toBeNull();
   });
 
   it("restores source identifiers omitted by a generated summary that fits the budget", async () => {
@@ -2478,7 +2494,7 @@ describe("compaction-safeguard recent-turn preservation", () => {
     expect(summary).toContain(`## Exact identifiers\nNone.\n${identifier}`);
     expect(summary).not.toContain(SUMMARY_TRUNCATED_MARKER.trim());
     expect(mockSummarizeInStages).toHaveBeenCalledTimes(1);
-    expect(consumeCompactionSafeguardCancelReason(sessionManager)).toBeNull();
+    expect(consumeCompactionSafeguardCancellation(sessionManager)).toBeNull();
   });
 
   it("fails closed when audit-required tail sections cannot fit the artifact cap", async () => {
@@ -2519,7 +2535,7 @@ describe("compaction-safeguard recent-turn preservation", () => {
 
     expect(result).toEqual({ cancel: true });
     expect(mockSummarizeInStages).toHaveBeenCalledTimes(1);
-    expect(consumeCompactionSafeguardCancelReason(sessionManager)).toBe(
+    expect(consumeCompactionSafeguardCancellation(sessionManager)?.reason).toBe(
       "Compaction safeguard required facts exceed the finalized summary budget.",
     );
   });
@@ -2753,7 +2769,7 @@ describe("compaction-safeguard recent-turn preservation", () => {
 
     await expect(handler(event, context)).rejects.toBe(abortError);
     expect(mockSummarizeInStages).toHaveBeenCalledTimes(2);
-    expect(consumeCompactionSafeguardCancelReason(sessionManager)).toBeNull();
+    expect(consumeCompactionSafeguardCancellation(sessionManager)).toBeNull();
   });
 
   it.each([true, false])(
@@ -2831,7 +2847,7 @@ describe("compaction-safeguard recent-turn preservation", () => {
         expect(finalSummary).toContain("## Pending user asks\nNone.");
       } else {
         expect(result).toEqual({ cancel: true });
-        expect(consumeCompactionSafeguardCancelReason(sessionManager)).toContain(
+        expect(consumeCompactionSafeguardCancellation(sessionManager)?.reason).toContain(
           "failed quality checks",
         );
       }
@@ -3116,7 +3132,7 @@ describe("compaction-safeguard recent-turn preservation", () => {
     expect(auditInput.summary).toContain(identifier);
     expect(auditInput.summary).toContain(latestAsk);
     expect(mockAuditSummaryQuality.mock.results[0]?.value).toEqual({ ok: true, reasons: [] });
-    expect(consumeCompactionSafeguardCancelReason(sessionManager)).toBeNull();
+    expect(consumeCompactionSafeguardCancellation(sessionManager)).toBeNull();
   });
 
   it("retries when generated summary misses headings even if preserved turns contain them", async () => {
@@ -3370,7 +3386,7 @@ describe("compaction-safeguard recent-turn preservation", () => {
     expect(requireRecord(mockCallArg(mockSummarizeInStages, 1)).customInstructions).toContain(
       "Additional requirements:",
     );
-    expect(consumeCompactionSafeguardCancelReason(sessionManager)).toBe(
+    expect(consumeCompactionSafeguardCancellation(sessionManager)?.reason).toBe(
       "Compaction safeguard finalized summary failed quality checks and corrective generation failed.",
     );
     const terminalWarnings = compactionLogger.warn.mock.calls.flat().join("\n");

--- a/src/agents/agent-hooks/compaction-safeguard.ts
+++ b/src/agents/agent-hooks/compaction-safeguard.ts
@@ -69,7 +69,7 @@ import {
 } from "./compaction-safeguard-quality.js";
 import {
   getCompactionSafeguardRuntime,
-  setCompactionSafeguardCancelReason,
+  setCompactionSafeguardCancellation,
 } from "./compaction-safeguard-runtime.js";
 
 const log = createSubsystemLogger("compaction-safeguard");
@@ -967,7 +967,7 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
       containsRealConversation(
         stripRuntimeContextCustomMessages(collectSessionContextMessages(ctx.sessionManager)),
       );
-    setCompactionSafeguardCancelReason(ctx.sessionManager, undefined);
+    setCompactionSafeguardCancellation(ctx.sessionManager, undefined);
     if (!hasRealConversation) {
       // When there are no summarizable messages AND no real turn-prefix content,
       // cancelling compaction leaves context unchanged but the SDK re-triggers
@@ -1138,7 +1138,7 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
             "was not called and model was not passed through runtime registry.",
         );
       }
-      setCompactionSafeguardCancelReason(
+      setCompactionSafeguardCancellation(
         ctx.sessionManager,
         "Compaction safeguard could not resolve a summarization model.",
       );
@@ -1147,7 +1147,7 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
 
     const authResult = await resolveModelAuth(ctx, model);
     if (!authResult.ok) {
-      setCompactionSafeguardCancelReason(ctx.sessionManager, authResult.reason);
+      setCompactionSafeguardCancellation(ctx.sessionManager, authResult.reason);
       return { cancel: true };
     }
     try {
@@ -1334,7 +1334,7 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
               "Compaction safeguard: corrective generation failed; " +
                 `reasonCode=corrective_generation_failed attempt=${attempt + 1}`,
             );
-            setCompactionSafeguardCancelReason(
+            setCompactionSafeguardCancellation(
               ctx.sessionManager,
               "Compaction safeguard finalized summary failed quality checks and corrective generation failed.",
             );
@@ -1381,7 +1381,7 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
             "Compaction safeguard: required quality facts exceed finalized artifact budget; " +
               `requiredChars>${MAX_COMPACTION_SUMMARY_CHARS} identifierCount=${identifiers.length}`,
           );
-          setCompactionSafeguardCancelReason(
+          setCompactionSafeguardCancellation(
             ctx.sessionManager,
             "Compaction safeguard required facts exceed the finalized summary budget.",
           );
@@ -1407,7 +1407,7 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
             "Compaction safeguard: finalized summary failed quality checks; " +
               `reasonCodes=${reasonCodes.join(",")} reasonCount=${quality.reasons.length}`,
           );
-          setCompactionSafeguardCancelReason(
+          setCompactionSafeguardCancellation(
             ctx.sessionManager,
             "Compaction safeguard finalized summary failed quality checks.",
           );
@@ -1439,9 +1439,10 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
       log.warn(
         `Compaction summarization failed; cancelling compaction to preserve history: ${message}`,
       );
-      setCompactionSafeguardCancelReason(
+      setCompactionSafeguardCancellation(
         ctx.sessionManager,
         `Compaction safeguard could not summarize the session: ${message}`,
+        error,
       );
       return { cancel: true };
     }

--- a/src/agents/embedded-agent-runner/compact-reasons.test.ts
+++ b/src/agents/embedded-agent-runner/compact-reasons.test.ts
@@ -1,34 +1,73 @@
 // Classification coverage for compaction failure and skip reason telemetry.
 import { describe, expect, it } from "vitest";
+import { describeFailoverError, resolveFailoverReasonFromError } from "../failover-error.js";
 import {
   classifyCompactionReason,
   formatUnknownCompactionReasonDetail,
   isBenignCompactionSkipResult,
   isBenignCompactionSkipReason,
-  resolveCompactionFailureReason,
+  resolveCompactionFailure,
 } from "./compact-reasons.js";
 
-describe("resolveCompactionFailureReason", () => {
-  it("replaces generic compaction cancellation with the safeguard reason", () => {
-    // Safeguard cancellation is the actionable root cause; preserving only the
-    // generic cancellation text would hide the provider/auth failure.
-    expect(
-      resolveCompactionFailureReason({
-        reason: "Compaction cancelled",
-        safeguardCancelReason:
-          "Compaction safeguard could not resolve an API key for anthropic/claude-opus-4-6.",
-      }),
-    ).toBe("Compaction safeguard could not resolve an API key for anthropic/claude-opus-4-6.");
+describe("resolveCompactionFailure", () => {
+  const providerError = Object.assign(new Error("provider rejected the request"), {
+    status: 429,
+    code: "rate_limit_exceeded",
+  });
+  const safeguardCancellation = { reason: "Summarization could not finish.", error: providerError };
+
+  it.each(["Compaction cancelled", "Error: Compaction cancelled"])(
+    "recovers provider classification through the generic wrapper %s",
+    (message) => {
+      const failure = resolveCompactionFailure({
+        error: new Error(message),
+        safeguardCancellation,
+      });
+
+      expect(failure.reason).toBe(safeguardCancellation.reason);
+      expect(describeFailoverError(failure.error)).toMatchObject({
+        reason: "rate_limit",
+        status: 429,
+        code: "rate_limit_exceeded",
+      });
+    },
+  );
+
+  it("does not classify an intentional decline from keywords in its display reason", () => {
+    const failure = resolveCompactionFailure({
+      error: new Error("Compaction cancelled"),
+      safeguardCancellation: {
+        reason: "Quality audit rejected a summary about a request timeout.",
+      },
+    });
+
+    expect(failure.reason).toContain("Quality audit rejected");
+    expect(resolveFailoverReasonFromError(failure.error)).toBeNull();
   });
 
-  it("preserves non-generic compaction failures", () => {
-    expect(
-      resolveCompactionFailureReason({
-        reason: "Compaction timed out",
-        safeguardCancelReason:
-          "Compaction safeguard could not resolve an API key for anthropic/claude-opus-4-6.",
-      }),
-    ).toBe("Compaction timed out");
+  it.each([
+    new Error("Compaction timed out"),
+    Object.assign(new Error("Compaction cancelled"), { name: "AbortError" }),
+    Object.assign(new Error("Compaction cancelled"), { name: "TimeoutError" }),
+    new Error("session setup failed"),
+    new Error("cleanup failed"),
+  ])("preserves genuine $name/$message despite a stale cancellation record", (error) => {
+    const failure = resolveCompactionFailure({ error, safeguardCancellation });
+
+    expect(failure.reason).toBe(error.message);
+    expect(failure.error).toBe(error);
+  });
+
+  it("preserves caller cancellation even when its reason matches the generic wrapper", () => {
+    const error = new Error("Compaction cancelled");
+    const failure = resolveCompactionFailure({
+      error,
+      safeguardCancellation,
+      abortSignal: AbortSignal.abort(error),
+    });
+
+    expect(failure).toEqual({ reason: error.message, error });
+    expect(resolveFailoverReasonFromError(failure.error)).toBeNull();
   });
 });
 

--- a/src/agents/embedded-agent-runner/compact-reasons.ts
+++ b/src/agents/embedded-agent-runner/compact-reasons.ts
@@ -3,6 +3,8 @@
  */
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import { sanitizeForLog } from "../../../packages/terminal-core/src/ansi.js";
+import { formatErrorMessage } from "../../infra/errors.js";
+import type { CompactionSafeguardCancellation } from "../agent-hooks/compaction-safeguard-runtime.js";
 import { extractFailoverHttpStatus } from "../failover/retry-evidence.js";
 
 const MAX_COMPACTION_REASON_DETAIL_CHARS = 100;
@@ -17,15 +19,23 @@ function isGenericCompactionCancelledReason(reason: string): boolean {
   return normalized === "compaction cancelled" || normalized === "error: compaction cancelled";
 }
 
-/** Prefer a safeguard cancel reason when the runtime only reports generic cancellation. */
-export function resolveCompactionFailureReason(params: {
-  reason: string;
-  safeguardCancelReason?: string | null;
-}): string {
-  if (isGenericCompactionCancelledReason(params.reason) && params.safeguardCancelReason) {
-    return params.safeguardCancelReason;
-  }
-  return params.reason;
+/** Project display text and failure provenance together, without classifying intentional declines. */
+export function resolveCompactionFailure(params: {
+  error: unknown;
+  safeguardCancellation?: CompactionSafeguardCancellation | null;
+  abortSignal?: AbortSignal;
+}): { reason: string; error: unknown } {
+  const reason = formatErrorMessage(params.error);
+  // AgentSessionCompaction wraps hook cancellation in a plain Error("Compaction cancelled").
+  // Only that wrapper yields to safeguard provenance; genuine errors and caller aborts win.
+  const cancellation =
+    !params.abortSignal?.aborted &&
+    params.error instanceof Error &&
+    params.error.name === "Error" &&
+    isGenericCompactionCancelledReason(reason)
+      ? params.safeguardCancellation
+      : undefined;
+  return { reason: cancellation?.reason ?? reason, error: cancellation?.error ?? params.error };
 }
 
 /** Bucket a raw compaction reason into stable telemetry/status classes. */

--- a/src/agents/embedded-agent-runner/compact.hooks.harness.ts
+++ b/src/agents/embedded-agent-runner/compact.hooks.harness.ts
@@ -1092,16 +1092,15 @@ export async function loadCompactHooksHarness(): Promise<{
     };
   });
 
-  vi.doMock("../embedded-agent-helpers.js", () => ({
-    ensureSessionHeader: vi.fn(async () => {}),
-    pickFallbackThinkingLevel: vi.fn((params: { message?: string; attempted?: Set<string> }) =>
-      params.message?.includes("Reasoning is mandatory") && !params.attempted?.has("minimal")
-        ? "minimal"
-        : undefined,
-    ),
-    validateAnthropicTurns: vi.fn((m: unknown[]) => m),
-    validateGeminiTurns: vi.fn((m: unknown[]) => m),
-  }));
+  vi.doMock("../embedded-agent-helpers.js", async () => {
+    const { pickFallbackThinkingLevel } = await import("../embedded-agent-helpers/thinking.js");
+    return {
+      ensureSessionHeader: vi.fn(async () => {}),
+      pickFallbackThinkingLevel,
+      validateAnthropicTurns: vi.fn((m: unknown[]) => m),
+      validateGeminiTurns: vi.fn((m: unknown[]) => m),
+    };
+  });
 
   vi.doMock("../agent-project-settings.js", () => ({
     createPreparedEmbeddedAgentSettingsManager: createPreparedEmbeddedAgentSettingsManagerMock,

--- a/src/agents/embedded-agent-runner/compact.hooks.test.ts
+++ b/src/agents/embedded-agent-runner/compact.hooks.test.ts
@@ -4,7 +4,7 @@ import { mkdtemp, realpath, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { expectDefined } from "@openclaw/normalization-core";
-import type { AgentMessage } from "openclaw/plugin-sdk/agent-core";
+import type { AgentMessage, StreamFn } from "openclaw/plugin-sdk/agent-core";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi, type Mock } from "vitest";
 import { createDeferred } from "../../../test/helpers/promise.js";
 import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
@@ -12,6 +12,19 @@ import { createReplyOperation } from "../../auto-reply/reply/reply-run-registry.
 import { upsertSessionEntryCore } from "../../config/sessions/session-accessor.js";
 import type { PluginManifestRecord } from "../../plugins/manifest-registry.js";
 import { closeOpenClawAgentDatabasesForTest } from "../../state/openclaw-agent-db.js";
+import {
+  createAssistant,
+  createAssistantResultStream,
+  createTestSession,
+  registerAgentSessionLoopTestLifecycle,
+  testModel,
+} from "../sessions/agent-session-loop-correctness.test-support.js";
+import { createResourceLoader } from "../sessions/agent-session-loop-resource-loader.test-support.js";
+import { generateSummary as generateRealSummary } from "../sessions/compaction/compaction.js";
+import { createEventBus } from "../sessions/event-bus.js";
+import { createExtensionRuntime, loadExtensionFromFactory } from "../sessions/extensions/loader.js";
+import { SessionManager } from "../sessions/session-manager.js";
+import { SettingsManager } from "../sessions/settings-manager.js";
 import {
   acquireAgentRunPreparedModelRuntimeMock,
   attemptServerEndpointCompactionMock,
@@ -1681,6 +1694,199 @@ describe("compactEmbeddedAgentSessionDirect hooks", () => {
     if (fallbackCall[3] === undefined) {
       throw new Error("Expected fallback resolve-model options");
     }
+  });
+
+  describe("safeguard failure provenance", () => {
+    registerAgentSessionLoopTestLifecycle();
+    const originalHistoryLimit = expectDefined(
+      limitHistoryTurnsMock.getMockImplementation(),
+      "history-limit fixture implementation",
+    );
+
+    let safeguard: typeof import("../agent-hooks/compaction-safeguard.js").default;
+    let setSafeguardRuntime: typeof import("../agent-hooks/compaction-safeguard-runtime.js").setCompactionSafeguardRuntime;
+    let summaryBridge: typeof import("../sessions/index.js").generateSummary;
+
+    beforeAll(async () => {
+      // The outer harness resets modules and mocks the session SDK. Retain the real
+      // disposable session fixture above, but share the safeguard registry with the runner.
+      safeguard = (await import("../agent-hooks/compaction-safeguard.js")).default;
+      setSafeguardRuntime = (await import("../agent-hooks/compaction-safeguard-runtime.js"))
+        .setCompactionSafeguardRuntime;
+      summaryBridge = (await import("../sessions/index.js")).generateSummary;
+    });
+
+    afterEach(() => {
+      vi.mocked(summaryBridge).mockReset().mockResolvedValue("summary");
+      limitHistoryTurnsMock.mockImplementation(originalHistoryLimit);
+    });
+
+    it.each([
+      { scenario: "provider timeout", errorMessage: "request timed out", outcome: "fallback" },
+      {
+        scenario: "provider rate limit",
+        errorMessage: "429 rate limit exceeded",
+        outcome: "fallback",
+      },
+      { scenario: "intentional quality rejection", errorMessage: undefined, outcome: "cancel" },
+      { scenario: "explicit model timeout", errorMessage: "request timed out", outcome: "cancel" },
+      {
+        scenario: "reasoning-mandatory rejection",
+        errorMessage: "400 Reasoning is mandatory for this endpoint and cannot be disabled.",
+        outcome: "thinking",
+      },
+    ] as const)(
+      "keeps model fallback boundaries for $scenario",
+      async ({ scenario, errorMessage, outcome }) => {
+        const [
+          { createAgentSessionForEmbeddedRunner },
+          { guardSessionManager },
+          { resolveEmbeddedAgentStreamFn },
+          { buildEmbeddedExtensionFactories },
+        ] = await Promise.all([
+          import("../sessions/sdk.js"),
+          import("../session-tool-result-guard-wrapper.js"),
+          import("./stream-resolution.js"),
+          import("./extensions.js"),
+        ]);
+        const fallback = outcome === "fallback";
+        const primary = "summary-primary";
+        const backup = "summary-backup";
+        const explicitModel = scenario === "explicit model timeout";
+        const fallbackSummary = [
+          "## Decisions",
+          "Review the deployment checklist before rollout.",
+          "## Open TODOs",
+          "Compare the remaining options.",
+          "## Constraints/Rules",
+          "None.",
+          "## Pending user asks",
+          "Compare the remaining options.",
+          "## Exact identifiers",
+          "None.",
+        ].join("\n");
+        const sessionManager = SessionManager.inMemory(TEST_WORKSPACE_DIR);
+        for (const content of [
+          "Review the deployment checklist.",
+          "Compare the remaining options.",
+          "Keep the rollout notes.",
+        ]) {
+          sessionManager.appendMessage({ role: "user", content, timestamp: 1 });
+        }
+        const originalMessages = sessionManager.buildSessionContext().messages;
+        const settingsManager = SettingsManager.inMemory({
+          compaction: { enabled: false, reserveTokens: 1_024, keepRecentTokens: 1 },
+          retry: { enabled: false },
+        });
+        const extension = await loadExtensionFromFactory(
+          safeguard,
+          TEST_WORKSPACE_DIR,
+          createEventBus(),
+          createExtensionRuntime(),
+        );
+        const requestedModels: string[] = [];
+        const requestedThinking: Array<string | undefined> = [];
+        const stream = vi.fn<StreamFn>((activeModel, _context, options) => {
+          requestedModels.push(activeModel.id);
+          requestedThinking.push(options?.reasoning);
+          const rejected =
+            activeModel.id === primary &&
+            errorMessage &&
+            !(outcome === "thinking" && options?.reasoning === "minimal");
+          return createAssistantResultStream(
+            rejected
+              ? { ...createAssistant(activeModel, [], "error"), errorMessage }
+              : createAssistant(activeModel, [
+                  {
+                    type: "text",
+                    text: outcome === "cancel" ? "Missing required sections." : fallbackSummary,
+                  },
+                ]),
+          );
+        });
+        vi.mocked(summaryBridge).mockImplementation(generateRealSummary);
+        vi.mocked(guardSessionManager).mockReturnValue(sessionManager);
+        limitHistoryTurnsMock.mockImplementation((messages) => messages);
+        resolveEffectiveCompactionModeMock.mockReturnValue("safeguard");
+        vi.mocked(resolveEmbeddedAgentStreamFn).mockReturnValue(stream);
+        vi.mocked(buildEmbeddedExtensionFactories).mockImplementation(({ model }) => {
+          setSafeguardRuntime(sessionManager, {
+            model,
+            contextWindowTokens: 128_000,
+            recentTurnsPreserve: 0,
+            qualityGuardEnabled: true,
+            qualityGuardMaxRetries: 0,
+          });
+          return [];
+        });
+        vi.mocked(createAgentSessionForEmbeddedRunner).mockImplementation(
+          async ({ model, thinkingLevel }) => {
+            if (!model) {
+              throw new Error("Expected the prepared compaction model");
+            }
+            const created = await createTestSession({
+              model: {
+                ...testModel,
+                ...model,
+                reasoning: outcome === "thinking",
+                maxTokens: 1_024,
+              },
+              sessionManager,
+              settingsManager,
+              resourceLoader: createResourceLoader(extension.handlers),
+            });
+            created.session.setThinkingLevel(thinkingLevel ?? "off");
+            return created;
+          },
+        );
+        const config = {
+          agents: {
+            defaults: {
+              model: { primary: `openai/${primary}`, fallbacks: [`openai/${backup}`] },
+              compaction: {
+                mode: "safeguard" as const,
+                thinkingLevel: "off" as const,
+                ...(explicitModel ? { model: `openai/${primary}` } : {}),
+                recentTurnsPreserve: 0,
+                qualityGuard: { enabled: true, maxRetries: 0 },
+              },
+            },
+          },
+        };
+        const configBefore = structuredClone(config);
+
+        const result = await compactEmbeddedAgentSessionDirect(
+          wrappedCompactionArgs({ provider: "openai", model: primary, config }),
+        );
+
+        expect([...new Set(requestedModels)], JSON.stringify(result)).toEqual(
+          fallback ? [primary, backup] : [primary],
+        );
+        expect(config).toEqual(configBefore);
+        if (outcome !== "cancel") {
+          if (outcome === "thinking") {
+            expect([...new Set(requestedThinking)]).toEqual(["off", "minimal"]);
+          }
+          expect(result).toMatchObject({
+            ok: true,
+            compacted: true,
+            result: { summary: fallbackSummary },
+          });
+          expect(
+            sessionManager.getBranch().findLast((entry) => entry.type === "compaction"),
+          ).toMatchObject({
+            summary: fallbackSummary,
+          });
+        } else {
+          expect(result).toMatchObject({ ok: false, compacted: false });
+          expect(result.reason).toMatch(explicitModel ? /timed out/i : /quality/i);
+          expect(sessionManager.getEntries().some((entry) => entry.type === "compaction")).toBe(
+            false,
+          );
+          expect(sessionManager.buildSessionContext().messages).toEqual(originalMessages);
+        }
+      },
+    );
   });
 
   it("plans runtime plugins for the canonical model behind a fallback alias", async () => {

--- a/src/agents/embedded-agent-runner/compaction-session-execution.ts
+++ b/src/agents/embedded-agent-runner/compaction-session-execution.ts
@@ -19,8 +19,9 @@ import {
 import { getCurrentPluginMetadataSnapshot } from "../../plugins/current-plugin-metadata-snapshot.js";
 import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
 import {
-  consumeCompactionSafeguardCancelReason,
-  setCompactionSafeguardCancelReason,
+  consumeCompactionSafeguardCancellation,
+  getCompactionSafeguardRuntime,
+  setCompactionSafeguardCancellation,
 } from "../agent-hooks/compaction-safeguard-runtime.js";
 import { createPreparedEmbeddedAgentSettingsManager } from "../agent-project-settings.js";
 import {
@@ -37,7 +38,7 @@ import { agentSessionAutomaticCompaction } from "../sessions/agent-session-compa
 import { type AgentSession, estimateTokens, SessionManager } from "../sessions/index.js";
 import { getModelRegistryRuntime } from "../sessions/model-registry-runtime.js";
 import { createAgentSessionForEmbeddedRunner } from "../sessions/sdk.js";
-import { resolveCompactionFailureReason } from "./compact-reasons.js";
+import { resolveCompactionFailure } from "./compact-reasons.js";
 import { compactionCheckpointStore, persistCompactionCheckpoint } from "./compaction-checkpoint.js";
 import {
   containsRealConversationMessages,
@@ -226,6 +227,8 @@ export async function executePreparedCompactionSession(runtime: PreparedCompacti
         apiRegistry: getModelRegistryRuntime(modelRegistry).apiRegistry,
       });
       while (true) {
+        // A thinking retry starts a new attempt; setup/endpoint failures must not reuse its predecessor's cause.
+        setCompactionSafeguardCancellation(sessionManager, undefined);
         // Rebuild the compaction session on retry so provider wrappers, payload
         // shaping, and the embedded system prompt all reflect the fallback level.
         attemptedThinking.add(thinkLevel);
@@ -455,13 +458,11 @@ export async function executePreparedCompactionSession(runtime: PreparedCompacti
           const clientResult = serverResult
             ? undefined
             : await compactWithSafetyTimeout(
-                () => {
-                  setCompactionSafeguardCancelReason(compactionSessionManager, undefined);
-                  return resolveEffectiveCompactionMode(params.config) === "default" &&
-                    trigger !== "manual"
+                () =>
+                  resolveEffectiveCompactionMode(params.config) === "default" &&
+                  trigger !== "manual"
                     ? activeSession[agentSessionAutomaticCompaction](params.customInstructions)
-                    : activeSession.compact(params.customInstructions);
-                },
+                    : activeSession.compact(params.customInstructions),
                 compactionTimeoutMs,
                 {
                   abortSignal: params.abortSignal,
@@ -579,8 +580,13 @@ export async function executePreparedCompactionSession(runtime: PreparedCompacti
             },
           };
         } catch (err) {
+          const failure = resolveCompactionFailure({
+            error: err,
+            safeguardCancellation: getCompactionSafeguardRuntime(sessionManager)?.cancellation,
+            abortSignal: params.abortSignal,
+          });
           const fallbackThinking = pickFallbackThinkingLevel({
-            message: formatErrorMessage(err),
+            message: formatErrorMessage(failure.error),
             attempted: attemptedThinking,
           });
           if (fallbackThinking) {
@@ -618,11 +624,12 @@ export async function executePreparedCompactionSession(runtime: PreparedCompacti
       await runtime.disposeToolRuntimes();
     }
   } catch (err) {
-    const reason = resolveCompactionFailureReason({
-      reason: formatErrorMessage(err),
-      safeguardCancelReason: consumeCompactionSafeguardCancelReason(compactionSessionManager),
+    const failure = resolveCompactionFailure({
+      error: err,
+      safeguardCancellation: consumeCompactionSafeguardCancellation(compactionSessionManager),
+      abortSignal: params.abortSignal,
     });
-    return fail(reason, err);
+    return fail(failure.reason, failure.error);
   } finally {
     if (!checkpointSnapshotRetained) {
       await compactionCheckpointStore.cleanupSnapshot(checkpointSnapshot);

--- a/src/agents/embedded-agent-runner/direct-compaction.ts
+++ b/src/agents/embedded-agent-runner/direct-compaction.ts
@@ -1,6 +1,5 @@
 /** Coordinates one direct compaction attempt through explicit lifecycle phases. */
 import { formatErrorMessage } from "../../infra/errors.js";
-import { resolveCompactionFailureReason } from "./compact-reasons.js";
 import { executePreparedCompactionSession } from "./compaction-session-execution.js";
 import {
   prepareDirectCompactionAttempt,
@@ -24,11 +23,7 @@ export async function compactEmbeddedAgentSessionDirectOnce(
     runtime = await buildPreparedCompactionRuntime(preparation.value);
     return await executePreparedCompactionSession(runtime);
   } catch (err) {
-    const reason = resolveCompactionFailureReason({
-      reason: formatErrorMessage(err),
-      safeguardCancelReason: undefined,
-    });
-    return preparation.value.fail(reason, err);
+    return preparation.value.fail(formatErrorMessage(err), err);
   } finally {
     await runtime?.dispose();
   }


### PR DESCRIPTION
Closes #99943 — compaction provider timeouts bypass the configured model fallback chain.

## What Problem This Solves

Fixes an issue where users compacting a session would receive a safeguard failure without trying their configured backup model when built-in summarization timed out or hit a rate limit. The same lost failure detail could prevent the existing reasoning-level recovery from running.

The [current composed reproduction](https://github.com/openclaw/openclaw/issues/99943#issuecomment-5460596444) distinguishes this from the earlier investigation: the shared classifier already recognizes timeout text, but the failing path supplies `Compaction cancelled` instead. Thanks @mettlyz11 for reporting the fallback symptom.

## Why This Change Was Made

The safeguard now retains the original summarization failure alongside its display reason in the existing session-scoped cancellation record. The compaction execution owner resolves both together after AgentSession's generic cancellation wrapper, allowing the existing model/thinking recovery policies to see the real failure. Genuine errors and active caller cancellation remain authoritative; intentional quality declines carry no provider error.

Each rebuilt attempt clears its predecessor's cancellation, and terminal failure consumes the record once. This replaces the reason-only path rather than adding another registry, classifier, public hook result, or compatibility alias. Native harness ownership, configured compaction providers, smaller-transcript recovery, and timeout budgets are unchanged.

## User Impact

With `compaction.model` unset, eligible built-in summarization failures can use the session's existing backup-model chain without changing the session's model preferences. Explicit compaction-model selection stays exact. Caller cancellation and failed safeguard quality checks do not become reasons to switch models. The [compaction documentation](https://docs.openclaw.ai/concepts/compaction#using-a-different-model) now states these boundaries and correctly identifies the active session model as the starting model.

No new configuration, default, schema, dependency, or persistent-state contract is introduced. AI-assisted implementation; the owning source, callers, actual cancellation conversion, extension exception-isolation contract, and sibling paths were inspected.

## Evidence

### Regression and local validation

Before the production repair, the composed timeout and rate-limit regressions failed while five controls passed. They use the real safeguard, summary pipeline, disposable AgentSession, cancellation conversion, and outer fallback coordinator; only host dependencies and the provider stream are injected. A separate reasoning-mandatory rejection also failed to retry with the supported thinking level.

Afterward, **412 distinct owner/sibling cases passed**: compact hooks 159, safeguard/registry 149, failure projection 45, runtime context/selection 47, and AgentSession compaction 12. The final eight-case focused recheck passed after removing an unnecessary setup-error adapter call:

```bash
node scripts/run-vitest.mjs src/agents/embedded-agent-runner/compact.hooks.test.ts -t 'safeguard failure provenance|keeps compaction fallback selection ephemeral|preserves explicit compaction.model behavior|aborts in-flight compaction' --maxWorkers=1
```

Normal `pnpm build`, `git diff --check`, and the canonical ten-file `node scripts/check-changed.mjs -- <changed paths>` run passed, including core/core-test typechecks, targeted lint, formatting, dead exports, and runtime import cycles. Fresh isolated Codex autoreview reported no P0 findings; it was P0-scoped and did not run tests, not an all-severity approval.

Production is **+68/−60 (net +8)**; tests/support **+321/−55 (net +266)**, including the six-line Reef CI fixture repair below; docs **+3/−1**. The small production increase carries the original failure and caller-abort precedence at their existing owner boundary; duplicate clearing/consumption and the redundant setup adapter were removed. The hooks harness is test support, not production.

### CI refresh

The first [exact-head CI run](https://github.com/openclaw/openclaw/actions/runs/33239748126) failed only the existing QA suppression inventory in `checks-node-compact-small-36`: the merge-ref contained two intentional credential-redaction suppressions while the inventory still expected one. The correction was already merged on `main` in [PR #132394 — worker-slot UI plus the inventory correction](https://github.com/openclaw/openclaw/pull/132394). Rebased onto `c1473eac606d6445e9f74ba2d534b5236cdd71c9` to include that existing fix; no additional suppression or product fix was added here.

The first refreshed candidate was `f69b260fc6eaf6a813f15406fa2baca7325c17da`. `git range-diff` reports the repair unchanged, and all five production-file hashes still match the reviewed/Gateway-tested candidate. The inventory test's four cases and the eight focused compaction cases pass after the rebase. Fresh exact-head CI is required before landing.

The [second CI run](https://github.com/openclaw/openclaw/actions/runs/33240428013) cleared that inventory failure but found another inherited main failure: `src/infra/state-migrations.media-persistence.test.ts` had 1,034 counted lines against the 1,000-line limit. Waited for the existing test-only helper extraction to land in [PR #132444 — planner test startup cleanup](https://github.com/openclaw/openclaw/pull/132444), then rebased onto its merge `9d79bf3f8c5f18f7c35d028d57402f5085659640`. No duplicate fix, raised limit, suppression, or removed assertion was added here.

The next candidate, `4d919efadf52ddee24d8fdb83e5f8edf962a616c`, kept the repair patch-identical and all five production-file hashes matched the reviewed/Gateway-tested source. All 15 migration tests, targeted migration test/support lint, and all eight focused compaction cases passed after that refresh.

The [third CI run](https://github.com/openclaw/openclaw/actions/runs/33241239672) then exposed a separate incomplete Reef unit-test fixture: startup now performs REST inbox reconciliation before starting the mocked inbox loop, but the account-ownership fixture did not mock `pull()`, so it could reach the real relay. No exact existing repair was found. The six-line test-only fix supplies an empty inbox response and guards against future external fetches without changing production code, timeout values, or authority-retirement assertions.

Safe whole-file reproduction with a rejecting fetch spy caught attempted network-call counts **1, 2, 1, 3** across the four ownership cases while 17 controls passed; no real requests were sent. Completing the missing transport mock makes all 21 file cases pass, and the full Reef suite passes **315 tests in 24 files**, with targeted lint. The guard asserts only the call count after cleanup so a failure cannot dump signed headers. This is deterministic fixture-boundary evidence, not a claim of identical CI per-worker scheduling; the original full extension-suite CI envelope will rerun.

Current candidate: `fa6fdd1ed1bd7b7b275f2aa3b98b6ce6cbc6a304`. Fresh isolated Codex autoreview of the full compaction repair plus this fixture change reports no actionable P0 findings (P0-scoped; no tests run by the reviewer). [Exact-head CI is now green](https://github.com/openclaw/openclaw/actions/runs/33242390477), including `openclaw/ci-gate`; no checks were bypassed. The latest ClawSweeper review covers this exact head and has no actionable findings, and its remaining CI rank-up move is complete.

The [ClawSweeper review](https://github.com/openclaw/openclaw/pull/132449#issuecomment-5460985453) found no actionable code or security defects. Its rank-up move is to resolve CI; maintainer handling is to land this focused repair only after the refreshed required checks are green. The rebase is mechanical and does not change the reviewed repair's behavior.

### Candidate Gateway proof

**PASS for recovery and the explicit-model control**, using a real built Gateway, inbound qa-channel `/compact`, and the existing loopback HTTP mock/fault proxy. Provider: `blacksmith-testbox`; lease: `tbx_01m163s4htckkrbg492paa1qhq`; [Testbox environment run](https://github.com/openclaw/openclaw/actions/runs/33238905260). One normal `OPENCLAW_BUILD_PRIVATE_QA=1 pnpm build` supplied both cases. Empty owned HOME/config/state and separate loopback-only network namespaces; only normal disposable mock credentials.

```json
{
  "candidateRecovery": {"verdict":"PASS","primaryHttp408Responses":3,"backupSummaryRequests":1,"distinctBackupCredential":true,"acceptedCompactions":1,"compactionCountDelta":1,"delivered":"compacted"},
  "explicitModelControl": {"verdict":"PASS","primaryHttp408Responses":3,"backupSummaryRequests":0,"acceptedCompactions":0,"compactionCountDelta":0,"delivered":"compaction-failed"},
  "bothCases": {"originalHistoryDurable":true,"sameSessionAndRoute":true,"modelPreferencesUnchanged":true,"originalModelFollowupDelivered":true,"expectedFollowupContext":true,"noSecondCompaction":true,"sourceAndBuildStable":true,"gatewayStopped":true,"ownedPortsClosed":true,"runtimeStateRemoved":true}
}
```

Recovery persisted an 867-character `fromHook` summary with all required headings and the default three recent turns. Every summary request carried the actual eight-message history; the retained user tail remained outside summarization. The backup used a distinct disposable profile credential, and follow-up returned to the original primary credential/model. No credential values or credential hashes were exported.

Source identity: committed candidate `2d3e05c7b8d025756f04321ffe3905dbf31f2eba` is byte-identical to the tested patch against base `ecfbad65d0c32f143def0bf360d7417b835e73f6` (patch SHA-256 `ed341e80681f02c7c17e62ceb01e964459737c6e3cf5dff3ea7343ea1d4b8e3b`); all ten synced file-content hashes matched with no additional source changes. Both cells checked the actual remote HEAD/patch and representative build entries before and after execution. Driver SHA-256: `5f0a292e44351133cc920d61a9eece332fe003acc489b2493021bc36d501f568`.

The first proof attempt completed its behavior assertions but failed final Git inspection: running the Gateway as root left the task checkout's index root-owned and unreadable by its owner. A diagnostic confirmed the permission failure. The corrected launcher uses root only for network-namespace setup, then runs the whole driver/Gateway as the checkout owner. The index's original ownership was restored without changing its bytes; no product change, `safe.directory` override, broader permission grant, or removed assertion was needed. Both complete reruns passed.

This is **mock-provider HTTP/Gateway proof**, not authenticated external-provider, OAuth, or native-Codex proof. The composed RED run supplies before evidence; the explicit-model Gateway case is a candidate control, not a pre-fix run. Rate-limit provenance, quality rejection, caller cancellation, and reasoning-level recovery are covered by the composed/owner regressions. No semantic-fidelity claim is made for the synthetic summary.
