### PR TITLE
test: clear the two lint breaks current main hands to every PR

### DIFF
--- a/src/infra/state-migrations.media-persistence.fixture.ts
+++ b/src/infra/state-migrations.media-persistence.fixture.ts
@@ -1,0 +1,192 @@
+// Shared database and archive fixtures for the legacy media persistence
+// migration tests. Extracted so the test file stays under the max-lines
+// boundary; both files live in the same lint/test lane.
+import fs from "node:fs";
+import path from "node:path";
+import {
+  encodeSessionArchiveContent,
+  SESSION_ARCHIVE_ZSTD_SUFFIX,
+} from "../config/sessions/archive-compression.js";
+import { reconcileSessionTranscriptIndexInTransaction } from "../config/sessions/session-transcript-index.js";
+import { registerOpenClawAgentDatabase } from "../state/openclaw-agent-db-registry.js";
+import {
+  closeOpenClawAgentDatabasesForTest,
+  OPENCLAW_AGENT_SCHEMA_VERSION,
+  openOpenClawAgentDatabase,
+} from "../state/openclaw-agent-db.js";
+import { requireNodeSqlite } from "./node-sqlite.js";
+
+export const tempDirs: string[] = [];
+export const PREVIOUS_VERSION = 16;
+
+export type FixtureEvent = Record<string, unknown>;
+
+export function createEvent(params: {
+  id: string;
+  message: Record<string, unknown>;
+  parentId: string | null;
+  timestamp: number;
+}): FixtureEvent {
+  return {
+    type: "message",
+    id: params.id,
+    parentId: params.parentId,
+    timestamp: params.timestamp,
+    message: params.message,
+  };
+}
+
+export function createLegacyDatabaseFixture(params: {
+  agentId?: string;
+  env: NodeJS.ProcessEnv;
+  eventsBySession: Record<string, FixtureEvent[]>;
+  schemaVersion?: number;
+}): string {
+  const agentId = params.agentId ?? "main";
+  const schemaVersion = params.schemaVersion ?? PREVIOUS_VERSION;
+  const opened = openOpenClawAgentDatabase({ agentId, env: params.env });
+  const databasePath = opened.path;
+  closeOpenClawAgentDatabasesForTest();
+  const { DatabaseSync } = requireNodeSqlite();
+  const database = new DatabaseSync(databasePath);
+  try {
+    database.exec("PRAGMA foreign_keys = ON;");
+    if (schemaVersion < OPENCLAW_AGENT_SCHEMA_VERSION) {
+      database.exec("DROP TABLE session_participants;");
+    }
+    database.exec(`PRAGMA user_version = ${schemaVersion};`);
+    database
+      .prepare(
+        "UPDATE schema_meta SET schema_version = ?, app_version = ? WHERE meta_key = 'primary'",
+      )
+      .run(schemaVersion, "legacy-test");
+    for (const [sessionId, events] of Object.entries(params.eventsBySession)) {
+      const sessionKey = `agent:${agentId}:${sessionId}`;
+      const firstTimestamp = Number(events[0]?.timestamp ?? 1);
+      database
+        .prepare(
+          "INSERT INTO session_nodes(session_key,current_session_id,entry_json,updated_at) VALUES(?,?,?,?)",
+        )
+        .run(sessionKey, sessionId, "{}", firstTimestamp);
+      database
+        .prepare(
+          "INSERT INTO session_windows(session_id,session_key,created_at,updated_at) VALUES(?,?,?,?)",
+        )
+        .run(sessionId, sessionKey, firstTimestamp, firstTimestamp);
+      database
+        .prepare(
+          "INSERT INTO transcript_rewrite_watermarks(session_id,generation,updated_at) VALUES(?,?,?)",
+        )
+        .run(sessionId, `generation-${sessionId}`, firstTimestamp);
+      events.forEach((event, seq) => {
+        const createdAt = Number(event.timestamp ?? firstTimestamp) + 100;
+        database
+          .prepare(
+            "INSERT INTO transcript_events(session_id,seq,event_json,created_at) VALUES(?,?,?,?)",
+          )
+          .run(sessionId, seq, JSON.stringify(event), createdAt);
+        database
+          .prepare(
+            "INSERT INTO transcript_event_identities(session_id,event_id,seq,event_type,parent_id,message_idempotency_key,created_at) VALUES(?,?,?,?,?,?,?)",
+          )
+          .run(
+            sessionId,
+            String(event.id),
+            seq,
+            String(event.type),
+            typeof event.parentId === "string" ? event.parentId : null,
+            (event.message as { idempotencyKey?: string }).idempotencyKey ?? null,
+            createdAt,
+          );
+      });
+      reconcileSessionTranscriptIndexInTransaction(database, sessionId);
+    }
+  } finally {
+    database.close();
+  }
+  registerOpenClawAgentDatabase({
+    agentId,
+    env: params.env,
+    path: databasePath,
+    schemaVersion,
+  });
+  return databasePath;
+}
+
+export function readDatabaseSnapshot(databasePath: string) {
+  const { DatabaseSync } = requireNodeSqlite();
+  const database = new DatabaseSync(databasePath);
+  try {
+    const version = database.prepare("PRAGMA user_version").get() as { user_version: number };
+    const rows = database
+      .prepare(
+        "SELECT session_id,seq,event_json,created_at FROM transcript_events ORDER BY session_id,seq",
+      )
+      .all() as Array<{
+      session_id: string;
+      seq: number;
+      event_json: string;
+      created_at: number;
+    }>;
+    const identities = database
+      .prepare(
+        "SELECT session_id,event_id,seq,event_type,parent_id,message_idempotency_key,created_at FROM transcript_event_identities ORDER BY session_id,seq",
+      )
+      .all();
+    const activeBranch = database
+      .prepare(
+        "SELECT session_id,active_position,event_seq,message_position FROM session_transcript_active_events ORDER BY session_id,active_position",
+      )
+      .all();
+    const windows = database
+      .prepare(
+        "SELECT session_id,session_key,created_at,updated_at,transcript_observed_at FROM session_windows ORDER BY session_id",
+      )
+      .all();
+    const generations = database
+      .prepare(
+        "SELECT session_id,generation FROM transcript_rewrite_watermarks ORDER BY session_id",
+      )
+      .all();
+    const trajectoryCount = database
+      .prepare("SELECT count(*) AS count FROM trajectory_runtime_events")
+      .get() as { count: number };
+    const trajectoryRows = database
+      .prepare(
+        "SELECT session_id,seq,run_id,event_json,created_at FROM trajectory_runtime_events ORDER BY session_id,seq",
+      )
+      .all() as Array<{
+      session_id: string;
+      seq: number;
+      run_id: string | null;
+      event_json: string;
+      created_at: number;
+    }>;
+    return {
+      activeBranch,
+      generations,
+      identities,
+      rows,
+      trajectoryCount: trajectoryCount.count,
+      trajectoryRows,
+      version,
+      windows,
+    };
+  } finally {
+    database.close();
+  }
+}
+
+export function writeArchive(filePath: string, events: FixtureEvent[], compressed: boolean): void {
+  const content = `${events.map((event) => JSON.stringify(event)).join("\n")}\n`;
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  if (!compressed) {
+    fs.writeFileSync(filePath, content);
+    return;
+  }
+  const encoded = encodeSessionArchiveContent(content);
+  if (encoded.suffix !== SESSION_ARCHIVE_ZSTD_SUFFIX) {
+    throw new Error("test runtime does not support zstd");
+  }
+  fs.writeFileSync(filePath, encoded.bytes);
+}

--- a/src/infra/state-migrations.media-persistence.test.ts
+++ b/src/infra/state-migrations.media-persistence.test.ts
@@ -3,198 +3,29 @@ import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { cleanupTempDirs, makeTempDir } from "../../test/helpers/temp-dir.js";
 import {
-  encodeSessionArchiveContent,
   readSessionArchiveContentSync,
   SESSION_ARCHIVE_ZSTD_SUFFIX,
 } from "../config/sessions/archive-compression.js";
 import { appendTranscriptEventInTransaction } from "../config/sessions/session-accessor.sqlite-transcript-store.js";
-import { reconcileSessionTranscriptIndexInTransaction } from "../config/sessions/session-transcript-index.js";
-import { registerOpenClawAgentDatabase } from "../state/openclaw-agent-db-registry.js";
+import { listOpenClawRegisteredAgentDatabases } from "../state/openclaw-agent-db-registry.js";
 import {
   closeOpenClawAgentDatabasesForTest,
-  listOpenClawRegisteredAgentDatabases,
   OPENCLAW_AGENT_SCHEMA_VERSION,
   openOpenClawAgentDatabase,
   runOpenClawAgentWriteTransaction,
 } from "../state/openclaw-agent-db.js";
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
 import { requireNodeSqlite } from "./node-sqlite.js";
+import {
+  createEvent,
+  createLegacyDatabaseFixture,
+  PREVIOUS_VERSION,
+  readDatabaseSnapshot,
+  tempDirs,
+  writeArchive,
+  type FixtureEvent,
+} from "./state-migrations.media-persistence.fixture.js";
 import { migrateLegacyMediaPersistence } from "./state-migrations.media-persistence.js";
-
-const tempDirs: string[] = [];
-const PREVIOUS_VERSION = 16;
-
-type FixtureEvent = Record<string, unknown>;
-
-function createEvent(params: {
-  id: string;
-  message: Record<string, unknown>;
-  parentId: string | null;
-  timestamp: number;
-}): FixtureEvent {
-  return {
-    type: "message",
-    id: params.id,
-    parentId: params.parentId,
-    timestamp: params.timestamp,
-    message: params.message,
-  };
-}
-
-function createLegacyDatabaseFixture(params: {
-  agentId?: string;
-  env: NodeJS.ProcessEnv;
-  eventsBySession: Record<string, FixtureEvent[]>;
-  schemaVersion?: number;
-}): string {
-  const agentId = params.agentId ?? "main";
-  const schemaVersion = params.schemaVersion ?? PREVIOUS_VERSION;
-  const opened = openOpenClawAgentDatabase({ agentId, env: params.env });
-  const databasePath = opened.path;
-  closeOpenClawAgentDatabasesForTest();
-  const { DatabaseSync } = requireNodeSqlite();
-  const database = new DatabaseSync(databasePath);
-  try {
-    database.exec("PRAGMA foreign_keys = ON;");
-    if (schemaVersion < OPENCLAW_AGENT_SCHEMA_VERSION) {
-      database.exec("DROP TABLE session_participants;");
-    }
-    database.exec(`PRAGMA user_version = ${schemaVersion};`);
-    database
-      .prepare(
-        "UPDATE schema_meta SET schema_version = ?, app_version = ? WHERE meta_key = 'primary'",
-      )
-      .run(schemaVersion, "legacy-test");
-    for (const [sessionId, events] of Object.entries(params.eventsBySession)) {
-      const sessionKey = `agent:${agentId}:${sessionId}`;
-      const firstTimestamp = Number(events[0]?.timestamp ?? 1);
-      database
-        .prepare(
-          "INSERT INTO session_nodes(session_key,current_session_id,entry_json,updated_at) VALUES(?,?,?,?)",
-        )
-        .run(sessionKey, sessionId, "{}", firstTimestamp);
-      database
-        .prepare(
-          "INSERT INTO session_windows(session_id,session_key,created_at,updated_at) VALUES(?,?,?,?)",
-        )
-        .run(sessionId, sessionKey, firstTimestamp, firstTimestamp);
-      database
-        .prepare(
-          "INSERT INTO transcript_rewrite_watermarks(session_id,generation,updated_at) VALUES(?,?,?)",
-        )
-        .run(sessionId, `generation-${sessionId}`, firstTimestamp);
-      events.forEach((event, seq) => {
-        const createdAt = Number(event.timestamp ?? firstTimestamp) + 100;
-        database
-          .prepare(
-            "INSERT INTO transcript_events(session_id,seq,event_json,created_at) VALUES(?,?,?,?)",
-          )
-          .run(sessionId, seq, JSON.stringify(event), createdAt);
-        database
-          .prepare(
-            "INSERT INTO transcript_event_identities(session_id,event_id,seq,event_type,parent_id,message_idempotency_key,created_at) VALUES(?,?,?,?,?,?,?)",
-          )
-          .run(
-            sessionId,
-            String(event.id),
-            seq,
-            String(event.type),
-            typeof event.parentId === "string" ? event.parentId : null,
-            (event.message as { idempotencyKey?: string }).idempotencyKey ?? null,
-            createdAt,
-          );
-      });
-      reconcileSessionTranscriptIndexInTransaction(database, sessionId);
-    }
-  } finally {
-    database.close();
-  }
-  registerOpenClawAgentDatabase({
-    agentId,
-    env: params.env,
-    path: databasePath,
-    schemaVersion,
-  });
-  return databasePath;
-}
-
-function readDatabaseSnapshot(databasePath: string) {
-  const { DatabaseSync } = requireNodeSqlite();
-  const database = new DatabaseSync(databasePath);
-  try {
-    const version = database.prepare("PRAGMA user_version").get() as { user_version: number };
-    const rows = database
-      .prepare(
-        "SELECT session_id,seq,event_json,created_at FROM transcript_events ORDER BY session_id,seq",
-      )
-      .all() as Array<{
-      session_id: string;
-      seq: number;
-      event_json: string;
-      created_at: number;
-    }>;
-    const identities = database
-      .prepare(
-        "SELECT session_id,event_id,seq,event_type,parent_id,message_idempotency_key,created_at FROM transcript_event_identities ORDER BY session_id,seq",
-      )
-      .all();
-    const activeBranch = database
-      .prepare(
-        "SELECT session_id,active_position,event_seq,message_position FROM session_transcript_active_events ORDER BY session_id,active_position",
-      )
-      .all();
-    const windows = database
-      .prepare(
-        "SELECT session_id,session_key,created_at,updated_at,transcript_observed_at FROM session_windows ORDER BY session_id",
-      )
-      .all();
-    const generations = database
-      .prepare(
-        "SELECT session_id,generation FROM transcript_rewrite_watermarks ORDER BY session_id",
-      )
-      .all();
-    const trajectoryCount = database
-      .prepare("SELECT count(*) AS count FROM trajectory_runtime_events")
-      .get() as { count: number };
-    const trajectoryRows = database
-      .prepare(
-        "SELECT session_id,seq,run_id,event_json,created_at FROM trajectory_runtime_events ORDER BY session_id,seq",
-      )
-      .all() as Array<{
-      session_id: string;
-      seq: number;
-      run_id: string | null;
-      event_json: string;
-      created_at: number;
-    }>;
-    return {
-      activeBranch,
-      generations,
-      identities,
-      rows,
-      trajectoryCount: trajectoryCount.count,
-      trajectoryRows,
-      version,
-      windows,
-    };
-  } finally {
-    database.close();
-  }
-}
-
-function writeArchive(filePath: string, events: FixtureEvent[], compressed: boolean): void {
-  const content = `${events.map((event) => JSON.stringify(event)).join("\n")}\n`;
-  fs.mkdirSync(path.dirname(filePath), { recursive: true });
-  if (!compressed) {
-    fs.writeFileSync(filePath, content);
-    return;
-  }
-  const encoded = encodeSessionArchiveContent(content);
-  if (encoded.suffix !== SESSION_ARCHIVE_ZSTD_SUFFIX) {
-    throw new Error("test runtime does not support zstd");
-  }
-  fs.writeFileSync(filePath, encoded.bytes);
-}
 
 afterEach(() => {
   closeOpenClawAgentDatabasesForTest();

--- a/test/scripts/lint-suppressions.test.ts
+++ b/test/scripts/lint-suppressions.test.ts
@@ -199,7 +199,8 @@ describe("production lint suppressions", () => {
         "extensions/matrix/src/onboarding.test-harness.ts|typescript/no-unnecessary-type-parameters|1",
         // Oxlint 1.78 checks AggregateError cause options at the wrong argument position.
         "extensions/qa-lab/src/gateway-child-lifecycle.ts|preserve-caught-error|1",
-        "extensions/qa-lab/src/gateway-child-setup.ts|preserve-caught-error|1",
+        // Candidate output can quote credentials; only the redacted diagnostic crosses.
+        "extensions/qa-lab/src/gateway-child-setup.ts|preserve-caught-error|2",
         "extensions/slack/src/monitor/provider-support.ts|typescript/no-unnecessary-type-parameters|1",
         "src/agents/agent-bundle-mcp-runtime.ts|unicorn/prefer-add-event-listener|1",
         "src/agents/agent-tools.abort.ts|typescript/prefer-promise-reject-errors|1",


### PR DESCRIPTION
## What Problem This Solves

Every PR run against current `main` fails in one of two lanes that no pending change owns:

1. `check-lint-core-5`: `src/infra/state-migrations.media-persistence.test.ts` has 1034 counted lines against the 1000 max (`eslint(max-lines)`), so the stripe exits 1.
2. `checks-node-compact-small-*`: `test/scripts/lint-suppressions.test.ts` "keeps the intentional production suppression tail on an explicit allowlist" expects one `preserve-caught-error` entry for `extensions/qa-lab/src/gateway-child-setup.ts` while the tree has two, so the allowlist assertion fails.

Both reproduce on a pristine checkout of `main` at `ec23435db9a` with the exact CI commands:

```
node scripts/run-oxlint-shards.mts --only=core --split-core --core-stripe=5/5 --threads=1
# src/infra/state-migrations.media-persistence.test.ts:1074:4: error eslint(max-lines): File has too many lines (1034). help: Maximum allowed is 1000.

node scripts/run-vitest.mjs run test/scripts/lint-suppressions.test.ts
# -   "extensions/qa-lab/src/gateway-child-setup.ts|preserve-caught-error|1",
# +   "extensions/qa-lab/src/gateway-child-setup.ts|preserve-caught-error|2",
```

## Why This Change Was Made

These are cross-lane breaks: the PRs that produced them touched files whose change classification did not select these lanes, so PR CI stayed green and the breaks surface on the next full run through any unrelated PR. Left alone, they block every open PR from landing. This PR clears them without touching production code.

## User Impact

None at runtime — test-support and lint-allowlist only. Production LOC delta is zero.

## Evidence

**Media persistence test split.** The shared fixtures (`tempDirs`, `PREVIOUS_VERSION`, `createEvent`, `createLegacyDatabaseFixture`, `readDatabaseSnapshot`, `writeArchive`, `FixtureEvent`) move verbatim to a colocated `state-migrations.media-persistence.fixture.ts`, following the existing `src/agents/embedded-agent-runner/run.overflow-compaction.fixture.ts` precedent. No test case, assertion, or lane assignment changes; the test file drops to 903 total lines (~866 counted), under the max.

- `node scripts/run-vitest.mjs run src/infra/state-migrations.media-persistence.test.ts` → 15/15 passed.
- The exact `check-lint-core-5` stripe command above → exits 0 (only remaining finding on a scratch checkout was an untracked scratch file, not in this tree's committed state).

**Suppression allowlist.** The second suppression at `gateway-child-setup.ts:457` is the intentional redaction boundary on the plugin setup failure path: candidate output can quote credentials, so the error cause is dropped and only the bounded redacted diagnostic (`toErrorObject` + `redactQaGatewayDebugText` + length cap) crosses. Adding `cause` would attach credential-bearing output to a thrown error. The allowlist therefore records the second entry with that justification rather than weakening the boundary, and the sibling `gateway-child-lifecycle.ts:87` entry keeps its existing note.

- `node scripts/run-vitest.mjs run test/scripts/lint-suppressions.test.ts` → 4/4 passed.

This allowlist entry grows the ratchet (1 → 2) rather than shrinking it. It does not silence a violation in any pending change — it records a suppression that already landed on `main` through a PR whose lane selection never ran this cross-lane test, and the suppression itself is security-justified at the code site.

## Proof gaps

None intended. If maintainers prefer the alternative repair for the qa-lab entry (delete the suppression and fix the underlying code), note that the code path deliberately drops the cause to keep credentials out of thrown errors, so the suppression is the correct end state; the only other option would be weakening the redaction, which this PR does not do.
