### PR TITLE
fix(macos): keep config edits made while a save is in flight

### DIFF
--- a/apps/macos/Sources/OpenClaw/ChannelsStore+Config.swift
+++ b/apps/macos/Sources/OpenClaw/ChannelsStore+Config.swift
@@ -102,10 +102,7 @@ extension ChannelsStore {
         while true {
             self.configLoadingSourceKey = requestSourceKey
             do {
-                let snap: ConfigSnapshot = try await GatewayConnection.shared.requestDecoded(
-                    method: .configGet,
-                    params: nil,
-                    timeoutMs: 10000)
+                let snap: ConfigSnapshot = try await Self.fetchConfigSnapshot()
                 // An edit can land while the fetch above is in flight, so whether this may
                 // replace the draft is decided here rather than before the request.
                 var applyForce = requestForce
@@ -129,6 +126,20 @@ extension ChannelsStore {
             requestSourceKey = self.currentConfigCacheSourceKey()
             self.resetConfigCacheIfSourceChanged(requestSourceKey)
         }
+    }
+
+    /// The one step of a reload that needs a live Gateway, kept separate so tests can answer
+    /// it and exercise everything after it for real.
+    static func fetchConfigSnapshot() async throws -> ConfigSnapshot {
+        #if DEBUG
+        if let fetch = await ConfigStore._testFetchConfigSnapshotOverride() {
+            return try await fetch()
+        }
+        #endif
+        return try await GatewayConnection.shared.requestDecoded(
+            method: .configGet,
+            params: nil,
+            timeoutMs: 10000)
     }
 
     func applyConfigSnapshot(_ snap: ConfigSnapshot, sourceKey: String, force: Bool) {

--- a/apps/macos/Sources/OpenClaw/ChannelsStore+Config.swift
+++ b/apps/macos/Sources/OpenClaw/ChannelsStore+Config.swift
@@ -203,11 +203,18 @@ extension ChannelsStore {
         return nil
     }
 
+    /// Whether a finished save still describes the newest draft, and may therefore reload over
+    /// it and clear dirty. An edit admitted while the save was in flight makes it stale.
+    static func saveMayReplaceDraft(submittedRevision: Int, currentRevision: Int) -> Bool {
+        submittedRevision == currentRevision
+    }
+
     func updateConfigValue(path: ConfigPath, value: Any?) {
         var root: Any = self.configDraft
         setValue(&root, path: path, value: value)
         self.configDraft = root as? [String: Any] ?? self.configDraft
         self.configDirty = true
+        self.configDraftRevision &+= 1
     }
 
     func saveConfigDraft() async {
@@ -215,9 +222,19 @@ extension ChannelsStore {
         self.isSavingConfig = true
         defer { self.isSavingConfig = false }
 
+        // Only the Save and Reload buttons are disabled during a save. The form controls stay
+        // live, so what is written here can be out of date by the time the write returns.
+        let submitted = self.configDraft
+        let submittedRevision = self.configDraftRevision
+
         do {
-            try await ConfigStore.save(self.configDraft)
-            await self.loadConfig()
+            try await ConfigStore.save(submitted)
+            // A forced reload replaces the draft and clears dirty, which is right for the
+            // draft that was just written and wrong for a newer edit made while it was in
+            // flight. Without force the snapshot defers to the dirty draft instead.
+            await self.loadConfig(force: Self.saveMayReplaceDraft(
+                submittedRevision: submittedRevision,
+                currentRevision: self.configDraftRevision))
         } catch {
             self.configStatus = error.localizedDescription
         }

--- a/apps/macos/Sources/OpenClaw/ChannelsStore+Config.swift
+++ b/apps/macos/Sources/OpenClaw/ChannelsStore+Config.swift
@@ -82,7 +82,11 @@ extension ChannelsStore {
         if !force, !refresh, self.configLoaded {
             return
         }
-        guard !self.queueConfigReloadIfLoading(sourceKey: sourceKey, force: force, refresh: refresh)
+        guard !self.queueConfigReloadIfLoading(
+            sourceKey: sourceKey,
+            force: force,
+            refresh: refresh,
+            forceUnlessDraftChangedFrom: forceUnlessDraftChangedFrom)
         else { return }
         self.configLoading = true
         self.configLoadingSourceKey = sourceKey
@@ -92,6 +96,7 @@ extension ChannelsStore {
         }
 
         var requestForce = force
+        var requestGuard = forceUnlessDraftChangedFrom
         var requestSourceKey = sourceKey
 
         while true {
@@ -104,7 +109,7 @@ extension ChannelsStore {
                 // An edit can land while the fetch above is in flight, so whether this may
                 // replace the draft is decided here rather than before the request.
                 var applyForce = requestForce
-                if let admitted = forceUnlessDraftChangedFrom,
+                if let admitted = requestGuard,
                    !Self.saveMayReplaceDraft(
                        submittedRevision: admitted,
                        currentRevision: self.configDraftRevision)
@@ -118,7 +123,9 @@ extension ChannelsStore {
 
             guard self.configReloadPending != .none else { break }
             requestForce = self.configReloadPending == .force
+            requestGuard = self.configReloadPendingDraftGuard
             self.configReloadPending = .none
+            self.configReloadPendingDraftGuard = nil
             requestSourceKey = self.currentConfigCacheSourceKey()
             self.resetConfigCacheIfSourceChanged(requestSourceKey)
         }
@@ -287,10 +294,20 @@ extension ChannelsStore {
         self.configSourceKey = sourceKey
     }
 
-    func queueConfigReloadIfLoading(sourceKey: String, force: Bool, refresh: Bool = false) -> Bool {
+    func queueConfigReloadIfLoading(
+        sourceKey: String,
+        force: Bool,
+        refresh: Bool = false,
+        forceUnlessDraftChangedFrom: Int? = nil) -> Bool
+    {
         guard self.configLoading else { return false }
         if force || self.configLoadingSourceKey != sourceKey {
             self.configReloadPending = .force
+            // The queued force inherits whatever condition it was issued with. Dropping it is
+            // how a save that waited behind a running refresh could still replace a newer
+            // draft. A caller asking for an unconditional reload clears it, which is right,
+            // because that is a reload the user asked for rather than a save tidying up.
+            self.configReloadPendingDraftGuard = forceUnlessDraftChangedFrom
         } else if refresh, self.configReloadPending == .none {
             self.configReloadPending = .refresh
         }

--- a/apps/macos/Sources/OpenClaw/ChannelsStore+Config.swift
+++ b/apps/macos/Sources/OpenClaw/ChannelsStore+Config.swift
@@ -69,7 +69,14 @@ extension ChannelsStore {
         }
     }
 
-    func loadConfig(force: Bool = true, refresh: Bool = false) async {
+    /// - Parameter forceUnlessDraftChangedFrom: revision captured by a caller that wants a forced
+    ///   reload only while the draft it knows about is still the newest. The fetch below is an
+    ///   await of its own, so this is re-checked when the snapshot is applied rather than here.
+    func loadConfig(
+        force: Bool = true,
+        refresh: Bool = false,
+        forceUnlessDraftChangedFrom: Int? = nil) async
+    {
         let sourceKey = self.currentConfigCacheSourceKey()
         self.resetConfigCacheIfSourceChanged(sourceKey)
         if !force, !refresh, self.configLoaded {
@@ -94,7 +101,17 @@ extension ChannelsStore {
                     method: .configGet,
                     params: nil,
                     timeoutMs: 10000)
-                self.applyConfigSnapshot(snap, sourceKey: requestSourceKey, force: requestForce)
+                // An edit can land while the fetch above is in flight, so whether this may
+                // replace the draft is decided here rather than before the request.
+                var applyForce = requestForce
+                if let admitted = forceUnlessDraftChangedFrom,
+                   !Self.saveMayReplaceDraft(
+                       submittedRevision: admitted,
+                       currentRevision: self.configDraftRevision)
+                {
+                    applyForce = false
+                }
+                self.applyConfigSnapshot(snap, sourceKey: requestSourceKey, force: applyForce)
             } catch {
                 self.configStatus = error.localizedDescription
             }
@@ -229,12 +246,11 @@ extension ChannelsStore {
 
         do {
             try await ConfigStore.save(submitted)
-            // A forced reload replaces the draft and clears dirty, which is right for the
-            // draft that was just written and wrong for a newer edit made while it was in
-            // flight. Without force the snapshot defers to the dirty draft instead.
-            await self.loadConfig(force: Self.saveMayReplaceDraft(
-                submittedRevision: submittedRevision,
-                currentRevision: self.configDraftRevision))
+            // Still reload, so normalization from the gateway lands as before, but let it
+            // replace the draft only while the one just written is still the newest. Deciding
+            // that here would leave the fetch inside loadConfig as a second window for an edit
+            // to be lost in, so the revision travels down and is checked at apply time.
+            await self.loadConfig(forceUnlessDraftChangedFrom: submittedRevision)
         } catch {
             self.configStatus = error.localizedDescription
         }

--- a/apps/macos/Sources/OpenClaw/ChannelsStore.swift
+++ b/apps/macos/Sources/OpenClaw/ChannelsStore.swift
@@ -306,6 +306,9 @@ final class ChannelsStore {
     var configReloadPending: ConfigReloadRequest = .none
     var configDraft: [String: Any] = [:]
     var configDirty = false
+    /// Bumped by every edit. A save captures this at admission so its completion can tell
+    /// whether the draft it wrote is still the newest one before it reloads over it.
+    var configDraftRevision = 0
 
     let interval: TimeInterval = 45
     let isPreview: Bool

--- a/apps/macos/Sources/OpenClaw/ChannelsStore.swift
+++ b/apps/macos/Sources/OpenClaw/ChannelsStore.swift
@@ -304,6 +304,9 @@ final class ChannelsStore {
     /// refetches without overwriting a dirty local draft; `force` overwrites it.
     enum ConfigReloadRequest { case none, refresh, force }
     var configReloadPending: ConfigReloadRequest = .none
+    /// Travels with a queued forced reload so a save waiting behind a running refresh keeps the
+    /// condition it was issued with. Without it the replay forces unconditionally.
+    var configReloadPendingDraftGuard: Int?
     var configDraft: [String: Any] = [:]
     var configDirty = false
     /// Bumped by every edit. A save captures this at admission so its completion can tell

--- a/apps/macos/Sources/OpenClaw/ConfigStore.swift
+++ b/apps/macos/Sources/OpenClaw/ConfigStore.swift
@@ -16,6 +16,10 @@ enum ConfigStore {
         #if DEBUG
         /// Isolates focused notification assertions without changing the production sender contract.
         var notificationCenter: NotificationCenter?
+        /// Answers `config.get` so a test can drive a successful fetch. The fetch is the only
+        /// step in a reload that needs a live Gateway, so replacing just it leaves the whole
+        /// apply path after it running as it does in production.
+        var fetchConfigSnapshot: (@MainActor @Sendable () async throws -> ConfigSnapshot)?
         #endif
     }
 
@@ -174,6 +178,12 @@ enum ConfigStore {
 
     static func _testClearOverrides() async {
         await self.overrideStore.setOverride(.init())
+    }
+
+    static func _testFetchConfigSnapshotOverride()
+        async -> (@MainActor @Sendable () async throws -> ConfigSnapshot)?
+    {
+        await self.overrideStore.overrides.fetchConfigSnapshot
     }
 
     @MainActor

--- a/apps/macos/Tests/OpenClawIPCTests/ChannelsConfigLiveGatewayProbe.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/ChannelsConfigLiveGatewayProbe.swift
@@ -3,14 +3,25 @@ import OpenClawProtocol
 import Testing
 @testable import OpenClaw
 
-/// Drives save, reload and apply against a live Gateway with no fetch override, so the
-/// snapshot that lands is one the Gateway really produced.
-/// Set OPENCLAW_PROOF_GATEWAY=1 with OPENCLAW_GATEWAY_URL and OPENCLAW_GATEWAY_TOKEN.
+/// Races a save against a live Gateway with no fetch override, so the snapshot that lands is
+/// one the Gateway really produced.
+///
+/// Set OPENCLAW_PROOF_GATEWAY=1 with OPENCLAW_GATEWAY_URL and OPENCLAW_GATEWAY_TOKEN. This
+/// writes config, so it refuses anything but a loopback Gateway and puts the original config
+/// back before it returns. Point it at a Gateway started with its own OPENCLAW_HOME.
 @Suite(.serialized)
 @MainActor
 struct ChannelsConfigLiveGatewayProbe {
     @Test func `an edit during a real gateway save survives the reload`() async {
         guard ProcessInfo.processInfo.environment["OPENCLAW_PROOF_GATEWAY"] == "1" else { return }
+        guard Self.isLoopbackGateway() else {
+            Issue.record("probe writes config, so it only runs against a loopback Gateway")
+            return
+        }
+        guard let original = await Self.fetch() else {
+            Issue.record("could not read the Gateway config to restore afterwards")
+            return
+        }
 
         let store = ChannelsStore(isPreview: true)
         store.configSourceKey = nil
@@ -28,29 +39,13 @@ struct ChannelsConfigLiveGatewayProbe {
             isRemoteMode: { true },
             saveRemote: { root in
                 // A real write to the real Gateway, then hold so an edit can land behind it.
-                let data = try JSONSerialization.data(
-                    withJSONObject: root, options: [.prettyPrinted, .sortedKeys])
-                guard let raw = String(data: data, encoding: .utf8) else { return }
-                // The Gateway refuses a write without the hash it last handed out.
-                let current: ConfigSnapshot = try await GatewayConnection.shared.requestDecoded(
-                    method: .configGet,
-                    params: nil,
-                    timeoutMs: 10000)
-                var params: [String: AnyCodable] = ["raw": AnyCodable(raw)]
-                if let baseHash = current.hash {
-                    params["baseHash"] = AnyCodable(baseHash)
-                }
-                let _: ProbeWriteAck = try await GatewayConnection.shared.requestDecoded(
-                    method: .configSet,
-                    params: params,
-                    timeoutMs: 10000)
+                try await Self.write(root)
                 await gate.wait()
             }))
 
         let saving = Task { await store.saveConfigDraft() }
         let reachedWrite = await gate.waitUntilEntered()
         print("PROOF save reached the gateway write: \(reachedWrite)")
-        #expect(reachedWrite)
 
         store.updateConfigValue(
             path: [.key("channels"), .key("discord"), .key("enabled")],
@@ -64,9 +59,65 @@ struct ChannelsConfigLiveGatewayProbe {
         print("PROOF after status=\(store.configStatus ?? "nil")")
         print("PROOF after value=\(Self.discordEnabled(store) as Any) dirty=\(store.configDirty)")
 
-        #expect(store.configStatus == nil)
-        #expect(Self.discordEnabled(store) == false)
-        #expect(store.configDirty == true)
+        let status = store.configStatus
+        let value = Self.discordEnabled(store)
+        let dirty = store.configDirty
+
+        // Put the Gateway back the way it was before asserting, so a failure still restores.
+        let restored = await Self.restore(original)
+        print("PROOF restored original config: \(restored)")
+
+        #expect(reachedWrite)
+        #expect(status == nil)
+        #expect(value == false)
+        #expect(dirty == true)
+        #expect(restored)
+    }
+
+    static func isLoopbackGateway() -> Bool {
+        let raw = ProcessInfo.processInfo.environment["OPENCLAW_GATEWAY_URL"] ?? ""
+        guard let host = URLComponents(string: raw)?.host else { return false }
+        return ["127.0.0.1", "localhost", "::1"].contains(host)
+    }
+
+    static func fetch() async -> ConfigSnapshot? {
+        try? await GatewayConnection.shared.requestDecoded(
+            method: .configGet,
+            params: nil,
+            timeoutMs: 10000)
+    }
+
+    static func write(_ root: [String: Any]) async throws {
+        let data = try JSONSerialization.data(
+            withJSONObject: root, options: [.prettyPrinted, .sortedKeys])
+        guard let raw = String(data: data, encoding: .utf8) else { return }
+        try await self.writeRaw(raw)
+    }
+
+    static func writeRaw(_ raw: String) async throws {
+        // The Gateway refuses a write without the hash it last handed out.
+        let current: ConfigSnapshot = try await GatewayConnection.shared.requestDecoded(
+            method: .configGet,
+            params: nil,
+            timeoutMs: 10000)
+        var params: [String: AnyCodable] = ["raw": AnyCodable(raw)]
+        if let baseHash = current.hash {
+            params["baseHash"] = AnyCodable(baseHash)
+        }
+        let _: ProbeWriteAck = try await GatewayConnection.shared.requestDecoded(
+            method: .configSet,
+            params: params,
+            timeoutMs: 10000)
+    }
+
+    static func restore(_ original: ConfigSnapshot) async -> Bool {
+        guard let raw = original.raw else { return false }
+        do {
+            try await self.writeRaw(raw)
+            return true
+        } catch {
+            return false
+        }
     }
 
     static func discordEnabled(_ store: ChannelsStore) -> Bool? {
@@ -83,6 +134,7 @@ private struct ProbeWriteAck: Decodable {
 private actor SaveGate {
     private var entered = false
     private var released = false
+
     func wait() async {
         self.entered = true
         var spins = 0

--- a/apps/macos/Tests/OpenClawIPCTests/ChannelsConfigLiveGatewayProbe.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/ChannelsConfigLiveGatewayProbe.swift
@@ -24,6 +24,15 @@ struct ChannelsConfigLiveGatewayProbe {
             Issue.record("could not read the Gateway config to restore afterwards")
             return
         }
+        // The environment only says what this process asked for. GatewayEndpointStore
+        // resolves the real target from config, defaults and stored routes, so the connection
+        // can land somewhere the checks above never saw. config.get reports the file the
+        // Gateway is actually serving, which is the one thing that proves who is on the other
+        // end. Nothing is written until this passes.
+        if let refusal = Self.ownershipRefusal(original) {
+            Issue.record("probe writes config, so it refuses this Gateway: \(refusal)")
+            return
+        }
 
         let store = ChannelsStore(isPreview: true)
         store.configSourceKey = nil
@@ -100,6 +109,30 @@ struct ChannelsConfigLiveGatewayProbe {
     }
 
     static let operatorDefaultPort = 18789
+
+    /// Confirms the Gateway on the other end serves the isolated config this run set up,
+    /// rather than trusting that the environment routed us where we asked.
+    static func ownershipRefusal(_ snapshot: ConfigSnapshot) -> String? {
+        guard let expected = ProcessInfo.processInfo.environment["OPENCLAW_CONFIG_PATH"],
+              !expected.isEmpty
+        else {
+            return "OPENCLAW_CONFIG_PATH is not set, so the served config cannot be checked"
+        }
+        guard let served = snapshot.path, !served.isEmpty else {
+            return "the Gateway did not report which config file it serves"
+        }
+        guard Self.samePath(served, expected) else {
+            return "the Gateway serves \(served), not the isolated config at \(expected)"
+        }
+        return nil
+    }
+
+    static func samePath(_ left: String, _ right: String) -> Bool {
+        let resolve = { (path: String) -> String in
+            URL(fileURLWithPath: path).resolvingSymlinksInPath().standardizedFileURL.path
+        }
+        return resolve(left) == resolve(right)
+    }
 
     static func fetch() async -> ConfigSnapshot? {
         try? await GatewayConnection.shared.requestDecoded(

--- a/apps/macos/Tests/OpenClawIPCTests/ChannelsConfigLiveGatewayProbe.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/ChannelsConfigLiveGatewayProbe.swift
@@ -1,0 +1,107 @@
+import Foundation
+import OpenClawProtocol
+import Testing
+@testable import OpenClaw
+
+/// Drives save, reload and apply against a live Gateway with no fetch override, so the
+/// snapshot that lands is one the Gateway really produced.
+/// Set OPENCLAW_PROOF_GATEWAY=1 with OPENCLAW_GATEWAY_URL and OPENCLAW_GATEWAY_TOKEN.
+@Suite(.serialized)
+@MainActor
+struct ChannelsConfigLiveGatewayProbe {
+    @Test func `an edit during a real gateway save survives the reload`() async {
+        guard ProcessInfo.processInfo.environment["OPENCLAW_PROOF_GATEWAY"] == "1" else { return }
+
+        let store = ChannelsStore(isPreview: true)
+        store.configSourceKey = nil
+        await store.loadConfig()
+        print("PROOF load status=\(store.configStatus ?? "nil") loaded=\(store.configLoaded)")
+
+        // A is what the save submits. B is typed while that write is in flight.
+        store.updateConfigValue(
+            path: [.key("channels"), .key("discord"), .key("enabled")],
+            value: true)
+        print("PROOF A submitted dirty=\(store.configDirty) value=\(Self.discordEnabled(store) as Any)")
+
+        let gate = SaveGate()
+        await ConfigStore._testSetOverrides(.init(
+            isRemoteMode: { true },
+            saveRemote: { root in
+                // A real write to the real Gateway, then hold so an edit can land behind it.
+                let data = try JSONSerialization.data(
+                    withJSONObject: root, options: [.prettyPrinted, .sortedKeys])
+                guard let raw = String(data: data, encoding: .utf8) else { return }
+                // The Gateway refuses a write without the hash it last handed out.
+                let current: ConfigSnapshot = try await GatewayConnection.shared.requestDecoded(
+                    method: .configGet,
+                    params: nil,
+                    timeoutMs: 10000)
+                var params: [String: AnyCodable] = ["raw": AnyCodable(raw)]
+                if let baseHash = current.hash {
+                    params["baseHash"] = AnyCodable(baseHash)
+                }
+                let _: ProbeWriteAck = try await GatewayConnection.shared.requestDecoded(
+                    method: .configSet,
+                    params: params,
+                    timeoutMs: 10000)
+                await gate.wait()
+            }))
+
+        let saving = Task { await store.saveConfigDraft() }
+        let reachedWrite = await gate.waitUntilEntered()
+        print("PROOF save reached the gateway write: \(reachedWrite)")
+        #expect(reachedWrite)
+
+        store.updateConfigValue(
+            path: [.key("channels"), .key("discord"), .key("enabled")],
+            value: false)
+        print("PROOF B typed mid-flight value=\(Self.discordEnabled(store) as Any)")
+
+        await gate.release()
+        await saving.value
+        await ConfigStore._testClearOverrides()
+
+        print("PROOF after status=\(store.configStatus ?? "nil")")
+        print("PROOF after value=\(Self.discordEnabled(store) as Any) dirty=\(store.configDirty)")
+
+        #expect(store.configStatus == nil)
+        #expect(Self.discordEnabled(store) == false)
+        #expect(store.configDirty == true)
+    }
+
+    static func discordEnabled(_ store: ChannelsStore) -> Bool? {
+        let channels = store.configDraft["channels"] as? [String: Any]
+        let discord = channels?["discord"] as? [String: Any]
+        return discord?["enabled"] as? Bool
+    }
+}
+
+private struct ProbeWriteAck: Decodable {
+    let hash: String?
+}
+
+private actor SaveGate {
+    private var entered = false
+    private var released = false
+    func wait() async {
+        self.entered = true
+        var spins = 0
+        while !self.released, spins < 1500 {
+            try? await Task.sleep(nanoseconds: 10_000_000)
+            spins += 1
+        }
+    }
+
+    func waitUntilEntered() async -> Bool {
+        var spins = 0
+        while !self.entered, spins < 1500 {
+            try? await Task.sleep(nanoseconds: 10_000_000)
+            spins += 1
+        }
+        return self.entered
+    }
+
+    func release() {
+        self.released = true
+    }
+}

--- a/apps/macos/Tests/OpenClawIPCTests/ChannelsConfigLiveGatewayProbe.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/ChannelsConfigLiveGatewayProbe.swift
@@ -6,16 +6,18 @@ import Testing
 /// Races a save against a live Gateway with no fetch override, so the snapshot that lands is
 /// one the Gateway really produced.
 ///
-/// Set OPENCLAW_PROOF_GATEWAY=1 with OPENCLAW_GATEWAY_URL and OPENCLAW_GATEWAY_TOKEN. This
-/// writes config, so it refuses anything but a loopback Gateway and puts the original config
-/// back before it returns. Point it at a Gateway started with its own OPENCLAW_HOME.
+/// Set OPENCLAW_PROOF_GATEWAY=1 with OPENCLAW_GATEWAY_URL and OPENCLAW_GATEWAY_TOKEN.
+///
+/// This writes config, so per AGENTS.md it runs only against a session-owned dev Gateway:
+/// loopback, an isolated OPENCLAW_STATE_DIR, and never the operator's default port 18789.
+/// It also puts the original config back before asserting, so a failing run restores too.
 @Suite(.serialized)
 @MainActor
 struct ChannelsConfigLiveGatewayProbe {
     @Test func `an edit during a real gateway save survives the reload`() async {
         guard ProcessInfo.processInfo.environment["OPENCLAW_PROOF_GATEWAY"] == "1" else { return }
-        guard Self.isLoopbackGateway() else {
-            Issue.record("probe writes config, so it only runs against a loopback Gateway")
+        if let refusal = Self.refusalReason() {
+            Issue.record("probe writes config, so it refuses this Gateway: \(refusal)")
             return
         }
         guard let original = await Self.fetch() else {
@@ -74,11 +76,30 @@ struct ChannelsConfigLiveGatewayProbe {
         #expect(restored)
     }
 
-    static func isLoopbackGateway() -> Bool {
-        let raw = ProcessInfo.processInfo.environment["OPENCLAW_GATEWAY_URL"] ?? ""
-        guard let host = URLComponents(string: raw)?.host else { return false }
-        return ["127.0.0.1", "localhost", "::1"].contains(host)
+    /// AGENTS.md: live gateway tests use a session owned dev gateway only, isolated
+    /// OPENCLAW_STATE_DIR and a free port, never the operator's gateway port while it runs.
+    ///
+    /// This checks the values that actually route the connection. `GatewayEndpointStore`
+    /// resolves the port from OPENCLAW_GATEWAY_PORT and the loaded config, not from a URL,
+    /// so checking a URL here would pass while the app connected somewhere else entirely.
+    static func refusalReason() -> String? {
+        let env = ProcessInfo.processInfo.environment
+        guard let rawPort = env["OPENCLAW_GATEWAY_PORT"], let port = Int(rawPort) else {
+            return "OPENCLAW_GATEWAY_PORT is not set, so the port is whatever the operator uses"
+        }
+        if port == Self.operatorDefaultPort {
+            return "port \(port) is the operator default"
+        }
+        guard let stateDir = env["OPENCLAW_STATE_DIR"], !stateDir.isEmpty else {
+            return "OPENCLAW_STATE_DIR is not set, so the state is not isolated"
+        }
+        guard let configPath = env["OPENCLAW_CONFIG_PATH"], !configPath.isEmpty else {
+            return "OPENCLAW_CONFIG_PATH is not set, so this would read the operator's config"
+        }
+        return nil
     }
+
+    static let operatorDefaultPort = 18789
 
     static func fetch() async -> ConfigSnapshot? {
         try? await GatewayConnection.shared.requestDecoded(

--- a/apps/macos/Tests/OpenClawIPCTests/ChannelsSettingsSmokeTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/ChannelsSettingsSmokeTests.swift
@@ -330,6 +330,44 @@ struct ChannelsSettingsSmokeTests {
         #expect(store.configDirty == true)
     }
 
+    @Test func `a real save that is raced by an edit does not reload over it`() async {
+        // Crosses saveConfigDraft and ConfigStore.save rather than poking the pieces, so a
+        // later miswiring of the completion is caught. The write is held open, an edit lands
+        // while it is in flight, and then it is released.
+        let store = makeChannelsStore(channels: [:])
+        // Left nil so the first cache check adopts the real source key instead of treating a
+        // made up one as a source change, which would reset the draft before the save runs.
+        store.configSourceKey = nil
+        store.configLoaded = true
+        store.configDraft = ["channels": ["discord": ["enabled": false]]]
+        store.configDirty = true
+        store.configStatus = nil
+
+        let gate = SaveGate()
+        await ConfigStore._testSetOverrides(.init(
+            isRemoteMode: { true },
+            saveRemote: { _ in await gate.wait() }))
+
+        let saving = Task { await store.saveConfigDraft() }
+        await gate.waitUntilEntered()
+
+        store.updateConfigValue(
+            path: [.key("channels"), .key("discord"), .key("enabled")],
+            value: true)
+
+        await gate.release()
+        await saving.value
+        await ConfigStore._testClearOverrides()
+
+        let channels = store.configDraft["channels"] as? [String: Any]
+        let discord = channels?["discord"] as? [String: Any]
+        #expect(discord?["enabled"] as? Bool == true)
+        #expect(store.configDirty == true)
+        // The unforced reload returns before it asks the gateway for anything, so a raced save
+        // leaves no load behind it. A forced one would have reached out and recorded its error.
+        #expect(store.configStatus == nil)
+    }
+
     @Test func `a save with no edit behind it still reloads and clears dirty`() {
         let store = makeChannelsStore(channels: [:])
         store.configDraft = ["channels": ["discord": ["enabled": true]]]
@@ -379,5 +417,36 @@ struct ChannelsSettingsSmokeTests {
         store.configSchemaReloadPending = false
         #expect(store.queueConfigSchemaReloadIfLoading(sourceKey: "source-b", force: false) == true)
         #expect(store.configSchemaReloadPending == true)
+    }
+}
+
+/// Holds a save open so an edit can land while it is in flight.
+private actor SaveGate {
+    private var entered = false
+    private var released = false
+    private var enteredWaiters: [CheckedContinuation<Void, Never>] = []
+    private var releaseWaiters: [CheckedContinuation<Void, Never>] = []
+
+    func wait() async {
+        self.entered = true
+        for waiter in self.enteredWaiters {
+            waiter.resume()
+        }
+        self.enteredWaiters.removeAll()
+        if self.released { return }
+        await withCheckedContinuation { self.releaseWaiters.append($0) }
+    }
+
+    func waitUntilEntered() async {
+        if self.entered { return }
+        await withCheckedContinuation { self.enteredWaiters.append($0) }
+    }
+
+    func release() {
+        self.released = true
+        for waiter in self.releaseWaiters {
+            waiter.resume()
+        }
+        self.releaseWaiters.removeAll()
     }
 }

--- a/apps/macos/Tests/OpenClawIPCTests/ChannelsSettingsSmokeTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/ChannelsSettingsSmokeTests.swift
@@ -366,6 +366,39 @@ struct ChannelsSettingsSmokeTests {
         #expect(store.configDirty == true)
     }
 
+    @Test func `a reload queued behind a running one keeps its draft condition`() {
+        // A save issued while a refresh is already running does not reload immediately, it is
+        // queued. The condition it was issued with has to be queued too, or the replay forces
+        // unconditionally and erases the newer draft anyway.
+        let store = makeChannelsStore(channels: [:])
+        store.configLoading = true
+        store.configLoadingSourceKey = "source-a"
+
+        let admitted = store.configDraftRevision
+        let queued = store.queueConfigReloadIfLoading(
+            sourceKey: "source-a",
+            force: true,
+            forceUnlessDraftChangedFrom: admitted)
+
+        #expect(queued == true)
+        #expect(store.configReloadPending == .force)
+        #expect(store.configReloadPendingDraftGuard == admitted)
+    }
+
+    @Test func `an unconditional queued reload clears the condition`() {
+        // A reload the user asked for should replace the draft, so it must not inherit a
+        // condition left behind by a save.
+        let store = makeChannelsStore(channels: [:])
+        store.configLoading = true
+        store.configLoadingSourceKey = "source-a"
+        store.configReloadPendingDraftGuard = 7
+
+        _ = store.queueConfigReloadIfLoading(sourceKey: "source-a", force: true)
+
+        #expect(store.configReloadPending == .force)
+        #expect(store.configReloadPendingDraftGuard == nil)
+    }
+
     @Test func `a save with no edit behind it still reloads and clears dirty`() {
         let store = makeChannelsStore(channels: [:])
         store.configDraft = ["channels": ["discord": ["enabled": true]]]

--- a/apps/macos/Tests/OpenClawIPCTests/ChannelsSettingsSmokeTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/ChannelsSettingsSmokeTests.swift
@@ -448,16 +448,42 @@ struct ChannelsSettingsSmokeTests {
         #expect(store.configReloadPendingDraftGuard == nil)
     }
 
-    @Test func `a save with no edit behind it still reloads and clears dirty`() {
+    @Test func `a save with no edit behind it still reloads and clears dirty`() async {
+        // The other half of the guard. Nothing is typed during this save, so the reload has
+        // to force exactly as it always did and the gateway's own view has to land. Asserting
+        // only that the revision comparison says true would still pass if the save stopped
+        // reloading altogether, which is the case this is here to catch.
         let store = makeChannelsStore(channels: [:])
+        store.configSourceKey = nil
+        store.configLoaded = true
         store.configDraft = ["channels": ["discord": ["enabled": true]]]
         store.configDirty = true
+        store.configStatus = nil
 
-        let admitted = store.configDraftRevision
+        // Stands in for normalization: what comes back is not what went out.
+        let normalized = ConfigSnapshot(
+            path: nil,
+            exists: true,
+            raw: nil,
+            hash: nil,
+            parsed: nil,
+            valid: true,
+            config: ["channels": SnapshotAnyCodable(["discord": ["enabled": false]])],
+            issues: nil)
 
-        #expect(ChannelsStore.saveMayReplaceDraft(
-            submittedRevision: admitted,
-            currentRevision: store.configDraftRevision) == true)
+        await ConfigStore._testSetOverrides(.init(
+            isRemoteMode: { true },
+            saveRemote: { _ in },
+            fetchConfigSnapshot: { normalized }))
+
+        await store.saveConfigDraft()
+        await ConfigStore._testClearOverrides()
+
+        #expect(store.configStatus == nil)
+        let channels = store.configDraft["channels"] as? [String: Any]
+        let discord = channels?["discord"] as? [String: Any]
+        #expect(discord?["enabled"] as? Bool == false)
+        #expect(store.configDirty == false)
     }
 
     @Test func `forced config load queues behind background load`() {

--- a/apps/macos/Tests/OpenClawIPCTests/ChannelsSettingsSmokeTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/ChannelsSettingsSmokeTests.swift
@@ -366,6 +366,55 @@ struct ChannelsSettingsSmokeTests {
         #expect(store.configDirty == true)
     }
 
+    @Test func `a raced save survives a config get that succeeds`() async {
+        // The test above holds the write open but leaves the reload to reach a real Gateway,
+        // which is not there, so it lands in the catch and would pass even with the guard
+        // gone. This one answers config.get with the values the save sent, which is the case
+        // the defect needs: the apply runs for real and has to leave the newer edit alone.
+        let store = makeChannelsStore(channels: [:])
+        store.configSourceKey = nil
+        store.configLoaded = true
+        store.configDraft = ["channels": ["discord": ["enabled": false]]]
+        store.configDirty = true
+        store.configStatus = nil
+
+        // What the gateway would hand back after storing the draft as it was submitted.
+        let saved = ConfigSnapshot(
+            path: nil,
+            exists: true,
+            raw: nil,
+            hash: nil,
+            parsed: nil,
+            valid: true,
+            config: ["channels": SnapshotAnyCodable(["discord": ["enabled": false]])],
+            issues: nil)
+
+        let gate = SaveGate()
+        await ConfigStore._testSetOverrides(.init(
+            isRemoteMode: { true },
+            saveRemote: { _ in await gate.wait() },
+            fetchConfigSnapshot: { saved }))
+
+        let saving = Task { await store.saveConfigDraft() }
+        await gate.waitUntilEntered()
+
+        store.updateConfigValue(
+            path: [.key("channels"), .key("discord"), .key("enabled")],
+            value: true)
+
+        await gate.release()
+        await saving.value
+        await ConfigStore._testClearOverrides()
+
+        // The fetch succeeded, so the apply really ran. Without the revision condition it
+        // would have forced and put enabled back to false with dirty cleared.
+        #expect(store.configStatus == nil)
+        let channels = store.configDraft["channels"] as? [String: Any]
+        let discord = channels?["discord"] as? [String: Any]
+        #expect(discord?["enabled"] as? Bool == true)
+        #expect(store.configDirty == true)
+    }
+
     @Test func `a reload queued behind a running one keeps its draft condition`() {
         // A save issued while a refresh is already running does not reload immediately, it is
         // queued. The condition it was issued with has to be queued too, or the replay forces

--- a/apps/macos/Tests/OpenClawIPCTests/ChannelsSettingsSmokeTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/ChannelsSettingsSmokeTests.swift
@@ -290,6 +290,58 @@ struct ChannelsSettingsSmokeTests {
         #expect(store.configDirty == false)
     }
 
+    @Test func `an edit during a save keeps the save from reloading over it`() {
+        // Save admits draft A, the form stays live, and an edit to B lands before the write
+        // returns. The completion must not force a reload, which would republish A over B and
+        // clear dirty as if B had been persisted.
+        let store = makeChannelsStore(channels: [:])
+        store.configSourceKey = "source-a"
+        store.configLoaded = true
+        store.configDraft = ["channels": ["discord": ["enabled": false]]]
+        store.configDirty = false
+
+        let admitted = store.configDraftRevision
+        store.updateConfigValue(
+            path: [.key("channels"), .key("discord"), .key("enabled")],
+            value: true)
+
+        #expect(store.configDirty == true)
+        #expect(store.configDraftRevision != admitted)
+        #expect(ChannelsStore.saveMayReplaceDraft(
+            submittedRevision: admitted,
+            currentRevision: store.configDraftRevision) == false)
+
+        // That false is what loadConfig receives, and a non forced snapshot leaves the newer
+        // edit and the dirty flag alone.
+        let snap = ConfigSnapshot(
+            path: nil,
+            exists: true,
+            raw: nil,
+            hash: nil,
+            parsed: nil,
+            valid: true,
+            config: ["channels": SnapshotAnyCodable(["discord": ["enabled": false]])],
+            issues: nil)
+        store.applyConfigSnapshot(snap, sourceKey: "source-a", force: false)
+
+        let channels = store.configDraft["channels"] as? [String: Any]
+        let discord = channels?["discord"] as? [String: Any]
+        #expect(discord?["enabled"] as? Bool == true)
+        #expect(store.configDirty == true)
+    }
+
+    @Test func `a save with no edit behind it still reloads and clears dirty`() {
+        let store = makeChannelsStore(channels: [:])
+        store.configDraft = ["channels": ["discord": ["enabled": true]]]
+        store.configDirty = true
+
+        let admitted = store.configDraftRevision
+
+        #expect(ChannelsStore.saveMayReplaceDraft(
+            submittedRevision: admitted,
+            currentRevision: store.configDraftRevision) == true)
+    }
+
     @Test func `forced config load queues behind background load`() {
         let store = makeChannelsStore(channels: [:])
         store.configLoading = true

--- a/apps/macos/Tests/OpenClawIPCTests/ChannelsSettingsSmokeTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/ChannelsSettingsSmokeTests.swift
@@ -333,7 +333,8 @@ struct ChannelsSettingsSmokeTests {
     @Test func `a real save that is raced by an edit does not reload over it`() async {
         // Crosses saveConfigDraft and ConfigStore.save rather than poking the pieces, so a
         // later miswiring of the completion is caught. The write is held open, an edit lands
-        // while it is in flight, and then it is released.
+        // while it is in flight, and then it is released. The reload still runs, so gateway
+        // normalization is not lost, but it must not replace the newer edit.
         let store = makeChannelsStore(channels: [:])
         // Left nil so the first cache check adopts the real source key instead of treating a
         // made up one as a source change, which would reset the draft before the save runs.
@@ -363,9 +364,6 @@ struct ChannelsSettingsSmokeTests {
         let discord = channels?["discord"] as? [String: Any]
         #expect(discord?["enabled"] as? Bool == true)
         #expect(store.configDirty == true)
-        // The unforced reload returns before it asks the gateway for anything, so a raced save
-        // leaves no load behind it. A forced one would have reached out and recorded its error.
-        #expect(store.configStatus == nil)
     }
 
     @Test func `a save with no edit behind it still reloads and clears dirty`() {


### PR DESCRIPTION
Closes #127614

## What Problem This Solves

Fixes an issue where users editing a Channel or Advanced Config field while a save is still running would lose that edit. The older saved values are republished over it and Save greys out, so the form looks fully persisted while the newest change is gone.

Only the Save and Reload buttons are disabled during a save. The actual form controls stay live, which is what makes this reachable on any ordinarily slow save.

## Why This Change Was Made

`saveConfigDraft` took its copy of the draft, awaited the write, and then called `loadConfig()`. That default is `force: true`, and a forced snapshot is exactly the one that bypasses the dirty guard in `applyConfigSnapshot`, replaces the whole draft and clears dirty. An edit admitted while the write was in flight had no way to survive it.

Every edit now bumps a draft revision, and the save captures that revision when it admits the draft. The reload only forces when the revision has not moved since. When it has, the unforced path is used, and that path already defers to a dirty draft, so the newer edit and its dirty state are left alone.

The reload is still forced for the ordinary case, so normalization from the gateway and the dirty clear both behave as before when nothing was typed during the save.

## User Impact

Edits made while a save is running are kept, and Save stays enabled so they can be written. Channel tokens, toggles and Advanced Config fields no longer disappear silently on a slow save.

No change for a save with nothing typed behind it, which is the ordinary path.

## Evidence

Added to `ChannelsSettingsSmokeTests`, next to the existing `non forced config snapshots do not overwrite dirty draft` which covers the snapshot side but not the save overlap:

```
✔ Test "an edit during a save keeps the save from reloading over it" passed
✔ Test "a save with no edit behind it still reloads and clears dirty" passed
✔ Suite ChannelsSettingsSmokeTests passed  (13 tests)
```

The first follows the sequence in the issue. It records the revision at admission, edits a still-enabled field, and checks the save can no longer replace the draft. It then applies a snapshot carrying the older saved values through the unforced path and asserts the newer edit and dirty both survive:

```swift
let admitted = store.configDraftRevision
store.updateConfigValue(path: [.key("channels"), .key("discord"), .key("enabled")], value: true)

#expect(ChannelsStore.saveMayReplaceDraft(
    submittedRevision: admitted,
    currentRevision: store.configDraftRevision) == false)

store.applyConfigSnapshot(snap, sourceKey: "source-a", force: false)
#expect(discord?["enabled"] as? Bool == true)
#expect(store.configDirty == true)
```

`swiftformat --lint --config config/swiftformat` reports `0/3 files require formatting` on the changed files, using the pinned 0.62.1.

Full `swift test` for `apps/macos` is running against this branch and I will post the before/after counts when it finishes. The three failures already present on a clean checkout here, `TalkMLXSpeechSynthesizerTests`, `AppStateIsolationTests` and `CLIInstallerTests`, are environment dependent and unrelated.

---

disclaimer: this contribution was prepared with the assistance of an ai agent. i read the save and snapshot paths and the existing dirty guard myself before changing anything, and ran the suite and formatter locally.


---

## Real-run evidence

Added after review. The earlier tests poked the pieces; this one crosses `saveConfigDraft` and `ConfigStore.save` for real. It installs a `saveRemote` override that blocks, starts the save, waits until the write is genuinely in flight, edits a still-enabled field, then releases:

```swift
let gate = SaveGate()
await ConfigStore._testSetOverrides(.init(
    isRemoteMode: { true },
    saveRemote: { _ in await gate.wait() }))

let saving = Task { await store.saveConfigDraft() }
await gate.waitUntilEntered()
store.updateConfigValue(path: [.key("channels"), .key("discord"), .key("enabled")], value: true)
await gate.release()
await saving.value
```

A raced save leaves no load behind it. Put the forced call back, everything else identical, and the completion records the reload it made:

```
✘ "a real save that is raced by an edit does not reload over it"
    Expectation failed: (store.configStatus →
      "gateway connect: connect to gateway @ ws://127.0.0.1:18789: Could not connect to the server.")
      == nil
```

14/14 in `ChannelsSettingsSmokeTests` on this branch.

## What I could not produce, stated plainly

A screenshot of the Settings form does not distinguish the two revisions, and I would rather say so than post one that looks like it does.

I built a probe that renders the real `ChannelConfigForm` on screen against a real `ChannelsStore`, holds the write open, types into the field mid-flight and photographs both revisions. The frames come out byte identical, 38,485 and 38,638 bytes on each side.

The defect needs a **successful** config fetch to land. `loadConfig` reads through `GatewayConnection.shared.requestDecoded(method: .configGet)`; with no gateway that throws, `applyConfigSnapshot` is never reached, and the old code does not overwrite the draft either. The overwrite this PR prevents cannot occur without a gateway answering `configGet` with the previously saved values. I deleted the probe rather than attach images implying a difference I had not shown.

So the mechanism is proven above without a gateway; the overwrite itself needs a live one.


---

## Follow-up: the guard was in the wrong place

Review found that judging the revision before calling `loadConfig` leaves the config fetch inside it as a second window. An edit landing during that fetch was still overwritten and still marked saved. That is this same defect moved later rather than removed, and the finding was correct.

Fixed in `396eae79`. The revision travels down and is checked where the snapshot is applied:

```swift
var applyForce = requestForce
if let admitted = forceUnlessDraftChangedFrom,
   !Self.saveMayReplaceDraft(
       submittedRevision: admitted,
       currentRevision: self.configDraftRevision)
{
    applyForce = false
}
self.applyConfigSnapshot(snap, sourceKey: requestSourceKey, force: applyForce)
```

This is also better than the previous shape. The reload still runs, so gateway normalization lands as it always did, and only the replacement is withheld. The earlier version skipped the reload entirely when raced, which quietly gave up normalization too. I removed the assertion that encoded that older behaviour.

## What I cannot prove here, and why

I wrote a test for the fetch window and then deleted it, because it passed with the guard removed. It computed the decision itself and called `applyConfigSnapshot` directly, so it tested the decision rather than the wiring, which is the same weakness you identified in the earlier tests. Shipping it would have implied coverage that is not there.

The wiring cannot be exercised from a test here. Reaching `applyConfigSnapshot` through `loadConfig` requires `GatewayConnection.shared.requestDecoded(method: .configGet)` to succeed, and there is no seam for it. With no gateway the fetch throws, the `catch` records the error, and the apply is never reached, so the unsafe direction cannot be produced. That is the same reason the screenshot comparison came out byte identical.

So: the placement is correct and the decision function is tested, but the wiring at the apply boundary is verified by reading rather than by a test. I would rather say that than leave a test in place that passes either way.



---

## Follow-up 2: a third window, found while checking the second

After moving the guard to apply time I walked the path again looking for other ways in, because the first fix moved the defect rather than removing it and I did not want to repeat that. There is a third window and it is not the fetch.

`saveConfigDraft` does not always get to run its own reload. If a refresh is already running, `queueConfigReloadIfLoading` parks the request and the running loop picks it up afterwards. The queue only recorded that a force was wanted:

```swift
self.configReloadPending = .force
```

The revision the save was allowed to overwrite was dropped on the floor. So a save that arrived while a refresh was in flight came back unconditional, and when the queued reload finally ran it replaced whatever the user had typed in the meantime. Same defect as the original report, reached through the queue instead of directly.

Fixed by carrying the condition into the queue and restoring it when the queued request runs:

```swift
func queueConfigReloadIfLoading(
    sourceKey: String,
    force: Bool,
    refresh: Bool = false,
    forceUnlessDraftChangedFrom: Int? = nil) -> Bool
{
    ...
    self.configReloadPending = .force
    self.configReloadPendingDraftGuard = forceUnlessDraftChangedFrom
```

An unconditional reload still clears the condition, because that one is a reload the user asked for rather than a save tidying up after itself.

## These two tests do fail without the change

Unlike the one I deleted last time. Removing only the guard, tests untouched:

```
✘ "a reload queued behind a running one keeps its draft condition"
    (store.configReloadPendingDraftGuard → nil) == (admitted → 0)

✘ "an unconditional queued reload clears the condition"
    (store.configReloadPendingDraftGuard → 7) == nil
```

16/16 in `ChannelsSettingsSmokeTests` with the change in.

## The full suite numbers i said i would post

`swift test` on `apps/macos` against this branch: **1883 tests passed**, and the only suites that failed are the three that already fail on a clean checkout here, `TalkMLXSpeechSynthesizerTests`, `AppStateIsolationTests` and `CLIInstallerTests`.

The run does not reach a clean finish. It deadlocks with 68 tests still outstanding and prints `SWIFT TASK CONTINUATION MISUSE: wait() leaked its continuation without resuming it`. That is not this branch. None of the outstanding tests are in the config area, and the suite holding the largest group, `UpdateOrchestrationTests`, passes in 0.37 seconds when run on its own on this same branch:

```
✔ Test run with 25 tests in 1 suite passed after 0.367 seconds.
```

The change also cannot reach them. `configReloadPendingDraftGuard`, `forceUnlessDraftChangedFrom`, `configDraftRevision` and `saveMayReplaceDraft` appear only in the two source files changed here and in the test file, nowhere else in `Sources/` or `Tests/`.

`swiftformat --lint --config config/swiftformat` gives `0/26 files require formatting`. `swiftlint lint --config config/swiftlint.yml` is clean on all three files.



---

## Follow-up 3: the successful config.get, which i said i could not produce

The [P2] is right and it is the important one. My raced-save test held the write open but let the reload reach a real Gateway, which is not there, so it landed in the `catch` and the closing assertions passed **with the guard removed as well**. That is the third time I have shipped a test that does not discriminate, and it is the same root cause each time: asserting on a path the test never actually reaches.

I also said earlier in this PR that a successful fetch could not be driven from here. That was wrong, and it was wrong the same way the screenshot claim on #132565 was wrong: I concluded it from the absence of a seam instead of looking at what the repo already does.

`ConfigStore` has an override struct with a `saveRemote` hook that this branch already uses. The fetch needed the same treatment. It is the only step of a reload that needs a live Gateway, so it is the only step a test replaces, and everything after it runs exactly as in production:

```swift
static func fetchConfigSnapshot() async throws -> ConfigSnapshot {
    #if DEBUG
    if let fetch = await ConfigStore._testFetchConfigSnapshotOverride() {
        return try await fetch()
    }
    #endif
    return try await GatewayConnection.shared.requestDecoded(
        method: .configGet, params: nil, timeoutMs: 10000)
}
```

`#if DEBUG` on both the field and the accessor, so release builds are byte for byte what they were.

### the test now reproduces the reported defect end to end

`config.get` answers with the values the save submitted, which is the case the defect needs:

```swift
await ConfigStore._testSetOverrides(.init(
    isRemoteMode: { true },
    saveRemote: { _ in await gate.wait() },
    fetchConfigSnapshot: { saved }))

let saving = Task { await store.saveConfigDraft() }
await gate.waitUntilEntered()
store.updateConfigValue(path: [.key("channels"), .key("discord"), .key("enabled")], value: true)
await gate.release()
await saving.value
```

Remove only the revision condition, tests untouched, and the user's edit is gone and Save has greyed out — the issue as filed:

```
✘ "a raced save survives a config get that succeeds"
    Expectation failed: (discord?["enabled"] as? Bool → false) == true
    Expectation failed: (store.configDirty → false) == true
```

With it in, 17 of 17 in `ChannelsSettingsSmokeTests`, 25 of 25 across that and `ConfigStore`.

`#expect(store.configStatus == nil)` is in there deliberately: it fails if the fetch ever falls back to the catch path again, so this test cannot silently rot into the previous one.

### checks

| check | result |
|---|---|
| `swift test --filter ChannelsSettings\|ConfigStore` | 25 tests, 2 suites, passed |
| new test with only the guard reverted | fails as above |
| `swiftformat --lint --config config/swiftformat` | 0/3 files require formatting |
| `swiftlint --config config/swiftlint.yml` | clean on all three files |



---

## Your CI ran the new test and it passed

The proof above is no longer only from my machine. On `a0d43a1b`, `macos-swift` executed 1,894 tests in 196 suites, and both of these are in that run:

```
✔ Test "a raced save survives a config get that succeeds" passed after 1.378 seconds.
✔ Suite ChannelsSettingsSmokeTests passed after 23.183 seconds.
```

That is the test which, with only the revision condition removed, puts the field back to the saved value and clears dirty. It ran on your runner, through the real `saveConfigDraft` and a successful `config.get`, and passed.

`ConfigStoreTests` also passed, which is the suite that covers the file the `#if DEBUG` seam was added to:

```
✔ Suite ConfigStoreTests passed after 27.279 seconds.
```

### about the red gate

`ci-gate` is red because 11 suites failed, none of them here:

```
CronJobsStoreTests              DashboardHTTPFixtureTests       DashboardReconnectTests
DashboardWindowOwnershipTests   ExecApprovalsSocketAuthTests    ExecApprovalsSocketPathGuardTests
LowCoverageHelperTests          MacNodeCodexThreadCatalogTests  ManagedProcessTests
PortGuardianRecordStoreTests    TailscaleServeGatewayDiscoveryTests
```

Sockets, ports, spawned processes, dashboard windows and service discovery. One of them reports `Caught error: .timedOut`. Nothing in that list reads config, and this branch touches `ChannelsStore+Config.swift`, `ConfigStore.swift` and one test file. The seam is `#if DEBUG` on both the field and the accessor and returns nil unless a test sets it, so release behaviour is unchanged and the non-test path is the same `requestDecoded` call it always was.

I could not find a run of `macos-swift` on `main` to compare against, so I am not asserting these are failing everywhere, only that they are not this change and that the suites which are this change passed in the same run.



---

## Follow-up 4: the unraced half was the same weak shape

The [P3] is right and it is the same mistake as the one before it, on the other side of the guard. `a save with no edit behind it still reloads and clears dirty` did nothing but call the equality helper:

```swift
#expect(ChannelsStore.saveMayReplaceDraft(
    submittedRevision: admitted,
    currentRevision: store.configDraftRevision) == true)
```

That passes if `saveConfigDraft` stops reloading altogether, which is precisely the regression the ordinary path needs protected. Now that the fetch can be answered, there is no reason for it to stay that way.

It runs the real save with nothing typed behind it and a successful `config.get` that returns something different from what went out, standing in for gateway normalization:

```swift
await ConfigStore._testSetOverrides(.init(
    isRemoteMode: { true },
    saveRemote: { _ in },
    fetchConfigSnapshot: { normalized }))

await store.saveConfigDraft()
```

Then it asserts the gateway's view actually landed and dirty was cleared. Make the apply never force, tests untouched:

```
✘ "a save with no edit behind it still reloads and clears dirty"
    Expectation failed: (discord?["enabled"] as? Bool → true) == false
    Expectation failed: (store.configDirty → true) == false
```

The two tests now fail in opposite directions, which is what pins the guard from both sides:

| change | raced test | unraced test |
|---|---|---|
| remove the revision condition | fails, the edit is overwritten | passes |
| make the apply never force | passes | fails, normalization never lands |

17 of 17 in `ChannelsSettingsSmokeTests`, 25 of 25 with `ConfigStore`. `swiftformat --lint` reports `0/1 files require formatting` and `swiftlint --config config/swiftlint.yml` is clean.



---

## Follow-up 5: real behaviour, against a live Gateway

The proof gate asks for the real path rather than a controlled harness. Here it is. **No fetch override in this one.** `GatewayConnection.shared` talks to a Gateway I started from this checkout, the write is a real `config.set`, and the reload applies whatever that Gateway hands back.

Added as `ChannelsConfigLiveGatewayProbe`, gated on `OPENCLAW_PROOF_GATEWAY` so it does nothing on a runner, the same shape as the Talk overlay probes on #132565.

```
export OPENCLAW_HOME=<scratch>            # nothing touches a real ~/.openclaw
export OPENCLAW_GATEWAY_URL=ws://127.0.0.1:18789
export OPENCLAW_GATEWAY_TOKEN=<token>
node scripts/run-node.mjs gateway         # gateway.mode=local, fixed token
swift test --filter ChannelsConfigLiveGatewayProbe
```

**With the fix in:**

```
PROOF load status=nil loaded=true
PROOF A submitted dirty=true value=Optional(true)
PROOF save reached the gateway write: true
PROOF B typed mid-flight value=Optional(false)
PROOF after status=nil
PROOF after value=Optional(false) dirty=true
✔ Test run with 1 test in 1 suite passed after 0.152 seconds.
```

**Remove only the revision condition, nothing else changed:**

```
PROOF load status=nil loaded=true
PROOF A submitted dirty=true value=Optional(true)
PROOF save reached the gateway write: true
PROOF B typed mid-flight value=Optional(false)
PROOF after status=nil
PROOF after value=Optional(true) dirty=false
✘ Expectation failed: (Self.discordEnabled(store) → true) == false
✘ Expectation failed: (store.configDirty → false) == true
```

The user typed `false` while the write was in flight and got `true` back with Save greyed out. That is the issue as filed, reproduced against a Gateway rather than a stub.

Two details that matter for reading it:

- `PROOF after status=nil` on **both** runs. The fetch succeeded, so this is the apply path and not the `catch`. That was the exact weakness you found in the earlier test.
- `save reached the gateway write: true` is asserted, so the probe fails rather than silently passes if the save never reaches the Gateway at all.

The write goes through `config.set` properly. My first attempt was rejected by the Gateway with `[INVALID_REQUEST] config base hash required; re-run config.get and retry`, so the probe fetches the current hash and sends it as `baseHash`, which is what `ConfigStore.saveToGateway` does.

### what this still is not

It drives `ChannelsStore` directly rather than clicking the Settings form. The form calls the same `saveConfigDraft` owner, which is already noted in your evidence list as covering both reported surfaces, but I would rather state the gap than let the transcript imply more than it shows.

### and a correction

Earlier in this PR I wrote that a successful fetch could not be driven from here, and later that a live Gateway was out of reach. Both were wrong, and wrong the same way as the screenshot claim on #132565: I concluded it from not finding a seam instead of checking what the repo already does. `OPENCLAW_GATEWAY_URL` and `OPENCLAW_GATEWAY_TOKEN` steer `GatewayEndpointStore`, and the gateway runs from source with `gateway.mode=local`. It took about twenty minutes once I actually looked.



---

## Follow-up 6: the probe could have changed someone's config

The [P1] is correct and it is the kind of finding I am glad came before a maintainer ran anything. I was careful in my own run, pointing a throwaway Gateway at a scratch `OPENCLAW_HOME` and diffing the real `~/.openclaw/openclaw.json` afterwards to confirm it was untouched. **But the probe did not enforce any of that.** Someone following the instructions with `OPENCLAW_GATEWAY_URL` aimed at a Gateway they actually use would have had their channel config written and left that way.

Three changes, all in the test:

1. it refuses any Gateway that is not loopback

```swift
guard Self.isLoopbackGateway() else {
    Issue.record("probe writes config, so it only runs against a loopback Gateway")
    return
}
```

2. it reads the config before it touches anything, and bails if it cannot

3. it writes that exact `raw` back at the end, **before** the assertions run, so a failing run restores too

```
### guard: non loopback url
↳ probe writes config, so it only runs against a loopback Gateway
✘ Test run with 1 test in 1 suite failed after 0.001 seconds with 1 issue.
```

I checked the restore actually restores rather than merely appearing to. Setting the value to `false` first, so the probe's own write of `true` has to be undone to get back:

```
before = False
PROOF restored original config: true
✔ Test run with 1 test in 1 suite passed after 0.598 seconds.
after  = False
```

## one correction on the proof reading

The scores say "both transport steps are overridden". The write is, and deliberately so, because holding it open is the only way to make the race deterministic. **The read is not.** There is no fetch override in this probe. `loadConfig` goes through `GatewayConnection.shared.requestDecoded(method: .configGet)` to the Gateway, and the snapshot that reaches `applyConfigSnapshot` is one the Gateway produced. The `saveRemote` override does not replace the write either, it performs the real `config.set` and then pauses:

```swift
saveRemote: { root in
    try await Self.write(root)   // real config.set, with the baseHash the Gateway demands
    await gate.wait()            // only the timing is injected
}
```

If the transport were faked, the Gateway would not have rejected my first attempt with `[INVALID_REQUEST] config base hash required; re-run config.get and retry`, and the config file on disk would not have changed and then changed back.

Happy to be told that still is not what the gate means. The honest gap remains the one I stated: this drives `ChannelsStore` rather than clicking the Settings form, though both surfaces call the same `saveConfigDraft` owner, which your own evidence list already notes.



---

## Follow-up 7: the probe now proves which Gateway it reached

The [P1] is right and it is the hole under the previous fix. My guard read environment variables, but `GatewayEndpointStore` resolves the real target from config, defaults and stored routes, so the connection can land somewhere those checks never saw. Checking the environment proves what this process *asked for*, not where it *arrived*.

`config.get` reports the file the Gateway is actually serving, which is the one thing that settles it. The probe now reads before it writes and refuses unless that file is the isolated one this run set up:

```swift
static func ownershipRefusal(_ snapshot: ConfigSnapshot) -> String? {
    ...
    guard let served = snapshot.path, !served.isEmpty else {
        return "the Gateway did not report which config file it serves"
    }
    guard Self.samePath(served, expected) else {
        return "the Gateway serves \(served), not the isolated config at \(expected)"
    }
    return nil
}
```

Paths are compared after resolving symlinks, and nothing is written until it passes.

### checked against an actual foreign Gateway

I stood up a second Gateway on its own free port with its own `OPENCLAW_HOME` and a different config, then pointed the probe at it while still claiming my isolated config path. It passes every environment check — loopback, non-default port, `OPENCLAW_STATE_DIR` set, `OPENCLAW_CONFIG_PATH` set — and is refused anyway:

```
↳ probe writes config, so it refuses this Gateway: the Gateway serves
  .../ocroot_other/openclaw.json, not the isolated config at .../ocroot3/openclaw.json
✘ Test run with 1 test in 1 suite failed after 0.455 seconds with 1 issue.
```

And it wrote nothing:

```
foreign gateway config discord.enabled  = True    (unchanged)
my own gateway config discord.enabled   = False   (unchanged)
```

The proof itself still runs against its own Gateway:

```
PROOF save reached the gateway write: true
PROOF after value=Optional(false) dirty=true
PROOF restored original config: true
✔ Test run with 1 test in 1 suite passed after 0.219 seconds.
```

### checks

| check | result |
|---|---|
| `swift test --filter ChannelsSettingsSmokeTests` | 17 tests passed |
| `swift test --filter ConfigStoreTests` | 8 tests passed |
| `swift test --filter ChannelsConfigLiveGatewayProbe` | passes, no-ops without the env |
| foreign-Gateway refusal | refuses, writes nothing |
| `swiftformat --lint` | `0/1 files require formatting` |
| `swiftlint --config config/swiftlint.yml` | clean |

Running those three filters together hangs on this machine with the leaked-continuation deadlock noted earlier; each finishes in seconds on its own, which is why they are listed separately.
