### PR TITLE
fix(build): ignore tool scratch churn in boundary topology walks

### DIFF
--- a/scripts/lib/extension-boundary-inputs.mts
+++ b/scripts/lib/extension-boundary-inputs.mts
@@ -162,6 +162,12 @@ export class BoundaryInputSnapshot {
           ) {
             continue;
           }
+          // Tool scratch (.vite-temp bundles, jiti/vitest caches) churns under
+          // installed roots while sibling tasks run and would flip the topology
+          // digest mid-compile. Resolution never enters dot-entries except .pnpm.
+          if (installed && entry.name !== ".pnpm" && entry.name.startsWith(".")) {
+            continue;
+          }
           if (
             /^extensions\/[^/]+\/(?:__rootdir_boundary_canary__\.ts|tsconfig\.rootdir-canary\.json)$/u.test(
               id,

--- a/test/scripts/build-artifact-cache.test.ts
+++ b/test/scripts/build-artifact-cache.test.ts
@@ -254,6 +254,28 @@ describe("native owner content records", () => {
     expect(matches()).toBe(false);
   });
 
+  it("ignores tool scratch churn under installed roots", () => {
+    const f = fixture(true);
+    fs.mkdirSync(path.join(f.root, "node_modules"));
+    const run = f.prepare();
+    // Sibling config loads mint these between the before and seal walks.
+    f.write("node_modules/.vite-temp/vitest.config.ts.timestamp-1-a.mjs", "export default {};");
+    const record = f.seal(run);
+    const matches = () =>
+      new BoundaryInputSnapshot(f.root).matches(
+        record,
+        f.config,
+        f.args,
+        Object.keys(record.outputs),
+      );
+    expect(matches()).toBe(true);
+    fs.rmSync(path.join(f.root, "node_modules/.vite-temp"), { recursive: true });
+    f.write("node_modules/.cache/jiti/config.deadbeef.mjs", "export default {};");
+    expect(matches()).toBe(true);
+    f.write("node_modules/.pnpm/pkg@1.0.0/node_modules/pkg/index.js", "export const value = 1;");
+    expect(matches()).toBe(false);
+  });
+
   it("propagates non-ENOENT link resolution errors", () => {
     const f = fixture(true);
     fs.symlinkSync("loop", path.join(f.root, "loop"));


### PR DESCRIPTION
## What Problem This Solves

`pnpm check:changed` intermittently fails during extension-lint preparation with:

```
Error: Boundary configuration or resolution topology changed during compilation
prepare-extension-package-boundary-artifacts failed with exit code 1
```

`BoundaryInputSnapshot.namespace()` (new in #132532, refined in #132603) records every file name under installed roots with no scratch exclusions. Vite writes a transient `node_modules/.vite-temp/<config>.timestamp-<ms>-<rand>.mjs` bundle on every ESM config load and async-unlinks it (installed vite 8.2.2, `loadConfigFromBundledFile`), and jiti keeps hash-named `.mjs` files under `node_modules/.cache`. Any sibling task loading a vitest/vite config in the same checkout mints such names between the before-compile and after-compile topology walks, the digests differ, and `record()` throws — discarding an already-successful native emit. Stale leftover scratch files also spuriously invalidated warm boundary caches via the signature.

## Why This Change Was Made

Fix at the scanner's owner, not by retrying: skip dot-entries under installed roots except `.pnpm`. npm package names cannot start with `.`, so bare-specifier resolution never enters these directories; pnpm's virtual store is the one dot-entry lookups traverse (symlink targets) and stays in the walk. Install-driven changes to skipped metadata (`.modules.yaml`, `.bin`) remain covered by the lockfile and `.modules.yaml` content hashes already in the signature. This kills the whole churn class (vite, jiti, vitest caches, future tools) instead of denylisting one directory name, and stops the walk from pointlessly traversing ~11k vitest-cache entries per scan.

Named tradeoff: vite's EACCES/deno fallback writes `<config>.timestamp-*.mjs` next to the config file outside installed roots and is not excluded — an unwritable `node_modules` breaks pnpm itself long before this scanner.

## User Impact

Developers and CI running `pnpm check:changed` (or `pnpm lint`) while any sibling task loads a vite/vitest config in the same checkout no longer hit spurious topology failures, and warm boundary caches are no longer invalidated by leftover tool scratch.

## Evidence

- Live repro pre-fix: `prepare-extension-package-boundary-artifacts` racing a loop of real `vite.loadConfigFromFile("vitest.config.ts")` calls fails deterministically with the exact error right after `[plugin-sdk boundary dts] emitted 8204 files`.
- Post-fix, the identical race completes all 8 boundary units (exit 0) with 429 distinct transient `.vite-temp` files observed churning during the run; an immediate warm rerun reports every unit `fresh; skipping`.
- New regression test `ignores tool scratch churn under installed roots` in `test/scripts/build-artifact-cache.test.ts` fails pre-fix with the exact production error and passes post-fix; it also asserts changes inside `node_modules/.pnpm` still invalidate. Full file: 30/30 green.
- `node scripts/check-changed.mjs` exit 0 (format, erasability, script + test-root typecheck, lint lanes).
- Production LOC +6 (3 code, 3 comment — the installed-root counterpart of the existing non-installed skip list; this walker has a single skip site and nothing to absorb the exclusion into), tests +22.
