### PR TITLE
fix(acp): settle the ledger record when session update delivery fails

### DIFF
--- a/src/acp/translator.session-updates.test.ts
+++ b/src/acp/translator.session-updates.test.ts
@@ -102,6 +102,37 @@ describe("AcpTranslatorSessionUpdates", () => {
     expect(ledger.recordUpdate).not.toHaveBeenCalled();
   });
 
+  it("settles the ledger record before propagating a delivery failure", async () => {
+    const ledger = createLedger();
+    let recordSettled = false;
+    vi.mocked(ledger.recordUpdate).mockImplementation(async () => {
+      await new Promise((resolve) => {
+        setTimeout(resolve, 20);
+      });
+      recordSettled = true;
+    });
+    const updates = createUpdates({
+      ledger,
+      sessionUpdate: vi.fn(async () => {
+        throw new Error("client gone");
+      }),
+    });
+
+    await expect(
+      updates.emit({
+        sessionId: "session-1",
+        sessionKey: "agent:main:session-1",
+        record: true,
+        update,
+      }),
+    ).rejects.toThrow("client gone");
+
+    // The delivery error must still propagate, but only after the ledger write
+    // settled — replay readers rely on every emitted update being recorded.
+    expect(ledger.recordUpdate).toHaveBeenCalledTimes(1);
+    expect(recordSettled).toBe(true);
+  });
+
   it("preserves ledger order without waiting for ACP delivery", async () => {
     let releaseFirstDelivery!: () => void;
     const firstDelivery = new Promise<void>((resolve) => {

--- a/src/acp/translator.session-updates.ts
+++ b/src/acp/translator.session-updates.ts
@@ -157,14 +157,22 @@ export class AcpTranslatorSessionUpdates {
             update: params.update,
           })
         : undefined;
-    if (params.waitForDelivery === false) {
-      void delivery.catch((err: unknown) => {
-        this.options.log(`session update delivery failed for ${params.sessionId}: ${String(err)}`);
-      });
-    } else {
-      await delivery;
+    try {
+      if (params.waitForDelivery === false) {
+        void delivery.catch((err: unknown) => {
+          this.options.log(
+            `session update delivery failed for ${params.sessionId}: ${String(err)}`,
+          );
+        });
+      } else {
+        await delivery;
+      }
+    } finally {
+      // The ledger write must settle even when delivery rejects: callers absorb
+      // delivery errors (e.g. finishPrompt) and still rely on the replay ledger
+      // reflecting every emitted update before the turn settles.
+      await recording;
     }
-    await recording;
   }
 
   async sendAvailableCommands(


### PR DESCRIPTION
## What Problem This Solves

Fixes #132497

`AcpTranslatorSessionUpdates.emit()` mirrors every replayable ACP update into the replay ledger — the class contract is "keeps ACP client updates and replay ledger writes in sync". But it only awaits the ledger record **after** a successful ACP delivery: when the client rejects the `sessionUpdate` delivery (e.g. a disconnecting client), `emit()` propagates the delivery error and the `await recording` line never runs, orphaning the ledger write.

Callers that absorb the delivery error make this user-visible: `finishPrompt`'s snapshot path (`src/acp/translator.prompt-stream.ts`) catches delivery rejections and still resolves the prompt, so the turn settles while the terminal update's ledger record is still in flight. A replay read landing in that window sees a ledger that looks complete but is missing the final update(s) — with no incomplete marker, because `recordLedgerUpdate` only marks the ledger incomplete when the *write itself* fails. Silent-failure class: the replay presents an incomplete transcript as complete.

## Why This Change Was Made

`emit()` now settles the recording side in a `finally`: the delivery error still propagates to the caller exactly as before, just after the ledger write has completed. The `waitForDelivery: false` (best-effort) path is behavior-identical — it already fell through to the same `await recording` line, and it still does. No new helpers, no signature changes; one inline comment records the invariant at the code site.

This shape also matches the precedent in `src/acp/event-ledger` callers and the deferred-delivery branch discussed in #109973, where the ledger write is likewise awaited before delivery is released.

## User Impact

- Before: a client that disconnects/rejects mid-delivery can leave the session's replay ledger missing the final updates while still looking complete — a reconnecting client replays a silently truncated transcript.
- After: the ledger record is guaranteed settled before the delivery error propagates, so replay either contains the update or (if the write itself failed) is marked incomplete as before.

## Evidence

Regression test in `src/acp/translator.session-updates.test.ts` (`settles the ledger record before propagating a delivery failure`): rejecting `sessionUpdate` + deferred `recordUpdate`; asserts the delivery error still propagates **and** the ledger write has settled by the time it does.

- Pre-fix (prod file reverted, test kept): **1 failed | 4 passed** — `emit()` rejected before the write settled.
- Post-fix: **5 passed (5)**.
- Full ACP lane, exact-head terminal proof on `945538b8c3f` (Docker, Node v24.18.0, Debian 12):

```text
$ node scripts/run-vitest.mjs run src/acp/
 Test Files  63 passed (63)
      Tests  572 passed (572)
```

Proof-scope note: the change is a bridge-internal settle-ordering invariant (not channel-visible behavior), so the boundary proof is the regression test driving the real class with a rejecting connection + deferred ledger — the exact fault pair the bug needs — rather than a mock-gateway run. `tsgo` cannot complete in the 15 GB proof box (OOM at ~11.5 GB RSS); full typecheck is left to CI. The diff restructures one statement into `try/finally` with no type surface change.

Production diff: +15/-7 in `emit()` (try/finally + invariant comment). Test diff: one regression test.
