### PR TITLE
docs: clarify paired-node Codex continuation limits

### DIFF
--- a/docs/nodes/index.md
+++ b/docs/nodes/index.md
@@ -366,13 +366,22 @@ By default, selecting a row opens the normal Chat pane and reads its persisted t
 through bounded, cursor-paginated
 `thread/turns/list` calls with full item projection. Use the row menu, the viewer header, or the **Open Codex/Claude sessions in** preference to start `codex resume <thread-id>` in the operator terminal on the computer that owns the session. The paired-node terminal path is an allowlisted PTY relay owned by the Codex plugin, not arbitrary node command execution.
 
-The relay does not provide the full OpenClaw harness continuation and archive ownership contracts. **Continue** and **Archive** are therefore unavailable for remote rows. On the Gateway computer, stored and idle
-rows can start a distinct model-locked Chat branch. Either can be archived only
-after the operator confirms that no other Codex client is using it; a stored
-row's live activity remains unknown. Active rows cannot branch or archive.
+The terminal relay is separate from paired-node Chat continuation. A connected
+node that advertises and permits both catalog commands plus
+`codex.cli.session.resume` can continue a stored or idle interactive thread for
+an operator with `operator.admin`. The Chat mirrors bounded visible history;
+later messages run native Codex CLI resume against the exact thread on that
+node and return the final text, without a streaming App Server harness bridge.
+Nodes without the required commands remain readable without Chat continuation.
+Paired-node **Archive** is unavailable.
+
+On the Gateway computer, stored and idle rows can start a distinct model-locked
+Chat branch. Either can be archived only after the operator confirms that no
+other Codex client is using it; a stored row's live activity remains unknown.
+Active rows cannot branch or archive.
 
 See [Supervise Codex sessions](/plugins/codex-supervision) for setup,
-pagination, local continuation, and the metadata security boundary.
+pagination, local and paired-node continuation, and the metadata security boundary.
 
 ### Claude sessions and transcripts
 

--- a/docs/plugins/codex-harness-reference.md
+++ b/docs/plugins/codex-harness-reference.md
@@ -151,8 +151,13 @@ enumeration errors, cycles, or safety-limit exhaustion. Confirmation still
 covers unknown native clients and the status-to-archive race. A supervised
 model-locked Chat cannot be deleted while it protects the native binding.
 Active sources cannot create a branch or be archived, but an existing supervised
-Chat can still be opened. Every paired-node row stays read-only; the node
-transport does not yet provide the streaming lifecycle needed by the harness.
+Chat can still be opened. Paired-node continuation requires `operator.admin`, a
+stored or idle interactive thread, and a connected node advertising and
+permitting the catalog list, transcript read, and `codex.cli.session.resume`
+commands. It binds Chat to native CLI resume on that node, not the local branch
+flow or a streaming App Server harness. Other paired-node rows remain readable,
+and paired-node archive is unavailable. See
+[paired-node limits](/plugins/codex-supervision#understand-paired-node-limits).
 
 `appServer.homeScope: "user"` alone changes which Codex home a managed harness
 process uses; it does not publish the fleet catalog. Enabling supervision does

--- a/docs/plugins/codex-harness-runtime.md
+++ b/docs/plugins/codex-harness-runtime.md
@@ -131,11 +131,15 @@ in another process, so confirmation covers unknown clients and the gap between
 status read and archive. A supervised model-locked Chat cannot be deleted while
 it protects the native binding.
 
-Paired-node catalogs stay metadata-only in the initial release. The current
-node invoke boundary is request/response and cannot carry the long-lived turn
-events, approval requests, or streaming output required by a real Codex harness
-binding. Remote **Continue** and **Archive** therefore remain unavailable even
-when the row is idle.
+Paired-node catalogs expose bounded, paginated transcripts. Eligible stored or
+idle rows can also create or reopen a model-locked Chat when the connected node
+advertises and permits the catalog list, transcript read, and
+`codex.cli.session.resume` commands, and the operator has `operator.admin`.
+Later messages resume the exact native thread through the node's Codex CLI and
+return its final text; this is not the Gateway-local branch flow or a streaming
+App Server harness bridge. Nodes without those capabilities remain readable
+without continuation, and paired-node archive remains unavailable. See
+[paired-node limits](/plugins/codex-supervision#understand-paired-node-limits).
 
 See [Codex supervision](/plugins/codex-supervision) for operator setup and the
 visible Control UI behavior.

--- a/docs/plugins/codex-harness.md
+++ b/docs/plugins/codex-harness.md
@@ -362,9 +362,14 @@ snapshot, canonical branch, and later turns while ordinary Codex sessions remain
 agent-scoped. The first canonical start uses exactly the model and provider that
 Codex returns for the snapshot fork. Later resumes leave selection to Codex's
 native configuration; the outer OpenClaw model and fallback chain never replace
-it. Stored and idle rows can be archived after explicit no-other-runner
+it. Stored and idle local rows can be archived after explicit no-other-runner
 confirmation. Active sources cannot create a branch or be archived; an existing
-supervised Chat can still be opened. Paired-node sessions remain metadata-only.
+supervised Chat can still be opened. Paired-node sessions expose bounded,
+paginated transcripts. Eligible stored or idle paired-node rows also support
+continuation for `operator.admin` when the node advertises and permits the
+required catalog and CLI-resume commands. That flow resumes the exact native
+thread on the node rather than creating a Gateway-local branch; paired-node
+archive remains unavailable.
 
 See [Supervise Codex sessions](/plugins/codex-supervision) for setup, branching
 rules, paired-node limits, metadata exposure, and troubleshooting.

--- a/docs/plugins/codex-supervision.md
+++ b/docs/plugins/codex-supervision.md
@@ -4,7 +4,7 @@ title: "Supervise Codex sessions"
 sidebarTitle: "Codex supervision"
 read_when:
   - You want Codex Desktop or CLI sessions to appear in OpenClaw
-  - You need to branch from or archive a stored or idle local Codex session
+  - You need to continue a stored or idle Codex session or archive a local one
   - You are exposing Codex sessions and transcript history from paired nodes
 ---
 
@@ -13,7 +13,7 @@ shows non-archived Codex CLI, VS Code, Atlas, and ChatGPT source sessions from
 the Gateway computer and opted-in paired computers in the normal sessions
 sidebar and Chat pane.
 
-The initial release deliberately keeps ownership narrow:
+Supported actions depend on the source host and its capabilities:
 
 - A stored or idle local session can create a model-locked OpenClaw Chat from
   its bounded persisted user and assistant history. The first message starts a
@@ -23,16 +23,18 @@ The initial release deliberately keeps ownership narrow:
   supervised binding prevents OpenClaw from substituting another runtime,
   model, or fallback. A separate native Codex control can still change that
   persisted pair. An already-created branch opens its existing Chat.
-- A stored session discovered from another Codex process has unknown live
+- A stored local session discovered from another Codex process has unknown live
   activity. It can branch, or it can be archived only after the operator
   confirms that no other Codex client is using it.
 - An active source stays visible but cannot create a branch or be archived until
   its current turn finishes. If it already has a supervised Chat, **Open Chat**
   remains available.
 - A session on a paired node exposes its persisted transcript through bounded,
-  cursor-paginated App Server reads. Remote continuation
-  requires a future streaming node bridge; remote archive additionally requires
-  a runner-ownership lease or equivalent fencing.
+  cursor-paginated App Server reads. A stored or idle interactive session can
+  also continue in Chat when the node permits the required catalog and
+  CLI-resume commands and the operator has `operator.admin`. Later messages
+  resume the exact native thread on that node, not a Gateway-local branch.
+  Paired-node archive remains unavailable.
 - Archived sessions are not listed. A stored or idle local session can be
   archived only after the operator confirms that no other Codex client is using
   it.
@@ -99,7 +101,7 @@ Set `appServer.homeScope: "user"` explicitly if the harness should share native
 Codex state too. Supervision honors explicit `appServer` connection settings
 instead of replacing them with its local user-home default.
 
-A Chat adopted from the **Codex** sidebar group is not an ordinary harness session.
+A Gateway-local Chat adopted from the **Codex** sidebar group is not an ordinary harness session.
 Its private supervision binding uses the supervision connection for source
 reads, canonical branch creation, history injection, and every later turn. With
 the default local connection, that preserves the native user Codex home, auth,
@@ -189,12 +191,17 @@ All three commands accept `--agent <id>` and inherit `--url`, `--token`, and `--
 Gateway client. Session listing defaults to 75,000 ms so cold paired-node
 catalogs can complete; continue and archive default to 30,000 ms. They also expose the shared
 `--expect-final` switch, which does not change these unary supervision RPCs.
-Each command requires the `operator.write` Gateway scope.
+Each shell command requests the `operator.write` Gateway scope.
 Standard `-h, --help` output is available on each subcommand.
 There is no archived or include-archived option. `sessions` can list paired
 hosts. `continue` and `archive` default to `gateway:local`; pass the listed
-opaque local `--host` id to target another local Codex store. Paired rows remain
-list-only. Archive always requires `--confirm-no-other-runner`.
+opaque local `--host` id to target another local Codex store. The shell
+`continue` command requests only `operator.write`; passing a node host does not
+request the `operator.admin` scope required for paired-node continuation. Unless
+the Gateway separately grants that scope to the authenticated identity, the
+request is refused. Use the admin-authorized Control UI flow described below
+for paired-node continuation. Archive remains Gateway-local and always requires
+`--confirm-no-other-runner`.
 
 These shell commands are distinct from the in-chat `/codex` runtime commands.
 `/codex threads [filter]` lists App Server threads available to the current
@@ -344,11 +351,39 @@ endpoints. Opening a row in the operator terminal runs `codex resume <thread-id>
 on the owning host and relays that command's PTY; it does not expose a general
 shell or gateway-supplied argv.
 
-The terminal relay does not provide the harness continuation or archive ownership
-contracts. Remote rows therefore remain visible but do not offer **Continue** or
-**Archive**, even when the remote thread is idle. Use Codex on that computer
-through **Open in terminal**, or use a future continuation flow with a safe
-runner-ownership boundary.
+Chat continuation is a separate capability from the terminal relay. It requires
+`operator.admin` and a connected node that both advertises and permits all three
+commands:
+
+- `codex.appServer.threads.list.v1`
+- `codex.appServer.thread.turns.list.v1`
+- `codex.cli.session.resume`
+
+The CLI-resume command is a dangerous node command: it needs explicit Gateway
+command allowlisting (`gateway.nodes.commands.allow`) as well as approval of
+the node's command surface; a deny rule still blocks it. The native macOS catalog
+and terminal relay alone do not provide it, although a Mac app's embedded node
+worker can advertise additional commands. Check the actual advertised and
+permitted commands, not just the host platform. Nodes exposing only list,
+transcript, and terminal commands remain readable without Chat continuation.
+
+Open an eligible non-archived interactive row in the Control UI Chat pane and
+send a text message. Continuation freshly checks that the source is `idle` or
+`notLoaded`, creates or reopens a model-locked Chat, and binds it to the exact
+native thread on the owning node. A new Chat mirrors bounded user and assistant
+history from the newest transcript page. The catalog action itself does not
+fork or resume the native thread; the UI then forwards your draft to the bound
+Chat. That message and later turns run `codex exec resume` on the node with its
+native CLI configuration and return its final text. This text-prompt path does
+not create the Gateway-local branch or forward the full App Server harness
+events, approvals, tool calls, or structured attachments. Bound turns still
+require owner/admin authority and are blocked while OpenClaw sandboxing is active.
+
+Avoid running the same thread in another Codex client while using this Chat.
+The node prevents overlapping OpenClaw resume turns within its own process, but
+`notLoaded` does not prove that another native client is idle and there is no
+cross-process runner lease. Paired-node **Archive** remains unavailable,
+regardless of continuation or terminal capabilities.
 
 ## Metadata and permissions
 
@@ -364,7 +399,9 @@ Catalog projection excludes transcript previews, turns, rollout paths,
 the Codex home path, Git remotes, commit SHAs, and raw App Server errors. Catalog
 access and Control UI transcript reads require the `operator.write` Gateway
 scope because fleet aggregation uses the standard `node.invoke` path, even
-though both node commands are read-only.
+though both catalog node commands are read-only. Paired-node continuation
+additionally requires `operator.admin`; subsequent bound turns enforce the
+native-execution owner/admin check.
 
 `supervision.allowRawTranscripts` and `supervision.allowWriteControls` govern
 autonomous agent and standalone MCP tools. Both default to `false`. With
@@ -419,10 +456,13 @@ plugin and `supervision.enabled` are true, the current plugin allowlist permits
 `codex`, and the sessions are not archived. Restart the Gateway or node after
 changing activation.
 
-**Continue is disabled:** an unmapped row is active, belongs to a paired node,
-its host is offline, or another action is pending. Gateway-local stored and idle
-rows offer **Continue as branch** instead of unsafe exact-thread takeover. A row
-that already has a supervised Chat offers **Open Chat**.
+**Continue is disabled or refused:** an unmapped row is active or in an
+ineligible state, its host is offline, or another action is pending. For a
+paired-node row, also verify `operator.admin` and that all three continuation
+commands are advertised and permitted; terminal access alone is insufficient.
+Gateway-local stored and idle rows offer **Continue as branch** instead of
+unsafe exact-thread takeover. A row that already has a supervised Chat offers
+**Open Chat**.
 
 **Archive is disabled:** archive is available for stored/activity-unknown and
 idle Gateway-local rows after no-other-runner confirmation. Active, error,

--- a/docs/specs/codex-supervision.md
+++ b/docs/specs/codex-supervision.md
@@ -11,8 +11,9 @@ read_when:
 
 ## Goal
 
-Codex supervision lets an OpenClaw operator discover native Codex sessions and,
-when safe, create a local branch through the normal OpenClaw Chat surface.
+Codex supervision lets an OpenClaw operator discover native Codex sessions,
+create a Gateway-local branch, or continue an eligible paired-node thread
+through the normal OpenClaw Chat surface.
 Codex App Server remains the thread and model-loop owner. OpenClaw supplies the
 fleet catalog, authenticated operator UI, session binding, and channel delivery.
 
@@ -34,14 +35,17 @@ Enable agent-facing supervision tools with:
 plugins.entries.codex.config.supervision.enabled = true
 ```
 
-The active initial product is intentionally smaller than the long-term fleet
-plan:
+The current product supports:
 
 - List only non-archived Codex threads.
 - Group local and opted-in paired-node rows by stable host identity.
 - Create a normal, model-locked Chat branch from a stored or idle Gateway-local
   thread, start its full Codex harness thread on the first turn, or open the Chat
   created for an earlier branch.
+- Continue a stored or idle paired-node thread through a model-locked Chat when
+  the node's catalog and CLI-resume commands are advertised and invocable, and
+  the caller has `operator.admin`. Later messages resume that exact native
+  thread on its node rather than creating the Gateway-local branch described below.
 - Archive a stored or idle Gateway-local thread only after explicit
   no-other-runner confirmation.
 - Show active local sources without new-branch or archive controls while still
@@ -100,8 +104,8 @@ stored threads. Explicit `appServer` connection settings are honored. When
 `homeScope` is unset, the supervision connection resolves it to `"user"` for stdio
 or Unix and `"agent"` for WebSocket. Set `appServer.homeScope: "user"`
 explicitly only when the ordinary harness should also share the native Codex
-home. A Chat adopted from the Codex sidebar group is the exception: its private
-supervision binding keeps source reads, canonical branch creation, and later
+home. A Gateway-local Chat adopted from the Codex sidebar group is the exception:
+its private supervision binding keeps source reads, canonical branch creation, and later
 turns on the supervision connection. Live status and ownership remain
 process-local; a thread unknown to OpenClaw's supervision process is `notLoaded`
 even when Codex Desktop is actively running it.
@@ -172,8 +176,8 @@ The plugin registers three Gateway-backed shell commands:
 
 ```text
 openclaw codex sessions [--search <text>] [--host <id>] [--limit <count>] [--cursor <cursor>] [--json] [gateway-options]
-openclaw codex continue <thread-id> [--json] [gateway-options]
-openclaw codex archive <thread-id> --confirm-no-other-runner [--json] [gateway-options]
+openclaw codex continue <thread-id> [--agent <id>] [--host <id>] [--json] [gateway-options]
+openclaw codex archive <thread-id> --confirm-no-other-runner [--agent <id>] [--host <id>] [--json] [gateway-options]
 ```
 
 `[gateway-options]` is `--url <url>`, `--token <token>`, `--timeout <ms>`, and
@@ -184,9 +188,15 @@ is title-only and case-insensitive; each response scans a bounded native page
 chain, and `--cursor` continues older results. The limit defaults to 50 per host
 and accepts 1 through 100, and a cursor requires one stable `--host`
 destination. No command accepts
-an archived/include-archived option. Only `sessions` can target paired hosts;
-`continue` and `archive` always send `hostId: "gateway:local"`, and archive
-requires the explicit confirmation flag.
+an archived/include-archived option. All three commands accept `--agent <id>`
+and `--host <id>`. `continue` and `archive` default to `gateway:local`; a listed
+opaque local host id selects another local store. The shell commands request
+only `operator.write`, so passing a node host to `continue` does not by itself
+satisfy the paired-node provider's `operator.admin` requirement. It is refused
+unless the Gateway separately grants that scope to the authenticated identity.
+The recommended paired-node continuation surface is the admin-authorized
+Control UI path described below.
+Archive remains Gateway-local and requires the explicit confirmation flag.
 
 The shell namespace is not the in-chat `/codex` runtime namespace. In
 particular, `/codex sessions --host <node>` lists Codex CLI session files on one
@@ -317,8 +327,8 @@ Therefore:
 
 - passive catalog clients do not subscribe or auto-deny approvals
 - rows currently reported active expose neither a new branch nor Archive
-- an unmapped source becomes a visible-history branch whose canonical harness
-  thread never resumes the source
+- an unmapped Gateway-local source becomes a visible-history branch whose
+  canonical harness thread never resumes the source
 - `notLoaded` is shown as activity unknown and can be archived only after
   informed no-other-runner confirmation
 - local archive requires that confirmation plus a fresh `idle` or `notLoaded`
@@ -329,15 +339,46 @@ implied by showing an active row.
 
 ## Paired-node boundary
 
-Node invoke is currently request/response only. It can safely return bounded
-catalog metadata and transcript turn pages, but it cannot carry the long-lived event stream, approval
-requests, tool calls, cancellation, and assistant deltas required by a Codex
-harness run.
+Paired-node continuation uses the existing request/response Codex CLI resume
+command, not a remote App Server harness stream. The node must be connected,
+and all three commands must be both advertised and permitted by the Gateway's
+node invocation policy:
 
-The node contract therefore supports list and transcript-turn pages. Remote
-rows stay readable, but **Continue** and **Archive** are unavailable, regardless of idle status. A
-real remote continuation requires a node-side runner and streaming bridge that
-preserves the same approval and binding invariants as the local harness.
+- `codex.appServer.threads.list.v1`
+- `codex.appServer.thread.turns.list.v1`
+- `codex.cli.session.resume`
+
+The resume command is dangerous and requires explicit
+`gateway.nodes.commands.allow` authorization in addition to the node's approved
+command surface; `gateway.nodes.commands.deny` still takes precedence. The
+native macOS catalog and terminal relay alone do not advertise this CLI-resume
+command, but the Mac app can merge additional commands from its embedded node
+worker. Eligibility follows the live command set, not the host platform.
+
+`sessions.catalog.continue` requires `operator.admin` before joining any pending
+adoption. It rechecks the live node capabilities and freshly locates the source
+in the non-archived catalog. Only interactive `idle` or `notLoaded` rows qualify;
+active, error, archived, unavailable, or non-interactive sources are rejected.
+For a new Chat, it reads one bounded page of up to 50 newest turns and imports
+visible user and assistant history through the last terminal turn in that page,
+using the same history-size limits as local continuation.
+
+The plugin creates or reuses an agent-qualified, model-locked Chat and returns
+a `codex-cli-node-session` conversation binding containing the exact thread id,
+node id, owning agent, and cwd. The Gateway installs the binding before the
+plugin finalizes or unhides the Chat. No native fork or resume occurs during
+this catalog action. Later authorized messages run `codex exec resume` against
+that exact native thread on the owning node, with the prompt on stdin, and
+return the final text using the node's native CLI configuration. They do not
+start the Gateway-local canonical branch or forward the full App Server
+approval, tool, and delta stream or structured attachments. Bound turns retain
+the owner/admin check and are blocked while OpenClaw sandboxing is active.
+
+The node runner rejects overlapping OpenClaw resume turns for the same thread
+within its process; it does not provide a lease across native Codex clients.
+Operators must avoid concurrent use of that thread elsewhere. Nodes missing the
+required capabilities remain readable without Chat continuation. Paired-node
+archive remains prohibited; the terminal relay does not change either gate.
 
 ## Permissions
 
@@ -345,9 +386,11 @@ Each computer opts in locally. Enabling the Gateway does not authorize another
 node to read its Codex metadata. The node capability must pass normal pairing
 and command-policy approval.
 
-Fleet listing and transcript viewing use the `operator.write` Gateway scope
-because they invoke paired nodes. Local continuation and archive are
-authenticated operator actions and remain subject to host and status checks.
+Fleet listing, transcript viewing, local continuation, and archive use the
+`operator.write` Gateway scope. Paired-node continuation additionally requires
+`operator.admin`, and subsequent bound turns retain the native-execution
+owner/admin authorization check. Neither scope bypasses node connectivity,
+command approval, invocation policy, or source eligibility checks.
 
 Autonomous agent and standalone MCP access is separate. The shipped
 `codex_endpoint_probe`, `codex_sessions_list`, `codex_session_read`,
@@ -390,7 +433,7 @@ without a second runtime facade.
 
 ## Future work
 
-- node-side streaming runner and event bridge for remote continuation
+- full remote App Server harness streaming beyond the current CLI-resume path
 - explicit runner and approval-owner leases for simultaneous client handoff
 - remote archive after a runner-ownership lease or equivalent fencing exists
 - interrupt and richer active-session observation
@@ -439,7 +482,15 @@ surfaces remain the recovery path for archived threads.
   explicit confirmation remains responsible for unknown clients and the
   status-to-archive race.
 - Confirmed stored or idle local archive removes the row after native success.
-- Paired-node rows remain visible without Continue or Archive.
+- Paired-node continuation requires a connected node with all three commands
+  advertised and invocable, an interactive `idle` or `notLoaded` source, and
+  `operator.admin`; missing authority is rejected before adoption deduplication.
+- Paired-node continuation creates or reuses a model-locked Chat with bounded
+  history and installs its conversation binding before finalizing visibility.
+  Later authorized messages resume the exact native thread on its node, not a
+  session-family sibling or a Gateway-local branch.
+- Paired-node rows without continuation capabilities remain readable, and no
+  paired-node row offers Archive.
 - Passive listing never subscribes to or answers thread approvals.
 - Legacy Supervisor config migrates to the canonical Codex config shape.
 - Legacy list is loaded-only by default, stored enumeration obeys its per-endpoint


### PR DESCRIPTION
Related context: #104261 (larger leased remote-supervision proposal; remains open).

## What Problem This Solves

The Codex supervision guide and architecture spec describe every paired-node source as view-only and defer continuation to a future streaming bridge. Four linked harness and node pages repeat the same obsolete limit. Current main already supports capability-gated paired-node continuation through the native Codex CLI, so those statements hide a supported operator flow and conflate it with full remote App Server supervision.

## Why This Change Was Made

Correct only the existing documentation. Explain the three advertised-and-invocable node commands, effective `operator.admin` requirement, dangerous-command allowlisting, eligible source states, and the model-locked Chat binding. Subsequent text messages resume the exact native thread on its owning node and return the completed reply; they do not create the Gateway-local canonical branch or provide a full streaming App Server harness bridge. Paired-node archive remains unavailable.

Keep the shell CLI caveat explicit: `codex continue` requests only `operator.write`; selecting a node host does not itself request admin authority. The admin-authorized Control UI is the recommended path unless the Gateway separately grants the authenticated identity the required scope. Native Mac eligibility follows its actual command set, including any embedded worker commands, rather than its platform label.

No runtime, schema, persistence, SDK authority, configuration, adoption naming policy, or initialized canonical-descendant fork design changes. The larger [leased remote-supervision proposal](https://github.com/openclaw/openclaw/issues/104261) remains separate and is not closed by this documentation correction.

## User Impact

Operators can distinguish supported buffered CLI continuation from Gateway-local branching, terminal relay, and future leased/streaming supervision. The docs retain the remote archive prohibition, cross-process concurrency warning, per-turn owner/admin and sandbox checks, and the text-only transport limitations.

Documentation only: six pages, +175/-61 lines. Production LOC: +0/-0. Tests: +0/-0.

## Evidence

Source-audited entry points and owners:

- `extensions/codex/src/session-catalog.ts` and `extensions/codex/src/session-catalog-node-continue.ts`: node dispatch, connected/advertised/invocable conjunction, fresh source eligibility, admin check before deduplication, and exact thread binding.
- `extensions/codex/src/node-cli-sessions.ts`, `extensions/codex/src/conversation-binding.ts`, and `extensions/codex/src/command-authorization.ts`: buffered native CLI execution, subsequent authorization, process-local serialization, and final-text delivery.
- `extensions/codex/src/session-cli.ts`, `src/cli/gateway-rpc.runtime.ts`, and `src/gateway/server/ws-connection/connect-admission.ts`: requested CLI scope versus effective identity scopes.
- `src/gateway/server-methods/session-catalog.ts`, `src/gateway/server-plugins-node-runtime.ts`, `src/gateway/node-command-policy.ts`, and `src/gateway/node-invoke-plugin-policy.ts`: binding-before-finalization, current capability projection, allow/deny policy, and dispatch revalidation.
- Control UI catalog composer/continuation callers and native Mac worker-manifest merging were inspected. Existing node continuation, listing, archive, CLI, conversation-binding, transcript-mirror, and Gateway catalog tests were read.

Direct sibling Codex inspection used the pinned `rust-v0.150.1` source (`90854393966b21e9ebfd21b122334eb09a20c93d`): [CLI resume dispatch](https://github.com/openai/codex/blob/90854393966b21e9ebfd21b122334eb09a20c93d/codex-rs/exec/src/lib.rs#L818-L842), [native resume configuration](https://github.com/openai/codex/blob/90854393966b21e9ebfd21b122334eb09a20c93d/codex-rs/exec/src/lib.rs#L1201-L1226), [exact UUID resolution](https://github.com/openai/codex/blob/90854393966b21e9ebfd21b122334eb09a20c93d/codex-rs/exec/src/lib.rs#L1644-L1649), and [resume appends to the existing thread regression](https://github.com/openai/codex/blob/90854393966b21e9ebfd21b122334eb09a20c93d/codex-rs/exec/tests/suite/resume.rs#L686-L738).

Completed local documentation checks:

```bash
pnpm docs:list
node scripts/check-docs-mdx.mjs docs/plugins/codex-supervision.md docs/specs/codex-supervision.md docs/plugins/codex-harness.md docs/plugins/codex-harness-reference.md docs/plugins/codex-harness-runtime.md docs/nodes/index.md
node scripts/docs-link-audit.mjs
node --import ./scripts/tsx.mjs scripts/check-docs-i18n-glossary.mts
node_modules/.bin/oxfmt --check docs/nodes/index.md docs/plugins/codex-harness-reference.md docs/plugins/codex-harness-runtime.md docs/plugins/codex-harness.md docs/plugins/codex-supervision.md docs/specs/codex-supervision.md
git diff --check
```

The installed oxfmt check passed for all six files. MDX passed for all six files. The internal-link audit reported 6,992 links and zero broken links. Newly introduced anchors were checked directly. The optional whole-repository anchor crawl was stopped without a result.

Proof limits: two targeted runtime test attempts stalled during startup before reporting any test results and were stopped; they are not passing proof. A read-only live `node.list` inspection found no connected node advertising the complete continuation command set, so no positive native continuation roundtrip was attempted. No operator capabilities, configuration, or live sessions were changed. This PR corrects documentation of existing behavior and makes no runtime change; it does not claim new end-to-end runtime proof.

Independent precommit autoreview completed successfully with no findings. An initial local tooling attempt was blocked by mismatched esbuild installation and a missing formatter; after `pnpm install --frozen-lockfile`, all focused documentation checks above passed on retry without tracked dependency changes.

Exact-head CI passed for `c2b5e305fbe1fc5fa416f6055f4764a0c8225de7`: [CI run 33258246199](https://github.com/openclaw/openclaw/actions/runs/33258246199), including `preflight`, `security-fast`, `check-docs`, and required `openclaw/ci-gate`.

ClawSweeper’s completed review found no actionable patch findings; its dependency-proof request and sole Rank-up move are resolved by the direct pinned-Codex inspection linked above. The acting landing reviewer personally read those source ranges in the sibling checkout, confirming exact UUID thread resume, native configuration, and the upstream append regression. This is source/test inspection, not a newly run runtime test. No rank-up item is skipped.

AI-assisted documentation investigation and editing.
