### PR TITLE
fix(agents): avoid persistent skill watchers in one-shot ingress runs

### DIFF
--- a/scripts/e2e/lib/codex-npm-plugin-live/assertions.mjs
+++ b/scripts/e2e/lib/codex-npm-plugin-live/assertions.mjs
@@ -912,6 +912,7 @@ function assertAgentError() {
     'Requested agent harness "codex" is not registered',
     "Unknown model: codex/",
     'Agent harness runtime "codex" is not present in the prepared registry.',
+    'Agent harness runtime "codex" is unavailable because its plugin registration is missing from this prepared run.',
   ];
   if (!expectedErrors.some((message) => combined.includes(message))) {
     throw new Error(`unexpected post-uninstall agent error:\nstdout=${stdout}\nstderr=${stderr}`);

--- a/src/agents/command/session-preparation.ts
+++ b/src/agents/command/session-preparation.ts
@@ -79,7 +79,9 @@ export async function prepareEmbeddedSessionState(params: {
         advertiseExecNode: nodeSkillsEligibility.canExec,
       }),
     },
-    watch: params.watchSkills,
+    // A one-shot caller has no later turn to consume invalidations; persistent
+    // watchers would keep its process alive after the reply has completed.
+    watch: params.watchSkills && params.opts.oneShotCliRun !== true,
     ...(params.pluginMetadataSnapshot
       ? { pluginMetadataSnapshot: params.pluginMetadataSnapshot }
       : {}),

--- a/src/commands/agent.test.ts
+++ b/src/commands/agent.test.ts
@@ -761,6 +761,30 @@ describe("agentCommand", () => {
     });
   });
 
+  it.each([
+    ["local", undefined, false],
+    ["local", true, false],
+    ["ingress", undefined, true],
+    ["ingress", true, false],
+  ] as const)(
+    "owns skill watching for %s runs with oneShotCliRun=%s",
+    async (entrypoint, oneShotCliRun, watch) => {
+      await withTempHome(async (home) => {
+        mockConfig(home, path.join(home, "sessions.json"));
+        const opts = { message: "inspect skills", agentId: "main", oneShotCliRun };
+        if (entrypoint === "ingress") {
+          await agentCommandFromIngress({ ...opts, allowModelOverride: false }, runtime);
+        } else {
+          await agentCommand(opts, runtime);
+        }
+
+        expect(resolveReusableWorkspaceSkillSnapshot).toHaveBeenCalledWith(
+          expect.objectContaining({ watch }),
+        );
+      });
+    },
+  );
+
   it("does not scaffold an implicit ACP workspace when the command supplies cwd", async () => {
     await withTempHome(async (home) => {
       const store = path.join(home, "sessions.json");

--- a/test/scripts/codex-install-assertions.test.ts
+++ b/test/scripts/codex-install-assertions.test.ts
@@ -23,6 +23,8 @@ const tempDirs: string[] = [];
 const tmpFixtureFiles = [
   "/tmp/openclaw-codex-agent.err",
   "/tmp/openclaw-codex-agent.json",
+  "/tmp/openclaw-codex-agent-after-uninstall.err",
+  "/tmp/openclaw-codex-agent-after-uninstall.json",
   "/tmp/openclaw-codex-followthrough.err",
   "/tmp/openclaw-codex-followthrough.json",
   "/tmp/openclaw-codex-inspect.json",
@@ -640,6 +642,29 @@ function createCodexInstallFixture(root: string) {
 }
 
 describe("Codex install helpers", () => {
+  it.each([
+    { status: 1, missingRegistration: true, accepted: true },
+    { status: 0, missingRegistration: true, accepted: false },
+    { status: 1, missingRegistration: false, accepted: false },
+  ])("validates the post-uninstall agent failure: %j", (testCase) => {
+    const message = testCase.missingRegistration
+      ? 'Agent harness runtime "codex" is unavailable because its plugin registration is missing from this prepared run. Enable or reinstall the plugin that provides this runtime, restart the Gateway, then retry.'
+      : "Provider request failed";
+    writeJson("/tmp/openclaw-codex-agent-after-uninstall.json", {
+      ok: false,
+      error: { type: "cli_error", message },
+    });
+    writeFileSync("/tmp/openclaw-codex-agent-after-uninstall.err", message);
+
+    const result = spawnSync(
+      process.execPath,
+      [CODEX_NPM_PLUGIN_LIVE_ASSERTIONS_SCRIPT, "assert-agent-error", String(testCase.status)],
+      { encoding: "utf8" },
+    );
+
+    expect(result.status === 0, result.stderr).toBe(testCase.accepted);
+  });
+
   it("configures the canonical OpenAI model for the Codex runtime by default", () => {
     const root = makeTempDir(tempDirs, "openclaw-codex-npm-configure-");
 


### PR DESCRIPTION
## Summary
One-shot ingress helpers could finish their model/tool work and write a successful result yet never exit. The Codex npm Docker lane exposed this: its follow-through process retained an inotify watcher long after the Codex child and work had completed, eventually hitting the lane timeout.

Honor the existing oneShotCliRun contract when preparing workspace skills. One-shot callers still load their skills snapshot but do not create persistent watchers for later turns. Normal ingress sessions retain watching, and the local CLI behavior stays unchanged. No forced exit, timeout increase, global watcher teardown, or new configuration is added.

The Docker uninstall assertion also recognizes the current prepared-runtime missing-plugin error while retaining historical frozen-package expectations.

Release note: one-shot ingress runs can exit naturally after a completed reply instead of retaining a persistent skills watcher.

## Validation
- Original full Docker lane timed out: https://github.com/openclaw/openclaw/actions/runs/33237600353
- Direct Linux evidence: successful follow-through result and seven successful tools; no remaining Codex child; helper still held an inotify descriptor for several minutes.
- Regression: one-shot ingress failed before the change while three local/normal-ingress siblings passed. All63 agent-command tests passed after repair.
- Existing Codex install assertion suite:40 tests passed; current error case failed before the assertion repair.
- Full rebuilt Codex npm Docker lane passed in1m36s, exit0: https://github.com/openclaw/openclaw/actions/runs/33241739767 . Native preflight, three conversation turns with recall, follow-through/progress/work/artifact/completion, natural process exit, and uninstall fail-closed assertions passed.
- Fixed core tarball SHA-256:870a9c741d167428196ebbb49fef3109dafc01715827a09c0032e8fc91d12a1c. Proof used the original frozen Codex companion artifact.
- Independent Codex autoreview completed without accepted actionable findings. Direct Chokidar source confirms persistent watchers are the default; direct Codex protocol/source inspection performed during the lane investigation.
- Production executable LOC is neutral; two explanatory comment lines added. Test/support adds50 lines.

Main independently landed the timeout diagnostics repair in#132434; that duplicate change is excluded here. Exact-head hosted CI is required before landing.
