### PR TITLE
fix(agents): route approval waits by run

### DIFF
--- a/src/agents/agent-run-approval-wait.ts
+++ b/src/agents/agent-run-approval-wait.ts
@@ -1,4 +1,4 @@
-import { onAgentEvent } from "../infra/agent-events.js";
+import { onAgentEventForRun } from "../infra/agent-events.js";
 
 export type AgentRunApprovalWait = {
   pending: boolean;
@@ -26,9 +26,8 @@ export function observeAgentRunApprovalWait(params: {
     return state;
   }
   // Lifecycle facts pause scheduling only; the original admitted run retains all authority.
-  unsubscribe = onAgentEvent((event) => {
+  unsubscribe = onAgentEventForRun(params.runId, (event) => {
     if (
-      event.runId !== params.runId ||
       event.stream !== "lifecycle" ||
       (params.sessionId && event.sessionId && event.sessionId !== params.sessionId)
     ) {


### PR DESCRIPTION
Fixes #129173

## What Problem This Solves

The run-specific approval-wait observer still subscribes through the process-global agent-event listener set. During concurrent runs, every agent event invokes that observer before it immediately rejects foreign run IDs.

The broader run-indexed dispatch work already landed in #129174. This change addresses the remaining approval-wait callback identified on current main.

## What Changed

- subscribe the approval-wait observer with the existing `onAgentEventForRun` API;
- remove the now-redundant foreign-run check from the callback;
- preserve the existing lifecycle-stream, session-id, approval-id, pause accounting, and disposal behavior.

## Scope

One production file, +2/-3 lines. No configuration, protocol, persistence, public API, or user-visible behavior changes.

## Evidence

### Problem reproduction

On current `main`, `observeAgentRunApprovalWait()` registers through the process-global `onAgentEvent()` listener and its first filter rejects `event.runId !== params.runId`. With multiple concurrent approval-wait observers, an event for one run therefore enters every observer callback before the foreign-run checks discard it. The run-indexed dispatcher introduced by #129174 already provides the owner-scoped route needed here.

### After-fix behavior

The PR head registers the observer with `onAgentEventForRun(params.runId, ...)`, so the dispatcher invokes it only for the matching run. The callback retains the existing lifecycle, session, approval-id, timeout-pause, and disposal filters.

Existing focused coverage exercises the behavior preserved by this change:

- `src/infra/agent-events.run-listeners.test.ts` verifies that run-indexed listeners receive only their subscribed run's events, preserve ordering, and clean up correctly.
- `src/agents/embedded-agent-runner/run/attempt-timeout-prepare.test.ts` verifies approval-wait timeout behavior, including foreign-run and wrong-session approval-resolution events not affecting the owning run's paused timeout.

CI on commit `0caa973e7a45838895bb9f2cfc490706f4e9ce0e` completed the repository's selected test/lint/type/security lanes; CodeQL, OpenGrep, build-artifacts, security-fast, and the hosted core checks passed. The aggregate CI gate separately reports `checks-node-core-test-nondist-shard=failure`; that shard failure has not been attributed here and should be assessed independently from the evidence gate.

## Validation

The existing run-listener tests cover run-indexed dispatch semantics, and the embedded attempt-timeout coverage verifies that foreign run/session approval events do not alter timeout behavior.

No new concurrent-load benchmark was run for this final leftover observer; the unnecessary global callback invocation is directly established by the dispatcher and subscription source.