### PR TITLE
fix: clean up health tests after failed or delayed setup

### DIFF
--- a/src/gateway/server.health.lifecycle.test.ts
+++ b/src/gateway/server.health.lifecycle.test.ts
@@ -1,0 +1,241 @@
+import { EventEmitter } from "node:events";
+import { existsSync } from "node:fs";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { setImmediate } from "node:timers/promises";
+import { afterEach, expect, test, vi } from "vitest";
+import { createDeferred } from "../../test/helpers/promise.js";
+
+type HealthHook = () => void | Promise<void>;
+let drainHealthCleanup: (() => Promise<void>) | undefined;
+let healthImport: Promise<unknown> | undefined;
+
+afterEach(async () => {
+  try {
+    // A timed-out import still runs. Join it before resetting the mock registry;
+    // collectHealthFixture fences the canceled test before it can inject faults.
+    await healthImport;
+    // A red health cleanup can skip the remaining owner hook. Drain it only
+    // after recording the failure, so this regression cannot leak its HOME.
+    await drainHealthCleanup?.();
+  } finally {
+    drainHealthCleanup = undefined;
+    healthImport = undefined;
+    vi.restoreAllMocks();
+    vi.doUnmock("vitest");
+    vi.doUnmock("./server.js");
+    vi.doUnmock("./server.e2e-ws-harness.js");
+    vi.doUnmock("./server-restart-sentinel.js");
+    vi.resetModules();
+  }
+});
+
+async function collectHealthFixture(signal: AbortSignal) {
+  vi.resetModules();
+  const setupHooks: HealthHook[] = [];
+  const cleanupHooks: HealthHook[] = [];
+  const bodies = new Map<string, HealthHook>();
+  const ws = new EventEmitter();
+  const close = vi.fn(async () => {});
+  const harness = { close, openClient: async () => ({ ws }) };
+  const start = vi.fn(async () => harness);
+  const prepare = vi.fn(async () => {});
+  const vitest = await vi.importActual<typeof import("vitest")>("vitest");
+  vi.doMock("vitest", () => ({
+    ...vitest,
+    beforeAll: (hook: HealthHook) => setupHooks.push(hook),
+    afterAll: (hook: HealthHook) => cleanupHooks.push(hook),
+    beforeEach: vi.fn(),
+    afterEach: vi.fn(),
+    describe: (_name: string, body: () => void) => body(),
+    test: (name: string, optionsOrBody: { timeout: number } | HealthHook, body?: HealthHook) => {
+      const run = typeof optionsOrBody === "function" ? optionsOrBody : body;
+      if (!run) {
+        throw new Error(`Missing health test body: ${name}`);
+      }
+      bodies.set(name, run);
+    },
+  }));
+  // Keep installGatewayTestHooks and its real environment lifecycle intact.
+  // Only server construction is controlled; the normal suite proves health RPCs.
+  vi.doMock("./server.js", () => ({ resetPreparedModelCatalogForTest: prepare }));
+  vi.doMock("./server.e2e-ws-harness.js", () => ({ startGatewayServerHarness: start }));
+  const cleanup = async () => {
+    // Vitest's default stack order stops this phase on the first rejection.
+    while (cleanupHooks.length) {
+      await cleanupHooks.pop()!();
+    }
+  };
+  drainHealthCleanup = async () => {
+    const errors: unknown[] = [];
+    while (cleanupHooks.length) {
+      try {
+        await cleanup();
+      } catch (error) {
+        errors.push(error);
+      }
+    }
+    if (errors.length) {
+      throw new AggregateError(errors, "Health fixture recovery cleanup failed");
+    }
+  };
+  healthImport = import("./server.health.test.js");
+  await healthImport;
+  signal.throwIfAborted();
+  return {
+    bodies,
+    close,
+    harness,
+    start,
+    prepare,
+    ws,
+    cleanup,
+    setup: async () => {
+      for (const hook of setupHooks) {
+        await hook();
+      }
+    },
+  };
+}
+
+test.for(["HOME acquisition", "shared reset"])(
+  "health teardown preserves a %s failure without dereferencing a fixture",
+  async (phase, { signal }) => {
+    const fixture = await collectHealthFixture(signal);
+    const homeBefore = process.env.HOME;
+    const failure = new Error(`injected shared ${phase} failure`);
+    if (phase === "HOME acquisition") {
+      vi.spyOn(fs, "mkdtemp").mockRejectedValueOnce(failure);
+    } else {
+      fixture.prepare.mockRejectedValueOnce(failure);
+    }
+    await expect(fixture.setup()).rejects.toBe(failure);
+    expect(fixture.start).not.toHaveBeenCalled();
+    const partialHome = process.env.HOME!;
+    if (phase === "shared reset") {
+      expect(partialHome).not.toBe(homeBefore);
+      expect(existsSync(partialHome)).toBe(true);
+    }
+    await expect(fixture.cleanup()).resolves.toBeUndefined();
+    expect(process.env.HOME).toBe(homeBefore);
+    if (phase === "shared reset") {
+      expect(existsSync(partialHome)).toBe(false);
+    }
+  },
+);
+
+test("health teardown preserves rejected startup and removes its partial fixture state", async ({
+  signal,
+}) => {
+  const fixture = await collectHealthFixture(signal);
+  const failure = new Error("injected startup failure before harness publication");
+  let partialState: string | undefined;
+  fixture.start.mockImplementation(async () => {
+    partialState = path.join(process.env.HOME!, "partial-health-startup");
+    await fs.mkdir(partialState);
+    throw failure;
+  });
+  await expect(fixture.setup()).rejects.toBe(failure);
+  expect(existsSync(partialState!)).toBe(true);
+  await expect(fixture.cleanup()).resolves.toBeUndefined();
+  expect(existsSync(partialState!)).toBe(false);
+  expect(fixture.close).not.toHaveBeenCalled();
+});
+
+test("health cleanup retains its environment until pending startup settles and the server closes", async ({
+  signal,
+}) => {
+  const fixture = await collectHealthFixture(signal);
+  const started = createDeferred();
+  const releaseStartup = createDeferred<typeof fixture.harness>();
+  const releaseClose = createDeferred();
+  fixture.start.mockImplementation(() => {
+    started.resolve();
+    return releaseStartup.promise;
+  });
+  fixture.close.mockImplementation(() => releaseClose.promise);
+  const setup = fixture.setup();
+  let cleanup: Promise<unknown> | undefined;
+  try {
+    await Promise.race([started.promise, setup]);
+    expect(fixture.start).toHaveBeenCalledOnce();
+    const home = process.env.HOME!;
+    let cleanupSettled = false;
+    // Drive the schedule after a beforeAll timeout: its async body is still
+    // running when Vitest enters afterAll. No wall-clock timeout is needed.
+    cleanup = fixture.cleanup().then(
+      () => {
+        cleanupSettled = true;
+      },
+      (error: unknown) => {
+        cleanupSettled = true;
+        return error;
+      },
+    );
+    await setImmediate();
+    expect.soft(cleanupSettled).toBe(false);
+    expect.soft(process.env.HOME === home).toBe(true);
+    expect.soft(existsSync(home)).toBe(true);
+    releaseStartup.resolve(fixture.harness);
+    await setup;
+    await setImmediate();
+    expect.soft(fixture.close).toHaveBeenCalledOnce();
+    expect.soft(cleanupSettled).toBe(false);
+    expect.soft(process.env.HOME === home).toBe(true);
+    expect.soft(existsSync(home)).toBe(true);
+    releaseClose.resolve();
+    expect.soft(await cleanup).toBeUndefined();
+    expect.soft(existsSync(home)).toBe(false);
+  } finally {
+    releaseStartup.resolve(fixture.harness);
+    releaseClose.resolve();
+    await Promise.allSettled([setup, cleanup]);
+  }
+});
+
+test("health teardown awaits the shutdown test's original close promise without closing twice", async ({
+  signal,
+}) => {
+  const fixture = await collectHealthFixture(signal);
+  const closing = createDeferred();
+  const releaseClose = createDeferred();
+  fixture.close.mockImplementation(() => {
+    closing.resolve();
+    fixture.ws.emit(
+      "message",
+      Buffer.from(
+        JSON.stringify({
+          type: "event",
+          event: "shutdown",
+          payload: { reason: "gateway stopping" },
+        }),
+      ),
+    );
+    return releaseClose.promise;
+  });
+  await fixture.setup();
+  const home = process.env.HOME!;
+  const shutdown = fixture.bodies.get("shutdown event is broadcast on close");
+  expect(shutdown).toBeTypeOf("function");
+  const body = Promise.resolve(shutdown!());
+  let cleanup: Promise<void> | undefined;
+  try {
+    await Promise.race([closing.promise, body]);
+    let cleanupSettled = false;
+    cleanup = fixture.cleanup().then(() => {
+      cleanupSettled = true;
+    });
+    await setImmediate();
+    expect(fixture.close).toHaveBeenCalledOnce();
+    expect(cleanupSettled).toBe(false);
+    expect(process.env.HOME === home).toBe(true);
+    expect(existsSync(home)).toBe(true);
+    releaseClose.resolve();
+    await Promise.all([body, cleanup]);
+    expect(fixture.close).toHaveBeenCalledOnce();
+    expect(existsSync(home)).toBe(false);
+  } finally {
+    releaseClose.resolve();
+    await Promise.allSettled([body, cleanup]);
+  }
+});

--- a/src/gateway/server.health.test.ts
+++ b/src/gateway/server.health.test.ts
@@ -2,7 +2,7 @@
  * Gateway health endpoint integration tests.
  */
 import { randomUUID } from "node:crypto";
-import { afterAll, beforeAll, describe, expect, test, vi } from "vitest";
+import { describe, expect, test, vi } from "vitest";
 import { emitAgentEvent } from "../infra/agent-events.js";
 import { emitHeartbeatEvent } from "../infra/heartbeat-events.js";
 import { GATEWAY_CLIENT_MODES, GATEWAY_CLIENT_NAMES } from "../utils/message-channel.js";
@@ -15,7 +15,6 @@ vi.mock("./server-restart-sentinel.js", () => ({
   recoverPendingRestartContinuationDeliveries: vi.fn(async () => undefined),
 }));
 
-installGatewayTestHooks({ scope: "suite" });
 const HEALTH_E2E_TIMEOUT_MS = 20_000;
 const PRESENCE_EVENT_TIMEOUT_MS = 6_000;
 const SHUTDOWN_EVENT_TIMEOUT_MS = 3_000;
@@ -25,12 +24,14 @@ const CLI_PRESENCE_TIMEOUT_MS = 3_000;
 let harness: GatewayServerHarness;
 let harnessClose: Promise<void> | undefined;
 
-beforeAll(async () => {
-  harness = await startGatewayServerHarness();
-});
-
-afterAll(async () => {
-  await (harnessClose ?? harness.close());
+installGatewayTestHooks({
+  scope: "suite",
+  setup: async () => {
+    harness = await startGatewayServerHarness();
+  },
+  cleanup: async () => {
+    await (harnessClose ?? harness?.close());
+  },
 });
 
 describe("gateway server health/presence", () => {


### PR DESCRIPTION
Related: #132574 — suite-owned Gateway fixture setup/cleanup.

<details>
<summary>Additional instructions</summary>

Maintainers can update this same-repository branch. AI-assisted maintainer-requested repair.

</details>

## What Problem This Solves

Resolves a problem where the Gateway health/presence test suite adds an `undefined.close` teardown error after an earlier setup failure or rejected startup, and can leave a server unclosed when startup completes after teardown begins. A normal pre-fix run reproduced the setup timeout followed by the teardown error; deterministic fault injection covers the failure schedules without waiting for a wall-clock timeout.

## Why This Change Was Made

Register the health fixture's setup and cleanup with the suite-owned lifecycle added in #132574. That owner joins pending setup before closing the fixture and releasing its environment; cleanup tolerates a harness that was never created. Preserve the intentional shutdown-broadcast test and reuse its original `harnessClose` promise rather than closing twice.

Remove the independent health `beforeAll`/`afterAll` registration. A missing-harness guard alone would avoid the extra error but would not own late startup. The regression tests import the real health suite registrations and retain the shared environment lifecycle; only fixture construction is fault-controlled. Normal health/presence coverage runs against the actual Gateway in the same non-isolated worker as the fault and environment cases. The deterministic driver enforces the partial-setup and delayed-startup interleavings internally; no custom file ordering is needed.

## User Impact

No production behavior changes. Maintainers get reliable cleanup and clearer setup-failure diagnostics without changing timeout budgets, consumer environment defaults, or production APIs. This is a test-only follow-up; the shared lifecycle implementation already landed in #132574 and is not duplicated here.

Production LOC: +0/-0. Tests/test support: +250/-8 (net +242), across the health fixture and its focused five-case fault coverage.

## Evidence

- Negative control: retain the shared owner from #132574 but temporarily use the original independent health hooks. The final regression suite reports four expected failures (HOME acquisition, partial shared reset, rejected startup, delayed startup/close) and one passing early-shutdown-reuse case. Failures include `Cannot read properties of undefined (reading 'close')` and zero close calls after delayed startup.
- Fixed tree at `f78fe998f65c5beb6df6eda45e0ca12d0298cff4`: all 21 focused tests pass together: five lifecycle fault cases, nine actual health/presence tests including shutdown, and seven existing environment-lifecycle tests. The initial proof observed faults → health → environment; the refreshed passing run observed health → environment → faults under the normal runner.
- The first refreshed run reported 20 passed, one shutdown-test timeout at the unchanged 6,000 ms budget, and one unhandled timeout. One unchanged bounded rerun passed all 21 with no unhandled errors (55.62 s Vitest / 73.70 s wrapper; shutdown 932 ms). No source, timeout, environment, cache, or sequencing changes were made between attempts. Host load was observed but was not established as the cause of the failed attempt.
- The final proof uses the unchanged repository test wrapper and pinned dependencies, with no environment or timeout overrides:

```bash
node scripts/run-vitest.mjs src/gateway/server.health.lifecycle.test.ts src/gateway/server.health.test.ts src/gateway/test-helpers.server-env.test.ts
```

- Refreshed changed-scope checks completed with exit 0, including core-test typechecking, changed-file formatting/lint, dead-export scans, and required guards:

```bash
node scripts/check-changed.mjs -- src/gateway/server.health.test.ts src/gateway/server.health.lifecycle.test.ts
```

- `git diff --check` passes. Fresh isolated Codex autoreview completed with exit 0 and no accepted/actionable findings at its configured P0 scope. The reviewed files remain byte-identical after mechanical rebase; [exact-head CI run 33259179414, attempt 1](https://github.com/openclaw/openclaw/actions/runs/33259179414) is green, including `openclaw/ci-gate`. Final native landing proof will be posted before merge.
- Direct Vitest runner source inspection confirms that hook timeout rejects the wrapper without canceling its original async body, `afterAll` still runs after failed setup, and stack-ordered cleanup stops on the first rejection. Deferred promises reproduce that schedule deterministically.
- Initial validation exposed stale ancestor dependencies; `pnpm install --frozen-lockfile` restored the checkout's pinned versions without manifest or lockfile changes. All focused tests and changed checks then passed.

Provenance: the local shallow history carries the faulty hooks at its boundary, so it does not establish the original introducing commit. This PR does not attribute introduction to that boundary commit.

ClawSweeper follow-up: [the fresh exact-head review](https://github.com/openclaw/openclaw/pull/132653#issuecomment-5463166020) found no actionable code or security findings and requested normal maintainer landing. Its dependency-source limitation is resolved by direct local inspection of installed `@vitest/runner@4.1.11`, `dist/chunk-artifact.js`: `withTimeout` at 2261 rejects only the wrapper while the original thenable continues; `getSuiteHooks` at 2567 reverses stack cleanup; `callSuiteHook` at 2608–2638 awaits hooks without catching each rejection, so one rejection skips later hooks; `runSuite` finally at 3169 still invokes `afterAll` after failed setup. The inspected artifact SHA-256 is `a0bc0dbd844b52e715ad3f35b628312fa16d324123406541f66a528577205087`. Maintainer acceptance of the supplied fault proof was already given and remains in effect; no code follow-up, skipped rank-up move, or re-review request is needed for this unchanged head.
