### PR TITLE
fix(visitor-access): bound external JSON responses

### DIFF
--- a/extensions/visitor-access/src/cloudflare.test.ts
+++ b/extensions/visitor-access/src/cloudflare.test.ts
@@ -35,6 +35,51 @@ function fetchSequence(...responses: Response[]) {
   return fetcher;
 }
 
+function oversizedJsonResponse() {
+  const prefix = new TextEncoder().encode('{"success":true,"result":[],"padding":"');
+  const suffix = new TextEncoder().encode('"}');
+  const chunk = new Uint8Array(1024 * 1024).fill(120);
+  const totalPaddingBytes = 32 * 1024 * 1024;
+  let phase = 0;
+  let remaining = totalPaddingBytes;
+  let enqueuedBytes = 0;
+  let canceled = false;
+  const body = new ReadableStream<Uint8Array>({
+    pull(controller) {
+      if (phase === 0) {
+        phase = 1;
+        enqueuedBytes += prefix.byteLength;
+        controller.enqueue(prefix);
+        return;
+      }
+      if (remaining > 0) {
+        const next = Math.min(remaining, chunk.byteLength);
+        remaining -= next;
+        enqueuedBytes += next;
+        controller.enqueue(chunk.subarray(0, next));
+        return;
+      }
+      controller.enqueue(suffix);
+      controller.close();
+    },
+    cancel() {
+      canceled = true;
+    },
+  });
+  return {
+    response: new Response(body, { headers: { "content-type": "application/json" } }),
+    state: {
+      get canceled() {
+        return canceled;
+      },
+      get enqueuedBytes() {
+        return enqueuedBytes;
+      },
+      totalPaddingBytes,
+    },
+  };
+}
+
 function requestBody(fetcher: ReturnType<typeof fetchSequence>, index: number) {
   const body = fetcher.mock.calls[index]?.[1]?.body;
   if (typeof body !== "string") {
@@ -44,6 +89,26 @@ function requestBody(fetcher: ReturnType<typeof fetchSequence>, index: number) {
 }
 
 describe("VisitorPolicyClient", () => {
+  it("bounds successful JSON responses while accepting a legitimate large body", async () => {
+    const legitimate = new VisitorPolicyClient(
+      config,
+      vi
+        .fn<typeof fetch>()
+        .mockResolvedValue(
+          Response.json({ success: true, result: [], padding: "x".repeat(1024 * 1024) }),
+        ),
+    );
+    await expect(legitimate.read()).resolves.toBeUndefined();
+
+    const oversized = oversizedJsonResponse();
+    const fetcher = vi.fn<typeof fetch>().mockResolvedValue(oversized.response);
+    await expect(new VisitorPolicyClient(config, fetcher).read()).rejects.toThrow(
+      "Cloudflare returned an unreadable response",
+    );
+    expect(oversized.state.canceled).toBe(true);
+    expect(oversized.state.enqueuedBytes).toBeLessThan(oversized.state.totalPaddingBytes);
+  });
+
   it("creates only the named app policy when absent, leaving other policies untouched", async () => {
     const maintainers = { id: "maintainers", name: "GitHub organization", decision: "allow" };
     const fetcher = fetchSequence(

--- a/extensions/visitor-access/src/cloudflare.ts
+++ b/extensions/visitor-access/src/cloudflare.ts
@@ -1,3 +1,4 @@
+import { readProviderJsonResponse } from "openclaw/plugin-sdk/provider-http";
 import { z } from "zod";
 import type { VisitorAccessConfig } from "./config.js";
 import { VisitorAccessError } from "./errors.js";
@@ -167,7 +168,11 @@ export class VisitorPolicyClient {
     }
     let data: unknown;
     try {
-      data = await response.json();
+      data = await readProviderJsonResponse(response, "Cloudflare visitor access response", {
+        requestHeaders: {
+          Authorization: `Bearer ${this.config.apiToken}`,
+        },
+      });
     } catch {
       throw new VisitorAccessError(
         "Cloudflare returned an unreadable response; retry and inspect the visitor policy.",

--- a/extensions/visitor-access/src/visitors.test.ts
+++ b/extensions/visitor-access/src/visitors.test.ts
@@ -33,12 +33,58 @@ function visitorGrant(email: string, overrides: Partial<VisitorGrant> = {}): Vis
   return { email, createdAt: NOW - DAY_MS, expiresAt: NOW + DAY_MS, ...overrides };
 }
 
+function oversizedGithubResponse() {
+  const prefix = new TextEncoder().encode('{"email":"Visitor@Example.com","padding":"');
+  const suffix = new TextEncoder().encode('"}');
+  const chunk = new Uint8Array(1024 * 1024).fill(120);
+  const totalPaddingBytes = 32 * 1024 * 1024;
+  let phase = 0;
+  let remaining = totalPaddingBytes;
+  let enqueuedBytes = 0;
+  let canceled = false;
+  const body = new ReadableStream<Uint8Array>({
+    pull(controller) {
+      if (phase === 0) {
+        phase = 1;
+        enqueuedBytes += prefix.byteLength;
+        controller.enqueue(prefix);
+        return;
+      }
+      if (remaining > 0) {
+        const next = Math.min(remaining, chunk.byteLength);
+        remaining -= next;
+        enqueuedBytes += next;
+        controller.enqueue(chunk.subarray(0, next));
+        return;
+      }
+      controller.enqueue(suffix);
+      controller.close();
+    },
+    cancel() {
+      canceled = true;
+    },
+  });
+  return {
+    response: new Response(body, { headers: { "content-type": "application/json" } }),
+    state: {
+      get canceled() {
+        return canceled;
+      },
+      get enqueuedBytes() {
+        return enqueuedBytes;
+      },
+      totalPaddingBytes,
+    },
+  };
+}
+
 function visitorFixture(
   options: {
     config?: Partial<VisitorAccessConfig>;
     grants?: VisitorGrant[];
     emails?: string[];
     githubEmail?: string | null;
+    githubResponse?: Response;
   } = {},
 ) {
   const resolved = { ...config, ...options.config };
@@ -102,7 +148,7 @@ function visitorFixture(
       if (!/^\/users\/[a-z0-9-]+$/.test(url.pathname) || method !== "GET") {
         throw new Error("Unexpected GitHub request");
       }
-      return Response.json({ email: options.githubEmail ?? null });
+      return options.githubResponse ?? Response.json({ email: options.githubEmail ?? null });
     }
     if (url.origin !== "https://api.cloudflare.com" || !url.pathname.startsWith(policiesPath)) {
       throw new Error("Unexpected Cloudflare endpoint");
@@ -188,6 +234,27 @@ describe("VisitorAccessService", () => {
     expect(result).toContain("2026-09-11T12:00:00.000Z");
     expect(result).toContain("https://team.openclaw.ai");
     expect(result).toContain("GitHub account");
+  });
+
+  it("bounds GitHub email responses while accepting a legitimate large body", async () => {
+    const legitimate = visitorFixture({
+      githubResponse: Response.json({
+        email: "Visitor@Example.com",
+        padding: "x".repeat(1024 * 1024),
+      }),
+    });
+    await expect(legitimate.service.invite({ github: "Visitor" })).resolves.toContain(
+      "visitor@example.com",
+    );
+
+    const oversized = oversizedGithubResponse();
+    const fixture = visitorFixture({ githubResponse: oversized.response });
+    await expect(fixture.service.invite({ github: "Visitor" })).rejects.toThrow(
+      "GitHub email lookup failed",
+    );
+    expect(oversized.state.canceled).toBe(true);
+    expect(oversized.state.enqueuedBytes).toBeLessThan(oversized.state.totalPaddingBytes);
+    expect(fixture.emails()).toEqual([]);
   });
 
   it("asks for an explicit account email when GitHub has no public email, without granting access", async () => {

--- a/extensions/visitor-access/src/visitors.ts
+++ b/extensions/visitor-access/src/visitors.ts
@@ -1,3 +1,4 @@
+import { readProviderJsonResponse } from "openclaw/plugin-sdk/provider-http";
 import { z } from "zod";
 import type { PluginLogger, PluginStateKeyedStore } from "../api.js";
 import type { VisitorPolicyClient } from "./cloudflare.js";
@@ -104,7 +105,7 @@ export class VisitorAccessService {
       if (!response.ok) {
         throw new Error("GitHub lookup failed");
       }
-      body = await response.json();
+      body = await readProviderJsonResponse(response, "GitHub visitor email response");
     } catch {
       throw new VisitorAccessError(
         "GitHub email lookup failed. Check the login and retry, or pass email explicitly.",


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where the visitor-access plugin could buffer an unexpectedly large Cloudflare or GitHub response while managing visitor grants.

## Why This Change Was Made

Cloudflare policy responses and GitHub email lookups now use the existing bounded provider JSON reader. Existing validation and user-facing error handling remain unchanged when a response is malformed or too large.

## User Impact

Visitor grant operations continue to accept normal responses and fail safely instead of buffering excessive external response bodies.

## Evidence

- `pnpm exec vitest run extensions/visitor-access/src/cloudflare.test.ts extensions/visitor-access/src/visitors.test.ts`: 42 tests passed.
- Loopback production-module comparison with the same Cloudflare/GitHub inputs. The **before-fix** baseline is the base SHA; the **after-fix** result was run against the tested head SHA:

```text
before-fix base 532dfd4ecb82fde540ac9c39ab1e333b291cb688: 1 MiB ok; 32 MiB Cloudflare/GitHub bodies accepted; 503 control returned the existing error
after-fix tested head SHA 2910998ca80cbce6671d4fcaa0813cbb2e0c797b: 1 MiB ok; 32 MiB bodies returned the existing unreadable/lookup errors; 503 control returned the same error
```

Canonical precedent: the existing `readProviderJsonResponse` bounded provider reader and its 16 MiB cap. The head reuses that established helper contract.

<details>
<summary>Testing proof-live.mjs</summary>

```javascript
import http from "node:http";
import path from "node:path";
import { pathToFileURL } from "node:url";

const { VisitorPolicyClient } = await import(
  pathToFileURL(path.join(process.cwd(), "extensions/visitor-access/src/cloudflare.ts")).href
);
const { VisitorAccessService } = await import(
  pathToFileURL(path.join(process.cwd(), "extensions/visitor-access/src/visitors.ts")).href
);

const config = {
  accountId: "proof-account",
  appId: "proof-app",
  apiToken: "redacted-proof-token",
  policyName: "Visitors (openclaw-managed)",
  defaultTtlDays: 14,
  maxVisitors: 50,
};
let mode = "cloudflare-large";
const oversizedPaddingBytes = 32 * 1024 * 1024;

function writeJson(res, payload, status = 200) {
  res.statusCode = status;
  res.setHeader("content-type", "application/json");
  res.end(JSON.stringify(payload));
}

function writeOversizedJson(res, prefix, suffix) {
  res.setHeader("content-type", "application/json");
  res.write(prefix);
  const chunk = Buffer.alloc(1024 * 1024, 120);
  let remaining = oversizedPaddingBytes;
  const writeNext = () => {
    if (res.destroyed) {
      return;
    }
    if (remaining === 0) {
      res.end(suffix);
      return;
    }
    const next = Math.min(remaining, chunk.length);
    remaining -= next;
    if (!res.write(chunk.subarray(0, next))) {
      res.once("drain", writeNext);
      return;
    }
    setImmediate(writeNext);
  };
  writeNext();
}

const server = http.createServer((req, res) => {
  if (req.url === "/cloudflare") {
    if (mode === "cloudflare-oversized") {
      writeOversizedJson(res, '{"success":true,"result":[],"padding":"', '"}');
      return;
    }
    if (mode === "cloudflare-error") {
      writeJson(res, { success: false }, 503);
      return;
    }
    const result = req.method === "GET" ? [] : { id: "visitor-policy" };
    writeJson(res, {
      success: true,
      result,
      ...(mode === "cloudflare-large" ? { padding: "x".repeat(1024 * 1024) } : {}),
    });
    return;
  }
  if (req.url === "/github") {
    if (mode === "github-oversized") {
      writeOversizedJson(res, '{"email":"Visitor@Example.com","padding":"', '"}');
      return;
    }
    writeJson(res, {
      email: "Visitor@Example.com",
      ...(mode === "github-large" ? { padding: "x".repeat(1024 * 1024) } : {}),
    });
    return;
  }
  writeJson(res, { error: "not found" }, 404);
});

await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
const address = server.address();
if (!address || typeof address === "string") {
  throw new Error("missing proof server address");
}
const loopback = `http://127.0.0.1:${address.port}`;
const routeFetcher = (input, init) => {
  const source = String(input);
  const route = source.includes("api.github.com") ? "/github" : "/cloudflare";
  return fetch(`${loopback}${route}`, init);
};

async function capture(operation) {
  try {
    const value = await operation();
    return { status: "ok", value: value ?? null };
  } catch (error) {
    return { status: "error", message: error instanceof Error ? error.message : String(error) };
  }
}

const cloudflare = async () =>
  await capture(() => new VisitorPolicyClient(config, routeFetcher).read());

const createService = () => {
  const grants = new Map();
  const store = {
    async register(key, value) {
      grants.set(key, structuredClone(value));
    },
    async registerIfAbsent(key, value) {
      if (grants.has(key)) return false;
      grants.set(key, structuredClone(value));
      return true;
    },
    async lookup(key) {
      return structuredClone(grants.get(key));
    },
    async consume(key) {
      const value = grants.get(key);
      grants.delete(key);
      return structuredClone(value);
    },
    async delete(key) {
      return grants.delete(key);
    },
    async entries() {
      return [...grants].map(([key, value]) => ({ key, value, createdAt: value.createdAt }));
    },
    async clear() {
      grants.clear();
    },
  };
  const logger = { info() {}, warn() {}, error() {}, debug() {} };
  return new VisitorAccessService(
    config,
    store,
    new VisitorPolicyClient(config, routeFetcher),
    logger,
    routeFetcher,
  );
};

mode = "cloudflare-large";
const cloudflareLarge = await cloudflare();
mode = "cloudflare-oversized";
const cloudflareOversized = await cloudflare();
mode = "github-large";
const githubLarge = await capture(() => createService().invite({ github: "Visitor" }));
mode = "github-oversized";
const githubOversized = await capture(() => createService().invite({ github: "Visitor" }));
mode = "cloudflare-error";
const negativeControl = await cloudflare();

await new Promise((resolve) => server.close(resolve));
console.log(
  JSON.stringify({
    cloudflareLarge,
    cloudflareOversized,
    githubLarge: { status: githubLarge.status },
    githubOversized: { status: githubOversized.status, message: githubOversized.message },
    negativeControl: { status: negativeControl.status, message: negativeControl.message },
  }),
);
```

</details>

AI-assisted: built with Codex
