### PR TITLE
fix(release): retain bounded npm diagnostics per phase

### DIFF
--- a/scripts/lib/cross-os-release-checks/install.ts
+++ b/scripts/lib/cross-os-release-checks/install.ts
@@ -27,7 +27,7 @@ import {
 import { readLogTextWindow } from "./logs.ts";
 import { runCommand } from "./process.ts";
 import { logPhase } from "./reporting.ts";
-import { formatError, resolveCommandPath, shellEscapeForSh } from "./shared.ts";
+import { resolveCommandPath, shellEscapeForSh } from "./shared.ts";
 
 export async function prepareCandidate(params: {
   outputDir: string;
@@ -423,7 +423,7 @@ export async function installPackageSpec(params: {
     npm_config_prefix: params.lane.prefixDir,
   };
   rmSync(installedPackageRoot(params.lane.prefixDir), { force: true, recursive: true });
-  try {
+  await withNpmDiagnostics(params.lane.homeDir, params.logPath, installEnv, async () => {
     await runCommand(
       npmCommand(),
       buildNpmGlobalInstallArgs(params.packageSpec, { ignoreScripts: params.ignoreScripts }),
@@ -434,44 +434,141 @@ export async function installPackageSpec(params: {
         timeoutMs: params.timeoutMs ?? installTimeoutMs(),
       },
     );
-  } catch (error) {
-    const debugTail = appendLatestNpmDebugLogTail(params.lane.homeDir, params.logPath, installEnv);
-    if (!debugTail) {
-      throw error;
+  });
+}
+
+const NPM_DIAGNOSTIC_LOG_LIMIT = 8;
+const NPM_DIAGNOSTIC_TIMERS = new Set([
+  "npm",
+  "command:install",
+  "idealTree",
+  "idealTree:init",
+  "idealTree:buildDeps",
+  "reify",
+  "reify:loadTrees",
+  "reify:diffTrees",
+  "reify:retireShallow",
+  "reify:createSparse",
+  "reify:loadBundles",
+  "reify:unpack",
+  "reify:build",
+  "reify:trash",
+  "reify:save",
+]);
+const NPM_DIAGNOSTIC_ERROR_CODES = new Set([
+  "EACCES",
+  "EBADENGINE",
+  "EBUSY",
+  "ECONNREFUSED",
+  "ECONNRESET",
+  "EEXIST",
+  "EINTEGRITY",
+  "EISDIR",
+  "ENOENT",
+  "ENOSPC",
+  "ENOTEMPTY",
+  "ENOTFOUND",
+  "EPERM",
+  "ERESOLVE",
+  "ETIMEDOUT",
+  "EAI_AGAIN",
+  "E401",
+  "E403",
+  "E404",
+]);
+
+export async function withNpmDiagnostics<T>(
+  homeDir: string,
+  logPath: string,
+  env: NodeJS.ProcessEnv,
+  run: () => Promise<T>,
+) {
+  const findLogs = () => resolveNpmDebugLogDirs(homeDir, env).flatMap(findNpmDebugLogs);
+  const before = new Map(findLogs().map((file) => [file.path, file]));
+  try {
+    return await run();
+  } finally {
+    try {
+      const changed = [...new Map(findLogs().map((file) => [file.path, file])).values()]
+        .filter((file) => {
+          const previous = before.get(file.path);
+          return !previous || file.size !== previous.size || file.mtimeMs !== previous.mtimeMs;
+        })
+        .toSorted(
+          (left, right) => left.mtimeMs - right.mtimeMs || left.path.localeCompare(right.path),
+        );
+      // Capture before the next npm invocation rotates logs. Never export npm's
+      // free text: its redactor does not cover provider keys or URL query secrets.
+      const logs = changed.slice(-NPM_DIAGNOSTIC_LOG_LIMIT).map((file) => {
+        const previousSize = before.get(file.path)?.size ?? 0;
+        const offsetBytes = previousSize <= file.size ? previousSize : 0;
+        const maxBytes = CROSS_OS_NPM_DEBUG_LOG_TAIL_BYTES / NPM_DIAGNOSTIC_LOG_LIMIT;
+        const truncated = file.size - offsetBytes > maxBytes;
+        const window = readLogTextWindow(file.path, { maxBytes, offsetBytes });
+        const text = truncated ? window.replace(/^[^\n]*(?:\n|$)/u, "") : window;
+        return Object.assign(projectNpmDebugLog(text), { truncated });
+      });
+      appendFileSync(
+        logPath,
+        `\n[release-checks] npm-diagnostics ${JSON.stringify({
+          logs,
+          truncated: changed.length > NPM_DIAGNOSTIC_LOG_LIMIT,
+        })}\n`,
+        "utf8",
+      );
+    } catch {
+      // Diagnostics must not replace the install result or original failure.
     }
-    throw new Error(`${formatError(error)}\n\nnpm debug log tail:\n${debugTail}`, { cause: error });
   }
 }
 
-export function appendLatestNpmDebugLogTail(
-  homeDir: string,
-  logPath: string,
-  env = process.env,
-  platform = process.platform,
-) {
-  try {
-    const candidates = resolveNpmDebugLogDirs(homeDir, env, platform)
-      .flatMap(findNpmDebugLogs)
-      .toSorted((left, right) => left.mtimeMs - right.mtimeMs);
-    const latest = candidates.at(-1);
-    if (!latest) {
-      return "";
+function projectNpmDebugLog(text: string) {
+  const fetch = { count: 0, cacheHits: 0, cacheMisses: 0, durationMs: 0, maxDurationMs: 0 };
+  const timings: Record<string, number> = {};
+  const errorCodes = new Set<string>();
+  let command: string | null = null;
+  let exitCode: number | null = null;
+  let lastActivity: string | null = null;
+  for (const line of text.split(/\r?\n/u)) {
+    command =
+      line.match(
+        /^\d+ verbose title npm (install|i|root|view|pack|exec|rebuild|run-script|--version)(?:\s|$)/u,
+      )?.[1] ?? command;
+    lastActivity =
+      line.match(
+        /^\d+ (?:silly|verbose|http|info|warn|error) (fetch manifest|idealTree|reify|tar|run|fetch|cache)\b/u,
+      )?.[1] ?? lastActivity;
+    const exit = line.match(/^\d+ verbose exit (-?\d{1,3})$/u);
+    if (exit) {
+      exitCode = Number(exit[1]);
     }
-
-    const tail = readLogTextWindow(latest.path, { maxBytes: CROSS_OS_NPM_DEBUG_LOG_TAIL_BYTES });
-    if (!tail.trim()) {
-      return "";
+    const code = line.match(/^\d+ (?:error|verbose) code (\S+)$/u)?.[1];
+    if (code && NPM_DIAGNOSTIC_ERROR_CODES.has(code)) {
+      errorCodes.add(code);
     }
-
-    appendFileSync(
-      logPath,
-      `\n${new Date().toISOString()} npm-debug-log path=${latest.path}\n${tail}\n`,
-      "utf8",
+    const timing = line.match(/^\d+ timing (\S+) Completed in (\d+)ms$/u);
+    if (timing && NPM_DIAGNOSTIC_TIMERS.has(timing[1]!) && isNpmTiming(Number(timing[2]))) {
+      timings[timing[1]!] = Number(timing[2]);
+    }
+    // npm-registry-fetch emits both network and cache reads; summed durations
+    // describe this bounded tail and may overlap, so they are not wall time.
+    const request = line.match(
+      /^\d+ http (?:fetch|cache) .+ (\d+)ms(?: attempt #\d+)?(?: \(cache (hit|miss|updated|revalidated|stale)\))?$/u,
     );
-    return tail;
-  } catch {
-    return "";
+    if (request && isNpmTiming(Number(request[1]))) {
+      const durationMs = Number(request[1]);
+      fetch.count++;
+      fetch.cacheHits += Number(request[2] === "hit");
+      fetch.cacheMisses += Number(request[2] === "miss");
+      fetch.durationMs += durationMs;
+      fetch.maxDurationMs = Math.max(fetch.maxDurationMs, durationMs);
+    }
   }
+  return { command, exitCode, lastActivity, errorCodes: [...errorCodes], fetch, timings };
+}
+
+function isNpmTiming(value: number) {
+  return Number.isSafeInteger(value) && value >= 0 && value <= 60 * 60 * 1000;
 }
 
 export function resolveNpmDebugLogDirs(
@@ -516,24 +613,22 @@ function normalizeNpmCacheLogDir(logDir: string) {
 }
 
 function findNpmDebugLogs(logsDir: string) {
-  if (!existsSync(logsDir)) {
-    return [];
-  }
-
-  return readdirSync(logsDir)
-    .flatMap((fileName) => {
-      if (!fileName.endsWith("-debug-0.log")) {
+  try {
+    return readdirSync(logsDir).flatMap((fileName) => {
+      if (!/-debug-\d+\.log$/u.test(fileName)) {
         return [];
       }
       const path = join(logsDir, fileName);
       try {
         const stat = statSync(path);
-        return stat.isFile() ? [{ path, mtimeMs: stat.mtimeMs }] : [];
+        return stat.isFile() ? [{ path, mtimeMs: stat.mtimeMs, size: stat.size }] : [];
       } catch {
         return [];
       }
-    })
-    .toSorted((left, right) => left.mtimeMs - right.mtimeMs);
+    });
+  } catch {
+    return [];
+  }
 }
 
 export function buildNpmGlobalInstallArgs(

--- a/scripts/lib/cross-os-release-checks/install.ts
+++ b/scripts/lib/cross-os-release-checks/install.ts
@@ -438,23 +438,6 @@ export async function installPackageSpec(params: {
 }
 
 const NPM_DIAGNOSTIC_LOG_LIMIT = 8;
-const NPM_DIAGNOSTIC_TIMERS = new Set([
-  "npm",
-  "command:install",
-  "idealTree",
-  "idealTree:init",
-  "idealTree:buildDeps",
-  "reify",
-  "reify:loadTrees",
-  "reify:diffTrees",
-  "reify:retireShallow",
-  "reify:createSparse",
-  "reify:loadBundles",
-  "reify:unpack",
-  "reify:build",
-  "reify:trash",
-  "reify:save",
-]);
 const NPM_DIAGNOSTIC_ERROR_CODES = new Set([
   "EACCES",
   "EBADENGINE",
@@ -524,7 +507,6 @@ export async function withNpmDiagnostics<T>(
 
 function projectNpmDebugLog(text: string) {
   const fetch = { count: 0, cacheHits: 0, cacheMisses: 0, durationMs: 0, maxDurationMs: 0 };
-  const timings: Record<string, number> = {};
   const errorCodes = new Set<string>();
   let command: string | null = null;
   let exitCode: number | null = null;
@@ -546,10 +528,6 @@ function projectNpmDebugLog(text: string) {
     if (code && NPM_DIAGNOSTIC_ERROR_CODES.has(code)) {
       errorCodes.add(code);
     }
-    const timing = line.match(/^\d+ timing (\S+) Completed in (\d+)ms$/u);
-    if (timing && NPM_DIAGNOSTIC_TIMERS.has(timing[1]!) && isNpmTiming(Number(timing[2]))) {
-      timings[timing[1]!] = Number(timing[2]);
-    }
     // npm-registry-fetch emits both network and cache reads; summed durations
     // describe this bounded tail and may overlap, so they are not wall time.
     const request = line.match(
@@ -564,7 +542,7 @@ function projectNpmDebugLog(text: string) {
       fetch.maxDurationMs = Math.max(fetch.maxDurationMs, durationMs);
     }
   }
-  return { command, exitCode, lastActivity, errorCodes: [...errorCodes], fetch, timings };
+  return { command, exitCode, lastActivity, errorCodes: [...errorCodes], fetch };
 }
 
 function isNpmTiming(value: number) {

--- a/scripts/lib/cross-os-release-checks/lanes.ts
+++ b/scripts/lib/cross-os-release-checks/lanes.ts
@@ -42,6 +42,7 @@ import {
   runInstalledBrowserOverrideImportSmoke,
   shouldRunWindowsInstalledBrowserOverrideImportSmoke,
   verifyInstalledCandidate,
+  withNpmDiagnostics,
 } from "./install.ts";
 import {
   ensureDevUpdateGitInstall,
@@ -253,14 +254,16 @@ export async function runUpgradeLane(
     let usedWindowsPackagedUpgradeTimeoutFallback = false;
     await runTimedLanePhase(lane, "update", async () => {
       try {
-        updateResult = await runOpenClaw({
-          lane,
-          env: updateEnv,
-          args: updateArgs,
-          logPath: updateLogPath,
-          timeoutMs: updateTimeoutMs(),
-          check: false,
-        });
+        updateResult = await withNpmDiagnostics(lane.homeDir, updateLogPath, updateEnv, () =>
+          runOpenClaw({
+            lane,
+            env: updateEnv,
+            args: updateArgs,
+            logPath: updateLogPath,
+            timeoutMs: updateTimeoutMs(),
+            check: false,
+          }),
+        );
       } catch (error) {
         if (!isRecoverableWindowsPackagedUpgradeTimeoutError(error, process.platform)) {
           throw error;

--- a/test/scripts/cross-os-release-npm-diagnostics.test.ts
+++ b/test/scripts/cross-os-release-npm-diagnostics.test.ts
@@ -1,0 +1,172 @@
+import { appendFileSync, existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.ts";
+
+const mocks = vi.hoisted(() => ({ runCommand: vi.fn() }));
+vi.mock("../../scripts/lib/cross-os-release-checks/process.ts", () => mocks);
+
+import { installPackageSpec } from "../../scripts/lib/cross-os-release-checks/install.ts";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+afterEach(() => mocks.runCommand.mockReset());
+
+function fixture() {
+  const rootDir = tempDirs.make("cross-os-npm-diagnostics-");
+  const homeDir = join(rootDir, "home");
+  const logsDir = join(homeDir, ".npm", "_logs");
+  mkdirSync(logsDir, { recursive: true });
+  return {
+    lane: {
+      name: "upgrade",
+      rootDir,
+      prefixDir: join(rootDir, "prefix"),
+      homeDir,
+      stateDir: join(homeDir, ".openclaw"),
+      appDataDir: join(homeDir, "AppData"),
+      gatewayPort: 0,
+      phaseTimings: [],
+    },
+    env: { npm_config_logs_dir: logsDir },
+    packageSpec: "openclaw@2026.7.1-2",
+    logPath: join(rootDir, "install.log"),
+    logsDir,
+  };
+}
+
+function diagnostics(logPath: string) {
+  const log = existsSync(logPath) ? readFileSync(logPath, "utf8") : "";
+  const record = log.match(/^\[release-checks\] npm-diagnostics (.+)$/mu)?.[1];
+  expect(record, "phase must retain npm diagnostics").toBeDefined();
+  return JSON.parse(record!);
+}
+
+describe("cross-OS npm diagnostic capture", () => {
+  it("retains only numeric and allowlisted observations after a successful install", async () => {
+    const params = fixture();
+    const secret = "credential-sentinel-must-never-be-exported";
+    mocks.runCommand.mockImplementation(async () => {
+      writeFileSync(
+        join(params.logsDir, "2026-08-29T00_00_00_000Z-debug-0.log"),
+        [
+          `0 verbose title npm install https://user:${secret}@registry.test/package.tgz`,
+          `1 http fetch GET 200 https://registry.test/?token=${secret} 123ms (cache miss)`,
+          "2 http cache https://registry.test/public 5ms (cache hit)",
+          "3 timing reify:unpack Completed in 200ms",
+          `4 timing reifyNode:${secret} Completed in 999ms`,
+          `5 error ${secret}`,
+          "6 verbose exit 0",
+          "7 timing reify:build Completed in 999999999999999999ms",
+          "8 timing reify:trash Completed in -1ms",
+          `9 error code ${secret}`,
+          `10 verbose title npm ${secret}`,
+        ].join("\n"),
+      );
+      return { exitCode: 0, stdout: "installed", stderr: "" };
+    });
+
+    await installPackageSpec(params);
+
+    expect(diagnostics(params.logPath)).toMatchObject({
+      logs: [
+        {
+          command: "install",
+          exitCode: 0,
+          fetch: { count: 2, cacheHits: 1, cacheMisses: 1, durationMs: 128, maxDurationMs: 123 },
+          timings: { "reify:unpack": 200 },
+        },
+      ],
+    });
+    const output = readFileSync(params.logPath, "utf8");
+    expect(output).not.toContain(secret);
+    expect(output).not.toContain("registry.test");
+    expect(output).not.toContain(params.logsDir);
+    expect(output).not.toContain("reifyNode");
+    expect(diagnostics(params.logPath).logs[0].timings).toEqual({ "reify:unpack": 200 });
+  });
+
+  it("captures a failed command without replacing its error or copying raw diagnostic text", async () => {
+    const params = fixture();
+    const failure = new Error("install failed");
+    mocks.runCommand.mockImplementation(async () => {
+      writeFileSync(
+        join(params.logsDir, "2026-08-29T00_00_00_000Z-debug-0.log"),
+        "0 error code ETIMEDOUT\n1 error password=credential-sentinel\n2 verbose exit 1\n",
+      );
+      throw failure;
+    });
+
+    await expect(installPackageSpec(params)).rejects.toBe(failure);
+    expect(diagnostics(params.logPath)).toMatchObject({
+      logs: [{ errorCodes: ["ETIMEDOUT"], exitCode: 1 }],
+    });
+    expect(readFileSync(params.logPath, "utf8")).not.toContain("credential-sentinel");
+  });
+
+  it("ignores stale process logs and bounds the retained tail and process count", async () => {
+    const params = fixture();
+    writeFileSync(join(params.logsDir, "stale-debug-0.log"), "0 error code EACCES\n");
+    mocks.runCommand.mockImplementation(async () => {
+      for (let index = 0; index < 12; index++) {
+        writeFileSync(
+          join(
+            params.logsDir,
+            `2026-08-29T00_00_${String(index).padStart(2, "0")}_000Z-debug-0.log`,
+          ),
+          `0 error code ENOSPC\n${"credential-sentinel\n".repeat(20_000)}1 error code EPERM\n`,
+        );
+      }
+      return { exitCode: 0, stdout: "", stderr: "" };
+    });
+
+    await installPackageSpec(params);
+    const result = diagnostics(params.logPath);
+    expect(result.truncated).toBe(true);
+    expect(result.logs).toHaveLength(8);
+    expect(
+      result.logs.every(
+        (log: { truncated: boolean; errorCodes: string[] }) =>
+          log.truncated && log.errorCodes.join() === "EPERM",
+      ),
+    ).toBe(true);
+    expect(Buffer.byteLength(readFileSync(params.logPath, "utf8"))).toBeLessThan(16 * 1024);
+  });
+
+  it("does not fail installation when npm logs are unavailable", async () => {
+    const params = fixture();
+    params.env.npm_config_logs_dir = join(params.lane.rootDir, "not-a-directory");
+    writeFileSync(params.env.npm_config_logs_dir, "not a directory");
+    mocks.runCommand.mockResolvedValue({ exitCode: 0, stdout: "", stderr: "" });
+
+    await expect(installPackageSpec(params)).resolves.toBeUndefined();
+    expect(diagnostics(params.logPath)).toMatchObject({ logs: [] });
+  });
+
+  it("attributes only newly appended and rotated log records to the next phase", async () => {
+    const params = fixture();
+    const npmLogPath = join(params.logsDir, "2026-08-29T00_00_00_000Z-debug-0.log");
+    mocks.runCommand
+      .mockImplementationOnce(async () => {
+        writeFileSync(npmLogPath, "0 error code EPERM\n");
+        return { exitCode: 0, stdout: "", stderr: "" };
+      })
+      .mockImplementationOnce(async () => {
+        appendFileSync(npmLogPath, "1 error code ETIMEDOUT\n");
+        writeFileSync(npmLogPath.replace("debug-0", "debug-1"), "2 verbose exit 1\n");
+        return { exitCode: 0, stdout: "", stderr: "" };
+      });
+
+    await installPackageSpec(params);
+    const nextLogPath = join(params.lane.rootDir, "next-install.log");
+    await installPackageSpec({ ...params, logPath: nextLogPath });
+
+    expect(diagnostics(params.logPath).logs[0].errorCodes).toEqual(["EPERM"]);
+    expect(diagnostics(nextLogPath).logs).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ errorCodes: ["ETIMEDOUT"] }),
+        expect.objectContaining({ exitCode: 1 }),
+      ]),
+    );
+    expect(readFileSync(nextLogPath, "utf8")).not.toContain("EPERM");
+  });
+});

--- a/test/scripts/cross-os-release-npm-diagnostics.test.ts
+++ b/test/scripts/cross-os-release-npm-diagnostics.test.ts
@@ -52,12 +52,10 @@ describe("cross-OS npm diagnostic capture", () => {
           `0 verbose title npm install https://user:${secret}@registry.test/package.tgz`,
           `1 http fetch GET 200 https://registry.test/?token=${secret} 123ms (cache miss)`,
           "2 http cache https://registry.test/public 5ms (cache hit)",
-          "3 timing reify:unpack Completed in 200ms",
-          `4 timing reifyNode:${secret} Completed in 999ms`,
           `5 error ${secret}`,
           "6 verbose exit 0",
-          "7 timing reify:build Completed in 999999999999999999ms",
-          "8 timing reify:trash Completed in -1ms",
+          "7 http fetch GET 200 https://registry.test/public 999999999999999999ms",
+          "8 http fetch GET 200 https://registry.test/public -1ms",
           `9 error code ${secret}`,
           `10 verbose title npm ${secret}`,
         ].join("\n"),
@@ -73,7 +71,6 @@ describe("cross-OS npm diagnostic capture", () => {
           command: "install",
           exitCode: 0,
           fetch: { count: 2, cacheHits: 1, cacheMisses: 1, durationMs: 128, maxDurationMs: 123 },
-          timings: { "reify:unpack": 200 },
         },
       ],
     });
@@ -81,8 +78,6 @@ describe("cross-OS npm diagnostic capture", () => {
     expect(output).not.toContain(secret);
     expect(output).not.toContain("registry.test");
     expect(output).not.toContain(params.logsDir);
-    expect(output).not.toContain("reifyNode");
-    expect(diagnostics(params.logPath).logs[0].timings).toEqual({ "reify:unpack": 200 });
   });
 
   it("captures a failed command without replacing its error or copying raw diagnostic text", async () => {

--- a/test/scripts/openclaw-cross-os-release-checks-upgrade-lane.test.ts
+++ b/test/scripts/openclaw-cross-os-release-checks-upgrade-lane.test.ts
@@ -1,3 +1,5 @@
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createScriptTestHarness } from "./test-helpers.js";
 
@@ -123,11 +125,25 @@ describe("cross-OS packaged upgrade lane evidence", () => {
   it("records bounded evidence when the supported Windows timeout fallback succeeds", async () => {
     vi.spyOn(process, "platform", "get").mockReturnValue("win32");
     arrangeSuccessfulLane();
-    mocks.runOpenClaw.mockRejectedValueOnce(
-      new Error(
+    let npmLogPath = "";
+    let capturedBeforeFallback = false;
+    mocks.runOpenClaw.mockImplementationOnce(async ({ env }) => {
+      const npmLogsDir = join(env.LOCALAPPDATA, "npm-cache", "_logs");
+      mkdirSync(npmLogsDir, { recursive: true });
+      npmLogPath = join(npmLogsDir, "2026-08-29T00_00_00_000Z-debug-0.log");
+      writeFileSync(npmLogPath, "0 error code ETIMEDOUT\n1 error token=updater-secret\n");
+      throw new Error(
         "Command timed out: C:\\prefix\\node_modules\\openclaw\\openclaw.mjs update --tag http://127.0.0.1:49951/openclaw-candidate.tgz --yes --json --no-restart --timeout 600",
-      ),
-    );
+      );
+    });
+    mocks.installPackageSpec
+      .mockImplementationOnce(async () => {})
+      .mockImplementationOnce(async () => {
+        capturedBeforeFallback = readFileSync(join(logsDir, "upgrade-update.log"), "utf8").includes(
+          '"errorCodes":["ETIMEDOUT"]',
+        );
+        writeFileSync(npmLogPath, "0 verbose exit 0\n");
+      });
 
     const result = await runUpgradeLane(upgradeParams());
 
@@ -145,6 +161,10 @@ describe("cross-OS packaged upgrade lane evidence", () => {
         expect.objectContaining({ name: "update-fallback-install", status: "pass" }),
       ]),
     );
+    expect(capturedBeforeFallback).toBe(true);
+    expect(readFileSync(join(logsDir, "upgrade-update.log"), "utf8")).not.toContain(
+      "updater-secret",
+    );
   });
 
   it("retains sanitized updater timings when a later upgrade phase fails", async () => {
@@ -154,7 +174,7 @@ describe("cross-OS packaged upgrade lane evidence", () => {
       exitCode: 0,
       stdout: JSON.stringify({
         durationMs: 622_000,
-        root: String.raw`C:\private\openclaw`,
+        root: String.raw`C:\npm-updater-private-fixture\openclaw`,
         steps: [
           {
             name: "global update",
@@ -186,7 +206,7 @@ describe("cross-OS packaged upgrade lane evidence", () => {
         expect.objectContaining({ name: "run-bundled-plugin-postinstall", status: "fail" }),
       ]),
     );
-    expect(JSON.stringify(result)).not.toContain("private");
+    expect(JSON.stringify(result)).not.toContain("npm-updater-private-fixture");
     expect(JSON.stringify(result)).not.toContain("npm install");
   });
 });

--- a/test/scripts/openclaw-cross-os-release-checks.test.ts
+++ b/test/scripts/openclaw-cross-os-release-checks.test.ts
@@ -9,7 +9,6 @@ import {
   realpathSync,
   rmSync,
   symlinkSync,
-  utimesSync,
   writeFileSync,
 } from "node:fs";
 import { createConnection as createNetConnection, createServer as createNetServer } from "node:net";
@@ -32,7 +31,6 @@ import {
   buildWindowsFreshShellVersionCheckScript,
   buildInstalledBrowserOverrideImportProbeScript,
   buildNpmGlobalInstallArgs,
-  appendLatestNpmDebugLogTail,
   assertManagedGatewayInstallerHostAvailable,
   buildGatewayStopArgsFromHelpText,
   buildGatewayStatusArgsFromHelpText,
@@ -2052,66 +2050,14 @@ describe("scripts/openclaw-cross-os-release-checks", () => {
     });
   });
 
-  it("reads npm debug logs from the Windows cache root", () => {
-    withTempDir("openclaw-cross-os-npm-debug-", (dir) => {
-      const homeDir = join(dir, "home");
-      const localAppData = join(homeDir, "AppData", "Local");
-      const logsDir = join(localAppData, "npm-cache", "_logs");
-      const logPath = join(dir, "install.log");
-      mkdirSync(logsDir, { recursive: true });
-      writeFileSync(join(logsDir, "2026-07-05T00_00_00_000Z-debug-0.log"), "windows log\n");
-      writeFileSync(logPath, "install failed\n");
-
-      expect(resolveNpmDebugLogDirs(homeDir, { LOCALAPPDATA: localAppData }, "win32")).toContain(
-        logsDir,
-      );
-      expect(
-        appendLatestNpmDebugLogTail(homeDir, logPath, { LOCALAPPDATA: localAppData }, "win32"),
-      ).toContain("windows log");
-      expect(readFileSync(logPath, "utf8")).toContain("windows log");
-    });
-  });
-
-  it("prefers npm configured log directories over cache defaults", () => {
-    withTempDir("openclaw-cross-os-npm-logs-dir-", (dir) => {
-      const homeDir = join(dir, "home");
-      const logsDir = join(dir, "custom-logs");
-      const logPath = join(dir, "install.log");
-      mkdirSync(logsDir, { recursive: true });
-      mkdirSync(join(homeDir, ".npm", "_logs"), { recursive: true });
-      writeFileSync(
-        join(homeDir, ".npm", "_logs", "2026-07-05T00_00_00_000Z-debug-0.log"),
-        "old fallback log\n",
-      );
-      utimesSync(
-        join(homeDir, ".npm", "_logs", "2026-07-05T00_00_00_000Z-debug-0.log"),
-        new Date("2020-01-01T00:00:00Z"),
-        new Date("2020-01-01T00:00:00Z"),
-      );
-      writeFileSync(join(logsDir, "2026-07-05T00_00_00_000Z-debug-0.log"), "custom log\n");
-      writeFileSync(logPath, "install failed\n");
-
-      expect(resolveNpmDebugLogDirs(homeDir, { npm_config_logs_dir: logsDir })).toContain(logsDir);
-      expect(
-        appendLatestNpmDebugLogTail(homeDir, logPath, { npm_config_logs_dir: logsDir }),
-      ).toContain("custom log");
-      expect(readFileSync(logPath, "utf8")).toContain("custom log");
-    });
-  });
-
-  it("keeps npm debug log collection best-effort", () => {
-    withTempDir("openclaw-cross-os-npm-debug-best-effort-", (dir) => {
-      const homeDir = join(dir, "home");
-      const logPath = join(dir, "install.log");
-      const logsDir = join(dir, "not-a-directory");
-      writeFileSync(logPath, "install failed\n");
-      writeFileSync(logsDir, "not a directory\n");
-
-      expect(appendLatestNpmDebugLogTail(homeDir, logPath, { npm_config_logs_dir: logsDir })).toBe(
-        "",
-      );
-      expect(readFileSync(logPath, "utf8")).toBe("install failed\n");
-    });
+  it("resolves Windows and configured npm diagnostic directories", () => {
+    const homeDir = join(tmpdir(), "openclaw-npm-diagnostics-home");
+    const localAppData = join(homeDir, "AppData", "Local");
+    const logsDir = join(homeDir, "custom-logs");
+    expect(resolveNpmDebugLogDirs(homeDir, { LOCALAPPDATA: localAppData }, "win32")).toContain(
+      join(localAppData, "npm-cache", "_logs"),
+    );
+    expect(resolveNpmDebugLogDirs(homeDir, { npm_config_logs_dir: logsDir })).toContain(logsDir);
   });
 
   it("resolves relative npm log config from the install working directory", () => {


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where release maintainers cannot explain a slow Windows packaged upgrade after recovery starts. In run 33256912172, job 99112468278 passed after 54m17s: baseline installation took 19m36s, the historical updater timed out after 12 minutes, and direct candidate recovery took another 18 minutes. Successful npm installs retained no npm diagnostics, and the updater timeout did not preserve its inner npm logs before the next invocation. The previous install-error path also copied arbitrary debug-log text into the reported error.

## Why This Change Was Made

The existing install owner now snapshots npm log metadata around each invocation and appends a bounded numeric projection to that phase's existing artifact log. The upgrade lane uses the same owner around the historical updater, so its observations are captured before fallback starts. Only fixed command/activity/error-code names, exit codes, request/cache counts and observed request durations can leave the reader. There are no raw log tails, paths, URLs, argv, or package names in the new record.

The reader retains at most eight changed log tails and reads at most 32 KiB from each (256 KiB total). Truncation is explicit; counts describe only the retained tail, overlapping request durations are not wall time, and native phase timings are not collected. No npm flags, environment settings, timeouts, retry rules, baseline scenarios, artifact identities, or runner assignments change. The old raw-tail/error-rewrapping path is removed. Tooling LOC: +123/-47 (net +76); tests: +201/-68 (net +133); product runtime: 0. The tooling growth provides the bounded evidence boundary while deleting the previous raw-tail path.

## User Impact

No product behavior changes. Maintainers can distinguish npm resolution/fetch/extraction activity and recovered updater failures using existing release artifacts. This is diagnostic groundwork, not a claimed Windows speedup. The original run remains a successful manual-recovery lane, not a successful historical updater.

## Evidence

- Five focused/sibling test files: 153 tests passed. Coverage includes Windows cache lookup, historical timeout recovery and existing identity/assertion contracts.
- Four new diagnostic regressions failed before the repair. The upgraded lane test separately failed because timeout evidence was absent when fallback began, then passed after shared capture was wired around the actual updater boundary.
- Secret sentinels and URLs never enter the projected record; malformed/out-of-range request durations are rejected. Tests cover input/process-count bounds, rotated/appended logs, stale-log exclusion, and preserving the original installation error.
- A real offline installation of a tiny local package passed through the actual install owner on macOS, Node 24.20.0/npm 11.19.0, and produced the expected command/exit/cache projection. npm 11.17.0's actual logging/timer source was also inspected because that version ran in the original Windows job. The one hosted Windows replay is [run 33266593713](https://github.com/openclaw/openclaw/actions/runs/33266593713), with tooling pinned to `921f627326efef6eca3c8e15bd06cb3988e8e347`, the original `d9fe780239a2cb7158aad437112156605e8d375c` candidate and sealed package/registry artifacts, `2026.7.1-2` baseline, and unchanged `windows-2025` runner. It passed in 25 minutes. The historical updater completed without fallback; baseline installation took 554.943s and update took 678.416s. Candidate SHA-256 `34882261b66f480a5e5ecb105535870205ea48df55c98dc4e201078f32b28a49` and baseline SHA-256 `5bb525f36f471a41239615d321c441778c7e1c007018ed6d84b795be77803276` matched the original run. The two phase records were 224 and 585 bytes, and all native timing fields were empty as expected. This is diagnostic proof, not a controlled speedup comparison.
- Initial `921f627` [CI 33266579924](https://github.com/openclaw/openclaw/actions/runs/33266579924) passed: 102 successful jobs and 17 expected skips.
- Independent Codex P0 autoreview found no actionable findings. The full changed-file gate passed, including script and test-root typechecks, script lint, and Docker/catalog boundaries.

An existing test's generic `private` sentinel accidentally matched macOS `/private/tmp` stack paths; it now checks a unique private-data sentinel without weakening its projection assertion.

## Review follow-up

Removed the native-timer allowlist, parser and output field after ClawSweeper identified that npm defaults cannot populate them. Enabling npm timing would print raw timing output; this repair deliberately keeps the invocation unchanged and collects only the default debug observations. The corresponding Rank-up move is addressed by the review's removal alternative, not by adding a flag.

The completed Windows run used the original `921f627` harness. The follow-up only deletes the unused timer projection and its synthetic assertions; installation commands, updater recovery, timeouts, candidate/registry binding, and bounded default-log capture are unchanged. Its Windows evidence belongs to that original head; final cleanup `677e5125a7a` passed the same 153 tests, real offline npm owner flow, full changed gate, and fresh Codex P0 review. Final-head CI is pending.
