### PR TITLE
fix(codex): prevent macOS Unix transport test hangs

### DIFF
--- a/extensions/codex/src/app-server/transport-websocket.test.ts
+++ b/extensions/codex/src/app-server/transport-websocket.test.ts
@@ -289,11 +289,18 @@ describe("Codex app-server websocket transport", () => {
   }, 5_000);
 
   it("can speak JSON-RPC over the canonical unix control socket", async () => {
-    const tempDir = await mkdtemp(path.join(os.tmpdir(), "openclaw-codex-unix-"));
+    // macOS socket paths must fit sockaddr_un even when the runner nests TMPDIR.
+    const tempRoot = process.platform === "darwin" ? "/tmp" : os.tmpdir();
+    const tempDir = await mkdtemp(path.join(tempRoot, "openclaw-codex-unix-"));
     tempDirs.push(tempDir);
     const socketPath = path.join(tempDir, "app-server.sock");
     const httpServer = http.createServer();
     httpServers.push(httpServer);
+    // Bind before ws forwards HTTP errors, so a listen failure rejects this test.
+    await new Promise<void>((resolve, reject) => {
+      httpServer.once("error", reject);
+      httpServer.listen(socketPath, resolve);
+    });
     const server = new WebSocketServer({ server: httpServer });
     servers.push(server);
     const upgradeExtensions: Array<string | undefined> = [];
@@ -314,10 +321,6 @@ describe("Codex app-server websocket transport", () => {
           socket.send(JSON.stringify({ id: message.id, result: { data: [] } }));
         }
       });
-    });
-    await new Promise<void>((resolve, reject) => {
-      httpServer.once("error", reject);
-      httpServer.listen(socketPath, resolve);
     });
 
     const client = CodexAppServerClient.start({


### PR DESCRIPTION
Related: #132413 (orphan-reaper follow-up discovery; that change did not touch this transport).

## What Problem This Solves

Resolves a problem where running the Codex Unix-socket transport test on macOS hangs for the full 120-second test timeout, even when run alone on pristine main.

## Why This Change Was Made

The failure happens before either WebSocket peer can attempt an upgrade. The managed Vitest runner canonicalizes and nests `TMPDIR`; the fixture then creates a 112-byte socket pathname on this host, beyond macOS's 103-byte Unix-socket limit. `httpServer.listen()` emits `EINVAL`. Because `WebSocketServer` has already registered its error-forwarding listener, it re-emits the error without a listener and throws before the later HTTP error listener can reject the test's promise.

Use a short, uniquely allocated `/tmp` fixture on macOS and bind the HTTP server before attaching `WebSocketServer`, so startup errors reject normally. Existing cleanup still owns the directory and both servers. No production transport, configuration, dependencies, timeout, or protocol changes.

Provenance: the long fixture prefix and early WebSocketServer attachment came from #104045 (code author and merger @steipete, July 11). #132208 (code author and merger @steipete, August 29) exposed it by nesting and canonicalizing the runner temp root. The recent runner isolation is intentional and remains intact.

## User Impact

Developers can run the real Unix-socket JSON-RPC test on macOS without a two-minute hang. Operators see no runtime behavior change.

## Evidence

- Baseline at `265d34e54e9`: `node scripts/run-vitest.mjs extensions/codex/src/app-server/transport-websocket.test.ts -- -t 'can speak JSON-RPC over the canonical unix control socket'` failed at 120032 ms on macOS, Node 24.20.0.
- Temporary phase tracing showed a 112-byte path, no listening callback, no client construction, and no upgrade. A standalone Node probe reproducing the runner's path and listener order confirmed `EINVAL`, `listening=false`, and no promise rejection; the corrected order rejects `EINVAL` immediately. Diagnostic instrumentation is not in the patch.
- After the fix, `node scripts/run-vitest.mjs extensions/codex/src/app-server/transport-websocket.test.ts`: all 8 cases pass on macOS Node 24.20.0, including real JSON-RPC initialize/thread-list over the Unix socket and the 7 TCP/auth/heartbeat/UTF-8 cases.
- The shared local install has ws 8.21.1. Separately tested the pinned ws 8.21.3 package directly on both Node 24.20.0 and 26.7.0: Unix WebSocket upgrade, message exchange, and shutdown pass. Its source preserves the same error forwarding and createConnection contracts. Hosted CI will validate the lockfile install.
- Direct contracts inspected: [Node IPC path limits](https://nodejs.org/api/net.html#identifying-paths-for-ipc-connections); [ws 8.21.3 error forwarding](https://github.com/websockets/ws/blob/8.21.3/lib/websocket-server.js#L121-L130) and [client createConnection](https://github.com/websockets/ws/blob/8.21.3/lib/websocket.js#L752-L753).
- Personally inspected sibling Codex source at `6478a751fde8884b2fdc76486fe23175a8e795d4`: `codex-rs/app-server-transport/src/transport/unix_socket.rs:58-87` accepts UnixStream, runs `accept_async`, and shares the WebSocket message loop; `transport/mod.rs:54-64` owns the canonical socket pathname. No transport contract change is needed.
- Production LOC: +0/-0. Tests: +8/-5 (net +3; includes moving the existing listen block).

No model/provider call is needed for this test-only fixture repair; the existing regression exercises real local sockets without replacing the transport with mocks.

Local checks: formatting, conflict/max-lines/assertion guards, dependency pins, plugin boundaries, and all three dead-export scans passed. The full changed gate stopped in extension typechecking against the shared older dependency install (missing newer markdown-it exports, Pi TUI APIs, and Crabline artifact types). No transport-test diagnostic was reported. Exact-head CI with the lockfile install remains the merge gate; this is not claimed as a green full local check. Codex autoreview is clean.

Exact-head CI passed: [run 33257687490](https://github.com/openclaw/openclaw/actions/runs/33257687490) for `543ebb8bc68a0da98da5bd9a406af4eedf8b4d76`, including changed-plugin tests, test/production types, package boundaries, lint, and `openclaw/ci-gate`. This clean lockfile-installed run resolves the local dependency-install validation gap. The separate local oxlint wrapper also stopped during the same stale-dependency declaration-generation preflight, before linting; CI is the complete lint/type proof.
