### PR TITLE
feat(sandbox): recreate only image-mismatched runtimes

### DIFF
--- a/docs/cli/sandbox.md
+++ b/docs/cli/sandbox.md
@@ -31,6 +31,7 @@ Remove sandbox runtimes to force recreation with current config. Runtimes are re
 
 ```bash
 openclaw sandbox recreate --all
+openclaw sandbox recreate --all --mismatched # only image-mismatched runtimes
 openclaw sandbox recreate --agent mybot        # includes agent:mybot:* sub-sessions
 openclaw sandbox recreate --session "agent:main:main"
 openclaw sandbox recreate --browser --all      # only browser containers
@@ -43,9 +44,10 @@ Options:
 - `--session <key>`: recreate the runtime with this exact scope key (as shown by `sandbox list`); no short-name expansion
 - `--agent <id>`: recreate runtimes for one agent (matches `agent:<id>` and `agent:<id>:*`)
 - `--browser`: only affect browser containers
+- `--mismatched`: only affect image-backed runtimes whose current image differs from the configured image
 - `--force`: skip the confirmation prompt
 
-Pass exactly one of `--all`, `--session`, or `--agent`.
+Pass exactly one of `--all`, `--session`, or `--agent`. `--mismatched` is a modifier and does not select a scope by itself. It excludes SSH target and OpenShell source mismatches; use regular `recreate` when those settings change.
 
 For `ssh` and OpenShell `remote`, recreate matters more than with Docker: the remote workspace is canonical after the initial seed, `recreate` deletes that canonical remote workspace for the selected scope, and the next run reseeds it from the current local workspace.
 
@@ -77,7 +79,7 @@ Prefer `openclaw sandbox recreate` over manual backend-specific cleanup. It uses
 
 | Change                                                                                                                                                         | Command                                                             |
 | -------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
-| Container sandbox image update (`agents.defaults.sandbox.docker.image`)                                                                                        | `openclaw sandbox recreate --all`                                   |
+| Container sandbox image update (`agents.defaults.sandbox.docker.image`)                                                                                        | `openclaw sandbox recreate --all --mismatched`                      |
 | Sandbox config (`agents.defaults.sandbox.*`)                                                                                                                   | `openclaw sandbox recreate --all`                                   |
 | SSH target/auth (`agents.defaults.sandbox.ssh.{target,workspaceRoot,identityFile,certificateFile,knownHostsFile,identityData,certificateData,knownHostsData}`) | `openclaw sandbox recreate --all`                                   |
 | OpenShell source/policy/mode (`plugins.entries.openshell.config.{from,mode,policy}`)                                                                           | `openclaw sandbox recreate --all`                                   |

--- a/src/cli/sandbox-cli.ts
+++ b/src/cli/sandbox-cli.ts
@@ -19,6 +19,7 @@ const SANDBOX_EXAMPLES = {
     ["openclaw sandbox list", "List all sandbox containers."],
     ["openclaw sandbox list --browser", "List only browser containers."],
     ["openclaw sandbox recreate --all", "Recreate all containers."],
+    ["openclaw sandbox recreate --all --mismatched", "Recreate image-mismatched runtimes."],
     ["openclaw sandbox recreate --session main", "Recreate a specific session."],
     ["openclaw sandbox recreate --agent mybot", "Recreate agent containers."],
     ["openclaw sandbox explain", "Explain effective sandbox config."],
@@ -33,6 +34,7 @@ const SANDBOX_EXAMPLES = {
     ["openclaw sandbox recreate --session main", "Recreate a specific session."],
     ["openclaw sandbox recreate --agent mybot", "Recreate a specific agent (includes sub-agents)."],
     ["openclaw sandbox recreate --browser --all", "Recreate only browser containers."],
+    ["openclaw sandbox recreate --all --mismatched", "Recreate image-mismatched runtimes."],
     ["openclaw sandbox recreate --all --force", "Skip confirmation."],
   ],
   explain: [
@@ -111,6 +113,7 @@ export function registerSandboxCli(program: Command) {
     .option("--session <key>", "Recreate container for specific session")
     .option("--agent <id>", "Recreate containers for specific agent")
     .option("--browser", "Only recreate browser containers", false)
+    .option("--mismatched", "Only recreate runtimes whose configured image does not match", false)
     .option("--force", "Skip confirmation prompt", false)
     .addHelpText(
       "after",
@@ -129,6 +132,8 @@ export function registerSandboxCli(program: Command) {
           "  --agent        Remove containers for agent (includes agent:id:* variants)",
         )}\n\n${theme.heading("Modifiers:")}\n${theme.muted(
           "  --browser      Only affect browser containers (not regular sandbox)",
+        )}\n${theme.muted(
+          "  --mismatched   Only affect runtimes with an image mismatch",
         )}\n${theme.muted("  --force        Skip confirmation prompt")}`,
     )
     .action(
@@ -139,6 +144,7 @@ export function registerSandboxCli(program: Command) {
             session: opts.session as string | undefined,
             agent: opts.agent as string | undefined,
             browser: Boolean(opts.browser),
+            mismatched: Boolean(opts.mismatched),
             force: Boolean(opts.force),
           },
           defaultRuntime,

--- a/src/commands/sandbox-display.ts
+++ b/src/commands/sandbox-display.ts
@@ -68,13 +68,22 @@ export function displaySummary(
     containers.filter((c) => c.running).length + browsers.filter((b) => b.running).length;
   const mismatchCount =
     containers.filter((c) => !c.imageMatch).length + browsers.filter((b) => !b.imageMatch).length;
+  const imageMismatchCount =
+    containers.filter((c) => !c.imageMatch && (c.configLabelKind ?? "Image") === "Image").length +
+    browsers.filter((b) => !b.imageMatch).length;
 
   runtime.log(`Total: ${totalCount} (${runningCount} running)`);
 
   if (mismatchCount > 0) {
     runtime.log(`\n⚠️  ${mismatchCount} runtime(s) with config mismatch detected.`);
+    const onlyImageMismatches = imageMismatchCount === mismatchCount;
+    const command = onlyImageMismatches
+      ? browsers.length > 0
+        ? "openclaw sandbox recreate --browser --all --mismatched"
+        : "openclaw sandbox recreate --all --mismatched"
+      : "openclaw sandbox recreate --all";
     runtime.log(
-      `   Run '${formatCliCommand("openclaw sandbox recreate --all")}' to update all runtimes.`,
+      `   Run '${formatCliCommand(command)}' to update ${onlyImageMismatches ? "image-mismatched" : "all"} runtimes.`,
     );
   }
 }

--- a/src/commands/sandbox-display.ts
+++ b/src/commands/sandbox-display.ts
@@ -6,6 +6,7 @@ import type { SandboxBrowserInfo, SandboxContainerInfo } from "../agents/sandbox
 import { formatCliCommand } from "../cli/command-format.js";
 import { formatDurationCompact } from "../infra/format-time/format-duration.ts";
 import type { RuntimeEnv } from "../runtime.js";
+import { isImageBackedSandboxMismatch } from "./sandbox-runtime-filter.js";
 
 export function displayContainers(containers: SandboxContainerInfo[], runtime: RuntimeEnv): void {
   if (containers.length === 0) {
@@ -69,7 +70,7 @@ export function displaySummary(
   const mismatchCount =
     containers.filter((c) => !c.imageMatch).length + browsers.filter((b) => !b.imageMatch).length;
   const imageMismatchCount =
-    containers.filter((c) => !c.imageMatch && (c.configLabelKind ?? "Image") === "Image").length +
+    containers.filter(isImageBackedSandboxMismatch).length +
     browsers.filter((b) => !b.imageMatch).length;
 
   runtime.log(`Total: ${totalCount} (${runningCount} running)`);

--- a/src/commands/sandbox-runtime-filter.ts
+++ b/src/commands/sandbox-runtime-filter.ts
@@ -1,0 +1,13 @@
+import type { SandboxContainerInfo } from "../agents/sandbox.js";
+
+/** True only for Docker-style runtime image mismatches safe for image-only recreation. */
+export function isImageBackedSandboxMismatch(container: SandboxContainerInfo): boolean {
+  // Missing backend ids predate pluggable backends and are legacy Docker.
+  // Explicit remote backends must never enter image-only destructive cleanup.
+  const backendId = container.backendId ?? "docker";
+  return (
+    !container.imageMatch &&
+    (backendId === "docker" || backendId === "podman") &&
+    (container.configLabelKind ?? "Image") === "Image"
+  );
+}

--- a/src/commands/sandbox.test.ts
+++ b/src/commands/sandbox.test.ts
@@ -145,10 +145,11 @@ describe("sandboxListCommand", () => {
       expectLogContains(runtime, "sandbox recreate --all --mismatched");
     });
 
-    it("should keep broad recreate guidance when non-image labels also mismatch", async () => {
+    it("should keep broad recreate guidance when remote backends also mismatch", async () => {
       mocks.listSandboxContainers.mockResolvedValue([
         createContainer({ imageMatch: false }),
-        createContainer({ configLabelKind: "Target", imageMatch: false }),
+        createContainer({ backendId: "ssh", configLabelKind: undefined, imageMatch: false }),
+        createContainer({ backendId: "openshell", configLabelKind: "Image", imageMatch: false }),
       ]);
 
       await sandboxListCommand({ browser: false, json: false }, runtime as never);
@@ -294,6 +295,23 @@ describe("sandboxRecreateCommand", () => {
         configLabelKind: undefined,
         imageMatch: false,
       });
+      const podmanMismatch = createContainer({
+        backendId: "podman",
+        containerName: "podman-mismatch",
+        imageMatch: false,
+      });
+      const legacySshMismatch = createContainer({
+        backendId: "ssh",
+        containerName: "legacy-ssh-mismatch",
+        configLabelKind: undefined,
+        imageMatch: false,
+      });
+      const legacyOpenShellMismatch = createContainer({
+        backendId: "openshell",
+        containerName: "legacy-openshell-mismatch",
+        configLabelKind: "Image",
+        imageMatch: false,
+      });
       const targetMismatch = createContainer({
         containerName: "target-mismatch",
         configLabelKind: "Target",
@@ -308,6 +326,9 @@ describe("sandboxRecreateCommand", () => {
         matching,
         mismatched,
         legacyMismatch,
+        podmanMismatch,
+        legacySshMismatch,
+        legacyOpenShellMismatch,
         targetMismatch,
         sourceMismatch,
       ]);
@@ -317,9 +338,16 @@ describe("sandboxRecreateCommand", () => {
         runtime as never,
       );
 
-      expect(mocks.removeSandboxContainer).toHaveBeenCalledTimes(2);
+      expect(mocks.removeSandboxContainer).toHaveBeenCalledTimes(3);
       expect(mocks.removeSandboxContainer).toHaveBeenCalledWith(mismatched.containerName);
       expect(mocks.removeSandboxContainer).toHaveBeenCalledWith(legacyMismatch.containerName);
+      expect(mocks.removeSandboxContainer).toHaveBeenCalledWith(podmanMismatch.containerName);
+      expect(mocks.removeSandboxContainer).not.toHaveBeenCalledWith(
+        legacySshMismatch.containerName,
+      );
+      expect(mocks.removeSandboxContainer).not.toHaveBeenCalledWith(
+        legacyOpenShellMismatch.containerName,
+      );
       expect(mocks.removeSandboxContainer).not.toHaveBeenCalledWith(targetMismatch.containerName);
       expect(mocks.removeSandboxContainer).not.toHaveBeenCalledWith(sourceMismatch.containerName);
     });

--- a/src/commands/sandbox.test.ts
+++ b/src/commands/sandbox.test.ts
@@ -123,7 +123,7 @@ describe("sandboxListCommand", () => {
     });
 
     it("should display browsers when --browser flag is set", async () => {
-      const browser = createBrowser({ containerName: "browser-1" });
+      const browser = createBrowser({ containerName: "browser-1", imageMatch: false });
       mocks.listSandboxBrowsers.mockResolvedValue([browser]);
 
       await sandboxListCommand({ browser: true, json: false }, runtime as never);
@@ -131,6 +131,7 @@ describe("sandboxListCommand", () => {
       expectLogContains(runtime, "🌐 Sandbox Browser Containers");
       expectLogContains(runtime, browser.containerName);
       expectLogContains(runtime, String(browser.cdpPort));
+      expectLogContains(runtime, "sandbox recreate --browser --all --mismatched");
     });
 
     it("should show warning when image mismatches detected", async () => {
@@ -141,7 +142,19 @@ describe("sandboxListCommand", () => {
 
       expectLogContains(runtime, "⚠️");
       expectLogContains(runtime, "config mismatch");
-      expectLogContains(runtime, "sandbox recreate --all");
+      expectLogContains(runtime, "sandbox recreate --all --mismatched");
+    });
+
+    it("should keep broad recreate guidance when non-image labels also mismatch", async () => {
+      mocks.listSandboxContainers.mockResolvedValue([
+        createContainer({ imageMatch: false }),
+        createContainer({ configLabelKind: "Target", imageMatch: false }),
+      ]);
+
+      await sandboxListCommand({ browser: false, json: false }, runtime as never);
+
+      expectLogContains(runtime, "openclaw sandbox recreate --all'");
+      expect(runtime.log).not.toHaveBeenCalledWith(expect.stringContaining("--mismatched"));
     });
 
     it("should display message when no containers found", async () => {
@@ -271,6 +284,58 @@ describe("sandboxRecreateCommand", () => {
 
       expect(mocks.removeSandboxBrowserContainer).toHaveBeenCalledTimes(2);
       expect(mocks.removeSandboxContainer).not.toHaveBeenCalled();
+    });
+
+    it("should recreate only normal runtimes with an image mismatch", async () => {
+      const matching = createContainer({ containerName: "matching", imageMatch: true });
+      const mismatched = createContainer({ containerName: "mismatched", imageMatch: false });
+      const legacyMismatch = createContainer({
+        containerName: "legacy-mismatch",
+        configLabelKind: undefined,
+        imageMatch: false,
+      });
+      const targetMismatch = createContainer({
+        containerName: "target-mismatch",
+        configLabelKind: "Target",
+        imageMatch: false,
+      });
+      const sourceMismatch = createContainer({
+        containerName: "source-mismatch",
+        configLabelKind: "Source",
+        imageMatch: false,
+      });
+      mocks.listSandboxContainers.mockResolvedValue([
+        matching,
+        mismatched,
+        legacyMismatch,
+        targetMismatch,
+        sourceMismatch,
+      ]);
+
+      await sandboxRecreateCommand(
+        { all: true, browser: false, mismatched: true, force: true },
+        runtime as never,
+      );
+
+      expect(mocks.removeSandboxContainer).toHaveBeenCalledTimes(2);
+      expect(mocks.removeSandboxContainer).toHaveBeenCalledWith(mismatched.containerName);
+      expect(mocks.removeSandboxContainer).toHaveBeenCalledWith(legacyMismatch.containerName);
+      expect(mocks.removeSandboxContainer).not.toHaveBeenCalledWith(targetMismatch.containerName);
+      expect(mocks.removeSandboxContainer).not.toHaveBeenCalledWith(sourceMismatch.containerName);
+    });
+
+    it("should recreate only browser runtimes with an image mismatch", async () => {
+      const matching = createBrowser({ containerName: "matching", imageMatch: true });
+      const mismatched = createBrowser({ containerName: "mismatched", imageMatch: false });
+      mocks.listSandboxBrowsers.mockResolvedValue([matching, mismatched]);
+
+      await sandboxRecreateCommand(
+        { all: true, browser: true, mismatched: true, force: true },
+        runtime as never,
+      );
+
+      expect(mocks.removeSandboxBrowserContainer).toHaveBeenCalledTimes(1);
+      expect(mocks.removeSandboxBrowserContainer).toHaveBeenCalledWith(mismatched.containerName);
     });
   });
 

--- a/src/commands/sandbox.ts
+++ b/src/commands/sandbox.ts
@@ -36,6 +36,7 @@ type SandboxRecreateOptions = {
   session?: string;
   agent?: string;
   browser: boolean;
+  mismatched?: boolean;
   force: boolean;
 };
 
@@ -138,6 +139,13 @@ async function fetchAndFilterContainers(opts: SandboxRecreateOptions): Promise<F
     const matchesAgent = createAgentMatcher(opts.agent);
     containers = containers.filter(matchesAgent);
     browsers = browsers.filter(matchesAgent);
+  }
+
+  if (opts.mismatched) {
+    containers = containers.filter(
+      (container) => !container.imageMatch && (container.configLabelKind ?? "Image") === "Image",
+    );
+    browsers = browsers.filter((browser) => !browser.imageMatch);
   }
 
   return { containers, browsers };

--- a/src/commands/sandbox.ts
+++ b/src/commands/sandbox.ts
@@ -23,6 +23,7 @@ import {
   displayRecreateResult,
   displaySummary,
 } from "./sandbox-display.js";
+import { isImageBackedSandboxMismatch } from "./sandbox-runtime-filter.js";
 
 // --- Types ---
 
@@ -142,9 +143,7 @@ async function fetchAndFilterContainers(opts: SandboxRecreateOptions): Promise<F
   }
 
   if (opts.mismatched) {
-    containers = containers.filter(
-      (container) => !container.imageMatch && (container.configLabelKind ?? "Image") === "Image",
-    );
+    containers = containers.filter(isImageBackedSandboxMismatch);
     browsers = browsers.filter((browser) => !browser.imageMatch);
   }
 


### PR DESCRIPTION
Closes #132725

## What Problem This Solves

Operators who change a sandbox container or browser image currently have to run a broad `openclaw sandbox recreate --all`, which also stops healthy runtimes whose images already match current configuration. Manual `docker rm` bypasses OpenClaw's backend and SQLite registry cleanup owners.

## Why This Change Was Made

Add `--mismatched` to the existing recreate command after normal scope selection, reusing preview, confirmation, backend removal, registry cleanup, and failure reporting. The shared selector accepts only Docker/Podman `Image` mismatches, including legacy Docker defaults. Explicit SSH and OpenShell records remain excluded even when a missing legacy label normalizes to `Image`.

The current integration preserves main's browser-scoped display summary. Both selective and broad repair guidance retain `--browser` when inspecting browser runtimes, and counts use only the selected scope. No retry, automatic cleanup, scheduling policy, or backend-specific removal owner is added.

## User Impact

```bash
openclaw sandbox recreate --all --mismatched
openclaw sandbox recreate --browser --all --mismatched
```

Only stale-image runtimes in the selected scope are previewed and removed. Matching runtimes remain available; SSH/OpenShell stay on the existing broad recreate path. Existing confirmation still applies unless `--force` is supplied.

## Evidence

### Latest published integration — source and checks

Product HEAD: `0e9d272e548a6f0a04b781e680af9be5da6d4b9c`.
Tree: `5087d7c5af8873a4c476bf9c02f287c129eecfa0`.

This normal merge commit preserves the preceding PR head `64a9fea4eeb6f1956473c25d9ad56c98a8548276` and pinned main `9910bd1ca21e9d0d1c0fbbe9bf92b2627108ce06` as parents. Author and committer: `Alix-007 <li.long15@xydigit.com>`. No force-push.

Recorded validation on the frozen tree above, Linux / Node 26.1.0:

- Focused sandbox tests: 27 total, 27 passed, 0 failed, 0 pending. The integration retains both browser-scoped guidance and the Docker/Podman-only mismatch selection controls.
- Three-file type-aware lint: `Found 0 warnings and 0 errors.`
- Native staged-content/format guard and main-relative diff check passed.
- One fresh independent P0–P2 source review returned `scoped-clean`.

These are retained execution results, not checks rerun merely to refresh this description. The published integration note is https://github.com/openclaw/openclaw/pull/132749#issuecomment-5664682533 . Full build, full typecheck, and current hosted CI are not certified by these scoped results.

GitHub subsequently reported another merge conflict as main advanced. This description update does not resolve or waive that conflict; the previous integration is not claimed to cover every later main revision.

### Historical real behavior receipt — original scope and revision retained

The following behavior was executed at `06d230fc9f457532f177e7af0e267a5f8e7a9d28`, not rerun at the latest head. Its baseline was `d58c93f334ce5f867707a07591c0d032f6d1f641`; validation completed `2026-09-04T16:18:59Z`, using Node `v24.15.0`, Docker `17.03.3`, and SQLite `3.51.3`.

Entry: `registerSandboxCli` → Commander `parseAsync` → `sandboxRecreateCommand` → the existing backend selector/removal and SQLite registry owners.

Command: `openclaw sandbox recreate --all --mismatched --force`.

The same command on its baseline failed with `error: unknown option '--mismatched'`. The candidate used isolated config/state, a matching `node:24-alpine` Docker container, a mismatched `alpine:latest` container, and legacy SSH/OpenShell registry controls:

```json
{
  "acceptanceGreen": {
    "exitCode": 0,
    "mismatchedContainerRemoved": true,
    "mismatchedRegistryRemoved": true
  },
  "mustNotFireControls": {
    "matchingDockerPreserved": true,
    "legacySshPreserved": true,
    "legacyOpenShellPreserved": true,
    "remoteRemovalCalls": [],
    "remoteNamesHiddenFromPreview": true
  },
  "errors": []
}
```

Observed operator output selected only the mismatched Docker runtime:

```text
Sandbox runtimes to be recreated:
  - oc-proof-mismatched-* [docker] (running)
Total: 1 runtime(s)
Removing sandbox runtimes...
Done: 1 removed, 0 failed
Runtimes will be automatically recreated when the agent is next used.
```

Real Docker inspection and SQLite readback retained the matching Docker, legacy SSH, and legacy OpenShell records. Disposable Docker fixtures and isolated state/config were cleaned up. No proof artifact is committed to the product branch.

Historical focused checks at that revision: sandbox command 22/22; sandbox management 4/4; SSH backend 21/21; core tsgo, diff check, and independent review passed. They remain historical evidence rather than newly executed current-head results.

### Limits and remaining decisions

- Not live-tested: browser-container removal, Podman, real SSH, or OpenShell. Their selection boundaries have focused test coverage; the earlier production-manager controls establish that remote records did not reach removal in that fixture.
- No new configuration key, persistence schema, migration, authorization rule, or independent cleanup mechanism. The proposed public CLI modifier still needs maintainer product acceptance.
- Later-main merge compatibility and current hosted CI remain separate from the recorded proof and scoped checks.

AI-assisted implementation and review. Execution claims above retain their actual source revisions; no rating, merge approval, or unexecuted platform behavior is asserted.