### PR TITLE
fix(browser): avoid unnecessary runtime loading for CLI commands

### DIFF
--- a/extensions/browser/src/browser-runtime.ts
+++ b/extensions/browser/src/browser-runtime.ts
@@ -37,13 +37,11 @@ export type {
   BrowserDeleteProfileResult,
   BrowserDoctorCheck,
   BrowserDoctorReport,
-  BrowserImportProfileResult,
   BrowserResetProfileResult,
   BrowserStatus,
   BrowserTab,
   BrowserTransport,
   ProfileStatus,
-  SystemProfileInfo,
   SnapshotResult,
 } from "./browser/client.js";
 export type { BrowserExecutable } from "./browser/chrome.executables.js";
@@ -61,11 +59,7 @@ export {
   resolveGoogleChromeExecutableForPlatform,
 } from "./browser/chrome.executables.js";
 export { redactCdpUrl } from "./browser/cdp.helpers.js";
-export {
-  DEFAULT_UPLOAD_DIR,
-  resolveExistingPathsWithinRoot,
-  resolveExistingUploadPaths,
-} from "./browser/paths.js";
+export { DEFAULT_UPLOAD_DIR, resolveExistingPathsWithinRoot } from "./browser/paths.js";
 export { getBrowserProfileCapabilities } from "./browser/profile-capabilities.js";
 export {
   isBrowserHostLocalRoute,

--- a/extensions/browser/src/cli/browser-cli-actions-input/register.files-downloads.test.ts
+++ b/extensions/browser/src/cli/browser-cli-actions-input/register.files-downloads.test.ts
@@ -1,6 +1,7 @@
 // Browser tests cover register.files downloads plugin behavior.
 import { Command } from "commander";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import * as browserPathsModule from "../../browser/paths.js";
 import * as browserCliSharedModule from "../browser-cli-shared.js";
 import {
   createBrowserProgram,
@@ -31,7 +32,7 @@ vi.spyOn(cliCoreApiModule.defaultRuntime, "writeJson").mockImplementation(
 );
 vi.spyOn(cliCoreApiModule.defaultRuntime, "error").mockImplementation(browserCliRuntime.error);
 vi.spyOn(cliCoreApiModule.defaultRuntime, "exit").mockImplementation(browserCliRuntime.exit);
-vi.spyOn(cliCoreApiModule, "resolveExistingUploadPaths").mockResolvedValue({
+vi.spyOn(browserPathsModule, "resolveExistingUploadPaths").mockResolvedValue({
   ok: true,
   paths: ["/tmp/openclaw/uploads/a.pdf", "/tmp/openclaw/uploads/b.pdf"],
 });
@@ -51,7 +52,7 @@ function getLastRequestOptions(): { timeoutMs?: number } | undefined {
 describe("browser action input file/download commands", () => {
   beforeEach(() => {
     mocks.callBrowserRequest.mockClear();
-    vi.mocked(cliCoreApiModule.resolveExistingUploadPaths).mockClear();
+    vi.mocked(browserPathsModule.resolveExistingUploadPaths).mockClear();
     getBrowserCliRuntimeCapture().resetRuntimeCapture();
     getBrowserCliRuntime().exit.mockImplementation(() => {});
   });
@@ -77,7 +78,7 @@ describe("browser action input file/download commands", () => {
       { from: "user" },
     );
 
-    expect(cliCoreApiModule.resolveExistingUploadPaths).toHaveBeenCalledWith({
+    expect(browserPathsModule.resolveExistingUploadPaths).toHaveBeenCalledWith({
       requestedPaths: ["/tmp/openclaw/uploads/a.pdf", "media://inbound/b"],
     });
     const request = mocks.callBrowserRequest.mock.calls.at(-1)?.[1] as

--- a/extensions/browser/src/cli/browser-cli-actions-input/register.files-downloads.ts
+++ b/extensions/browser/src/cli/browser-cli-actions-input/register.files-downloads.ts
@@ -3,6 +3,7 @@
  */
 import type { Command } from "commander";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { resolveExistingUploadPaths } from "../../browser/paths.js";
 import {
   BROWSER_TAB_REFERENCE_HELP,
   callBrowserRequest,
@@ -10,12 +11,7 @@ import {
   withBrowserActionTimeoutSlack,
   type BrowserParentOpts,
 } from "../browser-cli-shared.js";
-import {
-  danger,
-  defaultRuntime,
-  resolveExistingUploadPaths,
-  shortenHomePath,
-} from "../core-api.js";
+import { danger, defaultRuntime, shortenHomePath } from "../core-api.js";
 import { resolveBrowserActionContext } from "./shared.js";
 
 const DEFAULT_BROWSER_HOOK_TIMEOUT_MS = 120000;

--- a/extensions/browser/src/cli/browser-cli-actions-input/shared.ts
+++ b/extensions/browser/src/cli/browser-cli-actions-input/shared.ts
@@ -5,15 +5,13 @@ import fs from "node:fs/promises";
 import type { Command } from "commander";
 import { FsSafeError, readRegularFile } from "openclaw/plugin-sdk/security-runtime";
 import { resolveBrowserActRequestTimeoutMs } from "../../browser/act-policy.js";
-import type { BrowserActRequest } from "../../browser/client-actions.types.js";
-import { callBrowserRequest, type BrowserParentOpts } from "../browser-cli-shared.js";
+import type { BrowserActRequest, BrowserFormField } from "../../browser/client-actions.types.js";
 import {
-  danger,
-  defaultRuntime,
   normalizeBrowserFormField,
   normalizeBrowserFormFieldValue,
-  type BrowserFormField,
-} from "../core-api.js";
+} from "../../browser/form-fields.js";
+import { callBrowserRequest, type BrowserParentOpts } from "../browser-cli-shared.js";
+import { danger, defaultRuntime } from "../core-api.js";
 
 type BrowserActionContext = {
   parent: BrowserParentOpts;

--- a/extensions/browser/src/cli/browser-cli-cookie-sync.test.ts
+++ b/extensions/browser/src/cli/browser-cli-cookie-sync.test.ts
@@ -1,7 +1,6 @@
 import { Command } from "commander";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { createCliRuntimeCapture } from "../../test-support.js";
-import * as parentCoreApiModule from "../core-api.js";
 import * as cliCoreApiModule from "./core-api.js";
 
 const { defaultRuntime: runtime, resetRuntimeCapture } = createCliRuntimeCapture();
@@ -29,11 +28,9 @@ const systemProfileMocks = vi.hoisted(() => ({
   })),
 }));
 
-vi.mock("../sdk-node-runtime.js", async () => {
-  const actual =
-    await vi.importActual<typeof import("../sdk-node-runtime.js")>("../sdk-node-runtime.js");
-  return { ...actual, callGatewayFromCli: gatewayMocks.callGatewayFromCli };
-});
+vi.spyOn(cliCoreApiModule, "callGatewayFromCli").mockImplementation(
+  gatewayMocks.callGatewayFromCli,
+);
 
 vi.mock("../system-profile-api.js", () => ({
   assertSystemCookiePlatform: vi.fn(),
@@ -41,7 +38,7 @@ vi.mock("../system-profile-api.js", () => ({
   resolveSystemCookieSource: vi.fn(),
 }));
 
-vi.spyOn(parentCoreApiModule, "runCommandWithRuntime").mockImplementation(
+vi.spyOn(cliCoreApiModule, "runCommandWithRuntime").mockImplementation(
   async (_runtime, action, onError) => {
     try {
       await action();

--- a/extensions/browser/src/cli/browser-cli-extension.test.ts
+++ b/extensions/browser/src/cli/browser-cli-extension.test.ts
@@ -5,6 +5,20 @@ import type { installChromeExtensionBootstrap } from "../browser/extension-insta
 import { relayKeyIdFromHex } from "../browser/extension-relay/auth-v2-crypto.js";
 import * as cliCoreApiModule from "./core-api.js";
 
+// Metadata output must remain usable without loading browser or agent execution runtimes.
+vi.mock("../control-service.js", () => {
+  throw new Error("Browser extension CLI must not load browser control services");
+});
+vi.mock("openclaw/plugin-sdk/agent-harness-runtime", () => {
+  throw new Error("Browser extension CLI must not load agent runtime");
+});
+vi.mock("openclaw/plugin-sdk/media-runtime", () => {
+  throw new Error("Browser extension CLI must not load media runtime");
+});
+vi.mock("openclaw/plugin-sdk/media-understanding-runtime", () => {
+  throw new Error("Browser extension CLI must not load media understanding runtime");
+});
+
 const relayMocks = vi.hoisted(() => {
   let relayKey = "";
   for (let byteIndex = 0; byteIndex < 32; byteIndex += 1) {
@@ -240,28 +254,38 @@ describe("browser extension pairing Gateway URL", () => {
     });
   });
 
-  it("prints only safe v2 relay metadata via cdp --json", async () => {
-    vi.spyOn(cliCoreApiModule, "getRuntimeConfig").mockReturnValue({});
+  it.each([
+    { label: "default", config: {}, port: 18799 },
+    {
+      label: "configured",
+      config: {
+        browser: {
+          profiles: { custom: { driver: "extension" as const, cdpPort: 21117, color: "#00AA00" } },
+        },
+      },
+      port: 21117,
+    },
+  ])("prints safe $label v2 metadata through the lazy root CLI", async ({ config, port }) => {
+    vi.spyOn(cliCoreApiModule, "getRuntimeConfig").mockReturnValue(config);
     const logSpy = vi.spyOn(cliCoreApiModule.defaultRuntime, "log").mockImplementation(runtime.log);
     const writeJsonSpy = vi
       .spyOn(cliCoreApiModule.defaultRuntime, "writeJson")
       .mockImplementation(runtime.writeJson);
-    const { registerBrowserExtensionCommands } = await import("./browser-cli-extension.js");
+    const { registerBrowserCli } = await import("./browser-cli.js");
     const program = new Command();
-    const browser = program.command("browser");
-    registerBrowserExtensionCommands(browser, () => ({}));
+    registerBrowserCli(program, ["node", "openclaw", "browser", "extension", "cdp", "--json"]);
 
     await program.parseAsync(["browser", "extension", "cdp", "--json"], { from: "user" });
 
     expect(writeJsonSpy).toHaveBeenCalledWith({
-      browserUrl: "http://127.0.0.1:18799",
-      wsEndpoint: "ws://127.0.0.1:18799/cdp",
+      browserUrl: `http://127.0.0.1:${port}`,
+      wsEndpoint: `ws://127.0.0.1:${port}/cdp`,
       auth: {
         label: "openclaw.browser-relay.auth",
         version: 2,
         keyId: relayKeyIdFromHex(relayMocks.relayKey),
-        challengeUrl: "http://127.0.0.1:18799/_openclaw/relay/auth/v2/challenge",
-        completeUrl: "http://127.0.0.1:18799/_openclaw/relay/auth/v2/complete",
+        challengeUrl: `http://127.0.0.1:${port}/_openclaw/relay/auth/v2/challenge`,
+        completeUrl: `http://127.0.0.1:${port}/_openclaw/relay/auth/v2/complete`,
         role: "cdp",
         transport: "connection",
         method: "SEQUENCE",

--- a/extensions/browser/src/cli/browser-cli-extension.ts
+++ b/extensions/browser/src/cli/browser-cli-extension.ts
@@ -5,6 +5,7 @@
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import type { Command } from "commander";
+import { resolveBrowserConfig } from "../browser/config.js";
 import {
   browserExtensionStatus,
   FOUNDATION_CHROME_WEB_STORE_URL,
@@ -30,7 +31,6 @@ import {
   defaultRuntime,
   getRuntimeConfig,
   info,
-  resolveBrowserConfig,
   runCommandWithRuntime,
   theme,
 } from "./core-api.js";

--- a/extensions/browser/src/cli/browser-cli-inspect.test.ts
+++ b/extensions/browser/src/cli/browser-cli-inspect.test.ts
@@ -11,33 +11,9 @@ import * as cliCoreApiModule from "./core-api.js";
 
 const { defaultRuntime: runtime, resetRuntimeCapture } = createCliRuntimeCapture();
 
-const gatewayMocks = vi.hoisted(() => ({
-  callGatewayFromCli: vi.fn(async () => ({
-    ok: true,
-    format: "ai",
-    targetId: "t1",
-    url: "https://example.com",
-    snapshot: "ok",
-  })),
+const configMocks = vi.hoisted(() => ({
+  getRuntimeConfig: vi.fn(() => ({ browser: {} })),
 }));
-
-vi.mock("../sdk-node-runtime.js", async () => {
-  const actual =
-    await vi.importActual<typeof import("../sdk-node-runtime.js")>("../sdk-node-runtime.js");
-  return {
-    ...actual,
-    callGatewayFromCli: gatewayMocks.callGatewayFromCli,
-  };
-});
-
-const configMocks = vi.hoisted(() => {
-  const loadConfig = vi.fn(() => ({ browser: {} }));
-  return {
-    getRuntimeConfig: loadConfig,
-    loadConfig,
-  };
-});
-vi.mock("../config/config.js", () => configMocks);
 
 const sharedMocks = vi.hoisted(() => ({
   callBrowserRequest: vi.fn(
@@ -84,7 +60,7 @@ function installInspectSpies() {
     vi
       .spyOn(browserCliSharedModule, "callBrowserRequest")
       .mockImplementation(sharedMocks.callBrowserRequest),
-    vi.spyOn(cliCoreApiModule, "getRuntimeConfig").mockImplementation(configMocks.loadConfig),
+    vi.spyOn(cliCoreApiModule, "getRuntimeConfig").mockImplementation(configMocks.getRuntimeConfig),
     vi.spyOn(cliCoreApiModule.defaultRuntime, "log").mockImplementation(runtime.log),
     vi.spyOn(cliCoreApiModule.defaultRuntime, "writeJson").mockImplementation(runtime.writeJson),
     vi.spyOn(cliCoreApiModule.defaultRuntime, "error").mockImplementation(runtime.error),
@@ -123,7 +99,7 @@ describe("browser cli snapshot defaults", () => {
     vi.clearAllMocks();
     restoreInspectSpies();
     resetRuntimeCapture();
-    configMocks.loadConfig.mockReturnValue({ browser: {} });
+    configMocks.getRuntimeConfig.mockReturnValue({ browser: {} });
   });
 
   it.each([
@@ -226,19 +202,9 @@ describe("browser cli snapshot defaults", () => {
       expectMode: undefined,
     },
   ])("$label", async ({ args, expectMode }) => {
-    configMocks.loadConfig.mockReturnValue({
+    configMocks.getRuntimeConfig.mockReturnValue({
       browser: { snapshotDefaults: { mode: "efficient" } },
     });
-
-    if (args.includes("--format") && args.includes("aria")) {
-      gatewayMocks.callGatewayFromCli.mockResolvedValueOnce({
-        ok: true,
-        format: "aria",
-        targetId: "t1",
-        url: "https://example.com",
-        snapshot: "ok",
-      });
-    }
 
     const params = await runSnapshot(args);
     expect(params?.path).toBe("/snapshot");
@@ -251,13 +217,13 @@ describe("browser cli snapshot defaults", () => {
   });
 
   it("does not set mode when config defaults are absent", async () => {
-    configMocks.loadConfig.mockReturnValue({ browser: {} });
+    configMocks.getRuntimeConfig.mockReturnValue({ browser: {} });
     const params = await runSnapshot([]);
     expect((params?.query as { mode?: unknown } | undefined)?.mode).toBeUndefined();
   });
 
   it("applies explicit efficient mode without config defaults", async () => {
-    configMocks.loadConfig.mockReturnValue({ browser: {} });
+    configMocks.getRuntimeConfig.mockReturnValue({ browser: {} });
     const params = await runSnapshot(["--efficient"]);
     expect(params?.query?.format).toBe("ai");
     expect(params?.query?.mode).toBe("efficient");

--- a/extensions/browser/src/cli/browser-cli-inspect.ts
+++ b/extensions/browser/src/cli/browser-cli-inspect.ts
@@ -5,6 +5,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import type { Command } from "commander";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
+import type { SnapshotResult } from "../browser/client.js";
 import { writeExternalFileWithinOutputRoot } from "../browser/output-files.js";
 import {
   BROWSER_TAB_REFERENCE_HELP,
@@ -20,7 +21,6 @@ import {
   getRuntimeConfig,
   inheritOptionFromParent,
   shortenHomePath,
-  type SnapshotResult,
 } from "./core-api.js";
 
 function parseOptionalIntegerOption(

--- a/extensions/browser/src/cli/browser-cli-manage.test-helpers.ts
+++ b/extensions/browser/src/cli/browser-cli-manage.test-helpers.ts
@@ -3,7 +3,6 @@
  */
 import type { Command } from "commander";
 import { vi } from "vitest";
-import * as parentCoreApiModule from "../core-api.js";
 import * as browserCliSharedModule from "./browser-cli-shared.js";
 import * as cliCoreApiModule from "./core-api.js";
 
@@ -46,7 +45,7 @@ const browserManageMocks = vi.hoisted(() => ({
 vi.spyOn(browserCliSharedModule, "callBrowserRequest").mockImplementation(
   browserManageMocks.callBrowserRequest,
 );
-vi.spyOn(parentCoreApiModule, "runCommandWithRuntime").mockImplementation(
+vi.spyOn(cliCoreApiModule, "runCommandWithRuntime").mockImplementation(
   async (_runtime, action, onError) => {
     try {
       await action();

--- a/extensions/browser/src/cli/browser-cli-manage.ts
+++ b/extensions/browser/src/cli/browser-cli-manage.ts
@@ -3,7 +3,19 @@
  * checks.
  */
 import type { Command } from "commander";
+import { redactCdpUrl } from "openclaw/plugin-sdk/browser-cdp";
 import { formatBrowserGraphicsSummary } from "../browser/chrome.graphics.js";
+import type {
+  BrowserCreateProfileResult,
+  BrowserDeleteProfileResult,
+  BrowserImportProfileResult,
+  BrowserResetProfileResult,
+  BrowserStatus,
+  BrowserTab,
+  BrowserTransport,
+  ProfileStatus,
+  SystemProfileInfo,
+} from "../browser/client.js";
 import type { BrowserDoctorReport } from "../browser/doctor.js";
 import {
   BROWSER_TAB_REFERENCE_HELP,
@@ -14,22 +26,7 @@ import {
   runBrowserCliCommand as runBrowserCommand,
   type BrowserParentOpts,
 } from "./browser-cli-shared.js";
-import {
-  danger,
-  defaultRuntime,
-  info,
-  redactCdpUrl,
-  shortenHomePath,
-  type BrowserCreateProfileResult,
-  type BrowserDeleteProfileResult,
-  type BrowserImportProfileResult,
-  type BrowserResetProfileResult,
-  type BrowserStatus,
-  type BrowserTab,
-  type BrowserTransport,
-  type ProfileStatus,
-  type SystemProfileInfo,
-} from "./core-api.js";
+import { danger, defaultRuntime, info, shortenHomePath } from "./core-api.js";
 
 const BROWSER_MANAGE_REQUEST_TIMEOUT_MS = 45_000;
 

--- a/extensions/browser/src/cli/browser-cli-shared.ts
+++ b/extensions/browser/src/cli/browser-cli-shared.ts
@@ -12,8 +12,13 @@ import {
 } from "../browser-gateway-contract.js";
 import { BROWSER_ACTION_TRANSPORT_SLACK_MS } from "../browser/act-policy.js";
 import { normalizeBrowserTimerDelayMs } from "../browser/timer-delay.js";
-import { danger, defaultRuntime, runCommandWithRuntime } from "../core-api.js";
-import { callGatewayFromCli, type GatewayRpcOpts } from "./core-api.js";
+import {
+  callGatewayFromCli,
+  danger,
+  defaultRuntime,
+  runCommandWithRuntime,
+  type GatewayRpcOpts,
+} from "./core-api.js";
 
 /** Parent Browser CLI options inherited by subcommands. */
 export type BrowserParentOpts = GatewayRpcOpts & {

--- a/extensions/browser/src/cli/browser-cli-state.option-collisions.test.ts
+++ b/extensions/browser/src/cli/browser-cli-state.option-collisions.test.ts
@@ -1,6 +1,5 @@
 // Browser tests cover browser cli state.option collisions plugin behavior.
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import * as parentCoreApiModule from "../core-api.js";
 import * as browserCliResizeModule from "./browser-cli-resize.js";
 import * as browserCliSharedModule from "./browser-cli-shared.js";
 import * as cliCoreApiModule from "./core-api.js";
@@ -15,7 +14,7 @@ vi.spyOn(browserCliSharedModule, "callBrowserRequest").mockImplementation(mocks.
 vi.spyOn(browserCliResizeModule, "runBrowserResizeWithOutput").mockImplementation(
   mocks.runBrowserResizeWithOutput,
 );
-vi.spyOn(parentCoreApiModule, "runCommandWithRuntime").mockImplementation(
+vi.spyOn(cliCoreApiModule, "runCommandWithRuntime").mockImplementation(
   async (_runtime, action, onError) => {
     try {
       await action();

--- a/extensions/browser/src/cli/browser-cli.test.ts
+++ b/extensions/browser/src/cli/browser-cli.test.ts
@@ -1,6 +1,72 @@
 // Browser tests cover browser cli plugin behavior.
 import { Command } from "commander";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("../control-service.js", () => {
+  throw new Error("Browser CLI registration must not load browser control services");
+});
+vi.mock("openclaw/plugin-sdk/agent-harness-runtime", () => {
+  throw new Error("Browser CLI registration must not load agent runtime");
+});
+vi.mock("openclaw/plugin-sdk/media-understanding-runtime", () => {
+  throw new Error("Browser CLI registration must not load media understanding runtime");
+});
+vi.mock("openclaw/plugin-sdk/media-runtime", () => {
+  throw new Error("Browser CLI registration must not load media runtime");
+});
+
+describe("Browser CLI import boundary", () => {
+  it("registers root help without loading browser services or agent/media runtime", async () => {
+    const { registerBrowserCli } = await import("./browser-cli.js");
+    const program = new Command();
+    registerBrowserCli(program, ["node", "openclaw", "browser", "--help"]);
+    const browser = program.commands[0];
+    expect(browser?.helpInformation()).toContain("--browser-profile");
+    expect(browser?.commands.map((command) => command.name())).toContain("extension");
+  });
+
+  it("registers extension leaves without loading browser services or agent/media runtime", async () => {
+    const { registerBrowserExtensionCommands } = await import("./browser-cli-extension.js");
+    const program = new Command();
+    const browser = program.command("browser");
+    registerBrowserExtensionCommands(browser, () => ({}));
+    expect(browser.commands[0]?.commands.map((command) => command.name())).toEqual([
+      "path",
+      "install",
+      "status",
+      "uninstall-host",
+      "pair",
+      "cdp",
+    ]);
+  });
+
+  it("registers Gateway-backed command siblings without loading local browser services", async () => {
+    const { registerBrowserManageCommands } = await import("./browser-cli-manage.js");
+    const { registerBrowserInspectCommands } = await import("./browser-cli-inspect.js");
+    const { registerBrowserStateCommands } = await import("./browser-cli-state.js");
+    const program = new Command();
+    const browser = program.command("browser");
+    for (const register of [
+      registerBrowserManageCommands,
+      registerBrowserInspectCommands,
+      registerBrowserStateCommands,
+    ]) {
+      register(browser, () => ({}));
+    }
+    expect(browser.commands.map((command) => command.name())).toEqual(
+      expect.arrayContaining([
+        "start",
+        "doctor",
+        "import-profile",
+        "snapshot",
+        "screenshot",
+        "cookies",
+        "storage",
+        "set",
+      ]),
+    );
+  });
+});
 
 function runBrowserStatus(argv: string[]) {
   const program = new Command();

--- a/extensions/browser/src/cli/core-api.ts
+++ b/extensions/browser/src/cli/core-api.ts
@@ -1,4 +1,20 @@
 /**
- * Browser CLI-facing barrel for shared OpenClaw core APIs.
+ * Shared CLI helpers only; Browser runtime imports belong to the lazy command leaves.
  */
-export * from "../core-api.js";
+export {
+  formatCliCommand,
+  formatHelpExamples,
+  inheritOptionFromParent,
+  runCommandWithRuntime,
+  theme,
+} from "openclaw/plugin-sdk/cli-runtime";
+export {
+  addGatewayClientOptions,
+  callGatewayFromCli,
+  type GatewayRpcOpts,
+} from "openclaw/plugin-sdk/gateway-runtime";
+export { getRuntimeConfig } from "openclaw/plugin-sdk/runtime-config-snapshot";
+export { danger, defaultRuntime, info } from "openclaw/plugin-sdk/runtime-env";
+export { formatDocsLink } from "openclaw/plugin-sdk/setup-tools";
+export { parseBooleanValue } from "openclaw/plugin-sdk/string-coerce-runtime";
+export { shortenHomePath } from "openclaw/plugin-sdk/text-utility-runtime";

--- a/extensions/browser/src/core-api.ts
+++ b/extensions/browser/src/core-api.ts
@@ -1,5 +1,5 @@
 /**
- * Browser plugin internal barrel that gathers runtime, SDK, CLI, and gateway
+ * Browser plugin internal barrel that gathers runtime, SDK, and gateway
  * APIs for modules that need a stable local import surface.
  */
 export {
@@ -7,49 +7,18 @@ export {
   createBrowserRouteDispatcher,
   isBrowserHostLocalRoute,
   isPersistentBrowserProfileMutation,
-  normalizeBrowserFormField,
-  normalizeBrowserFormFieldValue,
-  redactCdpUrl,
-  resolveBrowserConfig,
-  resolveExistingUploadPaths,
   resolveRequestedBrowserProfile,
   startBrowserControlServiceFromConfig,
 } from "./browser-runtime.js";
 export { persistBrowserProxyResultFiles } from "./browser/proxy-files.js";
-export type {
-  BrowserCreateProfileResult,
-  BrowserDeleteProfileResult,
-  BrowserImportProfileResult,
-  BrowserFormField,
-  BrowserResetProfileResult,
-  BrowserStatus,
-  BrowserTab,
-  BrowserTransport,
-  ProfileStatus,
-  SystemProfileInfo,
-  SnapshotResult,
-} from "./browser-runtime.js";
+export { getRuntimeConfig } from "./sdk-config.js";
 export {
-  danger,
-  formatCliCommand,
-  formatDocsLink,
-  formatHelpExamples,
-  inheritOptionFromParent,
-  info,
-  theme,
-} from "./sdk-setup-tools.js";
-export { getRuntimeConfig, parseBooleanValue, shortenHomePath } from "./sdk-config.js";
-export {
-  addGatewayClientOptions,
-  callGatewayFromCli,
-  defaultRuntime,
   ErrorCodes,
   errorShape,
   isNodeCommandAllowed,
   respondUnavailableOnNodeInvokeError,
   resolveNodeCommandAllowlist,
-  runCommandWithRuntime,
   safeParseJson,
   withTimeout,
 } from "./sdk-node-runtime.js";
-export type { GatewayRequestHandlers, GatewayRpcOpts, NodeSession } from "./sdk-node-runtime.js";
+export type { GatewayRequestHandlers, NodeSession } from "./sdk-node-runtime.js";

--- a/extensions/browser/src/sdk-config.ts
+++ b/extensions/browser/src/sdk-config.ts
@@ -1,8 +1,6 @@
 /**
  * Browser-local SDK config bridge.
  */
-import { parseBooleanValue } from "openclaw/plugin-sdk/string-coerce-runtime";
-
 export {
   getRuntimeConfig,
   getRuntimeConfigSourceSnapshot,
@@ -17,7 +15,4 @@ export {
   CONFIG_DIR,
   escapeRegExp,
   resolveUserPath,
-  shortenHomePath,
 } from "openclaw/plugin-sdk/text-utility-runtime";
-/** Parses common string booleans with optional custom truthy/falsy tokens. */
-export { parseBooleanValue };

--- a/extensions/browser/src/sdk-node-runtime.ts
+++ b/extensions/browser/src/sdk-node-runtime.ts
@@ -1,13 +1,10 @@
 /**
- * Browser-local SDK bridge for gateway, plugin runtime, CLI runtime, and timeout
- * helpers.
+ * Browser-local SDK bridge for gateway, plugin runtime, and timeout helpers.
  */
 import { toErrorObject } from "openclaw/plugin-sdk/error-runtime";
 import { clampTimerTimeoutMs } from "openclaw/plugin-sdk/number-runtime";
 
 export {
-  addGatewayClientOptions,
-  callGatewayFromCli,
   ensureGatewayStartupAuth,
   ErrorCodes,
   errorShape,
@@ -18,18 +15,12 @@ export {
   resolveNodeCommandAllowlist,
   safeParseJson,
 } from "openclaw/plugin-sdk/gateway-runtime";
-export type {
-  GatewayRequestHandlers,
-  GatewayRpcOpts,
-  NodeSession,
-} from "openclaw/plugin-sdk/gateway-runtime";
-export { runCommandWithRuntime } from "openclaw/plugin-sdk/cli-runtime";
+export type { GatewayRequestHandlers, NodeSession } from "openclaw/plugin-sdk/gateway-runtime";
 export type { OpenClawPluginService } from "openclaw/plugin-sdk/plugin-entry";
 export {
   startLazyPluginServiceModule,
   type LazyPluginServiceHandle,
 } from "openclaw/plugin-sdk/plugin-runtime";
-export { defaultRuntime } from "openclaw/plugin-sdk/runtime-env";
 
 function normalizeTimeoutMs(timeoutMs: number | undefined): number | undefined {
   return clampTimerTimeoutMs(timeoutMs);

--- a/extensions/browser/src/sdk-setup-tools.ts
+++ b/extensions/browser/src/sdk-setup-tools.ts
@@ -13,14 +13,7 @@ export {
   readPositiveIntegerParam,
   readStringParam,
 } from "openclaw/plugin-sdk/channel-actions";
-export {
-  formatCliCommand,
-  formatHelpExamples,
-  inheritOptionFromParent,
-  note,
-  theme,
-} from "openclaw/plugin-sdk/cli-runtime";
-export { danger, info } from "openclaw/plugin-sdk/runtime-env";
+export { formatCliCommand, note } from "openclaw/plugin-sdk/cli-runtime";
 export {
   IMAGE_REDUCE_QUALITY_STEPS,
   buildImageResizeSideGrid,
@@ -31,4 +24,3 @@ export {
 export { detectMime } from "openclaw/plugin-sdk/media-mime";
 export { ensureMediaDir, saveMediaBuffer } from "openclaw/plugin-sdk/media-runtime";
 export { describeImageFile } from "openclaw/plugin-sdk/media-understanding-runtime";
-export { formatDocsLink } from "openclaw/plugin-sdk/setup-tools";


### PR DESCRIPTION
Related: [generic CLI startup preparation](https://github.com/openclaw/openclaw/pull/131503). This is the independent Browser CLI import-boundary cut; the [iMessage Doctor split](https://github.com/openclaw/openclaw/pull/132435) is already landed. Native relay changes are not included.

## What Problem This Solves

Fixes unnecessary runtime loading while registering Browser CLI command groups. Read-only commands such as `browser extension path`, as well as commands that dispatch to a Gateway, should not require local Browser control services, the agent harness, or media execution modules just to register their CLI handlers.

## Why This Change Was Made

The command groups were already lazy, but their shared private barrel forwarded the full Browser runtime and SDK setup/media graph back into registration. Replace that wildcard path with named exports from existing SDK entrypoints, and import Browser-specific config, upload and form helpers only in the lazy groups that use them.

Remove the obsolete private forwarding exports rather than preserve aliases. Keep client/result imports type-only and use the existing CDP redactor directly from its owning SDK module, not through Browser config/auth helpers. Public `runtime-api.ts` and command behavior remain unchanged, including request scopes and payloads, timeout precedence, output/error handling, URL redaction, upload containment, form coercion and cookie allowlists. There are no configuration, schema, dependency, permission or protocol changes.

## User Impact

Browser CLI registration no longer pulls in unrelated execution runtimes through its shared barrel. The existing lazy command groups and public API remain available. This does not change native relay authentication, Chrome installation/pairing, browser actions, or user profiles, and it is not a five-second startup guarantee.

## Evidence

AI-assisted; implementation and independent Codex review were checked against the actual entrypoints, owners, SDK exports and installed Commander 15 contracts.

- Baseline: 266 owner tests passed across 19 files. Three new registrar tests then failed on the intended agent-runtime import before production changes, and the same three passed after extraction.
- Final owner selection: 270 tests passed across 19 files. Four CLI configuration/metadata lifetime, authority and late-alias sibling suites passed 54 tests. Existing `snapshot --limit 1e3` rejection before dispatch remains covered.
- The complete changed-file gate passed on the final source, including types, lint, formatting, declaration/closure guards, dead exports and import cycles. The first gate correctly found a leftover private `parseBooleanValue` forward; it was deleted and the full gate rerun, not suppressed.
- Fresh isolated pre-commit Codex review: scoped-clean at P0, no findings.
- Fresh full `pnpm build` passed all 15 phases with no ineffective dynamic imports. Canonical packaging and a normal lifecycle-enabled npm installation passed on `fad648df83852acc7a66b0a1fef512a0a580c3a7`.
- The first built CLI child was `browser extension path` (1.85s, exit 0); the first installed CLI child was the same action (2.39s, exit 0), each in fresh synthetic state without an installed extension copy or prior help/native warmup. Both returned the actual bundled directory and verified manifest.
- Each path check was followed by `browser --url <owned-loopback-tripwire> snapshot --limit 1e3`: expected exit 1 and exact validation error, with zero connections. Built/installed times were 1.19s/1.28s. All four children retained the original 30,000ms budget; installation retained 900s.
- Tarball hashes, size, inventory and modes matched npm's receipt; all 11,065 expected installed files matched the archive byte-for-byte, with only the documented install guard removed. All 37 selected CLI/manifest/asset hashes matched across build, archive and installation. These are observed single-run action times, not a comparative benchmark or a general five-second guarantee.
- [Exact-head hosted CI](https://github.com/openclaw/openclaw/actions/runs/33241904336) passed on `fad648df83852acc7a66b0a1fef512a0a580c3a7`: 41 successful jobs, 18 intentionally skipped, no failed or pending jobs.

Artifact identity: build ID `2026.8.1-fad648df8385-2026-08-29T07-35-15.120Z`; tarball SHA-256 `bfcd00253c9a93453815999df49ec0e93a39787eeef054ac2e605a75f49fb366`; extension manifest SHA-256 `2edfb18bbf168c7b8ebb5e146e757699d53a2a4c0cadd32199e411dbd12ad7ad`.

Audit notes: an initial supplementary verifier counted only regular tar files, while npm's `getContents` includes directories too. Inspection of npm's implementation and corrected verification of the unchanged archive confirmed 11,066 files plus 249 directories; no repack or installation retry occurred. The final audit wrapper also flagged raw Git index-byte drift. The parent independently checked every staged path/mode/object/stage and all 35,012 tracked file contents/modes against the starting snapshot, plus source/commit/artifact hashes: all matched. Git index bytes also include stat/cache/extension metadata, so this did not invalidate source identity. The index writer remains unattributed, and both original audit failures are retained rather than rewritten as passes. All canonical execution phases passed.

Source commands:

```bash
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs extensions/browser/src/cli extensions/browser/src/browser/paths.test.ts extensions/browser/index.test.ts
```

```bash
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/plugins/cli-config-lifetime.test.ts src/plugins/cli-metadata-lifetime.test.ts src/plugins/cli-metadata-authority.test.ts src/plugins/loader.lazy-alias.test.ts
```

Production LOC: **+53/-100 (net -47)**. Tests/support: **+117/-65 (net +52)**. The SDK config bridge preserves the port/config narrowing already on main; those earlier deletions are not counted here. No new cache, SDK surface, compatibility path, test-only production seam or baseline exception was introduced.

Proof boundaries: source registration tests exercise real registrars with forbidden runtime imports; command behavior tests retain real Commander parsing. Fresh artifact acceptance must start with `browser extension path` in isolated state, without native/help warmup, and reject invalid snapshot input without reaching a real Gateway. No operator Chrome, Gateway, native registrations, credentials or profiles are used. No visual/UI behavior changed.

The maintainer-owned [Windows full-plugin entrypoint PR](https://github.com/openclaw/openclaw/pull/127035) targets different files and carries separate native-Windows proof requirements. It is not being adopted, closed, or represented as proven by this CLI-barrel change.
