### PR TITLE
fix(logging): hold recovery while CLI background work is outstanding

### DIFF
--- a/src/agents/cli-runner/execute-plugin.test.ts
+++ b/src/agents/cli-runner/execute-plugin.test.ts
@@ -94,6 +94,7 @@ function runPlugin(
     onNoOutputTimeout?: NonNullable<
       Parameters<typeof executePluginOwnedProcess>[0]["onNoOutputTimeout"]
     >;
+    onOutstandingWorkChange?: (active: boolean) => void;
     onInterrupted?: (reason: "aborted" | "timeout") => boolean;
   } = {},
 ) {
@@ -119,6 +120,7 @@ function runPlugin(
         }
       : {}),
     ...(options.onNoOutputTimeout ? { onNoOutputTimeout: options.onNoOutputTimeout } : {}),
+    onOutstandingWorkChange: options.onOutstandingWorkChange,
     ...(options.onInterrupted ? { onInterrupted: options.onInterrupted } : {}),
     noOutputTimeoutMs: options.noOutputTimeoutMs ?? 2_000,
     consumeStdout: options.consumeStdout ?? (() => {}),
@@ -876,6 +878,7 @@ describe("plugin-owned CLI execution host boundary", () => {
     });
     const approval = createDeferred<{ id: string; decision: "allow-once" }>();
     mockCallGatewayTool.mockReturnValueOnce(approval.promise);
+    const outstandingWork = vi.fn();
     let completed = false;
     const run = runPlugin(
       context,
@@ -886,7 +889,7 @@ describe("plugin-owned CLI execution host boundary", () => {
         expect(decision.behavior).toBe("allow");
         yield SUCCESS_RESULT;
       },
-      { noOutputTimeoutMs: 100 },
+      { noOutputTimeoutMs: 100, onOutstandingWorkChange: outstandingWork },
     ).then((result) => {
       completed = true;
       return result;
@@ -895,9 +898,11 @@ describe("plugin-owned CLI execution host boundary", () => {
 
     await vi.advanceTimersByTimeAsync(150);
     expect(completed).toBe(false);
+    expect(outstandingWork).toHaveBeenLastCalledWith(true);
 
     approval.resolve({ id: "approval-pending", decision: "allow-once" });
     await expect(run).resolves.toMatchObject({ reason: "exit", timedOut: false });
+    expect(outstandingWork).toHaveBeenLastCalledWith(false);
   });
 
   it("keeps the overall deadline authoritative while a native approval is outstanding", async () => {

--- a/src/agents/cli-runner/execute-plugin.ts
+++ b/src/agents/cli-runner/execute-plugin.ts
@@ -403,6 +403,7 @@ export async function executePluginOwnedProcess(params: {
   sessionId?: string;
   noOutputTimeoutMs: number;
   consumeStdout: (chunk: string) => void;
+  onOutstandingWorkChange?: (active: boolean) => void;
   activeToolCount?: () => number;
   onNoOutputTimeout?: (error: FailoverError) => void;
   onInterrupted?: (reason: CliTerminalInterruption["reason"]) => boolean;
@@ -433,8 +434,12 @@ export async function executePluginOwnedProcess(params: {
     observed: false,
     replayUnsafe: false,
   };
-  const updatePendingApproval = (delta: number) =>
-    (outstanding.approvals = Math.max(0, outstanding.approvals + delta));
+  const reportOutstandingWork = () =>
+    params.onOutstandingWorkChange?.(outstanding.approvals > 0 || outstanding.background > 0);
+  const updatePendingApproval = (delta: number) => {
+    outstanding.approvals = Math.max(0, outstanding.approvals + delta);
+    reportOutstandingWork();
+  };
   let noOutputTimer: ReturnType<typeof setTimeout> | undefined;
   const overallTimeoutMs = clampPositiveTimerTimeoutMs(run.timeoutMs);
   const noOutputTimeoutMs = clampPositiveTimerTimeoutMs(params.noOutputTimeoutMs);
@@ -583,6 +588,7 @@ export async function executePluginOwnedProcess(params: {
         Array.isArray(next.value.tasks)
       ) {
         outstanding.background = next.value.tasks.filter(isRecord).length;
+        reportOutstandingWork();
       }
       params.consumeStdout(`${JSON.stringify(next.value)}\n`);
       outstanding.observed = true;
@@ -630,6 +636,7 @@ export async function executePluginOwnedProcess(params: {
   } finally {
     clearTimeout(overallTimer);
     clearTimeout(noOutputTimer);
+    params.onOutstandingWorkChange?.(false);
     // Permission callbacks can be retained by the plugin or its subprocess.
     // Closing the turn fences those capabilities before any outer cleanup runs.
     if (!controller.signal.aborted) {

--- a/src/agents/cli-runner/execute-process.ts
+++ b/src/agents/cli-runner/execute-process.ts
@@ -248,6 +248,7 @@ export async function executeCliProcess(params: {
         sessionId: params.resolvedSessionId,
         noOutputTimeoutMs: params.noOutputTimeoutMs,
         consumeStdout,
+        onOutstandingWorkChange: backendActivity?.setOutstandingWork,
         activeToolCount: params.events.activeParsedToolCount,
         onNoOutputTimeout: (error) => {
           pluginTimeout.error = error;

--- a/src/agents/cli-runner/execute.background-work.test.ts
+++ b/src/agents/cli-runner/execute.background-work.test.ts
@@ -1,0 +1,104 @@
+import { afterEach, expect, it, vi } from "vitest";
+import { createDeferred } from "../../../test/helpers/promise.js";
+import { waitForDiagnosticEventsDrained } from "../../infra/diagnostic-events.js";
+import {
+  BLOCKED_TOOL_CALL_ABORT_FLOOR_MS,
+  closeDiagnosticEmbeddedRunOwner,
+  createDiagnosticEmbeddedRunOwner,
+  getDiagnosticSessionActivitySnapshot,
+  markDiagnosticEmbeddedRunStarted,
+} from "../../logging/diagnostic-run-activity.js";
+import { markDiagnosticModelStartedForTest } from "../../logging/diagnostic-run-activity.test-support.js";
+import { logSessionStateChange, startDiagnosticHeartbeat } from "../../logging/diagnostic.js";
+import { resetDiagnosticStateForTest } from "../../logging/diagnostic.test-support.js";
+import { buildPreparedCliRunContext } from "../cli-runner.test-helpers.js";
+import { executePreparedCliRun } from "./execute.js";
+import { wrapPreparedCliRunWithTestAdmission } from "./execute.test-support.js";
+
+afterEach(() => {
+  resetDiagnosticStateForTest();
+  vi.useRealTimers();
+});
+
+it.each(["embedded_run", "model_call"] as const)(
+  "keeps a CLI background task alive through %s recovery and releases its allowance on clear",
+  async (activeWorkKind) => {
+    vi.useFakeTimers({
+      toFake: ["Date", "setTimeout", "clearTimeout", "setInterval", "clearInterval"],
+    });
+    vi.setSystemTime(Date.parse("2026-08-04T00:00:00Z"));
+    const recoverStuckSession = vi.fn();
+    startDiagnosticHeartbeat({ diagnostics: { enabled: true } }, { recoverStuckSession });
+    const context = buildPreparedCliRunContext({
+      runId: "background-run",
+      sessionId: "background-session",
+      sessionKey: "agent:main:background",
+      agentId: "main",
+      model: "fixture-model",
+      config: { plugins: { enabled: false } },
+      timeoutMs: 1_800_000,
+      backend: {
+        command: process.execPath,
+        sessionMode: "none",
+        reliability: { watchdog: { fresh: { minMs: 180_000, maxMs: 180_000 } } },
+      },
+    });
+    context.backendResolved.bundleMcp = false;
+    const started = createDeferred<number>();
+    const clear = createDeferred();
+    const cleared = createDeferred<number>();
+    const finish = createDeferred();
+    context.executionTarget = {
+      kind: "plugin",
+      async *execute() {
+        yield {
+          type: "system",
+          subtype: "background_tasks_changed",
+          tasks: [{ task_id: "background-agent", task_type: "local_agent" }],
+        };
+        started.resolve(Date.now());
+        await clear.promise;
+        yield { type: "system", subtype: "background_tasks_changed", tasks: [] };
+        cleared.resolve(Date.now());
+        await finish.promise;
+        yield { type: "result", subtype: "success", result: "background completed" };
+      },
+    };
+    const owner = createDiagnosticEmbeddedRunOwner(context.params);
+    context.params.diagnosticOwner = owner;
+    logSessionStateChange({ ...context.params, state: "processing" });
+    markDiagnosticEmbeddedRunStarted({ ...context.params, owner });
+    if (activeWorkKind === "model_call") {
+      markDiagnosticModelStartedForTest(context.params);
+    }
+    const run = wrapPreparedCliRunWithTestAdmission(executePreparedCliRun)(context);
+    try {
+      const startedAt = await started.promise;
+      await vi.advanceTimersByTimeAsync(390_000);
+      expect(recoverStuckSession).not.toHaveBeenCalled();
+      expect(getDiagnosticSessionActivitySnapshot(context.params)).toMatchObject({
+        activeWorkKind,
+        activeBackendLivenessDeadlineAtMs: startedAt + BLOCKED_TOOL_CALL_ABORT_FLOOR_MS,
+        lastProgressAgeMs: 390_000,
+      });
+
+      clear.resolve();
+      const clearedAt = await cleared.promise;
+      expect(getDiagnosticSessionActivitySnapshot(context.params)).toMatchObject({
+        activeBackendLivenessDeadlineAtMs: clearedAt + 180_000,
+        lastProgressAgeMs: 0,
+      });
+      finish.resolve();
+      await expect(run).resolves.toMatchObject({ text: "background completed" });
+      await waitForDiagnosticEventsDrained();
+      expect(
+        getDiagnosticSessionActivitySnapshot(context.params).activeBackendLivenessDeadlineAtMs,
+      ).toBeUndefined();
+    } finally {
+      clear.resolve();
+      finish.resolve();
+      await Promise.allSettled([run]);
+      closeDiagnosticEmbeddedRunOwner(owner);
+    }
+  },
+);

--- a/src/agents/cli-runner/execute.background-work.test.ts
+++ b/src/agents/cli-runner/execute.background-work.test.ts
@@ -69,7 +69,7 @@ it.each(["embedded_run", "model_call"] as const)(
     logSessionStateChange({ ...context.params, state: "processing" });
     markDiagnosticEmbeddedRunStarted({ ...context.params, owner });
     if (activeWorkKind === "model_call") {
-      markDiagnosticModelStartedForTest(context.params);
+      markDiagnosticModelStartedForTest({ ...context.params, model: context.modelId });
     }
     const run = wrapPreparedCliRunWithTestAdmission(executePreparedCliRun)(context);
     try {

--- a/src/logging/diagnostic-backend-liveness.test.ts
+++ b/src/logging/diagnostic-backend-liveness.test.ts
@@ -11,6 +11,7 @@ import {
   resetDiagnosticEventsForTest,
 } from "../infra/diagnostic-events.js";
 import {
+  BLOCKED_TOOL_CALL_ABORT_FLOOR_MS,
   beginDiagnosticBackendActivity,
   closeDiagnosticEmbeddedRunOwner,
   createDiagnosticEmbeddedRunOwner,
@@ -156,6 +157,45 @@ describe("owned backend silence allowances", () => {
     expect(closed.activeBackendLivenessDeadlineAtMs).toBeUndefined();
   });
 
+  it.each([30_000, 1_200_000])(
+    "changes the %ims allowance without manufacturing output or progress",
+    (noOutputTimeoutMs) => {
+      vi.useFakeTimers();
+      const startedAt = 1_000_000;
+      vi.setSystemTime(startedAt);
+      const ref = { sessionId: "background-allowance", runId: "background-allowance-run" };
+      const owner = createDiagnosticEmbeddedRunOwner(ref);
+      markDiagnosticEmbeddedRunStarted({ ...ref, owner });
+      const backend = beginDiagnosticBackendActivity({
+        owner,
+        noOutputTimeoutMs,
+        assertCurrent: () => {},
+      });
+      try {
+        vi.setSystemTime(startedAt + 60_000);
+        backend.setOutstandingWork(true);
+        const deadline = startedAt + Math.max(noOutputTimeoutMs, BLOCKED_TOOL_CALL_ABORT_FLOOR_MS);
+        expect(getDiagnosticSessionActivitySnapshot(ref)).toMatchObject({
+          activeBackendLivenessDeadlineAtMs: deadline,
+          lastProgressAgeMs: 60_000,
+          lastProgressReason: "embedded_run:started",
+        });
+        vi.setSystemTime(deadline);
+        backend.setOutstandingWork(true);
+        expect(getDiagnosticSessionActivitySnapshot(ref).activeBackendLivenessDeadlineAtMs).toBe(
+          deadline,
+        );
+        backend.setOutstandingWork(false);
+        expect(getDiagnosticSessionActivitySnapshot(ref).activeBackendLivenessDeadlineAtMs).toBe(
+          startedAt + noOutputTimeoutMs,
+        );
+      } finally {
+        backend.close();
+        closeDiagnosticEmbeddedRunOwner(owner);
+      }
+    },
+  );
+
   it.each(["attempt close", "owner close", "authority expiry", "owner replacement"] as const)(
     "revokes the allowance and retained observations after %s",
     (closure) => {
@@ -177,6 +217,7 @@ describe("owned backend silence allowances", () => {
         },
       });
       expect(backend.observeOutput(true)).toBe(true);
+      backend.setOutstandingWork(true);
 
       if (closure === "attempt close") {
         backend.close();
@@ -212,6 +253,8 @@ describe("owned backend silence allowances", () => {
       now += 1_000;
       const before = getDiagnosticSessionActivitySnapshot(ref);
       expect(backend.observeOutput(true)).toBe(false);
+      backend.setOutstandingWork(false);
+      backend.setOutstandingWork(true);
       backend.close();
       expect(getDiagnosticSessionActivitySnapshot(ref)).toEqual(before);
       replacement?.close();

--- a/src/logging/diagnostic-run-activity.ts
+++ b/src/logging/diagnostic-run-activity.ts
@@ -35,6 +35,7 @@ import {
   shouldIgnoreRecoveredOwnerStartEvent,
 } from "./diagnostic-run-activity-recovery.js";
 import {
+  BLOCKED_TOOL_CALL_ABORT_FLOOR_MS,
   buildDiagnosticSessionActivitySnapshot,
   type DiagnosticSessionActivitySnapshot,
 } from "./diagnostic-run-activity-snapshot.js";
@@ -195,8 +196,13 @@ export function beginDiagnosticBackendActivity(params: {
   owner: DiagnosticEmbeddedRunOwner;
   noOutputTimeoutMs: number;
   assertCurrent: () => void;
-}): { observeOutput: (modelProgress: boolean) => boolean; close: () => void } {
+}): {
+  observeOutput: (modelProgress: boolean) => boolean;
+  setOutstandingWork: (active: boolean) => void;
+  close: () => void;
+} {
   const { owner, noOutputTimeoutMs, assertCurrent } = params;
+  let quietAllowanceMs = noOutputTimeoutMs;
   const registration = resolveCurrentDiagnosticOwner(owner, assertCurrent);
   const backendActivity: DiagnosticBackendActivity = {
     deadlineAtMs: Date.now() + noOutputTimeoutMs,
@@ -205,19 +211,34 @@ export function beginDiagnosticBackendActivity(params: {
   if (registration) {
     registration.backendActivity = backendActivity;
   }
+  const currentActivity = () => {
+    const current = resolveCurrentDiagnosticOwner(owner, assertCurrent);
+    return current?.backendActivity === backendActivity ? current.activity : undefined;
+  };
   return {
     observeOutput: (modelProgress) => {
-      const current = resolveCurrentDiagnosticOwner(owner, assertCurrent);
-      if (!current || current.backendActivity !== backendActivity) {
+      const activity = currentActivity();
+      if (!activity) {
         return false;
       }
       const now = Date.now();
-      backendActivity.deadlineAtMs = now + noOutputTimeoutMs;
-      if (!modelProgress || current.activity.activeTools.size > 0) {
+      backendActivity.deadlineAtMs = now + quietAllowanceMs;
+      if (!modelProgress || activity.activeTools.size > 0) {
         return false;
       }
-      touchSessionActivity(current.activity, "model_call:stream_progress", now);
+      touchSessionActivity(activity, "model_call:stream_progress", now);
       return true;
+    },
+    setOutstandingWork: (active) => {
+      if (!currentActivity()) {
+        return;
+      }
+      const allowanceMs = active
+        ? Math.max(noOutputTimeoutMs, BLOCKED_TOOL_CALL_ABORT_FLOOR_MS)
+        : noOutputTimeoutMs;
+      // Work-state changes preserve the last output's origin, not a new progress clock.
+      backendActivity.deadlineAtMs += allowanceMs - quietAllowanceMs;
+      quietAllowanceMs = allowanceMs;
     },
     close: () => {
       // Compare-release remains valid after abort and cannot retire a later attempt.


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users lose a CLI-backed turn when diagnostic recovery aborts a quiet parent while its background agent is still running.

Closes #118386.

## Why This Change Was Made

The CLI watchdog already grants outstanding work the existing 15-minute quiet-work floor. Diagnostic recovery knew only the ordinary backend allowance and could abort the same run earlier.

Current main now has an exact-owner backend deadline. This repair carries background-task and pending native-input state through that owner instead of adding a separate background-work store. Changing the allowance preserves the last output's time; repeated work-state reports do not manufacture progress or slide the deadline.

The existing snapshot protects both `embedded_run` and `model_call`, plus the consumers of the shared stale-run threshold. No new recovery branch, public configuration, database state, protocol field, or run-ID fallback is added.

## User Impact

- CLI background work can finish beyond the ordinary diagnostic stall threshold.
- Silent runs without outstanding work retain their ordinary watchdog and recovery behavior.
- Clearing work restores the ordinary allowance.
- Overall timeouts remain authoritative.
- Closed owners and late callbacks cannot extend or erase a replacement's allowance.

## Evidence

Baseline: `b6a2e5b4eff71070a02e755d55aea0dd53904a20`.
Runtime proof commit: `2ff77ba33c946ed4a5a53cec92de829e5049ba04`.
Published head: `bd2a4824068d800eb239ece991430764341ce975`.

The follow-up commit changes only the regression's diagnostic argument from the optional configured model to the resolved model. Production code, dependencies, build inputs, and product-proof scenarios are unchanged. The retained runtime build and logs belong to `2ff77ba33c94`; they are not relabeled as a new build.

The product proof uses the real built OpenClaw CLI, Gateway, installed CLI backend plugin, subprocess, and diagnostic heartbeat with real timers. The controlled subprocess emits `background_tasks_changed` and later completes. It uses a 180-second quiet allowance, matching the short CLI allowance involved in the reported conflict. No source-module invocation, diagnostic injection, fake product timers, external channel, or live model is used.

Before:

- A normal CLI control returned `CONTROL_OK`.
- The background-task event arrived and its subprocess remained active.
- At 387 seconds without output, diagnostics changed from `recovery=none` to `recovery=checking`, aborted the child, and the CLI returned `CLI run aborted` before the planned 410-second completion.
- An ordinary silent control stopped after 180.8 seconds.

After, on the exact candidate commit:

- The same background turn remained alive at the 387-second diagnostic heartbeat and returned `BACKGROUND_COMPLETED` successfully after 411.1 seconds.
- A second background turn survived the same threshold, then emitted an empty task list at 410.1 seconds. Its next quiet interval ended after 180.0 seconds with `CLI produced no output for 180s and was terminated.`
- An ordinary silent turn still stopped after 180.8 seconds.
- All control turns returned `CONTROL_OK`; all fixture gateways and subprocesses shut down.

Focused verification:

```text
node scripts/run-vitest.mjs src/agents/cli-runner/execute.background-work.test.ts
node scripts/run-vitest.mjs src/agents/cli-runner/execute.background-work.test.ts src/agents/cli-runner/execute-plugin.test.ts src/agents/cli-runner/execute.supervisor-capture.test.ts
node scripts/run-vitest.mjs src/logging/diagnostic-backend-liveness.test.ts src/logging/diagnostic.test.ts src/logging/diagnostic-stuck-session-recovery.integration.test.ts
pnpm build qaRuntime
```

- Both new execution/heartbeat regressions fail on baseline main because recovery runs at 360 and 390 seconds.
- The candidate passes all 109 CLI execution tests and all 120 tests in the three focused logging suites.
- Coverage includes both diagnostic classifications, clearing, bounded expiry without fresh output, longer ordinary allowances, owner/attempt closure, authority expiry, same-ID replacement, pending native approvals, and overall timeout.
- Pinned formatting, targeted lint, max-lines and assertion-safety checks pass.
- Independent pre-commit review found no actionable P0–P2 findings.
- CI found a test-only `TS2345` error in the diagnostic event argument. The follow-up supplies `context.modelId`; fresh independent review found no issues with that correction.

Production: +37/-8, net +29. Tests: +153/-1, net +152. The necessary production growth carries a producer fact through the existing lifetime owner. The contributor's separate fact map, fallback identities, extra snapshot traversal and recovery condition are not retained.

The bounded availability tradeoff from the prior review remains explicit: outstanding work receives the existing quiet-work floor, not unlimited grace. All state is process-local; the prior automated persistent-store warning does not describe this repair.

The distinct Codex-harness producer issue #113972 is not claimed fixed. Contributor credit is preserved for @LiuwqGit.
