### PR TITLE
fix(test): prevent Gateway E2E worker exhaustion

### DIFF
--- a/.github/workflows/openclaw-live-and-e2e-checks-reusable.yml
+++ b/.github/workflows/openclaw-live-and-e2e-checks-reusable.yml
@@ -1072,6 +1072,9 @@ jobs:
         run: scripts/sandbox-setup.sh
 
       - name: Run repo E2E suite
+        env:
+          OPENCLAW_E2E_WORKERS: "2"
+          OPENCLAW_E2E_USE_PREBUILT_DIST: "1"
         run: pnpm test:e2e
 
   validate_special_e2e:

--- a/docs/reference/test.md
+++ b/docs/reference/test.md
@@ -188,7 +188,7 @@ not sweep old directories or infer ownership from names, ages, or PIDs.
 - Gateway tests are included in the untargeted `pnpm test` full suite; run them alone with `pnpm test:gateway`.
 - `pnpm test:e2e`: repo E2E aggregate = `pnpm test:e2e:gateway && pnpm test:e2e:agent-plugin-gateway && pnpm test:ui:e2e`.
 - `pnpm test:e2e:gateway`: gateway end-to-end smoke tests (multi-instance WS/HTTP/node pairing). Defaults to `threads` + `isolate: false` with one worker in `vitest.e2e.config.ts`; opt into parallelism with `OPENCLAW_E2E_WORKERS=<n>` (capped at 16), and enable verbose logs with `OPENCLAW_E2E_VERBOSE=1`.
-  Broad runs use four sequential Vitest shards in fresh processes to bound worker memory. The worker limit applies within each process; ordinary test failures are retained while remaining shards finish. Explicit filters, watch mode, caller-supplied shards, coverage, and report-output options keep one direct invocation.
+  Broad runs prepare the shared runtime once, then use four sequential Vitest shards in fresh processes to bound worker memory. The worker limit applies within each process; ordinary test failures are retained while remaining shards finish. Explicit filters, watch mode, caller-supplied shards, coverage, and report-output options keep one direct invocation.
 - `pnpm test:live`: provider live tests (Claude/Minimax/DeepSeek/z.ai/etc, gated by `*.live.test.ts`). Requires API keys and `LIVE=1` (or `OPENCLAW_LIVE_TEST=1`) to unskip; verbose output with `OPENCLAW_LIVE_TEST_QUIET=0`.
 
 ## Full Docker suite (`pnpm test:docker:all`)

--- a/docs/reference/test.md
+++ b/docs/reference/test.md
@@ -188,6 +188,7 @@ not sweep old directories or infer ownership from names, ages, or PIDs.
 - Gateway tests are included in the untargeted `pnpm test` full suite; run them alone with `pnpm test:gateway`.
 - `pnpm test:e2e`: repo E2E aggregate = `pnpm test:e2e:gateway && pnpm test:e2e:agent-plugin-gateway && pnpm test:ui:e2e`.
 - `pnpm test:e2e:gateway`: gateway end-to-end smoke tests (multi-instance WS/HTTP/node pairing). Defaults to `threads` + `isolate: false` with one worker in `vitest.e2e.config.ts`; opt into parallelism with `OPENCLAW_E2E_WORKERS=<n>` (capped at 16), and enable verbose logs with `OPENCLAW_E2E_VERBOSE=1`.
+  Broad runs use four sequential Vitest shards in fresh processes to bound worker memory. The worker limit applies within each process; ordinary test failures are retained while remaining shards finish. Explicit filters, watch mode, caller-supplied shards, coverage, and report-output options keep one direct invocation.
 - `pnpm test:live`: provider live tests (Claude/Minimax/DeepSeek/z.ai/etc, gated by `*.live.test.ts`). Requires API keys and `LIVE=1` (or `OPENCLAW_LIVE_TEST=1`) to unskip; verbose output with `OPENCLAW_LIVE_TEST_QUIET=0`.
 
 ## Full Docker suite (`pnpm test:docker:all`)

--- a/scripts/lib/vitest-build-prerequisites.mts
+++ b/scripts/lib/vitest-build-prerequisites.mts
@@ -119,6 +119,20 @@ export function isE2eBuildSkipped(env: NodeJS.ProcessEnv) {
   return env.OPENCLAW_E2E_SKIP_BUILD === "1" || env.OPENCLAW_E2E_USE_PREBUILT_DIST === "1";
 }
 
+export async function prepareE2eVitestRuntime(env: NodeJS.ProcessEnv) {
+  if (isE2eBuildSkipped(env)) {
+    return {};
+  }
+  console.error("[test] preparing E2E runtime before Vitest workers");
+  await runE2eGlobalSetup(
+    (args, commandEnv) =>
+      runManagedCommand({ bin: process.execPath, args, cwd: process.cwd(), env: commandEnv }),
+    env,
+  );
+  // Only successful preparation may tell readers to reuse this shared generation.
+  return { OPENCLAW_E2E_USE_PREBUILT_DIST: "1" };
+}
+
 function runE2eSetupCommand(args: string[], env: NodeJS.ProcessEnv): Promise<number> {
   const child = spawn(process.execPath, args, {
     cwd: process.cwd(),

--- a/scripts/run-vitest.mts
+++ b/scripts/run-vitest.mts
@@ -73,6 +73,8 @@ const TOOLING_DOCKER_VITEST_CONFIG = "test/vitest/vitest.tooling-docker.config.t
 const TOOLING_VITEST_CONFIG = "test/vitest/vitest.tooling.config.ts";
 const GATEWAY_CORE_VITEST_CONFIG = "test/vitest/vitest.gateway-core.config.ts";
 const GATEWAY_SERVER_VITEST_CONFIG = "test/vitest/vitest.gateway-server.config.ts";
+const E2E_VITEST_CONFIG = "test/vitest/vitest.e2e.config.ts";
+const E2E_TEST_PROCESS_COUNT = 4;
 const GATEWAY_VITEST_CONFIG = "test/vitest/vitest.gateway.config.ts";
 export const VITEST_CONFIG_NO_OUTPUT_TIMEOUT_MS = new Map([
   ["test/vitest/vitest.e2e.config.ts", DEFAULT_LONG_RUNNING_VITEST_NO_OUTPUT_TIMEOUT_MS],
@@ -615,8 +617,8 @@ function insertVitestTargets(argv: string[], targets: string[]): string[] {
 }
 
 /**
- * Splits config-only Gateway server runs into fresh processes before the
- * non-isolated module graph reaches the worker heap limit.
+ * Bounds shared-worker lifetime with fresh processes so broad non-isolated
+ * runs do not exhaust the worker heap.
  */
 export function resolveBoundedVitestInvocations(
   argv: string[],
@@ -631,16 +633,48 @@ export function resolveBoundedVitestInvocations(
   const env = options.env ?? process.env;
   const cwd = options.cwd ?? process.cwd();
   const mode = resolveExplicitVitestMode(argv);
+  const isE2E = matchesVitestConfigPath(normalizedConfig, E2E_VITEST_CONFIG);
   if (
-    !matchesVitestConfigPath(normalizedConfig, GATEWAY_SERVER_VITEST_CONFIG) ||
+    (!isE2E && !matchesVitestConfigPath(normalizedConfig, GATEWAY_SERVER_VITEST_CONFIG)) ||
     mode === "watch" ||
+    hasExplicitDisabledRunFlag(argv) ||
     (mode !== "run" && parsePermissiveBooleanToken(env.CI) !== true) ||
     hasNonRunVitestSubcommand(argv) ||
     hasAlternateVitestRootArg(argv) ||
     collectExplicitProjectRouterTargetArgs(argv, cwd).length > 0 ||
-    UNBOUNDED_CONFIG_ONLY_OPTIONS.some((option) => hasVitestOption(argv, option))
+    [...UNBOUNDED_CONFIG_ONLY_OPTIONS, "--bail"].some((option) => hasVitestOption(argv, option))
   ) {
     return [argv];
+  }
+  if (isE2E) {
+    // Let Vitest own include/exclude and shard membership. Filtered and report-producing
+    // calls retain one process so small selections and aggregate outputs keep their semantics.
+    if (
+      collectExplicitFileTargetArgs(argv, (arg) => arg !== "run").length > 0 ||
+      argv.includes("--") ||
+      [
+        "--exclude",
+        "--testNamePattern",
+        "-t",
+        "--tagsFilter",
+        "--sequence.sequencer",
+        "--reporter",
+        "--reporters",
+        "--listTags",
+        "--clearCache",
+        "--standalone",
+        "--help",
+        "-h",
+        "--version",
+        "-v",
+      ].some((option) => hasVitestOption(argv, option))
+    ) {
+      return [argv];
+    }
+    return Array.from({ length: E2E_TEST_PROCESS_COUNT }, (_, index) => [
+      ...argv,
+      `--shard=${index + 1}/${E2E_TEST_PROCESS_COUNT}`,
+    ]);
   }
   const chunks = options.gatewayServerTargetChunks ?? createGatewayServerTestTargetChunks(cwd);
   return chunks.length > 1 ? chunks.map((targets) => insertVitestTargets(argv, targets)) : [argv];
@@ -1400,29 +1434,37 @@ async function main(
     throw error;
   }
 
+  let failedExitCode = 0;
   for (const [index, invocation] of invocations.entries()) {
     const guardedVitestArgs = resolveExplicitTestFileNoPassArgs(invocation);
     const spawnEnv = resolveRunVitestSpawnEnv(env, guardedVitestArgs);
     if (invocations.length > 1) {
-      console.error("[vitest] Gateway server process " + (index + 1) + "/" + invocations.length);
+      console.error("[vitest] bounded process " + (index + 1) + "/" + invocations.length);
     }
-    const exitCode = await finishVitestProcess(
-      spawnWatchedVitestProcess({
-        pnpmArgs: [
-          "exec",
-          "node",
-          ...resolveVitestNodeArgs(env),
-          vitestCliEntry,
-          ...guardedVitestArgs,
-        ],
-        spawnParams: resolveVitestSpawnParams(spawnEnv),
-        env: spawnEnv,
-      }),
-    );
-    if (exitCode !== 0) {
+    const handle = spawnWatchedVitestProcess({
+      pnpmArgs: [
+        "exec",
+        "node",
+        ...resolveVitestNodeArgs(env),
+        vitestCliEntry,
+        ...guardedVitestArgs,
+      ],
+      spawnParams: resolveVitestSpawnParams(spawnEnv),
+      env: spawnEnv,
+    });
+    const exitCode = await finishVitestProcess(handle);
+    // Ordinary test failures must not hide later files. Signals are forwarded by
+    // finishVitestProcess and stop this owner before another child is admitted.
+    if (
+      handle.getForwardedSignal() ||
+      handle.child.signalCode ||
+      (exitCode !== 0 && exitCode !== 1)
+    ) {
       return;
     }
+    failedExitCode ||= exitCode;
   }
+  process.exitCode = failedExitCode;
 }
 
 if (import.meta.main) {

--- a/scripts/run-vitest.mts
+++ b/scripts/run-vitest.mts
@@ -19,6 +19,7 @@ import { signalExitCode } from "./lib/managed-child-process.mts";
 import { resolveRepoRoot } from "./lib/repo-root.mjs";
 import { spawnTestProjectsRunner } from "./lib/test-projects-delegation.mts";
 import {
+  prepareE2eVitestRuntime,
   resolveVitestRuntimeCliSelections,
   prepareVitestRuntime,
 } from "./lib/vitest-build-prerequisites.mts";
@@ -1401,6 +1402,10 @@ async function main(
   const invocations = resolveBoundedVitestInvocations(vitestArgs, { env });
   const config = resolveVitestConfigArg(vitestArgs);
   const relativeConfig = config ? toRepoRelativeArg(path.resolve(config), repoRoot) : "";
+  const invocationEnv =
+    invocations.length > 1 && relativeConfig === E2E_VITEST_CONFIG
+      ? { ...env, ...(await prepareE2eVitestRuntime(env)) }
+      : env;
   // Canonical configs have known project scopes. Custom roots/projects keep
   // their own setup; never infer their runtime selection from a config name.
   if (
@@ -1413,9 +1418,9 @@ async function main(
   ) {
     const code = await prepareVitestRuntime(
       invocations.flatMap((cliArgs) =>
-        resolveVitestRuntimeCliSelections(relativeConfig, cliArgs, env),
+        resolveVitestRuntimeCliSelections(relativeConfig, cliArgs, invocationEnv),
       ),
-      env,
+      invocationEnv,
     );
     if (code !== 0) {
       process.exitCode = code;
@@ -1437,7 +1442,7 @@ async function main(
   let failedExitCode = 0;
   for (const [index, invocation] of invocations.entries()) {
     const guardedVitestArgs = resolveExplicitTestFileNoPassArgs(invocation);
-    const spawnEnv = resolveRunVitestSpawnEnv(env, guardedVitestArgs);
+    const spawnEnv = resolveRunVitestSpawnEnv(invocationEnv, guardedVitestArgs);
     if (invocations.length > 1) {
       console.error("[vitest] bounded process " + (index + 1) + "/" + invocations.length);
     }
@@ -1445,7 +1450,7 @@ async function main(
       pnpmArgs: [
         "exec",
         "node",
-        ...resolveVitestNodeArgs(env),
+        ...resolveVitestNodeArgs(invocationEnv),
         vitestCliEntry,
         ...guardedVitestArgs,
       ],

--- a/scripts/test-projects.mts
+++ b/scripts/test-projects.mts
@@ -5,11 +5,9 @@ import fs from "node:fs";
 import { performance } from "node:perf_hooks";
 import pMap from "p-map";
 import { formatMs } from "./lib/check-timing-summary.mts";
-import { runManagedCommand } from "./lib/managed-child-process.mts";
 import {
-  isE2eBuildSkipped,
+  prepareE2eVitestRuntime,
   prepareVitestRuntime,
-  runE2eGlobalSetup,
 } from "./lib/vitest-build-prerequisites.mts";
 import {
   isCiLikeEnv,
@@ -310,18 +308,11 @@ async function main() {
     return;
   }
 
-  const runBuildCommand = (commandArgs: string[], env: NodeJS.ProcessEnv) =>
-    runManagedCommand({ bin: process.execPath, args: commandArgs, cwd: process.cwd(), env });
   const e2eSpecs = runSpecs.filter((spec) => spec.config === "test/vitest/vitest.e2e.config.ts");
   if (e2eSpecs.length > 0) {
-    if (!isE2eBuildSkipped(baseEnv)) {
-      console.error("[test] preparing E2E runtime before Vitest workers");
-      await runE2eGlobalSetup(runBuildCommand, baseEnv);
-      // E2E preparation also covers runtime/private-QA readers. Only a completed
-      // owner may tell config-level setup to reuse that shared generation.
-      for (const spec of e2eSpecs) {
-        spec.env = { ...spec.env, OPENCLAW_E2E_USE_PREBUILT_DIST: "1" };
-      }
+    const preparedEnv = await prepareE2eVitestRuntime(baseEnv);
+    for (const spec of e2eSpecs) {
+      spec.env = { ...spec.env, ...preparedEnv };
     }
   } else {
     const code = await prepareVitestRuntime(

--- a/test/scripts/run-vitest-bounded.test.ts
+++ b/test/scripts/run-vitest-bounded.test.ts
@@ -1,0 +1,84 @@
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { isProcessAlive } from "../helpers/process-wait.js";
+import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
+
+const repoRoot = path.resolve(import.meta.dirname, "../..");
+const posixDescribe = process.platform === "win32" ? describe.skip : describe;
+
+posixDescribe("bounded Vitest process ownership", () => {
+  const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+  it.each(["test-failure", "cancel"])(
+    "joins fresh children and preserves %s",
+    { timeout: 60_000 },
+    (outcome) => {
+      const root = tempDirs.make("oc-vt-bounded-");
+      fs.symlinkSync(
+        path.join(repoRoot, "node_modules"),
+        path.join(root, "node_modules"),
+        "junction",
+      );
+      const configPath = path.join(root, "test/vitest/vitest.e2e.config.ts");
+      fs.mkdirSync(path.dirname(configPath), { recursive: true });
+      const receiptPath = path.join(root, "executed.jsonl");
+      fs.writeFileSync(
+        configPath,
+        `export default {
+  root: ${JSON.stringify(root)},
+  test: {
+    include: ["case-*.test.ts"], pool: "threads", isolate: false, maxWorkers: 1,
+    env: { FIXTURE_SHARD: process.argv.find(arg => arg.startsWith("--shard=")) ?? "unsharded" },
+  },
+};`,
+      );
+      for (let index = 0; index < 4; index++) {
+        fs.writeFileSync(
+          path.join(root, `case-${index}.test.ts`),
+          `import fs from "node:fs";
+import { expect, it } from "vitest";
+it("case ${index}", () => {
+  fs.appendFileSync(${JSON.stringify(receiptPath)}, JSON.stringify({ index: ${index}, pid: process.pid }) + "\\n");
+  ${outcome === "cancel" ? 'process.kill(process.pid, "SIGTERM");' : 'expect(process.env.FIXTURE_SHARD).not.toBe("--shard=1/4");'}
+});`,
+        );
+      }
+      const env = { ...process.env };
+      for (const key of Object.keys(env)) {
+        if (key.startsWith("VITEST") || key.startsWith("OPENCLAW_")) {
+          delete env[key];
+        }
+      }
+      const result = spawnSync(
+        process.execPath,
+        [path.join(repoRoot, "scripts/run-vitest.mjs"), "run", "--config", configPath],
+        {
+          cwd: repoRoot,
+          env: { ...env, CI: "1", NO_COLOR: "1", FORCE_COLOR: "0" },
+          encoding: "utf8",
+          timeout: 45_000,
+        },
+      );
+      expect(result.error, result.stderr).toBeUndefined();
+      const receipts = fs
+        .readFileSync(receiptPath, "utf8")
+        .trim()
+        .split("\n")
+        .map((line) => JSON.parse(line) as { index: number; pid: number });
+      if (outcome === "cancel") {
+        expect(result.signal === "SIGTERM" || result.status === 143, result.stderr).toBe(true);
+        expect(receipts).toHaveLength(1);
+      } else {
+        // The first shard fails, later shards pass: success must not erase that failure.
+        expect(result.status, result.stderr).toBe(1);
+        expect(receipts.map(({ index }) => index).sort()).toEqual([0, 1, 2, 3]);
+        expect(new Set(receipts.map(({ pid }) => pid)).size).toBe(4);
+      }
+      for (const { pid } of receipts) {
+        expect(isProcessAlive(pid)).toBe(false);
+      }
+    },
+  );
+});

--- a/test/scripts/run-vitest-bounded.test.ts
+++ b/test/scripts/run-vitest-bounded.test.ts
@@ -1,8 +1,14 @@
-import { spawnSync } from "node:child_process";
+import { spawn, spawnSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
-import { isProcessAlive } from "../helpers/process-wait.js";
+import {
+  isProcessAlive,
+  waitForChildClose,
+  waitForDead,
+  waitForPidFile,
+} from "../helpers/process-wait.js";
+import { createDeferred, withTestTimeout } from "../helpers/promise.js";
 import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
 
 const repoRoot = path.resolve(import.meta.dirname, "../..");
@@ -10,6 +16,135 @@ const posixDescribe = process.platform === "win32" ? describe.skip : describe;
 
 posixDescribe("bounded Vitest process ownership", () => {
   const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+  it.each(["success", "runtime-failure", "ai-failure", "prebuilt", "skip", "custom", "cancel"])(
+    "prepares the direct E2E reader generation once: %s",
+    { timeout: 60_000 },
+    async (outcome) => {
+      const root = tempDirs.make("oc-vt-preparation-");
+      const receiptsPath = path.join(root, "events.jsonl");
+      const pidPath = path.join(root, "builder.pid");
+      const executable = path.join(root, "command.mjs");
+      const preload = path.join(root, "preload.mjs");
+      fs.writeFileSync(
+        executable,
+        `import fs from "node:fs";
+const kind = process.argv[2];
+const record = (event) => fs.appendFileSync(${JSON.stringify(receiptsPath)}, JSON.stringify({
+  kind, event, pid: process.pid, shard: process.argv[3],
+  prebuilt: process.env.OPENCLAW_E2E_USE_PREBUILT_DIST ?? "",
+  skip: process.env.OPENCLAW_E2E_SKIP_BUILD ?? "",
+}) + "\\n");
+record("start");
+if (kind === "runtime" && ${JSON.stringify(outcome)} === "cancel") {
+  fs.writeFileSync(${JSON.stringify(pidPath)}, String(process.pid));
+  setInterval(() => {}, 1000);
+} else {
+  record("end");
+  process.exit(${JSON.stringify(outcome)} === kind + "-failure" ? 7 : 0);
+}
+`,
+      );
+      // Preserve the real CLI and managed process owners; replace only the
+      // expensive executables so build/read admission remains observable.
+      fs.writeFileSync(
+        preload,
+        `import cp from "node:child_process";
+import { syncBuiltinESMExports } from "node:module";
+const spawn = cp.spawn;
+cp.spawn = (bin, args, options) => {
+  const kind = args.includes("scripts/run-node.mjs") ? "runtime"
+    : args.includes("scripts/tsdown-build.mts") ? "ai"
+    : args.some(arg => arg === "vitest" || arg.endsWith("/vitest.mjs")) ? "reader" : null;
+  return kind ? spawn(process.execPath, [${JSON.stringify(executable)}, kind,
+    args.find(arg => arg.startsWith("--shard=")) ?? "direct"], options) : spawn(bin, args, options);
+};
+syncBuiltinESMExports();
+`,
+      );
+      const env = { ...process.env };
+      for (const key of Object.keys(env)) {
+        if (key.startsWith("VITEST") || key.startsWith("OPENCLAW_")) delete env[key];
+      }
+      if (outcome === "prebuilt") env.OPENCLAW_E2E_USE_PREBUILT_DIST = "1";
+      if (outcome === "skip") env.OPENCLAW_E2E_SKIP_BUILD = "1";
+      const child = spawn(
+        process.execPath,
+        [
+          "--import",
+          preload,
+          path.join(repoRoot, "scripts/run-vitest.mts"),
+          "run",
+          "--config",
+          outcome === "custom"
+            ? path.join(root, "custom.config.ts")
+            : "test/vitest/vitest.e2e.config.ts",
+        ],
+        { cwd: repoRoot, env: { ...env, CI: "1" }, stdio: ["ignore", "pipe", "pipe"] },
+      );
+      let output = "";
+      child.stdout.on("data", (chunk) => {
+        output += chunk;
+      });
+      child.stderr.on("data", (chunk) => {
+        output += chunk;
+      });
+      const closed = waitForChildClose(child, 15_000).catch((error: unknown) => error);
+      const stopped = createDeferred();
+      child.once("close", () => stopped.resolve());
+      let builderPid: number | undefined;
+      try {
+        if (outcome === "cancel") {
+          builderPid = await waitForPidFile(pidPath, 5_000);
+          child.kill("SIGTERM");
+        }
+        const failed = outcome.endsWith("-failure") || outcome === "cancel";
+        expect(await closed, output).toEqual({ code: failed ? 1 : 0, signal: null });
+        const events = fs
+          .readFileSync(receiptsPath, "utf8")
+          .trim()
+          .split("\n")
+          .map(
+            (line) =>
+              JSON.parse(line) as {
+                kind: string;
+                event: string;
+                pid: number;
+                shard: string;
+                prebuilt: string;
+                skip: string;
+              },
+          );
+        const readers = events.filter(({ kind, event }) => kind === "reader" && event === "start");
+        const builds = events.filter(({ kind, event }) => kind !== "reader" && event === "start");
+        expect(builds.map(({ kind }) => kind)).toEqual(
+          ["prebuilt", "skip", "custom"].includes(outcome)
+            ? []
+            : ["runtime-failure", "cancel"].includes(outcome)
+              ? ["runtime"]
+              : ["runtime", "ai"],
+        );
+        expect(readers).toHaveLength(failed ? 0 : outcome === "custom" ? 1 : 4);
+        if (outcome === "success") {
+          expect(events.slice(0, 4).map(({ kind, event }) => `${kind}:${event}`)).toEqual([
+            "runtime:start",
+            "runtime:end",
+            "ai:start",
+            "ai:end",
+          ]);
+        }
+        for (const reader of readers) {
+          expect(reader.prebuilt).toBe(["success", "prebuilt"].includes(outcome) ? "1" : "");
+          expect(reader.skip).toBe(outcome === "skip" ? "1" : "");
+        }
+        for (const pid of new Set(events.map(({ pid }) => pid))) await waitForDead(pid, 5_000);
+      } finally {
+        if (child.exitCode === null && child.signalCode === null) child.kill("SIGTERM");
+        await withTestTimeout(stopped.promise, 5_000, "E2E preparation CLI cleanup");
+        if (builderPid) await waitForDead(builderPid, 5_000);
+      }
+    },
+  );
 
   it.each(["test-failure", "cancel"])(
     "joins fresh children and preserves %s",

--- a/test/scripts/run-vitest.test.ts
+++ b/test/scripts/run-vitest.test.ts
@@ -255,6 +255,45 @@ describe("scripts/run-vitest", () => {
     ).toHaveLength(2);
   });
 
+  it("bounds the complete E2E selection without multiplying configured workers", () => {
+    const argv = ["run", "--config", "test/vitest/vitest.e2e.config.ts", "--maxWorkers", "2"];
+    expect(resolveBoundedVitestInvocations(argv, { env: {} })).toEqual([
+      [...argv, "--shard=1/4"],
+      [...argv, "--shard=2/4"],
+      [...argv, "--shard=3/4"],
+      [...argv, "--shard=4/4"],
+    ]);
+  });
+
+  it.each([
+    ["doctor"],
+    ["src/commands"],
+    ["src/commands/doctor.e2e.test.ts"],
+    ["--", "doctor"],
+    ["--shard=2/3"],
+    ["--shard", "2/3"],
+    ["--watch"],
+    ["--run=false"],
+    ["--no-run"],
+    ["--bail", "1"],
+    ["--coverage"],
+    ["--outputFile", "report.json"],
+    ["--reporter=json"],
+    ["--listTags"],
+    ["--listTags=json"],
+    ["--clearCache"],
+    ["--standalone"],
+    ["--testNamePattern", "doctor"],
+    ["-t", "doctor"],
+    ["--exclude", "src/**"],
+    ["--root", "/other"],
+    ["--project", "other"],
+    ["--help"],
+  ])("preserves explicit E2E selection or execution options %j", (...options) => {
+    const argv = ["run", "--config", "test/vitest/vitest.e2e.config.ts", ...options];
+    expect(resolveBoundedVitestInvocations(argv, { env: {} })).toEqual([argv]);
+  });
+
   it.each([
     ["local watch default", ["--config", "test/vitest/vitest.gateway-server.config.ts"]],
     ["explicit watch", ["watch", "--config", "test/vitest/vitest.gateway-server.config.ts"]],

--- a/test/scripts/test-projects-build-admission.test.ts
+++ b/test/scripts/test-projects-build-admission.test.ts
@@ -13,7 +13,7 @@ vi.mock("../../scripts/lib/managed-child-process.mts", () => ({
 }));
 vi.mock("../../scripts/lib/vitest-build-prerequisites.mts", async (importOriginal) => ({
   ...(await importOriginal<typeof import("../../scripts/lib/vitest-build-prerequisites.mts")>()),
-  runE2eGlobalSetup: commands.prepareE2e,
+  prepareE2eVitestRuntime: commands.prepareE2e,
 }));
 vi.mock("../../scripts/run-vitest.mts", async (importOriginal) => ({
   ...(await importOriginal<typeof import("../../scripts/run-vitest.mts")>()),
@@ -42,7 +42,7 @@ let startCount = 0;
 
 beforeEach(() => {
   commands.prepare.mockReset();
-  commands.prepareE2e.mockReset();
+  commands.prepareE2e.mockReset().mockResolvedValue({ OPENCLAW_E2E_USE_PREBUILT_DIST: "1" });
   commands.reader.mockReset().mockImplementation(() => ({
     completion: Promise.resolve({ code: 0, signal: null }),
     getForwardedSignal: () => undefined,
@@ -354,18 +354,19 @@ describe("test-projects build admission", () => {
     "admits the built native-host integration after %s",
     async (mode) => {
       if (mode === "prebuilt") vi.stubEnv("OPENCLAW_E2E_USE_PREBUILT_DIST", "1");
-      const preparation = createDeferred();
+      const preparation = createDeferred<NodeJS.ProcessEnv>();
       commands.prepareE2e.mockReturnValue(preparation.promise);
+      if (mode === "prebuilt") preparation.resolve({});
       await start([nativeHostTarget]);
       if (mode !== "prebuilt") {
         expect(commands.reader).not.toHaveBeenCalled();
         expect(commands.prepareE2e).toHaveBeenCalledOnce();
         if (mode === "failed build") preparation.reject(new Error("build failed"));
-        else preparation.resolve();
+        else preparation.resolve({ OPENCLAW_E2E_USE_PREBUILT_DIST: "1" });
       }
       await terminal.promise;
       expect(commands.prepare).not.toHaveBeenCalled();
-      expect(commands.prepareE2e).toHaveBeenCalledTimes(mode === "prebuilt" ? 0 : 1);
+      expect(commands.prepareE2e).toHaveBeenCalledOnce();
       expect(commands.reader).toHaveBeenCalledTimes(mode === "failed build" ? 0 : 1);
       if (mode === "failed build") {
         expect(process.exitCode).toBe(1);
@@ -399,7 +400,7 @@ describe("test-projects build admission", () => {
 
   it("coalesces mixed E2E and private QA preparation before marking only E2E prebuilt", async () => {
     vi.stubEnv("OPENCLAW_TEST_PROJECTS_PARALLEL", "2");
-    const preparation = createDeferred();
+    const preparation = createDeferred<NodeJS.ProcessEnv>();
     commands.prepareE2e.mockReturnValue(preparation.promise);
     await start([...targets, e2eTarget]);
     try {
@@ -407,7 +408,7 @@ describe("test-projects build admission", () => {
       expect(commands.prepare).not.toHaveBeenCalled();
       expect(commands.reader).not.toHaveBeenCalled();
     } finally {
-      preparation.resolve();
+      preparation.resolve({ OPENCLAW_E2E_USE_PREBUILT_DIST: "1" });
       await terminal.promise;
     }
     expect(await terminal.promise).toMatch(/^\[test\] passed 3 Vitest shards/u);
@@ -433,9 +434,12 @@ describe("test-projects build admission", () => {
     "preserves the explicit %s contract",
     async (key) => {
       vi.stubEnv(key, "1");
+      commands.prepareE2e.mockResolvedValue({});
       await start([...targets, e2eTarget]);
       await terminal.promise;
-      expect(commands.prepareE2e).not.toHaveBeenCalled();
+      expect(commands.prepareE2e).toHaveBeenCalledExactlyOnceWith(
+        expect.objectContaining({ [key]: "1" }),
+      );
       expect(commands.prepare).not.toHaveBeenCalled();
       expect(commands.reader).toHaveBeenCalledTimes(3);
       for (const [options] of commands.reader.mock.calls) {


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where broad Gateway E2E release verification exhausts a long-lived worker before completing its test inventory. The observed hosted run spent 62m24 in that stage before reporting only `Worker exited unexpectedly`; later aggregate E2E stages never ran. The original [hosted failure](https://github.com/openclaw/openclaw/actions/runs/33256261564/job/99110547220) is retained. An instrumented Linux reproduction captured the underlying `ERR_WORKER_OUT_OF_MEMORY` event and exit code 1. The active file passed separately, so this change bounds worker lifetime without blaming or omitting a test.

## Why This Change Was Made

The existing `run-vitest` process owner now runs broad Gateway E2E through four sequential native Vitest shards. Vitest continues to own file selection and exclusions, and each process keeps the configured worker count. Ordinary failures remain nonzero while later chunks finish; cancellation stops further admission. Explicit filters, watch/disabled-run modes, caller shards, bail, administrative commands, coverage, and report outputs keep a direct invocation. The existing Gateway server target planner is unchanged; its shared execution loop also retains failures across its full selected inventory.

Direct broad Gateway E2E and the project scheduler now share one preparation owner. It runs the existing runtime/AI prerequisites once, returns only the prebuilt environment patch after both succeed, and preserves each selected project’s environment. Build failure or cancellation admits no reader. Custom configurations and direct filtered modes retain their existing setup.

The release job already set the generic Vitest worker budget to two, but Gateway E2E reads its own existing worker setting and therefore ran with its default of one. The repo E2E step now sets that existing setting to two and reuses dist only after its required `pnpm build` predecessor succeeds. The four chunks remain sequential; this does not create eight concurrent workers.

## User Impact

Release maintainers get bounded worker lifetime while retaining the same E2E selection. Runtime product behavior is unchanged.

No test assertions, test/watchdog deadlines, heap limits, dependencies, configuration variables, or release coverage were weakened. The local E2E worker default remains one. This PR does not claim an end-to-end release speedup.

## Evidence

- Before: exact Node worker OOM captured on the frozen release candidate after 21m29; 155 files dispatched and 153 finished. Kernel/cgroup OOM counters remained zero. This establishes worker heap exhaustion, not a specific retained-object leak.
- Regression: the real process fixture failed before the change. Afterward, four different processes cover all fixtures, an early failed shard survives later successful shards, and cancellation starts only one child with process cleanup verified.
- 129 focused runner/ownership tests passed locally and against pinned Vitest 4.1.11 on Linux. The later preparation-owner correction adds actual CLI/process coverage, replacing only the heavyweight build/test executables at the spawn boundary: four cases failed before the fix; afterward all seven cases passed, including both build failures, cancellation, and prebuilt/skip/custom controls. Final focused coverage is 141 runner/global-setup tests plus 65 isolated project-admission tests, all passing.
- Native Vitest 4.1.11 inventory proof: exactly 197 files partition into 50/49/49/49, no duplicates and exact equality with the unsharded selection.
- Full corrected Linux proof at `d0579e6e275708868e874c8148d08d3f11b6b9a3`: all 197 files dispatched and completed exactly once in 23m35s; 1,755 tests passed, eight failed, and 18 were skipped. The eight assertion failures remain nonzero and are tracked separately; seven were already known, while completing the inventory exposed one missing heartbeat registration assertion. There were no worker errors or explicit worker exit calls. Every executed partition matched native Vitest membership exactly.
- Process and build ownership: four distinct sequential processes joined; the full 35,136-file tracked byte/mode/tree guard passed before and after, and the exact candidate build stamp stayed unchanged. The possible post-run child was gone by bounded inspection, and the lease was stopped cleanly.
- Sampled process-tree peak RSS was 7,341,572 KiB, versus 11,398,408 KiB in the unbounded reproduction. These were different fresh machines, and the baseline did not complete, so this is not a successful-run A/B or a hosted release speedup claim.
- An earlier partial trial was discarded after candidate Git identity caused a child CLI to rebuild shared dist. The corrected proof builds the exact candidate and verifies canonical CLI build readiness before parallel readers start.
- The main refresh includes the independently merged test-inventory repair in #132743 and image selection repair in #132702. The release step sets the same existing two-worker/prebuilt settings used in the 197-file proof. The later preparation-owner correction preserves this already-prebuilt path and separately proves the local command’s one-time preparation.
- Formatting, script lint, script erasability and other cheap changed-scope guards passed. The initial local changed gates stopped at 16 errors outside changed files against stale shared dependencies; these are not represented as a passing typecheck. The task-owned dependency symlink was replaced with a frozen install inside this disposable checkout, preserving the shared target. The complete five-file gate then passed, including both typechecks. The final expanded eight-file gate passed all 16 checks, including both typechecks and script lint.
- Independent structured review through P2: no actionable findings in either the runner or workflow follow-up. Workflow formatting, Zizmor, and the composite-action input guard passed.
- Initial PR CI passed all checks except the known test-inventory failure and its aggregate gate; #132743 fixes that omission. The refreshed `a9127d7b4bf` CI had one non-E2E `core-unit-src-security-1` process terminate with SIGKILL, with no failed assertion or primary heap diagnostic; this is not labeled an OOM or dismissed as a flake. New exact-head CI is pending for the preparation-owner correction.

Tooling/workflow delta: +55 lines net; tests/support: +262; docs: +1. The added tooling owns process lifetime and failure aggregation in the existing runner, using the dependency's native partitioner instead of introducing another test inventory or config.
