### PR TITLE
fix(tasks): retain CLI runs in standalone maintenance

### DIFF
--- a/src/commands/tasks.test.ts
+++ b/src/commands/tasks.test.ts
@@ -197,7 +197,7 @@ describe("tasks commands", () => {
         };
       };
 
-      expect(payload.summary.byCode.lost).toBe(1);
+      expect(payload.summary.byCode.stale_running).toBe(1);
       expect(payload.summary.taskFlows.byCode.stale_waiting).toBe(1);
       expect(payload.summary.taskFlows.byCode.missing_linked_tasks).toBe(1);
       expect(payload.summary.combined.total).toBe(3);

--- a/src/tasks/task-registry.maintenance.ts
+++ b/src/tasks/task-registry.maintenance.ts
@@ -183,6 +183,7 @@ export type TaskRegistryMaintenanceTaskDiagnostic = {
     | "active_background_exec"
     | "backing_session_missing"
     | "backing_session_present"
+    | "cli_runtime_not_authoritative"
     | "cron_runtime_not_authoritative"
     | "lost_grace_pending"
     | "subagent_recovery_wedged";
@@ -398,10 +399,14 @@ function hasCliRunIdentity(task: TaskRecord): boolean {
 }
 
 function hasBackingSession(task: TaskRecord, context?: BackingSessionLookupContext): boolean {
+  const hasProcessLocalLiveness =
+    task.runtime === "cron" || task.runtime === "cli" || task.runtime === "acp";
+  // Only the Gateway owns these process-local liveness registries. A standalone
+  // maintenance process must stay conservative when its local registries are empty.
+  if (hasProcessLocalLiveness && !taskRegistryMaintenanceRuntime.isRuntimeAuthoritative()) {
+    return true;
+  }
   if (task.runtime === "cron") {
-    if (!taskRegistryMaintenanceRuntime.isRuntimeAuthoritative()) {
-      return true;
-    }
     const jobId = task.sourceId?.trim();
     return jobId ? taskRegistryMaintenanceRuntime.isCronJobActive(jobId) : false;
   }
@@ -431,11 +436,6 @@ function hasBackingSession(task: TaskRecord, context?: BackingSessionLookupConte
     return !isHarnessOwnedSubagentTask(task);
   }
   if (task.runtime === "acp") {
-    // The live-turn map is process-local; only the gateway owns it. A standalone CLI
-    // maintenance run has an empty map, so stay conservative there and never reclaim.
-    if (!taskRegistryMaintenanceRuntime.isRuntimeAuthoritative()) {
-      return true;
-    }
     // The persisted entry survives a crash, so only a live in-process turn proves the ACP run is alive.
     return taskRegistryMaintenanceRuntime.hasActiveAcpTurn(childSessionKey);
   }
@@ -962,6 +962,9 @@ function explainActiveTaskRetention(params: {
   }
   if (params.task.runtime === "acp" && !taskRegistryMaintenanceRuntime.isRuntimeAuthoritative()) {
     return { decision: "retained", reason: "acp_runtime_not_authoritative" };
+  }
+  if (params.task.runtime === "cli" && !taskRegistryMaintenanceRuntime.isRuntimeAuthoritative()) {
+    return { decision: "retained", reason: "cli_runtime_not_authoritative" };
   }
   if (params.task.runtime === "cli" && hasActiveCliRun(params.task)) {
     return { decision: "retained", reason: "active_cli_run" };

--- a/src/tasks/task-registry.test.ts
+++ b/src/tasks/task-registry.test.ts
@@ -75,6 +75,7 @@ import {
   getInspectableTaskAuditFindings,
   getInspectableTaskRegistrySummary,
   getInspectableTaskAuditSummary,
+  getTaskRegistryMaintenanceDiagnostics,
   previewTaskRegistryMaintenance,
   resetTaskRegistryMaintenanceRuntimeForTests,
   reconcileInspectableTasks,
@@ -185,6 +186,7 @@ function configureTaskRegistryMaintenanceRuntimeForTest(params: {
   listAcpSessionEntries?: () => Promise<AcpSessionStoreEntry[]>;
   hasActiveAcpTurn?: (sessionKey: string) => boolean;
   isBackgroundExecSessionActive?: (sessionId: string) => boolean;
+  runtimeAuthoritative?: boolean;
   sessionBindings?: SessionBindingRecord[];
   closeAcpSession?: (params: {
     cfg: AcpSessionStoreEntry["cfg"];
@@ -268,7 +270,7 @@ function configureTaskRegistryMaintenanceRuntimeForTest(params: {
       params.currentTasks.set(patch.taskId, next);
       return next;
     },
-    isRuntimeAuthoritative: () => true,
+    isRuntimeAuthoritative: () => params.runtimeAuthoritative ?? true,
     listTaskRegistryRecordsByRuntimeSourceIdFromSqlite: () => [],
   });
 }
@@ -3142,7 +3144,7 @@ describe("task-registry", () => {
           sourceId: session.id,
           runId: `exec:${session.id}`,
           task: "Background CLI command",
-          lastEventAt: Date.now() - 10 * 60_000,
+          lastEventAt: Date.now() - 40 * 60_000,
         });
         const currentTasks = new Map([[task.taskId, task]]);
         configureTaskRegistryMaintenanceRuntimeForTest({
@@ -3160,6 +3162,34 @@ describe("task-registry", () => {
         expectRecordFields(currentTasks.get(task.taskId), { status: "running" });
 
         markExited(session, null, "SIGTERM", "killed");
+
+        configureTaskRegistryMaintenanceRuntimeForTest({
+          currentTasks,
+          snapshotTasks: [task],
+          isBackgroundExecSessionActive,
+          runtimeAuthoritative: false,
+        });
+        expect(previewTaskRegistryMaintenance().reconciled).toBe(0);
+        expect(getTaskRegistryMaintenanceDiagnostics().staleRunningTasks).toContainEqual(
+          expect.objectContaining({
+            taskId: task.taskId,
+            decision: "retained",
+            reason: "cli_runtime_not_authoritative",
+          }),
+        );
+        expect(await runTaskRegistryMaintenance()).toEqual({
+          reconciled: 0,
+          recovered: 0,
+          cleanupStamped: 0,
+          pruned: 0,
+        });
+        expectRecordFields(currentTasks.get(task.taskId), { status: "running" });
+
+        configureTaskRegistryMaintenanceRuntimeForTest({
+          currentTasks,
+          snapshotTasks: [task],
+          isBackgroundExecSessionActive,
+        });
 
         expect(await runTaskRegistryMaintenance()).toEqual({
           reconciled: 1,


### PR DESCRIPTION
## Summary

- keep running CLI task rows during standalone task maintenance
- keep Gateway maintenance authoritative for process-local liveness
- report retained CLI rows as `cli_runtime_not_authoritative`

Fixes #127985

## Problem

`openclaw tasks maintenance --apply` runs outside the Gateway. Its process-local background-exec and agent-run registries are empty. It treated that empty local view as proof that a real running command was lost.

## Root cause

The maintenance owner checked runtime authority for cron and ACP tasks, but checked CLI liveness before an authority guard. A standalone process could therefore write a false `lost` state.

## Fix

Use one authority boundary for every process-local liveness registry. Standalone maintenance now retains cron, CLI, and ACP rows. The Gateway still reconciles these rows from its authoritative live registries.

## Live proof

The same source-driven CLI scenario ran against exact main `f471291b97257c21524f4399f18e97b432ff53b2` and this head. It started a real background shell command, advanced its creation clock by six minutes, ran standalone `tasks maintenance --apply`, released the command, and required a unique completion marker.

- Main: maintenance reported `reconciled: 1` and changed the running row to `lost` with `backing session missing`. The real process then emitted its marker and restored the final row to `succeeded`.
- Head: maintenance reported `reconciled: 0`, kept the row `running`, observed the real completion marker, and persisted `succeeded` with `Command completed`.

## Tests

- pre-fix regression: failed with `expected 1 to be 0`
- `node scripts/run-vitest.mjs src/tasks/task-registry.test.ts`: 135 passed
- `node scripts/run-vitest.mjs src/commands/tasks.test.ts`: 27 passed
- focused Oxfmt and Oxlint: passed
- max-lines and assertion-safety ratchets: passed
- conflict-marker, test-temp, and diff checks: passed

## Line count

- production: +3 net (11 added, 8 removed)
- tests: +30 net (32 added, 2 removed)
