### PR TITLE
fix(test): avoid startup race in heartbeat routing verification

### DIFF
--- a/test/e2e/qa-lab/runtime/gateway-heartbeat-session-routing.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/gateway-heartbeat-session-routing.e2e.test.ts
@@ -26,6 +26,7 @@ import { peekSystemEvents, resetSystemEventsForTest } from "../../../../src/infr
 import { resetTaskRegistryForTests } from "../../../../src/tasks/task-runtime.test-helpers.js";
 import { captureEnv, deleteTestEnvValue, setTestEnvValue } from "../../../../src/test-utils/env.js";
 import { normalizeSessionDeliveryState } from "../../../../src/utils/delivery-context.shared.js";
+import { waitForFile } from "../../../helpers/process-wait.js";
 import { useAutoCleanupTempDirTracker } from "../../../helpers/temp-dir.js";
 
 const PROOF_CHANNEL_ID = "heartbeat-route-proof";
@@ -112,6 +113,7 @@ function writeAssistantResponse(response: ServerResponse, text: string): void {
 async function writeRouteCapturePlugin(params: {
   pluginDir: string;
   tracePath: string;
+  cronReadyPath: string;
 }): Promise<void> {
   await fs.mkdir(params.pluginDir, { recursive: true });
   await fs.writeFile(
@@ -136,6 +138,9 @@ async function writeRouteCapturePlugin(params: {
       "module.exports = {",
       `  id: ${JSON.stringify(PROOF_CHANNEL_ID)},`,
       "  register(api) {",
+      '    api.on("cron_reconciled", (event) => {',
+      `      fs.writeFileSync(${JSON.stringify(params.cronReadyPath)}, JSON.stringify(event));`,
+      "    });",
       "    api.registerChannel({",
       "      plugin: {",
       `        id: ${JSON.stringify(PROOF_CHANNEL_ID)},`,
@@ -222,6 +227,7 @@ describe("Gateway heartbeat session routing", () => {
       const workspaceDir = path.join(tempHome, "workspace");
       const pluginDir = path.join(workspaceDir, "plugins", PROOF_CHANNEL_ID);
       const deliveryTracePath = path.join(tempHome, "heartbeat-deliveries.jsonl");
+      const cronReadyPath = path.join(tempHome, "cron-reconciled.json");
       const bundledPluginsDir = path.join(tempHome, "empty-bundled-plugins");
       const configPath = path.join(stateDir, "openclaw.json");
       await Promise.all([
@@ -234,7 +240,7 @@ describe("Gateway heartbeat session routing", () => {
           path.join(workspaceDir, "HEARTBEAT.md"),
           "Process all pending system events and report what was handled.\n",
         ),
-        writeRouteCapturePlugin({ pluginDir, tracePath: deliveryTracePath }),
+        writeRouteCapturePlugin({ pluginDir, tracePath: deliveryTracePath, cronReadyPath }),
       ]);
 
       const token = nextId("heartbeat-routing-token");
@@ -405,6 +411,12 @@ describe("Gateway heartbeat session routing", () => {
         ).resolves.toEqual({ ok: true });
         expect(peekSystemEvents(configuredSessionKey)).toContain(configuredEvent);
 
+        // A connected Gateway may still be starting cron; its lifecycle hook owns readiness.
+        await waitForFile(cronReadyPath, 15_000);
+        expect(JSON.parse(await fs.readFile(cronReadyPath, "utf8"))).toEqual({
+          reason: "startup",
+          enabled: true,
+        });
         const listed = await client.request<{
           jobs: Array<{
             agentId?: string;


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where full release verification could fail the heartbeat session-routing proof immediately after connecting to its Gateway, before the background scheduler had published its monitor.

## Why This Change Was Made

A connected Gateway does not imply cron readiness. The existing proof plugin now records the documented `cron_reconciled` lifecycle signal, and the fixture waits for that signal before its original `cron.list` assertion. This reuses the existing file-readiness helper and keeps the readiness decision with the scheduler owner.

The original monitor, configured-session and explicit-wake routing, delivery, and persisted-transcript assertions remain unchanged. The overall 90-second deadline is unchanged; there are no new retries, sleeps, runtime fallbacks, or production APIs.

## User Impact

No application behavior changes. Release verification no longer mistakes normal background cron startup for a missing heartbeat monitor. Production LOC: +0/-0. Test LOC: +13/-1.

## Evidence

- Reproduced the unchanged fixture on a fresh Linux Testbox after a frozen dependency install and normal private-QA build: `cron.list` returned no `heartbeat:main` monitor, failing the original assertion at line 419.
- The repaired real Gateway flow passed both heartbeat routes, outbound delivery checks, and transcript checks. The final focused run passed in 7.97 seconds, with all 35,197 tracked source paths, bytes, executable bits, symlink targets, Git tree, and file count verified before and after.
- All 66 related cron-lifecycle, heartbeat-monitor, and readiness-helper tests passed. The actual changed-file gate passed, including test-root types and script lint. Independent Codex review found no actionable issue.
- [Testbox provisioning run](https://github.com/openclaw/openclaw/actions/runs/33268361103). Delegated proof commands exited successfully; the lease was stopped after verification. The unchanged failing reproduction used exact Git identity and owner hashes; the final passing proof additionally used the complete source manifest.

Focused command: `node scripts/run-vitest.mjs --config test/vitest/vitest.e2e.config.ts test/e2e/qa-lab/runtime/gateway-heartbeat-session-routing.e2e.test.ts`.

Source contract: [Gateway lifecycle hooks](https://docs.openclaw.ai/plugins/hooks#gateway-lifecycle). The fixture originated in #127153; the production routing repair from that PR is unchanged.
