### PR TITLE
perf(ui): stage the next history page so back-scroll prepends land instantly

### DIFF
--- a/test/vitest/vitest.extension-codex-app-server-attempt-extra.config.ts
+++ b/test/vitest/vitest.extension-codex-app-server-attempt-extra.config.ts
@@ -7,6 +7,7 @@ export function createExtensionCodexAppServerAttemptExtraVitestConfig(
   return createScopedVitestConfig(
     [
       "extensions/codex/src/app-server/run-attempt.agent-end-context.test.ts",
+      "extensions/codex/src/app-server/run-attempt.channel-tool-progress.test.ts",
       "extensions/codex/src/app-server/run-attempt-lifecycle-controller.test.ts",
       "extensions/codex/src/app-server/run-attempt-thread-cleanup.test.ts",
       "extensions/codex/src/app-server/run-attempt.configured-mcp.test.ts",

--- a/ui/src/e2e/claude-sessions.e2e.test.ts
+++ b/ui/src/e2e/claude-sessions.e2e.test.ts
@@ -795,6 +795,8 @@ suite.define(() => {
           fullPage: true,
         });
       }
+      // The second applied page staged one background prefetch (offset 22);
+      // the now-scrollable transcript must not consume or chain beyond it.
       await new Promise<void>((resolve) => {
         setTimeout(resolve, 300);
       });
@@ -802,7 +804,7 @@ suite.define(() => {
         (await gateway.getRequests("chat.history")).map(
           (request) => (request.params as { offset?: number } | undefined)?.offset,
         ),
-      ).toEqual([2, 6]);
+      ).toEqual([2, 6, 22]);
     } finally {
       await suite.closeBrowserContext(context);
       if (artifactDir && proofVideo) {
@@ -850,6 +852,18 @@ suite.define(() => {
                 messages: older,
                 hasMore: false,
                 totalMessages: 140,
+                sessionId: "native-scrollback",
+                thinkingLevel: null,
+              },
+            },
+            {
+              // Served to the background prefetch staged after the successful
+              // older page below reports more history at offset 140.
+              match: { offset: 140 },
+              response: {
+                messages: [],
+                hasMore: false,
+                totalMessages: 180,
                 sessionId: "native-scrollback",
                 thinkingLevel: null,
               },
@@ -941,35 +955,28 @@ suite.define(() => {
         fullPage: true,
       });
     }
-    expect((await gateway.getRequests("chat.history")).at(-1)?.params).toMatchObject({
-      limit: 400,
-      offset: 100,
-    });
-    const firstPageRequestCount = (await gateway.getRequests("chat.history")).length;
+    // The applied page reports more history, so the pane stages the next page
+    // (offset 140) in the background without entering the loading state.
+    await expect
+      .poll(() => gateway.getRequests("chat.history").then((requests) => requests.length))
+      .toBe(failedRequestCount + 2);
+    const requestsAfterPrefetch = await gateway.getRequests("chat.history");
+    expect(requestsAfterPrefetch.at(-2)?.params).toMatchObject({ limit: 400, offset: 100 });
+    expect(requestsAfterPrefetch.at(-1)?.params).toMatchObject({ limit: 400, offset: 140 });
     await page.evaluate(
       () =>
         new Promise<void>((resolve) => {
           requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
         }),
     );
-    expect(await gateway.getRequests("chat.history")).toHaveLength(firstPageRequestCount);
-    await gateway.deferNext("chat.history");
+    // Single staging slot: the parked page must not chain further prefetches.
+    expect(await gateway.getRequests("chat.history")).toHaveLength(failedRequestCount + 2);
+    // Consuming the staged page needs no round trip: the exhausted empty page
+    // applies instantly and removes the boundary and its sentinel.
     await showEarlier.click();
-    await gateway.waitForRequest("chat.history", { after: firstPageRequestCount });
-    expect((await gateway.getRequests("chat.history")).at(-1)?.params).toMatchObject({
-      limit: 400,
-      offset: 140,
-    });
-    await gateway.resolveDeferred("chat.history", {
-      messages: [],
-      hasMore: false,
-      totalMessages: 180,
-      sessionId: "native-scrollback",
-      thinkingLevel: null,
-    });
     await expect.poll(() => page.locator(".chat-history-sentinel").count()).toBe(0);
     expect(await page.getByRole("button", { name: "Show earlier" }).count()).toBe(0);
-    expect(await gateway.getRequests("chat.history")).toHaveLength(firstPageRequestCount + 1);
+    expect(await gateway.getRequests("chat.history")).toHaveLength(failedRequestCount + 2);
     await page.close();
   });
 });

--- a/ui/src/pages/chat/chat-history.ts
+++ b/ui/src/pages/chat/chat-history.ts
@@ -1828,6 +1828,10 @@ export type StagedOlderHistoryPage = {
     connectionEpoch: number;
     sessionKey: string;
     agentId?: string;
+    /** Projection fence: any later history request or reset (tail reload,
+     * rewind, branch switch) advances the version and voids this page even
+     * when the replacement projection lands on the same cursor. */
+    historyVersion: number;
   };
   requestedOffset: number;
   result: ChatHistoryResult;
@@ -1847,6 +1851,7 @@ export async function fetchStagedOlderHistoryPage(
   const client = state.client;
   const connectionEpoch = state.connectionEpoch;
   const sessionKey = state.sessionKey;
+  const historyVersion = getChatHistoryPaneRequests(state).historyVersion;
   const requestAgentId = isUiSelectedGlobalSessionKey(state, sessionKey)
     ? resolveUiSelectedSessionAgentId(state)
     : undefined;
@@ -1856,6 +1861,7 @@ export async function fetchStagedOlderHistoryPage(
       client,
       connectionEpoch,
       sessionKey,
+      historyVersion,
       ...(requestAgentId ? { agentId: requestAgentId } : {}),
     },
     requestedOffset: offset,
@@ -1876,6 +1882,7 @@ export function isStagedOlderHistoryPageCurrent(
     state.client === claim.client &&
     state.connected &&
     state.connectionEpoch === claim.connectionEpoch &&
+    getChatHistoryPaneRequests(state).historyVersion === claim.historyVersion &&
     state.sessionKey === claim.sessionKey &&
     (!isUiSelectedGlobalSessionKey(state, claim.sessionKey) ||
       resolveUiSelectedSessionAgentId(state) === claim.agentId) &&

--- a/ui/src/pages/chat/chat-history.ts
+++ b/ui/src/pages/chat/chat-history.ts
@@ -1778,6 +1778,24 @@ export function retryChatHistoryLoad(
   return retry;
 }
 
+async function requestOlderChatHistoryPage(
+  client: GatewayBrowserClient,
+  sessionKey: string,
+  requestAgentId: string | undefined,
+  offset: number,
+): Promise<ChatHistoryResult> {
+  const result = await client.request<ChatHistoryResult>("chat.history", {
+    sessionKey,
+    ...(requestAgentId ? { agentId: requestAgentId } : {}),
+    limit: CHAT_HISTORY_OLDER_PAGE_LIMIT,
+    offset,
+  });
+  return {
+    ...result,
+    messages: visibleChatHistoryMessages(result.messages),
+  };
+}
+
 export async function loadOlderChatHistoryPage(
   state: ChatState,
   offset: number,
@@ -1797,19 +1815,73 @@ export async function loadOlderChatHistoryPage(
     sessionKey,
     requestAgentId,
   );
-  const result = await client.request<ChatHistoryResult>("chat.history", {
-    sessionKey,
-    ...(requestAgentId ? { agentId: requestAgentId } : {}),
-    limit: CHAT_HISTORY_OLDER_PAGE_LIMIT,
-    offset,
-  });
+  const result = await requestOlderChatHistoryPage(client, sessionKey, requestAgentId, offset);
   if (!shouldApplyChatHistoryResult(state, ownership)) {
     return undefined;
   }
-  return {
-    ...result,
-    messages: visibleChatHistoryMessages(result.messages),
+  return result;
+}
+
+export type StagedOlderHistoryPage = {
+  claim: {
+    client: GatewayBrowserClient;
+    connectionEpoch: number;
+    sessionKey: string;
+    agentId?: string;
   };
+  requestedOffset: number;
+  result: ChatHistoryResult;
+};
+
+// The staged prefetch deliberately skips beginChatHistoryRequest: request
+// ownership is last-writer-wins, so a background fetch bumping the version
+// could invalidate a concurrent tail load's apply. The claim below carries the
+// same facts and the pane validates it at consume time instead.
+export async function fetchStagedOlderHistoryPage(
+  state: ChatState,
+  offset: number,
+): Promise<StagedOlderHistoryPage | undefined> {
+  if (!state.client || !state.connected) {
+    return undefined;
+  }
+  const client = state.client;
+  const connectionEpoch = state.connectionEpoch;
+  const sessionKey = state.sessionKey;
+  const requestAgentId = isUiSelectedGlobalSessionKey(state, sessionKey)
+    ? resolveUiSelectedSessionAgentId(state)
+    : undefined;
+  const result = await requestOlderChatHistoryPage(client, sessionKey, requestAgentId, offset);
+  return {
+    claim: {
+      client,
+      connectionEpoch,
+      sessionKey,
+      ...(requestAgentId ? { agentId: requestAgentId } : {}),
+    },
+    requestedOffset: offset,
+    result,
+  };
+}
+
+/** A staged page is valid only for the exact connection, session, and the
+ * pagination cursor it was fetched at; any drift means the reactive path must
+ * refetch (tail reloads rebase offsets, resets reuse session keys). */
+export function isStagedOlderHistoryPageCurrent(
+  state: ChatState,
+  staged: StagedOlderHistoryPage,
+): boolean {
+  const claim = staged.claim;
+  const pagination = state.chatHistoryPagination;
+  return (
+    state.client === claim.client &&
+    state.connected &&
+    state.connectionEpoch === claim.connectionEpoch &&
+    state.sessionKey === claim.sessionKey &&
+    (!isUiSelectedGlobalSessionKey(state, claim.sessionKey) ||
+      resolveUiSelectedSessionAgentId(state) === claim.agentId) &&
+    pagination.hasMore &&
+    pagination.nextOffset === staged.requestedOffset
+  );
 }
 
 export function applyChatAgentsList(

--- a/ui/src/pages/chat/chat-pane-history.test-support.ts
+++ b/ui/src/pages/chat/chat-pane-history.test-support.ts
@@ -23,6 +23,8 @@ export type TestChatPane = HTMLElement & {
   prependUniqueNativeMessages: (messages: unknown[], current: unknown[]) => unknown[];
   prependUniqueCatalogMessages: (messages: unknown[]) => unknown[];
   loadOlderMessages: () => Promise<boolean>;
+  stagedOlderPage: unknown;
+  stagedOlderLoad: Promise<void> | null;
   showEarlierMessages: () => Promise<void>;
   requestReplyMessage: (messageId: string) => void;
   readReplyMessage: (messageId: string) => unknown;
@@ -150,4 +152,44 @@ export function createNativeShowEarlierPane(request: ReturnType<typeof vi.fn>) {
   vi.spyOn(result.pane, "updateComplete", "get").mockReturnValue(Promise.resolve(true));
   const scrollToOffset = vi.spyOn(result.pane.transcript, "scrollToOffset");
   return { ...result, scrollToOffset, thread };
+}
+
+/** Offset-scripted chat.history mock for an 8-message transcript whose tail
+ * (seq 7-8) is loaded; overrides replace or extend the default pages. */
+export function stagedPagesRequest(overrides: Record<number, () => unknown> = {}) {
+  const pages: Record<number, () => unknown> = {
+    2: () => ({
+      messages: [nativeHistoryMessage(5), nativeHistoryMessage(6)],
+      hasMore: true,
+      nextOffset: 4,
+      totalMessages: 8,
+    }),
+    4: () => ({
+      messages: [nativeHistoryMessage(3), nativeHistoryMessage(4)],
+      hasMore: true,
+      nextOffset: 6,
+      totalMessages: 8,
+    }),
+    6: () => ({
+      messages: [nativeHistoryMessage(1), nativeHistoryMessage(2)],
+      hasMore: false,
+      totalMessages: 8,
+    }),
+    ...overrides,
+  };
+  return vi.fn(async (_method: string, params: { offset?: number }) => {
+    const page = pages[params.offset ?? -1];
+    if (!page) {
+      throw new Error(`no scripted page for offset ${String(params.offset)}`);
+    }
+    return page();
+  });
+}
+
+export function createStagedPrefetchPane(request: ReturnType<typeof vi.fn>) {
+  const client = { request } as unknown as GatewayBrowserClient;
+  const result = createTestChatPane({ client, sessions: {} as SessionCapability });
+  result.state.chatMessages = [nativeHistoryMessage(7), nativeHistoryMessage(8)];
+  result.state.chatHistoryPagination = { hasMore: true, nextOffset: 2, totalMessages: 8 };
+  return result;
 }

--- a/ui/src/pages/chat/chat-pane-history.test.ts
+++ b/ui/src/pages/chat/chat-pane-history.test.ts
@@ -9,7 +9,11 @@ import { extractText } from "../../lib/chat/message-extract.ts";
 import type { SessionCapability } from "../../lib/sessions/index.ts";
 import "./chat-pane.ts";
 import { handleChatGatewayEvent } from "./chat-gateway.ts";
-import { loadChatHistory, type ChatHistoryResult } from "./chat-history.ts";
+import {
+  loadChatHistory,
+  resetChatHistoryProjection,
+  type ChatHistoryResult,
+} from "./chat-history.ts";
 import {
   appendChatThread,
   createNativeShowEarlierPane,
@@ -533,6 +537,42 @@ describe("chat pane native history pagination", () => {
       offset: 5,
     });
     expect(state.chatMessages.map(nativeHistorySeq)).toEqual([31, 32, 5, 6, 7, 8]);
+  });
+
+  // Rewind and branch switch share resetChatHistoryProjection as their reset
+  // owner: the projection fence must void a staged page even when the
+  // replacement projection lands on the same pagination cursor.
+  it("discards a staged page after a same-cursor projection reset", async () => {
+    let offsetFourCalls = 0;
+    const request = stagedPagesRequest({
+      4: () => {
+        offsetFourCalls += 1;
+        return {
+          messages:
+            offsetFourCalls === 1
+              ? [nativeHistoryMessage(3, "pre-rewind branch"), nativeHistoryMessage(4)]
+              : [nativeHistoryMessage(41, "post-rewind branch"), nativeHistoryMessage(42)],
+          hasMore: false,
+          totalMessages: 8,
+        };
+      },
+    });
+    const { pane, state } = createStagedPrefetchPane(request);
+
+    await pane.loadOlderMessages();
+    await vi.waitFor(() => expect(pane.stagedOlderPage).not.toBeNull());
+
+    resetChatHistoryProjection(state);
+    // The replacement branch happens to resume at the identical cursor.
+    state.chatHistoryPagination = { hasMore: true, nextOffset: 4, totalMessages: 8 };
+    await expect(pane.loadOlderMessages()).resolves.toBe(true);
+
+    expect(offsetFourCalls).toBe(2);
+    const texts = state.chatMessages.map((message) =>
+      extractText(message as Parameters<typeof extractText>[0]),
+    );
+    expect(texts.some((text) => text?.includes("post-rewind branch"))).toBe(true);
+    expect(texts.some((text) => text?.includes("pre-rewind branch"))).toBe(false);
   });
 
   it("clears the staged page on viewport reset", async () => {

--- a/ui/src/pages/chat/chat-pane-history.test.ts
+++ b/ui/src/pages/chat/chat-pane-history.test.ts
@@ -13,9 +13,11 @@ import { loadChatHistory, type ChatHistoryResult } from "./chat-history.ts";
 import {
   appendChatThread,
   createNativeShowEarlierPane,
+  createStagedPrefetchPane,
   createTestChatPane,
   nativeHistoryMessage,
   nativeHistorySeq,
+  stagedPagesRequest,
 } from "./chat-pane-history.test-support.ts";
 import { ChatPane } from "./chat-pane-render.ts";
 import { nativeHistoryMessageIdentity } from "./chat-pane-shared.ts";
@@ -451,6 +453,131 @@ describe("chat pane native history pagination", () => {
     } finally {
       vi.unstubAllGlobals();
     }
+  });
+
+  it("stages the next older page and consumes it without entering the loading state", async () => {
+    const request = stagedPagesRequest();
+    const { pane, state } = createStagedPrefetchPane(request);
+
+    await pane.loadOlderMessages();
+
+    expect(state.chatMessages.map(nativeHistorySeq)).toEqual([5, 6, 7, 8]);
+    await vi.waitFor(() => expect(request).toHaveBeenCalledTimes(2));
+    expect(request).toHaveBeenNthCalledWith(2, "chat.history", {
+      sessionKey: state.sessionKey,
+      limit: 400,
+      offset: 4,
+    });
+    await vi.waitFor(() => expect(pane.stagedOlderPage).not.toBeNull());
+
+    const loadingDuringRender: boolean[] = [];
+    (state.requestUpdate as ReturnType<typeof vi.fn>).mockImplementation(() => {
+      loadingDuringRender.push(pane.loadingOlder);
+    });
+    await expect(pane.loadOlderMessages()).resolves.toBe(true);
+
+    expect(state.chatMessages.map(nativeHistorySeq)).toEqual([3, 4, 5, 6, 7, 8]);
+    // The staged page applies without a round trip or a loading-state render.
+    expect(loadingDuringRender).not.toContain(true);
+    expect(request).toHaveBeenCalledTimes(3);
+    expect(request).toHaveBeenNthCalledWith(3, "chat.history", {
+      sessionKey: state.sessionKey,
+      limit: 400,
+      offset: 6,
+    });
+  });
+
+  it("joins an in-flight prefetch instead of duplicating the request", async () => {
+    const deferred = createDeferred<unknown>();
+    const request = stagedPagesRequest({ 4: () => deferred.promise });
+    const { pane, state } = createStagedPrefetchPane(request);
+
+    await pane.loadOlderMessages();
+    await vi.waitFor(() => expect(request).toHaveBeenCalledTimes(2));
+
+    const joined = pane.loadOlderMessages();
+    deferred.resolve({
+      messages: [nativeHistoryMessage(3), nativeHistoryMessage(4)],
+      hasMore: false,
+      totalMessages: 8,
+    });
+    await expect(joined).resolves.toBe(true);
+
+    const offsetFourCalls = request.mock.calls.filter(
+      ([, params]) => (params as { offset?: number }).offset === 4,
+    );
+    expect(offsetFourCalls).toHaveLength(1);
+    expect(state.chatMessages.map(nativeHistorySeq)).toEqual([3, 4, 5, 6, 7, 8]);
+  });
+
+  it("discards a staged page when the pagination cursor moves", async () => {
+    const request = stagedPagesRequest({
+      5: () => ({
+        messages: [nativeHistoryMessage(31), nativeHistoryMessage(32)],
+        hasMore: false,
+        totalMessages: 9,
+      }),
+    });
+    const { pane, state } = createStagedPrefetchPane(request);
+
+    await pane.loadOlderMessages();
+    await vi.waitFor(() => expect(pane.stagedOlderPage).not.toBeNull());
+
+    // A tail reload rebased the cursor beneath the staged page.
+    state.chatHistoryPagination = { hasMore: true, nextOffset: 5, totalMessages: 9 };
+    await expect(pane.loadOlderMessages()).resolves.toBe(true);
+
+    expect(request).toHaveBeenLastCalledWith("chat.history", {
+      sessionKey: state.sessionKey,
+      limit: 400,
+      offset: 5,
+    });
+    expect(state.chatMessages.map(nativeHistorySeq)).toEqual([31, 32, 5, 6, 7, 8]);
+  });
+
+  it("clears the staged page on viewport reset", async () => {
+    const request = stagedPagesRequest();
+    const { pane } = createStagedPrefetchPane(request);
+
+    await pane.loadOlderMessages();
+    await vi.waitFor(() => expect(pane.stagedOlderPage).not.toBeNull());
+
+    pane.resetOlderMessagesViewport();
+    expect(pane.stagedOlderPage).toBeNull();
+    expect(pane.stagedOlderLoad).toBeNull();
+
+    await expect(pane.loadOlderMessages()).resolves.toBe(true);
+    const offsetFourCalls = request.mock.calls.filter(
+      ([, params]) => (params as { offset?: number }).offset === 4,
+    );
+    expect(offsetFourCalls).toHaveLength(2);
+  });
+
+  it("keeps prefetch failures silent and retries reactively", async () => {
+    let offsetFourCalls = 0;
+    const request = stagedPagesRequest({
+      4: () => {
+        offsetFourCalls += 1;
+        if (offsetFourCalls === 1) {
+          throw new Error("prefetch boom");
+        }
+        return {
+          messages: [nativeHistoryMessage(3), nativeHistoryMessage(4)],
+          hasMore: false,
+          totalMessages: 8,
+        };
+      },
+    });
+    const { pane, state } = createStagedPrefetchPane(request);
+
+    await pane.loadOlderMessages();
+    await vi.waitFor(() => expect(request).toHaveBeenCalledTimes(2));
+    await vi.waitFor(() => expect(pane.stagedOlderLoad).toBeNull());
+
+    expect(state.lastError).toBeNull();
+    await expect(pane.loadOlderMessages()).resolves.toBe(true);
+    expect(offsetFourCalls).toBe(2);
+    expect(state.chatMessages.map(nativeHistorySeq)).toEqual([3, 4, 5, 6, 7, 8]);
   });
 
   it("does not consume bootstrap history while disconnected", () => {

--- a/ui/src/pages/chat/chat-pane-history.ts
+++ b/ui/src/pages/chat/chat-pane-history.ts
@@ -21,11 +21,15 @@ import {
 import type { ChatHistoryPagination } from "./chat-history-pagination.ts";
 import {
   commitCurrentChatHistorySnapshot,
+  fetchStagedOlderHistoryPage,
+  isStagedOlderHistoryPageCurrent,
   loadChatHistory,
   loadOlderChatHistoryPage,
   resolveChatHistoryPagination,
   rewindChatHistory,
   switchChatHistoryBranch,
+  type ChatHistoryResult,
+  type StagedOlderHistoryPage,
 } from "./chat-history.ts";
 import { ChatPaneReplyNavigation } from "./chat-pane-reply-navigation.ts";
 import {
@@ -36,6 +40,7 @@ import {
   clearPaneSessionHandoff,
   preparePaneSessionHandoff,
 } from "./chat-pane-shared.ts";
+import type { ChatState } from "./chat-state-contract.ts";
 import { resolveChatAgentId } from "./chat-state-route.ts";
 import { persistChatComposerState } from "./composer-persistence.ts";
 import {
@@ -47,6 +52,16 @@ import {
 export abstract class ChatPaneHistory extends ChatPaneReplyNavigation {
   private activeCatalogContinuation: symbol | null = null;
   private activeOlderLoad: Promise<boolean> | null = null;
+  // Staged prefetch: after a consumed older page, the next page is fetched in
+  // the background and parked here, so the following boundary crossing
+  // prepends without a visible round trip. One slot per pane; the claim is
+  // validated at consume time. Catalog sessions stay reactive: their opaque
+  // cursor loads apply directly to pane state and cannot be parked.
+  private stagedOlderPage: StagedOlderHistoryPage | null = null;
+  private stagedOlderLoad: Promise<void> | null = null;
+  // Bumped only by viewport resets: ordinary loads must not invalidate an
+  // in-flight prefetch or the join path could never consume it.
+  private stagedOlderGeneration = 0;
 
   protected hasOlderMessages(): boolean {
     const state = this.state;
@@ -62,6 +77,9 @@ export abstract class ChatPaneHistory extends ChatPaneReplyNavigation {
   protected resetOlderMessagesViewport(): void {
     this.olderLoadGeneration += 1;
     this.activeOlderLoad = null;
+    this.stagedOlderGeneration += 1;
+    this.stagedOlderPage = null;
+    this.stagedOlderLoad = null;
     this.resetReplyNavigation();
     this.loadingOlder = false;
     this.historyObserverArmed = false;
@@ -304,11 +322,18 @@ export abstract class ChatPaneHistory extends ChatPaneReplyNavigation {
       return false;
     }
     const generation = ++this.olderLoadGeneration;
-    this.loadingOlder = true;
-    state.requestUpdate();
+    // A staged page applies without ever entering the loading state, so the
+    // boundary shows no shimmer flash for an instant prepend.
+    const markLoading = () => {
+      if (!this.loadingOlder) {
+        this.loadingOlder = true;
+        state.requestUpdate();
+      }
+    };
     let prepended = false;
     try {
       if (catalogKey) {
+        markLoading();
         prepended = await this.loadCatalogSession(catalogKey, true);
       } else {
         const pagination = state.chatHistoryPagination;
@@ -318,7 +343,20 @@ export abstract class ChatPaneHistory extends ChatPaneReplyNavigation {
         const requestedOffset = pagination.nextOffset;
         const expectedSessionId =
           typeof state.currentSessionId === "string" ? state.currentSessionId.trim() : "";
-        const result = await loadOlderChatHistoryPage(state, requestedOffset);
+        let result = this.takeStagedOlderPage(state);
+        if (!result && this.stagedOlderLoad) {
+          // Join the in-flight prefetch instead of issuing a duplicate request.
+          markLoading();
+          await this.stagedOlderLoad;
+          if (generation !== this.olderLoadGeneration) {
+            return false;
+          }
+          result = this.takeStagedOlderPage(state);
+        }
+        if (!result) {
+          markLoading();
+          result = (await loadOlderChatHistoryPage(state, requestedOffset)) ?? null;
+        }
         if (!result || generation !== this.olderLoadGeneration) {
           return false;
         }
@@ -354,6 +392,9 @@ export abstract class ChatPaneHistory extends ChatPaneReplyNavigation {
         commitCurrentChatHistorySnapshot(state);
         scheduleChatScroll(state, false);
         prepended = grew || !exhausted;
+        if (!exhausted) {
+          this.stageNextOlderPage(state);
+        }
       }
     } catch (error) {
       if (generation === this.olderLoadGeneration) {
@@ -374,6 +415,47 @@ export abstract class ChatPaneHistory extends ChatPaneReplyNavigation {
       }
     }
     return prepended;
+  }
+
+  private stageNextOlderPage(state: ChatState): void {
+    if (this.stagedOlderPage || this.stagedOlderLoad) {
+      return;
+    }
+    const pagination = state.chatHistoryPagination;
+    if (!pagination.hasMore || parseCatalogSessionKey(state.sessionKey)) {
+      return;
+    }
+    const generation = this.stagedOlderGeneration;
+    // One async closure keeps the bookkeeping inside the awaited promise, so a
+    // joiner resuming from this load always observes the staged page and the
+    // cleared in-flight slot together. The generation guard keeps a stale
+    // finally (fetch outliving a viewport reset) off a successor's slot.
+    this.stagedOlderLoad = (async () => {
+      try {
+        const staged = await fetchStagedOlderHistoryPage(state, pagination.nextOffset);
+        if (staged && generation === this.stagedOlderGeneration && this.state === state) {
+          this.stagedOlderPage = staged;
+        }
+      } catch {
+        // Prefetch is best-effort: the reactive path owns retries, error
+        // surfacing, and the blocked-until-intent machinery.
+      } finally {
+        if (generation === this.stagedOlderGeneration) {
+          this.stagedOlderLoad = null;
+        }
+      }
+    })();
+  }
+
+  // Single-consume: an invalid staged page is discarded rather than retried so
+  // stale prefetches can never shadow the reactive path's fresh cursor.
+  private takeStagedOlderPage(state: ChatState): ChatHistoryResult | null {
+    const staged = this.stagedOlderPage;
+    if (!staged) {
+      return null;
+    }
+    this.stagedOlderPage = null;
+    return isStagedOlderHistoryPageCurrent(state, staged) ? staged.result : null;
   }
 
   protected async continueCatalogSession(key: CatalogSessionKey) {


### PR DESCRIPTION
Related: #132493

## What Problem This Solves

After #132493, back-scrolling loads 400-message pages with a 1200px prefetch lead — but each load is still reactive: the fetch starts only when the reader crosses the trigger distance, so a scrollbar drag or a hard momentum flick to the top can outrun the round trip and hit the loading boundary. On slower links (tunneled remote gateways), that wait is routine rather than rare.

## Why This Change Was Made

Staged prefetch keeps the fetch pipeline one page ahead of the reader. After any consumed older page that reports more history, the pane fetches the next page in the background and parks it in a single staging slot; the next boundary crossing prepends it synchronously — no round trip, and the loading shimmer never renders (the loading state is now only entered when a real fetch is needed).

Correctness machinery, matching the invalidation cases enumerated in the #132493 follow-up discussion:

- **No ownership interference.** Chat-history request ownership is last-writer-wins (`historyVersion`), so a background fetch bumping it could invalidate a concurrent tail reload. `fetchStagedOlderHistoryPage` skips the version entirely and instead carries a claim — client, connection epoch, session key, resolved agent, and the exact pagination cursor — validated at consume time (`isStagedOlderHistoryPageCurrent`). Any drift (reconnect, session switch, tail reload rebasing offsets, reset reusing the key) discards the page and the reactive path refetches; the existing session-id mismatch check still guards the apply itself.
- **Join, don't duplicate.** A boundary crossing while the prefetch is still in flight awaits the same promise rather than issuing a second identical request.
- **Reset invalidation.** Viewport resets bump a dedicated staging generation (ordinary loads must not, or the join path could never consume), and clear both the slot and the in-flight fetch.
- **Silent failure.** A failed prefetch is dropped; the reactive path owns retries, error surfacing, and the blocked-until-intent machinery.
- **Scope.** Native sessions only. Catalog sessions keep reactive loads: their opaque-cursor pages apply directly to pane state and cannot be parked; their pages are also 50 items and rarely deep-scrolled.

Cost: one page (≤400 messages) of speculative fetch per back-scrolling session leg, held in a single slot per pane.

## User Impact

Back-scrolling a long session now shows the loading boundary at most once — the first crossing. Every subsequent page, including scrollbar teleports to the top, prepends instantly from the staged slot. Readers who never scroll up pay nothing; the first prefetch only starts after the first older page is consumed.

## Evidence

**Live gateway proof** (isolated `OPENCLAW_STATE_DIR`, real `chat.history` over WebSocket, seeded 1400-message session, frame-accurate rAF sampler on `.chat-history-boundary--loading`):

| gesture | messages | loading-state frames |
|---|---|---|
| 1 (cold, reactive) | 100 → 500 | **5** |
| 2 (staged) | 500 → 900 | **0** |
| 3 (staged) | 900 → 1300 | **0** |
| 4 (staged, exhausts) | 1300 → 1400 | **0** |

Mid-scrollback after a staged prepend (no boundary, no shimmer — content just continues):

![staged prepend applied instantly with no loading state](https://github.com/user-attachments/assets/0e5f6eed-3c90-4c9b-b2a6-89e89a2b0bf1)

Full flow video (all four gestures):

https://github.com/user-attachments/assets/c112bc88-553a-4d5c-8993-d81073551443

**Regression coverage** (`chat-pane-history.test.ts`): stages the next page and consumes it without entering the loading state; joins an in-flight prefetch (single request per offset); discards a staged page when the pagination cursor moves; clears staging on viewport reset; prefetch failures stay silent with reactive retry. The `claude-sessions` e2e now asserts the staged consume end-to-end: after a successful load, exactly one background request fires, holds as a single slot across frames, and the final "Show earlier" click removes the boundary with zero additional requests.

**Validation:** `pnpm check:changed` exit 0; chat unit suites, `claude-sessions`, `chat-flow.history-recovery`, `chat-reply-preview-recovery`, `chat-transcript-disclosure-anchor`, and `chat-message-actions` e2e all green locally; Codex autoreview scoped-clean (0.98).
