### PR TITLE
test: clean up state and async task fixtures

### DIFF
--- a/src/agents/embedded-agent-runner/run/attempt.async-tasks.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.async-tasks.test.ts
@@ -1,5 +1,5 @@
 // Coverage for waiting on completion-required async tool tasks.
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   completeTaskRunByRunId,
   createRunningTaskRun,
@@ -23,10 +23,13 @@ function requireCreatedTask(task: TaskRecord | null): TaskRecord {
 }
 
 describe("waitForCompletionRequiredAsyncTasks", () => {
+  beforeEach(() => resetTaskRegistryForTests());
+  // Aborted and timed-out waits leave tasks running; release them before the next suite.
+  afterEach(() => resetTaskRegistryForTests());
+
   it("waits for async task ids discovered during the attempt", async () => {
     // Tool metadata is the primary source for async task ids produced during
     // the current attempt.
-    resetTaskRegistryForTests();
     const task = requireCreatedTask(
       createRunningTaskRun({
         runtime: "cli",
@@ -74,7 +77,6 @@ describe("waitForCompletionRequiredAsyncTasks", () => {
   });
 
   it("requires a wait when the cron run has an active tracked media task", () => {
-    resetTaskRegistryForTests();
     const sessionKey = "agent:main:cron:daily-media:run:run-123";
     createRunningTaskRun({
       runtime: "cli",
@@ -100,7 +102,6 @@ describe("waitForCompletionRequiredAsyncTasks", () => {
   });
 
   it("skips media task waiting after sessions_yield pauses the attempt", () => {
-    resetTaskRegistryForTests();
     const sessionKey = "agent:main:cron:daily-media:run:run-123";
     createRunningTaskRun({
       runtime: "cli",
@@ -142,7 +143,6 @@ describe("waitForCompletionRequiredAsyncTasks", () => {
   it("waits for active cron media tasks from the task registry", async () => {
     // Cron media tools may start tasks before metadata is flushed, so the
     // registry is also consulted by session key.
-    resetTaskRegistryForTests();
     const sessionKey = "agent:main:cron:daily-media:run:run-123";
     createRunningTaskRun({
       runtime: "cli",
@@ -182,7 +182,6 @@ describe("waitForCompletionRequiredAsyncTasks", () => {
   });
 
   it("waits for active cron video tasks from the task registry", async () => {
-    resetTaskRegistryForTests();
     const sessionKey = "agent:main:cron:daily-media:run:run-123";
     createRunningTaskRun({
       runtime: "cli",
@@ -222,7 +221,6 @@ describe("waitForCompletionRequiredAsyncTasks", () => {
   });
 
   it("waits for async task ids discovered after an earlier async completion", async () => {
-    resetTaskRegistryForTests();
     const sessionKey = "agent:main:cron:daily-media:run:run-123";
     const imageTask = requireCreatedTask(
       createRunningTaskRun({
@@ -312,7 +310,6 @@ describe("waitForCompletionRequiredAsyncTasks", () => {
   });
 
   it("reports tasks that do not finish before the deadline", async () => {
-    resetTaskRegistryForTests();
     createRunningTaskRun({
       runtime: "cli",
       taskKind: "music_generation",
@@ -352,7 +349,6 @@ describe("waitForCompletionRequiredAsyncTasks", () => {
   });
 
   it("stops waiting when the run abort signal fires", async () => {
-    resetTaskRegistryForTests();
     const sessionKey = "agent:main:cron:daily-media:run:run-123";
     createRunningTaskRun({
       runtime: "cli",

--- a/src/state/openclaw-state-db.permissions.test.ts
+++ b/src/state/openclaw-state-db.permissions.test.ts
@@ -1,9 +1,9 @@
 // State database permission hardening tests cover best-effort chmod on
 // filesystems without POSIX permission support (Azure Files, NFS, certain
 // Docker volume drivers).
-import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 
 // The permission helper hardens via the named import `chmodSync` from node:fs.
 // A namespace `vi.spyOn(fs, ...)` cannot rebind an
@@ -57,23 +57,20 @@ function enotsupError(): Error {
 }
 
 describe("state database permission hardening without chmod support", () => {
-  let stateDir: string | undefined;
-
-  afterEach(() => {
-    chmodFailHook.error = undefined;
-    chmodFailHook.calls = 0;
-    chmodFailHook.failProbe = true;
-    chmodFailHook.removeTargetSuffix = undefined;
-    chmodFailHook.targets = [];
-    closeOpenClawStateDatabaseForTest();
-    if (stateDir) {
-      fs.rmSync(stateDir, { recursive: true, force: true });
-      stateDir = undefined;
-    }
+  const tempDirs = useAutoCleanupTempDirTracker((cleanup) => {
+    afterEach(() => {
+      chmodFailHook.error = undefined;
+      chmodFailHook.calls = 0;
+      chmodFailHook.failProbe = true;
+      chmodFailHook.removeTargetSuffix = undefined;
+      chmodFailHook.targets = [];
+      closeOpenClawStateDatabaseForTest();
+      cleanup();
+    });
   });
 
   it("opens the state database when chmodSync throws ENOTSUP", () => {
-    stateDir = fs.mkdtempSync(join(tmpdir(), "openclaw-state-chmod-"));
+    const stateDir = tempDirs.make("openclaw-state-chmod-");
     chmodFailHook.error = enotsupError();
 
     const database = openOpenClawStateDatabase({ env: { OPENCLAW_STATE_DIR: stateDir } });
@@ -84,7 +81,7 @@ describe("state database permission hardening without chmod support", () => {
   });
 
   it("rethrows EPERM when existing permissions are too broad", () => {
-    stateDir = fs.mkdtempSync(join(tmpdir(), "openclaw-state-chmod-"));
+    const stateDir = tempDirs.make("openclaw-state-chmod-");
     fs.chmodSync(stateDir, 0o755);
     chmodFailHook.error = chmodError("EPERM");
     chmodFailHook.failProbe = false;
@@ -95,7 +92,7 @@ describe("state database permission hardening without chmod support", () => {
   });
 
   it("opens when EPERM leaves existing permissions restrictive", () => {
-    stateDir = fs.mkdtempSync(join(tmpdir(), "openclaw-state-chmod-"));
+    const stateDir = tempDirs.make("openclaw-state-chmod-");
     openOpenClawStateDatabase({ env: { OPENCLAW_STATE_DIR: stateDir } });
     closeOpenClawStateDatabaseForTest();
     chmodFailHook.error = chmodError("EPERM");
@@ -106,7 +103,7 @@ describe("state database permission hardening without chmod support", () => {
   });
 
   it("opens when EROFS leaves existing permissions restrictive", () => {
-    stateDir = fs.mkdtempSync(join(tmpdir(), "openclaw-state-chmod-"));
+    const stateDir = tempDirs.make("openclaw-state-chmod-");
     openOpenClawStateDatabase({ env: { OPENCLAW_STATE_DIR: stateDir } });
     closeOpenClawStateDatabaseForTest();
     chmodFailHook.error = chmodError("EROFS");
@@ -117,7 +114,7 @@ describe("state database permission hardening without chmod support", () => {
   });
 
   it("rethrows EROFS when existing permissions are too broad", () => {
-    stateDir = fs.mkdtempSync(join(tmpdir(), "openclaw-state-chmod-"));
+    const stateDir = tempDirs.make("openclaw-state-chmod-");
     fs.chmodSync(stateDir, 0o755);
     chmodFailHook.error = chmodError("EROFS");
 
@@ -127,7 +124,7 @@ describe("state database permission hardening without chmod support", () => {
   });
 
   it("opens when the filesystem probe also rejects chmod with EPERM", () => {
-    stateDir = fs.mkdtempSync(join(tmpdir(), "openclaw-state-chmod-"));
+    const stateDir = tempDirs.make("openclaw-state-chmod-");
     fs.chmodSync(stateDir, 0o755);
     chmodFailHook.error = chmodError("EPERM");
 
@@ -139,7 +136,7 @@ describe("state database permission hardening without chmod support", () => {
   it("rethrows unexpected chmod errors at open", () => {
     // EACCES is not in CHMOD_UNSUPPORTED_CODES: a real permission fault on a
     // POSIX filesystem must keep the credentials-adjacent hardening fatal.
-    stateDir = fs.mkdtempSync(join(tmpdir(), "openclaw-state-chmod-"));
+    const stateDir = tempDirs.make("openclaw-state-chmod-");
     chmodFailHook.error = chmodError("EACCES");
 
     expect(() => openOpenClawStateDatabase({ env: { OPENCLAW_STATE_DIR: stateDir } })).toThrow(
@@ -150,7 +147,7 @@ describe("state database permission hardening without chmod support", () => {
   it.each(["-wal", "-shm", "-journal"])(
     "opens when the %s sidecar disappears before chmod",
     (suffix) => {
-      stateDir = fs.mkdtempSync(join(tmpdir(), "openclaw-state-chmod-"));
+      const stateDir = tempDirs.make("openclaw-state-chmod-");
       const options = { env: { OPENCLAW_STATE_DIR: stateDir } };
       openOpenClawStateDatabase(options);
       closeOpenClawStateDatabaseForTest();
@@ -170,7 +167,7 @@ describe("state database permission hardening without chmod support", () => {
     // resolveSqliteDatabaseFilePaths lists the unsuffixed database first. Losing
     // it must stay fatal: swallowing that ENOENT would fall through to a SQLite
     // open that creates a fresh empty database instead of surfacing the loss.
-    stateDir = fs.mkdtempSync(join(tmpdir(), "openclaw-state-chmod-"));
+    const stateDir = tempDirs.make("openclaw-state-chmod-");
     const options = { env: { OPENCLAW_STATE_DIR: stateDir } };
     openOpenClawStateDatabase(options);
     closeOpenClawStateDatabaseForTest();
@@ -182,7 +179,7 @@ describe("state database permission hardening without chmod support", () => {
   });
 
   it("repairs the schema when chmodSync throws ENOTSUP", () => {
-    stateDir = fs.mkdtempSync(join(tmpdir(), "openclaw-state-chmod-"));
+    const stateDir = tempDirs.make("openclaw-state-chmod-");
     openOpenClawStateDatabase({ env: { OPENCLAW_STATE_DIR: stateDir } });
     closeOpenClawStateDatabaseForTest();
 
@@ -194,7 +191,7 @@ describe("state database permission hardening without chmod support", () => {
   });
 
   it("commits write transactions when chmodSync throws ENOTSUP", () => {
-    stateDir = fs.mkdtempSync(join(tmpdir(), "openclaw-state-chmod-"));
+    const stateDir = tempDirs.make("openclaw-state-chmod-");
     chmodFailHook.error = enotsupError();
     const options = { env: { OPENCLAW_STATE_DIR: stateDir } };
 

--- a/src/state/user-profiles.test.ts
+++ b/src/state/user-profiles.test.ts
@@ -1,8 +1,8 @@
-import { existsSync, mkdtempSync, readFileSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { GIT_COAUTHOR_PREFERENCE_KEY } from "../../packages/gateway-protocol/src/index.js";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { OPENCLAW_STATE_SCHEMA_VERSION } from "./openclaw-state-db-contract.js";
 import { tableExists, tableHasColumn } from "./openclaw-state-db-schema-helpers.js";
 import {
@@ -31,7 +31,13 @@ import {
   syncGitHubIdentity,
 } from "./user-profiles.js";
 
-const statePaths: string[] = [];
+const tempDirs = useAutoCleanupTempDirTracker((cleanup) => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    closeOpenClawStateDatabaseForTest();
+    cleanup();
+  });
+});
 
 it("publishes profile changes only after the owning transaction commits", () => {
   const options = stateOptions();
@@ -61,10 +67,8 @@ it("publishes profile changes only after the owning transaction commits", () => 
 });
 
 function stateOptions() {
-  const directory = mkdtempSync(join(tmpdir(), "openclaw-user-profiles-"));
-  const path = join(directory, "openclaw.sqlite");
-  statePaths.push(path);
-  return { path };
+  const directory = tempDirs.make("openclaw-user-profiles-");
+  return { path: join(directory, "openclaw.sqlite") };
 }
 
 function fixtureImage(path: string): Buffer {
@@ -123,11 +127,6 @@ function syncEmailGitHubProfile(
     options,
   );
 }
-
-afterEach(() => {
-  vi.restoreAllMocks();
-  closeOpenClawStateDatabaseForTest();
-});
 
 describe("user profiles", () => {
   it.each([false, true])(


### PR DESCRIPTION
## What Problem This Solves

Follow-up to #125451, requested during maintainer review of its temporary-directory warning. The permissions suite already removed its directory, so the warning was advisory. The neighboring user-profile suite, however, appended database paths to an unused array and never removed its fixture directories after each test.

Normal detached POSIX test runs eventually remove their enclosing namespace, but the profile fixtures accumulate until then; execution paths without that outer cleanup retain the directories.

## Why This Change Was Made

Use the existing `useAutoCleanupTempDirTracker` in both suites, explicitly restoring fault hooks/mocks and closing SQLite handles before directory removal. The permissions suite now uses test-local directory variables instead of shared mutable ownership; the profile suite drops its unused `statePaths` array.

The sidecar race repair remains unchanged. Its three sidecar disappearance cases and missing-main-database failure case protect different boundaries and remain intact. A broader test migration is unnecessary: the adjacent agent-permissions suite already uses tracked cleanup, and inspected backup, incognito, and outbox-schema suites explicitly remove their fixtures. No new helper or duplicate helper-wiring test is needed.

## User Impact

No production, configuration, schema, or user-facing behavior changes. Test fixtures are removed after each test, with database closure ordered before removal. Production LOC: +0/-0. Tests: +38/-46 (net -8).

## Evidence

- Blacksmith Testbox `tbx_01m16zhjbmxm4nd0xzseq3s9m4`, [run 33258304283](https://github.com/openclaw/openclaw/actions/runs/33258304283).
- Temporary suite-teardown probe against immutable baseline `8d30790f083c467b240f0ef0e0da81cb0db09d73`: all 53 profile tests passed but all 53 fixture directories still existed, failing the cleanup assertion. With this patch, all 53 tests passed and zero directories remained. The probe was removed after verification; it is not committed.
- `node scripts/run-vitest.mjs src/state/openclaw-state-db.permissions.test.ts src/state/openclaw-agent-db.permissions.test.ts test/helpers/temp-dir.test.ts --reporter=dot`: 23 tests passed across three files.
- Targeted formatting and `git diff --check` passed.
- Fresh Codex autoreview completed without actionable findings.

### CI-discovered task fixture leak

The first exact-head CI run, [33258625174](https://github.com/openclaw/openclaw/actions/runs/33258625174), failed `checks-node-compact-large-17`. The async-task wait suite reset the task registry only before tests, then its abort case left `tool:music_generate:run-123` running. A later benchmark correctly waited for that leaked task and timed out.

The same producer-then-consumer order under `isolate: false` reproduced the failure: 16 passed, 1 failed, with `activeTasks: 1` and the exact leaked music task in the gateway snapshot. Moving the existing resets to `beforeEach` and adding matching `afterEach` cleanup made all 17 pass. The real benchmark, its timeout, and production code are unchanged. The temporary sequencer/diagnostic were removed after proof. Proof ran on Blacksmith Testbox `tbx_01m170ehamwzrhhwf103stz0w3`, [run 33258972246](https://github.com/openclaw/openclaw/actions/runs/33258972246).

The full originally failing CI group also passed with the final three-file patch: 96 tests in `agents-core-runner-cli-3`, 684 in `agents-core-subagents`, and 7,490 in `core-unit-fast-1` (five skipped), for **8,270 passed / 5 skipped**.

The two-file changed gate passed before this CI discovery. The third test fix passed targeted formatting and a second fresh Codex autoreview; [final exact-head CI run 33259249878](https://github.com/openclaw/openclaw/actions/runs/33259249878) passed on `27727f0c4a703034de0ca15b6d24b4e1ae37cafc`, covering the complete three-file patch.

AI-assisted: yes.
