### PR TITLE
perf: reduce remote-exec attachment transfer round trips

### DIFF
--- a/src/gateway/worker-environments/worker-turn-attachments.boundary.test.ts
+++ b/src/gateway/worker-environments/worker-turn-attachments.boundary.test.ts
@@ -289,6 +289,10 @@ describe("current attachments in an active remote placement", () => {
           return { meta: { durationMs: 1 } };
         },
       );
+      if (executionMode === "remote-exec") {
+        // At most one setup, three PDF chunks, and one image chunk.
+        expect(vi.mocked(tunnel.runWorkspaceCommand).mock.calls.length).toBeLessThanOrEqual(5);
+      }
       expect(tunnel.syncWorkspace).not.toHaveBeenCalled();
       expect(tunnel.reconcileWorkspace).toHaveBeenCalledOnce();
       const retainedFiles =

--- a/src/gateway/worker-environments/worker-turn-attachments.ts
+++ b/src/gateway/worker-environments/worker-turn-attachments.ts
@@ -7,6 +7,7 @@ import { sanitizeUntrustedFileName } from "../../infra/fs-safe-advanced.js";
 import { readPersistedMediaFacts } from "../../media/media-facts.js";
 import { resolveInboundMediaReference } from "../../media/media-reference.js";
 import { readMediaBuffer } from "../../media/store.js";
+import { NODE_WORKER_WORKSPACE_STDIN_MAX_BYTES } from "../../worker/node-workspace-protocol.js";
 import { resolveChatAttachmentMaxBytes } from "../chat-attachment-policy.js";
 import { MAX_PAYLOAD_BYTES } from "../server-constants.js";
 import type { WorkerWorkspaceTunnelHandle } from "./tunnel-contract.js";
@@ -16,8 +17,8 @@ import {
 } from "./workspace-path-exclusions.js";
 
 const MAX_TURN_ATTACHMENTS = 16;
-// Base64 expansion stays below the node workspace command's 128 KiB stdin cap.
-const ATTACHMENT_CHUNK_BYTES = 64 * 1024;
+// Fill the command's stdin budget without splitting a base64 quartet.
+const ATTACHMENT_CHUNK_BYTES = Math.floor(NODE_WORKER_WORKSPACE_STDIN_MAX_BYTES / 4) * 3;
 
 // Enter verified directories before mutation: process cwd pins the directory,
 // including when another process renames it. All following names are basenames.
@@ -104,14 +105,16 @@ export async function prepareWorkerTurnAttachments(params: {
   check();
   // The recorder retains originals for inline images and facts already staged
   // locally. Runtime media alone omits those images or points at a host copy.
-  const facts = (message ? readPersistedMediaFacts(message) : undefined) ?? turn.media ?? [];
+  const facts =
+    heldFacts ?? (message ? readPersistedMediaFacts(message) : undefined) ?? turn.media ?? [];
   const files: Array<{ name: string; buffer: Buffer }> = [];
   const seen = new Set<string>();
   let remainingBytes = MAX_PAYLOAD_BYTES;
   const maxBytes = resolveChatAttachmentMaxBytes(turn.config ?? {});
   for (const fact of facts) {
+    const sources = [fact.url, fact.path];
     let reference: Awaited<ReturnType<typeof resolveInboundMediaReference>> = null;
-    for (const source of [fact.url, fact.path]) {
+    for (const source of sources) {
       if (!source) {
         continue;
       }
@@ -122,9 +125,7 @@ export async function prepareWorkerTurnAttachments(params: {
       }
     }
     if (!reference) {
-      if (
-        [fact.path, fact.url].some((source) => source && !isPassThroughRemoteMediaSource(source))
-      ) {
+      if (sources.some((source) => source && !isPassThroughRemoteMediaSource(source))) {
         throw new Error(
           "Cloud attachment original is unavailable in managed media storage; attach the file again and retry.",
         );
@@ -158,7 +159,12 @@ export async function prepareWorkerTurnAttachments(params: {
   }
   const directory = `${WORKER_ATTACHMENT_DIRECTORY_PREFIX}${randomUUID()}`;
   const deadline = Date.now() + turn.timeoutMs;
-  const execute = async (args: string[], input?: string, cleanup = false): Promise<string> => {
+  const execute = async (
+    operation: "init" | "write" | "cleanup",
+    args: string[] = [],
+    input?: string,
+  ): Promise<string> => {
+    const cleanup = operation === "cleanup";
     const assertDispatchCurrent = cleanup ? assertCurrent : check;
     assertDispatchCurrent();
     const timeoutMs = cleanup ? 5_000 : Math.min(60_000, Math.max(1, deadline - Date.now()));
@@ -166,7 +172,15 @@ export async function prepareWorkerTurnAttachments(params: {
       throw new Error("Cloud attachment transfer timed out; retry this turn.");
     }
     const result = await tunnel.runWorkspaceCommand({
-      argv: ["node", "-e", STAGE_ATTACHMENT_SCRIPT, params.remoteWorkspaceDir, directory, ...args],
+      argv: [
+        "node",
+        "-e",
+        STAGE_ATTACHMENT_SCRIPT,
+        params.remoteWorkspaceDir,
+        directory,
+        operation,
+        ...args,
+      ],
       ...(input === undefined ? {} : { input }),
       transportRetry: "never",
       assertCurrent: assertDispatchCurrent,
@@ -179,14 +193,16 @@ export async function prepareWorkerTurnAttachments(params: {
         `Cloud attachment transfer failed: ${truncateUtf16Safe(result.stderr.trim() || "remote write failed", 512)}. Retry this turn.`,
       );
     }
-    return result.stdout.trim();
+    const identity = result.stdout.trim();
+    if (!cleanup && !/^\d+:\d+$/.test(identity)) {
+      const kind = operation === "init" ? "directory" : "file";
+      throw new Error(`Cloud attachment transfer returned an invalid ${kind} identity.`);
+    }
+    return identity;
   };
   let directoryIdentity: string | undefined;
   try {
-    directoryIdentity = await execute(["init"]);
-    if (!/^\d+:\d+$/.test(directoryIdentity)) {
-      throw new Error("Cloud attachment transfer returned an invalid directory identity.");
-    }
+    directoryIdentity = await execute("init");
     for (const file of files) {
       const hash = createHash("sha256").update(file.buffer).digest("hex");
       let fileIdentity = "new";
@@ -196,8 +212,8 @@ export async function prepareWorkerTurnAttachments(params: {
         offset += ATTACHMENT_CHUNK_BYTES
       ) {
         fileIdentity = await execute(
+          "write",
           [
-            "write",
             directoryIdentity,
             file.name,
             String(offset),
@@ -207,14 +223,11 @@ export async function prepareWorkerTurnAttachments(params: {
           ],
           file.buffer.subarray(offset, offset + ATTACHMENT_CHUNK_BYTES).toString("base64"),
         );
-        if (!/^\d+:\d+$/.test(fileIdentity)) {
-          throw new Error("Cloud attachment transfer returned an invalid file identity.");
-        }
       }
     }
   } catch (error) {
     if (directoryIdentity) {
-      await execute(["cleanup", directoryIdentity], undefined, true).catch(() => undefined);
+      await execute("cleanup", [directoryIdentity]).catch(() => undefined);
     }
     throw error;
   }

--- a/src/worker/node-workspace-protocol.ts
+++ b/src/worker/node-workspace-protocol.ts
@@ -6,7 +6,7 @@ import type { NodeWorkerWorkspaceTransferInput } from "./node-workspace-transfer
 const IDENTIFIER_MAX_CHARS = 256;
 const GATEWAY_NAMESPACE_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/u;
 const REQUEST_MAX_BYTES = 256 * 1024;
-const INPUT_MAX_BYTES = 128 * 1024;
+export const NODE_WORKER_WORKSPACE_STDIN_MAX_BYTES = 128 * 1024;
 const OUTPUT_MAX_BYTES = 64 * 1024;
 const STDERR_MAX_BYTES = 16 * 1024;
 const ARGV_MAX_ITEMS = 128;
@@ -107,7 +107,8 @@ export function parseNodeWorkerWorkspaceExecInput(
   }
   if (
     value.input !== undefined &&
-    (typeof value.input !== "string" || Buffer.byteLength(value.input, "utf8") > INPUT_MAX_BYTES)
+    (typeof value.input !== "string" ||
+      Buffer.byteLength(value.input, "utf8") > NODE_WORKER_WORKSPACE_STDIN_MAX_BYTES)
   ) {
     throw new Error("INVALID_REQUEST: workspace command input exceeds its bound");
   }


### PR DESCRIPTION
Related: #132358 (images and PDFs in remote cloud sessions), #132114 (the newer OpenClaw bulk-media path).

## What Problem This Solves

Remote-exec attachment uploads leave one third of the existing command-input budget unused, causing extra remote process launches and round trips for larger originals. This is the maintainer-requested optimization and cleanup following the remote image/PDF repair.

## Why This Change Was Made

Derive the base64 chunk size from the existing workspace-command stdin limit: 96 KiB of original bytes fills the unchanged 128 KiB input budget. The shared uploader also reuses parsed media facts and source candidates, validates directory/file responses in one place, and derives cleanup behavior from its typed operation instead of an independent flag.

This uploader serves remote-exec placements, including Codex. OpenClaw worker turns now use the bulk-transfer owner from #132114; this change leaves that path intact and retains its sibling boundary coverage. Checksums, inode and symlink checks, admission/dispatch authority, aggregate attachment limits, and workspace reconciliation exclusions remain intact. No configuration, storage schema, provider behavior, or protocol limits change.

## User Impact

Larger image/PDF originals in remote-exec sessions require roughly one third fewer write commands. A real 220,009-byte PDF transfer dropped from four writes to three while preserving its exact bytes. Uploads retain their existing availability, safety checks, and visible errors.

## Evidence

- A direct production probe executed the actual transfer script and validated every request with the workspace protocol parser. Before: four writes with base64 input lengths 87,384 / 87,384 / 87,384 / 31,204. After: three writes of 131,072 / 131,072 / 31,204. Original bytes matched exactly in both runs.
- The two-mode integration regression transfers a multi-chunk PDF plus an image, bounds remote-exec upload to at most five commands, preserves existing remote edits, and confirms remote-exec originals remain excluded from reconciliation while ordinary similarly named user directories still reconcile. OpenClaw bulk-media retention follows the new contract from #132114.
- Focused tests cover corrupt transfers, symlink replacement, lost claims, unavailable local sources, and managed-original URL preference. All 29 tests passed on the updated base, including both attachment modes and the current worker-lifecycle coverage.

```sh
node scripts/run-vitest.mjs src/gateway/worker-environments/worker-turn-attachments.boundary.test.ts src/gateway/worker-environments/worker-turn-attachments.test.ts src/gateway/worker-environments/worker-turn-run-owner.test.ts src/worker/node-workspace-protocol.test.ts --pool=forks
```
- Full changed-file formatting, production/test types, lint, architecture and repository guards passed on the final adapted patch. Fresh Codex autoreview is clean; the subsequent rebase is patch-identical by `git range-diff`.
- The original real OpenAI-key cloud verification for both harnesses is recorded in #132358. This transport cleanup does not claim a new provider-inference run; its proof exercises real subprocess writes and the existing protocol boundary.

Production delta: +35/-21 lines (net +14); tests: +4. Growth is the shared protocol-bound export and typed command/response handling, including formatter-expanded arguments; duplicate response validators and the separate cleanup flag are removed. No new helper modules or dependencies.

AI-assisted with Codex.

### Landing validation

The first CI run, [33259474462](https://github.com/openclaw/openclaw/actions/runs/33259474462), failed two unrelated tests. The benchmark failure matched the task-registry fixture leak tracked in #132649: its producing async-task suite finished immediately before the benchmark. This branch now includes the producer-owned cleanup landed in #132643; the original producer/benchmark order passes all 17 tests in the shared, non-isolated worker. No assertions, timeouts, or test-routing rules were weakened.

DeepInfra's failure exhausted the five-second operation budget before the initial POST, not during CONNECT. Its four unchanged transport tests passed locally, including the real CONNECT tunnel. The original failure remains recorded; its precise timing cause was not established. The first failed-job retry was cancelled once the landed fixture repair was found, and the branch was rebased to include that repair. Exact-head CI [33261006895](https://github.com/openclaw/openclaw/actions/runs/33261006895) completed successfully on `8d0ad9ff5eb34afa62165199b35d854230af790d`, including both previously failing shards.

ClawSweeper found no introduced code defect and requested normal CI/maintainer completion. Its automatic stored-data warning does not apply: this patch changes neither database schema nor attachment storage format, ownership, or retention. No migration is needed.
