### PR TITLE
fix(acpx): preserve argv agent commands so ACP adapters start on Windows

### DIFF
--- a/extensions/acpx/src/codex-auth-bridge.migration.test.ts
+++ b/extensions/acpx/src/codex-auth-bridge.migration.test.ts
@@ -28,10 +28,6 @@ beforeEach(async () => {
   });
 });
 
-function quoteArg(value: string): string {
-  return JSON.stringify(value);
-}
-
 function restoreEnv(name: keyof typeof previousEnv): void {
   const value = previousEnv[name];
   if (value === undefined) {
@@ -62,14 +58,36 @@ function generatedClaudePaths(stateDir: string): {
   };
 }
 
-function expectCodexWrapperCommand(command: string | undefined, wrapperPath: string): void {
-  expect(command).toContain(quoteArg(process.execPath));
-  expect(command).toContain(quoteArg(wrapperPath));
+function commandText(command: string | string[] | undefined): string {
+  return Array.isArray(command) ? command.join(" ") : (command ?? "");
 }
 
-function expectClaudeWrapperCommand(command: string | undefined, wrapperPath: string): void {
-  expect(command).toContain(quoteArg(process.execPath));
-  expect(command).toContain(quoteArg(wrapperPath));
+function commandArgv(command: string | string[] | undefined): string[] {
+  // Generated wrapper commands are already argv; only legacy string commands
+  // still need splitting.
+  return Array.isArray(command) ? [...command] : splitCommandParts(command ?? "");
+}
+
+function expectWrapperArgv(command: string | string[] | undefined, wrapperPath: string): void {
+  // Wrapper commands must stay argv: acpx rejects raw command strings on Windows
+  // because the executable/argument boundaries are ambiguous there.
+  expect(Array.isArray(command)).toBe(true);
+  expect(command).toContain(process.execPath);
+  expect(command).toContain(wrapperPath);
+}
+
+function expectCodexWrapperCommand(
+  command: string | string[] | undefined,
+  wrapperPath: string,
+): void {
+  expectWrapperArgv(command, wrapperPath);
+}
+
+function expectClaudeWrapperCommand(
+  command: string | string[] | undefined,
+  wrapperPath: string,
+): void {
+  expectWrapperArgv(command, wrapperPath);
 }
 
 afterEach(async () => {
@@ -116,17 +134,18 @@ describe("prepareAcpxCodexAuthConfig command migration", () => {
     });
 
     expectCodexWrapperCommand(resolved.agents.codex, generated.wrapperPath);
-    expect(resolved.agents.codex).not.toContain("npx @zed-industries/codex-acp@0.12.0");
-    expect(resolved.agents.codex).not.toContain(quoteArg("-c"));
-    expect(resolved.agents.codex).toContain(quoteArg(OPENCLAW_CODEX_CONFIG_ARG));
+    expect(commandText(resolved.agents.codex)).not.toContain(
+      "npx @zed-industries/codex-acp@0.12.0",
+    );
+    // argv entries are compared as whole arguments, not as quoted substrings.
+    expect(resolved.agents.codex).not.toContain("-c");
+    expect(resolved.agents.codex).toContain(OPENCLAW_CODEX_CONFIG_ARG);
     expect(resolved.agents.codex).toContain(
-      quoteArg(
-        JSON.stringify({
-          model: "gpt-5.4",
-          model_reasoning_effort: "high",
-          mcp_servers: { "foo.bar": { command: "node", args: ["server.js"] } },
-        }),
-      ),
+      JSON.stringify({
+        model: "gpt-5.4",
+        model_reasoning_effort: "high",
+        mcp_servers: { "foo.bar": { command: "node", args: ["server.js"] } },
+      }),
     );
     const isolatedConfig = await fs.readFile(generated.configPath, "utf8");
     expect(isolatedConfig).toContain('[mcp_servers."foo.bar"]');
@@ -138,7 +157,7 @@ describe("prepareAcpxCodexAuthConfig command migration", () => {
     expect(wrapper).toContain("CODEX_HOME: codexHome");
     expect(wrapper).not.toContain(sourceCodexHome);
 
-    const [nodePath, wrapperPath, ...wrapperArgs] = splitCommandParts(resolved.agents.codex ?? "");
+    const [nodePath, wrapperPath, ...wrapperArgs] = commandArgv(resolved.agents.codex);
     if (!nodePath || !wrapperPath) {
       throw new Error("expected generated Codex ACP wrapper command");
     }
@@ -190,7 +209,7 @@ describe("prepareAcpxCodexAuthConfig command migration", () => {
     });
 
     expectCodexWrapperCommand(resolved.agents.codex, generated.wrapperPath);
-    const commandParts = splitCommandParts(resolved.agents.codex ?? "");
+    const commandParts = commandArgv(resolved.agents.codex);
     expect(commandParts.slice(2)).toStrictEqual([
       "cli",
       "-c",
@@ -293,8 +312,8 @@ describe("prepareAcpxCodexAuthConfig command migration", () => {
     });
 
     expectCodexWrapperCommand(resolved.agents.codex, generated.wrapperPath);
-    expect(resolved.agents.codex).not.toContain(quoteArg("-c"));
-    expect(resolved.agents.codex).toContain(quoteArg(JSON.stringify({ model: "gpt-5.4" })));
+    expect(resolved.agents.codex).not.toContain("-c");
+    expect(resolved.agents.codex).toContain(JSON.stringify({ model: "gpt-5.4" }));
   });
 
   it("normalizes an explicitly configured Claude ACP npx command to the local wrapper", async () => {

--- a/extensions/acpx/src/codex-auth-bridge.test.ts
+++ b/extensions/acpx/src/codex-auth-bridge.test.ts
@@ -29,10 +29,6 @@ beforeEach(async () => {
   });
 });
 
-function quoteArg(value: string): string {
-  return JSON.stringify(value);
-}
-
 function restoreEnv(name: keyof typeof previousEnv): void {
   const value = previousEnv[name];
   if (value === undefined) {
@@ -63,14 +59,26 @@ function generatedClaudePaths(stateDir: string): {
   };
 }
 
-function expectCodexWrapperCommand(command: string | undefined, wrapperPath: string): void {
-  expect(command).toContain(quoteArg(process.execPath));
-  expect(command).toContain(quoteArg(wrapperPath));
+function expectWrapperArgv(command: string | string[] | undefined, wrapperPath: string): void {
+  // Wrapper commands must stay argv: acpx rejects raw command strings on Windows
+  // because the executable/argument boundaries are ambiguous there.
+  expect(Array.isArray(command)).toBe(true);
+  expect(command).toContain(process.execPath);
+  expect(command).toContain(wrapperPath);
 }
 
-function expectClaudeWrapperCommand(command: string | undefined, wrapperPath: string): void {
-  expect(command).toContain(quoteArg(process.execPath));
-  expect(command).toContain(quoteArg(wrapperPath));
+function expectCodexWrapperCommand(
+  command: string | string[] | undefined,
+  wrapperPath: string,
+): void {
+  expectWrapperArgv(command, wrapperPath);
+}
+
+function expectClaudeWrapperCommand(
+  command: string | string[] | undefined,
+  wrapperPath: string,
+): void {
+  expectWrapperArgv(command, wrapperPath);
 }
 
 function expectWrapperToContainPathSuffix(wrapper: string, pathSuffix: string[]): void {

--- a/extensions/acpx/src/codex-auth-bridge.ts
+++ b/extensions/acpx/src/codex-auth-bridge.ts
@@ -745,8 +745,10 @@ async function writeClaudeAcpWrapper(baseDir: string, installedBinPath?: string)
   return wrapperPath;
 }
 
-function buildWrapperCommand(wrapperPath: string, args: string[] = []): string {
-  return [process.execPath, wrapperPath, ...args].map(quoteCommandPart).join(" ");
+function buildWrapperCommand(wrapperPath: string, args: string[] = []): string[] {
+  // Return argv rather than a joined command line: acpx rejects raw command
+  // strings on Windows and needs explicit executable/argument boundaries.
+  return [process.execPath, wrapperPath, ...args];
 }
 
 function isAcpPackageSpec(value: string, packageName: string): boolean {
@@ -764,16 +766,18 @@ function isPackageRunnerCommand(value: string): boolean {
   return /^(?:npx|npm|pnpm|bunx)(?:\.cmd|\.exe)?$/i.test(basename(value));
 }
 
+function toConfiguredCommandParts(command: string | string[] | undefined): string[] {
+  // Configured commands arrive either as argv, which already carries argument
+  // boundaries, or as a legacy shell string that still has to be split.
+  return Array.isArray(command) ? [...command] : splitCommandParts(command?.trim() ?? "");
+}
+
 function extractConfiguredAdapterArgs(params: {
-  configuredCommand?: string;
+  configuredCommand?: string | string[];
   packageName: string;
   binName: string;
 }): string[] | undefined {
-  const trimmedConfiguredCommand = params.configuredCommand?.trim();
-  if (!trimmedConfiguredCommand) {
-    return [];
-  }
-  const parts = splitCommandParts(trimmedConfiguredCommand);
+  const parts = toConfiguredCommandParts(params.configuredCommand);
   if (!parts.length) {
     return [];
   }
@@ -879,7 +883,9 @@ type CodexAdapterLaunch = {
   migratedConfig?: Record<string, unknown>;
 };
 
-function resolveCodexAdapterLaunch(configuredCommand?: string): CodexAdapterLaunch | undefined {
+function resolveCodexAdapterLaunch(
+  configuredCommand?: string | string[],
+): CodexAdapterLaunch | undefined {
   const legacyAdapterArgs = extractConfiguredAdapterArgs({
     configuredCommand,
     packageName: LEGACY_CODEX_ACP_PACKAGE,
@@ -910,14 +916,17 @@ function resolveCodexAdapterLaunch(configuredCommand?: string): CodexAdapterLaun
   return { args: maintainedAdapterArgs };
 }
 
-function buildCodexAcpWrapperCommand(wrapperPath: string, configuredCommand?: string): string {
+function buildCodexAcpWrapperCommand(
+  wrapperPath: string,
+  configuredCommand?: string | string[],
+): string[] {
   const launch = resolveCodexAdapterLaunch(configuredCommand);
   if (launch) {
     return buildWrapperCommand(wrapperPath, launch.args);
   }
   return buildWrapperCommand(wrapperPath, [
     RUN_CONFIGURED_COMMAND_SENTINEL,
-    ...splitCommandParts(configuredCommand?.trim() ?? ""),
+    ...toConfiguredCommandParts(configuredCommand),
   ]);
 }
 
@@ -935,7 +944,10 @@ async function persistMigratedCodexMcpConfig(params: {
   await fs.writeFile(configPath, stringifyToml(merged as TomlTableWithoutBigInt), "utf8");
 }
 
-function buildClaudeAcpWrapperCommand(wrapperPath: string, configuredCommand?: string): string {
+function buildClaudeAcpWrapperCommand(
+  wrapperPath: string,
+  configuredCommand?: string | string[],
+): string | string[] {
   const configuredAdapterArgs = extractConfiguredAdapterArgs({
     configuredCommand,
     packageName: CLAUDE_ACP_PACKAGE,
@@ -943,6 +955,11 @@ function buildClaudeAcpWrapperCommand(wrapperPath: string, configuredCommand?: s
   });
   if (configuredAdapterArgs) {
     return buildWrapperCommand(wrapperPath, configuredAdapterArgs);
+  }
+  // A command that is not a Claude ACP adapter is forwarded untouched, in
+  // whichever form it was configured.
+  if (Array.isArray(configuredCommand)) {
+    return configuredCommand.length > 0 ? [...configuredCommand] : buildWrapperCommand(wrapperPath);
   }
   return configuredCommand?.trim() || buildWrapperCommand(wrapperPath);
 }

--- a/extensions/acpx/src/config-schema.ts
+++ b/extensions/acpx/src/config-schema.ts
@@ -56,7 +56,7 @@ export type ResolvedAcpxPluginConfig = {
   openClawToolsMcpBridge: boolean;
   timeoutSeconds?: number;
   mcpServers: Record<string, McpServerConfig>;
-  agents: Record<string, string>;
+  agents: Record<string, string | string[]>;
 };
 
 const nonEmptyTrimmedString = (message: string) =>

--- a/extensions/acpx/src/process-lease.ts
+++ b/extensions/acpx/src/process-lease.ts
@@ -190,10 +190,21 @@ function quoteEnvValue(value: string): string {
 }
 
 function appendAcpxLeaseArgs(params: {
-  command: string;
+  command: string | string[];
   leaseId: string;
   gatewayInstanceId: string;
-}): string {
+}): string | string[] {
+  if (Array.isArray(params.command)) {
+    // Argv elements are passed to the process verbatim, so the lease identity
+    // is appended unquoted: shell quoting would become part of the value.
+    return [
+      ...params.command,
+      OPENCLAW_ACPX_LEASE_ID_ARG,
+      params.leaseId,
+      OPENCLAW_GATEWAY_INSTANCE_ID_ARG,
+      params.gatewayInstanceId,
+    ];
+  }
   return [
     params.command,
     OPENCLAW_ACPX_LEASE_ID_ARG,
@@ -208,6 +219,21 @@ export function withAcpxLeaseEnvironment(params: {
   command: string;
   leaseId: string;
   gatewayInstanceId: string;
-}): string {
+}): string;
+export function withAcpxLeaseEnvironment(params: {
+  command: string[];
+  leaseId: string;
+  gatewayInstanceId: string;
+}): string[];
+export function withAcpxLeaseEnvironment(params: {
+  command: string | string[];
+  leaseId: string;
+  gatewayInstanceId: string;
+}): string | string[];
+export function withAcpxLeaseEnvironment(params: {
+  command: string | string[];
+  leaseId: string;
+  gatewayInstanceId: string;
+}): string | string[] {
   return appendAcpxLeaseArgs(params);
 }

--- a/extensions/acpx/src/runtime.test.ts
+++ b/extensions/acpx/src/runtime.test.ts
@@ -1325,9 +1325,22 @@ describe("AcpxRuntime fresh reset wrapper", () => {
       `npx @agentclientprotocol/codex-acp@1.6.0 ${OPENCLAW_CODEX_CONFIG_ARG} '{"model":"gpt-5.4","model_reasoning_effort":"medium"}'`,
     );
     expect(testing.isCodexAcpCommand("openclaw acp")).toBe(false);
-    expect(testing.normalizeAgentCommand(["node", "/tmp/codex acp/index.js", "--label", ""])).toBe(
-      "node '/tmp/codex acp/index.js' --label ''",
-    );
+    // argv survives verbatim, including a deliberately empty argument that
+    // shell quoting could not round-trip on Windows.
+    expect(
+      testing.normalizeAgentCommand(["node", "/tmp/codex acp/index.js", "--label", ""]),
+    ).toEqual(["node", "/tmp/codex acp/index.js", "--label", ""]);
+    expect(
+      testing.appendCodexAcpConfigOverrides(["npx", "@agentclientprotocol/codex-acp@1.6.0"], {
+        model: "gpt-5.4",
+        reasoningEffort: "medium",
+      }),
+    ).toEqual([
+      "npx",
+      "@agentclientprotocol/codex-acp@1.6.0",
+      OPENCLAW_CODEX_CONFIG_ARG,
+      '{"model":"gpt-5.4","model_reasoning_effort":"medium"}',
+    ]);
   });
 
   it("passes gpt-5.5 Codex ACP startup through instead of blocking it", async () => {

--- a/extensions/acpx/src/runtime.ts
+++ b/extensions/acpx/src/runtime.ts
@@ -696,14 +696,40 @@ function quoteShellArg(value: string): string {
   return `'${value.replace(/'/g, "'\\''")}'`;
 }
 
-function normalizeAgentCommand(command: string | string[]): string | undefined {
-  const normalized = Array.isArray(command)
-    ? command.map((part) => quoteShellArg(part)).join(" ")
-    : command;
-  return normalized.trim() || undefined;
+function renderCommandLine(command: string | string[]): string {
+  // The boundary between the two representations: argv is what gets spawned,
+  // this rendering is what adapter detection, lease identity and diagnostics
+  // reason about. Quoting is applied only where a bare token would be ambiguous.
+  return Array.isArray(command) ? command.map(quoteShellArg).join(" ") : command;
 }
 
-function appendCodexAcpConfigOverrides(command: string, override: CodexAcpModelOverride): string {
+function normalizeAgentCommand(command: string | string[]): string | string[] | undefined {
+  // Preserve argv arrays: collapsing them into a shell string loses the
+  // executable/argument boundaries acpx requires on Windows, and quoting cannot
+  // round-trip deliberately empty arguments. Mirrors acpx' own registry
+  // normalization: a usable argv needs a non-empty executable, and every
+  // remaining element is kept verbatim.
+  if (Array.isArray(command)) {
+    return command.length > 0 && command[0]?.trim() ? [...command] : undefined;
+  }
+  return command.trim() || undefined;
+}
+
+// Overloads keep the command shape: a configured shell string stays a string
+// for the lease and diagnostics bookkeeping, argv stays argv for spawning.
+function appendCodexAcpConfigOverrides(command: string, override: CodexAcpModelOverride): string;
+function appendCodexAcpConfigOverrides(
+  command: string[],
+  override: CodexAcpModelOverride,
+): string[];
+function appendCodexAcpConfigOverrides(
+  command: string | string[],
+  override: CodexAcpModelOverride,
+): string | string[];
+function appendCodexAcpConfigOverrides(
+  command: string | string[],
+  override: CodexAcpModelOverride,
+): string | string[] {
   const config = {
     ...(override.model ? { model: override.model } : {}),
     ...(override.reasoningEffort ? { model_reasoning_effort: override.reasoningEffort } : {}),
@@ -711,22 +737,29 @@ function appendCodexAcpConfigOverrides(command: string, override: CodexAcpModelO
   if (Object.keys(config).length === 0) {
     return command;
   }
-  return `${command} ${OPENCLAW_CODEX_CONFIG_ARG} ${quoteShellArg(JSON.stringify(config))}`;
+  const serializedConfig = JSON.stringify(config);
+  if (Array.isArray(command)) {
+    return [...command, OPENCLAW_CODEX_CONFIG_ARG, serializedConfig];
+  }
+  return `${command} ${OPENCLAW_CODEX_CONFIG_ARG} ${quoteShellArg(serializedConfig)}`;
 }
 
 function createModelScopedAgentRegistry(params: {
   agentRegistry: AcpAgentRegistry;
   scope: AsyncLocalStorage<CodexAcpModelOverride | undefined>;
-  leaseCommand: (command: string) => string;
+  leaseCommand: (command: string | string[]) => string | string[];
 }): AcpAgentRegistry {
   return {
-    resolve(agentName: string): string {
+    resolve(agentName: string): string | string[] {
       const command = normalizeAgentCommand(params.agentRegistry.resolve(agentName)) ?? "";
       const override = params.scope.getStore();
+      // Adapter detection inspects the command line; argv is rendered only for
+      // that check, while the override itself preserves the original form.
+      const commandLine = renderCommandLine(command);
       if (
         !override ||
         normalizeAgentName(agentName) !== CODEX_ACP_AGENT_ID ||
-        !isCodexAcpCommand(command)
+        !isCodexAcpCommand(commandLine)
       ) {
         return params.leaseCommand(command);
       }
@@ -746,7 +779,11 @@ function resolveAgentCommand(params: {
   if (!normalizedAgentName) {
     return undefined;
   }
-  return normalizeAgentCommand(params.agentRegistry.resolve(normalizedAgentName));
+  // Callers of this helper reason about the command as text: adapter detection,
+  // session records and diagnostics all compare or persist strings. The registry
+  // keeps the original form for spawning.
+  const command = normalizeAgentCommand(params.agentRegistry.resolve(normalizedAgentName));
+  return command === undefined ? undefined : renderCommandLine(command);
 }
 
 function shouldUseBridgeSafeDelegateForCommand(command: string | undefined): boolean {
@@ -953,12 +990,14 @@ export class AcpxRuntime implements CompleteAcpRuntime {
     });
   }
 
-  private commandWithLaunchLease(command: string): string {
+  private commandWithLaunchLease(command: string | string[]): string | string[] {
     const launch = this.launchLeaseScope.getStore();
     if (!launch) {
       return command;
     }
-    if (command === launch.stableCommand) {
+    // Lease identity is tracked as text, so argv is matched through its rendered
+    // form. A reused lease replays the command recorded for it.
+    if (renderCommandLine(command) === launch.stableCommand) {
       return launch.resolvedCommand;
     }
     return withAcpxLeaseEnvironment({


### PR DESCRIPTION
> **AI-assisted PR.** Written with Claude Code (Opus 5). The author reviewed the change, reproduced both the failure and the fix on a Windows 11 machine, and understands what the code does. Details on how it was validated are in **Evidence**.

## What Problem This Solves

On Windows, the acpx backend never becomes healthy. `/acp doctor` reports:

```
registeredBackend: acpx
runtimeDoctor: error (embedded ACP runtime probe failed)
healthy: no
ACP error (ACP_BACKEND_UNAVAILABLE): ACP runtime backend is currently unavailable. Try again in a moment.
```

so `/acp spawn <id>` and `sessions_spawn({ runtime: "acp" })` are unusable on that platform.

The cause is a single type narrowing. acpx' agent registry resolves an agent to `string | string[]`, and acpx requires the structured form on Windows — its own guidance is that custom agents should use `agents.<name>.argv`, "which is required on Windows", because a raw command string leaves the executable/argument boundary ambiguous there.

`ResolvedAcpxPluginConfig`, however, declared:

```ts
agents: Record<string, string>;
```

That narrowing propagated outward and forced every command into a shell string. `buildWrapperCommand()` assembled argv and then collapsed it with `.map(quoteCommandPart).join(" ")`; `normalizeAgentCommand()` did the same to anything the registry returned. acpx received exactly the form it rejects on Windows.

The collapse is lossy beyond Windows, too: a deliberately empty argument (`--label ""`) cannot survive quoting and re-splitting, so it silently disappears from the launched process.

## Why This Change Was Made

Keep argv intact along the path that actually launches a process, and render a command line only where callers genuinely reason about text.

| File | Change |
| --- | --- |
| `config-schema.ts` | `agents: Record<string, string \| string[]>` — matches acpx' `resolve(): string \| string[]` |
| `codex-auth-bridge.ts` | Generated Codex/Claude wrapper commands stay argv; configured commands are accepted in either form |
| `runtime.ts` | `normalizeAgentCommand` preserves argv; `appendCodexAcpConfigOverrides` appends `--config` as argv elements |
| `process-lease.ts` | Lease identity is appended as argv elements, unquoted — shell quoting would otherwise become part of the value |

A new `renderCommandLine()` names the boundary between the two representations. Adapter detection, lease identity and diagnostics keep the previous string rendering — it is the old `normalizeAgentCommand()` behaviour, extracted and given a name rather than removed. Overloads on `appendCodexAcpConfigOverrides()` and `withAcpxLeaseEnvironment()` keep a string input a string, so the lease and session-record bookkeeping stays string-typed and no persisted format changes.

Every string-configured agent takes the same code path as before.

`normalizeAgentCommand()` mirrors acpx' own registry normalization: a usable argv needs a non-empty executable, and every remaining element is kept verbatim — including empty ones.

## User Impact

- ACP adapters start on Windows; `/acp doctor` reports `healthy: yes`.
- `agents.<name>` can be configured as an argv array on every platform. That is the only way to express an argument containing spaces or an intentionally empty argument.
- No change for existing string configuration.

## Evidence

**Runtime, Windows 11, OpenClaw 2026.8.1-beta.3.** Verified by applying the equivalent change to the installed plugin bundle and restarting the gateway — this source tree is a fresh clone of `main`, so the runtime proof comes from the patched bundle rather than a build of this branch.

Before:

```
runtimeDoctor: error (embedded ACP runtime probe failed)
healthy: no
```

After:

```
healthy: yes
capabilities: session/set_config_option, session/set_mode, session/status
claude
just now
```

The diagnostic chain in between is itself evidence that argv was reaching string-only code paths: `raw command strings on win32` → `command.trim is not a function` → `runtime_agent_mismatch` → `healthy: yes`. Each stage moved the failure one layer deeper.

**Static and unit validation on this branch.**

- `pnpm tsgo:extensions` — clean. The compiler located every place the widened type flows, which is how the four production sites above were found; the same boundary the runtime patch had arrived at empirically.
- acpx suite (`--project extension-acpx`), full JSON comparison of failing test names against a stash of this branch: **29 failures before, 29 after, identical by name.** No new failures and no test accidentally turned green. Those 29 are pre-existing Windows failures in `process-reaper.test.ts` (15), `runtime.test.ts` (8), `process-lease.test.ts` (3), `mcp-proxy.test.ts`, `pi-session-upstream-activity.test.ts` and `runtime-elicitation.process.test.ts` — unrelated to this change and not addressed here.
- `pnpm test:extension acpx` — 29 failed, 230 passed (259), matching the baseline exactly.
- `pnpm check:changed` — green, all lanes.

**Tests updated.** Three test files asserted the collapsed string form and now assert argv. The behavioural case worth calling out:

```ts
// argv survives verbatim, including a deliberately empty argument that
// shell quoting could not round-trip on Windows.
expect(
  testing.normalizeAgentCommand(["node", "/tmp/codex acp/index.js", "--label", ""]),
).toEqual(["node", "/tmp/codex acp/index.js", "--label", ""]);
```

This test caught a real defect in an earlier revision of the change, which dropped empty argv elements.

**Not run:** the `autoreview` skill — it is not present in this checkout, so it could not be run. Review was manual, plus the checks above.

**Out of scope:** the ACP session-spawn path has a separate failure after the backend is healthy (agent id mismatch, cf. #48136). This PR only addresses the argv contract.
