### PR TITLE
fix(plugin-sdk): registration leaves private declarations in packages

### DIFF
--- a/docs/plugins/sdk-subpaths.md
+++ b/docs/plugins/sdk-subpaths.md
@@ -28,9 +28,11 @@ then `pnpm plugin-sdk:check-exports`. The same registration command maintains
 package exports, private artifact exclusions in `package.json`'s `files`, and
 private workspace declaration aliases in
 `extensions/tsconfig.package-boundary.paths.json` and `extensions/xai/tsconfig.json`.
-It owns only exact flat `!dist/plugin-sdk/<name>.js` and `.d.ts` exclusions with
-lowercase alphanumeric or hyphenated names, preserving other file rules and their
-order, unrelated mappings, and XAI's intentional private-alias omissions.
+It owns literal flat `!dist/plugin-sdk/<name>.js` and `.d.ts` exclusions, including
+names with underscores, uppercase letters, dots, or Unicode, and removes obsolete
+exclusions when entries become public or are removed. Nested paths, glob or escape
+syntax, non-entrypoint metadata, and other file rules retain their order; unrelated
+mappings and XAI's intentional private-alias omissions are preserved.
 These local declaration aliases do not add types to JavaScript-only published
 SDK exports; test-only entries remain unexported.
 

--- a/docs/plugins/sdk-subpaths.md
+++ b/docs/plugins/sdk-subpaths.md
@@ -25,9 +25,12 @@ inventory of every internal runtime helper. Four files define the boundary:
 
 After changing the entrypoint inventories, run `pnpm plugin-sdk:sync-exports`,
 then `pnpm plugin-sdk:check-exports`. The same registration command maintains
-package exports and private workspace declaration aliases in
+package exports, private artifact exclusions in `package.json`'s `files`, and
+private workspace declaration aliases in
 `extensions/tsconfig.package-boundary.paths.json` and `extensions/xai/tsconfig.json`.
-It preserves unrelated mappings and XAI's intentional private-alias omissions.
+It owns only exact flat `!dist/plugin-sdk/<name>.js` and `.d.ts` exclusions with
+lowercase alphanumeric or hyphenated names, preserving other file rules and their
+order, unrelated mappings, and XAI's intentional private-alias omissions.
 These local declaration aliases do not add types to JavaScript-only published
 SDK exports; test-only entries remain unexported.
 

--- a/scripts/sync-plugin-sdk-exports.mts
+++ b/scripts/sync-plugin-sdk-exports.mts
@@ -61,11 +61,11 @@ function syncRootPackageMetadata() {
   const pendingExclusions = new Set(
     listUnpackagedPrivatePluginSdkDistArtifacts().map((artifact) => `!${artifact}`),
   );
-  // Own only canonical flat JS/declaration exclusions; nested paths, globs and
+  // Own literal flat JS/declaration exclusions, including retired names; nested paths, globs and
   // other package rules stay owner-managed. Retain existing order for npm matching.
   const nextFiles = packageJson.files.filter(
     (file) =>
-      !/^!dist\/plugin-sdk\/[a-z0-9-]+\.(?:js|d\.ts)$/u.test(file) ||
+      !/^!dist\/plugin-sdk\/[^/\\*?[\]{}()]*\.(?:js|d\.ts)$/u.test(file) ||
       pendingExclusions.delete(file),
   );
   nextFiles.push(...pendingExclusions);

--- a/scripts/sync-plugin-sdk-exports.mts
+++ b/scripts/sync-plugin-sdk-exports.mts
@@ -1,11 +1,12 @@
 #!/usr/bin/env node
 
-// Regenerates package.json plugin-sdk export entries from the canonical entry list
+// Regenerates package.json plugin-sdk exports and private artifact exclusions
 // and keeps workspace facade exports and private declaration aliases aligned.
 import fs from "node:fs";
 import path from "node:path";
 import {
   buildPluginSdkPackageExports,
+  listUnpackagedPrivatePluginSdkDistArtifacts,
   pluginSdkEntrypoints,
   privateLocalOnlyPluginSdkEntrypoints,
 } from "./lib/plugin-sdk-entries.mts";
@@ -27,11 +28,12 @@ function writeOrCheckJson(relativePath: string, value: unknown) {
   );
 }
 
-function syncRootPackageExports() {
+function syncRootPackageMetadata() {
   const packageJsonPath = path.join(repoRoot, "package.json");
-  const packageJson: Record<string, unknown> & { exports?: Record<string, unknown> } = JSON.parse(
-    fs.readFileSync(packageJsonPath, "utf8"),
-  );
+  const packageJson: Record<string, unknown> & {
+    exports?: Record<string, unknown>;
+    files: string[];
+  } = JSON.parse(fs.readFileSync(packageJsonPath, "utf8"));
   const currentExports = packageJson.exports ?? {};
   const syncedPluginSdkExports = buildPluginSdkPackageExports();
 
@@ -56,10 +58,25 @@ function syncRootPackageExports() {
     Object.assign(nextExports, syncedPluginSdkExports);
   }
 
-  if (JSON.stringify(currentExports) === JSON.stringify(nextExports)) {
+  const pendingExclusions = new Set(
+    listUnpackagedPrivatePluginSdkDistArtifacts().map((artifact) => `!${artifact}`),
+  );
+  // Own only canonical flat JS/declaration exclusions; nested paths, globs and
+  // other package rules stay owner-managed. Retain existing order for npm matching.
+  const nextFiles = packageJson.files.filter(
+    (file) =>
+      !/^!dist\/plugin-sdk\/[a-z0-9-]+\.(?:js|d\.ts)$/u.test(file) ||
+      pendingExclusions.delete(file),
+  );
+  nextFiles.push(...pendingExclusions);
+  if (
+    JSON.stringify(currentExports) === JSON.stringify(nextExports) &&
+    JSON.stringify(packageJson.files) === JSON.stringify(nextFiles)
+  ) {
     return;
   }
   packageJson.exports = nextExports;
+  packageJson.files = nextFiles;
   writeOrCheckJson("package.json", packageJson);
 }
 
@@ -167,7 +184,7 @@ const facadeSubpaths = collectFacadeSubpaths();
 if (facadeSubpaths === null) {
   process.exit(1);
 }
-syncRootPackageExports();
+syncRootPackageMetadata();
 syncFacadePackageExports(facadeSubpaths);
 syncPrivateDeclarationAliases("extensions/tsconfig.package-boundary.paths.json", "../");
 // XAI's independent package boundary contract intentionally excludes these two
@@ -180,5 +197,5 @@ if (failed) {
   process.exit(1);
 }
 if (checkOnly) {
-  console.log("plugin-sdk exports synced.");
+  console.log("plugin-sdk registration synced.");
 }

--- a/test/scripts/sync-plugin-sdk-exports.test.ts
+++ b/test/scripts/sync-plugin-sdk-exports.test.ts
@@ -25,11 +25,16 @@ const fixtureFiles = [
   "!assets/internal.txt",
   "!dist/plugin-sdk/nested/internal.d.ts",
   "!dist/plugin-sdk/owner-*.js",
+  "!dist/plugin-sdk/owner-?.js",
+  "!dist/plugin-sdk/owner-[ab].js",
+  "!dist/plugin-sdk/owner-{a,b}.js",
+  "!dist/plugin-sdk/owner-@(a|b).js",
   "!dist/**/*.map",
   "!dist/plugin-sdk/.tsbuildinfo",
   "!dist/plugin-sdk/qa-lab.*",
-  "!dist/plugin-sdk/owner_entry.d.ts",
+  "!dist/plugin-sdk/owner_entry.json",
 ];
+const literalEntries = ["private-entry", "private_entry", "Private.entry-Ü"];
 
 function writeJson(root: string, file: string, value: unknown) {
   fs.mkdirSync(path.dirname(path.join(root, file)), { recursive: true });
@@ -119,6 +124,17 @@ function runSync(root: string, ...args: string[]) {
   );
 }
 
+function expectStableSync(root: string) {
+  const synced = readOutputs(root);
+  for (let pass = 0; pass < 2; pass++) {
+    for (const args of [[], ["--check"]]) {
+      const result = runSync(root, ...args);
+      expect(result.status, result.stderr).toBe(0);
+      expect(readOutputs(root)).toEqual(synced);
+    }
+  }
+}
+
 describe("plugin SDK registration CLI", () => {
   it("detects files-only drift without writing, repairs it and stays byte-idempotent", () => {
     const root = createFixture();
@@ -201,10 +217,10 @@ describe("plugin SDK registration CLI", () => {
     expect(readOutputs(root)).toEqual(synced);
   });
 
-  it("registers private workspace types without publishing them or test-only exports", () => {
+  it.each(literalEntries)("packs %s without private types or test-only exports", (entry) => {
     const root = createFixture({
-      entries: ["public-entry", "private-entry", "test-fixtures"],
-      privateEntries: ["private-entry", "test-fixtures", "qa-lab"],
+      entries: ["public-entry", entry, "test-fixtures"],
+      privateEntries: [entry, "test-fixtures", "qa-lab"],
     });
     const included = [
       "assets/public.txt",
@@ -212,7 +228,7 @@ describe("plugin SDK registration CLI", () => {
       "dist/plugin-sdk/owner-extra.d.ts",
       "dist/plugin-sdk/public-entry.js",
       "dist/plugin-sdk/public-entry.d.ts",
-      "dist/plugin-sdk/private-entry.js",
+      `dist/plugin-sdk/${entry}.js`,
     ];
     const excluded = [
       "assets/internal.txt",
@@ -221,8 +237,8 @@ describe("plugin SDK registration CLI", () => {
       "dist/plugin-sdk/public-entry.js.map",
       "dist/plugin-sdk/.tsbuildinfo",
       "dist/plugin-sdk/qa-lab.js",
-      "dist/plugin-sdk/owner_entry.d.ts",
-      "dist/plugin-sdk/private-entry.d.ts",
+      "dist/plugin-sdk/owner_entry.json",
+      `dist/plugin-sdk/${entry}.d.ts`,
       "dist/plugin-sdk/test-fixtures.js",
       "dist/plugin-sdk/test-fixtures.d.ts",
     ];
@@ -245,7 +261,7 @@ describe("plugin SDK registration CLI", () => {
     );
     expect(readPackage(root).files).toEqual([
       ...fixtureFiles,
-      "!dist/plugin-sdk/private-entry.d.ts",
+      `!dist/plugin-sdk/${entry}.d.ts`,
       "!dist/plugin-sdk/test-fixtures.d.ts",
       "!dist/plugin-sdk/test-fixtures.js",
     ]);
@@ -255,7 +271,7 @@ describe("plugin SDK registration CLI", () => {
         types: "./dist/plugin-sdk/public-entry.d.ts",
         default: "./dist/plugin-sdk/public-entry.js",
       },
-      "./plugin-sdk/private-entry": { default: "./dist/plugin-sdk/private-entry.js" },
+      [`./plugin-sdk/${entry}`]: { default: `./dist/plugin-sdk/${entry}.js` },
     });
     for (const { file, prefix } of declarationConfigs) {
       expect(readConfig(root, file).compilerOptions.paths).toEqual({
@@ -264,27 +280,34 @@ describe("plugin SDK registration CLI", () => {
           `${prefix}packages/plugin-sdk/dist/src/plugin-sdk/custom.d.ts`,
           "./override.d.ts",
         ],
-        "openclaw/plugin-sdk/private-entry": [
-          `${prefix}packages/plugin-sdk/dist/src/plugin-sdk/private-entry.d.ts`,
+        [`openclaw/plugin-sdk/${entry}`]: [
+          `${prefix}packages/plugin-sdk/dist/src/plugin-sdk/${entry}.d.ts`,
         ],
         "openclaw/plugin-sdk/test-fixtures": [
           `${prefix}packages/plugin-sdk/dist/src/plugin-sdk/test-fixtures.d.ts`,
         ],
       });
     }
+    expectStableSync(root);
   });
 
-  it.each(["removed", "public"])(
-    "prunes generated aliases and exclusions when a private entry becomes %s",
-    (kind) => {
+  it.each(
+    literalEntries.flatMap((entry) => ["removed", "public"].map((kind) => ({ entry, kind }))),
+  )(
+    "prunes generated aliases and exclusions when $entry becomes $kind, then re-registers it",
+    ({ entry, kind }) => {
+      const formerEntry = `former-${entry}`;
       const root = createFixture({
-        entries: [
-          "private-entry",
-          "test-fixtures",
-          ...(kind === "public" ? ["former-private"] : []),
-        ],
-        privateEntries: ["private-entry", "test-fixtures"],
+        entries: ["private-entry", "test-fixtures", formerEntry],
+        privateEntries: ["private-entry", "test-fixtures", formerEntry],
       });
+      expect(runSync(root).status).toBe(0);
+      writeJson(root, entryList, [
+        "private-entry",
+        "test-fixtures",
+        ...(kind === "public" ? [formerEntry] : []),
+      ]);
+      writeJson(root, privateList, ["private-entry", "test-fixtures"]);
       const manifest = readPackage(root);
       const retained = [
         "!dist/plugin-sdk/test-fixtures.js",
@@ -296,17 +319,10 @@ describe("plugin SDK registration CLI", () => {
         ...retained,
         "!dist/plugin-sdk/private-entry.js",
         "!dist/plugin-sdk/private-entry.d.ts",
-        "!dist/plugin-sdk/former-private.js",
-        "!dist/plugin-sdk/former-private.d.ts",
+        `!dist/plugin-sdk/${formerEntry}.js`,
+        `!dist/plugin-sdk/${formerEntry}.d.ts`,
       ];
       writeJson(root, "package.json", manifest);
-      for (const { file, prefix } of declarationConfigs) {
-        const config = readConfig(root, file);
-        config.compilerOptions.paths["openclaw/plugin-sdk/former-private"] = [
-          `${prefix}packages/plugin-sdk/dist/src/plugin-sdk/former-private.d.ts`,
-        ];
-        writeJson(root, file, config);
-      }
 
       const result = runSync(root);
 
@@ -328,29 +344,31 @@ describe("plugin SDK registration CLI", () => {
         });
       }
       const exports = readPackage(root).exports;
-      expect(exports["./plugin-sdk/former-private"]).toEqual(
+      expect(exports[`./plugin-sdk/${formerEntry}`]).toEqual(
         kind === "public"
           ? {
-              types: "./dist/plugin-sdk/former-private.d.ts",
-              default: "./dist/plugin-sdk/former-private.js",
+              types: `./dist/plugin-sdk/${formerEntry}.d.ts`,
+              default: `./dist/plugin-sdk/${formerEntry}.js`,
             }
           : undefined,
       );
-      writeJson(root, entryList, ["private-entry", "test-fixtures", "former-private"]);
-      writeJson(root, privateList, ["private-entry", "test-fixtures", "former-private"]);
+      expectStableSync(root);
+      writeJson(root, entryList, ["private-entry", "test-fixtures", formerEntry]);
+      writeJson(root, privateList, ["private-entry", "test-fixtures", formerEntry]);
       expect(runSync(root).status).toBe(0);
       expect(readPackage(root).files).toEqual([
         ...retained,
-        "!dist/plugin-sdk/former-private.d.ts",
+        `!dist/plugin-sdk/${formerEntry}.d.ts`,
       ]);
       for (const { file, prefix } of declarationConfigs) {
         expect(
-          readConfig(root, file).compilerOptions.paths["openclaw/plugin-sdk/former-private"],
-        ).toEqual([`${prefix}packages/plugin-sdk/dist/src/plugin-sdk/former-private.d.ts`]);
+          readConfig(root, file).compilerOptions.paths[`openclaw/plugin-sdk/${formerEntry}`],
+        ).toEqual([`${prefix}packages/plugin-sdk/dist/src/plugin-sdk/${formerEntry}.d.ts`]);
       }
-      expect(readPackage(root).exports["./plugin-sdk/former-private"]).toEqual({
-        default: "./dist/plugin-sdk/former-private.js",
+      expect(readPackage(root).exports[`./plugin-sdk/${formerEntry}`]).toEqual({
+        default: `./dist/plugin-sdk/${formerEntry}.js`,
       });
+      expectStableSync(root);
     },
   );
 

--- a/test/scripts/sync-plugin-sdk-exports.test.ts
+++ b/test/scripts/sync-plugin-sdk-exports.test.ts
@@ -2,6 +2,8 @@ import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
+import { resolveNpmJsonEntries } from "../../scripts/lib/npm-json-output.mts";
+import { resolveNpmRunner } from "../../scripts/npm-runner.mts";
 import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
 
 const repoRoot = path.resolve(import.meta.dirname, "../..");
@@ -17,6 +19,17 @@ const outputFiles = [
 ];
 const entryList = "scripts/lib/plugin-sdk-entrypoints.json";
 const privateList = "scripts/lib/plugin-sdk-private-local-only-subpaths.json";
+const fixtureFiles = [
+  "dist/",
+  "assets/",
+  "!assets/internal.txt",
+  "!dist/plugin-sdk/nested/internal.d.ts",
+  "!dist/plugin-sdk/owner-*.js",
+  "!dist/**/*.map",
+  "!dist/plugin-sdk/.tsbuildinfo",
+  "!dist/plugin-sdk/qa-lab.*",
+  "!dist/plugin-sdk/owner_entry.d.ts",
+];
 
 function writeJson(root: string, file: string, value: unknown) {
   fs.mkdirSync(path.dirname(path.join(root, file)), { recursive: true });
@@ -36,8 +49,8 @@ function readOutputs(root: string) {
   return outputFiles.map((file) => fs.readFileSync(path.join(root, file), "utf8"));
 }
 
-function readPackageExports(root: string): Record<string, unknown> {
-  return JSON.parse(fs.readFileSync(path.join(root, "package.json"), "utf8")).exports;
+function readPackage(root: string): { exports: Record<string, unknown>; files: string[] } {
+  return JSON.parse(fs.readFileSync(path.join(root, "package.json"), "utf8"));
 }
 
 function createFixture(inventory?: { entries: string[]; privateEntries: string[] }) {
@@ -58,7 +71,13 @@ function createFixture(inventory?: { entries: string[]; privateEntries: string[]
   if (inventory) {
     writeJson(root, entryList, inventory.entries);
     writeJson(root, privateList, inventory.privateEntries);
-    writeJson(root, "package.json", { type: "module", exports: { ".": "./index.js" } });
+    writeJson(root, "package.json", {
+      name: "sdk-registration-fixture",
+      version: "1.0.0",
+      type: "module",
+      exports: { ".": "./index.js" },
+      files: fixtureFiles,
+    });
     writeJson(root, "packages/plugin-sdk/package.json", { exports: {} });
     for (const { file, prefix } of declarationConfigs) {
       writeJson(root, file, {
@@ -101,6 +120,36 @@ function runSync(root: string, ...args: string[]) {
 }
 
 describe("plugin SDK registration CLI", () => {
+  it("detects files-only drift without writing, repairs it and stays byte-idempotent", () => {
+    const root = createFixture();
+    const original = readOutputs(root);
+    expect(runSync(root).status).toBe(0);
+    expect(readOutputs(root)).toEqual(original);
+    const manifest = readPackage(root);
+    const exclusion = "!dist/plugin-sdk/gateway-config-runtime.d.ts";
+    manifest.files = manifest.files.filter((file) => file !== exclusion);
+    writeJson(root, "package.json", manifest);
+    const before = readOutputs(root);
+
+    const result = runSync(root, "--check");
+
+    expect(readOutputs(root)).toEqual(before);
+    expect(result.status, result.stderr).toBe(1);
+    expect(result.stderr).toContain("package.json out of sync");
+    expect(result.stderr).toContain("pnpm plugin-sdk:sync-exports");
+    expect(result.stdout).not.toContain("synced");
+    for (const file of outputFiles.slice(1)) {
+      expect(result.stderr).not.toContain(file);
+    }
+    expect(runSync(root).status).toBe(0);
+    expect(readPackage(root)).toEqual({ ...manifest, files: [...manifest.files, exclusion] });
+    expect(readOutputs(root).slice(1)).toEqual(before.slice(1));
+    const synced = readOutputs(root);
+    expect(runSync(root).status).toBe(0);
+    expect(runSync(root, "--check").status).toBe(0);
+    expect(readOutputs(root)).toEqual(synced);
+  });
+
   it.each(declarationConfigs)("checks $file independently without writing", ({ file }) => {
     const root = createFixture();
     const config = readConfig(root, file);
@@ -157,10 +206,50 @@ describe("plugin SDK registration CLI", () => {
       entries: ["public-entry", "private-entry", "test-fixtures"],
       privateEntries: ["private-entry", "test-fixtures", "qa-lab"],
     });
+    const included = [
+      "assets/public.txt",
+      "dist/plugin-sdk/nested/public.d.ts",
+      "dist/plugin-sdk/owner-extra.d.ts",
+      "dist/plugin-sdk/public-entry.js",
+      "dist/plugin-sdk/public-entry.d.ts",
+      "dist/plugin-sdk/private-entry.js",
+    ];
+    const excluded = [
+      "assets/internal.txt",
+      "dist/plugin-sdk/nested/internal.d.ts",
+      "dist/plugin-sdk/owner-extra.js",
+      "dist/plugin-sdk/public-entry.js.map",
+      "dist/plugin-sdk/.tsbuildinfo",
+      "dist/plugin-sdk/qa-lab.js",
+      "dist/plugin-sdk/owner_entry.d.ts",
+      "dist/plugin-sdk/private-entry.d.ts",
+      "dist/plugin-sdk/test-fixtures.js",
+      "dist/plugin-sdk/test-fixtures.d.ts",
+    ];
+    for (const file of [...included, ...excluded]) {
+      fs.mkdirSync(path.dirname(path.join(root, file)), { recursive: true });
+      fs.writeFileSync(path.join(root, file), "fixture\n");
+    }
     const result = runSync(root);
 
     expect(result.status, result.stderr).toBe(0);
-    expect(readPackageExports(root)).toEqual({
+    const npm = resolveNpmRunner({ npmArgs: ["pack", "--dry-run", "--json", "--ignore-scripts"] });
+    const packed = spawnSync(npm.command, npm.args, { ...npm, cwd: root, encoding: "utf8" });
+    expect(packed.status, packed.stderr).toBe(0);
+    const packs = resolveNpmJsonEntries(JSON.parse(packed.stdout)) as {
+      files: { path: string }[];
+    }[];
+    expect(packs).toHaveLength(1);
+    expect(packs.flatMap((pack) => pack.files.map((file) => file.path)).toSorted()).toEqual(
+      ["package.json", ...included].toSorted(),
+    );
+    expect(readPackage(root).files).toEqual([
+      ...fixtureFiles,
+      "!dist/plugin-sdk/private-entry.d.ts",
+      "!dist/plugin-sdk/test-fixtures.d.ts",
+      "!dist/plugin-sdk/test-fixtures.js",
+    ]);
+    expect(readPackage(root).exports).toEqual({
       ".": "./index.js",
       "./plugin-sdk/public-entry": {
         types: "./dist/plugin-sdk/public-entry.d.ts",
@@ -186,12 +275,31 @@ describe("plugin SDK registration CLI", () => {
   });
 
   it.each(["removed", "public"])(
-    "prunes generated aliases when a private entry becomes %s",
+    "prunes generated aliases and exclusions when a private entry becomes %s",
     (kind) => {
       const root = createFixture({
-        entries: kind === "public" ? ["former-private"] : [],
-        privateEntries: [],
+        entries: [
+          "private-entry",
+          "test-fixtures",
+          ...(kind === "public" ? ["former-private"] : []),
+        ],
+        privateEntries: ["private-entry", "test-fixtures"],
       });
+      const manifest = readPackage(root);
+      const retained = [
+        "!dist/plugin-sdk/test-fixtures.js",
+        ...fixtureFiles,
+        "!dist/plugin-sdk/private-entry.d.ts",
+        "!dist/plugin-sdk/test-fixtures.d.ts",
+      ];
+      manifest.files = [
+        ...retained,
+        "!dist/plugin-sdk/private-entry.js",
+        "!dist/plugin-sdk/private-entry.d.ts",
+        "!dist/plugin-sdk/former-private.js",
+        "!dist/plugin-sdk/former-private.d.ts",
+      ];
+      writeJson(root, "package.json", manifest);
       for (const { file, prefix } of declarationConfigs) {
         const config = readConfig(root, file);
         config.compilerOptions.paths["openclaw/plugin-sdk/former-private"] = [
@@ -203,6 +311,7 @@ describe("plugin SDK registration CLI", () => {
       const result = runSync(root);
 
       expect(result.status, result.stderr).toBe(0);
+      expect(readPackage(root).files).toEqual(retained);
       for (const { file, prefix } of declarationConfigs) {
         expect(readConfig(root, file).compilerOptions.paths).toEqual({
           "openclaw/plugin-sdk/*": [`${prefix}dist/plugin-sdk/*.d.ts`],
@@ -210,9 +319,15 @@ describe("plugin SDK registration CLI", () => {
             `${prefix}packages/plugin-sdk/dist/src/plugin-sdk/custom.d.ts`,
             "./override.d.ts",
           ],
+          "openclaw/plugin-sdk/private-entry": [
+            `${prefix}packages/plugin-sdk/dist/src/plugin-sdk/private-entry.d.ts`,
+          ],
+          "openclaw/plugin-sdk/test-fixtures": [
+            `${prefix}packages/plugin-sdk/dist/src/plugin-sdk/test-fixtures.d.ts`,
+          ],
         });
       }
-      const exports = readPackageExports(root);
+      const exports = readPackage(root).exports;
       expect(exports["./plugin-sdk/former-private"]).toEqual(
         kind === "public"
           ? {
@@ -221,15 +336,19 @@ describe("plugin SDK registration CLI", () => {
             }
           : undefined,
       );
-      writeJson(root, entryList, ["former-private"]);
-      writeJson(root, privateList, ["former-private"]);
+      writeJson(root, entryList, ["private-entry", "test-fixtures", "former-private"]);
+      writeJson(root, privateList, ["private-entry", "test-fixtures", "former-private"]);
       expect(runSync(root).status).toBe(0);
+      expect(readPackage(root).files).toEqual([
+        ...retained,
+        "!dist/plugin-sdk/former-private.d.ts",
+      ]);
       for (const { file, prefix } of declarationConfigs) {
         expect(
           readConfig(root, file).compilerOptions.paths["openclaw/plugin-sdk/former-private"],
         ).toEqual([`${prefix}packages/plugin-sdk/dist/src/plugin-sdk/former-private.d.ts`]);
       }
-      expect(readPackageExports(root)["./plugin-sdk/former-private"]).toEqual({
+      expect(readPackage(root).exports["./plugin-sdk/former-private"]).toEqual({
         default: "./dist/plugin-sdk/former-private.js",
       });
     },


### PR DESCRIPTION
Related: #132649, whose producer fixture cleanup is now on main via #132643.

Related: #132311 (private declaration aliases), #132485 (browser repair that exposed the package exclusion gap).

<details>
<summary>Additional instructions</summary>

This same-repository maintainer branch remains available for maintainer updates.

</details>

## What Problem This Solves

Resolves a problem where maintainers registering a private Plugin SDK entrypoint could successfully run sync and check, yet still publish its private declaration and fail release validation. The browser repair exposed this for `gateway-config-runtime`: its runtime export and workspace declaration aliases were generated, but its package exclusion required manual maintenance.

The required CI investigation also reproduced #132649: an async-task test aborted its waiter but left its fixture running, so the following benchmark correctly refused to drain. The equivalent producer cleanup has since been confirmed on main in #132643; this PR retains that canonical repair.

## Why This Change Was Made

The existing `syncRootPackageMetadata` owner now reconciles exports and package `files` from `listUnpackagedPrivatePluginSdkDistArtifacts()`, the same registration-derived contract used by release-check. There is no second inventory or generator.

The synchronizer owns literal flat SDK `.js` and `.d.ts` exclusions, including underscore, mixed-case, dot, and Unicode names. It keeps valid order, removes duplicates and obsolete exclusions, and appends missing exclusions in canonical order. Nested paths, glob/escape syntax, metadata, unrelated rules, and intentional workspace alias omissions retain their contracts. The ClawSweeper name/idempotence finding and both rank-up moves are addressed by supporting the existing inventory contract rather than restricting its grammar.

The canonical CI repair adds teardown in the test that creates the leaked fixture and consolidates its setup. It changes no runtime drain, timeout, isolation, or shared-runner policy. It is credited to #132643 rather than duplicated here.

Production tooling: +25/-8 (net +17); tests: +169/-32 (net +137); docs: +7/-2 (net +5). The tooling growth supplies the missing package-files projection inside the existing owner. There are no dependency, baseline, budget, configuration, inventory, lockfile, SQLite schema, or persisted user-state changes; package metadata reconciliation needs no user-data migration.

AI-assisted with Codex; final implementation and proof reviewed by the maintainer.

## User Impact

One registration command repairs the complete package boundary, and check mode detects files-only drift. Private declarations and test-only runtime artifacts remain unpackaged; public SDK types, production-private runtime JavaScript, and local workspace aliases retain their existing contracts. The separately landed CI producer cleanup prevents unfinished fixtures leaking into the benchmark.

## Evidence

- Before the initial fix, sync and check both exited 0 while actual npm dry-pack leaked a private declaration. Four initial registration regressions failed before repair.
- Final registration suite: 15 tests passed, including actual npm pack, repeated byte-idempotence, underscore/mixed-case/dot/Unicode names, public promotion, removal/re-add, and preserved glob/nested/metadata rules. Six new lifecycle/idempotence cases failed before the literal matcher repair. One initial after-run had an npm-pack test timeout; the unchanged command passed on retry, without increasing timeouts.
- `node scripts/run-vitest.mjs test/release-check.test.ts src/plugins/contracts/plugin-sdk-package-contract-guardrails.test.ts` — 82 tests passed. The earlier four-file registration/release/SDK contract run passed 109 tests.
- `node scripts/check-changed.mjs -- scripts/sync-plugin-sdk-exports.mts test/scripts/sync-plugin-sdk-exports.test.ts docs/plugins/sdk-subpaths.md` — complete selected gate passed.
- `node scripts/check-changed.mjs -- src/agents/embedded-agent-runner/run/attempt.async-tasks.test.ts` — complete selected core-test gate passed.
- CI reproduction: the exact original 643-file `core-unit-fast-1` list reproduced the benchmark failure. Diagnostics showed one running task fixture and zero root requests or other active-work categories. The ordered producer/benchmark pair failed before cleanup and passed all 17 tests afterward, with no runtime diagnostics. The original 643-file shard then passed: 642 files passed/1 skipped; 7,493 tests passed/4 skipped. Local proof used macOS Node 26; hosted CI uses Linux Node 24.
- Earlier full build and real npm dry-pack proof used the original `b3362142c72` baseline plus the initial packaging repair: 147 public SDK entrypoints, 173 private runtime entrypoints, and 215 private exclusions checked; zero missing or leaked SDK artifacts and zero forbidden pack paths. `gateway-config-runtime.js` was packed and its built declaration excluded. This is retained build evidence, not a claim of a full local build at the final head; the registry and checked-in package/alias manifests are unchanged.
- After the conflict-only rebase, all 15 SDK tests and the ordered 17-test producer/benchmark pair passed again; the SDK patch ID is unchanged and the fixture file matches main exactly. Registration `--check` and `git diff --check` passed. Fresh full-candidate isolated Codex autoreview completed scoped-clean at the requested P0 threshold, with no accepted/actionable findings.

Final source: [0c01eb8ba97e](https://github.com/openclaw/openclaw/commit/0c01eb8ba97ebdd3bd728188ba40a6584aa13f1f). Exact-head [CI run 33263880672](https://github.com/openclaw/openclaw/actions/runs/33263880672) passed (168 successful jobs, 17 skipped), including required `openclaw/ci-gate`. The latest exact-head ClawSweeper review has no actionable finding. Native review artifacts validated with zero findings; prepare/merge receipts follow through the native landing workflow. Full [land-ready proof](https://github.com/openclaw/openclaw/pull/132645#issuecomment-5463120557) records commands, retained-build limits, and the non-required cancelled dispatch. The prior failed run was [33258749921](https://github.com/openclaw/openclaw/actions/runs/33258749921); it was not blindly rerun.
