### PR TITLE
fix(windows): preserve UTC process identities outside UTC

### DIFF
--- a/src/infra/windows-port-pids.test.ts
+++ b/src/infra/windows-port-pids.test.ts
@@ -24,6 +24,23 @@ describe("readWindowsProcessStartTimeSync", () => {
     expect(spawnSyncMock.mock.calls[0]?.[0]).toBe(getWindowsPowerShellExePath());
   });
 
+  it("treats timezone-less PowerShell ISO creation time as UTC", () => {
+    const originalTimeZone = process.env.TZ;
+    process.env.TZ = "America/Los_Angeles";
+    try {
+      spawnSyncMock.mockReturnValueOnce({
+        status: 0,
+        stdout: "2026-07-06T12:34:56.1234567",
+      } as never);
+
+      expect(readWindowsProcessStartTimeSync(456, 1000)).toBe(
+        Date.parse("2026-07-06T12:34:56.123Z"),
+      );
+    } finally {
+      process.env.TZ = originalTimeZone;
+    }
+  });
+
   it("falls back to WMIC DMTF creation time output", () => {
     spawnSyncMock.mockReturnValueOnce({ status: 1, stdout: "" } as never).mockReturnValueOnce({
       status: 0,

--- a/src/infra/windows-port-pids.ts
+++ b/src/infra/windows-port-pids.ts
@@ -114,7 +114,10 @@ function parseWindowsProcessStartTime(raw: Buffer | string): number | null {
       .trim() ??
     lines.find((line) => normalizeLowercaseStringOrEmpty(line) !== "creationdate") ??
     "";
-  const parsedIso = Date.parse(value);
+  const isoValue = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?$/.test(value)
+    ? `${value}Z`
+    : value;
+  const parsedIso = Date.parse(isoValue);
   if (Number.isFinite(parsedIso)) {
     return parsedIso;
   }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Windows operators run OpenClaw outside UTC and process-identity checks can read a UTC PowerShell creation timestamp as local time. The resulting offset can make a live lock owner look different or prevent stale-lock recovery.

## Why This Change Was Made

The PowerShell probe emits a timezone-less ISO timestamp after converting `CreationDate` to UTC. The parser now recognizes that exact ISO shape and applies the UTC designator before parsing; explicitly zoned ISO input and the WMIC DMTF fallback retain their existing paths.

## User Impact

Windows lock ownership, durable fences, and stale-lock checks use the correct process creation time on non-UTC hosts, avoiding false PID-reuse decisions.

## Evidence

- Added a deterministic regression under `TZ=America/Los_Angeles`: pre-fix it failed by 25,200,000 ms (seven hours); after the fix it returns the explicit-UTC epoch.
- `node scripts/run-vitest.mjs src/infra/windows-port-pids.test.ts` — 4 passed.
- `node scripts/run-tsgo.mjs -p tsconfig.core.json` — exit 0.
- `node scripts/run-oxlint.mjs src/infra/windows-port-pids.ts src/infra/windows-port-pids.test.ts` — 0 warnings, 0 errors.
- `oxfmt --check` and `git diff --check` — clean.

AI-assisted; I reviewed the change and validation output.