### PR TITLE
fix(cli): fail sessions tail on follow read errors

### DIFF
--- a/src/commands/sessions-tail.test.ts
+++ b/src/commands/sessions-tail.test.ts
@@ -284,6 +284,31 @@ describe("sessionsTailCommand", () => {
     expect(output).toContain("sqlite ok");
   });
 
+  it("exits unsuccessfully when the followed trajectory store becomes unreadable", async () => {
+    vi.useFakeTimers();
+    const runtime = makeRuntime();
+    await writeSessionEntry();
+    await appendEvents([makeEvent({ type: "session.started", ts: "2026-05-18T12:04:17.000Z" })]);
+
+    const run = sessionsTailCommand(
+      { agent: "main", store: storePath, sessionKey, tail: "0", follow: true },
+      runtime,
+    );
+    closeOpenClawAgentDatabasesForTest();
+    fs.writeFileSync(storePath, "not a SQLite database");
+    try {
+      await vi.advanceTimersByTimeAsync(1_000);
+    } finally {
+      process.emit("SIGTERM", "SIGTERM");
+      await run;
+    }
+
+    expect(runtime.error).toHaveBeenCalledWith(
+      expect.stringContaining(`Failed to read trajectory progress for ${sessionKey}`),
+    );
+    expect(runtime.exit).toHaveBeenCalledWith(1);
+  });
+
   it("resolves the target store from a fully qualified non-default agent session key", async () => {
     const runtime = makeRuntime();
     const opsSessionKey = "agent:ops:telegram:direct:owner";

--- a/src/commands/sessions-tail.ts
+++ b/src/commands/sessions-tail.ts
@@ -274,6 +274,7 @@ async function followSelections(
               error,
             )}`,
           );
+          runtime.exit(1);
         }
       }
     }, FOLLOW_INTERVAL_MS);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators using `openclaw sessions tail --follow` could see a trajectory-store read error but the command would keep polling. A later signal could then end the command successfully, so monitoring automation could treat an unreadable session trajectory as healthy.

This PR is AI-assisted. I reviewed the implementation and understand the shipped behavior.

## Why This Change Was Made

The follow loop now exits with status 1 at the existing CLI runtime boundary after reporting a trajectory read failure. This keeps the diagnostic and terminal outcome aligned without adding a retry, fallback reader, config surface, or second error policy.

The existing `RuntimeEnv.exit` seam is the canonical CLI mechanism; an external library or plugin cannot correct this process-level outcome. Initial snapshot failures already propagate through the command, and all followed selections share this same owner catch.

## User Impact

`openclaw sessions tail --follow` now fails visibly and returns a nonzero status when its SQLite trajectory store becomes unreadable. Valid stores and ordinary event following are unchanged.

Production LOC: `+1/-0`. Test LOC: `+25/-0`. No config, protocol, schema, security, compatibility, or upgrade impact.

## Evidence

Product head SHA: `65cfa2e833439ed6ecc3860689f82cf98a3ad182`

Production entry and exact command (Node 24.15.0+):

```bash
proof_dir=$(mktemp -d)
proof_store="$proof_dir/sessions.sqlite"
proof_key="agent:main:telegram:direct:owner"

export OPENCLAW_STATE_DIR="$proof_dir/state"
export OPENCLAW_CONFIG_PATH="$proof_dir/openclaw.json"
export PROOF_STORE="$proof_store"
export PROOF_KEY="$proof_key"

node --import ./scripts/tsx.mjs --input-type=module -e '
  import { upsertSessionEntryCore } from "./src/config/sessions/session-accessor.ts";
  import { appendSqliteTrajectoryRuntimeEvents } from "./src/trajectory/runtime-store.sqlite.ts";
  const storePath = process.env.PROOF_STORE;
  const sessionKey = process.env.PROOF_KEY;
  await upsertSessionEntryCore(
    { sessionKey, storePath },
    { sessionId: "proof-session", updatedAt: Date.now(), status: "running" },
  );
  appendSqliteTrajectoryRuntimeEvents(
    { agentId: "main", sessionId: "proof-session", storePath },
    [{
      traceSchema: "openclaw-trajectory",
      schemaVersion: 1,
      traceId: "proof-trace",
      source: "runtime",
      seq: 1,
      sessionId: "proof-session",
      sessionKey,
      type: "session.started",
      ts: new Date().toISOString(),
    }],
  );
'

node --import ./scripts/tsx.mjs src/entry.ts sessions tail \
  --store "$proof_store" --agent main --session-key "$proof_key" \
  --tail 1 --follow >"$proof_dir/stdout.log" 2>"$proof_dir/stderr.log" &
proof_pid=$!
for proof_attempt in $(seq 1 120); do
  rg -q "session.started" "$proof_dir/stdout.log" && break
  kill -0 "$proof_pid" 2>/dev/null || break
  sleep 1
done
printf '%s' "not a SQLite database" >"$proof_store"
set +e
wait "$proof_pid"
proof_status=$?
set -e
jq -n --argjson status "$proof_status" \
  --rawfile stdout "$proof_dir/stdout.log" \
  --rawfile stderr "$proof_dir/stderr.log" \
  '{
    initialEvent: ($stdout | contains("session.started")),
    error: ($stderr | contains("Failed to read trajectory progress")),
    exitCode: $status
  }'
rm -rf "$proof_dir"
```

Canonical owner exercised: `sessionsTailCommand` -> follow interval -> SQLite trajectory reader -> `RuntimeEnv.exit`.

Recorder/readback boundary: real SQLite session/trajectory store, CLI stdout/stderr, and shell exit status.

Parent-red observation: the regression test produced 7 passes and one intended failure; the error diagnostic matched, but `runtime.exit(1)` had zero calls. The same source CLI scenario could report the malformed database and remain alive until externally stopped.

Head-green observation:

```json
{"initialEvent":true,"error":true,"exitCode":1}
```

The stderr readback contained `Failed to read trajectory progress for agent:main:telegram:direct:owner: database disk image is malformed`.

Legal control / must-not-fire result: the same invocation first read and rendered the valid `session.started` event. The full focused file passed 8/8, covering valid snapshots, valid follow updates, missing events, selection, and tail parsing.

Focused validation:

```text
pnpm dlx node@24.15.0 scripts/run-vitest.mjs src/commands/sessions-tail.test.ts
8 passed
oxfmt --check src/commands/sessions-tail.ts src/commands/sessions-tail.test.ts
git diff --check
```

Cleanup and limitations: the proof removed its temporary directory and process. It covers one followed session and a terminal SQLite read failure; it does not exercise transient lock contention or a multi-session partial failure.

Fresh competition scans at admission, parent-red, and pre-push found no viable PR implementing this terminal outcome. Open PR #125905 adds rendered trajectory metrics, while draft #116437 moves session-store ownership; neither changes follow-read failure handling.
