### PR TITLE
refactor(browser): simplify commanded document transitions

### DIFF
--- a/extensions/browser/chrome-extension/modules/tab-document-provenance.js
+++ b/extensions/browser/chrome-extension/modules/tab-document-provenance.js
@@ -25,25 +25,13 @@ export function createTabDocumentProvenance({ access }) {
     document?.navigation.cancel();
   }
 
-  function commitTabDocument(tabId, url) {
-    const document = documents.get(tabId);
-    if (!document || url === "about:blank") {
-      return;
-    }
-    if (document.navigation.confirmed) {
-      documents.delete(tabId);
-    } else {
-      access.invalidateTab(tabId);
-    }
-  }
-
   function observeTab(tab) {
     const document = documents.get(tab?.id);
     if (!document) {
       return;
     }
-    if (tab.url && document.navigation.confirmed) {
-      commitTabDocument(tab.id, tab.url);
+    if (tab.url && tab.url !== "about:blank" && document.navigation.confirmed) {
+      documents.delete(tab.id);
     }
     if (
       !document.isCurrent() ||
@@ -139,7 +127,7 @@ export function createTabDocumentProvenance({ access }) {
         event.params.frame.id === document.navigation.frameId &&
         frameUrl !== "about:blank"
       ) {
-        commitTabDocument(event.tabId, frameUrl);
+        documents.delete(event.tabId);
       } else {
         try {
           document.navigation.observe(event, send);
@@ -148,8 +136,6 @@ export function createTabDocumentProvenance({ access }) {
         }
         return;
       }
-    } else if (root) {
-      commitTabDocument(event.tabId, frameUrl);
     }
     send(event);
   }
@@ -228,18 +214,13 @@ function createDocumentNavigation({ frameId, isCurrent, revoke }) {
           fail();
           return;
         }
-        if (state.kind === "blank") {
-          if (state.loaderId !== frame.loaderId) {
-            fail();
-            return;
-          }
-        } else if (state.kind === "pending") {
+        if (state.kind === "pending") {
           if (state.commit && state.commit !== frame.loaderId) {
             fail();
             return;
           }
           state.commit = frame.loaderId;
-        } else if (state.kind === "responded" && state.loaderId !== frame.loaderId) {
+        } else if (state.loaderId !== frame.loaderId) {
           fail();
           return;
         }


### PR DESCRIPTION
Related: https://github.com/openclaw/openclaw/pull/132485 (Chrome tracing and reconnect repair)

## What Problem This Solves

Maintainer-requested simplification of the Chrome plugin's commanded-document lifecycle after the tracing repair. The owner retained an unreachable helper branch and repeated the same loader check in two navigation states, making the authority transition harder to audit than necessary.

## Why This Change Was Made

Remove `commitTabDocument`: both effective callers already require confirmed navigation, while its no-document caller is a no-op. Inline the two confirmed nonblank record removals. Pending navigation still checks its observed commit separately; responded and confirmed states share their identical loader-consistency check.

This keeps one canonical document owner and changes no state, callback, URL policy, epoch/currentness check, event-buffer bound, cleanup authority, public API, configuration, or dependency. The caller's synchronous root-commit callback cannot create a document record. Creation/access-policy, Runtime, Fetch and physical-session changes owned by the separate mixed-client relay repair are deliberately outside this PR.

Production LOC: +5/-24 (net -19). Tests: +0/-0. No compatibility path or new abstraction.

## User Impact

No intended user-visible behavior change. Commanded blank navigation and tracing continue to respect tab-group membership, pause/revocation, incognito, URL eligibility, attachment identity and connection lifecycle. This cleanup does not claim to repair or clear separate mixed-client Fetch/SSRF behavior.

## Evidence

- The same five owner/boundary suites passed on the original code and the simplified code: **144 tests each**, including commit-before/after-response, loader disagreement, bounded buffering, fragment handling, trace/return order, creation, explicit close, revocation, reconnect and restart. All 144 passed again after repairing the checkout's incomplete dependency installation.
- Full changed checks passed, including production/test typechecks, lint, boundary/ratchet checks, dead-export scans and zero runtime import cycles.
- The first changed-check attempt exposed a missing installed `matrix-events-sdk` manifest. One `pnpm install --frozen-lockfile` repaired the local install without tracked dependency changes; the doctor declaration/closure checks then passed all five tests and the complete changed-check retry passed.
- Isolated Codex autoreview returned no findings at its default blocking-priority scope. Four independent cleanup reviews preceded the change.
- Fresh **local Docker** proof on exact head `3f0b8053e5af8128165946b51e719b6f6d3af8c7` passed: canonical `pnpm build` (528.692s), then the unchanged six-case Chrome/MCP controller (175.734s). Linux arm64, Node24.18.1, Playwright1.62.1 and official Chrome DevTools MCP1.8.0; no host mounts, credentials, published ports or remote compute.
- Outcomes: the historical control reproduced the exact denied blank transition; both All and Selected default-reload traces parsed native navigation and returned to the exact source URL including its fragment; active pause detached the native debugger and disposed recording; actual transport loss/reconnect rejected stale control while the original MCP remained alive during the fresh-client disposal probe; explicit blank navigation/close removed the native target. Unrelated tabs remained unchanged.
- Verified 35,140 source entries,57 fixture files,345 official MCP files and14,455 built files. The source and packaged provenance module both hash to `84c9c39dc1c7feb19c29ac70db6c437bbbd7f0691c9f8e95fdb05f9c5fa70660`. Host source did not drift. All six captures were inspected; they corroborate visible page state, while structured native assertions establish lifecycle behavior. The close capture precedes the deliberate close.
- Cleanup: zero remaining Node/browser/MCP processes; the exact owned container is absent. The outer wrapper initially returned1 only because its case-sensitive absence-text assertion expected `No such object` while Docker29 returned lowercase `no such object`, after successful removal. Original failure evidence was preserved and reconciled using a successful exact-ID container listing against the healthy local daemon. No Chrome rerun or product/fixture assertion change was needed.
- Observer limitation: the external process sampler captured browser processes but missed MCP rows. Each unchanged fixture independently verified its real MCP PID executable and server version; the final full-process inventory verified no workload remained.
- Exact-head CI is green: https://github.com/openclaw/openclaw/actions/runs/33258738741 . Current ClawSweeper review has no code findings; its requested exact-head CI and maintainer-handling checks are satisfied. Its latest comment was read directly; no additional code rank-up move was present. The separately reproduced task-registry leak on the main base was fixed by [#132643 — state and async-task fixture cleanup](https://github.com/openclaw/openclaw/pull/132643), merged as `2c7f11e3d4b9dc3045817466bc8aadb965e65852` at2026-08-29T15:15:33Z with [green exact-head CI](https://github.com/openclaw/openclaw/actions/runs/33259249878). The unchanged original producer→benchmark sequence passed17 tests on refreshed main `6c715ed03752e213e32b683aee65c7cc0254fd79`; its fixture blob is byte-identical to that canonical fix. No duplicate fix or weakened benchmark is included here. **Attribution correction (2026-08-29):** this section previously linked an intermediate duplicate in #132666. That duplicate was dropped before merge; final [#132666](https://github.com/openclaw/openclaw/pull/132666) contains only voice-call test/support changes. The browser merge and reported test results are unchanged.

Focused command:

```bash
node scripts/run-vitest.mjs run extensions/browser/chrome-extension/modules/tab-document-provenance.test.ts extensions/browser/chrome-extension/modules/tab-access.test.ts extensions/browser/chrome-extension/modules/tab-access-events.navigation.test.ts extensions/browser/chrome-extension/background.document-navigation.test.ts extensions/browser/chrome-extension/background.creation-lifecycle.test.ts
```

Changed checks:

```bash
node scripts/check-changed.mjs -- extensions/browser/chrome-extension/modules/tab-document-provenance.js
```

AI-assisted; maintainer-requested cleanup. No operator browser/profile, native registration, Gateway, account or credential changes. No UI/visual behavior change; synthetic captures, if taken, remain local unless separately approved for upload.
