### PR TITLE
fix(skills): preserve recovery evidence in live review fixtures

### DIFF
--- a/src/skills/workshop/experience-review.live.test.ts
+++ b/src/skills/workshop/experience-review.live.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import { redactAgentDiagnosticPayload } from "../../agents/diagnostic-redaction.js";
 import { isLiveTestEnabled } from "../../agents/live-test-helpers.js";
 import { resolveAgentRunSessionTarget } from "../../agents/run-session-target.js";
@@ -19,7 +19,10 @@ import {
   type OpenClawTestState,
 } from "../../test-utils/openclaw-test-state.js";
 import { createTrackedTempDirs } from "../../test-utils/tracked-temp-dirs.js";
-import { readSkillReviewOutcomes } from "./collection-review-state.js";
+import {
+  readSkillReviewOutcomes,
+  recordSkillExperienceReviewOutcome,
+} from "./collection-review-state.js";
 import { runSkillExperienceReview, type ExperienceReviewCandidate } from "./experience-review.js";
 import { listSkillProposals } from "./service.js";
 
@@ -226,14 +229,28 @@ beforeAll(async () => {
   workspaceDir = await tempDirs.make("openclaw-live-skill-review-workspace-");
 });
 
+function logReviewOutcomes() {
+  // Persisted failures contain raw provider errors; keep only structured
+  // outcome metadata in CI logs, regardless of secret spelling or format.
+  const outcomes = Object.fromEntries(
+    Object.entries(readSkillReviewOutcomes().experienceReviews).map(([key, review]) => [
+      key,
+      {
+        attemptedAtMs: review.attemptedAtMs,
+        outcome: review.outcome,
+        proposalId: review.proposalId,
+        usage: review.usage,
+      },
+    ]),
+  );
+  console.log("WORKSHOP_REVIEW_OUTCOMES", JSON.stringify(outcomes));
+}
+
 afterAll(async () => {
   unsubscribeDiagnostics();
   if (LIVE) {
     console.log("WORKSHOP_RUNTIME_DIAGNOSTICS", JSON.stringify([...reviewDiagnostics.values()]));
-    console.log(
-      "WORKSHOP_REVIEW_OUTCOMES",
-      JSON.stringify(readSkillReviewOutcomes().experienceReviews),
-    );
+    logReviewOutcomes();
   }
   await testState.cleanup();
   await tempDirs.cleanup();
@@ -328,6 +345,33 @@ async function candidate(
   }
   return result;
 }
+
+describe("skill experience review diagnostics", () => {
+  it("logs persisted failure outcomes without raw provider error text", async () => {
+    const diagnosticWorkspace = await tempDirs.make("openclaw-live-skill-review-diagnostic-");
+    recordSkillExperienceReviewOutcome(diagnosticWorkspace, {
+      attemptedAtMs: 1,
+      outcome: "failed",
+      error: "provider rejected Authorization: Bearer synthetic-workshop-credential",
+      usage: { inputTokens: 3, cachedInputTokens: 1, outputTokens: 2 },
+    });
+    const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
+    try {
+      logReviewOutcomes();
+      expect(log).toHaveBeenCalledOnce();
+      const [label, json] = log.mock.calls[0]!;
+      expect(label).toBe("WORKSHOP_REVIEW_OUTCOMES");
+      expect(Object.values(JSON.parse(json))).toContainEqual({
+        attemptedAtMs: 1,
+        outcome: "failed",
+        usage: { inputTokens: 3, cachedInputTokens: 1, outputTokens: 2 },
+      });
+      expect(json).not.toContain("synthetic-workshop-credential");
+    } finally {
+      log.mockRestore();
+    }
+  });
+});
 
 describe("skill experience review transcript fixture", () => {
   it.each([

--- a/src/skills/workshop/experience-review.live.test.ts
+++ b/src/skills/workshop/experience-review.live.test.ts
@@ -1,18 +1,25 @@
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { redactAgentDiagnosticPayload } from "../../agents/diagnostic-redaction.js";
 import { isLiveTestEnabled } from "../../agents/live-test-helpers.js";
 import { resolveAgentRunSessionTarget } from "../../agents/run-session-target.js";
+import {
+  sanitizeToolCallInputs,
+  sanitizeToolUseResultPairingForModel,
+} from "../../agents/session-transcript-repair.js";
 import { SessionManager } from "../../agents/sessions/index.js";
 import {
   makeAgentAssistantMessage,
   makeAgentUserMessage,
 } from "../../agents/test-helpers/agent-message-fixtures.js";
 import { createSessionEntryWithTranscript } from "../../config/sessions/session-accessor.js";
+import { onAgentRuntimeEvent } from "../../infra/agent-events.js";
 import type { Message } from "../../llm/types.js";
 import {
   createOpenClawTestState,
   type OpenClawTestState,
 } from "../../test-utils/openclaw-test-state.js";
 import { createTrackedTempDirs } from "../../test-utils/tracked-temp-dirs.js";
+import { readSkillReviewOutcomes } from "./collection-review-state.js";
 import { runSkillExperienceReview, type ExperienceReviewCandidate } from "./experience-review.js";
 import { listSkillProposals } from "./service.js";
 
@@ -24,6 +31,27 @@ const modelId = process.env.OPENCLAW_LIVE_SKILL_EXPERIENCE_MODEL ?? "gpt-5.6-lun
 const tempDirs = createTrackedTempDirs();
 let testState: OpenClawTestState;
 let workspaceDir = "";
+const reviewDiagnostics = new Map<string, unknown>();
+const unsubscribeDiagnostics = LIVE
+  ? onAgentRuntimeEvent((event) => {
+      if (
+        !event.runId.startsWith("skill-workshop-review:") ||
+        !["assistant", "tool", "lifecycle", "error"].includes(event.stream)
+      ) {
+        return;
+      }
+      const phase = typeof event.data.phase === "string" ? event.data.phase : "";
+      const toolCallId = typeof event.data.toolCallId === "string" ? event.data.toolCallId : "";
+      const key = `${event.runId}:${event.stream}:${phase}:${toolCallId}`;
+      if (reviewDiagnostics.size < 100 || reviewDiagnostics.has(key)) {
+        reviewDiagnostics.set(key, {
+          runId: event.runId,
+          stream: event.stream,
+          data: redactAgentDiagnosticPayload(event.data),
+        });
+      }
+    })
+  : () => undefined;
 
 function assistantText(text: string) {
   return makeAgentAssistantMessage({ model: modelId, content: [{ type: "text", text }] });
@@ -53,6 +81,140 @@ function toolRound(
   ];
 }
 
+function positiveMessages(): Message[] {
+  return [
+    makeAgentUserMessage({
+      content:
+        "Deploy this repository from its checked-in manifest. Do not ask for values already present there.",
+    }),
+    ...toolRound("deploy-project", "exec", { command: "deploy" }, "project required", true),
+    ...toolRound(
+      "deploy-region",
+      "exec",
+      { command: "deploy --project app" },
+      "region required",
+      true,
+    ),
+    ...toolRound(
+      "deploy-service",
+      "exec",
+      { command: "deploy --project app --region us" },
+      "service required",
+      true,
+    ),
+    assistantText("I am still guessing required fields one at a time."),
+    ...toolRound(
+      "read-manifest",
+      "read",
+      { path: "deploy.json" },
+      "project=app region=us service=api health=/ready",
+    ),
+    assistantText("The manifest contains all required deployment inputs."),
+    ...toolRound(
+      "deploy-complete",
+      "exec",
+      { command: "deploy --project app --region us --service api" },
+      "deployed",
+    ),
+    ...toolRound("fetch-health", "exec", { command: "fetch /ready" }, "200 ok"),
+    assistantText("Deployment verified."),
+    assistantText("Next time the manifest should be read before the first deploy call."),
+    assistantText("That preflight would remove three failed tool rounds."),
+    assistantText("Done."),
+  ];
+}
+
+function negativeMessages(): Message[] {
+  return [
+    makeAgentUserMessage({
+      content:
+        "One-time audit: check these ten unrelated opaque receipts. Policy requires one signed lookup per receipt; no batching or reuse is possible.",
+    }),
+    ...Array.from({ length: 10 }, (_, index) =>
+      toolRound(
+        `receipt-${index + 1}`,
+        "exec",
+        { command: `signed_receipt_lookup --id ${index + 1}` },
+        "valid",
+      ),
+    ).flat(),
+    assistantText("All ten one-time receipts are valid."),
+  ];
+}
+
+function interruptedMessages(): Message[] {
+  // Copying only a WAL-mode main file can pass integrity_check while missing
+  // committed rows. This recovery was reproduced against SQLite's backup API.
+  return [
+    makeAgentUserMessage({
+      content:
+        "Back up the running SQLite event database, verify the backup, then update the operations guide.",
+    }),
+    ...toolRound(
+      "copy-backup",
+      "exec",
+      { command: "cp events.db backup.db && python3 verify-backup.py events.db backup.db" },
+      "source events=3; backup events=0; backup integrity_check=ok; verification failed: committed events missing",
+      true,
+    ),
+    ...toolRound(
+      "copy-backup-retry",
+      "exec",
+      { command: "cp events.db backup.db && python3 verify-backup.py events.db backup.db" },
+      "source events=3; backup events=0; backup integrity_check=ok; verification failed: committed events missing",
+      true,
+    ),
+    ...toolRound(
+      "inspect-journal",
+      "exec",
+      {
+        command:
+          "sqlite3 events.db 'PRAGMA journal_mode; SELECT count(*) FROM events;' && ls events.db*",
+      },
+      "wal\n3\nevents.db events.db-shm events.db-wal",
+    ),
+    assistantText(
+      "The committed events are still in the WAL. A valid main-file copy is not a complete snapshot.",
+    ),
+    ...toolRound(
+      "read-backup-api",
+      "read",
+      { path: "docs/sqlite-online-backup.md" },
+      "https://sqlite.org/backup.html: The online backup API copies a database into a consistent snapshot while the source remains in use. Python sqlite3.Connection.backup exposes that API.",
+    ),
+    ...toolRound(
+      "online-backup",
+      "exec",
+      {
+        command:
+          'python3 -c \'import sqlite3; source=sqlite3.connect("events.db"); target=sqlite3.connect("snapshot.db"); source.backup(target); target.close(); source.close()\'',
+      },
+      "exit code 0",
+    ),
+    ...toolRound(
+      "verify-snapshot",
+      "exec",
+      { command: "python3 verify-backup.py events.db snapshot.db" },
+      "source events=3; backup events=3; backup integrity_check=ok; verification passed",
+    ),
+    assistantText(
+      "The online backup contains all committed events and passes the integrity check while the source remains open. Moving on to the operations guide.",
+    ),
+    makeAgentAssistantMessage({
+      model: modelId,
+      stopReason: "toolUse",
+      content: [
+        {
+          type: "toolCall",
+          id: "read-operations-guide",
+          name: "read",
+          arguments: { path: "OPERATIONS.md" },
+        },
+      ],
+    }),
+  ];
+}
+
 beforeAll(async () => {
   // Full home isolation: the embedded review resolves the shared-main auth
   // store via HOME, and a real ~/.openclaw with pending doctor migration
@@ -65,6 +227,14 @@ beforeAll(async () => {
 });
 
 afterAll(async () => {
+  unsubscribeDiagnostics();
+  if (LIVE) {
+    console.log("WORKSHOP_RUNTIME_DIAGNOSTICS", JSON.stringify([...reviewDiagnostics.values()]));
+    console.log(
+      "WORKSHOP_REVIEW_OUTCOMES",
+      JSON.stringify(readSkillReviewOutcomes().experienceReviews),
+    );
+  }
   await testState.cleanup();
   await tempDirs.cleanup();
 });
@@ -160,12 +330,16 @@ async function candidate(
 }
 
 describe("skill experience review transcript fixture", () => {
-  it("persists messages through a canonical session", async () => {
-    const runId = "transcript-fixture";
+  it.each([
+    ["positive", positiveMessages],
+    ["negative", negativeMessages],
+    ["interrupted", interruptedMessages],
+  ] as const)("preserves %s evidence through canonical transcript replay", async (name, build) => {
+    const runId = `transcript-fixture-${name}`;
     const sessionId = `live-skill-review-${runId}`;
     const sessionKey = `agent:main:${sessionId}`;
-    const message = makeAgentUserMessage({ content: "Review this completed task." });
-    const seeded = await candidate(runId, [message]);
+    const messages = build();
+    const seeded = await candidate(runId, messages);
     const target = await resolveAgentRunSessionTarget({
       agentId: "main",
       config: seeded.config,
@@ -173,10 +347,18 @@ describe("skill experience review transcript fixture", () => {
       sessionId,
       sessionKey,
     });
+    const stored = SessionManager.open(target, workspaceDir).buildSessionContext().messages;
+    expect(stored).toEqual(messages);
 
-    expect(SessionManager.open(target, workspaceDir).buildSessionContext().messages).toEqual([
-      message,
-    ]);
+    // The review replays native tools. Invented tool names lose their calls
+    // and orphaned results, removing the recovery evidence from the evaluation.
+    const replay = sanitizeToolUseResultPairingForModel(
+      sanitizeToolCallInputs(stored, { allowedToolNames: ["exec", "read", "skill_workshop"] }),
+      true,
+    );
+    expect(replay.filter((message) => message.role === "toolResult")).toEqual(
+      expect.arrayContaining(messages.filter((message) => message.role === "toolResult")),
+    );
   });
 });
 
@@ -195,42 +377,7 @@ describeLive("skill experience review live OpenAI eval", () => {
   }, 600_000);
 
   it("proposes a recovered preflight procedure but ignores routine one-off work", async () => {
-    const positiveMessages: Message[] = [
-      makeAgentUserMessage({
-        content:
-          "Deploy this repository from its checked-in manifest. Do not ask for values already present there.",
-      }),
-      ...toolRound("deploy-project", "deploy", {}, "project required", true),
-      ...toolRound("deploy-region", "deploy", { project: "app" }, "region required", true),
-      ...toolRound(
-        "deploy-service",
-        "deploy",
-        { project: "app", region: "us" },
-        "service required",
-        true,
-      ),
-      assistantText("I am still guessing required fields one at a time."),
-      ...toolRound(
-        "read-manifest",
-        "read",
-        { path: "deploy.json" },
-        "project=app region=us service=api health=/ready",
-      ),
-      assistantText("The manifest contains all required deployment inputs."),
-      ...toolRound(
-        "deploy-complete",
-        "deploy",
-        { project: "app", region: "us", service: "api" },
-        "deployed",
-      ),
-      ...toolRound("fetch-health", "fetch", { path: "/ready" }, "200 ok"),
-      assistantText("Deployment verified."),
-      assistantText("Next time the manifest should be read before the first deploy call."),
-      assistantText("That preflight would remove three failed tool rounds."),
-      assistantText("Done."),
-    ];
-
-    const positiveCandidate = await candidate("live-positive", positiveMessages);
+    const positiveCandidate = await candidate("live-positive", positiveMessages());
     await runSkillExperienceReview(positiveCandidate, {
       getCurrentConfig: () => positiveCandidate.config ?? {},
     });
@@ -238,60 +385,14 @@ describeLive("skill experience review live OpenAI eval", () => {
     expect(afterPositive.proposals).toHaveLength(1);
     expect(afterPositive.proposals[0]).toMatchObject({ status: "pending" });
 
-    const negativeMessages: Message[] = [
-      makeAgentUserMessage({
-        content:
-          "One-time audit: check these ten unrelated opaque receipts. Policy requires one signed lookup per receipt; no batching or reuse is possible.",
-      }),
-      ...Array.from({ length: 10 }, (_, index) =>
-        toolRound(`receipt-${index + 1}`, "signed_receipt_lookup", { id: index + 1 }, "valid"),
-      ).flat(),
-      assistantText("All ten one-time receipts are valid."),
-    ];
-
-    const negativeCandidate = await candidate("live-negative", negativeMessages);
+    const negativeCandidate = await candidate("live-negative", negativeMessages());
     await runSkillExperienceReview(negativeCandidate, {
       getCurrentConfig: () => negativeCandidate.config ?? {},
     });
     const afterNegative = await listSkillProposals({ workspaceDir });
     expect(afterNegative.proposals).toEqual(afterPositive.proposals);
 
-    const interruptedMessages: Message[] = [
-      makeAgentUserMessage({
-        content: "Publish the package. The registry keeps rejecting the token.",
-      }),
-      ...toolRound("publish-token", "publish", {}, "401 invalid token", true),
-      ...toolRound("publish-retry", "publish", { retry: true }, "401 invalid token", true),
-      assistantText("Retrying does not help; the stored scope must be wrong."),
-      ...toolRound(
-        "registry-whoami",
-        "exec",
-        { command: "registry whoami" },
-        "authenticated to legacy-registry.example, expected registry.example",
-      ),
-      ...toolRound(
-        "registry-login",
-        "exec",
-        { command: "registry login --host registry.example" },
-        "login ok",
-      ),
-      ...toolRound("publish-complete", "publish", {}, "published 1.2.3"),
-      assistantText("Publish verified. Moving on to the release notes."),
-      makeAgentAssistantMessage({
-        model: modelId,
-        stopReason: "toolUse",
-        content: [
-          {
-            type: "toolCall",
-            id: "read-changelog",
-            name: "read",
-            arguments: { path: "CHANGELOG.md" },
-          },
-        ],
-      }),
-    ];
-
-    const interruptedCandidate = await candidate("live-interrupted", interruptedMessages, {
+    const interruptedCandidate = await candidate("live-interrupted", interruptedMessages(), {
       turnAborted: true,
     });
     await runSkillExperienceReview(interruptedCandidate, {

--- a/src/skills/workshop/experience-review.live.test.ts
+++ b/src/skills/workshop/experience-review.live.test.ts
@@ -1,3 +1,4 @@
+import path from "node:path";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import { redactAgentDiagnosticPayload } from "../../agents/diagnostic-redaction.js";
 import { isLiveTestEnabled } from "../../agents/live-test-helpers.js";
@@ -14,6 +15,7 @@ import {
 import { createSessionEntryWithTranscript } from "../../config/sessions/session-accessor.js";
 import { onAgentRuntimeEvent } from "../../infra/agent-events.js";
 import type { Message } from "../../llm/types.js";
+import { closeOpenClawStateDatabaseByPath } from "../../state/openclaw-state-db.js";
 import {
   createOpenClawTestState,
   type OpenClawTestState,
@@ -229,11 +231,13 @@ beforeAll(async () => {
   workspaceDir = await tempDirs.make("openclaw-live-skill-review-workspace-");
 });
 
-function logReviewOutcomes() {
+function logReviewOutcomes(
+  reviews: ReturnType<typeof readSkillReviewOutcomes>["experienceReviews"],
+) {
   // Persisted failures contain raw provider errors; keep only structured
   // outcome metadata in CI logs, regardless of secret spelling or format.
   const outcomes = Object.fromEntries(
-    Object.entries(readSkillReviewOutcomes().experienceReviews).map(([key, review]) => [
+    Object.entries(reviews).map(([key, review]) => [
       key,
       {
         attemptedAtMs: review.attemptedAtMs,
@@ -250,7 +254,7 @@ afterAll(async () => {
   unsubscribeDiagnostics();
   if (LIVE) {
     console.log("WORKSHOP_RUNTIME_DIAGNOSTICS", JSON.stringify([...reviewDiagnostics.values()]));
-    logReviewOutcomes();
+    logReviewOutcomes(readSkillReviewOutcomes().experienceReviews);
   }
   await testState.cleanup();
   await tempDirs.cleanup();
@@ -348,16 +352,24 @@ async function candidate(
 
 describe("skill experience review diagnostics", () => {
   it("logs persisted failure outcomes without raw provider error text", async () => {
+    const liveOutcomesBefore = readSkillReviewOutcomes();
     const diagnosticWorkspace = await tempDirs.make("openclaw-live-skill-review-diagnostic-");
-    recordSkillExperienceReviewOutcome(diagnosticWorkspace, {
-      attemptedAtMs: 1,
-      outcome: "failed",
-      error: "provider rejected Authorization: Bearer synthetic-workshop-credential",
-      usage: { inputTokens: 3, cachedInputTokens: 1, outputTokens: 2 },
-    });
+    // Workspace keys share one database. Isolate synthetic failures so the
+    // live afterAll output contains only outcomes from actual review runs.
+    const diagnosticStore = { path: path.join(diagnosticWorkspace, "openclaw.sqlite") };
     const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
     try {
-      logReviewOutcomes();
+      recordSkillExperienceReviewOutcome(
+        diagnosticWorkspace,
+        {
+          attemptedAtMs: 1,
+          outcome: "failed",
+          error: "provider rejected Authorization: Bearer synthetic-workshop-credential",
+          usage: { inputTokens: 3, cachedInputTokens: 1, outputTokens: 2 },
+        },
+        diagnosticStore,
+      );
+      logReviewOutcomes(readSkillReviewOutcomes(diagnosticStore).experienceReviews);
       expect(log).toHaveBeenCalledOnce();
       const [label, json] = log.mock.calls[0]!;
       expect(label).toBe("WORKSHOP_REVIEW_OUTCOMES");
@@ -367,8 +379,10 @@ describe("skill experience review diagnostics", () => {
         usage: { inputTokens: 3, cachedInputTokens: 1, outputTokens: 2 },
       });
       expect(json).not.toContain("synthetic-workshop-credential");
+      expect(readSkillReviewOutcomes()).toEqual(liveOutcomesBefore);
     } finally {
       log.mockRestore();
+      closeOpenClawStateDatabaseByPath(diagnosticStore.path);
     }
   });
 });


### PR DESCRIPTION
Related: #129973 (Skill Workshop review outcomes and deterministic evaluation contract), #131904 (which skills detached reviews can read).

## What Problem This Solves

Resolves a problem where full release verification evaluated Skill Workshop with incomplete recovery evidence. Native transcript replay removed invented `deploy`, `fetch`, `publish`, and receipt-lookup tool calls and their orphaned results. The interrupted positive case also represented a transient credential/registry problem, which the documented reviewer contract permits the model to decline.

## Why This Change Was Made

Use native `exec`/`read` calls in the shared live fixtures and verify that every actual tool result survives canonical transcript storage and replay. Replace the interrupted credential example with a reproduced SQLite WAL backup recovery: copying the main file twice passes the integrity check but misses committed rows; an online backup preserves those rows. The transcript still ends with an unfinished guide read after the successful recovery.

The fixture correction preserves the production prompt, model, mutation limits, proposal assertions, and timeouts. Bounded, redacted runtime diagnostics retain visible tool/lifecycle events and the existing review outcome when the live evaluation fails. No production, database schema, or persistence-policy changes are included.

## User Impact

Internal release-verification repair only. The live test still requires a pending proposal for successful recovery, no proposal for routine one-off work, and a new proposal for verified progress before interruption. This repairs the evaluation inputs; it does not claim that live model classification is deterministic or resolve the broader outcome-contract discussion in #129973. The separate production capability guidance in #131904 remains open.

AI-assisted maintainer work requested as part of shortening full release verification.

## Evidence

- Original scoped native run [33236864447](https://github.com/openclaw/openclaw/actions/runs/33236864447): positive count `0` on the first attempt; interrupted count `1 > 1` failed on the whole-shard retry. A single-file baseline [33239104897](https://github.com/openclaw/openclaw/actions/runs/33239104897) reproduced the positive failure without skips.
- Actual fixture replay before repair retained only 1/6 positive, 0/10 negative, and 2/5 interrupted tool results. The three strengthened fixture checks failed on those original inputs and passed after native-tool repair. `node --import tsx scripts/test-live.mts src/skills/workshop/experience-review.live.test.ts -t 'transcript fixture'`: 3 passed; the unselected live case is intentionally excluded from this local check.
- Native-tool repair alone [33239472532](https://github.com/openclaw/openclaw/actions/runs/33239472532) passed the positive and negative cases but still failed the transient-auth interrupted case. Diagnostics showed normal completion, no interrupted-review tool call, and the existing `nothing` outcome. No runtime error or timeout was hidden.
- The replacement recovery was executed locally against SQLite 3.53.4: source count 3; both main-file copies count 0 with `integrity_check=ok`; online backup count 3 with `integrity_check=ok`. Contract references: [SQLite online backup](https://sqlite.org/backup.html), [Python Connection.backup](https://docs.python.org/3/library/sqlite3.html#sqlite3.Connection.backup).
- Full live candidate [Testbox 33239812755](https://github.com/openclaw/openclaw/actions/runs/33239812755): **4 passed, 0 skipped**, including all three original live assertions in their original order. Observed pending manifest-deployment proposal, unchanged negative count, then pending SQLite-backup proposal. Provider `blacksmith-testbox`, lease `tbx_01m1653sbzs4899cdz54krh0rs`, command 180.287s, exit 0; lease stopped after completion. Workflow source `8c23dc68b67b9af2062bd789a23e6d6d2650672f` plus the one synced test file, SHA-256 `e66ff1a7972dbb26b2d4c991facfa8426b524c9ea2e08c0c2fbc3ad64ac42d6e`. Review owner and prompt hashes match the baseline. This is observed before/after behavior, not a same-head timing comparison.
- Independent Codex autoreview: clean at the configured P0 scope. Formatting and `git diff --check`: passed. `node scripts/check-changed.mjs -- src/skills/workshop/experience-review.live.test.ts` passed every repository guard and core-test typechecking, then found two untyped diagnostic-key interpolations in final lint. Those fields now narrow to strings; the final targeted lint and all three fixture checks passed, followed by a fresh clean review. The only edit after the green live run is this diagnostic-key typing; all three live transcripts, model settings, assertions, and production files are unchanged.

Production LOC delta: 0. Test-only delta: +192/-91, including moving the three fixtures into shared builders so the replay checks exercise the same evidence as the live evaluation.
