### PR TITLE
fix(release): bound FRV transport uncertainty

### DIFF
--- a/scripts/full-release-validation-policy.mjs
+++ b/scripts/full-release-validation-policy.mjs
@@ -26,6 +26,8 @@ const EXACT_TARGET_EVIDENCE_REUSE_POLICY = "exact-target-full-validation-v1";
 const CHANGELOG_ONLY_EVIDENCE_REUSE_POLICY = "changelog-only-release-v1";
 const HARD_GH_TRANSPORT_PATTERN =
   /HTTP (?:400|401|403|404|410|422)\b|Bad credentials|authentication required|not authenticated|gh auth login|unknown (?:command|flag)|Usage: gh\b|ENOENT|EACCES/iu;
+const RATE_LIMITED_403_PATTERN =
+  /HTTP 403\b[\s\S]*(?:rate limit|abuse detection)|(?:rate limit|abuse detection)[\s\S]*HTTP 403\b/iu;
 const TRANSIENT_GH_TRANSPORT_PATTERN =
   /HTTP 429\b|HTTP 5[0-9][0-9]\b|Server Error|secondary rate limit|API rate limit|abuse detection|error connecting to|context deadline exceeded|connection reset by peer|connection refused|TLS handshake timeout|i\/o timeout|timed out|\btimeout\b|network is unreachable|unexpected EOF|ETIMEDOUT|ECONNRESET|EAI_AGAIN/iu;
 const RELEASE_GH_ARTIFACT_MISSING_LINE_PATTERN =
@@ -218,6 +220,9 @@ function releaseGhTransportErrorText(error) {
 
 export function classifyReleaseGhTransportError(error) {
   const text = releaseGhTransportErrorText(error);
+  if (RATE_LIMITED_403_PATTERN.test(text)) {
+    return "transient";
+  }
   if (HARD_GH_TRANSPORT_PATTERN.test(text)) {
     return "hard";
   }
@@ -342,10 +347,12 @@ function compositeJobsDigestPayload(value) {
   };
 }
 
+function jsonSha256(value) {
+  return createHash("sha256").update(JSON.stringify(value)).digest("hex");
+}
+
 export function releaseCompositeJobsSha256(value) {
-  return createHash("sha256")
-    .update(JSON.stringify(canonicalValue(compositeJobsDigestPayload(value))))
-    .digest("hex");
+  return jsonSha256(canonicalValue(compositeJobsDigestPayload(value)));
 }
 
 export function composeReleaseAttemptJobs(attempts, expected = {}) {
@@ -728,9 +735,7 @@ function executionPlanDigestPayload(plan) {
 }
 
 export function releaseExecutionPlanSha256(plan) {
-  return createHash("sha256")
-    .update(JSON.stringify(executionPlanDigestPayload(plan)))
-    .digest("hex");
+  return jsonSha256(executionPlanDigestPayload(plan));
 }
 
 export function buildReleaseExecutionPlanArtifact({
@@ -936,6 +941,15 @@ function normalizeIssues(issues, fallbackKind) {
     .map((issue) => normalizeIssue(issue, fallbackKind));
 }
 
+function blockerEvidence(issue) {
+  const { message: _message, ...compact } = normalizeIssue(issue, "release_blocker");
+  return Object.fromEntries(Object.entries(compact).filter(([, value]) => value));
+}
+
+function blockerIndex(issues) {
+  return issues.map((issue) => jsonSha256(blockerEvidence(issue))).toSorted();
+}
+
 function isReleaseCheckJobAdvisory({ jobName, releaseProfile, workflowRef }) {
   if (
     jobName.startsWith("Run QA Lab parity lane (") ||
@@ -1013,41 +1027,32 @@ export function terminalPolicyPass(child, releaseProfile, workflowRef) {
   return false;
 }
 
-function dispatchMissingBlockers(children) {
-  return children
-    .filter(
-      (child) =>
-        child.required &&
-        child.selected &&
-        (!/^[1-9][0-9]*$/u.test(String(child.runId ?? "")) ||
-          positiveInteger(child.runAttempt) === undefined),
-    )
-    .map((child) => ({
-      child: child.key,
-      conclusion: stringValue(child.result, "missing"),
-      job: child.dispatchName || `Dispatch ${child.key}`,
-      kind: "dispatch_missing",
-      message: `${child.key} required dispatch did not record an exact run ID and attempt`,
-      runId: stringValue(child.runId),
-      url: stringValue(child.url),
-    }));
-}
-
-function dispatchResultBlockers(children) {
-  return children
-    .filter(
-      (child) =>
-        child.required && child.selected && child.source === "fresh" && child.result !== "success",
-    )
-    .map((child) => ({
-      child: child.key,
-      conclusion: stringValue(child.result, "missing"),
-      job: child.dispatchName || `Dispatch ${child.key}`,
-      kind: "dispatch_failed",
-      message: `${child.key} required dispatch ended with ${stringValue(child.result, "missing")}`,
-      runId: stringValue(child.runId),
-      url: stringValue(child.url),
-    }));
+function dispatchBlockers(children) {
+  return children.flatMap((child) => {
+    if (!child.required || !child.selected) {
+      return [];
+    }
+    const missing =
+      !/^[1-9][0-9]*$/u.test(String(child.runId ?? "")) ||
+      positiveInteger(child.runAttempt) === undefined;
+    if (!missing && (child.source !== "fresh" || child.result === "success")) {
+      return [];
+    }
+    const kind = missing ? "dispatch_missing" : "dispatch_failed";
+    return [
+      {
+        child: child.key,
+        conclusion: stringValue(child.result, "missing"),
+        job: child.dispatchName || `Dispatch ${child.key}`,
+        kind,
+        message: missing
+          ? `${child.key} required dispatch did not record an exact run ID and attempt`
+          : `${child.key} required dispatch ended with ${stringValue(child.result, "missing")}`,
+        runId: stringValue(child.runId),
+        url: stringValue(child.url),
+      },
+    ];
+  });
 }
 
 function releaseState(cancelled, activeRunIds, blockers, errors) {
@@ -1083,6 +1088,9 @@ export function classifyReleaseSnapshot({
       job: job.name,
       kind: "job_failure",
       message: `${child.key} job failed policy`,
+      primaryAt: stringValue(
+        job.completed_at ?? job.completedAt ?? job.started_at ?? job.startedAt,
+      ),
       runId: child.runId,
       url: job.html_url ?? job.url ?? child.url,
     })),
@@ -1105,27 +1113,31 @@ export function classifyReleaseSnapshot({
       job: "<workflow>",
       kind: "workflow_failure",
       message: `${child.key} workflow failed release policy`,
+      primaryAt: stringValue(child.updatedAt ?? child.createdAt),
       runId: child.runId,
       url: child.url,
     }));
-  const blockers = normalizeIssues(
-    [
-      ...localFailures,
-      ...extraBlockers,
-      ...dispatchMissingBlockers(selected),
-      ...dispatchResultBlockers(selected),
-      ...childJobBlockers,
-      ...terminalBlockers,
-    ],
-    "release_blocker",
-  );
+  const rawBlockers = [
+    ...localFailures,
+    ...extraBlockers,
+    ...dispatchBlockers(selected),
+    ...childJobBlockers,
+    ...terminalBlockers,
+  ];
+  const blockers = normalizeIssues(rawBlockers, "release_blocker");
   const errors = normalizeIssues([...extraErrors, ...childErrors], "orchestration_error");
 
   const activeRunIds = active.map((child) => String(child.runId)).toSorted();
+  const primary = [...childJobBlockers, ...terminalBlockers]
+    .filter((issue) => issue.primaryAt)
+    .toSorted((left, right) => String(left.primaryAt).localeCompare(String(right.primaryAt), "en"));
   return {
     activeRunIds,
+    blockerCount: rawBlockers.length,
+    blockerIndex: blockerIndex(rawBlockers),
     blockers,
     errors,
+    firstPrimaryFailure: primary[0] ? blockerEvidence(primary[0]) : null,
     state: releaseState(cancelled, activeRunIds, blockers, errors),
   };
 }
@@ -1193,6 +1205,7 @@ export function buildReleaseStateArtifact({
   mode,
   releaseProfile,
   rerunGroup,
+  transport = { status: "certain" },
 }) {
   const activeRunIds = (decision.activeRunIds ?? []).map(String);
   if (
@@ -1202,6 +1215,8 @@ export function buildReleaseStateArtifact({
   ) {
     throw new Error("release state active run IDs are malformed, duplicated, or unordered");
   }
+  const completeBlockerIndex = decision.blockerIndex ?? blockerIndex(decision.blockers ?? []);
+  const { deadlineMonotonicMs: _deadline, error: _error, ...transportEvidence } = transport;
   return {
     version: 2,
     kind:
@@ -1220,8 +1235,12 @@ export function buildReleaseStateArtifact({
     executionPlanSha256: executionPlan.sha256,
     state: decision.state,
     activeRunIds,
+    blockerCount: decision.blockerCount ?? completeBlockerIndex.length,
+    blockerIndex: completeBlockerIndex,
     blockers: decision.blockers,
     errors: decision.errors,
+    firstPrimaryFailure: decision.firstPrimaryFailure ?? null,
+    transport: transportEvidence,
     cancellation: {
       cancelledRunIds: [...(cancellation.cancelledRunIds ?? [])].map(String),
       requested: cancellation.requested === true,
@@ -1320,6 +1339,29 @@ function validateExecutionPlanChildBindings(children, payload) {
   }
 }
 
+function validateTransport(value) {
+  const affected = value?.affected;
+  if (
+    (value?.status === "certain" && Object.keys(value).length !== 1) ||
+    (value?.status !== "certain" &&
+      (!["uncertain", "expired"].includes(value?.status) ||
+        !Array.isArray(affected) ||
+        affected.length === 0 ||
+        affected.some(
+          (entry) =>
+            !entry?.child ||
+            entry.errorClass !== "transient" ||
+            !positiveInteger(entry.runAttempt) ||
+            !/^[1-9][0-9]*$/u.test(String(entry.runId)),
+        ) ||
+        !Number.isFinite(Date.parse(value.startedAt)) ||
+        !Number.isFinite(Date.parse(value.deadlineAt))))
+  ) {
+    throw new Error("release state transport is invalid");
+  }
+  return value;
+}
+
 export function validateReleaseStateArtifact(payload, expected, expectedMode) {
   const expectedValues = expected ?? {};
   if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
@@ -1359,6 +1401,37 @@ export function validateReleaseStateArtifact(payload, expected, expectedMode) {
   }
   const blockers = normalizeIssues(payload.blockers, "release_blocker");
   const errors = normalizeIssues(payload.errors, "orchestration_error");
+  const machineFields = ["blockerCount", "blockerIndex", "firstPrimaryFailure", "transport"];
+  const machineEvidence = Object.hasOwn(payload, "transport");
+  if (machineFields.some((key) => Object.hasOwn(payload, key) !== machineEvidence)) {
+    throw new Error("release state machine evidence is incomplete");
+  }
+  const completeBlockerIndex =
+    machineEvidence && Array.isArray(payload.blockerIndex)
+      ? payload.blockerIndex.map(String).toSorted()
+      : blockerIndex(blockers);
+  const firstFailure = machineEvidence ? payload.firstPrimaryFailure : null;
+  const transport = machineEvidence
+    ? validateTransport(payload.transport)
+    : payload.state === "passed"
+      ? { status: "certain" }
+      : null;
+  if (
+    (machineEvidence &&
+      (!Number.isSafeInteger(payload.blockerCount) ||
+        payload.blockerCount < 0 ||
+        payload.blockerCount !== completeBlockerIndex.length ||
+        completeBlockerIndex.some((value) => !/^[a-f0-9]{64}$/u.test(value)) ||
+        JSON.stringify(payload.blockerIndex) !== JSON.stringify(completeBlockerIndex) ||
+        (firstFailure !== null &&
+          (JSON.stringify(firstFailure) !== JSON.stringify(blockerEvidence(firstFailure)) ||
+            !completeBlockerIndex.includes(blockerIndex([firstFailure])[0]))))) ||
+    (payload.state === "passed" && transport?.status !== "certain") ||
+    (transport?.status === "expired" &&
+      !errors.some(({ kind }) => kind === "transport_deadline_exceeded"))
+  ) {
+    throw new Error("release state machine evidence is invalid");
+  }
   if (!Array.isArray(payload.activeRunIds)) {
     throw new Error("release state active run IDs are invalid");
   }
@@ -1466,11 +1539,15 @@ export function validateReleaseStateArtifact(payload, expected, expectedMode) {
   return {
     ...payload,
     activeRunIds,
+    blockerCount: machineEvidence ? payload.blockerCount : null,
+    blockerIndex: completeBlockerIndex,
     blockers,
     children,
     errors,
+    firstPrimaryFailure: firstFailure,
     parentRunAttempt: positiveInteger(payload.parentRunAttempt),
     sourceParentRunAttempt: positiveInteger(payload.sourceParentRunAttempt),
+    transport,
   };
 }
 
@@ -1614,9 +1691,22 @@ function verifyStateStructure(state, executionPlan, label) {
   if (JSON.stringify(state.activeRunIds) !== JSON.stringify(baseline.activeRunIds)) {
     throw new Error(`${label} activeRunIds differs from canonical release policy`);
   }
+  const snapshotsByKey = new Map(snapshots.map((snapshot) => [snapshot.key, snapshot]));
+  if (
+    state.transport?.affected?.some(({ child, runAttempt, runId }) => {
+      const snapshot = snapshotsByKey.get(child);
+      return snapshot?.runId !== runId || snapshot.runAttempt !== runAttempt;
+    })
+  ) {
+    throw new Error(`${label} transport provenance differs from exact child state`);
+  }
   for (const key of ["blockers", "errors"]) {
-    const claimed = new Set(state[key].map((issue) => JSON.stringify(issue)));
-    if (baseline[key].some((issue) => !claimed.has(JSON.stringify(issue)))) {
+    const indexed = key === "blockers" && state.blockerCount !== null;
+    const claimed = new Set(
+      (indexed ? state.blockerIndex : state[key]).map((issue) => JSON.stringify(issue)),
+    );
+    const required = indexed ? baseline.blockerIndex : baseline[key];
+    if (required.some((issue) => !claimed.has(JSON.stringify(issue)))) {
       throw new Error(`${label} omits baseline ${key}`);
     }
   }
@@ -1636,6 +1726,7 @@ function verifyStateTransition(decision, drain) {
         child === "<evidence>" && ["reused_evidence_invalid", "provenance_mismatch"].includes(kind),
     );
   if (
+    drain.transport?.status === "uncertain" ||
     ["qualifying", "blocked_diagnostics_running"].includes(drain.state) ||
     decision.state === "qualifying" ||
     (decision.state === "passed" && drain.state === "blocked_complete") ||

--- a/scripts/full-release-validation-state.d.mts
+++ b/scripts/full-release-validation-state.d.mts
@@ -1,29 +1,33 @@
+import type { ReleaseRecord } from "./full-release-validation-policy.mjs";
 export * from "./full-release-validation-policy.mjs";
 export function validateChildBinding(
-  child: Record<string, unknown>,
-  run: Record<string, unknown>,
-  composite: Record<string, unknown>,
-): Record<string, unknown>;
+  child: ReleaseRecord,
+  run: ReleaseRecord,
+  composite: ReleaseRecord,
+): ReleaseRecord;
 export function readChild(
-  child: Record<string, unknown>,
-  previous: Record<string, unknown> | undefined,
+  child: ReleaseRecord,
+  previous: ReleaseRecord | undefined,
   signal?: AbortSignal,
   options?: {
     readAttemptJobs?: (
       runId: string,
       runAttempt: number,
       signal?: AbortSignal,
-    ) => Promise<Record<string, unknown>[]>;
-    readRun?: (runId: string, signal?: AbortSignal) => Promise<Record<string, unknown>>;
-    transientGracePolls?: number;
+    ) => Promise<ReleaseRecord[]>;
+    readRun?: (runId: string, signal?: AbortSignal) => Promise<ReleaseRecord>;
   },
-): Promise<Record<string, unknown>>;
-export function parsePlanInputs(value: string): Record<string, unknown>;
-export function hydrateReusedPlan(
-  plan: Record<string, unknown>[],
-  evidence: Record<string, unknown>,
-): Record<string, unknown>[];
-export function formatReleaseStateHeartbeat(
-  mode: string,
-  decision: Record<string, unknown>,
-): string;
+): Promise<ReleaseRecord>;
+export function releaseGhRetryDelayMs(
+  attempt: number,
+  deadlineMonotonicMs?: number,
+  nowMonotonicMs?: number,
+): number;
+export function updateReleaseTransportEpisode(
+  previous: ReleaseRecord | undefined,
+  children: ReleaseRecord[],
+  options?: { deadline?: number; monotonicNow?: number; wallNow?: number },
+): ReleaseRecord;
+export function parsePlanInputs(value: string): ReleaseRecord;
+export function hydrateReusedPlan(plan: ReleaseRecord[], evidence: ReleaseRecord): ReleaseRecord[];
+export function formatReleaseStateHeartbeat(mode: string, decision: ReleaseRecord): string;

--- a/scripts/full-release-validation-state.mjs
+++ b/scripts/full-release-validation-state.mjs
@@ -42,8 +42,9 @@ const API_ERROR_PATTERN =
   /HTTP [45][0-9][0-9]|API|Bad credentials|rate limit|network|connection|timeout|ETIMEDOUT|ECONNRESET|EAI_AGAIN/u;
 const DEFAULT_POLL_INTERVAL_MS = 60_000;
 const DEFAULT_HEARTBEAT_INTERVAL_MS = 5 * 60_000;
-const DEFAULT_TRANSIENT_READ_GRACE_POLLS = 2;
 const GH_TIMEOUT_MS = 60_000;
+const TRANSPORT_UNCERTAINTY_MS = 15 * 60_000;
+let ghRetryDeadline;
 
 function stringValue(value, fallback = "") {
   return typeof value === "string" ? value : fallback;
@@ -89,6 +90,13 @@ async function abortableSleep(milliseconds, signal) {
   }
 }
 
+const deadlineDelayMs = (delay, deadline, now) =>
+  Number.isFinite(deadline) ? Math.max(0, Math.min(delay, deadline - now)) : delay;
+
+export function releaseGhRetryDelayMs(attempt, deadlineMonotonicMs, nowMonotonicMs) {
+  return deadlineDelayMs(Math.min(attempt * 10_000, 60_000), deadlineMonotonicMs, nowMonotonicMs);
+}
+
 async function runGh(args, options = {}) {
   const attempts = options.attempts ?? 6;
   let lastError;
@@ -111,7 +119,11 @@ async function runGh(args, options = {}) {
       if (attempt === attempts || classifyReleaseGhTransportError(error) !== "transient") {
         throw error;
       }
-      await abortableSleep(Math.min(attempt * 10_000, 60_000), options.signal);
+      const delay = releaseGhRetryDelayMs(attempt, ghRetryDeadline, performance.now());
+      if (delay === 0) {
+        throw error;
+      }
+      await abortableSleep(delay, options.signal);
     }
   }
   throw lastError;
@@ -191,12 +203,8 @@ export async function readChild(child, previous, signal, options = {}) {
     return { ...child, errors: [], jobs: [], status: "skipped" };
   }
   if (!child.runId || !child.runAttempt) {
-    return {
-      ...child,
-      errors: [issue("dispatch_missing", child, `${child.key} omitted its exact run identity`)],
-      jobs: [],
-      status: "missing",
-    };
+    const error = issue("dispatch_missing", child, `${child.key} omitted its exact run identity`);
+    return { ...child, errors: [error], jobs: [], status: "missing" };
   }
   try {
     const run = options.readRun
@@ -226,11 +234,19 @@ export async function readChild(child, previous, signal, options = {}) {
       if (attempts.slice(0, -1).some((attempt) => attempt.jobs.length === 0)) {
         throw new Error(`${child.key} child attempt evidence is gapped`);
       }
-      return validateChildBinding(child, run, {
+      const partial = validateChildBinding(child, run, {
         jobs: [],
         observedRunAttempts: [],
         sha256: "",
       });
+      return (previous?.compositeJobsSha256 || previous?.transportFailure) &&
+        partial.errors.length === 0
+        ? {
+            ...previous,
+            conclusion: stringValue(run.conclusion),
+            status: stringValue(run.status),
+          }
+        : partial;
     }
     const evidence = composeReleaseChildAttemptEvidence({
       attempts,
@@ -247,14 +263,7 @@ export async function readChild(child, previous, signal, options = {}) {
       sha256: evidence.compositeJobsSha256,
     });
   } catch (error) {
-    const transientReadFailures = Number(previous?.transientReadFailures ?? 0) + 1;
-    const transientGracePolls =
-      Number.isSafeInteger(options.transientGracePolls) && options.transientGracePolls >= 0
-        ? options.transientGracePolls
-        : DEFAULT_TRANSIENT_READ_GRACE_POLLS;
-    const degraded =
-      classifyReleaseGhTransportError(error) === "transient" &&
-      transientReadFailures <= transientGracePolls;
+    const degraded = classifyReleaseGhTransportError(error) === "transient";
     const provenanceMismatch =
       error instanceof Error && error.message.startsWith("release child provenance changed:");
     const readError = issue(
@@ -262,33 +271,61 @@ export async function readChild(child, previous, signal, options = {}) {
       child,
       `${child.key} GitHub read failed: ${error instanceof Error ? error.message : String(error)}`,
     );
-    if (degraded) {
-      console.warn(
-        `${child.key} GitHub read degraded (${transientReadFailures}/${transientGracePolls}); preserving the last snapshot`,
-      );
-    }
+    ghRetryDeadline ??= degraded ? performance.now() + TRANSPORT_UNCERTAINTY_MS : undefined;
     return {
       ...child,
-      conclusion: stringValue(previous?.conclusion),
-      createdAt: stringValue(previous?.createdAt),
+      ...previous,
       errors: degraded
         ? (previous?.errors ?? []).filter((entry) => entry.kind === "provenance_mismatch")
         : [
             ...(previous?.errors ?? []).filter((entry) => entry.kind === "provenance_mismatch"),
             readError,
           ],
-      jobs: previous?.jobs ?? [],
-      compositeJobsSha256: stringValue(previous?.compositeJobsSha256),
-      observedRunAttempts: previous?.observedRunAttempts ?? [],
-      plannedRunAttempt: positiveInteger(
-        previous?.plannedRunAttempt ?? child.runAttempt,
-        "planned run attempt",
-      ),
-      status: degraded ? "read_degraded" : stringValue(previous?.status, "unknown"),
-      transientReadFailures,
-      updatedAt: stringValue(previous?.updatedAt),
+      status: degraded ? "transport_uncertain" : stringValue(previous?.status, "unknown"),
+      transportFailure: degraded ? { errorClass: "transient" } : undefined,
     };
   }
+}
+
+export function updateReleaseTransportEpisode(previous, children, options = {}) {
+  const monotonicNow = options.monotonicNow ?? performance.now();
+  const wallNow = options.wallNow ?? Date.now();
+  const uncertain = children.filter((child) => child.transportFailure?.errorClass === "transient");
+  const affected = uncertain
+    .map((child) => ({
+      child: child.key,
+      compositeJobsSha256: stringValue(child.compositeJobsSha256),
+      errorClass: "transient",
+      lastValidAt: stringValue(child.updatedAt),
+      runAttempt: child.runAttempt,
+      runId: String(child.runId),
+    }))
+    .toSorted((left, right) => left.child.localeCompare(right.child, "en"));
+  if (affected.length === 0) {
+    return { status: "certain" };
+  }
+  const deadline = options.deadline ?? ghRetryDeadline ?? monotonicNow + TRANSPORT_UNCERTAINTY_MS;
+  const wallStart = wallNow + deadline - monotonicNow - TRANSPORT_UNCERTAINTY_MS;
+  const episode = previous?.deadlineMonotonicMs
+    ? previous
+    : {
+        deadlineAt: new Date(wallStart + TRANSPORT_UNCERTAINTY_MS).toISOString(),
+        deadlineMonotonicMs: deadline,
+        startedAt: new Date(wallStart).toISOString(),
+      };
+  return {
+    ...episode,
+    affected,
+    error:
+      monotonicNow >= episode.deadlineMonotonicMs
+        ? issue(
+            "transport_deadline_exceeded",
+            { key: "<collector>" },
+            `GitHub transport remained uncertain; affected ${affected.map((child) => `${child.child}:${child.runId}:${child.runAttempt}`).join(",")}`,
+          )
+        : undefined,
+    status: monotonicNow >= episode.deadlineMonotonicMs ? "expired" : "uncertain",
+  };
 }
 
 export function parsePlanInputs(value) {
@@ -751,6 +788,7 @@ async function collectMode(mode) {
   let finished = false;
   const abortController = new AbortController();
   let decisionReuse = { blockers: [], children: plan, errors: [] };
+  let transport = { status: "certain" };
 
   const writePayload = (decision, cancellation = {}) => {
     const payload = buildReleaseStateArtifact({
@@ -762,6 +800,7 @@ async function collectMode(mode) {
       mode,
       releaseProfile,
       rerunGroup,
+      transport,
     });
     writeResult(outputPath, payload);
     appendSummary(mode, payload);
@@ -778,6 +817,7 @@ async function collectMode(mode) {
       extraBlockers: executionPlan.blockers,
       extraErrors: [
         ...executionPlan.errors,
+        ...(transport.error ? [transport.error] : []),
         {
           child: "<collector>",
           kind: "collector_cancelled",
@@ -854,13 +894,16 @@ async function collectMode(mode) {
 
   let nextHeartbeat = 0;
   while (!finished) {
+    ghRetryDeadline = transport.deadlineMonotonicMs;
     snapshots = await Promise.all(
       plan.map((child, index) => readChild(child, snapshots[index], abortController.signal)),
     );
+    transport = updateReleaseTransportEpisode(transport, snapshots);
+    const transportReadErrors = transport.error ? [transport.error] : [];
     let decision = classifyReleaseSnapshot({
       children: snapshots,
       extraBlockers: [...executionPlan.blockers, ...decisionReuse.blockers],
-      extraErrors: [...executionPlan.errors, ...decisionReuse.errors],
+      extraErrors: [...transportReadErrors, ...executionPlan.errors, ...decisionReuse.errors],
       localFailures: gateFailures,
       releaseProfile,
       workflowRef: expected.workflowRef,
@@ -884,7 +927,12 @@ async function collectMode(mode) {
             ...decisionReuse.blockers,
             ...decision.blockers,
           ],
-          extraErrors: [...executionPlan.errors, ...decisionReuse.errors, ...cancellationErrors],
+          extraErrors: [
+            ...transportReadErrors,
+            ...executionPlan.errors,
+            ...decisionReuse.errors,
+            ...cancellationErrors,
+          ],
           localFailures: gateFailures,
           releaseProfile,
           workflowRef: expected.workflowRef,
@@ -893,9 +941,11 @@ async function collectMode(mode) {
     }
     const done =
       mode === "decision"
-        ? decision.state !== "qualifying"
-        : decision.state === "orchestration_error" ||
-          (decision.state !== "qualifying" && decision.activeRunIds.length === 0);
+        ? decision.state !== "qualifying" &&
+          !(decision.state === "passed" && transport.status === "uncertain")
+        : transport.status !== "uncertain" &&
+          (decision.state === "orchestration_error" ||
+            (decision.state !== "qualifying" && decision.activeRunIds.length === 0));
     if (done) {
       const payload = writePayload(decision, { cancelledRunIds, requested: false });
       finished = true;
@@ -903,7 +953,10 @@ async function collectMode(mode) {
         payload.state === "passed" ? 0 : payload.state === "orchestration_error" ? 2 : 1;
       return;
     }
-    await abortableSleep(pollIntervalMs, abortController.signal);
+    await abortableSleep(
+      deadlineDelayMs(pollIntervalMs, transport.deadlineMonotonicMs, performance.now()),
+      abortController.signal,
+    );
   }
 }
 

--- a/test/scripts/full-release-validation-state.test.ts
+++ b/test/scripts/full-release-validation-state.test.ts
@@ -6,6 +6,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import {
   composeReleaseAttemptJobs,
   isReleaseGhArtifactMissingError,
+  MAX_RELEASE_ARTIFACT_BYTES,
   releaseExecutionPlanSha256,
 } from "../../scripts/full-release-validation-policy.mjs";
 import {
@@ -17,12 +18,15 @@ import {
   classifyReleaseSnapshot,
   formatReleaseStateOutcome,
   readChild,
+  releaseGhRetryDelayMs,
   releaseStateChildEvidence,
+  serializeReleaseArtifact,
   selectReleaseStateArtifacts,
   validateChildBinding,
   validateReleaseExecutionPlanArtifact,
   validateReleaseStateArtifact,
   verifyReleaseStateArtifacts,
+  updateReleaseTransportEpisode,
 } from "../../scripts/full-release-validation-state.mjs";
 import { fullReleaseCandidateBindingFixture } from "../helpers/full-release-candidate.js";
 import { waitForChildClose, waitForFile } from "../helpers/process-wait.js";
@@ -374,7 +378,9 @@ describe("full release execution plan", () => {
     ["getaddrinfo EAI_AGAIN api.github.com", "transient"],
     ["unexpected EOF", "transient"],
     ["HTTP 401: Bad credentials", "hard"],
-    ["HTTP 403: secondary rate limit", "hard"],
+    ["HTTP 403: secondary rate limit", "transient"],
+    ["HTTP 403: Resource not accessible by integration", "hard"],
+    ["HTTP 403: permission denied", "hard"],
     ["HTTP 404: workflow not found", "hard"],
     ["HTTP 410: artifact expired", "hard"],
     ["HTTP 422: invalid workflow input", "hard"],
@@ -782,7 +788,12 @@ describe("release decision policy", () => {
     expect(result).toMatchObject({ plannedRunAttempt: 1, runAttempt: 2 });
   });
 
-  it("preserves the last valid snapshot through a transient read and then recovers", async () => {
+  it.each([
+    "HTTP 503: Server Error",
+    "HTTP 429: API rate limit exceeded",
+    "HTTP 403: secondary rate limit",
+    "read ECONNRESET",
+  ])("preserves the last valid snapshot through %s and then recovers", async (message) => {
     const planned = child("normalCi");
     const previous = {
       ...planned,
@@ -794,8 +805,8 @@ describe("release decision policy", () => {
     const readRun = async () => {
       if (fail) {
         fail = false;
-        throw Object.assign(new Error("HTTP 503: Server Error"), {
-          stderr: "HTTP 503: Server Error",
+        throw Object.assign(new Error(message), {
+          stderr: message,
         });
       }
       return {
@@ -830,14 +841,12 @@ describe("release decision policy", () => {
     const degraded = await readChild(planned, previous, undefined, {
       readAttemptJobs,
       readRun,
-      transientGracePolls: 2,
     });
     expect(degraded).toMatchObject({
       conclusion: "success",
       errors: [],
       jobs: previous.jobs,
-      status: "read_degraded",
-      transientReadFailures: 1,
+      status: "transport_uncertain",
     });
     expect(
       classifyReleaseSnapshot({
@@ -850,7 +859,6 @@ describe("release decision policy", () => {
     const recovered = await readChild(planned, degraded, undefined, {
       readAttemptJobs,
       readRun,
-      transientGracePolls: 2,
     });
     expect(recovered).toMatchObject({
       conclusion: "success",
@@ -866,7 +874,7 @@ describe("release decision policy", () => {
     ).toMatchObject({ errors: [], state: "passed" });
   });
 
-  it("fails closed after the transient read grace boundary", async () => {
+  it("keeps exhausted transient reads uncertain instead of terminal", async () => {
     const planned = child("normalCi");
     const readRun = async () => {
       throw Object.assign(new Error("HTTP 503: Server Error"), {
@@ -875,14 +883,11 @@ describe("release decision policy", () => {
     };
     let snapshot: Record<string, unknown> = planned;
     for (let attempt = 0; attempt < 3; attempt += 1) {
-      snapshot = await readChild(planned, snapshot, undefined, {
-        readRun,
-        transientGracePolls: 2,
-      });
+      snapshot = await readChild(planned, snapshot, undefined, { readRun });
     }
     expect(snapshot).toMatchObject({
-      errors: [expect.objectContaining({ kind: "api_error" })],
-      transientReadFailures: 3,
+      errors: [],
+      status: "transport_uncertain",
     });
     expect(
       classifyReleaseSnapshot({
@@ -891,8 +896,8 @@ describe("release decision policy", () => {
         workflowRef: "main",
       }),
     ).toMatchObject({
-      errors: [expect.objectContaining({ kind: "api_error" })],
-      state: "orchestration_error",
+      errors: [],
+      state: "qualifying",
     });
   });
 
@@ -902,7 +907,6 @@ describe("release decision policy", () => {
       readRun: async () => {
         throw Object.assign(new Error("read ECONNRESET"), { stderr: "read ECONNRESET" });
       },
-      transientGracePolls: 2,
     });
     expect(
       classifyReleaseSnapshot({
@@ -950,6 +954,143 @@ describe("release decision policy", () => {
         workflowRef: "main",
       }),
     ).toMatchObject({ state: "orchestration_error" });
+  });
+
+  it.each(["HTTP 403: Resource not accessible by integration", "HTTP 403: Bad credentials"])(
+    "keeps %s terminal",
+    async (message) => {
+      const planned = child("normalCi");
+      const observed = await readChild(planned, planned, undefined, {
+        readRun: async () => {
+          throw Object.assign(new Error(message), { stderr: message });
+        },
+      });
+      expect(observed).toMatchObject({
+        errors: [expect.objectContaining({ kind: "api_error" })],
+        transportFailure: undefined,
+      });
+    },
+  );
+
+  it("keeps malformed child responses terminal", async () => {
+    const planned = child("normalCi");
+    const observed = await readChild(planned, planned, undefined, {
+      readRun: async () => ({}),
+    });
+    expect(observed.errors).toEqual([expect.objectContaining({ kind: "api_error" })]);
+  });
+
+  it("preserves complete composite evidence when the run read succeeds but jobs fail", async () => {
+    const planned = child("normalCi");
+    const previous = {
+      ...planned,
+      compositeJobsSha256: "f".repeat(64),
+      conclusion: "success",
+      jobs: [{ conclusion: "success", name: "test", status: "completed" }],
+      observedRunAttempts: [1],
+      plannedRunAttempt: 1,
+      status: "completed",
+      transportFailure: { errorClass: "transient" },
+    };
+    const observed = await readChild(planned, previous, undefined, {
+      readAttemptJobs: async (_runId, attempt) => {
+        if (attempt === 2) {
+          throw Object.assign(new Error("HTTP 503: Server Error"), {
+            stderr: "HTTP 503: Server Error",
+          });
+        }
+        return previous.jobs;
+      },
+      readRun: async () => ({
+        actor: { login: "github-actions[bot]" },
+        conclusion: "",
+        display_title: planned.displayTitle,
+        event: "workflow_dispatch",
+        head_branch: planned.workflowRef,
+        head_sha: planned.workflowSha,
+        id: 101,
+        path: ".github/workflows/ci.yml",
+        repository: { full_name: "openclaw/openclaw" },
+        run_attempt: 2,
+        status: "in_progress",
+        triggering_actor: { login: "github-actions[bot]" },
+      }),
+    });
+    expect(observed).toMatchObject({
+      compositeJobsSha256: previous.compositeJobsSha256,
+      jobs: previous.jobs,
+      runAttempt: 1,
+      status: "transport_uncertain",
+      transportFailure: { errorClass: "transient" },
+    });
+    expect(
+      await readChild(
+        planned,
+        {
+          ...planned,
+          status: "transport_uncertain",
+          transportFailure: { errorClass: "transient" },
+        },
+        undefined,
+        {
+          readAttemptJobs: async () => [],
+          readRun: async () => ({
+            actor: { login: "github-actions[bot]" },
+            display_title: planned.displayTitle,
+            event: "workflow_dispatch",
+            head_branch: planned.workflowRef,
+            head_sha: planned.workflowSha,
+            id: 101,
+            path: ".github/workflows/ci.yml",
+            repository: { full_name: "openclaw/openclaw" },
+            run_attempt: 1,
+            status: "in_progress",
+            triggering_actor: { login: "github-actions[bot]" },
+          }),
+        },
+      ),
+    ).toMatchObject({
+      status: "in_progress",
+      transportFailure: { errorClass: "transient" },
+    });
+  });
+
+  it("uses one fixed monotonic transport deadline until recovery", () => {
+    const uncertainChild = {
+      ...child("normalCi"),
+      transportFailure: { errorClass: "transient" },
+    };
+    const first = updateReleaseTransportEpisode(undefined, [uncertainChild], {
+      deadline: 900_000,
+      monotonicNow: 100,
+      wallNow: Date.parse("2026-08-29T00:00:00.100Z"),
+    });
+    const repeated = updateReleaseTransportEpisode(first, [uncertainChild], {
+      monotonicNow: 899_999,
+      wallNow: Date.parse("2026-08-29T01:00:00Z"),
+    });
+    const expired = updateReleaseTransportEpisode(first, [uncertainChild], {
+      monotonicNow: 900_100,
+      wallNow: Date.parse("2026-08-29T02:00:00Z"),
+    });
+    expect(repeated).toMatchObject({
+      deadlineAt: first.deadlineAt,
+      startedAt: "2026-08-29T00:00:00.000Z",
+      status: "uncertain",
+    });
+    expect(expired).toMatchObject({
+      deadlineAt: first.deadlineAt,
+      error: { kind: "transport_deadline_exceeded" },
+      status: "expired",
+    });
+    expect(
+      updateReleaseTransportEpisode(first, [{ ...uncertainChild, transportFailure: undefined }]),
+    ).toEqual({ status: "certain" });
+  });
+
+  it("caps GitHub retry sleep at the remaining transport deadline", () => {
+    expect(releaseGhRetryDelayMs(6, 105_000, 100_000)).toBe(5_000);
+    expect(releaseGhRetryDelayMs(6, 100_000, 100_000)).toBe(0);
   });
 
   it("cancels only exact active affected children", () => {
@@ -1018,6 +1159,7 @@ describe("release state artifacts", () => {
       mode,
       releaseProfile: "stable",
       rerunGroup: "ci",
+      transport: options.transport,
     });
   }
 
@@ -1139,6 +1281,153 @@ describe("release state artifacts", () => {
         { ...stateExpected(), parentRunAttempt: 2 },
       ),
     ).toMatchObject({ decision: { state: "passed" }, drain: { state: "passed" } });
+  });
+
+  it("records a blocker while transport is simultaneously uncertain", () => {
+    const transport = updateReleaseTransportEpisode(undefined, [
+      {
+        ...child("normalCi"),
+        transportFailure: { errorClass: "transient" },
+      },
+    ]);
+    const payload = artifact(
+      "decision",
+      2,
+      executionPlan({ rerunGroup: "ci" }),
+      { conclusion: "", jobs: [FAILED_JOB], status: "in_progress" },
+      { transport },
+    );
+    expect(payload).toMatchObject({
+      blockerCount: 1,
+      state: "blocked_diagnostics_running",
+      transport: { status: "uncertain" },
+    });
+  });
+
+  it("records expired transport without serializing collector internals", () => {
+    const transport = updateReleaseTransportEpisode(
+      undefined,
+      [{ ...child("normalCi"), transportFailure: { errorClass: "transient" } }],
+      {
+        deadline: 900_000,
+        monotonicNow: 0,
+        wallNow: Date.parse("2026-08-29T00:00:00Z"),
+      },
+    );
+    const expired = updateReleaseTransportEpisode(
+      transport,
+      [{ ...child("normalCi"), transportFailure: { errorClass: "transient" } }],
+      { monotonicNow: 900_000, wallNow: Date.parse("2026-08-29T00:15:00Z") },
+    );
+    const payload = artifact(
+      "decision",
+      2,
+      executionPlan({ rerunGroup: "ci" }),
+      {},
+      {
+        extraErrors: [expired.error],
+        transport: expired,
+      },
+    );
+    expect(payload.errors).toContainEqual(
+      expect.objectContaining({ kind: "transport_deadline_exceeded" }),
+    );
+    expect(payload.transport).not.toHaveProperty("deadlineMonotonicMs");
+    expect(payload.transport).not.toHaveProperty("error");
+    expect(() => validateReleaseStateArtifact(payload, stateExpected(), "decision")).not.toThrow();
+  });
+
+  it("does not create fail-fast cancellation targets from uncertainty alone", () => {
+    const snapshots = [
+      {
+        ...child("normalCi"),
+        status: "transport_uncertain",
+        transportFailure: { errorClass: "transient" },
+      },
+    ];
+    const decision = classifyReleaseSnapshot({
+      children: snapshots,
+      releaseProfile: "stable",
+      workflowRef: "main",
+    });
+    expect(decision).toMatchObject({ blockers: [], state: "qualifying" });
+    expect(affectedActiveRunIds(snapshots, decision.blockers)).toEqual([]);
+  });
+
+  it("keeps a complete deterministic 31-entry blocker index", () => {
+    const jobs = Array.from({ length: 31 }, (_, index) => ({
+      ...FAILED_JOB,
+      completed_at: `2026-08-29T00:00:${String(index).padStart(2, "0")}Z`,
+      name: `failed-${String(index).padStart(2, "0")}`,
+    }));
+    const payload = artifact("decision", 2, executionPlan({ rerunGroup: "ci" }), {
+      conclusion: "failure",
+      jobs,
+    });
+    expect(payload.blockers).toHaveLength(25);
+    expect(payload.blockerIndex).toHaveLength(31);
+    expect(payload).toMatchObject({
+      blockerCount: 31,
+      firstPrimaryFailure: { job: "failed-00", kind: "job_failure" },
+    });
+    expect(() => validateReleaseStateArtifact(payload, stateExpected(), "decision")).not.toThrow();
+  });
+
+  it("keeps a maximal paginated retry blocker index within the artifact budget", () => {
+    const attempts = Array.from({ length: 5 }, (_unused, attempt) => ({
+      jobs: Array.from({ length: 100 }, (_, offset) => {
+        const index = attempt * 100 + offset;
+        return {
+          ...FAILED_JOB,
+          name: `failed-${String(index).padStart(3, "0")}`,
+          url: `https://example.invalid/jobs/${"x".repeat(960)}-${index}`,
+        };
+      }),
+      runAttempt: attempt + 1,
+    }));
+    const composite = composeReleaseAttemptJobs(attempts, {
+      effectiveRunAttempt: 5,
+      plannedRunAttempt: 1,
+    });
+    const payload = artifact("decision", 2, executionPlan({ rerunGroup: "ci" }), {
+      compositeJobsSha256: composite.sha256,
+      conclusion: "failure",
+      jobs: composite.jobs,
+      observedRunAttempts: attempts.map(({ runAttempt }) => runAttempt),
+      plannedRunAttempt: 1,
+      runAttempt: 5,
+    });
+    const bytes = Buffer.byteLength(serializeReleaseArtifact(payload), "utf8");
+    expect(payload.blockerIndex).toHaveLength(500);
+    expect(bytes).toBeLessThanOrEqual(MAX_RELEASE_ARTIFACT_BYTES);
+  });
+
+  it("reads legacy v2 evidence without claiming blocked-list completeness", () => {
+    const passed = structuredClone(artifact("decision"));
+    const blocked = structuredClone(stateArtifact("decision", "blocked_complete"));
+    for (const payload of [passed, blocked]) {
+      delete payload.blockerCount;
+      delete payload.blockerIndex;
+      delete payload.firstPrimaryFailure;
+      delete payload.transport;
+    }
+    expect(validateReleaseStateArtifact(passed, stateExpected(), "decision")).toMatchObject({
+      blockerCount: null,
+      transport: { status: "certain" },
+    });
+    expect(validateReleaseStateArtifact(blocked, stateExpected(), "decision")).toMatchObject({
+      blockerCount: null,
+      state: "blocked_complete",
+      transport: null,
+    });
+  });
+
+  it("rejects malformed complete blocker evidence", () => {
+    const payload = structuredClone(stateArtifact("decision", "blocked_complete"));
+    payload.blockerCount = Number(payload.blockerCount) + 1;
+    expect(() => validateReleaseStateArtifact(payload, stateExpected(), "decision")).toThrow(
+      "release state machine evidence is invalid",
+    );
   });
 
   it("round-trips mixed-case composite jobs through state validation", () => {
@@ -2482,8 +2771,8 @@ printf '%s\\n' '{"id":101,"event":"workflow_dispatch","path":".github/workflows/
       "releaseChecksIndependent",
       "releaseChecksCandidate",
     ]);
-    expect(restored.children.filter((child) => phasedKeys.has(child.key))).toEqual(
-      sealed.children.filter((child) => phasedKeys.has(child.key)),
+    expect(restored.children.filter((entry) => phasedKeys.has(entry.key))).toEqual(
+      sealed.children.filter((entry) => phasedKeys.has(entry.key)),
     );
     expect(readFileSync(githubOutput, "utf8")).toContain("source_parent_attempt=1\n");
   });

--- a/test/scripts/release-ci-summary.test.ts
+++ b/test/scripts/release-ci-summary.test.ts
@@ -388,28 +388,28 @@ describe("Release Decision artifact polling", () => {
     ).toBeUndefined();
   });
 
-  it("treats transient download transport failures as unavailable this poll", () => {
-    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
-    try {
-      expect(
-        tryReadReleaseDecisionArtifact(parent, "123", "openclaw/openclaw", () => {
-          throw Object.assign(new Error("HTTP 503: Server Error"), {
-            stderr: "HTTP 503: Server Error",
-          });
-        }),
-      ).toBeUndefined();
-      expect(warn).toHaveBeenCalledWith(
-        expect.stringContaining("release decision artifact unavailable this poll"),
-      );
-    } finally {
-      warn.mockRestore();
-    }
-  });
+  it.each(["HTTP 503: Server Error", "HTTP 403: secondary rate limit"])(
+    "treats transient download transport failure %s as unavailable this poll",
+    (message) => {
+      const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+      try {
+        expect(
+          tryReadReleaseDecisionArtifact(parent, "123", "openclaw/openclaw", () => {
+            throw Object.assign(new Error(message), { stderr: message });
+          }),
+        ).toBeUndefined();
+        expect(warn).toHaveBeenCalledWith(
+          expect.stringContaining("release decision artifact unavailable this poll"),
+        );
+      } finally {
+        warn.mockRestore();
+      }
+    },
+  );
 
   it("keeps authentication and invocation failures hard", () => {
     for (const message of [
       "HTTP 401: Bad credentials",
-      "HTTP 403: secondary rate limit",
       "unknown flag: --name\nUsage: gh run download",
     ]) {
       expect(() =>


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Full Release Validation could convert an exhausted temporary GitHub API outage into a terminal orchestration failure, discard the last complete child snapshot, or leave downstream evidence unable to distinguish primary blockers from collector fallout.

## Why This Change Was Made

The FRV collector now owns one fixed 15-minute monotonic transport-uncertainty episode per parent run, attempt, and mode. Only exhausted 429, 5xx, network failures, and rate-limit-evidenced 403 responses enter uncertainty; malformed responses, provenance mismatches, invocation failures, and hard authorization or request errors remain terminal.

During uncertainty, the collector preserves the last provenance-valid complete composite snapshot, never redispatches or mutates release state, and prevents uncertainty-only children from triggering fail-fast cancellation. A complete valid read clears the episode; expiry records `transport_deadline_exceeded`.

Artifact v2 remains additive and carries transport evidence, a complete deterministic blocker index/count, and the first primary child failure. The complete index uses canonical SHA-256 blocker identities so maximal paginated/retried failure sets stay within the 1 MiB artifact contract. Legacy passed v2 artifacts remain readable, while legacy blocked artifacts do not claim blocker-list completeness.

## User Impact

Release operators get bounded recovery from temporary GitHub read failures without hiding hard failures, repeating release work, or losing the evidence needed to diagnose the actual first blocker.

## Evidence

- Pre-fix regression: the focused suite failed the new rate-limit-403 and exhausted-transient uncertainty expectations; the maximal paginated/retried blocker fixture also failed artifact serialization above the 1 MiB limit.
- Focused proof: `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs test/scripts/full-release-validation-state.test.ts` (`178 passed`).
- Existing release-summary proof: `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs test/scripts/release-ci-summary.test.ts` (`80 passed`), including rate-limit-evidenced 403 recovery while authentication and invocation failures remain hard.
- Covered: 503, 429, rate-limit 403, network recovery, hard 403, malformed/provenance terminal behavior, fixed-clock expiry, capped sleep, split run/jobs read failure, higher-attempt composition, blocker plus uncertainty, no uncertainty-only fail-fast cancellation, 31-entry blocker index, maximal paginated/retried artifact serialization, and legacy v2 validation.
- Static proof: targeted type-aware oxlint, formatting, `actionlint .github/workflows/full-release-validation.yml`, and `git diff --check` pass.
- Type graphs: `pnpm tsgo:scripts` and `pnpm tsgo:test:root` reach only the existing untouched `ui/vite.config.ts` missing-`pako` declaration baseline.
- Independent review: bounded P0 autoreview reported no accepted/actionable findings (correctness 0.93).
- Production/declaration LOC: +261/-113 (net +148). Tests: +327/-38 (net +289).
- Rebase proof: `range-diff` from the prior base/head to current main/head is exact (`=`); the rebase introduced no behavioral or test diff.
- Workflow runner labels and the separate Release Decision / Diagnostic Drain jobs are unchanged.
- `CHANGELOG.md` is intentionally unchanged because the repository PR gate marks it release-owned for normal PRs; this body carries the release-note context.
