### PR TITLE
perf(scripts): load runtime dependencies only for execution

### DIFF
--- a/scripts/bench-model.ts
+++ b/scripts/bench-model.ts
@@ -1,8 +1,8 @@
 // Bench Model script supports OpenClaw repository automation.
 import { pathToFileURL } from "node:url";
-import { completeSimple, type Model } from "openclaw/plugin-sdk/llm";
+import type { Model } from "openclaw/plugin-sdk/llm";
 import { expectDefined } from "../packages/normalization-core/src/expect.js";
-import { parseStrictIntegerOption } from "./lib/dev-tooling-safety.ts";
+import { parseStrictIntegerOption } from "./lib/strict-integer-option.ts";
 
 type Usage = {
   input?: number;
@@ -128,6 +128,8 @@ async function runModel(opts: {
   runs: number;
   prompt: string;
 }): Promise<RunResult[]> {
+  // Keep SDK initialization outside the measured model-call samples.
+  const { completeSimple } = await import("openclaw/plugin-sdk/llm");
   const results: RunResult[] = [];
   for (let i = 0; i < opts.runs; i += 1) {
     const started = Date.now();

--- a/scripts/bench-web-fetch.ts
+++ b/scripts/bench-web-fetch.ts
@@ -2,11 +2,8 @@
 import { mkdir, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { performance } from "node:perf_hooks";
-import { extractBasicHtmlContent } from "../src/agents/tools/web-fetch-utils.js";
-import { createWebFetchTool } from "../src/agents/tools/web-fetch.js";
 import type { OpenClawConfig } from "../src/config/types.openclaw.js";
 import type { LookupFn } from "../src/infra/net/ssrf.js";
-import { extractReadableContent } from "../src/web-fetch/content-extractors.runtime.js";
 import * as cliArgs from "./lib/arg-utils.mts";
 
 type BenchmarkCaseId =
@@ -266,109 +263,115 @@ async function withOfflineProviderEnv<T>(run: () => Promise<T>): Promise<T> {
   }
 }
 
-function createTool() {
-  const tool = createWebFetchTool({
-    config: toolConfig,
-    lookupFn,
-    sandboxed: false,
-  });
-  if (!tool?.execute) {
-    throw new Error("web_fetch tool was not created");
-  }
-  return tool;
-}
+async function loadCaseFactory(): Promise<() => Record<BenchmarkCaseId, BenchmarkCase>> {
+  const { extractBasicHtmlContent } = await import("../src/agents/tools/web-fetch-utils.js");
+  const { createWebFetchTool } = await import("../src/agents/tools/web-fetch.js");
+  const { extractReadableContent } = await import("../src/web-fetch/content-extractors.runtime.js");
 
-function createCases(): Record<BenchmarkCaseId, BenchmarkCase> {
-  const textTool = createTool();
-  const markdownTool = createTool();
-  const articleTool = createTool();
-  const articleTextTool = createTool();
-  const shellTool = createTool();
-  return {
-    "tool-create": {
-      id: "tool-create",
-      label: "create web_fetch tool",
-      run: () => {
-        createTool();
+  function createTool() {
+    const tool = createWebFetchTool({
+      config: toolConfig,
+      lookupFn,
+      sandboxed: false,
+    });
+    if (!tool?.execute) {
+      throw new Error("web_fetch tool was not created");
+    }
+    return tool;
+  }
+
+  return () => {
+    const textTool = createTool();
+    const markdownTool = createTool();
+    const articleTool = createTool();
+    const articleTextTool = createTool();
+    const shellTool = createTool();
+    return {
+      "tool-create": {
+        id: "tool-create",
+        label: "create web_fetch tool",
+        run: () => {
+          createTool();
+        },
       },
-    },
-    "tool-text": {
-      id: "tool-text",
-      label: "execute text/plain fetch",
-      run: async () => {
-        installMockFetch({ body: TEXT_BODY, contentType: "text/plain; charset=utf-8" });
-        await textTool.execute("bench", { url: "https://example.com/plain" });
+      "tool-text": {
+        id: "tool-text",
+        label: "execute text/plain fetch",
+        run: async () => {
+          installMockFetch({ body: TEXT_BODY, contentType: "text/plain; charset=utf-8" });
+          await textTool.execute("bench", { url: "https://example.com/plain" });
+        },
       },
-    },
-    "tool-markdown": {
-      id: "tool-markdown",
-      label: "execute text/markdown fetch",
-      run: async () => {
-        installMockFetch({ body: MARKDOWN_BODY, contentType: "text/markdown; charset=utf-8" });
-        await markdownTool.execute("bench", { url: "https://example.com/markdown" });
+      "tool-markdown": {
+        id: "tool-markdown",
+        label: "execute text/markdown fetch",
+        run: async () => {
+          installMockFetch({ body: MARKDOWN_BODY, contentType: "text/markdown; charset=utf-8" });
+          await markdownTool.execute("bench", { url: "https://example.com/markdown" });
+        },
       },
-    },
-    "tool-html-article": {
-      id: "tool-html-article",
-      label: "execute article HTML fetch",
-      run: async () => {
-        installMockFetch({ body: ARTICLE_HTML, contentType: "text/html; charset=utf-8" });
-        await articleTool.execute("bench", { url: "https://example.com/article" });
+      "tool-html-article": {
+        id: "tool-html-article",
+        label: "execute article HTML fetch",
+        run: async () => {
+          installMockFetch({ body: ARTICLE_HTML, contentType: "text/html; charset=utf-8" });
+          await articleTool.execute("bench", { url: "https://example.com/article" });
+        },
       },
-    },
-    "tool-html-article-text": {
-      id: "tool-html-article-text",
-      label: "execute article HTML fetch as text",
-      run: async () => {
-        installMockFetch({ body: ARTICLE_HTML, contentType: "text/html; charset=utf-8" });
-        await articleTextTool.execute("bench", {
-          url: "https://example.com/article-text",
-          extractMode: "text",
-        });
+      "tool-html-article-text": {
+        id: "tool-html-article-text",
+        label: "execute article HTML fetch as text",
+        run: async () => {
+          installMockFetch({ body: ARTICLE_HTML, contentType: "text/html; charset=utf-8" });
+          await articleTextTool.execute("bench", {
+            url: "https://example.com/article-text",
+            extractMode: "text",
+          });
+        },
       },
-    },
-    "tool-html-shell": {
-      id: "tool-html-shell",
-      label: "execute shell HTML fallback fetch",
-      run: async () => {
-        installMockFetch({ body: SHELL_HTML, contentType: "text/html; charset=utf-8" });
-        await shellTool.execute("bench", { url: "https://example.com/shell" });
+      "tool-html-shell": {
+        id: "tool-html-shell",
+        label: "execute shell HTML fallback fetch",
+        run: async () => {
+          installMockFetch({ body: SHELL_HTML, contentType: "text/html; charset=utf-8" });
+          await shellTool.execute("bench", { url: "https://example.com/shell" });
+        },
       },
-    },
-    "extract-readable-article": {
-      id: "extract-readable-article",
-      label: "extract readable article HTML",
-      run: async () => {
-        await extractReadableContent({
-          html: ARTICLE_HTML,
-          url: "https://example.com/article",
-          extractMode: "markdown",
-          config: toolConfig,
-        });
+      "extract-readable-article": {
+        id: "extract-readable-article",
+        label: "extract readable article HTML",
+        run: async () => {
+          await extractReadableContent({
+            html: ARTICLE_HTML,
+            url: "https://example.com/article",
+            extractMode: "markdown",
+            config: toolConfig,
+          });
+        },
       },
-    },
-    "extract-readable-article-text": {
-      id: "extract-readable-article-text",
-      label: "extract readable article HTML as text",
-      run: async () => {
-        await extractReadableContent({
-          html: ARTICLE_HTML,
-          url: "https://example.com/article-text",
-          extractMode: "text",
-          config: toolConfig,
-        });
+      "extract-readable-article-text": {
+        id: "extract-readable-article-text",
+        label: "extract readable article HTML as text",
+        run: async () => {
+          await extractReadableContent({
+            html: ARTICLE_HTML,
+            url: "https://example.com/article-text",
+            extractMode: "text",
+            config: toolConfig,
+          });
+        },
       },
-    },
-    "extract-basic-shell": {
-      id: "extract-basic-shell",
-      label: "extract basic shell HTML",
-      run: async () => {
-        await extractBasicHtmlContent({
-          html: SHELL_HTML,
-          extractMode: "markdown",
-        });
+      "extract-basic-shell": {
+        id: "extract-basic-shell",
+        label: "extract basic shell HTML",
+        run: async () => {
+          await extractBasicHtmlContent({
+            html: SHELL_HTML,
+            extractMode: "markdown",
+          });
+        },
       },
-    },
+    };
   };
 }
 
@@ -407,6 +410,8 @@ async function main(): Promise<void> {
     return;
   }
   const options = parseOptions(args);
+  // Preserve runtime import environment, then construct tools inside the offline scope.
+  const createCases = await loadCaseFactory();
   const report = await withOfflineProviderEnv(async () => {
     const casesById = createCases();
     const cases: CaseReport[] = [];

--- a/scripts/test-force.ts
+++ b/scripts/test-force.ts
@@ -5,7 +5,7 @@ import os from "node:os";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { forceFreePort } from "../src/cli/ports.js";
-import { resolveGatewayPort } from "../src/config/config.js";
+import { resolveGatewayPort } from "../src/config/paths.js";
 
 type PortProcess = ReturnType<typeof forceFreePort>[number];
 


### PR DESCRIPTION
## Summary

Three repository CLIs eagerly load broad runtime graphs for help or invalid arguments. Keep those entry paths lightweight while preserving their real operational owners:

- test-force imports the identical port resolver directly from its existing paths owner instead of the broad config facade.
- bench-model imports the existing dependency-free integer parser directly, and loads the real public LLM SDK inside the async model-run owner, before the sample timer.
- bench-web-fetch loads its three real runtime modules after validation, then returns the unchanged case constructor. Imports retain the original environment; tool construction, warmups and samples remain inside the existing cleared-credential scope.

No new exports, dependencies, options, caches or mocks. All 14 existing tests, including their real CLI children and existing concurrency, remain unchanged. Tooling delta +106/-99 (net +7); most web-fetch lines are unchanged code nested in its new private loading owner. The small growth separates import, credential-scope and measured-work lifetimes without mutable module globals or duplicate implementations.

## Validation

- Same normal wrapper and Node 26.5.0, all 14 cases pass: model benchmark 3.241s to 0.193s; web-fetch benchmark 3.802s to 1.602s; test-force 4.295s to 0.488s. Web-fetch figures are elapsed file time because its cases already run concurrently; these are not whole-suite claims.
- All 75 owning/sibling cases pass, including port resolution, real LLM facade/host initialization and readable-content runtime tests.
- Actual model benchmark CLI through the real SDK with child-local fixture protocol adapters and blocked network: identical full request/model shapes, four calls in MiniMax-then-Opus order, exact samples and summaries. Moving SDK import inside the sample deliberately adds 1000ms and fails the proof. No live provider request or real credential used.
- Actual web-fetch benchmark runs all nine cases with real tools/extractors and its existing offline response fixtures. Observer verifies original-environment imports, eight tool constructions and fifteen requests with credentials cleared, restoration before report output, and two samples per case. Moving imports or construction across the scope, or removing credential clearing, each fails independently.
- Port resolver is the same function object through both imports; six representative normal-force selections match. No real gateway listener was signalled.
- Local changed-file gate, full build and independent Codex autoreview passed. No ineffective-dynamic-import warning.

Normal benchmark requests and measurements remain unchanged. A model-SDK load failure can now occur after the normal benchmark header; help and validation no longer require that SDK. No changelog needed for internal tooling performance.
