### PR TITLE
fix(plugins): keep concurrent catalog adoption scoped to each agent

### DIFF
--- a/docs/plugins/sdk-entrypoints.md
+++ b/docs/plugins/sdk-entrypoints.md
@@ -171,8 +171,10 @@ export default definePluginEntry({
   CLI-backed catalogs that expose the same local-plus-paired-node shape can use
   `createSessionCatalogFamily(...)`. The family composer owns canonical cursor
   validation, node payload validation, host projection, adopted-session
-  projection, per-host publication, read routing, single-flight continuation,
-  and terminal plan routing. The provider must supply its local store reads,
+  projection, per-host publication, read routing, single-flight continuation
+  per resolved agent and source, and terminal plan routing. Different agents
+  do not share in-flight adoption results; adopted-source lookup keys remain
+  host/thread pairs. The provider must supply its local store reads,
   identifiers and commands, error text, capability projection, continuation
   availability and persistence operations, upstream-activity check, and terminal
   executable/arguments. There are no default continuation, capability-mutation,

--- a/src/plugin-sdk/session-catalog.test.ts
+++ b/src/plugin-sdk/session-catalog.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../test/helpers/promise.js";
 import type { PluginRuntime } from "./plugin-runtime.js";
 import {
   createSessionCatalogFamily,
@@ -53,7 +54,7 @@ describe("session catalog SDK", () => {
     ).toThrow("bad thread");
   });
 
-  it("composes explicit local, node, adoption, capability, and continuation operations", async () => {
+  function createFamilyFixture() {
     const invoke = vi.fn().mockResolvedValue({
       payloadJSON: JSON.stringify({ sessions: [session("remote-thread")] }),
     });
@@ -72,8 +73,12 @@ describe("session catalog SDK", () => {
         invoke,
       },
     } as unknown as PluginRuntime;
-    const create = vi.fn().mockResolvedValue({ sessionKey: "agent:main:created" });
-    const complete = vi.fn(async (continued: { sessionKey: string }) => continued);
+    const create = vi.fn<SessionCatalogFamilyOptions["continuation"]["create"]>(
+      async ({ agentId }) => ({ sessionKey: `agent:${agentId}:created` }),
+    );
+    const complete = vi.fn<SessionCatalogFamilyOptions["continuation"]["complete"]>(
+      async (continued) => continued,
+    );
     const options: SessionCatalogFamilyOptions = {
       runtime,
       local: {
@@ -114,7 +119,7 @@ describe("session catalog SDK", () => {
         sessionUnavailable: "session unavailable",
       },
       continuation: {
-        resolveAgentId: () => "main",
+        resolveAgentId: (agentId = "main") => agentId,
         availability: () => ({ available: true }),
         listAdopted: (_agentId, entries) =>
           entries
@@ -136,6 +141,11 @@ describe("session catalog SDK", () => {
       checkUpstreamActivity: async () => [],
     };
     const provider = createSessionCatalogFamily(options, sessionCatalogPaging.isExactCursor);
+    return { provider, options, create, complete };
+  }
+
+  it("composes explicit local, node, adoption, capability, and continuation operations", async () => {
+    const { provider } = createFamilyFixture();
     const onHost = vi.fn();
 
     const hosts = await provider.list({
@@ -168,13 +178,87 @@ describe("session catalog SDK", () => {
     ]);
     expect(onHost).toHaveBeenCalledTimes(2);
 
-    const [first, second] = await Promise.all([
-      provider.continueSession!({ hostId: "gateway", threadId: "local-thread" }),
-      provider.continueSession!({ hostId: "gateway", threadId: "local-thread" }),
-    ]);
-    expect(first).toEqual({ sessionKey: "agent:main:created" });
-    expect(second).toEqual(first);
-    expect(create).toHaveBeenCalledOnce();
-    expect(complete).toHaveBeenCalledOnce();
+    await expect(
+      provider.continueSession({ hostId: "gateway", threadId: "local-thread" }),
+    ).resolves.toEqual({ sessionKey: "agent:main:created" });
   });
+
+  it.each([
+    { joinDuring: "lookup", firstAgentId: "main", secondAgentId: "main" },
+    { joinDuring: "lookup", firstAgentId: "main", secondAgentId: "other" },
+    { joinDuring: "lookup", firstAgentId: undefined, secondAgentId: "main" },
+    { joinDuring: "completion", firstAgentId: "main", secondAgentId: "main" },
+    { joinDuring: "completion", firstAgentId: "main", secondAgentId: "other" },
+    { joinDuring: "completion", firstAgentId: undefined, secondAgentId: "main" },
+  ])(
+    "coordinates $firstAgentId/$secondAgentId adoption during $joinDuring and reuses stored adoption",
+    async ({ joinDuring, firstAgentId, secondAgentId }) => {
+      const { provider, options, create, complete } = createFamilyFixture();
+      const request = { hostId: "gateway", threadId: "local-thread" };
+      const sourceKey = sessionCatalogAdoptedSourceKey(request.hostId, request.threadId);
+      const adopted = new Map<string, Map<string, string>>();
+      const entered = createDeferred();
+      const release = createDeferred();
+      const secondResolved = createDeferred();
+      let resolutions = 0;
+      options.continuation.resolveAgentId = (agentId = "main") => {
+        if (++resolutions === 2) {
+          secondResolved.resolve();
+        }
+        return agentId;
+      };
+      const listAdopted = vi.fn(async (agentId = "main") => {
+        if (joinDuring === "lookup") {
+          entered.resolve();
+          await release.promise;
+        }
+        return adopted.get(agentId) ?? new Map<string, string>();
+      });
+      options.continuation.listAdopted = listAdopted;
+      create.mockImplementation(async ({ agentId }) => {
+        const sessionKey = `agent:${agentId}:created`;
+        adopted.set(agentId, new Map([[sourceKey, sessionKey]]));
+        return { sessionKey };
+      });
+      complete.mockImplementation(async (continued) => {
+        if (joinDuring === "completion") {
+          entered.resolve();
+          await release.promise;
+        }
+        return continued;
+      });
+
+      const first = provider.continueSession({ ...request, agentId: firstAgentId });
+      await entered.promise;
+      const second = provider.continueSession({ ...request, agentId: secondAgentId });
+      // Resolution is synchronous; the second request enters single-flight before this resumes.
+      await secondResolved.promise;
+      release.resolve();
+      const results = await Promise.all([first, second]);
+
+      expect
+        .soft(results)
+        .toEqual([
+          { sessionKey: "agent:main:created" },
+          { sessionKey: `agent:${secondAgentId}:created` },
+        ]);
+      const agentIds = [...new Set(["main", secondAgentId])];
+      expect.soft(listAdopted.mock.calls).toEqual(agentIds.map((agentId) => [agentId]));
+      expect.soft(create).toHaveBeenCalledTimes(agentIds.length);
+      expect.soft(complete).toHaveBeenCalledTimes(agentIds.length);
+      for (const agentId of agentIds) {
+        const continued = { sessionKey: `agent:${agentId}:created` };
+        expect.soft(create).toHaveBeenCalledWith({
+          ...request,
+          agentId,
+          session: session(request.threadId),
+        });
+        expect.soft(complete).toHaveBeenCalledWith(continued, request.threadId);
+        // Stored source identity stays host/thread-only after the in-flight operation ends.
+        await expect(provider.continueSession({ ...request, agentId })).resolves.toEqual(continued);
+      }
+      expect(create).toHaveBeenCalledTimes(agentIds.length);
+      expect(complete).toHaveBeenCalledTimes(agentIds.length * 2);
+    },
+  );
 });

--- a/src/plugins/session-catalog-family.ts
+++ b/src/plugins/session-catalog-family.ts
@@ -512,8 +512,10 @@ export function createSessionCatalogFamily(
       }
       const agentId = options.continuation.resolveAgentId(request.agentId);
       const sourceKey = sessionCatalogAdoptedSourceKey(request.hostId, request.threadId);
+      // Scope in-flight results to the agent without changing host/thread adoption lookup keys.
+      const operationKey = `${agentId}\0${sourceKey}`;
       return await continueAdoption({
-        sourceKey,
+        sourceKey: operationKey,
         findExisting: async () => (await options.continuation.listAdopted(agentId)).get(sourceKey),
         create: async () => {
           const session = await options.continuation.loadSession(request.threadId);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators continuing the same native CLI catalog thread for two different agents at the same time could receive the first agent's adopted session for both requests. This affects the shared OpenCode/Pi catalog continuation path.

Related: #107215 tracks the broader provider-authoritative identity follow-up; this PR does not close it.

## Why This Change Was Made

The catalog family resolves the destination agent, but previously deduplicated the whole adoption operation by host/thread alone. Qualify that in-flight operation with the resolved agent while retaining the original host/thread key for adopted-session lookup. Same-agent requests still share one operation through completion.

The repair stays at the family operation owner. The generic coordinator, public SDK shapes, source/storage hashes, agent-scoped persistence, and legacy cross-agent existing-session lookup are unchanged. No naming changes, schema/config/protocol changes, migration, or new compatibility path.

Production: +3/-1 (net +2); tests: +96/-12 (net +84); docs: +4/-2 (net +2). The two added production lines name the operation key and explain why it differs from the stored source key. Moving agent policy into the generic coordinator or changing storage identity would broaden the contract without improving this fix.

## User Impact

Different destination agents no longer share an in-flight adoption result. Repeated requests for the same resolved agent—including omitted versus explicit default agent—remain deduplicated until completion, and later requests reuse stored adoption.

Release-note context: fix cross-agent concurrent adoption in the shared native CLI session catalog family. Stable-release exposure has not been established.

AI-assisted with Codex; the implementation and ownership boundary have been inspected by the maintainer's landing worker.

## Evidence

The regression uses the real family and coordinator with explicit injected callbacks. Six table cases cover same/different agents and omitted/explicit default agent, joining during lookup or completion. Before the production fix, two cross-agent cases failed and six tests passed; after the fix, all eight passed. No production test seam was added.

Previously completed local proof:

```sh
node scripts/run-vitest.mjs src/plugin-sdk/session-catalog.test.ts src/plugins/session-catalog.test.ts extensions/acpx/src/pi-session-catalog-continuation.test.ts extensions/acpx/src/pi-session-catalog-node.test.ts extensions/opencode/session-catalog.test.ts extensions/anthropic/session-catalog.test.ts extensions/codex/src/session-catalog-adoption.test.ts extensions/codex/src/session-catalog-node-continue.test.ts src/gateway/server-methods/session-catalog-visibility.test.ts src/plugins/runtime/runtime-agent.acp-binding.test.ts --reporter=verbose
node scripts/check-changed.mjs -- src/plugins/session-catalog-family.ts src/plugin-sdk/session-catalog.test.ts docs/plugins/sdk-entrypoints.md
```

The first command passed 149 tests across 10 files/7 shards. The changed gate passed production/test types, lint, and SDK, deadcode, boundary, storage, and import guards. A first test-only type failure from `Promise.withResolvers` was fixed by using the existing `createDeferred` helper; compiler settings were not changed. Fresh isolated autoreview before commit reported no accepted/actionable findings.

The repair was cleanly rebased onto current main, preserving the separately landed native-title naming change. At head `d4248cc3f81ba49c1e3cae87ea49a14be56d779c`, post-rebase `node scripts/run-vitest.mjs src/plugin-sdk/session-catalog.test.ts extensions/opencode/session-catalog.test.ts --reporter=verbose` passed 26 tests in two files. Fresh isolated branch autoreview was clean again.

Codex sibling review: personally inspected upstream commit `92cbfb4d2431bdc53dc03507aea2dc5b8e932e40`, `codex-rs/app-server-protocol/src/protocol/v2/thread.rs:1473` and `codex-rs/app-server/src/request_processors/thread_processor.rs:2312`. OpenClaw's Codex local/node paths already qualify operation identity by agent while retaining source-scoped native action locks; Anthropic also has an agent-qualified operation key.

**Live Gateway/Control UI proof passed:** the documented Manual RPC panel issued three overlapping same-source continuations (`main`, `other`, duplicate `main`) through the real OpenCode catalog family. Results, one stored adoption per agent, and two correctly scoped upstream links were verified. [Inspected screenshots, recordings, and the redacted trace](https://github.com/openclaw/openclaw/pull/132734#issuecomment-5464166198) are attached in the verification comment. No handler mocks, route interception, provider credentials, or model inference were used. Pre-fix evidence is the failing real-family regression; the recordings show the repaired live flow.

The live Gateway/UI were built from `d4248cc3f81ba49c1e3cae87ea49a14be56d779c`. The current head `24d016776675d1f9dfa7647b6ff8dca1558a9bd4` is a patch-identical rebase through [the merged CI test-registration repair #132743](https://github.com/openclaw/openclaw/pull/132743); the catalog owner, Gateway, config, agent, OpenCode/ACPX, relevant UI, and protocol source is byte-identical. [Exact-head CI run 33267750911 passed](https://github.com/openclaw/openclaw/actions/runs/33267750911), and fresh isolated autoreview is clean.

The local dependency refresh (`pnpm install --frozen-lockfile`) followed by `pnpm build` resolved the earlier Teams Cards build failure. Earlier Testbox/sidebar attempts are not counted as proof. The final ownership-map test passed 23/23; a later local catalog collection stalled and was stopped without claiming a pass, while exact-head hosted CI passed the complete gate. Source remains +2 production lines for the operation/source identity distinction, with no persisted data-model or schema change.
