### PR TITLE
feat(tts): save remote Gateway output locally

### DIFF
--- a/docs/cli/infer.md
+++ b/docs/cli/infer.md
@@ -238,7 +238,7 @@ openclaw infer tts status --json
 Notes:
 
 - `tts status` only supports `--gateway` (it reflects gateway-managed TTS state).
-- Local and loopback-Gateway `tts convert --output` copies stage beside the destination and replace it only after success; a failed copy leaves an existing file unchanged.
+- `tts convert --output` stages beside the destination and replaces it only after success; a failed local, loopback-Gateway, or remote-Gateway transfer leaves an existing file unchanged. Remote output requires a Gateway version that supports inline TTS transfer.
 - Use `tts convert --provider <id>` when selecting a provider without overriding its model.
 - Use `tts providers`, `tts voices`, `tts personas`, `tts set-provider`, and `tts set-persona` to inspect and configure TTS behavior.
 

--- a/src/cli/capability-cli.test.ts
+++ b/src/cli/capability-cli.test.ts
@@ -3745,13 +3745,68 @@ describe("capability cli", () => {
     expect(firstGatewayCall()?.params?.voiceId).toBe("alloy");
   });
 
-  it("fails clearly when gateway TTS output is requested against a remote gateway", async () => {
+  it("writes remote gateway TTS output from inline audio", async () => {
     const gatewayConnection = await import("../gateway/connection-details.js");
     vi.mocked(gatewayConnection.buildGatewayConnectionDetailsWithResolvers).mockReturnValueOnce({
       url: "wss://gateway.example.com",
       urlSource: "config gateway.remote.url",
       message: "Gateway target: wss://gateway.example.com",
     });
+    const audio = Buffer.from("remote-tts-audio");
+    mocks.callGateway.mockResolvedValueOnce({
+      audioPath: "/tmp/gateway-tts.mp3",
+      audioBase64: audio.toString("base64"),
+      provider: "openai",
+      outputFormat: "mp3",
+      voiceCompatible: false,
+    } as never);
+    const outputPath = path.join(tempDirs.make("openclaw-remote-tts-output-"), "speech.mp3");
+
+    await runCapability(
+      "tts",
+      "convert",
+      "--gateway",
+      "--text",
+      "hello",
+      "--output",
+      outputPath,
+      "--json",
+    );
+
+    expect(firstGatewayCall()?.params?.includeAudio).toBe(true);
+    expect(await fs.readFile(outputPath)).toEqual(audio);
+    expect(firstJsonOutput()?.outputs).toEqual([
+      { path: outputPath, format: "mp3", voiceCompatible: false },
+    ]);
+  });
+
+  it.each([
+    {
+      name: "missing",
+      audioBase64: undefined,
+      message: "did not return inline TTS audio; update the Gateway",
+    },
+    {
+      name: "malformed",
+      audioBase64: "not-base64!",
+      message: "returned invalid inline TTS audio",
+    },
+  ])("preserves remote TTS output when inline audio is $name", async ({ audioBase64, message }) => {
+    const gatewayConnection = await import("../gateway/connection-details.js");
+    vi.mocked(gatewayConnection.buildGatewayConnectionDetailsWithResolvers).mockReturnValueOnce({
+      url: "wss://gateway.example.com",
+      urlSource: "config gateway.remote.url",
+      message: "Gateway target: wss://gateway.example.com",
+    });
+    mocks.callGateway.mockResolvedValueOnce({
+      audioPath: "/tmp/gateway-tts.mp3",
+      audioBase64,
+      provider: "openai",
+      outputFormat: "mp3",
+      voiceCompatible: false,
+    } as never);
+    const outputPath = path.join(tempDirs.make("openclaw-remote-tts-invalid-"), "speech.mp3");
+    await fs.writeFile(outputPath, "existing-speech");
 
     await expect(
       runCapability(
@@ -3761,12 +3816,13 @@ describe("capability cli", () => {
         "--text",
         "hello",
         "--output",
-        "hello.mp3",
+        outputPath,
         "--json",
       ),
     ).rejects.toThrow("exit 1");
 
-    expectRuntimeErrorContains("--output is not supported for remote gateway TTS yet");
+    expectRuntimeErrorContains(message);
+    expect(await fs.readFile(outputPath, "utf8")).toBe("existing-speech");
   });
 
   it.each(["local", "gateway"] as const)(
@@ -3825,6 +3881,9 @@ describe("capability cli", () => {
         ).rejects.toThrow("exit 1");
 
         expectRuntimeErrorContains("injected TTS copy failure");
+        if (transport === "gateway") {
+          expect(firstGatewayCall()?.params?.includeAudio).toBeUndefined();
+        }
         expect(mocks.runtime.writeJson).not.toHaveBeenCalled();
         expect(await fs.readFile(outputPath, "utf8")).toBe("existing-speech");
         if (process.platform !== "win32") {

--- a/src/cli/capability-cli/tts-runtime.ts
+++ b/src/cli/capability-cli/tts-runtime.ts
@@ -1,5 +1,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
+import { canonicalizeBase64, estimateBase64DecodedBytes } from "@openclaw/media-core/base64";
+import { MAX_AUDIO_BYTES } from "@openclaw/media-core/constants";
 import { isRecord as isObjectRecord } from "@openclaw/normalization-core/record-coerce";
 import {
   normalizeLowercaseStringOrEmpty,
@@ -45,6 +47,35 @@ async function copyTtsOutputAtomically(sourcePath: string, targetPath: string): 
   });
 }
 
+function decodeInlineTtsAudio(value: unknown): Buffer {
+  if (typeof value !== "string") {
+    throw new Error(
+      "Remote Gateway did not return inline TTS audio; update the Gateway and retry.",
+    );
+  }
+  if (estimateBase64DecodedBytes(value) > MAX_AUDIO_BYTES) {
+    throw new Error(`Remote Gateway TTS audio exceeds the ${MAX_AUDIO_BYTES} byte transfer limit.`);
+  }
+  const canonical = canonicalizeBase64(value);
+  if (!canonical) {
+    throw new Error("Remote Gateway returned invalid inline TTS audio.");
+  }
+  const audio = Buffer.from(canonical, "base64");
+  if (audio.length === 0 || audio.length > MAX_AUDIO_BYTES) {
+    throw new Error("Remote Gateway returned invalid inline TTS audio.");
+  }
+  return audio;
+}
+
+async function writeInlineTtsOutputAtomically(audio: Buffer, targetPath: string): Promise<void> {
+  await publishOutputFileAtomically({
+    filePath: targetPath,
+    writeTemp: async (tempPath) => {
+      await fs.writeFile(tempPath, audio, { flag: "wx" });
+    },
+  });
+}
+
 export async function runTtsConvert(params: {
   text: string;
   channel?: string;
@@ -58,8 +89,11 @@ export async function runTtsConvert(params: {
     const gatewayConnection = buildGatewayConnectionDetailsWithResolvers({
       config: getRuntimeConfig(),
     });
+    const gatewayHost = new URL(gatewayConnection.url).hostname;
+    const remoteOutputRequested = Boolean(params.output && !isLoopbackHost(gatewayHost));
     const result: {
       audioPath?: string;
+      audioBase64?: string;
       provider?: string;
       outputFormat?: string;
       voiceCompatible?: boolean;
@@ -71,19 +105,18 @@ export async function runTtsConvert(params: {
         provider: normalizeOptionalString(params.provider),
         modelId: params.modelId,
         voiceId: params.voiceId,
+        ...(remoteOutputRequested ? { includeAudio: true } : {}),
       },
       timeoutMs: 120_000,
     });
     let outputPath = result.audioPath;
     if (params.output && result.audioPath) {
-      const gatewayHost = new URL(gatewayConnection.url).hostname;
-      if (!isLoopbackHost(gatewayHost)) {
-        throw new Error(
-          `--output is not supported for remote gateway TTS yet (gateway target: ${gatewayConnection.url}).`,
-        );
-      }
       const target = path.resolve(params.output);
-      await copyTtsOutputAtomically(result.audioPath, target);
+      if (remoteOutputRequested) {
+        await writeInlineTtsOutputAtomically(decodeInlineTtsAudio(result.audioBase64), target);
+      } else {
+        await copyTtsOutputAtomically(result.audioPath, target);
+      }
       outputPath = target;
     }
     return {

--- a/src/gateway/server-methods/tts.test.ts
+++ b/src/gateway/server-methods/tts.test.ts
@@ -2,9 +2,13 @@
  * Tests for text-to-speech gateway methods and provider error envelopes.
  */
 
+import fs from "node:fs/promises";
+import path from "node:path";
+import { MAX_AUDIO_BYTES } from "@openclaw/media-core/constants";
 import { expectDefined } from "@openclaw/normalization-core";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ErrorCodes } from "../../../packages/gateway-protocol/src/index.js";
+import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
 import { setActiveDegradedSecretOwners } from "../../secrets/runtime-degraded-state.js";
 import { expectGatewayErrorResponse } from "./gateway-response.test-helpers.js";
 
@@ -51,6 +55,8 @@ const mocks = vi.hoisted(() => ({
     voiceCompatible: false,
   })),
 }));
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 vi.mock("../../config/config.js", () => ({
   getRuntimeConfig:
@@ -369,6 +375,68 @@ describe("ttsHandlers", () => {
       message: 'Error: Unknown TTS provider "bad".',
     });
     expect(mocks.textToSpeech).not.toHaveBeenCalled();
+  });
+
+  it("returns tts.convert audio inline only when requested", async () => {
+    const audio = Buffer.from("gateway-inline-tts-audio");
+    const audioPath = path.join(tempDirs.make("openclaw-tts-inline-"), "speech.mp3");
+    await fs.writeFile(audioPath, audio);
+    mocks.textToSpeech.mockResolvedValueOnce({
+      success: true,
+      audioPath,
+      provider: "openai",
+      outputFormat: "mp3",
+      voiceCompatible: false,
+    });
+    const { ttsHandlers } = await import("./tts.js");
+    const respond = vi.fn();
+
+    await expectDefined(
+      ttsHandlers["tts.convert"],
+      'ttsHandlers["tts.convert"] test invariant',
+    )({
+      params: { text: "hello", includeAudio: true },
+      respond,
+      context: { getRuntimeConfig: mocks.getRuntimeConfig },
+    } as never);
+
+    expect(respond).toHaveBeenCalledWith(true, {
+      audioPath,
+      audioBase64: audio.toString("base64"),
+      provider: "openai",
+      outputFormat: "mp3",
+      voiceCompatible: false,
+    });
+  });
+
+  it("rejects tts.convert inline audio above the transfer limit", async () => {
+    const audioPath = path.join(tempDirs.make("openclaw-tts-inline-limit-"), "speech.mp3");
+    const handle = await fs.open(audioPath, "w");
+    await handle.truncate(MAX_AUDIO_BYTES + 1);
+    await handle.close();
+    mocks.textToSpeech.mockResolvedValueOnce({
+      success: true,
+      audioPath,
+      provider: "openai",
+      outputFormat: "mp3",
+      voiceCompatible: false,
+    });
+    const { ttsHandlers } = await import("./tts.js");
+    const respond = vi.fn();
+
+    await expectDefined(
+      ttsHandlers["tts.convert"],
+      'ttsHandlers["tts.convert"] test invariant',
+    )({
+      params: { text: "hello", includeAudio: true },
+      respond,
+      context: { getRuntimeConfig: mocks.getRuntimeConfig },
+    } as never);
+
+    expectGatewayErrorResponse(respond, {
+      code: ErrorCodes.UNAVAILABLE,
+      message: `Error: TTS audio exceeds the ${MAX_AUDIO_BYTES} byte inline transfer limit.`,
+    });
   });
 
   it("tts.speak returns the synthesized clip inline with provider metadata", async () => {

--- a/src/gateway/server-methods/tts.ts
+++ b/src/gateway/server-methods/tts.ts
@@ -1,4 +1,6 @@
 // Gateway RPC handlers for text-to-speech status, preferences, and conversion.
+import fs from "node:fs/promises";
+import { MAX_AUDIO_BYTES } from "@openclaw/media-core/constants";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import {
   ErrorCodes,
@@ -6,6 +8,7 @@ import {
   validateTtsSpeakParams,
 } from "../../../packages/gateway-protocol/src/index.js";
 import type { OpenClawConfig } from "../../config/types.js";
+import { readFileDescriptorBounded } from "../../infra/boundary-file-read.js";
 import {
   assertSecretOwnerAvailable,
   SecretSurfaceUnavailableError,
@@ -41,6 +44,31 @@ function yieldBeforeTtsStatusSetup(): Promise<void> {
   return new Promise((resolve) => {
     setImmediate(resolve);
   });
+}
+
+async function readInlineTtsAudio(audioPath: string): Promise<string> {
+  const handle = await fs.open(audioPath, "r");
+  try {
+    // Base64 expansion keeps the default audio cap below the 25 MiB Gateway
+    // frame ceiling while leaving room for the response envelope.
+    let audio: Buffer;
+    try {
+      audio = await readFileDescriptorBounded(handle.fd, MAX_AUDIO_BYTES);
+    } catch (error) {
+      if (error instanceof RangeError) {
+        // Keep filesystem implementation details out of the remote error envelope.
+        // eslint-disable-next-line preserve-caught-error
+        throw new Error(`TTS audio exceeds the ${MAX_AUDIO_BYTES} byte inline transfer limit.`);
+      }
+      throw error;
+    }
+    if (audio.length === 0) {
+      throw new Error("TTS audio output is empty");
+    }
+    return audio.toString("base64");
+  } finally {
+    await handle.close();
+  }
 }
 
 function resolveTtsGatewayStatusFacts(cfg: OpenClawConfig) {
@@ -135,6 +163,7 @@ export const ttsHandlers: GatewayRequestHandlers = {
       const providerRaw = normalizeOptionalString(params.provider);
       const modelId = normalizeOptionalString(params.modelId);
       const voiceId = normalizeOptionalString(params.voiceId);
+      const includeAudio = params.includeAudio === true;
       let overrides;
       try {
         // Explicit provider/model/voice requests are validated before synthesis
@@ -157,8 +186,10 @@ export const ttsHandlers: GatewayRequestHandlers = {
         disableFallback: Boolean(overrides.provider || modelId || voiceId),
       });
       if (result.success && result.audioPath) {
+        const audioBase64 = includeAudio ? await readInlineTtsAudio(result.audioPath) : undefined;
         respond(true, {
           audioPath: result.audioPath,
+          ...(audioBase64 ? { audioBase64 } : {}),
           provider: result.provider,
           outputFormat: result.outputFormat,
           voiceCompatible: result.voiceCompatible,

--- a/src/gateway/server-methods/tts.ts
+++ b/src/gateway/server-methods/tts.ts
@@ -51,16 +51,17 @@ async function readInlineTtsAudio(audioPath: string): Promise<string> {
   try {
     // Base64 expansion keeps the default audio cap below the 25 MiB Gateway
     // frame ceiling while leaving room for the response envelope.
-    let audio: Buffer;
+    let audio: Buffer | null = null;
     try {
       audio = await readFileDescriptorBounded(handle.fd, MAX_AUDIO_BYTES);
     } catch (error) {
-      if (error instanceof RangeError) {
-        // Keep filesystem implementation details out of the remote error envelope.
-        // eslint-disable-next-line preserve-caught-error
-        throw new Error(`TTS audio exceeds the ${MAX_AUDIO_BYTES} byte inline transfer limit.`);
+      if (!(error instanceof RangeError)) {
+        throw error;
       }
-      throw error;
+    }
+    if (audio === null) {
+      // Keep filesystem implementation details out of the remote error envelope.
+      throw new Error(`TTS audio exceeds the ${MAX_AUDIO_BYTES} byte inline transfer limit.`);
     }
     if (audio.length === 0) {
       throw new Error("TTS audio output is empty");


### PR DESCRIPTION
Closes #132548

## What Problem This Solves

`openclaw infer tts convert --gateway --output <path>` could only save output when the CLI and Gateway shared a filesystem. With a remote Gateway, `tts.convert` returned a path on the Gateway host, so the CLI rejected `--output` and the operator had no way to retrieve the generated audio through the conversion workflow.

Current `main` reproduced this consistently: the remote-output acceptance test exited with code 1 before any destination file could be published.

## Why This Change Was Made

The transfer belongs at the existing `tts.convert` Gateway boundary. This change therefore:

- lets the CLI opt into an additive inline-audio response only for remote `--output` requests;
- bounds the decoded audio at the existing 16 MiB `MAX_AUDIO_BYTES` limit, safely below the 25 MiB Gateway frame ceiling after base64 and JSON overhead;
- reads the generated file through a pinned descriptor with the bounded filesystem helper;
- validates canonical base64 and decoded size before using the existing atomic output publisher;
- leaves local and loopback Gateway conversion on the existing path-based flow; and
- gives a clear upgrade-required error when an older Gateway omits the optional response field, without replacing an existing destination file.

The issue's ClawSweeper review independently recommended this bounded opt-in response, atomic publication, and explicit older-Gateway behavior.

Existing-solutions preflight: OpenClaw's providers and plugins already synthesize audio, but none transports a conversion artifact across the CLI/Gateway filesystem boundary. `tts.speak` is a separate playback RPC and does not preserve the `tts.convert` provider/model/voice/output workflow. A third-party library or hosted service would not solve this product boundary.

## User Impact

Operators connected to a remote Gateway can now save converted TTS audio to a local `--output` path. Calls without `--output`, and local or loopback Gateway calls, keep their existing behavior.

Compatibility and security impact:

- no config, environment variable, dependency, database, migration, or default changes;
- only optional request and response fields are added to the existing RPC;
- inline audio is opt-in and capped at 16 MiB decoded;
- older Gateways fail with an actionable update message; and
- destination replacement remains atomic.

Known limitation: generated audio over 16 MiB is rejected, and remote output requires a Gateway version that supports the inline response.

## Evidence

### Maintenance validation — 2026-09-09

I rebased this PR onto upstream main `338a53fbde2cd2668e987156a22b4383b4207bdc`. The current contributor head is `77b5557ff507ec55a9a16e976e714018719edc70`.

Updated the base to include the upstream SSH stderr-drain fix that addresses the previously failing tunnel test. The remote TTS feature patch is unchanged by this rebase.

Validation on Linux with Node 24.16.0 and the repository-pinned pnpm 12.3.4 / Vitest 5:
- `node scripts/run-vitest.mjs run src/cli/capability-cli.test.ts src/gateway/server-methods/tts.test.ts src/gateway/worker-environments/tunnel.test.ts --reporter=dot`: 277 passed.
- Fresh structured autoreview covered actionable priorities P0–P3; no remaining accepted findings.
- `git diff --check` passed. Contributor author/committer identities and maintainer edit permission were verified before the exact-lease push.

These are focused regression checks, not a new live behavior proof. The earlier runtime/media/transcript receipts below belong to their stated historical heads and were not rerun on this rebased head. Upstream CI for the new head is reported by the checks attached to this PR; I am not claiming it green before completion.

### Earlier validation receipts (historical heads)


### September 5 Completed CI Status

Head: `60be8229551cabc8933409d274ba61435255b710`. The checks associated with this head have completed with 167 success, 46 skipped, 1 neutral and 2 failures (one actual test shard plus the aggregate gate). [Job 101223475850](https://github.com/openclaw/openclaw/actions/runs/33935744129/job/101223475850) failed `src/gateway/worker-environments/tunnel.test.ts:341`, where an SSH child-process stderr-tail assertion received the generic `Worker SSH tunnel failed` message. This PR does not modify that test, `tunnel-ssh-runner.ts`, or the process runner; its changed surface is the TTS CLI/Gateway owner and adjacent tests/docs. This is not a claim that the failure was reproduced on base or that its root cause has been fully diagnosed. The aggregate remains red and the earlier TTS proof does not replace it. Leon has read-only upstream repository permissions; no upstream Actions rerun is claimed.


### Persistence And Version Boundaries

September 5 source audit at `60be8229551cabc8933409d274ba61435255b710`: the added `audioBase64` is a transient response field, decoded before publishing the operator-requested audio artifact. It is not copied into the existing CLI result envelope, config, preferences, database, cache, or session state. The full baseline delta adds no persistent schema or state-store change; a data migration is not applicable to this transfer. This does not imply complete wire interoperability proof.

- Existing callers that omit `includeAudio` keep the path-only Gateway response. The older CLI still rejects its own remote `--output` path; it does not gain the new capability merely by upgrading the Gateway.
- The new CLI accepts an older path-only response for existing no-output/loopback behavior. For the newly supported remote-output request, missing inline bytes produce an explicit Gateway-upgrade error before output publication. The existing regression uses a mocked old-shaped response and verifies preservation of the actual destination file; it is not an old Gateway binary run.
- Local synthesis and loopback copies retain their existing atomic-publication path. Current copy-failure regressions cover both and assert the existing destination survives.
- Evidence map: [CLI transport and result](https://github.com/openclaw/openclaw/blob/60be8229551cabc8933409d274ba61435255b710/src/cli/capability-cli/tts-runtime.ts#L89), [opt-in Gateway response](https://github.com/openclaw/openclaw/blob/60be8229551cabc8933409d274ba61435255b710/src/gateway/server-methods/tts.ts#L172), [missing-inline preservation regression](https://github.com/openclaw/openclaw/blob/60be8229551cabc8933409d274ba61435255b710/src/cli/capability-cli.test.ts#L3678), [local/loopback copy regression](https://github.com/openclaw/openclaw/blob/60be8229551cabc8933409d274ba61435255b710/src/cli/capability-cli.test.ts#L3723).

No new tests or dual-version live runs are claimed by this source audit. Real old-CLI/new-Gateway and new-CLI/old-Gateway interoperability runs remain unperformed; existing real Gateway/CLI and dependency receipts below retain their original scope and heads.


Exact head: [`2cf811984cb38310654003d33bf4f34fd9f4caf3`](https://github.com/Leon-SK668/openclaw/commit/2cf811984cb38310654003d33bf4f34fd9f4caf3)

Acceptance red, before production changes:

- the new remote-output CLI acceptance test failed on current `main` because the existing guard exited 1.

Acceptance green, on the exact head:

- `node scripts/run-vitest.mjs src/gateway/server-methods/tts.test.ts` - 14 passed
- `node scripts/run-vitest.mjs src/cli/capability-cli.test.ts -t 'TTS|tts'` - 21 passed, 176 skipped
- `pnpm exec oxfmt --check docs/cli/infer.md src/cli/capability-cli.test.ts src/cli/capability-cli/tts-runtime.ts src/gateway/server-methods/tts.test.ts src/gateway/server-methods/tts.ts` - passed
- `pnpm exec oxlint src/cli/capability-cli.test.ts src/cli/capability-cli/tts-runtime.ts src/gateway/server-methods/tts.test.ts src/gateway/server-methods/tts.ts` - passed
- docs MDX validation for `docs/cli/infer.md` - passed
- `git diff --check` - passed

Real behavior proof used a real `startGatewayServer`, a temporary deterministic speech-provider plugin, and production `runTtsConvert` over `ws://localtest.me:<port>` so the CLI took the remote path. Receipt:

- `tts.convert`: 541 ms
- output: 180-byte WAV, prefix `RIFF`
- SHA-256: `6512d6fc1e826f38efb99fe7db2a30d47081e5052ffa48575909231ca74387f7`
- local output bytes exactly matched the Gateway synthesis buffer
- Gateway shut down cleanly after readback

Fresh pre-push autoreview found no P0/P1 defects and no actionable findings (confidence 0.93).

Diff size: 5 files, production +71/-7, tests +131/-4, docs +1/-1. No generated or lock files.

Full local build is not claimed: the isolated checkout install was blocked by the repository's minimum-release-age policy for unrelated dependency releases, and the shared dependency view lacked an unrelated bundled Discord SDK. No supply-chain policy was relaxed; focused owner tests and the real Gateway proof above passed, with hosted CI left to run the full repository gates.

## AI Assistance

Codex assisted with repository investigation, implementation, focused validation, and review. The contributor reviewed the final diff and evidence. No transcript is attached.


### Pinned Filesystem Contract Audit

September 5, 2026; product head remains `60be8229551cabc8933409d274ba61435255b710`. No source changes or new end-to-end execution are claimed in this update.

- Personally inspected the installed `@openclaw/fs-safe@0.7.2` JavaScript and types, matching the package and lockfile pin: `dist/bounded-read.js`, `dist/byte-budget.js`, `dist/sibling-temp.js`, and `dist/sibling-staged-file.js`. The bounded reader consumes no more than the limit plus one byte, throws `FsSafeError("too-large")`, and leaves descriptor ownership with its caller. OpenClaw `src/infra/boundary-file-read.ts` maps that error to `RangeError`; `src/gateway/server-methods/tts.ts` converts it to the transfer-limit response and closes the descriptor in `finally`.
- Traced publication through `src/cli/output-file.runtime.ts` -> `src/infra/sibling-temp-file.ts` -> `src/infra/owned-temp-file.ts` and the pinned sibling-stage implementation. Publication uses a completed sibling file, retained descriptor/identity checks, serialized destination writes, and same-directory rename. Existing destination mode is supplied by the CLI owner; directory chmod is disabled. Atomic publication is not a claim of crash durability, which the CLI does not request here.
- Executed an isolated Linux/Node 24 dependency probe using the pinned `readFileDescriptorBounded` and `writeSiblingTempFile`: exact six-byte boundary returned all bytes; a five-byte cap rejected six bytes while the caller could still stat the descriptor; a producer failure preserved the existing target; successful staging left old bytes visible until publication, then exposed new bytes and retained mode `0640`. All five checks passed. This probes the actual dependency against real temporary files, not a mocked filesystem, but does not replace the earlier CLI/Gateway behavior proof or establish cross-platform behavior.
- Dependency source SHA-256: bounded reader `73e939b611bb80f839ee49730119ee163e7884cb17b85e8d5eb4048ca08ece80`; sibling entry `19519f24e1c82e59ad0180ecd20d37642f633d4e20ec8675c9dfa619f7959114`; staged publication `cc735208d96baf56f706eb3c2e3c83ba926977343ae7edee000087fabbc8fabd`.
- Compatibility boundary: the five-file PR adds optional per-request `includeAudio` and per-response `audioBase64`; it does not modify a persisted config/store schema or database version. The output is the user-requested audio artifact. Existing local/loopback copying remains on its prior path. When an older Gateway omits inline audio, the new client reports the explicit upgrade-required error before replacing an existing output. The missing/malformed response regressions cover that preservation boundary; no hidden remote-path fallback or data migration is added.


<!-- leon-evidence-maintenance-20260919-aa0yfe -->
### Current-head evidence maintenance — September 19, 2026

The product head remains `77b5557ff507ec55a9a16e976e714018719edc70`. Its [main CI run 34324254907](https://github.com/openclaw/openclaw/actions/runs/34324254907) completed successfully; the historical SSH test failure above belongs to the older explicitly identified head.

The [latest durable review](https://github.com/openclaw/openclaw/pull/132560#issuecomment-5462203562) reports no patch finding and Platinum / Platinum / Platinum, but retains a compatibility-proof prerequisite. The added fields are transient, optional RPC transfer fields; no persisted schema or version changes in this PR require data migration. That source boundary does not establish dual-version live interoperability: an old-CLI/new-Gateway and new-CLI/old-Gateway binary matrix has not been executed in this update. The owner must resolve the remaining applicability/compatibility gate; it is not silently treated as passed.
