### PR TITLE
fix(tui): preserve large pasted drafts after blocked submit

### DIFF
--- a/src/tui/tui-command-handlers.test.ts
+++ b/src/tui/tui-command-handlers.test.ts
@@ -2083,6 +2083,7 @@ describe("tui command handlers", () => {
         });
         const editor = {
           getText: vi.fn(() => ""),
+          getExpandedText: vi.fn(() => ""),
           setText: vi.fn(),
           addToHistory: vi.fn(),
         };

--- a/src/tui/tui-reset-transition-pty.e2e.test.ts
+++ b/src/tui/tui-reset-transition-pty.e2e.test.ts
@@ -16,25 +16,33 @@ const EXIT_TIMEOUT_MS = 8_000;
 const TEST_TIMEOUT_MS = 25_000;
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
-describe("TUI reset transition PTY", () => {
-  it(
+describe.each([
+  { input: "typed suffix", nativePaste: false },
+  { input: "large paste with default macOS coalescing", nativePaste: true },
+])("TUI reset transition PTY ($input)", ({ nativePaste }) => {
+  it.skipIf(nativePaste && process.platform !== "darwin")(
     "preserves overlapping input while /reset owns the terminal session transition",
     async () => {
       const tempDir = tempDirs.make("openclaw-tui-reset-pty-");
       const scriptPath = await writeTuiPtyFixtureScript(tempDir);
       const logPath = path.join(tempDir, "fixture-log.jsonl");
       const resetReleasePath = path.join(tempDir, "release-reset-session");
+      const newerDraft = nativePaste
+        ? Array.from({ length: 11 }, (_, index) => `line-${index}`).join("\n")
+        : "newer suffix";
+      const preservedDraft = `overlap during reset\n${newerDraft}`;
       const run = startPty(process.execPath, ["--import", "tsx", scriptPath], {
         cwd: process.cwd(),
         env: {
           OPENCLAW_THEME: "dark",
           OPENCLAW_TUI_PTY_LOG_PATH: logPath,
           OPENCLAW_TUI_PTY_RESET_RELEASE_PATH: resetReleasePath,
-          OPENCLAW_TUI_PTY_SUBMIT_BURST_WINDOW_MS: "1000",
+          OPENCLAW_TUI_PTY_SUBMIT_BURST_WINDOW_MS: nativePaste ? undefined : "1000",
           OPENCLAW_TUI_PTY_TYPE_CHUNK_SIZE: "1",
           OPENCLAW_TUI_PTY_TYPE_DELAY_MS: "2",
-          // Synthetic Return must not consult the host macOS modifier state.
-          TERM_PROGRAM: undefined,
+          // Emulate iTerm for Darwin's default coalescing, without Apple Terminal's
+          // host modifier-state lookup for synthetic Return.
+          TERM_PROGRAM: nativePaste ? "iTerm.app" : undefined,
           NO_COLOR: undefined,
         },
         exitTimeoutMs: EXIT_TIMEOUT_MS,
@@ -50,24 +58,36 @@ describe("TUI reset transition PTY", () => {
         await waitForLogEntry(
           (entry) => entry.method === "resetSession" && objectFieldEquals(entry, "reason", "reset"),
         );
-        await run.write("overlap during reset\r");
-        await waitForLogEntry(
-          (entry) =>
-            entry.method === "submitBurstCaptured" &&
-            objectFieldEquals(entry, "value", "overlap during reset"),
-        );
-        await run.write("newer suffix");
-        // Release before the controlled paste coalescer flushes. Admission must use
-        // the transition snapshot captured when Enter arrived, not live state.
+        if (nativePaste) {
+          await run.write(`overlap during reset\r\u001b[200~${newerDraft}\u001b[201~`, {
+            delay: false,
+          });
+          await run.waitForOutput("session change in progress; wait for /reset to finish");
+          expect(
+            (await readFixtureLog(logPath)).filter((entry) => entry.method === "sendChat"),
+          ).toEqual([]);
+        } else {
+          await run.write("overlap during reset\r");
+          await waitForLogEntry(
+            (entry) =>
+              entry.method === "submitBurstCaptured" &&
+              objectFieldEquals(entry, "value", "overlap during reset"),
+          );
+          await run.write(newerDraft);
+          // Release before the controlled paste coalescer flushes. Admission must use
+          // the transition snapshot captured when Enter arrived, not live state.
+        }
         await writeFile(resetReleasePath, "released\n", "utf8");
         await run.waitForOutput("session main (Reset session after)");
-        await run.waitForOutput("overlap during reset\nnewer suffix", 7_000);
+        if (!nativePaste) {
+          await run.waitForOutput(preservedDraft, 7_000);
+        }
 
         await run.write("\r", { delay: false });
         await waitForLogEntry(
           (entry) =>
             entry.method === "sendChat" &&
-            objectFieldEquals(entry, "message", "overlap during reset\nnewer suffix"),
+            (nativePaste || objectFieldEquals(entry, "message", preservedDraft)),
         );
         await run.waitForOutput("PTY_RESPONSE: overlap during reset", 7_000);
 
@@ -76,9 +96,12 @@ describe("TUI reset transition PTY", () => {
         );
         expect(sends).toEqual([
           expect.objectContaining({
-            payload: expect.objectContaining({ message: "overlap during reset\nnewer suffix" }),
+            payload: expect.objectContaining({ message: preservedDraft }),
           }),
         ]);
+        if (nativePaste) {
+          await run.waitForOutput("line-10");
+        }
         console.info(
           "[behavior-evidence] tui-reset-transition",
           JSON.stringify({

--- a/src/tui/tui-submit-test-helpers.ts
+++ b/src/tui/tui-submit-test-helpers.ts
@@ -8,6 +8,7 @@ type MockFn = ReturnType<typeof vi.fn>;
 
 type SubmitHarness = {
   editor: {
+    getExpandedText: MockFn;
     setText: MockFn;
     addToHistory: MockFn;
   };
@@ -25,6 +26,7 @@ export function createSubmitHarness(params?: {
   admitMessage?: (value: string) => TuiChatSubmitAdmission;
 }): SubmitHarness {
   const editor = {
+    getExpandedText: vi.fn(() => ""),
     setText: vi.fn(),
     addToHistory: vi.fn(),
   };

--- a/src/tui/tui-submit.ts
+++ b/src/tui/tui-submit.ts
@@ -33,6 +33,7 @@ function runSubmitAction(
 export function createEditorSubmitHandler(params: {
   editor: {
     getText?: () => string;
+    getExpandedText: () => string;
     setText: (value: string) => void;
     addToHistory: (value: string) => void;
   };
@@ -51,9 +52,9 @@ export function createEditorSubmitHandler(params: {
   };
 
   const restoreBlockedEditor = (value: string) => {
-    // pi-tui clears before onSubmit. Preserve text typed while a buffered submit
-    // waited by replaying the blocked value before the newer editor-owned draft.
-    const newerDraft = params.editor.getText?.() ?? "";
+    // Expand newer pastes before setText clears their backing storage, then
+    // prepend the blocked submit to the newer editor-owned draft.
+    const newerDraft = params.editor.getExpandedText();
     params.editor.setText(newerDraft ? `${value}\n${newerDraft}` : value);
   };
 

--- a/src/tui/tui.submit-handler.test.ts
+++ b/src/tui/tui.submit-handler.test.ts
@@ -285,67 +285,71 @@ describe("createSubmitBurstCoalescer", () => {
     vi.useRealTimers();
   });
 
-  it("preserves a newer real editor draft when a buffered message flushes", () => {
-    vi.useFakeTimers();
-    const tui = { requestRender: vi.fn() } as unknown as TUI;
-    const editor = new CustomEditor(tui, editorTheme);
-    const sendMessage = vi.fn();
-    const submit = createEditorSubmitHandler({
-      editor,
-      handleCommand: vi.fn(),
-      sendMessage,
-      handleBangLine: vi.fn(),
-      onSubmitError: vi.fn(),
-    });
-    editor.onSubmit = createSubmitBurstCoalescer({
-      submit,
-      enabled: true,
-      burstWindowMs: 50,
-    });
-    editor.setText("submitted message");
+  it.each(
+    [
+      { name: "typed text", newerDraft: "new draft", paste: false },
+      {
+        name: "an eleven-line paste",
+        newerDraft: Array.from({ length: 11 }, (_, index) => `line-${index}`).join("\n"),
+        paste: true,
+      },
+      { name: "a 1001-character paste", newerDraft: "x".repeat(1001), paste: true },
+    ].flatMap((input) => [
+      { ...input, initiallyBlocked: false },
+      { ...input, initiallyBlocked: true },
+    ]),
+  )(
+    "preserves $name across buffered submission (blocked=$initiallyBlocked)",
+    ({ newerDraft, paste, initiallyBlocked }) => {
+      vi.useFakeTimers();
+      const tui = { requestRender: vi.fn() } as unknown as TUI;
+      const editor = new CustomEditor(tui, editorTheme);
+      const sendMessage = vi.fn();
+      let blocked = initiallyBlocked;
+      const submit = createEditorSubmitHandler({
+        editor,
+        handleCommand: vi.fn(),
+        sendMessage,
+        handleBangLine: vi.fn(),
+        onSubmitError: vi.fn(),
+        admitMessage: () =>
+          blocked ? { status: "blocked", reason: "pending" } : { status: "allowed" },
+      });
+      const submitBurst = createSubmitBurstCoalescer({ submit, enabled: true });
+      editor.onSubmit = submitBurst;
+      try {
+        editor.setText("submitted message");
+        editor.handleInput("\r");
+        expect(sendMessage).not.toHaveBeenCalled();
 
-    editor.handleInput("\r");
-    for (const character of "new draft") {
-      editor.handleInput(character);
-    }
+        if (paste) {
+          editor.handleInput(`\u001b[200~${newerDraft}\u001b[201~`);
+          expect(editor.getText()).not.toBe(newerDraft);
+        } else {
+          for (const character of newerDraft) {
+            editor.handleInput(character);
+          }
+        }
+        expect(editor.getExpandedText()).toBe(newerDraft);
 
-    vi.advanceTimersByTime(50);
+        vi.advanceTimersByTime(50);
+        const preservedDraft = initiallyBlocked ? `submitted message\n${newerDraft}` : newerDraft;
+        expect(editor.getExpandedText()).toBe(preservedDraft);
+        expect(sendMessage.mock.calls).toEqual(initiallyBlocked ? [] : [["submitted message"]]);
 
-    expect(sendMessage).toHaveBeenCalledExactlyOnceWith("submitted message");
-    expect(editor.getText()).toBe("new draft");
-    vi.useRealTimers();
-  });
-
-  it("preserves text typed after a buffered submit is blocked", () => {
-    vi.useFakeTimers();
-    const tui = { requestRender: vi.fn() } as unknown as TUI;
-    const editor = new CustomEditor(tui, editorTheme);
-    const sendMessage = vi.fn();
-    const submit = createEditorSubmitHandler({
-      editor,
-      handleCommand: vi.fn(),
-      sendMessage,
-      handleBangLine: vi.fn(),
-      onSubmitError: vi.fn(),
-      admitMessage: () => ({ status: "blocked", reason: "pending" }),
-    });
-    editor.onSubmit = createSubmitBurstCoalescer({
-      submit,
-      enabled: true,
-      burstWindowMs: 50,
-    });
-    editor.setText("blocked message");
-
-    editor.handleInput("\r");
-    for (const character of "plus newer text") {
-      editor.handleInput(character);
-    }
-    vi.advanceTimersByTime(50);
-
-    expect(sendMessage).not.toHaveBeenCalled();
-    expect(editor.getText()).toBe("blocked message\nplus newer text");
-    vi.useRealTimers();
-  });
+        blocked = false;
+        editor.handleInput("\r");
+        vi.advanceTimersByTime(50);
+        expect(sendMessage.mock.calls).toEqual(
+          initiallyBlocked ? [[preservedDraft]] : [["submitted message"], [preservedDraft]],
+        );
+        expect(editor.getExpandedText()).toBe("");
+      } finally {
+        submitBurst.dispose();
+        vi.useRealTimers();
+      }
+    },
+  );
 
   it("passes through immediately when disabled", () => {
     const submit = vi.fn();


### PR DESCRIPTION
Related: #132526

<details>
<summary>Additional instructions</summary>

This is a same-repository branch. GitHub's fork-collaboration toggle applies
only to cross-repository pull requests, so it is not applicable here.

</details>

## What Problem This Solves

Fixes an issue where TUI users retrying a blocked buffered submission would send
a large-paste placeholder instead of their newer pasted text. This can happen
while a session reset is in progress: the earlier message is restored alongside
a newer native bracketed paste, but the ordinary retry sends the paste marker.

## Why This Change Was Made

The submit owner was reading the editor's compact display text before replacing
the draft. That replacement clears the backing paste map. It now reads the
editor's existing expanded-text capability before replacing the draft, preserving
the complete content without changing submission admission, timing, queues,
configuration, dependencies, or protocol behavior.

This is the canonical owner-boundary repair, not a paste-marker parser or a new
editor fallback. Production is +4/-3 (net +1): the sole added capability is the
required internal editor method declaration. Tests are +106/-78, with +2/-0
test-support lines for existing mocks. Manual Undo can recover the earlier
snapshot before retry; this is not claimed as immediately irrecoverable loss.
Older stable source already had draft-loss behavior, so no newly introduced
regression or last-known-good version is asserted.

## User Impact

Blocked submission restores the short message and complete newer draft. Retrying
sends their combined text once, including pastes that the editor compacted into
an eleven-line or 1,001-character placeholder.

Release-note context: preserve large pasted drafts when retrying a blocked TUI
submission. No release or distribution publication is part of this PR.

## Evidence

The existing real-PTY reset fixture exercises real `runTui()` and the native
editor with a fake backend. The new Darwin row omits the coalescing override,
emulates iTerm's environment, and takes the normal 50 ms fallback. The existing
1,000 ms plain-typed control remains unchanged. Each phase ran once, with the
same test sequence and timeouts:

```text
Before: typed control PASS; default-Darwin large-paste retry FAIL
Received: overlap during reset + [paste #1 +11 lines]
Expected: overlap during reset + line-0 through line-10
After: 2/2 PASS, including the exact sole expanded sendChat payload
```

Both runs reached the blocked notice, zero-early-send check, reset completion,
ordinary Return retry, and response before the final payload assertion. Neither
was an import failure, missed-race timeout, or widened-timeout substitute. The
native child/process groups and pipes were drained and verified absent.

The real-editor/coalescer regression separately produced exactly two intended
baseline failures and four passing controls. All 35 submit-handler cases pass
after the repair, including later retry/exact-once assertions. Four affected
before/during × new/reset command-transition cases also pass; the other 221
command cases were filtered, not reported as executed. The initial six-case
baseline's final outer tool item was not retained; its complete raw result,
normal wrapper outcome, and separately verified process absence remain recorded.
Both paired PTY runs and the later passing runs retain final outer receipts.

These are qualified local observations on Darwin arm64/Node 24.20.0 with pi-tui
0.84.2 and Vitest 4.1.11. Installed Vite 8.2.1 differs from the target 8.2.2;
separately, the installed Vitest runner lacks the target throttle patch. They are
not claimed as CI dependency-parity proof. This uses a real PTY and fake backend,
not the physical iTerm application, Gateway transport, or a live provider.

Independent source and actual before/after review accepted the five-file repair.
The final automatic Codex review completed two passes with no actionable P0–P2
findings. [CI run 33245915942](https://github.com/openclaw/openclaw/actions/runs/33245915942)
completed successfully for published head
`4d0df5ba609aac29c7cfab932335d91ef105fe92`: 167 successful jobs and 18 skipped.
The actual checkout and harness were merge
`6f9e4a95a15de74fe8df6f9700e95c8f502ad601`, whose five changed source files
byte-match the reviewed candidate. This does not claim whole-toolchain parity
with the earlier local observations.

The [named hosted TUI job](https://github.com/openclaw/openclaw/actions/runs/33245915942/job/99083291333)
ran all 35 submit-handler cases, including the six preservation rows, and the
four affected before/during × new/reset controls successfully. Its complete TUI
project passed 47 files / 1,458 tests on Linux / Node 24.19.0; the five-config
group completed successfully. The new Darwin-only PTY row is not claimed as
hosted execution: its real-PTY before/after evidence is the local pair above.

The canonical changed-check dry plan selected core/core-test checks and the
exact five-file type-aware lint command. The separately bounded local lint
attempt reached its 60-second supervision limit without diagnostics and was
drained; it is inconclusive, not a lint pass or a diagnosed source failure. No
retry or timeout increase was used. The subsequent exact-head hosted lint,
type, and selected core checks all succeeded.

The [latest ClawSweeper review](https://github.com/openclaw/openclaw/pull/132528#issuecomment-5461619222)
covered this exact head and found no actionable findings. Its remaining normal
maintainer-flow and exact-head-CI notes are handled by the successful run above
and the repository-native prepare/merge gates; this is not a landing claim.

Screenshot/video upload is not authorized in this environment, and isolated
terminal capture requires foreground approval that has not been provided.
Complete baseline/candidate logs and genuine ANSI recordings remain local. No
operator window/profile was changed, and text/ANSI is not presented as an image
or screenshot. AI-assisted repair and validation.
