### PR TITLE
fix(cli): honor model thinking defaults in infer runs

### DIFF
--- a/src/cli/capability-cli.test.ts
+++ b/src/cli/capability-cli.test.ts
@@ -1278,6 +1278,46 @@ describe("capability cli", () => {
     expect(firstCompletionCall()?.options?.reasoning).toBe("high");
   });
 
+  it("uses the prepared model thinking default for local model probes", async () => {
+    mocks.prepareSimpleCompletionModelForAgent.mockResolvedValueOnce({
+      selection: {
+        provider: "zai",
+        modelId: "glm-5.3-flash",
+        agentDir: "/tmp/agent",
+      },
+      model: {
+        provider: "zai",
+        id: "glm-5.3-flash",
+        name: "GLM-5.3 Flash",
+        reasoning: true,
+        maxTokens: 128,
+      },
+      auth: {
+        apiKey: "zai-test",
+        source: "env:ZAI_API_KEY",
+        mode: "api-key",
+      },
+    } as never);
+
+    await runCapability(
+      "model",
+      "run",
+      "--model",
+      "zai/glm-5.3-flash",
+      "--prompt",
+      "hello",
+      "--json",
+    );
+
+    expect(firstCompletionCall()?.options?.reasoning).toBe("max");
+  });
+
+  it("keeps explicit thinking overrides ahead of prepared model defaults", async () => {
+    await runCapability("model", "run", "--prompt", "hello", "--thinking", "high", "--json");
+
+    expect(firstCompletionCall()?.options?.reasoning).toBe("high");
+  });
+
   it("passes image files to gateway model probes as attachments", async () => {
     const tempInput = path.join(os.tmpdir(), `openclaw-model-run-gateway-image-${Date.now()}.png`);
     await fs.writeFile(tempInput, Buffer.from(PNG_1X1_BASE64, "base64"));

--- a/src/cli/capability-cli.test.ts
+++ b/src/cli/capability-cli.test.ts
@@ -1312,6 +1312,48 @@ describe("capability cli", () => {
     expect(firstCompletionCall()?.options?.reasoning).toBe("max");
   });
 
+  it("honors the prepared catalog entry's reasoning policy over the prepared model", async () => {
+    mocks.loadModelCatalog.mockResolvedValueOnce([
+      {
+        provider: "zai",
+        id: "glm-5.3-flash",
+        name: "GLM-5.3 Flash",
+        reasoning: false,
+      },
+    ] as never);
+    mocks.prepareSimpleCompletionModelForAgent.mockResolvedValueOnce({
+      selection: {
+        provider: "zai",
+        modelId: "glm-5.3-flash",
+        agentDir: "/tmp/agent",
+      },
+      model: {
+        provider: "zai",
+        id: "glm-5.3-flash",
+        name: "GLM-5.3 Flash",
+        reasoning: true,
+        maxTokens: 128,
+      },
+      auth: {
+        apiKey: "zai-test",
+        source: "env:ZAI_API_KEY",
+        mode: "api-key",
+      },
+    } as never);
+
+    await runCapability(
+      "model",
+      "run",
+      "--model",
+      "zai/glm-5.3-flash",
+      "--prompt",
+      "hello",
+      "--json",
+    );
+
+    expect(firstCompletionCall()?.options?.reasoning).toBe("off");
+  });
+
   it("keeps explicit thinking overrides ahead of prepared model defaults", async () => {
     await runCapability("model", "run", "--prompt", "hello", "--thinking", "high", "--json");
 

--- a/src/cli/capability-cli/model.ts
+++ b/src/cli/capability-cli/model.ts
@@ -20,6 +20,7 @@ import { updateAuthProfileStoreWithLock } from "../../agents/auth-profiles/store
 import { buildExplicitSessionIdSessionKey } from "../../agents/command/session.js";
 import { DEFAULT_PROVIDER } from "../../agents/defaults.js";
 import { canonicalizeCaseOnlyCatalogModelRef } from "../../agents/model-selection.js";
+import { resolveThinkingDefault } from "../../agents/model-thinking-default.js";
 import { loadPreparedModelCatalog } from "../../agents/prepared-model-catalog.js";
 import {
   completeWithPreparedSimpleCompletionModel,
@@ -222,6 +223,21 @@ async function runModelRun(params: {
     }
     const localModelRunSystemPrompt =
       prepared.model.api === "openai-chatgpt-responses" ? LOCAL_MODEL_RUN_SYSTEM_PROMPT : undefined;
+    const effectiveThinking =
+      params.thinking ??
+      resolveThinkingDefault({
+        cfg,
+        provider: prepared.selection.provider,
+        model: prepared.selection.modelId,
+        catalog: [
+          {
+            provider: prepared.selection.provider,
+            id: prepared.selection.modelId,
+            name: prepared.model.name ?? prepared.selection.modelId,
+            reasoning: prepared.model.reasoning,
+          },
+        ],
+      });
     const result = await completeWithPreparedSimpleCompletionModel({
       model: prepared.model,
       auth: prepared.auth,
@@ -241,7 +257,7 @@ async function runModelRun(params: {
           typeof prepared.model.maxTokens === "number" && Number.isFinite(prepared.model.maxTokens)
             ? prepared.model.maxTokens
             : undefined,
-        ...(params.thinking ? { reasoning: params.thinking } : {}),
+        reasoning: effectiveThinking,
       },
     });
     const text = collectModelRunText(result.content);

--- a/src/cli/capability-cli/model.ts
+++ b/src/cli/capability-cli/model.ts
@@ -20,7 +20,7 @@ import { updateAuthProfileStoreWithLock } from "../../agents/auth-profiles/store
 import { buildExplicitSessionIdSessionKey } from "../../agents/command/session.js";
 import { DEFAULT_PROVIDER } from "../../agents/defaults.js";
 import { canonicalizeCaseOnlyCatalogModelRef } from "../../agents/model-selection.js";
-import { resolveThinkingDefault } from "../../agents/model-thinking-default.js";
+import { resolveThinkingDefaultWithRuntimeCatalog } from "../../agents/model-thinking-default.js";
 import { loadPreparedModelCatalog } from "../../agents/prepared-model-catalog.js";
 import {
   completeWithPreparedSimpleCompletionModel,
@@ -225,19 +225,12 @@ async function runModelRun(params: {
       prepared.model.api === "openai-chatgpt-responses" ? LOCAL_MODEL_RUN_SYSTEM_PROMPT : undefined;
     const effectiveThinking =
       params.thinking ??
-      resolveThinkingDefault({
+      (await resolveThinkingDefaultWithRuntimeCatalog({
         cfg,
         provider: prepared.selection.provider,
         model: prepared.selection.modelId,
-        catalog: [
-          {
-            provider: prepared.selection.provider,
-            id: prepared.selection.modelId,
-            name: prepared.model.name ?? prepared.selection.modelId,
-            reasoning: prepared.model.reasoning,
-          },
-        ],
-      });
+        loadRuntimeCatalog: () => loadPreparedModelCatalog({ config: cfg, readOnly: true }),
+      }));
     const result = await completeWithPreparedSimpleCompletionModel({
       model: prepared.model,
       auth: prepared.auth,


### PR DESCRIPTION
Closes #132625

## What Problem This Solves

`openclaw infer model run` used the local simple-completion transport without resolving the selected provider/model's default thinking level when `--thinking` was omitted. For always-thinking Z.AI GLM-5.3 models, that omission was normalized to `enable_thinking: false`, and the provider rejected the request with HTTP 400.

The local inference path now resolves the effective thinking default after the prepared model is selected, using the same complete prepared catalog + policy resolver as agent runs. An explicit `--thinking` value still takes precedence.

## Root Cause

The local model-run branch only added `options.reasoning` for an explicit CLI flag. It already had the final prepared provider/model identity, but did not pass that identity through thinking-default resolution before calling the simple-completion runtime.

## Why This Change Was Made

Rather than synthesizing a reduced catalog row (provider/id/name/reasoning), the branch now calls `resolveThinkingDefaultWithRuntimeCatalog` with `loadPreparedModelCatalog`, so the selected model's full `thinkingLevelMap`, `compat`, `params`, and `thinkingPolicyProvider` metadata participate in the resolution exactly as they do for agent turns. A model whose map or policy owner changes the supported default therefore resolves correctly instead of as if that policy were absent.

## User Impact

Users can run always-thinking models such as `zai/glm-5.3-flash` through `infer model run` without adding a redundant `--thinking` flag. Explicit thinking levels remain unchanged.

## Evidence

Exact head: `ead51f5af53f27c498fda2f2f474ab85e79c90a1`

- `node scripts/run-vitest.mjs src/cli/capability-cli.test.ts`: **198 passed**, including a new regression "honors the prepared catalog entry's reasoning policy over the prepared model" that asserts a catalog `reasoning: false` wins over the prepared model's `reasoning: true`.
- `node scripts/run-vitest.mjs extensions/zai/provider-policy-api.test.ts extensions/zai/index.test.ts`: **38 passed**
- `check:changed` passed formatting, dead-code checks, production typecheck, plugin boundaries, and all preceding guards. Its core-test typecheck reached an unrelated current-tree baseline error (`pako`/`mermaid` missing declarations in the reused dependency tree).
- `git diff --check`: passed.

A credentialed live Z.AI request was not run; the regression exercises the production CLI boundary and real bundled Z.AI thinking policy without network credentials.

## AI-Assisted Development

This change was developed with AI assistance. The implementation, focused tests, provider policy tests, full CLI suite, changed-file checks, and final diff were reviewed before submission.