### PR TITLE
refactor: unify context-engine host parameter projection

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -2748,7 +2748,7 @@ src/config/zod-schema.channels-config.ts	3
 src/config/zod-schema.core.ts	1
 src/config/zod-schema.ts	2
 src/context-engine/delegate.ts	1
-src/context-engine/registry.ts	10
+src/context-engine/registry.ts	9
 src/context-engine/runtime-settings.ts	2
 src/cron/delivery-channel-validation.ts	2
 src/cron/delivery-context.ts	1

--- a/src/context-engine/host-param-projection.test.ts
+++ b/src/context-engine/host-param-projection.test.ts
@@ -340,42 +340,126 @@ describe("context-engine host parameter projection", () => {
     ]);
   });
 
-  it("does not mutate frozen engines reused by a factory", async () => {
-    const engineId = `host-param-frozen-${++engineCounter}`;
-    const assemble = vi.fn<ContextEngine["assemble"]>(async (params) => ({
-      messages: params.messages,
-      estimatedTokens: 0,
-    }));
-    class FrozenProbeEngine implements ContextEngine {
-      readonly #info = { id: engineId, name: "Frozen Probe", acceptedHostParams: [] };
+  it.each(["process", "logical-turn"] as const)(
+    "does not mutate frozen engines reused by a factory (%s)",
+    async (mode) => {
+      const engineId = `host-param-frozen-${++engineCounter}`;
+      const assemble = vi.fn<ContextEngine["assemble"]>(async (params) => ({
+        messages: params.messages,
+        estimatedTokens: 0,
+      }));
+      class FrozenProbeEngine implements ContextEngine {
+        readonly #info = { id: engineId, name: "Frozen Probe", acceptedHostParams: [] };
 
-      get info() {
-        return this.#info;
+        get info() {
+          return this.#info;
+        }
+
+        async ingest() {
+          return { ingested: true };
+        }
+
+        assemble = assemble;
+
+        async compact() {
+          return { ok: true, compacted: false };
+        }
       }
+      const sharedEngine = Object.freeze(new FrozenProbeEngine());
+      registerContextEngineForOwner(engineId, () => sharedEngine, `test:${engineId}`);
 
-      async ingest() {
-        return { ingested: true };
+      const config = { plugins: { slots: { contextEngine: engineId } } };
+      const firstTurn =
+        mode === "logical-turn" ? await resolveLogicalTurnContextEngines(config) : undefined;
+      const secondTurn =
+        mode === "logical-turn" ? await resolveLogicalTurnContextEngines(config) : undefined;
+      const first = firstTurn?.configured.engine ?? (await resolveContextEngine(config));
+      const second = secondTurn?.configured.engine ?? (await resolveContextEngine(config));
+      try {
+        expect(first.info).toEqual({ id: engineId, name: "Frozen Probe", acceptedHostParams: [] });
+        await first.assemble({ sessionId: "session-1", sessionKey: "first", messages: [message] });
+        await second.assemble({
+          sessionId: "session-2",
+          sessionKey: "second",
+          messages: [message],
+        });
+
+        expect(assemble).toHaveBeenCalledTimes(2);
+        expect(assemble.mock.contexts[0]).toBe(sharedEngine);
+        expect(assemble.mock.contexts[1]).toBe(sharedEngine);
+        expect(assemble.mock.calls.map(([params]) => params)).toEqual([
+          { sessionId: "session-1", messages: [message] },
+          { sessionId: "session-2", messages: [message] },
+        ]);
+      } finally {
+        await Promise.allSettled([
+          firstTurn?.fallback.engine.dispose?.(),
+          secondTurn?.fallback.engine.dispose?.(),
+        ]);
       }
+    },
+  );
 
-      assemble = assemble;
+  it("preserves raw call identity despite process quarantine", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const engineId = `host-param-quarantined-${++engineCounter}`;
+    const processFailure = new Error("process compact failed");
+    const syncFailure = new Error("raw assemble failed");
+    const retainedPromise = Promise.resolve({ messages: [message], estimatedTokens: 0 });
+    const assemble = vi
+      .fn<ContextEngine["assemble"]>()
+      .mockReturnValueOnce(retainedPromise)
+      .mockImplementationOnce(() => {
+        throw syncFailure;
+      });
+    const info = { id: engineId, name: "Quarantined Probe", acceptedHostParams: [] };
+    registerContextEngineForOwner(
+      engineId,
+      () => ({
+        info,
+        ingest: async () => ({ ingested: true }),
+        assemble,
+        compact: async () => {
+          throw processFailure;
+        },
+      }),
+      `plugin:${engineId}`,
+    );
+    const config = { plugins: { slots: { contextEngine: engineId } } };
+    const processEngine = await resolveContextEngine(config);
+    await expect(
+      processEngine.compact({ sessionId: "session-1", sessionKey: "agent:main:session-1" }),
+    ).rejects.toBe(processFailure);
+    const quarantine = listContextEngineQuarantines();
+    expect(quarantine).toEqual([expect.objectContaining({ engineId, operation: "compact" })]);
 
-      async compact() {
-        return { ok: true, compacted: false };
+    const resolution = await resolveLogicalTurnContextEngines(config);
+    try {
+      expect(resolution.configured.ownerPluginId).toBe(engineId);
+      expect(resolution.configured.engine.info).toBe(info);
+      const params = { sessionId: "session-1", sessionKey: "raw", messages: [message] };
+      const result = resolution.configured.engine.assemble(params);
+      expect(result).toBe(retainedPromise);
+      await expect(result).resolves.toEqual({ messages: [message], estimatedTokens: 0 });
+
+      let returned: ReturnType<ContextEngine["assemble"]> | undefined;
+      let thrown: unknown;
+      try {
+        returned = resolution.configured.engine.assemble(params);
+      } catch (error) {
+        thrown = error;
       }
+      // Drain an accidental async rejection before asserting synchronous error identity.
+      await returned?.catch(() => {});
+      expect(thrown).toBe(syncFailure);
+      expect(assemble).toHaveBeenCalledTimes(2);
+      expect(listContextEngineQuarantines()).toEqual(quarantine);
+    } finally {
+      await Promise.allSettled([
+        processEngine.dispose?.(),
+        resolution.configured.engine.dispose?.(),
+        resolution.fallback.engine.dispose?.(),
+      ]);
     }
-    const sharedEngine = Object.freeze(new FrozenProbeEngine());
-    registerContextEngineForOwner(engineId, () => sharedEngine, `test:${engineId}`);
-
-    const first = await resolveContextEngine({ plugins: { slots: { contextEngine: engineId } } });
-    const second = await resolveContextEngine({ plugins: { slots: { contextEngine: engineId } } });
-    expect(first.info).toEqual({ id: engineId, name: "Frozen Probe", acceptedHostParams: [] });
-    await first.assemble({ sessionId: "session-1", sessionKey: "first", messages: [message] });
-    await second.assemble({ sessionId: "session-2", sessionKey: "second", messages: [message] });
-
-    expect(assemble).toHaveBeenCalledTimes(2);
-    expect(assemble.mock.calls.map(([params]) => params)).toEqual([
-      { sessionId: "session-1", messages: [message] },
-      { sessionId: "session-2", messages: [message] },
-    ]);
   });
 });

--- a/src/context-engine/registry.ts
+++ b/src/context-engine/registry.ts
@@ -74,36 +74,6 @@ function projectContextEngineHostParams(
   );
 }
 
-function wrapContextEngineHostParamProjection(
-  engine: ContextEngine,
-  metadata: ResolvedContextEngineMetadata,
-): ContextEngine {
-  const wrapped = new Proxy(
-    Object.create(engine, { info: { get: () => engine.info } }) as ContextEngine,
-    {
-      get(_target, property) {
-        if (property === "info") {
-          return engine.info;
-        }
-        const method = Reflect.get(engine, property, engine);
-        if (typeof method !== "function") {
-          return method;
-        }
-        if (!GUARDED_CONTEXT_ENGINE_METHODS.has(property)) {
-          return method.bind(engine);
-        }
-        return (params: Record<string, unknown>) =>
-          method.call(engine, projectContextEngineHostParams(engine, property, params));
-      },
-    },
-  );
-  resolvedEngineMetadata.set(wrapped, {
-    ...metadata,
-    sourceEngine: resolvedEngineMetadata.get(engine)?.sourceEngine ?? engine,
-  });
-  return wrapped;
-}
-
 function wrapResolvedContextEngine(
   engine: ContextEngine,
   metadata: ResolvedContextEngineMetadata & {
@@ -646,7 +616,7 @@ async function resolveRawContextEngineRef(
     );
     throw new Error(contractError);
   }
-  const projectedEngine = wrapContextEngineHostParamProjection(engine, {
+  const projectedEngine = wrapResolvedContextEngine(engine, {
     engineId,
     owner: entry.owner,
   });


### PR DESCRIPTION
## What Problem This Solves

Internal context-engine cleanup: logical-turn resolution maintained a second copy of the host-parameter projection proxy, including its frozen-engine handling, receiver binding, and source-engine metadata. The copies could drift even though the canonical wrapper already provides the required direct-call behavior when fallback metadata is absent.

## Why This Change Was Made

Reuse that existing no-fallback branch and delete the duplicate private wrapper. Raw logical-turn resolution still passes only its engine ID and registration owner. It does not acquire process-quarantine interception or lazy fallback, and keeps exact Promise returns, synchronous throws, original method receivers, and source identity used by maintenance/disposal.

The logical-turn resolver still constructs its default fallback engine up front; this change does not remove that existing behavior. There is no new API, configuration, compatibility path, or dependency.

## User Impact

No intended user-visible change. This removes 30 production lines while adding coverage for the behavior the shared wrapper must preserve. Tests grow by 84 lines; the complete PR therefore grows by 54 lines and is not an overall line-removal credit.

## Evidence

The same three complete suites passed against both the original production owner and the candidate: 97 cases each, including the expanded frozen-engine cases, raw Promise/synchronous-error identity under process quarantine, and existing maintenance coalescing/disposal/shutdown cases.

```sh
node scripts/run-vitest.mjs src/context-engine/host-param-projection.test.ts src/context-engine/context-engine.test.ts src/agents/embedded-agent-runner/context-engine-maintenance.test.ts --reporter=verbose
```

Both runs used Node 24.19, the repository's pinned pnpm 12 installation, and the normal test router. Source and dependency audits preserved the exact candidate and classified only the observed generated test-cache changes. These are paired characterization tests, not a fabricated failing bug reproduction.

The first full changed-path run stopped at the assertion-safety ratchet: deleting the duplicate wrapper removed one assertion, so the registry allowance had to shrink from ten to nine. Only that baseline row changed; the guard and all other allowances are unchanged. The failed run is retained. The corrected complete three-path run passed all 30 selected checks, including core and test typechecks, core/script lint, and all three dead-export scans. Independent precommit and separate published-commit Codex reviews completed with no blocking findings. [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/33248762867) passed for `1db5102152c424378d9e3fd1fe930339f8e6d9eb`. Mandatory hosted native preparation and normal squash merge completed successfully, without rebase, replacement push, auto-merge, or override. [Landed commit](https://github.com/openclaw/openclaw/commit/7f83a051de4c83344085d902fae3754e04d4502b) matches the complete tree reconstructed from its actual main parent and the reviewed source; all 35,105 entries match. The current-main assertion-baseline reductions are preserved alongside this PR's exact one-row shrink.

The latest ClawSweeper review found no introduced regression and requested ordinary maintainer handling after exact-head CI. That CI is now complete; the authorized maintainer cleanup is proceeding through the normal landing gates. Its automated stored-data label does not describe a schema change here: this patch changes an in-memory projection wrapper and test coverage only, with no persistence, vector/embedding metadata, migration, configuration, or public type change. No migration is needed. No additional actionable rank-up move was listed.

Named follow-up: clarify the context-engine documentation's gateway-only disposal wording and the distinction between logical-turn ownership and process quarantine. This refactor does not change either lifecycle.
