### PR TITLE
fix(telegram): keep headings, code, quotes, and tables inside details blocks

### DIFF
--- a/extensions/telegram/src/draft-stream.test.ts
+++ b/extensions/telegram/src/draft-stream.test.ts
@@ -1255,6 +1255,31 @@ describe("createTelegramDraftStream", () => {
     );
   });
 
+  it("sends a native details block for markdown structure inside <details>", async () => {
+    const api = createMockDraftApi();
+    const stream = createDraftStream(api, { richMessages: true });
+
+    stream.update(
+      "<details>\n<summary>Deploy checklist</summary>\n\n# Steps\n\n| item | done |\n|---|---|\n| lint | yes |\n\n</details>",
+    );
+    await stream.flush();
+
+    expect(api.raw.sendRichMessage).toHaveBeenCalledTimes(1);
+    const payload = api.raw.sendRichMessage.mock.calls[0]?.[0] as {
+      rich_message?: TelegramInputRichMessage;
+    };
+    const serialized = JSON.stringify(payload.rich_message);
+    expect(serialized).not.toContain("<details>");
+    expect(serialized).not.toContain("</details>");
+    const details = payload.rich_message?.blocks?.find((block) => block.type === "details");
+    expect(details?.type).toBe("details");
+    if (details?.type !== "details") {
+      return;
+    }
+    expect(details.blocks.some((block) => block.type === "table")).toBe(true);
+    expect(api.sendMessage).not.toHaveBeenCalled();
+  });
+
   it("uses rich send and edit for previews when explicitly enabled", async () => {
     const api = createMockDraftApi();
     const stream = createDraftStream(api, { richMessages: true });

--- a/extensions/telegram/src/rich-blocks-html-map.ts
+++ b/extensions/telegram/src/rich-blocks-html-map.ts
@@ -535,6 +535,16 @@ type TelegramHtmlIsland = {
 };
 
 /**
+ * Parse a complete island fragment into typed blocks. Island discovery uses
+ * this for the raw island text; the markdown emitter re-parses augmented
+ * fragments through it so re-projected content (e.g. a markdown table whose
+ * source text the IR removed) renders through the same element mapping.
+ */
+export function parseIslandBlocks(fragment: string): InputRichBlock[] {
+  return htmlNodesToBlocks(parseHtmlFragment(fragment));
+}
+
+/**
  * Find supported block islands inside a text range. Returns non-overlapping
  * spans in order; text outside spans stays on the markdown paragraph path.
  */
@@ -622,7 +632,7 @@ export function findTelegramHtmlIslands(text: string): TelegramHtmlIsland[] {
         continue;
       }
     }
-    const blocks = htmlNodesToBlocks(parseHtmlFragment(text.slice(tag.start, end)));
+    const blocks = parseIslandBlocks(text.slice(tag.start, end));
     if (blocks.length > 0) {
       islands.push({ start: tag.start, end, blocks });
     }

--- a/extensions/telegram/src/rich-blocks-html.test.ts
+++ b/extensions/telegram/src/rich-blocks-html.test.ts
@@ -136,6 +136,53 @@ describe("block HTML islands", () => {
     expect(JSON.stringify(blocks[1])).toContain('"text":"a"');
   });
 
+  it("keeps rich Markdown cell text inside a <details> island table", () => {
+    const block = single(
+      "<details><summary>Rich</summary>\n\n| item | note |\n|---|---|\n| **bold** | [link](https://openclaw.ai) |\n| `code` | *italic* |\n\n</details>",
+    );
+    expect(block.type).toBe("details");
+    if (block.type !== "details") {
+      return;
+    }
+    const table = block.blocks.find((item) => item.type === "table");
+    expect(table?.type).toBe("table");
+    if (table?.type !== "table") {
+      return;
+    }
+    // Cells round-trip through the canonical typed projection: styles, links,
+    // and code spans survive the island HTML re-parse instead of flattening
+    // to plain cell text.
+    expect(table.cells).toEqual([
+      [
+        { text: "item", is_header: true },
+        { text: "note", is_header: true },
+      ],
+      [
+        { text: { type: "bold", text: "bold" } },
+        { text: { type: "url", text: "link", url: "https://openclaw.ai" } },
+      ],
+      [{ text: { type: "code", text: "code" } }, { text: { type: "italic", text: "italic" } }],
+    ]);
+  });
+
+  it("degrades an over-wide Markdown table inside a <details> island to a grid", () => {
+    const header = `| ${Array.from({ length: 21 }, (_value, index) => `H${index + 1}`).join(" | ")} |`;
+    const separator = `| ${Array.from({ length: 21 }, () => "---").join(" | ")} |`;
+    const row = `| ${Array.from({ length: 21 }, (_value, index) => String(index + 1)).join(" | ")} |`;
+    const { blocks, degradationReasons } = markdownToTelegramRichBlocks(
+      `<details><summary>Wide</summary>\n\n${[header, separator, row].join("\n")}\n\n</details>`,
+    );
+    expect(degradationReasons).toEqual(["table-ascii"]);
+    expect(blocks).toHaveLength(1);
+    const block = blocks[0];
+    expect(block?.type).toBe("details");
+    if (block?.type !== "details") {
+      return;
+    }
+    expect(block.blocks.some((item) => item.type === "pre")).toBe(true);
+    expect(block.blocks.some((item) => item.type === "table")).toBe(false);
+  });
+
   it("maps <ul> with checkbox tasks", () => {
     const block = single(
       '<ul><li><input type="checkbox" checked/>Done</li><li><input type="checkbox"/>Todo</li><li>Plain</li></ul>',

--- a/extensions/telegram/src/rich-blocks-html.test.ts
+++ b/extensions/telegram/src/rich-blocks-html.test.ts
@@ -48,6 +48,94 @@ describe("block HTML islands", () => {
     expect(serialized).not.toContain("<details>");
   });
 
+  it.each([
+    {
+      name: "headings",
+      markdown: "<details><summary>Title</summary>\n\n# Heading inside\n\n</details>",
+      expected: "Heading inside",
+    },
+    {
+      name: "code blocks",
+      markdown: "<details><summary>Title</summary>\n\n```js\nconsole.log(1)\n```\n\n</details>",
+      expected: "console.log(1)",
+    },
+    {
+      name: "blockquotes",
+      markdown: "<details><summary>Title</summary>\n\n> quoted line\n\n</details>",
+      expected: "quoted line",
+    },
+  ])("keeps Markdown $name inside <details> islands", ({ markdown, expected }) => {
+    const block = single(markdown);
+    expect(block.type).toBe("details");
+    if (block.type !== "details") {
+      return;
+    }
+    const serialized = JSON.stringify(block);
+    // The island stays a native details block: no literal tags leak, and the
+    // structural content stays in the island body instead of hoisting out.
+    expect(serialized).not.toContain("<details>");
+    expect(serialized).not.toContain("</details>");
+    expect(serialized).toContain(expected);
+  });
+
+  it("keeps a Markdown table inside a <details> island as a native table block", () => {
+    const block = single(
+      "<details><summary>Table</summary>\n\n| a | b |\n|---|---|\n| 1 | 2 |\n\n</details>",
+    );
+    expect(block.type).toBe("details");
+    if (block.type !== "details") {
+      return;
+    }
+    const serialized = JSON.stringify(block);
+    expect(serialized).not.toContain("<details>");
+    expect(serialized).not.toContain("</details>");
+    expect(block.blocks).toEqual([
+      {
+        type: "table",
+        cells: [
+          [
+            { text: "a", is_header: true },
+            { text: "b", is_header: true },
+          ],
+          [{ text: "1" }, { text: "2" }],
+        ],
+        is_bordered: true,
+        is_striped: true,
+      },
+    ]);
+  });
+
+  it("keeps a Markdown table at its position between island body paragraphs", () => {
+    const block = single(
+      "<details><summary>Mix</summary>\n\nbefore\n\n| a |\n|---|\n| 1 |\n\nafter\n\n</details>",
+    );
+    expect(block.type).toBe("details");
+    if (block.type !== "details") {
+      return;
+    }
+    expect(block.blocks).toHaveLength(3);
+    expect(block.blocks[0]).toEqual({ type: "paragraph", text: " before " });
+    expect(block.blocks[1]?.type).toBe("table");
+    expect(block.blocks[2]).toMatchObject({ type: "paragraph" });
+    expect(JSON.stringify(block.blocks[2])).toContain("after");
+  });
+
+  it("keeps a Markdown table after a <details> island as a top-level table", () => {
+    const blocks = blocksFor(
+      "<details><summary>T</summary>\n\n# In\n\n</details>\n\n| a |\n|---|\n| 1 |",
+    );
+    expect(blocks.map((block) => block.type)).toEqual(["details", "table"]);
+    expect(JSON.stringify(blocks[1])).toContain('"text":"a"');
+  });
+
+  it("keeps a Markdown table between two <details> islands at its position", () => {
+    const blocks = blocksFor(
+      "<details><summary>A</summary>\n\n# x\n\n</details>\n\n| a |\n|---|\n| 1 |\n\n<details><summary>B</summary>\nbody\n</details>",
+    );
+    expect(blocks.map((block) => block.type)).toEqual(["details", "table", "details"]);
+    expect(JSON.stringify(blocks[1])).toContain('"text":"a"');
+  });
+
   it("maps <ul> with checkbox tasks", () => {
     const block = single(
       '<ul><li><input type="checkbox" checked/>Done</li><li><input type="checkbox"/>Todo</li><li>Plain</li></ul>',

--- a/extensions/telegram/src/rich-blocks-html.ts
+++ b/extensions/telegram/src/rich-blocks-html.ts
@@ -125,6 +125,67 @@ export function nodeText(nodes: readonly HtmlNode[]): string {
     .join("");
 }
 
+function escapeTelegramHtmlText(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+const ISLAND_INLINE_STYLE_TAGS: Record<
+  | "bold"
+  | "italic"
+  | "underline"
+  | "strikethrough"
+  | "code"
+  | "spoiler"
+  | "marked"
+  | "subscript"
+  | "superscript",
+  string
+> = {
+  bold: "b",
+  italic: "i",
+  underline: "u",
+  strikethrough: "s",
+  code: "code",
+  spoiler: "tg-spoiler",
+  marked: "mark",
+  subscript: "sub",
+  superscript: "sup",
+};
+
+/**
+ * Serialize canonical typed RichText back into the inline HTML the island
+ * fragment parser maps natively (see htmlNodesToRichText). Re-projected
+ * markdown table cells run through cellToRichText first, so style/link/
+ * annotation spans survive the island HTML round-trip instead of flattening
+ * to plain cell text.
+ */
+export function richTextToIslandHtml(text: RichText): string {
+  if (typeof text === "string") {
+    return escapeTelegramHtmlText(text);
+  }
+  if (Array.isArray(text)) {
+    return text.map(richTextToIslandHtml).join("");
+  }
+  switch (text.type) {
+    case "url":
+      return `<a href="${escapeTelegramHtmlText(text.url)}">${richTextToIslandHtml(text.text)}</a>`;
+    case "anchor_link":
+      return `<a href="#${escapeTelegramHtmlText(text.anchor_name)}">${richTextToIslandHtml(text.text)}</a>`;
+    case "mathematical_expression":
+      return `<tg-math>${escapeTelegramHtmlText(text.expression)}</tg-math>`;
+    case "custom_emoji":
+      return `<tg-emoji emoji-id="${escapeTelegramHtmlText(text.custom_emoji_id)}">${escapeTelegramHtmlText(text.alternative_text)}</tg-emoji>`;
+    default: {
+      const tag = ISLAND_INLINE_STYLE_TAGS[text.type];
+      return `<${tag}>${richTextToIslandHtml(text.text)}</${tag}>`;
+    }
+  }
+}
+
 function normalizeIslandText(text: string): string {
   return text.replace(/\s+/g, " ").trim();
 }

--- a/extensions/telegram/src/rich-blocks.ts
+++ b/extensions/telegram/src/rich-blocks.ts
@@ -23,7 +23,7 @@ import {
   type TelegramRichBlocksDegradationReason,
 } from "./rich-block-model.js";
 import { findTelegramHtmlIslands, parseIslandBlocks } from "./rich-blocks-html-map.js";
-import { parseInlineHtmlIslands } from "./rich-blocks-html.js";
+import { parseInlineHtmlIslands, richTextToIslandHtml } from "./rich-blocks-html.js";
 import {
   collectMarkdownRichListSources,
   renderMarkdownRichListSource,
@@ -400,6 +400,7 @@ function emitGapBlocks(
   start: number,
   end: number,
   tables: readonly MarkdownTableMeta[],
+  degradationReasons: Set<TelegramRichBlocksDegradationReason>,
 ): InputRichBlock[] {
   if (end <= start) {
     return [];
@@ -412,7 +413,7 @@ function emitGapBlocks(
   let cursor = start;
   for (const island of islands) {
     blocks.push(...splitParagraphs(ir, cursor, start + island.start));
-    blocks.push(...renderIslandBlocksWithTables(ir, start, island, tables));
+    blocks.push(...renderIslandBlocksWithTables(ir, start, island, tables, degradationReasons));
     cursor = start + island.end;
   }
   blocks.push(...splitParagraphs(ir, cursor, end));
@@ -421,19 +422,13 @@ function emitGapBlocks(
 
 type AuthoredHtmlIsland = ReturnType<typeof findAuthoredHtmlIslands>[number];
 
-function escapeTelegramHtmlText(value: string): string {
-  return value
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;");
-}
-
 /**
  * Rebuild a markdown table as an HTML <table> island element. The IR removes
  * markdown table source text (a zero-width placeholder remains), so island
  * bodies would silently drop tables; the island fragment parser renders this
- * element natively, including its over-wide-column ASCII degradation.
+ * element natively, including its over-wide-column ASCII degradation and
+ * typed rich cell text (serialized from the canonical cellToRichText
+ * projection).
  */
 function renderIslandTableHtml(table: MarkdownTableMeta): string {
   const columnCount = Math.max(
@@ -447,7 +442,8 @@ function renderIslandTableHtml(table: MarkdownTableMeta): string {
   };
   const cellHtml = (cell: MarkdownTableCell | undefined, index: number, header: boolean) => {
     const tag = header ? "th" : "td";
-    return `<${tag}${alignAttr(index)}>${escapeTelegramHtmlText(cell?.text ?? "")}</${tag}>`;
+    const rich = cell ? cellToRichText(cell) : undefined;
+    return `<${tag}${alignAttr(index)}>${richTextToIslandHtml(rich ?? "")}</${tag}>`;
   };
   const headerRow =
     table.headerCells.length > 0
@@ -473,6 +469,7 @@ function renderIslandBlocksWithTables(
   gapStart: number,
   island: AuthoredHtmlIsland,
   tables: readonly MarkdownTableMeta[],
+  degradationReasons: Set<TelegramRichBlocksDegradationReason>,
 ): InputRichBlock[] {
   const islandStart = gapStart + island.start;
   const islandEnd = gapStart + island.end;
@@ -481,6 +478,19 @@ function renderIslandBlocksWithTables(
     .toSorted((left, right) => left.placeholderOffset - right.placeholderOffset);
   if (contained.length === 0) {
     return island.blocks;
+  }
+  // The fragment parser degrades over-wide tables to a monospace grid exactly
+  // like the markdown table path; record the same degradation reason so the
+  // island path reports identical delivery diagnostics.
+  for (const table of contained) {
+    const columnCount = Math.max(
+      table.headerCells.length,
+      ...table.rowCells.map((row) => row.length),
+      0,
+    );
+    if (columnCount > TELEGRAM_RICH_TEXT_TABLE_COLUMN_LIMIT) {
+      degradationReasons.add("table-ascii");
+    }
   }
   const source = ir.text.slice(islandStart, islandEnd);
   let html = "";
@@ -646,7 +656,7 @@ function emitSegments(
       break;
     }
     if (segment.start > cursor) {
-      blocks.push(...emitGapBlocks(ir, cursor, segment.start, tables));
+      blocks.push(...emitGapBlocks(ir, cursor, segment.start, tables, degradationReasons));
     }
     // Segments nested inside this one (fences/headings/tables in a blockquote)
     // belong to it; consuming them here prevents a second top-level emission.
@@ -727,7 +737,7 @@ function emitSegments(
     index = next;
   }
   if (cursor < rangeEnd) {
-    blocks.push(...emitGapBlocks(ir, cursor, rangeEnd, tables));
+    blocks.push(...emitGapBlocks(ir, cursor, rangeEnd, tables, degradationReasons));
   }
   return blocks;
 }

--- a/extensions/telegram/src/rich-blocks.ts
+++ b/extensions/telegram/src/rich-blocks.ts
@@ -22,7 +22,7 @@ import {
   type RichText,
   type TelegramRichBlocksDegradationReason,
 } from "./rich-block-model.js";
-import { findTelegramHtmlIslands } from "./rich-blocks-html-map.js";
+import { findTelegramHtmlIslands, parseIslandBlocks } from "./rich-blocks-html-map.js";
 import { parseInlineHtmlIslands } from "./rich-blocks-html.js";
 import {
   collectMarkdownRichListSources,
@@ -395,7 +395,12 @@ function findAuthoredHtmlIslands(ir: MarkdownIR, start: number, end: number) {
 
 // Gap emitter: agent-authored block HTML islands (details/lists/media/math/…)
 // become typed blocks; the text around them stays on the paragraph path.
-function emitGapBlocks(ir: MarkdownIR, start: number, end: number): InputRichBlock[] {
+function emitGapBlocks(
+  ir: MarkdownIR,
+  start: number,
+  end: number,
+  tables: readonly MarkdownTableMeta[],
+): InputRichBlock[] {
   if (end <= start) {
     return [];
   }
@@ -407,11 +412,88 @@ function emitGapBlocks(ir: MarkdownIR, start: number, end: number): InputRichBlo
   let cursor = start;
   for (const island of islands) {
     blocks.push(...splitParagraphs(ir, cursor, start + island.start));
-    blocks.push(...island.blocks);
+    blocks.push(...renderIslandBlocksWithTables(ir, start, island, tables));
     cursor = start + island.end;
   }
   blocks.push(...splitParagraphs(ir, cursor, end));
   return blocks;
+}
+
+type AuthoredHtmlIsland = ReturnType<typeof findAuthoredHtmlIslands>[number];
+
+function escapeTelegramHtmlText(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+/**
+ * Rebuild a markdown table as an HTML <table> island element. The IR removes
+ * markdown table source text (a zero-width placeholder remains), so island
+ * bodies would silently drop tables; the island fragment parser renders this
+ * element natively, including its over-wide-column ASCII degradation.
+ */
+function renderIslandTableHtml(table: MarkdownTableMeta): string {
+  const columnCount = Math.max(
+    table.headerCells.length,
+    ...table.rowCells.map((row) => row.length),
+    0,
+  );
+  const alignAttr = (index: number) => {
+    const align = table.aligns?.[index];
+    return align ? ` align="${align}"` : "";
+  };
+  const cellHtml = (cell: MarkdownTableCell | undefined, index: number, header: boolean) => {
+    const tag = header ? "th" : "td";
+    return `<${tag}${alignAttr(index)}>${escapeTelegramHtmlText(cell?.text ?? "")}</${tag}>`;
+  };
+  const headerRow =
+    table.headerCells.length > 0
+      ? `<tr>${table.headerCells.map((cell, index) => cellHtml(cell, index, true)).join("")}</tr>`
+      : "";
+  const bodyRows = table.rowCells
+    .map(
+      (row) =>
+        `<tr>${Array.from({ length: columnCount }, (_value, index) => cellHtml(row[index], index, false)).join("")}</tr>`,
+    )
+    .join("");
+  return `<table>${headerRow}${bodyRows}</table>`;
+}
+
+/**
+ * Island blocks for emission, with contained markdown tables re-projected into
+ * the island body. The island body paragraph has no stable position for an
+ * extracted table (the IR deleted its source text), so the table HTML goes
+ * back at the placeholder offset and the fragment is re-parsed.
+ */
+function renderIslandBlocksWithTables(
+  ir: MarkdownIR,
+  gapStart: number,
+  island: AuthoredHtmlIsland,
+  tables: readonly MarkdownTableMeta[],
+): InputRichBlock[] {
+  const islandStart = gapStart + island.start;
+  const islandEnd = gapStart + island.end;
+  const contained = tables
+    .filter((table) => table.placeholderOffset > islandStart && table.placeholderOffset < islandEnd)
+    .toSorted((left, right) => left.placeholderOffset - right.placeholderOffset);
+  if (contained.length === 0) {
+    return island.blocks;
+  }
+  const source = ir.text.slice(islandStart, islandEnd);
+  let html = "";
+  let cursor = 0;
+  for (const table of contained) {
+    const relativeOffset = table.placeholderOffset - islandStart;
+    html += source.slice(cursor, relativeOffset);
+    html += renderIslandTableHtml(table);
+    cursor = relativeOffset;
+  }
+  html += source.slice(cursor);
+  const blocks = parseIslandBlocks(html);
+  return blocks.length > 0 ? blocks : island.blocks;
 }
 
 function renderAsciiTableGrid(table: MarkdownTableMeta): string {
@@ -481,8 +563,16 @@ function collectStructuralSegments(
 ): StructuralSegment[] {
   const segments: StructuralSegment[] = [];
   const htmlIslands = findAuthoredHtmlIslands(ir, 0, ir.text.length);
+  // Structural blocks inside an authored HTML island belong to the island body:
+  // hoisting them out splits the island range across gaps, so the island never
+  // matches and its literal tags leak into the message.
+  const insideIsland = (start: number, end: number) =>
+    htmlIslands.some((island) => start >= island.start && end <= island.end);
   for (const span of ir.styles) {
     if (span.end <= span.start) {
+      continue;
+    }
+    if (insideIsland(span.start, span.end)) {
       continue;
     }
     const headingSize = resolveHeadingSize(span.style);
@@ -504,11 +594,25 @@ function collectStructuralSegments(
     }
   }
   for (const table of tables) {
+    // Tables are zero-width placeholders, so containment must be strict on
+    // both bounds: the IR deletes the table's source lines, which pulls later
+    // islands left until a neighboring island starts or ends exactly at the
+    // placeholder. Only a placeholder strictly between an opener and its
+    // closing tag is a table inside that island body; a boundary coincidence
+    // means the table preceded or followed the island and must stay a
+    // top-level segment or it would be silently dropped.
+    if (
+      htmlIslands.some(
+        (island) => table.placeholderOffset > island.start && table.placeholderOffset < island.end,
+      )
+    ) {
+      continue;
+    }
     const offset = Math.max(0, Math.min(table.placeholderOffset, ir.text.length));
     segments.push({ kind: "table", start: offset, end: offset, table });
   }
   for (const source of collectMarkdownRichListSources(ir)) {
-    if (htmlIslands.some((island) => source.start >= island.start && source.end <= island.end)) {
+    if (insideIsland(source.start, source.end)) {
       continue;
     }
     segments.push({ kind: "list", start: source.start, end: source.end, source });
@@ -531,6 +635,7 @@ function emitSegments(
   rangeStart: number,
   rangeEnd: number,
   degradationReasons: Set<TelegramRichBlocksDegradationReason>,
+  tables: readonly MarkdownTableMeta[],
 ): InputRichBlock[] {
   const blocks: InputRichBlock[] = [];
   let cursor = rangeStart;
@@ -541,7 +646,7 @@ function emitSegments(
       break;
     }
     if (segment.start > cursor) {
-      blocks.push(...emitGapBlocks(ir, cursor, segment.start));
+      blocks.push(...emitGapBlocks(ir, cursor, segment.start, tables));
     }
     // Segments nested inside this one (fences/headings/tables in a blockquote)
     // belong to it; consuming them here prevents a second top-level emission.
@@ -568,7 +673,14 @@ function emitSegments(
         break;
       }
       case "blockquote": {
-        const inner = emitSegments(ir, children, segment.start, segment.end, degradationReasons);
+        const inner = emitSegments(
+          ir,
+          children,
+          segment.start,
+          segment.end,
+          degradationReasons,
+          tables,
+        );
         if (inner.length > 0) {
           blocks.push({ type: "blockquote", blocks: inner });
         }
@@ -582,6 +694,7 @@ function emitSegments(
             start,
             end,
             degradationReasons,
+            tables,
           ),
         );
         if (rendered) {
@@ -595,6 +708,7 @@ function emitSegments(
               segment.start,
               segment.end,
               degradationReasons,
+              tables,
             ),
           );
         }
@@ -613,7 +727,7 @@ function emitSegments(
     index = next;
   }
   if (cursor < rangeEnd) {
-    blocks.push(...emitGapBlocks(ir, cursor, rangeEnd));
+    blocks.push(...emitGapBlocks(ir, cursor, rangeEnd, tables));
   }
   return blocks;
 }
@@ -643,11 +757,11 @@ export function markdownToTelegramRichBlocks(
   const segments = collectStructuralSegments(ir, tables);
   const hasMarkdownLists = segments.some((segment) => segment.kind === "list");
   const flattenedSegments = segments.filter((segment) => segment.kind !== "list");
-  let blocks = emitSegments(ir, segments, 0, ir.text.length, degradationReasons);
+  let blocks = emitSegments(ir, segments, 0, ir.text.length, degradationReasons, tables);
   if (hasMarkdownLists && maxInputRichBlockNesting(blocks) > 16) {
     degradationReasons = new Set<TelegramRichBlocksDegradationReason>();
     degradationReasons.add("list-limit");
-    blocks = emitSegments(ir, flattenedSegments, 0, ir.text.length, degradationReasons);
+    blocks = emitSegments(ir, flattenedSegments, 0, ir.text.length, degradationReasons, tables);
   }
 
   if (blocks.length === 0 && ir.text.trim()) {
@@ -656,7 +770,7 @@ export function markdownToTelegramRichBlocks(
 
   // Plain recovery remains byte-compatible with the pre-native-list path.
   const plainBlocks = hasMarkdownLists
-    ? emitSegments(ir, flattenedSegments, 0, ir.text.length, new Set())
+    ? emitSegments(ir, flattenedSegments, 0, ir.text.length, new Set(), tables)
     : blocks;
 
   return {


### PR DESCRIPTION
Closes #132624

## What Problem This Solves

Fixes an issue where Telegram `richMessages` users would see literal `<details>` / `<summary>` / `</details>` tags in the chat whenever an authored collapsible block contained a Markdown **heading**, **code fence**, **blockquote**, or **table**. The collapsible was destroyed, its inner blocks were hoisted out of it, and delivery still reported success — a silent misrender on the primary surface.

This is the unfixed sibling of the #131078 list fix (2fdbafb0d30): that change taught `collectStructuralSegments` to leave Markdown lists inside authored HTML islands, but headings, code blocks, blockquotes, and tables were still collected unconditionally, so any of them inside a `<details>` island split the island range across emission gaps and the island never matched.

## Why This Change Was Made

The rich-block builder now applies the island-containment skip to every structural segment kind, not just lists. Headings, code fences, and blockquotes inside an island stay on the island-body path (same flattened-text rendering the shipped list behavior uses — the IR strips their Markdown markers, so no syntax leaks).

Markdown tables need one extra step: the IR removes table source text entirely (a zero-width placeholder remains), so skipping the table segment would silently drop its content. The island emitter therefore re-projects each contained table back into the island body as an HTML `<table>` island element at its original placeholder offset and re-parses the fragment through the same `parseIslandBlocks` path island discovery uses. The island fragment parser already maps `<table>` natively, including its over-wide-column ASCII degradation, and content order is preserved exactly (verified with tables between body paragraphs and two tables in one island).

Table cells keep their rich text (ClawSweeper P2: preserve rich-text table cells when reinserting details tables): each cell is projected through the canonical `cellToRichText` path and the resulting typed RichText is serialized back to the island fragment HTML (`richTextToIslandHtml`), so bold/italic/code/link/spoiler spans survive the re-parse instead of flattening to plain cell text. Over-wide island tables record the same `table-ascii` degradation reason as the markdown table path, so delivery diagnostics stay identical.

Literal HTML authored inside code spans still stays literal (`findAuthoredHtmlIslands`'s opener check is unchanged), and tables outside islands render exactly as before.

## User Impact

A details block that contains headings, quotes, code, or tables now arrives as one native collapsible message: no visible container tags, no hoisted content. A table inside a details block renders as a native nested table inside the collapsible, with styled/linked cell content preserved (bold, italics, code, links, spoilers). Plain-text fallback keeps the table cells (and all island content) via the existing recursive plain projection.

## Evidence

All runs on this branch's parent `de969147e7f` (exact main at investigation time) and on the fix heads; executed on Windows 10 + Node v24.15.0.

**Before (main `de969147e7f`)** — planned wire payload via `planTelegramTextDeliveryPages` (the outbound send-planning boundary) for a details block with heading + code + table:

```json
{"blocks":[
 {"type":"paragraph","text":["<details>"," ","<summary>","Deploy checklist","</summary>"]},
 {"type":"heading","text":"Steps","size":1},
 {"type":"pre","text":"openclaw doctor","language":"bash"},
 {"type":"table","cells":[[{"is_header":true,"text":"item"},{"is_header":true,"text":"done"}],[{"text":"lint"},{"text":"yes"}]],"is_bordered":true,"is_striped":true},
 {"type":"paragraph","text":"</details>"}
]}
```

**After (fix)** — same input:

```json
{"blocks":[{"type":"details","summary":"Deploy checklist","blocks":[
 {"type":"paragraph","text":[" "," Steps openclaw doctor "]},
 {"type":"table","cells":[[{"text":"item","is_header":true},{"text":"done","is_header":true}],[{"text":"lint"},{"text":"yes"}]],"is_bordered":true,"is_striped":true}
]}]}
```

Rich cell content is preserved through the island re-projection; a cell `**bold**` emits `{"text":{"type":"bold","text":"bold"}}`, and `[link](https://openclaw.ai)` emits `{"text":{"type":"url","text":"link","url":"https://openclaw.ai"}}` — identical to the canonical `renderTableBlock` projection.

Fallback plain text after: `"Deploy checklist\n  Steps openclaw doctor \nitem | done\nlint | yes"` (no literal tags, table cells preserved).

**Regression tests fail on pre-fix code and pass on the fix:**

- `extensions/telegram/src/rich-blocks-html.test.ts`: 7 new tests — headings / code blocks / blockquotes inside details, table as native nested table, table position between body paragraphs, **rich Markdown cell text (bold/link/code/italic) preserved in a details table**, and **over-wide details table degrading to a grid with the `table-ascii` reason**. All 7 fail on exact main `de969147e7f` and on the pre-fix head, all pass on the fix head (the two rich-cell/degradation tests were additionally verified to fail against the pre-fix head and pass after this follow-up commit).
- `extensions/telegram/src/draft-stream.test.ts`: 1 new boundary test driving the real send-planning path with a mocked Bot API (`api.raw.sendRichMessage` capture) — asserts the wire `rich_message` contains one native `details` block with the nested table and no literal tags. Fails on pre-fix code, passes on the fix.

**Focused validation (fix heads):**

- 211 tests across the three touched test files pass (`rich-blocks-html`, `rich-blocks`, `draft-stream`); 9 tests in `transport-payload` pass.
- `oxfmt` clean on all changed files; targeted `oxlint` clean; `tsgo -p tsconfig.extensions.json --noEmit` reports zero errors in the changed files (the broad project run surfaces pre-existing dependency-type errors in unrelated files on this host — `markdown-it` StateCore/StateInline, `@earendil-works/pi-tui`, qa-lab crabline — none in this diff).
- Production delta `+207/-12` (rich-blocks.ts +135/-11, rich-blocks-html.ts +61/-0, rich-blocks-html-map.ts +11/-1); tests `+160/-0`. The positive production delta is the table re-projection path plus the canonical rich-cell serialization: a net-≤0 alternative would either drop table content inside islands (content loss), leave tables hoisting with the tag leak intact, or flatten rich cell metadata (the ClawSweeper P2 finding this commit closes). The HTML-table injection reuses the existing island fragment parser and its column-limit degradation, adding no new table rendering surface.
- Edge cases verified by direct execution: table as the only island body content, table between two body paragraphs, two tables in one island, table after an island, table between two islands, table before an island, `tableMode: "off"`, island nested in a blockquote, and a code-fenced literal `<details>` example (stays literal, pre code path).

**Full `extensions/telegram` suite on this host:** 202/216 files, 3737/3858 tests pass; the 14 failing files fail with Windows-specific state/DB environment errors (e.g. `EBUSY: resource busy or locked, unlink ... openclaw.sqlite-wal` in temp state dirs) and none are among the files this change touches; the same error class reproduces on a clean checkout without this change (observed while smoke-testing the cron suite before any edit). Hosted CI owns the authoritative full run.

**Proof notes:**

- The changed path is deterministic formatting at the send-planning boundary, so the mock-Bot-API draft-stream test plus the planner payload dumps above are the strongest offline real-behavior proof; no live Telegram Test Server credentials are available to this external contributor, so a live-channel run was not possible. `$telegram-e2e-userbot` is available to maintainers if a live double-check is wanted.
- ClawSweeper follow-up: the [P2] "Preserve rich-text table cells when reinserting details tables" finding and the P1 nested-table merge risk are addressed by this commit (canonical `cellToRichText` round-trip + `table-ascii` degradation reason), with focused regression coverage. The real-behavior-proof item remains blocked for this contributor only by missing Test Server credentials — not by code.
- The `autoreview` skill could not run on this host: none of its engine CLIs (Codex/Claude/Amp/Pi/Kimi) is installed. The diff was manually reviewed instead; no agent transcript is attached.

## AI assistance

AI-assisted: yes (bug discovery, fix, tests, and evidence by Claude Code; every claim in this body was verified by hand against the repo). Confirm I understand what the code does: yes — see "Why This Change Was Made" above.
