### PR TITLE
fix(gateway): gateway replacement no longer stalls after startup SIGTERM

### DIFF
--- a/src/cli/command-execution-startup.ts
+++ b/src/cli/command-execution-startup.ts
@@ -53,6 +53,7 @@ export async function ensureCliExecutionBootstrap(params: {
   validateConfigOnly?: boolean;
   skipPristineCoreStateMigrations?: boolean;
   skipPristineStartupStateMigrations?: boolean;
+  signal?: AbortSignal;
 }) {
   const {
     runtime,
@@ -80,6 +81,7 @@ export async function ensureCliExecutionBootstrap(params: {
         ...(suppressDoctorStdout ? { suppressDoctorStdout: true } : {}),
         ...(skipPristineStartupStateMigrations ? { skipPristineStartupStateMigrations: true } : {}),
         ...(skipPristineCoreStateMigrations ? { skipPristineCoreStateMigrations: true } : {}),
+        ...(params.signal ? { signal: params.signal } : {}),
       });
     });
   }

--- a/src/cli/gateway-cli/pre-bootstrap.ts
+++ b/src/cli/gateway-cli/pre-bootstrap.ts
@@ -20,6 +20,7 @@ import { getGatewayRunRuntimeHooks } from "./runtime-hooks.js";
 type GatewayRunGuardParams = {
   opts: GatewayRunPreBootstrapOptions & Pick<GatewayRunOpts, "allowUnconfigured" | "dev">;
   runtime: RuntimeEnv;
+  signal?: AbortSignal;
 };
 
 type GatewayRunEnvironmentSelection = {
@@ -208,6 +209,11 @@ async function readGuardedGatewayRunConfig(
       observe: false,
       pluginValidation: "core-only",
     });
+    // Startup cancellation observed during the read must refuse the config before any
+    // recovery planning; ownership guards alone do not see the abort.
+    if (params.signal?.aborted) {
+      return null;
+    }
     const guard = (snapshot: ConfigFileSnapshot) =>
       enforceGatewayRunFutureConfigGuard({ ...params, snapshot });
     if (!guard(current)) {
@@ -219,6 +225,9 @@ async function readGuardedGatewayRunConfig(
       observe: false,
       pluginValidation: "core-only",
     }).prepareConfigRecovery(current);
+    if (params.signal?.aborted) {
+      return null;
+    }
     return recovery ? (guard(recovery.snapshot) ? recovery.snapshot : null) : current;
   });
 }

--- a/src/cli/gateway-cli/run-command.ts
+++ b/src/cli/gateway-cli/run-command.ts
@@ -70,6 +70,9 @@ export function addGatewayRunCommand(cmd: Command, hooks: GatewayRunCommandHooks
       const resolved = resolveGatewayRunOptions(opts, command);
       try {
         await hooks.beforeRun?.(resolved);
+        if (getGatewayRunRuntimeHooks().startupSignal?.aborted) {
+          return;
+        }
         const { runGatewayCommand } = await import("./run.js");
         await runGatewayCommand(resolved, getGatewayRunRuntimeHooks());
       } catch (error) {

--- a/src/cli/gateway-cli/run-loop.test.ts
+++ b/src/cli/gateway-cli/run-loop.test.ts
@@ -626,6 +626,31 @@ describe("runGatewayLoop", () => {
     },
   );
 
+  it("releases the gateway lock when startup is aborted after acquisition", async () => {
+    vi.clearAllMocks();
+    const controller = new AbortController();
+    const reason = new Error("Gateway startup interrupted by SIGTERM");
+    const release = vi.fn(async () => {});
+    acquireGatewayLock.mockImplementationOnce(async () => {
+      controller.abort(reason);
+      return { release };
+    });
+    const start = vi.fn();
+    const { runtime } = createRuntimeWithExitSignal();
+    const { runGatewayLoop } = await import("./run-loop.js");
+
+    await expect(
+      runGatewayLoop({
+        start: start as unknown as Parameters<typeof runGatewayLoop>[0]["start"],
+        runtime: runtime as unknown as Parameters<typeof runGatewayLoop>[0]["runtime"],
+        startupSignal: controller.signal,
+      }),
+    ).rejects.toBe(reason);
+
+    expect(start).not.toHaveBeenCalled();
+    expect(release).toHaveBeenCalledTimes(1);
+  });
+
   it("keeps the ordinary drain when a handoff refuses late terminal persistence", async () => {
     vi.clearAllMocks();
     await withIsolatedSignals(async ({ captureSignal }) => {

--- a/src/cli/gateway-cli/run-loop.ts
+++ b/src/cli/gateway-cli/run-loop.ts
@@ -35,6 +35,7 @@ import type { RuntimeEnv } from "../../runtime.js";
 import { AsyncWorkScope } from "../../shared/async-work-scope.js";
 import { drainGlobalSingletonLifecycleState } from "../../shared/global-singleton.js";
 import { createLazyImportLoader } from "../../shared/lazy-promise.js";
+import { sleep } from "../../utils/sleep.js";
 import { createGatewayHostLifecycle } from "./host-lifecycle.js";
 import {
   armShutdownHardExitWatchdog,
@@ -160,7 +161,11 @@ export async function runGatewayLoop(params: {
   beginBoot?: (startedAtMs: number) => void | Promise<void>;
   completeBoot?: (completion: GatewayBootLifecycleCompletion) => void;
   onRestartStartupFailure?: (error: unknown, signal: AbortSignal) => Promise<void>;
+  /** Signal owned by CLI preflight until this loop installs its process handlers. */
+  startupSignal?: AbortSignal;
+  releaseStartupSignalOwner?: () => void;
 }) {
+  params.startupSignal?.throwIfAborted();
   // macOS/BSD process inspection reports process.title instead of the original
   // argv. Give the long-running Gateway a verifiable identity for lock readers.
   if (process.title === "openclaw") {
@@ -182,16 +187,17 @@ export async function runGatewayLoop(params: {
   // here pulls the lifecycle re-export graph into memory, immune to later disk
   // rotation.
   const eagerLifecycleRuntime = await loadGatewayLifecycleRuntimeModule();
+  params.startupSignal?.throwIfAborted();
   const supervisorMode = eagerLifecycleRuntime.detectGatewayRespawnSupervisor(
     process.env,
     process.platform,
     { includeLinuxOpenClawGatewayServiceMarker: true },
   );
-  let lock = await acquireGatewayLock({ port: params.lockPort });
   // Process-owned signal handling must survive gaps with no listening server.
   // Node's signal listeners and pending promises do not retain the event loop.
   const processLifetime = params.ownsProcessLifecycle ? new MessageChannel() : undefined;
   processLifetime?.port1.ref();
+  let lock: Awaited<ReturnType<typeof acquireGatewayLock>> = null;
   let server: Awaited<ReturnType<typeof startGatewayServer>> | null = null;
   let hostLifecycle: ReturnType<typeof createGatewayHostLifecycle> | undefined;
   let startupOperations = createGatewayStartupOperations();
@@ -1186,11 +1192,26 @@ export async function runGatewayLoop(params: {
     });
   };
 
-  process.on("SIGTERM", onSigterm);
-  process.on("SIGINT", onSigint);
-  process.on("SIGUSR1", onSigusr1);
-
   try {
+    // Keep acquisition inside the cleanup owner so an abort on resolution cannot strand the lock.
+    lock = await acquireGatewayLock({
+      port: params.lockPort,
+      ...(params.startupSignal
+        ? { sleep: async (ms: number) => await sleep(ms, params.startupSignal) }
+        : {}),
+    });
+    params.startupSignal?.throwIfAborted();
+
+    process.on("SIGTERM", onSigterm);
+    process.on("SIGINT", onSigint);
+    process.on("SIGUSR1", onSigusr1);
+    // Transfer ownership only after the normal handlers are installed. If
+    // startup was interrupted in the handoff window, the finally block below
+    // still releases the lock and removes every listener before propagating
+    // the abort.
+    params.releaseStartupSignalOwner?.();
+    params.startupSignal?.throwIfAborted();
+
     const onRestart = async () => {
       // After an in-process restart (SIGUSR1), reset command-queue lane state.
       // Interrupted tasks from the previous lifecycle may have left `active`

--- a/src/cli/gateway-cli/run.supervised-lock.test.ts
+++ b/src/cli/gateway-cli/run.supervised-lock.test.ts
@@ -166,9 +166,49 @@ describe("supervised gateway lock recovery", () => {
     });
     expect(testing.resolveGatewayLockErrorExitCode(failure)).toBe(1);
     expect(startLoop).toHaveBeenCalledTimes(4);
-    expect(sleep).toHaveBeenNthCalledWith(1, 5);
-    expect(sleep).toHaveBeenNthCalledWith(2, 5);
-    expect(sleep).toHaveBeenNthCalledWith(3, 2);
+    expect(sleep.mock.calls.map(([ms]) => ms)).toEqual([5, 5, 2]);
+  });
+
+  it("stops supervised lock recovery when gateway startup is cancelled", async () => {
+    const controller = new AbortController();
+    const reason = new Error("Gateway startup interrupted by SIGTERM");
+    let sleepStarted!: () => void;
+    const sleeping = new Promise<void>((resolve) => {
+      sleepStarted = resolve;
+    });
+    const startLoop = vi.fn(async () => {
+      throw new GatewayLockError("gateway already running");
+    });
+    const sleep = vi.fn(async (_ms: number, signal?: AbortSignal) => {
+      sleepStarted();
+      expect(signal).toBe(controller.signal);
+      await new Promise<void>((_resolve, reject) => {
+        signal?.addEventListener(
+          "abort",
+          () => {
+            expect(signal.reason).toBe(reason);
+            reject(reason);
+          },
+          { once: true },
+        );
+      });
+    });
+
+    const recovery = testing.runGatewayLoopWithSupervisedLockRecovery({
+      startLoop,
+      supervisor: "systemd",
+      port: 18789,
+      healthHost: "127.0.0.1",
+      log: createLogger(),
+      startupSignal: controller.signal,
+      probeHealth: vi.fn(async () => false),
+      sleep,
+    });
+    await sleeping;
+    controller.abort(reason);
+
+    await expect(recovery).rejects.toBe(reason);
+    expect(startLoop).toHaveBeenCalledTimes(1);
   });
 
   it("bounds supervised retries for EADDRINUSE lock errors", async () => {
@@ -200,9 +240,7 @@ describe("supervised gateway lock recovery", () => {
     );
 
     expect(startLoop).toHaveBeenCalledTimes(4);
-    expect(sleep).toHaveBeenNthCalledWith(1, 5);
-    expect(sleep).toHaveBeenNthCalledWith(2, 5);
-    expect(sleep).toHaveBeenNthCalledWith(3, 2);
+    expect(sleep.mock.calls.map(([ms]) => ms)).toEqual([5, 5, 2]);
   });
 
   it.each(["gateway already running", "another gateway instance is already listening"])(

--- a/src/cli/gateway-cli/run.test-support.ts
+++ b/src/cli/gateway-cli/run.test-support.ts
@@ -18,6 +18,7 @@ type GatewayRunTestApi = {
     port: number;
     timeoutMs?: number;
     tlsFingerprint?: string;
+    signal?: AbortSignal;
   }): Promise<boolean>;
   resolveGatewayLockErrorExitCode(err: unknown): number;
   resolveGatewayStartupFailureExitCode(err: unknown): number;
@@ -27,9 +28,14 @@ type GatewayRunTestApi = {
     port: number;
     healthHost: string;
     log: GatewayRunTestLogger;
+    startupSignal?: AbortSignal;
     now?: () => number;
-    sleep?: (ms: number) => Promise<void>;
-    probeHealth?: (params: { host: string; port: number }) => Promise<boolean>;
+    sleep?: (ms: number, signal?: AbortSignal) => Promise<void>;
+    probeHealth?: (params: {
+      host: string;
+      port: number;
+      signal?: AbortSignal;
+    }) => Promise<boolean>;
     retryMs?: number;
     timeoutMs?: number;
   }): Promise<void>;

--- a/src/cli/gateway-cli/run.ts
+++ b/src/cli/gateway-cli/run.ts
@@ -64,6 +64,7 @@ import { setConsoleSubsystemFilter, setConsoleTimestampPrefix } from "../../logg
 import { withDiagnosticPhase } from "../../logging/diagnostic-phase.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { defaultRuntime } from "../../runtime.js";
+import { sleep as sleepWithSignal } from "../../utils/sleep.js";
 import { printClawBanner, type ClawBannerResult } from "../claw-banner.js";
 import { formatCliCommand } from "../command-format.js";
 import { formatInvalidConfigPort, formatInvalidPortOption } from "../error-format.js";
@@ -452,7 +453,9 @@ async function probeGatewayHealthz(params: {
   port: number;
   timeoutMs?: number;
   tlsFingerprint?: string;
+  signal?: AbortSignal;
 }): Promise<boolean> {
+  params.signal?.throwIfAborted();
   const timeoutMs = params.timeoutMs ?? SUPERVISED_GATEWAY_HEALTH_PROBE_TIMEOUT_MS;
   const result = await requestGatewayLocalHttpProbe({
     ...params,
@@ -464,7 +467,7 @@ async function probeGatewayHealthz(params: {
 
 function createConfiguredGatewayHealthProbe(cfg: OpenClawConfig) {
   const probe = createConfiguredGatewayLocalProbe(cfg);
-  return async (params: { host: string; port: number }): Promise<boolean> => {
+  return async (params: { host: string; port: number; signal?: AbortSignal }): Promise<boolean> => {
     const result = await probe.requestHttp({
       ...params,
       pathname: "/healthz",
@@ -480,12 +483,14 @@ async function runGatewayLoopWithSupervisedLockRecovery(params: {
   port: number;
   healthHost: string;
   log: GatewayRunLogger;
+  startupSignal?: AbortSignal;
   now?: () => number;
-  sleep?: (ms: number) => Promise<void>;
-  probeHealth?: (params: { host: string; port: number }) => Promise<boolean>;
+  sleep?: (ms: number, signal?: AbortSignal) => Promise<void>;
+  probeHealth?: (params: { host: string; port: number; signal?: AbortSignal }) => Promise<boolean>;
   retryMs?: number;
   timeoutMs?: number;
 }) {
+  params.startupSignal?.throwIfAborted();
   const supervisor = params.supervisor;
   if (!supervisor) {
     await params.startLoop();
@@ -493,18 +498,14 @@ async function runGatewayLoopWithSupervisedLockRecovery(params: {
   }
 
   const now = params.now ?? Date.now;
-  const sleep =
-    params.sleep ??
-    (async (ms: number) =>
-      await new Promise((resolve) => {
-        setTimeout(resolve, ms);
-      }));
+  const sleep = params.sleep ?? sleepWithSignal;
   const probeHealth = params.probeHealth ?? ((probeParams) => probeGatewayHealthz(probeParams));
   const retryMs = params.retryMs ?? SUPERVISED_GATEWAY_LOCK_RETRY_MS;
   const timeoutMs = params.timeoutMs ?? SUPERVISED_GATEWAY_LOCK_RETRY_TIMEOUT_MS;
   const startedAt = now();
 
   for (;;) {
+    params.startupSignal?.throwIfAborted();
     try {
       await params.startLoop();
       return;
@@ -513,7 +514,13 @@ async function runGatewayLoopWithSupervisedLockRecovery(params: {
         throw err;
       }
 
-      if (await probeHealth({ host: params.healthHost, port: params.port })) {
+      const healthy = await probeHealth({
+        host: params.healthHost,
+        port: params.port,
+        ...(params.startupSignal ? { signal: params.startupSignal } : {}),
+      });
+      params.startupSignal?.throwIfAborted();
+      if (healthy) {
         if (supervisor === "systemd") {
           throw new SupervisedGatewayLockError(
             "gateway already running under systemd; existing gateway is healthy, exiting with code 78 to prevent a systemd Restart=always loop",
@@ -540,7 +547,7 @@ async function runGatewayLoopWithSupervisedLockRecovery(params: {
       params.log.warn(
         `gateway already running under ${supervisor}; waiting ${waitMs}ms before retrying startup`,
       );
-      await sleep(waitMs);
+      await sleep(waitMs, params.startupSignal);
     }
   }
 }
@@ -605,6 +612,7 @@ async function runGatewayCommandOnce(opts: GatewayRunOpts, hooks: GatewayRunRunt
   }
 
   const startupTrace = createGatewayCliStartupTrace();
+  const throwIfStartupAborted = () => hooks.startupSignal?.throwIfAborted();
 
   // The heaviest part of gateway startup is loading the server module tree
   // (channels, plugins, HTTP stack, etc.). Start it before the foreground TTY
@@ -634,6 +642,7 @@ async function runGatewayCommandOnce(opts: GatewayRunOpts, hooks: GatewayRunRunt
     }
   };
   const { startGatewayServer } = await loadServerModule();
+  throwIfStartupAborted();
 
   setConsoleTimestampPrefix(true);
 
@@ -649,6 +658,7 @@ async function runGatewayCommandOnce(opts: GatewayRunOpts, hooks: GatewayRunRunt
     await startupTrace.measure("cli.dev-config", () =>
       ensureDevGatewayConfig({ reset: Boolean(opts.reset) }),
     );
+    throwIfStartupAborted();
     if (opts.reset) {
       const { reloadTrustedGatewayRunEnvironment } = await import("./pre-bootstrap.js");
       if (!(await reloadTrustedGatewayRunEnvironment({ runtime: defaultRuntime }))) {
@@ -662,6 +672,7 @@ async function runGatewayCommandOnce(opts: GatewayRunOpts, hooks: GatewayRunRunt
     await readGatewayStartupConfigWithShellEnv({
       startupTrace,
     });
+  throwIfStartupAborted();
   if (
     !enforceGatewayRunFutureConfigGuard({
       opts,
@@ -713,6 +724,7 @@ async function runGatewayCommandOnce(opts: GatewayRunOpts, hooks: GatewayRunRunt
     }
   }
   await hooks.refreshManagedProxy?.(cfg.proxy);
+  throwIfStartupAborted();
   const portOverride = parsePort(opts.port);
   if (opts.port !== undefined && portOverride === null) {
     defaultRuntime.error(formatInvalidPortOption("--port"));
@@ -1110,6 +1122,10 @@ async function runGatewayCommandOnce(opts: GatewayRunOpts, hooks: GatewayRunRunt
       beginBoot,
       completeBoot,
       onRestartStartupFailure: triageStartupFailure,
+      ...(hooks.startupSignal ? { startupSignal: hooks.startupSignal } : {}),
+      ...(hooks.releaseStartupSignalOwner
+        ? { releaseStartupSignalOwner: hooks.releaseStartupSignalOwner }
+        : {}),
       start: async ({
         processStartedAt,
         startupStartedAt,
@@ -1150,9 +1166,16 @@ async function runGatewayCommandOnce(opts: GatewayRunOpts, hooks: GatewayRunRunt
       port,
       healthHost,
       log: gatewayLog,
+      ...(hooks.startupSignal ? { startupSignal: hooks.startupSignal } : {}),
       probeHealth: createConfiguredGatewayHealthProbe(cfg),
     });
   } catch (err) {
+    // The CLI-owned startup signal has already recorded the conventional
+    // signal exit code and the run-loop finally block released its lock.
+    // Avoid converting that controlled abort into a generic startup failure.
+    if (hooks.startupSignal?.aborted) {
+      return;
+    }
     if (isGatewayLockError(err)) {
       const errMessage = formatErrorMessage(err);
       defaultRuntime.error(

--- a/src/cli/gateway-cli/runtime-hooks.ts
+++ b/src/cli/gateway-cli/runtime-hooks.ts
@@ -3,6 +3,9 @@ import type { OpenClawConfig } from "../../config/types.openclaw.js";
 export type GatewayRunRuntimeHooks = {
   releaseManagedProxy?: () => Promise<void> | void;
   refreshManagedProxy?: (config: OpenClawConfig["proxy"]) => Promise<void> | void;
+  /** Signal owned by the CLI until the Gateway run loop installs its handlers. */
+  startupSignal?: AbortSignal;
+  releaseStartupSignalOwner?: () => void;
 };
 
 let activeGatewayRunRuntimeHooks: GatewayRunRuntimeHooks = {};

--- a/src/cli/gateway-cli/startup-signal.test.ts
+++ b/src/cli/gateway-cli/startup-signal.test.ts
@@ -1,0 +1,78 @@
+// Process regression for Gateway startup signal ownership and lease cleanup.
+import { execFile } from "node:child_process";
+import path from "node:path";
+import process from "node:process";
+import { promisify } from "node:util";
+import { describe, expect, it } from "vitest";
+
+const execFileAsync = promisify(execFile);
+
+describe("gateway startup signal owner", () => {
+  it("aborts startup work on SIGTERM and releases the plugin lifecycle lease", async () => {
+    const signalModule = new URL("./startup-signal.ts", import.meta.url).href;
+    const leaseModule = new URL("../../plugins/plugin-lifecycle-lease.ts", import.meta.url).href;
+    const script = `
+      const { installGatewayStartupSignalOwner } = await import(${JSON.stringify(signalModule)});
+      const { withPluginLifecycleLease } = await import(${JSON.stringify(leaseModule)});
+      const { DatabaseSync } = await import("node:sqlite");
+      const statePath = process.env.OPENCLAW_STATE_DIR + "/state/openclaw.sqlite";
+      const owner = installGatewayStartupSignalOwner();
+      const operation = withPluginLifecycleLease(
+        { env: process.env, signal: owner.signal, leaseMs: 60_000, waitMs: 1_000 },
+        async (lease) => {
+          console.log("__LEASE_ACQUIRED__");
+          setTimeout(() => process.kill(process.pid, "SIGTERM"), 25);
+          await new Promise((resolve, reject) => {
+            const timer = setTimeout(resolve, 30_000);
+            lease.signal.addEventListener("abort", () => {
+              clearTimeout(timer);
+              reject(lease.signal.reason);
+            }, { once: true });
+          });
+        },
+      );
+      await operation.catch((error) => {
+        console.error("__ABORTED__", error?.code ?? error?.name ?? String(error));
+      });
+      const database = new DatabaseSync(statePath, { readOnly: true });
+      const lease = database.prepare(
+        "SELECT 1 FROM state_leases WHERE scope = 'core:plugin-lifecycle' AND lease_key = 'global'",
+      ).get();
+      database.close();
+      console.log("__RESULT__" + JSON.stringify({
+        aborted: owner.signal.aborted,
+        exitCode: process.exitCode,
+        leaseActive: Boolean(lease),
+      }));
+      owner.dispose();
+      process.exitCode = 0;
+    `;
+    const root = path.resolve(".");
+    const result = await execFileAsync(
+      process.execPath,
+      ["--import", "tsx", "--input-type=module", "--eval", script],
+      {
+        cwd: root,
+        env: {
+          ...process.env,
+          HOME: process.env.HOME,
+          OPENCLAW_STATE_DIR: `/tmp/openclaw-startup-signal-${process.pid}`,
+          OPENCLAW_TEST_FAST: "1",
+          NO_COLOR: "1",
+        },
+        encoding: "utf8",
+        timeout: 10_000,
+      },
+    );
+    const output = `${result.stderr}\n${result.stdout}`;
+    expect(output).toContain("__LEASE_ACQUIRED__");
+    expect(output).toContain("__ABORTED__");
+    const resultLine = result.stdout.split("\n").find((line) => line.startsWith("__RESULT__"));
+    expect(resultLine, output).toBeDefined();
+    expect(JSON.parse(resultLine!.slice("__RESULT__".length))).toEqual({
+      aborted: true,
+      exitCode: 143,
+      leaseActive: false,
+    });
+  }, 20_000);
+});

--- a/src/cli/gateway-cli/startup-signal.ts
+++ b/src/cli/gateway-cli/startup-signal.ts
@@ -1,0 +1,47 @@
+import process from "node:process";
+
+export type GatewayStartupSignalOwner = {
+  signal: AbortSignal;
+  /** Stop owning process signals once the Gateway run loop has installed its handlers. */
+  release(): void;
+  /** Remove listeners when startup exits before the run loop takes ownership. */
+  dispose(): void;
+};
+
+/** Own SIGINT/SIGTERM across Gateway preflight and hand off to the run loop. */
+export function installGatewayStartupSignalOwner(): GatewayStartupSignalOwner {
+  const controller = new AbortController();
+  let released = false;
+  const onSignal = (signal: NodeJS.Signals, exitCode: number) => {
+    if (controller.signal.aborted) {
+      return;
+    }
+    process.exitCode = exitCode;
+    controller.abort(new Error(`Gateway startup interrupted by ${signal}`));
+  };
+  const onSigterm = () => onSignal("SIGTERM", 143);
+  const onSigint = () => onSignal("SIGINT", 130);
+  const removeListeners = () => {
+    process.removeListener("SIGTERM", onSigterm);
+    process.removeListener("SIGINT", onSigint);
+  };
+  process.on("SIGTERM", onSigterm);
+  process.on("SIGINT", onSigint);
+  return {
+    signal: controller.signal,
+    release() {
+      if (released) {
+        return;
+      }
+      released = true;
+      removeListeners();
+    },
+    dispose() {
+      if (released) {
+        return;
+      }
+      released = true;
+      removeListeners();
+    },
+  };
+}

--- a/src/cli/program/config-guard.ts
+++ b/src/cli/program/config-guard.ts
@@ -227,6 +227,7 @@ export async function ensureConfigReady(
     skipPristineCoreStateMigrations?: boolean;
     skipPristineStartupStateMigrations?: boolean;
     validateConfigOnly?: boolean;
+    signal?: AbortSignal;
   },
   recoveryDeps?: InvalidConfigRecoveryDeps,
 ): Promise<void> {
@@ -284,6 +285,7 @@ export async function ensureConfigReady(
         ...(params.skipPristineCoreStateMigrations
           ? { skipPristineCoreStateMigrations: true }
           : {}),
+        ...(params.signal ? { signal: params.signal } : {}),
       });
     try {
       return !params.suppressDoctorStdout

--- a/src/cli/program/preaction.test.ts
+++ b/src/cli/program/preaction.test.ts
@@ -4,6 +4,7 @@ import { repoInstallSpec } from "openclaw/plugin-sdk/test-fixtures";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { loggingState } from "../../logging/state.js";
 import { isConfigSetJsonParseOnly } from "../config-output-mode.js";
+import { installGatewayRunRuntimeHooks } from "../gateway-cli/runtime-hooks.js";
 import { setCommandJsonMode } from "./json-mode.js";
 import { applyParentDefaultHelpAction } from "./parent-default-help.js";
 import {
@@ -374,34 +375,24 @@ describe("registerPreActionHooks", () => {
     expect(ensurePluginRegistryLoadedMock).not.toHaveBeenCalled();
   });
 
-  it("runs gateway pre-bootstrap before full-CLI gateway bootstrap", async () => {
-    prepareGatewayRunBootstrapMock.mockResolvedValueOnce(false);
+  it("passes CLI options and the startup signal to Gateway pre-bootstrap", async (context) => {
+    const startupSignal = new AbortController().signal;
+    context.onTestFinished(installGatewayRunRuntimeHooks({ startupSignal }));
     const gatewayRunCommand = resolveActionCommand(["gateway", "run"]);
     gatewayRunCommand.setOptionValueWithSource("force", true, "cli");
-    try {
-      await runPreAction({
-        parseArgv: ["gateway", "run"],
-        processArgv: [
-          "node",
-          "openclaw",
-          "--log-level",
-          "debug",
-          "gateway",
-          "run",
-          "--raw-stream-path",
-          "--reset",
-          "--force",
-        ],
-      });
-    } finally {
+    context.onTestFinished(() => {
       gatewayRunCommand.setOptionValueWithSource("force", false, "default");
-    }
+    });
+    await runPreAction({
+      parseArgv: ["gateway", "run"],
+      processArgv: ["node", "openclaw", "gateway", "run", "--reset", "--force"],
+    });
 
     expect(prepareGatewayRunBootstrapMock).toHaveBeenCalledWith({
       opts: expect.objectContaining({ force: true, reset: false }),
       runtime: runtimeMock,
+      signal: startupSignal,
     });
-    expect(ensureConfigReadyMock).not.toHaveBeenCalled();
   });
 
   it("passes the gateway config recheck to the state migration boundary", async () => {

--- a/src/cli/program/preaction.ts
+++ b/src/cli/program/preaction.ts
@@ -14,6 +14,7 @@ import {
 import { inheritOptionFromParent } from "../command-options.js";
 import { resolveCliCommandPathPolicy } from "../command-path-policy.js";
 import { resolveCliStartupPolicy } from "../command-startup-policy.js";
+import { getGatewayRunRuntimeHooks } from "../gateway-cli/runtime-hooks.js";
 import { applyResolvedCommandOutputMode } from "../json-output-mode.js";
 import { isModelsPlainMachineOutput } from "../models-output-mode.js";
 import {
@@ -178,16 +179,25 @@ export function registerPreActionHooks(program: Command, programVersion: string)
     if (isGuidedConfigAction(actionCommand) || isGuidedConfigCommandPath(commandPath)) {
       return;
     }
+    const startupSignal = getGatewayRunRuntimeHooks().startupSignal;
     await runStateStoreGuard(commandPath);
     if (startupPolicy.skipConfigGuard) {
       // Config validation and plugin activation are independent startup policies.
       // A cold config read must not suppress a plugin runtime explicitly required by the command.
-      await ensureCliExecutionBootstrap({
-        runtime: defaultRuntime,
-        commandPath,
-        startupPolicy,
-        skipConfigGuard: true,
-      });
+      try {
+        await ensureCliExecutionBootstrap({
+          runtime: defaultRuntime,
+          commandPath,
+          startupPolicy,
+          skipConfigGuard: true,
+          ...(startupSignal ? { signal: startupSignal } : {}),
+        });
+      } catch (error) {
+        if (startupSignal?.aborted) {
+          return;
+        }
+        throw error;
+      }
       return;
     }
     let beforeStateMigrations: ((snapshot?: ConfigFileSnapshot) => Promise<boolean>) | undefined;
@@ -205,7 +215,11 @@ export function registerPreActionHooks(program: Command, programVersion: string)
       const resolvedOptions = resolveGatewayRunOptions(actionCommand.opts(), actionCommand);
       allowInvalid ||= resolvedOptions.allowUnconfigured === true;
       const opts = resolvedOptions;
-      const shouldBootstrap = await prepareGatewayRunBootstrap({ opts, runtime: defaultRuntime });
+      const shouldBootstrap = await prepareGatewayRunBootstrap({
+        opts,
+        runtime: defaultRuntime,
+        ...(startupSignal ? { signal: startupSignal } : {}),
+      });
       if (!shouldBootstrap) {
         return;
       }
@@ -239,19 +253,34 @@ export function registerPreActionHooks(program: Command, programVersion: string)
         return (await existingGuard?.(snapshot)) ?? true;
       };
     }
-    await ensureCliExecutionBootstrap({
-      runtime: defaultRuntime,
-      commandPath,
-      startupPolicy,
-      allowInvalid,
-      ...(beforeStateMigrations ? { beforeStateMigrations } : {}),
-      ...(skipPristineStartupStateMigrations ? { skipPristineStartupStateMigrations: true } : {}),
-      ...(skipPristineCoreStateMigrations ? { skipPristineCoreStateMigrations: true } : {}),
-    });
+    try {
+      await ensureCliExecutionBootstrap({
+        runtime: defaultRuntime,
+        commandPath,
+        startupPolicy,
+        allowInvalid,
+        ...(startupSignal ? { signal: startupSignal } : {}),
+        ...(beforeStateMigrations ? { beforeStateMigrations } : {}),
+        ...(skipPristineStartupStateMigrations ? { skipPristineStartupStateMigrations: true } : {}),
+        ...(skipPristineCoreStateMigrations ? { skipPristineCoreStateMigrations: true } : {}),
+      });
+    } catch (error) {
+      if (startupSignal?.aborted) {
+        return;
+      }
+      throw error;
+    }
     if (beforeStateMigrations && isGatewayRunAction(actionCommand)) {
-      const { reloadTrustedGatewayRunEnvironment } =
-        await import("../gateway-cli/pre-bootstrap.js");
-      await reloadTrustedGatewayRunEnvironment({ runtime: defaultRuntime });
+      try {
+        const { reloadTrustedGatewayRunEnvironment } =
+          await import("../gateway-cli/pre-bootstrap.js");
+        await reloadTrustedGatewayRunEnvironment({ runtime: defaultRuntime });
+      } catch (error) {
+        if (startupSignal?.aborted) {
+          return;
+        }
+        throw error;
+      }
     }
   });
 }

--- a/src/cli/run-main.exit.test.ts
+++ b/src/cli/run-main.exit.test.ts
@@ -1022,6 +1022,7 @@ describe("runCli exit behavior", () => {
         beforeStateMigrations: expect.any(Function),
         commandPath: ["gateway"],
         loadPlugins: false,
+        signal: expect.any(AbortSignal),
       }),
     );
     expect(readConfigFileSnapshotMock.mock.calls).toEqual([
@@ -1032,6 +1033,45 @@ describe("runCli exit behavior", () => {
     const bootstrapOrder = ensureCliExecutionBootstrapMock.mock.invocationCallOrder[0] ?? 0;
     expect(admissionOrder).toBeGreaterThan(0);
     expect(bootstrapOrder).toBeGreaterThan(admissionOrder);
+  });
+
+  it("stops suspicious config recovery when Gateway startup is interrupted", async () => {
+    const processOnSpy = vi.spyOn(process, "on");
+    const previousExitCode = process.exitCode;
+    const currentSnapshot = {
+      exists: true,
+      valid: true,
+      sourceConfig: { gateway: { mode: "local" } },
+    };
+    // Main plans suspicious-config recovery through prepareConfigRecovery after the guarded
+    // read instead of the recoverSuspicious callback, so fire the startup SIGTERM from the
+    // first guard read that runs after the startup signal owner registered its handler, and
+    // expect the bootstrap to refuse before plugin/bootstrap admission.
+    let interrupted = false;
+    readConfigFileSnapshotMock.mockImplementation(async () => {
+      if (!interrupted) {
+        const sigtermHandler = processOnSpy.mock.calls.find(([event]) => event === "SIGTERM")?.[1];
+        if (typeof sigtermHandler === "function") {
+          interrupted = true;
+          sigtermHandler();
+        }
+      }
+      return currentSnapshot;
+    });
+
+    try {
+      await runCli(["node", "openclaw", "gateway"]);
+      const hooks = addGatewayRunCommandMock.mock.calls[0]?.[1] as
+        | { beforeRun?: (opts: { force?: boolean }) => Promise<void> }
+        | undefined;
+      await hooks?.beforeRun?.({});
+
+      expect(interrupted).toBe(true);
+      expect(ensureCliExecutionBootstrapMock).not.toHaveBeenCalled();
+    } finally {
+      process.exitCode = previousExitCode;
+      processOnSpy.mockRestore();
+    }
   });
 
   it("defers config-drift exit to the migration owner before startup migrations", async () => {
@@ -3482,6 +3522,81 @@ describe("runCli exit behavior", () => {
       stderr.mockRestore();
     }
     expect(getPendingCliDisposers()).not.toContain("managed-proxy");
+  });
+
+  it("waits for Gateway startup cleanup before the managed proxy exits on SIGTERM", async () => {
+    const handle = makeProxyHandle();
+    startProxyMock.mockResolvedValueOnce(handle);
+    let rejectBootstrap: (reason?: unknown) => void = () => {};
+    ensureCliExecutionBootstrapMock.mockReturnValueOnce(
+      new Promise<void>((_resolve, reject) => {
+        rejectBootstrap = reject;
+      }),
+    );
+    commanderParseAsyncMock.mockImplementationOnce(async () => {
+      const hooks = addGatewayRunCommandMock.mock.calls[0]?.[1] as
+        | { beforeRun?: (opts: { force?: boolean }) => Promise<void> }
+        | undefined;
+      await hooks?.beforeRun?.({});
+    });
+
+    const processOnSpy = vi.spyOn(process, "on");
+    const processOnceSpy = vi.spyOn(process, "once");
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation(((code?: number | string) => {
+      void code;
+      return undefined as never;
+    }) as typeof process.exit);
+    const previousExitCode = process.exitCode;
+    const startupError = new Error("configured-plugin repair aborted");
+
+    try {
+      const runPromise = runCli(["node", "openclaw", "gateway", "run"]);
+      await vi.waitFor(
+        () => {
+          expect(startProxyMock).toHaveBeenCalledWith(undefined);
+          expect(ensureCliExecutionBootstrapMock).toHaveBeenCalledWith(
+            expect.objectContaining({ signal: expect.any(AbortSignal) }),
+          );
+          expect(processOnSpy.mock.calls.some(([event]) => event === "SIGTERM")).toBe(true);
+          expect(processOnceSpy.mock.calls.some(([event]) => event === "SIGTERM")).toBe(true);
+        },
+        { timeout: 5_000 },
+      );
+
+      const startupSigtermHandler = processOnSpy.mock.calls.find(
+        ([event]) => event === "SIGTERM",
+      )?.[1];
+      const proxySigtermHandler = processOnceSpy.mock.calls.find(
+        ([event]) => event === "SIGTERM",
+      )?.[1];
+      if (
+        typeof startupSigtermHandler !== "function" ||
+        typeof proxySigtermHandler !== "function"
+      ) {
+        throw new Error("Gateway SIGTERM handlers were not registered");
+      }
+      startupSigtermHandler();
+      proxySigtermHandler();
+
+      await new Promise<void>((resolve) => {
+        setTimeout(resolve, 0);
+      });
+      expect(exitSpy).not.toHaveBeenCalled();
+
+      rejectBootstrap(startupError);
+      await runPromise;
+      await vi.waitFor(() => {
+        expect(exitSpy).toHaveBeenCalledWith(143);
+      });
+      expect(stopProxyMock.mock.invocationCallOrder[0]).toBeLessThan(
+        exitSpy.mock.invocationCallOrder[0]!,
+      );
+    } finally {
+      process.exitCode = previousExitCode;
+      exitSpy.mockRestore();
+      processOnceSpy.mockRestore();
+      processOnSpy.mockRestore();
+    }
   });
 
   it("synchronously kills the managed proxy during hard process exit", async () => {

--- a/src/cli/run-main.ts
+++ b/src/cli/run-main.ts
@@ -37,6 +37,10 @@ import { resolveCliStartupPolicy as resolveCliStartupPolicyForArgv } from "./com
 import { maybeRunCliInContainer, parseCliContainerArgs } from "./container-target.js";
 import { shouldStartLocalOnboarding } from "./fresh-install-config.js";
 import {
+  installGatewayStartupSignalOwner,
+  type GatewayStartupSignalOwner,
+} from "./gateway-cli/startup-signal.js";
+import {
   consumeGatewayFastPathRootOptionToken,
   consumeGatewayRunOptionToken,
   resolveGatewayCatalogCommandPath,
@@ -68,7 +72,11 @@ import {
 } from "./run-main-policy.js";
 import { withCliCommandCleanup, type CliHarnessCleanup } from "./runtime-cleanup-scope.js";
 import { closeCliResources, runCliDisposer } from "./runtime-cleanup.js";
-import { registerSignalExitBarrier, waitForSignalExitBarriers } from "./signal-exit-barrier.js";
+import {
+  registerSignalExitBarrier,
+  registerSignalExitGate,
+  waitForSignalExitBarriers,
+} from "./signal-exit-barrier.js";
 import {
   configureGatewayStartupTraceConsoleFormatting,
   createGatewayDispatchStartupTrace,
@@ -165,6 +173,7 @@ function isGatewayRunInvocationArgv(argv: string[]): boolean {
 async function tryRunGatewayRunFastPath(
   argv: string[],
   startupTrace: ReturnType<typeof createGatewayDispatchStartupTrace>,
+  startupSignalOwner?: GatewayStartupSignalOwner,
 ): Promise<boolean> {
   if (!isGatewayRunFastPathArgv(argv)) {
     return false;
@@ -214,7 +223,11 @@ async function tryRunGatewayRunFastPath(
         wasPreparedGatewayRunCoreStatePristine,
         wasPreparedGatewayRunStatePristine,
       } = await import("./gateway-cli/pre-bootstrap.js");
-      const prepared = await prepareGatewayRunBootstrap({ opts, runtime: defaultRuntime });
+      const prepared = await prepareGatewayRunBootstrap({
+        opts,
+        runtime: defaultRuntime,
+        ...(startupSignalOwner ? { signal: startupSignalOwner.signal } : {}),
+      });
       if (prepared) {
         skipPristineStartupStateMigrations = wasPreparedGatewayRunStatePristine();
         skipPristineCoreStateMigrations = wasPreparedGatewayRunCoreStatePristine();
@@ -230,19 +243,30 @@ async function tryRunGatewayRunFastPath(
     if (!shouldBootstrap) {
       return;
     }
-    await startupTrace.measure("gateway-run-bootstrap", async () => {
-      await ensureCliExecutionBootstrap({
-        runtime: defaultRuntime,
-        commandPath,
-        startupPolicy,
-        loadPlugins: false,
-        ...(beforeStateMigrations ? { beforeStateMigrations } : {}),
-        ...(skipPristineStartupStateMigrations ? { skipPristineStartupStateMigrations: true } : {}),
-        ...(skipPristineCoreStateMigrations ? { skipPristineCoreStateMigrations: true } : {}),
+    try {
+      await startupTrace.measure("gateway-run-bootstrap", async () => {
+        await ensureCliExecutionBootstrap({
+          runtime: defaultRuntime,
+          commandPath,
+          startupPolicy,
+          loadPlugins: false,
+          ...(startupSignalOwner ? { signal: startupSignalOwner.signal } : {}),
+          ...(beforeStateMigrations ? { beforeStateMigrations } : {}),
+          ...(skipPristineStartupStateMigrations
+            ? { skipPristineStartupStateMigrations: true }
+            : {}),
+          ...(skipPristineCoreStateMigrations ? { skipPristineCoreStateMigrations: true } : {}),
+        });
+        const { reloadTrustedGatewayRunEnvironment } =
+          await import("./gateway-cli/pre-bootstrap.js");
+        await reloadTrustedGatewayRunEnvironment({ runtime: defaultRuntime });
       });
-      const { reloadTrustedGatewayRunEnvironment } = await import("./gateway-cli/pre-bootstrap.js");
-      await reloadTrustedGatewayRunEnvironment({ runtime: defaultRuntime });
-    });
+    } catch (error) {
+      if (startupSignalOwner?.signal.aborted) {
+        return;
+      }
+      throw error;
+    }
   };
   const gateway = addGatewayRunCommand(
     program.command("gateway").description("Run, inspect, and query the WebSocket Gateway"),
@@ -1289,6 +1313,18 @@ async function runCliWithPreparedOutputMode(
     installProxySignalHandlers();
   };
   let uninstallGatewayRunRuntimeHooks: (() => void) | null = null;
+  const gatewayStartupSignalOwner = isGatewayRunInvocation
+    ? installGatewayStartupSignalOwner()
+    : null;
+  let settleGatewayRunCleanup: (() => void) | undefined;
+  const gatewayRunCleanupSettled = gatewayStartupSignalOwner
+    ? new Promise<void>((resolve) => {
+        settleGatewayRunCleanup = resolve;
+      })
+    : null;
+  const unregisterGatewayRunSignalExitGate = gatewayRunCleanupSettled
+    ? registerSignalExitGate(gatewayRunCleanupSettled)
+    : null;
 
   try {
     const startupTraces = [startupTrace, options.additionalStartupTrace].filter(
@@ -1343,6 +1379,12 @@ async function runCliWithPreparedOutputMode(
       uninstallGatewayRunRuntimeHooks = installGatewayRunRuntimeHooks({
         releaseManagedProxy: stopStartedProxy,
         refreshManagedProxy: replaceStartedProxy,
+        ...(gatewayStartupSignalOwner
+          ? {
+              startupSignal: gatewayStartupSignalOwner.signal,
+              releaseStartupSignalOwner: () => gatewayStartupSignalOwner.release(),
+            }
+          : {}),
       });
     }
 
@@ -1492,7 +1534,11 @@ async function runCliWithPreparedOutputMode(
       shouldUseCliEnvProxy && shouldBootstrapCliProxyBeforeFastPath();
     if (
       !bootstrapProxyBeforeFastPath &&
-      (await tryRunGatewayRunFastPath(normalizedArgv, startupTrace))
+      (await tryRunGatewayRunFastPath(
+        normalizedArgv,
+        startupTrace,
+        gatewayStartupSignalOwner ?? undefined,
+      ))
     ) {
       return;
     }
@@ -1505,7 +1551,11 @@ async function runCliWithPreparedOutputMode(
 
     if (
       bootstrapProxyBeforeFastPath &&
-      (await tryRunGatewayRunFastPath(normalizedArgv, startupTrace))
+      (await tryRunGatewayRunFastPath(
+        normalizedArgv,
+        startupTrace,
+        gatewayStartupSignalOwner ?? undefined,
+      ))
     ) {
       return;
     }
@@ -1705,13 +1755,19 @@ async function runCliWithPreparedOutputMode(
       stopStartupProgress();
     }
   } finally {
-    pluginCliSession?.close();
-    uninstallGatewayRunRuntimeHooks?.();
-    const resources = options.harnessCleanup?.pluginResources;
-    await runCliDisposer("managed-proxy", stopStartedProxy, resources?.runCleanup);
-    await closeCliResources(options.harnessCleanup);
-    if (!resources) {
-      pauseNonTtyStdinForCliExit();
+    try {
+      gatewayStartupSignalOwner?.dispose();
+      pluginCliSession?.close();
+      uninstallGatewayRunRuntimeHooks?.();
+      const resources = options.harnessCleanup?.pluginResources;
+      await runCliDisposer("managed-proxy", stopStartedProxy, resources?.runCleanup);
+      await closeCliResources(options.harnessCleanup);
+      if (!resources) {
+        pauseNonTtyStdinForCliExit();
+      }
+    } finally {
+      settleGatewayRunCleanup?.();
+      unregisterGatewayRunSignalExitGate?.();
     }
   }
 }

--- a/src/commands/doctor-config-preflight-measure.ts
+++ b/src/commands/doctor-config-preflight-measure.ts
@@ -26,7 +26,15 @@ export async function measureDoctorConfigPreflightStep<T>(
   name: string,
   run: () => T | Promise<T>,
   measure?: ConfigSnapshotReadMeasure,
+  signal?: AbortSignal,
 ): Promise<T> {
+  signal?.throwIfAborted();
   const tracedRun = () => measureGatewayStartupPreflightStep(name, run);
-  return measure ? await measure(`doctor.config-preflight.${name}`, tracedRun) : await tracedRun();
+  try {
+    return measure
+      ? await measure(`doctor.config-preflight.${name}`, tracedRun)
+      : await tracedRun();
+  } finally {
+    signal?.throwIfAborted();
+  }
 }

--- a/src/commands/doctor-config-preflight-plugin-verification.ts
+++ b/src/commands/doctor-config-preflight-plugin-verification.ts
@@ -25,7 +25,9 @@ async function planStartupPluginVerification(params: {
   cfg: OpenClawConfig;
   env: NodeJS.ProcessEnv;
   measure?: ConfigSnapshotReadMeasure;
+  signal?: AbortSignal;
 }) {
+  params.signal?.throwIfAborted();
   const { planStartupPluginConvergence } = await measureDoctorConfigPreflightStep(
     "plugin-plan-import",
     () => import("./doctor/shared/startup-plugin-convergence-plan.js"),
@@ -80,7 +82,9 @@ export async function runStartupUpgradeConvergence(params: {
   cfg: OpenClawConfig;
   env: NodeJS.ProcessEnv;
   measure?: ConfigSnapshotReadMeasure;
+  signal?: AbortSignal;
 }): Promise<StartupPluginConvergenceResult> {
+  params.signal?.throwIfAborted();
   const plan = await planStartupPluginVerification(params);
   if (!plan.required) {
     return { blockingDiagnostic: null, quarantinedPlugins: [] };
@@ -97,6 +101,7 @@ export async function runStartupUpgradeConvergence(params: {
         cfg: params.cfg,
         env: params.env,
         compatibilityHostVersion: resolveCompatibilityHostVersion(params.env),
+        ...(params.signal ? { signal: params.signal } : {}),
       }),
     params.measure,
   );
@@ -149,7 +154,9 @@ export async function refreshStartupPluginQuarantine(params: {
   cfg: OpenClawConfig;
   env: NodeJS.ProcessEnv;
   measure?: ConfigSnapshotReadMeasure;
+  signal?: AbortSignal;
 }): Promise<StartupPluginConvergenceResult> {
+  params.signal?.throwIfAborted();
   const plan = await planStartupPluginVerification(params);
   if (!plan.required) {
     return { blockingDiagnostic: null, quarantinedPlugins: [] };

--- a/src/commands/doctor-config-preflight-startup.ts
+++ b/src/commands/doctor-config-preflight-startup.ts
@@ -180,7 +180,9 @@ export async function prepareStartupMigrationPlugins(params: {
   snapshotRead: DoctorConfigPreflightPluginSnapshotRead;
   readRefreshedSnapshot: () => Promise<DoctorConfigPreflightPluginSnapshotRead>;
   beforeStateMigrations?: (snapshot: ConfigFileSnapshot) => Promise<boolean>;
+  signal?: AbortSignal;
 }): Promise<DoctorConfigPreflightPluginSnapshotRead> {
+  params.signal?.throwIfAborted();
   if (params.converge) {
     if (!params.lease) {
       throw new Error("Startup plugin convergence requires the startup migration lease.");
@@ -190,7 +192,10 @@ export async function prepareStartupMigrationPlugins(params: {
   setActiveDegradedPlugins([]);
   const convergence = await (
     params.converge ? runStartupUpgradeConvergence : refreshStartupPluginQuarantine
-  )(params);
+  )({
+    ...params,
+    ...(params.signal ? { signal: params.signal } : {}),
+  });
   setActiveDegradedPlugins(convergence.quarantinedPlugins);
   if (convergence.blockingDiagnostic) {
     throwStartupMigrationRefusal(

--- a/src/commands/doctor-config-preflight.ts
+++ b/src/commands/doctor-config-preflight.ts
@@ -114,7 +114,8 @@ export async function runDoctorConfigPreflight(
     skipPristineStartupStateMigrations?: boolean;
     /** Enable migrations that may retire security-sensitive stores only during explicit repair. */
     doctorOnlyStateMigrations?: boolean;
-  } = {},
+    // Abort process-owned startup work when the Gateway receives SIGINT/SIGTERM.
+  } & { signal?: AbortSignal } = {},
 ): Promise<DoctorConfigPreflightResult> {
   const stateMigrationsRequested = options.migrateState !== false;
   const gatewayStartupCheckpointRequired = options.requireStartupMigrationCheckpoint === true;
@@ -129,7 +130,7 @@ export async function runDoctorConfigPreflight(
   }
   noteStaleUpdateRuns(options);
   const measurePreflightStep = <T>(name: string, run: () => T | Promise<T>) =>
-    measureDoctorConfigPreflightStep(name, run, options.measure);
+    measureDoctorConfigPreflightStep(name, run, options.measure, options.signal);
   const migrationCheckpointRequired =
     gatewayStartupCheckpointRequired || options.requireStateMigrationCheckpoint === true;
   let migrationCheckpoint = migrationCheckpointRequired
@@ -190,6 +191,7 @@ export async function runDoctorConfigPreflight(
     }
     startupMigrationLease = await migrationCheckpoint.acquireStartupMigrationLeaseWithWait({
       env: startupMigrationEnv,
+      ...(options.signal ? { signal: options.signal } : {}),
     });
     // Another process may have completed the same work between our pre-lease read and acquisition.
     // Refresh every checkpoint input under the lease so only work still missing from state runs.
@@ -458,6 +460,7 @@ export async function runDoctorConfigPreflight(
         snapshotRead: { ...configSnapshotRead, snapshot },
         readRefreshedSnapshot: () => readConfigSnapshotForPreflight(false),
         beforeStateMigrations: options.beforeStateMigrations,
+        ...(options.signal ? { signal: options.signal } : {}),
       });
       if (shouldRecordStartupCheckpoint) {
         if (

--- a/src/commands/doctor/shared/missing-configured-plugin-install.install.ts
+++ b/src/commands/doctor/shared/missing-configured-plugin-install.install.ts
@@ -170,6 +170,7 @@ async function installCandidatePackage(
           : undefined,
         coreVersion: resolveCompatibilityHostVersion(params.env),
         versionBoundToCore: candidate.versionBoundToOpenClaw,
+        ...(params.signal ? { signal: params.signal } : {}),
       })
     : null;
   const clawhubInstallSpec = clawhubSpecs?.installSpec ?? candidate.clawhubSpec;

--- a/src/commands/doctor/shared/missing-configured-plugin-install.install.ts
+++ b/src/commands/doctor/shared/missing-configured-plugin-install.install.ts
@@ -85,6 +85,7 @@ export async function installCandidate(params: {
   repairReason?: InstallCandidateRepairReason;
   onCapabilityConsent?: PluginCapabilityConsentHandler;
   beforePersistentEffect?: () => void | Promise<void>;
+  signal?: AbortSignal;
 }): Promise<{
   records: Record<string, PluginInstallRecord>;
   changes: string[];
@@ -94,6 +95,7 @@ export async function installCandidate(params: {
   code?: string;
 }> {
   const consent = capturePluginCapabilityConsentHandlerErrors(params.onCapabilityConsent);
+  params.signal?.throwIfAborted();
   try {
     const result = await installCandidatePackage({
       ...params,
@@ -255,6 +257,7 @@ async function installCandidatePackage(
             expectedPluginId: candidate.pluginId,
             expectedIntegrity: source.expectedIntegrity,
             onBeforePluginArtifactCommit: capabilityConsent.onBeforePluginArtifactCommit,
+            ...(params.signal ? { signal: params.signal } : {}),
           };
           if (source.source === "clawhub") {
             const result = await installPluginFromClawHub({

--- a/src/commands/doctor/shared/missing-configured-plugin-install.repair.ts
+++ b/src/commands/doctor/shared/missing-configured-plugin-install.repair.ts
@@ -76,6 +76,7 @@ export async function repairMissingConfiguredPluginInstalls(params: {
   cfg: OpenClawConfig;
   env?: NodeJS.ProcessEnv;
   onCapabilityConsent?: PluginCapabilityConsentHandler;
+  signal?: AbortSignal;
   /**
    * Optional pre-seeded records. When provided, this map is used instead of
    * the disk-loaded install-record snapshot. Pass the in-memory records
@@ -93,6 +94,7 @@ export async function repairMissingConfiguredPluginInstalls(params: {
     blockedPluginIds: collectBlockedPluginIds(params.cfg),
     ...(params.onCapabilityConsent ? { onCapabilityConsent: params.onCapabilityConsent } : {}),
     ...(params.baselineRecords ? { baselineRecords: params.baselineRecords } : {}),
+    ...(params.signal ? { signal: params.signal } : {}),
   });
 }
 
@@ -106,6 +108,7 @@ export async function repairMissingPluginInstallsForIds(params: {
   baselineRecords?: Record<string, PluginInstallRecord>;
   onCapabilityConsent?: PluginCapabilityConsentHandler;
   beforePersistentEffect?: () => void | Promise<void>;
+  signal?: AbortSignal;
 }): Promise<RepairMissingPluginInstallsResult> {
   return repairMissingPluginInstalls({
     cfg: params.cfg,
@@ -126,6 +129,7 @@ export async function repairMissingPluginInstallsForIds(params: {
     ...(params.onCapabilityConsent ? { onCapabilityConsent: params.onCapabilityConsent } : {}),
     beforePersistentEffect: params.beforePersistentEffect,
     ...(params.baselineRecords ? { baselineRecords: params.baselineRecords } : {}),
+    ...(params.signal ? { signal: params.signal } : {}),
   });
 }
 
@@ -138,16 +142,19 @@ async function repairMissingPluginInstalls(params: {
   baselineRecords?: Record<string, PluginInstallRecord>;
   onCapabilityConsent?: PluginCapabilityConsentHandler;
   beforePersistentEffect?: () => void | Promise<void>;
+  signal?: AbortSignal;
 }): Promise<RepairMissingPluginInstallsResult> {
   // Baseline, awaited review, package publication, and the index write share one generation.
-  return await withPluginLifecycleLease({ env: params.env }, () =>
-    repairMissingPluginInstallsWithLease(params),
+  return await withPluginLifecycleLease(
+    { env: params.env, ...(params.signal ? { signal: params.signal } : {}) },
+    (lease) => repairMissingPluginInstallsWithLease({ ...params, signal: lease.signal }),
   );
 }
 
 async function repairMissingPluginInstallsWithLease(
   params: Parameters<typeof repairMissingPluginInstalls>[0],
 ): Promise<RepairMissingPluginInstallsResult> {
+  params.signal?.throwIfAborted();
   const env = params.env ?? process.env;
   const {
     knownIds,
@@ -211,6 +218,7 @@ async function repairMissingPluginInstallsWithLease(
   };
 
   for (const [pluginId, record] of Object.entries(records)) {
+    params.signal?.throwIfAborted();
     const bundled = bundledPluginsById.get(pluginId);
     if (!bundled || !recordMatchesBundledPackage(record, bundled)) {
       continue;
@@ -300,6 +308,7 @@ async function repairMissingPluginInstallsWithLease(
       },
       ...(params.onCapabilityConsent ? { onCapabilityConsent: params.onCapabilityConsent } : {}),
       beforePersistentEffect: params.beforePersistentEffect,
+      ...(params.signal ? { signal: params.signal } : {}),
     });
     for (const outcome of updateResult.outcomes) {
       if (
@@ -359,6 +368,7 @@ async function repairMissingPluginInstallsWithLease(
         ? new Set([...(params.blockedPluginIds ?? []), ...deferredPluginIds])
         : params.blockedPluginIds,
   })) {
+    params.signal?.throwIfAborted();
     const repair = resolveConfiguredPluginCandidateRepair({
       candidate,
       records: nextRecords,
@@ -397,6 +407,7 @@ async function repairMissingPluginInstallsWithLease(
       repairReason,
       ...(params.onCapabilityConsent ? { onCapabilityConsent: params.onCapabilityConsent } : {}),
       beforePersistentEffect: params.beforePersistentEffect,
+      ...(params.signal ? { signal: params.signal } : {}),
     });
     if (shouldReplaceBrokenOfficialInstall) {
       const installedRecord = installed.records[candidate.pluginId];

--- a/src/commands/doctor/shared/missing-configured-plugin-install.test.ts
+++ b/src/commands/doctor/shared/missing-configured-plugin-install.test.ts
@@ -4068,6 +4068,51 @@ describe("repairMissingConfiguredPluginInstalls", () => {
     expect(result.changes).toEqual(['Repaired missing configured plugin "demo".']);
   });
 
+  it("propagates cancellation from persisted-record repair without continuing fallback", async () => {
+    const records = {
+      demo: {
+        source: "npm",
+        spec: "@openclaw/plugin-demo@1.0.0",
+        installPath: "/missing/demo",
+      },
+    };
+    const controller = new AbortController();
+    const abortReason = new Error("Gateway startup interrupted by SIGTERM");
+    mocks.loadInstalledPluginIndexInstallRecords.mockResolvedValue(records);
+    mocks.updateNpmInstalledPlugins.mockImplementationOnce(
+      async (params: { signal?: AbortSignal }) => {
+        expect(params.signal).toBeDefined();
+        expect(params.signal?.aborted).toBe(false);
+        controller.abort(abortReason);
+        params.signal?.throwIfAborted();
+        throw new Error("expected composed repair signal to abort");
+      },
+    );
+
+    const { repairMissingConfiguredPluginInstalls } =
+      await import("./missing-configured-plugin-install.js");
+    await expect(
+      repairMissingConfiguredPluginInstalls({
+        cfg: {
+          plugins: {
+            entries: {
+              demo: { enabled: true },
+            },
+          },
+        },
+        env: {},
+        signal: controller.signal,
+      }),
+    ).rejects.toMatchObject({
+      code: "OPENCLAW_STATE_LEASE_ABORTED",
+      message: expect.stringContaining("aborted"),
+    });
+
+    expect(mocks.updateNpmInstalledPlugins).toHaveBeenCalledTimes(1);
+    expect(mocks.installPluginFromNpmSpec).not.toHaveBeenCalled();
+    expect(mocks.writePersistedInstalledPluginIndexInstallRecords).not.toHaveBeenCalled();
+  });
+
   it("forwards capability consent to persisted-record repair", async () => {
     const records = {
       demo: {

--- a/src/commands/doctor/shared/post-core-plugin-convergence.ts
+++ b/src/commands/doctor/shared/post-core-plugin-convergence.ts
@@ -165,7 +165,9 @@ export async function runPostCorePluginConvergence(params: {
    */
   baselineInstallRecords?: Record<string, PluginInstallRecord>;
   onCapabilityConsent?: PluginCapabilityConsentHandler;
+  signal?: AbortSignal;
 }): Promise<PostCoreConvergenceResult> {
+  params.signal?.throwIfAborted();
   const env: NodeJS.ProcessEnv = {
     ...params.env,
     OPENCLAW_COMPATIBILITY_HOST_VERSION: params.compatibilityHostVersion ?? VERSION,
@@ -193,6 +195,7 @@ export async function runPostCorePluginConvergence(params: {
     env,
     ...(prunedBaseline ? { baselineRecords: prunedBaseline.records } : {}),
     onCapabilityConsent: params.onCapabilityConsent,
+    ...(params.signal ? { signal: params.signal } : {}),
   });
 
   const warnings: PostCoreConvergenceWarning[] = repair.warnings.map((message) => ({
@@ -222,6 +225,7 @@ export async function runPostCorePluginConvergence(params: {
     records,
     env,
   });
+  params.signal?.throwIfAborted();
   const smokeRecords = filterRecordsToActive({ cfg: params.cfg, records });
   const resolveInstallRecordPaths = (
     installRecords: Record<string, PluginInstallRecord>,

--- a/src/gateway/local-http-probe.ts
+++ b/src/gateway/local-http-probe.ts
@@ -51,7 +51,12 @@ export async function requestGatewayLocalHttpProbe(params: {
       }
       settled = true;
       clearTimeout(deadline);
+      params.signal?.removeEventListener("abort", onAbort);
       resolve(result);
+    };
+    const onAbort = () => {
+      req.destroy();
+      finish(null);
     };
     const request = params.tlsFingerprint ? httpsRequest : httpRequest;
     const req = request(
@@ -100,6 +105,7 @@ export async function requestGatewayLocalHttpProbe(params: {
       req.destroy();
       finish(null);
     }, params.timeoutMs);
+    params.signal?.addEventListener("abort", onAbort, { once: true });
     req.once("timeout", () => {
       req.destroy();
       finish(null);
@@ -141,6 +147,7 @@ export function createConfiguredGatewayLocalProbe(
   return {
     async requestHttp(params) {
       const resolvedTlsFingerprint = await resolveTlsFingerprint();
+      params.signal?.throwIfAborted();
       if (tlsConfig?.enabled === true && !resolvedTlsFingerprint) {
         return null;
       }

--- a/src/infra/clawhub-artifacts.test.ts
+++ b/src/infra/clawhub-artifacts.test.ts
@@ -253,6 +253,61 @@ describe("clawhub artifacts", () => {
     }
   });
 
+  it.each([
+    ["legacy archive", "archive", "/api/v1/packages/demo/download"],
+    ["ClawPack artifact", "clawpack", "/api/v1/packages/demo/versions/1.2.3/artifact/download"],
+  ] as const)(
+    "aborts a held %s request with the caller signal",
+    async (_label, artifact, requestPath) => {
+      const controller = new AbortController();
+      const reason = new Error("Gateway startup interrupted by SIGTERM");
+      let requestedPath = "";
+      let markStarted: () => void = () => undefined;
+      const started = new Promise<void>((resolve) => {
+        markStarted = resolve;
+      });
+      let releaseFetch: (() => void) | undefined;
+
+      const download = downloadClawHubPackageArchive({
+        name: "demo",
+        version: "1.2.3",
+        artifact,
+        signal: controller.signal,
+        fetchImpl: async (input, init) => {
+          requestedPath = new URL(input instanceof Request ? input.url : String(input)).pathname;
+          const requestSignal = init?.signal;
+          if (!requestSignal) {
+            throw new Error("ClawHub download did not receive a request signal");
+          }
+          return await new Promise<Response>((resolve, reject) => {
+            const abort = () => {
+              const abortReason = requestSignal.reason;
+              reject(
+                abortReason instanceof Error
+                  ? abortReason
+                  : new Error("ClawHub download request aborted"),
+              );
+            };
+            requestSignal.addEventListener("abort", abort, { once: true });
+            releaseFetch = () => {
+              requestSignal.removeEventListener("abort", abort);
+              resolve(new Response("released", { status: 400 }));
+            };
+            markStarted();
+          });
+        },
+      });
+      const rejection = expect(download).rejects.toBe(reason);
+
+      await started;
+      controller.abort(reason);
+      releaseFetch?.();
+
+      await rejection;
+      expect(requestedPath).toBe(requestPath);
+    },
+  );
+
   it("downloads ClawPack package artifacts from the version route and verifies response headers", async () => {
     const bytes = new Uint8Array([7, 8, 9]);
     const sha256Hex = createHash("sha256").update(bytes).digest("hex");

--- a/src/infra/clawhub-artifacts.ts
+++ b/src/infra/clawhub-artifacts.ts
@@ -98,6 +98,7 @@ export async function downloadClawHubPackageArchive(params: {
   baseUrl?: string;
   token?: string;
   timeoutMs?: number;
+  signal?: AbortSignal;
   fetchImpl?: ClawHubFetch;
 }): Promise<ClawHubDownloadResult> {
   if (params.artifact === "clawpack") {
@@ -111,6 +112,7 @@ export async function downloadClawHubPackageArchive(params: {
       )}/artifact/download`,
       token: params.token,
       timeoutMs: params.timeoutMs,
+      ...(params.signal ? { signal: params.signal } : {}),
       fetchImpl: params.fetchImpl,
     });
     if (!response.ok) {
@@ -186,6 +188,7 @@ export async function downloadClawHubPackageArchive(params: {
     search,
     token: params.token,
     timeoutMs: params.timeoutMs,
+    ...(params.signal ? { signal: params.signal } : {}),
     fetchImpl: params.fetchImpl,
   });
   if (!response.ok) {

--- a/src/infra/clawhub-client.ts
+++ b/src/infra/clawhub-client.ts
@@ -29,6 +29,7 @@ type ClawHubRequestParams = {
   json?: unknown;
   token?: string;
   timeoutMs?: number;
+  signal?: AbortSignal;
   search?: Record<string, string | undefined>;
   fetchImpl?: ClawHubFetch;
   skipAuth?: boolean;
@@ -216,7 +217,11 @@ export async function requestClawHub(
       ...(params.json === undefined ? {} : { "Content-Type": "application/json" }),
       ...params.headers,
     };
-    const init: RequestInit = { signal: controller.signal };
+    const init: RequestInit = {
+      signal: params.signal
+        ? AbortSignal.any([params.signal, controller.signal])
+        : controller.signal,
+    };
     if (params.method) {
       init.method = params.method;
     }
@@ -243,6 +248,7 @@ export async function requestClawHub(
     disposeRetry: async ({ response }) => {
       await response.body?.cancel().catch(() => undefined);
     },
+    ...(params.signal ? { signal: params.signal } : {}),
   });
 }
 

--- a/src/infra/clawhub-install-trust.ts
+++ b/src/infra/clawhub-install-trust.ts
@@ -553,6 +553,7 @@ async function fetchClawHubSubjectSecurity(params: {
   baseUrl?: string;
   token?: string;
   timeoutMs?: number;
+  signal?: AbortSignal;
 }): Promise<ClawHubFetchedSubjectSecurity> {
   if (params.subject.kind === "plugin") {
     const security = await fetchClawHubPackageSecurity({
@@ -561,6 +562,7 @@ async function fetchClawHubSubjectSecurity(params: {
       baseUrl: params.baseUrl,
       token: params.token,
       timeoutMs: params.timeoutMs,
+      ...(params.signal ? { signal: params.signal } : {}),
     });
     return {
       security,
@@ -601,10 +603,12 @@ export async function checkClawHubPackageTrust(params: {
   baseUrl?: string;
   token?: string;
   timeoutMs?: number;
+  signal?: AbortSignal;
   logger?: ClawHubInstallLogger;
   mode?: "install" | "update";
   confirmInstall?: () => boolean | Promise<boolean>;
 }): Promise<ClawHubTrustFailure | ClawHubTrustAcceptedResult> {
+  params.signal?.throwIfAborted();
   let trust: ClawHubPackageSecurityTrust;
   let overview: string;
   let warningLinks: ClawHubFetchedSubjectSecurity["links"];
@@ -617,6 +621,7 @@ export async function checkClawHubPackageTrust(params: {
       baseUrl: params.baseUrl,
       token: params.token,
       timeoutMs: params.timeoutMs,
+      ...(params.signal ? { signal: params.signal } : {}),
     });
     const identityFailure = validateClawHubSecurityIdentity({
       security: fetchedSecurity.security,
@@ -631,6 +636,7 @@ export async function checkClawHubPackageTrust(params: {
     overview = fetchedSecurity.security.overview;
     warningLinks = fetchedSecurity.links;
   } catch (error) {
+    params.signal?.throwIfAborted();
     return {
       ok: false,
       error: `ClawHub release trust check failed for "${releaseLabel}": ${sanitizeTerminalText(formatErrorMessage(error))}`,
@@ -638,6 +644,7 @@ export async function checkClawHubPackageTrust(params: {
       version: params.version,
     };
   }
+  params.signal?.throwIfAborted();
 
   const assessment = assessClawHubTrust(trust);
   const checkedAt = new Date().toISOString();

--- a/src/infra/clawhub-packages.test.ts
+++ b/src/infra/clawhub-packages.test.ts
@@ -81,12 +81,16 @@ describe("clawhub packages", () => {
 
   it("fetches typed package security reports", async () => {
     let requestedUrl = "";
+    let requestSignal: AbortSignal | undefined;
+    const controller = new AbortController();
     await expect(
       fetchClawHubPackageSecurity({
         name: "@openclaw/diagnostics-otel",
         version: "2026.3.22",
-        fetchImpl: async (input) => {
+        signal: controller.signal,
+        fetchImpl: async (input, init) => {
           requestedUrl = input instanceof Request ? input.url : String(input);
+          requestSignal = init?.signal ?? undefined;
           return new Response(
             JSON.stringify({
               package: {
@@ -139,6 +143,9 @@ describe("clawhub packages", () => {
     expect(new URL(requestedUrl).pathname).toBe(
       "/api/v1/packages/%40openclaw%2Fdiagnostics-otel/versions/2026.3.22/security",
     );
+    expect(requestSignal).toBeDefined();
+    controller.abort();
+    expect(requestSignal?.aborted).toBe(true);
   });
 
   it("rejects malformed package security reports", async () => {

--- a/src/infra/clawhub-packages.ts
+++ b/src/infra/clawhub-packages.ts
@@ -342,6 +342,7 @@ export async function fetchClawHubPackageDetail(params: {
   baseUrl?: string;
   token?: string;
   timeoutMs?: number;
+  signal?: AbortSignal;
   fetchImpl?: ClawHubFetch;
 }): Promise<ClawHubPackageDetail> {
   return await fetchClawHubJson<ClawHubPackageDetail>({
@@ -349,6 +350,7 @@ export async function fetchClawHubPackageDetail(params: {
     path: `/api/v1/packages/${encodeURIComponent(params.name)}`,
     token: params.token,
     timeoutMs: params.timeoutMs,
+    ...(params.signal ? { signal: params.signal } : {}),
     fetchImpl: params.fetchImpl,
   });
 }
@@ -359,6 +361,7 @@ export async function fetchClawHubPackageVersion(params: {
   baseUrl?: string;
   token?: string;
   timeoutMs?: number;
+  signal?: AbortSignal;
   fetchImpl?: ClawHubFetch;
 }): Promise<ClawHubPackageVersion> {
   return await fetchClawHubJson<ClawHubPackageVersion>({
@@ -368,6 +371,7 @@ export async function fetchClawHubPackageVersion(params: {
     )}`,
     token: params.token,
     timeoutMs: params.timeoutMs,
+    ...(params.signal ? { signal: params.signal } : {}),
     fetchImpl: params.fetchImpl,
   });
 }
@@ -378,6 +382,7 @@ export async function fetchClawHubPackageArtifact(params: {
   baseUrl?: string;
   token?: string;
   timeoutMs?: number;
+  signal?: AbortSignal;
   fetchImpl?: ClawHubFetch;
 }): Promise<ClawHubPackageArtifactResolverResponse> {
   return await fetchClawHubJson<ClawHubPackageArtifactResolverResponse>({
@@ -387,6 +392,7 @@ export async function fetchClawHubPackageArtifact(params: {
     )}/artifact`,
     token: params.token,
     timeoutMs: params.timeoutMs,
+    ...(params.signal ? { signal: params.signal } : {}),
     fetchImpl: params.fetchImpl,
   });
 }
@@ -397,6 +403,7 @@ export async function fetchClawHubPackageSecurity(params: {
   baseUrl?: string;
   token?: string;
   timeoutMs?: number;
+  signal?: AbortSignal;
   fetchImpl?: ClawHubFetch;
 }): Promise<ClawHubPackageSecurityResponse> {
   const response = await fetchClawHubJson<unknown>({
@@ -406,6 +413,7 @@ export async function fetchClawHubPackageSecurity(params: {
     )}/security`,
     token: params.token,
     timeoutMs: params.timeoutMs,
+    ...(params.signal ? { signal: params.signal } : {}),
     fetchImpl: params.fetchImpl,
   });
   return parseClawHubPackageSecurityResponse(response);

--- a/src/infra/clawhub-retry.test.ts
+++ b/src/infra/clawhub-retry.test.ts
@@ -197,6 +197,30 @@ describe("retryClawHubRead", () => {
     expect(delays).toEqual([1_000]);
   });
 
+  it("does not retry or wait after the caller cancels a ClawHub read", async () => {
+    const controller = new AbortController();
+    const reason = new Error("Gateway startup interrupted by SIGTERM");
+    const sleep = vi.fn(async () => {});
+    let attempts = 0;
+
+    await expect(
+      retryClawHubRead(
+        async () => {
+          attempts += 1;
+          controller.abort(reason);
+          throw reason;
+        },
+        {
+          disposeRetry: async () => {},
+          signal: controller.signal,
+          sleep,
+        },
+      ),
+    ).rejects.toBe(reason);
+    expect(attempts).toBe(1);
+    expect(sleep).not.toHaveBeenCalled();
+  });
+
   it("retries transient internal server errors", async () => {
     const delays: number[] = [];
     let attempts = 0;

--- a/src/infra/clawhub-retry.ts
+++ b/src/infra/clawhub-retry.ts
@@ -1,4 +1,5 @@
 // Defines the bounded retry contract shared by ClawHub runtime and release reads.
+import { sleepWithAbort } from "./backoff.js";
 import { parseRetryAfterHeaderSeconds } from "./retry-after.js";
 import { retryAsync } from "./retry.js";
 
@@ -12,6 +13,7 @@ type ClawHubResponseHandle = {
 type ClawHubRetryOptions<T extends ClawHubResponseHandle> = {
   disposeRetry: (result: T) => Promise<void>;
   retryRateLimit?: boolean;
+  signal?: AbortSignal;
   sleep?: (ms: number) => Promise<void>;
 };
 
@@ -48,10 +50,12 @@ export async function retryClawHubRead<T extends ClawHubResponseHandle>(
   request: () => Promise<T>,
   options: ClawHubRetryOptions<T>,
 ): Promise<T> {
+  options.signal?.throwIfAborted();
   try {
     return await retryAsync(
       async () => {
         const result = await request();
+        options.signal?.throwIfAborted();
         if (isRetryableClawHubStatus(result.response.status, options.retryRateLimit === true)) {
           throw new RetryableClawHubResponse(result);
         }
@@ -61,6 +65,7 @@ export async function retryClawHubRead<T extends ClawHubResponseHandle>(
         attempts: CLAWHUB_RETRY_DELAYS_MS.length + 1,
         minDelayMs: 0,
         maxDelayMs: CLAWHUB_MAX_RETRY_AFTER_MS,
+        shouldRetry: () => options.signal?.aborted !== true,
         delayMs: ({ attempt }) => CLAWHUB_RETRY_DELAYS_MS[attempt - 1] ?? 0,
         retryAfterMs: (error) =>
           error instanceof RetryableClawHubResponse
@@ -71,10 +76,21 @@ export async function retryClawHubRead<T extends ClawHubResponseHandle>(
             await options.disposeRetry(err.result);
           }
         },
-        sleep: options.sleep,
+        sleep: options.signal
+          ? async (ms) => {
+              options.signal?.throwIfAborted();
+              if (options.sleep) {
+                await options.sleep(ms);
+              } else {
+                await sleepWithAbort(ms, options.signal);
+              }
+              options.signal?.throwIfAborted();
+            }
+          : options.sleep,
       },
     );
   } catch (error) {
+    options.signal?.throwIfAborted();
     // Callers own final HTTP error handling and therefore need the response.
     if (error instanceof RetryableClawHubResponse) {
       return error.result;

--- a/src/infra/git-source.ts
+++ b/src/infra/git-source.ts
@@ -17,17 +17,20 @@ export async function acquireGitSource(params: {
   ref?: string;
   refMode: "detached" | "resolve-remote" | "shallow-branch";
   timeoutMs?: number;
+  signal?: AbortSignal;
   commandEnv?: () => { baseEnv?: NodeJS.ProcessEnv; env?: NodeJS.ProcessEnv };
   cloneSeparator?: boolean;
   recordCommit?: boolean;
   formatFailure?: (failure: GitSourceFailure) => string;
   cleanupOnFailure?: () => Promise<void>;
 }): Promise<{ ok: true; commit?: string } | { ok: false; error: string }> {
+  params.signal?.throwIfAborted();
   const run = (argv: string[], cwd?: string) =>
     runCommandWithTimeout(argv, {
       ...params.commandEnv?.(),
       ...(cwd ? { cwd } : {}),
       timeoutMs: params.timeoutMs ?? 120_000,
+      ...(params.signal ? { signal: params.signal } : {}),
     });
   const failure = async (details: GitSourceFailure) => {
     await params.cleanupOnFailure?.();
@@ -59,6 +62,7 @@ export async function acquireGitSource(params: {
   }
   argv.push(params.url, params.repoDir);
   const clone = await run(argv);
+  params.signal?.throwIfAborted();
   if (clone.code !== 0) {
     return await failure({ action: "clone", ...clone });
   }
@@ -87,6 +91,7 @@ export async function acquireGitSource(params: {
       checkoutRef = commitish;
     }
     const checkout = await run(["git", "switch", "--detach", "--", checkoutRef], params.repoDir);
+    params.signal?.throwIfAborted();
     if (checkout.code !== 0) {
       return await failure({ action: "checkout", ...checkout });
     }
@@ -96,6 +101,7 @@ export async function acquireGitSource(params: {
     return { ok: true };
   }
   const rev = await run(["git", "rev-parse", "HEAD"], params.repoDir);
+  params.signal?.throwIfAborted();
   if (rev.code !== 0) {
     return await failure({ action: "resolve commit for", ...rev });
   }

--- a/src/infra/install-flow.test.ts
+++ b/src/infra/install-flow.test.ts
@@ -127,6 +127,32 @@ describe("withExtractedArchiveRoot", () => {
     });
   });
 
+  it("does not hand an extracted archive to installers after cancellation", async () => {
+    const controller = new AbortController();
+    const reason = new Error("Gateway startup interrupted by SIGTERM");
+    vi.spyOn(installSource, "withInstallWorkspace").mockImplementation(
+      async (_prefix, fn) => await fn("/tmp/openclaw-install-flow"),
+    );
+    vi.spyOn(archive, "extractArchive").mockImplementation(async () => {
+      controller.abort(reason);
+    });
+    vi.spyOn(archive, "resolvePackedRootDir").mockResolvedValue(
+      "/tmp/openclaw-install-flow/extract/package",
+    );
+    const onExtracted = vi.fn(async () => ({ ok: true as const }));
+
+    await expect(
+      withExtractedArchiveRoot({
+        archivePath: "/tmp/plugin.tgz",
+        tempDirPrefix: "openclaw-plugin-",
+        timeoutMs: 1000,
+        signal: controller.signal,
+        onExtracted,
+      }),
+    ).rejects.toBe(reason);
+    expect(onExtracted).not.toHaveBeenCalled();
+  });
+
   it("returns extract failure when extraction throws", async () => {
     const result = await runExtractedArchiveFailureCase(() => {
       vi.spyOn(archive, "extractArchive").mockRejectedValue(new Error("boom"));

--- a/src/infra/install-flow.ts
+++ b/src/infra/install-flow.ts
@@ -45,11 +45,15 @@ export async function withExtractedArchiveRoot<TResult extends { ok: boolean }>(
   logger?: ArchiveLogger;
   limits?: ArchiveExtractLimits;
   rootMarkers?: readonly string[];
+  signal?: AbortSignal;
   onExtracted: (rootDir: string) => Promise<TResult>;
 }): Promise<TResult | { ok: false; error: string }> {
+  params.signal?.throwIfAborted();
   return await withInstallWorkspace(params.tempDirPrefix, async (tmpDir) => {
+    params.signal?.throwIfAborted();
     const extractDir = path.join(tmpDir, "extract");
     await fs.mkdir(extractDir, { recursive: true });
+    params.signal?.throwIfAborted();
 
     params.logger?.info?.(`Extracting ${params.archivePath}…`);
     try {
@@ -60,7 +64,9 @@ export async function withExtractedArchiveRoot<TResult extends { ok: boolean }>(
         logger: params.logger,
         limits: params.limits,
       });
+      params.signal?.throwIfAborted();
     } catch (err) {
+      params.signal?.throwIfAborted();
       return { ok: false, error: `failed to extract archive: ${String(err)}` };
     }
 
@@ -69,7 +75,9 @@ export async function withExtractedArchiveRoot<TResult extends { ok: boolean }>(
       rootDir = await resolvePackedRootDir(extractDir, {
         rootMarkers: params.rootMarkers ? [...params.rootMarkers] : undefined,
       });
+      params.signal?.throwIfAborted();
     } catch (err) {
+      params.signal?.throwIfAborted();
       return { ok: false, error: String(err) };
     }
     return await params.onExtracted(rootDir);

--- a/src/infra/install-package-dir.cancellation.test.ts
+++ b/src/infra/install-package-dir.cancellation.test.ts
@@ -1,0 +1,135 @@
+// Regressions for startup-cancellation during staged package-dir installs.
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createSuiteTempRootTracker } from "../test-helpers/temp-dir.js";
+import { pathExists } from "./fs-safe.js";
+import { installPackageDir } from "./install-package-dir.js";
+import {
+  createExistingInstallFixture,
+  listMatchingDirs,
+} from "./install-package-dir.test-support.js";
+
+vi.mock("./fs-safe.js", async () => {
+  const actual = await vi.importActual<typeof import("./fs-safe.js")>("./fs-safe.js");
+  return {
+    ...actual,
+    pathExists: vi.fn(actual.pathExists),
+  };
+});
+
+async function expectMissingPath(target: string) {
+  await expect(fs.stat(target)).rejects.toMatchObject({ code: "ENOENT" });
+}
+
+describe("installPackageDir startup cancellation", () => {
+  const fixtureRootTracker = createSuiteTempRootTracker({
+    prefix: "openclaw-install-package-dir-cancel-",
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await fixtureRootTracker.cleanup();
+  });
+
+  it("does not publish staged files after validation observes cancellation", async () => {
+    await fixtureRootTracker.setup();
+    const fixtureRoot = await fixtureRootTracker.make("cancelled-install");
+    const sourceDir = path.join(fixtureRoot, "source");
+    const installBaseDir = path.join(fixtureRoot, "plugins");
+    const targetDir = path.join(installBaseDir, "demo");
+    const controller = new AbortController();
+    const reason = new Error("Gateway startup interrupted by SIGTERM");
+    await fs.mkdir(sourceDir, { recursive: true });
+    await fs.writeFile(path.join(sourceDir, "marker.txt"), "new");
+
+    await expect(
+      installPackageDir({
+        sourceDir,
+        targetDir,
+        mode: "install",
+        timeoutMs: 1_000,
+        copyErrorPrefix: "failed to copy plugin",
+        hasDeps: false,
+        depsLogMessage: "",
+        signal: controller.signal,
+        afterInstall: async () => {
+          controller.abort(reason);
+          return { ok: true };
+        },
+      }),
+    ).rejects.toBe(reason);
+    await expectMissingPath(targetDir);
+    await expect(
+      listMatchingDirs(installBaseDir, ".openclaw-install-stage-"),
+    ).resolves.toHaveLength(0);
+  });
+
+  it("cleans the staged directory when cancellation lands during the update target check", async () => {
+    await fixtureRootTracker.setup();
+    const fixtureRoot = await fixtureRootTracker.make("cancelled-update-target-check");
+    const { installBaseDir, sourceDir, targetDir } =
+      await createExistingInstallFixture(fixtureRoot);
+    const controller = new AbortController();
+    const reason = new Error("Gateway startup interrupted by SIGTERM");
+
+    vi.mocked(pathExists).mockImplementationOnce(async () => {
+      controller.abort(reason);
+      return true;
+    });
+
+    await expect(
+      installPackageDir({
+        sourceDir,
+        targetDir,
+        mode: "update",
+        timeoutMs: 1_000,
+        copyErrorPrefix: "failed to copy plugin",
+        hasDeps: false,
+        depsLogMessage: "",
+        signal: controller.signal,
+      }),
+    ).rejects.toBe(reason);
+    await expect(fs.readFile(path.join(targetDir, "marker.txt"), "utf8")).resolves.toBe("old");
+    await expect(
+      listMatchingDirs(installBaseDir, ".openclaw-install-stage-"),
+    ).resolves.toHaveLength(0);
+    await expect(
+      listMatchingDirs(installBaseDir, ".openclaw-install-backups"),
+    ).resolves.toHaveLength(0);
+  });
+
+  it("does not publish staged files when cancellation lands during final publication preparation", async () => {
+    await fixtureRootTracker.setup();
+    const fixtureRoot = await fixtureRootTracker.make("cancelled-final-publication");
+    const sourceDir = path.join(fixtureRoot, "source");
+    const installBaseDir = path.join(fixtureRoot, "plugins");
+    const targetDir = path.join(installBaseDir, "demo");
+    const controller = new AbortController();
+    const reason = new Error("Gateway startup interrupted by SIGTERM");
+    await fs.mkdir(sourceDir, { recursive: true });
+    await fs.writeFile(path.join(sourceDir, "marker.txt"), "new");
+
+    await expect(
+      installPackageDir({
+        sourceDir,
+        targetDir,
+        mode: "install",
+        timeoutMs: 1_000,
+        copyErrorPrefix: "failed to copy plugin",
+        hasDeps: false,
+        depsLogMessage: "",
+        signal: controller.signal,
+        // The guard runs synchronously before the publication rename; an abort
+        // observed there must refuse the move instead of publishing the stage.
+        beforePersistentApply() {
+          controller.abort(reason);
+        },
+      }),
+    ).rejects.toBe(reason);
+    await expectMissingPath(targetDir);
+    await expect(
+      listMatchingDirs(installBaseDir, ".openclaw-install-stage-"),
+    ).resolves.toHaveLength(0);
+  });
+});

--- a/src/infra/install-package-dir.test.ts
+++ b/src/infra/install-package-dir.test.ts
@@ -9,6 +9,7 @@ import { runCommandWithTimeout, type CommandOptions, type SpawnResult } from "..
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
 import { createSuiteTempRootTracker } from "../test-helpers/temp-dir.js";
 import { npmCommandFailureCases } from "../test-utils/npm-spec-install-test-helpers.js";
+import { pathExists } from "./fs-safe.js";
 import {
   copyPackageDirInstallTransactionRequest,
   installPackageDir,
@@ -26,6 +27,14 @@ vi.mock("../process/exec.js", async () => {
   return {
     ...actual,
     runCommandWithTimeout: vi.fn(actual.runCommandWithTimeout),
+  };
+});
+
+vi.mock("./fs-safe.js", async () => {
+  const actual = await vi.importActual<typeof import("./fs-safe.js")>("./fs-safe.js");
+  return {
+    ...actual,
+    pathExists: vi.fn(actual.pathExists),
   };
 });
 
@@ -246,6 +255,73 @@ describe("installPackageDir", () => {
     });
     expect(backupReached).toBe(false);
     await expect(fs.readFile(path.join(targetDir, "marker.txt"), "utf8")).resolves.toBe("old");
+  });
+
+  it("does not publish staged files after validation observes cancellation", async () => {
+    await fixtureRootTracker.setup();
+    const fixtureRoot = await fixtureRootTracker.make("cancelled-install");
+    const sourceDir = path.join(fixtureRoot, "source");
+    const installBaseDir = path.join(fixtureRoot, "plugins");
+    const targetDir = path.join(installBaseDir, "demo");
+    const controller = new AbortController();
+    const reason = new Error("Gateway startup interrupted by SIGTERM");
+    await fs.mkdir(sourceDir, { recursive: true });
+    await fs.writeFile(path.join(sourceDir, "marker.txt"), "new");
+
+    await expect(
+      installPackageDir({
+        sourceDir,
+        targetDir,
+        mode: "install",
+        timeoutMs: 1_000,
+        copyErrorPrefix: "failed to copy plugin",
+        hasDeps: false,
+        depsLogMessage: "",
+        signal: controller.signal,
+        afterInstall: async () => {
+          controller.abort(reason);
+          return { ok: true };
+        },
+      }),
+    ).rejects.toBe(reason);
+    await expectMissingPath(targetDir);
+    await expect(
+      listMatchingDirs(installBaseDir, ".openclaw-install-stage-"),
+    ).resolves.toHaveLength(0);
+  });
+
+  it("cleans the staged directory when cancellation lands during the update target check", async () => {
+    await fixtureRootTracker.setup();
+    const fixtureRoot = await fixtureRootTracker.make("cancelled-update-target-check");
+    const { installBaseDir, sourceDir, targetDir } =
+      await createExistingInstallFixture(fixtureRoot);
+    const controller = new AbortController();
+    const reason = new Error("Gateway startup interrupted by SIGTERM");
+
+    vi.mocked(pathExists).mockImplementationOnce(async () => {
+      controller.abort(reason);
+      return true;
+    });
+
+    await expect(
+      installPackageDir({
+        sourceDir,
+        targetDir,
+        mode: "update",
+        timeoutMs: 1_000,
+        copyErrorPrefix: "failed to copy plugin",
+        hasDeps: false,
+        depsLogMessage: "",
+        signal: controller.signal,
+      }),
+    ).rejects.toBe(reason);
+    await expect(fs.readFile(path.join(targetDir, "marker.txt"), "utf8")).resolves.toBe("old");
+    await expect(
+      listMatchingDirs(installBaseDir, ".openclaw-install-stage-"),
+    ).resolves.toHaveLength(0);
+    await expect(
+      listMatchingDirs(installBaseDir, ".openclaw-install-backups"),
+    ).resolves.toHaveLength(0);
   });
 
   it("restores edits detected after the existing install moves to backup", async () => {

--- a/src/infra/install-package-dir.test.ts
+++ b/src/infra/install-package-dir.test.ts
@@ -9,7 +9,6 @@ import { runCommandWithTimeout, type CommandOptions, type SpawnResult } from "..
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
 import { createSuiteTempRootTracker } from "../test-helpers/temp-dir.js";
 import { npmCommandFailureCases } from "../test-utils/npm-spec-install-test-helpers.js";
-import { pathExists } from "./fs-safe.js";
 import {
   copyPackageDirInstallTransactionRequest,
   installPackageDir,
@@ -27,14 +26,6 @@ vi.mock("../process/exec.js", async () => {
   return {
     ...actual,
     runCommandWithTimeout: vi.fn(actual.runCommandWithTimeout),
-  };
-});
-
-vi.mock("./fs-safe.js", async () => {
-  const actual = await vi.importActual<typeof import("./fs-safe.js")>("./fs-safe.js");
-  return {
-    ...actual,
-    pathExists: vi.fn(actual.pathExists),
   };
 });
 
@@ -255,73 +246,6 @@ describe("installPackageDir", () => {
     });
     expect(backupReached).toBe(false);
     await expect(fs.readFile(path.join(targetDir, "marker.txt"), "utf8")).resolves.toBe("old");
-  });
-
-  it("does not publish staged files after validation observes cancellation", async () => {
-    await fixtureRootTracker.setup();
-    const fixtureRoot = await fixtureRootTracker.make("cancelled-install");
-    const sourceDir = path.join(fixtureRoot, "source");
-    const installBaseDir = path.join(fixtureRoot, "plugins");
-    const targetDir = path.join(installBaseDir, "demo");
-    const controller = new AbortController();
-    const reason = new Error("Gateway startup interrupted by SIGTERM");
-    await fs.mkdir(sourceDir, { recursive: true });
-    await fs.writeFile(path.join(sourceDir, "marker.txt"), "new");
-
-    await expect(
-      installPackageDir({
-        sourceDir,
-        targetDir,
-        mode: "install",
-        timeoutMs: 1_000,
-        copyErrorPrefix: "failed to copy plugin",
-        hasDeps: false,
-        depsLogMessage: "",
-        signal: controller.signal,
-        afterInstall: async () => {
-          controller.abort(reason);
-          return { ok: true };
-        },
-      }),
-    ).rejects.toBe(reason);
-    await expectMissingPath(targetDir);
-    await expect(
-      listMatchingDirs(installBaseDir, ".openclaw-install-stage-"),
-    ).resolves.toHaveLength(0);
-  });
-
-  it("cleans the staged directory when cancellation lands during the update target check", async () => {
-    await fixtureRootTracker.setup();
-    const fixtureRoot = await fixtureRootTracker.make("cancelled-update-target-check");
-    const { installBaseDir, sourceDir, targetDir } =
-      await createExistingInstallFixture(fixtureRoot);
-    const controller = new AbortController();
-    const reason = new Error("Gateway startup interrupted by SIGTERM");
-
-    vi.mocked(pathExists).mockImplementationOnce(async () => {
-      controller.abort(reason);
-      return true;
-    });
-
-    await expect(
-      installPackageDir({
-        sourceDir,
-        targetDir,
-        mode: "update",
-        timeoutMs: 1_000,
-        copyErrorPrefix: "failed to copy plugin",
-        hasDeps: false,
-        depsLogMessage: "",
-        signal: controller.signal,
-      }),
-    ).rejects.toBe(reason);
-    await expect(fs.readFile(path.join(targetDir, "marker.txt"), "utf8")).resolves.toBe("old");
-    await expect(
-      listMatchingDirs(installBaseDir, ".openclaw-install-stage-"),
-    ).resolves.toHaveLength(0);
-    await expect(
-      listMatchingDirs(installBaseDir, ".openclaw-install-backups"),
-    ).resolves.toHaveLength(0);
   });
 
   it("restores edits detected after the existing install moves to backup", async () => {

--- a/src/infra/install-package-dir.ts
+++ b/src/infra/install-package-dir.ts
@@ -252,7 +252,9 @@ export async function installPackageDir<
   afterInstall?: (installedDir: string) => Promise<InstallPackageDirSuccess | TAfterInstallFailure>;
   afterBackup?: (backupDir: string) => Promise<InstallPackageDirSuccess | TAfterInstallFailure>;
   beforePersistentApply?: () => void;
+  signal?: AbortSignal;
 }): Promise<InstallPackageDirSuccess | InstallPackageDirFailure | TAfterInstallFailure> {
+  params.signal?.throwIfAborted();
   const transactionRequest = resolvePackageDirInstallTransactionRequest(params);
   const deferCommit = transactionRequest !== undefined;
   // Retained transactions keep their original lease, even inside a successor's async context.
@@ -267,7 +269,9 @@ export async function installPackageDir<
       installBaseDir,
       candidatePaths: [params.targetDir],
     });
+    params.signal?.throwIfAborted();
   } catch (err) {
+    params.signal?.throwIfAborted();
     return { ok: false, error: `${params.copyErrorPrefix}: ${String(err)}` };
   }
   let installBaseRealPath: string;
@@ -280,7 +284,9 @@ export async function installPackageDir<
     if (installBaseRealPath !== initialInstallBaseRealPath) {
       throw new Error(INSTALL_BASE_CHANGED_ERROR_MESSAGE);
     }
+    params.signal?.throwIfAborted();
   } catch (err) {
+    params.signal?.throwIfAborted();
     if (isInstallBaseChangedError(err)) {
       params.logger?.warn?.(INSTALL_BASE_CHANGED_ABORT_WARNING);
     }
@@ -386,6 +392,11 @@ export async function installPackageDir<
       error: [error, ...recovery].join("; "),
     };
   };
+  const failOrRethrow = async (error: string, cause?: unknown) => {
+    const failure = await fail(error, cause);
+    params.signal?.throwIfAborted();
+    return failure;
+  };
   const restoreBackup = async (): Promise<void> => {
     if (!published.backup) {
       return;
@@ -448,20 +459,24 @@ export async function installPackageDir<
         verbatimSymlinks: true,
       });
     }
+    params.signal?.throwIfAborted();
   } catch (err) {
-    return await fail(`${params.copyErrorPrefix}: ${String(err)}`, err);
+    return await failOrRethrow(`${params.copyErrorPrefix}: ${String(err)}`, err);
   }
 
   try {
     await params.afterCopy?.(stageDir);
+    params.signal?.throwIfAborted();
   } catch (err) {
-    return await fail(`post-copy validation failed: ${String(err)}`, err);
+    return await failOrRethrow(`post-copy validation failed: ${String(err)}`, err);
   }
 
   if (params.hasDeps) {
     try {
+      params.signal?.throwIfAborted();
       await sanitizeManifestForNpmInstall(stageDir);
       const hiddenProjectNpmConfig = await hideProjectNpmConfigForInstall(stageDir);
+      params.signal?.throwIfAborted();
       params.logger?.info?.(params.depsLogMessage);
       const npmRes = await (async () => {
         try {
@@ -476,33 +491,46 @@ export async function installPackageDir<
               timeoutMs: Math.max(params.timeoutMs, 300_000),
               cwd: stageDir,
               env: createSafeNpmInstallEnv(process.env, { npmConfigCwd: stageDir }),
+              ...(params.signal ? { signal: params.signal, killProcessTree: true } : {}),
             },
           );
         } finally {
           await restoreProjectNpmConfigAfterInstall(hiddenProjectNpmConfig);
         }
       })();
+      params.signal?.throwIfAborted();
       if (npmRes.code !== 0) {
-        return await fail(`npm install failed: ${formatNpmCommandFailureOutput(npmRes)}`);
+        return await failOrRethrow(`npm install failed: ${formatNpmCommandFailureOutput(npmRes)}`);
       }
     } catch (error) {
-      return await fail(`npm install failed: ${String(error)}`, error);
+      return await failOrRethrow(`npm install failed: ${String(error)}`, error);
     }
   }
 
   if (params.afterInstall) {
     try {
       const postInstallResult = await params.afterInstall(stageDir);
+      params.signal?.throwIfAborted();
       if (!postInstallResult.ok) {
-        const failed = await fail(postInstallResult.error);
+        const failed = await failOrRethrow(postInstallResult.error);
         return { ...postInstallResult, error: failed.error };
       }
     } catch (err) {
-      return await fail(`post-install validation failed: ${String(err)}`, err);
+      return await failOrRethrow(`post-install validation failed: ${String(err)}`, err);
     }
   }
 
-  if (params.mode === "update" && (await pathExists(canonicalTargetDir))) {
+  let existingTargetPresent = false;
+  if (params.mode === "update") {
+    try {
+      params.signal?.throwIfAborted();
+      existingTargetPresent = await pathExists(canonicalTargetDir);
+      params.signal?.throwIfAborted();
+    } catch (err) {
+      return await failOrRethrow(`${params.copyErrorPrefix}: ${String(err)}`, err);
+    }
+  }
+  if (existingTargetPresent) {
     const backupRoot = path.join(installBaseRealPath, ".openclaw-install-backups");
     const backupPath = path.join(
       backupRoot,
@@ -528,8 +556,11 @@ export async function installPackageDir<
         sourceHardlinks,
         to: backupPath,
       });
+      params.signal?.throwIfAborted();
     } catch (err) {
-      return await fail(`${params.copyErrorPrefix}: ${String(err)}`, err);
+      // A refused move leaves no publication receipt, so rollback has nothing to restore;
+      // a post-rename failure keeps the receipt and rollback still restores the original tree.
+      return await failOrRethrow(`${params.copyErrorPrefix}: ${String(err)}`, err);
     }
   }
 
@@ -538,16 +569,18 @@ export async function installPackageDir<
     // reach the replacement, while a refusal can still restore the original tree.
     try {
       const backupResult = await params.afterBackup(published.backup.path);
+      params.signal?.throwIfAborted();
       if (!backupResult.ok) {
-        const failed = await fail(backupResult.error);
+        const failed = await failOrRethrow(backupResult.error);
         return { ...backupResult, error: failed.error };
       }
     } catch (err) {
-      return await fail(`backup validation failed: ${String(err)}`, err);
+      return await failOrRethrow(`backup validation failed: ${String(err)}`, err);
     }
   }
 
   try {
+    params.signal?.throwIfAborted();
     await assertInstallBaseStable({
       installBaseDir,
       expectedRealPath: installBaseRealPath,
@@ -563,7 +596,7 @@ export async function installPackageDir<
     });
     stageDir = null;
   } catch (err) {
-    return await fail(`${params.copyErrorPrefix}: ${String(err)}`, err);
+    return await failOrRethrow(`${params.copyErrorPrefix}: ${String(err)}`, err);
   }
 
   if (published.backup) {
@@ -609,6 +642,7 @@ export async function installPackageDir<
           if (quarantine) {
             throw new Error("cannot commit an install after rollback has started");
           }
+          params.signal?.throwIfAborted();
           assertOwned?.();
           if (published.backup) {
             assertDirectoryIdentity(published.backup.path, published.backup);

--- a/src/infra/install-package-dir.ts
+++ b/src/infra/install-package-dir.ts
@@ -315,6 +315,9 @@ export async function installPackageDir<
   };
   const assertPersistentApply = () => {
     params.beforePersistentApply?.();
+    // A startup cancellation observed between the pre-move abort check and the
+    // rename must refuse publication; ownership guards alone do not see it.
+    params.signal?.throwIfAborted();
     assertRollbackOwned();
   };
   let stageDir: string | null = null;

--- a/src/infra/startup-migration-checkpoint.ts
+++ b/src/infra/startup-migration-checkpoint.ts
@@ -54,6 +54,7 @@ type StartupMigrationLeaseWaitParams = Omit<StartupMigrationLeaseParams, "nowMs"
   now?: () => number;
   monotonicNow?: () => number;
   sleep?: (ms: number) => Promise<void>;
+  signal?: AbortSignal;
 };
 
 class StartupMigrationLeaseConflictError extends Error {
@@ -458,6 +459,7 @@ export async function acquireStartupMigrationLeaseWithWait(
   const deadlineMs = monotonicNow() + timeoutMs;
 
   while (true) {
+    params.signal?.throwIfAborted();
     try {
       return acquireStartupMigrationLease({
         env: params.env,
@@ -477,6 +479,7 @@ export async function acquireStartupMigrationLeaseWithWait(
         throw error;
       }
       await sleep(Math.min(pollIntervalMs, remainingMs));
+      params.signal?.throwIfAborted();
     }
   }
 }

--- a/src/plugins/clawhub.test.ts
+++ b/src/plugins/clawhub.test.ts
@@ -278,6 +278,7 @@ type PackageLookupCall = {
   artifact?: string;
   baseUrl?: string;
   name?: string;
+  signal?: AbortSignal;
   version?: string;
 };
 
@@ -290,6 +291,7 @@ type ArchiveInstallCall = {
     requestedSpecifier?: string;
     source?: { kind?: string; authority?: string; mutable?: boolean; network?: boolean };
   };
+  signal?: AbortSignal;
   trustedSourceLinkedOfficialInstall?: boolean;
 };
 
@@ -1599,6 +1601,44 @@ describe("installPluginFromClawHub", () => {
     });
 
     expectSuccessfulClawHubInstall(result);
+  });
+
+  it("rethrows startup cancellation instead of mapping a package lookup failure", async () => {
+    const controller = new AbortController();
+    const reason = new Error("Gateway startup interrupted by SIGTERM");
+    fetchClawHubPackageDetailMock.mockImplementationOnce(
+      async ({ signal }: { signal?: AbortSignal }) => {
+        expect(signal).toBe(controller.signal);
+        controller.abort(reason);
+        throw reason;
+      },
+    );
+
+    await expect(
+      installPluginFromClawHub({ spec: "clawhub:demo", signal: controller.signal }),
+    ).rejects.toBe(reason);
+    expect(fetchClawHubPackageArtifactMock).not.toHaveBeenCalled();
+    expect(downloadClawHubPackageArchiveMock).not.toHaveBeenCalled();
+    expect(installPluginFromArchiveMock).not.toHaveBeenCalled();
+  });
+
+  it("does not begin archive installation after a completed download observes cancellation", async () => {
+    const controller = new AbortController();
+    const reason = new Error("Gateway startup interrupted by SIGTERM");
+    downloadClawHubPackageArchiveMock.mockImplementationOnce(async () => {
+      controller.abort(reason);
+      return {
+        archivePath: "/tmp/clawhub-demo/archive.zip",
+        integrity: DEMO_ARCHIVE_INTEGRITY,
+        cleanup: archiveCleanupMock,
+      };
+    });
+
+    await expect(
+      installPluginFromClawHub({ spec: "clawhub:demo", signal: controller.signal }),
+    ).rejects.toBe(reason);
+    expect(installPluginFromArchiveMock).not.toHaveBeenCalled();
+    expect(archiveCleanupMock).toHaveBeenCalledOnce();
   });
 
   it("recovers version-specific compatibility from version endpoint when artifact metadata is sparse", async () => {

--- a/src/plugins/clawhub.test.ts
+++ b/src/plugins/clawhub.test.ts
@@ -1641,6 +1641,37 @@ describe("installPluginFromClawHub", () => {
     expect(archiveCleanupMock).toHaveBeenCalledOnce();
   });
 
+  it.each(["install", "update"] as const)(
+    "settles a published %s when cancellation lands after publication",
+    async (mode) => {
+      const controller = new AbortController();
+      const reason = new Error("Gateway startup interrupted by SIGTERM");
+      installPluginFromArchiveMock.mockImplementationOnce(async () => {
+        // The archive installer resolves only once the replacement is published,
+        // so a cancellation observed here must not discard the settled result:
+        // its record carries the deferred transaction that commits or rolls
+        // back the displaced package.
+        controller.abort(reason);
+        return {
+          ok: true,
+          pluginId: "demo",
+          targetDir: "/tmp/openclaw/plugins/demo",
+          version: "2026.3.22",
+        };
+      });
+
+      const result = await installPluginFromClawHub({
+        spec: "clawhub:demo",
+        mode,
+        signal: controller.signal,
+      });
+
+      expect(controller.signal.aborted).toBe(true);
+      expectSuccessfulClawHubInstall(result);
+      expect(archiveCleanupMock).toHaveBeenCalledOnce();
+    },
+  );
+
   it("recovers version-specific compatibility from version endpoint when artifact metadata is sparse", async () => {
     parseClawHubPluginSpecMock.mockReturnValueOnce({ name: "demo", version: "2026.6.8" });
     resolveLatestVersionFromPackageMock.mockReturnValue("2026.6.10");

--- a/src/plugins/clawhub.ts
+++ b/src/plugins/clawhub.ts
@@ -137,6 +137,7 @@ const CLAWHUB_GENERATED_ARCHIVE_METADATA_FILE = "_meta.json";
 type ClawHubArchiveEntryLimits = {
   maxEntryBytes: number;
   addArchiveBytes: (bytes: number) => boolean;
+  signal?: AbortSignal;
 };
 
 function normalizeClawHubClawPackInstallFields(
@@ -672,6 +673,7 @@ async function readLimitedClawHubArchiveEntry<T>(
     onEnd: () => T;
   },
 ): Promise<T | ClawHubInstallFailure> {
+  limits.signal?.throwIfAborted();
   const hintedSize = (entry as JSZipObjectWithSize)["_data"]?.uncompressedSize;
   if (
     typeof hintedSize === "number" &&
@@ -684,22 +686,53 @@ async function readLimitedClawHubArchiveEntry<T>(
     );
   }
   let entryBytes = 0;
-  return await new Promise<T | ClawHubInstallFailure>((resolve) => {
+  return await new Promise<T | ClawHubInstallFailure>((resolve, reject) => {
     let settled = false;
     const stream = entry.nodeStream("nodebuffer") as NodeJS.ReadableStream & {
       destroy?: (error?: Error) => void;
     };
+    const removeAbortListener = () => limits.signal?.removeEventListener("abort", onAbort);
+    const finish = (value: T | ClawHubInstallFailure) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      removeAbortListener();
+      resolve(value);
+    };
+    const onAbort = () => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      removeAbortListener();
+      stream.destroy?.();
+      const reason = limits.signal?.reason;
+      reject(
+        reason instanceof Error
+          ? reason
+          : new Error("ClawHub archive verification aborted", { cause: reason }),
+      );
+    };
+    limits.signal?.addEventListener("abort", onAbort, { once: true });
+    if (limits.signal?.aborted) {
+      onAbort();
+      return;
+    }
     stream.on("data", (chunk: Buffer | Uint8Array | string) => {
       if (settled) {
+        return;
+      }
+      if (limits.signal?.aborted) {
+        onAbort();
         return;
       }
       const buffer =
         typeof chunk === "string" ? Buffer.from(chunk) : Buffer.from(chunk as Uint8Array);
       entryBytes += buffer.byteLength;
       if (entryBytes > limits.maxEntryBytes) {
-        settled = true;
         stream.destroy?.();
-        resolve(
+        finish(
           buildClawHubInstallFailure(
             `ClawHub archive fallback verification rejected "${entry.name}" because it exceeds the per-file size limit.`,
             CLAWHUB_INSTALL_ERROR_CODE.ARCHIVE_INTEGRITY_MISMATCH,
@@ -708,9 +741,8 @@ async function readLimitedClawHubArchiveEntry<T>(
         return;
       }
       if (!limits.addArchiveBytes(buffer.byteLength)) {
-        settled = true;
         stream.destroy?.();
-        resolve(
+        finish(
           buildClawHubInstallFailure(
             "ClawHub archive fallback verification exceeded the total extracted-size limit.",
             CLAWHUB_INSTALL_ERROR_CODE.ARCHIVE_INTEGRITY_MISMATCH,
@@ -721,18 +753,13 @@ async function readLimitedClawHubArchiveEntry<T>(
       handlers.onChunk(buffer);
     });
     stream.once("end", () => {
-      if (settled) {
-        return;
-      }
-      settled = true;
-      resolve(handlers.onEnd());
+      finish(handlers.onEnd());
     });
     stream.once("error", (error: unknown) => {
       if (settled) {
         return;
       }
-      settled = true;
-      resolve(
+      finish(
         buildClawHubInstallFailure(
           error instanceof Error ? error.message : String(error),
           CLAWHUB_INSTALL_ERROR_CODE.ARCHIVE_INTEGRITY_MISMATCH,
@@ -834,9 +861,12 @@ async function verifyClawHubArchiveFiles(params: {
   packageName: string;
   packageVersion: string;
   files: ClawHubFileVerificationEntry[];
+  signal?: AbortSignal;
 }): Promise<ClawHubArchiveFileVerificationResult> {
+  params.signal?.throwIfAborted();
   try {
     const archiveStat = await fs.stat(params.archivePath);
+    params.signal?.throwIfAborted();
     if (archiveStat.size > DEFAULT_MAX_ARCHIVE_BYTES_ZIP) {
       return buildClawHubInstallFailure(
         "ClawHub archive fallback verification rejected the downloaded archive because it exceeds the ZIP archive size limit.",
@@ -844,20 +874,31 @@ async function verifyClawHubArchiveFiles(params: {
       );
     }
     const archiveBytes = await fs.readFile(params.archivePath);
+    params.signal?.throwIfAborted();
     const zip = await loadZipArchiveWithPreflight(archiveBytes, {
       maxArchiveBytes: DEFAULT_MAX_ARCHIVE_BYTES_ZIP,
       maxEntries: DEFAULT_MAX_ENTRIES,
       maxExtractedBytes: DEFAULT_MAX_EXTRACTED_BYTES,
       maxEntryBytes: DEFAULT_MAX_ENTRY_BYTES,
     });
+    params.signal?.throwIfAborted();
     const actualFiles = new Map<string, string>();
     const validatedGeneratedPaths = new Set<string>();
     let extractedBytes = 0;
+    let entryCount = 0;
     const addArchiveBytes = (bytes: number): boolean => {
       extractedBytes += bytes;
       return extractedBytes <= DEFAULT_MAX_EXTRACTED_BYTES;
     };
     for (const entry of Object.values(zip.files as Record<string, JSZip.JSZipObject>)) {
+      params.signal?.throwIfAborted();
+      entryCount += 1;
+      if (entryCount > DEFAULT_MAX_ENTRIES) {
+        return buildClawHubInstallFailure(
+          "ClawHub archive fallback verification exceeded the archive entry limit.",
+          CLAWHUB_INSTALL_ERROR_CODE.ARCHIVE_INTEGRITY_MISMATCH,
+        );
+      }
       if (entry.dir) {
         continue;
       }
@@ -872,7 +913,9 @@ async function verifyClawHubArchiveFiles(params: {
         const metaResult = await readClawHubArchiveEntryBuffer(entry, {
           maxEntryBytes: DEFAULT_MAX_ENTRY_BYTES,
           addArchiveBytes,
+          ...(params.signal ? { signal: params.signal } : {}),
         });
+        params.signal?.throwIfAborted();
         if (isClawHubInstallFailure(metaResult)) {
           return metaResult;
         }
@@ -890,13 +933,16 @@ async function verifyClawHubArchiveFiles(params: {
       const sha256 = await hashClawHubArchiveEntry(entry, {
         maxEntryBytes: DEFAULT_MAX_ENTRY_BYTES,
         addArchiveBytes,
+        ...(params.signal ? { signal: params.signal } : {}),
       });
+      params.signal?.throwIfAborted();
       if (typeof sha256 !== "string") {
         return sha256;
       }
       actualFiles.set(relativePath, sha256);
     }
     for (const file of params.files) {
+      params.signal?.throwIfAborted();
       const actualSha256 = actualFiles.get(file.path);
       if (!actualSha256) {
         return buildClawHubInstallFailure(
@@ -929,6 +975,7 @@ async function verifyClawHubArchiveFiles(params: {
       validatedGeneratedPaths: [...validatedGeneratedPaths].toSorted(),
     };
   } catch (error) {
+    params.signal?.throwIfAborted();
     return mapClawHubArchiveReadFailure(error);
   }
 }
@@ -939,7 +986,10 @@ async function resolveCompatiblePackageVersion(params: {
   baseUrl?: string;
   token?: string;
   timeoutMs?: number;
+  signal?: AbortSignal;
 }): Promise<({ ok: true } & ClawHubInstallArtifactDecision) | ClawHubInstallFailure> {
+  const throwIfAborted = () => params.signal?.throwIfAborted();
+  throwIfAborted();
   const requestedVersion = resolveRequestedVersion(params);
   if (!requestedVersion) {
     return buildClawHubInstallFailure(
@@ -955,8 +1005,10 @@ async function resolveCompatiblePackageVersion(params: {
       baseUrl: params.baseUrl,
       token: params.token,
       timeoutMs: params.timeoutMs,
+      ...(params.signal ? { signal: params.signal } : {}),
     });
   } catch (error) {
+    throwIfAborted();
     if (isMissingArtifactResolverRoute(error)) {
       try {
         const versionDetail = await fetchClawHubPackageVersion({
@@ -965,12 +1017,15 @@ async function resolveCompatiblePackageVersion(params: {
           baseUrl: params.baseUrl,
           token: params.token,
           timeoutMs: params.timeoutMs,
+          ...(params.signal ? { signal: params.signal } : {}),
         });
+        throwIfAborted();
         artifactResponse = buildArtifactResolverResponseFromVersion({
           detail: params.detail,
           versionDetail,
         });
       } catch (versionError) {
+        throwIfAborted();
         return mapClawHubRequestError(versionError, {
           stage: "version",
           name: params.detail.package?.name ?? "unknown",
@@ -1005,9 +1060,12 @@ async function resolveCompatiblePackageVersion(params: {
         baseUrl: params.baseUrl,
         token: params.token,
         timeoutMs: params.timeoutMs,
+        ...(params.signal ? { signal: params.signal } : {}),
       });
+      throwIfAborted();
       versionEndpointCompatibility = selectedVersion.version?.compatibility ?? null;
     } catch (error) {
+      throwIfAborted();
       return mapClawHubRequestError(error, {
         stage: "version",
         name: params.detail.package?.name ?? "unknown",
@@ -1237,6 +1295,8 @@ export async function installPluginFromClawHub(
   | ClawHubInstallFailure
   | Extract<InstallPluginResult, { ok: false }>
 > {
+  const throwIfAborted = () => params.signal?.throwIfAborted();
+  throwIfAborted();
   const parsed = parseClawHubPluginSpec(params.spec);
   if (!parsed?.name) {
     return buildClawHubInstallFailure(
@@ -1263,8 +1323,11 @@ export async function installPluginFromClawHub(
       baseUrl: params.baseUrl,
       token: params.token,
       timeoutMs: params.timeoutMs,
+      ...(params.signal ? { signal: params.signal } : {}),
     });
+    throwIfAborted();
   } catch (error) {
+    throwIfAborted();
     return mapClawHubRequestError(error, {
       stage: "package",
       name: parsed.name,
@@ -1276,7 +1339,9 @@ export async function installPluginFromClawHub(
     baseUrl: params.baseUrl,
     token: params.token,
     timeoutMs: params.timeoutMs,
+    ...(params.signal ? { signal: params.signal } : {}),
   });
+  throwIfAborted();
   if (!versionState.ok) {
     return versionState;
   }
@@ -1316,14 +1381,20 @@ export async function installPluginFromClawHub(
         baseUrl: params.baseUrl,
         token: params.token,
         timeoutMs: params.timeoutMs,
+        ...(params.signal ? { signal: params.signal } : {}),
         logger: params.logger,
         mode: params.mode,
       });
+  throwIfAborted();
   if (trustResult && !trustResult.ok) {
     return trustResult;
   }
-  if (params.mode !== "update" && params.confirmInstall && !(await params.confirmInstall())) {
-    return buildClawHubInstallFailure("Install cancelled.");
+  if (params.mode !== "update" && params.confirmInstall) {
+    const confirmed = await params.confirmInstall();
+    throwIfAborted();
+    if (!confirmed) {
+      return buildClawHubInstallFailure("Install cancelled.");
+    }
   }
   if (!versionState.verification && !expectedClawPackSha256) {
     return buildClawHubInstallFailure(
@@ -1345,8 +1416,10 @@ export async function installPluginFromClawHub(
       baseUrl: params.baseUrl,
       token: params.token,
       timeoutMs: params.timeoutMs,
+      ...(params.signal ? { signal: params.signal } : {}),
     });
   } catch (error) {
+    throwIfAborted();
     if (isClawHubArtifactDownloadPolicyBlock(error)) {
       return buildClawHubInstallFailure(
         formatClawHubArtifactDownloadPolicyBlock({
@@ -1380,6 +1453,7 @@ export async function installPluginFromClawHub(
     );
   }
   try {
+    throwIfAborted();
     if (expectedIntegrity && archive.integrity !== expectedIntegrity) {
       return buildClawHubInstallFailure(
         `ClawHub archive integrity mismatch for "${releaseLabel}": expected ${expectedIntegrity}, got ${archive.integrity}.`,
@@ -1430,7 +1504,9 @@ export async function installPluginFromClawHub(
         packageName: canonicalPackageName,
         packageVersion: versionState.version,
         files: versionState.verification.files,
+        ...(params.signal ? { signal: params.signal } : {}),
       });
+      throwIfAborted();
       if (!fallbackVerification.ok) {
         return fallbackVerification;
       }
@@ -1461,6 +1537,7 @@ export async function installPluginFromClawHub(
         dryRun: params.dryRun,
         expectedPluginId: runtimeIdResolution.expectedPluginId,
         beforePersistentApply: params.beforePersistentApply,
+        ...(params.signal ? { signal: params.signal } : {}),
         onBeforePluginArtifactCommit: params.onBeforePluginArtifactCommit
           ? (artifact) =>
               params.onBeforePluginArtifactCommit!({
@@ -1487,6 +1564,7 @@ export async function installPluginFromClawHub(
         },
       }),
     );
+    throwIfAborted();
     if (!installResult.ok) {
       return installResult;
     }

--- a/src/plugins/clawhub.ts
+++ b/src/plugins/clawhub.ts
@@ -1564,10 +1564,16 @@ export async function installPluginFromClawHub(
         },
       }),
     );
-    throwIfAborted();
     if (!installResult.ok) {
+      // Nothing was published, so a concurrent cancellation still owns the
+      // outcome instead of a validation or policy failure that lost the race.
+      throwIfAborted();
       return installResult;
     }
+    // A successful install may already be published on disk, and its record
+    // carries the deferred transaction that settles or rolls back a displaced
+    // package. Throwing on a late cancellation here would discard both, so the
+    // published result is returned for the caller to settle.
 
     const pkg = detail.package!;
     const clawpackFields = normalizeClawHubClawPackInstallFields(versionState.clawpack);

--- a/src/plugins/git-install-target.test.ts
+++ b/src/plugins/git-install-target.test.ts
@@ -196,4 +196,35 @@ describe("git install target ownership", () => {
     });
     expect(await git(installed.targetDir, "rev-parse", "HEAD")).toBe(installed.git.commit);
   });
+
+  it.each([{ deferred: false }, { deferred: true }])(
+    "keeps the existing checkout when cancellation reaches $deferred publication",
+    async ({ deferred }) => {
+      const installed = await installPluginFromGitSpec({ spec });
+      if (!installed.ok) {
+        throw new Error(installed.error);
+      }
+      const markerPath = path.join(installed.targetDir, "operator-note.txt");
+      await fs.writeFile(markerPath, "keep this checkout");
+      await commitPlugin("demo", "2.0.0");
+      const controller = new AbortController();
+      const options = {
+        spec,
+        mode: "update" as const,
+        signal: controller.signal,
+        onBeforePluginArtifactCommit: async () => {
+          controller.abort();
+        },
+      };
+
+      await expect(
+        installPluginFromGitSpec(deferred ? requestDeferredPluginInstall(options) : options),
+      ).rejects.toMatchObject({ name: "AbortError" });
+      expect(await git(installed.targetDir, "rev-parse", "HEAD")).toBe(installed.git.commit);
+      await expect(fs.readFile(markerPath, "utf8")).resolves.toBe("keep this checkout");
+      await expect(
+        fs.readFile(path.join(installed.targetDir, "package.json"), "utf8"),
+      ).resolves.toContain('"version":"1.0.0"');
+    },
+  );
 });

--- a/src/plugins/git-install.test.ts
+++ b/src/plugins/git-install.test.ts
@@ -6,6 +6,7 @@ import path from "node:path";
 import { redactSensitiveUrlLikeString } from "@openclaw/net-policy/redact-sensitive-url";
 import { expectDefined } from "@openclaw/normalization-core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../test/helpers/promise.js";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import type { DiagnosticSecurityEvent } from "../infra/diagnostic-events.js";
 import { resolvePreferredOpenClawTmpDir } from "../infra/tmp-openclaw-dir.js";
@@ -82,6 +83,7 @@ function firstInstallOptions():
       emitSuccessSecurityEvent?: boolean;
       packageDir?: string;
       mode?: string;
+      signal?: AbortSignal;
       installPolicyRequest?: { kind?: string; requestedSpecifier?: string };
     }
   | undefined {
@@ -91,6 +93,7 @@ function firstInstallOptions():
         emitSuccessSecurityEvent?: boolean;
         packageDir?: string;
         mode?: string;
+        signal?: AbortSignal;
         installPolicyRequest?: { kind?: string; requestedSpecifier?: string };
       }
     | undefined;
@@ -873,5 +876,51 @@ describe("installPluginFromGitSpec", () => {
     } finally {
       await fs.rm(gitDir, { recursive: true, force: true });
     }
+  });
+
+  it("keeps the existing managed repo when cancellation arrives during package validation", async () => {
+    const gitDir = trackedTempDirs.make("openclaw-git-install-abort-validation-");
+    const normalizedSpec = "git:https://github.com/acme/demo.git";
+    const existingRepoDir = expectedGitRepoDir({ gitDir, normalizedSpec });
+    const markerPath = path.join(existingRepoDir, "existing.txt");
+    await fs.mkdir(existingRepoDir, { recursive: true });
+    await fs.writeFile(markerPath, "keep");
+    runCommandWithTimeoutMock
+      .mockResolvedValueOnce({ code: 0, stdout: "", stderr: "" })
+      .mockResolvedValueOnce({ code: 0, stdout: "new-commit\n", stderr: "" })
+      .mockResolvedValueOnce({ code: 0, stdout: "", stderr: "" });
+    const validationStarted = createDeferred();
+    const releaseValidation = createDeferred();
+    const controller = new AbortController();
+    installPluginFromInstalledPackageDirMock.mockImplementation(
+      async (params: { packageDir: string; signal?: AbortSignal }) => {
+        await fs.mkdir(params.packageDir, { recursive: true });
+        await fs.writeFile(path.join(params.packageDir, "replacement.txt"), "new");
+        validationStarted.resolve();
+        await releaseValidation.promise;
+        return {
+          ok: true,
+          pluginId: "demo",
+          targetDir: params.packageDir,
+          version: "2.0.0",
+          extensions: ["index.js"],
+        };
+      },
+    );
+
+    const update = installPluginFromGitSpec({
+      spec: normalizedSpec,
+      gitDir,
+      mode: "update",
+      signal: controller.signal,
+    });
+    await validationStarted.promise;
+    controller.abort();
+    releaseValidation.resolve();
+
+    await expect(update).rejects.toMatchObject({ name: "AbortError" });
+    expect(firstInstallOptions()?.signal).toBe(controller.signal);
+    await expect(fs.readFile(markerPath, "utf8")).resolves.toBe("keep");
+    await expect(fs.access(path.join(existingRepoDir, "replacement.txt"))).rejects.toThrow();
   });
 });

--- a/src/plugins/git-install.ts
+++ b/src/plugins/git-install.ts
@@ -295,19 +295,23 @@ async function replaceManagedGitRepo(params: {
   stagedRepoDir: string;
   persistentRepoDir: string;
   deferCommit?: boolean;
+  signal?: AbortSignal;
   onBeforePublish?: (stagedRepoDir: string) => Promise<void>;
   beforePersistentApply?: () => void;
   assertOwned?: () => void;
 }): Promise<{ ok: true; transaction?: PluginInstallTransaction } | { ok: false; error: string }> {
+  params.signal?.throwIfAborted();
   let artifactConsentFailure: { error: unknown } | undefined;
   const reviewFinalArtifact = async (stagedRepoDir: string) => {
+    params.signal?.throwIfAborted();
     try {
       await params.onBeforePublish?.(stagedRepoDir);
-      return { ok: true as const };
     } catch (error) {
       artifactConsentFailure = { error };
       throw error;
     }
+    params.signal?.throwIfAborted();
+    return { ok: true as const };
   };
   try {
     const installParams = {
@@ -323,6 +327,7 @@ async function replaceManagedGitRepo(params: {
       // Publication copies the clone again; review that final copy.
       afterInstall: reviewFinalArtifact,
       beforePersistentApply: params.beforePersistentApply,
+      ...(params.signal ? { signal: params.signal } : {}),
     };
     const result = await installPackageDir(
       params.deferCommit
@@ -335,6 +340,7 @@ async function replaceManagedGitRepo(params: {
     const transaction = result.ok ? resolvePackageDirInstallTransaction(result) : undefined;
     return result.ok ? { ok: true, ...(transaction ? { transaction } : {}) } : result;
   } catch (err) {
+    params.signal?.throwIfAborted();
     if (artifactConsentFailure) {
       throw artifactConsentFailure.error;
     }
@@ -404,6 +410,7 @@ export async function installPluginFromGitSpec(
       refMode: "resolve-remote",
       timeoutMs: params.timeoutMs,
       commandEnv: () => ({ env: createGitCommandEnv() }),
+      ...(params.signal ? { signal: params.signal } : {}),
     });
     if (!acquired.ok) {
       return acquired;
@@ -464,6 +471,7 @@ export async function installPluginFromGitSpec(
             packageLock: true,
             quiet: true,
           }),
+          ...(params.signal ? { signal: params.signal } : {}),
         },
       );
       if (install.code !== 0) {
@@ -484,7 +492,9 @@ export async function installPluginFromGitSpec(
       mode: effectiveMode,
       emitSuccessSecurityEvent: false,
       installPolicyRequest,
+      ...(params.signal ? { signal: params.signal } : {}),
     });
+    params.signal?.throwIfAborted();
     if (!result.ok) {
       return result;
     }
@@ -496,6 +506,7 @@ export async function installPluginFromGitSpec(
         persistentRepoDir,
         deferCommit: transactionRequest?.deferCommit,
         assertOwned: transactionRequest?.assertOwned,
+        ...(params.signal ? { signal: params.signal } : {}),
         onBeforePublish: async (stagedArtifactDir) => {
           await params.onBeforePluginArtifactCommit?.({
             pluginId: result.pluginId,

--- a/src/plugins/install-channel-specs.test.ts
+++ b/src/plugins/install-channel-specs.test.ts
@@ -224,6 +224,23 @@ describe("resolveNpmInstallSpecsForUpdateChannel", () => {
   );
 });
 
+it("rethrows the original abort raised during parallel channel metadata resolution", async () => {
+  const reason = new Error("Gateway startup interrupted by SIGTERM");
+  const controller = new AbortController();
+  vi.mocked(resolveNpmSpecMetadata).mockImplementation(async ({ signal }) => {
+    controller.abort(reason);
+    expect(signal).toBeInstanceOf(AbortSignal);
+    throw reason;
+  });
+
+  await expect(
+    resolveNpmInstallSpecsForUpdateChannel({
+      spec: "@openclaw/demo",
+      updateChannel: "beta",
+      signal: controller.signal,
+    }),
+  ).rejects.toBe(reason);
+});
 describe("resolveClawHubInstallSpecsForUpdateChannel", () => {
   it.each([
     ["stable", false, "2026.7.33", undefined],

--- a/src/plugins/install-channel-specs.test.ts
+++ b/src/plugins/install-channel-specs.test.ts
@@ -241,6 +241,33 @@ it("rethrows the original abort raised during parallel channel metadata resoluti
     }),
   ).rejects.toBe(reason);
 });
+
+it("joins both metadata requests before propagating cancellation", async () => {
+  const reason = new Error("Gateway startup interrupted by SIGTERM");
+  const controller = new AbortController();
+  let siblingSettled = false;
+  vi.mocked(resolveNpmSpecMetadata).mockImplementation(async ({ spec }) => {
+    if (spec.endsWith("@beta")) {
+      controller.abort(reason);
+      throw reason;
+    }
+    // The sibling request keeps awaiting subprocess-tree termination after
+    // the beta side raised; propagation must wait for it to settle so a
+    // slower cleanup is not cut short by an early startup release.
+    await new Promise<void>((resolve) => setTimeout(resolve, 25));
+    siblingSettled = true;
+    return { ok: false as const, error: "aborted" };
+  });
+
+  await expect(
+    resolveNpmInstallSpecsForUpdateChannel({
+      spec: "@openclaw/demo",
+      updateChannel: "beta",
+      signal: controller.signal,
+    }),
+  ).rejects.toBe(reason);
+  expect(siblingSettled).toBe(true);
+});
 describe("resolveClawHubInstallSpecsForUpdateChannel", () => {
   it.each([
     ["stable", false, "2026.7.33", undefined],

--- a/src/plugins/install-channel-specs.ts
+++ b/src/plugins/install-channel-specs.ts
@@ -112,6 +112,7 @@ type ChannelInstallParams = {
   coreVersion?: string;
   versionBoundToCore?: boolean;
   timeoutMs?: number;
+  signal?: AbortSignal;
 };
 
 function resolveCoreBoundNpmSpec(params: ChannelInstallParams): string | undefined {
@@ -156,12 +157,15 @@ export async function resolveNpmInstallSpecsForUpdateChannel(
       recordSpec: params.spec,
     };
   }
+  params.signal?.throwIfAborted();
   const { resolveNpmSpecMetadata } = await import("../infra/install-source-utils.js");
   const resolveTag = async (tag: "beta" | "latest") => {
     const result = await resolveNpmSpecMetadata({
       spec: `${target.name}@${tag}`,
       timeoutMs: params.timeoutMs,
+      ...(params.signal ? { signal: params.signal } : {}),
     });
+    params.signal?.throwIfAborted();
     if (!result.ok) {
       if (result.category === "metadata-env") {
         throw new NpmChannelResolutionError(
@@ -181,6 +185,7 @@ export async function resolveNpmInstallSpecsForUpdateChannel(
     return { version: result.metadata.version ?? null, metadata: result.metadata, tag };
   };
   const [beta, latest] = await Promise.all([resolveTag("beta"), resolveTag("latest")]);
+  params.signal?.throwIfAborted();
   const selected = selectNpmChannelVersion(beta, latest);
   if (!selected.version || !selected.metadata) {
     // Preserve the install owner's normal unavailable-source result and declared source fallback.

--- a/src/plugins/install-channel-specs.ts
+++ b/src/plugins/install-channel-specs.ts
@@ -184,8 +184,21 @@ export async function resolveNpmInstallSpecsForUpdateChannel(
     }
     return { version: result.metadata.version ?? null, metadata: result.metadata, tag };
   };
-  const [beta, latest] = await Promise.all([resolveTag("beta"), resolveTag("latest")]);
+  // Join both started requests before propagating cancellation: rejecting as
+  // soon as one side aborts lets startup release its lease while the sibling
+  // request is still awaiting subprocess-tree termination, which lets managed
+  // shutdown exit before slower cleanup finishes.
+  const settled = await Promise.allSettled([resolveTag("beta"), resolveTag("latest")]);
+  type ChannelMetadataResult = Awaited<ReturnType<typeof resolveTag>>;
+  const resolveOutcome = (outcome: PromiseSettledResult<ChannelMetadataResult>) => {
+    if (outcome.status === "rejected") {
+      throw outcome.reason;
+    }
+    return outcome.value;
+  };
   params.signal?.throwIfAborted();
+  const beta = resolveOutcome(settled[0]!);
+  const latest = resolveOutcome(settled[1]!);
   const selected = selectNpmChannelVersion(beta, latest);
   if (!selected.version || !selected.metadata) {
     // Preserve the install owner's normal unavailable-source result and declared source fallback.

--- a/src/plugins/install-managed-npm.ts
+++ b/src/plugins/install-managed-npm.ts
@@ -170,6 +170,8 @@ export async function installPluginFromManagedNpmRoot(
       }
     | undefined;
   const runManagedNpmInstall = async (npmRoot: string): Promise<InstallPluginResult> => {
+    const throwIfAborted = () => params.signal?.throwIfAborted();
+    throwIfAborted();
     const installRoot = resolveManagedNpmRootPackageDir(npmRoot, params.packageName);
     const prepared = await resolveManagedNpmRootDependencySpecForInstall({
       npmRoot,
@@ -188,6 +190,7 @@ export async function installPluginFromManagedNpmRoot(
         signal: params.signal,
         logger,
       });
+      throwIfAborted();
       if (repairedOpenClawPeer) {
         logger.info?.(`Repaired stale openclaw peer dependency in ${npmRoot}`);
       }
@@ -226,6 +229,7 @@ export async function installPluginFromManagedNpmRoot(
           }),
         };
       } catch (error) {
+        throwIfAborted();
         return {
           ok: false,
           error: `npm peer dependency planning failed: ${error instanceof Error ? error.message : String(error)}`,
@@ -240,6 +244,7 @@ export async function installPluginFromManagedNpmRoot(
       omitNpmAliasOverrides,
     });
     const initialPeerSync = await syncManagedPeerDependenciesForInstall();
+    throwIfAborted();
     if (!initialPeerSync.ok) {
       return { ok: false, error: initialPeerSync.error };
     }
@@ -267,6 +272,7 @@ export async function installPluginFromManagedNpmRoot(
       }),
     };
     let install = await runCommandWithTimeout(npmInstallArgs, npmInstallOptions);
+    throwIfAborted();
     if (install.code !== 0 && isNpmAliasOverrideCompatibilityError(install)) {
       logger.warn?.(
         "npm rejected managed npm overrides; retrying plugin install without npm-incompatible overrides for this npm version.",
@@ -280,6 +286,7 @@ export async function installPluginFromManagedNpmRoot(
         omitNpmAliasOverrides,
       });
       const aliasRetryPeerSync = await syncManagedPeerDependenciesForInstall();
+      throwIfAborted();
       if (!aliasRetryPeerSync.ok) {
         return {
           ok: false,
@@ -287,6 +294,7 @@ export async function installPluginFromManagedNpmRoot(
         };
       }
       install = await runCommandWithTimeout(npmInstallArgs, npmInstallOptions);
+      throwIfAborted();
     }
     if (!recovery && install.code !== 0 && isManagedNpmProjectCorruptionInstallFailure(install)) {
       const originalError = formatNpmCommandFailureOutput(install);
@@ -311,6 +319,7 @@ export async function installPluginFromManagedNpmRoot(
     let settledManagedPeerDependencies = false;
     for (let peerSyncPass = 0; peerSyncPass < 10; peerSyncPass += 1) {
       const peerSync = await syncManagedPeerDependenciesForInstall();
+      throwIfAborted();
       if (!peerSync.ok) {
         return { ok: false, error: peerSync.error };
       }
@@ -320,6 +329,7 @@ export async function installPluginFromManagedNpmRoot(
         break;
       }
       install = await runCommandWithTimeout(npmInstallArgs, npmInstallOptions);
+      throwIfAborted();
       if (install.code !== 0) {
         return {
           ok: false,
@@ -329,6 +339,7 @@ export async function installPluginFromManagedNpmRoot(
     }
     if (!settledManagedPeerDependencies) {
       const peerSync = await syncManagedPeerDependenciesForInstall();
+      throwIfAborted();
       if (!peerSync.ok) {
         return { ok: false, error: peerSync.error };
       }
@@ -393,6 +404,7 @@ export async function installPluginFromManagedNpmRoot(
           },
         });
       } catch (error) {
+        throwIfAborted();
         return {
           ok: false,
           error: `Failed to repair missing or incomplete current-platform package(s) ${incompletePlatformPackageNames.join(", ")}: ${String(error)}`,
@@ -408,6 +420,7 @@ export async function installPluginFromManagedNpmRoot(
           }
         }
       }
+      throwIfAborted();
       if (install.code !== 0) {
         return {
           ok: false,
@@ -440,6 +453,7 @@ export async function installPluginFromManagedNpmRoot(
         signal: params.signal,
         logger,
       });
+      throwIfAborted();
       if (repairedOpenClawPeer) {
         logger.info?.(`Repaired stale openclaw peer dependency in ${npmRoot} after npm install`);
       }

--- a/src/plugins/install-package.cancellation.test.ts
+++ b/src/plugins/install-package.cancellation.test.ts
@@ -1,0 +1,48 @@
+/**
+ * Regressions for startup cancellation reaching an archive's inner package install.
+ * The archive wrapper builds a fresh options object for the extracted package, so
+ * the abort signal has to be forwarded explicitly or SIGTERM during plugin
+ * convergence leaves the extracted package install running until it finishes.
+ */
+import { describe, expect, it, vi } from "vitest";
+
+const withExtractedArchiveRootMock = vi.fn();
+
+vi.mock("./install.runtime.js", async () => {
+  const actual =
+    await vi.importActual<typeof import("./install.runtime.js")>("./install.runtime.js");
+  return {
+    ...actual,
+    resolveArchiveSourcePath: async () => ({ ok: true, path: "/fake/plugin.tgz" }),
+    withExtractedArchiveRoot: (...args: unknown[]) => withExtractedArchiveRootMock(...args),
+  };
+});
+
+const { installPluginFromArchive } = await import("./install-package.js");
+
+describe("installPluginFromArchive startup cancellation", () => {
+  it("forwards the abort signal into the extracted package install", async () => {
+    const controller = new AbortController();
+    const reason = new Error("Gateway startup interrupted by SIGTERM");
+    // Cancellation lands inside the extraction window: the extracted package
+    // install starts there and is the layer that observes the abort.
+    withExtractedArchiveRootMock.mockImplementationOnce(
+      async (params: { onExtracted: (rootDir: string) => Promise<unknown> }) => {
+        controller.abort(reason);
+        return await params.onExtracted("/fake/extracted");
+      },
+    );
+
+    const failure = await installPluginFromArchive({
+      archivePath: "/fake/plugin.tgz",
+      signal: controller.signal,
+    }).then(
+      () => null,
+      (error: unknown) => error,
+    );
+
+    // Without the forwarded signal the extracted package install keeps running
+    // and the archive flow fails later on the fake source tree instead.
+    expect(failure).toBe(reason);
+  });
+});

--- a/src/plugins/install-package.ts
+++ b/src/plugins/install-package.ts
@@ -62,6 +62,7 @@ function pickPackageInstallCommonParams(
     onBeforePluginArtifactCommit: params.onBeforePluginArtifactCommit,
     beforePersistentApply: params.beforePersistentApply,
     onEffectiveMode: params.onEffectiveMode,
+    ...(params.signal ? { signal: params.signal } : {}),
   });
 }
 
@@ -95,7 +96,9 @@ async function installBundleFromSourceDir(
     sourceDir: string;
   } & InternalPackageInstallCommonParams,
 ): Promise<InstallPluginResult | null> {
+  params.signal?.throwIfAborted();
   const runtime = await loadPluginInstallRuntime();
+  params.signal?.throwIfAborted();
   const bundleFormat = runtime.detectBundleManifestFormat(params.sourceDir);
   if (!bundleFormat) {
     return null;
@@ -175,6 +178,7 @@ async function installBundleFromSourceDir(
         version: manifestRes.manifest.version,
       }),
   });
+  params.signal?.throwIfAborted();
   if (scanResult) {
     return scanResult;
   }
@@ -195,6 +199,7 @@ async function installBundleFromSourceDir(
       copyErrorPrefix: "failed to copy plugin bundle",
       hasDeps: false,
       depsLogMessage: "",
+      ...(params.signal ? { signal: params.signal } : {}),
       onBeforePluginArtifactCommit: params.onBeforePluginArtifactCommit,
       beforePersistentApply: params.beforePersistentApply,
     }),
@@ -222,7 +227,9 @@ async function installPluginFromSourceDir(
     sourceDir: string;
   } & InternalPackageInstallCommonParams,
 ): Promise<InstallPluginResult> {
+  params.signal?.throwIfAborted();
   const nativePackageManifest = await detectNativePackageInstallSource(params.sourceDir);
+  params.signal?.throwIfAborted();
   if (nativePackageManifest) {
     return withArtifactInspection(
       await installPluginFromPackageDir({
@@ -237,6 +244,7 @@ async function installPluginFromSourceDir(
     sourceDir: params.sourceDir,
     ...pickPackageInstallCommonParams(params),
   });
+  params.signal?.throwIfAborted();
   if (bundleResult) {
     return bundleResult;
   }
@@ -264,7 +272,9 @@ async function installPluginFromPackageDir(
     packageManifest?: PackageManifest;
   } & InternalPackageInstallCommonParams,
 ): Promise<InstallPluginResult> {
+  params.signal?.throwIfAborted();
   const runtime = await loadPluginInstallRuntime();
+  params.signal?.throwIfAborted();
   const { logger, timeoutMs, mode, dryRun } = runtime.resolveTimedInstallModeOptions(
     params,
     defaultLogger,
@@ -303,12 +313,14 @@ async function installPluginFromPackageDir(
     resolveEffectiveMode: async (pluginId) =>
       (await resolvePreparedTargetForPluginId(pluginId)).effectiveMode,
   });
+  params.signal?.throwIfAborted();
   if (!validated.ok) {
     return validated;
   }
   const { plugin } = validated;
 
   preparedTarget = await resolvePreparedTargetForPluginId(plugin.pluginId);
+  params.signal?.throwIfAborted();
   const effectiveMode = preparedTarget.effectiveMode;
   params.onEffectiveMode?.(effectiveMode);
   const shouldInstallRuntimeDeps =
@@ -333,6 +345,7 @@ async function installPluginFromPackageDir(
       sourceHardlinks: shouldInstallRuntimeDeps ? "package-manager" : "reject",
       depsLogMessage: "Installing plugin dependencies…",
       nameEncoder: encodePluginInstallDirName,
+      ...(params.signal ? { signal: params.signal } : {}),
       onBeforePluginArtifactCommit: params.onBeforePluginArtifactCommit,
       beforePersistentApply: params.beforePersistentApply,
       afterInstall: async (installedDir) => {
@@ -362,7 +375,9 @@ export async function installPluginFromArchive(
     archivePath: string;
   } & PackageInstallCommonParams,
 ): Promise<InstallPluginResult> {
+  params.signal?.throwIfAborted();
   const runtime = await loadPluginInstallRuntime();
+  params.signal?.throwIfAborted();
   const logger = params.logger ?? defaultLogger;
   const timeoutMs = params.timeoutMs ?? 120_000;
   const mode = params.mode ?? "install";
@@ -372,6 +387,7 @@ export async function installPluginFromArchive(
     source: localPluginInstallPolicySource("plugin-archive"),
   };
   const archivePathResult = await runtime.resolveArchiveSourcePath(params.archivePath);
+  params.signal?.throwIfAborted();
   if (!archivePathResult.ok) {
     return archivePathResult;
   }
@@ -384,6 +400,7 @@ export async function installPluginFromArchive(
     timeoutMs,
     logger,
     rootMarkers: PLUGIN_ARCHIVE_ROOT_MARKERS,
+    ...(params.signal ? { signal: params.signal } : {}),
     onExtracted: async (sourceDir) =>
       await installPluginFromSourceDir({
         sourceDir,

--- a/src/plugins/install-package.ts
+++ b/src/plugins/install-package.ts
@@ -417,6 +417,7 @@ export async function installPluginFromArchive(
             trustedSourceLinkedOfficialInstall: params.trustedSourceLinkedOfficialInstall,
             requirePluginManifest: true,
             installPolicyRequest,
+            ...(params.signal ? { signal: params.signal } : {}),
             onBeforePluginArtifactCommit: params.onBeforePluginArtifactCommit,
             beforePersistentApply: params.beforePersistentApply,
             onEffectiveMode: (resolvedMode) => {

--- a/src/plugins/install-security-scan.types.ts
+++ b/src/plugins/install-security-scan.types.ts
@@ -17,6 +17,8 @@ type InstallPolicyWarningAcknowledgementResult = { status: "approved" } | { stat
 /** Overrides that intentionally loosen install safety policy for trusted/operator paths. */
 export type InstallSafetyOverrides = {
   config?: OpenClawConfig;
+  signal?: AbortSignal;
+  dangerouslyForceUnsafeInstall?: boolean;
   onInstallPolicyWarning?: (
     request: InstallPolicyWarningAcknowledgementRequest,
   ) => Promise<InstallPolicyWarningAcknowledgementResult>;

--- a/src/plugins/install-shared.ts
+++ b/src/plugins/install-shared.ts
@@ -382,10 +382,13 @@ export async function installPluginDirectoryIntoExtensions(params: {
     installedDir: string,
   ) => Promise<Extract<InstallPluginResult, { ok: false }> | null>;
   nameEncoder?: (pluginId: string) => string;
+  signal?: AbortSignal;
   onBeforePluginArtifactCommit?: PluginInstallArtifactConsentHandler;
   beforePersistentApply?: () => void;
 }): Promise<InstallPluginResult> {
+  params.signal?.throwIfAborted();
   const runtime = await loadPluginInstallRuntime();
+  params.signal?.throwIfAborted();
   let targetDir = params.targetDir;
   if (!targetDir) {
     const targetDirResult = await resolvePluginInstallTarget({
@@ -399,11 +402,13 @@ export async function installPluginDirectoryIntoExtensions(params: {
     }
     targetDir = targetDirResult.targetDir;
   }
+  params.signal?.throwIfAborted();
   const availability = await ensureInstallTargetAvailableForMode({
     runtime,
     targetPath: targetDir,
     mode: params.mode,
   });
+  params.signal?.throwIfAborted();
   if (!availability.ok) {
     return availability;
   }
@@ -432,8 +437,10 @@ export async function installPluginDirectoryIntoExtensions(params: {
     depsLogMessage: params.depsLogMessage,
     afterCopy: params.afterCopy,
     beforePersistentApply: params.beforePersistentApply,
+    ...(params.signal ? { signal: params.signal } : {}),
     afterInstall: async (installedDir: string) => {
       const postInstallResult = await params.afterInstall?.(installedDir);
+      params.signal?.throwIfAborted();
       if (postInstallResult) {
         return postInstallResult;
       }
@@ -445,6 +452,7 @@ export async function installPluginDirectoryIntoExtensions(params: {
           stagedArtifactDir: installedDir,
           mode: params.mode,
         });
+        params.signal?.throwIfAborted();
       } catch (error) {
         // installPackageDir converts hook failures into results; retain the typed rejection.
         artifactConsentFailure = { error };

--- a/src/plugins/install.npm-spec.test.ts
+++ b/src/plugins/install.npm-spec.test.ts
@@ -1708,7 +1708,9 @@ describe("installPluginFromNpmSpec", () => {
     }
     let managedInstallAttempts = 0;
     runCommandWithTimeoutMock.mockImplementation(async (argv, options) => {
-      if (isManagedNpmInstallCommand(argv) && options?.cwd === npmProjectRoot) {
+      // The staged managed-npm flow installs inside a stage directory before
+      // publication, so intercept by command identity rather than final root.
+      if (isManagedNpmInstallCommand(argv)) {
         managedInstallAttempts += 1;
         controller.abort(abortReason);
         return {

--- a/src/plugins/install.npm-spec.test.ts
+++ b/src/plugins/install.npm-spec.test.ts
@@ -1688,6 +1688,55 @@ describe("installPluginFromNpmSpec", () => {
     expect(fs.existsSync(resolveTestPluginPackageDir(npmRoot, "version-drift-plugin"))).toBe(false);
   });
 
+  it("propagates an aborted managed npm install without entering recovery", async () => {
+    const npmRoot = path.join(suiteTempRootTracker.makeTempDir(), "npm");
+    const packageName = "aborted-install-plugin";
+    const npmProjectRoot = resolvePluginNpmProjectDir({ npmDir: npmRoot, packageName });
+    const abortReason = new Error("startup SIGTERM");
+    const controller = new AbortController();
+    mockNpmViewAndInstall({
+      spec: `${packageName}@1.0.0`,
+      packageName,
+      version: "1.0.0",
+      pluginId: packageName,
+      npmRoot,
+      expectedDependencySpec: "1.0.0",
+    });
+    const delegate = runCommandWithTimeoutMock.getMockImplementation();
+    if (!delegate) {
+      throw new Error("expected npm mock implementation");
+    }
+    let managedInstallAttempts = 0;
+    runCommandWithTimeoutMock.mockImplementation(async (argv, options) => {
+      if (isManagedNpmInstallCommand(argv) && options?.cwd === npmProjectRoot) {
+        managedInstallAttempts += 1;
+        controller.abort(abortReason);
+        return {
+          code: null,
+          stdout: "",
+          stderr: "",
+          signal: "SIGTERM",
+          killed: true,
+          termination: "signal" as const,
+        };
+      }
+      return await delegate(argv, options);
+    });
+
+    await expect(
+      installPluginFromNpmSpec({
+        spec: `${packageName}@1.0.0`,
+        npmDir: npmRoot,
+        logger: { info: () => {}, warn: () => {} },
+        signal: controller.signal,
+      }),
+    ).rejects.toBe(abortReason);
+    expect(managedInstallAttempts).toBe(1);
+    expect(fs.existsSync(path.join(npmProjectRoot, "_openclaw-quarantined-npm-projects"))).toBe(
+      false,
+    );
+  });
+
   it("quarantines incomplete integrity metadata and rebuilds the managed project once", async () => {
     const npmRoot = path.join(suiteTempRootTracker.makeTempDir(), "npm");
     const packageName = "missing-integrity-plugin";

--- a/src/plugins/marketplace.test.ts
+++ b/src/plugins/marketplace.test.ts
@@ -173,6 +173,23 @@ async function expectRemoteMarketplaceError(params: { manifest: unknown; expecte
   expect(runCommandWithTimeoutMock).toHaveBeenCalledTimes(1);
 }
 
+it("removes the marketplace clone directory when acquisition throws", async () => {
+  const reason = new Error("Gateway startup interrupted by SIGTERM");
+  let clonedTmpDir = "";
+  runCommandWithTimeoutMock.mockImplementationOnce(async (argv: string[]) => {
+    const repoDir = argv.at(-1);
+    expect(typeof repoDir).toBe("string");
+    clonedTmpDir = path.dirname(repoDir as string);
+    expect(clonedTmpDir).toContain("openclaw-marketplace-");
+    // Acquisition rejections bypass cleanupOnFailure, mirroring the abort
+    // path where runCommandWithTimeout forwards cancellation by throwing.
+    throw reason;
+  });
+
+  await expect(listMarketplacePlugins({ marketplace: "owner/repo" })).rejects.toBe(reason);
+  await expect(fs.access(clonedTmpDir)).rejects.toMatchObject({ code: "ENOENT" });
+});
+
 function installPluginInput(callIndex = 0): Record<string, unknown> {
   const input = installPluginFromPathMock.mock.calls[callIndex]?.[0];
   if (!input || typeof input !== "object") {

--- a/src/plugins/marketplace.ts
+++ b/src/plugins/marketplace.ts
@@ -7,11 +7,10 @@ import { hasHttpUrlPrefix } from "@openclaw/net-policy/url-protocol";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { sanitizeForLog } from "../../packages/terminal-core/src/ansi.js";
 import { resolveArchiveKind } from "../infra/archive.js";
-import { formatErrorMessage } from "../infra/errors.js";
+import { formatErrorMessage, toErrorObject } from "../infra/errors.js";
 import { pathExists } from "../infra/fs-safe.js";
 import { acquireGitSource } from "../infra/git-source.js";
 import { resolveOsHomeRelativePath } from "../infra/home-dir.js";
-import { readChunkWithIdleTimeout } from "../infra/http-response-body-timeout.js";
 import { tryReadJson } from "../infra/json-files.js";
 import { fetchWithSsrFGuard } from "../infra/net/fetch-guard.js";
 import { isPathInside } from "../infra/path-guards.js";
@@ -527,6 +526,7 @@ async function cloneMarketplaceRepo(params: {
   source: string;
   timeoutMs?: number;
   logger?: MarketplaceLogger;
+  signal?: AbortSignal;
 }): Promise<
   | { ok: true; rootDir: string; cleanup: () => Promise<void>; label: string; ref?: string }
   | { ok: false; error: string }
@@ -547,6 +547,7 @@ async function cloneMarketplaceRepo(params: {
     repoDir,
     refMode: isImmutableGitCommitRef(normalized.ref) ? "detached" : "shallow-branch",
     timeoutMs: params.timeoutMs,
+    ...(params.signal ? { signal: params.signal } : {}),
     cloneSeparator: false,
     recordCommit: false,
     cleanupOnFailure: cleanup,
@@ -572,7 +573,9 @@ async function loadMarketplace(params: {
   source: string;
   logger?: MarketplaceLogger;
   timeoutMs?: number;
+  signal?: AbortSignal;
 }): Promise<{ ok: true; marketplace: LoadedMarketplace } | { ok: false; error: string }> {
+  params.signal?.throwIfAborted();
   const loadMarketplaceFromManifestFile = async (paramsLocal: {
     manifestPath: string;
     sourceLabel: string;
@@ -699,6 +702,7 @@ async function loadMarketplace(params: {
     source,
     timeoutMs: params.timeoutMs,
     logger: params.logger,
+    ...(params.signal ? { signal: params.signal } : {}),
   });
   if (!cloned.ok) {
     return cloned;
@@ -775,6 +779,62 @@ function parseMarketplaceContentLength(raw: string): number {
   return size;
 }
 
+async function readMarketplaceChunkWithTimeout(
+  reader: ReadableStreamDefaultReader<Uint8Array>,
+  chunkTimeoutMs: number,
+  signal?: AbortSignal,
+): Promise<Awaited<ReturnType<typeof reader.read>>> {
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+  let terminated = false;
+
+  return await new Promise((resolve, reject) => {
+    const clear = () => {
+      if (timeoutId !== undefined) {
+        clearTimeout(timeoutId);
+        timeoutId = undefined;
+      }
+    };
+
+    const abort = () => {
+      terminated = true;
+      clear();
+      void reader.cancel().catch(() => undefined);
+      reject(toErrorObject(signal?.reason, "marketplace download aborted"));
+    };
+
+    if (signal?.aborted) {
+      abort();
+      return;
+    }
+    signal?.addEventListener("abort", abort, { once: true });
+
+    timeoutId = setTimeout(() => {
+      terminated = true;
+      clear();
+      signal?.removeEventListener("abort", abort);
+      void reader.cancel().catch(() => undefined);
+      reject(new Error(`download timed out after ${chunkTimeoutMs}ms`));
+    }, chunkTimeoutMs);
+
+    void reader.read().then(
+      (result) => {
+        clear();
+        signal?.removeEventListener("abort", abort);
+        if (!terminated) {
+          resolve(result);
+        }
+      },
+      (err: unknown) => {
+        clear();
+        signal?.removeEventListener("abort", abort);
+        if (!terminated) {
+          reject(toErrorObject(err, "Non-Error rejection"));
+        }
+      },
+    );
+  });
+}
+
 async function writeMarketplaceChunk(
   fileHandle: Awaited<ReturnType<typeof fs.open>>,
   chunk: Uint8Array,
@@ -794,6 +854,7 @@ async function streamMarketplaceResponseToFile(params: {
   targetPath: string;
   maxBytes: number;
   chunkTimeoutMs: number;
+  signal?: AbortSignal;
 }): Promise<void> {
   const reader = params.response.body.getReader();
   const fileHandle = await fs.open(params.targetPath, "wx");
@@ -801,10 +862,10 @@ async function streamMarketplaceResponseToFile(params: {
 
   try {
     while (true) {
-      const { done, value } = await readChunkWithIdleTimeout(
+      const { done, value } = await readMarketplaceChunkWithTimeout(
         reader,
         params.chunkTimeoutMs,
-        ({ chunkTimeoutMs }) => new Error(`download timed out after ${chunkTimeoutMs}ms`),
+        params.signal,
       );
       if (done) {
         return;
@@ -837,6 +898,7 @@ async function streamMarketplaceResponseToFile(params: {
 async function downloadUrlToTempFile(
   url: string,
   timeoutMs?: number,
+  signal?: AbortSignal,
 ): Promise<
   | {
       ok: true;
@@ -856,6 +918,7 @@ async function downloadUrlToTempFile(
     const { response, finalUrl, release } = await fetchWithSsrFGuard({
       url,
       timeoutMs: downloadTimeoutMs,
+      ...(signal ? { signal } : {}),
       auditContext: "marketplace-plugin-download",
     });
     try {
@@ -911,6 +974,7 @@ async function downloadUrlToTempFile(
         targetPath,
         maxBytes: MAX_MARKETPLACE_ARCHIVE_BYTES,
         chunkTimeoutMs: downloadTimeoutMs,
+        ...(signal ? { signal } : {}),
       });
       return {
         ok: true,
@@ -1055,6 +1119,7 @@ async function resolveMarketplaceEntryInstallPath(params: {
   marketplaceOrigin: MarketplaceManifestOrigin;
   logger?: MarketplaceLogger;
   timeoutMs?: number;
+  signal?: AbortSignal;
 }): Promise<
   | {
       ok: true;
@@ -1069,7 +1134,7 @@ async function resolveMarketplaceEntryInstallPath(params: {
   if (params.source.kind === "path") {
     if (hasHttpUrlPrefix(params.source.path)) {
       if (resolveArchiveKind(params.source.path)) {
-        return await downloadUrlToTempFile(params.source.path, params.timeoutMs);
+        return await downloadUrlToTempFile(params.source.path, params.timeoutMs, params.signal);
       }
       return {
         ok: false,
@@ -1104,6 +1169,7 @@ async function resolveMarketplaceEntryInstallPath(params: {
       source: sourceSpec,
       timeoutMs: params.timeoutMs,
       logger: params.logger,
+      ...(params.signal ? { signal: params.signal } : {}),
     });
     if (!cloned.ok) {
       return cloned;
@@ -1128,7 +1194,7 @@ async function resolveMarketplaceEntryInstallPath(params: {
   }
 
   if (resolveArchiveKind(params.source.url)) {
-    return await downloadUrlToTempFile(params.source.url, params.timeoutMs);
+    return await downloadUrlToTempFile(params.source.url, params.timeoutMs, params.signal);
   }
 
   if (!normalizeGitCloneSource(params.source.url)) {
@@ -1142,6 +1208,7 @@ async function resolveMarketplaceEntryInstallPath(params: {
     source: params.source.url,
     timeoutMs: params.timeoutMs,
     logger: params.logger,
+    ...(params.signal ? { signal: params.signal } : {}),
   });
   if (!cloned.ok) {
     return cloned;
@@ -1237,10 +1304,12 @@ export async function installPluginFromMarketplace(
     beforePersistentApply?: () => void;
   },
 ): Promise<MarketplaceInstallResult> {
+  params.signal?.throwIfAborted();
   const loaded = await loadMarketplace({
     source: params.marketplace,
     logger: params.logger,
     timeoutMs: params.timeoutMs,
+    ...(params.signal ? { signal: params.signal } : {}),
   });
   if (!loaded.ok) {
     return loaded;
@@ -1248,6 +1317,7 @@ export async function installPluginFromMarketplace(
 
   let installCleanup: (() => Promise<void>) | undefined;
   try {
+    params.signal?.throwIfAborted();
     const entry = loaded.marketplace.manifest.plugins.find(
       (plugin) => plugin.name === params.plugin,
     );
@@ -1267,6 +1337,7 @@ export async function installPluginFromMarketplace(
       marketplaceOrigin: loaded.marketplace.origin,
       logger: params.logger,
       timeoutMs: params.timeoutMs,
+      ...(params.signal ? { signal: params.signal } : {}),
     });
     if (!resolved.ok) {
       return resolved;
@@ -1286,6 +1357,7 @@ export async function installPluginFromMarketplace(
         expectedPluginId: params.expectedPluginId,
         onBeforePluginArtifactCommit: params.onBeforePluginArtifactCommit,
         beforePersistentApply: params.beforePersistentApply,
+        ...(params.signal ? { signal: params.signal } : {}),
         installPolicyRequest: {
           kind: marketplaceInstallPolicyRequestKind({
             marketplaceOrigin: loaded.marketplace.origin,

--- a/src/plugins/marketplace.ts
+++ b/src/plugins/marketplace.ts
@@ -542,20 +542,29 @@ async function cloneMarketplaceRepo(params: {
     await fs.rm(tmpDir, { recursive: true, force: true }).catch(() => undefined);
   };
   params.logger?.info?.(`Cloning marketplace source ${normalized.label}...`);
-  const acquired = await acquireGitSource({
-    ...normalized,
-    repoDir,
-    refMode: isImmutableGitCommitRef(normalized.ref) ? "detached" : "shallow-branch",
-    timeoutMs: params.timeoutMs,
-    ...(params.signal ? { signal: params.signal } : {}),
-    cloneSeparator: false,
-    recordCommit: false,
-    cleanupOnFailure: cleanup,
-    formatFailure: ({ action, stdout, stderr }) => {
-      const detail = stderr.trim() || stdout.trim() || `git ${action} failed`;
-      return `failed to ${action} marketplace source ${normalized.label}: ${detail}`;
-    },
-  });
+  // This caller owns tmpDir: acquisition rejections (cancellation included)
+  // bypass cleanupOnFailure and never hand back a cleanup handle, so remove
+  // the abandoned clone directory here and rethrow the original error.
+  let acquired: Awaited<ReturnType<typeof acquireGitSource>>;
+  try {
+    acquired = await acquireGitSource({
+      ...normalized,
+      repoDir,
+      refMode: isImmutableGitCommitRef(normalized.ref) ? "detached" : "shallow-branch",
+      timeoutMs: params.timeoutMs,
+      ...(params.signal ? { signal: params.signal } : {}),
+      cloneSeparator: false,
+      recordCommit: false,
+      cleanupOnFailure: cleanup,
+      formatFailure: ({ action, stdout, stderr }) => {
+        const detail = stderr.trim() || stdout.trim() || `git ${action} failed`;
+        return `failed to ${action} marketplace source ${normalized.label}: ${detail}`;
+      },
+    });
+  } catch (error) {
+    await cleanup();
+    throw error;
+  }
   if (!acquired.ok) {
     return acquired;
   }

--- a/src/plugins/update-attempt.ts
+++ b/src/plugins/update-attempt.ts
@@ -267,6 +267,7 @@ export async function buildDryRunPluginUpdateOutcome(params: {
   hasSpecOverride: boolean;
   updateChannel?: UpdateChannel;
   timeoutMs?: number;
+  signal?: AbortSignal;
   channelFallbackSuffix: string;
 }): Promise<PluginUpdateOutcome> {
   const npmProbeVersion =
@@ -286,8 +287,10 @@ export async function buildDryRunPluginUpdateOutcome(params: {
           probeNpmVersion: npmProbeVersion,
           updateChannel: params.updateChannel,
           timeoutMs: params.timeoutMs,
+          ...(params.signal ? { signal: params.signal } : {}),
         })
       : undefined;
+  params.signal?.throwIfAborted();
 
   if (unchanged) {
     const message =
@@ -337,7 +340,10 @@ export async function runPluginUpdateAttempt(params: {
   installNpmSpecForUpdate: typeof installPluginFromNpmSpec;
   logger: PluginUpdateLogger;
   onIntegrityDrift?: (params: PluginUpdateIntegrityDriftParams) => boolean | Promise<boolean>;
+  signal?: AbortSignal;
 }): Promise<PluginUpdateAttemptResult> {
+  const throwIfAborted = () => params.signal?.throwIfAborted();
+  throwIfAborted();
   const dryRunOption = params.dryRun ? { dryRun: true } : {};
   const phase = params.dryRun ? "check" : "update";
   const installNpmSpec = params.dryRun ? installPluginFromNpmSpec : params.installNpmSpecForUpdate;
@@ -368,6 +374,7 @@ export async function runPluginUpdateAttempt(params: {
                 onIntegrityDrift: params.onIntegrityDrift,
               }),
               logger: params.logger,
+              ...(params.signal ? { signal: params.signal } : {}),
             }),
           )
         : params.record.source === "clawhub"
@@ -384,6 +391,7 @@ export async function runPluginUpdateAttempt(params: {
                 onBeforePluginArtifactCommit: params.onBeforePluginArtifactCommit,
                 expectedPluginId: params.pluginId,
                 logger: params.logger,
+                ...(params.signal ? { signal: params.signal } : {}),
               }),
             )
           : params.record.source === "git"
@@ -399,6 +407,7 @@ export async function runPluginUpdateAttempt(params: {
                   onBeforePluginArtifactCommit: params.onBeforePluginArtifactCommit,
                   expectedPluginId: params.pluginId,
                   logger: params.logger,
+                  ...(params.signal ? { signal: params.signal } : {}),
                 }),
               )
             : await installPluginFromMarketplace(
@@ -414,15 +423,18 @@ export async function runPluginUpdateAttempt(params: {
                   onBeforePluginArtifactCommit: params.onBeforePluginArtifactCommit,
                   expectedPluginId: params.pluginId,
                   logger: params.logger,
+                  ...(params.signal ? { signal: params.signal } : {}),
                 }),
               );
   } catch (error) {
+    throwIfAborted();
     return {
       kind: "exception",
       message: `Failed to ${phase} ${params.pluginId}: ${String(error)}`,
       error,
     };
   }
+  throwIfAborted();
 
   let activeClawHubInstallSpec = params.effectiveSpec;
   let channelFallbackSuffix = "";
@@ -442,6 +454,7 @@ export async function runPluginUpdateAttempt(params: {
     params.logger.warn?.(
       `Plugin "${params.pluginId}" has no beta ClawHub release for ${params.clawhubSpecs.fallbackLabel ?? params.effectiveSpec}; using ${params.clawhubSpecs.fallbackSpec} instead. Core update can still complete.`,
     );
+    throwIfAborted();
     result = await installPluginFromClawHub(
       installParams({
         spec: params.clawhubSpecs.fallbackSpec,
@@ -455,8 +468,10 @@ export async function runPluginUpdateAttempt(params: {
         onBeforePluginArtifactCommit: params.onBeforePluginArtifactCommit,
         expectedPluginId: params.pluginId,
         logger: params.logger,
+        ...(params.signal ? { signal: params.signal } : {}),
       }),
     );
+    throwIfAborted();
     activeClawHubInstallSpec = params.clawhubSpecs.fallbackSpec;
   }
 

--- a/src/plugins/update-claw-lifecycle.ts
+++ b/src/plugins/update-claw-lifecycle.ts
@@ -33,6 +33,7 @@ export async function runPluginUpdateWithClawHubLease<T>(params: {
   clawhubPackage?: string;
   dryRun: boolean;
   run: () => Promise<T>;
+  signal?: AbortSignal;
 }): Promise<T | { kind: "exception"; message: string; error: unknown }> {
   try {
     if (!params.clawhubPackage || params.dryRun) {
@@ -51,6 +52,7 @@ export async function runPluginUpdateWithClawHubLease<T>(params: {
       { required: true },
     );
   } catch (error) {
+    params.signal?.throwIfAborted();
     return {
       kind: "exception",
       message: `Failed to update ${params.pluginId}: ${error instanceof Error ? error.message : String(error)}`,

--- a/src/plugins/update-installed.ts
+++ b/src/plugins/update-installed.ts
@@ -107,7 +107,9 @@ export async function updateNpmInstalledPlugins(params: {
   onCapabilityConsent?: PluginCapabilityConsentHandler;
   beforePersistentEffect?: () => void | Promise<void>;
   packagePluginIds?: Readonly<Record<string, readonly string[]>>;
+  signal?: AbortSignal;
 }): Promise<PluginUpdateSummary> {
+  params.signal?.throwIfAborted();
   const logger = params.logger ?? {};
   const consentCallbacks = capturePluginCapabilityConsentHandlerErrors(params.onCapabilityConsent);
   const installs = params.config.plugins?.installs ?? {};
@@ -155,6 +157,7 @@ export async function updateNpmInstalledPlugins(params: {
   const completedCanonicalUpdates = new Set<string>();
 
   for (const pluginId of targets) {
+    params.signal?.throwIfAborted();
     if (params.skipIds?.has(pluginId)) {
       recordSkippedOutcome(pluginId, `Skipping "${pluginId}" (already updated).`);
       continue;
@@ -377,6 +380,7 @@ export async function updateNpmInstalledPlugins(params: {
         : await resolveNpmSpecMetadata({
             spec: effectiveSpec!,
             timeoutMs: params.timeoutMs,
+            ...(params.signal ? { signal: params.signal } : {}),
           });
       if (metadataResult.ok) {
         const bypassTrustedOfficialUnchangedNpmCheck = shouldBypassTrustedOfficialUnchangedNpmCheck(
@@ -391,21 +395,22 @@ export async function updateNpmInstalledPlugins(params: {
               metadata: metadataResult.metadata,
               spec: effectiveSpec!,
               timeoutMs: params.timeoutMs,
+              ...(params.signal ? { signal: params.signal } : {}),
             })
           : undefined;
-        const expectedIntegrityMetadata =
-          trustedPrereleaseFallback?.metadata ?? metadataResult.metadata;
+        params.signal?.throwIfAborted();
+        const expectedMetadata = trustedPrereleaseFallback?.metadata ?? metadataResult.metadata;
         expectedIntegrity =
           catalogExpectedIntegrity ??
           expectedIntegrityForNpmUpdate({
             effectiveSpec,
-            metadata: expectedIntegrityMetadata,
+            metadata: expectedMetadata,
             record,
             trustedSourceLinkedOfficialInstall,
           });
         if (
           !catalogExpectedIntegrity &&
-          (!isNpmMetadataCompatibleWithCurrentHost(expectedIntegrityMetadata) ||
+          (!isNpmMetadataCompatibleWithCurrentHost(expectedMetadata) ||
             (bypassTrustedOfficialUnchangedNpmCheck && !trustedPrereleaseFallback))
         ) {
           expectedIntegrity = undefined;
@@ -433,6 +438,7 @@ export async function updateNpmInstalledPlugins(params: {
             resolution: metadataResult.metadata,
             updateChannel,
             timeoutMs: params.timeoutMs,
+            ...(params.signal ? { signal: params.signal } : {}),
             hasSpecOverride: Boolean(npmSpecOverride),
             syncOfficialInstall: Boolean(
               params.syncOfficialPluginInstalls && trustedSourceLinkedOfficialInstall,
@@ -491,6 +497,7 @@ export async function updateNpmInstalledPlugins(params: {
           installNpmSpecForUpdate,
           logger,
           onIntegrityDrift: params.onIntegrityDrift,
+          ...(params.signal ? { signal: params.signal } : {}),
         }),
       );
     const attempt = await runPluginUpdateWithClawHubLease({
@@ -498,7 +505,9 @@ export async function updateNpmInstalledPlugins(params: {
       clawhubPackage: recordClawHubPackage,
       dryRun: params.dryRun === true,
       run: runAttempt,
+      ...(params.signal ? { signal: params.signal } : {}),
     });
+    params.signal?.throwIfAborted();
     consentCallbacks.rethrowCallbackError();
     if (attempt.kind === "exception") {
       if (attempt.error instanceof ManagedPluginLifecycleError && attempt.error.capabilityConsent) {
@@ -585,6 +594,7 @@ export async function updateNpmInstalledPlugins(params: {
           hasSpecOverride: Boolean(npmSpecOverride),
           updateChannel,
           timeoutMs: params.timeoutMs,
+          ...(params.signal ? { signal: params.signal } : {}),
           channelFallbackSuffix,
         }),
       );

--- a/src/plugins/update-installed.ts
+++ b/src/plugins/update-installed.ts
@@ -206,6 +206,7 @@ export async function updateNpmInstalledPlugins(params: {
       coreVersion: params.coreVersion,
       versionBoundToCore: params.versionBoundPluginIds?.has(pluginId),
       timeoutMs: params.timeoutMs,
+      ...(params.signal ? { signal: params.signal } : {}),
     });
     if (normalizedPluginConfig) {
       const enableState = resolveEffectiveEnableState({

--- a/src/plugins/update-source.ts
+++ b/src/plugins/update-source.ts
@@ -31,7 +31,6 @@ import {
   resolveOfficialExternalPluginInstall,
 } from "./official-external-plugin-catalog.js";
 import { satisfiesPluginApiRange, resolvePackagePluginApiRange } from "./package-compat.js";
-
 /** Logger surface used by plugin update flows. */
 export type PluginUpdateLogger = {
   info?: (message: string) => void;
@@ -225,7 +224,9 @@ export async function resolveNewerExactPinnedNpmDefaultLine(params: {
   probeNpmVersion: string | undefined;
   updateChannel?: UpdateChannel;
   timeoutMs?: number;
+  signal?: AbortSignal;
 }): Promise<{ packageName: string; registryLine: "beta" | "latest"; version: string } | undefined> {
+  params.signal?.throwIfAborted();
   if (!params.currentVersion || !params.probeNpmVersion || !params.recordedSpec) {
     return undefined;
   }
@@ -268,6 +269,7 @@ export async function resolveTrustedOfficialPrereleaseFallbackMetadataForUpdate(
   metadata: NpmSpecResolution;
   spec: string;
   timeoutMs?: number;
+  signal?: AbortSignal;
 }): Promise<
   | {
       kind: "stable" | "prerelease-only";
@@ -290,6 +292,7 @@ export async function resolveTrustedOfficialPrereleaseFallbackMetadataForUpdate(
   const versions = await loadNpmPackageVersions({
     packageName: parsedSpec.name,
     timeoutMs: params.timeoutMs,
+    ...(params.signal ? { signal: params.signal } : {}),
   });
   const stableVersion = versions
     ?.filter((value) => !isPrereleaseSemverVersion(value))
@@ -299,6 +302,7 @@ export async function resolveTrustedOfficialPrereleaseFallbackMetadataForUpdate(
     const stableMetadata = await resolveNpmSpecMetadata({
       spec: `${parsedSpec.name}@${stableVersion}`,
       timeoutMs: params.timeoutMs,
+      ...(params.signal ? { signal: params.signal } : {}),
     });
     return stableMetadata.ok ? { kind: "stable", metadata: stableMetadata.metadata } : undefined;
   }
@@ -316,6 +320,7 @@ export async function resolveTrustedOfficialPrereleaseFallbackMetadataForUpdate(
   const prereleaseMetadata = await resolveNpmSpecMetadata({
     spec: `${parsedSpec.name}@${prereleaseVersion}`,
     timeoutMs: params.timeoutMs,
+    ...(params.signal ? { signal: params.signal } : {}),
   });
   return prereleaseMetadata.ok
     ? { kind: "prerelease-only", metadata: prereleaseMetadata.metadata }

--- a/src/plugins/update-source.ts
+++ b/src/plugins/update-source.ts
@@ -243,7 +243,9 @@ export async function resolveNewerExactPinnedNpmDefaultLine(params: {
     spec: packageName,
     updateChannel: params.updateChannel,
     timeoutMs: params.timeoutMs,
+    ...(params.signal ? { signal: params.signal } : {}),
   }).catch(() => undefined);
+  params.signal?.throwIfAborted();
   if (!specs) {
     return undefined;
   }
@@ -434,6 +436,7 @@ export function resolveNpmUpdateTarget(params: {
   coreVersion?: string;
   versionBoundToCore?: boolean;
   timeoutMs?: number;
+  signal?: AbortSignal;
 }) {
   const official = params.trustedOfficialInstall;
   const specOverride =
@@ -453,6 +456,7 @@ export function resolveNpmUpdateTarget(params: {
           coreVersion: params.coreVersion,
           versionBoundToCore: params.versionBoundToCore,
           timeoutMs: params.timeoutMs,
+          ...(params.signal ? { signal: params.signal } : {}),
         }
       : undefined,
   };

--- a/src/plugins/update-unchanged.ts
+++ b/src/plugins/update-unchanged.ts
@@ -18,6 +18,7 @@ export async function reconcileUnchangedUpdate(params: {
   resolution: NpmSpecResolution;
   updateChannel?: UpdateChannel;
   timeoutMs?: number;
+  signal?: AbortSignal;
   hasSpecOverride: boolean;
   syncOfficialInstall: boolean;
 }): Promise<{ config: OpenClawConfig; changed: boolean; outcome: PluginUpdateOutcome }> {
@@ -28,8 +29,10 @@ export async function reconcileUnchangedUpdate(params: {
         probeNpmVersion: params.resolution.version,
         updateChannel: params.updateChannel,
         timeoutMs: params.timeoutMs,
+        ...(params.signal ? { signal: params.signal } : {}),
       })
     : undefined;
+  params.signal?.throwIfAborted();
 
   let config = params.config;
   let changed = false;


### PR DESCRIPTION
<!--
Optional linked context:
Add a visible `Closes #<issue-number>` or `Related: #<issue-number>` line
below this comment.

Required PR title:
type: user-facing description
Use a parenthesized scope only when it adds clarity:
fix(auth): login redirect loops when session cookie is expired

Types: feat, fix, improve, refactor, docs, chore.
For fixes, describe the user-visible symptom and trigger:
fix: task list fails to load when user has no environments
Avoid implementation details such as:
fix: add null check to task query
-->

Closes #132317

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

<!--
Describe the concrete user, product, or operational problem.
For fixes, begin with:
"Fixes an issue where users <do X> would <experience Y> when <condition>."
or:
"Resolves a problem where..."

Name the affected UI surface or workflow. Do not describe the code-level cause here.
-->

Fixes an issue where users running the Gateway would see a replacement Gateway stall after the original process received SIGTERM during startup plugin convergence. The interrupted startup could leave the `core:plugin-lifecycle/global` lease owned until its five-minute TTL expired, causing crash-loop recovery to fail to start a replacement promptly.

## Why This Change Was Made

<!--
In one or two sentences, explain the complete shipped solution, key design
decisions, and relevant boundaries or non-goals. Include implementation detail
only when it helps reviewers understand user-visible behavior or risk.
Avoid file-by-file narration.
-->

Gateway startup now owns SIGINT/SIGTERM across preflight and passes the abort signal through configured-plugin repair, managed npm installation, and plugin-update fallback paths. Managed-proxy signal shutdown also waits for the complete Gateway run cleanup before exiting the process, so the lease-releasing `finally` path cannot be cut off. Every post-staging abort in the package-directory installer—including cancellation that lands while the update target-existence check is awaited—is routed through the installer's existing cleanup owner, which restores any displaced install, removes the staged directory, and then rethrows the original abort reason. This does not alter lease TTLs, bypass ownership, or change configuration/schema behavior; the branch is rebased on current `main`, keeping main's installer transaction/quarantine ownership checks intact.

## User Impact

<!--
State what users, operators, or developers can now do or expect. Lead with the
concrete benefit and use user-facing language. If there is no user-visible
impact, say so plainly.
-->

When a Gateway is interrupted while startup is converging plugins, startup unwinds immediately and releases its lifecycle lease. A supervisor or operator can then start a replacement Gateway without waiting for the stale five-minute lease expiry, and the replacement can become ready normally.

## Evidence

<!--
Show the most useful proof that this change works. Screenshots, screencasts,
terminal output, focused tests, CI results, live observations, redacted logs,
and artifact links are all useful. Include before/after evidence for visual
changes when it clarifies the result.

Reviewers will inspect the code, tests, and CI. Use this section to make the
validation easy to understand, not to restate the diff.
-->

- An owner-boundary regression aborts startup as `acquireGatewayLock()` resolves. On the pre-fix code it failed because the acquired handle was never released; after the fix it propagates the original abort, never starts the server, and releases the handle exactly once.
- A staging-cleanup regression interrupts the startup signal exactly while the update-mode target-existence check is awaited. On the pre-fix code it failed with an abandoned `.openclaw-install-stage-*` directory (expected 0, found 1); after the fix the staged directory is removed, the existing install is untouched, no backup is created, and the original SIGTERM reason is rethrown.
- Startup cancellation now also reaches npm channel metadata resolution: `resolveNpmInstallSpecsForUpdateChannel` throws the original abort before starting the parallel beta/latest metadata requests, forwards the signal into each `npm view` subprocess (process-tree termination), and rechecks after the await before any fallback or ordinary-error handling. The configured-plugin install, plugin-update, and exact-pin diagnostics callers pass their signal through.
- A final-publication regression aborts inside the synchronous guard that runs immediately before the publication rename. On the pre-fix code the install still published and returned `{ ok: true }` after cancellation; after the fix the move is refused, the staged directory is removed, nothing is published, and the original SIGTERM reason is rethrown. Cancellation regressions live in `src/infra/install-package-dir.cancellation.test.ts`.
- The proxy-enabled Gateway startup regression holds configured-plugin preflight open, invokes both SIGTERM handlers, proves `process.exit(143)` does not run early, then confirms the managed proxy is stopped before exit after startup cleanup settles.
- Plugin-update cancellation rejects with the original SIGTERM abort instead of recording an ordinary update failure; configured-plugin persisted-record repair also aborts without fallback installation or index writes.
- 2026-09-09 re-sync: the branch was rebased again onto current `main` (`d721a1525`, 4 commits, new head `bc77ab4e7`) after main moved and overlapped this PR. Three files conflicted and were resolved semantically: `install-security-scan.types.ts` keeps the union of `InstallSafetyOverrides` (main's tightened structure plus the PR's optional `signal`/`dangerouslyForceUnsafeInstall` members); `run-main.ts` final CLI cleanup keeps the PR's `try/finally` that disposes the startup signal owner and always settles the Gateway run cleanup gate, while adopting main's `pluginResources.runCleanup` disposer argument and `pauseNonTtyStdinForCliExit` guard; `run-main.exit.test.ts` keeps both main's new bounded-cleanup proxy test and the PR's startup-SIGTERM proxy test. No commits dropped.
- That sync pushed `src/commands/doctor-config-preflight.ts` over the oxlint max-lines budget (main had grown it to 698/700 counted lines); the repair declares the new `signal` option as an inline intersection on the existing options type (a pattern already used in this repo) and drops the entry-only signal guard pass-through into `completeStartupMigrationPreflight` (with its callee param reverted), leaving the PR's functional threading — lease-wait abort, plugin-convergence abort, measure step, configured-plugin repair, managed npm install, and plugin-update fallback — fully intact. File is at exactly 700/700 counted lines; no lint suppressions added.
- Validation on the new head `bc77ab4e7`: `oxfmt --check` over all 57 changed files passed; focused CLI suites (startup-signal, run-loop, supervised-lock, preaction, run-main.exit) passed 414/414; configured-plugin repair passed 133/133; `pnpm check:changed` (format, oxlint incl. max-lines, core typecheck, and repo gates) passed.
- One test intent was ported during the 2026-09-08 rebase: `main` replaced the `recoverSuspicious` callback path with the `prepareConfigRecovery` plan model, so the "stops suspicious config recovery" regression now raises SIGTERM at the first guarded config read and asserts `readGuardedGatewayRunConfig` refuses bootstrap without invoking `ensureCliExecutionBootstrap`. The intent (startup SIGTERM stops suspicious config recovery) is unchanged; only the mechanism assertion follows main's refactor.
- The real process-level startup regression sends SIGTERM while a plugin lifecycle lease is held and observes `aborted: true`, `exitCode: 143`, and `leaseActive: false` after unwind.
- In a real isolated interrupted-convergence sequence on the rebased head (main now resolves the missing configured plugin through the npm source first, so the boundary is a held `npm view @openclaw/matrix` packument request), Gateway-1 was blocked in convergence before readiness while `core:plugin-lifecycle/global` was active. SIGTERM killed the managed npm subprocess tree, terminated the gateway process by signal (observed `exit_code: -15`, i.e. SIGTERM; the controlled-exit path asserts `143` when the process exit hook runs), and removed the lease in 54ms; a real plugin installer then acquired the same lease within 1.5s and released it, and a different-PID Gateway on the same state, config, and port reached `/readyz=200 ready=true` in 4.2s—well below the five-minute lease TTL.

Scope/risk is limited to signal ownership, lock/lease cleanup ordering, exit ordering, and propagation of an already-aborted caller signal. Normal installer/update failures retain their existing retry and recovery behavior, and rollback cleanup remains on the existing paths.

