### PR TITLE
test(ios): cover rejected sends during newer draft edits

### DIFF
--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatViewModelOutboxTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatViewModelOutboxTests.swift
@@ -1657,29 +1657,62 @@ struct ChatViewModelOutboxTests {
         #expect(await transport.state.sentIdempotencyKeys.isEmpty)
     }
 
-    @Test func `definitive live-send rejection restores draft without queueing`() async throws {
+    @Test(arguments: ["", "a newer unsent draft"])
+    func `definitive live-send rejection restores draft without queueing`(newDraft: String) async throws {
         let (store, _, databaseDirectory) = try makeOutboxStore()
         defer { try? FileManager.default.removeItem(at: databaseDirectory) }
         let transport = OutboxTestTransport(healthy: true)
-        await transport.state.update { $0.sendResponseErrors = true }
+        let sendGate = DeleteGate()
+        await transport.state.update {
+            $0.sendResponseErrors = true
+            $0.heldSendGate = sendGate
+        }
         let vm = await makeOutboxViewModel(transport: transport, outbox: store)
 
         await MainActor.run { vm.load() }
         // Wait for outbox restore too: until it completes, sends deliberately
         // route behind the outbox (FIFO gate), which is not the path under test.
         try await waitUntil("bootstrap healthy") {
-            await MainActor.run { vm.healthOK && vm.hasRestoredOutboxMessages }
+            await MainActor.run { vm.healthOK && !vm.isLoading && vm.hasRestoredOutboxMessages }
         }
         await MainActor.run {
             vm.input = "keep this draft"
             vm.send()
         }
-        try await waitUntil("definitive rejection surfaced") {
-            await MainActor.run { vm.errorText != nil }
+        do {
+            try await waitUntil("live send reached the held request") {
+                let requestStarted = await transport.state.heldSendGate == nil
+                return await MainActor.run { requestStarted && vm.isSending && vm.input.isEmpty }
+            }
+            await MainActor.run { vm.input = newDraft }
+        } catch {
+            await sendGate.open()
+            throw error
         }
-        #expect(await MainActor.run { vm.input } == "keep this draft")
+        await sendGate.open()
+        try await waitUntil("definitive rejection surfaced") {
+            await MainActor.run { !vm.isSending && vm.errorText?.contains("rejected") == true }
+        }
+        let recoverableDrafts = await MainActor.run {
+            var drafts = [vm.input]
+            while vm.recallPreviousInput(caretOnFirstLine: true) {
+                drafts.append(vm.input)
+            }
+            _ = vm.cancelInputRecall()
+            return drafts
+        }
+        // Check recoverability without choosing concatenation, ordering, or a new recovery surface.
+        #expect(recoverableDrafts.contains { $0.contains("keep this draft") })
+        if newDraft.isEmpty {
+            #expect(await MainActor.run { vm.input } == "keep this draft")
+        } else {
+            #expect(recoverableDrafts.contains { $0.contains(newDraft) })
+        }
         #expect(await userTexts(vm).isEmpty)
         #expect(await store.loadCommands().isEmpty)
+        #expect(await transport.state.sentMessages.isEmpty)
+        #expect(await transport.state.sentIdempotencyKeys.isEmpty)
+        #expect(await MainActor.run { vm.pendingRunCount == 0 && vm.canSend })
     }
 
     @Test func `ambiguous live transport failure requires explicit retry`() async throws {


### PR DESCRIPTION
## What Problem This Solves

This is a test-only diagnostic for a possible native chat draft-loss case, not a production fix or a merge-ready PR.

The shared chat model clears the submitted text while a healthy live send awaits its result. The iOS composer remains editable. If the user types a newer draft and the Gateway then definitively rejects the original send, source inspection predicts that the original text is no longer recoverable: restoration only fills an empty composer, the rejected send is not queued, and its optimistic echo is removed. The rejection error itself remains visible.

## Why This Change Was Made

Extend the existing definitive-rejection test with two arguments: an empty replacement draft (the existing control) and a distinct newer draft. Hold the existing transport request, edit the composer, then release the existing explicit rejection. No production code, protocol, database schema, workflow, package target, timeout or new test seam changes.

The oracle checks preservation across the existing composer and model-level recall surfaces, while retaining visible rejection, no queued command, no optimistic echo, no accepted send and no pending run. It does not choose concatenation, recording failed input as successful history, new storage or a new recovery UI. Those decisions remain outside this diagnostic.

## User Impact

None shipped by this test-only stage. It is intended to establish whether the ordinary rejected-send/new-draft interleaving loses user text before selecting a repair. Source inspection is not an observed failure, and this PR must not be landed while the proposed preservation assertion is failing.

## Evidence

- Frozen source baseline: `c1473eac606d6445e9f74ba2d534b5236cdd71c9`; diagnostic head: `6d092b79c4cf5bba55485068c5e71fcdfc5dfc90`.
- Independent source review accepted the existing gate, error, bootstrap and recall contracts and the complete test-only extension. Production delta:0; tests:+38/−5.
- Complete selected P2 review passed: all four automatic passes returned no findings (minimum confidence0.82). This reviews the diagnostic test, not a production repair. No local Swift test, build, simulator, device or operator app was run.
- Ordinary hosted OpenClawKit execution: pending. The diagnostic must first be made ready for review because draft PRs skip CI preflight. The existing macOS job runs the shared package in a fresh scratch directory; no workflow or runner change is requested.
- Expected outcome, not yet observed: the empty-draft control passes; the newer-draft case reports loss of the original text. Compiler or unrelated CI failures will not count as that baseline.

The shared-model test does not prove touch-only iOS recovery, a wire-decoder change, the whole workflow or an installed-app flow. The complete generated protocol and unrelated omnibus test remain unchanged. A production repair, real baseline result and subsequent GREEN evidence require a separate follow-up decision.
