### PR TITLE
perf(tooling): filter boundary records before scanning references

### DIFF
--- a/scripts/plugin-boundary-report.ts
+++ b/scripts/plugin-boundary-report.ts
@@ -366,11 +366,12 @@ export function isPluginCompatEligibleForRemoval(
 }
 
 function collectCompatDebt(
+  records: readonly PluginCompatRecord[],
   files: readonly WorkspaceTextFile[],
   today = new Date(),
   options: { includeReferenceFiles?: boolean } = {},
 ): CompatDebtRecord[] {
-  return listPluginCompatRecords()
+  return records
     .filter((record) => record.status === "deprecated")
     .map((record) => {
       const tokens = extractCompatTokens(record);
@@ -403,10 +404,11 @@ function collectCompatDebt(
 }
 
 function collectRemovalPendingDebt(
+  records: readonly PluginCompatRecord[],
   files: readonly WorkspaceTextFile[],
   today = new Date(),
 ): RemovalPendingDebtRecord[] {
-  return listPluginCompatRecords()
+  return records
     .filter((record) => record.status === "removal-pending")
     .map((record) => {
       const references = collectReferenceFiles(files, extractCompatSurfaceTokens(record));
@@ -456,10 +458,6 @@ function collectMemoryHostBoundary(
     sourceBridgeFiles: sourceBridgeFiles.toSorted(),
     packageCoreReferenceFiles: [...packageCoreReferenceFiles].toSorted(),
   };
-}
-
-function matchesOwner(owner: string | undefined, value: string | undefined): boolean {
-  return owner === undefined || value === owner;
 }
 
 function countByOwner(records: readonly CompatDebtRecord[]): Record<string, number> {
@@ -533,15 +531,16 @@ function buildSummary(report: BoundaryReport, owner?: string): BoundaryReportSum
 }
 
 function buildReport(options: Partial<Pick<CliOptions, "owner" | "summary">> = {}): BoundaryReport {
+  const records = listPluginCompatRecords().filter(
+    (record) => options.owner === undefined || record.owner === options.owner,
+  );
   const files = options.summary
     ? collectSummaryWorkspaceTextFileSources()
     : collectWorkspaceTextFileSources();
-  const compatRecords = collectCompatDebt(files, new Date(), {
+  const compatRecords = collectCompatDebt(records, files, new Date(), {
     includeReferenceFiles: !options.summary,
-  }).filter((record) => matchesOwner(options.owner, record.owner));
-  const removalPending = collectRemovalPendingDebt(files).filter((record) =>
-    matchesOwner(options.owner, record.owner),
-  );
+  });
+  const removalPending = collectRemovalPendingDebt(records, files);
   return {
     generatedAt: new Date().toISOString(),
     compat: {


### PR DESCRIPTION
## Summary

An owner-filtered plugin boundary report scans every compatibility record across the workspace before throwing away records belonging to other owners. Select the requested records once before the two debt collectors, so they only do reference and history work needed by the requested report.

Global SDK and memory boundary sections still scan the same workspace. Unfiltered reports retain every record. Remove the now-unused owner helper; production/tooling delta +10/-11, tests unchanged. No caching, new options, dependencies, sharding, concurrency or test selection changes.

## Validation

- Same normal test wrapper and Node 26.5.0: all four existing tests pass; execution 21.488s before, 6.899s and 6.918s after. These are focused execution times, not whole-suite claims.
- Eight real reports compared before/after: full and summary, each unfiltered or filtered to channel, SDK or an unknown owner. Exact JSON, exit codes and stderr match after excluding only the generated timestamp. Global sections remain identical; owner subsets and unknown-owner emptiness independently checked.
- Deliberately including every record fails the unknown-owner assertion; excluding every record fails the unfiltered assertion. Candidate restored and all four tests rerun successfully.
- Local changed-file gate passed; independent Codex autoreview clean.

Existing CLI/report contracts are unchanged. No changelog required for internal tooling performance.
