### PR TITLE
fix: preserve visible partial replies when provider turns fail

### DIFF
--- a/extensions/telegram/src/bot-message-dispatch-turn.ts
+++ b/extensions/telegram/src/bot-message-dispatch-turn.ts
@@ -224,8 +224,11 @@ export async function runTelegramDispatchTurn(turn: Turn) {
                       turn.rotateAnswerLaneWhenQueuedBlocksSettle = false;
                     } else if (
                       turn.answerLane.hasStreamedMessage &&
-                      !turn.activeAnswerDraftIsToolProgressOnly
+                      !turn.activeAnswerDraftIsToolProgressOnly &&
+                      (turn.activeAnswerBlockDelivery || turn.queuedAnswerBlockRotations.length > 0)
                     ) {
+                      // Only accepted blocks need a new message. A provider retry must
+                      // keep editing its unfinished preview instead of retaining it as final.
                       turn.rotateAnswerLaneWhenQueuedBlocksSettle = true;
                     }
                   });

--- a/extensions/telegram/src/bot-message-dispatch.draft-failures-progress.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.draft-failures-progress.test.ts
@@ -5,6 +5,7 @@ import {
   allDeliveredReplyTexts,
   describeTelegramDispatch,
   createContext,
+  createBot,
   createDirectSessionPayload,
   createStatusReactionController,
   createTelegramDraftStream,
@@ -199,6 +200,48 @@ describeTelegramDispatch("dispatchTelegramMessage draft-failures-progress", () =
       );
     },
   );
+
+  it("keeps a retried partial and its terminal failure in one Telegram message", async () => {
+    const actualDraft =
+      await vi.importActual<typeof import("./draft-stream.js")>("./draft-stream.js");
+    createTelegramDraftStream.mockImplementation(actualDraft.createTelegramDraftStream);
+    const bot = createBot();
+    const partialText = "A visible partial answer before the provider failed";
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
+      async ({ dispatcherOptions, replyOptions }) => {
+        await replyOptions?.onAssistantMessageStart?.();
+        await replyOptions?.onPartialReply?.({ text: partialText });
+        await replyOptions?.onAssistantMessageStart?.();
+        await replyOptions?.onPartialReply?.({ text: partialText });
+        await dispatcherOptions.deliver(
+          { text: "The model failed. Please try again.", isError: true },
+          { kind: "final" },
+        );
+        return { queuedFinal: true };
+      },
+    );
+
+    await dispatchWithContext({
+      bot,
+      context: createContext({
+        ctxPayload: createDirectSessionPayload(),
+        threadSpec: { id: undefined, scope: "none" },
+        replyThreadId: undefined,
+      }),
+      streamMode: "partial",
+      telegramCfg: { streaming: { mode: "partial" } },
+    });
+
+    expect(bot.api.sendMessage).toHaveBeenCalledOnce();
+    expect(bot.api.editMessageText).toHaveBeenLastCalledWith(
+      123,
+      1001,
+      `${partialText}\n\nThe model failed. Please try again.`,
+      expect.anything(),
+    );
+    expect(deliverReplies).not.toHaveBeenCalled();
+    expect(bot.api.deleteMessage).not.toHaveBeenCalled();
+  });
 
   it("clears a pending partial and sends one fallback after an unexpected reply failure", async () => {
     const { answerDraftStream } = setupDraftStreams();

--- a/extensions/telegram/src/bot-message-dispatch.draft-failures-progress.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.draft-failures-progress.test.ts
@@ -206,6 +206,9 @@ describeTelegramDispatch("dispatchTelegramMessage draft-failures-progress", () =
       await vi.importActual<typeof import("./draft-stream.js")>("./draft-stream.js");
     createTelegramDraftStream.mockImplementation(actualDraft.createTelegramDraftStream);
     const bot = createBot();
+    const sendMessage = vi.spyOn(bot.api, "sendMessage");
+    const editMessageText = vi.spyOn(bot.api, "editMessageText");
+    const deleteMessage = vi.spyOn(bot.api, "deleteMessage");
     const partialText = "A visible partial answer before the provider failed";
     dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
       async ({ dispatcherOptions, replyOptions }) => {
@@ -232,15 +235,15 @@ describeTelegramDispatch("dispatchTelegramMessage draft-failures-progress", () =
       telegramCfg: { streaming: { mode: "partial" } },
     });
 
-    expect(bot.api.sendMessage).toHaveBeenCalledOnce();
-    expect(bot.api.editMessageText).toHaveBeenLastCalledWith(
+    expect(sendMessage).toHaveBeenCalledOnce();
+    expect(editMessageText).toHaveBeenLastCalledWith(
       123,
       1001,
       `${partialText}\n\nThe model failed. Please try again.`,
       expect.anything(),
     );
     expect(deliverReplies).not.toHaveBeenCalled();
-    expect(bot.api.deleteMessage).not.toHaveBeenCalled();
+    expect(deleteMessage).not.toHaveBeenCalled();
   });
 
   it("clears a pending partial and sends one fallback after an unexpected reply failure", async () => {

--- a/src/auto-reply/reply/agent-runner-core.ts
+++ b/src/auto-reply/reply/agent-runner-core.ts
@@ -286,8 +286,7 @@ export async function handleReplyAgentRunError(
   error: unknown,
   context: {
     cfg: OpenClawConfig;
-    blockReplyPipeline: BlockReplyPipeline | null;
-    didDeliverVisiblePartialReply: () => boolean;
+    resolveVisibleReplyDelivery: () => Promise<boolean>;
     isHeartbeat: boolean;
     isRestartRecoveryArmed: () => boolean;
     replyOperation: ReplyOperation;
@@ -298,8 +297,7 @@ export async function handleReplyAgentRunError(
 ): Promise<ReplyPayload | undefined> {
   const {
     cfg,
-    blockReplyPipeline,
-    didDeliverVisiblePartialReply,
+    resolveVisibleReplyDelivery,
     isHeartbeat,
     isRestartRecoveryArmed,
     replyOperation,
@@ -356,19 +354,8 @@ export async function handleReplyAgentRunError(
     replyOperation.fail("run_failed", error);
     return returnWithQueuedFollowupDrain(knownFailurePayload);
   }
-  if (blockReplyPipeline) {
-    try {
-      await blockReplyPipeline.flush({ force: true });
-    } catch (flushError) {
-      logVerbose(
-        `failed to flush streamed reply blocks before surfacing run failure: ${String(flushError)}`,
-      );
-    }
-  }
-  const didDeliverVisibleReply =
-    (blockReplyPipeline?.didStreamTerminalReply?.() === true && !blockReplyPipeline.isAborted()) ||
-    didDeliverVisiblePartialReply();
-  if (!isHeartbeat && didDeliverVisibleReply && !replyOperation.abortSignal.aborted) {
+  const visibleReplyDelivered = await resolveVisibleReplyDelivery();
+  if (!isHeartbeat && visibleReplyDelivered && !replyOperation.abortSignal.aborted) {
     replyOperation.fail("run_failed", error);
     return returnWithQueuedFollowupDrain(
       buildTerminalAgentRunFailureReplyPayload({

--- a/src/auto-reply/reply/agent-runner-error-handler.ts
+++ b/src/auto-reply/reply/agent-runner-error-handler.ts
@@ -189,6 +189,7 @@ export async function handleAgentExecutionError(params: {
       payload: markAgentRunFailureReplyPayload({
         text: resolveExternalRunFailureTextForConversation({
           text: switchErrorText,
+          visibleReplyDelivered: turn.didDeliverVisiblePartialReply?.(),
           sessionCtx: turn.sessionCtx,
           isGenericRunnerFailure: !params.shouldSurfaceToControlUi,
           cfg: turn.followupRun.run.config,
@@ -505,6 +506,7 @@ export async function handleAgentExecutionError(params: {
                 : GENERIC_EXTERNAL_RUN_FAILURE_TEXT));
   const userVisibleFallbackText = resolveExternalRunFailureTextForConversation({
     text: fallbackText,
+    visibleReplyDelivered: turn.didDeliverVisiblePartialReply?.(),
     sessionCtx: turn.sessionCtx,
     isGenericRunnerFailure: externalRunFailureReply?.isGenericRunnerFailure ?? false,
     cfg: turn.followupRun.run.config,

--- a/src/auto-reply/reply/agent-runner-error-handler.ts
+++ b/src/auto-reply/reply/agent-runner-error-handler.ts
@@ -169,6 +169,7 @@ export async function handleAgentExecutionError(params: {
       params.state.pendingLifecycleTerminal = undefined;
       return { kind: "retry", liveModelSwitchError: err };
     }
+    const visibleReplyDelivered = await turn.resolveVisibleReplyDelivery?.();
     defaultRuntime.error(
       `Live model switch failed after ${MAX_LIVE_SWITCH_RETRIES} retries ` +
         `(${sanitizeForLog(err.provider)}/${sanitizeForLog(err.model)}). The requested model may be unavailable.`,
@@ -189,7 +190,7 @@ export async function handleAgentExecutionError(params: {
       payload: markAgentRunFailureReplyPayload({
         text: resolveExternalRunFailureTextForConversation({
           text: switchErrorText,
-          visibleReplyDelivered: turn.didDeliverVisiblePartialReply?.(),
+          visibleReplyDelivered,
           sessionCtx: turn.sessionCtx,
           isGenericRunnerFailure: !params.shouldSurfaceToControlUi,
           cfg: turn.followupRun.run.config,
@@ -506,7 +507,7 @@ export async function handleAgentExecutionError(params: {
                 : GENERIC_EXTERNAL_RUN_FAILURE_TEXT));
   const userVisibleFallbackText = resolveExternalRunFailureTextForConversation({
     text: fallbackText,
-    visibleReplyDelivered: turn.didDeliverVisiblePartialReply?.(),
+    visibleReplyDelivered: await turn.resolveVisibleReplyDelivery?.(),
     sessionCtx: turn.sessionCtx,
     isGenericRunnerFailure: externalRunFailureReply?.isGenericRunnerFailure ?? false,
     cfg: turn.followupRun.run.config,

--- a/src/auto-reply/reply/agent-runner-execute.ts
+++ b/src/auto-reply/reply/agent-runner-execute.ts
@@ -70,7 +70,7 @@ type ExecutePreparedReplyAgentRunInput = Pick<
   checkpointBeforeAgentReply: ReturnType<
     typeof createReplyRestartRecoveryClaimController
   >["checkpointBeforeAgentReply"];
-  didDeliverVisiblePartialReply: () => boolean;
+  resolveVisibleReplyDelivery: () => Promise<boolean>;
   getActiveIsNewSession: () => boolean;
   getActiveSessionEntry: () => SessionEntry | undefined;
   isHeartbeat: boolean;
@@ -339,7 +339,7 @@ export async function executePreparedReplyAgentRun(
           replyThreading: replyThreadingOverride ?? sessionCtx.ReplyThreading,
           replyOperation,
           opts: agentTurnOpts,
-          didDeliverVisiblePartialReply: context.didDeliverVisiblePartialReply,
+          resolveVisibleReplyDelivery: context.resolveVisibleReplyDelivery,
           typingSignals,
           blockReplyPipeline,
           blockStreamingEnabled,

--- a/src/auto-reply/reply/agent-runner-execute.ts
+++ b/src/auto-reply/reply/agent-runner-execute.ts
@@ -70,6 +70,7 @@ type ExecutePreparedReplyAgentRunInput = Pick<
   checkpointBeforeAgentReply: ReturnType<
     typeof createReplyRestartRecoveryClaimController
   >["checkpointBeforeAgentReply"];
+  didDeliverVisiblePartialReply: () => boolean;
   getActiveIsNewSession: () => boolean;
   getActiveSessionEntry: () => SessionEntry | undefined;
   isHeartbeat: boolean;
@@ -338,6 +339,7 @@ export async function executePreparedReplyAgentRun(
           replyThreading: replyThreadingOverride ?? sessionCtx.ReplyThreading,
           replyOperation,
           opts: agentTurnOpts,
+          didDeliverVisiblePartialReply: context.didDeliverVisiblePartialReply,
           typingSignals,
           blockReplyPipeline,
           blockStreamingEnabled,

--- a/src/auto-reply/reply/agent-runner-execution-provider-failures.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution-provider-failures.test.ts
@@ -131,7 +131,7 @@ describe("executeAgentTurn: provider failures", () => {
             },
           },
         },
-        { didDeliverVisiblePartialReply: () => partialDelivered },
+        { resolveVisibleReplyDelivery: async () => partialDelivered },
       );
 
       expect(result).toMatchObject({

--- a/src/auto-reply/reply/agent-runner-execution-provider-failures.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution-provider-failures.test.ts
@@ -3,6 +3,7 @@ import { formatBillingErrorMessage } from "../../agents/embedded-agent-helpers.j
 import { resolveMaxRunRetryIterations } from "../../agents/embedded-agent-runner/run/helpers.js";
 import { FailoverError } from "../../agents/failover-error.js";
 import { BILLING_ERROR_USER_MESSAGE } from "../../agents/failover/user-copy.js";
+import { LiveSessionModelSwitchError } from "../../agents/live-model-switch-error.js";
 import { ProviderAuthError } from "../../agents/model-auth.js";
 import { getReplyPayloadMetadata } from "../reply-payload.js";
 import type { TemplateContext } from "../templating.js";
@@ -102,6 +103,48 @@ describe("executeAgentTurn: provider failures", () => {
       if (result.kind === "final") {
         expect(result.payload.text).toBe(SILENT_REPLY_TOKEN);
       }
+    },
+  );
+
+  it.each(
+    NON_DIRECT_FAILURE_SURFACE_CASES.flatMap((surface) =>
+      ["provider", "live model switch"].map((failure) => ({ surface, failure })),
+    ),
+  )(
+    "surfaces $failure failure after an accepted partial in $surface.label chats",
+    async ({ surface: testCase, failure }) => {
+      let partialDelivered = false;
+      state.runEmbeddedAgentMock.mockImplementation(async (params: EmbeddedAgentParams) => {
+        await params.onPartialReply?.({ text: "partial answer" });
+        throw failure === "provider"
+          ? new Error("model stream failed")
+          : new LiveSessionModelSwitchError({ provider: "openai", model: "gpt-5.4" });
+      });
+
+      const result = await executeTestTurn(
+        {
+          sessionCtx: createNonDirectFailureSessionCtx(testCase),
+          opts: {
+            onPartialReply: () => {
+              partialDelivered = true;
+              return true;
+            },
+          },
+        },
+        { didDeliverVisiblePartialReply: () => partialDelivered },
+      );
+
+      expect(result).toMatchObject({
+        kind: "final",
+        payload: {
+          text:
+            failure === "provider"
+              ? GENERIC_RUN_FAILURE_TEXT
+              : expect.stringContaining("Model switch could not be completed"),
+          isError: true,
+        },
+      });
+      expect(state.runEmbeddedAgentMock).toHaveBeenCalledTimes(failure === "provider" ? 1 : 3);
     },
   );
 

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -495,7 +495,7 @@ async function executeAgentTurnInternalWithRetryState(
   const terminalFailurePayload = terminalRunFailed
     ? buildTerminalAgentRunFailureReplyPayload({
         isHeartbeat: params.isHeartbeat,
-        visibleReplyDelivered: params.didDeliverVisiblePartialReply?.() === true,
+        visibleReplyDelivered: (await params.resolveVisibleReplyDelivery?.()) === true,
         sessionCtx: params.sessionCtx,
         cfg: params.followupRun.run.config,
       })

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -495,7 +495,7 @@ async function executeAgentTurnInternalWithRetryState(
   const terminalFailurePayload = terminalRunFailed
     ? buildTerminalAgentRunFailureReplyPayload({
         isHeartbeat: params.isHeartbeat,
-        visibleReplyDelivered: false,
+        visibleReplyDelivered: params.didDeliverVisiblePartialReply?.() === true,
         sessionCtx: params.sessionCtx,
         cfg: params.followupRun.run.config,
       })

--- a/src/auto-reply/reply/agent-runner-execution.types.ts
+++ b/src/auto-reply/reply/agent-runner-execution.types.ts
@@ -81,7 +81,7 @@ export type AgentTurnParams = {
   replyThreading?: TemplateContext["ReplyThreading"];
   replyOperation?: ReplyOperation;
   opts?: InternalGetReplyOptions;
-  didDeliverVisiblePartialReply?: () => boolean;
+  resolveVisibleReplyDelivery?: () => Promise<boolean>;
   typingSignals: TypingSignaler;
   blockReplyPipeline: BlockReplyPipeline | null;
   blockStreamingEnabled: boolean;

--- a/src/auto-reply/reply/agent-runner-execution.types.ts
+++ b/src/auto-reply/reply/agent-runner-execution.types.ts
@@ -81,6 +81,7 @@ export type AgentTurnParams = {
   replyThreading?: TemplateContext["ReplyThreading"];
   replyOperation?: ReplyOperation;
   opts?: InternalGetReplyOptions;
+  didDeliverVisiblePartialReply?: () => boolean;
   typingSignals: TypingSignaler;
   blockReplyPipeline: BlockReplyPipeline | null;
   blockStreamingEnabled: boolean;

--- a/src/auto-reply/reply/agent-runner-failure-reply.ts
+++ b/src/auto-reply/reply/agent-runner-failure-reply.ts
@@ -111,8 +111,10 @@ export function resolveExternalRunFailureTextForConversation(params: {
   sessionCtx: ExternalFailureConversationContext;
   isGenericRunnerFailure: boolean;
   cfg?: OpenClawConfig;
+  visibleReplyDelivered?: boolean;
 }): string {
-  if (!isNonDirectConversationContext(params.sessionCtx)) {
+  // Group silence must not strand an already-visible partial without its terminal failure.
+  if (params.visibleReplyDelivered || !isNonDirectConversationContext(params.sessionCtx)) {
     return params.text;
   }
   if (!params.isGenericRunnerFailure && !params.text.includes(AGENT_FAILED_BEFORE_REPLY_TEXT)) {
@@ -318,17 +320,12 @@ export function buildTerminalAgentRunFailureReplyPayload(params: {
   const text = params.isHeartbeat
     ? HEARTBEAT_EXTERNAL_RUN_FAILURE_TEXT
     : GENERIC_EXTERNAL_RUN_FAILURE_TEXT;
-  // Once output is visible, hiding its terminal failure leaves a misleading partial reply.
-  // Keep normal group silence only for failures that produced no visible output.
   return markAgentRunFailureReplyPayload({
-    text: params.visibleReplyDelivered
-      ? text
-      : resolveExternalRunFailureTextForConversation({
-          text,
-          sessionCtx: params.sessionCtx,
-          isGenericRunnerFailure: true,
-          cfg: params.cfg,
-        }),
+    text: resolveExternalRunFailureTextForConversation({
+      ...params,
+      text,
+      isGenericRunnerFailure: true,
+    }),
   });
 }
 

--- a/src/auto-reply/reply/agent-runner-run.ts
+++ b/src/auto-reply/reply/agent-runner-run.ts
@@ -12,6 +12,7 @@ import {
   BLOCK_REPLY_SEND_TIMEOUT_MS,
   cleanupReplyAgentRun,
   handleReplyAgentRunError,
+  hasSuccessfulTerminalSourceReplyDelivery,
   refreshSessionEntryFromStore,
   resolveAdmittedRunSessionFile,
   type RunReplyAgentParams,
@@ -422,6 +423,20 @@ export async function runReplyAgent(
           buffer: createAudioAsVoiceBuffer({ isAudioPayload }),
         })
       : null;
+  const resolveVisibleReplyDelivery = async () => {
+    // Settle accepted or in-flight blocks before deciding whether a terminal failure may stay silent.
+    try {
+      await blockReplyPipeline?.flush({ force: true });
+    } catch (flushError) {
+      logVerbose(
+        `failed to flush streamed reply blocks before surfacing run failure: ${String(flushError)}`,
+      );
+    }
+    return (
+      didDeliverVisiblePartialReply ||
+      hasSuccessfulTerminalSourceReplyDelivery({ blockReplyPipeline })
+    );
+  };
   const replySessionKey = sessionKey ?? followupRun.run.sessionKey;
   const replyRouteThreadId = resolveRoutedDeliveryThreadId({
     ctx: sessionCtx,
@@ -558,7 +573,7 @@ export async function runReplyAgent(
       checkpointBeforeAgentReply,
       commandBody,
       defaultModel,
-      didDeliverVisiblePartialReply: () => didDeliverVisiblePartialReply,
+      resolveVisibleReplyDelivery,
       followupRun,
       getActiveIsNewSession: () => activeIsNewSession,
       getActiveSessionEntry: () => activeSessionEntry,
@@ -612,9 +627,8 @@ export async function runReplyAgent(
       replyOperation,
     );
     return await handleReplyAgentRunError(error, {
-      blockReplyPipeline,
       cfg,
-      didDeliverVisiblePartialReply: () => didDeliverVisiblePartialReply,
+      resolveVisibleReplyDelivery,
       isHeartbeat,
       isRestartRecoveryArmed,
       replyOperation,

--- a/src/auto-reply/reply/agent-runner-run.ts
+++ b/src/auto-reply/reply/agent-runner-run.ts
@@ -558,6 +558,7 @@ export async function runReplyAgent(
       checkpointBeforeAgentReply,
       commandBody,
       defaultModel,
+      didDeliverVisiblePartialReply: () => didDeliverVisiblePartialReply,
       followupRun,
       getActiveIsNewSession: () => activeIsNewSession,
       getActiveSessionEntry: () => activeSessionEntry,

--- a/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
+++ b/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
@@ -14,6 +14,7 @@ import {
   vi,
   type MockInstance,
 } from "vitest";
+import { createDeferred } from "../../../test/helpers/promise.js";
 import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
 import { buildCurrentRunRestartRecoveryClaim } from "../../agents/agent-command-restart-recovery.js";
 import {
@@ -1803,7 +1804,7 @@ describe("runReplyAgent heartbeat followup guard", () => {
               resetTriggered: false,
             })
           : undefined;
-      const deliveryStarted = Promise.withResolvers<void>();
+      const deliveryStarted = createDeferred<void>();
       let blockFlush: Promise<void> | undefined;
       const onBlockReply = vi.fn(async () => {
         deliveryStarted.resolve();

--- a/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
+++ b/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
@@ -1804,7 +1804,7 @@ describe("runReplyAgent heartbeat followup guard", () => {
               resetTriggered: false,
             })
           : undefined;
-      const deliveryStarted = createDeferred<void>();
+      const deliveryStarted = createDeferred();
       let blockFlush: Promise<void> | undefined;
       const onBlockReply = vi.fn(async () => {
         deliveryStarted.resolve();

--- a/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
+++ b/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
@@ -1745,6 +1745,35 @@ describe("runReplyAgent heartbeat followup guard", () => {
     },
   );
 
+  it.each([true, undefined, false])(
+    "reports provider failure after a group partial with visibility %s",
+    async (callbackResult) => {
+      const onPartialReply = vi.fn(async () => callbackResult);
+      state.runEmbeddedAgentMock.mockImplementationOnce(async (params: AgentRunParams) => {
+        await params.onPartialReply?.({ text: "partial answer" });
+        throw new Error("model stream failed");
+      });
+      const { run } = createMinimalRun({
+        blockStreamingEnabled: false,
+        opts: { onPartialReply, preserveProgressCallbackStartOrder: true },
+        sessionCtx: {
+          ChatType: "group",
+          SessionKey: "agent:test:telegram:group:-100123",
+        },
+      });
+
+      const result = await run();
+      const payload = Array.isArray(result) ? result[0] : result;
+
+      expect(payload).toMatchObject({
+        text: callbackResult === false ? "NO_REPLY" : GENERIC_EXTERNAL_RUN_FAILURE_TEXT,
+        ...(callbackResult === false ? {} : { isError: true }),
+      });
+      expect(onPartialReply).toHaveBeenCalledOnce();
+      expect(state.runEmbeddedAgentMock).toHaveBeenCalledOnce();
+    },
+  );
+
   it("rethrows after a delivered partial without visible content", async () => {
     const accounting = await import("./session-run-accounting.js");
     const persistSpy = vi

--- a/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
+++ b/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
@@ -1,6 +1,7 @@
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { setImmediate } from "node:timers/promises";
 // E2E tests for run-reply-agent execution and generated session artifacts.
 import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
 import {
@@ -80,6 +81,7 @@ type AgentRunParams = {
     isReasoning?: boolean;
     isCommentary?: boolean;
   }) => Promise<void> | void;
+  onBlockReplyFlush?: () => Promise<void>;
   onToolResult?: (payload: ReplyPayload) => Promise<void> | void;
   shouldEmitToolResult?: () => boolean;
   shouldEmitToolOutput?: () => boolean;
@@ -1771,6 +1773,75 @@ describe("runReplyAgent heartbeat followup guard", () => {
       });
       expect(onPartialReply).toHaveBeenCalledOnce();
       expect(state.runEmbeddedAgentMock).toHaveBeenCalledOnce();
+    },
+  );
+
+  it.each([
+    { label: "accepted answer", payload: { text: "answer block" }, delivered: true },
+    { label: "in-flight answer", payload: { text: "answer block" }, delivered: true },
+    { label: "queued answer", payload: { text: "answer block" }, delivered: true },
+    { label: "aborted answer", payload: { text: "answer block" }, delivered: false },
+    {
+      label: "reasoning",
+      payload: { text: "internal reasoning", isReasoning: true },
+      delivered: false,
+    },
+    {
+      label: "commentary",
+      payload: { text: "working on it", isCommentary: true },
+      delivered: false,
+    },
+    { label: "rejected answer", payload: { text: "answer block" }, delivered: false },
+  ])(
+    "reports provider failure after $label block delivery",
+    async ({ label, payload, delivered }) => {
+      const replyOperation =
+        label === "aborted answer"
+          ? createReplyOperation({
+              sessionKey: "main",
+              sessionId: "session",
+              resetTriggered: false,
+            })
+          : undefined;
+      const deliveryStarted = Promise.withResolvers<void>();
+      let blockFlush: Promise<void> | undefined;
+      const onBlockReply = vi.fn(async () => {
+        deliveryStarted.resolve();
+        if (label === "in-flight answer" || replyOperation) {
+          await setImmediate();
+          replyOperation?.abortByUser();
+        }
+        if (label === "rejected answer") {
+          throw new Error("transport rejected the block");
+        }
+      });
+      state.runEmbeddedAgentMock.mockImplementationOnce(async (params: AgentRunParams) => {
+        await params.onBlockReply?.(payload);
+        blockFlush = label === "queued answer" ? undefined : params.onBlockReplyFlush?.();
+        if (label !== "queued answer") {
+          await deliveryStarted.promise;
+        }
+        if (label !== "in-flight answer" && label !== "queued answer" && !replyOperation) {
+          await blockFlush;
+        }
+        throw new Error("model stream failed after block delivery");
+      });
+      const { run } = createMinimalRun({
+        replyOperation,
+        blockStreamingEnabled: true,
+        opts: { onBlockReply, reasoningPayloadsEnabled: true, commentaryPayloadsEnabled: true },
+        sessionCtx: { ChatType: "group" },
+      });
+
+      const result = await run();
+      await blockFlush;
+      const reply = Array.isArray(result) ? result[0] : result;
+
+      expect(onBlockReply).toHaveBeenCalledOnce();
+      expect(reply).toMatchObject({
+        text: delivered ? GENERIC_EXTERNAL_RUN_FAILURE_TEXT : "NO_REPLY",
+        ...(delivered ? { isError: true } : {}),
+      });
     },
   );
 
@@ -4439,6 +4510,29 @@ describe("runReplyAgent typing (heartbeat)", () => {
     const result = await run();
 
     expect(result).toBeUndefined();
+  });
+
+  it("does not duplicate an empty terminal failure after an accepted answer block", async () => {
+    const onBlockReply = vi.fn();
+    state.runEmbeddedAgentMock.mockImplementationOnce(async (params: AgentRunParams) => {
+      await params.onBlockReply?.({ text: "complete answer" });
+      return {
+        payloads: [],
+        meta: { error: { kind: "tool_result_mismatch", message: "terminal error after delivery" } },
+      };
+    });
+    const { run } = createMinimalRun({
+      blockStreamingEnabled: true,
+      opts: { onBlockReply },
+      sessionCtx: { ChatType: "group" },
+    });
+
+    expect(await run()).toBeUndefined();
+    expect(onBlockReply).toHaveBeenCalledOnce();
+    expect(onBlockReply).toHaveBeenCalledWith(
+      expect.objectContaining({ text: "complete answer" }),
+      expect.any(Object),
+    );
   });
 
   it("does not persist active fallback state for internal subagent announce fallback", async () => {


### PR DESCRIPTION
## What Problem This Solves
Fixes an issue where users see an unfinished partial answer without a useful failure message when a provider stream or live model switch fails in a group conversation. Telegram retries could also post that unfinished preview twice.

## Why This Change Was Made
Move the existing block flush and delivery check into one asynchronous run-owned resolver, used by terminal failure handling and the outer catch. It waits for queued/in-flight blocks to settle, then combines the confirmed partial flag with the canonical accepted-terminal-block fact. The failure policy can then distinguish a silent turn from an answer the user has already seen. Telegram rotates a preview only after an accepted or queued block; retrying an unfinished preview keeps the same editable message. Auth, billing, overload, abort, and genuinely silent no-output behavior remain unchanged. No new retry policy, configuration, or persistence surface.

## User Impact
A failed streamed reply has a visible outcome, and Telegram does not duplicate an unfinished preview during retry. This restores the existing documented preview/final-delivery contract. Release-note text: Preserve visible partial replies on provider/model-switch failures and avoid duplicating unfinished Telegram previews.

## Evidence
- Reproduced the canonical Telegram failure after the first 11 scenarios passed; scenario 12 exposed duplicate partial/failure delivery. The complete21-scenario candidate replay now passes: [Package Acceptance33246887103](https://github.com/openclaw/openclaw/actions/runs/33246887103), exact package source `72e84d96eac09de1669a4e81c54cca81a4ba78e7`. Live Telegram, mocked model; zero functional failures/skips. Advisory RTT20/21 met target, so latency is not claimed uniformly green.
- Captured failing provider and live-model-switch regressions across six non-direct surfaces; 99 final provider/model-switch tests pass.
- Real whole-runner regression: accepted and legacy-void partial callbacks fail on the old code, rejected callbacks remain silent; fixed suite passes 161 tests.
- 389 broader sibling tests passed, including 257 Telegram dispatch tests and auth/context/terminal paths. A real draft transport regression proves retry reuses the unfinished message; accepted-block rotation remains covered.
- Core typed lint, formatting, diff checks, and fresh independent Codex autoreview passed. Local plugin typed lint is blocked by unrelated borrowed dependency mismatches; exact-head hosted CI remains required.

The sibling block path exposed the same invariant: accepted, in-flight and queued answers were classified as silent before the outer finalizer flushed delivery. Pristine whole-runner proof fails those three cases while five controls pass. After the shared owner refactor, all169 whole-runner tests pass on [Testbox33247935439](https://github.com/openclaw/openclaw/actions/runs/33247935439). Rejected sends, reasoning, commentary, user aborts and the existing completed-answer/empty-terminal suppression remain unchanged. Live-model-switch exhaustion settles delivery before committing failure; retry paths do not flush early. The only other execution caller disables partial/block callbacks and passes no block pipeline.

The fullrunner proof uses pinned baseline `bbe4f3a7f7dce27452ccd5457a558c2d5ccbfd76` plus a frozen11-file overlay. The final published files match those hashes. The earlier21-scenario Telegram proof covers the unchanged Telegram encoding; the later block-owner behavior has fullrunner proof. Local148 focused tests and typed core lint passed on the worker snapshot;145 tests in four selected projects passed after final PR integration. Format and fresh independent Codex review are clean.

Application production+40/-32 (net+8); tests+212. The former outer-catch-only flush/check is removed and reused at one run owner. Growth is the async delivery-settlement seam, one ordering temporary and the transport acceptance boundary, not a second failure flow. No persistence/configuration changes or new retries/timeouts. Exact-head CI remains required before landing.

