### PR TITLE
fix(qa): prevent hung packaged bootstrap from blocking shutdown

### DIFF
--- a/docs/concepts/qa-e2e-automation.md
+++ b/docs/concepts/qa-e2e-automation.md
@@ -1099,12 +1099,19 @@ QA Lab acquires an exclusive lease, heartbeats it for the duration of the
 run, and releases it on shutdown. Pool kinds are `"buzz"`, `"discord"`,
 `"slack"`, `"telegram"`, and `"whatsapp"`.
 
-The suite owns its Gateway lifecycle before startup begins, including startup
-retries and replacement processes. Transport adapters drain their driver work in
+The suite owns its Gateway lifecycle before startup begins, including packaged
+auth and plugin-repair commands, startup retries, replacement processes, and
+commands run against the active Gateway. Each CLI command has a two-minute
+execution limit. Stop closes admission immediately and settles all owned process
+groups; leader exit does not bypass shutdown or the bounded wait for inherited
+stdio to close. On POSIX, CLI commands use their own process groups, so concurrent
+commands do not replace the active Gateway's identity.
+
+Transport adapters drain their driver work in
 `cleanup()` and release Gateway-backed credentials in
 `cleanupAfterGatewayStop()`. The suite runs that second phase only when no
-Gateway was spawned or process-group termination was confirmed. A readiness
-failure or an exited group leader is not shutdown proof.
+subprocess was spawned or all owned process groups were confirmed stopped. A
+readiness failure or an exited group leader is not shutdown proof.
 
 Failed startup or replacement settles the process without finalizing its logs
 or staging directory. The caller retains the lifecycle owner and always calls

--- a/extensions/qa-lab/src/gateway-child-bootstrap.test.ts
+++ b/extensions/qa-lab/src/gateway-child-bootstrap.test.ts
@@ -1,0 +1,363 @@
+import { spawnSync } from "node:child_process";
+import { existsSync, readFileSync } from "node:fs";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { clearTimeout as clearRealTimeout, setTimeout as realTimeout } from "node:timers";
+import { inspect } from "node:util";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { runQaGatewayCliCommand } from "./gateway-child-command.js";
+import { QaGatewayChildLifecycle } from "./gateway-child-lifecycle.js";
+import { createQaGatewayChild } from "./gateway-child.js";
+import { isQaPosixProcessGroupAlive } from "./posix-process-group.js";
+import { createTempDirHarness } from "./temp-dir.test-helper.js";
+
+// RPC is outside these process-lifetime tests. HTTP readiness and all processes stay real.
+vi.mock("./gateway-rpc-client.js", () => ({
+  startQaGatewayRpcClient: async () => ({ request: async () => ({}), stop: async () => {} }),
+}));
+
+type FixtureRecord = {
+  kind: string;
+  pid: number;
+  pgid: number;
+  descendant?: number;
+  tempRoot?: string;
+  submittedKey?: string;
+};
+
+// The fixture never contacts a provider or stores auth. Its independent failsafes
+// and the parent watchdog also bound cleanup when the production owner is broken.
+const fixtureSource = String.raw`
+import fs from "node:fs";
+import http from "node:http";
+import { spawn, execFileSync } from "node:child_process";
+import { once } from "node:events";
+const [record, phase, mode, command, ...args] = process.argv.slice(2);
+const pgid = Number(execFileSync("/bin/ps", ["-o", "pgid=", "-p", String(process.pid)], { encoding: "utf8" }).trim());
+const write = (kind, extra = {}) => fs.appendFileSync(record,
+  JSON.stringify({ kind, pid: process.pid, pgid, ...extra }) + "\n");
+if (command === "descendant") {
+  process.on("SIGTERM", () => {});
+  setTimeout(() => process.exit(20), 30_000);
+  write("descendant");
+  process.send("ready");
+} else {
+  let input = "";
+  if (command === "models") for await (const chunk of process.stdin) input += chunk;
+  const current = command === "models" ? args[args.indexOf("--provider") + 1]
+    : command === "update" ? (args.includes("--help") ? "help" : "repair") : command;
+  write(current);
+  if (current === phase) {
+    process.on("SIGTERM", () => {});
+    setTimeout(() => process.exit(20), 30_000);
+    const child = spawn(process.execPath, [process.argv[1], record, phase, mode, "descendant"],
+      { stdio: ["ignore", mode === "closed-pipes" ? "ignore" : "inherit", mode === "closed-pipes" ? "ignore" : "inherit", "ipc"] });
+    await once(child, "message");
+    write("ready", { descendant: child.pid, tempRoot: process.env.OPENCLAW_QA_TEMP_ROOT,
+      ...(mode === "failure" ? { submittedKey: input.trim() } : {}) });
+    if (mode !== "running") {
+      if (mode === "failure") fs.writeSync(2, "Authorization: Bearer " + input.trim() + "\ncontext retained\n" + "diagnostic ".repeat(400));
+      process.stdout.write("fixture-output");
+      process.exit(mode === "failure" ? 17 : 0);
+    }
+  } else if (current === "gateway") {
+    http.createServer((_request, response) => response.end("ok"))
+      .listen(Number(args[args.indexOf("--port") + 1]), "127.0.0.1");
+  } else {
+    if (current === "help") process.stdout.write("--accept-capabilities");
+    process.exit(0);
+  }
+}
+`;
+
+async function bounded<T>(promise: Promise<T>, ms = 5_000): Promise<T> {
+  let timer: NodeJS.Timeout | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<never>((_, reject) => {
+        timer = realTimeout(() => reject(new Error("bootstrap operation did not settle")), ms);
+      }),
+    ]);
+  } finally {
+    clearRealTimeout(timer);
+  }
+}
+
+const dirs = createTempDirHarness();
+const cleanups: Array<() => Promise<void>> = [];
+const realKill = process.kill.bind(process);
+beforeEach(() => {
+  vi.stubEnv("OPENCLAW_QA_LIVE_ANTHROPIC_SETUP_TOKEN", undefined);
+  vi.stubEnv("OPENCLAW_LIVE_SETUP_TOKEN_VALUE", undefined);
+  vi.stubEnv("OPENCLAW_QA_KEEP_TEMP", undefined);
+});
+afterEach(async () => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+  try {
+    const results = await Promise.allSettled(cleanups.splice(0).map((cleanup) => cleanup()));
+    for (const result of results) {
+      if (result.status === "rejected") {
+        throw result.reason;
+      }
+    }
+    await dirs.cleanup();
+  } finally {
+    vi.unstubAllEnvs();
+  }
+});
+
+async function fixture(phase: string, mode: string) {
+  const root = await dirs.makeTempDir("qa-bootstrap-lifetime-");
+  const record = path.join(root, "events.jsonl");
+  const cli = path.join(root, "fixture.mjs");
+  await fs.writeFile(cli, fixtureSource);
+  const records = (): FixtureRecord[] =>
+    existsSync(record)
+      ? readFileSync(record, "utf8")
+          .trim()
+          .split("\n")
+          .filter(Boolean)
+          .map((line) => JSON.parse(line))
+      : [];
+  const pidAlive = (pid: number) => {
+    try {
+      realKill(pid, 0);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ESRCH") {
+        return false;
+      }
+      throw error;
+    }
+    // ps handles both zombie orphans and exit between the independent probes.
+    const state = spawnSync("/bin/ps", ["-o", "stat=", "-p", String(pid)], { encoding: "utf8" });
+    if (state.error) {
+      throw state.error;
+    }
+    return state.status === 0 && !state.stdout.trim().startsWith("Z");
+  };
+  const assertStopped = () => {
+    for (const entry of records()) {
+      expect(pidAlive(entry.pid), `fixture PID ${entry.pid}`).toBe(false);
+      if (entry.pid === entry.pgid) {
+        expect(isQaPosixProcessGroupAlive(entry.pgid)).toBe(false);
+      }
+    }
+  };
+  const killFixtures = () => {
+    for (const pid of new Set(records().map((entry) => entry.pid))) {
+      if (!Number.isSafeInteger(pid) || pid <= 1) {
+        throw new Error("invalid fixture PID");
+      }
+      try {
+        realKill(pid, "SIGKILL");
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== "ESRCH") {
+          throw error;
+        }
+      }
+    }
+  };
+  const owner = createQaGatewayChild();
+  const pending: Promise<unknown>[] = [];
+  const track = <T>(promise: Promise<T>) => {
+    const observed = promise.catch((error: unknown) => error);
+    pending.push(observed);
+    return observed;
+  };
+  const watchdog = realTimeout(killFixtures, 20_000);
+  cleanups.push(async () => {
+    try {
+      // Close admission first, then independently kill children even if stop hangs.
+      const stopping = owner.stop();
+      killFixtures();
+      await bounded(Promise.all([...pending, stopping]));
+      await vi.waitFor(assertStopped, { timeout: 5_000 });
+    } finally {
+      clearRealTimeout(watchdog);
+    }
+  });
+  const command = {
+    executablePath: process.execPath,
+    argsPrefix: [cli, record, phase, mode],
+    tempParentDir: root,
+    usePackagedPlugins: true,
+  };
+  return {
+    root,
+    records,
+    assertStopped,
+    owner,
+    track,
+    command,
+    start: () =>
+      owner.start({
+        repoRoot: process.cwd(),
+        command,
+        providerMode: "mock-openai",
+        controlUiEnabled: false,
+        transportBaseUrl: "http://127.0.0.1:1",
+      }),
+    ready: async (count = 1) => {
+      await vi.waitFor(
+        () => expect(records().filter((entry) => entry.kind === "ready")).toHaveLength(count),
+        { timeout: 10_000 },
+      );
+      const ready = records().filter((entry) => entry.kind === "ready");
+      for (const entry of ready) {
+        expect(entry.pgid).toBe(entry.pid);
+        expect(records().find((item) => item.pid === entry.descendant)?.pgid).toBe(entry.pgid);
+      }
+      return ready;
+    },
+  };
+}
+
+describe.skipIf(process.platform === "win32")("packaged QA bootstrap lifetime", () => {
+  it.each([
+    { phase: "openai", mode: "running" },
+    { phase: "anthropic", mode: "running" },
+    { phase: "help", mode: "leader-exited" },
+    { phase: "repair", mode: "leader-exited" },
+  ])("stops during $phase ($mode) before any gateway spawn", async ({ phase, mode }) => {
+    const f = await fixture(phase, mode);
+    const starting = f.track(f.start());
+    const [ready] = await f.ready();
+    await expect(bounded(f.owner.stop())).resolves.toEqual({
+      process: "confirmed-stopped",
+      errors: [],
+    });
+    expect(await bounded(starting)).toBeInstanceOf(Error);
+    f.assertStopped();
+    expect(f.records().some((entry) => entry.kind === "gateway")).toBe(false);
+    expect(existsSync(ready!.tempRoot!)).toBe(false);
+  });
+
+  it("owns overlapping post-start commands without displacing the gateway", async () => {
+    const f = await fixture("hang", "running");
+    const gateway = await f.start();
+    const pid = gateway.pid;
+    const commands = [f.track(gateway.runCli(["hang"])), f.track(gateway.runCli(["hang"]))];
+    await f.ready(2);
+    expect(gateway.pid).toBe(pid);
+    expect(isQaPosixProcessGroupAlive(pid!)).toBe(true);
+    await expect(bounded(f.owner.stop())).resolves.toEqual({
+      process: "confirmed-stopped",
+      errors: [],
+    });
+    for (const command of commands) {
+      expect(await bounded(command)).toBeInstanceOf(Error);
+    }
+    f.assertStopped();
+    expect(() => gateway.runCli(["hang"])).toThrow("lifecycle is closed");
+  });
+
+  it.each(["leader-exited", "closed-pipes"])(
+    "settles descendants after successful CLI exit (%s)",
+    async (mode) => {
+      const f = await fixture("probe", mode);
+      const lifetime = new QaGatewayChildLifecycle();
+      const command = f.track(
+        runQaGatewayCliCommand({
+          ...f.command,
+          lifetime,
+          args: ["probe"],
+          cwd: f.root,
+          env: { HOME: f.root },
+        }),
+      );
+      cleanups.push(async () => {
+        await lifetime.stop();
+      });
+      await f.ready();
+      expect(await bounded(command)).toBe("fixture-output");
+      f.assertStopped();
+      await expect(lifetime.stop()).resolves.toEqual({ process: "confirmed-stopped", errors: [] });
+    },
+  );
+
+  it.each(["timeout", "stdout", "stderr", "process"] as const)(
+    "settles a real CLI tree after %s failure without retaining raw error graphs",
+    async (failure) => {
+      const f = await fixture("probe", "running");
+      const lifetime = new QaGatewayChildLifecycle();
+      const registration = vi.spyOn(lifetime, "register");
+      if (failure === "timeout") {
+        vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+      }
+      const command = f.track(
+        runQaGatewayCliCommand({
+          ...f.command,
+          lifetime,
+          args: ["probe"],
+          cwd: f.root,
+          env: { HOME: f.root },
+        }),
+      );
+      cleanups.push(async () => {
+        await lifetime.stop();
+      });
+      await f.ready();
+      const child = registration.mock.calls[0]![0];
+      if (failure === "timeout") {
+        await vi.advanceTimersByTimeAsync(120_000);
+      } else {
+        const error = new AggregateError(
+          [new Error("unlabeled-nested-secret")],
+          "apiKey=synthetic-stream-secret",
+          { cause: new Error("unlabeled-cause-secret") },
+        );
+        if (failure === "process") {
+          child.emit("error", error);
+        } else {
+          child[failure]!.destroy(error);
+        }
+      }
+      const error = await bounded(command);
+      expect(error).toBeInstanceOf(Error);
+      expect(String(error)).toContain(
+        failure === "timeout" ? "exceeded 120000ms" : `${failure} failed`,
+      );
+      const diagnostic = inspect(error, { depth: null });
+      expect(diagnostic).not.toMatch(/synthetic-stream-secret|unlabeled-(nested|cause)-secret/u);
+      f.assertStopped();
+      await expect(lifetime.stop()).resolves.toEqual({ process: "confirmed-stopped", errors: [] });
+    },
+  );
+
+  it("retains denied bootstrap shutdown and safely reports combined failures until a later stop", async () => {
+    const f = await fixture("openai", "failure");
+    const signalFault = vi.spyOn(process, "kill").mockImplementation((pid, signal) => {
+      const ready = f.records().find((entry) => entry.kind === "ready");
+      if (ready && pid === -ready.pgid && (signal === "SIGTERM" || signal === "SIGKILL")) {
+        throw Object.assign(new Error("synthetic group signal denied"), { code: "EPERM" });
+      }
+      return realKill(pid, signal);
+    });
+    const starting = f.track(f.start());
+    const [ready] = await f.ready();
+    const error = await bounded(starting);
+    expect(error).toBeInstanceOf(AggregateError);
+    const diagnostic = inspect(error, { depth: null });
+    expect(diagnostic).toContain("OpenClaw CLI exited 17");
+    expect(diagnostic).toContain("process tree remained alive");
+    expect(ready!.submittedKey).toMatch(/^sk-qa-mock-[a-f0-9]{32}$/u);
+    expect(diagnostic).not.toContain(ready!.submittedKey);
+    expect(diagnostic).not.toContain("diagnostic ".repeat(400));
+    const stopped = await bounded(f.owner.stop());
+    expect(stopped.process).toBe("unconfirmed");
+    expect(stopped.errors.length).toBeGreaterThan(0);
+    expect(inspect(stopped, { depth: null })).not.toContain(ready!.submittedKey);
+    expect(isQaPosixProcessGroupAlive(ready!.pgid)).toBe(true);
+    expect(existsSync(ready!.tempRoot!)).toBe(true);
+    expect(f.records().some((entry) => entry.kind === "gateway")).toBe(false);
+    signalFault.mockRestore();
+    await expect(bounded(f.owner.stop())).resolves.toEqual({
+      process: "confirmed-stopped",
+      errors: [],
+    });
+    f.assertStopped();
+    expect(existsSync(ready!.tempRoot!)).toBe(false);
+  });
+});

--- a/extensions/qa-lab/src/gateway-child-command.ts
+++ b/extensions/qa-lab/src/gateway-child-command.ts
@@ -2,7 +2,6 @@
 import { spawn, type ChildProcess } from "node:child_process";
 import { existsSync } from "node:fs";
 import path from "node:path";
-import { formatErrorMessage, toErrorObject } from "openclaw/plugin-sdk/error-runtime";
 import {
   appendQaChildOutput,
   appendQaChildOutputTail,
@@ -11,7 +10,9 @@ import {
   formatQaChildOutputTail,
   readQaChildOutput,
 } from "./child-output.js";
-import { hasQaGatewayChildExited, monitorQaChildFailure } from "./gateway-child-process.js";
+import type { QaGatewayChildLifecycle } from "./gateway-child-lifecycle.js";
+import { monitorQaChildFailure } from "./gateway-child-process.js";
+import { createQaGatewayCliError } from "./gateway-log-redaction.js";
 import type { QaGatewayProcessBoundaryConfig } from "./gateway-process-boundary.js";
 
 type QaGatewayChildDirectCommand = {
@@ -23,6 +24,9 @@ type QaGatewayChildDirectCommand = {
   usePackagedPlugins?: boolean;
   processBoundary?: undefined;
 };
+
+const QA_GATEWAY_CLI_EXECUTION_TIMEOUT_MS = 120_000;
+const QA_GATEWAY_CLI_DRAIN_TIMEOUT_MS = 1_000;
 
 type QaGatewayChildVerifiedCommand = Omit<QaGatewayChildDirectCommand, "processBoundary"> & {
   processBoundary: QaGatewayProcessBoundaryConfig;
@@ -49,6 +53,7 @@ export function resolveQaGatewayChildCommand(repoRoot: string): QaGatewayChildCo
 }
 
 export async function runQaGatewayCliCommand(params: {
+  lifetime: QaGatewayChildLifecycle;
   executablePath: string;
   argsPrefix: readonly string[];
   args: readonly string[];
@@ -56,51 +61,104 @@ export async function runQaGatewayCliCommand(params: {
   env: NodeJS.ProcessEnv;
   stdin?: string;
 }): Promise<string> {
+  params.lifetime.assertOpen();
   const hasStdin = params.stdin !== undefined;
   const child = spawn(params.executablePath, [...params.argsPrefix, ...params.args], {
     cwd: params.cwd,
     env: { ...params.env, OPENCLAW_CLI: "1" },
+    detached: process.platform !== "win32",
     stdio: [hasStdin ? "pipe" : "ignore", "pipe", "pipe"],
   });
-  const result = readQaGatewayCliCommand(child);
+  // Admission, spawn, and registration share one synchronous turn, before any
+  // stdin or process events can race a stop request.
+  const owned = params.lifetime.register(child, null, "cli");
+  const result = readQaGatewayCliCommand(child, params.lifetime, owned);
+  params.lifetime.completeCli(owned, result);
   if (hasStdin) {
-    child.stdin?.once("error", () => {});
     child.stdin?.end(params.stdin);
   }
   return await result;
 }
 
-async function readQaGatewayCliCommand(child: ChildProcess): Promise<string> {
+async function readQaGatewayCliCommand(
+  child: ChildProcess,
+  lifetime: QaGatewayChildLifecycle,
+  owned: ReturnType<QaGatewayChildLifecycle["register"]>,
+): Promise<string> {
   const stdout = createQaChildOutputCapture();
   const stderr = createQaChildOutputTail();
   child.stdout?.on("data", (chunk) => appendQaChildOutput(stdout, chunk));
   child.stderr?.on("data", (chunk) => appendQaChildOutputTail(stderr, chunk));
-  const exitCode = await new Promise<number>((resolve, reject) => {
-    monitorQaChildFailure(child, (failure) => {
-      if (failure.source === "process") {
-        reject(toErrorObject(failure.error, "OpenClaw CLI process failed"));
-        return;
-      }
-      if (!hasQaGatewayChildExited(child) && !child.killed) {
-        try {
-          child.kill("SIGKILL");
-        } catch {
-          // The child exited between the state check and signal.
-        }
-      }
-      reject(
-        new Error(
-          `qa gateway cli ${failure.source} stream failed: ${formatErrorMessage(failure.error)}`,
-          { cause: failure.error },
-        ),
-      );
-    });
-    child.once("close", (code) => resolve(code ?? 1));
+  let failure: Error | undefined;
+  let finish!: (code: number | undefined) => void;
+  const terminal = new Promise<number | undefined>((resolve) => {
+    finish = resolve;
   });
-  const stdoutText = readQaChildOutput(stdout);
-  if (exitCode !== 0) {
-    const stderrText = formatQaChildOutputTail(stderr, "stderr");
-    throw new Error(`OpenClaw CLI exited ${exitCode}: ${stderrText || stdoutText}`);
+  const fail = (error: unknown) => {
+    failure ??= createQaGatewayCliError(error);
+    finish(undefined);
+  };
+  monitorQaChildFailure(child, ({ source, error }) => {
+    fail(`qa gateway cli ${source} failed: ${createQaGatewayCliError(error).message}`);
+  });
+  child.stdin?.once("error", (error) =>
+    fail(`qa gateway cli stdin failed: ${createQaGatewayCliError(error).message}`),
+  );
+  child.once("exit", (code) => finish(code ?? 1));
+  const closed = new Promise<void>((resolve) => {
+    child.once("close", () => resolve());
+  });
+  const onAbort = () => fail("qa gateway CLI cancelled: lifecycle is closed");
+  lifetime.signal.addEventListener("abort", onAbort, { once: true });
+  const executionTimer = setTimeout(
+    () => fail(`qa gateway CLI exceeded ${QA_GATEWAY_CLI_EXECUTION_TIMEOUT_MS}ms`),
+    QA_GATEWAY_CLI_EXECUTION_TIMEOUT_MS,
+  );
+  let drainTimer: NodeJS.Timeout | undefined;
+  let exitCode: number | undefined;
+  let stopped: Awaited<ReturnType<QaGatewayChildLifecycle["stopProcess"]>>;
+  try {
+    exitCode = await terminal;
+    clearTimeout(executionTimer);
+    // Leader exit is not group settlement or pipe closure. Settle the owned tree
+    // even after success/errors; never wait for close after unconfirmed shutdown.
+    stopped = await lifetime.stopProcess(owned);
+    if (stopped.process !== "unconfirmed") {
+      await Promise.race([
+        closed,
+        new Promise<void>((resolve) => {
+          drainTimer = setTimeout(() => {
+            fail("qa gateway CLI stdio did not close after process-tree shutdown");
+            resolve();
+          }, QA_GATEWAY_CLI_DRAIN_TIMEOUT_MS);
+        }),
+      ]);
+    }
+  } finally {
+    clearTimeout(executionTimer);
+    clearTimeout(drainTimer);
+    lifetime.signal.removeEventListener("abort", onAbort);
+    child.stdin?.destroy();
+    child.stdout?.destroy();
+    child.stderr?.destroy();
   }
+  const stdoutText = readQaChildOutput(stdout);
+  if (exitCode !== 0 && !failure) {
+    const stderrText = formatQaChildOutputTail(stderr, "stderr");
+    failure = createQaGatewayCliError(
+      `OpenClaw CLI exited ${exitCode}: ${stderrText || stdoutText}`,
+    );
+  }
+  if (stopped.errors.length) {
+    throw new AggregateError(
+      failure ? [failure, ...stopped.errors] : stopped.errors,
+      failure?.message ?? "qa gateway CLI cleanup failed",
+      { cause: failure },
+    );
+  }
+  if (failure) {
+    throw failure;
+  }
+  lifetime.assertOpen();
   return stdoutText;
 }

--- a/extensions/qa-lab/src/gateway-child-lifecycle.test.ts
+++ b/extensions/qa-lab/src/gateway-child-lifecycle.test.ts
@@ -1,7 +1,7 @@
 import { readFileSync } from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createQaGatewayChild } from "./gateway-child.js";
 import { isQaPosixProcessGroupAlive, signalQaPosixProcessGroup } from "./posix-process-group.js";
 import { createTempDirHarness } from "./temp-dir.test-helper.js";
@@ -20,6 +20,10 @@ vi.mock("./gateway-rpc-client.js", () => ({
 const dirs = createTempDirHarness();
 const owners: ReturnType<typeof createQaGatewayChild>[] = [];
 const groups: number[] = [];
+beforeEach(() => {
+  vi.stubEnv("OPENCLAW_QA_LIVE_ANTHROPIC_SETUP_TOKEN", undefined);
+  vi.stubEnv("OPENCLAW_LIVE_SETUP_TOKEN_VALUE", undefined);
+});
 afterEach(async () => {
   vi.restoreAllMocks();
   boundary.create.mockReset();

--- a/extensions/qa-lab/src/gateway-child-lifecycle.ts
+++ b/extensions/qa-lab/src/gateway-child-lifecycle.ts
@@ -8,6 +8,7 @@ import {
   preserveQaGatewayDebugArtifacts,
 } from "./gateway-child-artifacts.js";
 import { closeQaGatewayLogStream, stopQaGatewayChildProcessTree } from "./gateway-child-process.js";
+import { createQaGatewayCliError } from "./gateway-log-redaction.js";
 import type { reserveQaGatewayPort } from "./gateway-port-reservation.js";
 import type {
   createQaGatewayProcessBoundaryController,
@@ -24,10 +25,13 @@ export type QaGatewayStopResult = {
 export type QaGatewayStopOptions = { keepTemp?: boolean; preserveToDir?: string };
 
 type OwnedProcess = {
+  kind: "gateway" | "cli";
   child: ChildProcess;
   prepared: PreparedSpawn | null;
   identity: QaGatewayVerifiedProcessIdentity | null;
   settlement?: Promise<QaGatewayStopResult>;
+  stopResult?: QaGatewayStopResult;
+  completion?: Promise<void>;
   ready: boolean;
   checkFailure: () => void;
 };
@@ -41,7 +45,9 @@ export class QaGatewayChildLifecycle {
   controller: BoundaryController | null = null;
   rpcClient: Awaited<ReturnType<typeof startQaGatewayRpcClient>> | null = null;
   readonly logStreams: Array<["stdout" | "stderr", WriteStream]> = [];
-  private closed = false;
+  private readonly cancellation = new AbortController();
+  private readonly processes = new Set<OwnedProcess>();
+  private spawned = false;
   private current: OwnedProcess | null = null;
   private operation: Promise<unknown> | null = null;
   private stopping: Promise<QaGatewayStopResult> | null = null;
@@ -49,15 +55,51 @@ export class QaGatewayChildLifecycle {
 
   repoRoot?: string;
 
+  get signal() {
+    return this.cancellation.signal;
+  }
+
   assertOpen() {
-    if (this.closed) {
+    if (this.signal.aborted) {
       throw new Error("qa gateway child lifecycle is closed");
     }
   }
 
-  register(child: ChildProcess, prepared: PreparedSpawn | null) {
-    this.current = { child, prepared, identity: null, ready: false, checkFailure: () => {} };
-    return this.current;
+  register(
+    child: ChildProcess,
+    prepared: PreparedSpawn | null,
+    kind: OwnedProcess["kind"] = "gateway",
+  ) {
+    const owned: OwnedProcess = {
+      child,
+      prepared,
+      kind,
+      identity: null,
+      ready: false,
+      checkFailure: () => {},
+    };
+    if (kind === "gateway") {
+      if (this.current?.stopResult?.process === "confirmed-stopped") {
+        this.processes.delete(this.current);
+      }
+      this.current = owned;
+    }
+    this.spawned ||= child.pid !== undefined;
+    this.processes.add(owned);
+    return owned;
+  }
+
+  completeCli(owned: OwnedProcess, operation: Promise<string>) {
+    owned.completion = operation
+      .then(
+        () => {},
+        () => {},
+      )
+      .finally(() => {
+        if (owned.stopResult?.process === "confirmed-stopped") {
+          this.processes.delete(owned);
+        }
+      });
   }
 
   async run<T>(operation: () => Promise<T>): Promise<T> {
@@ -73,10 +115,10 @@ export class QaGatewayChildLifecycle {
     try {
       return await pending;
     } catch (error) {
-      this.closed = true;
+      this.cancellation.abort();
       // Settle the failed operation's process, but leave logs and staging owned
       // until explicit stop supplies the caller's artifact preservation policy.
-      const result = await this.stopProcess();
+      const result = await this.stopAllProcesses();
       const message = `${formatErrorMessage(error)}${this.tempRoot ? `\nQA gateway temp root preserved at ${this.tempRoot}` : ""}`;
       const primary =
         error instanceof QaSuiteInfraError
@@ -97,8 +139,7 @@ export class QaGatewayChildLifecycle {
     }
   }
 
-  stopProcess() {
-    const current = this.current;
+  stopProcess(current = this.current) {
     if (!current) {
       return Promise.resolve<QaGatewayStopResult>({ process: "never-spawned", errors: [] });
     }
@@ -106,7 +147,7 @@ export class QaGatewayChildLifecycle {
     // record only after confirmed termination, never after a leader-only exit.
     current.settlement ??= (async (): Promise<QaGatewayStopResult> => {
       const errors: unknown[] = [];
-      if (this.controller) {
+      if (current.kind === "gateway" && this.controller) {
         try {
           if (current.identity) {
             await this.controller.markExited(current.identity);
@@ -129,16 +170,20 @@ export class QaGatewayChildLifecycle {
         );
         return { process: "confirmed-stopped", errors };
       } catch (error) {
-        return { process: "unconfirmed", errors: [...errors, error] };
+        const failure = current.kind === "cli" ? createQaGatewayCliError(error) : error;
+        return { process: "unconfirmed", errors: [...errors, failure] };
       }
-    })();
+    })().then((result) => {
+      current.stopResult = result;
+      return result;
+    });
     return current.settlement;
   }
 
   stop(opts?: QaGatewayStopOptions): Promise<QaGatewayStopResult> {
     // Close admission before any await: staging/acceptance/replacement cannot
     // spawn or resume a child after a caller has requested stop.
-    this.closed = true;
+    this.cancellation.abort();
     this.stopping ??= this.stopOnce(opts).then((result) => {
       if (result.errors.length) {
         this.stopping = null;
@@ -149,17 +194,37 @@ export class QaGatewayChildLifecycle {
   }
 
   private async stopOnce(opts?: QaGatewayStopOptions): Promise<QaGatewayStopResult> {
-    const settlement = await this.current?.settlement;
-    if (settlement?.process === "unconfirmed" && this.current) {
-      this.current.settlement = undefined;
+    for (const owned of this.processes) {
+      if (owned.stopResult?.process === "unconfirmed") {
+        owned.settlement = undefined;
+        owned.stopResult = undefined;
+      }
     }
-    await this.stopProcess();
+    await this.stopAllProcesses();
     await this.operation?.catch(() => {});
     return this.finish(opts);
   }
 
+  private async stopAllProcesses(): Promise<QaGatewayStopResult> {
+    const results = await Promise.all(
+      [...this.processes].map(async (owned) => {
+        const result = await this.stopProcess(owned);
+        await owned.completion;
+        return result;
+      }),
+    );
+    return {
+      process: results.some((result) => result.process === "unconfirmed")
+        ? "unconfirmed"
+        : this.spawned
+          ? "confirmed-stopped"
+          : "never-spawned",
+      errors: results.flatMap((result) => result.errors),
+    };
+  }
+
   private async finish(opts?: QaGatewayStopOptions): Promise<QaGatewayStopResult> {
-    const stopped = await this.stopProcess();
+    const stopped = await this.stopAllProcesses();
     const errors = [...stopped.errors];
     const attempt = async (cleanup: () => Promise<unknown>) => {
       try {

--- a/extensions/qa-lab/src/gateway-child-setup.ts
+++ b/extensions/qa-lab/src/gateway-child-setup.ts
@@ -4,10 +4,8 @@ import fs from "node:fs/promises";
 import net from "node:net";
 import path from "node:path";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
-import { toErrorObject } from "openclaw/plugin-sdk/error-runtime";
 import { uniqueStrings } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { resolvePreferredOpenClawTmpDir } from "openclaw/plugin-sdk/temp-path";
-import { sliceUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import {
   createQaBundledPluginsDir,
   resolveQaOwnerPluginIdsForProviderIds,
@@ -26,7 +24,7 @@ import {
 } from "./gateway-child-env.js";
 import type { QaGatewayChildLifecycle } from "./gateway-child-lifecycle.js";
 import { createQaGatewayChildLogCollector } from "./gateway-child-process.js";
-import { redactQaGatewayDebugText } from "./gateway-log-redaction.js";
+import { createQaGatewayCliError, redactQaGatewayDebugText } from "./gateway-log-redaction.js";
 import { reserveQaGatewayPort } from "./gateway-port-reservation.js";
 import { createQaGatewayProcessBoundaryController } from "./gateway-process-boundary.js";
 import { splitQaModelRef, type QaProviderMode } from "./model-selection.js";
@@ -48,7 +46,6 @@ import { seedQaAgentWorkspace } from "./qa-agent-workspace.js";
 import { buildQaGatewayConfig, type QaThinkingLevel } from "./qa-gateway-config.js";
 import type { QaTransportAdapter } from "./qa-transport.js";
 import type { RuntimeId } from "./runtime-parity.js";
-const QA_PACKAGE_BOOTSTRAP_FAILURE_MAX_CHARS = 2_048;
 export type QaGatewayChildStateMutationContext = {
   configPath: string;
   runtimeEnv: NodeJS.ProcessEnv;
@@ -118,17 +115,14 @@ async function runQaPackagedBootstrap(
   try {
     await operation();
   } catch (error) {
-    const details = sliceUtf16Safe(
-      redactQaGatewayDebugText(toErrorObject(error, failureMessage).message),
-      0,
-      QA_PACKAGE_BOOTSTRAP_FAILURE_MAX_CHARS,
-    );
+    const details = createQaGatewayCliError(error).message;
     // oxlint-disable-next-line preserve-caught-error -- Candidate CLI output can contain credentials; only the bounded redacted message crosses this boundary, never its raw cause.
     throw new Error(`${failureMessage}: ${details}`);
   }
 }
 
 async function stageQaPackagedMockAuthProfiles(params: {
+  lifetime: QaGatewayChildLifecycle;
   command: QaGatewayChildCommand;
   configPath: string;
   cwd: string;
@@ -140,6 +134,7 @@ async function stageQaPackagedMockAuthProfiles(params: {
       `installed package mock auth bootstrap failed for ${provider}`,
       () =>
         runQaGatewayCliCommand({
+          lifetime: params.lifetime,
           executablePath: params.command.executablePath,
           argsPrefix: params.command.argsPrefix ?? [],
           args: [
@@ -424,6 +419,7 @@ export async function prepareQaGatewayChild(
             mode: 0o600,
           });
           await stageQaPackagedMockAuthProfiles({
+            lifetime,
             command: gatewayCommand,
             configPath: packagedAuthConfigPath,
             cwd: gatewayCwd,
@@ -437,6 +433,7 @@ export async function prepareQaGatewayChild(
         }
         if (usesPackagedCandidate && gatewayCommand) {
           const command = {
+            lifetime,
             executablePath: gatewayCommand.executablePath,
             argsPrefix: gatewayCommand.argsPrefix ?? [],
             cwd: gatewayCwd,

--- a/extensions/qa-lab/src/gateway-child.test.ts
+++ b/extensions/qa-lab/src/gateway-child.test.ts
@@ -9,7 +9,7 @@ import { pathToFileURL } from "node:url";
 import { inspect } from "node:util";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { toErrorObject } from "openclaw/plugin-sdk/error-runtime";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   createQaBundledPluginsDir,
   resolveQaOwnerPluginIdsForProviderIds,
@@ -22,6 +22,7 @@ import {
   buildQaRuntimeEnv,
   stageQaCodexMockModelCatalog,
 } from "./gateway-child-env.js";
+import { QaGatewayChildLifecycle } from "./gateway-child-lifecycle.js";
 import {
   closeQaGatewayLogStream,
   createQaGatewayChildLogCollector,
@@ -69,6 +70,10 @@ vi.mock("./node-exec.js", () => ({
 
 const tempDirs = createTempDirHarness();
 const owners: ReturnType<typeof createQaGatewayChild>[] = [];
+beforeEach(() => {
+  vi.stubEnv("OPENCLAW_QA_LIVE_ANTHROPIC_SETUP_TOKEN", undefined);
+  vi.stubEnv("OPENCLAW_LIVE_SETUP_TOKEN_VALUE", undefined);
+});
 function ownGateway() {
   const owner = createQaGatewayChild();
   owners.push(owner);
@@ -217,6 +222,7 @@ if (args[0] === "update") {
     await fail(8, "plugin fixture rejected: Authorization: Bearer " + "fixture-plugin-secret".repeat(200));
   }
   if (args.includes("--help")) {
+    record({ kind: "help", args, authDbPath, configPath, stateDir });
     process.stdout.write(process.env.QA_LEGACY_PLUGIN_SETUP === "1" ? "Options: --yes" : "Options: --accept-capabilities --yes");
     process.exit(0);
   }
@@ -273,6 +279,7 @@ async function readJsonLines(filePath: string): Promise<Array<Record<string, unk
 describe("runQaGatewayCliCommand", () => {
   it("runs CLI commands with the Gateway fixture environment", async () => {
     const output = await runQaGatewayCliCommand({
+      lifetime: new QaGatewayChildLifecycle(),
       executablePath: process.execPath,
       argsPrefix: [
         "--eval",
@@ -289,6 +296,7 @@ describe("runQaGatewayCliCommand", () => {
   it("reports CLI stderr when a fixture command fails", async () => {
     await expect(
       runQaGatewayCliCommand({
+        lifetime: new QaGatewayChildLifecycle(),
         executablePath: process.execPath,
         argsPrefix: ["--eval", 'process.stderr.write("fixture failure"); process.exit(7)'],
         args: [],
@@ -1603,8 +1611,15 @@ describe("buildQaRuntimeEnv", () => {
       });
       expect(records.at(-1)?.configPath).not.toBe(authConfigPaths[0]);
       expect(records.at(-1)?.fixtureProfiles).toBeUndefined();
-      expect(records.map((record) => record.kind)).toEqual(["auth", "auth", "plugins", "gateway"]);
-      expect(records[2]).toMatchObject({
+      expect(records.map((record) => record.kind)).toEqual([
+        "auth",
+        "auth",
+        "help",
+        "plugins",
+        "gateway",
+      ]);
+      expect(records[2]?.args).toEqual(["update", "repair", "--help"]);
+      expect(records[3]).toMatchObject({
         args: [
           "update",
           "repair",
@@ -1655,6 +1670,15 @@ describe("buildQaRuntimeEnv", () => {
       expect(records.filter((record) => record.kind === "plugins")).toHaveLength(configBuilds);
       expect(mutateConfig).toHaveBeenCalledTimes(configBuilds);
       expect(records.filter((record) => record.kind === "auth")).toHaveLength(2);
+      expect(records.map((record) => record.kind)).toEqual([
+        "auth",
+        "auth",
+        "help",
+        "plugins",
+        "gateway",
+        ...(retry === "bind" ? ["help", "plugins"] : []),
+        "gateway",
+      ]);
       expect(new Set(records.map((record) => record.stateDir)).size).toBe(1);
       for (const gateway of gateways) {
         expect(gateway.args).toContainEqual(String(gateway.configPort));
@@ -1717,7 +1741,7 @@ describe("buildQaRuntimeEnv", () => {
           ? provider === "openai"
             ? ["auth"]
             : ["auth", "auth"]
-          : ["auth", "auth", "plugins"],
+          : ["auth", "auth", ...(phase === "repair" ? ["help"] : []), "plugins"],
       );
       expect(records[0]).toMatchObject({
         kind: "auth",
@@ -1740,7 +1764,7 @@ describe("buildQaRuntimeEnv", () => {
           readFile(path.join(tempParentDir, tempRoots[0]!, `gateway.${stream}.log`), "utf8"),
         ).resolves.toBe("");
       }
-      await expect(owner.stop()).resolves.toEqual({ process: "never-spawned", errors: [] });
+      await expect(owner.stop()).resolves.toEqual({ process: "confirmed-stopped", errors: [] });
       await expect(readdir(tempParentDir)).resolves.toEqual([]);
     },
   );

--- a/extensions/qa-lab/src/gateway-child.ts
+++ b/extensions/qa-lab/src/gateway-child.ts
@@ -253,6 +253,7 @@ async function startOwnedGatewayChild(
     runCli(args: readonly string[]) {
       throwActiveChildFailure();
       return runQaGatewayCliCommand({
+        lifetime,
         executablePath: nodeExecPath,
         argsPrefix: cliArgsPrefix,
         args,

--- a/extensions/qa-lab/src/gateway-log-redaction.ts
+++ b/extensions/qa-lab/src/gateway-log-redaction.ts
@@ -1,6 +1,7 @@
 // Qa Lab plugin module implements gateway log redaction behavior.
+import { coerceErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import { redactSensitiveText } from "openclaw/plugin-sdk/logging-core";
-import { escapeRegExp } from "openclaw/plugin-sdk/text-utility-runtime";
+import { escapeRegExp, sliceUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import {
   QA_PROVIDER_SECRET_ENV_KEY_PATTERNS,
   QA_PROVIDER_SECRET_ENV_VARS,
@@ -139,4 +140,11 @@ export function redactQaGatewayDebugText(text: string) {
 export function formatQaGatewayLogsForError(logs: string) {
   const sanitized = redactQaGatewayDebugText(logs).trim();
   return sanitized.length > 0 ? `\nGateway logs:\n${sanitized}` : "";
+}
+
+export function createQaGatewayCliError(error: unknown): Error {
+  // Candidate errors can carry credentials in nested causes, spawnargs, or output.
+  // Retain only a bounded, redacted message, including for lifecycle-held failures.
+  const message = coerceErrorMessage(error);
+  return new Error(sliceUtf16Safe(redactQaGatewayDebugText(message), 0, 2_048));
 }

--- a/extensions/qa-lab/src/gateway-startup-lease.integration.test.ts
+++ b/extensions/qa-lab/src/gateway-startup-lease.integration.test.ts
@@ -23,7 +23,7 @@ import { once } from "node:events";
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-const [root, command, leaderText] = process.argv.slice(2);
+const [root, surface, command, leaderText] = process.argv.slice(2);
 const record = (kind, details = {}) => fs.appendFileSync(
   path.join(root, "events.jsonl"), JSON.stringify({ at: Date.now(), kind, ...details }) + "\n");
 const pgid = () => Number(execFileSync("/bin/ps", ["-o", "pgid=", "-p", String(process.pid)],
@@ -31,7 +31,7 @@ const pgid = () => Number(execFileSync("/bin/ps", ["-o", "pgid=", "-p", String(p
 if (command === "models") {
   for await (const ignored of process.stdin) { /* discard synthetic auth */ }
   record("auth-cli-completed");
-  process.exit(0);
+  if (surface !== "bootstrap") process.exit(0);
 }
 if (command === "update" && leaderText === "repair") {
   if (process.argv.includes("--help")) {
@@ -48,14 +48,14 @@ if (command === "descendant") {
   const identity = { leaderPid: Number(leaderText), descendantPid: process.pid, pgid: pgid() };
   record("descendant-ready", identity);
   process.send(identity);
-} else if (command === "gateway") {
+} else if (command === "gateway" || (command === "models" && surface === "bootstrap")) {
   setTimeout(() => process.exit(19), 10_000);
   const identity = { leaderPid: process.pid, pgid: pgid() };
   fs.writeFileSync(path.join(root, "identity.json"), JSON.stringify(identity));
-  record("gateway-start", identity);
+  record(surface + "-start", identity);
   const descendant = spawn(process.execPath,
-    [fileURLToPath(import.meta.url), root, "descendant", String(process.pid)],
-    { detached: false, stdio: ["ignore", "ignore", "ignore", "ipc"] });
+    [fileURLToPath(import.meta.url), root, surface, "descendant", String(process.pid)],
+    { detached: false, stdio: ["ignore", "inherit", "inherit", "ipc"] });
   const [ready] = await once(descendant, "message");
   if (ready.descendantPid !== descendant.pid || ready.pgid !== process.pid) process.exit(18);
   fs.writeFileSync(path.join(root, "identity.json"), JSON.stringify(ready));
@@ -98,7 +98,7 @@ function serializeError(error: unknown): unknown {
     : String(error);
 }
 
-async function reproduce(denyGroupSignals: boolean) {
+async function reproduce(denyGroupSignals: boolean, surface: "gateway" | "bootstrap") {
   await fs.mkdir(artifactRoot, { recursive: true });
   const root = await fs.mkdtemp(path.join(artifactRoot, denyGroupSignals ? "fault-" : "control-"));
   const eventsPath = path.join(root, "events.jsonl");
@@ -253,6 +253,8 @@ async function reproduce(denyGroupSignals: boolean) {
   vi.stubEnv("OPENCLAW_QA_CONVEX_SITE_URL", baseUrl);
   vi.stubEnv("OPENCLAW_QA_CONVEX_SECRET_CI", "synthetic-only");
   vi.stubEnv("OPENCLAW_QA_ALLOW_INSECURE_HTTP", "1");
+  vi.stubEnv("OPENCLAW_QA_LIVE_ANTHROPIC_SETUP_TOKEN", undefined);
+  vi.stubEnv("OPENCLAW_LIVE_SETUP_TOKEN_VALUE", undefined);
   const killSpy = vi.spyOn(process, "kill").mockImplementation((pid, signal) => {
     const identity = readIdentity(root);
     if (identity && pid === -identity.pgid) {
@@ -298,7 +300,7 @@ async function reproduce(denyGroupSignals: boolean) {
           adapterFactories: [factory],
           sutOpenClawCommand: {
             executablePath: process.execPath,
-            argsPrefix: [fixturePath, root],
+            argsPrefix: [fixturePath, root, surface],
             tempParentDir,
             usePackagedPlugins: true,
           },
@@ -398,22 +400,31 @@ describe.skipIf(process.platform === "win32")(
   "gateway startup lease lifetime (real process group)",
   () => {
     it.each([
-      { label: "positive control: successful tree shutdown", denyGroupSignals: false },
-      { label: "fault: process-group shutdown denied", denyGroupSignals: true },
-    ])(
-      "$label releases only after descendant exit",
+      { surface: "gateway", denyGroupSignals: false },
+      { surface: "gateway", denyGroupSignals: true },
+      { surface: "bootstrap", denyGroupSignals: false },
+      { surface: "bootstrap", denyGroupSignals: true },
+    ] as const)(
+      "$surface startup releases only after descendant exit (denied=$denyGroupSignals)",
       { timeout: 45_000 },
-      async ({ denyGroupSignals }) => {
-        const result = await reproduce(denyGroupSignals);
+      async ({ denyGroupSignals, surface }) => {
+        const result = await reproduce(denyGroupSignals, surface);
         expect(result.scenarioCalls).toBe(0);
         const repaired = result.events.findIndex(
           (event) => event.kind === "plugin-repair-completed",
         );
-        expect(repaired).toBeGreaterThan(-1);
-        expect(result.events.findIndex((event) => event.kind === "gateway-start")).toBeGreaterThan(
-          repaired,
+        if (surface === "gateway") {
+          expect(repaired).toBeGreaterThan(-1);
+          expect(
+            result.events.findIndex((event) => event.kind === "gateway-start"),
+          ).toBeGreaterThan(repaired);
+        } else {
+          expect(repaired).toBe(-1);
+        }
+        expect(result.events.filter((event) => event.kind === "gateway-start")).toHaveLength(
+          surface === "gateway" ? 1 : 0,
         );
-        expect(result.events.filter((event) => event.kind === "gateway-start")).toHaveLength(1);
+        expect(result.events.filter((event) => event.kind === `${surface}-start`)).toHaveLength(1);
         expect(result.events.find((event) => event.kind === "leader-exit")).toMatchObject({
           exitCode: 17,
         });
@@ -454,7 +465,9 @@ describe.skipIf(process.platform === "win32")(
           expect(result.suiteError).toBeInstanceOf(Error);
         }
         expect(JSON.stringify(serializeError(result.suiteError))).toContain(
-          "gateway exited before listening (exitCode=17",
+          surface === "gateway"
+            ? "gateway exited before listening (exitCode=17"
+            : "OpenClaw CLI exited 17",
         );
         expect(
           result.releases.every((release) => !release.descendantAlive),


### PR DESCRIPTION
Related: [packaged Gateway plugin preparation](https://github.com/openclaw/openclaw/pull/132399).

<details>
<summary>Additional instructions</summary>

This is a same-repository branch; maintainers can update it.

</details>

## What Problem This Solves

Resolves a problem where stopping packaged QA could hang indefinitely when an auth bootstrap, repair-help probe, or plugin repair command did not finish. Preparation ran before Gateway readiness's deadline, and a CLI leader could also exit while a descendant kept its output pipes open.

## Why This Change Was Made

The existing QA Gateway lifecycle now owns every CLI subprocess as well as the Gateway. CLI commands register synchronously, use their own POSIX process groups, have a fixed two-minute execution limit, and settle their trees before completing; a separate bounded stdio drain prevents inherited pipes from hanging teardown. Stop closes admission immediately. Unconfirmed termination retains ownership and runtime state, blocks lease release, and can be retried without losing the original process identity.

This reuses the existing tree-settlement owner and removes the CLI's leader-only kill path. Overlapping post-start `runCli()` calls do not displace the Gateway. Candidate failures are bounded and QA-redacted before entering retained/aggregate error graphs; raw causes and spawn arguments are not exposed. Auth's isolated config, auth → help → repair → launch order, legacy capability detection, new-port repair, and same-state migration retry semantics remain intact.

A Node spawn timeout/AbortSignal alone is insufficient: it signals only the leader and stops observing cancellation at leader exit. Racing the preparation promise alone would abandon its subprocess and lease-owning state. Lifecycle ownership is the canonical repair rather than a downstream cleanup workaround.

## User Impact

QA operators can stop a stuck packaged preparation command without leaving a background process free to mutate a runtime that QA has already released. If process-tree termination cannot be confirmed, QA reports that failure and retains the runtime and credential lease heartbeat instead of reporting successful shutdown.

No configuration, environment-variable surface, dependency, SQLite schema, protocol, redaction pattern, or suppression-policy changes. This changes the source-only QA harness, not the operator's installed Gateway.

## Evidence

AI-assisted implementation, manually inspected and independently reviewed.

- Before production edits: a real synthetic CLI/descendant fixture failed all four preparation-stop cases (both auth providers, help, repair), including exited leaders with inherited pipes. The five-second stop observation expired; independent fixture cleanup removed the synthetic processes.
- Final focused proof: **184 passed, 3 platform skips across 11 files**, covering process trees, both pipe-lifetime variants, timeout/process/stream failures, overlapping `runCli()`, safe complete error graphs, startup/replacement cleanup, retry ordering, and port cleanup.
- A real local synthetic credential broker proves successful bootstrap/Gateway tree settlement releases only after descendant exit; denied termination withholds release and keeps heartbeat/state owned. No provider credentials or operator Gateway were used.
- Three additional serial repetitions of the original four stop cases passed with the same five-second bound.
- Explicit-file changed gate passed: production/test typechecks, type-aware lint, formatting, doctor boundary tests, dependency/suppression/assertion guards, dead exports, and import cycles. `git diff --check` passed. Fresh pre-commit Codex autoreview returned `scoped-clean`, with no findings at the configured P0-only threshold; the patch remained unchanged through rebase.

Focused command:

```bash
node scripts/run-vitest.mjs extensions/qa-lab/src/gateway-child-bootstrap.test.ts extensions/qa-lab/src/gateway-child.test.ts extensions/qa-lab/src/gateway-child-lifecycle.test.ts extensions/qa-lab/src/gateway-startup-lease.integration.test.ts extensions/qa-lab/src/gateway-log-redaction.test.ts extensions/qa-lab/src/gateway-process-boundary.test.ts extensions/qa-lab/src/posix-command-settlement.test.ts extensions/qa-lab/src/posix-process-group.test.ts extensions/qa-lab/src/child-output.test.ts extensions/qa-lab/src/gateway-port-reservation.test.ts extensions/qa-lab/src/suite.test.ts
```

Changed gate:

```bash
node scripts/check-changed.mjs --base HEAD -- docs/concepts/qa-e2e-automation.md extensions/qa-lab/src/gateway-child-bootstrap.test.ts extensions/qa-lab/src/gateway-child-command.ts extensions/qa-lab/src/gateway-child-lifecycle.test.ts extensions/qa-lab/src/gateway-child-lifecycle.ts extensions/qa-lab/src/gateway-child-setup.ts extensions/qa-lab/src/gateway-child.test.ts extensions/qa-lab/src/gateway-child.ts extensions/qa-lab/src/gateway-log-redaction.ts extensions/qa-lab/src/gateway-startup-lease.integration.test.ts
```

Proof limits and failures: real-process proof above ran on macOS with Node 24.20.0 and synthetic candidate CLI entry points, not an actual package installation or a live provider. One earlier candidate run exceeded the stop observation bound; no causal production defect was established for that isolated timing miss, and it did not recur in the final complete run or three ordered repetitions. No shutdown, execution, drain, or assertion timeout was increased. Earlier dependency collection and double-redaction marker failures were repaired before final proof, without weakening assertions. After rebase, local test collection exposed an incomplete installed Kysely package. `pnpm install` did not repair it; supported `pnpm install --force --frozen-lockfile` restored the pinned package with no manifest or lockfile changes. The same 11-file focused command then passed again on commit `32eba00d42e134778b885d65d91bdaaf7a0ebafd`: 184 passed, 3 platform skips, 73.48 seconds wrapper runtime. The final committed-diff gate `node scripts/check-changed.mjs --base HEAD^` also passed, including both typecheck/lint lanes and zero runtime import cycles. Exact-head CI and native landing evidence will be added before merge.

Production LOC: **+185/-56 (net +129)**. Tests: **+429/-25 (net +404)**. Docs: **+11/-4 (net +7)**. Production growth supplies the missing multi-process lifetime registry, cancellation/deadline/drain handling, retained settlement, and safe error projection; tree termination is reused, not duplicated.

Named follow-up, kept separate: `cleanupQaGatewayTempRoots()` currently swallows filesystem removal failures. That preexisting diagnostic defect has been flagged for its cleanup owner and is not claimed fixed here.


Maintainer disposition of [ClawSweeper review](https://github.com/openclaw/openclaw/pull/132659#issuecomment-5463228838): no introduced correctness or security finding. Both before-merge items are addressed. [Exact-head CI run 33259709152](https://github.com/openclaw/openclaw/actions/runs/33259709152) completed green on `32eba00d42e134778b885d65d91bdaaf7a0ebafd`. The +129 production lines are accepted for the canonical lifecycle owner: the prior single-current-child representation cannot own concurrent commands or preserve unconfirmed process identity for a later stop. Leader-only AbortSignal handling and promise races cannot enforce the same process-tree/lease invariant. No separate Rank-up moves or source repair were requested; no re-review is needed for this unchanged reviewed head.
