### PR TITLE
fix(llama): honor configured embedding model during setup

### DIFF
--- a/extensions/llama-cpp/src/defaults.ts
+++ b/extensions/llama-cpp/src/defaults.ts
@@ -5,6 +5,7 @@ import type {
   ModelProviderConfig,
 } from "openclaw/plugin-sdk/provider-model-shared";
 import { resolveStateDir } from "openclaw/plugin-sdk/state-paths";
+import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 
 export const LLAMA_CPP_PROVIDER_ID = "llama-cpp";
 export const LLAMA_CPP_PROVIDER_LABEL = "llama.cpp";
@@ -63,6 +64,25 @@ export function resolveLlamaCppModelCacheDir(provider?: ModelProviderConfig): st
 
 export function resolveLegacyLlamaCppModelCacheDir(): string {
   return path.join(os.homedir(), ".node-llama-cpp", "models");
+}
+
+export function resolveLlamaCppEmbeddingModel(
+  local: { modelPath?: string; modelCacheDir?: string } = {},
+) {
+  const source = normalizeOptionalString(local.modelPath) ?? DEFAULT_LLAMA_CPP_EMBEDDING_MODEL;
+  const cacheDir = normalizeOptionalString(local.modelCacheDir) ?? resolveLlamaCppModelCacheDir();
+  const resolvedPath = /^(?:hf:|https?:\/\/)/iu.test(source)
+    ? undefined
+    : path.resolve(cacheDir, source);
+  return {
+    source,
+    cacheDir,
+    isDefault:
+      source === DEFAULT_LLAMA_CPP_EMBEDDING_MODEL ||
+      resolvedPath === path.resolve(cacheDir, DEFAULT_LLAMA_CPP_EMBEDDING_CACHE_FILE) ||
+      resolvedPath ===
+        path.resolve(resolveLegacyLlamaCppModelCacheDir(), DEFAULT_LLAMA_CPP_EMBEDDING_CACHE_FILE),
+  };
 }
 
 export function resolveHomePath(value: string): string {

--- a/extensions/llama-cpp/src/embedding-provider.ts
+++ b/extensions/llama-cpp/src/embedding-provider.ts
@@ -6,13 +6,13 @@ import {
   type EmbeddingProviderCreateOptions,
 } from "openclaw/plugin-sdk/embedding-providers";
 import type { ModelProviderConfig } from "openclaw/plugin-sdk/provider-model-shared";
-import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import {
   DEFAULT_LLAMA_CPP_EMBEDDING_CACHE_FILE,
   DEFAULT_LLAMA_CPP_EMBEDDING_MODEL,
   DEFAULT_LLAMA_CPP_EMBEDDING_MODEL_ID,
   LLAMA_CPP_PROVIDER_ID,
   resolveLegacyLlamaCppModelCacheDir,
+  resolveLlamaCppEmbeddingModel,
   resolveLlamaCppModelCacheDir,
 } from "./defaults.js";
 import { selectLlamaServerAsset } from "./llama-server-install.js";
@@ -27,11 +27,6 @@ import {
 type LlamaCppLocalOptions = {
   modelPath?: string;
   modelCacheDir?: string;
-};
-
-type LlamaCppEmbeddingModel = {
-  source: string;
-  isDefault: boolean;
 };
 
 const LOCAL_EMBEDDING_RUNTIME_FACTS = Symbol.for("openclaw.localEmbeddingRuntimeFacts");
@@ -65,11 +60,10 @@ function createCacheKeyData(model: string, dimensions?: number): Record<string, 
 
 function resolveModelIdentity(
   local: LlamaCppLocalOptions,
-  modelPath: string,
   dimensions?: number,
 ): LlamaCppModelIdentity {
-  const configuredCacheDir =
-    normalizeOptionalString(local.modelCacheDir) ?? resolveLlamaCppModelCacheDir();
+  const embeddingModel = resolveLlamaCppEmbeddingModel(local);
+  const configuredCacheDir = embeddingModel.cacheDir;
   const currentDefaultPath = path.resolve(
     configuredCacheDir,
     DEFAULT_LLAMA_CPP_EMBEDDING_CACHE_FILE,
@@ -78,16 +72,10 @@ function resolveModelIdentity(
     resolveLegacyLlamaCppModelCacheDir(),
     DEFAULT_LLAMA_CPP_EMBEDDING_CACHE_FILE,
   );
-  const isUri = /^(?:hf:|https?:\/\/)/iu.test(modelPath);
-  const resolvedPath = isUri ? undefined : path.resolve(configuredCacheDir, modelPath);
-  const isDefault =
-    modelPath === DEFAULT_LLAMA_CPP_EMBEDDING_MODEL ||
-    resolvedPath === currentDefaultPath ||
-    resolvedPath === legacyDefaultPath;
-  if (!isDefault) {
+  if (!embeddingModel.isDefault) {
     return {
-      model: modelPath,
-      cacheKeyData: createCacheKeyData(modelPath, dimensions),
+      model: embeddingModel.source,
+      cacheKeyData: createCacheKeyData(embeddingModel.source, dimensions),
       aliases: [],
     };
   }
@@ -96,8 +84,8 @@ function resolveModelIdentity(
     legacyDefaultPath,
     DEFAULT_LLAMA_CPP_EMBEDDING_CACHE_FILE,
   ]);
-  if (modelPath !== DEFAULT_LLAMA_CPP_EMBEDDING_MODEL) {
-    aliases.add(modelPath);
+  if (embeddingModel.source !== DEFAULT_LLAMA_CPP_EMBEDDING_MODEL) {
+    aliases.add(embeddingModel.source);
   }
   return {
     model: DEFAULT_LLAMA_CPP_EMBEDDING_MODEL,
@@ -106,16 +94,6 @@ function resolveModelIdentity(
       model,
       cacheKeyData: createCacheKeyData(model, dimensions),
     })),
-  };
-}
-
-function resolveLlamaCppEmbeddingModel(localValue?: unknown): LlamaCppEmbeddingModel {
-  const local = readLocalOptions({ local: localValue });
-  const source = normalizeOptionalString(local.modelPath) ?? DEFAULT_LLAMA_CPP_EMBEDDING_MODEL;
-  const identity = resolveModelIdentity(local, source);
-  return {
-    source,
-    isDefault: identity.model === DEFAULT_LLAMA_CPP_EMBEDDING_MODEL,
   };
 }
 
@@ -215,13 +193,12 @@ export const llamaCppEmbeddingProviderAdapter: EmbeddingProviderAdapter = {
     `Managed local embeddings are unavailable. Run \`openclaw configure\`, choose llama.cpp, and retry. ${error instanceof Error ? error.message : String(error)}`,
   resolveIndexIdentity: (options) => {
     const local = readIdentityLocalOptions(options);
-    const modelPath = normalizeOptionalString(local.modelPath) ?? DEFAULT_LLAMA_CPP_EMBEDDING_MODEL;
-    return resolveModelIdentity(local, modelPath, options.dimensions);
+    return resolveModelIdentity(local, options.dimensions);
   },
   create: async (options) => {
     const local = readIdentityLocalOptions(options);
     const embeddingModel = resolveLlamaCppEmbeddingModel(local);
-    const identity = resolveModelIdentity(local, embeddingModel.source, options.dimensions);
+    const identity = resolveModelIdentity(local, options.dimensions);
     await prepareEmbeddingServer(options, embeddingModel.source, embeddingModel.isDefault);
     const genericAdapter = getEmbeddingProvider("openai-compatible", options.config);
     if (!genericAdapter) {

--- a/extensions/llama-cpp/src/setup.test.ts
+++ b/extensions/llama-cpp/src/setup.test.ts
@@ -11,6 +11,7 @@ const mocks = vi.hoisted(() => ({
   ensureModel: vi.fn(),
   prepareServer: vi.fn(),
   removeProfiles: vi.fn(),
+  progressUpdate: vi.fn(),
 }));
 
 vi.mock("openclaw/plugin-sdk/provider-auth-runtime", async (importOriginal) => ({
@@ -36,6 +37,10 @@ import {
 import { detectLlamaCppSetup, prepareLlamaCppSetup, runLlamaCppSetup } from "./setup.js";
 
 const GIB = 1024 ** 3;
+const CUSTOM_EMBEDDING_MODEL =
+  "hf:ggml-org/embeddinggemma-300M-qat-q4_0-GGUF/embeddinggemma-300M-qat-Q4_0.gguf";
+const OTHER_CUSTOM_EMBEDDING_MODEL = "hf:example/other-embedding-GGUF/other-Q4_K_M.gguf";
+const NON_LOCAL_EMBEDDING_MODEL = "hf:example/non-local-embedding-GGUF/non-local-Q4.gguf";
 let tempRoot: string;
 let modelPath: string;
 
@@ -58,6 +63,7 @@ beforeEach(async () => {
     args: ["--host", "127.0.0.1", "--port", "19432"],
   });
   mocks.removeProfiles.mockReset().mockResolvedValue({ version: 1, profiles: {} });
+  mocks.progressUpdate.mockReset();
 });
 
 afterEach(async () => {
@@ -86,7 +92,7 @@ function authContext(confirm: boolean): ProviderAuthContext {
     prompter: {
       confirm: vi.fn(async () => confirm),
       note: vi.fn(async () => {}),
-      progress: vi.fn(() => ({ update: vi.fn(), stop: vi.fn() })),
+      progress: vi.fn(() => ({ update: mocks.progressUpdate, stop: vi.fn() })),
     },
     runtime: {},
   } as unknown as ProviderAuthContext;
@@ -266,6 +272,61 @@ describe("llama.cpp managed setup", () => {
     });
   });
 
+  it.each([
+    { name: "embedding-only", totalmem: 8 * GIB },
+    { name: "chat", totalmem: 16 * GIB },
+  ])("uses the configured embedding model during $name setup", async ({ totalmem }) => {
+    vi.mocked(os.totalmem).mockReturnValue(totalmem);
+    const ctx = authContext(true);
+    requestUnconfiguredLocalMemory(ctx);
+    ctx.config.memory = {
+      search: {
+        provider: "local",
+        local: { modelPath: CUSTOM_EMBEDDING_MODEL },
+      },
+    };
+    ctx.config.agents = {
+      entries: {
+        alpha: { memory: { search: { provider: "local" } } },
+        beta: { memory: { search: { provider: "local" } } },
+      },
+    };
+
+    await runLlamaCppSetup(ctx);
+
+    expect(ctx.prompter.confirm).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: expect.stringContaining("your configured local embedding model"),
+      }),
+    );
+    expect(mocks.ensureModel).toHaveBeenCalledWith(
+      expect.objectContaining({
+        source: CUSTOM_EMBEDDING_MODEL,
+        download: true,
+      }),
+    );
+    expect(mocks.prepareServer).toHaveBeenCalledWith(
+      expect.objectContaining({
+        embeddingModelIsDefault: false,
+        embeddingModelPath: path.join(tempRoot, "embedding.gguf"),
+      }),
+    );
+    const customDownload = mocks.ensureModel.mock.calls.find(
+      ([options]) => options.source === CUSTOM_EMBEDDING_MODEL && options.download === true,
+    );
+    if (!customDownload) {
+      throw new Error("configured embedding download was not requested");
+    }
+    customDownload[0].onProgress({
+      downloadedSize: 150_000_000,
+      totalSize: 300_000_000,
+      bytesPerSecond: 12_000_000,
+    });
+    expect(mocks.progressUpdate).toHaveBeenCalledWith(
+      expect.stringContaining("Downloading configured embedding model"),
+    );
+  });
+
   it("requires consent before embedding-only setup", async () => {
     vi.mocked(os.totalmem).mockReturnValue(8 * GIB);
     const ctx = authContext(false);
@@ -296,14 +357,38 @@ describe("llama.cpp managed setup", () => {
     ).toHaveLength(1);
   });
 
-  it("offers embedding-only setup for per-agent local memory intent", async () => {
+  it("uses the sole effective per-agent embedding model", async () => {
     vi.mocked(os.totalmem).mockReturnValue(8 * GIB);
     const ctx = authContext(true);
     delete ctx.config.models?.providers?.[LLAMA_CPP_PROVIDER_ID];
     ctx.config.agents = {
       defaults: { model: { primary: "openai/gpt-5.4" } },
       entries: {
-        helper: { memory: { search: { provider: "local" } } },
+        helper: {
+          memory: {
+            search: {
+              provider: "local",
+              local: { modelPath: CUSTOM_EMBEDDING_MODEL },
+            },
+          },
+        },
+        cloud: {
+          memory: {
+            search: {
+              provider: "openai",
+              local: { modelPath: NON_LOCAL_EMBEDDING_MODEL },
+            },
+          },
+        },
+        paused: {
+          memory: {
+            search: {
+              enabled: false,
+              provider: "local",
+              local: { modelPath: OTHER_CUSTOM_EMBEDDING_MODEL },
+            },
+          },
+        },
       },
     };
 
@@ -311,10 +396,62 @@ describe("llama.cpp managed setup", () => {
 
     expect(ctx.prompter.confirm).toHaveBeenCalledWith(
       expect.objectContaining({
-        message: expect.stringContaining("only the local embedding model"),
+        message: expect.stringContaining("your configured local embedding model"),
       }),
     );
     expect(result.configPatch?.models?.providers?.[LLAMA_CPP_PROVIDER_ID]?.models).toEqual([]);
+    expect(mocks.ensureModel).toHaveBeenCalledWith(
+      expect.objectContaining({ source: CUSTOM_EMBEDDING_MODEL, download: true }),
+    );
+    expect(mocks.ensureModel).not.toHaveBeenCalledWith(
+      expect.objectContaining({ source: OTHER_CUSTOM_EMBEDDING_MODEL }),
+    );
+    expect(mocks.ensureModel).not.toHaveBeenCalledWith(
+      expect.objectContaining({ source: NON_LOCAL_EMBEDDING_MODEL }),
+    );
+    expect(mocks.prepareServer).toHaveBeenCalledWith(
+      expect.objectContaining({ embeddingModelIsDefault: false }),
+    );
+  });
+
+  it.each([
+    { name: "embedding-only", totalmem: 8 * GIB },
+    { name: "chat", totalmem: 16 * GIB },
+  ])("stops $name setup when local-memory agents use different models", async ({ totalmem }) => {
+    vi.mocked(os.totalmem).mockReturnValue(totalmem);
+    const ctx = authContext(true);
+    delete ctx.config.models?.providers?.[LLAMA_CPP_PROVIDER_ID];
+    ctx.config.agents = {
+      entries: {
+        alpha: {
+          memory: {
+            search: {
+              provider: "local",
+              local: { modelPath: CUSTOM_EMBEDDING_MODEL },
+            },
+          },
+        },
+        beta: {
+          memory: {
+            search: {
+              provider: "local",
+              local: { modelPath: OTHER_CUSTOM_EMBEDDING_MODEL },
+            },
+          },
+        },
+      },
+    };
+
+    await expect(runLlamaCppSetup(ctx)).resolves.toEqual({ profiles: [] });
+
+    expect(ctx.prompter.note).toHaveBeenCalledWith(
+      expect.stringContaining("different local embedding models"),
+      "Setup skipped",
+    );
+    expect(ctx.prompter.confirm).not.toHaveBeenCalled();
+    expect(mocks.ensureModel).not.toHaveBeenCalledWith(expect.objectContaining({ download: true }));
+    expect(mocks.prepareServer).not.toHaveBeenCalled();
+    expect(mocks.removeProfiles).not.toHaveBeenCalled();
   });
 
   it.each(externalChatRoutes)(

--- a/extensions/llama-cpp/src/setup.ts
+++ b/extensions/llama-cpp/src/setup.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { listAgentIds, resolveAgentConfig } from "openclaw/plugin-sdk/agent-scope-runtime";
 import type {
   ProviderAppGuidedSetupContext,
   ProviderAuthContext,
@@ -16,7 +17,6 @@ import {
   LLAMA_CPP_DEFAULT_PROFILE_ID,
 } from "./auth-config.js";
 import {
-  DEFAULT_LLAMA_CPP_EMBEDDING_MODEL,
   DEFAULT_LLAMA_CPP_MODEL_CACHE_FILE,
   DEFAULT_LLAMA_CPP_MODEL_ID,
   LLAMA_CPP_PROVIDER_ID,
@@ -24,6 +24,7 @@ import {
   meetsLlamaCppDefaultModelRamFloor,
   resolveCachedLlamaCppModelPath,
   resolveLegacyLlamaCppModelCacheDir,
+  resolveLlamaCppEmbeddingModel,
   resolveLlamaCppModelCacheDir,
   resolveLlamaCppModelSource,
 } from "./defaults.js";
@@ -61,6 +62,12 @@ function formatDownloadProgress(
 
 function formatRamGb(totalmemBytes: number): string {
   return (totalmemBytes / 1024 ** 3).toFixed(1).replace(/\.0$/u, "");
+}
+
+function describeEmbeddingDownload(isDefault: boolean): string {
+  return isDefault
+    ? "the local embedding model (about 0.3 GB)"
+    : "your configured local embedding model";
 }
 
 function readPrimaryModel(config: ProviderAppGuidedSetupContext["config"]): string | undefined {
@@ -212,19 +219,37 @@ export async function prepareLlamaCppSetup(
   });
 }
 
-function hasLocalMemoryIntent(config: ProviderAuthContext["config"]): boolean {
-  return (
-    config.memory?.search?.provider === "local" ||
-    Object.values(config.agents?.entries ?? {}).some(
-      (agent) => agent.memory?.search?.provider === "local",
-    ) ||
-    config.agents?.list?.some((agent) => agent.memory?.search?.provider === "local") === true
-  );
+function resolveEmbeddingSetup(config: ProviderAuthContext["config"], cacheDir: string) {
+  const defaults = config.memory?.search;
+  const models = listAgentIds(config).flatMap((agentId) => {
+    const override = resolveAgentConfig(config, agentId)?.memory?.search;
+    // Match core memory config: each agent field overrides the top-level default.
+    if (
+      !(override?.enabled ?? defaults?.enabled ?? true) ||
+      (override?.provider ?? defaults?.provider) !== "local"
+    ) {
+      return [];
+    }
+    return [
+      resolveLlamaCppEmbeddingModel({
+        modelPath: override?.local?.modelPath ?? defaults?.local?.modelPath,
+        modelCacheDir: cacheDir,
+      }),
+    ];
+  });
+  const model = models[0] ?? resolveLlamaCppEmbeddingModel({ modelCacheDir: cacheDir });
+  return {
+    model,
+    localMemoryIntent: models.length > 0,
+    conflict: models.some((candidate) => candidate.source !== model.source),
+  };
 }
 
 async function resolveSetupPlan(
   ctx: ProviderAuthContext,
   candidates: LlamaCppChatCandidate[],
+  embeddingModelIsDefault: boolean,
+  localMemoryIntent: boolean,
 ): Promise<LlamaCppSetupPlan | undefined> {
   let candidate = candidates[0];
   const cachedPath = candidate ? await resolveCachedCandidate(candidate) : undefined;
@@ -234,11 +259,9 @@ async function resolveSetupPlan(
 
   candidate = candidates.find((entry) => entry.model.id === DEFAULT_LLAMA_CPP_MODEL_ID);
   const totalmemBytes = os.totalmem();
-  const localMemoryIntent = hasLocalMemoryIntent(ctx.config);
   if (candidate && meetsLlamaCppDefaultModelRamFloor(totalmemBytes)) {
     const consent = await ctx.prompter.confirm({
-      message:
-        "OpenClaw will install a verified llama.cpp server and download Gemma 4 E4B IT Q4_K_M (about 5.0 GB) plus the local embedding model (about 0.3 GB). Continue?",
+      message: `OpenClaw will install a verified llama.cpp server and download Gemma 4 E4B IT Q4_K_M (about 5.0 GB) plus ${describeEmbeddingDownload(embeddingModelIsDefault)}. Continue?`,
       initialValue: false,
     });
     if (consent) {
@@ -263,8 +286,7 @@ async function resolveSetupPlan(
 
   if (localMemoryIntent) {
     const consent = await ctx.prompter.confirm({
-      message:
-        "OpenClaw can install a verified llama.cpp server and download only the local embedding model (about 0.3 GB). This will not install or change your chat model. Continue?",
+      message: `OpenClaw can install a verified llama.cpp server and download only ${describeEmbeddingDownload(embeddingModelIsDefault)}. This will not install or change your chat model. Continue?`,
       initialValue: false,
     });
     if (consent) {
@@ -279,15 +301,29 @@ async function resolveSetupPlan(
 export async function runLlamaCppSetup(ctx: ProviderAuthContext): Promise<ProviderAuthResult> {
   const existing = ctx.config.models?.providers?.[LLAMA_CPP_PROVIDER_ID];
   const managedExisting = existing?.localService ? existing : undefined;
+  const cacheDir = resolveLlamaCppModelCacheDir(managedExisting);
+  const embeddingSetup = resolveEmbeddingSetup(ctx.config, cacheDir);
+  if (embeddingSetup.conflict) {
+    await ctx.prompter.note(
+      "Configured agents resolve to different local embedding models. Set memory.search.local.modelPath and any per-agent overrides to the same value, then retry llama.cpp setup.",
+      "Setup skipped",
+    );
+    return { profiles: [] };
+  }
+  const embeddingModel = embeddingSetup.model;
   const candidates = configuredCandidates(ctx.config, "setup");
-  const plan = await resolveSetupPlan(ctx, candidates);
+  const plan = await resolveSetupPlan(
+    ctx,
+    candidates,
+    embeddingModel.isDefault,
+    embeddingSetup.localMemoryIntent,
+  );
   if (!plan) {
     return { profiles: [] };
   }
 
   const progress = ctx.prompter.progress("Preparing managed llama.cpp server…");
   try {
-    const cacheDir = resolveLlamaCppModelCacheDir(managedExisting);
     let chatModel: ManagedLlamaChatModel;
     if (plan.kind === "chat") {
       const chatModelPath =
@@ -313,16 +349,19 @@ export async function runLlamaCppSetup(ctx: ProviderAuthContext): Promise<Provid
     } else {
       chatModel = { mode: "remove" };
     }
+    const embeddingModelLabel = embeddingModel.isDefault
+      ? "EmbeddingGemma"
+      : "configured embedding model";
     const embeddingModelPath = await ensureLlamaCppModel({
-      source: DEFAULT_LLAMA_CPP_EMBEDDING_MODEL,
+      source: embeddingModel.source,
       cacheDir,
       download: true,
       signal: ctx.signal,
-      onProgress: (status) => progress.update(formatDownloadProgress("EmbeddingGemma", status)),
+      onProgress: (status) => progress.update(formatDownloadProgress(embeddingModelLabel, status)),
     });
     const managed = await prepareManagedLlamaServer({
       chatModel,
-      embeddingModelIsDefault: true,
+      embeddingModelIsDefault: embeddingModel.isDefault,
       embeddingModelPath,
       port: readConfiguredPort(managedExisting),
     });


### PR DESCRIPTION
## Problem

Guided managed llama.cpp setup ignored `memory.search.local.modelPath`. It always downloaded the default Q8 EmbeddingGemma model first. The local memory runtime honored the configured model only later, which caused a second download and rewrote the managed preset.

## Root cause

Setup and runtime owned separate embedding-model selection logic. Runtime resolved the configured source and whether it was the default model. Setup hard-coded both values and checked per-agent local-memory intent without resolving the effective enabled state or model source.

## Fix

- Move embedding source, cache, and default classification into one llama.cpp resolver.
- Use that resolver for guided setup, runtime preparation, and memory index identity.
- Resolve each enabled agent's effective local model through the public agent-scope boundary.
- Use the model when all enabled local-memory agents agree; stop before consent or mutation when they differ.
- Ignore disabled and non-local agents when selecting the managed embedding model.

Production code is +88/-52 lines (net +36). Tests are +141/-4 lines. The production growth represents effective per-agent agreement as one setup decision; the resolver removes the duplicated source-selection path.

## Proof

- In a disposable Ubuntu 24.04 virtual machine with 8 GiB RAM, exact current `main` at `009cd5b800a1c4d1d30c104f7214f5fe45189f8e` was configured with the public Q4 EmbeddingGemma URI and `openai/gpt-5.4` chat.
- Main setup downloaded the 328,577,056-byte Q8 file, left Q4 absent, and wrote Q8 to the managed preset. The first real memory search then downloaded the 277,852,192-byte Q4 file and replaced the preset path.
- Exact final head `b64a8934d4b7898a63170f7cbcb11e120ce04c46` requested explicit consent for the configured embedding model, displayed `Downloading configured embedding model`, downloaded only Q4, saved `models: []`, and preserved `openai/gpt-5.4`.
- One active agent inherited global Q4 while one disabled local agent and one non-local agent retained different stale paths. Setup ignored both stale paths and installed only Q4.
- Two enabled local-memory agents with different model sources received `Setup skipped`; setup showed no consent prompt and created no model directory, server directory, config change, or preset.
- The managed server passed `/health`, returned two different 768-value embeddings for different inputs, and completed a real hybrid memory search.
- `node scripts/run-vitest.mjs extensions/llama-cpp --reporter=verbose`: 12 files and 136 tests passed.
- Focused Oxfmt, Oxlint, import-cycle, coercion-helper, max-lines, assertion-safety, dependency, storage, and plugin-boundary checks passed. Hosted CI owns type checks and builds.
- Every Gateway, llama.cpp process, virtual machine, forwarded port, key, and disposable state was removed after proof.

## Scope

Setup now refuses to choose a hidden precedence for conflicting enabled agent model sources. Runtime arbitration for already-authored conflicting configurations remains separate work because it affects how one shared server represents multiple embedding models.
