### PR TITLE
feat(ollama): add GLM-5.3 and GLM-5.3-Flash to Ollama Cloud catalog with full thinking effort

### DIFF
--- a/extensions/ollama/index.test.ts
+++ b/extensions/ollama/index.test.ts
@@ -41,7 +41,8 @@ const buildOllamaModelDefinitionMock = vi.hoisted(() =>
   vi.fn((modelId: string, contextWindow?: number, capabilities?: string[]) => {
     const normalized = modelId.trim().toLowerCase();
     const isKnownCloudReasoningModel =
-      normalized === "glm-5.2:cloud" || /^deepseek-v4-(?:flash|pro):cloud$/.test(normalized);
+      /^glm-5\.[23](-flash)?:cloud$/.test(normalized) ||
+      /^deepseek-v4-(?:flash|pro):cloud$/.test(normalized);
     return {
       id: modelId,
       name: modelId,
@@ -2158,6 +2159,7 @@ describe("ollama plugin", () => {
       "kimi-k3",
       "glm-5.1",
       "glm-5.2",
+      "glm-5.3",
     ]);
     expect(result.provider.models).toEqual([
       expect.objectContaining({
@@ -2190,6 +2192,13 @@ describe("ollama plugin", () => {
       }),
       expect.objectContaining({
         id: "glm-5.2",
+        contextWindow: 1_000_000,
+        reasoning: true,
+        input: ["text"],
+        compat: { supportsTools: true, supportsUsageInStreaming: true },
+      }),
+      expect.objectContaining({
+        id: "glm-5.3",
         contextWindow: 1_000_000,
         reasoning: true,
         input: ["text"],

--- a/extensions/ollama/openclaw.plugin.json
+++ b/extensions/ollama/openclaw.plugin.json
@@ -250,6 +250,30 @@
             }
           },
           {
+            "id": "glm-5.3",
+            "reasoning": true,
+            "input": ["text"],
+            "contextWindow": 1000000,
+            "maxTokens": 8192,
+            "compat": {
+              "supportsTools": true,
+              "supportsUsageInStreaming": true,
+              "codeMode": "capable"
+            }
+          },
+          {
+            "id": "glm-5.3-flash",
+            "reasoning": true,
+            "input": ["text", "image"],
+            "contextWindow": 1000000,
+            "maxTokens": 8192,
+            "compat": {
+              "supportsTools": true,
+              "supportsUsageInStreaming": true,
+              "codeMode": "capable"
+            }
+          },
+          {
             "id": "gpt-oss:120b",
             "reasoning": true,
             "input": ["text"],

--- a/extensions/ollama/provider-policy-api.test.ts
+++ b/extensions/ollama/provider-policy-api.test.ts
@@ -121,7 +121,7 @@ describe("ollama provider policy public artifact", () => {
     });
   });
 
-  it.each(["glm-5.2", "deepseek-v4-pro:cloud"])(
+  it.each(["glm-5.2", "glm-5.3", "glm-5.3:cloud", "deepseek-v4-pro:cloud"])(
     "exposes full native effort for cloud model %s when lightweight projections omit metadata",
     (modelId) => {
       expect(resolveThinkingProfile({ provider: "ollama-cloud", modelId }).levels).toEqual([

--- a/extensions/ollama/src/defaults.ts
+++ b/extensions/ollama/src/defaults.ts
@@ -36,6 +36,11 @@ export const OLLAMA_CLOUD_DEFAULT_MODELS = [
     contextWindow: 1_000_000,
     capabilities: ["completion", "thinking", "tools"],
   },
+  {
+    id: "glm-5.3",
+    contextWindow: 1_000_000,
+    capabilities: ["completion", "thinking", "tools"],
+  },
 ] as const;
 
 /** Cloud models are referenced bare, `:cloud`-suffixed, and `-cloud`-suffixed. */

--- a/extensions/ollama/src/model-reasoning.ts
+++ b/extensions/ollama/src/model-reasoning.ts
@@ -5,5 +5,7 @@ export function supportsOllamaCloudFullThinkingEffort(modelId: string): boolean 
   // These hosted families accept low, medium, high, and max even when
   // lightweight catalog projections omit their reasoning metadata.
   const normalized = normalizeOllamaCloudModelId(modelId);
-  return normalized === "glm-5.2" || /^deepseek-v4-(?:flash|pro)$/.test(normalized);
+  return (
+    /^glm-5\.[23]$/.test(normalized) || /^deepseek-v4-(?:flash|pro)$/.test(normalized)
+  );
 }

--- a/extensions/ollama/src/provider-models.test.ts
+++ b/extensions/ollama/src/provider-models.test.ts
@@ -84,6 +84,8 @@ describe("ollama provider models", () => {
     const servedModels = [
       ["glm-5.1", 202_752, ["text"], true],
       ["glm-5.2", 1_000_000, ["text"], true],
+      ["glm-5.3", 1_000_000, ["text"], true],
+      ["glm-5.3-flash", 1_000_000, ["text", "image"], true],
       ["minimax-m2.7", 196_608, ["text"], true],
       ["deepseek-v4-flash", 1_048_576, ["text"], true],
       ["deepseek-v4-flash:0731", 1_048_576, ["text"], true],


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users selecting `ollama-cloud/glm-5.3` or `ollama-cloud/glm-5.3-flash` would silently lose native thinking-effort control and see the models missing from the built-in Ollama Cloud catalog.

GLM-5.3 and GLM-5.3-Flash are now served on Ollama Cloud (published ~2026-08-28), but:

- `supportsOllamaCloudFullThinkingEffort` only whitelists `glm-5.2` and `deepseek-v4-(flash|pro)`, so `/think max` on glm-5.3 falls back to the compatible `high` mapping instead of the native effort ladder (low/high/max per the model card).
- The plugin manifest catalog (`openclaw.plugin.json`) and `OLLAMA_CLOUD_DEFAULT_MODELS` do not declare either model, so setups relying on the built-in catalog (before live discovery) cannot select them.

## Why This Change Was Made

- Extended the full-effort whitelist from the exact `glm-5.2` match to a `/^glm-5\.[23]$/` family pattern, matching how the deepseek family is already handled. GLM-5.3 exposes the same native `think` effort contract (low/medium/high/max) as GLM-5.2 on Ollama Cloud.
- Declared `glm-5.3` (text, 1M ctx, tools, codeMode capable) and `glm-5.3-flash` (text+image — it is natively multimodal, 1M ctx, tools) in the manifest catalog, mirroring the existing `glm-5.2` entry shape.
- Added `glm-5.3` to `OLLAMA_CLOUD_DEFAULT_MODELS` so cloud onboarding offers it; kept `glm-5.2` at its current position to avoid changing what existing setups resolve (the array order is a contract for default selection).
- Non-goal: no changes to local Ollama behavior, sampling defaults, or other providers.

## User Impact

- `ollama-cloud/glm-5.3` now forwards `/think low|high|max` as native effort instead of silently downgrading `max` to `high`.
- Both new models appear in the built-in Ollama Cloud catalog with correct context window (1M), input modalities, and tool support, so they are selectable before live discovery completes.
- Cloud onboarding default list includes glm-5.3.

## Evidence

- Model pages: https://ollama.com/library/glm-5.3 (reasoning_effort low/high/max, 1M ctx, tools) and https://ollama.com/library/glm-5.3-flash (multimodal input, 1M ctx, tools)
- Focused tests pass:
  - `extensions/ollama/provider-policy-api.test.ts` + `extensions/ollama/src/provider-models.test.ts` — 71 passed (includes new cases: glm-5.3 / glm-5.3:cloud expose full native effort; catalog declares both models with 1M ctx)
  - `extensions/ollama/index.test.ts` — 106 passed (hosted provider catalog now includes glm-5.3; mock whitelist extended to the glm-5.[23] family pattern)
- Verified against live Ollama Cloud behavior on 2026.8.1-beta.2 where glm-5.3 requests were downgraded to `high`.
