### PR TITLE
fix(maintainers): avoid waiting past validated hosted CI

### DIFF
--- a/docs/ci.md
+++ b/docs/ci.md
@@ -136,10 +136,25 @@ only to checks that still have the verified name and queued state. Active
 retries, unrelated checks, and ambiguous or incomplete evidence still block
 completion. This is an observation of CI state, not atomic merge authorization.
 
-`--completion ci-run` waits only for the attached CI workflow. Callers must
-separately verify required checks; CI success does not override another
-required check. The native `scripts/pr` merge flow uses this mode and then
-performs its own required-check verification before merging.
+Both watcher modes attach only to `pull_request` CI runs. `--completion ci-run`
+waits only for that attached workflow. Callers must separately verify required
+checks; CI success does not override another required check.
+
+The native `scripts/pr` merge flow reloads the saved prepare gate mode. Hosted
+mode (`OPENCLAW_TESTBOX=1` during prepare) revalidates the prepared head through
+the same hosted verifier used by prepare, including its 24-hour freshness,
+workflow identity, attempt binding, and existing patch-identical reuse rules.
+Accepted hosted proof proceeds directly
+to required-check verification without waiting on older PR CI. Local and Crabbox
+gate modes retain the `--completion ci-run` wait.
+
+Missing prepare artifacts or rejected hosted evidence stop merge verification;
+a saved mode or JSON report is not proof. Inspect `.local/gates-hosted-checks.log`,
+resolve the reported failure, and rerun prepare when its artifacts need refreshing.
+For missing CI, follow the verifier's `scripts/pr ci-dispatch <pr-number>` recovery
+guidance when available. Malformed required-check evidence and cancelled required
+checks also stop verification. Server-enforced publisher binding and the final
+pinned-head merge request remain intact. Hosted mode adds no bypass.
 
 ## PR context and evidence
 

--- a/scripts/pr-lib/gates.sh
+++ b/scripts/pr-lib/gates.sh
@@ -25,7 +25,7 @@ run_hosted_prepare_gates() {
   fi
 
   local repo
-  repo=$(gh repo view --json nameWithOwner --jq .nameWithOwner)
+  repo=$(gh repo view --json nameWithOwner --jq .nameWithOwner) || return 1
   local scripts_dir="${script_parent_dir:-}"
   if [ -z "$scripts_dir" ]; then
     scripts_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
@@ -319,7 +319,7 @@ write_gates_env_stamp() {
 }
 
 derive_prepare_gate_change_plan() {
-  PREPARE_GATE_CHANGED_FILES=$(git diff --name-only "$PR_MAIN_SHA...HEAD")
+  PREPARE_GATE_CHANGED_FILES=$(git diff --name-only "$PR_MAIN_SHA...${1:-HEAD}") || return 1
   PREPARE_GATE_DOCS_ONLY=false
   if file_list_is_docsish_only "$PREPARE_GATE_CHANGED_FILES"; then
     PREPARE_GATE_DOCS_ONLY=true

--- a/scripts/pr-lib/merge.sh
+++ b/scripts/pr-lib/merge.sh
@@ -158,10 +158,13 @@ merge_verify() {
   MERGE_USE_CRABBOX_ADMIN_BYPASS=false
   enter_worktree "$pr" false || return 1
 
-  require_artifact .local/prep.env
+  require_artifact .local/prep.env || return 1
+  require_artifact .local/gates.env || return 1
   # shellcheck disable=SC1091
-  source .local/prep.env
-  verify_prep_branch_matches_prepared_head "$pr" "${LOCAL_PREP_HEAD_SHA:-$PREP_HEAD_SHA}"
+  source .local/gates.env || return 1
+  # shellcheck disable=SC1091
+  source .local/prep.env || return 1
+  verify_prep_branch_matches_prepared_head "$pr" "${LOCAL_PREP_HEAD_SHA:-$PREP_HEAD_SHA}" || return 1
 
   local json
   json=$(gh_plain pr view "$pr" --json state,isDraft,headRefOid) || return 1
@@ -190,11 +193,18 @@ merge_verify() {
     exit 1
   fi
 
-  mark_pr_operation_side_effects_started
-  # Wait only for the attached CI workflow here. The direct required-check
-  # query below remains the merge authority, so optional contexts cannot stall it.
-  node "$script_parent_dir/watch-pr-ci.mjs" "$pr" "$PREP_HEAD_SHA" \
-    --completion ci-run >.local/merge-checks-watch.log 2>&1 || true
+  mark_pr_operation_side_effects_started || return 1
+  if [ "${GATES_MODE:-}" = "hosted_exact_or_recent_parent" ]; then
+    # The stamp selects the owner, not proof. Revalidate before skipping the
+    # PR-only watcher, which cannot observe accepted hosted release gates.
+    derive_prepare_gate_change_plan "$PREP_HEAD_SHA" || return 1
+    run_hosted_prepare_gates "$pr" "$PREP_HEAD_SHA" "$PREPARE_GATE_CHANGELOG_ONLY" || return 1
+  else
+    # Local/Crabbox preparation retains the attached-CI wait. Required checks
+    # below remain merge authority; optional contexts cannot stall this path.
+    node "$script_parent_dir/watch-pr-ci.mjs" "$pr" "$PREP_HEAD_SHA" \
+      --completion ci-run >.local/merge-checks-watch.log 2>&1 || true
+  fi
   local checks_json
   local checks_err_file
   local checks_exit_status
@@ -223,21 +233,26 @@ merge_verify() {
     esac
   fi
   rm -f "$checks_err_file"
-  if ! printf '%s\n' "$checks_json" | jq -e 'type == "array"' >/dev/null; then
+  # merge_run calls this function in an OR-list, disabling Bash errexit.
+  # Validate every row so malformed evidence cannot fall through as green.
+  if ! printf '%s\n' "$checks_json" | jq -e '
+    type == "array" and all(.[]; type == "object" and
+      (.bucket | IN("pass", "fail", "pending", "skipping", "cancel")))
+  ' >/dev/null; then
     echo "Merge verify failed: GitHub returned invalid required-check evidence." >&2
     return 1
   fi
   local required_count
-  required_count=$(printf '%s\n' "$checks_json" | jq 'length')
+  required_count=$(printf '%s\n' "$checks_json" | jq 'length') || return 1
   if [ "$required_count" -eq 0 ]; then
     echo "No required checks configured for this PR."
   fi
-  printf '%s\n' "$checks_json" | jq -r '.[] | "\(.bucket)\t\(.name)\t\(.state)"'
+  printf '%s\n' "$checks_json" | jq -r '.[] | "\(.bucket)\t\(.name)\t\(.state)"' || return 1
 
   local failed_required
-  failed_required=$(printf '%s\n' "$checks_json" | jq '[.[] | select(.bucket=="fail" or .bucket=="skipping")] | length')
+  failed_required=$(printf '%s\n' "$checks_json" | jq '[.[] | select(.bucket!="pass" and .bucket!="pending")] | length') || return 1
   local pending_required
-  pending_required=$(printf '%s\n' "$checks_json" | jq '[.[] | select(.bucket=="pending")] | length')
+  pending_required=$(printf '%s\n' "$checks_json" | jq '[.[] | select(.bucket=="pending")] | length') || return 1
 
   if [ "$pending_required" -gt 0 ]; then
     echo "Required checks are still pending."
@@ -255,7 +270,7 @@ merge_verify() {
   fi
 
   refresh_main_snapshot || return 1
-  git fetch origin "pull/$pr/head:pr-$pr" --force
+  git fetch origin "pull/$pr/head:pr-$pr" --force || return 1
   if ! git merge-base --is-ancestor "$PR_MAIN_SHA" "refs/heads/pr-$pr"; then
     echo "PR branch is behind main."
     if mainline_drift_requires_sync \
@@ -377,7 +392,7 @@ merge_run() {
 
   validate_review_artifact_data || return 1
   require_ready_review_recommendation || return 1
-  merge_verify "$pr"
+  merge_verify "$pr" || return 1
   # shellcheck disable=SC1091
   source .local/prep.env
 

--- a/test/scripts/pr-main-refresh.test-support.ts
+++ b/test/scripts/pr-main-refresh.test-support.ts
@@ -15,7 +15,7 @@ function shellQuote(value: string): string {
 }
 
 // Keep the complete wrapper/lock/entry/gate owners. Command resolution, Git
-// transport faults, and GitHub responses are synthetic; rg invocation is forbidden.
+// transport faults, and GitHub responses are synthetic.
 export function createMainRefreshFixture(directory: string) {
   const root = realpathSync(directory);
   const canonical = join(root, "canonical");
@@ -197,6 +197,18 @@ export function createMainRefreshFixture(directory: string) {
     moveAtCi: false,
     moveSharedAfterFetch: false,
     remoteOnlyBase: "",
+    hostedCi: "scheduled" as
+      | "scheduled"
+      | "release"
+      | "missing"
+      | "stale"
+      | "failed"
+      | "wrong-head"
+      | "unmarked"
+      | "wrong-workflow"
+      | "scheduled-failure"
+      | "api-error",
+    requiredChecks: "pass" as "pass" | "fail" | "pending" | "api-error",
   };
   writeFileSync(controlFile, JSON.stringify(control));
   writeFileSync(eventsFile, "");
@@ -318,7 +330,15 @@ if (args[0] === 'pr' && args[1] === 'view') {
     runGit(['-C', origin, 'update-ref', 'refs/heads/main', movedMain]);
   }
   event({ kind: 'required-checks' });
-  value = [{ name: 'synthetic CI', bucket: 'pass', state: 'SUCCESS' }];
+  if (control.requiredChecks === 'api-error') {
+    console.error('GitHub API unavailable');
+    process.exit(1);
+  }
+  value = [{ name: 'openclaw/ci-gate', bucket: 'pass', state: 'SUCCESS' }];
+  if (control.requiredChecks !== 'pass') value.push({
+    name: 'independent required check', bucket: control.requiredChecks,
+    state: control.requiredChecks === 'pending' ? 'IN_PROGRESS' : 'FAILURE',
+  });
 } else if (args[0] === 'repo' && args[1] === 'view') {
   value = { id: 'fixture-repo', nameWithOwner: 'fixture/repo', url: 'https://github.com/fixture/repo' };
 } else if (args[0] === 'run' && args[1] === 'view') {
@@ -326,7 +346,11 @@ if (args[0] === 'pr' && args[1] === 'view') {
     runGit(['-C', origin, 'update-ref', 'refs/heads/main', movedMain]);
   }
   event({ kind: 'ci-completed' });
-  value = { status: 'completed', conclusion: 'success' };
+  value = control.hostedCi === 'scheduled'
+    ? { status: 'completed', conclusion: 'success' }
+    : { status: 'in_progress', conclusion: null };
+} else if (args[0] === 'run' && args[1] === 'list') {
+  value = [];
 } else if (args[0] === 'api') {
   const endpoint = args.find((arg, index) => index > 0 &&
     (arg === 'graphql' || arg === 'users/fixture' || arg.startsWith('repos/')));
@@ -360,12 +384,21 @@ if (args[0] === 'pr' && args[1] === 'view') {
       base: { sha: baseSha },
     };
   } else if (endpoint.endsWith('/actions/workflows/ci.yml/runs')) {
-    value = { workflow_runs: [{ id: 1, conclusion: 'success' }] };
+    event({ kind: 'ci-watched' });
+    value = { workflow_runs: [{ id: 1, conclusion: null }] };
+  } else if (endpoint.includes('/actions/runs/1/attempts/1/jobs?')) {
+    value = { total_count: 2, jobs: ['macos-node', 'macos-swift'].map(name => ({
+      name, run_id: 1, run_attempt: 1, status: 'queued', conclusion: null,
+      runner_id: null, steps: [],
+    })) };
+  } else if (endpoint === 'repos/fixture/repo/actions/runs/1') {
+    value = { run_attempt: 1, status: 'in_progress', conclusion: null };
   } else if (/^repos\\/(fixture\\/repo|openclaw\\/openclaw)\\/actions\\/runs\\?/.test(endpoint)) {
     if (control.moveAtGate) {
       runGit(['-C', origin, 'update-ref', 'refs/heads/main', ${JSON.stringify(gateMain)}]);
     }
     event({ kind: 'hosted-gate' });
+    if (control.hostedCi === 'api-error') throw new Error('Hosted API unavailable');
     const workflows = [
       'CI', 'Blacksmith Testbox', 'Blacksmith ARM Testbox',
       'Blacksmith Build Artifacts Testbox', 'Workflow Sanity',
@@ -383,6 +416,22 @@ if (args[0] === 'pr' && args[1] === 'view') {
         created_at: new Date().toISOString(),
       })),
     };
+    if (control.hostedCi !== 'scheduled') {
+      Object.assign(value.workflow_runs[0], {
+        status: control.hostedCi === 'scheduled-failure' ? 'completed' : 'in_progress',
+        conclusion: control.hostedCi === 'scheduled-failure' ? 'failure' : null,
+      });
+      if (control.hostedCi !== 'missing') value.workflow_runs.push({
+        id: 6, run_number: 6, name: 'CI', event: 'workflow_dispatch',
+        head_sha: control.hostedCi === 'wrong-head' ? ${JSON.stringify(main)} : control.metadata.headRefOid,
+        path: control.hostedCi === 'wrong-workflow' ? '.github/workflows/other.yml' : '.github/workflows/ci.yml',
+        display_title: control.hostedCi === 'unmarked' ? 'CI' : 'CI release gate ' + control.metadata.headRefOid,
+        status: 'completed', conclusion: control.hostedCi === 'failed' ? 'failure' : 'success',
+        updated_at: new Date(Date.now() - (control.hostedCi === 'stale' ? 25 * 3600_000 : 0)).toISOString(),
+        created_at: new Date().toISOString(),
+      });
+      value.total_count = value.workflow_runs.length;
+    }
   } else {
     throw new Error('Unexpected GitHub API endpoint ' + endpoint);
   }
@@ -404,8 +453,7 @@ console.log(JSON.stringify(value));
   writeFileSync(
     join(bin, "rg"),
     `#!/bin/sh
-echo "unexpected rg invocation in main-refresh fixture" >&2
-exit 99
+exec grep "$@"
 `,
   );
   for (const command of ["git", "gh", "rg"]) {
@@ -414,6 +462,23 @@ exit 99
   env.PATH = `${bin}${delimiter}${env.PATH ?? ""}`;
   env.OPENCLAW_GH_BIN = join(bin, "gh");
   env.OPENCLAW_TESTBOX = "1";
+  // Advance only the real watcher's polling clock, so a stuck CI fixture
+  // reaches its normal deadline without an hour-long regression test.
+  const clock = join(root, "watch-clock.mjs");
+  writeFileSync(
+    clock,
+    `
+import { syncBuiltinESMExports } from 'node:module';
+import timers from 'node:timers/promises';
+if (process.argv[1]?.endsWith('/watch-pr-ci.mts')) {
+  const realNow = Date.now;
+  let waited = 0;
+  Date.now = () => realNow() + waited;
+  timers.setTimeout = async milliseconds => { waited += milliseconds; };
+  syncBuiltinESMExports();
+}
+`,
+  );
   return {
     root,
     canonical,
@@ -430,6 +495,8 @@ exit 99
     metadata,
     configure(update: Partial<typeof control>) {
       Object.assign(control, update);
+      if (control.hostedCi === "scheduled") delete env.NODE_OPTIONS;
+      else env.NODE_OPTIONS = `--import=${clock}`;
       writeFileSync(controlFile, JSON.stringify(control));
     },
     events() {

--- a/test/scripts/pr-main-refresh.test.ts
+++ b/test/scripts/pr-main-refresh.test.ts
@@ -473,6 +473,8 @@ read -r release < "$OPENCLAW_TEST_FETCH_HOLD"
       const f = fixture();
       const prepare = f.run("prepare-run");
       expect(prepare.status, prepare.stdout + prepare.stderr).toBe(0);
+      // This case owns the nonhosted watcher's post-wait refresh contract.
+      writeFileSync(join(f.local, "gates.env"), "GATES_MODE=full\n");
       f.configure({ moveAtCi: true });
       if (strict) f.env.OPENCLAW_PR_STRICT_DRIFT = "1";
       const before = f.events().length;

--- a/test/scripts/pr-merge-hosted.test.ts
+++ b/test/scripts/pr-merge-hosted.test.ts
@@ -1,0 +1,180 @@
+import { existsSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
+import { createMainRefreshFixture } from "./pr-main-refresh.test-support.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterAll);
+const describePosix = process.platform === "win32" ? describe.skip : describe;
+
+describePosix("native hosted merge handoff", () => {
+  let f: ReturnType<typeof createMainRefreshFixture>;
+  let preparedGates: string;
+
+  beforeAll(() => {
+    f = createMainRefreshFixture(tempDirs.make("openclaw-pr-merge-hosted-"));
+    f.configure({ hostedCi: "release" });
+    const prepare = f.run("prepare-run");
+    expect(prepare.status, prepare.stdout + prepare.stderr).toBe(0);
+    preparedGates = readFileSync(join(f.local, "gates.env"), "utf8");
+    expect(
+      JSON.parse(readFileSync(join(f.local, "gates-hosted-checks.json"), "utf8")),
+    ).toMatchObject({
+      headSha: f.head,
+      workflows: expect.arrayContaining([
+        expect.objectContaining({ id: 6, event: "workflow_dispatch", headSha: f.head }),
+      ]),
+    });
+    delete f.env.OPENCLAW_TESTBOX;
+    // A changelog-only checkout must not narrow the prepared source change's
+    // gates, nor may a PR-controlled helper replace the canonical verifier.
+    f.git(f.worktree, "checkout", "--detach", f.main);
+    writeFileSync(join(f.worktree, "CHANGELOG.md"), "Unrelated changelog-only checkout.\n");
+    f.git(f.worktree, "add", "CHANGELOG.md");
+    f.git(f.worktree, "commit", "-qm", "docs: unrelated changelog-only checkout");
+    writeFileSync(
+      join(f.worktree, "scripts/verify-pr-hosted-gates.mjs"),
+      "throw new Error('PR helper executed');\n",
+    );
+  });
+
+  beforeEach(() => {
+    // Reuse one successful preparation. Rejections must not dispatch or damage
+    // that state; the final case alone completes the synthetic server merge.
+    f.configure({ hostedCi: "release", requiredChecks: "pass" });
+    writeFileSync(join(f.local, "gates.env"), preparedGates);
+  });
+
+  it("revalidates prepared release-gate evidence without waiting for older stuck PR CI", () => {
+    const before = f.events().length;
+    const result = f.run("merge-verify");
+    expect(result.status, result.stdout + result.stderr).toBe(0);
+    const watchLog = join(f.local, "merge-checks-watch.log");
+    expect(existsSync(watchLog) ? readFileSync(watchLog, "utf8") : "").toBe("");
+    const events = f.events().slice(before);
+    const hosted = events.findIndex((event) => event.kind === "hosted-gate");
+    expect(hosted).toBeGreaterThanOrEqual(0);
+    expect(events.findIndex((event) => event.kind === "required-checks")).toBeGreaterThan(hosted);
+    expect(events.some((event) => event.kind === "ci-watched")).toBe(false);
+  });
+
+  it.each([
+    "missing",
+    "stale",
+    "failed",
+    "wrong-head",
+    "unmarked",
+    "wrong-workflow",
+    "scheduled-failure",
+    "api-error",
+  ] as const)(
+    "blocks %s hosted evidence despite saved green proof in an OR-list caller",
+    (hostedCi) => {
+      f.configure({ hostedCi });
+      const savedProof = readFileSync(join(f.local, "gates-hosted-checks.json"), "utf8");
+      const before = f.events().length;
+      const result = f.shell("merge_run 42 || exit 1");
+      const output = result.stdout + result.stderr;
+      expect(result.status, output).toBe(1);
+      expect(output).toContain("hosted CI/Testbox gates failed");
+      expect(readFileSync(join(f.local, "gates-hosted-checks.log"), "utf8")).toContain(
+        hostedCi === "api-error"
+          ? "Hosted API unavailable"
+          : "Missing successful recent CI workflow",
+      );
+      expect(
+        f
+          .events()
+          .slice(before)
+          .some((event) => event.kind === "required-checks" || event.kind === "ci-watched"),
+      ).toBe(false);
+      expect(readFileSync(join(f.local, "gates-hosted-checks.json"), "utf8")).toBe(savedProof);
+      expect(existsSync(join(f.local, "merge-output.log"))).toBe(false);
+      expect(
+        f.git(
+          f.canonical,
+          "for-each-ref",
+          "--format=%(refname)",
+          "refs/openclaw/pr-merge-outcomes/42",
+        ),
+      ).toBe("");
+    },
+  );
+
+  it("requires the prepare gate artifact before merge", () => {
+    rmSync(join(f.local, "gates.env"));
+    const result = f.shell("merge_run 42 || exit 1");
+    expect(result.status, result.stdout + result.stderr).toBe(1);
+    expect(result.stdout).toContain("Missing required artifact: .local/gates.env");
+    expect(existsSync(join(f.local, "merge-output.log"))).toBe(false);
+  });
+
+  it.each(["fail", "pending", "api-error"] as const)(
+    "keeps %s required checks blocking after hosted proof",
+    (requiredChecks) => {
+      f.configure({ requiredChecks });
+      const before = f.events().length;
+      const result = f.shell("merge_run 42 || exit 1");
+      const output = result.stdout + result.stderr;
+      expect(result.status, output).toBe(1);
+      expect(output).toContain(
+        requiredChecks === "api-error"
+          ? "unable to verify the required GitHub checks"
+          : requiredChecks === "pending"
+            ? "Required checks are still pending"
+            : "Required checks are failing",
+      );
+      const events = f.events().slice(before);
+      expect(events.findIndex((event) => event.kind === "required-checks")).toBeGreaterThan(
+        events.findIndex((event) => event.kind === "hosted-gate"),
+      );
+      expect(events.some((event) => event.kind === "ci-watched")).toBe(false);
+      expect(existsSync(join(f.local, "merge-output.log"))).toBe(false);
+    },
+  );
+
+  it.each(["full", "remote_testbox", "remote_crabbox_aws"])(
+    "retains the PR CI wait for %s preparation",
+    (mode) => {
+      f.configure({ hostedCi: "scheduled" });
+      writeFileSync(
+        join(f.local, "gates.env"),
+        preparedGates.replace("hosted_exact_or_recent_parent", mode),
+      );
+      const before = f.events().length;
+      const result = f.shell("merge_verify 42 || exit 1");
+      expect(result.status, result.stdout + result.stderr).toBe(0);
+      const events = f.events().slice(before);
+      const watched = events.findIndex((event) => event.kind === "ci-watched");
+      expect(watched).toBeGreaterThanOrEqual(0);
+      expect(events.findIndex((event) => event.kind === "required-checks")).toBeGreaterThan(
+        watched,
+      );
+      expect(events.some((event) => event.kind === "hosted-gate")).toBe(false);
+    },
+  );
+
+  it("dispatches once with the exact prepared head and ordinary server enforcement", () => {
+    const result = f.run("merge-run");
+    expect(result.status, result.stdout + result.stderr).toBe(0);
+    const mergeCalls = f
+      .events()
+      .filter(
+        (event) => event.kind === "gh" && event.args?.[0] === "pr" && event.args[1] === "merge",
+      );
+    expect(mergeCalls).toHaveLength(1);
+    expect(mergeCalls[0]?.args).toEqual([
+      "pr",
+      "merge",
+      "42",
+      "--repo",
+      "https://github.com/fixture/repo",
+      "--squash",
+      "--match-head-commit",
+      f.head,
+    ]);
+    expect(
+      JSON.parse(f.git(f.canonical, "show", "refs/openclaw/pr-merge-outcomes/42:outcome.json")),
+    ).toMatchObject({ head: f.head, route: "immediate", phase: "complete" });
+  });
+});

--- a/test/scripts/pr-merge-outcome.test.ts
+++ b/test/scripts/pr-merge-outcome.test.ts
@@ -63,6 +63,7 @@ function fixture(sourceMessage?: string, sourceVersions: Array<[string, string?]
     join(worktree, ".local/prep.env"),
     `PREP_HEAD_SHA=${head}\nLOCAL_PREP_HEAD_SHA=${head}\nPREP_MAINLINE_BASE_SHA=${base}\n`,
   );
+  writeFileSync(join(worktree, ".local/gates.env"), "GATES_MODE=full\n");
   for (const name of ["review.md", "review.json", "pr-meta.env", "pr-meta.json", "prep.md"]) {
     writeFileSync(join(worktree, ".local", name), "fixture\n");
   }

--- a/test/scripts/pr-review-artifact-validation.test.ts
+++ b/test/scripts/pr-review-artifact-validation.test.ts
@@ -114,21 +114,25 @@ function runArtifactsInit(existing: { review?: unknown; markdown?: string } = {}
   return { result, localDir };
 }
 
-function runMergeVerification(checks: "api-error" | "invalid-json" | "no-required" | "pending") {
+function runMergeVerification(
+  checks: "api-error" | "invalid-json" | "invalid-row" | "no-required" | "pending" | "cancelled",
+) {
   const fixtureRoot = tempDirs.make("openclaw-pr-merge-verification-");
   const localDir = join(fixtureRoot, ".local");
   const head = "a".repeat(40);
   mkdirSync(localDir);
   writeFileSync(join(localDir, "prep.env"), `PREP_HEAD_SHA=${head}\n`);
+  writeFileSync(join(localDir, "gates.env"), "GATES_MODE=full\n");
 
-  const checksResponse =
-    checks === "api-error"
-      ? "echo 'GitHub API unavailable' >&2; return 1"
-      : checks === "no-required"
-        ? "echo \"no required checks reported on the 'review-branch' branch\" >&2; return 1"
-        : checks === "pending"
-          ? `printf '%s\\n' '[{"name":"CI","bucket":"pending","state":"IN_PROGRESS"}]'; return 8`
-          : "printf '%s\\n' 'not valid JSON'";
+  const checksResponse = {
+    "api-error": "echo 'GitHub API unavailable' >&2; return 1",
+    "no-required":
+      "echo \"no required checks reported on the 'review-branch' branch\" >&2; return 1",
+    pending: `printf '%s\\n' '[{"name":"CI","bucket":"pending","state":"IN_PROGRESS"}]'; return 8`,
+    cancelled: `printf '%s\\n' '[{"name":"CI","bucket":"cancel","state":"CANCELLED"}]'`,
+    "invalid-json": "printf '%s\\n' 'not valid JSON'",
+    "invalid-row": `printf '%s\\n' '["malformed required row"]'`,
+  }[checks];
 
   return spawnSync(
     "bash",
@@ -147,7 +151,7 @@ function runMergeVerification(checks: "api-error" | "invalid-json" | "no-require
         "git() { :; }",
         "node() { :; }",
         `gh_plain() { case "$*" in *"--json name,bucket,state"*) ${checksResponse};; *"--json state,isDraft,headRefOid"*) printf '%s\\n' '{"isDraft":false,"headRefOid":"${head}"}';; *) return 0;; esac; }`,
-        "merge_verify 42",
+        "merge_verify 42 || exit 1",
       ].join("\n"),
       "pr-merge-verification",
       mergeScript,
@@ -445,11 +449,22 @@ describePosix("scripts/pr review artifact validation", () => {
     expect(result.stdout).not.toContain("merge-verify passed");
   });
 
-  it("rejects merge verification when GitHub returns malformed check evidence", () => {
-    const result = runMergeVerification("invalid-json");
+  it.each(["invalid-json", "invalid-row"] as const)(
+    "rejects malformed required-check evidence in an OR-list caller: %s",
+    (checks) => {
+      const result = runMergeVerification(checks);
+
+      expect(result.status).toBe(1);
+      expect(result.stderr).toContain("GitHub returned invalid required-check evidence");
+      expect(result.stdout).not.toContain("merge-verify passed");
+    },
+  );
+
+  it("rejects cancelled required checks in an OR-list caller", () => {
+    const result = runMergeVerification("cancelled");
 
     expect(result.status).toBe(1);
-    expect(result.stderr).toContain("GitHub returned invalid required-check evidence");
+    expect(result.stdout).toContain("Required checks are failing");
     expect(result.stdout).not.toContain("merge-verify passed");
   });
 


### PR DESCRIPTION
Closes #132633 (native merge waits past validated hosted CI).
Related: #132335 (already merged Peekaboo packaging diagnostics; the original patch and discussion are untouched).

## What Problem This Solves

Fixes an issue where maintainers using hosted PR preparation would wait on an older pending pull-request CI run even after prepare accepted successful release-gate evidence for the exact same head. The native merge path ignored the prepared gate mode and entered a watcher that can only observe pull-request runs.

## Why This Change Was Made

Merge reloads the prepared mode and revalidates hosted evidence through the existing canonical prepare verifier before continuing to required-check verification. This preserves freshness, workflow identity, attempt binding, and patch-identical reuse policy in one owner; saved artifacts select the verifier but never authorize merging. The change planner uses the explicit prepared head rather than an unrelated current checkout.

Local, Testbox, and Crabbox preparation retain their existing attached-CI wait. Required checks, server-enforced Actions publisher binding, and `--match-head-commit` remain intact; this introduces no options or bypass. Explicit error propagation also fixes reproduced malformed/cancelled required-check false passes when Bash disables `errexit` inside an OR-list.

## User Impact

Maintainers can proceed from valid hosted preparation to merge verification without waiting past accepted proof on an older CI run. Rejected evidence stops with the existing verifier's recovery guidance. No bot runtime, provider, channel, storage, runner policy, release, or version behavior changes.

## Evidence

AI-assisted implementation and review. Maintainer-owned source; tests run locally through the repository harness.

Before: the new regression failed against the original owner. The actual native wrapper accepted a newer hosted release gate during prepare, then logged `ATTACHED` for the older PR run and `TIMEOUT` during merge verification. Separate pre-fix reproductions showed malformed rows and cancelled required checks returning success in OR-list calls.

After: the native wrapper, real Git, and actual hosted verifier exercise prepare → hosted revalidation → required checks → one pinned, non-admin synthetic merge request. Fault cases cover missing/stale/failed/wrong-head/unmarked/wrong-workflow evidence, failed scheduled CI, API errors, missing artifacts, saved-JSON nonauthority, an unrelated current checkout and replaced PR-local verifier, blocking required checks, and unchanged nonhosted waits.

Retained focused proof: 457 distinct tests across the hosted verifier, native merge/prepare/outcome, watcher, main-refresh, required-check, and Crabbox sibling suites. The final fail-closed edit passed 74 focused tests. Changed-file checks and Bash syntax checks passed. Fresh isolated Codex P0 autoreviews of both the dirty candidate and rebased branch completed clean with no actionable findings. Exact-head CI and native prepare evidence are recorded below.

Historical live evidence: [release-gate run 33242699076](https://github.com/openclaw/openclaw/actions/runs/33242699076) succeeded at head `91c27cba55a00394cd2fc6e942f7a081e48aafdc` with 190 successful and four skipped jobs; [gate 99077461203](https://github.com/openclaw/openclaw/actions/runs/33242699076/job/99077461203) was published by GitHub Actions app 15368. The [older native run 33242291870](https://github.com/openclaw/openclaw/actions/runs/33242291870) later reran green; that recovery did not fix the handoff. Current live ruleset 19130959 still requires the Actions-owned gate. GitHub CLI 2.98.0's JSON path returns before ordinary failure/pending exit handling, so verification inspects buckets.

Limits: GitHub responses at the regression boundary are fixtures, not live merge mutations. The historical queue state cannot safely be recreated by manipulating real runners, and the original PR is already merged; live reads verify exact historical SHA, workflow, publisher, and enforcement. No new claim is made that both original macOS jobs are still pending or unacquired. This follow-up does not perform a live merge as a test.

Production/tooling delta: +32/−17 (net +15), tests/support net +265, docs net +15 after current-main integration. The growth is the required prepare-to-merge owner handoff and fail-closed propagation; existing verification is reused instead of duplicating acceptance policy. Current-main mergeability admission changes are preserved. The rebase preserved the patch exactly (`git range-diff` equal); final CI and native preparation evidence are recorded below.

Post-rebase focused proof at `2b920496b732b7f052a6a4a0b809a4813d10a276`: **49 tests passed**.

```sh
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs test/scripts/pr-merge-hosted.test.ts test/scripts/pr-review-artifact-validation.test.ts
```

The focused run used a separate temporary Vitest cache to avoid sharing a cache with the broader sibling run. The broader post-rebase run covered 282 cases: 277 passed initially, two source-fork-base recovery cases exited 143, and three main-refresh cases exceeded the existing 120-second limit on the loaded local host. All five failed cases then passed in an isolated rerun with unchanged source, assertions, and timeouts (the two recovery cases took 5.3/5.8 seconds; refresh cases took 83.7/36.6/32.9 seconds). The initial failures remain recorded rather than counted as clean first-pass proof.

```sh
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs test/scripts/pr-merge-hosted.test.ts test/scripts/pr-merge-outcome.test.ts test/scripts/pr-review-artifact-validation.test.ts test/scripts/pr-main-refresh.test.ts test/scripts/verify-pr-hosted-gates.test.ts
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs test/scripts/pr-merge-outcome.test.ts test/scripts/pr-main-refresh.test.ts -t 'refuses a (multiple|missing) source fork base|keeps nested preparation coherent|refreshes after CI and required checks with strict drift=false|rejects a moved prepared branch'
bash -n scripts/pr-lib/gates.sh scripts/pr-lib/merge.sh
git diff --check
```

Exact-head [CI run 33260551843](https://github.com/openclaw/openclaw/actions/runs/33260551843), attempt 1, completed successfully: 101 successful jobs and 17 skipped. [Required gate 99122517677](https://github.com/openclaw/openclaw/actions/runs/33260551843/job/99122517677) is successful. Native watcher returned `GREEN`. Native review artifacts validated, `OPENCLAW_TESTBOX=1 scripts/pr prepare-run 132673` completed at the same head, and `scripts/pr merge-verify 132673` passed. [Preparation checkpoint and ClawSweeper disposition](https://github.com/openclaw/openclaw/pull/132673#issuecomment-5463384496) include the exact commands, justified growth, advisory main drift, and lock recovery. No `merge-run` or issue closure has been performed; parent verification is the next checkpoint.
