### PR TITLE
fix(llama-cpp): bound managed server inspection responses

### DIFF
--- a/extensions/llama-cpp/src/managed-server.test.ts
+++ b/extensions/llama-cpp/src/managed-server.test.ts
@@ -313,58 +313,66 @@ describe("managed llama-server", () => {
     });
   });
 
-  it("bounds inspection responses while accepting a legitimate large metrics body", async () => {
-    let metricsBody = "x".repeat(1024 * 1024);
-    const server = http.createServer((req, res) => {
-      if (req.url?.startsWith("/metrics?")) {
-        res.setHeader("content-type", "text/plain");
-        res.end(metricsBody);
-        return;
+  it.each(["metrics", "props"] as const)(
+    "bounds %s inspection responses while accepting a legitimate large body",
+    async (endpoint) => {
+      let padding = "x".repeat(1024 * 1024);
+      const server = http.createServer((req, res) => {
+        if (req.url?.startsWith(`/${endpoint}?`)) {
+          res.setHeader("content-type", endpoint === "metrics" ? "text/plain" : "application/json");
+          res.end(endpoint === "metrics" ? padding : JSON.stringify({ padding }));
+          return;
+        }
+        res.setHeader("content-type", "application/json");
+        if (req.url === "/health") {
+          res.end(JSON.stringify({ status: "ok" }));
+          return;
+        }
+        if (req.url === "/models") {
+          res.end(JSON.stringify({ data: [{ id: "embedding-model" }] }));
+          return;
+        }
+        if (req.url?.startsWith("/props?")) {
+          res.end(JSON.stringify({ modalities: { vision: false } }));
+          return;
+        }
+        if (req.url?.startsWith("/metrics?")) {
+          res.setHeader("content-type", "text/plain");
+          res.end("llamacpp:requests_total 1\n");
+          return;
+        }
+        res.statusCode = 404;
+        res.end("{}");
+      });
+      servers.push(server);
+      await new Promise<void>((resolve) => {
+        server.listen(0, "127.0.0.1", resolve);
+      });
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        throw new Error("missing test server address");
       }
-      res.setHeader("content-type", "application/json");
-      if (req.url === "/health") {
-        res.end(JSON.stringify({ status: "ok" }));
-        return;
-      }
-      if (req.url === "/models") {
-        res.end(JSON.stringify({ data: [{ id: "embedding-model" }] }));
-        return;
-      }
-      if (req.url?.startsWith("/props?")) {
-        res.end(JSON.stringify({ modalities: { vision: false } }));
-        return;
-      }
-      res.statusCode = 404;
-      res.end("{}");
-    });
-    servers.push(server);
-    await new Promise<void>((resolve) => {
-      server.listen(0, "127.0.0.1", resolve);
-    });
-    const address = server.address();
-    if (!address || typeof address === "string") {
-      throw new Error("missing test server address");
-    }
-    const inspect = () =>
-      inspectLlamaServerRuntime({
-        baseUrl: `http://127.0.0.1:${address.port}/v1`,
-        modelId: "embedding-model",
+      const inspect = () =>
+        inspectLlamaServerRuntime({
+          baseUrl: `http://127.0.0.1:${address.port}/v1`,
+          modelId: "embedding-model",
+        });
+
+      await expect(inspect()).resolves.toMatchObject({
+        state: "ready",
+        endpoints: { health: "ready", models: "ready", props: "ready", metrics: "ready" },
       });
 
-    await expect(inspect()).resolves.toMatchObject({
-      state: "ready",
-      endpoints: { metrics: "ready" },
-    });
-
-    metricsBody = "x".repeat(32 * 1024 * 1024);
-    await expect(inspect()).resolves.toMatchObject({
-      state: "failed",
-      endpoints: {
-        health: "ready",
-        models: "ready",
-        props: "ready",
-        metrics: "unavailable",
-      },
-    });
-  });
+      padding = "x".repeat(32 * 1024 * 1024);
+      await expect(inspect()).resolves.toMatchObject({
+        state: "failed",
+        endpoints: {
+          health: "ready",
+          models: "ready",
+          props: endpoint === "props" ? "unavailable" : "ready",
+          metrics: endpoint === "metrics" ? "unavailable" : "ready",
+        },
+      });
+    },
+  );
 });

--- a/extensions/llama-cpp/src/managed-server.test.ts
+++ b/extensions/llama-cpp/src/managed-server.test.ts
@@ -312,4 +312,59 @@ describe("managed llama-server", () => {
       },
     });
   });
+
+  it("bounds inspection responses while accepting a legitimate large metrics body", async () => {
+    let metricsBody = "x".repeat(1024 * 1024);
+    const server = http.createServer((req, res) => {
+      if (req.url?.startsWith("/metrics?")) {
+        res.setHeader("content-type", "text/plain");
+        res.end(metricsBody);
+        return;
+      }
+      res.setHeader("content-type", "application/json");
+      if (req.url === "/health") {
+        res.end(JSON.stringify({ status: "ok" }));
+        return;
+      }
+      if (req.url === "/models") {
+        res.end(JSON.stringify({ data: [{ id: "embedding-model" }] }));
+        return;
+      }
+      if (req.url?.startsWith("/props?")) {
+        res.end(JSON.stringify({ modalities: { vision: false } }));
+        return;
+      }
+      res.statusCode = 404;
+      res.end("{}");
+    });
+    servers.push(server);
+    await new Promise<void>((resolve) => {
+      server.listen(0, "127.0.0.1", resolve);
+    });
+    const address = server.address();
+    if (!address || typeof address === "string") {
+      throw new Error("missing test server address");
+    }
+    const inspect = () =>
+      inspectLlamaServerRuntime({
+        baseUrl: `http://127.0.0.1:${address.port}/v1`,
+        modelId: "embedding-model",
+      });
+
+    await expect(inspect()).resolves.toMatchObject({
+      state: "ready",
+      endpoints: { metrics: "ready" },
+    });
+
+    metricsBody = "x".repeat(32 * 1024 * 1024);
+    await expect(inspect()).resolves.toMatchObject({
+      state: "failed",
+      endpoints: {
+        health: "ready",
+        models: "ready",
+        props: "ready",
+        metrics: "unavailable",
+      },
+    });
+  });
 });

--- a/extensions/llama-cpp/src/managed-server.ts
+++ b/extensions/llama-cpp/src/managed-server.ts
@@ -3,6 +3,10 @@ import fsp from "node:fs/promises";
 import net from "node:net";
 import path from "node:path";
 import {
+  readProviderJsonResponse,
+  readProviderTextResponse,
+} from "openclaw/plugin-sdk/provider-http";
+import {
   fetchWithSsrFGuard,
   ssrfPolicyFromHttpBaseUrlAllowedOrigin,
 } from "openclaw/plugin-sdk/ssrf-runtime";
@@ -593,7 +597,11 @@ async function fetchEndpoint(
       if (!response.ok) {
         return { ok: false };
       }
-      return { ok: true, value: accept === "json" ? await response.json() : await response.text() };
+      const value =
+        accept === "json"
+          ? await readProviderJsonResponse(response, "llama-server inspection")
+          : await readProviderTextResponse(response, "llama-server inspection");
+      return { ok: true, value };
     } finally {
       await release();
     }


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where managed llama.cpp inspection could buffer unexpectedly large local-server responses and put Gateway memory under pressure. The inspection runs when refreshing local embedding diagnostics, so a fast oversized response could exhaust memory even within the existing request deadline.

## Why This Change Was Made

Health, model-list, properties, and metrics responses now use the existing bounded provider readers. This puts the 16 MiB limit at the inspection response owner, while preserving the configured-origin guard, request deadline, and response cleanup. The same limit already protects the external-server discovery path.

The regression covers both response formats through the production inspection entrypoint and a real loopback HTTP server: ordinary large metrics text and properties JSON remain usable, while oversized bodies mark only their own endpoint unavailable.

## User Impact

Normal inspection responses continue to report readiness. A response above 16 MiB now reports that endpoint unavailable and the overall inspection failed. We accept this diagnostic ceiling for existing managed installations: bounded Gateway memory takes precedence over consuming an excessive diagnostic body. This intentionally changes the previous oversized-response behavior.

A successful embedding operation still returns its result when the diagnostic refresh reports failure. The change adds no configuration option, model download, or installation step. JSON responses also use the canonical reader's strict UTF-8 and parsing checks.

## Evidence

An independent harness exercised `inspectLlamaServerRuntime` on trusted main `6426cb310d6e8be691785621ea6f0f244819facc`, using an isolated HOME and an owned loopback server with no model operation or provider credentials:

| Scenario | Before the fix |
|---|---|
| 1 MiB metrics text | Ready, 27 ms |
| 32 MiB metrics text | Incorrectly ready after consuming the whole body, 43 ms |
| 32 MiB valid properties JSON | Incorrectly ready after consuming the whole body, 49 ms |
| HTTP 503 health | Failed; health unavailable |
| Malformed properties JSON | Failed; properties unavailable |

Both oversized-body assertions failed for the intended reason; all three controls passed. The production owner remained unchanged throughout this proof. Props and metrics requests included `autoload=false`; no running model service, installer, or external API was contacted.

[CI run 33615991000, attempt 2](https://github.com/openclaw/openclaw/actions/runs/33615991000/attempts/2) is **successful** on the published head `e3586876fbdbc4de1784be0696d7e5bce7470539`: 46 jobs succeeded and 17 skipped, including the guard and aggregate CI gate.

The [changed-plugin job](https://github.com/openclaw/openclaw/actions/runs/33615991000/job/100207380683) explicitly passed **all 14 managed-server tests**, including the metrics row in 163 ms and the properties row in 155 ms. Each row accepts a 1 MiB body, then rejects a 32 MiB body while preserving healthy sibling endpoint facts. The enclosing shard passed 79 files / 1,689 tests, with 1 file / 10 tests skipped. These exact-head tests ran at 09:48–09:50 UTC and their successful results were retained into attempt 2; the guard retry did not rerun the owner tests.

The test checkout was CI merge `617191eca11177c4250460a8c85963a7f21e7a18`, combining this exact head with base `c6dcb97176cfae5b918b5efd3b471f5bbbc689ed`. Both changed files have identical Git blobs and SHA-256 at the published head and tested merge:

| File | Git blob | SHA-256 |
|---|---|---|
| `extensions/llama-cpp/src/managed-server.ts` | `efddf6ce0a135be83def75d2dadc779f8a8e09e7` | `c795114ac1df92fa3668956a9696687fad6a2bd2a01b7420c37882fdec2af0a5` |
| `extensions/llama-cpp/src/managed-server.test.ts` | `55a461e9dfb353322797ebb2ccaab554337b2db9` | `485d1e21cf1814a0e3a19542362c79d4b83785d02f545c9ce35b81ed13bd9ec2` |

The log records Secret source: None and read-only Contents/Metadata permissions. Independent Codex review of the complete production/test candidate was source-only and found no P0 blocker or exposed credential. The independent baseline harness above is not presented as execution of the permanent test against old source; the published table's GREEN comes from this exact-head hosted run.

Attempt 1 failed in the existing CI guard's late Git fetch with exit 128 and unavailable GitHub username authentication, after coercion checks had passed. Its workflow and Git-owner implementation matched the main base. The retry passed [check-guards](https://github.com/openclaw/openclaw/actions/runs/33615991000/job/100207379395) and the [aggregate CI gate](https://github.com/openclaw/openclaw/actions/runs/33615991000/job/100208117381) without changing this head. The failed log does not establish a specific missing Git object or remote HTTP cause.

Production LOC: **+9/-1, net +8**. Tests: **+63/-0**. Production growth is the two canonical reader imports and format dispatch; the change removes both unbounded reads without adding a local reader, option, fallback, or production test seam.

## Scope and credit

Original repair and regression by @RileyJJY. The follow-up broadens regression coverage to the JSON inspection path while preserving the original contributor's production change.

The pinned llama.cpp b10534 server source (`2b5621094ef383cdcd8428ef6d22efe5df976532`) was inspected directly for properties JSON, metrics text, routing, and `autoload=false`. This proof concerns HTTP inspection; it does not claim an end-to-end model run. The separate unbounded Hugging Face artifact metadata/tree reads in `resolveHuggingFaceArtifact` remain a named follow-up requiring their own API-contract proof.

The latest completed ClawSweeper review (September 2, 09:58 UTC) covers this exact head and has no actionable code or security finding. Its Rank-up move asks to record acceptance of the 16 MiB diagnostic ceiling; that decision is already explicit under User Impact. The intentional oversized-response compatibility change remains accepted and disclosed.

Published revision: e3586876fbdbc4de1784be0696d7e5bce7470539.
