### PR TITLE
refactor: consolidate package tarball test fixtures

### DIFF
--- a/src/state/openclaw-agent-db.test.ts
+++ b/src/state/openclaw-agent-db.test.ts
@@ -3737,12 +3737,12 @@ describe("openclaw agent database", () => {
       older.close();
     }
     const repaired = openOpenClawAgentDatabase({ agentId: "worker-1", env });
-    expect(readSqliteNumberPragma(repaired.db, "user_version")).toBe(18);
+    expect(readSqliteNumberPragma(repaired.db, "user_version")).toBe(OPENCLAW_AGENT_SCHEMA_VERSION);
     expect(
       repaired.db
         .prepare("SELECT schema_version FROM schema_meta WHERE meta_key = 'primary'")
         .get(),
-    ).toEqual({ schema_version: 18 });
+    ).toEqual({ schema_version: OPENCLAW_AGENT_SCHEMA_VERSION });
     expect(
       repaired.db
         .prepare("SELECT event_json FROM transcript_events WHERE session_id = 'eligibility'")

--- a/src/state/openclaw-database-preflight.test.ts
+++ b/src/state/openclaw-database-preflight.test.ts
@@ -565,7 +565,10 @@ describe("OpenClaw database schema preflight", () => {
       const result = preflightOpenClawDatabaseSchemas({
         env,
         verifyCurrentSchemaShape: true,
-        supportedVersions: { state: OPENCLAW_STATE_SCHEMA_VERSION, agent: 18 },
+        supportedVersions: {
+          state: OPENCLAW_STATE_SCHEMA_VERSION,
+          agent: OPENCLAW_AGENT_SCHEMA_VERSION,
+        },
       });
       expect(result.incompatible).toEqual([]);
       expect(result.indeterminate).toEqual(
@@ -588,7 +591,9 @@ describe("OpenClaw database schema preflight", () => {
             )
             .get(),
         ).toEqual(shape === "absent" ? undefined : { name: "context_eligible" });
-        expect(inspected.prepare("PRAGMA user_version").get()).toEqual({ user_version: 18 });
+        expect(inspected.prepare("PRAGMA user_version").get()).toEqual({
+          user_version: OPENCLAW_AGENT_SCHEMA_VERSION,
+        });
       } finally {
         inspected.close();
       }

--- a/test/scripts/check-openclaw-package-tarball.test.ts
+++ b/test/scripts/check-openclaw-package-tarball.test.ts
@@ -11,7 +11,7 @@ import {
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
-import { delimiter, dirname, join } from "node:path";
+import { delimiter, dirname, isAbsolute, join } from "node:path";
 import { gte as semverGte, valid as validSemver } from "semver";
 import { describe, expect, it } from "vitest";
 import { LOCAL_BUILD_METADATA_DIST_PATHS } from "../../scripts/lib/local-build-metadata-paths.mts";
@@ -176,6 +176,60 @@ function withTarball(
   }
 }
 
+type TarballCheck = {
+  inventory?: Parameters<typeof withTarball>[0];
+  files?: Parameters<typeof withTarball>[1];
+  version?: Parameters<typeof withTarball>[3];
+  options?: Parameters<typeof withTarball>[4];
+  strict?: boolean;
+  status: 0 | "nonzero";
+  stderr?: string[];
+  notStderr?: string[];
+  successText?: boolean;
+};
+
+type NamedTarballCheck = TarballCheck & { name: string };
+
+function checkTarball({
+  inventory = ["dist/index.js"],
+  files = { "dist/index.js": "export {};\n" },
+  version,
+  options,
+  strict = false,
+  status,
+  stderr = [],
+  notStderr = [],
+  successText = false,
+}: TarballCheck) {
+  withTarball(
+    inventory,
+    files,
+    (tarball) => {
+      const args = strict
+        ? [CHECK_SCRIPT, "--require-bundled-workspace-deps", tarball]
+        : [CHECK_SCRIPT, tarball];
+      const result = spawnSync("node", args, { encoding: "utf8" });
+
+      if (status === 0) {
+        expect(result.status, result.stderr).toBe(0);
+      } else {
+        expect(result.status).not.toBe(0);
+      }
+      for (const text of stderr) {
+        expect(result.stderr).toContain(text);
+      }
+      for (const text of notStderr) {
+        expect(result.stderr).not.toContain(text);
+      }
+      if (successText) {
+        expect(result.stdout).toContain("OpenClaw package tarball integrity passed.");
+      }
+    },
+    version,
+    options,
+  );
+}
+
 describe("check-openclaw-package-tarball", () => {
   it("prints help before touching tarball state", () => {
     const result = spawnSync("node", [PUBLIC_CHECK_SCRIPT, "--help"], { encoding: "utf8" });
@@ -278,7 +332,10 @@ describe("check-openclaw-package-tarball", () => {
             "const fs = require('node:fs');",
             "const args = process.argv.slice(2);",
             "if (args[0] === '-tf') { console.log('package/package.json'); process.exit(0); }",
+            "if (args[0] === '-tvf') { console.log('-rw-r--r-- 0/0 0 2026-08-29 package/package.json'); process.exit(0); }",
+            "if (args[0] !== '-xf') { throw new Error('unexpected tar operation'); }",
             "const outputDir = args[args.indexOf('-C') + 1];",
+            "if (!fs.statSync(outputDir).isDirectory()) { throw new Error('missing extract dir'); }",
             "fs.writeFileSync(process.env.OPENCLAW_TEST_EXTRACT_DIR_FILE, outputDir);",
             "console.error('extract denied');",
             "process.exit(7);",
@@ -299,101 +356,69 @@ describe("check-openclaw-package-tarball", () => {
 
         expect(result.status).not.toBe(0);
         expect(result.stderr).toContain("extract denied");
-        expect(existsSync(readFileSync(extractDirFile, "utf8"))).toBe(false);
+        expect(result.stderr).toContain("tar -xf failed");
+        const extractDir = readFileSync(extractDirFile, "utf8");
+        expect(isAbsolute(extractDir)).toBe(true);
+        expect(existsSync(extractDir)).toBe(false);
       } finally {
         rmSync(root, { recursive: true, force: true });
       }
     },
   );
 
-  it("allows legacy private QA inventory entries omitted from shipped tarballs through 2026.4.25", () => {
-    withTarball(
-      ["dist/index.js", "dist/extensions/qa-channel/runtime-api.js"],
-      { "dist/index.js": "export {};\n" },
-      (tarball) => {
-        const result = spawnSync("node", [CHECK_SCRIPT, tarball], { encoding: "utf8" });
-
-        expect(result.status, result.stderr).toBe(0);
-        expect(result.stderr).toContain("legacy inventory references omitted private QA");
-        expect(result.stdout).toContain("OpenClaw package tarball integrity passed.");
-      },
-      "2026.4.25-beta.10",
-    );
-  });
-
-  it("rejects legacy private QA inventory omissions for newer packages", () => {
-    withTarball(
-      ["dist/index.js", "dist/extensions/qa-channel/runtime-api.js"],
-      { "dist/index.js": "export {};\n" },
-      (tarball) => {
-        const result = spawnSync("node", [CHECK_SCRIPT, tarball], { encoding: "utf8" });
-
-        expect(result.status).not.toBe(0);
-        expect(result.stderr).toContain(
-          "inventory references missing tar entry dist/extensions/qa-channel/runtime-api.js",
-        );
-        expect(result.stderr).not.toContain("legacy inventory references omitted private QA");
-      },
-      "2026.4.26",
-    );
-  });
+  const legacyInventoryCases: NamedTarballCheck[] = [
+    {
+      name: "allows legacy private QA inventory entries omitted from shipped tarballs through 2026.4.25",
+      inventory: ["dist/index.js", "dist/extensions/qa-channel/runtime-api.js"],
+      version: "2026.4.25-beta.10",
+      status: 0,
+      successText: true,
+      stderr: ["legacy inventory references omitted private QA"],
+    },
+    {
+      name: "rejects legacy private QA inventory omissions for newer packages",
+      inventory: ["dist/index.js", "dist/extensions/qa-channel/runtime-api.js"],
+      version: "2026.4.26",
+      status: "nonzero",
+      stderr: ["inventory references missing tar entry dist/extensions/qa-channel/runtime-api.js"],
+      notStderr: ["legacy inventory references omitted private QA"],
+    },
+  ];
+  for (const testCase of legacyInventoryCases) {
+    it(testCase.name, () => checkTarball(testCase));
+  }
 
   it("requires an install guard omitted from the dist inventory", () => {
-    withTarball(
-      ["dist/index.js"],
-      { "dist/index.js": "export {};\n" },
-      (tarball) => {
-        const result = spawnSync("node", [CHECK_SCRIPT, tarball], { encoding: "utf8" });
+    checkTarball({
+      version: "0.0.0",
+      options: { includeInstallGuard: false },
+      status: "nonzero",
+      stderr: [`missing required tar entry ${PACKAGE_INSTALL_GUARD_RELATIVE_PATH}`],
+    });
 
-        expect(result.status).not.toBe(0);
-        expect(result.stderr).toContain(
-          `missing required tar entry ${PACKAGE_INSTALL_GUARD_RELATIVE_PATH}`,
-        );
-      },
-      "0.0.0",
-      { includeInstallGuard: false },
-    );
+    checkTarball({
+      inventory: ["dist/index.js", PACKAGE_INSTALL_GUARD_RELATIVE_PATH],
+      status: "nonzero",
+      stderr: [
+        `package dist inventory must omit install guard ${PACKAGE_INSTALL_GUARD_RELATIVE_PATH}`,
+      ],
+    });
 
-    withTarball(
-      ["dist/index.js", PACKAGE_INSTALL_GUARD_RELATIVE_PATH],
-      { "dist/index.js": "export {};\n" },
-      (tarball) => {
-        const result = spawnSync("node", [CHECK_SCRIPT, tarball], { encoding: "utf8" });
-
-        expect(result.status).not.toBe(0);
-        expect(result.stderr).toContain(
-          `package dist inventory must omit install guard ${PACKAGE_INSTALL_GUARD_RELATIVE_PATH}`,
-        );
-      },
-    );
-
-    withTarball(
-      ["dist/index.js"],
-      { "dist/index.js": "export {};\n" },
-      (tarball) => {
-        const result = spawnSync("node", [CHECK_SCRIPT, tarball], { encoding: "utf8" });
-
-        expect(result.status, result.stderr).toBe(0);
-        expect(result.stderr).toContain("legacy package omits the preinstall completion guard");
-      },
-      "2026.7.1",
-      { includeInstallGuard: false },
-    );
+    checkTarball({
+      version: "2026.7.1",
+      options: { includeInstallGuard: false },
+      status: 0,
+      stderr: ["legacy package omits the preinstall completion guard"],
+    });
   });
 
   it("rejects stale deep plugin SDK declaration inventory entries", () => {
-    withTarball(
-      [FLAT_PLUGIN_SDK_DECLARATION, DEEP_PLUGIN_SDK_DECLARATION],
-      { [FLAT_PLUGIN_SDK_DECLARATION]: "export {};\n" },
-      (tarball) => {
-        const result = spawnSync("node", [CHECK_SCRIPT, tarball], { encoding: "utf8" });
-
-        expect(result.status).not.toBe(0);
-        expect(result.stderr).toContain(
-          `inventory references missing tar entry ${DEEP_PLUGIN_SDK_DECLARATION}`,
-        );
-      },
-    );
+    checkTarball({
+      inventory: [FLAT_PLUGIN_SDK_DECLARATION, DEEP_PLUGIN_SDK_DECLARATION],
+      files: { [FLAT_PLUGIN_SDK_DECLARATION]: "export {};\n" },
+      status: "nonzero",
+      stderr: [`inventory references missing tar entry ${DEEP_PLUGIN_SDK_DECLARATION}`],
+    });
   });
 
   it.each([
@@ -402,199 +427,112 @@ describe("check-openclaw-package-tarball", () => {
   ])(
     "rejects a packaged %s omitted from the postinstall inventory",
     (_, relativePath, contents) => {
-      withTarball(
-        ["dist/index.js"],
-        { "dist/index.js": "export {};\n", [relativePath]: contents },
-        (tarball) => {
-          const result = spawnSync("node", [CHECK_SCRIPT, tarball], { encoding: "utf8" });
-
-          expect(result.status).not.toBe(0);
-          expect(result.stderr).toContain(
-            `postinstall inventory omits packaged dist file ${relativePath}`,
-          );
-        },
-        "2026.7.2",
-        { postinstall: true },
-      );
+      checkTarball({
+        files: { "dist/index.js": "export {};\n", [relativePath]: contents },
+        version: "2026.7.2",
+        options: { postinstall: true },
+        status: "nonzero",
+        stderr: [`postinstall inventory omits packaged dist file ${relativePath}`],
+      });
     },
   );
 
-  it("accepts historical packages published before the Code Mode worker existed", () => {
-    withTarball(
-      ["dist/index.js"],
-      { "dist/index.js": "export {};\n" },
-      (tarball) => {
-        const result = spawnSync("node", [CHECK_SCRIPT, tarball], { encoding: "utf8" });
-
-        expect(result.status, result.stderr).toBe(0);
-        expect(result.stdout).toContain("OpenClaw package tarball integrity passed.");
-      },
-      "2026.5.14-beta.1",
-    );
-  });
-
-  it("rejects Code Mode packages that omit the dynamically loaded worker", () => {
-    withTarball(
-      ["dist/index.js"],
-      { "dist/index.js": "export {};\n" },
-      (tarball) => {
-        const result = spawnSync("node", [CHECK_SCRIPT, tarball], { encoding: "utf8" });
-
-        expect(result.status).not.toBe(0);
-        expect(result.stderr).toContain(`missing required tar entry ${CODE_MODE_WORKER_PATH}`);
-      },
-      FIRST_CODE_MODE_WORKER_VERSION,
-      { includeCodeModeWorker: false },
-    );
-  });
-
-  it("rejects Code Mode workers that postinstall would remove", () => {
-    withTarball(
-      ["dist/index.js"],
-      { "dist/index.js": "export {};\n" },
-      (tarball) => {
-        const result = spawnSync("node", [CHECK_SCRIPT, tarball], { encoding: "utf8" });
-
-        expect(result.status).not.toBe(0);
-        expect(result.stderr).toContain(
-          `postinstall inventory omits packaged dist file ${CODE_MODE_WORKER_PATH}`,
-        );
-      },
-      FIRST_CODE_MODE_WORKER_VERSION,
-      { includeCodeModeWorkerInInventory: false, postinstall: true },
-    );
-  });
-
-  it("rejects dist files that import missing relative chunks", () => {
-    withTarball(
-      ["dist/cli/run-main.js"],
-      { "dist/cli/run-main.js": 'await import("../memory-state-old.js");\n' },
-      (tarball) => {
-        const result = spawnSync("node", [CHECK_SCRIPT, tarball], { encoding: "utf8" });
-
-        expect(result.status).not.toBe(0);
-        expect(result.stderr).toContain(
-          "dist/cli/run-main.js imports missing dist/memory-state-old.js",
-        );
-      },
-      "2026.4.27",
-    );
-  });
-
-  it("rejects leaked private QA Docker chunks that import an omitted QA runtime", () => {
-    withTarball(
-      ["dist/docker-runtime-BVdgRgxA.js"],
-      {
+  const packageContractCases: NamedTarballCheck[] = [
+    {
+      name: "accepts historical packages published before the Code Mode worker existed",
+      version: "2026.5.14-beta.1",
+      status: 0,
+      successText: true,
+    },
+    {
+      name: "rejects Code Mode packages that omit the dynamically loaded worker",
+      version: FIRST_CODE_MODE_WORKER_VERSION,
+      options: { includeCodeModeWorker: false },
+      status: "nonzero",
+      stderr: [`missing required tar entry ${CODE_MODE_WORKER_PATH}`],
+    },
+    {
+      name: "rejects Code Mode workers that postinstall would remove",
+      version: FIRST_CODE_MODE_WORKER_VERSION,
+      options: { includeCodeModeWorkerInInventory: false, postinstall: true },
+      status: "nonzero",
+      stderr: [`postinstall inventory omits packaged dist file ${CODE_MODE_WORKER_PATH}`],
+    },
+    {
+      name: "rejects dist files that import missing relative chunks",
+      inventory: ["dist/cli/run-main.js"],
+      files: { "dist/cli/run-main.js": 'await import("../memory-state-old.js");\n' },
+      version: "2026.4.27",
+      status: "nonzero",
+      stderr: ["dist/cli/run-main.js imports missing dist/memory-state-old.js"],
+    },
+    {
+      name: "rejects leaked private QA Docker chunks that import an omitted QA runtime",
+      inventory: ["dist/docker-runtime-BVdgRgxA.js"],
+      files: {
         "dist/docker-runtime-BVdgRgxA.js":
           'import { createQaDockerRuntime } from "./qa-runtime-Bi1S3plf.js";\n' +
           "export { createQaDockerRuntime };\n",
       },
-      (tarball) => {
-        const result = spawnSync("node", [CHECK_SCRIPT, tarball], { encoding: "utf8" });
-
-        expect(result.status).not.toBe(0);
-        expect(result.stderr).toContain(
-          "dist/docker-runtime-BVdgRgxA.js imports missing dist/qa-runtime-Bi1S3plf.js",
-        );
-      },
-    );
-  });
-
-  it("accepts dist files whose relative chunks are present", () => {
-    withTarball(
-      ["dist/cli/run-main.js", "dist/memory-state-current.js"],
-      {
+      status: "nonzero",
+      stderr: ["dist/docker-runtime-BVdgRgxA.js imports missing dist/qa-runtime-Bi1S3plf.js"],
+    },
+    {
+      name: "accepts dist files whose relative chunks are present",
+      inventory: ["dist/cli/run-main.js", "dist/memory-state-current.js"],
+      files: {
         "dist/cli/run-main.js": 'await import("../memory-state-current.js");\n',
         "dist/memory-state-current.js": "export {};\n",
       },
-      (tarball) => {
-        const result = spawnSync("node", [CHECK_SCRIPT, tarball], { encoding: "utf8" });
-
-        expect(result.status, result.stderr).toBe(0);
-        expect(result.stdout).toContain("OpenClaw package tarball integrity passed.");
-      },
-      "2026.4.27",
-    );
-  });
-
-  it("rejects imported dist chunks omitted from the postinstall inventory", () => {
-    withTarball(
-      ["dist/cli/run-main.js"],
-      {
+      version: "2026.4.27",
+      status: 0,
+      successText: true,
+    },
+    {
+      name: "rejects imported dist chunks omitted from the postinstall inventory",
+      inventory: ["dist/cli/run-main.js"],
+      files: {
         "dist/cli/run-main.js": 'await import("../memory-state-current.js");\n',
         "dist/memory-state-current.js": "export {};\n",
       },
-      (tarball) => {
-        const result = spawnSync("node", [CHECK_SCRIPT, tarball], { encoding: "utf8" });
-
-        expect(result.status).not.toBe(0);
-        expect(result.stderr).toContain(
-          "postinstall inventory omits packaged dist file dist/memory-state-current.js",
-        );
-      },
-      "2026.4.27",
-      { postinstall: true },
-    );
-  });
-
-  it("rejects named imported chunks omitted from the postinstall inventory", () => {
-    withTarball(
-      ["dist/index.js"],
-      {
+      version: "2026.4.27",
+      options: { postinstall: true },
+      status: "nonzero",
+      stderr: ["postinstall inventory omits packaged dist file dist/memory-state-current.js"],
+    },
+    {
+      name: "rejects named imported chunks omitted from the postinstall inventory",
+      files: {
         "dist/index.js": 'import { value } from "./chunk.js";\nexport { value };\n',
         "dist/chunk.js": "export const value = 42;\n",
       },
-      (tarball) => {
-        const result = spawnSync("node", [CHECK_SCRIPT, tarball], { encoding: "utf8" });
-
-        expect(result.status).not.toBe(0);
-        expect(result.stderr).toContain(
-          "postinstall inventory omits packaged dist file dist/chunk.js",
-        );
-      },
-      "2026.4.27",
-      { postinstall: true },
-    );
-  });
-
-  it("rejects CommonJS require chunks omitted from the postinstall inventory", () => {
-    withTarball(
-      ["dist/index.cjs"],
-      {
+      version: "2026.4.27",
+      options: { postinstall: true },
+      status: "nonzero",
+      stderr: ["postinstall inventory omits packaged dist file dist/chunk.js"],
+    },
+    {
+      name: "rejects CommonJS require chunks omitted from the postinstall inventory",
+      inventory: ["dist/index.cjs"],
+      files: {
         "dist/index.cjs": 'module.exports = require("./chunk.cjs");\n',
         "dist/chunk.cjs": "module.exports = {};\n",
       },
-      (tarball) => {
-        const result = spawnSync("node", [CHECK_SCRIPT, tarball], { encoding: "utf8" });
-
-        expect(result.status).not.toBe(0);
-        expect(result.stderr).toContain(
-          "postinstall inventory omits packaged dist file dist/chunk.cjs",
-        );
-      },
-      "2026.4.27",
-      { postinstall: true },
-    );
-  });
-
-  it("rejects dist files with missing import.meta.url URL dependencies", () => {
-    withTarball(
-      ["dist/index.js"],
-      { "dist/index.js": 'const worker = new URL("./worker.js", import.meta.url);\n' },
-      (tarball) => {
-        const result = spawnSync("node", [CHECK_SCRIPT, tarball], { encoding: "utf8" });
-
-        expect(result.status).not.toBe(0);
-        expect(result.stderr).toContain("dist/index.js imports missing dist/worker.js");
-      },
-      "2026.4.27",
-    );
-  });
-
-  it("rejects formatted import.meta.url URL dependencies", () => {
-    withTarball(
-      ["dist/index.js"],
-      {
+      version: "2026.4.27",
+      options: { postinstall: true },
+      status: "nonzero",
+      stderr: ["postinstall inventory omits packaged dist file dist/chunk.cjs"],
+    },
+    {
+      name: "rejects dist files with missing import.meta.url URL dependencies",
+      files: { "dist/index.js": 'const worker = new URL("./worker.js", import.meta.url);\n' },
+      version: "2026.4.27",
+      status: "nonzero",
+      stderr: ["dist/index.js imports missing dist/worker.js"],
+    },
+    {
+      name: "rejects formatted import.meta.url URL dependencies",
+      files: {
         "dist/index.js": [
           "const worker = new URL(",
           '  "./worker.js",',
@@ -603,151 +541,87 @@ describe("check-openclaw-package-tarball", () => {
           "",
         ].join("\n"),
       },
-      (tarball) => {
-        const result = spawnSync("node", [CHECK_SCRIPT, tarball], { encoding: "utf8" });
-
-        expect(result.status).not.toBe(0);
-        expect(result.stderr).toContain("dist/index.js imports missing dist/worker.js");
-      },
-      "2026.4.27",
-    );
-  });
-
-  it("rejects import.meta.url URL dependencies omitted from the postinstall inventory", () => {
-    withTarball(
-      ["dist/index.js"],
-      {
+      version: "2026.4.27",
+      status: "nonzero",
+      stderr: ["dist/index.js imports missing dist/worker.js"],
+    },
+    {
+      name: "rejects import.meta.url URL dependencies omitted from the postinstall inventory",
+      files: {
         "dist/index.js": 'const worker = new URL("./worker.js", import.meta.url);\n',
         "dist/worker.js": "export {};\n",
       },
-      (tarball) => {
-        const result = spawnSync("node", [CHECK_SCRIPT, tarball], { encoding: "utf8" });
-
-        expect(result.status).not.toBe(0);
-        expect(result.stderr).toContain(
-          "postinstall inventory omits packaged dist file dist/worker.js",
-        );
-      },
-      "2026.4.27",
-      { postinstall: true },
-    );
-  });
-
-  it("allows import.meta.url package-root probes", () => {
-    withTarball(
-      ["dist/index.js"],
-      { "dist/index.js": 'const root = new URL("../..", import.meta.url);\n' },
-      (tarball) => {
-        const result = spawnSync("node", [CHECK_SCRIPT, tarball], { encoding: "utf8" });
-
-        expect(result.status, result.stderr).toBe(0);
-        expect(result.stdout).toContain("OpenClaw package tarball integrity passed.");
-      },
-      "2026.4.27",
-    );
-  });
-
-  it("rejects missing Control UI assets", () => {
-    withTarball(
-      ["dist/index.js"],
-      { "dist/index.js": "export {};\n" },
-      (tarball) => {
-        const result = spawnSync("node", [CHECK_SCRIPT, tarball], { encoding: "utf8" });
-
-        expect(result.status).not.toBe(0);
-        expect(result.stderr).toContain("missing required tar entry dist/control-ui/index.html");
-        expect(result.stderr).toContain(
-          "missing required tar entries under dist/control-ui/assets/",
-        );
-      },
-      "2026.4.27",
-      { includeControlUi: false },
-    );
-  });
-
-  it("rejects package tarballs without workspace templates", () => {
-    withTarball(
-      ["dist/index.js"],
-      { "dist/index.js": "export {};\n" },
-      (tarball) => {
-        const result = spawnSync("node", [CHECK_SCRIPT, tarball], { encoding: "utf8" });
-
-        expect(result.status).not.toBe(0);
-        for (const relativePath of WORKSPACE_TEMPLATE_PACK_PATHS) {
-          expect(result.stderr).toContain(`missing required tar entry ${relativePath}`);
-        }
-      },
-      "2026.6.11",
-      { includeWorkspaceTemplates: false },
-    );
-  });
-
-  it("allows package tarballs without npm lockfiles", () => {
-    withTarball(
-      ["dist/index.js"],
-      { "dist/index.js": "export {};\n" },
-      (tarball) => {
-        const result = spawnSync("node", [CHECK_SCRIPT, tarball], { encoding: "utf8" });
-
-        expect(result.status, result.stderr).toBe(0);
-        expect(result.stdout).toContain("OpenClaw package tarball integrity passed.");
-      },
-      "2026.5.20",
-      { includeShrinkwrap: false },
-    );
-  });
-
-  it("rejects package-lock.json in package tarballs", () => {
-    withTarball(
-      ["dist/index.js"],
-      { "dist/index.js": "export {};\n", "package-lock.json": "{}\n" },
-      (tarball) => {
-        const result = spawnSync("node", [CHECK_SCRIPT, tarball], { encoding: "utf8" });
-
-        expect(result.status).not.toBe(0);
-        expect(result.stderr).toContain("package tarball must not contain package-lock.json");
-      },
-      "2026.4.27",
-    );
-  });
-
-  it("rejects workspace protocol dependencies in package manifests", () => {
-    withTarball(
-      ["dist/index.js"],
-      { "dist/index.js": "export {};\n" },
-      (tarball) => {
-        const result = spawnSync("node", [CHECK_SCRIPT, tarball], { encoding: "utf8" });
-
-        expect(result.status).not.toBe(0);
-        expect(result.stderr).toContain(
-          "package.json dependencies.@openclaw/ai must not use workspace protocol workspace:*",
-        );
-      },
-      "2026.6.11",
-      { packageJson: { dependencies: { "@openclaw/ai": "workspace:*" } } },
-    );
-  });
-
-  it("rejects npm-shrinkwrap.json after the 2026.7.2 transition train", () => {
-    withTarball(
-      ["dist/index.js"],
-      { "dist/index.js": "export {};\n", "npm-shrinkwrap.json": "{}\n" },
-      (tarball) => {
-        const result = spawnSync("node", [CHECK_SCRIPT, tarball], { encoding: "utf8" });
-
-        expect(result.status).not.toBe(0);
-        expect(result.stderr).toContain("package tarball must not contain npm-shrinkwrap.json");
-      },
-      "2026.7.3",
-    );
-  });
+      version: "2026.4.27",
+      options: { postinstall: true },
+      status: "nonzero",
+      stderr: ["postinstall inventory omits packaged dist file dist/worker.js"],
+    },
+    {
+      name: "allows import.meta.url package-root probes",
+      files: { "dist/index.js": 'const root = new URL("../..", import.meta.url);\n' },
+      version: "2026.4.27",
+      status: 0,
+      successText: true,
+    },
+    {
+      name: "rejects missing Control UI assets",
+      version: "2026.4.27",
+      options: { includeControlUi: false },
+      status: "nonzero",
+      stderr: [
+        "missing required tar entry dist/control-ui/index.html",
+        "missing required tar entries under dist/control-ui/assets/",
+      ],
+    },
+    {
+      name: "rejects package tarballs without workspace templates",
+      version: "2026.6.11",
+      options: { includeWorkspaceTemplates: false },
+      status: "nonzero",
+      stderr: WORKSPACE_TEMPLATE_PACK_PATHS.map(
+        (relativePath) => `missing required tar entry ${relativePath}`,
+      ),
+    },
+    {
+      name: "allows package tarballs without npm lockfiles",
+      version: "2026.5.20",
+      options: { includeShrinkwrap: false },
+      status: 0,
+      successText: true,
+    },
+    {
+      name: "rejects package-lock.json in package tarballs",
+      files: { "dist/index.js": "export {};\n", "package-lock.json": "{}\n" },
+      version: "2026.4.27",
+      status: "nonzero",
+      stderr: ["package tarball must not contain package-lock.json"],
+    },
+    {
+      name: "rejects workspace protocol dependencies in package manifests",
+      version: "2026.6.11",
+      options: { packageJson: { dependencies: { "@openclaw/ai": "workspace:*" } } },
+      status: "nonzero",
+      stderr: [
+        "package.json dependencies.@openclaw/ai must not use workspace protocol workspace:*",
+      ],
+    },
+    {
+      name: "rejects npm-shrinkwrap.json after the 2026.7.2 transition train",
+      files: { "dist/index.js": "export {};\n", "npm-shrinkwrap.json": "{}\n" },
+      version: "2026.7.3",
+      status: "nonzero",
+      stderr: ["package tarball must not contain npm-shrinkwrap.json"],
+    },
+  ];
+  for (const testCase of packageContractCases) {
+    it(testCase.name, () => checkTarball(testCase));
+  }
 
   it.each(["2026.7.2-beta.4", "2026.7.2"])(
     "tolerates a valid shrinkwrap in the %s transition train",
     (version) => {
-      withTarball(
-        ["dist/index.js"],
-        {
+      checkTarball({
+        files: {
           "dist/index.js": "export {};\n",
           "npm-shrinkwrap.json": `${JSON.stringify({
             name: "openclaw",
@@ -756,23 +630,17 @@ describe("check-openclaw-package-tarball", () => {
             packages: { "": { name: "openclaw", version } },
           })}\n`,
         },
-        (tarball) => {
-          const result = spawnSync("node", [CHECK_SCRIPT, tarball], { encoding: "utf8" });
-          expect(result.status, result.stderr).toBe(0);
-          expect(result.stderr).toContain(
-            "2026.7.2 transition package contains npm-shrinkwrap.json",
-          );
-        },
         version,
-      );
+        status: 0,
+        stderr: ["2026.7.2 transition package contains npm-shrinkwrap.json"],
+      });
     },
   );
 
   it("accepts a valid shrinkwrap in an already-published package", () => {
     const version = "2026.6.11";
-    withTarball(
-      ["dist/index.js"],
-      {
+    checkTarball({
+      files: {
         "dist/index.js": "export {};\n",
         "npm-shrinkwrap.json": `${JSON.stringify({
           name: "openclaw",
@@ -781,92 +649,54 @@ describe("check-openclaw-package-tarball", () => {
           packages: { "": { name: "openclaw", version } },
         })}\n`,
       },
-      (tarball) => {
-        const result = spawnSync("node", [CHECK_SCRIPT, tarball], { encoding: "utf8" });
-        expect(result.status, result.stderr).toBe(0);
-      },
       version,
-    );
+      status: 0,
+    });
   });
 
-  it("accepts separately published private workspace dependencies by default", () => {
-    withTarball(
-      ["dist/index.js"],
-      { "dist/index.js": "export {};\n" },
-      (tarball) => {
-        const result = spawnSync("node", [CHECK_SCRIPT, tarball], { encoding: "utf8" });
-
-        expect(result.status, result.stderr).toBe(0);
-        expect(result.stdout).toContain("OpenClaw package tarball integrity passed.");
-      },
-      "2026.6.11",
-      { packageJson: { dependencies: { "@openclaw/ai": "2026.6.11" } } },
-    );
-  });
-
-  it("rejects private workspace dependencies that are not bundled when strict packaging requires it", () => {
-    withTarball(
-      ["dist/index.js"],
-      { "dist/index.js": "export {};\n" },
-      (tarball) => {
-        const result = spawnSync(
-          "node",
-          [CHECK_SCRIPT, "--require-bundled-workspace-deps", tarball],
-          { encoding: "utf8" },
-        );
-
-        expect(result.status).not.toBe(0);
-        expect(result.stderr).toContain(
-          "package.json dependencies.@openclaw/ai must be listed in bundleDependencies because it is private to the OpenClaw workspace",
-        );
-        expect(result.stderr).toContain(
-          "package.json dependencies.@openclaw/ai must be bundled in node_modules/@openclaw/ai",
-        );
-      },
-      "2026.6.11",
-      { packageJson: { dependencies: { "@openclaw/ai": "2026.6.11" } } },
-    );
-  });
-
-  it("rejects private workspace dependencies when only metadata is bundled", () => {
-    withTarball(
-      ["dist/index.js"],
-      {
+  const bundledRuntimeCases: NamedTarballCheck[] = [
+    {
+      name: "accepts separately published private workspace dependencies by default",
+      version: "2026.6.11",
+      options: { packageJson: { dependencies: { "@openclaw/ai": "2026.6.11" } } },
+      status: 0,
+      successText: true,
+    },
+    {
+      name: "rejects private workspace dependencies that are not bundled when strict packaging requires it",
+      version: "2026.6.11",
+      options: { packageJson: { dependencies: { "@openclaw/ai": "2026.6.11" } } },
+      strict: true,
+      status: "nonzero",
+      stderr: [
+        "package.json dependencies.@openclaw/ai must be listed in bundleDependencies because it is private to the OpenClaw workspace",
+        "package.json dependencies.@openclaw/ai must be bundled in node_modules/@openclaw/ai",
+      ],
+    },
+    {
+      name: "rejects private workspace dependencies when only metadata is bundled",
+      files: {
         "dist/index.js": "export {};\n",
         "node_modules/@openclaw/ai/package.json": AI_RUNTIME_PACKAGE_JSON,
       },
-      (tarball) => {
-        const result = spawnSync(
-          "node",
-          [CHECK_SCRIPT, "--require-bundled-workspace-deps", tarball],
-          { encoding: "utf8" },
-        );
-
-        expect(result.status).not.toBe(0);
-        expect(result.stderr).toContain(
-          "bundled @openclaw/ai is missing required runtime entry dist/index.mjs",
-        );
-        expect(result.stderr).toContain(
-          "bundled @openclaw/ai is missing required runtime entry dist/providers.mjs",
-        );
-        expect(result.stderr).toContain(
-          "bundled @openclaw/ai is missing required runtime entry dist/internal/runtime.mjs",
-        );
-      },
-      "2026.6.11",
-      {
+      version: "2026.6.11",
+      options: {
         packageJson: {
           dependencies: { "@openclaw/ai": "2026.6.11" },
           bundleDependencies: ["@openclaw/ai"],
         },
       },
-    );
-  });
-
-  it("accepts private workspace dependencies when their runtime is bundled", () => {
-    withTarball(
-      ["dist/index.js"],
-      {
+      strict: true,
+      status: "nonzero",
+      stderr: [
+        "bundled @openclaw/ai is missing required runtime entry dist/index.mjs",
+        "bundled @openclaw/ai is missing required runtime entry dist/providers.mjs",
+        "bundled @openclaw/ai is missing required runtime entry dist/internal/runtime.mjs",
+      ],
+    },
+    {
+      name: "accepts private workspace dependencies when their runtime is bundled",
+      files: {
         "dist/index.js": "export {};\n",
         "node_modules/@openclaw/ai/package.json": AI_RUNTIME_PACKAGE_JSON,
         "node_modules/@openclaw/ai/dist/index.mjs": "export {};\n",
@@ -876,60 +706,40 @@ describe("check-openclaw-package-tarball", () => {
           "export {};\n",
         "node_modules/@openclaw/ai/dist/internal/runtime.mjs": "export {};\n",
       },
-      (tarball) => {
-        const result = spawnSync(
-          "node",
-          [CHECK_SCRIPT, "--require-bundled-workspace-deps", tarball],
-          { encoding: "utf8" },
-        );
-
-        expect(result.status, result.stderr).toBe(0);
-        expect(result.stdout).toContain("OpenClaw package tarball integrity passed.");
-      },
-      "2026.6.11",
-      {
+      version: "2026.6.11",
+      options: {
         packageJson: {
           dependencies: { "@openclaw/ai": "2026.6.11" },
           bundleDependencies: ["@openclaw/ai"],
         },
       },
-    );
-  });
-
-  it("accepts frozen AI runtimes that predate an optional exported subpath", () => {
-    withTarball(
-      ["dist/index.js"],
-      {
+      strict: true,
+      status: 0,
+      successText: true,
+    },
+    {
+      name: "accepts frozen AI runtimes that predate an optional exported subpath",
+      files: {
         "dist/index.js": "export {};\n",
         "node_modules/@openclaw/ai/package.json": LEGACY_AI_RUNTIME_PACKAGE_JSON,
         "node_modules/@openclaw/ai/dist/index.mjs": "export {};\n",
         "node_modules/@openclaw/ai/dist/providers.mjs": "export {};\n",
         "node_modules/@openclaw/ai/dist/internal/runtime.mjs": "export {};\n",
       },
-      (tarball) => {
-        const result = spawnSync(
-          "node",
-          [CHECK_SCRIPT, "--require-bundled-workspace-deps", tarball],
-          { encoding: "utf8" },
-        );
-
-        expect(result.status, result.stderr).toBe(0);
-        expect(result.stdout).toContain("OpenClaw package tarball integrity passed.");
-      },
-      "2026.7.2-beta.4",
-      {
+      version: "2026.7.2-beta.4",
+      options: {
         packageJson: {
           dependencies: { "@openclaw/ai": "2026.7.2-beta.4" },
           bundleDependencies: ["@openclaw/ai"],
         },
       },
-    );
-  });
-
-  it("rejects a missing required bundled AI runtime entry", () => {
-    withTarball(
-      ["dist/index.js"],
-      {
+      strict: true,
+      status: 0,
+      successText: true,
+    },
+    {
+      name: "rejects a missing required bundled AI runtime entry",
+      files: {
         "dist/index.js": "export {};\n",
         "node_modules/@openclaw/ai/package.json": AI_RUNTIME_PACKAGE_JSON,
         "node_modules/@openclaw/ai/dist/index.mjs": "export {};\n",
@@ -938,32 +748,20 @@ describe("check-openclaw-package-tarball", () => {
           "export {};\n",
         "node_modules/@openclaw/ai/dist/internal/runtime.mjs": "export {};\n",
       },
-      (tarball) => {
-        const result = spawnSync(
-          "node",
-          [CHECK_SCRIPT, "--require-bundled-workspace-deps", tarball],
-          { encoding: "utf8" },
-        );
-
-        expect(result.status).not.toBe(0);
-        expect(result.stderr).toContain(
-          "bundled @openclaw/ai is missing required runtime entry dist/providers.mjs",
-        );
-      },
-      "2026.6.11",
-      {
+      version: "2026.6.11",
+      options: {
         packageJson: {
           dependencies: { "@openclaw/ai": "2026.6.11" },
           bundleDependencies: ["@openclaw/ai"],
         },
       },
-    );
-  });
-
-  it("rejects bundled AI entries that its manifest does not export", () => {
-    withTarball(
-      ["dist/index.js"],
-      {
+      strict: true,
+      status: "nonzero",
+      stderr: ["bundled @openclaw/ai is missing required runtime entry dist/providers.mjs"],
+    },
+    {
+      name: "rejects bundled AI entries that its manifest does not export",
+      files: {
         "dist/index.js": "export {};\n",
         "node_modules/@openclaw/ai/package.json": JSON.stringify({
           name: "@openclaw/ai",
@@ -981,32 +779,20 @@ describe("check-openclaw-package-tarball", () => {
           "export {};\n",
         "node_modules/@openclaw/ai/dist/internal/runtime.mjs": "export {};\n",
       },
-      (tarball) => {
-        const result = spawnSync(
-          "node",
-          [CHECK_SCRIPT, "--require-bundled-workspace-deps", tarball],
-          { encoding: "utf8" },
-        );
-
-        expect(result.status).not.toBe(0);
-        expect(result.stderr).toContain(
-          "bundled @openclaw/ai runtime specifier @openclaw/ai/providers is not resolvable",
-        );
-      },
-      "2026.6.11",
-      {
+      version: "2026.6.11",
+      options: {
         packageJson: {
           dependencies: { "@openclaw/ai": "2026.6.11" },
           bundleDependencies: ["@openclaw/ai"],
         },
       },
-    );
-  });
-
-  it("rejects missing relative imports from bundled AI runtime entries", () => {
-    withTarball(
-      ["dist/index.js"],
-      {
+      strict: true,
+      status: "nonzero",
+      stderr: ["bundled @openclaw/ai runtime specifier @openclaw/ai/providers is not resolvable"],
+    },
+    {
+      name: "rejects missing relative imports from bundled AI runtime entries",
+      files: {
         "dist/index.js": "export {};\n",
         "node_modules/@openclaw/ai/package.json": AI_RUNTIME_PACKAGE_JSON,
         "node_modules/@openclaw/ai/dist/index.mjs": "export {};\n",
@@ -1016,70 +802,50 @@ describe("check-openclaw-package-tarball", () => {
           "export {};\n",
         "node_modules/@openclaw/ai/dist/internal/runtime.mjs": 'export * from "./missing.mjs";\n',
       },
-      (tarball) => {
-        const result = spawnSync(
-          "node",
-          [CHECK_SCRIPT, "--require-bundled-workspace-deps", tarball],
-          { encoding: "utf8" },
-        );
-
-        expect(result.status).not.toBe(0);
-        expect(result.stderr).toContain(
-          "bundled @openclaw/ai dist/internal/runtime.mjs imports missing dist/internal/missing.mjs",
-        );
-      },
-      "2026.6.11",
-      {
+      version: "2026.6.11",
+      options: {
         packageJson: {
           dependencies: { "@openclaw/ai": "2026.6.11" },
           bundleDependencies: ["@openclaw/ai"],
         },
       },
-    );
-  });
-
-  it("rejects local build metadata entries in package tarballs", () => {
-    withTarball(
-      ["dist/index.js", ...LOCAL_BUILD_METADATA_DIST_PATHS],
-      {
+      strict: true,
+      status: "nonzero",
+      stderr: [
+        "bundled @openclaw/ai dist/internal/runtime.mjs imports missing dist/internal/missing.mjs",
+      ],
+    },
+    {
+      name: "rejects local build metadata entries in package tarballs",
+      inventory: ["dist/index.js", ...LOCAL_BUILD_METADATA_DIST_PATHS],
+      files: {
         "dist/index.js": "export {};\n",
         ...Object.fromEntries(LOCAL_BUILD_METADATA_DIST_PATHS.map((entry) => [entry, "{}\n"])),
       },
-      (tarball) => {
-        const result = spawnSync("node", [CHECK_SCRIPT, tarball], { encoding: "utf8" });
-
-        expect(result.status).not.toBe(0);
-        expect(result.stderr).toContain(
-          "forbidden local build metadata tar entry dist/.buildstamp",
-        );
-        expect(result.stderr).toContain(
-          "forbidden local build metadata tar entry dist/.runtime-postbuildstamp",
-        );
-      },
-      "2026.4.27",
-    );
-  });
-
-  it("allows local build metadata in already published legacy packages through 2026.4.26", () => {
-    withTarball(
-      ["dist/index.js", ...LOCAL_BUILD_METADATA_DIST_PATHS],
-      {
+      version: "2026.4.27",
+      status: "nonzero",
+      stderr: [
+        "forbidden local build metadata tar entry dist/.buildstamp",
+        "forbidden local build metadata tar entry dist/.runtime-postbuildstamp",
+      ],
+    },
+    {
+      name: "allows local build metadata in already published legacy packages through 2026.4.26",
+      inventory: ["dist/index.js", ...LOCAL_BUILD_METADATA_DIST_PATHS],
+      files: {
         "dist/index.js": "export {};\n",
         ...Object.fromEntries(LOCAL_BUILD_METADATA_DIST_PATHS.map((entry) => [entry, "{}\n"])),
       },
-      (tarball) => {
-        const result = spawnSync("node", [CHECK_SCRIPT, tarball], { encoding: "utf8" });
-
-        expect(result.status, result.stderr).toBe(0);
-        expect(result.stderr).toContain(
-          "legacy package includes local build metadata tar entry dist/.buildstamp",
-        );
-        expect(result.stderr).toContain(
-          "legacy package includes local build metadata tar entry dist/.runtime-postbuildstamp",
-        );
-        expect(result.stdout).toContain("OpenClaw package tarball integrity passed.");
-      },
-      "2026.4.26",
-    );
-  });
+      version: "2026.4.26",
+      status: 0,
+      successText: true,
+      stderr: [
+        "legacy package includes local build metadata tar entry dist/.buildstamp",
+        "legacy package includes local build metadata tar entry dist/.runtime-postbuildstamp",
+      ],
+    },
+  ];
+  for (const testCase of bundledRuntimeCases) {
+    it(testCase.name, () => checkTarball(testCase));
+  }
 });


### PR DESCRIPTION
## What Problem This Solves

Package-tarball tests repeat archive creation, checker execution, and output assertions across dozens of cases. Their extraction-failure fixture also stopped at permission listing, so its passing cleanup assertion did not demonstrate cleanup after extraction failed.

The first published head exposed a separate main-branch test regression: #132457's current-schema eligibility fixtures still expected version 18 after #132300 advanced the agent schema to 19. Hosted run [33250854190](https://github.com/openclaw/openclaw/actions/runs/33250854190) failed those four cases; the tarball tests were not the failing surface.

## Why This Change Was Made

One private test executor and three typed case tables replace repeated callbacks. Existing case names, registration order within each file, fixture inputs, exit-status predicates, and output assertions remain intact. The existing tarball fixture retains temporary-directory ownership. The fake tar now handles permission listing and fails specifically during extraction; the regression checks the failing phase and removal of the recorded absolute extraction directory. Production extraction cleanup was not shown to be broken.

The four stale assertions now use the already-imported `OPENCLAW_AGENT_SCHEMA_VERSION`. These fixtures construct a current database and remove only an additive column/index; they do not construct a historical version-18 database. Exact version/metadata equality, malformed transcript preservation, index/column checks, and preflight's no-repair guarantees remain. Historical migration and future-version refusal cases are unchanged. No production code or schema version is modified.

## User Impact

No user-visible behavior change. Maintainers get less duplicate test code, an extraction-cleanup test that reaches its intended boundary, and current-schema assertions that follow the fixture producer. Combined test delta: +391/-620, net 229 lines removed; production delta: zero.

## Evidence

- Original unchanged baseline: 56 cases passed (43 tarball and 13 import-parser sibling cases).
- Intended red/green: the extraction-phase assertion failed against the old fake tar and passed after its correction.
- The first consolidation passed runtime tests but failed the changed gate on inferred heterogeneous table types. Explicit `NamedTarballCheck[]` declarations fixed this without casts or relaxed assertions; its 56 focused cases and 14 changed checks then passed.
- After the hosted schema-test failure, the unchanged tarball patch was rebased onto `b3362142c72bcde6dae141e649826de10da0c000`, the four constant assertions were repaired, and the complete four-file local run passed 201 cases with four existing platform/filesystem skips. All four formerly failing cases passed. The 43 tarball and 13 parser case names and per-file order match the baseline.
- Fresh isolated precommit review: no actionable findings. The complete three-file diff and 28 owner/context datasets were reviewed; the helper refused the oversized optional whole database-test dataset before the first send. That refusal is retained, its limits were not changed, and the complete large test was inspected directly. This is not a reviewer whole-file or executed-test claim.
- The complete three-path changed gate passed all 22 checks, including all three dead-export scans, core/test-root types, and both lint lanes. Post-run verification confirmed the tested source remained unchanged and the owned processes finished. The warning-only temp-creation report compares committed revisions, so it is not coverage of the uncommitted state-test edits.
- Separate exact-published-head review completed with no actionable findings. Exact-head CI [33253187147](https://github.com/openclaw/openclaw/actions/runs/33253187147), attempt 2, is successful. Attempt 1 passed the four corrected schema cases but timed out in the unchanged historical-reader contract test (317.6 seconds against its existing 300-second limit). One unchanged local diagnostic passed that case in 23.0 seconds, including a cold historical-object fetch and checkout/removal. The CI slow phase remains unknown; no timeout, assertion, source, or historical reader was changed. One normal failed-job rerun passed; the original failure remains recorded.
- Current-main composition at `c3ce6873b8a4917a638f3f7aeb615a752c0ac06d` already contains the exact two schema-test afterimages in `16367468a7edce977360becc72443943d805593d`. The remaining merge delta is only the tarball test (+382/-616, net 234 removed). Actual landed accounting will use the real merge parent, not double-count the schema repair.
- Latest completed ClawSweeper review has no correctness findings. Its exact-head CI and normal maintainer-review before-merge requests are satisfied. Normal mandatory Testbox preparation and native merge completed successfully without rebasing or pushing another head. [Landed commit 1a064ee8](https://github.com/openclaw/openclaw/commit/1a064ee8c321e26c8257a639ed535afae4ac0009) was verified against its actual parent: all 35,132 tree entries match the parent plus the reviewed tarball-test blob; actual delta is +382/-616 (234 test lines removed), production zero. The native worktree, temporary refs and operation lock are gone; the permanent merge-outcome receipt is retained.

```sh
node scripts/run-vitest.mjs src/state/openclaw-agent-db.test.ts src/state/openclaw-database-preflight.test.ts test/scripts/check-openclaw-package-tarball.test.ts test/scripts/check-package-dist-imports.test.ts --reporter=verbose
node scripts/check-changed.mjs -- src/state/openclaw-agent-db.test.ts src/state/openclaw-database-preflight.test.ts test/scripts/check-openclaw-package-tarball.test.ts
```

Proof uses local Node 24.19 and normal repository runners. The changed gate's ratchets use `origin/main`, verified at `b3362142c72bcde6dae141e649826de10da0c000` for this run. Four existing skips cover Linux initialization cleanup, Linux hard-linked symlinks, Windows drive-relative paths, and the case-sensitive-volume hard-link case on this case-insensitive macOS volume. The exact-head hosted Linux checks are now green. This is real tar/checker and SQLite subprocess coverage, not clean-machine installation or release validation. The separate Control UI package-install suite is retained and source-reviewed, not claimed executed.


