### PR TITLE
perf(tools): load image sanitizer only for image results

### DIFF
--- a/src/agents/tool-images.runtime.ts
+++ b/src/agents/tool-images.runtime.ts
@@ -1,0 +1,2 @@
+// Keep lazy image sanitization reachable across in-place dist rebuilds.
+export { sanitizeToolResultImages } from "./tool-images.js";

--- a/src/agents/tools/common.ts
+++ b/src/agents/tools/common.ts
@@ -21,7 +21,6 @@ import type {
   AgentToolResult,
   AgentToolUpdateCallback,
 } from "../runtime/index.js";
-import { sanitizeToolResultImages } from "../tool-images.js";
 import { registerTrustedToolInputError } from "../tool-result-error.js";
 import { textResult } from "./tool-results.js";
 
@@ -517,6 +516,7 @@ async function imageResult(params: {
       },
     },
   };
+  const { sanitizeToolResultImages } = await import("../tool-images.js");
   return await sanitizeToolResultImages(result, params.label, params.imageSanitization);
 }
 

--- a/src/agents/tools/common.ts
+++ b/src/agents/tools/common.ts
@@ -516,7 +516,7 @@ async function imageResult(params: {
       },
     },
   };
-  const { sanitizeToolResultImages } = await import("../tool-images.js");
+  const { sanitizeToolResultImages } = await import("../tool-images.runtime.js");
   return await sanitizeToolResultImages(result, params.label, params.imageSanitization);
 }
 

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -381,6 +381,7 @@ function buildCoreDistEntries(): Record<string, string> {
     "agents/auth-profiles.runtime": "src/agents/auth-profiles.runtime.ts",
     "agents/model-catalog.runtime": "src/agents/model-catalog.runtime.ts",
     "agents/models-config.runtime": "src/agents/models-config.runtime.ts",
+    "agents/tool-images.runtime": "src/agents/tool-images.runtime.ts",
     "agents/code-mode.worker": "src/agents/code-mode.worker.ts",
     "agents/compaction-planning.worker": "src/agents/compaction-planning.worker.ts",
     "agents/model-provider-auth.worker": "src/agents/model-provider-auth.worker.ts",


### PR DESCRIPTION
## What Problem This Solves

Importing shared tool parameter readers also loads image processing even when the caller only constructs a tool schema. Public web-provider discovery pays this cost through DuckDuckGo's parameter-reader dependency.

## Why This Change Was Made

Load the sanitizer inside the existing asynchronous image-result function, immediately before its unchanged awaited call. A registered `tool-images.runtime` entry gives this lazy boundary a stable filename across in-place builds, following the existing model-config runtime facade. The sanitizer implementation and its static consumers remain unchanged; parameter readers, errors, MIME detection and safe-filesystem initialization retain their original module identities and timing.

The original direct lazy import emitted a hashed chunk. ClawSweeper correctly identified that a running process could lose its first image call after an in-place rebuild. The revision fixes that owner boundary and addresses the review's stable-entry and build-check rank-up move. A full implementation rename was unnecessary: the existing runtime-facade convention supplies the stable build contract without changing unrelated imports or log identity.

Production +3/-1 (net +2), build configuration +1, tests unchanged. The growth is the documented stable runtime export and its build entry. No public API, configuration, schema, sharding, worker count, scheduling or test-selection changes.

## User Impact

Parameter-only and provider-discovery paths avoid image-processing startup. Actual image results still always pass through the same sanitizer with the same limits; resizing, metadata and filesystem policy remain unchanged.

## Evidence

- Original paired measurements: all 17 public-artifact cases pass; execution 4.303s before and 2.064s after. DuckDuckGo discovery falls from 2.550s to 0.231s on the same baseline.
- A real process loaded the old built public SDK, exercised its parameter reader, and retained its image function while the entire private `dist` copy was replaced by a new full build. Its first image call failed with `ERR_MODULE_NOT_FOUND` for the removed hashed sanitizer wrapper.
- The same retained-process proof passes between two full repaired builds with different sanitizer hashes and the old hash absent. A load observer proves the sanitizer was cold before replacement; the stable entry loads the new implementation. Exact PNG bytes/MIME/text/private-media metadata survive, and actual backend resizing changes 16x16 to 8x8.
- The source probe also verifies public parameter-function identity, genuine versus forged trusted errors, exact image output, resizing, and missing-file/directory/symlink error codes. The original eager source fails its cold-import expectation; ignoring sanitization limits fails its independent dimension assertion.
- Both full builds pass with zero `INEFFECTIVE_DYNAMIC_IMPORT` warnings. The final production sanitizer is byte-identical to the original implementation; the alternate build used a temporary diagnostic-label change only to force a distinct real chunk hash.
- All 538 focused parsing, sanitizer, filesystem, DuckDuckGo, browser and build-helper cases pass. The 17-provider suite passes again at 1.929s, with DuckDuckGo at 0.225s.
- A cold parameter-import probe reports 215.9 MiB RSS with the eager dependency restored in the loader and 143.5 MiB with the stable lazy entry.
- The complete changed-file gate, including all typechecks, lint and import-cycle checks, passes. Independent Codex autoreview of the repair reports no actionable findings.

This build-replacement regression is checked with actual generated artifacts rather than a source-string unit test. Existing sanitizer, browser-image composition, stable-alias and stale-chunk-pruning tests remain the normal automated coverage. No live provider requests are needed for this unchanged internal import boundary.
