### PR TITLE
fix(qa): align release E2E fixtures with current contracts

### DIFF
--- a/src/commands/onboard-guided.inference.e2e.test.ts
+++ b/src/commands/onboard-guided.inference.e2e.test.ts
@@ -161,9 +161,25 @@ describe("guided onboarding inference composition", () => {
       expect(prompter.select).toHaveBeenNthCalledWith(
         1,
         expect.objectContaining({
+          initialValue: false,
+          options: [
+            expect.objectContaining({ value: false }),
+            expect.objectContaining({ value: true }),
+          ],
+        }),
+      );
+      expect(prompter.select).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({
           options: expect.arrayContaining([expect.objectContaining({ value: "full" })]),
         }),
       );
+      const persisted = await configModule.readConfigFileSnapshot();
+      expect(persisted.valid).toBe(true);
+      expect(persisted.sourceConfig).toMatchObject({
+        telemetry: { enabled: false, consentedAt: expect.any(String) },
+        wizard: { accessMode: "full" },
+      });
       expect(mockOpenAi.requestBodies).toHaveLength(1);
       expect(JSON.parse(mockOpenAi.requestBodies[0] ?? "{}")).toMatchObject({
         model: "gpt-5.6-sol",

--- a/test/e2e/qa-lab/media/media-audio-selection.e2e.test.ts
+++ b/test/e2e/qa-lab/media/media-audio-selection.e2e.test.ts
@@ -136,6 +136,11 @@ describe("QA media audio selection product proof", () => {
     ).toMatchObject({
       outcome: "success",
       attachments: [{ attachmentIndex: 3 }, { attachmentIndex: 2 }],
+      attachmentDispositions: {
+        0: { kind: "not-selected" },
+        2: { kind: "handled" },
+        3: { kind: "handled" },
+      },
     });
     expect(allModeCtx.Transcript).toBe(
       "Audio 1:\ntranscript:third.ogg\n\nAudio 2:\ntranscript:second.ogg",
@@ -144,6 +149,7 @@ describe("QA media audio selection product proof", () => {
       [
         "[Audio 1/2]\nTranscript:\ntranscript:third.ogg",
         "[Audio 2/2]\nTranscript:\ntranscript:second.ogg",
+        "[Audio attachment not processed: attachment limit reached]",
       ].join("\n\n"),
     );
   });

--- a/test/e2e/qa-lab/media/vision-channel-offload.e2e.test.ts
+++ b/test/e2e/qa-lab/media/vision-channel-offload.e2e.test.ts
@@ -202,7 +202,7 @@ describe("QA-channel vision offload", () => {
     expect(activeModelRequest.model, requestDiagnostics).toBe(ACTIVE_MODEL_ID);
     expect(activeModelRequest.imageInputCount, requestDiagnostics).toBe(0);
     expect(readInputRoles(activeModelRequest), requestDiagnostics).toEqual([
-      "system",
+      "developer",
       "user",
       "user",
     ]);

--- a/test/e2e/qa-lab/runtime/openclaw-workspace-mutation-tools.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/openclaw-workspace-mutation-tools.e2e.test.ts
@@ -86,7 +86,8 @@ test("OpenClaw applies and edits exact workspace bytes while rejecting escapes",
     path: ARTIFACT,
     edits: [{ oldText: "state: DRAFT", newText: "state: FINAL" }],
   });
-  expect(textOf(edited)).toBe(`Successfully replaced 1 block(s) in ${ARTIFACT}.`);
+  const artifactPath = path.join(workspace, ARTIFACT);
+  expect(textOf(edited)).toBe(`Successfully replaced 1 block(s) in ${artifactPath}.`);
   expect(edited.details).toMatchObject({
     changed: true,
     firstChangedLine: 3,
@@ -100,8 +101,8 @@ test("OpenClaw applies and edits exact workspace bytes while rejecting escapes",
   expect(details.diff).toBe(
     [" 1 # Workspace mutation", " 2 ", "-3 state: DRAFT", "+3 state: FINAL"].join("\n"),
   );
-  expect(details.patch).toContain(`--- ${ARTIFACT}`);
-  expect(details.patch).toContain(`+++ ${ARTIFACT}`);
+  expect(details.patch).toContain(`--- ${artifactPath}`);
+  expect(details.patch).toContain(`+++ ${artifactPath}`);
   expect(details.patch).toContain("-state: DRAFT\n+state: FINAL");
   const finalBytes = await fs.readFile(path.join(workspace, ARTIFACT), "utf8");
   expect(finalBytes).toBe(FINAL);


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where full release verification fails on four outdated E2E expectations after the corresponding runtime contracts were intentionally updated. These failures were exposed when the release E2E lane reached tests beyond its earlier worker crash.

## Why This Change Was Made

Keep verification aligned with the real owners instead of changing correct runtime behavior:

- Guided onboarding now asks telemetry consent before access mode. Check the opt-out default, persisted refusal, and full-access selection while retaining the actual embedded OpenAI probe and final handoff assertions.
- Audio attachment limits now produce a recorded disposition and a visible skip marker. Retain exact transcript ordering and body assertions, including the explanation for the unselected audio file.
- Both reasoning-model Responses requests use the `developer` role. Preserve the real image ingress, two ordered requests, image offload, provider summary, and one visible reply.
- Guarded file tools pass the checked absolute target to the edit tool. Check that target in the receipt and both patch headers while retaining exact bytes, diff, changed-line information, and escape rejection.

Production LOC: +0/-0. Tests: +27/-4. No runtime, schema, configuration, permission, timeout, or retry changes.

## User Impact

No shipped behavior changes. Release verification can exercise these existing flows without false failures or repeated full-suite reruns.

## Evidence

Frozen baseline: `d9fe780239a2cb7158aad437112156605e8d375c`.

On the same prepared Linux environment, the unchanged onboarding/audio/vision files reproduced all three assertion failures in 16.13 seconds; the audio executable-fallback case passed. The unchanged workspace mutation case independently reproduced the relative-versus-absolute receipt mismatch in 3.29 seconds. No runtime source edits or rebuilds were used between these reproductions and the candidate.

The final four-file candidate passed **5/5 tests in 29.46 seconds**, with no skipped tests: real embedded onboarding HTTP/SSE probe, audio selection and actual CLI fallback, real QA-channel/Gateway vision offload, and real guarded workspace mutations. Full tracked-source verification before and after the run confirms the frozen baseline plus exactly these four test changes (35,135 files; candidate tree `03d6afc2cade6e4425e2a8074561e624c13a9a17`). [Blacksmith Testbox workflow](https://github.com/openclaw/openclaw/actions/runs/33260207562).

Focused command, with the existing prebuilt runtime:

```sh
OPENCLAW_E2E_USE_PREBUILT_DIST=1 OPENCLAW_E2E_WORKERS=1 \
node scripts/run-vitest.mjs run --config test/vitest/vitest.e2e.config.ts \
  src/commands/onboard-guided.inference.e2e.test.ts \
  test/e2e/qa-lab/media/media-audio-selection.e2e.test.ts \
  test/e2e/qa-lab/media/vision-channel-offload.e2e.test.ts \
  test/e2e/qa-lab/runtime/openclaw-workspace-mutation-tools.e2e.test.ts
```

This is real local-fixture behavior proof, not a live external-provider test or a claim that the entire release suite passes. One successful run does not establish a statistical flake rate.

Provenance: telemetry consent was added by #128476 (`4d617f44f37`, authored/merged by @steipete); attachment dispositions by #122098 (`82ba647673f`, authored/merged by @obviyus); canonical Responses role selection by #131677 (`35ebb96a6d0`, authored/merged by @steipete); guarded path forwarding by #131434 (`d2f13bc2702`, authored/merged by @steipete). The existing E2E expectations missed those changes. The runtime contracts and their owner tests stay intact.

The full required `check-changed` gate for all four files passed, including repository guards, all three dead-export scans, core and root-test type checks, and core/script lint. Fresh isolated Codex autoreview reported no actionable findings.
