### PR TITLE
test: share HTTP rejection resource cleanup proof

### DIFF
--- a/src/infra/http-request-lifecycle.test.ts
+++ b/src/infra/http-request-lifecycle.test.ts
@@ -340,24 +340,26 @@ describe("bounded HTTP rejection transport", () => {
     );
   });
 
-  it("retains the SDK limiter until a peer ignoring the half-close is retired", async () => {
+  it("retains SDK capacity and Gateway admission until a peer ignoring the half-close is retired", async () => {
     const limiter = createWebhookInFlightLimiter({ maxInFlightPerKey: 1 });
     const retired = createDeferredCore();
     let socket: Socket | undefined;
     await withServer(
       async (req, res) => {
-        const pipeline = beginWebhookRequestPipelineOrReject({
-          req,
-          res,
-          inFlightLimiter: limiter,
-          inFlightKey: "test",
+        await runWithGatewayHttpWorkAdmission(res, () => {
+          const pipeline = beginWebhookRequestPipelineOrReject({
+            req,
+            res,
+            inFlightLimiter: limiter,
+            inFlightKey: "test",
+          });
+          expect(pipeline.ok).toBe(true);
+          installRequestBodyLimitGuard(req, res, { maxBytes });
+          if (pipeline.ok) {
+            pipeline.release();
+          }
+          return true;
         });
-        expect(pipeline.ok).toBe(true);
-        installRequestBodyLimitGuard(req, res, { maxBytes });
-        if (pipeline.ok) {
-          pipeline.release();
-        }
-        await waitForHttpRequestRejection(req);
         retired.resolve();
       },
       async (port) => {
@@ -367,8 +369,10 @@ describe("bounded HTTP rejection transport", () => {
         socket.write(postHeaders(`Content-Length: ${maxBytes + 1}`));
         await once(socket, "end");
         expect(limiter.tryAcquire("test")).toBe(false);
+        expect(getActiveGatewayRootWorkCount()).toBe(1);
         await retired.promise;
         expect(limiter.tryAcquire("test")).toBe(true);
+        expect(getActiveGatewayRootWorkCount()).toBe(0);
         limiter.release("test");
         socket.end();
         await closed;
@@ -387,34 +391,6 @@ describe("bounded HTTP rejection transport", () => {
         expect(result.wire).not.toContain("413");
         expect(result.wire).not.toContain("rejected");
         expect(result.wire).not.toContain("0\r\n\r\n");
-      },
-    );
-  });
-
-  it("retains a Gateway admission while an installed guard completes bounded cleanup", async () => {
-    const retired = createDeferredCore();
-    await withServer(
-      async (req, res) => {
-        await runWithGatewayHttpWorkAdmission(res, async () => {
-          installRequestBodyLimitGuard(req, res, { maxBytes });
-          return true;
-        });
-        retired.resolve();
-      },
-      async (port) => {
-        const socket = connect({ host: "127.0.0.1", port, allowHalfOpen: true });
-        const closed = once(socket, "close");
-        socket.on("data", () => {});
-        try {
-          socket.write(postHeaders(`Content-Length: ${maxBytes + 1}`));
-          await once(socket, "end");
-          expect(getActiveGatewayRootWorkCount()).toBe(1);
-          await retired.promise;
-          expect(getActiveGatewayRootWorkCount()).toBe(0);
-        } finally {
-          socket.end();
-          await closed;
-        }
       },
     );
   });


### PR DESCRIPTION
## What Problem This Solves

The HTTP rejection transport suite spends two separate one-second disposal deadlines proving that SDK capacity and Gateway work admission remain held for a peer that ignores the server's half-close.

## Why This Change Was Made

Exercise both lifecycle owners in one real HTTP request, using the normal Gateway admission -> webhook pipeline -> installed body guard composition. Keep separate assertions that each resource stays held after FIN and is released after bounded transport retirement. The real socket, one-second production deadline, limiter acquisition/release, admission checks, and every other transport scenario remain intact.

This is a maintainer-requested test execution optimization, assisted by Codex. No production behavior, sharding, concurrency, timeouts, dependencies, or test-selection configuration changes.

## User Impact

No runtime behavior changes. The focused suite's measured test execution fell from 4,228ms to 3,211ms (24.1%), removing one duplicate real disposal wait. Production LOC: +0/-0. Tests: +16/-40.

## Evidence

- `node scripts/run-vitest.mjs src/infra/http-request-lifecycle.test.ts`: all 32 consolidated cases pass; baseline was 33 cases.
- Grouped owner/sibling proof: `node scripts/run-vitest.mjs src/infra/http-request-lifecycle.test.ts src/infra/http-body.test.ts src/plugin-sdk/webhook-request-guards.test.ts src/process/gateway-work-admission.test.ts`: all four routed suites pass.
- Independent temporary mutations were both caught: releasing SDK capacity before transport closure fails the limiter assertion; returning Gateway admission without awaiting rejection closure fails the active-root assertion. Both runtime files were restored byte-for-byte afterward.
- Fresh isolated Codex autoreview: no actionable findings.
- Changed-file gate and exact-head hosted CI are required before landing; their final results will be recorded in the landing evidence.

The tests originated with the bounded HTTP rejection transport repair (#131724). This preserves that repair's real peer and cleanup guarantees; it consolidates duplicated setup rather than replacing the clock or weakening the checks.
