### PR TITLE
docs(mac): correct build commit metadata description

### DIFF
--- a/docs/platforms/mac/signing.md
+++ b/docs/platforms/mac/signing.md
@@ -15,7 +15,7 @@ title: "macOS signing"
 - Reads `SIGN_IDENTITY` from the environment (e.g. `export SIGN_IDENTITY="Apple Development: Your Name (TEAMID)"`, or a Developer ID Application cert). Without it, `codesign-mac-app.sh` auto-selects an identity in this order: Developer ID Application, Apple Distribution, Apple Development, then the first valid codesigning identity found.
 - `SIGN_IDENTITY` also accepts a certificate SHA-1 hash to distinguish certificates with the same common name.
 - `CODESIGN_TIMESTAMP=auto` (default) enables trusted timestamps for Developer ID Application signatures selected by name or certificate hash. Set `on`/`off` to force either way.
-- Stamps Info.plist with `OpenClawBuildTimestamp` (ISO8601 UTC) and `OpenClawGitCommit` (short hash, `unknown` if unavailable) so the About tab can show build, git, and debug/release channel.
+- Stamps Info.plist with `OpenClawBuildTimestamp` (ISO8601 UTC) and `OpenClawGitCommit` (full 40-character hexadecimal commit, or `unknown` for local builds when unavailable) so the About tab can show build, git, and debug/release channel.
 - Runs a Team ID audit after signing and fails if any Mach-O inside the bundle has a different Team ID. Set `SKIP_TEAM_ID_CHECK=1` to bypass.
 
 ## Usage


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where the [macOS signing guide](https://docs.openclaw.ai/platforms/mac/signing) describes `OpenClawGitCommit` as a short hash, although packaging stores a full 40-character hexadecimal commit.

## Why This Change Was Made

Corrects that one description and limits the documented `unknown` fallback to local builds without available metadata. The build-metadata producer, packaging, signing, and runtime behavior remain unchanged.

Related: #132335 (Peekaboo snapshot diagnostics). This documentation correction was identified during that work and deliberately kept separate.

## User Impact

Developers inspecting macOS build metadata can expect the full commit value already written to Info.plist. No behavior or configuration changes.

## Evidence

Source inspection: `scripts/lib/build-metadata.sh:10` validates `^[0-9a-fA-F]{40}$`; `openclaw_resolve_git_commit` normalizes valid commits and permits `unknown` only when metadata is not required. `scripts/package-mac-app.sh:48-51` requires metadata for release builds; line 805 stamps the resolved commit unchanged. Existing coverage in `test/scripts/package-mac-app.test.ts:672-803` checks full commits, invalid overrides, local fallback, and release failure. These tests were read, not executed.

Focused validation:

- `pnpm docs:list` — passed; the signing page is indexed.
- `./node_modules/.bin/oxfmt --check docs/platforms/mac/signing.md` — passed (one file).
- `git diff --check` — passed.
- `git diff --numstat` — only `docs/platforms/mac/signing.md`, +1/-1; production/test LOC 0.
- `node scripts/check-docs-mdx.mjs ../../../.worktrees/pr-132568/docs/platforms/mac/signing.md` — passed on the exact PR-head page after one frozen-lockfile install repaired missing local dependency files; both worktrees remained clean. Earlier review MDX proof and exact-head hosted docs CI also passed.

No unit tests, signing builds, or live app flows were run: this changes one documentation fact, with no runtime behavior change. Fresh autoreview is exempt under the trivial/docs-only policy.

Exact-head CI: [run 33251299147](https://github.com/openclaw/openclaw/actions/runs/33251299147) passed for `5168bc5812ab9f8d3a64ba2ca83a657c13d6d190`, including `check-docs`, `security-fast`, and the required `openclaw/ci-gate`.

AI-assisted; source and scope manually verified. This same-repository branch is writable by OpenClaw maintainers; GitHub's fork-only Allow edits setting does not apply.
