### PR TITLE
fix(maintainers): wait for calculated PR mergeability

### DIFF
--- a/scripts/pr-lib/merge-outcome.sh
+++ b/scripts/pr-lib/merge-outcome.sh
@@ -115,10 +115,28 @@ merge_outcome_read_remote() {
 }
 
 merge_outcome_observe() {
-  local pr="$1" oid
+  local pr="$1" oid attempt reread
   MERGE_OBSERVATION=$(merge_outcome_read_remote "$pr") || {
     merge_outcome_stop "authoritative PR/main metadata unavailable or invalid"; return 1;
   }
+  # GitHub calculates open-PR mergeability asynchronously. Match the metadata
+  # reader's three-attempt budget; only unresolved calculation fields may settle.
+  for attempt in 1 2 3; do
+    if printf '%s\n' "$MERGE_OBSERVATION" | jq -e '
+      .pr.state != "OPEN" or (.pr.mergeable != "UNKNOWN" and .pr.mergeStateStatus != "UNKNOWN")
+    ' >/dev/null; then break; fi
+    [ "$attempt" -lt 3 ] || { merge_outcome_stop "mergeability remained unknown after 3 observations"; return 1; }
+    sleep "$attempt"
+    reread=$(merge_outcome_read_remote "$pr") || return 1
+    if ! printf '%s\n' "$reread" | jq -e --argjson previous "$MERGE_OBSERVATION" '
+      del(.pr.mergeable,.pr.mergeStateStatus) == ($previous | del(.pr.mergeable,.pr.mergeStateStatus)) and
+      ($previous.pr.mergeable == "UNKNOWN" or .pr.mergeable == $previous.pr.mergeable) and
+      ($previous.pr.mergeStateStatus == "UNKNOWN" or .pr.mergeStateStatus == $previous.pr.mergeStateStatus)
+    ' >/dev/null; then
+      merge_outcome_stop "PR or main changed while mergeability was settling"; return 1
+    fi
+    MERGE_OBSERVATION="$reread"
+  done
   # Fetch immutable objects only. Do not replace a pinned observation with the
   # moving origin/main tracking ref or FETCH_HEAD.
   oid=$(printf '%s\n' "$MERGE_OBSERVATION" | jq -r .main)

--- a/test/scripts/pr-merge-outcome.test.ts
+++ b/test/scripts/pr-merge-outcome.test.ts
@@ -89,6 +89,7 @@ function fixture(sourceMessage?: string, sourceVersions: Array<[string, string?]
     mode: "success",
     landing: "requested",
     reads: 0,
+    observations: [] as Array<{ main?: string; pr?: Record<string, unknown> }>,
     calls: [] as string[][],
     mutations: 0,
     mergeBody: null as string | null,
@@ -177,7 +178,7 @@ else if(args[0]==="pr"&&args[1]==="view") {
   if(s.unavailable) fail("metadata unavailable");
   if(s.invalid) {out({data:{repository:{}}});process.exit(0);}
   if(args.some(x=>x.includes("viewerMergeBodyText"))) {out({data:{repository:{pullRequest:{...s.pr,viewerMergeBodyText:"Fixture body"}}}});}
-  else {const pr={...s.pr};if(s.drift&&s.reads%2===0) pr.baseRefName="changed";out({data:{repository:{...s.repo,ref:{target:{oid:main()}},pullRequest:pr}}});}
+  else {const observation=s.observations.shift()??{};const pr={...s.pr,...observation.pr};if(s.drift&&s.reads%2===0) pr.baseRefName="changed";out({data:{repository:{...s.repo,ref:{target:{oid:observation.main??main()}},pullRequest:pr}}});}
 } else if(args.some(x=>x.includes("/comments"))) {
   if(args.includes("POST")) {
     s.posts++;
@@ -325,6 +326,85 @@ merge_run 123 "\${1:-false}"
 }
 
 describePosix("native merge outcome with real Git and supervised lock recovery", () => {
+  it.each([false, true])("settles unknown mergeability before dispatch with auto=%s", (auto) => {
+    const f = fixture();
+    f.save({
+      ...f.state(),
+      pr: { ...f.state().pr, mergeStateStatus: "CLEAN" },
+      observations: Array.from({ length: auto ? 2 : 1 }, () => ({
+        pr: { mergeable: "UNKNOWN", mergeStateStatus: "UNKNOWN" },
+      })),
+    });
+    const run = f.run(auto);
+    expect(run.status, run.output).toBe(0);
+    expect(f.record()).toMatchObject({ phase: "complete", route: "immediate", head: f.head });
+    expect(f.state().mutations).toBe(1);
+    expect(f.state().posts).toBe(1);
+  });
+  it.each(["mergeable", "mergeStateStatus"])(
+    "refuses unresolved mergeability field %s within the read budget",
+    (field) => {
+      const f = fixture();
+      f.save({
+        ...f.state(),
+        observations: Array.from({ length: 3 }, () => ({ pr: { [field]: "UNKNOWN" } })),
+      });
+      const run = f.run();
+      expect(run.status, run.output).toBe(1);
+      expect(run.output).toContain("mergeability remained unknown");
+      expect(f.state().reads).toBe(3);
+      expect(f.state().mutations).toBe(0);
+      expect(f.state().posts).toBe(0);
+      expect(() => f.record()).toThrow();
+    },
+  );
+  it.each([
+    "head",
+    "main",
+    "state",
+    "base",
+    "draft",
+    "auto",
+    "queue",
+    "queue-policy",
+    "settled-mergeable",
+    "settled-status",
+  ])("refuses %s drift while mergeability settles", (change) => {
+    const f = fixture();
+    const pr: Record<string, unknown> = {};
+    if (change === "head") pr.headRefOid = f.base;
+    if (change === "state") pr.state = "CLOSED";
+    if (change === "base") pr.baseRefName = "release";
+    if (change === "draft") pr.isDraft = true;
+    if (change === "auto") pr.autoMergeRequest = { mergeMethod: "SQUASH" };
+    if (change === "queue") pr.isInMergeQueue = true;
+    if (change === "queue-policy") pr.isMergeQueueEnabled = true;
+    if (change === "settled-mergeable") pr.mergeable = "CONFLICTING";
+    const pending = { mergeable: "UNKNOWN", mergeStateStatus: "UNKNOWN" };
+    if (change === "settled-mergeable") pending.mergeable = "MERGEABLE";
+    if (change === "settled-status") pending.mergeStateStatus = "CLEAN";
+    f.save({
+      ...f.state(),
+      observations: [{ pr: pending }, { pr, ...(change === "main" ? { main: f.head } : {}) }],
+    });
+    const run = f.run();
+    expect(run.status, run.output).toBe(1);
+    expect(f.state().reads).toBe(2);
+    expect(f.state().mutations).toBe(0);
+    expect(f.state().posts).toBe(0);
+    expect(() => f.record()).toThrow();
+  });
+  it("reconciles a merged receipt without waiting for terminal mergeability", () => {
+    const f = fixture();
+    const unknown = { pr: { mergeable: "UNKNOWN", mergeStateStatus: "UNKNOWN" } };
+    f.save({ ...f.state(), observations: [{}, {}, unknown, unknown] });
+    const run = f.run();
+    expect(run.status, run.output).toBe(0);
+    expect(f.record().phase).toBe("complete");
+    expect(f.state().reads).toBe(4);
+    expect(f.state().mutations).toBe(1);
+    expect(f.state().posts).toBe(1);
+  });
   it.each([false, true])("confirms a real multi-commit rebase with queue=%s", (queue) => {
     const f = fixture(undefined, [["prefix\n"], ["after\n"]]);
     const main = f.advance("before\n");
@@ -637,6 +717,7 @@ describePosix("native merge outcome with real Git and supervised lock recovery",
     "invalid",
     "unavailable",
     "conflict",
+    "calculated-conflict",
     "drift",
     "no-op",
     "ancestral-revert",
@@ -651,6 +732,11 @@ describePosix("native merge outcome with real Git and supervised lock recovery",
     if (change === "unavailable") next.unavailable = true;
     if (change === "drift") next.drift = true;
     if (change === "conflict") f.advance("conflict\n");
+    if (change === "calculated-conflict")
+      next.observations = [
+        { pr: { mergeable: "UNKNOWN", mergeStateStatus: "UNKNOWN" } },
+        { pr: { mergeable: "CONFLICTING", mergeStateStatus: "DIRTY" } },
+      ];
     if (change === "no-op") f.advance();
     if (change === "ancestral-revert") {
       f.git(["push", "-q", "origin", f.head + ":refs/heads/main"]);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where maintainers landing an otherwise ready PR would be stopped by the native workflow when GitHub finished calculating mergeability between two reads. The refusal happened before any merge request, but required another preflight and process-lock recovery.

Related: #132480, #132430.

## Why This Change Was Made

The observation owner now settles an open PR's unknown mergeability fields before capturing the stable snapshot. It uses the existing metadata-read budget: three observations, with one- and two-second waits. Every other field must remain identical throughout, and a calculation field that is already definitive cannot change. Exhausted or invalid reads fail closed.

The final complete-snapshot comparison, exact-head admission, main identity, conflict checks, queue/auto state, retained intent, and one-dispatch recovery remain unchanged. Closed or merged PRs do not wait for a calculation that no longer matters. This is metadata polling, never a merge-request retry. GitHub documents `UNKNOWN` as a calculation still in progress: [GraphQL mergeability contract](https://docs.github.com/en/graphql/reference/pulls#mergeablestate).

The original whole-response comparison came from #132173 (`cb5d89bfaf4`), authored by Peter Steinberger with GitHub as commit committer; this repair preserves that change's duplicate-dispatch protection. Production runtime: no changes. Tooling: +19/-1 (net +18), justified by bounded asynchronous observation and drift validation. Tests: +87/-1 (net +86). No configuration, environment variable, dependency, or approval bypass is added.

## User Impact

Ready PRs can complete native landing when GitHub's calculation settles without a real authority change. Genuine main/head/state drift, conflicts, uncertain prior dispatch, or calculations that remain unknown still stop the operation.

## Evidence

- Two immediate live reads for #132480 returned the same main (`c02dbf8bfe77`) and prepared head (`946172eb2801`), with every identity, lifecycle, and queue field unchanged. Only `mergeable` changed from `UNKNOWN` to `MERGEABLE`, and `mergeStateStatus` from `UNKNOWN` to `CLEAN`. The old owner rejects precisely that response pair. Historical failure logs did not retain their response pairs, so this is a contemporaneous live reproduction, not a claim about every earlier refusal.
- Before the production edit, the real-Git native-outcome fixture failed four new cases: both normal/auto settling cases and both unresolved-field bounds. Nine drift/terminal controls passed. The initial repaired focused run passed all 13 cases; final coverage also exercises the last permitted read, drift in an already-settled calculation field, and calculated conflicts.
- The patched observation owner and unchanged stable reread also succeeded against live #132475 at head `04ffb4e8388` and main `1a0e72b4f1ee`. This exercised read-side behavior only; no merge request or outcome record was created.
- All 114 tests passed across `test/scripts/pr-merge-outcome.test.ts`, `test/scripts/pr-merge.test.ts`, and `test/scripts/pr-worktree-evidence.test.ts`, using `node scripts/run-vitest.mjs`. This includes ambiguous responses, crash/lock recovery, queue/auto routing, attribution, retained evidence, and exactly one merge/comment dispatch.
- The complete changed-file gate passed, including root-test types, script lint, and ownership checks. Bash syntax and diff whitespace checks passed.
- Independent Codex review found no blocking issue. Hosted exact-head CI will run on this PR; no full native landing using the new owner is claimed before it lands.
