### PR TITLE
fix(macos): prevent premature catalog frame-limit test failures

### DIFF
--- a/apps/macos/Tests/OpenClawIPCTests/MacNodeCodexThreadCatalogTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/MacNodeCodexThreadCatalogTests.swift
@@ -204,13 +204,28 @@ struct MacNodeCodexThreadCatalogTests {
     }
 
     private func openFIFOForWriting(_ url: URL) async throws -> FileHandle {
-        let handle = try await Task.detached {
-            try FileHandle(forWritingTo: url)
-        }.value
-        // The FIFO reader is a spawned fake child; if it exits before the exit
-        // gate write, an unsuppressed SIGPIPE kills the whole test harness.
-        try TestProcessSupport.suppressSIGPIPE(handle)
-        return handle
+        while true {
+            try Task.checkCancellation()
+            let descriptor = Darwin.open(url.path, O_WRONLY | O_NONBLOCK | O_CLOEXEC)
+            if descriptor >= 0 {
+                let handle = FileHandle(fileDescriptor: descriptor, closeOnDealloc: true)
+                do {
+                    try Task.checkCancellation()
+                    // The FIFO reader is a spawned fake child; if it exits before the
+                    // gate write, an unsuppressed SIGPIPE kills the whole test harness.
+                    try TestProcessSupport.suppressSIGPIPE(handle)
+                    return handle
+                } catch {
+                    try? handle.close()
+                    throw error
+                }
+            }
+            let openError = errno
+            guard openError == ENXIO || openError == EINTR else {
+                throw NSError(domain: NSPOSIXErrorDomain, code: Int(openError))
+            }
+            try await Task.sleep(for: .milliseconds(10))
+        }
     }
 
     private func requestEmptyList(
@@ -1429,7 +1444,6 @@ extension MacNodeCodexThreadCatalogTests {
         printf '{"id":%s,"result":{"data":[]}}\n' "$warmup_id"
         IFS= read -r first || exit 4
         first_id=$(printf '%s\n' "$first" | /usr/bin/sed -E 's/.*"id":([0-9]+).*/\1/')
-        printf 'ready\n' > "${0}.first-started"
         IFS= read -r _ < "${0}.response-gate"
         printf '{"id":%s,"result":{"data":[]}}\n' "$first_id"
         IFS= read -r second || exit 5
@@ -1438,31 +1452,65 @@ extension MacNodeCodexThreadCatalogTests {
         printf '{"id":%s,"result":{"data":[],"padding":"%s"}}\n' "$second_id" "$padding"
         IFS= read -r _ || exit 0
         """#)
+        defer { withExtendedLifetime(fake) {} }
         let client = CodexAppServerThreadClient(idleTimeoutSeconds: 10)
-        _ = try await self.requestEmptyList(client: client, executable: fake.executable)
+        do {
+            _ = try await self.requestEmptyList(client: client, executable: fake.executable)
 
-        let first = Task {
-            try await self.requestEmptyList(
-                client: client,
-                executable: fake.executable,
-                maxLineBytes: 1024)
-        }
-        #expect(await self.waitForFile(
-            URL(fileURLWithPath: fake.executable.path + ".first-started")))
-        let second = Task {
-            try await self.requestEmptyList(
-                client: client,
-                executable: fake.executable,
-                maxLineBytes: 64)
-        }
-
-        let responseGate = try await self.openFIFOForWriting(
-            URL(fileURLWithPath: fake.executable.path + ".response-gate"))
-        try responseGate.write(contentsOf: Data("respond\n".utf8))
-        try responseGate.close()
-        _ = try await first.value
-        await #expect(throws: MacNodeCodexThreadCatalog.CatalogError.responseTooLarge) {
-            try await second.value
+            let readiness = Task {
+                try await self.openFIFOForWriting(
+                    URL(fileURLWithPath: fake.executable.path + ".response-gate"))
+            }
+            let first = Task {
+                defer { readiness.cancel() }
+                return try await self.requestEmptyList(
+                    client: client,
+                    executable: fake.executable,
+                    maxLineBytes: 1024)
+            }
+            defer {
+                readiness.cancel()
+                first.cancel()
+            }
+            do {
+                // Acquiring the writer witnesses the first request reaching the fake's
+                // reader, without a separate deadline starting before queue admission.
+                let responseGate: FileHandle
+                do {
+                    responseGate = try await readiness.value
+                } catch is CancellationError {
+                    _ = try await first.value
+                    // A response before FIFO readiness is a fixture failure too.
+                    throw CancellationError()
+                }
+                defer { try? responseGate.close() }
+                let second = Task {
+                    try await self.requestEmptyList(
+                        client: client,
+                        executable: fake.executable,
+                        maxLineBytes: 64)
+                }
+                defer { second.cancel() }
+                do {
+                    try responseGate.write(contentsOf: Data("respond\n".utf8))
+                    try responseGate.close()
+                    _ = try await first.value
+                    await #expect(throws: MacNodeCodexThreadCatalog.CatalogError.responseTooLarge) {
+                        try await second.value
+                    }
+                } catch {
+                    second.cancel()
+                    _ = await second.result
+                    throw error
+                }
+            } catch {
+                first.cancel()
+                _ = await first.result
+                throw error
+            }
+        } catch {
+            await client.shutdown()
+            throw error
         }
         await client.shutdown()
     }


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where the native catalog frame-limit test could fail its readiness assertion under scheduling delay even though the first request succeeded and the next request correctly rejected an oversized response. The reported serial native run failed only the `first-started` marker expectation at `d53f57c3d25059244376b5a799b89b8756b240ea`.

## Why This Change Was Made

The test already had a response FIFO, but still started a separate marker deadline before its first task reached the client's serial queue. The request's own timeout starts inside queue admission. Successful FIFO-writer acquisition now establishes that the fake server has consumed the first request and reached its response gate before the second request is created.

The shared test-only FIFO helper uses cancellable nonblocking opens, and first-request completion cancels readiness so an early server failure is reported rather than leaving a blocking open behind. SIGPIPE protection and owned descriptor, task, fake-server, and client cleanup remain explicit.

Warmup, the two-second request timeout, the **1024 → 64** frame-limit transition, the throwing first-request success check, and the exact `responseTooLarge` expectation remain intact. No production code, queue hooks, dependency settings, or SwiftPM backend configuration changes are included. Increasing the marker timeout or moving the old blocking FIFO open earlier would not repair the causal/failure-aware readiness boundary.

The marker originated in [Codex App Server client reuse](https://github.com/openclaw/openclaw/pull/116325), authored and merged by @vincentkoc, and was retained by the later FIFO/warmup conversion in [session provenance and native fixture cleanup](https://github.com/openclaw/openclaw/pull/130986), authored and merged by @steipete. This is a test-fixture synchronization repair, not a Codex protocol-defect claim.

## User Impact

No runtime behavior changes. Native verification no longer imposes an unrelated pre-admission readiness deadline, without relaxing the frame-size or request-timeout contracts.

Production LOC: **+0 / −0**. Tests/test support: **+79 / −31 (net +48)**.

## Evidence

Reported pre-fix evidence: the serial native run on disposable macOS 26.6.2 / Swift 6.4 failed only the two-second `first-started` marker expectation; the first request succeeded and the second produced the expected `responseTooLarge`. The case took 4.444 seconds, which does not identify the delayed phase. The test/client originals are unchanged between the reported revision and the checked main baseline.

Completed source checks:

- `swiftformat --lint --cache ignore --config config/swiftformat apps/macos/Tests/OpenClawIPCTests/MacNodeCodexThreadCatalogTests.swift` (SwiftFormat 0.62.1)
- `node scripts/check-no-conflict-markers.mjs`
- `git diff --check`
- Fresh Codex autoreview of the uncommitted patch: P0-scoped `scoped-clean`, no findings (source review only)

Required exact-head CI is **green**: [run 33252731903, attempt 1](https://github.com/openclaw/openclaw/actions/runs/33252731903), including `macos-swift`, `macos-node`, and the Actions-owned [`openclaw/ci-gate`](https://github.com/openclaw/openclaw/actions/runs/33252731903/job/99109291708), at `a1272b232cb34b0f4f229d3403ae608f4b1503ed`.

Native evidence was independently read from the completed job logs:

- [Parallel native job](https://github.com/openclaw/openclaw/actions/runs/33252731903/job/99101179127): target case passed in **0.137 seconds**, catalog suite in **12.764 seconds**; **1,888 app tests / 196 suites** and **1,497 shared tests / 116 suites** passed.
- [Hosted serial native job](https://github.com/openclaw/openclaw/actions/runs/33253792826/job/99104070424): target case passed in **0.353 seconds**, catalog suite in **17.155 seconds**; the same **1,888 app tests** and **1,497 shared tests** passed. Serial mode was verified in the log; this does not claim an exact replay of the original execution order.

Both use the existing repository CI/native build-engine configuration selected by the maintainer. No workflow, runner, backend, or timeout setting was changed.

The broader hosted fallback [run 33253792826](https://github.com/openclaw/openclaw/actions/runs/33253792826) failed non-native baseline checks: Chromium fixture preregistration, a missing real ripgrep prerequisite for offline native-grep tests, and schema-version fixture assertions. The schema-test mismatch is already repaired on main by [16367468 — track current agent schema in eligibility checks](https://github.com/openclaw/openclaw/commit/16367468a7edce977360becc72443943d805593d). The browser fixture and hosted-ripgrep prerequisite are recorded as separate follow-ups, not added to this PR. The maintainer explicitly selected native-only landing on the successful required PR gate; the broader fallback is not represented as green and no gate bypass is used.

Local proof gap: no local native test or diagnostic control executed. The initial supplemental macOS 26.6 / Swift 6.3.3 VM failed to build the unchanged baseline on missing SwiftUI macro plugins. A verified Swift 6.4 payload was then prepared, but Parallels could not launch that guest bootstrap; a boot-runner alternative could not clone the active/suspended templates without disturbing their owners. All task-created VMs were cleaned up. The proposed controlled scheduling, early-exit, timeout, and frame-size sensitivity checks remain unexecuted; source review is not presented as runtime proof.

Follow-up outside this patch: audit the remaining marker-based timeout/cancellation readiness cases separately. Second-task creation preserves the existing queue scenario; this patch does not add a production queue-admission test seam.

AI-assisted.
