### PR TITLE
fix: preserve compact focus in split-turn summaries

### DIFF
--- a/docs/concepts/compaction.md
+++ b/docs/concepts/compaction.md
@@ -76,6 +76,8 @@ Type `/compact` in any chat to force a compaction. Add instructions to guide the
 /compact Focus on the API design decisions
 ```
 
+Client-side compaction in the built-in OpenClaw runtime passes focus to both older-history and split-turn-prefix summaries. The host limits operator-provided focus to 800 Unicode code points and escapes it as prompt data before adding it to model requests.
+
 Client-side manual compaction uses `agents.defaults.compaction.keepRecentTokens` (default: 20,000) as its cut-point budget and keeps that recent tail in rebuilt context.
 
 ### Provider checkpoints

--- a/packages/agent-core/src/harness/compaction/compaction.test.ts
+++ b/packages/agent-core/src/harness/compaction/compaction.test.ts
@@ -874,14 +874,7 @@ describe("generateSummary thinking options", () => {
       api: model.api,
       provider: model.provider,
       model: model.id,
-      usage: {
-        input: 0,
-        output: 0,
-        cacheRead: 0,
-        cacheWrite: 0,
-        totalTokens: 0,
-        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-      },
+      usage: createUsage(0),
       stopReason: "stop",
       timestamp: 1,
     };
@@ -975,72 +968,107 @@ describe("generateSummary thinking options", () => {
 });
 
 describe("split-turn compaction", () => {
-  it("serializes history and turn-prefix summaries", async () => {
-    const model: Model = {
-      id: "summary-model",
-      name: "Summary Model",
-      api: "test-api",
-      provider: "test-provider",
-      baseUrl: "https://example.test",
-      reasoning: false,
-      input: ["text"],
-      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-      contextWindow: 100_000,
-      maxTokens: 8_000,
-    };
-    let active = 0;
-    let maxActive = 0;
-    let callCount = 0;
-    const streamFn = vi.fn<StreamFn>(() => {
-      active++;
-      maxActive = Math.max(maxActive, active);
-      callCount++;
-      const stream = createAssistantMessageEventStream();
-      setTimeout(() => {
-        active--;
-        const message: AssistantMessage = {
-          role: "assistant",
-          content: [{ type: "text", text: `summary-${callCount}` }],
-          api: model.api,
-          provider: model.provider,
-          model: model.id,
-          usage: {
-            input: 0,
-            output: 0,
-            cacheRead: 0,
-            cacheWrite: 0,
-            totalTokens: 0,
-            cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-          },
-          stopReason: "stop",
-          timestamp: 1,
-        };
-        stream.push({ type: "done", reason: "stop", message });
-        stream.end();
-      }, 5);
-      return stream;
-    });
-    const result = await compact(
-      {
-        firstKeptEntryId: "kept-entry",
-        messagesToSummarize: [{ role: "user", content: "history", timestamp: 1 }],
-        turnPrefixMessages: [{ role: "user", content: "prefix", timestamp: 2 }],
-        isSplitTurn: true,
-        tokensBefore: 100,
-        fileOps: createFileOps(),
-        settings: { enabled: true, reserveTokens: 1_000, keepRecentTokens: 100 },
-      },
-      model,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      streamFn,
-    );
+  const operatorFocus = "Preserve API decisions.";
+  it.each([
+    {
+      name: "ordinary history",
+      history: true,
+      prefix: false,
+      budgets: [800],
+      focus: operatorFocus,
+    },
+    {
+      name: "history and prefix",
+      history: true,
+      prefix: true,
+      budgets: [800, 500],
+      focus: operatorFocus,
+    },
+    { name: "prefix-only", history: false, prefix: true, budgets: [500], focus: operatorFocus },
+    {
+      name: "caller-owned instructions",
+      history: true,
+      prefix: true,
+      budgets: [800, 500],
+      focus: `<policy>${"preserve generated policy ".repeat(200)}</policy>`,
+    },
+  ])(
+    "forwards focus and serializes $name summaries",
+    async ({ history, prefix, budgets, focus }) => {
+      const model: Model = {
+        id: "summary-model",
+        name: "Summary Model",
+        api: "test-api",
+        provider: "test-provider",
+        baseUrl: "https://example.test",
+        reasoning: false,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 100_000,
+        maxTokens: 8_000,
+      };
+      const prompts: string[] = [];
+      const outputBudgets: Array<number | undefined> = [];
+      let active = 0;
+      let maxActive = 0;
+      const streamFn = vi.fn<StreamFn>((_model, context, options) => {
+        const message = context.messages[0];
+        if (message?.role !== "user") {
+          throw new Error("expected a user summary prompt");
+        }
+        prompts.push(
+          typeof message.content === "string"
+            ? message.content
+            : message.content.map((block) => (block.type === "text" ? block.text : "")).join(""),
+        );
+        outputBudgets.push(options?.maxTokens);
+        active++;
+        maxActive = Math.max(maxActive, active);
+        const stream = createAssistantMessageEventStream();
+        setTimeout(() => {
+          active--;
+          const response: AssistantMessage = {
+            role: "assistant",
+            content: [{ type: "text", text: "summary" }],
+            api: model.api,
+            provider: model.provider,
+            model: model.id,
+            usage: createUsage(0),
+            stopReason: "stop",
+            timestamp: 1,
+          };
+          stream.push({ type: "done", reason: "stop", message: response });
+          stream.end();
+        }, 5);
+        return stream;
+      });
+      const result = await compact(
+        {
+          firstKeptEntryId: "kept-entry",
+          messagesToSummarize: history ? [{ role: "user", content: "history", timestamp: 1 }] : [],
+          turnPrefixMessages: prefix ? [{ role: "user", content: "prefix", timestamp: 2 }] : [],
+          isSplitTurn: prefix,
+          tokensBefore: 100,
+          fileOps: createFileOps(),
+          settings: { enabled: true, reserveTokens: 1_000, keepRecentTokens: 100 },
+        },
+        model,
+        undefined,
+        undefined,
+        focus,
+        undefined,
+        undefined,
+        streamFn,
+      );
 
-    expect(result.ok).toBe(true);
-    expect(streamFn).toHaveBeenCalledTimes(2);
-    expect(maxActive).toBe(1);
-  });
+      expect(result.ok).toBe(true);
+      expect(streamFn).toHaveBeenCalledTimes(budgets.length);
+      expect(maxActive).toBe(1);
+      expect(outputBudgets).toEqual(budgets);
+      for (const prompt of prompts) {
+        expect(prompt).toContain(focus);
+        expect(prompt.indexOf(focus)).toBeGreaterThan(prompt.lastIndexOf("</conversation>"));
+      }
+    },
+  );
 });

--- a/packages/agent-core/src/harness/compaction/compaction.ts
+++ b/packages/agent-core/src/harness/compaction/compaction.ts
@@ -587,7 +587,10 @@ function createSummarizationOptions(
 
 /** Runs one summarization completion and maps abort/error stops to CompactionError. */
 async function runSummarizationCompletion(params: {
-  promptText: string;
+  messages: AgentMessage[];
+  prompt: string;
+  customInstructions?: string;
+  previousSummary?: string;
   model: Model;
   maxTokens: number;
   apiKey: string | undefined;
@@ -598,12 +601,22 @@ async function runSummarizationCompletion(params: {
   runtime?: AgentCoreCompletionRuntimeDeps;
   errorLabel: string;
 }): Promise<Result<string, CompactionError>> {
+  const conversationText = serializeConversation(convertToLlm(params.messages));
+  let promptText = `<conversation>\n${conversationText}\n</conversation>\n\n`;
+  if (params.previousSummary) {
+    promptText += `<previous-summary>\n${params.previousSummary}\n</previous-summary>\n\n`;
+  }
+  promptText += params.prompt;
+  // SDK callers also pass generated policy here; the host bounds raw operator focus.
+  if (params.customInstructions) {
+    promptText += `\n\nAdditional focus: ${params.customInstructions}`;
+  }
   const context = {
     systemPrompt: SUMMARIZATION_SYSTEM_PROMPT,
     messages: [
       {
         role: "user" as const,
-        content: [{ type: "text" as const, text: params.promptText }],
+        content: [{ type: "text" as const, text: promptText }],
         timestamp: Date.now(),
       },
     ],
@@ -660,20 +673,12 @@ export async function generateSummary(
     Math.floor(0.8 * reserveTokens),
     model.maxTokens > 0 ? model.maxTokens : Number.POSITIVE_INFINITY,
   );
-  let basePrompt = previousSummary ? UPDATE_SUMMARIZATION_PROMPT : SUMMARIZATION_PROMPT;
-  if (customInstructions) {
-    basePrompt = `${basePrompt}\n\nAdditional focus: ${customInstructions}`;
-  }
-  const llmMessages = convertToLlm(currentMessages);
-  const conversationText = serializeConversation(llmMessages);
-  let promptText = `<conversation>\n${conversationText}\n</conversation>\n\n`;
-  if (previousSummary) {
-    promptText += `<previous-summary>\n${previousSummary}\n</previous-summary>\n\n`;
-  }
-  promptText += basePrompt;
-
+  const prompt = previousSummary ? UPDATE_SUMMARIZATION_PROMPT : SUMMARIZATION_PROMPT;
   return await runSummarizationCompletion({
-    promptText,
+    messages: currentMessages,
+    prompt,
+    customInstructions,
+    previousSummary,
     model,
     maxTokens,
     apiKey,
@@ -968,17 +973,24 @@ export async function compact(
 
   let latestContext = "";
   if (summarizeTurnPrefix) {
-    const turnPrefixResult = await generateTurnPrefixSummary(
-      turnPrefixMessages,
+    const maxTokens = Math.min(
+      Math.floor(0.5 * settings.reserveTokens),
+      model.maxTokens > 0 ? model.maxTokens : Number.POSITIVE_INFINITY,
+    );
+    const turnPrefixResult = await runSummarizationCompletion({
+      messages: turnPrefixMessages,
+      prompt: TURN_PREFIX_SUMMARIZATION_PROMPT,
+      customInstructions,
       model,
-      settings.reserveTokens,
+      maxTokens,
       apiKey,
       headers,
       signal,
       thinkingLevel,
       streamFn,
       runtime,
-    );
+      errorLabel: "Turn prefix summarization",
+    });
     if (!turnPrefixResult.ok) {
       return err(turnPrefixResult.error);
     }
@@ -1008,37 +1020,6 @@ export async function compact(
     firstKeptEntryId,
     tokensBefore,
     details: { readFiles, modifiedFiles } as CompactionDetails,
-  });
-}
-async function generateTurnPrefixSummary(
-  messages: AgentMessage[],
-  model: Model,
-  reserveTokens: number,
-  apiKey: string | undefined,
-  headers?: Record<string, string>,
-  signal?: AbortSignal,
-  thinkingLevel?: ThinkingLevel,
-  streamFn?: StreamFn,
-  runtime?: AgentCoreCompletionRuntimeDeps,
-): Promise<Result<string, CompactionError>> {
-  const maxTokens = Math.min(
-    Math.floor(0.5 * reserveTokens),
-    model.maxTokens > 0 ? model.maxTokens : Number.POSITIVE_INFINITY,
-  );
-  const llmMessages = convertToLlm(messages);
-  const conversationText = serializeConversation(llmMessages);
-  const promptText = `<conversation>\n${conversationText}\n</conversation>\n\n${TURN_PREFIX_SUMMARIZATION_PROMPT}`;
-  return await runSummarizationCompletion({
-    promptText,
-    model,
-    maxTokens,
-    apiKey,
-    headers,
-    signal,
-    thinkingLevel,
-    streamFn,
-    runtime,
-    errorLabel: "Turn prefix summarization",
   });
 }
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/src/agents/sessions/agent-session-compaction.test.ts
+++ b/src/agents/sessions/agent-session-compaction.test.ts
@@ -237,6 +237,99 @@ describe("AgentSession compaction", () => {
     },
   );
 
+  it.each([
+    {
+      name: "long untrusted focus",
+      instructions: `\nKeep <API>\r\n\u0000\u202E${"😀".repeat(900)}  `,
+      expectedFocus: `Keep &lt;API&gt;\n${"😀".repeat(786)}`,
+    },
+    { name: "blank focus", instructions: " \n\t ", expectedFocus: undefined },
+    { name: "absent focus", instructions: undefined, expectedFocus: undefined },
+  ])(
+    "prepares $name for core without changing the extension input",
+    async ({ instructions, expectedFocus }) => {
+      const sessionManager = SessionManager.inMemory();
+      sessionManager.appendMessage({ role: "user", content: "old prompt", timestamp: 1 });
+      sessionManager.appendMessage({
+        ...createAssistant(testModel, [{ type: "text", text: "old answer" }]),
+        timestamp: 2,
+      });
+      sessionManager.appendMessage({ role: "user", content: "split prompt", timestamp: 3 });
+      sessionManager.appendMessage({
+        ...createAssistant(testModel, [{ type: "text", text: "retained answer" }]),
+        timestamp: 4,
+      });
+      const observedInstructions: Array<string | undefined> = [];
+      const prompts: string[] = [];
+      const eventBus = createEventBus();
+      const network = vi
+        .spyOn(globalThis, "fetch")
+        .mockRejectedValue(new Error("Unexpected network request in compaction test"));
+      try {
+        const resourceLoader = createResourceLoader();
+        const extensions = resourceLoader.getExtensions();
+        extensions.extensions.push(
+          await loadExtensionFromFactory(
+            (api) => {
+              api.on("session_before_compact", (event) => {
+                observedInstructions.push(event.customInstructions);
+              });
+            },
+            sessionManager.getCwd(),
+            eventBus,
+            extensions.runtime,
+          ),
+        );
+        streamMocks.streamSimple.mockImplementation((model: Model, context: Context) => {
+          const message = context.messages[0];
+          if (message?.role !== "user") {
+            throw new Error("expected a user summary prompt");
+          }
+          prompts.push(
+            typeof message.content === "string"
+              ? message.content
+              : message.content.map((block) => (block.type === "text" ? block.text : "")).join(""),
+          );
+          return createAssistantResultStream(
+            createAssistant(model, [{ type: "text", text: "compacted summary" }]),
+          );
+        });
+        const { session } = await createTestSession({
+          sessionManager,
+          resourceLoader,
+          settingsManager: SettingsManager.inMemory({
+            compaction: { enabled: false, reserveTokens: 1_000, keepRecentTokens: 1 },
+            retry: { enabled: false },
+          }),
+        });
+
+        await session.compact(instructions);
+
+        expect(observedInstructions).toEqual([instructions]);
+        expect(prompts).toHaveLength(2);
+        for (const prompt of prompts) {
+          if (expectedFocus) {
+            expect.soft(prompt).toContain(`<untrusted-text>\n${expectedFocus}\n</untrusted-text>`);
+            expect.soft(prompt).not.toContain("\u0000");
+            expect.soft(prompt).not.toContain("\u202E");
+          } else {
+            expect.soft(prompt).not.toContain("Additional focus:");
+          }
+        }
+        expect(
+          sessionManager
+            .getEntries()
+            .filter((entry) => entry.type === "compaction")
+            .map((entry) => entry.fromHook),
+        ).toEqual([false]);
+        expect(network.mock.calls.length).toBe(0);
+      } finally {
+        eventBus.clear();
+        network.mockRestore();
+      }
+    },
+  );
+
   it("preserves the automatic authentication failure as a reasoned skip", async () => {
     const { session, modelRegistry } = await createTestSession({
       settingsManager: createAutoCompactionSettings(),

--- a/src/agents/sessions/agent-session-compaction.ts
+++ b/src/agents/sessions/agent-session-compaction.ts
@@ -1,8 +1,10 @@
 import { isContextOverflow } from "@openclaw/ai/internal/runtime";
+import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { capCompactionSummary } from "../../../packages/agent-core/src/harness/compaction/compaction.js";
 import { InvalidSummaryOutputError } from "../../../packages/agent-core/src/harness/types.js";
 import type { AssistantMessage } from "../../llm/types.js";
 import { MAX_OVERFLOW_COMPACTION_ATTEMPTS } from "../agent-compaction-constants.js";
+import { resolveCompactionInstructions } from "../agent-hooks/compaction-instructions.js";
 import { sanitizeCompactionReplayMessages } from "../compaction-replay.js";
 import {
   calculateContextTokens,
@@ -13,6 +15,7 @@ import {
   type CompactionPreparation,
   type CompactionResult,
 } from "../runtime/index.js";
+import { wrapUntrustedPromptDataBlock } from "../sanitize-for-prompt.js";
 import { AgentSessionInspection } from "./agent-session-inspection.js";
 import { unwrapCoreResult } from "./agent-session-utils.js";
 import { formatNoModelSelectedMessage } from "./auth-guidance.js";
@@ -218,13 +221,20 @@ export abstract class AgentSessionCompaction extends AgentSessionInspection {
     }
 
     if (!compactionResult) {
+      // Hooks keep the original input. Only the host's core path bounds raw focus
+      // before escaping, and both summaries and any retry share this prepared text.
+      const focus = normalizeOptionalString(options.customInstructions);
+      const boundedFocus = focus ? resolveCompactionInstructions(focus, undefined) : undefined;
+      const coreInstructions = boundedFocus
+        ? wrapUntrustedPromptDataBlock({ label: "Compaction focus", text: boundedFocus })
+        : undefined;
       const runCoreCompaction = () =>
         compact(
           preparation,
           model,
           auth.apiKey,
           auth.headers,
-          options.customInstructions,
+          coreInstructions,
           options.signal,
           this.thinkingLevel,
           this.agent.streamFn,


### PR DESCRIPTION
Closes #132546 — custom focus omitted from split-turn compaction summaries.

## What Problem This Solves

Fixes an issue where users supplying `/compact` guidance could lose that guidance when client-side compaction split a long turn. In explicit `compaction.mode: "default"`, the ordinary-history request received the focus, but the separately generated prefix summary did not. Prefix-only compaction omitted the focus entirely. The same omission existed in the exposed low-level compaction API.

New configs default to safeguard mode, whose sibling path already forwarded guidance. This is not presented as an out-of-box safeguard regression or a native-runtime fix.

## Why This Change Was Made

The existing completion helper now builds the conversation, previous-summary, template, and focus portions of both requests. History and prefix keep their distinct templates, output budgets, error labels, and sequential execution, but share the instruction-forwarding path. The one-use prefix helper that dropped the parameter is removed.

The host session prepares raw operator focus once, only after extension hooks decline to supply a compaction result and before the core retry closure. It reuses the existing 800-code-point resolver and prompt-data wrapper. Hooks still receive the original full input; blank or absent focus does not introduce default language instructions. Generated structure/identifier/merge/quality guidance and low-level SDK caller-owned strings remain unchanged. No new sanitizer, helper module, export, dependency, configuration key, schema, or result shape is added.

This ownership distinction avoids a broader sanitizer migration and avoids clipping generated policy inside the shared low-level API. The public SDK export and omission are present in published stable `v2026.7.1-2` source; that is tagged-source evidence, not an executed old-release run. Shallow blame does not establish the introducing commit, so no unrelated boundary commit is blamed.

## User Impact

Client-side history and split-prefix summaries now receive the same applicable focus. Host-managed default-mode focus also gains the existing safeguard-style 800-Unicode-code-point limit and prompt-data escaping; this is intentional bounded handling, not a claim that long default-mode input remains byte-identical. The limit is documented in the [manual compaction guide](https://docs.openclaw.ai/concepts/compaction#manual-compaction).

Plugin hooks retain the original input. The low-level `compact` / `generateSummary` APIs still accept caller-owned instruction strings without a new preparation requirement, including rich generated policy longer than the host focus limit. Branch-summary replacement, provider routing, native compaction, and persistence contracts are unchanged.

## Evidence

**Before/after boundary regression.** A fresh current-main injected-completion probe showed focus present in ordinary history at an 800-token output budget, absent from mixed/prefix-only prefix requests at a 500-token output budget. The existing core serialization test was extended rather than duplicated: its final pre-fix run had **3 intended failures and 45 passing controls**. The real Session/ExtensionRunner input-boundary suite had **2 expected failures and 18 passing controls** for unbounded/unescaped and blank focus handling.

After the repair, **503 distinct tests across 13 files pass**, including core and session boundaries, instruction resolution, sanitization, branch summaries, token/image/summary budgets, identifier preservation, fallback, and outer compaction hooks. Core tests retain serialization and 800/500 budget assertions and verify that a rich caller-owned instruction string over 4K remains intact. Session tests verify original hook input, bounded/escaped Unicode focus in both requests, blank/absent behavior, one persisted compaction, and no network leakage.

```bash
node scripts/run-vitest.mjs packages/agent-core/src/harness/compaction/compaction.test.ts src/agents/sessions/agent-session-compaction.test.ts
```

```bash
node scripts/run-vitest.mjs packages/agent-core/src/harness/compaction src/agents/agent-hooks/compaction-instructions.test.ts src/agents/sanitize-for-prompt.test.ts src/agents/agent-hooks/compaction-safeguard.test.ts src/agents/compaction.identifier-preservation.test.ts src/agents/compaction.summarize-fallback.test.ts src/agents/embedded-agent-runner/compact.hooks.test.ts
```

The final fixture-only cleanup received another passing 48-case core run; repeated tests are not added to the distinct total. The initial check caught test max-lines and variable shadowing. Reusing the existing usage fixture, removing an unnecessary response-number counter, and naming the response distinctly fixed those without weakening assertions, raising limits, or adding suppressions.

**Build/check/review:** normal build passed with the final production bytes; all **29 selected canonical changed gates** passed, including core/core-test types, typed lint, formatting, import cycles, and ownership/state guards. Two isolated Codex-backed P0 reviews were clean; they inspected tests but did not execute them.

```bash
pnpm build
```

```bash
node scripts/check-changed.mjs --timed -- docs/concepts/compaction.md packages/agent-core/src/harness/compaction/compaction.test.ts packages/agent-core/src/harness/compaction/compaction.ts src/agents/sessions/agent-session-compaction.test.ts src/agents/sessions/agent-session-compaction.ts
```

**Real built-Gateway / mock-provider HTTP proof: all three cells PASS.** [Blacksmith Testbox run 33249688369](https://github.com/openclaw/openclaw/actions/runs/33249688369), lease `tbx_01m16kp4dwxag84dk34zv6pft8`, performed one fresh private-QA build and actual inbound `qa-channel /compact` flows in explicit default mode. The normal keep budget remained 20,000; the existing manual owner selected its smallest valid cut for the tiny canonical fixtures. No production planner or model callback was replaced, and the stock mock server's responses were unchanged.

| Flow | History / prefix messages | Actual summary HTTP requests | Persisted result |
| --- | --- | --- | --- |
| Ordinary history | 8 / 0 | 1 history | One core compaction/count; 300-character mock summary |
| History plus prefix | 4 / 2 | 1 history + 1 prefix | One core compaction/count; 639-character mock summary |
| Prefix only | 0 / 2 | 1 prefix | One core compaction/count; 356-character mock summary |

Each actual summary request carried the same escaped 800-code-point focus outside the conversation, with the truncated tail marker absent. The long synthetic input included `<API>`, CRLF, and supplementary CJK characters. Channel ingress normalized CRLF before the host limit; the observed prepared block was 1,694 UTF-16 units, with the same hash in all requests. HTTP output budgets were 4,096 due to the model cap; the 800/500 ratio is separately proved by the unit fixture, not inferred from Gateway requests.

Every cell passed all 38 recorded checks, delivered success, preserved original and off-branch durable history, retained session/route/preferences and the original model, and completed a normal follow-up carrying the accepted summary and retained tail without another compaction. All persisted entries were `fromHook: false`, confirming the affected core path rather than safeguard delegation. Source/build identities stayed fixed; all owned services, ports, state homes and build HOME were cleaned, and the lease was stopped before commit.

```json
{
  "proofMode": "real-built-gateway/qa-channel/mock-provider-http",
  "candidateCommit": "9cfcb5d657cf948e40e396095fb787c66c2f33d3",
  "candidateBase": "16a3200cd32cec843fc75e57a27175f08da6b4df",
  "fullIndexPatchSha256": "71639f426938c07cbefc3025b81c7500d5b50a5da0f4b462417138b8832fd5c7",
  "driverSha256": "362f858a8babcc82159f8b74f0f97129ee528f89e3688811adc7ede7980d452f",
  "preparedFocusSha256": "f4936cc2ba598bb7f97d638c761a6d75797a2d9741e4583440ce8bdfe5a4e12b",
  "ordinary": { "verdict": "PASS", "summaryRequests": 1, "acceptedCompactions": 1 },
  "mixed": { "verdict": "PASS", "summaryRequests": 2, "acceptedCompactions": 1 },
  "prefixOnly": { "verdict": "PASS", "summaryRequests": 1, "acceptedCompactions": 1 },
  "focusTransport": "identical bounded escaped block outside every summary conversation",
  "originalModelFollowup": "PASS in all three cells",
  "sourceBuildIdentityAndCleanup": "PASS in all three cells"
}
```

Proof limits: this establishes transported focus and a working Gateway flow, **not semantic model adherence** to the mock provider's canned summaries. It is not authenticated external-provider, native Codex, or safeguard quality-audit proof. Before behavior, blank/absent focus, unchanged hook input, rich SDK guidance, and output-budget ratios use composed/unit boundaries, not a baseline Gateway run. No real credentials or operator state were used. All five committed blobs were independently verified against the reviewed and Gateway-tested candidate.

**Size:** production `+42/-51` (net **-9**); tests `+196/-75` (net **+121**); docs `+2/-0`. AI-assisted; reviewed and verified by the maintainer session.
