### PR TITLE
feat(ui): show exact active run IDs in debug overlay

### DIFF
--- a/ui/src/e2e/debug-active-runs.e2e.test.ts
+++ b/ui/src/e2e/debug-active-runs.e2e.test.ts
@@ -1,0 +1,101 @@
+import { mkdir } from "node:fs/promises";
+import path from "node:path";
+import { expect, it } from "vitest";
+import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
+import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
+
+const suite = createControlUiE2eSuite({
+  name: "Control UI Debug active run IDs mocked Gateway E2E",
+  startServerBeforeBrowser: true,
+  unavailableMessage: (executablePath) => `Playwright Chromium is unavailable at ${executablePath}`,
+});
+
+const captureUiProof = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
+const proofDir = path.resolve(".artifacts/control-ui-e2e/control-ui-debug-active-runs");
+
+suite.define(() => {
+  it("reads exact active run IDs back from the Debug overlay", async () => {
+    if (captureUiProof) {
+      await mkdir(path.join(proofDir, "video"), { recursive: true });
+    }
+    await suite.withPage(
+      {
+        locale: "en-US",
+        serviceWorkers: "block",
+        viewport: { height: 900, width: 1280 },
+        ...(captureUiProof
+          ? {
+              recordVideo: {
+                dir: path.join(proofDir, "video"),
+                size: { height: 900, width: 1280 },
+              },
+            }
+          : {}),
+      },
+      async ({ page }) => {
+        const gateway = await installMockGateway(page, {
+          methodResponses: {
+            "diagnostics.lanes": { lanes: [], dynamic: null },
+            "sessions.list": {
+              sessions: [
+                {
+                  activeRunIds: ["run-primary", "run-observer"],
+                  hasActiveRun: true,
+                  sessionId: "session-diagnostics",
+                },
+              ],
+            },
+            status: {},
+            "system.info": {},
+          },
+        });
+
+        const response = await page.goto(`${suite.server.baseUrl}debug`);
+        expect(response?.status()).toBe(200);
+        await page.locator(".page-title", { hasText: "Debug" }).waitFor();
+        const sessionsRequestCount = (await gateway.getRequests("sessions.list")).length;
+        await page.evaluate(() => {
+          window.dispatchEvent(new CustomEvent("openclaw:debug-overlay-request"));
+        });
+        await gateway.waitForRequest("sessions.list", { after: sessionsRequestCount });
+
+        const overlay = page.locator(".debug-overlay");
+        await overlay.waitFor();
+        const activeRuns = overlay.locator(".debug-overlay__section", {
+          has: page.getByRole("heading", { name: "Active runs" }),
+        });
+        await expect.poll(() => activeRuns.textContent()).toContain("2 active");
+        await expect.poll(() => activeRuns.textContent()).toContain("run-primary");
+        await expect.poll(() => activeRuns.textContent()).toContain("run-observer");
+        const rows = activeRuns.locator("li");
+        expect(await rows.count()).toBe(2);
+        expect(await rows.nth(0).getAttribute("title")).toBe("session-diagnostics / run-primary");
+        expect(await rows.nth(1).getAttribute("title")).toBe("session-diagnostics / run-observer");
+        expect(
+          (await gateway.getRequests("sessions.list")).at(sessionsRequestCount)?.params,
+        ).toEqual({});
+        expect(
+          await overlay.evaluate((element) => element.scrollWidth <= element.clientWidth),
+        ).toBe(true);
+
+        if (captureUiProof) {
+          await overlay.screenshot({
+            animations: "disabled",
+            path: path.join(proofDir, "active-run-ids-desktop.png"),
+          });
+        }
+
+        await page.setViewportSize({ height: 844, width: 390 });
+        expect(
+          await overlay.evaluate((element) => element.scrollWidth <= element.clientWidth),
+        ).toBe(true);
+        if (captureUiProof) {
+          await overlay.screenshot({
+            animations: "disabled",
+            path: path.join(proofDir, "active-run-ids-mobile.png"),
+          });
+        }
+      },
+    );
+  });
+});

--- a/ui/src/e2e/debug-active-runs.e2e.test.ts
+++ b/ui/src/e2e/debug-active-runs.e2e.test.ts
@@ -11,11 +11,12 @@ const suite = createControlUiE2eSuite({
 });
 
 const captureUiProof = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
-const proofDir = path.resolve(".artifacts/control-ui-e2e/control-ui-debug-active-runs");
 
 suite.define(() => {
   it("reads exact active run IDs back from the Debug overlay", async () => {
+    const proofDir = captureUiProof ? suite.artifactDir : "";
     if (captureUiProof) {
+      // suite.artifactDir is exclusive per retry/process, so fixed capture names stay isolated.
       await mkdir(path.join(proofDir, "video"), { recursive: true });
     }
     await suite.withPage(

--- a/ui/src/pages/debug/debug-overlay-sections.ts
+++ b/ui/src/pages/debug/debug-overlay-sections.ts
@@ -72,6 +72,12 @@ export type DebugOverlayStatusSample = {
 type ActiveSession = {
   key?: string;
   sessionId?: string;
+  activeRunIds?: string[];
+};
+
+type ActiveRunRow = {
+  sessionId: string;
+  runId?: string;
 };
 
 function renderLanes(diagnostics: CommandLaneDiagnostics): TemplateResult {
@@ -218,16 +224,26 @@ function renderStatus(
 }
 
 function renderActiveRuns(sessions: ActiveSession[]): TemplateResult {
+  const rows: ActiveRunRow[] = [];
+  for (const session of sessions) {
+    const sessionId = session.sessionId ?? session.key ?? t("common.unknown");
+    if (session.activeRunIds?.length) {
+      rows.push(...session.activeRunIds.map((runId) => ({ sessionId, runId })));
+    } else {
+      rows.push({ sessionId });
+    }
+  }
   return html`
     <div class="debug-overlay__count">
-      ${t("debug.overlay.activeRunsCount", { count: String(sessions.length) })}
+      ${t("debug.overlay.activeRunsCount", { count: String(rows.length) })}
     </div>
     ${
-      sessions.length > 0
+      rows.length > 0
         ? html`<ul class="debug-overlay__list">
-            ${sessions.map((session) => {
-              const id = session.sessionId ?? session.key ?? t("common.unknown");
-              return html`<li class="mono" title=${id}>${truncateUtf16Safe(id, 32)}</li>`;
+            ${rows.map((row) => {
+              const label =
+                row.runId === undefined ? row.sessionId : `${row.sessionId} / ${row.runId}`;
+              return html`<li class="mono" title=${label}>${truncateUtf16Safe(label, 64)}</li>`;
             })}
           </ul>`
         : html`<div class="debug-overlay__empty">${t("debug.overlay.noActiveRuns")}</div>`

--- a/ui/src/pages/debug/view.test.ts
+++ b/ui/src/pages/debug/view.test.ts
@@ -471,7 +471,19 @@ describe("DebugOverlay", () => {
         return { disks: sampleCount % 2 ? disks : disks.toReversed() };
       }
       if (method === "sessions.list") {
-        return { sessions: [] };
+        return {
+          sessions: [
+            {
+              sessionId: "session-diagnostics",
+              hasActiveRun: true,
+              activeRunIds: ["run-primary", "run-observer"],
+            },
+            {
+              sessionId: "session-runtime-owner",
+              hasActiveRun: true,
+            },
+          ],
+        };
       }
       return diagnosticResponse(method);
     });
@@ -496,6 +508,14 @@ describe("DebugOverlay", () => {
       expect(normalizedText(overlay.querySelector(".debug-overlay__vital--cpu"))).toContain(
         "loop 42%",
       );
+      const activeRuns = [...overlay.querySelectorAll(".debug-overlay__section")].find(
+        (section) => section.querySelector("h3")?.textContent.trim() === "Active runs",
+      );
+      expect(normalizedText(activeRuns)).toContain("3 active");
+      expect(normalizedText(activeRuns)).toContain("session-diagnostics");
+      expect(normalizedText(activeRuns)).toContain("run-primary");
+      expect(normalizedText(activeRuns)).toContain("run-observer");
+      expect(normalizedText(activeRuns)).toContain("session-runtime-owner");
       expect(overlay.querySelector(".debug-vital__chart")).toBeNull();
 
       await vi.advanceTimersByTimeAsync(2_000);


### PR DESCRIPTION
Closes #132572

## What Problem This Solves

The Control UI Debug overlay reports that a session is active but discards the exact `activeRunIds` already returned by `sessions.list`. Operators therefore cannot correlate the overlay with run-specific diagnostics, logs, or terminal state when a session has multiple active runs.

## Why This Change Was Made

The Debug overlay now renders one row for each exact, visibility-filtered run ID and shows the owning session beside it. When the Gateway reports aggregate activity without exact identities, the overlay retains the existing session-only fallback instead of guessing a run ID.

The existing-solutions preflight found no plugin, maintained library, or external platform that can repair this core Control UI renderer. The Gateway already owns and documents the required data contract, so this change consumes the existing seam without adding an API, configuration option, dependency, or parallel activity model.

The owner boundary is `ui/src/pages/debug/debug-overlay-sections.ts`. The caller remains the existing Debug overlay loader, and the callee remains the existing `sessions.list` Gateway method. Sibling clients keep their current `activeRunIds` handling; no Gateway or protocol behavior changes.

## User Impact

Operators can open the Debug overlay and read the exact active run IDs for each visible session. Multiple runs in one session are counted and listed separately, full values remain available in tooltips, and identity-unavailable activity still appears as a session-only row.

There are no config/default, protocol/schema, storage/migration, compatibility, permission, or security changes. The UI only displays IDs that the current Gateway client is already authorized to receive.

Known limitation: this is a current-state diagnostic view. It does not add run history, attention state, cancellation controls, or a broader activity API.

## Evidence

Exact head: `e31f580136425d7379c0e1e92d7f7bd3d0054f53`

### Inspectable after-fix visual proof

The focused UI E2E built and served the exact-head bundled production Control UI, opened `/debug` in Chromium, issued `sessions.list {}` through the page-level mocked Gateway protocol boundary, and read back two exact run IDs. The mock boundary is limited to Gateway data; the production bundle, router, request path, renderer, responsive layout, screenshots, and video are real.

Desktop viewport (`1280x900`), overlay capture `560x444`:

[![Desktop Debug overlay showing run-primary and run-observer](https://files.catbox.moe/unzs7n.png)](https://files.catbox.moe/unzs7n.png)

Mobile viewport (`390x844`), overlay capture `374x572`:

[![Mobile Debug overlay showing run-primary and run-observer](https://files.catbox.moe/oprpaq.png)](https://files.catbox.moe/oprpaq.png)

- [Browser recording (WebM)](https://files.catbox.moe/kgflax.webm)
- [Human-readable proof summary](https://files.catbox.moe/y93og3.md)
- [Machine-readable receipt with exact assertions and SHA-256 hashes](https://files.catbox.moe/nwo66o.json)

### Commands and checks

- Acceptance red on current `main`: with the new fixture but before the production change, the focused overlay test rendered `1 active` plus only `session-diagnostics`; assertions for `run-primary` and `run-observer` failed.
- `node scripts/run-vitest.mjs ui/src/pages/debug/view.test.ts` on Node 24.15.0: 12 passed. The test covers two exact IDs and the session-only fallback for an active runtime owner whose IDs are unavailable.
- `OPENCLAW_CAPTURE_UI_PROOF=1 node scripts/run-vitest.mjs ui/src/e2e/debug-active-runs.e2e.test.ts` on Node 24.15.0: 1 file passed, 1 test passed. It verified `2 active`, both exact IDs, two full session/run tooltip labels, `{}` request parameters, and no horizontal overflow at desktop and mobile sizes.
- Exact-head production Vite build: `corepack pnpm --dir ui exec vite build --configLoader runner` passed; built asset `debug-overlay-CzQHhdeh.js`, SHA-256 `b4762592a8808a2254aebcbba2a78f5e05ea851ec157c525dfd5a08ad7450174`.
- Visual artifact SHA-256: desktop `a4ff0ec77936232e2c6f3d3eeaaa4156b33e74045d243677664cef715e3813d5`; mobile `d78681dd9f3413767f5ce3d5b18f794771000b61edd4276b8bf6d6d89b1b772b`; video `b8a87560c37e09a2fede8c4681b7cfc57468ff0916f1e3e85048b27f77255770`.
- [Exact-head CI run 33253466910](https://github.com/openclaw/openclaw/actions/runs/33253466910): passed.
- `node_modules/.bin/oxfmt --check ui/src/pages/debug/debug-overlay-sections.ts ui/src/pages/debug/view.test.ts ui/src/e2e/debug-active-runs.e2e.test.ts`: passed.
- `git diff --check upstream/main...HEAD`: passed.
- Fresh commit-mode autoreview: Findings=None, patch correct, confidence 0.90.
- UI typecheck was attempted but the shared dependency checkout is stale relative to current `main`; it fails across unrelated packages (`@openclaw/fs-safe`, `markdown-it`, `p-limit`, and others) without reporting an error in these three changed files.

Scope: 3 files. Production `+21/-5`; tests `+122/-1`. No generated files, lockfiles, or proof assets are included.

AI disclosure: implemented and reviewed with OpenAI Codex assistance.
