### PR TITLE
fix: retain grep matches with fractional context

### DIFF
--- a/src/agents/sessions/tools/grep.ts
+++ b/src/agents/sessions/tools/grep.ts
@@ -7,6 +7,7 @@ import { readFileSync, statSync } from "node:fs";
 import path from "node:path";
 import { createInterface } from "node:readline";
 import { Text } from "@earendil-works/pi-tui";
+import { resolveNonNegativeIntegerOption } from "@openclaw/normalization-core/number-coercion";
 import { Type } from "typebox";
 import { releaseChildProcessOutputAfterExit } from "../../../process/child-process.js";
 import { spawnCommand } from "../../../process/exec.js";
@@ -224,7 +225,8 @@ export function createGrepToolDefinition(
               return;
             }
 
-            const contextValue = context && context > 0 ? context : 0;
+            // Fractional line indices would omit the matching row.
+            const contextValue = resolveNonNegativeIntegerOption(context, 0);
             const effectiveLimit = normalizePositiveLimit(limit, DEFAULT_LIMIT);
             const formatPath = (filePath: string): string => {
               if (isDirectory) {

--- a/src/agents/sessions/tools/index.test.ts
+++ b/src/agents/sessions/tools/index.test.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { validateToolArguments } from "@openclaw/llm-core/validation";
 import { afterEach, describe, expect, it } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../../../test/helpers/temp-dir.js";
+import { withEnvAsync } from "../../../test-utils/env.js";
 import type { AgentTool } from "../../runtime/index.js";
 import { ensureTool } from "../../utils/tools-manager.js";
 import {
@@ -161,70 +162,71 @@ describe("session tool factories", () => {
     { context: -1, expected: ["sample.txt:3: context needle"] },
   ])(
     "normalizes native grep context $context after argument validation",
-    async ({ context, expected }, { signal }) => {
-      const cwd = tempDirs.make("openclaw-tool-factories-grep-");
-      const filePath = path.join(cwd, "sample.txt");
-      await fs.writeFile(filePath, "first\nsecond\ncontext needle\nfourth\nfifth\n");
-      const rg = await ensureTool("rg", true);
-      signal.throwIfAborted();
-      if (!rg) {
-        throw new Error("Native grep fixture requires a working ripgrep executable");
-      }
+    ({ context, expected }, { signal }) =>
+      withEnvAsync({ OPENCLAW_OFFLINE: "1" }, async () => {
+        const cwd = tempDirs.make("openclaw-tool-factories-grep-");
+        const filePath = path.join(cwd, "sample.txt");
+        await fs.writeFile(filePath, "first\nsecond\ncontext needle\nfourth\nfifth\n");
+        const rg = await ensureTool("rg", true);
+        signal.throwIfAborted();
+        if (!rg) {
+          throw new Error("Native grep fixture requires a working ripgrep executable");
+        }
 
-      // A middle-line match exposes fractional indexing without boundary clamping.
-      const nativeOutput = execFileSync(
-        rg,
-        [
-          "--json",
-          "--line-number",
-          "--color=never",
-          "--fixed-strings",
-          "--",
-          "context needle",
-          filePath,
-        ],
-        { encoding: "utf8", timeout: 5_000, killSignal: "SIGKILL", maxBuffer: 1024 * 1024 },
-      );
-      const nativeEvents: unknown[] = nativeOutput
-        .trim()
-        .split("\n")
-        .map((line) => JSON.parse(line));
-      expect(nativeEvents).toContainEqual({
-        type: "match",
-        data: expect.objectContaining({
-          line_number: 3,
-          lines: { text: "context needle\n" },
-        }),
-      });
+        // A middle-line match exposes fractional indexing without boundary clamping.
+        const nativeOutput = execFileSync(
+          rg,
+          [
+            "--json",
+            "--line-number",
+            "--color=never",
+            "--fixed-strings",
+            "--",
+            "context needle",
+            filePath,
+          ],
+          { encoding: "utf8", timeout: 5_000, killSignal: "SIGKILL", maxBuffer: 1024 * 1024 },
+        );
+        const nativeEvents: unknown[] = nativeOutput
+          .trim()
+          .split("\n")
+          .map((line) => JSON.parse(line));
+        expect(nativeEvents).toContainEqual({
+          type: "match",
+          data: expect.objectContaining({
+            line_number: 3,
+            lines: { text: "context needle\n" },
+          }),
+        });
 
-      const tool = createTool("grep", cwd);
-      const args = {
-        pattern: "context needle",
-        path: "sample.txt",
-        literal: true,
-        ...(context === undefined ? {} : { context }),
-      };
-      const validated = validateToolArguments(tool, {
-        type: "toolCall",
-        id: "grep-context",
-        name: tool.name,
-        arguments: args,
-      });
-      expect(validated).toEqual(args);
-      const controller = new AbortController();
-      const execution = tool.execute(
-        "grep-context",
-        validated,
-        AbortSignal.any([signal, controller.signal]),
-      );
-      try {
-        const result = await execution;
-        expect(result.content).toEqual([{ type: "text", text: expected.join("\n") }]);
-        expect(result.details).toBeUndefined();
-      } finally {
-        controller.abort();
-        await Promise.allSettled([execution]);
-      }
-    },
+        const tool = createTool("grep", cwd);
+        const args = {
+          pattern: "context needle",
+          path: "sample.txt",
+          literal: true,
+          ...(context === undefined ? {} : { context }),
+        };
+        const validated = validateToolArguments(tool, {
+          type: "toolCall",
+          id: "grep-context",
+          name: tool.name,
+          arguments: args,
+        });
+        expect(validated).toEqual(args);
+        const controller = new AbortController();
+        const execution = tool.execute(
+          "grep-context",
+          validated,
+          AbortSignal.any([signal, controller.signal]),
+        );
+        try {
+          const result = await execution;
+          expect(result.content).toEqual([{ type: "text", text: expected.join("\n") }]);
+          expect(result.details).toBeUndefined();
+        } finally {
+          controller.abort();
+          await Promise.allSettled([execution]);
+        }
+      }),
   );
 });

--- a/src/agents/sessions/tools/index.test.ts
+++ b/src/agents/sessions/tools/index.test.ts
@@ -1,8 +1,11 @@
+import { execFileSync } from "node:child_process";
 import fs from "node:fs/promises";
 import path from "node:path";
+import { validateToolArguments } from "@openclaw/llm-core/validation";
 import { afterEach, describe, expect, it } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../../../test/helpers/temp-dir.js";
 import type { AgentTool } from "../../runtime/index.js";
+import { ensureTool } from "../../utils/tools-manager.js";
 import {
   allToolNames,
   createAllTools,
@@ -140,6 +143,88 @@ describe("session tool factories", () => {
       const listed = await requireTool(tools, "ls").execute("ls", {});
       expect(found.content).toEqual([{ type: "text", text: "remote.ts" }]);
       expect(listed.content).toEqual([{ type: "text", text: "remote.ts" }]);
+    },
+  );
+
+  it.for([
+    { context: undefined, expected: ["sample.txt:3: context needle"] },
+    { context: 0, expected: ["sample.txt:3: context needle"] },
+    {
+      context: 1,
+      expected: ["sample.txt-2- second", "sample.txt:3: context needle", "sample.txt-4- fourth"],
+    },
+    { context: 0.5, expected: ["sample.txt:3: context needle"] },
+    {
+      context: 1.5,
+      expected: ["sample.txt-2- second", "sample.txt:3: context needle", "sample.txt-4- fourth"],
+    },
+    { context: -1, expected: ["sample.txt:3: context needle"] },
+  ])(
+    "normalizes native grep context $context after argument validation",
+    async ({ context, expected }, { signal }) => {
+      const cwd = tempDirs.make("openclaw-tool-factories-grep-");
+      const filePath = path.join(cwd, "sample.txt");
+      await fs.writeFile(filePath, "first\nsecond\ncontext needle\nfourth\nfifth\n");
+      const rg = await ensureTool("rg", true);
+      signal.throwIfAborted();
+      if (!rg) {
+        throw new Error("Native grep fixture requires a working ripgrep executable");
+      }
+
+      // A middle-line match exposes fractional indexing without boundary clamping.
+      const nativeOutput = execFileSync(
+        rg,
+        [
+          "--json",
+          "--line-number",
+          "--color=never",
+          "--fixed-strings",
+          "--",
+          "context needle",
+          filePath,
+        ],
+        { encoding: "utf8", timeout: 5_000, killSignal: "SIGKILL", maxBuffer: 1024 * 1024 },
+      );
+      const nativeEvents: unknown[] = nativeOutput
+        .trim()
+        .split("\n")
+        .map((line) => JSON.parse(line));
+      expect(nativeEvents).toContainEqual({
+        type: "match",
+        data: expect.objectContaining({
+          line_number: 3,
+          lines: { text: "context needle\n" },
+        }),
+      });
+
+      const tool = createTool("grep", cwd);
+      const args = {
+        pattern: "context needle",
+        path: "sample.txt",
+        literal: true,
+        ...(context === undefined ? {} : { context }),
+      };
+      const validated = validateToolArguments(tool, {
+        type: "toolCall",
+        id: "grep-context",
+        name: tool.name,
+        arguments: args,
+      });
+      expect(validated).toEqual(args);
+      const controller = new AbortController();
+      const execution = tool.execute(
+        "grep-context",
+        validated,
+        AbortSignal.any([signal, controller.signal]),
+      );
+      try {
+        const result = await execution;
+        expect(result.content).toEqual([{ type: "text", text: expected.join("\n") }]);
+        expect(result.details).toBeUndefined();
+      } finally {
+        controller.abort();
+        await Promise.allSettled([execution]);
+      }
     },
   );
 });


### PR DESCRIPTION
Related: #105822

## What Problem This Solves

Fixes an issue where agents using the optional grep tool would receive blank fractional-numbered rows instead of the matching text when they requested a fractional context count, such as `0.5` or `1.5`.

## Why This Change Was Made

The registered schema accepts numeric context values, but the result formatter used them directly as array indices. Normalize the count once with the existing nonnegative-integer helper before constructing line ranges. This preserves the public Number schema and its existing omitted, zero, negative, and integer behavior instead of tightening validation or compensating in the output renderer. Limit normalization and the read, ls, and find contracts are unchanged.

Thanks @lzyyzznl for the earlier report and proposed repair in #105822. That inactive external PR was closed while awaiting real-behavior proof; this change takes the separately validated runtime-normalization approach and does not copy its schema-only test.

## User Impact

Grep searches with fractional context now retain the matching row and use the whole-number portion for surrounding lines. This affects sessions that enable grep; it does not add grep to the default tool set or change any configuration.

## Evidence

The regression extends the existing public factory test with six cases using a real file, the selected native ripgrep executable, and the registered argument validator. Before the fix, the two fractional cases returned blank fractional-index rows and failed the exact completed-content assertions; omitted, zero, one, and negative-one controls passed. The independent native JSON-match and unchanged-validated-arguments assertions passed before each failure.

The test now scopes the existing offline setting around each entire row with the existing environment helper. Both real tool-resolution calls remain, but a missing binary cannot invoke the downloader; it fails the fixture explicitly. This addresses the ClawSweeper finding and rank-up move without mocking ripgrep, skipping missing-dependency failures, or changing the runtime repair. The same corrected test was rerun against the original and fixed owner: two intended failures plus four controls before, then all six passing after, including the native/validation/content/details assertions. Both runs ended normally with verified process/group/stdio cleanup. The missing-binary branch was not separately executed; its no-download behavior follows the existing offline resolver contract.

This before/after proof is explicitly a local observation on macOS with Node24.20.0 and ripgrep15.2.0. The existing install has Vite8.2.1 rather than the target8.2.2, lacks the target runner throttle patch, and has other eager-import dependency drift; it is not target-lock CI or end-to-end Agent/Gateway proof. No dependency install, override, larger product timeout, mock result, or retry masks the failed assertions. A fresh full scoped Codex review of the final two-file candidate found no actionable P0–P2 findings. Separate supported Linux CI on the final head passed all 19 public-factory cases, including all six real native-ripgrep cases, with the exact reviewed source.

The production change is +3/-1: one canonical import, one invariant comment, and a replacement normalization expression. No parallel path or new helper is added. Tests: +87/-0.

Reviewed source: `51564fd27338970acda1caea677b93239dbbd3a8`. The test-only follow-up addresses the downloader finding. [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/33243010700) passed: 168 successful jobs, 17 skipped jobs, and the required CI gate green. [Focused hosted job](https://github.com/openclaw/openclaw/actions/runs/33243010700/job/99075593057) ran merge revision `126e540e8d2ca2c0f6f0054edd49e3e4c41cdb1b`, with runtime and test bytes identical to the reviewed head. The latest ClawSweeper review of that head reports no actionable findings.
