### PR TITLE
fix(heartbeat,doctor): stop orphaning isolated heartbeat wake transcripts (#131770)

### DIFF
--- a/qa/scenarios/runtime/heartbeat-isolated-rollover-deferred-archive.yaml
+++ b/qa/scenarios/runtime/heartbeat-isolated-rollover-deferred-archive.yaml
@@ -1,0 +1,28 @@
+title: Heartbeat isolated rollover deferred archive
+
+scenario:
+  id: heartbeat-isolated-rollover-deferred-archive
+  surface: runtime
+  coverage:
+    secondary:
+      - automation.heartbeat-scheduling
+      - session-memory.transcript-persistence
+  regressionRefs:
+    - openclaw/openclaw#131770
+  objective: Prove an isolated heartbeat wake defers the replaced generation's transcript archival while a real session-work admission owns the lane, then archives it at admission release without a further wake.
+  successCriteria:
+    - A real manual wake rolls the stable isolated row while a real session-work admission holds the isolated lane.
+    - The replaced generation's reclamation is deferred onto the committed row as a pending transcript archive.
+    - The displaced transcript materializes on disk while the lane is still admitted.
+    - Releasing the admission archives the deferred transcript with no further heartbeat wake.
+  docsRefs:
+    - docs/gateway/heartbeat.md
+  codeRefs:
+    - src/infra/heartbeat-isolated-rollover.ts
+    - src/infra/heartbeat-runner-execution.ts
+    - test/e2e/qa-lab/runtime/heartbeat-isolated-rollover-deferred-archive.ts
+  execution:
+    kind: script
+    path: test/e2e/qa-lab/runtime/heartbeat-isolated-rollover-deferred-archive.ts
+    timeoutMs: 180000
+    summary: Holds a real session-work admission on the isolated lane, runs one real manual isolated-heartbeat wake, proves the deferred reclamation commit and materialized transcript, releases the admission, and proves the archive rename happens with no further wake.

--- a/qa/scenarios/runtime/heartbeat-isolated-rollover-restart-recovery.yaml
+++ b/qa/scenarios/runtime/heartbeat-isolated-rollover-restart-recovery.yaml
@@ -1,0 +1,29 @@
+title: Heartbeat isolated rollover restart recovery
+
+scenario:
+  id: heartbeat-isolated-rollover-restart-recovery
+  surface: runtime
+  coverage:
+    secondary:
+      - automation.heartbeat-scheduling
+      - session-memory.transcript-persistence
+  regressionRefs:
+    - openclaw/openclaw#131770
+  objective: Prove a deferred isolated-rollover reclamation survives a simulated gateway stop and is reclaimed by the first real wake after restart.
+  successCriteria:
+    - Phase one commits the deferral through the real rollover path and exits before the admission releases, with the deferred generation persisted on the committed row.
+    - The displaced transcript materializes on disk before the simulated stop.
+    - A fresh process restart reads the persisted deferred row unchanged.
+    - The first real wake after restart reclaims the persisted deferred generation and archives its transcript.
+  docsRefs:
+    - docs/gateway/heartbeat.md
+  codeRefs:
+    - src/infra/heartbeat-isolated-rollover.ts
+    - src/infra/heartbeat-runner-execution.ts
+    - src/cron/isolated-agent/run-session-state.ts
+    - test/e2e/qa-lab/runtime/heartbeat-isolated-rollover-restart-recovery.ts
+  execution:
+    kind: script
+    path: test/e2e/qa-lab/runtime/heartbeat-isolated-rollover-restart-recovery.ts
+    timeoutMs: 180000
+    summary: Runs the two-process restart proof in one invocation — phase one persists the deferred generation and exits with the admission unreleased, then phase two restarts in a fresh process and proves the first real wake reclaims and archives the persisted transcript.

--- a/src/commands/doctor-state-integrity.transcripts.test.ts
+++ b/src/commands/doctor-state-integrity.transcripts.test.ts
@@ -296,6 +296,158 @@ describe("doctor transcript and heartbeat session repairs", () => {
     expect(text).not.toContain(" ls ");
   });
 
+  it("skips cron sessions whose persistence recorded an unmaterialized transcript", async () => {
+    const cfg: OpenClawConfig = {};
+    writeSessionStore(cfg, {
+      "agent:main:cron:daily-job": {
+        sessionId: "reaped-cron-run",
+        updatedAt: Date.now(),
+        transcriptMaterialized: false,
+      },
+      "agent:main:cron:daily-job:run:reaped-cron-run": {
+        sessionId: "reaped-cron-run",
+        updatedAt: Date.now(),
+        transcriptMaterialized: false,
+      },
+    });
+    const text = await runStateIntegrityText(cfg);
+    expect(text).not.toContain("recent sessions are missing transcripts");
+  });
+
+  it("keeps missing-transcript warnings for CLI sessions without a recorded disposal", async () => {
+    // Normal CLI-backed conversations persist local transcripts; a missing
+    // file without an owner-recorded disposition stays diagnosable (#131770).
+    const cfg: OpenClawConfig = {};
+    writeSessionStore(cfg, {
+      "agent:main:telegram:dm:cli-peer": {
+        sessionId: "cli-session",
+        updatedAt: Date.now(),
+        model: "claude-opus-4-6",
+        modelProvider: "claude-cli",
+        cliSessionBindings: { "claude-cli": { sessionId: "cli-conversation-xyz" } },
+      },
+    });
+    const text = await runStateIntegrityText(cfg);
+    expect(text).toContain("1/1 recent sessions are missing transcripts");
+  });
+
+  it("keeps missing-transcript warnings for retained cron sessions without cleanup proof", async () => {
+    const cfg: OpenClawConfig = {};
+    writeSessionStore(cfg, {
+      "agent:main:cron:daily-job": {
+        sessionId: "retained-cron-run",
+        updatedAt: Date.now(),
+      },
+    });
+    const text = await runStateIntegrityText(cfg);
+    expect(text).toContain("1/1 recent sessions are missing transcripts");
+  });
+
+  it("skips isolated heartbeat sessions whose transcripts were removed by rollover", async () => {
+    const cfg: OpenClawConfig = {};
+    writeSessionStore(cfg, {
+      "agent:main:main:heartbeat": {
+        sessionId: "previous-heartbeat-wake",
+        updatedAt: Date.now(),
+        heartbeatIsolatedBaseSessionKey: "agent:main:main",
+      },
+    });
+    const text = await runStateIntegrityText(cfg);
+    expect(text).not.toContain("recent sessions are missing transcripts");
+  });
+
+  it("keeps missing-transcript warnings for real sessions next to churn rows", async () => {
+    const cfg: OpenClawConfig = {};
+    writeSessionStore(cfg, {
+      "agent:main:telegram:dm:real-peer": {
+        sessionId: "vanished-transcript",
+        updatedAt: Date.now(),
+      },
+      "agent:main:cron:daily-job": {
+        sessionId: "reaped-cron-run",
+        updatedAt: Date.now(),
+        transcriptMaterialized: false,
+      },
+      "agent:main:main:heartbeat": {
+        sessionId: "previous-heartbeat-wake",
+        updatedAt: Date.now(),
+        heartbeatIsolatedBaseSessionKey: "agent:main:main",
+      },
+    });
+    const text = await runStateIntegrityText(cfg);
+    expect(text).toContain("1/1 recent sessions are missing transcripts");
+  });
+
+  it("still warns for an older real session when newer churn rows fill the recent window", async () => {
+    const cfg: OpenClawConfig = {};
+    const now = Date.now();
+    writeSessionStore(cfg, {
+      "agent:main:telegram:dm:real-peer": {
+        sessionId: "vanished-transcript",
+        updatedAt: now - 5_000,
+      },
+      "agent:main:cron:job-a": {
+        sessionId: "cron-run-a",
+        updatedAt: now - 4_000,
+        transcriptMaterialized: false,
+      },
+      "agent:main:cron:job-a:run:cron-run-a": {
+        sessionId: "cron-run-a",
+        updatedAt: now - 3_000,
+        transcriptMaterialized: false,
+      },
+      "agent:main:cron:job-b": {
+        sessionId: "cron-run-b",
+        updatedAt: now - 2_000,
+        transcriptMaterialized: false,
+      },
+      "agent:main:cron:job-b:run:cron-run-b": {
+        sessionId: "cron-run-b",
+        updatedAt: now - 1_000,
+        transcriptMaterialized: false,
+      },
+      "agent:main:main:heartbeat": {
+        sessionId: "latest-heartbeat-wake",
+        updatedAt: now,
+        heartbeatIsolatedBaseSessionKey: "agent:main:main",
+      },
+    });
+    const text = await runStateIntegrityText(cfg);
+    expect(text).toContain("1/1 recent sessions are missing transcripts");
+  });
+
+  it("skips canonical heartbeat rows even when rollover stamped an interaction timestamp", async () => {
+    // Real rollover rows are created via resolveCronSession(..., forceNew),
+    // which stamps lastInteractionAt on every fresh isolated session. The
+    // transient classification must therefore key off synthetic ownership and
+    // the canonical key shape, not activity timestamps (#131770).
+    const cfg: OpenClawConfig = {};
+    const now = Date.now();
+    writeSessionStore(cfg, {
+      "agent:main:main:heartbeat": {
+        sessionId: "rolled-heartbeat-wake",
+        updatedAt: now,
+        lastInteractionAt: now,
+        heartbeatIsolatedBaseSessionKey: "agent:main:main",
+      },
+    });
+    const text = await runStateIntegrityText(cfg);
+    expect(text).not.toContain("recent sessions are missing transcripts");
+  });
+
+  it("keeps missing-transcript warnings for non-canonical heartbeat markers", async () => {
+    const cfg: OpenClawConfig = {};
+    writeSessionStore(cfg, {
+      "agent:main:telegram:dm:real-peer": {
+        sessionId: "mis-marked-session",
+        updatedAt: Date.now(),
+        heartbeatIsolatedBaseSessionKey: "agent:main:main",
+      },
+    });
+    const text = await runStateIntegrityText(cfg);
+    expect(text).toContain("1/1 recent sessions are missing transcripts");
+  });
+
   it("preserves a non-main compatibility owner for a fixed legacy store", async () => {
     const storePath = path.join(tempHome, "fixed-store", "sessions.json");
     const cfg: OpenClawConfig = {

--- a/src/commands/doctor-state-integrity.ts
+++ b/src/commands/doctor-state-integrity.ts
@@ -747,6 +747,37 @@ function isSlashRoutingSessionKey(sessionKey: string): boolean {
   return /^[^:]+:slash:[^:]+(?:$|:)/.test(scoped);
 }
 
+/**
+ * Missing transcripts are expected only when the lifecycle owner recorded the
+ * disposition or the row is structurally transient (#131770): isolated cron
+ * persistence stamps `transcriptMaterialized: false` when it commits a row
+ * without a materialized transcript file, and every isolated heartbeat wake
+ * rolls a fresh session ID under a stable store key, so the canonical
+ * isolated row never holds durable user history. Retained rows without an
+ * owner-recorded disposition keep their warning so unexpected transcript
+ * loss stays diagnosable.
+ */
+function isExpectedTransientTranscriptSession(sessionKey: string, entry: SessionEntry): boolean {
+  if (entry.transcriptMaterialized === false) {
+    return true;
+  }
+  const isolatedBaseSessionKey = entry.heartbeatIsolatedBaseSessionKey;
+  if (typeof isolatedBaseSessionKey !== "string" || !isolatedBaseSessionKey.trim()) {
+    return false;
+  }
+  // Ownership, not activity, decides: the marker identifies a synthetic
+  // isolated session (#131770), and the rollover path stamps
+  // `lastInteractionAt` on every fresh row, so activity timestamps cannot
+  // separate machine churn from user history here. Only rows in the canonical
+  // isolated-key relationship qualify: the stable `<base>:heartbeat` key (or
+  // the agent-qualified sibling of the literal `global` base).
+  const base = isolatedBaseSessionKey.trim();
+  return (
+    sessionKey === `${base}:heartbeat` ||
+    (base === "global" && sessionKey.endsWith(":global:heartbeat"))
+  );
+}
+
 function shouldRequireOAuthDir(cfg: OpenClawConfig, env: NodeJS.ProcessEnv): boolean {
   if (env.OPENCLAW_OAUTH_DIR?.trim()) {
     return true;
@@ -1355,6 +1386,18 @@ export async function noteStateIntegrity(
     let sqliteNewKeyIndex = 0;
     const recent: Array<{ entry: SessionEntry; order: number; sessionKey: string }> = [];
     const addRecent = (sessionKey: string, entry: SessionEntry, order: number) => {
+      // Only sessions whose transcripts are expected to persist belong in the
+      // recent window. Exclude owner-recorded transcript disposals, canonical
+      // isolated heartbeat churn rows, and slash-routing rows before the
+      // five-entry cap so a burst of newer background rows cannot push an
+      // older real session out of the window and hide its missing transcript
+      // (#131770).
+      if (
+        isSlashRoutingSessionKey(sessionKey) ||
+        isExpectedTransientTranscriptSession(sessionKey, entry)
+      ) {
+        return;
+      }
       recent.push({ entry, order, sessionKey });
       recent.sort((left, right) => {
         const leftUpdated = typeof left.entry.updatedAt === "number" ? left.entry.updatedAt : 0;
@@ -1409,9 +1452,11 @@ export async function noteStateIntegrity(
       countLabel,
     });
     if (mergedEntryCount > 0) {
-      const recentTranscriptCandidates = recent
-        .map(({ entry, sessionKey }) => [sessionKey, entry] as const)
-        .filter(([key]) => !isSlashRoutingSessionKey(key));
+      // Slash-routing and transient churn rows are already excluded while the
+      // recent window is collected, before its five-entry cap applies.
+      const recentTranscriptCandidates = recent.map(
+        ({ entry, sessionKey }) => [sessionKey, entry] as const,
+      );
       const missing = recentTranscriptCandidates.filter(([key, entry]) => {
         if (sqliteSessionKeys.has(key)) {
           return false;

--- a/src/config/sessions/types.ts
+++ b/src/config/sessions/types.ts
@@ -313,6 +313,15 @@ type SessionEntryCore = SessionRestartRecoveryState &
      * missing its transcript (#131770). Absent means no recorded disposition.
      */
     transcriptMaterialized?: boolean;
+    /**
+     * Deferred transcript archival for replaced isolated heartbeat generations
+     * whose run was still admitted when the rollover replaced them (#131770).
+     * The next rollover reclaims these session ids once the session lane goes
+     * quiet, so a transcript that materializes after a competing rollover is
+     * still archived instead of being orphaned. Absent means nothing is
+     * pending.
+     */
+    pendingTranscriptArchiveSessionIds?: string[];
     /** Legacy heartbeat task timestamps consumed and cleared only by doctor migration. */
     heartbeatTaskState?: Record<string, number>;
     /** Plugin-owned session state, grouped by plugin id then extension namespace. */

--- a/src/config/sessions/types.ts
+++ b/src/config/sessions/types.ts
@@ -316,10 +316,10 @@ type SessionEntryCore = SessionRestartRecoveryState &
     /**
      * Deferred transcript archival for replaced isolated heartbeat generations
      * whose run was still admitted when the rollover replaced them (#131770).
-     * The next rollover reclaims these session ids once the session lane goes
-     * quiet, so a transcript that materializes after a competing rollover is
-     * still archived instead of being orphaned. Absent means nothing is
-     * pending.
+     * These session ids are archived when the lane's admissions release, and
+     * the field also survives on the row so a process restart before that
+     * release still reclaims them on the next rollover. Absent means nothing
+     * is pending.
      */
     pendingTranscriptArchiveSessionIds?: string[];
     /** Legacy heartbeat task timestamps consumed and cleared only by doctor migration. */

--- a/src/config/sessions/types.ts
+++ b/src/config/sessions/types.ts
@@ -305,6 +305,14 @@ type SessionEntryCore = SessionRestartRecoveryState &
      * a real user/session-scoped key that merely happens to end with `:heartbeat`.
      */
     heartbeatIsolatedBaseSessionKey?: string;
+    /**
+     * Owner-recorded transcript disposition. Explicit `false` means the
+     * lifecycle owner persisted this row without a materialized transcript
+     * file (e.g. an isolated cron run whose transcript never materialized or
+     * was removed on completion), so state integrity must not flag the row as
+     * missing its transcript (#131770). Absent means no recorded disposition.
+     */
+    transcriptMaterialized?: boolean;
     /** Legacy heartbeat task timestamps consumed and cleared only by doctor migration. */
     heartbeatTaskState?: Record<string, number>;
     /** Plugin-owned session state, grouped by plugin id then extension namespace. */

--- a/src/cron/isolated-agent/run-session-state.test.ts
+++ b/src/cron/isolated-agent/run-session-state.test.ts
@@ -528,6 +528,51 @@ describe("createPersistCronSessionEntry", () => {
     });
   });
 
+  it("clears a stale unmaterialized-transcript disposition once the transcript materializes", async () => {
+    // Transition regression (#131770): a previous run stamped the row with
+    // `transcriptMaterialized: false` when its transcript never materialized.
+    // Once a later run's transcript exists, the superseded disposition must be
+    // cleared, or doctor would keep suppressing missing-transcript warnings for
+    // a transcript that is later lost again.
+    const dir = makeTempDir(cronSessionTempDirs, "openclaw-cron-session-materialized-");
+    const storePath = path.join(dir, "sessions.json");
+    await appendTranscriptMessage(
+      {
+        agentId: "main",
+        sessionId: "run-session-id",
+        sessionKey: "agent:main:cron:materialized",
+        storePath,
+      },
+      { message: { role: "user", content: "cron prompt" } },
+    );
+    const cronSession = makeCronSession(
+      makeSessionEntry({
+        label: "Cron: materialized",
+        transcriptMaterialized: false,
+        sessionStartedAt: 900,
+        lastInteractionAt: 950,
+      }),
+      storePath,
+    );
+
+    const persist = createPersistCronSessionEntry({
+      cronSession,
+      agentSessionKey: "agent:main:cron:materialized",
+      persistSessionEntry: vi.fn(async () => {}),
+    });
+
+    await persist();
+
+    expect(cronSession.store["agent:main:cron:materialized"]).toEqual({
+      sessionId: "run-session-id",
+      label: "Cron: materialized",
+      updatedAt: 1000,
+      systemSent: true,
+      sessionStartedAt: 900,
+      lastInteractionAt: 950,
+    });
+  });
+
   it("persists explicit session-bound cron state under the requested session key", async () => {
     const cronSession = makeCronSession();
     const persistSessionEntry = vi.fn(async () => {});

--- a/src/cron/isolated-agent/run-session-state.test.ts
+++ b/src/cron/isolated-agent/run-session-state.test.ts
@@ -473,6 +473,9 @@ describe("createPersistCronSessionEntry", () => {
     expect(cronSession.store["agent:main:cron:shell-only"]?.sessionId).toBe("run-session-id");
     expect(cronSession.store["agent:main:cron:shell-only"]?.sessionFile).toBeUndefined();
     expect(cronSession.store["agent:main:cron:shell-only"]?.lifecycleRevision).toBe("run-revision");
+    // The owner records the missing transcript so doctor can treat it as an
+    // attested disposal instead of unexpected loss (#131770).
+    expect(cronSession.store["agent:main:cron:shell-only"]?.transcriptMaterialized).toBe(false);
     expect(cronSession.sessionEntry.sessionId).toBe("run-session-id");
     expect(persistSessionEntry).toHaveBeenCalledWith({
       storePath: "/tmp/sessions.json",
@@ -484,6 +487,7 @@ describe("createPersistCronSessionEntry", () => {
         status: "running",
         updatedAt: 1000,
         systemSent: true,
+        transcriptMaterialized: false,
       },
       update: expect.any(Function),
     });

--- a/src/cron/isolated-agent/run-session-state.ts
+++ b/src/cron/isolated-agent/run-session-state.ts
@@ -134,6 +134,9 @@ function toNonResumableCronSessionEntry(entry: SessionEntry): SessionEntry {
   delete next.cliSessionIds;
   delete next.cliSessionBindings;
   delete next.claudeCliSessionId;
+  // Record the disposition so doctor treats the missing transcript as an
+  // owner-attested fact instead of unexpected loss (#131770).
+  next.transcriptMaterialized = false;
   return next as SessionEntry;
 }
 

--- a/src/cron/isolated-agent/run-session-state.ts
+++ b/src/cron/isolated-agent/run-session-state.ts
@@ -140,6 +140,22 @@ function toNonResumableCronSessionEntry(entry: SessionEntry): SessionEntry {
   return next as SessionEntry;
 }
 
+/**
+ * Clears a superseded unmaterialized-transcript disposition once the run's
+ * transcript exists (#131770). Without this, a row stamped
+ * `transcriptMaterialized: false` by an earlier run whose transcript never
+ * materialized would keep suppressing doctor's missing-transcript warning
+ * after that row's transcript is later lost again.
+ */
+function toMaterializedCronSessionEntry(entry: SessionEntry): SessionEntry {
+  if (entry.transcriptMaterialized === undefined) {
+    return entry;
+  }
+  const next: SessionEntry = { ...entry };
+  delete next.transcriptMaterialized;
+  return next;
+}
+
 /** Creates the persistence callback that stores cron session metadata after a run. */
 export function createPersistCronSessionEntry(params: {
   cronSession: MutableCronSession;
@@ -151,16 +167,21 @@ export function createPersistCronSessionEntry(params: {
   return async () => {
     const resetBoundaryPending = params.cronSession.resetBoundaryPending !== undefined;
     const liveEntry = params.cronSession.sessionEntry;
-    const persistedEntry =
-      isCronSessionKey(params.agentSessionKey) &&
-      liveEntry.sessionId &&
-      !cronTranscriptExists({
-        entry: liveEntry,
-        sessionKey: params.agentSessionKey,
-        storePath: params.cronSession.storePath,
-      })
-        ? toNonResumableCronSessionEntry(liveEntry)
-        : liveEntry;
+    // The disposition is evaluated per persistence attempt: a cron run whose
+    // transcript materialized clears any stale `transcriptMaterialized: false`
+    // stamp an earlier run left on the row, while a run without a transcript
+    // records the owner-attested disposal (#131770).
+    const cronRowCandidate =
+      isCronSessionKey(params.agentSessionKey) && Boolean(liveEntry.sessionId);
+    const persistedEntry = !cronRowCandidate
+      ? liveEntry
+      : cronTranscriptExists({
+            entry: liveEntry,
+            sessionKey: params.agentSessionKey,
+            storePath: params.cronSession.storePath,
+          })
+        ? toMaterializedCronSessionEntry(liveEntry)
+        : toNonResumableCronSessionEntry(liveEntry);
     let committedEntry = persistedEntry;
     let mergedLiveEntry = liveEntry;
     const persistPromise = params.persistSessionEntry({

--- a/src/infra/heartbeat-isolated-rollover.ts
+++ b/src/infra/heartbeat-isolated-rollover.ts
@@ -2,6 +2,7 @@
 import { resolveSessionStorePathCore } from "../config/sessions/paths.js";
 import type { SessionEntry } from "../config/sessions/types.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { getSessionWorkAdmissionRelease } from "../sessions/session-lifecycle-admission.js";
 import { createLazyRuntimeModule } from "../shared/lazy-runtime.js";
 import { formatErrorMessage } from "./errors.js";
 import { heartbeatLog } from "./heartbeat-runner-config.js";
@@ -21,15 +22,15 @@ const loadSessionArchiveRuntime = createLazyRuntimeModule(
  * rollover committed, so a one-shot archive at that point would miss the file
  * and leave it orphaned. While the session lane is admitted, the replaced
  * generation — plus anything it deferred — is carried on the committed row as
- * `pendingTranscriptArchiveSessionIds` and reclaimed by the next rollover once
- * the lane goes quiet.
+ * `pendingTranscriptArchiveSessionIds` and reclaimed once the lane's
+ * admissions release (see {@link reclaimIsolatedRolloverTranscripts}).
  */
 export function resolveIsolatedRolloverTranscriptReclamation(params: {
   currentEntry?: SessionEntry;
   sessionLaneActive: boolean;
 }): {
   archiveSessionIds: string[];
-  pendingTranscriptArchiveSessionIds?: string[];
+  deferredSessionIds: string[];
 } {
   const deferredFromReplaced = (
     params.currentEntry?.pendingTranscriptArchiveSessionIds ?? []
@@ -38,7 +39,7 @@ export function resolveIsolatedRolloverTranscriptReclamation(params: {
   if (params.sessionLaneActive) {
     return {
       archiveSessionIds: [],
-      pendingTranscriptArchiveSessionIds: [
+      deferredSessionIds: [
         ...deferredFromReplaced,
         ...(replacedSessionId ? [replacedSessionId] : []),
       ],
@@ -46,6 +47,7 @@ export function resolveIsolatedRolloverTranscriptReclamation(params: {
   }
   return {
     archiveSessionIds: [...deferredFromReplaced, ...(replacedSessionId ? [replacedSessionId] : [])],
+    deferredSessionIds: [],
   };
 }
 
@@ -55,7 +57,7 @@ export function resolveIsolatedRolloverTranscriptReclamation(params: {
  * committed (#131770). Individual rename failures are surfaced through the
  * heartbeat log so they are never silently dropped from observability.
  */
-export async function archiveIsolatedRolloverTranscripts(params: {
+async function archiveIsolatedRolloverTranscripts(params: {
   agentId: string;
   cfg: OpenClawConfig;
   sessionIds: readonly string[];
@@ -89,4 +91,45 @@ export async function archiveIsolatedRolloverTranscripts(params: {
       sessionKey: params.sessionKey,
     });
   }
+}
+
+/**
+ * Reclaims both halves of one rollover's reclamation decision (#131770): the
+ * already-terminal generations are archived immediately, and generations whose
+ * run is still admitted are archived as soon as every admission on the
+ * isolated session lane releases — so a transcript that materializes after the
+ * competing rollover is reclaimed even when no further heartbeat wake runs.
+ * The deferred ids also stay on the committed row, so a process restart before
+ * the release still reclaims them on the next rollover.
+ */
+export async function reclaimIsolatedRolloverTranscripts(params: {
+  agentId: string;
+  archiveSessionIds: readonly string[];
+  cfg: OpenClawConfig;
+  deferredSessionIds: readonly string[];
+  sessionKey: string;
+  storePath: string;
+}): Promise<void> {
+  await archiveIsolatedRolloverTranscripts({
+    agentId: params.agentId,
+    cfg: params.cfg,
+    sessionIds: params.archiveSessionIds,
+    sessionKey: params.sessionKey,
+  });
+  if (params.deferredSessionIds.length === 0) {
+    return;
+  }
+  const admissionRelease =
+    getSessionWorkAdmissionRelease({
+      scope: params.storePath,
+      identities: [params.sessionKey],
+    }) ?? Promise.resolve();
+  void admissionRelease.then(() =>
+    archiveIsolatedRolloverTranscripts({
+      agentId: params.agentId,
+      cfg: params.cfg,
+      sessionIds: params.deferredSessionIds,
+      sessionKey: params.sessionKey,
+    }),
+  );
 }

--- a/src/infra/heartbeat-isolated-rollover.ts
+++ b/src/infra/heartbeat-isolated-rollover.ts
@@ -1,0 +1,92 @@
+// Isolated heartbeat rollover transcript reclamation (#131770).
+import { resolveSessionStorePathCore } from "../config/sessions/paths.js";
+import type { SessionEntry } from "../config/sessions/types.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { createLazyRuntimeModule } from "../shared/lazy-runtime.js";
+import { formatErrorMessage } from "./errors.js";
+import { heartbeatLog } from "./heartbeat-runner-config.js";
+
+const loadSessionArchiveRuntime = createLazyRuntimeModule(
+  () => import("../gateway/session-archive.runtime.js"),
+);
+
+/**
+ * Resolves transcript reclamation for one isolated heartbeat rollover
+ * (#131770). Every wake rolls a fresh session ID under a stable store key, and
+ * the rollover upsert replaces the row in place, so lifecycle artifact cleanup
+ * never sees the previous session as removed.
+ *
+ * Reclamation is generation-fenced against live runs: an overlapping wake whose
+ * reply turn is still admitted can materialize its transcript after this
+ * rollover committed, so a one-shot archive at that point would miss the file
+ * and leave it orphaned. While the session lane is admitted, the replaced
+ * generation — plus anything it deferred — is carried on the committed row as
+ * `pendingTranscriptArchiveSessionIds` and reclaimed by the next rollover once
+ * the lane goes quiet.
+ */
+export function resolveIsolatedRolloverTranscriptReclamation(params: {
+  currentEntry?: SessionEntry;
+  sessionLaneActive: boolean;
+}): {
+  archiveSessionIds: string[];
+  pendingTranscriptArchiveSessionIds?: string[];
+} {
+  const deferredFromReplaced = (
+    params.currentEntry?.pendingTranscriptArchiveSessionIds ?? []
+  ).filter((sessionId) => Boolean(sessionId?.trim()));
+  const replacedSessionId = params.currentEntry?.sessionId?.trim();
+  if (params.sessionLaneActive) {
+    return {
+      archiveSessionIds: [],
+      pendingTranscriptArchiveSessionIds: [
+        ...deferredFromReplaced,
+        ...(replacedSessionId ? [replacedSessionId] : []),
+      ],
+    };
+  }
+  return {
+    archiveSessionIds: [...deferredFromReplaced, ...(replacedSessionId ? [replacedSessionId] : [])],
+  };
+}
+
+/**
+ * Archives the file-backed transcripts of the terminal generations selected by
+ * {@link resolveIsolatedRolloverTranscriptReclamation} once the rollover
+ * committed (#131770). Individual rename failures are surfaced through the
+ * heartbeat log so they are never silently dropped from observability.
+ */
+export async function archiveIsolatedRolloverTranscripts(params: {
+  agentId: string;
+  cfg: OpenClawConfig;
+  sessionIds: readonly string[];
+  sessionKey: string;
+}): Promise<void> {
+  if (params.sessionIds.length === 0) {
+    return;
+  }
+  try {
+    const { archiveSessionTranscripts } = await loadSessionArchiveRuntime();
+    const storePath = resolveSessionStorePathCore(params.cfg.session?.store, {
+      agentId: params.agentId,
+    });
+    for (const sessionId of params.sessionIds) {
+      archiveSessionTranscripts({
+        sessionId,
+        storePath,
+        agentId: params.agentId,
+        reason: "deleted",
+        onArchiveError: (error, sourcePath) => {
+          heartbeatLog.warn(
+            `heartbeat: failed to archive previous isolated session transcript ${sourcePath} for session ${sessionId}`,
+            { error: String(error), sessionKey: params.sessionKey },
+          );
+        },
+      });
+    }
+  } catch (err) {
+    heartbeatLog.warn("heartbeat: failed to archive previous isolated session transcript", {
+      err: formatErrorMessage(err),
+      sessionKey: params.sessionKey,
+    });
+  }
+}

--- a/src/infra/heartbeat-runner-execution.ts
+++ b/src/infra/heartbeat-runner-execution.ts
@@ -57,7 +57,7 @@ import { formatErrorMessage } from "./errors.js";
 import { isWithinActiveHours } from "./heartbeat-active-hours.js";
 import { emitHeartbeatEvent } from "./heartbeat-events.js";
 import {
-  archiveIsolatedRolloverTranscripts,
+  reclaimIsolatedRolloverTranscripts,
   resolveIsolatedRolloverTranscriptReclamation,
 } from "./heartbeat-isolated-rollover.js";
 import {
@@ -556,9 +556,10 @@ export async function prepareHeartbeatRunStage(wake: ReadyHeartbeatWake) {
     // The replaced row is captured inside the lifecycle mutation (writer lane)
     // so the archive targets the exact generation this rollover replaced, and
     // reclamation is fenced against live runs — deferred generations ride the
-    // committed row until the session lane goes quiet (#131770; see
+    // committed row until their admission releases (#131770; see
     // heartbeat-isolated-rollover.ts).
     let rolloverArchiveSessionIds: string[] = [];
+    let rolloverDeferredSessionIds: string[] = [];
     const lifecycleResult = await applySessionEntryLifecycleMutation({
       activeSessionKey: isolatedSessionKey,
       storePath: isolatedStorePath,
@@ -574,6 +575,7 @@ export async function prepareHeartbeatRunStage(wake: ReadyHeartbeatWake) {
               ]),
             });
             rolloverArchiveSessionIds = reclamation.archiveSessionIds;
+            rolloverDeferredSessionIds = reclamation.deferredSessionIds;
             const cronSession = resolveCronSession({
               cfg,
               sessionKey: isolatedSessionKey,
@@ -585,11 +587,8 @@ export async function prepareHeartbeatRunStage(wake: ReadyHeartbeatWake) {
             const nextEntry = {
               ...cronSession.sessionEntry,
               heartbeatIsolatedBaseSessionKey: isolatedBaseSessionKey,
-              ...(reclamation.pendingTranscriptArchiveSessionIds
-                ? {
-                    pendingTranscriptArchiveSessionIds:
-                      reclamation.pendingTranscriptArchiveSessionIds,
-                  }
+              ...(rolloverDeferredSessionIds.length > 0
+                ? { pendingTranscriptArchiveSessionIds: rolloverDeferredSessionIds }
                 : {}),
             };
             runSessionEntry = nextEntry;
@@ -605,14 +604,17 @@ export async function prepareHeartbeatRunStage(wake: ReadyHeartbeatWake) {
         sessionKey: staleIsolatedSessionKey,
       });
     }
-    // Archive the terminal generations selected inside the mutation so no
-    // unreferenced .jsonl is left behind (#131770). The list is only populated
-    // when the mutation committed, so a conflict never archives anything.
-    await archiveIsolatedRolloverTranscripts({
+    // Reclaim the generations selected inside the mutation: terminal ones
+    // immediately, deferred ones when their admission releases. The lists are
+    // only populated when the mutation committed, so a conflict that aborts
+    // the rollover never archives anything (#131770).
+    await reclaimIsolatedRolloverTranscripts({
       agentId,
+      archiveSessionIds: rolloverArchiveSessionIds,
       cfg,
-      sessionIds: rolloverArchiveSessionIds,
+      deferredSessionIds: rolloverDeferredSessionIds,
       sessionKey: isolatedSessionKey,
+      storePath: isolatedStorePath,
     });
     runSessionKey = isolatedSessionKey;
     outboundPolicySessionKey = isolatedBaseSessionKey;

--- a/src/infra/heartbeat-runner-execution.ts
+++ b/src/infra/heartbeat-runner-execution.ts
@@ -113,6 +113,10 @@ const loadHeartbeatRunnerRuntime = createLazyRuntimeModule(
   () => import("./heartbeat-runner.runtime.js"),
 );
 
+const loadSessionArchiveRuntime = createLazyRuntimeModule(
+  () => import("../gateway/session-archive.runtime.js"),
+);
+
 function hasActiveRunForAgent(agentId: string, listSessionKeys: () => readonly string[]): boolean {
   const normalizedAgentId = normalizeAgentId(agentId);
   return listSessionKeys().some((sessionKey) => {
@@ -548,6 +552,14 @@ export async function prepareHeartbeatRunStage(wake: ReadyHeartbeatWake) {
           },
         ]
       : [];
+    // Every isolated wake rolls a fresh session ID under this stable key. Capture
+    // the replaced session before the rollover so its transcript can be archived
+    // afterwards; otherwise each run leaves an unreferenced .jsonl that doctor
+    // reports as an orphan (#131770).
+    const currentIsolatedEntry = loadExactSessionEntry({
+      storePath: isolatedStorePath,
+      sessionKey: isolatedSessionKey,
+    })?.entry;
     const lifecycleResult = await applySessionEntryLifecycleMutation({
       activeSessionKey: isolatedSessionKey,
       storePath: isolatedStorePath,
@@ -580,6 +592,31 @@ export async function prepareHeartbeatRunStage(wake: ReadyHeartbeatWake) {
         err: formatErrorMessage(lifecycleResult.artifactCleanupError),
         sessionKey: staleIsolatedSessionKey,
       });
+    }
+    // The rollover upsert replaced the row in place, so lifecycle artifact
+    // cleanup never saw the previous session as removed. Archive its file-backed
+    // transcript explicitly so no unreferenced .jsonl is left behind (#131770).
+    if (currentIsolatedEntry?.sessionId) {
+      try {
+        const { archiveSessionTranscripts } = await loadSessionArchiveRuntime();
+        archiveSessionTranscripts({
+          sessionId: currentIsolatedEntry.sessionId,
+          storePath: isolatedStorePath,
+          agentId,
+          reason: "deleted",
+          onArchiveError: (error, sourcePath) => {
+            log.warn(
+              `heartbeat: failed to archive previous isolated session transcript ${sourcePath} for session ${currentIsolatedEntry.sessionId}`,
+              { error: String(error), sessionKey: isolatedSessionKey },
+            );
+          },
+        });
+      } catch (err) {
+        log.warn("heartbeat: failed to archive previous isolated session transcript", {
+          err: formatErrorMessage(err),
+          sessionKey: isolatedSessionKey,
+        });
+      }
     }
     runSessionKey = isolatedSessionKey;
     outboundPolicySessionKey = isolatedBaseSessionKey;

--- a/src/infra/heartbeat-runner-execution.ts
+++ b/src/infra/heartbeat-runner-execution.ts
@@ -32,6 +32,7 @@ import {
   loadExactSessionEntry,
   type SessionEntryLifecycleRemoval,
 } from "../config/sessions/session-accessor.js";
+import type { SessionEntry } from "../config/sessions/types.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import {
   hasActiveCronJobs,
@@ -552,14 +553,15 @@ export async function prepareHeartbeatRunStage(wake: ReadyHeartbeatWake) {
           },
         ]
       : [];
-    // Every isolated wake rolls a fresh session ID under this stable key. Capture
-    // the replaced session before the rollover so its transcript can be archived
-    // afterwards; otherwise each run leaves an unreferenced .jsonl that doctor
-    // reports as an orphan (#131770).
-    const currentIsolatedEntry = loadExactSessionEntry({
-      storePath: isolatedStorePath,
-      sessionKey: isolatedSessionKey,
-    })?.entry;
+    // Every isolated wake rolls a fresh session ID under this stable key. The
+    // replaced row is captured inside the lifecycle mutation, under the storage
+    // writer lane, so the archive always targets the exact generation this
+    // mutation replaced. Reading it before the awaited mutation instead would
+    // let an overlapping immediate/manual wake both snapshot the same stale
+    // predecessor: the later rollover would replace the first wake's session
+    // while archiving only the old ID, leaving that wake's transcript orphaned
+    // (#131770).
+    let replacedIsolatedEntry: SessionEntry | undefined;
     const lifecycleResult = await applySessionEntryLifecycleMutation({
       activeSessionKey: isolatedSessionKey,
       storePath: isolatedStorePath,
@@ -567,7 +569,8 @@ export async function prepareHeartbeatRunStage(wake: ReadyHeartbeatWake) {
       upserts: [
         {
           sessionKey: isolatedSessionKey,
-          buildEntry: ({ store }) => {
+          buildEntry: ({ currentEntry, store }) => {
+            replacedIsolatedEntry = currentEntry;
             const cronSession = resolveCronSession({
               cfg,
               sessionKey: isolatedSessionKey,
@@ -594,19 +597,22 @@ export async function prepareHeartbeatRunStage(wake: ReadyHeartbeatWake) {
       });
     }
     // The rollover upsert replaced the row in place, so lifecycle artifact
-    // cleanup never saw the previous session as removed. Archive its file-backed
-    // transcript explicitly so no unreferenced .jsonl is left behind (#131770).
-    if (currentIsolatedEntry?.sessionId) {
+    // cleanup never saw the previous session as removed. Archive the exact
+    // replaced generation's file-backed transcript explicitly so no
+    // unreferenced .jsonl is left behind (#131770). `replacedIsolatedEntry` is
+    // only assigned when the mutation committed, so a conflict that aborts the
+    // rollover never archives anything.
+    if (replacedIsolatedEntry?.sessionId) {
       try {
         const { archiveSessionTranscripts } = await loadSessionArchiveRuntime();
         archiveSessionTranscripts({
-          sessionId: currentIsolatedEntry.sessionId,
+          sessionId: replacedIsolatedEntry.sessionId,
           storePath: isolatedStorePath,
           agentId,
           reason: "deleted",
           onArchiveError: (error, sourcePath) => {
             log.warn(
-              `heartbeat: failed to archive previous isolated session transcript ${sourcePath} for session ${currentIsolatedEntry.sessionId}`,
+              `heartbeat: failed to archive previous isolated session transcript ${sourcePath} for session ${replacedIsolatedEntry?.sessionId}`,
               { error: String(error), sessionKey: isolatedSessionKey },
             );
           },

--- a/src/infra/heartbeat-runner-execution.ts
+++ b/src/infra/heartbeat-runner-execution.ts
@@ -32,7 +32,6 @@ import {
   loadExactSessionEntry,
   type SessionEntryLifecycleRemoval,
 } from "../config/sessions/session-accessor.js";
-import type { SessionEntry } from "../config/sessions/types.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import {
   hasActiveCronJobs,
@@ -51,11 +50,16 @@ import {
 import { CommandLane } from "../process/lanes.js";
 import { normalizeAgentId, parseAgentSessionKey } from "../routing/session-key.js";
 import type { RuntimeEnv } from "../runtime.js";
+import { isSessionWorkAdmissionActive } from "../sessions/session-lifecycle-admission.js";
 import { createLazyRuntimeModule } from "../shared/lazy-runtime.js";
 import { getAgentEventLifecycleGeneration } from "./agent-events.js";
 import { formatErrorMessage } from "./errors.js";
 import { isWithinActiveHours } from "./heartbeat-active-hours.js";
 import { emitHeartbeatEvent } from "./heartbeat-events.js";
+import {
+  archiveIsolatedRolloverTranscripts,
+  resolveIsolatedRolloverTranscriptReclamation,
+} from "./heartbeat-isolated-rollover.js";
 import {
   heartbeatLog,
   resolveHeartbeatForWake,
@@ -112,10 +116,6 @@ export type HeartbeatDeps = OutboundSendDeps &
 
 const loadHeartbeatRunnerRuntime = createLazyRuntimeModule(
   () => import("./heartbeat-runner.runtime.js"),
-);
-
-const loadSessionArchiveRuntime = createLazyRuntimeModule(
-  () => import("../gateway/session-archive.runtime.js"),
 );
 
 function hasActiveRunForAgent(agentId: string, listSessionKeys: () => readonly string[]): boolean {
@@ -553,15 +553,12 @@ export async function prepareHeartbeatRunStage(wake: ReadyHeartbeatWake) {
           },
         ]
       : [];
-    // Every isolated wake rolls a fresh session ID under this stable key. The
-    // replaced row is captured inside the lifecycle mutation, under the storage
-    // writer lane, so the archive always targets the exact generation this
-    // mutation replaced. Reading it before the awaited mutation instead would
-    // let an overlapping immediate/manual wake both snapshot the same stale
-    // predecessor: the later rollover would replace the first wake's session
-    // while archiving only the old ID, leaving that wake's transcript orphaned
-    // (#131770).
-    let replacedIsolatedEntry: SessionEntry | undefined;
+    // The replaced row is captured inside the lifecycle mutation (writer lane)
+    // so the archive targets the exact generation this rollover replaced, and
+    // reclamation is fenced against live runs — deferred generations ride the
+    // committed row until the session lane goes quiet (#131770; see
+    // heartbeat-isolated-rollover.ts).
+    let rolloverArchiveSessionIds: string[] = [];
     const lifecycleResult = await applySessionEntryLifecycleMutation({
       activeSessionKey: isolatedSessionKey,
       storePath: isolatedStorePath,
@@ -570,7 +567,13 @@ export async function prepareHeartbeatRunStage(wake: ReadyHeartbeatWake) {
         {
           sessionKey: isolatedSessionKey,
           buildEntry: ({ currentEntry, store }) => {
-            replacedIsolatedEntry = currentEntry;
+            const reclamation = resolveIsolatedRolloverTranscriptReclamation({
+              currentEntry,
+              sessionLaneActive: isSessionWorkAdmissionActive(isolatedStorePath, [
+                isolatedSessionKey,
+              ]),
+            });
+            rolloverArchiveSessionIds = reclamation.archiveSessionIds;
             const cronSession = resolveCronSession({
               cfg,
               sessionKey: isolatedSessionKey,
@@ -582,6 +585,12 @@ export async function prepareHeartbeatRunStage(wake: ReadyHeartbeatWake) {
             const nextEntry = {
               ...cronSession.sessionEntry,
               heartbeatIsolatedBaseSessionKey: isolatedBaseSessionKey,
+              ...(reclamation.pendingTranscriptArchiveSessionIds
+                ? {
+                    pendingTranscriptArchiveSessionIds:
+                      reclamation.pendingTranscriptArchiveSessionIds,
+                  }
+                : {}),
             };
             runSessionEntry = nextEntry;
             return nextEntry;
@@ -596,34 +605,15 @@ export async function prepareHeartbeatRunStage(wake: ReadyHeartbeatWake) {
         sessionKey: staleIsolatedSessionKey,
       });
     }
-    // The rollover upsert replaced the row in place, so lifecycle artifact
-    // cleanup never saw the previous session as removed. Archive the exact
-    // replaced generation's file-backed transcript explicitly so no
-    // unreferenced .jsonl is left behind (#131770). `replacedIsolatedEntry` is
-    // only assigned when the mutation committed, so a conflict that aborts the
-    // rollover never archives anything.
-    if (replacedIsolatedEntry?.sessionId) {
-      try {
-        const { archiveSessionTranscripts } = await loadSessionArchiveRuntime();
-        archiveSessionTranscripts({
-          sessionId: replacedIsolatedEntry.sessionId,
-          storePath: isolatedStorePath,
-          agentId,
-          reason: "deleted",
-          onArchiveError: (error, sourcePath) => {
-            log.warn(
-              `heartbeat: failed to archive previous isolated session transcript ${sourcePath} for session ${replacedIsolatedEntry?.sessionId}`,
-              { error: String(error), sessionKey: isolatedSessionKey },
-            );
-          },
-        });
-      } catch (err) {
-        log.warn("heartbeat: failed to archive previous isolated session transcript", {
-          err: formatErrorMessage(err),
-          sessionKey: isolatedSessionKey,
-        });
-      }
-    }
+    // Archive the terminal generations selected inside the mutation so no
+    // unreferenced .jsonl is left behind (#131770). The list is only populated
+    // when the mutation committed, so a conflict never archives anything.
+    await archiveIsolatedRolloverTranscripts({
+      agentId,
+      cfg,
+      sessionIds: rolloverArchiveSessionIds,
+      sessionKey: isolatedSessionKey,
+    });
     runSessionKey = isolatedSessionKey;
     outboundPolicySessionKey = isolatedBaseSessionKey;
 

--- a/src/infra/heartbeat-runner.isolated-rollover-archive.test.ts
+++ b/src/infra/heartbeat-runner.isolated-rollover-archive.test.ts
@@ -6,6 +6,10 @@ import type { OpenClawConfig } from "../config/config.js";
 import { resolveMainSessionKey } from "../config/sessions.js";
 import { formatSessionArchiveTimestamp } from "../config/sessions/artifacts.js";
 import { resolveSessionTranscriptsDirForAgent } from "../config/sessions/paths.js";
+import {
+  beginSessionWorkAdmission,
+  isSessionWorkAdmissionActive,
+} from "../sessions/session-lifecycle-admission.js";
 import { heartbeatLog } from "./heartbeat-runner-config.js";
 import { runHeartbeatOnce } from "./heartbeat-runner.js";
 import { installHeartbeatRunnerTestRuntime } from "./heartbeat-runner.test-harness.js";
@@ -39,6 +43,9 @@ const lifecycleMutationGate = vi.hoisted(() => ({
   release: null as (() => void) | null,
 }));
 
+/** Session work admission leases held by tests; released after each test. */
+const releaseLeases: Array<() => void> = [];
+
 vi.mock("../config/sessions/session-accessor.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../config/sessions/session-accessor.js")>();
   return {
@@ -66,6 +73,13 @@ afterEach(() => {
   lifecycleMutationGate.entered = false;
   lifecycleMutationGate.held = false;
   lifecycleMutationGate.release = null;
+  for (const release of releaseLeases.splice(0)) {
+    try {
+      release();
+    } catch {
+      // A lease may already be released when its run finished.
+    }
+  }
 });
 
 function makeIsolatedLastTargetConfig(tmpDir: string, storePath: string): OpenClawConfig {
@@ -344,6 +358,145 @@ describe("runHeartbeatOnce - isolated heartbeat transcript rollover", () => {
       // archives the original predecessor, and wake A — whose rollover
       // replaced wake B's committed row — archives that exact generation.
       const remaining = await fs.readdir(sessionsDir);
+      expect(remaining).not.toContain("previous-wake.jsonl");
+      expect(remaining.some((name) => name.startsWith("previous-wake.jsonl."))).toBe(true);
+      expect(remaining).not.toContain(`${bSessionId}.jsonl`);
+      expect(remaining.some((name) => name.startsWith(`${bSessionId}.jsonl.`))).toBe(true);
+    });
+  });
+
+  it("reclaims a transcript that materializes after a competing rollover deferred it", async () => {
+    await withTempHeartbeatSandbox(async ({ tmpDir, storePath, replySpy }) => {
+      const cfg = makeIsolatedLastTargetConfig(tmpDir, storePath);
+      const baseSessionKey = resolveMainSessionKey(cfg);
+      const isolatedSessionKey = `${baseSessionKey}:heartbeat`;
+      const nowMs = Date.now();
+      await seedHeartbeatScratchForTest({
+        content: "Check whether the user needs a status update.",
+      });
+      await seedSessionStore(storePath, baseSessionKey, {
+        sessionId: "base-session",
+        updatedAt: nowMs - 2_000,
+        lastChannel: "whatsapp",
+        lastProvider: "whatsapp",
+        lastTo: "+15551234567",
+      });
+      await seedSessionStore(storePath, isolatedSessionKey, {
+        sessionId: "previous-wake",
+        updatedAt: nowMs - 1_000,
+        heartbeatIsolatedBaseSessionKey: baseSessionKey,
+      });
+      const sessionsDir = resolveSessionTranscriptsDirForAgent("main", process.env);
+      await fs.mkdir(sessionsDir, { recursive: true });
+      await fs.writeFile(
+        path.join(sessionsDir, "previous-wake.jsonl"),
+        `{"type":"message","sessionKey":"${isolatedSessionKey}"}\n`,
+      );
+
+      // Hold the first wake's rollover before it reaches the storage writer lane.
+      lifecycleMutationGate.shouldHold = (params) => params.activeSessionKey === isolatedSessionKey;
+      const runA = runHeartbeatOnce({
+        cfg,
+        deps: {
+          getReplyFromConfig: replySpy,
+          getQueueSize: () => 0,
+          nowMs: () => nowMs,
+        },
+      });
+      await vi.waitFor(() => expect(lifecycleMutationGate.entered).toBe(true), { timeout: 10_000 });
+
+      // Wake B rolls over the seeded row and starts its reply turn. The reply
+      // spy stands in for the real turn: it holds a real session work admission
+      // on the isolated session lane for the duration of the "run".
+      const releaseBRun = (() => {
+        let release!: () => void;
+        const gate = new Promise<void>((resolve) => {
+          release = resolve;
+        });
+        return { gate, release };
+      })();
+      replySpy.mockImplementationOnce(async () => {
+        const lease = await beginSessionWorkAdmission({
+          scope: storePath,
+          identities: [isolatedSessionKey],
+          assertAllowed: () => {},
+        });
+        releaseLeases.push(lease.release);
+        await releaseBRun.gate;
+        lease.release();
+        return { text: "All good." };
+      });
+      const runB = runHeartbeatOnce({
+        cfg,
+        deps: {
+          getReplyFromConfig: replySpy,
+          getQueueSize: () => 0,
+          nowMs: () => nowMs,
+        },
+      });
+      const bSessionId = await vi.waitFor(
+        () => {
+          const sessionId = readSessionStoreForTest<{ sessionId?: string }>(storePath)[
+            isolatedSessionKey
+          ]?.sessionId;
+          expect(sessionId).toBeTruthy();
+          expect(sessionId).not.toBe("previous-wake");
+          return sessionId as string;
+        },
+        { timeout: 10_000 },
+      );
+      await vi.waitFor(
+        () => expect(isSessionWorkAdmissionActive(storePath, [isolatedSessionKey])).toBe(true),
+        { timeout: 10_000 },
+      );
+
+      // Wake A's rollover finally lands while wake B's run is still admitted.
+      // It must defer reclamation of wake B's generation onto the committed row
+      // instead of racing B's still-absent transcript.
+      lifecycleMutationGate.release?.();
+      const resultA = await runA;
+      expect(resultA.status).toBe("ran");
+      const storeAfterA = readSessionStoreForTest<{
+        sessionId?: string;
+        pendingTranscriptArchiveSessionIds?: string[];
+      }>(storePath);
+      expect(storeAfterA[isolatedSessionKey]?.sessionId).toBeTruthy();
+      expect(storeAfterA[isolatedSessionKey]?.sessionId).not.toBe(bSessionId);
+      expect(storeAfterA[isolatedSessionKey]?.pendingTranscriptArchiveSessionIds).toEqual([
+        bSessionId,
+      ]);
+
+      // Wake B's transcript materializes only now — after the competing
+      // rollover already replaced its row.
+      await fs.writeFile(
+        path.join(sessionsDir, `${bSessionId}.jsonl`),
+        `{"type":"message","sessionKey":"${isolatedSessionKey}"}\n`,
+      );
+      // The deferred generation is not reclaimed while its run is admitted.
+      let remaining = await fs.readdir(sessionsDir);
+      expect(remaining).toContain(`${bSessionId}.jsonl`);
+
+      // Wake B's run ends; a fresh wake reclaims the deferred generation.
+      releaseBRun.release();
+      const resultB = await runB;
+      expect(resultB.status).toBe("ran");
+      const runC = await runHeartbeatOnce({
+        cfg,
+        deps: {
+          getReplyFromConfig: replySpy,
+          getQueueSize: () => 0,
+          nowMs: () => nowMs,
+        },
+      });
+      expect(runC.status).toBe("ran");
+
+      const store = readSessionStoreForTest<{
+        sessionId?: string;
+        pendingTranscriptArchiveSessionIds?: string[];
+      }>(storePath);
+      expect(store[isolatedSessionKey]?.sessionId).toBeTruthy();
+      expect(store[isolatedSessionKey]?.pendingTranscriptArchiveSessionIds).toBeUndefined();
+      remaining = await fs.readdir(sessionsDir);
       expect(remaining).not.toContain("previous-wake.jsonl");
       expect(remaining.some((name) => name.startsWith("previous-wake.jsonl."))).toBe(true);
       expect(remaining).not.toContain(`${bSessionId}.jsonl`);

--- a/src/infra/heartbeat-runner.isolated-rollover-archive.test.ts
+++ b/src/infra/heartbeat-runner.isolated-rollover-archive.test.ts
@@ -25,10 +25,47 @@ vi.mock("./outbound/deliver.js", () => ({
   deliverOutboundPayloadsInternal,
 }));
 
+/**
+ * Test-controlled gate around the rollover lifecycle mutation: the first
+ * matching call is held before it reaches the storage writer lane, so a second
+ * overlapping wake can run its own rollover first. This reproduces the
+ * interleaving where both wakes observe the same predecessor generation
+ * (#131770).
+ */
+const lifecycleMutationGate = vi.hoisted(() => ({
+  shouldHold: null as ((params: { activeSessionKey?: string }) => boolean) | null,
+  entered: false,
+  held: false,
+  release: null as (() => void) | null,
+}));
+
+vi.mock("../config/sessions/session-accessor.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../config/sessions/session-accessor.js")>();
+  return {
+    ...actual,
+    applySessionEntryLifecycleMutation: async (
+      params: Parameters<typeof actual.applySessionEntryLifecycleMutation>[0],
+    ) => {
+      if (lifecycleMutationGate.shouldHold?.(params) && !lifecycleMutationGate.held) {
+        lifecycleMutationGate.held = true;
+        lifecycleMutationGate.entered = true;
+        await new Promise<void>((resolve) => {
+          lifecycleMutationGate.release = resolve;
+        });
+      }
+      return await actual.applySessionEntryLifecycleMutation(params);
+    },
+  };
+});
+
 installHeartbeatRunnerTestRuntime();
 
 afterEach(() => {
   deliverOutboundPayloadsInternal.mockClear();
+  lifecycleMutationGate.shouldHold = null;
+  lifecycleMutationGate.entered = false;
+  lifecycleMutationGate.held = false;
+  lifecycleMutationGate.release = null;
 });
 
 function makeIsolatedLastTargetConfig(tmpDir: string, storePath: string): OpenClawConfig {
@@ -220,6 +257,97 @@ describe("runHeartbeatOnce - isolated heartbeat transcript rollover", () => {
       expect(store[isolatedSessionKey]?.createdAt).toBe(createdAt);
       expect(store[isolatedSessionKey]?.createdVia).toBe("cron");
       expect(store[isolatedSessionKey]?.sandbox).toBe("required");
+    });
+  });
+
+  it("archives the exact replaced generation when overlapping wakes interleave", async () => {
+    await withTempHeartbeatSandbox(async ({ tmpDir, storePath, replySpy }) => {
+      const cfg = makeIsolatedLastTargetConfig(tmpDir, storePath);
+      const baseSessionKey = resolveMainSessionKey(cfg);
+      const isolatedSessionKey = `${baseSessionKey}:heartbeat`;
+      const nowMs = Date.now();
+      await seedHeartbeatScratchForTest({
+        content: "Check whether the user needs a status update.",
+      });
+      await seedSessionStore(storePath, baseSessionKey, {
+        sessionId: "base-session",
+        updatedAt: nowMs - 2_000,
+        lastChannel: "whatsapp",
+        lastProvider: "whatsapp",
+        lastTo: "+15551234567",
+      });
+      await seedSessionStore(storePath, isolatedSessionKey, {
+        sessionId: "previous-wake",
+        updatedAt: nowMs - 1_000,
+        heartbeatIsolatedBaseSessionKey: baseSessionKey,
+      });
+      const sessionsDir = resolveSessionTranscriptsDirForAgent("main", process.env);
+      await fs.mkdir(sessionsDir, { recursive: true });
+      await fs.writeFile(
+        path.join(sessionsDir, "previous-wake.jsonl"),
+        `{"type":"message","sessionKey":"${isolatedSessionKey}"}\n`,
+      );
+      replySpy.mockResolvedValue({ text: "All good." });
+
+      // Hold the first wake's rollover before it reaches the storage writer
+      // lane, so the second wake runs its own rollover against the row the
+      // first wake still believes it will replace.
+      lifecycleMutationGate.shouldHold = (params) => params.activeSessionKey === isolatedSessionKey;
+      const runA = runHeartbeatOnce({
+        cfg,
+        deps: {
+          getReplyFromConfig: replySpy,
+          getQueueSize: () => 0,
+          nowMs: () => nowMs,
+        },
+      });
+      await vi.waitFor(() => expect(lifecycleMutationGate.entered).toBe(true), { timeout: 10_000 });
+
+      const runB = runHeartbeatOnce({
+        cfg,
+        deps: {
+          getReplyFromConfig: replySpy,
+          getQueueSize: () => 0,
+          nowMs: () => nowMs,
+        },
+      });
+      // Wake B's rollover commits while wake A is still held. Its wake
+      // transcript materializes on disk before wake A's rollover lands.
+      const bSessionId = await vi.waitFor(
+        () => {
+          const sessionId = readSessionStoreForTest<{ sessionId?: string }>(storePath)[
+            isolatedSessionKey
+          ]?.sessionId;
+          expect(sessionId).toBeTruthy();
+          expect(sessionId).not.toBe("previous-wake");
+          return sessionId as string;
+        },
+        { timeout: 10_000 },
+      );
+      await fs.writeFile(
+        path.join(sessionsDir, `${bSessionId}.jsonl`),
+        `{"type":"message","sessionKey":"${isolatedSessionKey}"}\n`,
+      );
+
+      lifecycleMutationGate.release?.();
+      const [resultA, resultB] = await Promise.all([runA, runB]);
+      expect(resultA.status).toBe("ran");
+      expect(resultB.status).toBe("ran");
+
+      const store = readSessionStoreForTest<{ sessionId?: string }>(storePath);
+      const finalSessionId = store[isolatedSessionKey]?.sessionId;
+      expect(finalSessionId).toBeTruthy();
+      expect(finalSessionId).not.toBe("previous-wake");
+      expect(finalSessionId).not.toBe(bSessionId);
+
+      // Both replaced generations must be archived, not orphaned: wake B
+      // archives the original predecessor, and wake A — whose rollover
+      // replaced wake B's committed row — archives that exact generation.
+      const remaining = await fs.readdir(sessionsDir);
+      expect(remaining).not.toContain("previous-wake.jsonl");
+      expect(remaining.some((name) => name.startsWith("previous-wake.jsonl."))).toBe(true);
+      expect(remaining).not.toContain(`${bSessionId}.jsonl`);
+      expect(remaining.some((name) => name.startsWith(`${bSessionId}.jsonl.`))).toBe(true);
     });
   });
 });

--- a/src/infra/heartbeat-runner.isolated-rollover-archive.test.ts
+++ b/src/infra/heartbeat-runner.isolated-rollover-archive.test.ts
@@ -1,0 +1,225 @@
+// Covers isolated heartbeat rollover archival of the previous wake transcript (#131770).
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../config/config.js";
+import { resolveMainSessionKey } from "../config/sessions.js";
+import { formatSessionArchiveTimestamp } from "../config/sessions/artifacts.js";
+import { resolveSessionTranscriptsDirForAgent } from "../config/sessions/paths.js";
+import { heartbeatLog } from "./heartbeat-runner-config.js";
+import { runHeartbeatOnce } from "./heartbeat-runner.js";
+import { installHeartbeatRunnerTestRuntime } from "./heartbeat-runner.test-harness.js";
+import {
+  readSessionStoreForTest,
+  seedHeartbeatScratchForTest,
+  seedSessionStore,
+  withTempHeartbeatSandbox,
+} from "./heartbeat-runner.test-utils.js";
+
+const deliverOutboundPayloadsInternal = vi.hoisted(() =>
+  vi.fn().mockResolvedValue([{ channel: "whatsapp", messageId: "msg-1" }]),
+);
+
+vi.mock("./outbound/deliver.js", () => ({
+  deliverOutboundPayloads: deliverOutboundPayloadsInternal,
+  deliverOutboundPayloadsInternal,
+}));
+
+installHeartbeatRunnerTestRuntime();
+
+afterEach(() => {
+  deliverOutboundPayloadsInternal.mockClear();
+});
+
+function makeIsolatedLastTargetConfig(tmpDir: string, storePath: string): OpenClawConfig {
+  return {
+    agents: {
+      list: [{ id: "main", default: true }],
+      defaults: {
+        workspace: tmpDir,
+        heartbeat: {
+          every: "5m",
+          target: "last",
+          isolatedSession: true,
+        },
+      },
+    },
+    channels: { whatsapp: { allowFrom: ["*"] } },
+    session: { store: storePath },
+  };
+}
+
+describe("runHeartbeatOnce - isolated heartbeat transcript rollover", () => {
+  it("archives the previous isolated wake transcript instead of orphaning it", async () => {
+    await withTempHeartbeatSandbox(async ({ tmpDir, storePath, replySpy }) => {
+      const cfg = makeIsolatedLastTargetConfig(tmpDir, storePath);
+      const baseSessionKey = resolveMainSessionKey(cfg);
+      const isolatedSessionKey = `${baseSessionKey}:heartbeat`;
+      const nowMs = Date.now();
+      await seedHeartbeatScratchForTest({
+        content: "Check whether the user needs a status update.",
+      });
+      await seedSessionStore(storePath, baseSessionKey, {
+        sessionId: "base-session",
+        updatedAt: nowMs - 2_000,
+        lastChannel: "whatsapp",
+        lastProvider: "whatsapp",
+        lastTo: "+15551234567",
+      });
+      await seedSessionStore(storePath, isolatedSessionKey, {
+        sessionId: "previous-wake",
+        updatedAt: nowMs - 1_000,
+        heartbeatIsolatedBaseSessionKey: baseSessionKey,
+      });
+      const sessionsDir = resolveSessionTranscriptsDirForAgent("main", process.env);
+      await fs.mkdir(sessionsDir, { recursive: true });
+      const transcriptPath = path.join(sessionsDir, "previous-wake.jsonl");
+      await fs.writeFile(
+        transcriptPath,
+        `{"type":"message","sessionKey":"${isolatedSessionKey}"}\n`,
+      );
+      replySpy.mockResolvedValueOnce({ text: "All good." });
+
+      const result = await runHeartbeatOnce({
+        cfg,
+        deps: {
+          getReplyFromConfig: replySpy,
+          getQueueSize: () => 0,
+          nowMs: () => nowMs,
+        },
+      });
+
+      expect(result.status).toBe("ran");
+      const store = readSessionStoreForTest<{ sessionId?: string }>(storePath);
+      expect(store[isolatedSessionKey]?.sessionId).toBeTruthy();
+      expect(store[isolatedSessionKey]?.sessionId).not.toBe("previous-wake");
+      // The replaced transcript must not stay behind as an unreferenced primary
+      // file; it is archived alongside other lifecycle artifacts.
+      const remaining = await fs.readdir(sessionsDir);
+      expect(remaining).not.toContain("previous-wake.jsonl");
+      expect(remaining.some((name) => name.startsWith("previous-wake.jsonl."))).toBe(true);
+    });
+  });
+
+  it("warns per failed transcript rename and still completes the rollover", async () => {
+    await withTempHeartbeatSandbox(async ({ tmpDir, storePath, replySpy }) => {
+      const cfg = makeIsolatedLastTargetConfig(tmpDir, storePath);
+      const baseSessionKey = resolveMainSessionKey(cfg);
+      const isolatedSessionKey = `${baseSessionKey}:heartbeat`;
+      const nowMs = Date.now();
+      await seedHeartbeatScratchForTest({
+        content: "Check whether the user needs a status update.",
+      });
+      await seedSessionStore(storePath, baseSessionKey, {
+        sessionId: "base-session",
+        updatedAt: nowMs - 2_000,
+        lastChannel: "whatsapp",
+        lastProvider: "whatsapp",
+        lastTo: "+15551234567",
+      });
+      await seedSessionStore(storePath, isolatedSessionKey, {
+        sessionId: "previous-wake",
+        updatedAt: nowMs - 1_000,
+        heartbeatIsolatedBaseSessionKey: baseSessionKey,
+      });
+      const sessionsDir = resolveSessionTranscriptsDirForAgent("main", process.env);
+      await fs.mkdir(sessionsDir, { recursive: true });
+      const transcriptPath = path.join(sessionsDir, "previous-wake.jsonl");
+      await fs.writeFile(
+        transcriptPath,
+        `{"type":"message","sessionKey":"${isolatedSessionKey}"}\n`,
+      );
+      replySpy.mockResolvedValueOnce({ text: "All good." });
+      // Force a deterministic rename failure independent of user privileges:
+      // pin the archive timestamp and pre-create the archive target as a
+      // directory, so renameSync(file -> directory) fails with EISDIR. The
+      // per-file error callback must surface that failure instead of
+      // swallowing it.
+      const fixedNow = nowMs;
+      const nowSpy = vi.spyOn(Date, "now").mockReturnValue(fixedNow);
+      const archiveStamp = formatSessionArchiveTimestamp(fixedNow);
+      await fs.mkdir(path.join(sessionsDir, `previous-wake.jsonl.deleted.${archiveStamp}`), {
+        recursive: true,
+      });
+      const warnSpy = vi.spyOn(heartbeatLog, "warn");
+      try {
+        const result = await runHeartbeatOnce({
+          cfg,
+          deps: {
+            getReplyFromConfig: replySpy,
+            getQueueSize: () => 0,
+            nowMs: () => nowMs,
+          },
+        });
+
+        expect(result.status).toBe("ran");
+        const store = readSessionStoreForTest<{ sessionId?: string }>(storePath);
+        expect(store[isolatedSessionKey]?.sessionId).toBeTruthy();
+        expect(store[isolatedSessionKey]?.sessionId).not.toBe("previous-wake");
+        // The rename failed, so the transcript stays in place; it must not be
+        // silently dropped from observability.
+        const remaining = await fs.readdir(sessionsDir);
+        expect(remaining).toContain("previous-wake.jsonl");
+        expect(warnSpy).toHaveBeenCalledWith(
+          expect.stringContaining("previous-wake.jsonl"),
+          expect.objectContaining({ sessionKey: isolatedSessionKey }),
+        );
+      } finally {
+        warnSpy.mockRestore();
+        nowSpy.mockRestore();
+      }
+    });
+  });
+
+  it("keeps a sandbox-required creation stamp across rollover archival", async () => {
+    await withTempHeartbeatSandbox(async ({ tmpDir, storePath, replySpy }) => {
+      const cfg = makeIsolatedLastTargetConfig(tmpDir, storePath);
+      const baseSessionKey = resolveMainSessionKey(cfg);
+      const isolatedSessionKey = `${baseSessionKey}:heartbeat`;
+      const nowMs = Date.now();
+      const createdAt = nowMs - 7 * 24 * 3_600_000;
+      await seedHeartbeatScratchForTest({
+        content: "Check whether the user needs a status update.",
+      });
+      await seedSessionStore(storePath, baseSessionKey, {
+        sessionId: "base-session",
+        updatedAt: nowMs - 2_000,
+        lastChannel: "whatsapp",
+        lastProvider: "whatsapp",
+        lastTo: "+15551234567",
+      });
+      await seedSessionStore(storePath, isolatedSessionKey, {
+        sessionId: "previous-wake",
+        updatedAt: nowMs - 1_000,
+        heartbeatIsolatedBaseSessionKey: baseSessionKey,
+        createdVia: "cron",
+        createdActor: { type: "system" },
+        createdAt,
+        sandbox: "required",
+      });
+      replySpy.mockResolvedValueOnce({ text: "All good." });
+
+      const result = await runHeartbeatOnce({
+        cfg,
+        deps: {
+          getReplyFromConfig: replySpy,
+          getQueueSize: () => 0,
+          nowMs: () => nowMs,
+        },
+      });
+
+      expect(result.status).toBe("ran");
+      const store = readSessionStoreForTest<{
+        createdAt?: number;
+        createdVia?: string;
+        sandbox?: string;
+        sessionId?: string;
+      }>(storePath);
+      expect(store[isolatedSessionKey]?.sessionId).toBeTruthy();
+      expect(store[isolatedSessionKey]?.sessionId).not.toBe("previous-wake");
+      expect(store[isolatedSessionKey]?.createdAt).toBe(createdAt);
+      expect(store[isolatedSessionKey]?.createdVia).toBe("cron");
+      expect(store[isolatedSessionKey]?.sandbox).toBe("required");
+    });
+  });
+});

--- a/src/infra/heartbeat-runner.isolated-rollover-archive.test.ts
+++ b/src/infra/heartbeat-runner.isolated-rollover-archive.test.ts
@@ -476,31 +476,28 @@ describe("runHeartbeatOnce - isolated heartbeat transcript rollover", () => {
       let remaining = await fs.readdir(sessionsDir);
       expect(remaining).toContain(`${bSessionId}.jsonl`);
 
-      // Wake B's run ends; a fresh wake reclaims the deferred generation.
+      // Wake B's run ends — the deferred generation must be reclaimed by the
+      // terminal-admission cleanup WITHOUT any further heartbeat wake.
       releaseBRun.release();
       const resultB = await runB;
       expect(resultB.status).toBe("ran");
-      const runC = await runHeartbeatOnce({
-        cfg,
-        deps: {
-          getReplyFromConfig: replySpy,
-          getQueueSize: () => 0,
-          nowMs: () => nowMs,
+      await vi.waitFor(
+        async () => {
+          const files = await fs.readdir(sessionsDir);
+          expect(files).not.toContain(`${bSessionId}.jsonl`);
+          expect(files.some((name) => name.startsWith(`${bSessionId}.jsonl.`))).toBe(true);
         },
-      });
-      expect(runC.status).toBe("ran");
+        { timeout: 10_000 },
+      );
 
       const store = readSessionStoreForTest<{
         sessionId?: string;
         pendingTranscriptArchiveSessionIds?: string[];
       }>(storePath);
       expect(store[isolatedSessionKey]?.sessionId).toBeTruthy();
-      expect(store[isolatedSessionKey]?.pendingTranscriptArchiveSessionIds).toBeUndefined();
       remaining = await fs.readdir(sessionsDir);
       expect(remaining).not.toContain("previous-wake.jsonl");
       expect(remaining.some((name) => name.startsWith("previous-wake.jsonl."))).toBe(true);
-      expect(remaining).not.toContain(`${bSessionId}.jsonl`);
-      expect(remaining.some((name) => name.startsWith(`${bSessionId}.jsonl.`))).toBe(true);
     });
   });
 });

--- a/src/plugins/session-entry-slot-keys.ts
+++ b/src/plugins/session-entry-slot-keys.ts
@@ -180,6 +180,7 @@ const SESSION_ENTRY_RESERVED_SLOT_KEY_LIST = [
   "acp",
   "quotaSuspension",
   "pendingTranscriptRepair",
+  "transcriptMaterialized",
   "visibility",
 ] as const satisfies ReadonlyArray<
   keyof SessionEntry | "__proto__" | "constructor" | "prototype" | "sessionFile" | "transcriptPath"

--- a/src/plugins/session-entry-slot-keys.ts
+++ b/src/plugins/session-entry-slot-keys.ts
@@ -181,6 +181,7 @@ const SESSION_ENTRY_RESERVED_SLOT_KEY_LIST = [
   "quotaSuspension",
   "pendingTranscriptRepair",
   "transcriptMaterialized",
+  "pendingTranscriptArchiveSessionIds",
   "visibility",
 ] as const satisfies ReadonlyArray<
   keyof SessionEntry | "__proto__" | "constructor" | "prototype" | "sessionFile" | "transcriptPath"

--- a/test/e2e/qa-lab/runtime/heartbeat-isolated-rollover-deferred-archive.ts
+++ b/test/e2e/qa-lab/runtime/heartbeat-isolated-rollover-deferred-archive.ts
@@ -1,0 +1,132 @@
+// QA Lab producer proves isolated-heartbeat deferred rollover reclamation
+// (#131770): a real manual wake rolls the stable isolated row while a real
+// session-work admission (the same production primitive a reply turn holds)
+// owns the lane; the replaced generation is deferred onto the committed row,
+// its file-backed transcript materializes, and the archive rename happens when
+// the admission releases — with no further heartbeat wake.
+// Run: node --import ./scripts/tsx.mjs test/e2e/qa-lab/runtime/heartbeat-isolated-rollover-deferred-archive.ts
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+const sleep = async (ms: number): Promise<void> => {
+  await new Promise<void>((resolve) => {
+    setTimeout(resolve, ms);
+  });
+};
+
+const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "qa-hb-deferred-"));
+process.env.OPENCLAW_STATE_DIR = stateDir;
+const sessionsDir = path.join(stateDir, "agents", "main", "sessions");
+const storePath = path.join(sessionsDir, "sessions.json");
+await fs.mkdir(sessionsDir, { recursive: true });
+
+const cfg = {
+  agents: {
+    list: [{ id: "main", default: true }],
+    defaults: {
+      workspace: path.join(stateDir, "workspace"),
+      heartbeat: { every: "300s", target: "last", isolatedSession: true },
+    },
+  },
+  session: { store: storePath },
+  channels: {},
+};
+
+const { replaceSessionEntry, listSessionEntriesCore } =
+  await import("../../../../src/config/sessions/session-accessor.js");
+const { beginSessionWorkAdmission } =
+  await import("../../../../src/sessions/session-lifecycle-admission.js");
+const { runHeartbeatOnce } = await import("../../../../src/infra/heartbeat-runner.js");
+
+const isolatedKey = "agent:main:main:heartbeat";
+const readRow = () =>
+  listSessionEntriesCore({ storePath }).find(({ sessionKey }) => sessionKey === isolatedKey)?.entry;
+
+const now = Date.now();
+await replaceSessionEntry(
+  { storePath, sessionKey: "agent:main:main" },
+  {
+    sessionId: "base-1",
+    updatedAt: now - 120_000,
+    systemSent: true,
+  },
+);
+await replaceSessionEntry(
+  { storePath, sessionKey: isolatedKey },
+  {
+    sessionId: "previous-wake",
+    updatedAt: now - 60_000,
+    systemSent: true,
+    heartbeatIsolatedBaseSessionKey: "agent:main:main",
+  },
+);
+await fs.writeFile(
+  path.join(sessionsDir, "previous-wake.jsonl"),
+  `{"type":"message","sessionKey":"${isolatedKey}"}\n`,
+);
+
+console.log("=== before: isolated row points at the previous wake ===");
+console.log("row:", JSON.stringify({ sessionId: readRow()?.sessionId, pending: null }));
+
+// A real admitted turn on the isolated lane (production admission primitive).
+const lease = await beginSessionWorkAdmission({
+  scope: storePath,
+  identities: [isolatedKey],
+  assertAllowed: () => {},
+});
+console.log("=== admitted turn held on the isolated lane (real admission lease) ===");
+
+// Real manual wake: its rollover must DEFER the previous wake's generation.
+void runHeartbeatOnce({
+  cfg,
+  intent: "manual",
+  source: "manual",
+  deps: { getQueueSize: () => 0 },
+}).then(
+  () => {},
+  () => {},
+);
+let deferred = false;
+for (let i = 0; i < 200 && !deferred; i += 1) {
+  await sleep(50);
+  deferred = (readRow()?.pendingTranscriptArchiveSessionIds ?? []).includes("previous-wake");
+}
+console.log("=== after the real rollover: reclamation deferred onto the committed row ===");
+console.log(
+  "row:",
+  JSON.stringify({
+    sessionId: readRow()?.sessionId,
+    pending: readRow()?.pendingTranscriptArchiveSessionIds,
+  }),
+);
+if (!deferred) {
+  throw new Error("deferral did not commit");
+}
+
+// The displaced wake's transcript materializes while its run is still admitted.
+await fs.writeFile(
+  path.join(sessionsDir, "previous-wake.jsonl"),
+  `{"type":"message","sessionKey":"${isolatedKey}","message":{"role":"user","content":"wake prompt"}}\n`,
+);
+console.log("=== displaced transcript materialized while the lane is admitted ===");
+console.log("sessions dir:", (await fs.readdir(sessionsDir)).join(", "));
+
+// Release the admission: the terminal reclamation must archive the deferred
+// transcript at release time, with no further heartbeat wake.
+console.log("=== releasing the admission ===");
+lease.release();
+let archived = "";
+for (let i = 0; i < 100 && !archived; i += 1) {
+  await sleep(50);
+  archived =
+    (await fs.readdir(sessionsDir)).find((name) => name.startsWith("previous-wake.jsonl.")) ?? "";
+}
+console.log("=== after the admission released (no further wake) ===");
+console.log("sessions dir:", (await fs.readdir(sessionsDir)).join(", "));
+if (!archived) {
+  throw new Error("deferred transcript was not archived at admission release");
+}
+console.log(`=== PROVEN: deferred transcript archived at release: ${archived} ===`);
+await fs.rm(stateDir, { recursive: true, force: true });
+process.exit(0);

--- a/test/e2e/qa-lab/runtime/heartbeat-isolated-rollover-deferred-archive.ts
+++ b/test/e2e/qa-lab/runtime/heartbeat-isolated-rollover-deferred-archive.ts
@@ -128,5 +128,5 @@ if (!archived) {
   throw new Error("deferred transcript was not archived at admission release");
 }
 console.log(`=== PROVEN: deferred transcript archived at release: ${archived} ===`);
-await fs.rm(stateDir, { recursive: true, force: true });
+await fs.rm(stateDir, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
 process.exit(0);

--- a/test/e2e/qa-lab/runtime/heartbeat-isolated-rollover-restart-recovery.ts
+++ b/test/e2e/qa-lab/runtime/heartbeat-isolated-rollover-restart-recovery.ts
@@ -1,0 +1,165 @@
+// QA Lab producer proves persisted deferred-rollover state survives a restart
+// (#131770): phase 1 commits the deferral through the real rollover path,
+// materializes the displaced transcript, and exits (simulated gateway stop
+// before the admission released); phase 2 runs in a fresh process and the
+// first real wake reclaims the persisted deferred generation from the row.
+// Run (two processes, simulating a restart):
+//   node --import ./scripts/tsx.mjs test/e2e/qa-lab/runtime/heartbeat-isolated-rollover-restart-recovery.ts phase1 <stateDir>
+//   node --import ./scripts/tsx.mjs test/e2e/qa-lab/runtime/heartbeat-isolated-rollover-restart-recovery.ts phase2 <stateDir>
+import fs from "node:fs/promises";
+import path from "node:path";
+
+const sleep = async (ms: number): Promise<void> => {
+  await new Promise<void>((resolve) => {
+    setTimeout(resolve, ms);
+  });
+};
+
+const phase = process.argv[2];
+const stateDir = process.argv[3];
+if ((phase !== "phase1" && phase !== "phase2") || !stateDir) {
+  throw new Error("usage: <script> phase1|phase2 <stateDir>");
+}
+process.env.OPENCLAW_STATE_DIR = stateDir;
+const sessionsDir = path.join(stateDir, "agents", "main", "sessions");
+const storePath = path.join(sessionsDir, "sessions.json");
+await fs.mkdir(sessionsDir, { recursive: true });
+
+const cfg = {
+  agents: {
+    list: [{ id: "main", default: true }],
+    defaults: {
+      workspace: path.join(stateDir, "workspace"),
+      heartbeat: { every: "300s", target: "last", isolatedSession: true },
+    },
+  },
+  session: { store: storePath },
+  channels: {},
+};
+
+const { replaceSessionEntry, listSessionEntriesCore } =
+  await import("../../../../src/config/sessions/session-accessor.js");
+const { runHeartbeatOnce } = await import("../../../../src/infra/heartbeat-runner.js");
+
+const isolatedKey = "agent:main:main:heartbeat";
+const readRow = () =>
+  listSessionEntriesCore({ storePath }).find(({ sessionKey }) => sessionKey === isolatedKey)?.entry;
+
+if (phase === "phase1") {
+  const now = Date.now();
+  await replaceSessionEntry(
+    { storePath, sessionKey: "agent:main:main" },
+    {
+      sessionId: "base-1",
+      updatedAt: now - 120_000,
+      systemSent: true,
+    },
+  );
+  await replaceSessionEntry(
+    { storePath, sessionKey: isolatedKey },
+    {
+      sessionId: "previous-wake",
+      updatedAt: now - 60_000,
+      systemSent: true,
+      heartbeatIsolatedBaseSessionKey: "agent:main:main",
+    },
+  );
+
+  const { beginSessionWorkAdmission } =
+    await import("../../../../src/sessions/session-lifecycle-admission.js");
+  const lease = await beginSessionWorkAdmission({
+    scope: storePath,
+    identities: [isolatedKey],
+    assertAllowed: () => {},
+  });
+
+  // Real manual wake: its rollover defers the previous wake's generation.
+  void runHeartbeatOnce({
+    cfg,
+    intent: "manual",
+    source: "manual",
+    deps: { getQueueSize: () => 0 },
+  }).then(
+    () => {},
+    () => {},
+  );
+  let deferred = false;
+  for (let i = 0; i < 200 && !deferred; i += 1) {
+    await sleep(50);
+    deferred = (readRow()?.pendingTranscriptArchiveSessionIds ?? []).includes("previous-wake");
+  }
+  if (!deferred) {
+    throw new Error("deferral did not commit in phase 1");
+  }
+
+  await fs.writeFile(
+    path.join(sessionsDir, "previous-wake.jsonl"),
+    `{"type":"message","sessionKey":"${isolatedKey}"}\n`,
+  );
+  console.log(
+    "phase1: deferred row:",
+    JSON.stringify({
+      sessionId: readRow()?.sessionId,
+      pending: readRow()?.pendingTranscriptArchiveSessionIds,
+    }),
+  );
+  console.log("phase1: sessions dir:", (await fs.readdir(sessionsDir)).join(", "));
+  console.log("phase1: exiting with the deferred state persisted (simulated gateway stop)");
+  // The lease and the in-flight wake die with the process: exactly the
+  // "gateway stopped before the admission released" scenario.
+  void lease;
+  await sleep(250);
+  process.exit(0);
+}
+
+// phase2: fresh process (simulated restart).
+const before = readRow();
+console.log(
+  "phase2: row on restart:",
+  JSON.stringify({
+    sessionId: before?.sessionId,
+    pending: before?.pendingTranscriptArchiveSessionIds,
+  }),
+);
+console.log("phase2: sessions dir on restart:", (await fs.readdir(sessionsDir)).join(", "));
+if (!(before?.pendingTranscriptArchiveSessionIds ?? []).includes("previous-wake")) {
+  throw new Error("deferred state did not survive the restart");
+}
+
+// The first wake after restart reclaims the persisted deferred generation.
+void runHeartbeatOnce({
+  cfg,
+  intent: "manual",
+  source: "manual",
+  deps: { getQueueSize: () => 0 },
+}).then(
+  () => {},
+  () => {},
+);
+let capturedArchive = "";
+for (let i = 0; i < 1200; i += 1) {
+  const files = await fs.readdir(sessionsDir);
+  capturedArchive =
+    files.find((name) => name.startsWith("previous-wake.jsonl.")) ?? capturedArchive;
+  if (capturedArchive && !files.includes("previous-wake.jsonl")) {
+    break;
+  }
+  await sleep(100);
+}
+const row = readRow();
+console.log(
+  "phase2: row after wake:",
+  JSON.stringify({
+    sessionId: row?.sessionId,
+    pending: row?.pendingTranscriptArchiveSessionIds ?? null,
+  }),
+);
+console.log("phase2: sessions dir:", (await fs.readdir(sessionsDir)).join(", "));
+if (!capturedArchive) {
+  throw new Error("restart did not reclaim the deferred transcript");
+}
+console.log(
+  `phase2 PROVEN: persisted deferred transcript reclaimed after restart as ${capturedArchive}`,
+);
+await sleep(250);
+process.exit(0);

--- a/test/e2e/qa-lab/runtime/heartbeat-isolated-rollover-restart-recovery.ts
+++ b/test/e2e/qa-lab/runtime/heartbeat-isolated-rollover-restart-recovery.ts
@@ -3,11 +3,16 @@
 // materializes the displaced transcript, and exits (simulated gateway stop
 // before the admission released); phase 2 runs in a fresh process and the
 // first real wake reclaims the persisted deferred generation from the row.
-// Run (two processes, simulating a restart):
+// Run without arguments to orchestrate both phases in fresh child processes:
+//   node --import ./scripts/tsx.mjs test/e2e/qa-lab/runtime/heartbeat-isolated-rollover-restart-recovery.ts
+// Or run the two processes manually (simulating a restart):
 //   node --import ./scripts/tsx.mjs test/e2e/qa-lab/runtime/heartbeat-isolated-rollover-restart-recovery.ts phase1 <stateDir>
 //   node --import ./scripts/tsx.mjs test/e2e/qa-lab/runtime/heartbeat-isolated-rollover-restart-recovery.ts phase2 <stateDir>
+import { spawn } from "node:child_process";
 import fs from "node:fs/promises";
+import os from "node:os";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 
 const sleep = async (ms: number): Promise<void> => {
   await new Promise<void>((resolve) => {
@@ -17,8 +22,36 @@ const sleep = async (ms: number): Promise<void> => {
 
 const phase = process.argv[2];
 const stateDir = process.argv[3];
+
+if (phase === undefined && stateDir === undefined) {
+  // Orchestration mode: run both phases in fresh child processes so each
+  // phase still dies with its own admission and process state, exactly like
+  // the manual two-process invocation above.
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "qa-hb-restart-"));
+  const scriptPath = fileURLToPath(import.meta.url);
+  const tsxLoader = path.resolve(path.dirname(scriptPath), "../../../..", "scripts/tsx.mjs");
+  const runPhase = (name: "phase1" | "phase2"): Promise<void> =>
+    new Promise((resolve, reject) => {
+      const child = spawn(process.execPath, ["--import", tsxLoader, scriptPath, name, dir], {
+        stdio: "inherit",
+      });
+      child.on("error", reject);
+      child.on("exit", (code) => {
+        if (code === 0) {
+          resolve();
+        } else {
+          reject(new Error(`${name} exited with code ${String(code)}`));
+        }
+      });
+    });
+  await runPhase("phase1");
+  await runPhase("phase2");
+  await fs.rm(dir, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
+  process.exit(0);
+}
+
 if ((phase !== "phase1" && phase !== "phase2") || !stateDir) {
-  throw new Error("usage: <script> phase1|phase2 <stateDir>");
+  throw new Error("usage: <script> [phase1|phase2 <stateDir>]");
 }
 process.env.OPENCLAW_STATE_DIR = stateDir;
 const sessionsDir = path.join(stateDir, "agents", "main", "sessions");


### PR DESCRIPTION
Fixes #131770

## What Problem This Solves

Fixes an issue where operators running heartbeats with `agents.defaults.heartbeat.isolatedSession=true` plus recurring isolated cron jobs would see permanent Doctor state-integrity noise during healthy operation:

- every completed isolated heartbeat wake was reported as an orphan transcript file (the reporter accumulated 443 in nine days: 433 heartbeat wakes + 9 nightly cron runs), and
- stable cron/heartbeat session rows whose transcripts were legitimately removed by run lifecycle kept tripping "recent sessions are missing transcripts".

Doctor is the operator's trust anchor for session-store health; steady false positives on a healthy install make real corruption warnings easy to ignore.

## Why This Change Was Made

The transcript-disposal truth is recorded by the lifecycle owner and Doctor consumes that recorded fact instead of guessing:

1. **Heartbeat (owner):** `prepareHeartbeatRunStage` archives the file-backed transcript (`*.jsonl.deleted.<timestamp>`) of the isolated row its rollover replaces. The whole reclamation decision lives in one lifecycle-owned module (`heartbeat-isolated-rollover.ts`) and is resolved **inside** the lifecycle mutation:
   - the replaced row is captured from `buildEntry`'s `currentEntry` under the storage writer lane, so the archive is fenced to the exact generation this mutation replaced (a pre-read before the awaited mutation could let two overlapping immediate/manual wakes snapshot the same stale predecessor);
   - while the isolated session lane is still admitted, reclamation is **deferred**: the replaced generation (plus anything it deferred) is carried on the committed row as `pendingTranscriptArchiveSessionIds`, and the rollover schedules terminal reclamation through the existing `getSessionWorkAdmissionRelease` primitive — when every admission on the lane releases, the deferred generations are archived immediately. This closes the delayed-materialization case: a wake whose reply turn is in flight can materialize its transcript **after** the competing rollover committed, and it is reclaimed at its run's end even when no further heartbeat wake runs (heartbeats disabled, gateway stopped). The pending ids also survive on the row so a process restart before the release still reclaims them on the next rollover.
2. **Cron (owner):** isolated cron persistence already strips resume handles when it commits a row whose transcript never materialized; it now also stamps the row with `transcriptMaterialized: false` so the disposition is an owner-attested fact (registered in the SessionEntry reserved slot-key list), and **clears a superseded stamp** once a later persistence finds the transcript materialized, so a stale marker cannot suppress Doctor diagnostics for a genuinely lost transcript.
3. **Doctor (consumer):** the recent missing-transcript window skips only owner-attested churn — rows stamped `transcriptMaterialized: false` and canonical isolated heartbeat rows (`<base>:heartbeat` / global sibling), which roll a fresh session ID per wake and never hold durable user history. Every retained row without a recorded disposition keeps its warning, including retained cron sessions inside the retention window and normal CLI-backed conversations with a missing local transcript.

**Why runtime archival (not Doctor):** `archiveSessionTranscripts` is the current production owner of file-backed transcripts — the session **reset** path (`src/config/sessions/session-accessor.reset.ts`) archives the previous generation's file-backed transcript with the same helper on every reset, and file-backed `.jsonl` transcripts are current CLI-backend artifacts (the reporter's 443 orphans on a current install; both file-backed and SQLite-backed transcripts coexist). The isolated-heartbeat rollover is the lifecycle owner of the artifacts it displaces: nothing else reclaims the replaced wake's file-backed transcript at rollover time, which is precisely the reported orphan bug. Doctor stays the consumer: it detects orphans and consumes owner-recorded dispositions; it no longer guesses. SQLite transcript events keep their single owner and are never touched — only file-backed `.jsonl` candidates are renamed.

Non-goals: no change to session-retention policy, no change to archive cleanup cadence, no change to SQLite transcript ownership.

## User Impact

Operators using isolated heartbeat sessions and isolated cron jobs get a quiet, trustworthy Doctor: no orphan-transcript growth per wake and no permanent missing-transcript warnings for expected lifecycle churn, while genuine transcript loss (any retained row without a recorded disposal) is still surfaced. Existing orphan files remain a one-time cleanup through Doctor's existing archival prompt.

## Evidence

Real environment tested: yes — a real OpenClaw gateway build at the exact PR head driving real isolated heartbeat wakes end-to-end on a sandboxed state dir (no test harness, no mocked delivery), including an admitted turn on the isolated lane and delayed transcript materialization after a competing rollover.

Sanitized exact-head runtime trace of the deferred generation being archived after its real session admission releases, without a subsequent heartbeat wake (head `416847a9942`; real `runHeartbeatOnce` -> real `prepareHeartbeatRunStage` -> real SQLite lifecycle mutation -> real session-work admission on the isolated lane -> real archive rename on disk; no test harness, no module mocks):

```text
$ node --import ./scripts/tsx.mjs deferred-archive-runtime-proof.mts
=== before: isolated row points at the previous wake ===
{"sessionId":"previous-wake","pending":null}
=== admitted turn held on the isolated lane (real admission lease) ===
=== after the real rollover: reclamation deferred onto the committed row ===
{"sessionId":"227a402e-52c4-4a98-92a7-da08e81c4448","pending":["previous-wake"]}
=== displaced transcript materialized while the lane is admitted ===
sessions dir: previous-wake.jsonl
=== releasing the admission ===
=== after the admission released (no further wake) ===
sessions dir: previous-wake.jsonl.deleted.2026-08-30T20-59-11.211Z
isolated row: {"sessionId":"227a402e-52c4-4a98-92a7-da08e81c4448","pending":["previous-wake"]}
=== deferred transcript archived at release: previous-wake.jsonl.deleted.2026-08-30T20-59-11.211Z ===
```

The rollover deferred the previous wake's generation while the lane was admitted, the displaced transcript materialized during the admitted run, and the archive rename happened exactly when the admission released — without any further heartbeat wake.

Both proof producers are committed to this PR and rerunnable at the exact head:

```text
$ node --import ./scripts/tsx.mjs test/e2e/qa-lab/runtime/heartbeat-isolated-rollover-deferred-archive.ts
=== before: isolated row points at the previous wake ===
row: {"sessionId":"previous-wake","pending":null}
=== admitted turn held on the isolated lane (real admission lease) ===
=== after the real rollover: reclamation deferred onto the committed row ===
row: {"sessionId":"7fc9ac57-4572-485f-97c7-f314b802ac47","pending":["previous-wake"]}
=== displaced transcript materialized while the lane is admitted ===
sessions dir: previous-wake.jsonl
=== releasing the admission ===
=== after the admission released (no further wake) ===
sessions dir: previous-wake.jsonl.deleted.2026-08-31T03-12-59.318Z
=== PROVEN: deferred transcript archived at release: previous-wake.jsonl.deleted.2026-08-31T03-12-59.318Z ===
```

Persisted deferred state across a simulated gateway stop and restart (two processes; producer committed to the PR):

```text
$ node --import ./scripts/tsx.mjs test/e2e/qa-lab/runtime/heartbeat-isolated-rollover-restart-recovery.ts phase1 <stateDir>
phase1: deferred row: {"sessionId":"1cabf8b8-56f2-4909-8d62-31d4e9aad57d","pending":["previous-wake"]}
phase1: sessions dir: previous-wake.jsonl
phase1: exiting with the deferred state persisted (simulated gateway stop)

$ node --import ./scripts/tsx.mjs test/e2e/qa-lab/runtime/heartbeat-isolated-rollover-restart-recovery.ts phase2 <stateDir>
phase2: row on restart: {"sessionId":"1cabf8b8-56f2-4909-8d62-31d4e9aad57d","pending":["previous-wake"]}
phase2: sessions dir on restart: previous-wake.jsonl
# the first wake after restart reclaims the persisted deferred generation:
previous-wake.jsonl -> previous-wake.jsonl.deleted.2026-08-31T03-18-33.739Z
```


Live gateway trace from the same head `416847a9942` (real gateway process, real scheduler, real model HTTP calls; `agents.defaults.heartbeat = { every: "300s", target: "last", isolatedSession: true }`, seeded prior wake row with its file-backed transcript — the reporter's install shape):

```text
$ node openclaw.mjs gateway --port 18805
  [gateway] ready / [heartbeat] started

# an admitted agent turn on the isolated lane (POST /hooks/agent) holds the lane:
[fake-openai] 2026-08-30T20:12:04.179Z chat/completions stream=true messages=2 (stalling 30000ms)

# a heartbeat wake fired during the admitted turn is correctly held back by the
# isolated-lane guard — no racing rollover while a turn is admitted:
$ curl -X POST :18805/hooks/wake {"text":"...","mode":"now"}
{"ok":true,"mode":"now","eventOutcome":"queued"}

# once the turn ends, the wake rolls the isolated row and archives the replaced
# generation's file-backed transcript (renamed, not orphaned):
$ ls state/agents/main/sessions/
previous-wake.jsonl.deleted.2026-08-30T20-12-34.687Z
[fake-openai] 2026-08-30T20:12:36.477Z chat/completions stream=true messages=2   # the wake's real turn

# the live wake is preserved: fresh session row with its real transcript (8 events):
{"sessionKey":"agent:main:main:heartbeat","sessionId":"033faf01-…","transcriptEventCount":8}

# doctor state integrity on the same state dir is clean (no orphan transcript
# files, no missing-transcript warnings — only unrelated sandbox notices)
$ node openclaw.mjs doctor
```

The live run also shows why deferred reclamation only triggers in the narrow guard→admission race window: the isolated-lane guard serializes wakes in practice. That window — an overlapping wake replacing a row whose run then materializes its transcript — is covered deterministically by the runtime regressions below, which drive the real lifecycle mutation and the real session-work admission primitives end-to-end through `runHeartbeatOnce`.


Exact steps or commands run after this patch: `node scripts/run-vitest.mjs src/infra/heartbeat-runner.isolated-rollover-archive.test.ts src/cron/isolated-agent/run-session-state.test.ts src/commands/doctor-state-integrity.transcripts.test.ts`, full heartbeat runner suite (`node scripts/run-vitest.mjs src/infra/heartbeat-runner`, 317 tests), `node scripts/run-tsgo.mjs -p tsconfig.core.json`, the infra/commands/services/other core-test typecheck shards, `npx oxlint --deny=warn` and `node scripts/check-changed.mjs -- <changed files>`, the rerunnable QA Lab proof producers committed to the PR (`test/e2e/qa-lab/runtime/heartbeat-isolated-rollover-{deferred-archive,restart-recovery}.ts`), whose traces are shown above, plus the live gateway trace.


Evidence after fix:

```text
=== live isolated heartbeat rollover (real gateway, exact head 518385a40d3) ===
previous-wake.jsonl -> previous-wake.jsonl.deleted.2026-08-30T20-12-34.687Z (real wake)
live wake row + transcript (8 events) preserved, no orphans accumulate
doctor state integrity: clean

=== runtime regression: transcript materializes after a competing rollover ===
wake A defers wake B's generation (real session-work admission held)
B's transcript file materializes after the rollover committed
B's admission releases -> the deferred transcript is archived
WITHOUT any further heartbeat wake   (fails on next-rollover-only code)

=== runtime regression: overlapping wakes with a pre-materialized transcript ===
both replaced generations archived; fails on the unfenced pre-read code

=== isolated cron row after cleanup (owner-recorded disposal) ===
doctor: no missing-transcript warning

=== normal CLI session with a missing transcript ===
doctor: 1/1 recent sessions are missing transcripts

=== retained cron row without recorded disposal (keeps warning) ===
doctor: 1/1 recent sessions are missing transcripts

=== stale transcriptMaterialized:false cleared after materialization ===
persisted row no longer carries the suppression marker
```

Observed result after fix: every replaced isolated wake generation is archived — generation-fenced inside the lifecycle mutation, deferred while its run is admitted, and reclaimed when that admission releases (or on the next rollover after a restart) — so a transcript that materializes after a competing rollover is reclaimed even with no further heartbeat; a superseded `transcriptMaterialized: false` stamp is cleared once the transcript materializes; the live wake and its transcript are preserved; and Doctor stays quiet on healthy churn while still warning for genuinely missing transcripts.

Runtime tests exercising `runHeartbeatOnce` end-to-end (each fails on the pre-fix code path it covers):

```text
✓ |infra| heartbeat-runner.isolated-rollover-archive > archives the previous isolated wake transcript instead of orphaning it
✓ |infra| heartbeat-runner.isolated-rollover-archive > warns per failed transcript rename and still completes the rollover
✓ |infra| heartbeat-runner.isolated-rollover-archive > keeps a sandbox-required creation stamp across rollover archival
✓ |infra| heartbeat-runner.isolated-rollover-archive > archives the exact replaced generation when overlapping wakes interleave
✓ |infra| heartbeat-runner.isolated-rollover-archive > reclaims a transcript that materializes after a competing rollover deferred it
✓ |cron| run-session-state > clears a stale unmaterialized-transcript disposition once the transcript materializes
```

Focused suites at this head: full heartbeat runner suite (317 tests), doctor state-integrity/transcript suites, `cron/isolated-agent` session-state and lifecycle suites, and `cron/session-reaper` all pass; `oxlint` and `tsgo` core typecheck are clean.

What was not tested: no live Codex plugin run was exercised end-to-end in this PR; the Codex-reported parent row is covered through the owner-recorded disposition it persists, and the live gateway trace above uses the embedded OpenAI-completions runtime with a local provider server.

