### PR TITLE
fix: preserve Gateway test cleanup after partial setup

### DIFF
--- a/src/gateway/server.e2e-ws-harness.test.ts
+++ b/src/gateway/server.e2e-ws-harness.test.ts
@@ -1,0 +1,38 @@
+import { afterEach, expect, test, vi } from "vitest";
+import { captureEnv } from "../test-utils/env.js";
+import { startGatewayServerHarness } from "./server.e2e-ws-harness.js";
+
+const startup = vi.hoisted(() => ({
+  port: vi.fn<() => Promise<number>>(),
+  server: vi.fn<() => Promise<never>>(),
+}));
+vi.mock("./test-helpers.js", () => ({
+  getGatewayTestPort: startup.port,
+  startTestGatewayServer: startup.server,
+  connectOk: vi.fn(),
+  trackConnectChallengeNonce: vi.fn(),
+}));
+
+afterEach(() => {
+  vi.resetAllMocks();
+});
+
+test.each(["port", "server"] as const)(
+  "restores its token snapshot when %s acquisition fails before publishing a close handle",
+  async (stage) => {
+    const env = captureEnv(["OPENCLAW_GATEWAY_TOKEN"]);
+    const failure = new Error(`injected ${stage} acquisition failure`);
+    process.env.OPENCLAW_GATEWAY_TOKEN = "fixture-token";
+    startup.port.mockResolvedValue(12345);
+    startup.server.mockRejectedValue(failure);
+    if (stage === "port") {
+      startup.port.mockRejectedValue(failure);
+    }
+    try {
+      await expect(startGatewayServerHarness()).rejects.toBe(failure);
+      expect(process.env.OPENCLAW_GATEWAY_TOKEN).toBe("fixture-token");
+    } finally {
+      env.restore();
+    }
+  },
+);

--- a/src/gateway/server.e2e-ws-harness.ts
+++ b/src/gateway/server.e2e-ws-harness.ts
@@ -23,14 +23,17 @@ export type GatewayServerHarness = {
 
 /** Start a loopback Gateway server with a helper for opening authenticated test clients. */
 export async function startGatewayServerHarness(): Promise<GatewayServerHarness> {
+  const port = await getGatewayTestPort();
   const envSnapshot = captureEnv(["OPENCLAW_GATEWAY_TOKEN"]);
   const clients = new Set<WebSocket>();
   delete process.env.OPENCLAW_GATEWAY_TOKEN;
-  const port = await getGatewayTestPort();
   const server = await startTestGatewayServer(port, {
     auth: { mode: "none" },
     bind: "loopback",
     controlUiEnabled: false,
+  }).catch((error: unknown) => {
+    envSnapshot.restore();
+    throw error;
   });
 
   const openClient = async (opts?: Parameters<typeof connectOk>[1]): Promise<GatewayWsClient> => {

--- a/src/gateway/server.sessions.create.test.ts
+++ b/src/gateway/server.sessions.create.test.ts
@@ -6,7 +6,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { promisify } from "node:util";
-import { afterAll, afterEach, beforeAll, beforeEach, expect, test, vi } from "vitest";
+import { afterEach, beforeEach, expect, test, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { getContextWindowCaches } from "../agents/context-cache.js";
 import {
@@ -163,13 +163,14 @@ vi.mock("./session-transcript-readers.js", async (importOriginal) => {
   return { ...actual, readSessionMessageCountAsync: sessionTranscriptReaderMocks.readCount };
 });
 
+let gitWorkspaceTemplate: string;
 const { createSessionStoreDir, createSelectedGlobalSessionStore, openClient } =
-  setupGatewaySessionsTestHarness();
+  setupGatewaySessionsTestHarness(async (makeTempDir) => {
+    gitWorkspaceTemplate = await createGitWorkspace(makeTempDir("openclaw-session-git-template-"));
+  });
 const execFileAsync = promisify(execFile);
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 const directoryLinkType = process.platform === "win32" ? "junction" : "dir";
-let gitWorkspaceTemplateRoot: string;
-let gitWorkspaceTemplate: string;
 
 async function waitForCreatedSessionRun(
   context: { chatAbortControllers: Map<string, ChatAbortControllerEntry> },
@@ -194,17 +195,6 @@ async function waitForCreatedSessionRun(
   }
   return removed;
 }
-
-beforeAll(async () => {
-  gitWorkspaceTemplateRoot = await fs.realpath(
-    await fs.mkdtemp(path.join(await fs.realpath(os.tmpdir()), "openclaw-session-git-template-")),
-  );
-  gitWorkspaceTemplate = await createGitWorkspace(gitWorkspaceTemplateRoot);
-});
-
-afterAll(async () => {
-  await fs.rm(gitWorkspaceTemplateRoot, { recursive: true, force: true });
-});
 
 // Read the real implementations back here rather than capturing them inside the
 // mock factories: Vitest runs a factory on first import of the mocked module, and

--- a/src/gateway/server.sessions.fixture-lifecycle.test.ts
+++ b/src/gateway/server.sessions.fixture-lifecycle.test.ts
@@ -1,0 +1,374 @@
+import fsSync from "node:fs";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { vi } from "vitest";
+import { createDeferredCore } from "../shared/deferred.js";
+import { captureEnv } from "../test-utils/env.js";
+
+// Run the actual fixture hooks with controlled setup/teardown overlap instead
+// of waiting for the runner's 180s timeout. Consumer test bodies stay uncalled.
+const hooks = vi.hoisted(() => ({
+  setup: [] as Array<() => unknown>,
+  cleanup: [] as Array<() => unknown>,
+}));
+vi.mock("vitest", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("vitest")>()),
+  beforeAll: (fn: () => unknown) => hooks.setup.push(fn),
+  afterAll: (fn: () => unknown) => hooks.cleanup.push(fn),
+  beforeEach: () => {},
+  afterEach: () => {},
+  test: Object.assign(() => {}, { each: () => () => {} }),
+}));
+
+const listeners = vi.hoisted(() => new Set<import("node:net").Server>());
+// The fixture owns a disposable server, not Gateway business logic. Keep its
+// real port, socket, harness and environment lifetime; fork tests cover RPC boot.
+vi.mock("./server.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./server.js")>()),
+  resetPreparedModelCatalogForTest: async () => {},
+  startGatewayServer: async (port: number) => {
+    const { createServer } = await import("node:net");
+    const listener = createServer();
+    listeners.add(listener);
+    await new Promise<void>((resolve, reject) => {
+      listener.once("error", reject);
+      listener.listen(port, "127.0.0.1", resolve);
+    });
+    return {
+      startupSettled: Promise.resolve(),
+      getTailscaleIngressEndpoint: () => undefined,
+      close: async () => {
+        if (listener.listening) {
+          await new Promise<void>((resolve, reject) => {
+            listener.close((error) => (error ? reject(error) : resolve()));
+          });
+        }
+      },
+    } satisfies import("./server.js").GatewayServer;
+  },
+}));
+
+const { afterEach, beforeEach, expect, test } =
+  await vi.importActual<typeof import("vitest")>("vitest");
+await import("./server.sessions.create.test.js");
+const consumerHooks = { setup: hooks.setup.splice(0), cleanup: hooks.cleanup.splice(0) };
+const sessions = await import("./test/server-sessions.test-helpers.js");
+const serverHarness = await import("./server.e2e-ws-harness.js");
+const gatewayHelpers = await import("./test-helpers.server.js");
+const startHarness = serverHarness.startGatewayServerHarness;
+let env: ReturnType<typeof captureEnv>;
+beforeEach(() => {
+  env = captureEnv([
+    "HOME",
+    "USERPROFILE",
+    "OPENCLAW_STATE_DIR",
+    "OPENCLAW_CONFIG_PATH",
+    "OPENCLAW_AGENT_DIR",
+    "OPENCLAW_GATEWAY_TOKEN",
+    "OPENCLAW_SKIP_BROWSER_CONTROL_SERVER",
+    "OPENCLAW_SKIP_GMAIL_WATCHER",
+    "OPENCLAW_SKIP_CANVAS_HOST",
+    "OPENCLAW_SKIP_CHANNELS",
+    "OPENCLAW_SKIP_PROVIDERS",
+    "OPENCLAW_SKIP_CRON",
+    "OPENCLAW_TEST_MINIMAL_GATEWAY",
+    "OPENCLAW_DISABLE_BUNDLED_PLUGINS",
+    "OPENCLAW_BUNDLED_PLUGINS_DIR",
+  ]);
+});
+afterEach(async () => {
+  // Preserve cleanup even on the unfixed side of these regressions.
+  for (const listener of listeners) {
+    if (listener.listening) {
+      await new Promise<void>((resolve) => {
+        listener.close(() => resolve());
+      });
+    }
+  }
+  listeners.clear();
+  vi.restoreAllMocks();
+  env.restore();
+});
+
+async function setup(fixture: typeof hooks) {
+  for (const hook of fixture.setup) {
+    await hook();
+  }
+}
+
+async function cleanup(fixture: typeof hooks) {
+  for (const hook of fixture.cleanup.toReversed()) {
+    await hook();
+  }
+}
+
+// Red runs still release resources if the broken consumer aborts teardown.
+async function emergencyCleanup(fixture: typeof hooks) {
+  for (const hook of fixture.cleanup.toReversed()) {
+    await Promise.resolve()
+      .then(hook)
+      .catch(() => {});
+  }
+}
+
+test("shared setup failure skips consumer acquisition without adding an invalid-path error", async () => {
+  const failure = new Error("injected shared setup failure");
+  const start = vi.spyOn(serverHarness, "startGatewayServerHarness").mockRejectedValue(failure);
+  try {
+    await expect(setup(consumerHooks)).rejects.toBe(failure);
+    await expect(cleanup(consumerHooks)).resolves.toBeUndefined();
+  } finally {
+    await emergencyCleanup(consumerHooks);
+    start.mockRestore();
+  }
+});
+
+test("partial session setup closes its acquired server before removing its environment", async () => {
+  sessions.setupGatewaySessionsTestHarness();
+  const fixture = { setup: hooks.setup.splice(0), cleanup: hooks.cleanup.splice(0) };
+  const failure = new Error("injected session directory acquisition failure");
+  const mkdtemp = fs.mkdtemp.bind(fs);
+  const mkdtempSync = fsSync.mkdtempSync.bind(fsSync);
+  const asyncTemp = vi.spyOn(fs, "mkdtemp").mockImplementation(async (prefix, options) => {
+    if (prefix.includes("openclaw-sessions-")) {
+      throw failure;
+    }
+    return await mkdtemp(prefix, options);
+  });
+  const syncTemp = vi.spyOn(fsSync, "mkdtempSync").mockImplementation((prefix, options) => {
+    if (prefix.includes("openclaw-sessions-")) {
+      throw failure;
+    }
+    return mkdtempSync(prefix, options);
+  });
+  let acquired: Awaited<ReturnType<typeof startHarness>> | undefined;
+  let closeCalls = 0;
+  const start = vi
+    .spyOn(serverHarness, "startGatewayServerHarness")
+    .mockImplementation(async () => {
+      acquired = await startHarness();
+      const home = process.env.HOME!;
+      const closeHarness = acquired.close;
+      acquired.close = async () => {
+        closeCalls++;
+        expect(process.env.HOME).toBe(home);
+        expect(fsSync.existsSync(home)).toBe(true);
+        await closeHarness();
+      };
+      return acquired;
+    });
+  try {
+    await expect(setup(fixture)).rejects.toBe(failure);
+    await cleanup(fixture);
+    expect(closeCalls).toBe(1);
+  } finally {
+    if (acquired) {
+      await acquired.server.close();
+    }
+    await emergencyCleanup(fixture);
+    start.mockRestore();
+    asyncTemp.mockRestore();
+    syncTemp.mockRestore();
+  }
+});
+
+test("teardown joins delayed server acquisition before cleaning session directories and environment", async () => {
+  sessions.setupGatewaySessionsTestHarness();
+  const fixture = { setup: hooks.setup.splice(0), cleanup: hooks.cleanup.splice(0) };
+  const acquired = createDeferredCore();
+  const release = createDeferredCore();
+  let server: Awaited<ReturnType<typeof startHarness>> | undefined;
+  let closeCalls = 0;
+  const roots = new Set<string>();
+  const mkdtemp = fs.mkdtemp.bind(fs);
+  const mkdtempSync = fsSync.mkdtempSync.bind(fsSync);
+  const asyncTemp = vi.spyOn(fs, "mkdtemp").mockImplementation(async (prefix, options) => {
+    const dir = await mkdtemp(prefix, options);
+    if (typeof dir === "string" && path.basename(dir).startsWith("openclaw-sessions-")) {
+      roots.add(dir);
+    }
+    return dir;
+  });
+  const syncTemp = vi.spyOn(fsSync, "mkdtempSync").mockImplementation((prefix, options) => {
+    const dir = mkdtempSync(prefix, options);
+    if (typeof dir === "string" && path.basename(dir).startsWith("openclaw-sessions-")) {
+      roots.add(dir);
+    }
+    return dir;
+  });
+  const start = vi
+    .spyOn(serverHarness, "startGatewayServerHarness")
+    .mockImplementation(async () => {
+      server = await startHarness();
+      const closeServer = server.close;
+      server.close = async () => {
+        closeCalls++;
+        await closeServer();
+      };
+      acquired.resolve();
+      await release.promise;
+      return server;
+    });
+  const pendingSetup = setup(fixture);
+  let pendingCleanup: Promise<void> | undefined;
+  try {
+    await Promise.race([acquired.promise, pendingSetup]);
+    pendingCleanup = cleanup(fixture);
+    release.resolve();
+    await Promise.all([pendingSetup, pendingCleanup]);
+    expect(closeCalls).toBe(1);
+    expect([...listeners].every((listener) => !listener.listening)).toBe(true);
+    expect(roots.size).toBe(1);
+    expect([...roots].every((root) => !fsSync.existsSync(root))).toBe(true);
+  } finally {
+    release.resolve();
+    await Promise.allSettled([pendingSetup, pendingCleanup]);
+    await server?.close();
+    await emergencyCleanup(fixture);
+    for (const root of roots) {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+    start.mockRestore();
+    asyncTemp.mockRestore();
+    syncTemp.mockRestore();
+  }
+});
+
+test("teardown leaves delayed template initialization alive until its writes settle", async () => {
+  const entered = createDeferredCore();
+  const release = createDeferredCore();
+  const mkdir = fs.mkdir.bind(fs);
+  const rm = fs.rm.bind(fs);
+  const rmSync = fsSync.rmSync.bind(fsSync);
+  let templateRoot: string | undefined;
+  let initializing = true;
+  let removedDuringInitialization = false;
+  const mkdirSpy = vi.spyOn(fs, "mkdir").mockImplementation(async (dir, options) => {
+    if (
+      String(dir).includes("openclaw-session-git-template-") &&
+      path.basename(String(dir)) === "workspace"
+    ) {
+      templateRoot = path.dirname(String(dir));
+      entered.resolve();
+      await release.promise;
+    }
+    return await mkdir(dir, options);
+  });
+  const rmSpy = vi.spyOn(fs, "rm").mockImplementation(async (dir, options) => {
+    if (String(dir) === templateRoot && initializing) {
+      removedDuringInitialization = true;
+    }
+    return await rm(dir, options);
+  });
+  const rmSyncSpy = vi.spyOn(fsSync, "rmSync").mockImplementation((dir, options) => {
+    if (String(dir) === templateRoot && initializing) {
+      removedDuringInitialization = true;
+    }
+    rmSync(dir, options);
+  });
+  const pendingSetup = setup(consumerHooks).finally(() => {
+    initializing = false;
+  });
+  let pendingCleanup: Promise<void> | undefined;
+  try {
+    await Promise.race([entered.promise, pendingSetup]);
+    pendingCleanup = cleanup(consumerHooks);
+    release.resolve();
+    await Promise.allSettled([pendingSetup, pendingCleanup]);
+    expect(removedDuringInitialization).toBe(false);
+    await expect(pendingSetup).resolves.toBeUndefined();
+    await expect(pendingCleanup).resolves.toBeUndefined();
+    expect(templateRoot).toBeDefined();
+    expect(fsSync.existsSync(templateRoot!)).toBe(false);
+  } finally {
+    release.resolve();
+    await Promise.allSettled([pendingSetup, pendingCleanup]);
+    mkdirSpy.mockRestore();
+    rmSpy.mockRestore();
+    rmSyncSpy.mockRestore();
+    await emergencyCleanup(consumerHooks);
+    if (templateRoot) {
+      await fs.rm(templateRoot, { recursive: true, force: true });
+    }
+  }
+});
+
+test("teardown joins pending home acquisition before restoring the environment", async () => {
+  gatewayHelpers.installGatewayTestHooks({ scope: "suite" });
+  const fixture = { setup: hooks.setup.splice(0), cleanup: hooks.cleanup.splice(0) };
+  const homeBefore = process.env.HOME;
+  const acquired = createDeferredCore();
+  const release = createDeferredCore();
+  const mkdtemp = fs.mkdtemp.bind(fs);
+  let home: string | undefined;
+  const temp = vi.spyOn(fs, "mkdtemp").mockImplementation(async (prefix, options) => {
+    const dir = await mkdtemp(prefix, options);
+    if (prefix.includes("openclaw-gateway-home-")) {
+      home = dir;
+      acquired.resolve();
+      await release.promise;
+    }
+    return dir;
+  });
+  const pendingSetup = setup(fixture);
+  let pendingCleanup: Promise<void> | undefined;
+  try {
+    await Promise.race([acquired.promise, pendingSetup]);
+    pendingCleanup = cleanup(fixture);
+    release.resolve();
+    await Promise.all([pendingSetup, pendingCleanup]);
+    expect(process.env.HOME).toBe(homeBefore);
+    expect(fsSync.existsSync(home!)).toBe(false);
+  } finally {
+    release.resolve();
+    await Promise.allSettled([pendingSetup, pendingCleanup]);
+    temp.mockRestore();
+    await emergencyCleanup(fixture);
+    if (home) {
+      await fs.rm(home, { recursive: true, force: true });
+    }
+  }
+});
+
+test("a server cleanup error does not skip session directory or environment cleanup", async () => {
+  const fixtureApi = sessions.setupGatewaySessionsTestHarness();
+  const fixture = { setup: hooks.setup.splice(0), cleanup: hooks.cleanup.splice(0) };
+  const homeBefore = process.env.HOME;
+  const failure = new Error("injected server cleanup failure");
+  let restoreClose: (() => void) | undefined;
+  try {
+    await setup(fixture);
+    const home = process.env.HOME!;
+    const { dir } = await fixtureApi.createSessionStoreDir();
+    const server = fixtureApi.getHarness();
+    const closeServer = server.close;
+    const close = vi.spyOn(server, "close").mockImplementation(async () => {
+      await closeServer();
+      throw failure;
+    });
+    restoreClose = () => close.mockRestore();
+    await expect(cleanup(fixture)).rejects.toBe(failure);
+    expect(fsSync.existsSync(dir)).toBe(false);
+    expect(fsSync.existsSync(home)).toBe(false);
+    expect(process.env.HOME).toBe(homeBefore);
+  } finally {
+    restoreClose?.();
+    await emergencyCleanup(fixture);
+  }
+});
+
+test("skipped environment setup does not release an enclosing suite's home", async () => {
+  gatewayHelpers.installGatewayTestHooks({ scope: "suite" });
+  const parent = { setup: hooks.setup.splice(0), cleanup: hooks.cleanup.splice(0) };
+  gatewayHelpers.installGatewayTestHooks({ scope: "suite" });
+  const skipped = { setup: hooks.setup.splice(0), cleanup: hooks.cleanup.splice(0) };
+  try {
+    await setup(parent);
+    const home = process.env.HOME!;
+    await cleanup(skipped);
+    expect(process.env.HOME).toBe(home);
+    expect(fsSync.existsSync(home)).toBe(true);
+  } finally {
+    await emergencyCleanup(parent);
+  }
+});

--- a/src/gateway/test-helpers.server.ts
+++ b/src/gateway/test-helpers.server.ts
@@ -12,6 +12,7 @@ import "./test-helpers.mocks.js";
 import { afterAll, afterEach, beforeAll, beforeEach, expect, vi } from "vitest";
 import { WebSocket } from "ws";
 import { PROTOCOL_VERSION } from "../../packages/gateway-protocol/src/index.js";
+import { runQaGatewayFixture } from "../../test/helpers/qa-gateway-cleanup.js";
 import { getRuntimeConfig, parseConfigJson5, resetConfigRuntimeState } from "../config/config.js";
 import { resolveSystemMainSessionKey, type SessionEntry } from "../config/sessions.js";
 import {
@@ -553,17 +554,32 @@ export async function prepareGatewayReplyRuntimeForTest(options?: {
   gatewayReplyRuntimePrepared = true;
 }
 
-export function installGatewayTestHooks(options?: { scope?: "test" | "suite" }) {
-  const scope = options?.scope ?? "test";
-  if (scope === "suite") {
-    beforeAll(async () => {
-      vi.useRealTimers();
-      if (activeSuiteHookScopeCount === 0) {
-        await setupGatewayTestHome();
-        await resetGatewayTestState({ uniqueConfigRoot: false });
-      }
-      activeSuiteHookScopeCount += 1;
+export function installGatewayTestHooks(
+  options?:
+    | { scope?: "test" }
+    | { scope: "suite"; setup?: () => Promise<void>; cleanup?: () => Promise<void> },
+) {
+  if (options?.scope === "suite") {
+    let homeSetup: Promise<void> | undefined;
+    let fixtureSetup: Promise<void> | undefined;
+    let suiteCleanup: Promise<void> | undefined;
+    beforeAll(() => {
+      fixtureSetup = undefined;
+      suiteCleanup = undefined;
+      homeSetup = (async () => {
+        vi.useRealTimers();
+        const createHome = activeSuiteHookScopeCount === 0;
+        activeSuiteHookScopeCount += 1;
+        if (createHome) {
+          await setupGatewayTestHome();
+          await resetGatewayTestState({ uniqueConfigRoot: false });
+        }
+      })();
+      return homeSetup;
     });
+    if (options.setup) {
+      beforeAll(() => (fixtureSetup = Promise.resolve().then(options.setup)));
+    }
     beforeEach(async () => {
       vi.useRealTimers();
       if (activeSuiteGatewayServerCount > 0) {
@@ -580,10 +596,25 @@ export function installGatewayTestHooks(options?: { scope?: "test" | "suite" }) 
       await cleanupGatewayTestHome({ restoreEnv: false });
     });
     afterAll(async () => {
-      activeSuiteHookScopeCount = Math.max(0, activeSuiteHookScopeCount - 1);
-      if (activeSuiteHookScopeCount === 0) {
-        await cleanupGatewayTestHome({ restoreEnv: true });
+      if (!homeSetup) {
+        return;
       }
+      await (suiteCleanup ??= runQaGatewayFixture(
+        async () => {
+          // Vitest times out hooks without cancelling them. Keep late acquisition
+          // and fixture cleanup inside the environment's lifetime; setup errors
+          // are already reported by beforeAll, not duplicated by this join.
+          await homeSetup?.catch(() => {});
+          await fixtureSetup?.catch(() => {});
+          await options.cleanup?.();
+        },
+        async () => {
+          activeSuiteHookScopeCount -= 1;
+          if (activeSuiteHookScopeCount === 0) {
+            await cleanupGatewayTestHome({ restoreEnv: true });
+          }
+        },
+      ));
     }, 300_000);
     return;
   }

--- a/src/gateway/test/server-sessions-resources.test-helpers.ts
+++ b/src/gateway/test/server-sessions-resources.test-helpers.ts
@@ -1,0 +1,63 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { runQaGatewayFixture } from "../../../test/helpers/qa-gateway-cleanup.js";
+import { createTempDirTracker } from "../../../test/helpers/temp-dir.js";
+import { createLazyRuntimeModule } from "../../shared/lazy-runtime.js";
+import type { GatewayServerHarness } from "../server.e2e-ws-harness.js";
+import { installGatewayTestHooks } from "../test-helpers.server.js";
+
+const getGatewayServerHarnessModule = createLazyRuntimeModule(
+  () => import("../server.e2e-ws-harness.js"),
+);
+
+export type GatewaySessionsSuiteSetup = (makeTempDir: (prefix: string) => string) => Promise<void>;
+
+export function installGatewaySessionsTestResources(
+  startServer: boolean,
+  setup?: GatewaySessionsSuiteSetup,
+) {
+  const tempDirs = createTempDirTracker();
+  const defaultAgentWorkspace = path.join(os.tmpdir(), "openclaw-gateway-test");
+  let harness: GatewayServerHarness | undefined;
+  let sharedSessionStoreDir: string | undefined;
+
+  installGatewayTestHooks({
+    scope: "suite",
+    setup: async () => {
+      await fs.mkdir(defaultAgentWorkspace, { recursive: true });
+      if (startServer) {
+        const { startGatewayServerHarness } = await getGatewayServerHarnessModule();
+        harness = await startGatewayServerHarness();
+      }
+      sharedSessionStoreDir = tempDirs.make("openclaw-sessions-");
+      await setup?.((prefix) => tempDirs.make(prefix));
+    },
+    cleanup: () =>
+      runQaGatewayFixture(
+        async () => {
+          const acquiredHarness = harness;
+          harness = undefined;
+          await acquiredHarness?.close();
+        },
+        () => {
+          sharedSessionStoreDir = undefined;
+          tempDirs.cleanup();
+        },
+      ),
+  });
+
+  const requireHarness = () => {
+    if (!harness) {
+      throw new Error("Gateway sessions test harness was not started");
+    }
+    return harness;
+  };
+  const requireSharedSessionStoreDir = () => {
+    if (!sharedSessionStoreDir) {
+      throw new Error("Gateway sessions shared session store dir was not created");
+    }
+    return sharedSessionStoreDir;
+  };
+  return { defaultAgentWorkspace, requireHarness, requireSharedSessionStoreDir };
+}

--- a/src/gateway/test/server-sessions.test-helpers.ts
+++ b/src/gateway/test/server-sessions.test-helpers.ts
@@ -3,19 +3,21 @@
  */
 import fsSync from "node:fs";
 import fs from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
 import type { AssistantMessage, UserMessage } from "openclaw/plugin-sdk/llm";
-import { afterAll, beforeAll, beforeEach, expect, vi } from "vitest";
+import { beforeEach, expect, vi } from "vitest";
 import type { InternalSessionEntry as SessionEntry } from "../../config/sessions.js";
 import type { InternalHookEvent } from "../../hooks/internal-hooks.js";
 import { resetSystemEventsForTest } from "../../infra/system-events.js";
 import { createLazyRuntimeModule } from "../../shared/lazy-runtime.js";
 import { createDirectChatContext } from "../server-chat.agent-events.test-helpers.js";
 import type { GatewayRequestContext } from "../server-methods/types.js";
-import type { GatewayServerHarness } from "../server.e2e-ws-harness.js";
 import { embeddedRunMock, agentDiscoveryMock, testState } from "../test-helpers.runtime-state.js";
 import * as gatewayTestHelpers from "../test-helpers.server.js";
+import {
+  installGatewaySessionsTestResources,
+  type GatewaySessionsSuiteSetup,
+} from "./server-sessions-resources.test-helpers.js";
 
 export const getSessionManagerModule = createLazyRuntimeModule(
   () => import("../../agents/sessions/index.js"),
@@ -27,10 +29,6 @@ export const getGatewayConfigModule = createLazyRuntimeModule(
 
 const getSessionAccessorModule = createLazyRuntimeModule(
   () => import("../../config/sessions/session-accessor.js"),
-);
-
-const getGatewayServerHarnessModule = createLazyRuntimeModule(
-  () => import("../server.e2e-ws-harness.js"),
 );
 
 const getGatewayServerMethodsModule = createLazyRuntimeModule(() => import("../server-methods.js"));
@@ -308,33 +306,14 @@ export function setupGatewaySessionsHandlerTestHarness() {
   return handlerFixture;
 }
 
-export function setupGatewaySessionsTestHarness() {
-  return createGatewaySessionsTestHarness(true);
+export function setupGatewaySessionsTestHarness(setup?: GatewaySessionsSuiteSetup) {
+  return createGatewaySessionsTestHarness(true, setup);
 }
 
-function createGatewaySessionsTestHarness(startServer: boolean) {
-  gatewayTestHelpers.installGatewayTestHooks({ scope: "suite" });
-
-  const defaultAgentWorkspace = path.join(os.tmpdir(), "openclaw-gateway-test");
-  let harness: GatewayServerHarness | undefined;
-  let sharedSessionStoreDir: string | undefined;
+function createGatewaySessionsTestHarness(startServer: boolean, setup?: GatewaySessionsSuiteSetup) {
+  const { defaultAgentWorkspace, requireHarness, requireSharedSessionStoreDir } =
+    installGatewaySessionsTestResources(startServer, setup);
   let sessionStoreCaseSeq = 0;
-
-  beforeAll(async () => {
-    await fs.mkdir(defaultAgentWorkspace, { recursive: true });
-    if (startServer) {
-      const { startGatewayServerHarness } = await getGatewayServerHarnessModule();
-      harness = await startGatewayServerHarness();
-    }
-    sharedSessionStoreDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-sessions-"));
-  });
-
-  afterAll(async () => {
-    await harness?.close();
-    if (sharedSessionStoreDir) {
-      await fs.rm(sharedSessionStoreDir, { recursive: true, force: true });
-    }
-  });
 
   beforeEach(async () => {
     const { clearConfigCache, clearRuntimeConfigSnapshot } = await getGatewayConfigModule();
@@ -379,20 +358,6 @@ function createGatewaySessionsTestHarness(startServer: boolean) {
       return true;
     });
   });
-
-  const requireHarness = () => {
-    if (!harness) {
-      throw new Error("Gateway sessions test harness was not started");
-    }
-    return harness;
-  };
-
-  const requireSharedSessionStoreDir = () => {
-    if (!sharedSessionStoreDir) {
-      throw new Error("Gateway sessions shared session store dir was not created");
-    }
-    return sharedSessionStoreDir;
-  };
 
   const openClient = async (opts?: Parameters<typeof gatewayTestHelpers.connectOk>[1]) =>
     await gatewayTestHelpers

--- a/test/helpers/temp-dir.test.ts
+++ b/test/helpers/temp-dir.test.ts
@@ -16,6 +16,70 @@ afterEach(() => {
 });
 
 describe("temp-dir test helpers", () => {
+  it.each(["array", "set"] as const)(
+    "continues after a failed removal and retains the failed directory in its %s",
+    (collection) => {
+      const dirs = collection === "array" ? [] : new Set<string>();
+      const failed = makeTempDir(dirs, "openclaw-temp-dir-failed-");
+      const other = makeTempDir(dirs, "openclaw-temp-dir-other-");
+      tempDirs.add(failed);
+      tempDirs.add(other);
+      const failure = new Error("injected directory removal failure");
+      const rmSync = fs.rmSync.bind(fs);
+      const remove = vi.spyOn(fs, "rmSync").mockImplementation((dir, options) => {
+        if (dir === failed) {
+          throw failure;
+        }
+        rmSync(dir, options);
+      });
+      try {
+        expect(() => cleanupTempDirs(dirs)).toThrow(failure);
+        expect(fs.existsSync(other)).toBe(false);
+        expect([...dirs]).toEqual([failed]);
+      } finally {
+        remove.mockRestore();
+        cleanupTempDirs(dirs);
+      }
+    },
+  );
+
+  it("reports every failed removal while still releasing the remaining directories", () => {
+    const dirs = new Set<string>();
+    const first = makeTempDir(dirs, "openclaw-temp-dir-first-failed-");
+    const second = makeTempDir(dirs, "openclaw-temp-dir-second-failed-");
+    const other = makeTempDir(dirs, "openclaw-temp-dir-success-");
+    for (const dir of dirs) {
+      tempDirs.add(dir);
+    }
+    const failures = new Map([
+      [first, new Error("first removal failed")],
+      [second, new Error("second removal failed")],
+    ]);
+    const rmSync = fs.rmSync.bind(fs);
+    const remove = vi.spyOn(fs, "rmSync").mockImplementation((dir, options) => {
+      const failure = failures.get(String(dir));
+      if (failure) {
+        throw failure;
+      }
+      rmSync(dir, options);
+    });
+    try {
+      let failure: unknown;
+      try {
+        cleanupTempDirs(dirs);
+      } catch (error) {
+        failure = error;
+      }
+      expect(failure).toBeInstanceOf(AggregateError);
+      expect((failure as AggregateError).errors).toEqual([...failures.values()]);
+      expect(fs.existsSync(other)).toBe(false);
+      expect([...dirs]).toEqual([first, second]);
+    } finally {
+      remove.mockRestore();
+      cleanupTempDirs(dirs);
+    }
+  });
+
   it("tracks created temp dirs and removes populated dirs", () => {
     const tracker = createTempDirTracker();
     const dir = tracker.make("openclaw-temp-dir-helper-");

--- a/test/helpers/temp-dir.ts
+++ b/test/helpers/temp-dir.ts
@@ -24,7 +24,7 @@ function resolveCanonicalSystemTempRoot(): string {
 interface TestTempDirTracker {
   readonly dirs: ReadonlySet<string>;
   make(prefix: string, root?: string): string;
-  cleanup(): void;
+  cleanup(this: void): void;
 }
 
 interface AutoCleanupTempDirTracker {
@@ -44,14 +44,28 @@ export function makeTempDir(tempDirs: TempDirCollection, prefix: string, root?: 
   return dir;
 }
 
-/** Remove all tracked temporary directories and clear the tracker. */
+/** Remove tracked directories, retaining failed removals for cleanup retry. */
 export function cleanupTempDirs(tempDirs: TempDirCollection): void {
-  const dirs = Array.isArray(tempDirs) ? tempDirs.splice(0) : [...tempDirs];
+  // Successful releases mutate the tracker; walk the original ownership snapshot.
+  const dirs = [...tempDirs];
+  const errors: unknown[] = [];
   for (const dir of dirs) {
-    fs.rmSync(dir, { recursive: true, force: true, maxRetries: 5, retryDelay: 20 });
+    try {
+      fs.rmSync(dir, { recursive: true, force: true, maxRetries: 5, retryDelay: 20 });
+      if (Array.isArray(tempDirs)) {
+        tempDirs.splice(tempDirs.indexOf(dir), 1);
+      } else {
+        tempDirs.delete(dir);
+      }
+    } catch (error) {
+      errors.push(error);
+    }
   }
-  if (!Array.isArray(tempDirs)) {
-    tempDirs.clear();
+  if (errors.length === 1) {
+    throw errors[0];
+  }
+  if (errors.length > 1) {
+    throw new AggregateError(errors, "Test temporary directory cleanup failed");
   }
 }
 
@@ -62,7 +76,7 @@ export function createTempDirTracker(): TestTempDirTracker {
     make(prefix: string, root?: string): string {
       return makeTempDir(dirs, prefix, root);
     },
-    cleanup(): void {
+    cleanup(this: void): void {
       cleanupTempDirs(dirs);
     },
   };


### PR DESCRIPTION
Related: https://github.com/openclaw/openclaw/pull/132227 (chat-fork context/lifecycle verification exposed this separate test-fixture failure).

<details>
<summary>Additional instructions</summary>

This is a maintainer-requested, AI-assisted test-lifecycle repair on a same-repository branch that maintainers can update.

</details>

## What Problem This Solves

Resolves a problem where Gateway session-creation verification obscured a failed shared setup with a secondary teardown exception. During verification of #132227, the shared setup reached its existing 180000 ms timeout and the skipped consumer setup never initialized its Git-template directory; teardown nevertheless called `fs.rm(undefined)`. The unchanged retry passed the selected fork cases. This is test-resource ownership work, not evidence of a production fork regression.

## Why This Change Was Made

The shared fixture now owns its server, session-directory, and Git-template lifetime together, reusing the canonical synchronous tracked-temp helper. Gateway suite teardown joins pending home/fixture setup before closing the acquired server, removing tracked directories, and restoring the environment; one cleanup failure does not skip remaining releases. Failed server acquisition also restores its token snapshot. The consumer-only unconditional cleanup path is removed.

An optional path guard alone would hide the secondary exception but leave late-acquisition leaks. The repair instead joins acquisition at the environment/resource owner. Production code, timeout values, consumer environment settings, and fork behavior are unchanged.

## User Impact

No production or user-facing behavior change. Developers retain the original setup failure without an invalid-path teardown error, and delayed setup cannot race the fixture's resource cleanup and environment restoration.

Production LOC: +0/-0. Test support: +142/-66 (net +76); tests: +481/-15 (net +466). The new resource module separates lifecycle ownership from the existing large session-mock module without introducing a production seam.

## Evidence

Before the repair, deterministic fault injection produced 11 intended regression failures: 8 Gateway lifecycle/harness failures (including the exact `ERR_INVALID_ARG_TYPE` from `fs.rm(undefined)`) and 3 tracked-temp cleanup failures. The partial-acquisition control already passed. The same regression selection passed 18 tests after the repair.

Pre-rebase validation of the reviewed patch passed (the final head has the identical stable patch ID):

```bash
node scripts/run-vitest.mjs src/gateway/server.sessions.fixture-lifecycle.test.ts src/gateway/server.e2e-ws-harness.test.ts src/gateway/test-helpers.server-env.test.ts src/gateway/test-helpers.server-rpc.test.ts src/gateway/server.sessions.archive-owner.test.ts test/helpers/temp-dir.test.ts test/helpers/qa-gateway-cleanup.test.ts
```

35 passed. This covers skipped/partial setup, delayed server handoff, delayed template writes, pending home acquisition, cleanup-error continuation, enclosing-suite ownership, and neighboring environment/RPC/session fixtures. Controlled promises drive the overlap rather than sleeps or larger timeouts. The failure-injection harness runs the actual fixture hooks and resource support against a disposable TCP listener; the next command covers real Gateway startup.

```bash
node scripts/run-vitest.mjs src/gateway/server.sessions.create.test.ts -t 'fork|100K fallback|clamps configured capacity'
```

13 passed; 117 intentionally excluded by the test-name filter. These tests use the real Gateway fixture.

```bash
node scripts/check-changed.mjs -- src/gateway/server.sessions.create.test.ts src/gateway/test/server-sessions.test-helpers.ts src/gateway/test/server-sessions-resources.test-helpers.ts src/gateway/test-helpers.server.ts src/gateway/server.e2e-ws-harness.ts src/gateway/server.e2e-ws-harness.test.ts src/gateway/server.sessions.fixture-lifecycle.test.ts test/helpers/temp-dir.ts test/helpers/temp-dir.test.ts
```

Passed the complete changed-check plan, including formatting, core/test typechecks, lint, and boundary guards. `git diff --check` passed. Fresh independent Codex autoreview found no actionable findings at its configured P0-only threshold. The complete source/lifecycle review and ClawSweeper review found no accepted patch defect.

Dependency contract was checked directly in installed Vitest 4.1.11: `withTimeout` leaves the underlying callback running, sequential `beforeAll` stops after rejection, `runSuite` still invokes `afterAll`, and stack teardown reverses registration order.

Validation notes: the first attempt was blocked by an incomplete local dependency install, repaired with `pnpm install`. Preliminary import-timeout attempts were not counted as regression proof. Initial lint findings in the new test/support code were fixed, and the entire changed gate was rerun successfully. The original startup slowdown remains undiagnosed; no timeout was increased. Full-suite and live-provider/UI proof are not needed for this test-only lifecycle boundary. A separate follow-up tracks the independently registered health/presence fixture's similar partial-setup assumption.

### Final-head landing validation

Head: `b6f9c854b961aa78fdf643dbac36fb3c8e4f8e51`. [CI run 33254883322, attempt 1](https://github.com/openclaw/openclaw/actions/runs/33254883322) completed successfully on this exact head, including the required `openclaw/ci-gate`. The rebase has an equal range-diff and the same stable patch ID as the original nine-file repair; no new production or fixture changes were added.

The initial [CI run 33251625064](https://github.com/openclaw/openclaw/actions/runs/33251625064) failed four unrelated database-fixture assertions expecting schema 18 instead of 19. The branch incorporates Vincent Koc's existing main fix [16367468](https://github.com/openclaw/openclaw/commit/16367468a7edce977360becc72443943d805593d), rather than duplicating it. Both state test files passed afterward: 145 passed, 4 skipped. The complete nine-path changed-check plan also passed again after the rebase.

The rebased combined local selection passed 33 cases, including all nine Gateway failure-injection/harness cases, but hit a 60-second setup-hook timeout and a 120-second direct-server timeout in the unchanged default-scope environment test. Those failures are retained as evidence, not counted as a pass. An initial native-worktree comparison used an older shared install and is not used as pinned-runner proof.

A final controlled comparison used the original checkout's matching declared dependencies—Node 24.20.0, Vitest 4.1.11, Vite 8.2.2, and tsx 4.23.12—with no environment overrides, dependency changes, timeout changes, or source edits. The following identical command ran once at baseline `f6f1d9155b235c9dd5c5b14716290abbc5f3395d` and once at the final PR head, preserving the file's original case order:

```bash
node scripts/run-vitest.mjs src/gateway/test-helpers.server-env.test.ts
```

Both runs passed all 7 cases. The fork/context command above also passed 13 cases at the final PR head, with 117 filter exclusions. Neither earlier timeout recurred; this comparison does not establish their cause or a performance improvement.

The latest [ClawSweeper review and rank-up move](https://github.com/openclaw/openclaw/pull/132574#issuecomment-5462351905) are addressed by the successful exact-head CI and direct pinned Vitest lifecycle inspection: `@vitest/runner/dist/chunk-artifact.js` at `withTimeout` (2261–2320), hook ordering (2567, 2608–2640), and `runSuite` teardown (3134–3175). The maintainer review accepts the single-owner repair. The original startup slowdown remains outside this cleanup-only fix.

