### PR TITLE
fix: keep summary checks after custom compactor timeouts

### DIFF
--- a/docs/concepts/compaction.md
+++ b/docs/concepts/compaction.md
@@ -216,7 +216,7 @@ summarization. Configured provider output keeps the provider's existing
 validation semantics.
 
 <Note>
-If the provider fails or returns an empty result, OpenClaw falls back to built-in LLM summarization.
+If the provider fails or returns an empty result, OpenClaw falls back through the built-in safeguard summarizer and its configured quality checks. Provider-local timeouts do not bypass those checks; cancellation of the compaction request is still respected.
 </Note>
 
 ## Compaction vs pruning

--- a/docs/reference/session-management-compaction.md
+++ b/docs/reference/session-management-compaction.md
@@ -259,7 +259,7 @@ Plugins register a compaction provider via `registerCompactionProvider()` on the
 - Providers receive the same compaction instructions and identifier-preservation policy as the built-in path, and the safeguard still preserves recent-turn and split-turn suffix context after provider output.
 - Built-in safeguard summarization re-distills prior summaries with new messages instead of preserving the full previous summary verbatim.
 - Safeguard mode enables built-in summary quality audits by default. After final budgeting, the retained generated body must contain the required headings, and the exact artifact to be persisted must retain pending asks and exact identifiers. Corrective attempts stay within `qualityGuard.maxRetries`; exhaustion or a corrective generation failure cancels before append and leaves the original transcript authoritative. Set `qualityGuard.enabled: false` to skip this behavior. Configured compaction-provider output remains outside the built-in audit loop.
-- If the provider fails or returns an empty result, OpenClaw falls back to built-in LLM summarization automatically. Abort/timeout signals the caller explicitly triggered are re-thrown, not swallowed, so cancellation is always respected.
+- If the provider fails or returns an empty result, OpenClaw falls back to built-in LLM summarization automatically. Provider-local failures, including timeouts, stay in that guarded fallback and use the built-in quality audit when enabled. Abort/timeout signals the caller explicitly triggered are re-thrown, not swallowed, so cancellation is always respected.
 
 Source: `src/plugins/compaction-provider.ts`, `src/agents/agent-hooks/compaction-safeguard.ts`.
 

--- a/src/agents/agent-hooks/compaction-safeguard.ts
+++ b/src/agents/agent-hooks/compaction-safeguard.ts
@@ -17,7 +17,6 @@ import {
 } from "../../../packages/agent-core/src/harness/compaction/utils.js";
 import { classifyToolUseResultPairing } from "../../../packages/agent-core/src/harness/session/tool-result-pairing.js";
 import { extractSections } from "../../auto-reply/reply/post-compaction-context.js";
-import { isAbortError } from "../../infra/abort-signal.js";
 import { openRootFile } from "../../infra/boundary-file-read.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
@@ -43,7 +42,6 @@ import {
 } from "../compaction.js";
 import { collectTextContentBlocks } from "../content-blocks.js";
 import { buildCopilotDynamicHeaders, hasCopilotVisionInput } from "../copilot-dynamic-headers.js";
-import { isTimeoutError } from "../failover-error.js";
 import { stripRuntimeContextCustomMessages } from "../internal-runtime-context.js";
 import {
   buildSessionContext as buildCoreSessionContext,
@@ -1113,8 +1111,9 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
             `Compaction provider "${compactionProvider.id}" returned empty result, falling back to LLM.`,
           );
         } catch (err) {
-          // Caller cancellation and real transport timeouts remain terminal.
-          if (signal?.aborted || (!isAbortError(err) && isTimeoutError(err))) {
+          // Escaped hook errors fall through to raw core compaction. Keep provider-local
+          // failures in the audited fallback unless the caller aborted.
+          if (signal?.aborted) {
             throw err;
           }
           log.warn(

--- a/src/agents/sessions/agent-session-compaction.test.ts
+++ b/src/agents/sessions/agent-session-compaction.test.ts
@@ -5,7 +5,15 @@ import type {
   SimpleStreamOptions,
 } from "openclaw/plugin-sdk/llm";
 import { describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../../test/helpers/promise.js";
+import type { CompactionProvider } from "../../plugins/compaction-provider.js";
+import { requireActivePluginRegistry } from "../../plugins/runtime.js";
 import { MAX_OVERFLOW_COMPACTION_ATTEMPTS } from "../agent-compaction-constants.js";
+import {
+  getCompactionSafeguardRuntime,
+  setCompactionSafeguardRuntime,
+} from "../agent-hooks/compaction-safeguard-runtime.js";
+import compactionSafeguardExtension from "../agent-hooks/compaction-safeguard.js";
 import { subscribeEmbeddedAgentSession } from "../embedded-agent-subscribe.js";
 import { agentSessionSetContextReplacementHook } from "./agent-session-compaction.js";
 import {
@@ -23,6 +31,8 @@ import {
   createResourceLoader,
 } from "./agent-session-loop-resource-loader.test-support.js";
 import type { AgentSessionEvent } from "./agent-session-types.js";
+import { createEventBus } from "./event-bus.js";
+import { loadExtensionFromFactory } from "./extensions/loader.js";
 import { SessionManager } from "./session-manager.js";
 import { SettingsManager } from "./settings-manager.js";
 
@@ -68,6 +78,165 @@ function collectCompactionEnds(session: Awaited<ReturnType<typeof createTestSess
 }
 
 describe("AgentSession compaction", () => {
+  it.each([
+    { name: "provider timeout", errorName: "TimeoutError", cancelCaller: false, recovers: false },
+    {
+      name: "provider timeout recovery",
+      errorName: "TimeoutError",
+      cancelCaller: false,
+      recovers: true,
+    },
+    { name: "ordinary provider failure", errorName: "Error", cancelCaller: false, recovers: false },
+    { name: "provider-side abort", errorName: "AbortError", cancelCaller: false, recovers: true },
+    { name: "caller cancellation", errorName: "AbortError", cancelCaller: true, recovers: false },
+  ])(
+    "preserves the safeguard boundary after $name",
+    async ({ errorName, cancelCaller, recovers }) => {
+      // A synthetic API plus the registered stream keep both real summarizers offline.
+      const model = {
+        ...testModel,
+        api: "compaction-test-api",
+        contextWindow: 4_096,
+        maxTokens: 128,
+      };
+      const summary = recovers
+        ? [
+            "## Decisions",
+            "The old prompt was answered.",
+            "## Open TODOs",
+            "None.",
+            "## Constraints/Rules",
+            "Preserve the session history.",
+            "## Pending user asks",
+            "None.",
+            "## Exact identifiers",
+            "None.",
+          ].join("\n")
+        : "Core summary without required safeguard headings";
+      const sessionManager = SessionManager.inMemory();
+      sessionManager.appendMessage({ role: "user", content: "old prompt", timestamp: 1 });
+      sessionManager.appendMessage({
+        ...createAssistant(model, [{ type: "text", text: "old answer" }]),
+        timestamp: 2,
+      });
+      sessionManager.appendMessage({ role: "user", content: "latest prompt", timestamp: 3 });
+      const providerStarted = createDeferred();
+      const releaseProvider = createDeferred();
+      const summarize = vi.fn<CompactionProvider["summarize"]>(async () => {
+        providerStarted.resolve();
+        await releaseProvider.promise;
+        throw Object.assign(new Error("synthetic custom-provider failure"), { name: errorName });
+      });
+      const registration = {
+        provider: { id: "session-compaction-test", label: "Session compaction test", summarize },
+      };
+      const registry = requireActivePluginRegistry();
+      registry.compactionProviders.push(registration);
+      setCompactionSafeguardRuntime(sessionManager, {
+        provider: registration.provider.id,
+        model,
+        recentTurnsPreserve: 0,
+        qualityGuardEnabled: true,
+        qualityGuardMaxRetries: 0,
+      });
+      const network = vi
+        .spyOn(globalThis, "fetch")
+        .mockRejectedValue(new Error("Unexpected network request in compaction test"));
+      const eventBus = createEventBus();
+      try {
+        const resourceLoader = createResourceLoader();
+        const extensions = resourceLoader.getExtensions();
+        extensions.extensions.push(
+          await loadExtensionFromFactory(
+            compactionSafeguardExtension,
+            sessionManager.getCwd(),
+            eventBus,
+            extensions.runtime,
+          ),
+        );
+        streamMocks.streamSimple.mockImplementation(
+          (activeModel: Model, _context: Context, options?: SimpleStreamOptions) =>
+            createAssistantResultStream(
+              createAssistant(
+                activeModel,
+                [{ type: "text", text: summary }],
+                options?.signal?.aborted ? "aborted" : "stop",
+              ),
+            ),
+        );
+        const { session } = await createTestSession({
+          model,
+          sessionManager,
+          resourceLoader,
+          settingsManager: SettingsManager.inMemory({
+            compaction: { enabled: false, reserveTokens: 64, keepRecentTokens: 1 },
+            retry: { enabled: false },
+          }),
+        });
+        const entriesBefore = structuredClone(sessionManager.getEntries());
+        const messagesBefore = structuredClone(session.messages);
+        const compactionEnds = collectCompactionEnds(session);
+        const compaction = session.compact().then(
+          (result) => ({ status: "resolved", summary: result.summary }),
+          (error: unknown) => ({
+            status: "rejected",
+            error: error instanceof Error ? error.message : String(error),
+          }),
+        );
+        // Cancel through the public session API while the custom provider is in flight.
+        await Promise.race([providerStarted.promise, compaction]);
+        const callerSignal = summarize.mock.calls[0]?.[0].signal;
+        const callerAbortedAtProviderEntry = callerSignal?.aborted;
+        if (cancelCaller) {
+          session.abortCompaction();
+        }
+        releaseProvider.resolve();
+        const result = await compaction;
+        const appended = sessionManager
+          .getEntries()
+          .filter((entry) => entry.type === "compaction")
+          .map(({ summary: text, fromHook }) => ({ summary: text, fromHook }));
+
+        const observation = {
+          providerCalls: summarize.mock.calls.length,
+          callerAbortedAtProviderEntry,
+          callerAborted: callerSignal?.aborted,
+          result,
+          outcomes: compactionEnds.map((event) => event.outcome.status),
+          appended,
+        };
+        expect.soft(observation).toMatchObject({
+          providerCalls: 1,
+          callerAbortedAtProviderEntry: false,
+          callerAborted: cancelCaller,
+          result: recovers ? { status: "resolved", summary } : { status: "rejected" },
+          outcomes: [recovers ? "completed" : "aborted"],
+          appended: recovers ? [{ summary, fromHook: true }] : [],
+        });
+        // The guarded pipeline may chunk the history; do not pin its request count.
+        if (!cancelCaller) {
+          expect(streamMocks.streamSimple).toHaveBeenCalled();
+        }
+        if (!recovers) {
+          expect.soft(sessionManager.getEntries()).toEqual(entriesBefore);
+          expect.soft(session.messages).toEqual(messagesBefore);
+        }
+        if (!cancelCaller && !recovers) {
+          expect(getCompactionSafeguardRuntime(sessionManager)?.cancellation?.reason).toContain(
+            "failed quality checks",
+          );
+        }
+        expect(network.mock.calls.length).toBe(0);
+      } finally {
+        releaseProvider.resolve();
+        setCompactionSafeguardRuntime(sessionManager, null);
+        registry.compactionProviders.splice(registry.compactionProviders.indexOf(registration), 1);
+        eventBus.clear();
+        network.mockRestore();
+      }
+    },
+  );
+
   it("preserves the automatic authentication failure as a reasoned skip", async () => {
     const { session, modelRegistry } = await createTestSession({
       settingsManager: createAutoCompactionSettings(),


### PR DESCRIPTION
Closes #132510 — custom compaction-provider timeouts bypassing safeguard validation.

## What Problem This Solves

Fixes an issue where operators using a custom compaction provider could have an invalid fallback summary accepted when that provider timed out, even with safeguard quality checks enabled. `/compact` could report success and replace active context with the unaudited summary. Original transcript entries remained durable; this is not a permanent transcript-loss claim.

## Why This Change Was Made

The custom-provider catch rethrew errors classified as timeouts. The extension dispatcher intentionally isolates handler exceptions, so the escaped error became an absent hook result and allowed raw core compaction to proceed without the safeguard's quality audit. The catch now lets only actual caller-signal cancellation escape; provider-local failures use the existing guarded built-in fallback.

This restores the documented provider-failure recovery path rather than introducing terminal provider timeouts or changing generic extension isolation. Successful custom-provider output retains its existing provider-owned validation. Ordinary errors, empty results, provider-side aborts, caller cancellation, and bounded quality correction keep their established owners. Two unused error-classifier imports are removed; no new helper, configuration option, API, dependency, schema, or retry loop is added.

The timeout escape originated in [the pluggable compaction registry](https://github.com/openclaw/openclaw/pull/56224) and was explicitly retained by [the provider-side AbortError repair](https://github.com/openclaw/openclaw/pull/97504). That historical intent did not make provider timeouts terminal through the real extension dispatcher: they fell through to raw core summarization. This repair keeps that reachable recovery but restores the documented safeguard boundary; it does not retry the custom provider.

## User Impact

Custom-compactor timeouts no longer bypass configured summary checks. Valid fallback output can still recover; invalid output produces a visible failure without appending a compaction or replacing active history. Caller cancellation remains authoritative. No operator migration or configuration change is required.

The behavior is clarified in the [compaction guide](https://docs.openclaw.ai/concepts/compaction) and [custom-provider reference](https://docs.openclaw.ai/reference/session-management-compaction#pluggable-compaction-providers).

## Evidence

**Exact-head CI is green:** [run 33246580422](https://github.com/openclaw/openclaw/actions/runs/33246580422) completed successfully for `ccf5f852fec3c7131d131754000f8bfeb54c7f98`; the repository watcher reported `GREEN` with no pending relevant checks. [ClawSweeper's exact-head review](https://github.com/openclaw/openclaw/pull/132536#issuecomment-5461689460) found no actionable correctness/security issue. Its sole before-merge item was incomplete CI, now satisfied.

**Before/after regression:** the new table composes the real safeguard factory, extension dispatcher, AgentSession, and core compactor. Only the custom provider and model stream are synthetic, with external fetch denied. Before the fix, both timeout cases failed: invalid output was accepted and both summaries were appended with `fromHook: false`; 15 controls passed. After the fix, all 17 session cases pass, including valid timeout recovery, invalid-output rejection, ordinary failure, provider-side abort recovery, and actual in-flight caller cancellation.

**Owner and sibling coverage: 325 distinct passing cases.**

```bash
node scripts/run-vitest.mjs src/agents/sessions/agent-session-compaction.test.ts
```

```bash
node scripts/run-vitest.mjs src/agents/embedded-agent-runner/compact.hooks.test.ts src/agents/agent-hooks/compaction-safeguard.test.ts
```

The sibling suites cover existing successful provider output, ordinary/empty-result fallback, caller aborts, quality retries, preserved turns, budgets, model fallback, and explicit-model boundaries. The final test-helper correction was verified by another passing 17-case session run; repeated cases are not added to the total.

**Build and static validation:** normal `pnpm build` passed with the final production bytes. The final canonical changed check passed all 29 selected stages, including core/core-test typechecks, typed lint, formatting, dead exports, import cycles, and state/boundary guards. Its earlier failures were test-only typing/lint issues, fixed by using the existing `createDeferred()` helper rather than changing compiler settings or adding suppressions.

```bash
pnpm build
```

```bash
node scripts/check-changed.mjs -- docs/concepts/compaction.md docs/reference/session-management-compaction.md src/agents/agent-hooks/compaction-safeguard.ts src/agents/sessions/agent-session-compaction.test.ts
```

**Real Gateway / mock-provider proof: both cells PASS.** One fresh private-QA build on [Blacksmith Testbox run 33246064519](https://github.com/openclaw/openclaw/actions/runs/33246064519), lease `tbx_01m16e9psn8awj5a74tgfgsvkf`, exercised inbound `qa-channel /compact` through a normally discovered and enabled ephemeral plugin using public `registerCompactionProvider`. The plugin threw `TimeoutError` with its actual caller signal active. The built Gateway used the stock mock OpenAI Responses HTTP server, default quality checks, the default single corrective retry, and default three-turn preservation.

| Observation | Valid fallback | Invalid fallback |
| --- | --- | --- |
| Custom-provider calls | 1, active caller signal | 1, active caller signal |
| Built-in summary HTTP requests | 1 | 2: initial plus bounded correction |
| Quality result | Accepted | Completed ask incorrectly marked pending; correction also rejected |
| Persisted compaction | 1, `fromHook: true`, 909-character summary | None |
| Compaction count | Incremented once | Unchanged |
| Delivered result | Success | Visible quality failure |
| Follow-up | Original model, accepted summary plus retained tail | Original model, intact original history |

Both cells retained original durable messages, the session/route/model preferences, and a successful ordinary follow-up with no additional compaction. All 37 recorded checks per cell passed; source/build/plugin identities remained stable, Gateway process trees stopped, owned ports closed, and temporary state/plugin homes were removed. The owned build home was also removed and the Testbox lease was stopped before committing.

```json
{
  "proofMode": "real-built-gateway/qa-channel/mock-provider-http",
  "beforeProof": "composed real Session/ExtensionRunner regression: 2 expected failures, 15 passes",
  "candidateCommit": "ccf5f852fec3c7131d131754000f8bfeb54c7f98",
  "candidateBase": "d2d2ff23cfc387c8f6a364408a85cae385f50898",
  "candidateFullIndexPatchSha256": "dfd93aa620c549cb9708e1ee9831a9936cf25eaa8be27ea871d5a4811b47fe6a",
  "driverSha256": "07a53aa5646bb0bb24812dd1f582751bb20a229e30e4fd3d1686feaf04434cea",
  "validFallback": { "verdict": "PASS", "summaryRequests": 1, "acceptedCompactions": 1, "fromHook": true },
  "invalidFallback": { "verdict": "PASS", "summaryRequests": 2, "acceptedCompactions": 0, "visibleQualityFailure": true },
  "originalModelFollowup": "PASS in both cells",
  "sourceBuildPluginIdentity": "PASS in both cells",
  "gatewayCleanup": "PASS in both cells"
}
```

Proof limits: this is mock-provider HTTP/Gateway evidence, not authenticated external-provider or native Codex proof. Before behavior is demonstrated by the composed regression, not a baseline Gateway run. The negative control uses semantically invalid stock mock output, not malformed HTTP/JSON. Actual caller cancellation is covered by the composed session regression. No real credentials, operator state, or native events were used. Git's host-dependent abbreviated object IDs initially produced different patch digests for identical files; full-index serialization and cross-checks against the retained original build record resolved that without changing source or weakening identity assertions.

**Review and size:** two isolated Codex-backed P0 autoreviews reported no actionable findings; they were static reviews and ran no tests. Production `+3/-4` (net **-1**); tests `+169/-0`; docs `+2/-2`. AI-assisted; reviewed and verified by the maintainer session.
