### PR TITLE
fix: keep CLI context budgets stable across provider discovery

### DIFF
--- a/docs/providers/anthropic.md
+++ b/docs/providers/anthropic.md
@@ -646,9 +646,12 @@ OpenClaw supports Anthropic's prompt caching feature for API-key auth.
     entries with that value are dropped during request header resolution, and
     unsupported older Claude models stay on their normal context window.
 
-    `params.context1m: true` behaves the same way for the Claude CLI backend
-    (`claude-cli/*`): eligible GA-capable Opus and Sonnet models already get the
-    1M window automatically, so the param is optional there too.
+    Claude CLI (`claude-cli/*`) has its own context budget. For older models
+    such as Sonnet 4.6, API availability does not automatically select the CLI's
+    extended context. OpenClaw uses CLI-owned metadata and configured limits;
+    an eligible `[1m]` model ref or `params.context1m: true` selects a 1M budget.
+    Native extended-context access still depends on the installed CLI and your
+    account; see [Claude Code extended context](https://code.claude.com/docs/en/model-config#extended-context).
 
     <Warning>
     Requires long-context access on your Anthropic credential. OAuth/subscription token auth keeps its required Anthropic beta headers, but OpenClaw strips the retired 1M beta header if it remains in older config.

--- a/src/agents/cli-runner/prepare.context-window.test.ts
+++ b/src/agents/cli-runner/prepare.context-window.test.ts
@@ -1,0 +1,83 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { CliBackendPlugin } from "../../plugins/cli-backend.types.js";
+import { testing as cliBackendsTesting } from "../cli-backends.test-support.js";
+import {
+  buildDefaultTestCliBackend,
+  createCliRunnerPrepareFixture,
+} from "../cli-runner.test-helpers.js";
+import { applyDiscoveredContextWindows } from "../context-cache-projection.js";
+import { getContextWindowCaches } from "../context-cache.js";
+import { resetContextWindowCacheForTest } from "../context.js";
+import { prepareCliRunContext } from "./prepare.js";
+import {
+  resetCliRunnerPrepareTestDeps,
+  setCliRunnerPrepareTestDeps,
+} from "./prepare.test-support.js";
+
+describe("CLI context-window ownership", () => {
+  let fixture: ReturnType<typeof createCliRunnerPrepareFixture>;
+
+  beforeEach(() => {
+    resetContextWindowCacheForTest();
+    setCliRunnerPrepareTestDeps({
+      isWorkspaceBootstrapPending: async () => false,
+      resolveBootstrapContextForRun: async () => ({ bootstrapFiles: [], contextFiles: [] }),
+      resolveOpenClawReferencePaths: async () => ({ docsPath: null, sourcePath: null }),
+      prepareClaudeCliSkillsPlugin: async () => ({ args: [], cleanup: async () => {} }),
+      loadManifestModelCatalog: () => [],
+    });
+    fixture = createCliRunnerPrepareFixture(prepareCliRunContext);
+  });
+
+  afterEach(() => {
+    resetCliRunnerPrepareTestDeps();
+    cliBackendsTesting.resetDepsForTest();
+    resetContextWindowCacheForTest();
+    fixture.cleanup();
+  });
+
+  it.each([
+    { provider: "claude-cli", model: "claude-sonnet-4-6", catalogProvider: "anthropic" },
+    { provider: "test-cli", model: "large-model", catalogProvider: "api-provider" },
+  ])("keeps $provider stable when another provider loads the same model", async (testCase) => {
+    const prepareExecution = vi.fn<NonNullable<CliBackendPlugin["prepareExecution"]>>(
+      async () => undefined,
+    );
+    cliBackendsTesting.setDepsForTest({
+      resolvePluginSetupCliBackend: () => undefined,
+      resolveRuntimeCliBackends: () => [
+        {
+          ...buildDefaultTestCliBackend(),
+          id: testCase.provider,
+          modelProvider: testCase.catalogProvider,
+          prepareExecution,
+        },
+      ],
+    });
+    const prepare = () => fixture.prepare({ provider: testCase.provider, model: testCase.model });
+    const cold = await prepare();
+    expect(cold.contextWindowInfo?.tokens).toBe(200_000);
+
+    // Discovery publishes both provider-qualified and bare keys. The latter cannot
+    // supply a different runtime's native budget on the next turn.
+    applyDiscoveredContextWindows({
+      cache: getContextWindowCaches().discoveredTokenCache,
+      models: [
+        { provider: testCase.catalogProvider, id: testCase.model, contextWindow: 1_000_000 },
+      ],
+    });
+    const resumed = await prepare();
+    expect(resumed.contextWindowInfo?.tokens).toBe(200_000);
+
+    // A provider-owned large window remains usable even without a manifest row.
+    applyDiscoveredContextWindows({
+      cache: getContextWindowCaches().discoveredTokenCache,
+      models: [{ provider: testCase.provider, id: testCase.model, contextWindow: 1_000_000 }],
+    });
+    const owned = await prepare();
+    expect(owned.contextWindowInfo?.tokens).toBe(1_000_000);
+    expect(prepareExecution.mock.calls.map(([context]) => context.contextTokenBudget)).toEqual([
+      200_000, 200_000, 1_000_000,
+    ]);
+  });
+});

--- a/src/agents/cli-runner/prepare.ts
+++ b/src/agents/cli-runner/prepare.ts
@@ -817,7 +817,7 @@ export async function prepareCliRunContext(
     requestedContextModelId,
     ...(normalizedContextModelId !== requestedContextModelId ? [normalizedContextModelId] : []),
   ];
-  const resolveContextModelTokens = (contextModelId: string, allowUnscopedModelLookup: boolean) =>
+  const resolveContextModelTokens = (contextModelId: string) =>
     resolveContextTokensForModel({
       cfg: params.config,
       provider: params.provider,
@@ -826,26 +826,17 @@ export async function prepareCliRunContext(
       modelContextWindow: params.modelContextWindow,
       modelContextTokens: params.modelContextTokens,
       allowAsyncLoad: false,
-      allowUnscopedModelLookup,
+      // A same-name API model may have a different native window from this CLI runtime.
+      allowUnscopedModelLookup: false,
     });
   let modelContextTokens: number | undefined;
   for (const contextModelId of contextModelIds) {
-    const candidateContextTokens = resolveContextModelTokens(contextModelId, false);
+    const candidateContextTokens = resolveContextModelTokens(contextModelId);
     if (candidateContextTokens !== undefined) {
       modelContextTokens =
         modelContextTokens === undefined
           ? candidateContextTokens
           : Math.min(modelContextTokens, candidateContextTokens);
-    }
-  }
-  // A process-wide bare-model cache has no provider provenance. If neither id
-  // has owned metadata, prefer the actual CLI target over the requested alias.
-  if (modelContextTokens === undefined) {
-    for (const contextModelId of contextModelIds.toReversed()) {
-      modelContextTokens = resolveContextModelTokens(contextModelId, true);
-      if (modelContextTokens !== undefined) {
-        break;
-      }
     }
   }
   modelContextTokens ??= DEFAULT_CONTEXT_TOKENS;


### PR DESCRIPTION
Claude CLI's first API-key-backed turn used a 200K context budget, but the next turn used 1M and restarted its warm native process. Recall still succeeded from native history. The live diagnostic traced the restart to a changed `CLAUDE_CODE_AUTO_COMPACT_WINDOW`; prompt, model, workspace, auth, and tool inputs were unchanged.

CLI preparation first consulted provider-owned metadata, but then explicitly fell back to a process-wide cache keyed only by model name. Loading Anthropic API metadata between turns populated that bare key with a 1M window, which the different CLI runtime then borrowed. Sonnet 4.6's CLI window is not automatically the API window: Claude Code documents a 200K boundary without extended context.

This removes the unowned lookup from CLI preparation. Explicit prepared facts, configured limits, provider-qualified metadata, aliases, fixed provider contracts, and selectable context windows retain their existing resolution. Fingerprint and lifecycle checks stay strict. Production shrinks by nine lines. The nearby docs now distinguish API availability from Claude CLI extended-context selection.

Validation:

- The regression warms the real cache between two preparation calls, reproducing the original order. Before the fix, Claude and generic CLI cases both change from 200K to 1M. After the fix, both stay at 200K; provider-owned 1M metadata remains usable even without a manifest row.
- 168 focused tests pass across the full CLI preparation suite, context lookup, live-session registry, and the new regression. Existing explicit-budget, alias, selectable-window, and authority-fencing coverage remains green.
- Formatting, typed targeted lint, and diff checks pass. Fresh isolated autoreview is clean, and the same 168 tests pass on current main16a3200cd32cec843fc75e57a27175f08da6b4df. Exact-head CI33247638331 is green.

Upstream contract: [Claude Code extended context and compaction](https://code.claude.com/docs/en/model-config#extended-context).

Real Docker proof is complete on [Testbox workflow33247258645](https://github.com/openclaw/openclaw/actions/runs/33247258645): the implicit200K API-key native resume/MCP path passed twice without instrumentation or warmup (167.71s and169.25s), and explicit native `claude-cli/claude-sonnet-4-6[1m]` passed168.22s. Exact recall, canonical-history absence, native-generation equality and admitted MCP cron identity/visibility/cleanup remained mandatory.

Proof uses pinned baseline `bbe4f3a7f7dce27452ccd5457a558c2d5ccbfd76` plus an exact13-file owner/fixture overlay. The executed prepare module was independently attested to SHA256 `8b3901a548f44d62c70836f8c04f5b7394947ff2422bfcb44bcf43a443ee3c8d`; the diagnostic showed stable200K budgets and fingerprints and was removed for clean repeats. The untouched live fixture SHA256 is `2d6102bc7868da635d6e80ff3f71ad12202cda5468bf3ea3716f77f33423feaa`. This is not a full latest-main Docker run.

One earlier post-patch clean run failed generation equality after170.12s; its executed module identity was not recorded. That unexplained failure is retained rather than discarded. Subsequent source-attested and two clean default runs plus explicit1M passed. Restoring accidentally borrowed API metadata to the native200K policy is intentional; explicit1M remains supported and live-proven.
