### PR TITLE
fix(browser): preserve targets when relay clients share Chrome

### DIFF
--- a/docs/tools/chrome-extension.md
+++ b/docs/tools/chrome-extension.md
@@ -253,14 +253,52 @@ path without a path-rewriting proxy prefix.
 ## External CDP clients
 
 The relay supports Browser Relay Authentication v2 clients such as mcporter.
-OpenClaw and an external client can stay connected together; a newly connected
-client receives the current execution contexts without resetting the first
-client's Runtime session. They still share the underlying tabs, so navigation
-or page changes can invalidate another client's snapshot refs.
+OpenClaw and an external client can stay connected together. When a client
+enables Runtime, the extension checks current tab access before the relay
+replays existing execution contexts to that new subscriber. This does not
+reset another client's Runtime session.
+
+Fetch request interception has one owner per native target session. Another
+client can use other CDP domains, but cannot replace that owner's interception
+settings or resolve its paused requests. Competing interception requests return
+an error rather than silently changing the active owner's policy. Fetch response
+streams also belong to the logical session that acquired them.
+
+Related targets (such as frames and workers) have separate logical sessions
+for each interested parent. Each parent's ordered auto-attach filter is
+preserved; the native attachment uses their union. New or broadened interests
+receive existing children only after the extension accepts the command. The
+native pause-on-attach setting remains shared: the latest update wins,
+including DevTools suspend/resume. Resuming a waiting target affects all its
+logical sessions.
+
+Clients still share the underlying tabs. Navigation or page changes can
+invalidate another client's snapshot refs; this is not an isolated browser per
+client or complete isolation of every CDP domain and competing client policy.
+A complete tab-list request returns an error when native targets cannot yet be
+matched to Playwright pages, rather than reporting a partial list as complete.
 
 If the extension connection drops, its debugger attachments retire before the
-replacement connection reattaches. This does not change the access mode or
-paused tabs. Take a fresh snapshot after reconnecting before using element refs.
+replacement connection reattaches. An uncertain native Fetch operation also
+retires the affected attachment instead of retrying the operation against a
+replacement. Fetch cleanup is bounded; debugger teardown is not a guarantee that
+pending network requests are canceled. These paths do not change the access
+mode or paused tabs. Take a fresh snapshot after the target reattaches before
+using element refs. If a client no longer exposes the target, reconnect that
+client.
+
+If native detach fails, the error is reported and cleanup debt stays with that
+exact attachment. Other tabs remain usable, but the affected tab cannot acquire
+a replacement until cleanup succeeds. After restoring Chrome access, retry an
+explicit attachment or **Disconnect**. Chrome's debugger Cancel action can also
+end the native attachment. Removing or replacing a tab alone is not treated as
+proof that its debugger client closed. Failed CDP operations are never retried
+against a replacement session.
+
+The connection-lifetime protections require updated extension code as well as
+an updated OpenClaw installation. Update the Store extension when available.
+For an unpacked development copy, rerun `openclaw browser extension install`
+and reload the installed copy from `chrome://extensions`.
 
 Print non-secret endpoint metadata:
 

--- a/extensions/browser/chrome-extension/background.access-mode.test.ts
+++ b/extensions/browser/chrome-extension/background.access-mode.test.ts
@@ -1,3 +1,4 @@
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   cleanupBackgroundHarnesses,
@@ -73,6 +74,13 @@ describe("relay command authorization", () => {
     );
 
     socket.receive({ type: "attach", seq: 20, tabId: 41 });
+    await vi.waitFor(() =>
+      expect(socket.send.mock.calls.map(([raw]) => JSON.parse(raw))).toContainEqual({
+        type: "result",
+        seq: 20,
+        result: { targetId: "tab-41" },
+      }),
+    );
     socket.receive({ type: "cdp", seq: 21, tabId: 41, method: "Runtime.evaluate" });
 
     await vi.waitFor(() => {
@@ -318,7 +326,7 @@ describe("relay command authorization", () => {
 
     await expect(changingMode).resolves.toMatchObject({ ok: true, accessMode: "selected" });
     await vi.waitFor(() => {
-      expect(harness.debuggerDetach).toHaveBeenCalledWith({ tabId: 61 });
+      expect(harness.debuggerDetach).toHaveBeenCalledWith({ targetId: "tab-61" });
       const frames = socket.send.mock.calls.map(([raw]) => JSON.parse(raw));
       expect(frames).toContainEqual({
         type: "error",
@@ -374,7 +382,7 @@ describe("relay command authorization", () => {
     releaseOlderMutation();
     await expect(olderMutation).resolves.toEqual({ ok: true, accessMode: "all" });
     await expect(downgrading).resolves.toEqual({ ok: true, accessMode: "selected" });
-    expect(harness.debuggerDetach).toHaveBeenCalledWith({ tabId: 204 });
+    expect(harness.debuggerDetach).toHaveBeenCalledWith({ targetId: "tab-204" });
   });
 
   it("rejects a stale tab action when a queued mode change executes first", async () => {
@@ -475,13 +483,10 @@ describe("relay command authorization", () => {
     socket.receive({ type: "attach", seq: 42, tabId: 212 });
     await vi.waitFor(() => expect(harness.debuggerAttach).toHaveBeenCalledTimes(2));
 
-    let releaseUnselectedDetach = () => {};
-    const unselectedDetach = new Promise<void>((resolve) => {
-      releaseUnselectedDetach = resolve;
-    });
-    harness.debuggerDetach.mockImplementation(async ({ tabId }: { tabId: number }) => {
-      if (tabId === 212) {
-        await unselectedDetach;
+    const unselectedDetach = createDeferred<void>();
+    harness.debuggerDetach.mockImplementation(async ({ targetId }) => {
+      if (targetId === "tab-212") {
+        await unselectedDetach.promise;
       }
     });
     socket.send.mockClear();
@@ -489,14 +494,18 @@ describe("relay command authorization", () => {
       type: "setAccessMode",
       accessMode: "selected",
     });
-    await vi.waitFor(() => expect(harness.debuggerDetach).toHaveBeenCalledWith({ tabId: 212 }));
+    await vi.waitFor(() =>
+      expect(harness.debuggerDetach).toHaveBeenCalledWith({ targetId: "tab-212" }),
+    );
 
     harness.unshareTab(211);
     harness.tabsUpdatedListener(211, { groupId: -1 });
-    releaseUnselectedDetach();
+    unselectedDetach.resolve();
 
     await expect(changingMode).resolves.toEqual({ ok: true, accessMode: "selected" });
-    await vi.waitFor(() => expect(harness.debuggerDetach).toHaveBeenCalledWith({ tabId: 211 }));
+    await vi.waitFor(() =>
+      expect(harness.debuggerDetach).toHaveBeenCalledWith({ targetId: "tab-211" }),
+    );
     harness.debuggerEventListener({ tabId: 211 }, "Runtime.consoleAPICalled", {});
     expect(
       socket.send.mock.calls
@@ -538,7 +547,7 @@ describe("relay command authorization", () => {
 
     await expect(changingMode).resolves.toMatchObject({ ok: true, accessMode: "selected" });
     await vi.waitFor(() => {
-      expect(harness.debuggerDetach).toHaveBeenCalledWith({ tabId: 62 });
+      expect(harness.debuggerDetach).toHaveBeenCalledWith({ targetId: "tab-62" });
       const frames = socket.send.mock.calls.map(([raw]) => JSON.parse(raw));
       expect(frames).toContainEqual({
         type: "error",
@@ -563,23 +572,16 @@ describe("relay command authorization", () => {
       throw new Error("expected relay and debugger event listener");
     }
     await harness.authenticate(socket);
-    let releaseTargets = (
-      _targets: Array<{ id?: string; tabId?: number; attached?: boolean }>,
-    ) => {};
-    harness.debuggerGetTargets.mockImplementationOnce(
-      async () =>
-        await new Promise((resolve) => {
-          releaseTargets = resolve;
-        }),
-    );
+    const targetInfo = createDeferred<{ targetInfo: { targetId: string } }>();
+    harness.debuggerGetTargetInfo.mockReturnValueOnce(targetInfo.promise);
     socket.receive({ type: "attach", seq: 26, tabId: 63 });
     await vi.waitFor(() => {
       expect(harness.debuggerAttach).toHaveBeenCalledWith({ tabId: 63 }, "1.3");
-      expect(harness.debuggerGetTargets).toHaveBeenCalled();
+      expect(harness.debuggerGetTargetInfo).toHaveBeenCalled();
     });
 
     const releaseModeStorage = harness.deferNextStorageSet();
-    releaseTargets([{ id: "target-63", tabId: 63, attached: true }]);
+    targetInfo.resolve({ targetInfo: { targetId: "target-63" } });
     const changingMode = sendRuntimeMessage(harness, {
       type: "setAccessMode",
       accessMode: "selected",
@@ -594,7 +596,7 @@ describe("relay command authorization", () => {
         message: "tab 63 access was revoked",
       });
     });
-    expect(harness.debuggerDetach).toHaveBeenCalledWith({ tabId: 63 });
+    expect(harness.debuggerDetach).toHaveBeenCalledWith({ targetId: "target-63" });
 
     harness.debuggerEventListener({ tabId: 63 }, "Runtime.consoleAPICalled", { value: 1 });
     const framesAfterEvent = socket.send.mock.calls.map(([raw]) => JSON.parse(raw));
@@ -618,17 +620,10 @@ describe("relay command authorization", () => {
       throw new Error("expected relay and debugger event listener");
     }
     await harness.authenticate(socket);
-    let releaseTargets = (
-      _targets: Array<{ id?: string; tabId?: number; attached?: boolean }>,
-    ) => {};
-    harness.debuggerGetTargets.mockImplementationOnce(
-      async () =>
-        await new Promise((resolve) => {
-          releaseTargets = resolve;
-        }),
-    );
+    const targetInfo = createDeferred<{ targetInfo: { targetId: string } }>();
+    harness.debuggerGetTargetInfo.mockReturnValueOnce(targetInfo.promise);
     socket.receive({ type: "attach", seq: 27, tabId: 64 });
-    await vi.waitFor(() => expect(harness.debuggerGetTargets).toHaveBeenCalled());
+    await vi.waitFor(() => expect(harness.debuggerGetTargetInfo).toHaveBeenCalled());
 
     harness.unshareTab(64);
     harness.tabsUpdatedListener(64, { groupId: -1 });
@@ -645,7 +640,7 @@ describe("relay command authorization", () => {
         .some((frame) => frame.type === "cdpEvent" && frame.method === "Runtime.consoleAPICalled"),
     ).toBe(false);
 
-    releaseTargets([{ id: "target-64", tabId: 64, attached: true }]);
+    targetInfo.resolve({ targetInfo: { targetId: "target-64" } });
     await vi.waitFor(() => {
       const frames = socket.send.mock.calls.map(([raw]) => JSON.parse(raw));
       expect(frames).toContainEqual({
@@ -654,7 +649,7 @@ describe("relay command authorization", () => {
         message: "tab 64 access was revoked",
       });
     });
-    expect(harness.debuggerDetach).toHaveBeenCalledWith({ tabId: 64 });
+    expect(harness.debuggerDetach).toHaveBeenCalledWith({ targetId: "target-64" });
   });
 
   it.each(["all", "selected"] as const)(
@@ -703,8 +698,8 @@ describe("relay command authorization", () => {
         const pendingDetach = new Promise<void>((resolve) => {
           releaseMutation = resolve;
         });
-        harness.debuggerDetach.mockImplementation(async ({ tabId }: { tabId: number }) => {
-          if (tabId === 202) {
+        harness.debuggerDetach.mockImplementation(async ({ targetId }) => {
+          if (targetId === "tab-202") {
             await pendingDetach;
           }
         });
@@ -718,7 +713,9 @@ describe("relay command authorization", () => {
       if (accessMode === "all") {
         await vi.waitFor(() => expect(harness.sessionStorageSet).toHaveBeenCalled());
       } else {
-        await vi.waitFor(() => expect(harness.debuggerDetach).toHaveBeenCalledWith({ tabId: 202 }));
+        await vi.waitFor(() =>
+          expect(harness.debuggerDetach).toHaveBeenCalledWith({ targetId: "tab-202" }),
+        );
       }
 
       await expect(
@@ -759,8 +756,8 @@ describe("relay command authorization", () => {
           .filter((frame) => frame.type === "cdpEvent")
           .map((frame) => frame.params?.phase),
       ).toEqual(["during", "after"]);
-      expect(harness.debuggerDetach).toHaveBeenCalledWith({ tabId: 202 });
-      expect(harness.debuggerDetach).not.toHaveBeenCalledWith({ tabId: 201 });
+      expect(harness.debuggerDetach).toHaveBeenCalledWith({ targetId: "tab-202" });
+      expect(harness.debuggerDetach).not.toHaveBeenCalledWith({ targetId: "tab-201" });
       expect(harness.debuggerAttach).toHaveBeenCalledTimes(2);
     },
   );
@@ -844,12 +841,21 @@ describe("relay command authorization", () => {
       throw new Error("expected relay socket");
     }
     await harness.authenticate(socket);
+    harness.shareTab(41);
+    socket.receive({ type: "attach", seq: 4, tabId: 41 });
+    await vi.waitFor(() =>
+      expect(socket.send.mock.calls.map(([raw]) => JSON.parse(raw))).toContainEqual({
+        type: "result",
+        seq: 4,
+        result: { targetId: "tab-41" },
+      }),
+    );
     harness.unshareTab(41);
 
     socket.receive({ type: "detach", seq: 5, tabId: 41 });
 
     await vi.waitFor(() => {
-      expect(harness.debuggerDetach).toHaveBeenCalledWith({ tabId: 41 });
+      expect(harness.debuggerDetach).toHaveBeenCalledWith({ targetId: "tab-41" });
       const frames = socket.send.mock.calls.map(([raw]) => JSON.parse(raw));
       expect(frames).toContainEqual({ type: "result", seq: 5, result: {} });
     });
@@ -908,7 +914,7 @@ describe("relay command authorization", () => {
     releaseAttach();
 
     await vi.waitFor(() => {
-      expect(harness.debuggerDetach).toHaveBeenCalledWith({ tabId: 43 });
+      expect(harness.debuggerDetach).toHaveBeenCalledWith({ targetId: "tab-43" });
       const frames = socket.send.mock.calls.map(([raw]) => JSON.parse(raw));
       expect(frames).toContainEqual({
         type: "error",
@@ -1062,7 +1068,7 @@ describe("relay command authorization", () => {
 
     if (detached) {
       await vi.waitFor(() => {
-        expect(harness.debuggerDetach).toHaveBeenCalledWith({ tabId: 111 });
+        expect(harness.debuggerDetach).toHaveBeenCalledWith({ targetId: "tab-111" });
       });
     } else {
       await new Promise<void>((resolve) => {

--- a/extensions/browser/chrome-extension/background.document-navigation.test.ts
+++ b/extensions/browser/chrome-extension/background.document-navigation.test.ts
@@ -11,13 +11,13 @@ import {
 const originalUrl = "https://example.com/existing";
 const blankResult = { frameId: "root", loaderId: "blank-loader" };
 
-async function setup() {
+async function setup(mode: "all" | "selected" = "selected") {
   const h = await loadBackground({
     storedConfig: {
       relayUrl: "ws://127.0.0.1:18797/extension",
       token: TEST_RELAY_KEY,
       authVersion: 2,
-      accessMode: "selected",
+      accessMode: mode,
     },
     initialTabs: [
       { id: 7, url: originalUrl, groupId: 7, windowId: 1 },
@@ -70,6 +70,37 @@ afterEach(async () => {
 });
 
 describe("commanded existing document navigation", () => {
+  it.each(["all", "selected"] as const)(
+    "does not admit an old %s navigation through a replacement native attachment",
+    async (mode) => {
+      const h = await setup(mode);
+      const access = createDeferred<void>();
+      releases.push(() => access.resolve());
+      const get = h.tabsGet.getMockImplementation()!;
+      let held = false;
+      h.tabsGet.mockImplementationOnce(async (id) => {
+        const tab = await get(id);
+        held = true;
+        await access.promise;
+        return tab;
+      });
+      h.native(async () => {
+        h.commitBlank();
+        return blankResult;
+      });
+      const navigating = h.navigate();
+      await vi.waitFor(() => expect(held).toBe(true));
+      expect(await h.request({ type: "detach", tabId: 7 })).toMatchObject({ type: "result" });
+      expect(await h.request({ type: "attach", tabId: 7 })).toMatchObject({ type: "result" });
+      access.resolve();
+      expect.soft(await navigating).toMatchObject({ type: "error" });
+      expect.soft(h.debuggerSendCommand).not.toHaveBeenCalled();
+      expect(h.tabsRemove).not.toHaveBeenCalled();
+      expect(h.tabsUpdate).not.toHaveBeenCalled();
+      expect(await h.navigate()).toMatchObject({ type: "result", result: blankResult });
+    },
+  );
+
   it("preserves the native blank/reset/trace/return order in selected mode", async () => {
     const h = await setup();
     h.native(async () => {

--- a/extensions/browser/chrome-extension/background.initial-target.test.ts
+++ b/extensions/browser/chrome-extension/background.initial-target.test.ts
@@ -249,7 +249,7 @@ describe.each(["all", "selected"] as const)("created initial target in %s mode",
         harness.debuggerAttach.mockRejectedValueOnce(failure);
       }
       if (stage === "target lookup") {
-        harness.debuggerGetTargets.mockRejectedValueOnce(failure);
+        harness.debuggerGetTargetInfo.mockRejectedValueOnce(failure);
       }
       if (stage === "focus") {
         harness.windowsUpdate.mockRejectedValueOnce(failure);
@@ -344,14 +344,14 @@ describe.each(["all", "selected"] as const)("created initial target in %s mode",
     async (stage) => {
       const harness = await createHarness(mode);
       const attaching = deferred(undefined);
-      harness.debuggerGetTargets.mockClear();
+      harness.debuggerGetTargetInfo.mockClear();
       if (stage === "attach") {
         harness.debuggerAttach.mockImplementationOnce(async () => await attaching.promise);
       }
       if (stage === "target lookup") {
-        harness.debuggerGetTargets.mockImplementationOnce(async () => {
+        harness.debuggerGetTargetInfo.mockImplementationOnce(async () => {
           await attaching.promise;
-          return [];
+          return { targetInfo: { targetId: "tab-101" } };
         });
       }
       if (stage === "focus") {
@@ -363,7 +363,7 @@ describe.each(["all", "selected"] as const)("created initial target in %s mode",
           stage === "focus"
             ? harness.windowsUpdate
             : stage === "target lookup"
-              ? harness.debuggerGetTargets
+              ? harness.debuggerGetTargetInfo
               : harness.debuggerAttach,
         ).toHaveBeenCalled(),
       );
@@ -484,7 +484,12 @@ describe.each(["all", "selected"] as const)("created initial target in %s mode",
       expect(await creating).toMatchObject({ type: "error" });
       await mutation;
       expect(harness.tabsRemove).not.toHaveBeenCalled();
-      expect(harness.debuggerDetach).toHaveBeenCalledWith({ tabId: 101 });
+      if (revocation === "cancel") {
+        // Chrome's onDetach already destroyed this exact native client.
+        expect(harness.debuggerDetach).not.toHaveBeenCalled();
+      } else {
+        expect(harness.debuggerDetach).toHaveBeenCalledWith({ targetId: "tab-101" });
+      }
       if (revocation === "replacement") {
         expect(await harness.command({ type: "attach", tabId: 102 })).toMatchObject({
           type: "error",

--- a/extensions/browser/chrome-extension/background.js
+++ b/extensions/browser/chrome-extension/background.js
@@ -59,7 +59,7 @@ const tabAccessPolicy = createTabAccessPolicy({
   getGroupColor: async () => (await getConfig()).groupColor,
 });
 const relayDebugger = createRelayDebugger({ policy: tabAccessPolicy, requireAutomationAllowed });
-const { attachedTabs, attachedAccessEpochs, attachingTabs, detach: detachDebugger } = relayDebugger;
+const { attachments, detach: detachDebugger } = relayDebugger;
 const tabAccessReady = (async () => {
   const retiredState = await prepareRetiredCopilotState();
   retiredCopilotCustodyBlocked = retiredState.blocked;
@@ -189,14 +189,21 @@ async function syncTabsToRelay() {
   if (!socket || socket.readyState !== WebSocket.OPEN || relayAuthenticatedSocket !== socket) {
     return;
   }
+  const generations = [...attachments].filter(([, record]) => !record.retired);
   const accessible = await tabAccessPolicy.listAccessibleTabs();
-  if (relayWs !== socket || relayAuthenticatedSocket !== socket) {
+  if (
+    relayWs !== socket ||
+    relayAuthenticatedSocket !== socket ||
+    socket.readyState !== WebSocket.OPEN
+  ) {
     return;
   }
   const accessibleIds = new Set(accessible.map((tab) => tab.id));
-  for (const tabId of attachedTabs) {
-    if (!accessibleIds.has(tabId)) {
-      void detachDebugger(tabId);
+  for (const [tabId, generation] of generations) {
+    if (!accessibleIds.has(tabId) && attachments.get(tabId) === generation) {
+      void detachDebugger(tabId).catch((error) =>
+        console.warn("Debugger access cleanup failed", error),
+      );
     }
   }
   // A creation is authorized internally, but discovery must wait for handoff.
@@ -209,17 +216,7 @@ async function syncTabsToRelay() {
 // ---------------------------------------------------------------------------
 
 async function detachAllDebuggerSessions() {
-  await relayDebugger.detachAll();
-  if (retiredCopilotCustodyBlocked) {
-    // Startup recovery must also release inherited copilot attachments. Chrome
-    // detach addresses only this extension's client; it never adopts a target.
-    const targets = await chrome.debugger.getTargets();
-    await Promise.all(
-      targets
-        .filter((target) => target.attached && typeof target.tabId === "number")
-        .map((target) => detachDebugger(target.tabId)),
-    );
-  }
+  await relayDebugger.detachAll(retiredCopilotCustodyBlocked);
 }
 
 async function reconcileAccessMode(nextMode, { transitioning = false } = {}) {
@@ -232,7 +229,8 @@ async function reconcileAccessMode(nextMode, { transitioning = false } = {}) {
     }
     return mode;
   }
-  await Promise.allSettled(attachingTabs.values());
+  const generations = [...attachments].filter(([, record]) => !record.retired);
+  await Promise.allSettled([...attachments.values()].map((record) => record.pending));
   if (mode === ACCESS_MODE_SELECTED) {
     const selectedIds = new Set(
       (
@@ -242,26 +240,28 @@ async function reconcileAccessMode(nextMode, { transitioning = false } = {}) {
       ).map((tab) => tab.id),
     );
     await Promise.allSettled(
-      [...attachedTabs]
-        .filter((tabId) => !selectedIds.has(tabId))
-        .map((tabId) => detachDebugger(tabId)),
+      generations
+        .filter(
+          ([tabId, generation]) => !selectedIds.has(tabId) && attachments.get(tabId) === generation,
+        )
+        .map(([tabId]) => detachDebugger(tabId)),
     );
   }
   if (transitioning) {
     tabAccessPolicy.endTransition();
   }
-  for (const tabId of attachedTabs) {
+  for (const [tabId, generation] of generations) {
     const epoch = tabAccessPolicy.capture(tabId);
     const state = await tabAccessPolicy.inspectTab(tabId, epoch);
-    if (!tabAccessPolicy.epochIsCurrent(tabId, epoch)) {
+    if (attachments.get(tabId) !== generation || !tabAccessPolicy.epochIsCurrent(tabId, epoch)) {
       // A post-transition tab event owns the newer revision. Keep this
       // attachment fail-closed until that handler reconciles it.
       continue;
     }
     if (!state.accessible) {
       await detachDebugger(tabId);
-    } else if (attachedTabs.has(tabId)) {
-      attachedAccessEpochs.set(tabId, epoch);
+    } else {
+      generation.epoch = epoch;
     }
   }
   await syncTabsToRelay();
@@ -269,14 +269,16 @@ async function reconcileAccessMode(nextMode, { transitioning = false } = {}) {
 }
 
 async function pauseTab(tabId) {
+  // Pause records controlled-document revocation before detach retires that document.
+  const pausing = tabAccessPolicy.pause(tabId);
+  const detaching = detachDebugger(tabId);
   let storageError = null;
   try {
-    await tabAccessPolicy.pause(tabId);
+    await pausing;
   } catch (error) {
     storageError = error;
   }
-  await Promise.allSettled([attachingTabs.get(tabId)]);
-  await detachDebugger(tabId);
+  await detaching;
   await syncTabsToRelay();
   if (storageError) {
     throw storageError instanceof Error
@@ -392,10 +394,10 @@ async function connectRelay(isConnectionAllowed = () => true) {
   let ws;
   const owner = relayDebugger.createOwner(
     () =>
+      connectionIsCurrent() &&
       relayWs === ws &&
       relayAuthenticatedSocket === ws &&
-      ws.readyState === WebSocket.OPEN &&
-      connectionIsCurrent(),
+      ws.readyState === WebSocket.OPEN,
   );
   const handleRelayCommand = createRelayCommandHandler({
     send: (message) => send(message, ws),
@@ -405,18 +407,21 @@ async function connectRelay(isConnectionAllowed = () => true) {
     createTab: (message, operation) => tabAccessPolicy.createTab(message, operation),
     focusWindowForTab,
     scheduleTabsSync,
+    captureDebugger: owner.capture,
     captureAccess: (tabId, method) => tabAccessPolicy.capture(tabId, method),
     requireAccessibleTab: owner.requireTab,
     requireNavigatedTab: (tabId, epoch) => owner.requireTab(tabId, epoch, true),
-    navigateTab: (tabId, epoch, params, isCurrent, sendCommand) =>
-      tabAccessPolicy.navigateTab(
+    navigateTab: (tabId, epoch, params, isCurrent, sendCommand) => {
+      const generation = attachments.get(tabId);
+      return tabAccessPolicy.navigateTab(
         tabId,
         epoch,
         params,
-        () => attachedAccessEpochs.get(tabId),
+        () => (attachments.get(tabId) === generation ? generation?.epoch : undefined),
         isCurrent,
         sendCommand,
-      ),
+      );
+    },
   });
   try {
     ws = openAuthenticatedRelaySocket({
@@ -559,7 +564,6 @@ const handlePopupMessage = createPopupMessageHandler({
   closeRelaySocket,
   connectRelay,
   setBadge,
-  attachingTabs,
   detachDebugger,
   removeTabFromOpenClawGroup,
   addTabToOpenClawGroup: (tabId) => tabAccessPolicy.addTabToGroup(tabId),
@@ -575,9 +579,8 @@ chrome.runtime.onMessage.addListener((msg, _sender, reply) => handlePopupMessage
 registerTabAccessEvents({
   accessReady: tabAccessReady,
   policy: tabAccessPolicy,
-  attachedTabs,
-  attachedAccessEpochs,
-  attachingTabs,
+  attachments,
+  nativeDetached: relayDebugger.nativeDetached,
   send,
   scheduleTabsSync,
   detachDebugger,

--- a/extensions/browser/chrome-extension/background.native-cleanup.test.ts
+++ b/extensions/browser/chrome-extension/background.native-cleanup.test.ts
@@ -1,0 +1,335 @@
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  cleanupBackgroundHarnesses,
+  loadBackground,
+  sendRuntimeMessage,
+  TEST_RELAY_KEY,
+} from "./background.test-harness.js";
+
+const releases: Array<() => void> = [];
+beforeEach(() => vi.resetModules());
+afterEach(async () => {
+  for (const release of releases.splice(0)) {
+    release();
+  }
+  await cleanupBackgroundHarnesses();
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+async function fixture() {
+  const h = await loadBackground({
+    storedConfig: {
+      relayUrl: "ws://127.0.0.1:18797/extension",
+      token: TEST_RELAY_KEY,
+      authVersion: 2,
+      accessMode: "all",
+    },
+    initialTabs: [7, 8, 9].map((id) => ({ id, url: `https://example.com/${id}`, groupId: -1 })),
+  });
+  // Chrome's tab lookup and its extension client registry have different lifetimes.
+  const tabs = new Map<number, string>();
+  const clients = new Set<string>();
+  let ordinal = 0;
+  const resolve = (source: { tabId?: number; targetId?: string }) => {
+    const id = source.targetId ?? (source.tabId === undefined ? undefined : tabs.get(source.tabId));
+    if (!id) {
+      throw new Error(`No tab with given id ${source.tabId}.`);
+    }
+    if (!clients.has(id)) {
+      throw new Error(`Debugger is not attached to the target with id: ${id}.`);
+    }
+    return id;
+  };
+  h.debuggerAttach.mockImplementation(async ({ tabId }) => {
+    if (tabs.has(tabId) && clients.has(tabs.get(tabId)!)) {
+      throw new Error("Another debugger is already attached");
+    }
+    const id = `native-${++ordinal}`;
+    tabs.set(tabId, id);
+    clients.add(id);
+  });
+  h.debuggerDetach.mockImplementation(async (source) => {
+    clients.delete(resolve(source));
+  });
+  h.debuggerGetTargets.mockImplementation(async () =>
+    [...tabs].map(([tabId, id]) => ({ tabId, id, attached: clients.has(id) })),
+  );
+  h.debuggerGetTargetInfo.mockImplementation(async (source) => ({
+    targetInfo: { targetId: resolve(source) },
+  }));
+  h.debuggerSendCommand.mockImplementation(async (source, method) => {
+    const targetId = resolve(source);
+    return method === "Target.getTargetInfo"
+      ? { targetInfo: { targetId, type: "page" } }
+      : { targetId };
+  });
+  const socket = h.relaySockets[0]!;
+  await h.authenticate(socket);
+  let seq = 0;
+  const frames = (s = socket) => s.send.mock.calls.map(([raw]) => JSON.parse(raw));
+  const command = async (type: string, tabId: number, s = socket) => {
+    const id = ++seq;
+    s.receive({ type, tabId, seq: id });
+    return await vi.waitFor(() => {
+      const result = frames(s).find((f) => f.seq === id);
+      expect(result).toBeDefined();
+      return result;
+    });
+  };
+  const attach = async (tabId: number, s = socket) => {
+    const response = await command("attach", tabId, s);
+    expect(response).toMatchObject({ type: "result", result: { targetId: tabs.get(tabId) } });
+    return tabs.get(tabId)!;
+  };
+  const reconnect = async () => {
+    socket.close();
+    h.alarmListener({ name: "openclaw-relay-watchdog" });
+    await vi.waitFor(() => expect(h.relaySockets).toHaveLength(2));
+    const next = h.relaySockets[1]!;
+    await h.authenticate(next);
+    return next;
+  };
+  const holdDetach = (tabId: number) => {
+    const gate = createDeferred<void>();
+    releases.push(() => gate.resolve());
+    const id = tabs.get(tabId);
+    const original = h.debuggerDetach.getMockImplementation()!;
+    h.debuggerDetach.mockImplementation(async (source) => {
+      if (resolve(source) === id) {
+        await gate.promise;
+      }
+      await original(source);
+    });
+    return gate;
+  };
+  return { h, socket, tabs, clients, command, attach, reconnect, frames, holdDetach };
+}
+
+describe("native debugger cleanup debt", () => {
+  it("keeps a refused tab local while draining another tab and admitting an unrelated tab", async () => {
+    const f = await fixture();
+    const oldA = await f.attach(7);
+    await f.attach(8);
+    const gate = f.holdDetach(8);
+    f.h.debuggerDetach.mockRejectedValueOnce(new Error("native cleanup refused"));
+    const next = await f.reconnect();
+    expect.soft(await f.command("attach", 9, next)).toMatchObject({ type: "result" });
+    expect(f.clients.has(oldA)).toBe(true);
+    let completed = false;
+    const b = f.command("attach", 8, next).then((result) => {
+      completed = true;
+      return result;
+    });
+    await new Promise<void>((resolve) => {
+      setImmediate(resolve);
+    });
+    expect.soft(completed).toBe(false);
+    gate.resolve();
+    expect.soft(await b).toMatchObject({ type: "result" });
+    expect.soft(await f.command("attach", 7, next)).toMatchObject({ type: "result" });
+    expect.soft(f.clients.has(oldA)).toBe(false);
+  });
+
+  it("retries settled cleanup on explicit acquire without adopting the old client", async () => {
+    const f = await fixture();
+    const old = await f.attach(7);
+    f.h.debuggerDetach.mockRejectedValueOnce(new Error("native cleanup refused"));
+    expect(await f.command("detach", 7)).toMatchObject({ type: "error" });
+    expect(f.clients.has(old)).toBe(true);
+    expect.soft(await f.command("attach", 7)).toMatchObject({ type: "result" });
+    expect.soft(f.clients.has(old)).toBe(false);
+    expect.soft(f.tabs.get(7)).not.toBe(old);
+  });
+
+  it.each(["NoTab", "removal", "replacement"])(
+    "retains the actual native client after %s and cleans by owned target identity",
+    async (ending) => {
+      const f = await fixture();
+      const old = await f.attach(7);
+      f.tabs.delete(7);
+      expect(f.clients.has(old)).toBe(true);
+      if (ending === "removal") {
+        f.h.tabsRemovedListener?.(7);
+      } else if (ending === "replacement") {
+        f.h.tabsReplacedListener(10, 7);
+      } else {
+        expect(await f.command("detach", 7)).toMatchObject({ type: "result" });
+      }
+      await vi.waitFor(() => expect(f.clients.has(old)).toBe(false));
+      expect(f.h.debuggerDetach).toHaveBeenCalledWith({ targetId: old });
+    },
+  );
+
+  it("does not invent cleanup debt for never-owned removed or replaced tabs", async () => {
+    const f = await fixture();
+    f.h.tabsRemovedListener?.(50);
+    f.h.tabsReplacedListener(52, 51);
+    await new Promise<void>((resolve) => {
+      setImmediate(resolve);
+    });
+    expect(f.h.debuggerDetach).not.toHaveBeenCalled();
+    await f.attach(7);
+  });
+
+  it("drains an in-flight detach after authoritative native closure before a successor", async () => {
+    const f = await fixture();
+    const old = await f.attach(7);
+    const gate = f.holdDetach(7);
+    const detaching = f.command("detach", 7);
+    await vi.waitFor(() => expect(f.h.debuggerDetach).toHaveBeenCalled());
+    f.clients.delete(old);
+    f.h.debuggerDetachListener?.({ tabId: 7 }, "target_closed");
+    let attached = false;
+    const acquiring = f.command("attach", 7).then((result) => {
+      attached = true;
+      return result;
+    });
+    await new Promise<void>((resolve) => {
+      setImmediate(resolve);
+    });
+    expect(attached).toBe(false);
+    gate.resolve();
+    await detaching;
+    expect.soft(await acquiring).toMatchObject({ type: "result" });
+    expect.soft(f.clients.size).toBe(1);
+    expect.soft(f.clients.has(old)).toBe(false);
+  });
+
+  it("uses same-client identity rather than an enumerated attached flag", async () => {
+    const f = await fixture();
+    f.h.debuggerGetTargets.mockResolvedValue([{ tabId: 7, id: "unrelated", attached: true }]);
+    await f.attach(7);
+    expect(f.h.debuggerGetTargetInfo).toHaveBeenCalledWith({ tabId: 7 });
+  });
+
+  it("rejects missing native identity and cleans its acquired client", async () => {
+    const f = await fixture();
+    f.h.debuggerGetTargets.mockResolvedValue([]);
+    f.h.debuggerGetTargetInfo.mockResolvedValue({ targetInfo: { targetId: "" } });
+    expect.soft(await f.command("attach", 7)).toMatchObject({ type: "error" });
+    expect.soft(f.clients.size).toBe(0);
+  });
+  it("retains unknown-identity NoTab debt until authoritative native closure", async () => {
+    const f = await fixture();
+    f.h.debuggerGetTargets.mockResolvedValue([]);
+    f.h.debuggerGetTargetInfo.mockImplementationOnce(async () => {
+      f.tabs.delete(7);
+      throw new Error("No tab with given id 7.");
+    });
+    expect(await f.command("attach", 7)).toMatchObject({ type: "error" });
+    const old = [...f.clients][0]!;
+    expect(f.clients.has(old)).toBe(true);
+    expect(await f.command("attach", 7)).toMatchObject({ type: "error" });
+    await f.attach(8);
+    f.clients.delete(old);
+    f.h.debuggerDetachListener?.({ tabId: 7 }, "target_closed");
+    await f.attach(7);
+    expect(f.clients.size).toBe(2);
+  });
+
+  it("captures cleanup identity after native success overtaken by access loss", async () => {
+    const f = await fixture();
+    const gate = createDeferred<void>();
+    releases.push(() => gate.resolve());
+    const attach = f.h.debuggerAttach.getMockImplementation()!;
+    f.h.debuggerAttach.mockImplementationOnce(async (source) => {
+      await attach(source, "1.3");
+      await gate.promise;
+    });
+    const acquiring = f.command("attach", 7);
+    await vi.waitFor(() => expect(f.clients.size).toBe(1));
+    const old = f.tabs.get(7)!;
+    const pausing = sendRuntimeMessage(f.h, {
+      type: "toggleTabAccess",
+      tabId: 7,
+      accessMode: "all",
+      grant: false,
+    });
+    await vi.waitFor(async () =>
+      expect(await sendRuntimeMessage(f.h, { type: "getTabAccess", tabId: 7 })).toMatchObject({
+        accessible: false,
+      }),
+    );
+    expect(await f.h.tabsGet(7)).toMatchObject({ url: "https://example.com/7" });
+    expect(f.h.debuggerGetTargetInfo).not.toHaveBeenCalled();
+    gate.resolve();
+    expect(await acquiring).toMatchObject({ type: "error" });
+    expect(await pausing).toMatchObject({ ok: true, accessible: false, denied: true });
+    expect(f.h.debuggerGetTargetInfo).toHaveBeenCalledWith({ tabId: 7 });
+    expect(f.h.debuggerDetach).toHaveBeenCalledWith({ targetId: old });
+    expect(f.clients.has(old)).toBe(false);
+  });
+
+  it("reports incomplete Disconnect and retries its retained native debt", async () => {
+    const f = await fixture();
+    const old = await f.attach(7);
+    const detach = f.h.debuggerDetach.getMockImplementation()!;
+    f.h.debuggerDetach.mockRejectedValue(new Error("native cleanup refused"));
+    expect(await sendRuntimeMessage(f.h, { type: "unpair" })).toMatchObject({
+      ok: false,
+      error: expect.stringContaining("native cleanup refused"),
+    });
+    expect(f.clients.has(old)).toBe(true);
+    f.h.debuggerDetach.mockImplementation(detach);
+    expect(await sendRuntimeMessage(f.h, { type: "unpair" })).toMatchObject({ ok: true });
+    expect(f.clients.has(old)).toBe(false);
+  });
+
+  it("fences inherited cleanup enumeration overtaken by re-pair and fresh acquisition", async () => {
+    const h = await loadBackground({
+      storedConfig: {
+        relayUrl: "ws://127.0.0.1:18797/extension",
+        token: TEST_RELAY_KEY,
+        authVersion: 2,
+        accessMode: "all",
+        copilotSessionRegistryV1: {
+          sessions: { 7: { creationPending: true } },
+          pendingArchives: [],
+        },
+      },
+    });
+    await sendRuntimeMessage(h, { type: "getStatus" });
+    const gate = createDeferred<Array<{ tabId: number; id: string; attached: boolean }>>();
+    releases.push(() => gate.resolve([]));
+    let held = false;
+    h.debuggerGetTargets.mockImplementationOnce(async () => {
+      held = true;
+      return await gate.promise;
+    });
+    h.storageValues.token = "invalid";
+    const status = sendRuntimeMessage(h, { type: "getStatus" });
+    await vi.waitFor(() => expect(held).toBe(true));
+    expect(await sendRuntimeMessage(h, { type: "unpair" })).toMatchObject({ ok: true });
+    expect(
+      await sendRuntimeMessage(h, {
+        type: "pair",
+        pairingString: `ws://127.0.0.1:18797/extension#${TEST_RELAY_KEY}`,
+        accessMode: "all",
+      }),
+    ).toMatchObject({ ok: true });
+    const socket = h.relaySockets.at(-1)!;
+    await h.authenticate(socket);
+    let live = false;
+    h.debuggerAttach.mockImplementation(async () => {
+      live = true;
+    });
+    h.debuggerDetach.mockImplementation(async () => {
+      live = false;
+    });
+    h.debuggerGetTargetInfo.mockResolvedValue({ targetInfo: { targetId: "fresh-native" } });
+    socket.receive({ type: "attach", tabId: 7, seq: 91 });
+    await vi.waitFor(() =>
+      expect(socket.send.mock.calls.map(([raw]) => JSON.parse(raw))).toContainEqual({
+        type: "result",
+        seq: 91,
+        result: { targetId: "fresh-native" },
+      }),
+    );
+    gate.resolve([{ tabId: 7, id: "fresh-native", attached: true }]);
+    expect(await status).toMatchObject({ ok: false, error: expect.stringContaining("superseded") });
+    expect(live).toBe(true);
+    expect(h.debuggerDetach).not.toHaveBeenCalled();
+  });
+});

--- a/extensions/browser/chrome-extension/background.relay-lifecycle.test.ts
+++ b/extensions/browser/chrome-extension/background.relay-lifecycle.test.ts
@@ -46,15 +46,19 @@ async function fixture() {
     }
     attached.set(id, { runtimeEnabled: false });
   });
-  h.debuggerDetach.mockImplementation(async ({ tabId: id }) => {
+  h.debuggerDetach.mockImplementation(async (source) => {
+    const id = source.tabId ?? Number(source.targetId?.slice("target-".length));
     if (!attached.delete(id)) {
-      throw new Error(`Debugger is not attached to the tab with id: ${id}.`);
+      throw new Error(`Debugger is not attached to the target with id: target-${id}.`);
     }
     // Native programmatic detach does not emit the user onDetach event.
   });
-  h.debuggerGetTargets.mockImplementation(async () =>
-    [...attached.keys()].map((id) => ({ id: `target-${id}`, tabId: id, attached: true })),
-  );
+  h.debuggerGetTargetInfo.mockImplementation(async ({ tabId: id }) => {
+    if (!attached.has(id)) {
+      throw new Error("Debugger is not attached");
+    }
+    return { targetInfo: { targetId: `target-${id}` } };
+  });
   h.debuggerSendCommand.mockImplementation(async (source, method) => {
     const session = attached.get(source.tabId);
     if (!session) {
@@ -130,8 +134,8 @@ describe("authenticated relay debugger lifetime", () => {
       expect(
         frames(next).filter((frame) => frame.method === "Runtime.executionContextCreated"),
       ).toHaveLength(1);
-      expect(f.h.debuggerDetach).toHaveBeenCalledWith({ tabId });
-      expect(f.h.debuggerDetach).not.toHaveBeenCalledWith({ tabId: 99 });
+      expect(f.h.debuggerDetach).toHaveBeenCalledWith({ targetId: `target-${tabId}` });
+      expect(f.h.debuggerDetach).not.toHaveBeenCalledWith({ targetId: "target-99" });
       expect(f.h.debuggerAttach).toHaveBeenCalledTimes(2);
       expect(f.h.sessionStorageValues).not.toHaveProperty("deniedTabIdsV1");
       expect(await sendRuntimeMessage(f.h, { type: "getTabAccess", tabId })).toMatchObject({
@@ -148,16 +152,16 @@ describe("authenticated relay debugger lifetime", () => {
       const gate = createDeferred<void>();
       const detachGate = createDeferred<void>();
       const attachImpl = f.h.debuggerAttach.getMockImplementation()!;
-      const targetsImpl = f.h.debuggerGetTargets.getMockImplementation()!;
+      const targetsImpl = f.h.debuggerGetTargetInfo.getMockImplementation()!;
       if (phase === "attach") {
         f.h.debuggerAttach.mockImplementationOnce(async (...args) => {
           await gate.promise;
           await attachImpl(...args);
         });
       } else {
-        f.h.debuggerGetTargets.mockImplementationOnce(async () => {
+        f.h.debuggerGetTargetInfo.mockImplementationOnce(async (source) => {
           await gate.promise;
-          return targetsImpl();
+          return targetsImpl(source);
         });
       }
       const detachImpl = f.h.debuggerDetach.getMockImplementation()!;
@@ -169,7 +173,7 @@ describe("authenticated relay debugger lifetime", () => {
         f.old.receive({ type: "attach", seq: 44, tabId });
         await vi.waitFor(() =>
           expect(
-            phase === "attach" ? f.h.debuggerAttach : f.h.debuggerGetTargets,
+            phase === "attach" ? f.h.debuggerAttach : f.h.debuggerGetTargetInfo,
           ).toHaveBeenCalled(),
         );
         f.old.close();
@@ -179,7 +183,9 @@ describe("authenticated relay debugger lifetime", () => {
         expect(f.h.debuggerAttach).toHaveBeenCalledTimes(1);
         expect(frames(next).some((frame) => frame.seq === 1)).toBe(false);
         gate.resolve();
-        await vi.waitFor(() => expect(f.h.debuggerDetach).toHaveBeenCalledWith({ tabId }));
+        await vi.waitFor(() =>
+          expect(f.h.debuggerDetach).toHaveBeenCalledWith({ targetId: `target-${tabId}` }),
+        );
         expect(f.h.debuggerAttach).toHaveBeenCalledTimes(1);
         detachGate.resolve();
         await vi.waitFor(() =>
@@ -217,7 +223,7 @@ describe("authenticated relay debugger lifetime", () => {
       f.old.finishClose();
       const next = await f.replacement();
       await f.attach(next);
-      expect(f.h.debuggerDetach).toHaveBeenCalledWith({ tabId });
+      expect(f.h.debuggerDetach).toHaveBeenCalledWith({ targetId: `target-${tabId}` });
       await reply(next, 9, { type: "cdp", tabId, method: "Runtime.enable" });
       gate.resolve({ stale: true });
       await flush();
@@ -233,7 +239,7 @@ describe("authenticated relay debugger lifetime", () => {
   });
 
   it.each(["attach", "cdp", "activateTab", "closeTab", "createTab"])(
-    "fences %s paused over a tab lookup before any subsequent Chrome operation",
+    "fences %s paused over a tab lookup while preserving creator-owned rollback",
     async (type) => {
       const f = await fixture();
       await f.attach(f.old);
@@ -261,10 +267,15 @@ describe("authenticated relay debugger lifetime", () => {
         expect(f.h.debuggerSendCommand).not.toHaveBeenCalled();
         expect(f.h.tabsUpdate).not.toHaveBeenCalled();
         expect(f.h.windowsUpdate).not.toHaveBeenCalled();
-        // Atomic creation retains guarded pre-handoff rollback on connection loss.
-        expect(f.h.tabsRemove.mock.calls).toEqual(type === "createTab" ? [[8]] : []);
+        if (type === "createTab") {
+          expect(f.h.tabsRemove).toHaveBeenCalledExactlyOnceWith(tabId + 1);
+          expect(await f.h.tabsQuery()).toEqual([expect.objectContaining({ id: tabId })]);
+        } else {
+          expect(f.h.tabsRemove).not.toHaveBeenCalled();
+        }
         expect(f.h.tabsGroup).not.toHaveBeenCalled();
         expect(frames(next).some((frame) => frame.seq === 8)).toBe(false);
+        expect(frames(f.old).some((frame) => frame.seq === 8)).toBe(false);
       } finally {
         gate.resolve();
         await flush();
@@ -300,6 +311,39 @@ describe("authenticated relay debugger lifetime", () => {
       expect(
         frames(next).filter((frame) => frame.method === "Runtime.executionContextCreated"),
       ).toHaveLength(1);
+    } finally {
+      gate.resolve();
+      await flush();
+    }
+  });
+
+  it("does not recapture attach authority revoked while a previous socket drains", async () => {
+    const f = await fixture();
+    await f.attach(f.old);
+    const gate = createDeferred<void>();
+    const detach = f.h.debuggerDetach.getMockImplementation()!;
+    f.h.debuggerDetach.mockImplementationOnce(async (source) => {
+      await gate.promise;
+      await detach(source);
+    });
+    try {
+      f.old.finishClose();
+      const next = await f.replacement();
+      next.receive({ type: "attach", seq: 9, tabId });
+      await reply(next, 10, { type: "ping" });
+      f.h.updateTab(tabId, { url: "chrome://settings" });
+      f.h.updateTab(tabId, { url: "https://example.com/returned" });
+      gate.resolve();
+      await vi.waitFor(() =>
+        expect(frames(next)).toContainEqual({
+          type: "error",
+          seq: 9,
+          message: expect.stringContaining("access was revoked"),
+        }),
+      );
+      expect(f.h.debuggerAttach).toHaveBeenCalledTimes(1);
+      await f.attach(next, 11);
+      expect(f.h.debuggerAttach).toHaveBeenCalledTimes(2);
     } finally {
       gate.resolve();
       await flush();
@@ -373,7 +417,7 @@ describe("authenticated relay debugger lifetime", () => {
     const f = await fixture();
     await f.attach(f.old);
     vi.spyOn(console, "warn").mockImplementation(() => {});
-    f.h.debuggerDetach.mockRejectedValueOnce(new Error("native detach refused"));
+    f.h.debuggerDetach.mockRejectedValue(new Error("native detach refused"));
     f.old.finishClose();
     const next = await f.replacement();
     expect(await reply(next, 1, { type: "attach", tabId })).toMatchObject({
@@ -400,22 +444,22 @@ describe("authenticated relay debugger lifetime", () => {
     expect(f.attached.get(tabId)).toEqual({ runtimeEnabled: true });
   });
 
-  it.each(["Debugger is not attached to the tab with id: 7.", "No tab with given id 7."])(
-    "accepts Chrome's terminal detach evidence: %s",
-    async (message) => {
-      const f = await fixture();
-      await f.attach(f.old);
-      f.attached.delete(tabId);
-      f.h.debuggerDetach.mockRejectedValueOnce(new Error(message));
-      f.old.finishClose();
-      const next = await f.replacement();
-      await f.attach(next);
-      await reply(next, 2, { type: "cdp", tabId, method: "Runtime.enable" });
-      expect(
-        frames(next).filter((frame) => frame.method === "Runtime.executionContextCreated"),
-      ).toHaveLength(1);
-    },
-  );
+  it.each([
+    "Debugger is not attached to the target with id: target-7.",
+    "No target with given id target-7.",
+  ])("accepts Chrome's terminal detach evidence: %s", async (message) => {
+    const f = await fixture();
+    await f.attach(f.old);
+    f.attached.delete(tabId);
+    f.h.debuggerDetach.mockRejectedValueOnce(new Error(message));
+    f.old.finishClose();
+    const next = await f.replacement();
+    await f.attach(next);
+    await reply(next, 2, { type: "cdp", tabId, method: "Runtime.enable" });
+    expect(
+      frames(next).filter((frame) => frame.method === "Runtime.executionContextCreated"),
+    ).toHaveLength(1);
+  });
 
   it("keeps renewed navigation authority after reconnect without forwarding retired-owner events", async () => {
     const f = await fixture();
@@ -457,3 +501,207 @@ describe("authenticated relay debugger lifetime", () => {
     }
   });
 });
+
+describe("same-transport native generation", () => {
+  it.each(["before dispatch", "native completion", "post-access completion"])(
+    "rejects old work held at %s across detach and reattach",
+    async (stage) => {
+      const f = await fixture();
+      await f.attach(f.old);
+      const gate = createDeferred<void>();
+      const entered = createDeferred<void>();
+      const getTab = f.h.tabsGet.getMockImplementation()!;
+      const holdAccess = () =>
+        f.h.tabsGet.mockImplementationOnce(async (id) => {
+          entered.resolve();
+          await gate.promise;
+          return getTab(id);
+        });
+      if (stage === "before dispatch") {
+        holdAccess();
+      } else {
+        f.h.debuggerSendCommand.mockImplementationOnce(async () => {
+          if (stage === "native completion") {
+            entered.resolve();
+            await gate.promise;
+          } else {
+            holdAccess();
+          }
+          return { oldGeneration: true };
+        });
+      }
+      try {
+        f.old.receive({ type: "cdp", seq: 90, tabId, method: "Runtime.evaluate" });
+        await entered.promise;
+        await reply(f.old, 91, { type: "detach", tabId });
+        await f.attach(f.old, 92);
+        gate.resolve();
+        await vi.waitFor(() =>
+          expect(frames(f.old).find((frame) => frame.seq === 90)).toMatchObject({ type: "error" }),
+        );
+        expect(f.h.debuggerSendCommand).toHaveBeenCalledTimes(stage === "before dispatch" ? 0 : 1);
+        expect(
+          await reply(f.old, 93, { type: "cdp", tabId, method: "Runtime.enable" }),
+        ).toMatchObject({ type: "result" });
+      } finally {
+        gate.resolve();
+        await flush();
+      }
+    },
+  );
+});
+
+describe("native attachment retirement ordering", () => {
+  it("fences creation handoff after native replacement and preserves a user-taken-over tab", async () => {
+    const f = await fixture();
+    const gate = createDeferred<void>();
+    f.h.windowsUpdate.mockImplementationOnce(async () => {
+      await gate.promise;
+      return undefined;
+    });
+    const createdTabId = tabId + 1;
+    try {
+      f.old.receive({ type: "createTab", seq: 80, url: "https://example.com/new", focus: true });
+      await vi.waitFor(() => expect(f.h.windowsUpdate).toHaveBeenCalled());
+      await reply(f.old, 81, { type: "detach", tabId: createdTabId });
+      expect(await reply(f.old, 82, { type: "attach", tabId: createdTabId })).toMatchObject({
+        type: "result",
+      });
+      f.h.updateTab(createdTabId, { url: "https://example.com/user-takeover" });
+      gate.resolve();
+      await vi.waitFor(() =>
+        expect(frames(f.old).find((frame) => frame.seq === 80)).toMatchObject({ type: "error" }),
+      );
+      expect(f.h.tabsRemove).not.toHaveBeenCalled();
+      expect(
+        await reply(f.old, 83, { type: "cdp", tabId: createdTabId, method: "Runtime.enable" }),
+      ).toMatchObject({ type: "result" });
+    } finally {
+      gate.resolve();
+      await flush();
+    }
+  });
+
+  it("does not hand off a pending native attach overtaken by explicit detach", async () => {
+    const f = await fixture();
+    const gate = createDeferred<void>();
+    const detachGate = createDeferred<void>();
+    const nativeAttach = f.h.debuggerAttach.getMockImplementation()!;
+    const nativeDetach = f.h.debuggerDetach.getMockImplementation()!;
+    f.h.debuggerAttach.mockImplementationOnce(async (...args) => {
+      await gate.promise;
+      await nativeAttach(...args);
+    });
+    f.h.debuggerDetach.mockImplementationOnce(async (...args) => {
+      await detachGate.promise;
+      await nativeDetach(...args);
+    });
+    try {
+      f.old.receive({ type: "attach", seq: 70, tabId });
+      await vi.waitFor(() => expect(f.h.debuggerAttach).toHaveBeenCalledTimes(1));
+      f.old.receive({ type: "detach", seq: 71, tabId });
+      f.old.receive({ type: "attach", seq: 72, tabId });
+      await reply(f.old, 73, { type: "ping" });
+      expect(f.h.debuggerAttach).toHaveBeenCalledTimes(1);
+      gate.resolve();
+      await vi.waitFor(() => expect(f.h.debuggerDetach).toHaveBeenCalled());
+      expect(f.h.debuggerAttach).toHaveBeenCalledTimes(1);
+      detachGate.resolve();
+      await vi.waitFor(() =>
+        expect(frames(f.old).find((frame) => frame.seq === 72)).toMatchObject({ type: "result" }),
+      );
+      expect(frames(f.old).find((frame) => frame.seq === 70)).toMatchObject({ type: "error" });
+    } finally {
+      gate.resolve();
+      detachGate.resolve();
+      await flush();
+    }
+  });
+
+  it.each(["native detach", "removal", "access loss"])(
+    "synchronously invalidates commands before %s reconciliation awaits",
+    async (ending) => {
+      const f = await fixture();
+      await f.attach(f.old);
+      const gate = createDeferred<void>();
+      const getTab = f.h.tabsGet.getMockImplementation()!;
+      f.h.tabsGet.mockClear();
+      f.h.tabsGet.mockImplementationOnce(async (id) => {
+        await gate.promise;
+        return getTab(id);
+      });
+      try {
+        f.old.receive({ type: "cdp", seq: 60, tabId, method: "Runtime.evaluate" });
+        await vi.waitFor(() => expect(f.h.tabsGet).toHaveBeenCalled());
+        if (ending === "native detach") {
+          f.attached.delete(tabId);
+          f.h.debuggerDetachListener?.({ tabId }, "target_closed");
+        } else if (ending === "removal") {
+          f.attached.delete(tabId);
+          f.h.tabsRemovedListener?.(tabId);
+        } else {
+          f.h.updateTab(tabId, { url: "chrome://settings" });
+          await vi.waitFor(() => expect(f.h.debuggerDetach).toHaveBeenCalled());
+          f.h.updateTab(tabId, { url: "https://example.com/returned" });
+        }
+        await f.attach(f.old, 61);
+        gate.resolve();
+        await vi.waitFor(() =>
+          expect(frames(f.old).find((frame) => frame.seq === 60)).toMatchObject({ type: "error" }),
+        );
+        expect(f.h.debuggerSendCommand).not.toHaveBeenCalled();
+        expect(
+          await reply(f.old, 62, { type: "cdp", tabId, method: "Runtime.enable" }),
+        ).toMatchObject({ type: "result" });
+      } finally {
+        gate.resolve();
+        await flush();
+      }
+    },
+  );
+});
+
+it("cancels attach admission when a same-socket detach arrives before native dispatch", async () => {
+  const f = await fixture();
+  f.old.receive({ type: "attach", seq: 51, tabId });
+  f.old.receive({ type: "detach", seq: 52, tabId });
+  f.old.receive({ type: "attach", seq: 53, tabId });
+  await vi.waitFor(() =>
+    expect(frames(f.old).find((frame) => frame.seq === 53)).toMatchObject({ type: "result" }),
+  );
+  expect(frames(f.old).find((frame) => frame.seq === 51)).toMatchObject({ type: "error" });
+  expect(f.h.debuggerAttach).toHaveBeenCalledTimes(1);
+});
+
+it.each(["socket close", "native replacement"])(
+  "rolls back only its created tab after %s during focus",
+  async (ending) => {
+    const f = await fixture();
+    const gate = createDeferred<void>();
+    f.h.windowsUpdate.mockImplementationOnce(async () => {
+      await gate.promise;
+      return undefined;
+    });
+    try {
+      f.old.receive({ type: "createTab", seq: 80, url: "https://example.com/new", focus: true });
+      await vi.waitFor(() => expect(f.h.windowsUpdate).toHaveBeenCalled());
+      if (ending === "socket close") {
+        f.old.finishClose();
+      } else {
+        await reply(f.old, 81, { type: "detach", tabId: tabId + 1 });
+        expect(await reply(f.old, 82, { type: "attach", tabId: tabId + 1 })).toMatchObject({
+          type: "result",
+        });
+      }
+      gate.resolve();
+      await vi.waitFor(() => expect(f.h.tabsRemove).toHaveBeenCalledExactlyOnceWith(tabId + 1));
+      expect(await f.h.tabsQuery()).toEqual([expect.objectContaining({ id: tabId })]);
+      expect(frames(f.old).some((frame) => frame.seq === 80 && frame.type === "result")).toBe(
+        false,
+      );
+    } finally {
+      gate.resolve();
+      await flush();
+    }
+  },
+);

--- a/extensions/browser/chrome-extension/background.test-harness.ts
+++ b/extensions/browser/chrome-extension/background.test-harness.ts
@@ -179,6 +179,16 @@ export async function loadBackground({
     }
     throw new Error("Specified native messaging host not found.");
   });
+  const debuggerGetTargetInfo = vi.fn(async (source: { tabId: number }) => ({
+    targetInfo: { targetId: `tab-${source.tabId}` },
+  }));
+  const debuggerSendCommand = vi.fn(
+    async (
+      _source: { tabId: number; sessionId?: string },
+      _method: string,
+      _params?: Record<string, unknown>,
+    ): Promise<Record<string, unknown>> => ({}),
+  );
   let runtimeLastError: { message?: string } | undefined;
   const chromeMock = {
     extension: { isAllowedFileSchemeAccess: vi.fn(async () => fileAccessAllowed) },
@@ -219,18 +229,19 @@ export async function loadBackground({
         ),
       },
       attach: vi.fn(async (_source: { tabId: number }, _version: string) => undefined),
-      detach: vi.fn(async (_source: { tabId: number }) => undefined),
+      detach: vi.fn(async (_source: { tabId?: number; targetId?: string }) => undefined),
       getTargets: vi.fn(
         async (): Promise<Array<{ id?: string; tabId?: number; attached?: boolean }>> =>
           inheritedDebuggerTabIds.map((tabId) => ({ id: `tab-${tabId}`, tabId, attached: true })),
       ),
-      sendCommand: vi.fn(
-        async (
-          _source: { tabId: number; sessionId?: string },
-          _method: string,
-          _params?: Record<string, unknown>,
-        ): Promise<Record<string, unknown>> => ({}),
-      ),
+      sendCommand: (
+        source: { tabId: number; sessionId?: string },
+        method: string,
+        params?: Record<string, unknown>,
+      ) =>
+        method === "Target.getTargetInfo"
+          ? debuggerGetTargetInfo(source)
+          : debuggerSendCommand(source, method, params),
     },
     runtime: {
       get lastError() {
@@ -468,7 +479,8 @@ export async function loadBackground({
     debuggerDetachListener,
     debuggerEventListener,
     debuggerGetTargets: chromeMock.debugger.getTargets,
-    debuggerSendCommand: chromeMock.debugger.sendCommand,
+    debuggerSendCommand,
+    debuggerGetTargetInfo,
     deferNextStorageGet: () => {
       let release = () => {};
       nextStorageGet = new Promise<void>((resolve) => {

--- a/extensions/browser/chrome-extension/background.test.ts
+++ b/extensions/browser/chrome-extension/background.test.ts
@@ -189,7 +189,9 @@ describe("native extension bootstrap", () => {
     expect(harness.debuggerAttach).not.toHaveBeenCalled();
 
     harness.releaseRetiredStatePreparation();
-    await vi.waitFor(() => expect(harness.debuggerDetach).toHaveBeenCalledWith({ tabId: 17 }));
+    await vi.waitFor(() =>
+      expect(harness.debuggerDetach).toHaveBeenCalledWith({ targetId: "tab-17" }),
+    );
     expect(harness.sendNativeMessage).not.toHaveBeenCalled();
     expect(harness.relaySockets).toHaveLength(0);
 
@@ -333,7 +335,9 @@ describe("native extension bootstrap", () => {
       },
     });
 
-    await vi.waitFor(() => expect(harness.debuggerDetach).toHaveBeenCalledWith({ tabId: 18 }));
+    await vi.waitFor(() =>
+      expect(harness.debuggerDetach).toHaveBeenCalledWith({ targetId: "tab-18" }),
+    );
     expect(harness.relaySockets).toHaveLength(0);
     expect(harness.sendNativeMessage).not.toHaveBeenCalled();
     expect(harness.debuggerAttach).not.toHaveBeenCalled();

--- a/extensions/browser/chrome-extension/bootstrap.chromium.test.ts
+++ b/extensions/browser/chrome-extension/bootstrap.chromium.test.ts
@@ -426,38 +426,6 @@ describe.runIf(runE2E)("Chrome native bootstrap Chromium E2E", () => {
           refreshConfigFromDisk: false,
         });
         const dispatcher = createBrowserRouteDispatcher(routeContext);
-        const creationPolicy = browserState.resolved.ssrfPolicy;
-        browserState.resolved.ssrfPolicy = {
-          dangerouslyAllowPrivateNetwork: false,
-          allowedHostnames: ["127.0.0.1"],
-        };
-        try {
-          for (const accessMode of ["all", "selected"] as const) {
-            expect(
-              await extensionPage.evaluate(
-                async (mode) =>
-                  await chrome.runtime.sendMessage({ type: "setAccessMode", accessMode: mode }),
-                accessMode,
-              ),
-            ).toMatchObject({ ok: true });
-            await assertRelayTabCreation({
-              context,
-              extensionPage,
-              dispatcher,
-              url: `http://127.0.0.1:${gatewayPort}/browser-owner-proof`,
-              accessMode,
-            });
-          }
-        } finally {
-          await extensionPage.evaluate(
-            async () =>
-              await chrome.runtime.sendMessage({
-                type: "setAccessMode",
-                accessMode: "all",
-              }),
-          );
-          browserState.resolved.ssrfPolicy = creationPolicy;
-        }
         const playwrightTabsResponse = await dispatcher.dispatch({
           method: "GET",
           path: "/tabs",
@@ -504,6 +472,52 @@ describe.runIf(runE2E)("Chrome native bootstrap Chromium E2E", () => {
           proofName: "existing-session-offscreen-labeled-ref.png",
         });
 
+        const earlyPlaywrightTarget = (
+          playwrightTabsResponse.body as { tabs?: Array<{ targetId?: string; url?: string }> }
+        ).tabs?.find((tab) => tab.url === controlled.url())?.targetId;
+        if (!earlyPlaywrightTarget) {
+          throw new Error("Initial Playwright inventory did not contain the controlled target");
+        }
+        // Capture the existing context before the socket fault; target detachment keeps it alive.
+        const connectOverCdp = vi.spyOn(chromium, "connectOverCDP");
+        let relayPlaywrightContext: BrowserContext;
+        try {
+          const relayPage = await getPageForTargetId({
+            cdpUrl: routeContext.forProfile("e2e").profile.cdpUrl,
+            targetId: earlyPlaywrightTarget,
+          });
+          relayPlaywrightContext = relayPage.context();
+          expect(connectOverCdp).not.toHaveBeenCalled();
+          const bindingSession = await relayPlaywrightContext.newCDPSession(relayPage);
+          const bindingName = "__openclawRelayBindingProof";
+          const bindingPayloads: string[] = [];
+          bindingSession.on("Runtime.bindingCalled", (event) => {
+            if (event.name === bindingName) {
+              bindingPayloads.push(event.payload);
+            }
+          });
+          try {
+            await bindingSession.send("Runtime.addBinding", { name: bindingName });
+            await bindingSession.send("Runtime.evaluate", {
+              expression: "globalThis.__openclawRelayBindingProof('before-enable')",
+            });
+            await expect.poll(() => bindingPayloads).toEqual(["before-enable"]);
+            await bindingSession.send("Runtime.enable");
+            await bindingSession.send("Runtime.disable");
+            await bindingSession.send("Runtime.evaluate", {
+              expression: "globalThis.__openclawRelayBindingProof('after-disable')",
+            });
+            await expect.poll(() => bindingPayloads).toEqual(["before-enable", "after-disable"]);
+          } finally {
+            await bindingSession
+              .send("Runtime.removeBinding", { name: bindingName })
+              .catch(() => {});
+            await bindingSession.detach().catch(() => {});
+          }
+        } finally {
+          connectOverCdp.mockRestore();
+        }
+
         expect(relay.bridge.cdpClientCount).toBeGreaterThanOrEqual(2);
         const previousConnections = extensionConnections;
         if (!extensionTransport) {
@@ -543,7 +557,7 @@ describe.runIf(runE2E)("Chrome native bootstrap Chromium E2E", () => {
         const distractingUrl = `data:text/html,${encodeURIComponent("<title>Unrelated tab</title>")}`;
         await distractingPage.goto(distractingUrl);
         await expect
-          .poll(() => relay.bridge.accessibleTabs().some((tab) => tab.url === distractingUrl))
+          .poll(() => relayPlaywrightContext.pages().some((page) => page.url() === distractingUrl))
           .toBe(true);
         const liveTabsResponse = await dispatcher.dispatch({
           method: "GET",
@@ -589,6 +603,7 @@ describe.runIf(runE2E)("Chrome native bootstrap Chromium E2E", () => {
           throw new Error("Extension service worker missing");
         }
         const finishNavigationProbe = await holdNavigationAccessCheck(worker, proofUrl);
+        let probe: Awaited<ReturnType<typeof finishNavigationProbe>>;
         try {
           const navigationResponse = await dispatcher.dispatch({
             method: "POST",
@@ -629,9 +644,42 @@ describe.runIf(runE2E)("Chrome native bootstrap Chromium E2E", () => {
           diagnostic.flush();
           detachedNavigation.mockRestore();
           browserState.resolved.ssrfPolicy = previousSsrfPolicy;
-          const probe = await finishNavigationProbe();
-          expect(probe.heldReads).toBeGreaterThan(0);
-          expect(probe.sawLoad).toBe(true);
+          probe = await finishNavigationProbe();
+        }
+        expect(probe.heldReads).toBeGreaterThan(0);
+        expect(probe.sawLoad).toBe(true);
+
+        const creationPolicy = browserState.resolved.ssrfPolicy;
+        browserState.resolved.ssrfPolicy = {
+          dangerouslyAllowPrivateNetwork: false,
+          allowedHostnames: ["127.0.0.1"],
+        };
+        try {
+          for (const accessMode of ["all", "selected"] as const) {
+            expect(
+              await extensionPage.evaluate(
+                async (mode) =>
+                  await chrome.runtime.sendMessage({ type: "setAccessMode", accessMode: mode }),
+                accessMode,
+              ),
+            ).toMatchObject({ ok: true });
+            await assertRelayTabCreation({
+              context,
+              extensionPage,
+              dispatcher,
+              url: `http://127.0.0.1:${gatewayPort}/browser-owner-proof`,
+              accessMode,
+            });
+          }
+        } finally {
+          await extensionPage.evaluate(
+            async () =>
+              await chrome.runtime.sendMessage({
+                type: "setAccessMode",
+                accessMode: "all",
+              }),
+          );
+          browserState.resolved.ssrfPolicy = creationPolicy;
         }
 
         const registration = status.registrations.find(

--- a/extensions/browser/chrome-extension/modules/popup-background.js
+++ b/extensions/browser/chrome-extension/modules/popup-background.js
@@ -41,7 +41,6 @@ export function createPopupMessageHandler({
   closeRelaySocket,
   connectRelay,
   setBadge,
-  attachingTabs,
   detachDebugger,
   removeTabFromOpenClawGroup,
   addTabToOpenClawGroup,
@@ -251,7 +250,6 @@ export function createPopupMessageHandler({
                   const selected = await isTabSelected(await chromeApi.tabs.get(tabId));
                   if (!msg.grant && selected) {
                     policy.invalidateTab(tabId);
-                    await Promise.allSettled([attachingTabs.get(tabId)]);
                     await detachDebugger(tabId);
                     await removeTabFromOpenClawGroup(tabId);
                   } else if (msg.grant && !selected) {

--- a/extensions/browser/chrome-extension/modules/relay-command-handler.d.ts
+++ b/extensions/browser/chrome-extension/modules/relay-command-handler.d.ts
@@ -9,6 +9,7 @@ export function createRelayCommandHandler(params: {
   createTab: (message: Record<string, unknown>, operation: CreatedTabOperation) => Promise<void>;
   focusWindowForTab: (tab: BrowserTabSnapshot) => Promise<void>;
   scheduleTabsSync: () => void;
+  captureDebugger: (tabId: number) => () => void;
   captureAccess: (tabId: number, method?: string) => TabAccessEpoch;
   navigateTab: (
     tabId: number,

--- a/extensions/browser/chrome-extension/modules/relay-command-handler.js
+++ b/extensions/browser/chrome-extension/modules/relay-command-handler.js
@@ -7,6 +7,7 @@ export function createRelayCommandHandler({
   createTab,
   focusWindowForTab,
   scheduleTabsSync,
+  captureDebugger,
   captureAccess,
   requireAccessibleTab,
   requireNavigatedTab,
@@ -35,25 +36,32 @@ export function createRelayCommandHandler({
         case "ping":
           reply({ type: "pong" });
           return;
-        case "attach":
-          reply({
-            type: "result",
-            seq,
-            result: await attachDebugger(message.tabId, assertCurrent),
-          });
+        case "attach": {
+          const attached = await attachDebugger(message.tabId, assertCurrent);
+          attached.assertCurrent();
+          reply({ type: "result", seq, result: { targetId: attached.targetId } });
           return;
+        }
         case "detach":
           await detachDebugger(message.tabId);
           reply({ type: "result", seq, result: {} });
           return;
         case "cdp": {
+          const assertAttachment = captureDebugger(message.tabId);
           const epoch = captureAccess(message.tabId, message.method);
           await requireTab(message.tabId, epoch);
+          assertAttachment();
           const target = message.sessionId
             ? { tabId: message.tabId, sessionId: message.sessionId }
             : { tabId: message.tabId };
-          const sendCommand = (method, params) =>
-            chrome.debugger.sendCommand(target, method, params);
+          // Provenance preflight and navigation share the command's original
+          // native generation, including policy awaits before either dispatch.
+          const sendCommand = async (method, params) => {
+            assertAttachment();
+            const result = await chrome.debugger.sendCommand(target, method, params);
+            assertAttachment();
+            return result;
+          };
           const controlledBlank =
             !message.sessionId &&
             message.method === "Page.navigate" &&
@@ -61,11 +69,13 @@ export function createRelayCommandHandler({
           const result = controlledBlank
             ? await navigateTab(message.tabId, epoch, message.params, isCurrent, sendCommand)
             : await sendCommand(message.method, message.params ?? {});
+          assertAttachment();
           await requireTab(
             message.tabId,
             epoch,
             controlledBlank ? requireNavigatedTab : requireAccessibleTab,
           );
+          assertAttachment();
           reply({ type: "result", seq, result: result ?? {} });
           return;
         }

--- a/extensions/browser/chrome-extension/modules/relay-command-handler.test.ts
+++ b/extensions/browser/chrome-extension/modules/relay-command-handler.test.ts
@@ -23,6 +23,7 @@ function createHarness() {
     send,
     isCurrent: () => true,
     attachDebugger: vi.fn(),
+    captureDebugger: vi.fn(() => () => {}),
     detachDebugger,
     createTab: vi.fn(),
     scheduleTabsSync: vi.fn(),

--- a/extensions/browser/chrome-extension/modules/relay-debugger.js
+++ b/extensions/browser/chrome-extension/modules/relay-debugger.js
@@ -1,129 +1,213 @@
-/** Physical debugger attachments belong to one authenticated relay transport. */
+/** Physical debugger attachments and cleanup debt belong to exact native acquisitions. */
 export function createRelayDebugger({ policy, requireAutomationAllowed }) {
-  const attachedTabs = new Set();
-  const attachedAccessEpochs = new Map();
-  const attachingTabs = new Map();
-  const detachingTabs = new Map();
-  let retirement = Promise.resolve();
+  const attachments = new Map();
   const owners = new Set();
+  let admission = 0;
 
-  async function detach(tabId) {
-    // Native programmatic detach emits no onDetach. Retire document authority
-    // before yielding, including while the native attachment is still pending.
-    policy.retireTabDocument(tabId);
-    attachedTabs.delete(tabId);
-    attachedAccessEpochs.delete(tabId);
-    const existing = detachingTabs.get(tabId);
-    if (existing) {
-      await existing;
-      return;
-    }
-    const pending = chrome.debugger.detach({ tabId }).catch((error) => {
-      // Chromium debugger_api.cc formats these terminal states for tab targets.
-      // Other failures cannot establish a fresh physical Runtime for a successor.
-      if (
-        error?.message !== `Debugger is not attached to the tab with id: ${tabId}.` &&
-        error?.message !== `No tab with given id ${tabId}.`
-      ) {
-        throw error;
-      }
-    });
-    detachingTabs.set(tabId, pending);
-    try {
-      await pending;
-    } finally {
-      if (detachingTabs.get(tabId) === pending) {
-        detachingTabs.delete(tabId);
-      }
+  function invalidate(record) {
+    if (!record.retired) {
+      policy.retireTabDocument(record.tabId);
+      record.retired = true;
+      record.epoch = undefined;
     }
   }
 
-  function createOwner(isCurrent) {
-    const ownedTabs = new Set();
-    const ownedAttaches = new Set();
+  function forget(record) {
+    if (attachments.get(record.tabId) === record) {
+      if (record.previous && !record.previous.closed) {
+        attachments.set(record.tabId, record.previous);
+      } else {
+        attachments.delete(record.tabId);
+      }
+    }
+    record.owned?.delete(record);
+    record.released?.();
+  }
+
+  function cleanup(record) {
+    invalidate(record);
+    if (record.cleaning) {
+      return record.cleaning;
+    }
+    const cleaning = Promise.resolve().then(async () => {
+      // Access closes immediately; dispatched acquisition/detach still drains
+      // before a successor can use this tab. No evaluation/body read is awaited.
+      await Promise.allSettled([record.pending]);
+      await record.previousCleanup;
+      if (record.native && !record.closed) {
+        const target = record.targetId ? { targetId: record.targetId } : { tabId: record.tabId };
+        try {
+          await chrome.debugger.detach(target);
+        } catch (error) {
+          // GetForId + FindClientHost prove absence of this exact host/client.
+          // NoTab fails before either lookup and never settles native debt.
+          if (
+            !record.closed &&
+            !(
+              record.targetId &&
+              (error?.message === `No target with given id ${record.targetId}.` ||
+                error?.message ===
+                  `Debugger is not attached to the target with id: ${record.targetId}.`)
+            )
+          ) {
+            throw error;
+          }
+        }
+      }
+      record.closed = true;
+      forget(record);
+    });
+    record.cleaning = cleaning;
+    void cleaning
+      .finally(() => {
+        if (record.cleaning === cleaning) {
+          record.cleaning = undefined;
+        }
+      })
+      .catch(() => {});
+    return cleaning;
+  }
+
+  function detach(tabId) {
+    const record = attachments.get(tabId);
+    return record ? cleanup(record) : Promise.resolve();
+  }
+
+  function nativeDetached(tabId) {
+    let record = attachments.get(tabId);
+    // A new acquisition may be waiting on an older native client's cleanup.
+    while (record?.previous && !record.previous.closed) {
+      record = record.previous;
+    }
+    if (!record) {
+      return;
+    }
+    invalidate(record);
+    record.closed = true;
+    void cleanup(record).catch((error) => console.warn("Debugger cleanup failed", error));
+  }
+
+  function createOwner(connectionIsCurrent) {
+    const owned = new Set();
     let active = true;
-    let retired;
-    const current = () => active && isCurrent();
+    const isCurrent = () => active && connectionIsCurrent();
     const assertCurrent = () => {
-      if (!current()) {
+      if (!isCurrent()) {
         throw new Error("Relay transport retired");
       }
     };
-    async function attach(tabId, assertCreation, creationEpoch) {
+    function capture(tabId) {
       assertCurrent();
-      await retirement;
-      assertCurrent();
-      assertCreation();
+      const record = attachments.get(tabId);
+      if (!record?.epoch || record.retired || record.owner !== isCurrent) {
+        throw new Error("Debugger is not attached");
+      }
+      const native = record.native;
+      return () => {
+        assertCurrent();
+        if (record.retired || attachments.get(tabId) !== record || record.native !== native) {
+          throw new Error("Debugger attachment retired");
+        }
+      };
+    }
+    async function attach(tabId, assertCallerCurrent, creationEpoch) {
       const epoch = creationEpoch ?? policy.capture(tabId);
-      const existing = attachingTabs.get(tabId);
-      if (existing) {
-        const result = await existing;
+      const assertAccess = () => {
         assertCurrent();
-        assertCreation();
+        assertCallerCurrent();
+        if (!policy.epochIsCurrent(tabId, epoch)) {
+          throw new Error(`tab ${tabId} access was revoked`);
+        }
+      };
+      assertAccess();
+      const previous = attachments.get(tabId);
+      if (previous && !previous.retired && previous.owner === isCurrent) {
+        const result = previous.pending
+          ? await previous.pending
+          : { targetId: previous.targetId, assertCurrent: capture(tabId) };
         await policy.requireTab(tabId, epoch);
-        assertCurrent();
-        assertCreation();
+        assertAccess();
+        result.assertCurrent();
         return result;
       }
-      const pending = (async () => {
-        await requireAutomationAllowed();
-        assertCurrent();
-        const assertAccess = () => {
-          assertCurrent();
-          assertCreation();
-          if (!policy.epochIsCurrent(tabId, epoch)) {
-            throw new Error(`tab ${tabId} access was revoked`);
+      const record = {
+        tabId,
+        owner: isCurrent,
+        owned,
+        previous,
+        retired: false,
+        epoch: undefined,
+        released: () => {
+          if (!active && owned.size === 0) {
+            owners.delete(owner);
           }
-        };
-        try {
-          await policy.requireTab(tabId, epoch);
-          assertAccess();
-          await detachingTabs.get(tabId);
-          assertAccess();
-          if (!attachedTabs.has(tabId)) {
-            await chrome.debugger.attach({ tabId }, "1.3");
-            // Retirement drains this attach promise before cleanup. Record a
-            // successful native attach even if its transport retired meanwhile.
-            ownedTabs.add(tabId);
-            await policy.requireTab(tabId, epoch);
-            assertAccess();
-            attachedTabs.add(tabId);
-          }
-          const targets = await chrome.debugger.getTargets();
-          await policy.requireTab(tabId, epoch);
-          assertAccess();
-          attachedAccessEpochs.set(tabId, epoch);
-          const target = targets.find(
-            (candidate) => candidate.tabId === tabId && candidate.attached,
-          );
-          return { targetId: target?.id ?? `tab-${tabId}` };
-        } catch (error) {
-          // Once retired, the retirement barrier owns cleanup. Never let an old
-          // catch detach a replacement or swallow a failed retirement detach.
-          if (active && ownedTabs.has(tabId)) {
-            await detach(tabId);
-          }
-          throw error;
+        },
+      };
+      admission++;
+      attachments.set(tabId, record);
+      owned.add(record);
+      const assertAcquisition = () => {
+        assertAccess();
+        if (record.retired || attachments.get(tabId) !== record) {
+          throw new Error("Debugger attachment retired");
         }
-      })();
-      attachingTabs.set(tabId, pending);
-      ownedAttaches.add(pending);
+      };
+      const pending = Promise.resolve().then(async () => {
+        if (previous) {
+          record.previousCleanup = cleanup(previous);
+          await record.previousCleanup;
+          record.previous = undefined;
+        }
+        assertAcquisition();
+        await requireAutomationAllowed();
+        assertAcquisition();
+        await policy.requireTab(tabId, epoch);
+        assertAcquisition();
+        await chrome.debugger.attach({ tabId }, "1.3");
+        // Mint only on native success. Identity discovery is cleanup authority
+        // even when access/socket closure overtakes the native callback.
+        record.native = {};
+        if (!record.closed) {
+          const result = await chrome.debugger.sendCommand({ tabId }, "Target.getTargetInfo", {});
+          const targetId = result?.targetInfo?.targetId;
+          if (typeof targetId !== "string" || !targetId) {
+            throw new Error("Debugger target identity unavailable");
+          }
+          record.targetId = targetId;
+        }
+        await policy.requireTab(tabId, epoch);
+        assertAcquisition();
+        record.epoch = epoch;
+        return { targetId: record.targetId, assertCurrent: capture(tabId) };
+      });
+      record.pending = pending;
       try {
         return await pending;
+      } catch (error) {
+        invalidate(record);
+        if (record.native) {
+          const [cleanupResult] = await Promise.allSettled([cleanup(record)]);
+          if (cleanupResult.status === "rejected") {
+            throw new Error(
+              `Debugger acquisition failed: ${String(error)}; cleanup incomplete: ${String(cleanupResult.reason)}`,
+              { cause: error },
+            );
+          }
+        } else {
+          forget(record);
+        }
+        throw error;
       } finally {
-        ownedAttaches.delete(pending);
-        if (attachingTabs.get(tabId) === pending) {
-          attachingTabs.delete(tabId);
+        if (record.pending === pending) {
+          record.pending = undefined;
         }
       }
     }
     const owner = {
-      isCurrent: current,
-      assertCurrent,
+      isCurrent,
       attach,
+      capture,
       requireTab: async (tabId, epoch, afterNavigation = false) => {
-        assertCurrent();
-        await retirement;
         assertCurrent();
         const tab = afterNavigation
           ? await policy.requireTabAfterNavigation(tabId, epoch)
@@ -131,41 +215,80 @@ export function createRelayDebugger({ policy, requireAutomationAllowed }) {
         assertCurrent();
         return tab;
       },
-      detach: async (tabId) => {
+      detach: (tabId) => {
         assertCurrent();
-        await retirement;
-        assertCurrent();
-        await detach(tabId);
+        return detach(tabId);
       },
-      retire: () => {
-        if (retired) {
-          return retired;
-        }
+      retire: async () => {
         active = false;
-        for (const tabId of ownedTabs) {
-          policy.retireTabDocument(tabId);
-          attachedTabs.delete(tabId);
-          attachedAccessEpochs.delete(tabId);
-        }
-        const pending = [
-          ...ownedAttaches,
-          ...[...ownedTabs].map((tabId) => detachingTabs.get(tabId)),
-        ];
-        // Serialize physical generations, not live commands. In particular,
-        // native detach rejects evaluations; waiting for them here can deadlock.
-        retired = retirement = retirement.then(async () => {
-          await Promise.allSettled(pending);
-          await Promise.all([...ownedTabs].map(detach));
+        const results = await Promise.allSettled([...owned].map(cleanup));
+        if (owned.size === 0) {
           owners.delete(owner);
-        });
-        return retired;
+        }
+        const errors = results.flatMap((result) =>
+          result.status === "rejected" ? [result.reason] : [],
+        );
+        if (errors.length) {
+          throw new AggregateError(
+            errors,
+            `Debugger cleanup incomplete: ${errors.map(String).join("; ")}`,
+          );
+        }
       },
     };
     owners.add(owner);
     return owner;
   }
-  async function detachAll() {
-    await Promise.all([...owners].map((owner) => owner.retire()));
-  }
-  return { detachAll, attachedTabs, attachedAccessEpochs, attachingTabs, detach, createOwner };
+  return {
+    attachments,
+    nativeDetached,
+    detach,
+    createOwner,
+    detachAll: async (inherited = false) => {
+      const capturedAdmission = admission;
+      const results = await Promise.allSettled([...owners].map((owner) => owner.retire()));
+      const errors = results.flatMap((result) =>
+        result.status === "rejected" ? [result.reason] : [],
+      );
+      if (inherited) {
+        try {
+          const targets = await chrome.debugger.getTargets();
+          if (admission !== capturedAdmission) {
+            throw new Error("Debugger cleanup superseded by new attachment");
+          }
+          const cleanups = targets
+            .filter((target) => target.attached && typeof target.tabId === "number")
+            .map(async (target) => {
+              if (attachments.has(target.tabId)) {
+                return detach(target.tabId);
+              }
+              if (typeof target.id !== "string" || !target.id) {
+                throw new Error("Inherited debugger identity unavailable");
+              }
+              const record = {
+                tabId: target.tabId,
+                targetId: target.id,
+                native: {},
+                retired: true,
+              };
+              attachments.set(target.tabId, record);
+              return cleanup(record);
+            });
+          for (const result of await Promise.allSettled(cleanups)) {
+            if (result.status === "rejected") {
+              errors.push(result.reason);
+            }
+          }
+        } catch (error) {
+          errors.push(error);
+        }
+      }
+      if (errors.length) {
+        throw new AggregateError(
+          errors,
+          `Debugger cleanup incomplete: ${errors.map(String).join("; ")}`,
+        );
+      }
+    },
+  };
 }

--- a/extensions/browser/chrome-extension/modules/tab-access-events.d.ts
+++ b/extensions/browser/chrome-extension/modules/tab-access-events.d.ts
@@ -37,7 +37,6 @@ export type TabAccessEventPolicy = {
   epochIsCurrent(tabId: number, epoch: TabAccessEpoch): boolean;
   invalidateTab(tabId: number): void;
   retireTab(tabId: number): void;
-  retireTabDocument: TabAccessPolicy["retireTabDocument"];
   forwardDocumentEvent: TabAccessPolicy["forwardDocumentEvent"];
   invalidateDocumentGroup: TabAccessPolicy["invalidateDocumentGroup"];
   renewTabAccess(
@@ -61,9 +60,11 @@ export function registerTabAccessEvents(options: {
   chromeApi?: TabAccessEventsChromeApi;
   accessReady: Promise<unknown>;
   policy: TabAccessEventPolicy;
-  attachedTabs: Set<number>;
-  attachedAccessEpochs: Map<number, TabAccessEpoch>;
-  attachingTabs: Map<number, Promise<unknown>>;
+  attachments: Map<
+    number,
+    { epoch?: TabAccessEpoch; pending?: Promise<unknown>; retired?: boolean }
+  >;
+  nativeDetached(tabId: number): void;
   send(message: Record<string, unknown>): void;
   scheduleTabsSync(): void;
   detachDebugger(tabId: number): Promise<void>;

--- a/extensions/browser/chrome-extension/modules/tab-access-events.js
+++ b/extensions/browser/chrome-extension/modules/tab-access-events.js
@@ -5,9 +5,8 @@ export function registerTabAccessEvents({
   chromeApi = chrome,
   accessReady,
   policy,
-  attachedTabs,
-  attachedAccessEpochs,
-  attachingTabs,
+  attachments,
+  nativeDetached,
   send,
   scheduleTabsSync,
   detachDebugger,
@@ -21,7 +20,7 @@ export function registerTabAccessEvents({
     if (typeof source.tabId !== "number") {
       return;
     }
-    const accessEpoch = attachedAccessEpochs.get(source.tabId);
+    const accessEpoch = attachments.get(source.tabId)?.epoch;
     if (!accessEpoch || !policy.epochIsCurrent(source.tabId, accessEpoch)) {
       return;
     }
@@ -41,15 +40,14 @@ export function registerTabAccessEvents({
     if (typeof source.tabId !== "number") {
       return;
     }
-    attachedTabs.delete(source.tabId);
-    attachedAccessEpochs.delete(source.tabId);
+    // Preserve controlled-document pause evidence before native retirement revokes it.
+    const revocation =
+      reason === "canceled_by_user" ? policy.beginRevocation(source.tabId) : undefined;
+    nativeDetached(source.tabId);
     send({ type: "detached", tabId: source.tabId, reason });
-    if (reason !== "canceled_by_user") {
-      policy.retireTabDocument(source.tabId);
+    if (revocation === undefined) {
       return;
     }
-    const revocation = policy.beginRevocation(source.tabId);
-    policy.retireTabDocument(source.tabId);
     void runAccessMutation(async () => {
       try {
         await accessReady;
@@ -68,10 +66,11 @@ export function registerTabAccessEvents({
 
   chromeApi.tabs.onRemoved.addListener((tabId) => {
     policy.retireTab(tabId);
+    void detachDebugger(tabId).catch((error) =>
+      console.warn("Debugger removal cleanup failed", error),
+    );
     void (async () => {
       await accessReady;
-      attachedTabs.delete(tabId);
-      attachedAccessEpochs.delete(tabId);
       scheduleTabsSync();
       await policy.forgetTab(tabId).catch(() => undefined);
     })();
@@ -81,15 +80,13 @@ export function registerTabAccessEvents({
     const revocation = policy.beginRevocation(addedTabId);
     policy.retireTab(addedTabId);
     policy.retireTab(removedTabId);
-    attachedTabs.delete(removedTabId);
-    attachedAccessEpochs.delete(removedTabId);
+    const detaching = [detachDebugger(removedTabId), detachDebugger(addedTabId)];
     scheduleTabsSync();
     void (async () => {
       try {
         await accessReady;
         await policy.replaceTab(addedTabId, removedTabId);
-        await Promise.allSettled([attachingTabs.get(removedTabId), attachingTabs.get(addedTabId)]);
-        await Promise.allSettled([detachDebugger(removedTabId), detachDebugger(addedTabId)]);
+        await Promise.allSettled(detaching);
       } finally {
         policy.endRevocation(revocation);
         scheduleTabsSync();
@@ -99,16 +96,22 @@ export function registerTabAccessEvents({
 
   chromeApi.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
     scheduleTabsSync();
+    const generation = attachments.get(tabId);
+    const pendingAttach = generation?.pending;
     if (policy.observeTabUpdate(tabId, changeInfo, tab)) {
-      const renewed = policy.renewTabAccess(tabId, attachedAccessEpochs.get(tabId), tab);
-      if (renewed && attachedTabs.has(tabId)) {
-        attachedAccessEpochs.set(tabId, renewed);
+      const renewed = policy.renewTabAccess(tabId, generation?.epoch, tab);
+      if (renewed && generation) {
+        generation.epoch = renewed;
       }
     }
     const eventEpoch = policy.capture(tabId);
     void (async () => {
       await accessReady;
-      const eventIsCurrent = () => policy.epochIsCurrent(tabId, eventEpoch);
+      const eventIsCurrent = () =>
+        policy.epochIsCurrent(tabId, eventEpoch) &&
+        attachments.get(tabId) === generation &&
+        generation?.pending === pendingAttach &&
+        !generation?.retired;
       if (!eventIsCurrent()) {
         return;
       }
@@ -117,14 +120,11 @@ export function registerTabAccessEvents({
         return;
       }
       if (!state.accessible) {
-        await Promise.allSettled([attachingTabs.get(tabId)]);
-        if (!eventIsCurrent()) {
-          return;
-        }
         await detachDebugger(tabId);
+        return;
       }
-      if (attachedTabs.has(tabId) && attachedAccessEpochs.has(tabId)) {
-        attachedAccessEpochs.set(tabId, eventEpoch);
+      if (generation?.epoch) {
+        generation.epoch = eventEpoch;
       }
     })();
   });
@@ -139,16 +139,14 @@ export function registerTabAccessEvents({
     // Group title/removal changes mutate the selected-mode ACL. Retire every
     // attachment epoch synchronously before any readiness or Chrome lookup.
     policy.invalidateAll(group);
+    const generations = [...attachments]
+      .filter(([, record]) => !record.retired)
+      .map(([tabId, generation]) => [tabId, generation, policy.capture(tabId)]);
     void accessReady.then(async () => {
       if (eventRevision !== groupEventRevision || policy.mode !== ACCESS_MODE_SELECTED) {
         return;
       }
-      const epochs = new Map(
-        [...attachedAccessEpochs.keys()]
-          .filter((tabId) => attachedTabs.has(tabId))
-          .map((tabId) => [tabId, policy.capture(tabId)]),
-      );
-      await Promise.allSettled(attachingTabs.values());
+      await Promise.allSettled([...attachments.values()].map((record) => record.pending));
       if (eventRevision !== groupEventRevision) {
         return;
       }
@@ -157,20 +155,22 @@ export function registerTabAccessEvents({
         return;
       }
       await Promise.allSettled(
-        [...attachedTabs]
-          .filter((tabId) => !selected.has(tabId))
-          .map((tabId) => detachDebugger(tabId)),
+        generations
+          .filter(
+            ([tabId, generation]) => !selected.has(tabId) && attachments.get(tabId) === generation,
+          )
+          .map(([tabId]) => detachDebugger(tabId)),
       );
       if (eventRevision !== groupEventRevision) {
         return;
       }
       let newerTabEventOwnsAccess = false;
-      for (const [tabId, epoch] of epochs) {
-        if (!selected.has(tabId) || !attachedTabs.has(tabId)) {
+      for (const [tabId, generation, epoch] of generations) {
+        if (!selected.has(tabId) || attachments.get(tabId) !== generation) {
           continue;
         }
         const state = await policy.inspectTab(tabId, epoch);
-        if (eventRevision !== groupEventRevision) {
+        if (eventRevision !== groupEventRevision || attachments.get(tabId) !== generation) {
           return;
         }
         if (!policy.epochIsCurrent(tabId, epoch)) {
@@ -179,7 +179,7 @@ export function registerTabAccessEvents({
           continue;
         }
         if (state.accessible) {
-          attachedAccessEpochs.set(tabId, epoch);
+          generation.epoch = epoch;
         } else {
           await detachDebugger(tabId);
           if (eventRevision !== groupEventRevision) {

--- a/extensions/browser/chrome-extension/modules/tab-access-events.navigation.test.ts
+++ b/extensions/browser/chrome-extension/modules/tab-access-events.navigation.test.ts
@@ -72,20 +72,17 @@ async function createNavigationHarness(
   if (proveAttachment) {
     await policy.requireTab(7, attachmentEpoch);
   }
-  const attachedTabs = new Set([7]);
-  const attachedAccessEpochs = new Map<number, TabAccessEpoch>([[7, attachmentEpoch]]);
+  const attachments = new Map<number, { epoch: TabAccessEpoch }>([[7, { epoch: attachmentEpoch }]]);
   const send = vi.fn<(message: Record<string, unknown>) => void>();
   const detachDebugger = vi.fn(async (tabId: number) => {
-    attachedTabs.delete(tabId);
-    attachedAccessEpochs.delete(tabId);
+    attachments.delete(tabId);
   });
   registerTabAccessEvents({
     chromeApi,
     accessReady: Promise.resolve(),
     policy,
-    attachedTabs,
-    attachedAccessEpochs,
-    attachingTabs: new Map(),
+    attachments,
+    nativeDetached: (tabId: number) => attachments.delete(tabId),
     send,
     scheduleTabsSync() {},
     detachDebugger,
@@ -97,7 +94,7 @@ async function createNavigationHarness(
     chromeApi,
     policy,
     attachmentEpoch,
-    attachedAccessEpochs,
+    attachments,
     send,
     detachDebugger,
     setTab(update: Partial<BrowserTabSnapshot>) {
@@ -110,7 +107,7 @@ async function createNavigationHarness(
         7,
         epoch,
         { url: "about:blank" },
-        () => attachedAccessEpochs.get(7),
+        () => attachments.get(7)?.epoch,
         () => true,
         async (method) => {
           if (method === "Page.getFrameTree") {
@@ -383,7 +380,7 @@ describe("Chrome navigation event access", () => {
           harness.policy.invalidateTab(7);
           break;
         case "forged epoch copy":
-          harness.attachedAccessEpochs.set(7, { ...harness.attachmentEpoch });
+          harness.attachments.set(7, { epoch: { ...harness.attachmentEpoch } });
           break;
         case "detached tab":
           harness.chromeApi.debugger.onDetach.emit({ tabId: 7 }, "target_closed");

--- a/extensions/browser/chrome-extension/modules/tab-access-events.test.ts
+++ b/extensions/browser/chrome-extension/modules/tab-access-events.test.ts
@@ -29,9 +29,7 @@ function createHarness(
   let groupUpdatedListener: (() => void) | undefined;
   let revision = 0;
   let accessible = true;
-  const attachedTabs = new Set([7]);
-  const attachedAccessEpochs = new Map([[7, { revision: 0, tabRevision: 0 }]]);
-  const attachingTabs = new Map<number, Promise<unknown>>();
+  const attachments = new Map([[7, { epoch: { revision: 0, tabRevision: 0 } }]]);
   const send = vi.fn();
   const policy = {
     mode,
@@ -56,7 +54,6 @@ function createHarness(
       revision += 1;
       return undefined;
     }),
-    retireTabDocument: vi.fn(),
     forwardDocumentEvent: vi.fn((event, emit) => emit(event)),
     invalidateDocumentGroup: vi.fn(),
     invalidateAll: vi.fn(() => {
@@ -70,8 +67,7 @@ function createHarness(
     replaceTab: vi.fn(async () => false),
   };
   const detachDebugger = vi.fn(async (tabId: number) => {
-    attachedTabs.delete(tabId);
-    attachedAccessEpochs.delete(tabId);
+    attachments.delete(tabId);
   });
   const pauseTab = vi.fn(async () => undefined);
   const removeTabFromOpenClawGroup = vi.fn(async () => undefined);
@@ -115,9 +111,8 @@ function createHarness(
     chromeApi,
     accessReady,
     policy,
-    attachedTabs,
-    attachedAccessEpochs,
-    attachingTabs,
+    attachments,
+    nativeDetached: (tabId: number) => attachments.delete(tabId),
     send,
     scheduleTabsSync: vi.fn(),
     detachDebugger,
@@ -135,8 +130,7 @@ function createHarness(
     throw new Error("expected tab access event listeners");
   }
   return {
-    attachedAccessEpochs,
-    attachingTabs,
+    attachments,
     detachDebugger,
     debuggerDetachListener,
     debuggerEventListener,
@@ -211,7 +205,7 @@ describe("tab access event epochs", () => {
       await vi.waitFor(() => expect(harness.policy.inspectTab).toHaveBeenCalledTimes(1));
       harness.tabsUpdatedListener(7, secondChange);
       await vi.waitFor(() => {
-        expect(harness.attachedAccessEpochs.get(7)).toEqual({ revision: 2, tabRevision: 0 });
+        expect(harness.attachments.get(7)?.epoch).toEqual({ revision: 2, tabRevision: 0 });
       });
 
       firstInspection.resolve({ accessible: false });
@@ -301,7 +295,7 @@ describe("tab access event epochs", () => {
 
     harness.tabsUpdatedListener(7, { url: "https://two.example" });
     await vi.waitFor(() => {
-      expect(harness.attachedAccessEpochs.get(7)).toEqual({ revision: 2, tabRevision: 0 });
+      expect(harness.attachments.get(7)?.epoch).toEqual({ revision: 2, tabRevision: 0 });
     });
     groupInspection.resolve({ accessible: false });
     await Promise.resolve();

--- a/extensions/browser/chrome-extension/modules/tab-access.d.ts
+++ b/extensions/browser/chrome-extension/modules/tab-access.d.ts
@@ -12,7 +12,7 @@ export type CreatedTabOperation = {
     tabId: number,
     assertCurrent: () => void,
     creationEpoch?: TabAccessEpoch,
-  ): Promise<{ targetId: string }>;
+  ): Promise<{ targetId: string; assertCurrent(): void }>;
   handoff(result: { tabId: number; targetId: string }): void;
 };
 

--- a/extensions/browser/chrome-extension/modules/tab-access.js
+++ b/extensions/browser/chrome-extension/modules/tab-access.js
@@ -275,6 +275,7 @@ export function createTabAccessPolicy({ chromeApi = chrome, isSelectedTab, getGr
     } finally {
       pendingCreations.delete(pending);
     }
+    let assertAttachment;
     const created = {
       tab,
       // Creation owns a tab, not its first HTTP document (which may redirect).
@@ -288,6 +289,7 @@ export function createTabAccessPolicy({ chromeApi = chrome, isSelectedTab, getGr
       namingGroup: undefined,
       initialGroup: false,
       assertCurrent: () => {
+        assertAttachment?.();
         if (createdTabs.get(tab.id) !== created || !epochIsCurrent(tab.id, created.epoch)) {
           throw new Error(`tab ${tab.id} creation access was revoked`);
         }
@@ -310,6 +312,7 @@ export function createTabAccessPolicy({ chromeApi = chrome, isSelectedTab, getGr
       await requireTab(tab.id, created.epoch);
       created.assertCurrent();
       const attached = await attachDebugger(tab.id, created.assertCurrent, created.epoch);
+      assertAttachment = attached.assertCurrent;
       created.assertCurrent();
       if (message.focus === true && typeof tab.windowId === "number") {
         await chromeApi.windows.update(tab.windowId, { focused: true });
@@ -317,11 +320,13 @@ export function createTabAccessPolicy({ chromeApi = chrome, isSelectedTab, getGr
       }
       await requireTab(tab.id, created.epoch);
       created.assertCurrent();
-      handoff({ tabId: tab.id, ...attached });
+      handoff({ tabId: tab.id, targetId: attached.targetId });
       created.handedOff = true;
     } catch (error) {
       // Rollback belongs to the creator, before any id is handed to the relay.
       // Never use ordinary close as a privileged bypass or close a user-revoked tab.
+      // Socket/native closure ends handoff authority, but not ownership of this
+      // unhanded tab. Rollback uses the creator epoch and unchanged tab identity.
       const ownsRollback = () =>
         createdTabs.get(tab.id) === created &&
         !deniedTabIds.has(tab.id) &&

--- a/extensions/browser/src/browser/extension-relay/relay-bridge.fetch.test.ts
+++ b/extensions/browser/src/browser/extension-relay/relay-bridge.fetch.test.ts
@@ -1,0 +1,606 @@
+import { asOptionalRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ExtensionRelayBridge } from "./relay-bridge.js";
+import {
+  flush,
+  FakeSocket,
+  replyFor,
+  defaultTabs,
+  sendHello,
+  wireExtension,
+} from "./relay-bridge.test-support.js";
+import type { RelayToExtensionMessage } from "./relay-protocol.js";
+
+function connectRelayClient(bridge: ExtensionRelayBridge) {
+  const socket = new FakeSocket();
+  const handlers = bridge.attachCdpClientSocket(socket);
+  let nextId = 1;
+  const send = (method: string, sessionId?: string, params?: Record<string, unknown>) => {
+    const id = nextId++;
+    handlers.onMessage(JSON.stringify({ id, method, sessionId, params }));
+    return id;
+  };
+  const response = (id: number) => socket.frames().find((frame) => frame.id === id);
+  return {
+    socket,
+    send,
+    response,
+    close: handlers.onClose,
+    async request(method: string, sessionId?: string, params?: Record<string, unknown>) {
+      const id = send(method, sessionId, params);
+      await flush();
+      return response(id);
+    },
+  };
+}
+
+type RelayClient = ReturnType<typeof connectRelayClient>;
+
+function sessionFrom(value: unknown): string {
+  expect(value).toMatchObject({ sessionId: expect.any(String) });
+  return (value as { sessionId: string }).sessionId;
+}
+
+function rootSession(client: RelayClient, targetId = "target-1"): string {
+  const attached = client.socket.frames().find((frame) => {
+    const params = frame.params as { targetInfo?: { targetId?: string } } | undefined;
+    return frame.method === "Target.attachedToTarget" && params?.targetInfo?.targetId === targetId;
+  });
+  return sessionFrom(attached?.params);
+}
+
+function fetchEvents(client: RelayClient, sessionId?: string) {
+  return client.socket
+    .frames()
+    .filter(
+      (frame) =>
+        (frame.method === "Fetch.requestPaused" || frame.method === "Fetch.authRequired") &&
+        (sessionId === undefined || frame.sessionId === sessionId),
+    );
+}
+
+function pausedRequestId(client: RelayClient, sessionId: string): string {
+  const params = fetchEvents(client, sessionId).at(-1)?.params;
+  expect(params).toMatchObject({ requestId: expect.any(String) });
+  return (params as { requestId: string }).requestId;
+}
+
+const ownershipError = { error: { code: expect.any(Number), message: expect.any(String) } };
+
+describe("ExtensionRelayBridge Fetch ownership", () => {
+  let bridge: ExtensionRelayBridge;
+  let extension: ReturnType<typeof wireExtension>;
+  let reply: typeof replyFor;
+  let owner: RelayClient;
+  let observer: RelayClient;
+  let sessionId: string;
+  let observerSessionId: string;
+
+  beforeEach(async () => {
+    bridge = new ExtensionRelayBridge();
+    reply = replyFor;
+    extension = wireExtension(bridge, (message) => reply(message));
+    sendHello(extension.handlers, [
+      ...defaultTabs(),
+      { tabId: 2, url: "https://other.example", title: "Other", active: false },
+    ]);
+    owner = connectRelayClient(bridge);
+    observer = connectRelayClient(bridge);
+    await Promise.all(
+      [owner, observer].map((client) =>
+        client.request("Target.setAutoAttach", undefined, { autoAttach: true, flatten: true }),
+      ),
+    );
+    sessionId = rootSession(owner);
+    observerSessionId = rootSession(observer);
+  });
+
+  afterEach(async () => {
+    bridge.dispose();
+    await flush();
+  });
+
+  function emitPaused(
+    requestId: string,
+    scope: { tabId: number; sessionId?: string } = { tabId: 1 },
+    method = "Fetch.requestPaused",
+    extra: Record<string, unknown> = {},
+  ) {
+    extension.handlers.onMessage(
+      JSON.stringify({
+        type: "cdpEvent",
+        ...scope,
+        method,
+        params: {
+          requestId,
+          ...extra,
+          request: { url: "https://example.com/blocked", method: "GET", headers: {} },
+          frameId: "frame-1",
+          resourceType: "Document",
+          ...(method === "Fetch.authRequired"
+            ? { authChallenge: { origin: "https://example.com", scheme: "basic", realm: "test" } }
+            : {}),
+        },
+      }),
+    );
+  }
+
+  function fetchCommands() {
+    return extension.socket
+      .frames()
+      .filter((frame) => frame.type === "cdp" && String(frame.method).startsWith("Fetch."));
+  }
+
+  it.each([
+    { event: "Fetch.requestPaused", resolve: "Fetch.continueRequest", params: {} },
+    {
+      event: "Fetch.authRequired",
+      resolve: "Fetch.continueWithAuth",
+      params: { authChallengeResponse: { response: "CancelAuth" } },
+    },
+  ])("delivers $event only to its owner and rejects another client's guessed ID", async (entry) => {
+    expect(
+      await owner.request("Fetch.enable", sessionId, { handleAuthRequests: true }),
+    ).toMatchObject({ result: {} });
+    emitPaused("physical-request", { tabId: 1 }, entry.event);
+    const requestId = pausedRequestId(owner, sessionId);
+
+    expect.soft(fetchEvents(observer)).toEqual([]);
+    const resolution = { ...entry.params, requestId };
+    expect
+      .soft(await observer.request(entry.resolve, observerSessionId, resolution))
+      .toMatchObject(ownershipError);
+    expect.soft(fetchCommands().filter((frame) => frame.method === entry.resolve)).toEqual([]);
+
+    expect(await owner.request(entry.resolve, sessionId, resolution)).toMatchObject({ result: {} });
+    expect.soft(fetchCommands().filter((frame) => frame.method === entry.resolve)).toEqual([
+      expect.objectContaining({
+        tabId: 1,
+        params: { ...entry.params, requestId: "physical-request" },
+      }),
+    ]);
+  });
+
+  it("rejects competing enable and ignores nonowner disable without blocking Page or another tab", async () => {
+    expect(await owner.request("Fetch.enable", sessionId)).toMatchObject({ result: {} });
+    await observer.request("Fetch.disable", observerSessionId);
+    expect.soft(fetchCommands().filter((frame) => frame.method === "Fetch.disable")).toEqual([]);
+
+    const [competing, page, otherTab] = await Promise.all([
+      observer.request("Fetch.enable", observerSessionId),
+      observer.request("Page.getFrameTree", observerSessionId),
+      observer.request("Fetch.enable", rootSession(observer, "target-2")),
+    ]);
+    expect.soft(competing).toMatchObject(ownershipError);
+    expect(page).toMatchObject({ result: {} });
+    expect(otherTab).toMatchObject({ result: {} });
+    expect
+      .soft(fetchCommands().filter((frame) => frame.method === "Fetch.enable"))
+      .toEqual([expect.objectContaining({ tabId: 1 }), expect.objectContaining({ tabId: 2 })]);
+
+    emitPaused("owner-still-live");
+    const requestId = pausedRequestId(owner, sessionId);
+    expect.soft(fetchEvents(observer, observerSessionId)).toEqual([]);
+    expect(await owner.request("Fetch.continueRequest", sessionId, { requestId })).toMatchObject({
+      result: {},
+    });
+    emitPaused("other-tab-request", { tabId: 2 });
+    expect(fetchEvents(observer, rootSession(observer, "target-2"))).toHaveLength(1);
+    expect.soft(fetchEvents(owner, rootSession(owner, "target-2"))).toEqual([]);
+  });
+
+  it.each(["root", "alias"])(
+    "keeps a %s Fetch owner separate from another session on the same client",
+    async (kind) => {
+      const browser = await owner.request("Target.attachToBrowserTarget");
+      const browserSession = sessionFrom(browser?.result);
+      const attached = await owner.request("Target.attachToTarget", browserSession, {
+        targetId: "target-1",
+        flatten: true,
+      });
+      const alias = sessionFrom(attached?.result);
+      const ownerSession = kind === "root" ? sessionId : alias;
+      const siblingSession = kind === "root" ? alias : sessionId;
+      expect(await owner.request("Fetch.enable", ownerSession)).toMatchObject({ result: {} });
+      emitPaused("alias-request");
+      const requestId = pausedRequestId(owner, ownerSession);
+
+      expect.soft(fetchEvents(owner, siblingSession)).toEqual([]);
+      expect
+        .soft(await owner.request("Fetch.continueRequest", siblingSession, { requestId }))
+        .toMatchObject(ownershipError);
+      await owner.request("Fetch.disable", siblingSession);
+      expect.soft(fetchCommands().filter((frame) => frame.method === "Fetch.disable")).toEqual([]);
+      expect
+        .soft(await owner.request("Fetch.enable", siblingSession))
+        .toMatchObject(ownershipError);
+      expect(
+        await owner.request("Fetch.continueRequest", ownerSession, { requestId }),
+      ).toMatchObject({
+        result: {},
+      });
+    },
+  );
+
+  it("fails the closing owner's pending request before disabling, then releases the scope to a connected client", async () => {
+    expect(await owner.request("Fetch.enable", sessionId)).toMatchObject({ result: {} });
+    emitPaused("abandoned-request");
+    pausedRequestId(owner, sessionId);
+    reply = (message) =>
+      message.type === "cdp" && message.method === "Fetch.failRequest" ? null : replyFor(message);
+    owner.close();
+    await flush();
+
+    const cleanup = fetchCommands().find((frame) => frame.method === "Fetch.failRequest");
+    expect.soft(cleanup).toMatchObject({ tabId: 1, params: { requestId: "abandoned-request" } });
+    expect.soft(fetchCommands().filter((frame) => frame.method === "Fetch.disable")).toEqual([]);
+    expect(await observer.request("Page.getFrameTree", observerSessionId)).toMatchObject({
+      result: {},
+    });
+    if (cleanup) {
+      extension.handlers.onMessage(
+        JSON.stringify({ type: "result", seq: cleanup.seq, result: {} }),
+      );
+    }
+    await flush();
+
+    expect
+      .soft(fetchCommands().map((frame) => frame.method))
+      .toEqual(["Fetch.enable", "Fetch.failRequest", "Fetch.disable"]);
+    expect(extension.socket.frames().filter((frame) => frame.type === "detach")).toEqual([]);
+    expect(await observer.request("Fetch.enable", observerSessionId)).toMatchObject({ result: {} });
+    emitPaused("successor-request");
+    expect(fetchEvents(observer, observerSessionId).at(-1)).toMatchObject({
+      params: { requestId: expect.any(String) },
+    });
+  });
+
+  it("retires the physical scope when owner-close cleanup is completion-ambiguous", async () => {
+    expect(await owner.request("Fetch.enable", sessionId)).toMatchObject({ result: {} });
+    emitPaused("abandoned-request");
+    pausedRequestId(owner, sessionId);
+    reply = (message) =>
+      message.type === "cdp" && message.method === "Fetch.failRequest"
+        ? { type: "error", seq: message.seq, message: "cleanup completion unknown" }
+        : replyFor(message);
+    owner.close();
+    await flush();
+    await flush();
+
+    expect
+      .soft(fetchCommands().map((frame) => frame.method))
+      .toEqual(["Fetch.enable", "Fetch.failRequest"]);
+    expect
+      .soft(extension.socket.frames().filter((frame) => frame.type === "detach"))
+      .toEqual([expect.objectContaining({ tabId: 1 })]);
+    expect(observer.socket.closed).toBe(false);
+    expect(await observer.request("Page.getFrameTree", observerSessionId)).toMatchObject(
+      ownershipError,
+    );
+  });
+
+  it("rejects a stale request ID after disable and successor enable without disturbing the new request", async () => {
+    expect(await owner.request("Fetch.enable", sessionId)).toMatchObject({ result: {} });
+    emitPaused("old-request");
+    const staleId = pausedRequestId(owner, sessionId);
+    expect(await owner.request("Fetch.disable", sessionId)).toMatchObject({ result: {} });
+    expect(await observer.request("Fetch.enable", observerSessionId)).toMatchObject({ result: {} });
+    emitPaused("new-request");
+    const currentId = pausedRequestId(observer, observerSessionId);
+    const beforeResolution = fetchCommands().length;
+
+    expect
+      .soft(
+        await observer.request("Fetch.continueRequest", observerSessionId, { requestId: staleId }),
+      )
+      .toMatchObject(ownershipError);
+    expect.soft(fetchCommands()).toHaveLength(beforeResolution);
+    expect(
+      await observer.request("Fetch.continueRequest", observerSessionId, { requestId: currentId }),
+    ).toMatchObject({
+      result: {},
+    });
+    expect(fetchCommands().at(-1)).toMatchObject({ params: { requestId: "new-request" } });
+  });
+
+  it("owns child Fetch independently of the root physical scope", async () => {
+    await owner.request("Target.setAutoAttach", sessionId, {
+      autoAttach: true,
+      waitForDebuggerOnStart: true,
+      flatten: true,
+    });
+    await observer.request("Target.setAutoAttach", observerSessionId, {
+      autoAttach: true,
+      waitForDebuggerOnStart: true,
+      flatten: true,
+    });
+    const childSession = "child-frame";
+    extension.handlers.onMessage(
+      JSON.stringify({
+        type: "cdpEvent",
+        tabId: 1,
+        method: "Target.attachedToTarget",
+        params: {
+          sessionId: childSession,
+          targetInfo: { targetId: "frame-target", type: "iframe" },
+          waitingForDebugger: false,
+        },
+      }),
+    );
+    const ownerChild = rootSession(owner, "frame-target");
+    const observerChild = rootSession(observer, "frame-target");
+    expect(await owner.request("Fetch.enable", ownerChild)).toMatchObject({ result: {} });
+    expect(await observer.request("Fetch.enable", observerSessionId)).toMatchObject({ result: {} });
+    emitPaused("child-request", { tabId: 1, sessionId: childSession });
+    const requestId = pausedRequestId(owner, ownerChild);
+
+    expect.soft(fetchEvents(observer, observerChild)).toEqual([]);
+    expect
+      .soft(await observer.request("Fetch.continueRequest", observerChild, { requestId }))
+      .toMatchObject(ownershipError);
+    expect(await owner.request("Fetch.continueRequest", ownerChild, { requestId })).toMatchObject({
+      result: {},
+    });
+    expect(fetchCommands().at(-1)).toMatchObject({
+      tabId: 1,
+      sessionId: childSession,
+      params: { requestId: "child-request" },
+    });
+  });
+
+  it("retires the physical scope when enable errors before a connected client reattaches", async () => {
+    let heldEnable: Extract<RelayToExtensionMessage, { type: "cdp" }> | undefined;
+    reply = (message) => {
+      if (message.type === "cdp" && message.method === "Fetch.enable") {
+        heldEnable ??= message;
+        return null;
+      }
+      return replyFor(message);
+    };
+    const enabling = owner.send("Fetch.enable", sessionId);
+    await flush();
+    expect(heldEnable).toMatchObject({ method: "Fetch.enable", tabId: 1 });
+    expect
+      .soft(await observer.request("Fetch.enable", observerSessionId))
+      .toMatchObject(ownershipError);
+    expect.soft(fetchCommands()).toHaveLength(1);
+    reply = replyFor;
+    extension.handlers.onMessage(
+      JSON.stringify({ type: "error", seq: heldEnable?.seq, message: "enable rejected" }),
+    );
+    await flush();
+    expect(owner.response(enabling)).toMatchObject({ error: { message: "enable rejected" } });
+    expect
+      .soft(extension.socket.frames().filter((frame) => frame.type === "detach"))
+      .toEqual([expect.objectContaining({ tabId: 1 })]);
+    expect(owner.socket.closed).toBe(false);
+    expect(observer.socket.closed).toBe(false);
+
+    const attached = await observer.request("Target.attachToTarget", undefined, {
+      targetId: "target-1",
+      flatten: true,
+    });
+    const replacementSessionId = sessionFrom(attached?.result);
+    expect(replacementSessionId).not.toBe(observerSessionId);
+    expect(await observer.request("Fetch.enable", replacementSessionId)).toMatchObject({
+      result: {},
+    });
+    emitPaused("after-rejected-enable");
+    expect(fetchEvents(observer, replacementSessionId)).toHaveLength(1);
+    expect.soft(fetchEvents(owner)).toEqual([]);
+  });
+
+  it("cleans up a successful enable reply that arrives after its client closes", async () => {
+    let heldEnable: Extract<RelayToExtensionMessage, { type: "cdp" }> | undefined;
+    reply = (message) => {
+      if (message.type === "cdp" && message.method === "Fetch.enable") {
+        heldEnable = message;
+        return null;
+      }
+      return replyFor(message);
+    };
+    const enabling = owner.send("Fetch.enable", sessionId);
+    await flush();
+    expect(heldEnable).toMatchObject({ method: "Fetch.enable", tabId: 1 });
+    owner.close();
+    reply = replyFor;
+    extension.handlers.onMessage(
+      JSON.stringify({ type: "result", seq: heldEnable?.seq, result: {} }),
+    );
+    await flush();
+
+    expect(owner.response(enabling)).toBeUndefined();
+    expect
+      .soft(fetchCommands().map((frame) => frame.method))
+      .toEqual(["Fetch.enable", "Fetch.disable"]);
+    expect(await observer.request("Fetch.enable", observerSessionId)).toMatchObject({ result: {} });
+    emitPaused("after-closed-enable");
+    expect(fetchEvents(observer, observerSessionId)).toHaveLength(1);
+  });
+
+  it("keeps raw and minted response streams private without intercepting unrelated IO", async () => {
+    reply = (message) =>
+      message.type === "cdp" && message.method === "Fetch.takeResponseBodyAsStream"
+        ? { type: "result", seq: message.seq, result: { stream: "native-stream" } }
+        : replyFor(message);
+    await owner.request("Fetch.enable", sessionId);
+    emitPaused("response", { tabId: 1 }, "Fetch.requestPaused", { responseStatusCode: 200 });
+    const body = await owner.request("Fetch.takeResponseBodyAsStream", sessionId, {
+      requestId: pausedRequestId(owner, sessionId),
+    });
+    const handle = asOptionalRecord(body?.result)?.stream;
+    if (typeof handle !== "string") {
+      throw new Error("Missing response stream");
+    }
+    for (const method of ["IO.read", "IO.close"]) {
+      for (const raw of [handle, "native-stream"]) {
+        expect(await observer.request(method, observerSessionId, { handle: raw })).toMatchObject(
+          ownershipError,
+        );
+      }
+    }
+    expect(
+      extension.socket
+        .frames()
+        .filter((frame) => frame.method === "IO.read" || frame.method === "IO.close"),
+    ).toEqual([]);
+    expect(await owner.request("IO.read", sessionId, { handle })).toMatchObject({ result: {} });
+    expect(
+      await observer.request("IO.read", observerSessionId, { handle: "unrelated-domain" }),
+    ).toMatchObject({ result: {} });
+    expect(
+      extension.socket
+        .frames()
+        .filter((frame) => frame.method === "IO.read")
+        .map((frame) => frame.params),
+    ).toEqual([{ handle: "native-stream" }, { handle: "unrelated-domain" }]);
+    expect(owner.socket.closed).toBe(false);
+    expect(observer.socket.closed).toBe(false);
+  });
+
+  it("retires the native root of an uncertain child without disturbing another tab", async () => {
+    await owner.request("Target.setAutoAttach", sessionId, {
+      autoAttach: true,
+      waitForDebuggerOnStart: true,
+      flatten: true,
+    });
+    await observer.request("Target.setAutoAttach", observerSessionId, {
+      autoAttach: true,
+      waitForDebuggerOnStart: true,
+      flatten: true,
+    });
+    extension.handlers.onMessage(
+      JSON.stringify({
+        type: "cdpEvent",
+        tabId: 1,
+        method: "Target.attachedToTarget",
+        params: { sessionId: "child", targetInfo: { targetId: "child-target", type: "iframe" } },
+      }),
+    );
+    reply = (message) =>
+      message.type === "cdp" && message.sessionId === "child" && message.method === "Fetch.enable"
+        ? { type: "error", seq: message.seq, message: "native completion unknown" }
+        : replyFor(message);
+    expect(await owner.request("Fetch.enable", rootSession(owner, "child-target"))).toMatchObject(
+      ownershipError,
+    );
+    await flush();
+    expect(extension.socket.frames().filter((frame) => frame.type === "detach")).toEqual([
+      expect.objectContaining({ tabId: 1 }),
+    ]);
+    expect(await observer.request("Runtime.enable", observerSessionId)).toMatchObject(
+      ownershipError,
+    );
+    expect(
+      await observer.request("Page.getFrameTree", rootSession(observer, "target-2")),
+    ).toMatchObject({ result: {} });
+    expect(owner.socket.closed).toBe(false);
+    expect(observer.socket.closed).toBe(false);
+  });
+
+  it("fences admission immediately and waits for cleanup and native detach before successor attach", async () => {
+    await owner.request("Fetch.enable", sessionId);
+    emitPaused("observed");
+    await observer.request("Target.detachFromTarget", undefined, { sessionId: observerSessionId });
+    reply = (message) =>
+      (message.type === "cdp" && message.method === "Fetch.failRequest") ||
+      message.type === "detach"
+        ? null
+        : replyFor(message);
+    const closing = owner.send("Target.detachFromTarget", undefined, { sessionId });
+    await flush();
+    const attaching = observer.send("Target.attachToTarget", undefined, { targetId: "target-1" });
+    await flush();
+    expect(await owner.request("Page.getFrameTree", sessionId)).toMatchObject(ownershipError);
+    expect(observer.response(attaching)).toBeUndefined();
+    expect(
+      extension.socket.frames().filter((frame) => frame.type === "attach" && frame.tabId === 1),
+    ).toHaveLength(1);
+    const cleanup = fetchCommands().find((frame) => frame.method === "Fetch.failRequest")!;
+    extension.handlers.onMessage(JSON.stringify({ type: "result", seq: cleanup.seq, result: {} }));
+    await flush();
+    expect(observer.response(attaching)).toBeUndefined();
+    const detaching = extension.socket
+      .frames()
+      .find((frame) => frame.type === "detach" && frame.tabId === 1)!;
+    reply = replyFor;
+    extension.handlers.onMessage(
+      JSON.stringify({ type: "result", seq: detaching.seq, result: {} }),
+    );
+    await flush();
+    expect(owner.response(closing)).toMatchObject({ result: {} });
+    const replacement = sessionFrom(observer.response(attaching)?.result);
+    expect(replacement).not.toBe(sessionId);
+    expect(await observer.request("Runtime.enable", replacement)).toMatchObject({ result: {} });
+    expect(fetchCommands().some((frame) => frame.method === "Fetch.disable")).toBe(false);
+  });
+
+  it.each(["last logical session", "owner with a live sibling"])(
+    "bounds retirement of a hung body read and evaluation for %s",
+    async (ending) => {
+      await owner.request("Fetch.enable", sessionId);
+      emitPaused("body", { tabId: 1 }, "Fetch.requestPaused", { responseStatusCode: 200 });
+      const requestId = pausedRequestId(owner, sessionId);
+      if (ending === "last logical session") {
+        await observer.request("Target.detachFromTarget", undefined, {
+          sessionId: observerSessionId,
+        });
+      }
+      reply = (message) =>
+        message.type === "cdp" &&
+        ["Fetch.getResponseBody", "Runtime.evaluate", "Fetch.failRequest"].includes(message.method)
+          ? null
+          : replyFor(message);
+      const body = owner.send("Fetch.getResponseBody", sessionId, { requestId });
+      const evaluation = owner.send("Runtime.evaluate", sessionId);
+      await flush();
+      emitPaused("known-request");
+      vi.useFakeTimers();
+      try {
+        owner.send("Target.detachFromTarget", undefined, { sessionId });
+        await vi.advanceTimersByTimeAsync(2001);
+        expect(
+          extension.socket.frames().filter((frame) => frame.type === "detach" && frame.tabId === 1),
+        ).toHaveLength(1);
+        expect(owner.response(body)).toMatchObject(ownershipError);
+        expect(owner.response(evaluation)).toMatchObject(ownershipError);
+        expect(fetchCommands().filter((frame) => frame.method === "Fetch.failRequest")).toEqual([
+          expect.objectContaining({
+            params: { requestId: "known-request", errorReason: "Aborted" },
+          }),
+        ]);
+        expect(fetchCommands().some((frame) => frame.method === "Fetch.disable")).toBe(false);
+        expect(owner.socket.closed).toBe(false);
+        expect(observer.socket.closed).toBe(false);
+      } finally {
+        vi.useRealTimers();
+      }
+    },
+  );
+
+  it("disposes held cleanup on extension loss without sending through its successor", async () => {
+    await owner.request("Fetch.enable", sessionId);
+    emitPaused("observed");
+    await observer.request("Target.detachFromTarget", undefined, { sessionId: observerSessionId });
+    reply = (message) =>
+      message.type === "cdp" && message.method === "Fetch.failRequest" ? null : replyFor(message);
+    owner.send("Target.detachFromTarget", undefined, { sessionId });
+    await flush();
+    const reattaching = observer.send("Target.attachToTarget", undefined, { targetId: "target-1" });
+    await flush();
+    expect(observer.response(reattaching)).toBeUndefined();
+    const previous = extension;
+    extension = wireExtension(bridge);
+    sendHello(extension.handlers, defaultTabs());
+    await flush();
+    const cleanup = previous.socket.frames().find((frame) => frame.method === "Fetch.failRequest")!;
+    previous.handlers.onMessage(JSON.stringify({ type: "result", seq: cleanup.seq, result: {} }));
+    await flush();
+    expect(observer.response(reattaching)).toMatchObject(ownershipError);
+    expect(
+      extension.socket
+        .frames()
+        .filter((frame) => frame.type === "detach" || String(frame.method).startsWith("Fetch.")),
+    ).toEqual([]);
+  });
+});

--- a/extensions/browser/src/browser/extension-relay/relay-bridge.test-support.ts
+++ b/extensions/browser/src/browser/extension-relay/relay-bridge.test-support.ts
@@ -49,7 +49,7 @@ export function wireExtension(
   return { socket, handlers };
 }
 
-function replyFor(msg: RelayToExtensionMessage): ExtensionToRelayMessage | null {
+export function replyFor(msg: RelayToExtensionMessage): ExtensionToRelayMessage | null {
   switch (msg.type) {
     case "attach":
       return { type: "result", seq: msg.seq, result: { targetId: `target-${msg.tabId}` } };

--- a/extensions/browser/src/browser/extension-relay/relay-bridge.test.ts
+++ b/extensions/browser/src/browser/extension-relay/relay-bridge.test.ts
@@ -1,3 +1,4 @@
+import { asOptionalRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 // Extension relay bridge: CDP target synthesis and extension command routing.
 import { describe, expect, it, vi } from "vitest";
 import { ExtensionRelayBridge } from "./relay-bridge.js";
@@ -671,6 +672,36 @@ describe("ExtensionRelayBridge", () => {
     );
     await flush();
 
+    const rootEvent = client.frames().find((frame) => frame.method === "Target.attachedToTarget");
+    const root = asOptionalRecord(rootEvent?.params)?.sessionId;
+    expect(typeof root).toBe("string");
+    cdp.onMessage(
+      JSON.stringify({
+        id: 10,
+        sessionId: root,
+        method: "Target.setAutoAttach",
+        params: { autoAttach: true, waitForDebuggerOnStart: true, flatten: true },
+      }),
+    );
+    await flush();
+    handlers.onMessage(
+      JSON.stringify({
+        type: "cdpEvent",
+        tabId: 1,
+        method: "Target.attachedToTarget",
+        params: {
+          sessionId: "child-abc",
+          targetInfo: { targetId: "child-target", type: "iframe" },
+          waitingForDebugger: false,
+        },
+      }),
+    );
+    const childEvent = client
+      .frames()
+      .findLast((frame) => frame.method === "Target.attachedToTarget");
+    const child = asOptionalRecord(childEvent?.params)?.sessionId;
+    expect(typeof child).toBe("string");
+    expect(child).not.toBe(root);
     // Extension reports a child (iframe) session for tab 1.
     handlers.onMessage(
       JSON.stringify({
@@ -689,7 +720,7 @@ describe("ExtensionRelayBridge", () => {
 
     // A command addressed to the now-stale child session must not route to a
     // reused tab; it should surface a clean "session not found" error.
-    cdp.onMessage(JSON.stringify({ id: 2, sessionId: "child-abc", method: "Page.reload" }));
+    cdp.onMessage(JSON.stringify({ id: 2, sessionId: child, method: "Page.reload" }));
     await flush();
     const response = client.frames().find((frame) => frame.id === 2);
     expect(response?.error).toBeTruthy();

--- a/extensions/browser/src/browser/extension-relay/relay-bridge.ts
+++ b/extensions/browser/src/browser/extension-relay/relay-bridge.ts
@@ -7,7 +7,7 @@
  * thin forwarder — the old assets/chrome-extension put this logic in an
  * untestable MV3 service worker, which is why it rotted and was removed.
  */
-import { once } from "node:events";
+import { addAbortListener, once } from "node:events";
 import { asOptionalRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { resolveCreateTargetParams } from "./create-target-params.js";
@@ -53,9 +53,11 @@ type PendingExtensionCommand = {
 
 type TabState = {
   info: RelayTabInfo;
+  claimants: Set<{ client: CdpClientState }>;
   /** Target identity lasts until access/extension loss; only the session ends on detach. */
   target?: { id: string; sessionId?: string };
   attaching?: Promise<{ targetId: string; sessionId: string }>;
+  retiring?: Promise<void>;
   /** Extension loss invalidated attachment work that auto-attach clients still expect restored. */
   restoreAttachment: boolean;
 };
@@ -93,7 +95,12 @@ export class ExtensionRelayBridge {
   private readonly tabs = new Map<number, TabState>();
   /** Browser-level sessions created by Playwright for page-scoped CDP access. */
   private readonly browserSessions = new Map<string, CdpClientState>();
-  private readonly sessions = new RelaySessionOwner(this.clients);
+  private readonly sessions = new RelaySessionOwner(
+    this.clients,
+    (root) => this.retireAttachment(root),
+    (error) => log.warn(`Debugger cleanup incomplete: ${String(error)}`),
+    (tabId) => (this.tabs.get(tabId)?.claimants.size ?? 0) > 0,
+  );
   private readonly pendingExtension = new Map<number, PendingExtensionCommand>();
   private nextSeq = 1;
   private nextSessionOrdinal = 1;
@@ -171,7 +178,7 @@ export class ExtensionRelayBridge {
    * DevTools-style descriptors for `/json/list`: RelayTabInfo plus the `id`
    * and `type` fields CDP discovery clients expect. `id` is the live debugger
    * targetId once a tab is attached; before that it is the same `tab-<tabId>`
-   * fallback ensureTabAttached mints, so unattached tabs still list stably.
+   * discovery-only placeholder; native attachment never fabricates an identity.
    * No per-target webSocketDebuggerUrl: all CDP traffic multiplexes over the
    * single browser endpoint (`/cdp`).
    */
@@ -302,8 +309,11 @@ export class ExtensionRelayBridge {
       }
       case "detached": {
         const tab = this.tabs.get(msg.tabId);
-        if (tab?.target?.sessionId) {
-          this.sessions.retire(tab.target.sessionId, tab.target.id);
+        if (tab) {
+          tab.attaching = undefined;
+        }
+        this.sessions.retireTab(msg.tabId);
+        if (tab?.target) {
           tab.target.sessionId = undefined;
         }
         break;
@@ -324,14 +334,13 @@ export class ExtensionRelayBridge {
       pending.reject(new Error("extension disconnected"));
     }
     this.pendingExtension.clear();
+    this.sessions.dispose();
     // Retire attach work synchronously so a replacement snapshot cannot reuse
     // a rejected promise. Keep the tab list so the same ids can be re-exposed.
     for (const tab of this.tabs.values()) {
       tab.restoreAttachment ||= tab.target?.sessionId !== undefined || tab.attaching !== undefined;
       tab.attaching = undefined;
-      if (tab.target?.sessionId) {
-        this.sessions.retire(tab.target.sessionId, tab.target.id);
-      }
+      tab.retiring = undefined;
       tab.target = undefined;
     }
   }
@@ -375,15 +384,25 @@ export class ExtensionRelayBridge {
   private callExtension(
     command: RelayCommandBody,
     timeoutMs = EXTENSION_COMMAND_TIMEOUT_MS,
+    signal?: AbortSignal,
   ): Promise<unknown> {
+    signal?.throwIfAborted();
     const seq = this.nextSeq++;
-    return new Promise<unknown>((resolve, reject) => {
+    let abortListener: Disposable | undefined;
+    const result = new Promise<unknown>((resolve, reject) => {
       const timer = setTimeout(() => {
         this.pendingExtension.delete(seq);
         reject(new Error(`extension relay command timed out: ${command.type}`));
       }, timeoutMs);
       timer.unref?.();
       this.pendingExtension.set(seq, { resolve, reject, timer });
+      if (signal) {
+        abortListener = addAbortListener(signal, () => {
+          this.pendingExtension.delete(seq);
+          clearTimeout(timer);
+          reject(new Error("Physical session detached"));
+        });
+      }
       try {
         this.sendToExtension({ ...command, seq });
       } catch (err) {
@@ -392,16 +411,15 @@ export class ExtensionRelayBridge {
         reject(err instanceof Error ? err : new Error(String(err)));
       }
     });
+    return result.finally(() => abortListener?.[Symbol.dispose]());
   }
 
   private syncTabs(tabs: RelayTabInfo[]): void {
     const nextIds = new Set(tabs.map((tab) => tab.tabId));
     const shouldAutoAttach = [...this.clients].some((client) => client.autoAttach);
-    for (const [tabId, tab] of this.tabs) {
+    for (const tabId of this.tabs.keys()) {
       if (!nextIds.has(tabId)) {
-        if (tab.target?.sessionId) {
-          this.sessions.retire(tab.target.sessionId, tab.target.id);
-        }
+        this.sessions.retireTab(tabId);
         this.tabs.delete(tabId);
       }
     }
@@ -411,17 +429,56 @@ export class ExtensionRelayBridge {
       if (existing) {
         existing.info = info;
       } else {
-        this.tabs.set(info.tabId, { info, restoreAttachment: false });
+        this.tabs.set(info.tabId, { info, claimants: new Set(), restoreAttachment: false });
       }
       if (shouldAutoAttach && shouldAttach) {
-        void this.ensureTabAttached(info.tabId)
-          .then(({ targetId, sessionId }) => {
-            this.announceAttachedTab(info.tabId, targetId, sessionId, { onlyAutoAttach: true });
-          })
-          .catch((err: unknown) => {
-            log.warn(`auto-attach of accessible tab ${info.tabId} failed: ${String(err)}`);
-          });
+        for (const client of this.clients) {
+          if (!client.autoAttach) {
+            continue;
+          }
+          void this.withAttachedTab(client, info.tabId, ({ targetId, sessionId }) => {
+            if (client.autoAttach) {
+              this.announceAttachedTab(info.tabId, targetId, sessionId, {
+                onlyAutoAttach: false,
+                onlyClient: client,
+              });
+            }
+          }).catch((err: unknown) =>
+            log.warn(`auto-attach of accessible tab ${info.tabId} failed: ${String(err)}`),
+          );
+        }
       }
+    }
+  }
+
+  private async withAttachedTab<T>(
+    client: CdpClientState,
+    tabId: number,
+    use: (attached: { targetId: string; sessionId: string }) => T,
+    createdTargetId?: string,
+  ): Promise<T> {
+    const tab = this.tabs.get(tabId);
+    const extension = this.extension;
+    if (!tab) {
+      throw new Error(`tab ${tabId} is not available to OpenClaw`);
+    }
+    // A pending claimant keeps the physical acquisition alive through announcement.
+    // Use a distinct token even for concurrent acquisitions by the same client.
+    const claimant = { client };
+    tab.claimants.add(claimant);
+    try {
+      const attached = await this.ensureTabAttached(tabId, createdTargetId);
+      if (
+        !this.clients.has(client) ||
+        this.tabs.get(tabId) !== tab ||
+        this.extension !== extension
+      ) {
+        throw new Error("Target claimant retired");
+      }
+      return use(attached);
+    } finally {
+      tab.claimants.delete(claimant);
+      this.detachUnusedAttachments();
     }
   }
 
@@ -429,9 +486,16 @@ export class ExtensionRelayBridge {
     tabId: number,
     createdTargetId?: string,
   ): Promise<{ targetId: string; sessionId: string }> {
+    const extension = this.extension;
     const tab = this.tabs.get(tabId);
     if (!tab) {
       throw new Error(`tab ${tabId} is not available to OpenClaw`);
+    }
+    if (tab.retiring) {
+      await tab.retiring;
+      if (this.tabs.get(tabId) !== tab || this.extension !== extension) {
+        throw new Error(`tab ${tabId} closed during retirement`);
+      }
     }
     if (tab.target?.sessionId) {
       return { targetId: tab.target.id, sessionId: tab.target.sessionId };
@@ -439,29 +503,65 @@ export class ExtensionRelayBridge {
     if (tab.attaching) {
       return await tab.attaching;
     }
-    const extension = this.extension;
-    const attaching = (async () => {
-      const result = asOptionalRecord(
-        createdTargetId
-          ? { targetId: createdTargetId }
-          : await this.callExtension({ type: "attach", tabId }),
-      );
-      const targetId = typeof result?.targetId === "string" ? result.targetId : `tab-${tabId}`;
+    // Even atomic creation completes in a continuation: the pending identity
+    // must be installed before a detach or extension replacement can retire it.
+    const attachment =
+      createdTargetId !== undefined
+        ? Promise.resolve({ targetId: createdTargetId })
+        : this.callExtension({ type: "attach", tabId });
+    const attaching = attachment.then(async (response) => {
+      const result = asOptionalRecord(response);
+      const targetId = result?.targetId;
+      if (typeof targetId !== "string" || !targetId) {
+        if (
+          this.extension === extension &&
+          this.tabs.get(tabId) === tab &&
+          tab.attaching === attaching
+        ) {
+          await this.callExtension({ type: "detach", tabId });
+        }
+        throw new Error("Extension did not return a native target identity");
+      }
       const sessionId = `openclaw-tab-${tabId}-${this.nextSessionOrdinal++}`;
       const attached = { targetId, sessionId };
       // Identity check, not just presence: the tab could have lost and regained
       // access under the same tabId while this attach was in flight, replacing
       // the TabState. Writing onto the new TabState would bind stale attach data.
       const current = this.tabs.get(tabId);
-      if (this.extension !== extension || current !== tab) {
+      if (current !== tab || this.extension !== extension || tab.attaching !== attaching) {
         throw new Error(`tab ${tabId} closed during attach`);
       }
       current.target = { id: targetId, sessionId };
-      this.sessions.registerRoot(tabId, sessionId);
+      this.sessions.registerRoot(
+        tabId,
+        targetId,
+        sessionId,
+        async (childSessionId, method, params, signal) => {
+          const assertCurrent = () => {
+            signal.throwIfAborted();
+            if (this.extension !== extension || this.tabs.get(tabId) !== tab) {
+              throw new Error("Extension or tab generation retired");
+            }
+          };
+          assertCurrent();
+          const commandResult = await this.callExtension(
+            {
+              type: "cdp",
+              tabId,
+              ...(childSessionId ? { sessionId: childSessionId } : {}),
+              method,
+              params,
+            },
+            EXTENSION_COMMAND_TIMEOUT_MS,
+            signal,
+          );
+          assertCurrent();
+          return commandResult;
+        },
+      );
       current.restoreAttachment = false;
-      this.detachAllWhenIdle();
       return attached;
-    })();
+    });
     tab.attaching = attaching;
     try {
       return await attaching;
@@ -569,37 +669,83 @@ export class ExtensionRelayBridge {
     };
     const onClose = () => {
       this.clients.delete(client);
-      this.sessions.close(client);
+      for (const tab of this.tabs.values()) {
+        for (const claim of tab.claimants) {
+          if (claim.client === client) {
+            tab.claimants.delete(claim);
+          }
+        }
+      }
+      void this.sessions
+        .close(client)
+        .catch((error: unknown) => log.warn(`Client cleanup incomplete: ${String(error)}`));
       for (const [sessionId, owner] of this.browserSessions) {
         if (owner === client) {
           this.browserSessions.delete(sessionId);
         }
       }
-      this.detachAllWhenIdle();
+      this.detachUnusedAttachments();
     };
     return { onMessage, onClose };
   }
 
   /**
-   * Drop chrome.debugger sessions once no CDP client is connected so the
-   * "OpenClaw is debugging this browser" infobar only spans active automation.
+   * Release a tab only after its last pending or delivered logical claimant leaves.
    */
-  private detachAllWhenIdle(): void {
-    if (this.clients.size > 0 || !this.extension) {
+  private detachUnusedAttachments(): void {
+    if (!this.extension) {
       return;
     }
-    for (const [tabId, tab] of this.tabs) {
-      if (tab.target?.sessionId) {
-        const { sessionId, id: targetId } = tab.target;
-        tab.target.sessionId = undefined;
-        this.sessions.retire(sessionId, targetId);
-        void this.callExtension({ type: "detach", tabId }).catch(() => {});
+    for (const tab of this.tabs.values()) {
+      if (
+        tab.target?.sessionId &&
+        tab.claimants.size === 0 &&
+        !this.sessions.hasRootSessions(tab.target.sessionId)
+      ) {
+        void this.retireAttachment(tab.target.sessionId).catch((error: unknown) =>
+          log.warn(`Debugger retirement failed: ${String(error)}`),
+        );
       }
     }
   }
 
+  private retireAttachment(rootSessionId: string): Promise<void> {
+    const entry = [...this.tabs].find(([, tab]) => tab.target?.sessionId === rootSessionId);
+    if (!entry) {
+      return Promise.resolve();
+    }
+    const [tabId, tab] = entry;
+    const extension = this.extension;
+    const target = tab.target;
+    if (!target) {
+      return Promise.resolve();
+    }
+    target.sessionId = undefined;
+    const retiring = this.sessions.retire(rootSessionId, async () => {
+      if (this.extension === extension && this.tabs.get(tabId) === tab) {
+        await this.callExtension({ type: "detach", tabId });
+      }
+    });
+    // This promise orders the current attempt, not native authority. After it
+    // settles, a fresh worker acquire must discharge exact native cleanup debt.
+    tab.retiring = retiring;
+    void retiring
+      .finally(() => {
+        if (tab.retiring === retiring) {
+          tab.retiring = undefined;
+        }
+      })
+      .catch(() => {});
+    return retiring;
+  }
+
   private respond(client: CdpClientState, request: CdpRequest, result: unknown): void {
     if (!this.clients.has(client)) {
+      return;
+    }
+    const logical = request.sessionId ? client.sessions.get(request.sessionId) : undefined;
+    if (logical) {
+      this.sessions.emit(logical, { id: request.id, result: result ?? {} });
       return;
     }
     client.socket.send(
@@ -617,10 +763,14 @@ export class ExtensionRelayBridge {
     message: string,
     code = -32000,
   ): void {
-    if (!this.clients.has(client)) {
-      return;
+    if (this.clients.has(client)) {
+      const logical = request.sessionId ? client.sessions.get(request.sessionId) : undefined;
+      if (logical) {
+        this.sessions.emit(logical, { id: request.id, error: { code, message } });
+      } else {
+        client.socket.send(toErrorPayload(request.id, request.sessionId, message, code));
+      }
     }
-    client.socket.send(toErrorPayload(request.id, request.sessionId, message, code));
   }
 
   private tabByTargetId(targetId: string): { tabId: number; tab: TabState } | null {
@@ -659,31 +809,79 @@ export class ExtensionRelayBridge {
       return;
     }
     if (request.method === "Target.detachFromTarget") {
-      await this.handleBrowserScopedRequest(client, request);
-      return;
-    }
-    const { tabId, childSessionId, runtime } = session.physical;
-    const command = {
-      type: "cdp",
-      tabId,
-      ...(childSessionId ? { sessionId: childSessionId } : {}),
-      method: request.method,
-      params: request.params,
-    } as const;
-    if (request.method === "Runtime.disable") {
-      runtime.disable(client, sessionId);
+      const child = this.sessions.child(session, request.params);
+      await this.sessions.detach(client, child.id);
       this.respond(client, request, {});
       return;
     }
+    if (request.method === "Target.sendMessageToTarget") {
+      const child = this.sessions.child(session, request.params);
+      if (child.flat || typeof request.params?.message !== "string") {
+        throw new Error("Non-flat Target child session not found");
+      }
+      const nested = asOptionalRecord(JSON.parse(request.params.message));
+      if (!nested || typeof nested.id !== "number" || typeof nested.method !== "string") {
+        throw new Error("Invalid Target message");
+      }
+      const target =
+        nested.sessionId === undefined
+          ? child
+          : typeof nested.sessionId === "string"
+            ? client.sessions.get(nested.sessionId)
+            : undefined;
+      let ancestor = target;
+      while (ancestor && ancestor !== child && ancestor.flat) {
+        ancestor = ancestor.parent;
+      }
+      if (!target || ancestor !== child) {
+        throw new Error("Nested Target session not found");
+      }
+      void this.handleCdpRequest(client, {
+        id: nested.id,
+        method: nested.method,
+        params: asOptionalRecord(nested.params),
+        sessionId: target.id,
+      });
+      this.respond(client, request, {});
+      return;
+    }
+    if (request.method === "Target.setAutoAttach") {
+      const result = await session.physical.target.command(session, request.params, () => {
+        if (client.sessions.get(sessionId) !== session || !this.clients.has(client)) {
+          throw new Error("Target parent detached");
+        }
+      });
+      this.respond(client, request, result);
+      return;
+    }
+    const { runtime, fetch } = session.physical;
+    const emit = (method: string, params: unknown) =>
+      this.sessions.emit(session, { method, params });
+    const fetchResult = fetch.command(session, emit, request.method, request.params);
+    if (fetchResult) {
+      const result = await fetchResult;
+      if (client.sessions.get(sessionId) !== session) {
+        throw new Error(`Session detached: ${sessionId}`);
+      }
+      this.respond(client, request, result);
+      return;
+    }
+    if (request.method === "Runtime.disable") {
+      runtime.disable(session);
+      this.respond(client, request, {});
+      return;
+    }
+    const send = () =>
+      this.sessions.send(
+        session.physical,
+        request.method,
+        request.params,
+        request.method === "Runtime.runIfWaitingForDebugger" ? "target" : undefined,
+      );
     const result =
       request.method === "Runtime.enable"
-        ? await runtime.enable(
-            client,
-            sessionId,
-            (method, params) => client.socket.send(JSON.stringify({ sessionId, method, params })),
-            () => this.callExtension(command),
-          )
-        : await this.callExtension(command);
+        ? await runtime.enable(session, emit, send)
+        : await send();
     if (client.sessions.get(sessionId) !== session) {
       throw new Error(`Session detached: ${sessionId}`);
     }
@@ -768,23 +966,19 @@ export class ExtensionRelayBridge {
         client.autoAttach = autoAttach;
         if (autoAttach) {
           const attachResults = await Promise.allSettled(
-            [...this.tabs.keys()].map(async (tabId) => {
-              const { targetId, sessionId } = await this.ensureTabAttached(tabId);
-              return { tabId, targetId, sessionId };
-            }),
+            [...this.tabs.keys()].map((tabId) =>
+              this.withAttachedTab(client, tabId, ({ targetId, sessionId }) => {
+                if (client.autoAttach) {
+                  this.announceAttachedTab(tabId, targetId, sessionId, {
+                    onlyAutoAttach: false,
+                    onlyClient: client,
+                  });
+                }
+              }),
+            ),
           );
           for (const settled of attachResults) {
-            if (settled.status === "fulfilled") {
-              this.announceAttachedTab(
-                settled.value.tabId,
-                settled.value.targetId,
-                settled.value.sessionId,
-                {
-                  onlyAutoAttach: false,
-                  onlyClient: client,
-                },
-              );
-            } else {
+            if (settled.status === "rejected") {
               log.warn(`setAutoAttach attach failed: ${String(settled.reason)}`);
             }
           }
@@ -804,52 +998,44 @@ export class ExtensionRelayBridge {
           this.respondError(client, request, "targetId is required", -32602);
           return;
         }
-        const attached = await this.ensureTabAttached(found.tabId);
-        if (!this.clients.has(client)) {
-          return;
-        }
-        if (
-          found.tab.target?.sessionId !== attached.sessionId ||
-          (request.sessionId && this.browserSessions.get(request.sessionId) !== client)
-        ) {
-          throw new Error("Target attachment retired");
-        }
-        // Explicit attaches, including ordinary browser-root requests, own
-        // a fresh logical session even when this client already auto-attached.
-        const sessionId = `openclaw-tab-${found.tabId}-${this.nextSessionOrdinal++}`;
-        this.sessions.announce(
-          client,
-          sessionId,
-          attached.sessionId,
-          {
+        await this.withAttachedTab(client, found.tabId, (attached) => {
+          if (attached.targetId !== targetId) {
+            throw new Error("Requested native target changed during attachment");
+          }
+          if (
+            found.tab.target?.sessionId !== attached.sessionId ||
+            (request.sessionId && this.browserSessions.get(request.sessionId) !== client)
+          ) {
+            throw new Error("Target attachment retired");
+          }
+          const sessionId = `openclaw-tab-${found.tabId}-${this.nextSessionOrdinal++}`;
+          this.sessions.announce(
+            client,
             sessionId,
-            targetInfo: this.targetInfoForTab(found.tab, attached.targetId),
-            waitingForDebugger: false,
-          },
-          request.sessionId,
-        );
-        this.respond(client, request, { sessionId });
+            attached.sessionId,
+            {
+              sessionId,
+              targetInfo: this.targetInfoForTab(found.tab, attached.targetId),
+              waitingForDebugger: false,
+            },
+            request.sessionId,
+          );
+          this.respond(client, request, { sessionId });
+        });
         return;
       }
       case "Target.detachFromTarget": {
         const sessionId = request.params?.sessionId as string | undefined;
         if (sessionId && this.browserSessions.get(sessionId) === client) {
           this.browserSessions.delete(sessionId);
-          this.sessions.detachChildren(client, sessionId);
+          await this.sessions.detachChildren(client, sessionId);
         } else {
           const session = sessionId ? client.sessions.get(sessionId) : undefined;
           if (!sessionId || !session) {
             this.respondError(client, request, `Session not found: ${String(sessionId)}`, -32001);
             return;
           }
-          const tabId = session.physical.tabId;
-          this.sessions.detach(client, sessionId);
-          const tab = this.tabs.get(tabId);
-          if (!this.sessions.hasTabSessions(tabId) && tab?.target?.sessionId) {
-            this.sessions.retire(tab.target.sessionId, tab.target.id);
-            tab.target.sessionId = undefined;
-            await this.callExtension({ type: "detach", tabId }).catch(() => {});
-          }
+          await this.sessions.detach(client, sessionId);
         }
         this.respond(client, request, {});
         return;
@@ -869,48 +1055,45 @@ export class ExtensionRelayBridge {
         if (this.extension !== extension) {
           return;
         }
-        if (!this.clients.has(client)) {
-          // The extension has already handed off; without an acknowledgement
-          // protocol we cannot reclaim the tab, but an idle relay can drop its banner.
-          if (
-            this.clients.size === 0 &&
-            typeof created?.tabId === "number" &&
-            typeof created.targetId === "string"
-          ) {
-            void this.callExtension({ type: "detach", tabId: created.tabId }).catch(() => {});
-          }
-          return;
-        }
         if (typeof created?.tabId !== "number") {
           this.respondError(client, request, "extension did not return a tabId for createTab");
           return;
         }
         const tabId = created.tabId;
+        if (!this.clients.has(client) && !this.tabs.has(tabId)) {
+          // An abandoned creator never publishes an invented inventory entry.
+          // No tab record means no pending/delivered peer can own this handoff.
+          if (typeof created.targetId === "string") {
+            void this.callExtension({ type: "detach", tabId }).catch((error: unknown) =>
+              log.warn(`Abandoned creation cleanup failed: ${String(error)}`),
+            );
+          }
+          return;
+        }
         if (!this.tabs.has(tabId)) {
           this.tabs.set(tabId, {
             info: { tabId, url, title: "", active: false },
+            claimants: new Set(),
             restoreAttachment: false,
           });
         }
         // Store 2.2.0 returns only tabId and still needs the separate attach.
         // New workers own create/group/attach/rollback and return the attachment.
-        const attached = await this.ensureTabAttached(
+        await this.withAttachedTab(
+          client,
           tabId,
+          (attached) => {
+            this.announceAttachedTab(tabId, attached.targetId, attached.sessionId, {
+              onlyAutoAttach: true,
+            });
+            this.announceAttachedTab(tabId, attached.targetId, attached.sessionId, {
+              onlyAutoAttach: false,
+              onlyClient: client,
+            });
+            this.respond(client, request, { targetId: attached.targetId });
+          },
           typeof created.targetId === "string" ? created.targetId : undefined,
         );
-        if (this.extension !== extension || !this.clients.has(client)) {
-          this.detachAllWhenIdle();
-          return;
-        }
-        // Announce before responding, mirroring Chrome's event-then-result order.
-        this.announceAttachedTab(tabId, attached.targetId, attached.sessionId, {
-          onlyAutoAttach: true,
-        });
-        this.announceAttachedTab(tabId, attached.targetId, attached.sessionId, {
-          onlyAutoAttach: false,
-          onlyClient: client,
-        });
-        this.respond(client, request, { targetId: attached.targetId });
         return;
       }
       case "Target.closeTarget": {
@@ -981,10 +1164,10 @@ export class ExtensionRelayBridge {
     this.extension?.socket.close(1001, "relay stopped");
     this.extension = null;
     this.connectionEvents.dispatchEvent(new Event("ready"));
+    this.sessions.dispose();
     for (const client of this.clients) {
       client.socket.close(1001, "relay stopped");
     }
-    this.sessions.dispose();
     this.clients.clear();
     this.browserSessions.clear();
     this.tabs.clear();

--- a/extensions/browser/src/browser/extension-relay/relay-fetch.test.ts
+++ b/extensions/browser/src/browser/extension-relay/relay-fetch.test.ts
@@ -1,0 +1,426 @@
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
+import { asOptionalRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { describe, expect, it, onTestFinished, vi } from "vitest";
+import { RelayFetch } from "./relay-fetch.js";
+
+type Sender = ConstructorParameters<typeof RelayFetch>[0];
+
+function stringField(value: unknown, key: string): string {
+  const field = asOptionalRecord(value)?.[key];
+  if (typeof field !== "string") {
+    throw new Error(`Missing string ${key}`);
+  }
+  return field;
+}
+
+function fixture(implementation: Sender = async () => ({})) {
+  const send = vi.fn<Sender>(implementation);
+  const fetch = new RelayFetch(send);
+  onTestFinished(() => fetch.dispose());
+  const owner = {};
+  const events: Array<{ method: string; params: unknown }> = [];
+  const emit = (method: string, params: unknown) => events.push({ method, params });
+  function command(method: string, params?: Record<string, unknown>, caller = owner) {
+    const result = fetch.command(caller, emit, method, params);
+    if (!result) {
+      throw new Error(`Unexpected unhandled command: ${method}`);
+    }
+    return result;
+  }
+  function pause(nativeId: string, params: Record<string, unknown> = {}, auth = false) {
+    fetch.event(auth ? "Fetch.authRequired" : "Fetch.requestPaused", {
+      requestId: nativeId,
+      ...params,
+    });
+    return stringField(events.at(-1)?.params, "requestId");
+  }
+  return { fetch, send, owner, emit, events, command, pause };
+}
+
+describe("RelayFetch request and stream ownership", () => {
+  it("keeps response-body reads nonterminal and does not serialize another request", async () => {
+    const started = createDeferred<void>();
+    const body = createDeferred<unknown>();
+    const f = fixture(async (method) => {
+      if (method === "Fetch.getResponseBody") {
+        started.resolve();
+        return body.promise;
+      }
+      return {};
+    });
+    await f.command("Fetch.enable");
+    const response = f.pause("response", { responseStatusCode: 200 });
+    const reading = f.command("Fetch.getResponseBody", { requestId: response });
+    await started.promise;
+    const other = f.pause("other");
+    await f.command("Fetch.continueRequest", { requestId: other });
+    await expect(f.command("Fetch.continueResponse", { requestId: response })).rejects.toThrow(
+      /in flight/,
+    );
+    body.resolve({ body: "ok", base64Encoded: false });
+    await expect(reading).resolves.toEqual({ body: "ok", base64Encoded: false });
+    await f.command("Fetch.continueResponse", { requestId: response });
+  });
+
+  it.each(["auth", "response"])(
+    "does not let an old continuation erase a replacement %s pause",
+    async (stage) => {
+      const started = createDeferred<void>();
+      const continued = createDeferred<unknown>();
+      const f = fixture(async (method) => {
+        if (method === "Fetch.continueRequest") {
+          started.resolve();
+          return continued.promise;
+        }
+        return {};
+      });
+      await f.command("Fetch.enable");
+      const requestId = f.pause("same");
+      const first = f.command("Fetch.continueRequest", { requestId });
+      await started.promise;
+      const next = f.pause(
+        "same",
+        stage === "response" ? { responseErrorReason: "Failed" } : {},
+        stage === "auth",
+      );
+      continued.resolve({});
+      await first;
+      const method = stage === "auth" ? "Fetch.continueWithAuth" : "Fetch.failRequest";
+      const params =
+        stage === "auth"
+          ? { authChallengeResponse: { response: "CancelAuth" } }
+          : { errorReason: "Aborted" };
+      await f.command(method, { requestId: next, ...params });
+      expect(f.send.mock.calls.at(-1)).toEqual([method, { requestId: "same", ...params }]);
+    },
+  );
+
+  it("prefixes redirect ids per lease and rejects stale ids after replacement", async () => {
+    const f = fixture();
+    await f.command("Fetch.enable");
+    const first = f.pause("job.0");
+    await f.command("Fetch.continueRequest", { requestId: first });
+    f.pause("job.1", { redirectedRequestId: "job.0", networkId: "network" });
+    expect(f.events.at(-1)?.params).toMatchObject({
+      redirectedRequestId: first,
+      networkId: "network",
+    });
+    await f.command("Fetch.disable");
+    await f.command("Fetch.enable");
+    const replacement = f.pause("job.0");
+    expect(replacement).not.toBe(first);
+    await expect(f.command("Fetch.continueRequest", { requestId: first })).rejects.toThrow(
+      /requestId/,
+    );
+  });
+
+  it("blocks explicit disable while a taken stream pause is unresolved", async () => {
+    const f = fixture(async (method) =>
+      method === "Fetch.takeResponseBodyAsStream" ? { stream: "native" } : {},
+    );
+    await f.command("Fetch.enable");
+    const requestId = f.pause("stream", { responseStatusCode: 200 });
+    const handle = stringField(
+      await f.command("Fetch.takeResponseBodyAsStream", { requestId }),
+      "stream",
+    );
+    await expect(f.command("Fetch.disable")).rejects.toThrow(/failed or fulfilled/);
+    await expect(f.command("Fetch.enable", undefined, {})).rejects.toThrow(/owned/);
+    await f.command("Fetch.failRequest", { requestId, errorReason: "Aborted" });
+    await f.command("Fetch.disable");
+    expect(
+      f.fetch.command(f.owner, f.emit, "IO.read", { handle: "native-unrelated" }),
+    ).toBeUndefined();
+    await f.command("IO.close", { handle });
+  });
+
+  it("retires a minted stream handle even when IO.close fails", async () => {
+    const closeError = new Error("close failed");
+    const f = fixture(async (method) => {
+      if (method === "Fetch.takeResponseBodyAsStream") {
+        return { stream: "native" };
+      }
+      if (method === "IO.close") {
+        throw closeError;
+      }
+      return {};
+    });
+    await f.command("Fetch.enable");
+    const requestId = f.pause("stream", { responseStatusCode: 200 });
+    const handle = stringField(
+      await f.command("Fetch.takeResponseBodyAsStream", { requestId }),
+      "stream",
+    );
+    await expect(f.command("IO.close", { handle })).rejects.toBe(closeError);
+    const before = f.send.mock.calls.length;
+    await expect(f.command("IO.close", { handle })).rejects.toThrow(/stream handle/);
+    expect(f.send).toHaveBeenCalledTimes(before);
+  });
+
+  it("serializes stream reads and retires readability after an ambiguous failure", async () => {
+    const readStarted = createDeferred<void>();
+    const read = createDeferred<unknown>();
+    const failure = new Error("read completion unknown");
+    const f = fixture(async (method) => {
+      if (method === "Fetch.takeResponseBodyAsStream") {
+        return { stream: "native" };
+      }
+      if (method === "IO.read") {
+        readStarted.resolve();
+        return read.promise;
+      }
+      return {};
+    });
+    await f.command("Fetch.enable");
+    const requestId = f.pause("stream", { responseStatusCode: 200 });
+    const handle = stringField(
+      await f.command("Fetch.takeResponseBodyAsStream", { requestId }),
+      "stream",
+    );
+    const reading = f.command("IO.read", { handle });
+    await readStarted.promise;
+    await expect(f.command("IO.read", { handle })).rejects.toThrow(/read in flight/);
+    read.reject(failure);
+    await expect(reading).rejects.toBe(failure);
+    const beforeRetry = f.send.mock.calls.length;
+    await expect(f.command("IO.read", { handle })).rejects.toThrow(/no longer readable/);
+    expect(f.send).toHaveBeenCalledTimes(beforeRetry);
+    await f.command("IO.close", { handle });
+  });
+});
+
+describe("RelayFetch uncertain state and retirement", () => {
+  class CompletedLookingError extends Error {}
+
+  it.each([
+    ["initial enable", false, "Fetch.enable"],
+    ["enable update", true, "Fetch.enable"],
+    ["request resolution", true, "Fetch.continueRequest"],
+    ["explicit disable", true, "Fetch.disable"],
+  ])("fences every physical Fetch error from %s", async (_label, preEnable, method) => {
+    const failure = new CompletedLookingError("native command returned an error");
+    const f = fixture();
+    if (preEnable) {
+      await f.command("Fetch.enable");
+    }
+    const params =
+      method === "Fetch.continueRequest" ? { requestId: f.pause("pending") } : undefined;
+    f.send.mockRejectedValueOnce(failure);
+    await expect(f.command(method, params)).rejects.toBe(failure);
+    const before = f.send.mock.calls.length;
+    await expect(f.command("Fetch.enable", undefined, {})).rejects.toBe(failure);
+    await expect(f.command("Fetch.disable")).rejects.toBe(failure);
+    await expect(f.fetch.close(f.owner)).rejects.toBe(failure);
+    expect(f.send).toHaveBeenCalledTimes(before);
+    const eventCount = f.events.length;
+    f.fetch.event("Fetch.requestPaused", { requestId: "late" });
+    expect(f.events).toHaveLength(eventCount);
+  });
+
+  it("bounds owner-close to one pause snapshot and disables after cleanup", async () => {
+    const cleanupStarted = createDeferred<void>();
+    const cleanup = createDeferred<unknown>();
+    const f = fixture(async (method, params) => {
+      if (method === "Fetch.failRequest" && params?.requestId === "first") {
+        cleanupStarted.resolve();
+        return cleanup.promise;
+      }
+      return {};
+    });
+    await f.command("Fetch.enable");
+    f.pause("first");
+    const closing = f.fetch.close(f.owner);
+    await cleanupStarted.promise;
+    const eventCount = f.events.length;
+    f.fetch.event("Fetch.requestPaused", { requestId: "late" });
+    expect(f.events).toHaveLength(eventCount);
+    cleanup.resolve({});
+    await closing;
+    expect(f.send.mock.calls.slice(1)).toEqual([
+      ["Fetch.failRequest", { requestId: "first", errorReason: "Aborted" }],
+      ["Fetch.disable", undefined],
+    ]);
+  });
+
+  it("closes residual streams when owner close overtakes explicit disable", async () => {
+    const disableStarted = createDeferred<void>();
+    const disable = createDeferred<unknown>();
+    const f = fixture(async (method) => {
+      if (method === "Fetch.takeResponseBodyAsStream") {
+        return { stream: "native-stream" };
+      }
+      if (method === "Fetch.disable") {
+        disableStarted.resolve();
+        return disable.promise;
+      }
+      return {};
+    });
+    await f.command("Fetch.enable");
+    const requestId = f.pause("stream", { responseStatusCode: 200 });
+    await f.command("Fetch.takeResponseBodyAsStream", { requestId });
+    await f.command("Fetch.failRequest", { requestId, errorReason: "Aborted" });
+    const disabling = f.command("Fetch.disable");
+    await disableStarted.promise;
+    const closing = f.fetch.close(f.owner);
+    disable.resolve({});
+    await Promise.all([disabling, closing]);
+    expect(f.send.mock.calls.at(-1)).toEqual(["IO.close", { handle: "native-stream" }]);
+  });
+
+  it("prepares physical retirement without awaiting a hanging operation", async () => {
+    const bodyStarted = createDeferred<void>();
+    const body = createDeferred<unknown>();
+    const f = fixture(async (method) => {
+      if (method === "Fetch.getResponseBody") {
+        bodyStarted.resolve();
+        return body.promise;
+      }
+      if (method === "Fetch.takeResponseBodyAsStream") {
+        return { stream: "native-stream" };
+      }
+      return {};
+    });
+    await f.command("Fetch.enable");
+    const streamPause = f.pause("stream", { responseStatusCode: 200 });
+    const handle = stringField(
+      await f.command("Fetch.takeResponseBodyAsStream", { requestId: streamPause }),
+      "stream",
+    );
+    f.pause("request");
+    f.pause("auth", {}, true);
+    const pendingBody = f.pause("body", { responseStatusCode: 200 });
+    const bodyRead = f.command("Fetch.getResponseBody", { requestId: pendingBody });
+    await bodyStarted.promise;
+
+    const retirement = f.fetch.prepareRetirement(100);
+    expect(f.fetch.prepareRetirement(100)).toBe(retirement);
+    await expect(retirement).resolves.toEqual({ errors: [] });
+    expect(f.send.mock.calls.slice(3)).toEqual([
+      ["Fetch.failRequest", { requestId: "stream", errorReason: "Aborted" }],
+      ["Fetch.failRequest", { requestId: "request", errorReason: "Aborted" }],
+      [
+        "Fetch.continueWithAuth",
+        { requestId: "auth", authChallengeResponse: { response: "CancelAuth" } },
+      ],
+      ["IO.close", { handle: "native-stream" }],
+    ]);
+    expect(f.send.mock.calls.some(([method]) => method === "Fetch.disable")).toBe(false);
+    const eventCount = f.events.length;
+    f.fetch.event("Fetch.requestPaused", { requestId: "late" });
+    expect(f.events).toHaveLength(eventCount);
+    await expect(f.command("IO.read", { handle })).rejects.toThrow(/detached/);
+
+    body.resolve({ body: "late", base64Encoded: false });
+    await expect(bodyRead).rejects.toThrow(/retired/);
+  });
+
+  it("returns retirement cleanup errors without attempting Fetch.disable", async () => {
+    const failure = new Error("cleanup failed");
+    const f = fixture(async (method) => {
+      if (method === "Fetch.failRequest") {
+        throw failure;
+      }
+      return {};
+    });
+    await f.command("Fetch.enable");
+    f.pause("request");
+    await expect(f.fetch.prepareRetirement(100)).resolves.toEqual({
+      errors: [failure],
+    });
+    expect(f.send.mock.calls.map(([method]) => method)).toEqual([
+      "Fetch.enable",
+      "Fetch.failRequest",
+    ]);
+  });
+
+  it("bounds cleanup commands issued during physical retirement", async () => {
+    const cleanup = createDeferred<unknown>();
+    const f = fixture(async (method) => {
+      if (method === "Fetch.failRequest") {
+        return cleanup.promise;
+      }
+      return {};
+    });
+    await f.command("Fetch.enable");
+    f.pause("request");
+    const result = await f.fetch.prepareRetirement(10);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0]).toEqual(
+      expect.objectContaining({ message: expect.stringMatching(/timed out/) }),
+    );
+    expect(f.send.mock.calls.map(([method]) => method)).toEqual([
+      "Fetch.enable",
+      "Fetch.failRequest",
+    ]);
+  });
+});
+
+describe("RelayFetch native completion boundaries", () => {
+  it.each(["IO.read", "IO.close"])(
+    "rejects raw Fetch handles for every logical caller: %s",
+    async (method) => {
+      const f = fixture(async (name) =>
+        name === "Fetch.takeResponseBodyAsStream" ? { stream: "native-stream" } : {},
+      );
+      await f.command("Fetch.enable");
+      const requestId = f.pause("response", { responseStatusCode: 200 });
+      const handle = stringField(
+        await f.command("Fetch.takeResponseBodyAsStream", { requestId }),
+        "stream",
+      );
+      for (const caller of [f.owner, {}]) {
+        const before = f.send.mock.calls.length;
+        await expect(f.command(method, { handle: "native-stream" }, caller)).rejects.toThrow(
+          /stream handle/,
+        );
+        expect(f.send).toHaveBeenCalledTimes(before);
+      }
+      await expect(f.command(method, { handle }, {})).rejects.toThrow(/stream handle/);
+      expect(
+        f.fetch.command({}, f.emit, method, { handle: "other-domain-stream" }),
+      ).toBeUndefined();
+      await f.command("IO.close", { handle });
+      await expect(f.command(method, { handle })).rejects.toThrow(/stream handle/);
+    },
+  );
+
+  it("keeps raw handle ownership while native close completion is unknown", async () => {
+    const gate = createDeferred<unknown>();
+    const f = fixture(async (method) =>
+      method === "Fetch.takeResponseBodyAsStream"
+        ? { stream: "native-stream" }
+        : method === "IO.close"
+          ? gate.promise
+          : {},
+    );
+    await f.command("Fetch.enable");
+    const requestId = f.pause("response", { responseStatusCode: 200 });
+    const handle = stringField(
+      await f.command("Fetch.takeResponseBodyAsStream", { requestId }),
+      "stream",
+    );
+    const closing = f.command("IO.close", { handle });
+    const rejected = expect(closing).rejects.toThrow("close completion unknown");
+    gate.reject(new Error("close completion unknown"));
+    await rejected;
+    const before = f.send.mock.calls.length;
+    await expect(f.command("IO.read", { handle: "native-stream" }, {})).rejects.toThrow(
+      /stream handle/,
+    );
+    await expect(f.command("IO.close", { handle })).rejects.toThrow(/stream handle/);
+    expect(f.send).toHaveBeenCalledTimes(before);
+  });
+
+  it.each(["Fetch.getResponseBody", "Fetch.takeResponseBodyAsStream"])(
+    "never mutates a request whose %s completion is unknown",
+    async (method) => {
+      const f = fixture();
+      await f.command("Fetch.enable");
+      const requestId = f.pause("body", { responseStatusCode: 200 });
+      f.send.mockRejectedValueOnce(new Error("body completion unknown"));
+      await expect(f.command(method, { requestId })).rejects.toThrow("body completion unknown");
+      await f.fetch.prepareRetirement(100);
+      expect(f.send.mock.calls.map(([name]) => name)).toEqual(["Fetch.enable", method]);
+    },
+  );
+});

--- a/extensions/browser/src/browser/extension-relay/relay-fetch.ts
+++ b/extensions/browser/src/browser/extension-relay/relay-fetch.ts
@@ -1,0 +1,504 @@
+import { randomUUID } from "node:crypto";
+import { asOptionalRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
+
+type PhysicalSender = (method: string, params?: Record<string, unknown>) => Promise<unknown>;
+type EventSender = (method: string, params: unknown) => void;
+type PauseKind = "request" | "auth" | "response" | "buffered" | "stream";
+type Pause = { nativeId: string; kind: PauseKind; pending?: Promise<unknown> };
+type Lease = {
+  owner: object;
+  prefix: string;
+  emit: EventSender;
+  pauses: Map<string, Pause>;
+  operations: Set<Promise<unknown>>;
+  control: Promise<void>;
+  acceptEvents: boolean;
+};
+type FetchState =
+  | { kind: "idle" | "gone" }
+  | { kind: "owned"; lease: Lease }
+  | { kind: "releasing"; lease: Lease; reason: "disable" | "close"; done: Promise<void> }
+  | { kind: "uncertain"; lease: Lease; error: unknown }
+  | { kind: "retiring"; lease?: Lease };
+type OwnedStream = {
+  owner: object;
+  nativeHandle: string;
+  readable: boolean;
+  reading: boolean;
+  closing?: Promise<unknown>;
+};
+
+const STREAM_PREFIX = "openclaw-fetch-stream:";
+const REQUEST_COMMANDS = new Set([
+  "Fetch.continueRequest",
+  "Fetch.continueResponse",
+  "Fetch.continueWithAuth",
+  "Fetch.failRequest",
+  "Fetch.fulfillRequest",
+  "Fetch.getResponseBody",
+  "Fetch.takeResponseBodyAsStream",
+]);
+
+/** One physical Fetch domain; exact logical-session objects own its exclusive lease. */
+export class RelayFetch {
+  private readonly instanceId = randomUUID();
+  private nextLease = 0;
+  private nextStream = 0;
+  private state: FetchState = { kind: "idle" };
+  private readonly streams = new Map<string, OwnedStream>();
+  private readonly closedOwners = new WeakSet<object>();
+  private retirement?: Promise<{ errors: unknown[] }>;
+
+  // Integration must bind this sender to the exact physical attachment generation,
+  // reject stale dispatch, and reject outstanding work when that generation ends.
+  constructor(private readonly send: PhysicalSender) {}
+
+  command(
+    owner: object,
+    emit: EventSender,
+    method: string,
+    params: unknown,
+  ): Promise<unknown> | undefined {
+    const input = asOptionalRecord(params);
+    const handle = input?.handle;
+    const ownedIO =
+      (method === "IO.read" || method === "IO.close") &&
+      typeof handle === "string" &&
+      (handle.startsWith(STREAM_PREFIX) ||
+        [...this.streams.values()].some((stream) => stream.nativeHandle === handle));
+    if (!method.startsWith("Fetch.") && !ownedIO) {
+      return undefined;
+    }
+    try {
+      if (
+        this.state.kind === "gone" ||
+        this.state.kind === "retiring" ||
+        this.closedOwners.has(owner)
+      ) {
+        throw new Error("Fetch session detached");
+      }
+      if (ownedIO && typeof handle === "string") {
+        return this.streamCommand(owner, method, handle, input);
+      }
+      if (method === "Fetch.enable") {
+        return this.enable(owner, emit, input);
+      }
+      if (method === "Fetch.disable") {
+        if (!("lease" in this.state) || this.state.lease.owner !== owner) {
+          return Promise.resolve({});
+        }
+        return this.release(this.state.lease, "disable").then(() => ({}));
+      }
+      if (!REQUEST_COMMANDS.has(method)) {
+        throw new Error(`Unsupported Fetch command: ${method}`);
+      }
+      const lease = this.ownedLease(owner);
+      const requestId = input?.requestId;
+      const nativeId =
+        typeof requestId === "string" && requestId.startsWith(lease.prefix)
+          ? requestId.slice(lease.prefix.length)
+          : undefined;
+      const pause = nativeId === undefined ? undefined : lease.pauses.get(nativeId);
+      if (!pause) {
+        throw new Error("Invalid Fetch requestId for this session");
+      }
+      this.validatePause(pause, method, input);
+      return this.runPause(lease, pause, method, input);
+    } catch (error) {
+      return Promise.reject(error instanceof Error ? error : new Error(String(error)));
+    }
+  }
+
+  event(method: string, params: unknown): boolean {
+    if (method !== "Fetch.requestPaused" && method !== "Fetch.authRequired") {
+      return false;
+    }
+    const input = asOptionalRecord(params);
+    const state = this.state;
+    const lease = "lease" in state ? state.lease : undefined;
+    if (!lease?.acceptEvents || typeof input?.requestId !== "string") {
+      return true;
+    }
+    const kind =
+      method === "Fetch.authRequired"
+        ? "auth"
+        : input.responseStatusCode !== undefined || input.responseErrorReason !== undefined
+          ? "response"
+          : "request";
+    const nativeId = input.requestId;
+    lease.pauses.set(nativeId, { nativeId, kind });
+    if (this.state.kind === "owned" && !this.closedOwners.has(lease.owner)) {
+      const redirectedRequestId =
+        typeof input.redirectedRequestId === "string"
+          ? lease.prefix + input.redirectedRequestId
+          : undefined;
+      lease.emit(method, {
+        ...input,
+        requestId: lease.prefix + nativeId,
+        ...(redirectedRequestId === undefined ? {} : { redirectedRequestId }),
+      });
+    }
+    return true;
+  }
+
+  async close(owner: object): Promise<void> {
+    this.closedOwners.add(owner);
+    const state = this.state;
+    if (state.kind === "uncertain" && state.lease.owner === owner) {
+      throw state.error;
+    }
+    const lease = "lease" in state ? state.lease : undefined;
+    if (lease?.owner === owner) {
+      await this.release(lease, "close");
+    }
+    const errors = await this.closeStreamSnapshot(
+      [...this.streams].filter(([, stream]) => stream.owner === owner),
+    );
+    if (errors.length > 0) {
+      throw new AggregateError(errors, "Fetch stream cleanup failed");
+    }
+  }
+
+  /**
+   * Stop admission and run bounded best-effort cleanup before the physical owner detaches.
+   * Existing hung commands are skipped; transport loss cannot guarantee fail-closed cancellation.
+   */
+  prepareRetirement(timeoutMs: number): Promise<{ errors: unknown[] }> {
+    if (this.retirement) {
+      return this.retirement;
+    }
+    const lease = "lease" in this.state ? this.state.lease : undefined;
+    if (lease) {
+      this.closedOwners.add(lease.owner);
+      lease.acceptEvents = false;
+    }
+    const pauses = lease ? [...lease.pauses.values()].filter((pause) => !pause.pending) : [];
+    lease?.pauses.clear();
+    const streams = [...this.streams];
+    this.state = { kind: "retiring", ...(lease ? { lease } : {}) };
+    this.retirement = Promise.resolve().then(async () => {
+      const errors: unknown[] = [];
+      const cleanup = [
+        ...pauses.map((pause) => this.sendPauseCleanup(pause)),
+        ...streams.map(([handle, stream]) => this.closeStream(handle, stream)),
+      ];
+      const settled = Promise.all(
+        cleanup.map(async (operation) => {
+          try {
+            await operation;
+          } catch (error) {
+            errors.push(error);
+          }
+        }),
+      );
+      let timer: NodeJS.Timeout | undefined;
+      const timedOut = await Promise.race([
+        settled.then(() => false),
+        new Promise<true>((resolve) => {
+          timer = setTimeout(() => resolve(true), timeoutMs);
+          timer.unref?.();
+        }),
+      ]);
+      if (timer) {
+        clearTimeout(timer);
+      }
+      return {
+        errors: [
+          ...errors,
+          ...(timedOut
+            ? [new Error(`Fetch retirement cleanup timed out after ${timeoutMs}ms`)]
+            : []),
+        ],
+      };
+    });
+    return this.retirement;
+  }
+
+  /** Physical loss cannot be canceled through a successor transport. */
+  dispose(): void {
+    const state = this.state;
+    const lease = "lease" in state ? state.lease : undefined;
+    if (lease) {
+      lease.acceptEvents = false;
+      lease.pauses.clear();
+    }
+    this.streams.clear();
+    this.state = { kind: "gone" };
+  }
+
+  private ownedLease(owner: object): Lease {
+    if (this.state.kind === "uncertain") {
+      throw this.state.error;
+    }
+    if (this.state.kind !== "owned" || this.state.lease.owner !== owner) {
+      throw new Error("Fetch interception is owned by another session or is being released");
+    }
+    return this.state.lease;
+  }
+
+  private assertLiveLease(lease: Lease): void {
+    if (!("lease" in this.state) || this.state.lease !== lease || this.state.kind === "retiring") {
+      throw new Error("Fetch attachment or lease retired");
+    }
+    if (this.state.kind === "uncertain") {
+      throw this.state.error;
+    }
+  }
+
+  private fence(lease: Lease, error: unknown): void {
+    if ("lease" in this.state && this.state.lease === lease && this.state.kind !== "retiring") {
+      lease.acceptEvents = false;
+      this.state = { kind: "uncertain", lease, error };
+    }
+  }
+
+  private async nativeFetch(
+    lease: Lease,
+    method: string,
+    params?: Record<string, unknown>,
+  ): Promise<unknown> {
+    this.assertLiveLease(lease);
+    try {
+      const result = await this.send(method, params);
+      this.assertLiveLease(lease);
+      return result;
+    } catch (error) {
+      // A protocol error can follow a partial native mutation or post-command access check.
+      this.fence(lease, error);
+      throw error;
+    }
+  }
+
+  private enable(
+    owner: object,
+    emit: EventSender,
+    params?: Record<string, unknown>,
+  ): Promise<unknown> {
+    if (this.state.kind === "idle") {
+      this.state = {
+        kind: "owned",
+        lease: {
+          owner,
+          emit,
+          prefix: `openclaw-fetch:${this.instanceId}:${++this.nextLease}:`,
+          pauses: new Map(),
+          operations: new Set(),
+          control: Promise.resolve(),
+          acceptEvents: true,
+        },
+      };
+    }
+    const lease = this.ownedLease(owner);
+    const operation = lease.control.then(async () => {
+      this.assertLiveLease(lease);
+      if (this.state.kind !== "owned") {
+        throw new Error("Fetch enable superseded by release");
+      }
+      const result = await this.nativeFetch(lease, "Fetch.enable", params);
+      this.assertLiveLease(lease);
+      if (this.state.kind !== "owned" || this.closedOwners.has(owner)) {
+        throw new Error("Fetch enable superseded by release");
+      }
+      return result;
+    });
+    this.trackOperation(lease, operation);
+    lease.control = operation.then(
+      () => undefined,
+      () => undefined,
+    );
+    return operation;
+  }
+
+  private validatePause(pause: Pause, method: string, params?: Record<string, unknown>): void {
+    if (pause.pending) {
+      throw new Error("Fetch request already has a command in flight");
+    }
+    const auth = method === "Fetch.continueWithAuth";
+    const body = method === "Fetch.getResponseBody" || method === "Fetch.takeResponseBodyAsStream";
+    const response = pause.kind === "response" || pause.kind === "buffered";
+    if (
+      auth !== (pause.kind === "auth") ||
+      ((body || method === "Fetch.continueResponse") && !response) ||
+      (method === "Fetch.takeResponseBodyAsStream" && pause.kind !== "response") ||
+      (pause.kind === "stream" &&
+        method !== "Fetch.failRequest" &&
+        !(method === "Fetch.fulfillRequest" && typeof params?.body === "string"))
+    ) {
+      throw new Error(`Invalid Fetch request stage for ${method}`);
+    }
+  }
+
+  private runPause(
+    lease: Lease,
+    pause: Pause,
+    method: string,
+    params?: Record<string, unknown>,
+  ): Promise<unknown> {
+    const operation: Promise<unknown> = Promise.resolve().then(async () => {
+      this.assertLiveLease(lease);
+      if (lease.pauses.get(pause.nativeId) !== pause) {
+        throw new Error("Fetch pause retired before command dispatch");
+      }
+      let result = await this.nativeFetch(lease, method, { ...params, requestId: pause.nativeId });
+      this.assertLiveLease(lease);
+      if (method === "Fetch.takeResponseBodyAsStream") {
+        const response = asOptionalRecord(result);
+        if (typeof response?.stream !== "string") {
+          const error = new Error("Fetch stream response did not contain a stream handle");
+          this.fence(lease, error);
+          throw error;
+        }
+        const handle = `${STREAM_PREFIX}${this.instanceId}:${++this.nextStream}`;
+        this.streams.set(handle, {
+          owner: lease.owner,
+          nativeHandle: response.stream,
+          readable: true,
+          reading: false,
+        });
+        result = { ...response, stream: handle };
+      }
+      if (lease.pauses.get(pause.nativeId) === pause) {
+        if (method === "Fetch.getResponseBody") {
+          pause.kind = "buffered";
+        } else if (method === "Fetch.takeResponseBodyAsStream") {
+          pause.kind = "stream";
+        } else {
+          lease.pauses.delete(pause.nativeId);
+        }
+      }
+      // Only native success proves body acquisition is quiescent. A rejected
+      // relay promise leaves this pause pending until physical retirement.
+      pause.pending = undefined;
+      if (this.closedOwners.has(lease.owner) || this.state.kind === "retiring") {
+        throw new Error("Fetch session closed during command");
+      }
+      return result;
+    });
+    pause.pending = operation;
+    this.trackOperation(lease, operation);
+    return operation;
+  }
+
+  private trackOperation(lease: Lease, operation: Promise<unknown>): void {
+    lease.operations.add(operation);
+    void operation
+      .finally(() => {
+        lease.operations.delete(operation);
+      })
+      .catch(() => {});
+  }
+
+  private release(lease: Lease, reason: "disable" | "close"): Promise<void> {
+    this.assertLiveLease(lease);
+    if (this.state.kind === "releasing") {
+      if (reason === "close") {
+        this.state.reason = "close";
+      }
+      return this.state.done;
+    }
+    const done = Promise.resolve().then(async () => {
+      await lease.control;
+      await Promise.allSettled(lease.operations);
+      this.assertLiveLease(lease);
+      const closeRequested = this.state.kind === "releasing" && this.state.reason === "close";
+      if (!closeRequested && [...lease.pauses.values()].some((pause) => pause.kind === "stream")) {
+        this.state = { kind: "owned", lease };
+        throw new Error(
+          "Fetch.disable requires streamed responses to be failed or fulfilled first",
+        );
+      }
+      lease.acceptEvents = false;
+      if (closeRequested) {
+        const pauses = [...lease.pauses.values()];
+        const streams = [...this.streams].filter(([, stream]) => stream.owner === lease.owner);
+        lease.pauses.clear();
+        // Events racing this bounded snapshot are consumed and dropped. Native disable may resume them.
+        const settled = await Promise.allSettled([
+          ...pauses.map((pause) => this.sendPauseCleanup(pause)),
+          ...streams.map(([handle, stream]) => this.closeStream(handle, stream)),
+        ]);
+        const errors = settled.flatMap((result) =>
+          result.status === "rejected" ? [result.reason] : [],
+        );
+        if (errors.length > 0) {
+          const error = new AggregateError(errors, "Fetch owner cleanup failed");
+          this.fence(lease, error);
+          throw error;
+        }
+        await this.nativeFetch(lease, "Fetch.disable");
+        this.state = { kind: "idle" };
+        return;
+      }
+      await this.nativeFetch(lease, "Fetch.disable");
+      lease.pauses.clear();
+      this.state = { kind: "idle" };
+    });
+    this.state = { kind: "releasing", lease, reason, done };
+    return done;
+  }
+
+  private sendPauseCleanup(pause: Pause): Promise<unknown> {
+    return pause.kind === "auth"
+      ? this.send("Fetch.continueWithAuth", {
+          requestId: pause.nativeId,
+          authChallengeResponse: { response: "CancelAuth" },
+        })
+      : this.send("Fetch.failRequest", { requestId: pause.nativeId, errorReason: "Aborted" });
+  }
+
+  private streamCommand(
+    owner: object,
+    method: string,
+    handle: string,
+    params?: Record<string, unknown>,
+  ): Promise<unknown> {
+    const stream = this.streams.get(handle);
+    if (!stream || stream.owner !== owner || stream.closing) {
+      throw new Error("Invalid Fetch stream handle for this session");
+    }
+    if (method === "IO.close") {
+      return this.closeStream(handle, stream);
+    }
+    if (!stream.readable) {
+      throw new Error("Fetch stream is no longer readable");
+    }
+    if (stream.reading) {
+      throw new Error("Fetch stream already has a read in flight");
+    }
+    stream.reading = true;
+    return this.send(method, { ...params, handle: stream.nativeHandle })
+      .then((result) => {
+        if (this.streams.get(handle) !== stream || this.closedOwners.has(owner)) {
+          throw new Error("Fetch stream retired during read");
+        }
+        return result;
+      })
+      .catch((error: unknown) => {
+        // A relay error may follow a native read that already advanced the cursor.
+        stream.readable = false;
+        throw error;
+      })
+      .finally(() => {
+        stream.reading = false;
+      });
+  }
+
+  private closeStream(handle: string, stream: OwnedStream): Promise<unknown> {
+    // Native IO.close removes the handle from its IO context. Only confirmed
+    // success releases the raw-handle claim; uncertain closes stay fenced until detach.
+    stream.readable = false;
+    return (stream.closing ??= this.send("IO.close", { handle: stream.nativeHandle }).then(
+      (result) => {
+        this.streams.delete(handle);
+        return result;
+      },
+    ));
+  }
+
+  private async closeStreamSnapshot(streams: Array<[string, OwnedStream]>): Promise<unknown[]> {
+    const results = await Promise.allSettled(
+      streams.map(([handle, stream]) => this.closeStream(handle, stream)),
+    );
+    return results.flatMap((result) => (result.status === "rejected" ? [result.reason] : []));
+  }
+}

--- a/extensions/browser/src/browser/extension-relay/relay-runtime.test.ts
+++ b/extensions/browser/src/browser/extension-relay/relay-runtime.test.ts
@@ -1,3 +1,4 @@
+import { asOptionalRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { describe, expect, it, onTestFinished } from "vitest";
 import { ExtensionRelayBridge } from "./relay-bridge.js";
 import {
@@ -24,7 +25,7 @@ function fixture() {
   const enabled = new Set<string>();
   const held: number[] = [];
   let hold = false;
-  let denyEnable = false;
+  let accessAllowed = true;
   let contextOffset = -10;
   const extension = wireExtension(bridge, (msg) => {
     if (msg.type === "ping") {
@@ -38,8 +39,8 @@ function fixture() {
     if (msg.type === "cdp") {
       const key = msg.sessionId ?? "root";
       if (msg.method === "Runtime.enable") {
-        if (denyEnable) {
-          return { type: "error", seq: msg.seq, message: "tab 1 access was revoked" };
+        if (!accessAllowed) {
+          return { type: "error", seq: msg.seq, message: "tab access was revoked" };
         }
         // V8 reports existing contexts only on the physical disabled -> enabled transition.
         if (!enabled.has(key)) {
@@ -95,7 +96,33 @@ function fixture() {
       const { sessionId } = announcement.params as { sessionId: string };
       return sessionId;
     }
-    return { socket, handlers, send, request, attach };
+    async function autoAttach(parent: string) {
+      expect(
+        (
+          await request("Target.setAutoAttach", parent, {
+            autoAttach: true,
+            waitForDebuggerOnStart: true,
+            flatten: true,
+          })
+        ).error,
+      ).toBeUndefined();
+    }
+    function child(targetId: string, parent?: string) {
+      const announcement = socket
+        .frames()
+        .findLast(
+          (frame) =>
+            frame.method === "Target.attachedToTarget" &&
+            (parent === undefined || frame.sessionId === parent) &&
+            asOptionalRecord(asOptionalRecord(frame.params)?.targetInfo)?.targetId === targetId,
+        );
+      const id = asOptionalRecord(announcement?.params)?.sessionId;
+      if (typeof id !== "string") {
+        throw new Error("Missing logical child announcement");
+      }
+      return id;
+    }
+    return { socket, handlers, send, request, attach, autoAttach, child };
   }
   function commands(method: string) {
     return extension.socket.frames().filter((frame) => frame.method === method);
@@ -106,8 +133,8 @@ function fixture() {
     event,
     client,
     commands,
-    denyEnable: () => {
-      denyEnable = true;
+    revokeAccess: () => {
+      accessAllowed = false;
     },
     hold: () => {
       hold = true;
@@ -148,22 +175,6 @@ function expectContextBeforeResult(
 }
 
 describe("relay logical Runtime subscriptions", () => {
-  it("does not replay cached contexts when current native admission rejects a late enable", async () => {
-    const f = fixture();
-    const first = f.client();
-    const root = await first.attach();
-    await first.request("Runtime.enable", root);
-    const late = f.client();
-    const lateRoot = await late.attach();
-    // The worker has revoked access, but its tabs/detach notification has not
-    // reached the relay. Native admission must still precede cached replay.
-    f.denyEnable();
-    const response = await late.request("Runtime.enable", lateRoot);
-    expect(response.error).toMatchObject({ message: "tab 1 access was revoked" });
-    expect(created(late.socket, lateRoot)).toEqual([]);
-    expect(created(first.socket, root)).toHaveLength(1);
-  });
-
   it("delivers the live default context to a late client before enable completes without replaying to established clients", async () => {
     const f = fixture();
     const first = f.client();
@@ -201,7 +212,7 @@ describe("relay logical Runtime subscriptions", () => {
     },
   );
 
-  it("validates concurrent enables and delivers each context once to subscribers", async () => {
+  it("admits each concurrent enable and delivers each context once to new subscribers", async () => {
     const f = fixture();
     const first = f.client();
     const second = f.client();
@@ -296,6 +307,11 @@ describe("relay logical Runtime subscriptions", () => {
           .map((frame) => frame.sessionId),
       ).toEqual([root]);
       await c.request("Target.detachFromTarget", parent, { sessionId: alias });
+      expect(c.socket.frames()).toContainEqual({
+        ...(parent ? { sessionId: parent } : {}),
+        method: "Target.detachedFromTarget",
+        params: { sessionId: alias, targetId: "target-1" },
+      });
       expect((await c.request("Runtime.enable", alias)).error).toBeDefined();
       expect(f.commands("Runtime.enable")).toHaveLength(2);
     },
@@ -306,13 +322,15 @@ describe("relay logical Runtime subscriptions", () => {
     const c = f.client();
     const root = await c.attach();
     await c.request("Runtime.enable", root);
+    await c.autoAttach(root);
     f.event("Target.attachedToTarget", {
       sessionId: "child",
       targetInfo: { type: "iframe", targetId: "frame" },
       waitingForDebugger: false,
     });
+    const child = c.child("frame", root);
     f.hold();
-    const pending = c.send("Runtime.enable", "child");
+    const pending = c.send("Runtime.enable", child);
     await flush();
     f.event("Target.detachedFromTarget", { sessionId: "child", targetId: "frame" });
     f.event("Runtime.executionContextCreated", { context: context(4) }, "child");
@@ -321,11 +339,11 @@ describe("relay logical Runtime subscriptions", () => {
     expect(c.socket.frames().find((frame) => frame.id === pending)?.error).toBeDefined();
     expect(created(c.socket, root).map((frame) => frame.params)).toEqual([{ context: context(1) }]);
     expect(
-      created(c.socket, "child").some(
+      created(c.socket, child).some(
         (frame) => (frame.params as { context: { id: number } }).context.id === 4,
       ),
     ).toBe(false);
-    expect((await c.request("Runtime.enable", "child")).error).toBeDefined();
+    expect((await c.request("Runtime.enable", child)).error).toBeDefined();
     expect(f.commands("Runtime.enable")).toHaveLength(2);
   });
 
@@ -346,40 +364,45 @@ describe("relay logical Runtime subscriptions", () => {
             ).result as { sessionId: string }
           ).sessionId
         : await second.attach();
+      await first.autoAttach(root);
+      await second.autoAttach(secondRoot);
       f.event("Target.attachedToTarget", {
         sessionId: "child",
         targetInfo: { type: "iframe", targetId: "frame" },
         waitingForDebugger: false,
       });
+      const firstChild = first.child("frame", root);
+      const secondChild = second.child("frame", secondRoot);
+      expect(firstChild).not.toBe(secondChild);
       expect(second.socket.frames()).toContainEqual({
         sessionId: secondRoot,
         method: "Target.attachedToTarget",
         params: {
-          sessionId: "child",
+          sessionId: secondChild,
           targetInfo: { type: "iframe", targetId: "frame" },
           waitingForDebugger: false,
         },
       });
-      await first.request("Runtime.enable", "child");
-      const response = await second.request("Runtime.enable", "child");
-      expectContextBeforeResult(second.socket, "child", response.id, [context(2)]);
-      expect(created(first.socket, "child")).toHaveLength(1);
-      await first.request("Target.detachFromTarget", root, { sessionId: "child" });
+      await first.request("Runtime.enable", firstChild);
+      const response = await second.request("Runtime.enable", secondChild);
+      expectContextBeforeResult(second.socket, secondChild, response.id, [context(2)]);
+      expect(created(first.socket, firstChild)).toHaveLength(1);
+      await first.request("Target.detachFromTarget", root, { sessionId: firstChild });
       expect(first.socket.frames()).toContainEqual({
         sessionId: root,
         method: "Target.detachedFromTarget",
-        params: { sessionId: "child" },
+        params: { sessionId: firstChild, targetId: "frame" },
       });
       f.event("Runtime.executionContextCreated", { context: context(4) }, "child");
-      expect(created(first.socket, "child")).toHaveLength(1);
-      expect(created(second.socket, "child").at(-1)?.params).toEqual({ context: context(4) });
+      expect(created(first.socket, firstChild)).toHaveLength(1);
+      expect(created(second.socket, secondChild).at(-1)?.params).toEqual({ context: context(4) });
       f.event("Target.detachedFromTarget", { sessionId: "child", targetId: "frame" });
       expect(second.socket.frames()).toContainEqual({
         sessionId: secondRoot,
         method: "Target.detachedFromTarget",
-        params: { sessionId: "child", targetId: "frame" },
+        params: { sessionId: secondChild, targetId: "frame" },
       });
-      expect((await second.request("Runtime.enable", "child")).error).toBeDefined();
+      expect((await second.request("Runtime.enable", secondChild)).error).toBeDefined();
       expect(f.commands("Target.detachFromTarget")).toEqual([]);
     },
   );
@@ -425,12 +448,14 @@ describe("relay logical Runtime subscriptions", () => {
         })
       ).result as { sessionId: string }
     ).sessionId;
+    await owner.autoAttach(root);
     f.event("Target.attachedToTarget", {
       sessionId: "child",
       targetInfo: { type: "worker", targetId: "worker" },
     });
+    const child = owner.child("worker", root);
     const foreign = f.client();
-    for (const session of [root, alias, browser, "child", "missing"]) {
+    for (const session of [root, alias, browser, child, "missing"]) {
       expect((await foreign.request("Runtime.evaluate", session)).error).toBeDefined();
       expect(
         (await foreign.request("Target.detachFromTarget", undefined, { sessionId: session })).error,
@@ -524,4 +549,242 @@ describe("relay logical Runtime subscriptions", () => {
       );
     },
   );
+
+  it.each([
+    "extension loss",
+    "extension replacement",
+    "native detach",
+    "access loss",
+    "bridge disposal",
+  ])("retires every logical target identity on %s", async (ending) => {
+    const f = fixture();
+    const c = f.client();
+    const root = await c.attach();
+    const browser = asOptionalRecord(
+      (await c.request("Target.attachToBrowserTarget")).result,
+    )?.sessionId;
+    if (typeof browser !== "string") {
+      throw new Error("Missing browser session");
+    }
+    const alias = asOptionalRecord(
+      (await c.request("Target.attachToTarget", browser, { targetId: "target-1" })).result,
+    )?.sessionId;
+    expect(typeof alias).toBe("string");
+    await c.autoAttach(root);
+    f.event("Target.attachedToTarget", {
+      sessionId: "child",
+      targetInfo: { targetId: "frame", type: "iframe" },
+      waitingForDebugger: false,
+    });
+    const child = c.child("frame", root);
+    await c.autoAttach(child);
+    f.event(
+      "Target.attachedToTarget",
+      {
+        sessionId: "grandchild",
+        targetInfo: { targetId: "worker", type: "worker" },
+        waitingForDebugger: false,
+      },
+      "child",
+    );
+    const grandchild = c.child("worker", child);
+    if (ending === "extension loss") {
+      f.extension.handlers.onClose();
+    }
+    if (ending === "extension replacement") {
+      sendHello(wireExtension(f.bridge).handlers);
+    }
+    if (ending === "native detach") {
+      f.extension.handlers.onMessage(
+        JSON.stringify({ type: "detached", tabId: 1, reason: "target_closed" }),
+      );
+    }
+    if (ending === "access loss") {
+      f.extension.handlers.onMessage(JSON.stringify({ type: "tabs", tabs: [] }));
+    }
+    if (ending === "bridge disposal") {
+      c.socket.send = (data) => {
+        expect(c.socket.closed).toBe(false);
+        FakeSocket.prototype.send.call(c.socket, data);
+      };
+      f.bridge.dispose();
+    }
+    const detached = c.socket
+      .frames()
+      .filter((frame) => frame.method === "Target.detachedFromTarget");
+    expect(detached.map((frame) => frame.params)).toEqual(
+      expect.arrayContaining([
+        { sessionId: root, targetId: "target-1" },
+        { sessionId: alias, targetId: "target-1" },
+        { sessionId: child, targetId: "frame" },
+        { sessionId: grandchild, targetId: "worker" },
+      ]),
+    );
+    expect(detached).toHaveLength(4);
+    expect(
+      detached.find((frame) => asOptionalRecord(frame.params)?.sessionId === alias)?.sessionId,
+    ).toBe(browser);
+    if (ending === "native detach") {
+      expect(f.bridge.devtoolsTargetDescriptors()).toEqual([
+        expect.objectContaining({ id: "target-1" }),
+      ]);
+      const next = await c.attach();
+      expect(next).not.toBe(root);
+      expect((await c.request("Runtime.enable", next)).error).toBeUndefined();
+    }
+    if (ending === "extension loss") {
+      expect(f.bridge.devtoolsTargetDescriptors()).toEqual([
+        expect.objectContaining({ id: "tab-1" }),
+      ]);
+      sendHello(wireExtension(f.bridge).handlers);
+      const next = await c.attach();
+      expect(next).not.toBe(root);
+      expect((await c.request("Runtime.enable", root)).error).toBeDefined();
+    }
+  });
+
+  it.each([undefined, "unrelated-target"])(
+    "uses owned child identities when detach carries %s",
+    async (targetId) => {
+      const f = fixture();
+      const c = f.client();
+      const root = await c.attach();
+      await c.request("Runtime.enable", root);
+      await c.autoAttach(root);
+      f.event("Target.attachedToTarget", {
+        sessionId: "child",
+        targetInfo: { targetId: "frame", type: "iframe" },
+        waitingForDebugger: false,
+      });
+      const child = c.child("frame", root);
+      await c.autoAttach(child);
+      f.event(
+        "Target.attachedToTarget",
+        {
+          sessionId: "grandchild",
+          targetInfo: { targetId: "worker", type: "worker" },
+          waitingForDebugger: false,
+        },
+        "child",
+      );
+      const grandchild = c.child("worker", child);
+      f.event("Target.detachedFromTarget", { sessionId: "child", targetId });
+      expect(
+        c.socket
+          .frames()
+          .filter((frame) => frame.method === "Target.detachedFromTarget")
+          .map((frame) => frame.params),
+      ).toEqual([
+        { sessionId: child, targetId: "frame" },
+        { sessionId: grandchild, targetId: "worker" },
+      ]);
+      expect((await c.request("Page.getFrameTree", root)).error).toBeUndefined();
+      expect(f.extension.socket.frames().filter((frame) => frame.type === "detach")).toEqual([]);
+      expect(created(c.socket, root)).toHaveLength(1);
+    },
+  );
+
+  it("requires current worker admission before replaying a cached Runtime to a new logical owner", async () => {
+    const f = fixture();
+    const first = f.client();
+    const root = await first.attach();
+    await first.request("Runtime.enable", root);
+    const late = f.client();
+    const lateRoot = await late.attach();
+    // The worker has observed access loss before its tab-list update reaches the relay.
+    f.revokeAccess();
+    const denied = await late.request("Runtime.enable", lateRoot);
+    expect.soft(denied.error).toMatchObject({ message: "tab access was revoked" });
+    expect.soft(created(late.socket, lateRoot)).toEqual([]);
+    expect(created(first.socket, root)).toHaveLength(1);
+    expect(f.commands("Runtime.enable")).toHaveLength(2);
+    expect(first.socket.closed).toBe(false);
+    expect(late.socket.closed).toBe(false);
+    expect(f.commands("Runtime.disable")).toEqual([]);
+  });
+
+  it("delivers live events during admission and replays only undelivered current contexts after success", async () => {
+    const f = fixture();
+    const first = f.client();
+    const root = await first.attach();
+    await first.request("Runtime.enable", root);
+    f.event("Runtime.executionContextCreated", { context: context(2) });
+    const late = f.client();
+    const lateRoot = await late.attach();
+    f.hold();
+    const pending = late.send("Runtime.enable", lateRoot);
+    await flush();
+    expect.soft(created(late.socket, lateRoot)).toEqual([]);
+    expect.soft(late.socket.frames().find((frame) => frame.id === pending)).toBeUndefined();
+    f.event("Runtime.executionContextCreated", { context: context(3) });
+    f.event("Runtime.consoleAPICalled", { type: "log", args: [] });
+    f.event("Runtime.executionContextDestroyed", { executionContextId: 1 });
+    expect
+      .soft(created(late.socket, lateRoot).map((frame) => frame.params))
+      .toEqual([{ context: context(3) }]);
+    expect(late.socket.frames()).toContainEqual({
+      sessionId: lateRoot,
+      method: "Runtime.consoleAPICalled",
+      params: { type: "log", args: [] },
+    });
+    f.release();
+    await flush();
+    expectContextBeforeResult(late.socket, lateRoot, pending, [context(3), context(2)]);
+    expect(created(first.socket, root)).toHaveLength(3);
+  });
+
+  it.each([false, true])(
+    "preserves native binding callbacks independently of Runtime enable (disabled=%s)",
+    async (disabled) => {
+      const f = fixture();
+      const client = f.client();
+      const root = await client.attach();
+      await f.client().attach();
+      expect(
+        (await client.request("Runtime.addBinding", root, { name: "relayBinding" })).error,
+      ).toBeUndefined();
+      if (disabled) {
+        await client.request("Runtime.enable", root);
+        await client.request("Runtime.disable", root);
+      }
+      const params = { name: "relayBinding", payload: "callback", executionContextId: 1 };
+      f.event("Runtime.bindingCalled", params);
+      expect(client.socket.frames()).toContainEqual({
+        sessionId: root,
+        method: "Runtime.bindingCalled",
+        params,
+      });
+      await client.request("Target.detachFromTarget", undefined, { sessionId: root });
+      const before = client.socket.frames().length;
+      f.event("Runtime.bindingCalled", params);
+      expect(client.socket.frames()).toHaveLength(before);
+    },
+  );
+
+  it("keeps a concurrent admission alive when another enable for the same logical owner fails", async () => {
+    const f = fixture();
+    const c = f.client();
+    const root = await c.attach();
+    f.hold();
+    const failed = c.send("Runtime.enable", root);
+    const admitted = c.send("Runtime.enable", root);
+    await flush();
+    f.extension.handlers.onMessage(
+      JSON.stringify({
+        type: "error",
+        seq: f.commands("Runtime.enable")[0]!.seq,
+        message: "admission failed",
+      }),
+    );
+    await flush();
+    expect(c.socket.frames().find((frame) => frame.id === failed)?.error).toBeDefined();
+    expect.soft(c.socket.frames().find((frame) => frame.id === admitted)).toBeUndefined();
+    f.release();
+    await flush();
+    expect(c.socket.frames().find((frame) => frame.id === admitted)).toMatchObject({ result: {} });
+    expectContextBeforeResult(c.socket, root, admitted);
+    f.event("Runtime.executionContextCreated", { context: context(3) });
+    expect(created(c.socket, root)).toHaveLength(2);
+    expect(f.commands("Runtime.disable")).toEqual([]);
+  });
 });

--- a/extensions/browser/src/browser/extension-relay/relay-runtime.ts
+++ b/extensions/browser/src/browser/extension-relay/relay-runtime.ts
@@ -1,112 +1,95 @@
-import { once } from "node:events";
 import { asOptionalRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 
-type RuntimeSubscription = {
+type Subscription = {
   send: (method: string, params: unknown) => void;
-  contexts: Set<number>;
+  pending: number;
+  delivered?: Set<number>;
 };
 
-/** One physical debugger Runtime, shared by connection + logical-session subscriptions. */
+/** One physical Runtime, subscribed by the same exact logical owners as Fetch. */
 export class RelayRuntime {
   private readonly contexts = new Map<number, unknown>();
-  private readonly subscribers = new Map<object, Map<string, RuntimeSubscription>>();
-  private readonly retirement = new AbortController();
-  private readonly retired = once(this.retirement.signal, "abort").then(() => undefined);
+  private readonly subscribers = new Map<object, Subscription>();
+
+  constructor(private readonly active: AbortSignal) {}
 
   async enable(
-    client: object,
-    sessionId: string,
-    send: (method: string, params: unknown) => void,
+    owner: object,
+    send: Subscription["send"],
     admit: () => Promise<unknown>,
   ): Promise<void> {
-    if (this.retirement.signal.aborted) {
-      throw new Error("Runtime session detached");
-    }
-    let sessions = this.subscribers.get(client);
-    if (!sessions) {
-      sessions = new Map();
-      this.subscribers.set(client, sessions);
-    }
-    let subscription = sessions.get(sessionId);
+    this.active.throwIfAborted();
+    let subscription = this.subscribers.get(owner);
     if (!subscription) {
-      subscription = { send, contexts: new Set() };
-      sessions.set(sessionId, subscription);
+      subscription = { send, pending: 0, delivered: new Set() };
+      this.subscribers.set(owner, subscription);
     }
+    subscription.pending++;
     try {
-      // Repeated native enable is idempotent (V8RuntimeAgentImpl::enable), but
-      // every call still validates current worker policy before cached replay.
-      await Promise.race([admit(), this.retired]);
-    } catch (error) {
-      if (sessions.get(sessionId) === subscription) {
-        this.disable(client, sessionId);
+      // Each enable must pass the worker's current access gate, even when native
+      // Runtime is already enabled and no longer emits its existing contexts.
+      await admit();
+      this.active.throwIfAborted();
+      if (this.subscribers.get(owner) !== subscription) {
+        throw new Error("Runtime session detached or disabled");
       }
-      throw error;
-    }
-    if (
-      this.retirement.signal.aborted ||
-      this.subscribers.get(client)?.get(sessionId) !== subscription
-    ) {
-      throw new Error("Runtime session detached or disabled");
-    }
-    // Native events may arrive during admission. Replay only contexts this
-    // logical subscriber has not seen, before its enable response.
-    for (const [id, params] of this.contexts) {
-      if (!subscription.contexts.has(id)) {
-        subscription.contexts.add(id);
-        subscription.send("Runtime.executionContextCreated", params);
+      if (subscription.delivered) {
+        for (const [id, params] of this.contexts) {
+          if (!subscription.delivered.has(id)) {
+            subscription.send("Runtime.executionContextCreated", params);
+          }
+        }
+        subscription.delivered = undefined;
+      }
+    } finally {
+      subscription.pending--;
+      if (
+        subscription.delivered &&
+        subscription.pending === 0 &&
+        this.subscribers.get(owner) === subscription
+      ) {
+        this.subscribers.delete(owner);
       }
     }
   }
 
-  disable(client: object, sessionId?: string): void {
-    const sessions = this.subscribers.get(client);
-    if (sessionId !== undefined) {
-      sessions?.delete(sessionId);
-    }
-    if (sessionId === undefined || sessions?.size === 0) {
-      this.subscribers.delete(client);
-    }
+  disable(owner: object): void {
+    this.subscribers.delete(owner);
     // Keep the physical subscription until debugger detach: disabling it can
     // lose context destruction events and reset another subscriber's Runtime.
   }
 
   event(method: string, params: unknown): void {
-    if (this.retirement.signal.aborted) {
+    if (this.active.aborted) {
       return;
     }
-    const id =
-      method === "Runtime.executionContextCreated"
-        ? asOptionalRecord(asOptionalRecord(params)?.context)?.id
-        : method === "Runtime.executionContextDestroyed"
-          ? asOptionalRecord(params)?.executionContextId
-          : undefined;
-    if (method === "Runtime.executionContextsCleared") {
+    const createdId = asOptionalRecord(asOptionalRecord(params)?.context)?.id;
+    const destroyedId = asOptionalRecord(params)?.executionContextId;
+    if (method === "Runtime.executionContextCreated" && typeof createdId === "number") {
+      this.contexts.set(createdId, params);
+    } else if (method === "Runtime.executionContextDestroyed" && typeof destroyedId === "number") {
+      this.contexts.delete(destroyedId);
+    } else if (method === "Runtime.executionContextsCleared") {
       this.contexts.clear();
-    } else if (typeof id === "number") {
-      if (method === "Runtime.executionContextCreated") {
-        this.contexts.set(id, params);
-      } else {
-        this.contexts.delete(id);
-      }
     }
-    for (const sessions of this.subscribers.values()) {
-      for (const subscription of sessions.values()) {
-        if (method === "Runtime.executionContextsCleared") {
-          subscription.contexts.clear();
-        } else if (typeof id === "number") {
-          if (method === "Runtime.executionContextCreated") {
-            subscription.contexts.add(id);
-          } else {
-            subscription.contexts.delete(id);
-          }
-        }
-        subscription.send(method, params);
+    for (const subscription of this.subscribers.values()) {
+      // Producer-authorized events stay live while admission awaits. Remember
+      // only current context IDs until initial replay, so that replay cannot duplicate them.
+      if (method === "Runtime.executionContextCreated" && typeof createdId === "number") {
+        subscription.delivered?.add(createdId);
+      } else if (
+        method === "Runtime.executionContextDestroyed" &&
+        typeof destroyedId === "number"
+      ) {
+        subscription.delivered?.delete(destroyedId);
+      } else if (method === "Runtime.executionContextsCleared") {
+        subscription.delivered?.clear();
       }
+      subscription.send(method, params);
     }
   }
 
   dispose(): void {
-    this.retirement.abort();
     this.contexts.clear();
     this.subscribers.clear();
   }

--- a/extensions/browser/src/browser/extension-relay/relay-session-owner.ts
+++ b/extensions/browser/src/browser/extension-relay/relay-session-owner.ts
@@ -1,32 +1,135 @@
 import { asOptionalRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { RelayFetch } from "./relay-fetch.js";
 import { RelayRuntime } from "./relay-runtime.js";
+import { RelayTarget } from "./relay-target.js";
 
+type PhysicalSender = (
+  childSessionId: string | undefined,
+  method: string,
+  params: Record<string, unknown> | undefined,
+  signal: AbortSignal,
+) => Promise<unknown>;
 type PhysicalSession = {
+  id: string;
   tabId: number;
+  nativeTargetId: string;
   rootSessionId: string;
   childSessionId?: string;
-  parentSessionId?: string;
   runtime: RelayRuntime;
+  target: RelayTarget<LogicalSession>;
+  parent?: PhysicalSession;
+  children: Set<PhysicalSession>;
+  subscribers: Set<LogicalSession>;
+  attached?: { targetInfo: Record<string, unknown>; waitingForDebugger: boolean };
+  retiring?: Promise<void>;
+  fetch: RelayFetch;
+  transport: PhysicalSender;
+  active: AbortController;
+  lifetime: AbortController;
 };
-
 type LogicalSession = {
   physical: PhysicalSession;
+  client: RelaySessionClient;
+  id: string;
   parentSessionId?: string;
+  parent?: LogicalSession;
+  children: Map<PhysicalSession, LogicalSession>;
+  flat: boolean;
+  detachedChildren: Set<PhysicalSession>;
 };
-
 export type RelaySessionClient = {
   socket: { send: (data: string) => void };
   sessions: Map<string, LogicalSession>;
 };
 
+// Cleanup must not wait for a hung body read/evaluation. After one second the
+// native owner detaches even if cleanup is incomplete; detach can resume unseen requests.
+const FETCH_RETIREMENT_MS = 1_000;
+
 /** Owns physical debugger lifetimes and their per-connection logical sessions. */
 export class RelaySessionOwner {
   private readonly physical = new Map<string, PhysicalSession>();
+  private nextAlias = 1;
 
-  constructor(private readonly clients: ReadonlySet<RelaySessionClient>) {}
+  constructor(
+    private readonly clients: ReadonlySet<RelaySessionClient>,
+    private readonly retireAttachment: (rootSessionId: string) => Promise<void>,
+    private readonly report: (error: unknown) => void,
+    private readonly hasPendingClaims: (tabId: number) => boolean,
+  ) {}
 
-  registerRoot(tabId: number, sessionId: string): void {
-    this.physical.set(sessionId, { tabId, rootSessionId: sessionId, runtime: new RelayRuntime() });
+  registerRoot(
+    tabId: number,
+    nativeTargetId: string,
+    sessionId: string,
+    transport: PhysicalSender,
+  ): void {
+    this.register({ tabId, nativeTargetId, rootSessionId: sessionId, transport });
+  }
+
+  private register(
+    scope: Pick<
+      PhysicalSession,
+      "tabId" | "nativeTargetId" | "rootSessionId" | "transport" | "childSessionId" | "parent"
+    >,
+  ): PhysicalSession {
+    const active = new AbortController();
+    const physical: PhysicalSession = {
+      ...scope,
+      id: scope.childSessionId ?? scope.rootSessionId,
+      runtime: new RelayRuntime(active.signal),
+      target: new RelayTarget(
+        (params) => this.send(physical, "Target.setAutoAttach", params, "target"),
+        () => this.reconcileChildren(physical),
+        () => active.signal.throwIfAborted(),
+      ),
+      children: new Set(),
+      subscribers: new Set(),
+      active,
+      lifetime: new AbortController(),
+      fetch: new RelayFetch((method, params) => this.send(physical, method, params, "fetch")),
+    };
+    physical.parent?.children.add(physical);
+    this.physical.set(scope.childSessionId ?? scope.rootSessionId, physical);
+    return physical;
+  }
+
+  async send(
+    physical: PhysicalSession,
+    method: string,
+    params?: Record<string, unknown>,
+    domain?: "fetch" | "target",
+  ): Promise<unknown> {
+    const assertCurrent = () => {
+      physical.lifetime.signal.throwIfAborted();
+      if (this.physical.get(physical.id) !== physical) {
+        throw new Error("Physical session detached");
+      }
+    };
+    assertCurrent();
+    // prepareRetirement is the only Fetch admission after active work is fenced.
+    const signal = physical.active.signal.aborted
+      ? physical.lifetime.signal
+      : physical.active.signal;
+    if (domain !== "fetch") {
+      physical.active.signal.throwIfAborted();
+    }
+    try {
+      const result = await physical.transport(physical.childSessionId, method, params, signal);
+      assertCurrent();
+      signal.throwIfAborted();
+      if (method === "Runtime.runIfWaitingForDebugger" && physical.attached) {
+        physical.attached.waitingForDebugger = false;
+      }
+      return result;
+    } catch (error) {
+      if (domain && !physical.active.signal.aborted) {
+        // Only an actual sender failure retires the scope. Local ownership/stage
+        // rejections never pass here and cannot evict another logical user.
+        void this.retireAttachment(physical.rootSessionId).catch(this.report);
+      }
+      throw error;
+    }
   }
 
   announce(
@@ -35,74 +138,322 @@ export class RelaySessionOwner {
     physicalId: string,
     params: unknown,
     parentSessionId?: string,
+    flat = true,
   ): void {
     const physical = this.physical.get(physicalId);
-    if (!physical || !this.clients.has(client) || client.sessions.has(sessionId)) {
+    if (
+      !physical ||
+      physical.active.signal.aborted ||
+      !this.clients.has(client) ||
+      client.sessions.has(sessionId)
+    ) {
       return;
     }
-    client.sessions.set(sessionId, { physical, parentSessionId });
-    client.socket.send(
-      JSON.stringify({ sessionId: parentSessionId, method: "Target.attachedToTarget", params }),
+    const parent = parentSessionId ? client.sessions.get(parentSessionId) : undefined;
+    const session: LogicalSession = {
+      physical,
+      client,
+      id: sessionId,
+      parentSessionId,
+      parent,
+      children: new Map(),
+      flat,
+      detachedChildren: new Set(),
+    };
+    client.sessions.set(sessionId, session);
+    physical.subscribers.add(session);
+    parent?.children.set(physical, session);
+    this.parentEvent(session, "Target.attachedToTarget", params);
+  }
+
+  private deliver(
+    session: LogicalSession,
+    payload: Record<string, unknown>,
+    flatId = session.id,
+  ): void {
+    if (session.parent && !session.flat) {
+      const message = flatId === session.id ? payload : { ...payload, sessionId: flatId };
+      this.deliver(session.parent, {
+        method: "Target.receivedMessageFromTarget",
+        params: {
+          sessionId: session.id,
+          targetId: session.physical.nativeTargetId,
+          message: JSON.stringify(message),
+        },
+      });
+    } else if (session.parent) {
+      this.deliver(session.parent, payload, flatId);
+    } else {
+      session.client.socket.send(JSON.stringify({ ...payload, sessionId: flatId }));
+    }
+  }
+
+  child(parent: LogicalSession, params?: Record<string, unknown>): LogicalSession {
+    const child =
+      params?.sessionId !== undefined
+        ? typeof params.sessionId === "string"
+          ? parent.client.sessions.get(params.sessionId)
+          : undefined
+        : [...parent.children.values()].find(
+            (candidate) => candidate.physical.nativeTargetId === params?.targetId,
+          );
+    if (!child || child.parent !== parent) {
+      throw new Error("Target child session not found");
+    }
+    return child;
+  }
+
+  private parentEvent(session: LogicalSession, method: string, params: unknown): void {
+    if (session.parent) {
+      this.deliver(session.parent, { method, params });
+    } else {
+      session.client.socket.send(
+        JSON.stringify({ sessionId: session.parentSessionId, method, params }),
+      );
+    }
+  }
+
+  emit(session: LogicalSession, payload: Record<string, unknown>): void {
+    if (this.clients.has(session.client) && session.client.sessions.get(session.id) === session) {
+      this.deliver(session, payload);
+    }
+  }
+
+  private childWanted(child: PhysicalSession): boolean {
+    const parent = child.parent;
+    return Boolean(
+      parent &&
+      [...parent.subscribers].some(
+        (session) =>
+          !session.detachedChildren.has(child) &&
+          parent.target.interest(session, String(child.attached?.targetInfo.type)),
+      ),
     );
   }
 
-  detach(client: RelaySessionClient, sessionId: string, targetId?: string): void {
-    const session = client.sessions.get(sessionId);
-    if (!session) {
+  private projectChild(parent: LogicalSession, child: PhysicalSession): void {
+    const info = child.attached;
+    const interest = parent.physical.target.interest(parent, String(info?.targetInfo.type));
+    if (
+      !info ||
+      !interest?.admitted ||
+      parent.children.has(child) ||
+      parent.detachedChildren.has(child)
+    ) {
       return;
     }
-    session.physical.runtime.disable(client, sessionId);
-    client.sessions.delete(sessionId);
-    client.socket.send(
-      JSON.stringify({
-        sessionId: session.parentSessionId,
-        method: "Target.detachedFromTarget",
-        params: { sessionId, ...(targetId ? { targetId } : {}) },
+    const id = `openclaw-child-${this.nextAlias++}`;
+    this.announce(
+      parent.client,
+      id,
+      child.id,
+      { ...info, sessionId: id },
+      parent.id,
+      interest.flatten,
+    );
+  }
+
+  private async reconcileChildren(physical: PhysicalSession): Promise<void> {
+    if (physical.active.signal.aborted) {
+      return;
+    }
+    const removed: LogicalSession[] = [];
+    for (const parent of physical.subscribers) {
+      for (const child of physical.children) {
+        const info = child.attached;
+        if (!info || child.active.signal.aborted) {
+          continue;
+        }
+        const interest = physical.target.interest(parent, String(info.targetInfo.type));
+        const existing = parent.children.get(child);
+        if (existing && (!interest || existing.flat !== interest.flatten)) {
+          removed.push(...this.remove(existing.client, existing.id));
+        }
+        this.projectChild(parent, child);
+      }
+    }
+    // The current parent Target transition already owns this queue; never enqueue
+    // its own child cleanup behind itself. Fetch cleanup is bounded by retire().
+    await Promise.all(
+      [...physical.children].map(async (child) => {
+        if (!child.subscribers.size && !this.childWanted(child)) {
+          await this.retire(child.id, () =>
+            this.send(
+              physical,
+              "Target.detachFromTarget",
+              { sessionId: child.childSessionId },
+              "target",
+            ).then(() => {}),
+          );
+        }
       }),
     );
-    this.detachChildren(client, sessionId);
+    await this.release(removed, physical);
   }
 
-  detachChildren(client: RelaySessionClient, parentSessionId: string): void {
-    for (const [sessionId, session] of client.sessions) {
-      if (session.parentSessionId === parentSessionId) {
-        this.detach(client, sessionId);
-      }
+  private remove(client: RelaySessionClient, sessionId: string): LogicalSession[] {
+    const session = client.sessions.get(sessionId);
+    if (!session) {
+      return [];
     }
+    session.physical.runtime.disable(session);
+    client.sessions.delete(sessionId);
+    session.physical.subscribers.delete(session);
+    session.parent?.children.delete(session.physical);
+    if (this.clients.has(client)) {
+      this.parentEvent(session, "Target.detachedFromTarget", {
+        sessionId,
+        targetId: session.physical.nativeTargetId,
+      });
+    }
+    return [
+      session,
+      ...[...session.children.values()].flatMap((child) => this.remove(client, child.id)),
+    ];
   }
 
-  retire(sessionId: string, targetId?: string): void {
-    const physical = this.physical.get(sessionId);
-    if (!physical) {
-      return;
-    }
-    this.physical.delete(sessionId);
-    physical.runtime.dispose();
-    for (const client of this.clients) {
-      for (const [id, session] of client.sessions) {
-        if (session.physical === physical) {
-          this.detach(client, id, targetId);
-        }
-      }
-    }
-    for (const [childId, child] of this.physical) {
-      if (child.parentSessionId === sessionId) {
-        this.retire(childId);
-      }
-    }
+  detach(client: RelaySessionClient, sessionId: string): Promise<void> {
+    const session = client.sessions.get(sessionId);
+    session?.parent?.detachedChildren.add(session.physical);
+    return this.release(this.remove(client, sessionId));
   }
 
-  hasTabSessions(tabId: number): boolean {
-    return [...this.clients].some((client) =>
-      [...client.sessions.values()].some((session) => session.physical.tabId === tabId),
+  detachChildren(client: RelaySessionClient, parentSessionId: string): Promise<void> {
+    return this.release(
+      [...client.sessions]
+        .filter(([, session]) => session.parentSessionId === parentSessionId)
+        .flatMap(([id]) => this.remove(client, id)),
     );
   }
 
-  close(client: RelaySessionClient): void {
-    for (const session of client.sessions.values()) {
-      session.physical.runtime.disable(client);
+  private async release(sessions: LogicalSession[], reconciling?: PhysicalSession): Promise<void> {
+    await Promise.all(
+      sessions.map(async (session) => {
+        const physical = session.physical;
+        if (physical.active.signal.aborted) {
+          return;
+        }
+        if (
+          !this.hasRootSessions(physical.rootSessionId) &&
+          !this.hasPendingClaims(physical.tabId)
+        ) {
+          await this.retireAttachment(physical.rootSessionId);
+          return;
+        }
+        const parent = physical.parent;
+        if (
+          parent &&
+          !physical.subscribers.size &&
+          !this.childWanted(physical) &&
+          parent !== reconciling
+        ) {
+          await parent.target.enqueue(() => this.reconcileChildren(parent));
+          return;
+        }
+        const targetCleanup = physical.target.remove(session);
+        let timer: NodeJS.Timeout | undefined;
+        try {
+          await Promise.all([
+            targetCleanup,
+            Promise.race([
+              physical.fetch.close(session),
+              new Promise<never>((_resolve, reject) => {
+                timer = setTimeout(
+                  () => reject(new Error("Fetch owner cleanup timed out")),
+                  FETCH_RETIREMENT_MS,
+                );
+                timer.unref?.();
+              }),
+            ]),
+          ]);
+        } catch (error) {
+          await this.retireAttachment(physical.rootSessionId);
+          throw error;
+        } finally {
+          clearTimeout(timer);
+        }
+        if (parent && parent !== reconciling && !physical.subscribers.size) {
+          await parent.target.enqueue(() => this.reconcileChildren(parent));
+        }
+      }),
+    );
+  }
+
+  retire(sessionId: string, detach?: () => Promise<void>): Promise<void> {
+    const physical = this.physical.get(sessionId);
+    if (!physical) {
+      return Promise.resolve();
     }
-    client.sessions.clear();
+    const descendants = (scope: PhysicalSession): PhysicalSession[] => [
+      scope,
+      ...[...scope.children].flatMap(descendants),
+    ];
+    const scopes = descendants(physical);
+    for (const scope of scopes) {
+      scope.active.abort(new Error("Physical session detached"));
+      scope.runtime.dispose();
+      scope.target.dispose();
+      for (const session of scope.subscribers) {
+        this.remove(session.client, session.id);
+      }
+    }
+
+    const dispose = () => {
+      for (const scope of scopes) {
+        scope.lifetime.abort(new Error("Physical session detached"));
+        scope.fetch.dispose();
+        scope.parent?.children.delete(scope);
+        for (const parent of scope.parent?.subscribers ?? []) {
+          parent.detachedChildren.delete(scope);
+        }
+        const id = scope.childSessionId ?? scope.rootSessionId;
+        if (this.physical.get(id) === scope) {
+          this.physical.delete(id);
+        }
+      }
+    };
+    if (!detach) {
+      dispose();
+      return physical.retiring ?? Promise.resolve();
+    }
+    if (physical.retiring) {
+      return physical.retiring;
+    }
+    const preparations = scopes.map((scope) => scope.fetch.prepareRetirement(FETCH_RETIREMENT_MS));
+    return (physical.retiring = (async () => {
+      try {
+        const results = await Promise.all(preparations);
+        for (const result of results) {
+          for (const error of result.errors) {
+            this.report(error);
+          }
+        }
+      } finally {
+        // Native closure/transport loss can end the scope while cleanup waits.
+        // Its terminal lifetime prevents late cleanup from detaching a successor.
+        const needsDetach = !physical.lifetime.signal.aborted;
+        dispose();
+        if (needsDetach) {
+          await detach();
+        }
+      }
+    })());
+  }
+
+  retireTab(tabId: number): void {
+    for (const [id, scope] of this.physical) {
+      if (scope.tabId === tabId) {
+        void this.retire(id);
+      }
+    }
+  }
+
+  hasRootSessions(id: string): boolean {
+    return (this.physical.get(id)?.subscribers.size ?? 0) > 0;
+  }
+
+  close(client: RelaySessionClient): Promise<void> {
+    return this.release([...client.sessions.keys()].flatMap((id) => this.remove(client, id)));
   }
 
   forward(
@@ -113,12 +464,16 @@ export class RelaySessionOwner {
   ): void {
     const sessionId = childSessionId ?? rootSessionId;
     const physical = this.physical.get(sessionId);
-    // Only a parent attachment creates child routing; late events cannot
-    // resurrect a detached child or cross into a replacement root attachment.
-    if (!physical || physical.rootSessionId !== rootSessionId) {
+    // Only parent attachment creates child routing; late events cannot resurrect a scope.
+    if (!physical || physical.active.signal.aborted || physical.rootSessionId !== rootSessionId) {
       return;
     }
-    if (method.startsWith("Runtime.")) {
+    if (physical.fetch.event(method, params)) {
+      return;
+    }
+    // V8 binding callbacks depend on add/removeBinding, not Runtime.enable.
+    // Preserve their native forwarding independently of Runtime subscriptions.
+    if (method.startsWith("Runtime.") && method !== "Runtime.bindingCalled") {
       physical.runtime.event(method, params);
       return;
     }
@@ -126,53 +481,75 @@ export class RelaySessionOwner {
       const detached = asOptionalRecord(params);
       if (
         typeof detached?.sessionId === "string" &&
-        this.physical.get(detached.sessionId)?.parentSessionId === sessionId
+        this.physical.get(detached.sessionId)?.parent === physical
       ) {
-        this.retire(
-          detached.sessionId,
-          typeof detached.targetId === "string" ? detached.targetId : undefined,
-        );
+        void this.retire(detached.sessionId);
       }
       return;
     }
+    if (method === "Target.targetInfoChanged") {
+      const info = asOptionalRecord(asOptionalRecord(params)?.targetInfo);
+      const child = [...physical.children].find(
+        (candidate) => candidate.nativeTargetId === info?.targetId,
+      );
+      if (child?.attached && info && typeof info.type === "string") {
+        child.attached.targetInfo = info;
+        for (const parent of physical.subscribers) {
+          if (parent.children.has(child) && physical.target.interest(parent, info.type)?.admitted) {
+            this.emit(parent, { method, params });
+          }
+        }
+        void physical.target.enqueue(() => this.reconcileChildren(physical)).catch(this.report);
+        return;
+      }
+    }
     if (method === "Target.attachedToTarget") {
-      const childId = asOptionalRecord(params)?.sessionId;
-      if (typeof childId !== "string") {
+      const attached = asOptionalRecord(params);
+      const childId = attached?.sessionId;
+      const nativeTargetId = asOptionalRecord(attached?.targetInfo)?.targetId;
+      if (typeof childId !== "string" || typeof nativeTargetId !== "string") {
+        this.report(new Error("Native child attachment is missing its session or target identity"));
+        return;
+      }
+      const targetInfo = asOptionalRecord(attached?.targetInfo);
+      if (!targetInfo || typeof targetInfo.type !== "string" || !nativeTargetId) {
+        this.report(new Error("Native child attachment is missing its target type"));
         return;
       }
       if (!this.physical.has(childId)) {
-        this.physical.set(childId, {
+        const child = this.register({
           tabId: physical.tabId,
+          nativeTargetId,
           rootSessionId,
           childSessionId: childId,
-          parentSessionId: sessionId,
-          runtime: new RelayRuntime(),
+          parent: physical,
+          transport: physical.transport,
         });
+        child.attached = { targetInfo, waitingForDebugger: attached?.waitingForDebugger === true };
       }
-      // A real child id is connection-scoped. Announce it once on an owned
-      // parent, including alias-only clients, rather than duplicating it on every alias.
-      for (const client of this.clients) {
-        const parent = [...client.sessions].find(([, session]) => session.physical === physical);
-        if (parent) {
-          this.announce(client, childId, childId, params, parent[0]);
-        }
+      // Live projections use only admitted interests; a pending enable replays
+      // cached children after that caller's worker admission succeeds.
+      const child = this.physical.get(childId);
+      if (!child || child.parent !== physical || child.active.signal.aborted) {
+        return;
+      }
+      for (const parent of physical.subscribers) {
+        this.projectChild(parent, child);
+      }
+      if (!physical.target.wanted(targetInfo.type)) {
+        void physical.target.enqueue(() => this.reconcileChildren(physical)).catch(this.report);
       }
       return;
     }
-    for (const client of this.clients) {
-      for (const [id, session] of client.sessions) {
-        if (session.physical === physical) {
-          client.socket.send(JSON.stringify({ sessionId: id, method, params }));
-        }
-      }
+    for (const session of physical.subscribers) {
+      this.emit(session, { method, params });
     }
   }
 
   dispose(): void {
-    for (const session of this.physical.values()) {
-      session.runtime.dispose();
+    for (const id of this.physical.keys()) {
+      void this.retire(id);
     }
-    this.physical.clear();
     for (const client of this.clients) {
       client.sessions.clear();
     }

--- a/extensions/browser/src/browser/extension-relay/relay-target.ts
+++ b/extensions/browser/src/browser/extension-relay/relay-target.ts
@@ -1,0 +1,149 @@
+import { asOptionalRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
+
+type FilterEntry = { type?: string; exclude?: boolean };
+type Interest = { filter: FilterEntry[]; flatten: boolean; admitted: boolean };
+const DEFAULT_FILTER: FilterEntry[] = [
+  { type: "browser", exclude: true },
+  { type: "tab", exclude: true },
+  {},
+];
+const matches = (filter: FilterEntry[], type?: string) => {
+  const entry = filter.find((candidate) => candidate.type === undefined || candidate.type === type);
+  return entry !== undefined && entry.exclude !== true;
+};
+
+/** One native Target policy, projected onto exact logical parent interests. */
+export class RelayTarget<Owner extends object> {
+  private readonly interests = new Map<Owner, Interest>();
+  private tail: Promise<unknown> = Promise.resolve();
+  private waiting = false;
+
+  constructor(
+    private readonly send: (params: Record<string, unknown>) => Promise<unknown>,
+    private readonly reconcile: () => Promise<void>,
+    private readonly assertActive: () => void,
+  ) {}
+
+  enqueue<T>(operation: () => Promise<T>): Promise<T> {
+    const pending = this.tail.then(() => {
+      this.assertActive();
+      return operation();
+    });
+    this.tail = pending.catch(() => {});
+    return pending;
+  }
+
+  interest(owner: Owner, type: string): Interest | undefined {
+    const interest = this.interests.get(owner);
+    return interest && matches(interest.filter, type) ? interest : undefined;
+  }
+
+  wanted(type: string): boolean {
+    return [...this.interests.values()].some((interest) => matches(interest.filter, type));
+  }
+
+  private params(): Record<string, unknown> {
+    if (!this.interests.size) {
+      return { autoAttach: false, waitForDebuggerOnStart: false, flatten: true };
+    }
+    const filters = [...this.interests.values()].map((interest) => interest.filter);
+    const fallback = filters.some((filter) => matches(filter));
+    const types = [
+      ...new Set(
+        filters.flatMap((filter) =>
+          filter.flatMap((entry) => (entry.type === undefined ? [] : [entry.type])),
+        ),
+      ),
+    ].toSorted();
+    // Chromium uses first match, otherwise exclusion. Keep each logical filter
+    // ordered; union only its per-type decision plus the unknown-type default.
+    const union: FilterEntry[] = types.flatMap((type) => {
+      const include = filters.some((filter) => matches(filter, type));
+      return include === fallback ? [] : [{ type, exclude: !include }];
+    });
+    if (fallback) {
+      union.push({});
+    }
+    return { autoAttach: true, waitForDebuggerOnStart: this.waiting, flatten: true, filter: union };
+  }
+
+  command(
+    owner: Owner,
+    params: Record<string, unknown> | undefined,
+    assertCurrent: () => void,
+  ): Promise<unknown> {
+    if (
+      typeof params?.autoAttach !== "boolean" ||
+      typeof params.waitForDebuggerOnStart !== "boolean" ||
+      (params.flatten !== undefined && typeof params.flatten !== "boolean")
+    ) {
+      throw new Error("Invalid Target auto-attach parameters");
+    }
+    let filter = DEFAULT_FILTER;
+    if (params.filter !== undefined) {
+      if (!Array.isArray(params.filter)) {
+        throw new Error("Invalid Target filter");
+      }
+      filter = params.filter.map((value) => {
+        const entry = asOptionalRecord(value);
+        if (
+          !entry ||
+          (entry.type !== undefined && typeof entry.type !== "string") ||
+          (entry.exclude !== undefined && typeof entry.exclude !== "boolean")
+        ) {
+          throw new Error("Invalid Target filter entry");
+        }
+        return {
+          ...(typeof entry.type === "string" ? { type: entry.type } : {}),
+          ...(typeof entry.exclude === "boolean" ? { exclude: entry.exclude } : {}),
+        };
+      });
+    }
+    if (!params.autoAttach && params.filter !== undefined && filter.length) {
+      throw new Error("Target filter should be empty when disabling auto-attach");
+    }
+    const waiting = params.waitForDebuggerOnStart;
+    const next = params.autoAttach
+      ? { filter, flatten: params.flatten === true, admitted: false }
+      : undefined;
+    return this.enqueue(async () => {
+      assertCurrent();
+      if (next) {
+        this.interests.set(owner, next);
+      } else {
+        this.interests.delete(owner);
+      }
+      // Wait policy remains native/shared last-update behavior, including DevTools suspend.
+      this.waiting = waiting;
+      try {
+        await this.reconcile();
+        const result = await this.send(this.params());
+        assertCurrent();
+        if (next && this.interests.get(owner) === next) {
+          next.admitted = true;
+        }
+        await this.reconcile();
+        return result;
+      } catch (error) {
+        if (this.interests.get(owner) === next) {
+          this.interests.delete(owner);
+        }
+        throw error;
+      }
+    });
+  }
+
+  remove(owner: Owner): Promise<void> | undefined {
+    if (!this.interests.delete(owner)) {
+      return undefined;
+    }
+    return this.enqueue(async () => {
+      await this.reconcile();
+      await this.send(this.params());
+    });
+  }
+
+  dispose(): void {
+    this.interests.clear();
+  }
+}

--- a/extensions/browser/src/browser/extension-relay/relay-targets.test.ts
+++ b/extensions/browser/src/browser/extension-relay/relay-targets.test.ts
@@ -1,0 +1,566 @@
+import { asOptionalRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { describe, expect, it, onTestFinished, vi } from "vitest";
+import { ExtensionRelayBridge } from "./relay-bridge.js";
+import {
+  FakeSocket,
+  flush,
+  replyFor,
+  sendHello,
+  wireExtension,
+} from "./relay-bridge.test-support.js";
+import type { RelayCommandBody } from "./relay-protocol.js";
+
+const enabled = { autoAttach: true, waitForDebuggerOnStart: true, flatten: true };
+function fixture() {
+  const bridge = new ExtensionRelayBridge();
+  onTestFinished(() => bridge.dispose());
+  let hold: string | undefined;
+  let failure: string | undefined;
+  let targetId: string | undefined = "target-1";
+  const held: Array<RelayCommandBody & { seq: number }> = [];
+  const extension = wireExtension(bridge, (message) => {
+    if (message.type === "ping") {
+      return replyFor(message);
+    }
+    if (message.type === hold || (message.type === "cdp" && message.method === hold)) {
+      held.push(message);
+      return null;
+    }
+    if (message.type === failure || (message.type === "cdp" && message.method === failure)) {
+      failure = undefined;
+      return {
+        type: "error",
+        seq: message.seq,
+        message: "native transition failed after dispatch",
+      };
+    }
+    if (message.type === "attach") {
+      return { type: "result", seq: message.seq, result: targetId ? { targetId } : {} };
+    }
+    return replyFor(message);
+  });
+  sendHello(extension.handlers);
+  const event = (method: string, params: unknown, sessionId?: string) =>
+    extension.handlers.onMessage(
+      JSON.stringify({ type: "cdpEvent", tabId: 1, method, params, sessionId }),
+    );
+  const child = (id: string, parent?: string, type = "worker") =>
+    event(
+      "Target.attachedToTarget",
+      {
+        sessionId: id,
+        targetInfo: { targetId: `target-${id}`, type, url: "https://example.com/child" },
+        waitingForDebugger: true,
+      },
+      parent,
+    );
+  const commands = (method: string) =>
+    extension.socket
+      .frames()
+      .filter((f) => f.type === method || (f.type === "cdp" && f.method === method));
+  const client = () => {
+    const socket = new FakeSocket();
+    const handlers = bridge.attachCdpClientSocket(socket);
+    let nextRequest = 0;
+    const send = (method: string, sessionId?: string, params?: Record<string, unknown>) => {
+      const next = ++nextRequest;
+      handlers.onMessage(JSON.stringify({ id: next, method, sessionId, params }));
+      return next;
+    };
+    const response = async (id: number) =>
+      await vi.waitFor(() => {
+        const frame = socket.frames().find((f) => f.id === id);
+        expect(frame).toBeDefined();
+        return frame!;
+      });
+    const request = async (method: string, sessionId?: string, params?: Record<string, unknown>) =>
+      await response(send(method, sessionId, params));
+    const attached = (parent?: string) =>
+      socket
+        .frames()
+        .filter((f) => f.method === "Target.attachedToTarget" && f.sessionId === parent)
+        .map((f) => asOptionalRecord(f.params)!);
+    const attach = async () => {
+      await request("Target.setAutoAttach", undefined, enabled);
+      const id = attached().at(-1)?.sessionId;
+      if (typeof id !== "string") {
+        throw new Error("Root attachment missing");
+      }
+      return id;
+    };
+    const alias = async () => {
+      const result = await request("Target.attachToTarget", undefined, {
+        targetId: "target-1",
+        flatten: true,
+      });
+      const id = asOptionalRecord(result.result)?.sessionId;
+      if (typeof id !== "string") {
+        throw new Error("Logical attachment missing");
+      }
+      return id;
+    };
+    return { socket, send, response, request, attached, attach, alias, close: handlers.onClose };
+  };
+  return {
+    bridge,
+    extension,
+    event,
+    child,
+    commands,
+    client,
+    hold: (method?: string) => {
+      hold = method;
+    },
+    fail: (method: string) => {
+      failure = method;
+    },
+    target: (id?: string) => {
+      targetId = id;
+    },
+    held,
+    release: () => {
+      hold = undefined;
+      for (const message of held.splice(0)) {
+        extension.handlers.onMessage(
+          JSON.stringify({
+            type: "result",
+            seq: message.seq,
+            result: message.type === "attach" ? (targetId ? { targetId } : {}) : {},
+          }),
+        );
+      }
+    },
+  };
+}
+function childId(c: ReturnType<ReturnType<typeof fixture>["client"]>, parent: string) {
+  const id = c.attached(parent).at(-1)?.sessionId;
+  expect(typeof id).toBe("string");
+  return String(id);
+}
+
+describe("pending tab acquisition claims", () => {
+  it.each(["unrelated", "pending peer", "delivered peer"])(
+    "releases only an abandoned acquisition with %s remaining",
+    async (peer) => {
+      const f = fixture();
+      const first = f.client();
+      await first.attach();
+      const other = f.client();
+      first.close();
+      await flush();
+      const before = f.commands("detach").length;
+      if (peer === "delivered peer") {
+        await other.attach();
+      }
+      f.hold("attach");
+      const lost = f.client();
+      lost.send("Target.attachToTarget", undefined, { targetId: "target-1" });
+      if (peer !== "delivered peer") {
+        await vi.waitFor(() => expect(f.held).toHaveLength(1));
+      }
+      const waiting =
+        peer === "pending peer"
+          ? other.send("Target.attachToTarget", undefined, { targetId: "target-1" })
+          : undefined;
+      lost.close();
+      f.release();
+      if (waiting !== undefined) {
+        expect((await other.response(waiting)).error).toBeUndefined();
+      }
+      await flush();
+      if (peer === "unrelated") {
+        expect(f.commands("detach")).toHaveLength(before + 1);
+      } else {
+        expect(f.commands("detach")).toHaveLength(before);
+        expect(other.attached()).toHaveLength(1);
+      }
+    },
+  );
+
+  it("rejects requested target substitution without retiring a pending peer's successor", async () => {
+    const f = fixture();
+    const c = f.client();
+    await c.attach();
+    f.extension.handlers.onMessage(
+      JSON.stringify({ type: "detached", tabId: 1, reason: "target_closed" }),
+    );
+    f.hold("attach");
+    const request = c.send("Target.attachToTarget", undefined, { targetId: "target-1" });
+    const peer = f.client();
+    const pending = peer.send("Target.setAutoAttach", undefined, enabled);
+    await vi.waitFor(() => expect(f.held).toHaveLength(1));
+    f.target("target-2");
+    f.release();
+    expect.soft((await c.response(request)).error).toBeDefined();
+    await peer.response(pending);
+    expect.soft(c.attached()).toHaveLength(1);
+    expect(peer.attached()).toHaveLength(1);
+    expect(peer.attached()[0]).toMatchObject({ targetInfo: { targetId: "target-2" } });
+    expect(f.commands("detach")).toEqual([]);
+  });
+
+  it("never fabricates a successful native identity", async () => {
+    const f = fixture();
+    f.target(undefined);
+    const c = f.client();
+    await c.request("Target.setAutoAttach", undefined, enabled);
+    expect(c.attached()).toEqual([]);
+    expect((await c.request("Target.getTargets")).error).toBeDefined();
+  });
+
+  it("allows an explicit acquire after a failed retirement has settled", async () => {
+    const f = fixture();
+    const c = f.client();
+    const root = await c.attach();
+    f.fail("detach");
+    expect(
+      (await c.request("Target.detachFromTarget", undefined, { sessionId: root })).error,
+    ).toBeDefined();
+    expect
+      .soft((await c.request("Target.attachToTarget", undefined, { targetId: "target-1" })).error)
+      .toBeUndefined();
+    expect(f.commands("attach")).toHaveLength(2);
+  });
+});
+
+describe("logical Target interests", () => {
+  it("projects a child only to S2 when S1 was inserted first but never enabled", async () => {
+    const f = fixture();
+    const c = f.client();
+    const s1 = await c.attach();
+    const s2 = await c.alias();
+    await c.request("Target.setAutoAttach", s2, enabled);
+    f.child("child");
+    expect.soft(c.attached(s1)).toEqual([]);
+    expect(c.attached(s2)).toHaveLength(1);
+  });
+
+  it("keeps distinct child aliases and the surviving parent's Runtime/Fetch after parent detach", async () => {
+    const f = fixture();
+    const c = f.client();
+    const s1 = await c.attach();
+    const s2 = await c.alias();
+    for (const parent of [s1, s2]) {
+      await c.request("Target.setAutoAttach", parent, enabled);
+    }
+    f.child("child");
+    const a = childId(c, s1);
+    const b = childId(c, s2);
+    expect(a).not.toBe(b);
+    await c.request("Fetch.enable", b, {});
+    expect((await c.request("Fetch.enable", a, {})).error).toBeDefined();
+    await c.request("Target.detachFromTarget", undefined, { sessionId: s1 });
+    for (const method of ["Runtime.enable", "Runtime.evaluate", "Fetch.disable"]) {
+      expect((await c.request(method, b)).error).toBeUndefined();
+    }
+    expect(f.commands("Target.detachFromTarget")).toEqual([]);
+    expect(c.socket.frames()).toContainEqual({
+      sessionId: s1,
+      method: "Target.detachedFromTarget",
+      params: { sessionId: a, targetId: "target-child" },
+    });
+  });
+
+  it("replays late children and grandchildren only after current admission with current waiting state", async () => {
+    const f = fixture();
+    const c = f.client();
+    const s1 = await c.attach();
+    await c.request("Target.setAutoAttach", s1, enabled);
+    f.child("child");
+    const a = childId(c, s1);
+    await c.request("Target.setAutoAttach", a, enabled);
+    f.child("grandchild", "child");
+    await c.request("Runtime.runIfWaitingForDebugger", a);
+    const s2 = await c.alias();
+    f.hold("Target.setAutoAttach");
+    const pending = c.send("Target.setAutoAttach", s2, enabled);
+    await vi.waitFor(() => expect(f.held).toHaveLength(1));
+    expect(c.attached(s2)).toEqual([]);
+    f.release();
+    await c.response(pending);
+    const b = childId(c, s2);
+    expect(c.attached(s2)[0]).toMatchObject({ waitingForDebugger: false });
+    expect(c.attached(b)).toEqual([]);
+    await c.request("Target.setAutoAttach", b, enabled);
+    expect(c.attached(b)).toHaveLength(1);
+    expect(childId(c, a)).not.toBe(childId(c, b));
+  });
+
+  it("admits a broader filter before replaying its newly included children", async () => {
+    const f = fixture();
+    const c = f.client();
+    const first = await c.attach();
+    const peer = await c.alias();
+    await c.request("Target.setAutoAttach", first, {
+      ...enabled,
+      filter: [{ type: "worker" }],
+    });
+    await c.request("Target.setAutoAttach", peer, { ...enabled, filter: [{}] });
+    f.child("frame", undefined, "iframe");
+    expect(c.attached(first)).toEqual([]);
+    expect(c.attached(peer)).toHaveLength(1);
+    f.hold("Target.setAutoAttach");
+    const pending = c.send("Target.setAutoAttach", first, { ...enabled, filter: [{}] });
+    await vi.waitFor(() => expect(f.held).toHaveLength(1));
+    expect.soft(c.attached(first)).toEqual([]);
+    f.release();
+    expect((await c.response(pending)).error).toBeUndefined();
+    expect(c.attached(first)).toHaveLength(1);
+    expect(childId(c, first)).not.toBe(childId(c, peer));
+  });
+
+  it("unions ordered native filters without conflating omitted filter and catch-all", async () => {
+    const f = fixture();
+    const c = f.client();
+    const s1 = await c.attach();
+    const s2 = await c.alias();
+    expect((await c.request("Target.setAutoAttach", s1, enabled)).error).toBeUndefined();
+    expect(
+      (await c.request("Target.setAutoAttach", s2, { ...enabled, filter: [{}] })).error,
+    ).toBeUndefined();
+    f.child("tab", undefined, "tab");
+    f.child("worker");
+    expect.soft(c.attached(s1)).toHaveLength(1);
+    expect(c.attached(s2)).toHaveLength(2);
+    await c.request("Target.setAutoAttach", s1, { ...enabled, waitForDebuggerOnStart: false });
+    expect(f.commands("Target.setAutoAttach").at(-1)?.params).toMatchObject({
+      waitForDebuggerOnStart: false,
+      filter: [{}],
+    });
+    await c.request("Target.setAutoAttach", s2, {
+      ...enabled,
+      filter: [{ type: "worker", exclude: true }, {}],
+    });
+    f.child("next-worker");
+    expect(c.attached(s1)).toHaveLength(2);
+    expect(c.attached(s2)).toHaveLength(2);
+  });
+
+  it.each(["enable", "disable"])(
+    "retires uncertain native %s transitions visibly without disconnecting clients",
+    async (transition) => {
+      const f = fixture();
+      const c = f.client();
+      const root = await c.attach();
+      if (transition === "disable") {
+        await c.request("Target.setAutoAttach", root, enabled);
+        f.child("child");
+      }
+      f.fail("Target.setAutoAttach");
+      expect(
+        (
+          await c.request("Target.setAutoAttach", root, {
+            ...enabled,
+            autoAttach: transition === "enable",
+          })
+        ).error,
+      ).toBeDefined();
+      expect.soft((await c.request("Runtime.evaluate", root)).error).toBeDefined();
+      expect(c.socket.closed).toBe(false);
+      await flush();
+      expect(f.commands("detach")).toHaveLength(1);
+    },
+  );
+
+  it("cleans the last unused child without stranding its native wait", async () => {
+    const f = fixture();
+    const c = f.client();
+    const root = await c.attach();
+    await c.request("Target.setAutoAttach", root, enabled);
+    f.child("child");
+    const child = childId(c, root);
+    await c.request("Target.detachFromTarget", root, { sessionId: child });
+    expect(f.commands("Target.detachFromTarget").at(-1)?.params).toEqual({ sessionId: "child" });
+    expect((await c.request("Runtime.evaluate", root)).error).toBeUndefined();
+  });
+
+  it.each(["sessionId", "targetId"])(
+    "routes non-flat child commands by %s through the same logical owner",
+    async (selector) => {
+      const f = fixture();
+      const c = f.client();
+      const root = await c.attach();
+      await c.request("Target.setAutoAttach", root, { ...enabled, flatten: false });
+      f.child("child");
+      const child = childId(c, root);
+      expect(child).not.toBe("child");
+      await c.request("Target.sendMessageToTarget", root, {
+        [selector]: selector === "sessionId" ? child : "target-child",
+        message: JSON.stringify({
+          id: 71,
+          method: "Runtime.evaluate",
+          params: { expression: "1" },
+        }),
+      });
+      await vi.waitFor(() =>
+        expect(c.socket.frames()).toContainEqual({
+          sessionId: root,
+          method: "Target.receivedMessageFromTarget",
+          params: {
+            sessionId: child,
+            targetId: "target-child",
+            message: JSON.stringify({ id: 71, result: { ok: true, echoed: "Runtime.evaluate" } }),
+          },
+        }),
+      );
+      expect(f.commands("Runtime.evaluate").at(-1)?.sessionId).toBe("child");
+    },
+  );
+  it("updates cached child metadata only for interested parents", async () => {
+    const f = fixture();
+    const c = f.client();
+    const unenabled = await c.attach();
+    const parent = await c.alias();
+    await c.request("Target.setAutoAttach", parent, enabled);
+    f.child("child");
+    const info = { targetId: "target-child", type: "worker", url: "https://example.com/updated" };
+    f.event("Target.targetInfoChanged", { targetInfo: info });
+    expect
+      .soft(c.socket.frames().filter((frame) => frame.method === "Target.targetInfoChanged"))
+      .toEqual([
+        { sessionId: parent, method: "Target.targetInfoChanged", params: { targetInfo: info } },
+      ]);
+    await c.request("Target.setAutoAttach", unenabled, enabled);
+    expect(c.attached(unenabled)[0]).toMatchObject({ targetInfo: info });
+  });
+
+  it("does not serialize ordinary commands or an independent child behind a parent transition", async () => {
+    const f = fixture();
+    const c = f.client();
+    const root = await c.attach();
+    await c.request("Target.setAutoAttach", root, enabled);
+    f.child("child");
+    const child = childId(c, root);
+    f.hold("Target.setAutoAttach");
+    const pending = c.send("Target.setAutoAttach", root, {
+      ...enabled,
+      waitForDebuggerOnStart: false,
+    });
+    await vi.waitFor(() => expect(f.held).toHaveLength(1));
+    expect((await c.request("Runtime.evaluate", root)).error).toBeUndefined();
+    expect((await c.request("Runtime.enable", root)).error).toBeUndefined();
+    expect((await c.request("Fetch.enable", child)).error).toBeUndefined();
+    f.hold(undefined);
+    expect((await c.request("Target.setAutoAttach", child, enabled)).error).toBeUndefined();
+    expect(c.socket.frames().find((frame) => frame.id === pending)).toBeUndefined();
+    f.release();
+    expect((await c.response(pending)).error).toBeUndefined();
+  });
+
+  it("retires a partially mutating enable and discards its late native child", async () => {
+    const f = fixture();
+    const c = f.client();
+    const root = await c.attach();
+    f.hold("Target.setAutoAttach");
+    const pending = c.send("Target.setAutoAttach", root, enabled);
+    await vi.waitFor(() => expect(f.held).toHaveLength(1));
+    f.child("child");
+    expect(c.attached(root)).toEqual([]);
+    f.extension.handlers.onMessage(
+      JSON.stringify({
+        type: "error",
+        seq: f.held[0]!.seq,
+        message: "post-command admission failed",
+      }),
+    );
+    expect((await c.response(pending)).error).toBeDefined();
+    f.child("late-child");
+    expect(c.attached(root)).toEqual([]);
+    expect((await c.request("Runtime.evaluate", root)).error).toBeDefined();
+    expect(c.socket.closed).toBe(false);
+  });
+
+  it("does not reuse child aliases after the native parent is replaced", async () => {
+    const f = fixture();
+    const c = f.client();
+    const root = await c.attach();
+    await c.request("Target.setAutoAttach", root, enabled);
+    f.child("child");
+    const old = childId(c, root);
+    f.extension.handlers.onMessage(
+      JSON.stringify({ type: "detached", tabId: 1, reason: "target_closed" }),
+    );
+    const next = await c.attach();
+    await c.request("Target.setAutoAttach", next, enabled);
+    f.child("child");
+    const fresh = childId(c, next);
+    expect(fresh).not.toBe(old);
+    expect((await c.request("Runtime.evaluate", old)).error).toBeDefined();
+    expect((await c.request("Runtime.evaluate", fresh)).error).toBeUndefined();
+  });
+
+  it("keeps synthetic browser-root pages visible for Puppeteer's browser filter", async () => {
+    const f = fixture();
+    const c = f.client();
+    expect(
+      (
+        await c.request("Target.setAutoAttach", undefined, {
+          ...enabled,
+          filter: [{ type: "page", exclude: true }, {}],
+        })
+      ).error,
+    ).toBeUndefined();
+    expect(c.attached()).toHaveLength(1);
+  });
+
+  it("routes a flat descendant through its non-flat ancestor transport", async () => {
+    const f = fixture();
+    const c = f.client();
+    const root = await c.attach();
+    await c.request("Target.setAutoAttach", root, { ...enabled, flatten: false });
+    f.child("child");
+    const child = childId(c, root);
+    await c.request("Target.sendMessageToTarget", root, {
+      sessionId: child,
+      message: JSON.stringify({ id: 101, method: "Target.setAutoAttach", params: enabled }),
+    });
+    await flush();
+    f.child("grandchild", "child");
+    const nested = c.socket
+      .frames()
+      .filter((frame) => frame.method === "Target.receivedMessageFromTarget")
+      .map((frame) => JSON.parse(String(asOptionalRecord(frame.params)?.message)));
+    const grandchild = nested.find((frame) => frame.method === "Target.attachedToTarget")?.params
+      .sessionId;
+    expect(typeof grandchild).toBe("string");
+    await c.request("Target.sendMessageToTarget", root, {
+      sessionId: child,
+      message: JSON.stringify({ id: 102, sessionId: grandchild, method: "Runtime.evaluate" }),
+    });
+    await flush();
+    expect.soft(f.commands("Runtime.evaluate").at(-1)?.sessionId).toBe("grandchild");
+    expect(c.socket.frames()).toContainEqual({
+      sessionId: root,
+      method: "Target.receivedMessageFromTarget",
+      params: {
+        sessionId: child,
+        targetId: "target-child",
+        message: JSON.stringify({
+          id: 102,
+          result: { ok: true, echoed: "Runtime.evaluate" },
+          sessionId: grandchild,
+        }),
+      },
+    });
+  });
+
+  it("does not detach an already-closed child after held Fetch cleanup finishes", async () => {
+    const f = fixture();
+    const c = f.client();
+    const root = await c.attach();
+    await c.request("Target.setAutoAttach", root, enabled);
+    f.child("child");
+    const child = childId(c, root);
+    await c.request("Fetch.enable", child);
+    f.event("Fetch.requestPaused", { requestId: "paused" }, "child");
+    f.hold("Fetch.failRequest");
+    const detaching = c.send("Target.detachFromTarget", root, { sessionId: child });
+    await vi.waitFor(() => expect(f.held).toHaveLength(1));
+    f.event("Target.detachedFromTarget", { sessionId: "child", targetId: "target-child" });
+    f.fail("Target.detachFromTarget");
+    f.release();
+    expect.soft((await c.response(detaching)).error).toBeUndefined();
+    expect.soft(f.commands("Target.detachFromTarget")).toEqual([]);
+    expect((await c.request("Runtime.evaluate", root)).error).toBeUndefined();
+  });
+});

--- a/extensions/browser/src/browser/pw-session-actions.ts
+++ b/extensions/browser/src/browser/pw-session-actions.ts
@@ -309,6 +309,7 @@ async function readPagesViaPlaywright(
   return await withPlaywrightSafeReadReconnect(
     { cdpUrl: opts.cdpUrl, ssrfPolicy: opts.ssrfPolicy, attempt },
     async (browser) => {
+      let remainingTargetIds: Set<string> | undefined;
       if (opts.requireCompleteTargetList) {
         const session = await browser.newBrowserCDPSession();
         try {
@@ -316,6 +317,13 @@ async function readPagesViaPlaywright(
           if (!Array.isArray(result.targetInfos)) {
             throw new Error("Browser target enumeration was unavailable.");
           }
+          remainingTargetIds = new Set(
+            result.targetInfos
+              .filter(
+                (info) => info.type === "page" && !isBlockedTarget(opts.cdpUrl, info.targetId),
+              )
+              .map((info) => info.targetId),
+          );
         } finally {
           await session.detach().catch(() => {});
         }
@@ -360,12 +368,18 @@ async function readPagesViaPlaywright(
       );
       // Promise.all preserves candidate order and still propagates recoverable disconnects
       // to the outer reconnect path when any per-page task rejects.
+      // Native discovery can lead Page publication. Consume only projected IDs from that
+      // snapshot; a quarantined Page reference alone cannot identify a missing native target.
       const resolvedPages = pageResults.flatMap((result) =>
-        result.status === "available" ? [result.page] : [],
+        result.status === "available" &&
+        (!remainingTargetIds || remainingTargetIds.delete(result.page.targetId))
+          ? [result.page]
+          : [],
       );
       if (
-        resolvedPages.length === 0 &&
-        pageResults.some((result) => result.status === "unresolved")
+        (remainingTargetIds && remainingTargetIds.size > 0) ||
+        ((opts.requireCompleteTargetList || resolvedPages.length === 0) &&
+          pageResults.some((result) => result.status === "unresolved"))
       ) {
         return { status: "unavailable", reason: "target-identity-unresolved" };
       }

--- a/extensions/browser/src/browser/pw-session.connection.test-support.ts
+++ b/extensions/browser/src/browser/pw-session.connection.test-support.ts
@@ -1,0 +1,65 @@
+import { chromium } from "playwright-core";
+import { afterEach, vi } from "vitest";
+import * as chromeModule from "./chrome.js";
+import { pwAi } from "./pw-ai.js";
+import { markPageRefBlocked, markTargetBlocked } from "./pw-session-connection.js";
+
+const { registerManagedProxyBrowserCdpBypassMock } = vi.hoisted(() => ({
+  registerManagedProxyBrowserCdpBypassMock: vi.fn<(url: string) => (() => void) | undefined>(
+    () => undefined,
+  ),
+}));
+
+vi.mock("openclaw/plugin-sdk/ssrf-runtime-internal", () => ({
+  registerManagedProxyBrowserCdpBypass: registerManagedProxyBrowserCdpBypassMock,
+}));
+
+export type BrowserMockBundle = {
+  browser: import("playwright-core").Browser;
+  browserClose: ReturnType<typeof vi.fn>;
+};
+
+export function makeEmptyBrowser(): BrowserMockBundle {
+  const browserClose = vi.fn(async () => {});
+  const context = {
+    pages: () => [],
+    on: vi.fn(),
+    newCDPSession: vi.fn(),
+  } as unknown as import("playwright-core").BrowserContext;
+
+  const browser = {
+    contexts: () => [context],
+    on: vi.fn(),
+    off: vi.fn(),
+    close: browserClose,
+  } as unknown as import("playwright-core").Browser;
+
+  return { browser, browserClose };
+}
+
+export function setupPwSessionConnectionTest() {
+  const connectOverCdpSpy = vi.spyOn(chromium, "connectOverCDP");
+  const getChromeWebSocketEndpointSpy = vi.spyOn(chromeModule, "getChromeWebSocketEndpoint");
+  const getChromeWebSocketUrlSpy = getChromeWebSocketEndpointSpy;
+
+  const { closePlaywrightBrowserConnection } = pwAi;
+
+  afterEach(async () => {
+    connectOverCdpSpy.mockReset();
+    getChromeWebSocketUrlSpy.mockReset();
+    registerManagedProxyBrowserCdpBypassMock.mockReset();
+    registerManagedProxyBrowserCdpBypassMock.mockImplementation(() => undefined);
+    await closePlaywrightBrowserConnection().catch(() => {});
+    vi.useRealTimers();
+  });
+
+  return {
+    connectOverCdpSpy,
+    getChromeWebSocketEndpointSpy,
+    getChromeWebSocketUrlSpy,
+    markPageRefBlocked,
+    markTargetBlocked,
+    pwAi,
+    registerManagedProxyBrowserCdpBypassMock,
+  };
+}

--- a/extensions/browser/src/browser/pw-session.connections.test.ts
+++ b/extensions/browser/src/browser/pw-session.connections.test.ts
@@ -1,18 +1,17 @@
-// Browser tests cover pw session.connections plugin behavior.
-import { chromium } from "playwright-core";
-import { afterEach, describe, expect, it, vi } from "vitest";
-import * as chromeModule from "./chrome.js";
-import { pwAi } from "./pw-ai.js";
+import { describe, expect, it, vi } from "vitest";
+import {
+  type BrowserMockBundle,
+  makeEmptyBrowser,
+  setupPwSessionConnectionTest,
+} from "./pw-session.connection.test-support.js";
 
-const { registerManagedProxyBrowserCdpBypassMock } = vi.hoisted(() => ({
-  registerManagedProxyBrowserCdpBypassMock: vi.fn<(url: string) => (() => void) | undefined>(
-    () => undefined,
-  ),
-}));
-
-vi.mock("openclaw/plugin-sdk/ssrf-runtime-internal", () => ({
-  registerManagedProxyBrowserCdpBypass: registerManagedProxyBrowserCdpBypassMock,
-}));
+const {
+  connectOverCdpSpy,
+  getChromeWebSocketEndpointSpy,
+  getChromeWebSocketUrlSpy,
+  registerManagedProxyBrowserCdpBypassMock,
+  pwAi,
+} = setupPwSessionConnectionTest();
 
 const {
   closePlaywrightBrowserConnection,
@@ -22,15 +21,6 @@ const {
   retirePlaywrightBrowserConnection,
   retirePlaywrightBrowserConnectionExact,
 } = pwAi;
-
-const connectOverCdpSpy = vi.spyOn(chromium, "connectOverCDP");
-const getChromeWebSocketEndpointSpy = vi.spyOn(chromeModule, "getChromeWebSocketEndpoint");
-const getChromeWebSocketUrlSpy = getChromeWebSocketEndpointSpy;
-
-type BrowserMockBundle = {
-  browser: import("playwright-core").Browser;
-  browserClose: ReturnType<typeof vi.fn>;
-};
 
 function makeBrowser(targetId: string, url: string): BrowserMockBundle {
   const browserClose = vi.fn(async () => {});
@@ -52,80 +42,6 @@ function makeBrowser(targetId: string, url: string): BrowserMockBundle {
       ),
       detach: vi.fn(async () => {}),
     })),
-  } as unknown as import("playwright-core").BrowserContext;
-
-  const browser = {
-    contexts: () => [context],
-    on: vi.fn(),
-    off: vi.fn(),
-    close: browserClose,
-  } as unknown as import("playwright-core").Browser;
-
-  return { browser, browserClose };
-}
-
-function makePageEnumerationBrowser(
-  specs: Array<{
-    targetId: string;
-    title: string;
-    url: string;
-    readTitle?: () => Promise<string>;
-    readTargetInfo?: () => Promise<{ targetInfo: { targetId: string; title: string } }>;
-    detach?: () => Promise<void>;
-  }>,
-): BrowserMockBundle & {
-  pages: import("playwright-core").Page[];
-  newCDPSession: ReturnType<typeof vi.fn>;
-} {
-  const browserClose = vi.fn(async () => {});
-  const specByPage = new WeakMap<import("playwright-core").Page, (typeof specs)[number]>();
-  const pages = specs.map((spec) => {
-    const page = {
-      on: vi.fn(),
-      context: () => context,
-      title: vi.fn(spec.readTitle ?? (async () => spec.title)),
-      url: vi.fn(() => spec.url),
-    } as unknown as import("playwright-core").Page;
-    specByPage.set(page, spec);
-    return page;
-  });
-  const newCDPSession = vi.fn(async (page: import("playwright-core").Page) => {
-    const spec = specByPage.get(page);
-    if (!spec) {
-      throw new Error("unexpected page");
-    }
-    return {
-      send: vi.fn(async (method: string) => {
-        if (method !== "Target.getTargetInfo") {
-          return {};
-        }
-        return await (spec.readTargetInfo?.() ??
-          Promise.resolve({ targetInfo: { targetId: spec.targetId, title: spec.title } }));
-      }),
-      detach: vi.fn(spec.detach ?? (async () => {})),
-    };
-  });
-  const context = {
-    pages: () => pages,
-    on: vi.fn(),
-    newCDPSession,
-  } as unknown as import("playwright-core").BrowserContext;
-  const browser = {
-    contexts: () => [context],
-    on: vi.fn(),
-    off: vi.fn(),
-    close: browserClose,
-  } as unknown as import("playwright-core").Browser;
-
-  return { browser, browserClose, pages, newCDPSession };
-}
-
-function makeEmptyBrowser(): BrowserMockBundle {
-  const browserClose = vi.fn(async () => {});
-  const context = {
-    pages: () => [],
-    on: vi.fn(),
-    newCDPSession: vi.fn(),
   } as unknown as import("playwright-core").BrowserContext;
 
   const browser = {
@@ -229,15 +145,6 @@ function makeMutatingDisconnectBrowser(): BrowserMockBundle & {
 
   return { browser, browserClose, newPage };
 }
-
-afterEach(async () => {
-  connectOverCdpSpy.mockReset();
-  getChromeWebSocketUrlSpy.mockReset();
-  registerManagedProxyBrowserCdpBypassMock.mockReset();
-  registerManagedProxyBrowserCdpBypassMock.mockImplementation(() => undefined);
-  await closePlaywrightBrowserConnection().catch(() => {});
-  vi.useRealTimers();
-});
 
 describe("pw-session connection scoping", () => {
   it("keeps the exact managed-proxy bypass active through a discovered CDP handshake", async () => {
@@ -676,158 +583,6 @@ describe("pw-session connection scoping", () => {
     expect(connectOverCdpSpy).toHaveBeenCalledTimes(2);
     await vi.waitFor(() => expect(stale.browserClose).toHaveBeenCalledTimes(1));
     expect(refreshed.browserClose).not.toHaveBeenCalled();
-  });
-
-  it("lists healthy pages without awaiting a wedged page title", async () => {
-    vi.useFakeTimers();
-    const fixture = makePageEnumerationBrowser([
-      {
-        targetId: "WEDGED",
-        title: "Wedged",
-        url: "https://wedged.example",
-        readTitle: () => new Promise<string>(() => {}),
-      },
-      {
-        targetId: "HEALTHY",
-        title: "Healthy title",
-        url: "https://healthy.example",
-      },
-    ]);
-    connectOverCdpSpy.mockResolvedValue(fixture.browser);
-    getChromeWebSocketUrlSpy.mockResolvedValue(null);
-
-    let listed: Awaited<ReturnType<typeof listPagesViaPlaywright>> | undefined;
-    void listPagesViaPlaywright({ cdpUrl: "http://127.0.0.1:9222" }).then((pages) => {
-      listed = pages;
-    });
-    await vi.advanceTimersByTimeAsync(100);
-
-    expect(listed).toEqual([
-      {
-        targetId: "WEDGED",
-        title: "Wedged",
-        url: "https://wedged.example",
-        type: "page",
-      },
-      {
-        targetId: "HEALTHY",
-        title: "Healthy title",
-        url: "https://healthy.example",
-        type: "page",
-      },
-    ]);
-  });
-
-  it("times out stuck target-info reads in one window and shares them across enumerations", async () => {
-    vi.useFakeTimers();
-    const fixture = makePageEnumerationBrowser([
-      {
-        targetId: "STUCK_A",
-        title: "Stuck A",
-        url: "https://stuck-a.example",
-        readTargetInfo: () => new Promise(() => {}),
-        detach: () => new Promise(() => {}),
-      },
-      {
-        targetId: "STUCK_B",
-        title: "Stuck B",
-        url: "https://stuck-b.example",
-        readTargetInfo: () => new Promise(() => {}),
-        detach: () => new Promise(() => {}),
-      },
-      {
-        targetId: "HEALTHY",
-        title: "Healthy title",
-        url: "https://healthy.example",
-      },
-    ]);
-    connectOverCdpSpy.mockResolvedValue(fixture.browser);
-    getChromeWebSocketUrlSpy.mockResolvedValue(null);
-
-    let listed: Array<Awaited<ReturnType<typeof listPagesViaPlaywright>>> | undefined;
-    void Promise.all([
-      listPagesViaPlaywright({ cdpUrl: "http://127.0.0.1:9222" }),
-      listPagesViaPlaywright({ cdpUrl: "http://127.0.0.1:9222" }),
-    ]).then((pages) => {
-      listed = pages;
-    });
-    await vi.advanceTimersByTimeAsync(2_000);
-
-    expect(listed).toEqual([
-      [
-        {
-          targetId: "HEALTHY",
-          title: "Healthy title",
-          url: "https://healthy.example",
-          type: "page",
-        },
-      ],
-      [
-        {
-          targetId: "HEALTHY",
-          title: "Healthy title",
-          url: "https://healthy.example",
-          type: "page",
-        },
-      ],
-    ]);
-    expect(
-      fixture.pages
-        .slice(0, 2)
-        .map(
-          (page) =>
-            fixture.newCDPSession.mock.calls.filter(([candidate]) => candidate === page).length,
-        ),
-    ).toEqual([1, 1]);
-  });
-
-  it("reports unavailable when every accessible page identity is unresolved", async () => {
-    vi.useFakeTimers();
-    const fixture = makePageEnumerationBrowser([
-      {
-        targetId: "STUCK_A",
-        title: "Stuck A",
-        url: "https://stuck-a.example",
-        readTargetInfo: () => new Promise(() => {}),
-      },
-      {
-        targetId: "STUCK_B",
-        title: "Stuck B",
-        url: "https://stuck-b.example",
-        readTargetInfo: () => new Promise(() => {}),
-      },
-    ]);
-    connectOverCdpSpy.mockResolvedValue(fixture.browser);
-    getChromeWebSocketUrlSpy.mockResolvedValue(null);
-
-    const listing = listPagesViaPlaywright({ cdpUrl: "http://127.0.0.1:9222" });
-    const unavailable = expect(listing).rejects.toThrow(/target identities.*unavailable/i);
-    await vi.advanceTimersByTimeAsync(2_000);
-
-    await unavailable;
-  });
-
-  it("rejects an unavailable complete target enumeration even with zero cached pages", async () => {
-    const fixture = makeEmptyBrowser();
-    const detach = vi.fn(async () => {});
-    const browser = Object.assign(fixture.browser, {
-      newBrowserCDPSession: vi.fn(async () => ({
-        send: vi.fn(async () => {
-          throw new Error("Target identities are unavailable");
-        }),
-        detach,
-      })),
-    });
-    connectOverCdpSpy.mockResolvedValue(browser);
-    getChromeWebSocketUrlSpy.mockResolvedValue(null);
-
-    await expect(
-      listPagesViaPlaywright({
-        cdpUrl: "http://127.0.0.1:9222",
-        requireCompleteTargetList: true,
-      }),
-    ).rejects.toThrow(/target identities.*unavailable/i);
-    expect(detach).toHaveBeenCalledOnce();
   });
 
   it("times out stuck page enumeration and evicts the scoped connection", async () => {

--- a/extensions/browser/src/browser/pw-session.enumeration.test.ts
+++ b/extensions/browser/src/browser/pw-session.enumeration.test.ts
@@ -1,0 +1,401 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  type BrowserMockBundle,
+  makeEmptyBrowser,
+  setupPwSessionConnectionTest,
+} from "./pw-session.connection.test-support.js";
+
+const { connectOverCdpSpy, getChromeWebSocketUrlSpy, markPageRefBlocked, markTargetBlocked, pwAi } =
+  setupPwSessionConnectionTest();
+
+const { listPagesViaPlaywright } = pwAi;
+
+function makePageEnumerationBrowser(
+  specs: Array<{
+    targetId: string;
+    title: string;
+    url: string;
+    readTitle?: () => Promise<string>;
+    readTargetInfo?: () => Promise<{ targetInfo: { targetId: string; title: string } }>;
+    detach?: () => Promise<void>;
+  }>,
+): BrowserMockBundle & {
+  pages: import("playwright-core").Page[];
+  newCDPSession: ReturnType<typeof vi.fn>;
+} {
+  const browserClose = vi.fn(async () => {});
+  const specByPage = new WeakMap<import("playwright-core").Page, (typeof specs)[number]>();
+  const pages = specs.map((spec) => {
+    const page = {
+      on: vi.fn(),
+      context: () => context,
+      title: vi.fn(spec.readTitle ?? (async () => spec.title)),
+      url: vi.fn(() => spec.url),
+    } as unknown as import("playwright-core").Page;
+    specByPage.set(page, spec);
+    return page;
+  });
+  const newCDPSession = vi.fn(async (page: import("playwright-core").Page) => {
+    const spec = specByPage.get(page);
+    if (!spec) {
+      throw new Error("unexpected page");
+    }
+    return {
+      send: vi.fn(async (method: string) => {
+        if (method !== "Target.getTargetInfo") {
+          return {};
+        }
+        return await (spec.readTargetInfo?.() ??
+          Promise.resolve({ targetInfo: { targetId: spec.targetId, title: spec.title } }));
+      }),
+      detach: vi.fn(spec.detach ?? (async () => {})),
+    };
+  });
+  const context = {
+    pages: () => pages,
+    on: vi.fn(),
+    newCDPSession,
+  } as unknown as import("playwright-core").BrowserContext;
+  const browser = {
+    contexts: () => [context],
+    on: vi.fn(),
+    off: vi.fn(),
+    close: browserClose,
+  } as unknown as import("playwright-core").Browser;
+
+  return { browser, browserClose, pages, newCDPSession };
+}
+
+describe("pw-session page enumeration", () => {
+  it("lists healthy pages without awaiting a wedged page title", async () => {
+    vi.useFakeTimers();
+    const fixture = makePageEnumerationBrowser([
+      {
+        targetId: "WEDGED",
+        title: "Wedged",
+        url: "https://wedged.example",
+        readTitle: () => new Promise<string>(() => {}),
+      },
+      {
+        targetId: "HEALTHY",
+        title: "Healthy title",
+        url: "https://healthy.example",
+      },
+    ]);
+    connectOverCdpSpy.mockResolvedValue(fixture.browser);
+    getChromeWebSocketUrlSpy.mockResolvedValue(null);
+
+    let listed: Awaited<ReturnType<typeof listPagesViaPlaywright>> | undefined;
+    void listPagesViaPlaywright({ cdpUrl: "http://127.0.0.1:9222" }).then((pages) => {
+      listed = pages;
+    });
+    await vi.advanceTimersByTimeAsync(100);
+
+    expect(listed).toEqual([
+      {
+        targetId: "WEDGED",
+        title: "Wedged",
+        url: "https://wedged.example",
+        type: "page",
+      },
+      {
+        targetId: "HEALTHY",
+        title: "Healthy title",
+        url: "https://healthy.example",
+        type: "page",
+      },
+    ]);
+  });
+
+  it("times out stuck target-info reads in one window and shares them across enumerations", async () => {
+    vi.useFakeTimers();
+    const fixture = makePageEnumerationBrowser([
+      {
+        targetId: "STUCK_A",
+        title: "Stuck A",
+        url: "https://stuck-a.example",
+        readTargetInfo: () => new Promise(() => {}),
+        detach: () => new Promise(() => {}),
+      },
+      {
+        targetId: "STUCK_B",
+        title: "Stuck B",
+        url: "https://stuck-b.example",
+        readTargetInfo: () => new Promise(() => {}),
+        detach: () => new Promise(() => {}),
+      },
+      {
+        targetId: "HEALTHY",
+        title: "Healthy title",
+        url: "https://healthy.example",
+      },
+    ]);
+    connectOverCdpSpy.mockResolvedValue(fixture.browser);
+    getChromeWebSocketUrlSpy.mockResolvedValue(null);
+
+    let listed: Array<Awaited<ReturnType<typeof listPagesViaPlaywright>>> | undefined;
+    void Promise.all([
+      listPagesViaPlaywright({ cdpUrl: "http://127.0.0.1:9222" }),
+      listPagesViaPlaywright({ cdpUrl: "http://127.0.0.1:9222" }),
+    ]).then((pages) => {
+      listed = pages;
+    });
+    await vi.advanceTimersByTimeAsync(2_000);
+
+    expect(listed).toEqual([
+      [
+        {
+          targetId: "HEALTHY",
+          title: "Healthy title",
+          url: "https://healthy.example",
+          type: "page",
+        },
+      ],
+      [
+        {
+          targetId: "HEALTHY",
+          title: "Healthy title",
+          url: "https://healthy.example",
+          type: "page",
+        },
+      ],
+    ]);
+    expect(
+      fixture.pages
+        .slice(0, 2)
+        .map(
+          (page) =>
+            fixture.newCDPSession.mock.calls.filter(([candidate]) => candidate === page).length,
+        ),
+    ).toEqual([1, 1]);
+  });
+
+  it("reports unavailable when every accessible page identity is unresolved", async () => {
+    vi.useFakeTimers();
+    const fixture = makePageEnumerationBrowser([
+      {
+        targetId: "STUCK_A",
+        title: "Stuck A",
+        url: "https://stuck-a.example",
+        readTargetInfo: () => new Promise(() => {}),
+      },
+      {
+        targetId: "STUCK_B",
+        title: "Stuck B",
+        url: "https://stuck-b.example",
+        readTargetInfo: () => new Promise(() => {}),
+      },
+    ]);
+    connectOverCdpSpy.mockResolvedValue(fixture.browser);
+    getChromeWebSocketUrlSpy.mockResolvedValue(null);
+
+    const listing = listPagesViaPlaywright({ cdpUrl: "http://127.0.0.1:9222" });
+    const unavailable = expect(listing).rejects.toThrow(/target identities.*unavailable/i);
+    await vi.advanceTimersByTimeAsync(2_000);
+
+    await unavailable;
+  });
+
+  it("rejects an unavailable complete target enumeration even with zero cached pages", async () => {
+    const fixture = makeEmptyBrowser();
+    const detach = vi.fn(async () => {});
+    const browser = Object.assign(fixture.browser, {
+      newBrowserCDPSession: vi.fn(async () => ({
+        send: vi.fn(async () => {
+          throw new Error("Target identities are unavailable");
+        }),
+        detach,
+      })),
+    });
+    connectOverCdpSpy.mockResolvedValue(browser);
+    getChromeWebSocketUrlSpy.mockResolvedValue(null);
+
+    await expect(
+      listPagesViaPlaywright({
+        cdpUrl: "http://127.0.0.1:9222",
+        requireCompleteTargetList: true,
+      }),
+    ).rejects.toThrow(/target identities.*unavailable/i);
+    expect(detach).toHaveBeenCalledOnce();
+  });
+
+  it.each<{
+    name: string;
+    nativeIds: string[];
+    pageIds: string[];
+    unresolvedId?: string;
+    rejectedId?: string;
+    blockedId?: string;
+    blockedPageId?: string;
+    complete?: boolean;
+    expected: string[] | null;
+  }>([
+    {
+      name: "native page not yet published",
+      nativeIds: ["A", "B"],
+      pageIds: ["A"],
+      expected: null,
+    },
+    { name: "no published pages yet", nativeIds: ["A"], pageIds: [], expected: null },
+    {
+      name: "unresolved page metadata",
+      nativeIds: ["A", "B"],
+      pageIds: ["A", "B"],
+      unresolvedId: "B",
+      expected: null,
+    },
+    {
+      name: "rejected page metadata",
+      nativeIds: ["A", "B"],
+      pageIds: ["A", "B"],
+      rejectedId: "B",
+      expected: null,
+    },
+    {
+      name: "unresolved extra page",
+      nativeIds: ["A"],
+      pageIds: ["A", "B"],
+      unresolvedId: "B",
+      expected: null,
+    },
+    {
+      name: "equal counts with different identities",
+      nativeIds: ["A", "B"],
+      pageIds: ["A", "STALE"],
+      expected: null,
+    },
+    {
+      name: "native removal before page removal",
+      nativeIds: ["A"],
+      pageIds: ["A", "STALE"],
+      expected: ["A"],
+    },
+    { name: "last native page removed", nativeIds: [], pageIds: ["STALE"], expected: [] },
+    {
+      name: "all pages projected in page order",
+      nativeIds: ["B", "A"],
+      pageIds: ["A", "B"],
+      expected: ["A", "B"],
+    },
+    {
+      name: "known blocked target without a page",
+      nativeIds: ["A", "B"],
+      pageIds: ["A"],
+      blockedId: "B",
+      expected: ["A"],
+    },
+    {
+      name: "known blocked target with a page",
+      nativeIds: ["A", "B"],
+      pageIds: ["A", "B"],
+      blockedId: "B",
+      expected: ["A"],
+    },
+    {
+      name: "known blocked page and target",
+      nativeIds: ["A", "B"],
+      pageIds: ["A", "B"],
+      blockedId: "B",
+      blockedPageId: "B",
+      expected: ["A"],
+    },
+    {
+      name: "blocked page cannot identify missing native target",
+      nativeIds: ["A", "B"],
+      pageIds: ["A", "B"],
+      blockedPageId: "B",
+      unresolvedId: "B",
+      expected: null,
+    },
+    {
+      name: "blocked page after native removal",
+      nativeIds: ["A"],
+      pageIds: ["A", "B"],
+      blockedPageId: "B",
+      expected: ["A"],
+    },
+    {
+      name: "general read keeps a healthy subset",
+      nativeIds: ["A", "B"],
+      pageIds: ["A", "B"],
+      unresolvedId: "B",
+      complete: false,
+      expected: ["A"],
+    },
+    {
+      name: "general read ignores native inventory",
+      nativeIds: [],
+      pageIds: ["A"],
+      complete: false,
+      expected: ["A"],
+    },
+  ])("enforces enumeration completeness: $name", async (testCase) => {
+    const cdpUrl = "http://127.0.0.1:9222";
+    const fixture = makePageEnumerationBrowser(
+      testCase.pageIds.map((targetId) => ({
+        targetId,
+        title: `projected:${targetId}`,
+        url: "https://same.example/",
+        readTargetInfo: async () => {
+          if (targetId === testCase.rejectedId) {
+            throw new Error("Target metadata unavailable");
+          }
+          return {
+            targetInfo: {
+              targetId: targetId === testCase.unresolvedId ? "" : targetId,
+              title: `projected:${targetId}`,
+            },
+          };
+        },
+      })),
+    );
+    const inventoryRead = vi.fn(async () => ({
+      targetInfos: [
+        ...testCase.nativeIds.map((targetId) => ({
+          targetId,
+          type: "page",
+          title: "native title",
+          url: "https://native.example/",
+        })),
+        { targetId: "WORKER", type: "service_worker" },
+      ],
+    }));
+    const detach = vi.fn(async () => {});
+    Object.assign(fixture.browser, {
+      newBrowserCDPSession: vi.fn(async () => ({ send: inventoryRead, detach })),
+    });
+    connectOverCdpSpy.mockResolvedValue(fixture.browser);
+    getChromeWebSocketUrlSpy.mockResolvedValue(null);
+    if (testCase.blockedId) {
+      markTargetBlocked(cdpUrl, testCase.blockedId);
+    }
+    const blockedPage = fixture.pages.find(
+      (_, index) => testCase.pageIds[index] === testCase.blockedPageId,
+    );
+    if (blockedPage) {
+      markPageRefBlocked(cdpUrl, blockedPage);
+    }
+
+    const requireCompleteTargetList = testCase.complete ?? true;
+    const listing = listPagesViaPlaywright({ cdpUrl, requireCompleteTargetList });
+    if (testCase.expected === null) {
+      await expect(listing).rejects.toThrow(/target identities.*unavailable/i);
+    } else {
+      await expect(listing).resolves.toEqual(
+        testCase.expected.map((targetId) => ({
+          targetId,
+          title: `projected:${targetId}`,
+          url: "https://same.example/",
+          type: "page",
+        })),
+      );
+    }
+    expect(inventoryRead).toHaveBeenCalledTimes(requireCompleteTargetList ? 1 : 0);
+    expect(detach).toHaveBeenCalledTimes(requireCompleteTargetList ? 1 : 0);
+    expect(connectOverCdpSpy).toHaveBeenCalledOnce();
+    expect(fixture.browserClose).not.toHaveBeenCalled();
+    if (blockedPage) {
+      expect(fixture.newCDPSession).not.toHaveBeenCalledWith(blockedPage);
+    }
+  });
+});

--- a/src/state/openclaw-agent-db.test.ts
+++ b/src/state/openclaw-agent-db.test.ts
@@ -3737,12 +3737,12 @@ describe("openclaw agent database", () => {
       older.close();
     }
     const repaired = openOpenClawAgentDatabase({ agentId: "worker-1", env });
-    expect(readSqliteNumberPragma(repaired.db, "user_version")).toBe(18);
+    expect(readSqliteNumberPragma(repaired.db, "user_version")).toBe(OPENCLAW_AGENT_SCHEMA_VERSION);
     expect(
       repaired.db
         .prepare("SELECT schema_version FROM schema_meta WHERE meta_key = 'primary'")
         .get(),
-    ).toEqual({ schema_version: 18 });
+    ).toEqual({ schema_version: OPENCLAW_AGENT_SCHEMA_VERSION });
     expect(
       repaired.db
         .prepare("SELECT event_json FROM transcript_events WHERE session_id = 'eligibility'")

--- a/src/state/openclaw-database-preflight.test.ts
+++ b/src/state/openclaw-database-preflight.test.ts
@@ -565,7 +565,10 @@ describe("OpenClaw database schema preflight", () => {
       const result = preflightOpenClawDatabaseSchemas({
         env,
         verifyCurrentSchemaShape: true,
-        supportedVersions: { state: OPENCLAW_STATE_SCHEMA_VERSION, agent: 18 },
+        supportedVersions: {
+          state: OPENCLAW_STATE_SCHEMA_VERSION,
+          agent: OPENCLAW_AGENT_SCHEMA_VERSION,
+        },
       });
       expect(result.incompatible).toEqual([]);
       expect(result.indeterminate).toEqual(
@@ -588,7 +591,9 @@ describe("OpenClaw database schema preflight", () => {
             )
             .get(),
         ).toEqual(shape === "absent" ? undefined : { name: "context_eligible" });
-        expect(inspected.prepare("PRAGMA user_version").get()).toEqual({ user_version: 18 });
+        expect(inspected.prepare("PRAGMA user_version").get()).toEqual({
+          user_version: OPENCLAW_AGENT_SCHEMA_VERSION,
+        });
       } finally {
         inspected.close();
       }


### PR DESCRIPTION
Related: #132484 — mixed-client Chrome relay investigation.

**Landed:** [2a6fc9b92f89ee3689e2d0a8338976bf225532f0](https://github.com/openclaw/openclaw/commit/2a6fc9b92f89ee3689e2d0a8338976bf225532f0), through native review, prepare and merge. Verified source head: `1931abab7f3b465cc720c72a598d6ea462504b63`, based on `6b27585471a7c0133fbdb7b43830f0366e0e417b`. [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/33256186449), attempt 1, passed, as did the original-order and public-action Chrome reruns. Final Linux tracing/child-session acceptance passed all seven verdicts and twelve child checks. All changed production files are byte-identical in the landed commit; main's separate private native-host test-fixture update was preserved and inspected. This is a main-branch landing, not a release.

<details>
<summary>Additional instructions</summary>

This upstream branch remains editable by maintainers.

</details>

## What Problem This Solves

Resolves remaining failures where clients sharing the Chrome-extension relay could interfere with request interception, lose frame or worker sessions when another logical parent detached, or remain blocked by cleanup failure on an unrelated tab. Complete tab listing could also report success before every native target had a usable Playwright Page.

The original Playwright-before-MCP labeled-screenshot failure is documented in [the mixed-client investigation](https://github.com/openclaw/openclaw/issues/132484). Its Runtime/socket foundation landed separately in [the tracing and controlled-document repair](https://github.com/openclaw/openclaw/pull/132485) while this PR was preparing. This is the remaining ownership repair on top of that canonical code, not a second foundation.

Work is coordinated with [the standalone relay repair](https://github.com/openclaw/openclaw/pull/128379), without taking over that PR or claiming implementation equivalence.

## Why This Change Was Made

The extension owns each native acquisition and its unresolved cleanup debt; the relay owns physical root/child sessions and independently revocable logical clients. Runtime, Fetch and Target use the same logical-session identity, keeping the fix at the producer/lifecycle boundary rather than adding screenshot retries or disconnecting healthy clients.

Fetch requests and streams stay with their owner. Target auto-attachment preserves each parent's ordered filter, produces distinct child aliases, and admits late replay through the worker. Failed native cleanup remains local, visible and explicitly recoverable. Pending claims survive through announcement; explicit attachment cannot substitute another native target; complete enumeration requires actual native-to-Playwright projection.

Main's controlled-document, tracing, creation and compiled-native-host contracts remain intact. There is no global internal-page allowance, existing-tab rollback authority, pre-detach before explicit close, Runtime reset, new dependency/configuration/schema/wire field or version bump. The shipped Store 2.2.0 tabId-only creation reply remains supported alongside atomic replies.

The necessary CI refresh also preserves [main's navigation-matrix ownership changes](https://github.com/openclaw/openclaw/pull/132561) and fixes four test-only schema expectations. [The transcript-eligibility tests](https://github.com/openclaw/openclaw/pull/132457) create current databases; after [main advanced the creator-namespace schema](https://github.com/openclaw/openclaw/pull/132300), their literal-18 fields no longer described that fixture. They now use the already imported current-version constant. Database runtime, schema, migration, payload, index, drift and non-repair behavior are unchanged.

Production LOC: **+1,860/-509 (net +1,351)**. Tests: **+3,171/-449 (net +2,722)**, including 235 unchanged moved lines; test support **+87/-10 (net +77)**; docs **+44/-6 (net +38)**. Growth supplies absent ownership: native cleanup debt/recovery, Fetch request/auth/body/stream leases and per-parent child projection/filter admission. The global retirement chain, separate attaching map, permanent rejected cleanup registry, first-parent child routing, Runtime initialization cache and duplicate subscription state are removed. A net-neutral consumer patch would not preserve these supported concurrent-client contracts.

## User Impact

Clients can remain connected while another logical parent detaches or changes child-target interests. Request interception cannot be silently replaced by another client. Cleanup failure leaves the affected attachment fenced for explicit recovery without blocking unrelated tabs. Incomplete tab inventories return an error instead of silently omitting targets.

Tabs and some native policies remain shared: navigation can invalidate another client's snapshot, and pause-on-attach uses native last-update behavior, including DevTools suspend/resume. This is not complete CDP-domain isolation. Fetch cleanup is bounded, but dispatched native operations must drain; teardown does not guarantee pending network cancellation. Full native-generation protection requires updated extension bytes as well as OpenClaw. See [Chrome extension documentation](https://docs.openclaw.ai/tools/chrome-extension).

Broader ordinary Selected/group observation ordering, pause persistence, stronger retained native references, full synthetic-browser hierarchy, and binding/capture/daemon work remain explicitly in the standalone lane.

## Evidence

**Current resolved candidate:**

- **717 browser tests in 30 files** passed in the normal shared-worker lane with `isolate:false` retained. Main's moved matrices and all assertions are preserved; the exact two All/Selected replacement-generation regressions remain. Earlier owning regressions demonstrated native cleanup, logical child/filter, request/stream, binding, claimant and complete-inventory failures before their repairs.
- All four schema-fixture cases failed before and passed after the four expression substitutions. The full three database files passed **167 tests with 4 existing platform skips**. An initial unchanged version-8 migration case hit its elapsed maintenance-lease budget; an unchanged focused rerun and the exact full-command rerun both passed. No retry, environment override or larger timeout was added.
- Formatting, core/browser lint, extension-test types and the owning core-test shard passed. **`pnpm build`** and the full **`node scripts/check-changed.mjs --staged`** plan passed on the resolved candidate. Fresh isolated autoreview returned **scoped-clean**, no findings at its requested/default **P0-only** threshold, not broader severity clearance.
- Every changed production repair file is byte-identical to the previously reviewed be060 candidate. Main's upstream-only strict agent resolution in `vision.ts` is preserved; no production change was made for the CI repair.

**Current-head live evidence:** 1931 passed the complete original-order isolated Chrome bootstrap in 50.66 seconds: early extension `/tabs` before MCP, both labeled screenshots, actual socket replacement, binding callbacks before Runtime enable/after disable, navigation recovery, both-mode creation, native launcher probes, pause/unpair and cleanup. A separate current-head public `/tabs` → `/snapshot` → `/act` proof passed its request-ownership assertions with the original clients retained, then completed the original fixture. Actual Chrome 151.0.7922.34, Playwright 1.62.1 and MCP handshake 1.8.0 were used. All five images were inspected, the temporary fixture was restored exactly, and clients closed. The separate final Linux run below covers the remaining tracing and real child-session paths. Private scenario details and artifacts are not published.

**Final Linux acceptance passed on frozen 1931.** Provider `blacksmith-testbox`, lease `tbx_01m17a5ar51t95c5shj0z8pcn5`, backed by [Actions run 33266569748](https://github.com/openclaw/openclaw/actions/runs/33266569748). The workflow identifies the lease; the verified controller results—not workflow status—are the browser evidence. A fresh canonical install/build used Node 24.18.1, Playwright 1.62.1, Chrome 151.0.7922.34 and the unmodified MCP 1.8.0 package. The container had a private PID namespace, zero capabilities, no host mounts, and network detachment before browser proof.

All seven ordered cases met their exact oracle: the historical extension failed at the intended denied blank-navigation boundary; All/Selected default reload, active revocation, real socket loss, explicit close and real child projection passed. All twelve child checks passed, covering per-parent aliases and interest, current Runtime/wait replay, concurrent Runtime with interception active, surviving-parent request/session ownership and non-flat delivery. Original clients were retained where required. Parent matched all 35,131 source hashes to the frozen candidate and verified every safe archive member, source/package/58-fixture/complete-dist integrity, all six Linux screenshots, exact container removal, provider `completed` state and verified sync-root cleanup. Safe archive SHA-256: `aa85ea325be4fecf367bff9b48ac688d0a01a51a6ef37f30378084d018090a54`.

Earlier attempts remain recorded as setup failures, not passing negatives. The setup repairs were complete-inventory I/O, canonical Git stat-cache priming, ordinary Docker API readiness for socket activation, and normal npm declared-bin executable metadata. The raw tarball's non-executable bin reproduced `EACCES`; npm's bin preparation made the same bytes report 1.8.0 in a network-denied smoke test. All 345 upstream hashes stayed unchanged. The final payload changed only package acquisition and its executable-mode integrity guard plus the derived inventory; all browser fixtures, assertions, oracles, timeouts, access policy and product source remained unchanged. No live gate was waived.

The later [document-provenance simplification](https://github.com/openclaw/openclaw/pull/132646) is landed and disjoint; its old owner and exact patch were inspected. The known [main-CI fixture-lifetime repair](https://github.com/openclaw/openclaw/pull/132666) is also merged. Latest ClawSweeper state is still the opening acknowledgment, with no completed review or Rank-up moves; no completed ClawSweeper review is claimed.

Exact database proof commands:

```bash
node scripts/run-vitest.mjs src/state/openclaw-agent-db.test.ts src/state/openclaw-database-preflight.test.ts -t 'installs transcript eligibility|preflights the .* transcript eligibility index'
```

```bash
node scripts/run-vitest.mjs src/state/openclaw-agent-db.test.ts src/state/openclaw-database-preflight.test.ts src/state/openclaw-database-verify.test.ts
```

Original-order live entrypoint:

```bash
OPENCLAW_BROWSER_EXTENSION_E2E=1 OPENCLAW_E2E_WORKERS=1 node scripts/run-vitest.mjs extensions/browser/chrome-extension/bootstrap.chromium.test.ts
```

Exact Chromium/V8/Playwright/Puppeteer/MCP/DevTools contracts were inspected directly, including native identity/absence, first-match filters, shared wait settings, flat/non-flat envelopes, Runtime replay and operation uncertainty. No operator browser, account, Gateway or live configuration was used. Images remain local because host/device-class approval for external upload was not established. No release or stable-package verification is claimed.

AI-assisted implementation with independent Codex review. Release-note context: browser plugin concurrent-client request ownership, frame/worker sessions, cleanup recovery and complete tab inventory; preserves the already-landed screenshot/tracing foundation.
