### PR TITLE
test(tasks): avoid persisting empty fixture resets

### DIFF
--- a/src/tasks/task-flow-registry.audit.test.ts
+++ b/src/tasks/task-flow-registry.audit.test.ts
@@ -68,14 +68,14 @@ async function withTaskFlowAuditStateDir(run: (root: string) => Promise<void>): 
     },
     async (state) => {
       resetTaskRegistryDeliveryRuntimeForTests();
-      resetTaskRegistryForTests();
-      resetTaskFlowRegistryForTests();
+      resetTaskRegistryForTests({ persist: false });
+      resetTaskFlowRegistryForTests({ persist: false });
       try {
         await run(state.stateDir);
       } finally {
         resetTaskRegistryDeliveryRuntimeForTests();
-        resetTaskRegistryForTests();
-        resetTaskFlowRegistryForTests();
+        resetTaskRegistryForTests({ persist: false });
+        resetTaskFlowRegistryForTests({ persist: false });
       }
     },
   );
@@ -85,8 +85,8 @@ describe("task-flow-registry audit", () => {
   afterEach(() => {
     ORIGINAL_ENV.restore();
     resetTaskRegistryDeliveryRuntimeForTests();
-    resetTaskRegistryForTests();
-    resetTaskFlowRegistryForTests();
+    resetTaskRegistryForTests({ persist: false });
+    resetTaskFlowRegistryForTests({ persist: false });
   });
 
   it("surfaces restore failures as task-flow audit findings", () => {

--- a/src/tasks/task-flow-registry.maintenance.test.ts
+++ b/src/tasks/task-flow-registry.maintenance.test.ts
@@ -66,14 +66,14 @@ async function withTaskFlowMaintenanceStateDir(
     },
     async (state) => {
       resetTaskRegistryDeliveryRuntimeForTests();
-      resetTaskRegistryForTests();
-      resetTaskFlowRegistryForTests();
+      resetTaskRegistryForTests({ persist: false });
+      resetTaskFlowRegistryForTests({ persist: false });
       try {
         await run(state.stateDir);
       } finally {
         resetTaskRegistryDeliveryRuntimeForTests();
-        resetTaskRegistryForTests();
-        resetTaskFlowRegistryForTests();
+        resetTaskRegistryForTests({ persist: false });
+        resetTaskFlowRegistryForTests({ persist: false });
       }
     },
   );
@@ -83,8 +83,8 @@ describe("task-flow-registry maintenance", () => {
   afterEach(() => {
     ORIGINAL_ENV.restore();
     resetTaskRegistryDeliveryRuntimeForTests();
-    resetTaskRegistryForTests();
-    resetTaskFlowRegistryForTests();
+    resetTaskRegistryForTests({ persist: false });
+    resetTaskFlowRegistryForTests({ persist: false });
   });
 
   it("finalizes cancel-requested managed flows once no child tasks remain active", async () => {

--- a/src/tasks/task-flow-registry.store.test.ts
+++ b/src/tasks/task-flow-registry.store.test.ts
@@ -76,11 +76,11 @@ async function withFlowRegistryTempDir<T>(run: (root: string) => Promise<T>): Pr
     async (state) => {
       const root = state.stateDir;
       process.env.OPENCLAW_STATE_DIR = root;
-      resetTaskFlowRegistryForTests();
+      resetTaskFlowRegistryForTests({ persist: false });
       try {
         return await run(root);
       } finally {
-        resetTaskFlowRegistryForTests();
+        resetTaskFlowRegistryForTests({ persist: false });
       }
     },
   );
@@ -104,7 +104,7 @@ describe("task-flow-registry store runtime", () => {
   afterEach(() => {
     vi.useRealTimers();
     restoreOriginalStateDir();
-    resetTaskFlowRegistryForTests();
+    resetTaskFlowRegistryForTests({ persist: false });
   });
 
   it("does not create shared state for a read-only flow snapshot", async () => {
@@ -184,8 +184,6 @@ describe("task-flow-registry store runtime", () => {
 
   it("rejects corrupt persisted flow rows during sqlite restore", async () => {
     await withFlowRegistryTempDir(async () => {
-      resetTaskFlowRegistryForTests();
-
       const created = createManagedTaskFlow({
         ownerKey: "agent:main:main",
         controllerId: "tests/corrupt-flow",
@@ -208,8 +206,6 @@ describe("task-flow-registry store runtime", () => {
 
   it("drops invalid requester origins during sqlite restore", async () => {
     await withFlowRegistryTempDir(async () => {
-      resetTaskFlowRegistryForTests();
-
       const created = createManagedTaskFlow({
         ownerKey: "agent:main:main",
         controllerId: "tests/invalid-origin-flow",
@@ -237,8 +233,6 @@ describe("task-flow-registry store runtime", () => {
 
   it("restores persisted wait-state, revision, and cancel intent from sqlite", async () => {
     await withFlowRegistryTempDir(async () => {
-      resetTaskFlowRegistryForTests();
-
       const created = createManagedTaskFlow({
         ownerKey: "agent:main:main",
         controllerId: "tests/persisted-flow",
@@ -282,8 +276,6 @@ describe("task-flow-registry store runtime", () => {
 
   it("round-trips explicit json null through sqlite", async () => {
     await withFlowRegistryTempDir(async () => {
-      resetTaskFlowRegistryForTests();
-
       const created = createManagedTaskFlow({
         ownerKey: "agent:main:main",
         controllerId: "tests/null-roundtrip",
@@ -303,8 +295,6 @@ describe("task-flow-registry store runtime", () => {
 
   it("prunes large sqlite snapshots without binding every flow id at once", async () => {
     await withFlowRegistryTempDir(async () => {
-      resetTaskFlowRegistryForTests();
-
       const flows = new Map<string, TaskFlowRecord>();
       for (let index = 0; index < 1_200; index++) {
         const flow: TaskFlowRecord = {
@@ -443,8 +433,6 @@ describe("task-flow-registry store runtime", () => {
       return;
     }
     await withFlowRegistryTempDir(async () => {
-      resetTaskFlowRegistryForTests();
-
       createManagedTaskFlow({
         ownerKey: "agent:main:main",
         controllerId: "tests/secured-flow",

--- a/src/tasks/task-flow-registry.test.ts
+++ b/src/tasks/task-flow-registry.test.ts
@@ -62,11 +62,11 @@ async function withFlowRegistryTempDir<T>(run: () => Promise<T>): Promise<T> {
   return await withOpenClawTestState(
     { layout: "state-only", prefix: "openclaw-task-flow-registry-" },
     async () => {
-      resetTaskFlowRegistryForTests();
+      resetTaskFlowRegistryForTests({ persist: false });
       try {
         return await run();
       } finally {
-        resetTaskFlowRegistryForTests();
+        resetTaskFlowRegistryForTests({ persist: false });
       }
     },
   );
@@ -79,7 +79,7 @@ describe("task-flow-registry", () => {
 
   afterEach(() => {
     vi.useRealTimers();
-    resetTaskFlowRegistryForTests();
+    resetTaskFlowRegistryForTests({ persist: false });
   });
 
   it("creates managed flows and updates them through revision-checked helpers", async () => {


### PR DESCRIPTION
## Summary

Fresh task-flow fixtures persist empty snapshots during setup, immediately before deleting their temporary directory, and again after restoring the outer environment. Each empty reset opens SQLite and performs deletion transactions that contribute nothing to the test's state or assertions.

Use the reset helpers' existing `persist: false` option at eighteen lifecycle calls in the maintenance, audit, registry and store suites. Remove six store-test setup resets that immediately duplicate the fresh-directory wrapper. This follows the existing main task-registry and task-flow E2E fixtures. Both helpers still clear memory, restore/runtime/listener state and close database handles; each case still uses a fresh directory and performs its original real store operations. No mid-test persistence, reload or intentional store reset is changed.

Production delta 0; tests +18/-30. No schema, production persistence, mock, assertion, test count, isolation, scheduling or sharding changes.

## Validation

- Same normal runner and Node 26.5.0: all ten maintenance cases pass, execution 4.961s before and 0.968s after. All ten store cases pass, 2.929s before and 0.858s after; the 1,200-row fixture is unchanged.
- All 38 affected cases and the unchanged durable task-flow E2E case pass in their normal owning project order.
- Temporary durable probe resets only memory, reopens the real SQLite store after maintenance, then rechecks the exact retained flow IDs. It passes without an empty snapshot wipe.
- Omitting the in-memory deletion deliberately fails the existing exact remaining-flow-ID assertion. Disabling the actual SQLite upsert also makes both persisted-wait-state and explicit-null reopen assertions fail. Original production bytes restored afterward.
- Scheduled-maintenance sibling proof, full unit-fast run, local changed-file gate and independent Codex autoreview passed.

No schema values, cold-table assertions or runtime storage behavior changed. No changelog required for test-only performance work.
