### PR TITLE
fix(gateway): bind plugin agent dispatch to the owning runtime

### DIFF
--- a/src/agents/subagents/announce/subagent-announce.live.test.ts
+++ b/src/agents/subagents/announce/subagent-announce.live.test.ts
@@ -7,7 +7,8 @@ import { toErrorObject as toLintErrorObject } from "@openclaw/normalization-core
 import { afterEach, describe, expect, it } from "vitest";
 import { clearRuntimeConfigSnapshot, type OpenClawConfig } from "../../../config/config.js";
 import { callGateway as realCallGateway } from "../../../gateway/call.js";
-import { GatewayClient } from "../../../gateway/client.js";
+import type { GatewayClient } from "../../../gateway/client.js";
+import { connectTestGatewayClient } from "../../../gateway/gateway-cli-backend.live-helpers.js";
 import { dispatchGatewayMethodInProcess as realDispatchGatewayMethodInProcess } from "../../../gateway/server-plugins.js";
 import { startGatewayServer, type GatewayServer } from "../../../gateway/server.js";
 import { extractPayloadText } from "../../../gateway/test-helpers.agent-results.js";
@@ -18,7 +19,6 @@ import {
   createOpenClawTestState,
   type OpenClawTestState,
 } from "../../../test-utils/openclaw-test-state.js";
-import { GATEWAY_CLIENT_MODES, GATEWAY_CLIENT_NAMES } from "../../../utils/message-channel.js";
 import { isLiveTestEnabled, readLiveTestConfig } from "../../live-test-helpers.js";
 import {
   resolveSubagentController,
@@ -228,20 +228,11 @@ function createGatewayClient(params: {
   token: string;
   onEvent?: ConstructorParameters<typeof GatewayClient>[0]["onEvent"];
 }): Promise<GatewayClient> {
-  return new Promise((resolve, reject) => {
-    const client = new GatewayClient({
-      url: `ws://127.0.0.1:${params.port}`,
-      token: params.token,
-      deviceIdentity: null,
-      clientName: GATEWAY_CLIENT_NAMES.GATEWAY_CLIENT,
-      mode: GATEWAY_CLIENT_MODES.BACKEND,
-      scopes: ["operator.admin"],
-      requestTimeoutMs: REQUEST_TIMEOUT_MS,
-      onEvent: params.onEvent,
-      onHelloOk: () => resolve(client),
-      onConnectError: reject,
-    });
-    client.start();
+  return connectTestGatewayClient({
+    url: `ws://127.0.0.1:${params.port}`,
+    token: params.token,
+    requestTimeoutMs: REQUEST_TIMEOUT_MS,
+    onEvent: params.onEvent,
   });
 }
 
@@ -294,7 +285,7 @@ describeLive("subagent announce live", () => {
           OPENCLAW_SKIP_CRON: "1",
           OPENCLAW_SKIP_BROWSER_CONTROL_SERVER: "1",
           OPENCLAW_SKIP_CANVAS_HOST: "1",
-          OPENCLAW_TEST_MINIMAL_GATEWAY: "1",
+          OPENCLAW_TEST_MINIMAL_GATEWAY: undefined,
           OPENCLAW_DISABLE_BUNDLED_PLUGINS: undefined,
           OPENCLAW_BUNDLED_PLUGINS_DIR: path.resolve("extensions"),
           OPENCLAW_TEST_TRUST_BUNDLED_PLUGINS_DIR: "1",
@@ -316,6 +307,7 @@ describeLive("subagent announce live", () => {
         auth: { mode: "token", token },
         controlUiEnabled: false,
       });
+      await server.startupSettled;
       client = await createGatewayClient({ port, token });
 
       let initialError: unknown;
@@ -487,7 +479,7 @@ describeLive("subagent announce live", () => {
           OPENCLAW_SKIP_CRON: "1",
           OPENCLAW_SKIP_BROWSER_CONTROL_SERVER: "1",
           OPENCLAW_SKIP_CANVAS_HOST: "1",
-          OPENCLAW_TEST_MINIMAL_GATEWAY: "1",
+          OPENCLAW_TEST_MINIMAL_GATEWAY: undefined,
           OPENCLAW_DISABLE_BUNDLED_PLUGINS: undefined,
           OPENCLAW_BUNDLED_PLUGINS_DIR: path.resolve("extensions"),
           OPENCLAW_TEST_TRUST_BUNDLED_PLUGINS_DIR: "1",
@@ -508,6 +500,7 @@ describeLive("subagent announce live", () => {
         auth: { mode: "token", token },
         controlUiEnabled: false,
       });
+      await server.startupSettled;
       client = await createGatewayClient({ port, token });
 
       let initialError: unknown;
@@ -682,7 +675,7 @@ describeLive("subagent announce live", () => {
           OPENCLAW_SKIP_CRON: "1",
           OPENCLAW_SKIP_BROWSER_CONTROL_SERVER: "1",
           OPENCLAW_SKIP_CANVAS_HOST: "1",
-          OPENCLAW_TEST_MINIMAL_GATEWAY: "1",
+          OPENCLAW_TEST_MINIMAL_GATEWAY: undefined,
           OPENCLAW_DISABLE_BUNDLED_PLUGINS: undefined,
           OPENCLAW_BUNDLED_PLUGINS_DIR: path.resolve("extensions"),
           OPENCLAW_TEST_TRUST_BUNDLED_PLUGINS_DIR: "1",
@@ -724,6 +717,7 @@ describeLive("subagent announce live", () => {
         auth: { mode: "token", token },
         controlUiEnabled: false,
       });
+      await server.startupSettled;
       client = await createGatewayClient({ port, token });
 
       let initialError: unknown;

--- a/src/gateway/agent-turn/internal-facade.runtime.ts
+++ b/src/gateway/agent-turn/internal-facade.runtime.ts
@@ -1,1 +1,0 @@
-export { createInternalAgentTurnFacade } from "./internal-facade.js";

--- a/src/gateway/gateway-codex-bind.live.test.ts
+++ b/src/gateway/gateway-codex-bind.live.test.ts
@@ -5,16 +5,11 @@ import os from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
 import { renderCatFacePngBase64 } from "../../test/helpers/live-image-probe.js";
-import { resolveDefaultAgentDir, resolveDefaultAgentId } from "../agents/agent-scope-config.js";
+import { resolveDefaultAgentDir } from "../agents/agent-scope-config.js";
 import { saveAuthProfileStore } from "../agents/auth-profiles/store.js";
 import { isLiveTestEnabled } from "../agents/live-test-helpers.js";
-import { loadPublishedGatewayReplyDispatchRuntime } from "../agents/prepared-model-runtime.js";
 import type { ChannelOutboundContext } from "../channels/plugins/types.adapters.js";
-import {
-  clearConfigCache,
-  clearRuntimeConfigSnapshot,
-  getRuntimeConfig,
-} from "../config/config.js";
+import { clearConfigCache, clearRuntimeConfigSnapshot } from "../config/config.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { isTruthyEnvValue } from "../infra/env.js";
 import { getSessionBindingService } from "../infra/outbound/session-binding-service.js";
@@ -484,7 +479,6 @@ describeLive("gateway live (native Codex conversation binding)", () => {
           auth: { mode: "token", token },
           controlUiEnabled: false,
         });
-        await server.startupSettled;
         client = await connectTestGatewayClient({
           url: `ws://127.0.0.1:${port}`,
           token,
@@ -498,21 +492,7 @@ describeLive("gateway live (native Codex conversation binding)", () => {
         if (!activeRegistry) {
           throw new Error("expected gateway root plugin registry");
         }
-        const replyRuntime = await loadPublishedGatewayReplyDispatchRuntime({
-          agentId: resolveDefaultAgentId(getRuntimeConfig()),
-        });
-        if (!replyRuntime) {
-          throw new Error("expected gateway reply runtime");
-        }
-        // Install the mock transport into the same published registries that own
-        // inbound commands and agent replies; the root registry alone is not used by turns.
-        for (const registry of new Set([
-          activeRegistry,
-          replyRuntime.inboundPluginRegistry,
-          replyRuntime.pluginGeneration.pluginRegistry,
-        ])) {
-          registry?.channels.push(...channelRegistry.channels);
-        }
+        activeRegistry.channels.push(...channelRegistry.channels);
 
         seedPluginConversationBindingApprovalForTest({
           pluginRoot: resolveCodexPluginRoot(),

--- a/src/gateway/gateway-codex-bind.live.test.ts
+++ b/src/gateway/gateway-codex-bind.live.test.ts
@@ -5,11 +5,16 @@ import os from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
 import { renderCatFacePngBase64 } from "../../test/helpers/live-image-probe.js";
-import { resolveDefaultAgentDir } from "../agents/agent-scope-config.js";
+import { resolveDefaultAgentDir, resolveDefaultAgentId } from "../agents/agent-scope-config.js";
 import { saveAuthProfileStore } from "../agents/auth-profiles/store.js";
 import { isLiveTestEnabled } from "../agents/live-test-helpers.js";
+import { loadPublishedGatewayReplyDispatchRuntime } from "../agents/prepared-model-runtime.js";
 import type { ChannelOutboundContext } from "../channels/plugins/types.adapters.js";
-import { clearConfigCache, clearRuntimeConfigSnapshot } from "../config/config.js";
+import {
+  clearConfigCache,
+  clearRuntimeConfigSnapshot,
+  getRuntimeConfig,
+} from "../config/config.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { isTruthyEnvValue } from "../infra/env.js";
 import { getSessionBindingService } from "../infra/outbound/session-binding-service.js";
@@ -479,6 +484,7 @@ describeLive("gateway live (native Codex conversation binding)", () => {
           auth: { mode: "token", token },
           controlUiEnabled: false,
         });
+        await server.startupSettled;
         client = await connectTestGatewayClient({
           url: `ws://127.0.0.1:${port}`,
           token,
@@ -492,7 +498,21 @@ describeLive("gateway live (native Codex conversation binding)", () => {
         if (!activeRegistry) {
           throw new Error("expected gateway root plugin registry");
         }
-        activeRegistry.channels.push(...channelRegistry.channels);
+        const replyRuntime = await loadPublishedGatewayReplyDispatchRuntime({
+          agentId: resolveDefaultAgentId(getRuntimeConfig()),
+        });
+        if (!replyRuntime) {
+          throw new Error("expected gateway reply runtime");
+        }
+        // Install the mock transport into the same published registries that own
+        // inbound commands and agent replies; the root registry alone is not used by turns.
+        for (const registry of new Set([
+          activeRegistry,
+          replyRuntime.inboundPluginRegistry,
+          replyRuntime.pluginGeneration.pluginRegistry,
+        ])) {
+          registry?.channels.push(...channelRegistry.channels);
+        }
 
         seedPluginConversationBindingApprovalForTest({
           pluginRoot: resolveCodexPluginRoot(),

--- a/src/gateway/server-methods/agent-run-handler.ts
+++ b/src/gateway/server-methods/agent-run-handler.ts
@@ -13,7 +13,9 @@ export const agentRunHandler: GatewayRequestHandlers["agent"] = async ({
   context,
   client,
   isWebchatConnect,
+  sessionMutationCommitGuard,
 }) => {
+  sessionMutationCommitGuard?.();
   const io = createAgentTurnIo(respond);
   if (
     !assertValidParams(params, validateAgentParams, "agent", (ok, payload, error, meta) =>
@@ -32,10 +34,12 @@ export const agentRunHandler: GatewayRequestHandlers["agent"] = async ({
     principal,
     registerToolEventRecipient: context.registerToolEventRecipient,
   });
-  await createAgentTurnService({ context, isWebchatConnect }).startTurn({
-    preflight,
-    principal,
-    io,
-    onRunObserved,
-  });
+  await createAgentTurnService({ context, isWebchatConnect }, sessionMutationCommitGuard).startTurn(
+    {
+      preflight,
+      principal,
+      io,
+      onRunObserved,
+    },
+  );
 };

--- a/src/gateway/server-methods/agent-wait.ts
+++ b/src/gateway/server-methods/agent-wait.ts
@@ -21,7 +21,9 @@ export const agentWaitHandler: GatewayRequestHandlers["agent.wait"] = async ({
   context,
   client,
   isWebchatConnect,
+  sessionMutationCommitGuard,
 }) => {
+  sessionMutationCommitGuard?.();
   if (!assertValidParams(params, validateAgentWaitParams, "agent.wait", respond)) {
     return;
   }

--- a/src/gateway/server-plugin-in-process-dispatch.authorization.test.ts
+++ b/src/gateway/server-plugin-in-process-dispatch.authorization.test.ts
@@ -197,9 +197,20 @@ describe("typed in-process agent authorization", () => {
     },
   );
 
-  it.each(["explicit", "scoped"])(
-    "carries a %s Gateway binding into the session mutation commit guard",
-    async (binding) => {
+  it.each(
+    ["explicit", "scoped"].flatMap((binding) =>
+      [
+        { method: "sessions.create", params: { agentId: "main" } },
+        {
+          method: "agent",
+          params: { message: "host-bound dispatch", idempotencyKey: "host-bound-dispatch" },
+        },
+        { method: "agent.wait", params: { runId: "host-bound-run" } },
+      ].map((entry) => ({ binding, ...entry })),
+    ),
+  )(
+    "dispatches $method through its $binding host and rejects replacement before commit",
+    async ({ binding, method, params }) => {
       const admitted = createContext();
       const replacement = createContext();
       let current = admitted;
@@ -209,7 +220,7 @@ describe("typed in-process agent authorization", () => {
       admitted.getGatewayMethodRegistry = () =>
         createGatewayMethodRegistry([
           {
-            name: "sessions.create",
+            name: method,
             scope: "operator.write",
             owner: { kind: "core", area: "sessions" },
             handler: async ({
@@ -232,17 +243,18 @@ describe("typed in-process agent authorization", () => {
           ...(binding === "scoped" ? { resolveGatewayContext: () => current } : {}),
         },
         () =>
-          dispatchGatewayMethodInProcess(
-            "sessions.create",
-            { agentId: "main" },
-            {
-              forceSyntheticClient: true,
-              ...(binding === "explicit" ? { resolveGatewayContext: () => current } : {}),
-              syntheticScopes: ["operator.write"],
-            },
-          ),
+          dispatchGatewayMethodInProcess(method, params, {
+            forceSyntheticClient: true,
+            ...(binding === "explicit" ? { resolveGatewayContext: () => current } : {}),
+            syntheticScopes: ["operator.write"],
+          }),
       );
-      await setupStarted.promise;
+      await Promise.race([
+        setupStarted.promise,
+        dispatch.then(() => {
+          throw new Error(`${method} did not invoke the host-owned handler`);
+        }),
+      ]);
       current = replacement;
       releaseSetup.resolve();
 

--- a/src/gateway/server-plugin-in-process-dispatch.ts
+++ b/src/gateway/server-plugin-in-process-dispatch.ts
@@ -1,11 +1,9 @@
 import { AsyncLocalStorage } from "node:async_hooks";
-import type { AgentWaitParams } from "../../packages/gateway-protocol/src/index.js";
 import type { SubagentCompletionToolHandoffRegistration } from "../agents/subagents/announce/subagent-announce-handoff.js";
 import { getActivePluginRegistry } from "../plugins/runtime.js";
 import { getPluginRuntimeGatewayRequestScope } from "../plugins/runtime/gateway-request-scope.js";
 import type { PluginSubagentRequesterContext } from "../plugins/runtime/subagent-requester-context.js";
 import type { RuntimePluginToolGrant } from "../plugins/runtime/tool-grant.js";
-import { createLazyRuntimeModule } from "../shared/lazy-runtime.js";
 import { readInProcessAgentRuntimeIdentity } from "./in-process-agent-runtime-identity.js";
 import { ADMIN_SCOPE, WRITE_SCOPE } from "./operator-scopes.js";
 import {
@@ -13,7 +11,6 @@ import {
   type GatewayMethodDispatchResponse,
   unwrapGatewayMethodDispatchResponse,
 } from "./server-in-process-dispatch.js";
-import type { AgentRunRequest } from "./server-methods/agent-request-types.js";
 import type { TrustedSessionCreation } from "./server-methods/session-creation-provenance.js";
 import type { GatewayOperatorRoleActor } from "./server-methods/shared-types.js";
 import type {
@@ -32,10 +29,6 @@ import {
   cancelSubagentCompletionToolHandoff,
   registerSubagentCompletionToolHandoff,
 } from "./subagent-completion-tool-handoff.js";
-
-const loadInternalAgentTurnFacade = createLazyRuntimeModule(
-  () => import("./agent-turn/internal-facade.runtime.js"),
-);
 
 type OperatorToolGatewayAuthority = {
   authenticatedUserProfile: NonNullable<
@@ -337,37 +330,8 @@ export async function dispatchGatewayMethodInProcess<T>(
   params: Record<string, unknown>,
   options?: DispatchGatewayMethodInProcessOptions,
 ): Promise<T> {
-  if (method === "agent" || method === "agent.wait") {
-    return await withInProcessGatewayDispatch(method, options, async (resolved) => {
-      const { createInternalAgentTurnFacade } = await loadInternalAgentTurnFacade();
-      const facade = createInternalAgentTurnFacade({
-        assertContextCurrent: resolved.assertContextCurrent,
-        client: resolved.client,
-        getContext: () => {
-          resolved.assertContextCurrent();
-          return resolved.context;
-        },
-        ...(resolved.context.getGatewayMethodRegistry
-          ? { getMethodRegistry: resolved.context.getGatewayMethodRegistry }
-          : {}),
-        isWebchatConnect: resolved.isWebchatConnect,
-      });
-      return method === "agent"
-        ? await facade.dispatch<T>(params as AgentRunRequest, {
-            expectFinal: options?.expectFinal,
-            onAccepted: options?.onAccepted,
-            onSignalAbort: options?.onSignalAbort,
-            signal: options?.signal,
-            timeoutMs: options?.timeoutMs,
-          })
-        : await facade.wait<T>(
-            params as AgentWaitParams,
-            options?.timeoutMs,
-            options?.signal,
-            options?.onSignalAbort,
-          );
-    });
-  }
+  // The instance registry owns its prepared runtime. SDK callers may load a separate
+  // module graph, so constructing an agent service here would lose that ownership.
   const response = await dispatchGatewayMethodInProcessRaw(method, params, options);
   return unwrapGatewayMethodDispatchResponse(method, response) as T;
 }

--- a/src/gateway/server-plugins.subagent-ended-hook.test.ts
+++ b/src/gateway/server-plugins.subagent-ended-hook.test.ts
@@ -9,29 +9,12 @@ import type { GatewayRequestContext, GatewayRequestOptions } from "./server-meth
 type HandleGatewayRequestOptions = GatewayRequestOptions & {
   extraHandlers?: Record<string, unknown>;
 };
-type InternalAgentTurnFacadeOptions = {
-  client: NonNullable<GatewayRequestOptions["client"]>;
-};
 const handleGatewayRequest = vi.hoisted(() =>
   vi.fn(async (_opts: HandleGatewayRequestOptions) => {}),
 );
-const internalAgentTurnFacade = vi.hoisted(() => ({
-  create: vi.fn(),
-  dispatch: vi.fn(),
-  wait: vi.fn(),
-}));
 
 vi.mock("./server-methods.js", () => ({
   handleGatewayRequest,
-}));
-vi.mock("./agent-turn/internal-facade.runtime.js", () => ({
-  createInternalAgentTurnFacade: (options: InternalAgentTurnFacadeOptions) => {
-    internalAgentTurnFacade.create(options);
-    return {
-      dispatch: internalAgentTurnFacade.dispatch,
-      wait: internalAgentTurnFacade.wait,
-    };
-  },
 }));
 
 type ServerPluginsModule = typeof import("./server-plugins.js") & {
@@ -82,25 +65,19 @@ function lastAgentTurnRequest(): {
   client: NonNullable<GatewayRequestOptions["client"]>;
   params: Record<string, unknown>;
 } {
-  const params = internalAgentTurnFacade.dispatch.mock.calls.at(-1)?.[0] as
-    | Record<string, unknown>
-    | undefined;
-  const options = internalAgentTurnFacade.create.mock.calls.at(-1)?.[0] as
-    | InternalAgentTurnFacadeOptions
-    | undefined;
-  if (!params || !options) {
+  const options = handleGatewayRequest.mock.calls.findLast(
+    ([entry]) => entry.req.method === "agent",
+  )?.[0];
+  if (!options?.client || !options.req.params) {
     throw new Error("expected internal agent turn dispatch");
   }
-  return { client: options.client, params };
+  return { client: options.client, params: options.req.params as Record<string, unknown> };
 }
 
 beforeEach(() => {
-  internalAgentTurnFacade.create.mockReset();
-  internalAgentTurnFacade.dispatch.mockReset().mockResolvedValue({ runId: "plugin-run-1" });
-  internalAgentTurnFacade.wait.mockReset().mockResolvedValue({ status: "ok" });
   handleGatewayRequest.mockReset();
   handleGatewayRequest.mockImplementation(async (opts: HandleGatewayRequestOptions) => {
-    opts.respond(true, {});
+    opts.respond(true, opts.req.method === "agent" ? { runId: "plugin-run-1" } : { status: "ok" });
   });
 });
 
@@ -211,7 +188,7 @@ describe("createGatewaySubagentRuntime.run subagent_ended tracking (#59164)", ()
       }),
     ).rejects.toThrow(/requester-bound plugin hook invocation/);
 
-    expect(internalAgentTurnFacade.dispatch).not.toHaveBeenCalled();
+    expect(handleGatewayRequest).not.toHaveBeenCalled();
   });
 
   test("rejects unsupported runtime completion destinations", async () => {
@@ -230,7 +207,7 @@ describe("createGatewaySubagentRuntime.run subagent_ended tracking (#59164)", ()
       } as unknown as Parameters<typeof runtime.run>[0]),
     ).rejects.toThrow(/Unsupported plugin subagent completionDelivery/);
 
-    expect(internalAgentTurnFacade.dispatch).not.toHaveBeenCalled();
+    expect(handleGatewayRequest).not.toHaveBeenCalled();
   });
 
   test("preserves plugin identity on the tracked Gateway agent request", async () => {
@@ -296,7 +273,7 @@ describe("createGatewaySubagentRuntime.run subagent_ended tracking (#59164)", ()
       }),
     ).rejects.toThrow(/gateway request scope/);
 
-    expect(internalAgentTurnFacade.dispatch).not.toHaveBeenCalled();
+    expect(handleGatewayRequest).not.toHaveBeenCalled();
   });
 
   test("preserves the child session so the transcript stays readable until the plugin deletes it", async () => {
@@ -311,11 +288,15 @@ describe("createGatewaySubagentRuntime.run subagent_ended tracking (#59164)", ()
     const sessionStore = new Map<string, { messages: unknown[] }>([
       ["agent:main:subagent:plugin-readback", { messages: transcript }],
     ]);
-    internalAgentTurnFacade.dispatch.mockResolvedValue({ runId: "plugin-run-readback" });
-
     handleGatewayRequest.mockImplementation(async (opts: HandleGatewayRequestOptions) => {
       const req = opts.req as { method: string; params?: { key?: string } };
       switch (req.method) {
+        case "agent":
+          opts.respond(true, { runId: "plugin-run-readback" });
+          return;
+        case "agent.wait":
+          opts.respond(true, { status: "ok" });
+          return;
         case "sessions.get": {
           const key = req.params?.key ?? "";
           const stored = sessionStore.get(key);
@@ -405,7 +386,7 @@ describe("createGatewaySubagentRuntime.run subagent_ended tracking (#59164)", ()
     const serverPlugins = await loadServerPlugins();
     const runtime = serverPlugins.createGatewaySubagentRuntime(() => testGatewayContext);
     serverPlugins.setFallbackGatewayContext(createTestContext("plugin-wait", createTestCfg()));
-    internalAgentTurnFacade.wait.mockResolvedValue(result);
+    handleGatewayRequest.mockImplementationOnce(async (opts) => opts.respond(true, result));
 
     await expect(runtime.waitForRun({ runId: "plugin-run-wait" })).resolves.toEqual(expected);
   });

--- a/src/gateway/server-plugins.test.ts
+++ b/src/gateway/server-plugins.test.ts
@@ -99,43 +99,6 @@ vi.mock("../auto-reply/reply/dispatch-from-config.js", () => ({
   dispatchReplyFromConfig,
 }));
 
-vi.mock("./agent-turn/internal-facade.js", () => ({
-  createInternalAgentTurnFacade: (options: {
-    client: GatewayRequestOptions["client"];
-    getContext: () => GatewayRequestContext;
-    isWebchatConnect?: GatewayRequestOptions["isWebchatConnect"];
-  }) => ({
-    dispatch: async (
-      request: Record<string, unknown>,
-      dispatchOptions?: {
-        expectFinal?: boolean;
-        onAccepted?: (payload: unknown) => void;
-        onSignalAbort?: () => Promise<void> | void;
-        signal?: AbortSignal;
-        timeoutMs?: number;
-      },
-    ) => {
-      const { dispatchGatewayRequestInProcess } = await import("./server-in-process-dispatch.js");
-      return await dispatchGatewayRequestInProcess("agent", request, {
-        client: options.client,
-        context: options.getContext(),
-        isWebchatConnect: options.isWebchatConnect,
-        ...dispatchOptions,
-      });
-    },
-    wait: async (params: Record<string, unknown>, timeoutMs?: number, signal?: AbortSignal) => {
-      const { dispatchGatewayRequestInProcess } = await import("./server-in-process-dispatch.js");
-      return await dispatchGatewayRequestInProcess("agent.wait", params, {
-        client: options.client,
-        context: options.getContext(),
-        isWebchatConnect: options.isWebchatConnect,
-        signal,
-        timeoutMs,
-      });
-    },
-  }),
-}));
-
 vi.mock("../channels/registry.js", () => ({
   CHAT_CHANNEL_ORDER: [],
   CHANNEL_IDS: [],


### PR DESCRIPTION
## Summary
Native child-task completion could produce the correct child response but fail delivery with `published reply runtime missing`, leaving the parent waiting. Plugin SDK imports may have a different module graph from the running Gateway. The special in-process agent path constructed its own facade and service from that graph instead of using the host's prepared runtime.

Route plugin `agent` and `agent.wait` calls through the owning Gateway's method registry, as other in-process methods already do. Carry the instance commit guard into the agent handler/service, preserving rejection after host replacement and awaited preparation. Delete the obsolete lazy facade barrel and test mocks for the removed path.

The announce live fixture now waits for canonical Gateway readiness. It retains real model calls and completion assertions. The separate binding fixture investigation remains outside this PR.

Release note: native child-task completion stays bound to its owning Gateway runtime, so successful child responses can reach the parent.

## Validation
- Original full Docker run: https://github.com/openclaw/openclaw/actions/runs/33237600353
- Exact baseline module-identity probe: plugin SDK and prepared-runtime modules were distinct from the running Gateway's modules.
- Regression failed before repair: four agent/agent.wait cases bypassed the host handler; the two existing session cases passed.
- 131 focused tests passed, covering authorization, replacement, cancellation, completion hooks, and execution-owner checks.
- Rebuilt live Codex Docker harness passed native child completion, fanout, guardian/MCP, resume/new/deletion lifecycle (231.56 seconds).
- Rebuilt live subagent announce default scenario passed (29.53 seconds suite). Optional busy-parent and Gemini stress scenarios were not enabled; no claim is made for those variants.
- Independent Codex autoreview: no accepted actionable findings.
- Direct Codex source checked: `codex-rs/app-server-protocol/src/protocol/event_mapping.rs:78-255` and `codex-rs/app-server/src/bespoke_event_handling.rs:1359-1420`.
- Production LOC: -31 net; test/support LOC: -30 net. No new configuration, storage, or protocol surface.

Native completion and announce live proof are complete; exact-head CI is required before landing.
