### PR TITLE
test(agents): use small executables for candidate count coverage

### DIFF
--- a/src/agents/bash-tools.exec-host-gateway.test.ts
+++ b/src/agents/bash-tools.exec-host-gateway.test.ts
@@ -2020,7 +2020,7 @@ describe("processGatewayAllowlist", () => {
   it.runIf(process.platform !== "win32")(
     "defers compound plans with more than 64 candidates before Guardian review",
     async () => {
-      const command = Array.from({ length: 65 }, () => "node --version").join(" && ");
+      const command = Array.from({ length: 65 }, () => "/bin/echo ok").join(" && ");
       await configurePlanBackedCommand({ command });
 
       const result = await runGatewayAllowlist({ command, ask: "on-miss", autoReview: true });


### PR DESCRIPTION
## Summary

The command-count boundary test builds65 real command candidates to check the64-candidate Guardian limit. Its fixture used Node for every candidate, repeatedly hashing a large mutable executable even though executable identity and interpreter handling are covered by separate tests.

Use the existing small POSIX utility `/bin/echo` for those65 candidates. Keep real parsing and executable binding, the POSIX guard, all65 commands, and every original approval/reviewer assertion. Production delta0; test delta +1/-1. No mocks, production changes, scheduling, sharding or coverage reduction.

## Validation

- Same normal wrapper and Node26.5.0: all110 gateway cases pass before/after. Execution9.939s to4.463s. Maximum RSS1,201,307,648 to929,153,024 bytes, measured with `/usr/bin/time -l` (focused file, not whole suite).
- Temporarily raise the production candidate limit64→65: the exact test fails because the Guardian reviewer is called, proving the lighter fixture still reaches and protects the intended boundary. Restore production bytes and rerun the full gateway file successfully.
- Existing executable-binding sibling suite passes, including real filesystem binding paths. Separate Node/interpreter/PATH cases remain unchanged.
- Local changed-file gate passed; independent Codex autoreview clean.

No user-facing behavior changes; no changelog required for a test fixture optimization.
