### PR TITLE
fix(codex): restore configured channel tool progress

### DIFF
--- a/extensions/codex/src/app-server/event-projector-events.ts
+++ b/extensions/codex/src/app-server/event-projector-events.ts
@@ -122,8 +122,6 @@ export function projectNormalizedToolItem(params: {
         stream: "tool",
         data: {
           phase: params.phase,
-          // Codex tool lifecycle is private telemetry; channels render authored progress only.
-          hideFromChannelProgress: true,
           name,
           itemId: item.id,
           toolCallId: item.id,

--- a/extensions/codex/src/app-server/event-projector-tool-progress.ts
+++ b/extensions/codex/src/app-server/event-projector-tool-progress.ts
@@ -481,10 +481,8 @@ export class CodexToolProgressProjection {
 
   private shouldIncludeFormattedMeta(commandBearing: boolean): boolean {
     // Channel command detail comes from structured events, where commandText policy applies.
-    return (
-      !commandBearing ||
-      (!this.params.messageChannel && !this.params.messageProvider && this.shouldEmitToolOutput())
-    );
+    const channel = this.params.messageChannel ?? this.params.messageProvider;
+    return !commandBearing || (!channel && this.shouldEmitToolOutput());
   }
 
   private emitTranscriptToolCallProgress(params: ToolTranscriptCallInput): void {

--- a/extensions/codex/src/app-server/event-projector-tool-progress.ts
+++ b/extensions/codex/src/app-server/event-projector-tool-progress.ts
@@ -327,10 +327,9 @@ export class CodexToolProgressProjection {
       return;
     }
     this.resultSummaryItemIds.add(item.id);
-    const meta =
-      this.shouldEmitToolOutput() || !isCommandBearingToolItem(item, args)
-        ? itemMeta(item, this.toolProgressDetailMode())
-        : undefined;
+    const meta = this.shouldIncludeFormattedMeta(isCommandBearingToolItem(item, args))
+      ? itemMeta(item, this.toolProgressDetailMode())
+      : undefined;
     this.emitToolResultMessage({
       itemId: item.id,
       text: formatToolSummary(toolName, meta),
@@ -349,9 +348,12 @@ export class CodexToolProgressProjection {
     if (!toolName || !output || !shouldEmitTranscriptToolProgress(toolName, itemToolArgs(item))) {
       return;
     }
+    const meta = this.shouldIncludeFormattedMeta(isCommandBearingToolItem(item, itemToolArgs(item)))
+      ? itemMeta(item, this.toolProgressDetailMode())
+      : undefined;
     this.emitToolResultMessage({
       itemId: item.id,
-      text: formatToolOutput(toolName, itemMeta(item, this.toolProgressDetailMode()), output),
+      text: formatToolOutput(toolName, meta, output),
       finalOutput: true,
       isError: isNonSuccessItemStatus(itemStatus(item)),
     });
@@ -477,18 +479,25 @@ export class CodexToolProgressProjection {
       : this.params.verboseLevel === "full";
   }
 
+  private shouldIncludeFormattedMeta(commandBearing: boolean): boolean {
+    // Channel command detail comes from structured events, where commandText policy applies.
+    return (
+      !commandBearing ||
+      (!this.params.messageChannel && !this.params.messageProvider && this.shouldEmitToolOutput())
+    );
+  }
+
   private emitTranscriptToolCallProgress(params: ToolTranscriptCallInput): void {
     if (!shouldEmitTranscriptToolProgress(params.name, params.arguments)) {
       return;
     }
     this.transcriptProgressCallIds.add(params.id);
     const args = normalizeToolTranscriptArguments(params.arguments);
-    const meta =
-      this.shouldEmitToolOutput() || !isCodexCommandBearingToolCall(params.name, args)
-        ? inferToolMetaFromArgs(params.name, args, {
-            detailMode: this.toolProgressDetailMode(),
-          })
-        : undefined;
+    const meta = this.shouldIncludeFormattedMeta(isCodexCommandBearingToolCall(params.name, args))
+      ? inferToolMetaFromArgs(params.name, args, {
+          detailMode: this.toolProgressDetailMode(),
+        })
+      : undefined;
     if (
       !this.params.onToolResult ||
       !this.shouldEmitToolResult() ||

--- a/extensions/codex/src/app-server/event-projector-tool-progress.ts
+++ b/extensions/codex/src/app-server/event-projector-tool-progress.ts
@@ -453,10 +453,6 @@ export class CodexToolProgressProjection {
     if (params.finalOutput) {
       this.resultOutputItemIds.add(params.itemId);
     }
-    // Channel drafts consume structured events; this legacy formatted callback must stay private.
-    if (this.params.messageChannel || this.params.messageProvider) {
-      return;
-    }
     try {
       void Promise.resolve(
         this.params.onToolResult?.({

--- a/extensions/codex/src/app-server/event-projector-tool-progress.ts
+++ b/extensions/codex/src/app-server/event-projector-tool-progress.ts
@@ -459,6 +459,9 @@ export class CodexToolProgressProjection {
       void Promise.resolve(
         this.params.onToolResult?.({
           text,
+          ...((this.params.messageChannel || this.params.messageProvider) && {
+            channelData: { openclawToolProgressId: params.itemId },
+          }),
           ...(params.isError === true ? { isError: true } : {}),
         }),
       ).catch(() => {});

--- a/extensions/codex/src/app-server/event-projector.dynamic-tools.test.ts
+++ b/extensions/codex/src/app-server/event-projector.dynamic-tools.test.ts
@@ -264,15 +264,11 @@ describe("CodexAppServerEventProjector dynamic tool projection", () => {
     });
   });
 
-  it.each([
-    ["non-channel", undefined, 1],
-    ["channel", "telegram", 0],
-  ] as const)("handles transcript tool summaries for %s runs", async (_, messageChannel, calls) => {
+  it("emits verbose summaries for transcript-recorded dynamic tool calls", async () => {
     const onAgentEvent = vi.fn();
     const onToolResult = vi.fn();
     const projector = await createProjector({
       ...(await createParams()),
-      ...(messageChannel ? { messageChannel } : {}),
       verboseLevel: "on",
       onAgentEvent,
       onToolResult,
@@ -283,28 +279,15 @@ describe("CodexAppServerEventProjector dynamic tool projection", () => {
       tool: "browser",
       arguments: { action: "open", url: "http://127.0.0.1:3000" },
     });
-    projector.recordDynamicToolResult({
-      callId: "call-browser-1",
-      tool: "browser",
-      success: true,
-      contentItems: [{ type: "inputText", text: "opened" }],
-    });
 
     const toolEvents = onAgentEvent.mock.calls.filter(([event]) => {
       const record = requireRecord(event, "agent event");
       return record.stream === "tool";
     });
     expect(toolEvents).toHaveLength(0);
-    expect(onToolResult).toHaveBeenCalledTimes(calls);
-    if (calls > 0) {
-      const payload = mockCallArg(onToolResult, 0, 0, "onToolResult") as { text?: string };
-      expect(payload.text).toContain("Browser");
-    }
-    const messages = projector.buildResult(buildEmptyToolTelemetry()).messagesSnapshot;
-    expect(requireRecord(messages[2], "tool result")).toMatchObject({
-      role: "toolResult",
-      toolCallId: "call-browser-1",
-    });
+    expect(onToolResult).toHaveBeenCalledTimes(1);
+    const payload = mockCallArg(onToolResult, 0, 0, "onToolResult") as { text?: string };
+    expect(payload.text).toContain("Browser");
   });
 
   it("does not replay transcript summaries when only tool output is enabled", async () => {

--- a/extensions/codex/src/app-server/event-projector.native-finalization.test.ts
+++ b/extensions/codex/src/app-server/event-projector.native-finalization.test.ts
@@ -366,7 +366,6 @@ describe("CodexAppServerEventProjector native tool finalization", () => {
       itemId: "cmd-snapshot",
       name: "bash",
     }).data;
-    expect(toolStart.hideFromChannelProgress).toBe(true);
     expect(toolStart.args).toEqual({ command: "pnpm test extensions/codex", cwd: "/workspace" });
     const toolResult = findAgentEvent(onAgentEvent, {
       stream: "tool",
@@ -374,7 +373,6 @@ describe("CodexAppServerEventProjector native tool finalization", () => {
       itemId: "cmd-snapshot",
       name: "bash",
     }).data;
-    expect(toolResult.hideFromChannelProgress).toBe(true);
     expect(toolResult.status).toBe("completed");
     expect(toolResult.isError).toBe(false);
     expect(onToolResult).toHaveBeenCalledWith({

--- a/extensions/codex/src/app-server/event-projector.replay-safety.test.ts
+++ b/extensions/codex/src/app-server/event-projector.replay-safety.test.ts
@@ -261,11 +261,7 @@ describe("CodexAppServerEventProjector replay safety and progress projection", (
         itemId: "mcp-command-1",
         name: "server.exec",
       }).data,
-    ).toMatchObject({
-      commandBearing: true,
-      hideFromChannelProgress: true,
-      isError: false,
-    });
+    ).toMatchObject({ commandBearing: true, isError: false });
   });
 
   it("treats native collaboration calls as side-effect evidence", async () => {

--- a/extensions/codex/src/app-server/run-attempt-server-requests.ts
+++ b/extensions/codex/src/app-server/run-attempt-server-requests.ts
@@ -176,6 +176,11 @@ export function createCodexAttemptServerRequestController(
         name: call.tool,
         arguments: call.arguments,
       });
+      projector?.recordDynamicToolCall({
+        callId: call.callId,
+        tool: call.tool,
+        arguments: call.arguments,
+      });
       emitExecutionPhaseOnce(`tool:${call.callId}`, {
         phase: "tool_execution_started",
         tool: call.tool,
@@ -189,11 +194,12 @@ export function createCodexAttemptServerRequestController(
       const commandBearing = isCodexCommandBearingToolCall(call.tool, toolArgs);
       const shouldEmitDynamicToolProgress = shouldEmitTranscriptToolProgress(call.tool, toolArgs);
       if (shouldEmitDynamicToolProgress) {
-        await emitCodexAppServerEvent(params, {
+        void emitCodexAppServerEvent(params, {
           stream: "tool",
           data: {
             phase: "start",
             name: call.tool,
+            itemId: call.callId,
             toolCallId: call.callId,
             ...(toolMeta ? { meta: toolMeta } : {}),
             ...(toolArgs ? { args: toolArgs } : {}),
@@ -201,12 +207,6 @@ export function createCodexAttemptServerRequestController(
           },
         });
       }
-      // Emit the keyed row first so channels coalesce the formatted summary into it.
-      projector?.recordDynamicToolCall({
-        callId: call.callId,
-        tool: call.tool,
-        arguments: call.arguments,
-      });
       const dynamicToolTimeoutMs = resolveDynamicToolCallTimeoutMs({ call, config: params.config });
       const toolStartedAt = Date.now();
       let terminalDiagnosticObserved = false;
@@ -306,6 +306,7 @@ export function createCodexAttemptServerRequestController(
             data: {
               phase: "result",
               name: call.tool,
+              itemId: call.callId,
               toolCallId: call.callId,
               ...(toolMeta ? { meta: toolMeta } : {}),
               ...(commandBearing ? { commandBearing: true } : {}),

--- a/extensions/codex/src/app-server/run-attempt-server-requests.ts
+++ b/extensions/codex/src/app-server/run-attempt-server-requests.ts
@@ -176,11 +176,6 @@ export function createCodexAttemptServerRequestController(
         name: call.tool,
         arguments: call.arguments,
       });
-      projector?.recordDynamicToolCall({
-        callId: call.callId,
-        tool: call.tool,
-        arguments: call.arguments,
-      });
       emitExecutionPhaseOnce(`tool:${call.callId}`, {
         phase: "tool_execution_started",
         tool: call.tool,
@@ -206,6 +201,12 @@ export function createCodexAttemptServerRequestController(
           },
         });
       }
+      // Emit the keyed row first so channels coalesce the formatted summary into it.
+      projector?.recordDynamicToolCall({
+        callId: call.callId,
+        tool: call.tool,
+        arguments: call.arguments,
+      });
       const dynamicToolTimeoutMs = resolveDynamicToolCallTimeoutMs({ call, config: params.config });
       const toolStartedAt = Date.now();
       let terminalDiagnosticObserved = false;

--- a/extensions/codex/src/app-server/run-attempt-server-requests.ts
+++ b/extensions/codex/src/app-server/run-attempt-server-requests.ts
@@ -189,7 +189,7 @@ export function createCodexAttemptServerRequestController(
       const commandBearing = isCodexCommandBearingToolCall(call.tool, toolArgs);
       const shouldEmitDynamicToolProgress = shouldEmitTranscriptToolProgress(call.tool, toolArgs);
       if (shouldEmitDynamicToolProgress) {
-        void emitCodexAppServerEvent(params, {
+        await emitCodexAppServerEvent(params, {
           stream: "tool",
           data: {
             phase: "start",

--- a/extensions/codex/src/app-server/run-attempt-server-requests.ts
+++ b/extensions/codex/src/app-server/run-attempt-server-requests.ts
@@ -198,8 +198,6 @@ export function createCodexAttemptServerRequestController(
           stream: "tool",
           data: {
             phase: "start",
-            // OpenClaw tool execution stays observable without becoming public channel content.
-            hideFromChannelProgress: true,
             name: call.tool,
             toolCallId: call.callId,
             ...(toolMeta ? { meta: toolMeta } : {}),
@@ -306,7 +304,6 @@ export function createCodexAttemptServerRequestController(
             stream: "tool",
             data: {
               phase: "result",
-              hideFromChannelProgress: true,
               name: call.tool,
               toolCallId: call.callId,
               ...(toolMeta ? { meta: toolMeta } : {}),

--- a/extensions/codex/src/app-server/run-attempt.channel-tool-progress.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.channel-tool-progress.test.ts
@@ -75,10 +75,14 @@ describe("Codex channel tool progress", () => {
     const presentationOrder: string[] = [];
     params.messageChannel = "telegram";
     params.verboseLevel = "on";
-    params.onAgentEvent = (event) => {
+    params.onAgentEvent = async (event) => {
       onAgentEvent(event);
       if (event.stream === "tool") {
         presentationOrder.push(`event:${event.data.phase}`);
+      }
+      if (event.stream === "tool" && event.data.toolCallId === "dynamic-1") {
+        await Promise.resolve();
+        presentationOrder.push(`event:${event.data.phase}:complete`);
       }
     };
     params.onToolResult = (payload) => {
@@ -220,8 +224,9 @@ describe("Codex channel tool progress", () => {
         resultCount + 1,
       );
       if (testCase.label === "OpenClaw dynamic tool") {
-        expect(presentationOrder.slice(presentationCount, presentationCount + 2)).toEqual([
+        expect(presentationOrder.slice(presentationCount, presentationCount + 3)).toEqual([
           "event:start",
+          "event:start:complete",
           "summary",
         ]);
       }

--- a/extensions/codex/src/app-server/run-attempt.channel-tool-progress.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.channel-tool-progress.test.ts
@@ -1,0 +1,165 @@
+import path from "node:path";
+import { describe, expect, it, vi } from "vitest";
+import { itemNotification } from "./protocol.test-helpers.js";
+import {
+  createParams,
+  createStartedThreadHarness,
+  runCodexAppServerAttempt,
+  setupRunAttemptTestHooks,
+  tempDir,
+} from "./run-attempt-test-harness.js";
+
+setupRunAttemptTestHooks();
+
+describe("Codex channel tool progress", () => {
+  it("keeps every tool source available to channel policy and verbose callbacks", async () => {
+    const harness = createStartedThreadHarness();
+    const params = createParams(
+      path.join(tempDir, "channel-tool-progress-session.jsonl"),
+      path.join(tempDir, "channel-tool-progress-workspace"),
+    );
+    const onAgentEvent = vi.fn();
+    const onToolResult = vi.fn();
+    params.messageChannel = "telegram";
+    params.verboseLevel = "on";
+    params.onAgentEvent = onAgentEvent;
+    params.onToolResult = onToolResult;
+
+    const run = runCodexAppServerAttempt(params);
+    await harness.waitForMethod("turn/start");
+
+    const cases = [
+      {
+        label: "native command",
+        toolCallId: "command-1",
+        name: "bash",
+        drive: async () => {
+          await harness.notify(
+            itemNotification("item/started", {
+              type: "commandExecution",
+              id: "command-1",
+              command: "printf private-command",
+              cwd: params.workspaceDir,
+              status: "inProgress",
+            }),
+          );
+          await harness.notify(
+            itemNotification("item/completed", {
+              type: "commandExecution",
+              id: "command-1",
+              command: "printf private-command",
+              cwd: params.workspaceDir,
+              status: "completed",
+              aggregatedOutput: "done",
+              exitCode: 0,
+              durationMs: 1,
+            }),
+          );
+        },
+      },
+      {
+        label: "native file change",
+        toolCallId: "patch-1",
+        name: "apply_patch",
+        drive: async () => {
+          const item = {
+            type: "fileChange",
+            id: "patch-1",
+            changes: [{ path: "proof.txt", kind: "update" }],
+          };
+          await harness.notify(itemNotification("item/started", { ...item, status: "inProgress" }));
+          await harness.notify(
+            itemNotification("item/completed", { ...item, status: "completed" }),
+          );
+        },
+      },
+      {
+        label: "native web search",
+        toolCallId: "search-1",
+        name: "web_search",
+        drive: async () => {
+          const item = {
+            type: "webSearch",
+            id: "search-1",
+            query: "OpenClaw repository",
+            action: { type: "search", query: "OpenClaw repository" },
+          };
+          await harness.notify(itemNotification("item/started", { ...item, status: "inProgress" }));
+          await harness.notify(
+            itemNotification("item/completed", { ...item, status: "completed", durationMs: 1 }),
+          );
+        },
+      },
+      {
+        label: "native MCP call",
+        toolCallId: "mcp-1",
+        name: "progressproof.parity_probe",
+        drive: async () => {
+          const item = {
+            type: "mcpToolCall",
+            id: "mcp-1",
+            server: "progressproof",
+            tool: "parity_probe",
+            arguments: { marker: "telegram-progress" },
+          };
+          await harness.notify(itemNotification("item/started", { ...item, status: "inProgress" }));
+          await harness.notify(
+            itemNotification("item/completed", {
+              ...item,
+              status: "completed",
+              result: { content: [{ type: "text", text: "ok" }] },
+              durationMs: 1,
+            }),
+          );
+        },
+      },
+      {
+        label: "OpenClaw dynamic tool",
+        toolCallId: "dynamic-1",
+        name: "agents_list",
+        drive: async () => {
+          await harness.handleServerRequest({
+            id: "request-dynamic-1",
+            method: "item/tool/call",
+            params: {
+              threadId: "thread-1",
+              turnId: "turn-1",
+              callId: "dynamic-1",
+              namespace: null,
+              tool: "agents_list",
+              arguments: {},
+            },
+          });
+        },
+      },
+    ];
+
+    for (const testCase of cases) {
+      const resultCount = onToolResult.mock.calls.length;
+      await testCase.drive();
+      const toolEvents = onAgentEvent.mock.calls
+        .map(([event]) => event)
+        .filter(
+          (event) =>
+            event.stream === "tool" &&
+            event.data?.toolCallId === testCase.toolCallId &&
+            event.data?.name === testCase.name,
+        );
+
+      expect(toolEvents, testCase.label).toHaveLength(2);
+      expect(
+        toolEvents.map((event) => event.data?.phase),
+        `${testCase.label} lifecycle`,
+      ).toEqual(["start", "result"]);
+      for (const event of toolEvents) {
+        expect(event.data, testCase.label).not.toHaveProperty("hideFromChannelProgress");
+      }
+      expect(onToolResult.mock.calls.length, `${testCase.label} verbose callback`).toBe(
+        resultCount + 1,
+      );
+    }
+
+    await harness.completeTurn({ threadId: "thread-1", turnId: "turn-1" });
+    await run;
+  });
+});

--- a/extensions/codex/src/app-server/run-attempt.channel-tool-progress.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.channel-tool-progress.test.ts
@@ -72,10 +72,19 @@ describe("Codex channel tool progress", () => {
     );
     const onAgentEvent = vi.fn();
     const onToolResult = vi.fn();
+    const presentationOrder: string[] = [];
     params.messageChannel = "telegram";
     params.verboseLevel = "on";
-    params.onAgentEvent = onAgentEvent;
-    params.onToolResult = onToolResult;
+    params.onAgentEvent = (event) => {
+      onAgentEvent(event);
+      if (event.stream === "tool") {
+        presentationOrder.push(`event:${event.data.phase}`);
+      }
+    };
+    params.onToolResult = (payload) => {
+      onToolResult(payload);
+      presentationOrder.push("summary");
+    };
 
     const run = runCodexAppServerAttempt(params);
     await harness.waitForMethod("turn/start");
@@ -188,6 +197,7 @@ describe("Codex channel tool progress", () => {
 
     for (const testCase of cases) {
       const resultCount = onToolResult.mock.calls.length;
+      const presentationCount = presentationOrder.length;
       await testCase.drive();
       const toolEvents = onAgentEvent.mock.calls
         .map(([event]) => event)
@@ -209,6 +219,12 @@ describe("Codex channel tool progress", () => {
       expect(onToolResult.mock.calls.length, `${testCase.label} verbose callback`).toBe(
         resultCount + 1,
       );
+      if (testCase.label === "OpenClaw dynamic tool") {
+        expect(presentationOrder.slice(presentationCount, presentationCount + 2)).toEqual([
+          "event:start",
+          "summary",
+        ]);
+      }
     }
 
     await harness.completeTurn({ threadId: "thread-1", turnId: "turn-1" });

--- a/extensions/codex/src/app-server/run-attempt.channel-tool-progress.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.channel-tool-progress.test.ts
@@ -12,6 +12,58 @@ import {
 setupRunAttemptTestHooks();
 
 describe("Codex channel tool progress", () => {
+  it("keeps raw command detail behind the channel commandText policy", async () => {
+    const harness = createStartedThreadHarness();
+    const params = createParams(
+      path.join(tempDir, "channel-command-privacy-session.jsonl"),
+      path.join(tempDir, "channel-command-privacy-workspace"),
+    );
+    const onAgentEvent = vi.fn();
+    const onToolResult = vi.fn();
+    params.config = {
+      channels: {
+        telegram: {
+          streaming: { mode: "progress", progress: { commandText: "status" } },
+        },
+      },
+    };
+    params.messageChannel = "telegram";
+    params.toolProgressDetail = "raw";
+    params.verboseLevel = "full";
+    params.onAgentEvent = onAgentEvent;
+    params.onToolResult = onToolResult;
+
+    const run = runCodexAppServerAttempt(params);
+    await harness.waitForMethod("turn/start");
+    await harness.notify(
+      itemNotification("item/started", {
+        type: "commandExecution",
+        id: "private-command-1",
+        command: "printf raw-command-must-stay-private",
+        cwd: params.workspaceDir,
+        status: "inProgress",
+      }),
+    );
+
+    expect(onToolResult).toHaveBeenCalledWith({ text: "🛠️ Bash" });
+    const toolStart = onAgentEvent.mock.calls
+      .map(([event]) => event)
+      .find(
+        (event) =>
+          event.stream === "tool" &&
+          event.data?.phase === "start" &&
+          event.data?.toolCallId === "private-command-1",
+      );
+    expect(toolStart?.data?.args).toEqual({
+      command: "printf raw-command-must-stay-private",
+      cwd: params.workspaceDir,
+    });
+    expect(toolStart?.data?.meta).toContain("raw-command-must-stay-private");
+
+    await harness.completeTurn({ threadId: "thread-1", turnId: "turn-1" });
+    await run;
+  });
+
   it("keeps every tool source available to channel policy and verbose callbacks", async () => {
     const harness = createStartedThreadHarness();
     const params = createParams(

--- a/extensions/codex/src/app-server/run-attempt.channel-tool-progress.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.channel-tool-progress.test.ts
@@ -45,7 +45,10 @@ describe("Codex channel tool progress", () => {
       }),
     );
 
-    expect(onToolResult).toHaveBeenCalledWith({ text: "🛠️ Bash" });
+    expect(onToolResult).toHaveBeenCalledWith({
+      text: "🛠️ Bash",
+      channelData: { openclawToolProgressId: "private-command-1" },
+    });
     const toolStart = onAgentEvent.mock.calls
       .map(([event]) => event)
       .find(
@@ -72,23 +75,10 @@ describe("Codex channel tool progress", () => {
     );
     const onAgentEvent = vi.fn();
     const onToolResult = vi.fn();
-    const presentationOrder: string[] = [];
     params.messageChannel = "telegram";
     params.verboseLevel = "on";
-    params.onAgentEvent = async (event) => {
-      onAgentEvent(event);
-      if (event.stream === "tool") {
-        presentationOrder.push(`event:${event.data.phase}`);
-      }
-      if (event.stream === "tool" && event.data.toolCallId === "dynamic-1") {
-        await Promise.resolve();
-        presentationOrder.push(`event:${event.data.phase}:complete`);
-      }
-    };
-    params.onToolResult = (payload) => {
-      onToolResult(payload);
-      presentationOrder.push("summary");
-    };
+    params.onAgentEvent = onAgentEvent;
+    params.onToolResult = onToolResult;
 
     const run = runCodexAppServerAttempt(params);
     await harness.waitForMethod("turn/start");
@@ -201,7 +191,6 @@ describe("Codex channel tool progress", () => {
 
     for (const testCase of cases) {
       const resultCount = onToolResult.mock.calls.length;
-      const presentationCount = presentationOrder.length;
       await testCase.drive();
       const toolEvents = onAgentEvent.mock.calls
         .map(([event]) => event)
@@ -223,13 +212,9 @@ describe("Codex channel tool progress", () => {
       expect(onToolResult.mock.calls.length, `${testCase.label} verbose callback`).toBe(
         resultCount + 1,
       );
-      if (testCase.label === "OpenClaw dynamic tool") {
-        expect(presentationOrder.slice(presentationCount, presentationCount + 3)).toEqual([
-          "event:start",
-          "event:start:complete",
-          "summary",
-        ]);
-      }
+      expect(onToolResult.mock.calls[resultCount]?.[0], testCase.label).toMatchObject({
+        channelData: { openclawToolProgressId: testCase.toolCallId },
+      });
     }
 
     await harness.completeTurn({ threadId: "thread-1", turnId: "turn-1" });

--- a/extensions/codex/src/app-server/run-attempt.dynamic-tools.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.dynamic-tools.test.ts
@@ -242,7 +242,6 @@ describe("runCodexAppServerAttempt dynamic tools", () => {
       data?: {
         args?: Record<string, unknown>;
         commandBearing?: boolean;
-        hideFromChannelProgress?: boolean;
         isError?: boolean;
         name?: string;
         phase?: string;
@@ -262,7 +261,6 @@ describe("runCodexAppServerAttempt dynamic tools", () => {
     expect(startEvent?.data?.toolCallId).toBe("call-1");
     expect(startEvent?.data?.args?.action).toBe("search");
     expect(startEvent?.data?.commandBearing).toBe(true);
-    expect(startEvent?.data?.hideFromChannelProgress).toBe(true);
     expect(startEvent?.data?.args?.token).toBe("plain-…2345");
     expect(startEvent?.data?.args?.text).toBe("hello");
     const resultEvent = agentEvents.find(
@@ -273,7 +271,6 @@ describe("runCodexAppServerAttempt dynamic tools", () => {
     );
     expect(resultEvent?.data?.name).toBe("lookup");
     expect(resultEvent?.data?.commandBearing).toBe(true);
-    expect(resultEvent?.data?.hideFromChannelProgress).toBe(true);
     expect(resultEvent?.data?.toolCallId).toBe("call-1");
     expect(resultEvent?.data?.isError).toBe(true);
     expect(resultEvent?.data?.result).not.toHaveProperty("success");

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -1799,7 +1799,6 @@ describe("runCodexAppServerAttempt", () => {
       stream: "tool",
       data: {
         phase: "start",
-        hideFromChannelProgress: true,
         name: "python",
         toolCallId: "call-1",
         args: { code: "print('hi')" },
@@ -1809,7 +1808,6 @@ describe("runCodexAppServerAttempt", () => {
       stream: "tool",
       data: {
         phase: "result",
-        hideFromChannelProgress: true,
         name: "python",
         toolCallId: "call-1",
         isError: true,

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -1800,6 +1800,7 @@ describe("runCodexAppServerAttempt", () => {
       data: {
         phase: "start",
         name: "python",
+        itemId: "call-1",
         toolCallId: "call-1",
         args: { code: "print('hi')" },
       },
@@ -1809,6 +1810,7 @@ describe("runCodexAppServerAttempt", () => {
       data: {
         phase: "result",
         name: "python",
+        itemId: "call-1",
         toolCallId: "call-1",
         isError: true,
         result: {

--- a/extensions/telegram/src/bot-message-dispatch-progress.ts
+++ b/extensions/telegram/src/bot-message-dispatch-progress.ts
@@ -125,6 +125,15 @@ export async function pushToolProgress(
   if (!canPushToolProgress(turn)) {
     return false;
   }
+  // Structured rows own detail; formatted callbacks only fill a missing keyed row.
+  if (
+    options?.id &&
+    turn.progressCompositor
+      .getSnapshot()
+      .lines.some((entry) => typeof entry === "object" && entry.id === options.id)
+  ) {
+    return true;
+  }
   return await turn.progressCompositor.pushToolProgress(
     typeof line === "string" ? buildTelegramTextToolProgressLine(line, options?.id) : line,
     options,

--- a/extensions/telegram/src/bot-message-dispatch-progress.ts
+++ b/extensions/telegram/src/bot-message-dispatch-progress.ts
@@ -34,8 +34,9 @@ function buildTelegramThinkingProgressLine(progressTokens: number): ChannelProgr
   };
 }
 
-function buildTelegramTextToolProgressLine(text: string): ChannelProgressDraftLine {
+function buildTelegramTextToolProgressLine(text: string, id?: string): ChannelProgressDraftLine {
   return {
+    ...(id ? { id } : {}),
     kind: "item",
     label: "",
     text,
@@ -119,13 +120,13 @@ async function pushProgressEvent(turn: Turn, event: () => Promise<boolean>): Pro
 export async function pushToolProgress(
   turn: Turn,
   line?: string | ChannelProgressDraftLine,
-  options?: { toolName?: string; startImmediately?: boolean },
+  options?: { toolName?: string; startImmediately?: boolean; id?: string },
 ): Promise<boolean> {
   if (!canPushToolProgress(turn)) {
     return false;
   }
   return await turn.progressCompositor.pushToolProgress(
-    typeof line === "string" ? buildTelegramTextToolProgressLine(line) : line,
+    typeof line === "string" ? buildTelegramTextToolProgressLine(line, options?.id) : line,
     options,
   );
 }

--- a/extensions/telegram/src/bot-message-dispatch-turn.ts
+++ b/extensions/telegram/src/bot-message-dispatch-turn.ts
@@ -287,8 +287,10 @@ export async function runTelegramDispatchTurn(turn: Turn) {
               if (!text) {
                 return false;
               }
+              const progressId = payload.channelData?.openclawToolProgressId;
               const updatedDraft = await pushToolProgress(turn, text, {
                 startImmediately: true,
+                id: typeof progressId === "string" ? progressId : undefined,
               });
               if (updatedDraft) {
                 return true;

--- a/extensions/telegram/src/bot-message-dispatch.progress-updates.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.progress-updates.test.ts
@@ -365,6 +365,32 @@ describeTelegramDispatch("dispatchTelegramMessage progress-updates", () => {
     expect(draftStream.flush).toHaveBeenCalled();
   });
 
+  it("keeps a dynamic tool lifecycle and formatted summary in one row", async () => {
+    const draftStream = createSequencedDraftStream(2001);
+    createTelegramDraftStream.mockReturnValue(draftStream);
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ replyOptions }) => {
+      await replyOptions?.onReplyStart?.();
+      await replyOptions?.onAssistantMessageStart?.();
+      await replyOptions?.onToolStart?.({
+        name: "agents_list",
+        phase: "start",
+        toolCallId: "dynamic-1",
+      });
+      await replyOptions?.onToolResult?.({ text: "🧭 Agents" });
+      return { queuedFinal: false };
+    });
+
+    await dispatchWithContext({
+      context: createContext(),
+      streamMode: "progress",
+      telegramCfg: { streaming: { mode: "progress", progress: { label: "Working" } } },
+    });
+
+    expect(draftStream.updatePreview).toHaveBeenLastCalledWith(
+      telegramProgressPreview("Working\n\n🧭 Agents", "<b>Working</b>\n<b>🧭 Agents</b>"),
+    );
+  });
+
   it("reopens progress drafts for queued followups after the source dispatch settles", async () => {
     const draftStream = createSequencedDraftStream(2001);
     createTelegramDraftStream.mockReturnValue(draftStream);

--- a/extensions/telegram/src/bot-message-dispatch.progress-updates.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.progress-updates.test.ts
@@ -371,12 +371,16 @@ describeTelegramDispatch("dispatchTelegramMessage progress-updates", () => {
     dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ replyOptions }) => {
       await replyOptions?.onReplyStart?.();
       await replyOptions?.onAssistantMessageStart?.();
+      await replyOptions?.onToolResult?.({
+        text: "🧭 Agents",
+        channelData: { openclawToolProgressId: "dynamic-1" },
+      });
       await replyOptions?.onToolStart?.({
         name: "agents_list",
         phase: "start",
+        itemId: "dynamic-1",
         toolCallId: "dynamic-1",
       });
-      await replyOptions?.onToolResult?.({ text: "🧭 Agents" });
       return { queuedFinal: false };
     });
 

--- a/extensions/telegram/src/bot-message-dispatch.progress-updates.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.progress-updates.test.ts
@@ -395,6 +395,40 @@ describeTelegramDispatch("dispatchTelegramMessage progress-updates", () => {
     );
   });
 
+  it("keeps raw structured detail when its formatted summary arrives", async () => {
+    const draftStream = createSequencedDraftStream(2001);
+    createTelegramDraftStream.mockReturnValue(draftStream);
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ replyOptions }) => {
+      await replyOptions?.onReplyStart?.();
+      await replyOptions?.onAssistantMessageStart?.();
+      await replyOptions?.onToolStart?.({
+        name: "exec",
+        phase: "start",
+        itemId: "command-1",
+        toolCallId: "command-1",
+        args: { command: "echo private" },
+        detailMode: "raw",
+      });
+      await replyOptions?.onToolResult?.({
+        text: "🛠️ Bash",
+        channelData: { openclawToolProgressId: "command-1" },
+      });
+      return { queuedFinal: false };
+    });
+
+    await dispatchWithContext({
+      context: createContext(),
+      streamMode: "progress",
+      telegramCfg: {
+        streaming: { mode: "progress", progress: { commandText: "raw", label: "Working" } },
+      },
+    });
+
+    const previewText = draftStream.updatePreview.mock.calls.at(-1)?.[0]?.text;
+    expect(previewText).toContain("echo private");
+    expect(previewText?.match(/🛠️/gu)).toHaveLength(1);
+  });
+
   it("reopens progress drafts for queued followups after the source dispatch settles", async () => {
     const draftStream = createSequencedDraftStream(2001);
     createTelegramDraftStream.mockReturnValue(draftStream);

--- a/extensions/telegram/src/bot-message-dispatch.types.ts
+++ b/extensions/telegram/src/bot-message-dispatch.types.ts
@@ -139,6 +139,7 @@ type TelegramProgressCompositor = {
   readonly commentaryProgressEnabled: boolean;
   readonly hasStatusHeadline: boolean;
   readonly hasPlanProgress: boolean;
+  getSnapshot: () => { lines: ReadonlyArray<string | ChannelProgressDraftLine> };
   markFinalReplyStarted: () => void;
   markFinalReplyDelivered: () => void;
   beginNewTurn: (options?: { force?: boolean }) => boolean;


### PR DESCRIPTION
## What Problem This Solves

PR #132321 treated the noisy-presentation report in #132034 as a backend-wide privacy rule. It hid every Codex tool lifecycle event and stopped the existing formatted channel callback. This made the shipped `toolProgress` setting inert for Codex.

## Why This Change Was Made

- Remove backend-wide hide markers from native and dynamic Codex tool events.
- Restore the callback used by verbose and forced-progress delivery.
- Keep command-bearing formatted callbacks label-only on channels.
- Correlate formatted and structured progress with the same item ID, so one tool call creates one row.
- Keep richer structured raw detail when the formatted summary arrives later.
- Keep selective internal markers, including Guardian review and answer-candidate events.

## User Impact

- Enabled channel tool progress shows one compact row per Codex tool call.
- Disabled channel tool progress hides those rows while commentary remains independent.
- `commandText: "status"` keeps raw command text private.
- `commandText: "raw"` retains structured command detail.
- Transcript, trajectory, diagnostics, tool results, commentary, and final delivery keep their existing paths.
- No config, default, or compatibility surface changes.

## Evidence

- Main `f5eea3197c55c0ed0e609d182bd88a7f09ec55e9`: a Telegram Test Server DM reported `Runtime: OpenAI Codex`; commentary and final delivery arrived; `toolProgress: true` showed no tool rows.
- Final head `d014d286ba610150e5730128c33a9dc53ccff3a9`: status mode showed one row each for command, patch, web search, MCP, and dynamic tools; the raw command stayed private.
- Final raw-mode probe retained the detailed command row and kept one row per requested tool.
- Final disabled probe kept commentary and final delivery with no tool rows.
- Every final run used OpenAI Codex, delivered `CODEX_TOOL_PROGRESS_OK`, and produced zero mock-provider requests.
- Regressions fail against the hidden-event, raw-command, uncorrelated-row, and raw-detail-loss paths and pass on final head.
- Focused Codex, Telegram, shared channel, CLI progress, formatting, Oxlint, import-cycle, dead-code, boundary, and repository ratchet checks pass.
- One unrelated review-policy test fails on both unchanged main and this branch; the changed tool-progress suites pass.

Maintainer upstream proof is recorded in the PR discussion. The direct check used `openai/codex@6478a751fde8884b2fdc76486fe23175a8e795d4` and confirmed the typed item start/completion lifecycle for every projected source.
