### PR TITLE
chore: verify dependency-cache registry lifetime

### DIFF
--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -13,6 +13,7 @@ import {
   writeFileSync,
 } from "node:fs";
 import { isBuiltin } from "node:module";
+import { connect } from "node:net";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -31,7 +32,7 @@ import { visitModuleSpecifiers } from "../../scripts/lib/guard-inventory-utils.m
 import { pnpmLockfileDocuments } from "../../scripts/lib/pnpm-lockfile-documents.mjs";
 import { NATIVE_I18N_LOCALES } from "../../scripts/native-i18n-locales.ts";
 import { resolvePnpmRunner } from "../../scripts/pnpm-runner.mts";
-import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
+import { createTempDirTracker, useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
 
 const CHECKOUT_V6 = "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1";
 const CACHE_V5 = "actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9";
@@ -4432,14 +4433,23 @@ NODE
 
   it.skipIf(process.platform === "win32")(
     "preserves pnpm hard links and validates cached importers offline",
-    () => {
-      const root = tempDirs.make("openclaw-dependency-cache-");
+    async ({ onTestFinished, signal }) => {
+      const fixtureDirs = createTempDirTracker();
+      let stopRegistry: (() => Promise<void>) | undefined;
+      let readyTimeout: NodeJS.Timeout | undefined;
+      // Timeout does not join the test body. Keep close and deletion in one hook,
+      // outside afterEach, so a failed join cannot release the registry's files.
+      onTestFinished(async () => {
+        clearTimeout(readyTimeout);
+        await stopRegistry?.();
+        fixtureDirs.cleanup();
+      });
+      const root = fixtureDirs.make("openclaw-dependency-cache-");
       const source = path.join(root, "source");
       const registry = path.join(root, "registry");
       const workspace = path.join(root, "workspace");
       const consumer = path.join(workspace, "packages", "consumer");
       const store = path.join(workspace, ".cache", "openclaw-pnpm-store");
-      const readyFile = path.join(root, "registry-ready");
       mkdirSync(source, { recursive: true });
       mkdirSync(registry, { recursive: true });
       mkdirSync(consumer, { recursive: true });
@@ -4477,10 +4487,9 @@ NODE
       const tarball = path.join(registry, "cache-proof-dep-1.0.0.tgz");
       const registryScript = String.raw`
 const { createHash } = require("node:crypto");
-const { readFileSync, renameSync, writeFileSync } = require("node:fs");
+const { readFileSync } = require("node:fs");
 const { createServer } = require("node:http");
 const tarballPath = process.argv[1];
-const readyPath = process.argv[2];
 const tarball = readFileSync(tarballPath);
 const server = createServer((request, response) => {
   if (request.url === "/cache-proof-dep") {
@@ -4513,24 +4522,44 @@ const server = createServer((request, response) => {
   response.end();
 });
 server.listen(0, "127.0.0.1", () => {
-  // Publish the complete port before existence can signal readiness to the parent.
-  const pendingPath = readyPath + ".tmp";
-  writeFileSync(pendingPath, String(server.address().port));
-  renameSync(pendingPath, readyPath);
+  process.send(server.address().port);
 });
 `;
-      const registryServer = spawn(process.execPath, ["-e", registryScript, tarball, readyFile], {
-        stdio: "ignore",
+      const registryServer = spawn(process.execPath, ["-e", registryScript, tarball], {
+        stdio: ["ignore", "ignore", "ignore", "ipc"],
       });
-      try {
-        for (let attempt = 0; attempt < 200 && !existsSync(readyFile); attempt += 1) {
-          if (registryServer.exitCode !== null) {
-            throw new Error(`fixture registry exited with ${registryServer.exitCode}`);
-          }
-          Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 10);
+      let registryDidClose = false;
+      // Retain actual close from launch, including failed spawn; readiness must not own this join.
+      const registryClosed = new Promise<void>((resolve) => {
+        registryServer.once("close", () => {
+          registryDidClose = true;
+          resolve();
+        });
+      });
+      const failures: unknown[] = [];
+      registryServer.on("error", (error) => failures.push(error));
+      stopRegistry = async () => {
+        if (!registryDidClose) {
+          registryServer.kill("SIGTERM");
         }
-        expect(existsSync(readyFile)).toBe(true);
-        const registryUrl = `http://127.0.0.1:${readFileSync(readyFile, "utf8")}`;
+        await registryClosed;
+      };
+      try {
+        const port = await new Promise<number>((resolve, reject) => {
+          readyTimeout = setTimeout(() => reject(new Error("fixture registry not ready")), 2_000);
+          registryServer.once("message", (message) => {
+            if (typeof message !== "number") {
+              reject(new Error("fixture registry sent an invalid port"));
+              return;
+            }
+            resolve(message);
+          });
+          registryServer.once("error", reject);
+          void registryClosed.then(() => reject(new Error("fixture registry closed before ready")));
+        });
+        clearTimeout(readyTimeout);
+        signal.throwIfAborted();
+        const registryUrl = `http://127.0.0.1:${port}`;
         writeFileSync(
           path.join(workspace, "package.json"),
           JSON.stringify({
@@ -4617,7 +4646,22 @@ server.listen(0, "127.0.0.1", () => {
           readFileSync(path.join(consumer, "node_modules", "cache-proof-dep", "index.js"), "utf8"),
         ).toBe('module.exports = "cache-proof-v1";\n');
 
-        registryServer.kill("SIGTERM");
+        await stopRegistry();
+        signal.throwIfAborted();
+        expect(registryDidClose, "registry closed before source deletion/offline install").toBe(
+          true,
+        );
+        await expect(
+          new Promise<void>((resolve, reject) => {
+            const socket = connect({ host: "127.0.0.1", port, signal });
+            socket.once("error", reject);
+            socket.once("connect", () => {
+              socket.destroy();
+              resolve();
+            });
+          }),
+        ).rejects.toMatchObject({ code: "ECONNREFUSED" });
+        signal.throwIfAborted();
         rmSync(registry, { force: true, recursive: true });
         const cachedIdentity = statSync(restoredPackageFile);
         const cachedLockfile = readFileSync(path.join(workspace, "pnpm-lock.yaml"), "utf8");
@@ -4640,8 +4684,23 @@ server.listen(0, "127.0.0.1", () => {
         expect(`${drift.stdout}${drift.stderr}`).toContain(
           "cache-proof-dep (lockfile: 1.0.0, manifest: 2.0.0)",
         );
+      } catch (error) {
+        if (failures[0] !== error) {
+          failures.unshift(error);
+        }
       } finally {
-        registryServer.kill("SIGTERM");
+        clearTimeout(readyTimeout);
+        try {
+          await stopRegistry();
+        } catch (error) {
+          failures.push(error);
+        }
+      }
+      if (failures.length === 1) {
+        throw failures[0];
+      }
+      if (failures.length > 1) {
+        throw new AggregateError(failures, "dependency cache fixture failed");
       }
     },
   );


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where the dependency-cache fixture requested registry termination but began deleting its source and running offline reconciliation without proving that the registry child had closed. This is bounded maintainer-requested fixture correctness work, not a claim that an observed process leak caused other macOS failures.

## Why This Change Was Made

The fixture now receives readiness through IPC from the HTTP listen callback, retains the actual child-close promise from launch, and joins shutdown before checking connection refusal and starting offline reconciliation. One fixture-local `onTestFinished` owner joins shutdown before deleting directories; cancellation checks prevent a timed-out test body from resuming work. Primary errors remain first and cleanup errors are preserved.

This replaces readiness-file polling and kill-without-join ordering. It reuses `createTempDirTracker`; the shared timed `waitForChildClose` helper cannot retain eventual closure once its deadline rejects. No parent IPC disconnect is introduced. The existing 120-second test budget, 2-second readiness budget, Windows skip, and all hard-link, archive/restore, importer-content, frozen-lockfile, inode, and lockfile-drift assertions remain intact.

## User Impact

No product behavior changes. Developers get a real offline boundary and timeout-safe ownership in the existing cache fixture. Only `test/scripts/ci-workflow-guards.test.ts` changes: production +0/-0; tests +81/-22. No dependencies, production hooks, mocks, or configuration changes. AI-assisted; the implementation and its ownership contracts were reviewed directly.

## Evidence

- Final Linux real-pnpm proof and full-flow mutation: https://github.com/openclaw/openclaw/actions/runs/33254894657. Candidate passed (1.13 seconds); removing the shutdown join failed the exact `registry closed before source deletion/offline install` assertion, then the restored candidate passed. The delegated Testbox completed with exit code 0 and was stopped.
- Final macOS Node 24: `node scripts/run-vitest.mjs test/scripts/ci-workflow-guards.test.ts -t 'preserves pnpm hard links and validates cached importers offline'` passed: 1 test, 165 skipped, 77.31-second body.
- Twelve real-child lifecycle diagnostic scenarios using the installed Vitest runner passed, including spawn/setup failure, early exit, absent readiness, primary plus cleanup errors, retained files after failed join, and cancellation during readiness/close/socket waits. Removing cancellation checks failed the continuation assertion. These are retained diagnostics, not additional committed tests. The landing worker independently reran all twelve on Node 24.
- `git diff --check` and targeted `oxfmt --check` passed.
- Known local limitations: a final Node 26 run missed the unchanged 120-second deadline (129.18-second body); its owned PID/root were confirmed gone. An original full-flow mutation also timed out and is not regression proof. Local changed checks/typecheck and lint are blocked by dependency-installation mismatches: ACPX declarations, duplicate incompatible markdown-it types, missing pi-tui exports, and UI Vitest type depth. All eight type diagnostics reproduced with exact original HEAD test bytes. No shared dependencies or gates were weakened; exact-head hosted CI is required before landing.
- Fresh landing-worker Node 24 rerun also missed the unchanged deadline (192.70-second body): the unchanged `pnpm --silent run pnpm-path` bootstrap was directly observed still running after three minutes, before the registry child existed. An attempted diagnostic termination found that bootstrap had already exited; no signal was delivered. This run is a failure, not additional passing proof, and does not establish causality for other macOS failures.
- Fresh isolated Codex autoreview of the exact uncommitted diff returned no accepted/actionable findings at the required P0 threshold.
- One mechanical rebase integrated current main; `git range-diff` reports the fixture patch unchanged. All twelve lifecycle scenarios passed again with main's updated temp-directory helper. Exact-head CI follows below before native prepare/merge.
- Exact published-head CI passed: https://github.com/openclaw/openclaw/actions/runs/33258175878 on `f9ce4f371cb0779506260e80c05a0be6b7b38e25`. `checks-node-compact-small-35` / `core-tooling-6` ran the named fixture successfully in 1,420 ms. Build, types, lint, guards, and the selected Node matrix passed.
- Native `review-validate-artifacts` passed with zero findings; `OPENCLAW_TESTBOX=1 scripts/pr prepare-run 132636` passed hosted gates and verified the unchanged remote head. The latest ClawSweeper review has no findings, rank-up moves, or before-merge changes; the explicit maintainer landing direction supplies its remaining merge decision.
