### PR TITLE
fix(cli-runner): reseed history for session-less backends that opted in

### DIFF
--- a/src/agents/cli-runner.session-less-history.real.test.ts
+++ b/src/agents/cli-runner.session-less-history.real.test.ts
@@ -1,0 +1,164 @@
+/**
+ * Real-process proof for session-less CLI history delivery.
+ *
+ * Every other cli-runner suite mocks the process supervisor, so none of them show
+ * what an actual child receives. This one spawns a real node process as the CLI
+ * backend and reads back exactly what landed on its stdin.
+ */
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, expect, test } from "vitest";
+import {
+  appendTranscriptEventSync,
+  appendTranscriptMessageSync,
+  replaceSessionEntrySync,
+  type SessionTranscriptRuntimeTarget,
+} from "../config/sessions/session-accessor.js";
+import { CURRENT_SESSION_VERSION } from "../config/sessions/version.js";
+import { closeOpenClawAgentDatabaseByPath } from "../state/openclaw-agent-db.js";
+import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db-cache.js";
+import { createTestAdmittedRunContext } from "./admitted-run-context.test-support.js";
+import { testing as cliBackendsTesting } from "./cli-backends.test-support.js";
+import { runCliAgent } from "./cli-runner.js";
+
+const cleanups: Array<() => void> = [];
+
+afterEach(() => {
+  cliBackendsTesting.resetDepsForTest?.();
+  while (cleanups.length > 0) {
+    cleanups.pop()?.();
+  }
+});
+
+function createRealCliSession() {
+  const dir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-cli-real-")));
+  const previousStateDir = process.env.OPENCLAW_STATE_DIR;
+  const hadStateDir = Object.hasOwn(process.env, "OPENCLAW_STATE_DIR");
+  process.env.OPENCLAW_STATE_DIR = dir;
+  const sessionTarget: SessionTranscriptRuntimeTarget = {
+    agentId: "main",
+    sessionId: "session-real",
+    sessionKey: "agent:main:main",
+    storePath: path.join(dir, "agents", "main", "agent", "openclaw-agent.sqlite"),
+  };
+  replaceSessionEntrySync(sessionTarget, { sessionId: sessionTarget.sessionId, updatedAt: 0 });
+  const seeded = appendTranscriptEventSync(sessionTarget, {
+    type: "session",
+    version: CURRENT_SESSION_VERSION,
+    id: sessionTarget.sessionId,
+    timestamp: new Date(0).toISOString(),
+    cwd: dir,
+  });
+  if (!seeded.ok) {
+    throw new Error("could not initialize real CLI session transcript");
+  }
+  cleanups.push(() => {
+    // The run opens both the agent transcript and the shared state DB; Windows keeps
+    // the temp dir locked until each handle is released.
+    closeOpenClawAgentDatabaseByPath(sessionTarget.storePath);
+    closeOpenClawStateDatabaseForTest();
+    fs.rmSync(dir, { recursive: true, force: true });
+    if (hadStateDir) {
+      process.env.OPENCLAW_STATE_DIR = previousStateDir;
+    } else {
+      delete process.env.OPENCLAW_STATE_DIR;
+    }
+  });
+  return { dir, sessionTarget };
+}
+
+function appendMessage(
+  sessionTarget: SessionTranscriptRuntimeTarget,
+  cwd: string,
+  entry: { id: string; parentId: string | null; timestamp: string; message: unknown },
+) {
+  const appended = appendTranscriptMessageSync(sessionTarget, {
+    cwd,
+    eventId: entry.id,
+    parentId: entry.parentId,
+    now: Date.parse(entry.timestamp),
+    message: entry.message,
+  });
+  if (!appended.ok || !appended.value) {
+    throw new Error("could not append real CLI transcript message");
+  }
+}
+
+test("a real session-less CLI child receives prior conversation and the current ask once", async () => {
+  const { dir, sessionTarget } = createRealCliSession();
+  const stdinReceipt = path.join(dir, "cli-stdin-receipt.txt");
+  // A real CLI stand-in: drain stdin, record it verbatim, then answer on stdout.
+  const cliScript = path.join(dir, "fake-cli.cjs");
+  fs.writeFileSync(
+    cliScript,
+    [
+      "let received = '';",
+      "process.stdin.setEncoding('utf8');",
+      "process.stdin.on('data', (chunk) => { received += chunk; });",
+      "process.stdin.on('end', () => {",
+      `  require('node:fs').writeFileSync(${JSON.stringify(stdinReceipt)}, received);`,
+      "  process.stdout.write('acknowledged');",
+      "  process.exit(0);",
+      "});",
+    ].join("\n"),
+  );
+
+  appendMessage(sessionTarget, dir, {
+    id: "real-turn-1-user",
+    parentId: null,
+    timestamp: "2020-01-02T03:04:05.000Z",
+    message: { role: "user", content: "what is the capital of France", timestamp: 1 },
+  });
+  appendMessage(sessionTarget, dir, {
+    id: "real-turn-1-assistant",
+    parentId: "real-turn-1-user",
+    timestamp: "2020-01-02T03:04:06.000Z",
+    message: { role: "assistant", content: "Paris is the capital of France", timestamp: 2 },
+  });
+
+  cliBackendsTesting.setDepsForTest({
+    resolvePluginSetupCliBackend: () => undefined,
+    resolveRuntimeCliBackends: () => [
+      {
+        id: "claude-cli",
+        pluginId: "anthropic",
+        modelProvider: "claude-cli",
+        bundleMcp: false,
+        config: {
+          command: process.execPath,
+          args: [cliScript],
+          output: "text",
+          input: "stdin",
+          sessionMode: "none",
+          reseedFromRawTranscriptWhenUncompacted: true,
+        },
+      },
+    ],
+  });
+
+  await runCliAgent({
+    admittedRunContext: createTestAdmittedRunContext("run-real-1"),
+    sessionId: sessionTarget.sessionId,
+    sessionKey: sessionTarget.sessionKey,
+    sessionTarget,
+    sessionFile: sessionTarget.sessionKey,
+    workspaceDir: dir,
+    prompt: "and what about Germany",
+    provider: "claude-cli",
+    model: "opus",
+    timeoutMs: 30_000,
+    runId: "run-real-1",
+    config: {},
+  });
+
+  const delivered = fs.readFileSync(stdinReceipt, "utf8");
+
+  // Turn one actually reached the child process, not just prepare's return value.
+  expect(delivered).toContain("what is the capital of France");
+  expect(delivered).toContain("Paris is the capital of France");
+  // The current ask is present, and present exactly once - the persisted copy of
+  // this same turn must not be replayed back as history.
+  expect(delivered).toContain("and what about Germany");
+  expect(delivered.split("and what about Germany").length - 1).toBe(1);
+});

--- a/src/agents/cli-runner/prepare.test.ts
+++ b/src/agents/cli-runner/prepare.test.ts
@@ -4649,6 +4649,55 @@ describe("prepareCliRunContext", () => {
     expect(orphanCheck).not.toHaveBeenCalled();
   });
 
+  it("reseeds prior conversation for an uncompacted session-less backend that opted in", async () => {
+    const askedAt = "2020-01-02T03:04:05.000Z";
+    fixture.appendTranscript({
+      id: "msg-none-mode-1",
+      parentId: null,
+      timestamp: askedAt,
+      message: { role: "user", content: "prior session-less ask", timestamp: 1 },
+    });
+    setCliBackendForPrepareTest({
+      sessionMode: "none",
+      reseedFromRawTranscriptWhenUncompacted: true,
+    });
+
+    const context = await fixture.prepare({
+      sessionKey: "agent:main:telegram:direct:peer",
+      provider: "claude-cli",
+      model: "opus",
+    });
+
+    // No native session is ever resumed here, so the OpenClaw transcript is the only
+    // place prior conversation can come from - it must reach the fresh CLI run.
+    expect(context.reusableCliSession).toEqual({ mode: "none" });
+    expect(context.openClawHistoryPrompt).toBeDefined();
+    expect(context.openClawHistoryPrompt).toContain(`[${askedAt}] User: prior session-less ask`);
+    expect(context.openClawHistoryPrompt).toContain(
+      "<next_user_message>\nlatest ask\n</next_user_message>",
+    );
+  });
+
+  it("leaves an uncompacted session-less backend without raw reseed when it did not opt in", async () => {
+    fixture.appendTranscript({
+      id: "msg-none-mode-2",
+      parentId: null,
+      timestamp: "2020-01-02T03:04:05.000Z",
+      message: { role: "user", content: "prior session-less ask", timestamp: 1 },
+    });
+    setCliBackendForPrepareTest({ sessionMode: "none" });
+
+    const context = await fixture.prepare({
+      sessionKey: "agent:main:telegram:direct:peer",
+      provider: "claude-cli",
+      model: "opus",
+    });
+
+    // The backend opt-in still gates raw reseed; supplying a reason must not bypass it.
+    expect(context.reusableCliSession).toEqual({ mode: "none" });
+    expect(context.openClawHistoryPrompt ?? "").not.toContain("prior session-less ask");
+  });
+
   it("checks claude-cli transcript content under the resolved cwd", async () => {
     const { dir } = fixture.session;
     const taskDir = path.join(dir, "task");

--- a/src/agents/cli-runner/prepare.test.ts
+++ b/src/agents/cli-runner/prepare.test.ts
@@ -4698,6 +4698,68 @@ describe("prepareCliRunContext", () => {
     expect(context.openClawHistoryPrompt ?? "").not.toContain("prior session-less ask");
   });
 
+  it("does not repeat the current user turn that production persists before CLI preparation", async () => {
+    const askedAt = "2020-01-02T03:04:05.000Z";
+    fixture.appendTranscript({
+      id: "msg-ordering-prior",
+      parentId: null,
+      timestamp: askedAt,
+      message: { role: "user", content: "prior session-less ask", timestamp: 1 },
+    });
+    // Production admits and persists the user turn before CLI preparation
+    // (agent-runner-execute.ts -> admitUserTurn -> persistApproved), so the reseed
+    // read sees the current turn too. Mirror that ordering here.
+    fixture.appendTranscript({
+      id: "msg-ordering-current",
+      parentId: "msg-ordering-prior",
+      timestamp: "2020-01-02T03:04:06.000Z",
+      message: { role: "user", content: "latest ask", timestamp: 2 },
+    });
+    setCliBackendForPrepareTest({
+      sessionMode: "none",
+      reseedFromRawTranscriptWhenUncompacted: true,
+    });
+
+    const context = await fixture.prepare({
+      sessionKey: "agent:main:telegram:direct:peer",
+      provider: "claude-cli",
+      model: "opus",
+      userTurnTranscriptRecorder: {
+        message: undefined,
+        resolveMessage: vi.fn(async () => undefined),
+        getAdmissionReceipt: () => ({
+          agentId: "main",
+          sessionId: fixture.session.sessionTarget.sessionId,
+          sessionKey: "agent:main:telegram:direct:peer",
+          storePath: fixture.session.sessionTarget.storePath,
+          generation: "generation-1",
+          entryId: "msg-ordering-current",
+          rawSeq: 2,
+          effectiveParentId: "msg-ordering-prior",
+          activeMessagePosition: 1,
+          logicalTurnId: "ordering-turn",
+          role: "user" as const,
+        }),
+        markRuntimePersistencePending: vi.fn(),
+        markRuntimePersisted: vi.fn(),
+        markBlocked: vi.fn(),
+        hasPersisted: () => true,
+        isBlocked: () => false,
+        hasRuntimePersistencePending: () => false,
+        waitForRuntimePersistence: vi.fn(async () => {}),
+        persistApproved: vi.fn(async () => undefined),
+        persistBlocked: vi.fn(async () => undefined),
+        persistFallback: vi.fn(async () => undefined),
+      },
+    });
+
+    const historyPrompt = context.openClawHistoryPrompt ?? "";
+    expect(historyPrompt).toContain("prior session-less ask");
+    // The current turn already appears in <next_user_message>; replaying the persisted
+    // copy as history would hand the CLI the same ask twice.
+    expect(historyPrompt.split("latest ask").length - 1).toBe(1);
+  });
+
   it("checks claude-cli transcript content under the resolved cwd", async () => {
     const { dir } = fixture.session;
     const taskDir = path.join(dir, "task");

--- a/src/agents/cli-runner/prepare.ts
+++ b/src/agents/cli-runner/prepare.ts
@@ -1723,7 +1723,12 @@ export async function prepareCliRunContext(
     }
     const allowRawTranscriptReseed =
       backendResolved.config.reseedFromRawTranscriptWhenUncompacted === true;
-    const rawTranscriptReseedReason = reusableCliSessionId ? "session-expired" : invalidatedReason;
+    // `sessionMode: none` never resumes, so every turn is a fresh CLI session with no native
+    // memory. Without a reason the opt-in reseed below stays inert until the first compaction.
+    const rawTranscriptReseedReason = reusableCliSessionId
+      ? "session-expired"
+      : (invalidatedReason ??
+        (preparedBackendFinal.backend.sessionMode === "none" ? "no-native-session" : undefined));
     // Node placement keeps this: the history prompt is built from the
     // gateway-side OpenClaw transcript, so a fresh remote CLI session still
     // receives prior conversation context via stdin.

--- a/src/agents/cli-runner/prepare.ts
+++ b/src/agents/cli-runner/prepare.ts
@@ -1734,12 +1734,14 @@ export async function prepareCliRunContext(
     // receives prior conversation context via stdin.
     const shouldPrepareOpenClawHistoryPrompt =
       !skipsTurnPreparation && (!reusableCliSessionId || allowRawTranscriptReseed);
+    const currentTurnEntryId = params.userTurnTranscriptRecorder?.getAdmissionReceipt()?.entryId;
     const openClawHistoryPrompt = shouldPrepareOpenClawHistoryPrompt
       ? buildCliSessionHistoryPrompt({
           messages: await loadCliSessionReseedMessages({
             sessionTarget: params.sessionTarget,
             allowRawTranscriptReseed,
             rawTranscriptReseedReason,
+            ...(currentTurnEntryId ? { currentTurnEntryId } : {}),
           }),
           prompt: historyPromptCurrentTurn,
           maxHistoryChars: autoReseedHistoryChars,

--- a/src/agents/cli-runner/session-history.ts
+++ b/src/agents/cli-runner/session-history.ts
@@ -52,6 +52,7 @@ type RawTranscriptReseedReason =
   | "mcp"
   | "missing-transcript"
   | "orphaned-tool-use"
+  | "no-native-session"
   | "session-expired";
 
 const RAW_TRANSCRIPT_RESEED_ALLOWED_REASONS = new Set<RawTranscriptReseedReason>([
@@ -61,6 +62,9 @@ const RAW_TRANSCRIPT_RESEED_ALLOWED_REASONS = new Set<RawTranscriptReseedReason>
   "system-prompt",
   "cwd",
   "mcp",
+  // A backend that never carries a native session starts every turn empty, so an
+  // uncompacted transcript is the only place its prior conversation can come from.
+  "no-native-session",
   "session-expired",
 ]);
 

--- a/src/agents/cli-runner/session-history.ts
+++ b/src/agents/cli-runner/session-history.ts
@@ -331,9 +331,17 @@ export async function loadCliSessionReseedMessages(
   params: CliSessionHistoryParams & {
     allowRawTranscriptReseed?: boolean;
     rawTranscriptReseedReason?: RawTranscriptReseedReason;
+    currentTurnEntryId?: string;
   },
 ): Promise<unknown[]> {
-  const entries = await loadCliSessionEntries(params);
+  const loaded = await loadCliSessionEntries(params);
+  // The current user turn is admitted and persisted before CLI preparation, so it is
+  // already in the branch. It is re-rendered as <next_user_message>, and replaying the
+  // persisted copy here would hand the CLI the same ask twice. Fence on the admitted
+  // entry id, never on text: identical historical wording must survive.
+  const entries = params.currentTurnEntryId
+    ? loaded.filter((entry) => entry.id !== params.currentTurnEntryId)
+    : loaded;
   // This freshly loaded branch is reseed-owned; use persistence rather than provider timestamps.
   for (const entry of entries) {
     if (entry.type === "message") {


### PR DESCRIPTION
## What Problem This Solves

A CLI backend declared with `sessionMode: "none"` **and** `reseedFromRawTranscriptWhenUncompacted: true` receives no conversation history at all until the session's first compaction. The opt-in flag is silently inert for exactly the backends that depend on it most.

`sessionMode: "none"` means no session id is ever passed to the CLI, so every turn is a fresh process with no native memory. The OpenClaw transcript is the only place prior conversation can come from. Today it never arrives.

This is an internal contradiction, not a design choice. Two lines in the same function disagree:

- [`prepare.ts:1731`](https://github.com/openclaw/openclaw/blob/main/src/agents/cli-runner/prepare.ts#L1731) already decides such a turn deserves a history prompt: `shouldPrepareOpenClawHistoryPrompt = !skipsTurnPreparation && (!reusableCliSessionId || allowRawTranscriptReseed)`.
- [`prepare.ts:1726`](https://github.com/openclaw/openclaw/blob/main/src/agents/cli-runner/prepare.ts#L1726) then hands the loader `undefined`: `reusableCliSessionId ? "session-expired" : invalidatedReason`. For none-mode both operands are `undefined`, because [`prepare.ts:1480`](https://github.com/openclaw/openclaw/blob/main/src/agents/cli-runner/prepare.ts#L1480) collapses the candidate to `{ mode: "none" }`, which is neither a reuse id nor an `invalidate` reason.
- [`session-history.ts:346`](https://github.com/openclaw/openclaw/blob/main/src/agents/cli-runner/session-history.ts#L346) therefore rejects the reseed and returns `[]`, because a falsy reason can never be in `RAW_TRANSCRIPT_RESEED_ALLOWED_REASONS`.

So the caller asks for history, and the loader refuses it. `buildCliSessionHistoryPrompt` then returns `undefined` for the empty message list, and the turn ships with only the current message.

## Why This Change Was Made

The reason vocabulary is the existing mechanism for "this turn has no native continuity, reseed it." None-mode had no member to say that, so it said nothing.

- `session-history.ts` — adds `"no-native-session"` to `RawTranscriptReseedReason` and to the allowlist.
- `prepare.ts` — supplies that reason when, and only when, the backend's `sessionMode` is `"none"`.

Deliberately scoped to `sessionMode === "none"` rather than the broader `ignoreCliSessionCandidate`, which also covers side questions — those are intentionally context-free and are left untouched.

The backend opt-in still gates everything. `allowRawTranscriptReseed` is checked independently inside `loadCliSessionReseedMessages`, so a none-mode backend that never set `reseedFromRawTranscriptWhenUncompacted` gets exactly the behavior it has today. There is a dedicated regression for that.

No double-delivery risk: a none-mode CLI holds no native context, so the history prompt is additive, never duplicative.

## User Impact

A session-less CLI backend that opted into raw-transcript reseed now sees prior conversation from turn one instead of only after the first compaction. Backends using `sessionMode: "always"` or `"existing"`, side questions, and non-opted-in backends are unchanged.

## Evidence

**Regression proven to fail pre-fix.** With the two production files reverted and the tests unchanged:

```
AssertionError: the given combination of arguments (undefined and string) is invalid
for this assertion. You can use an array, a map, an object, a set, a string, or a
weakset instead of a string
```

`context.openClawHistoryPrompt` is `undefined` — no history prompt is produced at all. After the fix that assertion is gone. The test now leads with `expect(context.openClawHistoryPrompt).toBeDefined()` so the pre-fix failure reads plainly.

Two tests were added to `src/agents/cli-runner/prepare.test.ts`, following the existing `"arms raw-transcript reseed for a missing claude-cli transcript"` template:

1. **`reseeds prior conversation for an uncompacted session-less backend that opted in`** — appends a real transcript message, prepares a none-mode turn, and asserts the rendered history reaches `openClawHistoryPrompt` alongside the current turn. Fails pre-fix.
2. **`leaves an uncompacted session-less backend without raw reseed when it did not opt in`** — same setup minus the opt-in, asserts the prior message does *not* appear. This one passes both before and after by design: it pins the backend opt-in so a future change cannot widen the gate unnoticed.

**Verification run locally** (Node 22.23.2):

| Lane | Command | Result |
| --- | --- | --- |
| New regressions | `run-vitest.mjs prepare.test.ts -t "session-less"` | no `AssertionError` (see note) |
| Sibling suite | `run-vitest.mjs session-history.test.ts reseed-envelope.test.ts` | `reseed-envelope` 8/8 passed, no `AssertionError` |
| Types (prod) | `run-tsgo.mjs -p tsconfig.core.json` | no errors in touched files |
| Types (test) | `run-tsgo-core-test-shards.mjs src` | no errors in touched files |
| Lint (type-aware) | `run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json` | clean |
| Format | `oxfmt --check` | clean |

**Note on the local environment, stated plainly:** this Windows host cannot complete teardown for these fixtures — every test in `prepare.test.ts` ends with `EBUSY: resource busy or locked, unlink ...openclaw.sqlite`, including untouched pre-existing tests such as `"arms raw-transcript reseed for a missing claude-cli transcript"`, which I ran unmodified to confirm. I therefore used the presence or absence of `AssertionError` as the signal, which is what gives the clean pre-fix/post-fix differential above. Linux CI is the authoritative run for these suites.

**Production LOC delta:** +11 / −1 (net +10), of which 5 lines are invariant comments; the functional change is one enum member, one allowlist entry, and one reason expression. Test lines are separate.

## Scope

This addresses the **first** failure in #132758 (`sessionMode: "none"`, structural). The second (`sessionMode: "always"` phantom resume against a missing transcript) is intermittent and reported against 2026.6.11; it is not addressed here and needs its own reproduction. Worth noting for triage: the built-in claude-cli backend hardcodes `sessionMode: "always"` ([`extensions/anthropic/cli-backend.ts:221`](https://github.com/openclaw/openclaw/blob/main/extensions/anthropic/cli-backend.ts#L221)) and the quoted journal line shows `reuse=reusable`, which `{ mode: "none" }` never formats as — so the reporter's log appears to come from the `always` path rather than the none-mode path, even though the report attributes it to none-mode.

Refs #132758

---

## Update: current-turn duplication (second commit)

@gaoanze888 reviewed the first commit and pointed out that the new reseed can replay the current user turn. I verified the claim in source rather than taking it on trust, and it is correct:

- `agent-runner-execute.ts:250` calls `admitUserTurn(...)` before the run executes.
- `admitUserTurn` calls `recorder.persistApproved()` (`restart-recovery-claim.ts:203`), so the current user row is already in the transcript.
- `loadCliSessionEntries` reads the whole branch with no fence, and `buildCliSessionHistoryPrompt` then re-renders the same prompt inside `<next_user_message>`.

Reproduced with a test that mirrors that production ordering — prior history plus the persisted current row:

```
AssertionError: expected 2 to be 1
```

The ask was being handed to the CLI twice. After the fence, that assertion passes.

**Fix:** `loadCliSessionReseedMessages` now accepts `currentTurnEntryId` and drops that exact entry before `buildSessionContext`. Fencing is on the admitted entry id, never on text, so a user who legitimately repeats an earlier message keeps their history intact.

Applied at the loader, so it covers **every** raw-reseed reason (`missing-transcript`, `session-expired`, and the rest), not only session-less turns. The duplication pre-dated this PR on those paths; the first commit would have widened it from invalidation events to every none-mode turn. This follows the established `transcriptReadFence` pattern the embedded runner already uses (`attempt-history.ts:599`) and the declared `currentTurnFence: "before-current-turn-entry-v1"` contract.

`currentTurnEntryId` is optional, so callers without a recorder — including the existing `"arms raw-transcript reseed for a missing claude-cli transcript"` test — are unchanged.

**Re-verified:** `oxfmt --check` clean; type-aware oxlint clean; `tsgo` core and test shards show no errors in `cli-runner/`; full `prepare.test.ts` and the `session-history` / `reseed-envelope` suites report **0 AssertionErrors** (`reseed-envelope` 8/8 passed outright). Remaining local failures are the Windows `EBUSY` teardown described above.

---

## Update: real behavior proof (third commit)

ClawSweeper asked for an after-fix trace from a real session-less CLI process showing prior history delivered on a second turn. That did not exist anywhere in this repo — every `cli-runner` suite, including the ones named `*.e2e.test.ts` and `*.spawn.test.ts`, mocks the process supervisor via `execute.test-support.js`. `result.meta.finalPromptText` is the harness reporting its own input back to itself, so it cannot answer this question.

`src/agents/cli-runner.session-less-history.real.test.ts` closes that gap. It deliberately does **not** import `execute.test-support.js`, so the real supervisor stays wired, and it registers a backend whose command is `process.execPath` running a small script that drains stdin, writes it verbatim to a receipt file, and answers on stdout. A real transcript is seeded with a completed turn one, then `runCliAgent` executes turn two. The assertion reads the receipt — the actual bytes the child process received.

**Against pre-fix production code:**

```
AssertionError: expected 'and what about Germany' to contain 'what is the capital of France'
```

The real child received the bare current ask and nothing else. That is the reported bug, observed at the process boundary.

**With the fix:** `1 passed` (19.7s of real child-process work). The receipt contains turn one's user ask and assistant reply, plus the current ask exactly once — which also proves the current-turn fence end to end, not just at the loader.

This single test covers both commits: history delivery and non-duplication, at the only boundary that actually matters.

Incidental fix found while writing it: the run opens both the agent transcript DB and the shared state DB, and the existing fixtures only close the former, so Windows keeps the temp dir locked. This test closes both (`closeOpenClawAgentDatabaseByPath` + `closeOpenClawStateDatabaseForTest`) and therefore passes cleanly on Windows, unlike the `prepare.test.ts` suites described above.

`oxfmt --check`, type-aware oxlint, and `tsgo` test shards are all clean for the new file.

### Unrelated CI note

Head `e286cee6e5` saw one failure in `checks-node-compact-small-49`, in the `core-tooling-isolated` shard: `test/fixtures/vitest-fork-shutdown.mjs:292` throwing `ENOENT ... receipt.json`. That fixture reads a receipt written by a child that `installVitestProcessGroupCleanup` may `SIGKILL` first, so it is flaky by construction. It is a different vitest project from the suites this PR touches, has no import path to `cli-runner`, and the same shard passed on head `0753e91842`. Flagging rather than bundling an unrelated test-infrastructure repair into this PR; happy to raise it separately.
