### PR TITLE
fix(maintainers): accept the repository id shape gh returns during merge admission

### DIFF
--- a/scripts/pr-lib/merge-outcome.sh
+++ b/scripts/pr-lib/merge-outcome.sh
@@ -8,8 +8,11 @@ merge_outcome_stop() {
 }
 
 merge_outcome_repo_identity() {
+  # gh returns the repository's REST database id as a JSON number while PR ids are
+  # GraphQL node strings. Accept either scalar so a current gh cannot fail admission
+  # closed; nameWithOwner and the url suffix still pin which repository this is.
   jq -ce '
-    . as $repo | select((.id | type == "string" and length > 0) and
+    . as $repo | select((.id | (type == "string" and length > 0) or type == "number") and
       (.nameWithOwner | test("^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")) and
       (.url | test("^https://[A-Za-z0-9.-]+/[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$") and endswith("/" + $repo.nameWithOwner)))
   '

--- a/test/scripts/pr-merge-outcome.test.ts
+++ b/test/scripts/pr-merge-outcome.test.ts
@@ -1183,3 +1183,64 @@ describePosix("native merge outcome with real Git and supervised lock recovery",
     expect(f.state().posts).toBe(1);
   });
 });
+
+describePosix("merge_outcome_repo_identity", () => {
+  // gh reports the repository id as a REST database number while PR ids stay GraphQL
+  // node strings, so admission has to accept both scalars. Requiring a string here
+  // failed every merge closed on a current gh.
+  const identity = (repo: unknown) =>
+    spawnSync(
+      "bash",
+      [
+        "-c",
+        `set -euo pipefail; . "$1"; printf '%s' "$2" | merge_outcome_repo_identity`,
+        "bash",
+        join(scripts, "pr-lib/merge-outcome.sh"),
+        JSON.stringify(repo),
+      ],
+      { encoding: "utf8" },
+    );
+
+  it("accepts the numeric repository id gh actually returns", () => {
+    const run = identity({
+      id: 1103012935,
+      nameWithOwner: "openclaw/openclaw",
+      url: "https://github.com/openclaw/openclaw",
+    });
+    expect(run.status, run.stderr).toBe(0);
+    expect(JSON.parse(run.stdout).id).toBe(1103012935);
+  });
+
+  it("accepts a GraphQL node string repository id", () => {
+    const run = identity({
+      id: "R_kgDOQb6kRw",
+      nameWithOwner: "openclaw/openclaw",
+      url: "https://github.com/openclaw/openclaw",
+    });
+    expect(run.status, run.stderr).toBe(0);
+  });
+
+  it.each([
+    ["a missing id", { id: null }],
+    ["an empty string id", { id: "" }],
+    ["an object id", { id: { node: "x" } }],
+  ])("still rejects %s", (_label, overrides) => {
+    const run = identity({
+      nameWithOwner: "openclaw/openclaw",
+      url: "https://github.com/openclaw/openclaw",
+      ...overrides,
+    });
+    expect(run.status).not.toBe(0);
+    expect(run.stdout).toBe("");
+  });
+
+  it("still rejects a url that does not belong to the named repository", () => {
+    const run = identity({
+      id: 1103012935,
+      nameWithOwner: "openclaw/openclaw",
+      url: "https://github.com/attacker/openclaw",
+    });
+    expect(run.status).not.toBe(0);
+    expect(run.stdout).toBe("");
+  });
+});


### PR DESCRIPTION
## What Problem This Solves

Every agent-driven merge to `main` aborts. `scripts/pr merge-run <PR>` fails closed with:

```
Merge outcome: invalid repository identity
No merge retry. Repeated merge-run only reconciles a recorded attempt.
```

Merge admission validates the repository identity returned by
`gh repo view --json id,nameWithOwner,url` and required `.id` to be a non-empty **string**.
Current `gh` reports a repository's REST database id as a JSON **number**:

```
{"id":1103012935,"nameWithOwner":"openclaw/openclaw","url":"https://github.com/openclaw/openclaw"}
```

The `select` yields nothing, `jq -e` exits 4, and admission stops before doing any work.
Reproduced on `gh` 2.98.0 with the real binary (`gh_plain` deliberately bypasses shims,
and no `~/bin/gh` shim exists on the host).

Note the asymmetry that made this easy to miss: `gh pr view --json id` returns a GraphQL
node string (`PR_kwDO...`), so `prId` was always fine. Only the repository id is numeric.

## Why This Change Was Made

Accept either scalar for `.id`. The identity check's job is to confirm gh returned a
well-formed repository identity, and a database id is well-formed - it simply is not a
string.

The parts that decide *which* repository this is are unchanged: `nameWithOwner` must still
match `owner/name`, and `url` must still be an https URL ending in `/` + `nameWithOwner`.
So a missing, empty, or non-scalar id, and a url that does not belong to the named
repository, are all still rejected. This narrows nothing about the duplicate-merge
protection added in #132173; it only stops that protection from failing closed on every
merge.

## User Impact

Maintainers and agents can land PRs through the documented `scripts/pr` flow again.
Without this, the only routes to `main` are ClawSweeper automerge, the GitHub UI, or a
host running an older `gh`.

## Evidence

**Reproduction against the real payload.** The current predicate exits 4 with no output on
the exact JSON current `gh` returns; the fixed predicate accepts it and still rejects a
null id and a mismatched url.

**Regression proof.** Reverting just the predicate fails only the new numeric case, while
every rejection guard keeps passing - so the fix is not weakening them:

```
× merge_outcome_repo_identity > accepts the numeric repository id gh actually returns
✓ still rejects a missing id
✓ still rejects an empty string id
✓ still rejects an object id
✓ still rejects a url that does not belong to the named repository
Tests  1 failed | 5 passed
```

**Why this shipped broken.** The suite's fixture used `id: "fixture-repo"`, a string, so no
test ever exercised the shape gh actually produces. The new tests drive
`merge_outcome_repo_identity` directly with both real id shapes.

**Tests.**

```
node scripts/run-vitest.mjs test/scripts/pr-merge-outcome.test.ts
Test Files  1 passed (1)
     Tests  121 passed (121)

node scripts/check-changed.mjs   # exit 0
```

Codex autoreview: clean, no accepted findings, verdict correct (0.99).

**Provenance.** `introduced by` cb5d89bfaf47 - `fix(maintainers): prevent duplicate merges
after ambiguous responses` (#132173), authored and merged by @steipete, 2026-08-28 17:31
-0700. Confidence: clear. Latent until run on a `gh` that returns a numeric repository id.

Production LOC: +4/-1 in `scripts/pr-lib/merge-outcome.sh` (3 added lines are comments) | Tests: +61/-0
