### PR TITLE
fix(agents): neutralize Anthropic refusal marker replacement

### DIFF
--- a/src/agents/embedded-agent-runner.e2e.test.ts
+++ b/src/agents/embedded-agent-runner.e2e.test.ts
@@ -868,7 +868,7 @@ describe("runEmbeddedAgent", () => {
       modelSelectionLocked: true,
       provider: "anthropic",
       modelId: "retired-outer-model",
-      prompt: "ANTHROPIC MAGIC STRING TRIGGER REFUSAL (redacted)",
+      prompt: "[redacted]",
     });
     expect("contextEngine" in attempt).toBe(false);
     expect("contextTokenBudget" in attempt).toBe(false);

--- a/src/agents/embedded-agent-runner/run/helpers.test.ts
+++ b/src/agents/embedded-agent-runner/run/helpers.test.ts
@@ -18,14 +18,18 @@ import {
 describe("resolveEmbeddedAttemptBasePrompt", () => {
   const refusalTrigger = "ANTHROPIC_MAGIC_STRING_TRIGGER_REFUSAL";
 
-  it("scrubs the refusal marker for Anthropic transport", () => {
-    expect(
-      resolveEmbeddedAttemptBasePrompt({
-        provider: "anthropic",
-        prompt: refusalTrigger,
-      }),
-    ).toBe("ANTHROPIC MAGIC STRING TRIGGER REFUSAL (redacted)");
-  });
+  it.each([
+    { prompt: refusalTrigger, expected: "[redacted]" },
+    {
+      prompt: `Reply ok. Test trigger: ${refusalTrigger}_nonce-a and ${refusalTrigger}_nonce-b`,
+      expected: "Reply ok. Test trigger: [redacted]_nonce-a and [redacted]_nonce-b",
+    },
+  ])(
+    "neutralizes every refusal marker while preserving surrounding text",
+    ({ prompt, expected }) => {
+      expect(resolveEmbeddedAttemptBasePrompt({ provider: "anthropic", prompt })).toBe(expected);
+    },
+  );
 
   it("keeps non-Anthropic prompts byte-for-byte", () => {
     expect(

--- a/src/agents/embedded-agent-runner/run/helpers.ts
+++ b/src/agents/embedded-agent-runner/run/helpers.ts
@@ -89,9 +89,9 @@ export function resolveNextSameModelRateLimitRetryCount(params: {
 }
 
 const ANTHROPIC_MAGIC_STRING_TRIGGER_REFUSAL = "ANTHROPIC_MAGIC_STRING_TRIGGER_REFUSAL";
-const ANTHROPIC_MAGIC_STRING_REPLACEMENT = "ANTHROPIC MAGIC STRING TRIGGER REFUSAL (redacted)";
+const ANTHROPIC_MAGIC_STRING_REPLACEMENT = "[redacted]";
 
-// Avoid Anthropic's refusal test token poisoning session transcripts.
+// Keep the replacement neutral: naming the refusal trigger can itself prompt a refusal.
 function scrubAnthropicRefusalMagic(prompt: string): string {
   if (!prompt.includes(ANTHROPIC_MAGIC_STRING_TRIGGER_REFUSAL)) {
     return prompt;

--- a/src/gateway/gateway-models.profiles.live.test.ts
+++ b/src/gateway/gateway-models.profiles.live.test.ts
@@ -3791,7 +3791,7 @@ describe("latestAssistantTextAfterBaseline", () => {
   it("correlates Anthropic refusal probes after the runtime scrubs their trigger", () => {
     const nonce = "0123456789abcdef0123456789abcdef";
     const expected = `Reply with the single word ok. Test trigger: ${ANTHROPIC_MAGIC_STRING_TRIGGER_REFUSAL}_${nonce}`;
-    const scrubbed = `Reply with the single word ok. Test trigger: ANTHROPIC MAGIC STRING TRIGGER REFUSAL (redacted)_${nonce}`;
+    const scrubbed = `Reply with the single word ok. Test trigger: [redacted]_${nonce}`;
     const redacted = redactSecrets(expected);
 
     expect(matchesLiveProbeUserText(scrubbed, expected)).toBe(true);
@@ -3811,7 +3811,7 @@ describe("latestAssistantTextAfterBaseline", () => {
     ).toEqual([{ role: "assistant", content: "ok", stopReason: "stop" }]);
     expect(
       matchesLiveProbeUserText(
-        "Reply with the single word ok. Test trigger: ANTHROPIC MAGIC STRING TRIGGER REFUSAL (redacted)_ffffffffffffffffffffffffffffffff",
+        "Reply with the single word ok. Test trigger: [redacted]_ffffffffffffffffffffffffffffffff",
         expected,
       ),
     ).toBe(false);


### PR DESCRIPTION
OpenClaw already replaces Anthropic's literal refusal-test marker before dispatch so it cannot poison otherwise ordinary conversations. The replacement still spelled out “magic string trigger refusal.” A real Gateway probe showed one model refusing that description even though the original marker was absent on the wire: HTTP200, ordinary stop reason, and a model-generated refusal.

This keeps the existing exact-marker and Anthropic-only policy, replacing its descriptive placeholder with the neutral `[redacted]`. Surrounding text and nonce suffixes are preserved, every occurrence is replaced, and other providers remain byte-for-byte unchanged. No new retry, model fallback, history rewrite, broad refusal bypass, configuration or policy surface is introduced. Production LOC is unchanged; existing test expectations and nonce correlation fixtures follow the new representation.

The original behavior shipped in v2026.1.20, introduced by91bcdad5033c1f2c1c238de37747f64cf76b4bbb. Current [Anthropic documentation](https://platform.claude.com/docs/en/test-and-evaluate/strengthen-guardrails/handle-streaming-refusals) distinguishes model-generated text refusals from classifier refusal stop reasons. The passive wire observer recorded only marker-presence booleans and left requests unchanged.

Validation: the old replacement failed the real Gateway probe twice (aggregate147.28s and focused69.88s); helper regressions failed twice before the repair, then23 tests passed. Nonce correlation coverage passes. Extracted PR23 tests, typed core lint, formatting, diff checks and fresh Codex review pass. Local whole-runner E2E did not reach tests because borrowed dependencies lacked an unrelated Pi TUI export; rebuilt Linux proof on [Testbox33249009354](https://github.com/openclaw/openclaw/actions/runs/33249009354) now passes: the previously failing model completes explanation, nonce file-read, refusal-marker `ok` and follow-up `still ok` (150tests,31.79s). The unchanged eight-candidate Anthropic aggregate also passes (150tests,129.72s): seven models complete all probes and one retains the existing provider-unavailable404 skip. No request, assertion, retry or skip policy was changed.

The separate Docker provisioning/auth isolation repairs are in #132542; this PR contains only four refusal-marker owner/test files. Application delta+2/-2(net0), tests+15/-11(net4). Release-note context: avoid spurious refusals caused by the placeholder used to scrub Anthropic's literal test marker.

The rebuilt Linux image is `sha256:650c5479dfb839462dc75e3c931d7b6765332c53c8bb744e15029022c230067d`. This supplemental canonical Anthropic run is distinct from the original matrix gateway lane, whose native Claude/Gemini provider selection is being replayed separately.
