### PR TITLE
fix(logging): preserve newly written stability bundles

### DIFF
--- a/src/logging/diagnostic-stability-bundle.test.ts
+++ b/src/logging/diagnostic-stability-bundle.test.ts
@@ -217,42 +217,46 @@ describe("diagnostic stability bundles", () => {
     expect(files[1]).toContain("12-00-03");
   });
 
-  it("retains the just-published bundle when an older file has a future mtime", () => {
-    const older = writeDiagnosticStabilityBundleForFailureSync(
-      "gateway.startup_failed",
-      undefined,
-      {
-        stateDir: tempDir,
-        retention: 1,
-        now: new Date("2026-04-22T12:00:00.000Z"),
-      },
-    );
-    if (older.status !== "written") {
-      throw new Error(`expected written bundle, got ${older.status}`);
-    }
-    const future = new Date("2036-04-22T12:00:00.000Z");
-    fs.utimesSync(older.path, future, future);
+  it.each([1, 2])(
+    "keeps the published bundle within retention %i despite future mtimes",
+    (retention) => {
+      for (let index = 0; index < retention; index++) {
+        const older = writeDiagnosticStabilityBundleForFailureSync(
+          "gateway.startup_failed",
+          undefined,
+          {
+            stateDir: tempDir,
+            retention,
+            now: new Date(Date.UTC(2026, 3, 22, 12, 0, index)),
+          },
+        );
+        expect(older.status).toBe("written");
+        if (older.status !== "written") {
+          throw new Error("Fixture publication failed");
+        }
+        const future = new Date(Date.UTC(2036, 3, 22, 12, 0, index));
+        fs.utimesSync(older.path, future, future);
+      }
 
-    const current = writeDiagnosticStabilityBundleForFailureSync(
-      "gateway.restart_respawn_failed",
-      undefined,
-      {
-        stateDir: tempDir,
-        retention: 1,
-        now: new Date("2026-04-22T12:00:01.000Z"),
-      },
-    );
-
-    expect(current.status).toBe("written");
-    if (current.status !== "written") {
-      return;
-    }
-    expect(fs.existsSync(current.path)).toBe(true);
-    expect(current.message).toContain(current.path);
-    expect(fs.readdirSync(path.dirname(current.path))).toEqual([path.basename(current.path)]);
-    const latest = readLatestDiagnosticStabilityBundleSync({ stateDir: tempDir });
-    expect(latest.status === "found" ? latest.path : "").toBe(current.path);
-  });
+      const current = writeDiagnosticStabilityBundleForFailureSync(
+        "gateway.restart_respawn_failed",
+        undefined,
+        {
+          stateDir: tempDir,
+          retention,
+          now: new Date("2026-04-22T12:01:00.000Z"),
+        },
+      );
+      expect(current.status).toBe("written");
+      if (current.status !== "written") {
+        throw new Error("Current publication failed");
+      }
+      expect(current.message).toContain(current.path);
+      expect(fs.existsSync(current.path)).toBe(true);
+      expect(readDiagnosticStabilityBundleFileSync(current.path).status).toBe("found");
+      expect(fs.readdirSync(path.dirname(current.path))).toHaveLength(retention);
+    },
+  );
 
   it("reads the newest retained bundle", () => {
     startDiagnosticStabilityRecorder();

--- a/src/logging/diagnostic-stability-bundle.test.ts
+++ b/src/logging/diagnostic-stability-bundle.test.ts
@@ -217,6 +217,43 @@ describe("diagnostic stability bundles", () => {
     expect(files[1]).toContain("12-00-03");
   });
 
+  it("retains the just-published bundle when an older file has a future mtime", () => {
+    const older = writeDiagnosticStabilityBundleForFailureSync(
+      "gateway.startup_failed",
+      undefined,
+      {
+        stateDir: tempDir,
+        retention: 1,
+        now: new Date("2026-04-22T12:00:00.000Z"),
+      },
+    );
+    if (older.status !== "written") {
+      throw new Error(`expected written bundle, got ${older.status}`);
+    }
+    const future = new Date("2036-04-22T12:00:00.000Z");
+    fs.utimesSync(older.path, future, future);
+
+    const current = writeDiagnosticStabilityBundleForFailureSync(
+      "gateway.restart_respawn_failed",
+      undefined,
+      {
+        stateDir: tempDir,
+        retention: 1,
+        now: new Date("2026-04-22T12:00:01.000Z"),
+      },
+    );
+
+    expect(current.status).toBe("written");
+    if (current.status !== "written") {
+      return;
+    }
+    expect(fs.existsSync(current.path)).toBe(true);
+    expect(current.message).toContain(current.path);
+    expect(fs.readdirSync(path.dirname(current.path))).toEqual([path.basename(current.path)]);
+    const latest = readLatestDiagnosticStabilityBundleSync({ stateDir: tempDir });
+    expect(latest.status === "found" ? latest.path : "").toBe(current.path);
+  });
+
   it("reads the newest retained bundle", () => {
     startDiagnosticStabilityRecorder();
     emitDiagnosticEvent({ type: "webhook.received", channel: "telegram" });

--- a/src/logging/diagnostic-stability-bundle.ts
+++ b/src/logging/diagnostic-stability-bundle.ts
@@ -872,7 +872,7 @@ export function readLatestDiagnosticStabilityBundleSync(
   }
 }
 
-function pruneOldBundles(dir: string, retention: number): void {
+function pruneOldBundles(dir: string, retention: number, retainedFile: string): void {
   if (!Number.isFinite(retention) || retention < 1) {
     return;
   }
@@ -890,9 +890,10 @@ function pruneOldBundles(dir: string, retention: number): void {
         }
         return { file, mtimeMs };
       })
+      .filter((entry) => entry.file !== retainedFile)
       .toSorted((a, b) => b.mtimeMs - a.mtimeMs || b.file.localeCompare(a.file));
 
-    for (const entry of entries.slice(retention)) {
+    for (const entry of entries.slice(retention - 1)) {
       try {
         fs.unlinkSync(entry.file);
       } catch {
@@ -946,7 +947,7 @@ export function writeDiagnosticStabilityBundleSync(
       mode: 0o600,
       tempPrefix: ".openclaw-stability",
     });
-    pruneOldBundles(dir, options.retention ?? DEFAULT_DIAGNOSTIC_STABILITY_BUNDLE_RETENTION);
+    pruneOldBundles(dir, options.retention ?? DEFAULT_DIAGNOSTIC_STABILITY_BUNDLE_RETENTION, file);
     return { status: "written", path: file, bundle };
   } catch (error) {
     return { status: "failed", error };


### PR DESCRIPTION
## What Problem This Solves

A successful diagnostic-bundle write could return a path that had already been deleted. Retention ran after publication and sorted every artifact by modification time, so older files with future timestamps could evict the newly written bundle.

Fixes https://github.com/openclaw/openclaw/issues/127418.

## Why This Change Was Made

The writer passes the exact published file to the existing cleanup owner. Cleanup excludes that file and reserves one retention slot for it, preserving the ordering and failure handling of older artifacts. Production is +4/-3 (net +1); the extra line carries publication identity across the existing owner boundary. There is no new configuration, schema, or storage format.

Improved regression coverage exercises both retention limits 1 and 2 through the real writer and direct reader. Existing latest-file ordering remains unchanged: with a limit above 1, an older future-dated file may still sort first.

## Evidence

On trusted upstream a36fedbbf80339a26ded6b89543e4c3e58c917dd, actual temporary-file publication returned success but the new path was missing at retention limits 1, 2, and the default 20. The chronological control passed. A maintainer-authored equivalent owner repair preserved and read back the new file in all four scenarios, with the expected retained counts.

The two new regression cases failed on the original owner while all 11 existing cases passed. The repaired owner, stability recorder, and diagnostic export suites passed 46 tests across three files. Final targeted formatting, typed lint, and complete-candidate independent Codex review at P0 passed. Contributor source runs only in secretless hosted CI.

The original CI failed an unrelated detached Gateway-work benchmark after 30 seconds. A later run passed that benchmark, which does not establish the old timeout's cause. [Exact-head CI33365300210](https://github.com/openclaw/openclaw/actions/runs/33365300210) passed on `d1815df174f1a78fafc64f048f55d99be4970ae5`, including the repaired owner and its new regressions; no threshold or assertion was weakened. The broad local changed-file gate was interrupted and is not claimed as passing.

The remaining ClawSweeper dependency-source gap was checked directly against installed `@openclaw/fs-safe` 0.5.6: `dist/replace-file.js` completes the synchronous rename before returning; `dist/sibling-temp.js` likewise completes publication before returning a path. The subsequent OpenClaw retention step owned the deletion. The latest review's exact-head CI request is now satisfied, and the net +1 production line carries the authoritative published identity into that owner.

## Release-note context

Preserve newly written gateway stability bundles when older files have future modification times, so diagnostic messages name artifacts operators can read. Thanks @Alix-007.
