### PR TITLE
fix(msteams): send requested audio as native voice messages

### DIFF
--- a/docs/channels/msteams.md
+++ b/docs/channels/msteams.md
@@ -836,6 +836,7 @@ When `replyStyle: "top-level"` is in effect, channel-thread inbounds are intenti
 - **DMs:** images and file attachments work via Teams bot file APIs.
 - **Channels/groups:** attachments live in M365 storage (SharePoint/OneDrive). The webhook payload only includes an HTML stub, not the actual file bytes. **Graph API permissions are required** to download channel attachments.
 - For explicit file-first sends, use `action=upload-file` with `media` / `filePath` / `path`; optional `message` becomes the accompanying text/comment, and `filename` (or `title`) overrides the uploaded name.
+- Audio with the shared `asVoice` / `audioAsVoice` intent is sent as a Microsoft voice activity instead of a SharePoint file card. The activity carries the audio MIME type, audio data, and reply text as an accessibility transcription. Audio without that intent keeps the normal file-attachment behavior.
 
 Without Graph permissions, channel messages with images arrive as text-only (the image content is not accessible to the bot).
 By default, OpenClaw only downloads media from Microsoft/Teams hostnames. Override with `channels.msteams.mediaAllowHosts` (use `["*"]` to allow any host).

--- a/extensions/msteams/src/messenger.ts
+++ b/extensions/msteams/src/messenger.ts
@@ -35,6 +35,7 @@ import { getMSTeamsRuntime } from "./runtime.js";
 import { sendMSTeamsActivityWithReference } from "./sdk-proactive.js";
 import type { MSTeamsActivityLike } from "./sdk-types.js";
 import type { MSTeamsApp } from "./sdk.js";
+import { buildMSTeamsVoiceActivity } from "./voice-message.js";
 
 /**
  * MSTeams-specific media size limit (100MB).
@@ -85,6 +86,7 @@ type MSTeamsReplyRenderOptions = {
 export type MSTeamsRenderedMessage = {
   text?: string;
   mediaUrl?: string;
+  audioAsVoice?: boolean;
 };
 
 type MSTeamsSendRetryOptions = {
@@ -246,11 +248,18 @@ export function renderReplyPayloadsToMessages(
       // For inline mode, combine text with first media as attachment
       const firstMedia = reply.mediaUrls[0];
       if (firstMedia) {
-        out.push({ text: reply.text || undefined, mediaUrl: firstMedia });
+        out.push({
+          text: reply.text || undefined,
+          mediaUrl: firstMedia,
+          ...(payload.audioAsVoice ? { audioAsVoice: true } : {}),
+        });
         // Additional media URLs as separate messages
         for (let i = 1; i < reply.mediaUrls.length; i++) {
           if (reply.mediaUrls[i]) {
-            out.push({ mediaUrl: reply.mediaUrls[i] });
+            out.push({
+              mediaUrl: reply.mediaUrls[i],
+              ...(payload.audioAsVoice ? { audioAsVoice: true } : {}),
+            });
           }
         }
       } else {
@@ -265,7 +274,7 @@ export function renderReplyPayloadsToMessages(
       if (!mediaUrl) {
         continue;
       }
-      out.push({ mediaUrl });
+      out.push({ mediaUrl, ...(payload.audioAsVoice ? { audioAsVoice: true } : {}) });
     }
   }
 
@@ -316,6 +325,14 @@ async function buildActivity(
       );
       const isPersonal = conversationType === "personal";
       const isImage = media.kind === "image";
+
+      if (msg.audioAsVoice) {
+        return buildMSTeamsVoiceActivity({
+          contentType,
+          contentUrl: `data:${contentType};base64,${media.buffer.toString("base64")}`,
+          transcription: msg.text,
+        });
+      }
 
       if (
         requiresFileConsent({
@@ -375,6 +392,14 @@ async function buildActivity(
       // Image (any chat): use base64 (works for images in all conversation types)
       const base64 = media.buffer.toString("base64");
       contentUrl = `data:${media.contentType};base64,${base64}`;
+    }
+
+    if (msg.audioAsVoice) {
+      return buildMSTeamsVoiceActivity({
+        contentType,
+        contentUrl,
+        transcription: msg.text,
+      });
     }
 
     activity.attachments = [

--- a/extensions/msteams/src/messenger.voice.test.ts
+++ b/extensions/msteams/src/messenger.voice.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+import { renderReplyPayloadsToMessages } from "./messenger.js";
+
+describe("msteams voice reply rendering", () => {
+  it("preserves audioAsVoice on rendered audio media", () => {
+    const messages = renderReplyPayloadsToMessages(
+      [{ mediaUrl: "/tmp/reply.mp3", audioAsVoice: true }],
+      { textChunkLimit: 4000, tableMode: "code" },
+    );
+
+    expect(messages).toEqual([{ mediaUrl: "/tmp/reply.mp3", audioAsVoice: true }]);
+  });
+});

--- a/extensions/msteams/src/outbound.test.ts
+++ b/extensions/msteams/src/outbound.test.ts
@@ -243,6 +243,24 @@ describe("msteamsOutbound cfg threading", () => {
     });
   });
 
+  it("forwards the native voice-note intent for audio media sends", async () => {
+    await requireSendMedia()({
+      cfg,
+      to: "conversation:abc",
+      text: "voice reply",
+      mediaUrl: "file:///tmp/reply.mp3",
+      audioAsVoice: true,
+    });
+
+    expect(mocks.sendMessageMSTeams).toHaveBeenCalledWith({
+      cfg,
+      to: "conversation:abc",
+      text: "voice reply",
+      mediaUrl: "file:///tmp/reply.mp3",
+      audioAsVoice: true,
+    });
+  });
+
   it("preserves host-owned workspace media access for direct attachments", async () => {
     const readFile = vi.fn(async () => Buffer.from("approved attachment"));
     const mediaAccess = {

--- a/extensions/msteams/src/outbound.ts
+++ b/extensions/msteams/src/outbound.ts
@@ -34,7 +34,7 @@ type MSTeamsSendConfig = Parameters<typeof sendMessageMSTeams>[0]["cfg"];
 type MSTeamsSendResult = { messageId: string; conversationId: string };
 type MSTeamsMediaSendOptions = Pick<
   Parameters<typeof sendMessageMSTeams>[0],
-  "mediaUrl" | "mediaAccess" | "mediaLocalRoots" | "mediaReadFile"
+  "mediaUrl" | "audioAsVoice" | "mediaAccess" | "mediaLocalRoots" | "mediaReadFile"
 >;
 type MSTeamsTextSendFn = (to: string, text: string) => Promise<MSTeamsSendResult>;
 type MSTeamsMediaSendFn = (
@@ -129,6 +129,7 @@ export const msteamsOutbound: ChannelOutboundAdapter = {
     mediaAccess,
     mediaLocalRoots,
     mediaReadFile,
+    audioAsVoice,
     payload,
     deps,
     onDeliveryResult,
@@ -168,6 +169,7 @@ export const msteamsOutbound: ChannelOutboundAdapter = {
         send: async ({ text: textLocal, mediaUrl: mediaUrlLocal }) =>
           await send(deliveryTarget, textLocal, {
             mediaUrl: mediaUrlLocal,
+            ...((payload.audioAsVoice ?? audioAsVoice) ? { audioAsVoice: true } : {}),
             mediaAccess,
             mediaLocalRoots,
             mediaReadFile,
@@ -209,6 +211,7 @@ export const msteamsOutbound: ChannelOutboundAdapter = {
       mediaAccess,
       mediaLocalRoots,
       mediaReadFile,
+      audioAsVoice,
       deps,
       threadId,
     }) => {
@@ -216,6 +219,7 @@ export const msteamsOutbound: ChannelOutboundAdapter = {
       return toMSTeamsOutboundResult(
         await send(resolveMSTeamsThreadTarget(to, threadId), text, {
           mediaUrl,
+          ...(audioAsVoice ? { audioAsVoice: true } : {}),
           mediaAccess,
           mediaLocalRoots,
           mediaReadFile,

--- a/extensions/msteams/src/send.test.ts
+++ b/extensions/msteams/src/send.test.ts
@@ -317,6 +317,63 @@ describe("sendMessageMSTeams", () => {
     expect(result.receipt?.parts[1]?.kind).toBe("media");
   });
 
+  it("sends audioAsVoice media as a Microsoft voice activity", async () => {
+    const mediaBuffer = Buffer.from("voice-audio");
+    mockState.loadOutboundMediaFromUrl.mockResolvedValueOnce({
+      buffer: mediaBuffer,
+      contentType: "audio/mpeg",
+      fileName: "reply.mp3",
+      kind: "audio",
+    });
+
+    const result = await sendMessageMSTeams({
+      cfg: {} as OpenClawConfig,
+      to: "conversation:19:conversation@thread.tacv2",
+      text: "Spoken reply",
+      mediaUrl: "file:///tmp/reply.mp3",
+      audioAsVoice: true,
+    });
+
+    expect(mockState.sendMSTeamsActivityWithReference).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      {
+        type: "message",
+        valueType: "application/vnd.microsoft.activity.voice+json",
+        value: {
+          contentType: "audio/mpeg",
+          contentUrl: `data:audio/mpeg;base64,${mediaBuffer.toString("base64")}`,
+          transcription: "Spoken reply",
+        },
+      },
+      expect.anything(),
+    );
+    expect(mockState.uploadAndShareSharePoint).not.toHaveBeenCalled();
+    expect(result.messageId).toBe("message-1");
+  });
+
+  it("rejects audioAsVoice for non-audio media before platform dispatch", async () => {
+    mockState.loadOutboundMediaFromUrl.mockResolvedValueOnce({
+      buffer: Buffer.from("not audio"),
+      contentType: "application/pdf",
+      fileName: "report.pdf",
+      kind: "file",
+    });
+
+    await expect(
+      sendMessageMSTeams({
+        cfg: {} as OpenClawConfig,
+        to: "conversation:19:conversation@thread.tacv2",
+        text: "Wrong media",
+        mediaUrl: "file:///tmp/report.pdf",
+        audioAsVoice: true,
+      }),
+    ).rejects.toThrow("MS Teams voice messages require audio media");
+
+    expect(mockState.sendMSTeamsActivityWithReference).not.toHaveBeenCalled();
+    expect(mockState.uploadAndShareSharePoint).not.toHaveBeenCalled();
+  });
+
   it.each([
     { name: "trusted host reader", hostReader: true },
     { name: "reader-free gateway authority", hostReader: false },

--- a/extensions/msteams/src/send.ts
+++ b/extensions/msteams/src/send.ts
@@ -32,6 +32,7 @@ import {
   updateMSTeamsActivityWithReference,
 } from "./sdk-proactive.js";
 import { resolveMSTeamsSendContext, type MSTeamsProactiveContext } from "./send-context.js";
+import { buildMSTeamsVoiceActivity } from "./voice-message.js";
 
 type SendMSTeamsMessageParams = {
   /** Full config (for credentials) */
@@ -42,6 +43,8 @@ type SendMSTeamsMessageParams = {
   text: string;
   /** Optional media URL */
   mediaUrl?: string;
+  /** Send audio media as a Microsoft voice activity instead of a file attachment. */
+  audioAsVoice?: boolean;
   /** Optional filename override for uploaded media/files */
   filename?: string;
   mediaAccess?: OutboundMediaLoadOptions["mediaAccess"];
@@ -187,7 +190,17 @@ type SendMSTeamsCardResult = {
 export async function sendMessageMSTeams(
   params: SendMSTeamsMessageParams,
 ): Promise<SendMSTeamsMessageResult> {
-  const { cfg, to, text, mediaUrl, filename, mediaAccess, mediaLocalRoots, mediaReadFile } = params;
+  const {
+    cfg,
+    to,
+    text,
+    mediaUrl,
+    filename,
+    audioAsVoice,
+    mediaAccess,
+    mediaLocalRoots,
+    mediaReadFile,
+  } = params;
   const tableMode = resolveMarkdownTableMode({
     cfg,
     channel: "msteams",
@@ -225,6 +238,26 @@ export async function sendMessageMSTeams(
       isImage,
       conversationType,
     });
+
+    if (audioAsVoice) {
+      const contentType = media.contentType ?? "application/octet-stream";
+      const activity = buildMSTeamsVoiceActivity({
+        contentType,
+        contentUrl: `data:${contentType};base64,${media.buffer.toString("base64")}`,
+        transcription: messageText,
+      });
+      const messageId = await sendProactiveActivity({
+        ctx,
+        activity,
+        errorPrefix: "msteams voice message send",
+      });
+      log.info("sent voice activity", { conversationId, messageId });
+      return createMSTeamsSendResult({
+        messageId,
+        conversationId,
+        kind: "media",
+      });
+    }
 
     // Personal chats: base64 only works for images; use FileConsentCard for large files or non-images
     if (

--- a/extensions/msteams/src/voice-message.ts
+++ b/extensions/msteams/src/voice-message.ts
@@ -1,0 +1,21 @@
+const MSTEAMS_VOICE_ACTIVITY_TYPE = "application/vnd.microsoft.activity.voice+json";
+
+export function buildMSTeamsVoiceActivity(params: {
+  contentType: string;
+  contentUrl: string;
+  transcription?: string;
+}): Record<string, unknown> {
+  if (!params.contentType.toLowerCase().startsWith("audio/")) {
+    throw new Error("MS Teams voice messages require audio media.");
+  }
+  const transcription = params.transcription?.trim();
+  return {
+    type: "message",
+    valueType: MSTEAMS_VOICE_ACTIVITY_TYPE,
+    value: {
+      contentType: params.contentType,
+      contentUrl: params.contentUrl,
+      ...(transcription ? { transcription } : {}),
+    },
+  };
+}


### PR DESCRIPTION
Closes #132612

## What Problem This Solves

Fixes an issue where users requesting an audio response as a voice message in Microsoft Teams would receive an ordinary file attachment because the Teams outbound adapter discarded the voice-message intent.

## Why This Change Was Made

The Teams adapter now preserves `audioAsVoice` and emits the Microsoft Activity Protocol voice-message shape (`application/vnd.microsoft.activity.voice+json`) with audio content and optional transcription. Ordinary audio attachments retain the existing file-consent and SharePoint flows, and non-audio media is rejected when explicitly requested as voice.

## User Impact

Teams users can receive explicitly requested TTS/audio responses through the native voice-message activity path instead of always receiving an MP3 file card. Normal file delivery is unchanged.

## Evidence

- Red phase before implementation: the new outbound and send regression cases failed because `audioAsVoice` was dropped and media used the regular file path.
- Focused Teams suite: 42/42 tests passed.
- Follow-up focused run including both Full-Lane flakes: 44/44 tests passed.
- Extension typecheck and OXLint passed.
- Full Linux `pnpm build` passed from a clean checkout based on upstream main.
- `pnpm test:extension msteams`: 1,552 passed, 1 skipped; two unrelated timing/concurrency tests failed only in the 100-file parallel run and passed immediately when rerun together with the changed tests.
- The activity shape follows the Microsoft Activity Protocol voice-message contract, including support for a data URI in `contentUrl`.
- Live limitation: post-fix rendering has not yet been verified in the Teams client. The available server runs OpenClaw beta.3, while current contributor main expects a newer plugin SDK; the attempted test installation was rolled back before sending and the server was verified healthy afterward.

This PR is AI-assisted. I understand the implementation and independently inspected the diff, tests, build output, deployment boundary, and rollback state. Allow edits from maintainers is enabled on the fork PR.