### PR TITLE
fix: keep store-backed credentials and tools discoverable

### DIFF
--- a/docs/gateway/secrets.md
+++ b/docs/gateway/secrets.md
@@ -214,6 +214,8 @@ Define providers under `secrets.providers`:
 
 Provider aliases are source-specific. A matching explicit provider entry wins; if an `env` or `store` default alias is also used by an entry for another source, that source's built-in provider wins. Non-default aliases and `file` or `exec` providers must resolve to an explicit entry with the matching source.
 
+Read-only inspection recognizes valid `store` bindings without opening the database. That is configuration evidence, not proof that the value exists: credential availability stays unknown until runtime resolution.
+
 <Accordion title="Env provider">
 - Optional exact-name allowlist via `allowlist`. A matching explicit env provider enforces this list even when it is the selected default. Omit the list to allow any name; use `[]` to deny every name.
 - Missing or empty env values fail resolution. An explicit env SecretRef remains authoritative and does not fall through to another credential or auth profile.

--- a/src/agents/auth-profiles/read-only-availability.test.ts
+++ b/src/agents/auth-profiles/read-only-availability.test.ts
@@ -45,18 +45,64 @@ describe("resolveStoredCredentialReadOnlyAvailability", () => {
     ).toBe(expected);
   });
 
-  it("keeps an implicit store ref unknown until runtime resolution", () => {
-    expect(
-      resolveStoredCredentialReadOnlyAvailability({
-        credential: {
-          type: "api_key",
-          provider: "test",
-          keyRef: { source: "store", provider: "default", id: "STORED_API_KEY" },
-        },
-        cfg: {},
-        env: {},
-      }),
-    ).toBeUndefined();
+  describe.each(["api_key", "token"] as const)("%s store refs", (type) => {
+    it.each<{
+      name: string;
+      provider: string;
+      secrets?: OpenClawConfig["secrets"];
+      expected: boolean | undefined;
+    }>([
+      { name: "implicit default", provider: "default", expected: undefined },
+      {
+        name: "selected default without a declaration",
+        provider: "shared",
+        secrets: { defaults: { store: "shared" } },
+        expected: undefined,
+      },
+      ...(
+        [
+          { source: "file", path: "/tmp/unused-store-alias-fixture.json" },
+          { source: "env" },
+          { source: "exec", command: "/tmp/unused-store-alias-command" },
+        ] as const
+      ).map((provider) => ({
+        name: `selected default shadowing ${provider.source}`,
+        provider: "shared",
+        secrets: { defaults: { store: "shared" }, providers: { shared: provider } },
+        expected: undefined,
+      })),
+      {
+        name: "explicit matching non-default provider",
+        provider: "shared",
+        secrets: { providers: { shared: { source: "store" } } },
+        expected: undefined,
+      },
+      { name: "missing non-default provider", provider: "shared", expected: false },
+      {
+        name: "mismatched non-default provider",
+        provider: "shared",
+        secrets: { providers: { shared: { source: "file", path: "/tmp/unused.json" } } },
+        expected: false,
+      },
+      {
+        name: "old default after selecting another alias",
+        provider: "default",
+        secrets: { defaults: { store: "shared" } },
+        expected: false,
+      },
+    ])("classifies $name without resolving it", ({ provider, secrets, expected }) => {
+      const ref = { source: "store", provider, id: "STORED_API_KEY" } as const;
+      expect(
+        resolveStoredCredentialReadOnlyAvailability({
+          credential:
+            type === "api_key"
+              ? { type, provider: "test", key: "retained-inline", keyRef: ref }
+              : { type, provider: "test", token: "retained-inline", tokenRef: ref },
+          cfg: { secrets },
+          env: {},
+        }),
+      ).toBe(expected);
+    });
   });
 
   it("prefers explicit secret refs over retained inline values", () => {

--- a/src/agents/auth-profiles/read-only-availability.ts
+++ b/src/agents/auth-profiles/read-only-availability.ts
@@ -8,8 +8,8 @@ import {
 } from "../../config/types.secrets.js";
 import { canResolveEnvSecretRefInReadOnlyPath } from "../../plugin-sdk/secret-ref-readonly.internal.js";
 import {
+  isBuiltInDefaultSecretProviderRef,
   isValidSecretRef,
-  resolveDefaultSecretProviderAlias,
   SINGLE_VALUE_FILE_REF_ID,
 } from "../../secrets/ref-contract.js";
 import {
@@ -55,9 +55,7 @@ export function resolveSecretRefReadOnlyAvailability(
     return hasSecret(env[value.id]) ? true : undefined;
   }
   const source = cfg.secrets?.providers?.[value.provider];
-  const isImplicitProvider =
-    value.source === "store" && value.provider === resolveDefaultSecretProviderAlias(cfg, "store");
-  if ((!source && !isImplicitProvider) || (source && source.source !== value.source)) {
+  if (source?.source !== value.source && !isBuiltInDefaultSecretProviderRef(cfg, value)) {
     return false;
   }
   if (

--- a/src/agents/model-auth-availability.test.ts
+++ b/src/agents/model-auth-availability.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import type { SecretRef } from "../config/types.secrets.js";
 import type { ProviderModelRouteCandidate } from "../plugin-sdk/provider-model-types.js";
 import type { PluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.types.js";
 import { createModelAuthAvailabilityResolver } from "./model-auth-availability.js";
@@ -977,33 +978,55 @@ describe("createModelAuthAvailabilityResolver", () => {
     });
   });
 
-  it("keeps a non-OpenAI provider SecretRef unresolved without reading it", () => {
-    const result = createModelAuthAvailabilityResolver({
-      cfg: {
-        models: {
-          providers: {
-            anthropic: {
-              api: "anthropic-messages",
-              apiKey: { source: "env", provider: "default", id: "ANTHROPIC_API_KEY" },
-              baseUrl: "https://api.anthropic.com",
-              models: [],
+  it.each<{
+    name: string;
+    apiKey: SecretRef;
+    secrets: OpenClawConfig["secrets"];
+  }>([
+    {
+      name: "env",
+      apiKey: { source: "env", provider: "default", id: "ANTHROPIC_API_KEY" },
+      secrets: { providers: { default: { source: "env" } } },
+    },
+    {
+      name: "store default shadowing file",
+      apiKey: { source: "store", provider: "shared", id: "ANTHROPIC_API_KEY" },
+      secrets: {
+        defaults: { store: "shared" },
+        providers: { shared: { source: "file", path: "/tmp/unused-store-alias-fixture.json" } },
+      },
+    },
+  ])(
+    "keeps a non-OpenAI provider $name SecretRef unresolved without reading it",
+    ({ apiKey, secrets }) => {
+      const result = createModelAuthAvailabilityResolver({
+        cfg: {
+          models: {
+            providers: {
+              anthropic: {
+                api: "anthropic-messages",
+                apiKey,
+                baseUrl: "https://api.anthropic.com",
+                models: [],
+              },
             },
           },
+          secrets,
         },
-        secrets: { providers: { default: { source: "env" } } },
-      },
-      authStore: authStore(),
-      env: {},
-    }).evaluateModelAuth("anthropic", {
-      modelId: "claude-sonnet-4-6",
-      api: "anthropic-messages",
-    });
+        authStore: authStore(),
+        env: {},
+      }).evaluateModelAuth("anthropic", {
+        modelId: "claude-sonnet-4-6",
+        api: "anthropic-messages",
+      });
 
-    expect(result).toMatchObject({
-      availability: undefined,
-      evidence: "provider-config",
-      routeResolution: null,
-      selectedAuthMode: "api-key",
-    });
-  });
+      expect(result).toMatchObject({
+        availability: undefined,
+        evidence: "provider-config",
+        routeResolution: null,
+        selectedAuthMode: "api-key",
+      });
+      expect(result.unavailableReason).toBeUndefined();
+    },
+  );
 });

--- a/src/plugins/manifest-tool-availability.test.ts
+++ b/src/plugins/manifest-tool-availability.test.ts
@@ -1,6 +1,7 @@
 // Manifest tool-availability tests cover config, auth, environment, and base-URL gates.
 import { describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import type { SecretRef } from "../config/types.secrets.js";
 import type { PluginManifestRecord } from "./manifest-registry.js";
 import {
   hasManifestToolAvailability,
@@ -185,6 +186,25 @@ describe("manifestConfigSignalPasses", () => {
     };
     expect(manifestConfigSignalPasses({ config, env, signal: webSearchSignal })).toBe(expected);
   });
+
+  it.each([
+    { allowlist: ["XAI_API_KEY"], expected: true },
+    { allowlist: ["OTHER_API_KEY"], expected: false },
+  ])("honors the explicit env provider allowlist $allowlist", ({ allowlist, expected }) => {
+    const config: OpenClawConfig = {
+      ...xaiConfig({
+        webSearch: { apiKey: { source: "env", provider: "shared", id: "XAI_API_KEY" } },
+      }),
+      secrets: { providers: { shared: { source: "env", allowlist } } },
+    };
+    expect(
+      manifestConfigSignalPasses({
+        config,
+        env: { XAI_API_KEY: "token" },
+        signal: webSearchSignal,
+      }),
+    ).toBe(expected);
+  });
 });
 
 describe("manifestProviderBaseUrlGuardPasses", () => {
@@ -248,6 +268,86 @@ describe("hasManifestToolAvailability", () => {
         configSignals: [webSearchSignal],
       },
     },
+  });
+
+  it.each<{
+    name: string;
+    ref: SecretRef;
+    secrets?: OpenClawConfig["secrets"];
+    expected: boolean;
+  }>([
+    {
+      name: "implicit store default",
+      ref: { source: "store", provider: "default", id: "TOOL_API_KEY" },
+      expected: true,
+    },
+    {
+      name: "selected store default without a declaration",
+      ref: { source: "store", provider: "shared", id: "TOOL_API_KEY" },
+      secrets: { defaults: { store: "shared" } },
+      expected: true,
+    },
+    ...(
+      [
+        { source: "file", path: "/tmp/unused-store-alias-fixture.json" },
+        { source: "env" },
+        { source: "exec", command: "/tmp/unused-store-alias-command" },
+      ] as const
+    ).map((provider) => ({
+      name: `selected store default shadowing ${provider.source}`,
+      ref: { source: "store", provider: "shared", id: "TOOL_API_KEY" } as const,
+      secrets: { defaults: { store: "shared" }, providers: { shared: provider } },
+      expected: true,
+    })),
+    ...(
+      [
+        { source: "store" },
+        { source: "file", path: "/tmp/unused-store-alias-fixture.json" },
+        { source: "exec", command: "/tmp/unused-store-alias-command" },
+      ] as const
+    ).map((provider) => ({
+      name: `explicit matching non-default ${provider.source} provider`,
+      ref: {
+        source: provider.source,
+        provider: "shared",
+        id: provider.source === "file" ? "/tool/apiKey" : "TOOL_API_KEY",
+      },
+      secrets: { providers: { shared: provider } },
+      expected: true,
+    })),
+    {
+      name: "missing non-default store provider",
+      ref: { source: "store", provider: "shared", id: "TOOL_API_KEY" },
+      expected: false,
+    },
+    {
+      name: "mismatched non-default store provider",
+      ref: { source: "store", provider: "shared", id: "TOOL_API_KEY" },
+      secrets: { providers: { shared: { source: "file", path: "/tmp/unused.json" } } },
+      expected: false,
+    },
+    {
+      name: "old store default after selecting another alias",
+      ref: { source: "store", provider: "default", id: "TOOL_API_KEY" },
+      secrets: { defaults: { store: "shared" } },
+      expected: false,
+    },
+    ...(["file", "exec"] as const).map((source) => ({
+      name: `undeclared ${source} default`,
+      ref: { source, provider: "default", id: source === "file" ? "/tool/apiKey" : "TOOL_API_KEY" },
+      expected: false,
+    })),
+  ])("checks $name through config-only metadata", ({ ref, secrets, expected }) => {
+    const plugin = makePlugin({
+      toolMetadata: { x_search: { configSignals: [webSearchSignal] } },
+    });
+    const config: OpenClawConfig = {
+      ...xaiConfig({ webSearch: { apiKey: ref } }),
+      secrets,
+    };
+    expect(hasManifestToolAvailability({ plugin, toolNames: ["x_search"], config, env: {} })).toBe(
+      expected,
+    );
   });
 
   it("fails open for tools without availability signals", () => {

--- a/src/plugins/manifest-tool-availability.ts
+++ b/src/plugins/manifest-tool-availability.ts
@@ -2,8 +2,9 @@
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import { coerceSecretRef, type SecretRef } from "../config/types.secrets.js";
+import { coerceSecretRef } from "../config/types.secrets.js";
 import { canResolveEnvSecretRefInReadOnlyPath } from "../plugin-sdk/secret-ref-readonly.internal.js";
+import { isBuiltInDefaultSecretProviderRef } from "../secrets/ref-contract.js";
 import type { PluginManifestRecord } from "./manifest-registry.js";
 import type {
   PluginManifestCapabilityProviderAuthSignal,
@@ -62,34 +63,26 @@ function readEffectiveConfigs(params: {
   return [baseConfig];
 }
 
-function hasConfiguredSecretRefInConfigPath(params: {
-  config?: OpenClawConfig;
-  ref: SecretRef;
-}): boolean {
-  if (params.ref.source === "env") {
-    return canResolveEnvSecretRefInReadOnlyPath({
-      cfg: params.config,
-      provider: params.ref.provider,
-      id: params.ref.id,
-    });
-  }
-  const providerConfig = params.config?.secrets?.providers?.[params.ref.provider];
-  return Boolean(providerConfig && providerConfig.source === params.ref.source);
-}
-
 function hasConfiguredValue(params: {
   config?: OpenClawConfig;
   env: NodeJS.ProcessEnv;
   value: unknown;
 }): boolean {
   const secretRef = coerceSecretRef(params.value, params.config?.secrets?.defaults);
-  if (secretRef) {
+  if (secretRef?.source === "env") {
     return (
-      hasConfiguredSecretRefInConfigPath({
-        config: params.config,
-        ref: secretRef,
-      }) &&
-      (secretRef.source !== "env" || Boolean(params.env[secretRef.id]?.trim()))
+      canResolveEnvSecretRefInReadOnlyPath({
+        cfg: params.config,
+        provider: secretRef.provider,
+        id: secretRef.id,
+      }) && Boolean(params.env[secretRef.id]?.trim())
+    );
+  }
+  if (secretRef) {
+    const providerConfig = params.config?.secrets?.providers?.[secretRef.provider];
+    return (
+      providerConfig?.source === secretRef.source ||
+      isBuiltInDefaultSecretProviderRef(params.config ?? {}, secretRef)
     );
   }
   if (typeof params.value === "string") {

--- a/src/plugins/tools.optional.test.ts
+++ b/src/plugins/tools.optional.test.ts
@@ -3,6 +3,7 @@ import { expectDefined } from "@openclaw/normalization-core";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { DEFAULT_PLUGIN_TOOLS_ALLOWLIST_ENTRY } from "../agents/tool-policy.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import type { SecretRef } from "../config/types.secrets.js";
 import { resetLogger, setLoggerOverride } from "../logging/logger.js";
 import { loggingState } from "../logging/state.js";
 import { resolveInstalledPluginIndexPolicyHash } from "./installed-plugin-index-policy.js";
@@ -1292,7 +1293,29 @@ describe("resolvePluginTools optional tools", () => {
     expect(loadOpenClawPluginsMock).not.toHaveBeenCalled();
   });
 
-  it("loads plugin-owned tools when manifest config signals point at configured non-env SecretRefs", () => {
+  it.each<{
+    name: string;
+    apiKey: SecretRef;
+    secrets: OpenClawConfig["secrets"];
+  }>([
+    {
+      name: "explicit file provider",
+      apiKey: { source: "file", provider: "vault", id: "/xai/tool-key" },
+      secrets: {
+        providers: {
+          vault: { source: "file", path: "/tmp/openclaw-secrets.json", mode: "json" },
+        },
+      },
+    },
+    {
+      name: "store default shadowing file",
+      apiKey: { source: "store", provider: "shared", id: "TOOL_API_KEY" },
+      secrets: {
+        defaults: { store: "shared" },
+        providers: { shared: { source: "file", path: "/tmp/unused-store-alias-fixture.json" } },
+      },
+    },
+  ])("loads plugin-owned tools when manifest config signals use $name", ({ apiKey, secrets }) => {
     const base = createContext();
     const config = {
       ...base.config,
@@ -1302,25 +1325,13 @@ describe("resolvePluginTools optional tools", () => {
           xai: {
             config: {
               webSearch: {
-                apiKey: {
-                  source: "file",
-                  provider: "vault",
-                  id: "/xai/tool-key",
-                },
+                apiKey,
               },
             },
           },
         },
       },
-      secrets: {
-        providers: {
-          vault: {
-            source: "file",
-            path: "/tmp/openclaw-secrets.json",
-            mode: "json",
-          },
-        },
-      },
+      secrets,
     } as const;
     installToolManifestSnapshot({
       config,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users configuring a `store` SecretRef with a source-specific default alias could have credentials reported as unavailable and plugin tools silently hidden when another source declared the same alias. Manifest inspection also rejected an implicit store default when there was no provider declaration.

Related: [#132578 — env SecretRefs with shared default aliases](https://github.com/openclaw/openclaw/pull/132578). This follow-up repairs only the store inspection paths and preserves the env repair.

## Why This Change Was Made

The runtime resolver and config validator already accept these bindings under the [source-specific provider alias contract](https://docs.openclaw.ai/gateway/secrets#provider-config), but the auth and manifest inspectors duplicated a narrower rule. Both now use `isBuiltInDefaultSecretProviderRef` alongside explicit matching-provider checks. The single-use manifest binding helper is removed rather than adding another policy layer.

Auth inspection still returns unknown for a valid unresolved store reference; manifest inspection records only that a valid binding is configured. Neither path opens the secret store or resolves a credential. Explicit matching providers, non-default mismatch rejection, file-provider mode checks, env allowlists, and runtime fail-closed behavior remain unchanged. No SDK API, budget, config option, SQLite schema, or persistence changes.

## User Impact

Valid store-backed credentials remain discoverable without being falsely classified as invalid, and manifest-gated tools are no longer hidden solely because a store default shares an alias with another secret source. Actual secret availability is still established by runtime resolution.

Production LOC: **+16 / -25 (net -9)**. Tests: **+232 / -52 (net +180)**. Docs: **+2 / -0**.

AI-assisted, maintainer-directed repair.

## Evidence

Synthetic fixture: `source: "store"`, `provider: "shared"`, `defaults.store: "shared"`, with `providers.shared` declaring a file provider.

| Boundary | Before | After |
| --- | --- | --- |
| Canonical built-in binding | accepted | accepted |
| Direct/API-key/token read-only availability | `false` | unknown (`undefined`) |
| Manifest configuration signal | `false` | `true` |
| Tool construction | tool missing | tool returned; factory invoked once |

Thirteen intended regression cases failed before the production edits and pass after the repair. The isolated direct probe creates no state files. All proof uses synthetic inputs and isolated homes/state; no live credentials, operator services, or operator state were used.

- Before integrating the merged env-alias repair: 205 tests across the four changed test files passed.
- 97 sibling tests passed across runtime auth planning, config validation, canonical ref validation, store resolution, and SDK read-only env resolution.
- 32 SDK API-key readiness tests passed; unrelated SDK tests were intentionally excluded by the test-name filter.
- Before integration, the full changed-scope gate passed: formatting, core and test types, lint, dead-export checks, import-cycle checks, and the selected architecture guards.
- Fresh isolated autoreview: no accepted/actionable P0 findings.
- Full `pnpm build` passed, including runtime postbuild, SDK export verification, and UI build. The earlier local postbuild failure was traced to missing worktree workspace links, repaired through the pinned package manager without source or shared-install changes.

Post-integration validation on `b0b57c476d439ba59009e42551248aa373b9a694`:

- Both complete six-file runs: **249 passed, one unchanged Code Mode test timed out**. All store-alias regressions and preserved env collision/allowlist cases passed in both runs. The combined local proof is not green.
- Targeted formatting passed for all seven files; typed lint passed for all six TypeScript files with zero warnings/errors; `git diff --check HEAD^ HEAD` passed.
- Affected test types passed: `node scripts/run-tsgo.mjs -b test/tsconfig/tsconfig.core.test.agents-root.json test/tsconfig/tsconfig.core.test.agents-other.json test/tsconfig/tsconfig.core.test.plugins-platform.json --builders 1`.
- The rebase preserves the merged env helper, env collision cases, and both env-provider documentation bullets. There are no dependency-install input changes and no production conflict edits.
- Required exact-head [CI run 33261475169](https://github.com/openclaw/openclaw/actions/runs/33261475169) passed: 168 successful jobs, 17 skipped, no failed or pending jobs. The draft all-skipped run is not counted as proof.
- Supplementary clean-runner proof through **blacksmith-testbox**, lease `tbx_01m175d7gmqw3gx804js8gcx3n`, [backing workflow](https://github.com/openclaw/openclaw/actions/runs/33262900300): the complete optional-plugin tool suite passed **87/87 tests, zero skips**, including the unchanged Code Mode protection/taint test in **5.027 seconds**. The delegated command exited 0 and the lease stopped successfully; backing-workflow cancellation during one-shot cleanup is not the test verdict.
- That run verified the exact PR head, clean tracked tree, and test-file SHA256 `17cffc4f90fe51a4bad31135e4a101cd5dacedc39f390309a126f4f4233a589a` before execution. Vitest duration: 7.67 seconds; process wall time: 11.29 seconds. The test child had fresh synthetic home/state/config/temp directories and an explicit noncredential environment.
- The [latest ClawSweeper review](https://github.com/openclaw/openclaw/pull/132696#issuecomment-5463424060) found no correctness/security findings. Its sole rank-up move—finish required exact-head checks—is satisfied.

Combined post-integration command (isolated home/state/config/temp directories, `OPENCLAW_VITEST_MAX_WORKERS=2`):

```bash
node scripts/run-vitest.mjs src/agents/auth-profiles/read-only-availability.test.ts src/agents/model-auth-availability.test.ts src/plugins/manifest-tool-availability.test.ts src/plugins/tools.optional.test.ts src/plugin-sdk/secret-ref-readonly.test.ts src/secrets/ref-contract.test.ts
```

Earlier focused regression command:

```bash
node scripts/run-vitest.mjs src/agents/auth-profiles/read-only-availability.test.ts src/agents/model-auth-availability.test.ts src/plugins/manifest-tool-availability.test.ts src/plugins/tools.optional.test.ts
```

Sibling command:

```bash
node scripts/run-vitest.mjs src/agents/runtime-plan/prepare-auth.test.ts src/config/validation.policy.test.ts src/secrets/ref-contract.test.ts src/secrets/resolve-store.test.ts src/plugin-sdk/secret-ref-readonly.test.ts
```

SDK readiness command:

```bash
node scripts/run-vitest.mjs src/plugin-sdk/provider-auth.test.ts -t 'provider API-key readiness'
```

Complete supplementary Testbox command (no test-name filter):

```bash
node scripts/run-vitest.mjs src/plugins/tools.optional.test.ts --reporter=verbose
```

The unchanged Code Mode network-tool test hit its existing 120-second timeout on the first cold pre-fix run, passed unchanged in the complete post-fix loader suite, and timed out on both post-integration runs (249 tests passed, one failed each). A subsequent import-profile run timed out in the common `beforeAll` before reaching Code Mode while the local host was overloaded. The exact-head clean-runner pass above closes this proof gap without increasing timeouts, skipping tests, weakening assertions, or changing the test's imports. The compact CI fallback did not include this release-only plugin shard, so the supplementary full-file run is explicit evidence rather than an inference from green aggregate CI. Retaining directly changed plugin tests in that fallback is recorded as a separate follow-up.
