### PR TITLE
fix(cron): persist failure-alert delivery outcome instead of a permanent unknown

### DIFF
--- a/src/cron/service/failure-alerts.persistence.test.ts
+++ b/src/cron/service/failure-alerts.persistence.test.ts
@@ -24,6 +24,8 @@ type SendCronFailureAlert = NonNullable<
   Parameters<typeof createCronServiceState>[0]["sendCronFailureAlert"]
 >;
 
+type FailureAlertTransportParams = Parameters<SendCronFailureAlert>[0];
+
 function createAlertJob(params: { id: string; dueAt: number; includeSkipped?: boolean }): CronJob {
   const job = createDueIsolatedJob({
     id: params.id,
@@ -480,5 +482,74 @@ describe("cron failure alert persistence", () => {
         lastFailureNotificationDeliveryStatus: "not-requested",
       },
     });
+  });
+
+  it.each<{
+    name: string;
+    attempt: (alert: FailureAlertTransportParams) => Promise<void>;
+    expected: { delivered: boolean; deliveredField?: boolean; status: string; errorKey?: string };
+  }>([
+    {
+      name: "records a delivered alert after the send acknowledges the recipient",
+      attempt: async (alert) => alert.onDeliveryAttempt?.(true),
+      expected: { delivered: true, deliveredField: true, status: "delivered" },
+    },
+    {
+      name: "records an attempted-but-unconfirmed alert when delivery is uncertain",
+      attempt: async (alert) => alert.onDeliveryAttempt?.(false),
+      expected: { delivered: false, deliveredField: false, status: "not-delivered" },
+    },
+    {
+      name: "records a failed alert when the send rejects",
+      attempt: async () => {
+        throw new Error("target channel unreachable");
+      },
+      expected: {
+        delivered: false,
+        deliveredField: false,
+        status: "not-delivered",
+        errorKey: "target channel unreachable",
+      },
+    },
+  ])("persists the $name outcome onto the job", async ({ attempt, expected }) => {
+    const store = fixtures.makeStorePath();
+    const dueAt = Date.parse("2026-08-01T15:02:00.000Z");
+    const job = createAlertJob({ id: "failure-alert-outcome-persisted", dueAt });
+    await saveCronStore(store.storePath, { version: 1, jobs: [job] });
+
+    const sendCronFailureAlert = vi.fn<SendCronFailureAlert>(
+      async (alert: FailureAlertTransportParams) => {
+        await attempt(alert);
+      },
+    );
+    const state = createAlertState({
+      storePath: store.storePath,
+      nowMs: () => dueAt + 10,
+      sendCronFailureAlert,
+    });
+
+    await finalizeAlertOutcome({
+      state,
+      job,
+      status: "error",
+      error: "provider unavailable",
+      startedAt: dueAt,
+      endedAt: dueAt + 10,
+    });
+    expect(sendCronFailureAlert).toHaveBeenCalledOnce();
+
+    await vi.waitFor(async () => {
+      const storedState = (await loadCronStore(store.storePath)).jobs[0]?.state;
+      if (expected.deliveredField !== undefined) {
+        expect(storedState?.lastFailureNotificationDelivered).toBe(expected.deliveredField);
+      }
+    });
+    const persisted = (await loadCronStore(store.storePath)).jobs[0]?.state;
+    expect(persisted?.lastFailureNotificationDeliveryStatus).toBe(expected.status);
+    if (expected.errorKey) {
+      expect(persisted?.lastFailureNotificationDeliveryError).toContain(expected.errorKey);
+    } else {
+      expect(persisted?.lastFailureNotificationDeliveryError).toBeUndefined();
+    }
   });
 });

--- a/src/cron/service/failure-alerts.ts
+++ b/src/cron/service/failure-alerts.ts
@@ -19,7 +19,9 @@ import type {
   CronJob,
   CronMessageChannel,
 } from "../types.js";
+import { locked } from "./locked.js";
 import type { CronServiceState, DeferredCronNotifications } from "./state.js";
+import { persistOrRestore, snapshotStoreForRollback } from "./store.js";
 import { enqueueCronNotification } from "./wake.js";
 
 const DEFAULT_FAILURE_ALERT_AFTER = 2;
@@ -192,6 +194,36 @@ export function resolveFailureAlert(
   };
 }
 
+/** Persists the last failure-alert delivery outcome onto the live cron job. */
+function recordFailureAlertDeliveryOutcome(
+  state: CronServiceState,
+  jobId: string,
+  outcome: CronFailureNotificationDelivery,
+): void {
+  // Serialize with other cron operations for this store partition. The send is
+  // detached and outlives run finalization, so the persist is best-effort: a
+  // failed durable write must not fan out a second alert.
+  void locked(state, async () => {
+    const liveJob = state.store?.jobs.find((candidate) => candidate.id === jobId);
+    if (!liveJob) {
+      // Job was removed/replaced before the detached send settled; nothing to persist.
+      return;
+    }
+    // Snapshot under the lock so a failed durable write restores the store to
+    // exactly the durable-pre-write state, never a newer concurrent mutation.
+    const snapshot = snapshotStoreForRollback(state);
+    liveJob.state.lastFailureNotificationDelivered = outcome.delivered;
+    liveJob.state.lastFailureNotificationDeliveryStatus = outcome.status;
+    liveJob.state.lastFailureNotificationDeliveryError = outcome.error;
+    await persistOrRestore(state, snapshot);
+  }).catch((err: unknown) => {
+    state.deps.log.warn(
+      { jobId, err: String(err) },
+      "cron: failed to persist failure-alert delivery outcome",
+    );
+  });
+}
+
 function transportFailureAlert(
   state: CronServiceState,
   params: {
@@ -202,12 +234,19 @@ function transportFailureAlert(
   },
 ): void {
   let pendingFallback = true;
-  const fallback = (reachedRecipient = false) => {
-    if (pendingFallback && !reachedRecipient) {
+  let reachedRecipient: boolean | undefined;
+  const fallback = (reached = false) => {
+    if (pendingFallback && !reached) {
       enqueueCronNotification(state, params.job, params.payload.text ?? "", "failure-alert");
     }
     pendingFallback = false;
   };
+  const recordOutcome = (delivered: boolean, error?: string) =>
+    recordFailureAlertDeliveryOutcome(state, params.job.id, {
+      delivered,
+      status: delivered ? "delivered" : "not-delivered",
+      ...(error ? { error } : {}),
+    });
   if (!state.deps.sendCronFailureAlert) {
     fallback();
     return;
@@ -223,7 +262,18 @@ function transportFailureAlert(
       accountId: params.route.accountId,
       threadId: params.route.threadId,
       ...(params.route.alternateRoute ? { inheritSessionThread: false as const } : {}),
-      onDeliveryAttempt: fallback,
+      onDeliveryAttempt: (reached) => {
+        reachedRecipient = reached;
+        fallback(reached);
+      },
+    })
+    .then(() => {
+      // A concrete outcome is only persisted once the delivery path signals an
+      // attempt. If the send resolved without one (no reach signal), the prior
+      // "unknown" state is the truthful record and must not be downgraded.
+      if (reachedRecipient !== undefined) {
+        recordOutcome(reachedRecipient);
+      }
     })
     .catch((err: unknown) => {
       state.deps.log.warn(
@@ -231,6 +281,7 @@ function transportFailureAlert(
         "cron: failure alert delivery failed",
       );
       fallback();
+      recordOutcome(false, String(err));
     });
 }
 


### PR DESCRIPTION
Closes #131847

## What Problem This Solves

Resolves a problem where cron `failureAlert` delivery is fire-and-forget: the job's persisted `lastFailureNotificationDeliveryStatus` is set to `unknown` before the async send starts but is never updated afterward. Operators who rely on `failureAlert` for post-hoc audit get zero forensic value — after a real send success or failure, `openclaw cron get <id>` and `openclaw cron runs --id <id>` both show a permanent `status: unknown`, with no `delivered` flag and no error, so it is impossible to determine whether an alert actually reached the target channel.

## Why This Change Was Made

The failure-alert send is detached (it outlives run finalization), and `transportFailureAlert` never wrote the delivery outcome back onto the persisted job. This change records the real outcome once the send settles:

- when the delivery path signals the recipient was reached (`onDeliveryAttempt(true)`) — persist `{ delivered: true, status: "delivered" }`;
- when delivery is uncertain (`onDeliveryAttempt(false)`) — persist `{ delivered: false, status: "not-delivered" }`;
- when the send rejects — persist `{ delivered: false, status: "not-delivered", error }`.

The write-back updates the live store job under the cron store lock and persists it; if the job was removed before the detached send settled, the write is safely skipped, and a failed durable write logs a warning instead of fanning out a second alert. The prior `unknown` state is left intact when no delivery signal ever arrives (no fabricated outcome).

**Risk:** this touches the cron job-state persistence path. Failure is contained to a logged warning; the change never blocks run finalization and never re-fires an alert, so a bad write cannot cause data loss or duplicate delivery.

## User Impact

Operators using cron `failureAlert` can now audit alert delivery after the fact. `openclaw cron get <id>` and `openclaw cron runs --id <id>` reflect the true outcome (`delivered` / `not-delivered` with the send error) instead of a permanent `unknown`, so a silent alerting outage becomes visible when inspecting job/run state.

## Evidence

Focused regression tests (green locally) drive the three outcome paths against the durable cron store:

```
Test Files  1 passed (1)
     Tests  44 passed (44)   # includes 3 new write-back cases
```

New parameterized cases in `src/cron/service/failure-alerts.persistence.test.ts` each finalize a failed job, let the mock `sendCronFailureAlert` signal/reject, and assert the persisted job state:

- recipient reached → `lastFailureNotificationDelivered: true`, `lastFailureNotificationDeliveryStatus: "delivered"`
- delivery uncertain (`onDeliveryAttempt(false)`) → `delivered: false`, `status: "not-delivered"`
- send rejects → `delivered: false`, `status: "not-delivered"`, `lastFailureNotificationDeliveryError` populated

Existing cron failure-alert suites remain green (`service.failure-alert.test.ts`, `service.persists-delivered-status.test.ts`, `run-recovery.test.ts`, `ops.test.ts`, `failure-alerts.account-routing`, `failure-alert-notifications`, `failure-alert-silent-reply`).

Typecheck (`tsgo:core`), `oxlint`, and `oxfmt` are clean.

Live channel round-trips were not run in this environment (no channel credentials); the delivery-outcome mapping is covered by the transport-signal contract exercised in the focused tests.

AI-assisted: contributed via an automated coding agent; proof commands run locally by the agent.
