### PR TITLE
test(ui): verify streaming markdown scan reuse deterministically

### DIFF
--- a/ui/src/components/markdown.test.ts
+++ b/ui/src/components/markdown.test.ts
@@ -1,5 +1,6 @@
 // Control UI tests cover markdown behavior.
 import { describe, expect, it, vi } from "vitest";
+import * as markdownCore from "../../../packages/markdown-core/src/reasoning-tags.js";
 import { i18n } from "../i18n/index.ts";
 import { handleMarkdownCodeBlockClick } from "./markdown-code-blocks.ts";
 import { splitStableStreamingMarkdown } from "./markdown-streaming.ts";
@@ -865,35 +866,25 @@ PY
 });
 
 describe("toStreamingMarkdownHtml", () => {
-  it("keeps appended-prefix splitting below repeated full-rescan cost", () => {
-    const splitIncrementally = splitStableStreamingMarkdown as (
-      markdown: string,
-      streamKey: string,
-    ) => ReturnType<typeof splitStableStreamingMarkdown>;
+  it("reuses completed disclosure scans across appended prefixes", () => {
     const prefixes: string[] = [];
     let prefix = "<details><summary>Done</summary></details>\n\n";
-    // The ratio catches a reverted full-rescan path without making runner load
-    // part of the assertion by spending most of the test timeout on the baseline.
     for (let index = 0; index < 48; index += 1) {
       prefix += `${String(index).padStart(3, "0")} ${"streaming markdown ".repeat(30)}\n`;
       prefixes.push(prefix);
     }
-    const measure = (streamKey?: string) => {
-      const startedAt = performance.now();
+    const codeSpans = vi.spyOn(markdownCore, "findMarkdownCodeSpans");
+    try {
       for (const value of prefixes) {
-        if (streamKey) {
-          splitIncrementally(value, streamKey);
-        } else {
-          splitStableStreamingMarkdown(value);
-        }
+        splitStableStreamingMarkdown(value, "line-scan-regression");
       }
-      return performance.now() - startedAt;
-    };
-    measure("line-scan-warmup");
-    const fullRescanMs = measure();
-    const incrementalMs = measure("line-scan-regression");
-
-    expect(incrementalMs).toBeLessThan(fullRescanMs / 5);
+      // Appended plain lines must reuse the completed disclosure's code-ownership
+      // scan. Count that real work instead of timing sub-millisecond samples.
+      expect(codeSpans.mock.calls.length).toBe(1);
+      expect(codeSpans.mock.calls[0]?.[0]).toBe(prefixes[0]);
+    } finally {
+      codeSpans.mockRestore();
+    }
   }, 5_000);
 
   it("keeps chunked-prefix splits identical to full splits", () => {


### PR DESCRIPTION
## Problem

An unchanged streaming Markdown renderer failed the release-repair PR's UI shard because one incremental timing sample took 0.284526 ms against a 0.246251 ms threshold. The test compared one full scan with one incremental pass and assumed a stable fivefold speed difference. Its result depended on scheduling and JIT state rather than solely on retained scanning work.

## Change

Replace that timing assertion with a pass-through spy on the existing Markdown code-ownership scanner. The original 48-prefix fixture and five-second timeout remain: the completed disclosure must be scanned once, then reused as plain lines append. The neighboring tests still compare incremental splits and rendered HTML with full-render output, cover replacement/interleaved streams, and check truncation and disclosure semantics.

No production code, scanner API, cache policy, configuration, retries, or timeout changes. This proves retained code-ownership scan reuse; it does not claim a universal runtime speed ratio.

## Verification

- Original failure: [CI 33262482199, UI job 99126799378](https://github.com/openclaw/openclaw/actions/runs/33262482199/job/99126799378), exact source `ce71061e77e`.
- Reproduced the original timing instability with unchanged source: 2 failures in 50 measured trials. A proposed fixed paired/batched benchmark also failed after further JIT warmup and was rejected.
- Negative control: temporarily disabled the existing cached cursor, restoring a full rescan. The replacement test failed because the real code-ownership function ran 48 times instead of once. Restored the production file to its exact Git bytes afterward.
- All 153 tests across Markdown rendering, details, and streaming highlighting passed, including the existing output parity cases.
- Full required changed-file gate passed, including core test types, dependency/architecture guards, dead-code checks, formatting, and lint. After a diagnostic-only assertion split, all 153 sibling tests, formatting, and typed lint passed again. The full-rescan negative control still failed with 48 calls instead of one, now with bounded assertion output.
- Fresh frozen dependency install; no shared checkout or dependency mutations. Final managed Codex autoreview found no actionable findings (P0 scope).

The nearby `HTMLDetailsElement` log is a separate named follow-up: jsdom 29.1.1 schedules native disclosure toggle events outside its window timer registry, and a detached config-view fixture can leave one pending during window teardown. A real jsdom reproduction confirms the post-close event; this PR does not mask it with a production global guard.

Production LOC: +0/-0. Tests: +12/-21 (net -9). Test-only repair; no changelog required.
