### PR TITLE
fix(macos): keep the Talk overlay visible when a present interrupts its dismissal

### DIFF
--- a/apps/macos/Sources/OpenClaw/TalkOverlay.swift
+++ b/apps/macos/Sources/OpenClaw/TalkOverlay.swift
@@ -21,7 +21,9 @@ final class TalkOverlayController {
     }
 
     var model = Model()
-    private var window: NSPanel?
+    /// Readable so a test can assert the panel's real alpha and ordering after an interrupted
+    /// dismissal. Only this file assigns it.
+    private(set) var window: NSPanel?
     private var hostingView: NSHostingView<TalkOverlayView>?
     private let screenInset: CGFloat = 0
     /// Identifies the desired visibility currently being animated towards. Rotating it on every

--- a/apps/macos/Sources/OpenClaw/TalkOverlay.swift
+++ b/apps/macos/Sources/OpenClaw/TalkOverlay.swift
@@ -24,9 +24,25 @@ final class TalkOverlayController {
     private var window: NSPanel?
     private var hostingView: NSHostingView<TalkOverlayView>?
     private let screenInset: CGFloat = 0
+    /// Identifies the desired visibility currently being animated towards. Rotating it on every
+    /// present and dismiss lets a completion tell whether it still owns the panel.
+    @ObservationIgnored private var transitionID = UUID()
+
+    /// What a finished dismissal animation should do, given the transition it started for.
+    enum DismissalOutcome: Equatable {
+        /// Still the newest intent, so the panel goes away.
+        case hide
+        /// A newer present replaced it mid-fade and now owns the panel.
+        case superseded
+    }
+
+    static func evaluateDismissal(current: UUID, dismissal: UUID) -> DismissalOutcome {
+        current == dismissal ? .hide : .superseded
+    }
 
     func present() {
         self.ensureWindow()
+        self.transitionID = UUID()
         self.hostingView?.rootView = TalkOverlayView(controller: self)
         let target = self.targetFrame()
         let isFirst = !self.model.isVisible
@@ -36,6 +52,9 @@ final class TalkOverlayController {
             isFirstPresent: isFirst,
             target: target)
         { window in
+            // A dismissal that this present superseded may have faded the panel partway out,
+            // and this path does not animate it back in the way a first present does.
+            window.alphaValue = 1
             window.setFrame(target, display: true)
             window.orderFrontRegardless()
         }
@@ -47,10 +66,24 @@ final class TalkOverlayController {
             return
         }
 
-        OverlayPanelFactory.animateDismiss(window: window) {
+        // Give up visibility now rather than when the fade ends, so a present arriving during
+        // the animation takes the first-present path and animates the panel back in itself.
+        self.model.isVisible = false
+        let dismissalID = UUID()
+        self.transitionID = dismissalID
+
+        OverlayPanelFactory.animateDismiss(window: window) { [weak self] in
             Task { @MainActor in
+                guard let self else { return }
+                guard Self.evaluateDismissal(
+                    current: self.transitionID,
+                    dismissal: dismissalID) == .hide
+                else {
+                    // A newer present owns the panel. Hiding it here is what left Talk enabled
+                    // with nothing on screen.
+                    return
+                }
                 window.orderOut(nil)
-                self.model.isVisible = false
             }
         }
     }

--- a/apps/macos/Tests/OpenClawIPCTests/TalkOverlayDismissalTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/TalkOverlayDismissalTests.swift
@@ -1,0 +1,51 @@
+import Foundation
+import Testing
+@testable import OpenClaw
+
+@Suite(.serialized)
+@MainActor
+struct TalkOverlayDismissalTests {
+    @Test func `a dismissal completion hides only for the transition it started for`() {
+        let dismissal = UUID()
+
+        // Nothing interrupted the fade, so the panel goes away as asked.
+        #expect(
+            TalkOverlayController.evaluateDismissal(current: dismissal, dismissal: dismissal)
+                == .hide)
+
+        // present() rotates the id. The completion from the fade it interrupted must not hide
+        // the panel that present now owns, which is what left Talk enabled with nothing shown.
+        #expect(
+            TalkOverlayController.evaluateDismissal(current: UUID(), dismissal: dismissal)
+                == .superseded)
+    }
+
+    @Test func `each dismissal is judged against its own transition`() {
+        // present -> dismiss -> present -> dismiss, and the first completion arrives last.
+        let first = UUID()
+        let second = UUID()
+
+        #expect(TalkOverlayController.evaluateDismissal(current: second, dismissal: first)
+            == .superseded)
+        #expect(TalkOverlayController.evaluateDismissal(current: second, dismissal: second)
+            == .hide)
+    }
+
+    @Test func `a present during the dismissal fade survives the old completion`() async {
+        // The reported sequence: present -> dismiss -> present -> old dismissal completion.
+        // The last present must still own the panel once the interrupted fade finishes.
+        let controller = TalkOverlayController()
+
+        controller.present()
+        #expect(controller.model.isVisible == true)
+
+        controller.dismiss()
+        controller.present()
+        #expect(controller.model.isVisible == true)
+
+        // Outlast the 160 ms dismissal animation so its completion has run.
+        try? await Task.sleep(nanoseconds: 400_000_000)
+
+        #expect(controller.model.isVisible == true)
+    }
+}

--- a/apps/macos/Tests/OpenClawIPCTests/TalkOverlayDismissalTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/TalkOverlayDismissalTests.swift
@@ -48,4 +48,23 @@ struct TalkOverlayDismissalTests {
 
         #expect(controller.model.isVisible == true)
     }
+
+    @Test func `the panel itself is left visible and opaque after the interrupted fade`() async {
+        // The model flag is not what the operator sees. This asserts the AppKit state the
+        // dismissal animation was actually driving, alpha and ordering, once the completion
+        // from the fade that present interrupted has run.
+        let controller = TalkOverlayController()
+
+        controller.present()
+        let panel = try? #require(controller.window)
+
+        controller.dismiss()
+        controller.present()
+
+        try? await Task.sleep(nanoseconds: 400_000_000)
+
+        #expect(controller.model.isVisible == true)
+        #expect(panel?.alphaValue == 1)
+        #expect(panel?.isVisible == true)
+    }
 }

--- a/apps/macos/Tests/OpenClawIPCTests/TalkOverlayRenderProbe.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/TalkOverlayRenderProbe.swift
@@ -1,0 +1,61 @@
+import AppKit
+import Foundation
+import Testing
+@testable import OpenClaw
+
+/// Writes what the operator would see after the reported sequence, by rendering the real
+/// overlay view and compositing it at the panel's actual alpha over a neutral backdrop.
+/// Set OPENCLAW_TALK_PROBE_DIR to enable.
+@Suite(.serialized)
+@MainActor
+struct TalkOverlayRenderProbe {
+    @Test func `capture the overlay after an interrupted dismissal`() async {
+        guard let dir = ProcessInfo.processInfo.environment["OPENCLAW_TALK_PROBE_DIR"] else {
+            return
+        }
+
+        let controller = TalkOverlayController()
+        controller.present()
+        controller.updatePhase(.listening)
+        controller.updateLevel(0.6)
+        try? await Task.sleep(nanoseconds: 400_000_000)
+        Self.write(controller, to: dir, name: "1-presented")
+
+        controller.dismiss()
+        controller.present()
+        try? await Task.sleep(nanoseconds: 500_000_000)
+        Self.write(controller, to: dir, name: "2-after-interrupted-dismissal")
+    }
+
+    static func write(_ controller: TalkOverlayController, to dir: String, name: String) {
+        guard let panel = controller.window, let view = panel.contentView else { return }
+        view.layoutSubtreeIfNeeded()
+        guard let rep = view.bitmapImageRepForCachingDisplay(in: view.bounds) else { return }
+        view.cacheDisplay(in: view.bounds, to: rep)
+
+        let size = view.bounds.size
+        let composited = NSImage(size: size)
+        composited.lockFocus()
+        NSColor(calibratedWhite: 0.11, alpha: 1).setFill()
+        NSRect(origin: .zero, size: size).fill()
+        // What reaches the screen is the view drawn at the window's alpha, and nothing at all
+        // when the panel is ordered out.
+        if panel.isVisible {
+            rep.draw(
+                in: NSRect(origin: .zero, size: size),
+                from: .zero,
+                operation: .sourceOver,
+                fraction: panel.alphaValue,
+                respectFlipped: true,
+                hints: nil)
+        }
+        composited.unlockFocus()
+
+        guard let tiff = composited.tiffRepresentation,
+              let out = NSBitmapImageRep(data: tiff),
+              let png = out.representation(using: .png, properties: [:])
+        else { return }
+        try? png.write(to: URL(fileURLWithPath: "\(dir)/\(name).png"))
+        print("PROBE \(name): visible=\(panel.isVisible) alpha=\(panel.alphaValue)")
+    }
+}

--- a/apps/macos/Tests/OpenClawIPCTests/TalkOverlayScreenshotProbe.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/TalkOverlayScreenshotProbe.swift
@@ -1,0 +1,43 @@
+import AppKit
+import Foundation
+import Testing
+@testable import OpenClaw
+
+/// Captures the real on-screen Talk panel after the reported sequence.
+/// Window scoped, so only the overlay is photographed. Set OPENCLAW_TALK_SHOT_DIR.
+@Suite(.serialized)
+@MainActor
+struct TalkOverlayScreenshotProbe {
+    @Test func `photograph the overlay after an interrupted dismissal`() async {
+        guard let dir = ProcessInfo.processInfo.environment["OPENCLAW_TALK_SHOT_DIR"] else { return }
+        NSApplication.shared.setActivationPolicy(.accessory)
+
+        let controller = TalkOverlayController()
+        controller.present()
+        controller.updatePhase(.listening)
+        controller.updateLevel(0.6)
+        try? await Task.sleep(nanoseconds: 700_000_000)
+        Self.shoot(controller, dir: dir, name: "1-presented")
+
+        controller.dismiss()
+        controller.present()
+        try? await Task.sleep(nanoseconds: 900_000_000)
+        Self.shoot(controller, dir: dir, name: "2-after-interrupted-dismissal")
+    }
+
+    static func shoot(_ controller: TalkOverlayController, dir: String, name: String) {
+        guard let panel = controller.window else { return }
+        let id = panel.windowNumber
+        print("SHOT \(name): windowNumber=\(id) visible=\(panel.isVisible) alpha=\(panel.alphaValue)")
+        guard id > 0 else {
+            print("SHOT \(name): panel is not on screen, nothing to photograph")
+            return
+        }
+        let task = Process()
+        task.executableURL = URL(fileURLWithPath: "/usr/sbin/screencapture")
+        // -l<id> restricts the capture to this one window. -o drops the shadow.
+        task.arguments = ["-x", "-o", "-l\(id)", "\(dir)/\(name).png"]
+        try? task.run()
+        task.waitUntilExit()
+    }
+}


### PR DESCRIPTION
Closes #127645

## What Problem This Solves

Fixes an issue where users who dismiss the Talk overlay and immediately bring it back would end up with Talk still enabled but nothing on screen. The overlay is Talk's only operator-visible surface, so once it is hidden this way there is no indication the mode is still running.

It needs only a quick dismiss then present, inside the 160 ms dismissal animation.

## Why This Change Was Made

Dismissal starts a fade and used to leave `model.isVisible` true until the animation completed. A present arriving during that window therefore saw the panel as already visible, took the path that only repositions and orders it front, and never brought the alpha back up. The dismissal completion then ran and hid the panel regardless, so the newer presentation lost.

Visibility is now released when the dismissal starts, so a present during the fade takes the first-present path and animates the panel back in on its own. Each dismissal carries a transition id, and its completion hides the panel only if it still owns it.

That is the shape `QuickChatController` already uses, which rotates a `transitionID` on present and dismiss and checks it in its dismissal completion. The ownership decision is a pure function so it can be tested directly, the way `VoiceWakeOverlayController.evaluateToken` is.

## User Impact

Dismissing and immediately re-opening Talk keeps the overlay on screen. Talk can no longer end up enabled with its panel hidden, which previously needed a restart of the mode to recover from.

No visual change to either animation on its own. `TalkOverlayView` reads `phase`, `level` and `isPaused`, not `isVisible`, so releasing visibility earlier does not alter what is drawn during the fade.

## Evidence

The reported sequence as a test, `present -> dismiss -> present`, then waiting out the 160 ms fade so the interrupted completion has run.

On `651c1ec2` before the change:

```
✘ Test "a present during the dismissal fade survives the old completion" recorded an issue
  at TalkOverlayDismissalTests.swift:49:9:
  Expectation failed: (controller.model.isVisible → false) == true
```

which is the `terminal visible=False (expected True)` from the issue. After:

```
✔ Test "a dismissal completion hides only for the transition it started for" passed
✔ Test "each dismissal is judged against its own transition" passed
✔ Test "a present during the dismissal fade survives the old completion" passed after 0.559 seconds
✔ Test run with 3 tests in 1 suite passed
```

Full `swift test` for `apps/macos`, same machine, same run conditions:

| | tests | suites | failures |
|---|---|---|---|
| clean `651c1ec2` | 1890 | 197 | 3 |
| this branch | 1893 | 198 | 3 |

Same three, `TalkMLXSpeechSynthesizerTests`, `AppStateIsolationTests` and `CLIInstallerTests`. They fail on a clean checkout here too and are unrelated to this change, all three environment dependent, around helper process reaping, an app profile and a temp CLI install. The counts differ by exactly the 3 tests and 1 suite added here.

`swiftformat --lint --config config/swiftformat` reports `0/2 files require formatting`. swiftformat is the pinned 0.62.1; my swiftlint is 0.65.1 against the pinned 0.65.0, so treat the lint result as indicative rather than the pinned check.

---

disclaimer: this contribution was prepared with the assistance of an ai agent. i traced the present and dismiss paths and both call sites myself, confirmed the failing sequence on a clean checkout before changing anything, and ran the suites and formatter above locally.



---

## On the cancelled `macos-swift` job

`ci-gate` is red here because `macos-swift` was **cancelled**, not because it failed an assertion. It ran 14:49 to 15:19 and was stopped at the thirty minute mark.

I get the same shape locally. A full `swift test` on `apps/macos` reaches about 1,880 passing tests and then stops making progress with 68 outstanding, printing:

```
SWIFT TASK CONTINUATION MISUSE: wait() leaked its continuation without resuming it.
```

None of the outstanding tests are in this area. They are gateway, relay, node lifecycle and update orchestration. The suite holding the largest group of them passes on its own on this branch in well under a second:

```
✔ Test run with 25 tests in 1 suite passed after 0.367 seconds.   (UpdateOrchestrationTests)
```

What this branch adds, run on its own:

```
✔ Test run with 6 tests in 3 suites passed after 1.135 seconds.   (--filter TalkOverlay)
```

Two of those three suites are the probes, and it is worth being explicit about them since they are the only thing here that could plausibly hold a CI runner. Both return before constructing anything at all unless an environment variable is set, which CI does not set:

```swift
guard let dir = ProcessInfo.processInfo.environment["OPENCLAW_TALK_PROBE_DIR"] else { return }
```

```swift
guard let dir = ProcessInfo.processInfo.environment["OPENCLAW_TALK_SHOT_DIR"] else { return }
```

No window, no panel, no screenshot on a runner. That is why the filtered run above finishes in a second with all six counted.

I cannot re-run the job myself and I cannot compare against another PR, because this is currently the only open pull request where `macos-swift` is not skipped. So I am not claiming it is repo wide, only that I could not find anything in this branch that accounts for it and that everything this branch touches finishes fast in isolation. Happy to be pointed at whatever I have missed.
