### PR TITLE
fix(release): prevent FRV reruns from losing candidate artifacts

### DIFF
--- a/.agents/skills/release-openclaw-ci/SKILL.md
+++ b/.agents/skills/release-openclaw-ci/SKILL.md
@@ -58,6 +58,10 @@ Use this with `$release-openclaw-maintainer` and `$openclaw-testing` when a rele
 - Same-parent continuation requires the original root to have been dispatched
   with `fail_fast=false`. The controller verifies that exact logged input
   before any rerun mutation.
+- A parent that produced its own sealed candidate artifacts cannot be continued:
+  GitHub reruns make those prior-attempt artifacts unavailable. Keep the
+  candidate and Tooling SHAs frozen, supersede that parent, and start a fresh
+  all-group Full Release Validation.
 - After dispatch, one immutable execution-plan artifact records the original
   parent attempt, exact child tuples and titles, selected coverage, gates, and
   reuse identity. The same bytes are saved under an exact run-ID cache key.

--- a/.github/workflows/full-release-validation.yml
+++ b/.github/workflows/full-release-validation.yml
@@ -1674,8 +1674,8 @@ jobs:
           DIAGNOSTIC_DRAIN_PATH: ${{ runner.temp }}/full-release-diagnostics/full-release-diagnostic-manifest.json
         run: node scripts/full-release-validation-state.mjs verify
 
-      # Artifact v4 keeps prior attempts readable within the same workflow run.
-      # Exact IDs from the sealed plan prevent recovery from drifting to a newer upload.
+      # Exact IDs from the sealed plan prevent verification from drifting to a newer upload.
+      # Parent-owned candidate plans are rejected before same-parent continuation.
       - name: Verify sealed release candidate
         env:
           GH_TOKEN: ${{ github.token }}

--- a/docs/reference/full-release-validation.md
+++ b/docs/reference/full-release-validation.md
@@ -46,6 +46,10 @@ still-active child that owns the blocking failure.
 Same-parent continuation requires the original root to have been dispatched
 with `fail_fast=false`. The controller verifies that exact logged input before
 any rerun mutation.
+It is also unavailable when that parent produced the sealed candidate
+artifacts, because GitHub reruns make those prior-attempt artifacts unavailable.
+Keep the candidate and Tooling SHAs frozen, supersede the parent, and start a
+fresh all-group Full Release Validation.
 
 After dispatch, the parent writes one immutable
 `full-release-execution-plan-<run-id>` artifact and preserves the same bytes in

--- a/scripts/frv.mjs
+++ b/scripts/frv.mjs
@@ -249,6 +249,11 @@ export async function preflightContinuation(
   client,
   repository = DEFAULT_REPOSITORY,
 ) {
+  if (plan.candidate?.producer.runId === String(rootRunId)) {
+    throw new Error(
+      "parent-owned sealed candidate artifacts do not survive parent reruns; start a fresh all-group FRV",
+    );
+  }
   if (plan.rerunGroup !== "all") {
     throw new Error("FRV continuation requires an all-group root");
   }

--- a/test/scripts/frv.test.ts
+++ b/test/scripts/frv.test.ts
@@ -418,6 +418,55 @@ describe("FRV immutable plan eligibility", () => {
 });
 
 describe("FRV continuation preflight", () => {
+  it("rejects parent-owned candidate artifacts before any GitHub access", async () => {
+    const selected = child("normalCi", "101");
+    const parentOwnedPlan = {
+      ...plan([selected]),
+      candidate: { producer: { runId: "77" } },
+    };
+    let reads = 0;
+    let mutations = 0;
+    const read = async () => {
+      reads += 1;
+      throw new Error("unexpected GitHub read");
+    };
+    const mutate = async () => {
+      mutations += 1;
+    };
+
+    await expect(
+      continueFailed(parentOwnedPlan, "77", {
+        getAttemptJobs: read,
+        getJobLog: read,
+        getParentJobs: read,
+        getRun: read,
+        getRunAttempt: read,
+        repository: REPOSITORY,
+        rerunFailed: mutate,
+        rerunParent: mutate,
+        verify: mutate,
+      }),
+    ).rejects.toThrow(
+      "parent-owned sealed candidate artifacts do not survive parent reruns; start a fresh all-group FRV",
+    );
+    expect(reads).toBe(0);
+    expect(mutations).toBe(0);
+  });
+
+  it.each([
+    ["candidate-free", undefined],
+    ["externally produced", { producer: { runId: "88" } }],
+  ])("allows %s plans through candidate ownership preflight", async (_label, candidate) => {
+    const selected = child("normalCi", "101");
+    await expect(
+      preflightContinuation(
+        { ...plan([selected]), candidate },
+        "77",
+        preflightMethods([selected], (entry) => runFor(entry, 1, "failure")),
+      ),
+    ).resolves.toMatchObject({ id: 77 });
+  });
+
   it("rejects fail-fast roots before any rerun mutation", async () => {
     const selected = child("normalCi", "101");
     let mutations = 0;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where release operators could continue a failed Full Release Validation parent even when that parent produced the sealed candidate artifacts. GitHub reruns make those prior-attempt artifacts unavailable, so the rerun could only fail after child work had already been retried.

## Why This Change Was Made

The FRV controller now rejects parent-owned candidate plans before any GitHub read or rerun mutation and directs operators to start a fresh all-group validation while keeping the candidate and Tooling SHAs frozen. Candidate contracts, artifact verification, release branches, and publication behavior are unchanged. The larger external candidate-producer redesign remains deferred.

## User Impact

Release operators get an immediate, actionable failure instead of spending time rerunning children for a parent that cannot verify its sealed candidate.

AI-assisted: yes.

## Evidence

- Regression test failed before the fix because the controller performed an unexpected GitHub read; it passes after the guard.
- `node scripts/run-vitest.mjs run test/scripts/frv.test.ts test/scripts/full-release-validation-continuation-workflow.test.ts test/scripts/full-release-validation-state.test.ts` - 217 passed.
- `pnpm frv continue --failed --run 33259702098 --dry-run` - rejected parent-owned candidate artifacts with the fresh all-group recovery instruction; no workflow mutation.
- `pnpm check:docs` - passed.
- `pnpm lint:scripts` - passed.
- `git diff --check` - passed.
- Autoreview - clean, no accepted/actionable findings.
- `pnpm tsgo:test:root` reaches an unrelated current-main failure: `ui/vite.config.ts` imports `pako` without declarations. This PR does not touch UI or dependencies.
