### PR TITLE
fix(qa): select external runtimes from fixture requirements

### DIFF
--- a/extensions/qa-lab/src/docker-harness.ts
+++ b/extensions/qa-lab/src/docker-harness.ts
@@ -264,6 +264,7 @@ export async function writeQaDockerHarnessFiles(params: {
     providerBaseUrl,
     workspaceDir: "/tmp/openclaw/workspace",
     controlUiRoot: "/app/dist/control-ui",
+    enabledPluginIds: ["acpx"],
     transportPluginIds: QA_CHANNEL_REQUIRED_PLUGIN_IDS,
     transportConfig: createQaChannelGatewayConfig({
       baseUrl: qaBusBaseUrl,

--- a/extensions/qa-lab/src/providers/image-generation.test.ts
+++ b/extensions/qa-lab/src/providers/image-generation.test.ts
@@ -10,7 +10,7 @@ describe("QA provider image generation config", () => {
       requiredPluginIds: ["qa-channel"],
     });
 
-    expect(patch.plugins.allow).toEqual(["acpx", "memory-core", "openai", "qa-channel"]);
+    expect(patch.plugins.allow).toEqual(["memory-core", "openai", "qa-channel"]);
     expect(patch.plugins.entries?.openai).toEqual({ enabled: true });
     expect(patch.agents.defaults.mediaModels.image.primary).toBe("openai/gpt-image-1");
     expect(patch.models?.providers["mock-openai"]?.baseUrl).toBe("http://127.0.0.1:44080/v1");
@@ -22,12 +22,12 @@ describe("QA provider image generation config", () => {
       providerMode: "mock-openai",
       providerBaseUrl: "http://127.0.0.1:44080/v1",
       requiredPluginIds: ["qa-channel"],
-      existingPluginIds: ["openai", "anthropic", "qa-channel"],
+      existingPluginIds: ["acpx", "openai", "anthropic", "qa-channel"],
     });
 
     expect(patch.plugins.allow).toEqual([
-      "acpx",
       "memory-core",
+      "acpx",
       "openai",
       "anthropic",
       "qa-channel",
@@ -62,7 +62,7 @@ describe("QA provider image generation config", () => {
       requiredPluginIds: [],
     });
 
-    expect(patch.plugins.allow).toEqual(["acpx", "memory-core", "openai"]);
+    expect(patch.plugins.allow).toEqual(["memory-core", "openai"]);
     expect(patch.plugins.entries).toEqual({ openai: { enabled: true } });
     expect(patch.agents.defaults.mediaModels.image.primary).toBe("openai/gpt-image-1");
     expect(patch.models?.providers.aimock?.baseUrl).toBe("http://127.0.0.1:45080/v1");
@@ -76,7 +76,7 @@ describe("QA provider image generation config", () => {
     });
 
     expect(patch.plugins).toEqual({
-      allow: ["acpx", "memory-core", "openai", "qa-channel"],
+      allow: ["memory-core", "openai", "qa-channel"],
       entries: {
         openai: {
           enabled: true,

--- a/extensions/qa-lab/src/qa-gateway-config.test.ts
+++ b/extensions/qa-lab/src/qa-gateway-config.test.ts
@@ -60,6 +60,27 @@ function expectQaLabPluginEnabled(cfg: ReturnType<typeof buildQaGatewayConfig>) 
 }
 
 describe("buildQaGatewayConfig", () => {
+  it.each([false, true])("requires explicit ACP fixture selection (selected=%s)", (selected) => {
+    const cfg = buildQaGatewayConfig({
+      bind: "loopback",
+      gatewayPort: 18789,
+      gatewayToken: "token",
+      workspaceDir: "/tmp/qa-workspace",
+      transportPluginIds: ["telegram"],
+      enabledPluginIds: selected ? ["acpx"] : [],
+    });
+
+    expect(cfg.plugins?.allow?.includes("acpx")).toBe(selected);
+    expect(cfg.plugins?.entries?.acpx).toEqual(
+      selected
+        ? {
+            enabled: true,
+            config: { pluginToolsMcpBridge: true, openClawToolsMcpBridge: true },
+          }
+        : undefined,
+    );
+  });
+
   it("stamps fresh QA configs with the current OpenClaw version", () => {
     const cfg = buildQaGatewayConfig({
       bind: "loopback",
@@ -70,7 +91,7 @@ describe("buildQaGatewayConfig", () => {
     });
 
     expect(cfg.meta).toEqual({ lastTouchedVersion: OPENCLAW_VERSION });
-    expect(cfg.plugins?.allow).toEqual(["acpx", "memory-core", "qa-lab", "qa-channel"]);
+    expect(cfg.plugins?.allow).toEqual(["memory-core", "qa-lab", "qa-channel"]);
     expect(getPrimaryModel(cfg.agents?.defaults?.model)).toBe("mock-openai/gpt-5.6-luna");
     expect(cfg.agents?.entries?.qa).not.toHaveProperty("default");
     expect(cfg.channels?.["qa-channel"]?.baseUrl).toBe("http://127.0.0.1:43124");
@@ -113,16 +134,10 @@ describe("buildQaGatewayConfig", () => {
         apiKey: "test",
       },
     });
-    expect(cfg.plugins?.allow).toEqual(["acpx", "memory-core", "qa-lab", "qa-channel"]);
+    expect(cfg.plugins?.allow).toEqual(["memory-core", "qa-lab", "qa-channel"]);
     expectQaLabPluginEnabled(cfg);
     expect(cfg.plugins?.slots?.memory).toBe("memory-core");
-    expect(cfg.plugins?.entries?.acpx).toEqual({
-      enabled: true,
-      config: {
-        pluginToolsMcpBridge: true,
-        openClawToolsMcpBridge: true,
-      },
-    });
+    expect(cfg.plugins?.entries?.acpx).toBeUndefined();
     expect(cfg.plugins?.entries?.["memory-core"]).toEqual({ enabled: true });
     expect(cfg.plugins?.entries?.["qa-channel"]).toEqual({ enabled: true });
     expect(cfg.plugins?.entries?.openai).toBeUndefined();
@@ -185,7 +200,7 @@ describe("buildQaGatewayConfig", () => {
     expect(cfg.models?.providers?.anthropic?.models.map((model) => model.id)).toContain(
       "claude-opus-4-8",
     );
-    expect(cfg.plugins?.allow).toEqual(["acpx", "memory-core", "qa-lab"]);
+    expect(cfg.plugins?.allow).toEqual(["memory-core", "qa-lab"]);
   });
 
   it("falls back to provider defaults for blank model refs", () => {
@@ -236,7 +251,7 @@ describe("buildQaGatewayConfig", () => {
       transportConfig: {},
     });
 
-    expect(cfg.plugins?.allow).toEqual(["acpx", "memory-core", "qa-lab"]);
+    expect(cfg.plugins?.allow).toEqual(["memory-core", "qa-lab"]);
     expect(cfg.plugins?.entries?.["qa-channel"]).toBeUndefined();
     expect(cfg.channels?.["qa-channel"]).toBeUndefined();
   });
@@ -252,13 +267,7 @@ describe("buildQaGatewayConfig", () => {
       ...createQaChannelTransportParams(),
     });
 
-    expect(cfg.plugins?.allow).toEqual([
-      "acpx",
-      "memory-core",
-      "qa-lab",
-      "active-memory",
-      "qa-channel",
-    ]);
+    expect(cfg.plugins?.allow).toEqual(["memory-core", "qa-lab", "active-memory", "qa-channel"]);
     expect(cfg.plugins?.entries?.["active-memory"]).toEqual({ enabled: true });
   });
 
@@ -281,7 +290,7 @@ describe("buildQaGatewayConfig", () => {
     expect(getModelFallbacks(cfg.agents?.entries?.qa?.model)).toEqual(["openai/gpt-5.6-sol"]);
     expect(cfg.models).toBeUndefined();
     expect(cfg.memory?.search?.remote).toBeUndefined();
-    expect(cfg.plugins?.allow).toEqual(["acpx", "memory-core", "qa-lab", "openai", "qa-channel"]);
+    expect(cfg.plugins?.allow).toEqual(["memory-core", "qa-lab", "openai", "qa-channel"]);
     expect(cfg.plugins?.allow).not.toContain("anthropic");
     expect(cfg.plugins?.entries?.openai).toEqual({ enabled: true });
     expect(cfg.agents?.defaults?.models?.["openai/gpt-5.6-luna"]).toEqual({
@@ -325,7 +334,6 @@ describe("buildQaGatewayConfig", () => {
     });
 
     expect(cfg.plugins?.allow).toEqual([
-      "acpx",
       "memory-core",
       "qa-lab",
       "active-memory",
@@ -411,14 +419,7 @@ describe("buildQaGatewayConfig", () => {
     expect(cfg.models?.providers?.openai?.models.map((model) => model.id)).toContain(
       "gpt-5.6-luna-alt",
     );
-    expect(cfg.plugins?.allow).toEqual([
-      "acpx",
-      "memory-core",
-      "qa-lab",
-      "codex",
-      "openai",
-      "qa-channel",
-    ]);
+    expect(cfg.plugins?.allow).toEqual(["memory-core", "qa-lab", "codex", "openai", "qa-channel"]);
     expect(cfg.plugins?.entries?.codex).toEqual({
       enabled: true,
       config: { appServer: { sandbox: "workspace-write" } },
@@ -444,7 +445,6 @@ describe("buildQaGatewayConfig", () => {
     });
 
     expect(cfg.plugins?.allow).toEqual([
-      "acpx",
       "memory-core",
       "qa-lab",
       "anthropic",
@@ -472,7 +472,7 @@ describe("buildQaGatewayConfig", () => {
     });
 
     expect(getPrimaryModel(cfg.agents?.defaults?.model)).toBe("codex-cli/test-model");
-    expect(cfg.plugins?.allow).toEqual(["acpx", "memory-core", "qa-lab", "openai", "qa-channel"]);
+    expect(cfg.plugins?.allow).toEqual(["memory-core", "qa-lab", "openai", "qa-channel"]);
     expect(cfg.plugins?.entries?.openai).toEqual({ enabled: true });
     expect(cfg.plugins?.entries?.["codex-cli"]).toBeUndefined();
   });
@@ -512,7 +512,7 @@ describe("buildQaGatewayConfig", () => {
 
     expect(cfg.models?.mode).toBe("merge");
     expect(cfg.models?.providers?.["custom-openai"]?.api).toBe("openai-responses");
-    expect(cfg.plugins?.allow).toEqual(["acpx", "memory-core", "qa-lab", "openai", "qa-channel"]);
+    expect(cfg.plugins?.allow).toEqual(["memory-core", "qa-lab", "openai", "qa-channel"]);
   });
 
   it("can set a QA default thinking level for judge turns", () => {

--- a/extensions/qa-lab/src/qa-gateway-config.ts
+++ b/extensions/qa-lab/src/qa-gateway-config.ts
@@ -24,7 +24,8 @@ export const DEFAULT_QA_CONTROL_UI_ALLOWED_ORIGINS = Object.freeze([
   "http://localhost:43124",
 ]);
 
-export const QA_BASE_RUNTIME_PLUGIN_IDS = Object.freeze(["acpx", "memory-core"]);
+// External runtimes such as ACPX must be selected by the fixture that needs them.
+export const QA_BASE_RUNTIME_PLUGIN_IDS = Object.freeze(["memory-core"]);
 export const QA_CODEX_OPENAI_CATALOG_BASE_URL = "https://api.openai.com/v1";
 const QA_LAB_PLUGIN_ID = "qa-lab";
 const QA_DIRECT_FRONTIER_PLUGIN_IDS = new Set<string>(QA_FRONTIER_PROVIDER_IDS);
@@ -130,17 +131,22 @@ export function buildQaGatewayConfig(params: {
   const pluginEntries = Object.fromEntries(
     selectedPluginIds.map((pluginId) => [
       pluginId,
-      params.forcedRuntime === "codex" && pluginId === "codex"
+      pluginId === "acpx"
         ? {
             enabled: true,
-            config: {
-              appServer: {
-                sandbox: "workspace-write",
-                ...(params.fastMode === true ? { serviceTier: "priority" } : {}),
-              },
-            },
+            config: { pluginToolsMcpBridge: true, openClawToolsMcpBridge: true },
           }
-        : { enabled: true },
+        : params.forcedRuntime === "codex" && pluginId === "codex"
+          ? {
+              enabled: true,
+              config: {
+                appServer: {
+                  sandbox: "workspace-write",
+                  ...(params.fastMode === true ? { serviceTier: "priority" } : {}),
+                },
+              },
+            }
+          : { enabled: true },
     ]),
   );
   const transportPluginEntries = Object.fromEntries(
@@ -220,13 +226,6 @@ export function buildQaGatewayConfig(params: {
         memory: "memory-core",
       },
       entries: {
-        acpx: {
-          enabled: true,
-          config: {
-            pluginToolsMcpBridge: true,
-            openClawToolsMcpBridge: true,
-          },
-        },
         "memory-core": {
           enabled: true,
         },

--- a/extensions/qa-lab/src/suite-runtime-agent-media.test.ts
+++ b/extensions/qa-lab/src/suite-runtime-agent-media.test.ts
@@ -194,7 +194,6 @@ describe("qa suite runtime agent media helpers", () => {
     const patchCall = firstPatchConfigCall();
     expect(patchCall.env).toBe(env);
     expect(patchCall.patch.plugins.allow).toStrictEqual([
-      "acpx",
       "memory-core",
       "openai",
       "qa-channel",
@@ -206,7 +205,7 @@ describe("qa suite runtime agent media helpers", () => {
   it("preserves plugins already allowed by the gateway when configuring media", async () => {
     readConfigSnapshotMock.mockResolvedValue({
       hash: "hash",
-      config: { plugins: { allow: ["openai", "anthropic", "qa-channel"] } },
+      config: { plugins: { allow: ["acpx", "openai", "anthropic", "qa-channel"] } },
     });
 
     await ensureImageGenerationConfigured({
@@ -218,8 +217,8 @@ describe("qa suite runtime agent media helpers", () => {
     expect(patchConfigMock).toHaveBeenCalledTimes(1);
     const patchCall = firstPatchConfigCall();
     expect(patchCall.patch.plugins.allow).toStrictEqual([
-      "acpx",
       "memory-core",
+      "acpx",
       "openai",
       "anthropic",
       "qa-channel",


### PR DESCRIPTION
## Summary
Packaged Telegram acceptance never reached Telegram because its generated QA config enabled an external ACP runtime that the fixture neither requested nor installed. Gateway startup correctly rejected the unavailable plugin.

Select external runtimes through the existing scenario/fixture plugin requirements. Keep ACP explicitly selected in the interactive Docker scaffold, preserving its agentic runtime parity. When ACP is selected, construct both existing MCP bridge settings in that same owner path instead of allowing the generic entry to overwrite them.

This changes only QA fixture generation and tests, not product configuration options or the plugin startup policy. Runtime/tooling LOC is neutral; tests/support net-1.

## Validation
- Actual packaged Telegram startup failure: https://github.com/openclaw/openclaw/actions/runs/33241587325 (canary failed; subsequent20 scenarios did not run).
- Both regression cases fail before the fix: unnecessary default ACP and explicitly selected ACP missing bridge settings.
- 44 tests passed in an isolated snapshot across QA config, image generation, media integration, and Docker scaffold siblings.
- Formatting and whitespace checks passed; local broad lint preparation encountered unrelated host dependency type mismatches, so hosted CI is required.
- Independent Codex autoreview completed with no accepted actionable findings.

The full canonical Telegram workflow will be rerun with this harness and the original pinned package before landing. Existing broker credentials are used; no new credential or access provisioning is involved.
