### PR TITLE
feat(fleet): show log timestamps

### DIFF
--- a/docs/cli/fleet.md
+++ b/docs/cli/fleet.md
@@ -162,11 +162,14 @@ Stream a cell's container logs directly to the terminal:
 ```bash
 openclaw fleet logs acme
 openclaw fleet logs acme --follow
+openclaw fleet logs acme --timestamps
 openclaw fleet logs acme --tail 200
 openclaw fleet logs acme --since 10m
 ```
 
 Fleet verifies the registered container's ownership labels before reading any logs, so it refuses a foreign container using the expected cell name. The stream is pinned to that inspected container ID, so a concurrent replacement cannot redirect it to a newer generation. Press Ctrl-C to end `--follow` without treating the operator stop as a command failure. Log output is piped through a redaction filter that replaces the cell's current Gateway token with `<redacted>` before anything reaches the terminal.
+
+Use `--timestamps` to include Docker or Podman timestamps in the raw stream. It can be combined with `--follow`, `--tail`, and `--since`.
 
 `fleet logs` has no `--json` mode because container logs are a raw stdout/stderr stream. For scripts, bound the output with `--tail` and use ordinary shell redirection or pipelines.
 

--- a/src/cli/fleet-cli/register.test.ts
+++ b/src/cli/fleet-cli/register.test.ts
@@ -134,11 +134,21 @@ describe("fleet cli", () => {
   });
 
   it("normalizes logs options", async () => {
-    await runFleetCli(["logs", "acme", "--follow", "--tail", "100", "--since", "10m"]);
+    await runFleetCli([
+      "logs",
+      "acme",
+      "--follow",
+      "--timestamps",
+      "--tail",
+      "100",
+      "--since",
+      "10m",
+    ]);
 
     expect(mocks.runFleetLogsCommand).toHaveBeenCalledWith({
       tenant: "acme",
       follow: true,
+      timestamps: true,
       tail: 100,
       since: "10m",
     });
@@ -183,6 +193,7 @@ describe("fleet cli", () => {
     expect(mocks.runFleetLogsCommand).toHaveBeenCalledWith({
       tenant: "tenant-a",
       follow: false,
+      timestamps: false,
       tail: 500,
       since: "10m",
     });

--- a/src/cli/fleet-cli/register.ts
+++ b/src/cli/fleet-cli/register.ts
@@ -186,14 +186,20 @@ export function registerFleetCli(program: Command): void {
     .description("Stream tenant cell container logs")
     .argument("<tenant>", "Tenant slug")
     .option("--follow", "Follow log output", false)
+    .option("--timestamps", "Show timestamps", false)
     .option("--tail <count>", "Number of lines to show", (value: string) =>
       parseStrictPositiveIntOption(value, "--tail"),
     )
     .option("--since <value>", "Show logs since a duration or timestamp")
-    .action(async (tenant: string, options: { follow: boolean; tail?: number; since?: string }) => {
-      const runtime = await loadFleetRuntime();
-      await runtime.runFleetLogsCommand({ tenant, ...options });
-    });
+    .action(
+      async (
+        tenant: string,
+        options: { follow: boolean; timestamps: boolean; tail?: number; since?: string },
+      ) => {
+        const runtime = await loadFleetRuntime();
+        await runtime.runFleetLogsCommand({ tenant, ...options });
+      },
+    );
 
   for (const action of ["start", "stop", "restart"] as const) {
     fleet

--- a/src/fleet/containers.runtime.test.ts
+++ b/src/fleet/containers.runtime.test.ts
@@ -452,11 +452,21 @@ describe("fleet container runtime", () => {
   it.each([
     [{}, ["logs", "cell-acme"]],
     [{ follow: true }, ["logs", "--follow", "cell-acme"]],
+    [{ timestamps: true }, ["logs", "--timestamps", "cell-acme"]],
     [{ tail: 200 }, ["logs", "--tail", "200", "cell-acme"]],
     [{ since: "10m" }, ["logs", "--since", "10m", "cell-acme"]],
     [
-      { follow: true, tail: 100, since: "2026-07-11T10:00:00Z" },
-      ["logs", "--follow", "--tail", "100", "--since", "2026-07-11T10:00:00Z", "cell-acme"],
+      { follow: true, timestamps: true, tail: 100, since: "2026-07-11T10:00:00Z" },
+      [
+        "logs",
+        "--follow",
+        "--timestamps",
+        "--tail",
+        "100",
+        "--since",
+        "2026-07-11T10:00:00Z",
+        "cell-acme",
+      ],
     ],
   ] as const)("streams logs with exact argv for %o", async (options, expectedArgs) => {
     const stream = vi.fn<FleetContainerStreamExecutor>(async () => ({ code: 0, signal: null }));

--- a/src/fleet/containers.runtime.ts
+++ b/src/fleet/containers.runtime.ts
@@ -54,6 +54,7 @@ type FleetContainerStreamExecutor = (
 
 type FleetContainerLogsOptions = {
   follow?: boolean;
+  timestamps?: boolean;
   tail?: number;
   since?: string;
   redactValues: readonly string[];
@@ -574,6 +575,9 @@ function buildLogsArgs(containerName: string, options: FleetContainerLogsOptions
   const args = ["logs"];
   if (options.follow) {
     args.push("--follow");
+  }
+  if (options.timestamps) {
+    args.push("--timestamps");
   }
   if (options.tail !== undefined) {
     if (!Number.isSafeInteger(options.tail) || options.tail < 1) {

--- a/src/fleet/service.runtime.test.ts
+++ b/src/fleet/service.runtime.test.ts
@@ -554,11 +554,18 @@ describe("fleet service", () => {
     containers.inspect.mockResolvedValue(runningInspection());
 
     await expect(
-      service.logs({ tenant: "acme", follow: true, tail: 100, since: "10m" }),
+      service.logs({
+        tenant: "acme",
+        follow: true,
+        timestamps: true,
+        tail: 100,
+        since: "10m",
+      }),
     ).resolves.toBeUndefined();
 
     expect(containers.logs).toHaveBeenCalledWith("docker", "container-id", {
       follow: true,
+      timestamps: true,
       tail: 100,
       since: "10m",
       redactValues: ["old-token"],

--- a/src/fleet/service.runtime.test.ts
+++ b/src/fleet/service.runtime.test.ts
@@ -553,15 +553,8 @@ describe("fleet service", () => {
     await service.create({ tenant: "acme", gatewayToken: "token" });
     containers.inspect.mockResolvedValue(runningInspection());
 
-    await expect(
-      service.logs({
-        tenant: "acme",
-        follow: true,
-        timestamps: true,
-        tail: 100,
-        since: "10m",
-      }),
-    ).resolves.toBeUndefined();
+    const logOptions = { tenant: "acme", follow: true, timestamps: true, tail: 100, since: "10m" };
+    await expect(service.logs(logOptions)).resolves.toBeUndefined();
 
     expect(containers.logs).toHaveBeenCalledWith("docker", "container-id", {
       follow: true,

--- a/src/fleet/service.runtime.ts
+++ b/src/fleet/service.runtime.ts
@@ -145,6 +145,7 @@ export type FleetLifecycleAction = "start" | "stop" | "restart";
 export type FleetLogsOptions = {
   tenant: string;
   follow?: boolean;
+  timestamps?: boolean;
   tail?: number;
   since?: string;
 };
@@ -540,6 +541,7 @@ export function createFleetService(options: FleetServiceOptions = {}) {
       // Pin the inspected generation so a concurrent restore cannot redirect the stream.
       await containers.logs(record.runtime, inspection.containerId, {
         follow: logOptions.follow,
+        timestamps: logOptions.timestamps,
         tail: logOptions.tail,
         since: logOptions.since,
         redactValues: gatewayCredential ? [gatewayCredential] : [],


### PR DESCRIPTION
Closes #141952

## What Problem This Solves

Fleet operators could not request source timestamps from container logs, which made cross-container and incident-timeline correlation harder.

This supersedes #131019, which I voluntarily closed when real Fleet proof was not yet available. The branch is rebuilt on current main and now includes the exact container-backed proof requested in that review.

## Why This Change Was Made

Add `openclaw fleet logs --timestamps` and carry the option through Fleet's existing CLI, service, ownership-verification, and container-runtime boundaries to the native Docker/Podman `logs --timestamps` argument.

No timestamp parser or alternate logging path is introduced. Existing follow, tail, since, inspected-container pinning, redaction, and stream-exit behavior stay on the canonical path.

## User Impact

Operators can opt into native container timestamps when correlating Fleet logs across containers. Omitting `--timestamps` retains the existing output.

## Evidence

I ran the exact source CLI against an isolated, registered Fleet tenant backed by a real labeled Docker container:

```text
$ openclaw fleet logs alix-ts-proof --timestamps
2026-08-29T08:27:59.871504749Z fleet-timestamps-real-cli-proof
```

Proof setup details:

- the tenant was registered in Fleet's actual isolated SQLite registry
- the real container used the exact Fleet ownership labels and was resolved through Fleet's ownership inspection
- the host has Docker 17.03, which predates `docker context inspect`; a narrow proof-only shim returned the local Unix socket for that unsupported discovery call and delegated every real `inspect` and `logs` operation to `/usr/bin/docker`
- the same line was independently verified with native `docker logs --timestamps`
- the proof container was removed after the run

This closes the prior proof gap: the terminal output above traversed the source CLI, Fleet service, ownership check, real container runtime, redaction stream, and terminal sink.

## Verification

- latest-main base: `e6efad25278fcd1d65b0310e4c53673b0650f72c`
- focused CLI/service/container tests: `98/98` passed on Node 24
- `pnpm docs:list` passed; the affected Fleet CLI docs were reviewed
- changed checks passed format, conflict markers, ratchets, assertion safety, changelog attribution, doctor deprecation, wildcard exports, duplicate coverage, coercion declarations, dependency pins, plugin boundaries, wrapper shadowing, patch guard, Knip production/full/script, temp-path report, core graph boundary, and production typecheck
- exact remaining core test-type shards (`ui-pages`, `ui-e2e`, `ui-other`, and packages) passed
- `git diff --check` passed

A clean dependency install was attempted twice and correctly stopped at the repository minimum-release-age gate for the current Teams lock entries; no supply-chain policy was bypassed. Existing policy-verified dependencies plus exact current-lock type packages were used for the local verification above.

Production: `+16/-4` (net `+12`). Tests: `+32/-4` (net `+28`). Docs: `+3/-0`. No config, schema, protocol, or dependency surface.

AI-assisted: yes. I reviewed the full CLI-to-runtime path, native Docker/Podman option contract, real Fleet ownership path, and container-backed terminal proof.


## Maintainer validation (2026-09-10)

Fresh integration CI exposed a test-file line limit: main plus this PR counted 1,003 lines against the 1,000-line rule. Signed follow-up `30a6245dd34a1a217b6bf554244241bcafd992ae` extracts the identical log input into `logOptions`, reducing the integrated file to 996 counted lines while retaining every assertion. Production code is unchanged. The trusted linter reproduces the failure before and passes after; the trusted formatter passes. Independent review found no issues. Fresh CI: https://github.com/openclaw/openclaw/actions/runs/34546210845.


Final CI: [run 34546210845, attempt 2](https://github.com/openclaw/openclaw/actions/runs/34546210845/attempts/2) passed on `30a6245dd34a1a217b6bf554244241bcafd992ae`. The first attempt passed the repaired lint check and all other jobs, but an unchanged Code Mode lifecycle test exceeded its short host deadline before any nested dispatch. A failed-shard-only retry passed without source changes. Independent inspection confirmed that test is byte-identical to the tested main parent.
