### PR TITLE
test(docker): align package fixtures with runtime ownership contracts

### DIFF
--- a/scripts/e2e/compose-setup.sh
+++ b/scripts/e2e/compose-setup.sh
@@ -204,11 +204,15 @@ EOF
 cat >"$HEALTH_OVERRIDE_PATH" <<'EOF'
 services:
   openclaw-gateway:
+    # The E2E runner defaults to appuser; documented Compose uses the node home.
+    user: node
     healthcheck:
       interval: 1s
       timeout: 5s
       retries: 3
       start_period: 5s
+  openclaw-cli:
+    user: node
 EOF
 
 export OPENCLAW_IMAGE="$IMAGE_NAME"

--- a/scripts/e2e/lib/doctor-install-switch/assert-exec-start.mjs
+++ b/scripts/e2e/lib/doctor-install-switch/assert-exec-start.mjs
@@ -45,15 +45,21 @@ function assertEqual(label, actual, expected, argv) {
 }
 
 const [mode, unitPath, expected, positionRaw] = process.argv.slice(2);
-if (!mode || !unitPath || expected === undefined) {
+if (!mode || !unitPath || (mode !== "entrypoint-exists" && expected === undefined)) {
   fail(
-    "usage: assert-exec-start.mjs entrypoint <unit-path> <expected> | argument <unit-path> <expected> <one-based-position>",
+    "usage: assert-exec-start.mjs entrypoint <unit-path> <expected> | entrypoint-exists <unit-path> | argument <unit-path> <expected> <one-based-position>",
   );
 }
 
 const programArguments = readProgramArguments(unitPath);
 if (mode === "entrypoint") {
   assertEqual("entrypoint", resolveGatewayEntrypoint(programArguments), expected, programArguments);
+} else if (mode === "entrypoint-exists") {
+  const entrypoint = resolveGatewayEntrypoint(programArguments);
+  if (!fs.statSync(entrypoint, { throwIfNoEntry: false })?.isFile()) {
+    fail(`Entrypoint in service unit does not exist: ${entrypoint}`);
+  }
+  console.log(entrypoint);
 } else if (mode === "argument") {
   const position = Number.parseInt(positionRaw ?? "", 10);
   if (!Number.isSafeInteger(position) || position < 1) {

--- a/scripts/e2e/lib/sandbox-browser-sidecar/scenario.mjs
+++ b/scripts/e2e/lib/sandbox-browser-sidecar/scenario.mjs
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import { execFile } from "node:child_process";
+import { createHash } from "node:crypto";
 import fs from "node:fs/promises";
 import http from "node:http";
 import path from "node:path";
@@ -26,7 +27,9 @@ const stateDir = path.join(root, "state");
 const workspaceDir = path.join(root, "workspace");
 const sandboxRoot = path.join(root, "sandboxes");
 const configPath = path.join(stateDir, "openclaw.json");
-const sessionKey = "agent:main:sandbox-browser-sidecar";
+const sessionKey = requireEnv("OPENCLAW_E2E_SESSION_KEY");
+const workspaceHash = createHash("sha256").update(workspaceDir).digest("hex").slice(0, 32);
+const scopeKey = `${sessionKey}:workspace:${workspaceHash}`;
 const browserToken = `sandbox-browser-sidecar-${process.pid}`;
 const marker = `OPENCLAW_SANDBOX_BROWSER_SIDECAR_${process.pid}`;
 const ownedContainerNames = new Set();
@@ -99,11 +102,19 @@ async function docker(args, options) {
 }
 
 async function listTaskContainers() {
-  const { stdout } = await docker(["ps", "-a", "--format", "{{.Names}}"]);
+  // Container names can shorten the configured prefix; the scope label stays exact.
+  const { stdout } = await docker([
+    "ps",
+    "-a",
+    "--filter",
+    `label=openclaw.sessionKey=${scopeKey}`,
+    "--format",
+    "{{.Names}}",
+  ]);
   return stdout
     .split(/\r?\n/u)
     .map((value) => value.trim())
-    .filter((name) => name.startsWith(sandboxPrefix) || name.startsWith(browserPrefix));
+    .filter(Boolean);
 }
 
 async function cleanupTaskResources() {
@@ -216,10 +227,17 @@ try {
     (entry) => entry.containerName === first.browser.containerName,
   );
   assert(browserEntry, "packaged sandbox list did not report the browser container");
-  assert.equal(browserEntry.sessionKey, sessionKey);
+  assert.equal(browserEntry.sessionKey, scopeKey);
   assert.equal(browserEntry.running, true);
 
-  await run("openclaw", ["sandbox", "recreate", "--browser", "--session", sessionKey, "--force"]);
+  await run("openclaw", [
+    "sandbox",
+    "recreate",
+    "--browser",
+    "--session",
+    browserEntry.sessionKey,
+    "--force",
+  ]);
   const remaining = await listTaskContainers();
   assert(
     !remaining.includes(first.browser.containerName),

--- a/scripts/e2e/multi-node-update-docker.sh
+++ b/scripts/e2e/multi-node-update-docker.sh
@@ -122,142 +122,14 @@ ls -la "$PACKAGE_ROOT_A/package.json" 2>/dev/null || echo "WARNING: package.json
 echo ""
 echo "── Step 3: Install the systemd service (gateway) using node-A ──"
 
-# Create a systemctl shim since we are in Docker (no real systemd).
-SHIM_DIR="/usr/local/bin"
+# Reuse the service fixture that models manager-loaded definitions and restarts.
 GATEWAY_UNIT_PATH="/root/.config/systemd/user/openclaw-gateway.service"
-SYSTEMCTL_LOG="$ARTIFACTS/systemctl-shim.log"
 GATEWAY_DAEMON_LOG="$ARTIFACTS/gateway-daemon.log"
-GATEWAY_PID_FILE="$ARTIFACTS/gateway.pid"
-: >"$SYSTEMCTL_LOG"
-
-cat >"$SHIM_DIR/systemctl" <<SHIMEOF
-#!/usr/bin/env bash
-set -euo pipefail
-printf "%s %s\n" "\$(date -u +%H:%M:%S)" "\$*" >>"$SYSTEMCTL_LOG"
-
-filtered=()
-for ((i = 1; i <= \$#; i++)); do
-  arg="\${!i}"
-  case "\$arg" in
-    --user|--quiet|--no-page|--now|--value) ;;
-    --property)
-      i=\$((i + 1))
-      ;;
-    --property=*) ;;
-    *) filtered+=("\$arg") ;;
-  esac
-done
-command="\${filtered[0]:-status}"
-
-is_running() {
-  [ -s "$GATEWAY_PID_FILE" ] || return 1
-  local pid
-  pid="\$(cat "$GATEWAY_PID_FILE" 2>/dev/null || true)"
-  [ -n "\$pid" ] || return 1
-  kill -0 "\$pid" >/dev/null 2>&1
-}
-
-stop_gateway() {
-  [ -s "$GATEWAY_PID_FILE" ] || return 0
-  local pid
-  pid="\$(cat "$GATEWAY_PID_FILE" 2>/dev/null || true)"
-  if [[ "\$pid" =~ ^[0-9]+$ ]] && [ "\$pid" -gt 1 ] && kill -0 "\$pid" >/dev/null 2>&1; then
-    kill "\$pid" >/dev/null 2>&1 || true
-    for _ in \$(seq 1 100); do
-      kill -0 "\$pid" >/dev/null 2>&1 || break
-      sleep 0.1
-    done
-    kill -9 "\$pid" >/dev/null 2>&1 || true
-  fi
-  rm -f "$GATEWAY_PID_FILE"
-}
-
-load_unit_environment() {
-  local unit="\$1"
-  while IFS= read -r line; do
-    case "\$line" in
-      EnvironmentFile=*)
-        local spec="\${line#EnvironmentFile=}"
-        for token in \$spec; do
-          local file="\${token#-}"
-          [ -f "\$file" ] || continue
-          set -a
-          # shellcheck disable=SC1090
-          . "\$file"
-          set +a
-        done
-        ;;
-      Environment=*)
-        local assignment="\${line#Environment=}"
-        assignment="\${assignment#\"}"
-        assignment="\${assignment%\"}"
-        export "\$assignment"
-        ;;
-    esac
-  done <"\$unit"
-}
-
-start_gateway() {
-  local unit="$GATEWAY_UNIT_PATH"
-  local exec_start
-  if [ ! -f "\$unit" ]; then
-    echo "systemctl shim: unit not found: \$unit" >&2
-    return 1
-  fi
-  exec_start="\$(sed -n "s/^ExecStart=//p" "\$unit" | tail -n 1)"
-  if [ -z "\$exec_start" ]; then
-    echo "systemctl shim: no ExecStart in \$unit" >&2
-    return 1
-  fi
-  (
-    load_unit_environment "\$unit"
-    export OPENCLAW_NO_RESPAWN=1
-    echo "systemctl shim: starting: \$exec_start"
-    nohup bash -lc "exec \$exec_start" >>"$GATEWAY_DAEMON_LOG" 2>&1 &
-    printf "%s\n" "\$!" >"$GATEWAY_PID_FILE"
-  )
-}
-
-case "\$command" in
-  daemon-reload)
-    echo "daemon-reload (shim: no-op)"
-    ;;
-  enable)
-    echo "enable (shim: no-op)"
-    ;;
-  is-enabled)
-    echo "enabled"
-    ;;
-  restart|start)
-    stop_gateway
-    start_gateway
-    ;;
-  stop)
-    stop_gateway
-    ;;
-  is-active)
-    if is_running; then
-      echo "active"
-    else
-      echo "inactive"
-      exit 3
-    fi
-    ;;
-  show)
-    if is_running; then
-      printf "ActiveState=active\nSubState=running\nMainPID=%s\nExecMainStatus=0\nExecMainCode=0\n" "\$(cat "$GATEWAY_PID_FILE")"
-    else
-      printf "ActiveState=inactive\nSubState=dead\nMainPID=0\nExecMainStatus=0\nExecMainCode=0\n"
-    fi
-    ;;
-  *)
-    echo "systemctl shim: unsupported command: \$*" >&2
-    exit 1
-    ;;
-esac
-SHIMEOF
-chmod +x "$SHIM_DIR/systemctl"
-echo "systemctl shim installed."
+export OPENCLAW_UPGRADE_SURVIVOR_SYSTEMCTL_SHIM_LOG="$ARTIFACTS/systemctl-shim.log"
+export OPENCLAW_UPGRADE_SURVIVOR_SYSTEMCTL_SHIM_DAEMON_LOG="$GATEWAY_DAEMON_LOG"
+export OPENCLAW_UPGRADE_SURVIVOR_SYSTEMCTL_SHIM_PID_FILE="$ARTIFACTS/gateway.pid"
+source scripts/e2e/lib/upgrade-survivor/update-restart-auth.sh
+install_update_restart_systemctl_shim
 
 # Now install the gateway service using node-A.
 echo "Installing gateway service..."
@@ -404,14 +276,11 @@ else
 fi
 
 # Check 3: Does the entrypoint in the unit file actually exist?
-if [ -f "$GATEWAY_UNIT_PATH" ]; then
-  EXEC_START_AFTER="$(grep "^ExecStart=" "$GATEWAY_UNIT_PATH" | head -1 | sed "s/^ExecStart=//")"
-  ENTRYPOINT_PATH="$(echo "$EXEC_START_AFTER" | awk "{print \$2}")"
-  if [ -n "$ENTRYPOINT_PATH" ] && [ ! -f "$ENTRYPOINT_PATH" ]; then
-    echo "BUG: Entrypoint in service unit does not exist: $ENTRYPOINT_PATH"
-  elif [ -n "$ENTRYPOINT_PATH" ]; then
-    echo "OK: Entrypoint exists: $ENTRYPOINT_PATH"
-  fi
+ENTRYPOINT_FAILED=0
+if ENTRYPOINT_PATH="$(node scripts/e2e/lib/doctor-install-switch/assert-exec-start.mjs entrypoint-exists "$GATEWAY_UNIT_PATH")"; then
+  echo "OK: Entrypoint exists: $ENTRYPOINT_PATH"
+else
+  ENTRYPOINT_FAILED=1
 fi
 
 # Check 4: Were there any warnings about split install in the update output?
@@ -430,7 +299,7 @@ echo "── Step 9: Try starting the gateway with the post-update unit ──"
 
 GATEWAY_START_FAILED=0
 if [ -f "$GATEWAY_UNIT_PATH" ]; then
-  systemctl restart 2>&1 || true
+  systemctl --user restart openclaw-gateway.service 2>&1 || true
   if PORT=18789 node <<NODE
 const url = "http://127.0.0.1:" + process.env.PORT + "/healthz";
 const deadline = Date.now() + 30000;
@@ -465,7 +334,7 @@ NODE
     GATEWAY_HEALTH_FAILED=1
     cat "$GATEWAY_DAEMON_LOG" 2>/dev/null | tail -20 || true
   fi
-  systemctl stop 2>&1 || true
+  systemctl --user stop openclaw-gateway.service 2>&1 || true
 fi
 
 echo ""
@@ -483,11 +352,8 @@ fi
 if [ -f "$NPM_PREFIX_B/lib/node_modules/openclaw/package.json" ]; then
   EXIT_CODE=1
 fi
-if [ -f "$GATEWAY_UNIT_PATH" ]; then
-  ENTRYPOINT_PATH_CHECK="$(grep "^ExecStart=" "$GATEWAY_UNIT_PATH" | head -1 | sed "s/^ExecStart=//" | awk "{print \$2}")" || true
-  if [ -n "$ENTRYPOINT_PATH_CHECK" ] && [ ! -f "$ENTRYPOINT_PATH_CHECK" ]; then
-    EXIT_CODE=1
-  fi
+if [ "$ENTRYPOINT_FAILED" -ne 0 ]; then
+  EXIT_CODE=1
 fi
 if [ "$UPDATE_FAILED" -ne 0 ]; then
   EXIT_CODE=1

--- a/scripts/e2e/sandbox-browser-sidecar-docker.sh
+++ b/scripts/e2e/sandbox-browser-sidecar-docker.sh
@@ -16,6 +16,9 @@ SANDBOX_PREFIX="openclaw-e2e-sbx-${RUN_ID}-"
 BROWSER_PREFIX="openclaw-e2e-browser-${RUN_ID}-"
 NETWORK_NAME="openclaw-e2e-browser-${RUN_ID}"
 SCENARIO_ROOT="$(mktemp -d /tmp/openclaw-sandbox-browser-sidecar.XXXXXX)"
+SESSION_KEY="agent:main:sandbox-browser-sidecar"
+WORKSPACE_HASH="$(node -e 'process.stdout.write(require("node:crypto").createHash("sha256").update(process.argv[1]).digest("hex").slice(0, 32))' "$SCENARIO_ROOT/workspace")"
+SCOPE_KEY="${SESSION_KEY}:workspace:${WORKSPACE_HASH}"
 BUILD_DIR="$(mktemp -d /tmp/openclaw-sandbox-browser-sidecar-build.XXXXXX)"
 DOCKER_SOCKET="${OPENCLAW_DOCKER_SOCKET:-/var/run/docker.sock}"
 SCENARIO_SOURCE="$ROOT_DIR/scripts/e2e/lib/sandbox-browser-sidecar/scenario.mjs"
@@ -29,19 +32,15 @@ docker_socket_gid() {
   stat -f "%g" "$DOCKER_SOCKET"
 }
 
-remove_prefixed_containers() {
-  local prefix="$1"
+remove_task_containers() {
   local name
   while IFS= read -r name; do
-    case "$name" in
-      "$prefix"*) docker_e2e_docker_cmd rm -f "$name" >/dev/null 2>&1 || true ;;
-    esac
-  done < <(docker_e2e_docker_cmd ps -a --format '{{.Names}}' 2>/dev/null || true)
+    docker_e2e_docker_cmd rm -f "$name" >/dev/null 2>&1 || true
+  done < <(docker_e2e_docker_cmd ps -a --filter "label=openclaw.sessionKey=$SCOPE_KEY" --format '{{.Names}}' 2>/dev/null || true)
 }
 
 cleanup() {
-  remove_prefixed_containers "$SANDBOX_PREFIX"
-  remove_prefixed_containers "$BROWSER_PREFIX"
+  remove_task_containers
   docker_e2e_docker_cmd network rm "$NETWORK_NAME" >/dev/null 2>&1 || true
   docker_e2e_docker_cmd run --rm --user 0:0 \
     -v "$SCENARIO_ROOT:/target" \
@@ -101,6 +100,7 @@ docker_e2e_run_logged_print_with_harness sandbox-browser-sidecar \
   --group-add "$SOCKET_GID" \
   -e COREPACK_ENABLE_DOWNLOAD_PROMPT=0 \
   -e "OPENCLAW_E2E_ROOT=$SCENARIO_ROOT" \
+  -e "OPENCLAW_E2E_SESSION_KEY=$SESSION_KEY" \
   -e "OPENCLAW_E2E_SANDBOX_IMAGE=$SANDBOX_IMAGE" \
   -e "OPENCLAW_E2E_BROWSER_IMAGE=$BROWSER_IMAGE" \
   -e "OPENCLAW_E2E_SANDBOX_PREFIX=$SANDBOX_PREFIX" \

--- a/scripts/e2e/system-agent-rescue-docker-client.ts
+++ b/scripts/e2e/system-agent-rescue-docker-client.ts
@@ -6,6 +6,12 @@ import path from "node:path";
 import { handleSystemAgentCommand } from "../../dist/auto-reply/reply/commands-system-agent.js";
 import { clearConfigCache } from "../../dist/config/config.js";
 import type { OpenClawConfig } from "../../dist/config/types.openclaw.js";
+import { createSqliteAuditRecordStore } from "../../dist/infra/sqlite-audit-record-store.js";
+import {
+  SYSTEM_AGENT_AUDIT_MAX_ENTRIES,
+  SYSTEM_AGENT_AUDIT_SCOPE,
+  type SystemAgentAuditEntry,
+} from "../../dist/system-agent/audit.js";
 import { runSystemAgentRescueMessage } from "../../dist/system-agent/rescue-message.js";
 import { createE2eStateDir } from "./lib/temp-state-dir.ts";
 
@@ -80,7 +86,7 @@ async function main() {
     configPath,
     JSON.stringify(
       {
-        meta: { lastTouchedVersion: "docker-e2e", lastTouchedAt: new Date(0).toISOString() },
+        meta: { lastTouchedVersion: "docker-e2e" },
         agents: { defaults: {} },
       },
       null,
@@ -144,14 +150,7 @@ async function main() {
   const refApplied = await invoke("/openclaw yes", cfg);
   assert(refApplied.includes("[openclaw] done: config.setRef"), "SecretRef set failed");
 
-  const agentPlan = await invoke("/openclaw create agent work workspace /tmp/openclaw-work", cfg);
-  assert(
-    agentPlan.includes("Reply /openclaw yes to apply"),
-    "agent creation did not require approval",
-  );
-  const agentApplied = await invoke("/openclaw yes", cfg);
-  assert(agentApplied.includes("[openclaw] done: agents.create"), "agent creation did not apply");
-
+  // Fresh setup chooses the workspace before an authored fleet owns it.
   const setupPlan = await invokeWithDeps(
     "/openclaw setup workspace /tmp/openclaw-setup model openai/gpt-5.2",
     cfg,
@@ -160,6 +159,14 @@ async function main() {
   assert(setupPlan.includes("Reply /openclaw yes to apply"), "setup did not require approval");
   const setupApplied = await invokeWithDeps("/openclaw yes", cfg, deterministicInference);
   assert(setupApplied.includes("[openclaw] done: openclaw.setup"), "setup did not apply");
+
+  const agentPlan = await invoke("/openclaw create agent work workspace /tmp/openclaw-work", cfg);
+  assert(
+    agentPlan.includes("Reply /openclaw yes to apply"),
+    "agent creation did not require approval",
+  );
+  const agentApplied = await invoke("/openclaw yes", cfg);
+  assert(agentApplied.includes("[openclaw] done: agents.create"), "agent creation did not apply");
 
   const gatewayRestarts: string[] = [];
   const gatewayCommand = makeParams("/openclaw restart gateway", cfg).command;
@@ -275,10 +282,12 @@ async function main() {
     "agent config was not updated",
   );
 
-  const auditPath = path.join(stateDir, "audit", "system-agent.jsonl");
-  const auditLines = (await fs.readFile(auditPath, "utf8")).trim().split("\n");
-  assert(auditLines.length >= 2, "audit log did not record both operations");
-  const audits = auditLines.map((line) => JSON.parse(line));
+  const audits = createSqliteAuditRecordStore<SystemAgentAuditEntry>({
+    scope: SYSTEM_AGENT_AUDIT_SCOPE,
+    maxEntries: SYSTEM_AGENT_AUDIT_MAX_ENTRIES,
+  })
+    .entries()
+    .map((entry) => entry.value);
   assert(
     audits.some((audit) => audit.operation === "config.setDefaultModel"),
     "model audit operation missing",

--- a/test/e2e/qa-lab/plugins/plugin-lifecycle-probe-runtime.ts
+++ b/test/e2e/qa-lab/plugins/plugin-lifecycle-probe-runtime.ts
@@ -676,7 +676,7 @@ async function runPluginLifecycleMatrix() {
       summaryTsv,
       "install-v1",
       "node",
-      [entry, "plugins", "install", `npm:${packageName}@1.0.0`, "--force"],
+      [entry, "plugins", "install", `npm:${packageName}@1.0.0`, "--force", "--accept-capabilities"],
       runEnv,
     );
     assertVersion(pluginId, "1.0.0", runEnv);
@@ -790,7 +790,14 @@ async function runPluginLifecycleMatrix() {
       summaryTsv,
       "pack-install-v1",
       "node",
-      [entry, "plugins", "install", `npm:${packPackageName}@latest`, "--force"],
+      [
+        entry,
+        "plugins",
+        "install",
+        `npm:${packPackageName}@latest`,
+        "--force",
+        "--accept-capabilities",
+      ],
       runEnv,
     );
     assertVersion(packOwner, "1.0.0", runEnv);

--- a/test/scripts/docker-build-helper.test.ts
+++ b/test/scripts/docker-build-helper.test.ts
@@ -616,12 +616,78 @@ fi
     expect(runner).toContain('-v "$DOCKER_SOCKET:/var/run/docker.sock"');
     expect(runner).toContain('-v "$SCENARIO_ROOT:$SCENARIO_ROOT"');
     expect(runner).toContain("scripts/docker/sandbox/Dockerfile.browser");
-    expect(runner).toContain("remove_prefixed_containers");
     expect(scenario).toContain('from "openclaw/plugin-sdk/agent-harness-runtime"');
-    expect(scenario).toContain("Promise.all([");
     expect(scenario).toContain('"sandbox", "list", "--browser", "--json"');
-    expect(scenario).toContain('"sandbox", "recreate", "--browser", "--session"');
     expect(scenario).not.toMatch(/from\s+["'][.]{1,2}\/.*src\//u);
+  });
+
+  it("cleans only the sidecar task's containers when the runner exits early", () => {
+    const workDir = realpathSync(tempDirs.make("openclaw-sidecar-cleanup-"));
+    const binDir = join(workDir, "bin");
+    const scenarioRoot = join(workDir, "scenario");
+    const buildRoot = join(workDir, "build");
+    const containersPath = join(workDir, "containers.json");
+    const sessionKey = "agent:main:sandbox-browser-sidecar";
+    const workspaceHash = createHash("sha256")
+      .update(join(scenarioRoot, "workspace"))
+      .digest("hex")
+      .slice(0, 32);
+    const scopeKey = `${sessionKey}:workspace:${workspaceHash}`;
+    const unrelated = { name: "other-workspace", scopeKey: `${sessionKey}:workspace:other` };
+    writeFileSync(
+      containersPath,
+      JSON.stringify([
+        { name: "short-normal-sandbox", scopeKey },
+        { name: "short-browser-sidecar", scopeKey },
+        unrelated,
+      ]),
+    );
+    writeExecutables(binDir, {
+      mktemp: `#!/usr/bin/env node
+const fs = require("node:fs");
+const args = process.argv.slice(2);
+const template = args.at(-1);
+const target = template.includes("sandbox-browser-sidecar-build.")
+  ? ${JSON.stringify(buildRoot)}
+  : template.includes("sandbox-browser-sidecar.") ? ${JSON.stringify(scenarioRoot)} : undefined;
+if (target) {
+  fs.mkdirSync(target, { recursive: true });
+  console.log(target);
+} else {
+  process.stdout.write(require("node:child_process").execFileSync("/usr/bin/mktemp", args));
+}
+`,
+      docker: `#!/usr/bin/env node
+const fs = require("node:fs");
+const file = ${JSON.stringify(containersPath)};
+const containers = JSON.parse(fs.readFileSync(file, "utf8"));
+const args = process.argv.slice(2);
+if (args[0] === "ps") {
+  const filterIndex = args.indexOf("--filter");
+  const filter = filterIndex < 0 ? undefined : args[filterIndex + 1];
+  for (const container of containers) {
+    if (!filter || filter === "label=openclaw.sessionKey=" + container.scopeKey) console.log(container.name);
+  }
+} else if (args[0] === "rm") {
+  fs.writeFileSync(file, JSON.stringify(containers.filter((container) => !args.slice(1).includes(container.name))));
+}
+`,
+    });
+
+    const result = spawnSync("bash", [SANDBOX_BROWSER_SIDECAR_DOCKER_E2E_PATH], {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        PATH: `${binDir}:${process.env.PATH ?? ""}`,
+        OPENCLAW_DOCKER_SOCKET: join(workDir, "missing.sock"),
+      },
+    });
+
+    expect(result.status, result.stderr).toBe(1);
+    expect(result.stderr).toContain("Docker socket not found:");
+    expect(JSON.parse(readFileSync(containersPath, "utf8"))).toEqual([unrelated]);
+    expect(existsSync(scenarioRoot)).toBe(false);
+    expect(existsSync(buildRoot)).toBe(false);
   });
 
   it("gives cleanup-smoke builds enough Node heap while preserving explicit callers", () => {

--- a/test/scripts/docker-build-helper.test.ts
+++ b/test/scripts/docker-build-helper.test.ts
@@ -6165,12 +6165,8 @@ done
       'if [ "$UPDATE_FAILED" -ne 0 ]; then',
       'if [ "$GATEWAY_START_FAILED" -ne 0 ]; then',
       'if [ "$GATEWAY_HEALTH_FAILED" -ne 0 ]; then',
-      'printf "%s\\n" "\\$!" >"$GATEWAY_PID_FILE"',
-      'printf "ActiveState=active\\nSubState=running',
       'status.service?.runtime?.status !== "running"',
       "FAIL: gateway service was not running before update",
-      "OPENCLAW_NO_RESPAWN=1",
-      "is-enabled)",
       "/healthz",
       "FAIL: gateway install failed before update",
     ]);

--- a/test/scripts/doctor-install-switch-wrapper.test.ts
+++ b/test/scripts/doctor-install-switch-wrapper.test.ts
@@ -76,7 +76,8 @@ describe("doctor install switch ExecStart assertions", () => {
   it("resolves a quoted entrypoint after inserted Node heap flags", () => {
     const root = makeTempDir(tempDirs, "openclaw-doctor-exec-start-");
     const unitPath = path.join(root, "openclaw-gateway.service");
-    const entrypoint = "/opt/openclaw git/dist/index.js";
+    const entrypoint = path.join(root, "index with spaces.js");
+    writeFileSync(entrypoint, "export {};\n");
     writeFileSync(
       unitPath,
       [
@@ -89,6 +90,27 @@ describe("doctor install switch ExecStart assertions", () => {
 
     expect(result.status).toBe(0);
     expect(result.stderr).toBe("");
+
+    const exists = runExecStartAssertion(["entrypoint-exists", unitPath]);
+    expect(exists.status, exists.stderr).toBe(0);
+    expect(exists.stdout.trim()).toBe(entrypoint);
+  });
+
+  it.each(["missing", "directory"])("rejects a %s service entrypoint", (kind) => {
+    const root = makeTempDir(tempDirs, "openclaw-doctor-exec-start-");
+    const unitPath = path.join(root, "openclaw-gateway.service");
+    const entrypoint = path.join(root, "entry.js");
+    if (kind === "directory") {
+      mkdirSync(entrypoint);
+    }
+    writeFileSync(
+      unitPath,
+      `[Service]\nExecStart=/usr/bin/node --max-old-space-size=4096 "${entrypoint}" gateway\n`,
+    );
+
+    const result = runExecStartAssertion(["entrypoint-exists", unitPath]);
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain(`Entrypoint in service unit does not exist: ${entrypoint}`);
   });
 
   it("reads wrapper arguments from parsed ExecStart argv", () => {


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where package Docker acceptance lanes fail on valid runtime behavior because their setup and assertions still model retired fixture contracts. The affected lanes are Compose setup, multi-Node updates, system-agent rescue, sandbox browser sidecars, and the plugin lifecycle matrix.

## Why This Change Was Made

Keep fixture state and observation at the existing owners: use Compose's documented `node` user, reuse the shared systemd service fixture and parsed ExecStart assertion, read the packaged SQLite audit owner, and discover sandbox resources through their exact workspace-qualified session label. Rescue setup now runs before creating an authored fleet, and the lifecycle matrix explicitly accepts capabilities only on initial installs; subsequent enable, update, and downgrade steps still test consent carry-forward.

This removes the duplicate multi-Node systemctl implementation and its two whitespace-based entrypoint checks. The four source-string assertions for the deleted shim are removed while actual update, service, and health assertions remain. The earlier update-channel fixture repair is intentionally omitted: main already has the stronger implementation and fresh-clone regression test from #132376.

## User Impact

No application behavior, configuration, schema, dependencies, or public APIs change. Maintainers regain meaningful package acceptance results and task-owned sandbox cleanup without weakening the runtime assertions or adding retries.

## Evidence

- Original failures: full Docker run [33237600353](https://github.com/openclaw/openclaw/actions/runs/33237600353), source `bbe4f3a7f7dce27452ccd5457a558c2d5ccbfd76`.
- Actual repaired Docker runs: [Testbox run 33237712656](https://github.com/openclaw/openclaw/actions/runs/33237712656), using immutable package artifact `9710471670`; tarball SHA-256 `ab556f10319ee85331dad20d7e8d90c75c3ac7dafc881ecbe79fbfb683465926`. Compose setup, update-channel switch, multi-node update, plugin lifecycle matrix, system-agent rescue, and sandbox browser sidecar all exited zero. These were the unchanged original package plus the repaired harness overlay, not a rebuilt package from this PR snapshot.
- Current-main snapshot at `8fefe239bf956ec5b406ea63168c1a202d5a5a26`: 14 focused tests passed across the seven doctor-wrapper cases, six selected multi-node harness checks, and the existing update-channel fresh-clone test. Command: `node scripts/run-vitest.mjs test/scripts/doctor-install-switch-wrapper.test.ts test/scripts/update-channel-switch-fixture.test.ts test/scripts/docker-build-helper.test.ts -t 'doctor install switch|package-derived Git fixture|multi-node'`.
- Shell syntax, JavaScript syntax, targeted formatting, and `git diff --check` pass. Fresh isolated Codex autoreview completed with no accepted/actionable findings (default P0 scope).
- `check:changed` passed its first thirteen guards, then `tsgo:scripts` failed with sixteen diagnostics outside this patch. The identical typecheck on untouched base `8fefe239` with the same installed dependencies produced all sixteen identical diagnostics (MarkdownIt exports, Google FinishReason, pi-tui, Crabline declarations, and pako types). This is a baseline/dependency-environment limitation; a fully green changed gate is not claimed.
- Diff: application production `+0/-0`; test harness/support `+112/-184` (net `-72`) across nine files.

The Docker evidence predates this rebase onto current main. All changed executable harness files are identical to the successful overlay; the only merged upstream change is unrelated context in the large Docker-helper test. A new current-main package Docker sweep is not claimed here.
