### PR TITLE
refactor(claws): share extension provenance SQL params

### DIFF
--- a/src/claws/package-extension-provenance.ts
+++ b/src/claws/package-extension-provenance.ts
@@ -46,6 +46,29 @@ export type PackageRefRow = {
   updated_at_ms: number | bigint;
 };
 
+type PackageRefExtensionSqlParams = Pick<
+  PackageRefRow,
+  | "extension_id"
+  | "extension_format"
+  | "extension_detected_format"
+  | "extension_mapped_json"
+  | "extension_unavailable_json"
+  | "extension_adapter_identity"
+>;
+
+export function toPackageRefExtensionSqlParams(
+  extension: ClawAppliedExtension | undefined,
+): PackageRefExtensionSqlParams {
+  return {
+    extension_id: extension?.id ?? null,
+    extension_format: extension?.format ?? null,
+    extension_detected_format: extension?.detectedFormat ?? null,
+    extension_mapped_json: extension ? JSON.stringify(extension.mapped) : null,
+    extension_unavailable_json: extension ? JSON.stringify(extension.unavailable) : null,
+    extension_adapter_identity: extension?.adapterIdentity ?? null,
+  };
+}
+
 function parsePackageRefExtension(row: PackageRefRow): ClawAppliedExtension | undefined {
   const values = [
     row.extension_id,

--- a/src/claws/package-update-provenance.ts
+++ b/src/claws/package-update-provenance.ts
@@ -4,7 +4,10 @@ import {
   runOpenClawStateWriteTransaction,
   type OpenClawStateDatabaseOptions,
 } from "../state/openclaw-state-db.js";
-import type { PersistedClawPackageRef } from "./provenance.js";
+import {
+  toPackageRefExtensionSqlParams,
+  type PersistedClawPackageRef,
+} from "./package-extension-provenance.js";
 
 export function digestClawPackageRef(ref: PersistedClawPackageRef): string {
   const persisted = {
@@ -75,16 +78,7 @@ export function replaceClawPackageRefExpected(
           relationship: expected.relationship,
           origin: expected.origin,
           independent_owner: expected.independentOwner ? 1 : 0,
-          extension_id: expected.extension?.id ?? null,
-          extension_format: expected.extension?.format ?? null,
-          extension_detected_format: expected.extension?.detectedFormat ?? null,
-          extension_mapped_json: expected.extension
-            ? JSON.stringify(expected.extension.mapped)
-            : null,
-          extension_unavailable_json: expected.extension
-            ? JSON.stringify(expected.extension.unavailable)
-            : null,
-          extension_adapter_identity: expected.extension?.adapterIdentity ?? null,
+          ...toPackageRefExtensionSqlParams(expected.extension),
           installed_at_ms: expected.installedAtMs,
           updated_at_ms: expected.updatedAtMs,
         });
@@ -137,16 +131,7 @@ export function replaceClawPackageRefExpected(
           relationship: replacement.relationship,
           origin: replacement.origin,
           independent_owner: replacement.independentOwner ? 1 : 0,
-          extension_id: replacement.extension?.id ?? null,
-          extension_format: replacement.extension?.format ?? null,
-          extension_detected_format: replacement.extension?.detectedFormat ?? null,
-          extension_mapped_json: replacement.extension
-            ? JSON.stringify(replacement.extension.mapped)
-            : null,
-          extension_unavailable_json: replacement.extension
-            ? JSON.stringify(replacement.extension.unavailable)
-            : null,
-          extension_adapter_identity: replacement.extension?.adapterIdentity ?? null,
+          ...toPackageRefExtensionSqlParams(replacement.extension),
           installed_at_ms: replacement.installedAtMs,
           updated_at_ms: replacement.updatedAtMs,
         });

--- a/src/claws/provenance.test.ts
+++ b/src/claws/provenance.test.ts
@@ -36,6 +36,15 @@ async function makePlan(
   return await makeProvenancePlan(root, manifestValue, options);
 }
 
+const extensionFixture = Object.freeze({
+  id: "coding-tools",
+  format: "openclaw" as const,
+  detectedFormat: "claude" as const,
+  mapped: ["commands", "skills"],
+  unavailable: ["agents"],
+  adapterIdentity: "openclaw/test",
+});
+
 describe("Claw root install provenance", () => {
   it("replays an exact package ref without losing its relationship or origin", async () => {
     const { root, plan } = await makePlan();
@@ -77,30 +86,35 @@ describe("Claw root install provenance", () => {
 
   it("round-trips canonical extension inventory on the shared plugin dependency edge", async () => {
     const { root, plan } = await makePlan();
-    const extension = {
-      id: "coding-tools",
-      format: "claude" as const,
-      detectedFormat: "claude" as const,
-      mapped: ["commands", "skills"],
-      unavailable: ["agents"],
-      adapterIdentity: "openclaw/test",
+    const pkg = {
+      kind: "plugin" as const,
+      source: "clawhub" as const,
+      ref: "@acme/coding-tools",
+      version: "1.2.3",
+      integrity: `sha256:${"b".repeat(64)}`,
+      extension: extensionFixture,
     };
 
-    const persisted = persistClawPackageRef(
-      plan,
-      {
-        kind: "plugin",
-        source: "clawhub",
-        ref: "@acme/coding-tools",
-        version: "1.2.3",
-        integrity: `sha256:${"b".repeat(64)}`,
-        extension,
-      },
-      { env: stateEnv(root), nowMs: 42, relationship: "referenced" },
-    );
+    persistClawPackageRef(plan, pkg, {
+      env: stateEnv(root),
+      nowMs: 42,
+      status: "pending",
+      relationship: "referenced",
+    });
+    const replayed = persistClawPackageRef(plan, pkg, {
+      env: stateEnv(root),
+      nowMs: 84,
+      status: "complete",
+      relationship: "referenced",
+    });
 
-    expect(persisted.extension).toEqual(extension);
-    expect(readClawPackageRefs({ env: stateEnv(root) })).toEqual([persisted]);
+    expect(replayed).toMatchObject({
+      extension: extensionFixture,
+      status: "complete",
+      installedAtMs: 42,
+      updatedAtMs: 84,
+    });
+    expect(readClawPackageRefs({ env: stateEnv(root) })).toEqual([replayed]);
   });
 
   it("persists package identity, agent ownership, workspace, and config digest", async () => {
@@ -300,6 +314,7 @@ describe("Claw root install provenance", () => {
         ref: "@acme/audit",
         version: "2.3.4",
         integrity: "sha256:audit-2.3.4",
+        extension: extensionFixture,
       },
       { ...options, nowMs: 43 },
     );
@@ -321,6 +336,7 @@ describe("Claw root install provenance", () => {
         ref: "@acme/audit",
         version: "2.3.4",
         integrity: "sha256:audit-2.3.4",
+        extension: extensionFixture,
       },
       { ...options, nowMs: 45 },
     );

--- a/src/claws/provenance.ts
+++ b/src/claws/provenance.ts
@@ -11,6 +11,7 @@ import { digestClawAgentConfig } from "./agent-config-digest.js";
 import {
   CLAW_PACKAGE_REF_SCHEMA_VERSION,
   rowToPackageRef,
+  toPackageRefExtensionSqlParams,
   type ClawPackageOrigin,
   type ClawPackageRefStatus,
   type ClawPackageRelationship,
@@ -552,14 +553,7 @@ export function persistClawPackageRef(
           relationship: record.relationship,
           origin: record.origin,
           independent_owner: record.independentOwner ? 1 : 0,
-          extension_id: record.extension?.id ?? null,
-          extension_format: record.extension?.format ?? null,
-          extension_detected_format: record.extension?.detectedFormat ?? null,
-          extension_mapped_json: record.extension ? JSON.stringify(record.extension.mapped) : null,
-          extension_unavailable_json: record.extension
-            ? JSON.stringify(record.extension.unavailable)
-            : null,
-          extension_adapter_identity: record.extension?.adapterIdentity ?? null,
+          ...toPackageRefExtensionSqlParams(record.extension),
           updated_at_ms: record.updatedAtMs,
         });
       return;
@@ -596,14 +590,7 @@ export function persistClawPackageRef(
         relationship: record.relationship,
         origin: record.origin,
         independent_owner: record.independentOwner ? 1 : 0,
-        extension_id: record.extension?.id ?? null,
-        extension_format: record.extension?.format ?? null,
-        extension_detected_format: record.extension?.detectedFormat ?? null,
-        extension_mapped_json: record.extension ? JSON.stringify(record.extension.mapped) : null,
-        extension_unavailable_json: record.extension
-          ? JSON.stringify(record.extension.unavailable)
-          : null,
-        extension_adapter_identity: record.extension?.adapterIdentity ?? null,
+        ...toPackageRefExtensionSqlParams(record.extension),
         installed_at_ms: record.installedAtMs,
         updated_at_ms: record.updatedAtMs,
       });


### PR DESCRIPTION
## What Problem This Solves

Four Claw provenance write paths independently serialized the same extension metadata into SQLite parameters. That duplication made insert, update, compare-and-swap expectation, and compare-and-swap replacement behavior vulnerable to column or encoding drift.

## Why This Approach

- adds one internal serializer beside the persisted row shape and decoder that own this representation
- reuses it across all four write paths
- makes the accepted extension fields explicit with a private `Pick`
- preserves the existing SQL, scalar null handling, array JSON encoding, transaction order, and persistence semantics
- imports the persisted package-ref type directly from its owner instead of through an unrelated provenance module

This is an internal refactor only. It adds no SDK, config, protocol, schema, migration, or material persistent-store surface.

## User Impact

No user-visible behavior change. The refactor reduces the risk that equivalent provenance operations persist extension metadata differently.

## Evidence

- focused provenance suite: 33/33 passed
- formatter, OXLint, core typecheck, import-cycle checks, schema/storage/security guards: passed
- structured autoreview: no accepted or actionable findings
- independent owner-boundary review: no findings
- Blacksmith Testbox via Crabbox: `tbx_01m16g7ap5fzgqa4pkh23c0ctn`
- delegated clean-machine run: https://github.com/openclaw/openclaw/actions/runs/33247365184
- clean-machine `check:changed`, focused provenance suite (33/33), and full build: passed
- full-suite Testbox `tbx_01m17m034qq0tsv4ayrgmx8set`: 507/508 tooling files passed; the sole failure was the already-baselined `docs-i18n` temp cleanup `EACCES`, reproduced unchanged on current `main`
- exact-head CI: https://github.com/openclaw/openclaw/actions/runs/33275350486 passed, including `openclaw/ci-gate`

LOC classification:

- production: +32/-37, net -5
- tests: +37/-21, net +16
- generated, lockfile, and test-support changes: none

AI-assisted: yes. The implementation and proof were independently reviewed.
