### PR TITLE
improve(qa): shorten Gateway hard-kill recovery proof

### DIFF
--- a/extensions/qa-lab/src/gateway-kill-restart-send.e2e.test.ts
+++ b/extensions/qa-lab/src/gateway-kill-restart-send.e2e.test.ts
@@ -168,7 +168,7 @@ describe.skipIf(process.platform === "win32")("gateway hard-kill recovery", () =
         { cause: error },
       );
     }
-    // Nominal runtime is ~130s; heavily loaded hosts stretch child boots and
-    // waits severalfold, so the budget leaves real headroom before flaking.
+    // Heavily loaded hosts stretch child boots and the pending checkpoint wait,
+    // so the budget leaves real headroom before flaking.
   }, 600_000);
 });

--- a/extensions/qa-lab/src/providers/mock-openai/mock-openai-contracts.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/mock-openai-contracts.ts
@@ -354,6 +354,8 @@ export const QA_TOOL_SEARCH_FAILURE_PROMPT_RE = /tool search qa failure/i;
 export const QA_MCP_CODE_MODE_PROMPT_RE = /mcp code mode qa check/i;
 export const QA_RESTART_CODE_MODE_WAIT_PROMPT_RE = /code mode restart wait qa check/i;
 export const QA_RESTART_RECOVERY_PROMPT_RE = /previous turn was interrupted by a gateway restart/i;
+export const QA_KILL_RESTART_PROMPT_RE = /\bKILL-RESTART-PROMPT\b/u;
+export const QA_KILL_RESTART_RECOVERED_MARKER = "KILL-RESTART-RECOVERED-OK";
 const QA_AUDIO_TRANSCRIPTION_TEXT =
   "Reply with only this exact marker: WHATSAPP_QA_AUDIO_TRANSCRIPT_OK";
 const QA_GROUP_AUDIO_TRANSCRIPTION_TEXT =

--- a/extensions/qa-lab/src/providers/mock-openai/server.test.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/server.test.ts
@@ -6884,70 +6884,127 @@ Update and merge these partial structured summaries.`,
     expect(outputText(payload)).not.toBe("Protocol note: replay unsafe after write.");
   });
 
+  const restartCheckpointTools = [
+    {
+      type: "function",
+      name: "exec",
+      parameters: {
+        type: "object",
+        properties: {
+          language: { type: "string" },
+          code: { type: "string" },
+          restartSafe: { type: "boolean" },
+        },
+        required: ["code"],
+      },
+    },
+    {
+      type: "function",
+      name: "wait",
+      parameters: {
+        type: "object",
+        properties: { runId: { type: "string" } },
+        required: ["runId"],
+      },
+    },
+  ];
+  const restartRecoveryPrompt =
+    "Your previous turn was interrupted by a gateway restart. Continue from the existing transcript.";
+
+  async function expectRestartCheckpointExecution(
+    execArgs: Record<string, unknown>,
+    checkpoint: number,
+  ) {
+    expect(execArgs).toMatchObject({ language: "javascript", restartSafe: true });
+    expect(execArgs.code).toContain("qa_restart_wait");
+    expect(execArgs.code).toContain('catalog.search("qa_restart_wait")');
+    expect(execArgs.code).toContain(`CHECKPOINT-${checkpoint}`);
+
+    const started = createDeferred<void>();
+    const released = createDeferred<void>();
+    const calls: unknown[] = [];
+    const target = Object.assign(
+      (args: unknown) => {
+        calls.push(args);
+        started.resolve();
+        return released.promise;
+      },
+      { toolName: "qa_restart_wait" },
+    );
+    let yielded = false;
+    const execution: unknown = runInNewContext(`(async () => { ${String(execArgs.code)} })()`, {
+      catalog: {
+        search: async (name: string) => {
+          expect(name).toBe("qa_restart_wait");
+          return [target];
+        },
+      },
+      yield_control: () => {
+        yielded = true;
+      },
+    });
+    try {
+      await started.promise;
+      expect(yielded).toBe(true);
+    } finally {
+      released.resolve();
+      await expect(execution).resolves.toBe(`CHECKPOINT-${checkpoint}`);
+    }
+    expect(calls).toEqual([{}]);
+  }
+
+  it("settles hard-kill recovery after one real checkpoint and resets from request history", async () => {
+    const server = await startMockServer();
+    const prompt = "Code Mode restart wait QA check. Original prompt marker: KILL-RESTART-PROMPT.";
+    const tools = [
+      ...restartCheckpointTools,
+      { type: "function", name: "qa_restart_unsafe_probe", parameters: { type: "object" } },
+    ];
+    const input: Array<Record<string, unknown>> = [makeUserInput(prompt)];
+    const execPayload = await expectOpenAiNonStreamingResponsesJson(server, { tools, input });
+    expect(outputItems(execPayload)).toHaveLength(1);
+    const execCall = outputToolCall(execPayload, "exec");
+    const execArgs = outputToolArgsFromItem(execCall);
+    await expectRestartCheckpointExecution(execArgs, 1);
+
+    const runId = "kill-restart-checkpoint-1";
+    input.push(
+      execCall,
+      makeToolOutputWithCallId(
+        outputToolCallId(execCall, "kill-restart-exec"),
+        JSON.stringify({ status: "waiting", runId }),
+      ),
+    );
+    const waitPayload = await expectOpenAiNonStreamingResponsesJson(server, { tools, input });
+    expect(outputItems(waitPayload)).toHaveLength(1);
+    const waitCall = outputToolCall(waitPayload, "wait");
+    expect(outputToolArgsFromItem(waitCall)).toEqual({ runId });
+    input.push(waitCall, makeUserInput(restartRecoveryPrompt));
+
+    const recovered = await expectOpenAiNonStreamingResponsesJson(server, { tools, input });
+    expect(outputItems(recovered).map((item) => item.type)).toEqual(["message"]);
+    expect(outputText(recovered)).toBe("KILL-RESTART-RECOVERED-OK");
+
+    const freshPayload = await expectOpenAiNonStreamingResponsesJson(server, {
+      tools,
+      input: [makeUserInput(prompt)],
+    });
+    expect(outputItems(freshPayload)).toHaveLength(1);
+    expect(outputToolArgsFromItem(outputToolCall(freshPayload, "exec"))).toEqual(execArgs);
+  });
+
   it("derives three restart checkpoints from request history without server counters", async () => {
     const server = await startMockServer();
     const prompt =
       "Code Mode restart wait QA check. Original prompt marker: RESTART-CODE-MODE-PROMPT.";
-    const recoveryPrompt =
-      "Your previous turn was interrupted by a gateway restart. Continue from the existing transcript.";
-    const tools = [
-      {
-        type: "function",
-        name: "exec",
-        parameters: {
-          type: "object",
-          properties: {
-            language: { type: "string" },
-            code: { type: "string" },
-            restartSafe: { type: "boolean" },
-          },
-          required: ["code"],
-        },
-      },
-      {
-        type: "function",
-        name: "wait",
-        parameters: {
-          type: "object",
-          properties: { runId: { type: "string" } },
-          required: ["runId"],
-        },
-      },
-    ];
+    const tools = restartCheckpointTools;
     const input: Array<Record<string, unknown>> = [makeUserInput(prompt)];
 
     for (const checkpoint of [1, 2, 3]) {
       const execPayload = await expectOpenAiNonStreamingResponsesJson(server, { tools, input });
       const execCall = outputToolCall(execPayload, "exec");
       const execArgs = outputToolArgsFromItem(execCall);
-      expect(execArgs).toMatchObject({ language: "javascript", restartSafe: true });
-      expect(execArgs.code).toContain("qa_restart_wait");
-      expect(execArgs.code).toContain('catalog.search("qa_restart_wait")');
-      expect(execArgs.code).toContain(`CHECKPOINT-${checkpoint}`);
-
-      const started = createDeferred<void>();
-      const released = createDeferred<void>();
-      let yielded = false;
-      const target = Object.assign(
-        () => {
-          started.resolve();
-          return released.promise;
-        },
-        { toolName: "qa_restart_wait" },
-      );
-      const execution = runInNewContext(`(async () => { ${String(execArgs.code)} })()`, {
-        catalog: { search: async () => [target] },
-        yield_control: () => {
-          yielded = true;
-        },
-      }) as Promise<unknown>;
-      try {
-        await started.promise;
-        expect(yielded).toBe(true);
-      } finally {
-        released.resolve();
-        await expect(execution).resolves.toBe(`CHECKPOINT-${checkpoint}`);
-      }
+      await expectRestartCheckpointExecution(execArgs, checkpoint);
 
       const runId = `restart-checkpoint-${checkpoint}`;
       input.push(
@@ -6960,7 +7017,7 @@ Update and merge these partial structured summaries.`,
       const waitPayload = await expectOpenAiNonStreamingResponsesJson(server, { tools, input });
       const waitCall = outputToolCall(waitPayload, "wait");
       expect(outputToolArgsFromItem(waitCall)).toEqual({ runId });
-      input.push(waitCall, makeUserInput(recoveryPrompt));
+      input.push(waitCall, makeUserInput(restartRecoveryPrompt));
     }
 
     const finalPayload = await expectOpenAiNonStreamingResponsesJson(server, { tools, input });

--- a/extensions/qa-lab/src/providers/mock-openai/server.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/server.ts
@@ -96,6 +96,8 @@ import {
   QA_MCP_CODE_MODE_PROMPT_RE,
   QA_RESTART_CODE_MODE_WAIT_PROMPT_RE,
   QA_RESTART_RECOVERY_PROMPT_RE,
+  QA_KILL_RESTART_PROMPT_RE,
+  QA_KILL_RESTART_RECOVERED_MARKER,
   QA_MCP_CODE_MODE_API_FILE_PROMPT_RE,
   type MockScenarioState,
   sourceDiscoveryReadPathForProvider,
@@ -910,6 +912,14 @@ async function buildResponsesPayload(
     return buildFailedResponseEvents();
   }
   const toolJson = parseToolOutputJson(scenarioToolOutput);
+  // The hard-kill fixture shares the first real checkpoint below, but recovery
+  // must settle without scheduling the repeated-restart fixture's later waits.
+  if (
+    QA_KILL_RESTART_PROMPT_RE.test(allInputText) &&
+    QA_RESTART_RECOVERY_PROMPT_RE.test(allInputText)
+  ) {
+    return buildAssistantEvents(QA_KILL_RESTART_RECOVERED_MARKER);
+  }
   if (QA_RESTART_CODE_MODE_WAIT_PROMPT_RE.test(allInputText)) {
     const progress = readRestartCheckpointProgress(input);
     const currentControlCallId = extractToolOutputCallId(input);


### PR DESCRIPTION
## What Problem This Solves

Resolves an operational test-performance problem where the QA hard-kill recovery E2E spent roughly five minutes replaying two additional 30-second restart checkpoints after it had already exercised the real boundary it owns. That made the focused recovery command unusually slow and memory-heavy while duplicating the separate three-checkpoint restart contract.

## Why This Change Was Made

The hard-kill scenario now carries a dedicated prompt marker and settles after its first real pending restart-safe Code Mode call is interrupted by a process-group SIGKILL and recovered after Gateway restart. The general three-checkpoint fixture remains unchanged and continues to own repeated-restart progression; a focused mock-server regression proves the dedicated path emits no second or third checkpoint and resets solely from request history.

This is AI-assisted work. I reviewed the implementation and its owner/dependency boundaries.

## User Impact

There is no product-runtime behavior change. Maintainers and CI get materially faster, lower-memory proof of Gateway hard-kill recovery without losing the real process, socket, session, transcript, orphan-reconciliation, or queued-delivery coverage.

## Evidence

### Controlled performance benchmark

Current-`main` baseline versus this branch, on one Blacksmith Testbox with excluded warmups, eight order-balanced A/B pairs, one Vitest worker, distinct filesystem module caches, import-duration reporting, and `/usr/bin/time -v`:

| Pair | Current main | Candidate | Saving |
| ---: | ---: | ---: | ---: |
| 1 | `302.84s` | `24.35s` | `278.49s` |
| 2 | `309.84s` | `27.47s` | `282.37s` |
| 3 | `302.41s` | `25.51s` | `276.90s` |
| 4 | `319.89s` | `24.60s` | `295.29s` |
| 5 | `306.35s` | `24.46s` | `281.89s` |
| 6 | `307.93s` | `24.45s` | `283.48s` |
| 7 | `303.74s` | `24.63s` | `279.11s` |
| 8 | `305.33s` | `24.61s` | `280.72s` |

- Mean command wall: `307.29s` → `25.01s` (`282.28s`, `91.86%` faster)
- Favorable pairs: `8/8`
- Mean Vitest file duration: `92820.27ms` → `17451.98ms`
- Mean peak RSS: `5987649.5 KiB` → `1147689.5 KiB` (`80.83%` lower)
- Byte-exact A/B arms were SHA-256 verified before measurement.
- Testbox: `tbx_01m16d11cgf9rdgbz6xaabj95t`
- Evidence archive SHA-256: `cf434266c9cf0a15370e61675d1d6c9c33d2df887e4e77630046115e8e986876`

### Behavior and regression proof

- Pre-fix, the dedicated hard-kill recovery request continued into checkpoint 2 instead of returning the final recovery marker; the focused regression fails on that extra tool call.
- The E2E still starts a real Gateway child, waits for a real pending restart-safe `qa_restart_wait` call, SIGKILLs the owned process group, observes group death, restarts the Gateway, verifies startup-orphan reconciliation and transcript advancement, preserves the original session ID, delivers a queued follow-up reply, and reaches `done`.
- The existing three-checkpoint request-history regression remains intact and still executes all three generated Code Mode checkpoints.

### Validation

- `extensions/qa-lab/src/providers/mock-openai/server.test.ts`: all tests passed with one worker.
- Same server test passed with shuffled seeds `17` and `805`.
- `extensions/qa-lab/src/gateway-kill-restart-send.e2e.test.ts`: passed against the real Gateway child flow.
- `pnpm check:changed`: passed.
- Fresh branch autoreview against current `origin/main`: no accepted/actionable findings.
- Product production LOC: `+0/-0`; QA fixture/test-support: `+12` net; tests: `+57` net; E2E executable behavior unchanged.

### Dependency contract inspected

Checked `openai/codex` at `3b67b03a3f6b0590589fb85d2be26d0eb58ac159`: `TurnComplete` aborts pending server requests and resolves pending interrupts before completion handling (`codex-rs/app-server/src/bespoke_event_handling.rs:187-202`); `turn/interrupt` validates the active turn and submits `Op::Interrupt` (`codex-rs/app-server/src/request_processors/turn_processor.rs:1409-1471`); completion emits `TurnCompletedNotification` (`codex-rs/app-server/src/bespoke_event_handling.rs:1277-1302`, `codex-rs/app-server-protocol/src/protocol/v2/turn.rs:407-410`).
