### PR TITLE
test(release): expose Codex follow-through lifecycle phases

### DIFF
--- a/scripts/e2e/codex-npm-plugin-live-docker.sh
+++ b/scripts/e2e/codex-npm-plugin-live-docker.sh
@@ -498,7 +498,7 @@ PROMPT
 
 echo "Running Codex progress follow-through regression turn..."
 OPENCLAW_PACKAGE_ROOT="$(openclaw_e2e_package_root "$NPM_CONFIG_PREFIX")"
-if node scripts/e2e/lib/codex-npm-plugin-live/followthrough-turn.mjs \
+if openclaw_e2e_run_command node scripts/e2e/lib/codex-npm-plugin-live/followthrough-turn.mjs \
   "$OPENCLAW_PACKAGE_ROOT" \
   "$FOLLOWTHROUGH_SESSION_ID" \
   "$MODEL_REF" \
@@ -512,6 +512,7 @@ else
   followthrough_status=$?
 fi
 echo "followthrough_agent_status: $followthrough_status stdout_bytes=$(wc -c </tmp/openclaw-codex-followthrough.json 2>/dev/null || printf 0) stderr_bytes=$(wc -c </tmp/openclaw-codex-followthrough.err 2>/dev/null || printf 0)"
+openclaw_e2e_print_log /tmp/openclaw-codex-followthrough.log
 if [ "$followthrough_status" -ne 0 ]; then
   dump_debug_logs "$followthrough_status"
   exit "$followthrough_status"

--- a/scripts/e2e/lib/codex-npm-plugin-live/followthrough-turn.mjs
+++ b/scripts/e2e/lib/codex-npm-plugin-live/followthrough-turn.mjs
@@ -21,7 +21,26 @@ const agentRuntimePath = path.join(
   "plugin-sdk",
   "agent-runtime.js",
 );
+const startedAt = Date.now();
+const markPhase = (phase) => {
+  const resources = new Map();
+  for (const type of process.getActiveResourcesInfo()) {
+    resources.set(type, (resources.get(type) ?? 0) + 1);
+  }
+  console.log(
+    JSON.stringify({
+      phase,
+      elapsedMs: Date.now() - startedAt,
+      resources: Object.fromEntries(
+        [...resources].toSorted(([left], [right]) => left.localeCompare(right)).slice(0, 32),
+      ),
+    }),
+  );
+};
+process.once("beforeExit", () => markPhase("followthrough:before-exit"));
+markPhase("followthrough:import-start");
 const { agentCommandFromIngress } = await import(pathToFileURL(agentRuntimePath).href);
+markPhase("followthrough:import-complete");
 if (typeof agentCommandFromIngress !== "function") {
   throw new Error(
     `package agent runtime did not export agentCommandFromIngress: ${agentRuntimePath}`,
@@ -35,6 +54,7 @@ const quietRuntime = {
     throw new Error(`agent runtime exited with code ${code}`);
   },
 };
+markPhase("followthrough:turn-start");
 const result = await agentCommandFromIngress(
   {
     agentId: "main",
@@ -56,4 +76,8 @@ const result = await agentCommandFromIngress(
   },
   quietRuntime,
 );
+markPhase("followthrough:turn-and-cleanup-complete");
 fs.writeFileSync(outputPath, `${JSON.stringify(result)}\n`);
+markPhase("followthrough:result-written");
+// Observe lingering resources without keeping a completed one-shot process alive.
+setTimeout(() => markPhase("followthrough:resources-after-result"), 1_000).unref();

--- a/test/scripts/docker-build-helper.test.ts
+++ b/test/scripts/docker-build-helper.test.ts
@@ -5169,6 +5169,7 @@ grep -Fxq preserved "$TMPDIR/caller-fd"
       "assert-agent-error",
       "assert-followthrough",
       "followthrough-turn.mjs",
+      "if openclaw_e2e_run_command node scripts/e2e/lib/codex-npm-plugin-live/followthrough-turn.mjs",
       "docker_e2e_read_positive_int_env OPENCLAW_CODEX_NPM_PLUGIN_AGENT_TIMEOUT_SECONDS 420",
       'docker_e2e_read_positive_int_env OPENCLAW_CODEX_NPM_PLUGIN_AGENT_TIMEOUT_SECONDS "$AGENT_TURN_TIMEOUT_SECONDS"',
       '-e "OPENCLAW_CODEX_NPM_PLUGIN_AGENT_TIMEOUT_SECONDS=$AGENT_TURN_TIMEOUT_SECONDS"',
@@ -5239,6 +5240,18 @@ grep -Fxq preserved "$TMPDIR/caller-fd"
     expect(result.status, result.stderr).toBe(0);
     expect(result.stderr).toBe("");
     expect(result.stdout).toContain("unexpected subsystem output");
+    const phases = result.stdout
+      .split("\n")
+      .filter((line) => line.startsWith('{"phase":"followthrough:'))
+      .map((line) => JSON.parse(line).phase);
+    expect(phases).toEqual([
+      "followthrough:import-start",
+      "followthrough:import-complete",
+      "followthrough:turn-start",
+      "followthrough:turn-and-cleanup-complete",
+      "followthrough:result-written",
+      "followthrough:before-exit",
+    ]);
     expect(JSON.parse(readFileSync(outputPath, "utf8"))).toEqual({
       captured: expect.objectContaining({
         sessionId: "followthrough-session",


### PR DESCRIPTION
## Why

The packaged Codex follow-through check could spend the whole release-lane timeout without revealing whether it was importing, running a turn, cleaning up, or merely retaining a process resource after success. The original failed release run stopped at the helper banner and lost the inner log when its container was removed.

## Changes

Run the helper through the existing 480-second command runner, retain its existing 420-second agent deadline, and print its bounded log through the shared redaction helper. Emit fixed phase markers and bounded active-resource **type counts** around import, turn/cleanup, result writing, and natural process exit. The post-result observer is unreferenced, so diagnostics cannot keep the process alive. Preserve every existing follow-through assertion and result artifact.

The runtime watcher fix and uninstall classifier independently landed in #132512. This PR now contains only the diagnostic runner and its existing test coverage; it does not add another watcher policy, change product behavior, or duplicate those tests.

## Evidence

The diagnostic helper identified the frozen-package failure in [this Testbox](https://github.com/openclaw/openclaw/actions/runs/33245368342): native Codex CLI 0.150.1 completed the turn, cleanup, and result write in 13.393 seconds, while three `FSEventWrap` handles kept the process alive. Every original follow-through assertion passed. The owned diagnostic was manually stopped after 202 seconds, before the unchanged command deadline; this was not a full-lane pass.

The same helper then recorded natural exit in 18.401 seconds with no active resources in a [fresh Testbox](https://github.com/openclaw/openclaw/actions/runs/33246993682), using the earlier independently repaired core candidate `bf2230b4ee0cb6a0544ad19f0e9382d3b3d386f4`. All three conversation turns and every follow-through assertion passed. That complete scenario remains recorded as failed after 97 seconds solely because its final uninstall classifier rejected the correct missing-registration error. Its actual output passed a deterministic corrected-classifier replay with negative controls; the original numeric nonzero exit was not logged and is not inferred. The earlier candidate is not the artifact landed by #132512.

The canonical runtime repair #132512 separately records a complete [96-second package-lane pass](https://github.com/openclaw/openclaw/actions/runs/33241739767), including natural exit and uninstall checks. Its owner and classifier are preserved unchanged here. A separate earlier CLI post-result hang remains unattributed; this PR does not claim to fix it.

Five focused helper tests pass, including the executable helper's result/log separation, phase order, and natural exit. Script lint and changed-file gates are checked on this refreshed branch. Independent Codex review found no actionable issue. The initial CI caught two diagnostic sort lint errors; both are fixed.

Product delta: zero. Tooling: +26/-1 lines for bounded diagnostic evidence and the existing command runner. Tests: +13/-0 lines extending existing coverage. No configuration, storage, delegated authority, timeout increase, forced exit, or global watcher teardown is introduced.

## Review follow-through

The current ClawSweeper findings and first rank-up move are addressed: the duplicate ingress predicate, duplicate assertion coverage, and changelog hunk are gone; the existing main acquisition owner is unchanged. The maintainer scope decision is to retain these useful diagnostics in this same focused PR. Its serialized output is a test log and the unchanged test-result artifact, not a runtime store or schema migration.

The diagnostic-only rebase requested by the second rank-up move is complete. A new exact-head Testbox/model run is intentionally skipped: the helper already supplied real before/after lifecycle evidence, the remaining change is the validated sort correction and scope reduction, and no product runtime differs from main. Exact-head CI and the executable helper regression cover the refreshed tooling; a fresh full release run will provide integrated coverage. The earlier Testbox artifacts above retain their exact identities and are not relabeled as this head.
