### PR TITLE
fix(build): cold declaration checks reject their own workspace outputs

### DIFF
--- a/scripts/lib/extension-boundary-inputs.mts
+++ b/scripts/lib/extension-boundary-inputs.mts
@@ -69,7 +69,7 @@ export class BoundaryInputSnapshot {
     string,
     { files: string[]; roots: string[]; options: ts.CompilerOptions }
   >();
-  private topology?: string;
+  private topology?: { name: string; directory: string }[];
   private tools?: string;
   readonly rootDir: string;
   constructor(rootDir: string) {
@@ -131,9 +131,9 @@ export class BoundaryInputSnapshot {
     return result;
   }
 
-  private namespace() {
+  private namespace(outputRoot?: string) {
     if (this.topology === undefined) {
-      const names: string[] = [];
+      const names: { name: string; directory: string }[] = [];
       const visited = new Map<string, boolean>();
       const active = new Set<string>();
       const visit = (directory: string, installed = false) => {
@@ -149,6 +149,7 @@ export class BoundaryInputSnapshot {
         // Upgrade that traversal once; active ancestors still fence link cycles.
         visited.set(realDirectory, installed);
         active.add(realDirectory);
+        const add = (name: string) => names.push({ name, directory: realDirectory });
         const entries = fs
           .readdirSync(directory, { withFileTypes: true })
           .toSorted((left, right) => (left.name < right.name ? -1 : 1));
@@ -170,22 +171,22 @@ export class BoundaryInputSnapshot {
           }
           let isDirectory = entry.isDirectory();
           if (entry.isSymbolicLink()) {
-            names.push(`${id}->${fs.readlinkSync(file)}`);
+            add(`${id}->${fs.readlinkSync(file)}`);
             try {
               isDirectory = fs.statSync(file).isDirectory();
             } catch (error) {
               if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
                 throw error;
               }
-              names.push(`${id}:missing`);
+              add(`${id}:missing`);
               continue;
             }
-            names.push(`${id}:${isDirectory ? "directory" : "file"}`);
+            add(`${id}:${isDirectory ? "directory" : "file"}`);
           }
           if (isDirectory) {
             visit(file, installed || entry.name === "node_modules");
           } else if (/\.(?:[cm]?[jt]sx?|json)$/u.test(entry.name)) {
-            names.push(id);
+            add(id);
           }
         }
         active.delete(realDirectory);
@@ -194,9 +195,21 @@ export class BoundaryInputSnapshot {
       // the local resolution namespace invalidate conservatively; unrelated byte
       // edits do not. Installed package contents are included, not just lockfiles.
       visit(this.rootDir);
-      this.topology = digest(names.toSorted().join("\0"));
+      this.topology = names;
     }
-    return this.topology;
+    // Workspace aliases can expose this producer's outputs as installed inputs.
+    // Keep their link identities, and retain the same subtree for other consumers.
+    return digest(
+      this.topology
+        .filter(
+          ({ directory }) =>
+            !outputRoot ||
+            (directory !== outputRoot && !directory.startsWith(`${outputRoot}${path.sep}`)),
+        )
+        .map(({ name }) => name)
+        .toSorted()
+        .join("\0"),
+    );
   }
 
   private toolchain() {
@@ -214,13 +227,14 @@ export class BoundaryInputSnapshot {
     return this.tools;
   }
 
-  signature(config: string, args: string[], inputs: string[]) {
+  signature(config: string, args: string[], inputs: string[], outputRoot?: string) {
     const parsed = this.config(config);
     return digest(
       JSON.stringify(
         [
           ARTIFACT_CACHE_VERSION,
-          this.namespace(),
+          this.namespace(outputRoot),
+          outputRoot,
           this.toolchain(),
           config,
           args,
@@ -247,7 +261,7 @@ export class BoundaryInputSnapshot {
     try {
       return (
         record?.inputs !== undefined &&
-        record.signature === this.signature(config, args, record.inputs) &&
+        record.signature === this.signature(config, args, record.inputs, outputRoot) &&
         required.every((file) => Object.hasOwn(record.outputs, file)) &&
         (!outputRoot ||
           listCacheFiles(
@@ -272,6 +286,7 @@ export class BoundaryInputSnapshot {
     outputs: string[],
     before: BoundaryInputSnapshot,
     startedAt: number,
+    outputRoot?: string,
   ): ArtifactRecord {
     const info: { fileNames: string[]; fileInfos: unknown[]; packageJsons?: string[] } = JSON.parse(
       this.read(buildInfo).bytes.toString("utf8"),
@@ -292,9 +307,9 @@ export class BoundaryInputSnapshot {
     ]
       .map((file) => portableRelativePath(this.rootDir, file))
       .toSorted();
-    const signature = this.signature(config, args, inputs);
+    const signature = this.signature(config, args, inputs, outputRoot);
     if (
-      before.namespace() !== this.namespace() ||
+      before.namespace(outputRoot) !== this.namespace(outputRoot) ||
       before.toolchain() !== this.toolchain() ||
       JSON.stringify(before.config(config)) !== JSON.stringify(this.config(config)) ||
       before.config(config).files.some((file) => before.hash(file) !== this.hash(file))

--- a/scripts/prepare-extension-package-boundary-artifacts.mts
+++ b/scripts/prepare-extension-package-boundary-artifacts.mts
@@ -232,8 +232,14 @@ async function prepareExtensionPackageBoundaryArtifacts(argv: string[] = process
     rootDir: `extensions/${id}`,
     required: [`${LOCAL_PLUGIN_ROOT}/${id}/${entry}.d.ts`],
   }));
+  const batches = [[sdk], mode === "all" ? plugins : []].map((batch) =>
+    batch.map((unit) => {
+      fs.mkdirSync(resolve(repoRoot, unit.outDir), { recursive: true });
+      return { ...unit, outputRoot: fs.realpathSync(resolve(repoRoot, unit.outDir)) };
+    }),
+  );
   let before = new BoundaryInputSnapshot(repoRoot);
-  for (const batch of [[sdk], mode === "all" ? plugins : []]) {
+  for (const batch of batches) {
     if (!batch.length) {
       continue;
     }
@@ -262,9 +268,15 @@ async function prepareExtensionPackageBoundaryArtifacts(argv: string[] = process
         ];
         const previous = readArtifactRecord(recordPath);
         // Prime config/toolchain/topology before starting even an uncached owner.
-        before.signature(unit.config, args, []);
+        before.signature(unit.config, args, [], unit.outputRoot);
         if (
-          before.matches(previous, unit.config, args, [...unit.required, buildInfo], unit.outDir)
+          before.matches(
+            previous,
+            unit.config,
+            args,
+            [...unit.required, buildInfo],
+            unit.outputRoot,
+          )
         ) {
           process.stdout.write(`[${unit.id} boundary dts] fresh; skipping\n`);
           return null;
@@ -314,6 +326,7 @@ async function prepareExtensionPackageBoundaryArtifacts(argv: string[] = process
         outputs,
         before,
         unit.startedAt,
+        unit.outputRoot,
       );
       return Object.assign(unit, { record });
     });

--- a/test/scripts/build-artifact-cache.test.ts
+++ b/test/scripts/build-artifact-cache.test.ts
@@ -18,7 +18,7 @@ const native = path.join(
   path.dirname(require.resolve("@typescript/native-preview/package.json")),
   "lib/tsgo.js",
 );
-function fixture(noEmit = false) {
+function fixture(noEmit = false, outputRoot = "dist") {
   const root = fs.realpathSync(roots.make("native-boundary-cache-"));
   const write = (file: string, bytes: string) => {
     const target = path.join(root, file);
@@ -35,7 +35,7 @@ function fixture(noEmit = false) {
         allowJs: true,
         declaration: true,
         incremental: true,
-        outDir: "dist",
+        outDir: outputRoot,
         rootDir: ".",
         skipLibCheck: true,
       },
@@ -52,7 +52,7 @@ function fixture(noEmit = false) {
   write("unrelated/source.ts", "export const unrelated = 1;");
   write("src/api.test.ts", "export const test = 1;");
   const config = "tsconfig.json";
-  const buildInfo = "dist/.tsbuildinfo";
+  const buildInfo = `${outputRoot}/.tsbuildinfo`;
   const args = [
     "-p",
     path.join(root, config),
@@ -61,9 +61,11 @@ function fixture(noEmit = false) {
     path.join(root, buildInfo),
     "--listEmittedFiles",
   ];
+  const ownedOutputRoot = noEmit ? undefined : path.join(root, outputRoot);
   const prepare = () => {
+    fs.mkdirSync(path.join(root, outputRoot), { recursive: true });
     const before = new BoundaryInputSnapshot(root);
-    before.signature(config, args, []);
+    before.signature(config, args, [], ownedOutputRoot);
     fs.rmSync(path.join(root, buildInfo), { force: true });
     const startedAt = Date.now();
     const result = spawnSync(process.execPath, [native, ...args], { encoding: "utf8" });
@@ -83,11 +85,95 @@ function fixture(noEmit = false) {
       run.files,
       run.before,
       run.startedAt,
+      ownedOutputRoot,
     );
-  return { root, write, config, args, prepare, seal, outputRoot: noEmit ? undefined : "dist" };
+  return { root, write, config, args, prepare, seal, outputRoot: ownedOutputRoot };
 }
 
 describe("native owner content records", () => {
+  it("seals a cold producer reached through its own workspace package alias", () => {
+    const f = fixture(false, "packages/sdk/dist");
+    f.write("packages/sdk/package.json", '{"name":"fixture-sdk","type":"module"}');
+    fs.mkdirSync(path.join(f.root, "node_modules"));
+    fs.symlinkSync("../packages/sdk", path.join(f.root, "node_modules/fixture-sdk"), "dir");
+    fs.symlinkSync(".", path.join(f.root, "packages/sdk/self"), "dir");
+
+    const record = f.seal(f.prepare());
+    expect(record.outputs["packages/sdk/dist/src/api.d.ts"]).toBeDefined();
+    expect(
+      new BoundaryInputSnapshot(f.root).matches(
+        record,
+        f.config,
+        f.args,
+        Object.keys(record.outputs),
+        f.outputRoot,
+      ),
+    ).toBe(true);
+    fs.unlinkSync(path.join(f.root, "node_modules/fixture-sdk"));
+    expect(
+      new BoundaryInputSnapshot(f.root).matches(
+        record,
+        f.config,
+        f.args,
+        Object.keys(record.outputs),
+        f.outputRoot,
+      ),
+    ).toBe(false);
+  });
+
+  it("retains upstream output topology when a producer snapshot is reused by a consumer", () => {
+    const f = fixture(false, "packages/sdk/dist");
+    f.write("packages/sdk/package.json", '{"name":"fixture-sdk","type":"module"}');
+    f.write("consumer.json", '{"extends":"./base.json","files":["consumer.ts"]}');
+    f.write(
+      "consumer.ts",
+      'import { value } from "fixture-sdk/dist/nested/value.js"; const expected: 1 = value;',
+    );
+    fs.mkdirSync(path.join(f.root, "node_modules"));
+    fs.symlinkSync("../packages/sdk", path.join(f.root, "node_modules/fixture-sdk"), "dir");
+    const producer = f.prepare();
+    const shared = new BoundaryInputSnapshot(f.root);
+    shared.record(
+      f.config,
+      f.args,
+      "packages/sdk/dist/.tsbuildinfo",
+      producer.files,
+      producer.before,
+      producer.startedAt,
+      f.outputRoot,
+    );
+    const config = "consumer.json";
+    const metadata = ".artifacts/consumer.tsbuildinfo";
+    const args = [
+      "-p",
+      path.join(f.root, config),
+      "--noEmit",
+      "--incremental",
+      "--tsBuildInfoFile",
+      path.join(f.root, metadata),
+    ];
+    shared.signature(config, args, []);
+    const startedAt = Date.now();
+    const compiled = spawnSync(process.execPath, [native, ...args], { encoding: "utf8" });
+    expect(compiled.status, compiled.stdout + compiled.stderr).toBe(0);
+    const record = new BoundaryInputSnapshot(f.root).record(
+      config,
+      args,
+      metadata,
+      [metadata],
+      shared,
+      startedAt,
+    );
+    const matches = () =>
+      new BoundaryInputSnapshot(f.root).matches(record, config, args, [metadata]);
+    expect(matches()).toBe(true);
+    f.write("packages/sdk/dist/nested/value.ts", 'export const value = "changed";');
+    expect(matches()).toBe(false);
+    const changed = spawnSync(process.execPath, [native, ...args], { encoding: "utf8" });
+    expect(changed.status, changed.stdout + changed.stderr).toBe(1);
+    expect(changed.stdout).toContain("TS2322");
+  });
+
   it.each(["node_modules", "package", "source"])(
     "invalidates new resolution candidates behind linked %s directories",
     (layout) => {


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where cold release verification fails during declaration preparation after the type checks pass. A pnpm workspace alias exposes the SDK's newly generated declarations as installed-package resolution inputs, so the cache guard rejects its own successful compiler output as a concurrent input change.

## Why This Change Was Made

Bind the topology exclusion to each producer's canonical output directory, including paths reached through workspace aliases. Capture one complete namespace and project it per producer, so the subsequent plugin consumers still see SDK output topology. Materialize output directories under the existing artifact owner before taking the first snapshot.

Alias identities, external installed declarations, input bytes, compiler identity, output inventories, and joined-writer checks remain guarded. No blanket installed-package exclusions, retries, timeout changes, concurrency changes, or new configuration are added. This repairs the cold alias case introduced by #132532 (authored and merged by @steipete).

## User Impact

Release and changed-file checks can prepare declarations from a cold pnpm workspace and reuse the resulting cache. There is no product runtime or public API change.

## Evidence

- Native compiler regression failed before the repair with `Boundary configuration or resolution topology changed during compilation`. The repaired test covers cold emission, sealing, warm reuse, alias removal, and a symlink cycle. A second native-compiler test reuses the producer snapshot for a consumer: adding an upstream resolution candidate invalidates the record and changes compilation from success to TS2322.
- Full changed-file gate passed, including scripts and root-test type graphs. The related four-file local run passed 75 tests and hit three unchanged 30-second lifecycle deadlines on a heavily contended host; this run was not green. Those exact three cases then passed on Linux without changing deadlines (3 passed, 26 intentionally filtered out; 6.86 seconds Vitest, 10.24 seconds runner).
- Actual cold Linux proof: Blacksmith Testbox `tbx_01m16tgxt6ma5vwnfwysmz60vn`, [Actions lease](https://github.com/openclaw/openclaw/actions/runs/33254519852), Node 24.19.0. Separate frozen checkouts at `7b5fffb917db04c031e41c1bcd0c055df69f3a3d`, frozen-lockfile installs, empty declaration/cache outputs, and verified same-checkout pnpm aliases. The after checkout differs only by the two repaired owner files.
- Before: canonical SDK declaration preparation failed at the reported topology guard in **47.772 seconds**, leaving no SDK success record. After: canonical full preparation emitted all **eight** SDK/plugin units in **58.411 seconds**. Every recorded output hash matched disk. The unchanged warm full preparation skipped all eight units in **1.452 seconds**. The cold commands differ only in the baseline's SDK-only mode versus the broader repaired full mode; this is correctness/cache-reuse evidence, not a before/after cold speed comparison.
- Final tooling source hashes: `extension-boundary-inputs.mts` SHA-256 `1fa8b751658ee2d82ab4da8bafbf8bab62c0f4be808ae9db77bffc2fd4e4fe5f`; producer SHA-256 `3aab6160ae584ad5778d5bb09199994e7639e0d9d4228f851fd37a4df3bf3049`. Structured local receipts and cold/warm logs retained for maintainer inspection. The remote command completed successfully; its portal wrapper was interrupted only after the final successful timing receipt. The subsequent focused run joined normally, and the owned lease was stopped after receipt download.
- Independent Codex autoreview (P0 threshold) and direct maintainer source review found no actionable findings. Runtime LOC: zero; build tooling +45/-17 (net +28) carries canonical producer ownership through the shared snapshot, avoiding a second namespace walk or consumer blind spot. Regression tests +91/-5.
