### PR TITLE
fix(agents): map file tools for slash container workdirs

### DIFF
--- a/src/agents/agent-tools.read.ts
+++ b/src/agents/agent-tools.read.ts
@@ -600,8 +600,8 @@ function mapContainerPathToRoot(params: {
   if (!containerRoot) {
     return { filePath: params.filePath, matched: false };
   }
-  const normalizedRoot = containerRoot.replace(/\\/g, "/").replace(/\/+$/, "");
-  if (!normalizedRoot.startsWith("/") || !normalizedRoot) {
+  const normalizedRoot = containerRoot.replace(/\\/g, "/").replace(/\/+$/, "") || "/";
+  if (!normalizedRoot.startsWith("/")) {
     return { filePath: params.filePath, matched: false };
   }
 
@@ -614,7 +614,7 @@ function mapContainerPathToRoot(params: {
   if (normalizedCandidate === normalizedRoot) {
     return { filePath: path.resolve(params.root), matched: true };
   }
-  const prefix = `${normalizedRoot}/`;
+  const prefix = normalizedRoot === "/" ? "/" : `${normalizedRoot}/`;
   if (!normalizedCandidate.startsWith(prefix)) {
     return { filePath: candidate, matched: false };
   }

--- a/src/agents/agent-tools.read.workspace-root-guard.test.ts
+++ b/src/agents/agent-tools.read.workspace-root-guard.test.ts
@@ -72,6 +72,21 @@ describe("wrapToolWorkspaceRootGuardWithOptions", () => {
     });
   });
 
+  it("maps container workspace paths when the backend workdir is filesystem root", async () => {
+    const { tool } = createToolHarness();
+    const wrapped = wrapToolWorkspaceRootGuardWithOptions(tool, root, {
+      containerWorkdir: "/",
+    });
+
+    await wrapped.execute("tc-root-workdir", { path: "/docs/readme.md" });
+
+    expect(mocks.assertSandboxPath).toHaveBeenCalledWith({
+      filePath: path.resolve(root, "docs", "readme.md"),
+      cwd: root,
+      root,
+    });
+  });
+
   it("strips malformed XML arg-value suffixes before guarding path params", async () => {
     const { execute, tool } = createToolHarness();
     const wrapped = wrapToolWorkspaceRootGuardWithOptions(tool, root);

--- a/src/agents/sandbox/fs-bridge.backend.root-workdir.test.ts
+++ b/src/agents/sandbox/fs-bridge.backend.root-workdir.test.ts
@@ -1,0 +1,141 @@
+// Proves a slash-root container workspace through a real local backend.
+import { spawn } from "node:child_process";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  createSandboxedReadTool,
+  wrapToolWorkspaceRootGuardWithOptions,
+} from "../agent-tools.read.js";
+import type {
+  SandboxBackendCommandParams,
+  SandboxBackendCommandResult,
+  SandboxBackendHandle,
+} from "./backend-handle.types.js";
+
+function mapRootMountedArgs(args: readonly string[], hostRoot: string): string[] {
+  return args.map((arg) =>
+    arg === "/"
+      ? hostRoot
+      : arg === hostRoot || arg.startsWith(`${hostRoot}${path.sep}`)
+        ? arg
+        : arg.startsWith("/")
+          ? path.join(hostRoot, arg.slice(1))
+          : arg,
+  );
+}
+
+async function runRootMountedShellCommand(
+  params: SandboxBackendCommandParams,
+  hostRoot: string,
+): Promise<SandboxBackendCommandResult> {
+  const args = mapRootMountedArgs(params.args ?? [], hostRoot);
+  return await new Promise<SandboxBackendCommandResult>((resolve, reject) => {
+    const child = spawn("sh", ["-c", params.script, "openclaw-sandbox-fs", ...args], {
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    const stdoutChunks: Buffer[] = [];
+    const stderrChunks: Buffer[] = [];
+    let aborted = false;
+
+    const onAbort = () => {
+      if (aborted) {
+        return;
+      }
+      aborted = true;
+      child.kill("SIGTERM");
+    };
+    params.signal?.addEventListener("abort", onAbort);
+    child.stdout?.on("data", (chunk) => stdoutChunks.push(Buffer.from(chunk)));
+    child.stderr?.on("data", (chunk) => stderrChunks.push(Buffer.from(chunk)));
+    child.on("error", reject);
+    child.on("close", (code) => {
+      params.signal?.removeEventListener("abort", onAbort);
+      if (aborted || params.signal?.aborted) {
+        const error = new Error("Aborted");
+        error.name = "AbortError";
+        reject(error);
+        return;
+      }
+      const result = {
+        stdout: Buffer.concat(stdoutChunks),
+        stderr: Buffer.concat(stderrChunks),
+        code: code ?? 0,
+      };
+      if (result.code !== 0 && !params.allowFailure) {
+        reject(new Error(result.stderr.toString("utf8").trim() || `shell exited ${result.code}`));
+        return;
+      }
+      resolve(result);
+    });
+    child.stdin?.end(params.stdin);
+  });
+}
+
+describe("sandbox fs bridge slash-root backend", () => {
+  it.runIf(process.platform !== "win32")(
+    "reads a slash-root container path through the real guard and bridge",
+    async () => {
+      const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-fsbridge-root-test-"));
+      const workspaceDir = path.join(stateDir, "workspace");
+      await fs.mkdir(path.join(workspaceDir, "docs"), { recursive: true });
+      await fs.writeFile(path.join(workspaceDir, "docs", "readme.md"), "from-real-bridge");
+      const backend: SandboxBackendHandle = {
+        id: "local-test",
+        runtimeId: "local-backend-fsbridge-root",
+        runtimeLabel: "local-backend-fsbridge-root",
+        workdir: "/",
+        buildExecSpec: async ({ command, env }) => ({
+          argv: ["sh", "-c", command],
+          env,
+          stdinMode: "pipe-closed",
+        }),
+        runShellCommand: (params) => runRootMountedShellCommand(params, workspaceDir),
+      };
+
+      try {
+        const [{ createSandboxFsBridge }, { createSandboxTestContext }] = await Promise.all([
+          import("./fs-bridge.js"),
+          import("./test-fixtures.js"),
+        ]);
+        const sandbox = createSandboxTestContext({
+          overrides: {
+            workspaceDir,
+            agentWorkspaceDir: workspaceDir,
+            containerWorkdir: "/",
+            containerName: "local-backend-fsbridge-root",
+            backend,
+          },
+        });
+        const bridge = createSandboxFsBridge({ sandbox });
+        const readTool = wrapToolWorkspaceRootGuardWithOptions(
+          createSandboxedReadTool({ root: workspaceDir, bridge }),
+          workspaceDir,
+          { containerWorkdir: "/" },
+        );
+        const mapped = bridge.resolvePath({ filePath: "/docs/readme.md", cwd: workspaceDir });
+        const result = await readTool.execute("tc-root-workdir", { path: "/docs/readme.md" });
+
+        expect(mapped.relativePath).toBe("docs/readme.md");
+        expect(mapped.containerPath).toBe("/docs/readme.md");
+        expect(result.content).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              type: "text",
+              text: expect.stringContaining("from-real-bridge"),
+            }),
+          ]),
+        );
+        await expect(
+          bridge.readFile({ filePath: "../outside.txt", cwd: workspaceDir }),
+        ).rejects.toThrow(/escapes sandbox root/i);
+        console.info(
+          "REAL_SANDBOX_ROOT_PROOF path=/docs/readme.md mapped=/docs/readme.md content=from-real-bridge outside=REJECTED",
+        );
+      } finally {
+        await fs.rm(stateDir, { recursive: true, force: true });
+      }
+    },
+  );
+});

--- a/src/agents/sandbox/fs-bridge.backend.root-workdir.test.ts
+++ b/src/agents/sandbox/fs-bridge.backend.root-workdir.test.ts
@@ -4,6 +4,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../../config/config.js";
 import {
   createSandboxedReadTool,
   wrapToolWorkspaceRootGuardWithOptions,
@@ -13,6 +14,8 @@ import type {
   SandboxBackendCommandResult,
   SandboxBackendHandle,
 } from "./backend-handle.types.js";
+import { registerSandboxBackend } from "./backend.js";
+import { resolveSandboxContext } from "./context.js";
 
 function mapRootMountedArgs(args: readonly string[], hostRoot: string): string[] {
   return args.map((arg) =>
@@ -93,26 +96,40 @@ describe("sandbox fs bridge slash-root backend", () => {
         }),
         runShellCommand: (params) => runRootMountedShellCommand(params, workspaceDir),
       };
+      const restore = registerSandboxBackend("local-test", {
+        factory: async () => backend,
+        resolveWorkdir: () => backend.workdir,
+      });
 
       try {
-        const [{ createSandboxFsBridge }, { createSandboxTestContext }] = await Promise.all([
-          import("./fs-bridge.js"),
-          import("./test-fixtures.js"),
-        ]);
-        const sandbox = createSandboxTestContext({
-          overrides: {
-            workspaceDir,
-            agentWorkspaceDir: workspaceDir,
-            containerWorkdir: "/",
-            containerName: "local-backend-fsbridge-root",
-            backend,
+        const config: OpenClawConfig = {
+          agents: {
+            defaults: {
+              sandbox: {
+                mode: "all",
+                backend: "local-test",
+                scope: "session",
+                workspaceAccess: "rw",
+                prune: { idleHours: 0, maxAgeDays: 0 },
+              },
+            },
           },
-        });
-        const bridge = createSandboxFsBridge({ sandbox });
-        const readTool = wrapToolWorkspaceRootGuardWithOptions(
-          createSandboxedReadTool({ root: workspaceDir, bridge }),
+        };
+        const sandbox = await resolveSandboxContext({
+          config,
+          execOverrides: { host: "node", node: "build-node", security: "allowlist" },
+          sessionKey: "agent:main:root-workdir",
           workspaceDir,
-          { containerWorkdir: "/" },
+        });
+        if (!sandbox?.fsBridge) {
+          throw new Error("Sandbox context did not create an fs bridge");
+        }
+        expect(sandbox.containerWorkdir).toBe(backend.workdir);
+        const bridge = sandbox.fsBridge;
+        const readTool = wrapToolWorkspaceRootGuardWithOptions(
+          createSandboxedReadTool({ root: sandbox.workspaceDir, bridge }),
+          sandbox.workspaceDir,
+          { containerWorkdir: sandbox.containerWorkdir },
         );
         const mapped = bridge.resolvePath({ filePath: "/docs/readme.md", cwd: workspaceDir });
         const result = await readTool.execute("tc-root-workdir", { path: "/docs/readme.md" });
@@ -134,6 +151,7 @@ describe("sandbox fs bridge slash-root backend", () => {
           "REAL_SANDBOX_ROOT_PROOF path=/docs/readme.md mapped=/docs/readme.md content=from-real-bridge outside=REJECTED",
         );
       } finally {
+        restore();
         await fs.rm(stateDir, { recursive: true, force: true });
       }
     },

--- a/src/agents/sandbox/fs-bridge.backend.root-workdir.test.ts
+++ b/src/agents/sandbox/fs-bridge.backend.root-workdir.test.ts
@@ -1,9 +1,9 @@
 // Proves a slash-root container workspace through a real local backend.
 import { spawn } from "node:child_process";
 import fs from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import {
   createSandboxedReadTool,
@@ -77,10 +77,12 @@ async function runRootMountedShellCommand(
 }
 
 describe("sandbox fs bridge slash-root backend", () => {
+  const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
   it.runIf(process.platform !== "win32")(
     "reads a slash-root container path through the real guard and bridge",
     async () => {
-      const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-fsbridge-root-test-"));
+      const stateDir = tempDirs.make("openclaw-fsbridge-root-test-");
       const workspaceDir = path.join(stateDir, "workspace");
       await fs.mkdir(path.join(workspaceDir, "docs"), { recursive: true });
       await fs.writeFile(path.join(workspaceDir, "docs", "readme.md"), "from-real-bridge");
@@ -152,7 +154,6 @@ describe("sandbox fs bridge slash-root backend", () => {
         );
       } finally {
         restore();
-        await fs.rm(stateDir, { recursive: true, force: true });
       }
     },
   );


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where agents using a sandbox backend with `/` as its container workspace root could have valid absolute file paths rejected by the workspace guard instead of being resolved inside the agent workspace.

## Why This Change Was Made

The file-tool container-path mapper treated `/` as an empty root after trimming trailing separators. The fix preserves `/` as the root sentinel and uses a root-aware child prefix while leaving named workspace roots and additional mounts unchanged.

## User Impact

Sandboxed agents can use absolute paths such as `/docs/readme.md` when the backend workspace is rooted at `/`, without weakening the workspace boundary or changing paths outside the configured root.

## Evidence

**Final behavior proof (exact head)**

- [CI agentic-agents-support-hosted-1 job](https://github.com/openclaw/openclaw/actions/runs/33321456248/job/99284189641) ran the standard agents-support test shard at `c165125d04fc2b185ea9315b9e7ea2ae195fa8da`: 109 test files passed, 2,578 tests passed, and 2 tests were skipped.
- The test registered a local sandbox backend with workdir `/`, resolved the sandbox context through the production backend/context path, and exercised the real workspace guard and `createSandboxFsBridge` with the context-derived workdir.
- Inspectable output from that exact-head run:

  ```text
  REAL_SANDBOX_ROOT_PROOF path=/docs/readme.md mapped=/docs/readme.md content=from-real-bridge outside=REJECTED
  ```

- The same run verifies that `/docs/readme.md` is read from the temporary workspace through the bridge, while `../outside.txt` is rejected by the sandbox root boundary.

**Supporting checks**

- `oxfmt --check src/agents/sandbox/fs-bridge.backend.root-workdir.test.ts`
- `git diff --check`
- Full CI run [33353202459](https://github.com/openclaw/openclaw/actions/runs/33353202459) passed at the current head; `check-guards` completed without the temporary-directory cleanup annotation.
- Fresh autoreview reported no accepted or actionable findings.

**Proof boundary**

This is a configured local POSIX sandbox-backend proof of the guard-to-filesystem-bridge seam. It does not claim a live Docker image or remote provider session.

The follow-up commit only switches the proof fixture to the shared automatic temporary-directory cleanup helper; production mapping logic and the claim-matched assertions are unchanged from the recorded behavior proof above.

Exact head: `0213e8603c0547273fa67fe87e6784540eb1b341`
