### PR TITLE
feat(gateway): expose provider account priority

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewayProtocol.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewayProtocol.kt
@@ -897,6 +897,7 @@ enum class GatewayMethod(
   SessionsTitlePrepare("sessions.title.prepare"),
   TranscriptsList("transcripts.list"),
   TranscriptsGet("transcripts.get"),
+  ModelsAuthOrderSet("models.authOrderSet"),
 }
 
 enum class GatewayEvent(

--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -15646,6 +15646,28 @@ public struct ModelsAuthLogoutParams: Codable, Sendable {
     }
 }
 
+public struct ModelsAuthOrderSetParams: Codable, Sendable {
+    public let provider: String
+    public let profileids: [String]?
+    public let agentid: String?
+
+    public init(
+        provider: String,
+        profileids: [String]? = nil,
+        agentid: String? = nil)
+    {
+        self.provider = provider
+        self.profileids = profileids
+        self.agentid = agentid
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case provider
+        case profileids = "profileIds"
+        case agentid = "agentId"
+    }
+}
+
 public struct ModelsAuthStatusParams: Codable, Sendable {
     public let refresh: Bool?
     public let agentid: String?

--- a/packages/gateway-protocol/src/public-schema.ts
+++ b/packages/gateway-protocol/src/public-schema.ts
@@ -491,6 +491,7 @@ export {
   PluginsUninstallParamsSchema,
   PluginsUninstallResultSchema,
   ModelsAuthLogoutParamsSchema,
+  ModelsAuthOrderSetParamsSchema,
   ModelsAuthStatusParamsSchema,
   ModelsListParamsSchema,
   AuthProbeStatusSchema,

--- a/packages/gateway-protocol/src/schema/agents-models-skills.test.ts
+++ b/packages/gateway-protocol/src/schema/agents-models-skills.test.ts
@@ -7,6 +7,7 @@ import {
   AgentsListResultSchema,
   AgentsUpdateParamsSchema,
   ModelsAuthLogoutParamsSchema,
+  ModelsAuthOrderSetParamsSchema,
   ModelsAuthStatusParamsSchema,
   ModelsListParamsSchema,
   ModelsListResultSchema,
@@ -275,6 +276,17 @@ describe("Models auth params schemas", () => {
       { provider: "openai", agentId: "" },
     );
     expectRejected(ModelsAuthLogoutParamsSchema, { provider: "openai", profileIds: [] });
+    expectAccepted(
+      ModelsAuthOrderSetParamsSchema,
+      { provider: "openai", profileIds: ["openai:writer"] },
+      { provider: "openai", agentId: "writer" },
+    );
+    expectRejected(
+      ModelsAuthOrderSetParamsSchema,
+      { provider: "openai", profileIds: [] },
+      { provider: "openai", profileIds: null },
+      { provider: "openai", profileIds: ["openai:writer", "openai:writer"] },
+    );
   });
 });
 

--- a/packages/gateway-protocol/src/schema/agents-models-skills.ts
+++ b/packages/gateway-protocol/src/schema/agents-models-skills.ts
@@ -312,6 +312,13 @@ export const ModelsAuthLogoutParamsSchema = closedObject({
   agentId: Type.Optional(Type.String()),
 });
 
+/** Sets or clears the preferred auth-profile order for one provider and agent. */
+export const ModelsAuthOrderSetParamsSchema = closedObject({
+  provider: NonEmptyString,
+  profileIds: Type.Optional(Type.Array(NonEmptyString, { minItems: 1, uniqueItems: true })),
+  agentId: Type.Optional(Type.String()),
+});
+
 /** Model catalog result. */
 export const ModelCatalogProviderOutcomeSchema = closedObject({
   provider: NonEmptyString,
@@ -1426,6 +1433,7 @@ export type ModelCatalogProviderOutcome = Static<typeof ModelCatalogProviderOutc
 export type ModelsListResult = Static<typeof ModelsListResultSchema>;
 export type ModelsAuthStatusParams = Static<typeof ModelsAuthStatusParamsSchema>;
 export type ModelsAuthLogoutParams = Static<typeof ModelsAuthLogoutParamsSchema>;
+export type ModelsAuthOrderSetParams = Static<typeof ModelsAuthOrderSetParamsSchema>;
 export type AuthProbeStatus = Static<typeof AuthProbeStatusSchema>;
 export type ModelsProbeParams = Static<typeof ModelsProbeParamsSchema>;
 export type ModelsProbeTargetResult = Static<typeof ModelsProbeTargetResultSchema>;

--- a/packages/gateway-protocol/src/schema/protocol-schema-fragment-agents-skills.ts
+++ b/packages/gateway-protocol/src/schema/protocol-schema-fragment-agents-skills.ts
@@ -51,6 +51,7 @@ export const AgentSkillProtocolSchemas = {
   AgentsListResult: agentsModelsSkills.AgentsListResultSchema,
   ModelChoice: agentsModelsSkills.ModelChoiceSchema,
   ModelsAuthLogoutParams: agentsModelsSkills.ModelsAuthLogoutParamsSchema,
+  ModelsAuthOrderSetParams: agentsModelsSkills.ModelsAuthOrderSetParamsSchema,
   ModelsAuthStatusParams: agentsModelsSkills.ModelsAuthStatusParamsSchema,
   ModelsListParams: agentsModelsSkills.ModelsListParamsSchema,
   ModelsListResult: agentsModelsSkills.ModelsListResultSchema,

--- a/packages/gateway-protocol/src/validator-registry.ts
+++ b/packages/gateway-protocol/src/validator-registry.ts
@@ -377,6 +377,7 @@ export const validateChannelsStartParams = compile(S.ChannelsStartParamsSchema);
 export const validateChannelsStopParams = compile(S.ChannelsStopParamsSchema);
 export const validateChannelsLogoutParams = compile(S.ChannelsLogoutParamsSchema);
 export const validateModelsAuthLogoutParams = compile(S.ModelsAuthLogoutParamsSchema);
+export const validateModelsAuthOrderSetParams = compile(S.ModelsAuthOrderSetParamsSchema);
 export const validateModelsAuthStatusParams = compile(S.ModelsAuthStatusParamsSchema);
 export const validateModelsListParams = compile(S.ModelsListParamsSchema);
 export const validateSkillsStatusParams = compile(S.SkillsStatusParamsSchema);

--- a/src/agents/auth-profiles.ts
+++ b/src/agents/auth-profiles.ts
@@ -10,6 +10,7 @@ export type {
 } from "./auth-profiles/credential-state.js";
 export type { AuthProfileEligibilityReasonCode } from "./auth-profiles/order.js";
 export { resolveAuthProfileDisplayLabel } from "./auth-profiles/display.js";
+export { resolveAuthProfileMetadata } from "./auth-profiles/identity.js";
 export { formatAuthDoctorHint } from "./auth-profiles/doctor.js";
 export {
   externalCliDiscoveryForConfigStatus,
@@ -26,6 +27,7 @@ export {
   isConfiguredAwsSdkAuthProfileForProvider,
   isStoredCredentialCompatibleWithAuthProvider,
   resolveAuthProfileEligibility,
+  resolveExplicitAuthOrderSelection,
   resolveAuthProfileOrder,
 } from "./auth-profiles/order.js";
 export {
@@ -92,6 +94,7 @@ export type {
   AuthProfileStore,
   OAuthCredential,
   ProfileUsageStats,
+  RuntimeAuthProfileStore,
   TokenCredential,
 } from "./auth-profiles/types.js";
 export {

--- a/src/agents/auth-profiles/profiles.test.ts
+++ b/src/agents/auth-profiles/profiles.test.ts
@@ -8,6 +8,7 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { resolveOAuthDir } from "../../config/paths.js";
+import { writeConfigMachineState } from "../../state/config-machine-state.js";
 import {
   closeOpenClawAgentDatabasesForTest,
   openOpenClawAgentDatabase,
@@ -21,6 +22,7 @@ import {
   getRuntimeAuthProfileStoreStateMutationToken,
 } from "./mutation-lineage.js";
 import { resolveApiKeyForProfile } from "./oauth.js";
+import { reloadSharedAuthStoreOwnership, SHARED_AUTH_STORE_STATE_KEY } from "./path-resolve.js";
 import { loadPersistedAuthProfileStore } from "./persisted.js";
 import {
   clearLastGoodProfileWithLock,
@@ -1825,6 +1827,53 @@ describe("promoteAuthProfileInOrder", () => {
 });
 
 describe("setAuthProfileOrder", () => {
+  it("writes an explicit main-agent order to the canonical shared store", async () => {
+    await withAuthProfileTestState(
+      "openclaw-auth-order-set-shared-main-",
+      async ({ agentDir }) => {
+        writeConfigMachineState(
+          SHARED_AUTH_STORE_STATE_KEY,
+          { location: "state-db" },
+          { env: process.env },
+        );
+        reloadSharedAuthStoreOwnership(process.env);
+        saveAuthProfileStore({
+          version: AUTH_STORE_VERSION,
+          profiles: {
+            "openai:first": {
+              type: "oauth",
+              provider: "openai",
+              access: "first",
+              refresh: "first-refresh",
+              expires: Date.now() + 60_000,
+            },
+            "openai:second": {
+              type: "oauth",
+              provider: "openai",
+              access: "second",
+              refresh: "second-refresh",
+              expires: Date.now() + 60_000,
+            },
+          },
+          order: { openai: ["openai:first", "openai:second"] },
+        });
+
+        await setAuthProfileOrder({
+          agentDir,
+          provider: "openai",
+          order: ["openai:second", "openai:first"],
+          sharedStoreWrite: true,
+        });
+
+        expect(loadPersistedAuthProfileStore()?.order?.openai).toEqual([
+          "openai:second",
+          "openai:first",
+        ]);
+      },
+      { clearOAuthDir: true },
+    );
+  });
+
   it("canonicalizes every alias-equivalent provider state mutation", async () => {
     await withAuthProfileTestState("openclaw-auth-alias-state-", async ({ agentDir }) => {
       fs.mkdirSync(agentDir, { recursive: true });

--- a/src/agents/auth-profiles/profiles.ts
+++ b/src/agents/auth-profiles/profiles.ts
@@ -92,6 +92,7 @@ export async function setAuthProfileOrder(params: {
   agentDir?: string;
   provider: string;
   order?: string[] | null;
+  sharedStoreWrite?: boolean;
 }): Promise<AuthProfileStore | null> {
   const providerKey = resolveProviderIdForAuth(params.provider);
   const sanitized =
@@ -100,6 +101,7 @@ export async function setAuthProfileOrder(params: {
 
   return await updateAuthProfileStoreWithLock({
     agentDir: params.agentDir,
+    sharedStoreWrite: params.sharedStoreWrite,
     // Preserve requested IDs that the agent inherits (not owns) so the local
     // save path does not prune them from the order. Without this, a secondary
     // agent's `models auth order set --agent` accepts an inherited profile ID

--- a/src/gateway/methods/core-descriptors.since.test.ts
+++ b/src/gateway/methods/core-descriptors.since.test.ts
@@ -87,6 +87,7 @@ const CURRENT_TRAIN_METHODS = [
   "openclaw.setup.activate.start",
   "exec.approval.grants.list",
   "exec.approval.grants.revoke",
+  "models.authOrderSet",
   "sessions.patchMany",
   "sessions.goal.update",
   "sessions.goal.clear",

--- a/src/gateway/methods/core-descriptors.ts
+++ b/src/gateway/methods/core-descriptors.ts
@@ -33,6 +33,7 @@ type CoreGatewayMethodSpecRow = readonly [
   since: string,
   policy?: CoreGatewayMethodPolicy,
 ];
+const CONTROL_PLANE_WRITE = { controlPlaneWrite: true } as const;
 
 // This is the canonical core method policy table: every core handler must appear here so
 // listing, authorization, startup availability, and write throttling stay in sync.
@@ -660,6 +661,7 @@ const CORE_GATEWAY_METHOD_SPECS = [
   // Strong user/tenant isolation requires separate Gateways; see operator-scopes.md.
   ["transcripts.list", "transcripts", "operator.read", "2026.8"],
   ["transcripts.get", "transcripts", "operator.read", "2026.8"],
+  ["models.authOrderSet", "models-auth-order", "operator.admin", "2026.8", CONTROL_PLANE_WRITE],
 ] as const satisfies readonly CoreGatewayMethodSpecRow[];
 
 export type CoreGatewayHandlerFamily = Exclude<(typeof CORE_GATEWAY_METHOD_SPECS)[number][1], null>;

--- a/src/gateway/server-methods-list.test.ts
+++ b/src/gateway/server-methods-list.test.ts
@@ -135,6 +135,7 @@ describe("listGatewayMethods", () => {
     "sessions.title.prepare",
     "transcripts.list",
     "transcripts.get",
+    "models.authOrderSet",
   ];
 
   it("advertises plugin surface refresh for capability rotation", () => {

--- a/src/gateway/server-methods.ts
+++ b/src/gateway/server-methods.ts
@@ -130,6 +130,10 @@ const CORE_GATEWAY_HANDLER_MODULES = {
     import("./server-methods/models-auth-status.js").then(
       (module) => module.modelsAuthStatusHandlers,
     ),
+  "models-auth-order": () =>
+    import("./server-methods/models-auth-order.js").then(
+      (module) => module.modelsAuthOrderHandlers,
+    ),
   models: () => import("./server-methods/models.js").then((module) => module.modelsHandlers),
   "models-probe": () =>
     import("./server-methods/models-probe.js").then((module) => module.modelsProbeHandlers),

--- a/src/gateway/server-methods/models-auth-order.ts
+++ b/src/gateway/server-methods/models-auth-order.ts
@@ -1,0 +1,141 @@
+import {
+  ErrorCodes,
+  errorShape,
+  validateModelsAuthOrderSetParams,
+} from "../../../packages/gateway-protocol/src/index.js";
+import {
+  resolveExplicitAuthOrderSelection,
+  setAuthProfileOrder,
+} from "../../agents/auth-profiles.js";
+import {
+  clearCurrentProviderAuthState,
+  warmCurrentProviderAuthStateOffMainThread,
+} from "../../agents/model-provider-auth.js";
+import { refreshPreparedModelRuntimeSnapshots } from "../../agents/prepared-model-runtime.js";
+import { resolveProviderIdForAuth } from "../../agents/provider-auth-aliases.js";
+import { createSubsystemLogger } from "../../logging/subsystem.js";
+import { refreshActiveProviderAuthRuntimeSnapshot } from "../../secrets/runtime.js";
+import { readPreparedCatalog } from "../server-model-catalog-auth.js";
+import { formatForLog } from "../ws-log.js";
+import { modelAuthAgentScopeError, resolveModelAuthAgentScope } from "./model-auth-agent-scope.js";
+import { resolveConfigBoundProfileIds } from "./models-auth-status-config.js";
+import { clearModelAuthStatusUsageCache } from "./models-auth-status-usage-cache.js";
+import type { ModelAuthOrderSetResult } from "./models-auth-status.types.js";
+import type { GatewayRequestHandlers } from "./types.js";
+import { assertValidParams } from "./validation.js";
+
+const log = createSubsystemLogger("models-auth-order");
+
+export const modelsAuthOrderHandlers: GatewayRequestHandlers = {
+  "models.authOrderSet": async ({ params, respond, context }) => {
+    if (
+      !assertValidParams(params, validateModelsAuthOrderSetParams, "models.authOrderSet", respond)
+    ) {
+      return;
+    }
+    const provider = params.provider;
+    const profileIds = params.profileIds ?? null;
+    const rejectInvalidOrder = (message: string) =>
+      respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, message));
+    try {
+      const cfg = context.getRuntimeConfig();
+      const scope = resolveModelAuthAgentScope(cfg, params.agentId);
+      if (!scope.ok) {
+        respond(false, undefined, modelAuthAgentScopeError(scope));
+        return;
+      }
+      const preparedSnapshot = await readPreparedCatalog(context, scope.agentId);
+      if (!preparedSnapshot) {
+        throw new Error(`prepared model auth owner is unavailable (${scope.agentId})`);
+      }
+      const authAliasLookupParams = {
+        config: preparedSnapshot.config,
+        workspaceDir: preparedSnapshot.workspaceDir,
+        metadataSnapshot: preparedSnapshot.metadataSnapshot,
+        includeUntrustedWorkspacePlugins: false,
+      };
+      const authProvider = resolveProviderIdForAuth(provider, authAliasLookupParams);
+      const configuredOrder = resolveExplicitAuthOrderSelection({
+        storeOrder: preparedSnapshot.authStore.order,
+        configuredOrder: preparedSnapshot.config.auth?.order,
+        providerKey: provider,
+        providerAuthKey: authProvider,
+      });
+      if (profileIds && configuredOrder.order !== undefined && !configuredOrder.fromStore) {
+        rejectInvalidOrder(
+          `profile priority for provider ${provider} is controlled by auth configuration`,
+        );
+        return;
+      }
+      const availableProfileIds = Object.entries(preparedSnapshot.authStore.profiles)
+        .filter(
+          ([, credential]) =>
+            resolveProviderIdForAuth(credential.provider, authAliasLookupParams) === authProvider,
+        )
+        .map(([profileId]) => profileId);
+      const configBoundProfileIds = resolveConfigBoundProfileIds(
+        preparedSnapshot.config,
+        preparedSnapshot.authStore,
+        authAliasLookupParams,
+      );
+      if (
+        profileIds &&
+        availableProfileIds.some((profileId) => configBoundProfileIds.has(profileId))
+      ) {
+        rejectInvalidOrder(
+          `profile priority for provider ${provider} is controlled by provider configuration`,
+        );
+        return;
+      }
+      const invalidProfile = profileIds?.find((profileId) => {
+        const credential = preparedSnapshot.authStore.profiles[profileId];
+        return (
+          !credential ||
+          resolveProviderIdForAuth(credential.provider, authAliasLookupParams) !== authProvider
+        );
+      });
+      if (invalidProfile) {
+        rejectInvalidOrder(`profileId ${invalidProfile} is unavailable for provider ${provider}`);
+        return;
+      }
+      if (profileIds && profileIds.length !== availableProfileIds.length) {
+        rejectInvalidOrder(
+          `profileIds must include every available profile for provider ${provider}`,
+        );
+        return;
+      }
+      const updated = await setAuthProfileOrder({
+        agentDir: preparedSnapshot.agentDir,
+        provider: authProvider,
+        order: profileIds,
+        sharedStoreWrite: true,
+      });
+      if (!updated) {
+        respond(
+          false,
+          undefined,
+          errorShape(ErrorCodes.UNAVAILABLE, "auth profile order is temporarily unavailable"),
+        );
+        return;
+      }
+      clearModelAuthStatusUsageCache();
+      clearCurrentProviderAuthState();
+      const result: ModelAuthOrderSetResult = { provider, profileIds };
+      respond(true, result, undefined);
+      void Promise.all([
+        refreshActiveProviderAuthRuntimeSnapshot(),
+        refreshPreparedModelRuntimeSnapshots(cfg, {
+          catalogMode: "static",
+          allowGatewaySubagentBinding: true,
+          agentIds: new Set([scope.agentId]),
+          pluginMetadataSnapshot: preparedSnapshot.metadataSnapshot,
+        }),
+        warmCurrentProviderAuthStateOffMainThread(cfg),
+      ]).catch((err: unknown) => {
+        log.warn(`provider auth state refresh after reorder failed: ${formatForLog(err)}`);
+      });
+    } catch (err) {
+      respond(false, undefined, errorShape(ErrorCodes.UNAVAILABLE, formatForLog(err)));
+    }
+  },
+};

--- a/src/gateway/server-methods/models-auth-status-config.ts
+++ b/src/gateway/server-methods/models-auth-status-config.ts
@@ -1,0 +1,24 @@
+import type { AuthProfileStore } from "../../agents/auth-profiles.js";
+import { resolveProviderEntryApiKeyProfileReference } from "../../agents/model-auth.js";
+import type { ProviderAuthAliasLookupParams } from "../../agents/provider-auth-aliases.js";
+import type { OpenClawConfig } from "../../config/config.js";
+
+export function resolveConfigBoundProfileIds(
+  cfg: OpenClawConfig,
+  store: AuthProfileStore,
+  authAliasLookupParams?: ProviderAuthAliasLookupParams,
+): Set<string> {
+  const profileIds = new Set<string>();
+  for (const provider of Object.keys(cfg.models?.providers ?? {})) {
+    const reference = resolveProviderEntryApiKeyProfileReference({
+      cfg,
+      authAliasLookupParams,
+      provider,
+      store,
+    });
+    if (reference.kind === "profile" || reference.kind === "profile-incompatible") {
+      profileIds.add(reference.profileId);
+    }
+  }
+  return profileIds;
+}

--- a/src/gateway/server-methods/models-auth-status.test.ts
+++ b/src/gateway/server-methods/models-auth-status.test.ts
@@ -55,7 +55,11 @@ const mocks = vi.hoisted(() => ({
   resolvePersistedAuthProfileOwnerAgentDir: vi.fn(
     (params: { agentDir?: string }) => params.agentDir,
   ),
+  setAuthProfileOrder: vi.fn(
+    async (): Promise<AuthProfileStore | null> => ({ version: 1, profiles: {} }),
+  ),
   refreshActiveProviderAuthRuntimeSnapshot: vi.fn(async () => false),
+  refreshPreparedModelRuntimeSnapshots: vi.fn(async () => {}),
   clearCurrentProviderAuthState: vi.fn(),
   warmCurrentProviderAuthStateOffMainThread: vi.fn(async (_cfg: unknown) => {}),
   loadDeferredCatalog: vi.fn(),
@@ -93,6 +97,7 @@ vi.mock("../../agents/auth-profiles.js", async () => {
     removeAuthProfilesAcrossOwnerStores: mocks.removeAuthProfilesAcrossOwnerStores,
     removeProviderAuthProfilesWithLock: mocks.removeProviderAuthProfilesWithLock,
     resolvePersistedAuthProfileOwnerAgentDir: mocks.resolvePersistedAuthProfileOwnerAgentDir,
+    setAuthProfileOrder: mocks.setAuthProfileOrder,
   };
 });
 
@@ -118,6 +123,10 @@ vi.mock("../../secrets/runtime.js", () => ({
   refreshActiveProviderAuthRuntimeSnapshot: mocks.refreshActiveProviderAuthRuntimeSnapshot,
 }));
 
+vi.mock("../../agents/prepared-model-runtime.js", () => ({
+  refreshPreparedModelRuntimeSnapshots: mocks.refreshPreparedModelRuntimeSnapshots,
+}));
+
 vi.mock("../../agents/model-provider-auth.js", () => ({
   clearCurrentProviderAuthState: mocks.clearCurrentProviderAuthState,
   warmCurrentProviderAuthStateOffMainThread: mocks.warmCurrentProviderAuthStateOffMainThread,
@@ -128,6 +137,7 @@ vi.mock("../server-model-catalog-auth.js", () => ({
   readPreparedCatalog: mocks.readPreparedCatalog,
 }));
 
+import { modelsAuthOrderHandlers } from "./models-auth-order.js";
 import {
   aggregateRefreshableAuthStatus,
   invalidateModelAuthStatusCache,
@@ -138,12 +148,13 @@ import {
 
 function createOptions(
   params: Record<string, unknown> = {},
+  scopes: string[] = ["operator.admin"],
 ): GatewayRequestHandlerOptions & { respond: ReturnType<typeof vi.fn> } {
   const respond = vi.fn();
   return {
     req: { type: "req", id: "req-1", method: "models.authStatus", params },
     params,
-    client: null,
+    client: { connect: { scopes } } as never,
     isWebchatConnect: () => false,
     respond,
     context: { getRuntimeConfig: mocks.getRuntimeConfig } as unknown,
@@ -157,6 +168,10 @@ const handler = expectDefined(
 const logoutHandler = expectDefined(
   modelsAuthStatusHandlers["models.authLogout"],
   'modelsAuthStatusHandlers["models.authLogout"] test invariant',
+);
+const orderHandler = expectDefined(
+  modelsAuthOrderHandlers["models.authOrderSet"],
+  'modelsAuthOrderHandlers["models.authOrderSet"] test invariant',
 );
 
 function createActiveRun(providerId: string, authProviderId?: string, agentId = "main") {
@@ -211,6 +226,20 @@ function createLogoutOptions(
     isWebchatConnect: () => false,
     respond,
     context,
+  } as unknown as GatewayRequestHandlerOptions & { respond: ReturnType<typeof vi.fn> };
+}
+
+function createOrderOptions(
+  params: Record<string, unknown>,
+): GatewayRequestHandlerOptions & { respond: ReturnType<typeof vi.fn> } {
+  const respond = vi.fn();
+  return {
+    req: { type: "req", id: "req-order", method: "models.authOrderSet", params },
+    params,
+    client: null,
+    isWebchatConnect: () => false,
+    respond,
+    context: { getRuntimeConfig: mocks.getRuntimeConfig } as unknown,
   } as unknown as GatewayRequestHandlerOptions & { respond: ReturnType<typeof vi.fn> };
 }
 
@@ -306,6 +335,7 @@ function resetAuthStatusMocks(): void {
   mocks.listProfilesForProvider.mockReturnValue([]);
   mocks.removeAuthProfilesAcrossOwnerStores.mockResolvedValue(true);
   mocks.removeProviderAuthProfilesWithLock.mockResolvedValue({ version: 1, profiles: {} });
+  mocks.setAuthProfileOrder.mockResolvedValue({ version: 1, profiles: {} });
   mocks.resolvePersistedAuthProfileOwnerAgentDir.mockImplementation(
     (params: { agentDir?: string }) => params.agentDir,
   );
@@ -317,6 +347,8 @@ function resetAuthStatusMocks(): void {
   });
   mocks.loadProviderUsageSummary.mockResolvedValue(emptyUsageSummary());
   mocks.refreshActiveProviderAuthRuntimeSnapshot.mockResolvedValue(false);
+  mocks.refreshPreparedModelRuntimeSnapshots.mockResolvedValue();
+  mocks.warmCurrentProviderAuthStateOffMainThread.mockResolvedValue();
 }
 
 function firstDeferredAuthScope() {
@@ -606,6 +638,89 @@ describe("models.authStatus", () => {
       ).type,
     ).toBe("oauth");
     expect(result.providers[0]?.profiles[0]?.logoutSupported).toBe(true);
+  });
+
+  it("projects profile labels, last use, and explicit priority", async () => {
+    setPreparedAuthStore({
+      version: 1,
+      profiles: {
+        "openai:default": {
+          type: "oauth",
+          provider: "openai",
+          access: "access",
+          refresh: "refresh",
+          expires: 1_000_000,
+          email: "owner@example.com",
+          displayName: "Work account",
+        },
+      },
+      order: { openai: ["openai:default"] },
+      usageStats: { "openai:default": { lastUsed: 42 } },
+    });
+    mocks.buildAuthHealthSummary.mockReturnValue(createOpenAiCodexOauthHealthSummary());
+
+    const provider = await firstAuthStatusProvider();
+
+    expect(provider?.profileOrder).toEqual(["openai:default"]);
+    expect(provider?.profileOrderStored).toBe(true);
+    expect(provider?.profiles[0]).toMatchObject({
+      displayName: "Work account",
+      email: "owner@example.com",
+      lastUsedAt: 42,
+      source: "saved",
+    });
+  });
+
+  it("omits profile identity for read-only clients", async () => {
+    setPreparedAuthStore({
+      version: 1,
+      profiles: {
+        "openai:default": {
+          type: "oauth",
+          provider: "openai",
+          access: "access",
+          refresh: "refresh",
+          expires: 1_000_000,
+          email: "owner@example.com",
+          displayName: "Work account",
+        },
+      },
+      usageStats: { "openai:default": { lastUsed: 42 } },
+    });
+    mocks.buildAuthHealthSummary.mockReturnValue(createOpenAiCodexOauthHealthSummary());
+
+    const opts = createOptions({}, ["operator.read"]);
+    await handler(opts);
+
+    const result = firstRespondCall(opts)?.[1] as ModelAuthStatusResult;
+    expect(result.providers[0]?.profiles[0]).not.toHaveProperty("email");
+    expect(result.providers[0]?.profiles[0]).not.toHaveProperty("displayName");
+    expect(result.providers[0]?.profiles[0]).not.toHaveProperty("lastUsedAt");
+  });
+
+  it("marks externally supplied profiles and configuration-owned priority", async () => {
+    mocks.getRuntimeConfig.mockReturnValue({
+      auth: { order: { openai: ["openai:default"] } },
+    });
+    setPreparedAuthStore({
+      version: 1,
+      profiles: {
+        "openai:default": {
+          type: "oauth",
+          provider: "openai",
+          access: "access",
+          refresh: "refresh",
+          expires: 1_000_000,
+        },
+      },
+      runtimeExternalProfileIds: ["openai:default"],
+    });
+    mocks.buildAuthHealthSummary.mockReturnValue(createOpenAiCodexOauthHealthSummary());
+
+    const provider = await firstAuthStatusProvider();
+
+    expect(provider?.profileOrderLocked).toBe("auth-config");
+    expect(provider?.profiles[0]?.source).toBe("external");
   });
 
   it("projects provider capabilities from the published lifecycle metadata", async () => {
@@ -1430,6 +1545,14 @@ describe("models.authStatus", () => {
 
   it("routes claude-cli OAuth profiles to Anthropic usage with plan and billing", async () => {
     const runtimeConfig = {};
+    const plugins = [
+      {
+        id: "anthropic",
+        origin: "bundled" as const,
+        providerAuthAliases: { "claude-cli": "anthropic" },
+      },
+    ];
+    setPreparedMetadataSnapshot(createPluginMetadataSnapshotFixture({ plugins }));
     mocks.getRuntimeConfig.mockReturnValue(runtimeConfig);
     const profile = {
       profileId: "claude-cli",
@@ -1476,6 +1599,7 @@ describe("models.authStatus", () => {
     });
     const refreshed = expectDefined(result, "refreshed auth status");
     expect(refreshed.providers[0]?.displayName).toBe("Claude");
+    expect(refreshed.providers[0]?.authProvider).toBe("anthropic");
     expect(refreshed.providers[0]?.usage).toEqual({
       providerId: "anthropic",
       windows: [{ label: "5h", usedPercent: 22 }],
@@ -1483,6 +1607,11 @@ describe("models.authStatus", () => {
       billing: [{ type: "budget", used: 157.85, limit: 400, unit: "USD", period: "month" }],
       accountEmail: "clawd@example.com",
     });
+
+    const readOnly = createOptions({}, ["operator.read"]);
+    await handler(readOnly);
+    const readOnlyResult = firstRespondCall(readOnly)?.[1] as ModelAuthStatusResult;
+    expect(readOnlyResult.providers[0]?.usage).not.toHaveProperty("accountEmail");
   });
 
   it("adds DeepSeek API-key balance summaries to auth status usage", async () => {
@@ -2070,6 +2199,145 @@ describe("models.authStatus", () => {
     expect(ok).toBe(false);
     expect(payload).toBeUndefined();
     expect(String(requireRecord(error).code)).toMatch(/unavailable/i);
+  });
+});
+
+describe("models.authOrderSet", () => {
+  beforeEach(() => {
+    resetAuthStatusMocks();
+    setPreparedAuthStore({
+      version: 1,
+      profiles: {
+        "openai:one": {
+          type: "oauth",
+          provider: "openai",
+          access: "one",
+          refresh: "one-refresh",
+          expires: 1_000_000,
+        },
+        "openai:two": {
+          type: "oauth",
+          provider: "openai",
+          access: "two",
+          refresh: "two-refresh",
+          expires: 1_000_000,
+        },
+      },
+    });
+  });
+
+  it("persists a complete provider profile order", async () => {
+    const opts = createOrderOptions({
+      provider: "openai",
+      profileIds: ["openai:two", "openai:one"],
+    });
+
+    await orderHandler(opts);
+
+    expect(mocks.setAuthProfileOrder).toHaveBeenCalledWith({
+      agentDir: "/tmp/agent",
+      provider: "openai",
+      order: ["openai:two", "openai:one"],
+      sharedStoreWrite: true,
+    });
+    expect(firstRespondCall(opts)?.slice(0, 2)).toEqual([
+      true,
+      { provider: "openai", profileIds: ["openai:two", "openai:one"] },
+    ]);
+  });
+
+  it("acknowledges the durable order before background refresh finishes", async () => {
+    let finishPublication: (() => void) | undefined;
+    mocks.refreshPreparedModelRuntimeSnapshots.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          finishPublication = resolve;
+        }),
+    );
+    const opts = createOrderOptions({
+      provider: "openai",
+      profileIds: ["openai:two", "openai:one"],
+    });
+
+    const pending = orderHandler(opts);
+    await pending;
+
+    expect(firstRespondCall(opts)?.[0]).toBe(true);
+    expect(mocks.refreshPreparedModelRuntimeSnapshots).toHaveBeenCalledWith(
+      {},
+      expect.objectContaining({
+        catalogMode: "static",
+        allowGatewaySubagentBinding: true,
+        agentIds: new Set(["main"]),
+      }),
+    );
+
+    finishPublication?.();
+  });
+
+  it.each([
+    {
+      name: "auth order",
+      config: { auth: { order: { openai: ["openai:one", "openai:two"] } } },
+      message: "auth configuration",
+    },
+    {
+      name: "provider profile binding",
+      config: { models: { providers: { openai: { apiKey: "openai:one" } } } },
+      message: "provider configuration",
+    },
+  ])("rejects priority controlled by $name", async ({ config, message }) => {
+    mocks.getRuntimeConfig.mockReturnValue(config);
+    const opts = createOrderOptions({
+      provider: "openai",
+      profileIds: ["openai:two", "openai:one"],
+    });
+
+    await orderHandler(opts);
+
+    expect(mocks.setAuthProfileOrder).not.toHaveBeenCalled();
+    expect(firstRespondCall(opts)?.[2]?.message).toContain(message);
+  });
+
+  it("clears the stored override with null", async () => {
+    const opts = createOrderOptions({ provider: "openai" });
+
+    await orderHandler(opts);
+
+    expect(mocks.setAuthProfileOrder).toHaveBeenCalledWith({
+      agentDir: "/tmp/agent",
+      provider: "openai",
+      order: null,
+      sharedStoreWrite: true,
+    });
+  });
+
+  it("rejects an incomplete provider profile order without writing", async () => {
+    const opts = createOrderOptions({ provider: "openai", profileIds: ["openai:one"] });
+
+    await orderHandler(opts);
+
+    expect(mocks.setAuthProfileOrder).not.toHaveBeenCalled();
+    expect(firstRespondCall(opts)?.[0]).toBe(false);
+    expect(firstRespondCall(opts)?.[2]?.message).toContain("every available profile");
+  });
+
+  it("rejects profiles owned by another provider", async () => {
+    const opts = createOrderOptions({ provider: "anthropic", profileIds: ["openai:one"] });
+
+    await orderHandler(opts);
+
+    expect(mocks.setAuthProfileOrder).not.toHaveBeenCalled();
+    expect(firstRespondCall(opts)?.[0]).toBe(false);
+  });
+
+  it("rejects fields outside the registered request contract", async () => {
+    const opts = createOrderOptions({ provider: "openai", unexpected: true });
+
+    await orderHandler(opts);
+
+    expect(mocks.setAuthProfileOrder).not.toHaveBeenCalled();
+    expect(firstRespondCall(opts)?.[0]).toBe(false);
   });
 });
 

--- a/src/gateway/server-methods/models-auth-status.ts
+++ b/src/gateway/server-methods/models-auth-status.ts
@@ -19,14 +19,16 @@ import {
   listProfilesForProvider,
   removeAuthProfilesAcrossOwnerStores,
   removeProviderAuthProfilesWithLock,
+  resolveAuthProfileMetadata,
+  resolveExplicitAuthOrderSelection,
   resolvePersistedAuthProfileOwnerAgentDir,
+  type RuntimeAuthProfileStore,
 } from "../../agents/auth-profiles.js";
 import { getRuntimeExternalCliProfileIds } from "../../agents/auth-profiles/runtime-external-profile-references.js";
 import {
   isNonSecretApiKeyMarker,
   NON_ENV_SECRETREF_MARKER,
 } from "../../agents/model-auth-markers.js";
-import { resolveProviderEntryApiKeyProfileReference } from "../../agents/model-auth.js";
 import {
   clearCurrentProviderAuthState,
   warmCurrentProviderAuthStateOffMainThread,
@@ -42,11 +44,13 @@ import type { UsageProviderId } from "../../infra/provider-usage.types.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { refreshActiveProviderAuthRuntimeSnapshot } from "../../secrets/runtime.js";
 import { abortChatRunsForProvider, type ChatAbortOps } from "../chat-abort.js";
+import { ADMIN_SCOPE } from "../operator-scopes.js";
 import { loadDeferredCatalog, readPreparedCatalog } from "../server-model-catalog-auth.js";
 import { formatForLog } from "../ws-log.js";
 import { modelAuthAgentScopeError, resolveModelAuthAgentScope } from "./model-auth-agent-scope.js";
 import { resolveModelProviderCapabilities } from "./model-provider-capabilities.js";
 import { resolveProviderApiKeys } from "./models-auth-status-api-keys.js";
+import { resolveConfigBoundProfileIds } from "./models-auth-status-config.js";
 import {
   clearModelAuthStatusUsageCache,
   type ProviderUsageStatus,
@@ -65,6 +69,7 @@ import type { GatewayRequestContext, GatewayRequestHandlers } from "./types.js";
 export type {
   ModelAuthExpiry,
   ModelAuthLogoutResult,
+  ModelAuthOrderSetResult,
   ModelAuthStatusProfile,
   ModelAuthStatusProvider,
   ModelAuthStatusResult,
@@ -277,13 +282,35 @@ export function aggregateRefreshableAuthStatus(
 
 function mapProvider(
   prov: AuthProviderHealth,
+  cfg: OpenClawConfig,
+  store: AuthProfileStore,
+  authAliasLookupParams: ProviderAuthAliasLookupParams,
   usageByProvider: Map<string, ProviderUsageStatus>,
   expectsOAuthSet: Set<string>,
   apiKeys: ReadonlyMap<string, ModelAuthStatusProvider["apiKey"]>,
   logoutProfileIds: ReadonlySet<string>,
   configBoundProfileIds: ReadonlySet<string>,
+  externalProfileIds: ReadonlySet<string>,
   externalCliProfileIds: ReadonlySet<string>,
+  includeProfileIdentity: boolean,
 ): ModelAuthStatusProvider {
+  const providerKey = normalizeProviderId(prov.provider);
+  const authProviderKey = resolveProviderIdForAuth(prov.provider, authAliasLookupParams);
+  const profileOrder = resolveExplicitAuthOrderSelection({
+    storeOrder: store.order,
+    configuredOrder: cfg.auth?.order,
+    providerKey,
+    providerAuthKey: authProviderKey,
+  });
+  const runtimeStore: RuntimeAuthProfileStore = store;
+  const localProfileIds = new Set(
+    runtimeStore.runtimeLocalProfileIds ??
+      Object.keys(store.profiles).filter((profileId) => !externalProfileIds.has(profileId)),
+  );
+  const providerOrderLocked = prov.profiles.some((profile) =>
+    configBoundProfileIds.has(profile.profileId),
+  );
+  const configuredOrderLocked = profileOrder.order !== undefined && !profileOrder.fromStore;
   const usageProfile =
     prov.profiles.find((profile) => profile.type === "oauth" || profile.type === "token") ??
     prov.profiles.find((profile) => profile.type === "api_key");
@@ -318,22 +345,47 @@ function mapProvider(
   );
   return {
     provider: prov.provider,
+    authProvider: authProviderKey,
     displayName: providerDisplayName(prov.provider),
     status:
       apiKey && !hasRefreshableProfile && rollup.status === "missing" ? "static" : rollup.status,
     expiry: buildExpiry(rollup.remainingMs, rollup.expiresAt),
-    profiles: prov.profiles.map((prof) => ({
-      profileId: prof.profileId,
-      type: prof.type,
-      status: prof.status,
-      reasonCode: prof.reasonCode,
-      expiry: buildExpiry(prof.remainingMs, prof.expiresAt),
-      ...((prof.type === "oauth" || prof.type === "token") &&
-      logoutProfileIds.has(prof.profileId) &&
-      !configBoundProfileIds.has(prof.profileId)
-        ? { logoutSupported: true }
+    profiles: prov.profiles.map((prof) => {
+      const metadata = resolveAuthProfileMetadata({ cfg, store, profileId: prof.profileId });
+      const lastUsedAt = store.usageStats?.[prof.profileId]?.lastUsed;
+      return {
+        profileId: prof.profileId,
+        type: prof.type,
+        status: prof.status,
+        reasonCode: prof.reasonCode,
+        source: configBoundProfileIds.has(prof.profileId)
+          ? "config"
+          : externalProfileIds.has(prof.profileId)
+            ? "external"
+            : localProfileIds.has(prof.profileId)
+              ? "saved"
+              : "inherited",
+        expiry: buildExpiry(prof.remainingMs, prof.expiresAt),
+        ...(externalCliProfileIds.has(prof.profileId) ? { externallyManaged: true } : {}),
+        ...(includeProfileIdentity && metadata.displayName
+          ? { displayName: metadata.displayName }
+          : {}),
+        ...(includeProfileIdentity && metadata.email ? { email: metadata.email } : {}),
+        ...(includeProfileIdentity && lastUsedAt ? { lastUsedAt } : {}),
+        ...((prof.type === "oauth" || prof.type === "token") &&
+        logoutProfileIds.has(prof.profileId) &&
+        !configBoundProfileIds.has(prof.profileId)
+          ? { logoutSupported: true }
+          : {}),
+      };
+    }),
+    ...(profileOrder.order !== undefined ? { profileOrder: profileOrder.order } : {}),
+    ...(profileOrder.fromStore ? { profileOrderStored: true } : {}),
+    ...(providerOrderLocked
+      ? { profileOrderLocked: "provider-config" as const }
+      : configuredOrderLocked
+        ? { profileOrderLocked: "auth-config" as const }
         : {}),
-    })),
     ...(apiKey ? { apiKey } : {}),
     usage:
       usage && usageKey
@@ -343,30 +395,12 @@ function mapProvider(
             ...(usage.summary ? { summary: usage.summary } : {}),
             ...(usage.plan ? { plan: usage.plan } : {}),
             ...(usage.billing?.length ? { billing: usage.billing } : {}),
-            ...(usage.accountEmail ? { accountEmail: usage.accountEmail } : {}),
+            ...(includeProfileIdentity && usage.accountEmail
+              ? { accountEmail: usage.accountEmail }
+              : {}),
           }
         : undefined,
   };
-}
-
-function resolveConfigBoundProfileIds(
-  cfg: OpenClawConfig,
-  store: AuthProfileStore,
-  authAliasLookupParams?: ProviderAuthAliasLookupParams,
-): Set<string> {
-  const profileIds = new Set<string>();
-  for (const provider of Object.keys(cfg.models?.providers ?? {})) {
-    const reference = resolveProviderEntryApiKeyProfileReference({
-      cfg,
-      authAliasLookupParams,
-      provider,
-      store,
-    });
-    if (reference.kind === "profile" || reference.kind === "profile-incompatible") {
-      profileIds.add(reference.profileId);
-    }
-  }
-  return profileIds;
 }
 
 function resolveConfiguredProviders(
@@ -528,9 +562,11 @@ export const modelsAuthStatusHandlers: GatewayRequestHandlers = {
       respond(false, undefined, errorShape(ErrorCodes.UNAVAILABLE, formatForLog(err)));
     }
   },
-  "models.authStatus": async ({ params, respond, context }) => {
+  "models.authStatus": async ({ params, respond, context, client }) => {
     const now = Date.now();
     const refreshRequested = Boolean(params.refresh);
+    const includeProfileIdentity =
+      Array.isArray(client?.connect?.scopes) && client.connect.scopes.includes(ADMIN_SCOPE);
     const resolveScope = (cfg: OpenClawConfig) =>
       resolveModelAuthAgentScope(
         cfg,
@@ -582,6 +618,7 @@ export const modelsAuthStatusHandlers: GatewayRequestHandlers = {
       // Generic auth helpers may consult provider metadata indirectly. Carry this owner's exact
       // snapshot through them so a global miss cannot rediscover plugins on the event loop.
       const authAliasLookupParams: PreparedAuthMetadataLookupParams = {
+        config: cfg,
         workspaceDir,
         metadataSnapshot: preparedSnapshot.metadataSnapshot,
         includeUntrustedWorkspacePlugins: false,
@@ -657,12 +694,17 @@ export const modelsAuthStatusHandlers: GatewayRequestHandlers = {
       const providers = authHealth.providers.map((prov) =>
         mapProvider(
           prov,
+          cfg,
+          store,
+          authAliasLookupParams,
           usageByProvider,
           configured.expectsOAuth,
           apiKeys,
           logoutProfileIds,
           configBoundProfileIds,
+          externalProfileIds,
           externalCliProfileIds,
+          includeProfileIdentity,
         ),
       );
       const providerCapabilities = buildProviderCapabilities({

--- a/src/gateway/server-methods/models-auth-status.types.ts
+++ b/src/gateway/server-methods/models-auth-status.types.ts
@@ -24,14 +24,29 @@ export type ModelAuthStatusProfile = {
   expiry?: ModelAuthExpiry;
   /** True only for saved OAuth/token profiles this gateway can remove. */
   logoutSupported?: boolean;
+  /** Credential refresh is owned by an external CLI rather than OpenClaw. */
+  externallyManaged?: boolean;
+  /** Where the effective credential came from. */
+  source?: "config" | "external" | "inherited" | "saved";
+  displayName?: string;
+  email?: string;
+  lastUsedAt?: number;
 };
 
 export type ModelAuthStatusProvider = {
   provider: string;
+  /** Canonical credential owner used for profile ordering mutations. */
+  authProvider?: string;
   displayName: string;
   status: AuthProviderHealthStatus;
   expiry?: ModelAuthExpiry;
   profiles: ModelAuthStatusProfile[];
+  /** Explicit stored/config priority. Omitted when selection is automatic. */
+  profileOrder?: string[];
+  /** True when the priority is a stored override that can be reset. */
+  profileOrderStored?: boolean;
+  /** Present when configuration, rather than the auth store, owns priority. */
+  profileOrderLocked?: "auth-config" | "provider-config";
   apiKey?: {
     source: "config" | "env";
     envVar?: string;
@@ -70,4 +85,9 @@ export type ModelAuthLogoutResult = {
   provider: string;
   removedProfiles: string[];
   abortedRunIds: string[];
+};
+
+export type ModelAuthOrderSetResult = {
+  provider: string;
+  profileIds: string[] | null;
 };

--- a/src/gateway/server.models-auth-order.test.ts
+++ b/src/gateway/server.models-auth-order.test.ts
@@ -1,0 +1,81 @@
+import { expect, test, vi } from "vitest";
+import type { WebSocket } from "ws";
+import { resolveAgentDir } from "../agents/agent-scope.js";
+import {
+  loadAuthProfileStoreWithoutExternalProfiles,
+  saveAuthProfileStore,
+} from "../agents/auth-profiles.js";
+import { refreshPreparedModelRuntimeSnapshots } from "../agents/prepared-model-runtime.js";
+import { getRuntimeConfig } from "../config/io.js";
+import { rpcReq } from "./test-helpers.js";
+import { setupGatewaySessionsTestHarness } from "./test/server-sessions.test-helpers.js";
+
+const { openClient } = setupGatewaySessionsTestHarness();
+
+test("models.authOrderSet requires admin scope before updating the shared order", async () => {
+  const cfg = getRuntimeConfig();
+  const agentDir = resolveAgentDir(cfg, "main");
+  const previousStore = loadAuthProfileStoreWithoutExternalProfiles(agentDir);
+  const provider = "fixture";
+  const initialOrder = ["fixture:first", "fixture:second"];
+  const updatedOrder = initialOrder.toReversed();
+  saveAuthProfileStore(
+    {
+      ...previousStore,
+      profiles: {
+        ...previousStore.profiles,
+        "fixture:first": { type: "api_key", provider, key: "fixture-first" },
+        "fixture:second": { type: "api_key", provider, key: "fixture-second" },
+      },
+      order: { ...previousStore.order, [provider]: initialOrder },
+    },
+    agentDir,
+    { sharedStoreWrite: true },
+  );
+  await refreshPreparedModelRuntimeSnapshots(cfg, { gatewayLifecycle: true });
+
+  const clients: WebSocket[] = [];
+  try {
+    for (const scope of ["operator.read", "operator.write"]) {
+      const { ws } = await openClient({ scopes: [scope] });
+      clients.push(ws);
+      const denied = await rpcReq(ws, "models.authOrderSet", {
+        provider,
+        profileIds: updatedOrder,
+      });
+      expect(denied.error).toMatchObject({
+        code: "FORBIDDEN",
+        message: "missing scope: operator.admin",
+      });
+      expect(loadAuthProfileStoreWithoutExternalProfiles(agentDir).order?.[provider]).toEqual(
+        initialOrder,
+      );
+    }
+
+    const { ws } = await openClient({ scopes: ["operator.admin", "operator.read"] });
+    clients.push(ws);
+    const allowed = await rpcReq(ws, "models.authOrderSet", {
+      provider,
+      profileIds: updatedOrder,
+    });
+    expect(allowed.ok, JSON.stringify(allowed)).toBe(true);
+    expect(loadAuthProfileStoreWithoutExternalProfiles(agentDir).order?.[provider]).toEqual(
+      updatedOrder,
+    );
+    await vi.waitFor(async () => {
+      const status = await rpcReq<{
+        providers: Array<{ provider: string; profileOrder?: string[] }>;
+      }>(ws, "models.authStatus", {});
+      expect(status.ok, JSON.stringify(status)).toBe(true);
+      expect(status.payload?.providers).toContainEqual(
+        expect.objectContaining({ provider, profileOrder: updatedOrder }),
+      );
+    });
+  } finally {
+    for (const client of clients) {
+      client.close();
+    }
+    saveAuthProfileStore(previousStore, agentDir, { sharedStoreWrite: true });
+    await refreshPreparedModelRuntimeSnapshots(cfg, { gatewayLifecycle: true });
+  }
+});


### PR DESCRIPTION
The Gateway reports provider health, but it does not expose enough account information for a client to show or change account priority. Operators therefore have to leave the web UI and use local commands to manage multi-account rotation.

This PR adds administrator-only account metadata to `models.authStatus` and a `models.authOrderSet` RPC that saves or clears a complete provider order through the existing auth-profile store. A successful save is acknowledged as soon as it is durable, while runtime refresh continues in the background so clients can update optimistically.

## Change breakdown

| Part | Files | +LOC | -LOC |
| --- | ---: | ---: | ---: |
| Implementation and generated protocol clients | 14 | +306 | -34 |
| Tests | 6 | +413 | -1 |
| **Total** | **20** | **+719** | **-35** |

Delivery 1 of 4. The roster UI and usage views remain separate review units.

## Proof

The direct base has no `models.authOrderSet` method. The exact-head Gateway test opens real WebSocket clients through the normal dispatch and scope checks:

```text
operator.read  -> FORBIDDEN; shared order remains unchanged
operator.write -> FORBIDDEN; shared order remains unchanged
operator.admin -> order is written to the canonical shared store
status refresh -> profileOrder reports the persisted order
```

The administrator assertion reloads the shared store after the RPC rather than trusting the handler response. The refreshed `models.authStatus` response must then report the same order. Incomplete, duplicate, cross-provider, and configuration-owned orders are rejected without writing. Read-only clients receive health and order state without account names, email addresses, or per-account last-use timestamps.

## Implementation notes

The Gateway validates ownership and completeness, then delegates persistence to the existing `setAuthProfileOrder` function used by the CLI. It does not add a second ordering engine or auth-store transaction layer. The existing shared-store write route owns main-agent persistence.

There is no schema, config, or stored-data migration. This RPC writes the existing canonical `AuthProfileStore.order` field through its existing owner.

## Security disposition

- The public write is registered as an `operator.admin` control-plane method.
- Lower-scope denial is proven before mutation through real Gateway clients.
- CodeQL alerts 893 and 894 both report their most recent instance as fixed on the exact head.
- Security ownership accepted the administrator contract and merge direction.

## Validation

- 217 focused tests passed across Gateway dispatch/status, auth-profile persistence, protocol schemas, method registration, and release-train coverage.
- The exact-head real Gateway test proves read/write denial and administrator shared-store persistence.
- Production TypeScript typecheck, formatting, diff checks, Android ktlint, and Swift lint passed.
- The changed-files gate passed every relevant source, type, lint, boundary, dead-code, and generated-contract stage. Its unrelated macOS installer suite initially selected Homebrew's lowercase UUID utility; the affected test cluster passed with the platform `/usr/bin/uuidgen`, and this PR has no diff in that suite or installer.
- Validation head: `c56420d89e11211a3e71ac5822c4f75ea2655030`.
- Exact-head PR CI is running.

## How to verify

Call `models.authOrderSet` with every profile ID for one provider, then refresh `models.authStatus`. The saved `profileOrder` should match. Omit `profileIds` to remove the saved override and return to the configured or automatic order.
