### PR TITLE
fix(process): make credential descriptors reopenable

### DIFF
--- a/docs/plugins/sdk-subpaths.md
+++ b/docs/plugins/sdk-subpaths.md
@@ -251,7 +251,7 @@ Use `isLoopbackHost(host)` when a plugin must accept only the local machine. It 
     | `plugin-sdk/plugin-runtime` | Deprecated broad barrel for plugin command/hook/http/interactive helpers; prefer focused plugin runtime subpaths |
     | `plugin-sdk/hook-runtime` | Deprecated broad barrel for webhook/internal hook pipeline helpers; prefer focused hook/plugin runtime subpaths |
     | `plugin-sdk/lazy-runtime` | Lazy runtime import/binding helpers such as `createLazyRuntimeModule`, `createLazyRuntimeMethod`, and `createLazyRuntimeSurface` |
-    | `plugin-sdk/process-runtime` | Private-local after July 2026; bounded process execution with per-stream and aggregate output caps, opt-in stream-error termination, and configurable TERM-to-KILL grace |
+    | `plugin-sdk/process-runtime` | Private-local after July 2026; bounded process execution with per-stream and aggregate output caps, opt-in stream-error termination, configurable TERM-to-KILL grace, and `prepareSecretInputStdio` for one-shot credential descriptors |
     | `plugin-sdk/node-host` | Private-local after July 2026; Node-host executable resolution and PTY resume helpers |
     | `plugin-sdk/node-selection-runtime` | Private-local bundled runtime facade for shared capability-gated node selection policy |
     | `plugin-sdk/cli-argv` | Dependency-light root-option parsing for CLI metadata, including `getRootOptionAwareCommandPath` and `consumeRootOptionToken` |
@@ -348,6 +348,14 @@ Use `isLoopbackHost(host)` when a plugin must accept only the local machine. It 
     | `plugin-sdk/agent-runtime` | Deprecated broad barrel for agent dir/identity/workspace helpers, including `resolveAgentDir`, `resolveDefaultAgentDir`, and the deprecated `resolveOpenClawAgentDir` compatibility export; prefer focused agent/runtime subpaths |
     | `plugin-sdk/directory-runtime` | Config-backed directory query/dedup |
     | `plugin-sdk/keyed-async-queue` | Private-local after July 2026; `KeyedAsyncQueue` |
+
+    Private process callers declare `using prepared = prepareSecretInputStdio(stdio, secretInput)`
+    before spawning, then call `await prepared?.deliverTo(child)` once. Delivery closes the writer
+    and zeroes the transient credential buffer; disposal closes any untransferred descriptors,
+    including when spawning throws. POSIX uses anonymous pipes that support descriptor-path readers
+    without credential files; Windows retains its overlapped child pipe. Callers own child cleanup
+    when delivery fails.
+
   </Accordion>
 
   <Accordion title="Capability and testing subpaths">

--- a/extensions/anthropic/agent-sdk.runtime.test.ts
+++ b/extensions/anthropic/agent-sdk.runtime.test.ts
@@ -235,104 +235,111 @@ describe("Anthropic Agent SDK runtime ownership", () => {
     expect(sideQuestion).not.toHaveProperty("execute");
   });
 
-  it("owns the selected-credential process tree while keeping its descriptor private and zeroed", async () => {
-    const backend = buildAnthropicCliBackend();
-    const token = "selected-private-descriptor-fixture";
-    const prepared = (await backend.prepareExecution?.({
-      workspaceDir: "/tmp/openclaw-workspace",
-      provider: "claude-cli",
-      modelId: "claude-sonnet-4-6",
-      executionMode: "agent",
-      authCredential: { type: "token", token },
-    } as Parameters<NonNullable<typeof backend.prepareExecution>>[0])) as {
-      env: Record<string, string>;
-      secretInput: { fd: 3; createData: () => Buffer };
-      execute: CliBackendExecute;
-      cleanup?: () => Promise<void>;
-    };
-    let deliveredBuffer: Buffer | undefined;
-    const originalCreateData = prepared.secretInput.createData;
-    vi.spyOn(prepared.secretInput, "createData").mockImplementation(() => {
-      deliveredBuffer = originalCreateData();
-      return deliveredBuffer;
-    });
-    let descriptorOutput: { fd: number; digest: string } | undefined;
-    useSdkMessages([SUCCESS_RESULT], async (options) => {
-      const spawnProcess = options.spawnClaudeCodeProcess as
-        | ((input: ClaudeAgentSdkSpawnOptions) => ClaudeAgentSdkSpawnedProcess)
-        | undefined;
-      if (!spawnProcess) {
-        throw new Error("Selected Claude credentials require an SDK-private descriptor spawner.");
-      }
-      const args = [
-        "-e",
-        [
-          'const data = require("node:fs").readFileSync(3);',
-          'require("node:fs").writeSync(2, Buffer.alloc(1024 * 1024));',
-          'const digest = require("node:crypto").createHash("sha256").update(data).digest("hex");',
-          'const descendant = require("node:child_process").spawn(process.execPath, ["-e", "setInterval(() => {}, 1000)"], {stdio: "ignore"});',
-          "process.stdout.write(JSON.stringify({fd: Number(process.env.CLAUDE_CODE_OAUTH_TOKEN_FILE_DESCRIPTOR), digest, descendantPid: descendant.pid}));",
-          "data.fill(0);",
-          "setInterval(() => {}, 1000);",
-        ].join(""),
-      ];
-      const env = { PATH: process.env.PATH, ...prepared.env };
-      expect(JSON.stringify(args)).not.toContain(token);
-      expect(Object.values(env)).not.toContain(token);
-      const child = spawnProcess({
-        command: process.execPath,
-        args,
-        cwd: process.cwd(),
-        env,
-        signal: new AbortController().signal,
-      });
-      const output = await new Promise<string>((resolve, reject) => {
-        let stdout = "";
-        child.stdout.on("data", (chunk: Buffer | string) => {
-          stdout += chunk.toString();
-          child.kill("SIGTERM");
-        });
-        child.once("error", reject);
-        child.once("exit", (code, signal) => {
-          if (signal === "SIGTERM" || (process.platform === "win32" && code !== null)) {
-            resolve(stdout);
-          } else {
-            reject(new Error(`Credential descriptor proof exited ${String(code)}.`));
-          }
-        });
-      });
-      const { descendantPid, ...descriptor } = JSON.parse(output) as {
-        fd: number;
-        digest: string;
-        descendantPid: number;
+  it.each([
+    { type: "token" as const, descriptor: "CLAUDE_CODE_OAUTH_TOKEN_FILE_DESCRIPTOR" },
+    { type: "api_key" as const, descriptor: "CLAUDE_CODE_API_KEY_FILE_DESCRIPTOR" },
+  ])(
+    "owns the selected $type process tree while keeping its descriptor private and zeroed",
+    async ({ type, descriptor: descriptorEnv }) => {
+      const backend = buildAnthropicCliBackend();
+      const token = "selected-private-descriptor-fixture";
+      const prepared = (await backend.prepareExecution?.({
+        workspaceDir: "/tmp/openclaw-workspace",
+        provider: "claude-cli",
+        modelId: "claude-sonnet-4-6",
+        executionMode: "agent",
+        authCredential: type === "token" ? { type, token } : { type, key: token },
+      } as Parameters<NonNullable<typeof backend.prepareExecution>>[0])) as {
+        env: Record<string, string>;
+        secretInput: { fd: 3; createData: () => Buffer };
+        execute: CliBackendExecute;
+        cleanup?: () => Promise<void>;
       };
-      descriptorOutput = descriptor;
-      try {
-        await vi.waitFor(() => expect(() => process.kill(descendantPid, 0)).toThrow());
-      } finally {
+      let deliveredBuffer: Buffer | undefined;
+      const originalCreateData = prepared.secretInput.createData;
+      vi.spyOn(prepared.secretInput, "createData").mockImplementation(() => {
+        deliveredBuffer = originalCreateData();
+        return deliveredBuffer;
+      });
+      let descriptorOutput: { fd: number; digest: string } | undefined;
+      useSdkMessages([SUCCESS_RESULT], async (options) => {
+        const spawnProcess = options.spawnClaudeCodeProcess as
+          | ((input: ClaudeAgentSdkSpawnOptions) => ClaudeAgentSdkSpawnedProcess)
+          | undefined;
+        if (!spawnProcess) {
+          throw new Error("Selected Claude credentials require an SDK-private descriptor spawner.");
+        }
+        const args = [
+          "-e",
+          [
+            `const data = require("node:fs").readFileSync(${JSON.stringify(process.platform === "win32" ? 3 : process.platform === "darwin" ? "/dev/fd/3" : "/proc/self/fd/3")});`,
+            'if (require("node:fs").readFileSync(3).length !== 0) throw new Error("credential replayed");',
+            'require("node:fs").writeSync(2, Buffer.alloc(1024 * 1024));',
+            'const digest = require("node:crypto").createHash("sha256").update(data).digest("hex");',
+            'const descendant = require("node:child_process").spawn(process.execPath, ["-e", "setInterval(() => {}, 1000)"], {stdio: "ignore"});',
+            `process.stdout.write(JSON.stringify({fd: Number(process.env[${JSON.stringify(descriptorEnv)}]), digest, descendantPid: descendant.pid}));`,
+            "data.fill(0);",
+            "setInterval(() => {}, 1000);",
+          ].join(""),
+        ];
+        const env = { PATH: process.env.PATH, ...prepared.env };
+        expect(JSON.stringify(args)).not.toContain(token);
+        expect(Object.values(env)).not.toContain(token);
+        const child = spawnProcess({
+          command: process.execPath,
+          args,
+          cwd: process.cwd(),
+          env,
+          signal: new AbortController().signal,
+        });
+        const output = await new Promise<string>((resolve, reject) => {
+          let stdout = "";
+          child.stdout.on("data", (chunk: Buffer | string) => {
+            stdout += chunk.toString();
+            child.kill("SIGTERM");
+          });
+          child.once("error", reject);
+          child.once("exit", (code, signal) => {
+            if (signal === "SIGTERM" || (process.platform === "win32" && code !== null)) {
+              resolve(stdout);
+            } else {
+              reject(new Error(`Credential descriptor proof exited ${String(code)}.`));
+            }
+          });
+        });
+        const { descendantPid, ...descriptor } = JSON.parse(output) as {
+          fd: number;
+          digest: string;
+          descendantPid: number;
+        };
+        descriptorOutput = descriptor;
         try {
-          process.kill(descendantPid, "SIGKILL");
-        } catch {}
+          await vi.waitFor(() => expect(() => process.kill(descendantPid, 0)).toThrow());
+        } finally {
+          try {
+            process.kill(descendantPid, "SIGKILL");
+          } catch {}
+        }
+      });
+
+      const events: Record<string, unknown>[] = [];
+      for await (const event of prepared.execute(
+        createContext({ env: { ...createContext().env, ...prepared.env } }),
+      )) {
+        events.push(event);
       }
-    });
 
-    const events: Record<string, unknown>[] = [];
-    for await (const event of prepared.execute(
-      createContext({ env: { ...createContext().env, ...prepared.env } }),
-    )) {
-      events.push(event);
-    }
-
-    expect(events).toContainEqual(SUCCESS_RESULT);
-    expect(descriptorOutput).toEqual({
-      fd: 3,
-      digest: createHash("sha256").update(token).digest("hex"),
-    });
-    expect(deliveredBuffer).toBeDefined();
-    expect(deliveredBuffer?.every((byte) => byte === 0)).toBe(true);
-    await prepared.cleanup?.();
-    expect(() => prepared.secretInput.createData()).toThrow("no longer available");
-  });
+      expect(events).toContainEqual(SUCCESS_RESULT);
+      expect(descriptorOutput).toEqual({
+        fd: 3,
+        digest: createHash("sha256").update(token).digest("hex"),
+      });
+      expect(deliveredBuffer).toBeDefined();
+      expect(deliveredBuffer?.every((byte) => byte === 0)).toBe(true);
+      await prepared.cleanup?.();
+      expect(() => prepared.secretInput.createData()).toThrow("no longer available");
+    },
+  );
 
   it.each(
     [

--- a/extensions/anthropic/agent-sdk.runtime.ts
+++ b/extensions/anthropic/agent-sdk.runtime.ts
@@ -1,4 +1,4 @@
-import { spawn } from "node:child_process";
+import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import { PassThrough } from "node:stream";
 import type {
@@ -121,7 +121,7 @@ function spawnClaudeAgentSdkProcess(
     signal: options.signal,
     stdio,
     windowsHide: true,
-  });
+  }) as ChildProcessWithoutNullStreams; // SAFETY: stdio[0..2] are pipes.
   // The SDK only drains stderr for its built-in spawner; unread custom pipes
   // fill at 64 KiB and deadlock credential-backed Claude processes.
   child.stderr.resume();

--- a/extensions/anthropic/agent-sdk.runtime.ts
+++ b/extensions/anthropic/agent-sdk.runtime.ts
@@ -1,6 +1,6 @@
 import { spawn } from "node:child_process";
 import { randomUUID } from "node:crypto";
-import { PassThrough, Writable } from "node:stream";
+import { PassThrough } from "node:stream";
 import type {
   Options as ClaudeAgentSdkOptions,
   PermissionResult as ClaudeAgentSdkPermissionResult,
@@ -14,7 +14,11 @@ import type {
   CliBackendLiveSessionCloseReason,
   CliBackendLiveSessionHandle,
 } from "openclaw/plugin-sdk/cli-backend";
-import { killProcessTree } from "openclaw/plugin-sdk/process-runtime";
+import {
+  killProcessTree,
+  prepareSecretInputStdio,
+  type SpawnStdioEntry,
+} from "openclaw/plugin-sdk/process-runtime";
 import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 import {
   createClaudeAgentSdkUserMessage,
@@ -108,14 +112,14 @@ function spawnClaudeAgentSdkProcess(
   options: ClaudeAgentSdkSpawnOptions,
   secretInput?: ClaudeAgentSdkSecretInput,
 ): ClaudeAgentSdkSpawnedProcess {
+  const stdio: ["pipe", "pipe", "pipe", ...SpawnStdioEntry[]] = ["pipe", "pipe", "pipe"];
+  using secretDelivery = prepareSecretInputStdio(stdio, secretInput);
   const child = spawn(options.command, options.args, {
     cwd: options.cwd,
     detached: process.platform !== "win32",
     env: options.env,
     signal: options.signal,
-    stdio: secretInput
-      ? ["pipe", "pipe", "pipe", process.platform === "win32" ? "overlapped" : "pipe"]
-      : ["pipe", "pipe", "pipe"],
+    stdio,
     windowsHide: true,
   });
   // The SDK only drains stderr for its built-in spawner; unread custom pipes
@@ -134,34 +138,8 @@ function spawnClaudeAgentSdkProcess(
     });
     return true;
   };
-  if (!secretInput) {
-    return child;
-  }
-  let credential: Buffer | undefined;
-  try {
-    const descriptor = child.stdio[secretInput.fd];
-    if (!(descriptor instanceof Writable)) {
-      throw new Error(`Claude Agent SDK secret descriptor ${secretInput.fd} is unavailable.`);
-    }
-    credential = secretInput.createData();
-    const rejectDelivery = () => {
-      credential?.fill(0);
-      child.kill();
-    };
-    descriptor.on("error", rejectDelivery);
-    descriptor.once("close", () => descriptor.off("error", rejectDelivery));
-    descriptor.end(credential, (error?: Error | null) => {
-      credential?.fill(0);
-      if (error) {
-        child.kill();
-      }
-    });
-    return child;
-  } catch (error) {
-    credential?.fill(0);
-    child.kill();
-    throw error;
-  }
+  void secretDelivery?.deliverTo(child).catch(() => child.kill());
+  return child;
 }
 
 async function authorizeClaudeAgentSdkTool(params: {

--- a/src/plugin-sdk/process-runtime.ts
+++ b/src/plugin-sdk/process-runtime.ts
@@ -15,3 +15,4 @@ export type { OomScoreAdjustedSpawn, OomWrapOptions } from "../process/linux-oom
 export { resolveRuntimeWorkerArgv, resolveRuntimeWorkerUrl } from "../infra/runtime-worker-url.js";
 export { killProcessTree } from "../process/kill-tree.js";
 export { isPidAlive } from "../shared/pid-alive.js";
+export { prepareSecretInputStdio, type SpawnStdioEntry } from "../process/spawn-secret-input.js";

--- a/src/process/spawn-secret-input.test.ts
+++ b/src/process/spawn-secret-input.test.ts
@@ -1,13 +1,18 @@
-import type { ChildProcess } from "node:child_process";
+import { spawn, type ChildProcess } from "node:child_process";
 import { EventEmitter } from "node:events";
-import { describe, expect, it } from "vitest";
-import { writeSecretInputToChild } from "./spawn-secret-input.js";
+import { fstatSync } from "node:fs";
+import { describe, expect, it, vi } from "vitest";
+import { prepareSecretInputStdio, type SpawnStdioEntry } from "./spawn-secret-input.js";
 
 class ControlledSecretStream extends EventEmitter {
   private endCallback: ((error?: Error | null) => void) | undefined;
 
   end(_data: Buffer, callback?: (error?: Error | null) => void): this {
     this.endCallback = callback;
+    return this;
+  }
+
+  destroy(): this {
     return this;
   }
 
@@ -24,13 +29,20 @@ function childWithSecretStream(stream: ControlledSecretStream): ChildProcess {
 }
 
 function writeSecret(stream: ControlledSecretStream): Promise<void> {
-  return writeSecretInputToChild(childWithSecretStream(stream), {
-    fd: 3,
-    createData: () => Buffer.from("selected-secret"),
-  });
+  const original = Object.getOwnPropertyDescriptor(process, "platform")!;
+  Object.defineProperty(process, "platform", { configurable: true, value: "win32" });
+  try {
+    using prepared = prepareSecretInputStdio([], {
+      fd: 3,
+      createData: () => Buffer.from("selected-secret"),
+    });
+    return prepared!.deliverTo(childWithSecretStream(stream));
+  } finally {
+    Object.defineProperty(process, "platform", original);
+  }
 }
 
-describe("writeSecretInputToChild", () => {
+describe("Windows secret input delivery", () => {
   it("consumes pipe errors after delivery until the stream closes", async () => {
     const stream = new ControlledSecretStream();
     const write = writeSecret(stream);
@@ -57,5 +69,110 @@ describe("writeSecretInputToChild", () => {
 
     stream.emit("close");
     expect(stream.listenerCount("error")).toBe(0);
+  });
+});
+
+function expectDescriptorReleased(fd: number, original: ReturnType<typeof fstatSync>) {
+  let current: ReturnType<typeof fstatSync>;
+  try {
+    current = fstatSync(fd);
+  } catch (error) {
+    expect(error).toMatchObject({ code: "EBADF" });
+    return;
+  }
+  // Other Vitest workers can reuse the number after close; identity owns the pipe.
+  expect({ dev: current.dev, ino: current.ino }).not.toEqual({
+    dev: original.dev,
+    ino: original.ino,
+  });
+}
+
+describe.skipIf(process.platform === "win32")("POSIX secret input ownership", () => {
+  const descriptorPath = process.platform === "darwin" ? "/dev/fd/3" : "/proc/self/fd/3";
+
+  it.each(["path", "direct"])(
+    "delivers once through a %s reader without replay to descendants",
+    async (reader) => {
+      const stdio: SpawnStdioEntry[] = ["ignore", "pipe", "pipe"];
+      const data = Buffer.from("private-fixture");
+      using prepared = prepareSecretInputStdio(stdio, { fd: 3, createData: () => data });
+      const original = fstatSync(stdio[3] as number);
+      const child = spawn(
+        process.execPath,
+        [
+          "-e",
+          `
+      const fs = require("node:fs");
+      const value = fs.readFileSync(${JSON.stringify(reader === "path" ? descriptorPath : 3)}, "utf8");
+      const descendant = require("node:child_process").spawnSync(process.execPath,
+        ["-e", 'process.stdout.write(String(require("node:fs").readFileSync(3).length))'],
+        {stdio: ["ignore", "pipe", "inherit", 3]});
+      process.stdout.write(JSON.stringify({value, descendant: descendant.stdout.toString()}));
+    `,
+        ],
+        { stdio },
+      );
+      const output = new Promise<string>((resolve, reject) => {
+        let text = "";
+        child.stdout!.on("data", (chunk) => {
+          text += chunk;
+        });
+        child.on("error", reject);
+        child.once("close", (code) =>
+          code === 0 ? resolve(text) : reject(new Error(`child exited ${code}`)),
+        );
+      });
+      try {
+        await prepared!.deliverTo(child);
+        expect(JSON.parse(await output)).toEqual({ value: "private-fixture", descendant: "0" });
+        expect(data.every((byte) => byte === 0)).toBe(true);
+        expectDescriptorReleased(stdio[3] as number, original);
+      } finally {
+        child.kill("SIGKILL");
+      }
+    },
+  );
+
+  it("closes both untransferred ends when spawning throws", () => {
+    const stdio: SpawnStdioEntry[] = ["ignore", "pipe", "pipe"];
+    const createData = vi.fn(() => Buffer.from("not-delivered"));
+    expect(() => {
+      using prepared = prepareSecretInputStdio(stdio, { fd: 3, createData });
+      void prepared;
+      spawn("", [], { stdio });
+    }).toThrow();
+    expect(createData).not.toHaveBeenCalled();
+    expect(() => fstatSync(stdio[3] as number)).toThrow(expect.objectContaining({ code: "EBADF" }));
+  });
+  it("closes the writer without delivering bytes when credential creation throws", async () => {
+    const stdio: SpawnStdioEntry[] = ["ignore", "pipe", "pipe"];
+    const reason = new Error("credential unavailable");
+    using prepared = prepareSecretInputStdio(stdio, {
+      fd: 3,
+      createData: () => {
+        throw reason;
+      },
+    });
+    const child = spawn(
+      process.execPath,
+      ["-e", 'process.stdout.write(String(require("node:fs").readFileSync(3).length))'],
+      { stdio },
+    );
+    const output = new Promise<string>((resolve, reject) => {
+      let text = "";
+      child.stdout!.on("data", (chunk) => {
+        text += chunk;
+      });
+      child.on("error", reject);
+      child.once("close", (code) =>
+        code === 0 ? resolve(text) : reject(new Error(`child exited ${code}`)),
+      );
+    });
+    try {
+      await expect(prepared!.deliverTo(child)).rejects.toBe(reason);
+      await expect(output).resolves.toBe("0");
+    } finally {
+      child.kill("SIGKILL");
+    }
   });
 });

--- a/src/process/spawn-secret-input.ts
+++ b/src/process/spawn-secret-input.ts
@@ -13,6 +13,7 @@ let createPipe: (() => SecretPipe) | undefined;
 
 function createSecretPipe(): SecretPipe {
   createPipe ??= (() => {
+    // SAFETY: Koffi's require export has the same API as its typed default export.
     const koffi = require("koffi") as typeof import("koffi").default;
     const libc = koffi.load(null);
     const closeFd = libc.func("int close(int fd)");
@@ -98,7 +99,7 @@ export function prepareSecretInputStdio(
                     pipe!.close(fd);
                     callback(null);
                   } catch (error) {
-                    callback(toErrorObject(error));
+                    callback(toErrorObject(error, "secret input close failed"));
                   }
                 },
               },

--- a/src/process/spawn-secret-input.ts
+++ b/src/process/spawn-secret-input.ts
@@ -1,15 +1,60 @@
 import type { ChildProcess } from "node:child_process";
+import { createWriteStream, write, writev } from "node:fs";
+import { createRequire } from "node:module";
 import type { Writable } from "node:stream";
+import { toErrorObject } from "../infra/errors.js";
 import type { SpawnSecretInput } from "./supervisor/types.js";
 
-export type SpawnStdioEntry = "ignore" | "inherit" | "ipc" | "overlapped" | "pipe";
+export type SpawnStdioEntry = "ignore" | "inherit" | "ipc" | "overlapped" | "pipe" | number;
 
-export function addSecretInputStdio(
+const require = createRequire(import.meta.url);
+type SecretPipe = { fds: number[]; close: (fd: number) => void };
+let createPipe: (() => SecretPipe) | undefined;
+
+function createSecretPipe(): SecretPipe {
+  createPipe ??= (() => {
+    const koffi = require("koffi") as typeof import("koffi").default;
+    const libc = koffi.load(null);
+    const closeFd = libc.func("int close(int fd)");
+    const close = (fd: number) => {
+      if (closeFd(fd) !== 0) {
+        throw new Error(`secret input close failed (errno ${koffi.errno()})`);
+      }
+    };
+    const pipe = libc.func(
+      process.platform === "linux"
+        ? "int pipe2(_Out_ int *fds, int flags)"
+        : "int pipe(_Out_ int *fds)",
+    );
+    const fcntl =
+      process.platform === "linux" ? undefined : libc.func("int fcntl(int fd, int cmd, ...)");
+    return () => {
+      const fds = [-1, -1];
+      // Linux allocates with O_CLOEXEC atomically. POSIX F_SETFD=2/FD_CLOEXEC=1
+      // protects other execs on platforms without pipe2; no async work intervenes.
+      if (pipe(fds, ...(fcntl ? [] : [0x80000])) !== 0) {
+        throw new Error(`secret input pipe creation failed (errno ${koffi.errno()})`);
+      }
+      try {
+        if (fcntl && fds.some((fd) => fcntl(fd, 2, "int", 1) !== 0)) {
+          throw new Error(`secret input close-on-exec failed (errno ${koffi.errno()})`);
+        }
+        return { fds, close };
+      } catch (error) {
+        fds.forEach(close);
+        throw error;
+      }
+    };
+  })();
+  return createPipe();
+}
+
+export function prepareSecretInputStdio(
   stdio: SpawnStdioEntry[],
   secretInput: SpawnSecretInput | undefined,
-): void {
+): { deliverTo: (child: ChildProcess) => Promise<void>; [Symbol.dispose]: () => void } | undefined {
   if (!secretInput) {
-    return;
+    return undefined;
   }
   if (!Number.isInteger(secretInput.fd) || secretInput.fd < 3) {
     throw new Error("secret input file descriptor must be an integer greater than 2");
@@ -17,50 +62,79 @@ export function addSecretInputStdio(
   while (stdio.length <= secretInput.fd) {
     stdio.push("ignore");
   }
-  stdio[secretInput.fd] = process.platform === "win32" ? "overlapped" : "pipe";
-}
-
-export async function writeSecretInputToChild(
-  child: ChildProcess,
-  secretInput: SpawnSecretInput | undefined,
-): Promise<void> {
-  if (!secretInput) {
-    return;
-  }
-  const stream = child.stdio[secretInput.fd] as Writable | null | undefined;
-  if (!stream || typeof stream.end !== "function") {
-    throw new Error(`secret input file descriptor ${secretInput.fd} is unavailable`);
-  }
-  let data: Buffer | undefined;
-  try {
-    data = secretInput.createData();
-    // End the parent pipe immediately after delivery so descendants cannot
-    // inherit a still-readable credential stream.
-    await new Promise<void>((resolve, reject) => {
-      let settled = false;
-      const settle = (error?: Error | null) => {
-        if (settled) {
-          return;
-        }
-        settled = true;
-        if (error) {
-          reject(error);
-        } else {
-          resolve();
-        }
-      };
-      const onError = (error: Error) => {
-        settle(error);
-      };
-      // A child-process pipe can emit its terminal error after end's callback.
-      // Keep it handled until close while only the first outcome settles delivery.
-      stream.on("error", onError);
-      stream.once("close", () => {
-        stream.off("error", onError);
-      });
-      stream.end(data, settle);
-    });
-  } finally {
-    data?.fill(0);
-  }
+  // Node's POSIX stdio "pipe" is a socketpair, which cannot be reopened through
+  // /proc/self/fd. A real anonymous pipe supports external CLI descriptor readers
+  // while preserving one-shot consumption without credential files or shell relays.
+  const pipe = process.platform === "win32" ? undefined : createSecretPipe();
+  let [readFd, writeFd] = pipe?.fds ?? [];
+  stdio[secretInput.fd] = readFd ?? "overlapped";
+  const closeRead = () => {
+    if (readFd !== undefined) {
+      pipe!.close(readFd);
+      readFd = undefined;
+    }
+  };
+  return {
+    [Symbol.dispose]() {
+      closeRead();
+      if (writeFd !== undefined) {
+        pipe!.close(writeFd);
+        writeFd = undefined;
+      }
+    },
+    async deliverTo(child) {
+      closeRead();
+      const stream =
+        writeFd === undefined
+          ? (child.stdio[secretInput.fd] as Writable | null | undefined)
+          : createWriteStream("", {
+              fd: writeFd,
+              fs: {
+                write,
+                writev,
+                // Native allocations are outside Node's per-worker fd registry.
+                close(fd, callback) {
+                  try {
+                    pipe!.close(fd);
+                    callback(null);
+                  } catch (error) {
+                    callback(toErrorObject(error));
+                  }
+                },
+              },
+            });
+      writeFd = undefined;
+      if (!stream || typeof stream.end !== "function") {
+        throw new Error(`secret input file descriptor ${secretInput.fd} is unavailable`);
+      }
+      let data: Buffer | undefined;
+      try {
+        data = secretInput.createData();
+        // Close the writer after delivery: later readers must see EOF, never a replay.
+        await new Promise<void>((resolve, reject) => {
+          let settled = false;
+          const settle = (error?: Error | null) => {
+            if (settled) {
+              return;
+            }
+            settled = true;
+            if (error) {
+              reject(error);
+            } else {
+              resolve();
+            }
+          };
+          const onError = (error: Error) => settle(error);
+          // A pipe can emit its terminal error after end's callback. Retain the
+          // handler until close while only the first outcome settles delivery.
+          stream.on("error", onError);
+          stream.once("close", () => stream.off("error", onError));
+          stream.end(data, settle);
+        });
+      } finally {
+        data?.fill(0);
+        stream.destroy();
+      }
+    },
+  };
 }

--- a/src/process/supervisor/adapters/child.service-lifecycle.test.ts
+++ b/src/process/supervisor/adapters/child.service-lifecycle.test.ts
@@ -510,30 +510,38 @@ describe.skipIf(process.platform === "win32")("service-managed child lifecycle",
     }
   });
 
-  it("keeps stdin and the secret descriptor distinct from lifecycle channels", async () => {
-    process.env.OPENCLAW_SERVICE_MARKER = "openclaw";
-    const adapter = await createChildAdapter({
-      argv: [
-        "/bin/sh",
-        "-c",
-        'IFS= read -r secret <&3; IFS= read -r input; printf "%s:%s\\n" "${#secret}" "$input"',
-      ],
-      stdinMode: "pipe-open",
-      secretInput: {
-        fd: 3,
-        createData: () => Buffer.from("synthetic-secret\n", "utf8"),
-      },
-    });
-    let output = "";
-    adapter.onStdout((chunk) => {
-      output += chunk;
-    });
-    adapter.stdin?.write("ordinary-input\n");
-    adapter.stdin?.end();
+  it.each([false, true])(
+    "keeps reopenable secret input distinct from stdin and lifecycle channels (service=%s)",
+    async (service) => {
+      if (service) {
+        process.env.OPENCLAW_SERVICE_MARKER = "openclaw";
+      }
+      const adapter = await createChildAdapter({
+        argv: [
+          process.execPath,
+          "-e",
+          `const fs = require("node:fs");
+         const secret = fs.readFileSync(${JSON.stringify(process.platform === "darwin" ? "/dev/fd/3" : "/proc/self/fd/3")}, "utf8").trimEnd();
+         const input = fs.readFileSync(0, "utf8");
+         process.stdout.write(secret.length + ":" + input);`,
+        ],
+        stdinMode: "pipe-open",
+        secretInput: {
+          fd: 3,
+          createData: () => Buffer.from("synthetic-secret\n", "utf8"),
+        },
+      });
+      let output = "";
+      adapter.onStdout((chunk) => {
+        output += chunk;
+      });
+      adapter.stdin?.write("ordinary-input\n");
+      adapter.stdin?.end();
 
-    await expect(adapter.wait()).resolves.toEqual({ code: 0, signal: null });
-    expect(output).toBe("16:ordinary-input\n");
-  });
+      await expect(adapter.wait()).resolves.toEqual({ code: 0, signal: null });
+      expect(output).toBe("16:ordinary-input\n");
+    },
+  );
 
   it("fails closed when the command drops its lineage descriptor early", async () => {
     process.env.OPENCLAW_SERVICE_MARKER = "openclaw";

--- a/src/process/supervisor/adapters/child.service-lifecycle.test.ts
+++ b/src/process/supervisor/adapters/child.service-lifecycle.test.ts
@@ -510,10 +510,10 @@ describe.skipIf(process.platform === "win32")("service-managed child lifecycle",
     }
   });
 
-  it.each([false, true])(
-    "keeps reopenable secret input distinct from stdin and lifecycle channels (service=%s)",
-    async (service) => {
-      if (service) {
+  it.each(["direct", "service", "owned-worker"] as const)(
+    "keeps reopenable secret input distinct from stdin and lifecycle channels (%s)",
+    async (mode) => {
+      if (mode === "service") {
         process.env.OPENCLAW_SERVICE_MARKER = "openclaw";
       }
       const adapter = await createChildAdapter({
@@ -525,6 +525,7 @@ describe.skipIf(process.platform === "win32")("service-managed child lifecycle",
          const input = fs.readFileSync(0, "utf8");
          process.stdout.write(secret.length + ":" + input);`,
         ],
+        ownedWorker: mode === "owned-worker" ? true : undefined,
         stdinMode: "pipe-open",
         secretInput: {
           fd: 3,
@@ -535,6 +536,7 @@ describe.skipIf(process.platform === "win32")("service-managed child lifecycle",
       adapter.onStdout((chunk) => {
         output += chunk;
       });
+      adapter.closeStartGate?.();
       adapter.stdin?.write("ordinary-input\n");
       adapter.stdin?.end();
 

--- a/src/process/supervisor/adapters/child.test.ts
+++ b/src/process/supervisor/adapters/child.test.ts
@@ -412,6 +412,7 @@ describe("createChildAdapter", () => {
   );
 
   it("preserves startup failure when a worker error arrives during secret delivery", async () => {
+    setPlatform("win32");
     const { child, killMock } = createStubChild();
     const deliveryError = new Error("secret delivery failed");
     const secretStream = new Writable({
@@ -444,6 +445,7 @@ describe("createChildAdapter", () => {
   });
 
   it("writes secret input to an extra descriptor and zeroes the transient buffer", async () => {
+    setPlatform("win32");
     const { child } = createStubChild();
     const secretStream = new PassThrough();
     const chunks: Buffer[] = [];
@@ -480,6 +482,7 @@ describe("createChildAdapter", () => {
   });
 
   it("captures child close while secret input delivery is still pending", async () => {
+    setPlatform("win32");
     const { child, emitClose } = createStubChild();
     const secretStream = new Writable({
       write(_chunk, _encoding, callback) {

--- a/src/process/supervisor/adapters/child.test.ts
+++ b/src/process/supervisor/adapters/child.test.ts
@@ -271,50 +271,6 @@ describe("createChildAdapter", () => {
     }
   });
 
-  it("waits for an owned worker's secret descriptor to close after delivery", async () => {
-    vi.useFakeTimers();
-    setPlatform("darwin");
-    const { child, emitExit } = createStubChild();
-    const secretStream = new Writable({
-      autoDestroy: false,
-      write(_chunk, _encoding, callback) {
-        callback();
-      },
-    });
-    Object.defineProperty(child, "stdio", {
-      value: [child.stdin, child.stdout, child.stderr, secretStream, null],
-      configurable: true,
-    });
-    spawnWithFallbackMock.mockResolvedValue({ child, usedFallback: false });
-    const transient = Buffer.from("synthetic-secret");
-    const adapter = await createChildAdapter({
-      argv: ["node", "worker"],
-      ownedWorker: true,
-      secretInput: { fd: 3, createData: () => transient },
-    });
-    const settled = vi.fn();
-    const wait = adapter.wait();
-    void wait.then(settled);
-
-    try {
-      expect(secretStream.writableFinished).toBe(true);
-      expect(transient.equals(Buffer.alloc(transient.length))).toBe(true);
-      adapter.closeStartGate?.();
-      emitExit(0);
-      child.stdout?.emit("close");
-      child.stderr?.emit("close");
-      await vi.advanceTimersByTimeAsync(0);
-      expect(settled).not.toHaveBeenCalled();
-      secretStream.destroy();
-      await vi.advanceTimersByTimeAsync(0);
-      expect(settled).toHaveBeenCalledExactlyOnceWith({ code: 0, signal: null });
-      await expect(wait).resolves.toEqual({ code: 0, signal: null });
-    } finally {
-      secretStream.destroy();
-      adapter.dispose();
-    }
-  });
-
   it("keeps ordinary children supervised through repeated operational errors", async () => {
     const { child, emitClose, emitExit } = createStubChild(7865);
     spawnWithFallbackMock.mockResolvedValue({ child, usedFallback: false });

--- a/src/process/supervisor/adapters/child.ts
+++ b/src/process/supervisor/adapters/child.ts
@@ -9,11 +9,7 @@ import { createDeferredCore } from "../../../shared/deferred.js";
 import { onDecodedOutput } from "../../decoded-output.js";
 import { signalProcessTree } from "../../kill-tree.js";
 import { prepareOomScoreAdjustedSpawn } from "../../linux-oom-score.js";
-import {
-  addSecretInputStdio,
-  type SpawnStdioEntry,
-  writeSecretInputToChild,
-} from "../../spawn-secret-input.js";
+import { prepareSecretInputStdio, type SpawnStdioEntry } from "../../spawn-secret-input.js";
 import { spawnWithFallback } from "../../spawn-utils.js";
 import {
   buildWindowsCmdExeCommandLine,
@@ -151,7 +147,7 @@ export async function createChildAdapter(params: ChildAdapterInput): Promise<Wor
     (params.ownedWorker !== undefined || !isServiceManagedRuntime());
 
   const stdio: SpawnStdioEntry[] = [stdinMode === "inherit" ? "inherit" : "pipe", "pipe", "pipe"];
-  addSecretInputStdio(stdio, params.secretInput);
+  using secretDelivery = prepareSecretInputStdio(stdio, params.secretInput);
   if (params.ownedWorker !== undefined) {
     stdio.push("ipc");
   }
@@ -387,7 +383,7 @@ export async function createChildAdapter(params: ChildAdapterInput): Promise<Wor
 
   if (params.secretInput) {
     try {
-      await writeSecretInputToChild(spawned.child, params.secretInput);
+      await secretDelivery?.deliverTo(spawned.child);
     } catch (error) {
       spawned.child.kill("SIGKILL");
       throw error;

--- a/src/process/supervisor/service-child-relay-host.ts
+++ b/src/process/supervisor/service-child-relay-host.ts
@@ -8,7 +8,7 @@ import {
 } from "../../infra/runtime-worker-url.js";
 import { createDeferredCore } from "../../shared/deferred.js";
 import { onDecodedOutput } from "../decoded-output.js";
-import { addSecretInputStdio, writeSecretInputToChild } from "../spawn-secret-input.js";
+import { prepareSecretInputStdio } from "../spawn-secret-input.js";
 import { createManagedChildStdin } from "./adapters/child-stdin.js";
 import { toStringEnv } from "./adapters/env.js";
 import {
@@ -148,10 +148,10 @@ export async function createServiceChildRelayAdapter(params: {
   const stdio: StdioEntry[] = useWindowsJobAnchor
     ? ["ignore", "ignore", "ignore"]
     : [params.stdinMode === "inherit" ? "inherit" : "pipe", "pipe", "pipe"];
-  if (!useWindowsJobAnchor) {
-    // SAFETY: stdio contains only SpawnStdioEntry values until lifecycle descriptors are reserved.
-    addSecretInputStdio(stdio as Parameters<typeof addSecretInputStdio>[0], params.secretInput);
-  }
+  using secretDelivery = prepareSecretInputStdio(
+    stdio,
+    useWindowsJobAnchor ? undefined : params.secretInput,
+  );
   const controlFd = useWindowsJobAnchor ? undefined : reserveStdioEntry(stdio, "pipe");
   reserveStdioEntry(stdio, "ipc");
 
@@ -440,7 +440,7 @@ export async function createServiceChildRelayAdapter(params: {
 
   const [startupResult, secretDeliveryResult] = await Promise.allSettled([
     startup.promise,
-    writeSecretInputToChild(child, params.secretInput),
+    secretDelivery?.deliverTo(child),
   ]);
   const startupError = startupResult.status === "rejected" ? startupResult.reason : undefined;
   const secretDeliveryError =

--- a/src/state/openclaw-agent-db.test.ts
+++ b/src/state/openclaw-agent-db.test.ts
@@ -3737,12 +3737,12 @@ describe("openclaw agent database", () => {
       older.close();
     }
     const repaired = openOpenClawAgentDatabase({ agentId: "worker-1", env });
-    expect(readSqliteNumberPragma(repaired.db, "user_version")).toBe(18);
+    expect(readSqliteNumberPragma(repaired.db, "user_version")).toBe(OPENCLAW_AGENT_SCHEMA_VERSION);
     expect(
       repaired.db
         .prepare("SELECT schema_version FROM schema_meta WHERE meta_key = 'primary'")
         .get(),
-    ).toEqual({ schema_version: 18 });
+    ).toEqual({ schema_version: OPENCLAW_AGENT_SCHEMA_VERSION });
     expect(
       repaired.db
         .prepare("SELECT event_json FROM transcript_events WHERE session_id = 'eligibility'")

--- a/src/state/openclaw-database-preflight.test.ts
+++ b/src/state/openclaw-database-preflight.test.ts
@@ -565,7 +565,10 @@ describe("OpenClaw database schema preflight", () => {
       const result = preflightOpenClawDatabaseSchemas({
         env,
         verifyCurrentSchemaShape: true,
-        supportedVersions: { state: OPENCLAW_STATE_SCHEMA_VERSION, agent: 18 },
+        supportedVersions: {
+          state: OPENCLAW_STATE_SCHEMA_VERSION,
+          agent: OPENCLAW_AGENT_SCHEMA_VERSION,
+        },
       });
       expect(result.incompatible).toEqual([]);
       expect(result.indeterminate).toEqual(
@@ -588,7 +591,9 @@ describe("OpenClaw database schema preflight", () => {
             )
             .get(),
         ).toEqual(shape === "absent" ? undefined : { name: "context_eligible" });
-        expect(inspected.prepare("PRAGMA user_version").get()).toEqual({ user_version: 18 });
+        expect(inspected.prepare("PRAGMA user_version").get()).toEqual({
+          user_version: OPENCLAW_AGENT_SCHEMA_VERSION,
+        });
       } finally {
         inspected.close();
       }


### PR DESCRIPTION
## Problem

Selected Claude CLI profiles can fail authentication on Linux even when the stored token is valid. Node creates a socketpair for child stdio `"pipe"`, but Claude Code 2.1.251 reopens its credential descriptor through `/proc/self/fd/3` (Linux) or `/dev/fd/3` (macOS). On Linux the socket reopen fails with `ENXIO`, so the CLI falls through to unrelated native credentials. Direct numeric-descriptor tests did not exercise this dependency contract.

## Change

Move credential delivery into one disposable process-owned transport. POSIX allocates a real anonymous pipe through the existing Koffi dependency, marks both ends close-on-exec, and passes only the selected read descriptor to the child. Delivery owns the writer and zeroes its temporary buffer; disposal closes untransferred descriptors if spawning fails. Windows retains its existing overlapped pipe transport.

The ordinary child adapter, service relay, and Anthropic SDK now use the same owner. Delete the SDK's duplicate write/zero/error path and the old split prepare/write helpers. The existing private process-runtime facade exposes the helper; its lifecycle contract is documented. No credential files, shell relay, ambient-credential fallback, configuration option, schema change, or dependency addition.

Production delta: +50 lines across five files, after deleting 22 net lines from the SDK writer and four from its direct caller. The remaining growth implements the real OS descriptor lifecycle required by the native CLI; merely changing the SDK consumer cannot repair the shared transport. Tests cover both path and numeric readers, EOF for descendants, zeroing, failed spawn and credential creation, existing large-write startup failure, token/API-key selection, and ordinary/service process ownership.

## Evidence

- Official Claude Code 2.1.251 Linux, macOS, and Windows package integrity verified; descriptor-reader and bounded-reader source inspected directly. Windows source inspection is not a Windows runtime verdict.
- Linux native descriptor reproduction: socket reopen fails; anonymous pipe reopen succeeds with exact bytes and EOF, including when the writer closes before spawning. macOS anonymous-pipe probe also passes.
- SDK regression fails on pre-fix production code; Linux final focused and sibling set passes 121 tests using the repository's exact Koffi 3.1.6 dependency.
- Original Docker gateway selector (`claude-cli,google-gemini-cli`) passes **153/153 tests in 45.90s**, with all three selected Claude CLI models completing prompts and real nonce-file tool reads. Existing native credential files remain mounted; the selected static profile wins through the descriptor, without an ambient API key. The unchanged high-signal policy selects no Gemini model here; Gemini has separate live evidence. Native Claude Code **2.1.251** was verified in the running container.
- Canonical Docker image build passes; image digest `b5bd8666365fb605ebd865b17069d2475509d841f967fa3e8a68bb18b133ac5e`. The build plus exact original replay completed with exit 0 in 130.306s on the [proof testbox workflow](https://github.com/openclaw/openclaw/actions/runs/33249009354). Source overlay is recorded by manifest; this is targeted candidate proof, not a fresh all-lanes run of main.
- SDK package export and assertion-safety checks pass. The canonical current-main rerun passes **133 tests** (36 node-host, 68 process, 29 Anthropic SDK). The two database test files also pass **145 tests with 4 platform skips**, including all four previously failing cases. Exact-head CI is required before landing.

One build attempt failed because macOS tar metadata produced an AppleDouble `.ts` sibling; removing only those task-generated archive entries and transferring a metadata-free archive repaired the transport. The regression itself initially made an invalid late assertion about a reused descriptor number; the final test checks pipe identity instead. These failures are retained in the proof record.

The first CI run exposed two typing issues (the canonical error normalizer requires a fallback message; Node’s spawn overload cannot infer non-null standard streams with an extra numeric descriptor), which are repaired without changing credential delivery. A newly added mainline mock still represented the POSIX credential as a Node stream; it is replaced by a real owned-worker case preserving exact secret/stdin output, IPC disconnect, and natural exit. Four stale schema-18 expectations in two database tests now use the existing current-version constant after main’s schema-19 bump; their same-version/no-rewrite/index assertions remain intact. No schema or persistence behavior changes are included.

Release note: Fix selected Claude CLI credential profiles on POSIX by using reopenable one-shot anonymous pipes, shared across ordinary, service-managed, and SDK child processes.
