### PR TITLE
test(docker): bind live lanes to prepared candidate artifacts

### DIFF
--- a/scripts/e2e/codex-media-path-docker.sh
+++ b/scripts/e2e/codex-media-path-docker.sh
@@ -3,13 +3,18 @@ set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 source "$ROOT_DIR/scripts/lib/docker-e2e-image.sh"
+source "$ROOT_DIR/scripts/e2e/lib/prepublish-plugin-registry.sh"
 
 IMAGE_NAME="$(docker_e2e_resolve_image "openclaw-codex-media-path-e2e" OPENCLAW_CODEX_MEDIA_PATH_E2E_IMAGE)"
 PORT="$(docker_e2e_read_tcp_port_env OPENCLAW_CODEX_MEDIA_PATH_PORT 18790)"
 TIMEOUT_SECONDS="$(docker_e2e_read_positive_int_env OPENCLAW_CODEX_MEDIA_PATH_TIMEOUT_SECONDS 180)"
 LOG_TAIL_MAX_BYTES="$(docker_e2e_read_positive_int_env OPENCLAW_CODEX_MEDIA_PATH_LOG_TAIL_MAX_BYTES 2097152)"
 TOKEN="codex-media-path-e2e-$$"
-CODEX_PLUGIN_SPEC="${OPENCLAW_CODEX_MEDIA_PATH_PLUGIN_SPEC:-npm:@openclaw/codex}"
+OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_DOCKER_ARGS=()
+if [ -n "${OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_DIR:-}" ]; then
+  openclaw_prepublish_plugin_registry_configure_docker_args \
+    "$OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_DIR"
+fi
 
 docker_e2e_build_or_reuse "$IMAGE_NAME" codex-media-path "$ROOT_DIR/scripts/e2e/Dockerfile" "$ROOT_DIR"
 OPENCLAW_TEST_STATE_SCRIPT_B64="$(docker_e2e_test_state_shell_b64 codex-media-path empty)"
@@ -17,13 +22,14 @@ OPENCLAW_TEST_STATE_SCRIPT_B64="$(docker_e2e_test_state_shell_b64 codex-media-pa
 echo "Running Codex media-path Docker E2E..."
 docker_e2e_run_logged_with_harness codex-media-path \
   -e COREPACK_ENABLE_DOWNLOAD_PROMPT=0 \
-  -e "OPENCLAW_CODEX_MEDIA_PATH_PLUGIN_SPEC=$CODEX_PLUGIN_SPEC" \
+  -e OPENCLAW_CODEX_MEDIA_PATH_PLUGIN_SPEC \
   -e "OPENCLAW_CODEX_MEDIA_PATH_LOG_TAIL_MAX_BYTES=$LOG_TAIL_MAX_BYTES" \
   -e "OPENCLAW_CODEX_MEDIA_PATH_TIMEOUT_SECONDS=$TIMEOUT_SECONDS" \
   -e "OPENCLAW_ALLOW_INSECURE_PRIVATE_WS=1" \
   -e "OPENCLAW_GATEWAY_TOKEN=$TOKEN" \
   -e "OPENCLAW_TEST_STATE_SCRIPT_B64=$OPENCLAW_TEST_STATE_SCRIPT_B64" \
   -e "PORT=$PORT" \
+  "${OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_DOCKER_ARGS[@]}" \
   -v "$ROOT_DIR/src:/app/src:ro" \
   -v "$ROOT_DIR/test/helpers:/app/test/helpers:ro" \
   "$IMAGE_NAME" \

--- a/scripts/e2e/lib/codex-media-path/fake-codex-app-server.mjs
+++ b/scripts/e2e/lib/codex-media-path/fake-codex-app-server.mjs
@@ -17,8 +17,8 @@ runFakeCodexAppServer({
       sendResult(
         createFakeInitializeResponse({
           name: "openclaw-codex-media-path-e2e",
-          version: "0.125.0",
-          userAgent: "openclaw-codex-media-path-e2e/0.125.0 (Docker; test)",
+          version: "0.150.1",
+          userAgent: "openclaw-codex-media-path-e2e/0.150.1 (Docker; test)",
         }),
       ),
     "thread/start": ({ params, sendResult }) =>
@@ -27,7 +27,7 @@ runFakeCodexAppServer({
           params,
           threadId: "thread-codex-media-path-e2e",
           sessionId: "session-codex-media-path-e2e",
-          version: "0.125.0",
+          version: "0.150.1",
         }),
       ),
     "turn/start": ({ sendResult }) => {

--- a/scripts/e2e/lib/codex-media-path/scenario.sh
+++ b/scripts/e2e/lib/codex-media-path/scenario.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 
 source scripts/lib/openclaw-e2e-instance.sh
+source scripts/e2e/lib/prepublish-plugin-registry.sh
 openclaw_e2e_eval_test_state_from_b64 "${OPENCLAW_TEST_STATE_SCRIPT_B64:?missing OPENCLAW_TEST_STATE_SCRIPT_B64}"
 export OPENCLAW_SKIP_CHANNELS=1
 export OPENCLAW_SKIP_GMAIL_WATCHER=1
@@ -15,15 +16,20 @@ export OPENCLAW_CODEX_MEDIA_PATH_APP_SERVER_LOG="/tmp/openclaw-codex-media-path-
 
 PORT="${PORT:?missing PORT}"
 TOKEN="${OPENCLAW_GATEWAY_TOKEN:?missing OPENCLAW_GATEWAY_TOKEN}"
-PLUGIN_SPEC="${OPENCLAW_CODEX_MEDIA_PATH_PLUGIN_SPEC:?missing OPENCLAW_CODEX_MEDIA_PATH_PLUGIN_SPEC}"
+PLUGIN_SPEC="${OPENCLAW_CODEX_MEDIA_PATH_PLUGIN_SPEC:-npm:@openclaw/codex}"
+if [[ -z "${OPENCLAW_CODEX_MEDIA_PATH_PLUGIN_SPEC:-}" && -n "${OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_DIR:-}" ]]; then
+  PLUGIN_SPEC="npm:@openclaw/codex@${OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_CANDIDATE_VERSION:?missing candidate version}"
+fi
 GATEWAY_LOG="/tmp/openclaw-codex-media-path-gateway.log"
 CLIENT_LOG="/tmp/openclaw-codex-media-path-client.log"
 PLUGIN_INSTALL_LOG="/tmp/openclaw-codex-media-path-plugin-install.log"
 PLUGIN_INSPECT_LOG="/tmp/openclaw-codex-media-path-plugin-inspect.json"
 gateway_pid=""
+plugin_registry_pid=""
 
 cleanup() {
   openclaw_e2e_stop_process "$gateway_pid"
+  openclaw_e2e_stop_process "$plugin_registry_pid"
 }
 trap cleanup EXIT
 
@@ -39,6 +45,8 @@ mkdir -p "$OPENCLAW_STATE_DIR" "$OPENCLAW_TEST_WORKSPACE_DIR"
 rm -f "$OPENCLAW_CODEX_MEDIA_PATH_APP_SERVER_LOG"
 
 openclaw_e2e_enable_openclaw_cli_timeout
+openclaw_prepublish_plugin_registry_start_mounted \
+  /tmp/openclaw-codex-media-path-registry plugin_registry_pid '["@openclaw/codex"]'
 
 echo "Installing Codex plugin: $PLUGIN_SPEC"
 openclaw_e2e_fixture_plugin_command openclaw -- plugins install "$PLUGIN_SPEC" --force >"$PLUGIN_INSTALL_LOG" 2>&1

--- a/scripts/e2e/mcp-code-mode-gateway-live-docker.sh
+++ b/scripts/e2e/mcp-code-mode-gateway-live-docker.sh
@@ -5,6 +5,7 @@ set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 source "$ROOT_DIR/scripts/lib/docker-e2e-image.sh"
+source "$ROOT_DIR/scripts/e2e/lib/prepublish-plugin-registry.sh"
 
 IMAGE_NAME="$(docker_e2e_resolve_image "openclaw-mcp-code-mode-gateway-live-e2e" OPENCLAW_IMAGE)"
 PORT="$(docker_e2e_read_tcp_port_env OPENCLAW_MCP_CODE_MODE_LIVE_GATEWAY_PORT 18789)"
@@ -26,14 +27,12 @@ if [ ! -f "$PROFILE_FILE" ] && [ -f "$HOME/.profile" ]; then
   PROFILE_FILE="$HOME/.profile"
 fi
 
-PROFILE_MOUNT=()
 PROFILE_STATUS="none"
 if [ -f "$PROFILE_FILE" ] && [ -r "$PROFILE_FILE" ]; then
   set -a
   # shellcheck disable=SC1090
   source "$PROFILE_FILE"
   set +a
-  PROFILE_MOUNT=(-v "$PROFILE_FILE":/home/appuser/.profile:ro)
   PROFILE_STATUS="$PROFILE_FILE"
 fi
 
@@ -43,6 +42,11 @@ if [ -z "${OPENAI_API_KEY:-}" ]; then
 fi
 docker_e2e_build_or_reuse "$IMAGE_NAME" mcp-code-mode-gateway-live
 OPENCLAW_TEST_STATE_SCRIPT_B64="$(docker_e2e_test_state_shell_b64 mcp-code-mode-gateway-live empty)"
+OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_DOCKER_ARGS=()
+if [ -n "${OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_DIR:-}" ]; then
+  openclaw_prepublish_plugin_registry_configure_docker_args \
+    "$OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_DIR"
+fi
 
 # The profile is only a credential source. Keep this lane's OpenClaw runtime
 # isolated from host/testbox mode flags that can change packaged behavior.
@@ -71,18 +75,11 @@ docker_e2e_run_with_harness \
   -e "OPENCLAW_MCP_CODE_MODE_CLIENT_BODY_MAX_BYTES=$CLIENT_BODY_MAX_BYTES" \
   -e "OPENCLAW_ALLOW_INSECURE_PRIVATE_WS=1" \
   -e "OPENCLAW_MCP_CODE_MODE_MODEL=${OPENCLAW_MCP_CODE_MODE_LIVE_MODEL:-openclaw/main}" \
-  "${PROFILE_MOUNT[@]}" \
+  "${OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_DOCKER_ARGS[@]}" \
   "$IMAGE_NAME" \
   bash -lc "set -euo pipefail
     source scripts/lib/openclaw-e2e-instance.sh
-    for profile_path in \"\$HOME/.profile\" /home/appuser/.profile; do
-      if [ -f \"\$profile_path\" ] && [ -r \"\$profile_path\" ]; then
-        set +e +u
-        source \"\$profile_path\"
-        set -euo pipefail
-        break
-      fi
-    done
+    source scripts/e2e/lib/prepublish-plugin-registry.sh
     unset OPENCLAW_TESTBOX
     if [ -z \"\${OPENAI_API_KEY:-}\" ]; then
       echo \"ERROR: OPENAI_API_KEY was not available inside the container.\" >&2
@@ -91,14 +88,17 @@ docker_e2e_run_with_harness \
     openclaw_e2e_eval_test_state_from_b64 \"\${OPENCLAW_TEST_STATE_SCRIPT_B64:?missing OPENCLAW_TEST_STATE_SCRIPT_B64}\"
     entry=\"\$(openclaw_e2e_resolve_entrypoint)\"
     gateway_pid=
+    plugin_registry_pid=
     cleanup_inner() {
       openclaw_e2e_stop_process \"\${gateway_pid:-}\"
+      openclaw_e2e_stop_process \"\${plugin_registry_pid:-}\"
     }
     dump_logs_on_error() {
       status=\$?
       if [ \"\$status\" -ne 0 ]; then
         openclaw_e2e_dump_logs \
           /tmp/mcp-code-mode-live-gateway.log \
+          /tmp/mcp-code-mode-live-plugin-install.log \
           /tmp/mcp-code-mode-live-seed.log
         if [ -d \"\${OPENCLAW_STATE_DIR:-}/agents/main/sessions\" ]; then
           echo \"--- session MCP/code-mode excerpts ---\" >&2
@@ -111,6 +111,12 @@ docker_e2e_run_with_harness \
     }
     trap cleanup_inner EXIT
     trap dump_logs_on_error ERR
+    openclaw_prepublish_plugin_registry_start_mounted \
+      /tmp/openclaw-mcp-code-mode-live-registry plugin_registry_pid '[\"@openclaw/codex\"]'
+    openclaw_e2e_enable_openclaw_cli_timeout
+    openclaw_e2e_fixture_plugin_command openclaw -- plugins install \
+      \"npm:@openclaw/codex\${OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_CANDIDATE_VERSION:+@\$OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_CANDIDATE_VERSION}\" \
+      --force >/tmp/mcp-code-mode-live-plugin-install.log 2>&1
     tsx scripts/e2e/mcp-code-mode-gateway-seed.ts >/tmp/mcp-code-mode-live-seed.log
     gateway_pid=\"\$(openclaw_e2e_start_gateway \"\$entry\" $PORT /tmp/mcp-code-mode-live-gateway.log)\"
     openclaw_e2e_wait_gateway_ready \"\$gateway_pid\" /tmp/mcp-code-mode-live-gateway.log 480 $PORT

--- a/scripts/lib/docker-e2e-scenarios.mts
+++ b/scripts/lib/docker-e2e-scenarios.mts
@@ -332,6 +332,7 @@ function liveMcpCodeModeGatewayLane() {
     {
       cacheKey: "mcp-code-mode-gateway",
       e2eImageKind: "functional",
+      prepublishPluginPackages: ["@openclaw/codex"],
       provider: "openai",
       resources: ["npm", "service"],
       stateScenario: "empty",
@@ -398,8 +399,7 @@ export const mainLanes: DockerE2eLane[] = [
     "live-gateway",
     liveDockerScriptCommand(
       "test-live-gateway-models-docker.sh",
-      "OPENCLAW_IMAGE=openclaw:local-live-gateway OPENCLAW_DOCKER_BUILD_EXTENSIONS=matrix OPENCLAW_LIVE_GATEWAY_PROVIDERS=claude-cli,google-gemini-cli",
-      { skipBuild: false },
+      "OPENCLAW_LIVE_GATEWAY_PROVIDERS=claude-cli,google-gemini-cli",
     ),
     {
       providers: ["claude-cli", "google-gemini-cli"],
@@ -456,6 +456,7 @@ export const mainLanes: DockerE2eLane[] = [
     "codex-media-path",
     "OPENCLAW_SKIP_DOCKER_BUILD=1 pnpm test:docker:codex-media-path",
     {
+      prepublishPluginPackages: ["@openclaw/codex"],
       resources: ["npm"],
       stateScenario: "empty",
       weight: 3,

--- a/test/scripts/codex-media-path-client.test.ts
+++ b/test/scripts/codex-media-path-client.test.ts
@@ -135,6 +135,31 @@ describe("codex media path limits", () => {
 });
 
 describe("codex media path fake app-server", () => {
+  it("advertises the managed Codex version across initialization and thread creation", async () => {
+    const requestLog = path.join(tempRoots.make("openclaw-codex-media-path-"), "requests.jsonl");
+    const version = JSON.parse(readFileSync("extensions/codex/package.json", "utf8")).dependencies[
+      "@openai/codex"
+    ];
+    const child = spawn(process.execPath, [fakeAppServerPath], {
+      env: { ...process.env, OPENCLAW_CODEX_MEDIA_PATH_APP_SERVER_LOG: requestLog },
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    try {
+      const initialized = readStdoutLine(child);
+      child.stdin.write(jsonl({ id: "initialize", method: "initialize" }));
+      expect(JSON.parse(await initialized).result).toMatchObject({
+        serverInfo: { version },
+        userAgent: expect.stringContaining(`/${version} `),
+      });
+
+      const started = readStdoutLine(child);
+      child.stdin.write(jsonl({ id: "thread", method: "thread/start", params: {} }));
+      expect(JSON.parse(await started).result.thread.cliVersion).toBe(version);
+    } finally {
+      await stopChild(child);
+    }
+  });
+
   it("returns a structured error when request logging fails", async () => {
     const requestLogDirectory = tempRoots.make("openclaw-codex-media-path-");
     const child: ChildProcessWithoutNullStreams = spawn(process.execPath, [fakeAppServerPath], {

--- a/test/scripts/docker-e2e-plan.test.ts
+++ b/test/scripts/docker-e2e-plan.test.ts
@@ -139,6 +139,8 @@ function bundledPluginSweepLane(index: number): ReturnType<typeof summarizeLane>
 
 describe("scripts/lib/docker-e2e-plan", () => {
   it.each([
+    ["codex-media-path", ["@openclaw/codex"]],
+    ["live-mcp-code-mode-gateway", ["@openclaw/codex"]],
     ["release-typed-onboarding", ["@openclaw/codex"]],
     ["npm-onboard-channel-agent", ["@openclaw/codex"]],
     ["npm-onboard-discord-channel-agent", ["@openclaw/codex"]],
@@ -1362,6 +1364,25 @@ describe("scripts/lib/docker-e2e-plan", () => {
       package: false,
       prepublishPluginRegistry: false,
     });
+  });
+
+  it("preserves the shared image selection when launching the live gateway lane", () => {
+    const root = tempDirs.make("openclaw-live-gateway-image-");
+    const script = join(root, "scripts/test-live-gateway-models-docker.sh");
+    mkdirSync(dirname(script), { recursive: true });
+    writeFileSync(script, 'printf "%s\\n" "$OPENCLAW_IMAGE"\n');
+    const lane = requireFirstLane(planFor({ selectedLaneNames: ["live-gateway"] }));
+
+    const image = execFileSync("bash", ["-c", lane.command], {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        OPENCLAW_DOCKER_E2E_TRUSTED_HARNESS_DIR: root,
+        OPENCLAW_IMAGE: "openclaw:shared-candidate",
+      },
+    });
+
+    expect(image.trim()).toBe("openclaw:shared-candidate");
   });
 
   it("derives live Docker credentials from lane resources", () => {


### PR DESCRIPTION
## Summary
The full package Docker sweep found three live lanes that did not consume the artifacts prepared for them. Media-path tried to install the registry's current Codex plugin rather than the frozen candidate, MCP code mode lacked its required runtime plugin, and live-gateway overrode the prepared live image with an image that did not exist.

Declare the companion plugin in the lane catalog and reuse the existing prepublish registry mount/start/cleanup helpers. Install the exact candidate companion before starting the gateway, preserve explicit media plugin overrides, and align the fake app-server version with the managed binary contract. MCP forwards only its required provider environment instead of mounting and sourcing the entire host profile in the container. Live-gateway now reuses its prepared shared image without a redundant build.

## Validation
- Original full sweep: https://github.com/openclaw/openclaw/actions/runs/33237600353 .
- Replayed media-path and authenticated MCP code-mode Docker lanes both passed against the original frozen package plus verified companion registry (49.161s combined). MCP assertions confirmed the expected file, fixture API/tool results, and absence of context pollution.
- Candidate core tarball SHA-256: ab556f10319ee85331dad20d7e8d90c75c3ac7dafc881ecbe79fbfb683465926.
- Media version-contract regression failed before the repair;12 media tests passed afterward. Planner regressions failed before the catalog repair;69 planner/registry tests passed afterward.
- Direct Codex upstream initialization and version contracts inspected, alongside shared registry/image owners and sibling lanes. Independent Codex autoreview clean, plus manual broader review.
- Live-gateway's real replay is still in progress and will be recorded before landing. No claim that this entire candidate matrix is green yet.

Application production LOC:0. Docker tooling/fixtures:+40/-19; tests:+46/-0. The additional wiring uses existing artifact/lifecycle helpers; no new runtime configuration, fallback, schema, or dependency.
