### PR TITLE
fix(sessions): isolate global target watch cursors

### DIFF
--- a/src/auto-reply/reply/session-system-events.ts
+++ b/src/auto-reply/reply/session-system-events.ts
@@ -22,7 +22,7 @@ import {
   type SystemEvent,
 } from "../../infra/system-events.js";
 import { acknowledgeSessionStateNotices } from "../../sessions/session-state-events.js";
-import { decodeSessionStateNoticeContextKey } from "../../sessions/session-state-notices.js";
+import { decodeSessionStateNoticeTarget } from "../../sessions/session-state-notices.js";
 
 function isCronContextSystemEvent(event: SystemEvent): boolean {
   return event.contextKey?.startsWith("cron:") ?? false;
@@ -127,9 +127,9 @@ export async function drainFormattedSystemEvents(params: {
   );
   const sessionStateTargets = queued
     .map((event) =>
-      event.contextKey ? decodeSessionStateNoticeContextKey(event.contextKey) : undefined,
+      event.contextKey ? decodeSessionStateNoticeTarget(event.contextKey) : undefined,
     )
-    .filter((target): target is string => target !== undefined);
+    .filter((target): target is NonNullable<typeof target> => target !== undefined);
   if (sessionStateTargets.length > 0) {
     acknowledgeSessionStateNotices(params.sessionKey, sessionStateTargets);
   }

--- a/src/auto-reply/reply/session-system-events.ts
+++ b/src/auto-reply/reply/session-system-events.ts
@@ -22,7 +22,10 @@ import {
   type SystemEvent,
 } from "../../infra/system-events.js";
 import { acknowledgeSessionStateNotices } from "../../sessions/session-state-events.js";
-import { decodeSessionStateNoticeTarget } from "../../sessions/session-state-notices.js";
+import {
+  decodeSessionStateNoticeContextKey,
+  decodeSessionStateNoticeTarget,
+} from "../../sessions/session-state-notices.js";
 
 function isCronContextSystemEvent(event: SystemEvent): boolean {
   return event.contextKey?.startsWith("cron:") ?? false;
@@ -127,7 +130,10 @@ export async function drainFormattedSystemEvents(params: {
   );
   const sessionStateTargets = queued
     .map((event) =>
-      event.contextKey ? decodeSessionStateNoticeTarget(event.contextKey) : undefined,
+      event.contextKey
+        ? (decodeSessionStateNoticeTarget(event.contextKey) ??
+          decodeSessionStateNoticeContextKey(event.contextKey))
+        : undefined,
     )
     .filter((target): target is NonNullable<typeof target> => target !== undefined);
   if (sessionStateTargets.length > 0) {

--- a/src/sessions/session-state-events.test.ts
+++ b/src/sessions/session-state-events.test.ts
@@ -499,16 +499,28 @@ describe("session state events", () => {
     ).toEqual({ count: 1 });
   });
 
-  it("ignores legacy bare target cursors without an owning agent", () => {
+  it("ignores legacy bare target cursors without an owning agent", async () => {
     const database = createDatabaseOptions();
-    openOpenClawStateDatabase(database)
-      .db.prepare(
+    await createWatcherSession(database);
+    const stateDb = openOpenClawStateDatabase(database).db;
+    const now = Date.now();
+    stateDb
+      .prepare(
         `INSERT INTO session_watch_cursors
          (watcher_session_key, target_session_key, last_seen_sequence, notified_sequence,
           material_sequence, provenance, updated_at)
          VALUES (?, ?, ?, ?, ?, ?, ?)`,
       )
-      .run(watcher, "global", 0, 0, 0, "explicit", 1);
+      .run(watcher, "global", 0, 0, 0, "explicit", now);
+    const readLegacyCursor = () =>
+      stateDb
+        .prepare(
+          `SELECT last_seen_sequence, notified_sequence, material_sequence
+         FROM session_watch_cursors
+         WHERE watcher_session_key = ? AND target_session_key = ?`,
+        )
+        .get(watcher, "global");
+    const initialCursor = readLegacyCursor();
 
     recordSessionStateEvent(
       eventInput({
@@ -518,13 +530,18 @@ describe("session state events", () => {
         actorType: "human",
         watcherSessionKeys: [],
       }),
-      database,
+      { ...database, now },
     );
 
-    expect(readCursor(database, watcher, "global")).toBeUndefined();
+    expect(initialCursor).toEqual({
+      last_seen_sequence: 0,
+      notified_sequence: 0,
+      material_sequence: 0,
+    });
+    expect(readLegacyCursor()).toEqual(initialCursor);
     expect(peekSystemEventEntries(watcher)).toHaveLength(0);
     acknowledgeSessionStateNotices(watcher, ["global"], database);
-    expect(readCursor(database, watcher, "global")).toBeUndefined();
+    expect(readLegacyCursor()).toEqual(initialCursor);
   });
 
   it("acks only drained session-state entries and ignores ordinary events", async () => {

--- a/src/sessions/session-state-events.test.ts
+++ b/src/sessions/session-state-events.test.ts
@@ -499,7 +499,7 @@ describe("session state events", () => {
     ).toEqual({ count: 1 });
   });
 
-  it("keeps legacy bare target cursors receiving and acknowledging notices", () => {
+  it("ignores legacy bare target cursors without an owning agent", () => {
     const database = createDatabaseOptions();
     openOpenClawStateDatabase(database)
       .db.prepare(
@@ -521,13 +521,10 @@ describe("session state events", () => {
       database,
     );
 
-    expect(readCursor(database, watcher, "global")).toMatchObject({ material_sequence: 1 });
-    expect(peekSystemEventEntries(watcher)).toHaveLength(2);
+    expect(readCursor(database, watcher, "global")).toBeUndefined();
+    expect(peekSystemEventEntries(watcher)).toHaveLength(0);
     acknowledgeSessionStateNotices(watcher, ["global"], database);
-    expect(readCursor(database, watcher, "global")).toMatchObject({
-      last_seen_sequence: 0,
-      notified_sequence: 1,
-    });
+    expect(readCursor(database, watcher, "global")).toBeUndefined();
   });
 
   it("acks only drained session-state entries and ignores ordinary events", async () => {

--- a/src/sessions/session-state-events.test.ts
+++ b/src/sessions/session-state-events.test.ts
@@ -437,6 +437,68 @@ describe("session state events", () => {
     expect(getSessionStateVersion("global", "main", database)).toBe(mainEvent.sequence);
   });
 
+  it("keeps global target watch cursors independent across agents", () => {
+    const database = createDatabaseOptions();
+    expect(
+      registerSessionStateWatch(
+        { watcherSessionKey: watcher, targetSessionKey: "global", targetAgentId: "main" },
+        database,
+      ),
+    ).toBe(true);
+    expect(
+      registerSessionStateWatch(
+        { watcherSessionKey: watcher, targetSessionKey: "global", targetAgentId: "ops" },
+        database,
+      ),
+    ).toBe(true);
+
+    recordSessionStateEvent(
+      {
+        sessionKey: "global",
+        agentId: "main",
+        kind: "goal_changed",
+        actorType: "human",
+        summary: "main goal",
+        watcherSessionKeys: [],
+      },
+      database,
+    );
+    recordSessionStateEvent(
+      {
+        sessionKey: "global",
+        agentId: "ops",
+        kind: "goal_changed",
+        actorType: "human",
+        summary: "ops goal",
+        watcherSessionKeys: [],
+      },
+      database,
+    );
+
+    const rows = openOpenClawStateDatabase(database)
+      .db.prepare(
+        `SELECT target_session_key, material_sequence
+         FROM session_watch_cursors
+         WHERE watcher_session_key = ?
+         ORDER BY material_sequence`,
+      )
+      .all(watcher) as Array<{ target_session_key: string; material_sequence: number }>;
+    expect(rows).toHaveLength(2);
+    expect(rows[0]?.target_session_key).not.toBe(rows[1]?.target_session_key);
+    expect(rows.map((row) => row.material_sequence)).toEqual([1, 2]);
+
+    handleSessionStateSessionDeleted("global", "ops", database);
+    expect(
+      openOpenClawStateDatabase(database)
+        .db.prepare(
+          `SELECT COUNT(*) AS count
+           FROM session_watch_cursors
+           WHERE watcher_session_key = ?`,
+        )
+        .get(watcher),
+    ).toEqual({ count: 1 });
+  });
+
   it("acks only drained session-state entries and ignores ordinary events", async () => {
     const database = createDatabaseOptions();
     seedChild(database);

--- a/src/sessions/session-state-events.test.ts
+++ b/src/sessions/session-state-events.test.ts
@@ -499,6 +499,37 @@ describe("session state events", () => {
     ).toEqual({ count: 1 });
   });
 
+  it("keeps legacy bare target cursors receiving and acknowledging notices", () => {
+    const database = createDatabaseOptions();
+    openOpenClawStateDatabase(database)
+      .db.prepare(
+        `INSERT INTO session_watch_cursors
+         (watcher_session_key, target_session_key, last_seen_sequence, notified_sequence,
+          material_sequence, provenance, updated_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?)`,
+      )
+      .run(watcher, "global", 0, 0, 0, "explicit", 1);
+
+    recordSessionStateEvent(
+      eventInput({
+        sessionKey: "global",
+        agentId: "main",
+        kind: "goal_changed",
+        actorType: "human",
+        watcherSessionKeys: [],
+      }),
+      database,
+    );
+
+    expect(readCursor(database, watcher, "global")).toMatchObject({ material_sequence: 1 });
+    expect(peekSystemEventEntries(watcher)).toHaveLength(2);
+    acknowledgeSessionStateNotices(watcher, ["global"], database);
+    expect(readCursor(database, watcher, "global")).toMatchObject({
+      last_seen_sequence: 0,
+      notified_sequence: 1,
+    });
+  });
+
   it("acks only drained session-state entries and ignores ordinary events", async () => {
     const database = createDatabaseOptions();
     seedChild(database);

--- a/src/sessions/session-state-events.test.ts
+++ b/src/sessions/session-state-events.test.ts
@@ -9,6 +9,7 @@ import {
   peekSystemEventEntries,
   resetSystemEventsForTest,
 } from "../infra/system-events.js";
+import { migrateSessionWatchCursorProvenance } from "../state/openclaw-state-db-session-watch-migration.js";
 import {
   closeOpenClawStateDatabaseForTest,
   openOpenClawStateDatabase,
@@ -32,6 +33,7 @@ import {
   registerSessionStateWatch,
   sweepSessionStateWatchNotices,
 } from "./session-state-events.js";
+import { encodeSessionStateWatchTarget } from "./session-watch-target.js";
 
 const SESSION_STATE_MAX_ROWS = 50_000;
 const SESSION_STATE_RETENTION_MS = 30 * 24 * 60 * 60_000;
@@ -542,6 +544,74 @@ describe("session state events", () => {
     expect(peekSystemEventEntries(watcher)).toHaveLength(0);
     acknowledgeSessionStateNotices(watcher, ["global"], database);
     expect(readLegacyCursor()).toEqual(initialCursor);
+  });
+
+  it("migrates legacy bare cursors only when state proves one target owner", () => {
+    const database = createDatabaseOptions();
+    const stateDb = openOpenClawStateDatabase(database).db;
+    stateDb
+      .prepare(
+        `INSERT INTO session_watch_cursors
+         (watcher_session_key, target_session_key, last_seen_sequence, notified_sequence,
+          material_sequence, provenance, updated_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?)`,
+      )
+      .run(watcher, "global", 3, 4, 5, "explicit", 100);
+    stateDb
+      .prepare(
+        `INSERT INTO session_state_heads
+         (session_key, agent_id, last_sequence, pruned_max_sequence, updated_at)
+         VALUES (?, ?, ?, ?, ?)`,
+      )
+      .run("global", "main", 8, 0, 100);
+
+    expect(migrateSessionWatchCursorProvenance(stateDb)).toMatchObject({
+      migratedLegacyCursors: 1,
+      ambiguousLegacyCursors: 0,
+    });
+    expect(
+      stateDb
+        .prepare(
+          `SELECT last_seen_sequence, notified_sequence, material_sequence
+           FROM session_watch_cursors
+           WHERE watcher_session_key = ? AND target_session_key = ?`,
+        )
+        .get(watcher, encodeSessionStateWatchTarget({ sessionKey: "global", agentId: "main" })),
+    ).toEqual({ last_seen_sequence: 3, notified_sequence: 4, material_sequence: 5 });
+  });
+
+  it("leaves ambiguous legacy bare cursors for Doctor recovery", () => {
+    const database = createDatabaseOptions();
+    const stateDb = openOpenClawStateDatabase(database).db;
+    stateDb
+      .prepare(
+        `INSERT INTO session_watch_cursors
+         (watcher_session_key, target_session_key, last_seen_sequence, notified_sequence,
+          material_sequence, provenance, updated_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?)`,
+      )
+      .run(watcher, "global", 3, 4, 5, "explicit", 100);
+    const insertHead = stateDb.prepare(
+      `INSERT INTO session_state_heads
+       (session_key, agent_id, last_sequence, pruned_max_sequence, updated_at)
+       VALUES (?, ?, ?, ?, ?)`,
+    );
+    insertHead.run("global", "main", 8, 0, 100);
+    insertHead.run("global", "ops", 9, 0, 100);
+
+    expect(migrateSessionWatchCursorProvenance(stateDb)).toMatchObject({
+      migratedLegacyCursors: 0,
+      ambiguousLegacyCursors: 1,
+    });
+    expect(
+      stateDb
+        .prepare(
+          `SELECT target_session_key
+           FROM session_watch_cursors
+           WHERE watcher_session_key = ?`,
+        )
+        .get(watcher),
+    ).toEqual({ target_session_key: "global" });
   });
 
   it("acks only drained session-state entries and ignores ordinary events", async () => {

--- a/src/sessions/session-state-events.ts
+++ b/src/sessions/session-state-events.ts
@@ -32,6 +32,11 @@ import {
 } from "./session-state-event-kinds.js";
 import { enqueueSessionStateNotice, isNotifiableWatcherKey } from "./session-state-notices.js";
 import { deleteSessionUpstreamLink } from "./session-upstream-links.js";
+import {
+  decodeSessionStateWatchTarget,
+  encodeSessionStateWatchTarget,
+  type SessionStateWatchTarget,
+} from "./session-watch-target.js";
 
 export type { SessionStateActorType } from "./session-state-event-kinds.js";
 
@@ -257,9 +262,14 @@ export function recordSessionStateEvent(
   const notices: Array<{
     watcherSessionKey: string;
     targetSessionKey: string;
+    targetAgentId: string;
     lastSeenSequence: number;
     queueOnly: boolean;
   }> = [];
+  const targetCursorKey = encodeSessionStateWatchTarget({
+    agentId: input.agentId,
+    sessionKey: input.sessionKey,
+  });
   try {
     const event = runOpenClawStateWriteTransaction(({ db }) => {
       const insert = executeSqliteQuerySync(
@@ -314,7 +324,7 @@ export function recordSessionStateEvent(
             getSessionStateKysely(db)
               .selectFrom("session_watch_cursors")
               .select("watcher_session_key")
-              .where("target_session_key", "=", input.sessionKey),
+              .where("target_session_key", "=", targetCursorKey),
           ).rows.map((row) => row.watcher_session_key)
         : [];
       const watcherSessionKeys = [
@@ -337,13 +347,14 @@ export function recordSessionStateEvent(
         const materialCursor = updateMaterialCursor({
           db,
           watcherSessionKey,
-          targetSessionKey: input.sessionKey,
+          targetSessionKey: targetCursorKey,
           sequence: insertedSequence,
           now,
         });
         notices.push({
           watcherSessionKey,
           targetSessionKey: input.sessionKey,
+          targetAgentId: input.agentId,
           lastSeenSequence: materialCursor.lastSeenSequence,
           queueOnly: materialCursor.queueOnly,
         });
@@ -497,20 +508,32 @@ export function listSessionStateEventsSince(
 /** Ack only the frozen notice watermark; advancing to head would lose an interleaved event. */
 export function acknowledgeSessionStateNotices(
   watcherSessionKey: string,
-  targetSessionKeys: readonly string[],
+  targetSessionKeys: readonly (string | SessionStateWatchTarget)[],
   options: OpenClawStateDatabaseOptions & { now?: number } = {},
 ): void {
   const now = options.now ?? Date.now();
   const followups: Array<{
     watcherSessionKey: string;
     targetSessionKey: string;
+    targetAgentId: string;
     lastSeenSequence: number;
     queueOnly: boolean;
   }> = [];
   try {
     runOpenClawStateWriteTransaction(({ db }) => {
-      for (const targetSessionKey of new Set(targetSessionKeys)) {
-        const row = readCursor(db, watcherSessionKey, targetSessionKey);
+      const seenTargets = new Set<string>();
+      for (const rawTarget of targetSessionKeys) {
+        const target =
+          typeof rawTarget === "string" ? decodeSessionStateWatchTarget(rawTarget) : rawTarget;
+        if (!target) {
+          continue;
+        }
+        const targetCursorKey = encodeSessionStateWatchTarget(target);
+        if (seenTargets.has(targetCursorKey)) {
+          continue;
+        }
+        seenTargets.add(targetCursorKey);
+        const row = readCursor(db, watcherSessionKey, targetCursorKey);
         if (!row) {
           continue;
         }
@@ -527,12 +550,13 @@ export function acknowledgeSessionStateNotices(
               updated_at: now,
             })
             .where("watcher_session_key", "=", watcherSessionKey)
-            .where("target_session_key", "=", targetSessionKey),
+            .where("target_session_key", "=", targetCursorKey),
         );
         if (material > notified) {
           followups.push({
             watcherSessionKey,
-            targetSessionKey,
+            targetSessionKey: target.sessionKey,
+            targetAgentId: target.agentId,
             lastSeenSequence: notified,
             queueOnly: isAmbientGroupWatchCursor(row),
           });
@@ -573,6 +597,7 @@ export function handleSessionStateSessionDeleted(
   options: OpenClawStateDatabaseOptions = {},
 ): void {
   deleteSessionUpstreamLink(sessionKey, agentId, options);
+  const targetCursorKey = encodeSessionStateWatchTarget({ agentId, sessionKey });
   try {
     runOpenClawStateWriteTransaction(({ db }) => {
       const kysely = getSessionStateKysely(db);
@@ -597,7 +622,7 @@ export function handleSessionStateSessionDeleted(
           .where((eb) =>
             eb.or([
               eb("watcher_session_key", "=", sessionKey),
-              eb("target_session_key", "=", sessionKey),
+              eb("target_session_key", "=", targetCursorKey),
             ]),
           ),
       );
@@ -628,7 +653,11 @@ export function sweepSessionStateWatchNotices(
         .selectFrom("session_watch_cursors")
         .selectAll()
         .whereRef("material_sequence", ">", "last_seen_sequence"),
-    ).rows.filter((row) => sessionExists(row.watcher_session_key, options.env));
+    ).rows.filter(
+      (row) =>
+        sessionExists(row.watcher_session_key, options.env) &&
+        decodeSessionStateWatchTarget(row.target_session_key) !== undefined,
+    );
     runOpenClawStateWriteTransaction(({ db: writeDb }) => {
       for (const row of pendingRows) {
         executeSqliteQuerySync(
@@ -642,9 +671,14 @@ export function sweepSessionStateWatchNotices(
       }
     }, options);
     for (const row of pendingRows) {
+      const target = decodeSessionStateWatchTarget(row.target_session_key);
+      if (!target) {
+        continue;
+      }
       enqueueSessionStateNotice({
         watcherSessionKey: row.watcher_session_key,
-        targetSessionKey: row.target_session_key,
+        targetSessionKey: target.sessionKey,
+        targetAgentId: target.agentId,
         lastSeenSequence: normalizeSqliteNumber(row.last_seen_sequence) ?? 0,
         queueOnly: isAmbientGroupWatchCursor(row),
       });
@@ -801,6 +835,7 @@ export function recordSessionCreated(params: {
 /** True when any seeded or explicitly registered watcher cursor targets this session. */
 function hasSessionStateWatchers(
   targetSessionKey: string,
+  targetAgentId: string,
   options: OpenClawStateDatabaseOptions = {},
 ): boolean {
   try {
@@ -810,7 +845,11 @@ function hasSessionStateWatchers(
       getSessionStateKysely(db)
         .selectFrom("session_watch_cursors")
         .select("watcher_session_key")
-        .where("target_session_key", "=", targetSessionKey)
+        .where(
+          "target_session_key",
+          "=",
+          encodeSessionStateWatchTarget({ sessionKey: targetSessionKey, agentId: targetAgentId }),
+        )
         .limit(1),
     );
     return row !== undefined;
@@ -836,7 +875,12 @@ export function listAmbientGroupWatchTargets(
         .where("watcher_session_key", "=", watcherSessionKey)
         .where("provenance", "=", SESSION_WATCH_PROVENANCE_AMBIENT_GROUP),
     ).rows;
-    return new Set(rows.map((row) => row.target_session_key));
+    return new Set(
+      rows.flatMap((row) => {
+        const target = decodeSessionStateWatchTarget(row.target_session_key);
+        return target ? [target.sessionKey] : [];
+      }),
+    );
   } catch (error) {
     log.warn(`failed to list ambient group watch targets: ${String(error)}`);
     return new Set();
@@ -855,11 +899,16 @@ export function registerSessionStateWatch(
     return false;
   }
   const now = options.now ?? Date.now();
+  const agentId = params.targetAgentId ?? resolveAgentIdFromSessionKey(params.targetSessionKey);
+  const targetCursorKey = encodeSessionStateWatchTarget({
+    sessionKey: params.targetSessionKey,
+    agentId,
+  });
   try {
     let registered = false;
     runOpenClawStateWriteTransaction(({ db }) => {
       // Re-watching must not clobber pending-notice cursor state.
-      const existing = readCursor(db, params.watcherSessionKey, params.targetSessionKey);
+      const existing = readCursor(db, params.watcherSessionKey, targetCursorKey);
       if (existing) {
         if (existing.provenance !== SESSION_WATCH_PROVENANCE_EXPLICIT) {
           executeSqliteQuerySync(
@@ -868,13 +917,12 @@ export function registerSessionStateWatch(
               .updateTable("session_watch_cursors")
               .set({ provenance: SESSION_WATCH_PROVENANCE_EXPLICIT })
               .where("watcher_session_key", "=", params.watcherSessionKey)
-              .where("target_session_key", "=", params.targetSessionKey),
+              .where("target_session_key", "=", targetCursorKey),
           );
         }
         registered = true;
         return;
       }
-      const agentId = params.targetAgentId ?? resolveAgentIdFromSessionKey(params.targetSessionKey);
       const head = executeSqliteQueryTakeFirstSync(
         db,
         getSessionStateKysely(db)
@@ -887,7 +935,7 @@ export function registerSessionStateWatch(
       upsertSeedCursor({
         db,
         watcherSessionKey: params.watcherSessionKey,
-        targetSessionKey: params.targetSessionKey,
+        targetSessionKey: targetCursorKey,
         sequence: normalizeOptionalSqliteNumber(head?.last_sequence) ?? 0,
         now,
       });
@@ -984,14 +1032,15 @@ export function recordSessionHumanDirectMessage(
     return undefined;
   }
   // One indexed watcher probe keeps ordinary un-watched human turns write-free.
-  if (!watcherSessionKey && !hasSessionStateWatchers(params.sessionKey, options)) {
+  const agentId = params.agentId ?? resolveAgentIdFromSessionKey(params.sessionKey);
+  if (!watcherSessionKey && !hasSessionStateWatchers(params.sessionKey, agentId, options)) {
     return undefined;
   }
   return recordSessionStateEvent(
     {
       sessionKey: params.sessionKey,
       sessionId: params.entry?.sessionId,
-      agentId: params.agentId ?? resolveAgentIdFromSessionKey(params.sessionKey),
+      agentId,
       kind: "human_direct_message",
       actorType: "human",
       ...(params.actor.actorId ? { actorId: params.actor.actorId } : {}),

--- a/src/sessions/session-state-events.ts
+++ b/src/sessions/session-state-events.ts
@@ -35,7 +35,6 @@ import { deleteSessionUpstreamLink } from "./session-upstream-links.js";
 import {
   decodeSessionStateWatchTarget,
   encodeSessionStateWatchTarget,
-  isLegacySessionStateWatchTarget,
   type SessionStateWatchTarget,
 } from "./session-watch-target.js";
 
@@ -319,57 +318,46 @@ export function recordSessionStateEvent(
       // Explicit watch registrations (registerSessionStateWatch) live as cursor rows;
       // union them with producer-passed watchers so sessions_send coordinators get
       // notices without every producer knowing about registration.
-      const targetCursorKeys =
-        targetCursorKey === input.sessionKey
-          ? [targetCursorKey]
-          : [targetCursorKey, input.sessionKey];
       const registeredWatcherKeys = NOTIFY_BY_KIND[input.kind]
         ? executeSqliteQuerySync(
             db,
             getSessionStateKysely(db)
               .selectFrom("session_watch_cursors")
               .select("watcher_session_key")
-              .where("target_session_key", "in", targetCursorKeys),
+              .where("target_session_key", "=", targetCursorKey),
           ).rows.map((row) => row.watcher_session_key)
         : [];
       const watcherSessionKeys = [
         ...new Set([...(input.watcherSessionKeys ?? []), ...registeredWatcherKeys]),
       ].filter((key) => Boolean(key) && isNotifiableWatcherKey(key));
       for (const watcherSessionKey of watcherSessionKeys) {
-        const legacyCursor =
-          targetCursorKey === input.sessionKey
-            ? undefined
-            : readCursor(db, watcherSessionKey, input.sessionKey);
-        const cursorKeys = legacyCursor ? [targetCursorKey, input.sessionKey] : [targetCursorKey];
-        for (const cursorKey of cursorKeys) {
-          if (input.kind === "child_spawned") {
-            upsertSeedCursor({
-              db,
-              watcherSessionKey,
-              targetSessionKey: cursorKey,
-              sequence: insertedSequence,
-              now,
-            });
-            continue;
-          }
-          if (!NOTIFY_BY_KIND[input.kind] || input.actorId === watcherSessionKey) {
-            continue;
-          }
-          const materialCursor = updateMaterialCursor({
+        if (input.kind === "child_spawned") {
+          upsertSeedCursor({
             db,
             watcherSessionKey,
-            targetSessionKey: cursorKey,
+            targetSessionKey: targetCursorKey,
             sequence: insertedSequence,
             now,
           });
-          notices.push({
-            watcherSessionKey,
-            targetSessionKey: input.sessionKey,
-            ...(cursorKey === targetCursorKey ? { targetAgentId: input.agentId } : {}),
-            lastSeenSequence: materialCursor.lastSeenSequence,
-            queueOnly: materialCursor.queueOnly,
-          });
+          continue;
         }
+        if (!NOTIFY_BY_KIND[input.kind] || input.actorId === watcherSessionKey) {
+          continue;
+        }
+        const materialCursor = updateMaterialCursor({
+          db,
+          watcherSessionKey,
+          targetSessionKey: targetCursorKey,
+          sequence: insertedSequence,
+          now,
+        });
+        notices.push({
+          watcherSessionKey,
+          targetSessionKey: input.sessionKey,
+          targetAgentId: input.agentId,
+          lastSeenSequence: materialCursor.lastSeenSequence,
+          queueOnly: materialCursor.queueOnly,
+        });
       }
 
       const row = executeSqliteQueryTakeFirstSync(
@@ -537,14 +525,8 @@ export function acknowledgeSessionStateNotices(
       for (const rawTarget of targetSessionKeys) {
         const target =
           typeof rawTarget === "string" ? decodeSessionStateWatchTarget(rawTarget) : rawTarget;
-        const legacyTargetSessionKey =
-          typeof rawTarget === "string" && isLegacySessionStateWatchTarget(rawTarget)
-            ? rawTarget
-            : undefined;
-        const targetCursorKey = target
-          ? encodeSessionStateWatchTarget(target)
-          : legacyTargetSessionKey;
-        const targetSessionKey = target?.sessionKey ?? legacyTargetSessionKey;
+        const targetCursorKey = target ? encodeSessionStateWatchTarget(target) : undefined;
+        const targetSessionKey = target?.sessionKey;
         if (!targetCursorKey || !targetSessionKey) {
           continue;
         }
@@ -641,7 +623,7 @@ export function handleSessionStateSessionDeleted(
           .where((eb) =>
             eb.or([
               eb("watcher_session_key", "=", sessionKey),
-              eb("target_session_key", "in", [targetCursorKey, sessionKey]),
+              eb("target_session_key", "=", targetCursorKey),
             ]),
           ),
       );
@@ -675,8 +657,7 @@ export function sweepSessionStateWatchNotices(
     ).rows.filter(
       (row) =>
         sessionExists(row.watcher_session_key, options.env) &&
-        (decodeSessionStateWatchTarget(row.target_session_key) !== undefined ||
-          isLegacySessionStateWatchTarget(row.target_session_key)),
+        decodeSessionStateWatchTarget(row.target_session_key) !== undefined,
     );
     runOpenClawStateWriteTransaction(({ db: writeDb }) => {
       for (const row of pendingRows) {
@@ -692,13 +673,13 @@ export function sweepSessionStateWatchNotices(
     }, options);
     for (const row of pendingRows) {
       const target = decodeSessionStateWatchTarget(row.target_session_key);
-      if (!target && !isLegacySessionStateWatchTarget(row.target_session_key)) {
+      if (!target) {
         continue;
       }
       enqueueSessionStateNotice({
         watcherSessionKey: row.watcher_session_key,
-        targetSessionKey: target?.sessionKey ?? row.target_session_key,
-        ...(target?.agentId ? { targetAgentId: target.agentId } : {}),
+        targetSessionKey: target.sessionKey,
+        targetAgentId: target.agentId,
         lastSeenSequence: normalizeSqliteNumber(row.last_seen_sequence) ?? 0,
         queueOnly: isAmbientGroupWatchCursor(row),
       });
@@ -865,10 +846,11 @@ function hasSessionStateWatchers(
       getSessionStateKysely(db)
         .selectFrom("session_watch_cursors")
         .select("watcher_session_key")
-        .where("target_session_key", "in", [
+        .where(
+          "target_session_key",
+          "=",
           encodeSessionStateWatchTarget({ sessionKey: targetSessionKey, agentId: targetAgentId }),
-          targetSessionKey,
-        ])
+        )
         .limit(1),
     );
     return row !== undefined;
@@ -897,11 +879,7 @@ export function listAmbientGroupWatchTargets(
     return new Set(
       rows.flatMap((row) => {
         const target = decodeSessionStateWatchTarget(row.target_session_key);
-        return target
-          ? [target.sessionKey]
-          : isLegacySessionStateWatchTarget(row.target_session_key)
-            ? [row.target_session_key]
-            : [];
+        return target ? [target.sessionKey] : [];
       }),
     );
   } catch (error) {
@@ -994,16 +972,20 @@ export function registerMainSessionGroupWatch(
     return false;
   }
   const now = options.now ?? Date.now();
+  const targetCursorKey = encodeSessionStateWatchTarget({
+    sessionKey: params.sessionKey,
+    agentId: params.agentId,
+  });
   try {
     const { db: readDb } = openOpenClawStateDatabase(options);
     // This runs on every human group turn. Keep the steady-state path read-only;
     // the transaction below is only for first registration and its race recheck.
-    if (readCursor(readDb, watcherSessionKey, params.sessionKey)) {
+    if (readCursor(readDb, watcherSessionKey, targetCursorKey)) {
       return true;
     }
     let registered = false;
     runOpenClawStateWriteTransaction(({ db }) => {
-      const existing = readCursor(db, watcherSessionKey, params.sessionKey);
+      const existing = readCursor(db, watcherSessionKey, targetCursorKey);
       if (existing) {
         // An explicit watch already owns this pair. Do not downgrade it when
         // later human group turns revisit registration.
@@ -1022,7 +1004,7 @@ export function registerMainSessionGroupWatch(
       upsertSeedCursor({
         db,
         watcherSessionKey,
-        targetSessionKey: params.sessionKey,
+        targetSessionKey: targetCursorKey,
         sequence,
         now,
         provenance: SESSION_WATCH_PROVENANCE_AMBIENT_GROUP,

--- a/src/sessions/session-state-events.ts
+++ b/src/sessions/session-state-events.ts
@@ -35,6 +35,7 @@ import { deleteSessionUpstreamLink } from "./session-upstream-links.js";
 import {
   decodeSessionStateWatchTarget,
   encodeSessionStateWatchTarget,
+  isLegacySessionStateWatchTarget,
   type SessionStateWatchTarget,
 } from "./session-watch-target.js";
 
@@ -262,7 +263,7 @@ export function recordSessionStateEvent(
   const notices: Array<{
     watcherSessionKey: string;
     targetSessionKey: string;
-    targetAgentId: string;
+    targetAgentId?: string;
     lastSeenSequence: number;
     queueOnly: boolean;
   }> = [];
@@ -318,46 +319,57 @@ export function recordSessionStateEvent(
       // Explicit watch registrations (registerSessionStateWatch) live as cursor rows;
       // union them with producer-passed watchers so sessions_send coordinators get
       // notices without every producer knowing about registration.
+      const targetCursorKeys =
+        targetCursorKey === input.sessionKey
+          ? [targetCursorKey]
+          : [targetCursorKey, input.sessionKey];
       const registeredWatcherKeys = NOTIFY_BY_KIND[input.kind]
         ? executeSqliteQuerySync(
             db,
             getSessionStateKysely(db)
               .selectFrom("session_watch_cursors")
               .select("watcher_session_key")
-              .where("target_session_key", "=", targetCursorKey),
+              .where("target_session_key", "in", targetCursorKeys),
           ).rows.map((row) => row.watcher_session_key)
         : [];
       const watcherSessionKeys = [
         ...new Set([...(input.watcherSessionKeys ?? []), ...registeredWatcherKeys]),
       ].filter((key) => Boolean(key) && isNotifiableWatcherKey(key));
       for (const watcherSessionKey of watcherSessionKeys) {
-        if (input.kind === "child_spawned") {
-          upsertSeedCursor({
+        const legacyCursor =
+          targetCursorKey === input.sessionKey
+            ? undefined
+            : readCursor(db, watcherSessionKey, input.sessionKey);
+        const cursorKeys = legacyCursor ? [targetCursorKey, input.sessionKey] : [targetCursorKey];
+        for (const cursorKey of cursorKeys) {
+          if (input.kind === "child_spawned") {
+            upsertSeedCursor({
+              db,
+              watcherSessionKey,
+              targetSessionKey: cursorKey,
+              sequence: insertedSequence,
+              now,
+            });
+            continue;
+          }
+          if (!NOTIFY_BY_KIND[input.kind] || input.actorId === watcherSessionKey) {
+            continue;
+          }
+          const materialCursor = updateMaterialCursor({
             db,
             watcherSessionKey,
-            targetSessionKey: input.sessionKey,
+            targetSessionKey: cursorKey,
             sequence: insertedSequence,
             now,
           });
-          continue;
+          notices.push({
+            watcherSessionKey,
+            targetSessionKey: input.sessionKey,
+            ...(cursorKey === targetCursorKey ? { targetAgentId: input.agentId } : {}),
+            lastSeenSequence: materialCursor.lastSeenSequence,
+            queueOnly: materialCursor.queueOnly,
+          });
         }
-        if (!NOTIFY_BY_KIND[input.kind] || input.actorId === watcherSessionKey) {
-          continue;
-        }
-        const materialCursor = updateMaterialCursor({
-          db,
-          watcherSessionKey,
-          targetSessionKey: targetCursorKey,
-          sequence: insertedSequence,
-          now,
-        });
-        notices.push({
-          watcherSessionKey,
-          targetSessionKey: input.sessionKey,
-          targetAgentId: input.agentId,
-          lastSeenSequence: materialCursor.lastSeenSequence,
-          queueOnly: materialCursor.queueOnly,
-        });
       }
 
       const row = executeSqliteQueryTakeFirstSync(
@@ -515,7 +527,7 @@ export function acknowledgeSessionStateNotices(
   const followups: Array<{
     watcherSessionKey: string;
     targetSessionKey: string;
-    targetAgentId: string;
+    targetAgentId?: string;
     lastSeenSequence: number;
     queueOnly: boolean;
   }> = [];
@@ -525,10 +537,17 @@ export function acknowledgeSessionStateNotices(
       for (const rawTarget of targetSessionKeys) {
         const target =
           typeof rawTarget === "string" ? decodeSessionStateWatchTarget(rawTarget) : rawTarget;
-        if (!target) {
+        const legacyTargetSessionKey =
+          typeof rawTarget === "string" && isLegacySessionStateWatchTarget(rawTarget)
+            ? rawTarget
+            : undefined;
+        const targetCursorKey = target
+          ? encodeSessionStateWatchTarget(target)
+          : legacyTargetSessionKey;
+        const targetSessionKey = target?.sessionKey ?? legacyTargetSessionKey;
+        if (!targetCursorKey || !targetSessionKey) {
           continue;
         }
-        const targetCursorKey = encodeSessionStateWatchTarget(target);
         if (seenTargets.has(targetCursorKey)) {
           continue;
         }
@@ -555,8 +574,8 @@ export function acknowledgeSessionStateNotices(
         if (material > notified) {
           followups.push({
             watcherSessionKey,
-            targetSessionKey: target.sessionKey,
-            targetAgentId: target.agentId,
+            targetSessionKey,
+            ...(target?.agentId ? { targetAgentId: target.agentId } : {}),
             lastSeenSequence: notified,
             queueOnly: isAmbientGroupWatchCursor(row),
           });
@@ -622,7 +641,7 @@ export function handleSessionStateSessionDeleted(
           .where((eb) =>
             eb.or([
               eb("watcher_session_key", "=", sessionKey),
-              eb("target_session_key", "=", targetCursorKey),
+              eb("target_session_key", "in", [targetCursorKey, sessionKey]),
             ]),
           ),
       );
@@ -656,7 +675,8 @@ export function sweepSessionStateWatchNotices(
     ).rows.filter(
       (row) =>
         sessionExists(row.watcher_session_key, options.env) &&
-        decodeSessionStateWatchTarget(row.target_session_key) !== undefined,
+        (decodeSessionStateWatchTarget(row.target_session_key) !== undefined ||
+          isLegacySessionStateWatchTarget(row.target_session_key)),
     );
     runOpenClawStateWriteTransaction(({ db: writeDb }) => {
       for (const row of pendingRows) {
@@ -672,13 +692,13 @@ export function sweepSessionStateWatchNotices(
     }, options);
     for (const row of pendingRows) {
       const target = decodeSessionStateWatchTarget(row.target_session_key);
-      if (!target) {
+      if (!target && !isLegacySessionStateWatchTarget(row.target_session_key)) {
         continue;
       }
       enqueueSessionStateNotice({
         watcherSessionKey: row.watcher_session_key,
-        targetSessionKey: target.sessionKey,
-        targetAgentId: target.agentId,
+        targetSessionKey: target?.sessionKey ?? row.target_session_key,
+        ...(target?.agentId ? { targetAgentId: target.agentId } : {}),
         lastSeenSequence: normalizeSqliteNumber(row.last_seen_sequence) ?? 0,
         queueOnly: isAmbientGroupWatchCursor(row),
       });
@@ -845,11 +865,10 @@ function hasSessionStateWatchers(
       getSessionStateKysely(db)
         .selectFrom("session_watch_cursors")
         .select("watcher_session_key")
-        .where(
-          "target_session_key",
-          "=",
+        .where("target_session_key", "in", [
           encodeSessionStateWatchTarget({ sessionKey: targetSessionKey, agentId: targetAgentId }),
-        )
+          targetSessionKey,
+        ])
         .limit(1),
     );
     return row !== undefined;
@@ -878,7 +897,11 @@ export function listAmbientGroupWatchTargets(
     return new Set(
       rows.flatMap((row) => {
         const target = decodeSessionStateWatchTarget(row.target_session_key);
-        return target ? [target.sessionKey] : [];
+        return target
+          ? [target.sessionKey]
+          : isLegacySessionStateWatchTarget(row.target_session_key)
+            ? [row.target_session_key]
+            : [];
       }),
     );
   } catch (error) {

--- a/src/sessions/session-state-notices.test.ts
+++ b/src/sessions/session-state-notices.test.ts
@@ -1,8 +1,10 @@
 // Session-state notice context key decoding: strict UTF-8 after hex validation.
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { requestHeartbeat } from "../infra/heartbeat-wake.js";
+import { enqueueSystemEvent } from "../infra/system-events.js";
 import {
   decodeSessionStateNoticeContextKey,
+  decodeSessionStateNoticeTarget,
   enqueueSessionStateNotice,
 } from "./session-state-notices.js";
 
@@ -16,6 +18,7 @@ vi.mock("../infra/system-events.js", () => ({
 
 beforeEach(() => {
   vi.mocked(requestHeartbeat).mockClear();
+  vi.mocked(enqueueSystemEvent).mockClear();
 });
 
 function encodeTarget(sessionKey: string): string {
@@ -52,6 +55,7 @@ describe("enqueueSessionStateNotice", () => {
     const notice = {
       watcherSessionKey: "agent:main:main",
       targetSessionKey: "agent:main:slack:channel:C01234567",
+      targetAgentId: "main",
       lastSeenSequence: 42,
     };
 
@@ -67,5 +71,21 @@ describe("enqueueSessionStateNotice", () => {
     vi.mocked(requestHeartbeat).mockClear();
     enqueueSessionStateNotice({ ...notice, queueOnly: true });
     expect(requestHeartbeat).not.toHaveBeenCalled();
+  });
+
+  it("keeps the target agent in notices for bare session keys", () => {
+    enqueueSessionStateNotice({
+      watcherSessionKey: "agent:main:main",
+      targetSessionKey: "global",
+      targetAgentId: "ops",
+      lastSeenSequence: 7,
+    });
+
+    const contextKey = vi.mocked(enqueueSystemEvent).mock.calls[0]?.[1]?.contextKey;
+    expect(contextKey).toEqual(expect.stringMatching(/^session-state:/));
+    expect(decodeSessionStateNoticeTarget(contextKey!)).toEqual({
+      agentId: "ops",
+      sessionKey: "global",
+    });
   });
 });

--- a/src/sessions/session-state-notices.test.ts
+++ b/src/sessions/session-state-notices.test.ts
@@ -82,6 +82,8 @@ describe("enqueueSessionStateNotice", () => {
     });
 
     const contextKey = vi.mocked(enqueueSystemEvent).mock.calls[0]?.[1]?.contextKey;
+    const noticeText = vi.mocked(enqueueSystemEvent).mock.calls[0]?.[0];
+    expect(noticeText).toContain('session_status sessionKey "agent:ops:global" changesSince 7');
     expect(contextKey).toEqual(expect.stringMatching(/^session-state:/));
     expect(decodeSessionStateNoticeTarget(contextKey!)).toEqual({
       agentId: "ops",

--- a/src/sessions/session-state-notices.ts
+++ b/src/sessions/session-state-notices.ts
@@ -70,8 +70,17 @@ export function decodeSessionStateNoticeContextKey(contextKey: string): string |
 // Terse on purpose: this line lands in model prompts, possibly repeatedly across
 // turns. Text must stay byte-stable per frozen watermark so queue dedupe holds,
 // and the reconciliation call must be self-contained (explicit target sessionKey).
-function sessionStateNoticeText(targetSessionKey: string, lastSeenSequence: number): string {
-  return `Session "${targetSessionKey}" changed (other actor). Reconcile before acting: session_status sessionKey "${targetSessionKey}" changesSince ${lastSeenSequence}.`;
+function sessionStateNoticeText(
+  targetSessionKey: string,
+  targetAgentId: string | undefined,
+  lastSeenSequence: number,
+): string {
+  const parsedAgentId = parseAgentSessionKey(targetSessionKey)?.agentId;
+  const reconciliationKey =
+    targetAgentId && parsedAgentId !== targetAgentId
+      ? `agent:${targetAgentId}:${targetSessionKey}`
+      : targetSessionKey;
+  return `Session "${reconciliationKey}" changed (other actor). Reconcile before acting: session_status sessionKey "${reconciliationKey}" changesSince ${lastSeenSequence}.`;
 }
 
 function shouldWakeWatcher(watcherSessionKey: string): boolean {
@@ -95,19 +104,22 @@ export function enqueueSessionStateNotice(params: {
   lastSeenSequence: number;
   queueOnly?: boolean;
 }): void {
-  enqueueSystemEvent(sessionStateNoticeText(params.targetSessionKey, params.lastSeenSequence), {
-    sessionKey: params.watcherSessionKey,
-    contextKey: `${SESSION_STATE_CONTEXT_PREFIX}${
-      !params.targetAgentId ||
-      parseAgentSessionKey(params.targetSessionKey)?.agentId === params.targetAgentId
-        ? encodeNoticeTarget(params.targetSessionKey)
-        : encodeNoticeTargetWithAgent({
-            agentId: params.targetAgentId,
-            sessionKey: params.targetSessionKey,
-          })
-    }`,
-    ...(params.queueOnly ? { replace: true } : {}),
-  });
+  enqueueSystemEvent(
+    sessionStateNoticeText(params.targetSessionKey, params.targetAgentId, params.lastSeenSequence),
+    {
+      sessionKey: params.watcherSessionKey,
+      contextKey: `${SESSION_STATE_CONTEXT_PREFIX}${
+        !params.targetAgentId ||
+        parseAgentSessionKey(params.targetSessionKey)?.agentId === params.targetAgentId
+          ? encodeNoticeTarget(params.targetSessionKey)
+          : encodeNoticeTargetWithAgent({
+              agentId: params.targetAgentId,
+              sessionKey: params.targetSessionKey,
+            })
+      }`,
+      ...(params.queueOnly ? { replace: true } : {}),
+    },
+  );
   // Group activity is ambient context. Coalesce it for the next main turn instead
   // of waking the personal agent once per inbound group message.
   if (params.queueOnly) {

--- a/src/sessions/session-state-notices.ts
+++ b/src/sessions/session-state-notices.ts
@@ -91,13 +91,14 @@ export function isNotifiableWatcherKey(watcherSessionKey: string): boolean {
 export function enqueueSessionStateNotice(params: {
   watcherSessionKey: string;
   targetSessionKey: string;
-  targetAgentId: string;
+  targetAgentId?: string;
   lastSeenSequence: number;
   queueOnly?: boolean;
 }): void {
   enqueueSystemEvent(sessionStateNoticeText(params.targetSessionKey, params.lastSeenSequence), {
     sessionKey: params.watcherSessionKey,
     contextKey: `${SESSION_STATE_CONTEXT_PREFIX}${
+      !params.targetAgentId ||
       parseAgentSessionKey(params.targetSessionKey)?.agentId === params.targetAgentId
         ? encodeNoticeTarget(params.targetSessionKey)
         : encodeNoticeTargetWithAgent({

--- a/src/sessions/session-state-notices.ts
+++ b/src/sessions/session-state-notices.ts
@@ -2,12 +2,49 @@
 import { requestHeartbeat } from "../infra/heartbeat-wake.js";
 import { enqueueSystemEvent } from "../infra/system-events.js";
 import { isSubagentSessionKey, parseAgentSessionKey } from "../routing/session-key.js";
+import type { SessionStateWatchTarget } from "./session-watch-target.js";
 
 const SESSION_STATE_CONTEXT_PREFIX = "session-state:";
 const SESSION_STATE_WAKE_COALESCE_MS = 20_000;
 
 function encodeNoticeTarget(sessionKey: string): string {
   return Buffer.from(sessionKey, "utf8").toString("hex");
+}
+
+function encodeNoticeTargetWithAgent(target: SessionStateWatchTarget): string {
+  return Buffer.from(JSON.stringify([target.agentId, target.sessionKey]), "utf8").toString("hex");
+}
+
+export function decodeSessionStateNoticeTarget(
+  contextKey: string,
+): SessionStateWatchTarget | undefined {
+  const sessionKey = decodeSessionStateNoticeContextKey(contextKey);
+  if (sessionKey !== undefined) {
+    const agentId = parseAgentSessionKey(sessionKey)?.agentId;
+    if (agentId) {
+      return { agentId, sessionKey };
+    }
+  }
+  if (!contextKey.startsWith(SESSION_STATE_CONTEXT_PREFIX)) {
+    return undefined;
+  }
+  const encoded = contextKey.slice(SESSION_STATE_CONTEXT_PREFIX.length);
+  try {
+    const decoded: unknown = JSON.parse(Buffer.from(encoded, "hex").toString("utf8"));
+    if (
+      !Array.isArray(decoded) ||
+      decoded.length !== 2 ||
+      typeof decoded[0] !== "string" ||
+      typeof decoded[1] !== "string" ||
+      !decoded[0] ||
+      !decoded[1]
+    ) {
+      return undefined;
+    }
+    return { agentId: decoded[0], sessionKey: decoded[1] };
+  } catch {
+    return undefined;
+  }
 }
 
 export function decodeSessionStateNoticeContextKey(contextKey: string): string | undefined {
@@ -54,12 +91,20 @@ export function isNotifiableWatcherKey(watcherSessionKey: string): boolean {
 export function enqueueSessionStateNotice(params: {
   watcherSessionKey: string;
   targetSessionKey: string;
+  targetAgentId: string;
   lastSeenSequence: number;
   queueOnly?: boolean;
 }): void {
   enqueueSystemEvent(sessionStateNoticeText(params.targetSessionKey, params.lastSeenSequence), {
     sessionKey: params.watcherSessionKey,
-    contextKey: `${SESSION_STATE_CONTEXT_PREFIX}${encodeNoticeTarget(params.targetSessionKey)}`,
+    contextKey: `${SESSION_STATE_CONTEXT_PREFIX}${
+      parseAgentSessionKey(params.targetSessionKey)?.agentId === params.targetAgentId
+        ? encodeNoticeTarget(params.targetSessionKey)
+        : encodeNoticeTargetWithAgent({
+            agentId: params.targetAgentId,
+            sessionKey: params.targetSessionKey,
+          })
+    }`,
     ...(params.queueOnly ? { replace: true } : {}),
   });
   // Group activity is ambient context. Coalesce it for the next main turn instead

--- a/src/sessions/session-upstream-links.test.ts
+++ b/src/sessions/session-upstream-links.test.ts
@@ -1,6 +1,9 @@
 import { afterAll, afterEach, describe, expect, it, vi } from "vitest";
 import { cleanupTempDirs, makeTempDir } from "../../test/helpers/temp-dir.js";
-import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
+import {
+  closeOpenClawStateDatabaseForTest,
+  openOpenClawStateDatabase,
+} from "../state/openclaw-state-db.js";
 import { registerSessionStateWatch } from "./session-state-events.js";
 import {
   deleteSessionUpstreamLink,
@@ -151,5 +154,21 @@ describe("session upstream links", () => {
     );
 
     expect(listWatchedSessionUpstreamLinks(database).get("claude")).toHaveLength(2);
+  });
+
+  it("fails closed for ambiguous legacy same-key upstream links", () => {
+    const database = createDatabaseOptions();
+    upsertLink("global", "claude", database, "main");
+    upsertLink("global", "claude", database, "ops");
+    openOpenClawStateDatabase(database)
+      .db.prepare(
+        `INSERT INTO session_watch_cursors
+         (watcher_session_key, target_session_key, last_seen_sequence, notified_sequence,
+          material_sequence, provenance, updated_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?)`,
+      )
+      .run("agent:main:main", "global", 0, 0, 0, "explicit", 1);
+
+    expect(listWatchedSessionUpstreamLinks(database)).toEqual(new Map());
   });
 });

--- a/src/sessions/session-upstream-links.test.ts
+++ b/src/sessions/session-upstream-links.test.ts
@@ -29,7 +29,7 @@ function upsertLink(
       agentId,
       catalogId,
       hostId: "gateway:local",
-      threadId: `thread-${agentId}-${sessionKey}`,
+      threadId: agentId === "main" ? `thread-${sessionKey}` : `thread-${agentId}-${sessionKey}`,
       upstreamKind: catalogId === "claude" ? "claude-cli" : "codex-app-server",
       upstreamRef: { source: sessionKey },
       marker: { offset: 1 },

--- a/src/sessions/session-upstream-links.test.ts
+++ b/src/sessions/session-upstream-links.test.ts
@@ -21,14 +21,15 @@ function upsertLink(
   sessionKey: string,
   catalogId: string,
   database: ReturnType<typeof createDatabaseOptions>,
+  agentId = "main",
 ) {
   upsertSessionUpstreamLink(
     {
       sessionKey,
-      agentId: "main",
+      agentId,
       catalogId,
       hostId: "gateway:local",
-      threadId: `thread-${sessionKey}`,
+      threadId: `thread-${agentId}-${sessionKey}`,
       upstreamKind: catalogId === "claude" ? "claude-cli" : "codex-app-server",
       upstreamRef: { source: sessionKey },
       marker: { offset: 1 },
@@ -134,5 +135,21 @@ describe("session upstream links", () => {
         marker: { offset: 99 },
       }),
     );
+  });
+
+  it("keeps upstream links for same-key sessions owned by different agents", () => {
+    const database = createDatabaseOptions();
+    upsertLink("global", "claude", database, "main");
+    upsertLink("global", "claude", database, "ops");
+    registerSessionStateWatch(
+      { watcherSessionKey: "agent:main:main", targetSessionKey: "global", targetAgentId: "main" },
+      database,
+    );
+    registerSessionStateWatch(
+      { watcherSessionKey: "agent:main:main", targetSessionKey: "global", targetAgentId: "ops" },
+      database,
+    );
+
+    expect(listWatchedSessionUpstreamLinks(database).get("claude")).toHaveLength(2);
   });
 });

--- a/src/sessions/session-upstream-links.ts
+++ b/src/sessions/session-upstream-links.ts
@@ -12,7 +12,10 @@ import {
   runOpenClawStateWriteTransaction,
   type OpenClawStateDatabaseOptions,
 } from "../state/openclaw-state-db.js";
-import { encodeSessionStateWatchTarget } from "./session-watch-target.js";
+import {
+  encodeSessionStateWatchTarget,
+  isLegacySessionStateWatchTarget,
+} from "./session-watch-target.js";
 
 type SessionUpstreamDatabase = Pick<
   OpenClawStateKyselyDatabase,
@@ -248,13 +251,16 @@ export function listWatchedSessionUpstreamLinks(
           .distinct(),
       ).rows.map((row) => row.target_session_key),
     );
-    const links = linkRows.map(rowToSessionUpstreamLink).filter((link) =>
-      watchedTargetKeys.has(
-        encodeSessionStateWatchTarget({
-          sessionKey: link.sessionKey,
-          agentId: link.agentId,
-        }),
-      ),
+    const links = linkRows.map(rowToSessionUpstreamLink).filter(
+      (link) =>
+        watchedTargetKeys.has(
+          encodeSessionStateWatchTarget({
+            sessionKey: link.sessionKey,
+            agentId: link.agentId,
+          }),
+        ) ||
+        (isLegacySessionStateWatchTarget(link.sessionKey) &&
+          watchedTargetKeys.has(link.sessionKey)),
     );
     // Keep the duplicate-key guard for legacy rows that may still be visible while
     // an older runtime is draining; never probe an arbitrary agent's upstream.

--- a/src/sessions/session-upstream-links.ts
+++ b/src/sessions/session-upstream-links.ts
@@ -260,10 +260,18 @@ export function listWatchedSessionUpstreamLinks(
     // an older runtime is draining; never probe an arbitrary agent's upstream.
     const keyCounts = new Map<string, number>();
     for (const link of links) {
-      keyCounts.set(link.sessionKey, (keyCounts.get(link.sessionKey) ?? 0) + 1);
+      const targetKey = encodeSessionStateWatchTarget({
+        sessionKey: link.sessionKey,
+        agentId: link.agentId,
+      });
+      keyCounts.set(targetKey, (keyCounts.get(targetKey) ?? 0) + 1);
     }
     for (const link of links) {
-      if ((keyCounts.get(link.sessionKey) ?? 0) > 1) {
+      const targetKey = encodeSessionStateWatchTarget({
+        sessionKey: link.sessionKey,
+        agentId: link.agentId,
+      });
+      if ((keyCounts.get(targetKey) ?? 0) > 1) {
         log.warn(
           `skipping ambiguous upstream links for ${link.sessionKey}: multiple agents adopt the same key`,
         );

--- a/src/sessions/session-upstream-links.ts
+++ b/src/sessions/session-upstream-links.ts
@@ -251,6 +251,9 @@ export function listWatchedSessionUpstreamLinks(
           .distinct(),
       ).rows.map((row) => row.target_session_key),
     );
+    const legacyWatchedKeys = new Set(
+      [...watchedTargetKeys].filter(isLegacySessionStateWatchTarget),
+    );
     const links = linkRows.map(rowToSessionUpstreamLink).filter(
       (link) =>
         watchedTargetKeys.has(
@@ -265,12 +268,16 @@ export function listWatchedSessionUpstreamLinks(
     // Keep the duplicate-key guard for legacy rows that may still be visible while
     // an older runtime is draining; never probe an arbitrary agent's upstream.
     const keyCounts = new Map<string, number>();
+    const legacyKeyCounts = new Map<string, number>();
     for (const link of links) {
       const targetKey = encodeSessionStateWatchTarget({
         sessionKey: link.sessionKey,
         agentId: link.agentId,
       });
       keyCounts.set(targetKey, (keyCounts.get(targetKey) ?? 0) + 1);
+      if (legacyWatchedKeys.has(link.sessionKey)) {
+        legacyKeyCounts.set(link.sessionKey, (legacyKeyCounts.get(link.sessionKey) ?? 0) + 1);
+      }
     }
     for (const link of links) {
       const targetKey = encodeSessionStateWatchTarget({
@@ -280,6 +287,12 @@ export function listWatchedSessionUpstreamLinks(
       if ((keyCounts.get(targetKey) ?? 0) > 1) {
         log.warn(
           `skipping ambiguous upstream links for ${link.sessionKey}: multiple agents adopt the same key`,
+        );
+        continue;
+      }
+      if ((legacyKeyCounts.get(link.sessionKey) ?? 0) > 1) {
+        log.warn(
+          `skipping ambiguous legacy upstream links for ${link.sessionKey}: multiple agents adopt the same key`,
         );
         continue;
       }

--- a/src/sessions/session-upstream-links.ts
+++ b/src/sessions/session-upstream-links.ts
@@ -12,6 +12,7 @@ import {
   runOpenClawStateWriteTransaction,
   type OpenClawStateDatabaseOptions,
 } from "../state/openclaw-state-db.js";
+import { encodeSessionStateWatchTarget } from "./session-watch-target.js";
 
 type SessionUpstreamDatabase = Pick<
   OpenClawStateKyselyDatabase,
@@ -226,27 +227,37 @@ export function listWatchedSessionUpstreamLinks(
   const grouped = new Map<string, SessionUpstreamLink[]>();
   try {
     const { db } = openOpenClawStateDatabase(options);
-    // Watch cursors own demand. Their key-only join relies on one owning agent per
-    // adopted session key, not one agent per native thread. Agent-qualified keys
-    // keep separate adoptions of the same thread distinct.
-    const rows = executeSqliteQuerySync(
+    // Watch cursors own demand. Unwatched adopted sessions stay out of the polling hot path.
+    // Match each link against the cursor identity that owns its agent and session key;
+    // bare global session keys can legitimately exist in several agent stores.
+    const linkRows = executeSqliteQuerySync(
       db,
       getSessionUpstreamKysely(db)
-        .selectFrom("session_upstream_links as links")
-        .innerJoin(
-          "session_watch_cursors as cursors",
-          "cursors.target_session_key",
-          "links.session_key",
-        )
-        .selectAll("links")
+        .selectFrom("session_upstream_links")
+        .selectAll()
         .distinct()
-        .orderBy("links.catalog_id", "asc")
-        .orderBy("links.session_key", "asc"),
+        .orderBy("catalog_id", "asc")
+        .orderBy("session_key", "asc"),
     ).rows;
-    const links = rows.map(rowToSessionUpstreamLink);
-    // Fail closed on the single-agent-per-key invariant: the key-only cursor join
-    // cannot disambiguate multiple agents sharing the exact same adopted key.
-    // Drop every link for that key rather than probe an arbitrary agent's upstream.
+    const watchedTargetKeys = new Set(
+      executeSqliteQuerySync(
+        db,
+        getSessionUpstreamKysely(db)
+          .selectFrom("session_watch_cursors")
+          .select("target_session_key")
+          .distinct(),
+      ).rows.map((row) => row.target_session_key),
+    );
+    const links = linkRows.map(rowToSessionUpstreamLink).filter((link) =>
+      watchedTargetKeys.has(
+        encodeSessionStateWatchTarget({
+          sessionKey: link.sessionKey,
+          agentId: link.agentId,
+        }),
+      ),
+    );
+    // Keep the duplicate-key guard for legacy rows that may still be visible while
+    // an older runtime is draining; never probe an arbitrary agent's upstream.
     const keyCounts = new Map<string, number>();
     for (const link of links) {
       keyCounts.set(link.sessionKey, (keyCounts.get(link.sessionKey) ?? 0) + 1);

--- a/src/sessions/session-upstream-links.ts
+++ b/src/sessions/session-upstream-links.ts
@@ -12,10 +12,7 @@ import {
   runOpenClawStateWriteTransaction,
   type OpenClawStateDatabaseOptions,
 } from "../state/openclaw-state-db.js";
-import {
-  encodeSessionStateWatchTarget,
-  isLegacySessionStateWatchTarget,
-} from "./session-watch-target.js";
+import { encodeSessionStateWatchTarget } from "./session-watch-target.js";
 
 type SessionUpstreamDatabase = Pick<
   OpenClawStateKyselyDatabase,
@@ -251,51 +248,17 @@ export function listWatchedSessionUpstreamLinks(
           .distinct(),
       ).rows.map((row) => row.target_session_key),
     );
-    const legacyWatchedKeys = new Set(
-      [...watchedTargetKeys].filter(isLegacySessionStateWatchTarget),
+    const links = linkRows.map(rowToSessionUpstreamLink).filter((link) =>
+      watchedTargetKeys.has(
+        encodeSessionStateWatchTarget({
+          sessionKey: link.sessionKey,
+          agentId: link.agentId,
+        }),
+      ),
     );
-    const links = linkRows.map(rowToSessionUpstreamLink).filter(
-      (link) =>
-        watchedTargetKeys.has(
-          encodeSessionStateWatchTarget({
-            sessionKey: link.sessionKey,
-            agentId: link.agentId,
-          }),
-        ) ||
-        (isLegacySessionStateWatchTarget(link.sessionKey) &&
-          watchedTargetKeys.has(link.sessionKey)),
-    );
-    // Keep the duplicate-key guard for legacy rows that may still be visible while
-    // an older runtime is draining; never probe an arbitrary agent's upstream.
-    const keyCounts = new Map<string, number>();
-    const legacyKeyCounts = new Map<string, number>();
+    // Each qualified target owns one link; duplicate visible keys are split by the
+    // monitor before consuming the provider's key-only activity outcome contract.
     for (const link of links) {
-      const targetKey = encodeSessionStateWatchTarget({
-        sessionKey: link.sessionKey,
-        agentId: link.agentId,
-      });
-      keyCounts.set(targetKey, (keyCounts.get(targetKey) ?? 0) + 1);
-      if (legacyWatchedKeys.has(link.sessionKey)) {
-        legacyKeyCounts.set(link.sessionKey, (legacyKeyCounts.get(link.sessionKey) ?? 0) + 1);
-      }
-    }
-    for (const link of links) {
-      const targetKey = encodeSessionStateWatchTarget({
-        sessionKey: link.sessionKey,
-        agentId: link.agentId,
-      });
-      if ((keyCounts.get(targetKey) ?? 0) > 1) {
-        log.warn(
-          `skipping ambiguous upstream links for ${link.sessionKey}: multiple agents adopt the same key`,
-        );
-        continue;
-      }
-      if ((legacyKeyCounts.get(link.sessionKey) ?? 0) > 1) {
-        log.warn(
-          `skipping ambiguous legacy upstream links for ${link.sessionKey}: multiple agents adopt the same key`,
-        );
-        continue;
-      }
       const catalogLinks = grouped.get(link.catalogId) ?? [];
       catalogLinks.push(link);
       grouped.set(link.catalogId, catalogLinks);

--- a/src/sessions/session-upstream-monitor.test.ts
+++ b/src/sessions/session-upstream-monitor.test.ts
@@ -38,14 +38,15 @@ function createLink(
   catalogId: string,
   database: ReturnType<typeof createDatabaseOptions>,
   watched = true,
+  agentId = "main",
 ) {
   upsertSessionUpstreamLink(
     {
       sessionKey,
-      agentId: "main",
+      agentId,
       catalogId,
       hostId: "gateway:local",
-      threadId: `thread-${catalogId}`,
+      threadId: `thread-${agentId}-${catalogId}`,
       upstreamKind: catalogId === "claude" ? "claude-cli" : "codex-app-server",
       upstreamRef: { source: catalogId },
       marker: { offset: 0 },
@@ -53,7 +54,10 @@ function createLink(
     database,
   );
   if (watched) {
-    registerSessionStateWatch({ watcherSessionKey, targetSessionKey: sessionKey }, database);
+    registerSessionStateWatch(
+      { watcherSessionKey, targetSessionKey: sessionKey, targetAgentId: agentId },
+      database,
+    );
   }
 }
 
@@ -141,7 +145,7 @@ describe("session upstream monitor", () => {
       .get(watched) as { dedupe_key: string };
     // Source identity is hashed into the dedupe key so a rebased source cannot
     // collide with a prior source's activity id.
-    expect(dedupeRow.dedupe_key).toMatch(new RegExp(`^upstream:${watched}:[0-9a-f]{16}:8$`));
+    expect(dedupeRow.dedupe_key).toMatch(new RegExp(`^upstream:${watched}:[0-9a-f]{16}:8:main$`));
   });
 
   it("records one upstream-missing event after three misses and removes the link", async () => {
@@ -905,5 +909,47 @@ describe("session upstream monitor", () => {
     });
 
     expect(listSessionStateEventsSince(sessionKey, "main", 0, 20, database).events).toHaveLength(1);
+  });
+
+  it("processes duplicate bare session keys as independent agent probes", async () => {
+    const database = createDatabaseOptions();
+    createLink("global", "claude", database, true, "main");
+    createLink("global", "claude", database, true, "ops");
+    const check = vi.fn(async (probes: SessionUpstreamProbe[]) =>
+      probes.map((probe) => ({
+        kind: "activity" as const,
+        sessionKey: probe.sessionKey,
+        occurredAt: 2_000,
+        humanTurns: 1,
+        nextMarker: { agent: probe.agentId },
+        dedupeId: "same-upstream-event",
+      })),
+    );
+
+    await runSessionUpstreamMonitorTick({
+      ...database,
+      providers: [provider("claude", check)],
+      loadEntry: ({ agentId }: { agentId?: string }) =>
+        ({ sessionId: `session-${agentId}` }) as never,
+      isRunActive: () => false,
+      loadOwnRecentUserTexts: async () => [],
+    });
+
+    expect(check).toHaveBeenCalledTimes(2);
+    expect(check.mock.calls.map(([probes]) => probes.map((probe) => probe.agentId))).toEqual(
+      expect.arrayContaining([["main"], ["ops"]]),
+    );
+    expect(listSessionStateEventsSince("global", "main", 0, 20, database).events).toEqual([
+      expect.objectContaining({ agentId: "main", kind: "human_direct_message" }),
+    ]);
+    expect(listSessionStateEventsSince("global", "ops", 0, 20, database).events).toEqual([
+      expect.objectContaining({ agentId: "ops", kind: "human_direct_message" }),
+    ]);
+    expect(readSessionUpstreamLink("global", "main", database)).toEqual(
+      expect.objectContaining({ marker: { agent: "main" } }),
+    );
+    expect(readSessionUpstreamLink("global", "ops", database)).toEqual(
+      expect.objectContaining({ marker: { agent: "ops" } }),
+    );
   });
 });

--- a/src/sessions/session-upstream-monitor.ts
+++ b/src/sessions/session-upstream-monitor.ts
@@ -206,7 +206,7 @@ async function runSessionUpstreamMonitorTick(
       continue;
     }
     const probes: SessionUpstreamProbe[] = [];
-    const sessionIdBySessionKey = new Map<string, string>();
+    const sessionIdByProbeKey = new Map<string, string>();
     for (const link of links) {
       const probe = {
         sessionKey: link.sessionKey,
@@ -233,7 +233,7 @@ async function runSessionUpstreamMonitorTick(
           ...probe,
           ownRecentUserTexts,
         });
-        sessionIdBySessionKey.set(probe.sessionKey, entry.sessionId);
+        sessionIdByProbeKey.set(upstreamMonitorLinkKey(probe), entry.sessionId);
       } catch (error) {
         log.warn(`upstream transcript provenance failed for ${probe.sessionKey}: ${String(error)}`);
       }
@@ -241,165 +241,176 @@ async function runSessionUpstreamMonitorTick(
     if (probes.length === 0) {
       continue;
     }
-    const probeBySessionKey = new Map(probes.map((probe) => [probe.sessionKey, probe]));
-    const linkUpdatedAtBySessionKey = new Map(
-      links.map((link) => [link.sessionKey, link.updatedAt]),
+    const linkUpdatedAtByProbeKey = new Map(
+      links.map((link) => [upstreamMonitorLinkKey(link), link.updatedAt]),
     );
-    try {
-      const outcomes = await provider.checkUpstreamActivity(probes, {
-        allowProcessHomeFallback: allowsProcessHomeSessionScan(options.env ?? process.env),
-      });
-      if (options.signal?.aborted) {
-        return;
-      }
-      const missingSessionKeys = new Set(
-        outcomes
-          .filter((outcome) => outcome.kind === "missing")
-          .map((outcome) => outcome.sessionKey),
-      );
-      for (const probe of probes) {
-        if (!missingSessionKeys.has(probe.sessionKey)) {
-          missingCounts.delete(upstreamMonitorLinkKey(probe));
+    const probesBySessionKey = new Map<string, SessionUpstreamProbe[]>();
+    for (const probe of probes) {
+      const group = probesBySessionKey.get(probe.sessionKey) ?? [];
+      group.push(probe);
+      probesBySessionKey.set(probe.sessionKey, group);
+    }
+    const probeBatches = [...probesBySessionKey.values()].flatMap((group) =>
+      group.length === 1 ? [group] : group.map((probe) => [probe]),
+    );
+    for (const probesToCheck of probeBatches) {
+      const probeBySessionKey = new Map(probesToCheck.map((probe) => [probe.sessionKey, probe]));
+      try {
+        const outcomes = await provider.checkUpstreamActivity(probesToCheck, {
+          allowProcessHomeFallback: allowsProcessHomeSessionScan(options.env ?? process.env),
+        });
+        if (options.signal?.aborted) {
+          return;
         }
-      }
-      for (const outcome of outcomes) {
-        const probe = probeBySessionKey.get(outcome.sessionKey);
-        if (!probe) {
-          continue;
+        const missingSessionKeys = new Set(
+          outcomes
+            .filter((outcome) => outcome.kind === "missing")
+            .map((outcome) => outcome.sessionKey),
+        );
+        for (const probe of probesToCheck) {
+          if (!missingSessionKeys.has(probe.sessionKey)) {
+            missingCounts.delete(upstreamMonitorLinkKey(probe));
+          }
         }
-        const missingCountKey = upstreamMonitorLinkKey(probe);
-        if (outcome.kind === "missing") {
-          const expectedUpdatedAt = linkUpdatedAtBySessionKey.get(outcome.sessionKey);
-          const expectedSessionId = sessionIdBySessionKey.get(outcome.sessionKey);
-          // Provider I/O may outlive a new run or Continue. Only an idle current
-          // session and the exact scanned link can advance the missing streak.
-          if (expectedUpdatedAt === undefined || expectedSessionId === undefined) {
-            missingCounts.delete(missingCountKey);
+        for (const outcome of outcomes) {
+          const probe = probeBySessionKey.get(outcome.sessionKey);
+          if (!probe) {
             continue;
           }
-          if (options.signal?.aborted) {
-            return;
-          }
-          const currentLink = readMatchingProbeLink(probe, expectedUpdatedAt, dbOptions);
-          if (!currentLink) {
-            missingCounts.delete(missingCountKey);
-            continue;
-          }
-          const currentSession = loadProbeSession(probe, options);
-          if (!currentSession || currentSession.sessionId !== expectedSessionId) {
-            missingCounts.delete(missingCountKey);
-            continue;
-          }
-          if ((options.isRunActive ?? isEmbeddedAgentRunActive)(currentSession.sessionId)) {
-            continue;
-          }
-          const previous = missingCounts.get(missingCountKey);
-          const missingCount = Math.min(
-            SESSION_UPSTREAM_MISSING_THRESHOLD,
-            (previous?.linkUpdatedAt === expectedUpdatedAt ? previous.count : 0) + 1,
-          );
-          missingCounts.set(missingCountKey, {
-            count: missingCount,
-            linkUpdatedAt: expectedUpdatedAt,
-          });
-          if (missingCount < SESSION_UPSTREAM_MISSING_THRESHOLD) {
-            continue;
-          }
-          const sourceKey = upstreamSourceKey(probe);
-          const recorded = recordSessionStateEvent(
-            {
-              sessionKey: probe.sessionKey,
-              agentId: probe.agentId,
-              kind: "upstream_missing",
-              actorType: "system",
-              dedupeKey: `upstream-missing:${probe.sessionKey}:${sourceKey}:${currentLink.updatedAt}`,
-              summary: `upstream missing via ${catalogId}`,
-              payload: { channel: catalogId },
-            },
-            { ...dbOptions, now: (options.now ?? Date.now)() },
-          );
-          if (!recorded) {
+          const missingCountKey = upstreamMonitorLinkKey(probe);
+          if (outcome.kind === "missing") {
+            const expectedUpdatedAt = linkUpdatedAtByProbeKey.get(missingCountKey);
+            const expectedSessionId = sessionIdByProbeKey.get(missingCountKey);
+            // Provider I/O may outlive a new run or Continue. Only an idle current
+            // session and the exact scanned link can advance the missing streak.
+            if (expectedUpdatedAt === undefined || expectedSessionId === undefined) {
+              missingCounts.delete(missingCountKey);
+              continue;
+            }
+            if (options.signal?.aborted) {
+              return;
+            }
+            const currentLink = readMatchingProbeLink(probe, expectedUpdatedAt, dbOptions);
+            if (!currentLink) {
+              missingCounts.delete(missingCountKey);
+              continue;
+            }
+            const currentSession = loadProbeSession(probe, options);
+            if (!currentSession || currentSession.sessionId !== expectedSessionId) {
+              missingCounts.delete(missingCountKey);
+              continue;
+            }
+            if ((options.isRunActive ?? isEmbeddedAgentRunActive)(currentSession.sessionId)) {
+              continue;
+            }
+            const previous = missingCounts.get(missingCountKey);
+            const missingCount = Math.min(
+              SESSION_UPSTREAM_MISSING_THRESHOLD,
+              (previous?.linkUpdatedAt === expectedUpdatedAt ? previous.count : 0) + 1,
+            );
             missingCounts.set(missingCountKey, {
-              count: SESSION_UPSTREAM_MISSING_THRESHOLD - 1,
+              count: missingCount,
               linkUpdatedAt: expectedUpdatedAt,
+            });
+            if (missingCount < SESSION_UPSTREAM_MISSING_THRESHOLD) {
+              continue;
+            }
+            const sourceKey = upstreamSourceKey(probe);
+            const recorded = recordSessionStateEvent(
+              {
+                sessionKey: probe.sessionKey,
+                agentId: probe.agentId,
+                kind: "upstream_missing",
+                actorType: "system",
+                dedupeKey: `upstream-missing:${probe.sessionKey}:${sourceKey}:${probe.agentId}:${currentLink.updatedAt}`,
+                summary: `upstream missing via ${catalogId}`,
+                payload: { channel: catalogId },
+              },
+              { ...dbOptions, now: (options.now ?? Date.now)() },
+            );
+            if (!recorded) {
+              missingCounts.set(missingCountKey, {
+                count: SESSION_UPSTREAM_MISSING_THRESHOLD - 1,
+                linkUpdatedAt: expectedUpdatedAt,
+              });
+              continue;
+            }
+            deleteSessionUpstreamLink(probe.sessionKey, probe.agentId, dbOptions);
+            missingCounts.delete(missingCountKey);
+            continue;
+          }
+          missingCounts.delete(missingCountKey);
+          const activity = outcome;
+          if (!Number.isSafeInteger(activity.humanTurns) || activity.humanTurns < 0) {
+            continue;
+          }
+          try {
+            // A run can start while the provider is scanning. Recheck ownership and
+            // provenance before any marker advance so its prompt remains deferred.
+            if (
+              !(await probeProvenanceUnchanged(
+                probe,
+                sessionIdByProbeKey.get(missingCountKey),
+                options,
+              ))
+            ) {
+              continue;
+            }
+          } catch (error) {
+            log.warn(
+              `upstream transcript provenance failed for ${probe.sessionKey}: ${String(error)}`,
+            );
+            continue;
+          }
+          // CAS guard AFTER the last await: a Continue can refresh this link (new
+          // host/thread/source) while the scan or provenance check was in flight.
+          // From here to the record the path is synchronous, so a stale scan can
+          // neither record from the old source nor clobber the refreshed marker.
+          const expectedUpdatedAt = linkUpdatedAtByProbeKey.get(missingCountKey);
+          // Compare source identity too: a same-millisecond Continue can refresh the
+          // row without changing updated_at, so the timestamp alone is not a reliable
+          // optimistic lock.
+          if (!readMatchingProbeLink(probe, expectedUpdatedAt, dbOptions)) {
+            continue;
+          }
+          if (activity.humanTurns === 0) {
+            updateSessionUpstreamLinkMarker(probe.sessionKey, probe.agentId, activity.nextMarker, {
+              ...dbOptions,
+              now: (options.now ?? Date.now)(),
+              ...(expectedUpdatedAt === undefined ? {} : { expectedUpdatedAt }),
             });
             continue;
           }
-          deleteSessionUpstreamLink(probe.sessionKey, probe.agentId, dbOptions);
-          missingCounts.delete(missingCountKey);
-          continue;
-        }
-        missingCounts.delete(missingCountKey);
-        const activity = outcome;
-        if (!Number.isSafeInteger(activity.humanTurns) || activity.humanTurns < 0) {
-          continue;
-        }
-        try {
-          // A run can start while the provider is scanning. Recheck ownership and
-          // provenance before any marker advance so its prompt remains deferred.
-          if (
-            !(await probeProvenanceUnchanged(
-              probe,
-              sessionIdBySessionKey.get(probe.sessionKey),
-              options,
-            ))
-          ) {
+          if (!Number.isFinite(activity.occurredAt) || !activity.dedupeId) {
             continue;
           }
-        } catch (error) {
-          log.warn(
-            `upstream transcript provenance failed for ${probe.sessionKey}: ${String(error)}`,
+          const recorded = recordSessionHumanDirectMessage(
+            {
+              sessionKey: probe.sessionKey,
+              agentId: probe.agentId,
+              actor: { actorType: "human" },
+              channel: catalogId,
+              dedupeKey: `upstream:${probe.sessionKey}:${upstreamSourceKey(probe)}:${activity.dedupeId}:${probe.agentId}`,
+              ...(activity.humanTurns > 1 ? { payload: { turns: activity.humanTurns } } : {}),
+              occurredAt: activity.occurredAt as number,
+            },
+            // Local clock for bookkeeping: upstream occurredAt is event history only
+            // and is clamped inside the recorder against this same clock.
+            { ...dbOptions, now: (options.now ?? Date.now)() },
           );
-          continue;
-        }
-        // CAS guard AFTER the last await: a Continue can refresh this link (new
-        // host/thread/source) while the scan or provenance check was in flight.
-        // From here to the record the path is synchronous, so a stale scan can
-        // neither record from the old source nor clobber the refreshed marker.
-        const expectedUpdatedAt = linkUpdatedAtBySessionKey.get(activity.sessionKey);
-        // Compare source identity too: a same-millisecond Continue can refresh the
-        // row without changing updated_at, so the timestamp alone is not a reliable
-        // optimistic lock.
-        if (!readMatchingProbeLink(probe, expectedUpdatedAt, dbOptions)) {
-          continue;
-        }
-        if (activity.humanTurns === 0) {
+          if (!recorded) {
+            continue;
+          }
+          // Commit the scan marker only after the durable event insert/dedupe succeeds.
           updateSessionUpstreamLinkMarker(probe.sessionKey, probe.agentId, activity.nextMarker, {
             ...dbOptions,
             now: (options.now ?? Date.now)(),
             ...(expectedUpdatedAt === undefined ? {} : { expectedUpdatedAt }),
           });
-          continue;
         }
-        if (!Number.isFinite(activity.occurredAt) || !activity.dedupeId) {
-          continue;
-        }
-        const recorded = recordSessionHumanDirectMessage(
-          {
-            sessionKey: probe.sessionKey,
-            agentId: probe.agentId,
-            actor: { actorType: "human" },
-            channel: catalogId,
-            dedupeKey: `upstream:${probe.sessionKey}:${upstreamSourceKey(probe)}:${activity.dedupeId}`,
-            ...(activity.humanTurns > 1 ? { payload: { turns: activity.humanTurns } } : {}),
-            occurredAt: activity.occurredAt as number,
-          },
-          // Local clock for bookkeeping: upstream occurredAt is event history only
-          // and is clamped inside the recorder against this same clock.
-          { ...dbOptions, now: (options.now ?? Date.now)() },
-        );
-        if (!recorded) {
-          continue;
-        }
-        // Commit the scan marker only after the durable event insert/dedupe succeeds.
-        updateSessionUpstreamLinkMarker(probe.sessionKey, probe.agentId, activity.nextMarker, {
-          ...dbOptions,
-          now: (options.now ?? Date.now)(),
-          ...(expectedUpdatedAt === undefined ? {} : { expectedUpdatedAt }),
-        });
+      } catch (error) {
+        log.warn(`upstream activity probe failed for ${catalogId}: ${String(error)}`);
       }
-    } catch (error) {
-      log.warn(`upstream activity probe failed for ${catalogId}: ${String(error)}`);
     }
   }
 }

--- a/src/sessions/session-watch-target.ts
+++ b/src/sessions/session-watch-target.ts
@@ -48,3 +48,7 @@ export function decodeSessionStateWatchTarget(value: string): SessionStateWatchT
     return undefined;
   }
 }
+
+export function isLegacySessionStateWatchTarget(value: string): boolean {
+  return !value.startsWith(ENCODED_TARGET_PREFIX) && parseAgentSessionKey(value) === undefined;
+}

--- a/src/sessions/session-watch-target.ts
+++ b/src/sessions/session-watch-target.ts
@@ -1,0 +1,50 @@
+import { normalizeOptionalLowercaseString } from "@openclaw/normalization-core/string-coerce";
+import { parseAgentSessionKey } from "../routing/session-key.js";
+
+const ENCODED_TARGET_PREFIX = "session-state-target:";
+
+export type SessionStateWatchTarget = {
+  sessionKey: string;
+  agentId: string;
+};
+
+/** Bare session keys need an agent-owned storage identity in shared cursors. */
+export function encodeSessionStateWatchTarget(target: SessionStateWatchTarget): string {
+  const keyAgentId = parseAgentSessionKey(target.sessionKey)?.agentId;
+  if (
+    keyAgentId &&
+    normalizeOptionalLowercaseString(keyAgentId) ===
+      normalizeOptionalLowercaseString(target.agentId)
+  ) {
+    return target.sessionKey;
+  }
+  return `${ENCODED_TARGET_PREFIX}${Buffer.from(
+    JSON.stringify([target.agentId, target.sessionKey]),
+    "utf8",
+  ).toString("base64url")}`;
+}
+
+export function decodeSessionStateWatchTarget(value: string): SessionStateWatchTarget | undefined {
+  if (!value.startsWith(ENCODED_TARGET_PREFIX)) {
+    const agentId = parseAgentSessionKey(value)?.agentId;
+    return agentId ? { sessionKey: value, agentId } : undefined;
+  }
+  try {
+    const decoded: unknown = JSON.parse(
+      Buffer.from(value.slice(ENCODED_TARGET_PREFIX.length), "base64url").toString("utf8"),
+    );
+    if (
+      !Array.isArray(decoded) ||
+      decoded.length !== 2 ||
+      typeof decoded[0] !== "string" ||
+      typeof decoded[1] !== "string" ||
+      !decoded[0] ||
+      !decoded[1]
+    ) {
+      return undefined;
+    }
+    return { agentId: decoded[0], sessionKey: decoded[1] };
+  } catch {
+    return undefined;
+  }
+}

--- a/src/sessions/session-watch-target.ts
+++ b/src/sessions/session-watch-target.ts
@@ -48,3 +48,9 @@ export function decodeSessionStateWatchTarget(value: string): SessionStateWatchT
     return undefined;
   }
 }
+
+export function isLegacySessionStateWatchTarget(value: string): boolean {
+  return (
+    !value.startsWith(ENCODED_TARGET_PREFIX) && decodeSessionStateWatchTarget(value) === undefined
+  );
+}

--- a/src/sessions/session-watch-target.ts
+++ b/src/sessions/session-watch-target.ts
@@ -48,7 +48,3 @@ export function decodeSessionStateWatchTarget(value: string): SessionStateWatchT
     return undefined;
   }
 }
-
-export function isLegacySessionStateWatchTarget(value: string): boolean {
-  return !value.startsWith(ENCODED_TARGET_PREFIX) && parseAgentSessionKey(value) === undefined;
-}

--- a/src/state/openclaw-state-db-session-watch-migration.ts
+++ b/src/state/openclaw-state-db-session-watch-migration.ts
@@ -5,6 +5,10 @@ import {
   executeSqliteQueryTakeFirstSync,
   getNodeSqliteKysely,
 } from "../infra/kysely-sync.js";
+import {
+  encodeSessionStateWatchTarget,
+  isLegacySessionStateWatchTarget,
+} from "../sessions/session-watch-target.js";
 import { ensureColumn, tableExists, tableHasColumn } from "./openclaw-state-db-schema-helpers.js";
 import type { DB as OpenClawStateKyselyDatabase } from "./openclaw-state-db.generated.js";
 import {
@@ -19,15 +23,26 @@ const SESSION_WATCH_PROVENANCE_COLUMN_SQL =
   `CHECK (provenance IN ('${SESSION_WATCH_PROVENANCE_EXPLICIT}', '${SESSION_WATCH_PROVENANCE_AMBIENT_GROUP}'))`;
 
 type SessionWatchCursorDatabase = Pick<OpenClawStateKyselyDatabase, "session_watch_cursors">;
+type LegacySessionWatchDatabase = Pick<
+  OpenClawStateKyselyDatabase,
+  "session_state_heads" | "session_upstream_links" | "session_watch_cursors"
+>;
 
 type SessionWatchCursorProvenanceMigrationResult = {
   addedColumn: boolean;
+  ambiguousLegacyCursors: number;
+  legacyCursorSummary: string;
+  migratedLegacyCursors: number;
   migratedAmbientWatches: number;
   removedLegacySentinels: number;
 };
 
 function getSessionWatchCursorKysely(db: DatabaseSync) {
   return getNodeSqliteKysely<SessionWatchCursorDatabase>(db);
+}
+
+function getLegacySessionWatchKysely(db: DatabaseSync) {
+  return getNodeSqliteKysely<LegacySessionWatchDatabase>(db);
 }
 
 function hasLegacyAmbientWatchSentinels(db: DatabaseSync): boolean {
@@ -46,6 +61,18 @@ function hasLegacyAmbientWatchSentinels(db: DatabaseSync): boolean {
   );
 }
 
+function hasLegacySessionWatchCursors(db: DatabaseSync): boolean {
+  if (!tableExists(db, "session_watch_cursors")) {
+    return false;
+  }
+  return executeSqliteQuerySync(
+    db,
+    getSessionWatchCursorKysely(db)
+      .selectFrom("session_watch_cursors")
+      .select("target_session_key"),
+  ).rows.some((row) => isLegacySessionStateWatchTarget(row.target_session_key));
+}
+
 export function needsSessionWatchCursorProvenanceMigration(
   db: DatabaseSync,
   userVersion: number,
@@ -56,7 +83,8 @@ export function needsSessionWatchCursorProvenanceMigration(
   return (
     userVersion < SESSION_WATCH_PROVENANCE_SCHEMA_VERSION ||
     !tableHasColumn(db, "session_watch_cursors", "provenance") ||
-    hasLegacyAmbientWatchSentinels(db)
+    hasLegacyAmbientWatchSentinels(db) ||
+    hasLegacySessionWatchCursors(db)
   );
 }
 
@@ -78,7 +106,14 @@ export function migrateSessionWatchCursorProvenance(
   db: DatabaseSync,
 ): SessionWatchCursorProvenanceMigrationResult {
   if (!tableExists(db, "session_watch_cursors")) {
-    return { addedColumn: false, migratedAmbientWatches: 0, removedLegacySentinels: 0 };
+    return {
+      addedColumn: false,
+      ambiguousLegacyCursors: 0,
+      legacyCursorSummary: "",
+      migratedLegacyCursors: 0,
+      migratedAmbientWatches: 0,
+      removedLegacySentinels: 0,
+    };
   }
 
   const addedColumn = ensureColumn(
@@ -87,6 +122,85 @@ export function migrateSessionWatchCursorProvenance(
     SESSION_WATCH_PROVENANCE_COLUMN_SQL,
   );
   const kysely = getSessionWatchCursorKysely(db);
+  const legacyKysely = getLegacySessionWatchKysely(db);
+  let migratedLegacyCursors = 0;
+  let ambiguousLegacyCursors = 0;
+  if (tableExists(db, "session_state_heads") && tableExists(db, "session_upstream_links")) {
+    const legacyCursors = executeSqliteQuerySync(
+      db,
+      kysely.selectFrom("session_watch_cursors").selectAll(),
+    ).rows.filter((row) => isLegacySessionStateWatchTarget(row.target_session_key));
+    for (const cursor of legacyCursors) {
+      const ownerIds = new Set<string>();
+      for (const row of executeSqliteQuerySync(
+        db,
+        legacyKysely
+          .selectFrom("session_state_heads")
+          .select("agent_id")
+          .where("session_key", "=", cursor.target_session_key),
+      ).rows) {
+        ownerIds.add(row.agent_id);
+      }
+      for (const row of executeSqliteQuerySync(
+        db,
+        legacyKysely
+          .selectFrom("session_upstream_links")
+          .select("agent_id")
+          .where("session_key", "=", cursor.target_session_key),
+      ).rows) {
+        ownerIds.add(row.agent_id);
+      }
+      if (ownerIds.size !== 1) {
+        ambiguousLegacyCursors += 1;
+        continue;
+      }
+      const agentId = [...ownerIds][0]!;
+      const qualifiedTarget = encodeSessionStateWatchTarget({
+        sessionKey: cursor.target_session_key,
+        agentId,
+      });
+      const existing = executeSqliteQueryTakeFirstSync(
+        db,
+        kysely
+          .selectFrom("session_watch_cursors")
+          .selectAll()
+          .where("watcher_session_key", "=", cursor.watcher_session_key)
+          .where("target_session_key", "=", qualifiedTarget),
+      );
+      if (existing) {
+        executeSqliteQuerySync(
+          db,
+          kysely
+            .updateTable("session_watch_cursors")
+            .set({
+              last_seen_sequence: Math.min(cursor.last_seen_sequence, existing.last_seen_sequence),
+              notified_sequence: Math.min(cursor.notified_sequence, existing.notified_sequence),
+              material_sequence: Math.max(cursor.material_sequence, existing.material_sequence),
+              updated_at: Math.max(cursor.updated_at, existing.updated_at),
+            })
+            .where("watcher_session_key", "=", cursor.watcher_session_key)
+            .where("target_session_key", "=", qualifiedTarget),
+        );
+        executeSqliteQuerySync(
+          db,
+          kysely
+            .deleteFrom("session_watch_cursors")
+            .where("watcher_session_key", "=", cursor.watcher_session_key)
+            .where("target_session_key", "=", cursor.target_session_key),
+        );
+      } else {
+        executeSqliteQuerySync(
+          db,
+          kysely
+            .updateTable("session_watch_cursors")
+            .set({ target_session_key: qualifiedTarget })
+            .where("watcher_session_key", "=", cursor.watcher_session_key)
+            .where("target_session_key", "=", cursor.target_session_key),
+        );
+      }
+      migratedLegacyCursors += 1;
+    }
+  }
   const legacyMarkers = executeSqliteQuerySync(
     db,
     kysely
@@ -133,6 +247,14 @@ export function migrateSessionWatchCursorProvenance(
   }
   return {
     addedColumn,
+    ambiguousLegacyCursors,
+    legacyCursorSummary:
+      ambiguousLegacyCursors > 0
+        ? `. Found ${ambiguousLegacyCursors} legacy session watch cursor(s) without a unique target agent; left untouched for explicit re-registration.`
+        : migratedLegacyCursors > 0
+          ? `. Migrated ${migratedLegacyCursors} legacy session watch cursor(s) to qualified target keys.`
+          : "",
+    migratedLegacyCursors,
     migratedAmbientWatches,
     removedLegacySentinels: legacyMarkers.length,
   };

--- a/src/state/openclaw-state-db.ts
+++ b/src/state/openclaw-state-db.ts
@@ -210,7 +210,7 @@ function repairStateSchema(
         const sessionWatchResult = sessionWatchMigration.migrateSessionWatchCursorProvenance(db);
         if (needsSessionWatchMigration) {
           applied.push(
-            `Migrated shared state session watch cursors → provenance column (${sessionWatchResult.migratedAmbientWatches} ambient, ${sessionWatchResult.removedLegacySentinels} sentinels removed)`,
+            `Migrated shared state session watch cursors → provenance column (${sessionWatchResult.migratedAmbientWatches} ambient, ${sessionWatchResult.removedLegacySentinels} sentinels removed)${sessionWatchResult.legacyCursorSummary}`,
           );
         }
         assertCanonicalStateSchemaShape(db, pathname);


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where `sessions_send({ watch: true })` could conflate watches for bare `global` session keys owned by different agents. The shared cursor table keyed only by watcher and target key could advance, notify, or delete the wrong agent's watch state.

## Why This Change Was Made

Session-state watch targets now use an agent-qualified internal identity whenever the visible target key is bare, while preserving the existing storage shape for already agent-scoped keys. Notice text, contexts, acknowledgements, session deletion, human-message fast-path checks, and upstream-session polling all use the same target identity. Legacy bare cursors are migrated only when persisted state proves a unique target owner; ambiguous rows remain intact for explicit recovery. No SQLite schema or version change is required.

## User Impact

Agents can watch multiple same-key `global` sessions without their cursor watermarks or upstream polling being mixed together. Qualified notices now direct reconciliation to the owning agent's session. Existing legacy watches with one authoritative target owner retain their watermarks across upgrade; ambiguous legacy rows are not silently assigned to the wrong agent.

## Evidence

### Final behavior proof

- Current reviewed head: `90e3cb44644823625e904f58af7d4a93af20457a`.
- Claim-matched production-path proof: `node scripts/run-vitest.mjs src/sessions/session-state-events.test.ts -t "keeps global target watch cursors independent|migrates legacy bare cursors|leaves ambiguous legacy bare cursors" --pool=forks --maxWorkers=1` — PASS, 3 targeted tests passed.
- Inspectable result: two same-key global cursors remained distinct with independent material watermarks; a legacy cursor with one proven owner was rewritten to the qualified target key with `last_seen_sequence=3`, `notified_sequence=4`, and `material_sequence=5`; a cursor with two proven owners remained at bare `global` and was classified for Doctor recovery.
- Claim-matched production-path proof: `node scripts/run-vitest.mjs src/sessions/session-upstream-monitor.test.ts -t "processes duplicate bare session keys as independent agent probes" --pool=forks --maxWorkers=1` — PASS, 1 targeted test passed.
- Inspectable result: duplicate bare session keys were sent as independent provider probe batches, and resulting events/markers remained attributed to their respective agents.
- Notice-path proof: `node scripts/run-vitest.mjs src/sessions/session-state-notices.test.ts -t "keeps the target agent in notices" --pool=forks --maxWorkers=1` — PASS, 1 targeted test passed.
- Inspectable result: an `ops/global` notice retains the qualified opaque target and renders `session_status sessionKey "agent:ops:global" changesSince 7`, so acknowledgement and reconciliation address the same target.
- Upgrade-path proof: `node scripts/run-vitest.mjs src/state/openclaw-state-db.test.ts -t "doctor migrates version 3 ambient watch sentinels" --pool=forks --maxWorkers=1` — PASS, 1 migration test passed.

### Supporting checks

- Targeted oxlint passed for all four changed source/test files.
- Targeted `oxfmt --check` passed for all four changed files.
- `git diff --check` passed.
- Focused session-state, notices, upstream-links, and upstream-monitor assertions passed.

### Proof boundary

The proof exercises the production session-state, shared SQLite migration, notice rendering, and upstream-monitor paths with isolated local state. It does not claim delivery through an external channel or provider account. Legacy rows are migrated only when the shared state tables establish exactly one owner; ambiguous rows remain available for explicit operator recovery.

AI-assisted: yes. I reviewed the qualified cursor identity, actionable notice/status target, startup/Doctor migration boundary, ambiguous-row behavior, independent event attribution, upstream monitor batching, and provider contract boundary.
