### PR TITLE
feat(telegram): boundary-aware, configurable progress-line clipping (#130144)

### DIFF
--- a/docs/channels/telegram.md
+++ b/docs/channels/telegram.md
@@ -354,6 +354,7 @@ curl "https://api.telegram.org/bot<bot_token>/getUpdates"
     - `streaming.preview.toolProgress` controls whether tool/progress updates reuse the same edited preview message (default: `true` when preview streaming is active)
     - `streaming.preview.commandText` controls command/exec detail inside those lines: `status` (default, tool label only) or `raw` (explicit command text)
     - `streaming.progress.commentary` (default: `false`) opts into assistant commentary/preamble text in the temporary progress draft
+    - `streaming.progress.maxLineChars` bounds each compact progress line (default: `300` on Telegram, keeping its historical clip; the shared default is `120`): prose cuts at word boundaries, and command/path detail keeps its useful prefix and suffix
     - legacy `channels.telegram.streamMode`, boolean `streaming` values, and retired native draft preview keys are detected; run `openclaw doctor --fix` to migrate them
 
     Tool-progress lines are the short status updates shown while tools run (command execution, file reads, planning updates, patch summaries, Codex preamble/commentary in app-server mode). Telegram keeps these on by default (matches released behavior from `v2026.4.22`+).

--- a/docs/concepts/streaming.md
+++ b/docs/concepts/streaming.md
@@ -367,7 +367,8 @@ channel:
 | `streaming.progress.labels`       | built-in pool | Candidate labels used when `label: "auto"`                     |
 
 Slack always renders progress mode as its fixed session-card layout; these
-limits still bound the activity rows and plan text inside that card.
+limits still bound the activity rows and plan text inside that card. Telegram
+keeps its historical 300-char default when `maxLineChars` is unset.
 
 ### Commentary progress lane
 

--- a/extensions/telegram/src/bot-message-dispatch-progress.ts
+++ b/extensions/telegram/src/bot-message-dispatch-progress.ts
@@ -1,5 +1,6 @@
 import {
   createChannelProgressDraftCompositor,
+  resolveChannelProgressDraftMaxLineChars,
   type ChannelProgressDraftLine,
 } from "openclaw/plugin-sdk/channel-outbound";
 import type { TelegramBotDeps } from "./bot-deps.js";
@@ -14,6 +15,7 @@ import {
   formatTelegramProgressLine,
   renderTelegramProgressDraftPreview,
 } from "./progress-draft-preview.js";
+import { TELEGRAM_PROGRESS_MAX_CHARS } from "./truncate.js";
 
 type BufferedDispatchParams = Parameters<
   TelegramBotDeps["dispatchReplyWithBufferedBlockDispatcher"]
@@ -59,6 +61,13 @@ export function createProgressState(
     finalAnswerDelivered: false,
     verboseProgressActive: () => false,
   };
+  // Telegram keeps its historical 300-char budget unless
+  // channels.telegram.streaming.progress.maxLineChars overrides it; the shared
+  // resolver rejects non-positive values, so unset config stays on 300.
+  const progressMaxLineChars = resolveChannelProgressDraftMaxLineChars(
+    config.telegramCfg,
+    TELEGRAM_PROGRESS_MAX_CHARS,
+  );
   const progressCompositor = createChannelProgressDraftCompositor({
     entry: config.telegramCfg,
     mode: config.streamMode,
@@ -67,7 +76,7 @@ export function createProgressState(
     formatLine: (text) =>
       progressCompositor.hasStatusHeadline || progressCompositor.hasPlanProgress
         ? text
-        : formatTelegramProgressLine(text),
+        : formatTelegramProgressLine(text, progressMaxLineChars),
     reasoningGate: draftState.streamReasoningInProgressDraft,
     reasoningLinePrefix: "🧠 ",
     commentaryLinePrefix: "💬 ",
@@ -88,6 +97,7 @@ export function createProgressState(
           options?.lines ?? [],
           config.telegramCfg.richMessages === true,
           progressCompositor.hasStatusHeadline || progressCompositor.hasPlanProgress,
+          progressMaxLineChars,
         ),
       );
       if (options?.flush) {

--- a/extensions/telegram/src/bot-message-dispatch.progress-rendering.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.progress-rendering.test.ts
@@ -191,6 +191,45 @@ describeTelegramDispatch("dispatchTelegramMessage progress-rendering", () => {
     expect(toolLine).toContain("…");
   });
 
+  it("caps arbitrary structured item statuses within the configured budget", async () => {
+    vi.useFakeTimers();
+    try {
+      const draftStream = createSequencedDraftStream(2001);
+      createTelegramDraftStream.mockReturnValue(draftStream);
+      dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ replyOptions }) => {
+        // Named item events may carry an independent arbitrary status string;
+        // the rendered line must stay inside the configured whole-line budget.
+        await replyOptions?.onItemEvent?.({
+          kind: "deploy-check",
+          itemId: "item-1",
+          title: "Deploy check",
+          status: `retrying endpoint ${"x".repeat(200)} after timeout`,
+        });
+        await vi.advanceTimersByTimeAsync(5_000);
+        return { queuedFinal: false };
+      });
+
+      await dispatchWithContext({
+        context: createContext(),
+        streamMode: "progress",
+        telegramCfg: {
+          streaming: { mode: "progress", progress: { label: false, maxLineChars: 40 } },
+        },
+      });
+
+      const preview = draftStream.updatePreview.mock.calls.at(-1)?.[0];
+      const statusLine = (preview?.text ?? "")
+        .split("<br>")
+        .find((part) => part.includes("Deploy check"));
+      const plain = (statusLine ?? "").replace(/<[^>]+>/gu, "");
+      expect(Array.from(plain).length).toBeLessThanOrEqual(40);
+      expect(plain).toContain("Deploy check");
+      expect(plain).toContain("…");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("renders the headline immediately when the preamble arrives after tool progress", async () => {
     const draftStream = createSequencedDraftStream(2001);
     createTelegramDraftStream.mockReturnValue(draftStream);

--- a/extensions/telegram/src/bot-message-dispatch.progress-rendering.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.progress-rendering.test.ts
@@ -98,6 +98,99 @@ describeTelegramDispatch("dispatchTelegramMessage progress-rendering", () => {
     );
   });
 
+  it("caps the status headline with the configured budget", async () => {
+    const draftStream = createSequencedDraftStream(2001);
+    createTelegramDraftStream.mockReturnValue(draftStream);
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ replyOptions }) => {
+      await replyOptions?.onPlanUpdate?.({
+        phase: "update",
+        explanation:
+          "Implementing the change across every subsystem before validating the result end to end",
+        steps: [
+          { step: "Inspect", status: "completed" },
+          { step: "Patch", status: "in_progress" },
+        ],
+      });
+      return { queuedFinal: false };
+    });
+
+    await dispatchWithContext({
+      context: createContext(),
+      streamMode: "progress",
+      telegramCfg: {
+        streaming: { mode: "progress", progress: { label: false, maxLineChars: 24 } },
+      },
+    });
+
+    expect(draftStream.updatePreview).toHaveBeenLastCalledWith(
+      telegramProgressPreview(
+        "Implementing the change across every subsystem before validating the result end to end\n\n✅ Inspect\n▸ Patch",
+        "<b>Implementing the…</b>\n✅ Inspect\n▸ Patch",
+      ),
+    );
+  });
+
+  it("caps the status headline with the configured budget in rich-message mode", async () => {
+    const draftStream = createSequencedDraftStream(2001);
+    createTelegramDraftStream.mockReturnValue(draftStream);
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ replyOptions }) => {
+      await replyOptions?.onPlanUpdate?.({
+        phase: "update",
+        explanation:
+          "Implementing the change across every subsystem before validating the result end to end",
+        steps: [{ step: "Inspect", status: "completed" }],
+      });
+      return { queuedFinal: false };
+    });
+
+    await dispatchWithContext({
+      context: createContext(),
+      streamMode: "progress",
+      telegramCfg: {
+        richMessages: true,
+        streaming: { mode: "progress", progress: { label: false, maxLineChars: 24 } },
+      },
+    });
+
+    const preview = draftStream.updatePreview.mock.calls.at(-1)?.[0];
+    expect(preview?.text).toContain("Implementing the…");
+    expect(preview?.text).not.toContain("subsystem");
+    expect(JSON.stringify(preview?.richMessage)).toContain("Implementing the…");
+    expect(JSON.stringify(preview?.richMessage)).not.toContain("subsystem");
+  });
+
+  it("keeps a short configured budget on structured tool lines", async () => {
+    const draftStream = createSequencedDraftStream(2001);
+    createTelegramDraftStream.mockReturnValue(draftStream);
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ replyOptions }) => {
+      await replyOptions?.onReplyStart?.();
+      await replyOptions?.onToolStart?.({
+        name: "Bash",
+        phase: "start",
+        toolCallId: "bash-1",
+        args: { command: `cat path/to/${"nested/".repeat(20)}file.ts` },
+      });
+      return { queuedFinal: false };
+    });
+
+    await dispatchWithContext({
+      context: createContext(),
+      streamMode: "progress",
+      telegramCfg: {
+        streaming: {
+          mode: "progress",
+          progress: { label: false, maxLineChars: 12, commandText: "raw" },
+        },
+      },
+    });
+
+    const preview = draftStream.updatePreview.mock.calls.at(-1)?.[0];
+    const toolLine = (preview?.text ?? "").replace(/<[^>]+>/gu, "");
+    expect(Array.from(toolLine).length).toBeLessThanOrEqual(12);
+    expect(toolLine).toContain("Bash");
+    expect(toolLine).toContain("…");
+  });
+
   it("renders the headline immediately when the preamble arrives after tool progress", async () => {
     const draftStream = createSequencedDraftStream(2001);
     createTelegramDraftStream.mockReturnValue(draftStream);

--- a/extensions/telegram/src/progress-draft-preview.test.ts
+++ b/extensions/telegram/src/progress-draft-preview.test.ts
@@ -46,4 +46,55 @@ describe("renderTelegramProgressDraftPreview", () => {
     expect(rendered).toContain("<b>📖 Read</b>");
     expect(rendered.match(/📖/gu) ?? []).toHaveLength(1);
   });
+
+  it("honors a configured budget and cuts prose on word boundaries", () => {
+    const line = {
+      kind: "item" as const,
+      label: "Commentary",
+      text: "alpha beta gamma delta epsilon zeta eta theta iota kappa",
+      prefix: false,
+    };
+
+    const rendered = renderTelegramProgressDraftPreview("Working", [line], false, true, 24).text;
+
+    expect(rendered).toContain("alpha beta gamma…");
+    expect(rendered).not.toContain("epsilon");
+  });
+
+  it("keeps command detail prefixes and useful path suffixes", () => {
+    const path = `path/to/${"nested/".repeat(20)}file.ts`;
+    const line = buildChannelProgressDraftLine(
+      {
+        event: "tool",
+        toolCallId: "call-1",
+        name: "Bash",
+        phase: "start",
+        args: { command: `cat ${path}` },
+      },
+      { commandText: "raw" },
+    );
+    if (!line) {
+      throw new Error("expected a progress line for Bash");
+    }
+
+    const rendered = renderTelegramProgressDraftPreview("Working", [line], false, true, 60).text;
+
+    expect(rendered).toContain("<b>🛠️ Bash</b>");
+    // The tail of the path carries the information; keep it visible.
+    expect(rendered).toMatch(/…[^<]*file\.ts<\/code>/u);
+  });
+
+  it("keeps the historical 300 budget when no budget is passed", () => {
+    const line = {
+      kind: "item" as const,
+      label: "Commentary",
+      text: `${"x ".repeat(150)}tail`,
+      prefix: false,
+    };
+
+    const rendered = renderTelegramProgressDraftPreview("Working", [line], false, true).text;
+
+    expect(rendered).toContain("…");
+    expect(rendered).not.toContain("tail");
+  });
 });

--- a/extensions/telegram/src/progress-draft-preview.test.ts
+++ b/extensions/telegram/src/progress-draft-preview.test.ts
@@ -118,6 +118,85 @@ describe("renderTelegramProgressDraftPreview", () => {
     expect(JSON.stringify(preview.richMessage)).not.toContain("video");
   });
 
+  it("keeps the status tail inside the composed line budget", () => {
+    const path = `path/to/${"nested/".repeat(20)}file.ts`;
+    const line = buildChannelProgressDraftLine(
+      {
+        event: "tool",
+        toolCallId: "call-1",
+        name: "Bash",
+        phase: "start",
+        args: { command: `cat ${path}` },
+      },
+      { commandText: "raw" },
+    );
+    if (!line) {
+      throw new Error("expected a progress line for Bash");
+    }
+    const statusLine = { ...line, status: "running" };
+
+    const rendered = renderTelegramProgressDraftPreview(
+      "Working",
+      [statusLine],
+      false,
+      true,
+      16,
+    ).text;
+    const toolLine = (rendered.split("<br>")[1] ?? "").replace(/<[^>]+>/gu, "");
+
+    // label (8) + " " + status (7) already reaches 16, so the composed line
+    // stays at budget instead of appending an unbounded detail.
+    expect(Array.from(toolLine).length).toBeLessThanOrEqual(16);
+    expect(toolLine).toContain("running");
+  });
+
+  it("omits the status when the label fills the configured budget", () => {
+    const structured = (status: string) => ({
+      kind: "item" as const,
+      label: "Deploy check",
+      text: "Deploy check",
+      status,
+      prefix: false,
+    });
+
+    // Label (12) exactly fills the budget: no room for the joining separator
+    // plus status, so the status is omitted instead of overflowing the line.
+    const atBudget = renderTelegramProgressDraftPreview(
+      "Working",
+      [structured("running")],
+      false,
+      true,
+      12,
+    ).text;
+    const atBudgetLine = (atBudget.split("<br>")[1] ?? "").replace(/<[^>]+>/gu, "");
+    expect(atBudgetLine).toBe("Deploy check");
+
+    // One code point below the budget leaves only the separator: the status
+    // still does not fit and stays omitted.
+    const oneBelow = renderTelegramProgressDraftPreview(
+      "Working",
+      [structured("running")],
+      false,
+      true,
+      13,
+    ).text;
+    const oneBelowLine = (oneBelow.split("<br>")[1] ?? "").replace(/<[^>]+>/gu, "");
+    expect(oneBelowLine).toBe("Deploy check");
+
+    // Two code points below the budget fit the separator plus one clipped
+    // status character without exceeding the line budget.
+    const withRoom = renderTelegramProgressDraftPreview(
+      "Working",
+      [structured("running")],
+      false,
+      true,
+      15,
+    ).text;
+    const withRoomLine = (withRoom.split("<br>")[1] ?? "").replace(/<[^>]+>/gu, "");
+    expect(Array.from(withRoomLine).length).toBeLessThanOrEqual(15);
+    expect(withRoomLine).toContain("…");
+  });
+
   it("keeps the label and fallback detail within one line budget", () => {
     const path = `path/to/${"nested/".repeat(20)}file.ts`;
     const line = buildChannelProgressDraftLine(

--- a/extensions/telegram/src/progress-draft-preview.test.ts
+++ b/extensions/telegram/src/progress-draft-preview.test.ts
@@ -84,6 +84,66 @@ describe("renderTelegramProgressDraftPreview", () => {
     expect(rendered).toMatch(/…[^<]*file\.ts<\/code>/u);
   });
 
+  it("bounds the bold status headline with the configured budget", () => {
+    const narration = "I am checking whether the generated video exists after the render finished";
+
+    const rendered = renderTelegramProgressDraftPreview(
+      `${narration}\n\n✅ Inspect\n▸ Patch`,
+      [],
+      false,
+      true,
+      24,
+    ).text;
+
+    const bold = rendered.match(/<b>([^<]*)<\/b>/u)?.[1] ?? "";
+    expect(bold).toBe("I am checking whether…");
+    expect(rendered).toContain("✅ Inspect");
+    expect(rendered).not.toContain("video");
+  });
+
+  it("bounds the rich status headline with the configured budget", () => {
+    const narration = "I am checking whether the generated video exists after the render finished";
+
+    const preview = renderTelegramProgressDraftPreview(
+      `${narration}\n\n✅ Inspect`,
+      [],
+      true,
+      true,
+      24,
+    );
+
+    expect(preview.text).toContain("I am checking whether…");
+    expect(preview.text).not.toContain("video");
+    expect(JSON.stringify(preview.richMessage)).toContain("I am checking whether…");
+    expect(JSON.stringify(preview.richMessage)).not.toContain("video");
+  });
+
+  it("keeps the label and fallback detail within one line budget", () => {
+    const path = `path/to/${"nested/".repeat(20)}file.ts`;
+    const line = buildChannelProgressDraftLine(
+      {
+        event: "tool",
+        toolCallId: "call-1",
+        name: "Bash",
+        phase: "start",
+        args: { command: `cat ${path}` },
+      },
+      { commandText: "raw" },
+    );
+    if (!line) {
+      throw new Error("expected a progress line for Bash");
+    }
+
+    // A valid budget shorter than the label plus the canonical compactor's
+    // eight-character detail minimum must still bound the composed line.
+    const rendered = renderTelegramProgressDraftPreview("Working", [line], false, true, 12).text;
+    const toolLine = (rendered.split("<br>")[1] ?? "").replace(/<[^>]+>/gu, "");
+
+    expect(Array.from(toolLine).length).toBeLessThanOrEqual(12);
+    expect(toolLine).toContain("Bash");
+    expect(toolLine).toContain("…");
+  });
+
   it("keeps the historical 300 budget when no budget is passed", () => {
     const line = {
       kind: "item" as const,

--- a/extensions/telegram/src/progress-draft-preview.ts
+++ b/extensions/telegram/src/progress-draft-preview.ts
@@ -41,21 +41,29 @@ function escapeTelegramProgressHtml(text: string): string {
     .replaceAll('"', "&quot;");
 }
 
-function clipTelegramProgressDetail(detail: string, label: string, maxLineChars: number): string {
+function clipTelegramProgressDetail(
+  detail: string,
+  label: string,
+  maxLineChars: number,
+  reservedChars = 0,
+): string {
   // Mirror the shared compact renderer: the label prefix shares the line
   // budget, and the canonical compaction keeps the detail's useful prefix and
   // suffix around a middle ellipsis instead of blindly cutting the tail.
+  // `reservedChars` is what the rest of the composed line (the status tail)
+  // already consumes, so the label + detail + status line stays within one
+  // line budget like the shared renderer's whole-line cap.
+  const lineBudget = maxLineChars - reservedChars;
   const prefix = `${label}: `;
-  const compacted = clipTelegramProgressText(`${prefix}${detail}`, maxLineChars);
+  const compacted = clipTelegramProgressText(`${prefix}${detail}`, lineBudget);
   if (compacted.startsWith(prefix)) {
     return compacted.slice(prefix.length);
   }
   // The canonical compactor keeps the label only while the remaining detail
   // budget still reaches its eight-character minimum. For a valid budget
   // shorter than that, reserve the label and its rendered separator before
-  // clipping the fallback detail, so the composed label + detail line stays
-  // within one line budget like the shared renderer's whole-line cap.
-  const detailBudget = maxLineChars - Array.from(`${label} `).length;
+  // clipping the fallback detail.
+  const detailBudget = lineBudget - Array.from(`${label} `).length;
   return detailBudget >= 1 ? clipTelegramProgressText(detail, detailBudget) : "";
 }
 
@@ -66,6 +74,41 @@ function clipTelegramProgressLabel(label: string, maxLineChars: number): string 
   return Array.from(label).length > maxLineChars
     ? clipTelegramProgressText(label, maxLineChars)
     : label;
+}
+
+type TelegramProgressLineParts = {
+  label: string;
+  detail: string | undefined;
+  status: string | undefined;
+};
+
+function resolveTelegramProgressLineParts(
+  line: Exclude<ChannelProgressDraftCompositorLine, string>,
+  maxLineChars: number,
+): TelegramProgressLineParts {
+  const label = clipTelegramProgressLabel(
+    [line.icon, line.label].filter(Boolean).join(" "),
+    maxLineChars,
+  );
+  const labelLength = Array.from(label).length;
+  // The shared renderer bounds the whole composed line, status tail included,
+  // so reserve the label and status halves before the detail sees a budget.
+  const rawStatus =
+    line.status && line.status !== "completed" && line.status !== line.detail
+      ? line.status
+      : undefined;
+  // Reserve the joining separator before allocating status characters; when
+  // the label already fills the whole-line budget there is no room left for
+  // the status tail, so omit it instead of overflowing the visible line.
+  const statusBudget = maxLineChars - labelLength - 1;
+  const status =
+    rawStatus && statusBudget >= 1 ? clipTelegramProgressText(rawStatus, statusBudget) : undefined;
+  const statusLength = status ? Array.from(status).length + 1 : 0;
+  const rawDetail = line.detail && line.detail !== line.label ? line.detail : undefined;
+  const detail = rawDetail
+    ? clipTelegramProgressDetail(rawDetail, label, maxLineChars, statusLength)
+    : undefined;
+  return { label, detail, status };
 }
 
 function renderTelegramProgressStringLine(text: string, maxLineChars: number): string {
@@ -98,27 +141,25 @@ function renderTelegramProgressLine(
   if (!line.icon && (!line.label || line.label === "Commentary")) {
     return renderTelegramProgressText(line.text, maxLineChars);
   }
-  const label = clipTelegramProgressLabel(
-    [line.icon, line.label].filter(Boolean).join(" "),
-    maxLineChars,
-  );
+  const { label, detail, status } = resolveTelegramProgressLineParts(line, maxLineChars);
+  const labelLength = Array.from(label).length;
+  const statusLength = status ? Array.from(status).length + 1 : 0;
   const parts = [`<b>${escapeTelegramProgressHtml(label)}</b>`];
-  const detail = line.detail && line.detail !== line.label ? line.detail : undefined;
   if (detail) {
-    const clippedDetail = clipTelegramProgressDetail(detail, label, maxLineChars);
-    if (clippedDetail) {
-      parts.push(`<code>${escapeTelegramProgressHtml(clippedDetail)}</code>`);
-    }
+    parts.push(`<code>${escapeTelegramProgressHtml(detail)}</code>`);
   } else {
     const text = line.text.trim();
     if (text && text !== label) {
-      parts.push(
-        `<code>${escapeTelegramProgressHtml(clipTelegramProgressText(text, maxLineChars))}</code>`,
-      );
+      const textBudget = maxLineChars - labelLength - 1 - statusLength;
+      if (textBudget >= 1) {
+        parts.push(
+          `<code>${escapeTelegramProgressHtml(clipTelegramProgressText(text, textBudget))}</code>`,
+        );
+      }
     }
   }
-  if (line.status && line.status !== "completed" && line.status !== line.detail) {
-    parts.push(`<i>${escapeTelegramProgressHtml(line.status)}</i>`);
+  if (status) {
+    parts.push(`<i>${escapeTelegramProgressHtml(status)}</i>`);
   }
   return parts.join(" ");
 }
@@ -172,25 +213,23 @@ function progressLineToRichText(
   if (!line.icon && (!line.label || line.label === "Commentary")) {
     return progressTextToRichText(line.text, maxLineChars);
   }
-  const label = clipTelegramProgressLabel(
-    [line.icon, line.label].filter(Boolean).join(" "),
-    maxLineChars,
-  );
+  const { label, detail, status } = resolveTelegramProgressLineParts(line, maxLineChars);
+  const labelLength = Array.from(label).length;
+  const statusLength = status ? Array.from(status).length + 1 : 0;
   const parts: RichText[] = [boldRichText(label)];
-  const detail = line.detail && line.detail !== line.label ? line.detail : undefined;
   if (detail) {
-    const clippedDetail = clipTelegramProgressDetail(detail, label, maxLineChars);
-    if (clippedDetail) {
-      parts.push(codeRichText(clippedDetail));
-    }
+    parts.push(codeRichText(detail));
   } else {
     const text = line.text.trim();
     if (text && text !== label) {
-      parts.push(codeRichText(clipTelegramProgressText(text, maxLineChars)));
+      const textBudget = maxLineChars - labelLength - 1 - statusLength;
+      if (textBudget >= 1) {
+        parts.push(codeRichText(clipTelegramProgressText(text, textBudget)));
+      }
     }
   }
-  if (line.status && line.status !== "completed" && line.status !== line.detail) {
-    parts.push(italicRichText(line.status));
+  if (status) {
+    parts.push(italicRichText(status));
   }
   return joinRichText(parts, " ");
 }

--- a/extensions/telegram/src/progress-draft-preview.ts
+++ b/extensions/telegram/src/progress-draft-preview.ts
@@ -12,22 +12,25 @@ import {
 } from "./rich-block-model.js";
 import { markdownToTelegramRichBlocks } from "./rich-blocks.js";
 import { buildTelegramRichBlocksPlan } from "./rich-message.js";
-import { clipTelegramProgressText } from "./truncate.js";
+import { clipTelegramProgressText, TELEGRAM_PROGRESS_MAX_CHARS } from "./truncate.js";
 
 function sanitizeProgressMarkdownText(text: string): string {
   return text.replaceAll("`", "'");
 }
 
-function formatProgressAsMarkdownCode(text: string): string {
-  const clipped = clipTelegramProgressText(text);
+function formatProgressAsMarkdownCode(text: string, maxLineChars: number): string {
+  const clipped = clipTelegramProgressText(text, maxLineChars);
   return `\`${sanitizeProgressMarkdownText(clipped)}\``;
 }
 
-export function formatTelegramProgressLine(text: string): string {
+export function formatTelegramProgressLine(
+  text: string,
+  maxLineChars: number = TELEGRAM_PROGRESS_MAX_CHARS,
+): string {
   const trimmed = text.trim();
   return trimmed.startsWith("_") && trimmed.endsWith("_")
     ? trimmed
-    : formatProgressAsMarkdownCode(text);
+    : formatProgressAsMarkdownCode(text, maxLineChars);
 }
 
 function escapeTelegramProgressHtml(text: string): string {
@@ -38,38 +41,60 @@ function escapeTelegramProgressHtml(text: string): string {
     .replaceAll('"', "&quot;");
 }
 
-function renderTelegramProgressStringLine(text: string): string {
+function clipTelegramProgressDetail(detail: string, label: string, maxLineChars: number): string {
+  // Mirror the shared compact renderer: the label prefix shares the line
+  // budget, and the canonical compaction keeps the detail's useful prefix and
+  // suffix around a middle ellipsis instead of blindly cutting the tail.
+  const prefix = `${label}: `;
+  const compacted = clipTelegramProgressText(`${prefix}${detail}`, maxLineChars);
+  return compacted.startsWith(prefix)
+    ? compacted.slice(prefix.length)
+    : clipTelegramProgressText(detail, maxLineChars);
+}
+
+function renderTelegramProgressStringLine(text: string, maxLineChars: number): string {
   // Reasoning/commentary lanes carry model-authored markdown. Render through
   // renderTelegramHtmlText (parse_mode HTML-safe), not the full rich block
   // converter — block output from headings/lists can reject the edit.
   const trimmed = text.trim();
   const italic = trimmed.match(/^(\S+ )?_(.*)_$/u);
   const clipped = italic
-    ? `${italic[1] ?? ""}_${clipTelegramProgressText(italic[2] ?? "")}_`
-    : clipTelegramProgressText(trimmed);
+    ? `${italic[1] ?? ""}_${clipTelegramProgressText(italic[2] ?? "", maxLineChars)}_`
+    : clipTelegramProgressText(trimmed, maxLineChars);
   return renderTelegramHtmlText(clipped);
 }
 
-function renderTelegramProgressText(text: string): string {
-  return text.split(/\r?\n/u).map(renderTelegramProgressStringLine).filter(Boolean).join("<br>");
+function renderTelegramProgressText(text: string, maxLineChars: number): string {
+  return text
+    .split(/\r?\n/u)
+    .map((line) => renderTelegramProgressStringLine(line, maxLineChars))
+    .filter(Boolean)
+    .join("<br>");
 }
 
-function renderTelegramProgressLine(line: ChannelProgressDraftCompositorLine): string {
+function renderTelegramProgressLine(
+  line: ChannelProgressDraftCompositorLine,
+  maxLineChars: number,
+): string {
   if (typeof line === "string") {
-    return renderTelegramProgressText(line);
+    return renderTelegramProgressText(line, maxLineChars);
   }
   if (!line.icon && (!line.label || line.label === "Commentary")) {
-    return renderTelegramProgressText(line.text);
+    return renderTelegramProgressText(line.text, maxLineChars);
   }
   const label = [line.icon, line.label].filter(Boolean).join(" ");
   const parts = [`<b>${escapeTelegramProgressHtml(label)}</b>`];
   const detail = line.detail && line.detail !== line.label ? line.detail : undefined;
   if (detail) {
-    parts.push(`<code>${escapeTelegramProgressHtml(clipTelegramProgressText(detail))}</code>`);
+    parts.push(
+      `<code>${escapeTelegramProgressHtml(clipTelegramProgressDetail(detail, label, maxLineChars))}</code>`,
+    );
   } else {
     const text = line.text.trim();
     if (text && text !== label) {
-      parts.push(`<code>${escapeTelegramProgressHtml(clipTelegramProgressText(text))}</code>`);
+      parts.push(
+        `<code>${escapeTelegramProgressHtml(clipTelegramProgressText(text, maxLineChars))}</code>`,
+      );
     }
   }
   if (line.status && line.status !== "completed" && line.status !== line.detail) {
@@ -95,12 +120,12 @@ function joinRichText(parts: RichText[], separator: string): RichText {
   return result;
 }
 
-function markdownLineToRichText(text: string): RichText {
+function markdownLineToRichText(text: string, maxLineChars: number): RichText {
   const trimmed = text.trim();
   const italic = trimmed.match(/^(\S+ )?_(.*)_$/u);
   const clipped = italic
-    ? `${italic[1] ?? ""}_${clipTelegramProgressText(italic[2] ?? "")}_`
-    : clipTelegramProgressText(trimmed);
+    ? `${italic[1] ?? ""}_${clipTelegramProgressText(italic[2] ?? "", maxLineChars)}_`
+    : clipTelegramProgressText(trimmed, maxLineChars);
   const { blocks } = markdownToTelegramRichBlocks(clipped, { skipEntityDetection: true });
   const first = blocks[0];
   if (first?.type === "paragraph") {
@@ -109,30 +134,33 @@ function markdownLineToRichText(text: string): RichText {
   return clipped;
 }
 
-function progressTextToRichText(text: string): RichText | undefined {
+function progressTextToRichText(text: string, maxLineChars: number): RichText | undefined {
   const parts = text
     .split(/\r?\n/u)
-    .map(markdownLineToRichText)
+    .map((line) => markdownLineToRichText(line, maxLineChars))
     .filter((part) => part !== "");
   return parts.length ? joinRichText(parts, "\n") : undefined;
 }
 
-function progressLineToRichText(line: ChannelProgressDraftCompositorLine): RichText | undefined {
+function progressLineToRichText(
+  line: ChannelProgressDraftCompositorLine,
+  maxLineChars: number,
+): RichText | undefined {
   if (typeof line === "string") {
-    return progressTextToRichText(line);
+    return progressTextToRichText(line, maxLineChars);
   }
   if (!line.icon && (!line.label || line.label === "Commentary")) {
-    return progressTextToRichText(line.text);
+    return progressTextToRichText(line.text, maxLineChars);
   }
   const label = [line.icon, line.label].filter(Boolean).join(" ");
   const parts: RichText[] = [boldRichText(label)];
   const detail = line.detail && line.detail !== line.label ? line.detail : undefined;
   if (detail) {
-    parts.push(codeRichText(clipTelegramProgressText(detail)));
+    parts.push(codeRichText(clipTelegramProgressDetail(detail, label, maxLineChars)));
   } else {
     const text = line.text.trim();
     if (text && text !== label) {
-      parts.push(codeRichText(clipTelegramProgressText(text)));
+      parts.push(codeRichText(clipTelegramProgressText(text, maxLineChars)));
     }
   }
   if (line.status && line.status !== "completed" && line.status !== line.detail) {
@@ -159,6 +187,7 @@ export function renderTelegramProgressDraftPreview(
   lines: readonly ChannelProgressDraftCompositorLine[],
   richMessages: boolean,
   statusHeadlineActive = false,
+  maxLineChars: number = TELEGRAM_PROGRESS_MAX_CHARS,
 ): TelegramDraftPreview {
   const trimmed = text.trimEnd();
   if (statusHeadlineActive) {
@@ -167,23 +196,30 @@ export function renderTelegramProgressDraftPreview(
       .map((line) => line.trim())
       .filter(Boolean);
     const workLines = lines.filter(isStatusHeadlineWorkLine);
-    const renderedLines = workLines.map(renderTelegramProgressLine).filter(Boolean);
+    const renderedLines = workLines
+      .map((line) => renderTelegramProgressLine(line, maxLineChars))
+      .filter(Boolean);
     if (!richMessages) {
       const renderedStatusLines =
         statusLines.length > 1
           ? [
               `<b>${escapeTelegramProgressHtml(statusLines[0] ?? "")}</b>`,
-              ...statusLines.slice(1).map(renderTelegramProgressStringLine),
+              ...statusLines
+                .slice(1)
+                .map((line) => renderTelegramProgressStringLine(line, maxLineChars)),
             ]
-          : statusLines.map(renderTelegramProgressStringLine);
+          : statusLines.map((line) => renderTelegramProgressStringLine(line, maxLineChars));
       return { text: [...renderedStatusLines, ...renderedLines].join("<br>"), parseMode: "HTML" };
     }
     const richStatusParts: RichText[] =
       statusLines.length > 1
-        ? [boldRichText(statusLines[0] ?? ""), ...statusLines.slice(1).map(markdownLineToRichText)]
-        : statusLines.map(markdownLineToRichText);
+        ? [
+            boldRichText(statusLines[0] ?? ""),
+            ...statusLines.slice(1).map((line) => markdownLineToRichText(line, maxLineChars)),
+          ]
+        : statusLines.map((line) => markdownLineToRichText(line, maxLineChars));
     const richLineParts = workLines
-      .map(progressLineToRichText)
+      .map((line) => progressLineToRichText(line, maxLineChars))
       .filter((part): part is RichText => part !== undefined);
     const plainLineTexts = workLines
       .map((line) => line.text)
@@ -201,7 +237,9 @@ export function renderTelegramProgressDraftPreview(
       ).richMessage,
     };
   }
-  const renderedLines = lines.map(renderTelegramProgressLine).filter(Boolean);
+  const renderedLines = lines
+    .map((line) => renderTelegramProgressLine(line, maxLineChars))
+    .filter(Boolean);
   const textLines = trimmed
     .split(/\r?\n/u)
     .map((line) => line.trim())
@@ -214,7 +252,7 @@ export function renderTelegramProgressDraftPreview(
     return { text: htmlParts.join("<br>"), parseMode: "HTML" };
   }
   const richLineParts = lines
-    .map(progressLineToRichText)
+    .map((line) => progressLineToRichText(line, maxLineChars))
     .filter((part): part is RichText => part !== undefined);
   const richParts = heading ? [boldRichText(heading), ...richLineParts] : richLineParts;
   return {

--- a/extensions/telegram/src/progress-draft-preview.ts
+++ b/extensions/telegram/src/progress-draft-preview.ts
@@ -47,9 +47,25 @@ function clipTelegramProgressDetail(detail: string, label: string, maxLineChars:
   // suffix around a middle ellipsis instead of blindly cutting the tail.
   const prefix = `${label}: `;
   const compacted = clipTelegramProgressText(`${prefix}${detail}`, maxLineChars);
-  return compacted.startsWith(prefix)
-    ? compacted.slice(prefix.length)
-    : clipTelegramProgressText(detail, maxLineChars);
+  if (compacted.startsWith(prefix)) {
+    return compacted.slice(prefix.length);
+  }
+  // The canonical compactor keeps the label only while the remaining detail
+  // budget still reaches its eight-character minimum. For a valid budget
+  // shorter than that, reserve the label and its rendered separator before
+  // clipping the fallback detail, so the composed label + detail line stays
+  // within one line budget like the shared renderer's whole-line cap.
+  const detailBudget = maxLineChars - Array.from(`${label} `).length;
+  return detailBudget >= 1 ? clipTelegramProgressText(detail, detailBudget) : "";
+}
+
+function clipTelegramProgressLabel(label: string, maxLineChars: number): string {
+  // Structured labels stay verbatim while they fit; a label longer than the
+  // configured budget is itself compacted so the composed line can never
+  // exceed the budget through its label half alone.
+  return Array.from(label).length > maxLineChars
+    ? clipTelegramProgressText(label, maxLineChars)
+    : label;
 }
 
 function renderTelegramProgressStringLine(text: string, maxLineChars: number): string {
@@ -82,13 +98,17 @@ function renderTelegramProgressLine(
   if (!line.icon && (!line.label || line.label === "Commentary")) {
     return renderTelegramProgressText(line.text, maxLineChars);
   }
-  const label = [line.icon, line.label].filter(Boolean).join(" ");
+  const label = clipTelegramProgressLabel(
+    [line.icon, line.label].filter(Boolean).join(" "),
+    maxLineChars,
+  );
   const parts = [`<b>${escapeTelegramProgressHtml(label)}</b>`];
   const detail = line.detail && line.detail !== line.label ? line.detail : undefined;
   if (detail) {
-    parts.push(
-      `<code>${escapeTelegramProgressHtml(clipTelegramProgressDetail(detail, label, maxLineChars))}</code>`,
-    );
+    const clippedDetail = clipTelegramProgressDetail(detail, label, maxLineChars);
+    if (clippedDetail) {
+      parts.push(`<code>${escapeTelegramProgressHtml(clippedDetail)}</code>`);
+    }
   } else {
     const text = line.text.trim();
     if (text && text !== label) {
@@ -152,11 +172,17 @@ function progressLineToRichText(
   if (!line.icon && (!line.label || line.label === "Commentary")) {
     return progressTextToRichText(line.text, maxLineChars);
   }
-  const label = [line.icon, line.label].filter(Boolean).join(" ");
+  const label = clipTelegramProgressLabel(
+    [line.icon, line.label].filter(Boolean).join(" "),
+    maxLineChars,
+  );
   const parts: RichText[] = [boldRichText(label)];
   const detail = line.detail && line.detail !== line.label ? line.detail : undefined;
   if (detail) {
-    parts.push(codeRichText(clipTelegramProgressDetail(detail, label, maxLineChars)));
+    const clippedDetail = clipTelegramProgressDetail(detail, label, maxLineChars);
+    if (clippedDetail) {
+      parts.push(codeRichText(clippedDetail));
+    }
   } else {
     const text = line.text.trim();
     if (text && text !== label) {
@@ -195,6 +221,11 @@ export function renderTelegramProgressDraftPreview(
       .split(/\r?\n/u)
       .map((line) => line.trim())
       .filter(Boolean);
+    // The first status line is the draft's headline. It carries the shared
+    // narration's own 280-character cap, not the configured per-line budget,
+    // so bound it here with the same resolved budget as every other visible
+    // line in both HTML and rich-message mode.
+    const headline = statusLines[0] ? clipTelegramProgressText(statusLines[0], maxLineChars) : "";
     const workLines = lines.filter(isStatusHeadlineWorkLine);
     const renderedLines = workLines
       .map((line) => renderTelegramProgressLine(line, maxLineChars))
@@ -203,7 +234,7 @@ export function renderTelegramProgressDraftPreview(
       const renderedStatusLines =
         statusLines.length > 1
           ? [
-              `<b>${escapeTelegramProgressHtml(statusLines[0] ?? "")}</b>`,
+              `<b>${escapeTelegramProgressHtml(headline)}</b>`,
               ...statusLines
                 .slice(1)
                 .map((line) => renderTelegramProgressStringLine(line, maxLineChars)),
@@ -214,7 +245,7 @@ export function renderTelegramProgressDraftPreview(
     const richStatusParts: RichText[] =
       statusLines.length > 1
         ? [
-            boldRichText(statusLines[0] ?? ""),
+            boldRichText(headline),
             ...statusLines.slice(1).map((line) => markdownLineToRichText(line, maxLineChars)),
           ]
         : statusLines.map((line) => markdownLineToRichText(line, maxLineChars));
@@ -225,7 +256,9 @@ export function renderTelegramProgressDraftPreview(
       .map((line) => line.text)
       .map((line) => line.trim())
       .filter(Boolean);
-    const plainText = [...statusLines, ...plainLineTexts].join("\n");
+    const plainText = [headline, ...statusLines.slice(1), ...plainLineTexts]
+      .filter(Boolean)
+      .join("\n");
     return {
       text: plainText,
       richMessage: buildTelegramRichBlocksPlan(

--- a/extensions/telegram/src/truncate.test.ts
+++ b/extensions/telegram/src/truncate.test.ts
@@ -1,50 +1,85 @@
 // Telegram tests cover progress text clipping behavior.
 import { describe, expect, it } from "vitest";
-import { clipTelegramProgressText } from "./truncate.js";
+import { clipTelegramProgressText, TELEGRAM_PROGRESS_MAX_CHARS } from "./truncate.js";
 
-const TELEGRAM_PROGRESS_LIMIT = 300;
+const TELEGRAM_PROGRESS_LIMIT = TELEGRAM_PROGRESS_MAX_CHARS;
+
+function codePointLength(value: string): number {
+  return Array.from(value).length;
+}
+
+function hasLoneSurrogate(value: string): boolean {
+  return /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/u.test(value);
+}
 
 describe("clipTelegramProgressText", () => {
-  it("drops a surrogate-pair emoji whole when it straddles the limit", () => {
-    // 😀 is U+1F600, encoded as two UTF-16 code units (high \uD83D + low \uDE00).
-    // Placing the emoji at positions [MAX-2, MAX-1] (0-indexed) puts its high
-    // surrogate right on the .slice(0, MAX-1) cut edge. A raw .slice keeps only
-    // \uD83D — an unpaired high surrogate — which is invalid in a Telegram payload.
-    const base = "a".repeat(TELEGRAM_PROGRESS_LIMIT - 2); // 298 'a's
-    const out = clipTelegramProgressText(`${base}😀tail`);
+  it("returns text unchanged when it is within the default limit", () => {
+    const short = "hello 😀 world";
+    expect(clipTelegramProgressText(short)).toBe(short);
+    const exact = "x".repeat(TELEGRAM_PROGRESS_LIMIT);
+    expect(clipTelegramProgressText(exact)).toBe(exact);
+  });
+
+  it("keeps the historical 300 budget when no budget is passed", () => {
+    const oneOver = `${"x".repeat(TELEGRAM_PROGRESS_LIMIT)}y`;
+    const out = clipTelegramProgressText(oneOver);
+    expect(codePointLength(out)).toBeLessThanOrEqual(TELEGRAM_PROGRESS_LIMIT);
+    expect(out.endsWith("…")).toBe(true);
+    expect(hasLoneSurrogate(out)).toBe(false);
+  });
+
+  it("honors a configured budget", () => {
+    const out = clipTelegramProgressText("hello wonderful world of telegram", 20);
+    expect(out).toBe("hello wonderful…");
+    expect(codePointLength(out)).toBeLessThanOrEqual(20);
+  });
+
+  it("cuts prose on word boundaries", () => {
+    const sentence =
+      "I'm checking whether the generated video exists or if the generator bailed while writing output.";
+    expect(clipTelegramProgressText(sentence, 64)).toBe(
+      "I'm checking whether the generated video exists or if the…",
+    );
+  });
+
+  it("keeps command prefixes and useful path suffixes", () => {
+    const path = `path/to/${"nested/".repeat(20)}file.ts`;
+    const detail = `Ran command: cat ${path}`;
+    const out = clipTelegramProgressText(detail, 60);
+    expect(out.startsWith("Ran command: cat")).toBe(true);
+    expect(out.endsWith("file.ts")).toBe(true);
+    expect(out).toContain("…");
+    expect(codePointLength(out)).toBeLessThanOrEqual(60);
+    expect(hasLoneSurrogate(out)).toBe(false);
+  });
+
+  it("drops a surrogate-pair emoji whole when it straddles the cut", () => {
+    // 😀 is U+1F600, encoded as two UTF-16 code units. With a 299-code-point
+    // budget the head keeps 298 code points, so the emoji at positions
+    // [298, 299] is dropped whole instead of leaving a lone \uD83D-style high
+    // surrogate before the ellipsis, which serializes to an invalid character
+    // in the Telegram Bot API payload.
+    const base = "a".repeat(298);
+    const out = clipTelegramProgressText(`${base}😀tail`, 299);
     expect(out).toBe(`${base}…`);
-    // No dangling high surrogate (high not followed by a low surrogate).
-    expect(/[\uD800-\uDBFF](?![\uDC00-\uDFFF])/.test(out)).toBe(false);
+    expect(hasLoneSurrogate(out)).toBe(false);
   });
 
   it("keeps an emoji that fits entirely before the cut", () => {
-    // 296 'a's + '😀' (2 units) + 'xyz' (3 units) = 301 total > 300.
-    // The emoji sits at [296, 297] — entirely before the cut at 299 — so it stays.
-    const base = "a".repeat(TELEGRAM_PROGRESS_LIMIT - 4); // 296 'a's
-    const out = clipTelegramProgressText(`${base}😀xyz`);
-    expect(out).toBe(`${base}😀x…`);
-    expect(/[\uD800-\uDBFF](?![\uDC00-\uDFFF])/.test(out)).toBe(false);
+    // 297 'a's + '😀' (1 code point) + 'xyz' = 301 code points > 299.
+    // The emoji sits at code point 297 — entirely before the 298-code-point
+    // head — so it stays.
+    const base = "a".repeat(297);
+    const out = clipTelegramProgressText(`${base}😀xyz`, 299);
+    expect(out).toBe(`${base}😀…`);
+    expect(hasLoneSurrogate(out)).toBe(false);
   });
 
-  it("returns text unchanged when it is within the limit", () => {
-    const short = "hello 😀 world";
-    expect(clipTelegramProgressText(short)).toBe(short);
-  });
-
-  it("trims trailing whitespace before the ellipsis", () => {
-    // The sliced portion may end in spaces when trailing spaces straddle the cut.
+  it("never leaves trailing whitespace before the ellipsis", () => {
+    // Collapsed trailing spaces can straddle the cut.
     const text = `${"a".repeat(TELEGRAM_PROGRESS_LIMIT - 2)}  rest`;
     const out = clipTelegramProgressText(text);
-    expect(out).not.toContain("  …");
-    expect(out.endsWith("…")).toBe(true);
-  });
-
-  it("handles plain ASCII that fills exactly to the limit", () => {
-    const exact = "x".repeat(TELEGRAM_PROGRESS_LIMIT);
-    expect(clipTelegramProgressText(exact)).toBe(exact);
-    const oneOver = `${"x".repeat(TELEGRAM_PROGRESS_LIMIT)}y`;
-    const out = clipTelegramProgressText(oneOver);
-    expect(out.length).toBeLessThanOrEqual(TELEGRAM_PROGRESS_LIMIT);
+    expect(out).not.toMatch(/\s…$/u);
     expect(out.endsWith("…")).toBe(true);
   });
 });

--- a/extensions/telegram/src/truncate.ts
+++ b/extensions/telegram/src/truncate.ts
@@ -1,20 +1,24 @@
 // Telegram tests cover progress text clipping behavior.
-import { sliceUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
-
-const TELEGRAM_PROGRESS_MAX_CHARS = 300;
+import { compactChannelProgressDraftLine } from "openclaw/plugin-sdk/channel-outbound";
 
 /**
- * Clips Telegram progress text to at most {@link TELEGRAM_PROGRESS_MAX_CHARS} UTF-16 code units,
- * slicing on a code-point boundary so a surrogate pair straddling the limit is
- * dropped whole rather than leaving a lone high surrogate in the payload.
+ * Default per-line budget for Telegram progress text, counted in UTF-16 code
+ * units. Telegram historically clipped at 300; keep that budget when
+ * `channels.telegram.streaming.progress.maxLineChars` is unset.
  */
-export function clipTelegramProgressText(text: string): string {
-  if (text.length <= TELEGRAM_PROGRESS_MAX_CHARS) {
-    return text;
-  }
-  // Slice on a code-point boundary so an emoji (or any astral character) that
-  // straddles the limit is dropped whole instead of leaving a lone \uD83D-style
-  // high surrogate before the ellipsis, which serializes to an invalid character
-  // in the Telegram Bot API payload.
-  return `${sliceUtf16Safe(text, 0, TELEGRAM_PROGRESS_MAX_CHARS - 1).trimEnd()}…`;
+export const TELEGRAM_PROGRESS_MAX_CHARS = 300;
+
+/**
+ * Clips Telegram progress text to at most {@link maxLineChars} characters using
+ * the shared channel progress compaction: prose cuts at word boundaries, while
+ * command/path detail keeps its useful prefix and suffix around a middle
+ * ellipsis. Code-point-based cutting never leaves a lone surrogate before the
+ * ellipsis, which would serialize to an invalid character in the Telegram Bot
+ * API payload.
+ */
+export function clipTelegramProgressText(
+  text: string,
+  maxLineChars: number = TELEGRAM_PROGRESS_MAX_CHARS,
+): string {
+  return compactChannelProgressDraftLine(text, maxLineChars);
 }

--- a/scripts/plugin-sdk-surface-report.mts
+++ b/scripts/plugin-sdk-surface-report.mts
@@ -159,7 +159,8 @@ const defaultPublicDeprecatedExportsByEntrypointBudget = Object.freeze({
   // +1: shared ingress error factory projected through the deprecated message barrel.
   // +1: shared ingress retention defaults projected through the deprecated message barrel.
   // +1: WhatsApp ack-policy bridge counted via channel-message's wildcard re-export.
-  "channel-message": 132,
+  // +1: canonical progress-line compaction projected via channel-outbound's wildcard re-export.
+  "channel-message": 133,
   // +2: Slack progress-draft render bridge (function + mode type).
   "channel-outbound": 2,
   // +2: WhatsApp ack-policy bridge (function + mode type).
@@ -331,7 +332,9 @@ export function readPluginSdkSurfaceBudgets(env: NodeJS.ProcessEnv = process.env
       // +2: strict session-agent resolution aliases preserve shipped Plugin SDK behavior.
       // +1: manifest-owned plugin capability secret availability guard.
       // +1: canonical diagnostic flag checker through its focused subpath.
-      4355,
+      // +2: canonical boundary-aware progress-line compaction via channel-outbound
+      //     and channel-message's wildcard re-export.
+      4357,
       env,
     ),
     publicFunctionExports: readPluginSdkSurfaceBudgetEnv(
@@ -438,7 +441,9 @@ export function readPluginSdkSurfaceBudgets(env: NodeJS.ProcessEnv = process.env
       // +2: strict session-agent resolution aliases preserve shipped Plugin SDK behavior.
       // +1: manifest-owned plugin capability secret availability guard.
       // +1: canonical diagnostic flag checker through its focused subpath.
-      2592,
+      // +2: canonical boundary-aware progress-line compaction via channel-outbound
+      //     and channel-message's wildcard re-export.
+      2594,
       env,
     ),
     publicDeprecatedExports: readPluginSdkSurfaceBudgetEnv(
@@ -457,7 +462,8 @@ export function readPluginSdkSurfaceBudgets(env: NodeJS.ProcessEnv = process.env
       //     (voice-call/matrix runtime-doctor repair names, WhatsApp ack policy,
       //     Slack progress-draft render) so installed plugins survive upgrade (#124041 class).
       // -18: retire the expired August compatibility exports and messaging-targets subpath.
-      1134,
+      // +1: canonical progress-line compaction projected through the deprecated channel-message barrel.
+      1135,
       env,
     ),
     publicWildcardReexports: readPluginSdkSurfaceBudgetEnv(

--- a/src/channels/streaming.ts
+++ b/src/channels/streaming.ts
@@ -1017,7 +1017,12 @@ function compactPlainProgressLine(line: string, maxChars: number): string {
   return `${head}…`;
 }
 
-function compactChannelProgressDraftLine(line: string, maxChars: number): string {
+/**
+ * Canonical boundary-aware compaction for one channel progress line:
+ * prose cuts at word boundaries, while command/path detail keeps its
+ * useful prefix and suffix around a middle ellipsis.
+ */
+export function compactChannelProgressDraftLine(line: string, maxChars: number): string {
   const normalized = line.replace(/\s+/g, " ").trim();
   if (!normalized) {
     return "";

--- a/src/plugin-sdk/channel-outbound.ts
+++ b/src/plugin-sdk/channel-outbound.ts
@@ -93,6 +93,7 @@ export { logTypingFailure } from "../channels/logging.js";
 export {
   buildChannelProgressDraftLine,
   buildChannelProgressDraftLineForEntry,
+  compactChannelProgressDraftLine,
   createChannelProgressDraftGate,
   formatChannelProgressDraftLine,
   formatChannelProgressDraftLineForEntry,


### PR DESCRIPTION
Closes #130144

## What Problem This Solves

Telegram users watching agent work in progress drafts lost exactly the useful part of long lines: `clipTelegramProgressText` cut every progress line at a hardcoded 300 UTF-16 code units, mid-word for prose and mid-path for commands, so the failing command text or file path tail — the part that carries the information — vanished behind `…`. Operators also had no way to tune the per-line budget even though `channels.telegram.streaming.progress.maxLineChars` is already accepted by the shared streaming schema, contradicting the documented cross-channel contract ("Prose cuts at word boundaries; commands and paths keep useful suffixes") that Slack, Matrix, and Mattermost already honor.

## Why This Change Was Made

This repairs the existing configuration contract instead of adding a new Telegram-only knob: the native Telegram progress renderer now resolves the effective budget through the shared `resolveChannelProgressDraftMaxLineChars` seam (keeping Telegram's historical 300 default when the key is unset, so unconfigured previews are unchanged) and clips through the canonical boundary-aware compaction used by the shared compact progress renderer, now exported via `openclaw/plugin-sdk/channel-outbound` so channels don't diverge. Tool detail is compacted with the label sharing the line budget, mirroring how the shared renderer bounds the same composed line; code-point-based cutting preserves the existing surrogate safety (no lone surrogate before the ellipsis), and HTML escaping/rendering behavior is untouched. Non-goals: no new config keys, no changes to other channels' budgets.

## User Impact

- Long Telegram progress lines now cut prose at word boundaries and keep command/path prefixes and suffixes visible (e.g. the file name at the end of a long path), matching what Slack/Matrix/Mattermost users already see.
- `channels.telegram.streaming.progress.maxLineChars` now actually controls the Telegram progress-line budget; unset configs keep today's 300-character behavior.
- No change for unconfigured Telegram deployments: same 300 budget, same ellipsis style.

## Evidence

Focused tests (all green locally):

```
node scripts/run-vitest.mjs \
  extensions/telegram/src/truncate.test.ts \
  extensions/telegram/src/progress-draft-preview.test.ts \
  src/channels/streaming.lifecycle.test.ts
# Test Files  passed, Tests 28 passed
```

- `truncate.test.ts`: word-boundary prose cuts, command prefix/path suffix retention, configured budgets, surrogate-pair safety, trailing-whitespace handling, historical 300 default.
- `progress-draft-preview.test.ts`: configured budget cuts commentary prose at word boundaries; Bash command detail keeps the `file.ts` suffix around a middle ellipsis; default stays 300.
- Existing dispatch coverage stays green: `bot-message-dispatch.progress-{rendering,lifecycle,updates}.test.ts` + `draft-failures-progress` (91 tests), including the pre-existing `maxLineChars: 300` reasoning-line wiring test, plus the remaining `bot-message-dispatch.*` suites.
- `pnpm check:changed` passes end-to-end (typecheck core/core tests/extensions/extension tests/scripts, targeted lint, format, plugin-SDK surface budget ratchet bumped with attribution comments for the new seam export).

Example of the new clipping shape for a tool line (budget 60):

```
before: 🛠️ Bash  cat path/to/nested/nested/nested/nested/nested/nes…   (tail lost)
after:  🛠️ Bash  cat…ested/nested/nested/file.ts                        (suffix kept)
```
