### PR TITLE
test(voice-call): own fixture lifetimes before worker teardown

### DIFF
--- a/extensions/voice-call/src/manager.lifecycle.test.ts
+++ b/extensions/voice-call/src/manager.lifecycle.test.ts
@@ -32,17 +32,23 @@ describe("CallManager termination lifecycle", () => {
     const endedAt = Date.now() + 1_000;
 
     const pendingEnd = manager.endCall(call.callId, { reason: "timeout" });
-    expect(provider.attempts).toHaveLength(1);
+    try {
+      expect(provider.attempts).toHaveLength(1);
 
-    manager.processEvent({
-      id: "provider-terminal",
-      type: "call.ended",
-      callId: call.callId,
-      providerCallId: call.providerCallId,
-      timestamp: endedAt,
-      reason: "completed",
-    });
-    provider.attempts[0]?.resolve();
+      manager.processEvent({
+        id: "provider-terminal",
+        type: "call.ended",
+        callId: call.callId,
+        providerCallId: call.providerCallId,
+        timestamp: endedAt,
+        reason: "completed",
+      });
+    } finally {
+      for (const attempt of provider.attempts) {
+        attempt.resolve();
+      }
+      await pendingEnd;
+    }
 
     await expect(pendingEnd).resolves.toEqual({ success: true });
     expect(call).toMatchObject({
@@ -64,11 +70,18 @@ describe("CallManager termination lifecycle", () => {
     const [firstResult, secondResult] = await Promise.all([first, second]);
 
     const retry = manager.endCall(call.callId, { reason: "error" });
-    const retryAttempt = provider.attempts.at(-1);
-    if (!retryAttempt) {
-      throw new Error("expected retry hangup attempt");
+    try {
+      const retryAttempt = provider.attempts.at(-1);
+      if (!retryAttempt) {
+        throw new Error("expected retry hangup attempt");
+      }
+      retryAttempt.resolve();
+    } finally {
+      for (const attempt of provider.attempts) {
+        attempt.resolve();
+      }
+      await retry;
     }
-    retryAttempt.resolve();
     await expect(retry).resolves.toEqual({ success: true });
 
     expect(second).toBe(first);

--- a/extensions/voice-call/src/manager.notify.test.ts
+++ b/extensions/voice-call/src/manager.notify.test.ts
@@ -427,15 +427,18 @@ describe("CallManager notify and mapping", () => {
     expect(provider.playTtsCalls).toHaveLength(0);
 
     const first = manager.speakInitialMessage("call-uuid");
-    await provider.playTtsStartedPromise;
-    expect(provider.playTtsStarted).toHaveBeenCalledTimes(1);
+    const playbacks = [first];
+    try {
+      await provider.playTtsStartedPromise;
+      expect(provider.playTtsStarted).toHaveBeenCalledTimes(1);
 
-    const second = manager.speakInitialMessage("call-uuid");
-    await waitForPlaybackDispatch();
-    expect(provider.playTtsCalls).toHaveLength(1);
-
-    provider.releaseCurrentPlayback();
-    await Promise.all([first, second]);
+      playbacks.push(manager.speakInitialMessage("call-uuid"));
+      await waitForPlaybackDispatch();
+      expect(provider.playTtsCalls).toHaveLength(1);
+    } finally {
+      provider.releaseCurrentPlayback();
+      await Promise.all(playbacks);
+    }
 
     const call = requireCall(manager, callId);
     expect(call.metadata).not.toHaveProperty("initialMessage");

--- a/extensions/voice-call/src/manager.restore.test.ts
+++ b/extensions/voice-call/src/manager.restore.test.ts
@@ -5,13 +5,14 @@ import {
 } from "openclaw/plugin-sdk/plugin-state-test-runtime";
 // Voice Call tests cover manager.restore plugin behavior.
 import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, onTestFinished, vi } from "vitest";
 import { VoiceCallConfigSchema } from "./config.js";
 import { CallManager } from "./manager.js";
 import {
   createTestStorePath,
   FakeProvider,
   makePersistedCall,
+  registerTestManagerCleanup,
   writeCallsToStore,
 } from "./manager.test-harness.js";
 import { MAX_CALL_REPLAY_KEYS } from "./manager/replay-keys.js";
@@ -58,12 +59,13 @@ describe("CallManager verification on restore", () => {
   beforeEach(() => {
     resetPluginStateStoreForTests();
     installStateRuntime();
-  });
-
-  afterEach(() => {
-    vi.useRealTimers();
-    vi.restoreAllMocks();
-    resetPluginStateStoreForTests();
+    // Finish hooks are LIFO: managers must persist terminal state before stores
+    // close, and clear fake timers before the clock is restored.
+    onTestFinished(() => {
+      vi.useRealTimers();
+      vi.restoreAllMocks();
+      resetPluginStateStoreForTests();
+    });
   });
 
   async function initializeManager(params?: {
@@ -88,7 +90,7 @@ describe("CallManager verification on restore", () => {
       fromNumber: "+15550000000",
       ...params?.configOverrides,
     });
-    const manager = new CallManager(config, storePath);
+    const manager = registerTestManagerCleanup(new CallManager(config, storePath));
     await manager.initialize(provider, "https://example.com/voice/webhook");
 
     return { call, manager, provider, storePath };
@@ -139,7 +141,7 @@ describe("CallManager verification on restore", () => {
       provider: "plivo",
       fromNumber: "+15550000000",
     });
-    const manager = new CallManager(config, storePath);
+    const manager = registerTestManagerCleanup(new CallManager(config, storePath));
     await manager.initialize(new FakeProvider(), "https://example.com/voice/webhook");
 
     expect(manager.getCallByProviderCallId("call-target")?.callId).toBe("call-active");
@@ -289,7 +291,7 @@ describe("CallManager verification on restore", () => {
       maxDurationSeconds: 300,
     });
     const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
-    const manager = new CallManager(config, storePath);
+    const manager = registerTestManagerCleanup(new CallManager(config, storePath));
 
     await manager.initialize(provider, "https://example.com/voice/webhook");
 
@@ -406,7 +408,7 @@ describe("CallManager verification on restore", () => {
       provider: "plivo",
       fromNumber: "+15550000000",
     });
-    const manager = new CallManager(config, storePath);
+    const manager = registerTestManagerCleanup(new CallManager(config, storePath));
     await manager.initialize(provider, "https://example.com/voice/webhook");
 
     manager.processEvent({

--- a/extensions/voice-call/src/manager.test-harness.test.ts
+++ b/extensions/voice-call/src/manager.test-harness.test.ts
@@ -1,0 +1,85 @@
+import { AsyncLocalStorage, createHook } from "node:async_hooks";
+import { setImmediate } from "node:timers/promises";
+import { expect, it, onTestFinished } from "vitest";
+import { createManagerHarness, markCallAnswered } from "./manager.test-harness.js";
+
+it("finalizes each fixture's calls and destroys its real duration and transcript timers", async () => {
+  const ownership = new AsyncLocalStorage<"duration" | "transcript">();
+  const allocated = { duration: 0, transcript: 0 };
+  const pending = new Map<number, "duration" | "transcript">();
+  const observer = createHook({
+    init(id, type) {
+      const owner = ownership.getStore();
+      if (type === "Timeout" && owner) {
+        allocated[owner]++;
+        pending.set(id, owner);
+      }
+    },
+    destroy(id) {
+      pending.delete(id);
+    },
+  }).enable();
+  const fixtures: Array<Awaited<ReturnType<typeof createManagerHarness>>> = [];
+  const callIds: string[] = [];
+  const turns: Array<ReturnType<(typeof fixtures)[number]["manager"]["continueCall"]>> = [];
+  let turnResult: Awaited<(typeof turns)[number]> | undefined;
+
+  // Finish hooks are LIFO: register verification before allocating fixtures so
+  // it observes their cleanup, after afterEach and fixture teardown have run.
+  onTestFinished(async () => {
+    try {
+      await setImmediate(); // Node delivers timer destroy events on the next loop.
+      expect(allocated).toEqual({ duration: 2, transcript: 1 });
+      expect([...pending.values()], "fixture timers surviving test cleanup").toEqual([]);
+      for (const [index, { manager, provider }] of fixtures.entries()) {
+        expect(manager.getActiveCalls()).toEqual([]);
+        expect(provider.hangupCalls).toEqual([]);
+        expect(await manager.getCallFromMemoryOrStore(callIds[index]!)).toMatchObject({
+          state: "hangup-user",
+          endReason: "hangup-user",
+          endedAt: expect.any(Number),
+        });
+      }
+      expect(turnResult).toEqual({ success: false, error: "Call ended: hangup-user" });
+    } finally {
+      try {
+        // Keep failing-before proof contained; this runs only after assertions
+        // and uses carrier hangup, not the fixture's synthetic terminal event.
+        for (const { manager } of fixtures) {
+          for (const call of manager.getActiveCalls()) {
+            await manager.endCall(call.callId);
+          }
+        }
+        await Promise.all(turns);
+      } finally {
+        observer.disable();
+        ownership.disable();
+      }
+    }
+  });
+
+  for (let index = 0; index < 2; index++) {
+    const fixture = await createManagerHarness();
+    fixtures.push(fixture);
+    const started = await fixture.manager.initiateCall("+15550000001");
+    expect(started.success).toBe(true);
+    callIds.push(started.callId);
+    ownership.run("duration", () => {
+      markCallAnswered(fixture.manager, started.callId, `answered-${index}`);
+    });
+    if (index === 0) {
+      turns.push(
+        ownership.run("transcript", () =>
+          fixture.manager.continueCall(started.callId, "Waiting for a reply").then((result) => {
+            turnResult = result;
+            return result;
+          }),
+        ),
+      );
+    }
+  }
+  await setImmediate();
+  expect(allocated).toEqual({ duration: 2, transcript: 1 });
+  expect(pending.size).toBe(3);
+  expect(turnResult).toBeUndefined();
+});

--- a/extensions/voice-call/src/manager.test-harness.ts
+++ b/extensions/voice-call/src/manager.test-harness.ts
@@ -1,4 +1,5 @@
 // Voice Call plugin module implements manager harness behavior.
+import { randomUUID } from "node:crypto";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -7,6 +8,7 @@ import {
   createPluginStateSyncKeyedStoreForTests,
   resetPluginStateStoreForTests,
 } from "openclaw/plugin-sdk/plugin-state-test-runtime";
+import { onTestFinished } from "vitest";
 import { VoiceCallConfigSchema } from "./config.js";
 import { CallManager } from "./manager.js";
 import type { CallManagerContext } from "./manager/context.js";
@@ -105,6 +107,36 @@ function installVoiceCallStateRuntimeForTests(): void {
   setVoiceCallStateRuntime({ state: createVoiceCallStateRuntimeForTests() });
 }
 
+export function finalizeTestManagerCalls(manager: CallManager): void {
+  const errors: unknown[] = [];
+  for (const call of manager.getActiveCalls()) {
+    try {
+      // Synthetic carrier completion retires fixture timers/waiters even when
+      // its fake hangup deliberately fails. Provider work must be joined first.
+      manager.processEvent({
+        id: randomUUID(),
+        type: "call.ended",
+        callId: call.callId,
+        providerCallId: call.providerCallId,
+        timestamp: Date.now(),
+        reason: "hangup-user",
+      });
+    } catch (error) {
+      errors.push(error);
+    }
+  }
+  if (errors.length > 0) {
+    throw new AggregateError(errors, "Failed to finalize fixture calls");
+  }
+}
+
+export function registerTestManagerCleanup(manager: CallManager): CallManager {
+  // Register before initialize can fail. Store/runtime owners must outlive this
+  // LIFO finish hook; this fixture does not reset shared stores or runtimes.
+  onTestFinished(() => finalizeTestManagerCalls(manager));
+  return manager;
+}
+
 export async function createManagerHarness(
   configOverrides: Record<string, unknown> = {},
   provider = new FakeProvider(),
@@ -119,7 +151,7 @@ export async function createManagerHarness(
     ...configOverrides,
   });
   installVoiceCallStateRuntimeForTests();
-  const manager = new CallManager(config, createTestStorePath());
+  const manager = registerTestManagerCleanup(new CallManager(config, createTestStorePath()));
   await manager.initialize(provider, "https://example.com/voice/webhook");
   return { manager, provider };
 }

--- a/extensions/voice-call/src/runtime.realtime-routing.test.ts
+++ b/extensions/voice-call/src/runtime.realtime-routing.test.ts
@@ -12,6 +12,7 @@ import type {
 import { useAutoCleanupTempDirTracker } from "openclaw/plugin-sdk/test-env";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { WebSocket } from "ws";
+import { finalizeTestManagerCalls } from "./manager.test-harness.js";
 import type { VoiceCallStateRuntime } from "./runtime-state.js";
 import { createVoiceCallRuntime, type VoiceCallRuntime } from "./runtime.js";
 import { createVoiceCallBaseConfig } from "./test-fixtures.js";
@@ -238,11 +239,19 @@ describe("voice-call realtime route ownership", () => {
       await runtime?.stop();
       for (const ws of sockets) {
         if (ws.readyState !== WebSocket.CLOSED) {
+          const closed = waitForClose(ws);
           ws.terminate();
+          await closed;
         }
       }
       await Promise.all(servers.map((server) => server.close()));
-      resetPluginStateStoreForTests();
+      try {
+        if (runtime) {
+          finalizeTestManagerCalls(runtime.manager);
+        }
+      } finally {
+        resetPluginStateStoreForTests();
+      }
     }
   });
 });


### PR DESCRIPTION
Related: #132485 — shared Chrome tracing/reconnect repair; its CI investigation exposed the voice-call fixture lifetime follow-up handled here.

<details>
<summary>Additional instructions</summary>

**Maintainer edits:** this is a branch in the canonical repository, so maintainers can push fixes.

</details>

## What Problem This Solves

Resolves a problem where voice-call tests left real CallManager timers alive after their fixtures and test files completed. The shared worker then cleared the state runtime while those timer closures still retained managers that could later persist or log into an unrelated test's lifetime.

The remaining resource leak was directly reproduced: ten max-duration timers survived `manager.notify.test.ts` (one mapping case plus nine conversation cases), four survived restore tests, and five survived closed-loop tests. This is a maintainer-requested fixture ownership repair, not an attempt to suppress a failing CI log.

## Why This Change Was Made

The shared test harness now owns each manager before initialization and finalizes remaining synthetic calls through the existing public `call.ended` lifecycle. Restored managers use the same owner, with terminal persistence and timer/waiter release ordered before store/clock cleanup. Delayed playback and hangup tests release and join their work in `finally`; the realtime routing fixture also joins its test sockets before finalization.

This reuses the canonical production finalizer without changing production code. It does not add a manager shutdown contract, silently hang up real calls, access private manager fields, introduce a production test seam, suppress logs, sweep timers, or alter timer budgets. The four notification cases repaired in #132485 still await their actual auto-hangup and verify persisted terminal state; synthetic cleanup does not replace that proof.

## User Impact

No product or operator behavior changes. Developers get fixture-owned cleanup before non-isolated workers clear their runtime state, preventing these long-lived call timers from escaping into later files.

Active-call, runtime stop, restart, configuration, persistence/schema and provider semantics are unchanged. No operator voice call, Gateway restart, live configuration/state operation, dependency change, or release is involved.

## Evidence

The new committed `manager.test-harness.test.ts` uses real default-duration timers and AsyncLocalStorage-scoped `async_hooks` observation. Before changing the existing harness, it failed specifically because two duration timers and one transcript-wait timer survived test cleanup. After repair, it passes with zero survivors, both calls persisted terminal, and the pending `continueCall` settled. Allocation is checked as well as destruction, so an empty observer cannot false-pass.

| Proof | Result |
| --- | --- |
| New resource-boundary regression, unchanged command/assertions before and after | Failed before with 3 surviving native timers; passed after with 0 |
| Original cold-cache 63-file dispatch queue, two non-isolated workers | 63 files / 721 tests passed; notify 10→0, restore 4→0, closed-loop 5→0 surviving timers |
| Passive observer in that replay | 57 real manager timer allocations observed; 0 final survivors in either worker; 0 callbacks in later files; all 4 notification callbacks fired inside their owning file |
| Normal uninstrumented voice-call suite | 64 files / 722 tests passed |
| Focused consumer set, normal and single-worker execution | 10 files / 72 tests passed in each run |
| Complete changed-file gate | Passed: formatting, extension and extension-test types, typed lint, doctor-contract tests, dead-export and architecture/guard checks |
| Fresh independent Codex autoreview | Candidate scoped-clean at the configured P0 threshold; the six retained voice-call files are unchanged after dropping the upstream-equivalent CI commit |

Reproducible committed-test commands:

```bash
node scripts/run-vitest.mjs extensions/voice-call/src/manager.test-harness.test.ts --reporter=verbose
```

```bash
OPENCLAW_VITEST_MAX_WORKERS=2 node scripts/run-vitest.mjs extensions/voice-call --reporter=verbose
```

```bash
node scripts/check-changed.mjs -- extensions/voice-call/src/manager.test-harness.ts extensions/voice-call/src/manager.test-harness.test.ts extensions/voice-call/src/manager.notify.test.ts extensions/voice-call/src/manager.restore.test.ts extensions/voice-call/src/manager.lifecycle.test.ts extensions/voice-call/src/runtime.realtime-routing.test.ts
```

The historical dispatch order was preserved by a task-only sequencer extending the real shard config, not by modifying the production/shared runner. Original CI did not record complete worker assignment, so bit-for-bit Linux scheduling is not claimed. The exact console-RPC teardown rejection remains original-CI evidence; this change directly reproduces and repairs the native resource boundary. No separate injected failing-body run is claimed. Existing failure/retry, restored-call, real notification, and synthetic realtime lifecycle tests passed.

### Upstream CI blocker resolved

The requested landing found `main` [CI run 33257360392](https://github.com/openclaw/openclaw/actions/runs/33257360392) failing in the agent-concurrency benchmark. We independently reproduced another missing fixture teardown: `attempt.async-tasks.test.ts` left an intentionally running music task in memory and SQLite after the file completed. The benchmark correctly rejected it. The legitimate standalone CLI retention repair in #132602 exposed the latent leak; its production behavior must remain intact.

An equivalent producer cleanup then landed in [#132643 — state and async-task fixture cleanup](https://github.com/openclaw/openclaw/pull/132643), commit `2c7f11e3d4b9dc3045817466bc8aadb965e65852`, with a successful [CI gate](https://github.com/openclaw/openclaw/actions/runs/33259249878/job/99119175069). The redundant local commit was dropped rather than duplicating that work. **This PR changes only the six voice-call test/support files.**

The core producer → four intervening files → benchmark replay failed before with one active task and passed all 70 tests after canonical cleanup. Rebased-source sanity also passed those 70 tests using the real current-main owners without the initial diagnostic source overlay, plus 14 fixture/restore tests. The benchmark's 30-second deadline and every business assertion stayed unchanged. Exact-head CI remains this PR's landing gate.

Initial local setup exposed a missing Zod package manifest; normal `pnpm install` repaired it without lockfile or dependency changes. A cold diagnostic run hit the unchanged watchdog before test completion; final complete runs pass without increased budgets. No build/package proof is needed because the entire diff is tests and test support.

**Production LOC: +0/−0. Tests/support: +179/−35 (net +144)** across six files, including the new 85-line regression. No production path was added or removed. A general production manager disposer was rejected as the wrong ownership boundary for this defect because it would require a separate active-call/restart decision.

AI-assisted, maintainer-requested repair; source, dependency ordering and before/after evidence were independently inspected.
