### PR TITLE
fix: stabilize rollback-journal ownership race coverage

### DIFF
--- a/src/state/openclaw-state-ownership.test.ts
+++ b/src/state/openclaw-state-ownership.test.ts
@@ -362,7 +362,8 @@ describe("external shared-state ownership", () => {
     const writer = new DatabaseSync(databasePath);
     writer.exec(
       "PRAGMA journal_mode = DELETE; PRAGMA synchronous = FULL; " +
-        "PRAGMA cache_size = 2; PRAGMA cache_spill = ON;",
+        "PRAGMA cache_size = 2; PRAGMA cache_spill = ON; " +
+        "CREATE TABLE rollback_race_pressure (payload TEXT NOT NULL) STRICT;",
     );
     const baselineOwnership = {
       version: 1 as const,
@@ -378,17 +379,20 @@ describe("external shared-state ownership", () => {
     };
     const payload = JSON.stringify("x".repeat(8192));
     writer.exec("BEGIN IMMEDIATE;");
-    const insert = writer.prepare(
+    const writeOwnership = writer.prepare(
       `INSERT INTO config_machine_state (state_key, value_json, updated_at_ms)
-       VALUES (?, ?, ?)`,
+       VALUES (?, ?, ?)
+       ON CONFLICT(state_key) DO UPDATE SET
+         value_json = excluded.value_json, updated_at_ms = excluded.updated_at_ms`,
     );
-    insert.run(
+    writeOwnership.run(
       STATE_SUPERVISION_KEY,
       JSON.stringify(baselineOwnership),
       baselineOwnership.claimedAt,
     );
+    const insertPressure = writer.prepare("INSERT INTO rollback_race_pressure VALUES (?)");
     for (let index = 0; index < 256; index += 1) {
-      insert.run(`rollback-race-${index.toString().padStart(3, "0")}`, payload, index);
+      insertPressure.run(payload);
     }
     writer.exec("COMMIT;");
     const originalGet = Object.getOwnPropertyDescriptor(StatementSync.prototype, "get")?.value as
@@ -402,7 +406,6 @@ describe("external shared-state ownership", () => {
     }
     let transactionStarted = false;
     let transientOwnershipObserved = false;
-    let insertTransientOwnership = false;
     const get = vi.spyOn(StatementSync.prototype, "get").mockImplementation(function (
       this: import("node:sqlite").StatementSync,
       ...params: unknown[]
@@ -410,30 +413,16 @@ describe("external shared-state ownership", () => {
       if (!transactionStarted && params[0] === STATE_SUPERVISION_KEY) {
         transactionStarted = true;
         writer.exec("BEGIN IMMEDIATE;");
-        if (insertTransientOwnership) {
-          writer
-            .prepare(
-              `INSERT INTO config_machine_state (state_key, value_json, updated_at_ms)
-               VALUES (?, ?, ?)`,
-            )
-            .run(
-              STATE_SUPERVISION_KEY,
-              JSON.stringify(transientOwnership),
-              transientOwnership.claimedAt,
-            );
-        }
+        writeOwnership.run(
+          STATE_SUPERVISION_KEY,
+          JSON.stringify(transientOwnership),
+          transientOwnership.claimedAt,
+        );
+        // A same-table sweep can leave the ownership leaf pinned or last dirtied.
+        // Pressure another B-tree after releasing the ownership cursor so its page spills.
         writer
-          .prepare(
-            `UPDATE config_machine_state
-             SET value_json = CASE WHEN state_key = ? THEN ? ELSE ? END,
-                 updated_at_ms = ?`,
-          )
-          .run(
-            STATE_SUPERVISION_KEY,
-            JSON.stringify(transientOwnership),
-            JSON.stringify("y".repeat(8192)),
-            transientOwnership.claimedAt,
-          );
+          .prepare("UPDATE rollback_race_pressure SET payload = ?")
+          .run(JSON.stringify("y".repeat(8192)));
         const racedReader = new DatabaseSync(resolveImmutableSqliteFileUri(databasePath), {
           readOnly: true,
         });
@@ -467,7 +456,6 @@ describe("external shared-state ownership", () => {
         .run(STATE_SUPERVISION_KEY);
       transactionStarted = false;
       transientOwnershipObserved = false;
-      insertTransientOwnership = true;
       expect(
         runWithOpenClawStateWriteAccess(
           { databasePath, env },

--- a/src/state/openclaw-state-ownership.test.ts
+++ b/src/state/openclaw-state-ownership.test.ts
@@ -391,9 +391,6 @@ describe("external shared-state ownership", () => {
       baselineOwnership.claimedAt,
     );
     const insertPressure = writer.prepare("INSERT INTO rollback_race_pressure VALUES (?)");
-    for (let index = 0; index < 256; index += 1) {
-      insertPressure.run(payload);
-    }
     writer.exec("COMMIT;");
     const originalGet = Object.getOwnPropertyDescriptor(StatementSync.prototype, "get")?.value as
       | ((
@@ -418,11 +415,11 @@ describe("external shared-state ownership", () => {
           JSON.stringify(transientOwnership),
           transientOwnership.claimedAt,
         );
-        // A same-table sweep can leave the ownership leaf pinned or last dirtied.
-        // Pressure another B-tree after releasing the ownership cursor so its page spills.
-        writer
-          .prepare("UPDATE rollback_race_pressure SET payload = ?")
-          .run(JSON.stringify("y".repeat(8192)));
+        // Fresh pages force cache misses even when SQLite's global cache retains existing rows.
+        // Use another B-tree after releasing the ownership cursor; rollback discards these pages.
+        for (let index = 0; index < 256; index += 1) {
+          insertPressure.run(payload);
+        }
         const racedReader = new DatabaseSync(resolveImmutableSqliteFileUri(databasePath), {
           readOnly: true,
         });


### PR DESCRIPTION
## Why

The rollback-journal race test passed alone but failed its `transientOwnershipObserved` precondition inside the full unit cohort. The failure was real: an immutable reader still saw committed baseline ownership while the writer saw the transient row. Both native `StatementSync.get()` and `all()` agreed, ruling out a corrupted spy result.

On the affected Node 26.7.0 / SQLite 3.53.4 build, `ENABLE_MEMORY_MANAGEMENT` puts all connections in a [global page-cache group](https://github.com/sqlite/sqlite/blob/version-3.53.4/src/pcache1.c#L703). Other connections enlarge its budget, so [clean seed pages can survive commit](https://github.com/sqlite/sqlite/blob/version-3.53.4/src/pcache1.c#L1096) despite this writer's `cache_size=2`. Updating those resident pages takes the [cache-hit shortcut](https://github.com/sqlite/sqlite/blob/version-3.53.4/src/pcache1.c#L1010), which does not force a spill. A separate pressure table alone was insufficient and also failed the broad replay.

## Change

Commit an empty disposable pressure table, finish the ownership UPSERT, then insert large new pressure rows in the raced transaction. Fresh allocations force cache misses and [spill eligible dirty pages](https://github.com/sqlite/sqlite/blob/version-3.53.4/src/pcache.c#L445); the separate B-tree avoids holding the ownership cursor during pressure. Node's [`run()` resets its statement before returning](https://github.com/nodejs/node/blob/v26.7.0/src/node_sqlite.cc#L2936). Rollback restores the original database size and [truncates cached appended pages](https://github.com/sqlite/sqlite/blob/version-3.53.4/src/pager.c#L2139), so the second race allocates fresh pages again.

Both original transient-observation self-checks remain mandatory. Public inspection must still return baseline ownership after the update race, and write admission must still see no ownership after the insert race. The duplicated insert/update path becomes one UPSERT. No production code, shipped schema, configuration, or runtime behavior changes; no changelog required. Production delta: **0**. Test delta: **+17/-32**.

## Evidence

- Before: the original fixture passed standalone (23/23) and failed the observation self-check in the current full unit configuration (734 selected files). The first separate-table UPDATE candidate also passed standalone (23/23), then failed the same first-phase check in the full cohort. A diagnostic replay confirmed native reads saw baseline on disk while the writer saw transient ownership.
- Deterministic native reproduction: warm a second SQLite connection's cache, then run both update and insert races. Existing-row pressure UPDATE gives `false/false`; fresh-page INSERT gives `true/true` on the affected build. Five additional native repetitions reproduced that contrast every time (10/10 failed observations with UPDATE, 10/10 successful observations with fresh INSERT).
- Final full-cohort replay: all **23/23 ownership tests passed**, including both phases of the rollback race (2.01s), with the same 734-file selection. The broad run was stopped after the owner result; an unrelated transcript-eligibility expectation also failed, as on baseline. This is owner-suite proof in the full shared context, not a whole-suite green claim.
- Final focused run: **23/23 passed** (`node scripts/run-vitest.mjs src/state/openclaw-state-ownership.test.ts`, 31.41s Vitest). Independent Codex autoreview: no blocking findings. [Exact-head hosted CI passed](https://github.com/openclaw/openclaw/actions/runs/33255731350) on `d0a879efc81a49b5a017f8e05299a60c592e4adb`, with no failed jobs.
- Formatting and `git diff --check` pass. The broader local changed check passed its guards, formatting, and dead-export scan, then stopped on an unrelated missing `pako` declaration in the borrowed dependency installation. Exact-head hosted CI passed, including the clean-install checks.

The precise August 28 ~395-file subset/order could not be recovered from available transcripts and logs. The before/after replay uses the same current 734-file unit configuration and shared worker execution, not a claim of reproducing that exact historical subset. Earlier broad local runs were interrupted after the ownership result amid unrelated long-running failures; they are not reported as full-suite passes.

## Review follow-through

The ClawSweeper finding on `57a7a78f76cb` and both rank-up moves are addressed in `d0a879efc81`: fresh allocations replace the insufficient existing-row UPDATE; the owner suite passes in the full shared cohort; and direct Node/SQLite contract verification plus native cache diagnostics are recorded above. No review item was silently skipped.
