### PR TITLE
fix(signal): inline external-native outbound attachments

### DIFF
--- a/extensions/signal/src/client-container.ts
+++ b/extensions/signal/src/client-container.ts
@@ -555,10 +555,13 @@ export async function streamContainerEvents(params: {
 }
 
 /**
- * Convert local file paths to base64 data URIs for the container REST API.
- * The bbernhard container /v2/send only accepts `base64_attachments` (not file paths).
+ * Convert local file paths to base64 data URIs for transports that accept
+ * inline bytes (bbernhard container REST and native signal-cli JSON-RPC).
+ * The bbernhard container /v2/send only accepts `base64_attachments` (not file
+ * paths); native signal-cli accepts data URIs per RFC 2397, which removes the
+ * shared-filesystem assumption when the daemon runs under a different uid.
  */
-async function filesToBase64DataUris(
+export async function filesToBase64DataUris(
   filePaths: string[],
   maxAttachmentBytes: number,
 ): Promise<string[]> {

--- a/extensions/signal/src/media-access.test.ts
+++ b/extensions/signal/src/media-access.test.ts
@@ -15,6 +15,14 @@ const SIGNAL_IMAGE = Buffer.from(
   "base64",
 );
 
+function resolveTestOutboundAttachment(attachment: string): Promise<Buffer> {
+  const base64Marker = ";base64,";
+  if (attachment.startsWith("data:") && attachment.includes(base64Marker)) {
+    return Promise.resolve(Buffer.from(attachment.split(base64Marker)[1] ?? "", "base64"));
+  }
+  return fs.readFile(attachment);
+}
+
 type SignalMediaContext = {
   cfg: OpenClawConfig;
   to: string;
@@ -94,10 +102,10 @@ describe("Signal host-owned outbound media access", () => {
       request.on("end", () => {
         void (async () => {
           const envelope = JSON.parse(Buffer.concat(chunks).toString("utf8")) as SignalRpcEnvelope;
-          const attachmentPath = envelope.params?.attachments?.[0];
+          const attachment = envelope.params?.attachments?.[0];
           requests.push({
             envelope,
-            attachment: attachmentPath ? await fs.readFile(attachmentPath) : undefined,
+            attachment: attachment ? await resolveTestOutboundAttachment(attachment) : undefined,
           });
           response.writeHead(200, { "content-type": "application/json" });
           response.end(

--- a/extensions/signal/src/send.test.ts
+++ b/extensions/signal/src/send.test.ts
@@ -10,9 +10,17 @@ const resolveOutboundAttachmentFromUrlMock = vi.hoisted(() =>
     contentType: "image/png",
   })),
 );
+const filesToBase64DataUrisMock = vi.hoisted(() =>
+  vi.fn(async (..._args: unknown[]) => ["data:image/png;filename=image.png;base64,aGVsbG8="]),
+);
 
 vi.mock("./client-adapter.js", () => ({
   signalRpcRequest: (...args: unknown[]) => signalRpcRequestMock(...args),
+}));
+
+vi.mock("./client-container.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./client-container.js")>()),
+  filesToBase64DataUris: (...args: unknown[]) => filesToBase64DataUrisMock(...args),
 }));
 
 vi.mock("openclaw/plugin-sdk/media-runtime", async () => {
@@ -50,6 +58,7 @@ describe("sendMessageSignal receipts", () => {
     clearSignalApprovalReactionTargetsForTest();
     signalRpcRequestMock.mockReset();
     resolveOutboundAttachmentFromUrlMock.mockClear();
+    filesToBase64DataUrisMock.mockClear();
   });
 
   it("routes a named container account across send, typing, and receipt RPCs", async () => {
@@ -205,9 +214,13 @@ describe("sendMessageSignal receipts", () => {
       maxBytes,
       expect.objectContaining({ localRoots: ["/tmp"] }),
     );
+    expect(filesToBase64DataUrisMock).toHaveBeenCalledWith(["/tmp/image.png"], maxBytes);
     expect(signalRpcRequestMock).toHaveBeenCalledWith(
       "send",
-      expect.objectContaining({ attachments: ["/tmp/image.png"], message: "" }),
+      expect.objectContaining({
+        attachments: ["data:image/png;filename=image.png;base64,aGVsbG8="],
+        message: "",
+      }),
       expect.objectContaining({ maxAttachmentBytes: maxBytes }),
     );
     expect(result.messageId).toBe("1234567891");
@@ -545,17 +558,18 @@ describe("sendMessageSignal receipts", () => {
     });
 
     expect(resolveOutboundAttachmentFromUrlMock).toHaveBeenCalled();
+    expect(filesToBase64DataUrisMock).toHaveBeenCalledWith(["/tmp/image.png"], expect.any(Number));
     expect(signalRpcRequestMock).toHaveBeenCalledTimes(2);
     expect(signalRpcRequestMock.mock.calls[0]?.[1]).toEqual(
       expect.objectContaining({
-        attachments: ["/tmp/image.png"],
+        attachments: ["data:image/png;filename=image.png;base64,aGVsbG8="],
         quoteTimestamp: 1700000000001,
         quoteAuthor: "+15550002222",
       }),
     );
     expect(signalRpcRequestMock.mock.calls[1]?.[1]).toEqual(
       expect.objectContaining({
-        attachments: ["/tmp/image.png"],
+        attachments: ["data:image/png;filename=image.png;base64,aGVsbG8="],
         message: "caption",
       }),
     );

--- a/extensions/signal/src/send.ts
+++ b/extensions/signal/src/send.ts
@@ -20,6 +20,7 @@ import {
 } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { resolveSignalAccount } from "./accounts.js";
 import { signalRpcRequest, type SignalTransportKind } from "./client-adapter.js";
+import { filesToBase64DataUris } from "./client-container.js";
 import { markdownToSignalText, type SignalTextStyleRange } from "./format.js";
 import { normalizeSignalMessagingTarget } from "./normalize.js";
 import { registerSignalReplyContext } from "./reply-authors.js";
@@ -324,7 +325,14 @@ export async function sendMessageSignal(
       localRoots: opts.mediaLocalRoots,
       readFile: opts.mediaReadFile,
     });
-    attachments = [resolved.path];
+    const transportKind = opts.transportKind ?? accountInfo.transport.kind;
+    // External-native signal-cli may run as a separate service user and cannot
+    // traverse the gateway-owned 0700 outbound media directory. Carry the
+    // already-authorized bytes over JSON-RPC instead of exposing a local path.
+    attachments =
+      transportKind === "external-native"
+        ? await filesToBase64DataUris([resolved.path], maxBytes)
+        : [resolved.path];
     outboundMedia = {
       contentType: resolved.contentType,
       kind: kindFromMime(resolved.contentType ?? undefined) ?? "unknown",


### PR DESCRIPTION
Fixes #123815

## What Problem This Solves

An externally managed signal-cli daemon can run under a different OS user than the OpenClaw gateway. Outbound media is staged inside the gateway-owned media directory, which is private, so passing that filesystem path to the daemon can fail with `AttachmentInvalidException` even though the attachment was already validated.

## What Changed

- reuse Signal's existing bounded file-to-data-URI encoder;
- inline outbound attachments only for `external-native` transport so the bytes cross the existing JSON-RPC connection;
- keep managed-native and container send-boundary behavior unchanged;
- update Signal media-access and send regressions to cover inline delivery and native quote fallback.

## Scope

No config, schema, daemon lifecycle, or shared media-store permission changes.

## Validation

The branch includes focused Signal regression coverage and is based on current upstream `main`.

A live different-UID signal-cli daemon remains the strongest end-to-end proof; upstream CI should run the extension checks once the PR is opened.
