### PR TITLE
test(plugin-sdk): copy the node binary when hard-linking it is not permitted

### DIFF
--- a/src/plugin-sdk/windows-spawn.test.ts
+++ b/src/plugin-sdk/windows-spawn.test.ts
@@ -2,7 +2,7 @@
  * Tests Windows spawn compatibility helpers.
  */
 import { spawnSync } from "node:child_process";
-import { link, writeFile } from "node:fs/promises";
+import { copyFile, link, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
 import { createPluginSdkTestHarness } from "./test-helpers.js";
@@ -21,7 +21,15 @@ describe("resolveWindowsSpawnProgram", () => {
     async () => {
       const dir = await createTempDir("openclaw-windows-spawn-env-case-");
       const executable = path.join(dir, "mixed-env-tool.MiXeD");
-      await link(process.execPath, executable);
+      // Hard-linking needs write access to the SOURCE, which a non-elevated user
+      // does not have for a per-machine Node install: `process.execPath` under
+      // `C:\Program Files` fails with EPERM. Copying only needs read, so fall
+      // back to it rather than assuming the runner is elevated.
+      try {
+        await link(process.execPath, executable);
+      } catch {
+        await copyFile(process.execPath, executable);
+      }
       const env = { pAtH: dir, pAtHeXt: ".MiXeD" };
 
       const program = resolveWindowsSpawnProgram({


### PR DESCRIPTION
Related: #126874

## What Problem This Solves

Resolves a problem where `src/plugin-sdk/windows-spawn.test.ts` fails for anyone running the Windows suite without an elevated shell. The native-spawn case hard-links `process.execPath` into a temp directory, and a non-elevated user cannot do that when Node is installed per-machine, so the file reports 6 passed and 1 failed on an otherwise healthy host.

## Why This Change Was Made

Creating a hard link needs write access to the source file. A standard user has read and execute on `C:\Program Files` but not write, so `link()` returns EPERM. `copyFile` needs only read. The hard link stays as the fast path and the copy is the fallback, so nothing changes on a runner that is allowed to link. No production code is touched, and the test still spawns a real binary resolved through `PATHEXT`, so its coverage is the same.

## User Impact

Contributors on Windows can run the plugin-sdk suite without elevation and get a clean file.

## Evidence

Windows 11 build 26200, Node v24.18.0, non-elevated, per-machine Node install at `C:\Program Files\nodejs`.

Before, on unmodified `main`:

```
 Test Files  1 failed (1)
      Tests  1 failed | 6 passed (7)

Error: EPERM: operation not permitted, link 'C:\Program Files\nodejs\node.exe' ->
  '...\openclaw-windows-spawn-env-case-0\mixed-env-tool.MiXeD'
 ❯ ../../src/plugin-sdk/windows-spawn.test.ts:24:7
```

After, same host, same command:

```
 Test Files  1 passed (1)
      Tests  7 passed (7)
```

The cause is not `node.exe` and not the file being in use. Linking any source the user cannot write fails the same way:

| link source | result |
|---|---|
| user-owned file in Temp | OK |
| `C:\Program Files\nodejs\node.exe` (92,534,088 bytes, running) | EPERM |
| `C:\Program Files\nodejs\corepack` (334 bytes, not running) | EPERM |
| `C:\WINDOWS\win.ini` (92 bytes, not running) | EPERM |

`copyFile` of the same 92,534,088-byte binary took 32 ms here, and spawning the copy through the test's own `PATHEXT` path returned status 0 with stdout `native-ok`, which is what the assertions check.

`oxlint` on the touched file exits 0.

Credit to @nerclid, who ran the three host-native Windows files in #126874 and reported this failure.

## AI assistance

AI-assisted (Claude Code). For this change I reproduced the EPERM on an unmodified checkout, ran the four-source link probe above to establish that write access to the source is the actual constraint, measured the copy and spawned the copied binary, and ran the file before and after (1 failed / 6 passed, then 7 passed). I did not run the full suite or the build.
