### PR TITLE
fix(anthropic): stabilize SDK environment before session fingerprinting

### DIFF
--- a/extensions/anthropic/agent-sdk.runtime.test.ts
+++ b/extensions/anthropic/agent-sdk.runtime.test.ts
@@ -218,6 +218,7 @@ describe("Anthropic Agent SDK runtime ownership", () => {
       expect.objectContaining({
         env: {
           CLAUDE_AGENT_SDK_VERSION: "0.3.239",
+          NoDefaultCurrentDirectoryInExePath: "1",
           CLAUDE_CODE_OAUTH_TOKEN_FILE_DESCRIPTOR: "3",
         },
         secretInput: expect.objectContaining({ fd: 3 }),
@@ -226,7 +227,7 @@ describe("Anthropic Agent SDK runtime ownership", () => {
     );
     expect(emptyCredential).toEqual(
       expect.objectContaining({
-        env: { CLAUDE_AGENT_SDK_VERSION: "0.3.239" },
+        env: { CLAUDE_AGENT_SDK_VERSION: "0.3.239", NoDefaultCurrentDirectoryInExePath: "1" },
         execute: expect.any(Function),
       }),
     );

--- a/extensions/anthropic/cli-backend.ts
+++ b/extensions/anthropic/cli-backend.ts
@@ -39,10 +39,12 @@ type ClaudeCliPreparedExecution = CliBackendPreparedExecution & {
 };
 
 const CLAUDE_CLI_CREDENTIAL_FINGERPRINT_KEY = randomBytes(32);
-// Agent SDK query() writes this value into process.env. Seed it before core
+// SDK import and query() set these in process.env. Seed them before core
 // fingerprints the child env so the first resumed turn keeps its warm query.
-const CLAUDE_AGENT_SDK_VERSION =
-  anthropicPluginPackage.dependencies["@anthropic-ai/claude-agent-sdk"];
+const CLAUDE_AGENT_SDK_ENV = {
+  CLAUDE_AGENT_SDK_VERSION: anthropicPluginPackage.dependencies["@anthropic-ai/claude-agent-sdk"],
+  NoDefaultCurrentDirectoryInExePath: "1",
+};
 const CLAUDE_CLI_DEFAULT_ARGS = [
   "-p",
   "--output-format",
@@ -249,7 +251,7 @@ export function buildAnthropicCliBackend(
               }
             : undefined;
         const env = {
-          ...(agentSdkExecution ? { CLAUDE_AGENT_SDK_VERSION } : {}),
+          ...(agentSdkExecution ? CLAUDE_AGENT_SDK_ENV : {}),
           ...resolveClaudeCliAutoCompactEnv(context.contextTokenBudget),
           ...(context.contextWindow === "200k" ? { CLAUDE_CODE_DISABLE_1M_CONTEXT: "1" } : {}),
           ...resolveClaudeCliThinkingEnv(context.thinkingLevel, context.modelId),

--- a/extensions/anthropic/cli-shared.execution-env.test.ts
+++ b/extensions/anthropic/cli-shared.execution-env.test.ts
@@ -1,7 +1,45 @@
+import { execFileSync } from "node:child_process";
+import { createRequire } from "node:module";
+import { pathToFileURL } from "node:url";
 import { describe, expect, it } from "vitest";
+import { buildAnthropicCliBackend } from "./cli-backend.js";
 import { resolveClaudeCliThinkingEnv } from "./cli-shared.js";
 
 describe("Claude CLI execution environment", () => {
+  it("keeps the prepared child environment stable across the real SDK's first import", async () => {
+    const prepared = await buildAnthropicCliBackend().prepareExecution?.({
+      workspaceDir: "/tmp/openclaw-workspace",
+      provider: "claude-cli",
+      modelId: "claude-sonnet-4-6",
+      executionMode: "agent",
+    });
+    // A separate process preserves the first-import order even if another test loaded the SDK.
+    const changedKeys = execFileSync(
+      process.execPath,
+      [
+        "--input-type=module",
+        "-e",
+        `
+          const preparedEnv = JSON.parse(process.argv[1]);
+          const before = { ...process.env, ...preparedEnv };
+          await import(process.argv[2]);
+          const after = { ...process.env, ...preparedEnv };
+          const keys = [...new Set([...Object.keys(before), ...Object.keys(after)])];
+          process.stdout.write(JSON.stringify(keys.filter((key) => before[key] !== after[key])));
+        `,
+        JSON.stringify(prepared?.env ?? {}),
+        pathToFileURL(createRequire(import.meta.url).resolve("@anthropic-ai/claude-agent-sdk"))
+          .href,
+      ],
+      {
+        encoding: "utf8",
+        env: { ...process.env, NoDefaultCurrentDirectoryInExePath: undefined },
+      },
+    );
+
+    expect(JSON.parse(changedKeys)).toEqual([]);
+  });
+
   it.each([
     ["high", { CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING: "1", MAX_THINKING_TOKENS: "16384" }],
     ["off", { MAX_THINKING_TOKENS: "0" }],


### PR DESCRIPTION
## Summary
Claude CLI started a new native process on its first resumed turn even when its prompt, workspace, credentials and tools were unchanged. Native history still worked, hiding the lost warm process behind successful replies.

The official Agent SDK mutates the host environment during its first import. OpenClaw imports that SDK lazily after recording the first child-environment fingerprint, so the next turn inherited an extra key and correctly rejected process reuse. Seed the SDK-owned environment values in the Anthropic prepared-execution owner before fingerprinting. Strict fingerprinting, authorization and lifecycle fencing remain intact; no warmup, ignored key, new configuration, or fallback is added.

Release note: Claude CLI preserves its warm native process on the first resumed turn by preparing SDK-owned environment defaults before session fingerprinting.

## Validation
- Import-only probes against exact SDK0.3.238 and current-main0.3.239 both show the same added NoDefaultCurrentDirectoryInExePath key. The actual failing live flow independently recorded it as the only unexpected environment difference.
- Real first-import regression failed before the fix and passes afterward.104 tests pass across prepared environment, SDK reuse/permissions, CLI config/auth, and generic live-session registry. Changed-prompt restart and stale-authority rejection remain covered.
- Real subscription Docker replay passed231.41s (238.39s total), with original first/resume ordering, unchanged native-generation equality, exact recall, and absence of the marker from canonical replay: https://github.com/openclaw/openclaw/actions/runs/33243495176 .
- API-key resume/MCP still fails its generation assertion after this fix; that mode has an additional MCP surface and remains under separate fingerprint investigation. No passing claim or assertion relaxation for it. Cache sibling is also being checked.
- Fresh independent Codex autoreview, manual SDK/owner/fingerprint review, formatting and targeted lint passed. Local typed lint stops in unrelated stale dependency declarations; exact-head hosted CI is required.

Production:+6/-4 (net+2); tests:+40/-1. The extra production lines encode the real SDK environment contract at its existing plugin owner. No public API, dependency pin, persisted data or schema change.
