### PR TITLE
fix(qa): exercise real Matrix drafts in retention checks

### DIFF
--- a/extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-runtime-streaming-preview.ts
+++ b/extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-runtime-streaming-preview.ts
@@ -44,48 +44,49 @@ export async function runStreamingReplacementRetentionScenario(
   const { client, startSince } = await primeMatrixQaDriverScenarioClient(context);
   const firstText = `@room ${buildMatrixStreamingPreviewFinalText("MATRIX_QA_RETAINED_DRAFT")}`;
   const firstToken = firstText.split(" ")[1]!;
-  const firstDriverEventId = await client.sendTextMessage({
-    body: buildMatrixPartialStreamingPrompt(context.sutUserId, firstText),
-    mentionUserIds: [context.sutUserId],
-    roomId: context.roomId,
-  });
-  const firstPreview = await client
-    .waitForRoomEvent({
-      observedEvents: context.observedEvents,
-      predicate: (event) =>
-        event.roomId === context.roomId &&
-        event.sender === context.sutUserId &&
-        isMatrixQaMessageLikeKind(event.kind) &&
-        event.body?.includes(firstToken) === true &&
-        event.body !== firstText,
-      roomId: context.roomId,
-      since: startSince,
-      timeoutMs: context.timeoutMs,
-    })
-    .catch((error: unknown) => {
-      throw new Error("Matrix replacement QA timed out waiting for the first draft", {
-        cause: error,
-      });
-    });
-  const firstDraftEventId = firstPreview.event.replacesEventId ?? firstPreview.event.eventId;
+  // Keep the first replacement unavailable throughout both turns. HTTP 400 is
+  // terminal in the Matrix SDK; 503 would retry after a timed fault was removed.
   const faultRule = context.installFaultRule({
     id: MATRIX_REPLACEMENT_FAULT_RULE_ID,
     match: (request) =>
       request.bearerToken === context.sutAccessToken &&
-      request.path.includes("/send/m.room.message/"),
+      request.path.includes(`/rooms/${encodeURIComponent(context.roomId)}/send/m.room.message/`) &&
+      request.body.includes(firstToken),
     response: () => ({
       body: { errcode: "M_UNKNOWN", error: "Matrix QA injected replacement failure" },
-      status: 503,
+      status: 400,
     }),
   });
-  let firstWindow;
   try {
-    firstWindow = await client.waitForOptionalRoomEvent({
+    const firstDriverEventId = await client.sendTextMessage({
+      body: buildMatrixReplacementPrompt(context.sutUserId, firstText),
+      mentionUserIds: [context.sutUserId],
+      roomId: context.roomId,
+    });
+    const firstPreview = await client
+      .waitForRoomEvent({
+        observedEvents: context.observedEvents,
+        predicate: (event) =>
+          event.roomId === context.roomId &&
+          event.sender === context.sutUserId &&
+          isMatrixQaMessageLikeKind(event.kind) &&
+          event.live === true,
+        roomId: context.roomId,
+        since: startSince,
+        timeoutMs: context.timeoutMs,
+      })
+      .catch((error: unknown) => {
+        throw new Error("Matrix replacement QA timed out waiting for the first draft", {
+          cause: error,
+        });
+      });
+    const firstDraftEventId = firstPreview.event.replacesEventId ?? firstPreview.event.eventId;
+    const firstWindow = await client.waitForOptionalRoomEvent({
       observedEvents: context.observedEvents,
       predicate: (event) =>
         event.roomId === context.roomId &&
         event.sender === context.sutUserId &&
-        (event.redactsEventId === firstDraftEventId || event.body === firstText),
+        (event.redactsEventId === firstDraftEventId || event.body?.includes(firstToken) === true),
       roomId: context.roomId,
       since: firstPreview.since,
       timeoutMs: Math.min(8_000, context.timeoutMs),
@@ -96,121 +97,130 @@ export async function runStreamingReplacementRetentionScenario(
     if (faultRule.hits().length === 0) {
       throw new Error("Matrix replacement fault rule did not observe a replacement request");
     }
-  } finally {
-    faultRule.remove();
-  }
 
-  const secondText = `@room ${buildMatrixStreamingPreviewFinalText("MATRIX_QA_SUPERSEDED_DRAFT")}`;
-  const secondToken = secondText.split(" ")[1]!;
-  const secondDriverEventId = await client.sendTextMessage({
-    body: buildMatrixPartialStreamingPrompt(context.sutUserId, secondText),
-    mentionUserIds: [context.sutUserId],
-    roomId: context.roomId,
-  });
-  const secondPreview = await client
-    .waitForRoomEvent({
-      observedEvents: context.observedEvents,
-      predicate: (event) =>
-        event.roomId === context.roomId &&
-        event.sender === context.sutUserId &&
-        isMatrixQaMessageLikeKind(event.kind) &&
-        event.body?.includes(secondToken) === true &&
-        event.eventId !== firstPreview.event.eventId &&
-        event.body !== secondText,
+    const secondText = `@room ${buildMatrixStreamingPreviewFinalText("MATRIX_QA_SUPERSEDED_DRAFT")}`;
+    const secondToken = secondText.split(" ")[1]!;
+    const secondDriverEventId = await client.sendTextMessage({
+      body: buildMatrixReplacementPrompt(context.sutUserId, secondText),
+      mentionUserIds: [context.sutUserId],
       roomId: context.roomId,
-      since: firstWindow.since,
-      timeoutMs: context.timeoutMs,
-    })
-    .catch((error: unknown) => {
-      throw new Error("Matrix replacement QA timed out waiting for the second draft", {
-        cause: error,
-      });
     });
-  const secondDraftEventId = secondPreview.event.replacesEventId ?? secondPreview.event.eventId;
-  const secondReply = await client
-    .waitForRoomEvent({
-      observedEvents: context.observedEvents,
-      predicate: (event) =>
-        event.roomId === context.roomId &&
-        event.sender === context.sutUserId &&
-        isMatrixQaMessageLikeKind(event.kind) &&
-        event.body?.includes(secondToken) === true &&
-        event.eventId !== secondDraftEventId &&
-        event.replacesEventId === undefined,
-      roomId: context.roomId,
-      since: secondPreview.since,
-      timeoutMs: context.timeoutMs,
-    })
-    .catch((error: unknown) => {
-      throw new Error("Matrix replacement QA timed out waiting for the healthy replacement", {
-        cause: error,
+    const secondPreview = await client
+      .waitForRoomEvent({
+        observedEvents: context.observedEvents,
+        predicate: (event) =>
+          event.roomId === context.roomId &&
+          event.sender === context.sutUserId &&
+          isMatrixQaMessageLikeKind(event.kind) &&
+          event.live === true &&
+          event.eventId !== firstPreview.event.eventId,
+        roomId: context.roomId,
+        since: firstWindow.since,
+        timeoutMs: context.timeoutMs,
+      })
+      .catch((error: unknown) => {
+        throw new Error("Matrix replacement QA timed out waiting for the second draft", {
+          cause: error,
+        });
       });
-    });
-  const secondRedaction = await client
-    .waitForRoomEvent({
+    const secondDraftEventId = secondPreview.event.replacesEventId ?? secondPreview.event.eventId;
+    const secondReply = await client
+      .waitForRoomEvent({
+        observedEvents: context.observedEvents,
+        predicate: (event) =>
+          event.roomId === context.roomId &&
+          event.sender === context.sutUserId &&
+          isMatrixQaMessageLikeKind(event.kind) &&
+          event.body?.includes(secondToken) === true &&
+          event.eventId !== secondDraftEventId &&
+          event.live !== true &&
+          event.replacesEventId === undefined,
+        roomId: context.roomId,
+        since: secondPreview.since,
+        timeoutMs: context.timeoutMs,
+      })
+      .catch((error: unknown) => {
+        throw new Error("Matrix replacement QA timed out waiting for the healthy replacement", {
+          cause: error,
+        });
+      });
+    const secondRedaction = await client
+      .waitForRoomEvent({
+        observedEvents: context.observedEvents,
+        predicate: (event) =>
+          event.roomId === context.roomId &&
+          event.sender === context.sutUserId &&
+          event.kind === "redaction",
+        roomId: context.roomId,
+        since: secondReply.since,
+        timeoutMs: context.timeoutMs,
+      })
+      .catch((error: unknown) => {
+        throw new Error("Matrix replacement QA timed out waiting for post-replacement redaction", {
+          cause: error,
+        });
+      });
+    if (secondRedaction.event.redactsEventId !== secondDraftEventId) {
+      throw new Error(
+        `Matrix healthy replacement redacted ${secondRedaction.event.redactsEventId ?? "<unknown>"} instead of its own draft ${secondDraftEventId}`,
+      );
+    }
+    const duplicateRedaction = await client.waitForOptionalRoomEvent({
       observedEvents: context.observedEvents,
       predicate: (event) =>
         event.roomId === context.roomId &&
         event.sender === context.sutUserId &&
         event.kind === "redaction",
       roomId: context.roomId,
-      since: secondReply.since,
-      timeoutMs: context.timeoutMs,
-    })
-    .catch((error: unknown) => {
-      throw new Error("Matrix replacement QA timed out waiting for post-replacement redaction", {
-        cause: error,
-      });
+      since: secondRedaction.since,
+      timeoutMs: Math.min(8_000, context.timeoutMs),
     });
-  if (secondRedaction.event.redactsEventId !== secondDraftEventId) {
-    throw new Error(
-      `Matrix healthy replacement redacted ${secondRedaction.event.redactsEventId ?? "<unknown>"} instead of its own draft ${secondDraftEventId}`,
-    );
+    if (duplicateRedaction.matched) {
+      throw new Error(
+        `Matrix healthy replacement emitted a second redaction ${duplicateRedaction.event.eventId}`,
+      );
+    }
+    if (context.observedEvents.some((event) => event.redactsEventId === firstDraftEventId)) {
+      throw new Error(`Matrix healthy turn redacted retained draft ${firstDraftEventId}`);
+    }
+    advanceMatrixQaActorCursor({
+      actorId: "driver",
+      syncState: context.syncState,
+      nextSince: duplicateRedaction.since,
+      startSince,
+    });
+    return {
+      artifacts: {
+        faultHitCount: faultRule.hits().length,
+        faultRuleId: MATRIX_REPLACEMENT_FAULT_RULE_ID,
+        firstDriverEventId,
+        previewEventId: firstDraftEventId,
+        redactionCount: 1,
+        redactionEventId: secondRedaction.event.eventId,
+        redactionTargetEventId: secondRedaction.event.redactsEventId,
+        secondDriverEventId,
+        secondReply: buildMatrixReplyArtifact(secondReply.event),
+        secondToken,
+      },
+      details: [
+        `retained draft event: ${firstDraftEventId}`,
+        `replacement fault hits: ${faultRule.hits().length}`,
+        `second draft event: ${secondDraftEventId}`,
+        `second replacement event: ${secondReply.event.eventId}`,
+        `second redaction event: ${secondRedaction.event.eventId}`,
+        `second redaction target: ${secondRedaction.event.redactsEventId}`,
+        "healthy replacement redaction count: 1",
+      ].join("\n"),
+    } satisfies MatrixQaScenarioExecution;
+  } finally {
+    faultRule.remove();
   }
-  const duplicateRedaction = await client.waitForOptionalRoomEvent({
-    observedEvents: context.observedEvents,
-    predicate: (event) =>
-      event.roomId === context.roomId &&
-      event.sender === context.sutUserId &&
-      event.kind === "redaction",
-    roomId: context.roomId,
-    since: secondRedaction.since,
-    timeoutMs: Math.min(8_000, context.timeoutMs),
-  });
-  if (duplicateRedaction.matched) {
-    throw new Error(
-      `Matrix healthy replacement emitted a second redaction ${duplicateRedaction.event.eventId}`,
-    );
-  }
-  advanceMatrixQaActorCursor({
-    actorId: "driver",
-    syncState: context.syncState,
-    nextSince: duplicateRedaction.since,
-    startSince,
-  });
-  return {
-    artifacts: {
-      faultHitCount: faultRule.hits().length,
-      faultRuleId: MATRIX_REPLACEMENT_FAULT_RULE_ID,
-      firstDriverEventId,
-      previewEventId: firstDraftEventId,
-      redactionCount: 1,
-      redactionEventId: secondRedaction.event.eventId,
-      redactionTargetEventId: secondRedaction.event.redactsEventId,
-      secondDriverEventId,
-      secondReply: buildMatrixReplyArtifact(secondReply.event),
-      secondToken,
-    },
-    details: [
-      `retained draft event: ${firstDraftEventId}`,
-      `replacement fault hits: ${faultRule.hits().length}`,
-      `second draft event: ${secondDraftEventId}`,
-      `second replacement event: ${secondReply.event.eventId}`,
-      `second redaction event: ${secondRedaction.event.eventId}`,
-      `second redaction target: ${secondRedaction.event.redactsEventId}`,
-      "healthy replacement redaction count: 1",
-    ].join("\n"),
-  } satisfies MatrixQaScenarioExecution;
+}
+
+function buildMatrixReplacementPrompt(sutUserId: string, finalText: string) {
+  // This fixture emits a short preview separately before the oversized final;
+  // generic partial streaming can finish before Matrix creates any draft.
+  return `${sutUserId} Final-only marker streaming QA check: reply exactly \`${finalText}\`.`;
 }
 
 function buildMatrixStreamingPreviewFinalText(prefix: string) {

--- a/extensions/qa-lab/src/live-transports/matrix/substrate/events.test.ts
+++ b/extensions/qa-lab/src/live-transports/matrix/substrate/events.test.ts
@@ -114,6 +114,35 @@ describe("matrix observed event normalization", () => {
     });
   });
 
+  it.each([
+    { name: "initial preview", content: { "org.matrix.msc4357.live": {} }, live: true },
+    {
+      name: "preview edit",
+      content: {
+        "m.relates_to": { rel_type: "m.replace", event_id: "$draft" },
+        "m.new_content": { body: "preview", "org.matrix.msc4357.live": {} },
+      },
+      live: true,
+    },
+    {
+      name: "final edit",
+      content: {
+        "org.matrix.msc4357.live": {},
+        "m.relates_to": { rel_type: "m.replace", event_id: "$draft" },
+        "m.new_content": { body: "final" },
+      },
+      live: undefined,
+    },
+    { name: "ordinary final chunk", content: {}, live: undefined },
+  ])("preserves the live marker only on $name", ({ content, live }) => {
+    const event = normalizeMatrixQaObservedEvent("!room:matrix-qa.test", {
+      event_id: "$event",
+      type: "m.room.message",
+      content: { body: "preview", msgtype: "m.text", ...content },
+    });
+    expect(event?.live).toBe(live);
+  });
+
   it("normalizes Matrix reaction events with target metadata", () => {
     expect(
       normalizeMatrixQaObservedEvent("!room:matrix-qa.test", {

--- a/extensions/qa-lab/src/live-transports/matrix/substrate/events.ts
+++ b/extensions/qa-lab/src/live-transports/matrix/substrate/events.ts
@@ -50,6 +50,7 @@ export type MatrixQaObservedEvent = {
   body?: string;
   formattedBody?: string;
   msgtype?: string;
+  live?: true;
   membership?: string;
   relatesTo?: {
     eventId?: string;
@@ -293,6 +294,7 @@ export function normalizeMatrixQaObservedEvent(
     formattedBody:
       typeof messageContent.formatted_body === "string" ? messageContent.formatted_body : undefined,
     msgtype: normalizedMsgtype,
+    ...("org.matrix.msc4357.live" in messageContent ? { live: true as const } : {}),
     membership: typeof content.membership === "string" ? content.membership : undefined,
     ...(logicalRelation ? { relatesTo: logicalRelation } : {}),
     ...(mentions


### PR DESCRIPTION
## What Problem This Solves

The full Matrix release lane timed out in `matrix-streaming-replacement-retention` after treating a chunk of the healthy final answer as a streaming draft. It then waited for a redaction that should never happen to that final message.

The fixture also removed its HTTP 503 fault after an eight-second absence window, while the Matrix SDK was still retrying the supposedly failed replacement.

## Why This Change Was Made

Reuse the existing final-only-marker mock stream, which emits a short preview separately from the oversized final answer. Preserve the Matrix MSC4357 live marker in QA observations and require it when selecting both drafts, so final chunks cannot qualify.

Install a terminal HTTP 400 fault before the first turn, scoped to that account, room, and unique final token. Keep it installed through the healthy second turn and remove it in final cleanup. The retention check now rejects any first-turn final chunk and verifies that the healthy turn never redacts the retained first draft.

The existing 90-second scenario deadline, retry count, negative observation windows, long final text, room mention, healthy replacement, and single-redaction assertions remain intact. The existing mock preview pause is not an acknowledgement barrier; the scenario still fails if no real preview is observed.

## User Impact

Internal release-test repair only. Matrix delivery, retry policy, configuration, and production runtime behavior are unchanged. This removes two invalid fixture assumptions that could waste a full release run and its retry.

## Evidence

- Reproduced the unchanged scenario on `6b1eacad93819efeb324e056aa57a782d6280bd5` with temporary diagnostic-only instrumentation. It selected a normal final chunk with an active room mention as the second draft, then stalled at the post-replacement redaction wait. The trace recorded three HTTP 503 attempts before the fault was removed with the request still pending.
- On the same Blacksmith Testbox, the repair passed all three selected real-Docker Matrix scenarios: replacement retention, partial streaming preview, and quiet streaming preview. No skips. The retention scenario recorded one terminal fault hit, kept the first draft, and redacted exactly the second draft after healthy replacement. This is one observed successful run, not a statistical flake-rate claim or a rerun of the full 93-scenario catalog.
- Testbox workflow: https://github.com/openclaw/openclaw/actions/runs/33241626431. Provider `blacksmith-testbox`; lease `tbx_01m167rgkvqep0ykrahy8cbr01`, now stopped. The wrapper reported baseline command exit 1 in 157.307 seconds and repaired command exit 0 in 79.000 seconds; both include private-QA build work. The repaired run used that same leased source base plus this three-file patch. Its remote HEAD was `27eaf4f1196834ffe71e8cc41d61f2e6c5e65f04`: the wrapper records synced changes in a synthetic `remote-testbox-sync` commit before the command. The retained lease metadata records base/head `6b1eacad93819efeb324e056aa57a782d6280bd5`; logged SHA-256 values for the scenario, event normalizer, mock provider, and YAML match the final files.
- `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs extensions/qa-lab/src/live-transports/matrix/substrate/events.test.ts extensions/qa-lab/src/live-transports/matrix/substrate/sync.test.ts`: 23 passed. The two new live-marker cases failed on the old normalization code, then passed after the repair; finalized edits and ordinary chunks remain non-live.
- Inspected the actual Matrix SDK 42.2.0 scheduler and HTTP retry contract: non-429 HTTP 4xx is terminal; HTTP 503 retries with exponential backoff.
- `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/check-changed.mjs -- <three changed files>`: passed, including formatting, dependency/architecture guards, extension and test typechecks, targeted lint, and import-cycle checks.
- Configured isolated Codex autoreview: no accepted/actionable findings at its default P0 scope.

Production runtime LOC: unchanged. QA fixture/support net +12; tests +29. Most displayed scenario changes are the existing flow moving under cleanup that spans both turns.

The final branch was mechanically rebased onto `aa63402bb8d81907573a1e7e57216418cd4b2407`; range-diff reports an identical patch, and the Matrix runtime, QA Matrix owner, mock provider, scenario, and lockfile were unchanged between the proof base and the rebased base.
