### PR TITLE
fix(e2e): exclude dev tooling from prebuilt package fixtures

### DIFF
--- a/scripts/e2e/lib/package-git-fixture.mjs
+++ b/scripts/e2e/lib/package-git-fixture.mjs
@@ -43,6 +43,8 @@ function prepare(root) {
   ensureDependencyIgnores(root);
   const packageJsonPath = path.join(root, "package.json");
   const packageJson = readJson(packageJsonPath);
+  // npm still resolves omitted dev dependencies; this fixture runs the packed runtime.
+  delete packageJson.devDependencies;
   packageJson.scripts = {
     ...packageJson.scripts,
     openclaw: "node openclaw.mjs",

--- a/test/scripts/package-git-fixture.test.ts
+++ b/test/scripts/package-git-fixture.test.ts
@@ -3,10 +3,62 @@ import { spawnSync } from "node:child_process";
 import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
+import { resolveNpmRunner } from "../../scripts/npm-runner.mts";
 import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
 
 describe("package git fixture", () => {
   const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+  it("installs the packed runtime without resolving checkout-only development dependencies", () => {
+    const root = tempDirs.make("openclaw-package-git-fixture-install-");
+    const runtimeDir = path.join(root, "runtime");
+    mkdirSync(runtimeDir);
+    writeFileSync(
+      path.join(runtimeDir, "package.json"),
+      JSON.stringify({ name: "fixture-runtime", version: "1.0.0", main: "index.cjs" }),
+    );
+    writeFileSync(path.join(runtimeDir, "index.cjs"), 'module.exports = "packed runtime";\n');
+    writeFileSync(
+      path.join(root, "package.json"),
+      JSON.stringify({
+        name: "prebuilt-fixture",
+        version: "1.0.0",
+        dependencies: { "fixture-runtime": "file:./runtime" },
+        devDependencies: { "checkout-build-tool": "workspace:*" },
+      }),
+    );
+    const prepared = spawnSync(
+      process.execPath,
+      ["scripts/e2e/lib/package-git-fixture.mjs", "prepare", root],
+      { encoding: "utf8" },
+    );
+    expect(prepared.status, prepared.stderr).toBe(0);
+    const npm = resolveNpmRunner({
+      npmArgs: [
+        "install",
+        "--omit=dev",
+        "--offline",
+        "--ignore-scripts",
+        "--no-fund",
+        "--no-audit",
+      ],
+    });
+    const installed = spawnSync(npm.command, npm.args, {
+      cwd: root,
+      encoding: "utf8",
+      env: npm.env,
+      shell: npm.shell,
+      windowsVerbatimArguments: npm.windowsVerbatimArguments,
+      timeout: 30_000,
+    });
+    expect(installed.status, `${installed.stdout}\n${installed.stderr}`).toBe(0);
+    const runtime = spawnSync(process.execPath, ["-p", 'require("fixture-runtime")'], {
+      cwd: root,
+      encoding: "utf8",
+    });
+    expect(runtime.status, runtime.stderr).toBe(0);
+    expect(runtime.stdout.trim()).toBe("packed runtime");
+  });
 
   it("stages bundled ai runtime as a local file dependency", async () => {
     const root = tempDirs.make("openclaw-package-git-fixture-");


### PR DESCRIPTION
## What Problem This Solves

Full release verification fails before the doctor install-switch and update-channel-switch scenarios can run. Their package-derived Git fixtures retain checkout development dependencies. `npm install --omit=dev` still resolves those dependencies, so an unrelated development-only peer conflict blocks installation of the prebuilt runtime.

The frozen candidate reproduces `ERESOLVE`: the root development dependency on OpenTelemetry SDK 0.221.0 brings exporter 0.221.0, while Mistral's optional peer requires exporter ^0.220.0. The CI log then hides the original npm error because its canonical redactor imports the incomplete fixture and cannot load `tslog`.

## Why This Change Was Made

Remove root development dependencies in the existing shared package-Git fixture preparer, matching its existing handling of the relocated bundled AI package. Both callers execute the packed runtime; the channel-switch fixture already owns its synthetic build commands. Runtime dependencies, optional native dependencies, and npm's peer checks remain unchanged. No force, legacy-peer-deps, retry, or timeout workaround.

This follows npm's documented [`omit` contract](https://docs.npmjs.com/cli/v11/commands/npm-install/#omit): omitted dependencies are still resolved even though they are not installed on disk.

## User Impact

Internal release-test repair only. Doctor switching and stable/beta/dev update switching can exercise the selected package again. The package being tested is unchanged.

## Evidence

- Captured the original frozen-candidate failures in [release checks run 33256912172](https://github.com/openclaw/openclaw/actions/runs/33256912172): doctor job 99112921125 and update-channel job 99112921110, also repeated in package-core job 99112545458.
- Downloaded the original package artifact 9716030831 and verified its archive digest. The unchanged package is `2026.8.1`, source `d9fe780239a2cb7158aad437112156605e8d375c`, tarball SHA-256 `34882261b66f480a5e5ecb105535870205ea48df55c98dc4e201078f32b28a49`.
- The same strict local `npm install --omit=dev --no-fund --no-audit` fails with `ERESOLVE` before the fix, succeeds afterward, and the installed CLI reports `OpenClaw 2026.8.1 (d9fe780)`.
- Added a real offline npm regression: an omitted checkout-only dependency fails resolution before the fix; afterward the runtime dependency installs and executes. No resolver mocks or network access.
- `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs test/scripts/package-git-fixture.test.ts test/scripts/update-channel-switch-fixture.test.ts test/scripts/doctor-install-switch-wrapper.test.ts`: 11 passed. The new regression failed on the original preparer for the intended dependency-resolution reason.
- `node scripts/check-changed.mjs -- scripts/e2e/lib/package-git-fixture.mjs test/scripts/package-git-fixture.test.ts`: passed, including root test types, script lint and Docker package-boundary guards.
- Real Linux package proof: [Testbox run 33260586819](https://github.com/openclaw/openclaw/actions/runs/33260586819), lease `tbx_01m172fj96d110dygx2hydbxyx` (stopped). Both `bash scripts/e2e/doctor-install-switch-docker.sh` and `bash scripts/e2e/update-channel-switch-docker.sh` passed against the same sealed candidate and its verified prerelease registry, in 154 seconds combined. Tooling base `dae924b71a3afe07fff7343ba1a599a1917e6888`; both changed-file hashes were verified on the remote before execution.
- Codex review: clean, no actionable findings at the default P0 threshold.

Tooling: +2 lines. Tests: +52 lines. Product runtime: unchanged.

Known diagnostic limitation: an installation failure can prevent the candidate-owned redactor from loading, which suppresses the original npm log. This change preserves fail-closed redaction; a separate diagnostics repair would need an independently available canonical redactor, never a raw-log fallback. The unrelated cumulative ClawHub recovery-audit failures are already addressed by #132642 and are not part of this patch.

ClawSweeper disposition: the latest review found no correctness or security issues. Its remaining exact-head CI condition is satisfied by [CI run 33261450646](https://github.com/openclaw/openclaw/actions/runs/33261450646). The maintainer has reviewed and accepted this internal release-test repair under the explicit autonomous fix-and-land request. No additional product, API, configuration or ownership decision is introduced.
