### PR TITLE
test(codex): isolate native fixture provider credentials

### DIFF
--- a/src/gateway/gateway-codex-harness.fixture.test.ts
+++ b/src/gateway/gateway-codex-harness.fixture.test.ts
@@ -45,6 +45,9 @@ describe("native Codex fixture boundaries", () => {
             OPENCLAW_LIVE_USE_REAL_HOME: undefined,
             CODEX_HOME: customHome ? nativeHome : undefined,
             OPENAI_API_KEY: "synthetic-fixture-key",
+            CODEX_API_KEY: "synthetic-codex-key",
+            CEREBRAS_API_KEY: "synthetic-cerebras-key",
+            GROQ_API_KEY: "synthetic-groq-key",
             OPENAI_BASE_URL: baseUrl,
           },
           async () => {
@@ -69,6 +72,9 @@ describe("native Codex fixture boundaries", () => {
                 expect(instance.env.OPENAI_API_KEY).toBe(
                   authMode === "api-key" ? "synthetic-fixture-key" : undefined,
                 );
+                expect(instance.env.CODEX_API_KEY).toBeUndefined();
+                expect(instance.env.CEREBRAS_API_KEY).toBeUndefined();
+                expect(instance.env.GROQ_API_KEY).toBeUndefined();
                 expect(instance.env.OPENAI_BASE_URL).toBe(
                   authMode === "api-key" && baseUrl.trim() ? baseUrl : undefined,
                 );

--- a/test/helpers/gateway-codex-harness.ts
+++ b/test/helpers/gateway-codex-harness.ts
@@ -1,4 +1,5 @@
 import type { AgentEventPayload } from "../../src/infra/agent-events.js";
+import { listKnownProviderAuthEnvVarNames } from "../../src/secrets/provider-env-vars.js";
 // Native live fixture setup and capture shared with its offline boundary regressions.
 import { createOpenClawTestInstance } from "./openclaw-test-instance.js";
 
@@ -12,6 +13,7 @@ export function createCodexHarnessLiveInstance(
     state: { layout: "state-only" },
     gatewayToken: token,
     env: {
+      ...Object.fromEntries(listKnownProviderAuthEnvVarNames().map((name) => [name, undefined])),
       OPENCLAW_AGENT_RUNTIME: "codex",
       OPENCLAW_GATEWAY_TOKEN: token,
       OPENCLAW_ALLOW_SLOW_REPLY_TESTS: "1",


### PR DESCRIPTION
## Summary
The normal built Gateway in the Codex live fixture inherited unrelated provider credentials from its hosted environment. Those keys activated providers outside the fixture's intended scope and correctly triggered missing-plugin/capability-consent startup failures. Auth-file mode could also inherit a Codex API key, weakening what that lane actually proved.

Clear known provider credentials through the existing canonical metadata-backed scrubber before applying the fixture's explicit auth mode. Auth-file mode keeps native HOME/CODEX_HOME without API-key fallback; API-key mode restores only its selected OpenAI key and optional base URL. Production discovery, consent, authentication, and storage are unchanged.

## Validation
- Five existing native-home/auth-mode cases fail before the scrub; the owning fixture suite passes all six tests afterward. Synthetic Codex, Cerebras, and Groq keys prove the leak is removed.
- Full real auth-file Docker lane passed in87.64s: subagent fanout/native bridge, parent/resume/reset/status, image input, cron through MCP, guardian, and session deletion/native-history isolation.
- Full API-key sibling passed in45.97s. Each invocation ran one selected live test with one disabled alternate-lane skip; neither skipped its selected scenario.
- Exact source snapshot1a0e72b4f1ee4fcd7473e683d67c90fde367cb63 plus this two-file patch; Codex CLI0.150.1; built live image sha256:8bd0642e10150cdd5a26c36ed174bb5c3c9fca1c45b389559c7f244378dbd1f7. Linux dependencies were installed from the frozen lockfile. Testbox stopped after proof.
- Fresh independent Codex autoreview, manual fixture/credential-owner review, formatting and diff checks passed. Exact-head hosted CI required before landing.

The older in-process baseline's401 no longer reproduces through current main's built Gateway. Its precise cause is not proven, so this does not introduce a speculative production-auth change or attribute the401 to a specific mock.

Application production LOC0; test support+2 and regression assertions+6. No schema, new configuration, credential provisioning, or fallback changes. Raw account debug output remains private; proof summaries are redacted.
