### PR TITLE
fix(macos): restore Codex catalogs on paired Macs

### DIFF
--- a/apps/macos/Sources/OpenClaw/NodeMode/MacNodeCodexThreadCatalog.swift
+++ b/apps/macos/Sources/OpenClaw/NodeMode/MacNodeCodexThreadCatalog.swift
@@ -215,31 +215,6 @@ enum MacNodeCodexThreadCatalog {
             client: client)
     }
 
-    static func turns(
-        paramsJSON: String?,
-        executable: String,
-        arguments: [String]? = nil,
-        cwd: URL? = nil,
-        clearEnv: [String] = [],
-        timeoutSeconds: Double = MacNodeCodexThreadCatalog.defaultTimeoutSeconds,
-        maxLineBytes: Int = 20 * 1024 * 1024) async throws -> String
-    {
-        let params = try decodeTurnParams(paramsJSON)
-        let client = CodexAppServerThreadClient()
-        return try await self.withEphemeralClient(client) {
-            try await self.turns(
-                params: params,
-                invocation: ResolvedInvocation(
-                    executable: executable,
-                    arguments: arguments ?? self.defaultArguments,
-                    cwd: cwd,
-                    clearEnv: clearEnv),
-                client: client,
-                timeoutSeconds: timeoutSeconds,
-                maxLineBytes: maxLineBytes)
-        }
-    }
-
     private static func turns(
         params: TurnParams,
         invocation: ResolvedInvocation,

--- a/apps/macos/Sources/OpenClaw/NodeMode/MacNodeCodexThreadCatalog.swift
+++ b/apps/macos/Sources/OpenClaw/NodeMode/MacNodeCodexThreadCatalog.swift
@@ -979,23 +979,24 @@ extension MacNodeCodexThreadCatalog {
             .standardizedFileURL
     }
 
-    private static func decodeParams(_ paramsJSON: String?) throws -> ListParams {
+    private static func decodeRequestObject(_ paramsJSON: String?) throws -> [String: Any] {
         guard let paramsJSON, !paramsJSON.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
-            return ListParams()
+            return [:]
         }
-        guard let data = paramsJSON.data(using: .utf8) else {
-            throw CatalogError.invalidParams("parameters must be valid JSON")
+        guard let data = paramsJSON.data(using: .utf8),
+              let raw = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        else {
+            throw CatalogError.invalidParams("parameters must be a valid JSON object")
         }
-        let raw: Any
-        do {
-            raw = try JSONSerialization.jsonObject(with: data)
-        } catch {
-            throw CatalogError.invalidParams("parameters must be valid JSON")
-        }
-        guard let raw = raw as? [String: Any] else {
-            throw CatalogError.invalidParams("parameters must be an object")
-        }
-        let allowed = Set(["cursor", "limit", "searchTerm", "cwd"])
+        // Native discovery stays in the node user's Codex home. The Gateway's
+        // route owner is context, never an agent-home selector or native RPC field.
+        _ = try self.optionalString(raw, key: "agentId", maxLength: self.maxSessionIdLength)
+        return raw
+    }
+
+    private static func decodeParams(_ paramsJSON: String?) throws -> ListParams {
+        let raw = try self.decodeRequestObject(paramsJSON)
+        let allowed = Set(["agentId", "cursor", "limit", "searchTerm", "cwd"])
         if let unknown = raw.keys.first(where: { !allowed.contains($0) }) {
             throw CatalogError.invalidParams("unknown Codex session catalog parameter: \(unknown)")
         }
@@ -1021,13 +1022,8 @@ extension MacNodeCodexThreadCatalog {
     }
 
     private static func decodeTurnParams(_ paramsJSON: String?) throws -> TurnParams {
-        guard let paramsJSON,
-              let data = paramsJSON.data(using: .utf8),
-              let raw = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
-        else {
-            throw CatalogError.invalidParams("parameters must be a valid JSON object")
-        }
-        let allowed = Set(["threadId", "cursor", "limit"])
+        let raw = try self.decodeRequestObject(paramsJSON)
+        let allowed = Set(["agentId", "threadId", "cursor", "limit"])
         if let unknown = raw.keys.first(where: { !allowed.contains($0) }) {
             throw CatalogError.invalidParams("unknown Codex transcript parameter: \(unknown)")
         }

--- a/apps/macos/Tests/OpenClawIPCTests/MacNodeCodexThreadCatalogTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/MacNodeCodexThreadCatalogTests.swift
@@ -79,6 +79,7 @@ struct MacNodeCodexThreadCatalogTests {
             count=0
             [ ! -f "${0}.processes" ] || count=$(cat "${0}.processes")
             printf '%s\n' "$((count + 1))" > "${0}.processes"
+            printf '%s\n' "${CODEX_HOME-}" > "${0}.codex-home"
             """#)
         }
         if blocksEOFExit {
@@ -786,7 +787,7 @@ struct MacNodeCodexThreadCatalogTests {
             """#)
 
         let payload = try await MacNodeCodexThreadCatalog.list(
-            paramsJSON: #"{"cursor":" cursor ","limit":25,"searchTerm":" oNe ","cwd":" /work "}"#,
+            paramsJSON: #"{"agentId":"gateway-owner","cursor":" cursor ","limit":25,"searchTerm":" oNe ","cwd":" /work "}"#,
             executable: fake.executable.path)
         let response = try #require(
             JSONSerialization.jsonObject(with: Data(payload.utf8)) as? [String: Any])
@@ -808,6 +809,7 @@ struct MacNodeCodexThreadCatalogTests {
         #expect(captured[1]?["id"] == nil)
         #expect(captured[2]?["method"] as? String == "thread/list")
         let listParams = try #require(captured[2]?["params"] as? [String: Any])
+        #expect(listParams["agentId"] == nil)
         #expect(listParams["cursor"] as? String == "cursor")
         #expect(listParams["limit"] as? Int == 25)
         #expect(listParams["archived"] as? Bool == false)
@@ -820,45 +822,73 @@ struct MacNodeCodexThreadCatalogTests {
         #expect(listParams["useStateDbOnly"] as? Bool == false)
     }
 
-    @Test func `Mac node runtime reuses its owned App Server across invokes`() async throws {
+    @Test @MainActor func `Mac node runtime keeps its user home across Gateway catalog owners`() async throws {
         let fake = try makeEmptyListServer(
             tracksLaunches: true,
             captureHandshake: true)
-        let root = self.codexRoot(appServer: [
+        var root = self.codexRoot(appServer: [
             "transport": "stdio",
             "homeScope": "user",
             "command": fake.executable.path,
         ])
-        let client = MacNodeCodexThreadCatalogClient(
-            idleTimeoutSeconds: 10,
-            loadRoot: { root })
-        let runtime = MacNodeRuntime(
-            codexThreadCatalogEnabled: { true },
-            codexThreadCatalogClient: client)
+        let nodeAgents: [String: Any] = [
+            "ownership": "explicit",
+            "entries": ["node-local": [String: Any]()],
+        ]
+        root["agents"] = nodeAgents
+        let codexHome = fake.directory.appendingPathComponent("user-codex-home", isDirectory: true)
+        try FileManager.default.createDirectory(at: codexHome, withIntermediateDirectories: true)
 
-        let first = await runtime.handleInvoke(BridgeInvokeRequest(
-            id: "first",
-            command: MacNodeCodexThreadCatalogContract.listCommand))
-        let second = await runtime.handleInvoke(BridgeInvokeRequest(
-            id: "second",
-            command: MacNodeCodexThreadCatalogContract.listCommand))
+        try await TestIsolation.withEnvValues(["CODEX_HOME": codexHome.path]) {
+            let client = MacNodeCodexThreadCatalogClient(
+                idleTimeoutSeconds: 10,
+                loadRoot: { root })
+            let runtime = MacNodeRuntime(
+                computerControlEnabled: { false },
+                computerControlProvider: { .peekaboo },
+                codexThreadCatalogEnabled: { true },
+                codexThreadCatalogClient: client)
+            // These are Gateway owners, deliberately absent from the node's roster.
+            // Sidebar and continuation eligibility must keep the same native source.
+            let requests = [
+                #"{"agentId":"alpha","limit":50}"#,
+                #"{"agentId":"beta","limit":100}"#,
+                #"{"agentId":"gateway-only","limit":50}"#,
+            ]
+            var succeeded = true
+            for (index, paramsJSON) in requests.enumerated() {
+                let response = await runtime.handleInvoke(BridgeInvokeRequest(
+                    id: "owner-\(index)",
+                    command: MacNodeCodexThreadCatalogContract.listCommand,
+                    paramsJSON: paramsJSON))
+                #expect(response.ok, "\(response.error?.message ?? "missing catalog response")")
+                succeeded = succeeded && response.ok
+            }
+            await runtime.shutdown()
+            try #require(succeeded)
 
-        #expect(first.ok)
-        #expect(second.ok)
-        #expect(try self.readTrimmed(
-            URL(fileURLWithPath: fake.executable.path + ".processes")) == "1")
-        let captured = try String(contentsOf: fake.capture, encoding: .utf8)
-            .split(whereSeparator: \.isNewline)
-            .map { try #require(
-                JSONSerialization.jsonObject(with: Data($0.utf8)) as? [String: Any]) }
-        #expect(captured.map { $0["method"] as? String } == [
-            "initialize",
-            "initialized",
-            "thread/list",
-            "thread/list",
-        ])
-        #expect(captured.compactMap { ($0["id"] as? NSNumber)?.intValue } == [1, 2, 3])
-        await client.shutdown()
+            #expect(try self.readTrimmed(
+                URL(fileURLWithPath: fake.executable.path + ".processes")) == "1")
+            #expect(try self.readTrimmed(
+                URL(fileURLWithPath: fake.executable.path + ".codex-home")) == codexHome.path)
+            let captured = try String(contentsOf: fake.capture, encoding: .utf8)
+                .split(whereSeparator: \.isNewline)
+                .map { try #require(
+                    JSONSerialization.jsonObject(with: Data($0.utf8)) as? [String: Any]) }
+            #expect(captured.map { $0["method"] as? String } == [
+                "initialize",
+                "initialized",
+                "thread/list",
+                "thread/list",
+                "thread/list",
+            ])
+            #expect(captured.compactMap { ($0["id"] as? NSNumber)?.intValue } == [1, 2, 3, 4])
+            let listParams = try captured.dropFirst(2).map { request in
+                try #require(request["params"] as? [String: Any])
+            }
+            #expect(listParams.compactMap { $0["limit"] as? Int } == [50, 100, 50])
+            #expect(listParams.allSatisfy { $0["agentId"] == nil })
+        }
     }
 
     @Test func `reads one paginated transcript turn page from App Server`() async throws {
@@ -872,9 +902,24 @@ struct MacNodeCodexThreadCatalogTests {
         sleep 1
         """#)
 
-        let payload = try await MacNodeCodexThreadCatalog.turns(
-            paramsJSON: #"{"threadId":" thread-1 ","cursor":" turns-1 ","limit":25}"#,
-            executable: fake.executable.path)
+        let root = self.codexRoot(appServer: [
+            "transport": "stdio",
+            "homeScope": "user",
+            "command": fake.executable.path,
+        ])
+        let client = MacNodeCodexThreadCatalogClient(loadRoot: { root })
+        let runtime = MacNodeRuntime(
+            computerControlEnabled: { false },
+            computerControlProvider: { .peekaboo },
+            codexThreadCatalogEnabled: { true },
+            codexThreadCatalogClient: client)
+        let result = await runtime.handleInvoke(BridgeInvokeRequest(
+            id: "gateway-transcript",
+            command: MacNodeCodexThreadCatalogContract.turnsCommand,
+            paramsJSON: #"{"agentId":"gateway-only","threadId":" thread-1 ","cursor":" turns-1 ","limit":25}"#))
+        await runtime.shutdown()
+        try #require(result.ok, "\(result.error?.message ?? "missing transcript response")")
+        let payload = try #require(result.payloadJSON)
         let response = try #require(
             JSONSerialization.jsonObject(with: Data(payload.utf8)) as? [String: Any])
         let firstTurn = try #require((response["data"] as? [[String: Any]])?.first)
@@ -891,7 +936,10 @@ struct MacNodeCodexThreadCatalogTests {
         #expect(captured[2]?["method"] as? String == "thread/list")
         #expect(captured[3]?["method"] as? String == "thread/turns/list")
         #expect(captured.compactMap { ($0?["id"] as? NSNumber)?.intValue } == [1, 2, 3])
+        let eligibilityParams = try #require(captured[2]?["params"] as? [String: Any])
+        #expect(eligibilityParams["agentId"] == nil)
         let params = try #require(captured[3]?["params"] as? [String: Any])
+        #expect(params["agentId"] == nil)
         #expect(params["threadId"] as? String == "thread-1")
         #expect(params["cursor"] as? String == "turns-1")
         #expect(params["limit"] as? Int == 25)
@@ -1539,6 +1587,42 @@ extension MacNodeCodexThreadCatalogTests {
                 Issue.record("unexpected error: \(error)")
             }
         }
+    }
+
+    @Test func `rejects malformed Gateway agent ids before config access`() async {
+        let client = MacNodeCodexThreadCatalogClient(loadRoot: {
+            Issue.record("invalid agentId must fail before loading native config")
+            return [:]
+        })
+        let runtime = MacNodeRuntime(
+            computerControlEnabled: { false },
+            computerControlProvider: { .peekaboo },
+            codexThreadCatalogEnabled: { true },
+            codexThreadCatalogClient: client)
+        let malformed = ["null", "true", "42", "{}", "[]"].map {
+            ($0, "agentId must be a string")
+        } + [
+            (#""\#(String(repeating: "x", count: 257))""#, "agentId must be at most 256 characters"),
+            (#""\#(String(repeating: "😀", count: 129))""#, "agentId must be at most 256 characters"),
+        ]
+        for (agentIdJSON, message) in malformed {
+            let requests = [
+                (MacNodeCodexThreadCatalogContract.listCommand, #"{"agentId":\#(agentIdJSON),"limit":25}"#),
+                (
+                    MacNodeCodexThreadCatalogContract.turnsCommand,
+                    #"{"agentId":\#(agentIdJSON),"threadId":"thread-1","limit":25}"#),
+            ]
+            for (command, paramsJSON) in requests {
+                let result = await runtime.handleInvoke(BridgeInvokeRequest(
+                    id: "invalid-owner",
+                    command: command,
+                    paramsJSON: paramsJSON))
+                #expect(!result.ok)
+                #expect(result.error?.code == .invalidRequest)
+                #expect(result.error?.message == "INVALID_REQUEST: \(message)")
+            }
+        }
+        await runtime.shutdown()
     }
 
     @Test func `bounds fake App Server output and wait time`() async throws {

--- a/docs/plugins/codex-supervision.md
+++ b/docs/plugins/codex-supervision.md
@@ -124,6 +124,12 @@ honored for that stdio process. If the Mac config selects `"unix"`,
 capability or command, and a stale direct invocation fails instead of exposing
 the user Codex home or spawning a different local stdio App Server.
 
+The optional `agentId` in native Mac catalog list/read requests identifies the
+Gateway's OpenClaw route owner. It cannot select an agent-specific Codex home;
+the native catalog remains user-home stdio only. Headless node catalog requests
+still resolve `agentId` against that node's configured agents and use the selected
+agent's configured catalog source. This does not map agent IDs between computers.
+
 A newly advertised node command changes the node's approved command surface.
 Approve the update from the Gateway host:
 


### PR DESCRIPTION
Closes #132674

## What Problem This Solves

Fixes an issue where users browsing Codex sessions on an opted-in paired Mac would receive an unavailable catalog instead of session listings or transcripts. The failure also blocks the catalog checks used before opening a terminal or continuing a paired-node session.

## Why This Change Was Made

The native Mac catalog now validates the Gateway's optional `agentId` context at one shared JSON-envelope boundary. Native discovery still uses the node user's Codex home; the field never selects an agent home, grants authority, or reaches the Codex app-server. Explicit agent-home and non-stdio native configurations remain refused. Headless node agent/source binding is unchanged.

This also removes duplicated JSON decoding instead of adding another routing or fallback path, and deletes the obsolete transcript overload whose only caller was replaced by real-runtime regression coverage. Production LOC: +17/-46 (net -29). Tests: +120/-36 (net +84). Docs: +6/-0. No config option, schema, persistent-store design, SDK authority, or node command surface changes.

## User Impact

The existing Gateway payloads can list and read the native Mac catalog without changing which Codex store is exposed. A Gateway owner absent from the Mac's local agent roster does not invent a native agent-scoped source. Headless requests continue to require their existing node-local agent/source contract.

This does not redesign cross-machine agent mapping or durable CLI continuation-home identity. Native-vs-worker ownership and failure behavior are unchanged.

## Evidence

- Confirmed before repair through a signed, OS-isolated real `MacNodeRuntime -> MacNodeCodexThreadCatalogClient -> MacNodeCodexThreadCatalog` path. Gateway-shaped list/eligibility/transcript payloads failed at the unknown `agentId` check; a list without the field succeeded against actual Codex 0.150.1.
- The new native regressions fail against the pre-fix executable for that exact reason. The identical focused selection passes 7/7 after repair: representative list/read payloads, three Gateway owners retaining one user-home app-server, no upstream `agentId`, malformed/oversized context rejected before config access, and unchanged agent-home/non-stdio/unknown-field refusal. The local sandbox run relocates only the fake-server fixture directory into its session-owned temporary root; the unadapted checked-in tests run in macOS CI.
- `pnpm build:ci-artifacts` passed. Scoped SwiftFormat and docs formatting passed. Fresh independent Codex autoreview is clean.
- Initial exact-head Periphery run [33262968129](https://github.com/openclaw/openclaw/actions/runs/33262968129) correctly found the now-unused executable-based `turns` overload after its test moved to the real runtime. The follow-up deletes that entrypoint, rather than adding an ignore or weakening the scan. The native test bundle rebuilt successfully, all 7 focused signed regressions passed again, and independent cleanup review is clean. Fresh exact-head CI remains required.
- Headless sibling suites passed 34/34: `node scripts/run-vitest.mjs extensions/codex/src/session-catalog-node-listing.test.ts extensions/codex/src/session-catalog-node-continue.test.ts`.
- Scoped conflict/attribution/deprecation/export/coercion/dependency/format guards and the complete Swift lint lane passed with repository-pinned tools. The broader `check-changed` run then exceeded wall-time limits in five unchanged macOS lifecycle fixtures; all five passed a focused rerun with the original deadlines (93.02 seconds total). `node scripts/check-native-state-schema-version.mjs` also passed. This is not a claim that the original aggregate run was green. Exact-head CI supplies the complete macOS lanes.
- The cleanup head passed full hosted macOS Swift and Node lanes in [CI run 33265850684](https://github.com/openclaw/openclaw/actions/runs/33265850684), and the native Periphery scan passed in [run 33265759330](https://github.com/openclaw/openclaw/actions/runs/33265759330). This fallback was needed after two zero-job GitHub `BuildFailed/startup_failure` events and an HTTP 500 on the first dispatch; a bounded delayed retry started it. Its broader graph exposed an older browser fixture-permission bug already repaired by #132662 and one Windows child-process timeout. The exact [Windows job rerun](https://github.com/openclaw/openclaw/actions/runs/33265850684/job/99139018055) passed with unchanged code and deadlines. The branch was mechanically rebased to include the landed browser fixture repair; `git range-diff` proves both catalog patches unchanged, and fresh post-rebase independent review is clean. Fresh ordinary [PR CI run 33267163291](https://github.com/openclaw/openclaw/actions/runs/33267163291) passed at `da6a64dfa72d4fa4ba5565a51c63aaad3c621737`. The [shared-kit scans and intersection check](https://github.com/openclaw/openclaw/actions/runs/33267163301/attempts/2) also passed after retrying two unassigned, zero-step jobs on the workflow's configured GitHub-hosted fallback. All final-head checks are green.
- Live operator proof passed with an isolated Gateway, real authenticated/pair-approved `GatewayNodeSession`, real `MacNodeRuntime`, and actual Codex 0.150.1 using synthetic native state. The same paired identity and Codex home returned `NODE_INVOKE_FAILED` with zero rows before the repair and one native row with no error afterward. The actual Control UI opened its persisted user history. Successive `sessions.catalog.read` requests with `agentId: main` and `limit: 1` returned the latest item and then the older item through the native cursor. No model turn, continuation, operator state, or operator Gateway was used.

### Inspected before/after operator evidence

Before: the real Gateway receives the native parameter rejection; the Codex group shows a warning and no native rows.

![Before: Codex catalog warning with no native rows](https://github.com/user-attachments/assets/a9215370-01b9-4116-abd4-cd1285454c02)

After: the same native source appears and its persisted history opens. The view-only banner is expected: this isolated node advertises only the two catalog commands, not CLI continuation.

![After: paired Mac catalog and persisted user history](https://github.com/user-attachments/assets/e25975e5-25d8-44f2-8031-0dd7b41a2fa8)

Short recording of the real isolated flow; the browser closes at the end:

https://github.com/user-attachments/assets/2debfa05-7fd0-4ee3-b5dd-f8d659bf3b68

Dependency contract inspected directly in the sibling Codex checkout at `rust-v0.150.1` (source commit `90854393966b21e9ebfd21b122334eb09a20c93d`): `codex-rs/app-server-protocol/src/protocol/v2/thread.rs:1362,1681`, `app-server/src/message_processor.rs:288-291`, and `utils/home-dir/src/lib.rs:13-61`. Codex has no OpenClaw agent selector in these RPCs; its source store is process-bound.

Provenance: the cross-language mismatch was introduced by the paired-node agent-ownership work in #124172, authored and merged by Peter Steinberger (@steipete) on 2026-08-15. The TypeScript change did not update the native decoder. The checked beta tags contain this surface; no checked stable release tag does.

Named follow-ups outside this request-envelope repair: native activation/config parity for the existing `sessionCatalog` subtree, and explicit source-home continuity for later CLI continuation. Neither is silently treated as solved by accepting route-owner context. The Windows CI investigation also identified a separate test-fixture child-process teardown/diagnostic weakness in `test/scripts/direct-run-entrypoints.test.ts`; it is recorded for a scoped follow-up, not claimed to explain the initial timeout.

AI-assisted maintainer repair. No operator Gateway or state has been used for proof.
