### PR TITLE
fix(qa): keep Telegram release bootstrap configs current

### DIFF
--- a/extensions/qa-lab/src/gateway-child.test.ts
+++ b/extensions/qa-lab/src/gateway-child.test.ts
@@ -178,7 +178,8 @@ if (!recordPath || !configPath || !stateDir) {
 const record = (value) => fs.appendFileSync(recordPath, JSON.stringify(value) + "\\n");
 const fail = async (code, message) => {
   await new Promise((resolve) => process.stderr.write(
-    message + "\\ncontext retained\\n" + "diagnostic ".repeat(400), resolve));
+    message + "\\ncontext retained\\n" + "diagnostic ".repeat(400) +
+    "\\nterminal failure: Authorization: Bearer fixture-tail-secret", resolve));
   process.exit(code);
 };
 const authDbPath = path.join(stateDir, "agents", "qa", "agent", "openclaw-agent.sqlite");
@@ -1734,6 +1735,7 @@ describe("buildQaRuntimeEnv", () => {
       expect(error.message).toContain(`${prefix}${detail}\ncontext retained\n`);
       expect(error.cause.message.length).toBeLessThanOrEqual(prefix.length + 2_048);
       expect(error.cause.message).not.toContain("diagnostic ".repeat(400));
+      expect(error.cause.message).toContain("terminal failure: Authorization: Bearer <redacted>");
       expect(error.cause).not.toHaveProperty("cause");
       const records = await readJsonLines(recordPath);
       expect(records.map((record) => record.kind)).toEqual(
@@ -1757,6 +1759,7 @@ describe("buildQaRuntimeEnv", () => {
         expect(diagnostic).not.toContain(submittedKey);
       }
       expect(diagnostic).not.toContain("fixture-plugin-secret");
+      expect(diagnostic).not.toContain("fixture-tail-secret");
       const tempRoots = await readdir(tempParentDir);
       expect(tempRoots).toHaveLength(1);
       for (const stream of ["stdout", "stderr"]) {

--- a/extensions/qa-lab/src/gateway-log-redaction.test.ts
+++ b/extensions/qa-lab/src/gateway-log-redaction.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { formatQaGatewayLogsForError, redactQaGatewayDebugText } from "./gateway-log-redaction.js";
+import {
+  createQaGatewayCliError,
+  formatQaGatewayLogsForError,
+  redactQaGatewayDebugText,
+} from "./gateway-log-redaction.js";
 
 describe("gateway log redaction", () => {
   it("redacts raw Telegram bot tokens and Bot API URLs", () => {
@@ -93,4 +97,16 @@ describe("gateway log redaction", () => {
     expect(formatQaGatewayLogsForError(raw)).not.toMatch(/(^|[\r\n])[^\S\r\n]*::/u);
     expect(formatQaGatewayLogsForError(raw)).not.toContain("##[");
   });
+
+  it.each([995, 996, 997])(
+    "keeps a CLI truncation boundary inert with %s trailing chars",
+    (padding) => {
+      const raw = `${"context ".repeat(512)}::error::untrusted${"x".repeat(padding)}`;
+      const error = createQaGatewayCliError(raw);
+
+      expect(error.message).toContain("untrusted");
+      expect(error.message.length).toBeLessThanOrEqual(2_048);
+      expect(error.message).not.toMatch(/(^|[\r\n])[^\S\r\n]*::/u);
+    },
+  );
 });

--- a/extensions/qa-lab/src/gateway-log-redaction.ts
+++ b/extensions/qa-lab/src/gateway-log-redaction.ts
@@ -145,6 +145,15 @@ export function formatQaGatewayLogsForError(logs: string) {
 export function createQaGatewayCliError(error: unknown): Error {
   // Candidate errors can carry credentials in nested causes, spawnargs, or output.
   // Retain only a bounded, redacted message, including for lifecycle-held failures.
-  const message = coerceErrorMessage(error);
-  return new Error(sliceUtf16Safe(redactQaGatewayDebugText(message), 0, 2_048));
+  let message = redactQaGatewayDebugText(coerceErrorMessage(error));
+  const maxChars = 2_048;
+  if (message.length > maxChars) {
+    // Doctor can print setup panels before its terminal error. Preserve both
+    // ends after redaction so the bounded diagnostic retains the failure.
+    // Keep the tail on this line so slicing cannot create a workflow command.
+    const marker = "\n… output omitted … ";
+    const edgeChars = Math.floor((maxChars - marker.length) / 2);
+    message = `${sliceUtf16Safe(message, 0, edgeChars)}${marker}${sliceUtf16Safe(message, -edgeChars)}`;
+  }
+  return new Error(message);
 }

--- a/extensions/qa-lab/src/qa-gateway-config.test.ts
+++ b/extensions/qa-lab/src/qa-gateway-config.test.ts
@@ -111,6 +111,9 @@ describe("buildQaGatewayConfig", () => {
     expect(getModelFallbacks(cfg.agents?.defaults?.model)).toEqual([
       "mock-openai/gpt-5.6-luna-alt",
     ]);
+    expect(cfg.agents?.defaults?.modelPolicy).toEqual({
+      allow: ["mock-openai/gpt-5.6-luna", "mock-openai/gpt-5.6-luna-alt"],
+    });
     expect(getModelFallbacks(cfg.agents?.entries?.qa?.model)).toEqual([
       "mock-openai/gpt-5.6-luna-alt",
     ]);
@@ -546,6 +549,7 @@ describe("buildQaGatewayConfig", () => {
 
     expect(getPrimaryModel(cfg.agents?.defaults?.model)).toBe("openai/gpt-5.4");
     expect(getModelFallbacks(cfg.agents?.defaults?.model)).toBeUndefined();
+    expect(cfg.agents?.defaults?.modelPolicy).toEqual({ allow: ["openai/gpt-5.4"] });
   });
 
   it("can disable control ui for suite-only gateway children", () => {

--- a/extensions/qa-lab/src/qa-gateway-config.ts
+++ b/extensions/qa-lab/src/qa-gateway-config.ts
@@ -252,6 +252,7 @@ export function buildQaGatewayConfig(params: {
           [primaryModel]: resolveModelEntry(primaryModel),
           [alternateModel]: resolveModelEntry(alternateModel),
         },
+        modelPolicy: { allow: uniqueStrings([primaryModel, alternateModel]) },
         subagents: {
           allowAgents: ["*"],
           maxConcurrent: 2,


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where full release verification's isolated Telegram candidate fails during package bootstrap, before the first scenario starts. The generated QA config still relies on the legacy model-map restriction, so Doctor tries to migrate an intentionally immutable config. Its terminal permission error is then lost behind truncated setup output.

Related: [failed release Telegram execution](https://github.com/openclaw/openclaw/actions/runs/33256294772/job/99110969070).

## Why This Change Was Made

The QA config producer now declares the existing primary/alternate model restriction through `agents.defaults.modelPolicy.allow`; model parameters remain in `models`. This preserves the selected models and avoids the required legacy migration. Bootstrap diagnostics retain a redacted beginning and end within the existing 2,048-character limit, without retaining the raw error cause.

The trusted launcher, immutable config ownership, read-only candidate runtime, repair flags, plugin convergence, and skill coverage are unchanged. There is no staging/promotion protocol or new configuration surface. Production runtime LOC: 0; QA harness: +12/-2 (net +10); regression tests: +25/-2. The added harness lines preserve bounded terminal diagnostics without reactivating CI workflow commands at a truncated line boundary.

## User Impact

Release verification can complete required package bootstrap without trying to rewrite its trusted canonical model config, and later bootstrap failures retain their terminal reason. This changes internal QA fixtures and diagnostics, not operators' configuration defaults.

## Evidence

- Four owner/sibling test files: 138 passed, 1 skipped. The existing four-phase failure fixture failed before the diagnostic change and passed afterward; the default model-pair and same-model restriction cases both failed before the producer change. Two truncation-boundary cases also failed before keeping the tail on the marker line; all three boundary positions now pass.
- Focused typed lint and formatting passed with this checkout's own frozen dependencies. An initial lint prerequisite failure used stale shared dependencies; replacing only the task-owned dependency symlink with an isolated frozen install resolved it.
- Actual Linux packaged proof on [Blacksmith Testbox](https://github.com/openclaw/openclaw/actions/runs/33260641796): the original Telegram candidate artifact at `d9fe780239a2cb7158aad437112156605e8d375c` failed the full `update repair --accept-capabilities --yes --no-restart --json` bootstrap. Repeating with the model-policy producer fix passed. That producer is byte-identical in the refreshed PR. Main then centralized CLI lifecycle/error handling in #132659; this PR preserves that owner and applies the diagnostic change to its shared redactor, with fresh owner/sibling regression proof. The candidate package remained read-only; canonical config bytes and owner/mode stayed unchanged across both auth commands, help, and repair (0640 config, 1770 sticky parent). The SUT remained unable to write the canonical config. No live Telegram credentials were used in this Linux bootstrap proof. The owned user/mount were removed and the lease stopped.
- The broader local `check:changed` invocation exited 137 during the chained baseline/environment ratchet after printing a successful max-lines result. A bounded standalone retry with a 4 GiB Node heap passed both ratchets (882 max-lines suppressions; 500/500 environment names). The whole changed gate is still recorded as incomplete; exact-head CI remains required.
- Independent Codex autoreview: no actionable findings at the repository's default P0 threshold.
- Exact-head CI [33263667614](https://github.com/openclaw/openclaw/actions/runs/33263667614) passed on `9fe4940770167457a3eb5737cbd4083d0cb109e1`: 47 successful checks, 17 intentionally skipped, no failures.
- Authenticated Telegram [job 99130135316](https://github.com/openclaw/openclaw/actions/runs/33263683523/job/99130135316) passed all 12 canonical scenarios with no skips. The downloaded artifact's SHA-256 matched GitHub metadata; all 12 evidence entries bind to this exact PR head with live Telegram and provider execution. This is source-checkout pre-merge proof, not packaged release proof: the release-only workflow intentionally rejects open PR heads. Canonical packaged release Telegram verification remains required after landing.
- The same manually dispatched all-lanes QA run also passed mock parity and all 93 Matrix scenarios with no skips. Discord passed six of seven scenarios; its transcript authorization scenario correctly stopped because the leased fixture lacked an explicitly reserved voice-channel ID. Slack passed 20 of 22, with two independently investigated progress-commentary fixture failures. WhatsApp could not acquire a Convex credential within the existing 30-minute limit; all 47 evidence entries are blocked before channel execution. No arbitrary room was discovered or entered, no guard was weakened, and no lane was blindly retried. Every job is terminal; the aggregate run is not represented as green.

Named follow-up: **Doctor final config-write truthfulness during immutable-config repair**. With the required migration removed, Doctor still attempts the optional disable-unavailable-skills write, reports its permission failure as a warning, and returns success. A writable diagnostic copy showed only skill-disable entries and write metadata changes. This PR does not mask that warning, disable skills, or loosen the immutable-config boundary.

AI-assisted.
