### PR TITLE
fix(line): deliver a code block the Flex card cannot hold

### DIFF
--- a/extensions/line/src/markdown-to-line.test.ts
+++ b/extensions/line/src/markdown-to-line.test.ts
@@ -220,6 +220,25 @@ describe("processLineMessage", () => {
     ).toEqual(["Before", "Code", "Between", "Table", "After"]);
   });
 
+  it("delivers a code block the card cannot hold as text instead of cutting it", () => {
+    // The card shows 2000 characters. Nothing in LINE caps a Flex text there, so
+    // a longer block belongs to the reader in full, the way an oversized table
+    // already reaches them as text.
+    const code = Array.from({ length: 120 }, (_, i) => `const line${i} = ${i}; // padding`).join(
+      "\n",
+    );
+    expect(code.length).toBeGreaterThan(2000);
+
+    const result = processLineMessage(`Header\n\n\`\`\`ts\n${code}\n\`\`\`\n\nFooter`);
+
+    expect(result.flexMessages).toHaveLength(0);
+    expect(result.text).toContain("const line0 = 0;");
+    expect(result.text).toContain("const line119 = 119;");
+    expect(result.text).not.toContain("\n...");
+    expect(result.text.indexOf("Header")).toBeLessThan(result.text.indexOf("const line0"));
+    expect(result.text.indexOf("const line119")).toBeLessThan(result.text.indexOf("Footer"));
+  });
+
   it("processes text with code blocks", () => {
     const text = `Check this code:
 

--- a/extensions/line/src/markdown-to-line.ts
+++ b/extensions/line/src/markdown-to-line.ts
@@ -55,6 +55,10 @@ const LINE_MARKDOWN_OPTIONS = {
 } as const;
 const TRANSCRIPT_ROLE_PREFIX = "[assistant-authored transcript] ";
 const LINE_FLEX_BUBBLE_MAX_BYTES = 30_000;
+// How much code one Flex card shows. Nothing in LINE caps a Flex text this low —
+// it is the card's own readable budget — so a longer block is delivered as text
+// rather than cut down to it.
+const LINE_FLEX_CODE_CARD_MAX_CHARS = 2000;
 
 function parseLineMarkdown(text: string, tableMode: "block" | "bullets" | "off" = "block") {
   return markdownToIRWithMeta(text, { ...LINE_MARKDOWN_OPTIONS, tableMode });
@@ -390,7 +394,9 @@ export function convertTableToFlexBubble(table: MarkdownTable): FlexBubble {
 export function convertCodeBlockToFlexBubble(block: CodeBlock): FlexBubble {
   const titleText = block.language ? `Code (${block.language})` : "Code";
   const displayCode =
-    block.code.length > 2000 ? truncateUtf16Safe(block.code, 2000) + "\n..." : block.code;
+    block.code.length > LINE_FLEX_CODE_CARD_MAX_CHARS
+      ? `${truncateUtf16Safe(block.code, LINE_FLEX_CODE_CARD_MAX_CHARS)}\n...`
+      : block.code;
 
   return {
     type: "bubble",
@@ -461,6 +467,13 @@ export function processLineMessage(text: string): ProcessedLineMessage {
     // An empty fence has no code to show, and LINE rejects the whole push when a
     // Flex text is blank, so it drops out instead of costing the reply.
     if (!block.code.trim()) {
+      continue;
+    }
+    // A block the card would have to cut is delivered as the text it was written
+    // as, the same way an oversized table is: the reader gets all of it, chunked
+    // by the ordinary text limit, instead of a card ending in an ellipsis.
+    if (block.code.length > LINE_FLEX_CODE_CARD_MAX_CHARS) {
+      plainTextInsertions.push({ position: span.start, text: `\n\n${block.code}\n\n` });
       continue;
     }
     plainTextInsertions.push({

--- a/extensions/line/src/row-overflow-delivery.loopback.test.ts
+++ b/extensions/line/src/row-overflow-delivery.loopback.test.ts
@@ -365,6 +365,38 @@ describe("Row-overflow table delivery through production outbound adapter over l
     expect(requests.every((request) => request.body.messages.length <= 5)).toBe(true);
   });
 
+  it("delivers every line of an oversized code block through the production outbound adapter", async () => {
+    const code = Array.from(
+      { length: 120 },
+      (_, i) => `const line${i} = ${i}; // padding pad`,
+    ).join("\n");
+    const markdown = `Header\n\n\`\`\`ts\n${code}\n\`\`\`\n\nFooter`;
+    expect(code.length).toBeGreaterThan(2000);
+
+    await lineOutboundAdapter.sendPayload!({
+      to: "line:user:UtestCodeOverflow",
+      text: markdown,
+      payload: { text: markdown },
+      cfg: LINE_TEST_CFG,
+    });
+
+    const allMessages = collectAllWireMessages(requests);
+    const allText = allMessages
+      .filter((message) => message.type === "text" && message.text)
+      .map((message) => message.text!)
+      .join(" ");
+
+    for (const line of [0, 60, 119]) {
+      expect(allText).toContain(`const line${line} = ${line};`);
+    }
+    expect(allText).not.toContain("\n...");
+    expect(allText).toContain("Header");
+    expect(allText).toContain("Footer");
+    expect(allText.indexOf("Header")).toBeLessThan(allText.indexOf("const line0"));
+    expect(allText.indexOf("const line119")).toBeLessThan(allText.indexOf("Footer"));
+    expect(allMessages.some((message) => message.altText === "Code")).toBe(false);
+  });
+
   it("keeps rendered-code quick replies on final media on the actual LINE HTTP wire", async () => {
     const markdown = "```js\nfirst()\n```";
 


### PR DESCRIPTION
## What Problem This Solves

When an agent answers on LINE with a fenced code block longer than 2000 characters — a config file, a log excerpt, a diff — the reply keeps the first 2000 characters and throws the rest away. The card ends mid-token with an ellipsis, and the sentence after it is delivered as written, so the reply reads as complete when it is not:

![LINE code card cut at `const line52`, then a bare `const` and an ellipsis, followed by the message "That is the whole file."](https://github.com/user-attachments/assets/2bb468ab-051f-45be-a2dd-5cfca837c47d)

That screenshot is a 120-line file. 67 of those lines are not in the conversation anywhere.

Nothing about LINE requires the cut. `POST /v2/bot/message/validate/push` accepts a Flex text of 2 000, 5 000, and 10 000 characters alike — the 2000 is this plugin's own display budget for the code card:

```
len=2000   {} HTTP_STATUS=200
len=2001   {} HTTP_STATUS=200
len=5000   {} HTTP_STATUS=200
len=10000  {} HTTP_STATUS=200
```

Every other block in the same reply already survives. Prose is chunked at LINE's 5000-character limit and sent across several messages. A table too large for its card degrades to text through `formatOversizedTableAsBullets` and keeps every row. A code block is the only block that loses content.

## Why This Change Was Made

`processLineMessage` already owns the "this block does not fit its card" decision — the table loop right above the code loop makes exactly that call and falls back to text. The code loop had no such branch, so `convertCodeBlockToFlexBubble`'s internal truncation was the only thing standing between a long block and the wire.

The code loop now makes the same decision: a block within the card's budget still becomes the styled `Code` card, and a longer one is inserted into the plain-text projection at its own source offset, where the ordinary chunker carries it to the user like any other text. `convertCodeBlockToFlexBubble` keeps its truncation for direct callers, now expressed with the same named budget so the two cannot drift.

Production LOC: **+14 / −1**.

## User Impact

A long code block sent to LINE arrives in full, in source order, instead of stopping at 2000 characters. Blocks that fit the card are unchanged, so short snippets keep their monospace card.

## Evidence

**Live A/B through the real LINE push API.** The probe runs a worktree's own `processLineMessage` over the same 120-line reply, delivers the result the way the outbound adapter does, and reports how many source lines are missing from what was actually sent.

`origin/main`:

```
source lines=120 codeChars=4579
messages=3 kinds=text,flex,text
source lines missing from the delivered reply: 67
push 200 messageIds=629431320619254140,629431320652546117,629431320619516417
```

This branch:

```
source lines=120 codeChars=4579
messages=1 kinds=text
source lines missing from the delivered reply: 0
push 200 messageIds=629431308388401217
```

Both are accepted with `HTTP 200`, which is why the loss is invisible from the send side.

**Boundary proof on the LINE HTTP wire.** The new case joins the existing loopback suite, which drives the production outbound adapter against a local HTTP server standing in for `api.line.me` and asserts on the request bodies it receives:

```
✓ extensions/line/src/row-overflow-delivery.loopback.test.ts
    > delivers every line of an oversized code block through the production outbound adapter
```

**Red↔green.** With only `markdown-to-line.ts` restored to `origin/main`:

```
FAIL extensions/line/src/markdown-to-line.test.ts > delivers a code block the card cannot hold as text instead of cutting it
FAIL extensions/line/src/row-overflow-delivery.loopback.test.ts > delivers every line of an oversized code block through the production outbound adapter
Test Files  2 failed (2)
     Tests  2 failed | 47 passed (49)
```

**Local gates.**

```
$ node scripts/run-vitest.mjs extensions/line
 Test Files  44 passed (44)
      Tests  663 passed (663)

$ node scripts/run-tsgo.mjs -p tsconfig.extensions.json --noEmit                     # EXIT=0
$ node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.extensions.test.json --noEmit  # EXIT=0
$ node scripts/check-changed.mjs                                                     # EXIT=0
$ pnpm check:assertion-safety --base origin/main
assertion SAFETY ratchet OK: 4183 files, 12953 grandfathered assertions.
$ pnpm check:max-lines-ratchet --base origin/main
max-lines ratchet OK: 882 grandfathered suppressions.
```

No build was run: this change adds no import, no dynamic import, and no exported surface.
