### PR TITLE
fix(ui): stop child-session error refetch churn

### DIFF
--- a/ui/src/components/session-data-controller.ts
+++ b/ui/src/components/session-data-controller.ts
@@ -378,18 +378,18 @@ export class SessionDataController implements ReactiveController, SessionCatalog
     this.scroll.update(element);
   }
 
-  private resetChildSessionState(options: { preserveActiveLineage?: boolean } = {}): void {
+  private resetChildSessionState(preserveOperatorContext = false): void {
     this.childSessionGeneration += 1;
-    this.childSessionRowsByParent = options.preserveActiveLineage
+    this.childSessionRowsByParent = preserveOperatorContext
       ? preserveActiveSessionLineageRows(
           this.activeSessionLineageRouteKey,
           this.childSessionRowsByParent,
         )
       : {};
     this.loadedChildSessionKeys = new Set();
-    this.childSessionErrorsByParent = new Map();
     this.loadingChildSessionKeys = new Set();
-    if (options.preserveActiveLineage !== true) {
+    if (!preserveOperatorContext) {
+      this.childSessionErrorsByParent = new Map();
       this.activeSessionLineageRoot = null;
       this.activeSessionLineageSelectedRow = null;
       this.activeSessionLineageRouteKey = null;
@@ -417,9 +417,9 @@ export class SessionDataController implements ReactiveController, SessionCatalog
           ? preserveRosterPresentationMetadata(canonical, previous)
           : (previous ?? null);
       }
-      // The canonical root list advances after session events, but excludes hidden children.
-      // Drop child snapshots so expanded parents refetch live terminal state.
-      this.resetChildSessionState({ preserveActiveLineage: true });
+      // Canonical root changes invalidate successful child snapshots, not operator-owned failures.
+      // Expanded parents refetch only when no failure blocks them.
+      this.resetChildSessionState(true);
       this.notify();
     }
     const snapshot = sessions.state;
@@ -597,8 +597,7 @@ export class SessionDataController implements ReactiveController, SessionCatalog
       if (generation !== this.childSessionGeneration || sessions !== this.context?.sessions) {
         return;
       }
-      // Stop the expanded-row update loop. A canonical list revision or an
-      // explicit collapse/reopen clears the failure and retries the whole page set.
+      // Stop the expanded-row update loop until the operator chooses Retry or collapse/reopen.
       this.childSessionRowsByParent = {
         ...this.childSessionRowsByParent,
         [parentKey]: this.childSessionRowsByParent[parentKey] ?? [],

--- a/ui/src/e2e/child-session-load-errors.e2e.test.ts
+++ b/ui/src/e2e/child-session-load-errors.e2e.test.ts
@@ -1,0 +1,132 @@
+import { expect, it } from "vitest";
+import {
+  captureUiProof,
+  controlUiSessionUrl,
+  createSessionManagementE2eSuite,
+  installMockGateway,
+  sessionRow,
+  sessionsListResponse,
+} from "./session-management.test-support.ts";
+
+const suite = createSessionManagementE2eSuite(true);
+
+suite.define(() => {
+  it("keeps one failed child load and alert until the operator retries", async () => {
+    const mainKey = "agent:main:main";
+    const parentKey = "agent:main:parent";
+    const childKey = "agent:worker:child";
+    const unrelatedKey = "agent:main:unrelated";
+    const rootRows = () =>
+      sessionsListResponse([
+        sessionRow(mainKey, "Main", 30),
+        sessionRow(parentKey, "Parent task", 20, { childSessions: [childKey] }),
+        sessionRow(unrelatedKey, "Unrelated active task", 10),
+      ]);
+    const childFailure = {
+      __mockError: {
+        code: "UNAVAILABLE",
+        message: "Child sessions unavailable",
+      },
+    };
+    const childResponse = sessionsListResponse([
+      sessionRow(childKey, "Recovered child", 40, { spawnedBy: parentKey }),
+    ]);
+    const context = await suite.browser.newContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1280 },
+    });
+    const page = await context.newPage();
+    const gateway = await installMockGateway(page, {
+      methodResponses: {
+        "sessions.list": {
+          cases: [
+            { match: { spawnedBy: parentKey }, response: childFailure },
+            { response: rootRows() },
+          ],
+        },
+      },
+      sessionKey: mainKey,
+    });
+
+    try {
+      await page.goto(controlUiSessionUrl(suite.server.baseUrl, mainKey));
+      const parent = page.locator(`[data-session-key="${parentKey}"]`);
+      await parent.waitFor({ state: "visible", timeout: 10_000 });
+      await page.evaluate(() => {
+        const marker = { insertions: 0 };
+        Object.assign(globalThis, { childSessionAlertMarker: marker });
+        new MutationObserver((records) => {
+          for (const record of records) {
+            for (const node of record.addedNodes) {
+              if (!(node instanceof Element)) {
+                continue;
+              }
+              if (node.matches('[role="alert"]')) {
+                marker.insertions += 1;
+              }
+              marker.insertions += node.querySelectorAll('[role="alert"]').length;
+            }
+          }
+        }).observe(document.body, { childList: true, subtree: true });
+      });
+      await parent.locator(`[data-child-session-toggle="${parentKey}"]`).click();
+
+      const alert = page.locator(`[data-child-session-error="${parentKey}"]`);
+      await alert.waitFor({ state: "visible" });
+      const mountedAlert = await alert.elementHandle();
+      const childRequestCount = async () =>
+        (await gateway.getRequests("sessions.list")).filter(
+          (request) =>
+            typeof request.params === "object" &&
+            request.params !== null &&
+            "spawnedBy" in request.params &&
+            request.params.spawnedBy === parentKey,
+        ).length;
+      expect(await childRequestCount()).toBe(1);
+      await captureUiProof(page, "child-session-load-error.png");
+
+      for (let revision = 1; revision <= 3; revision += 1) {
+        const listRequests = (await gateway.getRequests("sessions.list")).length;
+        await gateway.emitGatewayEvent("sessions.changed", {
+          key: unrelatedKey,
+          reason: "run",
+          sessionKey: unrelatedKey,
+          updatedAt: 30 + revision,
+        });
+        await expect
+          .poll(async () => (await gateway.getRequests("sessions.list")).length)
+          .toBeGreaterThan(listRequests);
+        expect(await childRequestCount()).toBe(1);
+        expect(await alert.count()).toBe(1);
+        expect(await alert.evaluate((node, original) => node === original, mountedAlert)).toBe(
+          true,
+        );
+      }
+      expect(
+        await page.evaluate(
+          () =>
+            (
+              globalThis as typeof globalThis & {
+                childSessionAlertMarker: { insertions: number };
+              }
+            ).childSessionAlertMarker.insertions,
+        ),
+      ).toBe(1);
+
+      await gateway.setMethodResponse("sessions.list", {
+        cases: [
+          { match: { spawnedBy: parentKey }, response: childResponse },
+          { response: rootRows() },
+        ],
+      });
+      await alert.getByRole("button", { name: "Retry" }).click();
+      await page.getByText("Recovered child", { exact: true }).waitFor();
+      expect(await childRequestCount()).toBe(2);
+      expect(await alert.count()).toBe(0);
+      await captureUiProof(page, "child-session-load-recovered.png");
+    } finally {
+      await context.close();
+    }
+  });
+});

--- a/ui/src/test-helpers/app-sidebar-cases/child-session-errors.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/child-session-errors.ts
@@ -55,6 +55,13 @@ describe("AppSidebar child-session load errors", () => {
         expect(alert?.getAttribute("role")).toBe("alert");
         expect(alert?.textContent).toContain(visibleError);
       });
+      const mountedAlert = sidebar.querySelector(`[data-child-session-error="${parentKey}"]`);
+      harness.publishList({
+        result: sessionResult([{ ...parentSession(parentKey, childKey), updatedAt: 2 }]),
+      });
+      await sidebar.updateComplete;
+      expect(harness.list).toHaveBeenCalledOnce();
+      expect(sidebar.querySelector(`[data-child-session-error="${parentKey}"]`)).toBe(mountedAlert);
       if (failure !== visibleError) {
         expect(sidebar.textContent).not.toContain(failure);
       }

--- a/ui/src/test-helpers/app-sidebar-cases/child-sessions.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/child-sessions.ts
@@ -297,7 +297,7 @@ describe("AppSidebar agent chip", () => {
     );
   });
 
-  it("retries an incomplete child page set after the canonical list advances", async () => {
+  it("retries an incomplete child page set only after the operator retries", async () => {
     const gateway = createGateway({} as GatewayBrowserClient);
     const harness = createSessionsHarness("main", ["agent:main:parent"]);
     const page = (sessions: SessionsListResult["sessions"], hasMore: boolean) => ({
@@ -357,6 +357,13 @@ describe("AppSidebar agent chip", () => {
     );
 
     publishParent(11);
+    await sidebar.updateComplete;
+    expect(harness.list).toHaveBeenCalledTimes(2);
+    expect(sidebar.querySelector('[data-child-session-error="agent:main:parent"]')).not.toBeNull();
+
+    sidebar
+      .querySelector<HTMLButtonElement>('[data-retry-child-sessions="agent:main:parent"]')
+      ?.click();
     await waitForFast(() => expect(harness.list).toHaveBeenCalledTimes(3));
     await waitForFast(() =>
       expect(sidebar.querySelectorAll(".sidebar-recent-session--child")).toHaveLength(2),


### PR DESCRIPTION
Fixes #128920

## Problem

- A failed child-session list request records a visible error and stops automatic loading.
- An unrelated canonical session-list revision cleared that error.
- The expanded row then fetched again and inserted a new `role="alert"` node.
- Busy sessions could repeat this cycle for every canonical refresh.

## Root cause

`SessionDataController.resetChildSessionState()` treated Gateway-derived child snapshots and the operator-visible failed-load decision as the same reset scope. Canonical root revisions must invalidate successful child snapshots, but they do not own a retry decision for an unrelated rejected child request.

## Fix

- Preserve parent-scoped child-load errors across canonical revisions.
- Keep full scope, capability, filter, and Gateway lifecycle resets clearing retired errors.
- Clear a current error only when the operator selects Retry or collapses and reopens the parent.
- Keep incomplete page failures visible until the same explicit retry boundary.

## Proof

Chromium used the real Control UI source flow with a mocked Gateway WebSocket. The same scenario failed on `de969147e7f3ba404e20d8f9966b97f1981e5f17` and passed on `f859021ed286a4456061bbb15a5713fd9ec9cc05`.

| Scenario | Before | After |
| --- | --- | --- |
| Three unrelated canonical revisions after one failed child load | 4 child requests and 4 alert insertions | 1 child request and 1 stable alert insertion |
| Select Retry after the Gateway recovers | Recovery depended on the latest automatic cycle | Exactly 1 new request, alert removed, child rendered |

## Validation

- Focused child-session tests: 15 passed.
- Full sidebar suite: 311 passed.
- Mocked-Gateway Chromium regression: 1 passed.
- Formatting, Oxlint, Stylelint, max-lines, assertion-safety, dead-code, dependency, i18n, and boundary checks passed.
- Production code: 8 added, 9 removed lines.

Reported by @aniruddhaadak80.
