### PR TITLE
perf(markdown): skip code parsing without possible code markers

### DIFF
--- a/packages/markdown-core/src/code-spans.test.ts
+++ b/packages/markdown-core/src/code-spans.test.ts
@@ -90,6 +90,36 @@ describe("markdown-core code spans", () => {
       text: "    literal",
       expectedSlices: ["    literal"],
     },
+    {
+      name: "finds tilde fences without backticks",
+      text: "~~~\nliteral\n~~~",
+      expectedSlices: ["~~~\nliteral\n~~~"],
+    },
+    {
+      name: "finds tab-indented code blocks",
+      text: "\tliteral",
+      expectedSlices: ["\tliteral"],
+    },
+    {
+      name: "finds indented code inside blockquotes",
+      text: ">     literal",
+      expectedSlices: ["    literal"],
+    },
+    {
+      name: "finds indented code inside list items",
+      text: "- item\n\n      literal",
+      expectedSlices: ["    literal"],
+    },
+    {
+      name: "does not interpret short or Unicode indentation as code",
+      text: "   literal\n\n\u00a0\u00a0\u00a0\u00a0literal\n\n\u2003\u2003\u2003\u2003literal",
+      expectedSlices: [],
+    },
+    {
+      name: "does not turn HTML code tags or decoded entities into Markdown code",
+      text: "<code>literal</code>\n<pre>literal</pre>\n&#96;literal&#96;\n&Tab;literal",
+      expectedSlices: [],
+    },
   ] as const)("follows CommonMark block ownership: $name", ({ text, expectedSlices }) => {
     expectCodeRegionSlices(text, expectedSlices);
   });
@@ -115,8 +145,8 @@ describe("markdown-core code spans", () => {
   });
 
   it("walks deeply nested Markdown without exhausting the JavaScript stack", () => {
-    const input = `${"> ".repeat(10_000)}<think>x</think>`;
+    const input = `${"> ".repeat(10_000)}\`<think>x</think>\``;
 
-    expect(findMarkdownCodeSpans(input)).toEqual([]);
+    expectCodeRegionSlices(input, ["`<think>x</think>`"]);
   });
 });

--- a/packages/markdown-core/src/reasoning-tag-parser.ts
+++ b/packages/markdown-core/src/reasoning-tag-parser.ts
@@ -225,6 +225,10 @@ export function parseMarkdownOwnership(text: string): MarkdownOwnership {
 
 /** Returns parser-owned CommonMark/GFM code ranges, including their delimiters. */
 export function findMarkdownCodeSpans(text: string): Array<[number, number]> {
+  // CommonMark code needs a literal delimiter or indentation, even inside containers.
+  if (!/[`~\t]| {4}/u.test(text)) {
+    return [];
+  }
   return parseMarkdownOwnership(text).codeSpans;
 }
 


### PR DESCRIPTION
## Summary

Finding Markdown code spans fully parses every text block, including large streamed tool-call payloads with no possible Markdown code. Return an empty span list when the text has no literal backtick, tilde, tab or four consecutive ASCII spaces; retain the same full CommonMark/GFM parser for every possible code input.

The fast path belongs in the existing code-span owner, so callers in reasoning-tag stripping and tool-call repair share it. The broader ownership parser remains unchanged because its other callers need retention boundaries even for plain text. No cache, alternate parser, configuration, dependency, sharding, concurrency or test selection changes. Production +4/-0; tests +32/-2. The four production lines are the conservative prerequisite check and its invariant comment; folding it into the broader parser would incorrectly discard that parser's other outputs.

## Validation

- All 96 existing provider-stream cases retained, including their original large payloads: focused execution 10.095s before and 0.454s after using the same normal wrapper and Node 26.5.0.
- All 607 tests across 30 Markdown, tool-call repair, reasoning-tag and provider-stream files passed with their normal owning configurations.
- Temporary differential proof: 10,457 distinct inputs match the unchanged full parser, including 21 independently expected cases, 4,522 code-bearing inputs, container indentation, nested fences/lists, tabs, Unicode whitespace, entities, HTML and GFM tables. All 26,652 comparisons across four reasoning-tag stripping modes also match.
- Removing each backtick, tilde, tab or four-space condition separately causes the corresponding code-span assertions to fail. Original bytes restored and all owning/sibling tests rerun.
- Six focused contract rows cover the new prerequisite boundary. The 10,000-level nesting test now includes an inline-code tail so it continues exercising the actual AST walk.
- Local changed-file gate and full build passed; independent Codex autoreview clean.

This is a behavior-preserving internal parser optimization. Proof exercises the actual parser and provider-stream wrapper with deterministic inputs; no provider API or channel transport is changed and no live-provider request is needed. No changelog required for internal performance work.
