### PR TITLE
test(ui): reuse cold-open probes for sidebar inventory

### DIFF
--- a/ui/src/e2e/chat-sidebar-panel-contract.e2e.test.ts
+++ b/ui/src/e2e/chat-sidebar-panel-contract.e2e.test.ts
@@ -360,11 +360,6 @@ async function readColdOpenOutcome(page: Page): Promise<ColdOpenOutcome> {
   };
 }
 
-async function offeredLabels(page: Page, scenario: ControlUiMockGatewayScenario) {
-  const choices = await openColdSidebar(page, scenario);
-  return choices.locator(".side-panel-type-option__label").allTextContents();
-}
-
 async function readSlotColdOpenOutcome(
   label: OfferedSlotLabel,
   scenario: ControlUiMockGatewayScenario,
@@ -374,6 +369,10 @@ async function readSlotColdOpenOutcome(
   try {
     const page = await context.newPage();
     const choices = await openColdSidebar(page, scenario);
+    expect(
+      await choices.locator(".side-panel-type-option__label").allTextContents(),
+      `${label} cold-open offered slots`,
+    ).toEqual(offeredSlotLabels);
     await choices.filter({ hasText: label }).click();
     if (expectedOutcome) {
       await expect
@@ -723,17 +722,6 @@ suite.define(() => {
   });
 
   it("renders content for every offered slot with backing data", async () => {
-    const probeContext = await suite.newBrowserContext({ serviceWorkers: "block" });
-    try {
-      const offered = await offeredLabels(
-        await probeContext.newPage(),
-        populatedColdOpenScenario(),
-      );
-      expect(offered).toEqual(offeredSlotLabels);
-    } finally {
-      await suite.closeBrowserContext(probeContext);
-    }
-
     for (const label of offeredSlotLabels) {
       expect(
         await readSlotColdOpenOutcome(label, populatedColdOpenScenario(), "content"),
@@ -743,14 +731,6 @@ suite.define(() => {
   });
 
   it("keeps generic empty states actionable or explicitly allowlisted", async () => {
-    const probeContext = await suite.newBrowserContext({ serviceWorkers: "block" });
-    try {
-      const offered = await offeredLabels(await probeContext.newPage(), coldOpenScenario());
-      expect(offered).toEqual(offeredSlotLabels);
-    } finally {
-      await suite.closeBrowserContext(probeContext);
-    }
-
     const observedActionlessEmptyStates: OfferedSlotLabel[] = [];
     for (const label of offeredSlotLabels) {
       const outcome = await readSlotColdOpenOutcome(label, coldOpenScenario());


### PR DESCRIPTION
## Summary

The sidebar contract tests launched two inventory-only browser contexts, then repeated the same cold-open flow in sixteen isolated per-slot contexts. Move the complete offered-slot inventory assertion into every per-slot cold-open probe and delete the two redundant boots.

All seven cases, sixteen isolated slot probes, content/empty-state expectations, lazy-load checks, retained Browser/Desktop lifecycle coverage and cleanup remain. The inventory assertion now runs more often and still runs before selecting a slot. No production, sharding, concurrency or selection changes.

## Validation

- Same normal UI E2E wrapper and Node 26.5.0: seven cases passed; execution 21.139s before, 17.889s after, and 18.374s on the final repeat. This is focused execution time, not whole-suite time.
- All 15 sidebar-region component cases passed.
- Temporarily hiding Browser in the production available-slot list failed the moved inventory assertion in both populated and sparse scenarios, before clicking any slot. Original source restored before final validation.
- Independent Codex autoreview clean. Changed-file gate and exact-head hosted CI required before landing.

The sidebar definition owner and selector renderer still supply one complete ordered inventory. Only duplicate fixture setup is removed. Production LOC delta: 0. Test delta: +4/-24. No changelog needed.
