### PR TITLE
fix(install): prevent low-memory postinstall OOMs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,7 +69,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Low-memory installs:** stop parsing installed package JavaScript during bundled-plugin postinstall pruning, preventing multi-gigabyte transient heap use and OOMs on low-memory ARM hosts while retaining release-time package import validation.
 - Gateway/subagents: keep plugin completion turns bound to the owning Gateway runtime so successful native subagents can finish delivery without losing the published reply runtime.
 - **Upgrade config repair:** retain plugin-owned channel configuration migrations alongside core schemas so `doctor --fix` can repair older settings before an external plugin is installed or granted capabilities, while preserving installed-plugin ownership and state-migration boundaries.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Low-memory installs:** stop parsing installed package JavaScript during bundled-plugin postinstall pruning, preventing multi-gigabyte transient heap use and OOMs on low-memory ARM hosts while retaining release-time package import validation.
 - Gateway/subagents: keep plugin completion turns bound to the owning Gateway runtime so successful native subagents can finish delivery without losing the published reply runtime.
 - **Upgrade config repair:** retain plugin-owned channel configuration migrations alongside core schemas so `doctor --fix` can repair older settings before an external plugin is installed or granted capabilities, while preserving installed-plugin ownership and state-migration boundaries.
 

--- a/scripts/lib/guard-inventory-utils.mjs
+++ b/scripts/lib/guard-inventory-utils.mjs
@@ -1,10 +1,7 @@
 // Shared parsing, diffing, and reporting helpers for inventory guard scripts.
-import { promises as fs } from "node:fs";
 import { createRequire } from "node:module";
 import path from "node:path";
 
-const parsedTypeScriptSourceCache = new Map();
-const sourceTextCache = new Map();
 const require = createRequire(import.meta.url);
 let cachedTypeScript;
 
@@ -98,20 +95,6 @@ export function visitModuleSpecifiers(ts, sourceFile, visit, options = {}) {
   }
 
   walk(sourceFile);
-}
-
-/** Diff expected and actual inventory entries using JSON identity. */
-export function diffInventoryEntries(expected, actual, compareEntries) {
-  const expectedKeys = new Set(expected.map((entry) => JSON.stringify(entry)));
-  const actualKeys = new Set(actual.map((entry) => JSON.stringify(entry)));
-  return {
-    missing: expected
-      .filter((entry) => !actualKeys.has(JSON.stringify(entry)))
-      .toSorted(compareEntries),
-    unexpected: actual
-      .filter((entry) => !expectedKeys.has(JSON.stringify(entry)))
-      .toSorted(compareEntries),
-  };
 }
 
 /** Write one line to a stream without each caller repeating newline handling. */
@@ -302,73 +285,4 @@ export function formatGroupedInventoryHuman(params, inventory) {
     lines.push(`    resolved: ${entry.resolvedPath}`);
   }
   return lines.join("\n");
-}
-
-/** Parse TypeScript files and collect sorted inventory entries from each source file. */
-export async function collectTypeScriptInventory(params) {
-  const inventory = [];
-
-  for (const filePath of params.files) {
-    const cacheKey = `${params.scriptKind ?? "auto"}:${filePath}`;
-    let sourceFile = parsedTypeScriptSourceCache.get(cacheKey);
-    if (!sourceFile) {
-      let source = sourceTextCache.get(filePath);
-      if (source === undefined) {
-        source = await fs.readFile(filePath, "utf8");
-        sourceTextCache.set(filePath, source);
-      }
-      if (params.shouldParseSource && !params.shouldParseSource(source, filePath)) {
-        continue;
-      }
-      sourceFile = params.ts.createSourceFile(
-        filePath,
-        source,
-        params.ts.ScriptTarget.Latest,
-        true,
-        params.scriptKind,
-      );
-      parsedTypeScriptSourceCache.set(cacheKey, sourceFile);
-    }
-    inventory.push(...params.collectEntries(sourceFile, filePath));
-  }
-
-  return inventory.toSorted(params.compareEntries);
-}
-
-/** Run a baseline inventory check and return the intended process exit code. */
-export async function runBaselineInventoryCheck(params) {
-  const streams = params.io ?? { stdout: process.stdout, stderr: process.stderr };
-  const json = params.argv.includes("--json");
-  const actual = await params.collectActual();
-  const expected = await params.readExpected();
-  const { missing, unexpected } = params.diffInventory(expected, actual);
-  const matchesBaseline = missing.length === 0 && unexpected.length === 0;
-
-  if (json) {
-    writeLine(streams.stdout, JSON.stringify(actual, null, 2));
-  } else {
-    writeLine(streams.stdout, params.formatInventoryHuman(actual));
-    writeLine(
-      streams.stdout,
-      matchesBaseline
-        ? `Baseline matches (${actual.length} entries).`
-        : `Baseline mismatch (${unexpected.length} unexpected, ${missing.length} missing).`,
-    );
-    if (!matchesBaseline) {
-      if (unexpected.length > 0) {
-        writeLine(streams.stderr, "Unexpected entries:");
-        for (const entry of unexpected) {
-          writeLine(streams.stderr, `- ${params.formatEntry(entry)}`);
-        }
-      }
-      if (missing.length > 0) {
-        writeLine(streams.stderr, "Missing baseline entries:");
-        for (const entry of missing) {
-          writeLine(streams.stderr, `- ${params.formatEntry(entry)}`);
-        }
-      }
-    }
-  }
-
-  return matchesBaseline ? 0 : 1;
 }

--- a/scripts/lib/package-dist-imports.mjs
+++ b/scripts/lib/package-dist-imports.mjs
@@ -74,7 +74,7 @@ export function collectPackageDistImportErrors(params) {
 }
 
 /** Collect relative dist import edges from package JavaScript files. */
-export function collectPackageDistImports(params) {
+function collectPackageDistImports(params) {
   const files = [...new Set(params.files.map(normalizePackagePath))];
   const imports = [];
 

--- a/scripts/lib/package-dist-imports.mjs
+++ b/scripts/lib/package-dist-imports.mjs
@@ -94,29 +94,3 @@ export function collectPackageDistImports(params) {
 
   return imports;
 }
-
-/** Expand seed dist files to include all reachable relative dist imports. */
-export function expandPackageDistImportClosure(params) {
-  const files = [...new Set(params.files.map(normalizePackagePath))];
-  const fileSet = new Set(files);
-  const expectedSet = new Set(params.seedFiles.map(normalizePackagePath));
-  const imports = params.imports ?? collectPackageDistImports({ files, readText: params.readText });
-  const importsByImporter = new Map();
-  for (const { importerPath, importedPath } of imports) {
-    const importerImports = importsByImporter.get(importerPath) ?? [];
-    importerImports.push(importedPath);
-    importsByImporter.set(importerPath, importerImports);
-  }
-
-  const queue = [...expectedSet].filter((file) => fileSet.has(file));
-  for (const importerPath of queue) {
-    for (const importedPath of importsByImporter.get(importerPath) ?? []) {
-      if (fileSet.has(importedPath) && !expectedSet.has(importedPath)) {
-        expectedSet.add(importedPath);
-        queue.push(importedPath);
-      }
-    }
-  }
-
-  return [...expectedSet].toSorted((left, right) => left.localeCompare(right));
-}

--- a/scripts/postinstall-bundled-plugins.mjs
+++ b/scripts/postinstall-bundled-plugins.mjs
@@ -17,8 +17,6 @@ import {
 import { homedir } from "node:os";
 import { basename, dirname, isAbsolute, join, relative, resolve as pathResolve } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
-import { expandPackageDistImportClosure } from "./lib/package-dist-imports.mjs";
-
 const scriptDir = dirname(fileURLToPath(import.meta.url));
 const DEFAULT_PACKAGE_ROOT = join(scriptDir, "..");
 const DISABLE_POSTINSTALL_ENV = "OPENCLAW_DISABLE_BUNDLED_PLUGIN_POSTINSTALL";
@@ -506,23 +504,6 @@ export function pruneInstalledPackageDist(params = {}) {
     }
   }
   const installedFiles = listInstalledDistFiles(distScanParams);
-  const readFile = params.readFileSync ?? readFileSync;
-  expectedFiles = new Set(
-    expandPackageDistImportClosure({
-      files: installedFiles,
-      seedFiles: [...expectedFiles],
-      readText(relativePath) {
-        try {
-          return readFile(join(packageRoot, relativePath), "utf8");
-        } catch (error) {
-          if (error?.code === "ENOENT") {
-            return "";
-          }
-          throw error;
-        }
-      },
-    }),
-  );
   const removed = [];
 
   for (const relativePath of installedFiles) {

--- a/test/scripts/postinstall-bundled-plugins.test.ts
+++ b/test/scripts/postinstall-bundled-plugins.test.ts
@@ -53,50 +53,6 @@ async function writePluginPackage(
 }
 
 describe("bundled plugin postinstall", () => {
-  it("resolves TypeScript from NODE_PATH during external modules-dir installs", async () => {
-    const packageRoot = await createTempDirAsync("openclaw-postinstall-node-path-");
-    const scriptRoot = path.join(packageRoot, "scripts");
-    const externalModulesDir = path.join(packageRoot, "external-node-modules");
-    await fs.mkdir(path.join(scriptRoot, "lib"), { recursive: true });
-    await fs.mkdir(externalModulesDir, { recursive: true });
-    await fs.writeFile(
-      path.join(packageRoot, "package.json"),
-      '{"name":"openclaw","type":"module","version":"2026.7.2"}\n',
-    );
-    for (const relativePath of [
-      "scripts/postinstall-bundled-plugins.mjs",
-      "scripts/lib/package-dist-imports.mjs",
-      "scripts/lib/guard-inventory-utils.mjs",
-    ]) {
-      await fs.copyFile(
-        fileURLToPath(new URL(`../../${relativePath}`, import.meta.url)),
-        path.join(packageRoot, relativePath),
-      );
-    }
-    await fs.symlink(
-      fileURLToPath(new URL("../../node_modules/typescript", import.meta.url)),
-      path.join(externalModulesDir, "typescript"),
-      process.platform === "win32" ? "junction" : "dir",
-    );
-
-    const result = spawnSync(
-      process.execPath,
-      [path.join(scriptRoot, "postinstall-bundled-plugins.mjs")],
-      {
-        cwd: packageRoot,
-        encoding: "utf8",
-        env: {
-          ...process.env,
-          NODE_PATH: [externalModulesDir, process.env.NODE_PATH]
-            .filter(Boolean)
-            .join(path.delimiter),
-        },
-      },
-    );
-
-    expect(result.status, result.stderr).toBe(0);
-  });
-
   it("recognizes direct invocation through symlinked temp prefixes", () => {
     const realpathSync = vi.fn((value: string) =>
       value.replace(/^\/var\/folders\//u, "/private/var/folders/"),
@@ -138,20 +94,6 @@ describe("bundled plugin postinstall", () => {
       await fs.copyFile(
         fileURLToPath(new URL("../../scripts/postinstall-bundled-plugins.mjs", import.meta.url)),
         path.join(scriptRoot, "postinstall-bundled-plugins.mjs"),
-      );
-      await fs.copyFile(
-        fileURLToPath(new URL("../../scripts/lib/package-dist-imports.mjs", import.meta.url)),
-        path.join(scriptRoot, "lib", "package-dist-imports.mjs"),
-      );
-      await fs.copyFile(
-        fileURLToPath(new URL("../../scripts/lib/guard-inventory-utils.mjs", import.meta.url)),
-        path.join(scriptRoot, "lib", "guard-inventory-utils.mjs"),
-      );
-      await fs.mkdir(path.join(packageRoot, "node_modules"), { recursive: true });
-      await fs.symlink(
-        fileURLToPath(new URL("../../node_modules/typescript", import.meta.url)),
-        path.join(packageRoot, "node_modules", "typescript"),
-        process.platform === "win32" ? "junction" : "dir",
       );
       for (const sentinel of sentinels) {
         await fs.mkdir(path.dirname(sentinel), { recursive: true });
@@ -410,6 +352,36 @@ describe("bundled plugin postinstall", () => {
     await expectPathMissing(staleFile);
   });
 
+  it("prunes from the authoritative inventory without reading dist JavaScript", async () => {
+    const packageRoot = await createTempDirAsync("openclaw-packaged-install-no-js-read-");
+    const currentFile = path.join(packageRoot, "dist", "current.js");
+    const staleFile = path.join(packageRoot, "dist", "stale.js");
+    const inventoryPath = path.join(packageRoot, "dist", "postinstall-inventory.json");
+    await fs.mkdir(path.dirname(currentFile), { recursive: true });
+    await fs.writeFile(currentFile, "export {};\n");
+    await writePackageDistInventory(packageRoot);
+    await fs.writeFile(staleFile, "export {};\n");
+    const readFileSync = vi.fn((filePath: string | Buffer | URL, options?: BufferEncoding) => {
+      if (String(filePath) !== inventoryPath) {
+        throw new Error(`unexpected dist JavaScript read: ${String(filePath)}`);
+      }
+      return readFileSyncOriginal(filePath, options);
+    });
+
+    expect(
+      pruneInstalledPackageDist({
+        packageRoot,
+        readFileSync,
+        log: { log: vi.fn(), warn: vi.fn() },
+      }),
+    ).toEqual(["dist/stale.js"]);
+
+    await expectPathExists(currentFile);
+    await expectPathMissing(staleFile);
+    expect(readFileSync).toHaveBeenCalledOnce();
+    expect(readFileSync).toHaveBeenCalledWith(inventoryPath, "utf8");
+  });
+
   it("omits unpacked plugin-sdk test helpers from the package dist inventory", async () => {
     const packageRoot = await createTempDirAsync("openclaw-packaged-inventory-");
     const runtimeFile = path.join(packageRoot, "dist", "plugin-sdk", "runtime.js");
@@ -594,90 +566,6 @@ describe("bundled plugin postinstall", () => {
       "/srv/openclaw-home/state/plugin-runtime-deps",
       "/var/lib/openclaw/plugin-runtime-deps",
     ]);
-  });
-
-  it("keeps imported dist chunks even when inventory is stale", async () => {
-    const packageRoot = await createTempDirAsync("openclaw-packaged-install-import-");
-    const entryFile = path.join(packageRoot, "dist", "cli", "run-main.js");
-    const importedChunk = path.join(packageRoot, "dist", "memory-state-CcqRgDZU.js");
-    const staleFile = path.join(packageRoot, "dist", "memory-state-old.js");
-    await fs.mkdir(path.dirname(entryFile), { recursive: true });
-    await fs.writeFile(entryFile, 'await import("../memory-state-CcqRgDZU.js");\n');
-    await writePackageDistInventory(packageRoot);
-    await fs.writeFile(importedChunk, "export {};\n");
-    await fs.writeFile(staleFile, "export {};\n");
-
-    expect(
-      pruneInstalledPackageDist({
-        packageRoot,
-        log: { log: vi.fn(), warn: vi.fn() },
-      }),
-    ).toEqual(["dist/memory-state-old.js"]);
-
-    await expectPathExists(importedChunk);
-    await expectPathMissing(staleFile);
-  });
-
-  it("keeps named imported chunks without preserving template-literal pseudoimports", async () => {
-    const packageRoot = await createTempDirAsync("openclaw-packaged-install-named-import-");
-    const entryFile = path.join(packageRoot, "dist", "cli", "run-main.js");
-    const importedChunk = path.join(packageRoot, "dist", "memory-state-current.js");
-    const phantomChunk = path.join(packageRoot, "dist", "memory-state-phantom.js");
-    await fs.mkdir(path.dirname(entryFile), { recursive: true });
-    await fs.writeFile(
-      entryFile,
-      [
-        "import {",
-        "  value,",
-        '} from "../memory-state-current.js";',
-        "const example = `",
-        'import "../memory-state-phantom.js"',
-        "`;",
-        "export { value, example };",
-        "",
-      ].join("\n"),
-    );
-    await writePackageDistInventory(packageRoot);
-    await fs.writeFile(importedChunk, "export const value = 42;\n");
-    await fs.writeFile(phantomChunk, "export const stale = true;\n");
-
-    expect(
-      pruneInstalledPackageDist({
-        packageRoot,
-        log: { log: vi.fn(), warn: vi.fn() },
-      }),
-    ).toEqual(["dist/memory-state-phantom.js"]);
-
-    await expectPathExists(importedChunk);
-    await expectPathMissing(phantomChunk);
-  });
-
-  it("does not abort dist pruning when a listed chunk disappears before import expansion", async () => {
-    const packageRoot = await createTempDirAsync("openclaw-packaged-install-missing-chunk-");
-    const entryFile = path.join(packageRoot, "dist", "control-ui", "assets", "instances.js");
-    const staleFile = path.join(packageRoot, "dist", "stale.js");
-    await fs.mkdir(path.dirname(entryFile), { recursive: true });
-    await fs.writeFile(entryFile, 'import "./chunk.js";\n');
-    await writePackageDistInventory(packageRoot);
-    await fs.writeFile(staleFile, "export {};\n");
-    const readFileSync = vi.fn((filePath: string | Buffer | URL, options?: BufferEncoding) => {
-      if (String(filePath).endsWith("dist/control-ui/assets/instances.js")) {
-        const error = new Error("missing generated asset") as NodeJS.ErrnoException;
-        error.code = "ENOENT";
-        throw error;
-      }
-      return readFileSyncOriginal(filePath, options);
-    });
-
-    expect(
-      pruneInstalledPackageDist({
-        packageRoot,
-        readFileSync,
-        log: { log: vi.fn(), warn: vi.fn() },
-      }),
-    ).toEqual(["dist/stale.js"]);
-
-    await expectPathMissing(staleFile);
   });
 
   it("prunes stale private QA files without restoring compat sidecars", async () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where installing OpenClaw on low-memory hosts could exhaust memory during bundled-plugin postinstall pruning, especially on 2 GB ARM systems without swap.

## Why This Change Was Made

Packaged installs now treat the release-generated postinstall inventory as authoritative instead of reparsing every installed `dist` JavaScript file to reconstruct its import closure. Release/package validation still rejects missing imports and incomplete inventories before publication. The change also removes inventory helpers proven unused by the full-tree dead-code gate.

## User Impact

OpenClaw can install and start on constrained ARM hosts without the multi-gigabyte transient postinstall heap spike. The change also removes the runtime TypeScript dependency from this postinstall path.

## Evidence

- Regression: postinstall prunes an unlisted file while reading only `dist/postinstall-inventory.json`; any attempted JavaScript read fails the test.
- Focused tooling suite: 5 files, 147 tests passed.
- Autoreview: clean, no accepted/actionable findings.
- Standalone postinstall profile: max RSS fell from 2,179,776,512 bytes to 116,916,224 bytes; elapsed time fell from 11.78 seconds to 0.24 seconds.
- Native ARM packaged candidate:
  - 2 GB RAM, no swap: install passed, Gateway smoke passed, `oom_kill=0`, cgroup peak 1,350,975,488 bytes.
  - 2 GB RAM plus 2 GB swap: install passed, Gateway smoke passed, `oom_kill=0`, swap peak 0.
  - 4 GB RAM plus 2 GB swap: install passed, Gateway smoke passed, `oom_kill=0`, swap peak 0.
- Production delta: 131 lines removed, 0 net additions.
- `pnpm check:changed` reached the root test typecheck; it is blocked in the repo-managed sparse worktree by excluded `apps/android`, `qa`, and `ui/config` files plus the existing shared `pako` declaration error. Focused checks above pass.

AI-assisted: yes. The investigation, repair, profiling, and validation used Codex; the repository autoreview gate is clean.
