### PR TITLE
refactor: consolidate plugin registry diagnostics

### DIFF
--- a/src/plugins/registry-registrars-capabilities.ts
+++ b/src/plugins/registry-registrars-capabilities.ts
@@ -7,7 +7,7 @@ import { defaultSlotIdForKey } from "./slots.js";
 import type { OpenClawPluginApi, PluginRegistrationMode } from "./types.js";
 
 export function createCapabilityRegistrars(state: PluginRegistryState) {
-  const { registry, pushDiagnostic } = state;
+  const { registry, reportRegistrationError, reportRegistrationWarning } = state;
 
   const registerDetachedTaskRuntime = (
     record: PluginRecord,
@@ -15,12 +15,10 @@ export function createCapabilityRegistrars(state: PluginRegistryState) {
   ) => {
     const existing = registry.detachedTaskRuntimes[0];
     if (existing && existing.pluginId !== record.id) {
-      pushDiagnostic({
-        level: "error",
-        pluginId: record.id,
-        source: record.source,
-        message: `detached task runtime already registered by ${existing.pluginId}`,
-      });
+      reportRegistrationError(
+        record,
+        `detached task runtime already registered by ${existing.pluginId}`,
+      );
       return;
     }
     const next = { pluginId: record.id, runtime };
@@ -40,12 +38,7 @@ export function createCapabilityRegistrars(state: PluginRegistryState) {
       pluginRoot: record.rootDir,
     });
     if (!result.ok) {
-      pushDiagnostic({
-        level: "warn",
-        pluginId: record.id,
-        source: record.source,
-        message: result.error ?? "interactive handler registration failed",
-      });
+      reportRegistrationWarning(record, result.error ?? "interactive handler registration failed");
     }
   };
 
@@ -57,30 +50,18 @@ export function createCapabilityRegistrars(state: PluginRegistryState) {
   ) => {
     const normalizedId = normalizeOptionalString(id) ?? "";
     if (!normalizedId) {
-      pushDiagnostic({
-        level: "error",
-        pluginId: record.id,
-        source: record.source,
-        message: "context engine registration missing id",
-      });
+      reportRegistrationError(record, "context engine registration missing id");
       return;
     }
     if (typeof factory !== "function") {
-      pushDiagnostic({
-        level: "error",
-        pluginId: record.id,
-        source: record.source,
-        message: `context engine "${normalizedId}" registration missing factory`,
-      });
+      reportRegistrationError(
+        record,
+        `context engine "${normalizedId}" registration missing factory`,
+      );
       return;
     }
     if (normalizedId === defaultSlotIdForKey("contextEngine")) {
-      pushDiagnostic({
-        level: "error",
-        pluginId: record.id,
-        source: record.source,
-        message: `context engine id reserved by core: ${normalizedId}`,
-      });
+      reportRegistrationError(record, `context engine id reserved by core: ${normalizedId}`);
       return;
     }
     const result = registerContextEngineInRegistry(
@@ -94,12 +75,10 @@ export function createCapabilityRegistrars(state: PluginRegistryState) {
       },
     );
     if (!result.ok) {
-      pushDiagnostic({
-        level: "error",
-        pluginId: record.id,
-        source: record.source,
-        message: `context engine already registered: ${normalizedId} (${result.existingOwner})`,
-      });
+      reportRegistrationError(
+        record,
+        `context engine already registered: ${normalizedId} (${result.existingOwner})`,
+      );
       return;
     }
     if (!record.contextEngineIds?.includes(normalizedId)) {
@@ -116,32 +95,20 @@ export function createCapabilityRegistrars(state: PluginRegistryState) {
         ?.id,
     );
     if (!id) {
-      pushDiagnostic({
-        level: "error",
-        pluginId: record.id,
-        source: record.source,
-        message: "compaction provider registration missing id",
-      });
+      reportRegistrationError(record, "compaction provider registration missing id");
       return;
     }
     if (typeof provider?.summarize !== "function") {
-      pushDiagnostic({
-        level: "error",
-        pluginId: record.id,
-        source: record.source,
-        message: `compaction provider "${id}" registration missing summarize`,
-      });
+      reportRegistrationError(record, `compaction provider "${id}" registration missing summarize`);
       return;
     }
     const existing = registry.compactionProviders.find((entry) => entry.provider.id === id);
     if (existing) {
       const ownerDetail = existing.ownerPluginId ? ` (owner: ${existing.ownerPluginId})` : "";
-      pushDiagnostic({
-        level: "error",
-        pluginId: record.id,
-        source: record.source,
-        message: `compaction provider already registered: ${id}${ownerDetail}`,
-      });
+      reportRegistrationError(
+        record,
+        `compaction provider already registered: ${id}${ownerDetail}`,
+      );
       return;
     }
     registry.compactionProviders.push({ provider, ownerPluginId: record.id });

--- a/src/plugins/registry-registrars-host.ts
+++ b/src/plugins/registry-registrars-host.ts
@@ -70,10 +70,7 @@ function normalizeHostHookStringList(value: unknown): string[] | undefined | nul
 }
 
 export function createHostRegistrars(state: PluginRegistryState) {
-  const { registry, registryParams, pushDiagnostic } = state;
-  const reportRegistrationError = (record: PluginRecord, message: string) => {
-    pushDiagnostic({ level: "error", pluginId: record.id, source: record.source, message });
-  };
+  const { registry, registryParams, pushDiagnostic, reportRegistrationError } = state;
 
   const validateSessionActionSchema = (
     record: PluginRecord,

--- a/src/plugins/registry-registrars-memory.ts
+++ b/src/plugins/registry-registrars-memory.ts
@@ -4,19 +4,17 @@ import { hasKind } from "./slots.js";
 import type { OpenClawPluginApi } from "./types.js";
 
 export function createMemoryRegistrars(state: PluginRegistryState) {
-  const { registry, pushDiagnostic } = state;
+  const { registry, reportRegistrationError, reportRegistrationWarning } = state;
 
   const requireMemorySlot = (record: PluginRecord, surface: string): boolean => {
     if (!hasKind(record.kind, "memory")) {
       throw new Error(`only memory plugins can register a memory ${surface}`);
     }
     if (Array.isArray(record.kind) && record.kind.length > 1 && !record.memorySlotSelected) {
-      pushDiagnostic({
-        level: "warn",
-        pluginId: record.id,
-        source: record.source,
-        message: `dual-kind plugin not selected for memory slot; skipping memory ${surface} registration`,
-      });
+      reportRegistrationWarning(
+        record,
+        `dual-kind plugin not selected for memory slot; skipping memory ${surface} registration`,
+      );
       return false;
     }
     return true;
@@ -36,12 +34,7 @@ export function createMemoryRegistrars(state: PluginRegistryState) {
     builder: Parameters<OpenClawPluginApi["registerMemoryPromptSupplement"]>[0],
   ) => {
     if (typeof builder !== "function") {
-      pushDiagnostic({
-        level: "error",
-        pluginId: record.id,
-        source: record.source,
-        message: "memory prompt supplement registration missing builder",
-      });
+      reportRegistrationError(record, "memory prompt supplement registration missing builder");
       return;
     }
     registry.memoryPromptSupplements = registry.memoryPromptSupplements.filter(
@@ -55,12 +48,10 @@ export function createMemoryRegistrars(state: PluginRegistryState) {
     prepare: Parameters<OpenClawPluginApi["registerMemoryPromptPreparation"]>[0],
   ) => {
     if (typeof prepare !== "function") {
-      pushDiagnostic({
-        level: "error",
-        pluginId: record.id,
-        source: record.source,
-        message: "memory prompt preparation registration missing prepare function",
-      });
+      reportRegistrationError(
+        record,
+        "memory prompt preparation registration missing prepare function",
+      );
       return;
     }
     registry.memoryPromptPreparations = registry.memoryPromptPreparations.filter(

--- a/src/plugins/registry-registrars-network.ts
+++ b/src/plugins/registry-registrars-network.ts
@@ -45,8 +45,14 @@ function adaptPluginGatewayMethodHandler(handler: GatewayRequestHandler): Gatewa
 }
 
 export function createNetworkRegistrars(state: PluginRegistryState) {
-  const { registry, coreGatewayMethods, pluginsWithChannelRegistrationConflict, pushDiagnostic } =
-    state;
+  const {
+    registry,
+    coreGatewayMethods,
+    pluginsWithChannelRegistrationConflict,
+    pushDiagnostic,
+    reportRegistrationError,
+    reportRegistrationWarning,
+  } = state;
   let reportedLegacyCatalogSkip = false;
 
   const registerGatewayMethod = (
@@ -60,24 +66,17 @@ export function createNetworkRegistrars(state: PluginRegistryState) {
       return;
     }
     if (coreGatewayMethods.has(trimmed) || registry.gatewayHandlers[trimmed]) {
-      pushDiagnostic({
-        level: "error",
-        pluginId: record.id,
-        source: record.source,
-        message: `gateway method already registered: ${trimmed}`,
-      });
+      reportRegistrationError(record, `gateway method already registered: ${trimmed}`);
       return;
     }
     const wrappedHandler = adaptPluginGatewayMethodHandler(handler);
     registry.gatewayHandlers[trimmed] = wrappedHandler;
     const normalizedScope = normalizePluginGatewayMethodScope(trimmed, opts?.scope);
     if (normalizedScope.coercedToReservedAdmin) {
-      pushDiagnostic({
-        level: "warn",
-        pluginId: record.id,
-        source: record.source,
-        message: `gateway method scope coerced to operator.admin for reserved core namespace: ${trimmed}`,
-      });
+      reportRegistrationWarning(
+        record,
+        `gateway method scope coerced to operator.admin for reserved core namespace: ${trimmed}`,
+      );
     }
     registry.gatewayMethodDescriptors.push(
       createPluginGatewayMethodDescriptor({
@@ -94,35 +93,25 @@ export function createNetworkRegistrars(state: PluginRegistryState) {
     const id = provider.id.trim();
     const label = provider.label.trim();
     if (!id || !label) {
-      pushDiagnostic({
-        level: "error",
-        pluginId: record.id,
-        source: record.source,
-        message: "session catalog requires non-empty id and label",
-      });
+      reportRegistrationError(record, "session catalog requires non-empty id and label");
       return;
     }
     if (!state.allowProcessHomeSessionCatalogs && provider.supportsProcessHomeIsolation !== true) {
       if (!reportedLegacyCatalogSkip) {
         reportedLegacyCatalogSkip = true;
-        pushDiagnostic({
-          level: "warn",
-          pluginId: record.id,
-          source: record.source,
-          message:
-            "external session catalog skipped in isolated state: provider must declare supportsProcessHomeIsolation",
-        });
+        reportRegistrationWarning(
+          record,
+          "external session catalog skipped in isolated state: provider must declare supportsProcessHomeIsolation",
+        );
       }
       return;
     }
     const existing = registry.sessionCatalogs.find((entry) => entry.provider.id === id);
     if (existing) {
-      pushDiagnostic({
-        level: "error",
-        pluginId: record.id,
-        source: record.source,
-        message: `session catalog already registered: ${id} (${existing.pluginId})`,
-      });
+      reportRegistrationError(
+        record,
+        `session catalog already registered: ${id} (${existing.pluginId})`,
+      );
       return;
     }
     registry.sessionCatalogs.push({
@@ -146,21 +135,14 @@ export function createNetworkRegistrars(state: PluginRegistryState) {
   const registerHttpRoute = (record: PluginRecord, params: OpenClawPluginHttpRouteParams) => {
     const normalizedPath = normalizePluginHttpPath(params.path);
     if (!normalizedPath) {
-      pushDiagnostic({
-        level: "warn",
-        pluginId: record.id,
-        source: record.source,
-        message: "http route registration missing path",
-      });
+      reportRegistrationWarning(record, "http route registration missing path");
       return;
     }
     if (params.auth !== "gateway" && params.auth !== "plugin") {
-      pushDiagnostic({
-        level: "error",
-        pluginId: record.id,
-        source: record.source,
-        message: `http route registration missing or invalid auth: ${normalizedPath}`,
-      });
+      reportRegistrationError(
+        record,
+        `http route registration missing or invalid auth: ${normalizedPath}`,
+      );
       return;
     }
     const match = params.match ?? "exact";
@@ -173,15 +155,12 @@ export function createNetworkRegistrars(state: PluginRegistryState) {
       },
     );
     if (authOverlap) {
-      pushDiagnostic({
-        level: "error",
-        pluginId: record.id,
-        source: record.source,
-        message:
-          `http route overlap rejected: ${normalizedPath} (${match}, ${params.auth}) ` +
+      reportRegistrationError(
+        record,
+        `http route overlap rejected: ${normalizedPath} (${match}, ${params.auth}) ` +
           `overlaps ${authOverlap.path} (${authOverlap.match}, ${authOverlap.auth}) ` +
           `owned by ${describeHttpRouteOwner(authOverlap)}`,
-      });
+      );
       return;
     }
     const existingIndex = canonicalMatches[0]
@@ -210,14 +189,12 @@ export function createNetworkRegistrars(state: PluginRegistryState) {
       }
       const foreignOwner = canonicalMatches.find((route) => route.pluginId !== record.id);
       if (foreignOwner) {
-        pushDiagnostic({
-          level: "error",
-          pluginId: record.id,
-          source: record.source,
-          message: params.replaceExisting
+        reportRegistrationError(
+          record,
+          params.replaceExisting
             ? `http route replacement rejected: ${normalizedPath} (${match}) owned by ${describeHttpRouteOwner(foreignOwner)}`
             : `http route already registered: ${normalizedPath} (${match}) by ${describeHttpRouteOwner(foreignOwner)}`,
-        });
+        );
         return;
       }
       registry.httpRoutes[existingIndex] = registration;
@@ -238,12 +215,7 @@ export function createNetworkRegistrars(state: PluginRegistryState) {
     resolver: OpenClawPluginHostedMediaResolver,
   ) => {
     if (typeof resolver !== "function") {
-      pushDiagnostic({
-        level: "error",
-        pluginId: record.id,
-        source: record.source,
-        message: "hosted media resolver registration missing resolver",
-      });
+      reportRegistrationError(record, "hosted media resolver registration missing resolver");
       return;
     }
     registry.hostedMediaResolvers.push({
@@ -261,12 +233,10 @@ export function createNetworkRegistrars(state: PluginRegistryState) {
   ) => {
     const serverName = normalizeOptionalString(resolver?.serverName);
     if (!serverName || typeof resolver.resolve !== "function") {
-      pushDiagnostic({
-        level: "error",
-        pluginId: record.id,
-        source: record.source,
-        message: "MCP server connection resolver registration missing serverName or resolve",
-      });
+      reportRegistrationError(
+        record,
+        "MCP server connection resolver registration missing serverName or resolve",
+      );
       return;
     }
     const existingIndex = registry.mcpServerConnectionResolvers.findIndex(
@@ -288,12 +258,10 @@ export function createNetworkRegistrars(state: PluginRegistryState) {
       // must not depend on plugin load order. First registration wins; a
       // duplicate from another plugin is rejected, not silently replaced.
       if (existing && existing.pluginId !== record.id) {
-        pushDiagnostic({
-          level: "error",
-          pluginId: record.id,
-          source: record.source,
-          message: `MCP server connection resolver for "${serverName}" rejected: already registered by plugin "${existing.pluginId}"`,
-        });
+        reportRegistrationError(
+          record,
+          `MCP server connection resolver for "${serverName}" rejected: already registered by plugin "${existing.pluginId}"`,
+        );
         return;
       }
       registry.mcpServerConnectionResolvers[existingIndex] = registration;
@@ -309,12 +277,10 @@ export function createNetworkRegistrars(state: PluginRegistryState) {
     resolveChannelRuntime?: PluginChannelRegistration["resolveChannelRuntime"],
   ) => {
     if (record.origin === "workspace" && !record.enabled) {
-      pushDiagnostic({
-        level: "warn",
-        pluginId: record.id,
-        source: record.source,
-        message: `channel registration rejected for disabled workspace plugin: ${record.id}`,
-      });
+      reportRegistrationWarning(
+        record,
+        `channel registration rejected for disabled workspace plugin: ${record.id}`,
+      );
       return;
     }
     const registrationCapabilities = resolvePluginRegistrationCapabilities(mode);
@@ -352,12 +318,10 @@ export function createNetworkRegistrars(state: PluginRegistryState) {
         }
         return;
       }
-      pushDiagnostic({
-        level: "error",
-        pluginId: record.id,
-        source: record.source,
-        message: `channel already registered: ${id} (${existingRuntime.pluginId})`,
-      });
+      reportRegistrationError(
+        record,
+        `channel already registered: ${id} (${existingRuntime.pluginId})`,
+      );
       pluginsWithChannelRegistrationConflict.add(record.id);
       return;
     }
@@ -372,12 +336,10 @@ export function createNetworkRegistrars(state: PluginRegistryState) {
         existingSetup.rootDir = record.rootDir;
         return;
       }
-      pushDiagnostic({
-        level: "error",
-        pluginId: record.id,
-        source: record.source,
-        message: `channel setup already registered: ${id} (${existingSetup.pluginId})`,
-      });
+      reportRegistrationError(
+        record,
+        `channel setup already registered: ${id} (${existingSetup.pluginId})`,
+      );
       pluginsWithChannelRegistrationConflict.add(record.id);
       return;
     }

--- a/src/plugins/registry-registrars-operations.ts
+++ b/src/plugins/registry-registrars-operations.ts
@@ -58,7 +58,7 @@ export function canClaimReservedCommandOwnership(
 }
 
 export function createOperationRegistrars(state: PluginRegistryState) {
-  const { registry, pushDiagnostic } = state;
+  const { registry, reportRegistrationError, reportRegistrationWarning } = state;
 
   const registerWidgetPresenter = (record: PluginRecord, presenter: WidgetPresenter) => {
     const description = normalizeOptionalString(presenter.description);
@@ -83,12 +83,7 @@ export function createOperationRegistrars(state: PluginRegistryState) {
       typeof presenter.availability !== "function" ||
       typeof presenter.present !== "function"
     ) {
-      pushDiagnostic({
-        level: "error",
-        pluginId: record.id,
-        source: record.source,
-        message: "invalid widget presenter registration",
-      });
+      reportRegistrationError(record, "invalid widget presenter registration");
       return;
     }
     const existing =
@@ -98,12 +93,10 @@ export function createOperationRegistrars(state: PluginRegistryState) {
             (registration) => registration.presenter.target === presenter.target,
           );
     if (existing) {
-      pushDiagnostic({
-        level: "error",
-        pluginId: record.id,
-        source: record.source,
-        message: `widget presenter already registered for ${presenter.target} (${existing.pluginId})`,
-      });
+      reportRegistrationError(
+        record,
+        `widget presenter already registered for ${presenter.target} (${existing.pluginId})`,
+      );
       return;
     }
     registry.widgetPresenters.push({
@@ -123,12 +116,10 @@ export function createOperationRegistrars(state: PluginRegistryState) {
     const normalizeCommandRoot = (raw: string, source: "command" | "descriptor") => {
       const normalized = normalizeCommandDescriptorName(raw);
       if (!normalized) {
-        pushDiagnostic({
-          level: "error",
-          pluginId: record.id,
-          source: record.source,
-          message: `invalid cli ${source} name: ${JSON.stringify(raw.trim())}`,
-        });
+        reportRegistrationError(
+          record,
+          `invalid cli ${source} name: ${JSON.stringify(raw.trim())}`,
+        );
       }
       return normalized;
     };
@@ -169,12 +160,7 @@ export function createOperationRegistrars(state: PluginRegistryState) {
         .filter((command): command is string => command !== null),
     );
     if (commands.length === 0) {
-      pushDiagnostic({
-        level: "error",
-        pluginId: record.id,
-        source: record.source,
-        message: "cli registration missing explicit commands metadata",
-      });
+      reportRegistrationError(record, "cli registration missing explicit commands metadata");
       return;
     }
     const serializeCommandPath = (command: string) => [...normalizedParentPath, command].join(" ");
@@ -190,12 +176,10 @@ export function createOperationRegistrars(state: PluginRegistryState) {
         existing.commands.map((command) => [...(existing.parentPath ?? []), command].join(" ")),
       );
       const overlap = commandPaths.find((commandPath) => existingCommandPaths.has(commandPath));
-      pushDiagnostic({
-        level: "error",
-        pluginId: record.id,
-        source: record.source,
-        message: `cli command already registered: ${overlap ?? commands[0]} (${existing.pluginId})`,
-      });
+      reportRegistrationError(
+        record,
+        `cli command already registered: ${overlap ?? commands[0]} (${existing.pluginId})`,
+      );
       return;
     }
     record.cliCommands.push(...commandPaths);
@@ -222,12 +206,7 @@ export function createOperationRegistrars(state: PluginRegistryState) {
       (normalized.hotPrefixes?.length ?? 0) === 0 &&
       (normalized.noopPrefixes?.length ?? 0) === 0
     ) {
-      pushDiagnostic({
-        level: "warn",
-        pluginId: record.id,
-        source: record.source,
-        message: "reload registration missing prefixes",
-      });
+      reportRegistrationWarning(record, "reload registration missing prefixes");
       return;
     }
     registry.reloads.push({
@@ -252,12 +231,7 @@ export function createOperationRegistrars(state: PluginRegistryState) {
   ) => {
     const command = nodeCommand.command.trim();
     if (!command) {
-      pushDiagnostic({
-        level: "error",
-        pluginId: record.id,
-        source: record.source,
-        message: "node host command registration missing command",
-      });
+      reportRegistrationError(record, "node host command registration missing command");
       return;
     }
     // Native nodes already own system.notify. A bundled node-host plugin may
@@ -265,22 +239,15 @@ export function createOperationRegistrars(state: PluginRegistryState) {
     const bundledSystemNotify =
       record.origin === "bundled" && command === NODE_SYSTEM_NOTIFY_COMMAND;
     if (reservedNodeHostCommands.has(command) && !bundledSystemNotify) {
-      pushDiagnostic({
-        level: "error",
-        pluginId: record.id,
-        source: record.source,
-        message: `node host command reserved by core: ${command}`,
-      });
+      reportRegistrationError(record, `node host command reserved by core: ${command}`);
       return;
     }
     const existing = registry.nodeHostCommands.find((entry) => entry.command.command === command);
     if (existing) {
-      pushDiagnostic({
-        level: "error",
-        pluginId: record.id,
-        source: record.source,
-        message: `node host command already registered: ${command} (${existing.pluginId})`,
-      });
+      reportRegistrationError(
+        record,
+        `node host command already registered: ${command} (${existing.pluginId})`,
+      );
       return;
     }
     registry.nodeHostCommands.push({
@@ -301,31 +268,22 @@ export function createOperationRegistrars(state: PluginRegistryState) {
       Array.isArray(policy.commands) ? policy.commands : [],
     );
     if (commands.length === 0) {
-      pushDiagnostic({
-        level: "error",
-        pluginId: record.id,
-        source: record.source,
-        message: "node invoke policy registration missing commands",
-      });
+      reportRegistrationError(record, "node invoke policy registration missing commands");
       return;
     }
     const reservedCommand = commands.find(isPrivateNodeInvokeCommand);
     if (reservedCommand) {
-      pushDiagnostic({
-        level: "error",
-        pluginId: record.id,
-        source: record.source,
-        message: `node invoke policy command reserved by core: ${reservedCommand}`,
-      });
+      reportRegistrationError(
+        record,
+        `node invoke policy command reserved by core: ${reservedCommand}`,
+      );
       return;
     }
     if (typeof policy.handle !== "function") {
-      pushDiagnostic({
-        level: "error",
-        pluginId: record.id,
-        source: record.source,
-        message: `node invoke policy registration missing handler: ${commands.join(", ")}`,
-      });
+      reportRegistrationError(
+        record,
+        `node invoke policy registration missing handler: ${commands.join(", ")}`,
+      );
       return;
     }
     for (const command of commands) {
@@ -333,12 +291,10 @@ export function createOperationRegistrars(state: PluginRegistryState) {
         entry.policy.commands.includes(command),
       );
       if (existing) {
-        pushDiagnostic({
-          level: "error",
-          pluginId: record.id,
-          source: record.source,
-          message: `node invoke policy already registered for ${command} (${existing.pluginId})`,
-        });
+        reportRegistrationError(
+          record,
+          `node invoke policy already registered for ${command} (${existing.pluginId})`,
+        );
         return;
       }
     }
@@ -379,14 +335,12 @@ export function createOperationRegistrars(state: PluginRegistryState) {
     }
     // Snapshot and activating loads can both register the same owner; keep the first.
     if (existing?.pluginId !== record.id) {
-      pushDiagnostic({
-        level: "error",
-        pluginId: record.id,
-        source: record.source,
-        message: existing
+      reportRegistrationError(
+        record,
+        existing
           ? `${kind} already registered: ${id} (${existing.pluginId})`
           : `${kind} registration missing id`,
-      });
+      );
     }
     return undefined;
   };
@@ -429,40 +383,29 @@ export function createOperationRegistrars(state: PluginRegistryState) {
   const registerCommand = (record: PluginRecord, command: OpenClawPluginCommandDefinition) => {
     const name = command.name.trim();
     if (!name) {
-      pushDiagnostic({
-        level: "error",
-        pluginId: record.id,
-        source: record.source,
-        message: "command registration missing name",
-      });
+      reportRegistrationError(record, "command registration missing name");
       return;
     }
     const allowReservedCommandNames = command.ownership === "reserved";
     if (allowReservedCommandNames && !canClaimReservedCommandOwnership(record)) {
-      pushDiagnostic({
-        level: "error",
-        pluginId: record.id,
-        source: record.source,
-        message: `only bundled plugins can claim reserved command ownership: ${name}`,
-      });
+      reportRegistrationError(
+        record,
+        `only bundled plugins can claim reserved command ownership: ${name}`,
+      );
       return;
     }
     if (allowReservedCommandNames && !isReservedCommandName(name)) {
-      pushDiagnostic({
-        level: "error",
-        pluginId: record.id,
-        source: record.source,
-        message: `reserved command ownership requires a reserved command name: ${name}`,
-      });
+      reportRegistrationError(
+        record,
+        `reserved command ownership requires a reserved command name: ${name}`,
+      );
       return;
     }
     if (allowReservedCommandNames && record.id !== normalizeLowercaseStringOrEmpty(name)) {
-      pushDiagnostic({
-        level: "error",
-        pluginId: record.id,
-        source: record.source,
-        message: `command registration failed: Reserved command ownership requires plugin id "${record.id}" to match reserved command name "${normalizeLowercaseStringOrEmpty(name)}"`,
-      });
+      reportRegistrationError(
+        record,
+        `command registration failed: Reserved command ownership requires plugin id "${record.id}" to match reserved command name "${normalizeLowercaseStringOrEmpty(name)}"`,
+      );
       return;
     }
     const { ownership: _ownership, ...commandForRegistration } = command;
@@ -479,12 +422,7 @@ export function createOperationRegistrars(state: PluginRegistryState) {
       },
     );
     if (!result.ok) {
-      pushDiagnostic({
-        level: "error",
-        pluginId: record.id,
-        source: record.source,
-        message: `command registration failed: ${result.error}`,
-      });
+      reportRegistrationError(record, `command registration failed: ${result.error}`);
       return;
     }
     const registered = registry.commands.at(-1);

--- a/src/plugins/registry-registrars-providers.ts
+++ b/src/plugins/registry-registrars-providers.ts
@@ -21,6 +21,8 @@ export function createProviderRegistrars(state: PluginRegistryState) {
   const {
     registry,
     pushDiagnostic,
+    reportRegistrationError,
+    reportRegistrationWarning,
     registerSynthesizedTextModelCatalogProvider,
     registerSynthesizedMediaModelCatalogProvider,
     registerSynthesizedVoiceModelCatalogProvider,
@@ -39,12 +41,7 @@ export function createProviderRegistrars(state: PluginRegistryState) {
     const id = normalizedProvider.id;
     const existing = registry.providers.find((entry) => entry.provider.id === id);
     if (existing) {
-      pushDiagnostic({
-        level: "error",
-        pluginId: record.id,
-        source: record.source,
-        message: `provider already registered: ${id} (${existing.pluginId})`,
-      });
+      reportRegistrationError(record, `provider already registered: ${id} (${existing.pluginId})`);
       return;
     }
     if (!record.providerIds.includes(id)) {
@@ -67,30 +64,21 @@ export function createProviderRegistrars(state: PluginRegistryState) {
   ) => {
     const id = normalizeOptionalString((harness as Partial<AgentHarness> | undefined)?.id) ?? "";
     if (!id) {
-      pushDiagnostic({
-        level: "error",
-        pluginId: record.id,
-        source: record.source,
-        message: "agent harness registration missing id",
-      });
+      reportRegistrationError(record, "agent harness registration missing id");
       return;
     }
     if (id === "openclaw") {
-      pushDiagnostic({
-        level: "error",
-        pluginId: record.id,
-        source: record.source,
-        message: 'agent harness id "openclaw" is reserved for the built-in runtime',
-      });
+      reportRegistrationError(
+        record,
+        'agent harness id "openclaw" is reserved for the built-in runtime',
+      );
       return;
     }
     if (typeof harness.supports !== "function" || typeof harness.runAttempt !== "function") {
-      pushDiagnostic({
-        level: "error",
-        pluginId: record.id,
-        source: record.source,
-        message: `agent harness "${id}" registration missing required runtime methods`,
-      });
+      reportRegistrationError(
+        record,
+        `agent harness "${id}" registration missing required runtime methods`,
+      );
       return;
     }
     if (
@@ -99,24 +87,17 @@ export function createProviderRegistrars(state: PluginRegistryState) {
         id !== "codex" ||
         typeof options.nativeCompaction !== "function")
     ) {
-      pushDiagnostic({
-        level: "error",
-        pluginId: record.id,
-        source: record.source,
-        message: 'native compaction requires the registry-owned "codex" harness',
-      });
+      reportRegistrationError(
+        record,
+        'native compaction requires the registry-owned "codex" harness',
+      );
       return;
     }
     const existing = registry.agentHarnesses.find((entry) => entry.harness.id === id);
     if (existing) {
       const ownerPluginId = "pluginId" in existing ? existing.pluginId : undefined;
       const ownerDetail = ownerPluginId ? ` (owner: ${ownerPluginId})` : "";
-      pushDiagnostic({
-        level: "error",
-        pluginId: record.id,
-        source: record.source,
-        message: `agent harness already registered: ${id}${ownerDetail}`,
-      });
+      reportRegistrationError(record, `agent harness already registered: ${id}${ownerDetail}`);
       return;
     }
     const normalizedHarness = { ...harness, id, pluginId: harness.pluginId ?? record.id };
@@ -134,22 +115,15 @@ export function createProviderRegistrars(state: PluginRegistryState) {
   const registerCliBackend = (record: PluginRecord, backend: CliBackendPlugin) => {
     const id = backend.id.trim();
     if (!id) {
-      pushDiagnostic({
-        level: "error",
-        pluginId: record.id,
-        source: record.source,
-        message: "cli backend registration missing id",
-      });
+      reportRegistrationError(record, "cli backend registration missing id");
       return;
     }
     const existing = registry.cliBackends.find((entry) => entry.backend.id === id);
     if (existing) {
-      pushDiagnostic({
-        level: "error",
-        pluginId: record.id,
-        source: record.source,
-        message: `cli backend already registered: ${id} (${existing.pluginId})`,
-      });
+      reportRegistrationError(
+        record,
+        `cli backend already registered: ${id} (${existing.pluginId})`,
+      );
       return;
     }
     registry.cliBackends.push({
@@ -171,12 +145,10 @@ export function createProviderRegistrars(state: PluginRegistryState) {
       (!transforms.input || transforms.input.length === 0) &&
       (!transforms.output || transforms.output.length === 0)
     ) {
-      pushDiagnostic({
-        level: "warn",
-        pluginId: record.id,
-        source: record.source,
-        message: "text transform registration has no input or output replacements",
-      });
+      reportRegistrationWarning(
+        record,
+        "text transform registration has no input or output replacements",
+      );
       return;
     }
     registry.textTransforms.push({
@@ -191,21 +163,14 @@ export function createProviderRegistrars(state: PluginRegistryState) {
   const registerEmbeddingProvider = (record: PluginRecord, adapter: EmbeddingProviderAdapter) => {
     const id = adapter.id.trim();
     if (!id) {
-      pushDiagnostic({
-        level: "error",
-        pluginId: record.id,
-        source: record.source,
-        message: "embedding provider registration missing id",
-      });
+      reportRegistrationError(record, "embedding provider registration missing id");
       return;
     }
     if (!(record.contracts?.embeddingProviders ?? []).includes(id)) {
-      pushDiagnostic({
-        level: "error",
-        pluginId: record.id,
-        source: record.source,
-        message: `plugin must declare contracts.embeddingProviders for adapter: ${id}`,
-      });
+      reportRegistrationError(
+        record,
+        `plugin must declare contracts.embeddingProviders for adapter: ${id}`,
+      );
       return;
     }
     const coreEntry = getCoreEmbeddingProvider(id);
@@ -219,12 +184,7 @@ export function createProviderRegistrars(state: PluginRegistryState) {
             ? existing.pluginId
             : undefined;
       const ownerDetail = ownerPluginId ? ` (owner: ${ownerPluginId})` : "";
-      pushDiagnostic({
-        level: "error",
-        pluginId: record.id,
-        source: record.source,
-        message: `embedding provider already registered: ${id}${ownerDetail}`,
-      });
+      reportRegistrationError(record, `embedding provider already registered: ${id}${ownerDetail}`);
       return;
     }
     registry.embeddingProviders.push({
@@ -250,22 +210,15 @@ export function createProviderRegistrars(state: PluginRegistryState) {
       const id = provider.id.trim();
       const { kindLabel } = params;
       if (!id) {
-        pushDiagnostic({
-          level: "error",
-          pluginId: record.id,
-          source: record.source,
-          message: `${kindLabel} registration missing id`,
-        });
+        reportRegistrationError(record, `${kindLabel} registration missing id`);
         return params.onRegister ? undefined : false;
       }
       const existing = params.registrations.find((entry) => entry.provider.id === id);
       if (existing) {
-        pushDiagnostic({
-          level: "error",
-          pluginId: record.id,
-          source: record.source,
-          message: `${kindLabel} already registered: ${id} (${existing.pluginId})`,
-        });
+        reportRegistrationError(
+          record,
+          `${kindLabel} already registered: ${id} (${existing.pluginId})`,
+        );
         return params.onRegister ? undefined : false;
       }
       const ownedIds = params.ownedIds(record);
@@ -287,8 +240,7 @@ export function createProviderRegistrars(state: PluginRegistryState) {
     };
 
   const registerWorkerProvider = (record: PluginRecord, provider: WorkerProvider) => {
-    const reject = (message: string) =>
-      pushDiagnostic({ level: "error", pluginId: record.id, source: record.source, message });
+    const reject = (message: string) => reportRegistrationError(record, message);
     const validation = validateWorkerProviderContract(
       provider,
       record.contracts?.workerProviders ?? [],

--- a/src/plugins/registry-registrars-tools-hooks.ts
+++ b/src/plugins/registry-registrars-tools-hooks.ts
@@ -70,20 +70,23 @@ function canRegisterInstalledTrustedHook(record: PluginRecord): boolean {
 }
 
 export function createToolHookRegistrars(state: PluginRegistryState) {
-  const { registry, registryParams, pluginsWithChannelRegistrationConflict, pushDiagnostic } =
-    state;
+  const {
+    registry,
+    registryParams,
+    pluginsWithChannelRegistrationConflict,
+    reportRegistrationError,
+    reportRegistrationWarning,
+  } = state;
 
   const registerCodexAppServerExtensionFactory = (
     record: PluginRecord,
     factory: Parameters<OpenClawPluginApi["registerCodexAppServerExtensionFactory"]>[0],
   ) => {
     if (record.origin !== "bundled") {
-      pushDiagnostic({
-        level: "error",
-        pluginId: record.id,
-        source: record.source,
-        message: "only bundled plugins can register Codex app-server extension factories",
-      });
+      reportRegistrationError(
+        record,
+        "only bundled plugins can register Codex app-server extension factories",
+      );
       return;
     }
     if (
@@ -91,22 +94,14 @@ export function createToolHookRegistrars(state: PluginRegistryState) {
         CODEX_APP_SERVER_EXTENSION_RUNTIME_ID,
       )
     ) {
-      pushDiagnostic({
-        level: "error",
-        pluginId: record.id,
-        source: record.source,
-        message:
-          'plugin must declare contracts.embeddedExtensionFactories: ["codex-app-server"] to register Codex app-server extension factories',
-      });
+      reportRegistrationError(
+        record,
+        'plugin must declare contracts.embeddedExtensionFactories: ["codex-app-server"] to register Codex app-server extension factories',
+      );
       return;
     }
     if (typeof (factory as unknown) !== "function") {
-      pushDiagnostic({
-        level: "error",
-        pluginId: record.id,
-        source: record.source,
-        message: "codex app-server extension factory must be a function",
-      });
+      reportRegistrationError(record, "codex app-server extension factory must be a function");
       return;
     }
     if (
@@ -143,23 +138,16 @@ export function createToolHookRegistrars(state: PluginRegistryState) {
     policy?: PluginTypedHookPolicy,
   ) => {
     if (typeof (handler as unknown) !== "function") {
-      pushDiagnostic({
-        level: "error",
-        pluginId: record.id,
-        source: record.source,
-        message: "agent tool result middleware must be a function",
-      });
+      reportRegistrationError(record, "agent tool result middleware must be a function");
       return;
     }
     const runtimes = normalizeAgentToolResultMiddlewareRuntimes(options);
     const matcher = normalizePluginToolMatcher(options?.matcher);
     if (runtimes.length === 0) {
-      pushDiagnostic({
-        level: "error",
-        pluginId: record.id,
-        source: record.source,
-        message: "agent tool result middleware must target at least one supported runtime",
-      });
+      reportRegistrationError(
+        record,
+        "agent tool result middleware must target at least one supported runtime",
+      );
       return;
     }
     const declared = normalizeAgentToolResultMiddlewareRuntimeIds(
@@ -167,21 +155,17 @@ export function createToolHookRegistrars(state: PluginRegistryState) {
     );
     const missing = runtimes.filter((runtime) => !declared.includes(runtime));
     if (missing.length > 0) {
-      pushDiagnostic({
-        level: "error",
-        pluginId: record.id,
-        source: record.source,
-        message: `plugin must declare contracts.agentToolResultMiddleware for: ${missing.join(", ")}`,
-      });
+      reportRegistrationError(
+        record,
+        `plugin must declare contracts.agentToolResultMiddleware for: ${missing.join(", ")}`,
+      );
       return;
     }
     if (!canRegisterInstalledTrustedHook(record)) {
-      pushDiagnostic({
-        level: "error",
-        pluginId: record.id,
-        source: record.source,
-        message: "plugin must be explicitly enabled to register agent tool result middleware",
-      });
+      reportRegistrationError(
+        record,
+        "plugin must be explicitly enabled to register agent tool result middleware",
+      );
       return;
     }
     const existing = registry.agentToolResultMiddlewares.find(
@@ -235,12 +219,10 @@ export function createToolHookRegistrars(state: PluginRegistryState) {
     }
     const declaredNames = normalizePluginToolContractNames(record.contracts);
     if (declaredNames.length === 0) {
-      pushDiagnostic({
-        level: "error",
-        pluginId: record.id,
-        source: record.source,
-        message: "plugin must declare contracts.tools before registering agent tools",
-      });
+      reportRegistrationError(
+        record,
+        "plugin must declare contracts.tools before registering agent tools",
+      );
       return;
     }
     const names = [...(opts?.names ?? []), ...(opts?.name ? [opts.name] : [])];
@@ -253,12 +235,10 @@ export function createToolHookRegistrars(state: PluginRegistryState) {
     const normalized = normalizePluginToolNames(names);
     const undeclared = findUndeclaredPluginToolNames({ declaredNames, toolNames: normalized });
     if (undeclared.length > 0) {
-      pushDiagnostic({
-        level: "error",
-        pluginId: record.id,
-        source: record.source,
-        message: `plugin must declare contracts.tools for: ${undeclared.join(", ")}`,
-      });
+      reportRegistrationError(
+        record,
+        `plugin must declare contracts.tools for: ${undeclared.join(", ")}`,
+      );
       return;
     }
     if (normalized.length > 0) {
@@ -291,15 +271,12 @@ export function createToolHookRegistrars(state: PluginRegistryState) {
     // fire. Warn so authors move to `api.on(...)` instead of trusting a false "loaded".
     for (const event of normalizedEvents) {
       if (isPluginHookName(event)) {
-        pushDiagnostic({
-          level: "warn",
-          pluginId: record.id,
-          source: record.source,
-          message:
-            `hook event "${event}" is dispatched by the typed hook runner only; ` +
+        reportRegistrationWarning(
+          record,
+          `hook event "${event}" is dispatched by the typed hook runner only; ` +
             `api.registerHook registrations for it are not invoked. ` +
             `Use api.on("${event}", ...) instead.`,
-        });
+        );
       }
     }
     const entry = opts?.entry ?? null;
@@ -311,12 +288,10 @@ export function createToolHookRegistrars(state: PluginRegistryState) {
       (entryLocal) => entryLocal.entry.hook.name === hookName,
     );
     if (existingHook) {
-      pushDiagnostic({
-        level: "error",
-        pluginId: record.id,
-        source: record.source,
-        message: `hook already registered: ${hookName} (${existingHook.pluginId})`,
-      });
+      reportRegistrationError(
+        record,
+        `hook already registered: ${hookName} (${existingHook.pluginId})`,
+      );
       return;
     }
     const description = entry?.hook.description ?? opts?.description ?? "";
@@ -391,21 +366,14 @@ export function createToolHookRegistrars(state: PluginRegistryState) {
     policy?: PluginTypedHookPolicy,
   ) => {
     if (!isPluginHookName(hookName)) {
-      pushDiagnostic({
-        level: "warn",
-        pluginId: record.id,
-        source: record.source,
-        message: `unknown typed hook "${String(hookName)}" ignored`,
-      });
+      reportRegistrationWarning(record, `unknown typed hook "${String(hookName)}" ignored`);
       return;
     }
     if (!resolvePromptInjectionAllowed(policy) && isPromptInjectionHookName(hookName)) {
-      pushDiagnostic({
-        level: "warn",
-        pluginId: record.id,
-        source: record.source,
-        message: `typed hook "${hookName}" blocked by plugins.entries.${record.id}.hooks.allowPromptInjection=false`,
-      });
+      reportRegistrationWarning(
+        record,
+        `typed hook "${hookName}" blocked by plugins.entries.${record.id}.hooks.allowPromptInjection=false`,
+      );
       return;
     }
     if (
@@ -413,22 +381,17 @@ export function createToolHookRegistrars(state: PluginRegistryState) {
       !resolveConversationAccessAllowed(record.origin, policy)
     ) {
       if (record.origin !== "bundled") {
-        pushDiagnostic({
-          level: "warn",
-          pluginId: record.id,
-          source: record.source,
-          message:
-            `typed hook "${hookName}" blocked because non-bundled plugins must set ` +
+        reportRegistrationWarning(
+          record,
+          `typed hook "${hookName}" blocked because non-bundled plugins must set ` +
             `plugins.entries.${record.id}.hooks.allowConversationAccess=true`,
-        });
+        );
         return;
       }
-      pushDiagnostic({
-        level: "warn",
-        pluginId: record.id,
-        source: record.source,
-        message: `typed hook "${hookName}" blocked by plugins.entries.${record.id}.hooks.allowConversationAccess=false`,
-      });
+      reportRegistrationWarning(
+        record,
+        `typed hook "${hookName}" blocked by plugins.entries.${record.id}.hooks.allowConversationAccess=false`,
+      );
       return;
     }
     const timeoutMs = resolveTypedHookTimeoutMs({ hookName, opts, policy });
@@ -445,12 +408,7 @@ export function createToolHookRegistrars(state: PluginRegistryState) {
         ? normalizePluginToolMatcher(opts?.matcher)
         : undefined;
     if (opts?.matcher && hookName !== "before_tool_call" && hookName !== "after_tool_call") {
-      pushDiagnostic({
-        level: "warn",
-        pluginId: record.id,
-        source: record.source,
-        message: `typed hook "${hookName}" ignores tool matcher`,
-      });
+      reportRegistrationWarning(record, `typed hook "${hookName}" ignores tool matcher`);
     }
     record.hookCount += 1;
     registry.typedHooks.push({

--- a/src/plugins/registry-state.ts
+++ b/src/plugins/registry-state.ts
@@ -2,7 +2,7 @@ import type { PluginDiagnostic } from "./manifest-types.js";
 import { createModelCatalogRegistrationHandlers } from "./model-catalog-registration.js";
 import { createEmptyPluginRegistry } from "./registry-empty.js";
 import { bindPluginRegistryRuntime } from "./registry-runtime-binding.js";
-import type { PluginRegistryParams } from "./registry-types.js";
+import type { PluginRecord, PluginRegistryParams } from "./registry-types.js";
 import type { PluginHookName } from "./types.js";
 
 export type PluginTypedHookPolicy = {
@@ -70,6 +70,12 @@ export function createPluginRegistryState(registryParams: PluginRegistryParams) 
   const pushDiagnostic = (diagnostic: PluginDiagnostic) => {
     registry.diagnostics.push(diagnostic);
   };
+  const reportRegistrationError = (record: PluginRecord, message: string) => {
+    pushDiagnostic({ level: "error", pluginId: record.id, source: record.source, message });
+  };
+  const reportRegistrationWarning = (record: PluginRecord, message: string) => {
+    pushDiagnostic({ level: "warn", pluginId: record.id, source: record.source, message });
+  };
   const modelCatalogRegistrars = createModelCatalogRegistrationHandlers({
     registry,
     pushDiagnostic,
@@ -84,6 +90,8 @@ export function createPluginRegistryState(registryParams: PluginRegistryParams) 
     pluginsWithChannelRegistrationConflict: new Set<string>(),
     pluginSideEffectGuards: new Map<string, Set<PluginSideEffectGuard>>(),
     pushDiagnostic,
+    reportRegistrationError,
+    reportRegistrationWarning,
     ...modelCatalogRegistrars,
   };
 }

--- a/src/plugins/registry.diagnostics.test.ts
+++ b/src/plugins/registry.diagnostics.test.ts
@@ -1,0 +1,218 @@
+import { expectDefined } from "@openclaw/normalization-core";
+import { describe, expect, it } from "vitest";
+import { runPluginRegisterSyncInRegistry } from "./loader-module-runtime.js";
+import { createPluginRecord } from "./loader-records.js";
+import { createPluginRegistry } from "./registry.js";
+import type { PluginRuntime } from "./runtime/types.js";
+import type { OpenClawPluginApi } from "./types.js";
+
+function createDiagnosticFixture() {
+  const builder = createPluginRegistry({
+    logger: { info() {}, warn() {}, error() {}, debug() {} },
+    runtime: {} as PluginRuntime,
+    activateGlobalSideEffects: false,
+  });
+  const createRecord = (id: string) =>
+    createPluginRecord({
+      id,
+      source: `/plugins/${id}/index.ts`,
+      origin: "global",
+      enabled: true,
+      configSchema: false,
+    });
+  return { builder, createRecord };
+}
+
+describe("plugin registration diagnostics", () => {
+  it("preserves ordered severity and call-time provenance across registrars and rollback", () => {
+    const { builder, createRecord } = createDiagnosticFixture();
+    const alpha = createRecord("alpha");
+    const beta = createRecord("beta");
+    const alphaApi = builder.createApi(alpha, { config: {} });
+    const betaApi = builder.createApi(beta, { config: {} });
+    alpha.source = "/plugins/alpha/resolved.ts";
+
+    alphaApi.registerService({ id: "", start() {} });
+    betaApi.registerContextEngine("", () => {
+      throw new Error("invalid registration must not instantiate its factory");
+    });
+    alphaApi.registerReload({});
+    betaApi.registerTextTransforms({});
+    // @ts-expect-error JavaScript plugins may omit the required supplement builder.
+    alphaApi.registerMemoryPromptSupplement(undefined);
+    // @ts-expect-error JavaScript plugins may omit the required hosted-media resolver.
+    betaApi.registerHostedMediaResolver(undefined);
+    // @ts-expect-error Unknown JavaScript hook names must produce a diagnostic.
+    alphaApi.on("unknown-hook", () => {});
+    betaApi.registerRuntimeLifecycle({ id: "" });
+
+    const expected = [
+      ["error", "alpha", "/plugins/alpha/resolved.ts", "service registration missing id"],
+      ["error", "beta", "/plugins/beta/index.ts", "context engine registration missing id"],
+      ["warn", "alpha", "/plugins/alpha/resolved.ts", "reload registration missing prefixes"],
+      [
+        "warn",
+        "beta",
+        "/plugins/beta/index.ts",
+        "text transform registration has no input or output replacements",
+      ],
+      [
+        "error",
+        "alpha",
+        "/plugins/alpha/resolved.ts",
+        "memory prompt supplement registration missing builder",
+      ],
+      [
+        "error",
+        "beta",
+        "/plugins/beta/index.ts",
+        "hosted media resolver registration missing resolver",
+      ],
+      ["warn", "alpha", "/plugins/alpha/resolved.ts", 'unknown typed hook "unknown-hook" ignored'],
+      ["error", "beta", "/plugins/beta/index.ts", "runtime lifecycle registration missing id"],
+    ].map(([level, pluginId, source, message]) => ({ level, pluginId, source, message }));
+    expect(builder.registry.diagnostics).toEqual(expected);
+    expect(builder.registry.services).toEqual([]);
+    expect(builder.registry.contextEngines.size).toBe(0);
+    expect(builder.registry.reloads).toEqual([]);
+    expect(builder.registry.textTransforms).toEqual([]);
+    expect(builder.registry.memoryPromptSupplements).toEqual([]);
+    expect(builder.registry.hostedMediaResolvers).toEqual([]);
+    expect(builder.registry.typedHooks).toEqual([]);
+    expect(builder.registry.runtimeLifecycles).toEqual([]);
+
+    alpha.source = "/plugins/alpha/later.ts";
+    alphaApi.registerService({ id: "alpha-service", start() {} });
+    betaApi.registerService({ id: "beta-service", start() {} });
+    expect(builder.registry.services.map((entry) => entry.pluginId)).toEqual(["alpha", "beta"]);
+    builder.rollbackPluginGlobalSideEffects(alpha.id, alpha);
+    expect(builder.registry.services.map((entry) => entry.pluginId)).toEqual(["beta"]);
+    builder.rollbackPluginGlobalSideEffects(beta.id, beta);
+    expect(builder.registry.services).toEqual([]);
+    expect(builder.registry.diagnostics).toEqual(expected);
+  });
+
+  it("keeps provider and catalog ownership unchanged after blank and duplicate registration", () => {
+    const { builder, createRecord } = createDiagnosticFixture();
+    const alpha = createRecord("alpha");
+    const beta = createRecord("beta");
+    const alphaApi = builder.createApi(alpha, { config: {} });
+    const betaApi = builder.createApi(beta, { config: {} });
+    const speech = {
+      id: "shared-speech",
+      label: "Shared speech",
+      models: ["speech-model"],
+      isConfigured: () => true,
+      synthesize: async () => {
+        throw new Error("registration must not synthesize audio");
+      },
+    } satisfies Parameters<OpenClawPluginApi["registerSpeechProvider"]>[0];
+    const media = { id: "shared-media" };
+    alphaApi.registerSpeechProvider(speech);
+    alphaApi.registerMediaUnderstandingProvider(media);
+
+    betaApi.registerSpeechProvider({ ...speech, id: " " });
+    betaApi.registerSpeechProvider({ ...speech, label: "Rejected replacement" });
+    betaApi.registerMediaUnderstandingProvider({ id: " " });
+    betaApi.registerMediaUnderstandingProvider({ ...media });
+
+    expect(builder.registry.diagnostics).toEqual(
+      [
+        "speech provider registration missing id",
+        "speech provider already registered: shared-speech (alpha)",
+        "media provider registration missing id",
+        "media provider already registered: shared-media (alpha)",
+      ].map((message) => ({
+        level: "error",
+        pluginId: "beta",
+        source: "/plugins/beta/index.ts",
+        message,
+      })),
+    );
+    expect(
+      builder.registry.speechProviders.map(({ pluginId, provider }) => ({ pluginId, provider })),
+    ).toEqual([{ pluginId: "alpha", provider: speech }]);
+    expect(
+      builder.registry.mediaUnderstandingProviders.map(({ pluginId, provider }) => ({
+        pluginId,
+        provider,
+      })),
+    ).toEqual([{ pluginId: "alpha", provider: media }]);
+    expect(alpha.speechProviderIds).toEqual(["shared-speech"]);
+    expect(alpha.mediaUnderstandingProviderIds).toEqual(["shared-media"]);
+    expect(beta.speechProviderIds).toEqual([]);
+    expect(beta.mediaUnderstandingProviderIds).toEqual([]);
+    expect(
+      builder.registry.modelCatalogProviders.map(({ pluginId, provider }) => ({
+        pluginId,
+        provider: provider.provider,
+        kinds: provider.kinds,
+      })),
+    ).toEqual([{ pluginId: "alpha", provider: "shared-speech", kinds: ["voice"] }]);
+  });
+
+  it.each([false, true])(
+    "keeps reentrant diagnostics host-owned and stops coercion after register closes (throws=%s)",
+    (throws) => {
+      const { builder, createRecord } = createDiagnosticFixture();
+      const record = createRecord("owner");
+      let captured: OpenClawPluginApi | undefined;
+      let coercions = 0;
+      // Exercise the existing unknown-hook path for untyped plugin input, not host-record accessors.
+      const hookName = {
+        toString() {
+          coercions += 1;
+          const api = expectDefined(captured, "captured registration API");
+          api.id = "plugin-copy";
+          api.source = "/plugins/plugin-copy.ts";
+          api.registerReload({});
+          return "unknown-hook";
+        },
+      };
+      const register = () =>
+        runPluginRegisterSyncInRegistry(
+          (api) => {
+            captured = api;
+            // @ts-expect-error Untyped hook input reaches the existing rejection/coercion path.
+            api.on(hookName, () => {});
+            if (throws) {
+              throw new Error("registration failed");
+            }
+          },
+          builder.createApi(record, { config: {} }),
+          builder.registry,
+          record.id,
+        );
+      if (throws) {
+        expect(register).toThrow("registration failed");
+      } else {
+        register();
+      }
+
+      const expected = [
+        {
+          level: "warn",
+          pluginId: "owner",
+          source: "/plugins/owner/index.ts",
+          message: "reload registration missing prefixes",
+        },
+        {
+          level: "warn",
+          pluginId: "owner",
+          source: "/plugins/owner/index.ts",
+          message: 'unknown typed hook "unknown-hook" ignored',
+        },
+      ];
+      expect(builder.registry.diagnostics).toEqual(expected);
+      expect(record.id).toBe("owner");
+      expect(record.source).toBe("/plugins/owner/index.ts");
+      const retained = expectDefined(captured, "captured registration API");
+      // @ts-expect-error Closed registration must stop before coercing untyped hook input.
+      expect(retained.on(hookName, () => {})).toBeUndefined();
+      expect(coercions).toBe(1);
+      expect(builder.registry.diagnostics).toEqual(expected);
+      expect(builder.registry.typedHooks).toEqual([]);
+      expect(builder.registry.reloads).toEqual([]);
+    },
+  );
+});

--- a/test/scripts/type-suppression-inventory.test.ts
+++ b/test/scripts/type-suppression-inventory.test.ts
@@ -79,6 +79,11 @@ describe("type suppression inventory", () => {
       "src/plugin-sdk/plugin-entry.reply-trigger.test.ts:8:@ts-expect-error Trigger eligibility is only supported for before_agent_reply.",
       "src/plugin-sdk/plugin-entry.reply-trigger.test.ts:10:@ts-expect-error An empty trigger list cannot prove that a hook is inactive.",
       "src/plugin-sdk/plugin-entry.reply-trigger.test.ts:28:@ts-expect-error Tool authority is only supported for before_prompt_build.",
+      "src/plugins/registry.diagnostics.test.ts:41:@ts-expect-error JavaScript plugins may omit the required supplement builder.",
+      "src/plugins/registry.diagnostics.test.ts:43:@ts-expect-error JavaScript plugins may omit the required hosted-media resolver.",
+      "src/plugins/registry.diagnostics.test.ts:45:@ts-expect-error Unknown JavaScript hook names must produce a diagnostic.",
+      "src/plugins/registry.diagnostics.test.ts:176:@ts-expect-error Untyped hook input reaches the existing rejection/coercion path.",
+      "src/plugins/registry.diagnostics.test.ts:210:@ts-expect-error Closed registration must stop before coercing untyped hook input.",
     ]);
   });
 });


### PR DESCRIPTION
## What Problem This Solves

Plugin registrars repeated the same diagnostic-object construction even though registry state already owns diagnostic recording. Consolidating that construction keeps severity, message text and plugin provenance consistent without changing registration policy.

## Why This Change Was Made

Use the existing registry-state owner for registration errors and warnings, removing repeated construction across eight production files. Registrar-specific validation, return paths and the raw diagnostic sink remain intact. Characterization tests cover ordering, provenance, rollback, provider-like duplicate rejection, reentrant registration and late calls after registration closes.

The first CI run also caught five intentional negative-type test comments missing from the explicit suppression inventory. The follow-up records those exact file/line/reason entries; the scanner, zero-any checks, full inventory equality and all diagnostics assertions remain unchanged.

A later CI run exposed a newly composed tooling mismatch: the fork-shutdown fixture still used the profiler as an adapter for native exit-time CPU/heap output, while the newer profiler deliberately captures through awaited runner cleanup and accepts only `forks` and `threads`. Its startup refusal for VM/custom pools happened before the fixture could write its receipt, and an unconditional receipt read obscured the original child output.

That fixture repair was initially included here and proved locally. The canonical shutdown follow-ups have since landed in [#132820](https://github.com/openclaw/openclaw/pull/132820) and [#132824](https://github.com/openclaw/openclaw/pull/132824). This branch now incorporates those main fixes and drops its redundant fixture commit. The remaining PR is only the Registry consolidation and explicit negative-type inventory; no competing shutdown implementation remains.

## User Impact

The registry change is an internal behavior-preserving consolidation, not a new user-facing capability or a newly reproduced product bug. The remaining ten-file PR adds no configuration, dependency, persistence surface, plugin API or compatibility path. The shutdown repair is owned by the landed canonical main changes, not an additional patch in this PR.

Production: +248/-475 (227 lines removed). Tests: net +223. Total: four lines removed across ten files.

## Evidence

Paired owner/sibling checks passed 58 cases on each side; paired complete loader checks passed 183 cases on each side. These are local deterministic registry/loader checks, not authenticated provider or channel proof. The original nine-file changed gate and separate precommit/published-head reviews passed.

The [first exact-head CI run](https://github.com/openclaw/openclaw/actions/runs/33268150083) failed the explicit suppression-inventory assertion (eight expected, thirteen actual). The unchanged focused command reproduced that failure locally, then passed all six cases after adding only the five inventory entries:

```sh
node scripts/run-vitest.mjs test/scripts/type-suppression-inventory.test.ts src/plugins/registry.diagnostics.test.ts --reporter=verbose
```

The corrected ten-file changed gate passed, including core production/test and root-test typechecks, formatting, lint and the storage/architecture guards. The correction's precommit review also passed with no actionable findings.

The [next exact-head CI run](https://github.com/openclaw/openclaw/actions/runs/33270441057/job/99147981511) failed the shutdown fixture's `vmForks/raw` and `custom-opt-in/raw` cases. The fixture and joined-shutdown patch came from [#132403](https://github.com/openclaw/openclaw/pull/132403); the later profiler rewrite came from [#132224](https://github.com/openclaw/openclaw/pull/132224), authored and merged by @steipete as `81a74b23eb1f59aeb7fbd9641e7345e5161d9b8d`. This is an integration failure between those tooling changes, not a registry-diagnostic failure.

To reproduce and repair that composed failure, the branch was rebased from `2d5228d4d83111b13a8c377367acd6d6a5487025` onto `a9978c1c6edd570b8bbe34c7276df54aabcf639b`. This was failure-driven, not a refresh for unrelated main drift: the relevant shutdown files did not exist at the old base. All ten original changed-file afterimages and the original cleanup patch remained byte-identical through the rebase.

On the unchanged rebased source with its normal frozen install, the original twelve-case command reproduced exactly ten passes and those two failures:

```sh
node scripts/run-vitest.mjs test/scripts/vitest-fork-shutdown.test.ts --reporter=verbose
```

Before the canonical fixes landed, the local fixture candidate passed all 58 cases: the unchanged twelve-case shutdown matrix plus 46 profiler and state-cleanup siblings. The then-composed eleven-file changed gate and post-run source/index/runtime/process checks also passed. Those results are retained historical evidence for that source, not proof of the latest composed head.

The earlier isolated pre-commit Codex review completed both full-evidence passes with no P0 findings, and its signed fixture correction was published. That commit remains preserved in history but is no longer part of the PR diff.

The branch is now rebased onto `d3c07b02e244e73470df4a930911e8d58c4e456d` at `f619e7a1b276785ddd2134dcf94eebd1f05d8de3`, containing only the two Registry commits. The retained ten-file patch from `a9978c1c6edd570b8bbe34c7276df54aabcf639b` to `dc37994e275ecdd7d841c2ab6cf2eec861a07a62` is byte-identical to the new base-to-head patch, and all ten afterimages are preserved. This does not claim whole-tree equivalence to the former published head, which also contained the now-absorbed fixture repair.

The current canonical-main focused proof passed 275 cases across fourteen files and five Vitest shards, including the canonical twelve-case shutdown matrix. The complete post-run source/index/runtime check passed, and all observed cache/timing output changes were qualified against their owners; no installed runtime-package change was found.

The final local ten-path changed gate completed all 32 canonical stages successfully in 306 seconds. Its after-check found no source, dependency or generated-output delta. Two earlier attempts remain recorded: R1 timed out with exit 143 after 28 successful stages, interrupting the cycle check before the three remaining guards; R2 failed in its startup observer with an EPERM diagnostic and no test execution, followed by a fresh safe-closure check. The successful R3 used unchanged source, settings and timeout budgets. Neither earlier attempt is counted as a passed gate.

[Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/33276213568) for `f619e7a1b276785ddd2134dcf94eebd1f05d8de3` completed successfully across 185 jobs. The [latest completed ClawSweeper review](https://github.com/openclaw/openclaw/pull/132770#issuecomment-5464137011) reported no findings on that head; its remaining exact-head CI request is now satisfied.

The fresh whole-branch Codex review completed all six full-evidence passes with no findings at the required P0 threshold. Its final source, index, dependency, runtime and reviewer-process checks passed. Native current-main composition at `0dcbb900559944775bcca61452280e2f7383f007` preserved all ten reviewed file contents and all 49 existing owner/caller context files without conflicts. No drift-only rebase was performed.

Mandatory hosted preparation and the normal native merge both completed successfully. Landed as [2a11b571](https://github.com/openclaw/openclaw/commit/2a11b571ef3f3df1d59669b40d8ff58110901c64). Independent and lead audits reproduced the entire landed tree from its actual parent plus exactly the ten reviewed afterimages: all 35,286 files and modes match, and the complete patch remains byte-identical to reviewed `f619`. Actual-parent accounting confirms 227 production lines removed, 223 test lines added, and four total lines removed. The containing private main checkout is clean; the native temporary worktree, registration, operation lock and remote source branch are gone.

Both historical CI failures and the unchanged-source reproduction are retained, along with the failed local gate attempts; no timeout, setting, assertion or test selection was relaxed to obtain the reported passes.
