### PR TITLE
test: expire stalled Git fetches after fixture readiness

### DIFF
--- a/src/infra/state-migrations.media-persistence.test-support.ts
+++ b/src/infra/state-migrations.media-persistence.test-support.ts
@@ -1,0 +1,65 @@
+import { requireNodeSqlite } from "./node-sqlite.js";
+
+export function readDatabaseSnapshot(databasePath: string) {
+  const { DatabaseSync } = requireNodeSqlite();
+  const database = new DatabaseSync(databasePath);
+  try {
+    const version = database.prepare("PRAGMA user_version").get() as { user_version: number };
+    const rows = database
+      .prepare(
+        "SELECT session_id,seq,event_json,created_at FROM transcript_events ORDER BY session_id,seq",
+      )
+      .all() as Array<{
+      session_id: string;
+      seq: number;
+      event_json: string;
+      created_at: number;
+    }>;
+    const identities = database
+      .prepare(
+        "SELECT session_id,event_id,seq,event_type,parent_id,message_idempotency_key,created_at FROM transcript_event_identities ORDER BY session_id,seq",
+      )
+      .all();
+    const activeBranch = database
+      .prepare(
+        "SELECT session_id,active_position,event_seq,message_position FROM session_transcript_active_events ORDER BY session_id,active_position",
+      )
+      .all();
+    const windows = database
+      .prepare(
+        "SELECT session_id,session_key,created_at,updated_at,transcript_observed_at FROM session_windows ORDER BY session_id",
+      )
+      .all();
+    const generations = database
+      .prepare(
+        "SELECT session_id,generation FROM transcript_rewrite_watermarks ORDER BY session_id",
+      )
+      .all();
+    const trajectoryCount = database
+      .prepare("SELECT count(*) AS count FROM trajectory_runtime_events")
+      .get() as { count: number };
+    const trajectoryRows = database
+      .prepare(
+        "SELECT session_id,seq,run_id,event_json,created_at FROM trajectory_runtime_events ORDER BY session_id,seq",
+      )
+      .all() as Array<{
+      session_id: string;
+      seq: number;
+      run_id: string | null;
+      event_json: string;
+      created_at: number;
+    }>;
+    return {
+      activeBranch,
+      generations,
+      identities,
+      rows,
+      trajectoryCount: trajectoryCount.count,
+      trajectoryRows,
+      version,
+      windows,
+    };
+  } finally {
+    database.close();
+  }
+}

--- a/src/infra/state-migrations.media-persistence.test.ts
+++ b/src/infra/state-migrations.media-persistence.test.ts
@@ -20,6 +20,7 @@ import {
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
 import { requireNodeSqlite } from "./node-sqlite.js";
 import { migrateLegacyMediaPersistence } from "./state-migrations.media-persistence.js";
+import { readDatabaseSnapshot } from "./state-migrations.media-persistence.test-support.js";
 
 const tempDirs: string[] = [];
 const PREVIOUS_VERSION = 16;
@@ -116,70 +117,6 @@ function createLegacyDatabaseFixture(params: {
     schemaVersion,
   });
   return databasePath;
-}
-
-function readDatabaseSnapshot(databasePath: string) {
-  const { DatabaseSync } = requireNodeSqlite();
-  const database = new DatabaseSync(databasePath);
-  try {
-    const version = database.prepare("PRAGMA user_version").get() as { user_version: number };
-    const rows = database
-      .prepare(
-        "SELECT session_id,seq,event_json,created_at FROM transcript_events ORDER BY session_id,seq",
-      )
-      .all() as Array<{
-      session_id: string;
-      seq: number;
-      event_json: string;
-      created_at: number;
-    }>;
-    const identities = database
-      .prepare(
-        "SELECT session_id,event_id,seq,event_type,parent_id,message_idempotency_key,created_at FROM transcript_event_identities ORDER BY session_id,seq",
-      )
-      .all();
-    const activeBranch = database
-      .prepare(
-        "SELECT session_id,active_position,event_seq,message_position FROM session_transcript_active_events ORDER BY session_id,active_position",
-      )
-      .all();
-    const windows = database
-      .prepare(
-        "SELECT session_id,session_key,created_at,updated_at,transcript_observed_at FROM session_windows ORDER BY session_id",
-      )
-      .all();
-    const generations = database
-      .prepare(
-        "SELECT session_id,generation FROM transcript_rewrite_watermarks ORDER BY session_id",
-      )
-      .all();
-    const trajectoryCount = database
-      .prepare("SELECT count(*) AS count FROM trajectory_runtime_events")
-      .get() as { count: number };
-    const trajectoryRows = database
-      .prepare(
-        "SELECT session_id,seq,run_id,event_json,created_at FROM trajectory_runtime_events ORDER BY session_id,seq",
-      )
-      .all() as Array<{
-      session_id: string;
-      seq: number;
-      run_id: string | null;
-      event_json: string;
-      created_at: number;
-    }>;
-    return {
-      activeBranch,
-      generations,
-      identities,
-      rows,
-      trajectoryCount: trajectoryCount.count,
-      trajectoryRows,
-      version,
-      windows,
-    };
-  } finally {
-    database.close();
-  }
 }
 
 function writeArchive(filePath: string, events: FixtureEvent[], compressed: boolean): void {

--- a/test/scripts/ci-checkout.test-support.ts
+++ b/test/scripts/ci-checkout.test-support.ts
@@ -35,6 +35,25 @@ export function readCiCheckoutStep(job: string, name = "Checkout"): Step & { run
   return { ...step, run: step.run };
 }
 
+export function accelerateCiCheckoutFetchClock(run: string): string {
+  // Only fetch deadlines use fixture ticks; startup and cleanup keep real clocks.
+  return run
+    .replace(
+      "def run_git(",
+      `def fetch_clock():
+    return 2 * sum(name.startswith("fetch-tick-") and name.endswith(".json")
+                   for name in os.listdir(os.environ["TMPDIR"]))
+
+
+def run_git(`,
+    )
+    .replace("deadline = time.monotonic() + timeout", "deadline = fetch_clock() + timeout")
+    .replace(
+      "deadline is not None and time.monotonic() >= deadline",
+      "deadline is not None and fetch_clock() >= deadline",
+    );
+}
+
 export function expectCiCheckoutCleanup(report: Report) {
   expect(report.cleanupRemaining, "fixture cleanup left owned processes").toEqual([]);
   expect(report.boundaries.at(-1)?.name).toBe("exit");

--- a/test/scripts/ci-linux-git.test.ts
+++ b/test/scripts/ci-linux-git.test.ts
@@ -10,6 +10,7 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import { expect, it } from "vitest";
 import {
+  accelerateCiCheckoutFetchClock,
   expectCiCheckoutCleanup,
   readCiCheckoutStep,
   withCiCheckoutFixture,
@@ -74,16 +75,18 @@ function accelerate(run: string, timeoutReadyFile?: string) {
   // For cancellation, advance this copy's timeout only after full tree readiness
   // and retain the real TERM grace so the signal reaches drain, not startup.
   const timeoutCheck = "if deadline is not None and time.monotonic() >= deadline:";
-  const readyCheck = timeoutReadyFile
-    ? `if deadline is not None and os.path.isfile(${JSON.stringify(timeoutReadyFile)}):`
-    : timeoutCheck;
+  const accelerated = timeoutReadyFile
+    ? run.replace(
+        timeoutCheck,
+        `if deadline is not None and os.path.isfile(${JSON.stringify(timeoutReadyFile)}):`,
+      )
+    : accelerateCiCheckoutFetchClock(run);
   const killAt = timeoutReadyFile
     ? "kill_at = deadline - cleanup_seconds / 2"
     : "kill_at = time.monotonic()";
   return (
-    run
+    accelerated
       .replace(/fetch_timeout_seconds = [^\n]+/u, "fetch_timeout_seconds = 2")
-      .replace(timeoutCheck, readyCheck)
       .replace("kill_at = deadline - cleanup_seconds / 2", killAt)
       .replace(/retry_at = time\.monotonic\(\) \+ [^\n]+/u, "retry_at = time.monotonic() + 0.05")
       .replaceAll("--git 120", "--git 2")

--- a/test/scripts/ci-platform-checkout.test.ts
+++ b/test/scripts/ci-platform-checkout.test.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import { expectDefined } from "@openclaw/normalization-core";
 import { expect, it } from "vitest";
 import {
+  accelerateCiCheckoutFetchClock,
   ciCheckoutFixture,
   expectCiCheckoutCleanup,
   readCiCheckoutStep,
@@ -79,22 +80,8 @@ it.each([
     }
     // Only a ready, deliberately stalled tree advances the fetch clock. Real
     // process startup and teardown retain their independent wall-clock watchdogs.
-    const accelerated = run
+    const accelerated = accelerateCiCheckoutFetchClock(run)
       .replace(/fetch_timeout_seconds = [^\n]+/u, "fetch_timeout_seconds = 2")
-      .replace(
-        "def run_git(",
-        `def fetch_clock():
-    return 2 * sum(name.startswith("fetch-tick-") and name.endswith(".json")
-                   for name in os.listdir(os.environ["TMPDIR"]))
-
-
-def run_git(`,
-      )
-      .replace("deadline = time.monotonic() + timeout", "deadline = fetch_clock() + timeout")
-      .replace(
-        "deadline is not None and time.monotonic() >= deadline",
-        "deadline is not None and fetch_clock() >= deadline",
-      )
       .replace("kill_at = deadline - cleanup_seconds / 2", "kill_at = time.monotonic()")
       .replace(/retry_at = time\.monotonic\(\) \+ [^\n]+/u, "retry_at = time.monotonic() + 0.05");
     expect(accelerated).not.toBe(run);

--- a/test/scripts/fixtures/ci-platform-checkout.mjs
+++ b/test/scripts/fixtures/ci-platform-checkout.mjs
@@ -282,6 +282,9 @@ async function command() {
         process.exit(0);
       }
       if (result === "hang") {
+        if (!options.cancelDuringCleanup) {
+          publish(`fetch-tick-${attempt}.json`, attempt);
+        }
         return;
       }
       if (result === 0) {


### PR DESCRIPTION
## What Problem This Solves

The Linux Git checkout fixture spends two real seconds on each deliberately stalled fetch, even after its full process tree is ready. Its existing cases contain 23 such outcomes, so deadline waiting dominates execution.

## Why This Change Was Made

Reuse the platform fixture's existing fetch-only clock. A configured stalled Git parent publishes an immutable tick only after its grandchild has registered and reported readiness. The copied workflow owner then expires the fetch deadline immediately. Startup watchdogs, cleanup deadlines, process census, cancellation, retries and consumption still use their original boundaries.

The cancellation-during-cleanup case keeps its separate readiness trigger and real TERM grace. Its generated workflow body is byte-identical. The platform transformation is also byte-identical after extracting the shared helper.

## User Impact

All 42 Linux cases passed: summed case execution fell from **79.52s to 37.97s**, repeating at **39.02s**. The candidate runs also passed all 22 platform cases on Linux; all 22 passed separately on macOS. These are focused execution measurements, not a full-suite wall-time claim.

No sharding, workers, concurrency, test selection, workflow or production behavior changes. Optimization: tests/support +32/-20; production +0/-0.

## Evidence

- Linux baseline: `node scripts/run-vitest.mjs test/scripts/ci-linux-git.test.ts` (42 passed).
- Candidate and repeat: `node scripts/run-vitest.mjs test/scripts/ci-linux-git.test.ts test/scripts/ci-platform-checkout.test.ts` (64 passed).
- Omitting the workflow owner's drain made the existing ownership assertion observe live descendants at checkout and exit.
- Omitting post-drain cancellation precedence made the existing cancellation case observe an incorrect full npm-lock fallback.
- Injecting the existing 2.1-second tree-start delay passed with both ready attempts recorded. Publishing the tick before full readiness then failed the original exact ready-attempt assertion.
- Original bytes were restored between probes; the unmodified candidate passed all 64 cases afterward. Blacksmith Testbox wrapper exited 0 and stopped the lease: https://github.com/openclaw/openclaw/actions/runs/33240517584.
- Linux changed checks passed with wrapper exit 0 and Testbox stopped: https://github.com/openclaw/openclaw/actions/runs/33240405031.
- Complete fixture, tests, shared helper, canonical Python owner and relevant history inspected. Independent review and Codex autoreview through P3 found no actionable findings. Formatting/whitespace passed. All original assertions and case tables remain intact.
- Exact-head hosted CI must pass before landing.

## Shared CI Integration

The branch also carries the same bounded max-lines repair as #132444: move the existing media-migration snapshot reader verbatim into test support. All 15 migration tests passed before and after; focused lint and Codex review passed. Tests/support +66/-64; no database schema, runtime, SQL, assertion, cleanup, or test-placement change. The shared repair lands once and disappears from the remaining PR diffs.

Final exact-head CI passed: https://github.com/openclaw/openclaw/actions/runs/33240698203. Latest ClawSweeper is a started-review placeholder with no findings or rank-up moves; independent maintainer review and both Codex reviews are complete. The shared media fixture repair has landed in #132444.
