### PR TITLE
fix(codex): reap orphaned app-server children after a hard-killed gateway

### DIFF
--- a/extensions/codex/index.test.ts
+++ b/extensions/codex/index.test.ts
@@ -2,7 +2,7 @@
 import fs from "node:fs";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { createTestPluginApi } from "openclaw/plugin-sdk/plugin-test-api";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import openAIPlugin from "../openai/index.js";
 import { createCodexAppServerAgentHarness } from "./harness.js";
 import plugin from "./index.js";
@@ -14,6 +14,7 @@ import {
   createCodexTestBindingStateStore,
   testCodexAppServerBindingStore,
 } from "./src/app-server/session-binding.test-helpers.js";
+import { resetCodexAppServerProcessRegistryForTests } from "./src/app-server/transport-process-registry.js";
 import { CODEX_SUPERVISION_COMPAT_TOOL_NAMES } from "./src/supervision-tools.js";
 
 const runCodexAppServerAttemptMock = vi.hoisted(() => vi.fn());
@@ -53,6 +54,8 @@ function mockCallArg(mock: { mock: { calls: unknown[][] } }, index = 0, argIndex
 }
 
 describe("codex plugin", () => {
+  afterEach(() => resetCodexAppServerProcessRegistryForTests());
+
   it("is opt-in and does not advertise a text provider", () => {
     const manifest = JSON.parse(
       fs.readFileSync(new URL("./openclaw.plugin.json", import.meta.url), "utf8"),
@@ -154,7 +157,7 @@ describe("codex plugin", () => {
       }),
     );
 
-    expect(registerService).toHaveBeenCalledTimes(2);
+    expect(registerService).toHaveBeenCalledTimes(3);
     expect(registerService.mock.calls.map(([service]) => service)).toContainEqual(
       expect.objectContaining({
         id: "codex-app-server-connection-health",
@@ -180,11 +183,15 @@ describe("codex plugin", () => {
         }),
       );
 
-      expect(registerService).toHaveBeenCalledOnce();
+      expect(registerService).toHaveBeenCalledTimes(2);
       expect(mockCallArg(registerService)).toMatchObject({
         id: "codex-desktop-generation",
         start: expect.any(Function),
         stop: expect.any(Function),
+      });
+      expect(mockCallArg(registerService, 1)).toMatchObject({
+        id: "codex-app-server-process-reaper",
+        start: expect.any(Function),
       });
     }
   });

--- a/extensions/codex/index.ts
+++ b/extensions/codex/index.ts
@@ -33,6 +33,13 @@ import {
   type StoredCodexAppServerBinding,
 } from "./src/app-server/session-binding-store.js";
 import { retireSharedCodexAppServerClientsBeforeDesktopGeneration } from "./src/app-server/shared-client.js";
+import {
+  CODEX_APP_SERVER_PROCESS_MAX_ENTRIES,
+  CODEX_APP_SERVER_PROCESS_NAMESPACE,
+  createCodexAppServerProcessReaperService,
+  setCodexAppServerProcessRegistryStore,
+  type StoredCodexAppServerProcess,
+} from "./src/app-server/transport-process-registry.js";
 import type { CodexPluginsConfigBlock } from "./src/command-plugins-management.js";
 import { createCodexCommand } from "./src/commands.js";
 import { codexConversationBindingRuntime } from "./src/conversation-binding.js";
@@ -110,6 +117,7 @@ export default definePluginEntry({
         onGenerationChange: retireSharedCodexAppServerClientsBeforeDesktopGeneration,
       }),
     );
+    api.registerService(createCodexAppServerProcessReaperService());
     if (appServerConfig?.transport === "websocket") {
       api.registerService(
         createCodexAppServerConnectionHealthService({
@@ -120,6 +128,16 @@ export default definePluginEntry({
     }
     let bindingStateStore: PluginStateSyncKeyedStore<StoredCodexAppServerBinding> | undefined;
     let managedThreadStateStore: PluginStateSyncKeyedStore<StoredCodexManagedThread> | undefined;
+    let processRegistryStore: PluginStateSyncKeyedStore<StoredCodexAppServerProcess> | undefined;
+    // The base registration runtime rejects state access; defer opening until spawn or reap.
+    const openProcessRegistryStore = () =>
+      (processRegistryStore ??= api.runtime.state.openSyncKeyedStore<StoredCodexAppServerProcess>({
+        namespace: CODEX_APP_SERVER_PROCESS_NAMESPACE,
+        maxEntries: CODEX_APP_SERVER_PROCESS_MAX_ENTRIES,
+        overflowPolicy: "evict-oldest",
+        // No TTL: expiring a row could leave a long-lived orphan permanently untracked.
+      }));
+    setCodexAppServerProcessRegistryStore(openProcessRegistryStore);
     const openBindingStateStore = () =>
       (bindingStateStore ??= api.runtime.state.openSyncKeyedStore<StoredCodexAppServerBinding>({
         namespace: CODEX_APP_SERVER_BINDING_NAMESPACE,

--- a/extensions/codex/src/app-server/client.ts
+++ b/extensions/codex/src/app-server/client.ts
@@ -25,6 +25,7 @@ import {
   type RpcResponse,
 } from "./protocol.js";
 import { CodexAppServerRpcError } from "./rpc-error.js";
+import { registerCodexAppServerProcessSpawn } from "./transport-process-registry.js";
 import { createStdioTransport } from "./transport-stdio.js";
 import { createWebSocketTransport } from "./transport-websocket.js";
 import {
@@ -286,7 +287,9 @@ export class CodexAppServerClient {
     if (startOptions.transport === "websocket" || startOptions.transport === "unix") {
       return new CodexAppServerClient(createWebSocketTransport(startOptions));
     }
-    return new CodexAppServerClient(createStdioTransport(startOptions));
+    const child = createStdioTransport(startOptions);
+    void registerCodexAppServerProcessSpawn(child);
+    return new CodexAppServerClient(child);
   }
 
   /** Builds a client around a fake transport for tests. */

--- a/extensions/codex/src/app-server/shared-client.test.ts
+++ b/extensions/codex/src/app-server/shared-client.test.ts
@@ -13,6 +13,7 @@ import { codexNativeSubagentMonitorRuntime } from "./native-subagent-monitor.js"
 import { withCodexAppServerJsonClient } from "./request.js";
 import { createClientHarness } from "./test-support.js";
 import { CodexAdoptedThreadActiveError } from "./thread-lifecycle-errors.js";
+import * as processRegistry from "./transport-process-registry.js";
 import { CODEX_APP_SERVER_VERSION, MIN_SUPPORTED_CODEX_APP_SERVER_VERSION } from "./version.js";
 
 const mocks = vi.hoisted(() => ({
@@ -332,6 +333,31 @@ describe("shared Codex app-server client", () => {
     );
     expect(harness.process.stdin.destroyed).toBe(true);
     startSpy.mockRestore();
+  });
+
+  it("waits for orphan reaping before starting a fresh shared client", async () => {
+    const harness = createClientHarness();
+    const reaping = createDeferred<void>();
+    const reap = vi
+      .spyOn(processRegistry, "reapOrphanedCodexAppServerProcesses")
+      .mockReturnValue(reaping.promise);
+    const start = vi.spyOn(CodexAppServerClient, "start").mockReturnValue(harness.client);
+    const acquiring = getSharedCodexAppServerClient({ timeoutMs: 1_000 });
+    void acquiring.catch(() => undefined);
+    try {
+      await vi.waitFor(() => expect(reap).toHaveBeenCalledOnce());
+      await new Promise<void>((resolve) => {
+        setImmediate(resolve);
+      });
+      expect(start).not.toHaveBeenCalled();
+      reaping.resolve();
+      await sendInitializeResult(harness, `openclaw/${CODEX_APP_SERVER_VERSION} (Linux; test)`);
+      await expect(acquiring).resolves.toBe(harness.client);
+      expect(start).toHaveBeenCalledOnce();
+    } finally {
+      reaping.resolve();
+      harness.client.close();
+    }
   });
 
   it("recognizes selection changes thrown by another bundle copy", () => {

--- a/extensions/codex/src/app-server/shared-client.ts
+++ b/extensions/codex/src/app-server/shared-client.ts
@@ -48,6 +48,10 @@ import {
 import { acquireCodexNativeConfigFence } from "./native-config-fence.js";
 import { CodexAdoptedThreadActiveError } from "./thread-lifecycle-errors.js";
 import { withTimeout } from "./timeout.js";
+import {
+  reapOrphanedCodexAppServerProcesses,
+  resetCodexAppServerProcessRegistryForTests,
+} from "./transport-process-registry.js";
 
 export type { CodexAppServerPreparedAuth } from "./auth-bridge.js";
 
@@ -1003,6 +1007,8 @@ async function startInitializedCodexAppServerClient(params: {
   onStartedClient?: (client: CodexAppServerClient) => void;
   onInitializedClient?: () => void;
 }): Promise<CodexAppServerClient> {
+  // A fresh child must not share rollout state with a pre-restart orphan.
+  await reapOrphanedCodexAppServerProcesses();
   const acquireStartedAt = Date.now();
   const timeoutMs = params.timeoutMs ?? 0;
   const startOptionsCandidates = resolveManagedFallbackStartOptions(params.startOptions);
@@ -1276,6 +1282,7 @@ export function resetSharedCodexAppServerClientForTests(): void {
   for (const client of isolatedClients) {
     client.close();
   }
+  resetCodexAppServerProcessRegistryForTests();
   notifyDesktopGenerationDrainChecks(state);
 }
 

--- a/extensions/codex/src/app-server/transport-process-containment.ts
+++ b/extensions/codex/src/app-server/transport-process-containment.ts
@@ -7,7 +7,7 @@ type ContainableTransport = {
   kill?: (signal?: NodeJS.Signals) => unknown;
 };
 
-type PosixProcess = {
+export type PosixProcess = {
   pid: number;
   ppid: number;
   pgid: number;
@@ -20,6 +20,21 @@ const MAX_CONTAINED_PROCESSES = 512;
 const MAX_PROCESS_CONTAINMENT_MS = 2_000;
 const MAX_PROCESS_QUIESCE_PASSES = 16;
 const PROCESS_INSPECTION_MAX_BYTES = 8 * 1024 * 1024;
+
+export function inspectCodexTransportProcessSnapshot(
+  deadline: number,
+): Promise<PosixProcess[] | undefined> {
+  return readProcessSnapshot(deadline);
+}
+
+// ps -p exits nonzero for missing PIDs: undefined means absent OR inspection failed.
+// Use only where both outcomes require the same fail-closed action.
+export function inspectCodexTransportProcess(
+  pid: number,
+  deadline: number,
+): Promise<PosixProcess | undefined> {
+  return readProcess(pid, deadline);
+}
 
 export async function terminateCodexAppServerDescendants(
   child: ContainableTransport,

--- a/extensions/codex/src/app-server/transport-process-containment.ts
+++ b/extensions/codex/src/app-server/transport-process-containment.ts
@@ -36,6 +36,50 @@ export function inspectCodexTransportProcess(
   return readProcess(pid, deadline);
 }
 
+// Full command line for one PID; undefined conflates absent and failed like
+// inspectCodexTransportProcess. lstart is only second-granular, so callers use
+// command equality as the extra discriminator before exercising kill authority.
+export async function inspectCodexTransportProcessCommand(
+  pid: number,
+  deadline: number,
+): Promise<string | undefined> {
+  const remainingMs = deadline - Date.now();
+  if (remainingMs <= 0) {
+    return undefined;
+  }
+  return await new Promise<string | undefined>((resolve) => {
+    let settled = false;
+    const settle = (command: string | undefined) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearTimeout(timer);
+      resolve(command);
+    };
+    const inspector = execFile(
+      "ps",
+      ["-o", "command=", "-p", String(pid)],
+      { encoding: "utf8", maxBuffer: PROCESS_INSPECTION_MAX_BYTES },
+      (error, stdout) => {
+        const command = stdout.split("\n")[0]?.trim();
+        settle(error || !command ? undefined : command);
+      },
+    );
+    const timer = setTimeout(
+      () => {
+        settle(undefined);
+        inspector.stdout?.destroy();
+        inspector.stderr?.destroy();
+        inspector.kill("SIGKILL");
+        inspector.unref();
+      },
+      Math.max(1, remainingMs),
+    );
+    timer.unref?.();
+  });
+}
+
 export async function terminateCodexAppServerDescendants(
   child: ContainableTransport,
 ): Promise<(() => void) | undefined> {

--- a/extensions/codex/src/app-server/transport-process-registry.process.test.ts
+++ b/extensions/codex/src/app-server/transport-process-registry.process.test.ts
@@ -3,6 +3,7 @@ import { once } from "node:events";
 import { describe, expect, it } from "vitest";
 import {
   inspectCodexTransportProcess,
+  inspectCodexTransportProcessCommand,
   inspectCodexTransportProcessSnapshot,
   type PosixProcess,
 } from "./transport-process-containment.js";
@@ -38,11 +39,12 @@ describe.skipIf(process.platform === "win32")("Codex app-server orphan process r
         throw new Error("process fixtures did not acquire PIDs");
       }
       const deadline = Date.now() + 5_000;
-      const [orphanIdentity, ownerIdentity] = await Promise.all([
+      const [orphanIdentity, orphanCommand, ownerIdentity] = await Promise.all([
         inspectCodexTransportProcess(orphanPid, deadline),
+        inspectCodexTransportProcessCommand(orphanPid, deadline),
         inspectCodexTransportProcess(ownerPid, deadline),
       ]);
-      if (!orphanIdentity || !ownerIdentity) {
+      if (!orphanIdentity || !orphanCommand || !ownerIdentity) {
         throw new Error("could not inspect process fixture identities");
       }
       expect(orphanIdentity.pgid).toBe(orphanPid);
@@ -50,6 +52,7 @@ describe.skipIf(process.platform === "win32")("Codex app-server orphan process r
       store.register(key, {
         pid: orphanPid,
         startedAt: orphanIdentity.startedAt,
+        command: orphanCommand,
         ownerPid,
         ownerStartedAt: ownerIdentity.startedAt,
         spawnedAtMs: Date.now(),
@@ -140,13 +143,17 @@ describe.skipIf(process.platform === "win32")("Codex app-server orphan process r
           setTimeout(resolve, 100);
         });
       }
-      const orphanIdentity = await inspectCodexTransportProcess(orphanPid, Date.now() + 5_000);
-      if (!zombieRow || !orphanIdentity) {
+      const [orphanIdentity, orphanCommand] = await Promise.all([
+        inspectCodexTransportProcess(orphanPid, Date.now() + 5_000),
+        inspectCodexTransportProcessCommand(orphanPid, Date.now() + 5_000),
+      ]);
+      if (!zombieRow || !orphanIdentity || !orphanCommand) {
         throw new Error("could not inspect zombie or orphan fixture identities");
       }
       store.register(String(orphanPid), {
         pid: orphanPid,
         startedAt: orphanIdentity.startedAt,
+        command: orphanCommand,
         ownerPid: zombiePid,
         ownerStartedAt: zombieRow.startedAt,
         spawnedAtMs: Date.now(),

--- a/extensions/codex/src/app-server/transport-process-registry.process.test.ts
+++ b/extensions/codex/src/app-server/transport-process-registry.process.test.ts
@@ -1,0 +1,90 @@
+import { spawn } from "node:child_process";
+import { once } from "node:events";
+import { describe, expect, it } from "vitest";
+import {
+  inspectCodexTransportProcess,
+  inspectCodexTransportProcessSnapshot,
+} from "./transport-process-containment.js";
+import {
+  reapOrphanedCodexAppServerProcesses,
+  resetCodexAppServerProcessRegistryForTests,
+  setCodexAppServerProcessRegistryStore,
+} from "./transport-process-registry.js";
+import { createCodexProcessRegistryTestStore } from "./transport-process-registry.test-support.js";
+
+function spawnSleepFixture(detached: boolean) {
+  const child = spawn("sleep", ["60"], { detached, stdio: "ignore" });
+  const exited = new Promise<void>((resolve) => {
+    child.once("exit", () => resolve());
+    child.once("error", () => resolve());
+  });
+  return { child, exited };
+}
+
+describe.skipIf(process.platform === "win32")("Codex app-server orphan process reaper", () => {
+  it("preserves a live owner's child and kills its detached group after the owner exits", async () => {
+    const store = createCodexProcessRegistryTestStore();
+    const orphan = spawnSleepFixture(true);
+    const owner = spawnSleepFixture(false);
+    resetCodexAppServerProcessRegistryForTests();
+    setCodexAppServerProcessRegistryStore(() => store);
+
+    try {
+      await Promise.all([once(orphan.child, "spawn"), once(owner.child, "spawn")]);
+      const orphanPid = orphan.child.pid;
+      const ownerPid = owner.child.pid;
+      if (!orphanPid || !ownerPid) {
+        throw new Error("process fixtures did not acquire PIDs");
+      }
+      const deadline = Date.now() + 5_000;
+      const [orphanIdentity, ownerIdentity] = await Promise.all([
+        inspectCodexTransportProcess(orphanPid, deadline),
+        inspectCodexTransportProcess(ownerPid, deadline),
+      ]);
+      if (!orphanIdentity || !ownerIdentity) {
+        throw new Error("could not inspect process fixture identities");
+      }
+      expect(orphanIdentity.pgid).toBe(orphanPid);
+      const key = String(orphanPid);
+      store.register(key, {
+        pid: orphanPid,
+        startedAt: orphanIdentity.startedAt,
+        ownerPid,
+        ownerStartedAt: ownerIdentity.startedAt,
+        spawnedAtMs: Date.now(),
+      });
+
+      await reapOrphanedCodexAppServerProcesses();
+
+      expect(process.kill(orphanPid, 0)).toBe(true);
+      expect(store.lookup(key)).toBeDefined();
+
+      owner.child.kill("SIGKILL");
+      await owner.exited;
+      expect(process.kill(orphanPid, 0)).toBe(true);
+      resetCodexAppServerProcessRegistryForTests();
+      setCodexAppServerProcessRegistryStore(() => store);
+
+      await reapOrphanedCodexAppServerProcesses();
+      await expect.poll(() => orphan.child.signalCode, { timeout: 5_000 }).toBe("SIGKILL");
+      await orphan.exited;
+
+      const snapshot = await inspectCodexTransportProcessSnapshot(Date.now() + 5_000);
+      expect(snapshot).toBeDefined();
+      expect(snapshot?.some((row) => row.pid === orphanPid)).toBe(false);
+      expect(() => process.kill(orphanPid, 0)).toThrowError(
+        expect.objectContaining({ code: "ESRCH" }),
+      );
+      expect(store.entries()).toEqual([]);
+    } finally {
+      for (const fixture of [owner, orphan]) {
+        if (fixture.child.exitCode === null && fixture.child.signalCode === null) {
+          fixture.child.kill("SIGKILL");
+        }
+      }
+      await Promise.all([owner.exited, orphan.exited]);
+      store.clear();
+      resetCodexAppServerProcessRegistryForTests();
+    }
+  }, 20_000);
+});

--- a/extensions/codex/src/app-server/transport-process-registry.process.test.ts
+++ b/extensions/codex/src/app-server/transport-process-registry.process.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from "vitest";
 import {
   inspectCodexTransportProcess,
   inspectCodexTransportProcessSnapshot,
+  type PosixProcess,
 } from "./transport-process-containment.js";
 import {
   reapOrphanedCodexAppServerProcesses,
@@ -83,6 +84,86 @@ describe.skipIf(process.platform === "win32")("Codex app-server orphan process r
         }
       }
       await Promise.all([owner.exited, orphan.exited]);
+      store.clear();
+      resetCodexAppServerProcessRegistryForTests();
+    }
+  }, 20_000);
+
+  it("treats an unreaped zombie owner as dead and reaps its orphan", async () => {
+    const store = createCodexProcessRegistryTestStore();
+    const orphan = spawnSleepFixture(true);
+    // The inner sleep exits after 1s; its parent becomes the exec'd sleep binary,
+    // which never calls wait, so the inner pid stays a real Z-state process.
+    const holder = spawn("sh", ["-c", 'sh -c "exec sleep 1" & echo $!; exec sleep 60'], {
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+    const holderExited = new Promise<void>((resolve) => {
+      holder.once("exit", () => resolve());
+      holder.once("error", () => resolve());
+    });
+    resetCodexAppServerProcessRegistryForTests();
+    setCodexAppServerProcessRegistryStore(() => store);
+
+    try {
+      const zombiePid = await new Promise<number>((resolve, reject) => {
+        let buffered = "";
+        holder.stdout.on("data", (chunk: Buffer) => {
+          buffered += chunk.toString("utf8");
+          const line = buffered.split("\n")[0]?.trim();
+          if (line) {
+            resolve(Number(line));
+          }
+        });
+        holder.once("error", reject);
+        holder.once("exit", () => reject(new Error("holder exited before printing the pid")));
+      });
+      expect(Number.isSafeInteger(zombiePid)).toBe(true);
+      // The orphan's "spawn" event has usually fired while reading holder stdout;
+      // pid is assigned synchronously on success, so only wait when it is absent.
+      if (!orphan.child.pid) {
+        await once(orphan.child, "spawn");
+      }
+      const orphanPid = orphan.child.pid;
+      if (!orphanPid) {
+        throw new Error("orphan fixture did not acquire a PID");
+      }
+      let zombieRow: PosixProcess | undefined;
+      const zombieDeadline = Date.now() + 10_000;
+      while (Date.now() < zombieDeadline && !zombieRow) {
+        const snapshot = await inspectCodexTransportProcessSnapshot(Date.now() + 5_000);
+        const row = snapshot?.find((candidate) => candidate.pid === zombiePid);
+        if (row?.state.startsWith("Z")) {
+          zombieRow = row;
+          break;
+        }
+        await new Promise((resolve) => {
+          setTimeout(resolve, 100);
+        });
+      }
+      const orphanIdentity = await inspectCodexTransportProcess(orphanPid, Date.now() + 5_000);
+      if (!zombieRow || !orphanIdentity) {
+        throw new Error("could not inspect zombie or orphan fixture identities");
+      }
+      store.register(String(orphanPid), {
+        pid: orphanPid,
+        startedAt: orphanIdentity.startedAt,
+        ownerPid: zombiePid,
+        ownerStartedAt: zombieRow.startedAt,
+        spawnedAtMs: Date.now(),
+      });
+
+      await reapOrphanedCodexAppServerProcesses();
+      await expect.poll(() => orphan.child.signalCode, { timeout: 5_000 }).toBe("SIGKILL");
+      await orphan.exited;
+      expect(store.entries()).toEqual([]);
+    } finally {
+      if (holder.exitCode === null && holder.signalCode === null) {
+        holder.kill("SIGKILL");
+      }
+      if (orphan.child.exitCode === null && orphan.child.signalCode === null) {
+        orphan.child.kill("SIGKILL");
+      }
+      await Promise.all([holderExited, orphan.exited]);
       store.clear();
       resetCodexAppServerProcessRegistryForTests();
     }

--- a/extensions/codex/src/app-server/transport-process-registry.test-support.ts
+++ b/extensions/codex/src/app-server/transport-process-registry.test-support.ts
@@ -1,0 +1,41 @@
+import type { PluginStateSyncKeyedStore } from "openclaw/plugin-sdk/plugin-state-runtime";
+import type { StoredCodexAppServerProcess } from "./transport-process-registry.js";
+
+export function createCodexProcessRegistryTestStore(): Required<
+  PluginStateSyncKeyedStore<StoredCodexAppServerProcess>
+> {
+  const values = new Map<string, StoredCodexAppServerProcess>();
+  return {
+    register(key, value) {
+      values.set(key, value);
+    },
+    registerIfAbsent(key, value) {
+      if (values.has(key)) {
+        return false;
+      }
+      values.set(key, value);
+      return true;
+    },
+    update(key, updateValue) {
+      const next = updateValue(values.get(key));
+      if (next === undefined) {
+        return false;
+      }
+      values.set(key, next);
+      return true;
+    },
+    lookup: (key) => values.get(key),
+    consume(key) {
+      const value = values.get(key);
+      values.delete(key);
+      return value;
+    },
+    delete: (key) => values.delete(key),
+    deleteIf: (key, predicate) => {
+      const value = values.get(key);
+      return value !== undefined && predicate(value) && values.delete(key);
+    },
+    entries: () => [...values].map(([key, value]) => ({ key, value, createdAt: 0 })),
+    clear: () => values.clear(),
+  };
+}

--- a/extensions/codex/src/app-server/transport-process-registry.test.ts
+++ b/extensions/codex/src/app-server/transport-process-registry.test.ts
@@ -15,6 +15,7 @@ import { createCodexProcessRegistryTestStore } from "./transport-process-registr
 
 const STARTED_AT = "Sat Aug 29 10:00:00 2026";
 const OWNER_STARTED_AT = "Sat Aug 29 09:00:00 2026";
+const CHILD_COMMAND = "codex app-server --listen stdio://";
 
 class SpawnedChild extends EventEmitter {
   exitCode: number | null = null;
@@ -42,6 +43,7 @@ function createHarness() {
   const runtime = {
     platform: "linux" as NodeJS.Platform,
     inspectProcess,
+    inspectCommand: vi.fn(async (): Promise<string | undefined> => CHILD_COMMAND),
     inspectSnapshot: vi.fn(async (): Promise<PosixProcess[] | undefined> => [self, child]),
     kill: vi.fn(() => true),
     now: vi.fn(() => 1_000),
@@ -49,6 +51,7 @@ function createHarness() {
   const row: StoredCodexAppServerProcess = {
     pid: child.pid,
     startedAt: child.startedAt,
+    command: CHILD_COMMAND,
     ownerPid: process.pid + 1,
     ownerStartedAt: OWNER_STARTED_AT,
     spawnedAtMs: 100,
@@ -82,6 +85,7 @@ describe("Codex app-server process registry", () => {
     expect(store.lookup("101")).toEqual({
       pid: 101,
       startedAt: STARTED_AT,
+      command: CHILD_COMMAND,
       ownerPid: process.pid,
       ownerStartedAt: OWNER_STARTED_AT,
       spawnedAtMs: 1_000,
@@ -104,14 +108,18 @@ describe("Codex app-server process registry", () => {
     }
   });
 
-  it.each(["child", "owner"] as const)(
+  it.each(["child", "owner", "command"] as const)(
     "skips registration when the %s identity is unavailable",
     async (missing) => {
       const { store, runtime } = createHarness();
       const child = new SpawnedChild();
-      runtime.inspectProcess.mockImplementation(async (pid) =>
-        (missing === "owner") === (pid === process.pid) ? undefined : processRow(pid),
-      );
+      if (missing === "command") {
+        runtime.inspectCommand.mockResolvedValue(undefined);
+      } else {
+        runtime.inspectProcess.mockImplementation(async (pid) =>
+          (missing === "owner") === (pid === process.pid) ? undefined : processRow(pid),
+        );
+      }
       await registerCodexAppServerProcessSpawn(child, runtime);
       expect(store.entries()).toEqual([]);
       expect(embeddedAgentLog.warn).toHaveBeenCalledWith(
@@ -194,6 +202,25 @@ describe("Codex app-server process registry", () => {
       ownerPid: row.ownerPid,
       spawnedAtMs: row.spawnedAtMs,
     });
+  });
+
+  it("never kills a same-second replacement process running a different command", async () => {
+    const { store, runtime, seed } = createHarness();
+    seed();
+    // pid + lstart collide within lstart's 1s granularity; only the command differs.
+    runtime.inspectCommand.mockResolvedValue("/usr/bin/innocent-replacement");
+    await reapOrphanedCodexAppServerProcesses(runtime);
+    expect(runtime.kill).not.toHaveBeenCalled();
+    expect(store.entries()).toEqual([]);
+  });
+
+  it("keeps the row without killing when the command read fails", async () => {
+    const { store, runtime, seed, row } = createHarness();
+    seed();
+    runtime.inspectCommand.mockResolvedValue(undefined);
+    await reapOrphanedCodexAppServerProcesses(runtime);
+    expect(runtime.kill).not.toHaveBeenCalled();
+    expect(store.lookup("101")).toEqual(row);
   });
 
   it("reaps rows inherited from a pid-reusing predecessor gateway", async () => {

--- a/extensions/codex/src/app-server/transport-process-registry.test.ts
+++ b/extensions/codex/src/app-server/transport-process-registry.test.ts
@@ -166,15 +166,20 @@ describe("Codex app-server process registry", () => {
   });
 
   it.each([
-    { name: "dead owner, group leader", pgid: 101, ownerReused: false, target: -101 },
-    { name: "reused owner PID", pgid: 101, ownerReused: true, target: -101 },
-    { name: "non-leader child", pgid: 99, ownerReused: false, target: 101 },
-  ])("reaps an identity-confirmed orphan: $name", async ({ pgid, ownerReused, target }) => {
+    { name: "dead owner, group leader", pgid: 101, ownerRow: "absent", target: -101 },
+    { name: "reused owner PID", pgid: 101, ownerRow: "reused", target: -101 },
+    { name: "zombie owner", pgid: 101, ownerRow: "zombie", target: -101 },
+    { name: "non-leader child", pgid: 99, ownerRow: "absent", target: 101 },
+  ] as const)("reaps an identity-confirmed orphan: $name", async ({ pgid, ownerRow, target }) => {
     const { store, runtime, seed, child } = createHarness();
     const row = seed();
     runtime.inspectSnapshot.mockResolvedValue([
       child,
-      ...(ownerReused ? [processRow(row.ownerPid, "new owner")] : []),
+      // A zombie keeps its exact pid + lstart in the snapshot; only the state marks it dead.
+      ...(ownerRow === "reused" ? [processRow(row.ownerPid, "new owner")] : []),
+      ...(ownerRow === "zombie"
+        ? [{ ...processRow(row.ownerPid, row.ownerStartedAt), state: "Z+" }]
+        : []),
     ]);
     runtime.inspectProcess.mockResolvedValue({ ...child, pgid });
     await reapOrphanedCodexAppServerProcesses(runtime);

--- a/extensions/codex/src/app-server/transport-process-registry.test.ts
+++ b/extensions/codex/src/app-server/transport-process-registry.test.ts
@@ -1,0 +1,362 @@
+import { EventEmitter } from "node:events";
+import { embeddedAgentLog } from "openclaw/plugin-sdk/agent-harness-runtime";
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { PosixProcess } from "./transport-process-containment.js";
+import {
+  createCodexAppServerProcessReaperService,
+  reapOrphanedCodexAppServerProcesses,
+  registerCodexAppServerProcessSpawn,
+  resetCodexAppServerProcessRegistryForTests,
+  setCodexAppServerProcessRegistryStore,
+  type StoredCodexAppServerProcess,
+} from "./transport-process-registry.js";
+import { createCodexProcessRegistryTestStore } from "./transport-process-registry.test-support.js";
+
+const STARTED_AT = "Sat Aug 29 10:00:00 2026";
+const OWNER_STARTED_AT = "Sat Aug 29 09:00:00 2026";
+
+class SpawnedChild extends EventEmitter {
+  exitCode: number | null = null;
+  signalCode: string | null = null;
+
+  constructor(readonly pid = 101) {
+    super();
+  }
+}
+
+function processRow(pid: number, startedAt = STARTED_AT, pgid = pid): PosixProcess {
+  return { pid, ppid: 1, pgid, state: "S", startedAt };
+}
+
+function createHarness() {
+  const store = createCodexProcessRegistryTestStore();
+  const owner = processRow(process.pid, OWNER_STARTED_AT);
+  const child = processRow(101);
+  const inspectProcess = vi.fn(
+    async (pid: number): Promise<PosixProcess | undefined> => (pid === process.pid ? owner : child),
+  );
+  const runtime = {
+    platform: "linux" as NodeJS.Platform,
+    inspectProcess,
+    inspectSnapshot: vi.fn(async (): Promise<PosixProcess[] | undefined> => [child]),
+    kill: vi.fn(() => true),
+    now: vi.fn(() => 1_000),
+  };
+  const row: StoredCodexAppServerProcess = {
+    pid: child.pid,
+    startedAt: child.startedAt,
+    ownerPid: process.pid + 1,
+    ownerStartedAt: OWNER_STARTED_AT,
+    spawnedAtMs: 100,
+  };
+  const seed = (overrides: Partial<StoredCodexAppServerProcess> = {}) => {
+    const value = { ...row, ...overrides };
+    store.register(String(value.pid), value);
+    return value;
+  };
+  setCodexAppServerProcessRegistryStore(() => store);
+  return { store, runtime, row, seed, child };
+}
+
+describe("Codex app-server process registry", () => {
+  beforeEach(() => {
+    resetCodexAppServerProcessRegistryForTests();
+    vi.spyOn(embeddedAgentLog, "warn").mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    resetCodexAppServerProcessRegistryForTests();
+    vi.restoreAllMocks();
+  });
+
+  it("records exact spawn identities and removes the row on exit", async () => {
+    const { store, runtime } = createHarness();
+    const child = new SpawnedChild();
+    const registering = registerCodexAppServerProcessSpawn(child, runtime);
+    expect(child.listenerCount("exit")).toBe(1);
+    await registering;
+    expect(store.lookup("101")).toEqual({
+      pid: 101,
+      startedAt: STARTED_AT,
+      ownerPid: process.pid,
+      ownerStartedAt: OWNER_STARTED_AT,
+      spawnedAtMs: 1_000,
+    });
+    child.exitCode = 0;
+    child.emit("exit");
+    expect(store.entries()).toEqual([]);
+  });
+
+  it("shares one owner identity read across concurrent registrations", async () => {
+    const { runtime } = createHarness();
+    const children = [new SpawnedChild(101), new SpawnedChild(102)];
+    runtime.inspectProcess.mockImplementation(async (pid) => processRow(pid));
+    await Promise.all(children.map((child) => registerCodexAppServerProcessSpawn(child, runtime)));
+    expect(runtime.inspectProcess.mock.calls.filter(([pid]) => pid === process.pid)).toHaveLength(
+      1,
+    );
+    for (const child of children) {
+      child.emit("exit");
+    }
+  });
+
+  it.each(["child", "owner"] as const)(
+    "skips registration when the %s identity is unavailable",
+    async (missing) => {
+      const { store, runtime } = createHarness();
+      const child = new SpawnedChild();
+      runtime.inspectProcess.mockImplementation(async (pid) =>
+        (missing === "owner") === (pid === process.pid) ? undefined : processRow(pid),
+      );
+      await registerCodexAppServerProcessSpawn(child, runtime);
+      expect(store.entries()).toEqual([]);
+      expect(embeddedAgentLog.warn).toHaveBeenCalledWith(
+        expect.stringContaining("identity unavailable"),
+        { pid: child.pid },
+      );
+      child.emit("exit");
+    },
+  );
+
+  it("retries the owner identity read after a failed read", async () => {
+    const { store, runtime } = createHarness();
+    runtime.inspectProcess.mockImplementation(async (pid) =>
+      pid === process.pid ? undefined : processRow(pid),
+    );
+    await registerCodexAppServerProcessSpawn(new SpawnedChild(101), runtime);
+    expect(store.entries()).toEqual([]);
+    runtime.inspectProcess.mockImplementation(async (pid) => processRow(pid));
+    const child = new SpawnedChild(102);
+    await registerCodexAppServerProcessSpawn(child, runtime);
+    expect(store.lookup("102")).toBeDefined();
+    child.emit("exit");
+  });
+
+  it.each(["exitCode", "signalCode"] as const)(
+    "does not resurrect a row after early %s",
+    async (field) => {
+      const { store, runtime } = createHarness();
+      const pending = createDeferred<PosixProcess>();
+      runtime.inspectProcess.mockReturnValue(pending.promise);
+      const child = new SpawnedChild();
+      const registering = registerCodexAppServerProcessSpawn(child, runtime);
+      if (field === "exitCode") {
+        child.exitCode = 0;
+      } else {
+        child.signalCode = "SIGKILL";
+      }
+      child.emit("exit");
+      pending.resolve(processRow(child.pid));
+      await registering;
+      expect(store.entries()).toEqual([]);
+    },
+  );
+
+  it.each(["own", "foreign"] as const)("preserves children with a live %s owner", async (kind) => {
+    const { store, runtime, seed, child } = createHarness();
+    const row = seed(kind === "own" ? { ownerPid: process.pid } : {});
+    runtime.inspectSnapshot.mockResolvedValue(
+      kind === "own" ? [] : [child, processRow(row.ownerPid, row.ownerStartedAt)],
+    );
+    await reapOrphanedCodexAppServerProcesses(runtime);
+    expect(store.lookup("101")).toEqual(row);
+    expect(runtime.inspectProcess).not.toHaveBeenCalled();
+    expect(runtime.kill).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    { name: "dead owner, group leader", pgid: 101, ownerReused: false, target: -101 },
+    { name: "reused owner PID", pgid: 101, ownerReused: true, target: -101 },
+    { name: "non-leader child", pgid: 99, ownerReused: false, target: 101 },
+  ])("reaps an identity-confirmed orphan: $name", async ({ pgid, ownerReused, target }) => {
+    const { store, runtime, seed, child } = createHarness();
+    const row = seed();
+    runtime.inspectSnapshot.mockResolvedValue([
+      child,
+      ...(ownerReused ? [processRow(row.ownerPid, "new owner")] : []),
+    ]);
+    runtime.inspectProcess.mockResolvedValue({ ...child, pgid });
+    await reapOrphanedCodexAppServerProcesses(runtime);
+    expect(runtime.kill).toHaveBeenCalledExactlyOnceWith(target, "SIGKILL");
+    expect(store.entries()).toEqual([]);
+    expect(embeddedAgentLog.warn).toHaveBeenCalledWith("reaped orphaned codex app-server", {
+      pid: row.pid,
+      ownerPid: row.ownerPid,
+      spawnedAtMs: row.spawnedAtMs,
+    });
+  });
+
+  it.each(["gone", "reused"] as const)(
+    "deletes a child proven %s by the snapshot without signaling",
+    async (kind) => {
+      const { store, runtime, seed, child } = createHarness();
+      seed();
+      runtime.inspectSnapshot.mockResolvedValue(
+        kind === "gone" ? [] : [{ ...child, startedAt: "new child" }],
+      );
+      await reapOrphanedCodexAppServerProcesses(runtime);
+      expect(store.entries()).toEqual([]);
+      expect(runtime.inspectProcess).not.toHaveBeenCalled();
+      expect(runtime.kill).not.toHaveBeenCalled();
+    },
+  );
+
+  it("keeps a row re-registered with a new identity after the snapshot was judged", async () => {
+    const { store, runtime, seed } = createHarness();
+    const stale = seed();
+    const replacement = { ...stale, startedAt: "new child", ownerPid: process.pid + 2 };
+    // The reaper judged the stale row against its snapshot; a live owner re-registered
+    // the same pid meanwhile. Only the judged row may be deleted.
+    vi.spyOn(store, "entries").mockReturnValue([{ key: "101", value: stale, createdAt: 0 }]);
+    store.register("101", replacement);
+    runtime.inspectSnapshot.mockResolvedValue([]);
+    await reapOrphanedCodexAppServerProcesses(runtime);
+    expect(store.lookup("101")).toEqual(replacement);
+    expect(runtime.kill).not.toHaveBeenCalled();
+  });
+
+  it("keeps all rows and logs once when the snapshot fails", async () => {
+    const { store, runtime, seed } = createHarness();
+    seed();
+    seed({ pid: 102 });
+    const before = store.entries();
+    runtime.inspectSnapshot.mockResolvedValue(undefined);
+    await reapOrphanedCodexAppServerProcesses(runtime);
+    expect(store.entries()).toEqual(before);
+    expect(runtime.kill).not.toHaveBeenCalled();
+    expect(runtime.inspectProcess).not.toHaveBeenCalled();
+    expect(embeddedAgentLog.warn).toHaveBeenCalledOnce();
+  });
+
+  it.each(["unavailable", "pid", "startedAt"] as const)(
+    "retains the row when final confirmation differs: %s",
+    async (kind) => {
+      const { store, runtime, seed, child } = createHarness();
+      const row = seed();
+      runtime.inspectProcess.mockResolvedValue(
+        kind === "unavailable"
+          ? undefined
+          : { ...child, [kind]: kind === "pid" ? 102 : "new child" },
+      );
+      await reapOrphanedCodexAppServerProcesses(runtime);
+      expect(store.lookup("101")).toEqual(row);
+      expect(runtime.kill).not.toHaveBeenCalled();
+    },
+  );
+
+  it("returns the same promise without rescanning, including after settlement", async () => {
+    const { runtime, seed } = createHarness();
+    seed();
+    const pending = createDeferred<PosixProcess[]>();
+    runtime.inspectSnapshot.mockReturnValue(pending.promise);
+    const first = reapOrphanedCodexAppServerProcesses(runtime);
+    expect(reapOrphanedCodexAppServerProcesses(runtime)).toBe(first);
+    pending.resolve([]);
+    await first;
+    expect(reapOrphanedCodexAppServerProcesses(runtime)).toBe(first);
+    expect(runtime.inspectSnapshot).toHaveBeenCalledOnce();
+  });
+
+  it("starts the service without waiting for an in-flight reap", async () => {
+    const { runtime, seed } = createHarness();
+    seed();
+    const pending = createDeferred<PosixProcess[]>();
+    runtime.inspectSnapshot.mockReturnValue(pending.promise);
+    const reaping = reapOrphanedCodexAppServerProcesses(runtime);
+    const service = createCodexAppServerProcessReaperService();
+    expect(service.start({} as never)).toBeUndefined();
+    expect(reapOrphanedCodexAppServerProcesses(runtime)).toBe(reaping);
+    pending.resolve([]);
+    await reaping;
+  });
+
+  it.each(["snapshot", "confirmation", "next row"] as const)(
+    "stops at the deadline after %s",
+    async (boundary) => {
+      const { store, runtime, seed, child } = createHarness();
+      seed();
+      seed({ pid: 102 });
+      if (boundary === "snapshot") {
+        runtime.inspectSnapshot.mockImplementation(async () => {
+          runtime.now.mockReturnValue(6_000);
+          return [child];
+        });
+      } else if (boundary === "confirmation") {
+        runtime.inspectProcess.mockImplementation(async () => {
+          runtime.now.mockReturnValue(6_000);
+          return child;
+        });
+      } else {
+        runtime.kill.mockImplementation(() => {
+          runtime.now.mockReturnValue(6_000);
+          return true;
+        });
+      }
+      await reapOrphanedCodexAppServerProcesses(runtime);
+      expect(store.lookup("102")).toBeDefined();
+      expect(runtime.kill).toHaveBeenCalledTimes(boundary === "next row" ? 1 : 0);
+    },
+  );
+
+  it("removes malformed persisted rows without signaling", async () => {
+    const { store, runtime } = createHarness();
+    vi.spyOn(store, "entries").mockReturnValue([
+      { key: "bad", value: { pid: 101 } as StoredCodexAppServerProcess, createdAt: 0 },
+    ]);
+    const remove = vi.spyOn(store, "delete");
+    await reapOrphanedCodexAppServerProcesses(runtime);
+    expect(remove).toHaveBeenCalledExactlyOnceWith("bad");
+    expect(runtime.kill).not.toHaveBeenCalled();
+  });
+
+  it("deletes an identity-confirmed row even when signaling returns false", async () => {
+    const { store, runtime, seed } = createHarness();
+    seed();
+    runtime.kill.mockReturnValue(false);
+    await reapOrphanedCodexAppServerProcesses(runtime);
+    expect(runtime.kill).toHaveBeenCalledExactlyOnceWith(-101, "SIGKILL");
+    expect(store.entries()).toEqual([]);
+  });
+
+  it.each(["open", "register", "entries", "delete", "deleteIf"] as const)(
+    "contains %s store failures",
+    async (operation) => {
+      const { store, runtime, seed } = createHarness();
+      seed();
+      const fail = () => {
+        throw new Error("store unavailable");
+      };
+      if (operation === "open") {
+        setCodexAppServerProcessRegistryStore(fail);
+      } else {
+        vi.spyOn(store, operation).mockImplementation(fail);
+      }
+      // A distinct pid keeps the seeded foreign row alive so the reap reaches deleteIf.
+      const child = new SpawnedChild(operation === "deleteIf" ? 102 : 101);
+      await expect(registerCodexAppServerProcessSpawn(child, runtime)).resolves.toBeUndefined();
+      expect(() => child.emit("exit")).not.toThrow();
+      await expect(reapOrphanedCodexAppServerProcesses(runtime)).resolves.toBeUndefined();
+      expect(embeddedAgentLog.warn).toHaveBeenCalled();
+    },
+  );
+
+  it.each(["win32", "no store"] as const)("does nothing with %s", async (mode) => {
+    const { store, runtime, seed } = createHarness();
+    seed();
+    const before = store.entries();
+    if (mode === "win32") {
+      runtime.platform = "win32";
+    } else {
+      resetCodexAppServerProcessRegistryForTests();
+    }
+    const child = new SpawnedChild();
+    await registerCodexAppServerProcessSpawn(child, runtime);
+    await reapOrphanedCodexAppServerProcesses(runtime);
+    expect(child.listenerCount("exit")).toBe(0);
+    expect(store.entries()).toEqual(before);
+    expect(runtime.inspectProcess).not.toHaveBeenCalled();
+    expect(runtime.inspectSnapshot).not.toHaveBeenCalled();
+    expect(runtime.kill).not.toHaveBeenCalled();
+  });
+});

--- a/extensions/codex/src/app-server/transport-process-registry.test.ts
+++ b/extensions/codex/src/app-server/transport-process-registry.test.ts
@@ -32,6 +32,9 @@ function processRow(pid: number, startedAt = STARTED_AT, pgid = pid): PosixProce
 function createHarness() {
   const store = createCodexProcessRegistryTestStore();
   const owner = processRow(process.pid, OWNER_STARTED_AT);
+  // The reaper refuses snapshots that cannot see the observer, so every
+  // snapshot mock includes this process's own row.
+  const self = owner;
   const child = processRow(101);
   const inspectProcess = vi.fn(
     async (pid: number): Promise<PosixProcess | undefined> => (pid === process.pid ? owner : child),
@@ -39,7 +42,7 @@ function createHarness() {
   const runtime = {
     platform: "linux" as NodeJS.Platform,
     inspectProcess,
-    inspectSnapshot: vi.fn(async (): Promise<PosixProcess[] | undefined> => [child]),
+    inspectSnapshot: vi.fn(async (): Promise<PosixProcess[] | undefined> => [self, child]),
     kill: vi.fn(() => true),
     now: vi.fn(() => 1_000),
   };
@@ -56,7 +59,7 @@ function createHarness() {
     return value;
   };
   setCodexAppServerProcessRegistryStore(() => store);
-  return { store, runtime, row, seed, child };
+  return { store, runtime, row, seed, child, self };
 }
 
 describe("Codex app-server process registry", () => {
@@ -154,10 +157,10 @@ describe("Codex app-server process registry", () => {
   );
 
   it.each(["own", "foreign"] as const)("preserves children with a live %s owner", async (kind) => {
-    const { store, runtime, seed, child } = createHarness();
+    const { store, runtime, seed, child, self } = createHarness();
     const row = seed(kind === "own" ? { ownerPid: process.pid } : {});
     runtime.inspectSnapshot.mockResolvedValue(
-      kind === "own" ? [] : [child, processRow(row.ownerPid, row.ownerStartedAt)],
+      kind === "own" ? [self] : [self, child, processRow(row.ownerPid, row.ownerStartedAt)],
     );
     await reapOrphanedCodexAppServerProcesses(runtime);
     expect(store.lookup("101")).toEqual(row);
@@ -171,9 +174,10 @@ describe("Codex app-server process registry", () => {
     { name: "zombie owner", pgid: 101, ownerRow: "zombie", target: -101 },
     { name: "non-leader child", pgid: 99, ownerRow: "absent", target: 101 },
   ] as const)("reaps an identity-confirmed orphan: $name", async ({ pgid, ownerRow, target }) => {
-    const { store, runtime, seed, child } = createHarness();
+    const { store, runtime, seed, child, self } = createHarness();
     const row = seed();
     runtime.inspectSnapshot.mockResolvedValue([
+      self,
       child,
       // A zombie keeps its exact pid + lstart in the snapshot; only the state marks it dead.
       ...(ownerRow === "reused" ? [processRow(row.ownerPid, "new owner")] : []),
@@ -192,13 +196,35 @@ describe("Codex app-server process registry", () => {
     });
   });
 
+  it("reaps rows inherited from a pid-reusing predecessor gateway", async () => {
+    const { store, runtime, seed, child, self } = createHarness();
+    // Same numeric owner pid as this process, but the dead predecessor's lstart.
+    const row = seed({ ownerPid: process.pid, ownerStartedAt: "previous gateway" });
+    runtime.inspectSnapshot.mockResolvedValue([self, child]);
+    await reapOrphanedCodexAppServerProcesses(runtime);
+    expect(runtime.kill).toHaveBeenCalledExactlyOnceWith(-row.pid, "SIGKILL");
+    expect(store.entries()).toEqual([]);
+  });
+
+  it("keeps all rows when the snapshot omits this process", async () => {
+    const { store, runtime, seed, child } = createHarness();
+    seed();
+    const before = store.entries();
+    runtime.inspectSnapshot.mockResolvedValue([child]);
+    await reapOrphanedCodexAppServerProcesses(runtime);
+    expect(store.entries()).toEqual(before);
+    expect(runtime.inspectProcess).not.toHaveBeenCalled();
+    expect(runtime.kill).not.toHaveBeenCalled();
+    expect(embeddedAgentLog.warn).toHaveBeenCalledOnce();
+  });
+
   it.each(["gone", "reused"] as const)(
     "deletes a child proven %s by the snapshot without signaling",
     async (kind) => {
-      const { store, runtime, seed, child } = createHarness();
+      const { store, runtime, seed, child, self } = createHarness();
       seed();
       runtime.inspectSnapshot.mockResolvedValue(
-        kind === "gone" ? [] : [{ ...child, startedAt: "new child" }],
+        kind === "gone" ? [self] : [self, { ...child, startedAt: "new child" }],
       );
       await reapOrphanedCodexAppServerProcesses(runtime);
       expect(store.entries()).toEqual([]);
@@ -208,14 +234,14 @@ describe("Codex app-server process registry", () => {
   );
 
   it("keeps a row re-registered with a new identity after the snapshot was judged", async () => {
-    const { store, runtime, seed } = createHarness();
+    const { store, runtime, seed, self } = createHarness();
     const stale = seed();
     const replacement = { ...stale, startedAt: "new child", ownerPid: process.pid + 2 };
     // The reaper judged the stale row against its snapshot; a live owner re-registered
     // the same pid meanwhile. Only the judged row may be deleted.
     vi.spyOn(store, "entries").mockReturnValue([{ key: "101", value: stale, createdAt: 0 }]);
     store.register("101", replacement);
-    runtime.inspectSnapshot.mockResolvedValue([]);
+    runtime.inspectSnapshot.mockResolvedValue([self]);
     await reapOrphanedCodexAppServerProcesses(runtime);
     expect(store.lookup("101")).toEqual(replacement);
     expect(runtime.kill).not.toHaveBeenCalled();
@@ -279,13 +305,13 @@ describe("Codex app-server process registry", () => {
   it.each(["snapshot", "confirmation", "next row"] as const)(
     "stops at the deadline after %s",
     async (boundary) => {
-      const { store, runtime, seed, child } = createHarness();
+      const { store, runtime, seed, child, self } = createHarness();
       seed();
       seed({ pid: 102 });
       if (boundary === "snapshot") {
         runtime.inspectSnapshot.mockImplementation(async () => {
           runtime.now.mockReturnValue(6_000);
-          return [child];
+          return [self, child];
         });
       } else if (boundary === "confirmation") {
         runtime.inspectProcess.mockImplementation(async () => {

--- a/extensions/codex/src/app-server/transport-process-registry.ts
+++ b/extensions/codex/src/app-server/transport-process-registry.ts
@@ -131,7 +131,11 @@ async function reapProcesses(runtime: ProcessRegistryRuntime): Promise<void> {
       withRegistryStore((store) => store.delete(key));
       continue;
     }
-    if (byPid.get(value.ownerPid)?.startedAt === value.ownerStartedAt) {
+    const owner = byPid.get(value.ownerPid);
+    // A zombie owner is dead: an unreaped SIGKILLed gateway (wedged supervisor,
+    // init-less container) keeps its pid+lstart in the snapshot but no longer
+    // owns cleanup, and the memoized pass would otherwise skip its orphan forever.
+    if (owner?.startedAt === value.ownerStartedAt && !owner.state.startsWith("Z")) {
       continue;
     }
     if (byPid.get(value.pid)?.startedAt !== value.startedAt) {

--- a/extensions/codex/src/app-server/transport-process-registry.ts
+++ b/extensions/codex/src/app-server/transport-process-registry.ts
@@ -1,0 +1,230 @@
+import { embeddedAgentLog } from "openclaw/plugin-sdk/agent-harness-runtime";
+import type { OpenClawPluginService } from "openclaw/plugin-sdk/plugin-entry";
+import type { PluginStateSyncKeyedStore } from "openclaw/plugin-sdk/plugin-state-runtime";
+import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
+import {
+  inspectCodexTransportProcess,
+  inspectCodexTransportProcessSnapshot,
+  type PosixProcess,
+} from "./transport-process-containment.js";
+
+export type StoredCodexAppServerProcess = {
+  pid: number;
+  startedAt: string;
+  ownerPid: number;
+  ownerStartedAt: string;
+  spawnedAtMs: number;
+};
+
+export const CODEX_APP_SERVER_PROCESS_NAMESPACE = "app-server-processes";
+export const CODEX_APP_SERVER_PROCESS_MAX_ENTRIES = 64;
+const PROCESS_REGISTRY_INSPECTION_MS = 5_000;
+
+type RegistryStore = PluginStateSyncKeyedStore<StoredCodexAppServerProcess>;
+type SpawnedProcess = {
+  pid?: number;
+  exitCode?: number | null;
+  signalCode?: string | null;
+  once: (event: "exit", listener: () => void) => unknown;
+};
+type ProcessRegistryRuntime = {
+  platform: NodeJS.Platform;
+  inspectProcess: typeof inspectCodexTransportProcess;
+  inspectSnapshot: typeof inspectCodexTransportProcessSnapshot;
+  kill: (pid: number, signal: NodeJS.Signals) => boolean;
+  now: () => number;
+};
+const PROCESS_REGISTRY_RUNTIME: ProcessRegistryRuntime = {
+  platform: process.platform,
+  inspectProcess: inspectCodexTransportProcess,
+  inspectSnapshot: inspectCodexTransportProcessSnapshot,
+  kill: (pid, signal) => process.kill(pid, signal),
+  now: Date.now,
+};
+
+let openStore: (() => RegistryStore) | undefined;
+let ownerIdentity: Promise<PosixProcess | undefined> | undefined;
+let reapPromise: Promise<void> | undefined;
+
+export function setCodexAppServerProcessRegistryStore(open: () => RegistryStore): void {
+  openStore = open;
+}
+
+export async function registerCodexAppServerProcessSpawn(
+  child: SpawnedProcess,
+  runtime: ProcessRegistryRuntime = PROCESS_REGISTRY_RUNTIME,
+): Promise<void> {
+  const pid = child.pid;
+  if (runtime.platform === "win32" || !pid || !openStore) {
+    return;
+  }
+  // Attach before inspection yields so every exit path removes its registration.
+  child.once("exit", () => withRegistryStore((store) => store.delete(String(pid))));
+  const spawnedAtMs = runtime.now();
+  const deadline = spawnedAtMs + PROCESS_REGISTRY_INSPECTION_MS;
+  try {
+    // SIGKILL in this small spawn-to-identity window leaves cleanup to Codex's stdin-EOF drain.
+    const [identity, owner] = await Promise.all([
+      runtime.inspectProcess(pid, deadline),
+      (ownerIdentity ??= runtime.inspectProcess(process.pid, deadline)),
+    ]);
+    if (!owner) {
+      // Memoizing a failed owner read would silently disable registration for the
+      // whole process lifetime; drop it so the next spawn retries.
+      ownerIdentity = undefined;
+    }
+    if (!identity || !owner) {
+      // Without exact identities, a later reap could kill an innocent reused PID.
+      warnRegistry("codex app-server process identity unavailable; skipping registration", { pid });
+      return;
+    }
+    if (child.exitCode != null || child.signalCode != null) {
+      return;
+    }
+    withRegistryStore((store) =>
+      store.register(String(pid), {
+        pid,
+        startedAt: identity.startedAt,
+        ownerPid: process.pid,
+        ownerStartedAt: owner.startedAt,
+        spawnedAtMs,
+      }),
+    );
+  } catch (error) {
+    warnRegistry("codex app-server process registration failed", { pid, error });
+  }
+}
+
+export function reapOrphanedCodexAppServerProcesses(
+  runtime: ProcessRegistryRuntime = PROCESS_REGISTRY_RUNTIME,
+): Promise<void> {
+  return (reapPromise ??= reapProcesses(runtime).catch((error: unknown) => {
+    warnRegistry("codex app-server orphan reap failed", { error });
+  }));
+}
+
+async function reapProcesses(runtime: ProcessRegistryRuntime): Promise<void> {
+  if (runtime.platform === "win32" || !openStore) {
+    return;
+  }
+  // This deadline bounds inspection/signaling; synchronous store calls have their own lock timeout.
+  const deadline = runtime.now() + PROCESS_REGISTRY_INSPECTION_MS;
+  const entries = withRegistryStore((store) => store.entries());
+  if (!entries?.length || runtime.now() >= deadline) {
+    return;
+  }
+  const snapshot = await runtime.inspectSnapshot(deadline);
+  if (!snapshot) {
+    // Unknown ownership cannot authorize a kill or row deletion; cleanup must fail open.
+    warnRegistry("codex app-server process snapshot unavailable; skipping orphan reap");
+    return;
+  }
+  const byPid = new Map(snapshot.map((row) => [row.pid, row]));
+  for (const { key, value } of entries) {
+    if (runtime.now() >= deadline) {
+      return;
+    }
+    if (isRecord(value) && value.ownerPid === process.pid) {
+      continue;
+    }
+    if (!isStoredProcess(value)) {
+      withRegistryStore((store) => store.delete(key));
+      continue;
+    }
+    if (byPid.get(value.ownerPid)?.startedAt === value.ownerStartedAt) {
+      continue;
+    }
+    if (byPid.get(value.pid)?.startedAt !== value.startedAt) {
+      withRegistryStore((store) => deleteRegistryRowIfCurrent(store, key, value));
+      continue;
+    }
+    // Never carry numeric signal authority across an await after this final identity check.
+    const current = await runtime.inspectProcess(value.pid, deadline);
+    if (
+      runtime.now() >= deadline ||
+      !current ||
+      current.pid !== value.pid ||
+      current.startedAt !== value.startedAt
+    ) {
+      continue;
+    }
+    try {
+      // QA children can share their owner's group; only detached leaders own a killable group.
+      runtime.kill(current.pgid === current.pid ? -current.pid : current.pid, "SIGKILL");
+    } catch {
+      // The identity-confirmed process can disappear before the signal reaches it.
+    }
+    withRegistryStore((store) => deleteRegistryRowIfCurrent(store, key, value));
+    warnRegistry("reaped orphaned codex app-server", {
+      pid: value.pid,
+      spawnedAtMs: value.spawnedAtMs,
+      ownerPid: value.ownerPid,
+    });
+  }
+}
+
+// Rows judged against a snapshot may be seconds stale: a reaped/dead pid can be
+// re-registered by a live owner meanwhile, so delete only the exact row we judged.
+function deleteRegistryRowIfCurrent(
+  store: RegistryStore,
+  key: string,
+  expected: StoredCodexAppServerProcess,
+): boolean {
+  if (!store.deleteIf) {
+    return store.delete(key);
+  }
+  return store.deleteIf(
+    key,
+    (row) => row.startedAt === expected.startedAt && row.ownerStartedAt === expected.ownerStartedAt,
+  );
+}
+
+function isStoredProcess(value: unknown): value is StoredCodexAppServerProcess {
+  return (
+    isRecord(value) &&
+    Number.isSafeInteger(value.pid) &&
+    typeof value.pid === "number" &&
+    value.pid > 0 &&
+    typeof value.startedAt === "string" &&
+    value.startedAt.length > 0 &&
+    Number.isSafeInteger(value.ownerPid) &&
+    typeof value.ownerPid === "number" &&
+    value.ownerPid > 0 &&
+    typeof value.ownerStartedAt === "string" &&
+    value.ownerStartedAt.length > 0 &&
+    typeof value.spawnedAtMs === "number" &&
+    Number.isFinite(value.spawnedAtMs)
+  );
+}
+
+function withRegistryStore<T>(operation: (store: RegistryStore) => T): T | undefined {
+  try {
+    return openStore ? operation(openStore()) : undefined;
+  } catch (error) {
+    warnRegistry("codex app-server process registry access failed", { error });
+    return undefined;
+  }
+}
+
+function warnRegistry(message: string, details?: Record<string, unknown>): void {
+  try {
+    embeddedAgentLog.warn(message, details);
+  } catch {
+    // Diagnostics must not turn best-effort cleanup into a failed spawn or boot.
+  }
+}
+
+export function createCodexAppServerProcessReaperService(): OpenClawPluginService {
+  return {
+    id: "codex-app-server-process-reaper",
+    start: () => {
+      void reapOrphanedCodexAppServerProcesses();
+    },
+  };
+}
+
+export function resetCodexAppServerProcessRegistryForTests(): void {
+  openStore = undefined;
+  ownerIdentity = undefined;
+  reapPromise = undefined;
+}

--- a/extensions/codex/src/app-server/transport-process-registry.ts
+++ b/extensions/codex/src/app-server/transport-process-registry.ts
@@ -4,6 +4,7 @@ import type { PluginStateSyncKeyedStore } from "openclaw/plugin-sdk/plugin-state
 import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 import {
   inspectCodexTransportProcess,
+  inspectCodexTransportProcessCommand,
   inspectCodexTransportProcessSnapshot,
   type PosixProcess,
 } from "./transport-process-containment.js";
@@ -11,6 +12,7 @@ import {
 export type StoredCodexAppServerProcess = {
   pid: number;
   startedAt: string;
+  command: string;
   ownerPid: number;
   ownerStartedAt: string;
   spawnedAtMs: number;
@@ -30,6 +32,7 @@ type SpawnedProcess = {
 type ProcessRegistryRuntime = {
   platform: NodeJS.Platform;
   inspectProcess: typeof inspectCodexTransportProcess;
+  inspectCommand: typeof inspectCodexTransportProcessCommand;
   inspectSnapshot: typeof inspectCodexTransportProcessSnapshot;
   kill: (pid: number, signal: NodeJS.Signals) => boolean;
   now: () => number;
@@ -37,6 +40,7 @@ type ProcessRegistryRuntime = {
 const PROCESS_REGISTRY_RUNTIME: ProcessRegistryRuntime = {
   platform: process.platform,
   inspectProcess: inspectCodexTransportProcess,
+  inspectCommand: inspectCodexTransportProcessCommand,
   inspectSnapshot: inspectCodexTransportProcessSnapshot,
   kill: (pid, signal) => process.kill(pid, signal),
   now: Date.now,
@@ -64,8 +68,9 @@ export async function registerCodexAppServerProcessSpawn(
   const deadline = spawnedAtMs + PROCESS_REGISTRY_INSPECTION_MS;
   try {
     // SIGKILL in this small spawn-to-identity window leaves cleanup to Codex's stdin-EOF drain.
-    const [identity, owner] = await Promise.all([
+    const [identity, command, owner] = await Promise.all([
       runtime.inspectProcess(pid, deadline),
+      runtime.inspectCommand(pid, deadline),
       (ownerIdentity ??= runtime.inspectProcess(process.pid, deadline)),
     ]);
     if (!owner) {
@@ -73,7 +78,7 @@ export async function registerCodexAppServerProcessSpawn(
       // whole process lifetime; drop it so the next spawn retries.
       ownerIdentity = undefined;
     }
-    if (!identity || !owner) {
+    if (!identity || !command || !owner) {
       // Without exact identities, a later reap could kill an innocent reused PID.
       warnRegistry("codex app-server process identity unavailable; skipping registration", { pid });
       return;
@@ -85,6 +90,7 @@ export async function registerCodexAppServerProcessSpawn(
       store.register(String(pid), {
         pid,
         startedAt: identity.startedAt,
+        command,
         ownerPid: process.pid,
         ownerStartedAt: owner.startedAt,
         spawnedAtMs,
@@ -151,6 +157,20 @@ async function reapProcesses(runtime: ProcessRegistryRuntime): Promise<void> {
       withRegistryStore((store) => deleteRegistryRowIfCurrent(store, key, value));
       continue;
     }
+    // lstart is second-granular, so pid + lstart alone could match a same-second
+    // replacement process. Command equality is the extra kill-authority gate;
+    // absent-or-failed reads keep the row for a later pass instead of killing.
+    // lstart is second-granular, so pid + lstart alone could match a same-second
+    // replacement process. Command equality is the extra kill-authority gate;
+    // absent-or-failed reads keep the row for a later pass instead of killing.
+    const command = await runtime.inspectCommand(value.pid, deadline);
+    if (runtime.now() >= deadline || command === undefined) {
+      continue;
+    }
+    if (command !== value.command) {
+      withRegistryStore((store) => deleteRegistryRowIfCurrent(store, key, value));
+      continue;
+    }
     // Never carry numeric signal authority across an await after this final identity check.
     const current = await runtime.inspectProcess(value.pid, deadline);
     if (
@@ -188,7 +208,10 @@ function deleteRegistryRowIfCurrent(
   }
   return store.deleteIf(
     key,
-    (row) => row.startedAt === expected.startedAt && row.ownerStartedAt === expected.ownerStartedAt,
+    (row) =>
+      row.startedAt === expected.startedAt &&
+      row.command === expected.command &&
+      row.ownerStartedAt === expected.ownerStartedAt,
   );
 }
 
@@ -200,6 +223,8 @@ function isStoredProcess(value: unknown): value is StoredCodexAppServerProcess {
     value.pid > 0 &&
     typeof value.startedAt === "string" &&
     value.startedAt.length > 0 &&
+    typeof value.command === "string" &&
+    value.command.length > 0 &&
     Number.isSafeInteger(value.ownerPid) &&
     typeof value.ownerPid === "number" &&
     value.ownerPid > 0 &&

--- a/extensions/codex/src/app-server/transport-process-registry.ts
+++ b/extensions/codex/src/app-server/transport-process-registry.ts
@@ -120,15 +120,24 @@ async function reapProcesses(runtime: ProcessRegistryRuntime): Promise<void> {
     return;
   }
   const byPid = new Map(snapshot.map((row) => [row.pid, row]));
+  const self = byPid.get(process.pid);
+  if (!self) {
+    // A snapshot that cannot see the observer is not authoritative; without our
+    // own lstart, a pid-reused row could be misjudged in either direction.
+    warnRegistry("codex app-server process snapshot missing this process; skipping orphan reap");
+    return;
+  }
   for (const { key, value } of entries) {
     if (runtime.now() >= deadline) {
       return;
     }
-    if (isRecord(value) && value.ownerPid === process.pid) {
-      continue;
-    }
     if (!isStoredProcess(value)) {
       withRegistryStore((store) => store.delete(key));
+      continue;
+    }
+    // "Our row" is an identity claim, not a numeric pid match: a restarted
+    // gateway can reuse its predecessor's pid and must still reap those rows.
+    if (value.ownerPid === process.pid && value.ownerStartedAt === self.startedAt) {
       continue;
     }
     const owner = byPid.get(value.ownerPid);


### PR DESCRIPTION
Related: #132413 (follow-up 3)

## What Problem This Solves

Resolves a problem where a hard-killed (SIGKILLed) gateway orphans the detached Codex app-server child process. The stdio transport spawns the child as a detached process-group leader, so graceful shutdown can group-kill it — but nothing reaped survivors on the next boot. The orphan keeps executing the in-flight native turn against the pre-restart rollout state, and a fast gateway restart spawns a fresh app-server that shares the same CODEX_HOME with the still-draining orphan. This was named as follow-up 3 in #132413.

## Why This Change Was Made

Per the gateway audit doctrine (record facts where they happen), every stdio app-server spawn now registers the child's exact identity (pid + `ps lstart`) plus the owning process identity in the codex plugin's SQLite keyed-state store (namespace `app-server-processes`; no schema change, no pidfiles), and removes the row on child exit. A memoized, bounded (~5s) reaper runs at gateway startup as a plugin service and is also awaited before the first app-server spawn — plugin services start post-attach, so a turn can beat the service. Evidence rules are fail-closed: a single full `ps -axo` snapshot (which exits 0 regardless of target presence) proves owner death and child presence/identity; a final per-pid check immediately gates each SIGKILL with no await in between; `ps -p` exits nonzero for missing pids and therefore cannot distinguish absent from failed, so per-pid reads are used only where both outcomes take the same no-kill action. Group kill is applied only to confirmed group leaders (QA-mode children share their owner's group and get a direct pid signal). Row removal uses compare-and-delete so a judgment made against a stale snapshot can never clobber a row re-registered by a live owner. POSIX-only, matching the existing containment scope in `transport-process-containment.ts` (which gains only two narrow exported inspection wrappers, zero behavior change).

Upstream contract verified against the pinned `@openai/codex` 0.150.1 source (`rust-v0.150.1`): stdin EOF ends the stdio connection (`codex-rs/app-server-transport/src/transport/stdio.rs`), single-client stdio mode then breaks the processor loop (`codex-rs/app-server/src/lib.rs:1038`) and drains gracefully — 30s RPC drain (`message_processor.rs`), 10s background tasks + 10s thread shutdown (`thread_processor.rs`) — before exit. So orphans do self-terminate eventually, but continue turn execution for that window and indefinitely if the drain wedges; the reaper closes both the overlap and the wedge case.

Out of scope: the `codex exec-server` child spawned by `node-exec-server.runtime.ts` has a different lifecycle owner (node host, temp CODEX_HOME, terminated via its active-process registry and workspace teardown) and is intentionally not registered here.

## User Impact

After a gateway crash or SIGKILL, restarting no longer risks a leftover Codex app-server continuing the pre-restart turn against stale rollout state or racing the fresh child on the same CODEX_HOME — orphans are killed at the next boot or, at the latest, immediately before the next app-server spawn. No configuration changes; no behavior change on Windows.

## Evidence

- New unit suite `transport-process-registry.test.ts` (24 tests, table-driven): spawn/exit registration symmetry, identity-read failure and early-exit races, owner-identity retry after a failed read, live-owner preservation (own and foreign), identity-confirmed group vs direct kill, snapshot-proven gone/reused row cleanup without signaling, snapshot-failure pass abort (no kills, rows kept), stale-snapshot re-registration preserved via compare-and-delete, deadline stops, memoization, malformed-row cleanup, store-failure containment (open/register/entries/delete/deleteIf), win32/no-store no-ops.
- Real-process boundary proof `transport-process-registry.process.test.ts`: spawns a real detached `sleep` group leader plus a real owner process, registers genuine `ps` identities, proves the reaper preserves the child while the owner lives, then after the owner dies observes the actual SIGKILL, absence from a fresh snapshot, ESRCH on `kill(pid, 0)`, and an empty registry.
- Ordering regression in `shared-client.test.ts`: a pending reap blocks `CodexAppServerClient.start` until it settles.
- Focused suites green: registry (34), shared-client (96), index (29), client (46), transport containment process tests (2).
- `node scripts/check-changed.mjs` fully green (format, guards, dead-export scans, extension + extension-test typechecks, lint).
- `pnpm build` green; zero `INEFFECTIVE_DYNAMIC_IMPORT` warnings.
- Fresh Codex autoreview on the final diff: no accepted/actionable findings.
- Production LOC +273 / tests +526: the production growth is a previously absent persisted lifecycle owner (registration + reaper + startup/first-spawn integration); there was no existing path to absorb it.
- Known-unrelated: `transport-websocket.test.ts` "unix control socket" case times out on macOS dev hosts on pristine `main` (reproduced at d7e280fcf69 with zero diff; this change's code is not on that path — tracked as a separate follow-up task). CI (Linux, Node 24) is unaffected.
