### PR TITLE
fix(channels): accept env SecretRefs with shared default aliases

### DIFF
--- a/docs/gateway/secrets.md
+++ b/docs/gateway/secrets.md
@@ -215,8 +215,8 @@ Define providers under `secrets.providers`:
 Provider aliases are source-specific. A matching explicit provider entry wins; if an `env` or `store` default alias is also used by an entry for another source, that source's built-in provider wins. Non-default aliases and `file` or `exec` providers must resolve to an explicit entry with the matching source.
 
 <Accordion title="Env provider">
-- Optional exact-name allowlist via `allowlist`.
-- Missing or empty env values fail resolution.
+- Optional exact-name allowlist via `allowlist`. A matching explicit env provider enforces this list even when it is the selected default. Omit the list to allow any name; use `[]` to deny every name.
+- Missing or empty env values fail resolution. An explicit env SecretRef remains authoritative and does not fall through to another credential or auth profile.
 
 </Accordion>
 

--- a/docs/plugins/sdk-subpaths.md
+++ b/docs/plugins/sdk-subpaths.md
@@ -231,6 +231,8 @@ usage endpoint failed or returned no usable usage data.
     | `plugin-sdk/webhook-request-guards` | Request body size/timeout helpers, canonical Gateway browser-origin acceptance via `resolveAcceptedBrowserOrigin`, and `runDetachedWebhookWork` for tracked post-ack processing |
   </Accordion>
 
+For structured SecretRefs, `resolveReadOnlyEnvSecretRef` returns `blocked` when the ref cannot be used, including an allowed env ref whose value is missing or empty. Callers may apply their existing fallback only for `missing`; a blocked ref must not borrow ambient or auth-profile credentials. Its provider check follows source-specific default aliases and explicit env allowlists.
+
 Use `isLoopbackHost(host)` when a plugin must accept only the local machine. It accepts `localhost`, IPv4 loopback literals across `127.0.0.0/8`, `::1`, bracketed IPv6, and IPv4-mapped IPv6 loopback literals. It parses IP literals rather than matching text prefixes, so a DNS name such as `127.0.0.1.evil.com` is not loopback. Use `isPrivateOrLoopbackHost(host)` only when private-network hosts such as RFC 1918 addresses are also valid.
 
   <Accordion title="Runtime and storage subpaths">

--- a/extensions/clickclack/src/accounts.secret-ref.test.ts
+++ b/extensions/clickclack/src/accounts.secret-ref.test.ts
@@ -1,0 +1,232 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { listEnabledClickClackAccounts, resolveClickClackAccount } from "./accounts.js";
+import type { ClickClackAccountConfig, CoreConfig } from "./types.js";
+
+const selectedEnvId = "CLICKCLACK_SELECTED_TEST_TOKEN";
+const collisionProviders = [
+  { source: "file", path: "/unused" },
+  { source: "exec", command: "/unused" },
+  { source: "store" },
+] satisfies NonNullable<NonNullable<CoreConfig["secrets"]>["providers"]>[string][];
+
+function createConfig(
+  token: ClickClackAccountConfig["token"],
+  secrets: CoreConfig["secrets"],
+  accountId = "default",
+): CoreConfig {
+  return {
+    secrets,
+    channels: {
+      clickclack: {
+        baseUrl: "https://clickclack.example",
+        workspace: "test-workspace",
+        ...(accountId === "default"
+          ? { token }
+          : { token: "lower-priority-root-token", accounts: { [accountId]: { token } } }),
+      },
+    },
+  };
+}
+
+describe("ClickClack SecretRef provider policy", () => {
+  afterEach(() => vi.unstubAllEnvs());
+
+  it.each(
+    ["default", "work"].flatMap((accountId) =>
+      ["default", "selected"].flatMap((provider) =>
+        collisionProviders.map((declaration) => ({
+          accountId,
+          provider,
+          declaration,
+          source: declaration.source,
+        })),
+      ),
+    ),
+  )(
+    "uses injected env when $provider shadows $source for account $accountId",
+    ({ accountId, provider, declaration }) => {
+      vi.stubEnv(selectedEnvId, "ambient-token-must-not-win");
+      const cfg = createConfig(
+        { source: "env", provider, id: selectedEnvId },
+        {
+          defaults: provider === "default" ? undefined : { env: provider },
+          providers: { [provider]: declaration },
+        },
+        accountId,
+      );
+      expect(
+        resolveClickClackAccount({
+          cfg,
+          accountId,
+          env: { [selectedEnvId]: " injected-token " },
+        }),
+      ).toMatchObject({
+        accountId,
+        token: "injected-token",
+        tokenSource: "config",
+        tokenStatus: "available",
+        configured: true,
+      });
+    },
+  );
+
+  it.each([
+    { name: "unrestricted", allowlist: undefined, allowed: true },
+    { name: "matching", allowlist: [selectedEnvId], allowed: true },
+    { name: "empty", allowlist: [], allowed: false },
+    { name: "excluding", allowlist: ["OTHER_TOKEN"], allowed: false },
+  ])("honors a selected explicit env provider with $name allowlist", ({ allowlist, allowed }) => {
+    const cfg = createConfig(
+      { source: "env", provider: "selected", id: selectedEnvId },
+      {
+        defaults: { env: "selected" },
+        providers: { selected: { source: "env", allowlist } },
+      },
+    );
+    const resolve = () =>
+      resolveClickClackAccount({
+        cfg,
+        env: { [selectedEnvId]: "injected-token", CLICKCLACK_BOT_TOKEN: "fallback-token" },
+      });
+    if (allowed) {
+      expect(resolve()).toMatchObject({
+        token: "injected-token",
+        tokenSource: "config",
+        tokenStatus: "available",
+      });
+    } else {
+      expect(resolve).toThrow(
+        new Error(
+          `Environment variable "${selectedEnvId}" is not allowlisted in secrets.providers.selected.allowlist.`,
+        ),
+      );
+    }
+  });
+
+  it.each(collisionProviders)(
+    "rejects a non-default $source mismatch with its source diagnostic",
+    (declaration) => {
+      const cfg = createConfig(
+        { source: "env", provider: "other", id: selectedEnvId },
+        {
+          defaults: { env: "selected" },
+          providers: { other: declaration },
+        },
+      );
+      expect(() =>
+        resolveClickClackAccount({ cfg, env: { [selectedEnvId]: "injected-token" } }),
+      ).toThrow(
+        new Error(
+          `Secret provider "other" has source "${declaration.source}" but ref requests "env".`,
+        ),
+      );
+    },
+  );
+
+  it.each(["other", "default"])(
+    "rejects undeclared non-selected alias %s with its missing-provider diagnostic",
+    (provider) => {
+      const cfg = createConfig(
+        { source: "env", provider, id: selectedEnvId },
+        {
+          defaults: { env: "selected" },
+        },
+      );
+      expect(() =>
+        resolveClickClackAccount({ cfg, env: { [selectedEnvId]: "injected-token" } }),
+      ).toThrow(
+        new Error(
+          `Secret provider "${provider}" is not configured (ref: env:${provider}:${selectedEnvId}).`,
+        ),
+      );
+    },
+  );
+
+  it.each(
+    ["default", "work"].flatMap((accountId) =>
+      [undefined, ...collisionProviders].map((declaration) => ({
+        accountId,
+        declaration,
+        source: declaration?.source ?? "undeclared",
+      })),
+    ),
+  )(
+    "keeps missing selected env configured-unavailable without fallback ($accountId, $source)",
+    ({ accountId, declaration }) => {
+      vi.stubEnv(selectedEnvId, "ambient-token-must-not-win");
+      const cfg = createConfig(
+        { source: "env", provider: "selected", id: selectedEnvId },
+        {
+          defaults: { env: "selected" },
+          providers: declaration ? { selected: declaration } : undefined,
+        },
+        accountId,
+      );
+      expect(
+        resolveClickClackAccount({
+          cfg,
+          accountId,
+          env: { CLICKCLACK_BOT_TOKEN: "fallback-token" },
+        }),
+      ).toMatchObject({
+        accountId,
+        token: "",
+        tokenSource: "config",
+        tokenStatus: "configured_unavailable",
+        configured: true,
+      });
+    },
+  );
+
+  it.each([
+    { source: "file", id: "/selected/token" },
+    { source: "exec", id: "selected/token" },
+    { source: "store", id: selectedEnvId },
+  ] as const)("never borrows an env token for a $source source ref", ({ source, id }) => {
+    const cfg = createConfig({ source, provider: "default", id }, undefined);
+    expect(
+      resolveClickClackAccount({
+        cfg,
+        env: { [selectedEnvId]: "wrong-source-token", CLICKCLACK_BOT_TOKEN: "fallback-token" },
+      }),
+    ).toMatchObject({
+      token: "",
+      tokenSource: "config",
+      tokenStatus: "configured_unavailable",
+      configured: true,
+    });
+  });
+
+  it("filters disabled accounts while retaining enabled unavailable collision accounts", () => {
+    vi.stubEnv(selectedEnvId, "selected-token");
+    vi.stubEnv("CLICKCLACK_MISSING_TEST_TOKEN", undefined);
+    vi.stubEnv("CLICKCLACK_BOT_TOKEN", "fallback-token");
+    const tokenRef = { source: "env", provider: "default", id: selectedEnvId } as const;
+    const cfg: CoreConfig = {
+      secrets: { providers: { default: { source: "file", path: "/unused" } } },
+      channels: {
+        clickclack: {
+          baseUrl: "https://clickclack.example",
+          workspace: "test-workspace",
+          token: tokenRef,
+          accounts: {
+            work: { token: tokenRef },
+            disabled: { token: tokenRef, enabled: false },
+            unavailable: { token: { ...tokenRef, id: "CLICKCLACK_MISSING_TEST_TOKEN" } },
+          },
+        },
+      },
+    };
+    expect(
+      listEnabledClickClackAccounts(cfg).map(({ accountId, tokenStatus, token }) => ({
+        accountId,
+        tokenStatus,
+        token,
+      })),
+    ).toEqual([
+      { accountId: "default", tokenStatus: "available", token: "selected-token" },
+      { accountId: "unavailable", tokenStatus: "configured_unavailable", token: "" },
+      { accountId: "work", tokenStatus: "available", token: "selected-token" },
+    ]);
+  });
+});

--- a/extensions/clickclack/src/accounts.ts
+++ b/extensions/clickclack/src/accounts.ts
@@ -10,12 +10,12 @@ import { DEFAULT_ACCOUNT_ID, normalizeAccountId } from "openclaw/plugin-sdk/acco
 import { resolveNormalizedAccountEntry } from "openclaw/plugin-sdk/account-resolution-runtime";
 import { resolveIntegerOption } from "openclaw/plugin-sdk/number-runtime";
 import { mergePairLoopGuardConfig } from "openclaw/plugin-sdk/pair-loop-guard-runtime";
-import { resolveDefaultSecretProviderAlias } from "openclaw/plugin-sdk/provider-auth";
 import { tryReadSecretFileSync } from "openclaw/plugin-sdk/secret-file-runtime";
 import {
   normalizeSecretInputString,
   resolveSecretInputString,
 } from "openclaw/plugin-sdk/secret-input";
+import { canResolveEnvSecretRefInReadOnlyPath } from "openclaw/plugin-sdk/secret-ref-readonly";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import type {
   ClickClackAccountConfig,
@@ -160,24 +160,20 @@ function resolveClickClackToken(params: {
         : { token: "", tokenSource: "none", tokenStatus: "missing" };
     }
     if (resolved.status === "configured_unavailable" && resolved.ref.source === "env") {
-      const providerConfig = params.cfg.secrets?.providers?.[resolved.ref.provider];
-      if (providerConfig) {
+      if (!canResolveEnvSecretRefInReadOnlyPath({ cfg: params.cfg, ...resolved.ref })) {
+        const providerConfig = params.cfg.secrets?.providers?.[resolved.ref.provider];
+        if (!providerConfig) {
+          throw new Error(
+            `Secret provider "${resolved.ref.provider}" is not configured (ref: env:${resolved.ref.provider}:${resolved.ref.id}).`,
+          );
+        }
         if (providerConfig.source !== "env") {
           throw new Error(
             `Secret provider "${resolved.ref.provider}" has source "${providerConfig.source}" but ref requests "env".`,
           );
         }
-        if (providerConfig.allowlist && !providerConfig.allowlist.includes(resolved.ref.id)) {
-          throw new Error(
-            `Environment variable "${resolved.ref.id}" is not allowlisted in secrets.providers.${resolved.ref.provider}.allowlist.`,
-          );
-        }
-      } else if (
-        resolved.ref.provider !==
-        resolveDefaultSecretProviderAlias({ secrets: params.cfg.secrets }, "env")
-      ) {
         throw new Error(
-          `Secret provider "${resolved.ref.provider}" is not configured (ref: env:${resolved.ref.provider}:${resolved.ref.id}).`,
+          `Environment variable "${resolved.ref.id}" is not allowlisted in secrets.providers.${resolved.ref.provider}.allowlist.`,
         );
       }
       const token = normalizeSecretInputString((params.env ?? process.env)[resolved.ref.id]);

--- a/extensions/feishu/src/accounts.test.ts
+++ b/extensions/feishu/src/accounts.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   FeishuSecretRefUnavailableError,
   inspectFeishuCredentials,
+  listEnabledFeishuAccounts,
   listFeishuAccountIds,
   resolveDefaultFeishuAccountId,
   resolveDefaultFeishuAccountSelection,
@@ -14,6 +15,7 @@ import {
   FEISHU_SELECTED_SECRET_ENV,
   FEISHU_SIBLING_SECRET_ENV,
   createFeishuSecretRefPolicyConfig,
+  createFeishuTestConfig,
   feishuSecretRefPolicyCases,
 } from "./bot.test-support.js";
 import type { FeishuConfig } from "./types.js";
@@ -324,6 +326,62 @@ describe("resolveFeishuCredentials", () => {
 });
 
 describe("resolveFeishuAccount", () => {
+  it.each([true, false])(
+    "keeps collision credentials separate from enabled=%s filtering",
+    (enabled) => {
+      withEnvVar(FEISHU_SELECTED_SECRET_ENV, "selected-secret", () => {
+        const cfg = createFeishuTestConfig(
+          {
+            accounts: {
+              selected: {
+                enabled,
+                appId: "selected-app",
+                appSecret: { source: "env", provider: "default", id: FEISHU_SELECTED_SECRET_ENV },
+              },
+              sibling: { appId: "sibling-app", appSecret: "sibling-secret" },
+            },
+          },
+          { secrets: { providers: { default: { source: "file", path: "/unused" } } } },
+        );
+        expect(listEnabledFeishuAccounts(cfg).map((account) => account.accountId)).toEqual(
+          enabled ? ["selected", "sibling"] : ["sibling"],
+        );
+        expect(resolveFeishuAccount({ cfg, accountId: "selected" })).toMatchObject({
+          enabled,
+          configured: true,
+          appSecret: "selected-secret",
+        });
+      });
+    },
+  );
+
+  it.each(["encryptKey", "verificationToken"] as const)(
+    "inspects webhook %s through the selected env collision without weakening strict mode",
+    (field) => {
+      withEnvVar(FEISHU_SELECTED_SECRET_ENV, "event-secret", () => {
+        const cfg = createFeishuTestConfig(
+          {
+            connectionMode: "webhook",
+            appId: "app",
+            appSecret: "app-secret",
+            [field]: { source: "env", provider: "selected", id: FEISHU_SELECTED_SECRET_ENV },
+          },
+          {
+            secrets: {
+              defaults: { env: "selected" },
+              providers: { selected: { source: "exec", command: "/unused" } },
+            },
+          },
+        );
+        expect(() => resolveFeishuRuntimeAccount({ cfg }, { requireEventSecrets: true })).toThrow(
+          FeishuSecretRefUnavailableError,
+        );
+        expect(resolveFeishuAccount({ cfg })[field]).toBe("event-secret");
+        expect(resolveFeishuRuntimeAccount({ cfg })[field]).toBe("event-secret");
+      });
+    },
+  );
+
   it.each(feishuSecretRefPolicyCases)(
     "enforces read-only provider policy for $name",
     (testCase) => {
@@ -516,7 +574,7 @@ describe("resolveFeishuAccount", () => {
   });
 
   it.each(feishuSecretRefPolicyCases.filter((testCase) => testCase.configured))(
-    "does not resolve allowed ambient env refs in strict runtime account snapshots",
+    "does not resolve allowed ambient env refs in strict runtime account snapshots: $name",
     (testCase) => {
       withEnvVar(FEISHU_SELECTED_SECRET_ENV, "selected-secret", () => {
         expect(() =>

--- a/extensions/feishu/src/bot.test-support.ts
+++ b/extensions/feishu/src/bot.test-support.ts
@@ -11,6 +11,7 @@ type TestConfigBase = Record<string, unknown> & {
 type FeishuSecretRefPolicyCase = {
   name: string;
   provider: string;
+  defaultEnv?: string;
   providers: NonNullable<NonNullable<ClawdbotConfig["secrets"]>["providers"]>;
   configured: boolean;
 };
@@ -34,13 +35,42 @@ export const feishuSecretRefPolicyCases: FeishuSecretRefPolicyCase[] = [
   {
     name: "provider allowlist excluding the selected credential",
     provider: "corp-env",
+    defaultEnv: "corp-env",
     providers: { "corp-env": { source: "env", allowlist: [FEISHU_SIBLING_SECRET_ENV] } },
     configured: false,
   },
   {
     name: "configured env provider allowing the selected credential",
     provider: "corp-env",
+    defaultEnv: "corp-env",
     providers: { "corp-env": { source: "env", allowlist: [FEISHU_SELECTED_SECRET_ENV] } },
+    configured: true,
+  },
+  {
+    name: "selected env provider with an empty allowlist",
+    provider: "corp-env",
+    defaultEnv: "corp-env",
+    providers: { "corp-env": { source: "env", allowlist: [] } },
+    configured: false,
+  },
+  {
+    name: "literal env default shadowing a file provider",
+    provider: "default",
+    providers: { default: { source: "file", path: "/unused" } },
+    configured: true,
+  },
+  {
+    name: "selected env default shadowing an exec provider",
+    provider: "corp-env",
+    defaultEnv: "corp-env",
+    providers: { "corp-env": { source: "exec", command: "/unused" } },
+    configured: true,
+  },
+  {
+    name: "selected env default shadowing a store provider",
+    provider: "corp-env",
+    defaultEnv: "corp-env",
+    providers: { "corp-env": { source: "store" } },
     configured: true,
   },
 ];
@@ -58,6 +88,7 @@ export function createFeishuTestConfig(
 export function createFeishuSecretRefPolicyConfig({
   provider,
   providers,
+  defaultEnv,
 }: FeishuSecretRefPolicyCase): ClawdbotConfig {
   return createFeishuTestConfig(
     {
@@ -68,11 +99,19 @@ export function createFeishuSecretRefPolicyConfig({
         },
         sibling: {
           appId: "sibling-app",
-          appSecret: { source: "env", provider: "default", id: FEISHU_SIBLING_SECRET_ENV },
+          appSecret: { source: "env", provider: "sibling-env", id: FEISHU_SIBLING_SECRET_ENV },
         },
       },
     },
-    { secrets: { providers } },
+    {
+      secrets: {
+        defaults: defaultEnv ? { env: defaultEnv } : undefined,
+        providers: {
+          ...providers,
+          "sibling-env": { source: "env", allowlist: [FEISHU_SIBLING_SECRET_ENV] },
+        },
+      },
+    },
   );
 }
 

--- a/extensions/feishu/src/channel.test.ts
+++ b/extensions/feishu/src/channel.test.ts
@@ -331,8 +331,14 @@ describe("feishuPlugin actions", () => {
 
   it.each([
     {
-      name: "file-backed default provider",
+      name: "selected env default shadows file provider",
       provider: { source: "file", path: "/unused" },
+      allowed: true,
+    },
+    {
+      name: "non-default file provider",
+      provider: { source: "file", path: "/unused" },
+      defaultEnv: "other-env",
       allowed: false,
     },
     {
@@ -348,34 +354,38 @@ describe("feishuPlugin actions", () => {
   ] satisfies Array<{
     name: string;
     provider: FeishuSecretProviderConfig;
+    defaultEnv?: string;
     allowed: boolean;
-  }>)("enforces root SecretRef policy during discovery: $name", ({ provider, allowed }) => {
-    vi.stubEnv("FEISHU_DISCOVERY_SECRET", "ambient-secret");
-    try {
-      const discovery = describeFeishuMessageTool({
-        secrets: {
-          defaults: { env: "corp-env" },
-          providers: { "corp-env": provider },
-        },
-        channels: {
-          feishu: {
-            enabled: true,
-            appId: "cli_main",
-            appSecret: { source: "env", id: "FEISHU_DISCOVERY_SECRET" },
+  }>)(
+    "enforces root SecretRef policy during discovery: $name",
+    ({ provider, defaultEnv = "corp-env", allowed }) => {
+      vi.stubEnv("FEISHU_DISCOVERY_SECRET", "ambient-secret");
+      try {
+        const discovery = describeFeishuMessageTool({
+          secrets: {
+            defaults: { env: defaultEnv },
+            providers: { "corp-env": provider },
           },
-        },
-      } as OpenClawConfig);
+          channels: {
+            feishu: {
+              enabled: true,
+              appId: "cli_main",
+              appSecret: { source: "env", provider: "corp-env", id: "FEISHU_DISCOVERY_SECRET" },
+            },
+          },
+        });
 
-      expect(discovery?.capabilities).toEqual(allowed ? ["presentation"] : []);
-      if (allowed) {
-        expect(discovery?.actions).toContain("send");
-      } else {
-        expect(discovery?.actions).toEqual([]);
+        expect(discovery?.capabilities).toEqual(allowed ? ["presentation"] : []);
+        if (allowed) {
+          expect(discovery?.actions).toContain("send");
+        } else {
+          expect(discovery?.actions).toEqual([]);
+        }
+      } finally {
+        vi.unstubAllEnvs();
       }
-    } finally {
-      vi.unstubAllEnvs();
-    }
-  });
+    },
+  );
 
   it("declares native chat IDs as delivery targets for guarded message mutations", () => {
     for (const action of ["edit", "pin", "unpin"] as const) {

--- a/extensions/telegram/src/account-inspect.test.ts
+++ b/extensions/telegram/src/account-inspect.test.ts
@@ -53,33 +53,39 @@ describe("inspectTelegramAccount SecretRef resolution", () => {
     });
   });
 
-  it("does not read env values for non-env providers", () => {
-    withEnv({ TG_EXEC_PROVIDER: "123:token" }, () => {
-      const cfg: OpenClawConfig = {
-        secrets: {
-          defaults: {
-            env: "exec-provider",
-          },
-          providers: {
-            "exec-provider": {
-              source: "exec",
-              command: "/usr/bin/env",
+  it.each([
+    { provider: "default", value: "123:token", expected: "available" },
+    { provider: "exec-provider", value: "123:token", expected: "available" },
+    { provider: "exec-provider", value: undefined, expected: "configured_unavailable" },
+  ])(
+    "inspects env-template default $provider shadowing exec ($expected)",
+    ({ provider, value, expected }) => {
+      withEnv({ TG_EXEC_PROVIDER: value, TELEGRAM_BOT_TOKEN: "123:fallback" }, () => {
+        const cfg: OpenClawConfig = {
+          secrets: {
+            defaults: provider === "default" ? undefined : { env: provider },
+            providers: {
+              [provider]: {
+                source: "exec",
+                command: "/unused",
+              },
             },
           },
-        },
-        channels: {
-          telegram: {
-            botToken: "${TG_EXEC_PROVIDER}",
+          channels: {
+            telegram: {
+              botToken: "${TG_EXEC_PROVIDER}",
+            },
           },
-        },
-      };
+        };
 
-      const account = inspectTelegramAccount({ cfg, accountId: "default" });
-      expect(account.tokenSource).toBe("env");
-      expect(account.tokenStatus).toBe("configured_unavailable");
-      expect(account.token).toBe("");
-    });
-  });
+        const account = inspectTelegramAccount({ cfg, accountId: "default" });
+        expect(account.tokenSource).toBe("env");
+        expect(account.tokenStatus).toBe(expected);
+        expect(account.configured).toBe(true);
+        expect(account.token).toBe(expected === "available" ? "123:token" : "");
+      });
+    },
+  );
 
   it("matches runtime token lookup for account keys that need full normalization", () => {
     const cfg: OpenClawConfig = {

--- a/extensions/telegram/src/token.test.ts
+++ b/extensions/telegram/src/token.test.ts
@@ -26,6 +26,11 @@ describe("resolveTelegramBotUserIdFromToken", () => {
 
 describe("resolveTelegramToken", () => {
   const tempWorkspaces: TempWorkspaceSync[] = [];
+  const collisionProviders = [
+    { source: "file", path: "/unused" },
+    { source: "exec", command: "/unused" },
+    { source: "store" },
+  ] satisfies NonNullable<NonNullable<OpenClawConfig["secrets"]>["providers"]>[string][];
 
   function createTokenFile(fileName: string, contents = "file-token\n"): string {
     const workspace = tempWorkspaceSync({
@@ -403,57 +408,82 @@ describe("resolveTelegramToken", () => {
     });
   });
 
-  it("does not fall back to TELEGRAM_BOT_TOKEN when an explicit env SecretRef is configured but unavailable", () => {
-    vi.stubEnv("TELEGRAM_BOT_TOKEN", "fallback-env-token");
-    vi.stubEnv("TELEGRAM_REF_TOKEN", "");
-    const cfg = {
-      channels: {
-        telegram: {
-          botToken: { source: "env", provider: "default", id: "TELEGRAM_REF_TOKEN" },
+  it.each(
+    [undefined, ...collisionProviders].map((declaration) => ({
+      declaration,
+      source: declaration?.source ?? "undeclared",
+    })),
+  )(
+    "does not fall back to TELEGRAM_BOT_TOKEN when a selected ref is unavailable ($source)",
+    ({ declaration }) => {
+      vi.stubEnv("TELEGRAM_BOT_TOKEN", "fallback-env-token");
+      vi.stubEnv("TELEGRAM_REF_TOKEN", "");
+      const cfg = {
+        secrets: { providers: declaration ? { default: declaration } : undefined },
+        channels: {
+          telegram: {
+            botToken: { source: "env", provider: "default", id: "TELEGRAM_REF_TOKEN" },
+          },
         },
-      },
-    } as unknown as OpenClawConfig;
+      } as unknown as OpenClawConfig;
 
-    expect(resolveTelegramToken(cfg)).toEqual({
-      token: "",
-      source: "none",
-    });
-  });
+      expect(resolveTelegramToken(cfg)).toEqual({
+        token: "",
+        source: "none",
+      });
+    },
+  );
 
-  it("does not fall through when account-level env SecretRef is configured but unavailable", () => {
-    vi.stubEnv("TELEGRAM_BOT_TOKEN", "fallback-env-token");
-    vi.stubEnv("TELEGRAM_ACCOUNT_REF_TOKEN", "");
-    const cfg = {
-      channels: {
-        telegram: {
-          botToken: "channel-token",
-          accounts: {
-            default: {
-              botToken: {
-                source: "env",
-                provider: "default",
-                id: "TELEGRAM_ACCOUNT_REF_TOKEN",
+  it.each(
+    [undefined, ...collisionProviders].map((declaration) => ({
+      declaration,
+      source: declaration?.source ?? "undeclared",
+    })),
+  )(
+    "does not fall through when an account-level selected ref is unavailable ($source)",
+    ({ declaration }) => {
+      vi.stubEnv("TELEGRAM_BOT_TOKEN", "fallback-env-token");
+      vi.stubEnv("TELEGRAM_ACCOUNT_REF_TOKEN", "");
+      const cfg = {
+        secrets: {
+          defaults: { env: "selected" },
+          providers: declaration ? { selected: declaration } : undefined,
+        },
+        channels: {
+          telegram: {
+            botToken: "channel-token",
+            tokenFile: createTokenFile("fallback.txt", "channel-file-token"),
+            accounts: {
+              default: {
+                botToken: {
+                  source: "env",
+                  provider: "selected",
+                  id: "TELEGRAM_ACCOUNT_REF_TOKEN",
+                },
               },
             },
           },
         },
-      },
-    } as unknown as OpenClawConfig;
+      } as unknown as OpenClawConfig;
 
-    expect(resolveTelegramToken(cfg)).toEqual({
-      token: "",
-      source: "none",
-    });
-  });
+      expect(resolveTelegramToken(cfg)).toEqual({
+        token: "",
+        source: "none",
+      });
+    },
+  );
 
-  it("does not bypass env provider allowlists for env-backed SecretRefs", () => {
+  it.each(
+    [[], ["OTHER_TELEGRAM_BOT_TOKEN"], ["TELEGRAM_BOT_TOKEN"]].map((allowlist) => ({ allowlist })),
+  )("honors the selected explicit env provider allowlist $allowlist", ({ allowlist }) => {
     vi.stubEnv("TELEGRAM_BOT_TOKEN", "secretref-env-token");
     const cfg = {
       secrets: {
+        defaults: { env: "telegram-env" },
         providers: {
           "telegram-env": {
             source: "env",
-            allowlist: ["OTHER_TELEGRAM_BOT_TOKEN"],
+            allowlist,
           },
         },
       },
@@ -464,9 +494,13 @@ describe("resolveTelegramToken", () => {
       },
     } as unknown as OpenClawConfig;
 
-    expect(() => resolveTelegramToken(cfg)).toThrow(
-      /not allowlisted in secrets\.providers\.telegram-env\.allowlist/i,
-    );
+    if (allowlist.includes("TELEGRAM_BOT_TOKEN")) {
+      expect(resolveTelegramToken(cfg)).toEqual({ token: "secretref-env-token", source: "config" });
+    } else {
+      expect(() => resolveTelegramToken(cfg)).toThrow(
+        /not allowlisted in secrets\.providers\.telegram-env\.allowlist/i,
+      );
+    }
   });
 
   it("throws when an env SecretRef points at a provider configured with another source", () => {
@@ -505,19 +539,26 @@ describe("resolveTelegramToken", () => {
     );
   });
 
-  it("accepts env SecretRefs that use the configured default env provider alias", () => {
+  it.each(
+    ["default", "telegram-runtime"].flatMap((provider) =>
+      [undefined, ...collisionProviders].map((declaration) => ({
+        provider,
+        declaration,
+        source: declaration?.source ?? "undeclared",
+      })),
+    ),
+  )("accepts env default $provider shadowing $source", ({ provider, declaration }) => {
     vi.stubEnv("TELEGRAM_RUNTIME_TOKEN", "secretref-env-token");
     const cfg = {
       secrets: {
-        defaults: {
-          env: "telegram-runtime",
-        },
+        defaults: provider === "default" ? undefined : { env: provider },
+        providers: declaration ? { [provider]: declaration } : undefined,
       },
       channels: {
         telegram: {
           botToken: {
             source: "env",
-            provider: "telegram-runtime",
+            provider,
             id: "TELEGRAM_RUNTIME_TOKEN",
           },
         },

--- a/extensions/telegram/src/token.ts
+++ b/extensions/telegram/src/token.ts
@@ -12,7 +12,7 @@ import {
   normalizeSecretInputString,
   resolveSecretInputString,
 } from "openclaw/plugin-sdk/secret-input";
-import { resolveDefaultSecretProviderAlias } from "openclaw/plugin-sdk/secret-provider-alias";
+import { canResolveEnvSecretRefInReadOnlyPath } from "openclaw/plugin-sdk/secret-ref-readonly";
 import { resolveDefaultTelegramAccountId } from "./account-selection.js";
 
 type CredentialUnavailableDiagnostic = Extract<
@@ -36,28 +36,25 @@ function resolveEnvSecretRefValue(params: {
   cfg?: Pick<OpenClawConfig, "secrets">;
   provider: string;
   id: string;
-  env?: NodeJS.ProcessEnv;
 }): string | undefined {
+  // Share admission with inspection while retaining strict diagnostics below.
+  if (canResolveEnvSecretRefInReadOnlyPath(params)) {
+    return normalizeSecretInputString(process.env[params.id]);
+  }
   const providerConfig = params.cfg?.secrets?.providers?.[params.provider];
-  if (providerConfig) {
-    if (providerConfig.source !== "env") {
-      throw new Error(
-        `Secret provider "${params.provider}" has source "${providerConfig.source}" but ref requests "env".`,
-      );
-    }
-    if (providerConfig.allowlist && !providerConfig.allowlist.includes(params.id)) {
-      throw new Error(
-        `Environment variable "${params.id}" is not allowlisted in secrets.providers.${params.provider}.allowlist.`,
-      );
-    }
-  } else if (
-    params.provider !== resolveDefaultSecretProviderAlias({ secrets: params.cfg?.secrets }, "env")
-  ) {
+  if (!providerConfig) {
     throw new Error(
       `Secret provider "${params.provider}" is not configured (ref: env:${params.provider}:${params.id}).`,
     );
   }
-  return normalizeSecretInputString((params.env ?? process.env)[params.id]);
+  if (providerConfig.source !== "env") {
+    throw new Error(
+      `Secret provider "${params.provider}" has source "${providerConfig.source}" but ref requests "env".`,
+    );
+  }
+  throw new Error(
+    `Environment variable "${params.id}" is not allowlisted in secrets.providers.${params.provider}.allowlist.`,
+  );
 }
 
 function resolveRuntimeTokenValue(params: {

--- a/extensions/xai/src/tool-auth-shared.test.ts
+++ b/extensions/xai/src/tool-auth-shared.test.ts
@@ -1,4 +1,5 @@
 // Xai tests cover tool auth shared plugin behavior.
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { NON_ENV_SECRETREF_MARKER } from "openclaw/plugin-sdk/provider-auth-runtime";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
@@ -151,6 +152,53 @@ describe("xai tool auth helpers", () => {
       }),
     ).resolves.toBeUndefined();
   });
+
+  it.each(
+    [undefined, "   "].flatMap((envValue) =>
+      [
+        undefined,
+        { source: "env" as const },
+        { source: "file" as const, path: "/unused" },
+        { source: "exec" as const, command: "/unused" },
+        { source: "store" as const },
+      ].map((declaration) => ({
+        envValue,
+        declaration,
+        source: declaration?.source ?? "undeclared",
+      })),
+    ),
+  )(
+    "does not borrow profile auth for a missing configured env ref ($source, $envValue)",
+    async ({ envValue, declaration }) => {
+      vi.stubEnv("XAI_API_KEY", envValue);
+      const auth = {
+        hasAuthForProvider: vi.fn(() => true),
+        resolveApiKeyForProvider: vi.fn(async () => "profile-key"),
+      };
+      const sourceConfig: OpenClawConfig = {
+        secrets: {
+          defaults: { env: "selected" },
+          providers: declaration ? { selected: declaration } : undefined,
+        },
+        plugins: {
+          entries: {
+            xai: {
+              config: {
+                webSearch: {
+                  apiKey: { source: "env", provider: "selected", id: "XAI_API_KEY" },
+                },
+              },
+            },
+          },
+        },
+      };
+
+      expect(isXaiToolEnabled({ sourceConfig, auth })).toBe(false);
+      await expect(resolveXaiToolApiKeyWithAuth({ sourceConfig, auth })).resolves.toBeUndefined();
+      expect(auth.hasAuthForProvider).not.toHaveBeenCalled();
+      expect(auth.resolveApiKeyForProvider).not.toHaveBeenCalled();
+    },
+  );
 
   it("does not bypass blocked explicit tool config with auth profiles", async () => {
     const auth = {

--- a/src/agents/auth-profiles/read-only-availability.test.ts
+++ b/src/agents/auth-profiles/read-only-availability.test.ts
@@ -11,6 +11,40 @@ const cfg = {
 } satisfies OpenClawConfig;
 
 describe("resolveStoredCredentialReadOnlyAvailability", () => {
+  it.each([
+    {
+      name: "present selected env",
+      selected: true,
+      env: { COLLISION_KEY: "synthetic-key" },
+      expected: true,
+    },
+    { name: "missing selected env", selected: true, env: {}, expected: undefined },
+    {
+      name: "non-default mismatch",
+      selected: false,
+      env: { COLLISION_KEY: "synthetic-key" },
+      expected: false,
+    },
+  ])("preserves availability for $name under a file collision", ({ selected, env, expected }) => {
+    expect(
+      resolveStoredCredentialReadOnlyAvailability({
+        credential: {
+          type: "api_key",
+          provider: "test",
+          key: "retained-inline-key",
+          keyRef: { source: "env", provider: "selected", id: "COLLISION_KEY" },
+        },
+        cfg: {
+          secrets: {
+            defaults: selected ? { env: "selected" } : undefined,
+            providers: { selected: { source: "file", path: "/unused" } },
+          },
+        },
+        env,
+      }),
+    ).toBe(expected);
+  });
+
   it("keeps an implicit store ref unknown until runtime resolution", () => {
     expect(
       resolveStoredCredentialReadOnlyAvailability({

--- a/src/plugin-sdk/secret-ref-readonly.internal.ts
+++ b/src/plugin-sdk/secret-ref-readonly.internal.ts
@@ -1,19 +1,20 @@
 import type { OpenClawConfig } from "../config/config.js";
-import { resolveDefaultSecretProviderAlias } from "../secrets/ref-contract.js";
+import { isBuiltInDefaultSecretProviderRef } from "../secrets/ref-contract.js";
 
-/** Checks whether a read-only plugin path may resolve a secret through an env provider. */
+/** Checks env provider selection and allowlists without resolving a credential. */
 export function canResolveEnvSecretRefInReadOnlyPath(params: {
   cfg?: OpenClawConfig;
   provider: string;
   id: string;
 }): boolean {
   const providerConfig = params.cfg?.secrets?.providers?.[params.provider];
-  if (!providerConfig) {
-    return params.provider === resolveDefaultSecretProviderAlias(params.cfg ?? {}, "env");
+  if (providerConfig?.source === "env") {
+    const allowlist = providerConfig.allowlist;
+    return !allowlist || allowlist.includes(params.id);
   }
-  if (providerConfig.source !== "env") {
-    return false;
-  }
-  const allowlist = providerConfig.allowlist;
-  return !allowlist || allowlist.includes(params.id);
+  return isBuiltInDefaultSecretProviderRef(params.cfg ?? {}, {
+    source: "env",
+    provider: params.provider,
+    id: params.id,
+  });
 }

--- a/src/plugin-sdk/secret-ref-readonly.test.ts
+++ b/src/plugin-sdk/secret-ref-readonly.test.ts
@@ -2,40 +2,147 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "./config-contracts.js";
 import { resolveReadOnlyEnvSecretRef } from "./secret-ref-readonly.js";
 
+type SecretProvider = NonNullable<NonNullable<OpenClawConfig["secrets"]>["providers"]>[string];
+const collisionProviders = [
+  { source: "file", path: "/unused" },
+  { source: "exec", command: "/unused" },
+  { source: "store" },
+] satisfies SecretProvider[];
+
 describe("resolveReadOnlyEnvSecretRef", () => {
   afterEach(() => {
     vi.unstubAllEnvs();
   });
 
-  it("returns blocked when read-only provider policy forbids resolution", () => {
-    vi.stubEnv("EXPECTED_API_KEY", "ambient-value");
+  it.each([
+    ...["default", "selected"].flatMap((provider) =>
+      collisionProviders.map((declaration) => ({
+        name: `${provider} env default shadows ${declaration.source}`,
+        provider,
+        cfg: {
+          secrets: {
+            defaults: provider === "selected" ? { env: provider } : undefined,
+            providers: { [provider]: declaration },
+          },
+        },
+        expected: "available",
+      })),
+    ),
+    { name: "implicit env default", provider: "default", cfg: {}, expected: "available" },
+    {
+      name: "undeclared selected env default",
+      provider: "selected",
+      cfg: { secrets: { defaults: { env: "selected" } } },
+      expected: "available",
+    },
+    { name: "undeclared non-default", provider: "other", cfg: {}, expected: "blocked" },
+    {
+      name: "literal default is not selected",
+      provider: "default",
+      cfg: { secrets: { defaults: { env: "selected" } } },
+      expected: "blocked",
+    },
+    ...collisionProviders.map((declaration) => ({
+      name: `non-default ${declaration.source} mismatch`,
+      provider: "other",
+      cfg: { secrets: { providers: { other: declaration } } },
+      expected: "blocked",
+    })),
+    ...["default", "selected"].flatMap((provider) =>
+      [
+        { allowlist: undefined, expected: "available" },
+        { allowlist: ["EXPECTED_API_KEY"], expected: "available" },
+        { allowlist: [], expected: "blocked" },
+        { allowlist: ["OTHER_API_KEY"], expected: "blocked" },
+      ].map(({ allowlist, expected }) => ({
+        name: `${provider} matching env declaration with allowlist ${JSON.stringify(allowlist)}`,
+        provider,
+        cfg: {
+          secrets: {
+            defaults: { env: provider },
+            providers: { [provider]: { source: "env" as const, allowlist } },
+          },
+        },
+        expected,
+      })),
+    ),
+  ])("enforces provider policy: $name", ({ provider, cfg, expected }) => {
+    vi.stubEnv("EXPECTED_API_KEY", " synthetic-value ");
     const normalizeValue = vi.fn((value: unknown) =>
       typeof value === "string" && value.trim() ? value.trim() : undefined,
     );
-    const cfg = {
-      secrets: {
-        providers: {
-          restricted: {
-            source: "env",
-            allowlist: [],
-          },
-        },
-      },
-    } as OpenClawConfig;
 
     expect(
       resolveReadOnlyEnvSecretRef({
-        value: {
-          source: "env",
-          provider: "restricted",
-          id: "EXPECTED_API_KEY",
-        },
+        value: { source: "env", provider, id: "EXPECTED_API_KEY" },
         path: "plugins.entries.example.config.apiKey",
         cfg,
         expectedEnvId: "EXPECTED_API_KEY",
         normalizeValue,
       }),
+    ).toEqual(
+      expected === "available"
+        ? { status: "available", value: "synthetic-value" }
+        : { status: "blocked" },
+    );
+    if (expected === "blocked") {
+      expect(normalizeValue).not.toHaveBeenCalled();
+    }
+  });
+
+  it.each([
+    { source: "file", id: "/api/key" },
+    { source: "exec", id: "api-key" },
+    { source: "store", id: "EXPECTED_API_KEY" },
+    { source: "env", id: "OTHER_API_KEY" },
+  ])("blocks $source:$id before normalizing any value", ({ source, id }) => {
+    vi.stubEnv("EXPECTED_API_KEY", "synthetic-value");
+    vi.stubEnv("OTHER_API_KEY", "other-synthetic-value");
+    const normalizeValue = vi.fn(() => "must-not-be-used");
+    expect(
+      resolveReadOnlyEnvSecretRef({
+        value: { source, provider: "default", id },
+        path: "plugins.entries.example.config.apiKey",
+        cfg: { secrets: { providers: { default: { source: "file", path: "/unused" } } } },
+        expectedEnvId: "EXPECTED_API_KEY",
+        normalizeValue,
+      }),
     ).toEqual({ status: "blocked" });
     expect(normalizeValue).not.toHaveBeenCalled();
+  });
+
+  it.each(
+    [undefined, "", "   "].flatMap((value) => ["env", "exec"].map((source) => ({ value, source }))),
+  )("blocks missing selected env value $value with a $source declaration", ({ value, source }) => {
+    vi.stubEnv("EXPECTED_API_KEY", value);
+    expect(
+      resolveReadOnlyEnvSecretRef({
+        value: { source: "env", provider: "selected", id: "EXPECTED_API_KEY" },
+        path: "plugins.entries.example.config.apiKey",
+        cfg: {
+          secrets: {
+            defaults: { env: "selected" },
+            providers: {
+              selected:
+                source === "env" ? { source: "env" } : { source: "exec", command: "/unused" },
+            },
+          },
+        },
+        expectedEnvId: "EXPECTED_API_KEY",
+        normalizeValue: (input) =>
+          typeof input === "string" ? input.trim() || undefined : undefined,
+      }),
+    ).toEqual({ status: "blocked" });
+  });
+
+  it("keeps an absent credential missing so callers can apply their fallback", () => {
+    expect(
+      resolveReadOnlyEnvSecretRef({
+        value: undefined,
+        path: "plugins.entries.example.config.apiKey",
+        expectedEnvId: "EXPECTED_API_KEY",
+        normalizeValue: (value) => (typeof value === "string" ? value : undefined),
+      }),
+    ).toEqual({ status: "missing" });
   });
 });

--- a/src/plugin-sdk/secret-ref-readonly.ts
+++ b/src/plugin-sdk/secret-ref-readonly.ts
@@ -47,5 +47,6 @@ export function resolveReadOnlyEnvSecretRef(params: {
     return { status: "blocked" };
   }
   const envValue = params.normalizeValue(process.env[envId]);
-  return envValue ? { status: "available", value: envValue } : { status: "missing" };
+  // An absent selected value does not release the configured ref's credential ownership.
+  return envValue ? { status: "available", value: envValue } : { status: "blocked" };
 }

--- a/src/plugins/manifest-tool-availability.test.ts
+++ b/src/plugins/manifest-tool-availability.test.ts
@@ -160,6 +160,31 @@ describe("manifestConfigSignalPasses", () => {
       }),
     ).toBe(false);
   });
+
+  it.each([
+    {
+      name: "present selected env",
+      selected: true,
+      env: { COLLISION_KEY: "synthetic-key" },
+      expected: true,
+    },
+    { name: "missing selected env", selected: true, env: {}, expected: false },
+    {
+      name: "non-default mismatch",
+      selected: false,
+      env: { COLLISION_KEY: "synthetic-key" },
+      expected: false,
+    },
+  ])("evaluates $name under an exec collision", ({ selected, env, expected }) => {
+    const config = xaiConfig({
+      webSearch: { apiKey: { source: "env", provider: "selected", id: "COLLISION_KEY" } },
+    });
+    config.secrets = {
+      defaults: selected ? { env: "selected" } : undefined,
+      providers: { selected: { source: "exec", command: "/unused" } },
+    };
+    expect(manifestConfigSignalPasses({ config, env, signal: webSearchSignal })).toBe(expected);
+  });
 });
 
 describe("manifestProviderBaseUrlGuardPasses", () => {


### PR DESCRIPTION
Closes #132576

Related: #132352 (the independently landed Matrix default-alias repair).

<details>
<summary>Additional instructions</summary>

Maintainer edits are available on this same-repository branch.

</details>

## What Problem This Solves

Fixes an issue where operators using env SecretRefs with a source-specific default alias would see usable Telegram or Feishu accounts reported unavailable, or have Telegram and ClickClack token resolution rejected, when the alias also named a file, exec, or store provider declaration.

The canonical resolver already accepts that documented configuration. The affected channel and read-only entry points retained the older blanket source-mismatch rule.

## Why This Change Was Made

Use the existing public read-only SDK seam for one canonical env-provider admission decision, while retaining channel-owned strictness and diagnostics. Matching explicit env providers still enforce their allowlists, including empty-list denial; undeclared non-default aliases and non-default source mismatches still fail closed.

A configured structured env ref whose value is unavailable now stays `blocked`, rather than being classified as an absent credential. This preserves reference ownership when valid aliases become admissible and prevents xAI tool auth from borrowing an auth-profile credential. Required Feishu runtime credentials remain snapshot-only; account disablement, expected-env-ID constraints, token-file precedence, and existing diagnostic messages are unchanged.

No new SDK export, budget increase, config option, storage change, or dependency is introduced. Matrix, daemon-install performance, store-source inspection, and raw-reference parsing/projection work remain separate.

## User Impact

Valid shared env default aliases work consistently across the affected channel configuration surfaces. Healthy sibling accounts remain usable, while unavailable configured refs do not silently select lower-priority credentials. Operators using explicit env allowlists retain the same restrictions.

Production LOC: +34/-39 (net -5). Tests and test support: +713/-113. Documentation: +4/-2. The tests extend owner-boundary policy cases rather than adding a test-only production seam.

AI-assisted implementation and verification.

## Evidence

- Captured 62 intended failing-before regressions across alias admission and configured-reference ownership. The final typed Telegram env-template fixture was separately re-proven against the original admission implementation: two expected failures before, all nine inspection tests passing after.
- Focused and representative sibling local coverage: **833 tests passed across 20 files**, aggregated from the original 577-test owner/sibling suite plus all 256 Feishu channel tests after the discovery-fixture correction. Coverage includes the SDK, Telegram, Feishu accounts/channel/directory/outbound, ClickClack, xAI, auth-profile availability, manifest availability, configuration policy, and Comfy/Firecrawl/SearxNG/Tavily consumers. Post-rebase SDK/xAI sanity separately passed 53/53 (not double-counted).
- A real canonical-resolver policy sweep changed from **18/144 disagreements to 0/144**.
- A fresh-process channel sweep changed from **18 disagreements per boundary to zero** across **432 scenarios × four boundaries = 1,728 comparisons**. No lower-priority credential was used.
- Detailed isolated Node 24 probes passed for actual account/token/status-adapter boundaries. Thirteen Telegram denial and diagnostic control outputs remained byte-identical. These are local process-boundary proofs, not authenticated channel traffic.
- Full build, complete changed-file type/lint/architecture gates, SDK package/export-budget checks, documentation checks, and built Telegram/ClickClack entrypoint imports passed. The patch adds zero SDK exports.
- Fresh isolated Codex autoreview reported no P0 findings. Earlier import-bound attempts and test-fixture typing/naming failures were corrected before the final passing validation; no timeout or budget was increased.

Local proof commands included the repository test wrapper scoped to the affected files and sibling consumers, `pnpm build`, `node scripts/check-changed.mjs -- <changed paths>`, the SDK surface check, and the isolated built-entrypoint profiler. All fixtures used synthetic values and isolated state. No operator Gateway or real channel credential was used.

### Built CLI proof and limits

A real dist-backed `node openclaw.mjs models list --json --agent proof` invocation passed with an isolated synthetic auth profile holding an env keyRef, a selected shared env default alias, and a same-name file-provider declaration. The synthetic model was reported `available: true`, `missing: false`; exit 0, config unchanged, no credential value in output. V8 coverage recorded one call each to `resolveStoredCredentialReadOnlyAvailability`, `resolveSecretRefReadOnlyAvailability`, `canResolveEnvSecretRefInReadOnlyPath`, and `isBuiltInDefaultSecretProviderRef`, with zero calls to local command-secret hydration. This exercised the repaired read-only path rather than masking it through canonical materialization.

Artifact identity: the build was made before the repair commit, so its metadata records baseline `b41a06f2207795d2534680d7b77e767a35edce98`. All four changed production-source hashes matched repair commit `8ea38a68bb749c1ab0ed9e4d770d90ec5b4a010e` and remained stable during proof. The subsequent rebase to `ce6359ee6ffb0bccc709b3b74e08b2660ef2018b` is patch-identical (`git range-diff` reports `=`); the binary is not represented as a post-rebase build.

Additional built channel-inventory, public Telegram-facade, and missing-value CLI probes reached their fixed 90-second startup/import caps before owner coverage, so they are inconclusive, not behavior failures or passing proof. The empty-allowlist CLI control was not reached. The completed local test suites and fresh-process channel boundary/control sweeps cover those policy cases, but are not authenticated channel traffic. No live vendor API verification is claimed. No operator Gateway was touched; all proof-owned processes and synthetic state were cleaned up.

### Maintainer policy decision and hosted validation

The no-fallback change is intentional and follows the requested configured-reference ownership/security invariant. An explicitly configured env ref whose value is absent or empty must not borrow an auth-profile credential; an xAI tool in that state is unavailable. Operators must supply the selected env value, or remove the explicit ref if they intend to use the existing auth-profile selection path. Genuinely absent credential input still permits its existing fallback. The regression tests assert that neither auth-profile availability nor resolution callbacks run for a blocked configured ref. This is an upgrade-sensitive correction, documented in the secrets and SDK pages, not an accidental loss of ordinary auth-profile support.

The first hosted run, [33252199055](https://github.com/openclaw/openclaw/actions/runs/33252199055), failed the schema-eligibility shard and a Feishu discovery expectation. The unrelated schema tests hard-coded version 18 after the owner advanced to 19; current `main` already contains the test-only correction [16367468](https://github.com/openclaw/openclaw/commit/16367468a7edce977360becc72443943d805593d). That shard passed in [refreshed CI 33253267954](https://github.com/openclaw/openclaw/actions/runs/33253267954), leaving only Feishu discovery. No state/schema files were added to this PR.

The stale Feishu case expected a selected env default alias with a file declaration to be rejected. Its table now expects canonical acceptance and separately retains rejection of a genuinely non-default mismatched alias; existing allowlist controls and exact action/capability assertions remain. The corrected positive case fails against the byte-identical pre-fix shared owner, with all three controls passing, then the complete 256-test channel suite passes with the repair. The fixture now uses a typed explicit provider rather than a config assertion.

The final test-corrected head is `c8efbab19cb01f1955f99c84d15e7e50d0ce2726`. Its additional changed-file gates passed, including extension test types and targeted lint; fresh Codex autoreview of the complete candidate was scoped-clean with no P0 findings. The four production sources remain byte-identical to the original verified repair.

ClawSweeper found no introduced code or security defect. The configured-ref policy decision above resolves its auth/compatibility concern. [Final exact-head CI 33254974099](https://github.com/openclaw/openclaw/actions/runs/33254974099) is successful for `c8efbab19cb01f1955f99c84d15e7e50d0ce2726`, including required `openclaw/ci-gate`; its rank-up moves are satisfied. Native review artifacts bind that exact head for preparation and merge.
