### PR TITLE
fix(ui): stop Models requests after leaving the page

### DIFF
--- a/ui/src/pages/model-providers/load.test.ts
+++ b/ui/src/pages/model-providers/load.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import { GatewayPendingRequests } from "../../../../packages/gateway-client/src/pending-request.js";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import { loadModelProviderCost, loadModelProvidersData, loadModelProviderUsage } from "./load.ts";
 
@@ -236,27 +237,51 @@ describe("loadModelProvidersData", () => {
     });
   });
 
-  it("cancels both supplemental requests through the shared task signal", async () => {
-    const request = vi.fn(async (method: string) =>
-      method === "usage.status"
-        ? { updatedAt: 1, providers: [] }
-        : { aggregates: { byProvider: [] } },
-    );
-    const client = { request } as unknown as GatewayBrowserClient;
-    const signal = new AbortController().signal;
-
-    await Promise.all([
-      loadModelProviderUsage(client, signal),
-      loadModelProviderCost(client, signal),
-    ]);
-
-    expect(request).toHaveBeenCalledWith("usage.status", undefined, { signal });
-    expect(request).toHaveBeenCalledWith(
-      "sessions.usage",
-      expect.objectContaining({ agentScope: "all", groupBy: "family" }),
-      { signal },
-    );
-  });
+  it.each(["before dispatch", "while pending"] as const)(
+    "retires both supplemental requests when aborted %s",
+    async (when) => {
+      const pending = new GatewayPendingRequests({
+        createRequestId: () => "models-test",
+        nowMs: () => 0,
+      });
+      const sent: Array<{ method: string; params?: Record<string, unknown> }> = [];
+      const sender = {
+        send(frame: string) {
+          sent.push(JSON.parse(frame));
+        },
+      };
+      const client = {
+        request: <T>(...args: Parameters<GatewayBrowserClient["request"]>) =>
+          pending.request<T>(sender, ...args),
+      } as GatewayBrowserClient;
+      const controller = new AbortController();
+      if (when === "before dispatch") {
+        controller.abort();
+      }
+      const loading = Promise.allSettled([
+        loadModelProviderUsage(client, controller.signal),
+        loadModelProviderCost(client, controller.signal),
+      ]);
+      try {
+        if (when === "while pending") {
+          expect(sent.map(({ method }) => method)).toEqual(["usage.status", "sessions.usage"]);
+          expect(sent[0]?.params).toBeUndefined();
+          expect(sent[1]?.params).toMatchObject({ agentScope: "all", groupBy: "family" });
+          expect(sent[1]?.params).not.toHaveProperty("agentId");
+          expect(pending.hasPending).toBe(true);
+          controller.abort();
+        } else {
+          expect(sent).toEqual([]);
+        }
+        expect(pending.hasPending).toBe(false);
+        expect(await loading).toMatchObject([{ status: "rejected" }, { status: "rejected" }]);
+      } finally {
+        // Release any leaked wait if a cancellation regression makes the assertion fail.
+        pending.flush(new Error("test cleanup"));
+        await loading;
+      }
+    },
+  );
 
   it("surfaces an explicit catalog refresh failure while retaining cached configured models", async () => {
     const request = vi.fn(async (method: string, params?: unknown) => {

--- a/ui/src/pages/model-providers/load.ts
+++ b/ui/src/pages/model-providers/load.ts
@@ -1,6 +1,6 @@
 // Fetches the gateway signals behind the Models settings page.
-// Each source degrades independently: a missing usage hook or an older
-// gateway must not blank the provider list.
+// Each source degrades independently: unavailable usage data must not blank
+// the provider list.
 import type { SessionModelUsage } from "../../../../src/infra/session-cost-usage.types.js";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import type {
@@ -76,12 +76,6 @@ export async function loadModelProvidersData(
   client: GatewayBrowserClient,
   opts: { agentId: string; refresh?: boolean; signal?: AbortSignal },
 ): Promise<ModelProvidersData> {
-  const request = <T>(method: string, params?: unknown): Promise<T> =>
-    opts?.signal
-      ? client.request<T>(method, params, { signal: opts.signal })
-      : params === undefined
-        ? client.request<T>(method)
-        : client.request<T>(method, params);
   const loadConfiguredCatalog = (loadOpts: { preparedOnly?: true; refresh?: true }) =>
     settleRequest(
       loadModelCatalog(client, {
@@ -101,7 +95,8 @@ export async function loadModelProvidersData(
     settleRequest(loadModelAuthStatus(client, opts)),
     catalogLoad,
     catalogRefresh ?? Promise.resolve(undefined),
-    request<ConfigSnapshot>("config.get", {})
+    client
+      .request<ConfigSnapshot>("config.get", {}, { signal: opts.signal })
       .then((snapshot) => resolveEditableSnapshotConfig(snapshot))
       .catch(() => null),
   ]);

--- a/ui/src/pages/model-providers/route.test.ts
+++ b/ui/src/pages/model-providers/route.test.ts
@@ -1,0 +1,276 @@
+// @vitest-environment node
+import { createRouter } from "@openclaw/uirouter";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../../../test/helpers/promise.js";
+import type { AgentsListResult } from "../../api/types.ts";
+import { createAgentSelectionCapability } from "../../app/agent-selection.ts";
+import type { ApplicationContext } from "../../app/context.ts";
+import {
+  createGatewayStoreTestStore,
+  GATEWAY_STORE_TEST_HELLO,
+  stubGatewayStoreTestGlobals,
+} from "../../app/gateway-store.test-support.ts";
+import { createAgentCapability } from "../../lib/agents/index.ts";
+import { setAvatarGatewayOrigin } from "../../lib/identity-avatar-context.ts";
+import { page, type ModelProvidersRouteData } from "./route.ts";
+
+const modelMethods = ["models.authStatus", "models.list", "config.get"];
+const roster = {
+  defaultId: "main",
+  mainKey: "main",
+  scope: "per-sender",
+  agents: [{ id: "main" }, { id: "research" }],
+} satisfies AgentsListResult;
+const cleanups: Array<() => void> = [];
+
+function responseFor(method: string): unknown {
+  switch (method) {
+    case "agents.list":
+      return roster;
+    case "models.authStatus":
+      return { ts: 1, providers: [{ provider: "openai", status: "ok", profiles: [] }] };
+    case "models.list":
+      return { models: [{ id: "fixture", provider: "openai", name: "Fixture" }] };
+    case "config.get":
+      return { config: {}, hash: "fixture" };
+    default:
+      return {};
+  }
+}
+
+function createModelsRouter(selectedId: string | null = "main") {
+  const store = createGatewayStoreTestStore();
+  store.gateway.start();
+  const request = vi
+    .spyOn(store.gateway.snapshot.client!, "request")
+    .mockImplementation(async (method) => responseFor(method));
+  store.current().opts.onHello?.({ ...GATEWAY_STORE_TEST_HELLO });
+  // Match bootstrap's subscription order; the roster publishes before selection reconciles.
+  const agents = createAgentCapability(store.gateway);
+  const selection = createAgentSelectionCapability(store.gateway, agents);
+  selection.set(selectedId);
+  const context = Object.freeze({
+    gateway: store.gateway,
+    agents,
+    agentSelection: selection,
+  }) as ApplicationContext;
+  const router = createRouter<
+    "model-providers" | "other",
+    ApplicationContext,
+    null,
+    ModelProvidersRouteData
+  >({
+    routes: [
+      { ...page, component: () => null },
+      { id: "other", path: "/other", component: () => null },
+    ],
+  });
+  cleanups.push(() => {
+    router.stop();
+    agents.dispose();
+    store.gateway.stop();
+  });
+  return {
+    ...store,
+    context,
+    selection,
+    router,
+    request,
+    modelCalls: () =>
+      store.clients.flatMap((client) =>
+        client.request.mock.calls.filter(([method]) => modelMethods.includes(method)),
+      ),
+  };
+}
+
+type ModelsHarness = ReturnType<typeof createModelsRouter>;
+type OwnerChange = "navigation" | "disconnect" | "hello" | "client" | "set";
+
+async function replaceOwner(harness: ModelsHarness, change: OwnerChange) {
+  if (change === "navigation") {
+    await harness.router.navigate("other", harness.context);
+  } else if (change === "disconnect") {
+    harness.current().opts.onClose?.({ code: 1012, reason: "restart", willRetry: true });
+  } else if (change === "hello") {
+    const admitted = harness.gateway.snapshot;
+    harness.current().opts.onClose?.({ code: 1012, reason: "restart", willRetry: true });
+    harness.current().opts.onHello?.({ ...GATEWAY_STORE_TEST_HELLO });
+    expect(harness.gateway.snapshot.client).toBe(admitted.client);
+    expect(harness.gateway.snapshot.hello).not.toBe(admitted.hello);
+  } else if (change === "client") {
+    harness.gateway.connect();
+    harness.current().request.mockImplementation(async (method) => responseFor(method));
+    harness.current().opts.onHello?.({ ...GATEWAY_STORE_TEST_HELLO });
+  } else {
+    harness.selection.set("research");
+  }
+}
+
+describe("Models route admission", () => {
+  beforeEach(stubGatewayStoreTestGlobals);
+  afterEach(() => {
+    for (const cleanup of cleanups.splice(0)) {
+      cleanup();
+    }
+    setAvatarGatewayOrigin(null);
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it.each(["navigation", "disconnect", "hello", "client", "set"] as const)(
+    "does not dispatch after %s during the deferred import; a new load succeeds",
+    async (change) => {
+      const harness = createModelsRouter();
+      const { router, context, gateway, selection, modelCalls } = harness;
+      const loading = router.navigate("model-providers", context);
+      // import() yields even for a cached module, so these real producers precede requests.
+      await replaceOwner(harness, change);
+      await loading;
+      expect(modelCalls()).toEqual([]);
+      if (gateway.snapshot.phase !== "connected") {
+        harness.current().opts.onHello?.({ ...GATEWAY_STORE_TEST_HELLO });
+      }
+      await router.revalidate(context, "model-providers");
+      expect(router.getState().matches[0]?.data).toMatchObject({
+        gateway,
+        gatewaySnapshot: gateway.snapshot,
+        client: gateway.snapshot.client,
+        agentId: selection.state.selectedId,
+        data: {
+          authStatus: responseFor("models.authStatus"),
+          models: [{ id: "fixture", provider: "openai", name: "Fixture" }],
+          error: null,
+          updatedAt: expect.any(Number),
+        },
+      });
+    },
+  );
+
+  it.each(["navigation", "disconnect", "hello", "client", "set"] as const)(
+    "does not dispatch after %s while agent initialization is pending",
+    async (change) => {
+      const harness = createModelsRouter(null);
+      const started = createDeferred();
+      const response = createDeferred<typeof roster>();
+      harness.request.mockImplementation(async (method) => {
+        if (method === "agents.list") {
+          started.resolve();
+          return response.promise;
+        }
+        return responseFor(method);
+      });
+      const loading = harness.router.navigate("model-providers", harness.context);
+      await started.promise;
+      await replaceOwner(harness, change);
+      // A new connection can select its agent before the old roster request settles.
+      if (change === "disconnect" || change === "hello" || change === "client") {
+        harness.selection.set("main");
+      }
+      response.resolve(roster);
+      await loading;
+      expect(harness.modelCalls()).toEqual([]);
+    },
+  );
+
+  it.each(["import", "roster"] as const)(
+    "accepts metadata and scope-only changes during %s",
+    async (boundary) => {
+      const harness = createModelsRouter(boundary === "roster" ? null : "main");
+      const admitted = harness.gateway.snapshot;
+      const started = createDeferred();
+      const response = createDeferred<typeof roster>();
+      harness.request.mockImplementation(async (method) => {
+        if (method === "agents.list") {
+          started.resolve();
+          return response.promise;
+        }
+        return responseFor(method);
+      });
+      const loading = harness.router.navigate("model-providers", harness.context);
+      if (boundary === "roster") {
+        await started.promise;
+      }
+      harness.current().opts.onRecoveryScopeChange?.();
+      harness.selection.setScope(boundary === "import" ? null : "research");
+      expect(harness.gateway.snapshot).not.toBe(admitted);
+      expect(harness.gateway.snapshot.hello).toBe(admitted.hello);
+      response.resolve(roster);
+      await loading;
+      expect(harness.router.getState().matches[0]?.data?.gatewaySnapshot).toBe(admitted);
+      expect(harness.router.getState().matches[0]?.data).toMatchObject({
+        gatewaySnapshot: admitted,
+        agentId: "main",
+        data: { error: null, updatedAt: expect.any(Number) },
+      });
+      expect(
+        harness
+          .modelCalls()
+          .map(([method]) => method)
+          .toSorted(),
+      ).toEqual(modelMethods.toSorted());
+      expect(harness.context.agentSelection.state.selectedId).toBe("main");
+    },
+  );
+
+  it("does not initialize agents after navigation cancels the deferred import", async () => {
+    const harness = createModelsRouter(null);
+    const loading = harness.router.navigate("model-providers", harness.context);
+    await harness.router.navigate("other", harness.context);
+    await loading;
+    expect(harness.request).not.toHaveBeenCalledWith("agents.list", {});
+    expect(harness.modelCalls()).toEqual([]);
+  });
+
+  it("leaves roster failure to the agent owner without starting Models requests", async () => {
+    const harness = createModelsRouter(null);
+    harness.request.mockRejectedValue(new Error("roster unavailable"));
+    await harness.router.navigate("model-providers", harness.context);
+    expect(harness.context.agents.state.agentsError).toBe("roster unavailable");
+    expect(harness.modelCalls()).toEqual([]);
+    expect(harness.router.getState().matches[0]?.data).toMatchObject({
+      client: null,
+      agentId: null,
+      data: { updatedAt: null },
+    });
+  });
+
+  it.each(["navigation", "preload"] as const)(
+    "keeps %s cancellation ownership through every Models request",
+    async (kind) => {
+      const harness = createModelsRouter();
+      const started = createDeferred();
+      const response = createDeferred();
+      let requests = 0;
+      harness.request.mockImplementation(async (method) => {
+        if (modelMethods.includes(method)) {
+          if (++requests === modelMethods.length) {
+            started.resolve();
+          }
+          await response.promise;
+        }
+        return responseFor(method);
+      });
+      const loading =
+        kind === "navigation"
+          ? harness.router.navigate("model-providers", harness.context)
+          : harness.router.preloadRoute("model-providers", harness.context);
+      await started.promise;
+      const calls = harness.request.mock.calls.filter(([method]) => modelMethods.includes(method));
+      await harness.router.navigate("other", harness.context);
+      response.resolve();
+      await loading;
+      for (const [method, , options] of calls) {
+        // Catalog coalescing has its own controller, but must retire with its last subscriber.
+        expect(options?.signal, method).toBeDefined();
+        expect(options?.signal?.aborted, method).toBe(kind === "navigation");
+      }
+      if (kind === "preload") {
+        await harness.router.navigate("model-providers", harness.context);
+        expect(harness.modelCalls()).toHaveLength(modelMethods.length);
+        expect(harness.router.getState().matches[0]?.data?.data.authStatus).toEqual(
+          responseFor("models.authStatus"),
+        );
+      }
+    },
+  );
+});

--- a/ui/src/pages/model-providers/route.ts
+++ b/ui/src/pages/model-providers/route.ts
@@ -1,4 +1,4 @@
-import { definePage } from "@openclaw/uirouter";
+import { definePage, type RouteLoaderOptions } from "@openclaw/uirouter";
 import { html } from "lit";
 import { routePageSpec } from "../../app-route-paths.ts";
 import type { ApplicationContext } from "../../app/context.ts";
@@ -19,23 +19,40 @@ export type ModelProvidersRouteData = {
 
 async function loadModelProvidersRouteData(
   context: ApplicationContext,
+  options: RouteLoaderOptions,
 ): Promise<ModelProvidersRouteData> {
   const gateway = context.gateway;
   const gatewaySnapshot = gateway.snapshot;
+  let agentId = context.agentSelection.state.selectedId;
   const { EMPTY_MODEL_PROVIDERS_DATA, loadModelProvidersData } = await import("./load.ts");
   const client = gatewaySnapshot.phase === "connected" ? gatewaySnapshot.client : null;
-  if (!context.agentSelection.state.selectedId && client) {
-    await context.agents.ensureList();
+  // Both awaits can outlive the route or its Gateway/agent owner. Metadata-only
+  // snapshot publications preserve the client and hello, so remain valid.
+  const isCurrent = () => {
+    const current = gateway.snapshot;
+    return (
+      options.shouldRun() &&
+      current.phase === "connected" &&
+      current.client === gatewaySnapshot.client &&
+      current.hello === gatewaySnapshot.hello &&
+      context.agentSelection.state.selectedId === agentId
+    );
+  };
+  if (!client || !isCurrent()) {
+    return { gateway, gatewaySnapshot, data: EMPTY_MODEL_PROVIDERS_DATA, client: null, agentId };
   }
-  const selectedAgentId = context.agentSelection.state.selectedId;
-  const agentId = selectedAgentId ? normalizeAgentId(selectedAgentId) : null;
-  if (!client || !agentId) {
+  if (!agentId) {
+    const roster = await context.agents.ensureList();
+    // The roster may initialize selection; never adopt an unrelated user switch.
+    agentId = roster ? normalizeAgentId(roster.defaultId) : null;
+  }
+  if (!agentId || !isCurrent()) {
     return { gateway, gatewaySnapshot, data: EMPTY_MODEL_PROVIDERS_DATA, client: null, agentId };
   }
   return {
     gateway,
     gatewaySnapshot,
-    data: await loadModelProvidersData(client, { agentId }),
+    data: await loadModelProvidersData(client, { agentId, signal: options.signal }),
     client,
     agentId,
   };

--- a/ui/src/pages/route-provenance.test.ts
+++ b/ui/src/pages/route-provenance.test.ts
@@ -171,8 +171,8 @@ describe("route preload gateway provenance", () => {
 
     expect(data.gateway).toBe(mutable.gateway);
     expect(data.gatewaySnapshot).toBe(originalSnapshot);
-    expect(data.client).toBe(originalClient);
-    expect(originalRequest).toHaveBeenCalled();
+    expect(data.client).toBeNull();
+    expect(originalRequest).not.toHaveBeenCalled();
     expect(replacementRequest).not.toHaveBeenCalled();
   });
 


### PR DESCRIPTION
Related: [CLI startup follow-up (#131503)](https://github.com/openclaw/openclaw/pull/131503).
Preserves [progressive Models loading (#130546)](https://github.com/openclaw/openclaw/pull/130546).

<details>
<summary>Additional instructions</summary>

This is a same-repository maintainer branch, available for maintainer updates.

</details>

## What Problem This Solves

Fixes an issue where users leaving Models, changing the selected agent, or reconnecting the Gateway while the route was loading could still trigger requests for the retired page. Navigation cancellation also failed to retire the route's pending client requests.

## Why This Change Was Made

The Models route now revalidates its navigation, Gateway client/hello, and concrete selected-agent ownership after the lazy import and shared roster wait, then carries the router signal into its three core requests. Roster-driven default selection, metadata-only snapshot updates, scope-only changes, and independent preloads retain their existing behavior. The readonly application context is not treated as a replaceable Gateway source.

The [progressive-loading repair (#130546)](https://github.com/openclaw/openclaw/pull/130546) landed during preparation. This candidate preserves its separate core, provider-usage, and local-cost owners. That repair already forwarded the cost request signal; this PR strengthens transport-level preservation proof rather than claiming that forwarding as new work. The obsolete aggregate-loader test and one-use config request wrapper are removed, and the nearby older-Gateway comment is corrected to the same-version UI contract.

## User Impact

Leaving Models no longer starts obsolete core requests after delayed initialization, and route cancellation retires pending client waits. Current-agent loads, explicit refresh, provider-specific errors, and progressive quota/cost rendering keep working. This does not cancel work already dispatched on the server and is not an authorization-bypass or stale-data-display fix.

No configuration, schema, protocol, dependency-version, or timeout changes. No operator Gateway or Chrome profile was touched. AI-assisted repair under maintainer direction.

## Evidence

Reconciled against main at `11bf3cb3d099f8a1b5db3d209b339375aef9f34d`.

- Before the route repair: **13 failed, 14 passed** across the two focused files. All 13 failures exercised missing route ownership/cancellation; the strengthened supplemental transport cases already passed on main.
- After the repair: **178 passed across 11 files**, including the existing route-provenance suite, covering Models route/core/supplemental loading, Usage routing, Gateway replacement, page lifecycle, selection, shared catalog cancellation, and Models views.
- Built-Control-UI Chromium: **6 passed across 3 files**, with 5 unrelated scenarios excluded by the named filter. Includes core controls rendering while quota and cost are pending, followed by each completing independently.
- The complete five-file changed guard, formatting, typecheck, lint, and dead-export plan passed, as did `git diff --check`.
- Exact-head [CI 33264428504](https://github.com/openclaw/openclaw/actions/runs/33264428504), attempt 2, and [Workflow Sanity 33264428521](https://github.com/openclaw/openclaw/actions/runs/33264428521) passed. The required [openclaw/ci-gate](https://github.com/openclaw/openclaw/actions/runs/33264428504/job/99134120031) is green. Attempt 1 hit a pnpm cache-file ENOENT while materializing Knip; one targeted dependency-job retry passed, without source, dependency or timeout changes. Native preparation verified exact-head evidence and retained the same source/prepared head; merge awaits the final maintainer checkpoint.
- Fresh independent isolated Codex autoreview of the entire five-file candidate against the reconciled base was scoped-clean at the requested P0-only threshold (confidence 0.97), with no findings. Tests were run separately from that static review.

The attached, inspected images show the **final candidate** preserving catalog-error/Refresh recovery and progressive loading with synthetic Gateway responses. The progressive before/after images are successive loading stages within this candidate, not a pre-fix/post-fix code comparison. Cancellation itself is proven by the producer-backed red/green tests and real pending-request retirement. No authenticated provider execution or server-side cancellation is claimed.

Focused and sibling proof:

```bash
node scripts/run-vitest.mjs ui/src/pages/model-providers/route.test.ts ui/src/pages/model-providers/load.test.ts ui/src/pages/usage/route.test.ts ui/src/pages/gateway-source-replacement.test.ts ui/src/lit/gateway-page-controller.test.ts ui/src/app/agent-selection.test.ts ui/src/lib/model-catalog-store.test.ts ui/src/pages/model-providers/model-providers-page.test.ts ui/src/pages/model-providers/model-providers-page.usage.test.ts ui/src/pages/model-providers/view.test.ts ui/src/pages/route-provenance.test.ts
```

UI-package CI entrypoint: **34 passed across 3 files**.

```bash
pnpm --dir ui test src/pages/route-provenance.test.ts src/pages/model-providers/route.test.ts src/pages/model-providers/load.test.ts
```

Initial CI [33262372431](https://github.com/openclaw/openclaw/actions/runs/33262372431) failed both UI lanes on one missed sibling expectation: the existing provenance test still required old-client requests after Gateway replacement. The published repair reproduced **1 failed / 33 passed** locally. A subsequent test-only commit updates two assertions while preserving exact original Gateway/snapshot provenance and no replacement-client dispatch. The root and UI-package results above, plus the complete five-file changed gate, passed after that correction. Production bytes are unchanged; the six Chromium flows and four images remain the original validated runtime evidence, with no recapture or rebuild claim.

The separately reported main task-fixture cleanup is already merged in [#132643](https://github.com/openclaw/openclaw/pull/132643), commit [2c7f11e3d4b9](https://github.com/openclaw/openclaw/commit/2c7f11e3d4b9dc3045817466bc8aadb965e65852). It is not a remaining blocker and is not part of this patch.

Built-bundle browser proof:

```bash
OPENCLAW_UI_E2E_RECORD=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/model-providers.e2e.test.ts ui/src/e2e/model-provider-usage-outcomes.e2e.test.ts ui/src/e2e/model-providers-progressive.e2e.test.ts -t 'defers live provider discovery|lists configured providers|shows a visible warning|keeps provider-scoped usage errors|keeps configured models visible|renders provider controls before usage and cost settle'
```

Changed-file gate:

```bash
node scripts/check-changed.mjs -- ui/src/pages/model-providers/route.ts ui/src/pages/model-providers/load.ts ui/src/pages/model-providers/load.test.ts ui/src/pages/model-providers/route.test.ts ui/src/pages/route-provenance.test.ts
```

Production LOC: **+28/-16 (net +12)**. The growth supplies the missing route admission checks across both await boundaries; removing the one-use config wrapper absorbs five lines. Tests: **+324/-23 (net +301)**, including real router/Gateway/selection producer coverage and the replacement supplemental transport proof. No test-only production seam was added.

![Final candidate: catalog failure is visible while configured models remain available](https://github.com/user-attachments/assets/85a6fe27-ad32-45bc-96e8-4a2d8648f750)

![Final candidate: Refresh recovers the catalog without losing configured models](https://github.com/user-attachments/assets/bd53ce0d-5dc7-4586-bfca-a3e9536089e5)

![Final candidate: provider controls are usable while quota and cost are pending](https://github.com/user-attachments/assets/e1e48b3d-cda4-43a2-a4f0-b4ace4efd729)

![Final candidate: independent quota and cost results populate existing controls](https://github.com/user-attachments/assets/95c6934b-72f3-4319-85cf-1a828c936d36)

Source head: [e73b8d4f22df8b07b50786f2f0c0e9087a2a113b](https://github.com/openclaw/openclaw/commit/e73b8d4f22df8b07b50786f2f0c0e9087a2a113b). Production repair: [a8303ee3f31bd1fc87cdbf5ea1716ab5428d9576](https://github.com/openclaw/openclaw/commit/a8303ee3f31bd1fc87cdbf5ea1716ab5428d9576).
