### PR TITLE
fix(web-search): report the first error when every provider fails

### DIFF
--- a/docs/tools/web.md
+++ b/docs/tools/web.md
@@ -234,6 +234,11 @@ Configured endpoint providers after that:
 
 11. **SearXNG** -- `SEARXNG_BASE_URL` or `plugins.entries.searxng.config.webSearch.baseUrl` (order 200)
 
+If an auto-detected provider fails, OpenClaw tries the next eligible provider.
+If all attempts fail, it reports the first provider's error to help you diagnose
+the primary failure. An explicitly selected provider does not use automatic
+fallback.
+
 Key-free providers such as **Parallel Search (Free)**, **DuckDuckGo**,
 **Ollama Web Search**, and **Codex Hosted Search** never win auto-detection,
 even though they have an internal order value. They are used only when you

--- a/src/web-search/runtime-execution.test.ts
+++ b/src/web-search/runtime-execution.test.ts
@@ -1,0 +1,33 @@
+// Coverage for candidate fallback error attribution.
+import { describe, expect, it } from "vitest";
+import { executeWebSearchCandidates } from "./runtime-execution.js";
+
+function candidate(id: string, execute: () => Promise<unknown>) {
+  return {
+    id,
+    createTool: () => ({
+      description: id,
+      parameters: {},
+      execute,
+    }),
+  } as unknown as Parameters<typeof executeWebSearchCandidates>[0]["candidates"][number];
+}
+
+describe("executeWebSearchCandidates", () => {
+  it("surfaces the first candidate's error when every candidate fails", async () => {
+    await expect(
+      executeWebSearchCandidates({
+        candidates: [
+          candidate("google", async () => {
+            throw new Error("google unreachable");
+          }),
+          candidate("duckduckgo", async () => {
+            throw new Error("duckduckgo unreachable");
+          }),
+        ],
+        args: {},
+        allowFallback: true,
+      }),
+    ).rejects.toThrow("google unreachable");
+  });
+});

--- a/src/web-search/runtime-execution.test.ts
+++ b/src/web-search/runtime-execution.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, it, vi } from "vitest";
+import type { WebSearchProviderToolDefinition } from "../plugins/web-provider-types.js";
+import { createWebSearchTestProvider } from "../test-utils/web-provider-runtime.test-helpers.js";
+import { executeWebSearchCandidates } from "./runtime-execution.js";
+
+function candidate(id: string, execute: WebSearchProviderToolDefinition["execute"]) {
+  return createWebSearchTestProvider({
+    id,
+    pluginId: "fixture-search",
+    credentialPath: `plugins.entries.fixture-search.config.${id}`,
+    createTool: () => ({ description: id, parameters: {}, execute }),
+  });
+}
+
+describe("executeWebSearchCandidates", () => {
+  it("tries every fallback and retains the first error with its cause", async () => {
+    const cause = new Error("first transport failure");
+    const firstError = new Error("first provider failed", { cause });
+    const attempts: string[] = [];
+    const result = executeWebSearchCandidates({
+      candidates: [
+        candidate("first", async () => {
+          attempts.push("first");
+          throw firstError;
+        }),
+        candidate("second", async () => {
+          attempts.push("second");
+          throw new Error("second provider failed");
+        }),
+      ],
+      args: { query: "synthetic query" },
+      allowFallback: true,
+    });
+    await expect(result).rejects.toBe(firstError);
+    expect(firstError.cause).toBe(cause);
+    expect(attempts).toEqual(["first", "second"]);
+  });
+
+  it.each(["first rejection", null, undefined])(
+    "retains the first non-Error rejection: %s",
+    async (firstRejection) => {
+      await expect(
+        executeWebSearchCandidates({
+          candidates: [
+            candidate(
+              "first",
+              vi.fn<WebSearchProviderToolDefinition["execute"]>().mockRejectedValue(firstRejection),
+            ),
+            candidate("second", async () => {
+              throw new Error("second provider failed");
+            }),
+          ],
+          args: {},
+          allowFallback: true,
+        }),
+      ).rejects.toThrow(String(firstRejection));
+    },
+  );
+
+  it.each([true, false])(
+    "retains chronology across structured and thrown errors (structured first: %s)",
+    async (structuredFirst) => {
+      const thrown = new Error("ordinary provider failure");
+      const missingKey = async () => ({ error: "missing_fixture_api_key" });
+      const fail = async () => {
+        throw thrown;
+      };
+      const result = executeWebSearchCandidates({
+        candidates: [
+          candidate("first", structuredFirst ? missingKey : fail),
+          candidate("second", structuredFirst ? fail : missingKey),
+        ],
+        args: {},
+        allowFallback: true,
+      });
+      if (structuredFirst) {
+        await expect(result).rejects.toThrow(
+          'web_search provider "first" returned missing_fixture_api_key',
+        );
+      } else {
+        await expect(result).rejects.toBe(thrown);
+      }
+    },
+  );
+
+  it("does not treat a thrown undefined as an unavailable factory", async () => {
+    const unavailable = createWebSearchTestProvider({
+      id: "unavailable",
+      pluginId: "fixture-search",
+      credentialPath: "plugins.entries.fixture-search.config.unavailable",
+      createTool: () => null,
+    });
+    await expect(
+      executeWebSearchCandidates({
+        candidates: [
+          candidate(
+            "first",
+            vi.fn<WebSearchProviderToolDefinition["execute"]>().mockRejectedValue(undefined),
+          ),
+          unavailable,
+        ],
+        args: {},
+        allowFallback: true,
+      }),
+    ).rejects.toThrow("undefined");
+  });
+
+  it("gives cancellation precedence over a saved failure and later cleanup error", async () => {
+    const controller = new AbortController();
+    const reason = new Error("caller cancelled");
+    await expect(
+      executeWebSearchCandidates({
+        candidates: [
+          candidate("first", async () => {
+            throw new Error("first provider failure");
+          }),
+          candidate("second", async () => {
+            controller.abort(reason);
+            throw new Error("second provider cleanup failure");
+          }),
+        ],
+        args: {},
+        signal: controller.signal,
+        allowFallback: true,
+      }),
+    ).rejects.toBe(reason);
+  });
+
+  it("starts no provider factory when the caller is already cancelled", async () => {
+    const controller = new AbortController();
+    const reason = new Error("caller cancelled before search");
+    controller.abort(reason);
+    const createTool = vi.fn(() => ({
+      description: "unused",
+      parameters: {},
+      execute: async () => ({}),
+    }));
+    await expect(
+      executeWebSearchCandidates({
+        candidates: [
+          createWebSearchTestProvider({
+            id: "unused",
+            pluginId: "fixture-search",
+            credentialPath: "plugins.entries.fixture-search.config.unused",
+            createTool,
+          }),
+        ],
+        args: {},
+        signal: controller.signal,
+        allowFallback: true,
+      }),
+    ).rejects.toBe(reason);
+    expect(createTool).not.toHaveBeenCalled();
+  });
+});

--- a/src/web-search/runtime-execution.ts
+++ b/src/web-search/runtime-execution.ts
@@ -26,7 +26,9 @@ function isStructuredAvailabilityError(result: unknown): result is { error: stri
 export async function executeWebSearchCandidates(
   params: ExecuteWebSearchCandidatesParams,
 ): Promise<RunWebSearchResult> {
-  let lastError: unknown;
+  // The first candidate is the provider the caller's configuration actually
+  // relies on; keep its error instead of a less-relevant fallback's.
+  let firstError: unknown;
   let sawUnavailableProvider = false;
 
   for (const candidate of params.candidates) {
@@ -52,7 +54,9 @@ export async function executeWebSearchCandidates(
       if (params.allowFallback && isStructuredAvailabilityError(executed)) {
         // Some providers report missing credentials as structured tool output.
         // Treat that like unavailable only during auto-detected fallback.
-        lastError = new Error(`web_search provider "${candidate.id}" returned ${executed.error}`);
+        firstError ??= new Error(
+          `web_search provider "${candidate.id}" returned ${executed.error}`,
+        );
         continue;
       }
       return {
@@ -61,15 +65,15 @@ export async function executeWebSearchCandidates(
       };
     } catch (error) {
       params.signal?.throwIfAborted();
-      lastError = error;
+      firstError ??= error;
       if (!params.allowFallback) {
         throw error;
       }
     }
   }
 
-  if (sawUnavailableProvider && lastError === undefined) {
+  if (sawUnavailableProvider && firstError === undefined) {
     throw new Error("web_search is enabled but no provider is currently available.");
   }
-  throw lastError instanceof Error ? lastError : new Error(String(lastError));
+  throw firstError instanceof Error ? firstError : new Error(String(firstError));
 }

--- a/src/web-search/runtime-execution.ts
+++ b/src/web-search/runtime-execution.ts
@@ -26,7 +26,8 @@ function isStructuredAvailabilityError(result: unknown): result is { error: stri
 export async function executeWebSearchCandidates(
   params: ExecuteWebSearchCandidatesParams,
 ): Promise<RunWebSearchResult> {
-  let lastError: unknown;
+  // Keep the selected provider's failure, including null or undefined rejections.
+  let firstFailure: { error: unknown } | undefined;
   let sawUnavailableProvider = false;
 
   for (const candidate of params.candidates) {
@@ -52,7 +53,9 @@ export async function executeWebSearchCandidates(
       if (params.allowFallback && isStructuredAvailabilityError(executed)) {
         // Some providers report missing credentials as structured tool output.
         // Treat that like unavailable only during auto-detected fallback.
-        lastError = new Error(`web_search provider "${candidate.id}" returned ${executed.error}`);
+        firstFailure ??= {
+          error: new Error(`web_search provider "${candidate.id}" returned ${executed.error}`),
+        };
         continue;
       }
       return {
@@ -61,15 +64,16 @@ export async function executeWebSearchCandidates(
       };
     } catch (error) {
       params.signal?.throwIfAborted();
-      lastError = error;
+      firstFailure ??= { error };
       if (!params.allowFallback) {
         throw error;
       }
     }
   }
 
-  if (sawUnavailableProvider && lastError === undefined) {
+  if (sawUnavailableProvider && firstFailure === undefined) {
     throw new Error("web_search is enabled but no provider is currently available.");
   }
-  throw lastError instanceof Error ? lastError : new Error(String(lastError));
+  const error = firstFailure?.error;
+  throw error instanceof Error ? error : new Error(String(error));
 }


### PR DESCRIPTION
Closes #132752

## What Problem This Solves

When every automatic web-search provider fails, OpenClaw reports the last fallback's error. This hides the first selected provider's failure and can send operators toward the wrong cause.

## Why This Change Was Made

Retain the first failure at the shared search executor while continuing eligible fallback attempts. Track failure presence separately from its value so even `null` and `undefined` rejections are retained. Existing Error objects, including their causes, remain intact. Use the existing typed provider fixture for regression coverage and document the fallback behavior.

## User Impact

Operators see the primary failure after search providers are exhausted. Successful fallback, explicit provider selection, validation, and cancellation keep their existing behavior. The HTTP tool endpoint keeps its opaque error response; provider diagnostics remain in authenticated operator logs.

## Evidence

Tested an isolated built Gateway through authenticated `POST /tools/invoke` and `logs.tail`, using the real Brave and SearXNG HTTP clients against two synthetic local endpoints. Provider selection was automatic, with reverse configuration insertion order.

| Scenario | Before | After |
| --- | --- | --- |
| Brave fails with 503, then SearXNG fails with 502 | Operator diagnostic reports SearXNG's second failure | Operator diagnostic reports Brave's first failure |
| Brave fails, SearXNG succeeds | Normalized SearXNG results | Same |
| Explicit Brave selection fails | Brave only; no fallback | Same |
| Missing query | HTTP 400; no provider requests | Same |
| Caller cancels during Brave request | Brave request closes; no SearXNG request | Same |
| Tool endpoint error privacy | Opaque HTTP 500 | Same |

- Baseline: `969840671abdccdbf35ca23b2666f98cf5d10d74`.
- Candidate: `c016ec8a6b990f878026a9688909174a6241ad1b`; the tested staged tree is unchanged in this signed commit.
- Nine focused executor cases: seven expected failures on baseline, all nine pass after repair. They cover first Error identity/cause, string and nullish rejections, mixed structured/thrown errors, unavailable factories, and cancellation precedence.
- Existing runtime and provider-error controls also pass: 98 focused tests across three files.
- Focused formatting/lint and the changed documentation check pass. Full type and repository checks run in hosted CI.
- Independent source review found no remaining implementation issue. Independent public acceptance confirmed the changed attribution and preservation controls from complete transport observations.

AI-assisted. Synthetic provider failures use no real provider credentials. Raw proof retains private fixture metadata; the table above reports the observed behavior without that metadata.
