### PR TITLE
refactor: simplify audio attachment projection

### DIFF
--- a/src/media-understanding/apply.test.ts
+++ b/src/media-understanding/apply.test.ts
@@ -471,6 +471,72 @@ describe("applyMediaUnderstanding", () => {
     expect(ctx.Body).not.toContain("<file");
   });
 
+  it("keeps tiny audio-MIME text files eligible for extraction", async () => {
+    const ctx = await createAudioCtx({ fileName: "note.txt", content: "recoverable file text" });
+    const transcribeAudio = vi.fn(async () => ({ text: "must not run" }));
+    const result = await applyMediaUnderstanding({
+      ctx,
+      cfg: createGroqAudioConfig(),
+      providers: { groq: { id: "groq", transcribeAudio } },
+    });
+
+    expect(transcribeAudio).not.toHaveBeenCalled();
+    expect(result.appliedAudio).toBe(true);
+    expect(result.appliedFile).toBe(true);
+    expect(ctx.Transcript).toBe(
+      "[Voice note could not be transcribed because the audio attachment was too small]",
+    );
+    expect(ctx.Body).toContain('<file name="note.txt" mime="text/plain">');
+    expect(ctx.Body).toContain("recoverable file text");
+  });
+
+  it("keeps a successful transcript instead of an earlier tooSmall placeholder", async () => {
+    const { MediaUnderstandingSkipError } =
+      await import("../../packages/media-understanding-common/src/errors.js");
+    const ctx = await createAudioCtx();
+    const transcribeAudio = vi
+      .fn<NonNullable<MediaUnderstandingProvider["transcribeAudio"]>>()
+      .mockRejectedValueOnce(new MediaUnderstandingSkipError("tooSmall", "provider rejected clip"))
+      .mockResolvedValue({ text: "recovered transcript" });
+    const result = await applyMediaUnderstanding({
+      ctx,
+      cfg: {
+        tools: {
+          media: {
+            models: [
+              { provider: "groq", model: "primary", capabilities: ["audio"] },
+              { provider: "groq", model: "fallback", capabilities: ["audio"] },
+            ],
+            audio: { enabled: true },
+          },
+        },
+      },
+      providers: { groq: { id: "groq", transcribeAudio } },
+    });
+
+    expect(transcribeAudio).toHaveBeenCalledTimes(2);
+    expect(result.outputs).toEqual([
+      {
+        kind: "audio.transcription",
+        attachmentIndex: 0,
+        text: "recovered transcript",
+        provider: "groq",
+        model: "fallback",
+      },
+    ]);
+    const audioDecision = result.decisions.find((decision) => decision.capability === "audio");
+    expect(audioDecision?.attachments[0]).toMatchObject({
+      attempts: [{ outcome: "skipped" }, { outcome: "success" }],
+      chosen: { outcome: "success", model: "fallback" },
+    });
+    expectTranscriptApplied({
+      ctx,
+      transcript: "recovered transcript",
+      body: "[Audio]\nTranscript:\nrecovered transcript",
+      commandBody: "recovered transcript",
+    });
+  });
+
   it("keeps caption for command parsing when audio has user text", async () => {
     const ctx = await createAudioCtx({
       body: "/capture status",
@@ -1575,57 +1641,74 @@ describe("applyMediaUnderstanding", () => {
     );
   });
 
-  it("adds placeholder for tooSmall audio while preserving real transcript for valid audio", async () => {
-    const dir = await createTempMediaDir();
-    const validAudio = createSafeAudioFixtureBuffer(2048);
-    const tinyAudio = Buffer.alloc(100);
-    const validPath = path.join(dir, "valid.ogg");
-    const tinyPath = path.join(dir, "tiny.ogg");
-    await fs.writeFile(validPath, validAudio);
-    await fs.writeFile(tinyPath, tinyAudio);
+  it.each(["first", "last"] as const)(
+    "adds tooSmall placeholders in %s order while preserving real transcripts",
+    async (prefer) => {
+      const dir = await createTempMediaDir();
+      const validAudio = createSafeAudioFixtureBuffer(2048);
+      const tinyAudio = Buffer.alloc(100);
+      const validPath = path.join(dir, "valid.ogg");
+      const tinyPath = path.join(dir, "tiny.ogg");
+      await fs.writeFile(validPath, validAudio);
+      await fs.writeFile(tinyPath, tinyAudio);
 
-    const ctx: MsgContext = {
-      Body: "",
-      media: [
-        { path: validPath, contentType: "audio/ogg" },
-        { path: tinyPath, contentType: "audio/ogg" },
-      ],
-    };
-    const cfg: OpenClawConfig = {
-      tools: {
-        media: {
-          models: [{ provider: "groq", capabilities: ["audio"] }],
-          audio: {
-            enabled: true,
-            attachments: { mode: "all", maxAttachments: 2 },
+      const ctx: MsgContext = {
+        Body: "",
+        media: [
+          { path: validPath, contentType: "audio/ogg" },
+          { path: tinyPath, contentType: "audio/ogg" },
+        ],
+      };
+      const cfg: OpenClawConfig = {
+        tools: {
+          media: {
+            models: [{ provider: "groq", capabilities: ["audio"] }],
+            audio: {
+              enabled: true,
+              attachments: { mode: "all", maxAttachments: 2, prefer },
+            },
           },
         },
-      },
-    };
+      };
 
-    const result = await applyMediaUnderstanding({
-      ctx,
-      cfg,
-      providers: {
-        groq: {
-          id: "groq",
-          transcribeAudio: async (req) => ({ text: `transcribed ${req.fileName ?? "unknown"}` }),
+      const result = await applyMediaUnderstanding({
+        ctx,
+        cfg,
+        providers: {
+          groq: {
+            id: "groq",
+            transcribeAudio: async (req) => ({ text: `transcribed ${req.fileName ?? "unknown"}` }),
+          },
         },
-      },
-    });
+      });
 
-    expect(result.appliedAudio).toBe(true);
-    expect(ctx.Transcript).toContain("transcribed valid.ogg");
-    expect(ctx.Transcript).toContain(
-      "[Voice note could not be transcribed because the audio attachment was too small]",
-    );
-    expect(ctx.Body).toContain("[Audio 1/2]");
-    expect(ctx.Body).toContain("transcribed valid.ogg");
-    expect(ctx.Body).toContain("[Audio 2/2]");
-    expect(ctx.Body).toContain(
-      "[Voice note could not be transcribed because the audio attachment was too small]",
-    );
-  });
+      expect(result.appliedAudio).toBe(true);
+      expect(ctx.Transcript).toContain("transcribed valid.ogg");
+      expect(ctx.Transcript).toContain(
+        "[Voice note could not be transcribed because the audio attachment was too small]",
+      );
+      expect(ctx.Body).toContain("[Audio 1/2]");
+      expect(ctx.Body).toContain("transcribed valid.ogg");
+      expect(ctx.Body).toContain("[Audio 2/2]");
+      expect(ctx.Body).toContain(
+        "[Voice note could not be transcribed because the audio attachment was too small]",
+      );
+      expect(result.outputs.map((output) => output.attachmentIndex)).toEqual(
+        prefer === "last" ? [1, 0] : [0, 1],
+      );
+      const expectedTexts = [
+        "transcribed valid.ogg",
+        "[Voice note could not be transcribed because the audio attachment was too small]",
+      ];
+      if (prefer === "last") {
+        expectedTexts.reverse();
+      }
+      expect(ctx.Transcript).toBe(`Audio 1:\n${expectedTexts[0]}\n\nAudio 2:\n${expectedTexts[1]}`);
+      expect(ctx.Body).toBe(
+        `[Audio 1/2]\nTranscript:\n${expectedTexts[0]}\n\n[Audio 2/2]\nTranscript:\n${expectedTexts[1]}`,
+      );
+    },
+  );
 
   it("orders mixed media outputs as image, audio, video", async () => {
     const dir = await createTempMediaDir();

--- a/src/media-understanding/apply.ts
+++ b/src/media-understanding/apply.ts
@@ -84,32 +84,6 @@ function appendFileBlocks(body: string | undefined, blocks: string[]): string {
   return `${base}\n\n${suffix}`.trim();
 }
 
-function buildSyntheticSkippedAudioOutputs(
-  decisions: MediaUnderstandingDecision[],
-): MediaUnderstandingOutput[] {
-  const audioDecision = decisions.find((decision) => decision.capability === "audio");
-  if (!audioDecision) {
-    return [];
-  }
-  return audioDecision.attachments.flatMap((attachment) => {
-    const hasTooSmallAttempt = attachment.attempts.some((attempt) =>
-      attempt.reason?.trim().startsWith("tooSmall"),
-    );
-    if (!hasTooSmallAttempt) {
-      return [];
-    }
-    return [
-      {
-        kind: "audio.transcription" as const,
-        attachmentIndex: attachment.attachmentIndex,
-        text: EMPTY_VOICE_NOTE_PLACEHOLDER,
-        provider: "openclaw",
-        model: "synthetic-empty-audio",
-      },
-    ];
-  });
-}
-
 type ClassifiedFileAttachment = {
   outcome: FileAttachmentOutcome;
   filename?: string;
@@ -499,58 +473,38 @@ export async function applyMediaUnderstanding(params: {
     );
     const outputs: MediaUnderstandingOutput[] = [];
     const decisions: MediaUnderstandingDecision[] = [];
+    const audioAttachmentIndexes = new Set<number>();
     for (const entry of results) {
-      for (const output of entry.outputs) {
-        outputs.push(output);
-      }
       decisions.push(entry.decision);
-    }
-
-    const audioOutputAttachmentIndexes = new Set(
-      outputs
-        .filter((output) => output.kind === "audio.transcription")
-        .map((output) => output.attachmentIndex),
-    );
-    const syntheticSkippedAudioOutputs = buildSyntheticSkippedAudioOutputs(decisions).filter(
-      (output) => !audioOutputAttachmentIndexes.has(output.attachmentIndex),
-    );
-
-    // Merge synthetic placeholders into the audio slice while preserving the
-    // selected audio attachment order from `runCapability()` / `attachments.prefer`.
-    // When audio produced no real outputs, insert the synthetic slice at the
-    // audio capability slot (before video) instead of appending at the end.
-    if (syntheticSkippedAudioOutputs.length > 0) {
-      const audioDecision = decisions.find((decision) => decision.capability === "audio");
-      const audioAttachmentOrder =
-        audioDecision?.attachments.map((attachment) => attachment.attachmentIndex) ?? [];
-      const audioOutputsByAttachmentIndex = new Map<number, MediaUnderstandingOutput>();
-      for (const output of outputs) {
-        if (output.kind === "audio.transcription") {
-          audioOutputsByAttachmentIndex.set(output.attachmentIndex, output);
+      if (entry.decision.capability !== "audio") {
+        for (const output of entry.outputs) {
+          outputs.push(output);
         }
+        continue;
       }
-      for (const output of syntheticSkippedAudioOutputs) {
+      const audioOutputsByAttachmentIndex = new Map<number, MediaUnderstandingOutput>();
+      for (const output of entry.outputs) {
         audioOutputsByAttachmentIndex.set(output.attachmentIndex, output);
+        audioAttachmentIndexes.add(output.attachmentIndex);
       }
-      const mergedAudio = audioAttachmentOrder
-        .map((attachmentIndex) => audioOutputsByAttachmentIndex.get(attachmentIndex))
-        .filter((output): output is MediaUnderstandingOutput => Boolean(output));
-
-      const firstAudioIdx = outputs.findIndex((o) => o.kind === "audio.transcription");
-      if (firstAudioIdx >= 0) {
-        const before = outputs.slice(0, firstAudioIdx);
-        const afterLastAudio = outputs.slice(
-          outputs.reduce(
-            (last, o, i) => (o.kind === "audio.transcription" ? i : last),
-            firstAudioIdx,
-          ) + 1,
-        );
-        outputs.length = 0;
-        outputs.push(...before, ...mergedAudio, ...afterLastAudio);
-      } else {
-        const firstVideoIdx = outputs.findIndex((o) => o.kind === "video.description");
-        const audioInsertIdx = firstVideoIdx >= 0 ? firstVideoIdx : outputs.length;
-        outputs.splice(audioInsertIdx, 0, ...mergedAudio);
+      // Capability results retain image/audio/video order. Project audio in the
+      // runner's selected order so placeholders honor attachments.prefer and
+      // stay before video even when every audio attachment was too small.
+      for (const attachment of entry.decision.attachments) {
+        const output = audioOutputsByAttachmentIndex.get(attachment.attachmentIndex);
+        if (output) {
+          outputs.push(output);
+        } else if (
+          attachment.attempts.some((attempt) => attempt.reason?.trim().startsWith("tooSmall"))
+        ) {
+          outputs.push({
+            kind: "audio.transcription",
+            attachmentIndex: attachment.attachmentIndex,
+            text: EMPTY_VOICE_NOTE_PLACEHOLDER,
+            provider: "openclaw",
+            model: "synthetic-empty-audio",
+          });
+        }
       }
     }
 
@@ -590,18 +544,6 @@ export async function applyMediaUnderstanding(params: {
     // Only skip file extraction for attachments that have a real (non-synthetic)
     // audio transcription. Synthetic placeholders should not prevent file extraction
     // for tiny audio-MIME files that could be recovered as text via forcedTextMime.
-    const syntheticAudioIndexes = new Set(
-      syntheticSkippedAudioOutputs.map((o) => o.attachmentIndex),
-    );
-    const audioAttachmentIndexes = new Set(
-      outputs
-        .filter(
-          (output) =>
-            output.kind === "audio.transcription" &&
-            !syntheticAudioIndexes.has(output.attachmentIndex),
-        )
-        .map((output) => output.attachmentIndex),
-    );
     const fileContext =
       params.processingMode === "audio-only"
         ? { blocks: [], images: [], localPathSelfServeUpgrades: [] }


### PR DESCRIPTION
## What Problem This Solves

Audio preprocessing reconstructs attachment order several times after media capabilities have already recorded their results. That duplicate bookkeeping makes the relationship between real transcripts, too-small-audio placeholders and later text-file extraction harder to maintain.

## Why This Change Was Made

Project audio once at its existing capability position, using the runner's selected-attachment order. Real transcripts take precedence over earlier too-small attempts, while synthetic placeholders do not prevent eligible files from being extracted as text. This removes the separate synthetic-output collector, repeated filtering, order reconstruction and splice path without changing provider policy or configuration.

## User Impact

No intended user-visible behavior change. First/last attachment selection, image/audio/video ordering, caption precedence, transcript and command-body formatting, too-small voice-note messages and text-file recovery remain the contract.

Production changes are +26/−84 lines (**58 fewer**); tests are +128/−45 (**83 more**). The complete two-file change is therefore **25 lines larger**, not net-negative overall. No dependency, schema, configuration, documentation or changelog change is included.

## Evidence

The same 105 characterization cases passed on the original production implementation and the candidate, with matching case multiplicity and no skips or retries. Coverage includes application/echo behavior, tiny-audio runner handling, attachment normalization/selection and shared formatting. This is behavior-preservation evidence, not a bug red/green claim.

All 29 commands in the normal changed gate passed. The QA-enabled normal full build (`OPENCLAW_BUILD_PRIVATE_QA=1 pnpm build`) completed all 14 source-defined stages, including UI and declarations. The normal structured Codex review completed its three bounded passes at P0 with no findings; that review is not a full-severity, live-provider or landing-readiness verdict.

All four source-blind operator cases passed through the compiled Gateway, QA channel and stock mock provider: normal stored audio, mixed-media first order, mixed-media last order, and tiny audio plus text. Each finished with normal stop and a source-bound resource audit. The aggregate audit confirmed the 77 recorded runtime PIDs, eight groups and twelve listeners were absent; task-owned scratch/evidence was deliberately retained.

The provider and transport are synthetic: no live account, ASR-quality, real-channel or video claim is made. A separate tiny WAV plus text attachment does not prove contradictory MIME/path handling on the same file; the focused test covers that owner boundary. The stock mock does not expose a transcription-request ledger.

Named QA follow-up: **mock-child structured-log path escapes its owned runtime root**. The first case selected the shared default log path; its functional pass does not establish shared-log isolation or prove which historical bytes were written. Later fixture setup uses the existing `logging.file` setting for owned bootstrap/Gateway logs, without product changes. No shared log was inspected or removed, and no universal filesystem-isolation claim is made. Earlier setup/observer refusals remain retained separately from successful proof. Exact committed-head CI run [33261264664](https://github.com/openclaw/openclaw/actions/runs/33261264664) completed successfully for `dbf84a5d44b992ee3fbf286b523be2c7befa4c69`. A separate post-publication structured review completed seven bounded batches at P0 with no findings, with full source/dependency/generated/runtime custody and terminal cleanup; this is not a full-severity review or new runtime proof. Normal hosted preparation and native merge both returned exit 0, landing as [d2058cf1bbea](https://github.com/openclaw/openclaw/commit/d2058cf1bbeafd0a5235abc3478c702be549981b); the actual-parent whole-tree audit reconstructed landed tree `a6b4d3ceda44681bd81c0d5c8944f5a1a7115bdd` from parent `b2e0af84fe0eeb7d385e3024cecc180f148db673` and reviewed source `dbf84a5d44b992ee3fbf286b523be2c7befa4c69`.

Latest ClawSweeper follow-through: the maintainer directly reread the complete [latest review and Rank-up moves](https://github.com/openclaw/openclaw/pull/132691#issuecomment-5463383415). Its remaining request was to recheck those moves and let exact-head CI finish. Both are now satisfied; the review identified no concrete repair lane. Normal current-head native gates and current enforcement still apply.

Named upstream follow-up: **staged-input basename truncation can remove a classification-significant extension** (`src/media/staged-inputs.ts`, introduced in #132114). Prefixing an already long basename before truncation can remove a `.txt` suffix relevant to remote-media text recovery. This is a source-level counterexample affecting the original and candidate projections alike, not a reproduced Audio regression or a failed Audio test. The staging owner still needs a reachable-producer reproduction and focused regression proof; no staging, sanitizer or ownership guard is changed here.
