### PR TITLE
fix(release): accept repeated complete ClawHub recovery audits

### DIFF
--- a/scripts/e2e/lib/clawhub-fixture-server.cjs
+++ b/scripts/e2e/lib/clawhub-fixture-server.cjs
@@ -20,6 +20,7 @@ async function assertPrepublishRequests(
   version,
   securityMode = "required",
   attempts = "1",
+  minimumAttempts = "1",
 ) {
   if (!baseUrl || !requestedPackage || !version) {
     throw new Error("assert-prepublish-requests requires <base-url> <package-name> <version>");
@@ -29,6 +30,10 @@ async function assertPrepublishRequests(
   }
   if (attempts !== "1" && attempts !== "2" && attempts !== "complete") {
     throw new Error("assert-prepublish-requests attempts must be 1, 2, or complete");
+  }
+  const minimumCount = Number(minimumAttempts);
+  if (!Number.isInteger(minimumCount) || minimumCount < 1 || minimumCount > 16) {
+    throw new Error("assert-prepublish-requests minimum attempts must be an integer from 1 to 16");
   }
   const response = await fetch(new URL("/__fixture__/requests", baseUrl));
   if (!response.ok) {
@@ -50,8 +55,8 @@ async function assertPrepublishRequests(
   // phases. Every request must still belong to a complete authorized audit sequence.
   const count =
     attempts === "complete" ? payload.requests.length / expected.length : Number(attempts);
-  if (!Number.isInteger(count) || count < 1 || count > 16) {
-    throw new Error("expected 1-16 complete ClawHub artifact audit sequences");
+  if (!Number.isInteger(count) || count < minimumCount || count > 16) {
+    throw new Error(`expected ${minimumCount}-16 complete ClawHub artifact audit sequences`);
   }
   const expectedRequests = Array.from({ length: count }, () => expected).flat();
   if (JSON.stringify(payload.requests) !== JSON.stringify(expectedRequests)) {
@@ -666,6 +671,7 @@ if (profile === "assert-prepublish-requests") {
     process.argv[5],
     process.argv[6],
     process.argv[7],
+    process.argv[8],
   ).catch(
     /** @param {unknown} error */ (error) => {
       console.error(error);

--- a/scripts/e2e/lib/upgrade-survivor/run.sh
+++ b/scripts/e2e/lib/upgrade-survivor/run.sh
@@ -1216,14 +1216,14 @@ repair_fixture_plugin_consent() {
   fi
   if [ -n "${OPENCLAW_CLAWHUB_URL:-}" ]; then
     local attempts=1
-    if [ "$UPDATE_RESTART_MODE" = "auto-auth" ]; then
+    local minimum_attempts=1
+    if [ "$UPDATE_RESTART_MODE" = "auto-auth" ] || [ "$update_repair_required" = "1" ]; then
       attempts=complete
-    elif [ "$update_repair_required" = "1" ]; then
-      attempts=2
+      minimum_attempts=2
     fi
     phase assert-prepublish-recovery-requests node \
       "${OPENCLAW_UPGRADE_SURVIVOR_CLAWHUB_FIXTURE_SERVER:-scripts/e2e/lib/clawhub-fixture-server.cjs}" \
-      assert-prepublish-requests "$OPENCLAW_CLAWHUB_URL" "$prepublish_package" "$candidate_version" "$clawhub_security_mode" "$attempts"
+      assert-prepublish-requests "$OPENCLAW_CLAWHUB_URL" "$prepublish_package" "$candidate_version" "$clawhub_security_mode" "$attempts" "$minimum_attempts"
   fi
 }
 

--- a/test/scripts/clawhub-fixture-server.test.ts
+++ b/test/scripts/clawhub-fixture-server.test.ts
@@ -88,6 +88,7 @@ function runPrepublishAssertion(
   securityMode?: "required" | "absent",
   cwd = process.cwd(),
   attempts?: number | "complete",
+  minimumAttempts?: number,
 ) {
   return spawnSync(
     process.execPath,
@@ -99,6 +100,7 @@ function runPrepublishAssertion(
       version ?? "",
       ...(securityMode || attempts ? [securityMode ?? "required"] : []),
       ...(attempts ? [String(attempts)] : []),
+      ...(minimumAttempts ? [String(minimumAttempts)] : []),
     ],
     { cwd, encoding: "utf8", env: { ...process.env } },
   );
@@ -319,24 +321,45 @@ describe("ClawHub fixture server", () => {
     expect(
       runPrepublishAssertion(baseUrl, "@openclaw/whatsapp", version, undefined, isolatedCwd).status,
     ).toBe(0);
+    const completeWithMinimum = runPrepublishAssertion(
+      baseUrl,
+      "@openclaw/whatsapp",
+      version,
+      "required",
+      isolatedCwd,
+      "complete",
+      2,
+    );
+    expect(completeWithMinimum.status).toBe(1);
+    expect(completeWithMinimum.stderr).toContain(
+      "expected 2-16 complete ClawHub artifact audit sequences",
+    );
     const unexpectedStartupRequest = runNoRequestsAssertion(baseUrl, isolatedCwd);
     expect(unexpectedStartupRequest.status).toBe(1);
     expect(unexpectedStartupRequest.stderr).toContain("unexpected ClawHub fixture requests");
-    for (const requestPath of [
+    const completeRequestPaths = [
       whatsappPath,
       `${whatsappPath}/versions/${version}/artifact`,
       `${whatsappPath}/versions/${version}/security`,
       `${whatsappPath}/versions/${version}/artifact/download`,
-    ]) {
+    ];
+    for (const requestPath of completeRequestPaths) {
       const response = await fetch(`${baseUrl}${requestPath}`);
       expect(response.status).toBe(200);
       await response.arrayBuffer();
     }
-    expect(runPrepublishAssertion(baseUrl, "@openclaw/whatsapp", version).status).toBe(1);
     expect(
       runPrepublishAssertion(baseUrl, "@openclaw/whatsapp", version, "required", isolatedCwd, 2)
         .status,
     ).toBe(0);
+    for (let attempt = 2; attempt < 4; attempt += 1) {
+      for (const requestPath of completeRequestPaths) {
+        const response = await fetch(`${baseUrl}${requestPath}`);
+        expect(response.status).toBe(200);
+        await response.arrayBuffer();
+      }
+    }
+    expect(runPrepublishAssertion(baseUrl, "@openclaw/whatsapp", version).status).toBe(1);
     const complete = runPrepublishAssertion(
       baseUrl,
       "@openclaw/whatsapp",
@@ -344,30 +367,64 @@ describe("ClawHub fixture server", () => {
       "required",
       isolatedCwd,
       "complete",
+      2,
     );
     expect(complete.status, complete.stderr).toBe(0);
-    expect(complete.stdout).toContain("Verified 2 complete ClawHub artifact audit sequence(s).");
-    expect((await fetch(`${baseUrl}${whatsappPath}/versions/0.0.0/artifact`)).status).toBe(404);
-    const mismatch = runPrepublishAssertion(
+    expect(complete.stdout).toContain("Verified 4 complete ClawHub artifact audit sequence(s).");
+
+    expect((await fetch(`${baseUrl}${whatsappPath}`)).status).toBe(200);
+    const partial = runPrepublishAssertion(
       baseUrl,
       "@openclaw/whatsapp",
       version,
       "required",
       isolatedCwd,
+      "complete",
       2,
     );
-    expect(mismatch.status).toBe(1);
-    expect(mismatch.stderr).toContain("unexpected ClawHub fixture requests");
-    expect(
-      runPrepublishAssertion(
-        baseUrl,
-        "@openclaw/whatsapp",
-        version,
-        "required",
-        isolatedCwd,
-        "complete",
-      ).status,
-    ).toBe(1);
+    expect(partial.status).toBe(1);
+
+    expect((await fetch(`${baseUrl}/api/v1/packages/%40openclaw%2Fforeign`)).status).toBe(404);
+    for (const requestPath of completeRequestPaths.slice(1, 3)) {
+      expect((await fetch(`${baseUrl}${requestPath}`)).status).toBe(200);
+    }
+    const foreign = runPrepublishAssertion(
+      baseUrl,
+      "@openclaw/whatsapp",
+      version,
+      "required",
+      isolatedCwd,
+      "complete",
+      2,
+    );
+    expect(foreign.status).toBe(1);
+    expect(foreign.stderr).toContain("unexpected ClawHub fixture requests");
+
+    const { baseUrl: maximumBaseUrl } = await startFixtureServer(
+      "prepublish-artifacts",
+      [manifestPath],
+      isolatedCwd,
+    );
+    for (let attempt = 0; attempt < 17; attempt += 1) {
+      for (const requestPath of completeRequestPaths) {
+        const response = await fetch(`${maximumBaseUrl}${requestPath}`);
+        expect(response.status).toBe(200);
+        await response.arrayBuffer();
+      }
+    }
+    const aboveMaximum = runPrepublishAssertion(
+      maximumBaseUrl,
+      "@openclaw/whatsapp",
+      version,
+      "required",
+      isolatedCwd,
+      "complete",
+      2,
+    );
+    expect(aboveMaximum.status).toBe(1);
+    expect(aboveMaximum.stderr).toContain(
+      "expected 2-16 complete ClawHub artifact audit sequences",
+    );
   });
 
   it("serves separate plugin-family and skill search fixtures", async () => {


### PR DESCRIPTION
## What Problem This Solves

Resolves a release-validation failure where valid recovery flows were rejected when they performed more than exactly two complete ClawHub artifact audit sequences.

## Why This Change Was Made

The trusted release harness now validates the dynamically observed number of complete, correctly ordered audit sequences while requiring at least two sequences after recovery and retaining the existing maximum of 16.

## User Impact

No product runtime behavior changes. OpenClaw release validation no longer blocks valid upgrade recovery after repeated authorized ClawHub artifact checks.

## Evidence

- Original FRV package acceptance failed `root-managed-vps-upgrade` and `published-upgrade-survivor` after four valid complete audit sequences.
- `node scripts/run-vitest.mjs test/scripts/clawhub-fixture-server.test.ts test/scripts/docker-build-helper.test.ts`: 260/260 passed.
- Regression coverage: one complete sequence fails minimum 2; four complete pass; partial, same-size foreign-request, and 17-sequence ledgers fail.
- `node scripts/check-changed.mjs --dry-run -- scripts/e2e/lib/upgrade-survivor/run.sh scripts/e2e/lib/clawhub-fixture-server.cjs test/scripts/clawhub-fixture-server.test.ts`: `testRoot, tooling`.
- `shellcheck scripts/e2e/lib/upgrade-survivor/run.sh`: only pre-existing SC1091/SC2034/SC2155 findings; no changed-line finding.
- Autoreview: clean, no actionable findings.
- Fresh Testbox hydration: [run 33258515777](https://github.com/openclaw/openclaw/actions/runs/33258515777), exact tooling head `287a2d05c7d794541b3425c0b24d1717e3104663`.
- Frozen candidate: `eebb36abd90b2852fef7d4793bbfa4978305ebb9`, package `2026.9.1-beta.2`, package SHA-256 `53aaa442d1e90a76dd8174f67aa886ab39ad3f0bce4d90adc627fdf9862b7622`.
- `pnpm test:docker:root-managed-vps-upgrade`: passed; post-recovery assertion observed and accepted 4 complete ClawHub artifact audit sequences; gateway health/readiness/RPC status passed.
- `pnpm test:docker:published-upgrade-survivor`: passed in 148s with the frozen candidate package and candidate-built plugin registry.
- `pnpm test:docker:update-restart-auth`: passed; update-owned restart replaced the supervisor, preserved config/state, and passed gateway HTTP probes plus RPC status.
