### PR TITLE
test: run native Codex live fixture through built Gateway

### DIFF
--- a/src/gateway/gateway-codex-harness.fixture.test.ts
+++ b/src/gateway/gateway-codex-harness.fixture.test.ts
@@ -1,0 +1,147 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  createCodexHarnessLiveInstance,
+  createCodexHarnessEventCapture,
+  readCodexNativeUsageSnapshots,
+  CODEX_HARNESS_CONTEXT_EVENT_PREFIXES,
+} from "../../test/helpers/gateway-codex-harness.js";
+import { withIsolatedTestHome } from "../../test/test-env.js";
+import { withEnvAsync } from "../test-utils/env.js";
+
+describe("native Codex fixture boundaries", () => {
+  it.each([
+    { authMode: undefined, customHome: false, baseUrl: "https://example.invalid/v1" },
+    { authMode: undefined, customHome: true, baseUrl: "https://example.invalid/v1" },
+    { authMode: "api-key" as const, customHome: true, baseUrl: "https://example.invalid/v1" },
+    { authMode: "api-key" as const, customHome: false, baseUrl: "  " },
+    { authMode: "api-key" as const, customHome: true, baseUrl: " https://example.invalid/v1 " },
+  ])(
+    "preserves staged native home ($authMode, custom=$customHome, url=$baseUrl)",
+    async ({ authMode, customHome, baseUrl }) => {
+      const root = await fs.realpath(
+        await fs.mkdtemp(path.join(os.tmpdir(), "codex-fixture-env-")),
+      );
+      const nativeHome = path.join(root, customHome ? "custom-codex" : ".codex");
+      await fs.mkdir(nativeHome, { recursive: true });
+      const sentinels = {
+        "auth.json": '{"fixture":"not-a-credential"}\n',
+        "config.toml": "# synthetic staged config\n",
+      };
+      for (const [name, contents] of Object.entries(sentinels)) {
+        await fs.writeFile(path.join(nativeHome, name), contents);
+      }
+      try {
+        await withEnvAsync(
+          {
+            HOME: root,
+            USERPROFILE: root,
+            OPENCLAW_HOME: root,
+            OPENCLAW_STATE_DIR: path.join(root, "source-state"),
+            OPENCLAW_CONFIG_PATH: path.join(root, "source-config.json"),
+            OPENCLAW_LIVE_TEST: "1",
+            OPENCLAW_LIVE_USE_REAL_HOME: undefined,
+            CODEX_HOME: customHome ? nativeHome : undefined,
+            OPENAI_API_KEY: "synthetic-fixture-key",
+            OPENAI_BASE_URL: baseUrl,
+          },
+          async () => {
+            const staged = withIsolatedTestHome({ loadProfileEnv: false });
+            try {
+              const callerHome = process.env.HOME;
+              const instance = await createCodexHarnessLiveInstance(
+                "fixture-gateway-token",
+                authMode,
+              );
+              try {
+                expect(process.env.HOME).toBe(callerHome);
+                expect(instance.env.HOME).toBe(callerHome);
+                expect(instance.env.USERPROFILE).toBe(process.env.USERPROFILE);
+                expect(instance.env.OPENCLAW_HOME).toBe(process.env.OPENCLAW_HOME);
+                expect(instance.env.CODEX_HOME).toBe(customHome ? nativeHome : undefined);
+                const resolvedHome =
+                  instance.env.CODEX_HOME ?? path.join(instance.env.HOME!, ".codex");
+                for (const [name, contents] of Object.entries(sentinels)) {
+                  expect(await fs.readFile(path.join(resolvedHome, name), "utf8")).toBe(contents);
+                }
+                expect(instance.env.OPENAI_API_KEY).toBe(
+                  authMode === "api-key" ? "synthetic-fixture-key" : undefined,
+                );
+                expect(instance.env.OPENAI_BASE_URL).toBe(
+                  authMode === "api-key" && baseUrl.trim() ? baseUrl : undefined,
+                );
+                expect(instance.stateDir.startsWith(instance.state.root + path.sep)).toBe(true);
+                expect(instance.configPath.startsWith(instance.state.root + path.sep)).toBe(true);
+                expect(instance.state.workspaceDir.startsWith(instance.state.root + path.sep)).toBe(
+                  true,
+                );
+                expect(instance.stateDir.startsWith(staged.tempHome + path.sep)).toBe(false);
+                instance.state.applyEnv();
+                expect(process.env.HOME).toBe(callerHome);
+                expect(process.env.OPENCLAW_STATE_DIR).toBe(instance.stateDir);
+              } finally {
+                await instance.cleanup();
+              }
+              expect(process.env.HOME).toBe(callerHome);
+            } finally {
+              staged.cleanup();
+            }
+          },
+        );
+      } finally {
+        await fs.rm(root, { recursive: true, force: true });
+      }
+    },
+  );
+
+  it("retains full-context usage through the request capture and snapshot reader", () => {
+    const capture = createCodexHarnessEventCapture({
+      sessionKey: "session-a",
+      eventPrefixes: CODEX_HARNESS_CONTEXT_EVENT_PREFIXES,
+    });
+    capture.start(100);
+    const usage = {
+      activeContextTokens: 300_010,
+      promptTokens: 300_000,
+      modelContextWindow: 875_900,
+      cachedInputTokens: 250_000,
+      cacheWriteInputTokens: 5_000,
+      inputTokens: 300_000,
+      outputTokens: 10,
+    };
+    const emit = (stream: string, data: Record<string, unknown>, sessionKey = "session-a") =>
+      capture.onAgentEvent({ runId: "run-a", seq: 1, ts: 125, stream, data, sessionKey });
+    emit("assistant", { text: "first" }, "session-b");
+    expect(capture.firstAssistantMs).toBeUndefined();
+    emit("assistant", { text: "first" });
+    emit("codex_app_server.lifecycle", { phase: "turn_starting" });
+    emit("codex_app_server.guardian", { phase: "completed", status: "approved" });
+    emit("compaction", { phase: "end", completed: true });
+    emit("usage", usage, "session-b");
+    emit("tool", { phase: "result" });
+    emit("usage", usage);
+    expect(readCodexNativeUsageSnapshots(capture.events)).toEqual([usage]);
+    expect(capture.events.map(({ stream }) => stream)).toEqual([
+      "codex_app_server.lifecycle",
+      "codex_app_server.guardian",
+      "compaction",
+      "usage",
+    ]);
+    expect(capture.firstAssistantMs).toBe(25);
+    const guardian = createCodexHarnessEventCapture({
+      sessionKey: "session-a",
+      includeAllSessions: true,
+    });
+    guardian.onAgentEvent({
+      runId: "run-b",
+      seq: 1,
+      ts: 200,
+      stream: "codex_app_server.guardian",
+      sessionKey: "session-b",
+      data: { phase: "completed" },
+    });
+    expect(guardian.events).toHaveLength(1);
+  });
+});

--- a/src/gateway/gateway-codex-harness.live.test.ts
+++ b/src/gateway/gateway-codex-harness.live.test.ts
@@ -1,14 +1,24 @@
 // Codex harness live gateway tests exercise real CLI backend sessions, cron probes, media probes, and command surfaces.
 import { randomBytes, randomUUID } from "node:crypto";
 import fs from "node:fs/promises";
-import { createServer } from "node:net";
-import os from "node:os";
 import path from "node:path";
 import { setTimeout as delay } from "node:timers/promises";
 import { asOptionalRecord } from "@openclaw/normalization-core/record-coerce";
 import { describe, expect, it } from "vitest";
 import { GATEWAY_CLIENT_CAPS } from "../../packages/gateway-protocol/src/client-info.js";
-import type { EventFrame } from "../../packages/gateway-protocol/src/index.js";
+import type {
+  EventFrame,
+  TasksListResult,
+  ToolsInvokeResult,
+} from "../../packages/gateway-protocol/src/index.js";
+import {
+  createCodexHarnessLiveInstance,
+  createCodexHarnessEventCapture,
+  readCodexNativeUsageSnapshots,
+  CODEX_HARNESS_CONTEXT_EVENT_PREFIXES,
+  type CapturedAgentEvent,
+  type CodexNativeUsageSnapshot,
+} from "../../test/helpers/gateway-codex-harness.js";
 import {
   renderBitmapTextPngBase64,
   renderSolidColorPngBase64,
@@ -20,12 +30,10 @@ import {
 } from "../../test/helpers/openai-long-context-live.js";
 import { isLiveTestEnabled } from "../agents/live-test-helpers.js";
 import type { OpenClawConfig } from "../config/config.js";
-import type { ContextEngine } from "../context-engine/types.js";
+import type { AgentEventPayload } from "../infra/agent-events.js";
 import { isTruthyEnvValue } from "../infra/env.js";
 import { pluginStateEntriesInKeyRange } from "../plugin-state/plugin-state-store.js";
 import { extractFirstTextBlock } from "../shared/chat-message-content.js";
-import { setTestEnvValue } from "../test-utils/env.js";
-import type { CallGatewayOptions } from "./call.js";
 import type { GatewayClient } from "./client.js";
 import {
   connectTestGatewayClient,
@@ -52,7 +60,6 @@ import {
   runOpenClawCliJson,
   type CronListJob,
 } from "./live-agent-probes.js";
-import { restoreLiveEnv, snapshotLiveEnv, type LiveEnvSnapshot } from "./live-env-test-helpers.js";
 
 const LIVE = isLiveTestEnabled();
 const CODEX_HARNESS_LIVE = isTruthyEnvValue(process.env.OPENCLAW_LIVE_CODEX_HARNESS);
@@ -195,26 +202,9 @@ const CODEX_HARNESS_SUPPORTED_EFFORTS = new Map<string, readonly string[]>([
   ["gpt-5.2", ["low", "medium", "high", "xhigh"]],
 ]);
 
-type CapturedAgentEvent = {
-  stream: string;
-  data?: Record<string, unknown>;
-  sessionKey?: string;
-  ts?: number;
-};
-
 type CodexHarnessAttemptUsage = Partial<
   Record<"cacheRead" | "cacheWrite" | "input" | "output" | "total", number>
 >;
-
-type CodexNativeUsageSnapshot = {
-  activeContextTokens: number;
-  cachedInputTokens?: number;
-  cacheWriteInputTokens?: number;
-  inputTokens?: number;
-  modelContextWindow: number;
-  outputTokens?: number;
-  promptTokens: number;
-};
 
 type CodexHarnessAgentResult = {
   compactionCount: number;
@@ -318,45 +308,6 @@ function logCodexLiveStep(step: string, details?: Record<string, unknown>): void
   console.error(`[gateway-codex-live] ${step}${suffix}`);
 }
 
-function readCodexNativeUsageSnapshots(
-  events: readonly CapturedAgentEvent[],
-): CodexNativeUsageSnapshot[] {
-  return events.flatMap((event) => {
-    if (event.stream !== "usage") {
-      return [];
-    }
-    const activeContextTokens = event.data?.activeContextTokens;
-    const modelContextWindow = event.data?.modelContextWindow;
-    const promptTokens = event.data?.promptTokens;
-    if (
-      typeof activeContextTokens !== "number" ||
-      typeof modelContextWindow !== "number" ||
-      typeof promptTokens !== "number"
-    ) {
-      return [];
-    }
-    const optionalNumber = (key: string): number | undefined => {
-      const value = event.data?.[key];
-      return typeof value === "number" ? value : undefined;
-    };
-    const cachedInputTokens = optionalNumber("cachedInputTokens");
-    const cacheWriteInputTokens = optionalNumber("cacheWriteInputTokens");
-    const inputTokens = optionalNumber("inputTokens");
-    const outputTokens = optionalNumber("outputTokens");
-    return [
-      {
-        activeContextTokens,
-        modelContextWindow,
-        promptTokens,
-        ...(cachedInputTokens !== undefined ? { cachedInputTokens } : {}),
-        ...(cacheWriteInputTokens !== undefined ? { cacheWriteInputTokens } : {}),
-        ...(inputTokens !== undefined ? { inputTokens } : {}),
-        ...(outputTokens !== undefined ? { outputTokens } : {}),
-      },
-    ];
-  });
-}
-
 function readCompletedCodexCompactionStats(events: readonly CapturedAgentEvent[]): {
   count: number;
   durationMs?: number;
@@ -424,12 +375,22 @@ function isCodexAccountTokenError(error: unknown): boolean {
   return error instanceof Error && error.message.includes("Failed to extract accountId from token");
 }
 
+// Subscribe only to frames from the actual Gateway process; source-local event
+// buses would observe a different runtime than bundled plugin completion delivery.
+const gatewayAgentEventListeners = new Set<(event: AgentEventPayload) => void>();
+
+function onGatewayAgentEvent(listener: (event: AgentEventPayload) => void): () => void {
+  gatewayAgentEventListeners.add(listener);
+  return () => {
+    gatewayAgentEventListeners.delete(listener);
+  };
+}
+
 async function subscribeCodexLiveDebugEvents(sessionKey: string): Promise<() => void> {
   if (!CODEX_HARNESS_DEBUG) {
     return () => undefined;
   }
-  const { onAgentEvent } = await import("../infra/agent-events.js");
-  return onAgentEvent((event) => {
+  return onGatewayAgentEvent((event) => {
     if (event.sessionKey && event.sessionKey !== sessionKey) {
       return;
     }
@@ -441,33 +402,7 @@ async function subscribeCodexLiveDebugEvents(sessionKey: string): Promise<() => 
   });
 }
 
-function snapshotEnv(): LiveEnvSnapshot {
-  return snapshotLiveEnv(["OPENCLAW_ALLOW_SLOW_REPLY_TESTS"]);
-}
-
-function restoreEnv(snapshot: LiveEnvSnapshot): void {
-  restoreLiveEnv(snapshot);
-}
-
-async function getFreeGatewayPort(): Promise<number> {
-  const server = createServer();
-  await new Promise<void>((resolve, reject) => {
-    server.once("error", reject);
-    server.listen(0, "127.0.0.1", resolve);
-  });
-  const address = server.address();
-  const port = typeof address === "object" && address ? address.port : 0;
-  await new Promise<void>((resolve, reject) => {
-    server.close((error) => (error ? reject(error) : resolve()));
-  });
-  if (port <= 0) {
-    throw new Error("failed to allocate gateway port");
-  }
-  return port;
-}
-
-async function createLiveWorkspace(tempDir: string): Promise<string> {
-  const workspace = path.join(tempDir, "workspace");
+async function createLiveWorkspace(workspace: string): Promise<void> {
   await fs.mkdir(workspace, { recursive: true });
   await fs.writeFile(
     path.join(workspace, "AGENTS.md"),
@@ -478,32 +413,6 @@ async function createLiveWorkspace(tempDir: string): Promise<string> {
       "Do not add commentary when asked for an exact response.",
     ].join("\n"),
   );
-  return workspace;
-}
-
-async function removeLiveTempDir(dir: string): Promise<void> {
-  let lastError: unknown;
-  for (let attempt = 0; attempt < 100; attempt += 1) {
-    try {
-      await fs.rm(dir, { recursive: true, force: true });
-      return;
-    } catch (error) {
-      lastError = error;
-      const code = (error as { code?: unknown } | null)?.code;
-      if (code !== "EBUSY" && code !== "ENOTEMPTY" && code !== "EPERM" && code !== "EACCES") {
-        throw error;
-      }
-      await delay(100);
-    }
-  }
-  if (process.platform === "win32") {
-    logCodexLiveStep("temp-cleanup-deferred", {
-      dir,
-      error: lastError instanceof Error ? lastError.message : String(lastError),
-    });
-    return;
-  }
-  await fs.rm(dir, { recursive: true, force: true });
 }
 
 function parseModelKey(modelKey: string): { provider: string; modelId: string } {
@@ -664,6 +573,8 @@ async function writeLiveGatewayConfig(params: {
       mode: "local",
       port: params.port,
       auth: { mode: "token", token: params.token },
+      controlUi: { enabled: false },
+      ...(CODEX_HARNESS_SUBAGENT_PROBE ? { tools: { allow: ["sessions_spawn"] } } : {}),
     },
     plugins: {
       allow: ["codex"],
@@ -748,30 +659,12 @@ async function requestAgentTextWithEvents(params: {
   sessionKey: string;
 }): Promise<CodexHarnessAgentResult> {
   const { extractPayloadText } = await import("./test-helpers.agent-results.js");
-  const { onAgentEvent } = await import("../infra/agent-events.js");
-  const events: CapturedAgentEvent[] = [];
-  const eventPrefixes = params.eventPrefixes ?? [params.eventPrefix ?? "codex_app_server.guardian"];
-  let requestStartedAt = 0;
-  let firstAssistantMs: number | undefined;
-  const unsubscribe = onAgentEvent((event) => {
-    if (!params.includeAllSessions && event.sessionKey && event.sessionKey !== params.sessionKey) {
-      return;
-    }
-    if (event.stream === "assistant" && requestStartedAt > 0 && firstAssistantMs === undefined) {
-      firstAssistantMs = Math.max(0, event.ts - requestStartedAt);
-    }
-    if (!eventPrefixes.some((prefix) => event.stream.startsWith(prefix))) {
-      return;
-    }
-    events.push({
-      stream: event.stream,
-      sessionKey: event.sessionKey,
-      data: event.data,
-      ts: event.ts,
-    });
-  });
+  const capture = createCodexHarnessEventCapture(params);
+  const { events } = capture;
+  const unsubscribe = onGatewayAgentEvent(capture.onAgentEvent);
   try {
-    requestStartedAt = Date.now();
+    const requestStartedAt = Date.now();
+    capture.start(requestStartedAt);
     const payload = await params.client.request(
       "agent",
       {
@@ -802,7 +695,9 @@ async function requestAgentTextWithEvents(params: {
       events,
       compactionCount: Math.max(0, result?.meta?.agentMeta?.compactionCount ?? 0),
       elapsedMs: Date.now() - requestStartedAt,
-      ...(firstAssistantMs !== undefined ? { firstAssistantMs } : {}),
+      ...(capture.firstAssistantMs !== undefined
+        ? { firstAssistantMs: capture.firstAssistantMs }
+        : {}),
       ...(result?.meta?.stopReason ? { stopReason: result.meta.stopReason } : {}),
       ...(result?.meta?.agentMeta?.usage ? { usage: result.meta.agentMeta.usage } : {}),
     };
@@ -1206,7 +1101,7 @@ async function verifyCodexFullContextStress(params: {
     const marker = `OPENCLAW-CODEX-FULL-${turn}-${randomBytes(6).toString("hex").toUpperCase()}`;
     const result = await requestAgentTextWithEvents({
       client: params.client,
-      eventPrefixes: ["codex_app_server.", "compaction"],
+      eventPrefixes: CODEX_HARNESS_CONTEXT_EVENT_PREFIXES,
       sessionKey: params.sessionKey,
       message: [
         buildCodexHarnessDenseContext({ marker, chars: CODEX_HARNESS_LARGE_OUTPUT_BYTES }),
@@ -1260,7 +1155,7 @@ async function verifyCodexFullContextStress(params: {
   const triggerToken = "CODEX-FULL-CONTEXT-TRIGGER-OK";
   const triggerResult = await requestAgentTextWithEvents({
     client: params.client,
-    eventPrefixes: ["codex_app_server.", "compaction"],
+    eventPrefixes: CODEX_HARNESS_CONTEXT_EVENT_PREFIXES,
     sessionKey: params.sessionKey,
     message: `Reply exactly ${triggerToken} and nothing else.`,
   });
@@ -1514,9 +1409,8 @@ async function verifyCodexImageProbe(params: {
 }): Promise<void> {
   const runId = randomUUID();
   const expectedToken = `CODEX-IMAGE-${runId.slice(0, 6).toUpperCase()}`;
-  const { onAgentEvent } = await import("../infra/agent-events.js");
   const events: CapturedAgentEvent[] = [];
-  const unsubscribe = onAgentEvent((event) => {
+  const unsubscribe = onGatewayAgentEvent((event) => {
     if (
       !event.stream.startsWith("codex_app_server.") ||
       (event.sessionKey && event.sessionKey !== params.sessionKey)
@@ -1846,8 +1740,7 @@ async function verifyCodexSubagentProbe(params: {
   const runId = randomUUID();
   const expectedToken = `CODEX-SUBAGENT-${runId.slice(0, 6).toUpperCase()}`;
   const events: CapturedAgentEvent[] = [];
-  const { onAgentEvent } = await import("../infra/agent-events.js");
-  const unsubscribe = onAgentEvent((event) => {
+  const unsubscribe = onGatewayAgentEvent((event) => {
     if (!event.stream.startsWith("codex_app_server.")) {
       return;
     }
@@ -1858,49 +1751,6 @@ async function verifyCodexSubagentProbe(params: {
     });
   });
   try {
-    const { testing: subagentSpawnTesting, spawnSubagentDirect } =
-      await import("../agents/subagents/spawn/subagent-spawn.test-support.js");
-    const noOpContextEngine: ContextEngine = {
-      info: { id: "codex-harness-subagent-smoke", name: "Codex harness subagent smoke" },
-      ingest: async () => ({ ingested: false }),
-      assemble: async () => ({ messages: [], estimatedTokens: 0 }),
-      compact: async () => ({ ok: true, compacted: false }),
-    };
-    const gatewayTrace: Array<{
-      durationMs: number;
-      error?: string;
-      method: string;
-      status: "error" | "ok";
-      timeoutMs?: number | null;
-    }> = [];
-    subagentSpawnTesting.setDepsForTest({
-      resolveContextEngine: async () => noOpContextEngine,
-      callGateway: async <T = Record<string, unknown>>(opts: CallGatewayOptions): Promise<T> => {
-        const startedAt = Date.now();
-        try {
-          const result = await params.client.request(opts.method, opts.params, {
-            expectFinal: opts.method === "agent" ? false : opts.expectFinal,
-            timeoutMs: opts.timeoutMs,
-          });
-          gatewayTrace.push({
-            durationMs: Date.now() - startedAt,
-            method: opts.method,
-            status: "ok",
-            timeoutMs: opts.timeoutMs,
-          });
-          return result as T;
-        } catch (err) {
-          gatewayTrace.push({
-            durationMs: Date.now() - startedAt,
-            error: err instanceof Error ? err.message : String(err),
-            method: opts.method,
-            status: "error",
-            timeoutMs: opts.timeoutMs,
-          });
-          throw err;
-        }
-      },
-    });
     const probeReplies = [
       expectedToken,
       ...Array.from(
@@ -1910,34 +1760,46 @@ async function verifyCodexSubagentProbe(params: {
     ];
     const probes = probeReplies.map((expectedReply, index) => ({ expectedReply, index }));
     const spawnResults = await Promise.all(
-      probes.map(async (probe) => ({
-        expectedReply: probe.expectedReply,
-        index: probe.index,
-        result: await spawnSubagentDirect(
+      probes.map(async (probe) => {
+        const invoked = await params.client.request<ToolsInvokeResult>(
+          "tools.invoke",
           {
-            task: `Reply exactly ${probe.expectedReply} and nothing else.`,
-            agentId: "dev",
-            thinking: CODEX_HARNESS_THINKING,
-            mode: "run",
-            cleanup: "keep",
-            context: "isolated",
-            lightContext: true,
-            expectsCompletionMessage: false,
-            runTimeoutSeconds: CODEX_HARNESS_AGENT_TIMEOUT_SECONDS,
+            name: "sessions_spawn",
+            sessionKey: params.sessionKey,
+            args: {
+              task: `Reply exactly ${probe.expectedReply} and nothing else.`,
+              agentId: "dev",
+              thinking: CODEX_HARNESS_THINKING,
+              mode: "run",
+              cleanup: "keep",
+              context: "isolated",
+              lightContext: true,
+              expectsCompletionMessage: false,
+              runTimeoutSeconds: CODEX_HARNESS_AGENT_TIMEOUT_SECONDS,
+            },
           },
-          {
-            agentSessionKey: params.sessionKey,
-          },
-        ),
-      })),
+          { timeoutMs: CODEX_HARNESS_REQUEST_TIMEOUT_MS },
+        );
+        expect(invoked.ok, JSON.stringify(invoked)).toBe(true);
+        const result = asOptionalRecord(asOptionalRecord(invoked.output)?.details);
+        if (!result) {
+          throw new Error(`sessions_spawn returned no result: ${JSON.stringify(invoked)}`);
+        }
+        return { expectedReply: probe.expectedReply, index: probe.index, result };
+      }),
     );
     for (const probe of spawnResults) {
       if (probe.result.status !== "accepted") {
         throw new Error(
-          `Codex subagent ${probe.index + 1} spawn failed: ${JSON.stringify(probe.result)} trace=${JSON.stringify(gatewayTrace)}`,
+          `Codex subagent ${probe.index + 1} spawn failed: ${JSON.stringify(probe.result)}`,
         );
       }
-      if (!probe.result.childSessionKey?.includes(":subagent:") || !probe.result.runId) {
+      if (
+        typeof probe.result.childSessionKey !== "string" ||
+        !probe.result.childSessionKey.includes(":subagent:") ||
+        typeof probe.result.runId !== "string" ||
+        !probe.result.runId
+      ) {
         throw new Error(
           `subagent spawn did not return child/run identities: ${JSON.stringify(probe.result)}`,
         );
@@ -1981,14 +1843,12 @@ async function verifyCodexSubagentProbe(params: {
       uniqueThreads: new Set(threadIds).size,
     });
   } finally {
-    const { testing: subagentSpawnTesting } =
-      await import("../agents/subagents/spawn/subagent-spawn.test-support.js");
-    subagentSpawnTesting.setDepsForTest();
     unsubscribe();
   }
 }
 
 async function verifyCodexNativeSubagentBridgeProbe(params: {
+  stateEnv: NodeJS.ProcessEnv;
   client: GatewayClient;
   events: EventFrame[];
   sessionKey: string;
@@ -1996,7 +1856,6 @@ async function verifyCodexNativeSubagentBridgeProbe(params: {
   const runId = randomUUID();
   const childToken = `CODEX-NATIVE-CHILD-${runId.slice(0, 6).toUpperCase()}`;
   const parentToken = `CODEX-NATIVE-PARENT-${runId.slice(0, 6).toUpperCase()}`;
-  const { listTaskRecords } = await import("../tasks/runtime-internal.js");
   const { text, events } = await requestAgentTextWithEvents({
     // Native Codex waiting pauses this parent turn; task delivery resumes it separately.
     acceptYieldedTimeout: true,
@@ -2017,12 +1876,12 @@ async function verifyCodexNativeSubagentBridgeProbe(params: {
     events.some((event) => event.stream === "codex_app_server.lifecycle"),
     `expected Codex lifecycle events; events=${JSON.stringify(events)}`,
   ).toBe(true);
-  let codexNativeTasks = listCodexNativeTasks();
+  let codexNativeTasks = await listCodexNativeTasks();
   let deliveredTask = findDeliveredCodexNativeTask(codexNativeTasks);
   const deadline = Date.now() + CODEX_HARNESS_REQUEST_TIMEOUT_MS;
   while (!deliveredTask && Date.now() < deadline) {
     await delay(1_000);
-    codexNativeTasks = listCodexNativeTasks();
+    codexNativeTasks = await listCodexNativeTasks();
     deliveredTask = findDeliveredCodexNativeTask(codexNativeTasks);
   }
   expect(
@@ -2043,6 +1902,7 @@ async function verifyCodexNativeSubagentBridgeProbe(params: {
     const sessionId = await readCodexHarnessSessionId(params);
     const readBinding = () => {
       const row = pluginStateEntriesInKeyRange({
+        env: params.stateEnv,
         pluginId: "codex",
         namespace: "app-server-thread-bindings",
         keyStartInclusive: "session-key:dev:",
@@ -2080,16 +1940,19 @@ async function verifyCodexNativeSubagentBridgeProbe(params: {
     logCodexLiveStep("native-subagent-direct-input:legacy-not-applicable");
   }
 
-  function listCodexNativeTasks() {
-    return listTaskRecords().filter(
-      (entry) => entry.runtime === "subagent" && entry.taskKind === "codex-native",
-    );
+  async function listCodexNativeTasks() {
+    const { tasks, nextCursor } = await params.client.request<TasksListResult>("tasks.list", {
+      sessionKey: params.sessionKey,
+      limit: 500,
+    });
+    expect(nextCursor, "isolated native probe must fit in one task page").toBeUndefined();
+    return tasks.filter((entry) => entry.runtime === "subagent" && entry.kind === "codex-native");
   }
 
-  function findDeliveredCodexNativeTask(tasks: ReturnType<typeof listCodexNativeTasks>) {
+  function findDeliveredCodexNativeTask(tasks: Awaited<ReturnType<typeof listCodexNativeTasks>>) {
     return tasks.find(
       (entry) =>
-        entry.status === "succeeded" &&
+        entry.status === "completed" &&
         entry.deliveryStatus === "delivered" &&
         entry.terminalSummary?.includes(childToken),
     );
@@ -2097,6 +1960,7 @@ async function verifyCodexNativeSubagentBridgeProbe(params: {
 }
 
 async function verifyCodexSessionDeletion(params: {
+  stateEnv: NodeJS.ProcessEnv;
   client: GatewayClient;
   events: EventFrame[];
   modelKey: string;
@@ -2108,6 +1972,7 @@ async function verifyCodexSessionDeletion(params: {
   const sessionId = await readCodexHarnessSessionId({ client, sessionKey });
   const readBindings = () =>
     pluginStateEntriesInKeyRange({
+      env: params.stateEnv,
       pluginId: "codex",
       namespace: "app-server-thread-bindings",
       keyStartInclusive: "session-key:dev:",
@@ -2196,62 +2061,9 @@ describeLive("gateway live (Codex harness)", () => {
     "runs gateway agent turns through the plugin-owned Codex app-server harness",
     async () => {
       const modelKey = process.env.OPENCLAW_LIVE_CODEX_HARNESS_MODEL ?? DEFAULT_CODEX_MODEL;
-      const { clearRuntimeConfigSnapshot } = await import("../config/config.js");
-      const { startGatewayServer } = await import("./server.js");
-
-      const previousEnv = snapshotEnv();
-      const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-live-codex-harness-"));
-      const stateDir = path.join(tempDir, "state");
-      const workspace = await createLiveWorkspace(tempDir);
-      const configPath = path.join(tempDir, "openclaw.json");
       const token = `test-${randomUUID()}`;
-      const port = await getFreeGatewayPort();
-
-      clearRuntimeConfigSnapshot();
-      process.env.OPENCLAW_AGENT_RUNTIME = "codex";
-      // Keep the runtime fixed on the plugin-owned Codex app-server harness.
-      // CI can opt into API-key auth to avoid stale OAuth refresh secrets,
-      // while local maintainer runs can continue exercising staged ~/.codex auth.
-      // Only the Codex-auth path should force-clear OpenAI overrides; API-key
-      // mode may intentionally point at a custom endpoint.
-      if (CODEX_HARNESS_AUTH_MODE !== "api-key") {
-        delete process.env.OPENAI_BASE_URL;
-        delete process.env.OPENAI_API_KEY;
-      } else if (!process.env.OPENAI_BASE_URL?.trim()) {
-        delete process.env.OPENAI_BASE_URL;
-      }
-      setTestEnvValue("OPENCLAW_CONFIG_PATH", configPath);
-      // This live lane exercises the full config-loaded runtime inside Vitest's
-      // fast-test envelope, so config-override completeness checks do not apply.
-      setTestEnvValue("OPENCLAW_ALLOW_SLOW_REPLY_TESTS", "1");
-      process.env.OPENCLAW_GATEWAY_TOKEN = token;
-      process.env.OPENCLAW_SKIP_BROWSER_CONTROL_SERVER = "1";
-      process.env.OPENCLAW_SKIP_CANVAS_HOST = "1";
-      process.env.OPENCLAW_SKIP_CHANNELS = "1";
-      process.env.OPENCLAW_SKIP_CRON = "1";
-      process.env.OPENCLAW_SKIP_GMAIL_WATCHER = "1";
-      setTestEnvValue("OPENCLAW_STATE_DIR", stateDir);
-
-      await fs.mkdir(stateDir, { recursive: true });
-      await writeLiveGatewayConfig({
-        configPath,
-        modelKey,
-        port,
-        token,
-        workspace,
-        codexAppServerMode:
-          CODEX_HARNESS_GUARDIAN_PROBE || CODEX_HARNESS_MULTI_SESSION_PROBE ? "guardian" : "yolo",
-        ...(CODEX_HARNESS_MULTI_SESSION_PROBE
-          ? { codexApprovalPolicy: "untrusted", codexApprovalsReviewer: "user" }
-          : {}),
-        codeModeOnly: CODEX_HARNESS_CODE_MODE_ONLY,
-        compactionMode: CODEX_HARNESS_COMPACTION_MODE,
-        ...(CODEX_HARNESS_DISABLE_LOOP_RELAY ? { loopDetectionPreToolUseRelay: false } : {}),
-      });
-      const deviceIdentity = await ensurePairedTestGatewayClientIdentity({
-        displayName: "vitest-codex-harness-live",
-      });
-      let server: Awaited<ReturnType<typeof startGatewayServer>> | undefined;
+      const instance = await createCodexHarnessLiveInstance(token, CODEX_HARNESS_AUTH_MODE);
+      const { configPath, port } = instance;
       let client: Awaited<ReturnType<typeof connectTestGatewayClient>> | undefined;
       const gatewayEvents: EventFrame[] = [];
       const resolvedGuardianPluginApprovalIds = new Set<string>();
@@ -2290,18 +2102,43 @@ describeLive("gateway live (Codex harness)", () => {
             });
           });
       };
-      logCodexLiveStep("config-written", { configPath, modelKey, port });
+      const captureGatewayEvent = (event: EventFrame): void => {
+        gatewayEvents.push(event);
+        maybeResolveGuardianPluginApproval(event);
+        if (event.event === "agent") {
+          for (const listener of gatewayAgentEventListeners) {
+            listener(event.payload as AgentEventPayload);
+          }
+        }
+      };
       observedCodexThreadIds.clear();
       observedCodexClientIds.clear();
       observedCodexThreadActions.clear();
 
       try {
-        server = await startGatewayServer(port, {
-          bind: "loopback",
-          auth: { mode: "token", token },
-          controlUiEnabled: false,
+        instance.state.applyEnv();
+        const workspace = instance.state.workspaceDir;
+        await createLiveWorkspace(workspace);
+        await writeLiveGatewayConfig({
+          configPath,
+          modelKey,
+          port,
+          token,
+          workspace,
+          codexAppServerMode:
+            CODEX_HARNESS_GUARDIAN_PROBE || CODEX_HARNESS_MULTI_SESSION_PROBE ? "guardian" : "yolo",
+          ...(CODEX_HARNESS_MULTI_SESSION_PROBE
+            ? { codexApprovalPolicy: "untrusted", codexApprovalsReviewer: "user" }
+            : {}),
+          codeModeOnly: CODEX_HARNESS_CODE_MODE_ONLY,
+          compactionMode: CODEX_HARNESS_COMPACTION_MODE,
+          ...(CODEX_HARNESS_DISABLE_LOOP_RELAY ? { loopDetectionPreToolUseRelay: false } : {}),
         });
-        await server.startupSettled;
+        const deviceIdentity = await ensurePairedTestGatewayClientIdentity({
+          displayName: "vitest-codex-harness-live",
+        });
+        logCodexLiveStep("config-written", { configPath, modelKey, port });
+        await instance.startGateway();
         client = await connectTestGatewayClient({
           url: `ws://127.0.0.1:${port}`,
           token,
@@ -2313,10 +2150,7 @@ describeLive("gateway live (Codex harness)", () => {
           ...(CODEX_HARNESS_MULTI_SESSION_PROBE
             ? { caps: [GATEWAY_CLIENT_CAPS.PLUGIN_APPROVALS] }
             : {}),
-          onEvent: (event) => {
-            gatewayEvents.push(event);
-            maybeResolveGuardianPluginApproval(event);
-          },
+          onEvent: captureGatewayEvent,
         });
         activeApprovalClient = client;
         logCodexLiveStep("client-connected");
@@ -2363,6 +2197,7 @@ describeLive("gateway live (Codex harness)", () => {
               await verifyCodexSubagentProbe({ client: activeClient, sessionKey });
               logCodexLiveStep("native-subagent-bridge-probe:start", { sessionKey });
               await verifyCodexNativeSubagentBridgeProbe({
+                stateEnv: instance.env,
                 client: activeClient,
                 events: gatewayEvents,
                 sessionKey,
@@ -2620,17 +2455,9 @@ describeLive("gateway live (Codex harness)", () => {
             activeApprovalClient = undefined;
             await client?.stopAndWait();
             client = undefined;
-            await server?.close();
-            server = undefined;
-            clearRuntimeConfigSnapshot();
+            await instance.stopGateway();
             gatewayEvents.length = 0;
-
-            server = await startGatewayServer(port, {
-              bind: "loopback",
-              auth: { mode: "token", token },
-              controlUiEnabled: false,
-            });
-            await server.startupSettled;
+            await instance.startGateway();
             client = await connectTestGatewayClient({
               url: `ws://127.0.0.1:${port}`,
               token,
@@ -2638,10 +2465,7 @@ describeLive("gateway live (Codex harness)", () => {
               timeoutMs: GATEWAY_CONNECT_TIMEOUT_MS,
               requestTimeoutMs: CODEX_HARNESS_REQUEST_TIMEOUT_MS,
               clientDisplayName: `vitest-codex-resume-stress-${restart}`,
-              onEvent: (event) => {
-                gatewayEvents.push(event);
-                maybeResolveGuardianPluginApproval(event);
-              },
+              onEvent: captureGatewayEvent,
             });
             activeApprovalClient = client;
             await assertCodexHarnessSessionSelection({
@@ -2715,26 +2539,22 @@ describeLive("gateway live (Codex harness)", () => {
           }
         }
         await verifyCodexSessionDeletion({
+          stateEnv: instance.env,
           client,
           events: gatewayEvents,
           modelKey,
           sessionKey: "agent:dev:live-codex-harness",
         });
+      } catch (error) {
+        console.error(instance.logs());
+        throw error;
       } finally {
+        activeApprovalClient = undefined;
+        gatewayAgentEventListeners.clear();
         try {
-          clearRuntimeConfigSnapshot();
-          try {
-            await client?.stopAndWait();
-          } finally {
-            await server?.close();
-          }
-          const { resetTaskFlowRegistryForTests, resetTaskRegistryForTests } =
-            await import("../tasks/task-runtime.test-helpers.js");
-          resetTaskRegistryForTests({ persist: false });
-          resetTaskFlowRegistryForTests({ persist: false });
+          await client?.stopAndWait();
         } finally {
-          restoreEnv(previousEnv);
-          await removeLiveTempDir(tempDir);
+          await instance.cleanup();
         }
       }
     },

--- a/test/helpers/gateway-codex-harness.ts
+++ b/test/helpers/gateway-codex-harness.ts
@@ -1,0 +1,135 @@
+import type { AgentEventPayload } from "../../src/infra/agent-events.js";
+// Native live fixture setup and capture shared with its offline boundary regressions.
+import { createOpenClawTestInstance } from "./openclaw-test-instance.js";
+
+export function createCodexHarnessLiveInstance(
+  token: string,
+  authMode: "codex-auth" | "api-key" = "codex-auth",
+) {
+  return createOpenClawTestInstance({
+    name: "live-codex-harness",
+    // test-env already staged native Codex auth/config in the caller home.
+    state: { layout: "state-only" },
+    gatewayToken: token,
+    env: {
+      OPENCLAW_AGENT_RUNTIME: "codex",
+      OPENCLAW_GATEWAY_TOKEN: token,
+      OPENCLAW_ALLOW_SLOW_REPLY_TESTS: "1",
+      // Admission and completion must share the normal, built Gateway lifecycle.
+      OPENCLAW_TEST_MINIMAL_GATEWAY: "0",
+      OPENCLAW_SKIP_PROVIDERS: undefined,
+      OPENCLAW_BUNDLED_PLUGINS_DIR: undefined,
+      OPENCLAW_TEST_TRUST_BUNDLED_PLUGINS_DIR: undefined,
+      OPENAI_API_KEY: authMode === "api-key" ? process.env.OPENAI_API_KEY : undefined,
+      OPENAI_BASE_URL:
+        authMode === "api-key" && process.env.OPENAI_BASE_URL?.trim()
+          ? process.env.OPENAI_BASE_URL
+          : undefined,
+    },
+  });
+}
+
+// Full-context assertions consume native usage separately from lifecycle/compaction.
+export const CODEX_HARNESS_CONTEXT_EVENT_PREFIXES = [
+  "codex_app_server.",
+  "compaction",
+  "usage",
+] as const;
+
+export function createCodexHarnessEventCapture(params: {
+  eventPrefix?: string;
+  eventPrefixes?: readonly string[];
+  includeAllSessions?: boolean;
+  sessionKey: string;
+}) {
+  const events: CapturedAgentEvent[] = [];
+  const eventPrefixes = params.eventPrefixes ?? [params.eventPrefix ?? "codex_app_server.guardian"];
+  let requestStartedAt = 0;
+  let firstAssistantMs: number | undefined;
+  return {
+    events,
+    start(startedAt: number) {
+      requestStartedAt = startedAt;
+    },
+    get firstAssistantMs() {
+      return firstAssistantMs;
+    },
+    onAgentEvent(this: void, event: AgentEventPayload) {
+      if (
+        !params.includeAllSessions &&
+        event.sessionKey &&
+        event.sessionKey !== params.sessionKey
+      ) {
+        return;
+      }
+      if (event.stream === "assistant" && requestStartedAt > 0 && firstAssistantMs === undefined) {
+        firstAssistantMs = Math.max(0, event.ts - requestStartedAt);
+      }
+      if (!eventPrefixes.some((prefix) => event.stream.startsWith(prefix))) {
+        return;
+      }
+      events.push({
+        stream: event.stream,
+        sessionKey: event.sessionKey,
+        data: event.data,
+        ts: event.ts,
+      });
+    },
+  };
+}
+
+export type CapturedAgentEvent = {
+  stream: string;
+  data?: Record<string, unknown>;
+  sessionKey?: string;
+  ts?: number;
+};
+
+export type CodexNativeUsageSnapshot = {
+  activeContextTokens: number;
+  cachedInputTokens?: number;
+  cacheWriteInputTokens?: number;
+  inputTokens?: number;
+  modelContextWindow: number;
+  outputTokens?: number;
+  promptTokens: number;
+};
+
+export function readCodexNativeUsageSnapshots(
+  events: readonly CapturedAgentEvent[],
+): CodexNativeUsageSnapshot[] {
+  return events.flatMap((event) => {
+    if (event.stream !== "usage") {
+      return [];
+    }
+    const activeContextTokens = event.data?.activeContextTokens;
+    const modelContextWindow = event.data?.modelContextWindow;
+    const promptTokens = event.data?.promptTokens;
+    if (
+      typeof activeContextTokens !== "number" ||
+      typeof modelContextWindow !== "number" ||
+      typeof promptTokens !== "number"
+    ) {
+      return [];
+    }
+    const optionalNumber = (key: string): number | undefined => {
+      const value = event.data?.[key];
+      return typeof value === "number" ? value : undefined;
+    };
+    const cachedInputTokens = optionalNumber("cachedInputTokens");
+    const cacheWriteInputTokens = optionalNumber("cacheWriteInputTokens");
+    const inputTokens = optionalNumber("inputTokens");
+    const outputTokens = optionalNumber("outputTokens");
+    return [
+      {
+        activeContextTokens,
+        modelContextWindow,
+        promptTokens,
+        ...(cachedInputTokens !== undefined ? { cachedInputTokens } : {}),
+        ...(cacheWriteInputTokens !== undefined ? { cacheWriteInputTokens } : {}),
+        ...(inputTokens !== undefined ? { inputTokens } : {}),
+        ...(outputTokens !== undefined ? { outputTokens } : {}),
+      },
+    ];
+  });
+}


### PR DESCRIPTION
## What Problem This Solves

The native Codex live fixture mixed source-loaded Gateway components with the built runtime that owns admission and completion. Its replacement test home also hid native authentication already staged by the live-test environment, and its event filter omitted the usage frames needed by context assertions.

## Why This Change Was Made

Run the existing scenario through the canonical test-instance owner and a real built Gateway child, with real RPC and event delivery. Isolate OpenClaw state while preserving the caller's staged native home. Reuse one event-capture helper for lifecycle, guardian, compaction and usage observations. Keep the original delivered-child/source-ID/summary, turns, resume/reset, status, image, MCP, guardian and deletion assertions.

The shared fixture helper belongs under `test/helpers/`. Keeping it under `src/gateway/` as `.test-helpers.ts` incorrectly admitted test-only child-process dependencies into the production TypeScript graph, which does not allow their Windows JavaScript imports. The helper now lives in the existing test-owned graph, with no alias, declarations, `allowJs` change or exemption.

## User Impact

No production behavior changes. The live fixture now exercises the built Gateway lifecycle and can use either explicit API-key mode or the native authentication staged by the existing test environment. This does not repair or claim the separate native-continuity scenario, Ultra/full-context behavior, optional stress lanes, or the full release campaign.

## Evidence

Original full native proof ran both API-key and default native-auth flows on source tree `060399422d241d224ced563457f5c4fd058b1431`: each passed its complete original scenario, each observed three WebSocket usage frames, and each recorded one disabled optional scenario. [Original live workflow](https://github.com/openclaw/openclaw/actions/runs/33235327933). The complete tracked source fingerprint and built artifacts were preserved across those runs; this is original-source evidence, not a new-main live rerun. Default native-auth proof used no manual auth copy, credential-home override or inferred token kind. Optional restart/compaction/full-context/multi-session stress was off.

The production-core typecheck deterministically failed before the helper relocation with TS7016 on the two Windows JavaScript imports reached through the test-instance owner. After moving the helper and updating its two internal imports and two consumers, the identical core command and Gateway-root test typecheck passed. All 34 current fixture/shared-instance cases passed (6 fixture boundary cases and 28 shared-instance cases). Fresh restricted Codex review of the complete nonempty migration plus relocation reported no actionable findings. No secret scanner or reviewer isolation was bypassed.

```sh
node scripts/run-tsgo.mjs -p tsconfig.core.json
node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.gateway-root.json
OPENCLAW_VITEST_MAX_WORKERS=2 node scripts/run-vitest.mjs src/gateway/gateway-codex-harness.fixture.test.ts test/helpers/openclaw-test-instance.test.ts
OPENCLAW_VITEST_MAX_WORKERS=2 node scripts/check-changed.mjs -- src/gateway/gateway-codex-harness.live.test.ts src/gateway/gateway-codex-harness.fixture.test.ts test/helpers/gateway-codex-harness.ts
```

Source evidence: `createOpenClawTestInstance` owns child startup, RPC and cleanup; `createOpenClawTestState` with `state-only` owns isolated OpenClaw paths without replacing HOME. The Codex plugin's `event-projector-usage.ts` publishes native context fields on `usage`, consumed by the shared fixture capture. Direct upstream inspection used peeled `rust-v0.150.1` commit `90854393966b21e9ebfd21b122334eb09a20c93d`: `codex-rs/utils/home-dir/src/lib.rs` (home resolution), `codex-rs/login/src/auth/storage.rs` (native auth storage), `codex-rs/app-server/src/bespoke_event_handling.rs:1577` (token-usage producer), and `codex-rs/app-server-protocol/src/protocol/v2/thread.rs:1825` (usage notification fields). The annotated tag object is not the inspected commit.

Scope: three test/test-support paths, **+416/-314; production +0/-0**. The complete migration and its corrections are included, not only the final correction commit. No duplicate shared-helper test from already-landed #132425; no announce/RPC ancestry, changelog, configuration, schema, dependency or runtime changes. The separate open Ultra-effort work in #128481 is not adopted or overwritten.

Historical seven Mac shared-helper startup-prerequisite failures remain part of the earlier source record; they are not silently relabeled as green. The new 34-case run is a separate current-source result. Original source live proof remains qualified as above.

Current-main refresh: commit `99f744e167967db881fb47d059bf6c0a49a9e9ec` is based on `ebca271812c2fa49aae1464538b792254fc76d51`; all three postimages are byte-identical to the reviewed relocation commit. The complete changed gate passed before this mechanical refresh, including all three unused-export scans, all core test type graphs, the test-root graph, core lint and script lint. On the refreshed source, the production-core and Gateway-root test typechecks passed again, and **211 distinct tests** passed across the fixture, shared-instance, usage projection, turn-watch and turn-router suites. These include the intervening main lifecycle/settlement changes, whose complete production owners were inspected directly. No new-head provider-live result is claimed.

A separate production fix, #132430 (`25225a0e715d243266a8fa65aaa1dccfccb7d2ab`), landed during this PR's checks and binds internal agent turns to the captured Gateway lifecycle owner. It is preserved and is not included in this PR. Direct inspection covered its factory producer, dispatch consumer and stale-owner assertions; 49 additional ownership/authorization/announce cases passed on that exact main baseline. That managed checkout used its existing Vitest 4.1.10, while the 211-case author proof used 4.1.11; no dependencies were changed. These are separate source-bound proofs, not a combined provider-live run.
