### PR TITLE
fix(maintainers): compare gh and GraphQL repository identity by matching id shape

### DIFF
--- a/scripts/pr-lib/merge-outcome.sh
+++ b/scripts/pr-lib/merge-outcome.sh
@@ -97,11 +97,15 @@ merge_outcome_read_remote() {
   local response
   response=$(gh_plain api graphql --hostname "$MERGE_REPO_HOST" \
     -f owner="${MERGE_REPO_NAME%/*}" -f name="${MERGE_REPO_NAME#*/}" -F number="$1" \
-    -f 'query=query($owner:String!,$name:String!,$number:Int!){repository(owner:$owner,name:$name){id url nameWithOwner ref(qualifiedName:"refs/heads/main"){target{oid}} pullRequest(number:$number){id number url state headRefOid baseRefName isDraft mergeCommit{oid} autoMergeRequest{mergeMethod} isInMergeQueue isMergeQueueEnabled mergeable mergeStateStatus}}}') || return 1
+    -f 'query=query($owner:String!,$name:String!,$number:Int!){repository(owner:$owner,name:$name){id databaseId url nameWithOwner ref(qualifiedName:"refs/heads/main"){target{oid}} pullRequest(number:$number){id number url state headRefOid baseRefName isDraft mergeCommit{oid} autoMergeRequest{mergeMethod} isInMergeQueue isMergeQueueEnabled mergeable mergeStateStatus}}}') || return 1
   printf '%s\n' "$response" | jq -ce --argjson repo "$MERGE_REPO" --argjson pr "$1" '
     def oid: type == "string" and test("^[0-9a-f]{40}$");
     select(.errors == null) | .data.repository |
-    select({id,url,nameWithOwner} == $repo and (.ref.target.oid | oid)) |
+    # gh reports the repository id as its REST database id while GraphQL reports the node
+    # id, so the two sources never compare equal on identity alone. Match whichever
+    # representation gh supplied; url and nameWithOwner still pin the repository exactly.
+    select(.url == $repo.url and .nameWithOwner == $repo.nameWithOwner and
+      ($repo.id == .id or $repo.id == .databaseId) and (.ref.target.oid | oid)) |
     {main:.ref.target.oid, pr:.pullRequest} |
     select(.pr.number == $pr and (.pr.id | type == "string" and length > 0) and
       .pr.url == ($repo.url + "/pull/" + ($pr|tostring)) and

--- a/test/scripts/pr-merge-outcome.test.ts
+++ b/test/scripts/pr-merge-outcome.test.ts
@@ -68,11 +68,14 @@ function fixture(sourceMessage?: string, sourceVersions: Array<[string, string?]
     writeFileSync(join(worktree, ".local", name), "fixture\n");
   }
   const initial = {
+    // gh reports the REST database id (a number) while GraphQL reports the node id.
+    // The fixture models both so the merge path is exercised against real gh shapes.
     repo: {
-      id: "fixture-repo",
+      id: 1103012935 as string | number,
       url: "https://github.com/fixture/repo",
       nameWithOwner: "fixture/repo",
     },
+    repoNodeId: "R_kgDOQb6kRw" as string | null,
     pr: {
       id: "fixture-pr",
       number: 123,
@@ -196,7 +199,9 @@ else if(args[0]==="pr"&&args[1]==="view") {
     if(step?.unavailable) fail("metadata unavailable");
     if(step?.invalid) {save();out({data:{repository:{}}});process.exit(0);}
     const pr={...s.pr};if(s.drift&&s.reads%2===0) pr.baseRefName="changed";
-    out({data:{repository:{...s.repo,ref:{target:{oid:main()}},pullRequest:pr}}});
+    const repository={...s.repo,ref:{target:{oid:main()}},pullRequest:pr};
+    if(s.repoNodeId!==null) {repository.id=s.repoNodeId;repository.databaseId=s.repo.id;}
+    out({data:{repository}});
   }
 } else if(args.some(x=>x.includes("/comments"))) {
   if(args.includes("POST")) {
@@ -1243,5 +1248,23 @@ describePosix("merge_outcome_repo_identity", () => {
     });
     expect(run.status).not.toBe(0);
     expect(run.stdout).toBe("");
+  });
+});
+
+describePosix("repository identity across gh id representations", () => {
+  // The fixture's default state models current gh: a numeric CLI id and a GraphQL node
+  // id. This covers the other host shape, where gh reports the node id from both
+  // sources, so neither representation regresses.
+  it("merges when gh reports the node id from both sources", () => {
+    const f = fixture();
+    f.save({
+      ...f.state(),
+      repo: { ...f.state().repo, id: "R_kgDOQb6kRw" },
+      repoNodeId: null,
+    });
+    const run = f.run();
+    expect(run.status, run.output).toBe(0);
+    expect(f.record().phase).toBe("complete");
+    expect(f.state().mutations).toBe(1);
   });
 });


### PR DESCRIPTION
Follow-up to #132690, which fixed the first of two gh-shape defects on the same merge path.

## What Problem This Solves

Agent merges to `main` still abort, now one step later:

```
merge-verify passed for PR #132638
Merge outcome: authoritative PR/main metadata unavailable or invalid
```

`merge_outcome_read_remote` compares the GraphQL repository object against the identity
captured earlier from `gh repo view --json id,nameWithOwner,url`:

```
select({id,url,nameWithOwner} == $repo and (.ref.target.oid | oid))
```

Those two sources report different ids for the same repository:

```
gh repo view : {"id":1103012935,        "nameWithOwner":"openclaw/openclaw", ...}
GraphQL      : {"id":"R_kgDOQb6kRw","databaseId":1103012935, ...}
```

gh gives the REST database id; GraphQL gives the node id. The object equality can never
hold, so `jq -e` fails and admission stops. #132690 let admission past the first check;
this is the next one on the same path.

## Why This Change Was Made

Select `databaseId` alongside `id` and accept whichever representation gh supplied.
`url` and `nameWithOwner` still have to match exactly, so the repository remains pinned -
only the id comparison learns that one repository has two legitimate id shapes.

Verified against live data: the corrected predicate passes the complete observation
validation for #132638 and returns the expected `{main, pr}` object.

## User Impact

Restores `scripts/pr merge-run` for maintainers and agents. Without it the documented
landing flow gets as far as merge-verify and then stops without merging.

## Evidence

**Why no test caught either defect.** The fixture spread a single identity object into
both the `gh repo view` response and the GraphQL response, so the two could never
disagree. It now models GitHub's real shape - numeric id from the CLI, node id plus
`databaseId` from GraphQL - which means the existing 115 merge tests exercise the real
comparison rather than a self-consistent fiction.

**Regression proof.** With the fixture corrected and the production fix reverted, a normal
merge test fails with the exact production error:

```
× native merge outcome ... > completes cleanup when GitHub already deleted the source branch
Merge outcome: authoritative PR/main metadata unavailable or invalid
```

The added legacy-shape test still passes when reverted, which is correct - hosts whose gh
reports the node id from both sources were never affected - so it is guarding the other
representation rather than duplicating the same case.

**Tests.**

```
node scripts/run-vitest.mjs test/scripts/pr-merge-outcome.test.ts
Test Files  1 passed (1)
     Tests  122 passed (122)

node scripts/check-changed.mjs   # exit 0
```

Codex autoreview: clean, no accepted findings, verdict correct (0.99).

**Bug-class sweep.** This is the only cross-source id comparison on the merge path. The
other `$repo` comparisons (`merge_outcome_load_local`'s retained-record check and the
record built in `merge.sh`) compare gh-CLI-sourced values on both sides, so they stay
consistent; `merge.sh`'s other GraphQL query does not select a repository id.

**Landing note.** Like #132690, this cannot be landed by `scripts/pr merge-run` itself: the
wrapper trust boundary requires landing subcommands to run canonical/`origin-main` wrapper
code, which still contains this defect. It needs a maintainer merge or ClawSweeper
automerge; after that the flow is self-sufficient again.

Production LOC: +6/-2 in `scripts/pr-lib/merge-outcome.sh` (3 added lines are comments) | Tests: +25/-2
