### PR TITLE
fix: reduce first Grok web search startup delay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Grok web search startup:** avoid loading the full agent runtime before the first search, while preserving agent-scoped credentials and OAuth fallback behavior.
 - Gateway/subagents: keep plugin completion turns bound to the owning Gateway runtime so successful native subagents can finish delivery without losing the published reply runtime.
 - **Upgrade config repair:** retain plugin-owned channel configuration migrations alongside core schemas so `doctor --fix` can repair older settings before an external plugin is installed or granted capabilities, while preserving installed-plugin ownership and state-migration boundaries.
 

--- a/extensions/xai/src/web-search-provider.runtime.ts
+++ b/extensions/xai/src/web-search-provider.runtime.ts
@@ -1,5 +1,4 @@
 // Xai provider module implements model/runtime integration.
-import { resolveDefaultAgentDir } from "openclaw/plugin-sdk/agent-runtime";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import {
   coerceSecretRef,
@@ -217,12 +216,10 @@ async function resolveXaiProviderAuthCredential(params: {
 }): Promise<XaiResolvedWebSearchAuth | undefined> {
   try {
     const config = params.config as OpenClawConfig | undefined;
-    const agentDir =
-      params.agentDir?.trim() || (config ? resolveDefaultAgentDir(config) : undefined);
     const resolved = await resolveApiKeyForProvider({
       provider: XAI_PROVIDER_ID,
       cfg: config,
-      ...(agentDir ? { agentDir } : {}),
+      agentDir: params.agentDir,
       ...(params.profileId
         ? {
             profileId: params.profileId,

--- a/extensions/xai/web-search.test.ts
+++ b/extensions/xai/web-search.test.ts
@@ -21,6 +21,10 @@ const providerAuthMocks = vi.hoisted(() => ({
   listUsableProviderAuthProfileIds: vi.fn(() => ({ agentDir: "", profileIds: [] as string[] })),
 }));
 
+vi.mock("openclaw/plugin-sdk/agent-runtime", () => {
+  throw new Error("xAI web search must not load the broad agent runtime");
+});
+
 vi.mock("openclaw/plugin-sdk/provider-auth", async (importOriginal) => {
   const original = await importOriginal<typeof import("openclaw/plugin-sdk/provider-auth")>();
   return {
@@ -146,12 +150,16 @@ function requireXaiWebSearchTool(
   return tool;
 }
 
+const defaultAgentConfig = {
+  agents: {
+    list: [{ id: "main", default: true, agentDir: "/tmp/openclaw-xai-main-agent" }],
+  },
+};
+
 function createAuthSearchTool() {
   return requireXaiWebSearchTool({
     config: {
-      agents: {
-        list: [{ id: "main", default: true, agentDir: "/tmp/openclaw-xai-main-agent" }],
-      },
+      ...defaultAgentConfig,
       tools: { web: { search: { provider: "grok" } } },
     },
   });
@@ -287,9 +295,7 @@ describe("xai web search config resolution", () => {
     const mockFetch = installXaiWebSearchFetch();
     const tool = requireXaiWebSearchTool({
       config: {
-        agents: {
-          list: [{ id: "main", default: true, agentDir: "/tmp/openclaw-xai-main-agent" }],
-        },
+        ...defaultAgentConfig,
         ...xaiPluginConfig({ webSearch: { apiKey: "configured-xai-key" } }),
       },
     });
@@ -299,7 +305,7 @@ describe("xai web search config resolution", () => {
     expect(providerAuthRuntimeMocks.resolveApiKeyForProvider).toHaveBeenCalledWith(
       expect.objectContaining({
         provider: "xai",
-        agentDir: "/tmp/openclaw-xai-main-agent",
+        cfg: expect.objectContaining(defaultAgentConfig),
       }),
     );
     expect(fetchCallHeader(mockFetch, 0, "Authorization")).toBe("Bearer oauth-web-search-token");
@@ -364,7 +370,7 @@ describe("xai web search config resolution", () => {
       2,
       expect.objectContaining({
         provider: "xai",
-        agentDir: "/tmp/openclaw-xai-main-agent",
+        cfg: expect.objectContaining(defaultAgentConfig),
         profileId: "xai:default",
         lockedProfile: true,
         forceRefresh: true,
@@ -407,7 +413,7 @@ describe("xai web search config resolution", () => {
       3,
       expect.objectContaining({
         provider: "xai",
-        agentDir: "/tmp/openclaw-xai-main-agent",
+        cfg: expect.objectContaining(defaultAgentConfig),
         credentialPrecedence: "env-first",
       }),
     );
@@ -513,7 +519,7 @@ describe("xai web search config resolution", () => {
       2,
       expect.objectContaining({
         provider: "xai",
-        agentDir: "/tmp/openclaw-xai-main-agent",
+        cfg: expect.objectContaining(defaultAgentConfig),
         credentialPrecedence: "env-first",
       }),
     );


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the first Grok web search spends tens of seconds loading unrelated agent functionality before contacting xAI. The full release verification run at `d9fe780239a2cb7158aad437112156605e8d375c` exposed repeated Grok web-search timeouts; a separate same-order, six-case Linux diagnostic measured 52.35 seconds in the lazy runtime import and only 5.35 seconds in the successful HTTP request. The exact hosted timeout cause is not established by those measurements alone.

## Why This Change Was Made

The xAI web-search runtime imported the broad `agent-runtime` SDK barrel solely to calculate the default agent directory. The provider-auth owner already performs exactly that calculation before credential selection. Forward the caller's directory and existing config to that owner, removing both the broad import and duplicate policy.

OAuth preference, explicit agent selection, profile locking, refresh, API-key fallback, SecretRef handling, request deadlines, and test assertions remain intact. The regression guard rejects the unwanted runtime import; existing auth tests now verify config forwarding, while the canonical auth tests continue proving configured-agent selection. Production code is **net −3 lines**; tests are **net +6 lines**. There are no new config options, environment variables, retries, or timeouts.

## User Impact

The first Grok web search does less startup work and uses less memory. In the same six-test live sequence, the web-search case fell from 58.08 seconds to 9.58 seconds and peak process RSS fell from 3.40 GiB to 2.06 GiB. All six cases passed before and after; the already warm wrapped-tool path did not materially change.

## Evidence

- The new broad-import guard fails on the original code at `extensions/xai/src/web-search-provider.runtime.ts:2`; all 49 web-search owner tests pass after the repair.
- Real xAI requests used the original six tests, original order, assertions, 90-second testcase limits, and 60-second web request limit. Temporary timing/CPU instrumentation was removed, then the final source passed all six cases again: web search 10.57 seconds, whole file 65.93 seconds.
- Each Linux run checked all 35,135 Git-tracked files against the frozen base plus the exact patch before and after execution; no missing, different, or extra tracked source files were accepted.
- The local auth-owner shard passed 86 tests, including configured-agent profile selection, cooldown scope, and missing-auth diagnostics. The sibling xAI tool-auth file passed 21 tests. The combined Mac run was stopped during a later web-search module-initialization stall and is **not** claimed as a complete local pass.
- Full Linux build passed. Final owner/sibling tests passed **156/156**; the actual changed-scope gate passed, including production/test typechecking, lint, five doctor-contract tests, boundary guards, and runtime-cycle checks. Full source guards passed again after all checks.
- Independent Codex review found no actionable P0 issues. Exact PR-head CI remains required before landing.

This repair does not claim the frozen full release verification run is green, and it does not address that run's independent Workshop failure.
