### PR TITLE
fix(memory-wiki): keep dashboard calls responsive on large vaults

### DIFF
--- a/extensions/memory-wiki/index.ts
+++ b/extensions/memory-wiki/index.ts
@@ -3,6 +3,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { definePluginEntry, type OpenClawConfig } from "./api.js";
 import { registerWikiCli } from "./src/cli.js";
+import { refreshMemoryWikiIndexesAfterImport } from "./src/compile.js";
 import {
   activateMemoryWikiCompiledCacheOwner,
   configureMemoryWikiCompiledCacheStore,
@@ -146,6 +147,13 @@ export default definePluginEntry({
             await reconcileMemoryWikiCompiledCacheOwner(activeConfig, () =>
               loadMemoryWikiValidatedVaultIdentity(activeConfig.vault.path),
             );
+            if (activeConfig.ingest.autoCompile) {
+              await refreshMemoryWikiIndexesAfterImport({
+                config: activeConfig,
+                syncResult: { importedCount: 0, updatedCount: 0, removedCount: 0 },
+                rebuildInvalidCache: true,
+              });
+            }
             activeOwnerIds.add(resolveMemoryWikiCompiledCacheOwnerId(activeConfig));
           }
         } catch (error) {

--- a/extensions/memory-wiki/src/compile.ts
+++ b/extensions/memory-wiki/src/compile.ts
@@ -30,6 +30,7 @@ import {
 } from "./claim-health.js";
 import {
   createMemoryWikiCompiledCachePublicationId,
+  loadMemoryWikiCompiledCache,
   resolveMemoryWikiCompiledCacheGeneration,
   writeMemoryWikiCompiledCache,
   type MemoryWikiCompiledCacheSnapshot,
@@ -374,7 +375,12 @@ export type CompileMemoryWikiResult = {
 
 export type RefreshMemoryWikiIndexesResult = {
   refreshed: boolean;
-  reason: "auto-compile-disabled" | "no-import-changes" | "missing-indexes" | "import-changed";
+  reason:
+    | "auto-compile-disabled"
+    | "no-import-changes"
+    | "missing-indexes"
+    | "compiled-cache-invalid"
+    | "import-changed";
   compile?: CompileMemoryWikiResult;
 };
 
@@ -1459,7 +1465,8 @@ export async function refreshMemoryWikiIndexesAfterImport(params: {
     params.syncResult.updatedCount > 0 ||
     params.syncResult.removedCount > 0;
   const missingIndexes = await hasMissingWikiIndexes(params.config.vault.path);
-  if (!importChanged && !missingIndexes) {
+  const compiledCacheValid = await loadMemoryWikiCompiledCache(params.config).catch(() => null);
+  if (!importChanged && !missingIndexes && compiledCacheValid) {
     return {
       refreshed: false,
       reason: "no-import-changes",
@@ -1468,7 +1475,12 @@ export async function refreshMemoryWikiIndexesAfterImport(params: {
   const compile = await compileMemoryWikiVault(params.config);
   return {
     refreshed: true,
-    reason: missingIndexes && !importChanged ? "missing-indexes" : "import-changed",
+    reason:
+      missingIndexes && !importChanged
+        ? "missing-indexes"
+        : !importChanged && !compiledCacheValid
+          ? "compiled-cache-invalid"
+          : "import-changed",
     compile,
   };
 }

--- a/extensions/memory-wiki/src/compile.ts
+++ b/extensions/memory-wiki/src/compile.ts
@@ -1452,6 +1452,7 @@ async function hasMissingWikiIndexes(rootDir: string): Promise<boolean> {
 export async function refreshMemoryWikiIndexesAfterImport(params: {
   config: ResolvedMemoryWikiConfig;
   syncResult: { importedCount: number; updatedCount: number; removedCount: number };
+  rebuildInvalidCache?: boolean;
 }): Promise<RefreshMemoryWikiIndexesResult> {
   await initializeMemoryWikiVault(params.config);
   if (!params.config.ingest.autoCompile) {
@@ -1466,10 +1467,11 @@ export async function refreshMemoryWikiIndexesAfterImport(params: {
     params.syncResult.removedCount > 0;
   const missingIndexes = await hasMissingWikiIndexes(params.config.vault.path);
   const compiledCacheValid = await loadMemoryWikiCompiledCache(params.config).catch(() => null);
-  if (!importChanged && !missingIndexes && compiledCacheValid) {
+  const rebuildInvalidCache = params.rebuildInvalidCache === true;
+  if (!importChanged && !missingIndexes && (compiledCacheValid || !rebuildInvalidCache)) {
     return {
       refreshed: false,
-      reason: "no-import-changes",
+      reason: compiledCacheValid ? "no-import-changes" : "compiled-cache-invalid",
     };
   }
   const compile = await compileMemoryWikiVault(params.config);

--- a/extensions/memory-wiki/src/compile.ts
+++ b/extensions/memory-wiki/src/compile.ts
@@ -35,6 +35,8 @@ import {
   type MemoryWikiCompiledCacheSnapshot,
 } from "./compiled-cache.js";
 import type { ResolvedMemoryWikiConfig } from "./config.js";
+import type { MemoryWikiDashboardProjection } from "./dashboard-types.js";
+import { buildMemoryWikiImportInsightItem } from "./import-insights.js";
 import {
   appendMemoryWikiLog,
   loadMemoryWikiValidatedVaultIdentity,
@@ -59,6 +61,7 @@ import {
 import { withMemoryWikiVaultMutation } from "./mutation-coordinator.js";
 import { readMemoryWikiSourceSyncState } from "./source-sync-state.js";
 import { activateExistingMemoryWikiVault, initializeMemoryWikiVault } from "./vault.js";
+import { buildMemoryWikiOverviewItem } from "./wiki-overview.js";
 
 const COMPILE_PAGE_GROUPS: Array<{ kind: WikiPageKind; dir: string; heading: string }> = [
   { kind: "source", dir: "sources", heading: "Sources" },
@@ -387,6 +390,7 @@ async function collectMarkdownFiles(rootDir: string, relativeDir: string): Promi
 async function readPageSummaries(rootDir: string): Promise<{
   pages: WikiPageSummary[];
   frontmatterErrors: WikiPageFrontmatterError[];
+  dashboard: Record<string, MemoryWikiDashboardProjection>;
 }> {
   const filePaths = (
     await Promise.all(COMPILE_PAGE_GROUPS.map((group) => collectMarkdownFiles(rootDir, group.dir)))
@@ -399,7 +403,19 @@ async function readPageSummaries(rootDir: string): Promise<{
         () => fs.readFile(absolutePath, "utf8"),
         `read wiki page ${absolutePath}`,
       );
-      return scanWikiPageSummary({ absolutePath, relativePath, raw });
+      const result = scanWikiPageSummary({ absolutePath, relativePath, raw });
+      if (result.status !== "valid") {
+        return { result };
+      }
+      const parsed = parseWikiMarkdown(raw);
+      const importInsight = buildMemoryWikiImportInsightItem({ page: result.page, parsed });
+      return {
+        result,
+        dashboard: {
+          overview: buildMemoryWikiOverviewItem({ page: result.page, parsed }),
+          ...(importInsight ? { importInsight } : {}),
+        },
+      };
     }),
     limit: READ_PAGE_SUMMARIES_CONCURRENCY,
     errorMode: "stop",
@@ -410,10 +426,17 @@ async function readPageSummaries(rootDir: string): Promise<{
 
   return {
     pages: readResult.results
-      .flatMap((result) => (result.status === "valid" ? [result.page] : []))
+      .flatMap((entry) => (entry.result.status === "valid" ? [entry.result.page] : []))
       .toSorted((left, right) => left.title.localeCompare(right.title)),
-    frontmatterErrors: readResult.results.flatMap((result) =>
-      result.status === "invalid-frontmatter" ? [result.error] : [],
+    frontmatterErrors: readResult.results.flatMap((entry) =>
+      entry.result.status === "invalid-frontmatter" ? [entry.result.error] : [],
+    ),
+    dashboard: Object.fromEntries(
+      readResult.results.flatMap((entry) =>
+        entry.result.status === "valid" && entry.dashboard
+          ? [[entry.result.page.relativePath, entry.dashboard] as const]
+          : [],
+      ),
     ),
   };
 }
@@ -1126,10 +1149,12 @@ function sortClaims(page: WikiPageSummary): WikiClaim[] {
 
 function buildCompiledCacheSnapshot(
   pagesInput: WikiPageSummary[],
+  dashboardByPath: Record<string, MemoryWikiDashboardProjection> = {},
 ): MemoryWikiCompiledCacheSnapshot {
   const pages = [...pagesInput]
     .toSorted((left, right) => left.relativePath.localeCompare(right.relativePath))
     .map((page) => {
+      const dashboard = dashboardByPath[page.relativePath];
       return Object.assign(
         {},
         page.id ? { id: page.id } : {},
@@ -1171,6 +1196,7 @@ function buildCompiledCacheSnapshot(
               );
             }),
         },
+        dashboard ? { dashboard } : {},
       );
     });
   const claims = pagesInput
@@ -1278,7 +1304,7 @@ async function compileMemoryWikiVaultUnlocked(
     pages = scan.pages;
   }
   const counts = buildPageCounts(pages);
-  const compiledSnapshot = buildCompiledCacheSnapshot(pages);
+  const compiledSnapshot = buildCompiledCacheSnapshot(pages, scan.dashboard);
   const compiledCacheGeneration = resolveMemoryWikiCompiledCacheGeneration(compiledSnapshot);
   const compiledCachePublicationId = createMemoryWikiCompiledCachePublicationId();
   let compiledCacheSourceGeneration: string | undefined;
@@ -1335,7 +1361,7 @@ async function compileMemoryWikiVaultUnlocked(
       const sourceGenerationBeforeScan = await resolveMemoryWikiVaultSourceGeneration(rootDir);
       const verifiedScan = await readPageSummaries(rootDir);
       const verifiedGeneration = resolveMemoryWikiCompiledCacheGeneration(
-        buildCompiledCacheSnapshot(verifiedScan.pages),
+        buildCompiledCacheSnapshot(verifiedScan.pages, verifiedScan.dashboard),
       );
       const sourceGenerationAfterScan = await resolveMemoryWikiVaultSourceGeneration(rootDir);
       if (

--- a/extensions/memory-wiki/src/compiled-cache.integration.test.ts
+++ b/extensions/memory-wiki/src/compiled-cache.integration.test.ts
@@ -258,6 +258,24 @@ describe("Memory Wiki compiled cache lifecycle", () => {
     expect((await loadMemoryWikiCompiledCache(config))?.claims[0]?.text).toBe(text);
   });
 
+  it("rejects pre-dashboard cache snapshots after the format version bump", async () => {
+    const { config } = await createPersistentVault({ initialize: true });
+    const legacyStore = createMemoryWikiCompiledCacheStore(<T>(options: OpenBlobStoreOptions) => {
+      const store = createPluginBlobStoreForTests<T>("memory-wiki", options, blobStoreEnv);
+      return {
+        ...store,
+        async register(key: string, bytes: Uint8Array, metadata: T) {
+          await store.register(key, bytes, { ...metadata, version: 2 } as T);
+        },
+      };
+    });
+    configureMemoryWikiCompiledCacheStore(legacyStore);
+
+    await publishSnapshot(config, snapshot("legacy dashboard-free snapshot"));
+
+    await expect(loadMemoryWikiCompiledCache(config)).resolves.toBeNull();
+  });
+
   it("loads an externally compiled generation after lifecycle refresh without polling", async () => {
     const { config } = await createPersistentVault({
       initialize: true,

--- a/extensions/memory-wiki/src/compiled-cache.integration.test.ts
+++ b/extensions/memory-wiki/src/compiled-cache.integration.test.ts
@@ -10,7 +10,7 @@ import {
   resetPluginBlobStoreForTests,
 } from "openclaw/plugin-sdk/plugin-state-test-runtime";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { compileMemoryWikiVault } from "./compile.js";
+import { compileMemoryWikiVault, refreshMemoryWikiIndexesAfterImport } from "./compile.js";
 import {
   activateMemoryWikiCompiledCacheOwner,
   configureMemoryWikiCompiledCacheStore,
@@ -260,6 +260,7 @@ describe("Memory Wiki compiled cache lifecycle", () => {
 
   it("rejects pre-dashboard cache snapshots after the format version bump", async () => {
     const { config } = await createPersistentVault({ initialize: true });
+    await compileMemoryWikiVault(config);
     const legacyStore = createMemoryWikiCompiledCacheStore(<T>(options: OpenBlobStoreOptions) => {
       const store = createPluginBlobStoreForTests<T>("memory-wiki", options, blobStoreEnv);
       return {
@@ -274,6 +275,15 @@ describe("Memory Wiki compiled cache lifecycle", () => {
     await publishSnapshot(config, snapshot("legacy dashboard-free snapshot"));
 
     await expect(loadMemoryWikiCompiledCache(config)).resolves.toBeNull();
+
+    configureMemoryWikiCompiledCacheStore(createCacheStore());
+    await expect(
+      refreshMemoryWikiIndexesAfterImport({
+        config,
+        syncResult: { importedCount: 0, updatedCount: 0, removedCount: 0 },
+      }),
+    ).resolves.toMatchObject({ refreshed: true, reason: "compiled-cache-invalid" });
+    await expect(loadMemoryWikiCompiledCache(config)).resolves.not.toBeNull();
   });
 
   it("loads an externally compiled generation after lifecycle refresh without polling", async () => {

--- a/extensions/memory-wiki/src/compiled-cache.integration.test.ts
+++ b/extensions/memory-wiki/src/compiled-cache.integration.test.ts
@@ -282,6 +282,14 @@ describe("Memory Wiki compiled cache lifecycle", () => {
         config,
         syncResult: { importedCount: 0, updatedCount: 0, removedCount: 0 },
       }),
+    ).resolves.toMatchObject({ refreshed: false, reason: "compiled-cache-invalid" });
+    await expect(loadMemoryWikiCompiledCache(config)).resolves.toBeNull();
+    await expect(
+      refreshMemoryWikiIndexesAfterImport({
+        config,
+        syncResult: { importedCount: 0, updatedCount: 0, removedCount: 0 },
+        rebuildInvalidCache: true,
+      }),
     ).resolves.toMatchObject({ refreshed: true, reason: "compiled-cache-invalid" });
     await expect(loadMemoryWikiCompiledCache(config)).resolves.not.toBeNull();
   });

--- a/extensions/memory-wiki/src/compiled-cache.ts
+++ b/extensions/memory-wiki/src/compiled-cache.ts
@@ -17,7 +17,9 @@ const COMPILED_CACHE_NAMESPACE = "compiled-cache";
 const COMPILED_CACHE_MAX_ENTRIES = 256;
 const COMPILED_CACHE_MAX_BYTES_PER_ENTRY = 100 * 1024 * 1024;
 const COMPILED_CACHE_MAX_BYTES = 512 * 1024 * 1024;
-const COMPILED_CACHE_VERSION = 2;
+// Dashboard projections are persisted in each digest page. Bump the snapshot
+// version so pre-dashboard publications are rejected and rebuilt safely.
+const COMPILED_CACHE_VERSION = 3;
 
 export type MemoryWikiCompiledDigestClaim = {
   id?: string;

--- a/extensions/memory-wiki/src/compiled-cache.ts
+++ b/extensions/memory-wiki/src/compiled-cache.ts
@@ -5,6 +5,7 @@ import { gunzipSync, gzipSync } from "node:zlib";
 import type { PluginBlobStore } from "openclaw/plugin-sdk/plugin-state-runtime";
 import type { WikiFreshnessLevel } from "./claim-health.js";
 import type { ResolvedMemoryWikiConfig } from "./config.js";
+import type { MemoryWikiDashboardProjection } from "./dashboard-types.js";
 import type { WikiPageKind, WikiPageSummary, WikiRelationship } from "./markdown.js";
 
 export const LEGACY_MEMORY_WIKI_COMPILED_CACHE_PATHS = [
@@ -46,6 +47,7 @@ export type MemoryWikiCompiledDigestPage = {
   topRelationships: WikiRelationship[];
   claimCount: number;
   topClaims: MemoryWikiCompiledDigestClaim[];
+  dashboard?: MemoryWikiDashboardProjection;
 };
 
 export type MemoryWikiCompiledClaim = {

--- a/extensions/memory-wiki/src/dashboard-types.ts
+++ b/extensions/memory-wiki/src/dashboard-types.ts
@@ -1,0 +1,86 @@
+import type { WikiPageKind } from "./markdown.js";
+
+export type MemoryWikiImportInsightItem = {
+  pagePath: string;
+  title: string;
+  riskLevel: "low" | "medium" | "high" | "unknown";
+  riskReasons: string[];
+  labels: string[];
+  topicKey: string;
+  topicLabel: string;
+  digestStatus: "available" | "withheld";
+  activeBranchMessages: number;
+  userMessageCount: number;
+  assistantMessageCount: number;
+  firstUserLine?: string;
+  lastUserLine?: string;
+  assistantOpener?: string;
+  summary: string;
+  candidateSignals: string[];
+  correctionSignals: string[];
+  preferenceSignals: string[];
+  createdAt?: string;
+  updatedAt?: string;
+};
+
+export type MemoryWikiImportInsightCluster = {
+  key: string;
+  label: string;
+  itemCount: number;
+  highRiskCount: number;
+  withheldCount: number;
+  preferenceSignalCount: number;
+  updatedAt?: string;
+  items: MemoryWikiImportInsightItem[];
+};
+
+export type MemoryWikiImportInsightsStatus = {
+  sourceType: "chatgpt";
+  totalItems: number;
+  totalClusters: number;
+  clusters: MemoryWikiImportInsightCluster[];
+};
+
+export type MemoryWikiOverviewItem = {
+  pagePath: string;
+  title: string;
+  kind: WikiPageKind;
+  id?: string;
+  updatedAt?: string;
+  sourceType?: string;
+  claimCount: number;
+  questionCount: number;
+  contradictionCount: number;
+  claims: string[];
+  questions: string[];
+  contradictions: string[];
+  snippet?: string;
+};
+
+export type MemoryWikiOverviewCluster = {
+  key: WikiPageKind;
+  label: string;
+  itemCount: number;
+  claimCount: number;
+  questionCount: number;
+  contradictionCount: number;
+  updatedAt?: string;
+  items: MemoryWikiOverviewItem[];
+};
+
+export type MemoryWikiOverviewPageCounts = Record<WikiPageKind, number>;
+
+export type MemoryWikiOverviewStatus = {
+  totalItems: number;
+  totalPages: number;
+  pageCounts: MemoryWikiOverviewPageCounts;
+  totalClaims: number;
+  totalQuestions: number;
+  totalContradictions: number;
+  clusters: MemoryWikiOverviewCluster[];
+};
+
+export type MemoryWikiDashboardProjection = {
+  overview: MemoryWikiOverviewItem;
+  importInsight?: MemoryWikiImportInsightItem;
+};

--- a/extensions/memory-wiki/src/import-insights.test.ts
+++ b/extensions/memory-wiki/src/import-insights.test.ts
@@ -2,6 +2,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
+import { compileMemoryWikiVault } from "./compile.js";
 import { listMemoryWikiImportInsights } from "./import-insights.js";
 import { renderWikiMarkdown } from "./markdown.js";
 import { createMemoryWikiTestHarness } from "./test-helpers.js";
@@ -27,6 +28,51 @@ function hasLoneSurrogate(value: string): boolean {
 }
 
 describe("listMemoryWikiImportInsights", () => {
+  it("serves the immutable compiled projection without rereading source markdown", async () => {
+    const { rootDir, config } = await createVault({
+      prefix: "memory-wiki-import-insights-cache-",
+      initialize: true,
+    });
+    await fs.mkdir(path.join(rootDir, "sources"), { recursive: true });
+    const sourcePath = path.join(rootDir, "sources", "chatgpt-cache.md");
+    await fs.writeFile(
+      sourcePath,
+      renderWikiMarkdown({
+        frontmatter: {
+          pageType: "source",
+          title: "ChatGPT Export: cached dashboard",
+          sourceType: "chatgpt-export",
+          labels: ["topic/cache"],
+          updatedAt: "2026-02-01T00:00:00.000Z",
+        },
+        body: [
+          "# ChatGPT Export: cached dashboard",
+          "",
+          "## Auto Digest",
+          "- User messages: 1",
+          "- Assistant messages: 1",
+          "- First user line: cache this",
+          "",
+          "## Active Branch Transcript",
+          "### User",
+          "",
+          "cache this",
+          "",
+          "### Assistant",
+          "",
+          "Done.",
+        ].join("\n"),
+      }),
+      "utf8",
+    );
+    await compileMemoryWikiVault(config);
+    await fs.rm(sourcePath);
+
+    const result = await listMemoryWikiImportInsights(config);
+    expect(result.totalItems).toBe(1);
+    expect(result.clusters[0]?.items[0]?.firstUserLine).toBe("cache this");
+  });
+
   it("clusters ChatGPT import pages by topic and extracts digest fields", async () => {
     const { rootDir, config } = await createVault({
       prefix: "memory-wiki-import-insights-",

--- a/extensions/memory-wiki/src/import-insights.ts
+++ b/extensions/memory-wiki/src/import-insights.ts
@@ -1,50 +1,15 @@
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
+import { loadMemoryWikiCompiledCache } from "./compiled-cache.js";
 // Memory Wiki plugin module implements import insights behavior.
 import type { ResolvedMemoryWikiConfig } from "./config.js";
-import { parseWikiMarkdown } from "./markdown.js";
+import type {
+  MemoryWikiImportInsightItem,
+  MemoryWikiImportInsightCluster,
+  MemoryWikiImportInsightsStatus,
+} from "./dashboard-types.js";
+import { parseWikiMarkdown, type ParsedWikiMarkdown, type WikiPageSummary } from "./markdown.js";
 import { readQueryableWikiPages } from "./query.js";
-
-type MemoryWikiImportInsightItem = {
-  pagePath: string;
-  title: string;
-  riskLevel: "low" | "medium" | "high" | "unknown";
-  riskReasons: string[];
-  labels: string[];
-  topicKey: string;
-  topicLabel: string;
-  digestStatus: "available" | "withheld";
-  activeBranchMessages: number;
-  userMessageCount: number;
-  assistantMessageCount: number;
-  firstUserLine?: string;
-  lastUserLine?: string;
-  assistantOpener?: string;
-  summary: string;
-  candidateSignals: string[];
-  correctionSignals: string[];
-  preferenceSignals: string[];
-  createdAt?: string;
-  updatedAt?: string;
-};
-
-type MemoryWikiImportInsightCluster = {
-  key: string;
-  label: string;
-  itemCount: number;
-  highRiskCount: number;
-  withheldCount: number;
-  preferenceSignalCount: number;
-  updatedAt?: string;
-  items: MemoryWikiImportInsightItem[];
-};
-
-type MemoryWikiImportInsightsStatus = {
-  sourceType: "chatgpt";
-  totalItems: number;
-  totalClusters: number;
-  clusters: MemoryWikiImportInsightCluster[];
-};
 
 function normalizeStringArray(value: unknown): string[] {
   if (!Array.isArray(value)) {
@@ -296,95 +261,87 @@ function compareItemsByUpdated(
   return left.title.localeCompare(right.title);
 }
 
-export async function listMemoryWikiImportInsights(
-  config: ResolvedMemoryWikiConfig,
-): Promise<MemoryWikiImportInsightsStatus> {
-  const pages = await readQueryableWikiPages(config.vault.path);
-  const items = pages
-    .flatMap((page) => {
-      if (page.pageType !== "source") {
-        return [];
-      }
-      const parsed = parseWikiMarkdown(page.raw);
-      if (parsed.frontmatter.sourceType !== "chatgpt-export") {
-        return [];
-      }
-      const labels = normalizeStringArray(parsed.frontmatter.labels);
-      const topic = resolveTopic(labels);
-      const triageLines = extractHeadingSection(parsed.body, "Auto Triage");
-      const digestLines = extractHeadingSection(parsed.body, "Auto Digest");
-      const transcriptTurns = parseTranscriptTurns(parsed.body);
-      const digestStatus = digestLines.some((line) =>
-        line.toLowerCase().includes("withheld from durable-candidate generation"),
-      )
-        ? "withheld"
-        : "available";
-      const exposeImportContent = shouldExposeImportContent(digestStatus);
-      const userTurns = transcriptTurns.filter((turn) => turn.role === "user");
-      const assistantTurns = transcriptTurns.filter((turn) => turn.role === "assistant");
-      const assistantOpener = exposeImportContent
-        ? firstParagraph(assistantTurns[0]?.text ?? "")
-        : undefined;
-      const correctionSignals = exposeImportContent
-        ? extractCorrectionSignals(transcriptTurns)
-        : [];
-      const preferenceSignals = exposeImportContent ? extractPreferenceSignals(digestLines) : [];
-      const candidateSignals = exposeImportContent
-        ? deriveCandidateSignals({
-            preferenceSignals,
-            correctionSignals,
-          })
-        : [];
-      const firstUserLine = exposeImportContent
-        ? extractDigestField(digestLines, "First user line")
-        : undefined;
-      const lastUserLine = exposeImportContent
-        ? extractDigestField(digestLines, "Last user line")
-        : undefined;
-      const createdAt = normalizeOptionalString(parsed.frontmatter.createdAt);
-      const updatedAt = normalizeOptionalString(parsed.frontmatter.updatedAt);
-      return [
-        {
-          pagePath: page.relativePath,
-          title: page.title.replace(/^ChatGPT Export:\s*/i, ""),
-          riskLevel: normalizeRiskLevel(parsed.frontmatter.riskLevel),
-          riskReasons: normalizeStringArray(parsed.frontmatter.riskReasons),
-          labels,
-          topicKey: topic.key,
-          topicLabel: topic.label,
-          digestStatus,
-          activeBranchMessages: extractIntegerField(triageLines, "Active-branch messages"),
-          userMessageCount: Math.max(
-            extractIntegerField(digestLines, "User messages"),
-            userTurns.length,
-          ),
-          assistantMessageCount: Math.max(
-            extractIntegerField(digestLines, "Assistant messages"),
-            assistantTurns.length,
-          ),
-          ...(firstUserLine ? { firstUserLine } : {}),
-          ...(lastUserLine ? { lastUserLine } : {}),
-          ...(assistantOpener ? { assistantOpener } : {}),
-          summary: deriveSummary({
-            title: page.title.replace(/^ChatGPT Export:\s*/i, ""),
-            digestStatus,
-            ...(assistantOpener ? { assistantOpener } : {}),
-            ...(firstUserLine ? { firstUserLine } : {}),
-            riskReasons: normalizeStringArray(parsed.frontmatter.riskReasons),
-            topicLabel: topic.label,
-          }),
-          candidateSignals,
-          correctionSignals,
-          preferenceSignals,
-          ...(createdAt ? { createdAt } : {}),
-          ...(updatedAt ? { updatedAt } : {}),
-        } satisfies MemoryWikiImportInsightItem,
-      ];
-    })
-    .toSorted(compareItemsByUpdated);
+export function buildMemoryWikiImportInsightItem(params: {
+  page: WikiPageSummary;
+  parsed: ParsedWikiMarkdown;
+}): MemoryWikiImportInsightItem | null {
+  const { page, parsed } = params;
+  if (page.pageType !== "source" || parsed.frontmatter.sourceType !== "chatgpt-export") {
+    return null;
+  }
+  const labels = normalizeStringArray(parsed.frontmatter.labels);
+  const topic = resolveTopic(labels);
+  const triageLines = extractHeadingSection(parsed.body, "Auto Triage");
+  const digestLines = extractHeadingSection(parsed.body, "Auto Digest");
+  const transcriptTurns = parseTranscriptTurns(parsed.body);
+  const digestStatus = digestLines.some((line) =>
+    line.toLowerCase().includes("withheld from durable-candidate generation"),
+  )
+    ? "withheld"
+    : "available";
+  const exposeImportContent = shouldExposeImportContent(digestStatus);
+  const userTurns = transcriptTurns.filter((turn) => turn.role === "user");
+  const assistantTurns = transcriptTurns.filter((turn) => turn.role === "assistant");
+  const assistantOpener = exposeImportContent
+    ? firstParagraph(assistantTurns[0]?.text ?? "")
+    : undefined;
+  const correctionSignals = exposeImportContent ? extractCorrectionSignals(transcriptTurns) : [];
+  const preferenceSignals = exposeImportContent ? extractPreferenceSignals(digestLines) : [];
+  const candidateSignals = exposeImportContent
+    ? deriveCandidateSignals({
+        preferenceSignals,
+        correctionSignals,
+      })
+    : [];
+  const firstUserLine = exposeImportContent
+    ? extractDigestField(digestLines, "First user line")
+    : undefined;
+  const lastUserLine = exposeImportContent
+    ? extractDigestField(digestLines, "Last user line")
+    : undefined;
+  const createdAt = normalizeOptionalString(parsed.frontmatter.createdAt);
+  const updatedAt = normalizeOptionalString(parsed.frontmatter.updatedAt);
+  return {
+    pagePath: page.relativePath,
+    title: page.title.replace(/^ChatGPT Export:\s*/i, ""),
+    riskLevel: normalizeRiskLevel(parsed.frontmatter.riskLevel),
+    riskReasons: normalizeStringArray(parsed.frontmatter.riskReasons),
+    labels,
+    topicKey: topic.key,
+    topicLabel: topic.label,
+    digestStatus,
+    activeBranchMessages: extractIntegerField(triageLines, "Active-branch messages"),
+    userMessageCount: Math.max(extractIntegerField(digestLines, "User messages"), userTurns.length),
+    assistantMessageCount: Math.max(
+      extractIntegerField(digestLines, "Assistant messages"),
+      assistantTurns.length,
+    ),
+    ...(firstUserLine ? { firstUserLine } : {}),
+    ...(lastUserLine ? { lastUserLine } : {}),
+    ...(assistantOpener ? { assistantOpener } : {}),
+    summary: deriveSummary({
+      title: page.title.replace(/^ChatGPT Export:\s*/i, ""),
+      digestStatus,
+      ...(assistantOpener ? { assistantOpener } : {}),
+      ...(firstUserLine ? { firstUserLine } : {}),
+      riskReasons: normalizeStringArray(parsed.frontmatter.riskReasons),
+      topicLabel: topic.label,
+    }),
+    candidateSignals,
+    correctionSignals,
+    preferenceSignals,
+    ...(createdAt ? { createdAt } : {}),
+    ...(updatedAt ? { updatedAt } : {}),
+  } satisfies MemoryWikiImportInsightItem;
+}
+
+function buildImportInsightsStatus(
+  items: MemoryWikiImportInsightItem[],
+): MemoryWikiImportInsightsStatus {
+  const sortedItems = [...items].toSorted(compareItemsByUpdated);
 
   const clustersByKey = new Map<string, MemoryWikiImportInsightItem[]>();
-  for (const item of items) {
+  for (const item of sortedItems) {
     const list = clustersByKey.get(item.topicKey) ?? [];
     list.push(item);
     clustersByKey.set(item.topicKey, list);
@@ -392,24 +349,25 @@ export async function listMemoryWikiImportInsights(
 
   const clusters = [...clustersByKey.entries()]
     .map(([key, clusterItems]) => {
-      const sortedItems = [...clusterItems].toSorted(compareItemsByUpdated);
-      const updatedAt = sortedItems
+      const clusterSortedItems = [...clusterItems].toSorted(compareItemsByUpdated);
+      const updatedAt = clusterSortedItems
         .map((item) => item.updatedAt ?? item.createdAt)
         .find((value): value is string => typeof value === "string" && value.length > 0);
       return Object.assign(
         {
           key,
-          label: sortedItems[0]?.topicLabel ?? humanizeLabelSuffix(key),
-          itemCount: sortedItems.length,
-          highRiskCount: sortedItems.filter((item) => item.riskLevel === `high`).length,
-          withheldCount: sortedItems.filter((item) => item.digestStatus === `withheld`).length,
-          preferenceSignalCount: sortedItems.reduce(
+          label: clusterSortedItems[0]?.topicLabel ?? humanizeLabelSuffix(key),
+          itemCount: clusterSortedItems.length,
+          highRiskCount: clusterSortedItems.filter((item) => item.riskLevel === `high`).length,
+          withheldCount: clusterSortedItems.filter((item) => item.digestStatus === `withheld`)
+            .length,
+          preferenceSignalCount: clusterSortedItems.reduce(
             (sum, item) => sum + item.preferenceSignals.length,
             0,
           ),
         },
         updatedAt ? { updatedAt } : {},
-        { items: sortedItems },
+        { items: clusterSortedItems },
       ) satisfies MemoryWikiImportInsightCluster;
     })
     .toSorted((left, right) => {
@@ -426,8 +384,29 @@ export async function listMemoryWikiImportInsights(
 
   return {
     sourceType: "chatgpt",
-    totalItems: items.length,
+    totalItems: sortedItems.length,
     totalClusters: clusters.length,
     clusters,
   };
+}
+
+export async function listMemoryWikiImportInsights(
+  config: ResolvedMemoryWikiConfig,
+): Promise<MemoryWikiImportInsightsStatus> {
+  const compiled = await loadMemoryWikiCompiledCache(config).catch(() => null);
+  if (compiled) {
+    const items = compiled.digest.pages.flatMap((page) =>
+      page.dashboard?.importInsight ? [page.dashboard.importInsight] : [],
+    );
+    return buildImportInsightsStatus(items);
+  }
+  const pages = await readQueryableWikiPages(config.vault.path);
+  const items = pages.flatMap((page) => {
+    const item = buildMemoryWikiImportInsightItem({
+      page,
+      parsed: parseWikiMarkdown(page.raw),
+    });
+    return item ? [item] : [];
+  });
+  return buildImportInsightsStatus(items);
 }

--- a/extensions/memory-wiki/src/markdown.ts
+++ b/extensions/memory-wiki/src/markdown.ts
@@ -20,7 +20,7 @@ export const WIKI_RAW_SOURCE_MARKER = "<!-- openclaw:wiki:raw-source -->";
 export type WikiPageKind = (typeof WIKI_PAGE_KINDS)[number];
 type GeneratedSourceBody = "bridge" | "unsafe-local" | "local-file" | "chatgpt-export";
 
-type ParsedWikiMarkdown = {
+export type ParsedWikiMarkdown = {
   hasFrontmatter: boolean;
   frontmatter: Record<string, unknown>;
   body: string;

--- a/extensions/memory-wiki/src/wiki-overview.test.ts
+++ b/extensions/memory-wiki/src/wiki-overview.test.ts
@@ -2,6 +2,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
+import { compileMemoryWikiVault } from "./compile.js";
 import { renderWikiMarkdown } from "./markdown.js";
 import { createMemoryWikiTestHarness } from "./test-helpers.js";
 import { listMemoryWikiOverview } from "./wiki-overview.js";
@@ -9,6 +10,35 @@ import { listMemoryWikiOverview } from "./wiki-overview.js";
 const { createVault } = createMemoryWikiTestHarness();
 
 describe("listMemoryWikiOverview", () => {
+  it("serves the immutable compiled projection without rereading source markdown", async () => {
+    const { rootDir, config } = await createVault({
+      prefix: "memory-wiki-overview-cache-",
+      initialize: true,
+    });
+    await fs.mkdir(path.join(rootDir, "entities"), { recursive: true });
+    const entityPath = path.join(rootDir, "entities", "cached.md");
+    await fs.writeFile(
+      entityPath,
+      renderWikiMarkdown({
+        frontmatter: {
+          pageType: "entity",
+          title: "Cached entity",
+          claims: [{ text: "The compiled dashboard is immutable." }],
+          updatedAt: "2026-02-01T00:00:00.000Z",
+        },
+        body: "# Cached entity\n\nThe dashboard reads this summary from the publication.",
+      }),
+      "utf8",
+    );
+    await compileMemoryWikiVault(config);
+    await fs.rm(entityPath);
+
+    const result = await listMemoryWikiOverview(config);
+    const entity = result.clusters.find((cluster) => cluster.key === "entity")?.items[0];
+    expect(entity?.title).toBe("Cached entity");
+    expect(entity?.snippet).toBe("The dashboard reads this summary from the publication.");
+  });
+
   it("groups wiki pages by kind and surfaces claims, questions, and contradictions", async () => {
     const { rootDir, config } = await createVault({
       prefix: "memory-wiki-overview-",

--- a/extensions/memory-wiki/src/wiki-overview.test.ts
+++ b/extensions/memory-wiki/src/wiki-overview.test.ts
@@ -39,6 +39,76 @@ describe("listMemoryWikiOverview", () => {
     expect(entity?.snippet).toBe("The dashboard reads this summary from the publication.");
   });
 
+  it("keeps cached overview eligibility and ordering aligned with the raw reader", async () => {
+    const { rootDir, config } = await createVault({
+      prefix: "memory-wiki-overview-cache-parity-",
+      initialize: true,
+    });
+    await fs.mkdir(path.join(rootDir, "entities"), { recursive: true });
+    await fs.mkdir(path.join(rootDir, "sources"), { recursive: true });
+    await fs.mkdir(path.join(rootDir, "reports"), { recursive: true });
+
+    await fs.writeFile(
+      path.join(rootDir, "entities", "a.md"),
+      renderWikiMarkdown({
+        frontmatter: {
+          pageType: "entity",
+          title: "Alpha",
+          claims: [{ text: "Alpha has one claim." }],
+          updatedAt: "2026-04-01T00:00:00.000Z",
+        },
+        body: "# Alpha\n",
+      }),
+      "utf8",
+    );
+    await fs.writeFile(
+      path.join(rootDir, "entities", "b.md"),
+      renderWikiMarkdown({
+        frontmatter: {
+          pageType: "entity",
+          title: "Zulu",
+          claims: [{ text: "Zulu has the first claim." }, { text: "Zulu has the second claim." }],
+          updatedAt: "2026-04-02T00:00:00.000Z",
+        },
+        body: "# Zulu\n",
+      }),
+      "utf8",
+    );
+    await fs.writeFile(
+      path.join(rootDir, "sources", "empty.md"),
+      renderWikiMarkdown({
+        frontmatter: {
+          pageType: "source",
+          title: "Empty source",
+          updatedAt: "2026-04-03T00:00:00.000Z",
+        },
+        body: "# Empty source\n",
+      }),
+      "utf8",
+    );
+    await fs.writeFile(
+      path.join(rootDir, "reports", "empty.md"),
+      renderWikiMarkdown({
+        frontmatter: {
+          pageType: "report",
+          title: "Empty report",
+          updatedAt: "2026-04-04T00:00:00.000Z",
+        },
+        body: "# Empty report\n",
+      }),
+      "utf8",
+    );
+
+    await compileMemoryWikiVault(config);
+
+    const result = await listMemoryWikiOverview(config);
+    const entityItems = result.clusters.find((cluster) => cluster.key === "entity")?.items ?? [];
+
+    expect(entityItems.map((item) => item.title)).toEqual(["Zulu", "Alpha"]);
+    expect(result.clusters.some((cluster) => cluster.key === "source")).toBe(false);
+    expect(result.clusters.some((cluster) => cluster.key === "report")).toBe(false);
+  });
+
   it("groups wiki pages by kind and surfaces claims, questions, and contradictions", async () => {
     const { rootDir, config } = await createVault({
       prefix: "memory-wiki-overview-",

--- a/extensions/memory-wiki/src/wiki-overview.ts
+++ b/extensions/memory-wiki/src/wiki-overview.ts
@@ -1,7 +1,19 @@
 // Memory Wiki plugin module implements the memory wiki overview.
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { loadMemoryWikiCompiledCache } from "./compiled-cache.js";
 import type { ResolvedMemoryWikiConfig } from "./config.js";
-import { parseWikiMarkdown, type WikiPageKind } from "./markdown.js";
+import type {
+  MemoryWikiOverviewCluster,
+  MemoryWikiOverviewItem,
+  MemoryWikiOverviewPageCounts,
+  MemoryWikiOverviewStatus,
+} from "./dashboard-types.js";
+import {
+  parseWikiMarkdown,
+  type ParsedWikiMarkdown,
+  type WikiPageKind,
+  type WikiPageSummary,
+} from "./markdown.js";
 import { readQueryableWikiPages } from "./query.js";
 
 const OVERVIEW_KIND_ORDER: WikiPageKind[] = ["synthesis", "entity", "concept", "source", "report"];
@@ -12,45 +24,6 @@ const OVERVIEW_KIND_LABELS: Record<WikiPageKind, string> = {
   concept: "Concepts",
   source: "Sources",
   report: "Reports",
-};
-
-type MemoryWikiOverviewItem = {
-  pagePath: string;
-  title: string;
-  kind: WikiPageKind;
-  id?: string;
-  updatedAt?: string;
-  sourceType?: string;
-  claimCount: number;
-  questionCount: number;
-  contradictionCount: number;
-  claims: string[];
-  questions: string[];
-  contradictions: string[];
-  snippet?: string;
-};
-
-type MemoryWikiOverviewCluster = {
-  key: WikiPageKind;
-  label: string;
-  itemCount: number;
-  claimCount: number;
-  questionCount: number;
-  contradictionCount: number;
-  updatedAt?: string;
-  items: MemoryWikiOverviewItem[];
-};
-
-type MemoryWikiOverviewPageCounts = Record<WikiPageKind, number>;
-
-type MemoryWikiOverviewStatus = {
-  totalItems: number;
-  totalPages: number;
-  pageCounts: MemoryWikiOverviewPageCounts;
-  totalClaims: number;
-  totalQuestions: number;
-  totalContradictions: number;
-  clusters: MemoryWikiOverviewCluster[];
 };
 
 function createEmptyOverviewPageCounts(): MemoryWikiOverviewPageCounts {
@@ -96,6 +69,28 @@ function compareOverviewItems(left: MemoryWikiOverviewItem, right: MemoryWikiOve
 export async function listMemoryWikiOverview(
   config: ResolvedMemoryWikiConfig,
 ): Promise<MemoryWikiOverviewStatus> {
+  const compiled = await loadMemoryWikiCompiledCache(config).catch(() => null);
+  if (compiled) {
+    const pageCounts = createEmptyOverviewPageCounts();
+    let totalClaims = 0;
+    let totalQuestions = 0;
+    let totalContradictions = 0;
+    const items = compiled.digest.pages.flatMap((page) => {
+      pageCounts[page.kind] += 1;
+      totalClaims += page.claimCount;
+      totalQuestions += page.questions.length;
+      totalContradictions += page.contradictions.length;
+      return page.dashboard?.overview ? [page.dashboard.overview] : [];
+    });
+    return buildMemoryWikiOverviewStatus({
+      items,
+      totalPages: compiled.digest.pages.length,
+      pageCounts,
+      totalClaims,
+      totalQuestions,
+      totalContradictions,
+    });
+  }
   const pages = await readQueryableWikiPages(config.vault.path);
   const pageCounts = pages.reduce<MemoryWikiOverviewPageCounts>((counts, page) => {
     counts[page.kind] += 1;
@@ -105,26 +100,7 @@ export async function listMemoryWikiOverview(
   const totalQuestions = pages.reduce((sum, page) => sum + page.questions.length, 0);
   const totalContradictions = pages.reduce((sum, page) => sum + page.contradictions.length, 0);
   const items = pages
-    .map((page) => {
-      const parsed = parseWikiMarkdown(page.raw);
-      const updatedAt = normalizeOptionalString(page.updatedAt);
-      const sourceType = normalizeOptionalString(page.sourceType);
-      return Object.assign(
-        { pagePath: page.relativePath, title: page.title, kind: page.kind },
-        page.id ? { id: page.id } : {},
-        updatedAt ? { updatedAt } : {},
-        sourceType ? { sourceType } : {},
-        {
-          claimCount: page.claims.length,
-          questionCount: page.questions.length,
-          contradictionCount: page.contradictions.length,
-          claims: page.claims.map((claim) => claim.text).slice(0, 3),
-          questions: page.questions.slice(0, 3),
-          contradictions: page.contradictions.slice(0, 3),
-        },
-        extractSnippet(parsed.body) ? { snippet: extractSnippet(parsed.body) } : {},
-      ) satisfies MemoryWikiOverviewItem;
-    })
+    .map((page) => buildMemoryWikiOverviewItem({ page, parsed: parseWikiMarkdown(page.raw) }))
     .filter(
       (item) =>
         PRIMARY_OVERVIEW_KINDS.has(item.kind) ||
@@ -134,6 +110,25 @@ export async function listMemoryWikiOverview(
     )
     .toSorted(compareOverviewItems);
 
+  return buildMemoryWikiOverviewStatus({
+    items,
+    totalPages: pages.length,
+    pageCounts,
+    totalClaims,
+    totalQuestions,
+    totalContradictions,
+  });
+}
+
+function buildMemoryWikiOverviewStatus(params: {
+  items: MemoryWikiOverviewItem[];
+  totalPages: number;
+  pageCounts: MemoryWikiOverviewPageCounts;
+  totalClaims: number;
+  totalQuestions: number;
+  totalContradictions: number;
+}): MemoryWikiOverviewStatus {
+  const items = params.items;
   const clusters = OVERVIEW_KIND_ORDER.map((kind) => {
     const clusterItems = items.filter((item) => item.kind === kind);
     if (clusterItems.length === 0) {
@@ -155,11 +150,35 @@ export async function listMemoryWikiOverview(
 
   return {
     totalItems: items.length,
-    totalPages: pages.length,
-    pageCounts,
-    totalClaims,
-    totalQuestions,
-    totalContradictions,
+    totalPages: params.totalPages,
+    pageCounts: params.pageCounts,
+    totalClaims: params.totalClaims,
+    totalQuestions: params.totalQuestions,
+    totalContradictions: params.totalContradictions,
     clusters,
   };
+}
+
+export function buildMemoryWikiOverviewItem(params: {
+  page: WikiPageSummary;
+  parsed: ParsedWikiMarkdown;
+}): MemoryWikiOverviewItem {
+  const { page, parsed } = params;
+  const updatedAt = normalizeOptionalString(page.updatedAt);
+  const sourceType = normalizeOptionalString(page.sourceType);
+  return Object.assign(
+    { pagePath: page.relativePath, title: page.title, kind: page.kind },
+    page.id ? { id: page.id } : {},
+    updatedAt ? { updatedAt } : {},
+    sourceType ? { sourceType } : {},
+    {
+      claimCount: page.claims.length,
+      questionCount: page.questions.length,
+      contradictionCount: page.contradictions.length,
+      claims: page.claims.map((claim) => claim.text).slice(0, 3),
+      questions: page.questions.slice(0, 3),
+      contradictions: page.contradictions.slice(0, 3),
+    },
+    extractSnippet(parsed.body) ? { snippet: extractSnippet(parsed.body) } : {},
+  ) satisfies MemoryWikiOverviewItem;
 }

--- a/extensions/memory-wiki/src/wiki-overview.ts
+++ b/extensions/memory-wiki/src/wiki-overview.ts
@@ -66,6 +66,15 @@ function compareOverviewItems(left: MemoryWikiOverviewItem, right: MemoryWikiOve
   return left.title.localeCompare(right.title);
 }
 
+function isOverviewItemEligible(item: MemoryWikiOverviewItem): boolean {
+  return (
+    PRIMARY_OVERVIEW_KINDS.has(item.kind) ||
+    item.claimCount > 0 ||
+    item.questionCount > 0 ||
+    item.contradictionCount > 0
+  );
+}
+
 export async function listMemoryWikiOverview(
   config: ResolvedMemoryWikiConfig,
 ): Promise<MemoryWikiOverviewStatus> {
@@ -75,13 +84,16 @@ export async function listMemoryWikiOverview(
     let totalClaims = 0;
     let totalQuestions = 0;
     let totalContradictions = 0;
-    const items = compiled.digest.pages.flatMap((page) => {
-      pageCounts[page.kind] += 1;
-      totalClaims += page.claimCount;
-      totalQuestions += page.questions.length;
-      totalContradictions += page.contradictions.length;
-      return page.dashboard?.overview ? [page.dashboard.overview] : [];
-    });
+    const items = compiled.digest.pages
+      .flatMap((page) => {
+        pageCounts[page.kind] += 1;
+        totalClaims += page.claimCount;
+        totalQuestions += page.questions.length;
+        totalContradictions += page.contradictions.length;
+        return page.dashboard?.overview ? [page.dashboard.overview] : [];
+      })
+      .filter(isOverviewItemEligible)
+      .toSorted(compareOverviewItems);
     return buildMemoryWikiOverviewStatus({
       items,
       totalPages: compiled.digest.pages.length,
@@ -101,13 +113,7 @@ export async function listMemoryWikiOverview(
   const totalContradictions = pages.reduce((sum, page) => sum + page.contradictions.length, 0);
   const items = pages
     .map((page) => buildMemoryWikiOverviewItem({ page, parsed: parseWikiMarkdown(page.raw) }))
-    .filter(
-      (item) =>
-        PRIMARY_OVERVIEW_KINDS.has(item.kind) ||
-        item.claimCount > 0 ||
-        item.questionCount > 0 ||
-        item.contradictionCount > 0,
-    )
+    .filter(isOverviewItemEligible)
     .toSorted(compareOverviewItems);
 
   return buildMemoryWikiOverviewStatus({


### PR DESCRIPTION
<!--
Optional linked context:
Add a visible `Closes #<issue-number>` or `Related: #<issue-number>` line
below this comment.

Required PR title:
type: user-facing description
Use a parenthesized scope only when it adds clarity:
fix(auth): login redirect loops when session cookie is expired

Types: feat, fix, improve, refactor, docs, chore.
For fixes, describe the user-visible symptom and trigger:
fix: task list fails to load when user has no environments
Avoid implementation details such as:
fix: add null check to task query
-->

Related: #132077

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

<!--
Describe the concrete user, product, or operational problem.
For fixes, begin with:
"Fixes an issue where users <do X> would <experience Y> when <condition>."
or:
"Resolves a problem where..."

Name the affected UI surface or workflow. Do not describe the code-level cause here.
-->

Fixes an issue where users opening the Memory Wiki import-insights or overview dashboard would wait through a full-vault Markdown read and parse on every Gateway request, causing multi-minute stalls and dropped Control UI or Telegram connections on large vaults.

## Why This Change Was Made

<!--
In one or two sentences, explain the complete shipped solution, key design
decisions, and relevant boundaries or non-goals. Include implementation detail
only when it helps reviewers understand user-visible behavior or risk.
Avoid file-by-file narration.
-->

The existing compile/publication lifecycle now derives both dashboard projections once and stores them in the immutable, generation-bound compiled cache. The memory-wiki lifecycle service repairs a missing or incompatible publication before the Gateway serves dashboard requests, including unchanged vaults after the snapshot format upgrade; dashboard source synchronization never opts into that full rebuild on the RPC path. Dashboard RPCs read the snapshot (with the existing raw-reader fallback while a cache is unavailable), while overview eligibility and ordering stay identical to the raw reader.

## User Impact

<!--
State what users, operators, or developers can now do or expect. Lead with the
concrete benefit and use user-facing language. If there is no user-visible
impact, say so plainly.
-->

Large-vault dashboard calls are bounded by cache access and no longer perform request-time page-byte parsing. Upgraded vaults self-heal one incompatible compiled publication during lifecycle synchronization, and cached overview results retain the raw reader's filtering and ordering. Existing response shapes and privacy filtering remain unchanged.

## Evidence

<!--
Show the most useful proof that this change works. Screenshots, screencasts,
terminal output, focused tests, CI results, live observations, redacted logs,
and artifact links are all useful. Include before/after evidence for visual
changes when it clarifies the result.

Reviewers will inspect the code, tests, and CI. Use this section to make the
validation easy to understand, not to restate the diff.
-->

- Focused regression: compiled-cache lifecycle, plugin lifecycle, and overview parity tests pass (26 tests), including incompatible-cache rebuild, request-path deferral, and cached/raw filtering-order parity.
- `pnpm check:changed` passes formatting, extension/test typechecks, lint, dead-export, import-cycle, and repository guards.
- Pre-fix Gateway baseline on 320 × 18KB source pages: `wiki.importInsights` 12,376ms first call / ~1,770ms repeats; `wiki.overview` ~1,760ms per call.
- Post-fix real Gateway harness on the same representative vault: both methods 77–80ms per repeated call; a 10ms event-loop probe fired 41 times during the run.
- Fresh isolated `gateway:dev` proof on the latest PR head using the active Codex `claude-nas` provider: 6/6 authenticated RPC calls succeeded against 320 synthetic source pages (about 18KB each). `wiki.importInsights` returned 320 items in 1.41–1.44s per CLI call, `wiki.overview` reported 329 pages in 1.40–1.42s, and the Gateway event loop stayed non-degraded before and after the run. Each CLI call includes a fresh client handshake, so these timings are an end-to-end upper bound rather than an in-process benchmark.
- Exact-head cold-upgrade proof used the built `dist` Gateway on Node 24.16.0 with a 320 × ~18KB vault. The harness compiled a real v3 publication, converted it to the real dashboard-free v2 shape, then started the Gateway. The lifecycle owner replaced it with v3 before readiness, after channels had started. During recovery `/healthz` kept returning 200 while `/readyz` correctly returned 503; the worst observed event-loop delay was 147.7ms rather than a multi-minute request-time stall.
- Cache-hit boundary: on that same running Gateway and vault, both RPCs returned non-empty results from the v3 publication. Temporarily changing only the cache metadata to v2 forced the production raw-reader fallback; both fallbacks returned the same counts but took longer. The harness restored v3 afterward and verified the publication metadata.

<details>
<summary>Exact-head cold-upgrade Gateway trace (redacted)</summary>

```text
PR #132567 exact-head cold-upgrade Gateway proof
head=d9e7b20b52e7fbeb7bb5bdde8e19981bdd428f64
node=v24.16.0
distBuild.commit=d9e7b20b52e7fbeb7bb5bdde8e19981bdd428f64

fixture=320 pages x ~18432B
pre-start cache version=2 pages=320 dashboardPages=0

gateway +12291.3ms startup trace: sidecars.channels 1.3ms
gateway +18218.4ms startup trace:
  sidecars.plugin-services.memory-wiki.memory-wiki-compiled-cache-owner-cleanup
  5923.4ms total=8857.0ms eventLoopMax=147.7ms
gateway +18243.9ms startup trace: ready 2.5ms

startup probes=653
healthz={"200":132,"connect-error":521}
readyz={"200":1,"503":131,"connect-error":521}
maxHealthLatency=763.8ms
readyAt=18371.2ms

startup recovery:
  cache 2->3
  publicationChanged=true
  dashboardPages 0->320
  compileEventDuringStartup=true
  channelsCompletedBeforeRecovery=true

wiki.importInsights cache-hit:
  totalItems=320 totalClusters=1 cli=6325.4ms
  forced-v2 raw fallback sameResult=true cli=8420.3ms

wiki.overview cache-hit:
  totalItems=320 totalPages=320 totalQuestions=320 cli=6603.3ms
  forced-v2 raw fallback sameResult=true cli=8701.4ms

cache comparator restored metadata version=3
result=PASS
```

The `connect-error` samples occurred before the localhost HTTP listener bound. Once bound, health remained available throughout the one-time recovery; readiness opened only after recovery completed. This proof exercises the real exact-head dist Gateway and RPCs with synthetic local data and a localhost test token; it does not claim external-channel live proof.

</details>
