### PR TITLE
fix(control-ui): make Skill Workshop details readable on mobile

### DIFF
--- a/ui/src/e2e/plugins-hub-navigation.e2e.test.ts
+++ b/ui/src/e2e/plugins-hub-navigation.e2e.test.ts
@@ -100,6 +100,28 @@ const methodResponses = {
   },
 };
 
+const emptyMethodResponses = {
+  ...methodResponses,
+  "skills.proposals.list": {
+    ...methodResponses["skills.proposals.list"],
+    proposals: [],
+  },
+};
+
+const workshopFeatureMethods = [
+  "agents.list",
+  "config.get",
+  "plugins.list",
+  "skills.proposals.historyStatus",
+  "skills.proposals.inspect",
+  "skills.proposals.list",
+  "skills.proposals.apply",
+  "skills.proposals.evaluate",
+  "skills.proposals.reject",
+  "skills.proposals.requestRevision",
+  "skills.status",
+];
+
 type HubGeometry = {
   contentLeft: number;
   contentWidth: number;
@@ -248,6 +270,20 @@ async function expectWorkshopActionsReachable(
     .toBe(true);
 }
 
+async function expectEmptyWorkshopDoesNotScroll(page: Page, emptySelector: string) {
+  const content = page.locator(".content--skill-workshop");
+  const emptyState = page.locator(emptySelector);
+  await emptyState.waitFor({ state: "visible" });
+  expect(await emptyState.evaluate((element) => getComputedStyle(element).minHeight)).toBe("0px");
+  await content.evaluate((element) => element.scrollTo({ top: 0 }));
+  await expect
+    .poll(() => content.evaluate((element) => element.scrollHeight - element.clientHeight))
+    .toBeLessThanOrEqual(1);
+  await content.hover();
+  await page.mouse.wheel(0, 844);
+  expect(await content.evaluate((element) => element.scrollTop)).toBe(0);
+}
+
 async function selectHubTab(
   page: Page,
   name: "Installed" | "Discover" | "Skills" | "Workshop",
@@ -273,19 +309,7 @@ suite.define(() => {
       const context = await createContext(viewport);
       const page = await context.newPage();
       await installMockGateway(page, {
-        featureMethods: [
-          "agents.list",
-          "config.get",
-          "plugins.list",
-          "skills.proposals.historyStatus",
-          "skills.proposals.inspect",
-          "skills.proposals.list",
-          "skills.proposals.apply",
-          "skills.proposals.evaluate",
-          "skills.proposals.reject",
-          "skills.proposals.requestRevision",
-          "skills.status",
-        ],
+        featureMethods: workshopFeatureMethods,
         methodResponses,
       });
 
@@ -367,8 +391,34 @@ suite.define(() => {
           .poll(() => page.locator("#skill-workshop-mode-tab-board").getAttribute("active"))
           .not.toBeNull();
         expectStableGeometry(await hubGeometry(page), installed);
+        const boardLayout = await page.locator(".content--skill-workshop").evaluate((element) => {
+          const style = getComputedStyle(element);
+          return { display: style.display, overflow: style.overflow };
+        });
+        if (viewport.width > 768) {
+          expect(boardLayout).toEqual({ display: "flex", overflow: "hidden" });
+        }
+        if (viewport.width <= 768) {
+          const workshopMinHeight = await page
+            .locator(".sw-hub-panel .skill-workshop")
+            .evaluate((element) => getComputedStyle(element).minHeight);
+          expect(workshopMinHeight).toBe("0px");
+        }
         await captureScreenshot(page, `${label}-05-workshop-board-top.png`);
         await expectWorkshopActionsReachable(page, label, viewport);
+
+        if (label === "narrow") {
+          await page.getByRole("button", { name: /^Applied/u }).click();
+          await captureScreenshot(page, "narrow-07-workshop-board-filter-empty.png");
+          expect(
+            await page
+              .locator(".sw-detail--empty")
+              .evaluate((element) => getComputedStyle(element).minHeight),
+          ).toBe("0px");
+          await page
+            .locator(".content--skill-workshop")
+            .evaluate((element) => element.scrollTo({ top: 0 }));
+        }
 
         await page.locator("#skill-workshop-mode-tab-today").click();
         await expect
@@ -400,4 +450,26 @@ suite.define(() => {
       }
     },
   );
+
+  it("keeps an empty mobile Workshop board from scrolling into blank space", async () => {
+    const context = await createContext({ height: 844, width: 390 });
+    const page = await context.newPage();
+    await installMockGateway(page, {
+      featureMethods: workshopFeatureMethods,
+      methodResponses: emptyMethodResponses,
+    });
+
+    try {
+      await page.goto(`${suite.server.baseUrl}skills/workshop`);
+      await waitForControlUiRoute(page, {
+        pathname: "/skills/workshop",
+        routeId: "skill-workshop",
+      });
+      await page.locator("#skill-workshop-mode-tab-board").click();
+      await captureScreenshot(page, "narrow-empty-workshop-board.png");
+      await expectEmptyWorkshopDoesNotScroll(page, ".sw-empty-state");
+    } finally {
+      await context.close();
+    }
+  });
 });

--- a/ui/src/e2e/plugins-hub-navigation.e2e.test.ts
+++ b/ui/src/e2e/plugins-hub-navigation.e2e.test.ts
@@ -19,6 +19,19 @@ beforeEach(() => {
   }
 });
 
+const workshopProposal = {
+  id: "mobile-workshop-proof",
+  kind: "create",
+  status: "pending",
+  title: "Mobile Workshop Proof",
+  description: "Keep proposal details and actions reachable on narrow screens.",
+  skillName: "Mobile Workshop Proof",
+  skillKey: "mobile-workshop-proof",
+  createdAt: "2026-08-17T12:00:00.000Z",
+  updatedAt: "2026-08-17T12:00:00.000Z",
+  scanState: "clean",
+};
+
 const methodResponses = {
   "agents.list": {
     agents: [
@@ -63,9 +76,22 @@ const methodResponses = {
     lastScanReviewed: 0,
   },
   "skills.proposals.list": {
-    proposals: [],
+    proposals: [workshopProposal],
     schema: "openclaw.skill-workshop.proposals-manifest.v1",
     updatedAt: "2026-08-17T12:00:00.000Z",
+  },
+  "skills.proposals.inspect": {
+    content:
+      "# Mobile Workshop Proof\n\nKeep proposal details and actions reachable on narrow screens.",
+    record: {
+      ...workshopProposal,
+      proposedVersion: "v1",
+      target: {
+        skillKey: workshopProposal.skillKey,
+        skillName: workshopProposal.skillName,
+      },
+    },
+    supportFiles: [],
   },
   "skills.status": {
     workspaceDir: "/tmp/openclaw-e2e/workspace",
@@ -189,9 +215,37 @@ async function captureScreenshot(page: Page, name: string) {
   }
   await page.screenshot({
     animations: "disabled",
-    fullPage: true,
+    fullPage: false,
     path: path.join(proofDir, name),
   });
+}
+
+async function expectWorkshopActionsReachable(
+  page: Page,
+  label: string,
+  viewport: { height: number; width: number },
+) {
+  const content = page.locator(".content--skill-workshop");
+  const detail = page.locator(".sw-detail__body");
+  const actions = page.locator(".sw-action-bar");
+  await expect.poll(() => detail.textContent()).toContain("Keep proposal details and actions");
+  await actions.waitFor({ state: "attached" });
+
+  if (viewport.width <= 768) {
+    await content.hover();
+    await page.mouse.wheel(0, viewport.height * 2);
+    await captureScreenshot(page, `${label}-06-workshop-board-after-scroll.png`);
+    await expect.poll(() => content.evaluate((element) => element.scrollTop)).toBeGreaterThan(0);
+  }
+
+  await expect
+    .poll(() =>
+      actions.evaluate((element) => {
+        const rect = element.getBoundingClientRect();
+        return rect.bottom > 0 && rect.top < window.innerHeight;
+      }),
+    )
+    .toBe(true);
 }
 
 async function selectHubTab(
@@ -209,9 +263,10 @@ async function selectHubTab(
 suite.define(() => {
   it.each([
     { label: "desktop", viewport: { height: 1053, width: 2048 } },
+    { label: "standard", viewport: { height: 960, width: 1440 } },
     { label: "laptop", viewport: { height: 768, width: 1366 } },
     { label: "tablet", viewport: { height: 1024, width: 768 } },
-    { label: "narrow", viewport: { height: 852, width: 393 } },
+    { label: "narrow", viewport: { height: 844, width: 390 } },
   ])(
     "keeps the hub shell fixed through every $label tab transition",
     async ({ label, viewport }) => {
@@ -223,7 +278,12 @@ suite.define(() => {
           "config.get",
           "plugins.list",
           "skills.proposals.historyStatus",
+          "skills.proposals.inspect",
           "skills.proposals.list",
+          "skills.proposals.apply",
+          "skills.proposals.evaluate",
+          "skills.proposals.reject",
+          "skills.proposals.requestRevision",
           "skills.status",
         ],
         methodResponses,
@@ -307,15 +367,8 @@ suite.define(() => {
           .poll(() => page.locator("#skill-workshop-mode-tab-board").getAttribute("active"))
           .not.toBeNull();
         expectStableGeometry(await hubGeometry(page), installed);
-        const boardLayout = await page.locator(".content--skill-workshop").evaluate((element) => {
-          const style = getComputedStyle(element);
-          return { display: style.display, overflowY: style.overflowY };
-        });
-        expect(boardLayout).toEqual({
-          display: "flex",
-          overflowY: label === "narrow" ? "auto" : "hidden",
-        });
-        await captureScreenshot(page, `${label}-05-workshop-board.png`);
+        await captureScreenshot(page, `${label}-05-workshop-board-top.png`);
+        await expectWorkshopActionsReachable(page, label, viewport);
 
         await page.locator("#skill-workshop-mode-tab-today").click();
         await expect

--- a/ui/src/e2e/plugins-hub-navigation.e2e.test.ts
+++ b/ui/src/e2e/plugins-hub-navigation.e2e.test.ts
@@ -309,9 +309,12 @@ suite.define(() => {
         expectStableGeometry(await hubGeometry(page), installed);
         const boardLayout = await page.locator(".content--skill-workshop").evaluate((element) => {
           const style = getComputedStyle(element);
-          return { display: style.display, overflow: style.overflow };
+          return { display: style.display, overflowY: style.overflowY };
         });
-        expect(boardLayout).toEqual({ display: "flex", overflow: "hidden" });
+        expect(boardLayout).toEqual({
+          display: "flex",
+          overflowY: label === "narrow" ? "auto" : "hidden",
+        });
         await captureScreenshot(page, `${label}-05-workshop-board.png`);
 
         await page.locator("#skill-workshop-mode-tab-today").click();

--- a/ui/src/styles/skill-workshop.css
+++ b/ui/src/styles/skill-workshop.css
@@ -1259,10 +1259,23 @@
 @media (max-width: 768px) {
   .sw-triage {
     grid-template-columns: minmax(0, 1fr);
+    grid-template-rows: minmax(96px, 22vh) minmax(80vh, auto);
   }
 
   .sw-queue-resizer {
     display: none;
+  }
+
+  .content--skill-workshop {
+    overflow-y: auto;
+  }
+
+  .sw-hub-panel,
+  .sw-hub-panel::part(base),
+  .skill-workshop,
+  .sw-view,
+  .sw-view__pane {
+    min-height: auto;
   }
 }
 

--- a/ui/src/styles/skill-workshop.css
+++ b/ui/src/styles/skill-workshop.css
@@ -1257,11 +1257,24 @@
 }
 
 @media (max-width: 768px) {
-  /* Keep enough queue context to select a proposal and give its detail a full
-     viewport. The tab/flex chain returns to natural height so the page scrolls. */
+  /* Keep enough queue context to select a proposal and give populated details
+     a full viewport. Empty states stay intrinsic instead of creating blank scroll. */
   .sw-triage {
     grid-template-columns: minmax(0, 1fr);
-    grid-template-rows: minmax(96px, 22vh) minmax(80vh, auto);
+    grid-template-rows: minmax(96px, 22vh) auto;
+  }
+
+  .sw-triage > .sw-detail:not(.sw-detail--empty) {
+    min-height: 80vh;
+  }
+
+  .sw-triage > .sw-detail--empty,
+  .sw-empty-state {
+    min-height: 0;
+  }
+
+  .sw-empty-state {
+    padding: 8px 20px;
   }
 
   .sw-queue-resizer {
@@ -1276,7 +1289,6 @@
   #skill-workshop-mode-panel,
   .sw-hub-panel::part(base),
   #skill-workshop-mode-panel::part(base),
-  .skill-workshop,
   .sw-view,
   .sw-view__pane {
     min-height: auto;

--- a/ui/src/styles/skill-workshop.css
+++ b/ui/src/styles/skill-workshop.css
@@ -1257,6 +1257,8 @@
 }
 
 @media (max-width: 768px) {
+  /* Keep enough queue context to select a proposal and give its detail a full
+     viewport. The tab/flex chain returns to natural height so the page scrolls. */
   .sw-triage {
     grid-template-columns: minmax(0, 1fr);
     grid-template-rows: minmax(96px, 22vh) minmax(80vh, auto);
@@ -1271,7 +1273,9 @@
   }
 
   .sw-hub-panel,
+  #skill-workshop-mode-panel,
   .sw-hub-panel::part(base),
+  #skill-workshop-mode-panel::part(base),
   .skill-workshop,
   .sw-view,
   .sw-view__pane {

--- a/ui/src/styles/skill-workshop.css
+++ b/ui/src/styles/skill-workshop.css
@@ -1274,7 +1274,7 @@
   }
 
   .sw-empty-state {
-    padding: 8px 20px;
+    padding: 0 20px;
   }
 
   .sw-queue-resizer {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Skill Workshop descriptions were clipped on screens up to 768px.

## Why This Change Was Made

The mobile board now scrolls vertically and gives populated detail panes 80vh. Empty states keep their intrinsic height, so a zero-proposal board does not create an empty scroll region. Desktop behavior is unchanged.

## User Impact

Skill descriptions and actions are readable on mobile.

## Evidence

| Viewport | Current main | In this PR |
|---|---|---|
| Desktop, 1440×960 — layout remains unchanged | ![Current main desktop Skill Workshop](https://github.com/user-attachments/assets/a75593cf-2eea-497b-91d1-93f45e81f231)<br><sub>Fresh current-main build capture</sub> | ![Desktop Skill Workshop in this PR](https://github.com/user-attachments/assets/a0aad3a4-7b73-49a3-987c-2545c4bcea6c)<br><sub>Fresh PR-build capture</sub> |
| Mobile, 390×844 — scrolling now reaches the proposal detail and action bar | ![Current main mobile Skill Workshop clipped after attempted scroll](https://github.com/user-attachments/assets/b5868914-974c-43f0-9c68-4675ab04611b) | ![Mobile Skill Workshop action bar reachable in this PR](https://github.com/user-attachments/assets/f2c9355c-edea-43c7-a2cf-5a8ff087108c) |

Desktop is intentionally unchanged by this fix; the two desktop images above are distinct captures from the current-main and PR builds and are expected to render identically.

### Zero-proposal mobile board

![Zero-proposal mobile Skill Workshop fits without empty scroll](https://github.com/user-attachments/assets/e181b4d8-a88b-45c0-841d-40fccde6f5b0)

<sub>PR build at 390×844: the full zero-proposal state fits without a forced minimum-height scroll region.</sub>

- Current main reproduction: at 390px, the outer workshop container remains at `scrollTop = 0` after a downward scroll and the action bar is unreachable.
- In this PR, the production-bundle browser suite passes 6/6 tests at 2048×1053, 1440×960, 1366×768, 768×1024, and 390×844. It verifies mobile proposal reachability plus the zero-proposal no-scroll path.
- Computed-style assertions preserve desktop `display: flex` / `overflow: hidden`, prove `.sw-hub-panel .skill-workshop` remains the winning `min-height: 0px` rule on mobile, and prove filtered-empty detail does not inherit the populated-detail minimum.
- The repository-selected changed-file checks pass, including formatting, lint, style, typechecking, and dead-export analysis.

## Risk and coverage

The responsive override could have changed desktop sizing, tablet behavior, tab-panel height propagation, empty-state sizing, or proposal actions. The before/after desktop captures are layout-stable, and the same browser flow covers every tab transition plus all five workshop action methods across desktop, laptop, tablet, and phone sizes. A dedicated zero-proposal fixture proves the out-of-box mobile board has no scroll range. The mock gateway proves the built Control UI path with deterministic fixture data; a physical-device pass remains outside this PR's local proof.

LOC: +16/−4 production CSS lines and +85/−13 test lines. The production growth is owner-local responsive policy: populated details retain the readable viewport minimum, empty states remain intrinsic, and the existing mobile scroll surface is preserved. The dead lower-specificity selector was removed; no parallel runtime path was added.

Latest completed ClawSweeper review, `updated_at=2026-09-04T00:31:28Z`, reviewed prior head `79cc27ce617c` and said “Blocked before merge - 2 items remain” while also stating “No correctness finding was identified”; its two open items were the prior exact-head CI rollup failures. On follow-up head `430e2d4f209`, all 13 UI-E2E shards and the real-Gateway lane pass. `security-fast` and its consequential aggregate gate remain red after one failed-job rerun because the bulk advisory request exceeded its fixed 60-second timeout.

## Provenance

Original fix and diagnosis by @brayanjeshua; maintainer follow-up rebased it onto current main, completed the tab-panel height chain, removed the dead mobile selector, and added populated and empty-state behavioral regression proof.

References OCF-62

