### PR TITLE
test(xai): avoid repeated SDK reloads and deep audio comparisons

### DIFF
--- a/extensions/xai/lazy-capability-providers.test.ts
+++ b/extensions/xai/lazy-capability-providers.test.ts
@@ -92,8 +92,11 @@ vi.mock("./realtime-voice-provider.js", () => ({
   buildXaiRealtimeVoiceProvider: runtimeMocks.buildVoiceProvider,
 }));
 
-async function loadLazyProviders() {
-  return await import("./lazy-capability-providers.js");
+const lazyProvidersUrl = new URL("./lazy-capability-providers.ts", import.meta.url).href;
+let lazyProviderCase = 0;
+
+async function loadLazyProviders(): Promise<typeof import("./lazy-capability-providers.js")> {
+  return await import(`${lazyProvidersUrl}?testCase=${lazyProviderCase}`);
 }
 
 function createVoiceRequest(
@@ -109,7 +112,8 @@ function createVoiceRequest(
 }
 
 beforeEach(() => {
-  vi.resetModules();
+  // Refresh provider caches without reloading unchanged SDK dependencies.
+  lazyProviderCase += 1;
   for (const value of Object.values(runtimeMocks)) {
     value.mockReset();
   }
@@ -181,6 +185,7 @@ describe("xAI lazy capability providers", () => {
     const speech = lazy.createLazyXaiSpeechProvider();
     const transcription = lazy.createLazyXaiRealtimeTranscriptionProvider();
     const voice = lazy.createLazyXaiRealtimeVoiceProvider();
+    await vi.dynamicImportSettled();
 
     expect(
       [
@@ -227,10 +232,12 @@ describe("xAI lazy capability providers", () => {
     await session.connect();
 
     expect(runtimeMocks.buildTranscriptionProvider).toHaveBeenCalledOnce();
-    expect(runtimeMocks.transcriptionSendAudio.mock.calls.map(([audio]) => audio)).toEqual([
-      second,
-      third,
-    ]);
+    const forwardedAudio = runtimeMocks.transcriptionSendAudio.mock.calls.map(([audio]) => audio);
+    expect(forwardedAudio).toHaveLength(2);
+    for (const [index, expected] of [second, third].entries()) {
+      const audio = forwardedAudio[index];
+      expect(Buffer.isBuffer(audio) && audio.equals(expected)).toBe(true);
+    }
     expect(runtimeMocks.transcriptionConnect).toHaveBeenCalledOnce();
     expect(runtimeMocks.transcriptionConnect.mock.invocationCallOrder[0]).toBeLessThan(
       runtimeMocks.transcriptionSendAudio.mock.invocationCallOrder[0]!,


### PR DESCRIPTION
## Summary

The xAI lazy-provider tests were reloading unchanged SDK dependencies before every case and deeply walking two megabytes of copied audio buffers in JavaScript. Refresh only the provider module identity per case, retaining fresh loader closures and all mock resets, and compare the full buffers through native byte equality.

The existing lazy-construction assertion now waits for dynamic imports to settle so it also detects an asynchronous eager load. No production code, fixtures, sharding, concurrency, test selection or coverage is removed.

## Validation

- Same Node 26.5.0 runtime and normal test wrapper: 30 passing cases, warm execution 4.209s before and 1.850s after (56% less). Cold collection and whole-suite time are not included in this claim.
- Final focused run and xAI index/shared lazy-runtime/lazy-promise sibling run pass. The combined provider run passed 77 tests; shared helpers passed separately through their owning config.
- Temporary last-byte corruption, reversed queued audio and asynchronous eager-builder mutations all fail the intended assertions; production files restored before final validation.
- Independent Codex autoreview: no actionable findings. Changed-file gate and exact-head hosted CI must pass before landing.

Owner evidence: provider caches belong to each imported lazy-capability module; shared lazy-runtime closures and realtime lifecycle state are instance-owned. Installed Vite retains distinct query-bearing module IDs while reusing unchanged dependencies. Node Buffer.equals checks lengths and every byte. Production LOC delta: 0. Test delta: +14/-7. No changelog needed for test-only work.
