### PR TITLE
fix(logging): report dropped file log records

### DIFF
--- a/src/logging/logger-file-transport.test.ts
+++ b/src/logging/logger-file-transport.test.ts
@@ -1,5 +1,6 @@
-// Logger file transport tests cover async ordering, overflow, and exit durability.
 import fs from "node:fs";
+// Logger file transport tests cover async ordering, overflow, and exit durability.
+import { expectDefined } from "@openclaw/normalization-core";
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import { appendRegularFile } from "../infra/regular-file.js";
 import { createSuiteLogPathTracker } from "./log-test-helpers.js";
@@ -109,54 +110,117 @@ describe("async logger file transport", () => {
     ]);
   });
 
-  it("reports each append failure streak while continuing records", async () => {
-    const logPath = logPathTracker.nextPath();
-    let appendAttempts = 0;
+  it("tracks append failure streaks independently per file", async () => {
+    const firstPath = logPathTracker.nextPath();
+    const secondPath = logPathTracker.nextPath();
+    const attempts = new Map<string, number>();
     const stderrSpy = vi
       .spyOn(process.stderr, "write")
       .mockImplementation(() => true as unknown as ReturnType<typeof process.stderr.write>);
     testApi.setFileLogAppenderForTests(async (options) => {
-      appendAttempts += 1;
-      if (appendAttempts !== 3) {
+      const attempt = (attempts.get(options.filePath) ?? 0) + 1;
+      attempts.set(options.filePath, attempt);
+      const succeeds =
+        (options.filePath === firstPath && attempt === 3) ||
+        (options.filePath === secondPath && attempt === 2);
+      if (!succeeds) {
         throw new Error("injected append failure");
       }
       await appendRegularFile(options);
     });
-    setLoggerOverride({ level: "info", file: logPath });
-
-    getLogger().info("dropped-on-first-failure");
-    getLogger().info("dropped-on-repeated-failure");
-    getLogger().info("written-after-recovery");
-    getLogger().info("dropped-after-recovery");
+    setLoggerOverride({ level: "info", file: firstPath });
+    getLogger().info("first-file-failure");
+    setLoggerOverride({ level: "info", file: secondPath });
+    getLogger().info("second-file-failure");
+    getLogger().info("second-file-recovery");
+    setLoggerOverride({ level: "info", file: firstPath });
+    getLogger().info("first-file-repeated-failure");
+    getLogger().info("first-file-recovery");
+    getLogger().info("first-file-new-failure-streak");
     await testApi.flushFileLogQueueForTests();
 
-    const content = fs.readFileSync(logPath, "utf8");
-    expect(appendAttempts).toBe(4);
-    expect(stderrSpy).toHaveBeenCalledTimes(2);
-    expect(stderrSpy).toHaveBeenCalledWith(
-      expect.stringContaining("log file append failed; record dropped"),
+    expect(attempts).toEqual(
+      new Map([
+        [firstPath, 4],
+        [secondPath, 2],
+      ]),
     );
-    expect(content).not.toContain("dropped-on-first-failure");
-    expect(content).not.toContain("dropped-on-repeated-failure");
-    expect(content).toContain("written-after-recovery");
-    expect(content).not.toContain("dropped-after-recovery");
+    const warnings = stderrSpy.mock.calls.map(([line]) => String(line));
+    expect(warnings.filter((line) => line.includes(`file=${firstPath}`))).toHaveLength(2);
+    expect(warnings.filter((line) => line.includes(`file=${secondPath}`))).toHaveLength(1);
+    expect(fs.readFileSync(firstPath, "utf8")).toContain("first-file-recovery");
+    expect(fs.readFileSync(secondPath, "utf8")).toContain("second-file-recovery");
   });
 
-  it("reports repeated synchronous append failures once", () => {
-    const logPath = logPathTracker.nextPath();
-    fs.mkdirSync(logPath);
+  it("keeps synchronous append failure streaks isolated by file", () => {
+    const firstPath = logPathTracker.nextPath();
+    const secondPath = logPathTracker.nextPath();
+    fs.mkdirSync(firstPath);
+    fs.mkdirSync(secondPath);
     const stderrSpy = vi
       .spyOn(process.stderr, "write")
       .mockImplementation(() => true as unknown as ReturnType<typeof process.stderr.write>);
-    setLoggerOverride({ level: "info", file: logPath });
-
-    getLogger().info("first-unwritable-record");
-    getLogger().info("second-unwritable-record");
+    setLoggerOverride({ level: "info", file: firstPath });
+    getLogger().info("first-file-failure");
+    setLoggerOverride({ level: "info", file: secondPath });
+    getLogger().info("second-file-failure");
     testApi.drainFileLogQueueSyncForTests();
 
-    expect(stderrSpy).toHaveBeenCalledTimes(1);
-    expect(stderrSpy).toHaveBeenCalledWith(
-      expect.stringContaining("log file append failed; record dropped"),
+    fs.rmdirSync(secondPath);
+    getLogger().info("second-file-recovery");
+    setLoggerOverride({ level: "info", file: firstPath });
+    getLogger().info("first-file-repeated-failure");
+    testApi.drainFileLogQueueSyncForTests();
+
+    fs.rmdirSync(firstPath);
+    getLogger().info("first-file-recovery");
+    testApi.drainFileLogQueueSyncForTests();
+    fs.rmSync(firstPath);
+    fs.mkdirSync(firstPath);
+    getLogger().info("first-file-new-failure-streak");
+    testApi.drainFileLogQueueSyncForTests();
+
+    const warnings = stderrSpy.mock.calls.map(([line]) => String(line));
+    expect(warnings.filter((line) => line.includes(`file=${firstPath}`))).toHaveLength(2);
+    expect(warnings.filter((line) => line.includes(`file=${secondPath}`))).toHaveLength(1);
+    expect(fs.readFileSync(secondPath, "utf8")).toContain("second-file-recovery");
+  });
+
+  it("bounds append failure diagnostics across changing file targets", async () => {
+    const paths = Array.from({ length: 65 }, () => logPathTracker.nextPath());
+    const firstPath = expectDefined(paths[0], "first append failure path");
+    const lastPath = expectDefined(paths.at(-1), "last append failure path");
+    const stderrSpy = vi
+      .spyOn(process.stderr, "write")
+      .mockImplementation(() => true as unknown as ReturnType<typeof process.stderr.write>);
+    testApi.setFileLogAppenderForTests(async () => {
+      throw new Error("injected append failure");
+    });
+
+    for (const [index, file] of paths.entries()) {
+      setLoggerOverride({ level: "info", file });
+      getLogger().info(`failure-${index}`);
+    }
+    await testApi.flushFileLogQueueForTests();
+
+    const warnings = stderrSpy.mock.calls.map(([line]) => String(line));
+    expect(warnings.filter((line) => line.includes("diagnostics saturated"))).toHaveLength(1);
+    expect(warnings.some((line) => line.includes(`file=${lastPath}`))).toBe(false);
+
+    testApi.setFileLogAppenderForTests(async (options) => {
+      if (options.filePath !== firstPath) {
+        throw new Error("injected append failure");
+      }
+      await appendRegularFile(options);
+    });
+    setLoggerOverride({ level: "info", file: firstPath });
+    getLogger().info("tracked-file-recovery");
+    setLoggerOverride({ level: "info", file: lastPath });
+    getLogger().info("newly-tracked-failure");
+    await testApi.flushFileLogQueueForTests();
+
+    expect(stderrSpy.mock.calls.some(([line]) => String(line).includes(`file=${lastPath}`))).toBe(
+      true,
     );
   });
 

--- a/src/logging/logger-file-transport.test.ts
+++ b/src/logging/logger-file-transport.test.ts
@@ -109,26 +109,55 @@ describe("async logger file transport", () => {
     ]);
   });
 
-  it("continues with later records after one append fails", async () => {
+  it("reports each append failure streak while continuing records", async () => {
     const logPath = logPathTracker.nextPath();
     let appendAttempts = 0;
+    const stderrSpy = vi
+      .spyOn(process.stderr, "write")
+      .mockImplementation(() => true as unknown as ReturnType<typeof process.stderr.write>);
     testApi.setFileLogAppenderForTests(async (options) => {
       appendAttempts += 1;
-      if (appendAttempts === 1) {
+      if (appendAttempts !== 3) {
         throw new Error("injected append failure");
       }
       await appendRegularFile(options);
     });
     setLoggerOverride({ level: "info", file: logPath });
 
-    getLogger().info("dropped-on-write-failure");
-    getLogger().info("written-after-failure");
+    getLogger().info("dropped-on-first-failure");
+    getLogger().info("dropped-on-repeated-failure");
+    getLogger().info("written-after-recovery");
+    getLogger().info("dropped-after-recovery");
     await testApi.flushFileLogQueueForTests();
 
     const content = fs.readFileSync(logPath, "utf8");
-    expect(appendAttempts).toBe(2);
-    expect(content).not.toContain("dropped-on-write-failure");
-    expect(content).toContain("written-after-failure");
+    expect(appendAttempts).toBe(4);
+    expect(stderrSpy).toHaveBeenCalledTimes(2);
+    expect(stderrSpy).toHaveBeenCalledWith(
+      expect.stringContaining("log file append failed; record dropped"),
+    );
+    expect(content).not.toContain("dropped-on-first-failure");
+    expect(content).not.toContain("dropped-on-repeated-failure");
+    expect(content).toContain("written-after-recovery");
+    expect(content).not.toContain("dropped-after-recovery");
+  });
+
+  it("reports repeated synchronous append failures once", () => {
+    const logPath = logPathTracker.nextPath();
+    fs.mkdirSync(logPath);
+    const stderrSpy = vi
+      .spyOn(process.stderr, "write")
+      .mockImplementation(() => true as unknown as ReturnType<typeof process.stderr.write>);
+    setLoggerOverride({ level: "info", file: logPath });
+
+    getLogger().info("first-unwritable-record");
+    getLogger().info("second-unwritable-record");
+    testApi.drainFileLogQueueSyncForTests();
+
+    expect(stderrSpy).toHaveBeenCalledTimes(1);
+    expect(stderrSpy).toHaveBeenCalledWith(
+      expect.stringContaining("log file append failed; record dropped"),
+    );
   });
 
   it("synchronously drains a crash-adjacent fatal record through the exit-hook seam", () => {

--- a/src/logging/logger-file-transport.test.ts
+++ b/src/logging/logger-file-transport.test.ts
@@ -1,5 +1,7 @@
 // Logger file transport tests cover async ordering, overflow, and exit durability.
+import { spawnSync } from "node:child_process";
 import fs from "node:fs";
+import { fileURLToPath } from "node:url";
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import { appendRegularFile } from "../infra/regular-file.js";
 import { createSuiteLogPathTracker } from "./log-test-helpers.js";
@@ -169,17 +171,35 @@ describe("async logger file transport", () => {
     expect(fs.readFileSync(secondPath, "utf8")).toContain("second-file-recovery");
   });
 
-  it("warns when the synchronous exit drain drops a record", () => {
+  it("writes a piped append warning before process exit", () => {
     const logPath = logPathTracker.nextPath();
     fs.mkdirSync(logPath);
-    const stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
-    setLoggerOverride({ level: "info", file: logPath });
+    const loaderPath = fileURLToPath(new URL("../../scripts/tsx.mjs", import.meta.url));
+    const loggerUrl = new URL("./logger.ts", import.meta.url).href;
+    const script = `
+      import { getLogger, setLoggerOverride } from ${JSON.stringify(loggerUrl)};
+      const writeStderr = process.stderr.write.bind(process.stderr);
+      process.stderr.write = (chunk, ...args) => {
+        setImmediate(() => writeStderr(chunk, ...args));
+        return true;
+      };
+      setLoggerOverride({ level: "info", file: ${JSON.stringify(logPath)}, consoleStyle: "compact" });
+      getLogger().info("exit-dropped-record");
+      process.exit(0);
+    `;
 
-    getLogger().info("sync-dropped-record");
-    testApi.drainFileLogQueueSyncForTests();
+    const result = spawnSync(
+      process.execPath,
+      ["--import", loaderPath, "--input-type=module", "--eval", script],
+      {
+        encoding: "utf8",
+        env: { ...process.env, VITEST: "false" },
+      },
+    );
 
-    const warnings = stderrSpy.mock.calls.map(([line]) => String(line));
-    expect(warnings.filter((line) => line.includes(`file=${logPath}`))).toHaveLength(1);
+    expect(result.error).toBeUndefined();
+    expect(result.status).toBe(0);
+    expect(result.stderr).toContain("log file append failed; record dropped");
   });
 
   it("retries the warning after stderr rejects it", async () => {

--- a/src/logging/logger-file-transport.test.ts
+++ b/src/logging/logger-file-transport.test.ts
@@ -1,6 +1,5 @@
-import fs from "node:fs";
 // Logger file transport tests cover async ordering, overflow, and exit durability.
-import { expectDefined } from "@openclaw/normalization-core";
+import fs from "node:fs";
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import { appendRegularFile } from "../infra/regular-file.js";
 import { createSuiteLogPathTracker } from "./log-test-helpers.js";
@@ -110,118 +109,66 @@ describe("async logger file transport", () => {
     ]);
   });
 
-  it("tracks append failure streaks independently per file", async () => {
-    const firstPath = logPathTracker.nextPath();
-    const secondPath = logPathTracker.nextPath();
-    const attempts = new Map<string, number>();
-    const stderrSpy = vi
-      .spyOn(process.stderr, "write")
-      .mockImplementation(() => true as unknown as ReturnType<typeof process.stderr.write>);
+  it("warns once per append failure streak and continues with later records", async () => {
+    const logPath = logPathTracker.nextPath();
+    let appendAttempts = 0;
+    const stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
     testApi.setFileLogAppenderForTests(async (options) => {
-      const attempt = (attempts.get(options.filePath) ?? 0) + 1;
-      attempts.set(options.filePath, attempt);
-      const succeeds =
-        (options.filePath === firstPath && attempt === 3) ||
-        (options.filePath === secondPath && attempt === 2);
-      if (!succeeds) {
+      appendAttempts += 1;
+      if (appendAttempts !== 3) {
         throw new Error("injected append failure");
       }
       await appendRegularFile(options);
     });
-    setLoggerOverride({ level: "info", file: firstPath });
-    getLogger().info("first-file-failure");
-    setLoggerOverride({ level: "info", file: secondPath });
-    getLogger().info("second-file-failure");
-    getLogger().info("second-file-recovery");
-    setLoggerOverride({ level: "info", file: firstPath });
-    getLogger().info("first-file-repeated-failure");
-    getLogger().info("first-file-recovery");
-    getLogger().info("first-file-new-failure-streak");
+    setLoggerOverride({ level: "info", file: logPath });
+
+    getLogger().info("first-dropped-record");
+    getLogger().info("second-dropped-record");
+    getLogger().info("written-after-failure");
+    getLogger().info("dropped-after-recovery");
     await testApi.flushFileLogQueueForTests();
 
-    expect(attempts).toEqual(
-      new Map([
-        [firstPath, 4],
-        [secondPath, 2],
-      ]),
-    );
+    const content = fs.readFileSync(logPath, "utf8");
+    expect(appendAttempts).toBe(4);
+    expect(content).not.toContain("first-dropped-record");
+    expect(content).toContain("written-after-failure");
+    expect(content).not.toContain("dropped-after-recovery");
     const warnings = stderrSpy.mock.calls.map(([line]) => String(line));
-    expect(warnings.filter((line) => line.includes(`file=${firstPath}`))).toHaveLength(2);
-    expect(warnings.filter((line) => line.includes(`file=${secondPath}`))).toHaveLength(1);
-    expect(fs.readFileSync(firstPath, "utf8")).toContain("first-file-recovery");
-    expect(fs.readFileSync(secondPath, "utf8")).toContain("second-file-recovery");
+    expect(warnings.filter((line) => line.includes(`file=${logPath}`))).toHaveLength(2);
+    expect(warnings[0]).toContain("record dropped; check that the path is a writable regular file");
   });
 
-  it("keeps synchronous append failure streaks isolated by file", () => {
-    const firstPath = logPathTracker.nextPath();
-    const secondPath = logPathTracker.nextPath();
-    fs.mkdirSync(firstPath);
-    fs.mkdirSync(secondPath);
-    const stderrSpy = vi
-      .spyOn(process.stderr, "write")
-      .mockImplementation(() => true as unknown as ReturnType<typeof process.stderr.write>);
-    setLoggerOverride({ level: "info", file: firstPath });
-    getLogger().info("first-file-failure");
-    setLoggerOverride({ level: "info", file: secondPath });
-    getLogger().info("second-file-failure");
-    testApi.drainFileLogQueueSyncForTests();
+  it("warns when the synchronous exit drain drops a record", () => {
+    const logPath = logPathTracker.nextPath();
+    fs.mkdirSync(logPath);
+    const stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    setLoggerOverride({ level: "info", file: logPath });
 
-    fs.rmdirSync(secondPath);
-    getLogger().info("second-file-recovery");
-    setLoggerOverride({ level: "info", file: firstPath });
-    getLogger().info("first-file-repeated-failure");
-    testApi.drainFileLogQueueSyncForTests();
-
-    fs.rmdirSync(firstPath);
-    getLogger().info("first-file-recovery");
-    testApi.drainFileLogQueueSyncForTests();
-    fs.rmSync(firstPath);
-    fs.mkdirSync(firstPath);
-    getLogger().info("first-file-new-failure-streak");
+    getLogger().info("sync-dropped-record");
     testApi.drainFileLogQueueSyncForTests();
 
     const warnings = stderrSpy.mock.calls.map(([line]) => String(line));
-    expect(warnings.filter((line) => line.includes(`file=${firstPath}`))).toHaveLength(2);
-    expect(warnings.filter((line) => line.includes(`file=${secondPath}`))).toHaveLength(1);
-    expect(fs.readFileSync(secondPath, "utf8")).toContain("second-file-recovery");
+    expect(warnings.filter((line) => line.includes(`file=${logPath}`))).toHaveLength(1);
   });
 
-  it("bounds append failure diagnostics across changing file targets", async () => {
-    const paths = Array.from({ length: 65 }, () => logPathTracker.nextPath());
-    const firstPath = expectDefined(paths[0], "first append failure path");
-    const lastPath = expectDefined(paths.at(-1), "last append failure path");
-    const stderrSpy = vi
-      .spyOn(process.stderr, "write")
-      .mockImplementation(() => true as unknown as ReturnType<typeof process.stderr.write>);
+  it("retries the warning after stderr rejects it", async () => {
+    const logPath = logPathTracker.nextPath();
+    const stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    stderrSpy.mockImplementationOnce(() => {
+      throw new Error("injected stderr failure");
+    });
     testApi.setFileLogAppenderForTests(async () => {
       throw new Error("injected append failure");
     });
+    setLoggerOverride({ level: "info", file: logPath });
 
-    for (const [index, file] of paths.entries()) {
-      setLoggerOverride({ level: "info", file });
-      getLogger().info(`failure-${index}`);
-    }
+    getLogger().info("first-dropped-record");
+    await testApi.flushFileLogQueueForTests();
+    getLogger().info("second-dropped-record");
     await testApi.flushFileLogQueueForTests();
 
-    const warnings = stderrSpy.mock.calls.map(([line]) => String(line));
-    expect(warnings.filter((line) => line.includes("diagnostics saturated"))).toHaveLength(1);
-    expect(warnings.some((line) => line.includes(`file=${lastPath}`))).toBe(false);
-
-    testApi.setFileLogAppenderForTests(async (options) => {
-      if (options.filePath !== firstPath) {
-        throw new Error("injected append failure");
-      }
-      await appendRegularFile(options);
-    });
-    setLoggerOverride({ level: "info", file: firstPath });
-    getLogger().info("tracked-file-recovery");
-    setLoggerOverride({ level: "info", file: lastPath });
-    getLogger().info("newly-tracked-failure");
-    await testApi.flushFileLogQueueForTests();
-
-    expect(stderrSpy.mock.calls.some(([line]) => String(line).includes(`file=${lastPath}`))).toBe(
-      true,
-    );
+    expect(stderrSpy).toHaveBeenCalledTimes(2);
+    expect(String(stderrSpy.mock.calls[1]?.[0])).toContain(`file=${logPath}`);
   });
 
   it("synchronously drains a crash-adjacent fatal record through the exit-hook seam", () => {

--- a/src/logging/logger-file-transport.test.ts
+++ b/src/logging/logger-file-transport.test.ts
@@ -5,6 +5,8 @@ import { appendRegularFile } from "../infra/regular-file.js";
 import { createSuiteLogPathTracker } from "./log-test-helpers.js";
 import { getLogger, resetLogger, setLoggerOverride } from "./logger.js";
 import { testApi } from "./logger.test-support.js";
+import { registerSecretValueForRedaction } from "./secret-redaction-registry.js";
+import { resetSecretRedactionRegistryForTest } from "./secret-redaction-registry.test-support.js";
 
 const logPathTracker = createSuiteLogPathTracker("openclaw-file-transport-");
 
@@ -23,6 +25,7 @@ afterEach(async () => {
   testApi.resetFileLogTransportForTests();
   resetLogger();
   setLoggerOverride(null);
+  resetSecretRedactionRegistryForTest();
   vi.useRealTimers();
   vi.restoreAllMocks();
 });
@@ -110,7 +113,9 @@ describe("async logger file transport", () => {
   });
 
   it("warns once per append failure streak and continues with later records", async () => {
-    const logPath = logPathTracker.nextPath();
+    const secret = "append-warning-secret-1234567890";
+    registerSecretValueForRedaction(secret);
+    const logPath = `${logPathTracker.nextPath()}-${secret}`;
     let appendAttempts = 0;
     const stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
     testApi.setFileLogAppenderForTests(async (options) => {
@@ -134,8 +139,34 @@ describe("async logger file transport", () => {
     expect(content).toContain("written-after-failure");
     expect(content).not.toContain("dropped-after-recovery");
     const warnings = stderrSpy.mock.calls.map(([line]) => String(line));
-    expect(warnings.filter((line) => line.includes(`file=${logPath}`))).toHaveLength(2);
+    expect(warnings.filter((line) => line.includes("log file append failed"))).toHaveLength(2);
     expect(warnings[0]).toContain("record dropped; check that the path is a writable regular file");
+    expect(warnings.join("\n")).not.toContain(secret);
+  });
+
+  it("keeps failure streaks independent by file", async () => {
+    const firstPath = logPathTracker.nextPath();
+    const secondPath = logPathTracker.nextPath();
+    fs.mkdirSync(firstPath);
+    fs.mkdirSync(secondPath);
+    const stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+
+    setLoggerOverride({ level: "info", file: firstPath });
+    getLogger().info("first-file-failure");
+    setLoggerOverride({ level: "info", file: secondPath });
+    getLogger().info("second-file-failure");
+    await testApi.flushFileLogQueueForTests();
+
+    fs.rmdirSync(secondPath);
+    getLogger().info("second-file-recovery");
+    setLoggerOverride({ level: "info", file: firstPath });
+    getLogger().info("first-file-repeated-failure");
+    await testApi.flushFileLogQueueForTests();
+
+    const warnings = stderrSpy.mock.calls.map(([line]) => String(line));
+    expect(warnings.filter((line) => line.includes(`file=${firstPath}`))).toHaveLength(1);
+    expect(warnings.filter((line) => line.includes(`file=${secondPath}`))).toHaveLength(1);
+    expect(fs.readFileSync(secondPath, "utf8")).toContain("second-file-recovery");
   });
 
   it("warns when the synchronous exit drain drops a record", () => {
@@ -169,6 +200,47 @@ describe("async logger file transport", () => {
 
     expect(stderrSpy).toHaveBeenCalledTimes(2);
     expect(String(stderrSpy.mock.calls[1]?.[0])).toContain(`file=${logPath}`);
+  });
+
+  it("releases saturated failure tracking after a tracked file recovers", async () => {
+    const firstPath = logPathTracker.nextPath();
+    const lastPath = logPathTracker.nextPath();
+    const paths = [
+      firstPath,
+      ...Array.from({ length: 63 }, () => logPathTracker.nextPath()),
+      lastPath,
+    ];
+    const stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    testApi.setFileLogAppenderForTests(async () => {
+      throw new Error("injected append failure");
+    });
+
+    for (const [index, file] of paths.entries()) {
+      setLoggerOverride({ level: "info", file });
+      getLogger().info(`failure-${index}`);
+    }
+    await testApi.flushFileLogQueueForTests();
+
+    const warnings = stderrSpy.mock.calls.map(([line]) => String(line));
+    expect(warnings.filter((line) => line.includes("diagnostics saturated"))).toHaveLength(1);
+    expect(warnings.some((line) => line.includes(`file=${lastPath}`))).toBe(false);
+
+    testApi.setFileLogAppenderForTests(async (options) => {
+      if (options.filePath === firstPath) {
+        await appendRegularFile(options);
+        return;
+      }
+      throw new Error("injected append failure");
+    });
+    setLoggerOverride({ level: "info", file: firstPath });
+    getLogger().info("tracked-file-recovery");
+    setLoggerOverride({ level: "info", file: lastPath });
+    getLogger().info("newly-tracked-failure");
+    await testApi.flushFileLogQueueForTests();
+
+    expect(stderrSpy.mock.calls.some(([line]) => String(line).includes(`file=${lastPath}`))).toBe(
+      true,
+    );
   });
 
   it("synchronously drains a crash-adjacent fatal record through the exit-hook seam", () => {

--- a/src/logging/logger-file-transport.ts
+++ b/src/logging/logger-file-transport.ts
@@ -10,6 +10,7 @@ import { formatTimestamp } from "./timestamps.js";
 // Keep burst memory bounded while one equally bounded batch is in flight.
 const DEFAULT_MAX_QUEUED_RECORDS = 4_096;
 const MAX_ROTATED_LOG_FILES = 5;
+// A failing path stays armed until recovery; cap retained paths so target churn cannot leak memory.
 const MAX_TRACKED_APPEND_FAILURE_FILES = 64;
 
 type FileLogQueueEntry = {
@@ -106,11 +107,13 @@ function buildDroppedMarker(target: FileLogQueueEntry, count: number): FileLogQu
   };
 }
 
-function writeFileTransportWarning(message: string): void {
+function writeFileTransportWarning(message: string): boolean {
   try {
     process.stderr.write(`${formatConsoleDiagnosticLine({ level: "warn", message })}\n`);
+    return true;
   } catch {
     // Logging diagnostics must not stop the file queue.
+    return false;
   }
 }
 
@@ -127,18 +130,21 @@ function warnAboutAppendFailure(entry: FileLogQueueEntry): void {
   if (warnedAppendFiles.has(entry.file)) {
     return;
   }
-  if (warnedAppendFiles.size >= MAX_TRACKED_APPEND_FAILURE_FILES) {
-    if (!appendFailureTrackingSaturated) {
-      appendFailureTrackingSaturated = true;
-      writeFileTransportWarning(
-        "[openclaw] log file append failure diagnostics saturated; suppressing new file targets",
-      );
-    }
+  const saturated = warnedAppendFiles.size >= MAX_TRACKED_APPEND_FAILURE_FILES;
+  if (saturated && appendFailureTrackingSaturated) {
     return;
   }
-  warnedAppendFiles.add(entry.file);
-  const message = `[openclaw] log file append failed; record dropped; continuing file=${entry.file}`;
-  writeFileTransportWarning(message);
+  const message = saturated
+    ? "[openclaw] log file append failure diagnostics saturated; suppressing new file targets"
+    : `[openclaw] log file append failed; record dropped; check that the path is a writable regular file; file=${entry.file}`;
+  if (!writeFileTransportWarning(message)) {
+    return;
+  }
+  if (saturated) {
+    appendFailureTrackingSaturated = true;
+  } else {
+    warnedAppendFiles.add(entry.file);
+  }
 }
 
 function clearAppendFailure(entry: FileLogQueueEntry): void {

--- a/src/logging/logger-file-transport.ts
+++ b/src/logging/logger-file-transport.ts
@@ -10,6 +10,7 @@ import { formatTimestamp } from "./timestamps.js";
 // Keep burst memory bounded while one equally bounded batch is in flight.
 const DEFAULT_MAX_QUEUED_RECORDS = 4_096;
 const MAX_ROTATED_LOG_FILES = 5;
+const MAX_TRACKED_APPEND_FAILURE_FILES = 64;
 
 type FileLogQueueEntry = {
   file: string;
@@ -39,7 +40,8 @@ let processExiting = false;
 let processHooksInstalled = false;
 let appendFile: FileLogAppender = appendRegularFile;
 const warnedRotationFiles = new Map<string, number>();
-let warnedAppendFile: string | null = null;
+const warnedAppendFiles = new Set<string>();
+let appendFailureTrackingSaturated = false;
 
 function rotatedLogPath(file: string, index: number): string {
   const ext = path.extname(file);
@@ -104,12 +106,7 @@ function buildDroppedMarker(target: FileLogQueueEntry, count: number): FileLogQu
   };
 }
 
-function warnAboutRotationFailure(entry: FileLogQueueEntry): void {
-  if (warnedRotationFiles.get(entry.file) === entry.maxFileBytes) {
-    return;
-  }
-  warnedRotationFiles.set(entry.file, entry.maxFileBytes);
-  const message = `[openclaw] log file rotation failed; continuing writes file=${entry.file} maxFileBytes=${entry.maxFileBytes}`;
+function writeFileTransportWarning(message: string): void {
   try {
     process.stderr.write(`${formatConsoleDiagnosticLine({ level: "warn", message })}\n`);
   } catch {
@@ -117,16 +114,36 @@ function warnAboutRotationFailure(entry: FileLogQueueEntry): void {
   }
 }
 
-function warnAboutAppendFailure(entry: FileLogQueueEntry): void {
-  if (warnedAppendFile === entry.file) {
+function warnAboutRotationFailure(entry: FileLogQueueEntry): void {
+  if (warnedRotationFiles.get(entry.file) === entry.maxFileBytes) {
     return;
   }
-  warnedAppendFile = entry.file;
+  warnedRotationFiles.set(entry.file, entry.maxFileBytes);
+  const message = `[openclaw] log file rotation failed; continuing writes file=${entry.file} maxFileBytes=${entry.maxFileBytes}`;
+  writeFileTransportWarning(message);
+}
+
+function warnAboutAppendFailure(entry: FileLogQueueEntry): void {
+  if (warnedAppendFiles.has(entry.file)) {
+    return;
+  }
+  if (warnedAppendFiles.size >= MAX_TRACKED_APPEND_FAILURE_FILES) {
+    if (!appendFailureTrackingSaturated) {
+      appendFailureTrackingSaturated = true;
+      writeFileTransportWarning(
+        "[openclaw] log file append failure diagnostics saturated; suppressing new file targets",
+      );
+    }
+    return;
+  }
+  warnedAppendFiles.add(entry.file);
   const message = `[openclaw] log file append failed; record dropped; continuing file=${entry.file}`;
-  try {
-    process.stderr.write(`${formatConsoleDiagnosticLine({ level: "warn", message })}\n`);
-  } catch {
-    // Logging diagnostics must not stop the file queue.
+  writeFileTransportWarning(message);
+}
+
+function clearAppendFailure(entry: FileLogQueueEntry): void {
+  if (warnedAppendFiles.delete(entry.file)) {
+    appendFailureTrackingSaturated = false;
   }
 }
 
@@ -181,9 +198,7 @@ async function writeEntries(entries: FileLogQueueEntry[], generation: number): P
     try {
       await appendFile({ filePath: entry.file, content: entry.payload });
       cursor.bytes += payloadBytes;
-      if (warnedAppendFile === entry.file) {
-        warnedAppendFile = null;
-      }
+      clearAppendFailure(entry);
     } catch {
       // Match the old best-effort transport: a failed append must not stop later records.
       warnAboutAppendFailure(entry);
@@ -213,9 +228,7 @@ function writeEntriesSync(entries: FileLogQueueEntry[]): void {
     try {
       appendRegularFileSync({ filePath: entry.file, content: entry.payload });
       cursor.bytes += payloadBytes;
-      if (warnedAppendFile === entry.file) {
-        warnedAppendFile = null;
-      }
+      clearAppendFailure(entry);
     } catch {
       // Match the old best-effort transport: a failed append must not stop later records.
       warnAboutAppendFailure(entry);
@@ -376,7 +389,8 @@ function resetFileLogTransportForTests(): void {
   appendFile = appendRegularFile;
   maxQueuedRecords = DEFAULT_MAX_QUEUED_RECORDS;
   warnedRotationFiles.clear();
-  warnedAppendFile = null;
+  warnedAppendFiles.clear();
+  appendFailureTrackingSaturated = false;
 }
 
 export const fileLogTransport = {

--- a/src/logging/logger-file-transport.ts
+++ b/src/logging/logger-file-transport.ts
@@ -107,12 +107,15 @@ function buildDroppedMarker(target: FileLogQueueEntry, count: number): FileLogQu
   };
 }
 
-function writeFileTransportWarning(message: string): boolean {
+function writeFileTransportWarning(message: string, synchronous: boolean): boolean {
   try {
     const redactedMessage = redactSensitiveText(message);
-    process.stderr.write(
-      `${formatConsoleDiagnosticLine({ level: "warn", message: redactedMessage })}\n`,
-    );
+    const line = `${formatConsoleDiagnosticLine({ level: "warn", message: redactedMessage })}\n`;
+    if (synchronous) {
+      fs.writeSync(process.stderr.fd, line);
+    } else {
+      process.stderr.write(line);
+    }
     return true;
   } catch {
     // Logging diagnostics must not stop the file queue.
@@ -120,16 +123,16 @@ function writeFileTransportWarning(message: string): boolean {
   }
 }
 
-function warnAboutRotationFailure(entry: FileLogQueueEntry): void {
+function warnAboutRotationFailure(entry: FileLogQueueEntry, synchronous: boolean): void {
   if (warnedRotationFiles.get(entry.file) === entry.maxFileBytes) {
     return;
   }
   warnedRotationFiles.set(entry.file, entry.maxFileBytes);
   const message = `[openclaw] log file rotation failed; continuing writes file=${entry.file} maxFileBytes=${entry.maxFileBytes}`;
-  writeFileTransportWarning(message);
+  writeFileTransportWarning(message, synchronous);
 }
 
-function warnAboutAppendFailure(entry: FileLogQueueEntry): void {
+function warnAboutAppendFailure(entry: FileLogQueueEntry, synchronous: boolean): void {
   if (warnedAppendFiles.has(entry.file)) {
     return;
   }
@@ -140,7 +143,7 @@ function warnAboutAppendFailure(entry: FileLogQueueEntry): void {
   const message = saturated
     ? "[openclaw] log file append failure diagnostics saturated; suppressing new file targets"
     : `[openclaw] log file append failed; record dropped; check that the path is a writable regular file; file=${entry.file}`;
-  if (!writeFileTransportWarning(message)) {
+  if (!writeFileTransportWarning(message, synchronous)) {
     return;
   }
   if (saturated) {
@@ -169,7 +172,7 @@ function claimQueuedEntries(): FileLogQueueEntry[] {
   return entries;
 }
 
-function rotateIfNeeded(entry: FileLogQueueEntry, cursor: FileCursor): void {
+function rotateIfNeeded(entry: FileLogQueueEntry, cursor: FileCursor, synchronous: boolean): void {
   const payloadBytes = Buffer.byteLength(entry.payload, "utf8");
   if (cursor.bytes === 0 || cursor.bytes + payloadBytes <= entry.maxFileBytes) {
     return;
@@ -178,7 +181,7 @@ function rotateIfNeeded(entry: FileLogQueueEntry, cursor: FileCursor): void {
     cursor.bytes = 0;
     warnedRotationFiles.delete(entry.file);
   } else {
-    warnAboutRotationFailure(entry);
+    warnAboutRotationFailure(entry, synchronous);
   }
 }
 
@@ -201,7 +204,7 @@ async function writeEntries(entries: FileLogQueueEntry[], generation: number): P
       }
       cursors.set(entry.file, cursor);
     }
-    rotateIfNeeded(entry, cursor);
+    rotateIfNeeded(entry, cursor, false);
     const payloadBytes = Buffer.byteLength(entry.payload, "utf8");
     activeAppendInFlight = true;
     try {
@@ -210,7 +213,7 @@ async function writeEntries(entries: FileLogQueueEntry[], generation: number): P
       clearAppendFailure(entry);
     } catch {
       // Match the old best-effort transport: a failed append must not stop later records.
-      warnAboutAppendFailure(entry);
+      warnAboutAppendFailure(entry, false);
     } finally {
       activeAppendInFlight = false;
     }
@@ -232,7 +235,7 @@ function writeEntriesSync(entries: FileLogQueueEntry[]): void {
       cursor = { bytes: getCurrentLogFileBytesSync(entry.file) };
       cursors.set(entry.file, cursor);
     }
-    rotateIfNeeded(entry, cursor);
+    rotateIfNeeded(entry, cursor, true);
     const payloadBytes = Buffer.byteLength(entry.payload, "utf8");
     try {
       appendRegularFileSync({ filePath: entry.file, content: entry.payload });
@@ -240,7 +243,7 @@ function writeEntriesSync(entries: FileLogQueueEntry[]): void {
       clearAppendFailure(entry);
     } catch {
       // Match the old best-effort transport: a failed append must not stop later records.
-      warnAboutAppendFailure(entry);
+      warnAboutAppendFailure(entry, true);
     }
     index += 1;
   }

--- a/src/logging/logger-file-transport.ts
+++ b/src/logging/logger-file-transport.ts
@@ -39,6 +39,7 @@ let processExiting = false;
 let processHooksInstalled = false;
 let appendFile: FileLogAppender = appendRegularFile;
 const warnedRotationFiles = new Map<string, number>();
+let warnedAppendFile: string | null = null;
 
 function rotatedLogPath(file: string, index: number): string {
   const ext = path.extname(file);
@@ -116,6 +117,19 @@ function warnAboutRotationFailure(entry: FileLogQueueEntry): void {
   }
 }
 
+function warnAboutAppendFailure(entry: FileLogQueueEntry): void {
+  if (warnedAppendFile === entry.file) {
+    return;
+  }
+  warnedAppendFile = entry.file;
+  const message = `[openclaw] log file append failed; record dropped; continuing file=${entry.file}`;
+  try {
+    process.stderr.write(`${formatConsoleDiagnosticLine({ level: "warn", message })}\n`);
+  } catch {
+    // Logging diagnostics must not stop the file queue.
+  }
+}
+
 function claimQueuedEntries(): FileLogQueueEntry[] {
   const entries =
     queueStart === 0 ? queue : [...queue.slice(queueStart), ...queue.slice(0, queueStart)];
@@ -167,8 +181,12 @@ async function writeEntries(entries: FileLogQueueEntry[], generation: number): P
     try {
       await appendFile({ filePath: entry.file, content: entry.payload });
       cursor.bytes += payloadBytes;
+      if (warnedAppendFile === entry.file) {
+        warnedAppendFile = null;
+      }
     } catch {
       // Match the old best-effort transport: a failed append must not stop later records.
+      warnAboutAppendFailure(entry);
     } finally {
       activeAppendInFlight = false;
     }
@@ -195,8 +213,12 @@ function writeEntriesSync(entries: FileLogQueueEntry[]): void {
     try {
       appendRegularFileSync({ filePath: entry.file, content: entry.payload });
       cursor.bytes += payloadBytes;
+      if (warnedAppendFile === entry.file) {
+        warnedAppendFile = null;
+      }
     } catch {
       // Match the old best-effort transport: a failed append must not stop later records.
+      warnAboutAppendFailure(entry);
     }
     index += 1;
   }
@@ -354,6 +376,7 @@ function resetFileLogTransportForTests(): void {
   appendFile = appendRegularFile;
   maxQueuedRecords = DEFAULT_MAX_QUEUED_RECORDS;
   warnedRotationFiles.clear();
+  warnedAppendFile = null;
 }
 
 export const fileLogTransport = {

--- a/src/logging/logger-file-transport.ts
+++ b/src/logging/logger-file-transport.ts
@@ -109,7 +109,10 @@ function buildDroppedMarker(target: FileLogQueueEntry, count: number): FileLogQu
 
 function writeFileTransportWarning(message: string): boolean {
   try {
-    process.stderr.write(`${formatConsoleDiagnosticLine({ level: "warn", message })}\n`);
+    const redactedMessage = redactSensitiveText(message);
+    process.stderr.write(
+      `${formatConsoleDiagnosticLine({ level: "warn", message: redactedMessage })}\n`,
+    );
     return true;
   } catch {
     // Logging diagnostics must not stop the file queue.


### PR DESCRIPTION
## What Problem This Solves

File-log append failures dropped records while `flushLogger()` still resolved. Operators received no warning that the configured log was incomplete.

This PR is AI-assisted. The implementation and proof were reviewed by maintainers.

## Root Cause

The file transport caught and discarded errors from both the asynchronous appender and the forced-exit synchronous appender. Only this transport can observe whether the real append succeeded.

## Fix

The file transport now writes a direct stderr warning for the first dropped record in each file's continuous failure streak. It clears only that file's warning state after a successful append. It also bounds retained failure paths and emits one saturation warning when the bound is reached. Forced-exit drains use a synchronous stderr write so piped diagnostics survive `process.exit()`.

The direct stderr sink avoids `console.warn()` recursion into the same failed file transport. If stderr itself throws, the transport continues and retries the warning after the next dropped record. The warning tells the operator to check that the target is a writable regular file.

Queue ordering, retry policy, flush settlement, and process-exit rescue behavior are unchanged.

## Production Shape

- Owner: `src/logging/logger-file-transport.ts`.
- Modes: append success persists and rearms that file; first failure warns; repeated same-streak failures use the prior warning; another file has independent state; saturation is bounded.
- Production delta: +58/-9, net +49.
- Test delta: +138/-6, net +132.
- The positive production delta is the bounded per-file owner state and the shared non-recursive warning sink used by both append paths.

## Evidence

The same production entry was run with a real directory as the invalid log target and a real file as the control target.

Exact current main `c5c6199bc8592c988738480164a2950b920f6b39`:

```json
{"failedTargetType":"directory","failedRecordPersisted":false,"flushResolved":true,"appendFailureDiagnostic":false,"warningCount":0,"controlPersisted":true}
```

Exact repaired head `2a69e5853dffc46c7642fd8c10ffa73fc4094ebf`:

```json
{"failedTargetType":"directory","failedRecordPersisted":false,"flushResolved":true,"appendFailureDiagnostic":true,"warningCount":1,"pathSecretRedacted":true,"controlPersisted":true}
```

Observed warning:

```text
[openclaw] log file append failed; record dropped; check that the path is a writable regular file
```

Exact repaired-head forced-exit trace with piped stderr and a deferred stream write:

```json
{"sha":"2a69e5853dffc46c7642fd8c10ffa73fc4094ebf","exitStatus":0,"stderrPiped":true,"streamWriteDeferredPastExit":true,"appendFailureDiagnostic":true,"pathSecretRedacted":true,"warningCount":1}
```

## Validation

- Final warning regressions on exact current-main production: 5 expected failures because no warning was emitted.
- Piped-exit regression on the prior asynchronous-warning head: 1 expected failure because stderr was empty.
- Logger owner and sibling tests: 46 passed.
- `oxfmt --check` and type-aware `oxlint`: passed.
- `git diff --check`: passed.

## Integration Checks

- Current main and the pre-rebase main have identical file-transport and logger owner blobs.
- The branch was rebased after current main repaired an unrelated missing export.
- `@openclaw/fs-safe` 0.5.6 propagates non-file and append errors to the transport catch.
- No equivalent open repair was found.
- The prior ClawSweeper request for current-main and dependency-source evidence is satisfied above.

## ClawSweeper

- Exact-head review: patch correct, zero findings, security cleared, zero rank-up moves.
- Production growth decision: accept net +49 lines. The file transport needs bounded per-target state, one redacted non-recursive sink, and synchronous exit output. Removing any part restores silent loss, unbounded retention, recursion, or dropped exit diagnostics.
