### PR TITLE
test(plugins): synchronize cleanup race at hook entry

### DIFF
--- a/src/plugins/runtime.test.ts
+++ b/src/plugins/runtime.test.ts
@@ -1,5 +1,6 @@
 /** Covers plugin runtime registration API behavior and registry mutation guards. */
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, onTestFinished } from "vitest";
+import { createDeferredCore } from "../shared/deferred.js";
 import { getPluginRunContext, setPluginRunContext } from "./host-hook-runtime.js";
 import { createEmptyPluginRegistry } from "./registry.js";
 import type { PluginHttpRouteRegistration } from "./registry.js";
@@ -115,20 +116,10 @@ describe("setActivePluginRegistry", () => {
       },
     },
   ] as const)("continues cleanup when the $name", async ({ refresh }) => {
-    let releaseFirstCleanup: (() => void) | undefined;
-    let markFirstCleanupStarted: (() => void) | undefined;
-    let markSecondCleanupCalled: (() => void) | undefined;
-    const firstCleanupStarted = new Promise<void>((resolve) => {
-      markFirstCleanupStarted = resolve;
-    });
-    const secondCleanupCalled = new Promise<void>((resolve) => {
-      markSecondCleanupCalled = resolve;
-    });
-    if (!markFirstCleanupStarted || !markSecondCleanupCalled) {
-      throw new Error("Expected cleanup signal callbacks to be initialized");
-    }
-    const notifyFirstCleanupStarted = markFirstCleanupStarted;
-    const notifySecondCleanupCalled = markSecondCleanupCalled;
+    const firstCleanupStarted = createDeferredCore();
+    const firstCleanupReleased = createDeferredCore();
+    const secondCleanupCalled = createDeferredCore();
+    onTestFinished(() => firstCleanupReleased.resolve());
     const previous = createEmptyPluginRegistry();
     previous.plugins.push(
       createPluginRecord({
@@ -144,10 +135,8 @@ describe("setActivePluginRegistry", () => {
         lifecycle: {
           id: "first-cleanup",
           async cleanup() {
-            notifyFirstCleanupStarted();
-            await new Promise<void>((resolve) => {
-              releaseFirstCleanup = resolve;
-            });
+            firstCleanupStarted.resolve();
+            await firstCleanupReleased.promise;
           },
         },
         source: "/virtual/cleanup-refresh-race/index.ts",
@@ -159,7 +148,7 @@ describe("setActivePluginRegistry", () => {
         lifecycle: {
           id: "second-cleanup",
           cleanup() {
-            notifySecondCleanupCalled();
+            secondCleanupCalled.resolve();
           },
         },
         source: "/virtual/cleanup-refresh-race/index.ts",
@@ -170,15 +159,13 @@ describe("setActivePluginRegistry", () => {
 
     setActivePluginRegistry(previous);
     setActivePluginRegistry(next);
-    await waitForCleanupSignal(firstCleanupStarted, "first cleanup start");
+    // The race starts inside cleanup; cold lazy imports are not a cleanup deadline.
+    await firstCleanupStarted.promise;
 
     refresh(next);
-    if (!releaseFirstCleanup) {
-      throw new Error("Expected first cleanup release callback to be initialized");
-    }
-    releaseFirstCleanup();
+    firstCleanupReleased.resolve();
 
-    await waitForCleanupSignal(secondCleanupCalled, "second cleanup");
+    await waitForCleanupSignal(secondCleanupCalled.promise, "second cleanup");
   });
 
   it("includes plugin ids imported before registration failed", () => {


### PR DESCRIPTION
Related: #132365

## What Problem This Solves

The registry cleanup race tests fail before exercising their intended race when the real lazy cleanup module takes more than 500 ms to load. Both cases reproduced on clean current main: they reported `Timed out waiting for first cleanup start`, while subsequent normal cleanup completed successfully.

## Why This Change Was Made

Synchronize the race on the first cleanup hook actually entering, using the existing deferred helper. Only then refresh or replace the active registry, release the held hook, and require the second hook within the existing 500 ms deadline. Register release with Vitest's test-finish cleanup so a failed test cannot leave its controlled hook blocked.

The post-release 500 ms assertion, production 5-second cleanup deadline and Vitest test budget are unchanged. No warmup, mock, environment override or production change is introduced. The change removes optional callback scaffolding and its impossible initialization guards.

## User Impact

No runtime behavior change. These two tests now measure whether retiring-registry cleanup continues across a registry refresh or replacement, without making cold module loading part of that assertion.

## Evidence

The original four-file command and execution order failed on clean main `8fefe239bf956ec5b406ea63168c1a202d5a5a26`: 118 startup cases, 4 suppression guards and 7 other registry cases passed; both race cases failed at first hook entry. The affected runtime, cleanup owner and test bytes are unchanged from the earlier main `24e12d4403571582d61e9c33c15efa9849f23ef6`, where the same failures were independently recorded. The separate runtime-factory fix #132430 does not touch this boundary. Targeted archive and live PR search found no competing repair.

With this test-only change, the same command passed all **131 cases**. The first hook entered after 2.511 seconds of cold loading; the actual refresh/release/second-hook sequence then completed normally.

A separate mutation control temporarily made `shouldCleanup` depend on the captured active-registry version, which incorrectly cancels retiring cleanup when the active registry advances. Both corrected tests reached their first hook and then failed the retained **second-cleanup 500 ms check**; the other 7 registry tests passed. This was an injected negative control, not a claim about historical shipped code. The temporary mutation was removed, and `src/plugins/runtime.ts` was verified byte-for-byte against main before final verification.

```sh
OPENCLAW_VITEST_MAX_WORKERS=2 node scripts/run-vitest.mjs src/gateway/server-startup-plugins.test.ts src/gateway/server-startup-post-attach.test.ts src/plugins/runtime.test.ts test/scripts/lint-suppressions.test.ts
OPENCLAW_VITEST_MAX_WORKERS=2 node scripts/check-changed.mjs -- src/plugins/runtime.test.ts
```

Fresh restricted Codex review of the complete nonempty patch and full cleanup/lifecycle owner context reported no actionable findings. The installed Vitest test-finish contract was inspected directly, including execution after a failed test. No reviewer isolation or secret scan was bypassed.

One existing test file **+13/-26**, production **+0/-0**. No changelog, dependency, configuration, storage, protocol, runtime or release changes. The broader release campaign remains separate.

After removing the mutation, the original four-file order passed all 131 cases again; first hook entry took 1.657 seconds, confirming the test still exercised the cold path without prewarming it.

The complete changed-file gate passed after the production mutation was removed, including all three unused-export scans, core graph checks, all core test type graphs, formatting and lint.
