### PR TITLE
fix(wizard): offer the plugins that are actually active

### DIFF
--- a/src/plugins/config-state.ts
+++ b/src/plugins/config-state.ts
@@ -2,6 +2,8 @@ import { isRecord } from "@openclaw/normalization-core/record-coerce";
 /** Normalizes plugin config and resolves effective enablement, slots, and activation sources. */
 import { normalizeOptionalLowercaseString } from "@openclaw/normalization-core/string-coerce";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import type { PluginEntryConfig } from "../config/types.plugins.js";
+import { mergeDeep } from "../infra/deep-merge.js";
 import {
   createEffectiveEnableStateResolver,
   createPluginEnableStateResolver,
@@ -72,6 +74,37 @@ export function resolveSelectedContextEnginePluginIdFromConfig(
     return undefined;
   }
   return pluginId;
+}
+
+/**
+ * Merges every raw entry resolving to one plugin id into a single entry.
+ *
+ * Aliases are folded first and the canonical id last, so canonical values win regardless of
+ * the order the keys sit in the file. Without this, collapsing an alias onto the canonical id
+ * keeps only whichever of the two happened to be written last and silently drops the other
+ * side's settings.
+ */
+export function mergePluginEntryAliases(
+  config: OpenClawConfig,
+  pluginId: string,
+): PluginEntryConfig {
+  const resolvedId = normalizePluginId(pluginId);
+  const matching = Object.entries(config.plugins?.entries ?? {})
+    .filter(([entryId]) => normalizePluginId(entryId) === resolvedId)
+    .toSorted(([leftId], [rightId]) => {
+      if (leftId === resolvedId) {
+        return rightId === resolvedId ? 0 : 1;
+      }
+      if (rightId === resolvedId) {
+        return -1;
+      }
+      return leftId.localeCompare(rightId, "en");
+    });
+  let merged: PluginEntryConfig = {};
+  for (const [, entry] of matching) {
+    merged = mergeDeep(merged, entry) as PluginEntryConfig;
+  }
+  return merged;
 }
 
 /** Canonicalizes one plugin entry and its policy-list ids before a targeted mutation. */

--- a/src/plugins/config-state.ts
+++ b/src/plugins/config-state.ts
@@ -79,40 +79,55 @@ export function resolveSelectedContextEnginePluginIdFromConfig(
 /**
  * Merges every raw entry resolving to one plugin id into a single persisted entry.
  *
- * The raw entries are the base, because they are already in persisted shape. The normalized
- * entry is not: it carries derived policy such as `hasAllowedModelsConfig`, which the strict
- * config schema forbids, and it replaces the `allowedModels` list those flags were derived
- * from. Only `enabled` is taken from it, because raw entries are applied in file order, so a
- * later alias saying `enabled: true` beats a canonical `false` and the plugin is running;
- * folding with canonical last would write that `false` back and switch it off.
+ * Two precedences, because two different things are being merged.
  *
- * Aliases fold first and the canonical entry last so canonical values win a key clash
- * regardless of the order the two sit in the file.
+ * Policy (`enabled`, `hooks`, `subagent`, `llm`) folds in **file order**, which is how runtime
+ * normalization resolves it: the last raw entry wins. Any other order rewrites live policy.
+ * A later legacy alias denying `allowConversationAccess` or an LLM override is the effective
+ * setting, so folding canonical-last would write the grant back and hand the plugin a
+ * permission it is currently being refused.
+ *
+ * The config payload folds with the canonical entry **last**, so canonical values win a key
+ * clash whichever order the two sit in the file, and nothing is dropped from either side.
+ *
+ * Raw entries are the base throughout. The normalized entry is runtime policy rather than
+ * persisted config: it carries derived keys such as `hasAllowedModelsConfig` that the strict
+ * schema forbids, and it replaces the `allowedModels` list they were derived from.
  */
 export function mergePluginEntryAliases(
   config: OpenClawConfig,
   pluginId: string,
 ): PluginEntryConfig {
   const resolvedId = normalizePluginId(pluginId);
-  const matching = Object.entries(config.plugins?.entries ?? {})
-    .filter(([entryId]) => normalizePluginId(entryId) === resolvedId)
-    .toSorted(([leftId], [rightId]) => {
-      if (leftId === resolvedId) {
-        return rightId === resolvedId ? 0 : 1;
-      }
-      if (rightId === resolvedId) {
-        return -1;
-      }
-      return leftId.localeCompare(rightId, "en");
-    });
-  let merged: PluginEntryConfig = {};
-  for (const [, entry] of matching) {
-    merged = mergeDeep(merged, entry) as PluginEntryConfig;
+  const inFileOrder = Object.entries(config.plugins?.entries ?? {}).filter(
+    ([entryId]) => normalizePluginId(entryId) === resolvedId,
+  );
+  const canonicalLast = inFileOrder.toSorted(([leftId], [rightId]) => {
+    if (leftId === resolvedId) {
+      return rightId === resolvedId ? 0 : 1;
+    }
+    if (rightId === resolvedId) {
+      return -1;
+    }
+    return leftId.localeCompare(rightId, "en");
+  });
+
+  let policy: PluginEntryConfig = {};
+  for (const [, entry] of inFileOrder) {
+    const { config: _payload, ...rest } = entry;
+    policy = mergeDeep(policy, rest) as PluginEntryConfig;
   }
-  const effectiveEnabled = normalizePluginsConfig(config.plugins).entries[resolvedId]?.enabled;
+
+  let payload: Record<string, unknown> = {};
+  for (const [, entry] of canonicalLast) {
+    if (isRecord(entry.config)) {
+      payload = mergeDeep(payload, entry.config) as Record<string, unknown>;
+    }
+  }
+
   return {
-    ...merged,
-    ...(effectiveEnabled === undefined ? {} : { enabled: effectiveEnabled }),
+    ...policy,
+    ...(Object.keys(payload).length > 0 ? { config: payload } : {}),
   };
 }
 

--- a/src/plugins/config-state.ts
+++ b/src/plugins/config-state.ts
@@ -77,18 +77,21 @@ export function resolveSelectedContextEnginePluginIdFromConfig(
 }
 
 /**
- * Merges every raw entry resolving to one plugin id into a single entry.
+ * Merges the config payloads of every raw entry resolving to one plugin id.
  *
- * Aliases are folded first and the canonical id last, so canonical values win regardless of
- * the order the keys sit in the file. Without this, collapsing an alias onto the canonical id
- * keeps only whichever of the two happened to be written last and silently drops the other
- * side's settings.
+ * Enablement and the other policy fields come from the normalizer, because that is what the
+ * runtime actually resolves. Deciding them here instead would flip a plugin: raw entries are
+ * applied in file order, so a later alias saying `enabled: true` beats a canonical `false`,
+ * while a fold that always puts canonical last would write `false` back and switch off a
+ * plugin that is running. Only the config payload is merged, aliases first so canonical
+ * values win a key clash regardless of the order they sit in the file.
  */
 export function mergePluginEntryAliases(
   config: OpenClawConfig,
   pluginId: string,
 ): PluginEntryConfig {
   const resolvedId = normalizePluginId(pluginId);
+  const effective = normalizePluginsConfig(config.plugins).entries[resolvedId] ?? {};
   const matching = Object.entries(config.plugins?.entries ?? {})
     .filter(([entryId]) => normalizePluginId(entryId) === resolvedId)
     .toSorted(([leftId], [rightId]) => {
@@ -100,11 +103,19 @@ export function mergePluginEntryAliases(
       }
       return leftId.localeCompare(rightId, "en");
     });
-  let merged: PluginEntryConfig = {};
+  let mergedConfig: Record<string, unknown> = {};
   for (const [, entry] of matching) {
-    merged = mergeDeep(merged, entry) as PluginEntryConfig;
+    if (isRecord(entry.config)) {
+      mergedConfig = mergeDeep(mergedConfig, entry.config) as Record<string, unknown>;
+    }
   }
-  return merged;
+  // The normalized entry types `config` as unknown, and it is replaced below anyway, so the
+  // policy fields are taken on their own.
+  const { config: _normalizedConfig, ...policy } = effective;
+  return {
+    ...policy,
+    ...(Object.keys(mergedConfig).length > 0 ? { config: mergedConfig } : {}),
+  };
 }
 
 /** Canonicalizes one plugin entry and its policy-list ids before a targeted mutation. */

--- a/src/plugins/config-state.ts
+++ b/src/plugins/config-state.ts
@@ -77,21 +77,23 @@ export function resolveSelectedContextEnginePluginIdFromConfig(
 }
 
 /**
- * Merges the config payloads of every raw entry resolving to one plugin id.
+ * Merges every raw entry resolving to one plugin id into a single persisted entry.
  *
- * Enablement and the other policy fields come from the normalizer, because that is what the
- * runtime actually resolves. Deciding them here instead would flip a plugin: raw entries are
- * applied in file order, so a later alias saying `enabled: true` beats a canonical `false`,
- * while a fold that always puts canonical last would write `false` back and switch off a
- * plugin that is running. Only the config payload is merged, aliases first so canonical
- * values win a key clash regardless of the order they sit in the file.
+ * The raw entries are the base, because they are already in persisted shape. The normalized
+ * entry is not: it carries derived policy such as `hasAllowedModelsConfig`, which the strict
+ * config schema forbids, and it replaces the `allowedModels` list those flags were derived
+ * from. Only `enabled` is taken from it, because raw entries are applied in file order, so a
+ * later alias saying `enabled: true` beats a canonical `false` and the plugin is running;
+ * folding with canonical last would write that `false` back and switch it off.
+ *
+ * Aliases fold first and the canonical entry last so canonical values win a key clash
+ * regardless of the order the two sit in the file.
  */
 export function mergePluginEntryAliases(
   config: OpenClawConfig,
   pluginId: string,
 ): PluginEntryConfig {
   const resolvedId = normalizePluginId(pluginId);
-  const effective = normalizePluginsConfig(config.plugins).entries[resolvedId] ?? {};
   const matching = Object.entries(config.plugins?.entries ?? {})
     .filter(([entryId]) => normalizePluginId(entryId) === resolvedId)
     .toSorted(([leftId], [rightId]) => {
@@ -103,18 +105,14 @@ export function mergePluginEntryAliases(
       }
       return leftId.localeCompare(rightId, "en");
     });
-  let mergedConfig: Record<string, unknown> = {};
+  let merged: PluginEntryConfig = {};
   for (const [, entry] of matching) {
-    if (isRecord(entry.config)) {
-      mergedConfig = mergeDeep(mergedConfig, entry.config) as Record<string, unknown>;
-    }
+    merged = mergeDeep(merged, entry) as PluginEntryConfig;
   }
-  // The normalized entry types `config` as unknown, and it is replaced below anyway, so the
-  // policy fields are taken on their own.
-  const { config: _normalizedConfig, ...policy } = effective;
+  const effectiveEnabled = normalizePluginsConfig(config.plugins).entries[resolvedId]?.enabled;
   return {
-    ...policy,
-    ...(Object.keys(mergedConfig).length > 0 ? { config: mergedConfig } : {}),
+    ...merged,
+    ...(effectiveEnabled === undefined ? {} : { enabled: effectiveEnabled }),
   };
 }
 

--- a/src/plugins/toggle-config.ts
+++ b/src/plugins/toggle-config.ts
@@ -1,9 +1,11 @@
 // Toggles plugin enablement config for channels and agents.
 import { normalizeChatChannelId } from "../channels/ids.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import type { PluginEntryConfig } from "../config/types.plugins.js";
-import { mergeDeep } from "../infra/deep-merge.js";
-import { normalizePluginId, normalizePluginTargetConfig } from "./config-state.js";
+import {
+  mergePluginEntryAliases,
+  normalizePluginId,
+  normalizePluginTargetConfig,
+} from "./config-state.js";
 
 /** Returns config with a plugin enabled/disabled and optional built-in channel state synced. */
 export function setPluginEnabledInConfig(
@@ -15,23 +17,7 @@ export function setPluginEnabledInConfig(
   const builtInChannelId = normalizeChatChannelId(pluginId);
   const resolvedId = normalizePluginId(builtInChannelId ?? pluginId);
   const normalizedConfig = normalizePluginTargetConfig(config, resolvedId);
-  let existingEntry: PluginEntryConfig = {};
-  // Fold aliases first and the canonical entry last so duplicate config keeps
-  // every nested setting while canonical values win independent of file order.
-  const existingEntries = Object.entries(config.plugins?.entries ?? {})
-    .filter(([entryId]) => normalizePluginId(entryId) === resolvedId)
-    .toSorted(([leftId], [rightId]) => {
-      if (leftId === resolvedId) {
-        return rightId === resolvedId ? 0 : 1;
-      }
-      if (rightId === resolvedId) {
-        return -1;
-      }
-      return leftId.localeCompare(rightId, "en");
-    });
-  for (const [, entry] of existingEntries) {
-    existingEntry = mergeDeep(existingEntry, entry) as PluginEntryConfig;
-  }
+  const existingEntry = mergePluginEntryAliases(config, resolvedId);
 
   const next: OpenClawConfig = {
     ...normalizedConfig,

--- a/src/wizard/setup.plugin-config.test.ts
+++ b/src/wizard/setup.plugin-config.test.ts
@@ -541,6 +541,49 @@ describe("setupPluginConfig", () => {
     },
   );
 
+  it("does not switch a plugin off while folding a conflicting alias", async () => {
+    // Raw entries are applied in file order, so a later alias saying enabled true beats a
+    // canonical false and the plugin is running. A fold that always puts canonical last
+    // would write that false back and silently disable it on the next wizard answer.
+    loadPluginManifestRegistryCore.mockReturnValue({
+      plugins: [
+        {
+          ...makeManifestPlugin("google", {
+            apiKey: { label: "API key" },
+            region: { label: "Region" },
+          }),
+          enabledByDefault: false,
+        },
+      ],
+    });
+
+    const result = await setupPluginConfig({
+      config: {
+        plugins: {
+          entries: {
+            google: { enabled: false, config: { region: "eu" } },
+            "google-gemini-cli": { enabled: true },
+          },
+        },
+      } as unknown as OpenClawConfig,
+      prompter: {
+        intro: vi.fn(async () => {}),
+        outro: vi.fn(async () => {}),
+        note: vi.fn(async () => {}),
+        select: vi.fn(async () => "") as unknown as WizardPrompter["select"],
+        multiselect: vi.fn(async () => ["google"]) as unknown as WizardPrompter["multiselect"],
+        text: vi.fn(async () => "written-key"),
+        confirm: vi.fn(async () => true),
+        progress: vi.fn(() => ({ update: vi.fn(), stop: vi.fn() })),
+      },
+    });
+
+    // Still on, and the region it already had is still there.
+    expect(result.plugins?.entries?.google?.enabled).toBe(true);
+    expect(result.plugins?.entries?.google?.config).toMatchObject({ region: "eu" });
+    expect(result.plugins?.entries?.["google-gemini-cli"]).toBeUndefined();
+  });
+
   it("hands activation the discovery its inventory came from", async () => {
     // With only the registry forwarded, auto-enable re-derives a default scope discovery, so
     // a workspace scoped run judges activation against a different generation than the

--- a/src/wizard/setup.plugin-config.test.ts
+++ b/src/wizard/setup.plugin-config.test.ts
@@ -490,6 +490,57 @@ describe("setupPluginConfig", () => {
     expect(result.plugins?.entries?.["google-gemini-cli"]).toBeUndefined();
   });
 
+  it.each([
+    { name: "alias written first", aliasFirst: true },
+    { name: "canonical written first", aliasFirst: false },
+  ])(
+    "keeps both sides when alias and canonical both hold config, $name",
+    async ({ aliasFirst }) => {
+      // A config can carry both keys at once. Collapsing them keeps only whichever one the
+      // normalizer wrote last, so one side's settings vanish, and which side that is depends
+      // on the order they sit in the file. Both orders have to end up the same.
+      const aliasEntry = { enabled: true, config: { apiKey: "from-alias" } };
+      const canonicalEntry = { enabled: true, config: { region: "from-canonical" } };
+      const entries = aliasFirst
+        ? { "google-gemini-cli": aliasEntry, google: canonicalEntry }
+        : { google: canonicalEntry, "google-gemini-cli": aliasEntry };
+
+      loadPluginManifestRegistryCore.mockReturnValue({
+        plugins: [
+          {
+            ...makeManifestPlugin("google", {
+              apiKey: { label: "API key" },
+              region: { label: "Region" },
+              model: { label: "Model" },
+            }),
+            enabledByDefault: true,
+          },
+        ],
+      });
+
+      const result = await setupPluginConfig({
+        config: { plugins: { entries } } as unknown as OpenClawConfig,
+        prompter: {
+          intro: vi.fn(async () => {}),
+          outro: vi.fn(async () => {}),
+          note: vi.fn(async () => {}),
+          select: vi.fn(async () => "") as unknown as WizardPrompter["select"],
+          multiselect: vi.fn(async () => ["google"]) as unknown as WizardPrompter["multiselect"],
+          text: vi.fn(async () => "gemini-2"),
+          confirm: vi.fn(async () => true),
+          progress: vi.fn(() => ({ update: vi.fn(), stop: vi.fn() })),
+        },
+      });
+
+      expect(result.plugins?.entries?.google?.config).toEqual({
+        apiKey: "from-alias",
+        region: "from-canonical",
+        model: "gemini-2",
+      });
+      expect(result.plugins?.entries?.["google-gemini-cli"]).toBeUndefined();
+    },
+  );
+
   it("hands activation the discovery its inventory came from", async () => {
     // With only the registry forwarded, auto-enable re-derives a default scope discovery, so
     // a workspace scoped run judges activation against a different generation than the

--- a/src/wizard/setup.plugin-config.test.ts
+++ b/src/wizard/setup.plugin-config.test.ts
@@ -32,7 +32,7 @@ vi.mock("../plugins/plugin-metadata-snapshot.js", () => ({
 
 // Wraps the real resolver rather than replacing it, so every other test keeps running
 // against actual activation behaviour while this one can see what it was handed.
-let activationInputParams: { discovery?: unknown; manifestRegistry?: unknown } | undefined;
+const activationInputs: { discovery?: unknown; manifestRegistry?: unknown }[] = [];
 
 vi.mock("../plugins/activation-context.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../plugins/activation-context.js")>();
@@ -41,7 +41,7 @@ vi.mock("../plugins/activation-context.js", async (importOriginal) => {
     resolvePluginActivationInputs: (
       params: Parameters<typeof actual.resolvePluginActivationInputs>[0],
     ) => {
-      activationInputParams = params;
+      activationInputs.push(params);
       return actual.resolvePluginActivationInputs(params);
     },
   };
@@ -495,7 +495,7 @@ describe("setupPluginConfig", () => {
     // a workspace scoped run judges activation against a different generation than the
     // plugin list was built from.
     const discovery = { candidates: [], diagnostics: [] };
-    activationInputParams = undefined;
+    activationInputs.length = 0;
     loadPluginManifestRegistryCore.mockReturnValue({
       plugins: [makeManifestPlugin("brave", { token: { label: "Token" } })],
       discovery,
@@ -516,7 +516,7 @@ describe("setupPluginConfig", () => {
       },
     });
 
-    expect(activationInputParams?.discovery).toBe(discovery);
+    expect(activationInputs.at(-1)?.discovery).toBe(discovery);
   });
 
   it.each([

--- a/src/wizard/setup.plugin-config.test.ts
+++ b/src/wizard/setup.plugin-config.test.ts
@@ -541,6 +541,52 @@ describe("setupPluginConfig", () => {
     },
   );
 
+  it("does not grant a permission a later alias is denying", async () => {
+    // Runtime normalization takes the last raw entry, so an alias written after the canonical
+    // one is the effective policy. Folding canonical-last would write the grant back and hand
+    // the plugin conversation access and prompt injection it is currently refused.
+    loadPluginManifestRegistryCore.mockReturnValue({
+      plugins: [
+        {
+          ...makeManifestPlugin("google", { apiKey: { label: "API key" } }),
+          enabledByDefault: true,
+        },
+      ],
+    });
+
+    const result = await setupPluginConfig({
+      config: {
+        plugins: {
+          entries: {
+            google: {
+              enabled: true,
+              hooks: { allowConversationAccess: true, allowPromptInjection: true },
+            },
+            "google-gemini-cli": {
+              enabled: true,
+              hooks: { allowConversationAccess: false, allowPromptInjection: false },
+            },
+          },
+        },
+      } as unknown as OpenClawConfig,
+      prompter: {
+        intro: vi.fn(async () => {}),
+        outro: vi.fn(async () => {}),
+        note: vi.fn(async () => {}),
+        select: vi.fn(async () => "") as unknown as WizardPrompter["select"],
+        multiselect: vi.fn(async () => ["google"]) as unknown as WizardPrompter["multiselect"],
+        text: vi.fn(async () => "written-key"),
+        confirm: vi.fn(async () => true),
+        progress: vi.fn(() => ({ update: vi.fn(), stop: vi.fn() })),
+      },
+    });
+
+    expect(result.plugins?.entries?.google?.hooks).toEqual({
+      allowConversationAccess: false,
+      allowPromptInjection: false,
+    });
+  });
+
   it("does not write normalization-only fields into the saved config", async () => {
     // normalizePluginsConfig derives hasAllowedModelsConfig for runtime policy and drops the
     // allowedModels list it came from. Those derived keys are not allowed in persisted config,

--- a/src/wizard/setup.plugin-config.test.ts
+++ b/src/wizard/setup.plugin-config.test.ts
@@ -239,6 +239,61 @@ describe("discoverUnconfiguredPlugins", () => {
 });
 
 describe("setupPluginConfig", () => {
+  it("does not offer a default-on plugin that config explicitly disables", async () => {
+    // `enabledByDefault || entry.enabled === true` reads an explicit false as "not true" and
+    // falls back to the manifest default, so the wizard used to solicit settings for a plugin
+    // that is switched off and then warn that its config is present but the plugin is disabled.
+    loadPluginManifestRegistryCore.mockReturnValue({
+      plugins: [
+        {
+          ...makeManifestPlugin("xai", { apiKey: { label: "API key" } }),
+          origin: "bundled",
+          enabledByDefault: true,
+        },
+      ],
+    });
+
+    const multiselect = vi.fn(async () => {
+      throw new Error("multiselect should not run when no plugin is active");
+    });
+    const text = vi.fn(async () => {
+      throw new Error("text should not run when no plugin is active");
+    });
+
+    const result = await setupPluginConfig({
+      config: {
+        plugins: {
+          entries: {
+            xai: { enabled: false },
+          },
+        },
+      } as OpenClawConfig,
+      prompter: {
+        intro: vi.fn(async () => {}),
+        outro: vi.fn(async () => {}),
+        note: vi.fn(async () => {}),
+        select: vi.fn(async () => {
+          throw new Error("select should not run when no plugin is active");
+        }) as unknown as WizardPrompter["select"],
+        multiselect: multiselect as unknown as WizardPrompter["multiselect"],
+        text: text as unknown as WizardPrompter["text"],
+        confirm: vi.fn(async () => {
+          throw new Error("confirm should not run when no plugin is active");
+        }),
+        progress: vi.fn(() => ({ update: vi.fn(), stop: vi.fn() })),
+      },
+    });
+
+    expect(multiselect).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      plugins: {
+        entries: {
+          xai: { enabled: false },
+        },
+      },
+    });
+  });
+
   it("allows skipping plugin setup from the multiselect prompt", async () => {
     loadPluginManifestRegistryCore.mockReturnValue({
       plugins: [

--- a/src/wizard/setup.plugin-config.test.ts
+++ b/src/wizard/setup.plugin-config.test.ts
@@ -25,9 +25,27 @@ vi.mock("../plugins/plugin-metadata-snapshot.js", () => ({
     return {
       plugins: registry.plugins,
       manifestRegistry: registry,
+      discovery: registry.discovery,
     };
   },
 }));
+
+// Wraps the real resolver rather than replacing it, so every other test keeps running
+// against actual activation behaviour while this one can see what it was handed.
+let activationInputParams: { discovery?: unknown; manifestRegistry?: unknown } | undefined;
+
+vi.mock("../plugins/activation-context.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../plugins/activation-context.js")>();
+  return {
+    ...actual,
+    resolvePluginActivationInputs: (
+      params: Parameters<typeof actual.resolvePluginActivationInputs>[0],
+    ) => {
+      activationInputParams = params;
+      return actual.resolvePluginActivationInputs(params);
+    },
+  };
+});
 
 function makeManifestPlugin(
   id: string,
@@ -470,6 +488,35 @@ describe("setupPluginConfig", () => {
       region: "eu-west",
     });
     expect(result.plugins?.entries?.["google-gemini-cli"]).toBeUndefined();
+  });
+
+  it("hands activation the discovery its inventory came from", async () => {
+    // With only the registry forwarded, auto-enable re-derives a default scope discovery, so
+    // a workspace scoped run judges activation against a different generation than the
+    // plugin list was built from.
+    const discovery = { candidates: [], diagnostics: [] };
+    activationInputParams = undefined;
+    loadPluginManifestRegistryCore.mockReturnValue({
+      plugins: [makeManifestPlugin("brave", { token: { label: "Token" } })],
+      discovery,
+    });
+
+    await setupPluginConfig({
+      config: { plugins: { entries: { brave: { enabled: true } } } } as OpenClawConfig,
+      workspaceDir: "/tmp/openclaw-test-workspace",
+      prompter: {
+        intro: vi.fn(async () => {}),
+        outro: vi.fn(async () => {}),
+        note: vi.fn(async () => {}),
+        select: vi.fn(async () => "") as unknown as WizardPrompter["select"],
+        multiselect: vi.fn(async () => ["__skip__"]) as unknown as WizardPrompter["multiselect"],
+        text: vi.fn(async () => ""),
+        confirm: vi.fn(async () => true),
+        progress: vi.fn(() => ({ update: vi.fn(), stop: vi.fn() })),
+      },
+    });
+
+    expect(activationInputParams?.discovery).toBe(discovery);
   });
 
   it.each([

--- a/src/wizard/setup.plugin-config.test.ts
+++ b/src/wizard/setup.plugin-config.test.ts
@@ -41,6 +41,9 @@ function makeManifestPlugin(
     configSchema,
     enabled: true,
     enabledByDefault: true,
+    // Real manifest records always carry one, and activation resolution walks it.
+    rootDir: `/tmp/openclaw-test-plugins/${id}`,
+    origin: "bundled" as const,
   };
 }
 

--- a/src/wizard/setup.plugin-config.test.ts
+++ b/src/wizard/setup.plugin-config.test.ts
@@ -415,6 +415,63 @@ describe("setupPluginConfig", () => {
     expect(result.plugins?.entries?.brave?.config?.["webSearch.mode"]).toBeUndefined();
   });
 
+  it("keeps config saved under a legacy plugin id when the wizard writes", async () => {
+    // `google-gemini-cli` is a real alias for `google`. Looking the entry up by the canonical
+    // id alone reads back nothing, so the wizard re-asked for fields that were already set
+    // and then wrote a second entry, leaving the answers on the old key behind.
+    loadPluginManifestRegistryCore.mockReturnValue({
+      plugins: [
+        {
+          ...makeManifestPlugin("google", {
+            apiKey: { label: "API key" },
+            region: { label: "Region" },
+          }),
+          enabledByDefault: true,
+        },
+      ],
+    });
+
+    const asked: string[] = [];
+    const text = vi.fn(async (opts: { message: string }) => {
+      asked.push(opts.message);
+      return "eu-west";
+    });
+
+    const result = await setupPluginConfig({
+      config: {
+        plugins: {
+          entries: {
+            "google-gemini-cli": {
+              enabled: true,
+              config: { apiKey: "existing-key" },
+            },
+          },
+        },
+      } as unknown as OpenClawConfig,
+      prompter: {
+        intro: vi.fn(async () => {}),
+        outro: vi.fn(async () => {}),
+        note: vi.fn(async () => {}),
+        select: vi.fn(async () => "") as unknown as WizardPrompter["select"],
+        multiselect: vi.fn(async () => ["google"]) as unknown as WizardPrompter["multiselect"],
+        text: text as unknown as WizardPrompter["text"],
+        confirm: vi.fn(async () => true),
+        progress: vi.fn(() => ({ update: vi.fn(), stop: vi.fn() })),
+      },
+    });
+
+    // The key it already had is seen through the alias, so it is not asked for again.
+    expect(asked).toHaveLength(1);
+    expect(requireFirst(asked, "prompt")).toContain("Region");
+
+    // One entry on the canonical id carrying both the old value and the new one.
+    expect(result.plugins?.entries?.google?.config).toEqual({
+      apiKey: "existing-key",
+      region: "eu-west",
+    });
+    expect(result.plugins?.entries?.["google-gemini-cli"]).toBeUndefined();
+  });
+
   it.each([
     {
       name: "an existing array through a dotted index",

--- a/src/wizard/setup.plugin-config.test.ts
+++ b/src/wizard/setup.plugin-config.test.ts
@@ -541,6 +541,47 @@ describe("setupPluginConfig", () => {
     },
   );
 
+  it("does not write normalization-only fields into the saved config", async () => {
+    // normalizePluginsConfig derives hasAllowedModelsConfig for runtime policy and drops the
+    // allowedModels list it came from. Those derived keys are not allowed in persisted config,
+    // so folding through the normalized entry would both add a forbidden key and lose a real
+    // setting the user had.
+    loadPluginManifestRegistryCore.mockReturnValue({
+      plugins: [
+        {
+          ...makeManifestPlugin("google", {
+            apiKey: { label: "API key" },
+          }),
+          enabledByDefault: true,
+        },
+      ],
+    });
+
+    const result = await setupPluginConfig({
+      config: {
+        plugins: {
+          entries: {
+            google: { enabled: true, llm: { allowedModels: [] } },
+          },
+        },
+      } as unknown as OpenClawConfig,
+      prompter: {
+        intro: vi.fn(async () => {}),
+        outro: vi.fn(async () => {}),
+        note: vi.fn(async () => {}),
+        select: vi.fn(async () => "") as unknown as WizardPrompter["select"],
+        multiselect: vi.fn(async () => ["google"]) as unknown as WizardPrompter["multiselect"],
+        text: vi.fn(async () => "written-key"),
+        confirm: vi.fn(async () => true),
+        progress: vi.fn(() => ({ update: vi.fn(), stop: vi.fn() })),
+      },
+    });
+
+    const llm = result.plugins?.entries?.google?.llm as Record<string, unknown> | undefined;
+    expect(llm).toEqual({ allowedModels: [] });
+    expect(llm).not.toHaveProperty("hasAllowedModelsConfig");
+  });
+
   it("does not switch a plugin off while folding a conflicting alias", async () => {
     // Raw entries are applied in file order, so a later alias saying enabled true beats a
     // canonical false and the plugin is running. A fold that always puts canonical last

--- a/src/wizard/setup.plugin-config.ts
+++ b/src/wizard/setup.plugin-config.ts
@@ -1,7 +1,6 @@
 // Setup plugin config helpers build plugin config from onboarding answers.
 import { normalizeStringEntries } from "@openclaw/normalization-core/string-normalization";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import { normalizePluginId, normalizePluginTargetConfig } from "../plugins/config-state.js";
 import type { PluginManifestRecord } from "../plugins/manifest-registry.js";
 import type { PluginConfigUiHint } from "../plugins/types.js";
 import { getPath, setPathCreateStrict } from "../secrets/path-utils.js";
@@ -74,11 +73,25 @@ function getExistingPluginConfig(
   config: OpenClawConfig,
   pluginId: string,
 ): Record<string, unknown> {
-  // An entry saved under a legacy id sits on a different key, so a plain lookup on the
-  // canonical one reads back nothing and the plugin looks unconfigured.
-  const folded = normalizePluginTargetConfig(config, pluginId);
-  const normalizedId = normalizePluginId(pluginId);
-  return (folded.plugins?.entries?.[normalizedId]?.config as Record<string, unknown>) ?? {};
+  return (config.plugins?.entries?.[pluginId]?.config as Record<string, unknown>) ?? {};
+}
+
+/**
+ * Moves entries saved under a legacy plugin id onto the canonical one.
+ *
+ * An entry on an old key is invisible to a lookup by manifest id, so the wizard reads back
+ * nothing, asks again for fields the user already filled, and then writes a second entry
+ * beside the old one. Folding up front means everything below works on canonical ids.
+ */
+async function foldLegacyPluginEntries(
+  config: OpenClawConfig,
+  pluginIds: readonly string[],
+): Promise<OpenClawConfig> {
+  const { normalizePluginTargetConfig } = await loadPluginActivationModule();
+  return pluginIds.reduce(
+    (folded, pluginId) => normalizePluginTargetConfig(folded, pluginId),
+    config,
+  );
 }
 
 function toPathSegments(
@@ -228,6 +241,10 @@ async function listEnabledConfigurableManifestPlugins(params: {
     // re-resolves the setup registry from disk, which is both wasted work here and a second
     // source for the same answer.
     manifestRegistry: snapshot.manifestRegistry,
+    // Pass the discovery this snapshot was built from too. With only the registry,
+    // auto-enable re-derives a default-scope discovery and a workspace scoped run ends up
+    // judging activation against a different generation than the inventory came from.
+    discovery: snapshot.discovery,
   });
 
   return snapshot.plugins.filter((plugin) => {
@@ -256,12 +273,7 @@ async function promptPluginFields(params: {
   /** When true, show all fields including already-configured ones (for configure flow). */
   showConfigured?: boolean;
 }): Promise<OpenClawConfig> {
-  const { plugin, prompter } = params;
-  // Fold a legacy entry onto the canonical id before anything is read or written. Without
-  // this the write lands on a second key and leaves the old one behind holding the values
-  // the user already had.
-  const config = normalizePluginTargetConfig(params.config, plugin.id);
-  const targetId = normalizePluginId(plugin.id);
+  const { plugin, config, prompter } = params;
   const existing = getExistingPluginConfig(config, plugin.id);
   const updatedConfig = structuredClone(existing);
   let changed = false;
@@ -381,9 +393,7 @@ async function promptPluginFields(params: {
   }
 
   if (!changed) {
-    // Nothing was answered, so hand back what came in rather than rewriting entry keys
-    // the user did not ask us to touch.
-    return params.config;
+    return config;
   }
 
   // Merge updated plugin config back into the full config
@@ -393,8 +403,8 @@ async function promptPluginFields(params: {
       ...config.plugins,
       entries: {
         ...config.plugins?.entries,
-        [targetId]: {
-          ...config.plugins?.entries?.[targetId],
+        [plugin.id]: {
+          ...config.plugins?.entries?.[plugin.id],
           config: updatedConfig,
         },
       },
@@ -416,9 +426,14 @@ export async function setupPluginConfig(params: {
     workspaceDir: params.workspaceDir,
   });
 
+  const folded = await foldLegacyPluginEntries(
+    params.config,
+    manifestPlugins.map((plugin) => plugin.id),
+  );
+
   const unconfigured = discoverUnconfiguredPlugins({
     manifestPlugins,
-    config: params.config,
+    config: folded,
   });
 
   if (unconfigured.length === 0) {
@@ -444,7 +459,7 @@ export async function setupPluginConfig(params: {
     ],
   });
 
-  let config = params.config;
+  let config = folded;
   for (const pluginId of selected.filter((value) => value !== "__skip__")) {
     const plugin = unconfigured.find((p) => p.id === pluginId);
     if (!plugin) {
@@ -461,7 +476,9 @@ export async function setupPluginConfig(params: {
     });
   }
 
-  return config;
+  // Nothing was answered, so hand back what came in rather than rewriting entry keys the
+  // user did not ask us to touch.
+  return config === folded ? params.config : config;
 }
 
 /**
@@ -482,6 +499,11 @@ export async function configurePluginConfig(params: {
     manifestPlugins,
   });
 
+  const folded = await foldLegacyPluginEntries(
+    params.config,
+    manifestPlugins.map((plugin) => plugin.id),
+  );
+
   if (configurable.length === 0) {
     await params.prompter.note(
       t("wizard.plugins.configureEmpty"),
@@ -494,7 +516,7 @@ export async function configurePluginConfig(params: {
     message: t("wizard.plugins.configureSelect"),
     options: [
       ...configurable.map((p) => {
-        const existing = getExistingPluginConfig(params.config, p.id);
+        const existing = getExistingPluginConfig(folded, p.id);
         const configuredCount = Object.keys(p.uiHints).filter((k) => {
           const val = getPath(existing, toPathSegments(k, existing, p.jsonSchema).map(String));
           return val !== undefined && val !== null && val !== "";
@@ -523,10 +545,13 @@ export async function configurePluginConfig(params: {
     return params.config;
   }
 
-  return promptPluginFields({
+  const next = await promptPluginFields({
     plugin,
-    config: params.config,
+    config: folded,
     prompter: params.prompter,
     showConfigured: true,
   });
+
+  // Same as the onboard path: an untouched config goes back exactly as it came in.
+  return next === folded ? params.config : next;
 }

--- a/src/wizard/setup.plugin-config.ts
+++ b/src/wizard/setup.plugin-config.ts
@@ -31,12 +31,12 @@ const loadPluginMetadataSnapshotModule = createLazyRuntimeModule(
 );
 
 const loadPluginActivationModule = createLazyRuntimeModule(async () => {
-  const [configState, defaultEnablement, configPolicy] = await Promise.all([
+  const [configState, defaultEnablement, activationContext] = await Promise.all([
     import("../plugins/config-state.js"),
     import("../plugins/default-enablement.js"),
-    import("../plugins/config-policy.js"),
+    import("../plugins/activation-context.js"),
   ]);
-  return { ...configState, ...defaultEnablement, ...configPolicy };
+  return { ...configState, ...defaultEnablement, ...activationContext };
 });
 
 type JsonSchemaProperty = {
@@ -201,22 +201,40 @@ async function listEnabledConfigurableManifestPlugins(params: {
   const {
     resolveEffectivePluginActivationState,
     isPluginEnabledByDefaultForPlatform,
-    normalizePluginsConfigWithResolver,
+    resolvePluginActivationInputs,
   } = await loadPluginActivationModule();
 
   // `enabledByDefault || entry.enabled === true` is not what decides whether a plugin runs. It
   // misses an explicit false overriding a default-on manifest, a global `plugins.enabled: false`,
   // deny and allow policy, workspace policy, selected slots, auto-enable reasons and
-  // platform-specific defaults. Asking the same resolver validation and startup ask keeps the
-  // wizard offering the set that is actually active.
-  const normalizedPlugins = normalizePluginsConfigWithResolver(params.config.plugins);
+  // platform-specific defaults.
+  //
+  // Going through resolvePluginActivationInputs rather than normalizing here matters twice
+  // over. Its normalizer resolves built-in aliases, so a legacy plugin id used as an entry key
+  // still lines up with the manifest id, and `applyAutoEnable` materializes the auto-enables
+  // that runtime performs before activation is judged. Reading the raw config instead misses a
+  // plugin that is only on because auto-enable turned it on.
+  const inputs = resolvePluginActivationInputs({
+    rawConfig: params.config,
+    env: process.env,
+    workspaceDir: params.workspaceDir,
+    applyAutoEnable: true,
+    // Hand over the registry this function already loaded. Without it auto-enable detection
+    // re-resolves the setup registry from disk, which is both wasted work here and a second
+    // source for the same answer.
+    manifestRegistry: snapshot.manifestRegistry,
+  });
+
   return snapshot.plugins.filter((plugin) => {
+    const autoEnabledReason = inputs.autoEnabledReasons[plugin.id]?.[0];
     const activation = resolveEffectivePluginActivationState({
       id: plugin.id,
       origin: plugin.origin,
-      config: normalizedPlugins,
-      rootConfig: params.config,
+      config: inputs.normalized,
+      rootConfig: inputs.config,
       enabledByDefault: isPluginEnabledByDefaultForPlatform(plugin),
+      activationSource: inputs.activationSource,
+      ...(autoEnabledReason ? { autoEnabledReason } : {}),
     });
     return activation.activated;
   });

--- a/src/wizard/setup.plugin-config.ts
+++ b/src/wizard/setup.plugin-config.ts
@@ -30,6 +30,15 @@ const loadPluginMetadataSnapshotModule = createLazyRuntimeModule(
   () => import("../plugins/plugin-metadata-snapshot.js"),
 );
 
+const loadPluginActivationModule = createLazyRuntimeModule(async () => {
+  const [configState, defaultEnablement, configPolicy] = await Promise.all([
+    import("../plugins/config-state.js"),
+    import("../plugins/default-enablement.js"),
+    import("../plugins/config-policy.js"),
+  ]);
+  return { ...configState, ...defaultEnablement, ...configPolicy };
+});
+
 type JsonSchemaProperty = {
   type?: string;
   enum?: unknown[];
@@ -189,9 +198,27 @@ async function listEnabledConfigurableManifestPlugins(params: {
     workspaceDir: params.workspaceDir,
     env: process.env,
   });
+  const {
+    resolveEffectivePluginActivationState,
+    isPluginEnabledByDefaultForPlatform,
+    normalizePluginsConfigWithResolver,
+  } = await loadPluginActivationModule();
+
+  // `enabledByDefault || entry.enabled === true` is not what decides whether a plugin runs. It
+  // misses an explicit false overriding a default-on manifest, a global `plugins.enabled: false`,
+  // deny and allow policy, workspace policy, selected slots, auto-enable reasons and
+  // platform-specific defaults. Asking the same resolver validation and startup ask keeps the
+  // wizard offering the set that is actually active.
+  const normalizedPlugins = normalizePluginsConfigWithResolver(params.config.plugins);
   return snapshot.plugins.filter((plugin) => {
-    const entry = params.config.plugins?.entries?.[plugin.id];
-    return plugin.enabledByDefault || entry?.enabled === true;
+    const activation = resolveEffectivePluginActivationState({
+      id: plugin.id,
+      origin: plugin.origin,
+      config: normalizedPlugins,
+      rootConfig: params.config,
+      enabledByDefault: isPluginEnabledByDefaultForPlatform(plugin),
+    });
+    return activation.activated;
   });
 }
 

--- a/src/wizard/setup.plugin-config.ts
+++ b/src/wizard/setup.plugin-config.ts
@@ -1,6 +1,7 @@
 // Setup plugin config helpers build plugin config from onboarding answers.
 import { normalizeStringEntries } from "@openclaw/normalization-core/string-normalization";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { normalizePluginId, normalizePluginTargetConfig } from "../plugins/config-state.js";
 import type { PluginManifestRecord } from "../plugins/manifest-registry.js";
 import type { PluginConfigUiHint } from "../plugins/types.js";
 import { getPath, setPathCreateStrict } from "../secrets/path-utils.js";
@@ -73,7 +74,11 @@ function getExistingPluginConfig(
   config: OpenClawConfig,
   pluginId: string,
 ): Record<string, unknown> {
-  return (config.plugins?.entries?.[pluginId]?.config as Record<string, unknown>) ?? {};
+  // An entry saved under a legacy id sits on a different key, so a plain lookup on the
+  // canonical one reads back nothing and the plugin looks unconfigured.
+  const folded = normalizePluginTargetConfig(config, pluginId);
+  const normalizedId = normalizePluginId(pluginId);
+  return (folded.plugins?.entries?.[normalizedId]?.config as Record<string, unknown>) ?? {};
 }
 
 function toPathSegments(
@@ -251,7 +256,12 @@ async function promptPluginFields(params: {
   /** When true, show all fields including already-configured ones (for configure flow). */
   showConfigured?: boolean;
 }): Promise<OpenClawConfig> {
-  const { plugin, config, prompter } = params;
+  const { plugin, prompter } = params;
+  // Fold a legacy entry onto the canonical id before anything is read or written. Without
+  // this the write lands on a second key and leaves the old one behind holding the values
+  // the user already had.
+  const config = normalizePluginTargetConfig(params.config, plugin.id);
+  const targetId = normalizePluginId(plugin.id);
   const existing = getExistingPluginConfig(config, plugin.id);
   const updatedConfig = structuredClone(existing);
   let changed = false;
@@ -371,7 +381,9 @@ async function promptPluginFields(params: {
   }
 
   if (!changed) {
-    return config;
+    // Nothing was answered, so hand back what came in rather than rewriting entry keys
+    // the user did not ask us to touch.
+    return params.config;
   }
 
   // Merge updated plugin config back into the full config
@@ -381,8 +393,8 @@ async function promptPluginFields(params: {
       ...config.plugins,
       entries: {
         ...config.plugins?.entries,
-        [plugin.id]: {
-          ...config.plugins?.entries?.[plugin.id],
+        [targetId]: {
+          ...config.plugins?.entries?.[targetId],
           config: updatedConfig,
         },
       },

--- a/src/wizard/setup.plugin-config.ts
+++ b/src/wizard/setup.plugin-config.ts
@@ -87,11 +87,27 @@ async function foldLegacyPluginEntries(
   config: OpenClawConfig,
   pluginIds: readonly string[],
 ): Promise<OpenClawConfig> {
-  const { normalizePluginTargetConfig } = await loadPluginActivationModule();
-  return pluginIds.reduce(
-    (folded, pluginId) => normalizePluginTargetConfig(folded, pluginId),
-    config,
-  );
+  const { mergePluginEntryAliases, normalizePluginId, normalizePluginTargetConfig } =
+    await loadPluginActivationModule();
+  return pluginIds.reduce((folded, pluginId) => {
+    const resolvedId = normalizePluginId(pluginId);
+    const next = normalizePluginTargetConfig(folded, pluginId);
+    if (!next.plugins?.entries?.[resolvedId]) {
+      return next;
+    }
+    // The normalizer keeps only one of the duplicate entries, so the merged one is written
+    // back over it. Read the merge off the pre-fold config, which still holds both keys.
+    return {
+      ...next,
+      plugins: {
+        ...next.plugins,
+        entries: {
+          ...next.plugins.entries,
+          [resolvedId]: mergePluginEntryAliases(folded, pluginId),
+        },
+      },
+    };
+  }, config);
 }
 
 function toPathSegments(


### PR DESCRIPTION
Closes #127578

## What Problem This Solves

Fixes an issue where the CLI plugin wizard, during onboarding and `configure`, offers plugins that are switched off and skips plugins that are actually running.

Both directions are user visible. A plugin explicitly disabled in config is still offered, so the wizard solicits settings for it and then warns that config is present while the plugin is disabled. A plugin activated through slot selection, auto-enable, workspace policy or a platform default is left out, so the wizard never asks about something that does run.

## Why This Change Was Made

The inventory decided activation itself:

```ts
return plugin.enabledByDefault || entry?.enabled === true;
```

An explicit `enabled: false` is not `=== true`, so that arm falls through to the manifest default and the plugin stays in the list. The same shortcut ignores a global `plugins.enabled: false`, deny and allow policy, workspace policy, selected slots and context engines, auto-enable reasons, bundled channel configuration, and platform-specific default enablement.

It now asks `resolveEffectivePluginActivationState`, which is what config validation and gateway startup already use, with `isPluginEnabledByDefaultForPlatform` for the default, matching `validation-plugin-config.ts`. One source of truth for what is active rather than a second, weaker one in the wizard.

It is loaded through `createLazyRuntimeModule` alongside the existing metadata snapshot import, so the wizard still does not pull the plugin graph in eagerly.

## User Impact

The wizard offers the plugins that are actually active. It no longer asks for settings for a disabled plugin and then complains about the config it just wrote, and it no longer skips a plugin enabled by policy rather than by an explicit entry.

## Evidence

The reported shape, a bundled default-on manifest with `enabled: false` in config, as a test:

```
✓ setupPluginConfig > does not offer a default-on plugin that config explicitly disables
  Test Files  1 passed (1)
       Tests  21 passed (21)
```

On the old filter, everything else identical:

```
⎯⎯⎯⎯⎯⎯⎯ Failed Tests 1 ⎯⎯⎯⎯⎯⎯⎯
 FAIL  src/wizard/setup.plugin-config.test.ts > setupPluginConfig >
       does not offer a default-on plugin that config explicitly disables
  Tests  1 failed | 20 passed (21)
```

The test asserts the multiselect is never reached, so it fails on the wizard offering the plugin at all rather than on a later prompt detail.

| check | result |
|---|---|
| `vitest run src/wizard src/plugins/config-state.test.ts` | 25 files, 440 tests, all passed |
| `tsc --noEmit -p tsconfig.core.json` | no errors |
| `oxfmt --check` on both changed files | correctly formatted |

Node 24.20.0 and pnpm 12.0.0, matching the engine floor in `package.json`.

---

disclaimer: this contribution was prepared with the assistance of an ai agent. i read the wizard inventory, the canonical resolver and the existing validation caller before changing anything, and ran the tests, typecheck and formatter locally.


---

## Real-run evidence

Added after review. Not a mocked test: real bundled plugin registry, real metadata snapshot, real activation resolver, real config. The only substitution is the person at the keyboard, and `WizardPrompter` is an injected dependency of `setupPluginConfig`, so supplying one uses the entrypoint rather than bypassing it. The prompter records what the multiselect is offered, then skips.

**before**

```
xai explicitly disabled in config
  plugins offered : __skip__, github-copilot, google, huggingface, minimax, moonshot, ollama,
                    opencode, xai, acpx, amazon-bedrock, amazon-bedrock-mantle, anthropic,
                    device-pair, geolocation, google-meet, linux-node, teams-meetings, zoom-meetings
  xai offered     : true          <- config says disabled
```

**after**

```
xai explicitly disabled in config
  plugins offered : __skip__, github-copilot, google, huggingface, minimax, moonshot, ollama,
                    opencode, acpx, amazon-bedrock, amazon-bedrock-mantle, anthropic,
                    device-pair, geolocation, google-meet, linux-node, teams-meetings,
                    memory-core, zoom-meetings
  xai offered     : false

no entry for xai, manifest default applies
  xai offered     : true          <- default still honoured
```

Diffing the two offered sets shows both directions of the defect, including one I had not written a test for:

```
wrongly offered before, now gone : ['xai']
missed before, now offered       : ['memory-core']
```

`memory-core` is activated through canonical slot policy rather than an explicit entry, so the old `enabledByDefault || entry.enabled === true` had no way to see it. The wizard was not asking about a plugin that runs.

Reproduce with `node --import ./scripts/tsx.mjs <file>.mts` on Node 24.20.0, pnpm 12.0.0:

```ts
import { setupPluginConfig } from "./src/wizard/setup.plugin-config.js";
const offered: string[] = [];
const prompter = { /* noop, multiselect records opts.options and returns ["__skip__"] */ };
await setupPluginConfig({ config: { plugins: { entries: { xai: { enabled: false } } } }, prompter });
console.log(offered.includes("xai"));
```


---

## Follow-up: both parity gaps were real

Review found the resolver call still ignored legacy plugin-ID normalization and runtime auto-enable materialization. Both correct, fixed in `e7d17c10`.

**Legacy ids.** I normalized with `normalizePluginsConfigWithResolver`, whose default is `identityNormalizePluginId`. The canonical one is not identity:

```ts
const normalized = normalizeOptionalLowercaseString(id) ?? "";
return BUILT_IN_PLUGIN_ALIAS_LOOKUP.get(normalized) ?? normalized;
```

So a legacy plugin id used as an entry key never lined up with the manifest id, and that entry was silently ignored, which is the same class of bug this PR is about.

**Auto-enable.** I resolved against the raw config. Runtime materializes auto-enables before it judges activation, so a plugin that is only on because auto-enable turned it on still looked off.

Both come from routing through `resolvePluginActivationInputs`, which applies auto-enable, normalizes with the alias-aware resolver, and returns the activation source and reasons. That is the same input the gateway startup path uses:

```ts
const inputs = resolvePluginActivationInputs({
  rawConfig: params.config,
  env: process.env,
  workspaceDir: params.workspaceDir,
  applyAutoEnable: true,
  manifestRegistry: snapshot.manifestRegistry,
});

const autoEnabledReason = inputs.autoEnabledReasons[plugin.id]?.[0];
const activation = resolveEffectivePluginActivationState({
  id: plugin.id,
  origin: plugin.origin,
  config: inputs.normalized,
  rootConfig: inputs.config,
  enabledByDefault: isPluginEnabledByDefaultForPlatform(plugin),
  activationSource: inputs.activationSource,
  ...(autoEnabledReason ? { autoEnabledReason } : {}),
});
```

## One thing this surfaced in the tests

Turning auto-enable on made an unrelated existing test fail:

```
TypeError: The "paths[0]" argument must be of type string. Received undefined
 ❯ getPluginCacheRoot src/plugins/plugin-cache.ts:104
 ❯ resolveSetupApiPath src/plugins/setup-registry.ts:127
 ❯ resolvePluginSetupAutoEnableReasons src/plugins/setup-registry.ts:830
 ❯ applyPluginAutoEnable src/config/plugin-auto-enable.apply.ts:236
```

`makeManifestPlugin` in `setup.plugin-config.test.ts` omits `rootDir`, which `PluginManifestRecord` declares as required and which auto-enable detection resolves. The fixture only survived because the old filter never reached that code. I added `rootDir` and `origin` rather than switch auto-enable off to keep a mock that cannot survive the real path.

## Verification after the change

| check | result |
|---|---|
| `vitest run src/wizard src/plugins/config-state.test.ts` | 25 files, 440 tests, all passed |
| real wizard run, xai disabled | `xai offered : false` |
| real wizard run, no entry | `xai offered : true` |
| `tsc --noEmit -p tsconfig.core.json` | no errors |
| `oxfmt --check` | correctly formatted |



---

## Follow-up: carrying legacy entry config through the wizard

The [P1] finding on `setup.plugin-config.ts:228-240` is right and it is worth more than the alias read it points at. Fixed in the latest commit.

`getExistingPluginConfig` looked the entry up by raw key:

```ts
return (config.plugins?.entries?.[pluginId]?.config as Record<string, unknown>) ?? {};
```

`pluginId` is the manifest id, which is canonical. `google-gemini-cli`, `minimax-portal` and `minimax-portal-auth` are real aliases in `BUILT_IN_PLUGIN_ALIAS_LOOKUP`, so an entry saved under one of those is on a different key and this lookup reads back nothing. Two things follow, not one:

1. the plugin looks unconfigured, so the wizard asks again for fields the user already filled in
2. the write at the end spreads the raw entries and sets `[plugin.id]`, so it lands a second entry on the canonical key and leaves the old one sitting there with the previous values

Second point is the data loss. The wizard does not merge, it writes beside.

Fixed with `normalizePluginTargetConfig`, the targeted normalizer you pointed to, applied before the read and used as the base for the write so the fold and the write are the same object:

```ts
const config = normalizePluginTargetConfig(params.config, plugin.id);
const targetId = normalizePluginId(plugin.id);
const existing = getExistingPluginConfig(config, plugin.id);
```

One deliberate detail: `if (!changed)` now returns `params.config` rather than the folded one. If the user answered nothing, rewriting their entry keys is not something the wizard was asked to do.

### The legacy-ID regression test you asked for

Uses a real alias rather than an invented one. Config holds `apiKey` under `google-gemini-cli`, the manifest offers `google` with `apiKey` and `region`:

```ts
config: { plugins: { entries: { "google-gemini-cli": {
  enabled: true, config: { apiKey: "existing-key" } } } } }
```

With the change: one prompt, for `Region` only, and one entry afterwards.

```ts
expect(asked).toHaveLength(1);
expect(requireFirst(asked, "prompt")).toContain("Region");
expect(result.plugins?.entries?.google?.config).toEqual({
  apiKey: "existing-key",
  region: "eu-west",
});
expect(result.plugins?.entries?.["google-gemini-cli"]).toBeUndefined();
```

Without the source change, tests untouched:

```
× keeps config saved under a legacy plugin id when the wizard writes
  → expected [ 'API key', 'Region' ] to have a length of 1 but got 2
```

It re-asks for the key it already holds. That is the first half of the defect showing up directly, and the entry assertions cover the second.

### checks

| check | result |
|---|---|
| `vitest run src/wizard` | 24 files, 390 tests, all passed |
| `vitest run src/plugins/config-state.test.ts` | 51 passed |
| new test with the source change reverted | fails as above |
| `pnpm tsgo:core` | no errors |
| `pnpm tsgo:test:src` | no errors |
| `oxfmt --check` | correctly formatted |
| `run-oxlint.mjs src/wizard` | clean |

On the earlier question about pinning the `memory-core` direction: this test pins the alias direction against a real alias constant rather than against whichever plugins happen to be bundled, so it does not have the fragility I was worried about there. Happy to add the slot-activated one against a synthetic manifest as well if you want it.



---

## Follow-up 2: both findings were right, and one of them was mine to cause

### [P2] the lazy boundary i broke

Correct, and the repo says so itself. My static import at line 4 sat above a `createLazyRuntimeModule` that dynamically imports the same module, which makes the lazy one do nothing. `pnpm lint:tmp:dynamic-import-warts` names it:

```
src/wizard/setup.plugin-config.ts:36 runtime static + dynamic import
  of "../plugins/config-state.js" (static line 4)
```

That is a CI failure I introduced and did not run the guard for. Fixed by dropping the static import and taking the normalizer from the lazy module that was already there.

Rather than thread it through every call site, the fold now happens once at the two async entrypoints, so everything below already works on canonical ids and `getExistingPluginConfig` goes back to being a plain lookup:

```ts
async function foldLegacyPluginEntries(
  config: OpenClawConfig,
  pluginIds: readonly string[],
): Promise<OpenClawConfig> {
  const { normalizePluginTargetConfig } = await loadPluginActivationModule();
  return pluginIds.reduce(
    (folded, pluginId) => normalizePluginTargetConfig(folded, pluginId),
    config,
  );
}
```

This is better than what I had. `discoverUnconfiguredPlugins` is sync and on the real onboard path, and my previous version only folded inside `promptPluginFields`, so the plugin list was still built from unfolded config. Both entrypoints keep returning `params.config` untouched when nothing was answered.

Guard is clean now:

```
lint:tmp:dynamic-import-warts -> no hits for setup.plugin-config.ts
```

### [P1] discovery

Also correct. `resolvePluginActivationInputs` takes `discovery` and hands it to auto-enable at `activation-context.ts:139`, and the snapshot carries one at `plugin-metadata-snapshot.ts:649`. I forwarded only `manifestRegistry`, so auto-enable re-derived a default scope discovery and a workspace scoped run judged activation against a different generation than the inventory came from. One line:

```ts
manifestRegistry: snapshot.manifestRegistry,
discovery: snapshot.discovery,
```

### the wiring is tested this time, not the decision

You have twice caught me testing a decision function rather than the wiring around it, so this one watches the real call. The mock wraps the actual resolver instead of replacing it, so every other test in the file keeps running against real activation behaviour:

```ts
vi.mock("../plugins/activation-context.js", async (importOriginal) => {
  const actual = await importOriginal<typeof import("../plugins/activation-context.js")>();
  return {
    ...actual,
    resolvePluginActivationInputs: (params) => {
      activationInputParams = params;
      return actual.resolvePluginActivationInputs(params);
    },
  };
});
```

Remove the `discovery:` line and it fails:

```
× hands activation the discovery its inventory came from
  → expected undefined to be { candidates: [], diagnostics: [] } // Object.is equality
```

Worth saying how it failed first: with a sentinel of the wrong shape it got a `TypeError` from `channel-catalog-registry.ts:53` reading `candidates`, which is itself proof the value now travels into the channel auto-enable path instead of being ignored. I gave the sentinel the shape the repo's own tests use, `{ candidates: [], diagnostics: [] }`.

The legacy-id test still discriminates against the real baseline. I checked it against `HEAD~1` rather than `HEAD`, since `HEAD` already carries the first fold and reverting to it proves nothing:

```
× keeps config saved under a legacy plugin id when the wizard writes
  → expected [ 'API key', 'Region' ] to have a length of 1 but got 2
```

### checks

| check | result |
|---|---|
| `vitest run src/wizard` | 24 files, 391 tests, all passed |
| `lint:tmp:dynamic-import-warts` | no hits for this file |
| `pnpm tsgo:core` | 0 errors |
| `pnpm tsgo:test:src` | 0 errors |
| `oxfmt --check` | correctly formatted |
| both new tests with their line reverted | fail as shown |



---

## Follow-up 3: the fold was unsafe when both keys exist

Right again, and the confidence of 0.99 is deserved. I checked it rather than taking it, and it is worse than one side losing: **which side survives depends on the order the keys sit in the file.**

Same two entries, same plugin, only the write order differs:

```
ALIAS-FIRST     -> {"google":{"enabled":true,"config":{"region":"from-canonical"}}}
CANONICAL-FIRST -> {"google":{"enabled":true,"config":{"apiKey":"from-alias"}}}
```

`normalizePluginTargetConfig` rebuilds the entry from the normalized one, whose `config` is whichever raw key was applied last. So the settings that disappear are decided by JSON key order. My fold put that on the wizard path for every plugin, so this was mine to cause.

### the answer was already in the repo

`setPluginEnabledInConfig` had solved it, comment and all:

```ts
// Fold aliases first and the canonical entry last so duplicate config keeps
// every nested setting while canonical values win independent of file order.
```

Copying that into the wizard would have left two implementations of one rule, so it moved to a shared helper in `config-state.ts` and both callers use it. The toggle writer's inline block is now one line and its behaviour is unchanged.

```ts
export function mergePluginEntryAliases(
  config: OpenClawConfig,
  pluginId: string,
): PluginEntryConfig
```

The wizard fold writes the merged entry back over the one the normalizer kept, reading the merge off the pre-fold config since that is what still holds both keys.

### both key orders, as asked

```ts
const entries = aliasFirst
  ? { "google-gemini-cli": aliasEntry, google: canonicalEntry }
  : { google: canonicalEntry, "google-gemini-cli": aliasEntry };
```

Alias holds `apiKey`, canonical holds `region`, and the wizard is answered for a third field. Both orders must land on all three. With the merge reverted both fail, and the two failures are mirror images of each other, which is the order dependence stated in the output:

```
x keeps both sides ... 'alias written first'
  -> expected { region: 'from-canonical', ...(2) } to deeply equal { apiKey: 'from-alias', ...(2) }
x keeps both sides ... 'canonical written first'
  -> expected { apiKey: 'from-alias', ...(2) } to deeply equal { apiKey: 'from-alias', ...(2) }
```

### also fixed: the type check i had red

`check-test-types-core-1` was failing on my previous push and that was mine too:

```
src/wizard/setup.plugin-config.test.ts(519,35):
  error TS2339: Property 'discovery' does not exist on type 'never'.
```

I had reset a capture variable to `undefined`, which narrows it, so the optional chain read off `never`. It collects into an array now. I had checked types with `pnpm tsgo:test:src` before pushing, which passes; the shard CI runs is `pnpm tsgo:core:test`, which fails. I reproduced the failure locally with the right command before fixing it, so I know the gate I am now trusting is the real one.

### checks

| check | result |
|---|---|
| `vitest run src/wizard src/plugins/config-state.test.ts src/plugins/toggle-config.test.ts` | 25 files, 444 tests, all passed |
| `pnpm tsgo:core` | 0 errors |
| `pnpm tsgo:core:test` | clean, and it reproduced the earlier failure before the fix |
| `pnpm check:import-cycles` | 0 runtime value cycles |
| `lint:tmp:dynamic-import-warts` | no hits |
| `oxfmt --check` | correctly formatted |
| both new tests with the merge reverted | fail as shown |

`src/plugins/clawhub.test.ts` fails in my checkout, identically with my changes stashed. It asserts that output carries no ansi escape sequences and my terminal forces colour, so I have left it alone.



---

## Follow-up 4: the fold could switch a plugin off

Right again, and this was the worst one I have shipped on this PR. I checked it rather than taking it, both directions:

```
config: google {enabled: false}  +  google-gemini-cli {enabled: true}
  runtime resolves -> true      my fold wrote -> false     (disables a running plugin)

config: google {enabled: true}   +  google-gemini-cli {enabled: false}
  runtime resolves -> false     my fold wrote -> true      (enables a disabled one)
```

Raw entries are applied in file order, so a later alias beats the canonical entry and that is what the runtime resolves. My fold always sorted canonical last, which is correct for *config payload* precedence and exactly wrong for *policy*. Answering any wizard prompt would have written the inverted state back.

Policy now comes from the normalizer, which is the same thing the runtime reads, and only the config payload is merged:

```ts
const effective = normalizePluginsConfig(config.plugins).entries[resolvedId] ?? {};
...
const { config: _normalizedConfig, ...policy } = effective;
return {
  ...policy,
  ...(Object.keys(mergedConfig).length > 0 ? { config: mergedConfig } : {}),
};
```

Both directions now agree with the runtime, and the payload merge from the previous round is unaffected:

```
CHECK runtime=true  fold=true  config={"apiKey":"k","region":"eu"}
CHECK runtime=false fold=false config={"apiKey":"k","region":"eu"}
```

### the conflicting-enable regression test you asked for

Canonical `enabled: false`, alias `enabled: true` written after it, wizard answers a field. Revert the fix and it fails:

```
× does not switch a plugin off while folding a conflicting alias
  → expected false to be true
```

### checks

| check | result |
|---|---|
| `vitest run src/wizard src/plugins/config-state.test.ts src/plugins/toggle-config.test.ts` | 25 files, 445 tests, all passed |
| new test with the fix reverted | fails as above |
| `pnpm tsgo:core:test` | clean |
| `pnpm check:import-cycles` | 0 runtime value cycles |
| `run-oxlint.mjs src/wizard src/plugins` | clean |
| `oxfmt --check` | correctly formatted |

One note for the record: `pnpm tsgo:core` passed on my first attempt at this and `pnpm tsgo:core:test` caught a real `TS2322` in it, because the normalized entry types `config` as `unknown`. I only saw it because I now run the command CI runs rather than the one next to it.

Commits were also reauthored to my own address; the content is unchanged and the tree hashes matched before and after.



---

## Follow-up 5: the fold was writing fields the schema forbids

Correct, and it is worse than the finding states. I probed it rather than taking it:

```
in:  { enabled: true, llm: { allowedModels: [] }, config: { region: "eu" } }
out: { enabled: true, llm: { hasAllowedModelsConfig: true }, config: { region: "eu" } }
```

Two problems in one line. It **adds** `hasAllowedModelsConfig`, which the strict persisted schema forbids, and it **loses** the `allowedModels` list that flag was derived from. So a valid entry with an empty allowlist comes back both invalid and missing a real user setting.

The mistake was mine and it was structural: in the previous round I moved the base of the fold from the raw entries to the normalized entry, to fix the enablement inversion. The normalized entry is runtime policy, not persisted config, so everything derived came along with it.

The repo already had the right shape. `setPluginEnabledInConfig` always folded the **raw** entries, which are in persisted form by construction, and then set `enabled` itself. The fold does the same again, and reads only `enabled` off the normalizer, because that is the single field that has to agree with what the runtime resolves:

```ts
let merged: PluginEntryConfig = {};
for (const [, entry] of matching) {
  merged = mergeDeep(merged, entry) as PluginEntryConfig;
}
const effectiveEnabled = normalizePluginsConfig(config.plugins).entries[resolvedId]?.enabled;
return {
  ...merged,
  ...(effectiveEnabled === undefined ? {} : { enabled: effectiveEnabled }),
};
```

All four properties hold together now, which is what the last three rounds have each broken one of:

```
allowlist survives      {"enabled":true,"llm":{"allowedModels":[]},"config":{"region":"eu"}}
enabled, conflict A     runtime=true  fold=true
enabled, conflict B     runtime=false fold=false
canonical wins a clash  {"k":"canonical","only":"a"}
```

### regression test

Revert to the normalized base and it fails with the defect stated plainly:

```
× does not write normalization-only fields into the saved config
  → expected { hasAllowedModelsConfig: true } to deeply equal { allowedModels: [] }
```

### checks

| check | result |
|---|---|
| `vitest run src/wizard src/plugins/config-state.test.ts src/plugins/toggle-config.test.ts` | 25 files, 446 tests, all passed |
| new test with the fold reverted | fails as above |
| `pnpm tsgo:core:test` | clean |
| `run-oxlint.mjs src/wizard src/plugins` | clean |
| `oxfmt --check` | correctly formatted |
