### PR TITLE
feat(ui): preview Markdown files in Review

### DIFF
--- a/ui/src/components/markdown-render-options.ts
+++ b/ui/src/components/markdown-render-options.ts
@@ -1,7 +1,7 @@
 type MarkdownCodeBlockChrome = "copy" | "none";
 type MarkdownCodeBlockInteraction = "interactive" | "static";
 type MarkdownTableInteractions = "enabled" | "none";
-type MarkdownRenderMode = "document" | "message";
+type MarkdownRenderMode = "document" | "document-no-remote-images" | "message";
 
 export type MarkdownRenderOptions = {
   assistantTranscriptRoleHeaders?: boolean;

--- a/ui/src/components/markdown.ts
+++ b/ui/src/components/markdown.ts
@@ -507,7 +507,7 @@ function renderSanitizedMarkdown(renderInput: string, renderOptions: MarkdownRen
   const activeSanitizeOptions = renderOptions.progressBars
     ? progressSanitizeOptions
     : sanitizeOptions;
-  const documentMode = renderOptions.mode === "document";
+  const documentMode = renderOptions.mode !== "message";
   const truncated = documentMode
     ? { text: renderInput, truncated: false, total: renderInput.length }
     : truncateText(renderInput, MARKDOWN_CHAR_LIMIT);

--- a/ui/src/pages/chat/components/chat-detail-panel.ts
+++ b/ui/src/pages/chat/components/chat-detail-panel.ts
@@ -29,8 +29,10 @@ import {
   computeFileMatches,
   emptyCopyFeedback,
   readFileDraft,
+  resolveMarkdownPreviewFilePath,
   setFileDraft,
   type FileCopyAction,
+  type FileViewMode,
 } from "./chat-sidebar-file-view.ts";
 import type { FileEditorViewHandle } from "./file-editor-view.ts";
 
@@ -62,6 +64,8 @@ class ChatDetailPanel extends OpenClawLightDomElement {
   @state() private fileSearchQuery = "";
   @state() private fileSearchMatchIndex = 0;
   @state() private fileEditorMenuOpen = false;
+  @state() private fileViewMode: FileViewMode = "source";
+  @state() private filePreviewContent = "";
   @state() private fileCopyFeedback = emptyCopyFeedback;
   @state() private fileEditorLoading = false;
   @state() private fileEditing = false;
@@ -145,6 +149,8 @@ class ChatDetailPanel extends OpenClawLightDomElement {
       setFileDraft(this.content, null);
     }
     this.fileDraftContent = restoredDraft?.content ?? null;
+    this.filePreviewContent =
+      restoredDraft?.content ?? (this.content?.kind === "file" ? this.content.content : "");
     this.fileSavedContent = this.content?.kind === "file" ? this.content.content : "";
     this.fileHash =
       restoredDraft?.expectedHash ??
@@ -450,6 +456,7 @@ class ChatDetailPanel extends OpenClawLightDomElement {
 
   private updateSavedFile(content: FileSidebarContent, nextContent: string, hash: string) {
     this.fileSavedContent = nextContent;
+    this.filePreviewContent = nextContent;
     this.fileHash = hash;
     this.fileDirty = this.fileEditor?.getContent() !== nextContent;
     const draftContent = this.fileEditor?.getContent();
@@ -628,12 +635,48 @@ class ChatDetailPanel extends OpenClawLightDomElement {
     this.error = null;
   };
 
+  private readonly changeFileViewMode = (mode: FileViewMode) => {
+    const content = this.visibleContent;
+    if (content?.kind !== "file" || this.fileViewMode === mode) {
+      return;
+    }
+    if (mode === "preview") {
+      this.filePreviewContent =
+        this.fileEditor?.getContent() ?? this.fileDraftContent ?? content.content;
+      this.fileSearchOpen = false;
+      this.fileSearchQuery = "";
+      this.fileSearchMatchIndex = 0;
+    }
+    this.fileViewMode = mode;
+  };
+
+  private readonly openWorkspaceFileFromPanel = (target: {
+    path: string;
+    line?: number | null;
+  }) => {
+    const content = this.visibleContent;
+    const path =
+      content?.kind === "file" && this.fileViewMode === "preview"
+        ? resolveMarkdownPreviewFilePath(content.path, target.path)
+        : target.path;
+    this.onOpenWorkspaceFile?.({ ...target, path });
+  };
+
+  private sidebarNavigationCallbacks() {
+    return {
+      basePath: this.basePath,
+      onOpenImage: this.onOpenImage,
+      onOpenSessionLink: this.onOpenSessionLink,
+      onOpenWorkspaceFile: this.openWorkspaceFileFromPanel,
+    };
+  };
+
   private readonly handlePanelClick = (event: MouseEvent) => {
-    handleSidebarClick(event, this);
+    handleSidebarClick(event, this.sidebarNavigationCallbacks());
   };
 
   private readonly handlePanelKeyDown = (event: KeyboardEvent) => {
-    handleSidebarKeydown(event, this);
+    handleSidebarKeydown(event, this.sidebarNavigationCallbacks());
   };
 
   override render() {
@@ -655,10 +698,12 @@ class ChatDetailPanel extends OpenClawLightDomElement {
         loadingEditor: this.fileEditorLoading,
         mountKey: this.fileOperationVersion,
         matches,
+        previewContent: this.filePreviewContent,
         query: this.fileSearchQuery,
         saveNotice: this.fileSaveNotice,
         saving: this.fileSaving,
         searchOpen: this.fileSearchOpen,
+        viewMode: this.fileViewMode,
         onCopy: this.copyFileValue,
         onDiscard: this.discardFileEdits,
         onEdit: this.editFile,
@@ -675,6 +720,7 @@ class ChatDetailPanel extends OpenClawLightDomElement {
           this.fileEditorMenuOpen = open;
         },
         onToggleSearch: this.toggleFileSearch,
+        onViewModeChange: this.changeFileViewMode,
       },
       canvasPluginSurfaceUrl: this.canvasPluginSurfaceUrl,
       embedSandboxMode: this.embedSandboxMode,

--- a/ui/src/pages/chat/components/chat-detail-panel.ts
+++ b/ui/src/pages/chat/components/chat-detail-panel.ts
@@ -443,6 +443,7 @@ class ChatDetailPanel extends OpenClawLightDomElement {
       return;
     }
     this.fileEditor?.setContent(this.fileSavedContent);
+    this.filePreviewContent = this.fileSavedContent;
     const content = this.visibleContent;
     if (content?.kind === "file") {
       setFileDraft(content, null);

--- a/ui/src/pages/chat/components/chat-detail-panel.ts
+++ b/ui/src/pages/chat/components/chat-detail-panel.ts
@@ -669,7 +669,7 @@ class ChatDetailPanel extends OpenClawLightDomElement {
       onOpenSessionLink: this.onOpenSessionLink,
       onOpenWorkspaceFile: this.openWorkspaceFileFromPanel,
     };
-  };
+  }
 
   private readonly handlePanelClick = (event: MouseEvent) => {
     handleSidebarClick(event, this.sidebarNavigationCallbacks());

--- a/ui/src/pages/chat/components/chat-sidebar-file-view.browser.test.ts
+++ b/ui/src/pages/chat/components/chat-sidebar-file-view.browser.test.ts
@@ -174,6 +174,28 @@ describe.runIf(browserMode)("chat file editor", () => {
     expect(panel.querySelector(".cm-content")?.textContent).toContain("# Edited audit");
   });
 
+  it("refreshes Markdown preview after discarding edits", async () => {
+    const panel = await mountFile({
+      kind: "file",
+      path: "notes.md",
+      name: "notes.md",
+      content: "# Original",
+      edit: { hash: "hash-1", save: vi.fn(), fetchLatest: vi.fn() },
+    });
+
+    await userEvent.click(button(panel, "Edit file"));
+    await userEvent.fill(panel.querySelector<HTMLElement>(".cm-content")!, "# Draft");
+    await userEvent.click(button(panel, "Preview"));
+    await expect
+      .poll(() => panel.querySelector(".sidebar-file-preview h1")?.textContent)
+      .toBe("Draft");
+
+    await userEvent.click(button(panel, "Discard"));
+    await expect
+      .poll(() => panel.querySelector(".sidebar-file-preview h1")?.textContent)
+      .toBe("Original");
+  });
+
   it("enables save after an edit and keeps the saved content", async () => {
     const save = vi.fn().mockResolvedValue({ ok: true, hash: "hash-2" });
     const panel = await mountFile({

--- a/ui/src/pages/chat/components/chat-sidebar-file-view.browser.test.ts
+++ b/ui/src/pages/chat/components/chat-sidebar-file-view.browser.test.ts
@@ -41,6 +41,7 @@ beforeAll(async () => {
 
 type DetailPanel = HTMLElement & {
   content: FileSidebarContent;
+  onOpenWorkspaceFile?: (target: { path: string; line?: number | null }) => void;
   updateComplete: Promise<unknown>;
 };
 
@@ -116,6 +117,60 @@ describe.runIf(browserMode)("chat file editor", () => {
     expect(panel.querySelector(".cm-content")?.textContent).toContain("const second = 2;");
     const target = panel.querySelector(".file-view__line--target");
     expect(target?.getAttribute("data-line")).toBe("2");
+  });
+
+  it("renders large Markdown drafts in a responsive preview", async () => {
+    const initial = `# Audit\n\n[Guide](guide.md)\n\n![Remote diagram](https://example.com/private.png)\n\n- First item\n- Second item\n\n${"long prose ".repeat(4_500)}`;
+    expect(initial.length).toBeGreaterThan(40_000);
+    const panel = await mountFile({
+      kind: "file",
+      path: "notes/handoff.md",
+      name: "handoff.md",
+      content: initial,
+      edit: { hash: "hash-1", save: vi.fn(), fetchLatest: vi.fn() },
+    });
+    panel.style.width = "320px";
+    panel.style.height = "480px";
+    const openWorkspaceFile = vi.fn();
+    panel.onOpenWorkspaceFile = openWorkspaceFile;
+
+    await userEvent.click(button(panel, "Edit file"));
+    await userEvent.fill(
+      expectDefined(panel.querySelector<HTMLElement>(".cm-content"), "file editor"),
+      initial.replace("# Audit", "# Edited audit"),
+    );
+    await userEvent.click(button(panel, "Preview"));
+
+    const preview = expectDefined(
+      panel.querySelector<HTMLElement>(".sidebar-file-preview"),
+      "Markdown preview",
+    );
+    await expect.poll(() => preview.hidden).toBe(false);
+    const reader = expectDefined(
+      preview.querySelector<HTMLElement>(".sidebar-file-preview__content"),
+      "Markdown preview content",
+    );
+    expect(panel.querySelector<HTMLElement>(".file-view")?.hidden).toBe(true);
+    expect(reader.querySelector("h1")?.textContent).toBe("Edited audit");
+    expect(reader.querySelectorAll("li")).toHaveLength(2);
+    expect(reader.querySelector(".markdown-plain-text-fallback")).toBeNull();
+    expect(reader.querySelector("img")).toBeNull();
+    expect(reader.querySelector(".markdown-external-image")?.textContent).toContain(
+      "External image not loaded",
+    );
+
+    const guideLink = expectDefined(
+      reader.querySelector<HTMLAnchorElement>('a[data-file-path="guide.md"]'),
+      "relative Markdown link",
+    );
+    await userEvent.click(guideLink);
+    expect(openWorkspaceFile).toHaveBeenCalledWith({ path: "notes/guide.md", line: null });
+    expect(getComputedStyle(reader).overflowWrap).toBe("anywhere");
+    expect(reader.scrollWidth).toBeLessThanOrEqual(reader.clientWidth + 1);
+
+    await userEvent.click(button(panel, "Source"));
+    await expect.poll(() => panel.querySelector<HTMLElement>(".file-view")?.hidden).toBe(false);
+    expect(panel.querySelector(".cm-content")?.textContent).toContain("# Edited audit");
   });
 
   it("enables save after an edit and keeps the saved content", async () => {

--- a/ui/src/pages/chat/components/chat-sidebar-file-view.browser.test.ts
+++ b/ui/src/pages/chat/components/chat-sidebar-file-view.browser.test.ts
@@ -117,6 +117,7 @@ describe.runIf(browserMode)("chat file editor", () => {
     expect(panel.querySelector(".cm-content")?.textContent).toContain("const second = 2;");
     const target = panel.querySelector(".file-view__line--target");
     expect(target?.getAttribute("data-line")).toBe("2");
+    expect(panel.querySelector(".settings-segmented")).toBeNull();
   });
 
   it("renders large Markdown drafts in a responsive preview", async () => {

--- a/ui/src/pages/chat/components/chat-sidebar-file-view.ts
+++ b/ui/src/pages/chat/components/chat-sidebar-file-view.ts
@@ -1,15 +1,20 @@
 import { html, nothing } from "lit";
 import { keyed } from "lit/directives/keyed.js";
+import { unsafeHTML } from "lit/directives/unsafe-html.js";
 import { localEditorFilePath } from "../../../app/native-editor-locality.runtime.ts";
 import { icons } from "../../../components/icons.ts";
+import { toSanitizedMarkdownHtml } from "../../../components/markdown.ts";
 import { renderPanelLoadingSkeleton } from "../../../components/panel-loading-skeleton.ts";
 import "../../../components/tooltip.ts";
 import { t } from "../../../i18n/index.ts";
 import type { EditorId } from "../../../lib/editor-links.ts";
+import { detectTextDirection } from "../../../lib/text-direction.ts";
 import type { SidebarContent } from "./chat-sidebar-content-types.ts";
 import { renderChatSidebarEditorMenu } from "./chat-sidebar-editor-menu.ts";
 
 type FileSidebarContent = Extract<SidebarContent, { kind: "file" }>;
+
+export type FileViewMode = "source" | "preview";
 
 type RetainedFileDraft = {
   content: string;
@@ -54,6 +59,50 @@ export function computeFileMatches(content: string, query: string): number[] {
     );
 }
 
+function isMarkdownFile(content: FileSidebarContent): boolean {
+  return (
+    content.language?.toLocaleLowerCase() === "markdown" ||
+    /\.(?:md|markdown|mdown|mkd|mkdn)$/i.test(content.path)
+  );
+}
+
+function isAbsoluteFilePath(path: string): boolean {
+  return (
+    path.startsWith("/") ||
+    path.startsWith("\\") ||
+    path.startsWith("~/") ||
+    path.startsWith("~\\") ||
+    /^[a-z]:[\\/]/i.test(path)
+  );
+}
+
+export function resolveMarkdownPreviewFilePath(sourcePath: string, targetPath: string): string {
+  if (isAbsoluteFilePath(targetPath)) {
+    return targetPath;
+  }
+
+  const source = sourcePath.replaceAll("\\", "/");
+  const target = targetPath.replaceAll("\\", "/");
+  const segments = source.split("/");
+  segments.pop();
+  for (const segment of target.split("/")) {
+    if (!segment || segment === ".") {
+      continue;
+    }
+    if (segment === "..") {
+      const last = segments.at(-1);
+      if (last && last !== "..") {
+        segments.pop();
+      } else if (last !== "") {
+        segments.push(segment);
+      }
+      continue;
+    }
+    segments.push(segment);
+  }
+  return segments.join("/");
+}
+
 export type FileCopyAction = "path" | "contents";
 type FileCopyFeedback = Partial<Record<FileCopyAction, "copied" | "failed">>;
 export const emptyCopyFeedback: FileCopyFeedback = {};
@@ -68,10 +117,12 @@ export type FileViewControls = {
   loadingEditor: boolean;
   mountKey: number;
   matches: number[];
+  previewContent: string;
   query: string;
   saveNotice: { kind: "conflict" } | { kind: "error"; message: string } | null;
   saving: boolean;
   searchOpen: boolean;
+  viewMode: FileViewMode;
   onCopy: (action: FileCopyAction) => void;
   onDiscard: () => void;
   onEdit: () => void;
@@ -86,6 +137,7 @@ export type FileViewControls = {
   onSearchKeydown: (event: KeyboardEvent) => void;
   onEditorMenuOpenChange: (open: boolean) => void;
   onToggleSearch: () => void;
+  onViewModeChange: (mode: FileViewMode) => void;
 };
 
 function renderFileCopyButton(action: FileCopyAction, controls?: FileViewControls) {
@@ -120,6 +172,17 @@ export function renderSidebarFile(
 ) {
   const absolutePath = localEditorFilePath(content, controls?.execNode);
   const matchNumber = controls?.matches.length ? controls.currentMatchIndex + 1 : 0;
+  const markdownFile = isMarkdownFile(content);
+  const previewing = markdownFile && controls?.viewMode === "preview";
+  const markdownHtml =
+    previewing && controls.previewContent.trim()
+      ? toSanitizedMarkdownHtml(controls.previewContent, {
+          codeBlockInteraction: "interactive",
+          fileLinks: true,
+          mode: "document-no-remote-images",
+          sessionLinks: true,
+        })
+      : "";
   return html`
     <section class="sidebar-file-view">
       <div class="sidebar-file-view__path-bar">
@@ -169,17 +232,21 @@ export function renderSidebarFile(
                                 `
                               : nothing
                           }
-                          <openclaw-tooltip .content=${t("chat.detailPanel.searchInFile")}>
-                            <button
-                              class="btn btn--sm sidebar-file-view__action"
-                              type="button"
-                              aria-label=${t("chat.detailPanel.searchInFile")}
-                              aria-pressed=${String(controls.searchOpen)}
-                              @click=${controls.onToggleSearch}
-                            >
-                              ${icons.search}
-                            </button>
-                          </openclaw-tooltip>
+                          ${previewing
+                            ? nothing
+                            : html`
+                                <openclaw-tooltip .content=${t("chat.detailPanel.searchInFile")}>
+                                  <button
+                                    class="btn btn--sm sidebar-file-view__action"
+                                    type="button"
+                                    aria-label=${t("chat.detailPanel.searchInFile")}
+                                    aria-pressed=${String(controls.searchOpen)}
+                                    @click=${controls.onToggleSearch}
+                                  >
+                                    ${icons.search}
+                                  </button>
+                                </openclaw-tooltip>
+                              `}
                           ${
                             controls.onReveal
                               ? html`
@@ -215,8 +282,29 @@ export function renderSidebarFile(
           ? html`<div class="file-view__save-notice" role="alert">${t("common.copyFailed")}</div>`
           : nothing
       }
+      ${markdownFile && controls
+        ? html`
+            <div class="settings-segmented" role="group" aria-label=${content.name}>
+              ${(["source", "preview"] as const).map((mode) => {
+                const active = controls.viewMode === mode;
+                return html`
+                  <button
+                    class="settings-segmented__btn ${active
+                      ? "settings-segmented__btn--active"
+                      : ""}"
+                    type="button"
+                    aria-pressed=${String(active)}
+                    @click=${() => controls.onViewModeChange(mode)}
+                  >
+                    ${t(mode === "source" ? "agentTools.source" : "chat.workspaceFiles.preview")}
+                  </button>
+                `;
+              })}
+            </div>
+          `
+        : nothing}
       ${
-        controls?.searchOpen
+        controls?.searchOpen && !previewing
           ? html`
               <div class="file-view__search">
                 <input
@@ -292,7 +380,7 @@ export function renderSidebarFile(
             `
           : nothing
       }
-      <div class="file-view">
+      <div class="file-view" ?hidden=${previewing}>
         ${keyed(controls?.mountKey ?? content, html`<div class="file-view__mount"></div>`)}
         ${
           controls?.loadingEditor
@@ -300,6 +388,26 @@ export function renderSidebarFile(
             : nothing
         }
       </div>
+      ${markdownFile && controls
+        ? html`
+            <div class="file-view sidebar-file-preview" ?hidden=${!previewing}>
+              ${markdownHtml
+                ? html`
+                    <article
+                      class="sidebar-markdown sidebar-file-preview__content"
+                      dir=${detectTextDirection(controls.previewContent)}
+                    >
+                      ${unsafeHTML(markdownHtml)}
+                    </article>
+                  `
+                : html`
+                    <div class="sidebar-markdown-empty">
+                      ${t("chat.detailPanel.noPreviewableMarkdown")}
+                    </div>
+                  `}
+            </div>
+          `
+        : nothing}
       ${
         controls?.editing
           ? nothing

--- a/ui/src/pages/chat/components/chat-sidebar-file-view.ts
+++ b/ui/src/pages/chat/components/chat-sidebar-file-view.ts
@@ -284,7 +284,7 @@ export function renderSidebarFile(
       }
       ${markdownFile && controls
         ? html`
-            <div class="settings-segmented" role="group" aria-label=${content.name}>
+            <div class="settings-segmented sidebar-file-view__modes" role="group" aria-label=${content.name}>
               ${(["source", "preview"] as const).map((mode) => {
                 const active = controls.viewMode === mode;
                 return html`

--- a/ui/src/pages/chat/components/chat-sidebar-file-view.ts
+++ b/ui/src/pages/chat/components/chat-sidebar-file-view.ts
@@ -232,21 +232,23 @@ export function renderSidebarFile(
                                 `
                               : nothing
                           }
-                          ${previewing
-                            ? nothing
-                            : html`
-                                <openclaw-tooltip .content=${t("chat.detailPanel.searchInFile")}>
-                                  <button
-                                    class="btn btn--sm sidebar-file-view__action"
-                                    type="button"
-                                    aria-label=${t("chat.detailPanel.searchInFile")}
-                                    aria-pressed=${String(controls.searchOpen)}
-                                    @click=${controls.onToggleSearch}
-                                  >
-                                    ${icons.search}
-                                  </button>
-                                </openclaw-tooltip>
-                              `}
+                          ${
+                            previewing
+                              ? nothing
+                              : html`
+                                  <openclaw-tooltip .content=${t("chat.detailPanel.searchInFile")}>
+                                    <button
+                                      class="btn btn--sm sidebar-file-view__action"
+                                      type="button"
+                                      aria-label=${t("chat.detailPanel.searchInFile")}
+                                      aria-pressed=${String(controls.searchOpen)}
+                                      @click=${controls.onToggleSearch}
+                                    >
+                                      ${icons.search}
+                                    </button>
+                                  </openclaw-tooltip>
+                                `
+                          }
                           ${
                             controls.onReveal
                               ? html`
@@ -282,27 +284,29 @@ export function renderSidebarFile(
           ? html`<div class="file-view__save-notice" role="alert">${t("common.copyFailed")}</div>`
           : nothing
       }
-      ${markdownFile && controls
-        ? html`
-            <div class="settings-segmented" role="group" aria-label=${content.name}>
-              ${(["source", "preview"] as const).map((mode) => {
-                const active = controls.viewMode === mode;
-                return html`
-                  <button
-                    class="settings-segmented__btn ${active
-                      ? "settings-segmented__btn--active"
-                      : ""}"
-                    type="button"
-                    aria-pressed=${String(active)}
-                    @click=${() => controls.onViewModeChange(mode)}
-                  >
-                    ${t(mode === "source" ? "agentTools.source" : "chat.workspaceFiles.preview")}
-                  </button>
-                `;
-              })}
-            </div>
-          `
-        : nothing}
+      ${
+        markdownFile && controls
+          ? html`
+              <div class="settings-segmented" role="group" aria-label=${content.name}>
+                ${(["source", "preview"] as const).map((mode) => {
+                  const active = controls.viewMode === mode;
+                  return html`
+                    <button
+                      class="settings-segmented__btn ${
+                        active ? "settings-segmented__btn--active" : ""
+                      }"
+                      type="button"
+                      aria-pressed=${String(active)}
+                      @click=${() => controls.onViewModeChange(mode)}
+                    >
+                      ${t(mode === "source" ? "agentTools.source" : "chat.workspaceFiles.preview")}
+                    </button>
+                  `;
+                })}
+              </div>
+            `
+          : nothing
+      }
       ${
         controls?.searchOpen && !previewing
           ? html`
@@ -388,26 +392,30 @@ export function renderSidebarFile(
             : nothing
         }
       </div>
-      ${markdownFile && controls
-        ? html`
-            <div class="file-view sidebar-file-preview" ?hidden=${!previewing}>
-              ${markdownHtml
-                ? html`
-                    <article
-                      class="sidebar-markdown sidebar-file-preview__content"
-                      dir=${detectTextDirection(controls.previewContent)}
-                    >
-                      ${unsafeHTML(markdownHtml)}
-                    </article>
-                  `
-                : html`
-                    <div class="sidebar-markdown-empty">
-                      ${t("chat.detailPanel.noPreviewableMarkdown")}
-                    </div>
-                  `}
-            </div>
-          `
-        : nothing}
+      ${
+        markdownFile && controls
+          ? html`
+              <div class="file-view sidebar-file-preview" ?hidden=${!previewing}>
+                ${
+                  markdownHtml
+                    ? html`
+                        <article
+                          class="sidebar-markdown sidebar-file-preview__content"
+                          dir=${detectTextDirection(controls.previewContent)}
+                        >
+                          ${unsafeHTML(markdownHtml)}
+                        </article>
+                      `
+                    : html`
+                        <div class="sidebar-markdown-empty">
+                          ${t("chat.detailPanel.noPreviewableMarkdown")}
+                        </div>
+                      `
+                }
+              </div>
+            `
+          : nothing
+      }
       ${
         controls?.editing
           ? nothing

--- a/ui/src/pages/chat/components/chat-sidebar-file-view.ts
+++ b/ui/src/pages/chat/components/chat-sidebar-file-view.ts
@@ -284,7 +284,7 @@ export function renderSidebarFile(
       }
       ${markdownFile && controls
         ? html`
-            <div class="settings-segmented sidebar-file-view__modes" role="group" aria-label=${content.name}>
+            <div class="settings-segmented" role="group" aria-label=${content.name}>
               ${(["source", "preview"] as const).map((mode) => {
                 const active = controls.viewMode === mode;
                 return html`

--- a/ui/src/styles/chat/sidebar.css
+++ b/ui/src/styles/chat/sidebar.css
@@ -1170,6 +1170,10 @@ openclaw-session-discussion {
   white-space: nowrap;
 }
 
+.sidebar-file-view__modes {
+  align-self: center;
+  margin: 8px;
+}
 .sidebar-file-view__actions {
   display: inline-flex;
   flex: 0 0 auto;
@@ -1285,6 +1289,14 @@ openclaw-session-discussion {
   overflow: hidden;
 }
 
+.sidebar-file-preview {
+  padding: 20px 18px 24px;
+  overflow: auto;
+}
+
+.sidebar-file-preview__content {
+  overflow-wrap: anywhere;
+}
 .file-view__mount,
 .sidebar-file-view .cm-editor {
   height: 100%;

--- a/ui/src/styles/chat/sidebar.css
+++ b/ui/src/styles/chat/sidebar.css
@@ -1545,6 +1545,15 @@ openclaw-session-discussion {
   line-height: 1.45;
 }
 
+.sidebar-file-preview {
+  padding: 20px 18px 24px;
+  overflow: auto;
+}
+
+.sidebar-file-preview__content {
+  overflow-wrap: anywhere;
+}
+
 .sidebar-markdown-reader.sidebar-markdown :where(h1, h2) {
   font-family: var(--md-preview-serif);
   letter-spacing: -0.03em;

--- a/ui/src/styles/chat/sidebar.css
+++ b/ui/src/styles/chat/sidebar.css
@@ -1170,10 +1170,6 @@ openclaw-session-discussion {
   white-space: nowrap;
 }
 
-.sidebar-file-view__modes {
-  align-self: center;
-  margin: 8px;
-}
 .sidebar-file-view__actions {
   display: inline-flex;
   flex: 0 0 auto;

--- a/ui/src/styles/chat/sidebar.css
+++ b/ui/src/styles/chat/sidebar.css
@@ -1553,15 +1553,6 @@ openclaw-session-discussion {
   line-height: 1.45;
 }
 
-.sidebar-file-preview {
-  padding: 20px 18px 24px;
-  overflow: auto;
-}
-
-.sidebar-file-preview__content {
-  overflow-wrap: anywhere;
-}
-
 .sidebar-markdown-reader.sidebar-markdown :where(h1, h2) {
   font-family: var(--md-preview-serif);
   letter-spacing: -0.03em;


### PR DESCRIPTION
Closes #128090

## What Problem This Solves

Review files currently show Markdown only as source text, so headings, lists, links, and long-form handoff notes are harder to inspect in the Control UI review workflow. Users also need to read rendered Markdown without losing an unsaved edit or leaving the existing file-review context.

## Why This Change Was Made

This adds a Source/Preview mode at the existing Review-file owner for recognized Markdown files. Preview reuses OpenClaw's existing `markdown-it`/DOMPurify-backed document renderer in full-document, no-remote-images mode, while the current CodeMirror instance remains the single owner of drafts, edits, save/discard, conflict reloads, and file locality.

Existing-solutions preflight: OpenClaw already ships the maintained renderer and sanitizer needed for document presentation. A plugin or new library cannot add the missing mode inside the existing Review file lifecycle, so this change reuses the built-in seam and adds no dependency or custom rendering system.

Architecture and boundaries:

- The file-view owner recognizes Markdown and renders the segmented presentation mode.
- The detail-panel owner carries presentation state and reads the current editor value when Preview is selected.
- Relative Markdown file links resolve from the reviewed file's directory only while previewing; existing source-mode and non-file navigation is unchanged.
- Non-Markdown files keep the current source-only behavior.

The dependency contract was checked directly against DOMPurify 3.4.14: OpenClaw sanitizes the rendered document before applying its existing post-sanitize link/image policy hook. Preview therefore uses the same established boundary rather than a parallel sanitizer.

## User Impact

Users can switch a reviewed Markdown file between source and a responsive rendered document. Preview reflects unsaved editor content, supports the existing workspace/session link interactions, and switching back returns to the same editable CodeMirror document.

No config, environment variable, protocol, schema, storage, migration, permission, or compatibility surface changes. This does not add image activation, a second editor, or a new file persistence path.

## Evidence

Acceptance red before production changes:

- The focused real-browser scenario opened `notes/handoff.md` through the Review file owner and failed with `Missing Preview button` on unmodified `main`.

Public exact-head Control UI proof:

- Candidate: `1f600a4d2f793962c0020c3a0687769d2e658ec6`
- GitHub Actions run: https://github.com/Leon-SK668/openclaw/actions/runs/33293507249
- Job: https://github.com/Leon-SK668/openclaw/actions/runs/33293507249/job/99209128016
- Artifact: `pr132763-markdown-preview-exact-head-33293507249-1` (artifact id `9726704427`, retained through 2026-09-29)
- Result: 1 test file passed, 1 exact-head Chromium scenario passed; candidate checkout, receipt identity, and artifact upload all passed.

The artifact contains the desktop and mobile PNGs, WebM recording, machine-readable receipt, and Vitest log. It proves the running bundled Control UI path `/chat` -> Markdown chat file link -> Gateway `sessions.files.get` -> Review detail panel -> sanitized Markdown renderer.

Runtime readback:

- A Markdown Review file larger than 40,000 characters was edited without saving; Preview rendered `Unsaved operator draft` and list items `Alpha` / `Beta`.
- Returning to Source preserved that unsaved CodeMirror draft.
- The external HTTPS image produced zero `<img>` elements and zero requests.
- Clicking relative `guide.md` produced `{ sessionKey: "main", path: "notes/guide.md", agentId: "main" }`.
- Opening `plain.txt` produced zero Source/Preview controls.
- The 1280x900 desktop and 390x700 mobile captures were visually inspected; the UI was nonblank and controls, text, links, and content did not overlap.

Machine-readable receipt:

```json
{
  "productHead": "1f600a4d2f793962c0020c3a0687769d2e658ec6",
  "productionEntry": "running bundled Control UI /chat -> chat Markdown file link -> Review",
  "readback": {
    "heading": "Unsaved operator draft",
    "largeDocumentRendered": true,
    "listItems": ["Alpha", "Beta"],
    "nonMarkdownModeControls": 0,
    "relativeLinkRequest": {
      "agentId": "main",
      "path": "notes/guide.md",
      "sessionKey": "main"
    },
    "remoteImageElements": 0,
    "remoteImageRequests": [],
    "sourceDraftPreserved": true
  }
}
```

Focused validation:

```text
node scripts/run-vitest.mjs run --root ui --config vitest.config.ts --project browser src/pages/chat/components/chat-sidebar-file-view.browser.test.ts
  1 file passed; 10 tests passed

node scripts/run-vitest.mjs run --root ui --config vitest.config.ts --project unit src/components/markdown-document.test.ts src/components/markdown.test.ts
  2 files passed; 109 tests passed

node scripts/run-vitest.mjs run --root ui --config vitest.config.ts --project unit src/pages/chat/components/chat-sidebar.test.ts
  1 file passed; 52 tests passed

node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/pr132763-markdown-preview-proof.e2e.test.ts
  1 file passed; 1 exact-head browser scenario passed

node_modules/.bin/oxfmt --check <six changed files>
  passed

node_modules/.bin/oxlint <five changed TypeScript files>
  passed

.agents/skills/autoreview/scripts/autoreview --mode local ...
  no accepted/actionable findings; patch is correct; confidence 0.98
```

Exact-head upstream CI run https://github.com/openclaw/openclaw/actions/runs/33283321150 passed the required `openclaw/ci-gate`, Control UI, all 14 Control UI E2E shards, real-Gateway E2E, build, lint, type, security, and workflow gates.

Diff accounting:

- 6 files, +239/-17 total
- Production: +182/-17
- Tests: +57/-0
- Generated and lock files: none

Known limitation: Preview is available for files identified by the Markdown language or common Markdown extensions; other text files remain source-only.

## AI Assistance

This change was implemented with Codex assistance. The contributor reviewed the owner boundaries, current and sibling behavior, dependency contract, implementation, tests, proof output, and final diff. No secrets, raw agent logs, or generated proof assets are committed to the PR branch.
