### PR TITLE
fix(codex): reaper could kill a recycled-pid process and skipped cleanup until next use

### DIFF
--- a/docs/plugins/codex-harness-runtime.md
+++ b/docs/plugins/codex-harness-runtime.md
@@ -81,8 +81,10 @@ its registration is durable.
 
 Cleanup only targets a registered child whose original OpenClaw parent is no
 longer running. It checks process IDs, start times, and process groups before
-terminating the orphan and its discoverable descendants. When recorded, the child
-command line must also match the live process before signaling. Another live
+terminating the orphan and its discoverable descendants. When recorded, a
+fingerprint of the child command line must also match the live process before
+signaling; the durable registration stores only that digest, never the raw
+arguments. Another live
 OpenClaw instance, processes registered under another state directory, and externally
 managed WebSocket or Unix-socket app-servers are left alone. These portable
 process checks do not provide an atomic operating-system ownership guarantee

--- a/docs/plugins/codex-harness-runtime.md
+++ b/docs/plugins/codex-harness-runtime.md
@@ -72,16 +72,18 @@ Code Mode execution.
 ## Recovery after a hard Gateway stop
 
 On POSIX systems, OpenClaw checks for registered orphaned Codex app-server
-processes before spawning each fresh stdio child. This runs when the connection
-is needed, not necessarily at Gateway boot. OpenClaw records the parent and
-child process identities in the current state directory's SQLite plugin store
+processes before spawning each fresh stdio child. Gateway startup also runs a
+best-effort background sweep; the before-spawn check remains authoritative.
+OpenClaw records the parent and child process identities in the current state
+directory's SQLite plugin store
 before sending Codex `initialize`, so a child cannot start a native turn before
 its registration is durable.
 
 Cleanup only targets a registered child whose original OpenClaw parent is no
 longer running. It checks process IDs, start times, and process groups before
-terminating the orphan and its discoverable descendants. Another live OpenClaw
-instance, processes registered under another state directory, and externally
+terminating the orphan and its discoverable descendants. When recorded, the child
+command line must also match the live process before signaling. Another live
+OpenClaw instance, processes registered under another state directory, and externally
 managed WebSocket or Unix-socket app-servers are left alone. These portable
 process checks do not provide an atomic operating-system ownership guarantee
 or discover descendants that independently reparented before inspection.

--- a/extensions/codex/index.test.ts
+++ b/extensions/codex/index.test.ts
@@ -154,7 +154,13 @@ describe("codex plugin", () => {
       }),
     );
 
-    expect(registerService).toHaveBeenCalledTimes(2);
+    expect(registerService).toHaveBeenCalledTimes(3);
+    expect(registerService.mock.calls.map(([service]) => service)).toContainEqual(
+      expect.objectContaining({
+        id: "codex-app-server-process-reaper",
+        start: expect.any(Function),
+      }),
+    );
     expect(registerService.mock.calls.map(([service]) => service)).toContainEqual(
       expect.objectContaining({
         id: "codex-app-server-connection-health",
@@ -180,11 +186,15 @@ describe("codex plugin", () => {
         }),
       );
 
-      expect(registerService).toHaveBeenCalledOnce();
+      expect(registerService).toHaveBeenCalledTimes(2);
       expect(mockCallArg(registerService)).toMatchObject({
         id: "codex-desktop-generation",
         start: expect.any(Function),
         stop: expect.any(Function),
+      });
+      expect(mockCallArg(registerService, 1)).toMatchObject({
+        id: "codex-app-server-process-reaper",
+        start: expect.any(Function),
       });
     }
   });

--- a/extensions/codex/index.ts
+++ b/extensions/codex/index.ts
@@ -33,6 +33,7 @@ import {
   type StoredCodexAppServerBinding,
 } from "./src/app-server/session-binding-store.js";
 import { retireSharedCodexAppServerClientsBeforeDesktopGeneration } from "./src/app-server/shared-client.js";
+import { createCodexAppServerProcessReaperService } from "./src/app-server/transport-process-registration.js";
 import type { CodexPluginsConfigBlock } from "./src/command-plugins-management.js";
 import { createCodexCommand } from "./src/commands.js";
 import { codexConversationBindingRuntime } from "./src/conversation-binding.js";
@@ -110,6 +111,7 @@ export default definePluginEntry({
         onGenerationChange: retireSharedCodexAppServerClientsBeforeDesktopGeneration,
       }),
     );
+    api.registerService(createCodexAppServerProcessReaperService());
     if (appServerConfig?.transport === "websocket") {
       api.registerService(
         createCodexAppServerConnectionHealthService({

--- a/extensions/codex/src/app-server/transport-process-registration.test.ts
+++ b/extensions/codex/src/app-server/transport-process-registration.test.ts
@@ -1,4 +1,5 @@
 import { ChildProcess } from "node:child_process";
+import { createHash } from "node:crypto";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -40,13 +41,14 @@ const parent = { pid: process.pid + 1, pgid: process.pid + 1, startedAt: observe
 const child = { pid: process.pid + 2, pgid: process.pid + 2, startedAt: observer.startedAt };
 const liveChild: PosixProcess = { ...child, ppid: 1, state: "S" };
 const command = "/opt/codex app-server --listen stdio://";
+const commandFingerprint = createHash("sha256").update(command).digest("hex");
 
 async function openStore() {
   const { createPluginStateSyncKeyedStore } =
     await import("openclaw/plugin-sdk/plugin-state-store-runtime");
   return createPluginStateSyncKeyedStore<{
     parent: typeof parent;
-    child: typeof child & { command?: string };
+    child: typeof child & { commandFingerprint?: string };
   }>("codex", {
     namespace: "app-server-processes",
     maxEntries: 512,
@@ -81,7 +83,7 @@ describe("Codex process registration", () => {
   });
 
   it("never kills a same-second replacement process running a different command", async () => {
-    store.register("orphan", { parent, child: { ...child, command } });
+    store.register("orphan", { parent, child: { ...child, commandFingerprint } });
     vi.mocked(readCodexAppServerProcessCommand).mockResolvedValue("/usr/bin/unrelated-worker");
 
     await expect(prepareCodexAppServerProcessRegistration()).resolves.toBeTypeOf("function");
@@ -91,7 +93,7 @@ describe("Codex process registration", () => {
   });
 
   it.for(["legacy", "matching command"])("reaps a %s registration", async (mode) => {
-    const registeredChild = mode === "legacy" ? child : { ...child, command };
+    const registeredChild = mode === "legacy" ? child : { ...child, commandFingerprint };
     store.register("orphan", { parent, child: registeredChild });
 
     await expect(prepareCodexAppServerProcessRegistration()).resolves.toBeTypeOf("function");
@@ -104,7 +106,7 @@ describe("Codex process registration", () => {
   it.for(["gone", "replaced"])(
     "lets containment settle a %s child after command inspection fails",
     async (mode) => {
-      store.register("orphan", { parent, child: { ...child, command } });
+      store.register("orphan", { parent, child: { ...child, commandFingerprint } });
       vi.mocked(readCodexAppServerProcessCommand).mockResolvedValue(undefined);
       vi.mocked(readCodexAppServerProcess).mockResolvedValue(
         mode === "gone" ? undefined : { ...liveChild, startedAt: "a later start" },
@@ -112,13 +114,16 @@ describe("Codex process registration", () => {
 
       await expect(prepareCodexAppServerProcessRegistration()).resolves.toBeTypeOf("function");
 
-      expect(terminateCodexAppServerOrphan).toHaveBeenCalledExactlyOnceWith({ ...child, command });
+      expect(terminateCodexAppServerOrphan).toHaveBeenCalledExactlyOnceWith({
+        ...child,
+        commandFingerprint,
+      });
       expect(store.lookup("orphan")).toBeUndefined();
     },
   );
 
   it("refuses a spawn and retains the row when the matching child's command is unreadable", async () => {
-    const registration = { parent, child: { ...child, command } };
+    const registration = { parent, child: { ...child, commandFingerprint } };
     store.register("orphan", registration);
     vi.mocked(readCodexAppServerProcessCommand).mockResolvedValue(undefined);
     vi.mocked(readCodexAppServerProcess).mockResolvedValue(liveChild);
@@ -134,7 +139,7 @@ describe("Codex process registration", () => {
   it.for(["gone", "zombie", "replaced"])(
     "skips command inspection when the snapshot child is %s",
     async (mode) => {
-      store.register("orphan", { parent, child: { ...child, command } });
+      store.register("orphan", { parent, child: { ...child, commandFingerprint } });
       vi.mocked(readCodexAppServerProcessSnapshot).mockResolvedValue([
         observer,
         ...(mode === "gone"
@@ -151,7 +156,7 @@ describe("Codex process registration", () => {
   );
 
   it("leaves a live parent's child registered without inspecting its command", async () => {
-    const registration = { parent, child: { ...child, command } };
+    const registration = { parent, child: { ...child, commandFingerprint } };
     store.register("owned", registration);
     vi.mocked(readCodexAppServerProcessSnapshot).mockResolvedValue([
       observer,
@@ -214,9 +219,11 @@ describe("Codex process registration", () => {
         expect(store.entries().map((entry) => entry.value)).toEqual([
           {
             parent: { pid: observer.pid, pgid: observer.pgid, startedAt: observer.startedAt },
-            child: { ...child, command },
+            child: { ...child, commandFingerprint },
           },
         ]);
+        // Durable rows must never expose the raw argv (appServer.args can carry secrets).
+        expect(JSON.stringify(store.entries())).not.toContain(command);
         expect(kill).not.toHaveBeenCalled();
         spawned.emit("exit", 0, null);
         expect(store.entries()).toEqual([]);
@@ -234,7 +241,7 @@ describe("Codex process registration", () => {
   it.for(["success", "failure", "win32"])(
     "starts a nonblocking best-effort boot sweep: %s",
     async (mode) => {
-      store.register("orphan", { parent, child: { ...child, command } });
+      store.register("orphan", { parent, child: { ...child, commandFingerprint } });
       const warn = vi.fn();
       const service = createCodexAppServerProcessReaperService();
       const sweep = createDeferred<boolean>();

--- a/extensions/codex/src/app-server/transport-process-registration.test.ts
+++ b/extensions/codex/src/app-server/transport-process-registration.test.ts
@@ -1,0 +1,275 @@
+import { ChildProcess } from "node:child_process";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { PassThrough } from "node:stream";
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { terminateCodexAppServerOrphan } from "./transport-process-containment.js";
+import {
+  createCodexAppServerProcessReaperService,
+  prepareCodexAppServerProcessRegistration,
+} from "./transport-process-registration.js";
+import {
+  readCodexAppServerProcess,
+  readCodexAppServerProcessCommand,
+  readCodexAppServerProcessSnapshot,
+  type PosixProcess,
+} from "./transport-process-snapshot.js";
+
+vi.mock("./transport-process-snapshot.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./transport-process-snapshot.js")>()),
+  readCodexAppServerProcessSnapshot: vi.fn(),
+  readCodexAppServerProcess: vi.fn(),
+  readCodexAppServerProcessCommand: vi.fn(),
+}));
+
+vi.mock("./transport-process-containment.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./transport-process-containment.js")>()),
+  terminateCodexAppServerOrphan: vi.fn(),
+}));
+
+const observer: PosixProcess = {
+  pid: process.pid,
+  ppid: process.ppid,
+  pgid: process.pid,
+  state: "S",
+  startedAt: "Sat Aug 29 10:00:00 2026",
+};
+const parent = { pid: process.pid + 1, pgid: process.pid + 1, startedAt: observer.startedAt };
+const child = { pid: process.pid + 2, pgid: process.pid + 2, startedAt: observer.startedAt };
+const liveChild: PosixProcess = { ...child, ppid: 1, state: "S" };
+const command = "/opt/codex app-server --listen stdio://";
+
+async function openStore() {
+  const { createPluginStateSyncKeyedStore } =
+    await import("openclaw/plugin-sdk/plugin-state-store-runtime");
+  return createPluginStateSyncKeyedStore<{
+    parent: typeof parent;
+    child: typeof child & { command?: string };
+  }>("codex", {
+    namespace: "app-server-processes",
+    maxEntries: 512,
+    overflowPolicy: "reject-new",
+  });
+}
+
+describe("Codex process registration", () => {
+  let root: string;
+  let store: Awaited<ReturnType<typeof openStore>>;
+
+  beforeEach(async () => {
+    root = await fs.mkdtemp(path.join(os.tmpdir(), "codex-process-registration-"));
+    vi.stubEnv("OPENCLAW_STATE_DIR", root);
+    vi.spyOn(process, "platform", "get").mockReturnValue("darwin");
+    store = await openStore();
+    vi.mocked(readCodexAppServerProcessSnapshot).mockResolvedValue([
+      observer,
+      { ...parent, ppid: 1, state: "Z" },
+      liveChild,
+    ]);
+    vi.mocked(readCodexAppServerProcessCommand).mockResolvedValue(command);
+    vi.mocked(terminateCodexAppServerOrphan).mockResolvedValue(true);
+  });
+
+  afterEach(async () => {
+    store.clear();
+    vi.restoreAllMocks();
+    vi.resetAllMocks();
+    vi.unstubAllEnvs();
+    await fs.rm(root, { recursive: true, force: true });
+  });
+
+  it("never kills a same-second replacement process running a different command", async () => {
+    store.register("orphan", { parent, child: { ...child, command } });
+    vi.mocked(readCodexAppServerProcessCommand).mockResolvedValue("/usr/bin/unrelated-worker");
+
+    await expect(prepareCodexAppServerProcessRegistration()).resolves.toBeTypeOf("function");
+
+    expect(terminateCodexAppServerOrphan).not.toHaveBeenCalled();
+    expect(store.lookup("orphan")).toBeUndefined();
+  });
+
+  it.for(["legacy", "matching command"])("reaps a %s registration", async (mode) => {
+    const registeredChild = mode === "legacy" ? child : { ...child, command };
+    store.register("orphan", { parent, child: registeredChild });
+
+    await expect(prepareCodexAppServerProcessRegistration()).resolves.toBeTypeOf("function");
+
+    expect(terminateCodexAppServerOrphan).toHaveBeenCalledExactlyOnceWith(registeredChild);
+    expect(store.lookup("orphan")).toBeUndefined();
+    expect(readCodexAppServerProcessCommand).toHaveBeenCalledTimes(mode === "legacy" ? 0 : 1);
+  });
+
+  it.for(["gone", "replaced"])(
+    "lets containment settle a %s child after command inspection fails",
+    async (mode) => {
+      store.register("orphan", { parent, child: { ...child, command } });
+      vi.mocked(readCodexAppServerProcessCommand).mockResolvedValue(undefined);
+      vi.mocked(readCodexAppServerProcess).mockResolvedValue(
+        mode === "gone" ? undefined : { ...liveChild, startedAt: "a later start" },
+      );
+
+      await expect(prepareCodexAppServerProcessRegistration()).resolves.toBeTypeOf("function");
+
+      expect(terminateCodexAppServerOrphan).toHaveBeenCalledExactlyOnceWith({ ...child, command });
+      expect(store.lookup("orphan")).toBeUndefined();
+    },
+  );
+
+  it("refuses a spawn and retains the row when the matching child's command is unreadable", async () => {
+    const registration = { parent, child: { ...child, command } };
+    store.register("orphan", registration);
+    vi.mocked(readCodexAppServerProcessCommand).mockResolvedValue(undefined);
+    vi.mocked(readCodexAppServerProcess).mockResolvedValue(liveChild);
+
+    await expect(prepareCodexAppServerProcessRegistration()).rejects.toThrow(
+      `Cannot inspect registered Codex process ${child.pid} command. Check process command inspection permissions (/proc on Linux, ps on macOS), then retry.`,
+    );
+
+    expect(store.lookup("orphan")).toEqual(registration);
+    expect(terminateCodexAppServerOrphan).not.toHaveBeenCalled();
+  });
+
+  it.for(["gone", "zombie", "replaced"])(
+    "skips command inspection when the snapshot child is %s",
+    async (mode) => {
+      store.register("orphan", { parent, child: { ...child, command } });
+      vi.mocked(readCodexAppServerProcessSnapshot).mockResolvedValue([
+        observer,
+        ...(mode === "gone"
+          ? []
+          : [{ ...liveChild, ...(mode === "zombie" ? { state: "Z" } : { startedAt: "later" }) }]),
+      ]);
+
+      await prepareCodexAppServerProcessRegistration();
+
+      expect(readCodexAppServerProcessCommand).not.toHaveBeenCalled();
+      expect(terminateCodexAppServerOrphan).toHaveBeenCalledOnce();
+      expect(store.lookup("orphan")).toBeUndefined();
+    },
+  );
+
+  it("leaves a live parent's child registered without inspecting its command", async () => {
+    const registration = { parent, child: { ...child, command } };
+    store.register("owned", registration);
+    vi.mocked(readCodexAppServerProcessSnapshot).mockResolvedValue([
+      observer,
+      { ...parent, ppid: 1, state: "S" },
+      liveChild,
+    ]);
+
+    await prepareCodexAppServerProcessRegistration();
+
+    expect(readCodexAppServerProcessCommand).not.toHaveBeenCalled();
+    expect(terminateCodexAppServerOrphan).not.toHaveBeenCalled();
+    expect(store.lookup("owned")).toEqual(registration);
+  });
+
+  it.for(["live", "unreadable command", "exited during inspection"])(
+    "registers only a live child with its command: %s",
+    async (mode, ctx) => {
+      const stdin = new PassThrough();
+      const stdout = new PassThrough();
+      const stderr = new PassThrough();
+      // The typed stdio tuple makes this fixture structurally a
+      // ChildProcessWithoutNullStreams without widening casts.
+      const spawned = Object.assign(new ChildProcess(), {
+        pid: child.pid,
+        stdin,
+        stdout,
+        stderr,
+        stdio: [stdin, stdout, stderr, null, null] as [
+          PassThrough,
+          PassThrough,
+          PassThrough,
+          null,
+          null,
+        ],
+      });
+      ctx.onTestFinished(() => {
+        spawned.stdin.destroy();
+        spawned.stdout.destroy();
+        spawned.stderr.destroy();
+        spawned.removeAllListeners();
+      });
+      const kill = vi.spyOn(spawned, "kill").mockReturnValue(true);
+      vi.mocked(readCodexAppServerProcessSnapshot).mockResolvedValue([
+        observer,
+        { ...liveChild, ppid: process.pid },
+      ]);
+      vi.mocked(readCodexAppServerProcessCommand).mockImplementation(async () => {
+        if (mode === "exited during inspection") {
+          Object.defineProperty(spawned, "exitCode", { value: 0, configurable: true });
+          spawned.emit("exit", 0, null);
+        }
+        return mode === "unreadable command" ? undefined : command;
+      });
+      const register = await prepareCodexAppServerProcessRegistration();
+      const registered = register(spawned);
+      spawned.emit("spawn");
+
+      if (mode === "live") {
+        await registered;
+        expect(store.entries().map((entry) => entry.value)).toEqual([
+          {
+            parent: { pid: observer.pid, pgid: observer.pgid, startedAt: observer.startedAt },
+            child: { ...child, command },
+          },
+        ]);
+        expect(kill).not.toHaveBeenCalled();
+        spawned.emit("exit", 0, null);
+        expect(store.entries()).toEqual([]);
+      } else {
+        await expect(registered).rejects.toThrow("Cannot register the Codex child process command");
+        expect(kill).toHaveBeenCalledExactlyOnceWith("SIGKILL");
+        expect(
+          [spawned.stdin, spawned.stdout, spawned.stderr].every((stream) => stream.destroyed),
+        ).toBe(true);
+        expect(store.entries()).toEqual([]);
+      }
+    },
+  );
+
+  it.for(["success", "failure", "win32"])(
+    "starts a nonblocking best-effort boot sweep: %s",
+    async (mode) => {
+      store.register("orphan", { parent, child: { ...child, command } });
+      const warn = vi.fn();
+      const service = createCodexAppServerProcessReaperService();
+      const sweep = createDeferred<boolean>();
+      vi.mocked(terminateCodexAppServerOrphan).mockReturnValue(sweep.promise);
+      if (mode === "win32") {
+        vi.spyOn(process, "platform", "get").mockReturnValue("win32");
+      }
+
+      expect(
+        service.start({
+          config: {},
+          stateDir: root,
+          logger: { debug: vi.fn(), info: vi.fn(), warn, error: vi.fn() },
+        }),
+      ).toBeUndefined();
+
+      if (mode === "win32") {
+        expect(readCodexAppServerProcessSnapshot).not.toHaveBeenCalled();
+        expect(terminateCodexAppServerOrphan).not.toHaveBeenCalled();
+        expect(store.lookup("orphan")).toBeDefined();
+        expect(warn).not.toHaveBeenCalled();
+        return;
+      }
+      await expect.poll(() => vi.mocked(terminateCodexAppServerOrphan).mock.calls.length).toBe(1);
+      if (mode === "failure") {
+        sweep.reject(new Error("inspection unavailable"));
+        await expect
+          .poll(() => warn.mock.calls)
+          .toEqual([["Codex app-server orphan cleanup failed: Error: inspection unavailable"]]);
+        expect(store.lookup("orphan")).toBeDefined();
+      } else {
+        sweep.resolve(true);
+        await expect.poll(() => store.lookup("orphan")).toBeUndefined();
+        expect(warn).not.toHaveBeenCalled();
+      }
+    },
+  );
+});

--- a/extensions/codex/src/app-server/transport-process-registration.ts
+++ b/extensions/codex/src/app-server/transport-process-registration.ts
@@ -1,36 +1,42 @@
 import type { ChildProcessWithoutNullStreams } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import { once } from "node:events";
+import type { OpenClawPluginService } from "openclaw/plugin-sdk/plugin-entry";
 import { z } from "zod";
 import { terminateCodexAppServerOrphan } from "./transport-process-containment.js";
-import { readCodexAppServerProcessSnapshot } from "./transport-process-snapshot.js";
+import {
+  readCodexAppServerProcess,
+  readCodexAppServerProcessCommand,
+  readCodexAppServerProcessSnapshot,
+} from "./transport-process-snapshot.js";
 
 const processIdentity = z.object({
   pid: z.number().int().positive().safe(),
   pgid: z.number().int().positive().safe(),
   startedAt: z.string().min(1).max(64),
 });
-const registrationSchema = z.object({ parent: processIdentity, child: processIdentity }).strict();
+const childIdentity = processIdentity.extend({
+  // Unreleased dev/nightly rows stay reapable with identity-only authority instead
+  // of blocking spawns. Require command at the next natural schema touch.
+  command: z.string().min(1).max(4096).optional(),
+});
+const registrationSchema = z.object({ parent: processIdentity, child: childIdentity }).strict();
 type ProcessRegistration = z.infer<typeof registrationSchema>;
 
-/** Reap previous owners before spawn; commit this child's identity before initialization. */
-export async function prepareCodexAppServerProcessRegistration(): Promise<
-  (child: ChildProcessWithoutNullStreams) => Promise<void>
-> {
-  if (process.platform === "win32") {
-    return async (child) => {
-      await once(child, "spawn");
-    };
-  }
+async function openProcessRegistrationStore() {
   const { createPluginStateSyncKeyedStore } =
     await import("openclaw/plugin-sdk/plugin-state-store-runtime");
-  const store = createPluginStateSyncKeyedStore<ProcessRegistration>("codex", {
+  return createPluginStateSyncKeyedStore<ProcessRegistration>("codex", {
     namespace: "app-server-processes",
     maxEntries: 512,
     // Expiration or eviction could forget a child that still owns a native turn.
     overflowPolicy: "reject-new",
   });
-  const deadline = Date.now() + 10_000;
+}
+
+async function reapRegisteredCodexAppServerOrphans(requestedDeadline?: number): Promise<void> {
+  const store = await openProcessRegistrationStore();
+  const deadline = requestedDeadline ?? Date.now() + 10_000;
   for (const entry of store.entries()) {
     if (Date.now() >= deadline) {
       throw new Error("Codex orphan cleanup exceeded its startup budget. Retry to finish cleanup.");
@@ -46,6 +52,28 @@ export async function prepareCodexAppServerProcessRegistration(): Promise<
     if (parent?.startedAt === registration.parent.startedAt && !parent.state.startsWith("Z")) {
       continue;
     }
+    const child = snapshot.find((row) => row.pid === registration.child.pid);
+    if (
+      registration.child.command !== undefined &&
+      child?.startedAt === registration.child.startedAt &&
+      !child.state.startsWith("Z")
+    ) {
+      const command = await readCodexAppServerProcessCommand(registration.child.pid, deadline);
+      if (command === undefined) {
+        const current = await readCodexAppServerProcess(registration.child.pid, deadline);
+        if (current?.startedAt === registration.child.startedAt) {
+          throw new Error(
+            `Cannot inspect registered Codex process ${registration.child.pid} command. Check process command inspection permissions (/proc on Linux, ps on macOS), then retry.`,
+          );
+        }
+      } else if (command !== registration.child.command) {
+        // macOS lstart has second granularity: a replacement can inherit pid +
+        // startedAt. A different command revokes kill authority; Linux already
+        // uses tick-granular start identities.
+        store.delete(entry.key);
+        continue;
+      }
+    }
     if (!(await terminateCodexAppServerOrphan(registration.child))) {
       throw new Error(
         `Cannot reap registered Codex process ${registration.child.pid}. Stop it before retrying.`,
@@ -53,21 +81,54 @@ export async function prepareCodexAppServerProcessRegistration(): Promise<
     }
     store.delete(entry.key);
   }
+}
+
+export function createCodexAppServerProcessReaperService(): OpenClawPluginService {
+  return {
+    id: "codex-app-server-process-reaper",
+    start(ctx) {
+      if (process.platform === "win32") {
+        return;
+      }
+      // Boot cleanup is best-effort promptness. The before-spawn check remains
+      // authoritative and fails closed without delaying Gateway startup.
+      void (async () => {
+        try {
+          await reapRegisteredCodexAppServerOrphans();
+        } catch (error) {
+          ctx.logger.warn(`Codex app-server orphan cleanup failed: ${String(error)}`);
+        }
+      })();
+    },
+  };
+}
+
+/** Reap previous owners before spawn; commit this child's identity before initialization. */
+export async function prepareCodexAppServerProcessRegistration(): Promise<
+  (child: ChildProcessWithoutNullStreams) => Promise<void>
+> {
+  if (process.platform === "win32") {
+    return async (child) => {
+      await once(child, "spawn");
+    };
+  }
+  await reapRegisteredCodexAppServerOrphans();
+  const store = await openProcessRegistrationStore();
   return async (child) => {
     try {
       await once(child, "spawn");
       const snapshot = await readCodexAppServerProcessSnapshot();
       const parent = snapshot?.find((row) => row.pid === process.pid);
       const spawned = snapshot?.find((row) => row.pid === child.pid);
-      if (
-        !parent ||
-        !spawned ||
-        spawned.ppid !== process.pid ||
-        child.exitCode !== null ||
-        child.signalCode !== null
-      ) {
+      if (!parent || !spawned || spawned.ppid !== process.pid) {
         throw new Error(
           "Cannot register the Codex child process. Check process inspection permissions (/proc on Linux, ps on macOS), then retry.",
+        );
+      }
+      const command = await readCodexAppServerProcessCommand(spawned.pid, Date.now() + 2_000);
+      if (command === undefined || child.exitCode !== null || child.signalCode !== null) {
+        throw new Error(
+          "Cannot register the Codex child process command. Check process command inspection permissions (/proc on Linux, ps on macOS), then retry.",
         );
       }
       const key = randomUUID();
@@ -75,7 +136,7 @@ export async function prepareCodexAppServerProcessRegistration(): Promise<
       // this synchronous commit. A failed commit closes the uninitialized child.
       store.register(key, {
         parent: processIdentity.parse(parent),
-        child: processIdentity.parse(spawned),
+        child: childIdentity.parse({ ...spawned, command }),
       });
       child.once("exit", () => {
         try {

--- a/extensions/codex/src/app-server/transport-process-registration.ts
+++ b/extensions/codex/src/app-server/transport-process-registration.ts
@@ -1,5 +1,5 @@
 import type { ChildProcessWithoutNullStreams } from "node:child_process";
-import { randomUUID } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import { once } from "node:events";
 import type { OpenClawPluginService } from "openclaw/plugin-sdk/plugin-entry";
 import { z } from "zod";
@@ -16,12 +16,21 @@ const processIdentity = z.object({
   startedAt: z.string().min(1).max(64),
 });
 const childIdentity = processIdentity.extend({
+  // Durable rows hold only a digest: appServer.args is operator-configurable and
+  // may carry secrets, matching the spawn-identity argsFingerprint precedent.
   // Unreleased dev/nightly rows stay reapable with identity-only authority instead
-  // of blocking spawns. Require command at the next natural schema touch.
-  command: z.string().min(1).max(4096).optional(),
+  // of blocking spawns. Require the fingerprint at the next natural schema touch.
+  commandFingerprint: z
+    .string()
+    .regex(/^[a-f0-9]{64}$/)
+    .optional(),
 });
 const registrationSchema = z.object({ parent: processIdentity, child: childIdentity }).strict();
 type ProcessRegistration = z.infer<typeof registrationSchema>;
+
+function fingerprintProcessCommand(command: string): string {
+  return createHash("sha256").update(command).digest("hex");
+}
 
 async function openProcessRegistrationStore() {
   const { createPluginStateSyncKeyedStore } =
@@ -54,7 +63,7 @@ async function reapRegisteredCodexAppServerOrphans(requestedDeadline?: number): 
     }
     const child = snapshot.find((row) => row.pid === registration.child.pid);
     if (
-      registration.child.command !== undefined &&
+      registration.child.commandFingerprint !== undefined &&
       child?.startedAt === registration.child.startedAt &&
       !child.state.startsWith("Z")
     ) {
@@ -66,7 +75,7 @@ async function reapRegisteredCodexAppServerOrphans(requestedDeadline?: number): 
             `Cannot inspect registered Codex process ${registration.child.pid} command. Check process command inspection permissions (/proc on Linux, ps on macOS), then retry.`,
           );
         }
-      } else if (command !== registration.child.command) {
+      } else if (fingerprintProcessCommand(command) !== registration.child.commandFingerprint) {
         // macOS lstart has second granularity: a replacement can inherit pid +
         // startedAt. A different command revokes kill authority; Linux already
         // uses tick-granular start identities.
@@ -136,7 +145,10 @@ export async function prepareCodexAppServerProcessRegistration(): Promise<
       // this synchronous commit. A failed commit closes the uninitialized child.
       store.register(key, {
         parent: processIdentity.parse(parent),
-        child: childIdentity.parse({ ...spawned, command }),
+        child: childIdentity.parse({
+          ...spawned,
+          commandFingerprint: fingerprintProcessCommand(command),
+        }),
       });
       child.once("exit", () => {
         try {

--- a/extensions/codex/src/app-server/transport-process-snapshot.test.ts
+++ b/extensions/codex/src/app-server/transport-process-snapshot.test.ts
@@ -5,7 +5,10 @@ import path from "node:path";
 import { isPidAlive } from "openclaw/plugin-sdk/process-runtime";
 import { withEnvAsync } from "openclaw/plugin-sdk/test-env";
 import { describe, expect, it, vi } from "vitest";
-import { readCodexAppServerProcessSnapshot } from "./transport-process-snapshot.js";
+import {
+  readCodexAppServerProcessCommand,
+  readCodexAppServerProcessSnapshot,
+} from "./transport-process-snapshot.js";
 
 const procfs = vi.hoisted(() => ({
   readFile: vi.fn<(file: string) => Promise<string>>(),
@@ -27,6 +30,43 @@ vi.mock("node:fs/promises", async (importOriginal) => {
         ? procfs.readdir()
         : original.readdir(...args),
   };
+});
+
+describe("Codex procfs command inspector", () => {
+  it.for([
+    {
+      input: "/opt/codex\0app-server\0--listen\0stdio://\0",
+      expected: "/opt/codex app-server --listen stdio://",
+    },
+    { input: "", expected: undefined },
+    { input: "\0", expected: undefined },
+    { code: "ENOENT", expected: undefined },
+    { code: "ESRCH", expected: undefined },
+    { code: "EACCES", expected: undefined },
+  ])(
+    "reads command identity without authorizing absent or unreadable processes: %j",
+    async (fixture, ctx) => {
+      ctx.onTestFinished(() => {
+        procfs.readFile.mockReset();
+        vi.restoreAllMocks();
+      });
+      vi.spyOn(process, "platform", "get").mockReturnValue("linux");
+      procfs.readFile.mockImplementation(async (file) => {
+        expect(file).toBe(`/proc/${process.pid}/cmdline`);
+        if (fixture.code) {
+          throw Object.assign(new Error("command unavailable"), { code: fixture.code });
+        }
+        return fixture.input!;
+      });
+
+      expect(await readCodexAppServerProcessCommand(process.pid, Date.now() + 1_000)).toBe(
+        fixture.expected,
+      );
+      procfs.readFile.mockClear();
+      expect(await readCodexAppServerProcessCommand(process.pid, Date.now() - 1)).toBeUndefined();
+      expect(procfs.readFile).not.toHaveBeenCalled();
+    },
+  );
 });
 
 describe.skipIf(process.platform !== "linux")("Codex procfs process inspector", () => {
@@ -74,9 +114,14 @@ describe.skipIf(process.platform !== "linux")("Codex procfs process inspector", 
 describe.skipIf(process.platform === "win32" || process.platform === "linux")(
   "Codex POSIX process inspector",
   () => {
-    it.for(["unavailable", "hung"] as const)(
+    it.for([
+      ["snapshot", "unavailable"],
+      ["snapshot", "hung"],
+      ["command", "unavailable"],
+      ["command", "hung"],
+    ] as const)(
       "settles a %s ps inspector without leaking its process",
-      async (mode, ctx) => {
+      async ([kind, mode], ctx) => {
         const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "codex-ps-deadline-"));
         const inspectorPath = path.join(tempDir, "ps");
         const pidPath = path.join(tempDir, "inspector.pid");
@@ -111,7 +156,10 @@ ${mode === "unavailable" ? "process.exit(1);" : "setInterval(() => {}, 1000);"}
           async () => {
             const startedAt = Date.now();
             const budgetMs = 1_000;
-            const result = await readCodexAppServerProcessSnapshot(startedAt + budgetMs);
+            const result =
+              kind === "command"
+                ? await readCodexAppServerProcessCommand(process.pid, startedAt + budgetMs)
+                : await readCodexAppServerProcessSnapshot(startedAt + budgetMs);
             const pid = Number(await fs.readFile(pidPath, "utf8"));
             inspectorPid = pid;
             expect(pid).toBeGreaterThan(0);

--- a/extensions/codex/src/app-server/transport-process-snapshot.ts
+++ b/extensions/codex/src/app-server/transport-process-snapshot.ts
@@ -32,23 +32,53 @@ export async function readCodexAppServerProcess(
   return rows?.find((row) => row.pid === pid);
 }
 
+// Absent processes and failed inspection both return undefined. Neither grants
+// callers authority to signal a process.
+export async function readCodexAppServerProcessCommand(
+  pid: number,
+  deadline: number,
+): Promise<string | undefined> {
+  if (process.platform === "linux") {
+    const remainingMs = deadline - Date.now();
+    if (remainingMs <= 0) {
+      return undefined;
+    }
+    try {
+      const command = await readFile(`/proc/${pid}/cmdline`, {
+        encoding: "utf8",
+        signal: AbortSignal.timeout(remainingMs),
+      });
+      return command.split("\0").join(" ").trim() || undefined;
+    } catch {
+      return undefined;
+    }
+  }
+  const output = await readProcessOutput(["-o", "command=", "-p", String(pid)], deadline);
+  return output?.split("\n")[0]?.trim() || undefined;
+}
+
 async function readProcesses(
   args: string[],
   deadline: number,
 ): Promise<PosixProcess[] | undefined> {
+  const output = await readProcessOutput(args, deadline);
+  return output === undefined ? undefined : parseProcesses(output);
+}
+
+async function readProcessOutput(args: string[], deadline: number): Promise<string | undefined> {
   const remainingMs = deadline - Date.now();
   if (remainingMs <= 0) {
     return undefined;
   }
-  return await new Promise<PosixProcess[] | undefined>((resolve) => {
+  return await new Promise<string | undefined>((resolve) => {
     let settled = false;
-    const settle = (processes: PosixProcess[] | undefined) => {
+    const settle = (output: string | undefined) => {
       if (settled) {
         return;
       }
       settled = true;
       clearTimeout(timer);
-      resolve(processes);
+      resolve(output);
     };
     const inspector = execFile(
       "ps",
@@ -59,7 +89,7 @@ async function readProcesses(
         env: { ...process.env, LC_ALL: "C", TZ: "UTC" },
       },
       (error, stdout) => {
-        settle(error ? undefined : parseProcesses(stdout));
+        settle(error ? undefined : stdout);
       },
     );
     const timer = setTimeout(


### PR DESCRIPTION
Related: #132610, #132621, #132413

## What Problem This Solves

Resolves two gaps in the codex app-server orphan reaper that landed in #132610. First, its kill authority validates pid + process group + start time, and on macOS the start time comes from `ps lstart`, which is only second-granular: a registered child that dies and has its pid recycled within the same second could hand its identity to an unrelated process, which the reaper would then SIGKILL — group-killed when it is a process-group leader. (Linux is unaffected: its identities are `boot_id:startTicks`.) Second, the landed reaper runs only before the next app-server spawn, so an orphan whose stdin-EOF drain wedges persists until codex is next used, potentially hours after a gateway crash. Both gaps were identified during review of the superseded #132621 (ClawSweeper P1 and close-out notes).

## Why This Change Was Made

Registration now records a sha256 fingerprint of the child's exact command line (read from `/proc/<pid>/cmdline` on Linux, `ps -o command=` elsewhere) alongside the existing identities — only the digest is persisted, matching the spawn-identity `argsFingerprint` precedent, since `appServer.args` is operator-configurable and may carry secrets — and the reap loop compares the live process's fingerprint before entering the unchanged containment/kill path. A mismatch proves the pid was recycled and deletes only the stale registration without signaling; an unreadable command while the per-pid identity still matches refuses the spawn fail-closed (consistent with the landed philosophy); rows written by current unreleased builds lack the field and intentionally keep today's identity-only reaping via an optional schema field, to be tightened at the next natural schema touch. Verified against the pinned `@openai/codex` 0.150.1 source (`rust-v0.150.1`, resolves to 0eb410ad0dd) that the app-server never retitles its argv, so command equality is stable for a child's lifetime. A platform-specific process-generation identity was considered and rejected: macOS exposes nothing finer to Node portably, and command byte-equality reduces the collision to same-second + same-pid + identical-command while everything ambiguous fails closed.

A new best-effort service (`codex-app-server-process-reaper`) additionally runs the same sweep at gateway startup, fire-and-forget with contained errors, so crash orphans die at boot; the before-spawn fail-closed check remains the authoritative gate. The sweep body was factored module-privately out of `prepareCodexAppServerProcessRegistration` so both paths share one canonical implementation. Containment internals are untouched.

## User Impact

After a hard gateway stop, leftover Codex app-server processes are now cleaned up at the next gateway startup rather than at the next Codex use, and the cleanup can no longer — even in the pathological same-second pid-recycling case — kill an unrelated process that inherited a dead child's numeric identity. No configuration changes; Windows behavior unchanged.

## Evidence

- New `transport-process-registration.test.ts` (16 tests, isolated temp state dirs): the ClawSweeper-requested regression "never kills a same-second replacement process running a different command" (verified to fail with the gate disabled — the run observed `terminateCodexAppServerOrphan` being called for the identity-matching replacement, and the restored gate passes), legacy identity-only rows still reaped, unreadable-command fail-closed spawn refusal with the row kept, vanished-identity settlement through containment, registration persisting only the command fingerprint (with an assertion that the raw argv never reaches the durable store), exit-during-command-read not resurrecting rows, and the boot service (success / contained failure / win32 no-op, never blocking start).
- `transport-process-snapshot.test.ts` additions: Linux cmdline normalization (NUL argv, empty for zombies/kernel threads) and bounded `ps` cleanup for the command reader.
- Existing real-binary e2e `transport-orphan.test.ts` passes unmodified in both fixture and real-binary modes, implicitly covering the equal-command reap path.
- Focused suites green (registration, snapshot, orphan, index, transport-stdio); `node scripts/check-changed.mjs` fully green; `pnpm build` green with zero `INEFFECTIVE_DYNAMIC_IMPORT`; fresh Codex autoreview on the final diff reported no actionable findings.
- Production LOC +95/-25 (net ~+70): the command capture/gate and the boot service are the two named capabilities; the sweep factoring is move-only. Tests +330.
- Docs: `docs/plugins/codex-harness-runtime.md` recovery section updated for the boot sweep and the recorded-command requirement.
