### PR TITLE
fix(agents): honor static denies in profile warnings

### DIFF
--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -175,6 +175,10 @@ Choose the extension path by the job you need OpenClaw to do:
 
 ## Troubleshoot missing tools
 
+Configured `tools.exec` and `tools.fs` sections do not grant tool access. The
+profile migration warning suggests `alsoAllow` entries only when other active
+global, agent, and provider policies permit those tools.
+
 If the model cannot see or call a tool, start with the effective policy for
 the current turn:
 

--- a/src/agents/agent-tools.policy.test.ts
+++ b/src/agents/agent-tools.policy.test.ts
@@ -10,6 +10,7 @@ import type { OpenClawConfig } from "../config/config.js";
 import { retainLegacyDefaultAgentId } from "../config/legacy.default-agent-owner.js";
 import { replaceSessionEntry } from "../config/sessions/session-accessor.js";
 import type { SessionEntry } from "../config/sessions/types.js";
+import type { AgentToolsConfig } from "../config/types.tools.js";
 import { createWarnLogCapture } from "../logging/test-helpers/warn-log-capture.js";
 import {
   resolveEffectiveToolPolicy,
@@ -718,88 +719,68 @@ describe("resolveEffectiveToolPolicy", () => {
     }
   });
 
-  const staticDenyCases: Array<{
+  it.each<{
     name: string;
-    config: OpenClawConfig;
-    resolveArgs: { agentId?: string; modelProvider?: string };
-  }> = [
+    tools?: OpenClawConfig["tools"];
+    agentTools?: AgentToolsConfig;
+    warning?: string;
+  }>([
+    { name: "global deny", tools: { deny: ["process"] } },
     {
-      name: "global deny",
-      config: {
-        tools: {
-          profile: "messaging",
-          alsoAllow: ["exec"],
-          deny: ["process"],
-          exec: { mode: "allowlist" },
-        },
-      } as OpenClawConfig,
-      resolveArgs: {},
+      name: "global provider wildcard deny",
+      tools: { byProvider: { fixture: { deny: ["pro*"] } } },
+    },
+    { name: "agent group deny", agentTools: { deny: ["group:runtime"] } },
+    { name: "agent provider deny", agentTools: { byProvider: { fixture: { deny: ["process"] } } } },
+    { name: "global allow restriction", tools: { allow: ["exec"] } },
+    {
+      name: "provider profile",
+      tools: { byProvider: { fixture: { profile: "minimal" as const } } },
     },
     {
-      name: "global provider deny",
-      config: {
-        tools: {
-          profile: "messaging",
-          alsoAllow: ["exec"],
-          byProvider: { openai: { deny: ["process"] } },
-          exec: { mode: "allowlist" },
-        },
-      } as OpenClawConfig,
-      resolveArgs: { modelProvider: "openai" },
+      name: "provider profile alsoAllow",
+      tools: { byProvider: { fixture: { profile: "minimal" as const, alsoAllow: ["process"] } } },
+      warning: 'Add alsoAllow: ["process"]',
     },
     {
-      name: "agent deny",
-      config: {
+      name: "unselected provider deny",
+      tools: { byProvider: { other: { deny: ["*"] } } },
+      warning: 'Add alsoAllow: ["process"]',
+    },
+  ])("warns only about actionable grants with $name", async ({ tools, agentTools, warning }) => {
+    const warnLogs = createWarnLogCapture("openclaw-agent-tools-policy-test");
+    try {
+      const config: OpenClawConfig = {
+        tools,
         agents: {
-          list: [
-            {
-              id: "sage",
+          entries: {
+            ops: {
               tools: {
                 profile: "messaging",
                 alsoAllow: ["exec"],
-                deny: ["process"],
-                exec: { mode: "allowlist" },
+                exec: { host: "gateway" },
+                ...agentTools,
               },
             },
-          ],
+          },
         },
-      } as OpenClawConfig,
-      resolveArgs: { agentId: "sage" },
-    },
-    {
-      name: "agent provider deny",
-      config: {
-        agents: {
-          list: [
-            {
-              id: "sage",
-              tools: {
-                profile: "messaging",
-                alsoAllow: ["exec"],
-                byProvider: { openai: { deny: ["process"] } },
-                exec: { mode: "allowlist" },
-              },
-            },
-          ],
-        },
-      } as OpenClawConfig,
-      resolveArgs: { agentId: "sage", modelProvider: "openai" },
-    },
-  ];
-
-  it.each(staticDenyCases)(
-    "does not warn for an implied grant blocked by a $name (#131102)",
-    async ({ config, resolveArgs }) => {
-      const warnLogs = createWarnLogCapture("openclaw-agent-tools-policy-test");
-      try {
-        resolveEffectiveToolPolicy({ config, ...resolveArgs });
-
-        expect(await warnLogs.findText('tools policy: profile "messaging"')).toBeUndefined();
-      } finally {
-        warnLogs.cleanup();
+      };
+      const result = resolveEffectiveToolPolicy({
+        config,
+        agentId: "ops",
+        modelProvider: "fixture",
+      });
+      const logged = await warnLogs.findText('tools policy: profile "messaging"');
+      if (warning) {
+        expect(logged).toContain(warning);
+      } else {
+        expect(logged).toBeUndefined();
       }
-    },
-  );
+      expect(result.profileAlsoAllow).toEqual(["exec"]);
+    } finally {
+      warnLogs.cleanup();
+    }
+  });
 
   it("only lists configured sections whose grants are still missing (#47487)", async () => {
     const warnLogs = createWarnLogCapture("openclaw-agent-tools-policy-test");

--- a/src/agents/agent-tools.policy.test.ts
+++ b/src/agents/agent-tools.policy.test.ts
@@ -718,6 +718,89 @@ describe("resolveEffectiveToolPolicy", () => {
     }
   });
 
+  const staticDenyCases: Array<{
+    name: string;
+    config: OpenClawConfig;
+    resolveArgs: { agentId?: string; modelProvider?: string };
+  }> = [
+    {
+      name: "global deny",
+      config: {
+        tools: {
+          profile: "messaging",
+          alsoAllow: ["exec"],
+          deny: ["process"],
+          exec: { mode: "allowlist" },
+        },
+      } as OpenClawConfig,
+      resolveArgs: {},
+    },
+    {
+      name: "global provider deny",
+      config: {
+        tools: {
+          profile: "messaging",
+          alsoAllow: ["exec"],
+          byProvider: { openai: { deny: ["process"] } },
+          exec: { mode: "allowlist" },
+        },
+      } as OpenClawConfig,
+      resolveArgs: { modelProvider: "openai" },
+    },
+    {
+      name: "agent deny",
+      config: {
+        agents: {
+          list: [
+            {
+              id: "sage",
+              tools: {
+                profile: "messaging",
+                alsoAllow: ["exec"],
+                deny: ["process"],
+                exec: { mode: "allowlist" },
+              },
+            },
+          ],
+        },
+      } as OpenClawConfig,
+      resolveArgs: { agentId: "sage" },
+    },
+    {
+      name: "agent provider deny",
+      config: {
+        agents: {
+          list: [
+            {
+              id: "sage",
+              tools: {
+                profile: "messaging",
+                alsoAllow: ["exec"],
+                byProvider: { openai: { deny: ["process"] } },
+                exec: { mode: "allowlist" },
+              },
+            },
+          ],
+        },
+      } as OpenClawConfig,
+      resolveArgs: { agentId: "sage", modelProvider: "openai" },
+    },
+  ];
+
+  it.each(staticDenyCases)(
+    "does not warn for an implied grant blocked by a $name (#131102)",
+    async ({ config, resolveArgs }) => {
+      const warnLogs = createWarnLogCapture("openclaw-agent-tools-policy-test");
+      try {
+        resolveEffectiveToolPolicy({ config, ...resolveArgs });
+
+        expect(await warnLogs.findText('tools policy: profile "messaging"')).toBeUndefined();
+      } finally {
+        warnLogs.cleanup();
+      }
+    },
+  );
+
   it("only lists configured sections whose grants are still missing (#47487)", async () => {
     const warnLogs = createWarnLogCapture("openclaw-agent-tools-policy-test");
     try {

--- a/src/agents/agent-tools.policy.ts
+++ b/src/agents/agent-tools.policy.ts
@@ -39,7 +39,7 @@ import {
   type SessionCapabilityStore,
   type SubagentSessionRole,
 } from "./subagents/spawn/subagent-capabilities.js";
-import { createToolPolicyMatcher, isToolAllowedByPolicies } from "./tool-policy-match.js";
+import { createToolPolicyMatcher } from "./tool-policy-match.js";
 import { mergeAlsoAllowPolicy, resolveToolProfilePolicy } from "./tool-policy.js";
 import { AUTOMATIONS_TOOL_NAME } from "./tools/automations-tool-name.js";
 
@@ -318,18 +318,13 @@ function hasExplicitToolSection(section: unknown): boolean {
   return section !== undefined && section !== null;
 }
 
-/** Detect tool config sections that previously widened profiles implicitly.
- *  Used only for migration warnings — not merged into profileAlsoAllow.  #47487 */
-type ImplicitProfileGrantDetection = {
-  entries: Array<{ section: string; grants: string[] }>;
-};
-
+/** Detect removed implicit grants for migration warnings only (#47487). */
 function detectImplicitProfileGrants(params: {
   globalTools?: OpenClawConfig["tools"];
   agentTools?: AgentToolsConfig;
   includeGlobalSections: boolean;
-}): ImplicitProfileGrantDetection | undefined {
-  const entries: ImplicitProfileGrantDetection["entries"] = [];
+}): Array<{ section: string; grants: string[] }> {
+  const entries: Array<{ section: string; grants: string[] }> = [];
   if (
     hasExplicitToolSection(params.agentTools?.exec) ||
     (params.includeGlobalSections && hasExplicitToolSection(params.globalTools?.exec))
@@ -342,18 +337,7 @@ function detectImplicitProfileGrants(params: {
   ) {
     entries.push({ section: "tools.fs", grants: ["read", "write", "edit"] });
   }
-  if (entries.length === 0) {
-    return undefined;
-  }
-  return { entries };
-}
-
-function formatImplicitToolSections(sections: string[]): string {
-  return sections.join(" / ");
-}
-
-function formatToolListForWarning(toolNames: string[]): string {
-  return toolNames.map((toolName) => `"${toolName}"`).join(", ");
+  return entries;
 }
 
 /** Resolve the layered global, provider, agent, and profile tool policies. */
@@ -404,16 +388,7 @@ export function resolveEffectiveToolPolicy(params: {
   });
   const explicitProfileAlsoAllow =
     resolveExplicitProfileAlsoAllow(agentTools) ?? resolveExplicitProfileAlsoAllow(globalTools);
-  const globalPolicy = pickSandboxToolPolicy(globalTools);
-  const globalProviderPolicy = pickSandboxToolPolicy(providerPolicy);
   const agentPolicy = pickSandboxToolPolicy(agentTools);
-  const agentProviderPolicyLayer = pickSandboxToolPolicy(agentProviderPolicy);
-  const providerProfile = agentProviderPolicy?.profile ?? providerPolicy?.profile;
-  const providerProfileAlsoAllow = Array.isArray(agentProviderPolicy?.alsoAllow)
-    ? agentProviderPolicy.alsoAllow
-    : Array.isArray(providerPolicy?.alsoAllow)
-      ? providerPolicy.alsoAllow
-      : undefined;
   const clawToolPolicyConsent = resolveClawToolPolicyConsent({
     agentTools,
     agentId,
@@ -425,38 +400,56 @@ export function resolveEffectiveToolPolicy(params: {
     markFrozenClawToolAllowPolicy(agentPolicy);
   }
 
-  // Warn affected users about removed implicit grants (#47487), but only when
-  // the active profile/explicit alsoAllow do not already grant those tools.
+  const effectivePolicy = {
+    agentId,
+    globalPolicy: pickSandboxToolPolicy(globalTools),
+    globalProviderPolicy: pickSandboxToolPolicy(providerPolicy),
+    agentPolicy,
+    agentProviderPolicy: pickSandboxToolPolicy(agentProviderPolicy),
+    profile,
+    providerProfile: agentProviderPolicy?.profile ?? providerPolicy?.profile,
+    // alsoAllow is applied at the profile stage to avoid early filtering.
+    profileAlsoAllow: explicitProfileAlsoAllow
+      ? uniqueStrings(explicitProfileAlsoAllow)
+      : undefined,
+    providerProfileAlsoAllow: Array.isArray(agentProviderPolicy?.alsoAllow)
+      ? agentProviderPolicy?.alsoAllow
+      : Array.isArray(providerPolicy?.alsoAllow)
+        ? providerPolicy?.alsoAllow
+        : undefined,
+  };
+
+  // Recommend removed implicit grants only when adding them to the profile
+  // can work: every other static policy layer must permit the tool.
   if (profile) {
     const implicitGrants = detectImplicitProfileGrants({
       globalTools,
       agentTools,
       includeGlobalSections: profileSource === "global",
     });
-    if (implicitGrants) {
+    if (implicitGrants.length > 0) {
       const profilePolicy = mergeAlsoAllowPolicy(
         resolveToolProfilePolicy(profile),
         explicitProfileAlsoAllow,
       );
       const matchesProfile = createToolPolicyMatcher(profilePolicy);
-      const providerProfilePolicy = mergeAlsoAllowPolicy(
-        resolveToolProfilePolicy(providerProfile),
-        providerProfileAlsoAllow,
-      );
-      const staticOverridePolicies = [
-        providerProfilePolicy,
-        globalPolicy,
-        globalProviderPolicy,
-        agentPolicy,
-        agentProviderPolicyLayer,
-      ];
-      const uncoveredEntries = implicitGrants.entries
+      const restrictionMatchers = [
+        effectivePolicy.globalPolicy,
+        effectivePolicy.globalProviderPolicy,
+        effectivePolicy.agentPolicy,
+        effectivePolicy.agentProviderPolicy,
+        mergeAlsoAllowPolicy(
+          resolveToolProfilePolicy(effectivePolicy.providerProfile),
+          effectivePolicy.providerProfileAlsoAllow,
+        ),
+      ].map((policy) => createToolPolicyMatcher(policy));
+      const uncoveredEntries = implicitGrants
         .map((entry) => ({
           section: entry.section,
           grants: entry.grants.filter(
             (toolName) =>
               !matchesProfile(toolName) &&
-              isToolAllowedByPolicies(toolName, staticOverridePolicies),
+              restrictionMatchers.every((matches) => matches(toolName)),
           ),
         }))
         .filter((entry) => entry.grants.length > 0);
@@ -464,29 +457,15 @@ export function resolveEffectiveToolPolicy(params: {
       if (uncovered.length > 0) {
         logWarn(
           `tools policy: profile "${profile}"${agentId ? ` (agent "${agentId}")` : ""} has ` +
-            `configured tool sections (${formatImplicitToolSections(uncoveredEntries.map((entry) => entry.section))}) that no longer implicitly widen ` +
-            `the profile. Add alsoAllow: [${formatToolListForWarning(uncovered)}] ` +
+            `configured tool sections (${uncoveredEntries.map((entry) => entry.section).join(" / ")}) that no longer implicitly widen ` +
+            `the profile. Add alsoAllow: [${uncovered.map((toolName) => `"${toolName}"`).join(", ")}] ` +
             `explicitly if these tools should be available. See #47487.`,
         );
       }
     }
   }
 
-  const profileAlsoAllow = explicitProfileAlsoAllow
-    ? uniqueStrings(explicitProfileAlsoAllow)
-    : undefined;
-  return {
-    agentId,
-    globalPolicy,
-    globalProviderPolicy,
-    agentPolicy,
-    agentProviderPolicy: agentProviderPolicyLayer,
-    profile,
-    providerProfile,
-    // alsoAllow is applied at the profile stage to avoid early filtering.
-    profileAlsoAllow,
-    providerProfileAlsoAllow,
-  };
+  return effectivePolicy;
 }
 
 function denyAllToolPolicy(): SandboxToolPolicy {

--- a/src/agents/agent-tools.policy.ts
+++ b/src/agents/agent-tools.policy.ts
@@ -39,7 +39,7 @@ import {
   type SessionCapabilityStore,
   type SubagentSessionRole,
 } from "./subagents/spawn/subagent-capabilities.js";
-import { createToolPolicyMatcher } from "./tool-policy-match.js";
+import { createToolPolicyMatcher, isToolAllowedByPolicies } from "./tool-policy-match.js";
 import { mergeAlsoAllowPolicy, resolveToolProfilePolicy } from "./tool-policy.js";
 import { AUTOMATIONS_TOOL_NAME } from "./tools/automations-tool-name.js";
 
@@ -404,7 +404,16 @@ export function resolveEffectiveToolPolicy(params: {
   });
   const explicitProfileAlsoAllow =
     resolveExplicitProfileAlsoAllow(agentTools) ?? resolveExplicitProfileAlsoAllow(globalTools);
+  const globalPolicy = pickSandboxToolPolicy(globalTools);
+  const globalProviderPolicy = pickSandboxToolPolicy(providerPolicy);
   const agentPolicy = pickSandboxToolPolicy(agentTools);
+  const agentProviderPolicyLayer = pickSandboxToolPolicy(agentProviderPolicy);
+  const providerProfile = agentProviderPolicy?.profile ?? providerPolicy?.profile;
+  const providerProfileAlsoAllow = Array.isArray(agentProviderPolicy?.alsoAllow)
+    ? agentProviderPolicy.alsoAllow
+    : Array.isArray(providerPolicy?.alsoAllow)
+      ? providerPolicy.alsoAllow
+      : undefined;
   const clawToolPolicyConsent = resolveClawToolPolicyConsent({
     agentTools,
     agentId,
@@ -430,10 +439,25 @@ export function resolveEffectiveToolPolicy(params: {
         explicitProfileAlsoAllow,
       );
       const matchesProfile = createToolPolicyMatcher(profilePolicy);
+      const providerProfilePolicy = mergeAlsoAllowPolicy(
+        resolveToolProfilePolicy(providerProfile),
+        providerProfileAlsoAllow,
+      );
+      const staticOverridePolicies = [
+        providerProfilePolicy,
+        globalPolicy,
+        globalProviderPolicy,
+        agentPolicy,
+        agentProviderPolicyLayer,
+      ];
       const uncoveredEntries = implicitGrants.entries
         .map((entry) => ({
           section: entry.section,
-          grants: entry.grants.filter((toolName) => !matchesProfile(toolName)),
+          grants: entry.grants.filter(
+            (toolName) =>
+              !matchesProfile(toolName) &&
+              isToolAllowedByPolicies(toolName, staticOverridePolicies),
+          ),
         }))
         .filter((entry) => entry.grants.length > 0);
       const uncovered = uncoveredEntries.flatMap((entry) => entry.grants);
@@ -453,19 +477,15 @@ export function resolveEffectiveToolPolicy(params: {
     : undefined;
   return {
     agentId,
-    globalPolicy: pickSandboxToolPolicy(globalTools),
-    globalProviderPolicy: pickSandboxToolPolicy(providerPolicy),
+    globalPolicy,
+    globalProviderPolicy,
     agentPolicy,
-    agentProviderPolicy: pickSandboxToolPolicy(agentProviderPolicy),
+    agentProviderPolicy: agentProviderPolicyLayer,
     profile,
-    providerProfile: agentProviderPolicy?.profile ?? providerPolicy?.profile,
+    providerProfile,
     // alsoAllow is applied at the profile stage to avoid early filtering.
     profileAlsoAllow,
-    providerProfileAlsoAllow: Array.isArray(agentProviderPolicy?.alsoAllow)
-      ? agentProviderPolicy?.alsoAllow
-      : Array.isArray(providerPolicy?.alsoAllow)
-        ? providerPolicy?.alsoAllow
-        : undefined,
+    providerProfileAlsoAllow,
   };
 }
 


### PR DESCRIPTION
## What Problem This Solves

An agent with the messaging profile, explicit `alsoAllow: ["exec"]`, and `deny: ["process"]` receives a migration warning telling the operator to add `process` to `alsoAllow`. Following that advice cannot work because deny rules take precedence. Global, provider, restrictive allow-list, and provider-profile policies can produce the same contradiction.

## Why This Change Was Made

Resolve the canonical effective policy once and reuse its other static layers when preparing migration advice. The warning now includes a missing profile grant only if the global, selected-provider, agent, agent-provider, and provider-profile restrictions all permit that tool. The existing matcher preserves wildcard and group semantics, and its patterns are prepared once per layer.

The maintainer pass replaces the intermediate detection wrapper and one-use formatting helpers with their direct values. Production code shrinks by one line while covering all static policy layers. Tool authorization and the returned effective policy are unchanged.

## User Impact

Operators no longer receive impossible `alsoAllow` advice for tools blocked elsewhere. Missing grants still produce guidance when adding them can work, including selected-provider `alsoAllow`. The tools overview explains this diagnostic behavior. No configuration, default, protocol, or storage surface changes.

## Evidence

- Independent owner regression first failed in all six restricted cases on trusted main: 6 failures and 36 passing tests.
- The completed owner suite passes all 44 tests, including global/agent/provider denies, wildcard and group expansion, restrictive allows, provider profiles, provider `alsoAllow`, unselected-provider isolation, and existing positive migration-warning cases.
- The real built CLI completed seven fresh isolated local turns before and after the fix through the existing QA Lab mock provider. Four blocked-policy cases lose the impossible warning; missing-grant and provider-allowance controls retain it. The mixed exec/files case now recommends only the unblocked file tools. Every before/after tool inventory is identical, and `process` is never exposed. All owned processes terminate, ports close, and temporary state is removed.
- The canonical `qaRuntime` build passes. The full changed-file gate passes, including production/test types, all three dead-export scans, lint, and repository guards. An initial test-type inference error was corrected with a canonical config-typed table. The complete three-file native candidate passes the independent P0 review with no findings. Published-head CI remains pending.

This is the canonical repair for #131102 and overlaps the narrower agent-only fix in #131172. Thanks @sunlit-deng for the static-policy fix and @SuperMarioYL for identifying the warning defect.


Reviewed and pushed head: `268a6f836e3807c47477a051dcfd641b521e571c`. Contributor ancestry and credit are preserved. Required exact-head CI remains a landing gate.
