### PR TITLE
test(plugins): stop runtime task-flow tests leaking gateway restart blockers

### DIFF
--- a/src/plugins/runtime/runtime-task-test-harness.ts
+++ b/src/plugins/runtime/runtime-task-test-harness.ts
@@ -33,13 +33,15 @@ export function installRuntimeTaskDeliveryMock(): void {
   });
 }
 
-export function resetRuntimeTaskTestState(
-  taskRegistryOptions?: Parameters<typeof resetTaskRegistryForTests>[0],
-): void {
+// Runtime task tests write durable rows into the worker's shared state store.
+// Skipping the reset write leaves those rows behind, and the next
+// ensureTaskRegistryReady() restores them into the process registry as active
+// restart blockers for every later test file in the same worker.
+export function resetRuntimeTaskTestState(): void {
   resetDetachedTaskLifecycleRuntimeForTests();
   resetTaskRegistryControlRuntimeForTests();
   resetTaskRegistryDeliveryRuntimeForTests();
-  resetTaskRegistryForTests(taskRegistryOptions);
-  resetTaskFlowRegistryForTests({ persist: false });
+  resetTaskRegistryForTests();
+  resetTaskFlowRegistryForTests();
   vi.clearAllMocks();
 }

--- a/src/plugins/runtime/runtime-taskflow.test.ts
+++ b/src/plugins/runtime/runtime-taskflow.test.ts
@@ -4,6 +4,7 @@ import { createAcpTaskBackingDetailForTest } from "../../tasks/task-backing-auth
 import { createRunningTaskRunCore } from "../../tasks/task-executor.js";
 import { createTaskFlowForTask, getTaskFlowById } from "../../tasks/task-flow-registry.js";
 import { getTaskById } from "../../tasks/task-registry.js";
+import { getInspectableActiveTaskRestartBlockers } from "../../tasks/task-registry.maintenance.js";
 import {
   installRuntimeTaskDeliveryMock,
   resetRuntimeTaskTestState,
@@ -21,7 +22,7 @@ function requireCreatedFlow<T>(flow: T | null): T {
 }
 
 afterEach(() => {
-  resetRuntimeTaskTestState({ persist: false });
+  resetRuntimeTaskTestState();
 });
 
 describe("runtime TaskFlow", () => {
@@ -267,5 +268,13 @@ describe("runtime TaskFlow", () => {
     });
     expect(getTaskFlowById(managed.flowId)?.endedAt).toBeUndefined();
     expect(getTaskFlowById(mirrored.flowId)?.revision).toBe(0);
+  });
+
+  // Declared last on purpose: it observes what the earlier tests' afterEach
+  // resets left behind. A reset that keeps durable rows lets
+  // ensureTaskRegistryReady() restore them here, and every later test file in
+  // this isolate:false worker then inherits phantom active restart blockers.
+  it("leaves no restorable task restart blockers for later test files", () => {
+    expect(getInspectableActiveTaskRestartBlockers()).toStrictEqual([]);
   });
 });


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where `checks-node-compact-*` jobs on `main` intermittently failed with
`AssertionError: promise rejected "Error: spawn sample left 1 active gateway work items"` at
`test/scripts/bench-agent-concurrency.test.ts:134`, burning the full 30s drain timeout
(observed 30157ms). Seen on main run 33257360392 (job 99114375955) and reproduced on
PR #132638 run 33258273176, while adjacent main runs passed.

The failing assertion is process-wide: `waitForGatewayActiveWork()` only reports `drained`
when `createGatewayActiveWorkSnapshot().idle` is true, i.e. `totalActive === 0` for the
whole worker. The `core-unit-fast-2` shard runs ~645 files with `isolate: false`, so one
sibling file leaking active work makes that snapshot permanently non-idle.

## Why This Change Was Made

Root cause: `src/plugins/runtime/runtime-taskflow.test.ts` reset its state with
`resetRuntimeTaskTestState({ persist: false })`. That path clears the in-memory task and
task-flow registries and marks their restore state `uninitialized`, but deliberately skips
writing the emptied snapshot back — so the durable rows the test just created stay in the
worker's shared hermetic state store. The next `ensureTaskRegistryReady()` restores them,
and `getInspectableActiveTaskRestartBlockers()` then reports the test's two `running` ACP
tasks (`runId=runtime-taskflow-child`) as live restart blockers for every later file in the
same worker.

`persist: false` is legitimate for tests that own a per-test state directory; this file uses
the worker-wide directory from `test/setup.env.ts`, so skipping the write leaks state across
files. The repair is at the lifecycle owner: `resetRuntimeTaskTestState()` now always
persists the emptied registries, and the pass-through option is removed so the leaking
spelling is unrepresentable. `runtime-tasks.test.ts`, the only other caller, already used
the persisting default.

## User Impact

No production behavior change — test-support and test files only. CI stops flaking on the
gateway active-work drain assertion in the `unit-fast` lane.

## Evidence

Producer identified by instrumenting the whole `unit-fast` lane (1289 files, `--maxWorkers=1`,
`isolate: false`) with an `afterAll` probe that reports `createGatewayActiveWorkSnapshot()`
deltas per file. Exactly one producer:

```
[ACTIVE-WORK-DELTA] src/plugins/runtime/runtime-taskflow.test.ts 0->2 activeTasks=2
  :: task:runId=runtime-taskflow-child status=running runtime=acp title=Inspect PR 1
   | task:runId=runtime-taskflow-child status=running runtime=acp title=Inspect PR 1
```

Before/after on the same command and ordering:

- Pre-fix, full lane single-worker: `Test Files 2 failed | 1286 passed`, including the exact
  CI failure `Error: spawn sample left 2 active gateway work items` at
  `test/scripts/bench-agent-concurrency.test.ts:134`.
- Post-fix, same run: `Test Files 1287 passed | 2 skipped (1289)`.

Regression coverage: the new final test in `runtime-taskflow.test.ts` fails on pre-fix code
(`expected [ { …(5) }, { …(5) } ] to strictly equal []`) and passes after, reproducing the
original in-file execution order (tests create running tasks, `afterEach` resets, the next
observer restores the registry).

Also run: `node scripts/run-vitest.mjs src/plugins/runtime/runtime-taskflow.test.ts
src/plugins/runtime/runtime-tasks.test.ts` (green), `pnpm check:changed` (exit 0), and a
fresh Codex autoreview (`scoped-clean`, no accepted findings).

Follow-up worth considering separately: nothing structurally prevents another test from
reintroducing this class. A lane-wide `afterAll` idle assertion in the `unit-fast` setup
would catch it at the boundary, but it would turn any latent leak into a hard failure across
many files, so it is not bundled here.
