### PR TITLE
fix: release checks fail on valid Workshop abstention

### DIFF
--- a/src/skills/workshop/experience-review-decision.test-support.ts
+++ b/src/skills/workshop/experience-review-decision.test-support.ts
@@ -1,0 +1,73 @@
+import type { AgentMessage } from "@openclaw/agent-core";
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
+import { expect } from "vitest";
+import type { Message } from "../../llm/types.js";
+import type { readSkillReviewOutcomes } from "./collection-review-state.js";
+import type { observeExperienceReview } from "./experience-review-observation.test-support.js";
+import type { getSkillProposalRunProgress, listSkillProposals } from "./service.js";
+
+export function readExperienceReviewMessageText(content: Message["content"]): string {
+  return typeof content === "string"
+    ? content
+    : content.flatMap((part) => (part.type === "text" ? [part.text] : [])).join("\n");
+}
+
+export function assertExperienceReviewDecision(params: {
+  observation: Awaited<ReturnType<typeof observeExperienceReview>>;
+  messages: AgentMessage[];
+  progress: Awaited<ReturnType<typeof getSkillProposalRunProgress>>;
+  proposals: readonly Pick<
+    Awaited<ReturnType<typeof listSkillProposals>>["proposals"][number],
+    "id" | "status"
+  >[];
+  outcome: ReturnType<typeof readSkillReviewOutcomes>["experienceReviews"][string] | undefined;
+  startedAt: number;
+}): "proposed" | "abstained" {
+  const { observation, progress, proposals, outcome } = params;
+  expect(observation.requests[0]?.toolNames).toEqual(
+    expect.arrayContaining(["exec", "read", "skill_workshop"]),
+  );
+  expect(observation.requests[0]?.outputs).toEqual(
+    params.messages
+      .filter((message) => message.role === "toolResult")
+      .map((message) => readExperienceReviewMessageText(message.content)),
+  );
+  expect(outcome?.attemptedAtMs).toBeGreaterThanOrEqual(params.startedAt);
+  expect(outcome?.usage?.outputTokens).toBeGreaterThan(0);
+  expect(observation.toolResults.some((result) => result.isError)).toBe(false);
+  for (const call of observation.toolCalls) {
+    expect(call.name).toBe("skill_workshop");
+    expect(observation.toolResults).toContainEqual(
+      expect.objectContaining({ toolName: call.name, toolCallId: call.id, isError: false }),
+    );
+  }
+  const mutations = observation.toolCalls.filter(
+    (call) =>
+      call.name === "skill_workshop" &&
+      isRecord(call.arguments) &&
+      ["create", "patch", "update", "revise"].includes(String(call.arguments.action)),
+  );
+  if (progress.mutationCount === 0) {
+    expect(mutations).toHaveLength(0);
+    for (const call of observation.toolCalls) {
+      expect(isRecord(call.arguments) && call.arguments.action).toSatisfy(
+        (action: unknown) => action === "read" || action === "prepare_patch",
+      );
+    }
+    expect(progress.proposalIds).toEqual([]);
+    expect(observation.finalText).toBe("NO_REPLY");
+    expect(outcome?.outcome).toBe("nothing");
+    return "abstained";
+  }
+  expect(progress.mutationCount).toBe(1);
+  expect(progress.proposalIds).toHaveLength(1);
+  expect(mutations).toHaveLength(1);
+  const proposalId = progress.proposalIds[0]!;
+  expect(proposals).toContainEqual(expect.objectContaining({ id: proposalId, status: "pending" }));
+  const receipt = observation.toolResults.find(
+    (result) => result.toolName === "skill_workshop" && result.toolCallId === mutations[0]!.id,
+  );
+  expect(receipt && readExperienceReviewMessageText(receipt.content)).toContain(proposalId);
+  expect(outcome).toMatchObject({ outcome: "proposed", proposalId });
+  return "proposed";
+}

--- a/src/skills/workshop/experience-review-decision.test-support.ts
+++ b/src/skills/workshop/experience-review-decision.test-support.ts
@@ -1,16 +1,10 @@
 import type { AgentMessage } from "@openclaw/agent-core";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { expect } from "vitest";
-import type { Message } from "../../llm/types.js";
 import type { readSkillReviewOutcomes } from "./collection-review-state.js";
+import { readExperienceReviewMessageText } from "./experience-review-message-text.test-support.js";
 import type { observeExperienceReview } from "./experience-review-observation.test-support.js";
 import type { getSkillProposalRunProgress, listSkillProposals } from "./service.js";
-
-export function readExperienceReviewMessageText(content: Message["content"]): string {
-  return typeof content === "string"
-    ? content
-    : content.flatMap((part) => (part.type === "text" ? [part.text] : [])).join("\n");
-}
 
 export function assertExperienceReviewDecision(params: {
   observation: Awaited<ReturnType<typeof observeExperienceReview>>;

--- a/src/skills/workshop/experience-review-message-text.test-support.ts
+++ b/src/skills/workshop/experience-review-message-text.test-support.ts
@@ -1,0 +1,8 @@
+import type { Message } from "../../llm/types.js";
+
+// A leaf keeps observer/decision imports acyclic and the decision unit tests lightweight.
+export function readExperienceReviewMessageText(content: Message["content"]): string {
+  return typeof content === "string"
+    ? content
+    : content.flatMap((part) => (part.type === "text" ? [part.text] : [])).join("\n");
+}

--- a/src/skills/workshop/experience-review-observation.test-support.ts
+++ b/src/skills/workshop/experience-review-observation.test-support.ts
@@ -2,7 +2,7 @@ import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { vi } from "vitest";
 import * as responsesEgress from "../../../packages/ai/src/transports/openai-responses-prompt-observer-internal.js";
 import { SessionManager } from "../../agents/sessions/index.js";
-import { readExperienceReviewMessageText } from "./experience-review-decision.test-support.js";
+import { readExperienceReviewMessageText } from "./experience-review-message-text.test-support.js";
 
 export async function observeExperienceReview(run: () => Promise<void>) {
   let session: SessionManager | undefined;

--- a/src/skills/workshop/experience-review-observation.test-support.ts
+++ b/src/skills/workshop/experience-review-observation.test-support.ts
@@ -1,0 +1,61 @@
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
+import { vi } from "vitest";
+import * as responsesEgress from "../../../packages/ai/src/transports/openai-responses-prompt-observer-internal.js";
+import { SessionManager } from "../../agents/sessions/index.js";
+import { readExperienceReviewMessageText } from "./experience-review-decision.test-support.js";
+
+export async function observeExperienceReview(run: () => Promise<void>) {
+  let session: SessionManager | undefined;
+  const requests: Array<{ toolNames: string[]; outputs: unknown[] }> = [];
+  const fromEntries = SessionManager.fromEntries.bind(SessionManager);
+  const createEgressObserver = responsesEgress.createResponsesPromptEgressObserver;
+  // Keep the actual runner and transport. Silent reviews suppress public assistant events;
+  // the detached transcript and final provider request own the facts this smoke needs.
+  const sessionSpy = vi.spyOn(SessionManager, "fromEntries").mockImplementation((...args) => {
+    session = fromEntries(...args);
+    return session;
+  });
+  const providerSpy = vi
+    .spyOn(responsesEgress, "createResponsesPromptEgressObserver")
+    .mockImplementation((...args) => {
+      const originalObserver = createEgressObserver(...args);
+      return (request, metadata) => {
+        const payload: unknown = request;
+        const tools = isRecord(payload) && Array.isArray(payload.tools) ? payload.tools : [];
+        const input = Array.isArray(request.input) ? request.input : [];
+        if (requests.length === 0) {
+          requests.push({
+            toolNames: tools.flatMap((tool) =>
+              isRecord(tool) && typeof tool.name === "string" ? [tool.name] : [],
+            ),
+            outputs: input.flatMap((item) =>
+              isRecord(item) && item.type === "function_call_output" ? [item.output] : [],
+            ),
+          });
+        }
+        originalObserver?.(request, metadata);
+      };
+    });
+  try {
+    await run();
+    if (!session) {
+      throw new Error("Workshop review did not create a detached transcript");
+    }
+    const messages = session.buildSessionContext().messages;
+    const review = messages.slice(messages.findLastIndex((message) => message.role === "user") + 1);
+    const final = review.findLast((message) => message.role === "assistant");
+    return {
+      requests,
+      finalText: final ? readExperienceReviewMessageText(final.content).trim() : "",
+      toolCalls: review.flatMap((message) =>
+        message.role === "assistant"
+          ? message.content.filter((part) => part.type === "toolCall")
+          : [],
+      ),
+      toolResults: review.filter((message) => message.role === "toolResult"),
+    };
+  } finally {
+    providerSpy.mockRestore();
+    sessionSpy.mockRestore();
+  }
+}

--- a/src/skills/workshop/experience-review.e2e.test.ts
+++ b/src/skills/workshop/experience-review.e2e.test.ts
@@ -7,6 +7,7 @@ import {
   writeOpenAiResponsesText,
 } from "../../../test/helpers/openai-responses-sse.js";
 import { loadAgentRuntimePluginRegistryHandle } from "../../agents/runtime-plugins.js";
+import { sanitizeToolUseResultPairingForModel } from "../../agents/session-transcript-repair.js";
 import { withServer } from "../../plugin-sdk/test-helpers/http-test-server.js";
 import {
   createOpenClawTestState,
@@ -14,6 +15,8 @@ import {
 } from "../../test-utils/openclaw-test-state.js";
 import { createTrackedTempDirs } from "../../test-utils/tracked-temp-dirs.js";
 import { readSkillReviewOutcomes } from "./collection-review-state.js";
+import { assertExperienceReviewDecision } from "./experience-review-decision.test-support.js";
+import { observeExperienceReview } from "./experience-review-observation.test-support.js";
 import { runSkillExperienceReview } from "./experience-review.js";
 import {
   createExperienceReviewCandidate,
@@ -26,7 +29,7 @@ import {
 } from "./service.js";
 
 const modelId = "gpt-5.6-luna";
-const { positiveMessages } = createExperienceReviewMessages(modelId);
+const { positiveMessages, interruptedMessages } = createExperienceReviewMessages(modelId);
 const tempDirs = createTrackedTempDirs();
 let state: OpenClawTestState;
 const proposalBody = [
@@ -46,7 +49,7 @@ type Request = {
   input?: Array<{ type?: string; name?: string; call_id?: string; output?: unknown }>;
   tools?: Array<{ name?: string }>;
 };
-type Scenario = "proposed" | "nothing" | "rejected" | "failed";
+type Scenario = "proposed" | "nothing" | "interrupted" | "rejected" | "failed";
 
 beforeAll(async () => {
   state = await createOpenClawTestState({ layout: "home", prefix: "workshop-owner-contract-" });
@@ -91,7 +94,7 @@ function writeToolCall(response: ServerResponse, args: Record<string, unknown>):
 }
 
 describe("Workshop experience review through the real provider and tool owners", () => {
-  it.each<Scenario>(["proposed", "nothing", "rejected", "failed"])(
+  it.each<Scenario>(["proposed", "nothing", "interrupted", "rejected", "failed"])(
     "records %s without replacing the review runner, catalog, or proposal service",
     async (scenario) => {
       const requests: Request[] = [];
@@ -126,25 +129,31 @@ describe("Workshop experience review through the real provider and tool owners",
         async (baseUrl) => {
           const workspaceDir = await tempDirs.make(`workshop-contract-${scenario}-`);
           const runId = `owner-contract-${scenario}`;
-          const messages = positiveMessages();
+          const messages = scenario === "interrupted" ? interruptedMessages() : positiveMessages();
+          const replay = sanitizeToolUseResultPairingForModel(messages, true);
           const candidate = await createExperienceReviewCandidate(runId, messages, {
             workspaceDir,
             modelId,
             baseUrl: `${baseUrl}/v1`,
             apiKey: "test-token-placeholder",
+            turnAborted: scenario === "interrupted",
           });
           // Load the real provider plugin before entering the review lane, as the live proof does.
           loadAgentRuntimePluginRegistryHandle({ config: candidate.config ?? {}, workspaceDir });
           const outcomesBefore = new Set(Object.keys(readSkillReviewOutcomes().experienceReviews));
-          const run = runSkillExperienceReview(candidate, {
-            getCurrentConfig: () => candidate.config ?? {},
-          });
+          const startedAt = Date.now();
+          const run = observeExperienceReview(() =>
+            runSkillExperienceReview(candidate, {
+              getCurrentConfig: () => candidate.config ?? {},
+            }),
+          );
+          let observation: Awaited<ReturnType<typeof observeExperienceReview>> | undefined;
           if (scenario === "failed") {
             await expect(run).rejects.toThrow(
               "provider rejected the request schema or tool payload",
             );
           } else {
-            await run;
+            observation = await run;
           }
 
           expect(handlerErrors).toEqual([]);
@@ -159,7 +168,7 @@ describe("Workshop experience review through the real provider and tool owners",
               ?.filter((item) => item.type === "function_call_output")
               .map((item) => item.output),
           ).toEqual(
-            messages
+            replay
               .filter((message) => message.role === "toolResult")
               .map((message) =>
                 message.content.map((part) => (part.type === "text" ? part.text : "")).join("\n"),
@@ -206,6 +215,21 @@ describe("Workshop experience review through the real provider and tool owners",
           }
           if (scenario !== "failed") {
             expect(outcome?.usage?.outputTokens).toBeGreaterThan(0);
+            expect(observation).toBeDefined();
+            const decision = () =>
+              assertExperienceReviewDecision({
+                observation: observation!,
+                messages: replay,
+                progress,
+                proposals,
+                outcome,
+                startedAt,
+              });
+            if (scenario === "rejected") {
+              expect(decision).toThrow();
+            } else {
+              expect(decision()).toBe(scenario === "proposed" ? "proposed" : "abstained");
+            }
           }
         },
       );

--- a/src/skills/workshop/experience-review.live-contract.test.ts
+++ b/src/skills/workshop/experience-review.live-contract.test.ts
@@ -1,0 +1,202 @@
+import { describe, expect, it } from "vitest";
+import type { Message } from "../../llm/types.js";
+import { assertExperienceReviewDecision } from "./experience-review-decision.test-support.js";
+
+type DecisionInput = Parameters<typeof assertExperienceReviewDecision>[0];
+function abstention(): DecisionInput {
+  const messages: Message[] = [
+    {
+      role: "toolResult",
+      toolCallId: "history",
+      toolName: "exec",
+      content: [{ type: "text", text: "observed recovery" }],
+      isError: false,
+      timestamp: 0,
+    },
+  ];
+  return {
+    messages,
+    startedAt: 1,
+    progress: { mutationCount: 0, proposalIds: [] },
+    proposals: [],
+    outcome: {
+      attemptedAtMs: 1,
+      outcome: "nothing",
+      usage: { inputTokens: 10, cachedInputTokens: 0, outputTokens: 8 },
+    },
+    observation: {
+      requests: [
+        {
+          toolNames: ["exec", "read", "skill_workshop"],
+          outputs: messages
+            .filter((message) => message.role === "toolResult")
+            .map((message) =>
+              message.content
+                .flatMap((part) => (part.type === "text" ? [part.text] : []))
+                .join("\n"),
+            ),
+        },
+      ],
+      finalText: "NO_REPLY",
+      toolCalls: [],
+      toolResults: [],
+    },
+  };
+}
+
+function proposal(): DecisionInput {
+  const input = abstention();
+  input.progress = { mutationCount: 1, proposalIds: ["proposal-1"] };
+  input.proposals = [{ id: "proposal-1", status: "pending" }];
+  input.outcome = { ...input.outcome!, outcome: "proposed", proposalId: "proposal-1" };
+  input.observation.toolCalls = [
+    { type: "toolCall", id: "create", name: "skill_workshop", arguments: { action: "create" } },
+  ];
+  input.observation.toolResults = [
+    {
+      role: "toolResult",
+      toolCallId: "create",
+      toolName: "skill_workshop",
+      content: [{ type: "text", text: "Created proposal-1" }],
+      isError: false,
+      timestamp: 0,
+    },
+  ];
+  return input;
+}
+
+describe("Workshop live decision acceptance", () => {
+  it("requires explicit abstention with intact evidence and a fresh recorded outcome", () => {
+    expect(assertExperienceReviewDecision(abstention())).toBe("abstained");
+  });
+
+  it.each(["read", "prepare_patch"])(
+    "allows successful %s before explicit abstention",
+    (action) => {
+      const input = abstention();
+      input.observation.toolCalls.push({
+        type: "toolCall",
+        id: "prepare",
+        name: "skill_workshop",
+        arguments: { action, name: "existing-skill" },
+      });
+      input.observation.toolResults.push({
+        role: "toolResult",
+        toolCallId: "prepare",
+        toolName: "skill_workshop",
+        content: [{ type: "text", text: "Existing skill content" }],
+        isError: false,
+        timestamp: 0,
+      });
+      expect(assertExperienceReviewDecision(input)).toBe("abstained");
+    },
+  );
+
+  it.each([
+    [
+      "empty completion",
+      (input: DecisionInput) => {
+        input.observation.finalText = "";
+      },
+    ],
+    [
+      "generic completion",
+      (input: DecisionInput) => {
+        input.observation.finalText = "There is nothing useful to add.";
+      },
+    ],
+    [
+      "lost replay result",
+      (input: DecisionInput) => {
+        input.observation.requests[0]!.outputs.pop();
+      },
+    ],
+    [
+      "missing Workshop tool",
+      (input: DecisionInput) => {
+        input.observation.requests[0]!.toolNames = ["exec", "read"];
+      },
+    ],
+    [
+      "stale recorded outcome",
+      (input: DecisionInput) => {
+        input.outcome!.attemptedAtMs = 0;
+      },
+    ],
+    [
+      "missing outcome",
+      (input: DecisionInput) => {
+        input.outcome = undefined;
+      },
+    ],
+    [
+      "mutation attempt before abstention",
+      (input: DecisionInput) => {
+        input.observation.toolCalls.push({
+          type: "toolCall",
+          id: "read",
+          name: "skill_workshop",
+          arguments: { action: "create", name: "existing-skill" },
+        });
+        input.observation.toolResults.push({
+          role: "toolResult",
+          toolCallId: "read",
+          toolName: "skill_workshop",
+          content: [{ type: "text", text: "Existing skill content" }],
+          isError: false,
+          timestamp: 0,
+        });
+      },
+    ],
+    [
+      "rejected tool",
+      (input: DecisionInput) => {
+        input.observation.toolResults.push({
+          role: "toolResult",
+          toolCallId: "rejected",
+          toolName: "skill_workshop",
+          content: [{ type: "text", text: "name required" }],
+          isError: true,
+          timestamp: 0,
+        });
+      },
+    ],
+  ] as const)("rejects %s even when the proposal count is zero", (_label, corrupt) => {
+    const input = abstention();
+    corrupt(input);
+    expect(() => assertExperienceReviewDecision(input)).toThrow();
+  });
+  it("accepts one pending proposal backed by a matching successful tool receipt", () => {
+    expect(assertExperienceReviewDecision(proposal())).toBe("proposed");
+  });
+  it.each([
+    [
+      "missing mutation call",
+      (input: DecisionInput) => {
+        input.observation.toolCalls = [];
+      },
+    ],
+    [
+      "missing proposal record",
+      (input: DecisionInput) => {
+        input.proposals = [];
+      },
+    ],
+    [
+      "wrong tool receipt",
+      (input: DecisionInput) => {
+        input.observation.toolResults[0]!.toolCallId = "unrelated";
+      },
+    ],
+    [
+      "extra mutation",
+      (input: DecisionInput) => {
+        input.progress.mutationCount = 2;
+      },
+    ],
+  ] as const)("rejects %s even when one proposal ID is reported", (_label, corrupt) => {
+    const input = proposal();
+    corrupt(input);
+    expect(() => assertExperienceReviewDecision(input)).toThrow();
+  });
+});

--- a/src/skills/workshop/experience-review.live.test.ts
+++ b/src/skills/workshop/experience-review.live.test.ts
@@ -20,6 +20,8 @@ import {
   readSkillReviewOutcomes,
   recordSkillExperienceReviewOutcome,
 } from "./collection-review-state.js";
+import { assertExperienceReviewDecision } from "./experience-review-decision.test-support.js";
+import { observeExperienceReview } from "./experience-review-observation.test-support.js";
 import { runSkillExperienceReview, type ExperienceReviewCandidate } from "./experience-review.js";
 import {
   createExperienceReviewCandidate,
@@ -191,38 +193,46 @@ describeLive("skill experience review live OpenAI eval", () => {
     });
   }, 600_000);
 
-  it("proposes a recovered preflight procedure but ignores routine one-off work", async () => {
-    const positiveCandidate = await candidate("live-positive", positiveMessages());
-    await runSkillExperienceReview(positiveCandidate, {
-      getCurrentConfig: () => positiveCandidate.config ?? {},
-    });
-    const afterPositive = await listSkillProposals({ workspaceDir });
-    expect(afterPositive.proposals).toHaveLength(1);
-    expect(afterPositive.proposals[0]).toMatchObject({ status: "pending" });
-
-    const negativeCandidate = await candidate("live-negative", negativeMessages());
-    await runSkillExperienceReview(negativeCandidate, {
-      getCurrentConfig: () => negativeCandidate.config ?? {},
-    });
-    const afterNegative = await listSkillProposals({ workspaceDir });
-    expect(afterNegative.proposals).toEqual(afterPositive.proposals);
-
-    const interruptedCandidate = await candidate("live-interrupted", interruptedMessages(), {
-      turnAborted: true,
-    });
-    await runSkillExperienceReview(interruptedCandidate, {
-      getCurrentConfig: () => interruptedCandidate.config ?? {},
-    });
-    const afterInterrupted = await listSkillProposals({ workspaceDir });
-    // Capturing the recovery may revise a pending proposal instead of adding one.
-    const interruptedProgress = await getSkillProposalRunProgress({
-      workspaceDir,
-      runId: "live-interrupted",
-    });
-    expect(interruptedProgress.mutationCount).toBe(1);
-    expect(interruptedProgress.proposalIds).toHaveLength(1);
-    expect(afterInterrupted.proposals).toContainEqual(
-      expect.objectContaining({ id: interruptedProgress.proposalIds[0], status: "pending" }),
-    );
+  it("completes real reviews with proposal receipts or explicit abstention", async () => {
+    for (const [name, build, turnAborted] of [
+      ["positive", positiveMessages, false],
+      ["negative", negativeMessages, false],
+      ["interrupted", interruptedMessages, true],
+    ] as const) {
+      const runId = `live-${name}`;
+      const messages = build();
+      const reviewCandidate = await candidate(runId, messages, { turnAborted });
+      const before = await listSkillProposals({ workspaceDir });
+      const startedAt = Date.now();
+      const observation = await observeExperienceReview(() =>
+        runSkillExperienceReview(reviewCandidate, {
+          getCurrentConfig: () => reviewCandidate.config ?? {},
+        }),
+      );
+      const { proposals } = await listSkillProposals({ workspaceDir });
+      const progress = await getSkillProposalRunProgress({ workspaceDir, runId });
+      const outcomes = Object.values(readSkillReviewOutcomes().experienceReviews);
+      expect(outcomes).toHaveLength(1);
+      const decision = assertExperienceReviewDecision({
+        observation,
+        // Responses replay adds an explicit aborted result for the interrupted
+        // fixture's unfinished call; retain every original body in exact order.
+        messages: sanitizeToolUseResultPairingForModel(messages, true),
+        progress,
+        proposals,
+        outcome: outcomes[0],
+        startedAt,
+      });
+      if (decision === "abstained") {
+        expect(proposals).toEqual(before.proposals);
+      }
+      if (name === "negative") {
+        expect(decision).toBe("abstained");
+      }
+      console.log(
+        "WORKSHOP_LIVE_DECISION",
+        JSON.stringify({ case: name, decision, mutationCount: progress.mutationCount }),
+      );
+    }
   }, 300_000);
 });


### PR DESCRIPTION
Workshop's experience-review prompt deliberately allows `NO_REPLY`, but the release smoke required every positive/interrupted live model call to create a proposal. Frozen candidate diagnostics showed all six original tool-result bodies and the real tool catalog reached the provider intact; it explicitly replied `NO_REPLY`, and the owner recorded `nothing`. That legitimate decision failed the old proposal-count assertion.

This test-only follow-up keeps the original fixtures, model, prompt, one-mutation budget and real runner. A call-through observer checks the actual Responses request and detached transcript. Each live review must either produce exactly one successful mutation with a matching pending proposal, tool receipt and fresh `proposed` outcome, or explicitly answer `NO_REPLY` with no mutation attempts/errors, unchanged proposals and a fresh `nothing` outcome. Only successful Workshop `read`/`prepare_patch` calls may precede abstention. Empty/generic output, missing context/catalog, rejected tools, stale outcomes, errors and aborts fail.

The deterministic integration in #132707 independently preserves exact-one proposal coverage through a controlled provider, the real catalog and the real proposal service. This follow-up uses that same integration to prove the live observer and acceptance rules, including rejecting a failed mutation even when the coarse stored result is `nothing`. Fast negative cases protect the release criterion itself.

No production, prompt, model, configuration, persistence or SQLite schema changes. The finer durable outcome classification discussed in #129973 remains open; this does not change that product decision.

Validation: 16 focused acceptance cases passed; core test types passed; independent Codex review reported no actionable finding. On Blacksmith Testbox `tbx_01m175rx9ztqp3kar9n47h3cvv`, frozen release candidate `d9fe780239a2cb7158aad437112156605e8d375c` plus the test-only overlay passed all five controlled-provider scenarios and all four preflight checks; the positive, negative and interrupted live reviews each explicitly abstained with zero mutations. The real live sequence completed in 9.8 seconds. The first instrumented sequence exposed the interrupted fixture’s expected synthetic `aborted` result; the corrected check uses the existing canonical replay normalizer and retains exact ordered body comparison. The source was restored byte-for-byte and proof downloaded. The full changed gate passed; exact-head CI remains pending. Production LOC delta: 0; all additions are tests/test support.
