### PR TITLE
perf(build): load the plugin compiler only for actual builds

### DIFF
--- a/scripts/lib/plugin-npm-runtime-build.mts
+++ b/scripts/lib/plugin-npm-runtime-build.mts
@@ -2,7 +2,6 @@
 import fs from "node:fs";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
-import { build } from "tsdown";
 import {
   collectPluginSourceEntries,
   collectTopLevelPublicSurfaceEntries,
@@ -396,6 +395,7 @@ export async function buildPluginNpmRuntime(params: PluginNpmRuntimeBuildParams)
     return null;
   }
 
+  const { build } = await import("tsdown");
   assertRealOutputRoot(plan.outDir);
   fs.rmSync(plan.outDir, { recursive: true, force: true });
   await build({


### PR DESCRIPTION
## Summary

The plugin runtime CLI eagerly imports tsdown even when it only prints help or prepares already-built artifacts for native imports. Its 18-case native-import suite launches 26 CLI processes, only four of which compile anything.

Load tsdown inside the existing async build owner after a build plan is found and before the output-root guard and removal. This removes compiler startup from preparation without changing any compilation options, artifacts, linking policy, or validation. No new helper, dependency, configuration, sharding, concurrency or selection change. Production/tooling LOC delta: +1/-1; test delta: 0.

## Validation

- Same normal wrapper and Node 26.5.0; all 18 cases pass before and after. Initial execution 11.040s to9.436s. Two alternating repeats after the full build:13.492s to10.711s and17.172s to13.493s (about21% less in each pair). Absolute timings vary with host load; these are focused execution measurements, not whole-suite claims.
- All27 native-import, argument-parsing and bulk-build sibling cases pass, including actual ESM/CommonJS builds/imports, unchanged artifact hashes/mtimes and negative containment cases.
- Real CLI probe with a Node module hook that rejects tsdown: help and preparation pass; an actual build fails before deleting the existing output. Restoring the eager import makes both help and preparation fail. Original candidate restored afterward.
- Full local build passed (including63 external plugin builds); no ineffective-dynamic-import warning. Local changed-file gate passed. Independent Codex autoreview clean.

No user-facing behavior or compatibility changes; existing parser, plan owner, output guard, compiler and preparation paths remain canonical. No changelog needed for internal tooling performance.
