### PR TITLE
test(ui): skip idle animation frames between cloud retries

### DIFF
--- a/ui/src/e2e/new-session-page.cloud-dispatch.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.cloud-dispatch.e2e.test.ts
@@ -393,7 +393,7 @@ suite.define(() => {
 
       for (const delayMs of CLOUD_PROFILE_RETRY_DELAYS_MS) {
         const requestsBeforeRetry = (await gateway.getRequests("environments.list")).length;
-        await page.clock.runFor(delayMs + 1);
+        await page.clock.fastForward(delayMs + 1);
         await gateway.waitForRequest("environments.list", { after: requestsBeforeRetry });
       }
       await page.clock.resume();


### PR DESCRIPTION
## Summary

Cloud-dispatch coverage replays every browser animation frame while advancing through five retry delays totaling 104 virtual seconds. Fast-forward each existing delay separately instead, retaining the request wait between retries, six-attempt assertion, selected cloud profile/machine, and create/dispatch/send/reclaim flow.

This removes idle timer replay from test execution. It does not change production timing, screenshots/video behavior, sharding, concurrency, test selection, or assertions. The device-dispatch sibling still checks the 999ms/1ms retry boundary.

## Validation

- Same Node 26.5.0 runtime, normal UI E2E wrapper: both cases passed; execution 38.032s before and 7.162s after. The affected case fell from 36.348s to 5.493s. This is focused execution time, not a whole-suite claim.
- Final cloud plus device-dispatch run: all 15 cases passed; cloud file execution 6.744s.
- Temporary production mutation clearing the retained catalog at retry exhaustion failed the original selected-machine label assertion. Restored original source before final proof.
- Installed Playwright clock source confirms fastForward runs existing timers at the destination once. The next retry is scheduled only after the preceding request failure, so each interval remains separate.
- Independent Codex autoreview clean; changed-file gate and exact-head hosted CI required before landing.

Production LOC delta: 0. Test delta: +1/-1. The canonical retry owner and all public behavior remain unchanged. No changelog needed.
