### PR TITLE
fix(docs): ignore links inside fenced code

### DIFF
--- a/scripts/docs-link-audit.mts
+++ b/scripts/docs-link-audit.mts
@@ -502,6 +502,10 @@ export function parseFenceDelimiter(line: string): FenceDelimiter | null {
   return { marker, length: token.length };
 }
 
+function isClosingFence(line: string, fence: FenceDelimiter): boolean {
+  return line.trimStart().slice(fence.length).trim() === "";
+}
+
 export function sanitizeDocsConfigForEnglishOnly(value: unknown): unknown {
   if (Array.isArray(value)) {
     return value
@@ -748,7 +752,11 @@ function auditDocsLinks(options: { docsDir?: string; allowExternalClawHubRoutes?
       if (fence) {
         if (!codeFence) {
           codeFence = fence;
-        } else if (fence.marker === codeFence.marker && fence.length >= codeFence.length) {
+        } else if (
+          fence.marker === codeFence.marker &&
+          fence.length >= codeFence.length &&
+          isClosingFence(line, fence)
+        ) {
           codeFence = null;
         }
         continue;

--- a/scripts/docs-link-audit.mts
+++ b/scripts/docs-link-audit.mts
@@ -489,7 +489,7 @@ const markdownLinkRegex = /!?\[[^\]]*\]\(([^)]+)\)/g;
 
 type FenceDelimiter = { marker: "`" | "~"; length: number };
 
-export function parseFenceDelimiter(line: string): FenceDelimiter | null {
+function parseFenceDelimiter(line: string): FenceDelimiter | null {
   const trimmed = line.trimStart();
   const match = /^(?<token>`{3,}|~{3,})/u.exec(trimmed);
   const token = match?.groups?.token;

--- a/scripts/docs-link-audit.mts
+++ b/scripts/docs-link-audit.mts
@@ -490,8 +490,7 @@ const markdownLinkRegex = /!?\[[^\]]*\]\(([^)]+)\)/g;
 type FenceDelimiter = { marker: "`" | "~"; length: number };
 
 function parseFenceDelimiter(line: string): FenceDelimiter | null {
-  const trimmed = line.trimStart();
-  const match = /^(?<token>`{3,}|~{3,})/u.exec(trimmed);
+  const match = /^(?: {0,3})(?<token>`{3,}|~{3,})/u.exec(line);
   const token = match?.groups?.token;
   if (!token) {
     return null;

--- a/scripts/docs-link-audit.mts
+++ b/scripts/docs-link-audit.mts
@@ -487,23 +487,44 @@ function collectNavPageEntries(node: unknown): string[] {
 
 const markdownLinkRegex = /!?\[[^\]]*\]\(([^)]+)\)/g;
 
-type FenceDelimiter = { marker: "`" | "~"; length: number };
+/**
+ * Derive code ranges from the MDX tree so container-relative fences keep their
+ * indentation context. Fall back to tolerant Markdown token ranges for legacy
+ * malformed pages that the MDX parser cannot read.
+ */
+function collectCodeLines(rawText: string): Set<number> {
+  const codeLines = new Set<number>();
+  const addRange = (startLine: number, endLine: number) => {
+    for (let line = startLine; line <= endLine; line += 1) {
+      codeLines.add(line - 1);
+    }
+  };
 
-function parseFenceDelimiter(line: string): FenceDelimiter | null {
-  const match = /^(?: {0,3})(?<token>`{3,}|~{3,})/u.exec(line);
-  const token = match?.groups?.token;
-  if (!token) {
-    return null;
+  try {
+    const tree = MDX_PROCESSOR.parse(rawText);
+    const visit = (node: Nodes): void => {
+      if (node.type === "code" && node.position) {
+        addRange(node.position.start.line, node.position.end.line);
+      }
+      if ("children" in node) {
+        for (const child of node.children) {
+          visit(child);
+        }
+      }
+    };
+    visit(tree);
+    return codeLines;
+  } catch {
+    const tokens = MARKDOWN_PARSER.parse(rawText, {});
+    for (const token of tokens) {
+      if ((token.type === "fence" || token.type === "code_block") && token.map) {
+        for (let line = token.map[0]; line < token.map[1]; line += 1) {
+          codeLines.add(line);
+        }
+      }
+    }
+    return codeLines;
   }
-  const marker = token[0];
-  if (marker !== "`" && marker !== "~") {
-    return null;
-  }
-  return { marker, length: token.length };
-}
-
-function isClosingFence(line: string, fence: FenceDelimiter): boolean {
-  return line.trimStart().slice(fence.length).trim() === "";
 }
 
 export function sanitizeDocsConfigForEnglishOnly(value: unknown): unknown {
@@ -739,8 +760,7 @@ function auditDocsLinks(options: { docsDir?: string; allowExternalClawHubRoutes?
     const baseDir = normalizeSlashes(path.dirname(rel));
     const rawText = fs.readFileSync(abs, "utf8");
     const lines = rawText.split("\n");
-
-    let codeFence: FenceDelimiter | null = null;
+    const codeLines = collectCodeLines(rawText);
 
     for (let lineNum = 0; lineNum < lines.length; lineNum++) {
       let line = lines[lineNum];
@@ -748,20 +768,7 @@ function auditDocsLinks(options: { docsDir?: string; allowExternalClawHubRoutes?
         continue;
       }
 
-      const fence = parseFenceDelimiter(line);
-      if (fence) {
-        if (!codeFence) {
-          codeFence = fence;
-        } else if (
-          fence.marker === codeFence.marker &&
-          fence.length >= codeFence.length &&
-          isClosingFence(line, fence)
-        ) {
-          codeFence = null;
-        }
-        continue;
-      }
-      if (codeFence) {
+      if (codeLines.has(lineNum)) {
         continue;
       }
 

--- a/scripts/docs-link-audit.mts
+++ b/scripts/docs-link-audit.mts
@@ -51,7 +51,6 @@ type ScriptSpawn = (
 type RunDocsLinkAuditOptions = {
   args?: string[];
   comSpec?: string;
-  docsDir?: string;
   env?: NodeJS.ProcessEnv;
   nodeExecPath?: string;
   nodeVersion?: string;
@@ -109,6 +108,39 @@ function escapeHtmlAttribute(value: string) {
     .replaceAll('"', "&quot;")
     .replaceAll("<", "&lt;")
     .replaceAll(">", "&gt;");
+}
+
+function collectMarkdownCodeLines(tokens: MarkdownToken[]): Set<number> {
+  const lines = new Set<number>();
+  for (const token of tokens) {
+    if ((token.type === "fence" || token.type === "code_block") && token.map) {
+      for (let line = token.map[0]; line < token.map[1]; line++) {
+        lines.add(line);
+      }
+    }
+  }
+  return lines;
+}
+
+function collectCodeLines(raw: string): Set<number> {
+  try {
+    const lines = new Set<number>();
+    const visit = (node: Nodes): void => {
+      if (node.type === "code" && node.position) {
+        for (let line = node.position.start.line; line <= node.position.end.line; line++) {
+          lines.add(line - 1);
+        }
+      }
+      if ("children" in node) {
+        node.children.forEach(visit);
+      }
+    };
+    visit(MDX_PROCESSOR.parse(raw));
+    return lines;
+  } catch {
+    // Legacy malformed MDX still needs the same tolerant code ranges as external-link auditing.
+    return collectMarkdownCodeLines(MARKDOWN_PARSER.parse(raw, {}));
+  }
 }
 
 /**
@@ -183,14 +215,7 @@ function projectExternalLinkMarkdown(raw: string) {
     const inlineVerbatimLinks = new Map<string, number>();
     const transparentEnv: Record<string, unknown> = {};
     const transparentTokens = MARKDOWN_PARSER.parse(raw, transparentEnv);
-    const fallbackCodeLines = new Set<number>();
-    for (const token of transparentTokens) {
-      if ((token.type === "fence" || token.type === "code_block") && token.map) {
-        for (let line = token.map[0]; line < token.map[1]; line += 1) {
-          fallbackCodeLines.add(line);
-        }
-      }
-    }
+    const fallbackCodeLines = collectMarkdownCodeLines(transparentTokens);
     const childUrl = (child: MarkdownToken): string | undefined => {
       const value =
         child.type === "link_open"
@@ -487,46 +512,6 @@ function collectNavPageEntries(node: unknown): string[] {
 
 const markdownLinkRegex = /!?\[[^\]]*\]\(([^)]+)\)/g;
 
-/**
- * Derive code ranges from the MDX tree so container-relative fences keep their
- * indentation context. Fall back to tolerant Markdown token ranges for legacy
- * malformed pages that the MDX parser cannot read.
- */
-function collectCodeLines(rawText: string): Set<number> {
-  const codeLines = new Set<number>();
-  const addRange = (startLine: number, endLine: number) => {
-    for (let line = startLine; line <= endLine; line += 1) {
-      codeLines.add(line - 1);
-    }
-  };
-
-  try {
-    const tree = MDX_PROCESSOR.parse(rawText);
-    const visit = (node: Nodes): void => {
-      if (node.type === "code" && node.position) {
-        addRange(node.position.start.line, node.position.end.line);
-      }
-      if ("children" in node) {
-        for (const child of node.children) {
-          visit(child);
-        }
-      }
-    };
-    visit(tree);
-    return codeLines;
-  } catch {
-    const tokens = MARKDOWN_PARSER.parse(rawText, {});
-    for (const token of tokens) {
-      if ((token.type === "fence" || token.type === "code_block") && token.map) {
-        for (let line = token.map[0]; line < token.map[1]; line += 1) {
-          codeLines.add(line);
-        }
-      }
-    }
-    return codeLines;
-  }
-}
-
 export function sanitizeDocsConfigForEnglishOnly(value: unknown): unknown {
   if (Array.isArray(value)) {
     return value
@@ -760,6 +745,7 @@ function auditDocsLinks(options: { docsDir?: string; allowExternalClawHubRoutes?
     const baseDir = normalizeSlashes(path.dirname(rel));
     const rawText = fs.readFileSync(abs, "utf8");
     const lines = rawText.split("\n");
+
     const codeLines = collectCodeLines(rawText);
 
     for (let lineNum = 0; lineNum < lines.length; lineNum++) {
@@ -934,7 +920,7 @@ export function runDocsLinkAuditCli(options: RunDocsLinkAuditOptions = {}) {
     }
   }
 
-  const mirroredDocsDir = prepareMirroredDocsDir(options.docsDir ?? DOCS_DIR);
+  const mirroredDocsDir = prepareMirroredDocsDir(DOCS_DIR);
   try {
     const { checked, broken } = auditDocsLinks({
       docsDir: mirroredDocsDir.dir,

--- a/scripts/docs-link-audit.mts
+++ b/scripts/docs-link-audit.mts
@@ -486,6 +486,22 @@ function collectNavPageEntries(node: unknown): string[] {
 
 const markdownLinkRegex = /!?\[[^\]]*\]\(([^)]+)\)/g;
 
+type FenceDelimiter = { marker: "`" | "~"; length: number };
+
+export function parseFenceDelimiter(line: string): FenceDelimiter | null {
+  const trimmed = line.trimStart();
+  const match = /^(?<token>`{3,}|~{3,})/u.exec(trimmed);
+  const token = match?.groups?.token;
+  if (!token) {
+    return null;
+  }
+  const marker = token[0];
+  if (marker !== "`" && marker !== "~") {
+    return null;
+  }
+  return { marker, length: token.length };
+}
+
 export function sanitizeDocsConfigForEnglishOnly(value: unknown): unknown {
   if (Array.isArray(value)) {
     return value
@@ -720,7 +736,7 @@ function auditDocsLinks(options: { docsDir?: string; allowExternalClawHubRoutes?
     const rawText = fs.readFileSync(abs, "utf8");
     const lines = rawText.split("\n");
 
-    let inCodeFence = false;
+    let codeFence: FenceDelimiter | null = null;
 
     for (let lineNum = 0; lineNum < lines.length; lineNum++) {
       let line = lines[lineNum];
@@ -728,11 +744,16 @@ function auditDocsLinks(options: { docsDir?: string; allowExternalClawHubRoutes?
         continue;
       }
 
-      if (line.trim().startsWith("```")) {
-        inCodeFence = !inCodeFence;
+      const fence = parseFenceDelimiter(line);
+      if (fence) {
+        if (!codeFence) {
+          codeFence = fence;
+        } else if (fence.marker === codeFence.marker && fence.length >= codeFence.length) {
+          codeFence = null;
+        }
         continue;
       }
-      if (inCodeFence) {
+      if (codeFence) {
         continue;
       }
 

--- a/scripts/docs-link-audit.mts
+++ b/scripts/docs-link-audit.mts
@@ -51,6 +51,7 @@ type ScriptSpawn = (
 type RunDocsLinkAuditOptions = {
   args?: string[];
   comSpec?: string;
+  docsDir?: string;
   env?: NodeJS.ProcessEnv;
   nodeExecPath?: string;
   nodeVersion?: string;
@@ -927,7 +928,7 @@ export function runDocsLinkAuditCli(options: RunDocsLinkAuditOptions = {}) {
     }
   }
 
-  const mirroredDocsDir = prepareMirroredDocsDir(DOCS_DIR);
+  const mirroredDocsDir = prepareMirroredDocsDir(options.docsDir ?? DOCS_DIR);
   try {
     const { checked, broken } = auditDocsLinks({
       docsDir: mirroredDocsDir.dir,

--- a/src/scripts/docs-link-audit.test.ts
+++ b/src/scripts/docs-link-audit.test.ts
@@ -27,7 +27,7 @@ describe("docs-link-audit", () => {
     expect(normalizeRoute("/plugins/building-plugins?tab=all")).toBe("/plugins/building-plugins");
   });
 
-  it("ignores links inside tilde and nested fences in the real audit CLI", () => {
+  it("ignores fenced links but audits links after indented code", () => {
     const tempDirs: string[] = [];
     const fixtureRoot = makeTempDir(tempDirs, "docs-link-audit-fence-");
     const docsRoot = path.join(fixtureRoot, "docs");
@@ -35,7 +35,7 @@ describe("docs-link-audit", () => {
     fs.writeFileSync(path.join(docsRoot, "docs.json"), '{"navigation":[]}', "utf8");
     fs.writeFileSync(
       path.join(docsRoot, "page.md"),
-      "# Page\n\n~~~bash\n[not a real link](/not-a-published-route)\n~~~not-a-closer\n[still not a real link](/still-not-a-published-route)\n~~~\n\n````md\n```text\n[not another real link](/another-not-a-published-route)\n```\n````\n\n[page](/page)\n",
+      "# Page\n\n~~~bash\n[not a real link](/not-a-published-route)\n~~~not-a-closer\n[still not a real link](/still-not-a-published-route)\n~~~\n\n````md\n```text\n[not another real link](/another-not-a-published-route)\n```\n````\n\n    ~~~\n[after indented code](/must-be-reported)\n\n[page](/page)\n",
       "utf8",
     );
 
@@ -45,8 +45,9 @@ describe("docs-link-audit", () => {
         output.push(args.join(" "));
       });
       try {
-        expect(runDocsLinkAuditCli({ args: [], docsDir: docsRoot })).toBe(0);
-        expect(output).toContain("broken_links=0");
+        expect(runDocsLinkAuditCli({ args: [], docsDir: docsRoot })).toBe(1);
+        expect(output).toContain("broken_links=1");
+        expect(output.some((line) => line.includes("/must-be-reported"))).toBe(true);
       } finally {
         logSpy.mockRestore();
       }

--- a/src/scripts/docs-link-audit.test.ts
+++ b/src/scripts/docs-link-audit.test.ts
@@ -27,15 +27,15 @@ describe("docs-link-audit", () => {
     expect(normalizeRoute("/plugins/building-plugins?tab=all")).toBe("/plugins/building-plugins");
   });
 
-  it("ignores fenced links but audits links after indented code", () => {
+  it("ignores fences nested in MDX and lists but audits links after code", () => {
     const tempDirs: string[] = [];
     const fixtureRoot = makeTempDir(tempDirs, "docs-link-audit-fence-");
     const docsRoot = path.join(fixtureRoot, "docs");
     fs.mkdirSync(docsRoot, { recursive: true });
     fs.writeFileSync(path.join(docsRoot, "docs.json"), '{"navigation":[]}', "utf8");
     fs.writeFileSync(
-      path.join(docsRoot, "page.md"),
-      "# Page\n\n~~~bash\n[not a real link](/not-a-published-route)\n~~~not-a-closer\n[still not a real link](/still-not-a-published-route)\n~~~\n\n````md\n```text\n[not another real link](/another-not-a-published-route)\n```\n````\n\n    ~~~\n[after indented code](/must-be-reported)\n\n[page](/page)\n",
+      path.join(docsRoot, "page.mdx"),
+      "# Page\n\n<Accordion>\n    ~~~bash\n    [not a real link](/not-a-published-route)\n    ~~~not-a-closer\n    [still not a real link](/still-not-a-published-route)\n    ~~~\n</Accordion>\n\n- List example\n\n    ````md\n    ```text\n    [not another real link](/another-not-published-route)\n    ```\n    ````\n\n[after nested code](/must-be-reported)\n\n[page](/page)\n",
       "utf8",
     );
 

--- a/src/scripts/docs-link-audit.test.ts
+++ b/src/scripts/docs-link-audit.test.ts
@@ -46,7 +46,7 @@ describe("docs-link-audit", () => {
     fs.writeFileSync(path.join(docsRoot, "docs.json"), '{"navigation":[]}', "utf8");
     fs.writeFileSync(
       path.join(docsRoot, "page.md"),
-      "# Page\n\n~~~bash\n[not a real link](/not-a-published-route)\n~~~\n\n````md\n```text\n[not another real link](/another-not-a-published-route)\n```\n````\n\n[page](/page)\n",
+      "# Page\n\n~~~bash\n[not a real link](/not-a-published-route)\n~~~not-a-closer\n[still not a real link](/still-not-a-published-route)\n~~~\n\n````md\n```text\n[not another real link](/another-not-a-published-route)\n```\n````\n\n[page](/page)\n",
       "utf8",
     );
 

--- a/src/scripts/docs-link-audit.test.ts
+++ b/src/scripts/docs-link-audit.test.ts
@@ -1,4 +1,5 @@
 // Docs link audit tests cover documentation link validation behavior.
+import { execFileSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -7,6 +8,7 @@ import { cleanupTempDirs, makeTempDir } from "../../test/helpers/temp-dir.js";
 
 const {
   normalizeRoute,
+  parseFenceDelimiter,
   prepareAnchorAuditDocsDir,
   prepareExternalLinkAuditTree,
   prepareMirroredDocsDir,
@@ -14,6 +16,8 @@ const {
   runDocsLinkAuditCli,
   sanitizeDocsConfigForEnglishOnly,
 } = await import("../../scripts/docs-link-audit.mts");
+
+const repoRoot = path.resolve(import.meta.dirname, "../..");
 
 describe("docs-link-audit", () => {
   function tempEntries(prefix: string): Set<string> {
@@ -25,6 +29,40 @@ describe("docs-link-audit", () => {
       "/plugins/building-plugins",
     );
     expect(normalizeRoute("/plugins/building-plugins?tab=all")).toBe("/plugins/building-plugins");
+  });
+
+  it("parses backtick and tilde fences with their opening length", () => {
+    expect(parseFenceDelimiter("```ts")).toEqual({ marker: "`", length: 3 });
+    expect(parseFenceDelimiter("~~~~md")).toEqual({ marker: "~", length: 4 });
+    expect(parseFenceDelimiter("``short")).toBeNull();
+    expect(parseFenceDelimiter("[text](/route)")).toBeNull();
+  });
+
+  it("ignores links inside tilde and nested fences in the real audit CLI", () => {
+    const tempDirs: string[] = [];
+    const fixtureRoot = makeTempDir(tempDirs, "docs-link-audit-fence-");
+    const docsRoot = path.join(fixtureRoot, "docs");
+    fs.mkdirSync(docsRoot, { recursive: true });
+    fs.writeFileSync(path.join(docsRoot, "docs.json"), '{"navigation":[]}', "utf8");
+    fs.writeFileSync(
+      path.join(docsRoot, "page.md"),
+      "# Page\n\n~~~bash\n[not a real link](/not-a-published-route)\n~~~\n\n````md\n```text\n[not another real link](/another-not-a-published-route)\n```\n````\n\n[page](/page)\n",
+      "utf8",
+    );
+
+    try {
+      const output = execFileSync(
+        process.execPath,
+        [path.join(repoRoot, "scripts/docs-link-audit.mjs")],
+        {
+          cwd: fixtureRoot,
+          encoding: "utf8",
+        },
+      );
+      expect(output).toContain("broken_links=0");
+    } finally {
+      cleanupTempDirs(tempDirs);
+    }
   });
 
   it("prepares every external-link input without exposing code literals", () => {

--- a/src/scripts/docs-link-audit.test.ts
+++ b/src/scripts/docs-link-audit.test.ts
@@ -1,8 +1,10 @@
 // Docs link audit tests cover documentation link validation behavior.
+import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { describe, expect, it, vi } from "vitest";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
 import { cleanupTempDirs, makeTempDir } from "../../test/helpers/temp-dir.js";
 
 const {
@@ -20,40 +22,99 @@ describe("docs-link-audit", () => {
     return new Set(fs.readdirSync(os.tmpdir()).filter((entry) => entry.startsWith(prefix)));
   }
 
+  it.each([
+    {
+      name: "component and list fences",
+      source: [
+        "<Accordion>",
+        "    ~~~md",
+        "    [example](/hidden-tilde)",
+        "    ~~~not-a-closing-fence",
+        "    [example](/hidden-after-false-close)",
+        "    ~~~",
+        "</Accordion>",
+        "",
+        "- Example",
+        "",
+        "    ````md",
+        "    ```text",
+        "    [example](/hidden-nested)",
+        "    ```",
+        "    ````",
+        "",
+        "[real](/missing-page)",
+        "[valid](/page)",
+      ],
+      broken: 1,
+    },
+    {
+      name: "legacy malformed MDX",
+      source: [
+        "<!doctype html>",
+        "~~~md",
+        "[example](/hidden-fallback)",
+        "~~~",
+        "[real](/missing-page)",
+        "[valid](/page)",
+      ],
+      broken: 1,
+    },
+    {
+      name: "indented component prose",
+      source: ["<Accordion>", "    [real](/missing-page)", "</Accordion>", "[valid](/page)"],
+      broken: 1,
+    },
+    { name: "valid prose", source: ["[valid](/page)"], broken: 0 },
+  ])("audits real CLI links after $name", ({ source, broken }) => {
+    const tempDirs: string[] = [];
+    const fixtureRoot = makeTempDir(tempDirs, "docs-link-audit-cli-");
+    const docsRoot = path.join(fixtureRoot, "docs");
+    const clawHubRoot = path.join(fixtureRoot, "clawhub");
+    const home = path.join(fixtureRoot, "home");
+    fs.mkdirSync(docsRoot);
+    fs.mkdirSync(path.join(clawHubRoot, "docs"), { recursive: true });
+    fs.mkdirSync(home);
+    fs.writeFileSync(path.join(docsRoot, "docs.json"), JSON.stringify({ navigation: [] }));
+    fs.writeFileSync(path.join(docsRoot, "page.mdx"), `${source.join("\n")}\n`);
+
+    try {
+      const result = spawnSync(
+        process.execPath,
+        [fileURLToPath(new URL("../../scripts/docs-link-audit.mjs", import.meta.url))],
+        {
+          cwd: fixtureRoot,
+          encoding: "utf8",
+          env: {
+            PATH: process.env.PATH,
+            HOME: home,
+            USERPROFILE: home,
+            TSX_TSCONFIG_PATH: fileURLToPath(new URL("../../tsconfig.json", import.meta.url)),
+            OPENCLAW_DOCS_SYNC_CLAWHUB_REPO: clawHubRoot,
+          },
+          timeout: 30_000,
+        },
+      );
+      expect(result.error).toBeUndefined();
+      expect(result.stderr).toBe("");
+      expect(result.status).toBe(broken ? 1 : 0);
+      expect(result.stdout).toContain(`checked_internal_links=${broken + 1}\n`);
+      expect(result.stdout).toContain(`broken_links=${broken}\n`);
+      expect(result.stdout).not.toContain("/hidden-");
+      if (broken) {
+        expect(result.stdout).toContain(
+          `page.mdx:${source.findIndex((line) => line.includes("/missing-page")) + 1} :: /missing-page :: route/file not found`,
+        );
+      }
+    } finally {
+      cleanupTempDirs(tempDirs);
+    }
+  });
+
   it("normalizes route fragments away", () => {
     expect(normalizeRoute("/plugins/building-plugins#registering-agent-tools")).toBe(
       "/plugins/building-plugins",
     );
     expect(normalizeRoute("/plugins/building-plugins?tab=all")).toBe("/plugins/building-plugins");
-  });
-
-  it("ignores fences nested in MDX and lists but audits links after code", () => {
-    const tempDirs: string[] = [];
-    const fixtureRoot = makeTempDir(tempDirs, "docs-link-audit-fence-");
-    const docsRoot = path.join(fixtureRoot, "docs");
-    fs.mkdirSync(docsRoot, { recursive: true });
-    fs.writeFileSync(path.join(docsRoot, "docs.json"), '{"navigation":[]}', "utf8");
-    fs.writeFileSync(
-      path.join(docsRoot, "page.mdx"),
-      "# Page\n\n<Accordion>\n    ~~~bash\n    [not a real link](/not-a-published-route)\n    ~~~not-a-closer\n    [still not a real link](/still-not-a-published-route)\n    ~~~\n</Accordion>\n\n- List example\n\n    ````md\n    ```text\n    [not another real link](/another-not-published-route)\n    ```\n    ````\n\n[after nested code](/must-be-reported)\n\n[page](/page)\n",
-      "utf8",
-    );
-
-    try {
-      const output: string[] = [];
-      const logSpy = vi.spyOn(console, "log").mockImplementation((...args) => {
-        output.push(args.join(" "));
-      });
-      try {
-        expect(runDocsLinkAuditCli({ args: [], docsDir: docsRoot })).toBe(1);
-        expect(output).toContain("broken_links=1");
-        expect(output.some((line) => line.includes("/must-be-reported"))).toBe(true);
-      } finally {
-        logSpy.mockRestore();
-      }
-    } finally {
-      cleanupTempDirs(tempDirs);
-    }
   });
 
   it("prepares every external-link input without exposing code literals", () => {

--- a/src/scripts/docs-link-audit.test.ts
+++ b/src/scripts/docs-link-audit.test.ts
@@ -7,7 +7,6 @@ import { cleanupTempDirs, makeTempDir } from "../../test/helpers/temp-dir.js";
 
 const {
   normalizeRoute,
-  parseFenceDelimiter,
   prepareAnchorAuditDocsDir,
   prepareExternalLinkAuditTree,
   prepareMirroredDocsDir,
@@ -26,13 +25,6 @@ describe("docs-link-audit", () => {
       "/plugins/building-plugins",
     );
     expect(normalizeRoute("/plugins/building-plugins?tab=all")).toBe("/plugins/building-plugins");
-  });
-
-  it("parses backtick and tilde fences with their opening length", () => {
-    expect(parseFenceDelimiter("```ts")).toEqual({ marker: "`", length: 3 });
-    expect(parseFenceDelimiter("~~~~md")).toEqual({ marker: "~", length: 4 });
-    expect(parseFenceDelimiter("``short")).toBeNull();
-    expect(parseFenceDelimiter("[text](/route)")).toBeNull();
   });
 
   it("ignores links inside tilde and nested fences in the real audit CLI", () => {

--- a/src/scripts/docs-link-audit.test.ts
+++ b/src/scripts/docs-link-audit.test.ts
@@ -1,9 +1,8 @@
 // Docs link audit tests cover documentation link validation behavior.
-import { execFileSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { cleanupTempDirs, makeTempDir } from "../../test/helpers/temp-dir.js";
 
 const {
@@ -16,8 +15,6 @@ const {
   runDocsLinkAuditCli,
   sanitizeDocsConfigForEnglishOnly,
 } = await import("../../scripts/docs-link-audit.mts");
-
-const repoRoot = path.resolve(import.meta.dirname, "../..");
 
 describe("docs-link-audit", () => {
   function tempEntries(prefix: string): Set<string> {
@@ -51,15 +48,16 @@ describe("docs-link-audit", () => {
     );
 
     try {
-      const output = execFileSync(
-        process.execPath,
-        [path.join(repoRoot, "scripts/docs-link-audit.mjs")],
-        {
-          cwd: fixtureRoot,
-          encoding: "utf8",
-        },
-      );
-      expect(output).toContain("broken_links=0");
+      const output: string[] = [];
+      const logSpy = vi.spyOn(console, "log").mockImplementation((...args) => {
+        output.push(args.join(" "));
+      });
+      try {
+        expect(runDocsLinkAuditCli({ args: [], docsDir: docsRoot })).toBe(0);
+        expect(output).toContain("broken_links=0");
+      } finally {
+        logSpy.mockRestore();
+      }
     } finally {
       cleanupTempDirs(tempDirs);
     }


### PR DESCRIPTION
## What Problem This Solves

The docs link auditor reports links shown only inside code examples as broken. Its raw triple-backtick toggle does not understand tilde fences, nested fence lengths, or MDX component boundaries.

## Why This Change Was Made

Use the existing MDX parser to identify code ranges, with the same tolerant Markdown handling already used by external-link auditing for malformed legacy pages. Both paths share the Markdown code-range collector. The raw toggle is removed, and the regression uses the actual CLI without adding a test-only production option.

## User Impact

Documentation checks ignore example links while continuing to report broken prose links with the correct source line. This affects development tooling only and adds no dependency or configuration surface. Thanks @qingminglong for the original fix.

## Evidence

Trusted baseline `2f6d085fc3b6a7f9fbf27b4e614f7542689b680e` plus independently authored fixtures reproduced the failure through the actual `docs-link-audit.mjs` subprocess. With the authored repair, all 16 owner and sibling tests pass.

| CLI fixture | Before | After |
| --- | --- | --- |
| MDX component tilde fence and list-nested backticks | 5 checked, 4 broken | 2 checked, 1 genuine broken prose link |
| Malformed MDX with a tilde fence | 3 checked, 2 broken | 2 checked, 1 genuine broken prose link |
| Indented component prose | Correct broken prose link reported | Preserved |
| Valid prose | Exit 0 | Exit 0 |

The subprocesses use isolated temporary docs and home directories. Assertions verify exit status, exact counts, source line numbers, and exclusion of example links. Existing external-link parsing, malformed-MDX fallback, redirects, and cleanup tests remain green.

Focused command: `node scripts/run-vitest.mjs run --config test/vitest/vitest.tooling.config.ts src/scripts/docs-link-audit.test.ts --maxWorkers 1 --reporter=verbose`. The actual applicable `node scripts/check-changed.mjs -- scripts/docs-link-audit.mts src/scripts/docs-link-audit.test.ts` gates passed, including policy checks, formatting, typechecks, export scans and lint. Independent review of the complete native candidate completed clean at P0. Exact published-candidate CI remains required before landing.

Tooling delta: +36/-14 (net +22); tests: +90. The added range traversal replaces the incorrect scanner using existing dependencies, and sharing the fallback removes duplicated parsing policy.

## Review follow-through

Direct installed-dependency inspection resolves the latest review’s environment gap: `markdown-it` 15.0.0 `dist/markdown-it.mjs` fence parser records a half-open token line range after matching the marker and closing-fence length; `mdast-util-from-markdown` 2.0.3 records node start/end source positions, and the MDX extension retains child nodes inside components. The existing parser configuration therefore provides the ranges consumed by this repair. The real CLI tests and green CI validate the complete path.
