### PR TITLE
fix(ci): keep canceled docs-agent runs out of review history

### DIFF
--- a/.github/workflows/docs-agent.yml
+++ b/.github/workflows/docs-agent.yml
@@ -93,8 +93,7 @@ jobs:
               '.workflow_runs[]
                 | select(.id != $current_run_id)
                 | select(.created_at >= $one_hour_ago)
-                | select(.status != "cancelled")
-                | select((.conclusion // "") != "skipped")
+                | select(.conclusion != "cancelled" and .conclusion != "skipped")
                 | [.id, .status, (.conclusion // ""), .created_at, .head_sha]
                 | @tsv' "$runs_json"
           )"
@@ -112,8 +111,7 @@ jobs:
               --arg remote_main "$remote_main" \
               '.workflow_runs[]
                 | select(.id != $current_run_id)
-                | select(.status != "cancelled")
-                | select((.conclusion // "") != "skipped")
+                | select(.conclusion != "cancelled" and .conclusion != "skipped")
                 | .head_sha
                 | select(. != null and . != "")
                 | select(. != $remote_main)

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -880,7 +880,9 @@ Quality stays separate from security so quality findings can be scheduled, measu
 
 ### Docs Agent
 
-The `Docs Agent` workflow is an event-driven Codex maintenance lane for keeping existing docs aligned with recently landed changes. It has no pure schedule: a successful non-bot push CI run on `main` can trigger it, and manual dispatch can run it directly. Workflow-run invocations skip when `main` has moved on or when another non-skipped Docs Agent run was created in the last hour. When it runs, it reviews the commit range from the previous non-skipped Docs Agent source SHA to current `main`, so one hourly run can cover all main changes accumulated since the last docs pass.
+The `Docs Agent` workflow is an event-driven Codex maintenance lane for keeping existing docs aligned with recently landed changes. It has no pure schedule: a successful non-bot push CI run on `main` can trigger it, and manual dispatch can run it directly. Workflow-run invocations skip when `main` has moved on or when another eligible Docs Agent workflow-run invocation was created in the last hour. Canceled and skipped workflow conclusions are excluded from both hourly cadence and review-base selection; active runs with no conclusion still count. When admitted, the agent reviews the commit range from the previous eligible invocation's source SHA to current `main`.
+
+History eligibility tracks workflow attempts, not completed docs reviews: a gate-rejected attempt that finishes successfully remains eligible history.
 
 ### Duplicate PRs After Merge
 

--- a/test/scripts/docs-agent-workflow.test.ts
+++ b/test/scripts/docs-agent-workflow.test.ts
@@ -88,6 +88,7 @@ describe.skipIf(process.platform === "win32")("Docs Agent gate", () => {
   it.each([
     ["in progress", "in_progress", null],
     ["completed", "completed", "success"],
+    ["failed", "completed", "failure"],
   ])("throttles another %s run and prints its REST id", (_label, status, conclusion) => {
     const other = { ...currentRun, id: 122, status, conclusion, head_sha: previousSha };
     const result = runGate([currentRun, other]);
@@ -114,14 +115,25 @@ describe.skipIf(process.platform === "win32")("Docs Agent gate", () => {
     expect(result.output).toBe(admittedOutput(previousSha));
   });
 
-  it("ignores skipped runs and uses a prior run outside the hourly window", () => {
+  it.each([
+    ["skipped", currentRun.created_at],
+    ["cancelled", currentRun.created_at],
+    ["cancelled", "2026-08-28T22:29:59Z"],
+  ])("ignores %s history from %s for cadence and review base", (conclusion, createdAt) => {
     const result = runGate([
       currentRun,
-      { ...currentRun, id: 122, status: "completed", conclusion: "skipped", head_sha: parentSha },
+      {
+        ...currentRun,
+        id: 122,
+        created_at: createdAt,
+        status: "completed",
+        conclusion,
+        head_sha: parentSha,
+      },
       {
         ...currentRun,
         id: 121,
-        created_at: "2026-08-28T22:29:59Z",
+        created_at: "2026-08-28T22:29:58Z",
         status: "completed",
         conclusion: "success",
         head_sha: previousSha,


### PR DESCRIPTION
Closes #132669.

Related: https://github.com/openclaw/openclaw/pull/132640 (the already-landed, separate REST current-run ID repair).

<details>
<summary>Additional instructions</summary>

This is a same-repository branch; maintainers can update it.

</details>

## What Problem This Solves

Resolves a problem where canceled Docs Agent workflow runs suppress a later docs pass or advance its review base despite no review having occurred. GitHub reports terminal cancellation as `status="completed"`, `conclusion="cancelled"`; the existing cancellation exclusions checked the lifecycle status instead.

## Why This Change Was Made

Both history selectors now exclude canceled and skipped **conclusions** in one predicate. Active/null-conclusion history, existing success/failure handling, current REST ID exclusion, trusted-event checks, manual dispatch, concurrency, and Git/process lifecycles are unchanged. The tests extend the existing real-YAML gate harness from #132640 rather than introduce a second execution path.

Provenance: the explicit exclusions were introduced by the 2026-04-23 throttling commit, authored and committed directly by @steipete: https://github.com/openclaw/openclaw/commit/f7c4d7a5f0c4efece9d93e2c82f35111bb89ee7f. No PR is associated with that direct commit. The source check uses that original diff, not the shallow checkout's July blame boundary.

Production/workflow LOC: +2/-4 (net **-2**). Tests: +15/-3 (net +12). Docs: +3/-1 (net +2). No helper, dependency, configuration, or compatibility path is added.

## User Impact

Automatic Docs Agent history no longer treats a canceled attempt as an hourly-cadence reservation or review-range boundary. Existing operator controls and other workflow outcomes retain their behavior. This is workflow maintenance only; there are no Gateway, app, or operator-state changes.

The CI documentation explicitly describes the cancellation policy and distinguishes workflow history from completed docs review.

## Evidence

Live REST inspection on 2026-08-29 confirmed [run 33252918938](https://github.com/openclaw/openclaw/actions/runs/33252918938) has `status="completed"`, `conclusion="cancelled"`, and an empty jobs list. This matches the [GitHub workflow-runs REST contract](https://docs.github.com/en/rest/actions/workflow-runs#list-workflow-runs-for-a-workflow).

Regression proof executes the actual checked-in YAML `gate` shell with real Bash and jq; only Git, REST, and time are fixture-controlled. Before the repair, both new cancellation cases failed: a recent canceled run returned `run_agent=false`, and an older canceled run supplied its source SHA instead of the prior eligible SHA. The other eight cases passed, including the added failure-throttle control.

After the repair, all **10 gate tests pass**, including both cancellation regressions and the existing current-ID, skipped, active, successful, failed, superseded-source, and manual-dispatch behavior.

Completed local validation:

```bash
node scripts/run-vitest.mjs test/scripts/docs-agent-workflow.test.ts
```

```bash
node scripts/check-changed.mjs -- .github/workflows/docs-agent.yml test/scripts/docs-agent-workflow.test.ts docs/ci.md
```

```bash
pnpm check:workflows
```

```bash
actionlint .github/workflows/docs-agent.yml
```

```bash
git diff --check
```

The changed gate passed formatting, root-test typechecking, scripts lint, and its selected guards. The full workflow check passed actionlint, zizmor, composite-action interpolation, and conflict-marker checks. Independent Codex autoreview returned scoped-clean with no accepted/actionable findings at its default P0 threshold. Only test-title shortening and formatter output followed that review; behavior was unchanged.

The worktree initially lacked dependency launchers; one repository-native `pnpm install` restored them without any tracked dependency changes. All subsequent validation completed successfully.

### Scope and remaining proof boundary

No Docs Agent workflow was enabled or manually dispatched, and no paid agent or docs-publication step was executed for proof. Full workflow dispatch would cross the explicitly excluded paid/publication boundary; live REST evidence and local execution of the real decision gate cover this shell/REST repair without those side effects. No packaged/runtime build is needed because this change does not touch shipped bundles or module boundaries.

Named follow-up: **Docs Agent admission and review-coverage bookkeeping**. A gate-rejected workflow may finish `success`, so conclusion filtering does not prove admission or a completed review. [Run 33257441802](https://github.com/openclaw/openclaw/actions/runs/33257441802) provides live evidence: superseded-source rejection, successful job, all agent/publication steps skipped. That separate producer-owned decision is intentionally not redesigned here. This is also not the GNU timeout/process-tree repair.

AI-assisted; the code, dependency contract, and before/after gate behavior were inspected directly.
