### PR TITLE
test(gateway): restore event authorization fixture coverage

### DIFF
--- a/test/e2e/qa-lab/runtime/gateway-event-protocol-authz.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/gateway-event-protocol-authz.e2e.test.ts
@@ -17,6 +17,7 @@ import {
 installGatewayTestHooks({ scope: "suite" });
 
 type RecordingSocket = {
+  readyState: number;
   bufferedAmount: number;
   close: ReturnType<typeof vi.fn>;
   sent: Array<{ event?: string }>;
@@ -26,6 +27,7 @@ type RecordingSocket = {
 function makeRecordingSocket(): RecordingSocket {
   const sent: Array<{ event?: string }> = [];
   return {
+    readyState: WebSocket.OPEN,
     bufferedAmount: 0,
     close: vi.fn(),
     sent,


### PR DESCRIPTION
## What Problem This Solves

Resolves a release-verification failure where the Gateway event authorization test receives no events from any recording socket, so it fails before exercising its recipient matrix.

## Why This Change Was Made

The broadcaster correctly rejects non-open transports after #128144. This fixture predates that contract and omitted `readyState`, unlike the sibling broadcast fixtures. Mark its recording sockets `WebSocket.OPEN` so the existing role/scope assertions exercise connected clients.

Production code, authorization policy, test expectations, and timeouts are unchanged. Production LOC: +0/-0; test fixture: +2/-0.

## User Impact

No runtime behavior changes. Release verification can exercise the existing event authorization and protocol cases with a valid connected-socket fixture.

## Evidence

The unchanged frozen `d9fe780239a2cb7158aad437112156605e8d375c` Linux baseline failed the recipient assertion: expected `chat` and `plugin.example.read`, received `[]`. Its other three protocol cases passed.

A disposable copy of this test containing only these two additions passed all four cases in 4.13 seconds on the same isolated Linux environment, with complete source-tree identity checks before and after cleanup. The tested file SHA-256 is `cd9ad7954959c8fa629f0ebf36d4bf138d0a3d2e1ee353b8b057dfd616680cdd`, identical to this patch. The original test and broadcaster are unchanged on the current base. This is retained focused Linux proof, not a new full release-verification result.

The `ws` source and existing broadcaster regressions confirm the OPEN-state contract; closing/closed sockets must still be skipped. The canonical changed-scope gate passed, including root-test typechecking, formatting, repository guards, and script lint. A mechanical rebase preserved the exact patch and tested file hash. Independent Codex review found no blocking issue. No fresh full release-verification result is claimed.
