### PR TITLE
chore(imessage): verify reply-cache counter recovery after reload

### DIFF
--- a/extensions/imessage/src/monitor-reply-cache.test.ts
+++ b/extensions/imessage/src/monitor-reply-cache.test.ts
@@ -1,6 +1,18 @@
 // Imessage tests cover monitor reply cache plugin behavior.
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { loadFreshIMessageReplyCacheForTest } from "./test-support/runtime.js";
+import {
+  IMESSAGE_REPLY_CACHE_COUNTER_KEY,
+  IMESSAGE_REPLY_CACHE_COUNTER_MAX_ENTRIES,
+  IMESSAGE_REPLY_CACHE_COUNTER_NAMESPACE,
+  IMESSAGE_REPLY_CACHE_MAX_ENTRIES,
+  IMESSAGE_REPLY_CACHE_NAMESPACE,
+  IMESSAGE_REPLY_CACHE_TTL_MS,
+  resolveIMessageReplyCacheEntryKey,
+} from "./state-contract.js";
+import {
+  createIMessagePluginStateSyncStoreForTest,
+  loadFreshIMessageReplyCacheForTest,
+} from "./test-support/runtime.js";
 
 type ReplyCacheModule = typeof import("./monitor-reply-cache.js");
 let findLatestIMessageEntryForChat: ReplyCacheModule["findLatestIMessageEntryForChat"];
@@ -329,7 +341,7 @@ describe("findLatestIMessageEntryForChat", () => {
   });
 });
 
-describe("hydrate-on-resolve (post-restart short-id persistence)", () => {
+describe("SQLite reply-cache hydration", () => {
   it("hydrates SQLite state before resolving a short id whose mapping predates this run", async () => {
     // Issue-then-restart contract: a shortId we issued before a gateway
     // restart must still resolve afterwards. The first resolve call after
@@ -380,6 +392,58 @@ describe("hydrate-on-resolve (post-restart short-id persistence)", () => {
       }),
     ).toBe("guid-with-undefined-optionals");
   });
+
+  it.each([
+    { name: "missing", counter: undefined },
+    { name: "lagging", counter: 6 },
+  ])(
+    "allocates above live SQLite short ids with a $name counter after reload",
+    async ({ counter }) => {
+      const context = { accountId: "default", chatId: 42, timestamp: Date.now() };
+      const entries = [
+        { shortId: "1", messageId: "00000000-0000-4000-8000-000000000001" },
+        { shortId: "7", messageId: "00000000-0000-4000-8000-000000000007" },
+      ];
+      const store = createIMessagePluginStateSyncStoreForTest<
+        ReturnType<ReplyCacheModule["rememberIMessageReplyCache"]>
+      >({
+        namespace: IMESSAGE_REPLY_CACHE_NAMESPACE,
+        maxEntries: IMESSAGE_REPLY_CACHE_MAX_ENTRIES,
+      });
+      for (const entry of entries) {
+        store.register(
+          resolveIMessageReplyCacheEntryKey(entry.messageId),
+          { ...context, ...entry },
+          {
+            ttlMs: IMESSAGE_REPLY_CACHE_TTL_MS,
+          },
+        );
+      }
+      if (counter !== undefined) {
+        createIMessagePluginStateSyncStoreForTest<{ counter: number }>({
+          namespace: IMESSAGE_REPLY_CACHE_COUNTER_NAMESPACE,
+          maxEntries: IMESSAGE_REPLY_CACHE_COUNTER_MAX_ENTRIES,
+        }).register(IMESSAGE_REPLY_CACHE_COUNTER_KEY, { counter });
+      }
+
+      await loadReplyCache({ preservePersistentState: true });
+
+      // Allocate first so a resolver cannot pre-hydrate the cache.
+      const issued = rememberIMessageReplyCache({
+        ...context,
+        messageId: "00000000-0000-4000-8000-000000000008",
+      });
+      expect(issued.shortId).toBe("8");
+      for (const entry of [...entries, issued]) {
+        expect(
+          resolveIMessageMessageId(entry.shortId, {
+            requireKnownShortId: true,
+            chatContext: { chatId: context.chatId },
+          }),
+        ).toBe(entry.messageId);
+      }
+    },
+  );
 
   it("does not reuse short ids after cached rows expire", async () => {
     vi.useFakeTimers();
@@ -513,27 +577,5 @@ describe("current-message chat binding", () => {
         chatContext: { chatId: 42 },
       }),
     ).toBe(false);
-  });
-});
-
-describe("hydrate counter advancement (rowid-collision protection)", () => {
-  it("advances the short-id counter past a corrupt persisted line so new allocations don't collide", () => {
-    // Direct hydrate isn't easy to invoke without disk fixtures; instead
-    // verify the public contract: after rememberIMessageReplyCache fires,
-    // the next allocation never re-uses an existing live shortId.
-    const a = rememberIMessageReplyCache({
-      accountId: "default",
-      messageId: "msg-a",
-      chatIdentifier: "+12069106512",
-      timestamp: Date.now(),
-    });
-    const b = rememberIMessageReplyCache({
-      accountId: "default",
-      messageId: "msg-b",
-      chatIdentifier: "+12069106512",
-      timestamp: Date.now(),
-    });
-    expect(a.shortId).not.toBe(b.shortId);
-    expect(Number.parseInt(b.shortId, 10)).toBeGreaterThan(Number.parseInt(a.shortId, 10));
   });
 });


### PR DESCRIPTION
## What Problem This Solves

Maintainer-requested test audit: the iMessage reply-cache test named “advances the short-id counter past a corrupt persisted line so new allocations don't collide” only allocated two valid entries in one process. It neither seeded persisted state nor reloaded the cache, and still passed when live-row counter recovery was removed.

This corrects a misleading coverage claim; it does not claim to fix a runtime corruption defect.

## Why This Change Was Made

Replace that case with two table-driven tests at the existing SQLite/cache boundary. Seed live short IDs `1` and `7`, leave the durable counter missing or lagging at `6`, reload the cache, and make allocation the first cache operation. Require the new ID to be `8` and verify that the old and new IDs still resolve to their respective GUIDs.

Reuse the existing isolated SQLite store and module-reload facilities. Retain the resolve-first, undefined-optionals serialization, and expiry/counter tests because they protect different regressions. No production seam, JSONL runtime reader, schema, retention, or persistence change. The startup import-boundary split is separate and untouched.

Related history: [the iMessage monitor-state SQLite migration](https://github.com/openclaw/openclaw/pull/88797) retained the old test while introducing the current durable-counter/live-row recovery contract.

## User Impact

No runtime or user-visible behavior change. Maintainers gain meaningful protection against short-ID reuse after restart when the separate counter row is missing or behind live mappings.

Production LOC: **+0/-0**. Test support: **+0/-0**. Tests: **+66/-24** (one file).

AI-assisted; implementation and behavior were reviewed by the maintainer's agent.

## Evidence

Focused cache and migration proof, rerun after completing the worktree dependency install: **36 tests passed**.

```bash
node scripts/run-vitest.mjs extensions/imessage/src/monitor-reply-cache.test.ts extensions/imessage/src/state-migrations.test.ts
```

Baseline cache plus keyed-store/expiry/fresh-store contracts: **27 cache tests and 49 keyed-store tests passed**.

```bash
node scripts/run-vitest.mjs extensions/imessage/src/monitor-reply-cache.test.ts src/plugin-state/plugin-state-store.test.ts src/plugin-state/plugin-state-store.expiry.test.ts src/plugin-state/plugin-state-store.fresh-store.test.ts
```

Mutation sensitivity was checked using disposable copies only, removing exactly the live-row counter-max scan while keeping counter lookup and mapping hydration intact:

| Test against runtime | Observed result |
| --- | --- |
| Original misleading test against mutant | Passed |
| Replacement cases against the same mutant | Both failed at allocation: received `1` and `7`, expected `8` |
| Replacement cases against unchanged runtime | Both passed, including retained GUID mappings |

Original runtime/support files remained byte-identical, and all disposable copies were removed. A preliminary name filter selected zero cases; that run was rejected as proof, the filter corrected, and the complete comparison repeated successfully.

Complete changed gate, including extension-test types, targeted lint, formatting, guards, and all three dead-export scans: **passed**.

```bash
node scripts/check-changed.mjs -- extensions/imessage/src/monitor-reply-cache.test.ts
```

The first gate attempt hit unrelated Bedrock type errors in an incomplete worktree dependency install. A frozen-lockfile install restored the existing pinned dependencies; the exact typecheck and complete changed gate then passed with no source or lockfile changes. `git diff --check` also passed.

Fresh pre-commit Codex autoreview: **scoped-clean**, no accepted/actionable findings at the workflow's default P0 priority. The reviewer inspected the final test diff with the unchanged runtime, test-helper, state-contract, and keyed-store source; it did not execute tests itself.

Proof scope is real isolated SQLite and cache reloads, not a live Messages flow. No real Messages or operator state was accessed. No UI or runtime behavior changed.
