### PR TITLE
fix: show Crabbox help before preparing remote execution

### DIFF
--- a/scripts/crabbox-wrapper.mts
+++ b/scripts/crabbox-wrapper.mts
@@ -78,9 +78,6 @@ const workloadOption = isWorkloadRoutedCommand(args)
   ? extractWrapperValueOption(args, "--workload")
   : undefined;
 const userArgStart = args[0] === "actions" && args[1] === "hydrate" ? 2 : 1;
-if (args[userArgStart] === "--") {
-  args.splice(userArgStart, 1);
-}
 
 function extractWrapperValueOption(commandArgs: string[], name: string) {
   const equalsPrefix = `${name}=`;
@@ -3840,8 +3837,8 @@ if (
   process.exit(2);
 }
 
-// Help must not acquire provider state or materialize a sparse checkout. Only
-// run's parsed option prefix counts; remote arguments and flag values stay gated.
+// Classify help before removing the wrapper separator or preparing execution.
+// Only run's option prefix counts; remote arguments and flag values stay gated.
 // Upstream's `help <command> ...` alias appends --help, so extra payload is not safe.
 const helpFlags = new Set(["--help", "-h"]);
 const runOptions = args[0] === "run" ? parseRunInvocation(help.text, args).options : null;
@@ -3863,6 +3860,10 @@ if (
     console.error(`[crabbox] ${result.error.message}`);
   }
   process.exit(result.status ?? 1);
+}
+
+if (args[userArgStart] === "--") {
+  args.splice(userArgStart, 1);
 }
 
 const providerSelection = selectedProvider(args, providers, version.text);

--- a/scripts/crabbox-wrapper.mts
+++ b/scripts/crabbox-wrapper.mts
@@ -36,8 +36,8 @@ import {
 } from "./testbox-lease-freshness.mts";
 import { resolvePathEnvKey, resolveWindowsCmdExePath } from "./windows-cmd-helpers.mjs";
 
-type RunOption = { index: number; value: string };
-type RunInvocation = ReturnType<typeof parseRunInvocation>;
+type CommandOption = { index: number; value: string };
+type CommandInvocation = ReturnType<typeof parseCommandInvocation>;
 type CommandNormalizeOptions = { canShimIgnoreEnvironment?: boolean };
 type TargetContext = ReturnType<typeof effectiveTargetContext>;
 type ProcessEnv = NodeJS.ProcessEnv;
@@ -74,10 +74,9 @@ const args = process.argv.slice(2);
 if (args[0] === "--") {
   args.shift();
 }
-const workloadOption = isWorkloadRoutedCommand(args)
-  ? extractWrapperValueOption(args, "--workload")
-  : undefined;
-const userArgStart = args[0] === "actions" && args[1] === "hydrate" ? 2 : 1;
+const workloadCommand = isWorkloadRoutedCommand(args);
+const workloadOption = workloadCommand ? extractWrapperValueOption(args, "--workload") : undefined;
+const userArgStart = commandUserArgStart(args);
 
 function extractWrapperValueOption(commandArgs: string[], name: string) {
   const equalsPrefix = `${name}=`;
@@ -108,6 +107,10 @@ function isWorkloadRoutedCommand(commandArgs: string[]) {
     ["run", "warmup"].includes(commandArgs[0] ?? "") ||
     (commandArgs[0] === "actions" && commandArgs[1] === "hydrate")
   );
+}
+
+function commandUserArgStart(commandArgs: string[]) {
+  return commandArgs[0] === "actions" && commandArgs[1] === "hydrate" ? 2 : 1;
 }
 
 function commandCandidates(command: string, platform: Platform) {
@@ -615,9 +618,9 @@ function effectiveTargetContext(commandArgs: string[]) {
   };
 }
 
-let runValueOptionsFromHelp: Set<string>;
+let commandValueOptionsFromHelp: Set<string>;
 
-function parseRunValueOptionsFromHelp(text: string) {
+function parseCommandValueOptionsFromHelp(text: string) {
   const names = new Set<string>();
   for (const line of text.split(/\r?\n/u)) {
     const match = line.match(
@@ -630,44 +633,47 @@ function parseRunValueOptionsFromHelp(text: string) {
   return names;
 }
 
-function runOptionName(arg: string) {
+function commandOptionName(arg: string) {
   return arg.replace(/^-+/u, "").split("=", 1)[0] ?? "";
 }
 
-function parseRunInvocation(helpText: string, commandArgs: string[]) {
-  runValueOptionsFromHelp ??= parseRunValueOptionsFromHelp(helpText);
+function parseCommandInvocation(helpText: string, commandArgs: string[]) {
+  commandValueOptionsFromHelp ??= parseCommandValueOptionsFromHelp(helpText);
+  const routedCommand = isWorkloadRoutedCommand(commandArgs);
+  const optionStart = routedCommand ? commandUserArgStart(commandArgs) : 0;
   let start = -1;
-  let optionEnd = commandArgs.indexOf("--");
+  // A leaf value may itself be --; only unconsumed tokens end its option prefix.
+  let optionEnd = routedCommand ? commandArgs.length : commandArgs.indexOf("--");
   optionEnd = optionEnd < 0 ? commandArgs.length : optionEnd;
-  if (commandArgs[0] === "run") {
-    for (let index = 1; index < commandArgs.length; index += 1) {
+  if (routedCommand) {
+    for (let index = optionStart; index < commandArgs.length; index += 1) {
       const arg = commandArgs[index] ?? "";
       if (arg === "--") {
         start = index + 1;
         optionEnd = index;
         break;
       }
-      if (!arg.startsWith("-")) {
+      if (arg === "-" || !arg.startsWith("-")) {
         start = index;
         optionEnd = index;
         break;
       }
-      if (!arg.includes("=") && runValueOptionsFromHelp.has(runOptionName(arg))) {
+      if (!arg.includes("=") && commandValueOptionsFromHelp.has(commandOptionName(arg))) {
         index += 1;
       }
     }
   }
 
-  const optionEntries: Array<RunOption & { name: string }> = [];
-  const options = new Map<string, RunOption>();
-  for (let index = commandArgs[0] === "run" ? 1 : 0; index < optionEnd; index += 1) {
+  const optionEntries: Array<CommandOption & { name: string }> = [];
+  const options = new Map<string, CommandOption>();
+  for (let index = optionStart; index < optionEnd; index += 1) {
     const arg = commandArgs[index] ?? "";
     if (!arg.startsWith("-")) {
       continue;
     }
-    const name = runOptionName(arg);
+    const name = commandOptionName(arg);
     const assigned = arg.indexOf("=");
-    const consumesValue = commandArgs[0] !== "run" || runValueOptionsFromHelp.has(name);
+    const consumesValue = !routedCommand || commandValueOptionsFromHelp.has(name);
     const entry = {
       index,
       value:
@@ -681,7 +687,7 @@ function parseRunInvocation(helpText: string, commandArgs: string[]) {
     if (!options.has(name)) {
       options.set(name, entry);
     }
-    if (commandArgs[0] === "run" && assigned < 0 && consumesValue) {
+    if (routedCommand && assigned < 0 && consumesValue) {
       index += 1;
     }
   }
@@ -1047,16 +1053,17 @@ function enforceBrokeredCloud(
 
 function optionValue(commandArgsInput: string[], name: string) {
   return (
-    parseRunInvocation(help.text, commandArgsInput).options.get(runOptionName(name))?.value ?? ""
+    parseCommandInvocation(help.text, commandArgsInput).options.get(commandOptionName(name))
+      ?.value ?? ""
   );
 }
 
 function hasOption(commandArgsInput: string[], name: string) {
-  return parseRunInvocation(help.text, commandArgsInput).options.has(runOptionName(name));
+  return parseCommandInvocation(help.text, commandArgsInput).options.has(commandOptionName(name));
 }
 
 function commandOptionEnd(commandArgs: string[]) {
-  return parseRunInvocation(help.text, commandArgs).optionEnd;
+  return parseCommandInvocation(help.text, commandArgs).optionEnd;
 }
 
 function shouldPreferAzureForWindows(commandArgs: string[], advertisedProviders: string[] = []) {
@@ -1126,27 +1133,24 @@ function ensureNativeWindowsHydrateJob(commandArgs: string[]) {
     return commandArgs;
   }
 
-  const currentJob = optionValue(commandArgs, "--job");
-  if (currentJob && currentJob !== "hydrate") {
+  const invocation = parseCommandInvocation(help.text, commandArgs);
+  const job = invocation.options.get("job");
+  if (job?.value && job.value !== "hydrate") {
     return commandArgs;
   }
 
   const normalizedArgs = [...commandArgs];
   const replacementJob = "hydrate-windows-daemon";
-  const optionEnd = commandOptionEnd(normalizedArgs);
-  for (let index = 0; index < optionEnd; index += 1) {
-    const arg = normalizedArgs[index] ?? "";
-    if (arg === "--job" || arg === "-job") {
-      normalizedArgs[index + 1] = replacementJob;
-      return normalizedArgs;
+  if (job) {
+    const arg = normalizedArgs[job.index] ?? "";
+    if (arg.includes("=")) {
+      normalizedArgs[job.index] = `${arg.slice(0, arg.indexOf("=") + 1)}${replacementJob}`;
+    } else {
+      normalizedArgs[job.index + 1] = replacementJob;
     }
-    if (arg.startsWith("--job=") || arg.startsWith("-job=")) {
-      normalizedArgs[index] = `${arg.slice(0, arg.indexOf("=") + 1)}${replacementJob}`;
-      return normalizedArgs;
-    }
+  } else {
+    normalizedArgs.splice(invocation.optionEnd, 0, "--job", replacementJob);
   }
-
-  normalizedArgs.splice(optionEnd, 0, "--job", replacementJob);
   return normalizedArgs;
 }
 
@@ -1181,7 +1185,7 @@ function absolutizeLocalRunPaths(commandArgs: string[]) {
   }
 
   const normalizedArgs = [...commandArgs];
-  const invocation = parseRunInvocation(help.text, normalizedArgs);
+  const invocation = parseCommandInvocation(help.text, normalizedArgs);
   for (const { index, name: optionName } of invocation.optionEntries) {
     const arg = normalizedArgs[index] ?? "";
     const absolutize = optionName === "download" ? repoRelativeDownload : repoRelativePath;
@@ -1433,24 +1437,24 @@ function isLocalContainerProvider(providerName: string) {
   return ["local-container", "docker", "container", "local-docker"].includes(providerName);
 }
 
-function replaceRunPayload(invocation: RunInvocation, payload: string[]) {
+function replaceRunPayload(invocation: CommandInvocation, payload: string[]) {
   const normalizedArgs = [...invocation.args];
   normalizedArgs.splice(invocation.start, normalizedArgs.length - invocation.start, ...payload);
   return normalizedArgs;
 }
 
-function renderRunShellCommand(invocation: RunInvocation, join = shellJoin) {
+function renderRunShellCommand(invocation: CommandInvocation, join = shellJoin) {
   return invocation.options.has("shell") && invocation.commandArgs.length === 1
     ? invocation.commandArgs[0]
     : join(invocation.commandArgs);
 }
 
-function replaceRunCommandWithShell(initialInvocation: RunInvocation, shellCommand: string) {
+function replaceRunCommandWithShell(initialInvocation: CommandInvocation, shellCommand: string) {
   let invocation = initialInvocation;
   if (!invocation.options.has("shell")) {
     const normalizedArgs = [...invocation.args];
     normalizedArgs.splice(invocation.optionEnd, 0, "--shell");
-    invocation = parseRunInvocation(help.text, normalizedArgs);
+    invocation = parseCommandInvocation(help.text, normalizedArgs);
   }
   return replaceRunPayload(invocation, [shellCommand]);
 }
@@ -2540,7 +2544,7 @@ function remoteGitBootstrapForChangedGate(changedGateBase: string, changedGateAl
   ].join(" ");
 }
 
-function injectRemoteChangedGateEnvironment(invocation: RunInvocation, facts: RunFacts) {
+function injectRemoteChangedGateEnvironment(invocation: CommandInvocation, facts: RunFacts) {
   if (invocation.args[0] !== "run" || isNativeWindowsRemoteTarget(invocation.args)) {
     return invocation.args;
   }
@@ -2656,7 +2660,7 @@ function remotePosixHydratedNodeModulesBootstrap() {
 }
 
 function injectRemoteWindowsHydratedNodeModulesBootstrap(
-  invocation: RunInvocation,
+  invocation: CommandInvocation,
   facts: RunFacts,
   providerName: string,
 ) {
@@ -2680,7 +2684,7 @@ function injectRemoteWindowsHydratedNodeModulesBootstrap(
   );
 }
 
-function injectRemotePosixHydratedNodeModulesBootstrap(invocation: RunInvocation) {
+function injectRemotePosixHydratedNodeModulesBootstrap(invocation: CommandInvocation) {
   if (
     invocation.args[0] !== "run" ||
     isWindowsRemoteTarget(invocation.args) ||
@@ -2706,7 +2710,7 @@ function injectRemoteChangedGateGitBootstrap(
     return commandArgs;
   }
 
-  const invocation = parseRunInvocation(help.text, commandArgs);
+  const invocation = parseCommandInvocation(help.text, commandArgs);
   if (invocation.start < 0) {
     return commandArgs;
   }
@@ -3167,7 +3171,7 @@ function readLeadingShellWord(command: string, start: number) {
   return word ? { word, end: command.length } : null;
 }
 
-function analyzeRemoteCommand(invocation: RunInvocation) {
+function analyzeRemoteCommand(invocation: CommandInvocation) {
   const runArgs = invocation.commandArgs;
   const directScopedEnvCommand = invocation.options.has("shell")
     ? null
@@ -3196,7 +3200,7 @@ function analyzeRemoteCommand(invocation: RunInvocation) {
 }
 
 function prepareRemoteWsl2JsBootstrapScript(
-  run: RunInvocation,
+  run: CommandInvocation,
   facts: RunFacts,
   provider: string,
   changedGateBase: string,
@@ -3238,7 +3242,11 @@ function prepareRemoteWsl2JsBootstrapScript(
   };
 }
 
-function injectRemoteAwsMacosJsBootstrap(run: RunInvocation, facts: RunFacts, provider: string) {
+function injectRemoteAwsMacosJsBootstrap(
+  run: CommandInvocation,
+  facts: RunFacts,
+  provider: string,
+) {
   if (
     !isAwsMacosRemoteTarget(run.args, provider) ||
     (!facts.runtimeEntrypoint && !facts.packageManager && !facts.bun)
@@ -3286,7 +3294,7 @@ function remoteAwsMacosSwiftBootstrap() {
 }
 
 function injectRemoteAwsMacosSwiftBootstrap(
-  invocation: RunInvocation,
+  invocation: CommandInvocation,
   facts: RunFacts,
   providerName: string,
   force = false,
@@ -3306,8 +3314,8 @@ function injectRemoteAwsMacosSwiftBootstrap(
 }
 
 function replaceRunFlagWithScript(commandArgs: string[], flagName: string, scriptPath: string) {
-  const invocation = parseRunInvocation(help.text, commandArgs);
-  const normalizedName = runOptionName(flagName);
+  const invocation = parseCommandInvocation(help.text, commandArgs);
+  const normalizedName = commandOptionName(flagName);
   const normalizedArgs = [...commandArgs];
   for (const { index, name } of invocation.optionEntries) {
     if (name === normalizedName) {
@@ -3321,7 +3329,7 @@ function replaceRunFlagWithScript(commandArgs: string[], flagName: string, scrip
 function prepareAwsMacosScriptStdinBootstrap(commandArgs: string[], providerName: string) {
   if (
     !isAwsMacosRemoteTarget(commandArgs, providerName) ||
-    !parseRunInvocation(help.text, commandArgs).options.has("script-stdin")
+    !parseCommandInvocation(help.text, commandArgs).options.has("script-stdin")
   ) {
     return { args: commandArgs, cleanup: () => {}, prepared: false };
   }
@@ -3421,7 +3429,9 @@ function shouldUseFullCheckoutForRemoteSync(commandArgs: string[], _providerName
     return false;
   }
 
-  const changedGate = isChangedGateCommand(parseRunInvocation(help.text, commandArgs).commandArgs);
+  const changedGate = isChangedGateCommand(
+    parseCommandInvocation(help.text, commandArgs).commandArgs,
+  );
   if (changedGate && !isNativeWindowsRemoteTarget(commandArgs)) {
     return true;
   }
@@ -3751,7 +3761,7 @@ function injectRemoteTestboxBootstrap(commandArgs: string[], providerName: strin
   if (commandArgs[0] !== "run" || canonicalProviderName(providerName) !== "blacksmith-testbox") {
     return commandArgs;
   }
-  const invocation = parseRunInvocation(help.text, commandArgs);
+  const invocation = parseCommandInvocation(help.text, commandArgs);
   if (invocation.start < 0) {
     return commandArgs;
   }
@@ -3765,7 +3775,7 @@ function injectRemoteTestboxBootstrap(commandArgs: string[], providerName: strin
 }
 
 function applyRunTransforms(
-  initialInvocation: RunInvocation,
+  initialInvocation: CommandInvocation,
   initialFacts: RunFacts,
   options: {
     changedGateAlias: string;
@@ -3777,7 +3787,7 @@ function applyRunTransforms(
   const markedArgs = injectRemoteChangedGateEnvironment(initialInvocation, initialFacts);
   const localArgs =
     options.childCwd === repoRoot ? markedArgs : absolutizeLocalRunPaths(markedArgs);
-  let invocation = parseRunInvocation(help.text, localArgs);
+  let invocation = parseCommandInvocation(help.text, localArgs);
   const facts = analyzeRemoteCommand(invocation);
 
   const wsl2ScriptBootstrap = prepareRemoteWsl2JsBootstrapScript(
@@ -3788,16 +3798,16 @@ function applyRunTransforms(
     options.changedGateAlias,
   );
   let transformedArgs = wsl2ScriptBootstrap.args;
-  invocation = parseRunInvocation(help.text, transformedArgs);
+  invocation = parseCommandInvocation(help.text, transformedArgs);
   transformedArgs = injectRemoteAwsMacosJsBootstrap(invocation, facts, options.provider);
-  invocation = parseRunInvocation(help.text, transformedArgs);
+  invocation = parseCommandInvocation(help.text, transformedArgs);
   transformedArgs = injectRemoteAwsMacosSwiftBootstrap(
     invocation,
     facts,
     options.provider,
     facts.swift,
   );
-  invocation = parseRunInvocation(help.text, transformedArgs);
+  invocation = parseCommandInvocation(help.text, transformedArgs);
   transformedArgs = injectRemoteWindowsHydratedNodeModulesBootstrap(
     invocation,
     facts,
@@ -3810,7 +3820,7 @@ function applyRunTransforms(
       options.changedGateAlias,
     );
   }
-  invocation = parseRunInvocation(help.text, transformedArgs);
+  invocation = parseCommandInvocation(help.text, transformedArgs);
   transformedArgs = injectRemotePosixHydratedNodeModulesBootstrap(invocation);
   return {
     args: injectRemoteTestboxBootstrap(transformedArgs, options.provider),
@@ -3819,16 +3829,17 @@ function applyRunTransforms(
 }
 
 const version = probeCrabboxMetadata(binary, ["--version"]);
-const help = probeCrabboxMetadata(binary, ["run", "--help"]);
+const helpCommand = workloadCommand ? args.slice(0, userArgStart) : ["run"];
+const help = probeCrabboxMetadata(binary, [...helpCommand, "--help"]);
 const providers = parseProvidersFromHelp(help.text);
-runValueOptionsFromHelp = parseRunValueOptionsFromHelp(help.text);
+commandValueOptionsFromHelp = parseCommandValueOptionsFromHelp(help.text);
 const displayBinary = binary === "crabbox" ? "crabbox" : relative(repoRoot, binary);
 
 if (
   version.status !== 0 ||
   version.text.length === 0 ||
   help.status !== 0 ||
-  runValueOptionsFromHelp.size === 0
+  commandValueOptionsFromHelp.size === 0
 ) {
   console.error(
     `[crabbox] bin=${displayBinary} version=${version.text || "unknown"} providers=${providers.join(",") || "unknown"}`,
@@ -3838,17 +3849,17 @@ if (
 }
 
 // Classify help before removing the wrapper separator or preparing execution.
-// Only run's option prefix counts; remote arguments and flag values stay gated.
+// Only the leaf's option prefix counts; payloads and flag values stay gated.
 // Upstream's `help <command> ...` alias appends --help, so extra payload is not safe.
 const helpFlags = new Set(["--help", "-h"]);
-const runOptions = args[0] === "run" ? parseRunInvocation(help.text, args).options : null;
+const invocationOptions = workloadCommand ? parseCommandInvocation(help.text, args).options : null;
 if (
   helpFlags.has(args[0] ?? "") ||
   helpFlags.has(args[userArgStart] ?? "") ||
-  (args[0] === "help" && args.length <= 2) ||
+  (args[0] === "help" && args.length <= commandUserArgStart(args.slice(1)) + 1) ||
   (["run", "warmup"].includes(args[0] ?? "") && args[1] === "help") ||
-  runOptions?.has("help") ||
-  runOptions?.has("h")
+  invocationOptions?.has("help") ||
+  invocationOptions?.has("h")
 ) {
   const invocation = spawnInvocation(binary, args, process.env, process.platform);
   const result = spawnSync(invocation.command, invocation.args, {
@@ -3992,7 +4003,7 @@ const scriptStdinPrepared = scriptBootstrap.prepared;
 let wsl2ScriptBootstrap = { args: normalizedArgs, cleanup: () => {}, prepared: false };
 try {
   if (shouldUseFullCheckoutForRemoteSync(normalizedArgs, provider)) {
-    const invocation = parseRunInvocation(help.text, normalizedArgs);
+    const invocation = parseCommandInvocation(help.text, normalizedArgs);
     const facts = analyzeRemoteCommand(invocation);
     const changedGate = facts.changedGate ? changedGateBaseForCommand(facts.commandArgs) : null;
     const changedGateBase = changedGate?.resolvedBase ?? "";
@@ -4036,7 +4047,7 @@ function cleanupOnce() {
   cleanupChildCwd();
 }
 
-const invocation = parseRunInvocation(help.text, normalizedArgs);
+const invocation = parseCommandInvocation(help.text, normalizedArgs);
 const commandFacts = analyzeRemoteCommand(invocation);
 const runtimeEntrypoint = commandFacts.runtimeEntrypoint;
 if (

--- a/scripts/crabbox-wrapper.mts
+++ b/scripts/crabbox-wrapper.mts
@@ -3840,6 +3840,31 @@ if (
   process.exit(2);
 }
 
+// Help must not acquire provider state or materialize a sparse checkout. Only
+// run's parsed option prefix counts; remote arguments and flag values stay gated.
+// Upstream's `help <command> ...` alias appends --help, so extra payload is not safe.
+const helpFlags = new Set(["--help", "-h"]);
+const runOptions = args[0] === "run" ? parseRunInvocation(help.text, args).options : null;
+if (
+  helpFlags.has(args[0] ?? "") ||
+  helpFlags.has(args[userArgStart] ?? "") ||
+  (args[0] === "help" && args.length <= 2) ||
+  (["run", "warmup"].includes(args[0] ?? "") && args[1] === "help") ||
+  runOptions?.has("help") ||
+  runOptions?.has("h")
+) {
+  const invocation = spawnInvocation(binary, args, process.env, process.platform);
+  const result = spawnSync(invocation.command, invocation.args, {
+    cwd: repoRoot,
+    stdio: "inherit",
+    windowsVerbatimArguments: invocation.windowsVerbatimArguments,
+  });
+  if (result.error) {
+    console.error(`[crabbox] ${result.error.message}`);
+  }
+  process.exit(result.status ?? 1);
+}
+
 const providerSelection = selectedProvider(args, providers, version.text);
 if (providerSelection.error) {
   console.error(`[crabbox] ${providerSelection.error}`);

--- a/test/scripts/crabbox-wrapper.test.ts
+++ b/test/scripts/crabbox-wrapper.test.ts
@@ -65,6 +65,8 @@ const fakeRunValueOptionHelp = [
 ]
   .map((option) => `  -${option}\n`)
   .join("");
+const fakeWarmupValueOptionHelp = `${fakeRunValueOptionHelp}  -lease-id string\n`;
+const fakeHydrateValueOptionHelp = `${fakeRunValueOptionHelp}  -field value\n  -job string\n`;
 const defaultGitResponses: Record<string, { status?: number; stdout?: string; stderr?: string }> = {
   [GIT_CONFIG_SPARSE_KEY]: { stdout: "false\n" },
   [GIT_SPARSE_LIST_KEY]: { status: 1 },
@@ -109,6 +111,8 @@ async function main() {
   if (process.env.OPENCLAW_FAKE_CRABBOX_INVOCATION_LOG) fs.appendFileSync(process.env.OPENCLAW_FAKE_CRABBOX_INVOCATION_LOG, JSON.stringify(args) + "\n");
   if (args[0] === "--version") { console.log(process.env.OPENCLAW_FAKE_CRABBOX_VERSION || "crabbox 0.22.1"); return; }
   if (args[0] === "run" && args[1] === "--help") { process.stdout.write(helpText); return; }
+  if (args[0] === "warmup" && args[1] === "--help") { process.stdout.write(${JSON.stringify(`${helpText}${fakeWarmupValueOptionHelp}`)}); return; }
+  if (args[0] === "actions" && args[1] === "hydrate" && args[2] === "--help") { process.stdout.write(${JSON.stringify(`${helpText}${fakeHydrateValueOptionHelp}`)}); return; }
   if (args[0] === "doctor") {
     const provider = optionValue("provider"); const target = optionValue("target"); const windowsMode = optionValue("windows-mode");
     if (process.env.OPENCLAW_FAKE_CRABBOX_DOCTOR_PROGRESS) process.stderr.write(process.env.OPENCLAW_FAKE_CRABBOX_DOCTOR_PROGRESS + "\n");
@@ -199,6 +203,14 @@ main().catch((error) => { process.stderr.write(String(error?.stack || error) + "
         "fi",
         'if [ "$#" -eq 2 ] && [ "$1" = "run" ] && [ "$2" = "--help" ]; then',
         `  printf '%s' ${shellQuote(runHelpText)}`,
+        "  exit 0",
+        "fi",
+        'if [ "$#" -eq 2 ] && [ "$1" = "warmup" ] && [ "$2" = "--help" ]; then',
+        `  printf '%s' ${shellQuote(`${helpText}${fakeWarmupValueOptionHelp}`)}`,
+        "  exit 0",
+        "fi",
+        'if [ "$#" -eq 3 ] && [ "$1" = "actions" ] && [ "$2" = "hydrate" ] && [ "$3" = "--help" ]; then',
+        `  printf '%s' ${shellQuote(`${helpText}${fakeHydrateValueOptionHelp}`)}`,
         "  exit 0",
         "fi",
         "fast_run=1",
@@ -2085,21 +2097,38 @@ describe("scripts/crabbox-wrapper", () => {
     );
   });
 
-  it("repairs generic hydrate jobs for native Windows hydrate actions", () => {
-    const { output } = runSuccessfulWindowsHydrate("--job", "hydrate", "--id", "cbx_existing");
+  it.each([[], ["--field", "--job=custom"], ["--field", "--job"]])(
+    "repairs generic hydrate jobs for native Windows hydrate actions: %j",
+    (...prefix) => {
+      const { output } = runSuccessfulWindowsHydrate(
+        ...prefix,
+        "--job",
+        "hydrate",
+        "--id",
+        "cbx_existing",
+      );
 
-    expect(output.args).toEqual(
-      windowsHydrateArgs("--job", "hydrate-windows-daemon", "--id", "cbx_existing"),
-    );
-  });
+      expect(output.args).toEqual(
+        windowsHydrateArgs(...prefix, "--job", "hydrate-windows-daemon", "--id", "cbx_existing"),
+      );
+    },
+  );
 
-  it("repairs generic hydrate job assignments for native Windows hydrate actions", () => {
-    const { output } = runSuccessfulWindowsHydrate("--job=hydrate", "--id", "cbx_existing");
+  it.each([[], ["--field", "--job=custom"], ["--field", "--job"]])(
+    "repairs generic hydrate job assignments for native Windows hydrate actions: %j",
+    (...prefix) => {
+      const { output } = runSuccessfulWindowsHydrate(
+        ...prefix,
+        "--job=hydrate",
+        "--id",
+        "cbx_existing",
+      );
 
-    expect(output.args).toEqual(
-      windowsHydrateArgs("--job=hydrate-windows-daemon", "--id", "cbx_existing"),
-    );
-  });
+      expect(output.args).toEqual(
+        windowsHydrateArgs(...prefix, "--job=hydrate-windows-daemon", "--id", "cbx_existing"),
+      );
+    },
+  );
 
   it("keeps post-delimiter hydrate payloads untouched for native Windows hydrate actions", () => {
     const { output } = runSuccessfulWindowsHydrate(
@@ -3226,6 +3255,14 @@ describe("scripts/crabbox-wrapper", () => {
     ["run", "--help"],
     ["warmup", "--help"],
     ["actions", "hydrate", "--help"],
+    ["warmup", "--provider", "aws", "--help"],
+    ["actions", "hydrate", "--provider", "aws", "--help"],
+    ["warmup", "--keep", "--help"],
+    ["actions", "hydrate", "--reclaim", "--help"],
+    ["help", "actions", "hydrate"],
+    ["run", "--label", "--", "--help"],
+    ["warmup", "--lease-id", "--", "--help"],
+    ["actions", "hydrate", "--field", "--", "--help"],
   ])("prints help without provider checks or sparse checkout preparation: %j", (...args) => {
     const logPath = makeInvocationLog();
     writeFileSync(logPath, "");
@@ -3240,8 +3277,15 @@ describe("scripts/crabbox-wrapper", () => {
     });
 
     expect(result.status).toBe(0);
-    if (args[0] === "run") {
-      expect(result.stdout).toBe(`${defaultProviderHelp}${fakeRunValueOptionHelp}`);
+    const commandLength = args[0] === "actions" ? 2 : 1;
+    if (args.length === commandLength + 1) {
+      const optionHelp =
+        args[0] === "run"
+          ? fakeRunValueOptionHelp
+          : args[0] === "warmup"
+            ? fakeWarmupValueOptionHelp
+            : fakeHydrateValueOptionHelp;
+      expect(result.stdout).toBe(`${defaultProviderHelp}${optionHelp}`);
     } else {
       expect(parseFakeCrabboxOutput(result).args).toEqual(args);
     }
@@ -3258,6 +3302,11 @@ describe("scripts/crabbox-wrapper", () => {
     ["run", "--", "--help"],
     ["warmup", "--", "--help"],
     ["actions", "hydrate", "--", "--help"],
+    ["warmup", "--lease-id", "--help"],
+    ["actions", "hydrate", "--field", "--help"],
+    ["run", "--provider", "aws", "-", "--help"],
+    ["warmup", "--provider", "aws", "-", "--help"],
+    ["actions", "hydrate", "--provider", "aws", "-", "--help"],
   ])("keeps provider gates when help belongs to a payload: %j", (...args) => {
     const result = runDefaultWrapper(args, {
       configJson: directBrokerConfig("aws"),
@@ -3276,8 +3325,11 @@ describe("scripts/crabbox-wrapper", () => {
     expect(result.stderr).toContain("selected binary does not advertise provider bogus");
   });
 
-  it("does not bypass preparation for a help alias containing a remote payload", () => {
-    const result = runDefaultWrapper(["help", "run", "--", "echo ok"], {
+  it.each([
+    ["help", "run", "--", "echo ok"],
+    ["help", "actions", "hydrate", "--", "echo ok"],
+  ])("does not bypass preparation for a help alias containing a remote payload: %j", (...args) => {
+    const result = runDefaultWrapper(args, {
       configJson: managedBrokerConfig("bogus"),
     });
 

--- a/test/scripts/crabbox-wrapper.test.ts
+++ b/test/scripts/crabbox-wrapper.test.ts
@@ -3222,10 +3222,64 @@ describe("scripts/crabbox-wrapper", () => {
     }
   });
 
+  it.each([
+    ["run", "--help"],
+    ["warmup", "--help"],
+    ["actions", "hydrate", "--help"],
+  ])("prints help without provider checks or sparse checkout preparation: %j", (...args) => {
+    const logPath = makeInvocationLog();
+    writeFileSync(logPath, "");
+    const syncRoot = path.join(path.dirname(logPath), "sync");
+    const result = runDefaultWrapper(args, {
+      ...cleanSparseSyncOptions,
+      configJson: managedBrokerConfig("aws"),
+      env: {
+        OPENCLAW_CRABBOX_SYNC_TMPDIR: syncRoot,
+        OPENCLAW_FAKE_CRABBOX_INVOCATION_LOG: logPath,
+      },
+    });
+
+    expect(result.status).toBe(0);
+    if (args[0] === "run") {
+      expect(result.stdout).toBe(`${defaultProviderHelp}${fakeRunValueOptionHelp}`);
+    } else {
+      expect(parseFakeCrabboxOutput(result).args).toEqual(args);
+    }
+    expect(existsSync(syncRoot)).toBe(false);
+    expect(
+      readInvocations(logPath).filter(([command]) => command === "config" || command === "doctor"),
+    ).toEqual([]);
+  });
+
+  it.each([
+    ["--label", "--help", "--", "echo ok"],
+    ["--", "--help"],
+    ["node", "--help"],
+  ])("keeps provider gates when help belongs to the run payload: %j", (...payload) => {
+    const result = runDefaultWrapper(["run", "--provider", "aws", ...payload], {
+      configJson: directBrokerConfig("aws"),
+      env: { OPENCLAW_FAKE_CRABBOX_MISSING_BROKER_PROVIDERS: "aws" },
+    });
+
+    expect(result.status).toBe(2);
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toContain("provider=aws failed readiness for OpenClaw proof");
+  });
+
   it("keeps unsupported provider selections rejected", () => {
     const result = runDefaultWrapper(["run", "--provider", "bogus", "--", "echo ok"]);
 
     expect(result.status).toBe(2);
+    expect(result.stderr).toContain("selected binary does not advertise provider bogus");
+  });
+
+  it("does not bypass preparation for a help alias containing a remote payload", () => {
+    const result = runDefaultWrapper(["help", "run", "--", "echo ok"], {
+      configJson: managedBrokerConfig("bogus"),
+    });
+
+    expect(result.status).toBe(2);
+    expect(result.stdout).toBe("");
     expect(result.stderr).toContain("selected binary does not advertise provider bogus");
   });
 

--- a/test/scripts/crabbox-wrapper.test.ts
+++ b/test/scripts/crabbox-wrapper.test.ts
@@ -3252,11 +3252,14 @@ describe("scripts/crabbox-wrapper", () => {
   });
 
   it.each([
-    ["--label", "--help", "--", "echo ok"],
-    ["--", "--help"],
-    ["node", "--help"],
-  ])("keeps provider gates when help belongs to the run payload: %j", (...payload) => {
-    const result = runDefaultWrapper(["run", "--provider", "aws", ...payload], {
+    ["run", "--provider", "aws", "--label", "--help", "--", "echo ok"],
+    ["run", "--provider", "aws", "--", "--help"],
+    ["run", "--provider", "aws", "node", "--help"],
+    ["run", "--", "--help"],
+    ["warmup", "--", "--help"],
+    ["actions", "hydrate", "--", "--help"],
+  ])("keeps provider gates when help belongs to a payload: %j", (...args) => {
+    const result = runDefaultWrapper(args, {
       configJson: directBrokerConfig("aws"),
       env: { OPENCLAW_FAKE_CRABBOX_MISSING_BROKER_PROVIDERS: "aws" },
     });


### PR DESCRIPTION
## What Problem This Solves

Asking the Crabbox wrapper for help could run provider readiness checks and materialize a full temporary checkout from a clean sparse checkout. During release verification, `run --help` spent more than seven minutes preparing the repository before it was interrupted. No lease was needed or created.

## Why This Change Was Made

Delegate informational help to the selected Crabbox binary after its existing metadata sanity check, before provider selection, lease checks, script preparation, or sparse-sync preparation. Classify the original argument boundary before removing the optional wrapper separator. The binary still owns help text, streams, and exit status.

The existing argument parser now serves all workload-routed leaves (`run`, `warmup`, and `actions hydrate`) using each leaf's actual advertised value options. This replaces the run-only parser rather than adding another grammar. Exact help aliases use the same leaf boundary. Option values, arguments after `--`, and remote payloads containing help remain subject to the normal execution gates; unknown flags retain the upstream error. No extra metadata probe, provider policy, configuration, dependency, timeout, or product runtime change.

## User Impact

Maintainers can inspect help without preparing a remote execution environment. This is internal developer tooling; product runtime is unchanged and no release-note change is needed.

## Evidence

- Original regression: `run --help` returned help but created the sparse-sync directory. Separate leaf regressions observed configuration reads and provider readiness during help. The four option-prefixed warmup/hydrate cases failed before the shared-parser change; the nested `help actions hydrate` case failed before using the shared leaf boundary.
- Final focused and sibling run: **41 passed**, covering all changed help paths, payload/value/delimiter rejection, ordinary warmup, and hydrate jobs. One fake CLI fixture needed its real upstream `job string` option declared when the parser began consuming hydrate metadata; no production exception was added.
- Actual installed **Crabbox 0.41.1**, real clean sparse Git fixture: **29 cases passed** with identical direct-versus-wrapper stdout, stderr, and status. Coverage includes three leaves, short help, option-prefixed help, boolean flags, help-looking option values, unknown-flag errors, and exact aliases. Wrapper calls took 112–299 ms. HEAD, index, sparse selection, and worktree registry stayed unchanged; no sync directory, HOME state, or lease was created. These small-fixture timings are not an end-to-end benchmark of the interrupted full-repository checkout.
- Local full-file limitations are retained: an earlier revision passed 245/246 tests with one unchanged Git transport timeout. The later shared-parser full-file attempt recorded 237 passing tests and 20 failures: 19 existing Git/startup timeouts on the heavily loaded host, plus the missing fake hydrate `job` declaration fixed above. That run was interrupted and its owned process tree was joined. No deadlines were increased or assertions weakened, and the final focused run passed. Fresh exact-head hosted CI remains the complete-suite gate.
- The requested P2 review found three parser-boundary issues: standalone dash handling, consumed delimiter values, and a raw-token hydrate job rewrite. All ten new regression cases failed before correction and passed afterward. The shared parser now follows those Go flag boundaries, and the job rewriter uses the parsed option index; its old raw scan is removed. The final changed-file gate passed, and the follow-up Codex P2 review reported no actionable findings.

Internal tooling: +108/-71 (net +37); tests/test support: +121/-12 (net +109). The tooling count includes private parser/type renames. The positive delta owns early informational dispatch and one shared leaf grammar; product runtime LOC is zero.

Named follow-up outside this patch: the live-test helper imports the LLM stream graph before five otherwise tiny helper tests. That separately observed startup cost needs its own owner investigation.
