### PR TITLE
fix(release): retain frozen plugin security inventory

### DIFF
--- a/.github/workflows/full-release-validation.yml
+++ b/.github/workflows/full-release-validation.yml
@@ -897,6 +897,9 @@ jobs:
               dispatch_id="full-release-validation-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-plugin-prerelease-${PHASE}"
               dispatch_run_name="Plugin Prerelease ${dispatch_id}"
               args=(-f target_ref="$TARGET_SHA" -f expected_sha="$TARGET_SHA" -f full_release_validation=true -f phase="$PHASE" -f dispatch_id="$dispatch_id" -f node_test_exclude_patterns_json="$PLUGIN_PRERELEASE_NODE_EXCLUDE_PATTERNS_JSON")
+              if [[ -n "${TARGET_CONTEXT_REF:-}" ]]; then
+                args+=(-f target_context_ref="$TARGET_CONTEXT_REF")
+              fi
               if [[ -n "${CANDIDATE_ARTIFACT_JSON// }" ]]; then
                 args+=(-f candidate_artifact_json="$CANDIDATE_ARTIFACT_JSON")
               fi

--- a/.github/workflows/plugin-prerelease.yml
+++ b/.github/workflows/plugin-prerelease.yml
@@ -15,6 +15,11 @@ on:
         required: false
         default: ""
         type: string
+      target_context_ref:
+        description: Canonical release context for an exact-SHA frozen-target validation
+        required: false
+        default: ""
+        type: string
       full_release_validation:
         description: Enable release-only Docker prerelease lanes from Full Release Validation
         required: false
@@ -539,6 +544,7 @@ jobs:
         env:
           NODE_OPTIONS: --max-old-space-size=8192
           NODE_TEST_EXCLUDE_PATTERNS_JSON: ${{ needs.preflight.outputs.node_test_exclude_patterns_json }}
+          OPENCLAW_RELEASE_TARGET_CONTEXT_REF: ${{ inputs.target_context_ref }}
           OPENCLAW_NODE_TEST_CONFIGS_JSON: ${{ toJson(matrix.configs) }}
           OPENCLAW_NODE_TEST_INCLUDE_PATTERNS_JSON: ${{ toJson(matrix.includePatterns) }}
           OPENCLAW_VITEST_SHARD_NAME: ${{ matrix.shard_name }}

--- a/src/plugins/npm-install-security-scan.release.test.ts
+++ b/src/plugins/npm-install-security-scan.release.test.ts
@@ -68,8 +68,7 @@ const CURRENT_OPTIONAL_REVIEWED_PACKED_FINDING_COUNTS = new Map<string, number>(
   ["@openclaw/voice-call:dangerous-exec:dist/runtime-entry-<hash>.js", 1],
 ]);
 
-const FROZEN_TARGET_REVISION = "fdc1c2e6c1b5f41d00edb2eb55244fa7c51f87dd";
-const FROZEN_TARGET_REQUIRED_REVIEWED_SOURCE_FINDING_COUNTS = new Map<string, number>([
+const FROZEN_RELEASE_REQUIRED_REVIEWED_SOURCE_FINDING_COUNTS = new Map<string, number>([
   ["@openclaw/acpx:dangerous-exec:src/codex-auth-bridge.ts", 1],
   ["@openclaw/acpx:dangerous-exec:src/runtime-internals/mcp-proxy.mjs", 1],
   ["@openclaw/codex:dangerous-exec:src/app-server/transport-stdio.ts", 1],
@@ -83,7 +82,7 @@ const FROZEN_TARGET_REQUIRED_REVIEWED_SOURCE_FINDING_COUNTS = new Map<string, nu
   ["@openclaw/voice-call:dangerous-exec:src/tunnel.ts", 1],
   ["@openclaw/voice-call:dangerous-exec:src/webhook/tailscale.ts", 1],
 ]);
-const FROZEN_TARGET_OPTIONAL_REVIEWED_PACKED_FINDING_COUNTS = new Map<string, number>([
+const FROZEN_RELEASE_OPTIONAL_REVIEWED_PACKED_FINDING_COUNTS = new Map<string, number>([
   ["@openclaw/acpx:dangerous-exec:dist/mcp-proxy.mjs", 1],
   ["@openclaw/acpx:dangerous-exec:dist/service-<hash>.js", 1],
   ["@openclaw/codex:dangerous-exec:dist/client-<hash>.js", 1],
@@ -116,20 +115,25 @@ const CURRENT_SECURITY_INVENTORY_POLICY = createPluginSecurityInventoryPolicy({
   codexSourceLayouts: [CODEX_LEGACY_SOURCE_FINDING_COUNTS, CODEX_CURRENT_SOURCE_FINDING_COUNTS],
 });
 
-// This exact candidate predates the current plugin and finding inventory.
-// Keep its complete reviewed policy isolated so every other revision fails closed.
-const FROZEN_TARGET_SECURITY_INVENTORY_POLICY = createPluginSecurityInventoryPolicy({
-  requiredSourceFindingCounts: FROZEN_TARGET_REQUIRED_REVIEWED_SOURCE_FINDING_COUNTS,
-  optionalPackedFindingCounts: FROZEN_TARGET_OPTIONAL_REVIEWED_PACKED_FINDING_COUNTS,
+// A frozen release line can retain its complete reviewed inventory while the
+// trusted scanner evolves. The release controller validates the context first.
+const FROZEN_RELEASE_SECURITY_INVENTORY_POLICY = createPluginSecurityInventoryPolicy({
+  requiredSourceFindingCounts: FROZEN_RELEASE_REQUIRED_REVIEWED_SOURCE_FINDING_COUNTS,
+  optionalPackedFindingCounts: FROZEN_RELEASE_OPTIONAL_REVIEWED_PACKED_FINDING_COUNTS,
   codexSourceLayouts: [CODEX_LEGACY_SOURCE_FINDING_COUNTS],
 });
 
+const FROZEN_RELEASE_SECURITY_INVENTORY_POLICIES = new Map<string, PluginSecurityInventoryPolicy>([
+  ["extended-stable/2026.6.33", FROZEN_RELEASE_SECURITY_INVENTORY_POLICY],
+]);
+
 function selectPluginSecurityInventoryPolicy(
-  candidateRevision: string,
+  targetContextRef: string,
 ): PluginSecurityInventoryPolicy {
-  return candidateRevision === FROZEN_TARGET_REVISION
-    ? FROZEN_TARGET_SECURITY_INVENTORY_POLICY
-    : CURRENT_SECURITY_INVENTORY_POLICY;
+  return (
+    FROZEN_RELEASE_SECURITY_INVENTORY_POLICIES.get(targetContextRef) ??
+    CURRENT_SECURITY_INVENTORY_POLICY
+  );
 }
 
 function parseNpmPackFiles(raw: string, packageName: string): string[] {
@@ -370,20 +374,6 @@ function listFindExtensionPackageFiles(): string[] | null {
     .toSorted();
 }
 
-function resolveCandidateRevision(): string {
-  const result = spawnSync("git", ["rev-parse", "HEAD"], {
-    cwd: process.cwd(),
-    encoding: "utf8",
-    maxBuffer: 1024 * 1024,
-    stdio: ["ignore", "pipe", "ignore"],
-  });
-  const revision = result.stdout.trim();
-  if (result.status !== 0 || !/^[0-9a-f]{40}$/u.test(revision)) {
-    throw new Error("Could not resolve the exact candidate Git revision.");
-  }
-  return revision;
-}
-
 function collectPublishablePluginPackages(): PublishablePluginPackage[] {
   return listPublishablePluginPackageDirs()
     .flatMap((packageDir) => {
@@ -523,8 +513,9 @@ async function scanPublishablePluginPackage(
 }
 
 describe("publishable plugin npm package install security scan", () => {
-  const candidateRevision = resolveCandidateRevision();
-  const securityInventoryPolicy = selectPluginSecurityInventoryPolicy(candidateRevision);
+  const securityInventoryPolicy = selectPluginSecurityInventoryPolicy(
+    process.env.OPENCLAW_RELEASE_TARGET_CONTEXT_REF ?? "",
+  );
   const publishablePluginPackages = collectPublishablePluginPackages();
   const scanResultsByPackageName = new Map<
     string,
@@ -618,14 +609,14 @@ describe("publishable plugin npm package install security scan", () => {
     ).toEqual([]);
     expect(
       expectedOptionalReviewedFindingsForPackedPath(
-        FROZEN_TARGET_SECURITY_INVENTORY_POLICY,
+        FROZEN_RELEASE_SECURITY_INVENTORY_POLICY,
         "@openclaw/codex",
         "dist/client-frozen.js",
       ),
     ).toEqual(["@openclaw/codex:dangerous-exec:dist/client-<hash>.js"]);
     expect(
       expectedOptionalReviewedFindingsForPackedPath(
-        FROZEN_TARGET_SECURITY_INVENTORY_POLICY,
+        FROZEN_RELEASE_SECURITY_INVENTORY_POLICY,
         "@openclaw/codex",
         "dist/dynamic-tools-current.js",
       ),
@@ -684,28 +675,30 @@ describe("publishable plugin npm package install security scan", () => {
       resolveReviewedCodexSourceLayout(CURRENT_SECURITY_INVENTORY_POLICY, currentLayout),
     ).toEqual(currentLayout);
     expect(
-      resolveReviewedCodexSourceLayout(FROZEN_TARGET_SECURITY_INVENTORY_POLICY, legacyLayout),
+      resolveReviewedCodexSourceLayout(FROZEN_RELEASE_SECURITY_INVENTORY_POLICY, legacyLayout),
     ).toEqual(legacyLayout);
     expect(
-      resolveReviewedCodexSourceLayout(FROZEN_TARGET_SECURITY_INVENTORY_POLICY, currentLayout),
+      resolveReviewedCodexSourceLayout(FROZEN_RELEASE_SECURITY_INVENTORY_POLICY, currentLayout),
     ).toBeUndefined();
     expect(
-      resolveReviewedCodexSourceLayout(FROZEN_TARGET_SECURITY_INVENTORY_POLICY, [
+      resolveReviewedCodexSourceLayout(FROZEN_RELEASE_SECURITY_INVENTORY_POLICY, [
         ...legacyLayout,
         firstLegacyFinding,
       ]),
     ).toBeUndefined();
-    expect(selectPluginSecurityInventoryPolicy(FROZEN_TARGET_REVISION)).toBe(
-      FROZEN_TARGET_SECURITY_INVENTORY_POLICY,
+    expect(selectPluginSecurityInventoryPolicy("extended-stable/2026.6.33")).toBe(
+      FROZEN_RELEASE_SECURITY_INVENTORY_POLICY,
     );
-    expect(selectPluginSecurityInventoryPolicy(`0${FROZEN_TARGET_REVISION.slice(1)}`)).toBe(
-      CURRENT_SECURITY_INVENTORY_POLICY,
-    );
+    for (const targetContextRef of ["", "extended-stable/2026.7.33", "release/2026.6.35"]) {
+      expect(selectPluginSecurityInventoryPolicy(targetContextRef)).toBe(
+        CURRENT_SECURITY_INVENTORY_POLICY,
+      );
+    }
     const historicalFinding = "@openclaw/matrix:dangerous-exec:src/matrix/deps.ts";
     const currentFinding = "@openclaw/mxc-sandbox:dangerous-exec:src/readiness.ts";
     expect(
       isReviewedPublishableCriticalFinding(
-        FROZEN_TARGET_SECURITY_INVENTORY_POLICY,
+        FROZEN_RELEASE_SECURITY_INVENTORY_POLICY,
         historicalFinding,
       ),
     ).toBe(true);
@@ -716,7 +709,10 @@ describe("publishable plugin npm package install security scan", () => {
       isReviewedPublishableCriticalFinding(CURRENT_SECURITY_INVENTORY_POLICY, currentFinding),
     ).toBe(true);
     expect(
-      isReviewedPublishableCriticalFinding(FROZEN_TARGET_SECURITY_INVENTORY_POLICY, currentFinding),
+      isReviewedPublishableCriticalFinding(
+        FROZEN_RELEASE_SECURITY_INVENTORY_POLICY,
+        currentFinding,
+      ),
     ).toBe(false);
   });
 
@@ -768,7 +764,7 @@ describe("publishable plugin npm package install security scan", () => {
     ).toBe(false);
     expect(
       isReviewedPublishableCriticalFinding(
-        FROZEN_TARGET_SECURITY_INVENTORY_POLICY,
+        FROZEN_RELEASE_SECURITY_INVENTORY_POLICY,
         relocatedFinding,
       ),
     ).toBe(false);

--- a/src/plugins/npm-install-security-scan.release.test.ts
+++ b/src/plugins/npm-install-security-scan.release.test.ts
@@ -51,7 +51,7 @@ const CODEX_LEGACY_SOURCE_FINDING_COUNTS = new Map<string, number>([
 ]);
 const CODEX_CURRENT_SOURCE_FINDING_COUNTS = new Map<string, number>([
   ["@openclaw/codex:dangerous-exec:src/app-server/sandbox-exec-server/sandbox-child.ts", 1],
-  ["@openclaw/codex:dangerous-exec:src/app-server/transport-process-containment.ts", 1],
+  ["@openclaw/codex:dangerous-exec:src/app-server/transport-process-snapshot.ts", 1],
 ]);
 
 // Generated chunks can contain multiple reviewed execution sites. Counts are
@@ -730,7 +730,7 @@ describe("publishable plugin npm package install security scan", () => {
       "mixed",
       [
         "@openclaw/codex:dangerous-exec:src/app-server/sandbox-exec-server/http.ts",
-        "@openclaw/codex:dangerous-exec:src/app-server/transport-process-containment.ts",
+        "@openclaw/codex:dangerous-exec:src/app-server/transport-process-snapshot.ts",
       ],
     ],
     [
@@ -744,7 +744,7 @@ describe("publishable plugin npm package install security scan", () => {
       "duplicate occurrence",
       [
         ...expandReviewedFindingCounts(CODEX_CURRENT_SOURCE_FINDING_COUNTS),
-        "@openclaw/codex:dangerous-exec:src/app-server/transport-process-containment.ts",
+        "@openclaw/codex:dangerous-exec:src/app-server/transport-process-snapshot.ts",
       ],
     ],
   ];

--- a/src/skills/security/scanner.test.ts
+++ b/src/skills/security/scanner.test.ts
@@ -768,6 +768,18 @@ describe("scanDirectoryWithSummary", () => {
         findingCount: 0,
       },
     },
+    {
+      name: "excludes test helper source when test files are excluded",
+      files: {
+        "runtime.ts": `export const ok = true;`,
+        "worker.test-helper.ts": `import { spawn } from "node:child_process"; spawn("node");`,
+      },
+      options: { excludeTestFiles: true },
+      expected: {
+        scannedFiles: 1,
+        findingCount: 0,
+      },
+    },
   ];
 
   it("summarizes directory scan results", async () => {

--- a/src/skills/security/scanner.ts
+++ b/src/skills/security/scanner.ts
@@ -64,7 +64,7 @@ const MAX_LINE_RULE_FINDINGS_PER_RULE = 32;
 const FILE_SCAN_CACHE_MAX = 5000;
 const DIR_ENTRY_CACHE_MAX = 5000;
 const TEST_DIRECTORY_NAMES = new Set(["__fixtures__", "__mocks__", "__tests__", "test", "tests"]);
-const TEST_FILE_NAME_PATTERN = /\.(?:mock|spec|test)\.[^.]+$/i;
+const TEST_FILE_NAME_PATTERN = /\.(?:mock|spec|test|test-helper|test-support)\.[^.]+$/i;
 
 type FileScanCacheEntry = {
   size: number;

--- a/test/scripts/plugin-prerelease-test-plan.test.ts
+++ b/test/scripts/plugin-prerelease-test-plan.test.ts
@@ -486,6 +486,12 @@ describe("scripts/lib/plugin-prerelease-test-plan.mts", () => {
       required: false,
       type: "string",
     });
+    expect(pluginWorkflow.on.workflow_dispatch.inputs.target_context_ref).toEqual({
+      default: "",
+      description: "Canonical release context for an exact-SHA frozen-target validation",
+      required: false,
+      type: "string",
+    });
     expect(preflight.outputs.node_test_exclude_patterns_json).toBe(
       "${{ steps.node_test_exclusions.outputs.patterns_json }}",
     );
@@ -524,6 +530,9 @@ describe("scripts/lib/plugin-prerelease-test-plan.mts", () => {
     expect(runNodeShard?.env?.NODE_TEST_EXCLUDE_PATTERNS_JSON).toBe(
       "${{ needs.preflight.outputs.node_test_exclude_patterns_json }}",
     );
+    expect(runNodeShard?.env?.OPENCLAW_RELEASE_TARGET_CONTEXT_REF).toBe(
+      "${{ inputs.target_context_ref }}",
+    );
     expect(runNodeShard?.run).toContain('process.env.NODE_TEST_EXCLUDE_PATTERNS_JSON ?? "[]"');
     expect(runNodeShard?.run).toContain('pattern.slice("src/plugins/".length)');
     expect(runNodeShard?.run).toContain("`--exclude=${pattern.slice");
@@ -549,6 +558,7 @@ describe("scripts/lib/plugin-prerelease-test-plan.mts", () => {
     expect(pluginDispatch?.run).toContain(
       '-f node_test_exclude_patterns_json="$PLUGIN_PRERELEASE_NODE_EXCLUDE_PATTERNS_JSON"',
     );
+    expect(pluginDispatch?.run).toContain('args+=(-f target_context_ref="$TARGET_CONTEXT_REF")');
     expect(pluginDispatch?.run).toContain("- Frozen-target Node test omissions:");
     expect(evidenceReuse?.env?.PLUGIN_PRERELEASE_NODE_EXCLUDE_PATTERNS_JSON).toBe(
       "${{ inputs.plugin_prerelease_node_exclude_patterns_json }}",


### PR DESCRIPTION
## What Problem This Solves

Full Release Validation tests a frozen release candidate with current trusted release tooling. The candidate reviewed plugin-security inventory can legitimately differ from current `main`; that policy must be chosen by the validated release context, not by a mutable candidate SHA.

The CI follow-up also found current Codex source had moved its real bounded process inspection, while a `*.test-helper.ts` fixture was accidentally being scanned as production source.

## Canonical Fix

- Forward the already-validated canonical `target_context_ref` from Full Release Validation into Plugin Prerelease.
- Select a frozen inventory only from an exact release-context registry. `extended-stable/2026.6.33` uses its complete reviewed inventory; empty, other lines, and unknown contexts retain the current fail-closed inventory. Candidate commit SHAs are not selectors.
- Teach the scanner existing `excludeTestFiles` mode to recognize established `*.test-helper.*` and `*.test-support.*` names. `*.test-harness.*` remains scanned.
- Replace the stale current Codex inventory key with `src/app-server/transport-process-snapshot.ts`: the actual bounded `execFile("ps", argv)` identity check used before signalling a process. The excluded helper is test-only.

A future frozen line needs an independently reviewed policy entry; this is deliberate, not a permissive range match.

## Impact

No release-candidate, npm package, dependency, or runtime behavior changes. This repairs trusted validation routing and security-scan classification on `main`.

Production/tooling LOC: +10/-1 (net +9). Tests: +62/-44. The production growth is the explicit workflow context handoff plus the generic test-support filename classification; the remaining changes update inventory contract tests.

## Evidence

- Original frozen-inventory mismatch: [plugin prerelease failure](https://github.com/openclaw/openclaw/actions/runs/33238941484/job/99064876800).
- CI follow-up that exposed the current Codex layout: [compact Node shard](https://github.com/openclaw/openclaw/actions/runs/33284820281/job/99186151474).
- Frozen candidate `782a8f79688d1f102dc4c0e13d7b15fa8b06c869`, using the workflow copied scanner and `OPENCLAW_RELEASE_TARGET_CONTEXT_REF=extended-stable/2026.6.33`: 82 passed.
- Current focused proof: `npm-install-security-scan.release.test.ts` 103/103; `scanner.test.ts` 42/42; `package-acceptance-workflow.test.ts` 214/214; `plugin-prerelease-test-plan.test.ts` 19/19.
- `actionlint`, focused format check, and `git diff --check` passed. `check-changed` selects core, coreTests, testRoot, and tooling; exact-head CI is running for the broad gate.
