### PR TITLE
perf(scripts): skip irrelevant boundary report source reads

### DIFF
--- a/scripts/plugin-boundary-report.ts
+++ b/scripts/plugin-boundary-report.ts
@@ -22,6 +22,8 @@ const SKIPPED_DIRS = new Set([
   "node_modules",
 ]);
 const TEXT_FILE_PATTERN = /\.(?:[cm]?[jt]sx?|json|mdx?|ya?ml)$/u;
+const MEMORY_HOST_SOURCE_BRIDGE_TOKEN = "src/memory-host-sdk/";
+const MEMORY_HOST_CORE_REFERENCE_TOKEN = "../../../src/";
 type CliOptions = {
   json: boolean;
   summary: boolean;
@@ -185,10 +187,10 @@ function collectWorkspaceTextFilesFromGit(): string[] | null {
     .filter(isExistingTextFile);
 }
 
-function collectWorkspaceTextFilesMatchingGit(pattern: string): string[] | null {
+function collectWorkspaceTextFilesMatchingGit(patternArgs: readonly string[]): string[] | null {
   const result = spawnSync(
     "git",
-    ["grep", "--untracked", "-l", "-E", pattern, "--", ...SOURCE_ROOTS],
+    ["grep", "--untracked", "-l", ...patternArgs, "--", ...SOURCE_ROOTS],
     {
       cwd: REPO_ROOT,
       encoding: "utf8",
@@ -215,8 +217,26 @@ function repoRelative(file: string): string {
   return relative(REPO_ROOT, file).replaceAll("\\", "/");
 }
 
-function collectWorkspaceTextFileSources(): WorkspaceTextFile[] {
-  return collectWorkspaceTextFiles().map((file) => ({
+function collectWorkspaceTextFileSources(
+  records?: readonly PluginCompatRecord[],
+): WorkspaceTextFile[] {
+  const tokens = records?.flatMap((record) =>
+    record.status === "deprecated"
+      ? extractCompatTokens(record)
+      : record.status === "removal-pending"
+        ? extractCompatSurfaceTokens(record)
+        : [],
+  );
+  // Keep every file either collector can use; Git failure retains the exhaustive scan.
+  const matches = tokens
+    ? collectWorkspaceTextFilesMatchingGit([
+        "-F",
+        ...[...tokens, MEMORY_HOST_SOURCE_BRIDGE_TOKEN, MEMORY_HOST_CORE_REFERENCE_TOKEN].flatMap(
+          (token) => ["-e", token],
+        ),
+      ])
+    : null;
+  return (matches ?? collectWorkspaceTextFiles()).map((file) => ({
     file,
     relativeFile: repoRelative(file),
     source: readFileSync(file, "utf8"),
@@ -224,9 +244,10 @@ function collectWorkspaceTextFileSources(): WorkspaceTextFile[] {
 }
 
 function collectSummaryWorkspaceTextFileSources(): WorkspaceTextFile[] {
-  const pluginSdkFiles = collectWorkspaceTextFilesMatchingGit(
+  const pluginSdkFiles = collectWorkspaceTextFilesMatchingGit([
+    "-E",
     String.raw`openclaw/plugin-sdk/[a-z0-9][a-z0-9-]*`,
-  );
+  ]);
   if (!pluginSdkFiles) {
     return collectWorkspaceTextFileSources();
   }
@@ -445,10 +466,10 @@ function collectMemoryHostBoundary(
     if (!relativeFile.startsWith("packages/memory-host-sdk/src/")) {
       continue;
     }
-    if (source.includes("src/memory-host-sdk/")) {
+    if (source.includes(MEMORY_HOST_SOURCE_BRIDGE_TOKEN)) {
       sourceBridgeFiles.push(relativeFile);
     }
-    if (source.includes("../../../../src/") || source.includes("../../../src/")) {
+    if (source.includes(MEMORY_HOST_CORE_REFERENCE_TOKEN)) {
       packageCoreReferenceFiles.add(relativeFile);
     }
   }
@@ -536,7 +557,7 @@ function buildReport(options: Partial<Pick<CliOptions, "owner" | "summary">> = {
   );
   const files = options.summary
     ? collectSummaryWorkspaceTextFileSources()
-    : collectWorkspaceTextFileSources();
+    : collectWorkspaceTextFileSources(records);
   const compatRecords = collectCompatDebt(records, files, new Date(), {
     includeReferenceFiles: !options.summary,
   });


### PR DESCRIPTION
## What Problem This Solves

Full plugin-boundary reports read every source and documentation file before discarding files that contain no relevant compatibility or memory-boundary references. The four report tests spend roughly seven seconds executing this repeated scan.

## Why This Change Was Made

Reuse the existing native Git prefilter for full reports. Search literal tokens from the selected deprecated/removal-pending records plus the canonical memory-boundary markers, then retain the existing exact source checks and sorted reference arrays. Git failure still uses the exhaustive scan. Summary mode keeps its existing regex and source universe; neither mode caches source contents.

This is a maintainer-requested execution optimization, assisted by Codex. No sharding, test selection, concurrency, dependencies, public API, compatibility policy, or runtime changes. The owner is source discovery in the report script; no report data is discarded.

## User Impact

The same four tests execute about 70% faster: paired runs were 7,099→2,098ms and 7,192→2,181ms. Developers also avoid unnecessary reads when invoking full reports. Product runtime LOC +0/-0; tooling +30/-9; tests unchanged. The small tooling growth applies an existing native prefilter to the remaining exhaustive path while preserving its fallback.

## Evidence

- All four existing report tests pass in both measured pairs: `node scripts/run-vitest.mjs test/scripts/plugin-boundary-report.test.ts`.
- All 32 combinations of full/summary, all/channel/sdk/unknown owner, JSON/text and fail flag match the baseline's complete stdout, stderr and exit code. Only generatedAt is removed when comparing JSON; every reference array remains compared.
- 80 disposable-fixture result comparisons pass: tracked/untracked/ignored/deleted/symlink sources, suffix/skipped-directory rules, literal tokens, memory-only unknown-owner output, same-process add/change/delete, and non-Git exhaustive fallback. Existing full/summary ignored-memory differences remain intact.
- Independent mutations omitting compatibility tokens or memory markers each fail the fixture comparison for the missing reference arrays.
- `env -u OPENCLAW_TESTBOX node scripts/check-changed.mjs -- scripts/plugin-boundary-report.ts` passed. Fresh isolated Codex autoreview found no actionable finding. Refreshed-main focused proof is repeated before publication; exact-head hosted CI is required before landing.
- Directly inspected installed Git's git-grep documentation: fixed-string matching, OR patterns, working-tree/untracked inputs, ignore behavior and default no-textconv support the prefilter; downstream source matching remains authoritative.

Related: #132590 narrowed record selection before scanning; this change removes irrelevant file reads that remained afterward. No test scenarios or assertions are removed.
