### PR TITLE
fix(ci): stop downloading a second repository copy for the CI harness

### DIFF
--- a/.github/actions/git-owner/owner.py
+++ b/.github/actions/git-owner/owner.py
@@ -350,9 +350,17 @@ def checkout():
     os.makedirs(harness, exist_ok=True)
     run_git(harness, "init", harness)
     run_git(harness, "remote", "add", "origin", remote)
-    fetch(harness, f"+{os.environ['WORKFLOW_SHA']}:refs/remotes/origin/ci-harness", max_attempts=1)
+    # The harness only supplies .github/actions, so narrow the fetch before it runs:
+    # sparse first, then blob-less. A full snapshot here downloads a second copy of
+    # the repository that the checkout below immediately discards, and every extra
+    # byte is amplified by the shared runner egress.
     run_git(harness, "sparse-checkout", "set", ".github/actions")
-    run_git(harness, "checkout", "--force", "--detach", os.environ["WORKFLOW_SHA"])
+    fetch(harness, f"+{os.environ['WORKFLOW_SHA']}:refs/remotes/origin/ci-harness",
+          max_attempts=1, blobless=True)
+    # Checkout now materializes the sparse blobs over the network, so it carries the
+    # fetch deadline instead of running unbounded like a local checkout.
+    run_git(harness, "checkout", "--force", "--detach", os.environ["WORKFLOW_SHA"],
+            timeout=fetch_timeout_seconds)
     if not os.path.isfile(os.path.join(harness, action)):
         raise GitFailure(1)
     check_cancelled()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -559,9 +559,17 @@ jobs:
               os.makedirs(harness, exist_ok=True)
               run_git(harness, "init", harness)
               run_git(harness, "remote", "add", "origin", remote)
-              fetch(harness, f"+{os.environ['WORKFLOW_SHA']}:refs/remotes/origin/ci-harness", max_attempts=1)
+              # The harness only supplies .github/actions, so narrow the fetch before it runs:
+              # sparse first, then blob-less. A full snapshot here downloads a second copy of
+              # the repository that the checkout below immediately discards, and every extra
+              # byte is amplified by the shared runner egress.
               run_git(harness, "sparse-checkout", "set", ".github/actions")
-              run_git(harness, "checkout", "--force", "--detach", os.environ["WORKFLOW_SHA"])
+              fetch(harness, f"+{os.environ['WORKFLOW_SHA']}:refs/remotes/origin/ci-harness",
+                    max_attempts=1, blobless=True)
+              # Checkout now materializes the sparse blobs over the network, so it carries the
+              # fetch deadline instead of running unbounded like a local checkout.
+              run_git(harness, "checkout", "--force", "--detach", os.environ["WORKFLOW_SHA"],
+                      timeout=fetch_timeout_seconds)
               if not os.path.isfile(os.path.join(harness, action)):
                   raise GitFailure(1)
               check_cancelled()

--- a/test/scripts/ci-linux-git.test.ts
+++ b/test/scripts/ci-linux-git.test.ts
@@ -1,12 +1,16 @@
 import path from "node:path";
+import { expectDefined } from "@openclaw/normalization-core";
 import { expect, it } from "vitest";
 import { runCiGitStep, type FetchResult } from "./ci-git-owner.test-support.js";
 
 const candidate = "a".repeat(40);
+const harness = "b".repeat(40);
 const base = "c".repeat(40);
 const moved = "d".repeat(40);
 const merge = "e".repeat(40);
 const linuxIt = it.skipIf(process.platform !== "linux");
+// Command-shape assertions need no process-group census, so they also run on macOS.
+const posixIt = it.skipIf(process.platform === "win32");
 
 const resetProfiles = [
   {
@@ -437,6 +441,40 @@ linuxIt(
     expect(report.code).toBe(2);
     expect(report.fetches).toEqual([]);
     expect(report.readyAttempts).toEqual([]);
+  },
+  55_000,
+);
+
+posixIt(
+  "fetches the CI harness without a second full-repository snapshot",
+  async () => {
+    const report = await runCiGitStep({ job: "checks-fast-core", fetchResults: [0, 0] });
+    expect(report.code).toBe(0);
+    const harnessDirectory = path.join(report.workspace, ".ci-harness");
+    const harnessCommands = report.commands.filter(
+      ({ tool, cwd }) => tool === "git" && cwd === harnessDirectory,
+    );
+    // The harness supplies only .github/actions: narrowing must be in place before the
+    // fetch runs, so it never downloads the blobs the sparse checkout discards.
+    expect(harnessCommands.map(({ args }) => args[0])).toEqual([
+      "init",
+      "remote",
+      "sparse-checkout",
+      "fetch",
+      "checkout",
+    ]);
+    const harnessFetch = expectDefined(
+      harnessCommands.find(({ args }) => args[0] === "fetch"),
+      "harness fetch",
+    );
+    expect(harnessFetch.args).toEqual(expect.arrayContaining(["--filter=blob:none"]));
+    expect(harnessFetch.args.at(-1)).toBe(`+${harness}:refs/remotes/origin/ci-harness`);
+    // The selected checkout still needs real file contents, so it must stay unfiltered.
+    const workspaceFetch = expectDefined(
+      report.fetches.find(({ cwd }) => cwd === report.workspace),
+      "workspace fetch",
+    );
+    expect(workspaceFetch.args).not.toContain("--filter=blob:none");
   },
   55_000,
 );


### PR DESCRIPTION
## What Problem This Solves

Every CI job's `Checkout` step downloads the repository **twice**. After fetching the
selected commit into the workspace, the step builds a second Git repository in
`.ci-harness` to obtain `.github/actions`, and fetches it as a full `--depth=1`
snapshot. `sparse-checkout set` was applied *after* that fetch, so the narrowing never
reached the network transfer: the harness pulled a complete copy of the tree and then
discarded all but `.github/actions`.

`Checkout` runs in the serial prefix of every job, so this lands directly on the CI wall
and on runner egress.

## Why This Change Was Made

Narrow the harness fetch before it runs: set `sparse-checkout` first, then fetch with
`--filter=blob:none`. The checkout that follows materializes only the sparse paths.

Because that checkout now performs network work rather than being purely local, it
carries `fetch_timeout_seconds` instead of running unbounded; on timeout it raises the
same retryable failure the surrounding attempt loop already handles.

The workspace fetch is deliberately left unfiltered — jobs need real file contents — and
this change does not touch the process-group ownership, descendant cleanup, or macOS
cleanup behavior added by #132105, #132204, and #132169.

## User Impact

Maintainers and contributors get a faster, cheaper `Checkout` on every job. Measured
against the live remote:

| | before | after |
| --- | --- | --- |
| harness fetch | 18.59s | 0.98s |
| harness checkout | 0.11s | 1.08s |
| harness `.git` | 117 MB | 7.0 MB |

That is ~110 MB less per job. Across ~70 Blacksmith jobs in a run, roughly **7.7 GB less
egress per CI run** through the shared runner egress IP, where transfer cost is most
contended. No behavior change for job contents.

## Evidence

**End-to-end, real remote.** Ran the workflow's actual Python checkout driver with
per-command timing against `github.com/openclaw/openclaw`. Harness phase went 18.70s to
2.06s; `.ci-harness/.git` 117 MB to 7.0 MB; `setup-node-env/action.yml` present.

**Linux A/B on the real step script.** Extracted the `Checkout` step from `ci.yml` before
and after, ran both in `python:3.12-slim` with a recording `git` shim:

```
before:  init, remote, fetch (unfiltered), sparse-checkout, checkout
after:   init, remote, sparse-checkout, fetch --filter=blob:none, checkout
```

Workspace fetch stays unfiltered in both. Both exit 0.

**Harness completeness.** Verified every `.ci-harness/...` path the workflow consumes
resolves in the partial clone: `detect-docs-changes`, `ensure-base-commit`,
`setup-android-toolchain`, `setup-node-env`, `setup-pnpm-store-cache`, and
`setup-pnpm-store-cache/ensure-node.sh`.

**Tests.**

```
node scripts/run-vitest.mjs test/scripts/ci-linux-git.test.ts test/scripts/ci-workflow-guards.test.ts
Test Files  2 passed (2)
     Tests  165 passed | 44 skipped (209)
```

New regression test `fetches the CI harness without a second full-repository snapshot`
asserts the harness command order, the blob filter, and that the workspace fetch stays
unfiltered. It fails on pre-fix code for the intended reason:

```
expected [ 'init', 'remote', 'fetch', …(2) ] to deeply equal [ 'init', 'remote', …(3) ]
```

It is gated off Windows rather than Linux-only: it asserts command shape, not `ps`
process-group semantics, so it also runs on macOS instead of silently skipping.

**Scope note.** This was investigated after a run showed `Checkout` p50 at 85s. That
specific spike is *not* a code regression: measuring nine main runs shows Blacksmith
`Checkout` p50 swinging 12s-85s on unchanged code while GitHub-hosted runners stay flat
at 11-12s. The duplicate fetch is a real, permanent cost worth removing on its own, but
a single before/after run pair would not be valid proof of wall-clock impact given that
variance — the deterministic 117 MB to 7.0 MB reduction is the reliable measure.

Production LOC: +10/-2 in `.github/workflows/ci.yml` (6 added lines are comments) | Tests: +37/-0
