### PR TITLE
perf(test): consolidate duplicate sweeper close-reopen proof

### DIFF
--- a/test/scripts/pr-ci-sweeper.test.ts
+++ b/test/scripts/pr-ci-sweeper.test.ts
@@ -495,7 +495,7 @@ describe("runPrCiSweeper", () => {
     ).toEqual([]);
   });
 
-  it("does not spend the re-fire budget on PRs that change during revalidation", async () => {
+  it("closes and reopens a dropped-CI PR without spending budget on stale heads", async () => {
     const dropped = Array.from({ length: 11 }, (_, index) => ({
       ...pr(),
       number: 200 + index,
@@ -517,9 +517,11 @@ describe("runPrCiSweeper", () => {
       github: github as never,
       context: context as never,
       core: loggedCore as never,
+      appSlug: "openclaw-barnacle",
       now: NOW,
     });
 
+    expect(results).toHaveLength(dropped.length);
     expect(results.slice(0, 10)).toEqual(
       dropped.slice(0, 10).map((candidate) => ({
         number: candidate.number,
@@ -575,29 +577,6 @@ describe("runPrCiSweeper", () => {
     expect(results).toEqual([
       { number: 30, sha: "7".repeat(12), action: "refire", reason: "ci-run-missing" },
     ]);
-  });
-
-  it("closes and reopens a dropped-CI PR in live mode", async () => {
-    const dropped = {
-      ...pr(),
-      number: 9,
-      state: "open",
-      head: { sha: "c".repeat(40) },
-    };
-    const { github, calls } = fakeGithub({ prs: [dropped], runsBySha: {} });
-    const results = await runPrCiSweeper({
-      github: github as never,
-      context: context as never,
-      core: core as never,
-      appSlug: "openclaw-barnacle",
-      now: NOW,
-    });
-    expect(results).toEqual([
-      { number: 9, sha: "c".repeat(12), action: "refire", reason: "ci-run-missing" },
-    ]);
-    expect(
-      calls.filter((call) => call.method === "pulls.update").map((call) => call.args.state),
-    ).toEqual(["closed", "open"]);
   });
 
   it("revives a cancelled GitHub Actions check exactly once", async () => {


### PR DESCRIPTION
## What Problem This Solves

The PR CI sweeper suite waits twice for the same successful close/reopen behavior. Each invocation includes the real five-second reopen delay, so redundant coverage adds five seconds to every execution.

## Why This Change Was Made

Keep the stronger test that rejects ten stale heads before successfully closing and reopening one eligible PR. Its exact ordered update-argument assertion already covers the simpler standalone test. Carry over the explicit app identity and add an exact result count so all of the removed case's guarantees remain covered.

The standalone live case originated in #110889; #114745 added the stronger stale-head/budget regression without removing the overlapping case. No production code or timer changes. Tests +3/-24; no new test seam, fake clock, sharding, scheduling or concurrency changes.

## User Impact

No product behavior changes. The test suite executes one fewer duplicate real wait while retaining the successful close/reopen and stale-head budget coverage.

## Evidence

- Normal unit-fast routing: 64 tests in 10.011s before; 63 tests in 5.016s after.
- The retained case checks the complete ordered close/open arguments, all ten stale results, the final refire result, the total result count and the one-refire log.
- Temporarily omitting the owner's reopen call fails the retained test on its exact update-list assertion; original production bytes restored afterward.
- Classification, attached CI, conflict/auto-merge, budget and cancelled-run tests remain unchanged. The deleted case did not cover ownership-read or reopen failures, and this change does not claim new coverage of those paths.
- Changed-file checks and independent Codex autoreview pass.

No changelog required for test-only work.
