### PR TITLE
fix(runtime): preserve active user turn for local models

### DIFF
--- a/src/agents/embedded-agent-runner/run/attempt-session-boundary.runtime-context.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-session-boundary.runtime-context.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it, vi } from "vitest";
+import { OPENCLAW_RUNTIME_CONTEXT_CUSTOM_TYPE } from "../../internal-runtime-context.js";
+import type { AgentMessage } from "../../runtime/index.js";
+import type { guardSessionManager } from "../../session-tool-result-guard-wrapper.js";
+import type { AgentSession } from "../../sessions/index.js";
+import { prepareEmbeddedAttemptSessionBoundary } from "./attempt-session-prepare.js";
+
+function createActiveSession() {
+  const convertToLlm = vi.fn((input: AgentMessage[]) => input as never);
+  const activeSession = {
+    agent: {
+      reset: vi.fn(),
+      state: { messages: [] },
+      convertToLlm,
+    },
+  } as unknown as Pick<AgentSession, "agent">;
+  return { activeSession, convertToLlm };
+}
+
+function createSessionManager(): ReturnType<typeof guardSessionManager> {
+  return {
+    getLeafEntry: () => undefined,
+  } as unknown as ReturnType<typeof guardSessionManager>;
+}
+
+function runtimeContextCarrier(): AgentMessage {
+  return {
+    role: "custom",
+    customType: OPENCLAW_RUNTIME_CONTEXT_CUSTOM_TYPE,
+    content: "runtime context",
+    timestamp: 1,
+  } as AgentMessage;
+}
+
+function activeUser(): AgentMessage {
+  return {
+    role: "user",
+    content: [{ type: "text", text: "Reply exactly: PONG" }],
+    timestamp: 2,
+  } as AgentMessage;
+}
+
+async function convertWithModel(model: Record<string, unknown>) {
+  const { activeSession } = createActiveSession();
+  prepareEmbeddedAttemptSessionBoundary({
+    activeSession,
+    attempt: {
+      model: model as never,
+      prompt: "Reply exactly: PONG",
+      trigger: "user",
+    },
+    getUserTranscriptContexts: () => undefined,
+    isRawModelRun: false,
+    preparedUserTurnMessage: undefined,
+    sessionManager: createSessionManager(),
+    setActiveSessionSystemPrompt: vi.fn(),
+  });
+
+  return await activeSession.agent.convertToLlm([runtimeContextCarrier(), activeUser()]);
+}
+
+describe("runtime-context carrier placement at the LLM boundary", () => {
+  it("keeps the carrier before the active user for native Ollama", async () => {
+    const converted = await convertWithModel({
+      api: "ollama",
+      provider: "ollama",
+      id: "gpt-oss:20b",
+      baseUrl: "http://127.0.0.1:11434",
+    });
+
+    expect(converted.map((message) => message.role)).toEqual(["custom", "user"]);
+  });
+
+  it("keeps the carrier before the active user for local OpenAI-compatible models", async () => {
+    const converted = await convertWithModel({
+      api: "openai-completions",
+      provider: "local",
+      id: "gpt-oss:20b",
+      baseUrl: "http://127.0.0.1:11434/v1",
+      compat: {},
+    });
+
+    expect(converted.map((message) => message.role)).toEqual(["custom", "user"]);
+  });
+
+  it("keeps tail placement for OpenAI-compatible models with prompt-cache capability", async () => {
+    const converted = await convertWithModel({
+      api: "openai-completions",
+      provider: "custom-cache",
+      id: "cached-model",
+      baseUrl: "https://example.invalid/v1",
+      compat: { supportsPromptCacheKey: true },
+    });
+
+    expect(converted.map((message) => message.role)).toEqual(["user", "custom"]);
+  });
+});

--- a/src/agents/embedded-agent-runner/run/attempt-session-prepare.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-session-prepare.ts
@@ -22,6 +22,7 @@ import { sanitizeCompactionReplayMessages } from "../../compaction-replay.js";
 import { resolveUserTimezone } from "../../date-time.js";
 import { bootstrapHarnessContextEngine } from "../../harness/context-engine-lifecycle.js";
 import { relocateCurrentRuntimeContextCarrierToTail } from "../../internal-runtime-context.js";
+import { resolveProviderRequestCapabilities } from "../../provider-attribution.js";
 import type { AgentMessage } from "../../runtime/index.js";
 import { guardSessionManager } from "../../session-tool-result-guard-wrapper.js";
 import {
@@ -281,11 +282,46 @@ type SessionBoundaryAttempt = Pick<
   | "suppressNextUserMessagePersistence"
   | "trigger"
   | "userTurnTranscriptRecorder"
->;
+> & {
+  model?: EmbeddedRunAttemptParams["model"];
+};
 
 type LlmBoundaryOptions = NonNullable<Parameters<typeof normalizeMessagesForLlmBoundary>[1]>;
 
 type CurrentUserTimestampOverride = NonNullable<LlmBoundaryOptions["currentUserTimestampOverride"]>;
+
+function shouldRelocateRuntimeContextCarrierToTail(attempt: SessionBoundaryAttempt): boolean {
+  const model = attempt.model;
+  if (!model) {
+    return true;
+  }
+  const route = resolveProviderRequestCapabilities({
+    provider: model.provider,
+    api: model.api,
+    baseUrl: model.baseUrl,
+    modelId: model.id,
+    compat: model.compat,
+    transport: "stream",
+    capability: "llm",
+  });
+  // Native Ollama and other local endpoints have no provider-side prompt-cache
+  // breakpoint to protect, and local models may treat the carrier as the latest
+  // user request when it is moved to the absolute tail.
+  if (model.api === "ollama" || route.endpointClass === "local") {
+    return false;
+  }
+  if (model.api !== "openai-completions") {
+    return true;
+  }
+  const compat = model.compat as
+    | { supportsPromptCacheKey?: boolean; cacheControlFormat?: "anthropic" }
+    | undefined;
+  return (
+    compat?.supportsPromptCacheKey === true ||
+    compat?.cacheControlFormat === "anthropic" ||
+    route.isKnownNativeEndpoint
+  );
+}
 
 export function prepareEmbeddedAttemptSessionBoundary(input: {
   activeSession: Pick<AgentSession, "agent">;
@@ -368,14 +404,18 @@ export function prepareEmbeddedAttemptSessionBoundary(input: {
 
   if (typeof activeSession.agent.convertToLlm === "function") {
     const baseConvertToLlm = activeSession.agent.convertToLlm.bind(activeSession.agent);
-    activeSession.agent.convertToLlm = async (messages) =>
-      await baseConvertToLlm(
-        // Wire-only relocation keeps the request append-only through the active
-        // user turn without changing position-sensitive precheck normalization.
-        relocateCurrentRuntimeContextCarrierToTail(
-          normalizeMessagesForLlmBoundary(messages, buildBoundaryOptions()),
-        ),
+    const relocateRuntimeContextCarrier = shouldRelocateRuntimeContextCarrierToTail(attempt);
+    activeSession.agent.convertToLlm = async (messages) => {
+      const normalizedMessages = normalizeMessagesForLlmBoundary(messages, buildBoundaryOptions());
+      return await baseConvertToLlm(
+        // Tail placement exists to keep cache-capable transports append-only through
+        // the active user turn. Local transports without that cache contract keep
+        // the carrier immediately before the active user request instead.
+        relocateRuntimeContextCarrier
+          ? relocateCurrentRuntimeContextCarrierToTail(normalizedMessages)
+          : normalizedMessages,
       );
+    };
   }
 
   return {


### PR DESCRIPTION
Fixes #132597

## What Problem This Solves

Messaging-channel runtime context is carried in a transient custom message that is converted to a user-role provider message. The LLM boundary moved that carrier to the absolute tail for prompt-cache stability, which makes local models such as native Ollama treat internal runtime metadata as the latest user request instead of the visible message.

## What Changed

- keep the runtime-context carrier immediately before the active user turn for native Ollama and local endpoints;
- use the existing provider endpoint/capability classifier instead of a provider-name allowlist;
- preserve tail placement for known native cloud routes and OpenAI-compatible endpoints that explicitly advertise prompt-cache support;
- add regression coverage for native Ollama, local OpenAI-compatible models, and a cache-capable compatible endpoint.

## Scope

No config, transcript, persistence, or provider-name routing changes.

## Validation

The branch includes focused LLM-boundary regression coverage and is based on current upstream `main`.

Upstream CI should run the full repository checks once the PR is opened.
