### PR TITLE
test: avoid duplicate async task registry resets

### DIFF
--- a/src/agents/embedded-agent-runner/run/attempt.async-tasks.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.async-tasks.test.ts
@@ -1,5 +1,5 @@
 // Coverage for waiting on completion-required async tool tasks.
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeAll, describe, expect, it } from "vitest";
 import {
   completeTaskRunByRunId,
   createRunningTaskRun,
@@ -23,7 +23,7 @@ function requireCreatedTask(task: TaskRecord | null): TaskRecord {
 }
 
 describe("waitForCompletionRequiredAsyncTasks", () => {
-  beforeEach(() => resetTaskRegistryForTests());
+  beforeAll(() => resetTaskRegistryForTests());
   // Aborted and timed-out waits leave tasks running; release them before the next suite.
   afterEach(() => resetTaskRegistryForTests());
 


### PR DESCRIPTION
## What Problem This Solves

The eight async-task waiting tests reset and persist the same empty task registry twice between adjacent cases. Each reset reopens and closes SQLite, so redundant setup adds execution cost without adding isolation.

## Why This Change Was Made

Run the initial reset once in beforeAll and keep every afterEach reset. The suite uses one hermetic state root and sequential cases; afterEach already clears memory, listeners and runtime state, persists the empty snapshot and closes the database before the next case. This reduces sixteen resets to nine without changing the task operations or assertions.

The afterEach cleanup added in #132643 remains intact, including for aborts, timeouts and failed tests. Maintainer-requested test optimization, assisted by Codex. Production LOC +0/-0; tests +2/-2. No sharding, concurrency, configuration, timeout or persistence behavior changes.

## User Impact

No runtime change. In a paired run, Vitest's complete test phase fell from 1.48s to 1.17s (about 21%); wrapper wall time fell from 10.22s to 9.84s. Peak RSS was 510.6MB before and 504.2MB after. These are focused local measurements, not a full-suite wall-time claim.

## Evidence

- All eight original cases pass in both baseline/candidate pairs with all task writes, terminal results, timeout and abort assertions retained.
- Temporary beforeEach checks verified both in-memory maps and read-only persisted task/delivery snapshots were empty before all eight cases.
- An intentional failure immediately after the first persisted task creation produced exactly that one failure; the seven later cases still passed with empty memory/database checks. Removing the intentional failure yielded eight passes. Temporary instrumentation was removed.
- The installed Vitest runner invokes afterEach after callback failure; the canonical fast-test setup keeps one hermetic state root per worker and does not rotate it between cases.
- Fresh isolated Codex autoreview found no actionable findings. Owner/sibling tests and changed-file checks are completed before publication; exact-head hosted CI is required before landing.
