### PR TITLE
fix(release): validate extended-stable maintenance patches

### DIFF
--- a/scripts/full-release-validation-at-sha.mts
+++ b/scripts/full-release-validation-at-sha.mts
@@ -19,6 +19,7 @@ import {
   validateReleaseStateArtifact,
 } from "./full-release-validation-policy.mjs";
 import { execGhRead } from "./lib/plain-gh.mjs";
+import { classifyReleaseTrain, parseReleaseVersion } from "./lib/release-version.mjs";
 
 const WORKFLOW = "full-release-validation.yml";
 const TRUSTED_WORKFLOW_PATH = `.github/workflows/${WORKFLOW}`;
@@ -361,9 +362,17 @@ export function verifyTargetRef(
       );
     }
   } else if (extendedStableMatch) {
-    if (targetVersion !== extendedStableMatch[1]) {
+    const branchVersion = parseReleaseVersion(extendedStableMatch[1]!);
+    const candidateVersion = parseReleaseVersion(targetVersion);
+    if (
+      branchVersion === null ||
+      candidateVersion === null ||
+      classifyReleaseTrain(candidateVersion) !== "extended-stable" ||
+      candidateVersion.year !== branchVersion.year ||
+      candidateVersion.month !== branchVersion.month
+    ) {
       throw new Error(
-        `Target package version ${targetVersion} does not match extended-stable branch ${targetRef}`,
+        `Target package version ${targetVersion} does not belong to extended-stable branch ${targetRef}; expected a final ${branchVersion?.year}.${branchVersion?.month}.PATCH version with PATCH >= 33`,
       );
     }
   } else if (tagMatch && targetVersion !== tagMatch[1]) {

--- a/test/scripts/full-release-validation-at-sha.test.ts
+++ b/test/scripts/full-release-validation-at-sha.test.ts
@@ -438,24 +438,28 @@ describe("full-release-validation-at-sha", () => {
         () => true,
       ),
     ).toThrow("does not belong to release branch");
-    expect(
-      verifyTargetRef(
-        "extended-stable/2026.6.33",
-        candidateSha,
-        "2026.6.33",
-        () => branchTipSha,
-        () => true,
-      ),
-    ).toBe("extended-stable/2026.6.33");
-    expect(() =>
-      verifyTargetRef(
-        "extended-stable/2026.6.33",
-        candidateSha,
-        "2026.6.33-beta.1",
-        () => branchTipSha,
-        () => true,
-      ),
-    ).toThrow("does not match extended-stable branch");
+    for (const version of ["2026.6.33", "2026.6.34", "2026.6.35"]) {
+      expect(
+        verifyTargetRef(
+          "extended-stable/2026.6.33",
+          candidateSha,
+          version,
+          () => branchTipSha,
+          () => true,
+        ),
+      ).toBe("extended-stable/2026.6.33");
+    }
+    for (const version of ["2026.6.32", "2026.7.35", "2026.6.35-beta.1", "2026.6.35-1"]) {
+      expect(() =>
+        verifyTargetRef(
+          "extended-stable/2026.6.33",
+          candidateSha,
+          version,
+          () => branchTipSha,
+          () => true,
+        ),
+      ).toThrow("does not belong to extended-stable branch");
+    }
     expect(
       verifyTargetRef(
         "v2026.7.1-beta.5",


### PR DESCRIPTION
## What Problem This Solves

Resolves a release-validation recovery failure where the immutable full-validation helper rejected a valid extended-stable maintenance candidate such as `2026.6.35` on the canonical `extended-stable/2026.6.33` branch.

## Why This Change Was Made

The helper now follows the same extended-stable contract already enforced by Full Release Validation: retain the canonical `.33` branch shape and ancestry check, while accepting only final versions on the same `YYYY.M` line with patch `>=33`. It continues to reject a different month, prereleases, and patches below 33.

## User Impact

Release operators can use the SHA-pinned temporary workflow ref to avoid a moving-`main` dispatch race without weakening release identity validation.

## Evidence

- Reproduction: [failed full validation](https://github.com/openclaw/openclaw/actions/runs/33238921150) could not dispatch delayed candidate child workflows after `main` advanced.
- `node scripts/run-vitest.mjs test/scripts/full-release-validation-at-sha.test.ts` — 37 passed.
- Actual candidate dry run against `782a8f7` / `extended-stable/2026.6.33` / tooling `ec23435` completes validation and prints only the intended temporary refs; no remote refs were pushed.
- Formatter and `git diff --check` passed.
- The local changed gate cannot start because the host pnpm 12 native launcher is incomplete; exact-head CI remains required.
