### PR TITLE
test: honor explicit live profile credential mode

### DIFF
--- a/src/agents/live-test-helpers.test.ts
+++ b/src/agents/live-test-helpers.test.ts
@@ -3,7 +3,6 @@ import { describe, expect, it } from "vitest";
 import {
   isLiveProfileKeyModeEnabled,
   isLiveTestEnabled,
-  requiresLiveProfileCredential,
   resolveLiveCredentialPrecedence,
 } from "./live-test-helpers.js";
 
@@ -30,16 +29,12 @@ describe("isLiveProfileKeyModeEnabled", () => {
 
 describe("live credential precedence", () => {
   it("uses profile-first auth for OpenAI even when the global live mode is env-first", () => {
-    // OpenAI live tests exercise profile auth by default so registry/provider
-    // routing matches normal agent execution instead of raw env-only calls.
+    // Prefer stored OpenAI profiles without excluding the documented env fallback.
     expect(resolveLiveCredentialPrecedence("openai", false)).toBe("profile-first");
-    expect(requiresLiveProfileCredential("openai", false)).toBe(true);
   });
 
   it("keeps env-first auth for normal providers unless profile keys are required", () => {
     expect(resolveLiveCredentialPrecedence("anthropic", false)).toBe("env-first");
     expect(resolveLiveCredentialPrecedence("anthropic", true)).toBe("profile-first");
-    expect(requiresLiveProfileCredential("anthropic", false)).toBe(false);
-    expect(requiresLiveProfileCredential("anthropic", true)).toBe(true);
   });
 });

--- a/src/agents/live-test-helpers.ts
+++ b/src/agents/live-test-helpers.ts
@@ -16,22 +16,12 @@ export type CompleteSimpleContent<TApi extends Api = Api> = Awaited<
   ReturnType<typeof completeSimple<TApi>>
 >["content"];
 
-/** Return whether a provider requires profile credentials in the current live mode. */
-export function requiresLiveProfileCredential(
-  provider: string,
-  requireProfileKeys: boolean,
-): boolean {
-  return requireProfileKeys || provider === "openai";
-}
-
 /** Resolve whether profile or env credentials should be tried first. */
 export function resolveLiveCredentialPrecedence(
   provider: string,
   requireProfileKeys: boolean,
 ): "profile-first" | "env-first" {
-  return requiresLiveProfileCredential(provider, requireProfileKeys)
-    ? "profile-first"
-    : "env-first";
+  return requireProfileKeys || provider === "openai" ? "profile-first" : "env-first";
 }
 
 /** Write a namespaced live-test progress line to stderr. */

--- a/src/agents/models.profiles.live.test.ts
+++ b/src/agents/models.profiles.live.test.ts
@@ -27,7 +27,6 @@ import {
   isLiveProfileKeyModeEnabled,
   isLiveTestEnabled,
   readLiveTestConfig,
-  requiresLiveProfileCredential,
   resolveLiveCredentialPrecedence,
 } from "./live-test-helpers.js";
 import { shouldSkipLiveProviderDrift } from "./live-test-provider-drift.js";
@@ -1802,10 +1801,7 @@ describeLive("live models (profile keys)", () => {
             cfg,
             requireProfileKeys: REQUIRE_PROFILE_KEYS,
           });
-          if (
-            requiresLiveProfileCredential(model.provider, REQUIRE_PROFILE_KEYS) &&
-            !apiKeyInfo.source.startsWith("profile:")
-          ) {
+          if (REQUIRE_PROFILE_KEYS && !apiKeyInfo.source.startsWith("profile:")) {
             skipped.push({
               model: id,
               reason: `non-profile credential source: ${apiKeyInfo.source}`,

--- a/src/agents/openai-reasoning-compat.live.test.ts
+++ b/src/agents/openai-reasoning-compat.live.test.ts
@@ -12,7 +12,6 @@ import {
   isLiveProfileKeyModeEnabled,
   isLiveTestEnabled,
   logLiveProgress,
-  requiresLiveProfileCredential,
   readLiveTestConfig,
   resolveLiveCredentialPrecedence,
 } from "./live-test-helpers.js";
@@ -131,10 +130,7 @@ describeLive("openai reasoning compat live", () => {
         return;
       }
 
-      if (
-        requiresLiveProfileCredential(model.provider, REQUIRE_PROFILE_KEYS) &&
-        !apiKeyInfo.source.startsWith("profile:")
-      ) {
+      if (REQUIRE_PROFILE_KEYS && !apiKeyInfo.source.startsWith("profile:")) {
         logProgress(
           `[openai-reasoning-compat] skip (non-profile credential source: ${apiKeyInfo.source})`,
         );
@@ -191,10 +187,7 @@ describeLive("openai reasoning compat live", () => {
         return;
       }
 
-      if (
-        requiresLiveProfileCredential(model.provider, REQUIRE_PROFILE_KEYS) &&
-        !apiKeyInfo.source.startsWith("profile:")
-      ) {
+      if (REQUIRE_PROFILE_KEYS && !apiKeyInfo.source.startsWith("profile:")) {
         logProgress(
           `[openai-reasoning-compat] skip (non-profile credential source: ${apiKeyInfo.source})`,
         );

--- a/src/agents/tool-replay-repair.live.test.ts
+++ b/src/agents/tool-replay-repair.live.test.ts
@@ -15,7 +15,6 @@ import {
   isLiveProfileKeyModeEnabled,
   isLiveTestEnabled,
   logLiveProgress,
-  requiresLiveProfileCredential,
   readLiveTestConfig,
   resolveLiveCredentialPrecedence,
   type CompleteSimpleContent,
@@ -274,10 +273,7 @@ describeLive("tool replay repair live", () => {
           return;
         }
 
-        if (
-          requiresLiveProfileCredential(model.provider, REQUIRE_PROFILE_KEYS) &&
-          !apiKeyInfo.source.startsWith("profile:")
-        ) {
+        if (REQUIRE_PROFILE_KEYS && !apiKeyInfo.source.startsWith("profile:")) {
           logProgress(
             `[tool-replay-repair] skip ${target.ref} (non-profile credential source: ${apiKeyInfo.source})`,
           );
@@ -387,10 +383,7 @@ describeLive("tool replay repair live", () => {
           return;
         }
 
-        if (
-          requiresLiveProfileCredential(model.provider, REQUIRE_PROFILE_KEYS) &&
-          !apiKeyInfo.source.startsWith("profile:")
-        ) {
+        if (REQUIRE_PROFILE_KEYS && !apiKeyInfo.source.startsWith("profile:")) {
           logProgress(
             `[tool-replay-repair] skip ${target.ref} (non-profile credential source: ${apiKeyInfo.source})`,
           );

--- a/src/gateway/gateway-models.profiles.live.test.ts
+++ b/src/gateway/gateway-models.profiles.live.test.ts
@@ -41,7 +41,6 @@ import {
   isLiveProfileKeyModeEnabled,
   isLiveTestEnabled,
   readLiveTestConfig,
-  requiresLiveProfileCredential,
   resolveLiveCredentialPrecedence,
 } from "../agents/live-test-helpers.js";
 import { shouldSkipLiveProviderDrift } from "../agents/live-test-provider-drift.js";
@@ -2864,7 +2863,10 @@ function buildLiveGatewayAuthProfileStore(params: {
         );
       }
     } else if (
-      !requiresLiveProfileCredential(provider, params.requireProfileKeys ?? REQUIRE_PROFILE_KEYS)
+      resolveLiveCredentialPrecedence(
+        provider,
+        params.requireProfileKeys ?? REQUIRE_PROFILE_KEYS,
+      ) === "env-first"
     ) {
       if (auth.mode !== "aws-sdk") {
         if (!auth.apiKey) {


### PR DESCRIPTION
## What Problem This Solves

Full release verification discovered four runnable OpenAI API models but rejected every one before making a request because their credentials came from `OPENAI_API_KEY`. The direct live suites incorrectly treated OpenAI's preference for stored profiles as a requirement to use profiles exclusively.

## Why This Change Was Made

Separate credential precedence from the existing explicit profile-only mode. OpenAI still tries stored profiles first; all three direct live suites enforce profile-only credentials only when `OPENCLAW_LIVE_REQUIRE_PROFILE_KEYS=1`. Remove the redundant requirement helper and preserve the Gateway fixture's exact profile-materialization behavior through the existing precedence helper.

The subscription-only exception originated in `6930538500ed` for `openai-codex`; provider unification in `4c33aaa86c16` (#88451) broadened it to all `openai` models. The documented direct-model contract already allows profile-store credentials and environment fallbacks by default. Production model authentication continues to check the selected model API and reject API keys for subscription transport, or subscription credentials for the platform API. No production authentication, model routing, retry, timeout, or completion assertion changes.

## User Impact

Internal verification repair only. The environment-only Docker lane now exercises actual completions instead of rejecting its own supported credential source. Explicit profile-only mode and Gateway credential ownership/conflict checks remain intact. No changelog entry is needed.

## Evidence

Before: [frozen release job 99111575056](https://github.com/openclaw/openclaw/actions/runs/33256261564/job/99111575056), source `d9fe780239a2cb7158aad437112156605e8d375c`, passed 36 offline cases and then rejected all four selected OpenAI models as non-profile credentials.

After: one [Blacksmith Testbox](https://github.com/openclaw/openclaw/actions/runs/33259081440), with the same frozen source plus exactly these six files:

- Original Docker model command and limits: 37 tests passed; all four selected OpenAI models completed real requests. Test-file duration 15.53 seconds. The existing 45-second per-model timeout and completion assertions were unchanged.
- Negative control: the same Docker command with `OPENCLAW_LIVE_REQUIRE_PROFILE_KEYS=1` failed with the expected non-profile rejection for all four models.
- Credential helpers: 5 passed. Production model-auth profile regressions: 86 passed, including transport/auth-class rejection and configured agent scope.
- Gateway profile-store preparation: 11 passed; 155 unrelated cases excluded by the explicit test-name filter.
- Full required changed-file gate passed on the clean Linux dependency tree, including core and core-test type checks, lint, and guards. All 35,135 tracked source bytes/modes were checked before and after both proof commands against the frozen base plus this patch.
- Local helper tests also passed. The local full gate encountered 12 unrelated type errors from the shared checkout's different dependency versions; that shared install was left untouched, and the complete gate was repeated successfully on the isolated frozen Linux tree.
- Independent source review and configured isolated Codex autoreview found no actionable findings (autoreview scope: P0).

Direct dependency inspection: Codex `rust-v0.150.1` / `90854393966b` authentication and provider selection in `codex-rs/model-provider-info/src/lib.rs:139`, `:290`, and `codex-rs/model-provider/src/auth.rs:125`; OpenClaw's model-auth owner remains unchanged.

Production runtime LOC: +0/-0. Tests and test support: +11/-42 (net -31). No new configuration, dependencies, or public API.
