### PR TITLE
fix(line): deliver the controls an agent reply offers

### DIFF
--- a/extensions/line/src/auto-reply-delivery-recovery.test.ts
+++ b/extensions/line/src/auto-reply-delivery-recovery.test.ts
@@ -7,6 +7,7 @@ import {
   baseDeliveryParams,
   createDeps,
   createFlexMessage,
+  createQuickReply,
   LINE_TEST_CFG,
   type LineAutoReplyDeps,
 } from "./auto-reply-delivery.test-helpers.js";
@@ -274,14 +275,14 @@ describe("deliverLineAutoReply HTTP recovery", () => {
       "line:user:1",
       [
         createFlexMessage("Card", { type: "bubble" }),
-        { type: "text", text: "Choose one", quickReply: { items: ["A"] } },
+        { type: "text", text: "Choose one", quickReply: createQuickReply("A") },
       ],
       { cfg: LINE_TEST_CFG, accountId: "acc" },
     );
     expect(pushMessagesLine).toHaveBeenNthCalledWith(
       2,
       "line:user:1",
-      [{ type: "text", text: "Choose one", quickReply: { items: ["A"] } }],
+      [{ type: "text", text: "Choose one", quickReply: createQuickReply("A") }],
       { cfg: LINE_TEST_CFG, accountId: "acc" },
     );
   });
@@ -387,7 +388,7 @@ describe("deliverLineAutoReply HTTP recovery", () => {
     expect(pushMessagesLine).toHaveBeenNthCalledWith(
       2,
       "line:user:1",
-      [{ type: "text", text: "Options:\n- A", quickReply: { items: ["A"] } }],
+      [{ type: "text", text: "Options:\n- A", quickReply: createQuickReply("A") }],
       { cfg: LINE_TEST_CFG, accountId: "acc" },
     );
   });
@@ -615,7 +616,7 @@ describe("deliverLineAutoReply HTTP recovery", () => {
       "line:user:1",
       [
         { type: "text", text: "c5" },
-        { type: "text", text: "c6", quickReply: { items: ["A"] } },
+        { type: "text", text: "c6", quickReply: createQuickReply("A") },
       ],
       { cfg: LINE_TEST_CFG, accountId: "acc" },
     );
@@ -670,7 +671,7 @@ describe("deliverLineAutoReply HTTP recovery", () => {
     expect(pushMessagesLine).toHaveBeenNthCalledWith(
       3,
       "line:user:1",
-      [{ type: "text", text: "c6", quickReply: { items: ["A"] } }],
+      [{ type: "text", text: "c6", quickReply: createQuickReply("A") }],
       { cfg: LINE_TEST_CFG, accountId: "acc" },
     );
   });

--- a/extensions/line/src/auto-reply-delivery.row-overflow.test.ts
+++ b/extensions/line/src/auto-reply-delivery.row-overflow.test.ts
@@ -1,0 +1,147 @@
+// Line tests cover auto reply row-overflow table delivery.
+import { chunkMarkdownText } from "openclaw/plugin-sdk/reply-runtime";
+import { describe, expect, it } from "vitest";
+import { deliverLineAutoReply } from "./auto-reply-delivery.js";
+import { baseDeliveryParams, createDeps } from "./auto-reply-delivery.test-helpers.js";
+import { processLineMessage as processOrderedLineMessage } from "./markdown-to-line.js";
+
+describe("row-overflow table delivery boundary", () => {
+  it("delivers all rows as ordered text when a 15-row 2-column table overflows the receipt cap via reply token", async () => {
+    const { deps, replyMessageLine, pushMessagesLine } = createDeps({
+      processLineMessage: processOrderedLineMessage,
+      chunkMarkdownText,
+    });
+    const rows = Array.from({ length: 15 }, (_, i) => `| Item${i + 1} | $${i + 1}.00 |`).join("\n");
+    const markdown = `Header\n\n| Name | Price |\n|---|---|\n${rows}\n\nFooter`;
+
+    const result = await deliverLineAutoReply({
+      ...baseDeliveryParams,
+      payload: { text: markdown },
+      lineData: {},
+      deps,
+    });
+
+    expect(result.status).toBe("delivered");
+    expect(result.replyTokenUsed).toBe(true);
+    const allMessages = [
+      ...replyMessageLine.mock.calls.flatMap(([, msgs]) => msgs),
+      ...pushMessagesLine.mock.calls.flatMap(([, msgs]) => msgs),
+    ];
+    const allText = allMessages
+      .filter((m) => m.type === "text")
+      .map((m) => m.text)
+      .join(" ");
+    for (let i = 1; i <= 15; i++) {
+      expect(allText).toContain(`Item${i}`);
+    }
+    expect(allText).toContain("Header");
+    expect(allText).toContain("Footer");
+    expect(allText.indexOf("Header")).toBeLessThan(allText.indexOf("Item1"));
+    expect(allText.indexOf("Item15")).toBeLessThan(allText.indexOf("Footer"));
+    expect(allMessages.some((m) => m.type === "flex" && m.altText === "Table")).toBe(false);
+  });
+
+  it("delivers all rows as ordered text when an 11-row 3-column table overflows the generic cap via push path", async () => {
+    const { deps, pushMessagesLine } = createDeps({
+      processLineMessage: processOrderedLineMessage,
+      chunkMarkdownText,
+    });
+    const rows = Array.from({ length: 11 }, (_, i) => `| Row${i + 1} | Val${i + 1} | Extra |`).join(
+      "\n",
+    );
+    const markdown = `| Name | Value | Extra |\n|---|---|---|\n${rows}`;
+
+    const result = await deliverLineAutoReply({
+      ...baseDeliveryParams,
+      payload: { text: markdown },
+      replyToken: null,
+      lineData: {},
+      deps,
+    });
+
+    expect(result.status).toBe("delivered");
+    expect(result.replyTokenUsed).toBe(false);
+    expect(pushMessagesLine.mock.calls.length).toBeGreaterThan(0);
+    const allMessages = pushMessagesLine.mock.calls.flatMap(([, msgs]) => msgs);
+    const allText = allMessages
+      .filter((m) => m.type === "text")
+      .map((m) => m.text)
+      .join(" ");
+    for (let i = 1; i <= 11; i++) {
+      expect(allText).toContain(`Row${i}`);
+    }
+  });
+
+  it("keeps small table as Flex alongside overflow table text in source order", async () => {
+    const { deps, replyMessageLine, pushMessagesLine } = createDeps({
+      processLineMessage: processOrderedLineMessage,
+      chunkMarkdownText,
+    });
+    const keptTable = "| Small | Card |\n|---|---|\n| Kept | row |";
+    const bigRows = Array.from({ length: 13 }, (_, i) => `| Big${i + 1} | $${i + 1}.00 |`).join(
+      "\n",
+    );
+    const overflowTable = `| Name | Price |\n|---|---|\n${bigRows}`;
+    const markdown = `Header\n\n${keptTable}\n\nBetween\n\n${overflowTable}\n\nFooter`;
+
+    await deliverLineAutoReply({
+      ...baseDeliveryParams,
+      payload: { text: markdown },
+      lineData: {},
+      deps,
+    });
+
+    const allMessages = [
+      ...replyMessageLine.mock.calls.flatMap(([, msgs]) => msgs),
+      ...pushMessagesLine.mock.calls.flatMap(([, msgs]) => msgs),
+    ];
+    expect(allMessages.filter((m) => m.type === "flex").length).toBeGreaterThanOrEqual(1);
+    const allText = allMessages
+      .filter((m) => m.type === "text")
+      .map((m) => m.text)
+      .join(" ");
+    for (let i = 1; i <= 13; i++) {
+      expect(allText).toContain(`Big${i}`);
+    }
+    expect(allText).toContain("Header");
+    expect(allText).toContain("Footer");
+  });
+
+  it("delivers all rows when a 2-column table with inline markup overflows the generic cap", async () => {
+    const { deps, replyMessageLine, pushMessagesLine } = createDeps({
+      processLineMessage: processOrderedLineMessage,
+      chunkMarkdownText,
+    });
+    const markupRows = Array.from({ length: 11 }, (_, i) =>
+      i === 0 ? "| `code` **bold** | Val1 |" : `| Item${i + 1} | $${i + 1}.00 |`,
+    ).join("\n");
+    const markdown = `| Name | Price |\n|---|---|\n${markupRows}`;
+
+    const result = await deliverLineAutoReply({
+      ...baseDeliveryParams,
+      payload: { text: markdown },
+      lineData: {},
+      deps,
+    });
+
+    expect(result.status).toBe("delivered");
+    const allMessages = [
+      ...replyMessageLine.mock.calls.flatMap(([, msgs]) => msgs),
+      ...pushMessagesLine.mock.calls.flatMap(([, msgs]) => msgs),
+    ];
+    expect(allMessages.some((m) => m.type === "flex" && m.altText === "Table")).toBe(false);
+    const deliveredLines = allMessages
+      .filter((m) => m.type === "text")
+      .flatMap((message) => message.text.split(/\r?\n/u).map((line) => line.trim()));
+    const expectedLabels = [
+      "code bold",
+      ...Array.from({ length: 10 }, (_, index) => `Item${index + 2}`),
+    ];
+
+    expect(deliveredLines.filter((line) => expectedLabels.includes(line))).toEqual(expectedLabels);
+    expect(deliveredLines).toContain("• Price: Val1");
+    for (let item = 2; item <= 11; item += 1) {
+      expect(deliveredLines).toContain(`• Price: $${item}.00`);
+    }
+  });
+});

--- a/extensions/line/src/auto-reply-delivery.test-helpers.ts
+++ b/extensions/line/src/auto-reply-delivery.test-helpers.ts
@@ -9,7 +9,6 @@ export type LineAutoReplyDeps = Parameters<typeof deliverLineAutoReply>[0]["deps
 type LineAutoReplyTestDeps = {
   deps: LineAutoReplyDeps;
   replyMessageLine: Mock<LineAutoReplyDeps["replyMessageLine"]>;
-  createQuickReplyItems: Mock<(labels: string[]) => { items: string[] }>;
   buildMediaMessage: (
     ...args: Parameters<LineAutoReplyDeps["buildMediaMessage"]>
   ) => Promise<messagingApi.Message>;
@@ -33,6 +32,14 @@ export const createFlexMessage = (altText: string, contents: unknown) => ({
   contents,
 });
 
+/** LINE's wire shape for label-only quick replies, as the plugin builds them. */
+export const createQuickReply = (...labels: string[]) => ({
+  items: labels.map((label) => ({
+    type: "action" as const,
+    action: { type: "message" as const, label, text: label },
+  })),
+});
+
 export const createImageMessage = (url: string) => ({
   type: "image" as const,
   originalContentUrl: url,
@@ -46,7 +53,6 @@ const createLocationMessage: LineAutoReplyDeps["createLocationMessage"] = (locat
 
 export function createDeps(overrides?: Partial<LineAutoReplyDeps>): LineAutoReplyTestDeps {
   const replyMessageLine = vi.fn<LineAutoReplyDeps["replyMessageLine"]>(async () => ({}));
-  const createQuickReplyItems = vi.fn((labels: string[]) => ({ items: labels }));
   const buildMediaMessage: LineAutoReplyDeps["buildMediaMessage"] = vi.fn(
     async (mediaUrl, options) => {
       switch (options.mediaKind) {
@@ -82,7 +88,6 @@ export function createDeps(overrides?: Partial<LineAutoReplyDeps>): LineAutoRepl
     processLineMessage: (text) => ({ text, flexMessages: [] }),
     chunkMarkdownText: (text) => [text],
     replyMessageLine,
-    createQuickReplyItems: createQuickReplyItems as LineAutoReplyDeps["createQuickReplyItems"],
     pushMessagesLine,
     createFlexMessage: createFlexMessage as LineAutoReplyDeps["createFlexMessage"],
     buildMediaMessage,
@@ -93,7 +98,6 @@ export function createDeps(overrides?: Partial<LineAutoReplyDeps>): LineAutoRepl
   return {
     deps,
     replyMessageLine,
-    createQuickReplyItems,
     buildMediaMessage,
     pushMessagesLine,
   };

--- a/extensions/line/src/auto-reply-delivery.test.ts
+++ b/extensions/line/src/auto-reply-delivery.test.ts
@@ -14,6 +14,7 @@ import {
 } from "./auto-reply-delivery.test-helpers.js";
 import { processLineMessage as processOrderedLineMessage } from "./markdown-to-line.js";
 import { buildLineMediaMessage } from "./outbound-media.js";
+import { prepareLineReplyPayload } from "./rich-messages.js";
 import {
   createFlexMessage as createProviderFlexMessage,
   createLocationMessage as createRealLocationMessage,
@@ -194,6 +195,40 @@ describe("deliverLineAutoReply", () => {
       });
       expect(messages.slice(0, -1).every((message) => !("quickReply" in message))).toBe(true);
     }
+  });
+
+  // A select-only presentation renders quick replies but no Flex body, so the
+  // fallback prose is the only thing carrying the question. Delivering bare
+  // option labels would leave the user choosing between answers to nothing.
+  it("delivers the question with the options when only quick replies render", async () => {
+    const prepared = prepareLineReplyPayload({
+      text: "Agent needs input:\n1. Alpha",
+      presentationTextMode: "fallback",
+      presentation: {
+        blocks: [
+          {
+            type: "select",
+            options: [{ label: "Alpha", action: { type: "callback", value: "alpha" } }],
+          },
+        ],
+      },
+    });
+    const lineData = expectDefined(
+      prepared.channelData?.line as Record<string, unknown> | undefined,
+      "prepared LINE channel data",
+    );
+    const { deps, replyMessageLine } = createDeps();
+
+    await deliverLineAutoReply({
+      ...baseDeliveryParams,
+      payload: prepared,
+      lineData,
+      deps,
+    });
+
+    expect(replyMessageLine.mock.calls[0]?.[1]).toMatchObject([
+      { type: "text", text: "Agent needs input:\n1. Alpha" },
+    ]);
   });
 
   it("sends text and rich messages on one reply token instead of pushing the rich bubble", async () => {

--- a/extensions/line/src/auto-reply-delivery.test.ts
+++ b/extensions/line/src/auto-reply-delivery.test.ts
@@ -7,6 +7,7 @@ import {
   baseDeliveryParams,
   createDeps,
   createFlexMessage,
+  createQuickReply,
   createImageMessage,
   LINE_TEST_CFG,
   type LineAutoReplyDeps,
@@ -50,7 +51,7 @@ describe("deliverLineAutoReply", () => {
       ),
     ).toEqual(["Before", "Code", "Between", "Table", "After"]);
     if (quickReplies.length > 0) {
-      expect(messages.at(-1)).toMatchObject({ quickReply: { items: quickReplies } });
+      expect(messages.at(-1)).toMatchObject({ quickReply: createQuickReply(...quickReplies) });
       expect(messages.slice(0, -1).every((message) => !("quickReply" in message))).toBe(true);
     }
   });
@@ -92,7 +93,7 @@ describe("deliverLineAutoReply", () => {
     expect(messages.at(-1)).toMatchObject({
       type: "image",
       originalContentUrl: "https://example.com/image.jpg",
-      quickReply: { items: ["Continue"] },
+      quickReply: createQuickReply("Continue"),
     });
     expect(messages.slice(0, -1).every((message) => !("quickReply" in message))).toBe(true);
     expect(pushMessagesLine).not.toHaveBeenCalled();
@@ -129,7 +130,7 @@ describe("deliverLineAutoReply", () => {
       {
         type: "image",
         originalContentUrl: "https://example.com/image.jpg",
-        quickReply: { items: ["Continue"] },
+        quickReply: createQuickReply("Continue"),
       },
     ]);
   });
@@ -189,7 +190,7 @@ describe("deliverLineAutoReply", () => {
       expect(messages.at(-1)).toMatchObject({
         type: "flex",
         altText: "Code",
-        quickReply: { items: quickReplies },
+        quickReply: createQuickReply(...quickReplies),
       });
       expect(messages.slice(0, -1).every((message) => !("quickReply" in message))).toBe(true);
     }
@@ -199,7 +200,7 @@ describe("deliverLineAutoReply", () => {
     const lineData = {
       flexMessage: { altText: "Card", contents: { type: "bubble" } },
     };
-    const { deps, replyMessageLine, pushMessagesLine, createQuickReplyItems } = createDeps();
+    const { deps, replyMessageLine, pushMessagesLine } = createDeps();
 
     const result = await deliverLineAutoReply({
       ...baseDeliveryParams,
@@ -215,7 +216,6 @@ describe("deliverLineAutoReply", () => {
       { cfg: LINE_TEST_CFG, accountId: "acc" },
     );
     expect(pushMessagesLine).not.toHaveBeenCalled();
-    expect(createQuickReplyItems).not.toHaveBeenCalled();
     expect(result.visibleReplySent).toBe(true);
   });
 
@@ -528,7 +528,7 @@ describe("deliverLineAutoReply", () => {
       flexMessage: { altText: "Card", contents: { type: "bubble" } },
       quickReplies: ["A"],
     };
-    const { deps, replyMessageLine, pushMessagesLine, createQuickReplyItems } = createDeps({
+    const { deps, replyMessageLine, pushMessagesLine } = createDeps({
       processLineMessage: () => ({ text: "", flexMessages: [] }),
       chunkMarkdownText: () => [],
     });
@@ -549,13 +549,12 @@ describe("deliverLineAutoReply", () => {
       [
         {
           ...createFlexMessage("Card", { type: "bubble" }),
-          quickReply: { items: ["A"] },
+          quickReply: createQuickReply("A"),
         },
       ],
       { cfg: LINE_TEST_CFG, accountId: "acc" },
     );
     expect(pushMessagesLine).not.toHaveBeenCalled();
-    expect(createQuickReplyItems).toHaveBeenCalledExactlyOnceWith(["A"]);
     expect(result.visibleReplySent).toBe(true);
   });
 
@@ -588,7 +587,7 @@ describe("deliverLineAutoReply", () => {
     );
     expect(pushMessagesLine).toHaveBeenCalledExactlyOnceWith(
       "line:user:1",
-      [{ ...createFlexMessage("B6", { type: "bubble" }), quickReply: { items: ["A"] } }],
+      [{ ...createFlexMessage("B6", { type: "bubble" }), quickReply: createQuickReply("A") }],
       { cfg: LINE_TEST_CFG, accountId: "acc" },
     );
   });
@@ -613,7 +612,7 @@ describe("deliverLineAutoReply", () => {
         {
           type: "text",
           text: "Options:\n- A\n- B",
-          quickReply: { items: ["A", "B"] },
+          quickReply: createQuickReply("A", "B"),
         },
       ],
       { cfg: LINE_TEST_CFG, accountId: "acc" },
@@ -622,12 +621,56 @@ describe("deliverLineAutoReply", () => {
     expect(result.visibleReplySent).toBe(true);
   });
 
+  it("attaches the typed quick replies a rendered presentation carries", async () => {
+    // renderLinePresentation emits quickReplyItems, so the reply path must read
+    // that carrier and not only the plain-label one.
+    const lineData = {
+      quickReplyItems: [
+        { label: "Approve", action: { type: "callback" as const, value: "approve" } },
+        { label: "Status", action: { type: "command" as const, command: "/status" } },
+      ],
+    };
+    const { deps, replyMessageLine } = createDeps();
+
+    await deliverLineAutoReply({
+      ...baseDeliveryParams,
+      payload: { text: "Approve this run?", channelData: { line: lineData } },
+      lineData,
+      deps,
+    });
+
+    expect(replyMessageLine).toHaveBeenCalledExactlyOnceWith(
+      "token",
+      [
+        {
+          type: "text",
+          text: "Approve this run?",
+          quickReply: {
+            items: [
+              {
+                type: "action",
+                action: {
+                  type: "postback",
+                  label: "Approve",
+                  data: "approve",
+                  displayText: "Approve",
+                },
+              },
+              { type: "action", action: { type: "message", label: "Status", text: "/status" } },
+            ],
+          },
+        },
+      ],
+      { cfg: LINE_TEST_CFG, accountId: "acc" },
+    );
+  });
+
   it("sends rich messages before quick-reply text so quick replies remain visible", async () => {
     const lineData = {
       flexMessage: { altText: "Card", contents: { type: "bubble" } },
       quickReplies: ["A"],
     };
-    const { deps, pushMessagesLine, replyMessageLine, createQuickReplyItems } = createDeps();
+    const { deps, pushMessagesLine, replyMessageLine } = createDeps();
 
     await deliverLineAutoReply({
       ...baseDeliveryParams,
@@ -642,12 +685,11 @@ describe("deliverLineAutoReply", () => {
       "token",
       [
         createFlexMessage("Card", { type: "bubble" }),
-        { type: "text", text: "hello", quickReply: { items: ["A"] } },
+        { type: "text", text: "hello", quickReply: createQuickReply("A") },
       ],
       { cfg: LINE_TEST_CFG, accountId: "acc" },
     );
     expect(pushMessagesLine).not.toHaveBeenCalled();
-    expect(createQuickReplyItems).toHaveBeenCalledExactlyOnceWith(["A"]);
   });
 
   it("surfaces a visible partial delivery when an overflow bubble fails alongside quick-reply text", async () => {
@@ -959,152 +1001,6 @@ describe("deliverLineAutoReply", () => {
     ).rejects.toMatchObject({
       message: "LINE message send failed",
       cause: failure,
-    });
-  });
-
-  describe("row-overflow table delivery boundary", () => {
-    it("delivers all rows as ordered text when a 15-row 2-column table overflows the receipt cap via reply token", async () => {
-      const { deps, replyMessageLine, pushMessagesLine } = createDeps({
-        processLineMessage: processOrderedLineMessage,
-        chunkMarkdownText,
-      });
-      const rows = Array.from({ length: 15 }, (_, i) => `| Item${i + 1} | $${i + 1}.00 |`).join(
-        "\n",
-      );
-      const markdown = `Header\n\n| Name | Price |\n|---|---|\n${rows}\n\nFooter`;
-
-      const result = await deliverLineAutoReply({
-        ...baseDeliveryParams,
-        payload: { text: markdown },
-        lineData: {},
-        deps,
-      });
-
-      expect(result.status).toBe("delivered");
-      expect(result.replyTokenUsed).toBe(true);
-      const allMessages = [
-        ...replyMessageLine.mock.calls.flatMap(([, msgs]) => msgs),
-        ...pushMessagesLine.mock.calls.flatMap(([, msgs]) => msgs),
-      ];
-      const allText = allMessages
-        .filter((m) => m.type === "text")
-        .map((m) => m.text)
-        .join(" ");
-      for (let i = 1; i <= 15; i++) {
-        expect(allText).toContain(`Item${i}`);
-      }
-      expect(allText).toContain("Header");
-      expect(allText).toContain("Footer");
-      expect(allText.indexOf("Header")).toBeLessThan(allText.indexOf("Item1"));
-      expect(allText.indexOf("Item15")).toBeLessThan(allText.indexOf("Footer"));
-      expect(allMessages.some((m) => m.type === "flex" && m.altText === "Table")).toBe(false);
-    });
-
-    it("delivers all rows as ordered text when an 11-row 3-column table overflows the generic cap via push path", async () => {
-      const { deps, pushMessagesLine } = createDeps({
-        processLineMessage: processOrderedLineMessage,
-        chunkMarkdownText,
-      });
-      const rows = Array.from(
-        { length: 11 },
-        (_, i) => `| Row${i + 1} | Val${i + 1} | Extra |`,
-      ).join("\n");
-      const markdown = `| Name | Value | Extra |\n|---|---|---|\n${rows}`;
-
-      const result = await deliverLineAutoReply({
-        ...baseDeliveryParams,
-        payload: { text: markdown },
-        replyToken: null,
-        lineData: {},
-        deps,
-      });
-
-      expect(result.status).toBe("delivered");
-      expect(result.replyTokenUsed).toBe(false);
-      expect(pushMessagesLine.mock.calls.length).toBeGreaterThan(0);
-      const allMessages = pushMessagesLine.mock.calls.flatMap(([, msgs]) => msgs);
-      const allText = allMessages
-        .filter((m) => m.type === "text")
-        .map((m) => m.text)
-        .join(" ");
-      for (let i = 1; i <= 11; i++) {
-        expect(allText).toContain(`Row${i}`);
-      }
-    });
-
-    it("keeps small table as Flex alongside overflow table text in source order", async () => {
-      const { deps, replyMessageLine, pushMessagesLine } = createDeps({
-        processLineMessage: processOrderedLineMessage,
-        chunkMarkdownText,
-      });
-      const keptTable = "| Small | Card |\n|---|---|\n| Kept | row |";
-      const bigRows = Array.from({ length: 13 }, (_, i) => `| Big${i + 1} | $${i + 1}.00 |`).join(
-        "\n",
-      );
-      const overflowTable = `| Name | Price |\n|---|---|\n${bigRows}`;
-      const markdown = `Header\n\n${keptTable}\n\nBetween\n\n${overflowTable}\n\nFooter`;
-
-      await deliverLineAutoReply({
-        ...baseDeliveryParams,
-        payload: { text: markdown },
-        lineData: {},
-        deps,
-      });
-
-      const allMessages = [
-        ...replyMessageLine.mock.calls.flatMap(([, msgs]) => msgs),
-        ...pushMessagesLine.mock.calls.flatMap(([, msgs]) => msgs),
-      ];
-      expect(allMessages.filter((m) => m.type === "flex").length).toBeGreaterThanOrEqual(1);
-      const allText = allMessages
-        .filter((m) => m.type === "text")
-        .map((m) => m.text)
-        .join(" ");
-      for (let i = 1; i <= 13; i++) {
-        expect(allText).toContain(`Big${i}`);
-      }
-      expect(allText).toContain("Header");
-      expect(allText).toContain("Footer");
-    });
-
-    it("delivers all rows when a 2-column table with inline markup overflows the generic cap", async () => {
-      const { deps, replyMessageLine, pushMessagesLine } = createDeps({
-        processLineMessage: processOrderedLineMessage,
-        chunkMarkdownText,
-      });
-      const markupRows = Array.from({ length: 11 }, (_, i) =>
-        i === 0 ? "| `code` **bold** | Val1 |" : `| Item${i + 1} | $${i + 1}.00 |`,
-      ).join("\n");
-      const markdown = `| Name | Price |\n|---|---|\n${markupRows}`;
-
-      const result = await deliverLineAutoReply({
-        ...baseDeliveryParams,
-        payload: { text: markdown },
-        lineData: {},
-        deps,
-      });
-
-      expect(result.status).toBe("delivered");
-      const allMessages = [
-        ...replyMessageLine.mock.calls.flatMap(([, msgs]) => msgs),
-        ...pushMessagesLine.mock.calls.flatMap(([, msgs]) => msgs),
-      ];
-      expect(allMessages.some((m) => m.type === "flex" && m.altText === "Table")).toBe(false);
-      const deliveredLines = allMessages
-        .filter((m) => m.type === "text")
-        .flatMap((message) => message.text.split(/\r?\n/u).map((line) => line.trim()));
-      const expectedLabels = [
-        "code bold",
-        ...Array.from({ length: 10 }, (_, index) => `Item${index + 2}`),
-      ];
-
-      expect(deliveredLines.filter((line) => expectedLabels.includes(line))).toEqual(
-        expectedLabels,
-      );
-      expect(deliveredLines).toContain("• Price: Val1");
-      for (let item = 2; item <= 11; item += 1) {
-        expect(deliveredLines).toContain(`• Price: $${item}.00`);
-      }
     });
   });
 });

--- a/extensions/line/src/auto-reply-delivery.ts
+++ b/extensions/line/src/auto-reply-delivery.ts
@@ -16,8 +16,9 @@ import type { FlexContainer } from "./flex-templates/types.js";
 import type { ProcessedLineMessage } from "./markdown-to-line.js";
 import { hasLineSpecificMediaOptions } from "./outbound-media.js";
 import { buildLineQuickReplyFallbackText } from "./quick-reply-fallback.js";
+import { createLineQuickReply } from "./rich-messages.js";
 import { findLineHttpError, resolveLineNonDispatchRetryable } from "./send-retry.js";
-import type { LineChannelData, LineTemplateMessagePayload } from "./types.js";
+import type { LineChannelData, LineQuickReplyItem, LineTemplateMessagePayload } from "./types.js";
 
 type LineAutoReplyDeps = {
   buildTemplateMessageFromPayload: (
@@ -25,7 +26,6 @@ type LineAutoReplyDeps = {
   ) => messagingApi.TemplateMessage | null;
   processLineMessage: (text: string) => ProcessedLineMessage;
   chunkMarkdownText: (text: string, limit: number) => string[];
-  createQuickReplyItems: (labels: string[]) => messagingApi.QuickReply;
   pushMessagesLine: (
     to: string,
     messages: messagingApi.Message[],
@@ -217,7 +217,15 @@ export async function deliverLineAutoReply(params: {
   };
 
   const richMessages: messagingApi.Message[] = [];
-  const hasQuickReplies = Boolean(lineData.quickReplies?.length);
+  // The presentation renderer emits typed items; plain labels are the caller-authored carrier.
+  const quickReplyItems: LineQuickReplyItem[] = lineData.quickReplyItems?.length
+    ? lineData.quickReplyItems
+    : (lineData.quickReplies ?? []).map((label) => ({
+        label,
+        action: { type: "command", command: label },
+      }));
+  const quickReplyLabels = quickReplyItems.map((item) => item.label);
+  const hasQuickReplies = quickReplyItems.length > 0;
 
   if (lineData.flexMessage) {
     richMessages.push(
@@ -307,7 +315,7 @@ export async function deliverLineAutoReply(params: {
   if (hasQuickReplies && textMessages.length === 0 && richMediaMessages.length === 0) {
     textMessages.push({
       type: "text",
-      text: buildLineQuickReplyFallbackText(lineData.quickReplies),
+      text: buildLineQuickReplyFallbackText(quickReplyLabels),
     });
   }
   if (hasQuickReplies) {
@@ -320,7 +328,7 @@ export async function deliverLineAutoReply(params: {
     const target = expectDefined(targetMessages[lastIndex], "last LINE auto-reply message");
     targetMessages[lastIndex] = {
       ...target,
-      quickReply: deps.createQuickReplyItems(lineData.quickReplies!),
+      quickReply: createLineQuickReply(quickReplyItems),
     };
   }
 
@@ -354,8 +362,8 @@ export async function deliverLineAutoReply(params: {
           ? [
               {
                 type: "text" as const,
-                text: buildLineQuickReplyFallbackText(lineData.quickReplies),
-                quickReply: deps.createQuickReplyItems(lineData.quickReplies!),
+                text: buildLineQuickReplyFallbackText(quickReplyLabels),
+                quickReply: createLineQuickReply(quickReplyItems),
               },
             ]
           : [];
@@ -369,7 +377,7 @@ export async function deliverLineAutoReply(params: {
       // atomically. Retry its text/actions plus the tail that was never attempted.
       const lastRetryMessage = retryMessages.at(-1);
       if (quickRepliesNeedCarrier && lastRetryMessage && !lastRetryMessage.quickReply) {
-        lastRetryMessage.quickReply = deps.createQuickReplyItems(lineData.quickReplies!);
+        lastRetryMessage.quickReply = createLineQuickReply(quickReplyItems);
       }
       try {
         await sendLineMessages(retryMessages, false);

--- a/extensions/line/src/channel.rich-messages.test.ts
+++ b/extensions/line/src/channel.rich-messages.test.ts
@@ -113,7 +113,7 @@ describe("LINE rich-message boundaries", () => {
     });
   });
 
-  it("replaces fallback text with the controls it was standing in for", () => {
+  it("keeps fallback text when only quick replies render", () => {
     const prepared = prepareLineReplyPayload({
       text: "Agent needs input:\n1. Alpha",
       presentationTextMode: "fallback",
@@ -127,9 +127,33 @@ describe("LINE rich-message boundaries", () => {
       },
     });
 
-    const line = prepared.channelData?.line as { quickReplyItems?: unknown[] } | undefined;
-    expect(prepared.text).toBeUndefined();
+    const line = prepared.channelData?.line as
+      | { quickReplyItems?: unknown[]; flexMessage?: unknown }
+      | undefined;
+    // A select alone renders no Flex body, so the prose is still the only thing
+    // carrying the question. Clearing it delivers bare option labels.
+    expect(prepared.text).toBe("Agent needs input:\n1. Alpha");
+    expect(line?.flexMessage).toBeUndefined();
     expect(line?.quickReplyItems).toHaveLength(1);
+  });
+
+  it("replaces fallback text once a Flex body renders the same controls", () => {
+    const prepared = prepareLineReplyPayload({
+      text: "Agent needs input:\n1. Approve",
+      presentationTextMode: "fallback",
+      presentation: {
+        blocks: [
+          {
+            type: "buttons",
+            buttons: [{ label: "Approve", action: { type: "callback", value: "approve" } }],
+          },
+        ],
+      },
+    });
+
+    const line = prepared.channelData?.line as { flexMessage?: unknown } | undefined;
+    expect(line?.flexMessage).toBeDefined();
+    expect(prepared.text).toBeUndefined();
   });
 
   it("keeps a presentation LINE has no native controls for in the visible text", () => {

--- a/extensions/line/src/channel.rich-messages.test.ts
+++ b/extensions/line/src/channel.rich-messages.test.ts
@@ -3,7 +3,12 @@ import { Value } from "typebox/value";
 import { describe, expect, it } from "vitest";
 import { linePlugin } from "./channel.js";
 import { lineOutboundAdapter } from "./outbound.js";
-import { createLineQuickReply, lineMessageActions, renderLineCard } from "./rich-messages.js";
+import {
+  createLineQuickReply,
+  lineMessageActions,
+  prepareLineReplyPayload,
+  renderLineCard,
+} from "./rich-messages.js";
 import type { LineRichCard } from "./types.js";
 
 function resolveChannelDataSchema() {
@@ -75,6 +80,73 @@ describe("LINE rich-message boundaries", () => {
         { action: { type: "message", text: "/help" } },
       ],
     });
+  });
+
+  it("resolves a reply's presentation into LINE controls before delivery reads it", () => {
+    const prepared = prepareLineReplyPayload({
+      text: "Approve this run?",
+      presentation: {
+        blocks: [
+          {
+            type: "buttons",
+            buttons: [{ label: "Approve", action: { type: "callback", value: "approve" } }],
+          },
+          {
+            type: "select",
+            options: [{ label: "Deny", action: { type: "callback", value: "deny" } }],
+          },
+        ],
+      },
+    });
+
+    expect(prepared.presentation).toBeUndefined();
+    expect(prepared.text).toBe("Approve this run?");
+    const line = prepared.channelData?.line as {
+      flexMessage?: { contents?: { footer?: { contents?: Array<{ action?: unknown }> } } };
+      quickReplyItems?: unknown[];
+    };
+    expect(line.flexMessage?.contents?.footer?.contents).toMatchObject([
+      { action: { type: "postback", data: "approve" } },
+    ]);
+    expect(createLineQuickReply(line.quickReplyItems as never)).toMatchObject({
+      items: [{ action: { type: "postback", data: "deny" } }],
+    });
+  });
+
+  it("replaces fallback text with the controls it was standing in for", () => {
+    const prepared = prepareLineReplyPayload({
+      text: "Agent needs input:\n1. Alpha",
+      presentationTextMode: "fallback",
+      presentation: {
+        blocks: [
+          {
+            type: "select",
+            options: [{ label: "Alpha", action: { type: "callback", value: "alpha" } }],
+          },
+        ],
+      },
+    });
+
+    const line = prepared.channelData?.line as { quickReplyItems?: unknown[] } | undefined;
+    expect(prepared.text).toBeUndefined();
+    expect(line?.quickReplyItems).toHaveLength(1);
+  });
+
+  it("keeps a presentation LINE has no native controls for in the visible text", () => {
+    const prepared = prepareLineReplyPayload({
+      text: "Here are today's runs",
+      presentation: {
+        blocks: [
+          // Nothing here maps to a Flex action or a quick reply.
+          { type: "table", caption: "Runs", headers: ["Agent"], rows: [["main"]] },
+        ],
+      },
+    });
+
+    expect(prepared.channelData?.line).toBeUndefined();
+    expect(prepared.presentation).toBeUndefined();
+    expect(prepared.text).toContain("Here are today's runs");
+    expect(prepared.text).toContain("main");
   });
 
   it.each([

--- a/extensions/line/src/monitor.lifecycle.test.ts
+++ b/extensions/line/src/monitor.lifecycle.test.ts
@@ -3,6 +3,7 @@ import crypto from "node:crypto";
 import { createServer, IncomingMessage, type ServerResponse } from "node:http";
 import { Socket } from "node:net";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import type { ReplyPayload } from "openclaw/plugin-sdk/reply-runtime";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import { createMockIncomingRequest } from "openclaw/plugin-sdk/test-env";
 import { WEBHOOK_IN_FLIGHT_DEFAULTS } from "openclaw/plugin-sdk/webhook-request-guards";
@@ -10,6 +11,7 @@ import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vites
 
 type LineNodeWebhookHandler = (req: IncomingMessage, res: ServerResponse) => Promise<void>;
 type LineHandleWebhook = (...args: unknown[]) => Promise<void>;
+type LineBotOptions = Parameters<typeof import("./bot.js").createLineBot>[0];
 
 const {
   createLineBotMock,
@@ -18,7 +20,7 @@ const {
   runDetachedWebhookWorkMock,
   unregisterHttpMock,
 } = vi.hoisted(() => ({
-  createLineBotMock: vi.fn(() => ({
+  createLineBotMock: vi.fn((_options: LineBotOptions) => ({
     account: { accountId: "default" },
     handleWebhook: vi.fn<LineHandleWebhook>(),
     stop: vi.fn(),
@@ -135,7 +137,6 @@ vi.mock("./send.js", () => ({
   createFlexMessage: vi.fn(),
   createImageMessage: vi.fn(),
   createLocationMessage: vi.fn(),
-  createQuickReplyItems: vi.fn(),
   getUserDisplayName: vi.fn(),
   pushMessagesLine: vi.fn(),
   replyMessageLine: vi.fn(),
@@ -371,6 +372,66 @@ describe("monitorLineProvider lifecycle", () => {
       | undefined;
     expect(bot?.stop).toHaveBeenCalledOnce();
     expect(statusSink).not.toHaveBeenCalledWith(expect.objectContaining({ lifecycle: "ready" }));
+  });
+
+  it("resolves a reply's presentation into LINE controls before delivering it", async () => {
+    // The turn adapter owns this preparation: core renders presentations inside
+    // the outbound send pipeline, which replies delivered here never enter.
+    const { setLineRuntime } = await import("./runtime.js");
+    type ResolvedTurn = { delivery: { preparePayload?: (payload: ReplyPayload) => ReplyPayload } };
+    let resolvedTurn: ResolvedTurn | undefined;
+    const runTurn = async (params: {
+      adapter: { resolveTurn: () => ResolvedTurn };
+    }): Promise<{ dispatched: false }> => {
+      resolvedTurn = params.adapter.resolveTurn();
+      return { dispatched: false };
+    };
+    setLineRuntime({
+      channel: { inbound: { run: runTurn } },
+    } as unknown as Parameters<typeof setLineRuntime>[0]);
+    const monitor = await monitorLineProvider({
+      channelAccessToken: "token",
+      channelSecret: "secret", // pragma: allowlist secret
+      config: {} as OpenClawConfig,
+      runtime: {} as RuntimeEnv,
+    });
+    const onMessage = createLineBotMock.mock.calls[0]?.[0]?.onMessage;
+    if (!onMessage) {
+      throw new Error("expected the LINE bot to receive an inbound message handler");
+    }
+
+    try {
+      await onMessage(
+        {
+          ctxPayload: { From: "line:group:C1", MessageSid: "m1", RawBody: "approve?" },
+          replyToken: "reply-token",
+          route: { accountId: "default", agentId: "main", sessionKey: "line:C1" },
+          isGroup: true,
+          accountId: "default",
+          turn: { record: {} },
+        } as unknown as Parameters<typeof onMessage>[0],
+        {} as Parameters<typeof onMessage>[1],
+      );
+
+      const prepared = resolvedTurn?.delivery.preparePayload?.({
+        text: "Approve this run?",
+        presentation: {
+          blocks: [
+            {
+              type: "buttons",
+              buttons: [{ label: "Approve", action: { type: "callback", value: "approve" } }],
+            },
+          ],
+        },
+      });
+      const line = prepared?.channelData?.line as { flexMessage?: unknown } | undefined;
+
+      expect(prepared?.presentation).toBeUndefined();
+      expect(line?.flexMessage).toBeDefined();
+    } finally {
+      // A leaked registration makes later shared-path signature tests ambiguous.
+      await monitor.stop();
+    }
   });
 
   it("dispatches shared-path webhook posts to the account matching the signature", async () => {

--- a/extensions/line/src/monitor.ts
+++ b/extensions/line/src/monitor.ts
@@ -31,11 +31,11 @@ import { createLineBot } from "./bot.js";
 import { processLineMessage } from "./markdown-to-line.js";
 import { resolveLineDurableReplyOptions } from "./monitor-durable.js";
 import { buildLineMediaMessage } from "./outbound-media.js";
+import { prepareLineReplyPayload } from "./rich-messages.js";
 import { getLineRuntime } from "./runtime.js";
 import {
   createFlexMessage,
   createLocationMessage,
-  createQuickReplyItems,
   pushMessagesLine,
   replyMessageLine,
   showLoadingAnimation,
@@ -215,6 +215,9 @@ export async function monitorLineProvider(
                 ? { replyOptions: { abortSignal: ingressLifecycle.abortSignal } }
                 : {}),
               delivery: {
+                // Core renders presentations inside the outbound send pipeline only,
+                // so this path resolves them before either branch reads channelData.
+                preparePayload: prepareLineReplyPayload,
                 durable: (payload, info) =>
                   resolveLineDurableReplyOptions({
                     payload,
@@ -247,7 +250,6 @@ export async function monitorLineProvider(
                       processLineMessage,
                       chunkMarkdownText,
                       replyMessageLine,
-                      createQuickReplyItems,
                       pushMessagesLine,
                       createFlexMessage,
                       buildMediaMessage: buildLineMediaMessage,

--- a/extensions/line/src/rich-messages.ts
+++ b/extensions/line/src/rich-messages.ts
@@ -223,7 +223,13 @@ export function prepareLineReplyPayload(payload: ReplyPayload): ReplyPayload {
     }),
   );
   if (rendered) {
-    return rendered;
+    // Only a Flex body replaces the fallback prose. A select-only presentation
+    // renders quick replies without one, so dropping the text there would send
+    // bare option labels and lose the question they answer.
+    const renderedLine = isRecord(rendered.channelData?.line) ? rendered.channelData.line : {};
+    return usesFallbackText && renderedLine.flexMessage === undefined
+      ? { ...rendered, text: rest.text }
+      : rendered;
   }
   // LINE renders these controls natively or not at all; keep their labels visible.
   return {

--- a/extensions/line/src/rich-messages.ts
+++ b/extensions/line/src/rich-messages.ts
@@ -3,6 +3,9 @@ import type { messagingApi } from "@line/bot-sdk";
 import type { ChannelMessageActionAdapter } from "openclaw/plugin-sdk/channel-contract";
 import type { ChannelOutboundAdapter } from "openclaw/plugin-sdk/channel-send-result";
 import {
+  adaptMessagePresentationForChannel,
+  normalizeMessagePresentation,
+  renderMessagePresentationFallbackText,
   resolveMessagePresentationButtonAction,
   resolveMessagePresentationOptionAction,
   type MessagePresentation,
@@ -194,6 +197,40 @@ export function renderLinePresentation(
       ...payload.channelData,
       line: { ...lineData, ...(flexMessage ? { flexMessage } : {}), quickReplyItems },
     },
+  };
+}
+
+/**
+ * Resolve a reply's portable presentation into LINE-native controls.
+ *
+ * Core runs the presentation renderer inside the outbound send pipeline only, so
+ * replies the plugin delivers itself reach delivery with the controls still
+ * portable. Preparing them here keeps both LINE delivery paths on one rendering.
+ */
+export function prepareLineReplyPayload(payload: ReplyPayload): ReplyPayload {
+  const presentation = normalizeMessagePresentation(payload.presentation);
+  if (!presentation) {
+    return payload;
+  }
+  const { presentation: _presentation, presentationTextMode, ...rest } = payload;
+  // "fallback" text already renders these controls as prose; native ones replace it.
+  const usesFallbackText = presentationTextMode === "fallback";
+  const rendered = renderLinePresentation(
+    usesFallbackText ? { ...rest, text: undefined } : rest,
+    adaptMessagePresentationForChannel({
+      presentation,
+      capabilities: LINE_PRESENTATION_CAPABILITIES,
+    }),
+  );
+  if (rendered) {
+    return rendered;
+  }
+  // LINE renders these controls natively or not at all; keep their labels visible.
+  return {
+    ...rest,
+    text: usesFallbackText
+      ? (rest.text ?? renderMessagePresentationFallbackText({ presentation }))
+      : renderMessagePresentationFallbackText({ text: rest.text, presentation }),
   };
 }
 

--- a/extensions/line/src/row-overflow-delivery.loopback.test.ts
+++ b/extensions/line/src/row-overflow-delivery.loopback.test.ts
@@ -7,7 +7,7 @@ import { baseDeliveryParams, createDeps } from "./auto-reply-delivery.test-helpe
 import { processLineMessage } from "./markdown-to-line.js";
 import { lineOutboundAdapter } from "./outbound.js";
 import { setLineRuntime } from "./runtime.js";
-import { createQuickReplyItems, pushMessagesLine } from "./send.js";
+import { pushMessagesLine } from "./send.js";
 
 type WireMessage = { type: string; text?: string; altText?: string };
 
@@ -395,7 +395,6 @@ describe("Row-overflow table delivery through production outbound adapter over l
       processLineMessage,
       chunkMarkdownText,
       pushMessagesLine,
-      createQuickReplyItems,
     });
 
     const result = await deliverLineAutoReply({


### PR DESCRIPTION
Closes #132478

## What Problem This Solves

Fixes an issue where operators on LINE never see the buttons, yes/no choices, or selectable options an agent reply offers them. The reply arrives as plain prose with the controls removed — the labels are not even kept in the text — and the turn records it as fully delivered, so nothing anywhere reports that anything was lost.

LINE is the only channel this happens on. Telegram and Slack render the same controls on the same kind of reply.

## Why This Change Was Made

The behavior contract this restores: when a LINE reply offers the operator controls, those controls reach the operator as LINE controls, and when LINE has no way to express one, its label stays in the visible text. Nothing the reply carries disappears.

The LINE plugin already declares `presentationCapabilities` (`supported`, `buttons`, `selects`) and already ships `renderLinePresentation`. Core runs that renderer only inside the outbound send pipeline, and replies to an inbound message never enter it — LINE answers them itself so the first five messages ride the free reply token instead of push quota. The renderer was therefore wired into exactly one of the plugin's two exits.

The fix gives the LINE turn-delivery adapter the `preparePayload` step it never declared. It runs once, above the durable/direct split, so both branches see the same resolved channel data and the rendering can no longer depend on which branch a reply happens to take. `deliverLineAutoReply` then reads `quickReplyItems` — the carrier `renderLinePresentation` actually emits — alongside the plain-label `quickReplies` it already read, and both go through the one `createLineQuickReply` builder.

This follows the ownership boundary the repo already uses: each channel resolves presentations on the path it owns (Telegram `bot-message-dispatch-reply.ts:105`, Slack `reply-blocks.ts:130`). The alternative — rendering presentations in core before `delivery.deliver` — would strip `payload.presentation` out from under six channels that read it themselves, so it is out of scope here.

Non-goals, named rather than folded in:

- **Matrix has the same gap.** `matrixOutbound` declares `presentationCapabilities` and `renderPresentation` (`extensions/matrix/src/outbound.ts:119`, `:132`) while `deliverMatrixReplies` sends only `visibleText` and media (`extensions/matrix/src/matrix/monitor/replies.ts:136-195`). Different delivery model, no rig here to prove it live; needs its own change.
- **`LineChannelData.quickReplies` is retired structure.** `git grep quickReplies` finds no producer anywhere in the repo — `renderLinePresentation` emits `quickReplyItems`, and the message-tool schema rejects both. Deleting it means also deleting `createQuickReplyItems`, `createTextMessageWithQuickReplies` and `pushTextMessageWithQuickReplies` from `send.ts` plus their runtime-facade entries. That is a separate cleanup; this change reads both carriers so it is correct either way.
- **`approval` and `question` typed actions still have no LINE mapping.** They now degrade to visible labels in the text instead of vanishing. Giving them native LINE controls is a different piece of work.
- **Block replies never reach LINE at all** (observed while testing this, see Evidence). Separate bug, separate fix.

Production delta is +57/−10. The growth is the preparation step itself plus reading the second carrier; there is no smaller shape that makes a declared capability hold on a path that has no presentation handling whatsoever.

## User Impact

A LINE operator now gets the same reply every other channel already gives them. A reply that offers "Show status" and "Open docs" arrives as a tappable LINE card; a reply that offers a choice arrives with quick replies attached. When LINE genuinely cannot express a control, its label now appears in the message text instead of being deleted silently.

Replies without controls are byte-identical to before — the preparation returns the same payload object untouched.

## Evidence

**Behavior addressed:** LINE replies carrying a portable presentation reach the LINE Messaging API with their controls, or with their labels in the visible text when LINE cannot render them.

**Real environment tested:** Real LINE Messaging API channel and bot account, real gateway (`node dist/index.js gateway run`, port 18790) behind an ngrok tunnel, real inbound webhooks from the LINE desktop client, `openai/gpt-5.6-sol`. macOS 15.6, Node 24.

**Exact steps or command run after this patch:** one controlled A/B — the same `ReplyPayload`, the same account, the same shipped `deliverLineAutoReply` entry point with the real `pushMessagesLine`; the only variable is whether `prepareLineReplyPayload` runs. The payload carries a title, a text block, a `buttons` block (`command: /status`, `url: https://docs.openclaw.ai`) and a `select` block (`callback: restart`, `callback: noop`).

**Before evidence** (this half is `main`'s behavior — the preparation is skipped):

```
half=before
presentation reaching delivery: still portable
channelData.line: {}
delivery: {"status":"delivered","replyTokenUsed":false,"visibleReplySent":true}
LINE API messages sent:
[
  [
    {
      "type": "text",
      "text": "LINE reply presentation probe (before)"
    }
  ]
]
```

One text message. Title, text block, both buttons and both options gone — and the delivery reports success.

**Evidence after fix** (same payload, preparation applied):

```
half=after
presentation reaching delivery: resolved
delivery: {"status":"delivered","replyTokenUsed":false,"visibleReplySent":true}
LINE API messages sent:
[
  [
    { "type": "flex", "altText": "Gateway status", "contents": { "type": "bubble",
        "body": { "type": "box", "layout": "vertical", "contents": [
          { "type": "text", "text": "Gateway status", "weight": "bold", "size": "xl", "wrap": true },
          { "type": "text", "text": "The gateway is up. What next?", "size": "md", "wrap": true,
            "margin": "md", "color": "#666666" } ], "paddingAll": "lg" },
        "footer": { "type": "box", "layout": "vertical", "contents": [
          { "type": "button", "action": { "type": "message", "label": "Show status", "text": "/status" },
            "style": "primary" },
          { "type": "button", "action": { "type": "uri", "label": "Open docs",
            "uri": "https://docs.openclaw.ai" }, "style": "secondary", "margin": "sm" } ],
          "paddingAll": "md" } } },
    { "type": "text", "text": "LINE reply presentation probe (after)",
      "quickReply": { "items": [
        { "type": "action", "action": { "type": "postback", "label": "Restart", "data": "restart",
          "displayText": "Restart" } },
        { "type": "action", "action": { "type": "postback", "label": "Do nothing", "data": "noop",
          "displayText": "Do nothing" } } ] } }
  ]
]
```

**Observed result after fix:** both halves landed in the real LINE chat. The `before` message renders as a bare grey text bubble. The `after` message renders as a LINE card titled "Gateway status" with the body text and two tappable buttons — "Show status" (primary) and "Open docs" — followed by the text bubble. The quick replies are on the wire above; the LINE **desktop** client does not render quick replies at all, they only appear on mobile.

**Full inbound-to-reply chain on this build**, to show the running gateway is the patched one and the ordinary path is unchanged. Real webhook from the LINE desktop client:

```
POST /line/webhook  200
{"destination":"U2ceeb0b…","events":[{"type":"message",
 "message":{"type":"text","id":"629406584326062115","text":"…"},
 "replyToken":"ef148896652346e5…","source":{"type":"user","userId":"U<redacted-operator-id>…"},
 "timestamp":1787986862788,"mode":"active","deliveryContext":{"isRedelivery":false}}]}
```

The agent ran, called `ask_user`, and the turn answered in the real chat. `grep 'preparePayload: prepareLineReplyPayload' dist/monitor-*.js` confirms the wiring was in the dist the gateway loaded.

**Red/green proof** — each half of the fix reverted on its own, so the failure is attributable:

```
# remove only the wiring line from monitor.ts
$ pnpm exec vitest run … extensions/line/src/monitor.lifecycle.test.ts
 × monitorLineProvider lifecycle > resolves a reply's presentation into LINE controls before delivering it
   AssertionError: expected undefined to be defined
 Tests  1 failed | 14 passed (15)

# make deliverLineAutoReply read only the legacy quickReplies carrier
$ pnpm exec vitest run … extensions/line/src/auto-reply-delivery.test.ts
 × deliverLineAutoReply > attaches the typed quick replies a rendered presentation carries
 Tests  1 failed | 39 passed (40)
```

Both restored: `Test Files 45 passed (45) · Tests 666 passed (666)`.

**Additional review:** `node scripts/check-changed.mjs` exits 0 with zero `FAILED` lines (both tsgo lanes, oxlint, oxfmt, knip dead-export scan, import cycles, plugin boundaries, coercion guard). `pnpm check:assertion-safety --base origin/main` and `pnpm check:max-lines-ratchet --base origin/main` both OK. Splitting the row-overflow describe block into `auto-reply-delivery.row-overflow.test.ts` is a pure move that keeps `auto-reply-delivery.test.ts` under the 1000-line budget without a suppression.

Pre-existing quick-reply assertions changed shape because the reply path no longer takes an injected `createQuickReplyItems` double: they now assert the real LINE wire bytes (`{type:"action",action:{type:"message",label,text}}`) instead of the mock's identity output.

**What was not tested:** Matrix (named above as a separate change). `approval`/`question` typed actions were exercised through the live `ask_user` run, which confirmed no regression, but LINE cannot render them natively either way.

**Proof limitations or environment constraints:** the A/B pushes through `pushMessagesLine` rather than a reply token, because a reply token is single-use and cannot carry both halves of a controlled comparison. Both halves go through the same `deliverLineAutoReply` batching that the reply-token path uses. Quick-reply rendering could not be confirmed visually on desktop LINE, which does not render them; the wire bytes are the evidence for that half.
