### PR TITLE
improve(browser): speed document navigation coverage

### DIFF
--- a/extensions/browser/chrome-extension/background.document-navigation.test.ts
+++ b/extensions/browser/chrome-extension/background.document-navigation.test.ts
@@ -11,13 +11,13 @@ import {
 const originalUrl = "https://example.com/existing";
 const blankResult = { frameId: "root", loaderId: "blank-loader" };
 
-async function setup(mode: "all" | "selected") {
+async function setup() {
   const h = await loadBackground({
     storedConfig: {
       relayUrl: "ws://127.0.0.1:18797/extension",
       token: TEST_RELAY_KEY,
       authVersion: 2,
-      accessMode: mode,
+      accessMode: "selected",
     },
     initialTabs: [
       { id: 7, url: originalUrl, groupId: 7, windowId: 1 },
@@ -70,156 +70,76 @@ afterEach(async () => {
 });
 
 describe("commanded existing document navigation", () => {
-  it.each(["all", "selected"] as const)(
-    "preserves the native blank/reset/trace/return order in %s mode",
-    async (mode) => {
-      const h = await setup(mode);
-      h.native(async () => {
-        h.commitBlank();
-        return blankResult;
-      });
-      h.socket.send.mockClear();
-      expect(
-        await h.request({
-          type: "cdp",
-          tabId: 7,
-          method: "Page.navigate",
-          params: { url: "about:blank", frameId: "root" },
-        }),
-      ).toMatchObject({ type: "result", result: blankResult });
-      expect(
-        h
-          .frames()
-          .filter((f) => f.type === "cdpEvent" || f.seq)
-          .map((f) => f.method ?? f.type),
-      ).toEqual([
-        "Runtime.executionContextsCleared",
-        "Page.frameNavigated",
-        "Page.lifecycleEvent",
-        "result",
-      ]);
-      expect(await h.request({ type: "cdp", tabId: 7, method: "Tracing.start" })).toMatchObject({
-        type: "result",
-      });
-      expect(await h.request({ type: "attach", tabId: 8 })).toMatchObject({ type: "error" });
-      h.debuggerSendCommand.mockImplementationOnce(async () => {
-        const get = h.tabsGet.getMockImplementation()!;
-        h.tabsGet.mockImplementationOnce(async (id) => {
-          const stale = await get(id);
-          h.updateTab(id, { url: originalUrl }, false);
-          h.emit("Page.frameNavigated", {
-            frame: { id: "root", loaderId: "return", url: originalUrl },
-          });
-          return stale;
-        });
-        return { frameId: "root", loaderId: "return" };
-      });
-      expect(
-        await h.request({
-          type: "cdp",
-          tabId: 7,
-          method: "Page.navigate",
-          params: { url: originalUrl },
-        }),
-      ).toMatchObject({ type: "result" });
-      expect(await h.request({ type: "cdp", tabId: 7, method: "Tracing.end" })).toMatchObject({
-        type: "result",
-      });
-      h.updateTab(7, { url: "about:blank" });
-      expect(await sendRuntimeMessage(h, { type: "getTabAccess", tabId: 7 })).toMatchObject({
-        accessible: false,
-      });
-      expect(h.tabsRemove).not.toHaveBeenCalled();
-      expect(h.tabsUpdate).not.toHaveBeenCalled();
-    },
-  );
-  it.each(["all", "selected"] as const)(
-    "accepts a source URL fragment from the native frame contract in %s mode",
-    async (mode) => {
-      const h = await setup(mode);
-      h.updateTab(7, { url: `${originalUrl}#section` });
-      h.debuggerSendCommand.mockImplementation(async (...args: unknown[]) => {
-        if (args[1] === "Page.getFrameTree") {
-          return {
-            frameTree: {
-              frame: {
-                id: "root",
-                loaderId: "original",
-                url: originalUrl,
-                urlFragment: "#section",
-              },
-            },
-          };
-        }
-        if (args[1] === "Page.navigate") {
-          h.commitBlank();
-          return blankResult;
-        }
-        return {};
-      });
-      expect(await h.navigate()).toMatchObject({ type: "result", result: blankResult });
-      expect(await h.request({ type: "cdp", tabId: 7, method: "Tracing.start" })).toMatchObject({
-        type: "result",
-      });
-      expect(h.tabsRemove).not.toHaveBeenCalled();
-    },
-  );
-
-  it.each(["all", "selected"] as const)(
-    "honors an explicit close of the controlled blank in %s mode",
-    async (mode) => {
-      const h = await setup(mode);
-      h.native(async () => {
-        h.commitBlank();
-        return blankResult;
-      });
-      expect(await h.navigate()).toMatchObject({ type: "result" });
-      expect(await h.request({ type: "closeTab", tabId: 7 })).toMatchObject({ type: "result" });
-      expect(h.tabsRemove).toHaveBeenCalledExactlyOnceWith(7);
-    },
-  );
-
-  it("rejects a native blank commit with an uncommanded URL fragment", async () => {
-    const h = await setup("all");
+  it("preserves the native blank/reset/trace/return order in selected mode", async () => {
+    const h = await setup();
     h.native(async () => {
-      h.updateTab(7, { url: "about:blank" });
-      h.emit("Page.frameNavigated", {
-        frame: { id: "root", loaderId: "blank-loader", url: "about:blank", urlFragment: "#other" },
-      });
+      h.commitBlank();
       return blankResult;
     });
     h.socket.send.mockClear();
-    expect(await h.navigate()).toMatchObject({ type: "error" });
-    expect(h.frames().filter((frame) => frame.type === "cdpEvent")).toEqual([]);
+    expect(
+      await h.request({
+        type: "cdp",
+        tabId: 7,
+        method: "Page.navigate",
+        params: { url: "about:blank", frameId: "root" },
+      }),
+    ).toMatchObject({ type: "result", result: blankResult });
+    expect(
+      h
+        .frames()
+        .filter((f) => f.type === "cdpEvent" || f.seq)
+        .map((f) => f.method ?? f.type),
+    ).toEqual([
+      "Runtime.executionContextsCleared",
+      "Page.frameNavigated",
+      "Page.lifecycleEvent",
+      "result",
+    ]);
     expect(await h.request({ type: "cdp", tabId: 7, method: "Tracing.start" })).toMatchObject({
-      type: "error",
+      type: "result",
+    });
+    expect(await h.request({ type: "attach", tabId: 8 })).toMatchObject({ type: "error" });
+    h.debuggerSendCommand.mockImplementationOnce(async () => {
+      const get = h.tabsGet.getMockImplementation()!;
+      h.tabsGet.mockImplementationOnce(async (id) => {
+        const stale = await get(id);
+        h.updateTab(id, { url: originalUrl }, false);
+        h.emit("Page.frameNavigated", {
+          frame: { id: "root", loaderId: "return", url: originalUrl },
+        });
+        return stale;
+      });
+      return { frameId: "root", loaderId: "return" };
+    });
+    expect(
+      await h.request({
+        type: "cdp",
+        tabId: 7,
+        method: "Page.navigate",
+        params: { url: originalUrl },
+      }),
+    ).toMatchObject({ type: "result" });
+    expect(await h.request({ type: "cdp", tabId: 7, method: "Tracing.end" })).toMatchObject({
+      type: "result",
+    });
+    h.updateTab(7, { url: "about:blank" });
+    expect(await sendRuntimeMessage(h, { type: "getTabAccess", tabId: 7 })).toMatchObject({
+      accessible: false,
     });
     expect(h.tabsRemove).not.toHaveBeenCalled();
+    expect(h.tabsUpdate).not.toHaveBeenCalled();
   });
-
-  it.each(["all", "selected"] as const)(
-    "accepts a root commit after its native response in %s",
-    async (mode) => {
-      const h = await setup(mode);
-      h.native(async () => blankResult);
-      h.socket.send.mockClear();
-      expect(await h.navigate()).toMatchObject({ type: "result", result: blankResult });
-      expect(await h.request({ type: "cdp", tabId: 7, method: "Tracing.start" })).toMatchObject({
-        type: "error",
-      });
+  it("honors an explicit close of the controlled blank in selected mode", async () => {
+    const h = await setup();
+    h.native(async () => {
       h.commitBlank();
-      expect(await h.request({ type: "cdp", tabId: 7, method: "Tracing.start" })).toMatchObject({
-        type: "result",
-      });
-      expect(
-        h
-          .frames()
-          .filter((f) => f.type === "cdpEvent")
-          .map((f) => f.method),
-      ).toEqual(["Runtime.executionContextsCleared", "Page.frameNavigated", "Page.lifecycleEvent"]);
-      expect(h.tabsRemove).not.toHaveBeenCalled();
-    },
-  );
+      return blankResult;
+    });
+    expect(await h.navigate()).toMatchObject({ type: "result" });
+    expect(await h.request({ type: "closeTab", tabId: 7 })).toMatchObject({ type: "result" });
+    expect(h.tabsRemove).toHaveBeenCalledExactlyOnceWith(7);
+  });
 
   it.each([
     { pendingUrl: "https://example.com/next", response: "result" },
@@ -227,7 +147,7 @@ describe("commanded existing document navigation", () => {
   ])(
     "revalidates Selected pending $pendingUrl between response lookups",
     async ({ pendingUrl, response }) => {
-      const h = await setup("selected");
+      const h = await setup();
       h.native(async () => {
         h.commitBlank();
         const get = h.tabsGet.getMockImplementation()!;
@@ -243,361 +163,113 @@ describe("commanded existing document navigation", () => {
     },
   );
 
-  it.each([
-    "wrong frame",
-    "wrong loader",
-    "aborted",
-    "download",
-    "rejected",
-    "competing commit",
-  ] as const)("discards early events after native %s", async (failure) => {
-    const h = await setup("all");
+  it("never mints selected access from an unowned or child blank", async () => {
+    const h = await setup();
+    h.native(async () => blankResult);
+    expect(await h.navigate({ url: "about:blank", frameId: "child" })).toMatchObject({
+      type: "result",
+    });
+    expect(
+      await h.request({
+        type: "cdp",
+        tabId: 7,
+        sessionId: "child-session",
+        method: "Page.navigate",
+        params: { url: "about:blank" },
+      }),
+    ).toMatchObject({ type: "result" });
+    h.updateTab(7, { url: "about:blank" });
+    expect(
+      await h.request({ type: "cdp", tabId: 7, method: "Tracing.start", authorized: true }),
+    ).toMatchObject({ type: "error" });
+    expect(
+      await h.request({
+        type: "cdp",
+        tabId: 8,
+        method: "Page.navigate",
+        params: { url: "about:blank" },
+      }),
+    ).toMatchObject({ type: "error" });
+    expect(h.tabsRemove).not.toHaveBeenCalled();
+  });
+
+  it("fences a selected reconnect before response without deleting or restoring the tab", async () => {
+    const h = await setup();
+    const result = createDeferred<Record<string, unknown>>();
+    releases.push(() => result.resolve(blankResult));
     h.native(async () => {
       h.commitBlank();
-      if (failure === "rejected") {
-        throw new Error("native failure");
-      }
-      if (failure === "competing commit") {
-        h.updateTab(7, { url: originalUrl });
-        h.emit("Page.frameNavigated", {
-          frame: { id: "root", loaderId: "competitor", url: originalUrl },
-        });
-      }
-      return {
-        ...blankResult,
-        ...(failure === "wrong frame" ? { frameId: "child" } : {}),
-        ...(failure === "wrong loader" ? { loaderId: "other" } : {}),
-        ...(failure === "aborted" ? { errorText: "net::ERR_ABORTED" } : {}),
-        ...(failure === "download" ? { isDownload: true } : {}),
-      };
+      return await result.promise;
     });
+    const navigating = h.navigate();
+    await vi.waitFor(() => expect(h.debuggerSendCommand.mock.calls.length).toBe(2));
     h.socket.send.mockClear();
-    expect(await h.navigate()).toMatchObject({ type: "error" });
-    expect(h.frames().filter((f) => f.type === "cdpEvent")).toEqual([]);
-    h.updateTab(7, { url: "about:blank" });
-    expect(await h.request({ type: "attach", tabId: 7 })).toMatchObject({ type: "error" });
+    h.socket.close();
+    h.alarmListener({ name: "openclaw-relay-watchdog" });
+    await vi.waitFor(() => expect(h.relaySockets).toHaveLength(2));
+    const replacement = h.relaySockets[1];
+    assert(replacement);
+    await h.authenticate(replacement);
+    replacement.receive({ type: "attach", tabId: 7, seq: 9001 });
+    await vi.waitFor(() =>
+      expect(replacement.send.mock.calls.map(([raw]) => JSON.parse(raw))).toContainEqual(
+        expect.objectContaining({ type: "error", seq: 9001 }),
+      ),
+    );
+    h.emit("Tracing.tracingComplete", { stream: "revoked-stream" });
+    result.resolve(blankResult);
+    // Closed sockets intentionally cannot receive the old response.
+    await expect(navigating).rejects.toThrow();
+    expect(h.frames().some((f) => f.type === "cdpEvent")).toBe(false);
+    expect(await sendRuntimeMessage(h, { type: "getTabAccess", tabId: 7 })).toMatchObject({
+      accessible: false,
+    });
     expect(h.tabsRemove).not.toHaveBeenCalled();
     expect(h.tabsUpdate).not.toHaveBeenCalled();
   });
-
-  it.each(["all", "selected"] as const)(
-    "never mints %s access from an unowned or child blank",
-    async (mode) => {
-      const h = await setup(mode);
-      h.native(async () => blankResult);
-      expect(await h.navigate({ url: "about:blank", frameId: "child" })).toMatchObject({
-        type: "result",
-      });
-      expect(
-        await h.request({
-          type: "cdp",
-          tabId: 7,
-          sessionId: "child-session",
-          method: "Page.navigate",
-          params: { url: "about:blank" },
-        }),
-      ).toMatchObject({ type: "result" });
-      h.updateTab(7, { url: "about:blank" });
-      expect(
-        await h.request({ type: "cdp", tabId: 7, method: "Tracing.start", authorized: true }),
-      ).toMatchObject({ type: "error" });
-      expect(
-        await h.request({
-          type: "cdp",
-          tabId: 8,
-          method: "Page.navigate",
-          params: { url: "about:blank" },
-        }),
-      ).toMatchObject({ type: "error" });
-      expect(h.tabsRemove).not.toHaveBeenCalled();
-    },
-  );
-
-  it.each(["child frame", "child session", "wrong root"] as const)(
-    "does not accept a %s commit as root proof",
-    async (source) => {
-      const h = await setup("all");
-      h.native(async () => {
-        h.updateTab(7, { url: "about:blank" });
-        h.debuggerEventListener?.(
-          { tabId: 7, ...(source === "child session" ? { sessionId: "child" } : {}) },
-          "Page.frameNavigated",
-          {
-            frame: {
-              id: source === "wrong root" ? "other" : "root",
-              loaderId: "blank-loader",
-              url: "about:blank",
-              ...(source === "child frame" ? { parentId: "parent" } : {}),
-            },
-          },
-        );
-        return blankResult;
-      });
-      await h.navigate();
-      expect(await h.request({ type: "cdp", tabId: 7, method: "Tracing.start" })).toMatchObject({
-        type: "error",
-      });
-      expect(h.frames().some((f) => f.type === "cdpEvent")).toBe(false);
-    },
-  );
-
-  it.each(
-    (["all", "selected"] as const).flatMap((mode) =>
-      (["before response", "while blank"] as const).flatMap((phase) =>
-        ["pause", "mode", "remove", "replace", "detach", "unpair", "reconnect"].map((reason) => ({
-          mode,
-          phase,
-          reason,
-        })),
-      ),
-    ),
-  )(
-    "fences $mode $reason $phase without deleting the existing tab",
-    async ({ mode, phase, reason }) => {
-      const h = await setup(mode);
-      const result = createDeferred<Record<string, unknown>>();
-      releases.push(() => result.resolve(blankResult));
-      h.native(async () => {
-        h.commitBlank();
-        return phase === "before response" ? await result.promise : blankResult;
-      });
-      const navigating = h.navigate();
-      await vi.waitFor(() => expect(h.debuggerSendCommand.mock.calls.length).toBe(2));
-      if (phase === "while blank") {
-        expect(await navigating).toMatchObject({ type: "result" });
-      }
-      h.socket.send.mockClear();
-      if (reason === "pause") {
-        expect(
-          await sendRuntimeMessage(h, {
-            type: "toggleTabAccess",
-            accessMode: mode,
-            tabId: 7,
-            grant: false,
-          }),
-        ).toMatchObject({ ok: true, accessible: false });
-        if (mode === "all") {
-          expect(h.sessionStorageValues.deniedTabIdsV1).toEqual([7]);
-        }
-      } else if (reason === "mode") {
-        await sendRuntimeMessage(h, {
-          type: "setAccessMode",
-          accessMode: mode === "all" ? "selected" : "all",
-        });
-      } else if (reason === "remove") {
-        h.tabsRemovedListener?.(7);
-      } else if (reason === "replace") {
-        h.tabsReplacedListener(9, 7);
-      } else if (reason === "detach") {
-        await h.request({ type: "detach", tabId: 7 });
-      } else if (reason === "unpair") {
-        await sendRuntimeMessage(h, { type: "unpair" });
-      } else {
-        h.socket.close();
-        h.alarmListener({ name: "openclaw-relay-watchdog" });
-        await vi.waitFor(() => expect(h.relaySockets).toHaveLength(2));
-        const replacement = h.relaySockets[1];
-        assert(replacement);
-        await h.authenticate(replacement);
-        replacement.receive({ type: "attach", tabId: 7, seq: 9001 });
-        await vi.waitFor(() =>
-          expect(replacement.send.mock.calls.map(([raw]) => JSON.parse(raw))).toContainEqual(
-            expect.objectContaining({ type: "error", seq: 9001 }),
-          ),
-        );
-      }
-      h.emit("Tracing.tracingComplete", { stream: "revoked-stream" });
-      result.resolve(blankResult);
-      if (reason === "unpair" || reason === "reconnect") {
-        // Closed sockets intentionally cannot receive the old response.
-        if (phase === "before response") {
-          await expect(navigating).rejects.toThrow();
-        }
-      } else if (phase === "before response") {
-        expect(await navigating).toMatchObject({ type: "error" });
-      }
-      expect(h.frames().some((f) => f.type === "cdpEvent")).toBe(false);
-      expect(await sendRuntimeMessage(h, { type: "getTabAccess", tabId: 7 })).toMatchObject({
-        accessible: false,
-      });
-      expect(h.tabsRemove).not.toHaveBeenCalled();
-      expect(h.tabsUpdate).not.toHaveBeenCalled();
-    },
-  );
-  it.each(
-    (["all", "selected"] as const).flatMap((mode) =>
-      [
-        "group move",
-        "group rename",
-        "group removal",
-        "window move",
-        "incognito",
-        "file pending",
-        "internal pending",
-        "lookalike blank",
-        "user blank",
-      ].map((change) => ({ mode, change })),
-    ),
-  )("retires $mode controlled blank on $change", async ({ mode, change }) => {
-    const h = await setup(mode);
+  it("does not restore selected navigation provenance after worker restart", async () => {
+    const h = await setup();
     h.native(async () => {
       h.commitBlank();
       return blankResult;
     });
     expect(await h.navigate()).toMatchObject({ type: "result" });
-    h.socket.send.mockClear();
-    if (change === "group move") {
-      h.updateTab(7, { groupId: -1 });
-    } else if (change === "group rename") {
-      h.tabGroupUpdatedListener?.({ id: 7, title: "Other" });
-    } else if (change === "group removal") {
-      h.tabGroupRemovedListener?.({ id: 7 });
-    } else if (change === "window move") {
-      h.updateTab(7, { windowId: 2 });
-    } else if (change === "incognito") {
-      h.updateTab(7, { incognito: true });
-    } else if (change === "file pending") {
-      h.updateTab(7, { pendingUrl: "file:///tmp/fixture" });
-    } else if (change === "internal pending") {
-      h.updateTab(7, { pendingUrl: "chrome://settings" });
-    } else if (change === "lookalike blank") {
-      h.updateTab(7, { url: "about:blank#other" });
-    } else {
-      h.emit("Page.frameNavigated", {
-        frame: { id: "root", loaderId: "user", url: "about:blank" },
-      });
-    }
-    h.emit("Runtime.consoleAPICalled", { value: "revoked" });
-    expect(await h.request({ type: "cdp", tabId: 7, method: "Tracing.start" })).toMatchObject({
-      type: "error",
+    const initialTabs = await h.tabsQuery();
+    const storedConfig = { ...h.storageValues };
+    const sessionConfig = { ...h.sessionStorageValues };
+    await cleanupBackgroundHarnesses();
+    vi.resetModules();
+    const restarted = await loadBackground({ initialTabs, storedConfig, sessionConfig });
+    const socket = restarted.relaySockets[0];
+    assert(socket);
+    await restarted.authenticate(socket);
+    expect(await sendRuntimeMessage(restarted, { type: "getTabAccess", tabId: 7 })).toMatchObject({
+      accessible: false,
     });
-    expect(h.frames().some((f) => f.type === "cdpEvent")).toBe(false);
+    expect(restarted.tabsRemove).not.toHaveBeenCalled();
+  });
+  it("discards a stale selected discovery snapshot of the source before consuming blank provenance", async () => {
+    const h = await setup();
+    h.native(async () => {
+      h.commitBlank();
+      return blankResult;
+    });
+    const staleTabs = await h.tabsQuery();
+    const lookup = createDeferred<typeof staleTabs>();
+    releases.push(() => lookup.resolve(staleTabs));
+    let inspecting = false;
+    h.tabsQuery.mockImplementationOnce(async () => {
+      inspecting = true;
+      return await lookup.promise;
+    });
+    const status = sendRuntimeMessage(h, { type: "getStatus" });
+    await vi.waitFor(() => expect(inspecting).toBe(true));
+    expect(await h.navigate()).toMatchObject({ type: "result" });
+    lookup.resolve(staleTabs);
+    expect(await status).toMatchObject({ accessibleTabCount: 1 });
+    expect(await h.request({ type: "cdp", tabId: 7, method: "Tracing.start" })).toMatchObject({
+      type: "result",
+    });
     expect(h.tabsRemove).not.toHaveBeenCalled();
   });
-
-  it.each(["root commit", "detach and reattach", "pause and allow"] as const)(
-    "rejects a preflight overtaken by %s",
-    async (change) => {
-      const h = await setup("all");
-      const tree = createDeferred<Record<string, unknown>>();
-      releases.push(() => tree.resolve({}));
-      h.debuggerSendCommand.mockImplementationOnce(async () => await tree.promise);
-      const navigating = h.navigate();
-      await vi.waitFor(() => expect(h.debuggerSendCommand).toHaveBeenCalledOnce());
-      if (change === "root commit") {
-        h.emit("Page.frameNavigated", {
-          frame: { id: "root", loaderId: "new-source", url: originalUrl },
-        });
-      } else if (change === "detach and reattach") {
-        await h.request({ type: "detach", tabId: 7 });
-        expect(await h.request({ type: "attach", tabId: 7 })).toMatchObject({ type: "result" });
-      } else {
-        for (const grant of [false, true]) {
-          await sendRuntimeMessage(h, {
-            type: "toggleTabAccess",
-            accessMode: "all",
-            tabId: 7,
-            grant,
-          });
-        }
-      }
-      tree.resolve({
-        frameTree: { frame: { id: "root", loaderId: "original", url: originalUrl } },
-      });
-      expect(await navigating).toMatchObject({ type: "error" });
-      expect(h.debuggerSendCommand).toHaveBeenCalledOnce();
-      expect(h.tabsRemove).not.toHaveBeenCalled();
-    },
-  );
-
-  it.each(["event count", "event bytes"])(
-    "discards an over-budget native buffer by %s",
-    async (limit) => {
-      const h = await setup("all");
-      h.native(async () => {
-        h.commitBlank();
-        if (limit === "event bytes") {
-          h.emit("Runtime.consoleAPICalled", { value: "x".repeat(256 * 1024) });
-        } else {
-          for (let index = 0; index < 128; index++) {
-            h.emit("Runtime.executionContextCreated", { context: { id: index } });
-          }
-        }
-        return blankResult;
-      });
-      h.socket.send.mockClear();
-      expect(await h.navigate()).toMatchObject({ type: "error" });
-      expect(h.frames().some((f) => f.type === "cdpEvent")).toBe(false);
-      expect(h.tabsRemove).not.toHaveBeenCalled();
-    },
-  );
-
-  it.each(["all", "selected"] as const)(
-    "does not restore %s navigation provenance after worker restart",
-    async (mode) => {
-      const h = await setup(mode);
-      h.native(async () => {
-        h.commitBlank();
-        return blankResult;
-      });
-      expect(await h.navigate()).toMatchObject({ type: "result" });
-      const initialTabs = await h.tabsQuery();
-      const storedConfig = { ...h.storageValues };
-      const sessionConfig = { ...h.sessionStorageValues };
-      await cleanupBackgroundHarnesses();
-      vi.resetModules();
-      const restarted = await loadBackground({ initialTabs, storedConfig, sessionConfig });
-      const socket = restarted.relaySockets[0];
-      assert(socket);
-      await restarted.authenticate(socket);
-      expect(await sendRuntimeMessage(restarted, { type: "getTabAccess", tabId: 7 })).toMatchObject(
-        { accessible: false },
-      );
-      expect(restarted.tabsRemove).not.toHaveBeenCalled();
-    },
-  );
-  it.each(
-    (["all", "selected"] as const).flatMap((mode) =>
-      (["source before blank", "blank before return"] as const).map((snapshot) => ({
-        mode,
-        snapshot,
-      })),
-    ),
-  )(
-    "discards a stale $mode discovery snapshot of $snapshot before consuming provenance",
-    async ({ mode, snapshot }) => {
-      const h = await setup(mode);
-      h.native(async () => {
-        h.commitBlank();
-        return blankResult;
-      });
-      if (snapshot === "blank before return") {
-        expect(await h.navigate()).toMatchObject({ type: "result" });
-      }
-      const staleTabs = await h.tabsQuery();
-      const lookup = createDeferred<typeof staleTabs>();
-      releases.push(() => lookup.resolve(staleTabs));
-      let inspecting = false;
-      h.tabsQuery.mockImplementationOnce(async () => {
-        inspecting = true;
-        return await lookup.promise;
-      });
-      const status = sendRuntimeMessage(h, { type: "getStatus" });
-      await vi.waitFor(() => expect(inspecting).toBe(true));
-      if (snapshot === "source before blank") {
-        expect(await h.navigate()).toMatchObject({ type: "result" });
-      } else {
-        h.updateTab(7, { url: originalUrl }, false);
-        h.emit("Page.frameNavigated", {
-          frame: { id: "root", loaderId: "return", url: originalUrl },
-        });
-      }
-      lookup.resolve(staleTabs);
-      expect(await status).toMatchObject({ accessibleTabCount: 1 });
-      expect(await h.request({ type: "cdp", tabId: 7, method: "Tracing.start" })).toMatchObject({
-        type: "result",
-      });
-      expect(h.tabsRemove).not.toHaveBeenCalled();
-    },
-  );
 });

--- a/extensions/browser/chrome-extension/modules/relay-command-handler.test.ts
+++ b/extensions/browser/chrome-extension/modules/relay-command-handler.test.ts
@@ -1,3 +1,4 @@
+import assert from "node:assert/strict";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createRelayCommandHandler } from "./relay-command-handler.js";
 
@@ -5,6 +6,9 @@ function createHarness() {
   const send = vi.fn();
   const epoch = { revision: 1, tabRevision: 2 };
   const requireAccessibleTab = vi.fn(async () => ({ id: 7, windowId: 3 }));
+  const requireNavigatedTab = vi.fn(async () => ({ id: 7, windowId: 3 }));
+  const navigateTab = vi.fn(async () => ({ frameId: "root", loaderId: "blank-loader" }));
+  const detachDebugger = vi.fn(async () => undefined);
   const focusWindowForTab = vi.fn(async () => undefined);
   const chromeMock = {
     debugger: { sendCommand: vi.fn(async () => ({ value: 1 })) },
@@ -19,21 +23,24 @@ function createHarness() {
     send,
     isCurrent: () => true,
     attachDebugger: vi.fn(),
-    detachDebugger: vi.fn(async () => undefined),
+    detachDebugger,
     createTab: vi.fn(),
     scheduleTabsSync: vi.fn(),
     focusWindowForTab,
     captureAccess: vi.fn(() => epoch),
-    navigateTab: vi.fn(),
+    navigateTab,
     requireAccessibleTab,
-    requireNavigatedTab: requireAccessibleTab,
+    requireNavigatedTab,
   });
   return {
     chromeMock,
+    detachDebugger,
     epoch,
     focusWindowForTab,
     handler: (message: Record<string, unknown>) => handler(message),
+    navigateTab,
     requireAccessibleTab,
+    requireNavigatedTab,
     send,
   };
 }
@@ -41,14 +48,100 @@ function createHarness() {
 afterEach(() => vi.unstubAllGlobals());
 
 describe("relay authority rechecks", () => {
-  it("checks access before and after an async CDP command", async () => {
+  it.each([
+    { name: "evaluation", method: "Runtime.evaluate", params: undefined, sessionId: undefined },
+    {
+      name: "nonblank navigation",
+      method: "Page.navigate",
+      params: { url: "https://example.com" },
+      sessionId: undefined,
+    },
+    {
+      name: "blank fragment navigation",
+      method: "Page.navigate",
+      params: { url: "about:blank#other" },
+      sessionId: undefined,
+    },
+    {
+      name: "child-session blank navigation",
+      method: "Page.navigate",
+      params: { url: "about:blank" },
+      sessionId: "child",
+    },
+    { name: "reload", method: "Page.reload", params: {}, sessionId: undefined },
+    {
+      name: "history navigation",
+      method: "Page.navigateToHistoryEntry",
+      params: { entryId: 9 },
+      sessionId: undefined,
+    },
+  ])("checks ordinary access around native $name", async ({ method, params, sessionId }) => {
     const harness = createHarness();
-    await harness.handler({ type: "cdp", seq: 1, tabId: 7, method: "Runtime.evaluate" });
+    await harness.handler({ type: "cdp", seq: 1, tabId: 7, method, params, sessionId });
+    expect(harness.chromeMock.debugger.sendCommand).toHaveBeenCalledExactlyOnceWith(
+      sessionId ? { tabId: 7, sessionId } : { tabId: 7 },
+      method,
+      params ?? {},
+    );
     expect(harness.requireAccessibleTab.mock.calls).toEqual([
       [7, harness.epoch],
       [7, harness.epoch],
     ]);
+    const [beforeCommand, afterCommand] = harness.requireAccessibleTab.mock.invocationCallOrder;
+    const [command] = harness.chromeMock.debugger.sendCommand.mock.invocationCallOrder;
+    assert(beforeCommand !== undefined && command !== undefined && afterCommand !== undefined);
+    expect(beforeCommand).toBeLessThan(command);
+    expect(command).toBeLessThan(afterCommand);
+    expect(harness.navigateTab).not.toHaveBeenCalled();
+    expect(harness.requireNavigatedTab).not.toHaveBeenCalled();
     expect(harness.send).toHaveBeenCalledWith({ type: "result", seq: 1, result: { value: 1 } });
+  });
+
+  it("routes root sessionless literal blank navigation through provenance and its post-check", async () => {
+    const harness = createHarness();
+    const params = { url: "about:blank", frameId: "root" };
+    await harness.handler({ type: "cdp", seq: 5, tabId: 7, method: "Page.navigate", params });
+    expect(harness.requireAccessibleTab).toHaveBeenCalledExactlyOnceWith(7, harness.epoch);
+    expect(harness.navigateTab).toHaveBeenCalledExactlyOnceWith(
+      7,
+      harness.epoch,
+      params,
+      expect.any(Function),
+      expect.any(Function),
+    );
+    expect(harness.requireNavigatedTab).toHaveBeenCalledExactlyOnceWith(7, harness.epoch);
+    const [beforeNavigation] = harness.requireAccessibleTab.mock.invocationCallOrder;
+    const [navigation] = harness.navigateTab.mock.invocationCallOrder;
+    const [afterNavigation] = harness.requireNavigatedTab.mock.invocationCallOrder;
+    assert(
+      beforeNavigation !== undefined && navigation !== undefined && afterNavigation !== undefined,
+    );
+    expect(beforeNavigation).toBeLessThan(navigation);
+    expect(navigation).toBeLessThan(afterNavigation);
+    expect(harness.chromeMock.debugger.sendCommand).not.toHaveBeenCalled();
+    expect(harness.send).toHaveBeenCalledWith({
+      type: "result",
+      seq: 5,
+      result: { frameId: "root", loaderId: "blank-loader" },
+    });
+  });
+
+  it("reports a revoked navigated-tab post-check instead of a successful native result", async () => {
+    const harness = createHarness();
+    harness.requireNavigatedTab.mockRejectedValueOnce(new Error("tab 7 navigation was revoked"));
+    await harness.handler({
+      type: "cdp",
+      seq: 6,
+      tabId: 7,
+      method: "Page.navigate",
+      params: { url: "about:blank" },
+    });
+    expect(harness.navigateTab).toHaveBeenCalledOnce();
+    expect(harness.send).toHaveBeenCalledExactlyOnceWith({
+      type: "error",
+      seq: 6,
+      message: "tab 7 navigation was revoked",
+    });
   });
 
   it("checks access around tab activation and window focus", async () => {
@@ -64,6 +157,7 @@ describe("relay authority rechecks", () => {
     await harness.handler({ type: "closeTab", seq: 3, tabId: 7 });
     expect(harness.requireAccessibleTab).toHaveBeenCalledExactlyOnceWith(7, harness.epoch);
     expect(harness.chromeMock.tabs.remove).toHaveBeenCalledWith(7);
+    expect(harness.detachDebugger).not.toHaveBeenCalled();
     expect(harness.send).toHaveBeenCalledWith({ type: "result", seq: 3, result: {} });
   });
 

--- a/extensions/browser/chrome-extension/modules/tab-access-events.navigation.test.ts
+++ b/extensions/browser/chrome-extension/modules/tab-access-events.navigation.test.ts
@@ -26,12 +26,16 @@ const navigationEvents = [
 
 async function createNavigationHarness(
   mode: TabAccessMode,
-  { fileAccessAllowed = true, proveAttachment = true } = {},
+  {
+    fileAccessAllowed = true,
+    proveAttachment = true,
+    groupId = mode === "selected" ? 11 : -1,
+  } = {},
 ) {
   let tab: BrowserTabSnapshot = {
     id: 7,
     url: "https://source.example/",
-    groupId: mode === "selected" ? 11 : -1,
+    groupId,
     incognito: false,
   };
   const chromeApi = {
@@ -45,12 +49,15 @@ async function createNavigationHarness(
     },
     tabs: {
       get: vi.fn(async (_tabId: number) => tab),
-      query: async () => [tab],
+      query: vi.fn(async () => [tab]),
       onUpdated: chromeEvent<[number, { groupId?: number; url?: string }, BrowserTabSnapshot]>(),
       onRemoved: chromeEvent<[number]>(),
       onReplaced: chromeEvent<[number, number]>(),
     },
-    tabGroups: { onUpdated: chromeEvent<[]>(), onRemoved: chromeEvent<[]>() },
+    tabGroups: {
+      onUpdated: chromeEvent<[group?: { id: number; title?: string }]>(),
+      onRemoved: chromeEvent<[group?: { id: number; title?: string }]>(),
+    },
     debugger: {
       onEvent: chromeEvent<[{ tabId?: number; sessionId?: string }, string, unknown]>(),
       onDetach: chromeEvent<[{ tabId?: number }, string]>(),
@@ -93,6 +100,31 @@ async function createNavigationHarness(
     attachedAccessEpochs,
     send,
     detachDebugger,
+    setTab(update: Partial<BrowserTabSnapshot>) {
+      tab = { ...tab, ...update };
+    },
+    async controlBlank() {
+      const epoch = policy.capture(7, "Page.navigate");
+      await policy.requireTab(7, epoch);
+      await policy.navigateTab(
+        7,
+        epoch,
+        { url: "about:blank" },
+        () => attachedAccessEpochs.get(7),
+        () => true,
+        async (method) => {
+          if (method === "Page.getFrameTree") {
+            return { frameTree: { frame: { id: "root", url: tab.url } } };
+          }
+          tab = { ...tab, url: "about:blank" };
+          chromeApi.debugger.onEvent.emit({ tabId: 7 }, "Page.frameNavigated", {
+            frame: { id: "root", loaderId: "blank", url: tab.url },
+          });
+          return { frameId: "root", loaderId: "blank" };
+        },
+      );
+      await expect(policy.requireTab(7)).resolves.toMatchObject({ url: "about:blank" });
+    },
     update(update: Partial<BrowserTabSnapshot>) {
       tab = { ...tab, ...update };
       chromeApi.tabs.onUpdated.emit(7, { url: tab.url }, tab);
@@ -119,6 +151,152 @@ async function createNavigationHarness(
 }
 
 describe("Chrome navigation event access", () => {
+  it("projects native child session ids only while the attachment epoch is current", async () => {
+    const harness = await createNavigationHarness("selected");
+    const params = { frame: { id: "child", loaderId: "child-loader", url: "about:blank" } };
+    for (const source of [{ tabId: 7 }, { tabId: 7, sessionId: "child-session" }]) {
+      harness.chromeApi.debugger.onEvent.emit(source, "Page.frameNavigated", params);
+    }
+    expect(harness.send.mock.calls.map(([event]) => event)).toEqual([
+      { type: "cdpEvent", tabId: 7, method: "Page.frameNavigated", params },
+      {
+        type: "cdpEvent",
+        tabId: 7,
+        sessionId: "child-session",
+        method: "Page.frameNavigated",
+        params,
+      },
+    ]);
+    harness.send.mockClear();
+    harness.policy.invalidateTab(7);
+    harness.chromeApi.debugger.onEvent.emit({ tabId: 7 }, "Page.frameNavigated", params);
+    harness.chromeApi.debugger.onEvent.emit(
+      { tabId: 7, sessionId: "child-session" },
+      "Page.frameNavigated",
+      params,
+    );
+    expect(harness.send).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    "pause",
+    "mode change",
+    "disable",
+    "transition",
+    "remove",
+    "replace",
+    "detach",
+    "group rename",
+    "group removal",
+  ])("retires controlled blank authority on %s without reauthorizing it", async (reason) => {
+    const harness = await createNavigationHarness("all", { groupId: 11 });
+    await harness.controlBlank();
+    switch (reason) {
+      case "pause":
+        await harness.policy.pause(7);
+        expect(harness.policy.isDenied(7)).toBe(true);
+        await harness.policy.allow(7);
+        break;
+      case "mode change":
+        harness.policy.setMode("selected");
+        harness.policy.setMode("all");
+        break;
+      case "disable":
+        harness.policy.setEnabled(false);
+        harness.policy.setEnabled(true);
+        break;
+      case "transition":
+        harness.policy.beginTransition();
+        harness.policy.endTransition();
+        break;
+      case "remove":
+        harness.chromeApi.tabs.onRemoved.emit(7);
+        break;
+      case "replace":
+        harness.chromeApi.tabs.onReplaced.emit(8, 7);
+        break;
+      case "detach":
+        harness.chromeApi.debugger.onDetach.emit({ tabId: 7 }, "target_closed");
+        break;
+      case "group rename":
+        harness.chromeApi.tabGroups.onUpdated.emit({ id: 12, title: "Other" });
+        await expect(harness.policy.requireTab(7)).resolves.toMatchObject({ url: "about:blank" });
+        harness.chromeApi.tabGroups.onUpdated.emit({ id: 11, title: "Other" });
+        break;
+      case "group removal":
+        harness.chromeApi.tabGroups.onRemoved.emit({ id: 12 });
+        await expect(harness.policy.requireTab(7)).resolves.toMatchObject({ url: "about:blank" });
+        harness.chromeApi.tabGroups.onRemoved.emit({ id: 11 });
+        break;
+    }
+    harness.send.mockClear();
+    harness.emitNavigation();
+    await expect(harness.policy.requireTab(7)).rejects.toThrow(
+      reason === "remove" || reason === "replace"
+        ? "access was revoked"
+        : "restricted or unavailable",
+    );
+    await expect(harness.policy.requireTab(7)).rejects.toThrow("restricted or unavailable");
+    expect(harness.send).not.toHaveBeenCalled();
+  });
+
+  it.each(["source before blank", "blank before return"])(
+    "discards a stale selected discovery snapshot of %s before consuming provenance",
+    async (snapshot) => {
+      const harness = await createNavigationHarness("selected");
+      if (snapshot === "blank before return") {
+        await harness.controlBlank();
+      }
+      const stale = await harness.chromeApi.tabs.query();
+      let release = (_tabs: BrowserTabSnapshot[]) => {};
+      const lookup = new Promise<BrowserTabSnapshot[]>((resolve) => {
+        release = resolve;
+      });
+      let queried = () => {};
+      const started = new Promise<void>((resolve) => {
+        queried = resolve;
+      });
+      harness.chromeApi.tabs.query.mockImplementationOnce(() => {
+        queried();
+        return lookup;
+      });
+      const discovering = harness.policy.listAccessibleTabs();
+      await started;
+      try {
+        if (snapshot === "source before blank") {
+          await harness.controlBlank();
+        } else {
+          harness.setTab({ url: "https://return.example/" });
+          harness.chromeApi.debugger.onEvent.emit({ tabId: 7 }, "Page.frameNavigated", {
+            frame: { id: "root", loaderId: "return", url: "https://return.example/" },
+          });
+        }
+      } finally {
+        release(stale);
+      }
+      const url = snapshot === "source before blank" ? "about:blank" : "https://return.example/";
+      await expect(discovering).resolves.toEqual([expect.objectContaining({ id: 7, url })]);
+      await expect(harness.policy.requireTab(7)).resolves.toMatchObject({ id: 7, url });
+    },
+  );
+
+  it("rereads a selected lookup overtaken by a native root commit before checking provenance", async () => {
+    const harness = await createNavigationHarness("selected");
+    await harness.controlBlank();
+    const get = harness.chromeApi.tabs.get.getMockImplementation()!;
+    harness.chromeApi.tabs.get.mockImplementationOnce(async (tabId) => {
+      const stale = await get(tabId);
+      harness.setTab({ url: "https://return.example/" });
+      harness.chromeApi.debugger.onEvent.emit({ tabId: 7 }, "Page.frameNavigated", {
+        frame: { id: "root", loaderId: "return", url: "https://return.example/" },
+      });
+      return stale;
+    });
+    await expect(harness.policy.requireTab(7)).resolves.toMatchObject({
+      url: "https://return.example/",
+    });
+  });
+
   it.each(
     (["all", "selected"] as const).flatMap((mode) =>
       [

--- a/extensions/browser/chrome-extension/modules/tab-document-provenance.test.ts
+++ b/extensions/browser/chrome-extension/modules/tab-document-provenance.test.ts
@@ -1,0 +1,432 @@
+import assert from "node:assert/strict";
+import { describe, expect, it, vi } from "vitest";
+import type { TabAccessEpoch, TabAccessPolicy } from "./tab-access.js";
+import type { BrowserTabSnapshot } from "./tab-eligibility.js";
+
+type TabDocumentNavigation = {
+  readonly confirmed: boolean;
+  observe(event: Record<string, unknown>, send: (event: Record<string, unknown>) => void): void;
+  accept(result: unknown): void;
+};
+
+type TabDocumentAccess = {
+  readonly fileAccessAllowed: boolean;
+  invalidateTab(tabId: number): void;
+  requireTab(
+    tabId: number,
+    epoch: TabAccessEpoch,
+    afterNavigation?: boolean,
+  ): Promise<BrowserTabSnapshot>;
+  provenTabIsCurrent(tabId: number, epoch: TabAccessEpoch): boolean;
+  recordRootCommit(tabId: number, url: string): void;
+};
+
+type TabDocumentProvenance = Pick<TabAccessPolicy, "forwardDocumentEvent" | "navigateTab"> & {
+  get(tabId: number): { navigation: TabDocumentNavigation } | undefined;
+  rootRevision(tabId: number): number;
+  observeTab(tab: BrowserTabSnapshot | undefined): void;
+  revokeDocument(tabId: number): void;
+  retireAttachment: TabAccessPolicy["retireTabDocument"];
+  invalidateAll(): void;
+  invalidateGroup: TabAccessPolicy["invalidateDocumentGroup"];
+};
+
+type TabDocumentProvenanceModule = {
+  createTabDocumentProvenance: (options: { access: TabDocumentAccess }) => TabDocumentProvenance;
+};
+
+// Browser-serialized modules remain plain JavaScript. Keep test-only typing local
+// so direct owner coverage does not alter the packaged resolution topology.
+const { createTabDocumentProvenance } = await vi.importActual<TabDocumentProvenanceModule>(
+  "./tab-document-provenance.js",
+);
+
+const originalUrl = "https://example.com/existing";
+const blankResult = { frameId: "root", loaderId: "blank-loader" };
+const blankFrame = { id: "root", loaderId: "blank-loader", url: "about:blank" };
+const frameEvent = (frame = blankFrame, sessionId?: string) => ({
+  type: "cdpEvent",
+  tabId: 7,
+  ...(sessionId ? { sessionId } : {}),
+  method: "Page.frameNavigated",
+  params: { frame },
+});
+const contextEvent = {
+  type: "cdpEvent",
+  tabId: 7,
+  method: "Runtime.executionContextsCleared",
+  params: {},
+};
+
+function createHarness() {
+  const epoch: TabAccessEpoch = { revision: 1, tabRevision: 1 };
+  const attachmentEpoch: TabAccessEpoch = { revision: 1, tabRevision: 2 };
+  const proven = new Set([epoch, attachmentEpoch]);
+  const isAttached = vi.fn<() => TabAccessEpoch | undefined>(() => attachmentEpoch);
+  const isCurrent = vi.fn(() => true);
+  const tab: BrowserTabSnapshot = { id: 7, url: originalUrl, groupId: 7, windowId: 1 };
+  const access = {
+    fileAccessAllowed: false,
+    provenTabIsCurrent: (tabId: number, candidate: TabAccessEpoch) =>
+      tabId === 7 && proven.has(candidate),
+    requireTab: vi.fn(async () => tab),
+    recordRootCommit: vi.fn(),
+    invalidateTab: vi.fn((tabId: number) => {
+      proven.clear();
+      documents.revokeDocument(tabId);
+    }),
+  } satisfies TabDocumentAccess;
+  const documents = createTabDocumentProvenance({ access });
+  const send = vi.fn();
+  const tree = { frameTree: { frame: { id: "root", loaderId: "original", url: originalUrl } } };
+  const sendCommand = vi.fn(
+    async (_method: string, _params: Record<string, unknown>): Promise<unknown> => tree,
+  );
+  const emit = (event: Record<string, unknown>) => documents.forwardDocumentEvent(event, send);
+  const commitBlank = () => {
+    tab.url = "about:blank";
+    documents.observeTab(tab);
+    emit(contextEvent);
+    emit(frameEvent());
+  };
+  const navigate = (
+    native = async (): Promise<unknown> => blankResult,
+    params = { url: "about:blank", frameId: "root" },
+  ) => {
+    sendCommand.mockImplementation(async (method) =>
+      method === "Page.getFrameTree" ? tree : await native(),
+    );
+    return documents.navigateTab(7, epoch, params, isAttached, isCurrent, sendCommand);
+  };
+  return {
+    documents,
+    access,
+    epoch,
+    attachmentEpoch,
+    proven,
+    isAttached,
+    isCurrent,
+    tab,
+    tree,
+    send,
+    sendCommand,
+    emit,
+    commitBlank,
+    navigate,
+  };
+}
+
+describe("commanded tab document provenance", () => {
+  it.each(["before response", "after response"])(
+    "flushes ordered native events only when the root commits %s",
+    async (order) => {
+      const h = createHarness();
+      h.tab.url += "#section";
+      Object.assign(h.tree.frameTree.frame, { urlFragment: "#section" });
+      await expect(
+        h.navigate(async () => {
+          if (order === "before response") {
+            h.commitBlank();
+          }
+          expect(h.send).not.toHaveBeenCalled();
+          expect(h.documents.get(7)?.navigation.confirmed).toBe(false);
+          return blankResult;
+        }),
+      ).resolves.toEqual(blankResult);
+      if (order === "after response") {
+        expect(h.documents.get(7)?.navigation.confirmed).toBe(false);
+        h.commitBlank();
+      }
+      expect(h.documents.get(7)?.navigation.confirmed).toBe(true);
+      expect(h.send.mock.calls).toEqual([[contextEvent], [frameEvent()]]);
+      const trace = {
+        ...contextEvent,
+        method: "Tracing.tracingComplete",
+        params: { stream: "trace" },
+      };
+      h.emit(trace);
+      expect(h.send.mock.calls).toEqual([[contextEvent], [frameEvent()], [trace]]);
+      expect(h.access.recordRootCommit).toHaveBeenCalledExactlyOnceWith(7, "about:blank");
+    },
+  );
+
+  it.each([
+    { name: "source fragment disagreement", frame: { urlFragment: "#other" } },
+    { name: "child root tree", frame: { parentId: "parent" } },
+    { name: "missing root id", frame: { id: "" } },
+    { name: "source URL disagreement", frame: { url: "https://other.example/" } },
+  ])("rejects preflight $name", async ({ frame }) => {
+    const h = createHarness();
+    Object.assign(h.tree.frameTree.frame, frame);
+    await expect(h.navigate()).rejects.toThrow("current authorized root document");
+    expect(h.sendCommand).toHaveBeenCalledExactlyOnceWith("Page.getFrameTree", {});
+    expect(h.documents.get(7)).toBeUndefined();
+  });
+
+  it("does not mint provenance for a caller-constrained child frame", async () => {
+    const h = createHarness();
+    const params = { url: "about:blank", frameId: "child" };
+    await expect(h.navigate(async () => blankResult, params)).resolves.toEqual(blankResult);
+    expect(h.sendCommand).toHaveBeenLastCalledWith("Page.navigate", params);
+    expect(h.documents.get(7)).toBeUndefined();
+  });
+
+  it.each(["child frame", "child session", "wrong root", "uncommanded fragment"])(
+    "does not accept %s as root proof",
+    async (source) => {
+      const h = createHarness();
+      const event = frameEvent(
+        {
+          ...blankFrame,
+          ...(source === "child frame" ? { parentId: "parent" } : {}),
+          ...(source === "wrong root" ? { id: "other" } : {}),
+          ...(source === "uncommanded fragment" ? { urlFragment: "#other" } : {}),
+        },
+        source === "child session" ? "child" : undefined,
+      );
+      const navigating = h.navigate(async () => {
+        h.emit(event);
+        return blankResult;
+      });
+      if (source === "child frame" || source === "child session") {
+        await expect(navigating).resolves.toEqual(blankResult);
+        expect(h.documents.get(7)?.navigation.confirmed).toBe(false);
+        expect(h.documents.rootRevision(7)).toBe(0);
+        expect(h.access.recordRootCommit).not.toHaveBeenCalled();
+        expect(h.send).not.toHaveBeenCalled();
+        h.documents.invalidateAll();
+      } else {
+        await expect(navigating).rejects.toThrow("access was revoked");
+      }
+      expect(h.documents.get(7)).toBeUndefined();
+      expect(h.send).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each([
+    { name: "wrong frame", result: { ...blankResult, frameId: "child" } },
+    { name: "wrong loader", result: { ...blankResult, loaderId: "other" } },
+    { name: "missing loader", result: { frameId: "root" } },
+    { name: "aborted", result: { ...blankResult, errorText: "net::ERR_ABORTED" } },
+    { name: "download", result: { ...blankResult, isDownload: true } },
+    { name: "rejected", result: blankResult },
+    { name: "competing commit", result: blankResult },
+  ])("discards early events after native $name", async ({ name, result }) => {
+    const h = createHarness();
+    await expect(
+      h.navigate(async () => {
+        h.commitBlank();
+        if (name === "rejected") {
+          throw new Error("native failure");
+        }
+        if (name === "competing commit") {
+          h.emit(frameEvent({ ...blankFrame, loaderId: "competitor" }));
+        }
+        return result;
+      }),
+    ).rejects.toThrow(name === "rejected" ? "native failure" : /confirm|revoked/);
+    expect(h.documents.get(7)).toBeUndefined();
+    expect(h.send).not.toHaveBeenCalled();
+    expect(h.access.invalidateTab).toHaveBeenCalledWith(7);
+  });
+
+  it.each(["wrong loader", "missing loader", "competing document"])(
+    "revokes a responded navigation on %s",
+    async (change) => {
+      const h = createHarness();
+      await h.navigate();
+      h.emit(contextEvent);
+      h.emit(
+        frameEvent({
+          ...blankFrame,
+          loaderId: change === "missing loader" ? "" : "other",
+          url: change === "competing document" ? originalUrl : "about:blank",
+        }),
+      );
+      expect(h.documents.get(7)).toBeUndefined();
+      expect(h.send).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each(
+    ["before response", "after confirmation"].flatMap((phase) =>
+      [
+        "connection",
+        "attachment",
+        "command access",
+        "attachment access",
+        "retireAttachment",
+        "invalidateAll",
+        "invalidateGroup",
+      ].map((reason) => ({ phase, reason })),
+    ),
+  )("discards authority and queued events on $reason $phase", async ({ phase, reason }) => {
+    const h = createHarness();
+    let navigation: TabDocumentNavigation;
+    const revoke = () => {
+      switch (reason) {
+        case "connection":
+          h.isCurrent.mockReturnValue(false);
+          break;
+        case "attachment":
+          h.isAttached.mockReturnValue(undefined);
+          break;
+        case "command access":
+          h.proven.delete(h.epoch);
+          break;
+        case "attachment access":
+          h.proven.delete(h.attachmentEpoch);
+          break;
+        case "retireAttachment":
+          h.documents.retireAttachment(7);
+          break;
+        case "invalidateAll":
+          h.documents.invalidateAll();
+          break;
+        default:
+          h.documents.invalidateGroup({ id: 7 });
+      }
+    };
+    const navigating = h.navigate(async () => {
+      h.commitBlank();
+      const document = h.documents.get(7);
+      assert(document);
+      navigation = document.navigation;
+      if (phase === "before response") {
+        revoke();
+      }
+      return blankResult;
+    });
+    if (phase === "before response") {
+      await expect(navigating).rejects.toThrow("access was revoked");
+    } else {
+      await navigating;
+      h.send.mockClear();
+      revoke();
+      expect(() => navigation.observe(contextEvent, h.send)).toThrow("access was revoked");
+    }
+    h.isCurrent.mockReturnValue(true);
+    h.isAttached.mockReturnValue(h.attachmentEpoch);
+    h.proven.add(h.epoch).add(h.attachmentEpoch);
+    expect(() => navigation.accept(blankResult)).toThrow("access was revoked");
+    expect(() => navigation.observe(contextEvent, h.send)).toThrow("access was revoked");
+    expect(h.documents.get(7)).toBeUndefined();
+    expect(h.send).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    { name: "group move", tab: { groupId: -1 } },
+    { name: "window move", tab: { windowId: 2 } },
+    { name: "incognito", tab: { incognito: true } },
+    { name: "file pending", tab: { pendingUrl: "file:///tmp/fixture" } },
+    { name: "internal pending", tab: { pendingUrl: "chrome://settings" } },
+    { name: "restricted document", tab: { url: "chrome://settings" } },
+    { name: "lookalike blank", tab: { url: "about:blank#other" } },
+    { name: "user blank", tab: {} },
+    { name: "lost currentness", tab: {} },
+  ])("retires controlled blank on $name", async ({ name, tab }) => {
+    const h = createHarness();
+    await h.navigate(async () => {
+      h.commitBlank();
+      return blankResult;
+    });
+    const document = h.documents.get(7);
+    assert(document);
+    const navigation = document.navigation;
+    h.send.mockClear();
+    if (name === "lost currentness") {
+      h.isCurrent.mockReturnValue(false);
+    }
+    if (name === "user blank") {
+      h.emit(frameEvent({ ...blankFrame, loaderId: "user" }));
+    } else {
+      h.documents.observeTab(Object.assign(h.tab, tab));
+    }
+    expect(h.documents.get(7)).toBeUndefined();
+    expect(h.access.invalidateTab).toHaveBeenCalledWith(7);
+    expect(() => navigation.observe(contextEvent, h.send)).toThrow("access was revoked");
+    expect(h.send).not.toHaveBeenCalled();
+  });
+
+  it.each(["root commit", "attachment revision", "access revision"])(
+    "rejects a preflight overtaken by %s",
+    async (change) => {
+      const h = createHarness();
+      const navigating = h.navigate();
+      if (change === "root commit") {
+        h.emit(frameEvent({ ...blankFrame, url: originalUrl }));
+      } else if (change === "attachment revision") {
+        h.documents.retireAttachment(7);
+      } else {
+        h.proven.delete(h.epoch);
+      }
+      await expect(navigating).rejects.toThrow("current authorized root document");
+      expect(h.sendCommand).toHaveBeenCalledExactlyOnceWith("Page.getFrameTree", {});
+      expect(h.documents.get(7)).toBeUndefined();
+    },
+  );
+
+  it.each(
+    ["event count", "event bytes"].flatMap((limit) =>
+      [false, true].map((overflow) => ({ limit, overflow })),
+    ),
+  )("bounds native $limit exactly (overflow=$overflow)", async ({ limit, overflow }) => {
+    const h = createHarness();
+    const events: Record<string, unknown>[] = [frameEvent()];
+    if (limit === "event count") {
+      for (let index = 1; index < 128 + Number(overflow); index++) {
+        events.push({ ...contextEvent, params: { index } });
+      }
+    } else {
+      const event = { ...contextEvent, params: { value: "" } };
+      const overhead = JSON.stringify(events[0]).length + JSON.stringify(event).length;
+      event.params.value = "x".repeat(256 * 1024 - overhead + Number(overflow));
+      events.push(event);
+    }
+    const navigating = h.navigate(async () => {
+      for (const event of events) {
+        h.emit(event);
+      }
+      expect(h.send).not.toHaveBeenCalled();
+      return blankResult;
+    });
+    if (overflow) {
+      await expect(navigating).rejects.toThrow("access was revoked");
+      expect(h.documents.get(7)).toBeUndefined();
+      expect(h.send).not.toHaveBeenCalled();
+    } else {
+      await expect(navigating).resolves.toEqual(blankResult);
+      expect(h.documents.get(7)?.navigation.confirmed).toBe(true);
+      expect(h.send.mock.calls.map(([event]) => event)).toEqual(events);
+    }
+  });
+
+  it("stops flushing immediately when the receiver revokes attachment authority", async () => {
+    const h = createHarness();
+    h.send.mockImplementationOnce(() => h.documents.retireAttachment(7));
+    await expect(
+      h.navigate(async () => {
+        h.commitBlank();
+        return blankResult;
+      }),
+    ).rejects.toThrow("access was revoked");
+    expect(h.send.mock.calls).toEqual([[contextEvent]]);
+    expect(h.documents.get(7)).toBeUndefined();
+  });
+
+  it("scopes group invalidation and never restores retired documents in a fresh instance", async () => {
+    const h = createHarness();
+    await h.navigate(async () => {
+      h.commitBlank();
+      return blankResult;
+    });
+    h.documents.invalidateGroup({ id: 8 });
+    expect(h.documents.get(7)?.navigation.confirmed).toBe(true);
+    h.documents.invalidateGroup();
+    expect(h.documents.get(7)).toBeUndefined();
+    const fresh = createTabDocumentProvenance({ access: h.access });
+    expect(fresh.get(7)).toBeUndefined();
+    expect(fresh.rootRevision(7)).toBe(0);
+    expect(h.documents.rootRevision(7)).toBe(1);
+  });
+});


### PR DESCRIPTION
## What Problem This Solves

Resolves an internal test-performance problem where 79 document-navigation cases each reset modules, booted the full Chrome extension background worker, authenticated a relay socket, and exercised Chrome-global harness setup even when the assertion belonged to the narrow document-provenance state machine. This made the focused browser navigation suite spend about 16 seconds in repeated integration setup and obscured which owner protected each invariant.

## Why This Change Was Made

The combinatorial provenance, command-classification, Chrome-event, and stale-policy matrices now run against their owning modules. Eight full-background rows remain for the boundaries that cannot be proven below the worker: ordered blank/trace/return composition, explicit close ordering, selected pending-URL revalidation, unowned/child blank rejection, authenticated reconnect retirement, MV3 restart loss, and stale discovery ordering.

The browser-serialized provenance implementation remains plain JavaScript. Its direct test uses a local typed `vi.importActual` contract so no production declaration, package-resolution change, runtime seam, or product behavior is added.

This is AI-assisted work. I reviewed the implementation and its ownership/lifecycle boundaries.

## User Impact

There is no product-runtime behavior change. Maintainers and CI get much faster focused browser-extension proof with state-machine failures reported at the module that owns them, while retaining real background-worker, Chrome event, socket, selected-mode, close, and restart coverage.

## Evidence

### Controlled performance benchmark

Current-`main` background integration file versus this branch, on one Blacksmith Testbox with excluded warmups, eight order-balanced A/B pairs, one Vitest worker, distinct filesystem module caches, import-duration reporting, and `/usr/bin/time -v`:

| Pair | Current main | Candidate | Saving |
| ---: | ---: | ---: | ---: |
| 1 | `17.12s` | `3.14s` | `13.98s` |
| 2 | `17.14s` | `3.16s` | `13.98s` |
| 3 | `17.26s` | `3.12s` | `14.14s` |
| 4 | `17.13s` | `3.17s` | `13.96s` |
| 5 | `17.13s` | `3.09s` | `14.04s` |
| 6 | `17.10s` | `3.12s` | `13.98s` |
| 7 | `17.17s` | `3.13s` | `14.04s` |
| 8 | `17.13s` | `3.15s` | `13.98s` |

- Mean command wall: `17.1475s` → `3.135s` (`14.0125s`, `81.717%` faster)
- Favorable pairs: `8/8`
- Mean Vitest file duration: `16364.97ms` → `2361.72ms`
- Mean peak RSS: `402866.5 KiB` → `362551.5 KiB` (`10.01%` lower)
- Byte-exact baseline/candidate files were SHA-256 verified before measurement.
- Testbox: `tbx_01m16mnm0jfxr9d58agv9dhxde`
- Evidence archive SHA-256: `deebc3b18eed1ca735fcc058399fa143d1601394ddc8ff7f7129a080e6f77057`

### Coverage retained and clarified

- New direct provenance coverage preserves native response/root-commit agreement, URL fragments, child frame/session rejection, wrong frame/loader and failed navigation outcomes, revocation before and after confirmation, tab observation retirement, preflight races, exact event/byte buffer limits, ordered flushing, no replay, no reauthorization, and fresh-instance reset behavior.
- Command-handler coverage proves only root, sessionless, literal `about:blank` navigation enters provenance; nonblank, fragment, child-session, reload, and history commands stay on ordinary CDP forwarding; explicit close does not detach first.
- Chrome event/policy coverage proves current attachment-epoch filtering, child-session projection, detach/group/revision retirement, and selected stale-discovery rereads.
- The full background suite retains eight real worker/socket/Chrome integration rows. No timeout, guard, baseline, snapshot, or production implementation changed.

### Reversible fault proof

Temporarily routing root `Page.navigate({ url: "about:blank" })` through ordinary `chrome.debugger.sendCommand` produced exactly two intended failures:

- Handler owner test: expected the provenance `navigateTab` call, received zero calls.
- Full-background composition smoke: expected a successful controlled-blank result, received an error because no provenance was minted.

The production file was restored byte-for-byte, and all focused tests reran green.

### Validation

- Four focused files with one worker: `109/109` passed after rebase; Vitest `3.34s`.
- `pnpm check:changed`: passed after rebase, including canonical extension-test typecheck and lint; hosted proof: [run 33250124617](https://github.com/openclaw/openclaw/actions/runs/33250124617).
- `git diff --check origin/main...HEAD`: passed.
- Fresh pre-commit and final-base branch autoreviews: clean, no accepted/actionable findings.
- Product production LOC: `+0/-0`. Tests: `+870/-494` (net `+376`), with the full-background file reduced by 328 lines and the growth isolated to explicit owner-level coverage.
