### PR TITLE
fix(browser): unblock Chromium native bootstrap verification

### DIFF
--- a/extensions/browser/chrome-extension/bootstrap.chromium.test.ts
+++ b/extensions/browser/chrome-extension/bootstrap.chromium.test.ts
@@ -15,6 +15,7 @@ import {
   stableChromeExtensionDir,
 } from "../src/browser/extension-install-layout.js";
 import { installChromeExtensionBootstrap } from "../src/browser/extension-install.js";
+import { useNativeHostLaunchFixture } from "../src/browser/extension-install.test-support.js";
 import { handleGatewayExtensionUpgrade } from "../src/browser/extension-relay/gateway-relay-route.js";
 import { getPageForTargetId } from "../src/browser/pw-session.js";
 import { createBrowserRouteDispatcher } from "../src/browser/routes/dispatcher.js";
@@ -37,6 +38,7 @@ const runE2E =
   (process.platform === "linux" || process.platform === "darwin");
 const cleanups: Array<() => Promise<void>> = [];
 const STORE_ORIGIN = "chrome-extension://kcdjddhmeafeomebliikmbpblkmkfoig/";
+const nativeHostFixture = useNativeHostLaunchFixture();
 
 afterEach(async () => {
   for (const cleanup of cleanups.splice(0).toReversed()) {
@@ -201,7 +203,8 @@ describe.runIf(runE2E)("Chrome native bootstrap Chromium E2E", () => {
         const extensionSource = path.dirname(fileURLToPath(import.meta.url));
         // Match installation: Chrome launches the built host, not a fresh tsx
         // compilation of the source graph inside each bounded native request.
-        const nativeHostPath = await fs.realpath(
+        const launchFixture = await nativeHostFixture(
+          root,
           path.resolve("dist/extensions/browser/native-host-entry.js"),
         );
         const deps = {
@@ -215,8 +218,7 @@ describe.runIf(runE2E)("Chrome native bootstrap Chromium E2E", () => {
             OPENCLAW_CONFIG_PATH: configPath,
             OPENCLAW_GATEWAY_PORT: String(gatewayPort),
           },
-          nodePath: process.execPath,
-          nativeHostPath,
+          ...launchFixture,
         };
         const gatewayServer = http.createServer((req, res) => {
           if (req.url === "/browser-owner-proof") {
@@ -309,14 +311,35 @@ describe.runIf(runE2E)("Chrome native bootstrap Chromium E2E", () => {
           waitMs: 15_000,
           deps,
         });
-        await expect
-          .poll(
-            async () => await exactOwnedManifestsExist(relevantManifestPaths, expectedOrigins),
-            {
-              timeout: 15_000,
-            },
-          )
-          .toBe(true);
+        try {
+          await expect
+            .poll(
+              async () => await exactOwnedManifestsExist(relevantManifestPaths, expectedOrigins),
+              {
+                timeout: 15_000,
+              },
+            )
+            .toBe(true);
+        } catch (error) {
+          const status = await installPromise;
+          const modes = await Promise.all(
+            Object.entries(launchFixture).map(async ([kind, target]) => [
+              kind,
+              ((await fs.stat(target)).mode & 0o777).toString(8),
+            ]),
+          );
+          const issues = status.issues.map((issue) =>
+            issue
+              .replaceAll(launchFixture.nativeHostPath, "<native-host>")
+              .replaceAll(launchFixture.nodePath, "<node>")
+              .replaceAll(root, "<fixture>")
+              .replaceAll(extensionSource, "<bundled-extension>"),
+          );
+          throw new Error(
+            `Native host pre-registration failed: ${JSON.stringify({ modes: Object.fromEntries(modes), issues })}`,
+            { cause: error },
+          );
+        }
         process.stderr.write("[browser-extension-e2e] deterministic native host pre-registered\n");
         await loadUnpackedExtension(context, installed);
         const extensionId = await waitForExtensionId(context, installed);

--- a/extensions/browser/src/browser/extension-install.native-host.e2e.test.ts
+++ b/extensions/browser/src/browser/extension-install.native-host.e2e.test.ts
@@ -2,32 +2,20 @@ import { spawnSync } from "node:child_process";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest";
 import { relayTestKey } from "../../chrome-extension/relay-key.test-support.js";
 import { chromeProductRoots, installStableChromeExtension } from "./extension-install-layout.js";
 import { installChromeExtensionBootstrap } from "./extension-install.js";
 import {
   predictedId,
   useExtensionInstallFixture,
+  useNativeHostLaunchFixture,
   writeSecurePreferences,
 } from "./extension-install.test-support.js";
 
 const BUILT_NATIVE_HOST_PATH = path.resolve("dist/extensions/browser/native-host-entry.js");
 const fixture = useExtensionInstallFixture();
-const fileModesToRestore: Array<{ target: string; mode: number }> = [];
-
-afterEach(async () => {
-  await Promise.all(fileModesToRestore.splice(0).map(({ target, mode }) => fs.chmod(target, mode)));
-});
-
-async function makeTestFilePrivate(target: string): Promise<void> {
-  if (process.platform === "win32") {
-    return;
-  }
-  const mode = (await fs.stat(target)).mode & 0o777;
-  fileModesToRestore.push({ target, mode });
-  await fs.chmod(target, mode & ~0o022);
-}
+const nativeHostFixture = useNativeHostLaunchFixture();
 
 // Automatic native script launchers are POSIX-only; Windows uses manual pairing.
 describe.skipIf(process.platform === "win32")("native host registration", () => {
@@ -35,20 +23,13 @@ describe.skipIf(process.platform === "win32")("native host registration", () => 
     const value = await fixture();
     const stateDir = path.join(value.root, "custom state's dir");
     const configPath = path.join(value.root, "custom config's dir", "openclaw.json");
-    const nativeHostPath = BUILT_NATIVE_HOST_PATH;
-    // Keep shared-library Node installs in place, without changing a hosted
-    // interpreter's permissions. The installed launcher still targets a private file.
-    const nodeExecutable = `'${process.execPath.replaceAll("'", `'"'"'`)}'`;
-    await fs.writeFile(value.deps.nodePath, `#!/bin/sh\nexec ${nodeExecutable} "$@"\n`, {
-      mode: 0o700,
-    });
-    await makeTestFilePrivate(nativeHostPath);
+    const launchFixture = await nativeHostFixture(value.root, BUILT_NATIVE_HOST_PATH);
     const relayPort = 19_031;
     const token = relayTestKey(4);
     const deps = {
       ...value.deps,
       stateDir,
-      nativeHostPath,
+      ...launchFixture,
       env: {
         ...value.deps.env,
         OPENCLAW_STATE_DIR: stateDir,

--- a/extensions/browser/src/browser/extension-install.test-support.ts
+++ b/extensions/browser/src/browser/extension-install.test-support.ts
@@ -24,6 +24,29 @@ export async function writeSecurePreferences(params: {
   return file;
 }
 
+export function useNativeHostLaunchFixture() {
+  const modesToRestore: Array<{ target: string; mode: number }> = [];
+  afterEach(async () => {
+    for (const { target, mode } of modesToRestore.splice(0).toReversed()) {
+      await fs.chmod(target, mode);
+    }
+  });
+  return async (root: string, nativeHostEntry: string) => {
+    const nativeHostPath = await fs.realpath(nativeHostEntry);
+    const mode = (await fs.stat(nativeHostPath)).mode & 0o777;
+    modesToRestore.push({ target: nativeHostPath, mode });
+    await fs.chmod(nativeHostPath, mode & ~0o022);
+
+    // Built entries can inherit group-write permissions, and hosted Node can
+    // be shared-library linked. Keep the real interpreter in place behind a
+    // private launcher; never loosen the installer's target-permission guard.
+    const nodePath = path.join(root, "native-host-node");
+    const nodeExecutable = `'${process.execPath.replaceAll("'", `'"'"'`)}'`;
+    await fs.writeFile(nodePath, `#!/bin/sh\nexec ${nodeExecutable} "$@"\n`, { mode: 0o700 });
+    return { nativeHostPath, nodePath };
+  };
+}
+
 export function useExtensionInstallFixture() {
   // Register before caller cleanup hooks so Vitest restores mocks before deleting fixtures.
   const tempRoots = useAutoCleanupTempDirTracker(afterEach);


### PR DESCRIPTION
Related: #132485

## What Problem This Solves

Resolves a problem where full release verification stops during Chrome extension setup, before loading the extension or making its first native call. On the reproduced Linux build, the native-host entry was group-writable (`0664`), so the installer's security check correctly refused registration; the test only reported a 15-second manifest readiness timeout.

## Why This Change Was Made

Reuse the existing compiled native-host E2E fixture's permission handling in both real entrypoints. The shared fixture temporarily removes group/world-write bits from the test-owned built entry, restores its original mode afterward, and invokes the real Node interpreter through a private launcher without modifying the shared interpreter. The Chromium failure path also reports target modes and installer issues with fixture paths removed.

The installer and its permission guards remain unchanged. All Chromium scenario assertions, native-host framing checks, and deadlines are preserved. The switch from a source launcher to the built host in #132485 exposed this fixture mismatch.

## User Impact

No shipped runtime or configuration change. Release verification now reaches the actual browser bootstrap, pairing, reconnect, tab ownership, screenshot, and revocation checks instead of failing on fixture setup permissions.

## Evidence

The original frozen release job failed at pre-registration: [CI job 99110564049](https://github.com/openclaw/openclaw/actions/runs/33256281622/job/99110564049).

Before/after Linux proof used one [Blacksmith Testbox](https://github.com/openclaw/openclaw/actions/runs/33258101362) and frozen source `d9fe780239a2cb7158aad437112156605e8d375c`:

| Proof | Result |
| --- | --- |
| Before: unchanged scenario plus diagnostic capture | Fails at the same pre-registration poll; installer explicitly refuses the built entry at `0664`. Interpreter `0755`, source `0755`, profile `0700`; all inspected paths canonical. |
| After: full real Chromium scenario | 1 passed, 0 skipped; 22.67-second test body. |
| After: built native-host custom-installation-context E2E | 1 passed, 0 skipped. |
| Existing registration and layout permission tests | 44 passed. |
| Built-entry permission restoration | `0664` before and after. |

The after proof reused the baseline's unchanged build and completed all checks in 57.965 seconds. Remote synthetic sync commit `543ce06d5113d8d4caebd201df07a15ac1559f5a` differs from frozen `d9fe7802` in exactly the three test/support files in this PR; the installer, layout owner, and lockfile hashes match. The successful remote command emitted `exitCode: 0`; a subsequent local wrapper shutdown after that final receipt does not change the test result.

The full changed-file gate and configured isolated autoreview passed. Production LOC: +0/-0. Test and test-support LOC: +62/-35. No changelog is needed for this internal verification repair.
