### PR TITLE
test(openshell): settle exec preparations before workspace teardown

### DIFF
--- a/extensions/openshell/src/backend.exec-workdir.test.ts
+++ b/extensions/openshell/src/backend.exec-workdir.test.ts
@@ -168,27 +168,25 @@ describe("openshell backend exec workdir validation", () => {
       usePty: false,
     });
 
-    const uploadCalls = cliMocks.runOpenShellCli.mock.calls.filter(
-      ([params]) => params.args[0] === "sandbox" && params.args[1] === "upload",
-    );
-    expect(uploadCalls).toHaveLength(1);
-    expect(uploadCalls[0]?.[0]).toMatchObject({
-      args: [
-        "sandbox",
-        "upload",
-        "--no-git-ignore",
-        backend.runtimeId,
-        expect.stringMatching(/\/seed\.txt$/),
-        "/sandbox/",
-      ],
-      cwd: workspaceDir,
-    });
-    await backend.finalizeExec?.({
-      status: "completed",
-      exitCode: 0,
-      timedOut: false,
-      token: execSpec.finalizeToken,
-    });
+    try {
+      const uploadCalls = cliMocks.runOpenShellCli.mock.calls.filter(
+        ([params]) => params.args[0] === "sandbox" && params.args[1] === "upload",
+      );
+      expect(uploadCalls).toHaveLength(1);
+      expect(uploadCalls[0]?.[0]).toMatchObject({
+        args: [
+          "sandbox",
+          "upload",
+          "--no-git-ignore",
+          backend.runtimeId,
+          expect.stringMatching(/\/seed\.txt$/),
+          "/sandbox/",
+        ],
+        cwd: workspaceDir,
+      });
+    } finally {
+      await finalize(backend, execSpec.finalizeToken);
+    }
     const nestedFile = path.join(workspaceDir, "nested", "note.txt");
     const bridge = backend.createFsBridge?.({
       sandbox: createSandboxTestContext({
@@ -783,35 +781,30 @@ describe("openshell backend exec workdir validation", () => {
 
     const firstExec = await first.buildExecSpec({ command: "first", env: {}, usePty: false });
     const secondPreparation = second.buildExecSpec({ command: "second", env: {}, usePty: false });
-
+    // Observe rejection while the first lease is held; cleanup still awaits and rethrows it.
+    const secondSettled = Promise.allSettled([secondPreparation]);
     try {
-      await new Promise<void>((resolve) => {
-        setImmediate(resolve);
-      });
+      try {
+        await new Promise<void>((resolve) => {
+          setImmediate(resolve);
+        });
+        expect(cliMocks.runOpenShellCli.mock.calls.map(([params]) => params.args[1])).toEqual([
+          "get",
+        ]);
+      } finally {
+        await finalize(first, firstExec.finalizeToken);
+      }
+      await secondPreparation;
       expect(cliMocks.runOpenShellCli.mock.calls.map(([params]) => params.args[1])).toEqual([
+        "get",
+        "download",
         "get",
       ]);
     } finally {
-      await first.finalizeExec?.({
-        status: "completed",
-        exitCode: 0,
-        timedOut: false,
-        token: firstExec.finalizeToken,
-      });
+      await secondSettled;
+      const secondExec = await secondPreparation;
+      await finalize(second, secondExec.finalizeToken);
     }
-
-    const secondExec = await secondPreparation;
-    expect(cliMocks.runOpenShellCli.mock.calls.map(([params]) => params.args[1])).toEqual([
-      "get",
-      "download",
-      "get",
-    ]);
-    await second.finalizeExec?.({
-      status: "completed",
-      exitCode: 0,
-      timedOut: false,
-      token: secondExec.finalizeToken,
-    });
   });
 
   it.each(["exec preparation", "mirror publication", "SSH cleanup"])(
@@ -847,15 +840,8 @@ describe("openshell backend exec workdir validation", () => {
           failure === "SSH cleanup" ? "cleanup failed" : "download failed",
         );
       }
-      let secondExec: Awaited<ReturnType<SandboxBackendHandle["buildExecSpec"]>> | undefined;
-      const secondPreparation = second
-        .buildExecSpec({ command: "second", env: {}, usePty: false })
-        .then((prepared) => {
-          secondExec = prepared;
-          return prepared;
-        });
-      await vi.waitFor(() => expect(secondExec).toBeDefined());
-      await finalize(second, (await secondPreparation).finalizeToken);
+      const secondExec = await second.buildExecSpec({ command: "second", env: {}, usePty: false });
+      await finalize(second, secondExec.finalizeToken);
     },
   );
 
@@ -881,29 +867,19 @@ describe("openshell backend exec workdir validation", () => {
     const second = expectDefined(backends[1], "second OpenShell backend");
     const firstExec = await first.buildExecSpec({ command: "first", env: {}, usePty: false });
     const secondPreparation = second.buildExecSpec({ command: "second", env: {}, usePty: false });
-    let secondExec: Awaited<typeof secondPreparation> | undefined;
     try {
-      await vi.waitFor(() => {
-        const startedRuntimeIds = cliMocks.runOpenShellCli.mock.calls
-          .filter(([params]) => params.args[1] === "get")
-          .map(([params]) => params.args[2]);
-        expect(startedRuntimeIds).toEqual([first.runtimeId, second.runtimeId]);
-      });
-      secondExec = await secondPreparation;
+      await secondPreparation;
+      const startedRuntimeIds = cliMocks.runOpenShellCli.mock.calls
+        .filter(([params]) => params.args[1] === "get")
+        .map(([params]) => params.args[2]);
+      expect(startedRuntimeIds).toEqual([first.runtimeId, second.runtimeId]);
     } finally {
-      await first.finalizeExec?.({
-        status: "completed",
-        exitCode: 0,
-        timedOut: false,
-        token: firstExec.finalizeToken,
-      });
-      secondExec ??= await secondPreparation;
-      await second.finalizeExec?.({
-        status: "completed",
-        exitCode: 0,
-        timedOut: false,
-        token: secondExec.finalizeToken,
-      });
+      try {
+        await finalize(first, firstExec.finalizeToken);
+      } finally {
+        const secondExec = await secondPreparation;
+        await finalize(second, secondExec.finalizeToken);
+      }
     }
   });
 });

--- a/extensions/openshell/src/backend.remote-seed.test.ts
+++ b/extensions/openshell/src/backend.remote-seed.test.ts
@@ -116,17 +116,15 @@ describe("openshell remote-mode seed across gateway restart", () => {
 
     const execSpec = await backend.buildExecSpec({ command: "pwd", env: {}, usePty: false });
 
-    const uploads = seedUploadCalls();
-    expect(uploads.length).toBeGreaterThan(0);
-    expect(uploads[0]?.[0]).toMatchObject({
-      args: expect.arrayContaining([expect.stringMatching(/\/seed\.txt$/), "/sandbox/"]),
-    });
-    await backend.finalizeExec?.({
-      status: "completed",
-      exitCode: 0,
-      timedOut: false,
-      token: execSpec.finalizeToken,
-    });
+    try {
+      const uploads = seedUploadCalls();
+      expect(uploads.length).toBeGreaterThan(0);
+      expect(uploads[0]?.[0]).toMatchObject({
+        args: expect.arrayContaining([expect.stringMatching(/\/seed\.txt$/), "/sandbox/"]),
+      });
+    } finally {
+      await finalize(backend, execSpec.finalizeToken);
+    }
   });
 
   it("never re-seeds when a managed root already holds content", async () => {
@@ -134,17 +132,15 @@ describe("openshell remote-mode seed across gateway restart", () => {
 
     const execSpec = await backend.buildExecSpec({ command: "pwd", env: {}, usePty: false });
 
-    expect(seedUploadCalls()).toHaveLength(0);
-    const wipeCalls = sdkMocks.runSshSandboxCommand.mock.calls.filter(([params]) =>
-      String(params.remoteCommand).includes("rm -rf"),
-    );
-    expect(wipeCalls).toHaveLength(0);
-    await backend.finalizeExec?.({
-      status: "completed",
-      exitCode: 0,
-      timedOut: false,
-      token: execSpec.finalizeToken,
-    });
+    try {
+      expect(seedUploadCalls()).toHaveLength(0);
+      const wipeCalls = sdkMocks.runSshSandboxCommand.mock.calls.filter(([params]) =>
+        String(params.remoteCommand).includes("rm -rf"),
+      );
+      expect(wipeCalls).toHaveLength(0);
+    } finally {
+      await finalize(backend, execSpec.finalizeToken);
+    }
   });
 
   it.each(["same handle", "another handle"])(
@@ -160,20 +156,21 @@ describe("openshell remote-mode seed across gateway restart", () => {
         env: {},
         usePty: false,
       });
-      let secondExec: Awaited<ReturnType<SandboxBackendHandle["buildExecSpec"]>> | undefined;
-      const secondPreparation = second
-        .buildExecSpec({ command: "write-file", env: {}, usePty: false })
-        .then((prepared) => {
-          secondExec = prepared;
-          return prepared;
-        });
+      const secondPreparation = second.buildExecSpec({
+        command: "write-file",
+        env: {},
+        usePty: false,
+      });
       try {
-        await vi.waitFor(() => expect(secondExec).toBeDefined());
+        await secondPreparation;
         expect(seedUploadCalls()).toHaveLength(0);
       } finally {
-        await finalize(first, firstExec.finalizeToken);
-        const prepared = await secondPreparation;
-        await finalize(second, prepared.finalizeToken);
+        try {
+          await finalize(first, firstExec.finalizeToken);
+        } finally {
+          const prepared = await secondPreparation;
+          await finalize(second, prepared.finalizeToken);
+        }
       }
     },
   );
@@ -234,33 +231,46 @@ describe("openshell remote-mode seed across gateway restart", () => {
       return { code: 0, stdout: "", stderr: "" };
     });
     const firstPreparation = first.buildExecSpec({ command: "first", env: {}, usePty: false });
-    await seedStarted.promise;
-    let secondStarted = false;
-    const secondPreparation = second
-      .buildExecSpec({ command: "second", env: {}, usePty: false })
-      .then((prepared) => {
-        secondStarted = true;
-        return prepared;
-      });
+    let secondPreparation: typeof firstPreparation | undefined;
+    let preparationsSettled: Promise<PromiseSettledResult<Awaited<typeof firstPreparation>>[]> =
+      Promise.allSettled([firstPreparation]);
     try {
-      await new Promise<void>((resolve) => {
-        setImmediate(resolve);
-      });
-      expect(
-        cliMocks.runOpenShellCli.mock.calls.filter(([params]) => params.args[1] === "get"),
-      ).toHaveLength(1);
-      expect(secondStarted).toBe(false);
-    } finally {
-      releaseSeed.resolve();
-    }
-    const firstExec = await firstPreparation;
-    try {
-      await vi.waitFor(() => expect(secondStarted).toBe(true));
+      await Promise.race([seedStarted.promise, firstPreparation]);
+      let secondStarted = false;
+      secondPreparation = second
+        .buildExecSpec({ command: "second", env: {}, usePty: false })
+        .then((prepared) => {
+          secondStarted = true;
+          return prepared;
+        });
+      preparationsSettled = Promise.allSettled([firstPreparation, secondPreparation]);
+      try {
+        await new Promise<void>((resolve) => {
+          setImmediate(resolve);
+        });
+        expect(
+          cliMocks.runOpenShellCli.mock.calls.filter(([params]) => params.args[1] === "get"),
+        ).toHaveLength(1);
+        expect(secondStarted).toBe(false);
+      } finally {
+        releaseSeed.resolve();
+      }
+      await firstPreparation;
+      await secondPreparation;
       expect(seedUploadCalls()).toHaveLength(1);
     } finally {
-      await finalize(first, firstExec.finalizeToken);
-      const secondExec = await secondPreparation;
-      await finalize(second, secondExec.finalizeToken);
+      // An assertion or preparation failure must not leave work using a deleted workspace.
+      releaseSeed.resolve();
+      try {
+        const firstExec = await firstPreparation;
+        await finalize(first, firstExec.finalizeToken);
+      } finally {
+        await preparationsSettled;
+        const secondExec = await secondPreparation;
+        if (secondExec) {
+          await finalize(second, secondExec.finalizeToken);
+        }
+      }
     }
   });
 });


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where OpenShell validation could finish an assertion while an exec preparation or finalize token still owned its temporary workspace. Teardown could then remove the workspace beneath mirror staging, producing a late ENOENT instead of a cleanly settled test failure.

This is the maintainer-requested main forward-port of the test lifecycle repair in ff9d42ddd832afa1811945afa3a2bf53de743adb. It does not claim a permanent production mutex leak or a host-load root cause. The affected test structure was introduced with #131315; main's symlink-alias coverage from #131917 is retained.

## Why This Change Was Made

Await the actual `buildExecSpec` promise instead of a redundant positive `vi.waitFor` completion flag, observe already-started rejections, and use nested finalizers/settlement joins so assertions, preparation failures, and finalization failures cannot skip the remaining owned cleanup. Release the initial seed gate before joining preparations. The existing negative exclusivity checks, exact get/download/get order, independent-workspace and remote-command parallelism, and all three failure cases remain.

The same ownership rule also covers the earlier upload-assertion case: its existing token now finalizes in `finally`, before the subsequent filesystem-bridge operations. No new abstraction, production seam, deadline, retry, skip, dependency, runtime, API, configuration, or schema change is included.

## User Impact

No product behavior changes. Maintainers get test failures that settle their own preparations and exec tokens before temporary workspace teardown, with the same OpenShell behavior coverage. Production LOC: +0/-0. Tests: +117/-131 (net -14) across exactly two existing files. AI-assisted with Codex; reviewed and validated as a bounded maintainer repair.

## Evidence

Source baseline: `d179dc3e27ea6a81d5c7f7280fe4cd59fe935803`. The committed patch was rebased without conflict onto `b3362142c72bcde6dae141e649826de10da0c000`; both reviewed test blobs are unchanged. Node 24.20.0, pinned Vitest 4.1.11 and `@openclaw/fs-safe` 0.5.6, installed normally with the frozen lockfile in an isolated author worktree. Directly inspected the preparation/finalization owner, real exec caller, SSH sibling, queue/deferred owners, mirror staging, and installed dependency contracts. `waitFor` defaults to a separate 1000 ms timeout; workspace cleanup does not join application promises.

The retained original six-path order passed once before the patch and once after it: **199 tests = 71 tooling + 128 OpenShell**, 63.35 s before and 47.18 s after. The passing baseline does not negate the previously observed release-order shadow-poll failure and subsequent ENOENT. Release-candidate proof is not presented as current-main proof.

```sh
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs test/helpers/openclaw-test-instance.test.ts test/scripts/release-plan-producer.test.ts extensions/openshell/src/backend.exec-workdir.test.ts extensions/openshell/src/backend.remote-seed.test.ts extensions/openshell/src/mirror.test.ts extensions/openshell/src/openshell-core.test.ts --no-file-parallelism
```

A temporary fault-injection probe made the existing first upload assertion fail and recorded prepared execs / cleanup callbacks immediately before workspace removal: **before 1/0; after 1/1**. Both probe runs still failed at the deliberately broken assertion (exit 1), demonstrating cleanup without swallowing the failure. The probe and its counter were removed before final proof/review; no instrumentation is committed.

```sh
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-misc.config.ts extensions/openshell/src/backend.exec-workdir.test.ts extensions/openshell/src/backend.remote-seed.test.ts extensions/openshell/src/mirror.test.ts extensions/openshell/src/openshell-core.test.ts --maxWorkers=1 --no-file-parallelism --no-isolate
```

Shared-worker owner/sibling proof: **128 passed**, 8.18 s, including symlink aliases, preparation/publication/SSH-cleanup failure recovery, distinct-workspace parallelism, initial seed serialization, and later remote command overlap. Fresh managed Codex P0 autoreview of the nonempty final diff: **no accepted/actionable findings**.

Changed gate passed (exit 0), including the actual extension test typecheck and targeted extension lint, with the final source hashes unchanged:

```sh
node scripts/check-changed.mjs --dry-run -- extensions/openshell/src/backend.exec-workdir.test.ts extensions/openshell/src/backend.remote-seed.test.ts
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/check-changed.mjs -- extensions/openshell/src/backend.exec-workdir.test.ts extensions/openshell/src/backend.remote-seed.test.ts
git diff --check
```

Post-rebase sanity on `c570c56ed791dc3dc31e5cd602684f173ef3af31`: the same four OpenShell owner/sibling files passed all 128 tests with `--maxWorkers=1 --no-file-parallelism`. Exact-head [CI run 33250655494](https://github.com/openclaw/openclaw/actions/runs/33250655494) completed **success**, attempt 1, for `c570c56ed791dc3dc31e5cd602684f173ef3af31`. No new build or live OpenShell/provider run was needed for these two test-only paths; no product flow or external API changed. Existing test deadlines still govern truly hung operations and framework-forced timeouts.

Native preparation: `OPENCLAW_TESTBOX=1 scripts/pr prepare-run 132562` completed successfully at the unchanged exact head, with hosted CI/Testbox gates verified. The completed ClawSweeper review has no findings or before-merge actions.
