### PR TITLE
fix(test): register the Codex channel tool progress shard file

### DIFF
--- a/test/vitest/vitest.extension-codex-app-server-attempt-extra.config.ts
+++ b/test/vitest/vitest.extension-codex-app-server-attempt-extra.config.ts
@@ -9,6 +9,7 @@ export function createExtensionCodexAppServerAttemptExtraVitestConfig(
       "extensions/codex/src/app-server/run-attempt.agent-end-context.test.ts",
       "extensions/codex/src/app-server/run-attempt-lifecycle-controller.test.ts",
       "extensions/codex/src/app-server/run-attempt-thread-cleanup.test.ts",
+      "extensions/codex/src/app-server/run-attempt.channel-tool-progress.test.ts",
       "extensions/codex/src/app-server/run-attempt.configured-mcp.test.ts",
       "extensions/codex/src/app-server/run-attempt.context-engine.test.ts",
       "extensions/codex/src/app-server/run-attempt.dynamic-tools.test.ts",


### PR DESCRIPTION
## What Problem This Solves

`main` is red. Every pull request that merges current `main` inherits a failing `checks-node-compact-large-*` shard, and the failure names a file none of those PRs touch:

```
FAIL test/vitest-projects-config.test.ts > projects vitest config
     > covers each normal full-suite test file exactly once after configs cached filtered includes
AssertionError: expected [ Array(1) ] to strictly equal []
- []
+ [ "extensions/codex/src/app-server/run-attempt.channel-tool-progress.test.ts" ]
```

The Codex app-server attempt shards enumerate their test files explicitly rather than globbing. `run-attempt.channel-tool-progress.test.ts` arrived with #132664 without being added to a shard, so the guard that every full-suite test file is claimed exactly once has nothing to claim it - and the test itself never runs in CI.

## Why This Change Was Made

The file belongs to the `attempt-extra` shard by the split those configs already use: `attempt-extra` holds the `run-attempt.<feature>.test.ts` family, while `attempt-light` and `attempt-support` hold the `attempt-*` and `run-attempt-<infrastructure>` files. It is inserted in the list's existing order.

Registering the file is the smallest correct fix: it restores the guard's invariant and puts two real Codex assertions back into CI, rather than relaxing the guard.

## User Impact

None at runtime. This unblocks CI: `main` goes green again, and pull requests stop inheriting a failure that has nothing to do with their changes.

## Evidence

Reproduced on pristine `origin/main` (`3bdc535558f`), before the fix:

```
× projects vitest config > covers each normal full-suite test file exactly once
  → expected [ Array(1) ] to strictly equal []
Tests  1 failed | 22 passed (23)
```

With the file registered:

```
Tests  23 passed (23)
```

The newly claimed file passes in its shard, so this registers a green test rather than a red one:

```
✓ Codex channel tool progress > keeps raw command detail behind the channel commandText policy
✓ Codex channel tool progress > keeps every tool source available to channel policy and verbose callbacks
Test Files  1 passed (1)   Tests  2 passed (2)
```

`node scripts/check-changed.mjs --base origin/main` exits 0 with no failing lane.
