### PR TITLE
fix: prevent first Grok tool requests from stalling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,8 @@ Docs: https://docs.openclaw.ai
 
 - Gateway/subagents: keep plugin completion turns bound to the owning Gateway runtime so successful native subagents can finish delivery without losing the published reply runtime.
 
+- **xAI startup:** keep voice capability metadata and plugin-version reads off the full agent runtime import path so the first Grok request does not stall during provider loading.
+
 - **Control UI tool progress:** keep error-shaped partial output running until the tool returns its result, with consistent status in collapsed rows, expanded cards, and side-panel details.
 
 - MCP Apps: let standalone operations finish across catalog refreshes within per-request server budgets, propagate App cancellation without cancelling shared catalog work, and reload restored history views without replaying interrupted operations. Thanks @tzy-17. (#119388)

--- a/extensions/xai/lazy-capability-providers.test.ts
+++ b/extensions/xai/lazy-capability-providers.test.ts
@@ -5,6 +5,10 @@ import type {
 } from "openclaw/plugin-sdk/realtime-voice";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+vi.mock("openclaw/plugin-sdk/agent-runtime", () => {
+  throw new Error("Lazy capability metadata must not load the broad agent runtime");
+});
+
 const runtimeMocks = vi.hoisted(() => {
   const generateImage = vi.fn();
   const transcribeAudio = vi.fn();

--- a/extensions/xai/realtime-voice-config.ts
+++ b/extensions/xai/realtime-voice-config.ts
@@ -1,4 +1,4 @@
-import { resolveAgentDir } from "openclaw/plugin-sdk/agent-runtime";
+import { resolveAgentDir } from "openclaw/plugin-sdk/agent-scope-runtime";
 import {
   isProviderAuthProfileConfigured,
   type OpenClawConfig,

--- a/src/plugins/loader-module-runtime.ts
+++ b/src/plugins/loader-module-runtime.ts
@@ -1,5 +1,6 @@
 import { isPromiseLike } from "@openclaw/normalization-core/promise-like";
 import { toSafeImportPath } from "../shared/import-specifier.js";
+import { VERSION } from "../version.js";
 import { attachPluginApiFacades } from "./api-facades.js";
 import { isLateCallablePluginApiMethod } from "./api-lifecycle.js";
 import { unwrapDefaultModuleExport } from "./module-export.js";
@@ -200,8 +201,9 @@ export function createLazyPluginRuntime(params: {
     return resolvedRuntime;
   };
   const getRuntimeProperty = (prop: PropertyKey, ...receiver: [] | [unknown]): unknown => {
-    if (prop === "state" && !resolvedRuntime) {
-      return state;
+    // Reading prepared metadata must not initialize runtime services.
+    if (!resolvedRuntime && (prop === "state" || prop === "version")) {
+      return prop === "state" ? state : VERSION;
     }
     return receiver.length === 0
       ? Reflect.get(resolveRuntime(), prop)

--- a/src/plugins/loader.runtime-registry.test.ts
+++ b/src/plugins/loader.runtime-registry.test.ts
@@ -8,6 +8,7 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { PluginInstallRecord } from "../config/types.plugins.js";
 import { resetPluginStateStoreForTests } from "../plugin-state/plugin-state-store.js";
 import { withEnvAsync } from "../test-utils/env.js";
+import { VERSION } from "../version.js";
 import { setCurrentPluginMetadataSnapshot } from "./current-plugin-metadata.test-support.js";
 import {
   getRegisteredEmbeddingProvider,
@@ -197,7 +198,7 @@ it("keeps an empty scoped handle load from replacing the root registry", () => {
   expect(getActivePluginRegistry()).toBe(root);
 });
 
-it("keeps injected instance runtime surfaces independent of the broad runtime module", () => {
+it("keeps version and injected instance surfaces independent of the broad runtime module", () => {
   const gateway = {} as PluginRuntime["gateway"];
   const nodes = {} as PluginRuntime["nodes"];
   const subagent = {} as PluginRuntime["subagent"];
@@ -209,6 +210,8 @@ it("keeps injected instance runtime surfaces independent of the broad runtime mo
     runtimeOptions: { gateway, nodes, subagent },
   });
 
+  expect(runtime.version).toBe(VERSION);
+  expect(Object.getOwnPropertyDescriptor(runtime, "version")?.get?.()).toBe(VERSION);
   expect(runtime.gateway).toBe(gateway);
   expect(runtime.nodes).toBe(nodes);
   expect(runtime.subagent).toBe(subagent);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the first Grok tool request stalls during provider startup and fails the release verification test's existing 90-second deadline, before the API request is sent.

## Why This Change Was Made

Two metadata reads eagerly loaded the full agent runtime. xAI voice configuration now resolves agent directories through the existing focused SDK entrypoint, as the OpenAI voice provider already does. The lazy plugin runtime returns the same shared version constant without initializing runtime services; after materialization, its existing property and reflection behavior remains unchanged.

Both fixes are necessary: changing only the xAI import reduced discovery time but moved the remaining delay into the version lookup. There are no dependency patches, new caches, provider warmups, configuration changes, retries, timeout changes, or weakened assertions. Production code grows by two lines, including the ownership comment; tests grow by seven lines.

## User Impact

The measured first Grok tool case drops from 176 seconds to 39 seconds and passes. Provider discovery still takes about 36 seconds in the measured source-based test environment; this does not make startup instantaneous.

## Evidence

The original `src/agents/xai.live.test.ts` passes all six real-provider cases in their original order, with the original timeouts and payload/tool assertions. The first Grok 4.3 tool case takes 39.4 seconds and the warmed Grok 4.5 case takes 3.1 seconds. The whole file takes 109.1 seconds, including live web search.

Proof ran through the canonical authenticated [Testbox workflow](https://github.com/openclaw/openclaw/actions/runs/33238429104). Its command completed with exit 0; the owned lease was then stopped. The exact proof snapshot was `b4423e230170ffcdc7ac253d654c9f859c803072`, parent `769192c5f010b600916cbd84ac662559575777cc`, with this five-file patch.

- Both regression additions failed on their respective pre-fix owner paths.
- 130 xAI lazy-capability, realtime-voice, and stream tests passed; 41 shared plugin runtime tests passed.
- Required changed-file gate passed, including core/core-test/plugin/plugin-test typechecks, lint, and ownership guards.
- Full build passed; the isolated built xAI entrypoint profile passed at 351.7 MB peak RSS.
- Mandatory independent Codex review found no actionable blocking findings.

Follow-up: pinned Jiti source resolution still amplifies large import graphs by capturing unbounded stacks for expected resolution misses. This repair removes the unnecessary graphs; it does not patch or override that dependency.
