### PR TITLE
fix(gateway): drain supervised processes on restart

### DIFF
--- a/src/cli/gateway-cli/run-loop.test.ts
+++ b/src/cli/gateway-cli/run-loop.test.ts
@@ -727,6 +727,33 @@ describe("runGatewayLoop", () => {
     });
   });
 
+  it("exits instead of starting a new lifecycle when restart close fails", async () => {
+    vi.clearAllMocks();
+
+    await withIsolatedSignals(async ({ captureSignal }) => {
+      const close = vi.fn<GatewayCloseFn>(async () => {
+        throw new TypeError("close owner failed");
+      });
+      const { start, started } = createSignaledStart(close);
+      const { runtime, exited } = createRuntimeWithExitSignal();
+      await runLoopWithStart({ start, runtime });
+      await waitForStart(started);
+
+      captureSignal("SIGUSR1")();
+
+      await waitForLoopCondition(
+        () => runtime.exit.mock.calls.length > 0 || start.mock.calls.length > 1,
+        "expected restart close failure to exit or start a new lifecycle",
+      );
+      expect(runtime.exit).toHaveBeenCalledWith(1);
+      await expect(exited).resolves.toBe(1);
+      expect(start).toHaveBeenCalledOnce();
+      expect(gatewayLog.error).toHaveBeenCalledWith(
+        "shutdown step failed (gateway server close): close owner failed",
+      );
+    });
+  });
+
   it("completes SIGTERM shutdown while sidecar startup remains unresolved", async () => {
     vi.clearAllMocks();
 

--- a/src/cli/gateway-cli/run-loop.ts
+++ b/src/cli/gateway-cli/run-loop.ts
@@ -574,6 +574,7 @@ export async function runGatewayLoop(params: {
         | "restored-in-process"
         | "restart-after-exit"
         | undefined;
+      let shutdownFailed = false;
       const restartDrainTimeoutMs = isRestart ? resolveRestartDrainTimeoutMs(restartIntent) : 0;
       const restartDrainDeadlineAt =
         isRestart && restartDrainTimeoutMs !== undefined
@@ -734,6 +735,7 @@ export async function runGatewayLoop(params: {
           ...(closeDrainTimeoutMs !== null ? { drainTimeoutMs: closeDrainTimeoutMs } : {}),
         });
       } catch (err) {
+        shutdownFailed = true;
         gatewayLog.error(`shutdown step failed (gateway server close): ${formatErrorMessage(err)}`);
       } finally {
         const handoffClosed =
@@ -743,7 +745,9 @@ export async function runGatewayLoop(params: {
         }
         if (isRestart) {
           try {
-            if (handoffClosed) {
+            if (shutdownFailed) {
+              await forceExitAfterStabilityBundle("gateway.restart_close_failed");
+            } else if (handoffClosed) {
               await handleRestartAfterServerClose(
                 managedUpdateOwner,
                 managedUpdateCancellation === "restored-in-process",

--- a/src/gateway/server-close.test.ts
+++ b/src/gateway/server-close.test.ts
@@ -13,7 +13,7 @@ import {
   setActivePluginRegistry,
 } from "../plugins/runtime.js";
 import { getProcessSupervisor, type ManagedRun } from "../process/supervisor/index.js";
-import { resolveGlobalMap } from "../shared/global-singleton.js";
+import { resolveGlobalMap, resolveGlobalSingleton } from "../shared/global-singleton.js";
 
 type TriggerInternalHookMock = (event: InternalHookEvent) => Promise<void>;
 
@@ -336,6 +336,30 @@ describe("createGatewayCloseHandler", () => {
 
     expect(lifecycleSlot.size).toBe(0);
     expect(getActivePluginRegistry()).toBeNull();
+  });
+
+  it("rejects close when an ambient lifecycle owner cannot drain", async () => {
+    const drainError = new Error("owner drain failed");
+    let rejectDrain = true;
+    resolveGlobalSingleton(
+      Symbol("openclaw.test.gatewayCloseFailedLifecycleOwner"),
+      () => ({}),
+      () => {
+        if (rejectDrain) {
+          rejectDrain = false;
+          throw drainError;
+        }
+      },
+    );
+    const clearSecretsRuntimeSnapshot = vi.fn();
+    const close = createGatewayCloseHandler(
+      createGatewayCloseTestDeps({ clearSecretsRuntimeSnapshot }),
+    );
+
+    await expect(close({ reason: "test" })).rejects.toThrow(
+      "Failed to reset global singleton lifecycle state",
+    );
+    expect(clearSecretsRuntimeSnapshot).toHaveBeenCalledOnce();
   });
 
   it.skipIf(process.platform === "win32")(

--- a/src/gateway/server-close.test.ts
+++ b/src/gateway/server-close.test.ts
@@ -387,6 +387,52 @@ describe("createGatewayCloseHandler", () => {
     },
   );
 
+  it("replaces the process supervisor after a concurrent adapter startup failure", async () => {
+    let markEmbeddingDrainStarted!: () => void;
+    const embeddingDrainStarted = new Promise<void>((resolve) => {
+      markEmbeddingDrainStarted = resolve;
+    });
+    let releaseEmbeddingDrain!: () => void;
+    const embeddingDrainReleased = new Promise<void>((resolve) => {
+      releaseEmbeddingDrain = resolve;
+    });
+    const supervisor = getProcessSupervisor();
+    const close = createGatewayCloseHandler(
+      createGatewayCloseTestDeps({
+        drainRetainedOpenAiEmbeddingProviders: async () => {
+          markEmbeddingDrainStarted();
+          await embeddingDrainReleased;
+        },
+      }),
+    );
+    const closing = close({ reason: "test" });
+    await embeddingDrainStarted;
+
+    const failedStart = supervisor.spawn({
+      mode: "child",
+      argv: [`/openclaw-missing-adapter-${process.pid}`],
+      exactEnv: true,
+      stdinMode: "pipe-closed",
+      sessionId: "gateway-close-startup-failure",
+      backendId: "gateway-close-startup-failure",
+    });
+    releaseEmbeddingDrain();
+
+    await expect(failedStart).rejects.toThrow();
+    await closing;
+    const nextSupervisor = getProcessSupervisor();
+    const run = await nextSupervisor.spawn({
+      mode: "child",
+      argv: [process.execPath, "-e", ""],
+      exactEnv: true,
+      stdinMode: "pipe-closed",
+      sessionId: "gateway-close-fresh-supervisor",
+      backendId: "gateway-close-fresh-supervisor",
+    });
+    await expect(run.wait()).resolves.toMatchObject({ reason: "exit", exitCode: 0 });
+    expect(nextSupervisor).not.toBe(supervisor);
+  });
+
   it("joins an in-flight config reload before mutable runtime teardown", async () => {
     const events: string[] = [];
     mocks.fenceSessionSuspensionWritesForGatewayShutdown.mockImplementation(() => {

--- a/src/gateway/server-close.test.ts
+++ b/src/gateway/server-close.test.ts
@@ -12,6 +12,7 @@ import {
   resetPluginRuntimeStateForTest,
   setActivePluginRegistry,
 } from "../plugins/runtime.js";
+import { getProcessSupervisor, type ManagedRun } from "../process/supervisor/index.js";
 import { resolveGlobalMap } from "../shared/global-singleton.js";
 
 type TriggerInternalHookMock = (event: InternalHookEvent) => Promise<void>;
@@ -136,6 +137,15 @@ const originalRestartTraceEnv = process.env.OPENCLAW_GATEWAY_RESTART_TRACE;
 
 function firstMockCall<T extends readonly unknown[]>(mock: { mock: { calls: readonly T[] } }) {
   return mock.mock.calls[0];
+}
+
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code === "EPERM";
+  }
 }
 
 function createTestChatRunState() {
@@ -327,6 +337,55 @@ describe("createGatewayCloseHandler", () => {
     expect(lifecycleSlot.size).toBe(0);
     expect(getActivePluginRegistry()).toBeNull();
   });
+
+  it.skipIf(process.platform === "win32")(
+    "terminates supervised process trees before Gateway close returns",
+    async () => {
+      const previousServiceMarker = process.env.OPENCLAW_SERVICE_MARKER;
+      process.env.OPENCLAW_SERVICE_MARKER = "openclaw";
+      const supervisor = getProcessSupervisor();
+      let output = "";
+      let run: ManagedRun | undefined;
+
+      try {
+        run = await supervisor.spawn({
+          mode: "child",
+          argv: [
+            "/bin/sh",
+            "-c",
+            'sleep 60 >/dev/null 2>&1 & child=$!; printf "%s %s\\n" "$$" "$child"; wait',
+          ],
+          stdinMode: "pipe-closed",
+          sessionId: "gateway-close-test",
+          backendId: "gateway-close-test",
+          onStdout: (chunk) => {
+            output += chunk;
+          },
+        });
+        await vi.waitFor(() => expect(output).toMatch(/^\d+ \d+/u));
+        const match = /^(\d+) (\d+)/u.exec(output);
+        const rootPid = Number(match?.[1]);
+        const descendantPid = Number(match?.[2]);
+        expect(isProcessAlive(rootPid)).toBe(true);
+        expect(isProcessAlive(descendantPid)).toBe(true);
+
+        const close = createGatewayCloseHandler(createGatewayCloseTestDeps());
+        await close({ reason: "test" });
+
+        expect(isProcessAlive(rootPid)).toBe(false);
+        expect(isProcessAlive(descendantPid)).toBe(false);
+        expect(getProcessSupervisor()).not.toBe(supervisor);
+      } finally {
+        run?.cancel();
+        await run?.waitForExtinction?.().catch(() => undefined);
+        if (previousServiceMarker === undefined) {
+          delete process.env.OPENCLAW_SERVICE_MARKER;
+        } else {
+          process.env.OPENCLAW_SERVICE_MARKER = previousServiceMarker;
+        }
+      }
+    },
+  );
 
   it("joins an in-flight config reload before mutable runtime teardown", async () => {
     const events: string[] = [];

--- a/src/gateway/server-close.ts
+++ b/src/gateway/server-close.ts
@@ -1052,19 +1052,18 @@ export function createGatewayCloseHandler(
       });
     } finally {
       await shutdownStep("plugin-host-registry", clearActivePluginRegistry, warnings);
-      // Rent: plugin cleanup may still read ambient slots, so drain their shared
-      // lifecycle only after the registry owner has finished retiring plugins.
-      await shutdownStep(
-        "ambient-runtime-state",
-        () => drainGlobalSingletonLifecycleState(restartExpectedMs === null ? "close" : "restart"),
-        warnings,
-      );
       // Channel and plugin teardown still resolve account credentials. Keep the
       // active snapshot until every teardown owner is done, then always scrub it.
       try {
-        params.clearSecretsRuntimeSnapshot?.();
-      } catch {
-        /* ignore */
+        // Plugin cleanup may still read ambient slots. A failed owner drain must
+        // stop restart so the next lifecycle cannot reuse incomplete shutdown.
+        await drainGlobalSingletonLifecycleState(restartExpectedMs === null ? "close" : "restart");
+      } finally {
+        try {
+          params.clearSecretsRuntimeSnapshot?.();
+        } catch {
+          /* ignore */
+        }
       }
     }
 

--- a/src/process/supervisor/index.ts
+++ b/src/process/supervisor/index.ts
@@ -1,16 +1,27 @@
 // Process supervisor barrel exposes the supervised process API.
+import { resolveGlobalSingleton } from "../../shared/global-singleton.js";
 import { createProcessSupervisor } from "./supervisor.js";
 import type { ProcessSupervisor } from "./types.js";
 
-let singleton: ProcessSupervisor | null = null;
+const holder = resolveGlobalSingleton(
+  Symbol.for("openclaw.processSupervisorHolder"),
+  (): { current: ReturnType<typeof createProcessSupervisor> | null } => ({ current: null }),
+  async (value) => {
+    const supervisor = value.current;
+    await supervisor?.shutdown();
+    if (value.current === supervisor) {
+      value.current = null;
+    }
+  },
+);
 
 /** Return the process-wide supervisor used by runtime code that does not inject one. */
 export function getProcessSupervisor(): ProcessSupervisor {
-  if (singleton) {
-    return singleton;
+  if (holder.current) {
+    return holder.current;
   }
-  singleton = createProcessSupervisor();
-  return singleton;
+  holder.current = createProcessSupervisor();
+  return holder.current;
 }
 
 export type { ManagedRun, ProcessSupervisor } from "./types.js";

--- a/src/process/supervisor/supervisor.test.ts
+++ b/src/process/supervisor/supervisor.test.ts
@@ -209,6 +209,39 @@ describe("process supervisor", () => {
     },
   );
 
+  it("fences new runs and drains an unscoped startup during shutdown", async () => {
+    const adapter = createStubChildAdapter({
+      onKill: (signal, current) => {
+        current.settle(null, signal ?? "SIGTERM");
+      },
+    });
+    const startup = createDeferred<StubChildAdapter>();
+    createChildAdapterMock.mockReturnValueOnce(startup.promise);
+    const supervisor = createProcessSupervisor();
+    const pendingRun = spawnChild(supervisor, {
+      runId: "shutdown-starting",
+      sessionId: "shutdown-starting",
+      argv: createSilentIdleArgv(),
+    });
+
+    const shutdown = supervisor.shutdown();
+    await expect(
+      spawnChild(supervisor, {
+        runId: "shutdown-late",
+        sessionId: "shutdown-late",
+        argv: createSilentIdleArgv(),
+      }),
+    ).rejects.toThrow("process supervisor is shut down");
+    expect(createChildAdapterMock).toHaveBeenCalledTimes(1);
+
+    startup.resolve(adapter);
+    const run = await pendingRun;
+    await expect(shutdown).resolves.toBeUndefined();
+
+    expect(adapter.killMock).toHaveBeenCalledWith("SIGTERM");
+    await expect(run.wait()).resolves.toMatchObject({ reason: "manual-cancel" });
+  });
+
   it("cancels every starting scoped process without canceling a later arrival", async () => {
     const runCount = 16;
     const startups = Array.from({ length: runCount }, () => createDeferred<StubChildAdapter>());

--- a/src/process/supervisor/supervisor.test.ts
+++ b/src/process/supervisor/supervisor.test.ts
@@ -242,6 +242,36 @@ describe("process supervisor", () => {
     await expect(run.wait()).resolves.toMatchObject({ reason: "manual-cancel" });
   });
 
+  it("keeps shutdown fenced when live ownership extinction fails", async () => {
+    const extinction = createDeferred();
+    const adapter = createStubChildAdapter({
+      onKill: (signal, current) => {
+        current.settle(null, signal ?? "SIGTERM");
+      },
+    });
+    adapter.waitForExtinction = () => extinction.promise;
+    createChildAdapterMock.mockResolvedValueOnce(adapter);
+    const supervisor = createProcessSupervisor();
+    await spawnChild(supervisor, {
+      runId: "shutdown-failed-extinction",
+      sessionId: "shutdown-failed-extinction",
+      argv: createSilentIdleArgv(),
+    });
+
+    const shutdown = supervisor.shutdown();
+    extinction.reject(new Error("owner extinction failed"));
+
+    await expect(shutdown).rejects.toThrow("owner extinction failed");
+    await expect(
+      spawnChild(supervisor, {
+        runId: "shutdown-after-failed-extinction",
+        sessionId: "shutdown-after-failed-extinction",
+        argv: createSilentIdleArgv(),
+      }),
+    ).rejects.toThrow("process supervisor is shut down");
+    expect(createChildAdapterMock).toHaveBeenCalledOnce();
+  });
+
   it("cancels every starting scoped process without canceling a later arrival", async () => {
     const runCount = 16;
     const startups = Array.from({ length: runCount }, () => createDeferred<StubChildAdapter>());

--- a/src/process/supervisor/supervisor.ts
+++ b/src/process/supervisor/supervisor.ts
@@ -29,6 +29,7 @@ type StartingRun = {
   scopeKey?: string;
   terminationReason?: TerminationReason;
   cancel?: (reason: TerminationReason) => void;
+  pending?: Promise<ManagedRun>;
 };
 
 type StartingScope = {
@@ -96,12 +97,15 @@ function resolveElapsedTimeoutReason(params: {
 }
 
 export function createProcessSupervisor(): ProcessSupervisor & {
+  shutdown: () => Promise<void>;
   waitForScope: (scopeKey: string) => Promise<void>;
 } {
   const registry = createRunRegistry();
   const active = new Map<string, ActiveRun>();
   const startingRuns = new Map<string, StartingRun>();
   const startingScopes = new Map<string, StartingScope>();
+  let shuttingDown = false;
+  let shutdownPromise: Promise<void> | null = null;
 
   const cancel = (runId: string, reason: TerminationReason = "manual-cancel") => {
     const current = active.get(runId);
@@ -142,12 +146,14 @@ export function createProcessSupervisor(): ProcessSupervisor & {
     }
   };
 
-  const waitForScope = async (scopeKey: string): Promise<void> => {
+  const waitForRuns = async (scopeKey: string | null): Promise<void> => {
     let firstFailure: PromiseRejectedResult | undefined;
     while (true) {
-      const starts = Array.from(startingScopes.get(scopeKey)?.runs ?? []);
+      const starts = Array.from(startingRuns.values())
+        .filter((current) => scopeKey === null || current.scopeKey === scopeKey)
+        .flatMap((current) => (current.pending ? [current.pending] : []));
       const owned = Array.from(active.values())
-        .filter((current) => current.scopeKey === scopeKey)
+        .filter((current) => scopeKey === null || current.scopeKey === scopeKey)
         .map((current) => current.waitForExtinction());
       if (starts.length === 0 && owned.length === 0) {
         if (firstFailure) {
@@ -163,6 +169,7 @@ export function createProcessSupervisor(): ProcessSupervisor & {
       );
     }
   };
+  const waitForScope = (scopeKey: string): Promise<void> => waitForRuns(scopeKey);
 
   const startRun = async (
     input: SpawnInput,
@@ -533,6 +540,9 @@ export function createProcessSupervisor(): ProcessSupervisor & {
   };
 
   const spawn = (input: SpawnInput): Promise<ManagedRun> => {
+    if (shuttingDown) {
+      return Promise.reject(new Error("process supervisor is shut down"));
+    }
     const scopeKey = normalizeOptionalString(input.scopeKey);
     const runId = normalizeOptionalString(input.runId) ?? crypto.randomUUID();
     const startingRun: StartingRun = { scopeKey };
@@ -560,6 +570,7 @@ export function createProcessSupervisor(): ProcessSupervisor & {
       previous.length > 0
         ? Promise.allSettled(previous).then(() => startRun(input, scopeKey, runId, startingRun))
         : startRun(input, scopeKey, runId, startingRun);
+    startingRun.pending = pending;
     starting?.runs.add(pending);
     if (starting && input.replaceExistingScope) {
       starting.replacement = pending;
@@ -581,10 +592,24 @@ export function createProcessSupervisor(): ProcessSupervisor & {
     return pending;
   };
 
+  const shutdown = (): Promise<void> => {
+    // Publish the admission fence before cancellation can invoke owner callbacks.
+    shuttingDown = true;
+    return (shutdownPromise ??= Promise.resolve().then(async () => {
+      while (startingRuns.size || active.size) {
+        for (const runId of new Set([...startingRuns.keys(), ...active.keys()])) {
+          cancel(runId);
+        }
+        await waitForRuns(null);
+      }
+    }));
+  };
+
   return {
     spawn,
     cancel,
     cancelScope,
+    shutdown,
     waitForScope,
     getRecord: (runId: string) => registry.get(runId),
   };

--- a/src/process/supervisor/supervisor.ts
+++ b/src/process/supervisor/supervisor.ts
@@ -146,7 +146,10 @@ export function createProcessSupervisor(): ProcessSupervisor & {
     }
   };
 
-  const waitForRuns = async (scopeKey: string | null): Promise<void> => {
+  const waitForRuns = async (
+    scopeKey: string | null,
+    ignoreStartupFailures = false,
+  ): Promise<void> => {
     let firstFailure: PromiseRejectedResult | undefined;
     while (true) {
       const starts = Array.from(startingRuns.values())
@@ -164,9 +167,9 @@ export function createProcessSupervisor(): ProcessSupervisor & {
       // Startup can become active while the snapshot settles; recheck both maps
       // so shutdown cannot outrun an admitted command or retained descendants.
       const results = await Promise.allSettled([...owned, ...starts]);
-      firstFailure ??= results.find(
-        (result): result is PromiseRejectedResult => result.status === "rejected",
-      );
+      firstFailure ??= results
+        .slice(0, ignoreStartupFailures ? owned.length : undefined)
+        .find((result): result is PromiseRejectedResult => result.status === "rejected");
     }
   };
   const waitForScope = (scopeKey: string): Promise<void> => waitForRuns(scopeKey);
@@ -600,7 +603,9 @@ export function createProcessSupervisor(): ProcessSupervisor & {
         for (const runId of new Set([...startingRuns.keys(), ...active.keys()])) {
           cancel(runId);
         }
-        await waitForRuns(null);
+        // A failed startup owns no live process; only failed owner extinction
+        // must keep the process-wide supervisor fenced for operator recovery.
+        await waitForRuns(null, true);
       }
     }));
   };


### PR DESCRIPTION
Fixes #118652.

## What Problem This Solves

Gateway close could return while process-wide supervised commands were still alive. The supervisor lived in a module-local singleton, so the existing Gateway lifecycle drain could not reach it.

The first candidate repair also converted failed process-tree extinction into a warning. An in-process restart could then start a new Gateway lifecycle with the shared supervisor still fenced.

## Root cause

The process supervisor owned child admission and tree extinction, but it was not registered as a process-wide lifecycle owner. Gateway restart also treated a rejected lifecycle-owner drain as recoverable cleanup instead of a failed close.

## Fix

- Add one idempotent supervisor shutdown path that fences admission first.
- Cancel starting and active runs, then join the existing tree-extinction promises.
- Register the process-wide holder with the existing ambient lifecycle drain.
- Clear the holder only after successful shutdown.
- Propagate ambient owner-drain failure from Gateway close.
- Use the existing forced-stop recovery path instead of starting a successor lifecycle after failed close.

## Evidence

- Exact current main `87b71210c8d1f1107e80548d9b9fb582bb849bd0`: the production Gateway close handler returned while the real supervised root process was still alive.
- Exact head `09ba4ddb2f2df839f5abecd0be41dd134b93c076`: the same real service-managed shell and descendant were both absent before close returned.
- The exact head then created a fresh supervisor and completed a real Node child spawn with exit code 0.
- On pre-correction head `a41bc1fecbdd62ea9a070265a7d92026a6919cb7`, failed owner drain resolved as a warning and the run loop started another lifecycle.
- On the exact head, failed owner drain rejects close and the run loop exits with failure before another lifecycle starts.

## Validation

- `src/gateway/server-close.test.ts`: 59 passed.
- `src/process/supervisor/supervisor.test.ts`: 25 passed.
- `src/cli/gateway-cli/run-loop.test.ts`: 61 passed.
- Process-tree, scope-extinction, anchored-shell, shared-singleton, formatting, lint, ratchet, cycle, and dead-export checks passed.
- Hosted CI owns the prohibited local TypeScript checks.

## Scope

- Production: +66/-22, net +44.
- Tests: +220/-1, net +219.
- No config, protocol, dependency, persistence, or schema change.
