### PR TITLE
fix(test): preserve process fixture failures during cleanup

### DIFF
--- a/test/scripts/process-fixture-cleanup.test.ts
+++ b/test/scripts/process-fixture-cleanup.test.ts
@@ -1,0 +1,208 @@
+import { EventEmitter } from "node:events";
+import { PassThrough } from "node:stream";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const fixtures = [
+  { owner: "setup", name: "forwards output and SIGTERM through the runner process group" },
+  { owner: "timeout", name: "cleans timeout descendants before resolving the case" },
+  { owner: "parent", name: "cleans active case descendants on parent signal" },
+] as const;
+
+afterEach(() => {
+  for (const module of [
+    "vitest",
+    "node:fs",
+    "node:child_process",
+    "../../scripts/profile-extension-memory.mts",
+    "../../scripts/lib/vitest-build-prerequisites.mts",
+    "../helpers/promise.js",
+  ]) {
+    vi.doUnmock(module);
+  }
+  vi.restoreAllMocks();
+  vi.resetModules();
+});
+
+function errorTree(error: unknown): unknown[] {
+  if (error instanceof AggregateError) {
+    return error.errors.flatMap(errorTree);
+  }
+  return error instanceof Error && error.cause ? [error, ...errorTree(error.cause)] : [error];
+}
+
+async function captureFixture(owner: (typeof fixtures)[number]["owner"]) {
+  vi.resetModules();
+  const bodies = new Map<string, () => Promise<void>>();
+  const register = (name: string, body: () => Promise<void>) => bodies.set(name, body);
+  vi.doMock("vitest", () => ({
+    describe: (_name: string, body: () => void) => body(),
+    it: Object.assign(register, { each: () => () => {}, runIf: () => register, skip: register }),
+    expect,
+    vi,
+  }));
+  if (owner === "setup") {
+    await import("./vitest-e2e-global-setup.test.js");
+  } else {
+    await import("./profile-extension-memory.test.js");
+  }
+  const fixture = fixtures.find((entry) => entry.owner === owner)!;
+  const body = bodies.get(fixture.name);
+  expect(body, fixture.name).toBeTypeOf("function");
+  return body!;
+}
+
+// Execute the registered process fixtures, injecting OS faults at their real
+// dependencies. No extracted copy of the cleanup implementation is exercised.
+describe.skipIf(process.platform === "win32")("process fixture cleanup faults", () => {
+  it.each(
+    fixtures.flatMap(({ owner, name }) =>
+      ["EPERM", "ESRCH"].map((code) => ({ owner, name, code })),
+    ),
+  )("preserves failures and finishes safe $owner cleanup after $code", async ({ owner, code }) => {
+    const primary = new Error("fixture assertion failed");
+    const denied = Object.assign(new Error("injected kill failure"), { code });
+    const scratchError = new Error("scratch removal failed");
+    const leader = 81001;
+    const descendants = owner === "setup" ? [81002, 81003] : [81003];
+    const alive = new Set([leader, ...descendants]);
+    let parentSignaled = false;
+    const events: string[] = [];
+    const child = Object.assign(new EventEmitter(), {
+      pid: leader,
+      exitCode: null as number | null,
+      signalCode: null as NodeJS.Signals | null,
+      stdin: new PassThrough(),
+      stdout: new PassThrough(),
+      stderr: new PassThrough(),
+    });
+    const close = () => {
+      alive.delete(leader);
+      child.signalCode = "SIGKILL";
+      child.emit("exit", null, "SIGKILL");
+      events.push("close");
+      child.emit("close", null, "SIGKILL");
+    };
+    const fs = {
+      mkdtempSync: () => "/fixture",
+      mkdirSync: () => {},
+      writeFileSync: () => {},
+      existsSync: () => true,
+      readFileSync: (file: string) =>
+        String(file.endsWith("child.pid") ? descendants[0] : descendants.at(-1)),
+      rmSync: () => {
+        events.push("scratch");
+        if (owner === "setup" && code === "EPERM") {
+          throw scratchError;
+        }
+      },
+    };
+    vi.doMock("node:fs", () => ({ ...fs, default: fs }));
+    vi.doMock("node:child_process", () => ({
+      spawn: () => {
+        setImmediate(() => child.emit("spawn"));
+        return child;
+      },
+    }));
+    vi.doMock("../../scripts/lib/vitest-build-prerequisites.mts", () => ({}));
+    vi.doMock("../../scripts/profile-extension-memory.mts", () => ({
+      runCase: async () => {
+        throw primary;
+      },
+    }));
+    const { withTestTimeout } = await import("../helpers/promise.js");
+    vi.doMock("../helpers/promise.js", () => ({
+      // Keep the real deadline owner; shorten only this injected never-closing child.
+      withTestTimeout: (promise: PromiseLike<unknown>, ms: number, message: string) =>
+        withTestTimeout(promise, owner === "parent" && code === "EPERM" ? 20 : ms, message),
+    }));
+    vi.spyOn(vi, "waitFor").mockRejectedValue(primary);
+    vi.spyOn(process, "kill").mockImplementation((pid, signal) => {
+      if (signal === 0) {
+        const groupPids = [leader, ...descendants];
+        if (pid < 0 ? groupPids.some((member) => alive.has(member)) : alive.has(pid)) {
+          return true;
+        }
+        throw Object.assign(new Error("gone"), { code: "ESRCH" });
+      }
+      events.push(`kill:${pid}`);
+      if (signal === "SIGTERM" && !parentSignaled) {
+        parentSignaled = true;
+        throw primary;
+      }
+      const deniedTarget =
+        owner === "setup" ? descendants[0] : owner === "timeout" ? -leader : leader;
+      if (pid === deniedTarget) {
+        if (code === "ESRCH") {
+          alive.delete(Math.abs(pid));
+          if (pid < 0) {
+            alive.clear();
+          }
+          if (Math.abs(pid) === leader) {
+            setImmediate(close);
+          }
+        }
+        throw denied;
+      }
+      if (pid === -leader) {
+        setImmediate(() => {
+          alive.clear();
+          close();
+        });
+      } else {
+        alive.delete(pid);
+        if (pid === leader) {
+          setImmediate(close);
+        }
+      }
+      return true;
+    });
+
+    const body = await captureFixture(owner);
+    const failure: unknown = await body().catch((error: unknown) => error);
+    expect(errorTree(failure)).toContain(primary);
+    if (code === "EPERM") {
+      expect(errorTree(failure)).toContain(denied);
+    } else {
+      expect(failure).not.toBeInstanceOf(AggregateError);
+      if (owner !== "timeout") {
+        expect(failure).toBe(primary);
+      }
+    }
+    if (owner === "setup" && code === "EPERM") {
+      expect(errorTree(failure)).toContain(scratchError);
+    }
+    if (code === "EPERM") {
+      expect(events).toContain(`kill:${descendants.at(-1)}`);
+    }
+    if (owner === "parent" && code === "EPERM") {
+      expect(events).not.toContain("scratch");
+      expect(errorTree(failure)).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ message: expect.stringContaining("close") }),
+        ]),
+      );
+    } else {
+      expect(events.indexOf("close")).toBeGreaterThan(-1);
+      expect(events.indexOf("scratch")).toBeGreaterThan(events.indexOf("close"));
+    }
+  });
+
+  it("removes setup scratch after a fixture write fails before spawn", async () => {
+    const primary = new Error("fixture write failed");
+    const rmSync = vi.fn();
+    const fs = {
+      mkdtempSync: () => "/fixture",
+      mkdirSync: () => {},
+      writeFileSync: () => {
+        throw primary;
+      },
+      existsSync: () => false,
+      rmSync,
+    };
+    vi.doMock("node:fs", () => ({ ...fs, default: fs }));
+    vi.doMock("../../scripts/lib/vitest-build-prerequisites.mts", () => ({}));
+    const body = await captureFixture("setup");
+    await expect(body()).rejects.toBe(primary);
+    expect(rmSync).toHaveBeenCalledWith("/fixture", { force: true, recursive: true });
+  });
+});

--- a/test/scripts/profile-extension-memory.test.ts
+++ b/test/scripts/profile-extension-memory.test.ts
@@ -14,33 +14,19 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { describe, expect, it } from "vitest";
+import {
+  inspectManagedProcessGroup,
+  waitForManagedProcessGroupExit,
+} from "../../scripts/lib/managed-child-process.mts";
 import { parseArgs, runCase } from "../../scripts/profile-extension-memory.mts";
+import { killPidIfAlive } from "../../src/test-utils/process-tree.js";
+import { isProcessAlive, waitForDead, waitForPidFile } from "../helpers/process-wait.js";
+import { withTestTimeout } from "../helpers/promise.js";
+import { runQaGatewayFixture } from "../helpers/qa-gateway-cleanup.js";
 
 const SCRIPT_PATH = path.resolve("scripts/profile-extension-memory.mts");
 const TSX_PRELOAD = path.resolve("scripts/tsx.mjs");
 const SOURCE_TSCONFIG_PATH = path.resolve("tsconfig.json");
-
-async function waitForCondition(predicate: () => boolean, timeoutMs = 5_000): Promise<void> {
-  const started = Date.now();
-  while (Date.now() - started < timeoutMs) {
-    if (predicate()) {
-      return;
-    }
-    await new Promise((resolve) => {
-      setTimeout(resolve, 10);
-    });
-  }
-  throw new Error("timed out waiting for condition");
-}
-
-function isProcessAlive(pid: number): boolean {
-  try {
-    process.kill(pid, 0);
-    return true;
-  } catch {
-    return false;
-  }
-}
 
 function runProfileExtensionMemory(args: string[], cwd = process.cwd()) {
   return spawnSync(process.execPath, ["--import", TSX_PRELOAD, SCRIPT_PATH, ...args], {
@@ -60,27 +46,75 @@ function extractReportPath(stdout: string) {
   return reportPath;
 }
 
-async function waitForChildExit(
+async function cleanupProfileFixture(
+  root: string,
   child: ReturnType<typeof spawn>,
-  timeoutMs = 8_000,
-): Promise<{ status: number | null; signal: NodeJS.Signals | null }> {
-  let timer: ReturnType<typeof setTimeout> | undefined;
-  try {
-    return await Promise.race([
-      new Promise<{ status: number | null; signal: NodeJS.Signals | null }>((resolve, reject) => {
-        child.once("error", reject);
-        child.once("exit", (status, signal) => resolve({ status, signal }));
-      }),
-      new Promise<never>((_, reject) => {
-        timer = setTimeout(() => reject(new Error("timed out waiting for child exit")), timeoutMs);
-        timer.unref?.();
-      }),
-    ]);
-  } finally {
-    if (timer) {
-      clearTimeout(timer);
-    }
-  }
+  closed: Promise<unknown>,
+  descendantPidPath: string,
+  detached = true,
+): Promise<void> {
+  let childClosed = false;
+  let descendantPid: number | undefined;
+  await runQaGatewayFixture(
+    async () => {
+      if (!child.pid || (!detached && (child.exitCode !== null || child.signalCode !== null))) {
+        return;
+      }
+      try {
+        // The non-detached runner owns its case groups: let its SIGTERM handler
+        // stop them before exit instead of orphaning them with SIGKILL.
+        process.kill(detached ? -child.pid : child.pid, detached ? "SIGKILL" : "SIGTERM");
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== "ESRCH") {
+          throw error;
+        }
+      }
+    },
+    () => {
+      if (detached) {
+        killPidIfAlive(child.pid);
+      }
+    },
+    async () => {
+      await withTestTimeout(
+        closed,
+        5_000,
+        `profile child did not close; retained fixture: ${root}`,
+      );
+      childClosed = true;
+    },
+    async () => {
+      if (!existsSync(descendantPidPath)) {
+        return;
+      }
+      descendantPid = await waitForPidFile(descendantPidPath, 5_000);
+      killPidIfAlive(descendantPid);
+    },
+    async () => {
+      // A failed signal is not proof of exit. Retain PID files until the owned
+      // processes and the child's output are verified stopped.
+      await runQaGatewayFixture(
+        async () => {
+          if (descendantPid) {
+            await waitForDead(descendantPid, 5_000);
+          }
+        },
+        async () => {
+          if (!detached || !child.pid) {
+            return;
+          }
+          await waitForManagedProcessGroupExit(child, 5_000, { errorPolicy: "indeterminate" });
+          expect(
+            inspectManagedProcessGroup(child, { errorPolicy: "indeterminate" }),
+            `retained fixture: ${root}`,
+          ).toBe("dead");
+        },
+      );
+      if (childClosed) {
+        rmSync(root, { recursive: true, force: true });
+      }
+    },
+  );
 }
 
 describe("scripts/profile-extension-memory", () => {
@@ -392,40 +426,35 @@ describe("scripts/profile-extension-memory", () => {
       const root = mkdtempSync(path.join(tmpdir(), "openclaw-extension-memory-timeout-"));
       const hookPath = path.join(root, "rss-hook.mjs");
       const descendantPidPath = path.join(root, "descendant.pid");
-      let descendantPid = 0;
-      try {
-        writeFileSync(hookPath, "", "utf8");
-        const descendantScript = [
-          "import { writeFileSync } from 'node:fs';",
-          "process.on('SIGTERM', () => {});",
-          "setInterval(() => {}, 1000);",
-          `writeFileSync(${JSON.stringify(descendantPidPath)}, String(process.pid));`,
-        ].join("");
-        const body = [
-          "const childProcess = await import('node:child_process');",
-          "childProcess.spawn(process.execPath, [",
-          "  '--input-type=module',",
-          `  '--eval', ${JSON.stringify(descendantScript)},`,
-          "], { stdio: 'ignore' });",
-          "setInterval(() => {}, 1000);",
-        ].join("\n");
-        const child = spawn(
-          process.execPath,
-          ["--import", hookPath, "--input-type=module", "--eval", body],
-          { cwd: root, detached: true, env: process.env, stdio: ["ignore", "pipe", "pipe"] },
-        );
-        const childClosed = new Promise<void>((resolve) => {
-          child.once("close", () => resolve());
-        });
-        try {
-          await once(child, "spawn");
-          await waitForCondition(() => {
-            if (!existsSync(descendantPidPath)) {
-              return false;
-            }
-            descendantPid = Number.parseInt(readFileSync(descendantPidPath, "utf8"), 10);
-            return Number.isInteger(descendantPid) && descendantPid > 0;
+      let cleanup = async () => rmSync(root, { recursive: true, force: true });
+      await runQaGatewayFixture(
+        async () => {
+          writeFileSync(hookPath, "", "utf8");
+          const descendantScript = [
+            "import { writeFileSync } from 'node:fs';",
+            "process.on('SIGTERM', () => {});",
+            "setInterval(() => {}, 1000);",
+            `writeFileSync(${JSON.stringify(descendantPidPath)}, String(process.pid));`,
+          ].join("");
+          const body = [
+            "const childProcess = await import('node:child_process');",
+            "childProcess.spawn(process.execPath, [",
+            "  '--input-type=module',",
+            `  '--eval', ${JSON.stringify(descendantScript)},`,
+            "], { stdio: 'ignore' });",
+            "setInterval(() => {}, 1000);",
+          ].join("\n");
+          const child = spawn(
+            process.execPath,
+            ["--import", hookPath, "--input-type=module", "--eval", body],
+            { cwd: root, detached: true, env: process.env, stdio: ["ignore", "pipe", "pipe"] },
+          );
+          const childClosed = new Promise<void>((resolve) => {
+            child.once("close", () => resolve());
           });
+          cleanup = () => cleanupProfileFixture(root, child, childClosed, descendantPidPath);
+          await once(child, "spawn");
+          const descendantPid = await waitForPidFile(descendantPidPath, 5_000);
           expect(Number.isInteger(descendantPid)).toBe(true);
           expect(isProcessAlive(descendantPid)).toBe(true);
 
@@ -445,25 +474,10 @@ describe("scripts/profile-extension-memory", () => {
             signal: "SIGKILL",
             timedOut: true,
           });
-          await waitForCondition(() => !isProcessAlive(descendantPid));
-        } finally {
-          if (child.pid) {
-            try {
-              process.kill(-child.pid, "SIGKILL");
-            } catch (error) {
-              if (!(error instanceof Error && "code" in error && error.code === "ESRCH")) {
-                throw error;
-              }
-            }
-          }
-          await childClosed;
-        }
-      } finally {
-        if (descendantPid && isProcessAlive(descendantPid)) {
-          process.kill(descendantPid, "SIGKILL");
-        }
-        rmSync(root, { recursive: true, force: true });
-      }
+          await waitForDead(descendantPid, 5_000);
+        },
+        () => cleanup(),
+      );
     },
   );
 
@@ -474,74 +488,65 @@ describe("scripts/profile-extension-memory", () => {
       const hookPath = path.join(root, "rss-hook.mjs");
       const runnerPath = path.join(root, "parent-signal-runner.mjs");
       const descendantPidPath = path.join(root, "descendant.pid");
-      let descendantPid = 0;
-      try {
-        writeFileSync(hookPath, "", "utf8");
-        const descendantScript = [
-          "process.on('SIGTERM', () => {});",
-          "setInterval(() => {}, 1000);",
-        ].join("");
-        const body = [
-          "const childProcess = await import('node:child_process');",
-          "const fs = await import('node:fs');",
-          "const descendant = childProcess.spawn(process.execPath, [",
-          "  '--input-type=module',",
-          `  '--eval', ${JSON.stringify(descendantScript)},`,
-          "], { stdio: 'ignore' });",
-          `fs.writeFileSync(${JSON.stringify(descendantPidPath)}, String(descendant.pid));`,
-          "setInterval(() => {}, 1000);",
-        ].join("\n");
-        writeFileSync(
-          runnerPath,
-          [
-            `const { runCase } = await import(${JSON.stringify(
-              pathToFileURL(path.resolve("scripts/profile-extension-memory.mts")).href,
-            )});`,
-            "void runCase({",
-            `  body: ${JSON.stringify(body)},`,
-            "  env: process.env,",
-            `  hookPath: ${JSON.stringify(hookPath)},`,
-            "  name: 'parent-signal-descendant',",
-            `  repoRoot: ${JSON.stringify(root)},`,
-            "  shutdownGraceMs: 100,",
-            "  timeoutMs: 30000,",
-            "});",
-          ].join("\n"),
-          "utf8",
-        );
-        const runner = spawn(process.execPath, ["--import", TSX_PRELOAD, runnerPath], {
-          stdio: "ignore",
-        });
-
-        try {
-          await waitForCondition(() => {
-            if (!existsSync(descendantPidPath)) {
-              return false;
-            }
-            const candidatePid = Number.parseInt(readFileSync(descendantPidPath, "utf8"), 10);
-            if (!Number.isInteger(candidatePid) || candidatePid <= 0) {
-              return false;
-            }
-            descendantPid = candidatePid;
-            return true;
+      let cleanup = async () => rmSync(root, { recursive: true, force: true });
+      await runQaGatewayFixture(
+        async () => {
+          writeFileSync(hookPath, "", "utf8");
+          const descendantScript = [
+            "process.on('SIGTERM', () => {});",
+            "setInterval(() => {}, 1000);",
+          ].join("");
+          const body = [
+            "const childProcess = await import('node:child_process');",
+            "const fs = await import('node:fs');",
+            "const descendant = childProcess.spawn(process.execPath, [",
+            "  '--input-type=module',",
+            `  '--eval', ${JSON.stringify(descendantScript)},`,
+            "], { stdio: 'ignore' });",
+            `fs.writeFileSync(${JSON.stringify(descendantPidPath)}, String(descendant.pid));`,
+            "setInterval(() => {}, 1000);",
+          ].join("\n");
+          writeFileSync(
+            runnerPath,
+            [
+              `const { runCase } = await import(${JSON.stringify(
+                pathToFileURL(path.resolve("scripts/profile-extension-memory.mts")).href,
+              )});`,
+              "void runCase({",
+              `  body: ${JSON.stringify(body)},`,
+              "  env: process.env,",
+              `  hookPath: ${JSON.stringify(hookPath)},`,
+              "  name: 'parent-signal-descendant',",
+              `  repoRoot: ${JSON.stringify(root)},`,
+              "  shutdownGraceMs: 100,",
+              "  timeoutMs: 30000,",
+              "});",
+            ].join("\n"),
+            "utf8",
+          );
+          const runner = spawn(process.execPath, ["--import", TSX_PRELOAD, runnerPath], {
+            stdio: "ignore",
           });
+
+          const runnerClosed = new Promise<{ code: number | null; signal: NodeJS.Signals | null }>(
+            (resolve) => {
+              runner.once("close", (code, signal) => resolve({ code, signal }));
+            },
+          );
+          cleanup = () =>
+            cleanupProfileFixture(root, runner, runnerClosed, descendantPidPath, false);
+          await once(runner, "spawn");
+          const descendantPid = await waitForPidFile(descendantPidPath, 5_000);
           expect(isProcessAlive(descendantPid)).toBe(true);
 
-          const runnerExit = waitForChildExit(runner);
           process.kill(runner.pid!, "SIGTERM");
-          await expect(runnerExit).resolves.toEqual({ status: 143, signal: null });
-          await waitForCondition(() => !isProcessAlive(descendantPid));
-        } finally {
-          if (runner.pid && isProcessAlive(runner.pid)) {
-            process.kill(runner.pid, "SIGKILL");
-          }
-        }
-      } finally {
-        if (descendantPid && isProcessAlive(descendantPid)) {
-          process.kill(descendantPid, "SIGKILL");
-        }
-        rmSync(root, { recursive: true, force: true });
-      }
+          await expect(
+            withTestTimeout(runnerClosed, 8_000, "profile runner did not close"),
+          ).resolves.toEqual({ code: 143, signal: null });
+          await waitForDead(descendantPid, 5_000);
+        },
+        () => cleanup(),
+      );
     },
   );
 });

--- a/test/scripts/vitest-e2e-global-setup.test.ts
+++ b/test/scripts/vitest-e2e-global-setup.test.ts
@@ -1,14 +1,19 @@
 import { spawn } from "node:child_process";
+import { once } from "node:events";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
-import { runE2eGlobalSetup } from "../../scripts/lib/vitest-build-prerequisites.mts";
 import {
-  forceKillVitestProcessGroup,
-  forwardSignalToVitestProcessGroup,
-} from "../../scripts/vitest-process-group.mts";
-import { waitForChildClose, waitForDead, waitForPidFile } from "../helpers/process-wait.js";
+  inspectManagedProcessGroup,
+  waitForManagedProcessGroupExit,
+} from "../../scripts/lib/managed-child-process.mts";
+import { runE2eGlobalSetup } from "../../scripts/lib/vitest-build-prerequisites.mts";
+import { forwardSignalToVitestProcessGroup } from "../../scripts/vitest-process-group.mts";
+import { killPidIfAlive } from "../../src/test-utils/process-tree.js";
+import { waitForDead, waitForPidFile } from "../helpers/process-wait.js";
+import { withTestTimeout } from "../helpers/promise.js";
+import { runQaGatewayFixture } from "../helpers/qa-gateway-cleanup.js";
 
 type SetupCommandRunner = NonNullable<Parameters<typeof runE2eGlobalSetup>[0]>;
 
@@ -71,10 +76,13 @@ describe("vitest E2E global setup", () => {
     const fixtureDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-e2e-setup-group-"));
     const fixturePath = path.join(fixtureDir, "scripts", "run-node.mjs");
     const pidPaths = ["child.pid", "descendant.pid"].map((name) => path.join(fixtureDir, name));
-    fs.mkdirSync(path.dirname(fixturePath), { recursive: true });
-    fs.writeFileSync(
-      fixturePath,
-      `import { spawn } from "node:child_process";
+    let cleanup = async () => fs.rmSync(fixtureDir, { force: true, recursive: true });
+    await runQaGatewayFixture(
+      async () => {
+        fs.mkdirSync(path.dirname(fixturePath), { recursive: true });
+        fs.writeFileSync(
+          fixturePath,
+          `import { spawn } from "node:child_process";
 import fs from "node:fs";
 process.stdin.once("data", () => {
   const descendant = spawn(process.execPath, ["-e", "setInterval(() => {}, 1000)"], { stdio: "ignore" });
@@ -86,54 +94,104 @@ process.stdin.once("data", () => {
 });
 process.stdin.resume();
 `,
-    );
-    const setupUrl = new URL("../../scripts/lib/vitest-build-prerequisites.mts", import.meta.url)
-      .href;
-    const runnerScript = `import { runE2eGlobalSetup } from ${JSON.stringify(setupUrl)};
+        );
+        const setupUrl = new URL(
+          "../../scripts/lib/vitest-build-prerequisites.mts",
+          import.meta.url,
+        ).href;
+        const runnerScript = `import { runE2eGlobalSetup } from ${JSON.stringify(setupUrl)};
 process.chdir(${JSON.stringify(fixtureDir)});
 await runE2eGlobalSetup(undefined, process.env);`;
-    const runner = spawn(
-      process.execPath,
-      ["--import", "tsx", "--input-type=module", "--eval", runnerScript],
-      { detached: true, stdio: ["pipe", "pipe", "pipe"] },
-    );
-    const pids: number[] = [];
-    let stdout = "";
-    let stderr = "";
-    runner.stdout.setEncoding("utf8").on("data", (chunk) => (stdout += chunk));
-    runner.stderr.setEncoding("utf8").on("data", (chunk) => (stderr += chunk));
+        const runner = spawn(
+          process.execPath,
+          ["--import", "tsx", "--input-type=module", "--eval", runnerScript],
+          { detached: true, stdio: ["pipe", "pipe", "pipe"] },
+        );
+        const closed = new Promise<{ code: number | null; signal: NodeJS.Signals | null }>(
+          (resolve) => {
+            runner.once("close", (code, signal) => resolve({ code, signal }));
+          },
+        );
+        const pids: number[] = [];
+        cleanup = () =>
+          runQaGatewayFixture(
+            async () => {
+              if (!runner.pid) {
+                return;
+              }
+              try {
+                process.kill(-runner.pid, "SIGKILL");
+              } catch (error) {
+                if ((error as NodeJS.ErrnoException).code !== "ESRCH") {
+                  throw error;
+                }
+              }
+            },
+            () => killPidIfAlive(runner.pid),
+            ...pidPaths.map((file) => async () => {
+              if (!fs.existsSync(file)) {
+                return;
+              }
+              const pid = await waitForPidFile(file, PROCESS_TIMEOUT_MS);
+              killPidIfAlive(pid);
+            }),
+            async () => {
+              // Keep PID evidence unless every process and its output have finished.
+              await runQaGatewayFixture(
+                async () => {
+                  await withTestTimeout(
+                    closed,
+                    PROCESS_TIMEOUT_MS,
+                    `runner did not close; retained fixture: ${fixtureDir}`,
+                  );
+                },
+                async () => {
+                  if (!runner.pid) {
+                    return;
+                  }
+                  await waitForManagedProcessGroupExit(runner, PROCESS_TIMEOUT_MS, {
+                    errorPolicy: "indeterminate",
+                  });
+                  expect(
+                    inspectManagedProcessGroup(runner, { errorPolicy: "indeterminate" }),
+                    `retained fixture: ${fixtureDir}`,
+                  ).toBe("dead");
+                },
+              );
+              fs.rmSync(fixtureDir, { force: true, recursive: true });
+            },
+          );
+        await once(runner, "spawn");
+        let stdout = "";
+        let stderr = "";
+        runner.stdout.setEncoding("utf8").on("data", (chunk) => (stdout += chunk));
+        runner.stderr.setEncoding("utf8").on("data", (chunk) => (stderr += chunk));
 
-    try {
-      runner.stdin.write("start\n");
-      pids.push(
-        ...(await Promise.all(pidPaths.map((file) => waitForPidFile(file, PROCESS_TIMEOUT_MS)))),
-      );
-      await vi.waitFor(() => {
-        expect(stdout).toContain("setup-stdout");
-        expect(stderr).toContain("setup-stderr");
-      });
-      const closed = waitForChildClose(runner, PROCESS_TIMEOUT_MS);
-      expect(
-        forwardSignalToVitestProcessGroup({
-          child: runner,
-          kill: process.kill.bind(process),
-          signal: "SIGTERM",
-        }),
-      ).toBe(true);
-      await expect(closed).resolves.toEqual({ code: null, signal: "SIGTERM" });
-      await Promise.all(pids.map((pid) => waitForDead(pid, PROCESS_TIMEOUT_MS)));
-    } finally {
-      forceKillVitestProcessGroup(runner);
-      for (const pid of pids) {
-        try {
-          process.kill(pid, "SIGKILL");
-        } catch (error) {
-          if ((error as NodeJS.ErrnoException).code !== "ESRCH") {
-            throw error;
-          }
+        runner.stdin.write("start\n");
+        for (const file of pidPaths) {
+          pids.push(await waitForPidFile(file, PROCESS_TIMEOUT_MS));
         }
-      }
-      fs.rmSync(fixtureDir, { force: true, recursive: true });
-    }
+        await vi.waitFor(() => {
+          expect(stdout).toContain("setup-stdout");
+          expect(stderr).toContain("setup-stderr");
+        });
+        expect(
+          forwardSignalToVitestProcessGroup({
+            child: runner,
+            kill: process.kill.bind(process),
+            signal: "SIGTERM",
+          }),
+        ).toBe(true);
+        await expect(
+          withTestTimeout(
+            closed,
+            PROCESS_TIMEOUT_MS,
+            `runner did not close; retained fixture: ${fixtureDir}`,
+          ),
+        ).resolves.toEqual({ code: null, signal: "SIGTERM" });
+        await Promise.all(pids.map((pid) => waitForDead(pid, PROCESS_TIMEOUT_MS)));
+      },
+      () => cleanup(),
+    );
   });
 });


### PR DESCRIPTION
Related: [oxlint 1.79 migration](https://github.com/openclaw/openclaw/pull/132682). This is the separately requested process-test cleanup follow-up, not an expansion of that migration or its lint enforcement.

## What Problem This Solves

Resolves a problem where developers running process-fixture tests can lose the original assertion/setup failure when teardown also fails. A non-`ESRCH` kill error thrown from `finally` replaced the original failure and prevented later cleanup. Setup failures before spawning could also leave scratch behind.

The affected boundaries are the E2E setup runner's output/SIGTERM test and the plugin-memory profiler's timeout-descendant and parent-signal tests. Fault injection demonstrates these paths; this PR does not claim an observed operating-system permission incident.

## Why This Change Was Made

Reuse the existing `runQaGatewayFixture` error-composition owner instead of another cleanup framework. The three fixtures retain body and cleanup errors, attempt later safe teardown phases, and delete scratch only after child/output and applicable process-group completion are verified. A parent runner receives SIGTERM so its existing runtime owner can close its case groups; detached case leaders retain group termination. Child-close waits use the existing bounded timeout helper rather than an unbounded promise.

The cleanup starts at scratch acquisition, including pre-spawn failures. Duplicate local polling, liveness, and exit helpers are removed in favor of existing test/process helpers. Existing output-forwarding, SIGTERM, timeout-descendant, and parent-signal assertions remain intact. The new regression imports and executes the actual registered fixtures with injected OS/filesystem faults; it does not test copied cleanup snippets.

The explicit rethrow paths are present in the [Automations cleanup follow-through](https://github.com/openclaw/openclaw/pull/127198) and [package-local memory-profiler repair](https://github.com/openclaw/openclaw/pull/131538). Raw-parent patches and current source were inspected. These are preexisting fixture faults, not oxlint upgrade regressions.

## User Impact

No product runtime or visual behavior changes. Test failures retain their original diagnostics while safe cleanup continues; unverified termination keeps fixture evidence for recovery. No dependencies, runtime APIs, rules, lint targets, ignores, suppressions, baselines, assertion thresholds, or changelog entries change. The 234 unchanged supplemental lint findings remain outside this PR.

Production/tooling LOC: **+0/-0**. Tests/test support: **+483/-212 (net +271)** across three files; the new seven-case regression is 208 lines, while the two existing fixtures grow by a combined 63 lines. No new production seam or shared helper is introduced.

## Evidence

Before repair, the initial four fault cases fail against the old owners: all three process fixtures surface only the injected kill error instead of the primary failure, and the early setup-write case never removes scratch. After repair, the seven-case regression passes, covering `EPERM`, `ESRCH`, combined body/kill/filesystem errors, a never-closing parent with retained scratch, and pre-spawn setup failure.

The parent independently reran the final owner and real-process tests: **38 passed across four files**, including all seven fault cases:

```bash
node scripts/run-vitest.mjs test/scripts/process-fixture-cleanup.test.ts test/scripts/profile-extension-memory.test.ts test/scripts/vitest-e2e-global-setup.test.ts test/helpers/qa-gateway-cleanup.test.ts
```

Broader process-group/managed-child/helper coverage also passed **125 tests**, with one Linux-only test skipped on macOS. Final root-test typechecking, targeted type-aware lint of the changed files, formatting, and `git diff --check` pass. The changed gate passed with its existing test-root/tooling routing:

```bash
node scripts/check-changed.mjs -- test/scripts/process-fixture-cleanup.test.ts test/scripts/vitest-e2e-global-setup.test.ts test/scripts/profile-extension-memory.test.ts
```

One earlier proof attempt failed resolving `typebox/guard`; the allowed `pnpm install` reported the lockfile up to date and changed no pins. The Node 24 retry and subsequent final proof passed; the original resolution failure's cause remains unestablished.

Local real-process proof is macOS. Permission failures are injected; no live provider/channel flow, full product build, or full behavioral suite is claimed. Hosted PR CI supplies exact-head Linux proof. No screenshot is applicable to this test-only repair.

AI-assisted with Codex; reviewed against the actual fixture and process/dependency contracts.
