### PR TITLE
fix(sessions): keep reset history closed after compaction

### DIFF
--- a/docs/reference/session-management-compaction.md
+++ b/docs/reference/session-management-compaction.md
@@ -54,7 +54,7 @@ Per agent, on the Gateway host (resolved via `src/config/sessions.ts`):
 | `maxDiskBytes`          | `10gb`                | per-agent sessions disk budget; `false`, `0`, or `"0"` disables                             |
 | `highWaterBytes`        | 80% of `maxDiskBytes` | target after cleanup; zero-resolving values use the default, and negatives are invalid      |
 
-Reset advances the live `sessionKey -> sessionId` mapping but keeps the previous SQLite session, transcript, trajectory, and search rows. That history remains searchable under the same session key; ordinary entry and session lists show only the new live mapping. Retained reset history is bounded by the disk budget, not by `resetArchiveRetention`, which only ages archive artifacts. Explicit deletion is different: it writes and verifies a compressed transcript archive (`*.jsonl.deleted.<timestamp>.zst` when zstd is available) before removing the deleted session's rows.
+Reset boundaries start a fresh history window without deleting earlier transcript rows. When session rollover advances the live `sessionKey -> sessionId` mapping, the previous SQLite session, transcript, trajectory, and search rows also remain; ordinary entry and session lists show only the live mapping. Retained reset history is bounded by the disk budget, not by `resetArchiveRetention`, which only ages archive artifacts. Explicit deletion is different: it writes and verifies a compressed transcript archive (`*.jsonl.deleted.<timestamp>.zst` when zstd is available) before removing the deleted session's rows.
 
 `maxDiskBytes` enforcement uses physical bytes: the per-agent SQLite main file, its `-wal` file, and counted files in the agent sessions directory. It never estimates row JSON sizes or subtracts logical row sizes from that total.
 
@@ -130,7 +130,7 @@ A `sessionKey` identifies which conversation bucket you are in (routing + isolat
 
 Each `sessionKey` points at a current `sessionId` (the SQLite transcript identity that continues the conversation). Decision logic lives in `initSessionState()` in `src/auto-reply/reply/session.ts`.
 
-- **Reset** (`/new`, `/reset`) creates a new `sessionId` for that `sessionKey`.
+- **Gateway reset** (`/new`, `/reset`) records a reset boundary in an existing persisted session and keeps its `sessionId`. A session that does not exist yet receives a new id.
 - **No automatic reset** is the default. The current `sessionId` continues while compaction keeps the active model context bounded.
 - **Daily reset** (`session.reset.mode: "daily"`) creates a new `sessionId` on the next message after the configured local-hour boundary (`session.reset.atHour`, default `4`).
 - **Idle expiry** (`session.reset.mode: "idle"` with `session.reset.idleMinutes`, or legacy `session.idleMinutes`) creates a new `sessionId` when a message arrives after the idle window. If daily and idle are both configured, whichever expires first wins.
@@ -181,7 +181,10 @@ Notable entry types:
 - `custom_message`: extension-injected message that _does_ enter model context (rendered in the TUI when `display: true`, hidden entirely when `display: false`)
 - `custom`: extension state that does _not_ enter model context (for persisting extension state across reloads)
 - `compaction`: persisted compaction summary with `firstKeptEntryId` and `tokensBefore`
+- `reset`: a fresh history window, optionally retaining messages from `firstKeptEntryId`
 - `branch_summary`: persisted summary when navigating a tree branch
+
+History readers keep the latest reset window across later compactions: explicitly retained reset messages and messages after that reset remain visible, but older messages and compaction summaries do not reappear. Model context follows the latest reset or compaction instead, so compaction can summarize the current conversation without reopening its earlier history.
 
 OpenClaw intentionally does not "fix up" transcripts; the Gateway uses `SessionManager` to read/write them.
 

--- a/src/config/sessions/session-accessor.sqlite-active-events.test.ts
+++ b/src/config/sessions/session-accessor.sqlite-active-events.test.ts
@@ -191,107 +191,6 @@ describe("SQLite active transcript event projection", () => {
     expect(readSessionTranscriptActiveStats(scope).sizeBytes).toBeLessThan(1_000);
   });
 
-  it("counts paired reset tool results without counting discarded orphan results", async () => {
-    const assistantMessage = {
-      role: "assistant" as const,
-      api: "openai-responses" as const,
-      provider: "openai",
-      model: "gpt-5.6-sol",
-      content: [{ type: "toolCall" as const, id: "call-1", name: "read", arguments: {} }],
-      stopReason: "toolUse" as const,
-      timestamp: Date.parse("2026-08-15T00:00:00.000Z"),
-      usage: {
-        input: 1,
-        output: 1,
-        cacheRead: 0,
-        cacheWrite: 0,
-        totalTokens: 2,
-        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-      },
-    };
-    await persistSessionTranscriptTurn(scope, {
-      messages: [
-        {
-          eventId: "discarded-old",
-          parentId: null,
-          message: { role: "user", content: `discarded ${"x".repeat(12_000)}` },
-        },
-        {
-          eventId: "kept-user",
-          parentId: "discarded-old",
-          message: { role: "user", content: "kept question" },
-        },
-        { eventId: "kept-assistant", parentId: "kept-user", message: assistantMessage },
-        {
-          eventId: "kept-result",
-          parentId: "kept-assistant",
-          message: {
-            role: "toolResult",
-            toolCallId: "call-1",
-            toolName: "read",
-            content: [{ type: "text", text: `paired ${"p".repeat(3_000)}` }],
-            isError: false,
-            timestamp: Date.parse("2026-08-15T00:00:01.000Z"),
-          },
-        },
-        {
-          eventId: "discarded-orphan",
-          parentId: "kept-result",
-          message: {
-            role: "toolResult",
-            toolCallId: "orphan-call",
-            toolName: "read",
-            content: [{ type: "text", text: `orphan ${"o".repeat(20_000)}` }],
-            isError: false,
-            timestamp: Date.parse("2026-08-15T00:00:02.000Z"),
-          },
-        },
-      ],
-      touchSessionEntry: false,
-    });
-    await appendTranscriptEvent(scope, {
-      type: "reset",
-      id: "reset-boundary",
-      parentId: "discarded-orphan",
-      timestamp: "2026-08-15T00:00:03.000Z",
-      reason: "new",
-      firstKeptEntryId: "kept-user",
-    });
-    await persistSessionTranscriptTurn(scope, {
-      messages: [
-        {
-          eventId: "post-reset",
-          parentId: "reset-boundary",
-          message: { role: "user", content: "fresh turn" },
-        },
-      ],
-      touchSessionEntry: false,
-    });
-
-    const stats = readSessionTranscriptActiveStats(scope);
-    expect(stats.eventCount).toBe(4);
-    expect(stats.sizeBytes).toBeGreaterThan(3_000);
-    expect(stats.sizeBytes).toBeLessThan(8_000);
-
-    await persistSessionTranscriptTurn(scope, {
-      messages: [
-        {
-          eventId: "second-post-reset",
-          parentId: "post-reset",
-          message: { role: "assistant", content: "fresh answer" },
-        },
-      ],
-      touchSessionEntry: false,
-    });
-    const parseSpy = vi.spyOn(JSON, "parse");
-    try {
-      expect(readSessionTranscriptActiveStats(scope).eventCount).toBe(5);
-      expect(parseSpy).not.toHaveBeenCalled();
-    } finally {
-      parseSpy.mockRestore();
-    }
-  });
-
   it("keeps counting genuinely oversized post-reset events", async () => {
     await appendTranscriptEvent(scope, {
       type: "reset",
@@ -491,8 +390,8 @@ describe("SQLite active transcript event projection", () => {
       id: "newer-compaction",
       parentId: "post-reset",
       timestamp: "2026-07-22T00:01:00.000Z",
-      summary: "newer boundary shadows reset",
-      firstKeptEntryId: "old",
+      summary: "fresh-only summary",
+      firstKeptEntryId: "post-reset",
       tokensBefore: 10,
     });
     expect(
@@ -504,8 +403,8 @@ describe("SQLite active transcript event projection", () => {
     ).toBe("newer-compaction");
     expect(readSessionTranscriptActivePathEntryRelation(scope, "newer-compaction")).toBe("exact");
     expect(readSessionTranscriptActivePathEntryRelation(scope, "post-reset")).toBe("ancestor");
-    expect(readSessionTranscriptMessageEventCount(scope)).toBe(5);
-    expect(readSessionTranscriptMessageEventById(scope, "old")).toBeDefined();
+    expect(readSessionTranscriptMessageEventCount(scope)).toBe(3);
+    expect(readSessionTranscriptMessageEventById(scope, "old")).toBeUndefined();
   });
 
   it("fails closed when the latest indexed reset payload is malformed", async () => {

--- a/src/config/sessions/session-accessor.sqlite-bounded-context.test.ts
+++ b/src/config/sessions/session-accessor.sqlite-bounded-context.test.ts
@@ -1,5 +1,7 @@
 import path from "node:path";
-import { expect, it } from "vitest";
+import { expect, it, vi } from "vitest";
+import { SessionManager } from "../../agents/sessions/session-manager.js";
+import { makeAgentAssistantMessage } from "../../agents/test-helpers/agent-message-fixtures.js";
 import { openOpenClawAgentDatabase } from "../../state/openclaw-agent-db.js";
 import { withOpenClawTestState } from "../../test-utils/openclaw-test-state.js";
 import {
@@ -9,11 +11,15 @@ import {
   upsertSessionEntryCore,
 } from "./session-accessor.js";
 import { readSessionTranscriptBoundedActiveContextCore } from "./session-accessor.sqlite-active-context.js";
-import { readSessionTranscriptActiveStats } from "./session-accessor.sqlite-active-events.js";
+import {
+  readSessionTranscriptActiveStats,
+  readSessionTranscriptBoundedMessageTailPage,
+} from "./session-accessor.sqlite-active-events.js";
 import { importSqliteSessionRows } from "./session-accessor.sqlite-import.js";
 import {
   startSessionTranscriptIndexReconcile,
   waitForSessionTranscriptIndexReconcile,
+  waitForSessionTranscriptProjection,
 } from "./session-transcript-reconcile.js";
 
 async function withBoundedContextScope(
@@ -286,5 +292,223 @@ it("counts the retained tail instead of compacted transcript bytes", async () =>
     expect(stats.eventCount).toBe(4);
     expect(stats.sizeBytes).toBeGreaterThan(7_000);
     expect(stats.sizeBytes).toBeLessThan(12_000);
+    const history = readSessionTranscriptBoundedMessageTailPage(scope, {
+      maxBytes: 1024 * 1024,
+      maxMessages: 100,
+      offset: 0,
+    });
+    expect(history.events.map(({ event }) => (event as { id: string }).id)).toEqual([
+      "discarded-old",
+      "kept-user",
+      "kept-assistant",
+      "post-compaction",
+    ]);
+  });
+});
+
+it.each(["cold", "warm"])(
+  "keeps reset history closed across compaction with a %s history cache",
+  async (cache) => {
+    await withBoundedContextScope(async (scope) => {
+      const manager = SessionManager.open(scope);
+      const appendUser = (content: string) =>
+        manager.appendMessage({ role: "user", content, timestamp: 1 });
+      const readHistory = () =>
+        readSessionTranscriptBoundedMessageTailPage(scope, {
+          maxBytes: 1024 * 1024,
+          maxMessages: 100,
+          offset: 0,
+        });
+      const settle = async () => {
+        manager.flushPendingPersistence();
+        await waitForSessionTranscriptProjection(scope);
+      };
+      const expectHistory = (ids: string[]) => {
+        const page = readHistory();
+        expect(page.totalMessages).toBe(ids.length);
+        expect(page.events.map(({ event }) => (event as { id: string }).id)).toEqual(ids);
+      };
+
+      appendUser("before-reset user");
+      manager.appendMessage(
+        makeAgentAssistantMessage({
+          content: [{ type: "text", text: "before-reset assistant" }],
+        }),
+      );
+      manager.appendResetBoundary("new");
+      const freshUserId = appendUser("fresh user");
+      await settle();
+      if (cache === "warm") {
+        expectHistory([freshUserId]);
+      }
+
+      manager.appendCompaction("fresh-only summary", freshUserId, 100);
+      await settle();
+      expectHistory([freshUserId]);
+      expect(manager.buildSessionContext().messages).toMatchObject([
+        { role: "compactionSummary", summary: "fresh-only summary" },
+        { role: "user", content: "fresh user" },
+      ]);
+      expect(readSessionTranscriptActiveStats(scope).eventCount).toBe(2);
+
+      const nextUserId = appendUser("after compaction");
+      await settle();
+      expectHistory([freshUserId, nextUserId]);
+      expect(readSessionTranscriptActiveStats(scope).eventCount).toBe(3);
+
+      // A newer reset wins for both scopes; another compaction must not revive older resets.
+      manager.appendResetBoundary("new", nextUserId);
+      const newestUserId = appendUser("after second reset");
+      await settle();
+      expectHistory([nextUserId, newestUserId]);
+      expect(manager.buildSessionContext().messages).toMatchObject([
+        { role: "user", content: "after compaction" },
+        { role: "user", content: "after second reset" },
+      ]);
+      expect(readSessionTranscriptActiveStats(scope).eventCount).toBe(2);
+
+      manager.appendCompaction("newest-only summary", newestUserId, 100);
+      await settle();
+      expectHistory([nextUserId, newestUserId]);
+      const reopened = SessionManager.open(scope);
+      expect(reopened.buildSessionContext().messages).toMatchObject([
+        { role: "compactionSummary", summary: "newest-only summary" },
+        { role: "user", content: "after second reset" },
+      ]);
+      expect(readSessionTranscriptActiveStats(scope).eventCount).toBe(2);
+    });
+  },
+);
+
+it("counts paired reset tool results without counting discarded orphan results", async () => {
+  await withBoundedContextScope(async (scope) => {
+    const assistantMessage = {
+      role: "assistant" as const,
+      api: "openai-responses" as const,
+      provider: "openai",
+      model: "gpt-5.6-sol",
+      content: [{ type: "toolCall" as const, id: "call-1", name: "read", arguments: {} }],
+      stopReason: "toolUse" as const,
+      timestamp: Date.parse("2026-08-15T00:00:00.000Z"),
+      usage: {
+        input: 1,
+        output: 1,
+        cacheRead: 0,
+        cacheWrite: 0,
+        totalTokens: 2,
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+      },
+    };
+    await persistSessionTranscriptTurn(scope, {
+      messages: [
+        {
+          eventId: "discarded-old",
+          parentId: null,
+          message: { role: "user", content: `discarded ${"x".repeat(12_000)}` },
+        },
+        {
+          eventId: "kept-user",
+          parentId: "discarded-old",
+          message: { role: "user", content: "kept question" },
+        },
+        { eventId: "kept-assistant", parentId: "kept-user", message: assistantMessage },
+        {
+          eventId: "kept-result",
+          parentId: "kept-assistant",
+          message: {
+            role: "toolResult",
+            toolCallId: "call-1",
+            toolName: "read",
+            content: [{ type: "text", text: `paired ${"p".repeat(3_000)}` }],
+            isError: false,
+            timestamp: Date.parse("2026-08-15T00:00:01.000Z"),
+          },
+        },
+        {
+          eventId: "discarded-orphan",
+          parentId: "kept-result",
+          message: {
+            role: "toolResult",
+            toolCallId: "orphan-call",
+            toolName: "read",
+            content: [{ type: "text", text: `orphan ${"o".repeat(20_000)}` }],
+            isError: false,
+            timestamp: Date.parse("2026-08-15T00:00:02.000Z"),
+          },
+        },
+      ],
+      touchSessionEntry: false,
+    });
+    await appendTranscriptEvent(scope, {
+      type: "reset",
+      id: "reset-boundary",
+      parentId: "discarded-orphan",
+      timestamp: "2026-08-15T00:00:03.000Z",
+      reason: "new",
+      firstKeptEntryId: "kept-user",
+    });
+    await persistSessionTranscriptTurn(scope, {
+      messages: [
+        {
+          eventId: "post-reset",
+          parentId: "reset-boundary",
+          message: { role: "user", content: "fresh turn" },
+        },
+      ],
+      touchSessionEntry: false,
+    });
+
+    const stats = readSessionTranscriptActiveStats(scope);
+    expect(stats.eventCount).toBe(4);
+    expect(stats.sizeBytes).toBeGreaterThan(3_000);
+    expect(stats.sizeBytes).toBeLessThan(8_000);
+    expect(
+      readSessionTranscriptBoundedMessageTailPage(scope, {
+        maxBytes: 1024 * 1024,
+        maxMessages: 100,
+        offset: 0,
+      }).totalMessages,
+    ).toBe(3);
+
+    await persistSessionTranscriptTurn(scope, {
+      messages: [
+        {
+          eventId: "second-post-reset",
+          parentId: "post-reset",
+          message: { role: "assistant", content: "fresh answer" },
+        },
+      ],
+      touchSessionEntry: false,
+    });
+    const parseSpy = vi.spyOn(JSON, "parse");
+    try {
+      expect(readSessionTranscriptActiveStats(scope).eventCount).toBe(5);
+      expect(parseSpy).not.toHaveBeenCalled();
+    } finally {
+      parseSpy.mockRestore();
+    }
+
+    await appendTranscriptEvent(scope, {
+      type: "compaction",
+      id: "fresh-compaction",
+      parentId: "second-post-reset",
+      timestamp: "2026-08-15T00:00:04.000Z",
+      summary: "fresh-only summary",
+      firstKeptEntryId: "post-reset",
+      tokensBefore: 100,
+    });
+    const history = readSessionTranscriptBoundedMessageTailPage(scope, {
+      maxBytes: 1024 * 1024,
+      maxMessages: 100,
+      offset: 0,
+    });
+    expect(history.totalMessages).toBe(4);
+    expect(history.events.map(({ event }) => (event as { id: string }).id)).toEqual([
+      "kept-user",
+      "kept-assistant",
+      "post-reset",
+      "second-post-reset",
+    ]);
+    expect(readSessionTranscriptActiveStats(scope).eventCount).toBe(3);
   });
 });

--- a/src/config/sessions/session-accessor.sqlite-history-events.ts
+++ b/src/config/sessions/session-accessor.sqlite-history-events.ts
@@ -89,18 +89,16 @@ function resolveVisibleHistoryProjection(
       .where("identity.event_type", "in", ["compaction", "reset"])
       .orderBy("active.active_position", "asc"),
   ).rows;
-  const latestBoundaryIsReset = rows.at(-1)?.event_type === "reset";
-  const visibleRows = latestBoundaryIsReset ? rows.slice(-1) : rows;
-  let priorBoundaries = 0;
-  const boundaries = visibleRows.map((row): VisibleHistoryBoundary => {
-    const messagePosition = latestBoundaryIsReset
-      ? visibleMessages.kept.length
-      : Math.min(
-          row.next_message_position ?? projection.state.activeMessageCount,
-          visibleMessages.total,
-        );
+  const resetIndex = rows.findLastIndex((row) => row.event_type === "reset");
+  const visibleRows = rows.slice(Math.max(0, resetIndex));
+  const boundaries = visibleRows.map((row, index): VisibleHistoryBoundary => {
+    // Kept messages precede the latest reset; later markers share its logical window.
+    // Rebase raw positions so discarded messages cannot shift those markers.
+    const nextMessagePosition = row.next_message_position ?? projection.state.activeMessageCount;
+    const messagePosition =
+      visibleMessages.kept.length + Math.max(0, nextMessagePosition - visibleMessages.postStart);
     return {
-      displayPosition: messagePosition + priorBoundaries++,
+      displayPosition: messagePosition + index,
       eventId: row.event_id,
       eventSeq: row.seq,
       messagePosition,

--- a/src/config/sessions/session-accessor.sqlite-reset-window.ts
+++ b/src/config/sessions/session-accessor.sqlite-reset-window.ts
@@ -159,16 +159,16 @@ function readLatestActiveBoundaryMetadataByType(
   );
 }
 
-function readLatestActiveBoundaryMetadata(projection: ResetWindowProjection) {
+function readLatestActiveBoundaryMetadata(
+  projection: ResetWindowProjection,
+  scope: BoundaryWindowScope,
+) {
   const reset = readLatestActiveBoundaryMetadataByType(projection, "reset");
-  const compaction = readLatestActiveBoundaryMetadataByType(projection, "compaction");
-  if (!reset) {
-    return compaction;
-  }
-  if (!compaction) {
+  if (scope === "history") {
     return reset;
   }
-  return reset.seq > compaction.seq ? reset : compaction;
+  const compaction = readLatestActiveBoundaryMetadataByType(projection, "compaction");
+  return reset && (!compaction || reset.seq > compaction.seq) ? reset : compaction;
 }
 
 function readBoundaryPayload(
@@ -204,8 +204,8 @@ function findLatestResetMessageWindow(
   scope: BoundaryWindowScope,
 ): ResetMessageWindow | null {
   const db = getResetWindowKysely(projection.database);
-  const latestBoundary = readLatestActiveBoundaryMetadata(projection);
-  if (!latestBoundary || !isWindowBoundary(latestBoundary.event_type, scope)) {
+  const latestBoundary = readLatestActiveBoundaryMetadata(projection, scope);
+  if (!latestBoundary) {
     return null;
   }
   const boundaryPayload = readBoundaryPayload(projection, latestBoundary.seq, scope);
@@ -312,12 +312,8 @@ function resolveResetMessageWindow(
       return cached.window;
     }
     if (cached.generation === generation && cached.window) {
-      const latestBoundary = readLatestActiveBoundaryMetadata(projection);
-      if (
-        latestBoundary &&
-        isWindowBoundary(latestBoundary.event_type, scope) &&
-        latestBoundary.seq === cached.window.boundarySeq
-      ) {
+      const latestBoundary = readLatestActiveBoundaryMetadata(projection, scope);
+      if (latestBoundary?.seq === cached.window.boundarySeq) {
         const window = { ...cached.window, indexedSeq: projection.state.indexedSeq };
         cacheResetMessageWindow(key, { generation, indexedSeq: window.indexedSeq, window });
         return window;

--- a/src/gateway/session-transcript-readers.markers.test.ts
+++ b/src/gateway/session-transcript-readers.markers.test.ts
@@ -16,6 +16,30 @@ import {
 } from "./session-transcript-readers.js";
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+const timestamp = "2026-08-11T18:00:00.000Z";
+
+function message(id: string, content: string, role: "user" | "assistant" | "toolResult" = "user") {
+  return { type: "message" as const, id, message: { role, content } };
+}
+
+function compaction(id: string, firstKeptEntryId: string) {
+  return {
+    type: "compaction" as const,
+    id,
+    timestamp,
+    summary: `${id} summary`,
+    firstKeptEntryId,
+    tokensBefore: 100,
+  };
+}
+
+function reset(id: string, firstKeptEntryId?: string) {
+  return { type: "reset" as const, id, timestamp, reason: "reset", firstKeptEntryId };
+}
+
+function messageIds(messages: unknown[]) {
+  return messages.map((entry) => (entry as { __openclaw: { id: string } })["__openclaw"].id);
+}
 
 describe("session transcript reader marker projection", () => {
   let tempDir: string;
@@ -37,7 +61,7 @@ describe("session transcript reader marker projection", () => {
 
   async function writeTranscript(
     sessionId: string,
-    events: unknown[],
+    events: Array<{ id: string }>,
   ): Promise<SessionTranscriptReadScope> {
     const scope = {
       agentId: "main",
@@ -45,136 +69,140 @@ describe("session transcript reader marker projection", () => {
       sessionKey: `agent:main:${sessionId}`,
       storePath,
     };
-    await replaceTranscriptEvents(scope, events);
+    await replaceTranscriptEvents(scope, [
+      { type: "session", version: 3, id: sessionId },
+      ...events.map((event, index) => ({ ...event, parentId: events[index - 1]?.id ?? null })),
+    ]);
     return scope;
   }
 
   test.each([
     {
       name: "compaction",
-      sessionId: "reader-compaction-boundary",
-      markerId: "compaction-boundary",
-      markerKind: "compaction",
-      markerText: "Compaction",
-      events: (sessionId: string) => [
-        { type: "session", version: 3, id: sessionId },
-        {
-          type: "message",
-          id: "before-compaction",
-          parentId: null,
-          message: { role: "user", content: "before compaction" },
-        },
-        {
-          type: "compaction",
-          id: "compaction-boundary",
-          parentId: "before-compaction",
-          timestamp: "2026-08-11T18:00:00.000Z",
-          summary: "summary",
-          firstKeptEntryId: "before-compaction",
-          tokensBefore: 100,
-        },
-        {
-          type: "message",
-          id: "after-compaction",
-          parentId: "compaction-boundary",
-          message: { role: "assistant", content: "after compaction" },
-        },
+      events: [
+        message("before", "before compaction"),
+        compaction("summary", "before"),
+        message("after", "after compaction", "assistant"),
       ],
-      expected: ["before compaction", "compaction", "after compaction"],
+      expectedIds: ["before", "summary", "after"],
     },
     {
       name: "reset",
-      sessionId: "reader-reset-boundary",
-      markerId: "reset-boundary",
-      markerKind: "reset",
-      markerText: "Reset",
-      events: (sessionId: string) => [
-        { type: "session", version: 3, id: sessionId },
-        {
-          type: "message",
-          id: "old",
-          parentId: null,
-          message: { role: "user", content: "hidden old turn" },
-        },
-        {
-          type: "message",
-          id: "kept-user",
-          parentId: "old",
-          message: { role: "user", content: "kept question" },
-        },
-        {
-          type: "message",
-          id: "kept-assistant",
-          parentId: "kept-user",
-          message: { role: "assistant", content: "kept answer" },
-        },
-        {
-          type: "reset",
-          id: "reset-boundary",
-          parentId: "kept-assistant",
-          timestamp: "2026-08-11T18:00:00.000Z",
-          reason: "reset",
-          firstKeptEntryId: "kept-user",
-        },
-        {
-          type: "message",
-          id: "post-reset",
-          parentId: "reset-boundary",
-          message: { role: "assistant", content: "new answer" },
-        },
+      events: [
+        message("old", "hidden old turn"),
+        message("kept-user", "kept question"),
+        message("kept-assistant", "kept answer", "assistant"),
+        reset("reset", "kept-user"),
+        message("post-reset", "new answer", "assistant"),
       ],
-      expected: ["kept question", "kept answer", "reset", "new answer"],
+      expectedIds: ["kept-user", "kept-assistant", "reset", "post-reset"],
+    },
+    {
+      name: "reset-then-compaction",
+      events: [
+        message("old", "hidden old turn"),
+        compaction("old-summary", "old"),
+        reset("reset"),
+        message("fresh", "fresh user"),
+        compaction("fresh-summary", "fresh"),
+      ],
+      expectedIds: ["reset", "fresh", "fresh-summary"],
+    },
+    {
+      name: "empty-reset-adjacent-compactions",
+      events: [
+        message("old", "hidden old turn"),
+        compaction("old-summary", "old"),
+        reset("reset"),
+        compaction("fresh-summary", "reset"),
+        compaction("newest-summary", "reset"),
+      ],
+      expectedIds: ["reset", "fresh-summary", "newest-summary"],
+    },
+    {
+      name: "kept-reset-adjacent-compactions",
+      events: [
+        message("old", "hidden old turn"),
+        compaction("old-summary", "old"),
+        message("kept-user", "kept question"),
+        message("orphan-tool", "hidden orphan result", "toolResult"),
+        message("kept-assistant", "kept answer", "assistant"),
+        reset("reset", "kept-user"),
+        compaction("fresh-summary", "kept-user"),
+        compaction("newest-summary", "kept-user"),
+      ],
+      expectedIds: ["kept-user", "kept-assistant", "reset", "fresh-summary", "newest-summary"],
+    },
+    {
+      name: "repeated-resets",
+      events: [
+        message("old", "hidden old turn"),
+        compaction("old-summary", "old"),
+        reset("old-reset"),
+        message("middle", "hidden middle turn"),
+        compaction("middle-summary", "middle"),
+        reset("reset"),
+        message("fresh", "fresh user"),
+        compaction("fresh-summary", "fresh"),
+        compaction("newest-summary", "fresh"),
+        message("after", "after compactions", "assistant"),
+      ],
+      expectedIds: ["reset", "fresh", "fresh-summary", "newest-summary", "after"],
     },
   ])("projects $name boundaries through every SQLite history read", async (fixture) => {
-    const scope = await writeTranscript(fixture.sessionId, fixture.events(fixture.sessionId));
-    const summarize = (messages: unknown[]) =>
-      messages.map((message) => {
-        const record = message as { content?: unknown; __openclaw?: { kind?: string } };
-        return record["__openclaw"]?.kind ?? record.content;
-      });
-
+    const scope = await writeTranscript(`reader-${fixture.name}`, fixture.events);
     const full = await readSessionMessagesAsync(scope, {
       mode: "full",
       reason: `${fixture.name} boundary projection test`,
     });
     const recent = await readRecentSessionMessagesWithStatsAsync(scope, {
       maxBytes: 16_384,
-      maxLines: 10,
-      maxMessages: 10,
-    });
-    const markerIndex = fixture.expected.indexOf(fixture.markerKind);
-    const page = await readSessionMessagesPageWithStatsAsync(scope, {
-      maxMessages: 1,
-      offset: fixture.expected.length - markerIndex - 1,
-    });
-    const byId = await readSessionMessageByIdAsync(scope, fixture.markerId);
-    const anchored = await readSessionMessagesAroundIdWithStatsAsync(scope, {
-      messageId: fixture.markerId,
-      maxMessages: 10,
+      maxLines: 2,
+      maxMessages: 2,
     });
 
-    expect(summarize(full)).toEqual(fixture.expected);
-    expect(summarize(recent.messages)).toEqual(fixture.expected);
-    expect(recent.totalMessages).toBe(fixture.expected.length);
-    expect(summarize(page.messages)).toEqual([fixture.markerKind]);
-    expect(page.totalMessages).toBe(fixture.expected.length);
-    expect(await readSessionMessageCountAsync(scope)).toBe(fixture.expected.length);
-    expect(byId).toMatchObject({
-      found: true,
-      message: {
-        role: "system",
-        content: [{ type: "text", text: fixture.markerText }],
-        timestamp: Date.parse("2026-08-11T18:00:00.000Z"),
-        __openclaw: {
-          kind: fixture.markerKind,
-          id: fixture.markerId,
-          seq: markerIndex + 1,
-        },
-      },
-      seq: markerIndex + 1,
-    });
-    expect(anchored.found).toBe(true);
-    expect(summarize(anchored.messages)).toEqual(fixture.expected);
-    expect(anchored.totalMessages).toBe(fixture.expected.length);
+    expect(messageIds(full)).toEqual(fixture.expectedIds);
+    expect(messageIds(recent.messages)).toEqual(fixture.expectedIds.slice(-2));
+    expect(recent.totalMessages).toBe(fixture.expectedIds.length);
+    expect(await readSessionMessageCountAsync(scope)).toBe(fixture.expectedIds.length);
+    for (const [index, id] of fixture.expectedIds.entries()) {
+      const page = await readSessionMessagesPageWithStatsAsync(scope, {
+        maxMessages: 1,
+        offset: fixture.expectedIds.length - index - 1,
+      });
+      const byId = await readSessionMessageByIdAsync(scope, id);
+      const anchored = await readSessionMessagesAroundIdWithStatsAsync(scope, {
+        messageId: id,
+        maxMessages: 10,
+      });
+      expect(messageIds(page.messages)).toEqual([id]);
+      expect(page.totalMessages).toBe(fixture.expectedIds.length);
+      expect(byId).toMatchObject({ found: true, seq: index + 1 });
+      expect(byId.message).toMatchObject({ __openclaw: { id, seq: index + 1 } });
+      const entry = fixture.events.find((event) => event.id === id)!;
+      expect(byId.message).toMatchObject(
+        entry.type === "message"
+          ? entry.message
+          : {
+              role: "system",
+              content: [
+                { type: "text", text: entry.type === "compaction" ? "Compaction" : "Reset" },
+              ],
+              timestamp: Date.parse(timestamp),
+              __openclaw: { kind: entry.type },
+            },
+      );
+      expect(anchored.found).toBe(true);
+      expect(messageIds(anchored.messages)).toEqual(fixture.expectedIds);
+      expect(anchored.totalMessages).toBe(fixture.expectedIds.length);
+    }
+    for (const { id } of fixture.events.filter(
+      (event) => !fixture.expectedIds.includes(event.id),
+    )) {
+      expect(await readSessionMessageByIdAsync(scope, id)).toMatchObject({ found: false });
+      expect(
+        await readSessionMessagesAroundIdWithStatsAsync(scope, { messageId: id, maxMessages: 10 }),
+      ).toMatchObject({ found: false, messages: [], totalMessages: fixture.expectedIds.length });
+    }
   });
 });


### PR DESCRIPTION
Closes #132586

## What Problem This Solves

Fixes an issue where users would see messages and older compaction summaries reappear in session history after resetting a session and then compacting it. Reset and compaction markers could also appear after the wrong messages. Bounded history consumers, including CLI lifecycle hooks and session-memory capture, could receive the discarded turns even though model context already excluded them.

## Why This Change Was Made

The canonical history-window owner now selects the latest reset for both cold reads and cache refresh; model-context accounting still selects the latest reset or compaction. The event-history owner keeps the latest reset and subsequent boundaries, mapping their raw message positions through that same visible window so every reader agrees on order, counts and IDs.

This removes redundant selection checks and the mutable marker counter. There is no consumer guard, schema/config/protocol change, retention change, new store or durable transcript rewrite. Explicitly retained reset tails, compaction-only history and model-context behavior remain supported. The documentation now explains the history/context distinction and in-place Gateway resets.

## User Impact

A later compaction no longer revives reset-discarded history or saved memory content. Current reset/compaction markers remain in the correct order, and old hidden message or boundary IDs are not returned by history lookup or anchored paging. Raw transcript rows remain stored.

## Evidence

The exact real SessionManager/SQLite sequence appends a user and assistant message, resets, appends one fresh user message, warms history, then compacts using the fresh user's ID:

| Observation | Before | After |
| --- | ---: | ---: |
| Visible messages immediately after reset | 1 | 1 |
| Visible messages after subsequent compaction | 3 | 1 |
| Pre-reset messages returned after compaction | 2 | 0 |
| Model context contains pre-reset messages | false | false |

- Failing-first proof: four message-window cases failed before that owner was repaired. With the message repair present and the event owner unchanged, all four new marker cases failed on leaked summaries or ordering; the two original marker cases passed.
- Integrated proof: 89 tests passed across nine files (five serialized Vitest shards). Coverage includes cold/warm cache order, appends, repeated resets/compactions, retained pairing, empty post-reset history, adjacent boundaries, full/recent/offset/count/by-ID/anchor reads, bounded hydration, and upstream context-eligibility/display-position behavior.
- Production APIs: the byte-identical original probe passed after integration with the 1 → 1 result above; the strengthened probe passed all nine warm/cold stages, including marker order, CLI history, context-engine/reseed behavior and actual session-memory files. No mocks, provider calls or operator state were used.
- Changed-scope checks: the complete changed-scope gate passed, including targeted formatting, core/core-test typechecks, changed-file lint, dead-export scans, boundary/storage/schema guards and runtime import-cycle checks.
- Fresh isolated autoreview passed before commit and after integration, with no actionable findings at the required P0 scope. This is not a claim of broader-priority review or completed CI.

Focused test command:

```sh
node scripts/run-vitest.mjs src/config/sessions/session-accessor.sqlite-history-events.test.ts src/config/sessions/session-accessor.sqlite-bounded-context.test.ts src/config/sessions/session-accessor.sqlite-active-events.test.ts src/gateway/session-transcript-readers.markers.test.ts src/agents/cli-runner/session-history.test.ts src/gateway/session-companion-context.test.ts src/hooks/bundled/session-memory/handler-auto-reset.test.ts src/config/sessions/session-accessor.sqlite-context-accounting.test.ts src/agents/sessions/session-manager-bounded.test.ts
```

Production LOC: **+20/−26 (net −6)**. Tests: **+369/−218 (net +151)**, including relocation of existing retained-pairing coverage to keep its original suite within the file-size budget. Docs: **+5/−2**. The rebase preserves main's active-context module split, opaque ancestry/retained cuts, event-sequence/display metadata, context-eligibility filter and older-writer tests; its sole conflict was the test import block.

The first integrated test attempt was interrupted during prolonged module collection without an assertion failure. A subsequent API probe exposed a missing installed dependency entry point. A frozen-lockfile workspace install repaired dependency readiness without changing manifests or the lockfile; the unchanged focused test command and both production probes then passed.

**Live verification complete:** [Land-ready proof, inspected screenshot and video](https://github.com/openclaw/openclaw/pull/132606#issuecomment-5462982831). The real built Gateway/Control UI flow passed 117 target-flow assertions through old dialogue, compaction, same-session `/clear`, fresh dialogue, compaction, reload, pagination and old-ID lookup. Only provider HTTP responses were synthetic; Gateway WebSocket, compaction, SQLite and rendering were real. The full `pnpm build` passed. Before-fix evidence is the failing real-SQLite/API reproduction; the recording is after-fix live evidence.

**Exact-head CI:** [run 33255432806](https://github.com/openclaw/openclaw/actions/runs/33255432806) is green at `8f19112e90f7872f042353afbead024e085d88f4`, including `openclaw/ci-gate` and SQLite session lifecycle. The latest ClawSweeper rank-up move is addressed. Its serialized-state detector does not imply a schema change: this is a read-only query/projection repair with no persisted-data or migration change, as explained in the proof comment.

**Separate follow-up:** an intermediate live frame showed a transient duplicate fresh-message bubble despite unique canonical history IDs; a UI-rendering investigation was recorded separately. It does not change the verified reset-window result, and the recording is not presented as proof that every intermediate paint is defect-free. Native landing remains pending.

AI-assisted implementation; the owners, callers, integration and evidence were inspected directly. No agent transcript is attached.
