### PR TITLE
fix(telemetry): bound update response reads

### DIFF
--- a/docs/gateway/telemetry.md
+++ b/docs/gateway/telemetry.md
@@ -64,7 +64,7 @@ tracking identifier.
 
 The service responds with the latest version and, optionally, a short
 operator-facing note. OpenClaw displays an available update and its note through
-the existing update notice. Unreachable services, timeouts, invalid responses,
+the existing update notice. Unreachable services, timeouts, oversized or invalid responses,
 and other failed checks do not interrupt startup or normal operation.
 
 A successful response and its timestamp are cached in the existing shared state

--- a/src/infra/telemetry.test.ts
+++ b/src/infra/telemetry.test.ts
@@ -24,6 +24,51 @@ const TELEMETRY_URL = "https://telemetry.openclaw.ai/api/latest-version";
 const TELEMETRY_STATE_KEY = "telemetry.updateCheck";
 const mockHttp = useMockHttp();
 
+function oversizedTelemetryResponse() {
+  const prefix = new TextEncoder().encode('{"version":"2026.8.24","padding":"');
+  const suffix = new TextEncoder().encode('"}');
+  const chunk = new Uint8Array(1024 * 1024).fill(120);
+  const totalPaddingBytes = 32 * 1024 * 1024;
+  let phase = 0;
+  let remaining = totalPaddingBytes;
+  let enqueuedBytes = 0;
+  let canceled = false;
+  const body = new ReadableStream<Uint8Array>({
+    pull(controller) {
+      if (phase === 0) {
+        phase = 1;
+        enqueuedBytes += prefix.byteLength;
+        controller.enqueue(prefix);
+        return;
+      }
+      if (remaining > 0) {
+        const next = Math.min(remaining, chunk.byteLength);
+        remaining -= next;
+        enqueuedBytes += next;
+        controller.enqueue(chunk.subarray(0, next));
+        return;
+      }
+      controller.enqueue(suffix);
+      controller.close();
+    },
+    cancel() {
+      canceled = true;
+    },
+  });
+  return {
+    response: new Response(body, { headers: { "content-type": "application/json" } }),
+    state: {
+      get canceled() {
+        return canceled;
+      },
+      get enqueuedBytes() {
+        return enqueuedBytes;
+      },
+      totalPaddingBytes,
+    },
+  };
+}
+
 function installPluginRegistry(...plugins: Parameters<typeof createPluginRecord>[0][]): void {
   const registry = createEmptyPluginRegistry();
   registry.plugins.push(...plugins.map((plugin) => createPluginRecord(plugin)));
@@ -465,5 +510,26 @@ describe("anonymous telemetry", () => {
 
     expect(result?.note).toHaveLength(500);
     expect(persisted?.note).toHaveLength(500);
+  });
+
+  it("bounds update responses while accepting a legitimate large body", async () => {
+    let response: Response = Response.json({
+      version: "2026.8.24",
+      padding: "x".repeat(1024 * 1024),
+    });
+    const fetchImpl = vi.fn(async () => response);
+
+    await expect(
+      checkTelemetryUpdate({}, { surface: "gateway", fetchImpl, nowMs: NOW }),
+    ).resolves.toEqual({ version: "2026.8.24" });
+
+    const oversized = oversizedTelemetryResponse();
+    response = oversized.response;
+    await expect(
+      checkTelemetryUpdate({}, { surface: "gateway", fetchImpl, nowMs: NOW + DAY_MS + 1 }),
+    ).resolves.toEqual({ version: "2026.8.24" });
+    expect(oversized.state.canceled).toBe(true);
+    expect(oversized.state.enqueuedBytes).toBeLessThan(oversized.state.totalPaddingBytes);
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/infra/telemetry.test.ts
+++ b/src/infra/telemetry.test.ts
@@ -24,51 +24,6 @@ const TELEMETRY_URL = "https://telemetry.openclaw.ai/api/latest-version";
 const TELEMETRY_STATE_KEY = "telemetry.updateCheck";
 const mockHttp = useMockHttp();
 
-function oversizedTelemetryResponse() {
-  const prefix = new TextEncoder().encode('{"version":"2026.8.24","padding":"');
-  const suffix = new TextEncoder().encode('"}');
-  const chunk = new Uint8Array(1024 * 1024).fill(120);
-  const totalPaddingBytes = 32 * 1024 * 1024;
-  let phase = 0;
-  let remaining = totalPaddingBytes;
-  let enqueuedBytes = 0;
-  let canceled = false;
-  const body = new ReadableStream<Uint8Array>({
-    pull(controller) {
-      if (phase === 0) {
-        phase = 1;
-        enqueuedBytes += prefix.byteLength;
-        controller.enqueue(prefix);
-        return;
-      }
-      if (remaining > 0) {
-        const next = Math.min(remaining, chunk.byteLength);
-        remaining -= next;
-        enqueuedBytes += next;
-        controller.enqueue(chunk.subarray(0, next));
-        return;
-      }
-      controller.enqueue(suffix);
-      controller.close();
-    },
-    cancel() {
-      canceled = true;
-    },
-  });
-  return {
-    response: new Response(body, { headers: { "content-type": "application/json" } }),
-    state: {
-      get canceled() {
-        return canceled;
-      },
-      get enqueuedBytes() {
-        return enqueuedBytes;
-      },
-      totalPaddingBytes,
-    },
-  };
-}
-
 function installPluginRegistry(...plugins: Parameters<typeof createPluginRecord>[0][]): void {
   const registry = createEmptyPluginRegistry();
   registry.plugins.push(...plugins.map((plugin) => createPluginRecord(plugin)));
@@ -512,24 +467,53 @@ describe("anonymous telemetry", () => {
     expect(persisted?.note).toHaveLength(500);
   });
 
-  it("bounds update responses while accepting a legitimate large body", async () => {
-    let response: Response = Response.json({
-      version: "2026.8.24",
-      padding: "x".repeat(1024 * 1024),
+  it("bounds streamed update responses without replacing the cached result or successful ping", async () => {
+    const chunk = new Uint8Array(1024 * 1024).fill(120);
+    const encoder = new TextEncoder();
+    const chunks = [
+      encoder.encode('{"version":"2026.8.25","padding":"'),
+      ...Array<Uint8Array>(32).fill(chunk),
+      encoder.encode('"}'),
+    ][Symbol.iterator]();
+    let canceled = false;
+    let enqueuedBytes = 0;
+    const body = new ReadableStream<Uint8Array>({
+      pull(controller) {
+        const next = chunks.next();
+        if (next.done) {
+          controller.close();
+        } else {
+          enqueuedBytes += next.value.byteLength;
+          controller.enqueue(next.value);
+        }
+      },
+      cancel() {
+        canceled = true;
+      },
     });
-    const fetchImpl = vi.fn(async () => response);
+    const fetchImpl = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(
+        Response.json({ version: "2026.8.24", padding: "x".repeat(chunk.length) }),
+      )
+      .mockResolvedValueOnce(new Response(body));
+    const options = { surface: "gateway" as const, fetchImpl };
 
+    await expect(checkTelemetryUpdate({}, { ...options, nowMs: NOW })).resolves.toEqual({
+      version: "2026.8.24",
+    });
     await expect(
-      checkTelemetryUpdate({}, { surface: "gateway", fetchImpl, nowMs: NOW }),
+      checkTelemetryUpdate({}, { ...options, nowMs: NOW + DAY_MS + 1 }),
     ).resolves.toEqual({ version: "2026.8.24" });
-
-    const oversized = oversizedTelemetryResponse();
-    response = oversized.response;
+    expect(canceled).toBe(true);
+    expect(enqueuedBytes).toBeLessThan(32 * chunk.length);
+    expect(readConfigMachineState(TELEMETRY_STATE_KEY)).toEqual({
+      lastPingAt: NOW,
+      latestVersion: "2026.8.24",
+    });
     await expect(
-      checkTelemetryUpdate({}, { surface: "gateway", fetchImpl, nowMs: NOW + DAY_MS + 1 }),
+      checkTelemetryUpdate({}, { ...options, nowMs: NOW + DAY_MS + 30_001 }),
     ).resolves.toEqual({ version: "2026.8.24" });
-    expect(oversized.state.canceled).toBe(true);
-    expect(oversized.state.enqueuedBytes).toBeLessThan(oversized.state.totalPaddingBytes);
     expect(fetchImpl).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/infra/telemetry.ts
+++ b/src/infra/telemetry.ts
@@ -286,16 +286,12 @@ export async function checkTelemetryUpdate(
         lastFailedAttempt = { at: nowMs, endpoint, stateDirectory };
         return cached;
       }
-      const parsed = TelemetryResponseSchema.safeParse(
+      const parsed = TelemetryResponseSchema.parse(
         await readProviderJsonResponse(response, "Telemetry update response"),
       );
-      if (!parsed.success) {
-        lastFailedAttempt = { at: nowMs, endpoint, stateDirectory };
-        return cached;
-      }
-      const note = parsed.data.note?.trim().slice(0, TELEMETRY_NOTE_MAX_LENGTH);
+      const note = parsed.note?.trim().slice(0, TELEMETRY_NOTE_MAX_LENGTH);
       const update = {
-        version: parsed.data.version,
+        version: parsed.version,
         ...(note ? { note } : {}),
       };
       writeConfigMachineState(TELEMETRY_STATE_KEY, {

--- a/src/infra/telemetry.ts
+++ b/src/infra/telemetry.ts
@@ -2,6 +2,7 @@ import { collectConfiguredModelRefs } from "@openclaw/model-catalog-core/configu
 import { parseModelCatalogRef } from "@openclaw/model-catalog-core/model-catalog-refs";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { z } from "zod";
+import { readProviderJsonResponse } from "../agents/provider-http-errors.js";
 import { isChannelConfigMetadataKey } from "../channels/config-metadata.js";
 import { isBuiltInModelProviderOverlayId } from "../config/model-provider-config.js";
 import { resolveIsNixMode } from "../config/paths.js";
@@ -285,7 +286,9 @@ export async function checkTelemetryUpdate(
         lastFailedAttempt = { at: nowMs, endpoint, stateDirectory };
         return cached;
       }
-      const parsed = TelemetryResponseSchema.safeParse(await response.json());
+      const parsed = TelemetryResponseSchema.safeParse(
+        await readProviderJsonResponse(response, "Telemetry update response"),
+      );
       if (!parsed.success) {
         lastFailedAttempt = { at: nowMs, endpoint, stateDirectory };
         return cached;


### PR DESCRIPTION
## What Problem This Solves

A telemetry update endpoint could make a background update check consume an unexpectedly large JSON response and accept it as a successful daily check.

## Why This Change Was Made

Telemetry now uses the existing bounded JSON reader before applying its unchanged response schema. The reader enforces the established 16 MiB limit and cancels unread overflow. Schema failures share the existing failure handler, removing a duplicate branch and keeping production source net −1 line.

## User Impact

Valid update responses keep their existing behavior. Oversized, malformed, and invalid responses retain the cached update without advancing the last successful ping, and the existing failure backoff applies. The documentation names oversized responses among failed checks. No configuration, schema, or persistence format changes.

## Evidence

Published revision: `f8dd93117112b11bec118893a85dd1e5a88672ff`. [CI run 33615792870](https://github.com/openclaw/openclaw/actions/runs/33615792870) is green after one bounded retry of unrelated Git-fetch failures. No source changes or telemetry-test retries were needed. All three reviewed production, test, and docs file hashes match the CI merge `54da93256dbfd628748f8302238f1f1b4f82aa06`.

[Telemetry CI job 100201497184](https://github.com/openclaw/openclaw/actions/runs/33615792870/job/100201497184) passed all 25 telemetry cases: one new and 24 existing. The new case, `bounds streamed update responses without replacing the cached result or successful ping`, passed in 62 ms. It executes the changed production reader, schema validation, and cache owner with native `Response`/`ReadableStream` and an injected fetch. Its checked outcomes are:

| Scenario | Observed assertion result |
| --- | --- |
| Valid 1 MiB response | Version 2026.8.24 cached successfully |
| Distinct 32 MiB streamed response | Stream canceled before full consumption |
| Cache after overflow | Prior version and original successful-ping timestamp preserved |
| Check during failure backoff | Cached result returned; no third fetch |

The containing infra group passed 313 tests with 6 skips; the complete job passed 766 tests with 6 skips. Existing telemetry cases also cover GET/POST opt-in, DO_NOT_TRACK, daily caching, disabled checks, HTTP errors, malformed JSON, invalid schema, and note limits.

Separately, an independently authored native-fetch loopback HTTP probe against unchanged main `6426cb310d6e8be691785621ea6f0f244819facc` demonstrated the behavioral RED: a 33,554,467-byte streamed response replaced the cached version and advanced the successful ping. The same probe passed daily-cache, HTTP 503, backoff, malformed-JSON, invalid-schema, three-second body-deadline, and recovery controls. The unchanged canonical reader and npm updater accepted 1 MiB and rejected 32 MiB at the 16,777,216-byte limit.

The after-fix CI proof uses an injected fetch; it is not a PR-head loopback HTTP or live external-endpoint test. The HTTP transport contract is unchanged, and the changed body-reader, cancellation, and state boundary executes directly in that test. Candidate code was not executed locally. The permanent regression was not run on pre-fix code; the independent main HTTP probe supplies behavioral RED.

Trusted formatting and `git diff --check` passed. A fresh source-only Codex P0 review against full PR base `14e26a380d342a595bc1f536a19f4be0935a002e` found no actionable P0 finding. Production +6/−7 = −1; tests +50; docs net 0.

ClawSweeper's September 2, 09:58 UTC review requested after-fix runtime evidence because the earlier body said the candidate had not executed. The linked current-head CI job and explicit assertion results above address that request and its runtime-trace rank-up move. This evidence update supports the automatic review refresh; no code finding remained.

Thanks to @RileyJJY for the original fix and response-stream reproduction.
