### PR TITLE
fix(shared): invalidate hasBinary's cache after a skill install lands a binary

### DIFF
--- a/src/shared/config-eval.ts
+++ b/src/shared/config-eval.ts
@@ -171,6 +171,15 @@ let cachedHasBinaryPath: string | undefined;
 let cachedHasBinaryPathExt: string | undefined;
 const hasBinaryCache = new Map<string, boolean>();
 
+// hasBinary self-invalidates only on a PATH/PATHEXT string change, which an
+// install into an already-on-PATH prefix never triggers. Callers that install
+// a binary and then re-read its presence in the same process must reset first.
+export function resetBinaryDetectionCache(): void {
+  hasBinaryCache.clear();
+  cachedHasBinaryPath = undefined;
+  cachedHasBinaryPathExt = undefined;
+}
+
 /** Checks PATH for an executable binary, including PATHEXT candidates on Windows. */
 export function hasBinary(bin: string): boolean {
   const pathEnv = process.env.PATH ?? "";

--- a/src/skills/lifecycle/install.test.ts
+++ b/src/skills/lifecycle/install.test.ts
@@ -1,13 +1,15 @@
 // Skill install tests cover lifecycle install flows and validation failures.
 import fs from "node:fs/promises";
 import path from "node:path";
-import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
 import {
   initializeGlobalHookRunner,
   resetGlobalHookRunner,
 } from "../../plugins/hook-runner-global.js";
 import { createMockPluginRegistry } from "../../plugins/hooks.test-fixtures.js";
-import { captureEnv } from "../../test-utils/env.js";
+import { hasBinary, resetBinaryDetectionCache } from "../../shared/config-eval.js";
+import { captureEnv, setTestEnvValue } from "../../test-utils/env.js";
 import { createFixtureSuite } from "../../test-utils/fixture-suite.js";
 import {
   resolveSkillInvocationPolicy,
@@ -122,6 +124,8 @@ async function withWorkspaceCase(
 }
 
 describe("installSkill before_install hooks", () => {
+  const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
   beforeEach(() => {
     resetGlobalHookRunner();
     runCommandWithTimeoutMock.mockClear();
@@ -317,6 +321,37 @@ describe("installSkill before_install hooks", () => {
         },
       });
       expect(runCommandWithTimeoutMock).not.toHaveBeenCalled();
+    });
+  });
+
+  it("stops returning a pre-install hasBinary miss once a real install succeeds", async () => {
+    await withWorkspaceCase(async ({ workspaceDir }) => {
+      const envSnapshot = captureEnv(["PATH"]);
+      const dir = tempDirs.make("hasbinary-cache-");
+      const binPath = path.join(dir, "provisioned-tool-probe");
+      try {
+        // The install lands the binary in a directory already on PATH, so the
+        // PATH-string check that normally invalidates hasBinary's cache never fires.
+        setTestEnvValue("PATH", `${dir}${path.delimiter}${process.env.PATH ?? ""}`);
+        resetBinaryDetectionCache();
+        expect(hasBinary("provisioned-tool-probe")).toBe(false);
+
+        await fs.writeFile(binPath, "#!/bin/sh\nexit 0\n");
+        await fs.chmod(binPath, 0o755);
+
+        await writeInstallableSkill(workspaceDir, "cache-invalidation-skill");
+        const result = await installSkill({
+          workspaceDir,
+          skillName: "cache-invalidation-skill",
+          installId: "deps",
+        });
+
+        expect(result.ok).toBe(true);
+        expect(hasBinary("provisioned-tool-probe")).toBe(true);
+      } finally {
+        envSnapshot.restore();
+        resetBinaryDetectionCache();
+      }
     });
   });
 });

--- a/src/skills/lifecycle/install.ts
+++ b/src/skills/lifecycle/install.ts
@@ -11,6 +11,7 @@ import {
   type SkillInstallSpecMetadata,
 } from "../../plugins/install-security-scan.js";
 import { runCommandWithTimeout, type CommandOptions } from "../../process/exec.js";
+import { resetBinaryDetectionCache } from "../../shared/config-eval.js";
 import { resolveUserPath } from "../../utils.js";
 import {
   hasBinary as defaultHasBinary,
@@ -57,6 +58,12 @@ function getSkillsInstallDeps(): SkillsInstallDeps {
 }
 
 function withWarnings(result: SkillInstallResult, warnings: string[]): SkillInstallResult {
+  if (result.ok) {
+    // A successful install may have just landed a binary this process already
+    // cached as missing (e.g. a brew/uv prefix already on PATH); every
+    // installSkill return funnels through here.
+    resetBinaryDetectionCache();
+  }
   if (warnings.length === 0) {
     return result;
   }


### PR DESCRIPTION
Closes #132751


## What Problem This Solves

Fixes an issue where a skill's binary dependency continues to read as missing after `skills.install` successfully installs it, because `hasBinary`'s per-binary memoization only invalidates on a `PATH` string change, which an install into an already-on-PATH prefix never triggers.

## Why This Change Was Made

Added `resetBinaryDetectionCache` to `src/shared/config-eval.ts` and call it from `installSkill`'s single result-finalization choke point (`withWarnings`, which every return path in `installSkill` funnels through) whenever the install succeeded — so the next `hasBinary` read in the same process re-probes the filesystem instead of returning the pre-install memo.

## User Impact

A skill dependency installed via the Control UI or `skills.install` becomes eligible immediately, without needing a gateway restart.

## Evidence

New test `stops returning a pre-install hasBinary miss once a real install succeeds` (`src/skills/lifecycle/install.test.ts`) writes a real executable into a temp directory already on `PATH`, drives it through the real `installSkill` success path (mocked `runCommandWithTimeout` only — the install-result plumbing and cache are real), and asserts `hasBinary` flips `false` → `true` in-process.

RED (source reverted to base, test kept):

```
$ node scripts/run-vitest.mjs src/skills/lifecycle/install.test.ts
 × installSkill before_install hooks > stops returning a pre-install hasBinary miss once a real install succeeds
   → resetBinaryDetectionCache is not a function
 Test Files  1 failed (1)
      Tests  1 failed | 6 passed (7)
```

GREEN (patched):

```
$ node scripts/run-vitest.mjs src/skills/lifecycle/install.test.ts
 Test Files  1 passed (1)
      Tests  7 passed (7)
```

`pnpm build && pnpm check` were run over the touched paths (format/typecheck/lint) at the final branch tip — clean.

Authored by Tommy Joseph with assistance from Claude (Opus 5).

Closes #&lt;issue number, once filed alongside this PR&gt;
