### PR TITLE
fix: plugin conversation bindings fail for opaque targets

### DIFF
--- a/apps/macos/Tests/OpenClawIPCTests/PortGuardianRecordStoreTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/PortGuardianRecordStoreTests.swift
@@ -568,7 +568,7 @@ struct PortGuardianRecordStoreTests {
         let fixture = try Self.fixture()
         defer { fixture.cleanup() }
 
-        for version in [4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14] {
+        for version in [4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15] {
             let databaseURL = fixture.root.appendingPathComponent("supported-v\(version).sqlite")
             try Self.seedVersionedPortGuardianDatabase(databaseURL, schemaVersion: version)
             let store = try PortGuardianRecordStore(databaseURL: databaseURL)
@@ -580,7 +580,7 @@ struct PortGuardianRecordStoreTests {
             #expect(try store.records() == [record])
         }
 
-        for version in [15, 99] {
+        for version in [16, 99] {
             let databaseURL = fixture.root.appendingPathComponent("newer-v\(version).sqlite")
             try Self.seedVersionedPortGuardianDatabase(databaseURL, schemaVersion: version)
             #expect(throws: PortGuardianStoreError.self) {

--- a/apps/shared/OpenClawKit/Sources/OpenClawNativeState/OpenClawNativeStateSQLite.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawNativeState/OpenClawNativeStateSQLite.swift
@@ -37,7 +37,7 @@ public enum OpenClawNativeStateSQLiteValueType: Equatable, Sendable {
 /// One recursive connection lock serializes transactions and statement access.
 public final class OpenClawNativeStateSQLite: @unchecked Sendable {
     // Keep aligned with OPENCLAW_STATE_SCHEMA_VERSION. Native clients never upgrade this database.
-    private static let maximumSupportedSchemaVersion: Int64 = 14
+    private static let maximumSupportedSchemaVersion: Int64 = 15
     private static let defaultBusyTimeoutMilliseconds: Int32 = 5000
 
     private struct SchemaObject: Hashable {

--- a/docs/refactor/database-first.md
+++ b/docs/refactor/database-first.md
@@ -413,14 +413,14 @@ The branch already has a real shared SQLite base:
   discards the file without importing it. Because a file cannot prove whether
   its entries are live or stale after SQLite rows have been pruned, operators
   must let file-era active runs settle before upgrading across this boundary.
-- Current conversation bindings now live in typed shared
-  `current_conversation_bindings` rows keyed by normalized conversation id, with
-  target agent/session columns, conversation kind, status, expiry, and metadata
-  stored as relational columns instead of a duplicated opaque binding record.
-  The durable binding key includes the normalized conversation kind so
-  direct/group/channel refs cannot collide, and SQLite rejects invalid binding
-  kind/status values. The old
-  `bindings/current-conversations.json` file is doctor migration input only.
+- Current conversation bindings live in shared `current_conversation_bindings`
+  rows keyed by normalized channel, account, parent conversation, and conversation
+  id. `record_json` retains the complete binding; relational columns support
+  exact-target and conversation lookup and expiry. Shared-state schema 15 removes
+  the redundant agent/session projections: target keys already identify agent
+  sessions or plugin-owned destinations, and several conversations may share one
+  target. Plugin ownership and approval remain separate from target-key syntax.
+  The old `bindings/current-conversations.json` file is doctor migration input only.
 - Delivery queue recovery now overlays typed queue columns for channel, target,
   account, session, retry, error, platform-send, and recovery state onto the
   replay JSON. `entry_json` keeps the replay payloads, hooks, and formatting
@@ -1504,7 +1504,7 @@ task_runs(...)
 task_delivery_state(...)
 flow_runs(...)
 subagent_runs(run_id, child_session_key, controller_session_key, requester_session_key, created_at, payload_json)
-current_conversation_bindings(binding_key, binding_id, target_agent_id, target_session_id, target_session_key, channel, account_id, conversation_kind, parent_conversation_id, conversation_id, target_kind, status, bound_at, expires_at, metadata_json, updated_at)
+current_conversation_bindings(binding_key, binding_id, target_session_key, channel, account_id, conversation_kind, parent_conversation_id, conversation_id, target_kind, status, bound_at, expires_at, metadata_json, record_json, updated_at)
 plugin_binding_approvals(plugin_root, channel, account_id, plugin_id, plugin_name, approved_at)
 plugin_state_entries(plugin_id, namespace, entry_key, value_json, created_at, expires_at)
 plugin_blob_entries(plugin_id, namespace, entry_key, metadata_json, blob, created_at, expires_at)

--- a/docs/reference/database-schemas.md
+++ b/docs/reference/database-schemas.md
@@ -187,6 +187,15 @@ Normal admission remains bounded at 32 identities. Same-store alias repair sums 
 | 12      | Thirteen singleton/cache tables retired; durable state folded into config_machine_state                                                                                                                                                                                                                                         | Unreleased          |
 | 13      | State consolidation: cron jobs and subagent runs become JSON-canonical (113 projection columns, five unused indexes removed); installed_plugin_index and shared auth-profile singletons fold into config_machine_state; workspace_attestations merges into workspace_setup_state; gateway origin device tokens become canonical | Unreleased          |
 | 14      | Source-qualified cron creator capture; historical human job creators remain unknown                                                                                                                                                                                                                                             | Unreleased          |
+| 15      | Conversation bindings use exact target keys; redundant agent/session projections removed                                                                                                                                                                                                                                        | Unreleased          |
+
+### State schema 15
+
+Schema 15 removes `target_agent_id` and `target_session_id` from `current_conversation_bindings`. The target index uses the complete `target_session_key` and remains non-unique: several conversations may point at the same destination. This lets plugin-owned targets persist without inventing an OpenClaw agent owner. Channel/account isolation, plugin approvals, binding identifiers, target keys, JSON metadata, expiry, and detach behavior are unchanged.
+
+Startup and `openclaw doctor --fix` run the migration in the existing exclusive write transaction. They remove only the two projections and replace the target index, preserving all other row values. A dependent trigger, index, or failed schema check rolls the transaction back; migration does not discard an unknown dependency to force the upgrade. Column removal rewrites the binding table, so upgrade cost scales with its size.
+
+Stop older writers and create a verified, WAL-aware backup before upgrading. Builds supporting shared-state schema 14 or earlier refuse the migrated database. To return to an older build, restore that pre-upgrade backup into a separate state directory; do not lower the version markers or reconstruct an agent projection. See [downgrade limitations](#downgrades-are-unsupported) for the general recovery contract.
 
 ### State schema 13
 

--- a/extensions/voice-call/doctor-contract-api.ts
+++ b/extensions/voice-call/doctor-contract-api.ts
@@ -154,6 +154,8 @@ function describeVoiceCallSchemaMigration(migration: OpenClawStateDatabaseSchema
       return "cron jobs and subagent runs -> canonical JSON storage";
     case "creator-namespace-v14":
       return "cron creators -> explicit principal namespaces";
+    case "conversation-binding-targets-v15":
+      return "conversation bindings -> exact target keys without agent/session projections";
     case "worker-placement-execution-mode-v8":
       return "cloud worker placements -> execution-mode claims";
     case "operator-approvals-system-agent":
@@ -165,8 +167,6 @@ function describeVoiceCallSchemaMigration(migration: OpenClawStateDatabaseSchema
   }
   return migration.kind satisfies never;
 }
-
-/** Return true when a path exists and is a file. */
 
 /** Build the plugin state key for one migrated event chunk. */
 function buildChunkKey(eventKey: string, index: number): string {
@@ -245,8 +245,6 @@ async function readLegacyCallRecords(filePath: string): Promise<{
   }
   return { entries, warnings };
 }
-
-/** Archive the legacy JSONL source after a complete migration. */
 
 /** Select newest missing records that fit remaining plugin state capacity. */
 async function selectEntriesForImport(params: {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "2026.8.1",
   "openclaw": {
     "schemaVersions": {
-      "state": 14,
+      "state": 15,
       "agent": 19
     }
   },

--- a/src/audit/message-delivery-progress-store.test.ts
+++ b/src/audit/message-delivery-progress-store.test.ts
@@ -3,6 +3,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { openNodeSqliteDatabase } from "../infra/node-sqlite.js";
 import { OPENCLAW_STATE_SCHEMA_VERSION } from "../state/openclaw-state-db-contract.js";
 import { tableExists } from "../state/openclaw-state-db-schema-helpers.js";
 import {
@@ -275,11 +276,44 @@ describe("outbound message progress companion", () => {
     expect(
       tableExists(openOpenClawStateDatabase(database).db, "outbound_message_execution_bindings"),
     ).toBe(true);
+    const repositoryRoot = process.cwd();
+    ensurePinnedReaderCommit(repositoryRoot);
+    const projectedDatabase = openOpenClawStateDatabase(database).db;
+    // Only audit rows belong to this proof. Restore the empty binding table from
+    // the immutable reader's schema without inventing a production downgrade.
+    expect(
+      projectedDatabase
+        .prepare("SELECT COUNT(*) AS count FROM current_conversation_bindings")
+        .get(),
+    ).toEqual({ count: 0 });
+    const pinnedSchemaDatabase = openNodeSqliteDatabase(":memory:");
+    try {
+      pinnedSchemaDatabase.exec(
+        execFileSync(
+          "git",
+          ["show", `${PINNED_PRE_C04_READER_SHA}:src/state/openclaw-state-schema.sql`],
+          { cwd: repositoryRoot, encoding: "utf8" },
+        ),
+      );
+      const bindingStatements = pinnedSchemaDatabase
+        .prepare(
+          `SELECT sql FROM sqlite_schema
+           WHERE tbl_name = 'current_conversation_bindings'
+             AND type IN ('table', 'index') AND sql IS NOT NULL
+           ORDER BY type = 'table' DESC, name`,
+        )
+        .all() as Array<{ sql: string }>;
+      projectedDatabase.exec("DROP TABLE current_conversation_bindings;");
+      for (const { sql } of bindingStatements) {
+        projectedDatabase.exec(sql);
+      }
+    } finally {
+      pinnedSchemaDatabase.close();
+    }
     // This pinned reader predates the Workshop's first-use column and requires present lazy tables
     // to retain its exact shape; project that unrelated table to the reader's historical contract.
     // The v9-era reader needs the v13 projection removal, v12 singleton fold-in,
     // v11 curator retirement, and v10 dead-table retirement reversed in order.
-    const projectedDatabase = openOpenClawStateDatabase(database).db;
     projectedDatabase.exec("ALTER TABLE skill_workshop_proposals DROP COLUMN claim_released_time;");
     projectedDatabase.exec(STATE_SCHEMA_13_TO_12_DOWNGRADE_SQL);
     projectedDatabase.exec(STATE_SCHEMA_12_TO_11_DOWNGRADE_SQL);
@@ -287,8 +321,6 @@ describe("outbound message progress companion", () => {
     projectedDatabase.exec(STATE_SCHEMA_10_TO_9_DOWNGRADE_SQL);
     closeOpenClawStateDatabaseForTest();
 
-    const repositoryRoot = process.cwd();
-    ensurePinnedReaderCommit(repositoryRoot);
     const checkoutParent = tempDirs.make("message-progress-pinned-reader-");
     const pinnedCheckout = path.join(checkoutParent, "checkout");
     execFileSync(

--- a/src/auto-reply/reply/commands-context.ts
+++ b/src/auto-reply/reply/commands-context.ts
@@ -11,6 +11,11 @@ import type { MsgContext } from "../templating.js";
 import type { CommandContext } from "./commands-types.js";
 import { stripMentions } from "./mentions.js";
 
+/** Selection and execution must bind to the same channel, including origin-routed turns. */
+export function resolveCommandChannel(ctx: MsgContext): string {
+  return normalizeLowercaseStringOrEmpty(ctx.OriginatingChannel ?? ctx.Provider ?? ctx.Surface);
+}
+
 /** Builds command routing/auth metadata consumed by command handlers. */
 export function buildCommandContext(params: {
   ctx: MsgContext;
@@ -28,9 +33,7 @@ export function buildCommandContext(params: {
     commandAuthorized: params.commandAuthorized,
   });
   const surface = normalizeLowercaseStringOrEmpty(ctx.Surface ?? ctx.Provider);
-  const channel = normalizeLowercaseStringOrEmpty(
-    ctx.OriginatingChannel ?? ctx.Provider ?? surface,
-  );
+  const channel = resolveCommandChannel(ctx);
   const from = auth.from ?? normalizeOptionalString(ctx.SenderId);
   const to = auth.to ?? normalizeOptionalString(ctx.OriginatingTo);
   const abortKey = sessionKey ?? from ?? to;

--- a/src/auto-reply/reply/commands-plugin.test.ts
+++ b/src/auto-reply/reply/commands-plugin.test.ts
@@ -23,6 +23,7 @@ import { resetPluginRuntimeStateForTest, setActivePluginRegistry } from "../../p
 import type { PluginCommandContext, PluginCommandResult } from "../../plugins/types.js";
 import { resolveIncognitoOpenClawAgentSqlitePath } from "../../state/openclaw-agent-db.js";
 import { withEnvAsync } from "../../test-utils/env.js";
+import { buildCommandContext } from "./commands-context.js";
 import { handlePluginCommand } from "./commands-plugin.js";
 import type { HandleCommandsParams } from "./commands-types.js";
 import { shouldBypassPluginOwnedBindingForCommand } from "./dispatch-from-config.plugin-binding.js";
@@ -690,6 +691,67 @@ describe("handlePluginCommand", () => {
       reply: { text: "approved" },
     });
     expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([
+    {
+      name: "Gateway command routed to its originating channel",
+      Provider: "webchat",
+      Surface: "webchat",
+      OriginatingChannel: "whatsapp",
+    },
+    {
+      name: "provider taking precedence over a different surface",
+      Provider: "whatsapp",
+      Surface: "webchat",
+      OriginatingChannel: undefined,
+    },
+  ])("keeps binding selection and execution aligned for $name", async (route) => {
+    const handler = registerTestCommand();
+    const cfg = {
+      commands: { text: true },
+      channels: { whatsapp: { allowFrom: ["*"] } },
+    } as OpenClawConfig;
+    const commandBody = "/card";
+    const ctx = finalizeInboundContext({
+      Provider: route.Provider,
+      Surface: route.Surface,
+      OriginatingChannel: route.OriginatingChannel,
+      Body: commandBody,
+      CommandBody: commandBody,
+      CommandSource: "text",
+      CommandAuthorized: true,
+      SenderId: "test-user",
+      From: "test-user",
+      To: "test-bot",
+    });
+    const replyOptions: NonNullable<HandleCommandsParams["opts"]> &
+      PluginCommandExecutionReplyOptions = {};
+
+    expect(shouldBypassPluginOwnedBindingForCommand(ctx, cfg, replyOptions)).toBe(true);
+    expect(replyOptions[PLUGIN_COMMAND_DISPATCH]?.kind).toBe("plugin");
+    const params = buildPluginParams(commandBody, cfg);
+    params.ctx = ctx;
+    params.opts = replyOptions;
+    params.command = buildCommandContext({
+      ctx,
+      cfg,
+      sessionKey: params.sessionKey,
+      isGroup: false,
+      triggerBodyNormalized: commandBody,
+      commandAuthorized: true,
+    });
+
+    await expect(handlePluginCommand(params, true)).resolves.toEqual({
+      shouldContinue: false,
+      reply: { text: "from plugin" },
+    });
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(firstCommandContext(handler)).toMatchObject({
+      channel: "whatsapp",
+      commandBody,
+      sessionKey: params.sessionKey,
+    });
   });
 
   it("carries one binding selection into dispatch without rematching a replacement registry", async () => {

--- a/src/auto-reply/reply/dispatch-from-config.plugin-binding.ts
+++ b/src/auto-reply/reply/dispatch-from-config.plugin-binding.ts
@@ -15,6 +15,7 @@ import {
 } from "../commands-registry.js";
 import { shouldHandleTextCommands } from "../commands-text-routing.js";
 import type { FinalizedRuntimeMsgContext } from "../templating.js";
+import { resolveCommandChannel } from "./commands-context.js";
 import { resolveCommandContextText } from "./context-text.js";
 import { isExplicitSourceReplyCommand } from "./source-reply-delivery-mode.js";
 
@@ -63,7 +64,7 @@ export function shouldBypassPluginOwnedBindingForCommand(
   if (planned) {
     return true;
   }
-  const channel = normalizeOptionalString(ctx.Surface ?? ctx.Provider) ?? "";
+  const channel = resolveCommandChannel(ctx);
   const match = matchPluginCommandInvocation(createPluginCommandRuntime(), commandBody, {
     channel,
   });

--- a/src/auto-reply/reply/session.test.ts
+++ b/src/auto-reply/reply/session.test.ts
@@ -2606,6 +2606,78 @@ describe("initSessionState RawBody", () => {
     expect(result.sessionKey).toBe(boundSessionKey);
   });
 
+  it.each([
+    { name: "opaque plugin target", targetSessionKey: "plugin-binding:fixture-runtime:thread-17" },
+    { name: "adopted agent target", targetSessionKey: "agent:main:external-runtime:thread-17" },
+  ])("keeps escaped commands on the core session for $name", async ({ targetSessionKey }) => {
+    setMinimalCurrentConversationBindingRegistryForTests();
+    registerCurrentConversationBindingAdapterForTest({ channel: "slack", accountId: "default" });
+    const storePath = await createStorePath("openclaw-plugin-command-session-");
+    const sourceSessionKey = "agent:main:slack:source";
+    const sourceSessionId = "source-command-session";
+    const conversation = {
+      channel: "slack",
+      accountId: "default",
+      conversationId: "user:U123",
+    };
+    await writeSessionStoreFast(storePath, {
+      [sourceSessionKey]: { sessionId: sourceSessionId, updatedAt: Date.now() },
+    });
+    if (targetSessionKey.startsWith("agent:")) {
+      await writeSessionStoreFast(storePath, {
+        [targetSessionKey]: {
+          sessionId: "plugin-owned-session",
+          updatedAt: Date.now(),
+          label: "Plugin-owned state must remain untouched",
+        },
+      });
+    }
+    const targetBefore = { ...readSessionStoreFast(storePath) }[targetSessionKey];
+    const binding = await getSessionBindingService().bind({
+      targetSessionKey,
+      targetKind: "session",
+      conversation,
+      metadata: {
+        pluginBindingOwner: "plugin",
+        pluginId: "fixture-runtime",
+        pluginRoot: "/plugins/fixture-runtime",
+      },
+    });
+    const ctx = {
+      Body: "/fixture status",
+      RawBody: "/fixture status",
+      CommandBody: "/fixture status",
+      CommandSource: "text",
+      CommandAuthorized: true,
+      SessionKey: sourceSessionKey,
+      Provider: "slack",
+      Surface: "slack",
+      AccountId: "default",
+      From: "slack:user:U123",
+      To: "user:U123",
+      OriginatingTo: "user:U123",
+      SenderId: "U123",
+      ChatType: "direct",
+    };
+    const cfg = { session: { store: storePath } } as OpenClawConfig;
+
+    const result = await initSessionState({
+      ctx,
+      cfg,
+      expectedExistingSessionId: sourceSessionId,
+      pinExpectedExistingSession: true,
+    });
+
+    expect(result.sessionKey).toBe(sourceSessionKey);
+    expect(result.sessionId).toBe(sourceSessionId);
+    expect(result.sessionCtx.SessionKey).toBe(sourceSessionKey);
+    expect(
+      resolveReplySessionPreprocessingState({ cfg, ctx: finalizeInboundContext(ctx) }),
+    ).toMatchObject({ sessionKey: sourceSessionKey, sessionEntry: { sessionId: sourceSessionId } });
+    expect({ ...readSessionStoreFast(storePath) }[targetSessionKey]).toEqual(targetBefore);
+    expect(getSessionBindingService().resolveByConversation(conversation)).toEqual(binding);
+  });
+
   it("does not apply a source admission id to a bound conversation target", async () => {
     setMinimalCurrentConversationBindingRegistryForTests();
     registerCurrentConversationBindingAdapterForTest({

--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -63,6 +63,7 @@ import { isDiagnosticFlagEnabled } from "../../infra/diagnostic-flags.js";
 import { getSessionBindingService } from "../../infra/outbound/session-binding-service.js";
 import { deliverSessionMaintenanceWarning } from "../../infra/session-maintenance-warning.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
+import { isPluginOwnedSessionBindingRecord } from "../../plugins/conversation-binding.js";
 import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
 import type { PluginHookSessionEndReason } from "../../plugins/hook-types.js";
 import { runWithGatewayIndependentRootWorkContinuation } from "../../process/gateway-work-admission.js";
@@ -286,7 +287,8 @@ function resolveBoundConversationSessionKey(params: {
   if (params.touch !== false) {
     getSessionBindingService().touch(binding.bindingId);
   }
-  return binding.targetSessionKey;
+  // Plugins own their target handoff; escaped commands still initialize the core session.
+  return isPluginOwnedSessionBindingRecord(binding) ? undefined : binding.targetSessionKey;
 }
 
 function resolveInitSessionStateAttemptContext(

--- a/src/gateway/gateway-codex-bind.live.test.ts
+++ b/src/gateway/gateway-codex-bind.live.test.ts
@@ -20,7 +20,6 @@ import { seedPluginConversationBindingApprovalForTest } from "../plugins/convers
 import { clearPluginLoaderCache } from "../plugins/loader.test-fixtures.js";
 import { resetPluginRuntimeStateForTest } from "../plugins/runtime.js";
 import { clearSecretsRuntimeSnapshot } from "../secrets/runtime.js";
-import { extractFirstTextBlock } from "../shared/chat-message-content.js";
 import { activateTestChannelRegistry, createTestRegistry } from "../test-utils/channel-plugins.js";
 import { deleteTestEnvValue, setTestEnvValue } from "../test-utils/env.js";
 import { sleep } from "../utils.js";
@@ -117,23 +116,6 @@ function createSlackCurrentConversationBindingRegistry(outboundReplies: Captured
   ]);
 }
 
-function extractAssistantTexts(messages: unknown[]): string[] {
-  const texts: string[] = [];
-  for (const entry of messages) {
-    if (!entry || typeof entry !== "object") {
-      continue;
-    }
-    if ((entry as { role?: unknown }).role !== "assistant") {
-      continue;
-    }
-    const text = extractFirstTextBlock(entry);
-    if (typeof text === "string" && text.trim().length > 0) {
-      texts.push(text);
-    }
-  }
-  return texts;
-}
-
 function formatAssistantTextPreview(texts: string[], maxChars = 800): string {
   const combined = texts.join("\n\n").trim();
   if (!combined) {
@@ -145,6 +127,7 @@ function formatAssistantTextPreview(texts: string[], maxChars = 800): string {
 async function waitForOutboundText(params: {
   replies: CapturedOutboundReply[];
   contains: string;
+  caseInsensitive?: boolean;
   minReplyCount?: number;
   timeoutMs?: number;
 }): Promise<{ outboundTexts: string[]; matchedText: string }> {
@@ -159,9 +142,10 @@ async function waitForOutboundText(params: {
       }
     }
     const minReplyCount = params.minReplyCount ?? 1;
+    const expected = params.caseInsensitive ? params.contains.toLowerCase() : params.contains;
     const matchedText = outboundTexts
       .slice(Math.max(0, minReplyCount - 1))
-      .find((text) => text.includes(params.contains));
+      .find((text) => (params.caseInsensitive ? text.toLowerCase() : text).includes(expected));
     if (outboundTexts.length >= minReplyCount && matchedText) {
       return { outboundTexts, matchedText };
     }
@@ -230,46 +214,6 @@ async function sendChatAndWait(params: {
   logCodexBindStep(`${params.context} started (${started.runId})`);
   await waitForAgentRunOk(params.client, started.runId, params.context);
   logCodexBindStep(`${params.context} completed`);
-}
-
-async function waitForAssistantText(params: {
-  client: GatewayClient;
-  sessionKey: string;
-  contains: string;
-  caseInsensitive?: boolean;
-  minAssistantCount?: number;
-  timeoutMs?: number;
-}): Promise<{ messages: unknown[]; assistantTexts: string[]; matchedAssistantText: string }> {
-  const timeoutMs = params.timeoutMs ?? 60_000;
-  const startedAt = Date.now();
-
-  while (Date.now() - startedAt < timeoutMs) {
-    const history: { messages?: unknown[] } = await params.client.request("chat.history", {
-      sessionKey: params.sessionKey,
-      limit: 24,
-    });
-    const messages = history.messages ?? [];
-    const assistantTexts = extractAssistantTexts(messages);
-    const minAssistantCount = params.minAssistantCount ?? 1;
-    const expected = params.caseInsensitive ? params.contains.toLowerCase() : params.contains;
-    const matchedAssistantText = assistantTexts
-      .slice(Math.max(0, minAssistantCount - 1))
-      .find((text) => (params.caseInsensitive ? text.toLowerCase() : text).includes(expected));
-    if (assistantTexts.length >= minAssistantCount && matchedAssistantText) {
-      return { messages, assistantTexts, matchedAssistantText };
-    }
-    await sleep(500);
-  }
-
-  const finalHistory: { messages?: unknown[] } = await params.client.request("chat.history", {
-    sessionKey: params.sessionKey,
-    limit: 24,
-  });
-  throw new Error(
-    `timed out waiting for assistant text containing ${params.contains}: ${formatAssistantTextPreview(
-      extractAssistantTexts(finalHistory.messages ?? []),
-    )}`,
-  );
 }
 
 function resolveCodexPluginRoot(): string {
@@ -524,6 +468,7 @@ describeLive("gateway live (native Codex conversation binding)", () => {
           accountId,
           conversationId,
         });
+        expect(boundSessionKey).toMatch(/^plugin-binding:codex:/);
         logCodexBindStep(`binding resolved to ${boundSessionKey}`);
 
         const initialNonce = randomBytes(4).toString("hex").toUpperCase();
@@ -591,14 +536,14 @@ describeLive("gateway live (native Codex conversation binding)", () => {
         await sendCodexCommand("/codex fast on", "Codex fast mode enabled.");
         await sendCodexCommand("/codex fast status", "Codex fast mode: on.");
         await sendCodexCommand("/codex permissions default", "Codex permissions set to default.");
-        await sendCodexCommand("/codex permissions status", "Codex permissions: default.");
+        await sendCodexCommand("/codex permissions status", "Codex permissions: guarded.");
         await sendCodexCommand("/codex model", `Codex model: ${bindModel}`);
         await sendCodexCommand("/codex stop", "No active Codex run to stop.");
 
         const bindingStatus = await sendCodexCommand("/codex binding", "- Fast: on");
-        if (!bindingStatus.matchedText.includes("- Permissions: default")) {
+        if (!bindingStatus.matchedText.includes("- Permissions: guarded")) {
           throw new Error(
-            `binding status did not include default permissions: ${bindingStatus.matchedText}`,
+            `binding status did not include guarded permissions: ${bindingStatus.matchedText}`,
           );
         }
 
@@ -613,14 +558,16 @@ describeLive("gateway live (native Codex conversation binding)", () => {
           originatingChannel: "slack",
           originatingTo: conversationId,
           originatingAccountId: accountId,
+          deliver: true,
         });
-        const textHistory = await waitForAssistantText({
-          client: activeClient,
-          sessionKey: boundSessionKey,
+        // Opaque binding targets have no agent transcript; verify the channel's delivered reply.
+        const controlledTextReply = await waitForOutboundText({
+          replies: outboundReplies,
           contains: textToken,
+          minReplyCount: commandReplyCount + 1,
           timeoutMs: CODEX_BIND_REQUEST_TIMEOUT_MS,
         });
-        expect(textHistory.matchedAssistantText).toContain(textToken);
+        expect(controlledTextReply.matchedText).toContain(textToken);
 
         await sendChatAndWait({
           client: activeClient,
@@ -632,6 +579,7 @@ describeLive("gateway live (native Codex conversation binding)", () => {
           originatingChannel: "slack",
           originatingTo: conversationId,
           originatingAccountId: accountId,
+          deliver: true,
           attachments: [
             {
               mimeType: "image/png",
@@ -640,15 +588,15 @@ describeLive("gateway live (native Codex conversation binding)", () => {
             },
           ],
         });
-        const imageHistory = await waitForAssistantText({
-          client: activeClient,
-          sessionKey: boundSessionKey,
+        const imageReply = await waitForOutboundText({
+          replies: outboundReplies,
           contains: "cat",
           caseInsensitive: true,
-          minAssistantCount: textHistory.assistantTexts.length + 1,
+          minReplyCount: controlledTextReply.outboundTexts.length + 1,
           timeoutMs: CODEX_BIND_REQUEST_TIMEOUT_MS,
         });
-        expect(imageHistory.matchedAssistantText.toLowerCase()).toContain("cat");
+        expect(imageReply.matchedText.toLowerCase()).toContain("cat");
+        commandReplyCount = imageReply.outboundTexts.length;
 
         await sendCodexCommand("/codex detach", "Detached this conversation from Codex.");
         await sendCodexCommand("/codex binding", "No Codex conversation binding is attached.");

--- a/src/infra/outbound/current-conversation-bindings.test.ts
+++ b/src/infra/outbound/current-conversation-bindings.test.ts
@@ -71,8 +71,6 @@ function seedPersistedBinding(record: SessionBindingRecord): void {
       bindingDb.insertInto("current_conversation_bindings").values({
         binding_key: buildConversationKey(record.conversation),
         binding_id: record.bindingId,
-        target_agent_id: "codex",
-        target_session_id: null,
         target_session_key: record.targetSessionKey,
         channel: record.conversation.channel,
         account_id: record.conversation.accountId,
@@ -560,7 +558,7 @@ describe("generic current-conversation bindings", () => {
     });
   });
 
-  it("returns no generic bindings for session keys without an indexable agent owner", async () => {
+  it("does not match partial target keys or request aliases", async () => {
     await bindWorkspaceConversation("user:U123");
 
     expect(listGenericCurrentConversationBindingsBySession("agent:main")).toEqual([]);

--- a/src/infra/outbound/current-conversation-bindings.ts
+++ b/src/infra/outbound/current-conversation-bindings.ts
@@ -10,7 +10,6 @@ import { normalizeOptionalLowercaseString } from "@openclaw/normalization-core/s
 import { normalizeConversationText } from "../../acp/conversation-id.js";
 import { normalizeAnyChannelId } from "../../channels/registry.js";
 import { getActivePluginChannelRegistryFromState } from "../../plugins/runtime-channel-state.js";
-import { parseAgentSessionKey, resolveAgentIdFromSessionKey } from "../../routing/session-key.js";
 import type { DB as OpenClawStateKyselyDatabase } from "../../state/openclaw-state-db.generated.js";
 import {
   openOpenClawStateDatabase,
@@ -102,10 +101,6 @@ function bindingRowsToRecords(rows: Array<{ record_json: string }>): SessionBind
   });
 }
 
-function targetAgentIdForSessionKey(targetSessionKey: string): string {
-  return resolveAgentIdFromSessionKey(targetSessionKey);
-}
-
 function readCurrentConversationBindingRow(
   db: DatabaseSync,
   conversation: ConversationRef,
@@ -148,8 +143,6 @@ function currentConversationBindingRow(
   return {
     binding_key: bindingKey,
     binding_id: record.bindingId,
-    target_agent_id: targetAgentIdForSessionKey(record.targetSessionKey),
-    target_session_id: null,
     target_session_key: record.targetSessionKey,
     channel: conversation.channel,
     account_id: conversation.accountId,
@@ -245,14 +238,10 @@ function listCurrentConversationBindingRowsBySession(
   targetSessionKey: string,
   scope?: CurrentConversationBindingScope,
 ): CurrentConversationBindingRow[] {
-  if (!parseAgentSessionKey(targetSessionKey)) {
-    return [];
-  }
   const bindingDb = getNodeSqliteKysely<CurrentConversationBindingDatabase>(db);
   let query = bindingDb
     .selectFrom("current_conversation_bindings")
     .select(["binding_key", "binding_id", "target_session_key", "record_json"])
-    .where("target_agent_id", "=", targetAgentIdForSessionKey(targetSessionKey))
     .where("target_session_key", "=", targetSessionKey);
   if (scope) {
     const normalized = normalizeConversationRef({
@@ -269,7 +258,7 @@ function listCurrentConversationBindingRowsBySession(
   return executeSqliteQuerySync(db, query.orderBy("binding_id", "asc")).rows;
 }
 
-/** Lists latest durable bindings using the indexed session owner and optional account scope. */
+/** Lists latest durable bindings using the exact target key and optional account scope. */
 export function listCurrentConversationBindingRecordsBySession(
   targetSessionKey: string,
   scope?: CurrentConversationBindingScope,

--- a/src/infra/state-migrations.doctor.ts
+++ b/src/infra/state-migrations.doctor.ts
@@ -198,6 +198,8 @@ function describeStateSchemaMigration(migration: OpenClawStateDatabaseSchemaMigr
       return "cron jobs and subagent runs → canonical JSON storage";
     case "creator-namespace-v14":
       return "historical cron creators → unknown source attribution";
+    case "conversation-binding-targets-v15":
+      return "conversation bindings → exact target keys without agent/session projections";
     case "operator-approvals-system-agent":
       return "operator approvals → OpenClaw system changes";
     case "session-watch-cursor-provenance-v4":

--- a/src/infra/state-migrations.runtime-state.ts
+++ b/src/infra/state-migrations.runtime-state.ts
@@ -2,7 +2,6 @@ import fs from "node:fs";
 import path from "node:path";
 import type { DatabaseSync } from "node:sqlite";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
-import { resolveAgentIdFromSessionKey } from "../routing/session-key.js";
 import type { DB as OpenClawStateKyselyDatabase } from "../state/openclaw-state-db.generated.js";
 import { runOpenClawStateWriteTransaction } from "../state/openclaw-state-db.js";
 import { resolveRequiredHomeDir } from "./home-dir.js";
@@ -662,8 +661,6 @@ function normalizeLegacyCurrentConversationBindingFile(input: unknown): SessionB
 function currentConversationBindingRow(record: SessionBindingRecord): {
   binding_key: string;
   binding_id: string;
-  target_agent_id: string;
-  target_session_id: string | null;
   target_session_key: string;
   channel: string;
   account_id: string;
@@ -682,8 +679,6 @@ function currentConversationBindingRow(record: SessionBindingRecord): {
   return {
     binding_key: currentConversationBindingKey(conversation),
     binding_id: record.bindingId,
-    target_agent_id: resolveAgentIdFromSessionKey(record.targetSessionKey),
-    target_session_id: null,
     target_session_key: record.targetSessionKey,
     channel: conversation.channel,
     account_id: conversation.accountId,

--- a/src/infra/state-migrations.test.ts
+++ b/src/infra/state-migrations.test.ts
@@ -445,8 +445,6 @@ function insertCurrentConversationBindingRow(
     stateDb.insertInto("current_conversation_bindings").values({
       binding_key: params.bindingKey,
       binding_id: params.bindingId,
-      target_agent_id: "codex",
-      target_session_id: null,
       target_session_key: params.targetSessionKey,
       channel: params.channel,
       account_id: params.accountId,
@@ -4998,95 +4996,98 @@ describe("state migrations", () => {
     expect(readPluginBindingApprovalRows(env)).toEqual([]);
   });
 
-  it("imports non-conflicting legacy current-conversation bindings when SQLite has a conflict", async () => {
-    const root = await createTempDir();
-    const stateDir = path.join(root, ".openclaw");
-    const env = createEnv(stateDir);
-    const cfg = createConfig();
-    const bindingsDir = path.join(stateDir, "bindings");
-    const sourcePath = path.join(bindingsDir, "current-conversations.json");
-    const conflictingKey = "workspace\u241fdefault\u241f\u241fuser:U123";
-    const missingKey = "workspace\u241fdefault\u241f\u241fuser:U456";
-    await fs.mkdir(bindingsDir, { recursive: true });
-    insertCurrentConversationBindingRow(env, {
-      bindingKey: conflictingKey,
-      bindingId: `generic:${conflictingKey}`,
-      targetSessionKey: "agent:codex:acp:existing",
-      channel: "workspace",
-      accountId: "default",
-      conversationId: "user:U123",
-      recordJson: JSON.stringify({
+  it.each(["agent:codex:acp:legacy-missing", "plugin-binding:fixture:legacy-missing"])(
+    "imports non-conflicting legacy target %s when SQLite has a conflict",
+    async (targetSessionKey) => {
+      const root = await createTempDir();
+      const stateDir = path.join(root, ".openclaw");
+      const env = createEnv(stateDir);
+      const cfg = createConfig();
+      const bindingsDir = path.join(stateDir, "bindings");
+      const sourcePath = path.join(bindingsDir, "current-conversations.json");
+      const conflictingKey = "workspace\u241fdefault\u241f\u241fuser:U123";
+      const missingKey = "workspace\u241fdefault\u241f\u241fuser:U456";
+      await fs.mkdir(bindingsDir, { recursive: true });
+      insertCurrentConversationBindingRow(env, {
+        bindingKey: conflictingKey,
         bindingId: `generic:${conflictingKey}`,
         targetSessionKey: "agent:codex:acp:existing",
-        targetKind: "session",
-        conversation: {
-          channel: "workspace",
-          accountId: "default",
-          conversationId: "user:U123",
+        channel: "workspace",
+        accountId: "default",
+        conversationId: "user:U123",
+        recordJson: JSON.stringify({
+          bindingId: `generic:${conflictingKey}`,
+          targetSessionKey: "agent:codex:acp:existing",
+          targetKind: "session",
+          conversation: {
+            channel: "workspace",
+            accountId: "default",
+            conversationId: "user:U123",
+          },
+          status: "active",
+          boundAt: 1,
+        }),
+      });
+      await fs.writeFile(
+        sourcePath,
+        JSON.stringify({
+          version: 1,
+          bindings: [
+            {
+              bindingId: `generic:${conflictingKey}`,
+              targetSessionKey: "agent:codex:acp:legacy-conflict",
+              targetKind: "session",
+              conversation: {
+                channel: "workspace",
+                accountId: "default",
+                conversationId: "user:U123",
+              },
+              status: "active",
+              boundAt: 2,
+            },
+            {
+              bindingId: `generic:${missingKey}`,
+              targetSessionKey,
+              targetKind: "session",
+              conversation: {
+                channel: "workspace",
+                accountId: "default",
+                conversationId: "user:U456",
+              },
+              status: "active",
+              boundAt: 3,
+            },
+          ],
+        }),
+        "utf8",
+      );
+
+      const detected = await detectLegacyStateMigrations({ cfg, env, homedir: () => root });
+      const result = await runLegacyStateMigrations({ detected, config: cfg });
+
+      expect(result.changes).toContain(
+        "Migrated 1 current-conversation binding → shared SQLite state",
+      );
+      expect(result.warnings).toStrictEqual([]);
+      expect(result.notices).toEqual([
+        `Kept shared SQLite current-conversation bindings because 1 legacy binding conflicts: ${sourcePath}`,
+      ]);
+      expect(readCurrentConversationBindingRows(env)).toMatchObject([
+        {
+          binding_key: conflictingKey,
+          target_session_key: "agent:codex:acp:existing",
         },
-        status: "active",
-        boundAt: 1,
-      }),
-    });
-    await fs.writeFile(
-      sourcePath,
-      JSON.stringify({
-        version: 1,
-        bindings: [
-          {
-            bindingId: `generic:${conflictingKey}`,
-            targetSessionKey: "agent:codex:acp:legacy-conflict",
-            targetKind: "session",
-            conversation: {
-              channel: "workspace",
-              accountId: "default",
-              conversationId: "user:U123",
-            },
-            status: "active",
-            boundAt: 2,
-          },
-          {
-            bindingId: `generic:${missingKey}`,
-            targetSessionKey: "agent:codex:acp:legacy-missing",
-            targetKind: "session",
-            conversation: {
-              channel: "workspace",
-              accountId: "default",
-              conversationId: "user:U456",
-            },
-            status: "active",
-            boundAt: 3,
-          },
-        ],
-      }),
-      "utf8",
-    );
-
-    const detected = await detectLegacyStateMigrations({ cfg, env, homedir: () => root });
-    const result = await runLegacyStateMigrations({ detected, config: cfg });
-
-    expect(result.changes).toContain(
-      "Migrated 1 current-conversation binding → shared SQLite state",
-    );
-    expect(result.warnings).toStrictEqual([]);
-    expect(result.notices).toEqual([
-      `Kept shared SQLite current-conversation bindings because 1 legacy binding conflicts: ${sourcePath}`,
-    ]);
-    expect(readCurrentConversationBindingRows(env)).toMatchObject([
-      {
-        binding_key: conflictingKey,
-        target_session_key: "agent:codex:acp:existing",
-      },
-      {
-        binding_key: missingKey,
-        target_session_key: "agent:codex:acp:legacy-missing",
-      },
-    ]);
-    await expectMissingPath(sourcePath);
-    await expect(fs.readFile(`${sourcePath}.migrated`, "utf8")).resolves.toContain(
-      "legacy-conflict",
-    );
-  });
+        {
+          binding_key: missingKey,
+          target_session_key: targetSessionKey,
+        },
+      ]);
+      await expectMissingPath(sourcePath);
+      await expect(fs.readFile(`${sourcePath}.migrated`, "utf8")).resolves.toContain(
+        "legacy-conflict",
+      );
+    },
+  );
 
   it.each([
     {

--- a/src/plugins/conversation-binding.sqlite.test.ts
+++ b/src/plugins/conversation-binding.sqlite.test.ts
@@ -1,0 +1,173 @@
+import { expectDefined } from "@openclaw/normalization-core";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { getSessionBindingService } from "../infra/outbound/session-binding-service.js";
+import { drainGlobalSingletonLifecycleState } from "../shared/global-singleton.js";
+import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
+import { createChannelTestPluginBase, createTestRegistry } from "../test-utils/channel-plugins.js";
+import { captureEnv, setTestEnvValue } from "../test-utils/env.js";
+import {
+  detachPluginConversationBinding,
+  getCurrentPluginConversationBinding,
+  requestPluginConversationBinding,
+  resolvePluginConversationBindingApproval,
+} from "./conversation-binding.js";
+import { seedPluginConversationBindingApprovalForTest } from "./conversation-binding.test-fixtures.js";
+import {
+  captureActivePluginRegistrySnapshot,
+  restoreActivePluginRegistrySnapshot,
+  setActivePluginRegistry,
+} from "./runtime.js";
+import { cleanupTrackedTempDirs, makeTrackedTempDir } from "./test-helpers/fs-fixtures.js";
+
+function installGenericBindingChannel(): void {
+  setActivePluginRegistry(
+    createTestRegistry([
+      {
+        pluginId: "binding-test",
+        source: "test",
+        plugin: {
+          ...createChannelTestPluginBase({ id: "binding-test" }),
+          conversationBindings: { supportsCurrentConversationBinding: true },
+        },
+      },
+    ]),
+  );
+}
+
+describe("plugin conversation bindings through SQLite", () => {
+  const tempDirs: string[] = [];
+  let envSnapshot: ReturnType<typeof captureEnv>;
+  let registrySnapshot: ReturnType<typeof captureActivePluginRegistrySnapshot>;
+
+  beforeEach(async () => {
+    envSnapshot = captureEnv(["OPENCLAW_STATE_DIR"]);
+    registrySnapshot = captureActivePluginRegistrySnapshot();
+    await drainGlobalSingletonLifecycleState();
+    closeOpenClawStateDatabaseForTest();
+    setTestEnvValue("OPENCLAW_STATE_DIR", makeTrackedTempDir("plugin-binding-sqlite", tempDirs));
+    installGenericBindingChannel();
+  });
+
+  afterEach(async () => {
+    await drainGlobalSingletonLifecycleState();
+    closeOpenClawStateDatabaseForTest();
+    restoreActivePluginRegistrySnapshot(registrySnapshot);
+    envSnapshot.restore();
+    cleanupTrackedTempDirs(tempDirs);
+  });
+
+  it.each(["pending approval", "persistent approval"] as const)(
+    "keeps an opaque target usable across restart after %s",
+    async (approval) => {
+      const owner = { pluginId: "fixture-runtime", pluginRoot: "/plugins/fixture-runtime" };
+      const conversation = {
+        channel: "binding-test",
+        accountId: "default",
+        conversationId: "room:shared",
+      };
+      const input = {
+        ...owner,
+        conversation,
+        requestedBySenderId: "user-1",
+        binding: {
+          summary: "Continue the plugin conversation",
+          detachHint: "/detach",
+          data: { externalThread: "thread-17" },
+        },
+      };
+      if (approval === "persistent approval") {
+        seedPluginConversationBindingApprovalForTest({ ...owner, ...conversation });
+      }
+
+      const service = getSessionBindingService();
+      const requested = await requestPluginConversationBinding(input);
+      if (approval === "pending approval") {
+        expect(requested.status).toBe("pending");
+        if (requested.status !== "pending") {
+          throw new Error("Expected a plugin binding approval request");
+        }
+        expect(service.resolveByConversation(conversation)).toBeNull();
+        await expect(
+          resolvePluginConversationBindingApproval({
+            approvalId: requested.approvalId,
+            decision: "allow-always",
+            senderId: "user-1",
+          }),
+        ).resolves.toMatchObject({ status: "approved" });
+      } else {
+        expect(requested.status).toBe("bound");
+      }
+
+      const record = expectDefined(
+        service.resolveByConversation(conversation),
+        "approved plugin binding persisted",
+      );
+      expect(record.targetSessionKey).toMatch(/^plugin-binding:fixture-runtime:/);
+      expect(record.metadata).toMatchObject({ ...owner, ...input.binding });
+      expect(service.listBySession(record.targetSessionKey)).toEqual([record]);
+
+      const workConversation = { ...conversation, accountId: "work" };
+      const workRequest = await requestPluginConversationBinding({
+        ...input,
+        conversation: workConversation,
+      });
+      expect(workRequest.status).toBe("pending");
+      if (workRequest.status !== "pending") {
+        throw new Error("A different account must require its own approval");
+      }
+      expect(service.resolveByConversation(workConversation)).toBeNull();
+      await expect(
+        resolvePluginConversationBindingApproval({
+          approvalId: workRequest.approvalId,
+          decision: "allow-once",
+          senderId: "user-1",
+        }),
+      ).resolves.toMatchObject({ status: "approved" });
+      const workRecord = expectDefined(
+        service.resolveByConversation(workConversation),
+        "separate account binding persisted",
+      );
+      expect(workRecord.targetSessionKey).not.toBe(record.targetSessionKey);
+
+      await drainGlobalSingletonLifecycleState();
+      closeOpenClawStateDatabaseForTest();
+      installGenericBindingChannel();
+
+      await expect(
+        getCurrentPluginConversationBinding({ ...owner, conversation }),
+      ).resolves.toMatchObject({
+        bindingId: record.bindingId,
+        ...owner,
+        ...conversation,
+        ...input.binding,
+      });
+      expect(service.listBySession(record.targetSessionKey)).toEqual([record]);
+      expect(service.listBySession(workRecord.targetSessionKey)).toEqual([workRecord]);
+      const touchedAt = record.boundAt + 1_000;
+      service.touch(record.bindingId, touchedAt);
+      closeOpenClawStateDatabaseForTest();
+      expect(service.resolveByConversation(conversation)?.metadata).toMatchObject({
+        ...record.metadata,
+        lastActivityAt: touchedAt,
+      });
+
+      await expect(
+        detachPluginConversationBinding({ pluginRoot: "/plugins/other-runtime", conversation }),
+      ).resolves.toEqual({ removed: false });
+      expect(service.listBySession(record.targetSessionKey)).toHaveLength(1);
+      await expect(detachPluginConversationBinding({ ...owner, conversation })).resolves.toEqual({
+        removed: true,
+      });
+      expect(service.resolveByConversation(conversation)).toBeNull();
+      expect(service.listBySession(record.targetSessionKey)).toEqual([]);
+      expect(service.resolveByConversation(workConversation)).toEqual(workRecord);
+
+      await expect(
+        service.unbind({ targetSessionKey: workRecord.targetSessionKey, reason: "session-ended" }),
+      ).resolves.toEqual([workRecord]);
+      closeOpenClawStateDatabaseForTest();
+      expect(service.resolveByConversation(workConversation)).toBeNull();
+      expect(service.listBySession(workRecord.targetSessionKey)).toEqual([]);
+    },
+  );
+});

--- a/src/state/creator-namespace-migration.test.ts
+++ b/src/state/creator-namespace-migration.test.ts
@@ -11,6 +11,7 @@ import {
   openOpenClawAgentDatabase,
   withAgentDatabaseMaintenanceLease,
 } from "./openclaw-agent-db.js";
+import { OPENCLAW_STATE_SCHEMA_VERSION } from "./openclaw-state-db-contract.js";
 import {
   closeOpenClawStateDatabaseForTest,
   openOpenClawStateDatabase,
@@ -150,7 +151,9 @@ describe("creator namespace upgrades", () => {
         PRAGMA user_version = 13; UPDATE schema_meta SET schema_version = 13;`);
       closeOpenClawStateDatabaseForTest();
       const reopened = openOpenClawStateDatabase({ env: state.env });
-      expect(reopened.db.prepare("PRAGMA user_version").get()?.user_version).toBe(14);
+      expect(reopened.db.prepare("PRAGMA user_version").get()?.user_version).toBe(
+        OPENCLAW_STATE_SCHEMA_VERSION,
+      );
       expect((await loadCronStore(storePath)).jobs[0]).toMatchObject({
         createdActor: {
           type: "human",

--- a/src/state/openclaw-state-db-binding-targets.test.ts
+++ b/src/state/openclaw-state-db-binding-targets.test.ts
@@ -1,0 +1,229 @@
+import type { DatabaseSync } from "node:sqlite";
+import { afterEach, describe, expect, it } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { openNodeSqliteDatabase } from "../infra/node-sqlite.js";
+import { OPENCLAW_STATE_SCHEMA_VERSION } from "./openclaw-state-db-contract.js";
+import {
+  closeOpenClawStateDatabaseForTest,
+  openOpenClawStateDatabase,
+  repairOpenClawStateDatabaseSchema,
+} from "./openclaw-state-db.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+const migrationPaths = ["runtime open", "doctor repair"] as const;
+const pluginTarget = "plugin-binding:fixture:shared";
+
+afterEach(() => {
+  closeOpenClawStateDatabaseForTest();
+});
+
+function readBindings(database: DatabaseSync) {
+  return database.prepare("SELECT * FROM current_conversation_bindings ORDER BY binding_key").all();
+}
+
+function readMigrationSnapshot(database: DatabaseSync) {
+  return {
+    version: database.prepare("PRAGMA user_version").get(),
+    metadata: database.prepare("SELECT * FROM schema_meta WHERE meta_key = 'primary'").get(),
+    schema: database
+      .prepare(
+        "SELECT type, name, sql FROM sqlite_schema WHERE tbl_name = 'current_conversation_bindings' ORDER BY type, name",
+      )
+      .all(),
+    rows: readBindings(database),
+  };
+}
+
+function createVersion14Bindings() {
+  const stateDir = tempDirs.make("openclaw-binding-targets-v14-");
+  const options = { env: { OPENCLAW_STATE_DIR: stateDir } };
+  const databasePath = openOpenClawStateDatabase(options).path;
+  closeOpenClawStateDatabaseForTest();
+
+  const legacy = openNodeSqliteDatabase(databasePath);
+  try {
+    const columns = new Set(
+      legacy
+        .prepare("PRAGMA table_info(current_conversation_bindings)")
+        .all()
+        .map((row) => row.name),
+    );
+    for (const [column, declaration] of [
+      ["target_agent_id", "TEXT NOT NULL DEFAULT 'main'"],
+      ["target_session_id", "TEXT"],
+    ]) {
+      if (!columns.has(column)) {
+        legacy.exec(
+          `ALTER TABLE current_conversation_bindings ADD COLUMN ${column} ${declaration};`,
+        );
+      }
+    }
+    // A compatible future column must survive; copying only canonical columns loses its data.
+    legacy.exec(`
+      ALTER TABLE current_conversation_bindings ADD COLUMN future_note TEXT;
+      DROP INDEX idx_current_conversation_bindings_target;
+      CREATE INDEX idx_current_conversation_bindings_target
+        ON current_conversation_bindings(target_agent_id, target_session_key, updated_at DESC, binding_key);
+      PRAGMA user_version = 14;
+      UPDATE schema_meta SET schema_version = 14 WHERE meta_key = 'primary';
+    `);
+    const insert = legacy.prepare(`
+      INSERT INTO current_conversation_bindings (
+        binding_key, binding_id, target_agent_id, target_session_id, target_session_key,
+        channel, account_id, conversation_kind, parent_conversation_id, conversation_id,
+        target_kind, status, bound_at, expires_at, metadata_json, record_json, updated_at, future_note
+      ) VALUES (?, ?, ?, NULL, ?, 'fixture-channel', ?, 'current', ?, ?,
+                'session', 'active', 10, ?, ?, ?, 20, ?)
+    `);
+    for (const [conversationId, accountId, target, agent, expiresAt] of [
+      ["first", "work", pluginTarget, "main", 1],
+      ["second", "work", pluginTarget, "main", null],
+      ["third", "personal", "agent:worker:session", "worker", 9_000_000_000_000],
+    ] as const) {
+      const bindingId = `generic:fixture-channel␟${accountId}␟parent␟${conversationId}`;
+      const metadata = { owner: "fixture", lastActivityAt: 15 };
+      const record = {
+        bindingId,
+        targetSessionKey: target,
+        targetKind: "session",
+        conversation: {
+          channel: "fixture-channel",
+          accountId,
+          parentConversationId: "parent",
+          conversationId,
+        },
+        status: "active",
+        boundAt: 10,
+        ...(expiresAt === null ? {} : { expiresAt }),
+        metadata,
+      };
+      insert.run(
+        bindingId.slice("generic:".length),
+        bindingId,
+        agent,
+        target,
+        accountId,
+        "parent",
+        conversationId,
+        expiresAt,
+        JSON.stringify(metadata, null, 2),
+        JSON.stringify(record, null, 2),
+        `keep:${conversationId}`,
+      );
+    }
+    return { options, databasePath, before: readMigrationSnapshot(legacy) };
+  } finally {
+    legacy.close();
+  }
+}
+
+describe("conversation binding target migration", () => {
+  it.each(migrationPaths)(
+    "preserves bindings and additive data through %s and reopen",
+    (migrationPath) => {
+      const { options, databasePath, before } = createVersion14Bindings();
+      if (migrationPath === "doctor repair") {
+        expect(repairOpenClawStateDatabaseSchema(options).warnings).toEqual([]);
+      }
+      const migrated = openOpenClawStateDatabase(options);
+      const columns = migrated.db
+        .prepare("PRAGMA table_info(current_conversation_bindings)")
+        .all()
+        .map((row) => row.name);
+      expect(columns).not.toContain("target_agent_id");
+      expect(columns).not.toContain("target_session_id");
+      expect(readBindings(migrated.db)).toEqual(
+        before.rows.map(({ target_agent_id: _agent, target_session_id: _session, ...row }) => row),
+      );
+      expect(migrated.db.prepare("PRAGMA user_version").get()).toEqual({
+        user_version: OPENCLAW_STATE_SCHEMA_VERSION,
+      });
+      expect(
+        migrated.db
+          .prepare("SELECT schema_version FROM schema_meta WHERE meta_key = 'primary'")
+          .get(),
+      ).toEqual({ schema_version: OPENCLAW_STATE_SCHEMA_VERSION });
+      expect(
+        migrated.db
+          .prepare(
+            "SELECT name, \"unique\" FROM pragma_index_list('current_conversation_bindings') WHERE name = 'idx_current_conversation_bindings_target'",
+          )
+          .get(),
+      ).toEqual({ name: "idx_current_conversation_bindings_target", unique: 0 });
+      const query =
+        "SELECT binding_id FROM current_conversation_bindings WHERE target_session_key = ?";
+      expect(migrated.db.prepare(query).all(pluginTarget)).toHaveLength(2);
+      expect(
+        migrated.db
+          .prepare(`EXPLAIN QUERY PLAN ${query}`)
+          .all(pluginTarget)
+          .map((row) => row.detail),
+      ).toEqual([
+        expect.stringMatching(
+          /SEARCH current_conversation_bindings USING INDEX idx_current_conversation_bindings_target \(target_session_key=\?\)/,
+        ),
+      ]);
+      expect(migrated.db.prepare("PRAGMA integrity_check").get()).toEqual({
+        integrity_check: "ok",
+      });
+      expect(migrated.db.prepare("PRAGMA foreign_key_check").all()).toEqual([]);
+
+      const after = readMigrationSnapshot(migrated.db);
+      closeOpenClawStateDatabaseForTest();
+      expect(readMigrationSnapshot(openOpenClawStateDatabase(options).db)).toEqual(after);
+      closeOpenClawStateDatabaseForTest();
+      expect(repairOpenClawStateDatabaseSchema(options).warnings).toEqual([]);
+      const repaired = openNodeSqliteDatabase(databasePath, { readOnly: true });
+      try {
+        expect(readBindings(repaired)).toEqual(after.rows);
+        expect(readMigrationSnapshot(repaired).schema).toEqual(after.schema);
+      } finally {
+        repaired.close();
+      }
+    },
+  );
+
+  it.each(
+    migrationPaths.flatMap((migrationPath) =>
+      (["dependent trigger", "owner mismatch"] as const).map((failure) => ({
+        migrationPath,
+        failure,
+      })),
+    ),
+  )(
+    "preserves the complete old database after $failure through $migrationPath",
+    ({ migrationPath, failure }) => {
+      const { options, databasePath } = createVersion14Bindings();
+      const legacy = openNodeSqliteDatabase(databasePath);
+      let before: ReturnType<typeof readMigrationSnapshot>;
+      try {
+        if (failure === "dependent trigger") {
+          // The second DROP must fail after the first column and target index were removed.
+          legacy.exec(`CREATE TRIGGER fixture_binding_session_guard
+          AFTER UPDATE ON current_conversation_bindings
+          BEGIN SELECT OLD.target_session_id; END;`);
+        } else {
+          legacy.exec("UPDATE schema_meta SET role = 'agent' WHERE meta_key = 'primary';");
+        }
+        before = readMigrationSnapshot(legacy);
+      } finally {
+        legacy.close();
+      }
+      const reason = failure === "dependent trigger" ? /target_session_id/ : /expected global/;
+      if (migrationPath === "runtime open") {
+        expect(() => openOpenClawStateDatabase(options)).toThrow(reason);
+      } else {
+        expect(repairOpenClawStateDatabaseSchema(options)).toEqual({
+          changes: [],
+          warnings: [expect.stringMatching(reason)],
+        });
+      }
+      const preserved = openNodeSqliteDatabase(databasePath, { readOnly: true });
+      try {
+        expect(readMigrationSnapshot(preserved)).toEqual(before);
+      } finally {
+        preserved.close();
+      }
+    },
+  );
+});

--- a/src/state/openclaw-state-db-contract.ts
+++ b/src/state/openclaw-state-db-contract.ts
@@ -1,6 +1,7 @@
 import type { DatabaseSync } from "node:sqlite";
 import type { SqliteWalMaintenance } from "../infra/sqlite-wal.js";
 
+// v15 removes redundant agent/session projections from conversation bindings.
 // v14 retains unknown creator namespaces on historical cron jobs.
 // v13 keeps cron jobs and subagent runs canonical in JSON, removing unused projections.
 // v12 folds singleton state into config_machine_state and retires write-only cron epochs.
@@ -11,7 +12,7 @@ import type { SqliteWalMaintenance } from "../infra/sqlite-wal.js";
 // v7 retires the inert shared commitments table.
 // v6 makes every committed shared-state table part of the canonical runtime schema.
 // v5 records durable cloud-worker result refs on pending workspace fences.
-export const OPENCLAW_STATE_SCHEMA_VERSION = 14;
+export const OPENCLAW_STATE_SCHEMA_VERSION = 15;
 export const OPENCLAW_STATE_STRICT_SCHEMA_VERSION = 3;
 // Privacy-sensitive feature tables remain absent even in fresh databases until
 // their feature-local first write. The canonical SQL still owns their shape.
@@ -100,6 +101,7 @@ export type OpenClawStateDatabaseSchemaMigration = {
     | "singleton-state-foldin-v12"
     | "state-consolidation-v13"
     | "creator-namespace-v14"
+    | "conversation-binding-targets-v15"
     | "operator-approvals-system-agent"
     | "session-watch-cursor-provenance-v4"
     | "strict-tables-v3";

--- a/src/state/openclaw-state-db-maintenance.ts
+++ b/src/state/openclaw-state-db-maintenance.ts
@@ -55,6 +55,7 @@ const STATE_MIGRATION_ALLOWED_MISSING_TABLES = {
   11: STATE_V6_ADDITIVE_TABLES,
   12: STATE_V6_ADDITIVE_TABLES,
   13: LAZY_ADDITIVE_STATE_TABLES,
+  14: LAZY_ADDITIVE_STATE_TABLES,
 } as const satisfies Record<number, readonly string[]>;
 type OpenClawStateMigrationVersion = keyof typeof STATE_MIGRATION_ALLOWED_MISSING_TABLES;
 
@@ -251,6 +252,11 @@ export const openClawStateMigrationAssertions = new Map([
     (database: DatabaseSync, options: { pathname: string }) =>
       assertOpenClawStateDatabaseVersionForMigration(database, { ...options, version: 13 }),
   ],
+  [
+    14,
+    (database: DatabaseSync, options: { pathname: string }) =>
+      assertOpenClawStateDatabaseVersionForMigration(database, { ...options, version: 14 }),
+  ],
 ]);
 
 export function markCurrentStateSchemaVersion(
@@ -305,5 +311,28 @@ export function migrateCronCreatorNamespaces(db: DatabaseSync, previousVersion: 
      WHERE json_valid(job_json)
        AND json_extract(job_json, '$.createdActor.type') = 'human';
   `);
+  return true;
+}
+
+/** Keep opaque plugin targets independent of agent identity without rewriting binding records. */
+export function migrateConversationBindingTargets(
+  db: DatabaseSync,
+  previousVersion: number,
+): boolean {
+  if (previousVersion >= 15) {
+    return false;
+  }
+  const columns = ["target_agent_id", "target_session_id"].filter((column) =>
+    tableHasColumn(db, "current_conversation_bindings", column),
+  );
+  if (columns.length === 0) {
+    return false;
+  }
+  // The caller owns one transaction through index recreation and version publication.
+  // Unknown schema dependencies must fail and roll back, never be dropped to force migration.
+  db.exec("DROP INDEX IF EXISTS idx_current_conversation_bindings_target;");
+  for (const column of columns) {
+    db.exec(`ALTER TABLE current_conversation_bindings DROP COLUMN ${column};`);
+  }
   return true;
 }

--- a/src/state/openclaw-state-db-schema-additive.ts
+++ b/src/state/openclaw-state-db-schema-additive.ts
@@ -459,8 +459,6 @@ export function ensureAdditiveStateColumns(db: DatabaseSync): void {
     "managed_outgoing_image_records",
     "cleanup_pending INTEGER NOT NULL DEFAULT 0 CHECK (cleanup_pending IN (0, 1))",
   );
-  ensureColumn(db, "current_conversation_bindings", "target_agent_id TEXT NOT NULL DEFAULT 'main'");
-  ensureColumn(db, "current_conversation_bindings", "target_session_id TEXT");
   ensureColumn(
     db,
     "current_conversation_bindings",

--- a/src/state/openclaw-state-db-schema-repair.ts
+++ b/src/state/openclaw-state-db-schema-repair.ts
@@ -402,6 +402,13 @@ export function detectOpenClawStateDatabaseSchemaMigrationsFromDatabase(
   if (userVersion < 14 && tableExists(db, "cron_jobs")) {
     migrations.push({ kind: "creator-namespace-v14", path: pathname });
   }
+  if (
+    userVersion < 15 &&
+    (tableHasColumn(db, "current_conversation_bindings", "target_agent_id") ||
+      tableHasColumn(db, "current_conversation_bindings", "target_session_id"))
+  ) {
+    migrations.push({ kind: "conversation-binding-targets-v15", path: pathname });
+  }
   if (!hasCanonicalAgentDatabasesPrimaryKey(db)) {
     migrations.push({ kind: "agent-databases-composite-primary-key", path: pathname });
   }

--- a/src/state/openclaw-state-db.generated.d.ts
+++ b/src/state/openclaw-state-db.generated.d.ts
@@ -413,9 +413,7 @@ export interface CurrentConversationBindings {
   parent_conversation_id: string | null;
   record_json: string;
   status: string;
-  target_agent_id: string;
   target_kind: string;
-  target_session_id: string | null;
   target_session_key: string;
   updated_at: number;
 }

--- a/src/state/openclaw-state-db.test.ts
+++ b/src/state/openclaw-state-db.test.ts
@@ -2294,7 +2294,9 @@ describe("openclaw state database", () => {
       }
 
       const migrated = openOpenClawStateDatabase(options);
-      expect(readSqliteNumberPragma(migrated.db, "user_version")).toBe(14);
+      expect(readSqliteNumberPragma(migrated.db, "user_version")).toBe(
+        OPENCLAW_STATE_SCHEMA_VERSION,
+      );
       expect(collectSqliteSchemaShape(migrated.db).gateway_origin_device_tokens).toEqual(
         createInitialStateSchemaShape().gateway_origin_device_tokens,
       );
@@ -2625,7 +2627,7 @@ describe("openclaw state database", () => {
       });
       closeOpenClawStateDatabaseForTest();
       expect(readSqliteNumberPragma(openOpenClawStateDatabase(options).db, "user_version")).toBe(
-        14,
+        OPENCLAW_STATE_SCHEMA_VERSION,
       );
     },
   );
@@ -2893,7 +2895,7 @@ describe("openclaw state database", () => {
             }).db,
             "user_version",
           ),
-        ).toBe(14);
+        ).toBe(OPENCLAW_STATE_SCHEMA_VERSION);
       },
     );
   });
@@ -2929,7 +2931,7 @@ describe("openclaw state database", () => {
         db.prepare("UPDATE cron_jobs SET state_json = '[]'").run();
         expect(() => db.exec(STATE_SCHEMA_13_TO_12_DOWNGRADE_SQL)).toThrow(/CHECK constraint/);
         db.exec("ROLLBACK");
-        expect(readSqliteNumberPragma(db, "user_version")).toBe(14);
+        expect(readSqliteNumberPragma(db, "user_version")).toBe(OPENCLAW_STATE_SCHEMA_VERSION);
         expect(db.prepare("SELECT state_json FROM cron_jobs").get()).toEqual({ state_json: "[]" });
         db.close();
       },
@@ -2957,7 +2959,7 @@ describe("openclaw state database", () => {
     legacy.close();
 
     const migrated = openOpenClawStateDatabase(options);
-    expect(readSqliteNumberPragma(migrated.db, "user_version")).toBe(14);
+    expect(readSqliteNumberPragma(migrated.db, "user_version")).toBe(OPENCLAW_STATE_SCHEMA_VERSION);
     expect(
       migrated.db
         .prepare(
@@ -3289,6 +3291,7 @@ describe("openclaw state database", () => {
       { kind: "singleton-state-foldin-v12", path: fixture.databasePath },
       { kind: "state-consolidation-v13", path: fixture.databasePath },
       { kind: "creator-namespace-v14", path: fixture.databasePath },
+      { kind: "conversation-binding-targets-v15", path: fixture.databasePath },
       { kind: "audit-events-v2", path: fixture.databasePath },
       { kind: "strict-tables-v3", path: fixture.databasePath },
     ]);
@@ -3306,6 +3309,7 @@ describe("openclaw state database", () => {
         "Migrated shared state audit event ledger → versioned message lifecycle schema",
         "Consolidated shared state tables (v13)",
         "Qualified historical cron creator attribution as unknown (v14)",
+        "Removed redundant conversation binding target projections (v15)",
         "Migrated shared state tables to SQLite STRICT typing (48)",
       ],
       warnings: [],

--- a/src/state/openclaw-state-db.ts
+++ b/src/state/openclaw-state-db.ts
@@ -62,6 +62,7 @@ import {
   assertOpenClawStateDatabaseForMaintenance,
   assertSupportedSchemaVersion,
   markCurrentStateSchemaVersion,
+  migrateConversationBindingTargets,
   migrateCronCreatorNamespaces,
   openClawStateMigrationAssertions,
   resolveDatabasePath,
@@ -215,6 +216,9 @@ function repairOpenClawStateDatabaseSchemaWithWriteAccess(
           }
           if (migrateCronCreatorNamespaces(db, previousVersion)) {
             applied.push("Qualified historical cron creator attribution as unknown (v14)");
+          }
+          if (migrateConversationBindingTargets(db, previousVersion)) {
+            applied.push("Removed redundant conversation binding target projections (v15)");
           }
           executeCanonicalStateSchema(db, {
             includeVersionLazyAdditiveTables: previousVersion !== OPENCLAW_STATE_SCHEMA_VERSION,
@@ -399,6 +403,7 @@ function ensureSchema(
         ensureAdditiveStateColumns(db);
         migrateJsonCanonicalWideRowsV13(db, previousVersion);
         migrateCronCreatorNamespaces(db, previousVersion);
+        migrateConversationBindingTargets(db, previousVersion);
         sessionWatchMigration.migrateSessionWatchCursorProvenance(db);
         assertCanonicalStateSchemaShape(db, pathname);
         executeCanonicalStateSchema(db, {

--- a/src/state/openclaw-state-schema-compatibility.ts
+++ b/src/state/openclaw-state-schema-compatibility.ts
@@ -98,9 +98,6 @@ export const STATE_PERSISTENT_SCHEMA_COMPATIBILITY: SqliteSchemaCompatibility = 
     "current_conversation_bindings.conversation_kind": [
       "conversation_kind TEXT NOT NULL DEFAULT 'channel'",
     ],
-    "current_conversation_bindings.target_agent_id": [
-      "target_agent_id TEXT NOT NULL DEFAULT 'main'",
-    ],
     "operator_approvals.resolution_ref": ["resolution_ref TEXT"],
     "worker_environments.desktop_json": ["desktop_json TEXT"],
     "worker_environments.bootstrap_install_kind": ["bootstrap_install_kind TEXT"],

--- a/src/state/openclaw-state-schema.sql
+++ b/src/state/openclaw-state-schema.sql
@@ -1549,8 +1549,6 @@ CREATE INDEX IF NOT EXISTS idx_subagent_runs_controller_session_key
 CREATE TABLE IF NOT EXISTS current_conversation_bindings (
   binding_key TEXT NOT NULL PRIMARY KEY,
   binding_id TEXT NOT NULL,
-  target_agent_id TEXT NOT NULL,
-  target_session_id TEXT,
   target_session_key TEXT NOT NULL,
   channel TEXT NOT NULL,
   account_id TEXT NOT NULL,
@@ -1567,7 +1565,7 @@ CREATE TABLE IF NOT EXISTS current_conversation_bindings (
 ) STRICT;
 
 CREATE INDEX IF NOT EXISTS idx_current_conversation_bindings_target
-  ON current_conversation_bindings(target_agent_id, target_session_key, updated_at DESC, binding_key);
+  ON current_conversation_bindings(target_session_key, updated_at DESC, binding_key);
 CREATE INDEX IF NOT EXISTS idx_current_conversation_bindings_conversation
   ON current_conversation_bindings(channel, account_id, conversation_kind, conversation_id);
 CREATE INDEX IF NOT EXISTS idx_current_conversation_bindings_expires

--- a/src/state/user-profiles.test.ts
+++ b/src/state/user-profiles.test.ts
@@ -164,7 +164,6 @@ describe("user profiles", () => {
       openOpenClawStateDatabase(options).db.prepare("PRAGMA user_version").get()?.user_version,
     ).toBe(versionBefore);
     expect(versionBefore).toBe(OPENCLAW_STATE_SCHEMA_VERSION);
-    expect(OPENCLAW_STATE_SCHEMA_VERSION).toBe(14);
     expect(second).toEqual(first);
     expect(ensureProfileForEmail("ADA@example.com", options)).toEqual(first);
     expect(listProfiles(options)).toEqual([

--- a/test/vitest/vitest.extension-codex-app-server-attempt-extra.config.ts
+++ b/test/vitest/vitest.extension-codex-app-server-attempt-extra.config.ts
@@ -7,6 +7,7 @@ export function createExtensionCodexAppServerAttemptExtraVitestConfig(
   return createScopedVitestConfig(
     [
       "extensions/codex/src/app-server/run-attempt.agent-end-context.test.ts",
+      "extensions/codex/src/app-server/run-attempt.channel-tool-progress.test.ts",
       "extensions/codex/src/app-server/run-attempt-lifecycle-controller.test.ts",
       "extensions/codex/src/app-server/run-attempt-thread-cleanup.test.ts",
       "extensions/codex/src/app-server/run-attempt.configured-mcp.test.ts",

--- a/test/vitest/vitest.extension-codex-app-server-attempt-extra.config.ts
+++ b/test/vitest/vitest.extension-codex-app-server-attempt-extra.config.ts
@@ -7,7 +7,6 @@ export function createExtensionCodexAppServerAttemptExtraVitestConfig(
   return createScopedVitestConfig(
     [
       "extensions/codex/src/app-server/run-attempt.agent-end-context.test.ts",
-      "extensions/codex/src/app-server/run-attempt.channel-tool-progress.test.ts",
       "extensions/codex/src/app-server/run-attempt-lifecycle-controller.test.ts",
       "extensions/codex/src/app-server/run-attempt-thread-cleanup.test.ts",
       "extensions/codex/src/app-server/run-attempt.configured-mcp.test.ts",


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users binding a conversation to a plugin runtime would fail during persistence because the binding store required an OpenClaw agent identity. After persistence succeeded, escaped commands such as `/codex status` also tried to initialize an agent session at the plugin's target, either failing canonical-key validation or silently redirecting an adopted agent target.

## Why This Change Was Made

Keep one durable conversation-to-target mapping. Target keys are exact opaque destinations; plugin ownership and approval are separate facts. Remove the unused agent/session projections and their parsing, use a non-unique exact-target index, and let plugin dispatch own its target handoff while core commands retain their core session. Existing core/ACP bindings still retarget normally. Plugin command selection and execution now share the same originating-channel resolution, so routed commands retain their exact channel authority instead of being rejected as stale.

The maintainer approved the material storage design before implementation: shared-state schema 15 removes `target_agent_id` and `target_session_id`, preserving binding IDs, target bytes, record/metadata JSON, account/channel isolation, approvals, expiry, and detach behavior. Startup and Doctor perform the migration transactionally. Unknown dependent SQL causes rollback; it is never deleted to force migration. Native readers and package schema metadata are updated together. No new configuration, compatibility reader, sidecar, or agent-key alias is introduced.

## User Impact

Plugin conversations can bind, survive restart, receive model replies, accept control commands, and detach without pretending to belong to an agent. Several conversations may share one target.

Stop older writers and take a verified WAL-aware backup before upgrading. Older builds refuse schema 15; rollback requires the pre-upgrade backup in a separate state directory, not lowering version markers. SQLite column removal rewrites the table, so migration cost scales with binding count. Recovery details are in `docs/reference/database-schemas.md`.

## Evidence

- Before the fix, both real SQLite plugin-binding approval paths failed in `resolveAgentIdFromSessionKey`. Both command regressions also failed: an opaque target caused `SESSION_CANONICAL_KEY_MIGRATION_REQUIRED`; an adopted agent target redirected the command. A third regression reproduces the live invalid-selection reply when command selection binds to webchat but execution uses the originating channel; it also covers Provider-over-Surface precedence. The live test now expects the existing explicit `guarded` permission label after the `default` alias, matching the control owner and its existing tests. The channel E2E also checks actual outbound text and image replies instead of polling agent history for an opaque target: the existing transcript owner deliberately blocks writes and source-history fallback when no agent session owns that target. Deadlines remain unchanged; fresh reply counts and nonce/image assertions remain required.
- Migration tests cover startup and Doctor, duplicate exact targets, expired rows, byte-preserved JSON and additive data, index use, integrity, reopen/idempotence, owner mismatch, and complete rollback after the second column removal fails.
- Isolated cross-version proof uses the actual pre-change v14 source: create a binding and online backup; migrate using candidate source; verify the old opener refuses the migrated DB and accepts the backup; reopen successfully with the candidate.
- Real Codex app-server proof runs on Blacksmith Testbox `tbx_01m177jb8c297z21jegaeqwtkb` ([environment run](https://github.com/openclaw/openclaw/actions/runs/33264582184)), using Codex CLI 0.150.1 and public model `gpt-5.6-luna`. The Slack transport is a harness adapter; Codex authentication and model calls are real. PASS: bind, initial text delivery, status/models/binding, fast mode, permissions, model selection, stop, a fresh text reply after controls, image recognition, detach, and confirmation of no binding. The test took 184.23 seconds; the Docker command completed in 305.98 seconds with exit 0. An earlier lease stopped during execution; this successful run used a fresh lease and verified all 28 changed source hashes before testing.

Production LOC: +63/-37 (net +26); tests: +692/-171 (net +521); generated types: -2; docs: +9. The runtime binding path shrinks; growth is the approved versioned migration, admission/detection, and shared command-channel ownership. Two orphaned Voice Call comments were also removed. No config surface or dependency changed; the package edit only declares state schema 15.

Focused validation: 51 binding/migration tests; 704 state/import/routing tests; 101 lifecycle/catalog tests; 113 command/lifecycle/authority tests; seven Voice Call Doctor tests; 20 Codex conversation-control tests; three existing transcript privacy tests; 53 profile tests; nine audit progress tests, including the pinned historical reader and candidate reopen. These batches overlap. Native schema parity, generated types, formatting, focused lint, and import-cycle checks passed. Independent Codex review reported no P0 findings; owner-boundary review and focused regressions cover the migration and routing behavior. Local full typechecking encountered mismatched shared dependencies; clean Linux core/UI/core-test typechecking passed and exposed the Voice Call exhaustive-switch omission, now corrected. The final clean Linux core and plugin production typechecks both pass; a direct plugin-package invocation initially failed because packaged SDK declarations were not built, so verification used the repository’s canonical plugin typecheck graph. Final exact-head [CI 33269279851](https://github.com/openclaw/openclaw/actions/runs/33269279851) passed on `0e47f765b2a9092094ef17e8bb4636b66e05d7c3`; the PR check rollup has 235 successes, 27 intentional skips, and one neutral check.

Environment follow-up: Testbox checksum-full sync omitted the tracked `pnpm-lock.yaml` because it matches `.gitignore`. The Docker rerun restores the unchanged lock from the verified base commit and checks its SHA-256 plus every changed source file before running. Tracked-but-ignored input preservation in Testbox full sync remains a separate tooling follow-up.

CI follow-up: the first run exposed two historical test assumptions, now corrected: a redundant hard-coded current-version assertion in profile tests, and an audit compatibility fixture that needed the pinned reader’s exact empty binding-table/index shape restored before its existing historical projection. The pinned audit reader and candidate-reopen assertions remain unchanged. Windows checkout timed out before tests, and the dependency guard encountered HTTP 429; these are tracked separately from the test fixes.

The subsequent merge-ref CI also found a newly landed Codex test missing from its owner list. A one-line registration in the existing attempt-extra shard fixed it; all 23 inventory tests passed with the exact main-only file present. That registration independently landed on main in #132743, so this PR removes its duplicate and keeps the full-suite uniqueness assertion unchanged. The same run had a terminated pnpm download and a Chromium target-discovery failure. The unchanged Chromium lane passed both the previous run and the final-head rerun (job 99138022704); no browser assertion or runtime behavior was relaxed.

Named follow-up — browser bootstrap readiness: after restoring all-tab access, the Chromium fixture queries `/tabs` before relay auto-attachment necessarily publishes every target identity. The relay correctly refuses incomplete identity. This timing-sensitive browser path is outside the binding repair; preserve its fail-closed behavior and investigate synchronization at the fixture/attachment boundary if the unchanged lane fails again.

The native macOS suite ran 1,888 tests and found one remaining schema-boundary fixture: it still expected version 15 to be rejected after the reader maximum moved to 15. The fixture now exercises supported versions 4–15 and rejects 16 and 99. Production code is unchanged; native validation runs only on disposable CI workers. The previous Apple jobs were unassigned on Blacksmith, then ran on hosted macOS through the documented per-run retry path; no repository-wide runner settings changed.

Final native proof is green: 1,497 OpenClawKit tests; 1,889 macOS app tests, including the supported/newer schema case; two named-profile tests; and the isolated health fixture. iOS debug/release builds, lifecycle and Apple Watch simulator tests, and iPhone/iPad screenshots also passed. The final run retried only unfinished jobs after Blacksmith macOS queueing; all completed non-Apple results were retained, and no assertion or global CI setting was changed.
