### PR TITLE
improve: verify Workshop review outcomes through the real runtime

### DIFF
--- a/src/skills/workshop/experience-review.e2e.test.ts
+++ b/src/skills/workshop/experience-review.e2e.test.ts
@@ -1,0 +1,215 @@
+import fs from "node:fs/promises";
+import type { ServerResponse } from "node:http";
+import { text as readText } from "node:stream/consumers";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  writeOpenAiResponsesSse,
+  writeOpenAiResponsesText,
+} from "../../../test/helpers/openai-responses-sse.js";
+import { loadAgentRuntimePluginRegistryHandle } from "../../agents/runtime-plugins.js";
+import { withServer } from "../../plugin-sdk/test-helpers/http-test-server.js";
+import {
+  createOpenClawTestState,
+  type OpenClawTestState,
+} from "../../test-utils/openclaw-test-state.js";
+import { createTrackedTempDirs } from "../../test-utils/tracked-temp-dirs.js";
+import { readSkillReviewOutcomes } from "./collection-review-state.js";
+import { runSkillExperienceReview } from "./experience-review.js";
+import {
+  createExperienceReviewCandidate,
+  createExperienceReviewMessages,
+} from "./experience-review.test-support.js";
+import {
+  getSkillProposalRunProgress,
+  inspectSkillProposal,
+  listSkillProposals,
+} from "./service.js";
+
+const modelId = "gpt-5.6-luna";
+const { positiveMessages } = createExperienceReviewMessages(modelId);
+const tempDirs = createTrackedTempDirs();
+let state: OpenClawTestState;
+const proposalBody = [
+  "# Manifest Deployment",
+  "",
+  "1. Read the checked-in deployment manifest and collect project, region, service, and health path.",
+  "2. Deploy with the manifest values, then fetch its health path and verify a successful response.",
+].join("\n");
+const createArgs = {
+  action: "create",
+  name: "Manifest Deployment",
+  description: "Deploy from a checked-in manifest and verify service health.",
+  proposal_content: proposalBody,
+};
+type Request = {
+  model?: string;
+  input?: Array<{ type?: string; name?: string; call_id?: string; output?: unknown }>;
+  tools?: Array<{ name?: string }>;
+};
+type Scenario = "proposed" | "nothing" | "rejected" | "failed";
+
+beforeAll(async () => {
+  state = await createOpenClawTestState({ layout: "home", prefix: "workshop-owner-contract-" });
+});
+afterAll(async () => {
+  await state.cleanup();
+  await tempDirs.cleanup();
+});
+
+function writeToolCall(response: ServerResponse, args: Record<string, unknown>): void {
+  const item = {
+    type: "function_call",
+    id: "fc_workshop_contract",
+    call_id: "call_workshop_contract",
+    name: "skill_workshop",
+    arguments: JSON.stringify(args),
+    status: "completed",
+  };
+  writeOpenAiResponsesSse(response, [
+    {
+      type: "response.output_item.added",
+      output_index: 0,
+      item: { ...item, status: "in_progress", arguments: "" },
+    },
+    {
+      type: "response.function_call_arguments.done",
+      item_id: item.id,
+      output_index: 0,
+      arguments: item.arguments,
+    },
+    { type: "response.output_item.done", output_index: 0, item },
+    {
+      type: "response.completed",
+      response: {
+        id: "resp_workshop_contract_tool",
+        status: "completed",
+        output: [item],
+        usage: { input_tokens: 10, output_tokens: 10, total_tokens: 20 },
+      },
+    },
+  ]);
+}
+
+describe("Workshop experience review through the real provider and tool owners", () => {
+  it.each<Scenario>(["proposed", "nothing", "rejected", "failed"])(
+    "records %s without replacing the review runner, catalog, or proposal service",
+    async (scenario) => {
+      const requests: Request[] = [];
+      const handlerErrors: unknown[] = [];
+      await withServer(
+        (request, response) => {
+          void (async () => {
+            if (request.method !== "POST" || request.url !== "/v1/responses") {
+              response.writeHead(404).end();
+              return;
+            }
+            requests.push(JSON.parse(await readText(request)) as Request);
+            if (scenario === "failed" || requests.length > 2) {
+              response.writeHead(400, { "content-type": "application/json" });
+              response.end(JSON.stringify({ error: { message: "Controlled provider rejection" } }));
+              return;
+            }
+            if (requests.length === 1 && (scenario === "proposed" || scenario === "rejected")) {
+              writeToolCall(response, scenario === "proposed" ? createArgs : { action: "create" });
+              return;
+            }
+            writeOpenAiResponsesText(response, {
+              text: "NO_REPLY",
+              messageId: `msg_workshop_contract_${requests.length}`,
+              responseId: `resp_workshop_contract_${requests.length}`,
+            });
+          })().catch((error: unknown) => {
+            handlerErrors.push(error);
+            response.writeHead(400).end();
+          });
+        },
+        async (baseUrl) => {
+          const workspaceDir = await tempDirs.make(`workshop-contract-${scenario}-`);
+          const runId = `owner-contract-${scenario}`;
+          const messages = positiveMessages();
+          const candidate = await createExperienceReviewCandidate(runId, messages, {
+            workspaceDir,
+            modelId,
+            baseUrl: `${baseUrl}/v1`,
+            apiKey: "test-token-placeholder",
+          });
+          // Load the real provider plugin before entering the review lane, as the live proof does.
+          loadAgentRuntimePluginRegistryHandle({ config: candidate.config ?? {}, workspaceDir });
+          const outcomesBefore = new Set(Object.keys(readSkillReviewOutcomes().experienceReviews));
+          const run = runSkillExperienceReview(candidate, {
+            getCurrentConfig: () => candidate.config ?? {},
+          });
+          if (scenario === "failed") {
+            await expect(run).rejects.toThrow(
+              "provider rejected the request schema or tool payload",
+            );
+          } else {
+            await run;
+          }
+
+          expect(handlerErrors).toEqual([]);
+          expect(requests).toHaveLength(scenario === "proposed" || scenario === "rejected" ? 2 : 1);
+          expect(requests[0]?.model).toBe(modelId);
+          expect(requests[0]?.tools?.map((tool) => tool.name)).toEqual(
+            expect.arrayContaining(["exec", "read", "skill_workshop"]),
+          );
+          // Request IDs are rewritten for provider replay. Compare the actual output bodies.
+          expect(
+            requests[0]?.input
+              ?.filter((item) => item.type === "function_call_output")
+              .map((item) => item.output),
+          ).toEqual(
+            messages
+              .filter((message) => message.role === "toolResult")
+              .map((message) =>
+                message.content.map((part) => (part.type === "text" ? part.text : "")).join("\n"),
+              ),
+          );
+
+          const { proposals } = await listSkillProposals({ workspaceDir });
+          const progress = await getSkillProposalRunProgress({ workspaceDir, runId });
+          const outcomes = Object.entries(readSkillReviewOutcomes().experienceReviews).filter(
+            ([key]) => !outcomesBefore.has(key),
+          );
+          expect(outcomes).toHaveLength(1);
+          const outcome = outcomes[0]![1];
+          if (scenario === "proposed") {
+            expect(proposals).toHaveLength(1);
+            const proposal = proposals[0]!;
+            expect(proposal.status).toBe("pending");
+            expect(progress).toMatchObject({ mutationCount: 1, proposalIds: [proposal.id] });
+            const stored = await inspectSkillProposal(proposal.id, { workspaceDir });
+            expect(stored?.record).toMatchObject({ autonomousCapture: true, origin: { runId } });
+            expect(stored?.content).toContain(proposalBody);
+            await expect(fs.stat(stored!.record.target.skillFile)).rejects.toMatchObject({
+              code: "ENOENT",
+            });
+            expect(outcome).toMatchObject({ outcome: "proposed", proposalId: proposal.id });
+            const toolOutput = requests[1]?.input?.find(
+              (item) =>
+                item.type === "function_call_output" && item.call_id === "call_workshop_contract",
+            );
+            expect(toolOutput?.output).toContain(proposal.id);
+          } else {
+            expect(proposals).toEqual([]);
+            expect(progress.mutationCount).toBe(0);
+            expect(outcome).toMatchObject({
+              outcome: scenario === "failed" ? "failed" : "nothing",
+            });
+            if (scenario === "rejected") {
+              const toolOutput = requests[1]?.input?.find(
+                (item) =>
+                  item.type === "function_call_output" && item.call_id === "call_workshop_contract",
+              );
+              expect(toolOutput?.output).toContain("required");
+            }
+          }
+          if (scenario !== "failed") {
+            expect(outcome?.usage?.outputTokens).toBeGreaterThan(0);
+          }
+        },
+      );
+    },
+    120_000,
+  );
+});

--- a/src/skills/workshop/experience-review.live.test.ts
+++ b/src/skills/workshop/experience-review.live.test.ts
@@ -8,11 +8,6 @@ import {
   sanitizeToolUseResultPairingForModel,
 } from "../../agents/session-transcript-repair.js";
 import { SessionManager } from "../../agents/sessions/index.js";
-import {
-  makeAgentAssistantMessage,
-  makeAgentUserMessage,
-} from "../../agents/test-helpers/agent-message-fixtures.js";
-import { createSessionEntryWithTranscript } from "../../config/sessions/session-accessor.js";
 import { onAgentRuntimeEvent } from "../../infra/agent-events.js";
 import type { Message } from "../../llm/types.js";
 import { closeOpenClawStateDatabaseByPath } from "../../state/openclaw-state-db.js";
@@ -26,6 +21,10 @@ import {
   recordSkillExperienceReviewOutcome,
 } from "./collection-review-state.js";
 import { runSkillExperienceReview, type ExperienceReviewCandidate } from "./experience-review.js";
+import {
+  createExperienceReviewCandidate,
+  createExperienceReviewMessages,
+} from "./experience-review.test-support.js";
 import { getSkillProposalRunProgress, listSkillProposals } from "./service.js";
 
 const LIVE =
@@ -33,6 +32,8 @@ const LIVE =
   Boolean(process.env.OPENAI_API_KEY?.trim());
 const describeLive = LIVE ? describe : describe.skip;
 const modelId = process.env.OPENCLAW_LIVE_SKILL_EXPERIENCE_MODEL ?? "gpt-5.6-luna";
+const { positiveMessages, negativeMessages, interruptedMessages } =
+  createExperienceReviewMessages(modelId);
 const tempDirs = createTrackedTempDirs();
 let testState: OpenClawTestState;
 let workspaceDir = "";
@@ -57,168 +58,6 @@ const unsubscribeDiagnostics = LIVE
       }
     })
   : () => undefined;
-
-function assistantText(text: string) {
-  return makeAgentAssistantMessage({ model: modelId, content: [{ type: "text", text }] });
-}
-
-function toolRound(
-  id: string,
-  name: string,
-  args: Record<string, unknown>,
-  text: string,
-  isError = false,
-): Message[] {
-  return [
-    makeAgentAssistantMessage({
-      model: modelId,
-      stopReason: "toolUse",
-      content: [{ type: "toolCall", id, name, arguments: args }],
-    }),
-    {
-      role: "toolResult",
-      toolCallId: id,
-      toolName: name,
-      content: [{ type: "text", text }],
-      isError,
-      timestamp: 0,
-    },
-  ];
-}
-
-function positiveMessages(): Message[] {
-  return [
-    makeAgentUserMessage({
-      content:
-        "Deploy this repository from its checked-in manifest. Do not ask for values already present there.",
-    }),
-    ...toolRound("deploy-project", "exec", { command: "deploy" }, "project required", true),
-    ...toolRound(
-      "deploy-region",
-      "exec",
-      { command: "deploy --project app" },
-      "region required",
-      true,
-    ),
-    ...toolRound(
-      "deploy-service",
-      "exec",
-      { command: "deploy --project app --region us" },
-      "service required",
-      true,
-    ),
-    assistantText("I am still guessing required fields one at a time."),
-    ...toolRound(
-      "read-manifest",
-      "read",
-      { path: "deploy.json" },
-      "project=app region=us service=api health=/ready",
-    ),
-    assistantText("The manifest contains all required deployment inputs."),
-    ...toolRound(
-      "deploy-complete",
-      "exec",
-      { command: "deploy --project app --region us --service api" },
-      "deployed",
-    ),
-    ...toolRound("fetch-health", "exec", { command: "fetch /ready" }, "200 ok"),
-    assistantText("Deployment verified."),
-    assistantText("Next time the manifest should be read before the first deploy call."),
-    assistantText("That preflight would remove three failed tool rounds."),
-    assistantText("Done."),
-  ];
-}
-
-function negativeMessages(): Message[] {
-  return [
-    makeAgentUserMessage({
-      content:
-        "One-time audit: check these ten unrelated opaque receipts. Policy requires one signed lookup per receipt; no batching or reuse is possible.",
-    }),
-    ...Array.from({ length: 10 }, (_, index) =>
-      toolRound(
-        `receipt-${index + 1}`,
-        "exec",
-        { command: `signed_receipt_lookup --id ${index + 1}` },
-        "valid",
-      ),
-    ).flat(),
-    assistantText("All ten one-time receipts are valid."),
-  ];
-}
-
-function interruptedMessages(): Message[] {
-  // Copying only a WAL-mode main file can pass integrity_check while missing
-  // committed rows. This recovery was reproduced against SQLite's backup API.
-  return [
-    makeAgentUserMessage({
-      content:
-        "Back up the running SQLite event database, verify the backup, then update the operations guide.",
-    }),
-    ...toolRound(
-      "copy-backup",
-      "exec",
-      { command: "cp events.db backup.db && python3 verify-backup.py events.db backup.db" },
-      "source events=3; backup events=0; backup integrity_check=ok; verification failed: committed events missing",
-      true,
-    ),
-    ...toolRound(
-      "copy-backup-retry",
-      "exec",
-      { command: "cp events.db backup.db && python3 verify-backup.py events.db backup.db" },
-      "source events=3; backup events=0; backup integrity_check=ok; verification failed: committed events missing",
-      true,
-    ),
-    ...toolRound(
-      "inspect-journal",
-      "exec",
-      {
-        command:
-          "sqlite3 events.db 'PRAGMA journal_mode; SELECT count(*) FROM events;' && ls events.db*",
-      },
-      "wal\n3\nevents.db events.db-shm events.db-wal",
-    ),
-    assistantText(
-      "The committed events are still in the WAL. A valid main-file copy is not a complete snapshot.",
-    ),
-    ...toolRound(
-      "read-backup-api",
-      "read",
-      { path: "docs/sqlite-online-backup.md" },
-      "https://sqlite.org/backup.html: The online backup API copies a database into a consistent snapshot while the source remains in use. Python sqlite3.Connection.backup exposes that API.",
-    ),
-    ...toolRound(
-      "online-backup",
-      "exec",
-      {
-        command:
-          'python3 -c \'import sqlite3; source=sqlite3.connect("events.db"); target=sqlite3.connect("snapshot.db"); source.backup(target); target.close(); source.close()\'',
-      },
-      "exit code 0",
-    ),
-    ...toolRound(
-      "verify-snapshot",
-      "exec",
-      { command: "python3 verify-backup.py events.db snapshot.db" },
-      "source events=3; backup events=3; backup integrity_check=ok; verification passed",
-    ),
-    assistantText(
-      "The online backup contains all committed events and passes the integrity check while the source remains open. Moving on to the operations guide.",
-    ),
-    makeAgentAssistantMessage({
-      model: modelId,
-      stopReason: "toolUse",
-      content: [
-        {
-          type: "toolCall",
-          id: "read-operations-guide",
-          name: "read",
-          arguments: { path: "OPERATIONS.md" },
-        },
-      ],
-    }),
-  ];
-}
 
 beforeAll(async () => {
   // Full home isolation: the embedded review resolves the shared-main auth
@@ -265,89 +104,7 @@ async function candidate(
   messages: Message[],
   options: { turnAborted?: boolean } = {},
 ): Promise<ExperienceReviewCandidate> {
-  const sessionId = `live-skill-review-${runId}`;
-  const sessionKey = `agent:main:${sessionId}`;
-  const result: ExperienceReviewCandidate = {
-    ctx: {
-      agentId: "main",
-      runId,
-      sessionId,
-      sessionKey,
-      workspaceDir,
-      modelProviderId: "openai",
-      modelId,
-      foregroundPromptContext: {
-        agentId: "main",
-        agentDir: workspaceDir,
-        workspaceDir,
-        cwd: workspaceDir,
-        sandboxSessionKey: sessionKey,
-        trigger: "user",
-      },
-    },
-    config: {
-      models: {
-        providers: {
-          openai: {
-            api: "openai-responses",
-            agentRuntime: { id: "openclaw" },
-            apiKey: { source: "env", provider: "default", id: "OPENAI_API_KEY" },
-            baseUrl: "https://api.openai.com/v1",
-            models: [
-              {
-                id: modelId,
-                name: modelId,
-                api: "openai-responses",
-                agentRuntime: { id: "openclaw" },
-                input: ["text"],
-                reasoning: true,
-                contextWindow: 1_047_576,
-                maxTokens: 2_048,
-                cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-              },
-            ],
-          },
-        },
-      },
-      agents: {
-        entries: { main: { default: true } },
-        defaults: {
-          model: { primary: `openai/${modelId}` },
-          models: {
-            [`openai/${modelId}`]: {
-              agentRuntime: { id: "openclaw" },
-              params: { maxTokens: 2_048 },
-            },
-          },
-        },
-      },
-      skills: { workshop: { autonomous: { mode: "propose" } } },
-      // Only the OpenAI provider plugin is needed. A cold unrestricted load
-      // compiles all bundled extensions and runs provider discovery inside the
-      // review lane, which can exceed the lane's no-progress watchdog.
-      plugins: { allow: ["openai"] },
-    },
-    ...(options.turnAborted === undefined ? {} : { turnAborted: options.turnAborted }),
-  };
-  const target = await resolveAgentRunSessionTarget({
-    agentId: "main",
-    config: result.config,
-    missingSessionKey: "create",
-    sessionId,
-    sessionKey,
-  });
-  const created = await createSessionEntryWithTranscript(
-    target,
-    () => ({ ok: true, entry: { sessionId, updatedAt: Date.now() } }),
-    { cwd: workspaceDir },
-  );
-  if (!created.ok) {
-    throw new Error(`Failed to create live review session: ${created.error}`);
-  }
-  for (const message of messages) {
-    SessionManager.appendMessageToTranscript(target, message, { config: result.config });
-  }
-  return result;
+  return createExperienceReviewCandidate(runId, messages, { workspaceDir, modelId, ...options });
 }
 
 describe("skill experience review diagnostics", () => {

--- a/src/skills/workshop/experience-review.test-support.ts
+++ b/src/skills/workshop/experience-review.test-support.ts
@@ -1,0 +1,273 @@
+import { resolveAgentRunSessionTarget } from "../../agents/run-session-target.js";
+import { SessionManager } from "../../agents/sessions/index.js";
+import {
+  makeAgentAssistantMessage,
+  makeAgentUserMessage,
+} from "../../agents/test-helpers/agent-message-fixtures.js";
+import { createSessionEntryWithTranscript } from "../../config/sessions/session-accessor.js";
+import type { Message } from "../../llm/types.js";
+import type { ExperienceReviewCandidate } from "./experience-review.js";
+
+export function createExperienceReviewMessages(modelId: string) {
+  function assistantText(text: string) {
+    return makeAgentAssistantMessage({ model: modelId, content: [{ type: "text", text }] });
+  }
+
+  function toolRound(
+    id: string,
+    name: string,
+    args: Record<string, unknown>,
+    text: string,
+    isError = false,
+  ): Message[] {
+    return [
+      makeAgentAssistantMessage({
+        model: modelId,
+        stopReason: "toolUse",
+        content: [{ type: "toolCall", id, name, arguments: args }],
+      }),
+      {
+        role: "toolResult",
+        toolCallId: id,
+        toolName: name,
+        content: [{ type: "text", text }],
+        isError,
+        timestamp: 0,
+      },
+    ];
+  }
+
+  function positiveMessages(): Message[] {
+    return [
+      makeAgentUserMessage({
+        content:
+          "Deploy this repository from its checked-in manifest. Do not ask for values already present there.",
+      }),
+      ...toolRound("deploy-project", "exec", { command: "deploy" }, "project required", true),
+      ...toolRound(
+        "deploy-region",
+        "exec",
+        { command: "deploy --project app" },
+        "region required",
+        true,
+      ),
+      ...toolRound(
+        "deploy-service",
+        "exec",
+        { command: "deploy --project app --region us" },
+        "service required",
+        true,
+      ),
+      assistantText("I am still guessing required fields one at a time."),
+      ...toolRound(
+        "read-manifest",
+        "read",
+        { path: "deploy.json" },
+        "project=app region=us service=api health=/ready",
+      ),
+      assistantText("The manifest contains all required deployment inputs."),
+      ...toolRound(
+        "deploy-complete",
+        "exec",
+        { command: "deploy --project app --region us --service api" },
+        "deployed",
+      ),
+      ...toolRound("fetch-health", "exec", { command: "fetch /ready" }, "200 ok"),
+      assistantText("Deployment verified."),
+      assistantText("Next time the manifest should be read before the first deploy call."),
+      assistantText("That preflight would remove three failed tool rounds."),
+      assistantText("Done."),
+    ];
+  }
+
+  function negativeMessages(): Message[] {
+    return [
+      makeAgentUserMessage({
+        content:
+          "One-time audit: check these ten unrelated opaque receipts. Policy requires one signed lookup per receipt; no batching or reuse is possible.",
+      }),
+      ...Array.from({ length: 10 }, (_, index) =>
+        toolRound(
+          `receipt-${index + 1}`,
+          "exec",
+          { command: `signed_receipt_lookup --id ${index + 1}` },
+          "valid",
+        ),
+      ).flat(),
+      assistantText("All ten one-time receipts are valid."),
+    ];
+  }
+
+  function interruptedMessages(): Message[] {
+    // Copying only a WAL-mode main file can pass integrity_check while missing
+    // committed rows. This recovery was reproduced against SQLite's backup API.
+    return [
+      makeAgentUserMessage({
+        content:
+          "Back up the running SQLite event database, verify the backup, then update the operations guide.",
+      }),
+      ...toolRound(
+        "copy-backup",
+        "exec",
+        { command: "cp events.db backup.db && python3 verify-backup.py events.db backup.db" },
+        "source events=3; backup events=0; backup integrity_check=ok; verification failed: committed events missing",
+        true,
+      ),
+      ...toolRound(
+        "copy-backup-retry",
+        "exec",
+        { command: "cp events.db backup.db && python3 verify-backup.py events.db backup.db" },
+        "source events=3; backup events=0; backup integrity_check=ok; verification failed: committed events missing",
+        true,
+      ),
+      ...toolRound(
+        "inspect-journal",
+        "exec",
+        {
+          command:
+            "sqlite3 events.db 'PRAGMA journal_mode; SELECT count(*) FROM events;' && ls events.db*",
+        },
+        "wal\n3\nevents.db events.db-shm events.db-wal",
+      ),
+      assistantText(
+        "The committed events are still in the WAL. A valid main-file copy is not a complete snapshot.",
+      ),
+      ...toolRound(
+        "read-backup-api",
+        "read",
+        { path: "docs/sqlite-online-backup.md" },
+        "https://sqlite.org/backup.html: The online backup API copies a database into a consistent snapshot while the source remains in use. Python sqlite3.Connection.backup exposes that API.",
+      ),
+      ...toolRound(
+        "online-backup",
+        "exec",
+        {
+          command:
+            'python3 -c \'import sqlite3; source=sqlite3.connect("events.db"); target=sqlite3.connect("snapshot.db"); source.backup(target); target.close(); source.close()\'',
+        },
+        "exit code 0",
+      ),
+      ...toolRound(
+        "verify-snapshot",
+        "exec",
+        { command: "python3 verify-backup.py events.db snapshot.db" },
+        "source events=3; backup events=3; backup integrity_check=ok; verification passed",
+      ),
+      assistantText(
+        "The online backup contains all committed events and passes the integrity check while the source remains open. Moving on to the operations guide.",
+      ),
+      makeAgentAssistantMessage({
+        model: modelId,
+        stopReason: "toolUse",
+        content: [
+          {
+            type: "toolCall",
+            id: "read-operations-guide",
+            name: "read",
+            arguments: { path: "OPERATIONS.md" },
+          },
+        ],
+      }),
+    ];
+  }
+
+  return { positiveMessages, negativeMessages, interruptedMessages };
+}
+
+export async function createExperienceReviewCandidate(
+  runId: string,
+  messages: Message[],
+  options: {
+    workspaceDir: string;
+    modelId: string;
+    baseUrl?: string;
+    apiKey?: string;
+    turnAborted?: boolean;
+  },
+): Promise<ExperienceReviewCandidate> {
+  const { workspaceDir, modelId } = options;
+  const sessionId = `live-skill-review-${runId}`;
+  const sessionKey = `agent:main:${sessionId}`;
+  const result: ExperienceReviewCandidate = {
+    ctx: {
+      agentId: "main",
+      runId,
+      sessionId,
+      sessionKey,
+      workspaceDir,
+      modelProviderId: "openai",
+      modelId,
+      foregroundPromptContext: {
+        agentId: "main",
+        agentDir: workspaceDir,
+        workspaceDir,
+        cwd: workspaceDir,
+        sandboxSessionKey: sessionKey,
+        trigger: "user",
+      },
+    },
+    config: {
+      models: {
+        providers: {
+          openai: {
+            api: "openai-responses",
+            agentRuntime: { id: "openclaw" },
+            apiKey: options.apiKey ?? { source: "env", provider: "default", id: "OPENAI_API_KEY" },
+            baseUrl: options.baseUrl ?? "https://api.openai.com/v1",
+            ...(options.baseUrl ? { request: { allowPrivateNetwork: true } } : {}),
+            models: [
+              {
+                id: modelId,
+                name: modelId,
+                api: "openai-responses",
+                agentRuntime: { id: "openclaw" },
+                input: ["text"],
+                reasoning: true,
+                contextWindow: 1_047_576,
+                maxTokens: 2_048,
+                cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+              },
+            ],
+          },
+        },
+      },
+      agents: {
+        entries: { main: { default: true } },
+        defaults: {
+          model: { primary: `openai/${modelId}` },
+          models: {
+            [`openai/${modelId}`]: {
+              agentRuntime: { id: "openclaw" },
+              params: { maxTokens: 2_048 },
+            },
+          },
+        },
+      },
+      skills: { workshop: { autonomous: { mode: "propose" } } },
+      // Only the OpenAI provider plugin is needed. A cold unrestricted load
+      // compiles all bundled extensions and runs provider discovery inside the
+      // review lane, which can exceed the lane's no-progress watchdog.
+      plugins: { allow: ["openai"] },
+    },
+    ...(options.turnAborted === undefined ? {} : { turnAborted: options.turnAborted }),
+  };
+  const target = await resolveAgentRunSessionTarget({
+    agentId: "main",
+    config: result.config,
+    missingSessionKey: "create",
+    sessionId,
+    sessionKey,
+  });
+  const created = await createSessionEntryWithTranscript(
+    target,
+    () => ({ ok: true, entry: { sessionId, updatedAt: Date.now() } }),
+    { cwd: workspaceDir },
+  );
+  if (!created.ok) {
+    throw new Error(`Failed to create live review session: ${created.error}`);
+  }
+  for (const message of messages) {
+    SessionManager.appendMessageToTranscript(target, message, { config: result.config });
+  }
+  return result;
+}

--- a/test/embedded-transcript-cursor.e2e.test.ts
+++ b/test/embedded-transcript-cursor.e2e.test.ts
@@ -1,6 +1,6 @@
 // E2E: ordinary embedded Gateway turns preserve raw transcript cursor continuity.
 import { randomUUID } from "node:crypto";
-import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
+import { createServer, type IncomingMessage } from "node:http";
 import path from "node:path";
 import { readSessionTranscriptRawDelta } from "openclaw/plugin-sdk/session-transcript-runtime";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -10,6 +10,7 @@ import {
 } from "../src/config/sessions/session-accessor.js";
 import type { OpenClawConfig } from "../src/config/types.openclaw.js";
 import { connectGatewayClient, disconnectGatewayClient } from "../src/gateway/test-helpers.e2e.js";
+import { writeOpenAiResponsesText } from "./helpers/openai-responses-sse.js";
 import {
   createOpenClawTestInstance,
   type OpenClawTestInstance,
@@ -235,7 +236,11 @@ async function startMockModelServer(): Promise<MockModelServer> {
       }
       await drainRequest(request);
       responseCount += 1;
-      writeModelResponse(response, responseCount);
+      writeOpenAiResponsesText(response, {
+        text: `cursor settlement response ${responseCount}`,
+        messageId: `cursor-settlement-message-${responseCount}`,
+        responseId: `cursor-settlement-response-${responseCount}`,
+      });
     })().catch((error: unknown) => {
       response.writeHead(500, { "content-type": "application/json" });
       response.end(JSON.stringify({ error: { message: String(error) } }));
@@ -264,54 +269,4 @@ async function drainRequest(request: IncomingMessage): Promise<void> {
   for await (const chunk of request) {
     void chunk;
   }
-}
-
-function writeModelResponse(response: ServerResponse, sequence: number): void {
-  const text = `cursor settlement response ${sequence}`;
-  const message = {
-    type: "message",
-    id: `cursor-settlement-message-${sequence}`,
-    role: "assistant",
-    status: "completed",
-    content: [{ type: "output_text", text, annotations: [] }],
-  };
-  const events = [
-    {
-      type: "response.output_item.added",
-      output_index: 0,
-      item: { ...message, status: "in_progress", content: [] },
-    },
-    {
-      type: "response.output_text.delta",
-      item_id: message.id,
-      output_index: 0,
-      content_index: 0,
-      delta: text,
-    },
-    {
-      type: "response.output_text.done",
-      item_id: message.id,
-      output_index: 0,
-      content_index: 0,
-      text,
-    },
-    { type: "response.output_item.done", output_index: 0, item: message },
-    {
-      type: "response.completed",
-      response: {
-        id: `cursor-settlement-response-${sequence}`,
-        status: "completed",
-        output: [message],
-        usage: { input_tokens: 1, output_tokens: 1, total_tokens: 2 },
-      },
-    },
-  ];
-  response.writeHead(200, {
-    "content-type": "text/event-stream",
-    "cache-control": "no-store",
-    connection: "keep-alive",
-  });
-  response.end(
-    `${events.map((event) => `data: ${JSON.stringify(event)}\n\n`).join("")}data: [DONE]\n\n`,
-  );
 }

--- a/test/helpers/openai-responses-sse.ts
+++ b/test/helpers/openai-responses-sse.ts
@@ -1,0 +1,61 @@
+import type { ServerResponse } from "node:http";
+
+export function writeOpenAiResponsesSse(
+  response: ServerResponse,
+  events: readonly Record<string, unknown>[],
+): void {
+  response.writeHead(200, {
+    "content-type": "text/event-stream",
+    "cache-control": "no-store",
+    connection: "keep-alive",
+  });
+  response.end(
+    `${events.map((event) => `data: ${JSON.stringify(event)}\n\n`).join("")}data: [DONE]\n\n`,
+  );
+}
+
+export function writeOpenAiResponsesText(
+  response: ServerResponse,
+  params: { text: string; messageId: string; responseId: string },
+): void {
+  const { text } = params;
+  const message = {
+    type: "message",
+    id: params.messageId,
+    role: "assistant",
+    status: "completed",
+    content: [{ type: "output_text", text, annotations: [] }],
+  };
+  const events = [
+    {
+      type: "response.output_item.added",
+      output_index: 0,
+      item: { ...message, status: "in_progress", content: [] },
+    },
+    {
+      type: "response.output_text.delta",
+      item_id: message.id,
+      output_index: 0,
+      content_index: 0,
+      delta: text,
+    },
+    {
+      type: "response.output_text.done",
+      item_id: message.id,
+      output_index: 0,
+      content_index: 0,
+      text,
+    },
+    { type: "response.output_item.done", output_index: 0, item: message },
+    {
+      type: "response.completed",
+      response: {
+        id: params.responseId,
+        status: "completed",
+        output: [message],
+        usage: { input_tokens: 1, output_tokens: 1, total_tokens: 2 },
+      },
+    },
+  ];
+  writeOpenAiResponsesSse(response, events);
+}


### PR DESCRIPTION
Related: #129973

## What Problem This Solves

Release verification currently relies on a live model choosing to create a Workshop proposal, while the review prompt also permits an explicit `NO_REPLY`. The existing deterministic owner tests mock the embedded runner, and the catalog-policy tests use a synthetic Workshop tool. They do not prove that a provider request can pass through the real review, catalog, and proposal service to a recorded outcome.

## Why This Change Was Made

Add four controlled-provider integration cases through the real Responses HTTP transport and Workshop owners: a successful proposal, explicit abstention, rejected tool input, and provider failure. The proposal case requires exactly one pending draft, matching persisted content and run progress, a returned tool receipt, and the recorded `proposed` outcome. Abstention and rejection must leave no proposal; provider failure must throw and record `failed`.

The integration shares the existing canonical transcript fixtures with the live test, and shares Responses SSE encoding with the transcript-cursor E2E test. It uses the existing loopback server lifecycle helper. No runner, catalog, Workshop tool, or proposal service is replaced.

## User Impact

No runtime or release-acceptance behavior changes. All existing live assertions, prompts, model selection, and mutation limits remain unchanged. This supplies the missing deterministic owner coverage requested by #129973; the live criterion is proposed separately in #132726, and the finer durable no-mutation policy in #129973 remains open.

## Evidence

- Blacksmith Testbox `tbx_01m1733f5kagznqj90zvqfz3ma`, frozen `d9fe780239a2cb7158aad437112156605e8d375c` plus the test-only patch: all four controlled integration cases pass. The request assertions verify all six historical tool outputs and the real `exec`, `read`, and `skill_workshop` catalog entries.
- The unchanged live fixture preflight passes all four tests. The transcript-cursor E2E passes with the extracted SSE helper.
- The first controlled run caught an overly specific test assertion: provider errors are intentionally sanitized. The corrected case checks the existing sanitized rejection contract and the recorded failure.
- Core and root test typechecks, the original full changed-file gate, and Codex review pass.
- Mechanical refresh onto `f495a539f90` includes the independent UI timing-test repair from #132682. The five Workshop/SSE files are byte-identical to the original head (`git range-diff` is equal); 41 Workshop tests and all 107 Markdown tests pass, including the deterministic scan-count assertion. Fresh Codex review is clean. The refreshed full changed-file gate passed. [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/33267301371) is running on `ee82d9f27b5ffdd361671beef477f8ca2335b56a`.
- The latest ClawSweeper review reports no actionable correctness or security finding. Its unavailable current-main/protocol inspection was a review-host DNS limitation: the maintainer source audit and real HTTP/Testbox evidence cover those boundaries; no code workaround is required.

Production delta: zero. Changes are tests and shared test support; no schema, configuration, dependency, or persistent-state changes.
