### PR TITLE
fix(ci): prevent docs agent from throttling its own run

### DIFF
--- a/.github/workflows/docs-agent.yml
+++ b/.github/workflows/docs-agent.yml
@@ -91,11 +91,11 @@ jobs:
               --argjson current_run_id "$GITHUB_RUN_ID" \
               --arg one_hour_ago "$one_hour_ago" \
               '.workflow_runs[]
-                | select(.database_id != $current_run_id)
+                | select(.id != $current_run_id)
                 | select(.created_at >= $one_hour_ago)
                 | select(.status != "cancelled")
                 | select((.conclusion // "") != "skipped")
-                | [.database_id, .status, (.conclusion // ""), .created_at, .head_sha]
+                | [.id, .status, (.conclusion // ""), .created_at, .head_sha]
                 | @tsv' "$runs_json"
           )"
 
@@ -111,7 +111,7 @@ jobs:
               --argjson current_run_id "$GITHUB_RUN_ID" \
               --arg remote_main "$remote_main" \
               '.workflow_runs[]
-                | select(.database_id != $current_run_id)
+                | select(.id != $current_run_id)
                 | select(.status != "cancelled")
                 | select((.conclusion // "") != "skipped")
                 | .head_sha

--- a/test/scripts/docs-agent-workflow.test.ts
+++ b/test/scripts/docs-agent-workflow.test.ts
@@ -1,0 +1,145 @@
+import { spawnSync } from "node:child_process";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { parse } from "yaml";
+import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+const mainSha = "a".repeat(40);
+const parentSha = "b".repeat(40);
+const previousSha = "c".repeat(40);
+const currentRun = {
+  id: 123,
+  created_at: "2026-08-28T23:00:00Z",
+  status: "in_progress",
+  conclusion: null,
+  head_sha: mainSha,
+};
+type WorkflowRun = Omit<typeof currentRun, "conclusion"> & { conclusion: string | null };
+
+function runGate(runs: WorkflowRun[], options: { event?: string; workflowHeadSha?: string } = {}) {
+  const workflow = parse(readFileSync(".github/workflows/docs-agent.yml", "utf8")) as {
+    jobs: { "update-docs": { steps: Array<{ id?: string; run?: string }> } };
+  };
+  const gate = workflow.jobs["update-docs"].steps.find((step) => step.id === "gate");
+  if (!gate?.run) {
+    throw new Error("Docs Agent gate is missing");
+  }
+
+  const root = tempDirs.make("docs-agent-gate-");
+  const bin = join(root, "bin");
+  const output = join(root, "output");
+  mkdirSync(bin);
+  writeFileSync(output, "");
+  // Only the gate runs. Git/network and the clock are fixtures; jq executes the real filters.
+  const commands = {
+    git: `case "$*" in
+  'fetch --no-tags origin main') ;;
+  'rev-parse origin/main'|'rev-parse HEAD') printf '%s\\n' '${mainSha}' ;;
+  'rev-parse ${mainSha}^') printf '%s\\n' '${parentSha}' ;;
+  'cat-file -e ${previousSha}^{commit}'|'cat-file -e ${parentSha}^{commit}') ;;
+  *) printf 'Unexpected git call: %s\\n' "$*" >&2; exit 1 ;;
+esac`,
+    gh: `printf '%s\\n' "$DOCS_AGENT_RUNS_FIXTURE"`,
+    date: `printf '%s\\n' '2026-08-28T22:30:00Z'`,
+  };
+  for (const [name, script] of Object.entries(commands)) {
+    writeFileSync(join(bin, name), `#!/bin/sh\n${script}\n`, { mode: 0o755 });
+  }
+
+  const result = spawnSync("bash", ["--noprofile", "--norc", "-c", gate.run], {
+    cwd: root,
+    encoding: "utf8",
+    timeout: 10_000,
+    env: {
+      PATH: `${bin}:${process.env.PATH}`,
+      HOME: root,
+      RUNNER_TEMP: root,
+      GITHUB_OUTPUT: output,
+      GITHUB_REPOSITORY: "openclaw/openclaw",
+      GITHUB_RUN_ID: String(currentRun.id),
+      EVENT_NAME: options.event ?? "workflow_run",
+      WORKFLOW_HEAD_SHA: options.workflowHeadSha ?? mainSha,
+      DOCS_AGENT_RUNS_FIXTURE: JSON.stringify({ workflow_runs: runs }),
+    },
+  });
+  expect(result.status, result.stderr || result.error?.message).toBe(0);
+  return { stdout: result.stdout, output: readFileSync(output, "utf8") };
+}
+
+function admittedOutput(reviewBase: string) {
+  return [
+    "run_agent=true",
+    `base_sha=${mainSha}`,
+    `review_base_sha=${reviewBase}`,
+    `review_head_sha=${mainSha}`,
+    "",
+  ].join("\n");
+}
+
+describe.skipIf(process.platform === "win32")("Docs Agent gate", () => {
+  it("does not let the current REST run throttle itself", () => {
+    const result = runGate([currentRun]);
+    expect(result.output).toBe(admittedOutput(parentSha));
+    expect(result.stdout).not.toContain("skipping");
+  });
+
+  it.each([
+    ["in progress", "in_progress", null],
+    ["completed", "completed", "success"],
+  ])("throttles another %s run and prints its REST id", (_label, status, conclusion) => {
+    const other = { ...currentRun, id: 122, status, conclusion, head_sha: previousSha };
+    const result = runGate([currentRun, other]);
+    expect(result.output).toBe("run_agent=false\n");
+    expect(result.stdout).toContain("already ran or is running within the last hour");
+    expect(result.stdout).toContain(
+      [other.id, status, conclusion ?? "", other.created_at, previousSha].join("\t"),
+    );
+    expect(result.stdout).not.toContain("123\t");
+  });
+
+  it("excludes the current id from the review base even with an older run snapshot", () => {
+    const result = runGate([
+      { ...currentRun, created_at: "2026-08-28T21:00:00Z", head_sha: parentSha },
+      {
+        ...currentRun,
+        id: 122,
+        created_at: "2026-08-28T20:00:00Z",
+        status: "completed",
+        conclusion: "success",
+        head_sha: previousSha,
+      },
+    ]);
+    expect(result.output).toBe(admittedOutput(previousSha));
+  });
+
+  it("ignores skipped runs and uses a prior run outside the hourly window", () => {
+    const result = runGate([
+      currentRun,
+      { ...currentRun, id: 122, status: "completed", conclusion: "skipped", head_sha: parentSha },
+      {
+        ...currentRun,
+        id: 121,
+        created_at: "2026-08-28T22:29:59Z",
+        status: "completed",
+        conclusion: "success",
+        head_sha: previousSha,
+      },
+    ]);
+    expect(result.output).toBe(admittedOutput(previousSha));
+  });
+
+  it("still rejects superseded CI", () => {
+    const result = runGate([], { workflowHeadSha: previousSha });
+    expect(result.output).toBe("run_agent=false\n");
+    expect(result.stdout).toContain(`CI run is superseded by ${mainSha}`);
+  });
+
+  it("preserves manual dispatch admission without applying the hourly throttle", () => {
+    const result = runGate([currentRun, { ...currentRun, id: 122 }], {
+      event: "workflow_dispatch",
+    });
+    expect(result.output).toBe(admittedOutput(parentSha));
+  });
+});


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where the Docs Agent workflow counts its own current run as recent activity and skips the documentation maintenance it was about to perform. Its cadence diagnostics also print blank run identifiers, and an older current-run snapshot can contaminate review-base selection.

## Why This Change Was Made

The workflow consumes the GitHub REST workflow-runs response, whose identity field is `id`, not `database_id`. Both self-exclusion predicates and the diagnostic row now use that canonical field. This is a three-line, net-zero production fix in the existing gate; there is no compatibility fallback or parallel policy implementation.

The regression executes the actual gate shell extracted from the workflow, with real `jq` and isolated synthetic Git, REST, and clock inputs. Git timeout/process-tree handling, deadlines, retries, trust gates, manual dispatch semantics, permissions, and the one-hour window are unchanged. This is independent of the shared Git-lifecycle migration in [#132428](https://github.com/openclaw/openclaw/pull/132428); coordination confirmed that its Docs Agent port has not started.

## User Impact

Eligible Docs Agent runs no longer reject themselves solely because of a REST field-name mismatch. Another qualifying recent run still blocks admission, its numeric run ID is visible in the diagnostic, and the current run is excluded from the review base.

The existing workflow is active. Landing may restore its existing Codex maintenance activity; the maintainer explicitly requested landing after that consequence was explained. This PR does not enable or manually dispatch the workflow. No Gateway, app, operator-state, model-selection, or credential changes.

This is not a complete cadence redesign: pre-existing cancellation classification and accounting for gate-only successful workflow runs are separate follow-ups, not silently changed here.

## Evidence

- Fresh authenticated REST responses on 2026-08-29 at 12:38–12:42 UTC returned current-day run IDs. An explicit field-presence check returned `has("id") == true` and `has("database_id") == false`; this is not based on the older cached August 16 row. Examples: [current-day run 33252919643](https://github.com/openclaw/openclaw/actions/runs/33252919643) and [field-presence sample 33253132852](https://github.com/openclaw/openclaw/actions/runs/33253132852). The observed first run skipped because main was superseded, so it is schema/flow evidence, not a claimed live reproduction of self-throttling.
- [GitHub's REST contract](https://docs.github.com/en/rest/actions/workflow-runs#list-workflow-runs-for-a-workflow) defines `id`. [The documented Docs Agent cadence](https://docs.openclaw.ai/ci#docs-agent) is event-driven with an hourly throttle, not an hourly cron. Fresh workflow metadata at 14:23 UTC still reported `state: active`.
- Current main `f5eea3197c55c0ed0e609d182bd88a7f09ec55e9` retained the same faulty gate. History traces the mismatch to [the April 23 throttle commit](https://github.com/openclaw/openclaw/commit/f7c4d7a5f0c4efece9d93e2c82f35111bb89ee7f), not the later Git timeout patch.
- Regression before production edits: **5 failed, 2 passed**. After the three field corrections: **7 passed**. Cases cover current-run admission, other in-progress/completed runs and printed IDs, review-base exclusion, skipped/older rows, superseded CI, and manual admission.
- Passing local proof: `node scripts/run-vitest.mjs test/scripts/docs-agent-workflow.test.ts`; `node scripts/check-changed.mjs -- .github/workflows/docs-agent.yml test/scripts/docs-agent-workflow.test.ts` (including root test types and scripts lint); `actionlint .github/workflows/docs-agent.yml`; formatting, composite-action interpolation, and conflict-marker guards; `git diff --check`.
- Full local workflow sanity passed: `PATH="/opt/homebrew/bin:$PATH" node --import ./scripts/tsx.mjs scripts/check-workflows.mts`, including `actionlint`, pinned `pre-commit`/`zizmor`, composite-action interpolation, and conflict-marker guards. The initial failure was macOS selecting Python 3.9 while `pre-commit==4.6.2` requires Python >=3.10; using the already-installed Python 3.14 fixed it without pin or global configuration changes. The separate incomplete local dependency installation was repaired with the frozen lockfile.
- Fresh isolated Codex autoreview: **scoped-clean**, no accepted/actionable findings at the configured P0 threshold, verdict correct (0.99). Exact-head hosted CI and Workflow Sanity remain required before landing.
- Production LOC: **+3/-3 (net 0)**. Tests: **+145/-0**. No docs-agent/model execution was manually dispatched for proof.

AI-assisted implementation; maintainer reviewed the REST contract and the executable gate behavior. Independent review and exact-head CI results will be recorded before landing.
