### PR TITLE
fix(line): handle each event with the config that is live for it

### DIFF
--- a/extensions/line/src/bot-handlers.ts
+++ b/extensions/line/src/bot-handlers.ts
@@ -85,7 +85,10 @@ interface LineHandlerContext {
   mediaMaxBytes: number;
   processMessage: (
     ctx: LineInboundContext,
-    control: { turnAdoptionLifecycle?: LineWebhookTurnAdoptionLifecycle },
+    control: {
+      cfg: OpenClawConfig;
+      turnAdoptionLifecycle?: LineWebhookTurnAdoptionLifecycle;
+    },
   ) => Promise<void>;
   turnAdoptionLifecycle?: LineWebhookTurnAdoptionLifecycle;
   groupHistories?: Map<string, HistoryEntry[]>;
@@ -472,10 +475,12 @@ async function handleMessageEvent(event: MessageEvent, context: LineHandlerConte
       return;
     }
 
-    await processMessage(
-      messageContext,
-      context.turnAdoptionLifecycle ? { turnAdoptionLifecycle: context.turnAdoptionLifecycle } : {},
-    );
+    await processMessage(messageContext, {
+      cfg,
+      ...(context.turnAdoptionLifecycle
+        ? { turnAdoptionLifecycle: context.turnAdoptionLifecycle }
+        : {}),
+    });
     historyReservation.commit();
   } finally {
     historyReservation.release();
@@ -566,10 +571,12 @@ async function handlePostbackEvent(
     return;
   }
 
-  await context.processMessage(
-    postbackContext,
-    context.turnAdoptionLifecycle ? { turnAdoptionLifecycle: context.turnAdoptionLifecycle } : {},
-  );
+  await context.processMessage(postbackContext, {
+    cfg: context.cfg,
+    ...(context.turnAdoptionLifecycle
+      ? { turnAdoptionLifecycle: context.turnAdoptionLifecycle }
+      : {}),
+  });
 }
 
 export async function handleLineWebhookEvents(

--- a/extensions/line/src/bot.config-reload.test.ts
+++ b/extensions/line/src/bot.config-reload.test.ts
@@ -101,19 +101,29 @@ describe("the config a delivered LINE event is handled with", () => {
     expect(handled.historyLimit).toBe(75);
   });
 
-  it("keeps a config of its own rather than the process-global one", async () => {
-    // A monitor handed a config that is not what the process loaded owns it; a
-    // scoped or test monitor must not be hijacked by an unrelated global reload.
-    const ownConfig = configWithHistoryLimit(10);
-    setRuntimeConfigSnapshot(configWithHistoryLimit(33), configWithHistoryLimit(33));
-    const bot = createDeliverableBot(ownConfig);
+  // A monitor handed a config that is not what the process loaded owns it; a
+  // scoped or test monitor must not be hijacked by an unrelated global reload.
+  // Not every runtime snapshot carries the source it was built from - a pinned
+  // load publishes the config alone - and that is the case where the shared
+  // selector answers with the runtime config for any input at all.
+  it.each([
+    { label: "against a snapshot that carries its source", withSource: true },
+    { label: "against a snapshot published without its source", withSource: false },
+  ])(
+    "keeps a config of its own rather than the process-global one, $label",
+    async ({ withSource }) => {
+      const ownConfig = configWithHistoryLimit(10);
+      const startupRuntime = configWithHistoryLimit(33);
+      setRuntimeConfigSnapshot(startupRuntime, ...(withSource ? [startupRuntime] : []));
+      const bot = createDeliverableBot(ownConfig);
 
-    setRuntimeConfigSnapshot(configWithHistoryLimit(75), configWithHistoryLimit(75));
-    const handled = await bot.deliverOnce();
+      setRuntimeConfigSnapshot(configWithHistoryLimit(75), configWithHistoryLimit(75));
+      const handled = await bot.deliverOnce();
 
-    expect(handled.cfg).toBe(ownConfig);
-    expect(handled.historyLimit).toBe(10);
-  });
+      expect(handled.cfg).toBe(ownConfig);
+      expect(handled.historyLimit).toBe(10);
+    },
+  );
 
   it("keeps the account's own history limit ahead of the reloaded shared default", async () => {
     const startupConfig = {

--- a/extensions/line/src/bot.config-reload.test.ts
+++ b/extensions/line/src/bot.config-reload.test.ts
@@ -1,0 +1,138 @@
+// Line tests cover which config a delivered LINE event is handled with.
+import type { webhook } from "@line/bot-sdk";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import {
+  clearRuntimeConfigSnapshot,
+  setRuntimeConfigSnapshot,
+} from "openclaw/plugin-sdk/runtime-config-snapshot";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+type DeliverFn = (
+  event: webhook.Event,
+  destination: string,
+  control: Record<string, unknown>,
+) => Promise<void>;
+
+const { createLineWebhookSpoolMock, handleLineWebhookEventsMock } = vi.hoisted(() => ({
+  createLineWebhookSpoolMock: vi.fn(),
+  handleLineWebhookEventsMock: vi.fn(
+    async (_events: webhook.Event[], _context: { cfg: OpenClawConfig; historyLimit: number }) => {},
+  ),
+}));
+
+vi.mock("./webhook-spool.js", () => ({
+  createLineWebhookSpool: createLineWebhookSpoolMock,
+}));
+vi.mock("./bot-handlers.js", () => ({
+  handleLineWebhookEvents: handleLineWebhookEventsMock,
+}));
+
+const { createLineBot } = await import("./bot.js");
+
+function configWithHistoryLimit(historyLimit: number): OpenClawConfig {
+  return {
+    channels: {
+      line: { enabled: true, channelAccessToken: "test-token", channelSecret: "test-secret" },
+    },
+    messages: { groupChat: { historyLimit } },
+  } as OpenClawConfig;
+}
+
+// The bot only reveals the config it chose by handing it to the handlers, so
+// build one, then drive the spool's deliver callback and read what they were
+// given. Creation and delivery stay separate so a reload can land between them,
+// which is the only ordering the Gateway ever produces.
+function createDeliverableBot(startupConfig: OpenClawConfig): {
+  deliverOnce: () => Promise<{ cfg: OpenClawConfig; historyLimit: number }>;
+} {
+  let deliver: DeliverFn | undefined;
+  createLineWebhookSpoolMock.mockImplementation((spoolOptions: { deliver: DeliverFn }) => {
+    deliver = spoolOptions.deliver;
+    return { accept: vi.fn(), start: vi.fn(), stop: vi.fn() };
+  });
+
+  createLineBot({
+    channelAccessToken: "test-token",
+    channelSecret: "test-secret",
+    config: startupConfig,
+  });
+
+  if (!deliver) {
+    throw new Error("createLineBot did not build a spool deliver callback");
+  }
+  const deliverEvent = deliver;
+  return {
+    deliverOnce: async () => {
+      await deliverEvent({ type: "message" } as webhook.Event, "destination", {});
+      const context = handleLineWebhookEventsMock.mock.calls.at(-1)?.[1];
+      if (!context) {
+        throw new Error("handleLineWebhookEvents was not called");
+      }
+      return { cfg: context.cfg, historyLimit: context.historyLimit };
+    },
+  };
+}
+
+describe("the config a delivered LINE event is handled with", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    clearRuntimeConfigSnapshot();
+  });
+
+  afterEach(() => {
+    clearRuntimeConfigSnapshot();
+  });
+
+  it("follows a reload for a monitor the Gateway started from the process config", async () => {
+    // The real sequence: the Gateway starts the channel with the config it
+    // loaded, then a later write replaces the runtime config AND its source.
+    // `messages` changes are hot-applied without restarting the channel, so a
+    // monitor that never re-reads them keeps answering with the config it booted
+    // on for the rest of the process.
+    const startupConfig = configWithHistoryLimit(10);
+    setRuntimeConfigSnapshot(startupConfig, configWithHistoryLimit(10));
+    const bot = createDeliverableBot(startupConfig);
+
+    const reloaded = configWithHistoryLimit(75);
+    setRuntimeConfigSnapshot(reloaded, configWithHistoryLimit(75));
+    const handled = await bot.deliverOnce();
+
+    expect(handled.cfg).toBe(reloaded);
+    expect(handled.historyLimit).toBe(75);
+  });
+
+  it("keeps a config of its own rather than the process-global one", async () => {
+    // A monitor handed a config that is not what the process loaded owns it; a
+    // scoped or test monitor must not be hijacked by an unrelated global reload.
+    const ownConfig = configWithHistoryLimit(10);
+    setRuntimeConfigSnapshot(configWithHistoryLimit(33), configWithHistoryLimit(33));
+    const bot = createDeliverableBot(ownConfig);
+
+    setRuntimeConfigSnapshot(configWithHistoryLimit(75), configWithHistoryLimit(75));
+    const handled = await bot.deliverOnce();
+
+    expect(handled.cfg).toBe(ownConfig);
+    expect(handled.historyLimit).toBe(10);
+  });
+
+  it("keeps the account's own history limit ahead of the reloaded shared default", async () => {
+    const startupConfig = {
+      channels: {
+        line: {
+          enabled: true,
+          channelAccessToken: "test-token",
+          channelSecret: "test-secret",
+          historyLimit: 5,
+        },
+      },
+      messages: { groupChat: { historyLimit: 10 } },
+    } as OpenClawConfig;
+    setRuntimeConfigSnapshot(startupConfig, startupConfig);
+    const bot = createDeliverableBot(startupConfig);
+
+    setRuntimeConfigSnapshot(configWithHistoryLimit(75), configWithHistoryLimit(75));
+    const handled = await bot.deliverOnce();
+
+    expect(handled.historyLimit).toBe(5);
+  });
+});

--- a/extensions/line/src/bot.config-reload.test.ts
+++ b/extensions/line/src/bot.config-reload.test.ts
@@ -1,4 +1,3 @@
-// Line tests cover which config a delivered LINE event is handled with.
 import type { webhook } from "@line/bot-sdk";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import {
@@ -38,10 +37,7 @@ function configWithHistoryLimit(historyLimit: number): OpenClawConfig {
   } as OpenClawConfig;
 }
 
-// The bot only reveals the config it chose by handing it to the handlers, so
-// build one, then drive the spool's deliver callback and read what they were
-// given. Creation and delivery stay separate so a reload can land between them,
-// which is the only ordering the Gateway ever produces.
+// Capture the spool callback so a reload can land between creation and delivery.
 function createDeliverableBot(startupConfig: OpenClawConfig): {
   deliverOnce: () => Promise<{ cfg: OpenClawConfig; historyLimit: number }>;
 } {
@@ -84,11 +80,7 @@ describe("the config a delivered LINE event is handled with", () => {
   });
 
   it("follows a reload for a monitor the Gateway started from the process config", async () => {
-    // The real sequence: the Gateway starts the channel with the config it
-    // loaded, then a later write replaces the runtime config AND its source.
-    // `messages` changes are hot-applied without restarting the channel, so a
-    // monitor that never re-reads them keeps answering with the config it booted
-    // on for the rest of the process.
+    // `messages` reloads without restarting LINE, so the existing monitor must see it.
     const startupConfig = configWithHistoryLimit(10);
     setRuntimeConfigSnapshot(startupConfig, configWithHistoryLimit(10));
     const bot = createDeliverableBot(startupConfig);
@@ -101,11 +93,8 @@ describe("the config a delivered LINE event is handled with", () => {
     expect(handled.historyLimit).toBe(75);
   });
 
-  // A monitor handed a config that is not what the process loaded owns it; a
-  // scoped or test monitor must not be hijacked by an unrelated global reload.
-  // Not every runtime snapshot carries the source it was built from - a pinned
-  // load publishes the config alone - and that is the case where the shared
-  // selector answers with the runtime config for any input at all.
+  // A distinct supplied config is scoped. A missing source snapshot cannot prove
+  // that it belongs to the process runtime.
   it.each([
     { label: "against a snapshot that carries its source", withSource: true },
     { label: "against a snapshot published without its source", withSource: false },
@@ -124,6 +113,17 @@ describe("the config a delivered LINE event is handled with", () => {
       expect(handled.historyLimit).toBe(10);
     },
   );
+
+  it("keeps a supplied config when the process snapshot appears after startup", async () => {
+    const ownConfig = configWithHistoryLimit(10);
+    const bot = createDeliverableBot(ownConfig);
+
+    setRuntimeConfigSnapshot(configWithHistoryLimit(75), configWithHistoryLimit(75));
+    const handled = await bot.deliverOnce();
+
+    expect(handled.cfg).toBe(ownConfig);
+    expect(handled.historyLimit).toBe(10);
+  });
 
   it("keeps the account's own history limit ahead of the reloaded shared default", async () => {
     const startupConfig = {

--- a/extensions/line/src/bot.ts
+++ b/extensions/line/src/bot.ts
@@ -2,7 +2,12 @@
 import type { webhook } from "@line/bot-sdk";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { DEFAULT_GROUP_HISTORY_LIMIT, type HistoryEntry } from "openclaw/plugin-sdk/reply-history";
-import { getRuntimeConfig } from "openclaw/plugin-sdk/runtime-config-snapshot";
+import {
+  getRuntimeConfig,
+  getRuntimeConfigSnapshot,
+  getRuntimeConfigSourceSnapshot,
+  selectApplicableRuntimeConfig,
+} from "openclaw/plugin-sdk/runtime-config-snapshot";
 import {
   createNonExitingRuntime,
   logVerbose,
@@ -28,7 +33,10 @@ interface LineBotOptions {
   mediaMaxMb?: number;
   onMessage?: (
     ctx: LineInboundContext,
-    control: { turnAdoptionLifecycle?: LineWebhookTurnAdoptionLifecycle },
+    control: {
+      cfg: OpenClawConfig;
+      turnAdoptionLifecycle?: LineWebhookTurnAdoptionLifecycle;
+    },
   ) => Promise<void>;
 }
 
@@ -41,9 +49,31 @@ interface LineBot {
 export function createLineBot(opts: LineBotOptions): LineBot {
   const runtime: RuntimeEnv = opts.runtime ?? createNonExitingRuntime();
 
-  const cfg = opts.config ?? getRuntimeConfig();
+  const startupConfig = opts.config ?? getRuntimeConfig();
+  // A channel monitor outlives config reloads. Everything read here from outside
+  // `channels.line` — mention patterns, the group-chat history limit, routing
+  // bindings, the shared group-policy default — is hot-applied without restarting
+  // the channel, so each delivered event runs on the config live at that moment.
+  //
+  // Ownership is decided once, against the snapshot that was current at startup:
+  // a later reload replaces both the runtime config and its source, so asking
+  // again after one would always answer "not mine" and pin the monitor forever.
+  const startupRuntimeConfig = getRuntimeConfigSnapshot();
+  const followsRuntimeConfig =
+    !startupRuntimeConfig ||
+    startupRuntimeConfig === startupConfig ||
+    selectApplicableRuntimeConfig({
+      inputConfig: startupConfig,
+      runtimeConfig: startupRuntimeConfig,
+      runtimeSourceConfig: getRuntimeConfigSourceSnapshot(),
+    }) === startupRuntimeConfig;
+  const resolveTurnConfig = (): OpenClawConfig =>
+    (followsRuntimeConfig ? getRuntimeConfigSnapshot() : undefined) ?? startupConfig;
+  // Credentials and the account's own settings live under `channels.line`, whose
+  // changes restart the channel, so the account stays a prepared fact rather than
+  // a per-event re-read of its secret files.
   const account = resolveLineAccount({
-    cfg,
+    cfg: startupConfig,
     accountId: opts.accountId,
   });
 
@@ -66,7 +96,8 @@ export function createLineBot(opts: LineBotOptions): LineBot {
   const spool = createLineWebhookSpool({
     accountId: account.accountId,
     runtime,
-    deliver: async (event, _destination, control) =>
+    deliver: async (event, _destination, control) => {
+      const cfg = resolveTurnConfig();
       await handleLineWebhookEvents([event], {
         cfg,
         account,
@@ -82,7 +113,8 @@ export function createLineBot(opts: LineBotOptions): LineBot {
           account.config.historyLimit ??
           cfg.messages?.groupChat?.historyLimit ??
           DEFAULT_GROUP_HISTORY_LIMIT,
-      }),
+      });
+    },
   });
   spool.start();
 

--- a/extensions/line/src/bot.ts
+++ b/extensions/line/src/bot.ts
@@ -50,23 +50,15 @@ export function createLineBot(opts: LineBotOptions): LineBot {
   const runtime: RuntimeEnv = opts.runtime ?? createNonExitingRuntime();
 
   const startupConfig = opts.config ?? getRuntimeConfig();
-  // A channel monitor outlives config reloads. Everything read here from outside
-  // `channels.line` — mention patterns, the group-chat history limit, routing
-  // bindings, the shared group-policy default — is hot-applied without restarting
-  // the channel, so each delivered event runs on the config live at that moment.
-  //
-  // Ownership is decided once, against the snapshot that was current at startup:
-  // a later reload replaces both the runtime config and its source, so asking
-  // again after one would always answer "not mine" and pin the monitor forever.
+  // LINE monitors outlive reloads outside `channels.line`. Bind snapshot ownership
+  // once at startup; checking after reload would compare against the replaced source
+  // and pin a process-owned monitor to stale config.
   const startupRuntimeConfig = getRuntimeConfigSnapshot();
   const startupRuntimeSourceConfig = getRuntimeConfigSourceSnapshot();
-  // Without a source snapshot there is nothing to compare a distinct supplied
-  // config against, and the selector answers with the runtime config for any
-  // input. Taking that as ownership would hand a monitor started with its own
-  // config to unrelated process-global config on the next reload, so a scoped
-  // monitor stays with what it was started with.
+  // A snapshot without its source cannot prove that a distinct supplied config is
+  // process-owned, so keep scoped monitors pinned through later global reloads.
   const followsRuntimeConfig =
-    !startupRuntimeConfig ||
+    opts.config === undefined ||
     startupRuntimeConfig === startupConfig ||
     (startupRuntimeSourceConfig !== null &&
       selectApplicableRuntimeConfig({
@@ -76,9 +68,8 @@ export function createLineBot(opts: LineBotOptions): LineBot {
       }) === startupRuntimeConfig);
   const resolveTurnConfig = (): OpenClawConfig =>
     (followsRuntimeConfig ? getRuntimeConfigSnapshot() : undefined) ?? startupConfig;
-  // Credentials and the account's own settings live under `channels.line`, whose
-  // changes restart the channel, so the account stays a prepared fact rather than
-  // a per-event re-read of its secret files.
+  // `channels.line` changes restart the monitor, so account credentials and settings
+  // remain startup-prepared facts.
   const account = resolveLineAccount({
     cfg: startupConfig,
     accountId: opts.accountId,

--- a/extensions/line/src/bot.ts
+++ b/extensions/line/src/bot.ts
@@ -59,14 +59,21 @@ export function createLineBot(opts: LineBotOptions): LineBot {
   // a later reload replaces both the runtime config and its source, so asking
   // again after one would always answer "not mine" and pin the monitor forever.
   const startupRuntimeConfig = getRuntimeConfigSnapshot();
+  const startupRuntimeSourceConfig = getRuntimeConfigSourceSnapshot();
+  // Without a source snapshot there is nothing to compare a distinct supplied
+  // config against, and the selector answers with the runtime config for any
+  // input. Taking that as ownership would hand a monitor started with its own
+  // config to unrelated process-global config on the next reload, so a scoped
+  // monitor stays with what it was started with.
   const followsRuntimeConfig =
     !startupRuntimeConfig ||
     startupRuntimeConfig === startupConfig ||
-    selectApplicableRuntimeConfig({
-      inputConfig: startupConfig,
-      runtimeConfig: startupRuntimeConfig,
-      runtimeSourceConfig: getRuntimeConfigSourceSnapshot(),
-    }) === startupRuntimeConfig;
+    (startupRuntimeSourceConfig !== null &&
+      selectApplicableRuntimeConfig({
+        inputConfig: startupConfig,
+        runtimeConfig: startupRuntimeConfig,
+        runtimeSourceConfig: startupRuntimeSourceConfig,
+      }) === startupRuntimeConfig);
   const resolveTurnConfig = (): OpenClawConfig =>
     (followsRuntimeConfig ? getRuntimeConfigSnapshot() : undefined) ?? startupConfig;
   // Credentials and the account's own settings live under `channels.line`, whose

--- a/extensions/line/src/monitor.ts
+++ b/extensions/line/src/monitor.ts
@@ -163,12 +163,15 @@ export async function monitorLineProvider(
       }
 
       const { ctxPayload, replyToken, route } = ctx;
+      // Admission already resolved the config live for this event; the turn and
+      // its delivery run on that same one so the two can never disagree.
+      const turnConfig = deliveryControl.cfg;
 
       const shouldShowLoading = Boolean(ctx.userId && !ctx.isGroup);
 
       const stopLoading = shouldShowLoading
         ? startLineLoadingKeepalive({
-            cfg: config,
+            cfg: turnConfig,
             userId: ctx.userId!,
             accountId: ctx.accountId,
           })
@@ -204,7 +207,7 @@ export async function monitorLineProvider(
               rawText: ctxPayload.RawBody ?? ctxPayload.BodyForAgent ?? "",
             }),
             resolveTurn: () => ({
-              cfg: config,
+              cfg: turnConfig,
               channel: "line",
               accountId: route.accountId,
               route: { agentId: route.agentId, sessionKey: route.sessionKey },
@@ -228,7 +231,7 @@ export async function monitorLineProvider(
 
                   if (ctx.userId && !ctx.isGroup) {
                     void showLoadingAnimation(ctx.userId, {
-                      cfg: config,
+                      cfg: turnConfig,
                       accountId: ctx.accountId,
                     }).catch(() => {});
                   }
@@ -240,7 +243,7 @@ export async function monitorLineProvider(
                     replyToken,
                     replyTokenUsed,
                     accountId: ctx.accountId,
-                    cfg: config,
+                    cfg: turnConfig,
                     textLimit,
                     deps: {
                       buildTemplateMessageFromPayload,


### PR DESCRIPTION
## What Problem This Solves

Change `agents.entries.<id>.groupChat.mentionPatterns` while the Gateway is running and every channel starts honouring it — except LINE, which keeps answering with the config it booted on until the whole Gateway restarts.

The LINE monitor captures the config it was started with and never looks again. Everything it reads from outside `channels.line` is affected, and all of those prefixes are `kind: "none"` in `config-reload-plan.ts` — they are hot-applied without restarting the channel, so nothing else ever refreshes them for LINE:

| read | from |
| --- | --- |
| `buildMentionRegexes(cfg, agentId)` | `agents.entries.*.groupChat.mentionPatterns` |
| `historyLimit` fallback | `messages.groupChat.historyLimit` |
| `resolveDefaultGroupPolicy(cfg)` | `channels.defaults.groupPolicy` |
| `resolveAgentRoute({ cfg, … })` | `bindings`, `agents` |
| `hasControlCommand(rawText, cfg)` | command config |
| `resolvePinnedMainDmOwnerFromAllowlist` | `session.dmScope` |

Every other maintained channel already re-reads it per turn. Slack states the rule in the code: *"Channel monitors outlive config reloads; pin one live snapshot per turn without reconnecting."* Telegram calls `getRuntimeConfig()` at the top of each inbound event, Discord and WhatsApp likewise. LINE is the only one with no live read anywhere in its inbound path.

## Why This Change Was Made

`createLineBot` now resolves the applicable config once per delivered event and hands it to the handlers, and that same decision is carried into the turn through the delivery control so admission and delivery can never run on different configs.

Ownership is decided once, at startup, through the shared `selectApplicableRuntimeConfig` seam the SDK already exposes for this: a monitor the Gateway started from the process config follows reloads, a monitor handed a config of its own keeps it. **That latch is load-bearing** — my first attempt asked per turn instead, and the live run below proved it inert, because a reload replaces the runtime config *and* its source, so a later ownership question always answers "not mine". The unit test now encodes that exact ordering.

Credentials stay a prepared fact: `channels.line` changes restart the channel, so the account is resolved once instead of re-reading its secret files on every event.

Production LOC: **+61 / −19**.

## User Impact

Config the Gateway hot-applies now reaches a LINE turn. An operator who adds a mention pattern, raises the group history limit, changes the shared group-policy default, or edits a routing binding sees it take effect on the next LINE message instead of after a full Gateway restart.

## Evidence

**Live, on a real Gateway.** Isolated state dir and port 18795, LINE channel configured, group event injected with a valid signature over the real webhook route. Same config file, same injected event, same hot reload, once per build. `starting LINE provider` stays at `1` in both runs — the channel is never restarted.

`origin/main`:

```
### 1. BEFORE
20:41:51  line: received 1 webhook events
20:41:51  line: skipping group message (requireMention, not mentioned)
### 2. added agents.entries.main.groupChat.mentionPatterns = ['openclaw']
          config hot reload applied (agents.entries.main.groupChat)
### 3. AFTER
20:42:14  line: received 1 webhook events
20:42:14  line: skipping group message (requireMention, not mentioned)     ← still ignored
```

This branch:

```
### 1. BEFORE
20:37:06  line: received 1 webhook events
20:37:06  line: skipping group message (requireMention, not mentioned)
### 2. added agents.entries.main.groupChat.mentionPatterns = ['openclaw']
          config hot reload applied (agents.entries.main.groupChat)
### 3. AFTER
20:37:28  line: received 1 webhook events
20:37:28  line inbound: from=line:group:Cprobegroup… len=142 preview="[LINE group:…"   ← admitted
```

Both builds were verified to contain the expected code before running (`followsRuntimeConfig` present in the branch bundle, absent in the baseline bundle), and the log lines are filtered to this worktree's `dist` so a sibling Gateway on the same host cannot contaminate them.

**Ownership needs the snapshot to prove it.** A runtime snapshot does not always carry the source it was built from - a pinned load publishes the config alone - and with no source the shared selector answers with the runtime config for *any* input. Treating that answer as ownership would hand a monitor started with its own config to unrelated process-global config on the next reload, so ownership now requires a startup source snapshot, the way Slack's monitor already does (`extensions/slack/src/monitor/message-handler.ts`).

Re-run of the same live A/B with that guard in place, on a Gateway built from `00c3a8f1873`, isolated state dir and port 18797:

```
### 1. BEFORE (no messages.groupChat.mentionPatterns)
22:11:06  line: received 1 webhook events
22:11:06  line: skipping group message (requireMention, not mentioned)
### 2. added messages.groupChat.mentionPatterns = ['zzq']
22:11:26  [reload] config change detected; evaluating reload (messages)
### 3. AFTER
22:12:43  line: received 1 webhook events
22:12:43  line inbound: from=line:group:Cprobegroup… len=139 preview="[LINE group:…"
22:12:43  line: received message from U…  →  [diagnostic] message queued
```

`starting LINE provider` stays at `1` and `skipping group message` appears once, in the BEFORE half only. The guard closes the hijack without costing the hot-apply the PR exists for: the Gateway starts the channel with the config it loaded, which is the same object, so ownership is settled by identity before the selector is consulted at all.

**Red↔green.** With only the three production files restored to `origin/main`:

```
FAIL extensions/line/src/bot.config-reload.test.ts > follows a reload for a monitor the Gateway started from the process config
Tests  1 failed | 2 passed (3)
```

The two that pass on both are the ownership controls: a monitor with a config of its own keeps it, and an account-level `channels.line.historyLimit` still outranks the reloaded shared default.

The ownership control is now table-driven over both snapshot shapes. Reverting just the source-snapshot guard fails the row that has no source and leaves the other three passing:

```
FAIL keeps a config of its own rather than the process-global one, 'against a snapshot published without its source'
  → expected { channels: { line: … } } to be { channels: { line: … } } // Object.is equality
Tests  1 failed | 3 passed (4)
```

Full LINE suite `Test Files 45 passed (45) · Tests 665 passed (665)`. `node scripts/check-changed.mjs` exits 0 with no failing lane, both tsgo lanes included; `check:assertion-safety` and `check:max-lines-ratchet` pass.

**Local gates.**

```
$ node scripts/run-vitest.mjs extensions/line
 Test Files  45 passed (45)
      Tests  664 passed (664)

$ node scripts/run-tsgo.mjs -p tsconfig.extensions.json --noEmit                     # EXIT=0
$ node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.extensions.test.json --noEmit  # EXIT=0
$ node scripts/check-changed.mjs                                                     # EXIT=0
$ pnpm check:assertion-safety --base origin/main
assertion SAFETY ratchet OK: 4182 files, 12946 grandfathered assertions.
$ pnpm check:max-lines-ratchet --base origin/main
max-lines ratchet OK: 882 grandfathered suppressions.
$ pnpm build                                                                         # EXIT=0 (run twice, once per side of the A/B)
```

**Sibling surfaces.** Slack, Telegram, Discord and WhatsApp already follow reloads; this brings LINE to the same behaviour without changing theirs. The ownership predicate matches Slack's, which is the only other place that guards it — if maintainers would rather see that predicate extracted into one shared SDK helper and Slack migrated onto it, say so and I will do that instead of leaving two copies.

