### PR TITLE
fix(acp): keep delivered turns completed when transcript persistence fails

### DIFF
--- a/src/auto-reply/reply/dispatch-acp-transcript.runtime.ts
+++ b/src/auto-reply/reply/dispatch-acp-transcript.runtime.ts
@@ -8,6 +8,7 @@ import type { SessionAcpMeta } from "../../config/sessions/types.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { UserTurnTranscriptRecorder } from "../../sessions/user-turn-transcript.js";
 import type { ReplyDispatchAssistantTranscript } from "../get-reply-options.types.js";
+import { AcpTranscriptSessionFenceError } from "./dispatch-acp-transcript.js";
 
 export async function persistAcpDispatchTranscript(params: {
   cfg: OpenClawConfig;
@@ -40,10 +41,12 @@ export async function persistAcpDispatchTranscript(params: {
   });
   const sessionId = sessionEntry?.sessionId;
   if (!sessionId) {
-    throw new Error(`unknown ACP session key: ${params.sessionKey}`);
+    throw new AcpTranscriptSessionFenceError(`unknown ACP session key: ${params.sessionKey}`);
   }
   if (params.expectedSessionId && sessionId !== params.expectedSessionId) {
-    throw new Error("ACP transcript session changed before the turn could be persisted.");
+    throw new AcpTranscriptSessionFenceError(
+      "ACP transcript session changed before the turn could be persisted.",
+    );
   }
 
   const result = await persistAcpTurnTranscript({
@@ -63,7 +66,9 @@ export async function persistAcpDispatchTranscript(params: {
     assistantIdempotencyKey: params.assistantIdempotencyKey,
   });
   if (result.kind === "session-rebound") {
-    throw new Error("ACP transcript session changed before the turn could be persisted.");
+    throw new AcpTranscriptSessionFenceError(
+      "ACP transcript session changed before the turn could be persisted.",
+    );
   }
   return result.assistantTranscript && params.assistantIdempotencyKey
     ? {

--- a/src/auto-reply/reply/dispatch-acp-transcript.ts
+++ b/src/auto-reply/reply/dispatch-acp-transcript.ts
@@ -1,0 +1,9 @@
+/** Session-identity fence failures for ACP transcript persistence. */
+
+/**
+ * Thrown when session identity diverged before a turn could be persisted
+ * (missing entry, rebound session). Unlike operational I/O failures, these
+ * stay visible to the caller instead of being logged away, because writing
+ * anyway would attach the turn to the wrong session.
+ */
+export class AcpTranscriptSessionFenceError extends Error {}

--- a/src/auto-reply/reply/dispatch-acp.test.ts
+++ b/src/auto-reply/reply/dispatch-acp.test.ts
@@ -32,6 +32,7 @@ import {
   resolveAgentTurnAttachments,
   resolveInlineAgentImageAttachments,
 } from "./agent-turn-attachments.js";
+import { AcpTranscriptSessionFenceError } from "./dispatch-acp-transcript.js";
 import { tryDispatchAcpReplyCore } from "./dispatch-acp.js";
 import { createAbortAwareDispatcher } from "./dispatch-from-config.abort.js";
 import {
@@ -1071,6 +1072,41 @@ describe("tryDispatchAcpReplyCore", () => {
     );
     expect(String(transcript.finalText)).toContain("partial answer");
     expect(String(transcript.finalText)).toContain("acp died after streaming");
+  });
+
+  it("keeps a delivered turn completed when transcript persistence fails operationally", async () => {
+    setReadyAcpResolution();
+    mockRoutedTextTurn("hello");
+    transcriptMocks.persistAcpDispatchTranscript.mockRejectedValueOnce(
+      new Error("ENOSPC: no space left on device"),
+    );
+    const recordProcessed = vi.fn();
+
+    await runDispatch({ bodyForAgent: "reply", recordProcessed });
+
+    // The reply was fully delivered; an operational persistence failure must
+    // not contradict that with a user-facing "turn failed" error outcome.
+    expect(transcriptMocks.persistAcpDispatchTranscript).toHaveBeenCalledTimes(1);
+    expect(recordProcessed).toHaveBeenCalledWith("completed", { reason: "acp_dispatch" });
+  });
+
+  it("stays fail-visible when persistence hits a session identity fence", async () => {
+    setReadyAcpResolution();
+    mockRoutedTextTurn("hello");
+    transcriptMocks.persistAcpDispatchTranscript.mockRejectedValueOnce(
+      new AcpTranscriptSessionFenceError(
+        "ACP transcript session changed before the turn could be persisted.",
+      ),
+    );
+    const recordProcessed = vi.fn();
+
+    await runDispatch({ bodyForAgent: "reply", recordProcessed });
+
+    // Identity fences still surface: persisting would attach the turn to the
+    // wrong session, so the error outcome is the intended visibility.
+    expect(recordProcessed).toHaveBeenCalledWith("completed", {
+      reason: "acp_error:acp_turn_failed",
+    });
   });
 
   it("preserves an intentionally empty canonical agent prompt", async () => {

--- a/src/auto-reply/reply/dispatch-acp.ts
+++ b/src/auto-reply/reply/dispatch-acp.ts
@@ -71,6 +71,7 @@ import {
   createAcpDispatchDeliveryCoordinator,
   type AcpDispatchDeliveryCoordinator,
 } from "./dispatch-acp-delivery.js";
+import { AcpTranscriptSessionFenceError } from "./dispatch-acp-transcript.js";
 import { needsTtsFallback } from "./dispatch-from-config.finalize.js";
 import { appendRecentHistoryImageContext } from "./history-media.js";
 import { hasInboundMediaForUnderstanding } from "./inbound-media.js";
@@ -716,18 +717,32 @@ export async function tryDispatchAcpReplyCore(params: {
       return;
     }
     transcriptPersistenceAttempted = true;
-    const { persistAcpDispatchTranscript } = await loadDispatchAcpTranscriptRuntime();
-    assistantTranscript = await persistAcpDispatchTranscript({
-      cfg: params.cfg,
-      sessionKey: canonicalSessionKey,
-      expectedSessionId: transcriptSessionId,
-      promptText: transcriptPromptText,
-      finalText,
-      meta: acpResolution.kind === "ready" ? acpResolution.meta : undefined,
-      threadId: params.ctx.MessageThreadId,
-      userTurnTranscriptRecorder: params.userTurnTranscriptRecorder,
-      assistantIdempotencyKey: existingRunId,
-    });
+    try {
+      const { persistAcpDispatchTranscript } = await loadDispatchAcpTranscriptRuntime();
+      assistantTranscript = await persistAcpDispatchTranscript({
+        cfg: params.cfg,
+        sessionKey: canonicalSessionKey,
+        expectedSessionId: transcriptSessionId,
+        promptText: transcriptPromptText,
+        finalText,
+        meta: acpResolution.kind === "ready" ? acpResolution.meta : undefined,
+        threadId: params.ctx.MessageThreadId,
+        userTurnTranscriptRecorder: params.userTurnTranscriptRecorder,
+        assistantIdempotencyKey: existingRunId,
+      });
+    } catch (error) {
+      // Identity fences (rebound/missing session) stay fail-visible: persisting
+      // anyway would attach the turn to the wrong session. Operational failures
+      // must not turn an already-delivered turn into a user-facing "turn failed".
+      if (error instanceof AcpTranscriptSessionFenceError) {
+        throw error;
+      }
+      logVerbose(
+        `dispatch-acp: transcript persistence failed for ${canonicalSessionKey}: ${formatErrorMessage(
+          error,
+        )}`,
+      );
+    }
   };
   let admittedRunContext: AdmittedRunContext | undefined;
   let nativeActionEvidenceRecorded = false;


### PR DESCRIPTION
## What Problem This Solves

Fixes #132516

Since #132040 (`1c40abdb63b`), any **operational** ACP transcript-persistence failure (fs error, unreadable session store, lazy-import failure) turns an already fully delivered turn into a user-facing error. The success path persists the transcript only *after* the reply was fully delivered (`src/auto-reply/reply/dispatch-acp.ts:991`); if that write throws, the dispatch failure path (`:999-1031`) delivers `[error] ACP turn failed before completion.` as a second final message — factually wrong, the turn did complete — and records the outcome as `acp_error:acp_turn_failed`. One action ends in two contradictory visible outcomes. The aborted path (`:966`) has the same shape: a user-cancelled turn can be followed by an error message.

The same commit added the session-identity fence (`expectedSessionId` / session-rebound) whose throws *are* deliberately fail-visible — but it also removed the pre-existing `try/catch + logVerbose` that kept operational failures log-only since `eeeae78bccb`. That removal is not mentioned in the commit message or review discussion and has no test coverage; it reads as an incidental side effect of the fence work.

## Why This Change Was Made

Splits the two failure classes apart at the owner boundary:

- `persistAcpDispatchTranscript` now throws a typed `AcpTranscriptSessionFenceError` (new static sibling `dispatch-acp-transcript.ts`, keeping the `.runtime.ts` lazy boundary) for all three identity fences: missing session entry, `expectedSessionId` mismatch, session-rebound. #132040's fail-visibility for these is preserved byte-for-byte — persisting would attach the turn to the wrong session, which must stay loud.
- The `persistTranscript` closure in `dispatch-acp.ts` catches again, rethrowing only the fence type; operational failures return to the pre-#132040 `logVerbose` behavior and the turn keeps its true outcome.

One inline comment records the contract at the catch site. No new call paths, no signature changes for callers.

## User Impact

- Before: a transient disk/store hiccup after a completed ACP turn produces a bogus "turn failed" message after the real reply, and the turn is logged as an error.
- After: operational persistence failures stay in the verbose log; users see exactly one outcome per turn. Genuine session-rebound races keep the #132040 error visibility.

## Evidence

Two regression tests in `src/auto-reply/reply/dispatch-acp.test.ts`:

- `keeps a delivered turn completed when transcript persistence fails operationally` — pre-fix (prod files reverted to `origin/main`, tests kept): **1 failed | 126 passed** (outcome reason was `acp_error:acp_turn_failed`); post-fix: **127 passed (127)**.
- `stays fail-visible when persistence hits a session identity fence` — passes before and after, pinning the deliberate #132040 fence behavior against future softening.

Full sibling lane, exact-head terminal proof on `ed1676686e3` (Docker, Node v24.18.0, Debian 12):

```text
$ node scripts/run-vitest.mjs run src/auto-reply/
 Test Files  270 passed | 1 failed | 1 skipped (272)
      Tests  5515 passed | 1 failed | 2 skipped (5518)
```

The single failure is environment-only: `agent-runner-session-reset.test.ts` shells out to `git init` and the proof box has no `git` binary (`spawnSync git ENOENT`) — unrelated to this change (the test touches session-reset baselines, not transcript persistence).

Known proof gap: `tsgo -p tsconfig.json` cannot complete in the 15 GB proof box (OOM-killed at ~11.5 GB RSS); full typecheck is left to CI. The typed error is a single `class ... extends Error {}` consumed via `instanceof`.

Production diff: +44/-15 — the restored catch is the pre-#132040 shape; the growth is the typed fence error (9-line static module) plus its three throw sites, which is what lets the deliberate fence stay fail-visible instead of being swallowed with the operational noise. Test diff: two regression tests.
