### PR TITLE
fix(test): join tsgo cleanup after operation timeout

### DIFF
--- a/test/scripts/run-tsgo.test.ts
+++ b/test/scripts/run-tsgo.test.ts
@@ -2,6 +2,7 @@
 import { spawn, spawnSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
+import { performance } from "node:perf_hooks";
 import { pathToFileURL } from "node:url";
 import { describe, expect, it } from "vitest";
 import {
@@ -11,12 +12,9 @@ import {
 } from "../../scripts/lib/tsgo-sparse-guard.mts";
 import { resolveTsgoTimeoutMs } from "../../scripts/run-tsgo.mts";
 import { createBoundedChildOutput } from "../helpers/bounded-child-output.js";
-import {
-  isProcessAlive,
-  waitForChildClose,
-  waitForDead,
-  waitForPidFile,
-} from "../helpers/process-wait.js";
+import { isProcessAlive, waitForDead, waitForPidFile } from "../helpers/process-wait.js";
+import { withTestTimeout } from "../helpers/promise.js";
+import { createTempDirTracker } from "../helpers/temp-dir.js";
 import { createScriptTestHarness } from "./test-helpers.js";
 
 const { createTempDir } = createScriptTestHarness();
@@ -459,19 +457,29 @@ child.once("message", () => process.exit(0));
   it.each(["wrapper", "spawn"])(
     "reaps a wedged compiler on SIGTERM during %s",
     async (phase) => {
-      const cwd = fs.realpathSync(createTempDir("openclaw-run-tsgo-signal-"));
-      const pidFile = path.join(cwd, "fake-tsgo.pid");
-      fs.writeFileSync(path.join(cwd, "tsconfig.extensions.json"), "{}\n");
-      writeFakeTsgo(
-        cwd,
-        '#!/bin/sh\ntrap \'\' TERM HUP INT\necho $$ > "$(dirname "$0")/../../fake-tsgo.pid"\nwhile true; do sleep 1; done\n',
-      );
-      const preloadPath = path.join(cwd, "signal-during-spawn.mjs");
-      // Hold the real spawn boundary until the compiler is ready, then deliver an
-      // OS signal before the supervisor can register the returned child.
-      fs.writeFileSync(
-        preloadPath,
-        `
+      const fixtureDirs = createTempDirTracker();
+      // Detached compilers can outlive Vitest's temporary namespace. Retain their
+      // diagnostics outside it until both the wrapper and compiler are joined.
+      const artifacts = path.resolve(".artifacts/tsgo-signal");
+      fs.mkdirSync(artifacts, { recursive: true });
+      const cwd = fixtureDirs.make("fixture-", fs.realpathSync(artifacts));
+      let retainFixture = false;
+      try {
+        const pidFile = path.join(cwd, "fake-tsgo.pid");
+        // Give this fixture its own artifact lock rather than the enclosing checkout's.
+        fs.writeFileSync(path.join(cwd, "package.json"), '{"private":true}\n');
+        fs.writeFileSync(path.join(cwd, "pnpm-workspace.yaml"), "packages: []\n");
+        fs.writeFileSync(path.join(cwd, "tsconfig.extensions.json"), "{}\n");
+        writeFakeTsgo(
+          cwd,
+          '#!/bin/sh\ntrap \'\' TERM HUP INT\necho $$ > "$(dirname "$0")/../../fake-tsgo.pid"\nwhile true; do sleep 1; done\n',
+        );
+        const preloadPath = path.join(cwd, "signal-during-spawn.mjs");
+        // Hold the real spawn boundary until the compiler is ready, then deliver an
+        // OS signal before the supervisor can register the returned child.
+        fs.writeFileSync(
+          preloadPath,
+          `
 import childProcess from "node:child_process";
 import fs from "node:fs";
 import { syncBuiltinESMExports } from "node:module";
@@ -492,47 +500,77 @@ childProcess.spawn = (...args) => {
 };
 syncBuiltinESMExports();
 `,
-      );
-      const wrapper = spawn(
-        process.execPath,
-        [path.resolve("scripts/run-tsgo.mjs"), "-p", "tsconfig.extensions.json"],
-        {
-          cwd,
-          stdio: ["ignore", "ignore", "pipe"],
-          env: withSupervisorClock(cwd, {
-            ...process.env,
-            NODE_OPTIONS: `${process.env.NODE_OPTIONS ?? ""}${phase === "spawn" ? ` --import=${pathToFileURL(preloadPath).href}` : ""}`,
-          }),
-        },
-      );
-      const stderr = createBoundedChildOutput();
-      wrapper.stderr.on("data", (chunk) => stderr.append(chunk));
-      wrapper.once("error", (error) => stderr.append(`wrapper spawn error: ${error.message}\n`));
-      const wrapperClose = waitForChildClose(wrapper, 15_000);
-
-      try {
-        const compilerPid = await waitForPidFile(pidFile, 10_000);
-        if (phase === "wrapper") {
-          wrapper.kill("SIGTERM");
-        }
-
-        const wrapperResult = await wrapperClose;
-        expect([
-          { code: 143, signal: null },
-          { code: null, signal: "SIGTERM" },
-        ]).toContainEqual(wrapperResult);
-        await expect(waitForDead(compilerPid, 2_000)).resolves.toBeUndefined();
-      } catch (error) {
-        throw new Error(
-          `${String(error)}\nwrapper exitCode=${wrapper.exitCode}, signalCode=${wrapper.signalCode}\n${stderr.text()}`,
-          { cause: error },
         );
-      } finally {
-        if (wrapper.exitCode === null && wrapper.signalCode === null) {
-          wrapper.kill("SIGKILL");
+        const wrapper = spawn(
+          process.execPath,
+          [path.resolve("scripts/run-tsgo.mjs"), "-p", "tsconfig.extensions.json"],
+          {
+            cwd,
+            stdio: ["ignore", "ignore", "pipe"],
+            env: withSupervisorClock(cwd, {
+              ...process.env,
+              NODE_OPTIONS: `${process.env.NODE_OPTIONS ?? ""}${phase === "spawn" ? ` --import=${pathToFileURL(preloadPath).href}` : ""}`,
+            }),
+          },
+        );
+        retainFixture = true;
+        const deadline = performance.now() + 15_000;
+        const stderr = createBoundedChildOutput();
+        wrapper.stderr.on("data", (chunk) => stderr.append(chunk));
+        wrapper.once("error", (error) => stderr.append(`wrapper spawn error: ${error.message}\n`));
+        // A work deadline must not consume the real completion needed by teardown.
+        const wrapperClose = new Promise<{
+          code: number | null;
+          signal: NodeJS.Signals | null;
+        }>((resolve) => {
+          wrapper.once("close", (code, signal) => resolve({ code, signal }));
+        });
+        const errors: unknown[] = [];
+        try {
+          const compilerPid = await waitForPidFile(pidFile, 10_000);
+          if (phase === "wrapper") {
+            wrapper.kill("SIGTERM");
+          }
+
+          const wrapperResult = await withTestTimeout(
+            wrapperClose,
+            Math.max(0, deadline - performance.now()),
+            "child did not close before timeout",
+          );
+          expect([
+            { code: 143, signal: null },
+            { code: null, signal: "SIGTERM" },
+          ]).toContainEqual(wrapperResult);
+          await expect(waitForDead(compilerPid, 2_000)).resolves.toBeUndefined();
+        } catch (error) {
+          errors.push(error);
         }
-        reapFakeTsgo(cwd);
-        await wrapperClose;
+        try {
+          if (wrapper.exitCode === null && wrapper.signalCode === null) {
+            wrapper.kill("SIGKILL");
+          }
+          reapFakeTsgo(cwd);
+          const compilerPid = readFakeTsgoPid(cwd);
+          await Promise.all([
+            withTestTimeout(wrapperClose, 2_000, "wrapper did not close during cleanup"),
+            compilerPid === undefined ? undefined : waitForDead(compilerPid, 2_000),
+          ]);
+          retainFixture = false;
+        } catch (error) {
+          errors.push(error);
+        }
+        if (errors.length > 0) {
+          const cause = errors.length === 1 ? errors[0] : new AggregateError(errors);
+          const retained = retainFixture ? `\nfixture retained at ${cwd}` : "";
+          throw new Error(
+            `${errors.map(String).join("\n")}\nwrapper exitCode=${wrapper.exitCode}, signalCode=${wrapper.signalCode}${retained}\n${stderr.text()}`,
+            { cause },
+          );
+        }
+      } finally {
+        if (!retainFixture) {
+          fixtureDirs.cleanup();
+        }
       }
     },
     20_000,


### PR DESCRIPTION
Closes #132629

## What Problem This Solves

Resolves a problem where the tsgo signal-cancellation tests could finish timeout teardown before the wrapper's actual exit/output closure and replace useful diagnostics with a bare timeout. The same failure path could then allow the fixture directory to be deleted without a verified join.

## Why This Change Was Made

The fixture now retains the native child `close` observation independently of its work timeout. It preserves the original 15-second spawn-relative work deadline and 20-second test cap, then gives wrapper closure and recorded compiler death a shared two-second cleanup window. Body and cleanup errors are reported together with final stderr.

The fixture owns its directory rather than registering it for unconditional `afterEach` deletion. Failed joins retain it as a diagnostic artifact outside Vitest's temporary namespace; a minimal fixture workspace keeps the compiler artifact lock scoped to that fixture rather than the enclosing checkout. No shared test-helper, Node runtime, dependency, or other fixture changes.

## User Impact

No product/runtime behavior changes. Maintainers get complete tsgo failure diagnostics, and these tests do not treat an already-rejected timeout promise as proof that cleanup finished. Normal signal-cancellation coverage and its assertions remain intact.

## Evidence

- Before the change, a standalone real-child probe using the actual shared helper returned from `finally` with neither `exit` nor `close` observed and replaced the diagnostic error with `child did not close before timeout`.
- A temporary diagnostic invoked the actual `run-tsgo.test.ts` callback, omitted its initial SIGTERM, and left the real 15-second work deadline unchanged. Pre-fix: no native exit/close observed at callback return, stderr still open, bare timeout. Repaired: native exit then close observed, stderr closed, timeout plus the compiler's stderr sentinel preserved, fixture directory removed only after the joins.
- Both ordinary `wrapper` and `spawn` callbacks passed the same native-event and directory-release observations on macOS Node v24.20.0.
- A second macOS fault diagnostic suppresses PID readiness and gives an independently owned child the outer wrapper's real stderr descriptor. At callback return, native exit is observed but stderr/close are still pending; both readiness and cleanup errors, the stderr sentinel, and the retained fixture path remain visible. The diagnostic then separately kills and joins only its own children.
- Linux Blacksmith Testbox: `node scripts/run-vitest.mjs test/scripts/run-tsgo.test.ts test/helpers/process-wait.test.ts test/scripts/test-projects-build-admission.test.ts` passed **100 tests** across three files. `node scripts/check-changed.mjs -- test/scripts/run-tsgo.test.ts` passed all selected guards, formatting, root test typecheck, and script lint. The baseline full tsgo file also passed 23 tests. Testbox `tbx_01m16yhk30t2nn88grzrrhe75c`, Actions run https://github.com/openclaw/openclaw/actions/runs/33257542927.
- Fresh Codex autoreview completed successfully with no reported findings. [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/33259319328) passed for `4f166c347239b187ae7a77c13238c8090aaa2c6a`. [ClawSweeper's reviewed-head report](https://github.com/openclaw/openclaw/pull/132654#issuecomment-5463183045) found no actionable defects; its remaining CI/landing-review step is satisfied.
- Local oxfmt and `git diff --check` passed. The local install cannot resolve `@vitest/runner/utils`; it was left untouched. Linux Testbox runs provide the real Vitest/CI-environment proof, while local fault injection is explicitly manual callback proof, not a claim that local Vitest ran. An additional standalone Linux fault-probe attempt did not reach the callback: after a Testbox checkout-path transfer, its bare Node entrypoint could not resolve the externally hydrated `@openclaw/fs-safe`/`tsx` packages. No dependency repair was attempted. The successful Linux suite/gate run and macOS fault proofs above are the claimed evidence.
- A new permanent copied-promise or nested-test-runner test was deliberately not added: fault injection exercises the actual existing test callback, and the existing real wrapper/spawn cases remain the lasting owner-boundary coverage.

Production/tooling LOC: +0/-0. Tests: +95/-57 (net +38; includes reindentation around explicit fixture ownership). AI-assisted.
