### PR TITLE
perf(build): reuse canonical paths in boundary snapshots

### DIFF
--- a/scripts/lib/extension-boundary-inputs.mts
+++ b/scripts/lib/extension-boundary-inputs.mts
@@ -136,8 +136,7 @@ export class BoundaryInputSnapshot {
       const names: { name: string; directory: string }[] = [];
       const visited = new Map<string, boolean>();
       const active = new Set<string>();
-      const visit = (directory: string, installed = false) => {
-        const realDirectory = fs.realpathSync(directory);
+      const visit = (directory: string, realDirectory: string, installed = false) => {
         if (
           active.has(realDirectory) ||
           visited.get(realDirectory) === true ||
@@ -151,7 +150,7 @@ export class BoundaryInputSnapshot {
         active.add(realDirectory);
         const add = (name: string) => names.push({ name, directory: realDirectory });
         const entries = fs
-          .readdirSync(directory, { withFileTypes: true })
+          .readdirSync(realDirectory, { withFileTypes: true })
           .toSorted((left, right) => (left.name < right.name ? -1 : 1));
         for (const entry of entries) {
           const file = path.join(directory, entry.name);
@@ -184,7 +183,12 @@ export class BoundaryInputSnapshot {
             add(`${id}:${isDirectory ? "directory" : "file"}`);
           }
           if (isDirectory) {
-            visit(file, installed || entry.name === "node_modules");
+            // Extend the canonical parent path for ordinary children; resolve only links.
+            // Rewalking every ancestor multiplies metadata calls across installed trees.
+            const canonical = entry.isSymbolicLink()
+              ? fs.realpathSync(file)
+              : path.join(realDirectory, entry.name);
+            visit(file, canonical, installed || entry.name === "node_modules");
           } else if (/\.(?:[cm]?[jt]sx?|json)$/u.test(entry.name)) {
             add(id);
           }
@@ -194,8 +198,8 @@ export class BoundaryInputSnapshot {
       // A failed lookup can be outside declared roots. Name/existence changes in
       // the local resolution namespace invalidate conservatively; unrelated byte
       // edits do not. Installed package contents are included, not just lockfiles.
-      visit(this.rootDir);
-      this.topology = names;
+      visit(this.rootDir, fs.realpathSync(this.rootDir));
+      this.topology = names.toSorted((left, right) => (left.name < right.name ? -1 : 1));
     }
     // Workspace aliases can expose this producer's outputs as installed inputs.
     // Keep their link identities, and retain the same subtree for other consumers.
@@ -207,7 +211,6 @@ export class BoundaryInputSnapshot {
             (directory !== outputRoot && !directory.startsWith(`${outputRoot}${path.sep}`)),
         )
         .map(({ name }) => name)
-        .toSorted()
         .join("\0"),
     );
   }

--- a/test/scripts/build-artifact-cache.test.ts
+++ b/test/scripts/build-artifact-cache.test.ts
@@ -91,6 +91,32 @@ function fixture(noEmit = false, outputRoot = "dist") {
 }
 
 describe("native owner content records", () => {
+  it("traverses deep namespace candidates without resolving ordinary ancestors again", () => {
+    const f = fixture(true);
+    const depth = 32;
+    const nested = `namespace/${"nested/".repeat(depth)}`;
+    f.write(`${nested}candidate.ts`, "export {};");
+    const originalRealpath = fs.realpathSync;
+    let resolutions = 0;
+    fs.realpathSync = new Proxy(originalRealpath, {
+      apply(target, receiver, args) {
+        resolutions += 1;
+        return Reflect.apply(target, receiver, args);
+      },
+    });
+    let first: string;
+    try {
+      const snapshot = new BoundaryInputSnapshot(f.root);
+      first = snapshot.signature(f.config, f.args, []);
+      expect(snapshot.signature(f.config, f.args, [])).toBe(first);
+    } finally {
+      fs.realpathSync = originalRealpath;
+    }
+    expect(resolutions).toBeLessThan(depth);
+    f.write(`${nested}added.ts`, "export {};");
+    expect(new BoundaryInputSnapshot(f.root).signature(f.config, f.args, [])).not.toBe(first);
+  });
+
   it("seals a cold producer reached through its own workspace package alias", () => {
     const f = fixture(false, "packages/sdk/dist");
     f.write("packages/sdk/package.json", '{"name":"fixture-sdk","type":"module"}');


### PR DESCRIPTION
Related: #132631 (historical boundary preparation timeout; remains open).

## What Problem This Solves

Source-checkout plugin boundary checks and declaration-consuming lint repeatedly canonicalize every ordinary directory while capturing the resolution namespace. Profiling confirmed substantial redundant filesystem metadata work across installed package trees.

This PR publishes a measured work reduction. **Neither the historical 420-second publication-tail timeout in #132631 nor the separate earlier instrumented pre-entry stall reproduced during this repair; their exact causes remain unproven.** The baseline itself passed. This is not a claim that either historical stall is diagnosed or that all timeouts are eliminated.

## Why This Change Was Made

The namespace owner now carries the canonical parent path through ordinary Dirent directories, resolves symbolic links, reads the canonical directory, and retains logical namespace names. Captured topology is sorted once instead of once per signature. The inspected Node 26 `fs.realpathSync` implementation walks ancestors using a per-call `knownHard` set and native `binding.lstat`; resolving every ordinary descendant repeats that work.

This keeps one traversal and the existing public filesystem contract. It adds no cache, dependency, configuration, retry, fallback, narrower input policy, or timeout/heap/worker increase. Native, linked and external packages, cycles, installed-policy upgrades, dangling links, output-alias exclusion, source fences, output validity, and coordinator contracts remain covered. Timeout tuning or replacing the public filesystem contract would not repair this redundant discovery at its owner.

## User Impact

Developers running plugin boundary validation and normal plugin lint avoid redundant path canonicalization while preserving input/output validity. There is no application-runtime, package-output, loader, export, configuration, or public SDK behavior change.

The observed profiles do **not** establish an overall speedup: directory I/O varied substantially under uncontrolled host/cache conditions. The historical stalls remain a separate investigation tracked by #132631.

## Evidence

Frozen source base: `f5eea3197c55c0ed0e609d182bd88a7f09ec55e9`. All local proof below predates publication and used the exact source bytes in this PR. No source changes followed the accepted isolated Codex autoreview (no findings in its P0/blocker scope; the reviewer did not run tests).

### Measured work, not an end-to-end speed claim

| Namespace operation | Baseline | Candidate |
| --- | ---: | ---: |
| Preparer `realpathSync` calls | 39,930 | 108 |
| Preparer native `binding.lstat` calls | 481,365 | 1,446 |
| Checker `realpathSync` calls | 26,620 | 72 |
| Checker native `binding.lstat` calls | 320,910 | 964 |
| Preparer directory reads | 39,828 | 39,819 |
| Checker directory reads | 26,552 | 26,546 |
| Preparer / checker link reads | 2,592 / 1,728 | 2,592 / 1,728 |

These are instrumented Node filesystem API/native-binding counts, **not privileged OS syscall tracing**. Minor directory-count differences are observed snapshot differences; traversal coverage was not narrowed. Inclusive preparer canonicalization time fell from 53.879s to 0.030s, but directory-read time rose from 43.798s to 122.598s. Total instrumented wall time was 461.217s baseline versus 473.454s candidate; both passed. Timings include observational overhead, are not controlled comparisons, and nested inclusive timings must not be summed.

### Regression and real command proof

The new 32-level namespace regression failed before the production edit: 37 `realpathSync` calls against a bound of fewer than 32. It passes with the repair, still checks stable repeated signatures, and verifies that deep additions invalidate signatures.

```sh
# 79 owner/native/lifecycle tests passed
node scripts/run-vitest.mjs test/scripts/build-artifact-cache.test.ts test/scripts/prepare-extension-package-boundary-artifacts.test.ts test/scripts/check-extension-package-tsc-boundary.test.ts test/scripts/dist-artifact-ownership.test.ts
# 40 entry/startup tests passed
node scripts/run-vitest.mjs test/scripts/direct-run-entrypoints.test.ts
# Actual changed gate passed in 353.801s
node scripts/check-changed.mjs -- scripts/lib/extension-boundary-inputs.mts test/scripts/build-artifact-cache.test.ts
# Unmodified boundary command, full and warm on Node 24.20.0 and 26.7.0
node --import ./scripts/tsx.mjs scripts/check-extension-package-tsc-boundary.mts
# Normal plugin lint reached actual oxlint and native tsgolint; passed in 565.313s
node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.extensions.json extensions
```

| Uninstrumented boundary flow | Wall | Preparation | Plugin compiles / cache hits | Declaration owners emitted | Canary |
| --- | ---: | ---: | --- | ---: | ---: |
| Node 24.20.0 full | 415.143s | 222.583s | 123 / 0 | 8 | 1 |
| Node 24.20.0 warm | 56.271s | 28.051s | 0 / 123 | 0 | 1 |
| Node 26.7.0 full | 345.059s | 118.293s | 123 / 0 | 8 | 1 |
| Node 26.7.0 warm | 97.877s | 52.700s | 0 / 123 | 0 | 1 |

All exited 0 with unchanged deadlines and no tuning overrides. Runtime identity changes naturally invalidated all 131 records for each full run. Warm runs and normal lint preserved all 131 records exactly. Packaged `dist` remained identical: 12,328 entries / 12,066 files. This traversal-only patch required no gratuitous new package build; earlier package proof is historical, not new proof for this PR.

One earlier control was incomplete because its observer raced a disappearing process and lost the checker join; it is **not** counted as a pass. Its retained ownership record was recovered once on bounded positive owner/command-graph evidence and archived. Both retained archives remain preserved. Successful final commands joined with no observed task survivors or current owner entries; no universal detached-child cleanup guarantee is claimed.

Tooling LOC: +10/-7 (net +3). Tests: +26/-0. The small tooling growth explicitly carries the canonical path and documents its invariant; it adds no abstraction or policy surface. This is the complete delta for this PR, not an earlier repair's reduction.

AI-assisted with Codex. The owner flow, regression, measured work reduction, and remaining causal uncertainty were inspected and accepted for publication. Final landing remains a separate lead decision.


### Published-head CI and review

Head: `2970d2121b51e7a666105df91bf43364da92ffa1`. [CI run 33261930287, attempt 2](https://github.com/openclaw/openclaw/actions/runs/33261930287/attempts/2) is green, including the required `openclaw/ci-gate`. The [actual plugin package-boundary lane](https://github.com/openclaw/openclaw/actions/runs/33261930287/job/99125311797) and [normal lint lane](https://github.com/openclaw/openclaw/actions/runs/33261930287/job/99125311717) passed in attempt 1.

The first attempt failed only in `check-lint-core-3` setup: the Matrix 0.6.6 postinstall library download hit `connect ETIMEDOUT`, followed by its error handler's `ReferenceError: err is not defined`. The lint step never ran in that attempt. A failed-jobs rerun was requested on the unchanged commit; GitHub re-executed selected dependency lanes in attempt 2 and passed; no source, dependency, deadline, or workflow changes were made, and no checks were bypassed.

The [complete ClawSweeper review](https://github.com/openclaw/openclaw/pull/132701#issuecomment-5463461564), reviewed at 2026-08-29 16:10 UTC on this exact head, reports no correctness/security findings and no mechanical repair. Its procedural request to read the latest review/Rank-up guidance has been completed; no separate earlier Rank-up moves were present. Exact-head CI is now green. Ordinary maintainer judgment remains with the lead before landing. The +3 tooling-line rationale above is retained; no mechanical LOC workaround was added.

GitHub reports `MERGEABLE` / `CLEAN`. Live rules require `openclaw/ci-gate` from GitHub Actions and do not require an independent approval; this does not replace the lead's landing decision. The historical publication-tail and earlier startup causes remain unproven, directory-I/O variability remains explicit, and #132631 stays open.
