### PR TITLE
fix(google): preserve Gemini native compaction ownership

### DIFF
--- a/docs/gateway/cli-backends.md
+++ b/docs/gateway/cli-backends.md
@@ -302,6 +302,8 @@ Some CLI backends run an agent that compacts its own transcript, so OpenClaw mus
 
 `claude-cli` has no harness endpoint (Claude Code compacts internally), so it declares `ownsNativeCompaction: true`. Automatic OpenClaw compaction defers to Claude Code, while an explicit `/compact` resumes the bound Claude Code session and sends its native `/compact` command. OpenClaw passes the run's effective context budget through Claude Code's documented [`CLAUDE_CODE_AUTO_COMPACT_WINDOW`](https://code.claude.com/docs/en/env-vars), keeping native auto-compaction aligned with configured Anthropic `contextTokens` limits. Native-harness sessions such as Codex keep routing to their harness compaction endpoint instead.
 
+`google-gemini-cli` also owns automatic compaction and persists its compressed session for resume. OpenClaw defers to Gemini CLI rather than running a second summarizer. Explicit `/compact` is unsupported for this backend because it does not declare a manual compaction capability.
+
 ```typescript
 api.registerCliBackend({
   id: "my-cli",

--- a/extensions/google/cli-backend.ts
+++ b/extensions/google/cli-backend.ts
@@ -118,6 +118,9 @@ export function buildGoogleGeminiCliBackend(): CliBackendPlugin {
     },
     bundleMcp: true,
     bundleMcpMode: "gemini-system-settings",
+    // Gemini compresses and persists its native history before requests; a second
+    // compactor would require API auth outside the CLI and discard its resume binding.
+    ownsNativeCompaction: true,
     nativeToolMode: "selectable",
     toolAvailabilityEnforcement: "prepare-execution",
     authEpochMode: "profile-only",

--- a/src/agents/command/cli-compaction.test.ts
+++ b/src/agents/command/cli-compaction.test.ts
@@ -8,6 +8,7 @@ import { replaceSessionEntry } from "../../config/sessions/session-accessor.js";
 import { SESSION_TOTAL_TOKENS_VERSION, type SessionEntry } from "../../config/sessions/types.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { ContextEngine } from "../../context-engine/types.js";
+import { resolveCliBackendConfig } from "../cli-backends.js";
 import { createModelGenerationFixture } from "../embedded-agent-runner/model.generation-scope.test-support.js";
 import { SessionManager } from "../sessions/session-manager.js";
 import {
@@ -1183,29 +1184,34 @@ describe("runCliTurnCompactionLifecycle", () => {
     );
   });
 
-  it("skips compaction when backend declares ownsNativeCompaction and has no harness endpoint", async () => {
-    const compactAgentHarnessSession = vi.fn();
-    const scenario = await prepareCompactionScenario({
-      suffix: "claude-owns-compaction",
-      tmpDir,
-      deps: {
-        maybeCompactAgentHarnessSession: compactAgentHarnessSession as never,
-        resolveCliBackendConfig: () => ({
-          id: "claude-cli",
-          config: { command: "claude" },
-          bundleMcp: true,
-          ownsNativeCompaction: true,
-        }),
-      },
-    });
-    const { compactCalls, recordCliCompactionInStore, sessionEntry } = scenario;
-    const updatedEntry = await scenario.run();
+  it.each(["claude-cli", "google-gemini-cli"])(
+    "preserves %s native history and resume binding under compaction pressure",
+    async (provider) => {
+      const backend = resolveCliBackendConfig(provider);
+      expect(backend).not.toBeNull();
+      const compactAgentHarnessSession = vi.fn();
+      const scenario = await prepareCompactionScenario({
+        suffix: `${provider}-owns-compaction`,
+        tmpDir,
+        provider,
+        sessionEntry: {
+          cliSessionBindings: { [provider]: { sessionId: "native-session" } },
+        },
+        deps: {
+          maybeCompactAgentHarnessSession: compactAgentHarnessSession as never,
+          resolveCliBackendConfig: () => backend,
+        },
+      });
+      const { compactCalls, recordCliCompactionInStore, sessionEntry } = scenario;
+      const updatedEntry = await scenario.run();
 
-    expect(compactAgentHarnessSession).not.toHaveBeenCalled();
-    expect(compactCalls).toHaveLength(0);
-    expect(recordCliCompactionInStore).not.toHaveBeenCalled();
-    expect(updatedEntry).toBe(sessionEntry);
-  });
+      expect(compactAgentHarnessSession).not.toHaveBeenCalled();
+      expect(compactCalls).toHaveLength(0);
+      expect(recordCliCompactionInStore).not.toHaveBeenCalled();
+      expect(updatedEntry).toBe(sessionEntry);
+      expect(updatedEntry?.cliSessionBindings?.[provider]?.sessionId).toBe("native-session");
+    },
+  );
 
   it("does not skip compaction when backend does not declare ownsNativeCompaction", async () => {
     const scenario = await prepareCompactionScenario({


### PR DESCRIPTION
## Summary
Gemini CLI sessions could fail on a later turn when OpenClaw's generic compactor tried to summarize their history using separate API credentials. That path also replaces the native resume binding, even though Gemini CLI already owns automatic compression and persists the compressed conversation.

Declare native compaction ownership in the Google CLI backend using the existing backend capability. Core now leaves automatic compaction to Gemini, just as it does for Claude CLI. No provider-specific core branch, fallback, new configuration option, or storage change is needed. Document that explicit OpenClaw `/compact` remains unsupported for this backend until it declares a manual capability.

Release note: Gemini CLI sessions preserve native compaction and resume instead of invoking a second summarizer requiring separate API authentication.

## Validation
- Real Gemini Docker resume/MCP lane passed in286.13s (292.60s total), no skips: https://github.com/openclaw/openclaw/actions/runs/33243495176 . First/resume turns, exact recall, actual admitted-agent MCP cron creation, stored job identity and cleanup all passed. The live fixture required separate staging/producer corrections, tracked independently.
- The compaction-pressure regression failed against the old Google backend. The focused suite passes32tests, including actual Claude and Google backend metadata, generic compaction, native-harness routing, successor validation, and preserved resume state.
- Direct upstream v0.57.0 source inspected: [automatic compaction](https://github.com/google-gemini/gemini-cli/blob/v0.57.0/packages/core/src/core/client.ts#L643), [compressed-history continuation](https://github.com/google-gemini/gemini-cli/blob/v0.57.0/packages/core/src/core/client.ts#L1114), [durable resume synchronization](https://github.com/google-gemini/gemini-cli/blob/v0.57.0/packages/core/src/core/geminiChat.ts#L368), and [threshold ownership](https://github.com/google-gemini/gemini-cli/blob/v0.57.0/packages/core/src/context/chatCompressionService.ts#L248).
- Core automatic/manual compaction owners and Claude sibling inspected. Fresh independent Codex autoreview, formatting, and diff checks passed; exact-head CI required before landing.

Production:+3/-0 (one existing capability declaration and two invariant comments). Tests:+29/-23; docs:+2/-0. The declaration is the smallest owner-boundary repair; it introduces no new abstraction or persisted semantics.
