### PR TITLE
fix(line): send outbound media as the kind its URL proves

### DIFF
--- a/docs/channels/line.md
+++ b/docs/channels/line.md
@@ -362,14 +362,14 @@ The LINE plugin sends images, videos, and audio through the agent message tool:
 - **Videos**: require a preview image; set `channelData.line.previewImageUrl` to an image URL.
 - **Audio**: sent as LINE audio messages; duration defaults to 60 seconds unless `channelData.line.durationMs` is set.
 
-The media kind is taken from `channelData.line.mediaKind` when set, otherwise inferred
-from the other LINE options or the URL file suffix, with image as the fallback.
+When `mediaKind` is omitted, LINE infers it from LINE-specific options or the URL
+suffix. Native suffix inference supports JPEG/PNG, MP4, and MP3/M4A; suffixless URLs
+retain the image fallback. Other suffixed URLs and inferred MP4 without a preview
+become text links. Explicit video still requires `previewImageUrl`.
 
 Outbound media URLs must be public HTTPS URLs of at most 2000 characters. OpenClaw
 validates the target hostname before handing the URL to LINE and rejects loopback,
 link-local, and private-network targets.
-
-Generic media sends without LINE-specific options use the image route.
 
 ## Troubleshooting
 

--- a/extensions/line/runtime-api.ts
+++ b/extensions/line/runtime-api.ts
@@ -29,6 +29,11 @@ export {
 export { setLineRuntime } from "./src/runtime.js";
 export { firstDefined, normalizeAllowFrom } from "./src/bot-access.js";
 export { downloadLineMedia } from "./src/download.js";
+export {
+  createAudioMessage,
+  createImageMessage,
+  createVideoMessage,
+} from "./src/outbound-media.js";
 export { probeLineBot } from "./src/probe.js";
 export { buildTemplateMessageFromPayload } from "./src/template-messages.js";
 export {
@@ -72,12 +77,9 @@ export {
   stripMarkdown,
 } from "./src/markdown-to-line.js";
 export {
-  createAudioMessage,
   createFlexMessage,
-  createImageMessage,
   createLocationMessage,
   createTextMessageWithQuickReplies,
-  createVideoMessage,
   getUserDisplayName,
   getUserProfile,
   pushImageMessage,

--- a/extensions/line/src/auto-reply-delivery.test.ts
+++ b/extensions/line/src/auto-reply-delivery.test.ts
@@ -894,11 +894,11 @@ describe("deliverLineAutoReply", () => {
     );
   });
 
-  it("keeps the image route for generic media without LINE-specific options", async () => {
-    // A bare media URL stays on the image route, but shares validation with
-    // LINE-specific media. A .mp4 proves the explicit image fallback prevents
-    // extension-based video inference.
-    const { deps, replyMessageLine, buildMediaMessage } = createDeps({
+  it("leaves the media kind of a bare URL for the shared leaf to resolve", async () => {
+    // This path used to pin mediaKind to "image" for a bare media URL, so an
+    // audio or video URL reached LINE as an empty image bubble. The leaf reads
+    // the URL itself, so overriding the kind here is what hid the real one.
+    const { deps, buildMediaMessage } = createDeps({
       processLineMessage: () => ({ text: "", flexMessages: [] }),
       chunkMarkdownText: () => [],
     });
@@ -906,7 +906,7 @@ describe("deliverLineAutoReply", () => {
     const result = await deliverLineAutoReply({
       ...baseDeliveryParams,
       payload: {
-        mediaUrls: ["https://example.com/clip.mp4"],
+        mediaUrls: ["https://example.com/voice.m4a"],
         channelData: { line: {} },
       },
       lineData: {},
@@ -915,19 +915,14 @@ describe("deliverLineAutoReply", () => {
 
     expect(result.status).toBe("delivered");
     expect(buildMediaMessage).toHaveBeenCalledWith(
-      "https://example.com/clip.mp4",
+      "https://example.com/voice.m4a",
       {
-        mediaKind: "image",
+        mediaKind: undefined,
         previewImageUrl: undefined,
         durationMs: undefined,
         trackingId: undefined,
       },
       "line:user:1",
-    );
-    expect(replyMessageLine).toHaveBeenCalledWith(
-      "token",
-      [createImageMessage("https://example.com/clip.mp4")],
-      { cfg: LINE_TEST_CFG, accountId: "acc" },
     );
   });
 

--- a/extensions/line/src/auto-reply-delivery.ts
+++ b/extensions/line/src/auto-reply-delivery.ts
@@ -14,7 +14,6 @@ import { classifyTransientNetworkErrorCode } from "openclaw/plugin-sdk/retry-run
 import { sanitizeAssistantVisibleText } from "openclaw/plugin-sdk/text-chunking";
 import type { FlexContainer } from "./flex-templates/types.js";
 import type { ProcessedLineMessage } from "./markdown-to-line.js";
-import { hasLineSpecificMediaOptions } from "./outbound-media.js";
 import { buildLineQuickReplyFallbackText } from "./quick-reply-fallback.js";
 import { createLineQuickReply } from "./rich-messages.js";
 import { findLineHttpError, resolveLineNonDispatchRetryable } from "./send-retry.js";
@@ -275,15 +274,13 @@ export async function deliverLineAutoReply(params: {
       ? deps.chunkMarkdownText(processed.text, textLimit)
       : [];
 
-  // Match the push path (outbound.ts): honor channelData.line.mediaKind and the
-  // other LINE media options so a reply-token video/audio is not silently
-  // downgraded to an image. Generic media stays image-only but still goes
-  // through the same validation boundary. A media build failure is partial only
-  // after another visible part lands; media-only failures remain full failures.
+  // Match the push path (outbound.ts): hand the LINE media options to the same
+  // leaf so a reply-token video/audio is not downgraded to an image. A media
+  // build failure is partial only after another visible part lands; media-only
+  // failures remain full failures.
   const mediaUrls = resolveSendableOutboundReplyParts(payload).mediaUrls;
-  const useLineSpecificMedia = hasLineSpecificMediaOptions(lineData);
   const mediaOpts: Parameters<LineAutoReplyDeps["buildMediaMessage"]>[1] = {
-    mediaKind: useLineSpecificMedia ? lineData.mediaKind : "image",
+    mediaKind: lineData.mediaKind,
     previewImageUrl: lineData.previewImageUrl,
     durationMs: lineData.durationMs,
     trackingId: lineData.trackingId,

--- a/extensions/line/src/channel.sendPayload.test.ts
+++ b/extensions/line/src/channel.sendPayload.test.ts
@@ -617,7 +617,7 @@ describe("line outbound sendPayload", () => {
     );
   });
 
-  it("keeps generic media payloads on the image-only send path", async () => {
+  it("forwards generic media payloads to the shared send path unresolved", async () => {
     const { runtime, mocks } = createRuntime();
     setLineRuntime(runtime);
     const cfg = { channels: { line: {} } } as OpenClawConfig;
@@ -745,7 +745,7 @@ describe("line outbound sendPayload", () => {
     );
   });
 
-  it("keeps generic quick-reply media on the validated image route", async () => {
+  it("keeps generic quick-reply media on the validated media route", async () => {
     const { runtime, mocks } = createRuntime();
     setLineRuntime(runtime);
     const cfg = { channels: { line: {} } } as OpenClawConfig;
@@ -754,7 +754,7 @@ describe("line outbound sendPayload", () => {
       to: "line:user:U123",
       text: "",
       payload: {
-        mediaUrl: "https://example.com/clip.mp4",
+        mediaUrl: "https://example.com/photo.png",
         channelData: { line: { quickReplies: ["One"] } },
       },
       accountId: "default",
@@ -766,8 +766,8 @@ describe("line outbound sendPayload", () => {
       [
         {
           type: "image",
-          originalContentUrl: "https://example.com/clip.mp4",
-          previewImageUrl: "https://example.com/clip.mp4",
+          originalContentUrl: "https://example.com/photo.png",
+          previewImageUrl: "https://example.com/photo.png",
           quickReply: { items: ["One"] },
         },
       ],
@@ -776,6 +776,38 @@ describe("line outbound sendPayload", () => {
     expect(ssrfMocks.resolvePinnedHostnameWithPolicy).toHaveBeenCalledWith("example.com", {
       policy: { allowPrivateNetwork: false },
     });
+  });
+
+  it("sends inline quick-reply media as the kind its URL proves", async () => {
+    // The inline batch used to force every generic media URL onto the image
+    // route, so an audio clip arrived as an empty image bubble.
+    const { runtime, mocks } = createRuntime();
+    setLineRuntime(runtime);
+    const cfg = { channels: { line: {} } } as OpenClawConfig;
+
+    await lineOutboundAdapter.sendPayload!({
+      to: "line:user:U123",
+      text: "",
+      payload: {
+        mediaUrl: "https://example.com/voice.m4a",
+        channelData: { line: { quickReplies: ["One"] } },
+      },
+      accountId: "default",
+      cfg,
+    });
+
+    expect(mocks.pushMessagesLine).toHaveBeenCalledWith(
+      "line:user:U123",
+      [
+        {
+          type: "audio",
+          originalContentUrl: "https://example.com/voice.m4a",
+          duration: 60000,
+          quickReply: { items: ["One"] },
+        },
+      ],
+      { verbose: false, accountId: "default", cfg },
+    );
   });
 
   it("rejects insecure generic media before quick-reply batch sends", async () => {

--- a/extensions/line/src/outbound-media.test.ts
+++ b/extensions/line/src/outbound-media.test.ts
@@ -14,14 +14,11 @@ afterAll(() => {
   vi.resetModules();
 });
 
-import {
-  buildLineMediaMessage,
-  hasLineSpecificMediaOptions,
-  resolveLineOutboundMedia,
-  validateLineMediaUrl,
-} from "./outbound-media.js";
+import { buildLineMediaMessage } from "./outbound-media.js";
 
 const HTTPS_URL_ERROR = new Error("LINE outbound media URL must use HTTPS");
+const USER_TARGET = "line:user:Uabc";
+const PREVIEW_URL = "https://example.com/preview.jpg";
 
 function createCredentialBearingHttpUrl(): string {
   const url = new URL("http://example.com/image.jpg");
@@ -32,24 +29,32 @@ function createCredentialBearingHttpUrl(): string {
   return url.href;
 }
 
-describe("validateLineMediaUrl", () => {
-  beforeEach(() => {
-    ssrfMocks.resolvePinnedHostnameWithPolicy.mockReset();
-    ssrfMocks.resolvePinnedHostnameWithPolicy.mockResolvedValue({
-      hostname: "example.com",
-      addresses: ["93.184.216.34"],
-    });
+beforeEach(() => {
+  ssrfMocks.resolvePinnedHostnameWithPolicy.mockReset();
+  ssrfMocks.resolvePinnedHostnameWithPolicy.mockResolvedValue({
+    hostname: "example.com",
+    addresses: ["93.184.216.34"],
   });
+});
 
-  it("accepts HTTPS URL", async () => {
-    await expect(validateLineMediaUrl("https://example.com/image.jpg")).resolves.toBeUndefined();
+describe("buildLineMediaMessage URL boundary", () => {
+  it("pins the hostname of an accepted HTTPS URL", async () => {
+    await expect(
+      buildLineMediaMessage("https://example.com/image.jpg", {}, USER_TARGET),
+    ).resolves.toEqual({
+      type: "image",
+      originalContentUrl: "https://example.com/image.jpg",
+      previewImageUrl: "https://example.com/image.jpg",
+    });
     expect(ssrfMocks.resolvePinnedHostnameWithPolicy).toHaveBeenCalledWith("example.com", {
       policy: { allowPrivateNetwork: false },
     });
   });
 
-  it("accepts uppercase HTTPS scheme", async () => {
-    await expect(validateLineMediaUrl("HTTPS://EXAMPLE.COM/img.jpg")).resolves.toBeUndefined();
+  it("accepts an uppercase HTTPS scheme", async () => {
+    await expect(
+      buildLineMediaMessage("HTTPS://EXAMPLE.COM/img.jpg", {}, USER_TARGET),
+    ).resolves.toMatchObject({ type: "image" });
     expect(ssrfMocks.resolvePinnedHostnameWithPolicy).toHaveBeenCalledWith("example.com", {
       policy: { allowPrivateNetwork: false },
     });
@@ -58,36 +63,34 @@ describe("validateLineMediaUrl", () => {
   it.each([
     {
       name: "malformed media URL",
-      run: () => validateLineMediaUrl("not a url?query=fixture#fragment"),
-      expected: new Error("LINE outbound media URL must be a valid URL"),
+      run: () => buildLineMediaMessage("not a url?query=fixture#fragment", {}, USER_TARGET),
+      expected: new Error("LINE outbound media currently requires a public HTTPS URL"),
     },
     {
       name: "insecure media URL",
-      run: () => validateLineMediaUrl(createCredentialBearingHttpUrl()),
+      run: () => buildLineMediaMessage(createCredentialBearingHttpUrl(), {}, USER_TARGET),
       expected: HTTPS_URL_ERROR,
     },
     {
       name: "insecure preview URL",
       run: () =>
-        resolveLineOutboundMedia("https://example.com/video.mp4", {
-          mediaKind: "video",
-          previewImageUrl: createCredentialBearingHttpUrl(),
-        }),
-      expected: HTTPS_URL_ERROR,
-    },
-    {
-      name: "insecure resolved media URL",
-      run: () => resolveLineOutboundMedia(createCredentialBearingHttpUrl()),
+        buildLineMediaMessage(
+          "https://example.com/video.mp4",
+          { mediaKind: "video", previewImageUrl: createCredentialBearingHttpUrl() },
+          USER_TARGET,
+        ),
       expected: HTTPS_URL_ERROR,
     },
   ])("does not expose credentials from a $name", async ({ run, expected }) => {
     await expect(run()).rejects.toThrow(expected);
   });
 
-  it("rejects URL longer than 2000 chars", async () => {
+  it("rejects a URL longer than 2000 chars before any hostname lookup", async () => {
     const longUrl = `https://example.com/${"a".repeat(1981)}`;
     expect(longUrl.length).toBeGreaterThan(2000);
-    await expect(validateLineMediaUrl(longUrl)).rejects.toThrow(/2000 chars or less/i);
+    await expect(buildLineMediaMessage(longUrl, {}, USER_TARGET)).rejects.toThrow(
+      /2000 chars or less/i,
+    );
     expect(ssrfMocks.resolvePinnedHostnameWithPolicy).not.toHaveBeenCalled();
   });
 
@@ -96,130 +99,143 @@ describe("validateLineMediaUrl", () => {
       new Error("SSRF blocked private network target"),
     );
 
-    await expect(validateLineMediaUrl("https://127.0.0.1/image.jpg")).rejects.toThrow(
-      /private network/i,
-    );
+    await expect(
+      buildLineMediaMessage("https://127.0.0.1/image.jpg", {}, USER_TARGET),
+    ).rejects.toThrow(/private network/i);
     expect(ssrfMocks.resolvePinnedHostnameWithPolicy).toHaveBeenCalledWith("127.0.0.1", {
       policy: { allowPrivateNetwork: false },
     });
   });
-});
 
-describe("resolveLineOutboundMedia", () => {
-  beforeEach(() => {
-    ssrfMocks.resolvePinnedHostnameWithPolicy.mockReset();
-    ssrfMocks.resolvePinnedHostnameWithPolicy.mockResolvedValue({
-      hostname: "example.com",
-      addresses: ["93.184.216.34"],
-    });
-  });
-
-  it("respects explicit media kind without remote MIME probing", async () => {
-    await expect(
-      resolveLineOutboundMedia("https://example.com/download?id=123", { mediaKind: "video" }),
-    ).resolves.toEqual({
-      mediaUrl: "https://example.com/download?id=123",
-      mediaKind: "video",
-    });
-  });
-
-  it("preserves explicit video kind when a preview URL is provided", async () => {
-    await expect(
-      resolveLineOutboundMedia("https://example.com/download?id=123", {
-        mediaKind: "video",
-        previewImageUrl: "https://example.com/preview.jpg",
-      }),
-    ).resolves.toEqual({
-      mediaUrl: "https://example.com/download?id=123",
-      mediaKind: "video",
-      previewImageUrl: "https://example.com/preview.jpg",
-    });
-  });
-
-  it("infers audio kind from explicit duration metadata when mediaKind is omitted", async () => {
-    await expect(
-      resolveLineOutboundMedia("https://example.com/download?id=audio", {
-        durationMs: 60000,
-      }),
-    ).resolves.toEqual({
-      mediaUrl: "https://example.com/download?id=audio",
-      mediaKind: "audio",
-      durationMs: 60000,
-    });
-  });
-
-  it("does not infer video from previewImageUrl alone", async () => {
-    await expect(
-      resolveLineOutboundMedia("https://example.com/image.jpg", {
-        previewImageUrl: "https://example.com/preview.jpg",
-      }),
-    ).resolves.toEqual({
-      mediaUrl: "https://example.com/image.jpg",
-      mediaKind: "image",
-      previewImageUrl: "https://example.com/preview.jpg",
-    });
-  });
-
-  it("infers media kinds from known HTTPS file extensions", async () => {
-    await expect(resolveLineOutboundMedia("https://example.com/audio.mp3")).resolves.toEqual({
-      mediaUrl: "https://example.com/audio.mp3",
-      mediaKind: "audio",
-    });
-    await expect(resolveLineOutboundMedia("https://example.com/video.mp4")).resolves.toEqual({
-      mediaUrl: "https://example.com/video.mp4",
-      mediaKind: "video",
-    });
-    await expect(resolveLineOutboundMedia("https://example.com/image.jpg")).resolves.toEqual({
-      mediaUrl: "https://example.com/image.jpg",
-      mediaKind: "image",
-    });
-  });
-
-  it("falls back to image when no explicit LINE media options or known extension are present", async () => {
-    await expect(
-      resolveLineOutboundMedia("https://example.com/download?id=audio"),
-    ).resolves.toEqual({
-      mediaUrl: "https://example.com/download?id=audio",
-      mediaKind: "image",
-    });
-  });
-
-  it("rejects local paths because LINE outbound media requires public HTTPS URLs", async () => {
-    await expect(resolveLineOutboundMedia("./assets/image.jpg")).rejects.toThrow(
+  it("rejects a local path because LINE outbound media requires public HTTPS URLs", async () => {
+    await expect(buildLineMediaMessage("./assets/image.jpg", {}, USER_TARGET)).rejects.toThrow(
       /requires a public https url/i,
     );
   });
 });
 
-describe("hasLineSpecificMediaOptions", () => {
-  it("is false for empty or text-only channel data", () => {
-    expect(hasLineSpecificMediaOptions({})).toBe(false);
-    expect(hasLineSpecificMediaOptions({ quickReplies: ["A"] })).toBe(false);
-    expect(hasLineSpecificMediaOptions({ previewImageUrl: "  " })).toBe(false);
+describe("buildLineMediaMessage kind resolution", () => {
+  it("respects an explicit media kind without remote MIME probing", async () => {
+    await expect(
+      buildLineMediaMessage(
+        "https://example.com/download?id=123",
+        { mediaKind: "video", previewImageUrl: PREVIEW_URL },
+        USER_TARGET,
+      ),
+    ).resolves.toEqual({
+      type: "video",
+      originalContentUrl: "https://example.com/download?id=123",
+      previewImageUrl: PREVIEW_URL,
+    });
   });
 
-  it("is true when any LINE media option is set", () => {
-    expect(hasLineSpecificMediaOptions({ mediaKind: "video" })).toBe(true);
-    expect(hasLineSpecificMediaOptions({ previewImageUrl: "https://x/p.jpg" })).toBe(true);
-    expect(hasLineSpecificMediaOptions({ durationMs: 0 })).toBe(true);
-    expect(hasLineSpecificMediaOptions({ durationMs: 1000 })).toBe(true);
-    expect(hasLineSpecificMediaOptions({ trackingId: "t" })).toBe(true);
+  it("infers audio from explicit duration metadata when mediaKind is omitted", async () => {
+    await expect(
+      buildLineMediaMessage(
+        "https://example.com/download?id=audio",
+        { durationMs: 30000 },
+        USER_TARGET,
+      ),
+    ).resolves.toEqual({
+      type: "audio",
+      originalContentUrl: "https://example.com/download?id=audio",
+      duration: 30000,
+    });
   });
-});
 
-describe("buildLineMediaMessage", () => {
-  it("builds a video message and gates trackingId on user targets", async () => {
+  it("does not infer video from previewImageUrl alone", async () => {
+    await expect(
+      buildLineMediaMessage(
+        "https://example.com/image.jpg",
+        { previewImageUrl: PREVIEW_URL },
+        USER_TARGET,
+      ),
+    ).resolves.toEqual({
+      type: "image",
+      originalContentUrl: "https://example.com/image.jpg",
+      previewImageUrl: PREVIEW_URL,
+    });
+  });
+
+  it.each([
+    { url: "https://example.com/audio.mp3", expectedType: "audio" },
+    { url: "https://example.com/voice.m4a", expectedType: "audio" },
+    { url: "https://example.com/image.jpg", expectedType: "image" },
+    { url: "https://example.com/image.png", expectedType: "image" },
+    // An extensionless URL carries no evidence at all.
+    { url: "https://example.com/download?id=audio", expectedType: "image" },
+  ])("reads $url as a $expectedType message", async ({ url, expectedType }) => {
+    await expect(buildLineMediaMessage(url, {}, USER_TARGET)).resolves.toMatchObject({
+      type: expectedType,
+      originalContentUrl: url,
+    });
+  });
+
+  it.each([
+    // These suffixes name formats LINE cannot carry in its native message types.
+    "https://example.com/image.webp",
+    "https://example.com/animation.gif",
+    "https://example.com/clip.mov",
+    "https://example.com/clip.webm",
+    "https://example.com/audio.wav",
+    "https://example.com/audio.ogg",
+    "https://example.com/report.pdf",
+    "https://example.com/archive.zip",
+    "https://example.com/file.unknown",
+  ])("delivers unsupported %s as its URL", async (url) => {
+    await expect(buildLineMediaMessage(url, {}, USER_TARGET)).resolves.toEqual({
+      type: "text",
+      text: url,
+    });
+  });
+
+  it("reads an MP4 URL as a video message once a preview image exists", async () => {
+    const url = "https://example.com/video.mp4";
+    await expect(
+      buildLineMediaMessage(url, { previewImageUrl: PREVIEW_URL }, USER_TARGET),
+    ).resolves.toEqual({
+      type: "video",
+      originalContentUrl: url,
+      previewImageUrl: PREVIEW_URL,
+    });
+  });
+
+  it("names the missing preview image when the caller asked for a video", async () => {
+    await expect(
+      buildLineMediaMessage("https://example.com/clip.mp4", { mediaKind: "video" }, USER_TARGET),
+    ).rejects.toThrow(/require previewImageUrl/i);
+  });
+
+  it("names the missing preview image when tracking metadata declares video intent", async () => {
+    await expect(
+      buildLineMediaMessage(
+        "https://example.com/download?id=video",
+        { trackingId: "track-1" },
+        USER_TARGET,
+      ),
+    ).rejects.toThrow(/require previewImageUrl/i);
+  });
+
+  it("delivers an inferred video without a poster as its URL", async () => {
+    // Nobody asked for a video here, so a hard failure would lose a send the
+    // caller only described by its URL.
+    await expect(
+      buildLineMediaMessage("https://example.com/clip.mp4", {}, USER_TARGET),
+    ).resolves.toEqual({ type: "text", text: "https://example.com/clip.mp4" });
+  });
+
+  it("gates trackingId on user targets", async () => {
     const options = {
       mediaKind: "video" as const,
-      previewImageUrl: "https://example.com/preview.jpg",
+      previewImageUrl: PREVIEW_URL,
       trackingId: "track-1",
     };
     await expect(
-      buildLineMediaMessage("https://example.com/clip.mp4", options, "line:user:Uabc"),
+      buildLineMediaMessage("https://example.com/clip.mp4", options, USER_TARGET),
     ).resolves.toEqual({
       type: "video",
       originalContentUrl: "https://example.com/clip.mp4",
-      previewImageUrl: "https://example.com/preview.jpg",
+      previewImageUrl: PREVIEW_URL,
       trackingId: "track-1",
     });
     await expect(
@@ -227,27 +243,13 @@ describe("buildLineMediaMessage", () => {
     ).resolves.toEqual({
       type: "video",
       originalContentUrl: "https://example.com/clip.mp4",
-      previewImageUrl: "https://example.com/preview.jpg",
+      previewImageUrl: PREVIEW_URL,
     });
-  });
-
-  it("rejects a video missing its preview image", async () => {
-    await expect(
-      buildLineMediaMessage(
-        "https://example.com/clip.mp4",
-        { mediaKind: "video" },
-        "line:user:Uabc",
-      ),
-    ).rejects.toThrow(/require previewImageUrl/i);
   });
 
   it("builds an audio message with a default duration", async () => {
     await expect(
-      buildLineMediaMessage(
-        "https://example.com/voice.m4a",
-        { mediaKind: "audio" },
-        "line:user:Uabc",
-      ),
+      buildLineMediaMessage("https://example.com/voice.m4a", { mediaKind: "audio" }, USER_TARGET),
     ).resolves.toEqual({
       type: "audio",
       originalContentUrl: "https://example.com/voice.m4a",
@@ -257,11 +259,7 @@ describe("buildLineMediaMessage", () => {
 
   it("defaults an image preview to the media URL", async () => {
     await expect(
-      buildLineMediaMessage(
-        "https://example.com/photo.png",
-        { mediaKind: "image" },
-        "line:user:Uabc",
-      ),
+      buildLineMediaMessage("https://example.com/photo.png", { mediaKind: "image" }, USER_TARGET),
     ).resolves.toEqual({
       type: "image",
       originalContentUrl: "https://example.com/photo.png",

--- a/extensions/line/src/outbound-media.ts
+++ b/extensions/line/src/outbound-media.ts
@@ -1,12 +1,17 @@
 // Line plugin module implements outbound media behavior.
 import type { messagingApi } from "@line/bot-sdk";
+import { getFileExtension, mimeTypeFromFilePath } from "openclaw/plugin-sdk/media-mime";
 import { resolvePinnedHostnameWithPolicy, type SsrFPolicy } from "openclaw/plugin-sdk/ssrf-runtime";
-import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
-import type { LineChannelData, LineOutboundMediaKind } from "./types.js";
+import type { LineOutboundMediaKind } from "./types.js";
+
+// LINE accepts a tracking id on a video sent to a user, but the SDK type omits it.
+type LineVideoMessage = messagingApi.VideoMessage & { trackingId?: string };
 
 type LineOutboundMediaResolved = {
   mediaUrl: string;
-  mediaKind: LineOutboundMediaKind;
+  /** "unsupported" names a known format LINE cannot carry as native media. */
+  mediaKind: LineOutboundMediaKind | "unsupported";
+  kindSource: "declared" | "metadata" | "url" | "fallback";
   previewImageUrl?: string;
   durationMs?: number;
   trackingId?: string;
@@ -23,7 +28,7 @@ const LINE_OUTBOUND_MEDIA_SSRF_POLICY: SsrFPolicy = {
   allowPrivateNetwork: false,
 };
 
-export async function validateLineMediaUrl(url: string): Promise<void> {
+async function validateLineMediaUrl(url: string): Promise<void> {
   let parsed: URL;
   try {
     parsed = new URL(url);
@@ -49,25 +54,47 @@ function isHttpsUrl(url: string): boolean {
   }
 }
 
-function detectLineMediaKindFromUrl(url: string): LineOutboundMediaKind | undefined {
-  try {
-    const pathname = normalizeLowercaseStringOrEmpty(new URL(url).pathname);
-    if (/\.(png|jpe?g|gif|webp|bmp|heic|heif|avif)$/i.test(pathname)) {
-      return "image";
-    }
-    if (/\.(mp4|mov|m4v|webm)$/i.test(pathname)) {
-      return "video";
-    }
-    if (/\.(mp3|m4a|aac|wav|ogg|oga)$/i.test(pathname)) {
-      return "audio";
-    }
-  } catch {
-    return undefined;
+const LINE_MEDIA_KIND_BY_MIME: Readonly<Record<string, LineOutboundMediaKind | undefined>> = {
+  "image/jpeg": "image",
+  "image/png": "image",
+  "video/mp4": "video",
+  "audio/mpeg": "audio",
+  "audio/x-m4a": "audio",
+};
+
+// LINE's native message families accept narrower formats than the shared MIME
+// families. A known but unsupported suffix must remain visible as text instead
+// of becoming a native bubble the provider accepts but the client cannot render.
+function detectLineMediaKindFromUrl(
+  url: string,
+): LineOutboundMediaKind | "unsupported" | undefined {
+  const mimeType = mimeTypeFromFilePath(url);
+  if (mimeType === undefined) {
+    return getFileExtension(url) === undefined ? undefined : "unsupported";
   }
-  return undefined;
+  return LINE_MEDIA_KIND_BY_MIME[mimeType] ?? "unsupported";
 }
 
-export async function resolveLineOutboundMedia(
+function resolveLineMediaKind(
+  url: string,
+  opts: ResolveLineOutboundMediaOpts,
+): Pick<LineOutboundMediaResolved, "mediaKind" | "kindSource"> {
+  if (opts.mediaKind !== undefined) {
+    return { mediaKind: opts.mediaKind, kindSource: "declared" };
+  }
+  if (typeof opts.durationMs === "number") {
+    return { mediaKind: "audio", kindSource: "metadata" };
+  }
+  if (opts.trackingId?.trim()) {
+    return { mediaKind: "video", kindSource: "metadata" };
+  }
+  const detected = detectLineMediaKindFromUrl(url);
+  return detected === undefined
+    ? { mediaKind: "image", kindSource: "fallback" }
+    : { mediaKind: detected, kindSource: "url" };
+}
+
+async function resolveLineOutboundMedia(
   mediaUrl: string,
   opts: ResolveLineOutboundMediaOpts = {},
 ): Promise<LineOutboundMediaResolved> {
@@ -78,15 +105,9 @@ export async function resolveLineOutboundMedia(
     if (previewImageUrl) {
       await validateLineMediaUrl(previewImageUrl);
     }
-    const mediaKind =
-      opts.mediaKind ??
-      (typeof opts.durationMs === "number" ? "audio" : undefined) ??
-      (opts.trackingId?.trim() ? "video" : undefined) ??
-      detectLineMediaKindFromUrl(trimmedUrl) ??
-      "image";
     return {
       mediaUrl: trimmedUrl,
-      mediaKind,
+      ...resolveLineMediaKind(trimmedUrl, opts),
       ...(previewImageUrl ? { previewImageUrl } : {}),
       ...(typeof opts.durationMs === "number" ? { durationMs: opts.durationMs } : {}),
       ...(opts.trackingId ? { trackingId: opts.trackingId } : {}),
@@ -113,13 +134,46 @@ function isLineUserTarget(target: string): boolean {
   return /^U/i.test(normalized);
 }
 
-export function hasLineSpecificMediaOptions(lineData: LineChannelData): boolean {
-  return (
-    lineData.mediaKind !== undefined ||
-    Boolean(lineData.previewImageUrl?.trim()) ||
-    typeof lineData.durationMs === "number" ||
-    Boolean(lineData.trackingId?.trim())
-  );
+export function createImageMessage(
+  originalContentUrl: string,
+  previewImageUrl?: string,
+): messagingApi.ImageMessage {
+  return {
+    type: "image",
+    originalContentUrl,
+    previewImageUrl: previewImageUrl ?? originalContentUrl,
+  };
+}
+
+export function createVideoMessage(
+  originalContentUrl: string,
+  previewImageUrl: string,
+  trackingId?: string,
+): LineVideoMessage {
+  return {
+    type: "video",
+    originalContentUrl,
+    previewImageUrl,
+    ...(trackingId ? { trackingId } : {}),
+  };
+}
+
+export function createAudioMessage(
+  originalContentUrl: string,
+  durationMs: number,
+): messagingApi.AudioMessage {
+  return {
+    type: "audio",
+    originalContentUrl,
+    duration: durationMs,
+  };
+}
+
+// An image bubble LINE cannot fill renders as blank space the sender never sees,
+// so media the platform will not carry degrades to the URL it was made of — the
+// same shape createLocationMessage uses for a pin LINE will not draw.
+function lineMediaUrlFallback(mediaUrl: string): messagingApi.TextMessage {
+  return { type: "text", text: mediaUrl };
 }
 
 function buildLineMediaMessageObject(
@@ -127,32 +181,28 @@ function buildLineMediaMessageObject(
   opts?: { allowTrackingId?: boolean },
 ): messagingApi.Message {
   switch (resolved.mediaKind) {
+    case "unsupported":
+      return lineMediaUrlFallback(resolved.mediaUrl);
     case "video": {
       const previewImageUrl = resolved.previewImageUrl?.trim();
-      if (!previewImageUrl) {
+      if (previewImageUrl) {
+        return createVideoMessage(
+          resolved.mediaUrl,
+          previewImageUrl,
+          opts?.allowTrackingId ? resolved.trackingId : undefined,
+        );
+      }
+      // LINE always needs a poster for a video. Explicit kind or video-only
+      // metadata keeps the missing field visible; only URL inference degrades.
+      if (resolved.kindSource !== "url") {
         throw new Error("LINE video messages require previewImageUrl to reference an image URL");
       }
-      return {
-        type: "video",
-        originalContentUrl: resolved.mediaUrl,
-        previewImageUrl,
-        ...(opts?.allowTrackingId && resolved.trackingId
-          ? { trackingId: resolved.trackingId }
-          : {}),
-      };
+      return lineMediaUrlFallback(resolved.mediaUrl);
     }
     case "audio":
-      return {
-        type: "audio",
-        originalContentUrl: resolved.mediaUrl,
-        duration: resolved.durationMs ?? 60000,
-      };
+      return createAudioMessage(resolved.mediaUrl, resolved.durationMs ?? 60000);
     default:
-      return {
-        type: "image",
-        originalContentUrl: resolved.mediaUrl,
-        previewImageUrl: resolved.previewImageUrl ?? resolved.mediaUrl,
-      };
+      return createImageMessage(resolved.mediaUrl, resolved.previewImageUrl);
   }
 }
 

--- a/extensions/line/src/outbound.ts
+++ b/extensions/line/src/outbound.ts
@@ -19,11 +19,7 @@ import { PlatformMessageNotDispatchedError } from "openclaw/plugin-sdk/error-run
 import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
 import { resolveOutboundMediaUrls } from "openclaw/plugin-sdk/reply-payload";
 import { sanitizeAssistantVisibleText } from "openclaw/plugin-sdk/text-chunking";
-import {
-  buildLineMediaMessage,
-  hasLineSpecificMediaOptions,
-  resolveLineOutboundMedia,
-} from "./outbound-media.js";
+import { buildLineMediaMessage } from "./outbound-media.js";
 import { buildLineQuickReplyFallbackText } from "./quick-reply-fallback.js";
 import {
   createLineQuickReply,
@@ -160,9 +156,8 @@ export const lineOutboundAdapter: NonNullable<ChannelPlugin<ResolvedLineAccount>
         ? runtime.channel.text.chunkMarkdownText(processed.text, chunkLimit)
         : [];
     const mediaUrls = resolveOutboundMediaUrls(payload);
-    const useLineSpecificMedia = hasLineSpecificMediaOptions(lineData);
     const mediaOptions = {
-      mediaKind: useLineSpecificMedia ? lineData.mediaKind : ("image" as const),
+      mediaKind: lineData.mediaKind,
       previewImageUrl: lineData.previewImageUrl,
       durationMs: lineData.durationMs,
       trackingId: lineData.trackingId,
@@ -174,24 +169,11 @@ export const lineOutboundAdapter: NonNullable<ChannelPlugin<ResolvedLineAccount>
         if (!trimmed) {
           continue;
         }
-        if (!useLineSpecificMedia) {
-          await recordResult(
-            (lineRuntime?.sendMessageLine ?? outboundRuntime.sendMessageLine)(to, "", {
-              ...sendOptions,
-              mediaUrl: trimmed,
-            }),
-          );
-          continue;
-        }
-        const resolved = await resolveLineOutboundMedia(trimmed, mediaOptions);
         await recordResult(
           (lineRuntime?.sendMessageLine ?? outboundRuntime.sendMessageLine)(to, "", {
             ...sendOptions,
-            mediaUrl: resolved.mediaUrl,
-            mediaKind: resolved.mediaKind,
-            previewImageUrl: resolved.previewImageUrl,
-            durationMs: resolved.durationMs,
-            trackingId: resolved.trackingId,
+            ...mediaOptions,
+            mediaUrl: trimmed,
           }),
         );
       }

--- a/extensions/line/src/send.test.ts
+++ b/extensions/line/src/send.test.ts
@@ -103,14 +103,6 @@ const LINE_TEST_CFG = {
   },
 };
 
-function createCredentialBearingHttpUrl(): string {
-  const url = new URL("http://example.com/image.jpg");
-  url.username = ["line", "user"].join("-");
-  url.password = ["line", "fixture"].join("-");
-  url.searchParams.set("auth", ["line", "query"].join("-"));
-  return url.href;
-}
-
 describe("LINE send helpers", () => {
   const fixedSentAt = 1_800_000_000_000;
 
@@ -817,7 +809,25 @@ describe("LINE send helpers", () => {
     });
   });
 
-  it("sends video with explicit image preview URL", async () => {
+  it("sends a bare audio URL using the kind inferred by the LINE media owner", async () => {
+    await sendModule.sendMessageLine("line:user:U123", "", {
+      cfg: LINE_TEST_CFG,
+      mediaUrl: "https://example.com/voice.m4a",
+    });
+
+    expect(pushMessageMock).toHaveBeenCalledWith({
+      to: "U123",
+      messages: [
+        {
+          type: "audio",
+          originalContentUrl: "https://example.com/voice.m4a",
+          duration: 60000,
+        },
+      ],
+    });
+  });
+
+  it("forwards explicit video options through the shared LINE media owner", async () => {
     await sendModule.sendMessageLine("line:user:U100", "Video", {
       cfg: LINE_TEST_CFG,
       mediaUrl: "https://example.com/video.mp4",
@@ -835,15 +845,12 @@ describe("LINE send helpers", () => {
           previewImageUrl: "https://example.com/preview.jpg",
           trackingId: "track-1",
         },
-        {
-          type: "text",
-          text: "Video",
-        },
+        { type: "text", text: "Video" },
       ],
     });
   });
 
-  it("throws when video preview URL is missing", async () => {
+  it("keeps a missing explicit video preview as a visible caller error", async () => {
     await expect(
       sendModule.sendMessageLine("line:user:U200", "Video", {
         cfg: LINE_TEST_CFG,
@@ -851,88 +858,18 @@ describe("LINE send helpers", () => {
         mediaKind: "video",
       }),
     ).rejects.toThrow(/require previewimageurl/i);
+
+    expect(pushMessageMock).not.toHaveBeenCalled();
   });
 
-  it("blocks private-network media URLs before calling LINE", async () => {
-    resolvePinnedHostnameWithPolicyMock.mockRejectedValueOnce(
-      new Error("SSRF blocked private network target"),
-    );
-
+  it("keeps the image helper on the validated LINE media path", async () => {
     await expect(
-      sendModule.sendMessageLine("line:user:U200", "Image", {
+      sendModule.pushImageMessage("line:user:U123", "http://example.com/private.jpg", undefined, {
         cfg: LINE_TEST_CFG,
-        mediaUrl: "https://127.0.0.1/image.jpg",
       }),
-    ).rejects.toThrow(/private network/i);
+    ).rejects.toThrow("LINE outbound media URL must use HTTPS");
 
     expect(pushMessageMock).not.toHaveBeenCalled();
-  });
-
-  it.each([
-    {
-      name: "send media URL",
-      run: () =>
-        sendModule.sendMessageLine("line:user:U200", "Image", {
-          cfg: LINE_TEST_CFG,
-          mediaUrl: createCredentialBearingHttpUrl(),
-        }),
-    },
-    {
-      name: "send preview URL",
-      run: () =>
-        sendModule.sendMessageLine("line:user:U200", "Video", {
-          cfg: LINE_TEST_CFG,
-          mediaUrl: "https://example.com/video.mp4",
-          mediaKind: "video",
-          previewImageUrl: createCredentialBearingHttpUrl(),
-        }),
-    },
-    {
-      name: "push image URL",
-      run: () =>
-        sendModule.pushImageMessage("line:user:U200", createCredentialBearingHttpUrl(), undefined, {
-          cfg: LINE_TEST_CFG,
-        }),
-    },
-    {
-      name: "push image preview URL",
-      run: () =>
-        sendModule.pushImageMessage(
-          "line:user:U200",
-          "https://example.com/image.jpg",
-          createCredentialBearingHttpUrl(),
-          { cfg: LINE_TEST_CFG },
-        ),
-    },
-  ])("does not expose credentials from an insecure $name", async ({ run }) => {
-    await expect(run()).rejects.toThrow(new Error("LINE outbound media URL must use HTTPS"));
-    expect(pushMessageMock).not.toHaveBeenCalled();
-    expect(replyMessageMock).not.toHaveBeenCalled();
-  });
-
-  it("omits trackingId for non-user destinations", async () => {
-    await sendModule.sendMessageLine("line:group:C100", "Video", {
-      cfg: LINE_TEST_CFG,
-      mediaUrl: "https://example.com/video.mp4",
-      mediaKind: "video",
-      previewImageUrl: "https://example.com/preview.jpg",
-      trackingId: "track-group",
-    });
-
-    expect(pushMessageMock).toHaveBeenCalledWith({
-      to: "C100",
-      messages: [
-        {
-          type: "video",
-          originalContentUrl: "https://example.com/video.mp4",
-          previewImageUrl: "https://example.com/preview.jpg",
-        },
-        {
-          type: "text",
-          text: "Video",
-        },
-      ],
-    });
   });
 
   it("throws when push messages are empty", async () => {

--- a/extensions/line/src/send.ts
+++ b/extensions/line/src/send.ts
@@ -17,7 +17,7 @@ import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import { resolveLineAccount } from "./accounts.js";
 import { messageAction, normalizeLineMessageActions } from "./actions.js";
 import { resolveLineChannelAccessToken } from "./channel-access-token.js";
-import { validateLineMediaUrl } from "./outbound-media.js";
+import { buildLineMediaMessage } from "./outbound-media.js";
 import { recordLineSentMessages } from "./outbound-message-log.js";
 import { createLineSendReceipt } from "./send-receipt.js";
 import { runLinePushWithRetries } from "./send-retry.js";
@@ -25,9 +25,6 @@ import type { LineChannelData, LineOutboundMediaKind, LineSendResult } from "./t
 
 type Message = messagingApi.Message;
 type TextMessage = messagingApi.TextMessage;
-type ImageMessage = messagingApi.ImageMessage;
-type VideoMessage = messagingApi.VideoMessage & { trackingId?: string };
-type AudioMessage = messagingApi.AudioMessage;
 type LocationMessage = messagingApi.LocationMessage;
 type FlexContainer = messagingApi.FlexContainer;
 type TemplateMessage = messagingApi.TemplateMessage;
@@ -174,10 +171,6 @@ function normalizeTarget(to: string): string {
   return normalized;
 }
 
-function isLineUserChatId(chatId: string): boolean {
-  return /^U/i.test(chatId);
-}
-
 function resolveLineMessagingAccount(opts: LineClientOpts): {
   account: ReturnType<typeof resolveLineAccount>;
   token: string;
@@ -266,38 +259,6 @@ async function sendLineProviderMessages(
 
 function createTextMessage(text: string): TextMessage {
   return { type: "text", text };
-}
-
-export function createImageMessage(
-  originalContentUrl: string,
-  previewImageUrl?: string,
-): ImageMessage {
-  return {
-    type: "image",
-    originalContentUrl,
-    previewImageUrl: previewImageUrl ?? originalContentUrl,
-  };
-}
-
-export function createVideoMessage(
-  originalContentUrl: string,
-  previewImageUrl: string,
-  trackingId?: string,
-): VideoMessage {
-  return {
-    type: "video",
-    originalContentUrl,
-    previewImageUrl,
-    ...(trackingId ? { trackingId } : {}),
-  };
-}
-
-export function createAudioMessage(originalContentUrl: string, durationMs: number): AudioMessage {
-  return {
-    type: "audio",
-    originalContentUrl,
-    duration: durationMs,
-  };
 }
 
 function isValidLineLocation(location: LineLocation): boolean {
@@ -471,30 +432,18 @@ export async function sendMessageLine(
 
   const mediaUrl = opts.mediaUrl?.trim();
   if (mediaUrl) {
-    await validateLineMediaUrl(mediaUrl);
-    switch (opts.mediaKind) {
-      case "video": {
-        const previewImageUrl = opts.previewImageUrl?.trim();
-        if (!previewImageUrl) {
-          throw new Error("LINE video messages require previewImageUrl to reference an image URL");
-        }
-        await validateLineMediaUrl(previewImageUrl);
-        const trackingId = isLineUserChatId(chatId) ? opts.trackingId : undefined;
-        messages.push(createVideoMessage(mediaUrl, previewImageUrl, trackingId));
-        break;
-      }
-      case "audio":
-        messages.push(createAudioMessage(mediaUrl, opts.durationMs ?? 60000));
-        break;
-      default:
-        // Backward compatibility: keep image as default when media kind is unspecified.
+    messages.push(
+      await buildLineMediaMessage(
+        mediaUrl,
         {
-          const previewImageUrl = opts.previewImageUrl?.trim() || mediaUrl;
-          await validateLineMediaUrl(previewImageUrl);
-          messages.push(createImageMessage(mediaUrl, previewImageUrl));
-        }
-        break;
-    }
+          mediaKind: opts.mediaKind,
+          previewImageUrl: opts.previewImageUrl,
+          durationMs: opts.durationMs,
+          trackingId: opts.trackingId,
+        },
+        chatId,
+      ),
+    );
   }
 
   if (text?.trim()) {
@@ -581,11 +530,12 @@ export async function pushImageMessage(
   previewImageUrl: string | undefined,
   opts: LinePushOpts,
 ): Promise<LineSendResult> {
-  await validateLineMediaUrl(originalContentUrl);
-  if (previewImageUrl) {
-    await validateLineMediaUrl(previewImageUrl);
-  }
-  return pushLineMessages(to, [createImageMessage(originalContentUrl, previewImageUrl)], opts, {
+  const message = await buildLineMediaMessage(
+    originalContentUrl,
+    { mediaKind: "image", previewImageUrl },
+    to,
+  );
+  return pushLineMessages(to, [message], opts, {
     verboseMessage: (chatId) => `line: pushed image to ${chatId}`,
   });
 }


### PR DESCRIPTION
## What Problem This Solves

Sending an audio file, a video, or a PDF to LINE with `message(action="send", mediaUrl: "…")` puts an **empty bubble** in the chat. Nothing plays, nothing downloads, there is no error anywhere: LINE answers `HTTP 200` and OpenClaw records the reply as delivered.

The reason is that a media URL carrying no `channelData.line` options is pinned to LINE's *image* message type on every outbound path, so an `.mp3`, an `.mp4`, or a `.pdf` is handed to LINE as an image and the client renders nothing.

The plugin already knows better. `resolveLineOutboundMedia` reads the kind off the URL and has tests for it — but three of the four call sites that reach it override the result with `"image"` before it is consulted, and the fourth (`sendMessageLine`) carries its own duplicate `switch` that defaults to image and never looks at the URL at all.

## Why This Change Was Made

`outbound-media.ts` owns LINE media-kind resolution; the other modules were re-deciding it. This change makes them stop:

- `sendMessageLine` builds its media message through `buildLineMediaMessage` instead of a second copy of the video/audio/image switch. `pushImageMessage` uses the same leaf.
- `outbound.ts` and `auto-reply-delivery.ts` pass the caller's LINE options through instead of substituting `mediaKind: "image"`. With that gone, `hasLineSpecificMediaOptions` had no callers and is deleted, along with the double resolution `outbound.ts` was doing before handing the fields back to `sendMessageLine`.
- The hand-rolled extension regex is replaced by `mediaKindFromMime(mimeTypeFromFilePath(url))` from `openclaw/plugin-sdk/media-mime` — the table this plugin already uses in `rich-menu.ts`. It covers every extension the regex did, plus uppercase paths and `.m4a`.

The `"image"` default was never a product decision: it arrived as `// Backward compatibility: keep image as default when media kind is unspecified` in the commit that first added outbound media (`9449e54f4ff`), preserving the image-only behaviour that predated video and audio support.

Two URLs still have no LINE message type to become, and both would land back in the empty bubble if left on the image route: a family LINE does not carry at all (a PDF, an archive), and a video URL with no poster, since LINE always requires one. Both are delivered as the media URL in a text message — the shape `createLocationMessage` in this same plugin already uses for a pin LINE will not draw. A caller who explicitly asks for `mediaKind: "video"` without `previewImageUrl` still gets the error naming that field, because there the missing poster is theirs to supply. The result is that every accepted media URL now ends in something the recipient can see or tap.

A URL whose suffix proves nothing (no extension, an opaque `?id=` download) keeps the image route, which is what a bare `mediaUrl` almost always is.

Production LOC: **+113 / −146 (net −33)**. Test lines are +190 net, most of it the mock preamble for `send.media.test.ts`, which takes the 188 media lines out of `send.test.ts` (that file was over the 1000-line cap once the new cases landed; no suppression added).

## User Impact

An agent that sends a voice note, a recording, a clip, or a document to LINE now gets a playable audio bubble, a video bubble, or a tappable link instead of an empty one. Nothing changes for images, for explicit `channelData.line.mediaKind`, or for the SSRF/HTTPS/length validation every media URL still passes through.

## Evidence

**Live A/B against the real LINE Messaging API.** The same probe drives this branch's `sendMessageLine` and then `origin/main`'s, with the real channel token, capturing the request body actually put on the wire.

This branch:

```
bare .m4a: sent [{"type":"audio","originalContentUrl":"https://filesamples.com/samples/audio/m4a/sample3.m4a","duration":60000}]
bare .m4a: LINE accepted messageId=629429434742997303
bare .mp3: sent [{"type":"audio","originalContentUrl":"https://download.samplelib.com/mp3/sample-3s.mp3","duration":60000}]
bare .mp3: LINE accepted messageId=629429435481194722
bare .jpg: sent [{"type":"image","originalContentUrl":"https://download.samplelib.com/jpeg/sample-clouds-400x300.jpg","previewImageUrl":"https://download.samplelib.com/jpeg/sample-clouds-400x300.jpg"}]
bare .jpg: LINE accepted messageId=629429436185313383
.mp4 + previewImageUrl: sent [{"type":"video","originalContentUrl":"https://download.samplelib.com/mp4/sample-5s.mp4","previewImageUrl":"https://download.samplelib.com/jpeg/sample-clouds-400x300.jpg"}]
.mp4 + previewImageUrl: LINE accepted messageId=629429436655075796
bare .mp4 (no poster): sent [{"type":"text","text":"https://download.samplelib.com/mp4/sample-5s.mp4"}]
bare .mp4 (no poster): LINE accepted messageId=629429436974105115
bare .pdf: sent [{"type":"text","text":"https://www.w3.org/WAI/ER/tests/xhtml/testfiles/resources/pdf/dummy.pdf"}]
bare .pdf: LINE accepted messageId=629429437376757932
cases=6 locallyRejected=0
```

`origin/main`, same probe, same URLs, same channel:

```
bare .m4a: sent [{"type":"image","originalContentUrl":"https://filesamples.com/samples/audio/m4a/sample3.m4a","previewImageUrl":"https://filesamples.com/samples/audio/m4a/sample3.m4a"}]
bare .m4a: LINE accepted messageId=629427550107992585
bare .mp3: sent [{"type":"image","originalContentUrl":"https://download.samplelib.com/mp3/sample-3s.mp3","previewImageUrl":"https://download.samplelib.com/mp3/sample-3s.mp3"}]
bare .mp3: LINE accepted messageId=629427551231541666
bare .jpg: sent [{"type":"image","originalContentUrl":"https://download.samplelib.com/jpeg/sample-clouds-400x300.jpg","previewImageUrl":"https://download.samplelib.com/jpeg/sample-clouds-400x300.jpg"}]
bare .jpg: LINE accepted messageId=629427551550570849
.mp4 + previewImageUrl: sent [{"type":"image","originalContentUrl":"https://download.samplelib.com/mp4/sample-5s.mp4","previewImageUrl":"https://download.samplelib.com/jpeg/sample-clouds-400x300.jpg"}]
.mp4 + previewImageUrl: LINE accepted messageId=629427552254951664
bare .mp4 (no poster): sent [{"type":"image","originalContentUrl":"https://download.samplelib.com/mp4/sample-5s.mp4","previewImageUrl":"https://download.samplelib.com/mp4/sample-5s.mp4"}]
bare .mp4 (no poster): LINE accepted messageId=629427552691683404
cases=5 locallyRejected=0
```

Every `origin/main` send is an image message, and every one of them is accepted with `HTTP 200` — which is exactly why the failure is invisible. `POST /v2/bot/message/validate/push` also returns `200` for an image message pointing at an `.mp4`, so nothing short of looking at a real client catches this.

**What the client shows.** Same `.mp3` URL, sent both ways into the same chat: `origin/main`'s image message renders as an empty bubble, this branch's audio message renders as a playable `00:03` bubble.

![LINE client: the same .mp3 URL as an image message (empty bubble) and as an audio message (playable 00:03 bubble)](https://github.com/user-attachments/assets/59669296-61a6-48fd-a6b7-4afc1c2cfd53)

And the poster-less `.mp4`, which used to be an empty bubble, arrives as a tappable link:

![LINE client: a bare .mp4 URL with no poster delivered as a clickable link](https://github.com/user-attachments/assets/8669a321-cd08-4f2b-8b83-a08b021f5f2e)

**Red↔green.** With only the five production files restored to `origin/main` and the tests from this branch, nine cases fail for the intended reason; all pass with the change applied:

```
FAIL extensions/line/src/auto-reply-delivery.test.ts > leaves the media kind of a bare URL for the shared leaf to resolve
FAIL extensions/line/src/channel.sendPayload.test.ts > sends inline quick-reply media as the kind its URL proves
FAIL extensions/line/src/outbound-media.test.ts > delivers https://example.com/report.pdf as its URL because LINE cannot carry that family
FAIL extensions/line/src/outbound-media.test.ts > delivers https://example.com/archive.zip as its URL because LINE cannot carry that family
FAIL extensions/line/src/outbound-media.test.ts > delivers an inferred video without a poster as its URL
FAIL extensions/line/src/send.media.test.ts > sends a bare 'audio URL' as the kind its URL proves
FAIL extensions/line/src/send.media.test.ts > sends a bare 'family LINE cannot carry' as the kind its URL proves
FAIL extensions/line/src/send.media.test.ts > sends a bare video URL as a video message once a preview image exists
FAIL extensions/line/src/send.media.test.ts > keeps a bare video URL reachable when LINE has no poster for it
Test Files  4 failed (4)
     Tests  9 failed | 97 passed (106)
```

**Local gates.**

```
$ node scripts/run-vitest.mjs extensions/line
 Test Files  45 passed (45)
      Tests  670 passed (670)

$ node scripts/run-tsgo.mjs -p tsconfig.extensions.json --noEmit                     # EXIT=0
$ node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.extensions.test.json --noEmit  # EXIT=0
$ node scripts/check-changed.mjs                                                     # EXIT=0
$ pnpm check:assertion-safety --base origin/main
assertion SAFETY ratchet OK: 4183 files, 12963 grandfathered assertions.
$ pnpm check:max-lines-ratchet --base origin/main
max-lines ratchet OK: 883 grandfathered suppressions.
$ pnpm build                                                                         # EXIT=0, no [INEFFECTIVE_DYNAMIC_IMPORT]
```

Sibling surfaces: LINE is the only channel that pins outbound media to one type. WhatsApp resolves the kind through the same `mediaKindFromMime` + `mimeTypeFromFilePath` pair in `extensions/whatsapp/src/outbound-media-contract.ts`, which is the shape this change adopts.
