### PR TITLE
test: retain Code Mode suspension failure details

### DIFF
--- a/src/agents/code-mode.bridge.lifecycle.test.ts
+++ b/src/agents/code-mode.bridge.lifecycle.test.ts
@@ -587,7 +587,7 @@ describe("Code Mode subscribed bridge lifecycle", () => {
             controller.signal,
           ),
         );
-        expect(result.status).toBe("waiting");
+        expect(result.status, JSON.stringify(result)).toBe("waiting");
         const runId = result.runId as string;
         const initial = expectDefined(testing.activeRuns.get(runId), "initial snapshot");
         expect(applyCodeModeCatalog(owner).catalogReused).toBe(true);


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where maintainers investigating an intermittent OpenClaw Code Mode ownership-test failure see only `expected 'failed' to be 'waiting'`, without the returned error, code, phase, or telemetry needed to classify it. The observed failure occurred at the initial suspension assertion, before the ownership-transfer and cancellation actions ran.

## Why This Change Was Made

Pass the already-returned, bounded JSON result to Vitest's existing assertion-message argument. The expected status, test ordering, workers, clocks, timeouts, and mocks are unchanged. No new helper or production seam is introduced.

The schema-fixture corrections from the same investigation already landed in [the current-schema eligibility test fix](https://github.com/openclaw/openclaw/commit/16367468a7edce977360becc72443943d805593d), so they are not duplicated here.

## User Impact

Developer diagnostics only; no runtime, provider, UI, configuration, or storage behavior changes. This does **not** fix or suppress the intermittent initial-suspension failure. It preserves the result details when that assertion next fails.

Production LOC: **0**. Tests: **+1/-1 (net 0)**.

## Evidence

The original stress failure on `b3362142c72bcde6dae141e649826de10da0c000` reported only the scalar status mismatch at `src/agents/code-mode.bridge.lifecycle.test.ts:590`. Ten subsequent diagnostic runs passed without reproducing it; those passes are not being represented as a fix. Classification of that intermittent failure remains a separate follow-up.

Fresh validation on the current-main-based candidate:

- Focused lifecycle test file: **25 passed, zero failed or skipped**.
- Fresh isolated Codex structured review: **no actionable P0 findings**; confirms the amendment changes diagnostics, not the expected outcome.
- Changed-file checks: **passed**, including core test typecheck, focused lint/format, and repository guards.

Exact local validation commands:

```bash
OPENCLAW_VITEST_MAX_WORKERS=8 OPENCLAW_VITEST_FS_MODULE_CACHE_PATH="$PWD/node_modules/.experimental-vitest-cache/1-test-vitest-vitest.agents-core.config.ts" node scripts/run-vitest.mjs src/agents/code-mode.bridge.lifecycle.test.ts --reporter=verbose --reporter=json --outputFile=.artifacts/code-mode-test-landing-c6ebff/focused-tests.json
```

```bash
node scripts/check-changed.mjs -- src/agents/code-mode.bridge.lifecycle.test.ts
```

The supported module-cache path reuses the prior agents-core cache; it does not change test isolation or execution limits. New build/live/UI proof is not applicable to this assertion-message-only change. No claim is made about native Codex runtime behavior.

Maintainer-requested; AI-assisted.
