### PR TITLE
perf(plugins): avoid logging imports during provider discovery

### DIFF
--- a/docs/plugins/sdk-subpaths.md
+++ b/docs/plugins/sdk-subpaths.md
@@ -337,6 +337,7 @@ Use `isLoopbackHost(host)` when a plugin must accept only the local machine. It 
     | `plugin-sdk/exec-approvals-runtime` | Private-local after July 2026; Exec approval policy file helpers without the broad infra-runtime barrel |
     | `plugin-sdk/infra-runtime` | Deprecated compatibility shim; use injected runtime APIs or documented typed-public subpaths |
     | `plugin-sdk/collection-runtime` | Small bounded cache helpers |
+    | `plugin-sdk/diagnostic-flags` | `isDiagnosticFlagEnabled` for flag-only consumers without event, trace, or redaction initialization |
     | `plugin-sdk/diagnostic-runtime` | Diagnostic flag, event, trace-context, and low-cardinality dimension normalization helpers |
     | `plugin-sdk/error-runtime` | Error graph, formatting, unknown-value coercion, shared error classification helpers, `PlatformMessageNotDispatchedError`, `isApprovalNotFoundError` |
     | `plugin-sdk/fetch-runtime` | Private-local after July 2026; Wrapped fetch, proxy, EnvHttpProxyAgent option, and pinned lookup helpers |

--- a/extensions/brave/src/brave-web-search-provider.ts
+++ b/extensions/brave/src/brave-web-search-provider.ts
@@ -2,7 +2,7 @@
  * Brave web-search provider factory. It builds the agent tool definition and
  * lazy-loads HTTP execution only when a search is run.
  */
-import { isDiagnosticFlagEnabled } from "openclaw/plugin-sdk/diagnostic-runtime";
+import { isDiagnosticFlagEnabled } from "openclaw/plugin-sdk/diagnostic-flags";
 import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
 import type {
   SearchConfigRecord,

--- a/extensions/codex/src/app-server/profiler-flag.ts
+++ b/extensions/codex/src/app-server/profiler-flag.ts
@@ -3,7 +3,7 @@
  * OpenClaw diagnostic flags.
  */
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
-import { isDiagnosticFlagEnabled } from "openclaw/plugin-sdk/diagnostic-runtime";
+import { isDiagnosticFlagEnabled } from "openclaw/plugin-sdk/diagnostic-flags";
 
 const PROFILER_FLAGS = ["profiler", "codex.profiler"] as const;
 

--- a/extensions/telegram/src/send-context.ts
+++ b/extensions/telegram/src/send-context.ts
@@ -1,5 +1,5 @@
 import { type ApiClientOptions, Bot, HttpError } from "grammy";
-import { isDiagnosticFlagEnabled } from "openclaw/plugin-sdk/diagnostic-runtime";
+import { isDiagnosticFlagEnabled } from "openclaw/plugin-sdk/diagnostic-flags";
 import { formatUncaughtError } from "openclaw/plugin-sdk/error-runtime";
 import { redactSensitiveText } from "openclaw/plugin-sdk/logging-core";
 import { parseStrictInteger } from "openclaw/plugin-sdk/number-runtime";

--- a/package.json
+++ b/package.json
@@ -973,6 +973,10 @@
       "types": "./dist/plugin-sdk/device-bootstrap.d.ts",
       "default": "./dist/plugin-sdk/device-bootstrap.js"
     },
+    "./plugin-sdk/diagnostic-flags": {
+      "types": "./dist/plugin-sdk/diagnostic-flags.d.ts",
+      "default": "./dist/plugin-sdk/diagnostic-flags.js"
+    },
     "./plugin-sdk/diagnostic-runtime": {
       "types": "./dist/plugin-sdk/diagnostic-runtime.d.ts",
       "default": "./dist/plugin-sdk/diagnostic-runtime.js"

--- a/scripts/check-plugin-sdk-exports.mts
+++ b/scripts/check-plugin-sdk-exports.mts
@@ -48,6 +48,7 @@ const forbiddenPublicDeclarationSpecifiers = ["@openclaw/llm-core"];
 const FORBIDDEN_PUBLIC_PROTOCOL_REGISTRY_RE = /\bdeclare\s+const\s+ProtocolSchemas(?:\$\d+)?\b/u;
 const RELATIVE_DECLARATION_SPECIFIER_RE = /\b(?:from|import)\s*(?:\(\s*)?["']([^"']+)["']/gu;
 const requiredSubpathExports: Record<string, string[]> = {
+  "diagnostic-flags": ["isDiagnosticFlagEnabled"],
   "secret-input-runtime": [
     "assertPluginCapabilitySecretAvailable",
     "coerceSecretRef",

--- a/scripts/lib/plugin-sdk-entrypoints.json
+++ b/scripts/lib/plugin-sdk-entrypoints.json
@@ -182,6 +182,7 @@
   "direct-dm-guard-policy",
   "discord",
   "device-bootstrap",
+  "diagnostic-flags",
   "diagnostic-runtime",
   "error-runtime",
   "extension-shared",

--- a/scripts/plugin-sdk-surface-report.mts
+++ b/scripts/plugin-sdk-surface-report.mts
@@ -198,7 +198,8 @@ export function readPluginSdkSurfaceBudgets(env: NodeJS.ProcessEnv = process.env
       // -1: retire the deprecated messaging-targets subpath.
       // +2: bounded provider streams and read-only SecretRef resolution.
       // +1: read-only authoritative conversation-binding inspection for route-owner plugins.
-      147,
+      // +1: diagnostic flag checks without event, trace, or redaction initialization.
+      148,
       env,
     ),
     publicExports: readPluginSdkSurfaceBudgetEnv(
@@ -329,7 +330,8 @@ export function readPluginSdkSurfaceBudgets(env: NodeJS.ProcessEnv = process.env
       // +1: canonical SecretRef default-alias predicate for plugin binding parity.
       // +2: strict session-agent resolution aliases preserve shipped Plugin SDK behavior.
       // +1: manifest-owned plugin capability secret availability guard.
-      4356,
+      // +1: canonical diagnostic flag checker through its focused subpath.
+      4357,
       env,
     ),
     publicFunctionExports: readPluginSdkSurfaceBudgetEnv(
@@ -435,7 +437,8 @@ export function readPluginSdkSurfaceBudgets(env: NodeJS.ProcessEnv = process.env
       // +1: canonical SecretRef default-alias predicate for plugin binding parity.
       // +2: strict session-agent resolution aliases preserve shipped Plugin SDK behavior.
       // +1: manifest-owned plugin capability secret availability guard.
-      2592,
+      // +1: canonical diagnostic flag checker through its focused subpath.
+      2593,
       env,
     ),
     publicDeprecatedExports: readPluginSdkSurfaceBudgetEnv(

--- a/src/agents/tool-input-error.ts
+++ b/src/agents/tool-input-error.ts
@@ -1,0 +1,25 @@
+// Only host construction records trust; error names and prototypes are forgeable.
+const trustedToolInputErrors = new WeakSet<object>();
+
+export class ToolInputError extends Error {
+  readonly status: number = 400;
+
+  constructor(message: string) {
+    super(message);
+    this.name = "ToolInputError";
+    trustedToolInputErrors.add(this);
+  }
+}
+
+export class ToolAuthorizationError extends ToolInputError {
+  override readonly status = 403;
+
+  constructor(message: string) {
+    super(message);
+    this.name = "ToolAuthorizationError";
+  }
+}
+
+export function isTrustedToolInputError(error: unknown): boolean {
+  return typeof error === "object" && error !== null && trustedToolInputErrors.has(error);
+}

--- a/src/agents/tool-result-error.ts
+++ b/src/agents/tool-result-error.ts
@@ -5,6 +5,7 @@ import {
   truncateSanitizedExternalContent,
   wrapExternalContent,
 } from "../security/external-content.js";
+import { isTrustedToolInputError } from "./tool-input-error.js";
 
 const TOOL_TIMEOUT_ERROR_CODES = new Set([
   "ERR_TIMEOUT",
@@ -17,7 +18,6 @@ const TOOL_TIMEOUT_ERROR_CODES = new Set([
 const NETWORK_TOOL_ERROR_MAX_CHARS = 4_000;
 const protectedNetworkToolErrors = new WeakSet<object>();
 const protectedNetworkToolTimeoutErrors = new WeakSet<object>();
-const trustedToolInputErrors = new WeakSet<object>();
 const trustedToolNoStartErrors = new WeakSet<object>();
 
 function readToolErrorField(error: object, key: string): unknown {
@@ -143,15 +143,7 @@ export function resolveToolExecutionErrorKind(error: unknown): "failed" | "timed
 
 /** Authenticates host-owned preflight failures before a tool reaches untrusted network data. */
 export function isTrustedToolExecutionPreflightError(error: unknown): boolean {
-  return (
-    isTrustedSecretSurfaceUnavailableError(error) ||
-    (typeof error === "object" && error !== null && trustedToolInputErrors.has(error))
-  );
-}
-
-/** Records canonical host-created input failures without loading heavyweight tool implementations. */
-export function registerTrustedToolInputError(error: object): void {
-  trustedToolInputErrors.add(error);
+  return isTrustedSecretSurfaceUnavailableError(error) || isTrustedToolInputError(error);
 }
 
 /** Record host-owned proof that the protected operation never started, even if hooks ran. */

--- a/src/agents/tools/common.ts
+++ b/src/agents/tools/common.ts
@@ -21,9 +21,10 @@ import type {
   AgentToolResult,
   AgentToolUpdateCallback,
 } from "../runtime/index.js";
-import { registerTrustedToolInputError } from "../tool-result-error.js";
+import { ToolAuthorizationError, ToolInputError } from "../tool-input-error.js";
 import { textResult } from "./tool-results.js";
 
+export { ToolAuthorizationError, ToolInputError };
 export { jsonResult, textResult } from "./tool-results.js";
 
 export type AgentToolWithMeta<TParameters extends TSchema, TResult> = AgentTool<
@@ -84,25 +85,6 @@ export type ActionGate<T extends Record<string, boolean | undefined>> = (
   key: keyof T,
   defaultValue?: boolean,
 ) => boolean;
-
-export class ToolInputError extends Error {
-  readonly status: number = 400;
-
-  constructor(message: string) {
-    super(message);
-    this.name = "ToolInputError";
-    registerTrustedToolInputError(this);
-  }
-}
-
-export class ToolAuthorizationError extends ToolInputError {
-  override readonly status = 403;
-
-  constructor(message: string) {
-    super(message);
-    this.name = "ToolAuthorizationError";
-  }
-}
 
 export function createActionGate<T extends Record<string, boolean | undefined>>(
   actions: T | undefined,

--- a/src/plugin-sdk/diagnostic-flags.ts
+++ b/src/plugin-sdk/diagnostic-flags.ts
@@ -1,0 +1,2 @@
+// Flag checks avoid initializing diagnostic events, tracing, and redaction.
+export { isDiagnosticFlagEnabled } from "../infra/diagnostic-flags.js";


### PR DESCRIPTION
## What Problem This Solves

Provider artifact tests were spending time initializing logging and redaction while discovering provider metadata. The unchanged 17-case suite takes about 1.97 seconds of test execution on this machine before this change and 1.11 seconds afterward.

## Why This Change Was Made

Two import edges caused the work. Flag-only consumers imported the broad diagnostic runtime, and tool parameter readers reached error formatting just to register canonical input errors. Expose the existing flag checker through a focused generic SDK subpath, and move the input-error classes together with their private constructor-populated trust registry into one dependency-free owner. Keep existing public exports and the broad diagnostic runtime intact.

Brave, Codex profiler gating, and Telegram flag checks use the focused subpath. Tool error names, inheritance, statuses, exact identity, forged-prototype rejection, no-start tracking, timeout classification, filesystem checks, and image handling remain unchanged. The unused arbitrary input-error registration export is removed. No sharding, concurrency, worker counts, test selection, assertions, or timeouts change.

## User Impact

Faster provider discovery and test execution without a behavior or configuration change. The new documented `plugin-sdk/diagnostic-flags` subpath adds one callable reexport; package exports are canonically generated and the source-defined SDK surface limits account for exactly that addition. Production delta is +34/-33 (net +1); tooling +8/-3, package metadata +4, docs +1, tests unchanged. The growth establishes the lightweight ownership boundary rather than duplicating behavior.

## Evidence

Alternating before/after runs of the same 17-case suite: 1,985.743/1,109.198 ms and 1,953.161/1,104.856 ms, about 44% lower test execution time. This is a focused measurement, not a whole-suite percentage. A flag-only trial was rejected because it merely shifted the initialization to another provider.

- 97 existing parameter, error classification, network-wrapper, Code Mode preflight and adapter cases pass. Removing constructor registration fails both genuine input/auth identity cases; changing membership to `instanceof` fails forged-prototype and hostile-reflection cases. Both temporary mutations were restored.
- 87 final canonical flag, Brave, Codex profiler, Telegram HTTP, SDK generation and surface-report cases pass. A fresh broad unit-fast run passes 15,187 tests with zero failures and six pending cases.
- Full build passes. Actual built SDK/host paths share diagnostic function and input/auth error identities; the host rejects forged prototypes. Source image proof preserves PNG bytes/MIME/text/private metadata, real 16x16-to-8x8 resizing, and missing/directory/symlink rejection.
- Independent Codex autoreview and the complete repository changed gate pass, including all typechecks, lint, SDK export/surface checks, dead-export scans, and zero runtime import cycles. Isolated built entrypoints for Brave, Codex and Telegram load successfully. Hosted CI is verified on the exact PR head before landing.

No external provider request or live Telegram message is needed for these import-only changes: HTTP behavior, transport, protocol, flag evaluation, and call ordering are unchanged. The existing Telegram HTTP tests cover the real local HTTP composition. Codex app-server request/response ownership was checked directly in upstream `codex-rs/app-server/src/message_processor.rs:104,825-847`; no protocol field changes.

Canonical revision API diff (`929e8644`): one subpath and one function added, no removed or changed public signatures. The error-owner move changes reachable declaration closures for 109 existing exports; all 109 direct declarations remain byte-identical.

Maintainer SDK decision: retain the documented one-function `diagnostic-flags` subpath as a supported plugin contract. It serves three independent existing callers, exposes the existing canonical function, and changes no configuration, authority, persistence, or existing public signature. The maintained surface is worth the measured reduction; the broader diagnostic runtime remains supported. This addresses the ClawSweeper SDK-stewardship decision and rank-up request.

CI prerequisite: the first run (`33265797513`) failed only because main's #132664 added a Codex regression file without registering it in the existing inventory. Canonical repair #132743 is merged; the performance branch was mechanically refreshed onto that main with identical patch ID. The prerequisite restores two missing tests without changing the sharding layout and is not counted as a speedup.

Final refreshed head `1214732b93732b2e270c316c21ff1d77f0c92421`: [full hosted CI passes](https://github.com/openclaw/openclaw/actions/runs/33266518315). Rebuilt SDK/host identity and real image/filesystem probes also pass.

AI-assisted with Codex.
