### PR TITLE
test(voice): compare large audio buffers natively

### DIFF
--- a/extensions/discord/src/voice/realtime-playback.test.ts
+++ b/extensions/discord/src/voice/realtime-playback.test.ts
@@ -445,7 +445,7 @@ defineDiscordVoiceTests(
       output.on("data", (chunk: Buffer) => received.push(chunk));
       await finished(output);
 
-      expect(Buffer.concat(received)).toEqual(Buffer.concat(expected));
+      expect(Buffer.concat(received).equals(Buffer.concat(expected))).toBe(true);
       expect(player.play).toHaveBeenCalledOnce();
       expect(player.stop).not.toHaveBeenCalled();
       expect(realtimeSessionMock.handleBargeIn).not.toHaveBeenCalled();

--- a/extensions/google/index.test.ts
+++ b/extensions/google/index.test.ts
@@ -627,7 +627,10 @@ describe("google provider plugin hooks", () => {
     signalRealtimeBridgeReady();
 
     expect(loaded.sendAudio).toHaveBeenCalledTimes(2);
-    expect(loaded.sendAudio.mock.calls[0]?.[0]).toEqual(Buffer.alloc(512 * 1024, 0x02));
+    const retainedAudio = loaded.sendAudio.mock.calls[0]?.[0];
+    expect(
+      Buffer.isBuffer(retainedAudio) && retainedAudio.equals(Buffer.alloc(512 * 1024, 0x02)),
+    ).toBe(true);
     expect(loaded.sendAudio.mock.calls[1]?.[0]).toEqual(Buffer.from([0x03]));
   });
 


### PR DESCRIPTION
## Summary

Two voice tests deeply compare large copied buffers in JavaScript: Google's retained 512KiB lazy input and Discord's fully drained 1.3MB provider burst. Use native Buffer.equals for the same full-byte and length comparisons, retaining the Google Buffer-type check.

No fixture size, ordering, byte cap, copying, real stream/backpressure, playback or cleanup assertion is removed. The separate real 6.8-second Opus/Discord player integration is unchanged. No production, sharding, concurrency or selection changes.

## Validation

- Same normal wrapper and Node 26.5.0: Google 29 passing cases, execution 0.726s to 0.285s; Discord 18 passing cases, 1.351s to 0.262s. These are focused execution measurements, not whole-suite claims.
- Full Google and Discord suites plus the real Opus playback integration pass.
- Four temporary production mutations (last-byte corruption and wrong queue order, independently in each owner) all fail the new equality assertions. Source restored before final proof.
- Installed Node Buffer.equals validates length and compares every byte natively; no hashes, sampling or identity comparison.
- Independent Codex autoreview clean; changed-file gate and exact-head hosted CI required before landing.

Production LOC delta: 0. Test delta: +5/-2. No new helpers or changelog needed.
