### PR TITLE
fix(packaging): make macOS Docker tarballs readable on Linux

### DIFF
--- a/scripts/package-openclaw-for-docker.mts
+++ b/scripts/package-openclaw-for-docker.mts
@@ -864,10 +864,10 @@ async function normalizeOpenClawTarballModes(tarballPath: string) {
     await fs.rm(normalizedPath, { force: true });
     await run(
       "tar",
-      ["-czf", path.basename(normalizedPath), "-C", stageDir, ...stageRootEntries],
+      ["--no-xattrs", "-czf", path.basename(normalizedPath), "-C", stageDir, ...stageRootEntries],
       path.dirname(normalizedPath),
       {
-        // macOS bsdtar must not add AppleDouble (._*) sidecar entries.
+        // BSD tar has separate PAX xattr and AppleDouble (._*) metadata paths.
         env: { ...process.env, COPYFILE_DISABLE: "1" },
         timeoutMs,
       },

--- a/test/e2e/qa-lab/runtime/package-openclaw-for-docker.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/package-openclaw-for-docker.e2e.test.ts
@@ -1,6 +1,7 @@
 // Package OpenClaw For Docker tests cover QA Lab package artifact evidence.
 import { spawn } from "node:child_process";
 import { createHash } from "node:crypto";
+import { once } from "node:events";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -755,18 +756,29 @@ describe("package-openclaw-for-docker", () => {
 
       const entryModes = new Map<string, number>();
       const files: Array<{ path: string; size: number; mode: number }> = [];
-      await tar.t({
-        file: tarball,
-        onentry: (entry) => {
+      const extendedAttributeHeaders: string[] = [];
+      const parser = new tar.Parser({
+        onReadEntry: (entry) => {
           const mode = (entry.mode ?? 0) & 0o777;
           entryModes.set(entry.path, mode);
           files.push({ path: entry.path.replace(/^package\//u, ""), size: entry.size, mode });
+          entry.resume();
         },
       });
+      // ReadEntry drops unknown PAX fields, so inspect the raw header keys.
+      parser.on("meta", (metadata: string) => {
+        extendedAttributeHeaders.push(
+          ...(metadata.match(/(?:LIBARCHIVE|SCHILY)\.xattr\.[^=\n]+(?==)/gu) ?? []),
+        );
+      });
+      const parsed = once(parser, "end");
+      const bytes = fs.readFileSync(tarball);
+      parser.end(bytes);
+      await parsed;
+      expect(extendedAttributeHeaders).toEqual([]);
       expect(entryModes.get("package/dist/index.js")).toBe(0o644);
       expect(entryModes.get("package/openclaw.mjs")).toBe(0o755);
       expect(entryModes.get("package/package.json")).toBe(0o644);
-      const bytes = fs.readFileSync(tarball);
       const receipt = JSON.parse(fs.readFileSync(path.join(outputDir, "pack.json"), "utf8"));
       expect(receipt).toEqual([
         expect.objectContaining({


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where Docker and upgrade verification could fail while reading a package built on macOS. The canonical package normalizer included host extended attributes in the tarball, causing GNU tar to emit thousands of unknown-header warnings and exhaust the metadata reader's child-process buffer before the upgrade began.

## Why This Change Was Made

The existing `COPYFILE_DISABLE=1` disables AppleDouble sidecars, but BSD tar separately writes extended attributes into PAX headers. Pass `--no-xattrs` when creating the normalized archive and retain the AppleDouble protection. Both BSD tar and [GNU tar](https://www.gnu.org/software/tar/manual/html_chapter/operations.html) support this option.

Extend the existing real-package regression to inspect raw PAX header keys because node-tar drops unknown extended fields from parsed entries. The test continues to verify normalized modes and the final npm receipt's hashes and inventory. No consumer buffer increase, warning suppression, new dependency, or platform-specific fallback.

## User Impact

The canonical Docker package producer creates archives that Linux consumers can read without host xattr warnings. File contents, executable/readable modes, long paths, and archive receipt validation remain intact. This is internal package-verification tooling; there is no runtime configuration change.

Production LOC is unchanged (+2/-2); tests add 12 net lines.

## Evidence

- The extended real-package regression fails on the original producer with `LIBARCHIVE.xattr.com.apple.provenance` and `SCHILY.xattr.com.apple.provenance`, then passes with this change.
- Full package-producer test file: 50 passed, 3 existing skips. Changed-file checks and independent P0 autoreview passed.
- macOS BSD tar 3.5.3/libarchive 3.7.4 reproducer: `COPYFILE_DISABLE=1` still emits xattr PAX headers; adding `--no-xattrs` removes them while preserving regular/executable modes, a symlink, and a long path.
- Linux GNU tar 1.35 read both tiny archives with `tar -xOf ... package/package.json`. The original produced 759 stderr bytes; the fixed archive produced identical JSON with zero stderr bytes. Both commands exited 0.
- The actual patched canonical producer generated a retained fixture archive with no xattr headers, 0644 ordinary files, a 0755 executable, and its long filename intact. GNU tar 1.35 then read its package JSON and listed the archive; both commands exited 0 with zero stderr.
- Direct upstream contract inspection confirms [COPYFILE_DISABLE clears only the Mac copyfile flag](https://github.com/libarchive/libarchive/blob/v3.7.4/tar/bsdtar.c#L263), while [`--no-xattrs` disables the separate xattr path](https://github.com/libarchive/libarchive/blob/v3.7.4/tar/bsdtar.c#L597).
