### PR TITLE
fix(plugins): keep compiled plugin aliases on the built runtime

### DIFF
--- a/src/plugins/sdk-alias.test.ts
+++ b/src/plugins/sdk-alias.test.ts
@@ -1719,6 +1719,21 @@ describe("plugin sdk alias helpers", () => {
     ).toBe(fs.realpathSync(distChannelRuntimePath));
   });
 
+  it.each(["dist", "dist-runtime"])(
+    "keeps compiled %s plugin SDK aliases on the built module graph in test mode",
+    (outputDir) => {
+      const { fixture, distChannelRuntimePath } = createPluginSdkAliasTargetFixture();
+      const pluginEntry = writePluginEntry(
+        fixture.root,
+        path.join(outputDir, "extensions", "demo", "index.js"),
+      );
+
+      const aliases = withEnv({ NODE_ENV: "test" }, () => buildPluginLoaderAliasMap(pluginEntry));
+
+      expectPluginSdkAliasTargets(aliases, { channelRuntimePath: distChannelRuntimePath });
+    },
+  );
+
   it("loads source runtime shims through the non-native module loading boundary", async () => {
     const copiedExtensionRoot = path.join(makeTempDir(), bundledPluginRoot("discord"));
     const copiedSourceDir = path.join(copiedExtensionRoot, "src");
@@ -1780,6 +1795,13 @@ export const syntheticRuntimeMarker = {
     {
       name: "prefers dist plugin runtime module when loader runs from dist",
       modulePath: (root: string) => path.join(root, "dist", "plugins", "loader.js"),
+      expected: "dist" as const,
+    },
+    {
+      name: "prefers dist plugin runtime module for dist-runtime plugins in test mode",
+      modulePath: (root: string) =>
+        path.join(root, "dist-runtime", "extensions", "demo", "index.js"),
+      env: { NODE_ENV: "test" },
       expected: "dist" as const,
     },
     {

--- a/src/plugins/sdk-alias.ts
+++ b/src/plugins/sdk-alias.ts
@@ -427,7 +427,7 @@ function resolvePluginSdkAliasCandidateOrder(params: {
     return ["src", "dist"];
   }
   const normalizedModulePath = params.modulePath.replace(/\\/g, "/");
-  const isDistRuntime = normalizedModulePath.includes("/dist/");
+  const isDistRuntime = /\/dist(?:-runtime)?\//.test(normalizedModulePath);
   return isDistRuntime || params.isProduction ? ["dist", "src"] : ["src", "dist"];
 }
 


### PR DESCRIPTION
## What Problem This Solves
Compiled plugins loaded from `dist-runtime` could resolve Plugin SDK and shared runtime imports back into source when running in a mixed source/built checkout. The resolver recognized `dist` but missed the second compiled output directory.

## Why This Change Was Made
Use the existing compiled-first resolution for both compiled directory names. Explicit source/dist preferences and production-mode behavior remain unchanged. No new loader, fallback, cache, configuration or public SDK surface is added.

## Evidence
- Regression fails before the fix for `dist-runtime` and passes afterward, covering both Plugin SDK aliases and shared plugin-runtime resolution. Existing `dist`, source, explicit-preference and platform cases remain covered.
- Full SDK alias suite:73 passed,1 existing skip; core lint, formatting, diff checks and fresh independent Codex autoreview passed.
- Real rebuilt Docker gateway flow exercised the mixed source/built layout in https://github.com/openclaw/openclaw/actions/runs/33245961333 . Build succeeded and the built Anthropic entrypoint profile passed at365.457MiB max RSS. The full native model lane remains blocked by an expired exported OAuth credential; no green claim or auth-policy change.

A separately observed141s startup cost came from an eager Anthropic CLI probe, already fixed on main in #132324. This PR does not attribute that timing improvement to SDK alias selection.

Production+1/-1(net0); regression tests+22. Release-note context: Keep compiled plugin SDK/runtime imports on the built module graph in mixed source/built execution.
