### PR TITLE
perf(parallel): keep search limits on the lightweight descriptor

### DIFF
--- a/extensions/parallel/src/parallel-free-web-search-provider.shared.ts
+++ b/extensions/parallel/src/parallel-free-web-search-provider.shared.ts
@@ -1,5 +1,8 @@
 import { createWebSearchProviderContractFields } from "openclaw/plugin-sdk/provider-web-search-contract";
 
+// Shared by the tool schema and runtime validation without loading search execution.
+export const PARALLEL_FREE_SESSION_ID_MAX_LENGTH = 100;
+
 const PARALLEL_FREE_ONBOARDING_SCOPES: Array<"text-inference"> = ["text-inference"];
 
 export function createParallelFreeWebSearchProviderBase() {

--- a/extensions/parallel/src/parallel-free-web-search-provider.ts
+++ b/extensions/parallel/src/parallel-free-web-search-provider.ts
@@ -1,7 +1,9 @@
 import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
 import type { WebSearchProviderPlugin } from "openclaw/plugin-sdk/provider-web-search-contract";
-import { createParallelFreeWebSearchProviderBase } from "./parallel-free-web-search-provider.shared.js";
-import { PARALLEL_FREE_SESSION_ID_MAX_LENGTH } from "./parallel-search-normalize.js";
+import {
+  createParallelFreeWebSearchProviderBase,
+  PARALLEL_FREE_SESSION_ID_MAX_LENGTH,
+} from "./parallel-free-web-search-provider.shared.js";
 // Reuse the paid provider's tool schema — both transports accept the same
 // objective + search_queries shape — but the free Search MCP caps session_id at
 // 100 chars (its `tools/list` schema), tighter than the paid v1 REST limit, so

--- a/extensions/parallel/src/parallel-search-normalize.ts
+++ b/extensions/parallel/src/parallel-search-normalize.ts
@@ -22,6 +22,7 @@ import {
   normalizeOptionalString,
 } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
+import { PARALLEL_FREE_SESSION_ID_MAX_LENGTH } from "./parallel-free-web-search-provider.shared.js";
 
 // Internal-only bounds (the model-facing tool schema declares its own copies).
 const PARALLEL_MAX_SEARCH_COUNT = 40;
@@ -35,7 +36,6 @@ const PARALLEL_MAX_SEARCH_QUERIES = 5;
 // `tools/list` schema caps session_id at 100. Each runtime passes its own limit
 // (and advertises it in the tool schema) so callers never send an out-of-contract id.
 const PARALLEL_SESSION_ID_MAX_LENGTH = 1000;
-export const PARALLEL_FREE_SESSION_ID_MAX_LENGTH = 100;
 const PARALLEL_CLIENT_MODEL_MAX_LENGTH = 100;
 
 export const normalizeParallelSessionId: (


### PR DESCRIPTION
## Summary

The free Parallel search descriptor imports `parallel-search-normalize` only for the 100-character session ID limit. That pulls search execution dependencies into public-artifact discovery and plugin registration despite the runtime already being lazy.

Move the unchanged limit into the existing lightweight free-provider shared module. Both schema construction and runtime normalization consume the same constant. No new public API, schema, configuration, request, cache, cancellation or transport behavior changes.

Production +8/-3 (a constant relocation, import formatting and one ownership comment); tests unchanged. No sharding, worker count, concurrency, test selection, assertions or payload changes.

## Validation

- Normal public-artifact suite: all 17 cases pass; execution 6.166s before and 4.126s after. The Parallel case drops from 2.142s to 0.058s on the same refreshed build baseline.
- All 59 existing Parallel paid/free provider tests pass, including tool schemas, session limits, real request shaping, MCP handshake, cancellation and cache behavior through the existing endpoint fixture.
- A cold executable probe loads both actual public descriptors, constructs both schemas, checks limits 100/1000 and selection wiring while rejecting any import of search normalization. Candidate passes; original source fails with the expected eager-runtime marker.
- Changing the shared free limit to 101 deliberately fails the existing schema assertion. Original candidate bytes restored afterward.
- Full local build passes. Built-plugin isolated entrypoint profiling reports maximum RSS 191.2 MB before and 78.5 MB after; no combined-process measurement is claimed.
- Changed-file checks and independent Codex autoreview pass.

No changelog required for internal import-topology performance work. External API behavior is unchanged; runtime proof uses the existing paid/free transport fixtures without live provider requests.
