### PR TITLE
fix(cli): reject explicit empty nodes RPC --timeout instead of defaulting

### DIFF
--- a/src/cli/nodes-cli/rpc.test.ts
+++ b/src/cli/nodes-cli/rpc.test.ts
@@ -130,4 +130,9 @@ describe("node inventory resolution", () => {
       gatewayMocks.callGatewayFromCliWithTransport.mock.calls.map(([method]) => method),
     ).toEqual(["node.list"]);
   });
+
+  it("rejects an explicit empty --timeout instead of silently defaulting the transport", async () => {
+    await expect(resolveCliNode({ timeout: "" }, "some-node")).rejects.toThrow(/Invalid --timeout/);
+    expect(gatewayMocks.callGatewayFromCliWithTransport).not.toHaveBeenCalled();
+  });
 });

--- a/src/cli/nodes-cli/rpc.ts
+++ b/src/cli/nodes-cli/rpc.ts
@@ -38,7 +38,8 @@ function resolveNodesTransportTimeoutMs(
   invokeTimeoutMs?: unknown,
 ): number | null {
   const transportTimeoutMs =
-    overrideMs ?? parseTimeoutMsWithFallback(opts.timeout, DEFAULT_NODES_RPC_TIMEOUT_MS);
+    overrideMs ??
+    parseTimeoutMsWithFallback(opts.timeout, DEFAULT_NODES_RPC_TIMEOUT_MS, { invalidType: "error" });
   if (invokeTimeoutMs === 0) {
     // Zero disables the node deadline; null keeps Gateway startup bounded but the request unbounded.
     return null;


### PR DESCRIPTION
## What Problem This Solves

`nodes` CLI subcommands (e.g. `nodes status`, `nodes invoke`, `nodes pairing`) accept a global
`--timeout <ms>` option, but their transport-timeout resolver calls
`parseTimeoutMsWithFallback(opts.timeout, DEFAULT_NODES_RPC_TIMEOUT_MS)` **without** the
`{ invalidType: "error" }` option. So a present-but-malformed value such as `nodes ... --timeout ""`
is silently bridged to the 10s default, while every sibling CLI path that shares this helper —
`capability-cli`, `daemon-cli status`, `gateway-cli/register`, and `gateway-cli/discover` — rejects
an explicit-empty/unparseable `--timeout` as operator error.

## Why This Change Was Made

The merged malformed-`--days`/`--timeout` rejection (#127978) established the canonical behavior
for a present-but-unparseable global timeout: it is operator error, not a quiet fallback. That PR
migrated every `parseTimeoutMsWithFallback` caller to `{ invalidType: "error" }` **except** the
`nodes` CLI RPC path, leaving a one-caller inconsistency on the same shared invariant. This change
completes that sweep so `nodes` behaves identically to its sibling CLI surfaces.

## User Impact

`nodes ... --timeout ""` (or any non-string empty override) now fails fast with a clear
`Invalid --timeout. Use a positive millisecond value...` error before any gateway call, instead of
silently running with the 10,000ms default. No default, config, or API surface changes; valid
timeouts behave exactly as before.

## Evidence

- Root cause is the lone remaining caller without the `invalidType: "error"` option:
  `src/cli/nodes-cli/rpc.ts` `resolveNodesTransportTimeoutMs` vs the four sibling callers that
  already pass it (`src/cli/capability-cli/shared.ts`, `src/cli/daemon-cli/status.gather.ts`,
  `src/cli/gateway-cli/register.ts`, `src/cli/gateway-cli/discover.ts`).
- Regression test added to `src/cli/nodes-cli/rpc.test.ts`: `resolveCliNode({ timeout: "" }, ...)`
  must reject with `/Invalid --timeout/` and must not invoke the gateway transport. This fails on
  the pre-fix code (which silently falls back and calls the gateway) and passes after the change.
- `git diff --check` clean; production LOC delta is +1 (the added option), tests +5.
- Proof note: this session runs an untrusted contributor-fork checkout, so per project rules the
  repo test harness is not executed locally; runtime validation is delegated to fork CI on the pushed
  head (`505f3bff0a3`). The focused regression and typecheck (`check-test-types`) cover the change on CI.
