### PR TITLE
fix(agents): deprioritize inter-session turns

### DIFF
--- a/src/agents/embedded-agent-runner/run/lane-controller.lifecycle.test.ts
+++ b/src/agents/embedded-agent-runner/run/lane-controller.lifecycle.test.ts
@@ -52,6 +52,7 @@ function createController(options: {
   abortSignal?: AbortSignal;
   runId?: string;
   params?: Pick<LaneParams, "agentId" | "sessionKey">;
+  inputProvenance?: LaneParams["inputProvenance"];
 }) {
   let lifecycleGeneration = options.lifecycleGeneration;
   const runId = options.runId ?? "run-1";
@@ -67,6 +68,7 @@ function createController(options: {
     runId,
     lifecycleGeneration,
     trigger: options.trigger,
+    inputProvenance: options.inputProvenance,
     enqueue: options.enqueue,
     abortSignal: options.abortSignal,
     ...options.params,
@@ -157,6 +159,28 @@ describe("createEmbeddedRunLaneController lifecycle admission", () => {
     expect(state.getLifecycleGeneration()).toBe(currentGeneration);
     expect(state.getParams().lifecycleGeneration).toBe(currentGeneration);
     expect(getAgentRunContext("queued-across-restart")).toMatchObject({
+      lifecycleGeneration: currentGeneration,
+    });
+  });
+
+  it("rebinds inter-session user work that was queued before lifecycle rotation", async () => {
+    const queue = deferredTaskQueue();
+    const generation = getAgentEventLifecycleGeneration();
+    const state = createController({
+      lifecycleGeneration: generation,
+      enqueue: queue.enqueue as LaneParams["enqueue"],
+      trigger: "user",
+      inputProvenance: { kind: "inter_session", sourceTool: "sessions_send" },
+      runId: "inter-session-across-restart",
+    });
+    const run = state.controller.enqueueGlobal(async () => completedResult);
+
+    const currentGeneration = rotateAgentEventLifecycleGeneration();
+    queue.release();
+    await run;
+
+    expect(state.getLifecycleGeneration()).toBe(currentGeneration);
+    expect(getAgentRunContext("inter-session-across-restart")).toMatchObject({
       lifecycleGeneration: currentGeneration,
     });
   });

--- a/src/agents/embedded-agent-runner/run/lane-controller.ts
+++ b/src/agents/embedded-agent-runner/run/lane-controller.ts
@@ -16,7 +16,7 @@ import type { EmbeddedAgentRunResult } from "../types.js";
 import {
   EMBEDDED_RUN_LANE_TIMEOUT_GRACE_MS,
   resolveEmbeddedRunLaneTimeoutMs,
-  resolveEmbeddedRunSessionQueuePriority,
+  resolveEmbeddedRunSessionLanePolicy,
   shouldNoteLaneWait,
   withEmbeddedRunLaneTimeout,
 } from "./lane-runtime.js";
@@ -37,7 +37,7 @@ export function createEmbeddedRunLaneController<TParams extends LaneParams>(opti
   setParams: (params: TParams) => void;
 }) {
   const initialParams = options.getParams();
-  const sessionQueuePriority = resolveEmbeddedRunSessionQueuePriority(
+  const sessionLanePolicy = resolveEmbeddedRunSessionLanePolicy(
     initialParams.trigger,
     initialParams.inputProvenance,
   );
@@ -138,7 +138,7 @@ export function createEmbeddedRunLaneController<TParams extends LaneParams>(opti
     options.getParams().replyOperation?.markWaitingForGlobalLane();
     const globalOpts: CommandQueueEnqueueOptions = {
       ...opts,
-      priority: sessionQueuePriority,
+      priority: sessionLanePolicy.priority,
       onQueued: noteCapacityWait,
     };
     const taskWithCurrentLifecycle = async () => {
@@ -152,7 +152,7 @@ export function createEmbeddedRunLaneController<TParams extends LaneParams>(opti
       if (lifecycleGeneration !== currentLifecycleGeneration) {
         const wasQueuedBeforeRotation =
           options.initialQueuedLifecycleGeneration === lifecycleGeneration;
-        const canResumeAcrossRotation = sessionQueuePriority === "foreground";
+        const canResumeAcrossRotation = sessionLanePolicy.canResumeAcrossRotation;
         const newerSameIdExecutionOwnsContext =
           existingContext?.lifecycleGeneration === currentLifecycleGeneration;
         if (
@@ -224,7 +224,7 @@ export function createEmbeddedRunLaneController<TParams extends LaneParams>(opti
   const enqueueSession = <T>(task: () => Promise<T>, opts?: CommandQueueEnqueueOptions) => {
     const sessionOpts: CommandQueueEnqueueOptions = {
       ...opts,
-      priority: sessionQueuePriority,
+      priority: sessionLanePolicy.priority,
       onQueued: noteCapacityWait,
     };
     const admittedTask = () => {

--- a/src/agents/embedded-agent-runner/run/lane-runtime.test.ts
+++ b/src/agents/embedded-agent-runner/run/lane-runtime.test.ts
@@ -4,7 +4,7 @@ import { resetCommandQueueStateForTest } from "../../../process/command-queue.te
 import { MAIN_SESSION_RESTART_RECOVERY_SOURCE_TOOL } from "../../../sessions/input-provenance.js";
 import {
   EMBEDDED_RUN_LANE_HEARTBEAT_MS,
-  resolveEmbeddedRunSessionQueuePriority,
+  resolveEmbeddedRunSessionLanePolicy,
   withEmbeddedRunLaneProgressHeartbeat,
 } from "./lane-runtime.js";
 
@@ -14,7 +14,7 @@ afterEach(() => {
 });
 
 describe("embedded run lane priority", () => {
-  it("runs a foreground user turn before queued restart recovery", async () => {
+  it("runs a foreground user turn before queued restart recovery and inter-session work", async () => {
     const lane = "test:restart-recovery-priority";
     setCommandLaneConcurrency(lane, 1);
     let releaseBlocker: () => void = () => {};
@@ -31,10 +31,22 @@ describe("embedded run lane priority", () => {
         order.push("restart-recovery");
       },
       {
-        priority: resolveEmbeddedRunSessionQueuePriority("user", {
+        priority: resolveEmbeddedRunSessionLanePolicy("user", {
           kind: "internal_system",
           sourceTool: MAIN_SESSION_RESTART_RECOVERY_SOURCE_TOOL,
-        }),
+        }).priority,
+      },
+    );
+    const interSession = enqueueCommandInLane(
+      lane,
+      async () => {
+        order.push("inter-session");
+      },
+      {
+        priority: resolveEmbeddedRunSessionLanePolicy("user", {
+          kind: "inter_session",
+          sourceTool: "sessions_send",
+        }).priority,
       },
     );
     const foreground = enqueueCommandInLane(
@@ -42,13 +54,13 @@ describe("embedded run lane priority", () => {
       async () => {
         order.push("foreground-user");
       },
-      { priority: resolveEmbeddedRunSessionQueuePriority("user") },
+      { priority: resolveEmbeddedRunSessionLanePolicy("user").priority },
     );
 
     releaseBlocker();
-    await Promise.all([blocker, foreground, restartRecovery]);
+    await Promise.all([blocker, foreground, restartRecovery, interSession]);
 
-    expect(order).toEqual(["foreground-user", "restart-recovery"]);
+    expect(order).toEqual(["foreground-user", "restart-recovery", "inter-session"]);
   });
 });
 

--- a/src/agents/embedded-agent-runner/run/lane-runtime.ts
+++ b/src/agents/embedded-agent-runner/run/lane-runtime.ts
@@ -57,23 +57,36 @@ export function withEmbeddedRunLaneTimeout(
   return { ...opts, taskTimeoutMs: laneTaskTimeoutMs };
 }
 
-export function resolveEmbeddedRunSessionQueuePriority(
+export function resolveEmbeddedRunSessionLanePolicy(
   trigger: RunEmbeddedAgentParams["trigger"],
   inputProvenance?: RunEmbeddedAgentParams["inputProvenance"],
-): CommandQueueEnqueueOptions["priority"] {
-  if (isMainSessionRestartRecoveryInputProvenance(inputProvenance)) {
-    return "background";
-  }
+): {
+  priority: CommandQueueEnqueueOptions["priority"];
+  canResumeAcrossRotation: boolean;
+} {
+  let triggerPriority: CommandQueueEnqueueOptions["priority"];
   switch (trigger) {
     case "user":
     case "manual":
-      return "foreground";
+      triggerPriority = "foreground";
+      break;
     case "cron":
     case "heartbeat":
     case "memory":
     case "overflow":
-      return "background";
+      triggerPriority = "background";
+      break;
     default:
-      return "normal";
+      triggerPriority = "normal";
   }
+  const isRestartRecovery = isMainSessionRestartRecoveryInputProvenance(inputProvenance);
+  // Inter-session work must yield to humans without losing already-admitted
+  // user work when the Gateway lifecycle rotates while it waits.
+  return {
+    priority:
+      isRestartRecovery || inputProvenance?.kind === "inter_session"
+        ? "background"
+        : triggerPriority,
+    canResumeAcrossRotation: !isRestartRecovery && triggerPriority === "foreground",
+  };
 }


### PR DESCRIPTION
Fixes #70634

## What Problem This Solves

`sessions_send` creates authoritative `inter_session` provenance, but the embedded-run lane policy used the generic `user` trigger and queued that agent work as foreground work. An earlier agent turn could therefore run before a later human turn in the same session lane.

## Why This Change Was Made

The lane controller also used foreground priority as the only signal that queued work could rebind after a Gateway lifecycle rotation. Changing inter-session priority alone fixed ordering but caused queued agent work to fail after a restart.

This change replaces that coupled value with one lane policy:

- inter-session work uses background queue priority;
- human user work keeps foreground priority;
- user-triggered inter-session work keeps its existing lifecycle rebind behavior;
- restart recovery and scheduled background work keep their current behavior.

## User Impact

Human turns now run before queued agent-to-agent work. Active multi-agent traffic can no longer hold the same foreground queue tier as operator work.

## Evidence

Exact-main red: `85ec67d66fab32cb0a858c80caf53019592d6510`

- A real Telegram Test Server session supplied the delivery route.
- One controlled session-lane hold queued an authoritative `sessions_send` turn and an operator turn before one release.
- Provider request 4 was inter-session work.
- Provider request 5 was human work.

Repaired-head green: `80b6d57d95e3fc1aaaaa930161e1ebb8e5d11ba2`

- The identical Telegram and queue scenario reversed the two requests.
- Provider request 4 was human work.
- Provider request 5 was inter-session work.
- Telegram recorded the user-visible reply and the runner released its credential and ports.

Redacted execution trace:

```text
exact-base 85ec67d66fab32cb0a858c80caf53019592d6510
request 4: inputProvenance=inter_session, sourceTool=sessions_send
request 5: inputProvenance=external operator turn
observed order: inter_session -> human

exact-head 80b6d57d95e3fc1aaaaa930161e1ebb8e5d11ba2
request 4: inputProvenance=external operator turn
request 5: inputProvenance=inter_session, sourceTool=sessions_send
observed order: human -> inter_session

lifecycle: queued user-triggered inter_session work rebound to the current Gateway generation
lifecycle regression: passed on exact head
```

Focused validation:

- `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run/lane-runtime.test.ts src/agents/embedded-agent-runner/run/lane-controller.lifecycle.test.ts src/gateway/server.sessions-send.test.ts src/agents/tools/agent-step.test.ts`
- 30 tests passed across the changed owner, lifecycle guard, producer, and sibling step path.
- Formatting, Oxlint, maximum-lines, assertion-safety, conflict-marker, import-cycle, and `git diff --check` checks passed.

Production: +26/-13 lines, net +13. Tests: +43/-7 lines, net +36. The production growth replaces one overloaded priority decision with the two independent policy facts required by the existing queue and lifecycle contracts.
