### PR TITLE
fix(agents): preserve tightening exec overrides on moded sessions; unify permission reverse map

### DIFF
--- a/docs/plugins/codex-harness.md
+++ b/docs/plugins/codex-harness.md
@@ -998,6 +998,10 @@ Common forms:
 - `/codex stop` stops the active turn; `/codex steer <text>` steers it.
 - `/codex model <model>`, `/codex fast [on|off|status]`, and
   `/codex permissions [default|yolo|status]` change per-conversation state.
+  The permissions argument `default` (also `guardian`, `guarded`, or `approve`)
+  selects `guarded`; it does not clear the session permission mode. `yolo`
+  selects full access and requires `operator.admin`, even for an owner sender.
+  Status displays `default` only when no session permission mode is set.
 - `/codex compact` runs the same completion and session-accounting pipeline as
   `/compact`, then reports whether Codex compacted the session and the resulting
   token count. If compaction is skipped or fails, the reply includes the reason.

--- a/docs/tools/exec.md
+++ b/docs/tools/exec.md
@@ -172,7 +172,9 @@ Example:
 
 `/exec` is only honored for **authorized senders** through channel allowlists/pairing and access groups. Access-group enforcement is always on. It updates **session state only** and does not write config. Authorized external channel senders may set these session defaults. Internal gateway/webchat clients need `operator.admin` to persist them.
 
-To hard-disable exec, deny it via tool policy (`tools.deny: ["exec"]` or per-agent). Host approvals still apply unless you explicitly set `security=full` and `ask=off`.
+When a session has a permission mode, per-turn `/exec` overrides can only tighten its security and approval policy. For example, `/exec security=deny` blocks exec for that turn even in a full-access session; an override requesting looser security or fewer approvals leaves the session mode's limits unchanged. Full-access sessions bypass host approval-file floors only while effective security remains `full`. Tightening `ask` alone still applies the requested approval level without restoring those floors.
+
+To hard-disable exec, deny it via tool policy (`tools.deny: ["exec"]` or per-agent). Outside the full-access session exception above, host approval-file floors still apply.
 
 ## Exec approvals (companion app / node host)
 

--- a/extensions/codex/src/commands.test.ts
+++ b/extensions/codex/src/commands.test.ts
@@ -6453,7 +6453,7 @@ describe("codex command", () => {
       senderIsOwner: true,
       gatewayClientScopes: ["operator.write"],
       initialPermissionMode: "full",
-      expectedText: "Codex permissions set to default.",
+      expectedText: "Codex permissions set to guarded.",
       expectedPermissionMode: "guarded",
     },
   ] as const)("$name", async (testCase) => {
@@ -6472,6 +6472,7 @@ describe("codex command", () => {
       },
     });
 
+    const before = getSessionEntry({ sessionKey, storePath, readConsistency: "latest" });
     await expect(
       handleCodexCommand(
         createContext(`permissions ${testCase.mode}`, undefined, {
@@ -6483,18 +6484,12 @@ describe("codex command", () => {
         { deps: createDeps() },
       ),
     ).resolves.toEqual({ text: testCase.expectedText });
-    expect(
-      getSessionEntry({
-        sessionKey,
-        storePath,
-        readConsistency: "latest",
-      }),
-    ).toMatchObject({
-      ...(testCase.expectedPermissionMode
-        ? { permissionMode: testCase.expectedPermissionMode }
-        : {}),
-      sessionRoot: tempDir,
-    });
+    const after = getSessionEntry({ sessionKey, storePath, readConsistency: "latest" });
+    expect(after?.permissionMode).toBe(testCase.expectedPermissionMode);
+    expect(after?.sessionRoot).toBe(tempDir);
+    if (!testCase.expectedPermissionMode) {
+      expect(after).toEqual(before);
+    }
   });
 
   it("rejects model and binding replacement commands for a locked supervised session", async () => {

--- a/extensions/codex/src/conversation-control.test.ts
+++ b/extensions/codex/src/conversation-control.test.ts
@@ -131,7 +131,7 @@ describe("codex conversation controls", () => {
     );
     await expect(
       setCodexConversationPermissionsImpl({ session, mode: "default", config: {} }),
-    ).resolves.toBe("Codex permissions set to default.");
+    ).resolves.toBe("Codex permissions set to guarded.");
 
     const binding = await readCodexAppServerBinding(sessionFile);
     expect(binding?.threadId).toBe("thread-1");
@@ -192,7 +192,7 @@ describe("codex conversation controls", () => {
 
     await expect(
       setCodexConversationPermissionsImpl({ session, mode: "default", config: {} }),
-    ).resolves.toBe("Codex permissions set to default.");
+    ).resolves.toBe("Codex permissions set to guarded.");
     expect(
       getSessionEntry({ agentId: session.agentId, sessionKey: session.sessionKey, storePath }),
     ).toMatchObject({ permissionMode: "guarded" });

--- a/extensions/codex/src/conversation-control.ts
+++ b/extensions/codex/src/conversation-control.ts
@@ -321,7 +321,7 @@ export async function setCodexConversationPermissions(params: {
   if (!updated) {
     throw new Error("Codex session changed while applying the permission mode.");
   }
-  return `Codex permissions set to ${params.mode === "yolo" ? "full access" : "default"}.`;
+  return `Codex permissions set to ${params.mode === "yolo" ? "full access" : "guarded"}.`;
 }
 
 export function parseCodexFastModeArg(arg: string | undefined): boolean | undefined {

--- a/src/agents/agent-tools.scheduled-exec-target.test.ts
+++ b/src/agents/agent-tools.scheduled-exec-target.test.ts
@@ -3,7 +3,7 @@
  * A cap captured from a host-pinned creator surface must rebuild exec pinned to
  * that target; absence of the pin keeps baseline exec behavior.
  */
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import "./test-helpers/fast-coding-tools.js";
 import "./test-helpers/fast-openclaw-tools.js";
 import { createOpenClawCodingTools } from "./agent-tools.js";
@@ -45,6 +45,8 @@ vi.mock("./bash-tools.js", () => ({
 }));
 
 describe("createOpenClawCodingTools scheduled exec target", () => {
+  beforeEach(() => vi.clearAllMocks());
+
   it("pins exec to the scheduled cap's restrict-only target", async () => {
     const tools = createOpenClawCodingTools({
       scheduledToolPolicy: {
@@ -116,8 +118,8 @@ describe("createOpenClawCodingTools scheduled exec target", () => {
     );
   });
 
-  it("keeps the scheduled approval floor in a reused full-permission session", () => {
-    createOpenClawCodingTools({
+  it("keeps the scheduled approval floor in a reused full-permission session", async () => {
+    const tools = createOpenClawCodingTools({
       sessionPermissionPolicy: { root: process.cwd(), mode: "full" },
       scheduledToolPolicy: {
         version: 1,
@@ -126,9 +128,16 @@ describe("createOpenClawCodingTools scheduled exec target", () => {
       },
     });
 
+    const exec = tools.find((tool) => tool.name === "exec");
+    if (!exec) {
+      throw new Error("expected an exec tool on the scheduled surface");
+    }
+    await exec.execute("call-full-session", { command: "echo hi" });
     expect(shellSpies.defaults).toHaveBeenCalledWith(
       expect.objectContaining({
         host: "gateway",
+        mode: undefined,
+        security: "full",
         ask: "always",
         bypassHostApprovalFloors: false,
       }),

--- a/src/agents/agent-tools.session-permissions.test.ts
+++ b/src/agents/agent-tools.session-permissions.test.ts
@@ -342,6 +342,23 @@ describe("session permission filesystem tools", () => {
     });
   });
 
+  it("denies exec when a turn tightens the dispatch-provided full mode", async () => {
+    await withTempDir("openclaw-permission-exec-", async (root) => {
+      const tools = createOpenClawCodingTools({
+        workspaceDir: root,
+        sessionPermissionPolicy: { root, mode: "full" },
+        exec: { host: "gateway", mode: "full", security: "deny", ask: "off" },
+      });
+      const exec = tools.find((tool) => tool.name === "exec");
+      if (!exec) {
+        throw new Error("expected exec tool");
+      }
+      await expect(
+        exec.execute("tightened-exec", { command: "echo exec-policy-proof" }),
+      ).rejects.toThrow(/security=deny/);
+    });
+  });
+
   it("keeps full mode filesystem access unrestricted", async () => {
     await withTempDir("openclaw-permission-full-", async (root) => {
       const outside = path.join(path.dirname(root), `outside-${path.basename(root)}.txt`);

--- a/src/agents/agent-tools.ts
+++ b/src/agents/agent-tools.ts
@@ -87,7 +87,10 @@ import {
   resolveScheduledToolCallerContext,
   type ScheduledToolPolicyContext,
 } from "./scheduled-tool-policy.js";
-import { resolveSessionPermissionCoreToolPolicy } from "./session-permission-exec-mode.js";
+import {
+  resolveSessionPermissionCoreToolPolicy,
+  resolveSessionPermissionExecPolicy,
+} from "./session-permission-exec-mode.js";
 import {
   createCodingTools,
   createEditTool,
@@ -583,7 +586,9 @@ function createOpenClawCodingToolsInternal(options?: OpenClawCodingToolsOptions)
   const imageSanitization = resolveImageSanitizationLimits(options?.config);
   options?.recordToolPrepStage?.("workspace-policy");
   const { cleanupMs: cleanupMsOverride, ...execDefaults } = options?.exec ?? {};
-  const effectiveExecPolicy = applyExecPolicyLayer(execConfig, options?.exec);
+  const effectiveExecPolicy = sessionPermissionPolicy
+    ? resolveSessionPermissionExecPolicy(sessionPermissionPolicy, options?.exec)
+    : applyExecPolicyLayer(execConfig, options?.exec);
   // A scheduled cap narrows the rebuilt exec tool to its captured policy.
   // Its approval floor outranks a reused full session; the wrapper below
   // prevents caller arguments from weakening either restriction.
@@ -618,9 +623,11 @@ function createOpenClawCodingToolsInternal(options?: OpenClawCodingToolsOptions)
     execDefaults: {
       ...execDefaults,
       bypassHostApprovalFloors:
-        scheduledExecTarget?.ask !== "always" && sessionCoreToolPolicy?.bypassHostApprovalFloors,
+        scheduledExecTarget?.ask !== "always" &&
+        sessionCoreToolPolicy?.bypassHostApprovalFloors &&
+        effectiveExecPolicy.security === "full",
       host: scheduledExecTarget?.host ?? options?.exec?.host ?? execConfig.host,
-      mode: effectiveExecPolicy.mode,
+      mode: scheduledExecTarget?.ask ? undefined : effectiveExecPolicy.mode,
       security: effectiveExecPolicy.security,
       ask: scheduledExecTarget?.ask ?? effectiveExecPolicy.ask,
       config: execRuntimeConfig,

--- a/src/agents/bash-tools.exec-host-gateway.ts
+++ b/src/agents/bash-tools.exec-host-gateway.ts
@@ -106,6 +106,7 @@ type ProcessGatewayAllowlistParams = {
   defaultTimeoutSec: number;
   security: ExecSecurity;
   ask: ExecAsk;
+  bypassHostApprovalFloors?: boolean;
   autoReview?: boolean;
   autoReviewer?: ExecAutoReviewer;
   signal?: AbortSignal;
@@ -493,6 +494,7 @@ export async function processGatewayAllowlist(
     agentId: params.agentId,
     security: params.security,
     ask: params.ask,
+    bypassHostApprovalFloors: params.bypassHostApprovalFloors,
     host: "gateway",
   });
   const cwdAuthorizationBound = hostSecurity === "allowlist" || hostAsk !== "off";
@@ -670,6 +672,7 @@ export async function processGatewayAllowlist(
         source: options.source,
         security: options.source === "ask-fallback" ? fallbackSecurity : hostSecurity,
         ask: hostAsk,
+        bypassHostApprovalFloors: params.bypassHostApprovalFloors,
         allowlistSatisfied: allowlistAuthorizationSatisfied || durableApprovalSatisfied,
         ...(delayedAuthorization ? { policySnapshot: evaluationPolicySnapshot } : {}),
         requireAutoAllowSkills:

--- a/src/agents/bash-tools.exec-host-shared.ts
+++ b/src/agents/bash-tools.exec-host-shared.ts
@@ -222,6 +222,7 @@ export async function resolveExecHostApprovalContext(params: {
   security: ExecSecurity;
   ask: ExecAsk;
   host: "gateway" | "node";
+  bypassHostApprovalFloors?: boolean;
 }): Promise<ExecHostApprovalContext> {
   const approvals = await resolveExecApprovalsLocked(params.agentId, {
     security: params.security,
@@ -229,9 +230,15 @@ export async function resolveExecHostApprovalContext(params: {
   });
   // Session/config tool policy is the caller's requested contract. The host file
   // may tighten that contract, but it must not silently broaden it.
-  const hostSecurity = minSecurity(params.security, approvals.agent.security);
-  const hostAsk = maxAsk(params.ask, approvals.agent.ask);
-  const askFallback = minSecurity(hostSecurity, approvals.agent.askFallback);
+  const hostSecurity = params.bypassHostApprovalFloors
+    ? params.security
+    : minSecurity(params.security, approvals.agent.security);
+  const hostAsk = params.bypassHostApprovalFloors
+    ? params.ask
+    : maxAsk(params.ask, approvals.agent.ask);
+  const askFallback = params.bypassHostApprovalFloors
+    ? "deny"
+    : minSecurity(hostSecurity, approvals.agent.askFallback);
   if (hostSecurity === "deny") {
     throw new Error(`exec denied: host=${params.host} security=deny`);
   }

--- a/src/agents/bash-tools.exec-run.ts
+++ b/src/agents/bash-tools.exec-run.ts
@@ -350,7 +350,7 @@ export function createExecTool(
       const trustedAsk = defaults?.messageProvider && hostAsk === "off" ? undefined : requestedAsk;
       let ask = maxAsk(hostAsk, trustedAsk ?? hostAsk);
       const bypassApprovals =
-        defaults?.bypassHostApprovalFloors === true ||
+        (defaults?.bypassHostApprovalFloors === true && modePolicy.ask === "off") ||
         (elevatedRequested &&
           elevatedMode === "full" &&
           modePolicyAllowsFullBypass &&
@@ -517,6 +517,7 @@ export function createExecTool(
             defaultTimeoutSec,
             security,
             ask,
+            bypassHostApprovalFloors: defaults?.bypassHostApprovalFloors,
             autoReview,
             autoReviewer,
             signal,

--- a/src/agents/bash-tools.exec.security-floor.test.ts
+++ b/src/agents/bash-tools.exec.security-floor.test.ts
@@ -486,6 +486,33 @@ describe("exec security floor", () => {
     expect(callGatewayTool).not.toHaveBeenCalled();
   });
 
+  it.each([false, true])(
+    "honors ask-only tightening without restoring full-session host floors (approved=%s)",
+    async (approved) => {
+      writeDenyExecApprovalsFixture(tempRoot ?? os.tmpdir());
+      const calls = mockPendingApprovalGateway();
+      if (approved) {
+        vi.mocked(callGatewayTool).mockImplementation(async (method) => {
+          calls.push(method);
+          return { decision: "allow-once" };
+        });
+      }
+      const tool = createExecTool({
+        host: "gateway",
+        security: "full",
+        ask: "always",
+        bypassHostApprovalFloors: true,
+        messageProvider: approved ? "webchat" : undefined,
+        approvalRunningNoticeMs: 0,
+      });
+
+      const result = await tool.execute("call-session-full-tightened-ask", { command: "echo ok" });
+
+      expect(result.details.status).toBe(approved ? "completed" : "approval-pending");
+      expect(calls).toContain("exec.approval.request");
+    },
+  );
+
   it("honors normalized auto mode before elevated full bypass", async () => {
     const calls = mockPendingApprovalGateway();
     const autoReviewer = createAskingAutoReviewer();

--- a/src/agents/cli-runner/mcp-grant-context.ts
+++ b/src/agents/cli-runner/mcp-grant-context.ts
@@ -3,15 +3,8 @@ import { canonicalizeMainSessionAlias } from "../../config/sessions/main-session
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { McpLoopbackRequestContext } from "../../gateway/mcp-grant-store.js";
 import { normalizeMessageChannel } from "../../utils/message-channel.js";
+import { SESSION_PERMISSION_BY_EXEC_MODE } from "../session-permission-exec-mode.js";
 import type { RunCliAgentParams } from "./types.js";
-
-const SESSION_PERMISSION_BY_EXEC_MODE = {
-  deny: "read-only",
-  allowlist: "guarded",
-  ask: "guarded",
-  auto: "workspace",
-  full: "full",
-} as const;
 
 export function normalizeOptionalMcpContextValue(value: string | undefined): string | undefined {
   return value?.trim() || undefined;

--- a/src/agents/embedded-agent-runner/compact.hooks.test.ts
+++ b/src/agents/embedded-agent-runner/compact.hooks.test.ts
@@ -1358,11 +1358,14 @@ describe("compactEmbeddedAgentSessionDirect hooks", () => {
   });
 
   it.each([
-    { execMode: "auto", permissionMode: "workspace" },
-    { execMode: "full", permissionMode: "full" },
+    { execMode: "deny", permissionMode: "read-only", expectedExecMode: "deny" },
+    { execMode: "allowlist", permissionMode: "guarded", expectedExecMode: "ask" },
+    { execMode: "ask", permissionMode: "guarded", expectedExecMode: "ask" },
+    { execMode: "auto", permissionMode: "workspace", expectedExecMode: "auto" },
+    { execMode: "full", permissionMode: "full", expectedExecMode: "full" },
   ] as const)(
     "uses the final $permissionMode permission policy for compaction tools",
-    async ({ execMode, permissionMode }) => {
+    async ({ execMode, permissionMode, expectedExecMode }) => {
       await compactEmbeddedAgentSessionDirect(
         wrappedCompactionArgs({
           workspaceDir: join(TEST_WORKSPACE_DIR, "workspace"),
@@ -1383,7 +1386,7 @@ describe("compactEmbeddedAgentSessionDirect hooks", () => {
           root: join(TEST_WORKSPACE_DIR, "workspace"),
         },
       });
-      expect(toolOptions.exec).toEqual(expect.objectContaining({ mode: execMode }));
+      expect(toolOptions.exec).toEqual(expect.objectContaining({ mode: expectedExecMode }));
     },
   );
 

--- a/src/agents/embedded-agent-runner/prepared-compaction-runtime.ts
+++ b/src/agents/embedded-agent-runner/prepared-compaction-runtime.ts
@@ -57,7 +57,10 @@ import { resolveAgentPromptSurfaceForSessionKey } from "../prompt-surface.js";
 import { collectRuntimeChannelCapabilities } from "../runtime-capabilities.js";
 import { buildAgentRuntimePlan } from "../runtime-plan/build.js";
 import type { AgentRuntimePlan } from "../runtime-plan/types.js";
-import { resolveSessionPermissionExecMode } from "../session-permission-exec-mode.js";
+import {
+  resolveSessionPermissionExecMode,
+  SESSION_PERMISSION_BY_EXEC_MODE,
+} from "../session-permission-exec-mode.js";
 import { detectRuntimeShell } from "../shell-utils.js";
 import { resolveRuntimeAgentName } from "../system-prompt-params.js";
 import { toolPolicyRestrictsTools } from "../tool-policy.js";
@@ -107,15 +110,8 @@ export async function buildPreparedCompactionRuntime(prepared: DirectCompactionP
     effectiveCwd,
     effectiveSkillAgentId,
   } = prepared;
-  const permissionModes = {
-    deny: "read-only",
-    allowlist: "read-only",
-    ask: "guarded",
-    auto: "workspace",
-    full: "full",
-  } as const;
   const mode = params.execOverrides?.mode
-    ? permissionModes[params.execOverrides.mode]
+    ? SESSION_PERMISSION_BY_EXEC_MODE[params.execOverrides.mode]
     : (params.permissionMode ?? params.sessionEntry?.permissionMode);
   const root = params.sessionRoot ?? params.sessionEntry?.sessionRoot;
   const sessionPermissionPolicy = mode

--- a/src/agents/exec-defaults.test.ts
+++ b/src/agents/exec-defaults.test.ts
@@ -305,6 +305,120 @@ describe("resolveExecDefaults", () => {
     });
   });
 
+  it.each([
+    {
+      permissionMode: "guarded",
+      override: { security: "deny" },
+      security: "deny",
+      ask: "on-miss",
+      mode: "deny",
+    },
+    {
+      permissionMode: "guarded",
+      override: { ask: "always" },
+      security: "allowlist",
+      ask: "always",
+      mode: "ask",
+    },
+    {
+      permissionMode: "guarded",
+      override: { mode: "deny" },
+      security: "deny",
+      ask: "on-miss",
+      mode: "deny",
+    },
+    {
+      permissionMode: "guarded",
+      override: { security: "full", ask: "off" },
+      security: "allowlist",
+      ask: "on-miss",
+      mode: "ask",
+    },
+    {
+      permissionMode: "guarded",
+      override: { mode: "full" },
+      security: "allowlist",
+      ask: "on-miss",
+      mode: "ask",
+    },
+    {
+      permissionMode: "guarded",
+      override: undefined,
+      security: "allowlist",
+      ask: "on-miss",
+      mode: "ask",
+    },
+    {
+      permissionMode: "read-only",
+      override: { mode: "deny" },
+      security: "deny",
+      ask: "off",
+      mode: "deny",
+    },
+    {
+      permissionMode: "guarded",
+      override: { mode: "ask" },
+      security: "allowlist",
+      ask: "on-miss",
+      mode: "ask",
+    },
+    {
+      permissionMode: "workspace",
+      override: { mode: "auto" },
+      security: "allowlist",
+      ask: "on-miss",
+      mode: "auto",
+    },
+    {
+      permissionMode: "full",
+      override: { mode: "full" },
+      security: "full",
+      ask: "off",
+      mode: "full",
+    },
+    {
+      permissionMode: "workspace",
+      override: { mode: "auto", security: "deny", ask: "always" },
+      security: "deny",
+      ask: "always",
+      mode: "deny",
+    },
+  ] as const)(
+    "only tightens $permissionMode with $override",
+    ({ permissionMode, override, ...expected }) => {
+      expect(
+        resolveExecDefaults({
+          sessionEntry: { permissionMode },
+          execOverrides: override,
+          sandboxAvailable: false,
+        }),
+      ).toMatchObject(expected);
+    },
+  );
+
+  it.each([
+    {
+      override: { mode: "full", security: "allowlist" },
+      security: "deny",
+      ask: "always",
+      mode: "deny",
+    },
+    { override: { mode: "full", ask: "on-miss" }, security: "full", ask: "on-miss", mode: "full" },
+    { override: { mode: "full" }, security: "full", ask: "off", mode: "full" },
+  ] as const)(
+    "bounds tightened full sessions with host floors for $override",
+    ({ override, ...expected }) => {
+      expect(
+        resolveExecDefaults({
+          sessionEntry: { permissionMode: "full" },
+          execOverrides: override,
+          execApprovals: { version: 1, defaults: { security: "deny", ask: "always" } },
+          sandboxAvailable: false,
+        }),
+      ).toMatchObject(expected);
+    },
+  );
+
   it("keeps agent mode overrides ahead of the global mode", () => {
     expect(
       resolveExecDefaults({

--- a/src/agents/exec-defaults.ts
+++ b/src/agents/exec-defaults.ts
@@ -24,7 +24,7 @@ import { applyExecPolicyLayer } from "../infra/exec-policy.js";
 import { resolveAgentConfig, resolveSessionAgentId } from "./agent-scope.js";
 import { isRequestedExecTargetAllowed, resolveExecTarget } from "./bash-tools.exec-runtime.js";
 import { resolveSandboxRuntimeStatus } from "./sandbox/runtime-status.js";
-import { resolveSessionPermissionCoreToolPolicy } from "./session-permission-exec-mode.js";
+import { resolveSessionPermissionExecPolicy } from "./session-permission-exec-mode.js";
 
 /** Session-scoped exec fields that may be carried across an isolated runtime boundary. */
 export type ExecSessionDefaults = Pick<
@@ -42,7 +42,7 @@ type ResolvedExecConfig = {
   node?: string;
 };
 
-export type ExecPolicyOverrides = Omit<ResolvedExecConfig, "mode">;
+export type ExecPolicyOverrides = ResolvedExecConfig;
 
 // Legacy/config resolution keeps the most specific mode/security/ask while
 // preserving policy bounds from approvals and sandbox availability later.
@@ -173,10 +173,17 @@ export function resolveExecDefaults(params: {
   });
   const defaultSecurity = resolved.effectiveHost === "sandbox" ? "deny" : "full";
   const sessionPermissionPolicy = params.sessionEntry?.permissionMode
-    ? resolveSessionPermissionCoreToolPolicy({ mode: params.sessionEntry.permissionMode })
+    ? resolveSessionPermissionExecPolicy(
+        { mode: params.sessionEntry.permissionMode },
+        params.execOverrides,
+      )
     : undefined;
+  // Full sessions bypass host floors only while effective security remains full;
+  // ask-only tightening still applies without restoring those floors.
+  const bypassHostApprovalFloors =
+    params.sessionEntry?.permissionMode === "full" && sessionPermissionPolicy?.security === "full";
   const approvalDefaults =
-    resolved.effectiveHost === "sandbox" || sessionPermissionPolicy?.bypassHostApprovalFloors
+    resolved.effectiveHost === "sandbox" || bypassHostApprovalFloors
       ? undefined
       : resolveExecApprovalsFromFile({
           file: params.execApprovals ?? loadExecApprovals(),
@@ -190,15 +197,15 @@ export function resolveExecDefaults(params: {
     security: approvalDefaults?.security ?? defaultSecurity,
     ask: approvalDefaults?.ask ?? "off",
   };
-  const layeredPolicy: LayeredExecPolicy = sessionPermissionPolicy
-    ? { mode: sessionPermissionPolicy.execMode, security: defaultSecurity, ask: "off" }
-    : applyExecPolicyLayer(
-        applySessionLegacyExecPolicyLayer(
-          applyExecPolicyLayer(applyExecPolicyLayer(basePolicy, globalExec), agentExec),
-          params.sessionEntry,
-        ),
-        params.execOverrides,
-      );
+  const layeredPolicy: LayeredExecPolicy =
+    sessionPermissionPolicy ??
+    applyExecPolicyLayer(
+      applySessionLegacyExecPolicyLayer(
+        applyExecPolicyLayer(applyExecPolicyLayer(basePolicy, globalExec), agentExec),
+        params.sessionEntry,
+      ),
+      params.execOverrides,
+    );
   const modePolicy = resolveExecModePolicy(layeredPolicy);
   // Approval files bound every policy source except explicit admin-only full sessions.
   const security =

--- a/src/agents/session-permission-exec-mode.test.ts
+++ b/src/agents/session-permission-exec-mode.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+import { SESSION_PERMISSION_BY_EXEC_MODE } from "./session-permission-exec-mode.js";
+
+describe("session permission modes for exec policies", () => {
+  it.each([
+    ["deny", "read-only"],
+    ["allowlist", "guarded"],
+    ["ask", "guarded"],
+    ["auto", "workspace"],
+    ["full", "full"],
+  ] as const)("maps %s to %s", (execMode, permissionMode) => {
+    expect(SESSION_PERMISSION_BY_EXEC_MODE[execMode]).toBe(permissionMode);
+  });
+});

--- a/src/agents/session-permission-exec-mode.ts
+++ b/src/agents/session-permission-exec-mode.ts
@@ -1,4 +1,10 @@
-import type { ExecMode } from "../infra/exec-approvals.js";
+import {
+  type ExecAsk,
+  type ExecMode,
+  type ExecSecurity,
+  resolveExecPolicyForMode,
+} from "../infra/exec-approvals-core.js";
+import { maxAsk, minSecurity } from "../infra/exec-approvals-policy.js";
 import type { PreparedSessionPermissionPolicy } from "./tool-fs-policy.types.js";
 
 const EXEC_MODE_BY_PERMISSION_MODE = {
@@ -7,6 +13,14 @@ const EXEC_MODE_BY_PERMISSION_MODE = {
   workspace: "auto",
   full: "full",
 } as const satisfies Record<PreparedSessionPermissionPolicy["mode"], ExecMode>;
+
+export const SESSION_PERMISSION_BY_EXEC_MODE = {
+  deny: "read-only",
+  allowlist: "guarded",
+  ask: "guarded",
+  auto: "workspace",
+  full: "full",
+} as const satisfies Record<ExecMode, PreparedSessionPermissionPolicy["mode"]>;
 
 export function resolveSessionPermissionCoreToolPolicy(
   policy: Pick<PreparedSessionPermissionPolicy, "mode">,
@@ -25,4 +39,22 @@ export function resolveSessionPermissionExecMode(
   policy: Pick<PreparedSessionPermissionPolicy, "mode">,
 ): ExecMode {
   return resolveSessionPermissionCoreToolPolicy(policy).execMode;
+}
+
+export function resolveSessionPermissionExecPolicy(
+  policy: Pick<PreparedSessionPermissionPolicy, "mode">,
+  overrides?: { mode?: ExecMode; security?: ExecSecurity; ask?: ExecAsk },
+): { mode?: ExecMode; security: ExecSecurity; ask: ExecAsk } {
+  const mode = resolveSessionPermissionExecMode(policy);
+  const base = resolveExecPolicyForMode(mode);
+  const override = overrides?.mode ? resolveExecPolicyForMode(overrides.mode) : base;
+  // Overrides may tighten a session mode, never loosen it. Dispatch can echo
+  // the session mode alongside explicit security/ask, so clamp both inputs.
+  const security = minSecurity(
+    base.security,
+    minSecurity(override.security, overrides?.security ?? "full"),
+  );
+  const ask = maxAsk(base.ask, maxAsk(override.ask, overrides?.ask ?? "off"));
+  // Retaining a changed mode would make downstream normalization erase the tightening.
+  return { mode: security === base.security && ask === base.ask ? mode : undefined, security, ask };
 }

--- a/src/infra/exec-approvals-authorization.ts
+++ b/src/infra/exec-approvals-authorization.ts
@@ -23,6 +23,7 @@ export type ExecApprovalUsageAuthorization = {
   source: "current-policy" | "ask-fallback" | "explicit-approval" | "auto-review";
   security: ExecSecurity;
   ask: ExecAsk;
+  bypassHostApprovalFloors?: boolean;
   allowlistSatisfied: boolean;
   policySnapshot?: ExecApprovalPolicySnapshot;
   requireAutoAllowSkills?: boolean;
@@ -45,8 +46,14 @@ function assertCurrentUsageAuthorization(params: {
       ask: params.authorization.ask,
     },
   });
-  const security = minSecurity(params.authorization.security, current.agent.security);
-  const ask = maxAsk(params.authorization.ask, current.agent.ask);
+  // Full-session floor bypass survives an explicit ask; the delayed decision
+  // still binds to the policy snapshot below, so policy changes invalidate it.
+  const security = params.authorization.bypassHostApprovalFloors
+    ? params.authorization.security
+    : minSecurity(params.authorization.security, current.agent.security);
+  const ask = params.authorization.bypassHostApprovalFloors
+    ? params.authorization.ask
+    : maxAsk(params.authorization.ask, current.agent.ask);
   if (security === "deny") {
     throw new Error("Exec approval changed before execution");
   }


### PR DESCRIPTION
## What Problem This Solves

Three defects around session permission modes (`read-only|guarded|workspace|full`), found during an exec-policy surface audit:

1. **Per-turn `/exec` tightening was silently ignored on moded sessions.** Once a session had a permission mode, `resolveExecDefaults` replaced the whole layered policy with the mode tuple and discarded `execOverrides` entirely (`src/agents/exec-defaults.ts`). A user sending `/exec security=deny` on a full-access session got no effect and no explanation — and the regression capture showed a real exec completing despite `security=deny`, because tool construction and the exec host path re-derived policy the same way.
2. **The `/codex permissions` ack lied about what it wrote.** The non-yolo branch persists `guarded` but reported "set to default" — `guarded` is not Default (Default = no session mode).
3. **Two drifted copies of the exec-mode→permission-mode reverse map** (`src/agents/cli-runner/mcp-grant-context.ts` mapped `allowlist→guarded`; `src/agents/embedded-agent-runner/prepared-compaction-runtime.ts` mapped `allowlist→read-only`), so the same exec policy produced different permission semantics depending on the code path.

## Why This Change Was Made

- Overrides now compose with a session mode through one owner, `resolveSessionPermissionExecPolicy` (`src/agents/session-permission-exec-mode.ts`): tightening-only via the existing `minSecurity`/`maxAsk` lattice helpers, stable under dispatch's mode self-feedback, dropping the mode name when tightened so downstream mode normalization cannot re-expand it. The same helper now feeds tool construction (`agent-tools.ts`), so resolver and enforcement cannot disagree.
- Full-access sessions keep their contractual approval-file floor bypass, but only while *effective* security remains `full`; the bypass provenance now travels to the gateway exec host path and delayed authorization (`bash-tools.exec-run.ts`, `bash-tools.exec-host-shared.ts`, `exec-approvals-authorization.ts`) so an explicit tightened `ask` is enforced instead of blanket-bypassed, while approval-file floors are not double-applied to full sessions.
- The reverse map is now a single exported table next to the forward map; both former hand-rolled copies are deleted. `allowlist` canonically maps to `guarded`; investigation confirmed the compaction path has no tool-execution loop that would justify its stricter divergent copy (evidence in the audit: `packages/agent-core/src/harness/compaction/compaction.ts` builds one summary completion).
- The permissions ack now reports `guarded` when it writes guarded. The reported "yolo admin bypass" premise was **disproven**: the `operator.admin` gate exists at the dispatch site (`extensions/codex/src/command-handler-actions.ts`, added in #124909) and was mutation-tested to confirm it is load-bearing; it is unchanged here.

## User Impact

- `/exec security=…`/`ask=…` on a session with a permission mode now actually tightens that turn instead of doing nothing silently; loosening requests remain bounded by the session mode.
- A full-access session with a per-turn tightened `ask` now asks; untightened full sessions behave exactly as before.
- `/codex permissions default` ack text is truthful (`guarded`); status output for unset mode still reads `default`.
- Docs updated: `docs/tools/exec.md` (override tightening contract), `docs/plugins/codex-harness.md` (permissions argument semantics).

## Evidence

- Regression tests were written first and failed on pre-fix code: six resolver failures, two ack failures, one compaction mapping failure, plus captured end-to-end failures where a real exec ran despite `security=deny` and an ask-only tightening never requested approval. Loosening/no-override/self-feedback cases are positive controls.
- The pre-existing admin gate was mutation-tested in a scratch copy: with the three-line guard removed, unauthorized full-access succeeded; with it intact, refused. Production bytes restored and hash-verified.
- Focused suites: 500 tests across 9 files passed. `pnpm check:changed` passed (one earlier attempt hit a transient extension-lint boundary-artifact race from Vite temp files; noted as follow-up, reproduced independent of this diff).
- Broad `pnpm test extensions/codex`: 4,554 passed across 191 files; the single failure (`transport-websocket` unix-socket timeout) reproduces on unchanged baseline in isolation and is unrelated (follow-up filed in-body here).
- Production LOC +53 / tests +179 / docs +6: bug-fix growth is the enforcement-path provenance (`bypassHostApprovalFloors` reaching host + delayed authorization) plus the shared helper; a resolver-only fix demonstrably left enforcement ignoring the tightening, and both duplicate reverse tables were deleted.
- Autoreview (configured Codex reviewer): clean, no accepted findings.

Follow-ups (out of scope here): baseline `transport-websocket.test.ts` unix-socket hang; boundary-artifact scanner picking up transient `.vite-temp/*.mjs` names.
