### PR TITLE
fix(test): prevent reconciles from recreating cleaned fixtures

### DIFF
--- a/src/config/sessions/session-transcript-reconcile.lifecycle.test.ts
+++ b/src/config/sessions/session-transcript-reconcile.lifecycle.test.ts
@@ -1,22 +1,31 @@
+import path from "node:path";
 import { setTimeout as delay } from "node:timers/promises";
 import { Worker, type WorkerOptions } from "node:worker_threads";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createDeferred } from "../../../test/helpers/promise.js";
 import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
 import {
+  closeOpenClawAgentDatabaseByPath,
   closeOpenClawAgentDatabasesForTest,
+  isOpenClawAgentDatabaseOpen,
   openOpenClawAgentDatabase,
+  resolveOpenClawAgentSqlitePath,
+  type OpenClawAgentDatabaseOptions,
 } from "../../state/openclaw-agent-db.js";
 import {
+  closeOpenClawStateDatabaseByPath,
   closeOpenClawStateDatabaseForTest,
   openOpenClawStateDatabase,
 } from "../../state/openclaw-state-db.js";
+import { resolveOpenClawStateSqlitePath } from "../../state/openclaw-state-db.paths.js";
 import { withEnvAsync } from "../../test-utils/env.js";
 import { persistSessionTranscriptTurn } from "./session-accessor.js";
 import {
+  isSessionTranscriptIndexReconcileRunning,
   reconcileSessionTranscriptIndexes,
   startSessionTranscriptIndexReconcile,
   waitForSessionTranscriptIndexReconcile,
+  waitForSessionTranscriptIndexReconcilesInStateDir,
   waitForSessionTranscriptProjection,
 } from "./session-transcript-reconcile.js";
 import type { SessionTranscriptReconcileWorkerMessage } from "./session-transcript-reconcile.worker.js";
@@ -97,6 +106,73 @@ async function waitForCurrentProjection(databasePath: string, sessionId: string)
 }
 
 describe("session transcript reconcile worker lifecycle", () => {
+  it("drains later fixture owners without waiting for an unrelated state directory", async () => {
+    const root = tempDirs.make("openclaw-reconcile-scope-");
+    const stateDir = path.join(root, "state");
+    const env = { ...process.env, OPENCLAW_STATE_DIR: stateDir };
+    const first = { agentId: "main", env };
+    const later = { agentId: "later", env };
+    const unrelated = {
+      agentId: "main",
+      env: { ...env, OPENCLAW_STATE_DIR: `${stateDir}-unrelated` },
+    };
+    const realSetImmediate = globalThis.setImmediate;
+    const immediateSpy = vi.spyOn(globalThis, "setImmediate");
+    const checkpoint = () =>
+      new Promise<void>((resolve) => {
+        realSetImmediate(resolve);
+      });
+    const startDeferred = (options: OpenClawAgentDatabaseOptions) => {
+      const release = createDeferred();
+      immediateSpy.mockImplementationOnce((callback) => {
+        void release.promise.then(() => callback());
+        return realSetImmediate(() => undefined);
+      });
+      startSessionTranscriptIndexReconcile(options);
+      return release;
+    };
+    const releaseFirst = startDeferred(first);
+    const releaseUnrelated = startDeferred(unrelated);
+    let settled = false;
+    const scopedWait = waitForSessionTranscriptIndexReconcilesInStateDir(stateDir).then(() => {
+      settled = true;
+    });
+    // This owner did not exist in the waiter's initial snapshot, and no owner
+    // has opened its database yet: scope must come from the registered keys.
+    const releaseLater = startDeferred(later);
+    try {
+      releaseFirst.resolve();
+      await waitForSessionTranscriptIndexReconcile(first);
+      await checkpoint();
+      expect(settled).toBe(false);
+      expect(isSessionTranscriptIndexReconcileRunning(later)).toBe(true);
+
+      releaseLater.resolve();
+      await waitForSessionTranscriptIndexReconcile(later);
+      // A checkpoint makes a wrongly global wait fail here, while finally can
+      // still release the unrelated owner instead of deadlocking the test.
+      await checkpoint();
+      expect(settled).toBe(true);
+      expect(isSessionTranscriptIndexReconcileRunning(unrelated)).toBe(true);
+      expect(isOpenClawAgentDatabaseOpen(resolveOpenClawAgentSqlitePath(unrelated))).toBe(false);
+    } finally {
+      immediateSpy.mockRestore();
+      releaseFirst.resolve();
+      releaseLater.resolve();
+      releaseUnrelated.resolve();
+      await Promise.all([
+        scopedWait,
+        ...[first, later, unrelated].map(waitForSessionTranscriptIndexReconcile),
+      ]);
+      for (const options of [first, later, unrelated]) {
+        closeOpenClawAgentDatabaseByPath(resolveOpenClawAgentSqlitePath(options));
+      }
+      for (const options of [first, unrelated]) {
+        closeOpenClawStateDatabaseByPath(resolveOpenClawStateSqlitePath(options.env));
+      }
+    }
+  });
+
   it("resolves one session before unrelated projection repair completes", async () => {
     const stateDir = tempDirs.make("openclaw-active-transcript-");
     const scope = {

--- a/src/config/sessions/session-transcript-reconcile.ts
+++ b/src/config/sessions/session-transcript-reconcile.ts
@@ -6,6 +6,7 @@ import { setTimeout as delay } from "node:timers/promises";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { Worker, type WorkerOptions } from "node:worker_threads";
 import { toStringifiedError } from "@openclaw/normalization-core/error-coercion";
+import { isPathInside } from "../../infra/path-guards.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import {
   openOpenClawAgentDatabase,
@@ -409,6 +410,22 @@ export async function waitForSessionTranscriptIndexReconcile(
   params: OpenClawAgentDatabaseOptions,
 ): Promise<void> {
   await runningReconciles.get(reconcileKey(params))?.promise;
+}
+
+/** Test and maintenance drain for scheduled reconciles owned by one state directory. */
+export async function waitForSessionTranscriptIndexReconcilesInStateDir(
+  stateDir: string,
+): Promise<void> {
+  while (true) {
+    const owners = [...runningReconciles]
+      .filter(([databasePath]) => isPathInside(stateDir, databasePath))
+      .flatMap(([, owner]) => (owner.promise ? [owner.promise] : []));
+    if (owners.length === 0) {
+      return;
+    }
+    // Handoffs and other fixture databases may register owners while this batch settles.
+    await Promise.all(owners);
+  }
 }
 
 /** Waits only until the requested session's scheduled projection rebuild settles. */

--- a/src/test-utils/openclaw-test-state.test.ts
+++ b/src/test-utils/openclaw-test-state.test.ts
@@ -11,12 +11,17 @@ import {
 } from "../agents/auth-profiles/sqlite.js";
 import { saveAuthProfileStore } from "../agents/auth-profiles/store.js";
 import {
+  startSessionTranscriptIndexReconcile,
+  waitForSessionTranscriptIndexReconcile,
+} from "../config/sessions/session-transcript-reconcile.js";
+import {
   GATEWAY_STARTUP_MUTATED_ENV_KEYS,
   snapshotGatewayStartupEnv,
 } from "../gateway/test-helpers.env.js";
 import * as nodeSqlite from "../infra/node-sqlite.js";
 import {
   closeOpenClawAgentDatabaseByPath,
+  isOpenClawAgentDatabaseOpen,
   openOpenClawAgentDatabase,
 } from "../state/openclaw-agent-db.js";
 import {
@@ -418,6 +423,74 @@ describe("openclaw test state", () => {
         maxRetries: 20,
         retryDelay: 25,
       });
+    }
+  });
+
+  it("does not recreate fixture databases from a deferred transcript reconcile", async () => {
+    const state = await createOpenClawTestState({ label: "deferred-reconcile" });
+    const options = { agentId: "main", env: state.env };
+    const agent = openOpenClawAgentDatabase(options);
+    const shared = openOpenClawStateDatabase({ env: state.env });
+    const realSetImmediate = globalThis.setImmediate;
+    let resumeReconcile: (() => void) | undefined;
+    const immediateSpy = vi.spyOn(globalThis, "setImmediate").mockImplementationOnce((callback) => {
+      resumeReconcile = () => callback();
+      return realSetImmediate(() => undefined);
+    });
+    const originalRm = fs.rm;
+    let removalStarted = false;
+    const rmSpy = vi.spyOn(fs, "rm").mockImplementation((...args) => {
+      if (args[0] === state.root) {
+        removalStarted = true;
+      }
+      return originalRm(...args);
+    });
+    const openSpy = vi.spyOn(nodeSqlite, "openNodeSqliteDatabase");
+    let cleanup: Promise<void> | undefined;
+    let reconcile: Promise<void> | undefined;
+    try {
+      startSessionTranscriptIndexReconcile(options);
+      reconcile = waitForSessionTranscriptIndexReconcile(options);
+      expect(resumeReconcile).toBeDefined();
+      cleanup = state.cleanup();
+
+      // Empty drains settle before this real event-loop checkpoint. Old cleanup
+      // reaches rm; repaired cleanup must keep the fixture alive for the owner.
+      await new Promise<void>((resolve) => {
+        realSetImmediate(resolve);
+      });
+      if (removalStarted) {
+        await cleanup;
+        expect(agent.db.isOpen).toBe(false);
+        await expectPathMissing(state.root);
+      } else {
+        expect(agent.db.isOpen).toBe(true);
+        expect(process.env.OPENCLAW_STATE_DIR).toBe(state.stateDir);
+      }
+      resumeReconcile?.();
+      await reconcile;
+      await cleanup;
+
+      await expectPathMissing(state.root);
+      await expectPathMissing(agent.path);
+      await expectPathMissing(shared.path);
+      expect(isOpenClawAgentDatabaseOpen(agent.path)).toBe(false);
+      expect(agent.db.isOpen).toBe(false);
+      expect(shared.db.isOpen).toBe(false);
+      expect(openSpy.mock.calls.filter(([pathname]) => pathname === agent.path)).toEqual([]);
+    } finally {
+      immediateSpy.mockRestore();
+      resumeReconcile?.();
+      await reconcile;
+      await cleanup;
+      await state.cleanup();
+      openSpy.mockRestore();
+      rmSpy.mockRestore();
+      // cleanup is idempotent, so explicitly dispose anything the pre-fix
+      // reconcile recreated after it returned.
+      closeOpenClawAgentDatabaseByPath(agent.path);
+      closeOpenClawStateDatabaseByPath(shared.path);
+      await fs.rm(state.root, { recursive: true, force: true });
     }
   });
 

--- a/src/test-utils/openclaw-test-state.ts
+++ b/src/test-utils/openclaw-test-state.ts
@@ -11,13 +11,6 @@ import { saveAuthProfileStore } from "../agents/auth-profiles/store.js";
 import type { AuthProfileStore } from "../agents/auth-profiles/types.js";
 import * as configRuntime from "../config/config.js";
 import { GATEWAY_STARTUP_MUTATED_ENV_KEYS } from "../gateway/test-helpers.env.js";
-import { isPathInside } from "../infra/path-guards.js";
-import {
-  closeOpenClawAgentDatabaseByPath,
-  listOpenClawAgentDatabasesForTest,
-} from "../state/openclaw-agent-db.js";
-import { closeOpenClawStateDatabaseByPath } from "../state/openclaw-state-db.js";
-import { resolveOpenClawStateSqlitePath } from "../state/openclaw-state-db.paths.js";
 import { captureEnv } from "./env.js";
 import { cleanupSessionStateForTest } from "./session-state-cleanup.js";
 
@@ -368,16 +361,8 @@ export async function createOpenClawTestState(
           return;
         }
         cleaned = true;
-        await cleanupSessionStateForTest().catch(() => undefined);
+        await cleanupSessionStateForTest({ stateDir: paths.stateDir }).catch(() => undefined);
         closeAuthProfileReadPool({ kind: "root", rootPath: paths.stateDir });
-        // Agent close releases leases through shared state; closing shared state first
-        // can reopen it during teardown and leave Windows handles under the fixture root.
-        for (const database of listOpenClawAgentDatabasesForTest()) {
-          if (isPathInside(paths.stateDir, database.path)) {
-            closeOpenClawAgentDatabaseByPath(database.path);
-          }
-        }
-        closeOpenClawStateDatabaseByPath(resolveOpenClawStateSqlitePath(env));
         state.restoreEnv();
         await removeRoot();
       },

--- a/src/test-utils/session-state-cleanup.ts
+++ b/src/test-utils/session-state-cleanup.ts
@@ -1,4 +1,5 @@
 // Cleans session-related shared state after tests.
+import { waitForSessionTranscriptIndexReconcilesInStateDir } from "../config/sessions/session-transcript-reconcile.js";
 import {
   clearSessionStoreCacheForTest,
   drainSessionStoreWriterQueuesForTest,
@@ -38,13 +39,19 @@ export async function cleanupSessionStateForTest(
   options: { stateDir?: string } = {},
 ): Promise<void> {
   await (sessionStoreWriterQueueDrainerForTests ?? drainSessionStoreWriterQueuesForTest)();
+  if (options.stateDir) {
+    // Writers can publish deferred reconciles as the initial drain settles.
+    // Finish those owners and their writes before closing fixture databases.
+    await waitForSessionTranscriptIndexReconcilesInStateDir(options.stateDir);
+    await (sessionStoreWriterQueueDrainerForTests ?? drainSessionStoreWriterQueuesForTest)();
+  }
   await (fileLockDrainerForTests ?? drainFileLockStateForTest)();
   clearSessionStoreCacheForTest();
   if (!options.stateDir) {
     return;
   }
-  // A queued writer can reopen both databases after an earlier close. Scope
-  // final handle cleanup to the fixture owner so unrelated tests stay live.
+  // Close agent handles before shared state: releasing their leases can reopen
+  // shared state. Unrelated fixtures keep their handles.
   for (const database of listOpenClawAgentDatabasesForTest()) {
     if (isPathInside(options.stateDir, database.path)) {
       closeOpenClawAgentDatabaseByPath(database.path);


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where isolated OpenClaw test fixtures could finish cleanup while a deferred transcript-index reconcile was still waiting to start. When the callback resumed, it could recreate the removed fixture root and reopen agent/shared SQLite state, leaking handles and making teardown order-dependent across platforms.

## Why This Change Was Made

Fixture cleanup now joins every registered reconcile owner whose resolved database path belongs to that fixture, rescans for owners registered while earlier work settles, and drains session writers again before closing fixture-owned agent databases and shared state. Unrelated fixture reconciles remain live, and the duplicate database-close path in `OpenClawTestState` is removed so teardown has one canonical owner.

This PR is AI-assisted. I reviewed the lifecycle, ownership boundary, implementation, and proof.

## User Impact

There is no live runtime or SQLite schema change. OpenClaw tests that use isolated state now reliably leave their fixture roots deleted and database handles closed, avoiding cross-test leakage and Windows-style file-removal failures.

## Evidence

- Pre-fix deterministic regression held the reconcile `setImmediate` through cleanup and failed because the removed `openclaw-test-state-deferred-reconcile-*` root reappeared.
- The same regression passes after the fix and proves the root/database paths remain absent, the original handles are closed, no replacement agent handle is cached, and no physical agent database reopen occurs after disposal.
- `node scripts/run-vitest.mjs src/test-utils/openclaw-test-state.test.ts src/test-utils/session-state-cleanup.test.ts src/config/sessions/session-transcript-reconcile.lifecycle.test.ts` — 23 tests passed across 3 shards.
- `node scripts/check-changed.mjs -- src/config/sessions/session-transcript-reconcile.ts src/config/sessions/session-transcript-reconcile.lifecycle.test.ts src/test-utils/session-state-cleanup.ts src/test-utils/openclaw-test-state.ts src/test-utils/openclaw-test-state.test.ts` — passed the complete core/coreTests changed gate.
- `git diff --check` — passed.
- Fresh autoreview — no accepted/actionable findings.
- Production/test split: runtime source +17/-0; test support +10/-18; tests +149/-0. The runtime addition exposes the existing reconcile owner for scoped teardown; the duplicate close path is removed. It does not change scheduling or runtime callers.
- Provenance: the deferred reconcile boundary came from #129182 (233ac850f03c901166c0937398e96443089fd38e), authored and merged by @steipete on 2026-08-25; this repair joins that owner into fixture teardown.

The proof exercises a deterministic fixture lifecycle defect with real filesystem and SQLite operations. No user-facing channel/API behavior changes, and no authenticated live-channel or Windows-host execution is claimed.

CI follow-through: the first exact-head run, [33257697163](https://github.com/openclaw/openclaw/actions/runs/33257697163), passed the SQLite session lifecycle gate but failed one unchanged QA polling test: `does not attach a recovered history failure to a later predicate timeout` in `extensions/qa-lab/src/suite-runtime-agent-process.test.ts:819`. Its real 220 ms deadline expired while the initial retryable error remained; the test and polling implementation are identical to main and outside this five-file repair. The isolated command `node scripts/run-vitest.mjs extensions/qa-lab/src/suite-runtime-agent-process.test.ts -t 'does not attach a recovered history failure to a later predicate timeout'` passes unchanged. One failed-job rerun was requested on the same head; no assertions, deadlines, or source were changed. A worthwhile separate follow-up is to make this mock-only polling test control elapsed time deterministically; this PR does not claim to fix that timing sensitivity.

ClawSweeper disposition ([review](https://github.com/openclaw/openclaw/pull/132634#issuecomment-5463004304)): no blocking correctness/security findings or discrete repair request. The production-growth concern is accepted with the existing narrow boundary: the only non-test caller of the drain is `cleanupSessionStateForTest`; it is not exported through a public SDK or invoked by live runtime paths. Canonical cleanup retains agent-before-shared closure. The automated stored-data-model warning does not apply: the full five-file diff adds an in-memory owner wait and changes fixture teardown only, with no DDL, SQL write shape, schema version, migration, serialized format, or persistent-store semantics change. No migration/upgrade proof is therefore required. Maintainer handling is being completed through native review, exact-head CI, prepare, and merge; no repair lane or re-review request is needed for the unchanged reviewed head.

Final verification: [CI 33257697163, attempt 2](https://github.com/openclaw/openclaw/actions/runs/33257697163/attempts/2) completed successfully on `4169c0b6450f5503b7b229a4afcedf5fd7f52f23`; native review artifacts validated and `OPENCLAW_TESTBOX=1 scripts/pr prepare-run 132634` passed using exact-head hosted CI and Workflow Sanity evidence (standalone Testbox workflows not applicable). Native `scripts/pr merge-run 132634` squash-merged this exact head as [ed90980a12ac5c3138bcc8f42c3accbf7ec64ece](https://github.com/openclaw/openclaw/commit/ed90980a12ac5c3138bcc8f42c3accbf7ec64ece) at 2026-08-29T14:50:30Z. The landed commit contains exactly the five reviewed files, with identical file contents. No rebase, source change, gate bypass, release, or package publication occurred during landing.
