### PR TITLE
test: align live CLI fixtures with runtime auth and session contracts

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -2851,8 +2851,8 @@ src/gateway/desktop/host-guidance.ts	1
 src/gateway/desktop/managed-linux.ts	1
 src/gateway/desktop/node-source-context.ts	1
 src/gateway/exec-approval-manager.ts	7
-src/gateway/gateway-cli-backend.live-helpers.ts	4
-src/gateway/gateway-cli-backend.live-probe-helpers.ts	7
+src/gateway/gateway-cli-backend.live-helpers.ts	2
+src/gateway/gateway-cli-backend.live-probe-helpers.ts	4
 src/gateway/health/collector.ts	3
 src/gateway/hooks-mapping.ts	2
 src/gateway/hooks.ts	1

--- a/scripts/lib/live-docker-stage.sh
+++ b/scripts/lib/live-docker-stage.sh
@@ -32,6 +32,36 @@ openclaw_live_stage_mounted_auth() {
   fi
 }
 
+openclaw_live_stage_gemini_auth() {
+  local auth_type="gemini-api-key"
+  if [ -z "${GEMINI_API_KEY:-}" ]; then
+    [ -n "${GOOGLE_API_KEY:-}" ] || return 0
+    auth_type="vertex-ai"
+    export GOOGLE_GENAI_USE_VERTEXAI="${GOOGLE_GENAI_USE_VERTEXAI:-true}"
+  fi
+
+  # Staged user settings override Gemini's env-based auth selection. Align only
+  # the disposable container home with the credentials supplied for this run.
+  GEMINI_CLI_AUTH_TYPE="$auth_type" node <<'NODE'
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const settingsPath = path.join(os.homedir(), ".gemini", "settings.json");
+let settings = {};
+try {
+  settings = JSON.parse(fs.readFileSync(settingsPath, "utf8"));
+} catch {}
+settings.security = settings.security && typeof settings.security === "object" ? settings.security : {};
+settings.security.auth =
+  settings.security.auth && typeof settings.security.auth === "object" ? settings.security.auth : {};
+settings.security.auth.selectedType = process.env.GEMINI_CLI_AUTH_TYPE;
+settings.security.auth.enforcedType = process.env.GEMINI_CLI_AUTH_TYPE;
+fs.mkdirSync(path.dirname(settingsPath), { recursive: true });
+fs.writeFileSync(settingsPath, `${JSON.stringify(settings, null, 2)}\n`);
+NODE
+  echo "Using Gemini CLI auth type $auth_type"
+}
+
 openclaw_live_run_setup_command() {
   local timeout_seconds="${1:?setup timeout seconds required}"
   local label="${2:?setup label required}"

--- a/scripts/print-cli-backend-live-metadata.ts
+++ b/scripts/print-cli-backend-live-metadata.ts
@@ -1,6 +1,7 @@
 // Print Cli Backend Live Metadata script supports OpenClaw repository automation.
 import { pathToFileURL } from "node:url";
 import { resolveCliBackendConfig, resolveCliBackendLiveTest } from "../src/agents/cli-backends.js";
+import { resolvePluginSetupRegistry } from "../src/plugins/setup-registry.js";
 
 export async function resolveCliBackendLiveMetadata(provider: string) {
   if (provider === "codex-cli") {
@@ -66,7 +67,39 @@ async function loadFallbackBackend(id: string) {
   }
 }
 
+export async function resolveCliBackendDockerPackages(requested: readonly string[] = []) {
+  const backends = resolvePluginSetupRegistry().cliBackends;
+  const providers = requested.length
+    ? [
+        ...requested,
+        ...backends
+          .filter(
+            ({ backend }) => backend.modelProvider && requested.includes(backend.modelProvider),
+          )
+          .map(({ backend }) => backend.id),
+      ]
+    : backends.map(({ backend }) => backend.id);
+  const packages = new Set<string>();
+  for (const provider of providers) {
+    const metadata = await resolveCliBackendLiveMetadata(provider);
+    if ("dockerNpmPackage" in metadata && metadata.dockerNpmPackage) {
+      packages.add(metadata.dockerNpmPackage);
+    }
+  }
+  return [...packages].toSorted();
+}
+
 async function main() {
+  if (process.argv[2] === "--docker-packages") {
+    const requested = process.argv[3]
+      ?.split(",")
+      .map((id) => id.trim())
+      .filter((id) => id && id !== "all");
+    for (const npmPackage of await resolveCliBackendDockerPackages(requested)) {
+      process.stdout.write(`${npmPackage}\n`);
+    }
+    return;
+  }
   const provider = process.argv[2]?.trim().toLowerCase();
   if (!provider) {
     console.error("usage: node scripts/print-cli-backend-live-metadata.ts <provider>");

--- a/scripts/test-live-acp-bind-docker.sh
+++ b/scripts/test-live-acp-bind-docker.sh
@@ -187,32 +187,7 @@ WRAP
     if [ ! -x "$NPM_CONFIG_PREFIX/bin/gemini" ]; then
       run_setup_command npm install -g @google/gemini-cli
     fi
-    if [ -n "${GEMINI_API_KEY:-}" ] || [ -n "${GOOGLE_API_KEY:-}" ]; then
-      gemini_auth_type="gemini-api-key"
-      if [ -z "${GEMINI_API_KEY:-}" ] && [ -n "${GOOGLE_API_KEY:-}" ]; then
-        gemini_auth_type="vertex-ai"
-        export GOOGLE_GENAI_USE_VERTEXAI="${GOOGLE_GENAI_USE_VERTEXAI:-true}"
-      fi
-      GEMINI_CLI_AUTH_TYPE="$gemini_auth_type" node <<'NODE'
-const fs = require("node:fs");
-const os = require("node:os");
-const path = require("node:path");
-
-const settingsPath = path.join(os.homedir(), ".gemini", "settings.json");
-let settings = {};
-try {
-  settings = JSON.parse(fs.readFileSync(settingsPath, "utf8"));
-} catch {}
-settings.security = settings.security && typeof settings.security === "object" ? settings.security : {};
-settings.security.auth =
-  settings.security.auth && typeof settings.security.auth === "object" ? settings.security.auth : {};
-settings.security.auth.selectedType = process.env.GEMINI_CLI_AUTH_TYPE;
-settings.security.auth.enforcedType = process.env.GEMINI_CLI_AUTH_TYPE;
-fs.mkdirSync(path.dirname(settingsPath), { recursive: true });
-fs.writeFileSync(settingsPath, `${JSON.stringify(settings, null, 2)}\n`);
-NODE
-      echo "Using Gemini CLI auth type $gemini_auth_type"
-    fi
+    openclaw_live_stage_gemini_auth
     ;;
   opencode)
     if [ ! -x "$NPM_CONFIG_PREFIX/bin/opencode" ]; then

--- a/scripts/test-live-cli-backend-docker.sh
+++ b/scripts/test-live-cli-backend-docker.sh
@@ -214,6 +214,9 @@ if [ -n "${OPENCLAW_LIVE_CLI_BACKEND_COMMAND:-}" ] && [ -x "${OPENCLAW_LIVE_CLI_
   echo "==> CLI backend binary: ${OPENCLAW_LIVE_CLI_BACKEND_COMMAND}"
   "${OPENCLAW_LIVE_CLI_BACKEND_COMMAND}" -V || "${OPENCLAW_LIVE_CLI_BACKEND_COMMAND}" --version || true
 fi
+if [ "$provider" = "google-gemini-cli" ]; then
+  openclaw_live_stage_gemini_auth
+fi
 if [ "$provider" = "claude-cli" ]; then
   auth_mode="${OPENCLAW_LIVE_CLI_BACKEND_AUTH:-auto}"
   if [ "$auth_mode" = "subscription" ]; then

--- a/scripts/test-live-gateway-models-docker.sh
+++ b/scripts/test-live-gateway-models-docker.sh
@@ -38,7 +38,10 @@ export XDG_CACHE_HOME="${XDG_CACHE_HOME:-$HOME/.cache}"
 export COREPACK_HOME="${COREPACK_HOME:-$XDG_CACHE_HOME/node/corepack}"
 export NPM_CONFIG_CACHE="${NPM_CONFIG_CACHE:-$XDG_CACHE_HOME/npm}"
 export npm_config_cache="$NPM_CONFIG_CACHE"
-mkdir -p "$XDG_CACHE_HOME" "$COREPACK_HOME" "$NPM_CONFIG_CACHE"
+export NPM_CONFIG_PREFIX="$HOME/.npm-global"
+export npm_config_prefix="$NPM_CONFIG_PREFIX"
+export PATH="$NPM_CONFIG_PREFIX/bin:$PATH"
+mkdir -p "$NPM_CONFIG_PREFIX" "$XDG_CACHE_HOME" "$COREPACK_HOME" "$NPM_CONFIG_CACHE"
 chmod 700 "$XDG_CACHE_HOME" "$COREPACK_HOME" "$NPM_CONFIG_CACHE" || true
 tmp_dir="$(mktemp -d)"
 trusted_scripts_dir="${OPENCLAW_LIVE_DOCKER_SCRIPTS_DIR:-/src/scripts}"
@@ -50,6 +53,13 @@ openclaw_live_link_runtime_tree "$tmp_dir"
 openclaw_live_stage_state_dir "$tmp_dir/.openclaw-state"
 openclaw_live_prepare_staged_config
 cd "$tmp_dir"
+docker_packages="$(node --import tsx scripts/print-cli-backend-live-metadata.ts \
+  --docker-packages "${OPENCLAW_LIVE_GATEWAY_PROVIDERS:-}")"
+while IFS= read -r docker_package; do
+  [ -n "$docker_package" ] || continue
+  openclaw_live_run_setup_command 180 "live CLI backend setup" npm install -g "$docker_package"
+done <<<"$docker_packages"
+openclaw_live_stage_gemini_auth
 if [[ -f scripts/test-live.mjs ]]; then
   node scripts/test-live.mjs -- src/gateway/gateway-models.profiles.live.test.ts
 else

--- a/src/gateway/gateway-cli-backend.live-cache.test-helpers.ts
+++ b/src/gateway/gateway-cli-backend.live-cache.test-helpers.ts
@@ -9,7 +9,7 @@ import { computeCacheHitRate } from "../agents/live-cache-test-support.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { loadOpenClawPlugins } from "../plugins/loader.js";
 
-export const MCP_SCHEMA_PROBE_PLUGIN_ID = "mcp-schema-probe";
+export const CLI_BACKEND_PROBE_PLUGIN_ID = "cli-backend-probe";
 export const MCP_SCHEMA_PROBE_TOOL_NAME = "mcp_schema_probe_no_args";
 export const CLI_CACHE_AUTH_PROFILE_ID = "claude-cli:live-cache";
 
@@ -69,21 +69,25 @@ export function logCliCacheUsage(turn: string, result: unknown): number {
   return hitRate;
 }
 
-export async function createMcpSchemaProbePlugin(
+export async function createCliBackendProbePlugin(
   tempDir: string,
+  probes: {
+    mcpSchema: boolean;
+    continuity?: { sessionKey: string; firstTurnMarker: string; injectedContext: string };
+  },
 ): Promise<{ pluginPath: string; resultToken: string }> {
-  const pluginDir = path.join(tempDir, MCP_SCHEMA_PROBE_PLUGIN_ID);
+  const pluginDir = path.join(tempDir, CLI_BACKEND_PROBE_PLUGIN_ID);
   const resultToken = `MCP-SCHEMA-${randomBytes(6).toString("hex").toUpperCase()}`;
   await fs.mkdir(pluginDir, { recursive: true });
   await fs.writeFile(
     path.join(pluginDir, "openclaw.plugin.json"),
     `${JSON.stringify(
       {
-        id: MCP_SCHEMA_PROBE_PLUGIN_ID,
-        name: "MCP Schema Probe",
-        description: "Live test plugin for no-argument MCP tool schemas",
+        id: CLI_BACKEND_PROBE_PLUGIN_ID,
+        name: "CLI Backend Probe",
+        description: "Live test plugin for CLI session continuity and MCP tool schemas",
         configSchema: { type: "object", additionalProperties: false, properties: {} },
-        contracts: { tools: [MCP_SCHEMA_PROBE_TOOL_NAME] },
+        ...(probes.mcpSchema ? { contracts: { tools: [MCP_SCHEMA_PROBE_TOOL_NAME] } } : {}),
       },
       null,
       2,
@@ -92,10 +96,18 @@ export async function createMcpSchemaProbePlugin(
   await fs.writeFile(
     path.join(pluginDir, "index.cjs"),
     `module.exports = {
-  id: "${MCP_SCHEMA_PROBE_PLUGIN_ID}",
-  name: "MCP Schema Probe",
+  id: "${CLI_BACKEND_PROBE_PLUGIN_ID}",
+  name: "CLI Backend Probe",
   register(api) {
-    api.registerTool({
+    const continuity = ${JSON.stringify(probes.continuity ?? null)};
+    if (continuity) {
+      api.on("before_prompt_build", (event, ctx) => {
+        if (ctx.sessionKey === continuity.sessionKey && event.prompt.includes(continuity.firstTurnMarker)) {
+          return { prependContext: continuity.injectedContext };
+        }
+      });
+    }
+    if (${probes.mcpSchema}) api.registerTool({
       name: "${MCP_SCHEMA_PROBE_TOOL_NAME}",
       description: "Live test no-argument tool for MCP schema normalization",
       parameters: { type: "object" },

--- a/src/gateway/gateway-cli-backend.live-helpers.test.ts
+++ b/src/gateway/gateway-cli-backend.live-helpers.test.ts
@@ -221,33 +221,15 @@ describe("gateway cli backend live helpers", () => {
       memoryToken,
     });
 
-    expect(probe.firstTurnPrompt).toBe(
-      "Do not inspect files or run tools. Reply with exactly: CLI-BACKEND-112233.",
-    );
-    expect(probe.resumePrompt).toBe(
-      "Do not inspect files or run tools. " +
-        "Return exactly two whitespace-separated tokens: CLI-RESUME-445566 followed by " +
-        "the exact opaque session token from the earlier turn. Do not add prose.",
-    );
+    expect(probe.firstTurnPrompt).toContain("public test label");
+    expect(probe.firstTurnPrompt).toContain("not a credential");
+    expect(probe.firstTurnPrompt).toContain("CLI-BACKEND-112233");
+    expect(probe.resumePrompt).toContain("public test label");
+    expect(probe.resumePrompt).toContain("CLI-RESUME-445566");
     expect(probe.firstTurnPrompt).not.toContain(memoryToken);
     expect(probe.resumePrompt).not.toContain(memoryToken);
     expect(probe.injectedContext).toContain(memoryToken);
     expect(probe.expectedResumeMarker).toBe("CLI-RESUME-445566");
-  });
-
-  it("finds only Claude-imported native session ids", () => {
-    const { resolveImportedClaudeCliSessionId } = liveHelpers;
-
-    expect(
-      resolveImportedClaudeCliSessionId([
-        null,
-        { __openclaw: "invalid" },
-        { __openclaw: { importedFrom: "codex-cli", cliSessionId: "wrong-provider" } },
-        { __openclaw: { importedFrom: "claude-cli", cliSessionId: 42 } },
-        { __openclaw: { importedFrom: "claude-cli", cliSessionId: "claude-session" } },
-      ]),
-    ).toBe("claude-session");
-    expect(resolveImportedClaudeCliSessionId([])).toBeUndefined();
   });
 
   it("retries Codex CLI timeout payloads only before the final attempt", async () => {

--- a/src/gateway/gateway-cli-backend.live-helpers.ts
+++ b/src/gateway/gateway-cli-backend.live-helpers.ts
@@ -273,34 +273,20 @@ export function buildClaudeCliResumeContinuityProbe(params: {
   const firstTurnMarker = `CLI-BACKEND-${params.firstTurnNonce}`;
   return {
     firstTurnMarker,
-    firstTurnPrompt: `Do not inspect files or run tools. Reply with exactly: ${firstTurnMarker}.`,
+    firstTurnPrompt:
+      "This is a synthetic session-memory test. Remember the random public test label " +
+      "provided in runtime context; it is not a credential. " +
+      `Do not inspect files or run tools. Reply with exactly: ${firstTurnMarker}.`,
     injectedContext:
-      `Remember this exact opaque session token for a later turn: ${params.memoryToken}. ` +
-      "Do not include the token in this turn's reply.",
+      `The random public test label for this session-memory test is ${params.memoryToken}. ` +
+      "Remember it for the follow-up, without including it in this turn's reply.",
     resumePrompt:
       "Do not inspect files or run tools. " +
       `Return exactly two whitespace-separated tokens: CLI-RESUME-${params.resumeNonce} followed by ` +
-      "the exact opaque session token from the earlier turn. Do not add prose.",
+      "the exact public test label from the earlier turn. Do not add prose.",
     expectedFirstReply: `${firstTurnMarker}.`,
     expectedResumeMarker: `CLI-RESUME-${params.resumeNonce}`,
   };
-}
-
-export function resolveImportedClaudeCliSessionId(messages: unknown[]): string | undefined {
-  for (const message of messages) {
-    const metadata =
-      typeof message === "object" && message !== null
-        ? (message as Record<string, unknown>)["__openclaw"]
-        : undefined;
-    if (typeof metadata !== "object" || metadata === null) {
-      continue;
-    }
-    const imported = metadata as { cliSessionId?: unknown; importedFrom?: unknown };
-    if (imported.importedFrom === "claude-cli" && typeof imported.cliSessionId === "string") {
-      return imported.cliSessionId;
-    }
-  }
-  return undefined;
 }
 
 export function withClaudeMcpConfigOverrides(args: string[], mcpConfigPath: string): string[] {

--- a/src/gateway/gateway-cli-backend.live-probe-helpers.test.ts
+++ b/src/gateway/gateway-cli-backend.live-probe-helpers.test.ts
@@ -55,8 +55,6 @@ function writeJson(response: ServerResponse, status: number, body: unknown): voi
 function preflightParams(env: NodeJS.ProcessEnv = {}) {
   return {
     sessionKey: "session-key",
-    port: 12345,
-    token: "gateway-token",
     env,
   };
 }
@@ -72,40 +70,65 @@ describe("gateway CLI backend live probe helpers", () => {
     clearActiveMcpLoopbackRuntimeByOwnerToken(ownerToken);
   });
 
-  it("reads loopback JSON-RPC responses without invoking cron verification when cron is absent", async () => {
-    const methods: string[] = [];
-    const server = createHttpServer((request, response) => {
-      void (async () => {
-        const body = JSON.parse(await readRequestBody(request)) as {
-          id?: unknown;
-          method?: string;
-        };
-        if (body.method) {
-          methods.push(body.method);
+  it.each([false, true])(
+    "checks read-only loopback discovery with automations present=%s",
+    async (present) => {
+      const methods: string[] = [];
+      const server = createHttpServer((request, response) => {
+        void (async () => {
+          const body = JSON.parse(await readRequestBody(request)) as {
+            id?: unknown;
+            method?: string;
+          };
+          if (body.method) {
+            methods.push(body.method);
+          }
+          if (body.method === "notifications/initialized") {
+            response.writeHead(202);
+            response.end();
+            return;
+          }
+          writeJson(response, 200, {
+            jsonrpc: "2.0",
+            id: body.id ?? null,
+            result:
+              body.method === "tools/list"
+                ? {
+                    tools: present
+                      ? [{ name: "automations", inputSchema: { type: "object", properties: {} } }]
+                      : [],
+                  }
+                : body.method === "tools/call"
+                  ? {
+                      isError: true,
+                      content: [
+                        {
+                          type: "text",
+                          text: "trusted operational run instance required for this gateway call",
+                        },
+                      ],
+                    }
+                  : {},
+          });
+        })();
+      });
+      const port = await listen(server);
+      activateLoopbackRuntime(port);
+      try {
+        const preflight = verifyCliCronMcpLoopbackPreflight(preflightParams());
+        if (present) {
+          await expect(preflight).resolves.toBeUndefined();
+        } else {
+          await expect(preflight).rejects.toThrow(
+            "mcp loopback tools/list did not expose automations",
+          );
         }
-        if (body.method === "notifications/initialized") {
-          response.writeHead(202);
-          response.end();
-          return;
-        }
-        writeJson(response, 200, {
-          jsonrpc: "2.0",
-          id: body.id ?? null,
-          result: body.method === "tools/list" ? { tools: [] } : {},
-        });
-      })();
-    });
-    const port = await listen(server);
-    activateLoopbackRuntime(port);
-    try {
-      await expect(verifyCliCronMcpLoopbackPreflight(preflightParams())).rejects.toThrow(
-        "mcp loopback tools/list did not expose automations",
-      );
-      expect(methods).toEqual(["initialize", "notifications/initialized", "tools/list"]);
-    } finally {
-      server.close();
-    }
-  });
+        expect(methods).toEqual(["initialize", "notifications/initialized", "tools/list"]);
+      } finally {
+        server.close();
+      }
+    },
+  );
 
   it("bounds loopback JSON-RPC calls when the server accepts connections but never responds", async () => {
     const sockets = new Set<Socket>();

--- a/src/gateway/gateway-cli-backend.live-probe-helpers.ts
+++ b/src/gateway/gateway-cli-backend.live-probe-helpers.ts
@@ -243,17 +243,13 @@ async function callLoopbackJsonRpc(params: {
 
 export async function verifyCliCronMcpLoopbackPreflight(params: {
   sessionKey: string;
-  port: number;
-  token: string;
   env: NodeJS.ProcessEnv;
   messageProvider?: string;
   accountId?: string;
   expectedSchemaProbeToolName?: string;
 }): Promise<void> {
-  const cronProbe = createLiveCronProbeSpec();
   logCliCronProbe("loopback-preflight:start", {
     sessionKey: params.sessionKey,
-    jobName: cronProbe.name,
   });
 
   await callLoopbackJsonRpc({
@@ -300,62 +296,9 @@ export async function verifyCliCronMcpLoopbackPreflight(params: {
     throw new Error(`mcp loopback tools/list did not expose ${AUTOMATIONS_TOOL_NAME}`);
   }
 
-  const toolCall = await callLoopbackJsonRpc({
-    sessionKey: params.sessionKey,
-    messageProvider: params.messageProvider,
-    accountId: params.accountId,
-    env: params.env,
-    body: {
-      jsonrpc: "2.0",
-      id: "cron-add",
-      method: "tools/call",
-      params: {
-        name: AUTOMATIONS_TOOL_NAME,
-        arguments: JSON.parse(cronProbe.argsJson) as Record<string, unknown>,
-      },
-    },
-  });
-  const toolCallError =
-    (toolCall.result as { isError?: unknown } | undefined)?.isError === true ||
-    !(toolCall.result as { content?: unknown } | undefined);
-  logCliCronProbe("loopback-preflight:call", {
-    isError: toolCallError,
-    jobName: cronProbe.name,
-  });
-  if (toolCallError) {
-    throw new Error(`mcp loopback cron tools/call returned isError for job ${cronProbe.name}`);
-  }
-
-  const { job: createdJob, pollsUsed } = await pollCliCronJobVisible({
-    port: params.port,
-    token: params.token,
-    env: params.env,
-    expectedName: cronProbe.name,
-    expectedMessage: cronProbe.message,
-  });
-  logCliCronProbe("loopback-preflight:verify", {
-    jobName: cronProbe.name,
-    pollsUsed,
-    createdJob: Boolean(createdJob),
-  });
-  if (!createdJob) {
-    throw new Error(`mcp loopback cron tools/call did not create job ${cronProbe.name}`);
-  }
-  assertCronJobMatches({
-    job: createdJob,
-    expectedName: cronProbe.name,
-    expectedMessage: cronProbe.message,
-    expectedSessionKey: params.sessionKey,
-  });
-  if (createdJob.id) {
-    await removeCliCronJobBestEffort({
-      id: createdJob.id,
-      port: params.port,
-      token: params.token,
-      env: params.env,
-    });
-  }
-  logCliCronProbe("loopback-preflight:done", { jobName: cronProbe.name });
+  // The owner token permits discovery but carries no admitted agent turn.
+  // verifyCliCronMcpProbe proves mutations through the real agent's live MCP grant.
+  logCliCronProbe("loopback-preflight:done");
 }
 
 function getCliBackendProbeThinking(providerId: string): "low" | undefined {
@@ -408,7 +351,7 @@ export async function verifyCliCronMcpProbe(params: {
   token: string;
   env: NodeJS.ProcessEnv;
 }): Promise<void> {
-  const cronProbe = createLiveCronProbeSpec();
+  const cronProbe = createLiveCronProbeSpec({ sessionKey: params.sessionKey });
   const thinking = getCliBackendProbeThinking(params.providerId);
 
   let createdJob: CronListJob | undefined;

--- a/src/gateway/gateway-cli-backend.live.test.ts
+++ b/src/gateway/gateway-cli-backend.live.test.ts
@@ -11,23 +11,21 @@ import {
 } from "../agents/cli-backends.js";
 import { testing as cliBackendsTesting } from "../agents/cli-backends.test-support.js";
 import { getCliLiveSessionGeneration } from "../agents/cli-runner/cli-live-session-registry.js";
+import { loadCliSessionHistoryMessages } from "../agents/cli-runner/session-history.js";
 import { isLiveTestEnabled } from "../agents/live-test-helpers.js";
 import { shouldSkipLiveProviderDrift } from "../agents/live-test-provider-drift.js";
 import { parseModelRef } from "../agents/model-selection.js";
 import { clearRuntimeConfigSnapshot, type OpenClawConfig } from "../config/config.js";
+import { resolveSessionTranscriptRuntimeTarget } from "../config/sessions/session-accessor.js";
 import { isTruthyEnvValue } from "../infra/env.js";
-import {
-  initializeGlobalHookRunner,
-  resetGlobalHookRunner,
-} from "../plugins/hook-runner-global.js";
-import { createMockPluginRegistry } from "../plugins/hooks.test-helpers.js";
+import { resetGlobalHookRunner } from "../plugins/hook-runner-global.js";
 import { setTestEnvValue } from "../test-utils/env.js";
 import {
   CLI_CACHE_AUTH_PROFILE_ID,
-  createMcpSchemaProbePlugin,
+  CLI_BACKEND_PROBE_PLUGIN_ID,
+  createCliBackendProbePlugin,
   initializeCacheProbeGitWorkspace,
   logCliCacheUsage,
-  MCP_SCHEMA_PROBE_PLUGIN_ID,
   MCP_SCHEMA_PROBE_TOOL_NAME,
   prepareClaudeCacheProbeBackend,
   type RuntimeBackendEntry,
@@ -45,7 +43,6 @@ import {
   resolveCliBackendLiveArgs,
   resolveCliBackendLiveModelSelection,
   resolveCliBackendLiveProviderSkipDecision,
-  resolveImportedClaudeCliSessionId,
   resolveCliModelSwitchProbeTarget,
   restoreCliBackendLiveEnv,
   shouldAllowCliBackendLiveProviderSkip,
@@ -80,8 +77,6 @@ const CLI_MCP_SCHEMA_PROBE = isTruthyEnvValue(
 );
 const CLI_ALLOW_PROVIDER_SKIP = shouldAllowCliBackendLiveProviderSkip();
 const describeLive = LIVE && CLI_LIVE ? describe : describe.skip;
-
-const CLI_CONTINUITY_PROBE_PLUGIN_ID = "cli-continuity-probe";
 
 function createRuntimeBackendEntry(
   backend: ResolvedCliBackend,
@@ -387,12 +382,23 @@ describeLive("gateway live (cli backend)", () => {
       const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-live-cli-"));
       const stateDir = path.join(tempDir, "state");
       await fs.mkdir(stateDir, { recursive: true });
-      const schemaProbePlugin =
-        CLI_MCP_SCHEMA_PROBE || CLI_CACHE_PROBE
-          ? await createMcpSchemaProbePlugin(tempDir)
+      const enableMcpSchemaProbe = CLI_MCP_SCHEMA_PROBE || CLI_CACHE_PROBE;
+      // Load the continuity hook before startup so admitted generations own the fixture.
+      const probePlugin =
+        enableMcpSchemaProbe || resumeContinuityProbe
+          ? await createCliBackendProbePlugin(tempDir, {
+              mcpSchema: enableMcpSchemaProbe,
+              continuity: resumeContinuityProbe
+                ? {
+                    sessionKey,
+                    firstTurnMarker: resumeContinuityProbe.firstTurnMarker,
+                    injectedContext: resumeContinuityProbe.injectedContext,
+                  }
+                : undefined,
+            })
           : undefined;
-      const schemaProbePluginPath = schemaProbePlugin?.pluginPath;
-      const useMinimalToolsProfile = providerId === "codex-cli" && !schemaProbePluginPath;
+      const probePluginPath = probePlugin?.pluginPath;
+      const useMinimalToolsProfile = providerId === "codex-cli" && !enableMcpSchemaProbe;
       setTestEnvValue("OPENCLAW_STATE_DIR", stateDir);
       const bundleMcp = backendResolved.bundleMcp;
       const bootstrapWorkspace = await createBootstrapWorkspace(tempDir);
@@ -450,7 +456,7 @@ describeLive("gateway live (cli backend)", () => {
               },
             }
           : {}),
-        ...(schemaProbePluginPath || CLI_CACHE_PROBE
+        ...(probePluginPath || CLI_CACHE_PROBE
           ? {
               plugins: {
                 ...cfg.plugins,
@@ -462,18 +468,25 @@ describeLive("gateway live (cli backend)", () => {
                       slots: { memory: "none" },
                     }
                   : {}),
-                ...(schemaProbePluginPath
+                ...(probePluginPath
                   ? {
                       load: {
                         ...cfg.plugins?.load,
-                        paths: [...(cfg.plugins?.load?.paths ?? []), schemaProbePluginPath],
+                        paths: [...(cfg.plugins?.load?.paths ?? []), probePluginPath],
                       },
                     }
                   : {}),
                 entries: {
                   ...cfg.plugins?.entries,
-                  ...(schemaProbePluginPath
-                    ? { [MCP_SCHEMA_PROBE_PLUGIN_ID]: { enabled: true } }
+                  ...(probePluginPath
+                    ? {
+                        [CLI_BACKEND_PROBE_PLUGIN_ID]: {
+                          enabled: true,
+                          ...(resumeContinuityProbe
+                            ? { hooks: { allowConversationAccess: true } }
+                            : {}),
+                        },
+                      }
                     : {}),
                   ...(CLI_CACHE_PROBE ? { anthropic: { enabled: true } } : {}),
                 },
@@ -563,37 +576,6 @@ describeLive("gateway live (cli backend)", () => {
           cliBackendsTesting.setDepsForTest({
             resolvePluginSetupCliBackend: () => undefined,
             resolveRuntimeCliBackends: () => [cacheProbeBackend],
-          });
-        }
-        if (resumeContinuityProbe) {
-          const continuityHookRegistry = createMockPluginRegistry([
-            {
-              pluginId: CLI_CONTINUITY_PROBE_PLUGIN_ID,
-              hookName: "before_prompt_build",
-              handler: async (event: unknown, ctx: unknown) => {
-                const prompt = (event as { prompt?: unknown }).prompt;
-                const hookSessionKey = (ctx as { sessionKey?: unknown }).sessionKey;
-                if (
-                  hookSessionKey !== sessionKey ||
-                  typeof prompt !== "string" ||
-                  !prompt.includes(resumeContinuityProbe.firstTurnMarker)
-                ) {
-                  return undefined;
-                }
-                return { prependContext: resumeContinuityProbe.injectedContext };
-              },
-            },
-          ]);
-          initializeGlobalHookRunner(continuityHookRegistry);
-          // Keep bundled MCP capture enabled: the generation check below must cover the same
-          // delivery-capture process lifetime used by production Claude sessions.
-          cliBackendsTesting.setDepsForTest({
-            resolveRuntimeCliBackends: () => [
-              {
-                ...liveBackend,
-                pluginId: liveBackend.pluginId ?? CLI_CONTINUITY_PROBE_PLUGIN_ID,
-              },
-            ],
           });
         }
         client = await connectTestGatewayClient({
@@ -741,19 +723,26 @@ describeLive("gateway live (cli backend)", () => {
           let expectedLiveSessionGeneration: string | undefined;
           if (resumeContinuityProbe) {
             const nativeHistory = await activeClient.request<{
-              messages?: unknown[];
               sessionId?: string;
             }>("chat.history", { sessionKey });
-            const cliSessionId = resolveImportedClaudeCliSessionId(nativeHistory.messages ?? []);
-            // Hook-only runtime context belongs to the provider session, not the operator-visible
-            // transcript. The resumed reply below proves that the live provider retained it.
-            expect(JSON.stringify(nativeHistory.messages ?? [])).not.toContain(memoryToken);
-            expect(cliSessionId).toBeTruthy();
             const continuitySessionId = nativeHistory.sessionId;
             expect(continuitySessionId).toBeTruthy();
             if (!continuitySessionId) {
               throw new Error("Claude CLI continuity probe could not resolve its OpenClaw session");
             }
+            // chat.history also displays native CLI imports. Check the canonical replay
+            // source so recall cannot pass by reseeding the hook-only context from SQLite.
+            const canonicalHistory = JSON.stringify(
+              await loadCliSessionHistoryMessages({
+                sessionTarget: await resolveSessionTranscriptRuntimeTarget({
+                  agentId: "dev",
+                  sessionId: continuitySessionId,
+                  sessionKey,
+                }),
+              }),
+            );
+            expect(canonicalHistory).toContain(resumeContinuityProbe.expectedFirstReply);
+            expect(canonicalHistory).not.toContain(memoryToken);
             continuityOwner = {
               backendId: providerId,
               agentId: "dev",
@@ -799,7 +788,7 @@ describeLive("gateway live (cli backend)", () => {
           }
           const resumeText = extractPayloadText(resumePayload?.result);
           if (CLI_CACHE_PROBE) {
-            expect(resumeText).toContain(schemaProbePlugin?.resultToken);
+            expect(resumeText).toContain(probePlugin?.resultToken);
           } else if (providerId === "codex-cli") {
             expect(resumeText).toContain(`CLI-RESUME-${resumeNonce}`);
           } else if (resumeContinuityProbe) {
@@ -854,8 +843,6 @@ describeLive("gateway live (cli backend)", () => {
             if (settleHitRate === undefined) {
               return;
             }
-            // The first turn advertises one bootstrap-only tool. Allow the no-tool settle turn to
-            // run hot or cold, then capture the steady process after any valid schema rotation.
             cacheProbeSteadyGeneration = getCliLiveSessionGeneration(cacheProbeOwner!);
             expect(cacheProbeSteadyGeneration).toBeTruthy();
 
@@ -937,10 +924,8 @@ describeLive("gateway live (cli backend)", () => {
           });
           await verifyCliCronMcpLoopbackPreflight({
             sessionKey,
-            port,
-            token,
             env: process.env,
-            expectedSchemaProbeToolName: schemaProbePluginPath
+            expectedSchemaProbeToolName: enableMcpSchemaProbe
               ? MCP_SCHEMA_PROBE_TOOL_NAME
               : undefined,
           });

--- a/src/gateway/gateway-models.profiles.live.test.ts
+++ b/src/gateway/gateway-models.profiles.live.test.ts
@@ -16,8 +16,11 @@ import {
 } from "openclaw/plugin-sdk/llm";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { renderCatNoncePngBase64 } from "../../test/helpers/live-image-probe.js";
+import { installTestEnv } from "../../test/test-env.js";
 import { discoverAuthStorage, discoverModels } from "../agents/agent-model-discovery.js";
 import { resolveAgentWorkspaceDir, resolveDefaultAgentDir } from "../agents/agent-scope.js";
+import { buildPortableAuthProfileStoreForAgentCopy } from "../agents/auth-profiles/portability.js";
+import { listProfilesForProvider } from "../agents/auth-profiles/profile-list.js";
 import {
   ensureAuthProfileStore,
   ensureAuthProfileStoreWithoutExternalProfiles,
@@ -122,6 +125,7 @@ import { resolveEffectiveThinkingProfile } from "../plugins/provider-thinking.js
 import { LEGACY_IMPLICIT_AGENT_ID as DEFAULT_AGENT_ID } from "../routing/session-key.js";
 import { stripAssistantInternalScaffolding } from "../shared/text/assistant-visible-text.js";
 import { findFinalTagMatches, stripFinalTags } from "../shared/text/final-tags.js";
+import { withEnvAsync } from "../test-utils/env.js";
 import { deleteTestEnvValue, setTestEnvValue } from "../test-utils/env.js";
 import { getFreePort, isPortFree } from "../test-utils/ports.js";
 import { GATEWAY_CLIENT_MODES, GATEWAY_CLIENT_NAMES } from "../utils/message-channel.js";
@@ -2830,6 +2834,7 @@ type PreparedGatewayLiveModelCandidate = {
 function buildLiveGatewayAuthProfileStore(params: {
   store: AuthProfileStore;
   candidates: readonly PreparedGatewayLiveModelCandidate[];
+  requireProfileKeys?: boolean;
 }): AuthProfileStore {
   const directCredentialProviders = new Set<string>();
   const selectedProfileIds = new Map<string, string[]>();
@@ -2858,7 +2863,9 @@ function buildLiveGatewayAuthProfileStore(params: {
           `Prepared live auth profile "${selectedProfileId}" does not belong to ${modelRef}.`,
         );
       }
-    } else if (!requiresLiveProfileCredential(provider, REQUIRE_PROFILE_KEYS)) {
+    } else if (
+      !requiresLiveProfileCredential(provider, params.requireProfileKeys ?? REQUIRE_PROFILE_KEYS)
+    ) {
       if (auth.mode !== "aws-sdk") {
         if (!auth.apiKey) {
           throw new Error(`Prepared live auth for ${modelRef} is missing its direct credential.`);
@@ -2981,11 +2988,38 @@ function resolveGatewayLivePreparedProfileId(
     : undefined;
 }
 
-async function enterIsolatedGatewayLiveDiscoveryState(): Promise<() => Promise<void>> {
+async function enterIsolatedGatewayLiveDiscoveryState(params: {
+  config: OpenClawConfig;
+  providers?: Iterable<string>;
+}): Promise<() => Promise<void>> {
   const previousStateDir = process.env.OPENCLAW_STATE_DIR;
+  const source = ensureAuthProfileStoreWithoutExternalProfiles(
+    resolveDefaultAgentDir(params.config),
+    {
+      allowKeychainPrompt: false,
+      readOnly: true,
+      syncExternalCli: false,
+    },
+  );
+  const selected = params.providers
+    ? new Set(
+        [...params.providers].flatMap((provider) => listProfilesForProvider(source, provider)),
+      )
+    : undefined;
+  const portable = buildPortableAuthProfileStoreForAgentCopy({
+    ...source,
+    profiles: Object.fromEntries(
+      Object.entries(source.profiles).filter(([id]) => !selected || selected.has(id)),
+    ),
+  });
+  if (portable.skippedProfileIds.length > 0) {
+    logProgress(
+      `[all-models] isolated discovery omitted ${portable.skippedProfileIds.length} non-portable auth profile(s)`,
+    );
+  }
   const tempStateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-live-discovery-state-"));
   setTestEnvValue("OPENCLAW_STATE_DIR", tempStateDir);
-  return async () => {
+  const cleanup = async () => {
     if (previousStateDir === undefined) {
       delete process.env.OPENCLAW_STATE_DIR;
     } else {
@@ -2993,6 +3027,15 @@ async function enterIsolatedGatewayLiveDiscoveryState(): Promise<() => Promise<v
     }
     await fs.rm(tempStateDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 });
   };
+  try {
+    // Discovery may materialize env credentials; copy selected portable profiles
+    // first so it never writes the ambient store or duplicates native OAuth owners.
+    saveAuthProfileStore(portable.store, resolveDefaultAgentDir({}), { syncExternalCli: false });
+  } catch (error) {
+    await cleanup();
+    throw error;
+  }
+  return cleanup;
 }
 
 function createGatewayLiveModelSession(params: {
@@ -3199,7 +3242,7 @@ describe("buildLiveGatewayAuthProfileStore", () => {
     expect(resolveGatewayLivePreparedProfileId(store, "anthropic")).toBeUndefined();
   });
 
-  it("keeps prepared discovery credentials out of the ambient auth store", async () => {
+  it("copies selected portable discovery credentials without mutating the ambient auth store", async () => {
     const previousStateDir = process.env.OPENCLAW_STATE_DIR;
     const ambientStateDir = await fs.mkdtemp(
       path.join(os.tmpdir(), "openclaw-live-ambient-state-"),
@@ -3210,25 +3253,58 @@ describe("buildLiveGatewayAuthProfileStore", () => {
       version: 1,
       profiles: {
         "openai:ambient": { type: "api_key", provider: "openai", key: "ambient-test-key" },
+        "openai:token": { type: "token", provider: "openai", token: "ambient-test-token" },
+        "openai:refresh": {
+          type: "oauth",
+          provider: "openai",
+          access: "fixture-access",
+          refresh: "fixture-refresh",
+          expires: Date.now() + 60_000,
+        },
+        "unselected:ambient": {
+          type: "token",
+          provider: "unselected",
+          token: "unselected-test-token",
+        },
       },
+      order: { openai: ["openai:ambient", "openai:token", "openai:refresh"] },
     };
-    saveAuthProfileStore(ambientStore, ambientAgentDir);
+    saveAuthProfileStore(ambientStore, undefined, { syncExternalCli: false });
 
     try {
-      const leaveDiscoveryState = await enterIsolatedGatewayLiveDiscoveryState();
-      try {
-        const discoveryAgentDir = resolveDefaultAgentDir({});
-        expect(discoveryAgentDir).not.toBe(ambientAgentDir);
-        const prepared = materializeGatewayLiveDiscoveryAuth({
-          env: { OPENAI_API_KEY: "prepared-openai-test-key" },
-          providerList: ["openai"],
-          store: ensureAuthProfileStore(discoveryAgentDir, { allowKeychainPrompt: false }),
-        });
-        saveAuthProfileStore(prepared, discoveryAgentDir);
-      } finally {
-        await leaveDiscoveryState();
-      }
-
+      expect(existsSync(path.join(ambientStateDir, "agents"))).toBe(false);
+      await withEnvAsync(
+        { OPENCLAW_LIVE_TEST: "1", OPENCLAW_LIVE_USE_REAL_HOME: undefined },
+        async () => {
+          const testEnv = installTestEnv({ loadProfileEnv: false });
+          try {
+            const leaveDiscoveryState = await enterIsolatedGatewayLiveDiscoveryState({
+              config: {},
+              providers: ["openai"],
+            });
+            try {
+              const discoveryAgentDir = resolveDefaultAgentDir({});
+              expect(discoveryAgentDir).not.toBe(ambientAgentDir);
+              const copied = ensureAuthProfileStoreWithoutExternalProfiles(discoveryAgentDir);
+              expect(copied.profiles).toEqual({
+                "openai:ambient": ambientStore.profiles["openai:ambient"],
+                "openai:token": ambientStore.profiles["openai:token"],
+              });
+              expect(copied.order).toEqual({ openai: ["openai:ambient", "openai:token"] });
+              const prepared = materializeGatewayLiveDiscoveryAuth({
+                env: { OPENAI_API_KEY: "prepared-openai-test-key" },
+                providerList: ["openai"],
+                store: ensureAuthProfileStore(discoveryAgentDir, { allowKeychainPrompt: false }),
+              });
+              saveAuthProfileStore(prepared, discoveryAgentDir);
+            } finally {
+              await leaveDiscoveryState();
+            }
+          } finally {
+            testEnv.cleanup();
+          }
+        },
+      );
       expect(
         ensureAuthProfileStore(ambientAgentDir, { allowKeychainPrompt: false }).profiles,
       ).toEqual(ambientStore.profiles);
@@ -3265,6 +3341,7 @@ describe("buildLiveGatewayAuthProfileStore", () => {
 
     const isolated = buildLiveGatewayAuthProfileStore({
       store,
+      requireProfileKeys: false,
       candidates: [
         {
           model: createGatewayLiveTestModel("anthropic", "claude-sonnet-4-6"),
@@ -6284,7 +6361,10 @@ describeLive("gateway live (dev agent, profile keys)", () => {
   let leaveDiscoveryState: (() => Promise<void>) | undefined;
 
   beforeEach(async () => {
-    leaveDiscoveryState = await enterIsolatedGatewayLiveDiscoveryState();
+    leaveDiscoveryState = await enterIsolatedGatewayLiveDiscoveryState({
+      config: await readLiveTestConfig(),
+      providers: PROVIDERS ?? undefined,
+    });
   });
 
   afterEach(async () => {
@@ -6334,7 +6414,7 @@ describeLive("gateway live (dev agent, profile keys)", () => {
           env: process.env,
         });
         const workspaceDir = resolveAgentWorkspaceDir(cfg, DEFAULT_AGENT_ID);
-        const discoveryAgentDir = resolveDefaultAgentDir(cfg);
+        const discoveryAgentDir = resolveDefaultAgentDir({});
         const discoveryAuthProfileStore = ensureAuthProfileStore(discoveryAgentDir, {
           allowKeychainPrompt: false,
         });
@@ -6348,7 +6428,7 @@ describeLive("gateway live (dev agent, profile keys)", () => {
         }
         logProgress("[all-models] preparing models.json");
         const modelsJsonResult = await withGatewayLiveSetupTimeout(
-          ensureOpenClawModelsJson(cfg, undefined, {
+          ensureOpenClawModelsJson(cfg, discoveryAgentDir, {
             workspaceDir,
             ...(providerList ? { providerDiscoveryProviderIds: providerList } : {}),
           }),

--- a/src/gateway/gateway-models.profiles.live.test.ts
+++ b/src/gateway/gateway-models.profiles.live.test.ts
@@ -53,6 +53,7 @@ import { getApiKeyForModelCore, type ResolvedProviderAuth } from "../agents/mode
 import { normalizeProviderId } from "../agents/model-selection.js";
 import { shouldSuppressBuiltInModelCore } from "../agents/model-suppression.js";
 import { ensureOpenClawModelsJson } from "../agents/models-config.js";
+import { resolveProviderIdForAuth } from "../agents/provider-auth-aliases.js";
 import { STREAM_ERROR_FALLBACK_TEXT } from "../agents/stream-message-shared.js";
 import {
   appendPrioritizedDynamicLiveModels,
@@ -2840,7 +2841,7 @@ function buildLiveGatewayAuthProfileStore(params: {
   const materializedProfiles: AuthProfileStore["profiles"] = {};
 
   for (const { model, auth } of params.candidates) {
-    const provider = normalizeProviderId(model.provider);
+    const provider = resolveProviderIdForAuth(model.provider);
     const modelRef = `${model.provider}/${model.id}`;
     if (auth.source.startsWith("profile:") && !auth.profileId) {
       throw new Error(`Prepared live auth for ${modelRef} is missing its selected profile id.`);
@@ -2857,7 +2858,7 @@ function buildLiveGatewayAuthProfileStore(params: {
           `Prepared live auth profile "${selectedProfileId}" for ${modelRef} is missing from its source store.`,
         );
       }
-      if (normalizeProviderId(selectedProfile.provider) !== provider) {
+      if (resolveProviderIdForAuth(selectedProfile.provider) !== provider) {
         throw new Error(
           `Prepared live auth profile "${selectedProfileId}" does not belong to ${modelRef}.`,
         );
@@ -2913,7 +2914,7 @@ function buildLiveGatewayAuthProfileStore(params: {
   const profiles = {
     ...Object.fromEntries(
       Object.entries(params.store.profiles).filter(([, profile]) => {
-        return !directCredentialProviders.has(normalizeProviderId(profile.provider));
+        return !directCredentialProviders.has(resolveProviderIdForAuth(profile.provider));
       }),
     ),
     ...materializedProfiles,
@@ -2922,7 +2923,7 @@ function buildLiveGatewayAuthProfileStore(params: {
 
   const order: NonNullable<AuthProfileStore["order"]> = Object.fromEntries(
     Object.entries(params.store.order ?? {})
-      .filter(([provider]) => !directCredentialProviders.has(normalizeProviderId(provider)))
+      .filter(([provider]) => !directCredentialProviders.has(resolveProviderIdForAuth(provider)))
       .map(([provider, ids]) => [provider, ids.filter((id) => keepProfileIds.has(id))])
       .filter(([, ids]) => expectDefined(ids, "ids test invariant").length > 0),
   );
@@ -2934,7 +2935,8 @@ function buildLiveGatewayAuthProfileStore(params: {
     ? Object.fromEntries(
         Object.entries(params.store.lastGood).filter(([provider, id]) => {
           return (
-            !directCredentialProviders.has(normalizeProviderId(provider)) && keepProfileIds.has(id)
+            !directCredentialProviders.has(resolveProviderIdForAuth(provider)) &&
+            keepProfileIds.has(id)
           );
         }),
       )
@@ -3317,91 +3319,108 @@ describe("buildLiveGatewayAuthProfileStore", () => {
     }
   });
 
-  it("keeps an env-first provider on its prepared direct credential", () => {
-    const store: AuthProfileStore = {
-      version: 1,
-      profiles: {
-        anthropicProfile: {
-          type: "api_key",
-          provider: "anthropic",
-          key: "stored-anthropic-test-key",
-        },
-      },
-      order: {
-        anthropic: ["anthropicProfile"],
-      },
-      lastGood: {
-        anthropic: "anthropicProfile",
-      },
-      usageStats: {
-        anthropicProfile: { lastUsed: 1 },
-      },
-    };
-
-    const isolated = buildLiveGatewayAuthProfileStore({
-      store,
-      requireProfileKeys: false,
-      candidates: [
-        {
-          model: createGatewayLiveTestModel("anthropic", "claude-sonnet-4-6"),
-          auth: {
-            apiKey: "prepared-anthropic-test-key",
-            mode: "api-key",
-            source: "env: ANTHROPIC_API_KEY",
+  it.each(["anthropic", "claude-cli"])(
+    "keeps env-first %s on its prepared direct credential",
+    (modelProvider) => {
+      const store: AuthProfileStore = {
+        version: 1,
+        profiles: {
+          anthropicProfile: {
+            type: "api_key",
+            provider: "anthropic",
+            key: "stored-anthropic-test-key",
           },
         },
-      ],
-    });
-
-    expect(isolated.profiles.anthropicProfile).toBeUndefined();
-    expect(isolated.order).toBeUndefined();
-    expect(isolated.lastGood).toBeUndefined();
-    expect(isolated.usageStats).toBeUndefined();
-  });
-
-  it("preserves the exact selected source profile and prioritizes it in isolated order", () => {
-    const store: AuthProfileStore = {
-      version: 1,
-      profiles: {
-        "openai:other": {
-          type: "api_key",
-          provider: "openai",
-          key: "other-openai-test-key",
+        order: {
+          anthropic: ["anthropicProfile"],
         },
-        "openai:selected": {
-          type: "api_key",
-          provider: "openai",
-          key: "selected-openai-test-key",
+        lastGood: {
+          anthropic: "anthropicProfile",
         },
-      },
-      order: { openai: ["openai:other", "openai:selected"] },
-      usageStats: { "openai:selected": { lastUsed: 3 } },
-    };
+        usageStats: {
+          anthropicProfile: { lastUsed: 1 },
+        },
+      };
 
-    const isolated = buildLiveGatewayAuthProfileStore({
-      store,
-      candidates: [
-        {
-          model: createGatewayLiveTestModel("openai", "gpt-5.6-luna"),
-          auth: {
-            apiKey: "selected-openai-test-key",
-            profileId: "openai:selected",
-            mode: "api-key",
-            source: "profile:openai:selected",
+      const isolated = buildLiveGatewayAuthProfileStore({
+        store,
+        requireProfileKeys: false,
+        candidates: [
+          {
+            model: createGatewayLiveTestModel(modelProvider, "claude-sonnet-4-6"),
+            auth: {
+              apiKey: "prepared-anthropic-test-key",
+              mode: "api-key",
+              source: "env: ANTHROPIC_API_KEY",
+            },
+          },
+        ],
+      });
+
+      expect(isolated.profiles.anthropicProfile).toBeUndefined();
+      expect(isolated.order).toBeUndefined();
+      expect(isolated.lastGood).toBeUndefined();
+      expect(isolated.usageStats).toBeUndefined();
+    },
+  );
+
+  it.each([
+    { modelProvider: "openai", provider: "openai", modelId: "gpt-5.6-luna" },
+    { modelProvider: "claude-cli", provider: "anthropic", modelId: "claude-sonnet-4-6" },
+  ])(
+    "preserves the selected profile for $modelProvider in canonical auth order",
+    ({ modelProvider, provider, modelId }) => {
+      const store: AuthProfileStore = {
+        version: 1,
+        profiles: {
+          other: {
+            type: "api_key",
+            provider,
+            key: "other-test-key",
+          },
+          selected: {
+            type: "api_key",
+            provider,
+            key: "selected-test-key",
           },
         },
-      ],
-    });
+        order: { [provider]: ["other", "selected"] },
+        usageStats: { selected: { lastUsed: 3 } },
+      };
 
-    expect(isolated.profiles["openai:selected"]).toEqual(store.profiles["openai:selected"]);
-    expect(isolated.order?.openai).toEqual(["openai:selected", "openai:other"]);
-    expect(isolated.usageStats?.["openai:selected"]).toEqual({ lastUsed: 3 });
-  });
+      const isolated = buildLiveGatewayAuthProfileStore({
+        store,
+        candidates: [
+          {
+            model: createGatewayLiveTestModel(modelProvider, modelId),
+            auth: {
+              apiKey: "selected-test-key",
+              profileId: "selected",
+              mode: "api-key",
+              source: "profile:selected",
+            },
+          },
+        ],
+      });
 
-  it("rejects selected profiles absent from the authoritative source store", () => {
+      expect(isolated.profiles["selected"]).toEqual(store.profiles["selected"]);
+      expect(isolated.order?.[provider]).toEqual(["selected", "other"]);
+      expect(isolated.usageStats?.["selected"]).toEqual({ lastUsed: 3 });
+    },
+  );
+
+  it.each([
+    { provider: undefined, error: /openai:missing.*missing from its source store/ },
+    { provider: "unrelated", error: /openai:missing.*does not belong to openai/ },
+  ])("rejects missing or unrelated selected profiles ($provider)", ({ provider, error }) => {
     expect(() =>
       buildLiveGatewayAuthProfileStore({
-        store: { version: 1, profiles: {} },
+        store: {
+          version: 1,
+          profiles: provider
+            ? { "openai:missing": { type: "api_key", provider, key: "unrelated-test-key" } }
+            : {},
+        },
         candidates: [
           {
             model: createGatewayLiveTestModel("openai", "gpt-5.6-luna"),
@@ -3414,7 +3433,7 @@ describe("buildLiveGatewayAuthProfileStore", () => {
           },
         ],
       }),
-    ).toThrow(/openai:missing.*missing from its source store/);
+    ).toThrow(error);
   });
 });
 function extractTranscriptMessageText(message: unknown): string {

--- a/src/gateway/gateway-models.profiles.live.test.ts
+++ b/src/gateway/gateway-models.profiles.live.test.ts
@@ -125,8 +125,7 @@ import { resolveEffectiveThinkingProfile } from "../plugins/provider-thinking.js
 import { LEGACY_IMPLICIT_AGENT_ID as DEFAULT_AGENT_ID } from "../routing/session-key.js";
 import { stripAssistantInternalScaffolding } from "../shared/text/assistant-visible-text.js";
 import { findFinalTagMatches, stripFinalTags } from "../shared/text/final-tags.js";
-import { withEnvAsync } from "../test-utils/env.js";
-import { deleteTestEnvValue, setTestEnvValue } from "../test-utils/env.js";
+import { deleteTestEnvValue, setTestEnvValue, withEnvAsync } from "../test-utils/env.js";
 import { getFreePort, isPortFree } from "../test-utils/ports.js";
 import { GATEWAY_CLIENT_MODES, GATEWAY_CLIENT_NAMES } from "../utils/message-channel.js";
 import { GatewayClient } from "./client.js";

--- a/src/gateway/worker-environments/workspace-sync-scripts.test.ts
+++ b/src/gateway/worker-environments/workspace-sync-scripts.test.ts
@@ -596,7 +596,10 @@ esac
       await fs.writeFile(path.join(input.bin, "ps"), healthyPs);
       await fs.chmod(path.join(input.bin, "ps"), 0o755);
 
-      expect(await waitForProcessState(child.pid!, /^[^T]/u)).not.toMatch(/^T/u);
+      // SIGCONT precedes lease removal. Wait for the watchdog's terminal state,
+      // including an unreaped zombie, before asserting its completed cleanup.
+      expect(await waitForProcessState(lease.watchdog.pid, /^(?:Z|$)/u)).toMatch(/^(?:Z|$)/u);
+      expect(await processState(child.pid!)).toMatch(/^[^T]/u);
       await expect(fs.stat(leasePath(input.home, input.workspace, nonce))).rejects.toThrow();
     } finally {
       await stopIdleWorker(child);

--- a/test/helpers/stage-live-auth-profiles.ts
+++ b/test/helpers/stage-live-auth-profiles.ts
@@ -1,28 +1,34 @@
 import fs from "node:fs";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
+import { buildPortableAuthProfileStoreForAgentCopy } from "../../src/agents/auth-profiles/portability.js";
 import {
   inspectPersistedAuthProfileStateRaw,
   inspectPersistedAuthProfileStoreRaw,
   resolveAuthProfileDatabaseOwnerId,
   resolveAuthProfileDatabasePath,
-  runAuthProfileWriteTransaction,
-  writePersistedAuthProfileStateRaw,
-  writePersistedAuthProfileStoreRaw,
 } from "../../src/agents/auth-profiles/sqlite.js";
+import {
+  ensureAuthProfileStoreWithoutExternalProfiles,
+  saveAuthProfileStore,
+  withAuthProfileStoreAgentDir,
+} from "../../src/agents/auth-profiles/store.js";
+import { DEFAULT_AGENT_ID } from "../../src/routing/session-key.js";
 import { withOpenClawAgentDatabaseReadOnly } from "../../src/state/openclaw-agent-db-readonly.js";
 
 export function stageLiveAuthProfiles(realStateDir: string, tempStateDir: string): void {
   const agentsDir = path.join(realStateDir, "agents");
-  if (!fs.existsSync(agentsDir)) {
-    return;
-  }
-
-  for (const entry of fs.readdirSync(agentsDir, { withFileTypes: true })) {
-    if (!entry.isDirectory()) {
-      continue;
-    }
-    const sourceAgentDir = path.join(agentsDir, entry.name, "agent");
+  const agentIds = new Set([
+    DEFAULT_AGENT_ID,
+    ...(fs.existsSync(agentsDir)
+      ? fs
+          .readdirSync(agentsDir, { withFileTypes: true })
+          .filter((entry) => entry.isDirectory())
+          .map((entry) => entry.name)
+      : []),
+  ]);
+  for (const agentId of agentIds) {
+    const sourceAgentDir = path.join(agentsDir, agentId, "agent");
     const sourceDatabasePath = resolveAuthProfileDatabasePath(sourceAgentDir);
     const sourceSnapshot = withOpenClawAgentDatabaseReadOnly(
       (database) => {
@@ -48,45 +54,37 @@ export function stageLiveAuthProfiles(realStateDir: string, tempStateDir: string
     );
     if (!sourceSnapshot.found) {
       if (sourceSnapshot.reason === "schema-missing") {
-        throw new Error(
-          `Could not safely stage SQLite auth profiles for live agent "${entry.name}".`,
-        );
+        throw new Error(`Could not safely stage SQLite auth profiles for live agent "${agentId}".`);
       }
-      continue;
     }
-    const sourceStore = sourceSnapshot.value.store;
-    const sourceState = sourceSnapshot.value.state;
-    if (sourceStore.status === "unreadable" || sourceState.status === "unreadable") {
-      throw new Error(
-        `Could not safely stage SQLite auth profiles for live agent "${entry.name}".`,
-      );
+    const sourceStore = sourceSnapshot.found ? sourceSnapshot.value.store : undefined;
+    const sourceState = sourceSnapshot.found ? sourceSnapshot.value.state : undefined;
+    if (sourceStore?.status === "unreadable" || sourceState?.status === "unreadable") {
+      throw new Error(`Could not safely stage SQLite auth profiles for live agent "${agentId}".`);
     }
-    const storeTableMissing = sourceStore.status === "missing" && sourceStore.reason === "table";
-    const stateTableMissing = sourceState.status === "missing" && sourceState.reason === "table";
+    const storeTableMissing = sourceStore?.status === "missing" && sourceStore.reason === "table";
+    const stateTableMissing = sourceState?.status === "missing" && sourceState.reason === "table";
     if (storeTableMissing || stateTableMissing) {
       throw new Error(
-        `Could not safely stage SQLite auth profiles for live agent "${entry.name}": canonical auth schema is incomplete.`,
+        `Could not safely stage SQLite auth profiles for live agent "${agentId}": canonical auth schema is incomplete.`,
       );
     }
-    if (sourceStore.status !== "readable" && sourceState.status !== "readable") {
+    const portable = withAuthProfileStoreAgentDir(sourceAgentDir, realStateDir, () =>
+      buildPortableAuthProfileStoreForAgentCopy(
+        ensureAuthProfileStoreWithoutExternalProfiles(sourceAgentDir, {
+          readOnly: true,
+          syncExternalCli: false,
+        }),
+      ),
+    );
+    if (portable.copiedProfileIds.length === 0) {
       continue;
     }
-
-    const targetAgentDir = path.join(tempStateDir, "agents", entry.name, "agent");
-    fs.mkdirSync(targetAgentDir, { recursive: true });
-    // Copy only canonical auth rows; cloning the agent database would expose
-    // unrelated sessions to the isolated live-test home.
-    runAuthProfileWriteTransaction(
-      targetAgentDir,
-      (database) => {
-        if (sourceStore.status === "readable") {
-          writePersistedAuthProfileStoreRaw(sourceStore.raw, targetAgentDir, database);
-        }
-        if (sourceState.status === "readable") {
-          writePersistedAuthProfileStateRaw(sourceState.raw, targetAgentDir, database);
-        }
-      },
-      { stateDir: tempStateDir },
+    const targetAgentDir = path.join(tempStateDir, "agents", agentId, "agent");
+    // Copy the canonical portable view, including shared static credentials;
+    // never clone session databases or acquire another OAuth refresh owner.
+    withAuthProfileStoreAgentDir(targetAgentDir, tempStateDir, () =>
+      saveAuthProfileStore(portable.store, targetAgentDir, { syncExternalCli: false }),
     );
   }
 }

--- a/test/scripts/live-docker-stage.test.ts
+++ b/test/scripts/live-docker-stage.test.ts
@@ -1,4 +1,5 @@
 // Live Docker Stage tests cover live docker stage script behavior.
+import { spawnSync } from "node:child_process";
 import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -11,6 +12,48 @@ const stageScriptPath = path.join(repoRoot, "scripts/lib/live-docker-stage.sh");
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 describe("live Docker state staging", () => {
+  it.each([
+    { geminiKey: "test-gemini-key", googleKey: "", expectedType: "gemini-api-key" },
+    { geminiKey: "", googleKey: "test-google-key", expectedType: "vertex-ai" },
+    { geminiKey: "", googleKey: "", expectedType: "oauth-personal" },
+  ])("selects $expectedType from the supplied Gemini credentials", (testCase) => {
+    const home = tempDirs.make("openclaw-live-stage-gemini-");
+    const settingsPath = path.join(home, ".gemini", "settings.json");
+    mkdirSync(path.dirname(settingsPath));
+    writeFileSync(
+      settingsPath,
+      JSON.stringify({
+        security: { auth: { selectedType: "oauth-personal" } },
+        privacy: { usageStatisticsEnabled: false },
+      }),
+    );
+
+    const result = spawnSync(
+      "bash",
+      ["-c", 'source "$1"; openclaw_live_stage_gemini_auth', "bash", stageScriptPath],
+      {
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          HOME: home,
+          GEMINI_API_KEY: testCase.geminiKey,
+          GOOGLE_API_KEY: testCase.googleKey,
+          GOOGLE_GENAI_USE_VERTEXAI: "",
+        },
+      },
+    );
+
+    expect(result.status, result.stderr).toBe(0);
+    const settings = JSON.parse(readFileSync(settingsPath, "utf8"));
+    expect(settings.security.auth.selectedType).toBe(testCase.expectedType);
+    expect(settings.security.auth.enforcedType).toBe(
+      testCase.geminiKey || testCase.googleKey ? testCase.expectedType : undefined,
+    );
+    expect(settings.privacy).toEqual({ usageStatisticsEnabled: false });
+    expect(readFileSync(settingsPath, "utf8")).not.toContain("test-gemini-key");
+    expect(readFileSync(settingsPath, "utf8")).not.toContain("test-google-key");
+  });
+
   it("keeps repo-local generated artifacts out of the source copy", () => {
     const script = readFileSync(stageScriptPath, "utf8");
 

--- a/test/scripts/print-cli-backend-live-metadata.test.ts
+++ b/test/scripts/print-cli-backend-live-metadata.test.ts
@@ -1,8 +1,36 @@
 // Print Cli Backend Live Metadata tests cover print cli backend live metadata script behavior.
-import { describe, expect, it } from "vitest";
-import { resolveCliBackendLiveMetadata } from "../../scripts/print-cli-backend-live-metadata.js";
+import { describe, expect, it, vi } from "vitest";
+import {
+  resolveCliBackendDockerPackages,
+  resolveCliBackendLiveMetadata,
+} from "../../scripts/print-cli-backend-live-metadata.js";
+
+vi.mock("../../src/agents/cli-backends.js", () => ({
+  resolveCliBackendConfig: () => ({ config: { command: "fixture-cli" } }),
+  resolveCliBackendLiveTest: (provider: string) => ({
+    defaultModelRef: `${provider}/model`,
+    ...(provider.startsWith("fixture-cli") ? { dockerNpmPackage: "@fixture/cli@1.2.3" } : {}),
+  }),
+}));
+vi.mock("../../src/plugins/setup-registry.js", () => ({
+  resolvePluginSetupRegistry: () => ({
+    cliBackends: [{ backend: { id: "fixture-cli", modelProvider: "fixture-provider" } }],
+  }),
+}));
 
 describe("print-cli-backend-live-metadata", () => {
+  it.each([
+    { providers: ["api-provider"], expected: [] },
+    { providers: ["fixture-provider"], expected: ["@fixture/cli@1.2.3"] },
+    {
+      providers: ["fixture-cli", "fixture-cli-alias", "api-provider"],
+      expected: ["@fixture/cli@1.2.3"],
+    },
+    { providers: [], expected: ["@fixture/cli@1.2.3"] },
+  ])("resolves only selected Docker CLI packages: $providers", async ({ providers, expected }) => {
+    expect(await resolveCliBackendDockerPackages(providers)).toEqual(expected);
+  });
+
   it("builds one unsupported codex-cli metadata payload", async () => {
     expect(await resolveCliBackendLiveMetadata("codex-cli")).toEqual({
       provider: "codex-cli",

--- a/test/scripts/test-live-shard.test.ts
+++ b/test/scripts/test-live-shard.test.ts
@@ -146,13 +146,6 @@ describe("scripts/test-live-shard", () => {
     );
   });
 
-  it("keeps the Codex CLI backend live smoke on a minimal tool profile", () => {
-    const source = readFileSync("src/gateway/gateway-cli-backend.live.test.ts", "utf8");
-
-    expect(source).toContain('providerId === "codex-cli" && !schemaProbePluginPath');
-    expect(source).toContain('profile: "minimal" as const');
-  });
-
   it("rejects unknown shard names", () => {
     expect(() => selectLiveShardFiles("native-live-missing")).toThrow(/Unknown live test shard/u);
     expect(() => selectLiveShardFiles("native-live-extensions-l-z")).toThrow(

--- a/test/test-env.ts
+++ b/test/test-env.ts
@@ -383,10 +383,6 @@ function sanitizeLiveConfig(raw: string): string {
 }
 
 function copyLiveAuthProfiles(realStateDir: string, tempStateDir: string): void {
-  const agentsDir = path.join(realStateDir, "agents");
-  if (!fs.existsSync(agentsDir)) {
-    return;
-  }
   const liveAuthStageScript = path.resolve(
     path.dirname(fileURLToPath(import.meta.url)),
     "helpers",


### PR DESCRIPTION
## What Problem This Solves
The live CLI Docker fixtures could select stale Gemini auth settings, inject continuity hooks after the Gateway had captured its registry, and attempt a privileged cron mutation with a discovery-only MCP owner token. Gateway discovery also lost canonical shared credentials twice during test isolation, and its container did not provision the selected native CLI. These failures obscured real backend regressions.

## Why This Change Was Made
Reuse the existing Gemini auth staging logic from the ACP harness in both CLI paths, editing only disposable container settings. Load one real fixture plugin before Gateway startup. Check that the first-turn-only public label is absent from canonical replay while still requiring exact native recall and the same process generation. Remove the obsolete presentation-import-ID check.

MCP preflight now checks initialization, discovery and schema. The actual admitted agent remains responsible for cron mutation, and the probe verifies the explicit session target, stored identity, CLI visibility and cleanup. No authorization guard, generation assertion, retry or timeout is weakened.

## Evidence
- Final extracted snapshot:38 tests across five projects pass; the unauthorized preflight mutation regression failed before repair. Fresh independent Codex autoreview and manual owner/dependency review passed.
- Gemini0.57.0 auth source confirms configured selectedType overrides environment selection, and distinguishes Gemini API key from Vertex express auth. Three staging cases cover both key modes and preserved native OAuth; no credential values are written to settings.
- Real Gemini first/resume plus admitted cron MCP passed286.13s with the separate Google native-compaction repair (#132527).
- Real Claude subscription first/resume passed231.41s with the separate SDK environment repair (#132535); exact recall, canonical replay absence and native-generation equality passed without warmup.
- Real Claude API-key cache passed244.49s:99.74% steady hits, deliberate thinking switch cold then99.72% steady.
- Real proof workflow: https://github.com/openclaw/openclaw/actions/runs/33243495176 . These runs use the pinned original source plus explicit owned overlays; they are not a full current-main pass.

The API-key resume/MCP variant now has a clean, uninstrumented passing replay (167.71s) with the separate context-budget owner repair #132544. One earlier post-repair run failed process-generation equality; it remains recorded and repeatability is being checked separately.

## Gateway isolation follow-up
The container now installs selected CLI packages from owner metadata into a disposable prefix, including canonical-provider selections. Both isolation boundaries copy the canonical portable auth view with external CLI synchronization disabled. The outer test environment no longer assumes an agents directory exists: static credentials may live entirely in the shared state database. OAuth portability remains governed by the existing owner policy; no refresh owner is duplicated.

The regression follows the real order: shared canonical credential producer without an agents directory → test environment staging → Gateway discovery isolation. It verifies selected API-key/token profiles and order, excludes non-portable/unselected profiles, and leaves the source unchanged. The old raw auth-row copy is removed. A stale source-text grep was deleted after it failed CI on the renamed MCP fixture helper; behavioral coverage remains.

- Extracted current PR snapshot:161 Gateway helper tests pass (2 live-disabled skips), plus49 staging/lifetime/metadata/shard tests. Source-order regression and metadata selection failed before repair. Format, script typed lint, shell syntax and fresh Codex review pass.
- Local root typecheck is blocked by pre-existing borrowed dependency type mismatches (Google SDK, Markdown, Pi TUI, pako); exact-head hosted CI is the required type gate.
- Real gateway replay on workflow [33245961333](https://github.com/openclaw/openclaw/actions/runs/33245961333) now selects8 candidates with0 auth skips and makes real authenticated model calls. Six models completed explanation, file-read nonce and refusal/followup probes; one catalog model was unavailable. The aggregate remains red because one model returned a refusal in the refusal-marker probe (149 passed,1 failed;147.28s). This is not represented as a full lane pass.
- The original native claude-cli exported OAuth credential is expired; the successful credential boundary proof above uses the supported canonical Anthropic provider with a setup-token imported by the documented CLI, with ambient API-key fallback removed.

Application runtime LOC0. All growth is Docker automation and regression/support code. No schema, operator configuration, host credential changes or new authentication fallback.


## Final fixture/CI follow-ups
Canonical provider-auth alias resolution now owns all five identity comparisons/projections in isolated profile preparation. This admits a valid Anthropic profile selected for `claude-cli`, removes canonical stored credentials/order/last-good metadata for env-first aliases, and still rejects unrelated profiles. Two regressions failed before the change; the final extracted Gateway fixture passes164 tests (2 live-disabled skips). The original native provider replay now reaches its selected profiles and real model calls; expired-session responses remain under separate subprocess/dependency investigation, so the original matrix lane is not claimed green.

A separate CI-only test race was repaired in the same verification neighborhood: the watchdog sends SIGCONT before deleting its lease, so observing a resumed worker did not prove cleanup finished. The test now waits for the existing watchdog terminal-state boundary, then checks worker liveness and exact lease absence. No runtime code, timeout or assertion was weakened. The15-test file and three separate focused repetitions pass; the original CI failure is retained because a natural local before-run passed.
