### PR TITLE
fix(setup): preserve verified inference during first-agent creation

### DIFF
--- a/src/system-agent/inference-route.ts
+++ b/src/system-agent/inference-route.ts
@@ -290,7 +290,7 @@ export async function projectInferenceRoute(
       ? {
           agent: {
             id: normalizeAgentId(agent.id),
-            agentDir: agent.agentDir,
+            // route.agentDir pins the resolved owner; setup may materialize that same default.
             model: structuredClone(agent.model),
             params: structuredClone(agent.params),
             tools: structuredClone(agent.tools),

--- a/src/system-agent/setup-inference-route-guard.ts
+++ b/src/system-agent/setup-inference-route-guard.ts
@@ -8,7 +8,7 @@ import {
 
 function withoutAgentIdentity(projection: DefaultInferenceRouteProjection): unknown {
   const agent = isRecord(projection.agent)
-    ? { ...projection.agent, id: "<agent>", agentDir: "<agent-dir>" }
+    ? { ...projection.agent, id: "<agent>" }
     : projection.agent;
   return {
     ...projection,

--- a/src/system-agent/verified-inference.test-support.ts
+++ b/src/system-agent/verified-inference.test-support.ts
@@ -1,0 +1,58 @@
+import { vi } from "vitest";
+import type { PluginOrigin } from "../plugins/types.js";
+
+type TestPluginRecord = {
+  pluginId: string;
+  origin: PluginOrigin;
+  rootDir: string;
+  manifestPath: string;
+  manifestHash: string;
+  source: string;
+  packageName: string;
+  packageVersion: string;
+  installRecordHash?: string;
+  packageJson: { path: string; hash: string };
+};
+
+export function pluginRecord(
+  pluginId: string,
+  overrides: Partial<TestPluginRecord> = {},
+): TestPluginRecord {
+  const rootDir = `/plugins/${pluginId}`;
+  return {
+    pluginId,
+    origin: "global",
+    rootDir,
+    manifestPath: `${rootDir}/openclaw.plugin.json`,
+    manifestHash: `${pluginId}-manifest-v1`,
+    source: `${rootDir}/index.js`,
+    packageName: `@openclaw/${pluginId}`,
+    packageVersion: "1.0.0",
+    installRecordHash: `${pluginId}-install-v1`,
+    packageJson: { path: `${rootDir}/package.json`, hash: `${pluginId}-package-v1` },
+    ...overrides,
+  };
+}
+
+export function pluginArtifactDeps() {
+  return {
+    fingerprintPluginRuntimeArtifact: (record: { pluginId: string }) =>
+      `${record.pluginId}-runtime-v1`,
+  };
+}
+
+export function cliRuntimeArtifactDeps(fingerprint = "claude-cli-artifact-v1") {
+  return {
+    resolveCliRuntimeArtifactFingerprint: vi.fn(async () => fingerprint),
+  };
+}
+
+export const cliRuntimeArtifactAuth = {
+  runtimeArtifactFingerprint: "claude-cli-artifact-v1",
+  runtimeArtifactId: "claude-cli",
+} as const;
+
+export const codexRuntimeArtifactAuth = {
+  runtimeArtifactFingerprint: "codex-runtime-v1",
+  runtimeArtifactId: "codex-app-server",
+} as const;

--- a/src/system-agent/verified-inference.test.ts
+++ b/src/system-agent/verified-inference.test.ts
@@ -10,7 +10,6 @@ import {
   fingerprintResolvedProviderAuth,
 } from "../agents/execution-auth-binding.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import type { PluginOrigin } from "../plugins/types.js";
 import { resolveSystemAgentConfiguredRouteFromConfig } from "./inference-route.js";
 import { resolvePersistentApplyInference } from "./setup-inference.js";
 import {
@@ -23,6 +22,13 @@ import {
   resolveSystemAgentVerifiedInferenceRoute,
   type SystemAgentVerifiedInferenceDeps,
 } from "./verified-inference.js";
+import {
+  cliRuntimeArtifactAuth,
+  cliRuntimeArtifactDeps,
+  codexRuntimeArtifactAuth,
+  pluginArtifactDeps,
+  pluginRecord,
+} from "./verified-inference.test-support.js";
 
 const pluginRegistryState = vi.hoisted(() => ({
   providerOwnerIds: ["provider-owner"],
@@ -94,39 +100,6 @@ afterAll(() => {
   pluginMetadataSnapshot?.restore();
 });
 
-type TestPluginRecord = {
-  pluginId: string;
-  origin: PluginOrigin;
-  rootDir: string;
-  manifestPath: string;
-  manifestHash: string;
-  source: string;
-  packageName: string;
-  packageVersion: string;
-  installRecordHash?: string;
-  packageJson: { path: string; hash: string };
-};
-
-function pluginRecord(
-  pluginId: string,
-  overrides: Partial<TestPluginRecord> = {},
-): TestPluginRecord {
-  const rootDir = `/plugins/${pluginId}`;
-  return {
-    pluginId,
-    origin: "global",
-    rootDir,
-    manifestPath: `${rootDir}/openclaw.plugin.json`,
-    manifestHash: `${pluginId}-manifest-v1`,
-    source: `${rootDir}/index.js`,
-    packageName: `@openclaw/${pluginId}`,
-    packageVersion: "1.0.0",
-    installRecordHash: `${pluginId}-install-v1`,
-    packageJson: { path: `${rootDir}/package.json`, hash: `${pluginId}-package-v1` },
-    ...overrides,
-  };
-}
-
 beforeEach(() => {
   pluginMetadataSnapshot?.rebindForCurrentEnv();
   pluginRegistryState.providerOwnerIds = ["provider-owner"];
@@ -160,29 +133,6 @@ function authDeps(apiKey = "verified-key") {
     ),
   };
 }
-
-function pluginArtifactDeps() {
-  return {
-    fingerprintPluginRuntimeArtifact: (record: { pluginId: string }) =>
-      `${record.pluginId}-runtime-v1`,
-  };
-}
-
-function cliRuntimeArtifactDeps(fingerprint = "claude-cli-artifact-v1") {
-  return {
-    resolveCliRuntimeArtifactFingerprint: vi.fn(async () => fingerprint),
-  };
-}
-
-const cliRuntimeArtifactAuth = {
-  runtimeArtifactFingerprint: "claude-cli-artifact-v1",
-  runtimeArtifactId: "claude-cli",
-} as const;
-
-const codexRuntimeArtifactAuth = {
-  runtimeArtifactFingerprint: "codex-runtime-v1",
-  runtimeArtifactId: "codex-app-server",
-} as const;
 
 function config(model = "openai/gpt-5.5@openai:verified"): OpenClawConfig {
   return {
@@ -573,17 +523,24 @@ describe("verified OpenClaw inference binding", () => {
               deps,
             )
           : await bindingFor(baseConfig, deps);
-      const materialized = structuredClone(baseConfig);
-      materialized.agents!.entries!.main = {
-        name: "main",
-        workspace: "/tmp/first-run-workspace",
-        agentDir: binding.execution.agentDir,
-      };
+      const materialized = {
+        ...baseConfig,
+        agents: {
+          ...baseConfig.agents,
+          entries: {
+            main: {
+              name: "main",
+              workspace: "/tmp/first-run-workspace",
+              agentDir: binding.execution.agentDir,
+            },
+          },
+        },
+      } satisfies OpenClawConfig;
 
       await expect(revalidate(binding, materialized, deps)).resolves.toBe(binding.execution);
 
       const moved = structuredClone(materialized);
-      moved.agents!.entries!.main.agentDir = path.join(binding.execution.agentDir, "replacement");
+      moved.agents.entries.main.agentDir = path.join(binding.execution.agentDir, "replacement");
       await expect(revalidate(binding, moved, deps)).resolves.toBeNull();
 
       deps.resolveCliRuntimeArtifactFingerprint.mockResolvedValue("replacement-cli-artifact");

--- a/src/system-agent/verified-inference.test.ts
+++ b/src/system-agent/verified-inference.test.ts
@@ -547,6 +547,51 @@ describe("verified OpenClaw inference binding", () => {
     ).resolves.toBeNull();
   });
 
+  it.each(["cli", "embedded"] as const)(
+    "keeps a verified %s owner when first-agent setup materializes the same credential directory",
+    async (runner) => {
+      const baseConfig = config(
+        runner === "cli" ? "claude-cli/claude-opus-5" : "openai/gpt-5.5@openai:verified",
+      );
+      baseConfig.agents = { ...baseConfig.agents, entries: { main: {} } };
+      const deps = {
+        ...authDeps(),
+        ...pluginArtifactDeps(),
+        ...cliRuntimeArtifactDeps(),
+        resolveCliRuntimeOwnerFingerprint: vi.fn(async () => "opaque-cli-owner"),
+      };
+      const binding =
+        runner === "cli"
+          ? await createBinding(
+              await requireRoute(baseConfig, "cli"),
+              {
+                runtimeOwnerFingerprint: "opaque-cli-owner",
+                runtimeOwnerKind: "cli-runtime",
+                runtimeOwnerId: "claude-cli",
+                ...cliRuntimeArtifactAuth,
+              },
+              deps,
+            )
+          : await bindingFor(baseConfig, deps);
+      const materialized = structuredClone(baseConfig);
+      materialized.agents!.entries!.main = {
+        name: "main",
+        workspace: "/tmp/first-run-workspace",
+        agentDir: binding.execution.agentDir,
+      };
+
+      await expect(revalidate(binding, materialized, deps)).resolves.toBe(binding.execution);
+
+      const moved = structuredClone(materialized);
+      moved.agents!.entries!.main.agentDir = path.join(binding.execution.agentDir, "replacement");
+      await expect(revalidate(binding, moved, deps)).resolves.toBeNull();
+
+      deps.resolveCliRuntimeArtifactFingerprint.mockResolvedValue("replacement-cli-artifact");
+      harnessRuntimeArtifactState.fingerprint = "replacement-harness-artifact";
+      await expect(revalidate(binding, materialized, deps)).resolves.toBeNull();
+    },
+  );
+
   it("invalidates a strict CLI binding when its forwarded SecretRef changes", async () => {
     const profileId = "claude-cli:work";
     const cliConfig = {


### PR DESCRIPTION
## Summary
First-run setup can reject its own verified inference route after creating the first agent. The directory has not changed: setup merely writes the same default credential directory explicitly. The route fingerprint previously included both the resolved directory and its raw optional config spelling.

Use the canonical resolved directory as the identity fact and remove the redundant raw directory projection. Real directory changes, changed credentials, and replaced CLI or embedded runtime artifacts continue to invalidate the binding. Remove the corresponding obsolete setup normalization field.

Release note: first-run setup retains its verified model when agent creation writes out the existing default credential directory.

## Validation
- Full candidate Docker run exposed the original `system-agent-first-run` failure: https://github.com/openclaw/openclaw/actions/runs/33237600353
- Regression reproduced before the fix: both CLI and embedded cases failed when the default directory became explicit.
- 90 focused tests passed across verified inference, inference routing, setup apply, and setup concurrency. Coverage rejects real directory moves and runtime artifact replacements.
- Independent Codex autoreview completed with no accepted actionable findings.
- Production LOC: +2/-2; tests: +45/-0. No configuration, schema, or persistence design change.

Fresh candidate Docker proof and exact-head CI will be attached before landing.

## Completed Docker proof
[Fresh package acceptance run33241510713](https://github.com/openclaw/openclaw/actions/runs/33241510713) passed package integrity, npm12 installation, and the actual system-agent-first-run Docker lane with the production fix. Subsequent changes only extracted test fixtures and corrected test typing; production files are unchanged. All37 verified-inference tests and focused core lint now pass. The branch was rebased onto main's independent media fixture-size repair.
