### PR TITLE
fix(qa): report temporary directory cleanup failures

### DIFF
--- a/docs/concepts/qa-e2e-automation.md
+++ b/docs/concepts/qa-e2e-automation.md
@@ -1127,6 +1127,13 @@ after-stop cleanup when the process group is confirmed stopped. This ordering
 requires adapters to use the two cleanup phases; it does not change broker TTLs
 or provide a durable guarantee after the QA parent or host is lost.
 
+Temporary runtime and staged-plugin directories are removed independently, and
+removal failures are reported with redacted diagnostics. A cleanup error can
+therefore leave isolated runtime or auth state on disk even when process
+termination is confirmed. Correct the filesystem problem and retry `stop()` on
+the retained lifecycle owner; confirmed termination still permits after-stop
+credential cleanup.
+
 Payload shapes the broker validates on `admin/add`:
 
 - Buzz (`kind: "buzz"`): `{ relayUrl: string, roomId: string,

--- a/extensions/qa-lab/src/gateway-child-artifacts.test.ts
+++ b/extensions/qa-lab/src/gateway-child-artifacts.test.ts
@@ -12,56 +12,58 @@ afterEach(async () => {
 });
 
 describe("cleanupQaGatewayTempRoots", () => {
+  // Short messages expose cause leaks that padding could hide behind truncation.
   it.each([
-    { failedRoots: ["tempRoot"] },
-    { failedRoots: ["stagedBundledPluginsRoot"] },
-    { failedRoots: ["tempRoot", "stagedBundledPluginsRoot"] },
-  ])("reports $failedRoots failures after attempting both roots", async ({ failedRoots }) => {
-    const roots = {
-      tempRoot: await dirs.makeTempDir("qa-cleanup-runtime-"),
-      stagedBundledPluginsRoot: await dirs.makeTempDir("qa-cleanup-plugins-"),
-    };
-    const originalRm = fs.rm;
-    const attempts: string[] = [];
-    vi.spyOn(fs, "rm").mockImplementation(async (target, options) => {
-      const entry = Object.entries(roots).find(([, root]) => root === target);
-      if (entry) {
-        attempts.push(entry[0]);
-        if (failedRoots.includes(entry[0])) {
-          throw Object.assign(
-            new Error(
-              `EACCES: denied apiKey=synthetic-cleanup-secret\n${"diagnostic ".repeat(400)}`,
-            ),
-            { code: "EACCES", path: target, cause: new Error("synthetic-raw-cause") },
-          );
+    { failedRoots: ["tempRoot"], padding: "" },
+    { failedRoots: ["stagedBundledPluginsRoot"], padding: "" },
+    { failedRoots: ["tempRoot", "stagedBundledPluginsRoot"], padding: "diagnostic ".repeat(400) },
+  ])(
+    "reports $failedRoots failures after attempting both roots",
+    async ({ failedRoots, padding }) => {
+      const roots = {
+        tempRoot: await dirs.makeTempDir("qa-cleanup-runtime-"),
+        stagedBundledPluginsRoot: await dirs.makeTempDir("qa-cleanup-plugins-"),
+      };
+      const originalRm = fs.rm;
+      const attempts: string[] = [];
+      vi.spyOn(fs, "rm").mockImplementation(async (target, options) => {
+        const entry = Object.entries(roots).find(([, root]) => root === target);
+        if (entry) {
+          attempts.push(entry[0]);
+          if (failedRoots.includes(entry[0])) {
+            throw Object.assign(
+              new Error(`EACCES: denied apiKey=synthetic-cleanup-secret\n${padding}`),
+              { code: "EACCES", path: target, cause: new Error("synthetic-raw-cause") },
+            );
+          }
+        }
+        return originalRm(target, options);
+      });
+
+      const outcome = await cleanupQaGatewayTempRoots(roots).catch((error: unknown) => error);
+      expect(attempts).toEqual(Object.keys(roots));
+      for (const [label, root] of Object.entries(roots)) {
+        if (failedRoots.includes(label)) {
+          await expect(fs.stat(root)).resolves.toBeDefined();
+        } else {
+          await expect(fs.stat(root)).rejects.toMatchObject({ code: "ENOENT" });
         }
       }
-      return originalRm(target, options);
-    });
-
-    const outcome = await cleanupQaGatewayTempRoots(roots).catch((error: unknown) => error);
-    expect(attempts).toEqual(Object.keys(roots));
-    for (const [label, root] of Object.entries(roots)) {
-      if (failedRoots.includes(label)) {
-        await expect(fs.stat(root)).resolves.toBeDefined();
-      } else {
-        await expect(fs.stat(root)).rejects.toMatchObject({ code: "ENOENT" });
+      expect(outcome).toBeInstanceOf(AggregateError);
+      if (!(outcome instanceof AggregateError)) {
+        throw new Error("expected cleanup failure");
       }
-    }
-    expect(outcome).toBeInstanceOf(AggregateError);
-    if (!(outcome instanceof AggregateError)) {
-      throw new Error("expected cleanup failure");
-    }
-    expect(outcome.errors).toHaveLength(failedRoots.length);
-    for (const label of failedRoots) {
-      expect(outcome.message).toContain(label);
-    }
-    expect(outcome.message).toContain("EACCES");
-    expect(outcome.message.length).toBeLessThan(4_500);
-    expect(inspect(outcome, { depth: null })).not.toMatch(
-      /synthetic-cleanup-secret|synthetic-raw-cause/,
-    );
-  });
+      expect(outcome.errors).toHaveLength(failedRoots.length);
+      for (const label of failedRoots) {
+        expect(outcome.message).toContain(label);
+      }
+      expect(outcome.message).toContain("EACCES");
+      expect(outcome.message.length).toBeLessThan(4_500);
+      expect(inspect(outcome, { depth: null })).not.toMatch(
+        /synthetic-cleanup-secret|synthetic-raw-cause/,
+      );
+    },
+  );
 
   it.each([undefined, null, "missing"])(
     "accepts an already removed runtime with staged root %s",

--- a/extensions/qa-lab/src/gateway-child-artifacts.test.ts
+++ b/extensions/qa-lab/src/gateway-child-artifacts.test.ts
@@ -1,0 +1,78 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { inspect } from "node:util";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanupQaGatewayTempRoots } from "./gateway-child-artifacts.js";
+import { createTempDirHarness } from "./temp-dir.test-helper.js";
+
+const dirs = createTempDirHarness();
+afterEach(async () => {
+  vi.restoreAllMocks();
+  await dirs.cleanup();
+});
+
+describe("cleanupQaGatewayTempRoots", () => {
+  it.each([
+    { failedRoots: ["tempRoot"] },
+    { failedRoots: ["stagedBundledPluginsRoot"] },
+    { failedRoots: ["tempRoot", "stagedBundledPluginsRoot"] },
+  ])("reports $failedRoots failures after attempting both roots", async ({ failedRoots }) => {
+    const roots = {
+      tempRoot: await dirs.makeTempDir("qa-cleanup-runtime-"),
+      stagedBundledPluginsRoot: await dirs.makeTempDir("qa-cleanup-plugins-"),
+    };
+    const originalRm = fs.rm;
+    const attempts: string[] = [];
+    vi.spyOn(fs, "rm").mockImplementation(async (target, options) => {
+      const entry = Object.entries(roots).find(([, root]) => root === target);
+      if (entry) {
+        attempts.push(entry[0]);
+        if (failedRoots.includes(entry[0])) {
+          throw Object.assign(
+            new Error(
+              `EACCES: denied apiKey=synthetic-cleanup-secret\n${"diagnostic ".repeat(400)}`,
+            ),
+            { code: "EACCES", path: target, cause: new Error("synthetic-raw-cause") },
+          );
+        }
+      }
+      return originalRm(target, options);
+    });
+
+    const outcome = await cleanupQaGatewayTempRoots(roots).catch((error: unknown) => error);
+    expect(attempts).toEqual(Object.keys(roots));
+    for (const [label, root] of Object.entries(roots)) {
+      if (failedRoots.includes(label)) {
+        await expect(fs.stat(root)).resolves.toBeDefined();
+      } else {
+        await expect(fs.stat(root)).rejects.toMatchObject({ code: "ENOENT" });
+      }
+    }
+    expect(outcome).toBeInstanceOf(AggregateError);
+    if (!(outcome instanceof AggregateError)) {
+      throw new Error("expected cleanup failure");
+    }
+    expect(outcome.errors).toHaveLength(failedRoots.length);
+    for (const label of failedRoots) {
+      expect(outcome.message).toContain(label);
+    }
+    expect(outcome.message).toContain("EACCES");
+    expect(outcome.message.length).toBeLessThan(4_500);
+    expect(inspect(outcome, { depth: null })).not.toMatch(
+      /synthetic-cleanup-secret|synthetic-raw-cause/,
+    );
+  });
+
+  it.each([undefined, null, "missing"])(
+    "accepts an already removed runtime with staged root %s",
+    async (staging) => {
+      const parent = await dirs.makeTempDir("qa-cleanup-absent-");
+      await expect(
+        cleanupQaGatewayTempRoots({
+          tempRoot: path.join(parent, "runtime"),
+          stagedBundledPluginsRoot: staging ? path.join(parent, staging) : staging,
+        }),
+      ).resolves.toBeUndefined();
+    },
+  );
+});

--- a/extensions/qa-lab/src/gateway-child-artifacts.ts
+++ b/extensions/qa-lab/src/gateway-child-artifacts.ts
@@ -1,7 +1,7 @@
 // Qa Lab plugin module owns sanitized gateway debug artifacts and temp cleanup.
 import fs from "node:fs/promises";
 import path from "node:path";
-import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
+import { coerceErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import { sliceUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import { ensureRepoBoundDirectory } from "./cli-paths.js";
 import { redactQaGatewayDebugText } from "./gateway-log-redaction.js";
@@ -37,9 +37,9 @@ export async function cleanupQaGatewayTempRoots(params: {
     try {
       await fs.rm(root, { recursive: true, force: true });
     } catch (error) {
-      // Attempt both roots; retain only bounded, redacted diagnostics, since raw
-      // filesystem errors can expose credentials in paths or nested causes.
-      const details = sliceUtf16Safe(redactQaGatewayDebugText(formatErrorMessage(error)), 0, 2_048);
+      // Attempt both roots. Read only the top-level message before redaction;
+      // cause-aware formatting can expose arbitrary nested credentials.
+      const details = sliceUtf16Safe(redactQaGatewayDebugText(coerceErrorMessage(error)), 0, 2_048);
       errors.push(new Error(`${label}: ${details}`));
     }
   }

--- a/extensions/qa-lab/src/gateway-child-artifacts.ts
+++ b/extensions/qa-lab/src/gateway-child-artifacts.ts
@@ -1,6 +1,8 @@
 // Qa Lab plugin module owns sanitized gateway debug artifacts and temp cleanup.
 import fs from "node:fs/promises";
 import path from "node:path";
+import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
+import { sliceUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import { ensureRepoBoundDirectory } from "./cli-paths.js";
 import { redactQaGatewayDebugText } from "./gateway-log-redaction.js";
 
@@ -24,9 +26,28 @@ export async function cleanupQaGatewayTempRoots(params: {
   tempRoot: string;
   stagedBundledPluginsRoot?: string | null;
 }) {
-  await fs.rm(params.tempRoot, { recursive: true, force: true }).catch(() => {});
-  if (params.stagedBundledPluginsRoot) {
-    await fs.rm(params.stagedBundledPluginsRoot, { recursive: true, force: true }).catch(() => {});
+  const errors: Error[] = [];
+  for (const [label, root] of [
+    ["tempRoot", params.tempRoot],
+    ["stagedBundledPluginsRoot", params.stagedBundledPluginsRoot],
+  ] as const) {
+    if (!root) {
+      continue;
+    }
+    try {
+      await fs.rm(root, { recursive: true, force: true });
+    } catch (error) {
+      // Attempt both roots; retain only bounded, redacted diagnostics, since raw
+      // filesystem errors can expose credentials in paths or nested causes.
+      const details = sliceUtf16Safe(redactQaGatewayDebugText(formatErrorMessage(error)), 0, 2_048);
+      errors.push(new Error(`${label}: ${details}`));
+    }
+  }
+  if (errors.length) {
+    throw new AggregateError(
+      errors,
+      `qa gateway temp-root cleanup failed: ${errors.map((error) => error.message).join("; ")}`,
+    );
   }
 }
 

--- a/extensions/qa-lab/src/gateway-child-lifecycle.test.ts
+++ b/extensions/qa-lab/src/gateway-child-lifecycle.test.ts
@@ -314,6 +314,32 @@ describe.skipIf(process.platform === "win32")("QA gateway lifetime ownership", (
     expect(pids()).toHaveLength(1);
   });
 
+  it("reports failed runtime removal without undoing confirmed shutdown and retries cleanup", async () => {
+    const { params, pids } = await fixture();
+    const owner = own(params);
+    const gateway = await owner.start();
+    pids();
+    const originalRm = fs.rm;
+    const fault = vi.spyOn(fs, "rm").mockImplementation(async (target, options) => {
+      if (target === gateway.tempRoot) {
+        throw Object.assign(new Error("EACCES: runtime removal denied"), { code: "EACCES" });
+      }
+      return originalRm(target, options);
+    });
+    try {
+      const result = await owner.stop();
+      expect(result.process).toBe("confirmed-stopped");
+      expect(pids().every((pid) => !isQaPosixProcessGroupAlive(pid))).toBe(true);
+      await expect(fs.stat(gateway.tempRoot)).resolves.toBeDefined();
+      expect(result.errors.map(String).join("; ")).toContain("EACCES");
+      await expect(gateway.stop()).rejects.toThrow("EACCES");
+    } finally {
+      fault.mockRestore();
+    }
+    await expect(owner.stop()).resolves.toEqual({ process: "confirmed-stopped", errors: [] });
+    await expect(fs.stat(gateway.tempRoot)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
   it("reports artifact failure while still confirming process shutdown", async () => {
     const { params, pids } = await fixture();
     const owner = own(params);


### PR DESCRIPTION
Closes #132667 — QA cleanup hides temporary-directory removal failures.

<details>
<summary>Additional instructions</summary>

Maintainers can update this same-repository branch. This change is AI-assisted.

</details>

## What Problem This Solves

Fixes an issue where QA Lab operators could receive a successful Gateway cleanup result while isolated runtime/auth state or a staged-plugin directory remained on disk after a filesystem removal failure. Both removal calls discarded errors before the lifecycle's diagnostic collector could see them.

## Why This Change Was Made

Keep the repair at the temp-root cleanup owner: attempt both configured roots independently, then aggregate every failure with labeled, bounded, redacted messages. The aggregate message includes both root details for callers that render only the top-level message; raw filesystem errors and nested causes are not retained. The implementation uses the existing message-only `coerceErrorMessage`, rather than a cause-aware formatter, before QA redaction and truncation.

The existing lifecycle and credential-release policy are unchanged. Confirmed process-tree termination is still a separate fact from filesystem diagnostics: confirmed shutdown permits after-stop credential cleanup, while unconfirmed shutdown still retains ownership. Existing missing-directory behavior remains successful, and a later stop can retry a failed removal.

Production LOC: +24/-3 (net +21). Tests: +106/-0. Docs: +7/-0. The production growth supplies independent error collection and safe multi-root diagnostics; there is no new dependency, configuration, storage schema, public API, process path, or test-only production seam.

## User Impact

QA source-checkout runs now report retained-directory cleanup failures rather than silently returning an empty error list. Operators can correct the filesystem problem and retry cleanup. Normal packaged Gateway behavior is unchanged; QA Lab is source-checkout tooling. Recovery and the process/diagnostic distinction are documented in the [QA overview](https://docs.openclaw.ai/concepts/qa-e2e-automation#convex-credential-pool).

## Evidence

Before the repair, all four new failure regressions failed for the intended reason: the three root-removal fault combinations resolved without an error, and real-child `stop()` returned an empty diagnostic list. The other 13 tests in that focused run passed.

A real POSIX permissions fault, without mocking filesystem removal, reproduced the silent leak:

```json
{"outcome":"resolved","runtimeRemains":true,"stagedPluginsRemain":false}
```

After the repair, the same fault rejected with an `EACCES` diagnostic while independently removing the other root; after restoring permissions, retry removed both roots:

```json
{"reported":true,"rawCauseLeaked":false,"runtimeRemains":true,"stagedPluginsRemain":false}
{"retry":"resolved","runtimeRemains":false,"stagedPluginsRemain":false}
```

A late review caught a cause-chain leak in the first candidate: the general error formatter appended arbitrary nested causes. The original padded test messages hid that leak behind truncation. Two short-message regression cases failed before switching to message-only coercion and now pass; the long-message case still independently checks bounds. The corrected real-permission probe above also attaches a synthetic nested cause and verifies it never appears in inspected output.

After refreshing onto main with #132659 (bounded packaged-bootstrap subprocess lifetimes) and applying the sanitizer correction, regression and sibling coverage is **179 passed, 1 skipped** across seven files on macOS/Node 24.20.0. The skip is the existing Linux-only shell-startup environment test. These tests cover each root failing, both failing, bounded/redacted aggregate diagnostics without raw causes, optional/missing roots, real detached-child shutdown and cleanup retry, packaged-bootstrap command settlement, and release-versus-retained-heartbeat behavior with real process groups and a synthetic local credential broker. `git range-diff` confirms the repair commit is patch-identical after the refresh.

```bash
node scripts/run-vitest.mjs extensions/qa-lab/src/gateway-child-artifacts.test.ts extensions/qa-lab/src/gateway-child-lifecycle.test.ts extensions/qa-lab/src/gateway-child-bootstrap.test.ts extensions/qa-lab/src/gateway-child.test.ts extensions/qa-lab/src/suite.test.ts extensions/qa-lab/src/manual-lane.runtime.test.ts extensions/qa-lab/src/gateway-startup-lease.integration.test.ts
```

Changed-scope checks passed, including extension/test typechecks, type-aware lint, formatting, doctor-contract tests, dead-export checks, boundary guards, and import cycles:

```bash
node scripts/check-changed.mjs -- extensions/qa-lab/src/gateway-child-artifacts.ts extensions/qa-lab/src/gateway-child-artifacts.test.ts extensions/qa-lab/src/gateway-child-lifecycle.test.ts docs/concepts/qa-e2e-automation.md
```

`git diff --check` passed. Fresh Codex autoreview of the complete PR candidate, including the message-only correction, completed successfully with no accepted/actionable findings at its default P0 scope. No live provider/channel credentials or operator Gateway were used: this is local filesystem/process-lifecycle proof, not an authenticated live-channel run. There is no UI change.

**Review disposition:** the nested-cause finding is fixed and covered by short-message regressions. The later request to strip local filesystem paths is not applied: these are local operator recovery errors, consistent with the lifecycle's existing retained-root messages. Debug artifacts are preserved before cleanup diagnostics are generated, and standard-suite cleanup throws before terminal report/evidence publication. The adjacent README path omission is an artifact-minimization policy, not a blanket prohibition on useful local recovery paths.

**Separate existing follow-up:** retrying `stop({ preserveToDir })` with the same preservation directory can overwrite previously preserved logs after the runtime directory was already removed. This also reproduces with a one-shot RPC diagnostic and no filesystem fault, independently of this change. That artifact-preservation idempotence issue is recorded separately; this PR does not redesign lifecycle ownership or the in-flight bootstrap-lifetime work.
