### PR TITLE
perf(test): avoid inventory scans for exact test validation

### DIFF
--- a/scripts/test-projects.test-support.mts
+++ b/scripts/test-projects.test-support.mts
@@ -1358,6 +1358,11 @@ export function findUnmatchedExplicitTestTargets(args: string[], cwd = process.c
   const unmatched: UnmatchedExplicitTestTarget[] = [];
   for (const targetArg of targetArgs) {
     const relative = toRepoRelativeTarget(targetArg, cwd);
+    const absolute = path.resolve(cwd, targetArg);
+    // Existing exact tests need no inventory scan; lane assignment belongs to the run planner.
+    if (!isGlobTarget(relative) && isTestFileTarget(relative) && fs.existsSync(absolute)) {
+      continue;
+    }
     if (
       resolveVitestConfigTargetKind(relative) ||
       (isVitestConfigFileTarget(relative) && isExistingFileTarget(targetArg, cwd))
@@ -1378,7 +1383,6 @@ export function findUnmatchedExplicitTestTargets(args: string[], cwd = process.c
       continue;
     }
 
-    const absolute = path.resolve(cwd, targetArg);
     if (!fs.existsSync(absolute)) {
       if (resolveExplicitTestPrefixTargets(targetArg, cwd)) {
         continue;
@@ -1390,10 +1394,6 @@ export function findUnmatchedExplicitTestTargets(args: string[], cwd = process.c
           ? { includePattern: `${relative}{,.*}.{test,spec}.{js,jsx,ts,tsx,mjs,cjs,mts,cts}` }
           : {}),
       });
-      continue;
-    }
-
-    if (isTestFileTarget(relative)) {
       continue;
     }
 


### PR DESCRIPTION
## What Problem This Solves

Validating an explicit existing test path unnecessarily scans the repository test inventory. A gate-plan test spends several seconds reading thousands of unrelated files before accepting a target that the validator already knows exists.

## Why This Change Was Made

Accept existing non-glob test paths before lane classification. The run planner still classifies every target when constructing the actual run; only the preliminary validity check avoids that work. Missing paths, glob patterns, directories, source/support paths and configuration targets retain their existing handling.

Tooling +5/-5; production runtime and tests unchanged. No sharding, concurrency, worker counts or test-selection changes.

## User Impact

Focused test commands and their planning checks avoid an unnecessary inventory scan. Product behavior is unchanged.

## Evidence

- The seven existing Crabbox gate-plan tests pass: execution falls from 3.1446s to 0.0035s on the same checkout baseline.
- A direct fresh-process validation probe falls from 4,158ms and 4,919 unrelated test-file reads to 0.448ms and zero unrelated reads.
- Differential comparison preserves 16 validation cases, 10 fixture/deletion/glob cases and 16 actual run plans, including relative/absolute paths, missing tests, literal glob-shaped filenames, configuration paths and directories.
- Deliberately removing either the existence check or glob guard fails an independent expectation; candidate bytes restored afterward.
- Normal owning test runs pass all 395 tests across test-projects, ci-changed-node-test-plan and pr-crabbox-gate-plan.
- Changed-file checks and independent Codex autoreview pass. No new test duplicates the existing target-contract coverage; the temporary differential and negative probes exercise the optimization directly.

No changelog needed for internal test tooling.
