### PR TITLE
test: align release QA fixtures with owner contracts

### DIFF
--- a/extensions/qa-lab/src/providers/mock-openai/server.test.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/server.test.ts
@@ -8182,7 +8182,7 @@ Update and merge these partial structured summaries.`,
     expect(outputText(laterHeartbeatPayload)).toBe("HEARTBEAT_OK");
   });
 
-  it("scripts one failure-honest Code Mode terminal-tool continuation (#118274)", async () => {
+  it("reports a failed Code Mode read honestly through ordinary continuation", async () => {
     const server = await startMockServer();
     const prompt =
       "Failed tool terminal recovery QA check: read the missing file, then respond with exact marker: `QA-FAILED-TOOL-FINALIZED-OK`.";
@@ -8226,49 +8226,28 @@ Update and merge these partial structured summaries.`,
       String(plannedRequest.plannedToolCallId),
       JSON.stringify({ status: "failed", error: "ENOENT: qa-failed-terminal-missing-file.txt" }),
     );
-    const dishonestFinalization = await expectNonStreamingResponsesJson<{
-      output?: Array<{ content?: Array<{ text?: string }> }>;
-    }>(server, {
-      model: "gpt-5.6-luna",
-      input: [
-        makeUserInput(prompt),
-        makeUserInput(QA_SETTLED_TOOL_TERMINAL_CONTINUATION_INSTRUCTION),
-        failedToolOutput,
-      ],
-    });
-    expect(outputText(dishonestFinalization)).toBe("FAILED-TOOL-HONESTY-INSTRUCTION-MISSING");
-
     const recovered = await expectNonStreamingResponsesJson<{
       output?: Array<{ content?: Array<{ text?: string }> }>;
     }>(server, {
       model: "gpt-5.6-luna",
-      input: [
-        makeUserInput(prompt),
-        makeUserInput(
-          `${QA_SETTLED_TOOL_TERMINAL_CONTINUATION_INSTRUCTION} If a tool failed, say so; never claim completion or success.`,
-        ),
-        failedToolOutput,
-      ],
+      tools: codeModeTools,
+      input: [makeUserInput(prompt), failedToolOutput],
     });
     expect(outputText(recovered)).toBe(
       "The requested file could not be read: ENOENT. QA-FAILED-TOOL-FINALIZED-OK",
     );
 
-    const reconciled = await expectNonStreamingResponsesJson<{
+    const succeeded = await expectNonStreamingResponsesJson<{
       output?: Array<{ content?: Array<{ text?: string }> }>;
     }>(server, {
       model: "gpt-5.6-luna",
+      tools: codeModeTools,
       input: [
         makeUserInput(prompt),
-        makeUserInput(
-          "The previous Code Mode mutation may have partially applied. Do not repeat or finish any mutation. Use only the available read-only inspection tools to determine the authoritative current state, then report exactly what applied, what did not, what remains unknown, and what work is still required.",
-        ),
-        failedToolOutput,
+        makeToolOutputWithCallId(String(plannedRequest.plannedToolCallId), "file contents"),
       ],
     });
-    expect(outputText(reconciled)).toBe(
-      "The requested file could not be read: ENOENT. QA-FAILED-TOOL-FINALIZED-OK",
-    );
+    expect(outputText(succeeded)).toBe("BUG-TOOL-DID-NOT-FAIL");
   });
 });
 

--- a/extensions/qa-lab/src/providers/mock-openai/server.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/server.ts
@@ -293,9 +293,6 @@ const QA_CODE_MODE_TARGET_MARKER = "qa-code-mode-target:";
 const QA_RESTART_CHECKPOINT_COUNT = 3;
 const QA_RESTART_FINAL_TEXT = "unsafeVisible=false\nRESTART-CODE-MODE-WAIT-OK";
 const QA_FAILED_TOOL_TERMINAL_RECOVERY_PROMPT_RE = /failed tool terminal recovery qa check/i;
-// Code Mode uses this read-only continuation after an uncertain tool effect.
-const QA_CODE_MODE_RECONCILIATION_PROMPT_RE =
-  /the previous Code Mode mutation may have partially applied/i;
 const QA_TELEGRAM_VISIBLE_PARTIAL_FAILURE_PROMPT_RE = /telegram visible partial failure qa check/i;
 const QA_TELEGRAM_UNSENT_FAILURE_PROMPT_RE = /telegram unsent failure qa check/i;
 const QA_TELEGRAM_VISIBLE_PARTIAL_FAILURE_MARKER = "TELEGRAM-VISIBLE-PARTIAL-BEFORE-FAILURE";
@@ -1048,11 +1045,6 @@ async function buildResponsesPayload(
     QA_EMPTY_RESPONSE_SIDE_EFFECT_RECOVERY_PROMPT_RE.test(prompt) ||
     (prompt.includes(QA_SETTLED_TOOL_TERMINAL_CONTINUATION_NEEDLE) &&
       QA_EMPTY_RESPONSE_SIDE_EFFECT_RECOVERY_PROMPT_RE.test(allInputText));
-  const isCodeModeReconciliation = QA_CODE_MODE_RECONCILIATION_PROMPT_RE.test(prompt);
-  const isActiveFailedToolTerminalRecovery =
-    QA_FAILED_TOOL_TERMINAL_RECOVERY_PROMPT_RE.test(prompt) ||
-    ((prompt.includes(QA_SETTLED_TOOL_TERMINAL_CONTINUATION_NEEDLE) || isCodeModeReconciliation) &&
-      QA_FAILED_TOOL_TERMINAL_RECOVERY_PROMPT_RE.test(allInputText));
   const hasCallableCodeMode = hasCodeModeExecSurface(toolDeclarationBody);
   const canCallSessionsSpawn =
     hasToolDefinition(toolDeclarationBody, "sessions_spawn") || hasCallableCodeMode;
@@ -1385,24 +1377,15 @@ async function buildResponsesPayload(
     }
     return buildAssistantEvents("");
   }
-  if (isActiveFailedToolTerminalRecovery) {
-    if (
-      allInputText.includes(QA_SETTLED_TOOL_TERMINAL_CONTINUATION_NEEDLE) ||
-      isCodeModeReconciliation
-    ) {
-      if (
-        !isCodeModeReconciliation &&
-        !allInputText.includes("If a tool failed, say so; never claim completion or success.")
-      ) {
-        return buildAssistantEvents("FAILED-TOOL-HONESTY-INSTRUCTION-MISSING");
-      }
-      const marker = exactMarkerDirective ?? exactReplyDirective ?? "QA-FAILED-TOOL-FINALIZED-OK";
-      return buildAssistantEvents(`The requested file could not be read: ENOENT. ${marker}`);
-    }
+  if (QA_FAILED_TOOL_TERMINAL_RECOVERY_PROMPT_RE.test(prompt)) {
     if (!hasCompletedToolOutput) {
       return buildToolCallEventsWithArgs("read", { path: "qa-failed-terminal-missing-file.txt" });
     }
-    return buildAssistantEvents("FAILED-TOOL-TERMINAL-WAS-REPLAYED");
+    if (!hasToolErrorOutput(parseToolOutputJson(rawToolOutput), rawToolOutput)) {
+      return buildAssistantEvents("BUG-TOOL-DID-NOT-FAIL");
+    }
+    const marker = exactMarkerDirective ?? exactReplyDirective ?? "QA-FAILED-TOOL-FINALIZED-OK";
+    return buildAssistantEvents(`The requested file could not be read: ENOENT. ${marker}`);
   }
   const heartbeatReply = resolveHeartbeatPromptReply(prompt);
   if (heartbeatReply) {

--- a/qa/scenarios/channels/qa-channel-failed-tool-terminal-finalization.yaml
+++ b/qa/scenarios/channels/qa-channel-failed-tool-terminal-finalization.yaml
@@ -1,25 +1,23 @@
-title: QA channel final reply after a failed terminal tool
+title: QA channel final reply after a failed read
 
 scenario:
   id: qa-channel-failed-tool-terminal-finalization
   surface: channel
   coverage:
-    primary: [agent-runtime.failure-recovery-empty-response-recovery]
-    secondary: [channels.qa-channel-final-reply, agent-runtime.failure-recovery-retry-policy]
+    primary: [agent-runtime.failure-recovery-retry-policy]
+    secondary: [channels.qa-channel-final-reply]
   regressionRefs:
     - openclaw/openclaw#118274
   gatewayConfigPatch:
     tools:
       codeMode:
         enabled: true
-  objective: Verify a settled failed terminal tool receives one failure-honest, tool-free finalization and one channel reply.
+  objective: Verify a settled failed read receives one failure-honest ordinary continuation and one channel reply.
   successCriteria:
     - Code Mode dispatches exactly one missing-file read and records one failed exec result.
     - The failed tool call is never replayed or described as successful.
-    - The model receives one tools-disabled finalization and qa-channel delivers exactly one visible reply.
+    - The model receives one ordinary continuation with its failed result and qa-channel delivers exactly one visible reply.
   codeRefs:
-    - src/agents/embedded-agent-runner/run/incomplete-turn-resolution.ts
-    - src/agents/embedded-agent-runner/run/incomplete-turn-recovery.ts
     - src/agents/embedded-agent-runner/run/code-mode-outcome.ts
     - extensions/qa-lab/src/providers/mock-openai/server.ts
   execution:
@@ -28,19 +26,18 @@ scenario:
     isolationReason: Enables Code Mode and verifies one exact tool call and isolated qa-channel delivery.
     channel: qa-channel
     retryCount: 0
-    summary: Prove a real failed terminal Code Mode tool still produces one failure-honest qa-channel reply.
+    summary: Prove a real failed Code Mode read still produces one failure-honest qa-channel reply.
     config:
       requiredProviderMode: mock-openai
       channelId: qa-failed-terminal
       promptSnippet: Failed tool terminal recovery QA check
       retryNeedle: The previous assistant turn completed its tool calls but did not produce a user-visible answer.
-      failureHonestyNeedle: If a tool failed, say so; never claim completion or success.
       expectedMarker: QA-FAILED-TOOL-FINALIZED-OK
       expectedReply: "The requested file could not be read: ENOENT. QA-FAILED-TOOL-FINALIZED-OK"
 
 flow:
   steps:
-    - name: finalizes one failed Code Mode tool without replaying it
+    - name: reports one failed Code Mode read without replaying it
       actions:
         - assert:
             expr: "env.providerMode === config.requiredProviderMode"
@@ -88,30 +85,30 @@ flow:
         - set: readPlans
           value:
             expr: "scenarioRequests.filter((request) => request.plannedToolName === 'read')"
-        - set: finalizations
+        - set: continuations
           value:
-            expr: "scenarioRequests.filter((request) => String(request.allInputText ?? '').includes(config.retryNeedle))"
+            expr: "scenarioRequests.filter((request) => request.toolOutputCallId === readPlans[0]?.plannedToolCallId)"
         - assert:
             expr: "readPlans.length === 1 && readPlans[0].plannedWireToolName === 'exec'"
             message:
               expr: "`expected one Code Mode read plan, got ${JSON.stringify(readPlans)}`"
         - assert:
-            expr: "finalizations.length === 1 && String(finalizations[0].allInputText ?? '').includes(config.failureHonestyNeedle)"
+            expr: "scenarioRequests.length === 2 && continuations.length === 1 && !String(continuations[0].allInputText ?? '').includes(config.retryNeedle)"
             message:
-              expr: "`expected one failure-honest finalization, got ${JSON.stringify(finalizations)}`"
-        - set: replayedExecCalls
+              expr: "`expected one failure-honest continuation, got ${JSON.stringify(continuations)}`"
+        - set: readExecCalls
           value:
-            expr: "(Array.isArray(finalizations[0].body?.input) ? finalizations[0].body.input : []).filter((item) => item?.type === 'function_call' && item.name === 'exec' && String(item.arguments ?? '').includes('qa-failed-terminal-missing-file.txt'))"
+            expr: "(Array.isArray(continuations[0].body?.input) ? continuations[0].body.input : []).filter((item) => item?.type === 'function_call' && item.name === 'exec' && String(item.arguments ?? '').includes('qa-failed-terminal-missing-file.txt'))"
         - set: failedExecOutputs
           value:
-            expr: "(Array.isArray(finalizations[0].body?.input) ? finalizations[0].body.input : []).filter((item) => item?.type === 'function_call_output' && item.call_id === replayedExecCalls[0]?.call_id && /ENOENT|no such file/i.test(typeof item.output === 'string' ? item.output : JSON.stringify(item.output ?? '')))"
+            expr: "(Array.isArray(continuations[0].body?.input) ? continuations[0].body.input : []).filter((item) => item?.type === 'function_call_output' && item.call_id === readExecCalls[0]?.call_id && /ENOENT|no such file/i.test(typeof item.output === 'string' ? item.output : JSON.stringify(item.output ?? '')))"
         - assert:
-            expr: "replayedExecCalls.length === 1 && failedExecOutputs.length === 1 && finalizations[0].toolOutputCallId === replayedExecCalls[0].call_id"
+            expr: "readExecCalls.length === 1 && failedExecOutputs.length === 1 && continuations[0].toolOutputCallId === readExecCalls[0].call_id"
             message:
-              expr: "`finalization did not preserve the normalized parent exec/result pairing: calls=${JSON.stringify(replayedExecCalls.map((item) => item.call_id))} outputs=${JSON.stringify(failedExecOutputs.map((item) => item.call_id))}`"
+              expr: "`continuation did not preserve the normalized parent exec/result pairing: calls=${JSON.stringify(readExecCalls.map((item) => item.call_id))} outputs=${JSON.stringify(failedExecOutputs.map((item) => item.call_id))}`"
         - assert:
-            expr: "!Array.isArray(finalizations[0].body?.tools) || finalizations[0].body.tools.length === 0"
-            message: failed-tool finalization exposed a replayable model tool surface
+            expr: "['exec', 'wait'].every((name) => continuations[0].body?.tools?.some((tool) => tool.name === name))"
+            message: failed-read continuation lost its ordinary Code Mode tool surface
         - call: readSessionTranscriptSummary
           saveAs: transcript
           args:
@@ -123,9 +120,9 @@ flow:
               expr: "`expected exactly one settled failed exec result, got ${JSON.stringify(transcript)}`"
         - set: deliveries
           value:
-            expr: "state.getSnapshot().messages.filter((message) => message.direction === 'outbound' && message.conversation.id === config.channelId)"
+            expr: "state.getSnapshot().messages.filter((message) => message.direction === 'outbound' && !message.deleted && message.conversation.id === config.channelId)"
         - assert:
-            expr: "deliveries.length === 1 && reply.text.trim() === config.expectedReply"
+            expr: "deliveries.length === 1 && deliveries[0].text.trim() === config.expectedReply && reply.text.trim() === config.expectedReply"
             message:
               expr: "`expected exactly one failure-honest reply, got ${JSON.stringify(deliveries)}`"
-      detailsExpr: "`${reply.text}; calls=${String(transcript.assistantToolCallCounts.exec)} failed=${String(transcript.completedToolCallCounts.exec)} finalizations=${String(finalizations.length)}`"
+      detailsExpr: "`${reply.text}; calls=${String(transcript.assistantToolCallCounts.exec)} failed=${String(transcript.completedToolCallCounts.exec)} continuations=${String(continuations.length)}`"

--- a/qa/scenarios/channels/qa-channel-failed-tool-terminal-finalization.yaml
+++ b/qa/scenarios/channels/qa-channel-failed-tool-terminal-finalization.yaml
@@ -4,8 +4,8 @@ scenario:
   id: qa-channel-failed-tool-terminal-finalization
   surface: channel
   coverage:
-    primary: [agent-runtime.failure-recovery-retry-policy]
-    secondary: [channels.qa-channel-final-reply]
+    primary: [channels.qa-channel-final-reply]
+    secondary: [agent-runtime.failure-recovery-retry-policy]
   regressionRefs:
     - openclaw/openclaw#118274
   gatewayConfigPatch:

--- a/qa/scenarios/scheduling/cron-failed-tool-terminal-finalization.yaml
+++ b/qa/scenarios/scheduling/cron-failed-tool-terminal-finalization.yaml
@@ -4,8 +4,10 @@ scenario:
   id: cron-failed-tool-terminal-finalization
   surface: cron
   coverage:
-    primary: [agent-runtime.failure-recovery-retry-policy]
-    secondary: [automation.isolated-cron-execution, channels.qa-channel-final-reply]
+    primary: [automation.isolated-cron-execution]
+    secondary:
+      - agent-runtime.failure-recovery-retry-policy
+      - channels.qa-channel-final-reply
   regressionRefs:
     - openclaw/openclaw#118274
   gatewayConfigPatch:

--- a/qa/scenarios/scheduling/cron-failed-tool-terminal-finalization.yaml
+++ b/qa/scenarios/scheduling/cron-failed-tool-terminal-finalization.yaml
@@ -1,10 +1,10 @@
-title: Cron final reply after a failed terminal tool
+title: Cron final reply after a failed read
 
 scenario:
   id: cron-failed-tool-terminal-finalization
   surface: cron
   coverage:
-    primary: [agent-runtime.failure-recovery-empty-response-recovery]
+    primary: [agent-runtime.failure-recovery-retry-policy]
     secondary: [automation.isolated-cron-execution, channels.qa-channel-final-reply]
   regressionRefs:
     - openclaw/openclaw#118274
@@ -12,15 +12,14 @@ scenario:
     tools:
       codeMode:
         enabled: true
-  objective: Verify an isolated announce cron finalizes one failed terminal tool honestly and delivers one visible reply.
+  objective: Verify an isolated announce cron reports one failed read honestly and delivers one visible reply.
   successCriteria:
     - The isolated cron run completes successfully after one failed Code Mode exec.
-    - One failure-honest finalization observes the exact failed call and exposes no tools.
+    - One failure-honest ordinary continuation observes the exact failed call.
     - The failed tool never replays and qa-channel receives exactly one final reply.
   codeRefs:
     - src/cron/isolated-agent/run-executor.ts
-    - src/agents/embedded-agent-runner/run/incomplete-turn-resolution.ts
-    - src/agents/embedded-agent-runner/run/incomplete-turn-recovery.ts
+    - src/agents/embedded-agent-runner/run/code-mode-outcome.ts
     - extensions/qa-lab/src/providers/mock-openai/server.ts
   execution:
     kind: flow
@@ -28,19 +27,18 @@ scenario:
     isolationReason: Enables Code Mode and forces an isolated cron with exact delivery assertions.
     channel: qa-channel
     retryCount: 0
-    summary: Prove a real failed terminal Code Mode tool still produces one visible cron announcement.
+    summary: Prove a real failed Code Mode read still produces one visible cron announcement.
     config:
       requiredProviderMode: mock-openai
       channelId: qa-failed-cron
       promptSnippet: Failed tool terminal recovery QA check
       retryNeedle: The previous assistant turn completed its tool calls but did not produce a user-visible answer.
-      failureHonestyNeedle: If a tool failed, say so; never claim completion or success.
       expectedMarker: CRON-FAILED-TOOL-FINALIZED-OK
       expectedReply: "The requested file could not be read: ENOENT. CRON-FAILED-TOOL-FINALIZED-OK"
 
 flow:
   steps:
-    - name: forces an isolated cron containing one terminal tool failure
+    - name: forces an isolated cron containing one failed read
       actions:
         - assert:
             expr: "env.providerMode === config.requiredProviderMode"
@@ -102,7 +100,7 @@ flow:
             message:
               expr: "`expected one forced cron run, got ${JSON.stringify(runResponse)}`"
 
-    - name: proves one failed call, one honest finalization, and one delivery
+    - name: proves one failed call, one honest continuation, and one delivery
       actions:
         - call: waitForCronRunCompletion
           saveAs: completedRun
@@ -129,30 +127,30 @@ flow:
         - set: readPlans
           value:
             expr: "scenarioRequests.filter((request) => request.plannedToolName === 'read')"
-        - set: finalizations
+        - set: continuations
           value:
-            expr: "scenarioRequests.filter((request) => String(request.allInputText ?? '').includes(config.retryNeedle))"
+            expr: "scenarioRequests.filter((request) => request.toolOutputCallId === readPlans[0]?.plannedToolCallId)"
         - assert:
             expr: "readPlans.length === 1 && readPlans[0].plannedWireToolName === 'exec'"
             message:
               expr: "`expected one Code Mode read plan, got ${JSON.stringify(readPlans)}`"
         - assert:
-            expr: "finalizations.length === 1 && String(finalizations[0].allInputText ?? '').includes(config.failureHonestyNeedle)"
+            expr: "scenarioRequests.length === 2 && continuations.length === 1 && !String(continuations[0].allInputText ?? '').includes(config.retryNeedle)"
             message:
-              expr: "`expected one failure-honest cron finalization, got ${JSON.stringify(finalizations)}`"
-        - set: replayedExecCalls
+              expr: "`expected one failure-honest cron continuation, got ${JSON.stringify(continuations)}`"
+        - set: readExecCalls
           value:
-            expr: "(Array.isArray(finalizations[0].body?.input) ? finalizations[0].body.input : []).filter((item) => item?.type === 'function_call' && item.name === 'exec' && String(item.arguments ?? '').includes('qa-failed-terminal-missing-file.txt'))"
+            expr: "(Array.isArray(continuations[0].body?.input) ? continuations[0].body.input : []).filter((item) => item?.type === 'function_call' && item.name === 'exec' && String(item.arguments ?? '').includes('qa-failed-terminal-missing-file.txt'))"
         - set: failedExecOutputs
           value:
-            expr: "(Array.isArray(finalizations[0].body?.input) ? finalizations[0].body.input : []).filter((item) => item?.type === 'function_call_output' && item.call_id === replayedExecCalls[0]?.call_id && /ENOENT|no such file/i.test(typeof item.output === 'string' ? item.output : JSON.stringify(item.output ?? '')))"
+            expr: "(Array.isArray(continuations[0].body?.input) ? continuations[0].body.input : []).filter((item) => item?.type === 'function_call_output' && item.call_id === readExecCalls[0]?.call_id && /ENOENT|no such file/i.test(typeof item.output === 'string' ? item.output : JSON.stringify(item.output ?? '')))"
         - assert:
-            expr: "replayedExecCalls.length === 1 && failedExecOutputs.length === 1 && finalizations[0].toolOutputCallId === replayedExecCalls[0].call_id"
+            expr: "readExecCalls.length === 1 && failedExecOutputs.length === 1 && continuations[0].toolOutputCallId === readExecCalls[0].call_id"
             message:
-              expr: "`cron finalization did not preserve the normalized parent exec/result pairing: calls=${JSON.stringify(replayedExecCalls.map((item) => item.call_id))} outputs=${JSON.stringify(failedExecOutputs.map((item) => item.call_id))}`"
+              expr: "`cron continuation did not preserve the normalized parent exec/result pairing: calls=${JSON.stringify(readExecCalls.map((item) => item.call_id))} outputs=${JSON.stringify(failedExecOutputs.map((item) => item.call_id))}`"
         - assert:
-            expr: "!Array.isArray(finalizations[0].body?.tools) || finalizations[0].body.tools.length === 0"
-            message: cron finalization exposed a replayable model tool surface
+            expr: "['exec', 'wait'].every((name) => continuations[0].body?.tools?.some((tool) => tool.name === name))"
+            message: cron failed-read continuation lost its ordinary Code Mode tool surface
         - call: readSessionTranscriptSummary
           saveAs: transcript
           args:
@@ -166,11 +164,11 @@ flow:
           saveAs: deliveries
           args:
             - lambda:
-                expr: "(() => { const matches = state.getSnapshot().messages.filter((message) => message.direction === 'outbound' && message.conversation.id === config.channelId); return matches.length > 0 ? matches : undefined; })()"
+                expr: "(() => { const matches = state.getSnapshot().messages.filter((message) => message.direction === 'outbound' && !message.deleted && message.conversation.id === config.channelId); return matches.length > 0 ? matches : undefined; })()"
             - 10000
             - 100
         - assert:
             expr: "deliveries.length === 1 && deliveries[0].text.trim() === config.expectedReply"
             message:
               expr: "`expected exactly one failure-honest cron announcement, got ${JSON.stringify(deliveries)}`"
-      detailsExpr: "`${deliveries[0].text}; calls=${String(transcript.assistantToolCallCounts.exec)} failed=${String(transcript.completedToolCallCounts.exec)} finalizations=${String(finalizations.length)}`"
+      detailsExpr: "`${deliveries[0].text}; calls=${String(transcript.assistantToolCallCounts.exec)} failed=${String(transcript.completedToolCallCounts.exec)} continuations=${String(continuations.length)}`"

--- a/src/gateway/sessions-history-http.test.ts
+++ b/src/gateway/sessions-history-http.test.ts
@@ -729,7 +729,12 @@ describe("session history HTTP endpoints", () => {
         storePath,
         input: {
           idempotencyKey: `session-history-profile:${id}`,
-          sender: { id: profile.id, name: senderName, username: "ada" },
+          sender: {
+            id: profile.id,
+            identity: { type: "profile", id: profile.id },
+            name: senderName,
+            username: "ada",
+          },
           text,
         },
       });

--- a/test/e2e/qa-lab/runtime/otel-gateway-runtime.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/otel-gateway-runtime.e2e.test.ts
@@ -42,7 +42,7 @@ async function waitFor<T>(
     }
     await sleep(100);
   }
-  const context = timeoutContext?.();
+  const context = await timeoutContext?.();
   throw new Error(
     `timed out waiting for QA runtime evidence${
       context === undefined ? "" : `: ${JSON.stringify(context)}`
@@ -65,7 +65,7 @@ function expectResolvedParent(
 }
 
 describe("diagnostics-otel gateway runtime", () => {
-  test("exports linked success and failed-tool recovery spans from a real qa-channel run", async () => {
+  test("exports linked success and failed-read recovery spans from a real qa-channel run", async () => {
     const repoRoot = path.resolve(import.meta.dirname, "../../../..");
     const state = createQaBusState();
     const transport = {
@@ -100,7 +100,7 @@ describe("diagnostics-otel gateway runtime", () => {
       const activeReceiver = await startOtlpReceiver(["qa-plugin-usage-secret-sentinel"]);
       receiver = activeReceiver;
       mock = await startQaMockOpenAiServer();
-      await gatewayOwner.start({
+      const gateway = await gatewayOwner.start({
         repoRoot,
         useRepoCli: true,
         providerBaseUrl: `${mock.baseUrl}/v1`,
@@ -152,16 +152,62 @@ describe("diagnostics-otel gateway runtime", () => {
           senderName: "QA User",
           text,
         });
-        return await waitFor(() =>
-          state
-            .getSnapshot()
-            .messages.slice(cursor)
-            .find(
-              (message) =>
-                message.direction === "outbound" &&
-                message.conversation.id === targetConversation.id &&
-                message.text.includes(expectedText),
-            ),
+        return await waitFor(
+          () =>
+            state
+              .getSnapshot()
+              .messages.slice(cursor)
+              .find(
+                (message) =>
+                  message.direction === "outbound" &&
+                  message.conversation.id === targetConversation.id &&
+                  message.text.includes(expectedText),
+              ),
+          30_000,
+          async () => {
+            let requests: unknown;
+            try {
+              const response = await fetch(`${mock!.baseUrl}/debug/requests`, {
+                signal: AbortSignal.timeout(2_000),
+              });
+              const captured = (await response.json()) as Array<Record<string, unknown>>;
+              requests = captured.slice(-8).map((request) => ({
+                cursor: request.cursor,
+                requestKind: request.requestKind,
+                outcome: request.outcome,
+                errorCode: request.errorCode,
+                plannedToolName: request.plannedToolName,
+                plannedWireToolName: request.plannedWireToolName,
+                toolOutputCallId: request.toolOutputCallId,
+                toolOutputStructuredError: request.toolOutputStructuredError,
+                toolOutputLength:
+                  typeof request.toolOutput === "string" ? request.toolOutput.length : undefined,
+                reconciliation: String(request.allInputText ?? "").includes(
+                  CODE_MODE_RECONCILIATION_NEEDLE,
+                ),
+              }));
+            } catch {
+              requests = { unavailable: true };
+            }
+            return {
+              expectedText,
+              targetConversation,
+              messages: state
+                .getSnapshot()
+                .messages.slice(cursor)
+                .slice(-8)
+                .map((message) => ({
+                  id: message.id,
+                  direction: message.direction,
+                  conversation: message.conversation,
+                  isError: message.isError,
+                  deleted: message.deleted,
+                  text: message.text.slice(0, 2_000),
+                })),
+              requests,
+              gatewayLogs: gateway.logs().slice(-12_000),
+            };
+          },
         );
       };
 
@@ -192,33 +238,28 @@ describe("diagnostics-otel gateway runtime", () => {
         plannedToolName?: string;
         plannedWireToolName?: string;
         toolOutputCallId?: string;
+        toolOutput?: string;
       }>;
       const readPlans = scenarioRequests.filter((request) => request.plannedToolName === "read");
-      const finalizations = scenarioRequests.filter((request) =>
-        [
-          "The previous assistant turn completed its tool calls but did not produce a user-visible answer.",
-          CODE_MODE_RECONCILIATION_NEEDLE,
-        ].some((needle) => (request.allInputText ?? "").includes(needle)),
-      );
       expect(readPlans).toHaveLength(1);
       expect(readPlans[0]?.plannedToolCallId).toBeTruthy();
       expect(readPlans[0]?.plannedWireToolName).toBe("exec");
-      expect(finalizations).toHaveLength(1);
-      expect(finalizations[0]?.allInputText).toContain(CODE_MODE_RECONCILIATION_NEEDLE);
-      expect(finalizations[0]?.allInputText).toContain("report exactly what applied");
-      expect(finalizations[0]?.body?.tools?.map((tool) => tool.name)).toEqual(["read"]);
-      const finalizationInput = finalizations[0]?.body?.input ?? [];
-      // The failed exec belongs to the host-owned Code Mode surface, so it must not be replayed
-      // into the model transcript; the following OTel assertion carries its failure evidence.
-      expect(
-        finalizationInput.filter(
-          (item) => item.type === "function_call" || item.type === "function_call_output",
-        ),
-      ).toEqual([]);
-      expect(finalizations[0]?.toolOutputCallId).toBeUndefined();
-      expect(scenarioRequests.indexOf(finalizations[0]!)).toBe(
-        scenarioRequests.indexOf(readPlans[0]!) + 1,
+      expect(scenarioRequests).toHaveLength(2);
+      const continuation = scenarioRequests[1]!;
+      expect(continuation.toolOutputCallId).toBe(readPlans[0]?.plannedToolCallId);
+      expect(continuation.toolOutput).toMatch(/ENOENT|no such file/i);
+      expect(continuation.allInputText).not.toContain(CODE_MODE_RECONCILIATION_NEEDLE);
+      expect(continuation.body?.tools?.map((tool) => tool.name)).toEqual(
+        expect.arrayContaining(["exec", "wait"]),
       );
+      const continuationInput = continuation.body?.input ?? [];
+      for (const type of ["function_call", "function_call_output"]) {
+        expect(
+          continuationInput.filter(
+            (item) => item.type === type && item.call_id === readPlans[0]?.plannedToolCallId,
+          ),
+        ).toHaveLength(1);
+      }
       const failureEvidence = await waitFor(
         () => {
           const toolError = activeReceiver.capturedSpans.find(
@@ -245,7 +286,7 @@ describe("diagnostics-otel gateway runtime", () => {
               span.attributes["openclaw.channel"] === "qa-channel" &&
               span.attributes["openclaw.outcome"] === "completed",
           );
-          return runs.length >= 2 && harnesses.length >= 2 && modelCalls.length >= 2 && terminal
+          return runs.length >= 1 && harnesses.length >= 1 && modelCalls.length >= 2 && terminal
             ? { harnesses, modelCalls, runs, sameTrace, terminal, toolError }
             : undefined;
         },
@@ -256,6 +297,9 @@ describe("diagnostics-otel gateway runtime", () => {
         }),
       );
 
+      expect(failureEvidence.runs).toHaveLength(1);
+      expect(failureEvidence.harnesses).toHaveLength(1);
+      expect(failureEvidence.modelCalls).toHaveLength(2);
       const failureSpansById = indexSpansById(failureEvidence.sameTrace);
       expect(failureEvidence.terminal.parentSpanId).toBeFalsy();
       for (const harness of failureEvidence.harnesses) {


### PR DESCRIPTION
The full release repo E2E lane exposed two stale fixtures. Session history supplied a bare profile ID after profile avatars began requiring a qualified profile identity. The failed-read mock incorrectly demanded restricted terminal recovery, so a normal continuation emitted a bogus replay marker and the OTel test timed out waiting for an answer.

This changes the fixture producer and its channel, cron, and OTel consumers. The mock returns an honest ENOENT answer only after observing a failed tool result. Both flows still require exactly one failed read, one correlated exec/result pair, one ordinary continuation, and one visible final reply. Deleted channel previews are excluded from visible delivery counts, matching `extensions/qa-lab/src/bus-waiters.ts:47`. The profile fixture supplies its existing profile identity; avatar assertions are unchanged. OTel timeouts now include bounded request, bus, and redacted gateway evidence without changing the wait threshold.

The recovery contract belongs to `src/agents/tool-effect-receipt.ts:19` and `src/agents/embedded-agent-runner/run/code-mode-outcome.ts:58`: an exact host-owned `failed_no_effect` receipt permits ordinary continuation with the `exec`/`wait` tools still available. This is not replay authorization. Uncertain or partially applied mutations still enter restricted reconciliation; the unchanged negative controls in `src/agents/code-mode.agent-loop.test.ts:537`, `:595`, and `:619` cover side-effecting plugins, earlier effects, and partially applied mutations. See also [Code Mode recovery](https://docs.openclaw.ai/tools/code-mode).

Validation: the profile fixture failed before its identity correction, then all 139 history, projection, and transcript siblings passed. The mock regression failed before the oracle correction, then all 274 mock-provider tests and 21 real agent-loop recovery tests passed. On a fresh Linux Testbox, the real OTel gateway test passed, and both QA channel and cron scenarios passed with one failed call, one continuation, and one final delivery. The channel run first exposed a deleted preview plus one retained final; the final run asserts the retained reply's exact text. No scenario is skipped and no retry or larger timeout was added. The full fresh-dependency `check:changed` gate also passed (all types, lint, guards, and import cycles; 22m31s). Autoreview reported no actionable findings.

Linux proof: [Testbox job](https://github.com/openclaw/openclaw/actions/runs/33238628032), synthetic source `056493764763388e6856a5ac7e6576c2285775d2` over base `9db3ceffbb329d769565c4e09ee8ad8e31a10c7f`. The workflow seed is not the runtime source identity. The OTel run built synthetic `c90599767003812cfb29c4dc391fbd88face5eda`. The final YAML-only replay used that unchanged built runtime through `node openclaw.mjs`. The lease is intentionally stopped after evidence collection, so its enclosing Actions lifecycle may show cancellation.

Scope: six files; core product code unchanged. The private QA mock removes 17 net lines. Tests/scenario definitions change by +25 net lines. No changelog for internal test infrastructure. The separate assistant MEDIA publication defect remains a separate repair and is not hidden by this change.


Fresh CI caught an incorrect primary coverage claim in the first version of this patch. The catalog reserves retry-policy primary ownership for the empty-response recovery scenario. These two flows now claim their asserted product boundaries as primary: QA channel final delivery and isolated cron execution; retry policy remains supporting coverage. The existing canonical-owner assertion is unchanged. All 66 catalog, profile-selection, and profile-evidence tests pass. Actual planner arrays match the original base exactly: release 403, all 506, smoke 26, full mock suite 138, both explicit scenarios, and the separate 12-scenario release agentic pack. The two flow bodies are byte-identical to the Linux-tested version. No gate scenario was removed.
