### PR TITLE
fix(qa): verify Slack verbose progress privacy

### DIFF
--- a/docs/concepts/qa-e2e-automation.md
+++ b/docs/concepts/qa-e2e-automation.md
@@ -728,12 +728,12 @@ Slack YAML module scenarios (`qa/scenarios/channels/slack-*.yaml`):
   `slack-progress-commentary-verbose-dedupe` / `slack-progress-commentary-verbose-full` - opt-in real-Slack probes for
   independent commentary/tool-progress controls, the omitted-key legacy
   default, and single-delivery behavior for durable verbose progress. The `on`
-  probe requires a safe Exec summary without command text; the `full` probe
-  separately verifies command-marker delivery. Failures retain bounded
+  probe requires a safe Exec summary without command text or output; the `full`
+  probe requires the exact stdout marker in a separate tool-output message.
+  Both use the same command, retain command privacy, and require one commentary
+  identity separate from the final answer. Failures retain bounded
   presentation facts without raw Slack messages or platform identities,
   including marker formatting and `sleep` summaries missing the command marker.
-  Marker absence alone cannot prove redaction if the model omitted the shell
-  comment; the safe-summary assertion and separate `full` probe remain necessary.
 - `slack-reaction-glyph-native` - opt-in live message-tool reaction scenario.
   Instructs the agent to pass the exact `✅` glyph and confirms Slack stored
   `white_check_mark` for the SUT bot on the target message.

--- a/docs/concepts/qa-e2e-automation.md
+++ b/docs/concepts/qa-e2e-automation.md
@@ -730,8 +730,10 @@ Slack YAML module scenarios (`qa/scenarios/channels/slack-*.yaml`):
   default, and single-delivery behavior for durable verbose progress. The `on`
   probe requires a safe Exec summary without command text or output; the `full`
   probe requires the exact stdout marker in a separate tool-output message.
-  Both use the same command, retain command privacy, and require one commentary
-  identity separate from the final answer. Failures retain bounded
+  Both use the same command and require one commentary identity separate from
+  the final answer. Full verbosity allows the runtime's command metadata and
+  one separate start summary, while requiring a unique completed-output identity.
+  Failures retain bounded
   presentation facts without raw Slack messages or platform identities,
   including marker formatting and `sleep` summaries missing the command marker.
 - `slack-reaction-glyph-native` - opt-in live message-tool reaction scenario.

--- a/docs/concepts/qa-e2e-automation.md
+++ b/docs/concepts/qa-e2e-automation.md
@@ -733,6 +733,8 @@ Slack YAML module scenarios (`qa/scenarios/channels/slack-*.yaml`):
   Both use the same command and require one commentary identity separate from
   the final answer. Full verbosity allows the runtime's command metadata and
   one separate start summary, while requiring a unique completed-output identity.
+  Slack may strip command-summary headers during delivery, so the exact output
+  line, not a tool label, identifies completed output.
   Failures retain bounded
   presentation facts without raw Slack messages or platform identities,
   including marker formatting and `sleep` summaries missing the command marker.

--- a/docs/concepts/qa-e2e-automation.md
+++ b/docs/concepts/qa-e2e-automation.md
@@ -725,9 +725,12 @@ Slack YAML module scenarios (`qa/scenarios/channels/slack-*.yaml`):
 - `slack-restart-resume`
 - `slack-progress-commentary-true`, `slack-progress-commentary-false`,
   `slack-progress-commentary-omitted`, and
-  `slack-progress-commentary-verbose-dedupe` - opt-in real-Slack probes for
+  `slack-progress-commentary-verbose-dedupe` / `slack-progress-commentary-verbose-full` - opt-in real-Slack probes for
   independent commentary/tool-progress controls, the omitted-key legacy
-  default, and single-delivery behavior when durable verbose progress is on.
+  default, and single-delivery behavior for durable verbose progress. The `on`
+  probe requires a safe Exec summary without command text; the `full` probe
+  separately verifies command-marker delivery. Failures retain bounded
+  presentation facts without raw Slack messages or platform identities.
 - `slack-reaction-glyph-native` - opt-in live message-tool reaction scenario.
   Instructs the agent to pass the exact `✅` glyph and confirms Slack stored
   `white_check_mark` for the SUT bot on the target message.

--- a/docs/concepts/qa-e2e-automation.md
+++ b/docs/concepts/qa-e2e-automation.md
@@ -730,7 +730,10 @@ Slack YAML module scenarios (`qa/scenarios/channels/slack-*.yaml`):
   default, and single-delivery behavior for durable verbose progress. The `on`
   probe requires a safe Exec summary without command text; the `full` probe
   separately verifies command-marker delivery. Failures retain bounded
-  presentation facts without raw Slack messages or platform identities.
+  presentation facts without raw Slack messages or platform identities,
+  including marker formatting and `sleep` summaries missing the command marker.
+  Marker absence alone cannot prove redaction if the model omitted the shell
+  comment; the safe-summary assertion and separate `full` probe remain necessary.
 - `slack-reaction-glyph-native` - opt-in live message-tool reaction scenario.
   Instructs the agent to pass the exact `✅` glyph and confirms Slack stored
   `white_check_mark` for the SUT bot on the target message.

--- a/extensions/qa-lab/src/live-transports/slack/scenario-runtime.ts
+++ b/extensions/qa-lab/src/live-transports/slack/scenario-runtime.ts
@@ -31,6 +31,7 @@ export {
   slackQaProgressCommentaryOmittedScenario,
   slackQaProgressCommentaryTrueScenario,
   slackQaProgressCommentaryVerboseDedupeScenario,
+  slackQaProgressCommentaryVerboseFullScenario,
   slackQaReactionGlyphNativeScenario,
   slackQaTableInvalidBlocksFallbackScenario,
   slackQaTablePresentationNativeScenario,

--- a/extensions/qa-lab/src/live-transports/slack/slack-live.runtime.test.ts
+++ b/extensions/qa-lab/src/live-transports/slack/slack-live.runtime.test.ts
@@ -672,14 +672,15 @@ describe("Slack live QA runtime helpers", () => {
       const input = run && "input" in run ? run.input : "";
       const commentaryMarker = input.match(/SLACK-QA-COMMENTARY-[0-9A-F]{8}/u)?.[0];
       const toolMarker = input.match(/SLACK-QA-TOOL-[0-9A-F]{8}/u)?.[0];
+      const outputMarker = input.match(/SLACK-QA-OUTPUT-[0-9A-F]{8}/u)?.[0];
       const finalMarker = input.match(/SLACK-QA-COMMENTARY-DONE-[0-9A-F]{8}/u)?.[0];
       const verifyObserved = run && "verifyObserved" in run ? run.verifyObserved : undefined;
-      if (!commentaryMarker || !toolMarker || !finalMarker || !verifyObserved) {
+      if (!commentaryMarker || !toolMarker || !outputMarker || !finalMarker || !verifyObserved) {
         throw new Error(`missing Slack progress verifier: ${testCase.id}`);
       }
       // Progress cards compact command details from the middle, so the QA marker
       // stays at the command suffix where the real Slack presentation preserves it.
-      expect(input).toContain(`run: sleep 5 # ${toolMarker}.`);
+      expect(input).toContain(`sleep 5; printf '%s\\n' '${outputMarker}' # ${toolMarker}`);
       const messages = [
         {
           channelId: "C123456789",
@@ -692,7 +693,7 @@ describe("Slack live QA runtime helpers", () => {
                 channelId: "C123456789",
                 text: testCase.commentaryStyle === "lane" ? "Working…" : commentaryMarker,
                 ...(testCase.commentaryStyle === "lane"
-                  ? { blockText: [`• *Update* — ${commentaryMarker}`] }
+                  ? { blockText: [`• *Commentary* — _${commentaryMarker}_`] }
                   : {}),
                 ts: testCase.commentaryTs,
               },
@@ -706,7 +707,9 @@ describe("Slack live QA runtime helpers", () => {
                 text:
                   testCase.toolProgress === "standalone-redacted"
                     ? "🛠️ Exec"
-                    : `🛠️ Exec ${toolMarker}`,
+                    : testCase.toolProgress === "standalone"
+                      ? `🛠️ Exec\n\`\`\`\n${outputMarker}\n\`\`\``
+                      : `🛠️ Exec ${toolMarker}`,
                 ts: testCase.toolProgress === "draft" ? "1.500000" : "1.750000",
               },
             ]),
@@ -720,7 +723,7 @@ describe("Slack live QA runtime helpers", () => {
     }
   });
 
-  it("classifies only exact Slack commentary lane presentations", () => {
+  it("recognizes exact commentary rows within Slack progress cards", () => {
     const scenario = testing.findScenario(["slack-progress-commentary-true"])[0];
     const run = scenario?.buildRun("U999999999");
     const input = run && "input" in run ? run.input : "";
@@ -751,16 +754,33 @@ describe("Slack live QA runtime helpers", () => {
       { text: `_${commentaryMarker}_` },
       { text: ` \n_${commentaryMarker}_\t` },
       { text: `💬 ${commentaryMarker}` },
-      { blockText: [`• *Update* — ${commentaryMarker}`], text: "Working…" },
+      { text: `:speech_balloon: ${commentaryMarker}` },
+      { text: `_${commentaryMarker}_\n_more commentary_` },
+      {
+        blockText: [
+          `✅ *Working*`,
+          `• *Commentary* — _${commentaryMarker}_\n• *Commentary* — _another note_`,
+        ],
+        text: "Working…",
+      },
+      {
+        blockText: [
+          `• *Commentary* — _${commentaryMarker}_\n• *Commentary* — _${commentaryMarker}_`,
+        ],
+        text: "Working…",
+      },
     ]) {
       expect(() => verifyCommentaryMessage(message)).not.toThrow();
     }
-    for (const text of [
-      commentaryMarker,
-      `prefix _${commentaryMarker}_ suffix`,
-      `_${commentaryMarker}_\nmore`,
+    for (const message of [
+      { text: commentaryMarker },
+      { text: `prefix _${commentaryMarker}_ suffix` },
+      { text: `💬 ${commentaryMarker} extra prose` },
+      { text: "Working…", blockText: [`• *Exec* — _${commentaryMarker}_`] },
+      { text: "Working…", blockText: [`• *Commentary* — _${commentaryMarker} extra prose_`] },
+      { text: "Working…", blockText: [`• *Update* — ${commentaryMarker}`] },
     ]) {
-      expect(() => verifyCommentaryMessage({ text })).toThrow(
+      expect(() => verifyCommentaryMessage(message)).toThrow(
         "expected commentary in the Slack progress commentary lane",
       );
     }
@@ -885,9 +905,13 @@ describe("Slack live QA runtime helpers", () => {
     },
   );
 
-  it.each([false, true])(
-    "rejects command details in verbose-on progress (final edit: %s)",
-    (finalEdit) => {
+  it.each(
+    [false, true].flatMap((finalEdit) =>
+      ["TOOL", "OUTPUT"].map((markerKind) => ({ finalEdit, markerKind })),
+    ),
+  )(
+    "rejects $markerKind disclosure in verbose-on progress (final edit: $finalEdit)",
+    ({ finalEdit, markerKind }) => {
       const run = testing
         .findScenario(["slack-progress-commentary-verbose-dedupe"])[0]
         ?.buildRun("U_SUT");
@@ -895,7 +919,7 @@ describe("Slack live QA runtime helpers", () => {
         throw new Error("expected Slack progress message scenario");
       }
       const commentary = run.input.match(/SLACK-QA-COMMENTARY-[0-9A-F]{8}/u)?.[0];
-      const tool = run.input.match(/SLACK-QA-TOOL-[0-9A-F]{8}/u)?.[0];
+      const tool = run.input.match(new RegExp(`SLACK-QA-${markerKind}-[0-9A-F]{8}`, "u"))?.[0];
       expect(() =>
         run.verifyObserved?.({
           finalMessage: { text: run.matchText, ts: "3" },
@@ -909,9 +933,57 @@ describe("Slack live QA runtime helpers", () => {
             { channelId: "C123456789", text: run.matchText, ts: "3" },
           ],
         }),
-      ).toThrow("command details must stay hidden in verbose-on progress");
+      ).toThrow("command details and output must stay hidden in verbose-on progress");
     },
   );
+
+  it("requires actual full tool output instead of echoed command metadata", () => {
+    const run = testing
+      .findScenario(["slack-progress-commentary-verbose-full"])[0]
+      ?.buildRun("U_SUT");
+    if (!run || !("input" in run) || !run.verifyObserved) {
+      throw new Error("expected Slack progress message scenario");
+    }
+    const commentary = run.input.match(/SLACK-QA-COMMENTARY-[0-9A-F]{8}/u)?.[0];
+    const output = run.input.match(/SLACK-QA-OUTPUT-[0-9A-F]{8}/u)?.[0];
+    const command = run.input.match(/SLACK-QA-TOOL-[0-9A-F]{8}/u)?.[0];
+    const verify = (toolMessages: Array<{ text: string; ts: string }>) =>
+      run.verifyObserved?.({
+        finalMessage: { text: run.matchText, ts: "final" },
+        messages: [
+          { channelId: "C123456789", text: `💬 ${commentary}`, ts: "commentary" },
+          ...toolMessages.map((message) => ({ channelId: "C123456789", ...message })),
+          { channelId: "C123456789", text: run.matchText, ts: "final" },
+        ],
+      });
+    expect(() => verify([{ text: `🛠️ Exec: printf '${output}'`, ts: "tool" }])).toThrow(
+      "expected exact tool output",
+    );
+    expect(() => verify([{ text: output ?? "", ts: "tool" }])).toThrow(
+      "expected exact tool output",
+    );
+    expect(() => verify([{ text: `🛠️ Exec: # ${command}\n${output}`, ts: "tool" }])).toThrow(
+      "command details must stay hidden",
+    );
+    expect(() =>
+      verify([
+        { text: `🛠️ Exec\n${output}`, ts: "tool-1" },
+        { text: `🛠️ Exec\n${output}`, ts: "tool-2" },
+      ]),
+    ).toThrow("expected exact tool output in one standalone verbose message");
+    expect(() =>
+      verify([
+        { text: "🛠️ Exec", ts: "summary" },
+        { text: `🛠️ Exec\n${output}`, ts: "output" },
+      ]),
+    ).toThrow("expected exact tool output in one standalone verbose message");
+    expect(() =>
+      verify([
+        { text: "🛠️ Exec", ts: "tool" },
+        { text: `🛠️ Exec\n\`\`\`\n${output}\n\`\`\``, ts: "tool" },
+      ]),
+    ).not.toThrow();
+  });
 
   it.each(["slack-progress-commentary-verbose-dedupe", "slack-progress-commentary-verbose-full"])(
     "rejects absent or merged standalone tool identities for %s",
@@ -921,7 +993,7 @@ describe("Slack live QA runtime helpers", () => {
         throw new Error("expected Slack progress message scenario");
       }
       const commentary = run.input.match(/SLACK-QA-COMMENTARY-[0-9A-F]{8}/u)?.[0];
-      const tool = run.input.match(/SLACK-QA-TOOL-[0-9A-F]{8}/u)?.[0];
+      const output = run.input.match(/SLACK-QA-OUTPUT-[0-9A-F]{8}/u)?.[0];
       for (const toolTs of [undefined, "1", "3"]) {
         expect(() =>
           run.verifyObserved?.({
@@ -932,7 +1004,7 @@ describe("Slack live QA runtime helpers", () => {
                 ? [
                     {
                       channelId: "C123456789",
-                      text: scenarioId.endsWith("-full") ? `🛠️ Exec ${tool}` : "🛠️ Exec",
+                      text: scenarioId.endsWith("-full") ? `🛠️ Exec\n${output}` : "🛠️ Exec",
                       ts: toolTs,
                     },
                   ]

--- a/extensions/qa-lab/src/live-transports/slack/slack-live.runtime.test.ts
+++ b/extensions/qa-lab/src/live-transports/slack/slack-live.runtime.test.ts
@@ -379,6 +379,7 @@ describe("Slack live QA runtime helpers", () => {
       "slack-progress-commentary-false",
       "slack-progress-commentary-omitted",
       "slack-progress-commentary-verbose-dedupe",
+      "slack-progress-commentary-verbose-full",
       "slack-reaction-glyph-native",
       "slack-approval-exec-native",
       "slack-approval-plugin-native",
@@ -622,6 +623,10 @@ describe("Slack live QA runtime helpers", () => {
       buildScenarioConfig("slack-progress-commentary-verbose-dedupe").agents?.defaults
         ?.verboseDefault,
     ).toBe("on");
+    expect(
+      buildScenarioConfig("slack-progress-commentary-verbose-full").agents?.defaults
+        ?.verboseDefault,
+    ).toBe("full");
     expect(buildScenarioConfig("slack-progress-commentary-true").agents?.list?.[0]?.identity).toBe(
       undefined,
     );
@@ -649,6 +654,12 @@ describe("Slack live QA runtime helpers", () => {
       },
       {
         id: "slack-progress-commentary-verbose-dedupe",
+        commentaryTs: "1.500000",
+        commentaryStyle: "standalone",
+        toolProgress: "standalone-redacted",
+      },
+      {
+        id: "slack-progress-commentary-verbose-full",
         commentaryTs: "1.500000",
         commentaryStyle: "standalone",
         toolProgress: "standalone",
@@ -692,7 +703,10 @@ describe("Slack live QA runtime helpers", () => {
           : [
               {
                 channelId: "C123456789",
-                text: `🛠️ Exec ${toolMarker}`,
+                text:
+                  testCase.toolProgress === "standalone-redacted"
+                    ? "🛠️ Exec"
+                    : `🛠️ Exec ${toolMarker}`,
                 ts: testCase.toolProgress === "draft" ? "1.500000" : "1.750000",
               },
             ]),
@@ -837,35 +851,132 @@ describe("Slack live QA runtime helpers", () => {
     ).toThrow("exactly one Slack message identity containing commentary");
   });
 
-  it("accepts one standalone commentary identity even when Slack prefixes it as commentary", () => {
-    const scenario = testing.findScenario(["slack-progress-commentary-verbose-dedupe"])[0];
-    const run = scenario?.buildRun("U_SUT");
-    if (
-      !run ||
-      run.kind === "approval" ||
-      run.kind === "codex-approval" ||
-      run.kind === "direct-transport" ||
-      !run.verifyObserved
-    ) {
-      throw new Error("expected Slack commentary message scenario");
-    }
-    const commentaryMarker = run.input.match(/SLACK-QA-COMMENTARY-[0-9A-F]{8}/u)?.[0];
-    const toolMarker = run.input.match(/SLACK-QA-TOOL-[0-9A-F]{8}/u)?.[0];
-    const finalMarker = run.input.match(/SLACK-QA-COMMENTARY-DONE-[0-9A-F]{8}/u)?.[0];
-    if (!commentaryMarker || !toolMarker || !finalMarker) {
-      throw new Error("missing Slack progress markers");
-    }
+  it.each(["🛠️ Exec", ":hammer_and_wrench: Exec"])(
+    "accepts standalone commentary and the safe verbose tool summary %s",
+    (toolText) => {
+      const scenario = testing.findScenario(["slack-progress-commentary-verbose-dedupe"])[0];
+      const run = scenario?.buildRun("U_SUT");
+      if (
+        !run ||
+        run.kind === "approval" ||
+        run.kind === "codex-approval" ||
+        run.kind === "direct-transport" ||
+        !run.verifyObserved
+      ) {
+        throw new Error("expected Slack commentary message scenario");
+      }
+      const commentaryMarker = run.input.match(/SLACK-QA-COMMENTARY-[0-9A-F]{8}/u)?.[0];
+      const toolMarker = run.input.match(/SLACK-QA-TOOL-[0-9A-F]{8}/u)?.[0];
+      const finalMarker = run.input.match(/SLACK-QA-COMMENTARY-DONE-[0-9A-F]{8}/u)?.[0];
+      if (!commentaryMarker || !toolMarker || !finalMarker) {
+        throw new Error("missing Slack progress markers");
+      }
 
-    expect(() =>
-      run.verifyObserved?.({
-        finalMessage: { text: finalMarker, ts: "3.000000" },
+      expect(() =>
+        run.verifyObserved?.({
+          finalMessage: { text: finalMarker, ts: "3.000000" },
+          messages: [
+            { channelId: "C123456789", text: `💬 ${commentaryMarker}`, ts: "1.000000" },
+            { channelId: "C123456789", text: toolText, ts: "2.000000" },
+            { channelId: "C123456789", text: finalMarker, ts: "3.000000" },
+          ],
+        }),
+      ).not.toThrow();
+    },
+  );
+
+  it.each([false, true])(
+    "rejects command details in verbose-on progress (final edit: %s)",
+    (finalEdit) => {
+      const run = testing
+        .findScenario(["slack-progress-commentary-verbose-dedupe"])[0]
+        ?.buildRun("U_SUT");
+      if (!run || !("input" in run) || !run.verifyObserved) {
+        throw new Error("expected Slack progress message scenario");
+      }
+      const commentary = run.input.match(/SLACK-QA-COMMENTARY-[0-9A-F]{8}/u)?.[0];
+      const tool = run.input.match(/SLACK-QA-TOOL-[0-9A-F]{8}/u)?.[0];
+      expect(() =>
+        run.verifyObserved?.({
+          finalMessage: { text: run.matchText, ts: "3" },
+          messages: [
+            { channelId: "C123456789", text: `💬 ${commentary}`, ts: "1" },
+            {
+              channelId: "C123456789",
+              text: finalEdit ? `${tool} ${run.matchText}` : `🛠️ Exec ${tool}`,
+              ts: finalEdit ? "3" : "2",
+            },
+            { channelId: "C123456789", text: run.matchText, ts: "3" },
+          ],
+        }),
+      ).toThrow("command details must stay hidden in verbose-on progress");
+    },
+  );
+
+  it.each(["slack-progress-commentary-verbose-dedupe", "slack-progress-commentary-verbose-full"])(
+    "rejects absent or merged standalone tool identities for %s",
+    (scenarioId) => {
+      const run = testing.findScenario([scenarioId])[0]?.buildRun("U_SUT");
+      if (!run || !("input" in run) || !run.verifyObserved) {
+        throw new Error("expected Slack progress message scenario");
+      }
+      const commentary = run.input.match(/SLACK-QA-COMMENTARY-[0-9A-F]{8}/u)?.[0];
+      const tool = run.input.match(/SLACK-QA-TOOL-[0-9A-F]{8}/u)?.[0];
+      for (const toolTs of [undefined, "1", "3"]) {
+        expect(() =>
+          run.verifyObserved?.({
+            finalMessage: { text: run.matchText, ts: "3" },
+            messages: [
+              { channelId: "C123456789", text: `💬 ${commentary}`, ts: "1" },
+              ...(toolTs
+                ? [
+                    {
+                      channelId: "C123456789",
+                      text: scenarioId.endsWith("-full") ? `🛠️ Exec ${tool}` : "🛠️ Exec",
+                      ts: toolTs,
+                    },
+                  ]
+                : []),
+              { channelId: "C123456789", text: run.matchText, ts: "3" },
+            ],
+          }),
+        ).toThrow("standalone verbose message");
+      }
+    },
+  );
+
+  it("reports bounded presentation facts without raw Slack text or identities", () => {
+    const run = testing.findScenario(["slack-progress-commentary-true"])[0]?.buildRun("U_SUT");
+    if (!run || !("input" in run) || !run.verifyObserved) {
+      throw new Error("expected Slack progress message scenario");
+    }
+    const commentary = run.input.match(/SLACK-QA-COMMENTARY-[0-9A-F]{8}/u)?.[0];
+    const privateText = "private-observation-sentinel";
+    const privateId = "private-message-identity";
+    let failure = "";
+    try {
+      run.verifyObserved({
+        finalMessage: { text: run.matchText, ts: "final" },
         messages: [
-          { channelId: "C123456789", text: `💬 ${commentaryMarker}`, ts: "1.000000" },
-          { channelId: "C123456789", text: toolMarker, ts: "2.000000" },
-          { channelId: "C123456789", text: finalMarker, ts: "3.000000" },
+          ...Array.from({ length: 40 }, (_, index) => ({
+            channelId: "C123456789",
+            text: index === 39 ? `:speech_balloon: ${commentary}` : `${privateText} ${commentary}`,
+            blockText: [`• *Commentary* — _${commentary}_`, privateText.repeat(1_000)],
+            ts: privateId,
+          })),
+          { channelId: "C123456789", text: run.matchText, ts: "final" },
         ],
-      }),
-    ).not.toThrow();
+      });
+    } catch (error) {
+      failure = String(error);
+    }
+    expect(failure).toContain("expected commentary in the Slack progress commentary lane");
+    expect(failure).toContain("presentation=");
+    expect(failure).toContain('"colonCommentary":true');
+    expect(failure).not.toContain(privateText);
+    expect(failure).not.toContain(privateId);
+    expect(failure).not.toContain(commentary);
+    expect(failure.length).toBeLessThan(4_000);
   });
 
   it("settles complete channel and thread observations after the final reply", async () => {

--- a/extensions/qa-lab/src/live-transports/slack/slack-live.runtime.test.ts
+++ b/extensions/qa-lab/src/live-transports/slack/slack-live.runtime.test.ts
@@ -968,9 +968,9 @@ describe("Slack live QA runtime helpers", () => {
     expect(() => verify([{ text: output ?? "", ts: "tool" }])).toThrow(
       "expected exact tool output",
     );
-    expect(() => verify([{ text: `🛠️ Exec: # ${command}\n${output}`, ts: "tool" }])).toThrow(
-      "command details must stay hidden",
-    );
+    expect(() =>
+      verify([{ text: `🛠️ Run command: # ${command}\n${output}`, ts: "tool" }]),
+    ).not.toThrow();
     expect(() =>
       verify([
         { text: `🛠️ Exec\n${output}`, ts: "tool-1" },
@@ -979,10 +979,19 @@ describe("Slack live QA runtime helpers", () => {
     ).toThrow("expected exact tool output in one standalone verbose message");
     expect(() =>
       verify([
-        { text: "🛠️ Exec", ts: "summary" },
-        { text: `🛠️ Exec\n${output}`, ts: "output" },
+        { text: "🛠️ run sleep → print text", ts: "summary" },
+        { text: `🛠️ run sleep → print text\n${output}`, ts: "output" },
       ]),
-    ).toThrow("expected exact tool output in one standalone verbose message");
+    ).not.toThrow();
+    expect(() =>
+      verify([
+        { text: "🛠️ run sleep → print text", ts: "summary-1" },
+        { text: "🛠️ run sleep → print text", ts: "summary-2" },
+        { text: `🛠️ run sleep → print text\n${output}`, ts: "output" },
+      ]),
+    ).toThrow(
+      "expected exact tool output in one standalone verbose message and at most one summary",
+    );
     expect(() =>
       verify([
         { text: "🛠️ Exec", ts: "tool" },
@@ -990,6 +999,30 @@ describe("Slack live QA runtime helpers", () => {
       ]),
     ).not.toThrow();
   });
+
+  it.each(["🛠️ run sleep → print text", "🛠️ Exec\nunmarked output"])(
+    "rejects verbose-on metadata or output updates without protocol markers: %s",
+    (text) => {
+      const run = testing
+        .findScenario(["slack-progress-commentary-verbose-dedupe"])[0]
+        ?.buildRun("U_SUT");
+      if (!run || !("input" in run) || !run.verifyObserved) {
+        throw new Error("expected Slack progress message scenario");
+      }
+      const commentary = run.input.match(/SLACK-QA-COMMENTARY-[0-9A-F]{8}/u)?.[0];
+      expect(() =>
+        run.verifyObserved?.({
+          finalMessage: { text: run.matchText, ts: "final" },
+          messages: [
+            { channelId: "C123456789", text: `💬 ${commentary}`, ts: "commentary" },
+            { channelId: "C123456789", text: "🛠️ Exec", ts: "tool" },
+            { channelId: "C123456789", text, ts: "tool" },
+            { channelId: "C123456789", text: run.matchText, ts: "final" },
+          ],
+        }),
+      ).toThrow("command details and output must stay hidden in verbose-on progress");
+    },
+  );
 
   it.each(["slack-progress-commentary-verbose-dedupe", "slack-progress-commentary-verbose-full"])(
     "rejects absent or merged standalone tool identities for %s",

--- a/extensions/qa-lab/src/live-transports/slack/slack-live.runtime.test.ts
+++ b/extensions/qa-lab/src/live-transports/slack/slack-live.runtime.test.ts
@@ -1,4 +1,5 @@
 // Qa Lab tests cover slack live plugin behavior.
+import { sanitizeAssistantVisibleText } from "openclaw/plugin-sdk/text-chunking";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { readQaScenarioById } from "../../scenario-catalog.js";
 import { requireFlowScenario } from "../../scenario-catalog.test-utils.js";
@@ -965,9 +966,18 @@ describe("Slack live QA runtime helpers", () => {
     expect(() => verify([{ text: `🛠️ Exec: printf '${output}'`, ts: "tool" }])).toThrow(
       "expected exact tool output",
     );
-    expect(() => verify([{ text: output ?? "", ts: "tool" }])).toThrow(
+    expect(() => verify([{ text: `🛠️ ${output}`, ts: "tool" }])).toThrow(
       "expected exact tool output",
     );
+    // Slack's monitor transform removes compact command headers before delivery.
+    const summary = `🛠️ \`sleep 5; printf '%s\\n' '${output}' # ${command}\``;
+    const deliveredOutput = sanitizeAssistantVisibleText(
+      `${summary}\n\`\`\`txt\n${output}\n\`\`\``,
+    );
+    expect(sanitizeAssistantVisibleText(summary)).toBe("");
+    expect(deliveredOutput).toBe(`\`\`\`txt\n${output}\n\`\`\``);
+    expect(() => verify([{ text: deliveredOutput, ts: "tool" }])).not.toThrow();
+    expect(() => verify([{ text: output ?? "", ts: "tool" }])).not.toThrow();
     expect(() =>
       verify([{ text: `🛠️ Run command: # ${command}\n${output}`, ts: "tool" }]),
     ).not.toThrow();

--- a/extensions/qa-lab/src/live-transports/slack/slack-live.runtime.test.ts
+++ b/extensions/qa-lab/src/live-transports/slack/slack-live.runtime.test.ts
@@ -960,9 +960,9 @@ describe("Slack live QA runtime helpers", () => {
         messages: [
           ...Array.from({ length: 40 }, (_, index) => ({
             channelId: "C123456789",
-            text: index === 39 ? `:speech_balloon: ${commentary}` : `${privateText} ${commentary}`,
+            text: `:speech_balloon: ${commentary} ${privateText}\n${privateText}`,
             blockText: [`• *Commentary* — _${commentary}_`, privateText.repeat(1_000)],
-            ts: privateId,
+            ts: `${privateId}-${index}`,
           })),
           { channelId: "C123456789", text: run.matchText, ts: "final" },
         ],
@@ -970,12 +970,68 @@ describe("Slack live QA runtime helpers", () => {
     } catch (error) {
       failure = String(error);
     }
-    expect(failure).toContain("expected commentary in the Slack progress commentary lane");
+    expect(failure).toContain("expected exactly one Slack message identity containing commentary");
     expect(failure).toContain("presentation=");
-    expect(failure).toContain('"colonCommentary":true');
+    expect(failure).toContain('"text":"emoji/other"');
+    expect(JSON.parse(failure.split("presentation=")[1] ?? "[]")).toHaveLength(16);
     expect(failure).not.toContain(privateText);
     expect(failure).not.toContain(privateId);
     expect(failure).not.toContain(commentary);
+    expect(failure.length).toBeLessThan(4_000);
+  });
+
+  it("distinguishes marker envelopes and missing command comments without retaining text", () => {
+    const run = testing.findScenario(["slack-progress-commentary-true"])[0]?.buildRun("U_SUT");
+    if (!run || !("input" in run) || !run.verifyObserved) {
+      throw new Error("expected Slack progress message scenario");
+    }
+    const commentary = run.input.match(/SLACK-QA-COMMENTARY-[0-9A-F]{8}/u)?.[0];
+    const presentations = [
+      ["", "", "none/none"],
+      ["**", "**", "bold/bold"],
+      ["_", "_", "italic/italic"],
+      ["\\_", "\\_", "escaped-italic/escaped-italic"],
+      ["`", "`", "code/code"],
+      ["> ", "", "quote/none"],
+      ["• ", "", "bullet/none"],
+      [":speech_balloon: ", "", "emoji/none"],
+    ];
+    let failure = "";
+    try {
+      run.verifyObserved({
+        finalMessage: { text: "invalid final", ts: "final" },
+        messages: [
+          ...presentations.map(([prefix, suffix]) => ({
+            channelId: "C123456789",
+            text: `${prefix}${commentary}${suffix}`,
+            blockText: [`• *Commentary* — _${commentary}_\n_${commentary}_`],
+            ts: "same-private-identity",
+          })),
+          ...Array.from({ length: 40 }, () => ({
+            channelId: "C123456789",
+            text: "🛠️ `sleep 5`",
+            ts: "tool-private-identity",
+          })),
+        ],
+      });
+    } catch (error) {
+      failure = String(error);
+    }
+    const facts = JSON.parse(failure.split("presentation=")[1] ?? "[]");
+    expect(facts).toHaveLength(presentations.length + 1);
+    expect(facts.map((fact: { text: string }) => fact.text)).toEqual([
+      ...presentations.map((presentation) => presentation[2]),
+      "missing",
+    ]);
+    expect(facts[0]).toMatchObject({
+      block: "commentary-row/italic",
+      lines: [1, 2],
+      occurrences: [1, 2],
+    });
+    expect(facts.at(-1)).toMatchObject({ tool: "sleep-without-marker" });
+    expect(failure).not.toContain(commentary);
+    expect(failure).not.toContain("private-identity");
+    expect(failure).not.toContain("sleep 5");
     expect(failure.length).toBeLessThan(4_000);
   });
 

--- a/extensions/qa-lab/src/live-transports/slack/slack-live.runtime.test.ts
+++ b/extensions/qa-lab/src/live-transports/slack/slack-live.runtime.test.ts
@@ -830,13 +830,19 @@ describe("Slack live QA runtime helpers", () => {
         final,
       ]),
     ).toThrow("status headline");
-    expect(
-      verify("slack-progress-commentary-true", ([commentary, tool, final]) => [
-        `💬 ${commentary}`,
-        tool,
-        final,
-      ]),
-    ).toThrow("tool progress to stay out");
+    for (const toolPresentation of ["command", "output", "safe-summary"]) {
+      expect(
+        verify("slack-progress-commentary-true", ([commentary, tool, final]) => [
+          `💬 ${commentary}`,
+          toolPresentation === "command"
+            ? tool
+            : toolPresentation === "output"
+              ? tool.replace("-TOOL-", "-OUTPUT-")
+              : "🛠️ Exec",
+          final,
+        ]),
+      ).toThrow("tool progress to stay out");
+    }
     expect(
       verify("slack-progress-commentary-omitted", ([commentary, , final]) => [commentary, final]),
     ).toThrow("tool progress on the draft");

--- a/extensions/qa-lab/src/live-transports/slack/slack-live.scenario-fixtures.ts
+++ b/extensions/qa-lab/src/live-transports/slack/slack-live.scenario-fixtures.ts
@@ -85,11 +85,20 @@ function hasSlackCommentaryLaneMarker(
   message: { blockText?: string[]; text: string },
   marker: string,
 ) {
-  if (message.text.includes(`💬 ${marker}`) || message.text.trim() === `_${marker}_`) {
+  // A progress card can contain several authored rows within one Slack message.
+  if (
+    message.text
+      .split(/\r?\n/u)
+      .some((line) =>
+        [`💬 ${marker}`, `:speech_balloon: ${marker}`, `_${marker}_`].includes(line.trim()),
+      )
+  ) {
     return true;
   }
   const blockText = message.blockText ?? [];
-  return blockText.some((text) => text.trim() === `• *Update* — ${marker}`);
+  return blockText.some((text) =>
+    text.split(/\r?\n/u).some((line) => line.trim() === `• *Commentary* — _${marker}_`),
+  );
 }
 
 function isSlackSafeExecSummary(message: { text: string }) {
@@ -146,13 +155,14 @@ export function buildSlackProgressCommentaryRun(
   // stay byte-identical across draft edits and final-message reads.
   const commentaryMarker = `SLACK-QA-COMMENTARY-${suffix}`;
   const toolMarker = `SLACK-QA-TOOL-${suffix}`;
+  const outputMarker = `SLACK-QA-OUTPUT-${suffix}`;
   const finalMarker = `SLACK-QA-COMMENTARY-DONE-${suffix}`;
   return {
     expectReply: true,
     input: [
       `<@${sutUserId}> This is a Slack progress protocol test. First, emit an assistant commentary message whose entire text is exactly ${commentaryMarker}.`,
       "Do not call any tool until that commentary message is complete.",
-      `Then use the exec tool exactly once to run: sleep 5 # ${toolMarker}.`,
+      `Then use the exec tool exactly once to run this exact command: \`sleep 5; printf '%s\\n' '${outputMarker}' # ${toolMarker}\`.`,
       `After the command finishes, reply with only this exact marker: ${finalMarker}`,
     ].join(" "),
     matchText: finalMarker,
@@ -241,14 +251,21 @@ export function buildSlackProgressCommentaryRun(
           .map((message) => message.ts),
       );
       if (expectation.toolProgress === "standalone-redacted") {
-        if (messages.some((message) => observedSlackText(message).includes(toolMarker))) {
-          fail("command details must stay hidden in verbose-on progress");
+        if (
+          messages.some((message) =>
+            [toolMarker, outputMarker].some((marker) =>
+              observedSlackText(message).includes(marker),
+            ),
+          )
+        ) {
+          fail("command details and output must stay hidden in verbose-on progress");
         }
         const safeToolTimestamps = new Set(
           progressMessages.filter(isSlackSafeExecSummary).map((message) => message.ts),
         );
         if (
           safeToolTimestamps.size !== 1 ||
+          safeToolTimestamps.has(undefined) ||
           safeToolTimestamps.has(commentaryTs) ||
           safeToolTimestamps.has(finalMessage.ts)
         ) {
@@ -262,12 +279,30 @@ export function buildSlackProgressCommentaryRun(
           fail("expected commentary and tool progress on one Slack draft identity");
         }
       } else if (expectation.toolProgress === "standalone") {
+        if (messages.some((message) => observedSlackText(message).includes(toolMarker))) {
+          fail("command details must stay hidden in standalone channel tool output");
+        }
+        const toolMessages = progressMessages.filter((message) =>
+          isSlackSafeExecSummary({ text: message.text.split(/\r?\n/u)[0] ?? "" }),
+        );
+        const toolMessageTimestamps = new Set(toolMessages.map((message) => message.ts));
+        const outputTimestamps = new Set(
+          toolMessages
+            .filter((message) =>
+              observedSlackText(message)
+                .split(/\r?\n/u)
+                .some((line) => line.trim() === outputMarker),
+            )
+            .map((message) => message.ts),
+        );
         if (
-          toolTimestamps.size === 0 ||
-          toolTimestamps.has(commentaryTs) ||
-          toolTimestamps.has(finalMessage.ts)
+          toolMessageTimestamps.size !== 1 ||
+          outputTimestamps.size !== 1 ||
+          outputTimestamps.has(undefined) ||
+          outputTimestamps.has(commentaryTs) ||
+          outputTimestamps.has(finalMessage.ts)
         ) {
-          fail("expected tool progress only in standalone verbose messages");
+          fail("expected exact tool output in one standalone verbose message");
         }
       } else if (toolTimestamps.size !== 0) {
         fail("expected tool progress to stay out of Slack progress messages");

--- a/extensions/qa-lab/src/live-transports/slack/slack-live.scenario-fixtures.ts
+++ b/extensions/qa-lab/src/live-transports/slack/slack-live.scenario-fixtures.ts
@@ -97,6 +97,46 @@ function isSlackSafeExecSummary(message: { text: string }) {
   return /^(?:🛠️|:hammer_and_wrench:) Exec$/u.test(message.text.trim());
 }
 
+function slackMarkerEnvelope(text: string, marker: string) {
+  const line = text.split(/\r?\n/u).find((value) => value.includes(marker));
+  if (line === undefined) {
+    return "missing";
+  }
+  const index = line.indexOf(marker);
+  const classify = (value: string) => {
+    const edge = value.trim();
+    if (!edge) {
+      return "none";
+    }
+    if (/^(?:•\s+)?\*Commentary\*\s+—\s*_?$/u.test(edge)) {
+      return "commentary-row";
+    }
+    if (/^(?:•\s+)?\*Update\*\s+—\s*$/u.test(edge)) {
+      return "update-row";
+    }
+    if (/^(?:💬|:speech_balloon:)$/u.test(edge)) {
+      return "emoji";
+    }
+    if (edge === "\\_") {
+      return "escaped-italic";
+    }
+    if (edge === "_") {
+      return "italic";
+    }
+    if (/^\*{1,2}$/u.test(edge)) {
+      return "bold";
+    }
+    if (/^`{1,3}$/u.test(edge)) {
+      return "code";
+    }
+    if (/^>+$/u.test(edge)) {
+      return "quote";
+    }
+    return /^[•+-]$/u.test(edge) ? "bullet" : "other";
+  };
+  return `${classify(line.slice(0, index))}/${classify(line.slice(index + marker.length))}`;
+}
+
 export function buildSlackProgressCommentaryRun(
   sutUserId: string,
   expectation: SlackProgressCommentaryExpectation,
@@ -122,26 +162,38 @@ export function buildSlackProgressCommentaryRun(
         const identities = new Map<string, number>();
         // Failure artifacts may be public. Emit only closed presentation facts,
         // never message text, platform ids, command text, or credential fields.
-        const presentation = messages.slice(-16).map((message) => {
+        const presentation = new Set<string>();
+        for (const message of messages) {
           if (message.ts && !identities.has(message.ts)) {
             identities.set(message.ts, identities.size + 1);
           }
-          const text = message.text.trim();
-          return {
+          const texts = [message.text, (message.blockText ?? []).join("\n")];
+          const observedText = observedSlackText(message);
+          const facts = JSON.stringify({
             identity: message.ts ? identities.get(message.ts) : 0,
-            final: observedSlackText(message).includes(finalMarker),
-            commentary: observedSlackText(message).includes(commentaryMarker),
-            commentaryLane: hasSlackCommentaryLaneMarker(message, commentaryMarker),
-            bareCommentary: text === commentaryMarker,
-            colonCommentary: text === `:speech_balloon: ${commentaryMarker}`,
-            typedCommentaryBlock: (message.blockText ?? []).some(
-              (line) => line.trim() === `• *Commentary* — _${commentaryMarker}_`,
-            ),
-            safeExec: isSlackSafeExecSummary(message),
-            commandMarker: observedSlackText(message).includes(toolMarker),
-          };
-        });
-        throw new Error(`${reason}; presentation=${JSON.stringify(presentation)}`);
+            final: observedText.includes(finalMarker),
+            lane: hasSlackCommentaryLaneMarker(message, commentaryMarker),
+            text: slackMarkerEnvelope(texts[0]!, commentaryMarker),
+            block: slackMarkerEnvelope(texts[1]!, commentaryMarker),
+            lines: texts.map((text) => (text ? Math.min(9, text.split(/\r?\n/u).length) : 0)),
+            occurrences: texts.map((text) => Math.min(2, text.split(commentaryMarker).length - 1)),
+            tool: observedText.includes(toolMarker)
+              ? "command-marker"
+              : isSlackSafeExecSummary(message)
+                ? "safe-exec"
+                : /\bsleep\s+5\b/u.test(observedText)
+                  ? "sleep-without-marker"
+                  : "other",
+          });
+          // Repeated history polls must not crowd the distinct captured writes
+          // out of the bounded failure artifact. Assertions still see every write.
+          presentation.delete(facts);
+          presentation.add(facts);
+          if (presentation.size > 16) {
+            presentation.delete(presentation.values().next().value!);
+          }
+        }
+        throw new Error(`${reason}; presentation=[${[...presentation].join(",")}]`);
       }
       if (!finalMessage.ts) {
         fail("Slack progress commentary final message had no ts");

--- a/extensions/qa-lab/src/live-transports/slack/slack-live.scenario-fixtures.ts
+++ b/extensions/qa-lab/src/live-transports/slack/slack-live.scenario-fixtures.ts
@@ -106,6 +106,11 @@ function isSlackSafeExecSummary(message: { text: string }) {
   return /^(?:🛠️|:hammer_and_wrench:) Exec$/u.test(message.text.trim());
 }
 
+function hasSlackExecHeader(message: { text: string }) {
+  // Full output includes the runtime's command-derived label after the Exec glyph.
+  return /^(?:🛠️|:hammer_and_wrench:) \S.*$/u.test(message.text.split(/\r?\n/u)[0]?.trim() ?? "");
+}
+
 function slackMarkerEnvelope(text: string, marker: string) {
   const line = text.split(/\r?\n/u).find((value) => value.includes(marker));
   if (line === undefined) {
@@ -187,6 +192,10 @@ export function buildSlackProgressCommentaryRun(
             block: slackMarkerEnvelope(texts[1]!, commentaryMarker),
             lines: texts.map((text) => (text ? Math.min(9, text.split(/\r?\n/u).length) : 0)),
             occurrences: texts.map((text) => Math.min(2, text.split(commentaryMarker).length - 1)),
+            output: texts.map((text) =>
+              text.split(/\r?\n/u).some((line) => line.trim() === outputMarker),
+            ),
+            execHeader: hasSlackExecHeader(message),
             tool: observedText.includes(toolMarker)
               ? "command-marker"
               : isSlackSafeExecSummary(message)
@@ -251,16 +260,18 @@ export function buildSlackProgressCommentaryRun(
             (message) =>
               [toolMarker, outputMarker].some((marker) =>
                 observedSlackText(message).includes(marker),
-              ) || isSlackSafeExecSummary({ text: message.text.split(/\r?\n/u)[0] ?? "" }),
+              ) || hasSlackExecHeader(message),
           )
           .map((message) => message.ts),
       );
       if (expectation.toolProgress === "standalone-redacted") {
         if (
-          messages.some((message) =>
-            [toolMarker, outputMarker].some((marker) =>
-              observedSlackText(message).includes(marker),
-            ),
+          messages.some(
+            (message) =>
+              [toolMarker, outputMarker].some((marker) =>
+                observedSlackText(message).includes(marker),
+              ) ||
+              (hasSlackExecHeader(message) && !isSlackSafeExecSummary(message)),
           )
         ) {
           fail("command details and output must stay hidden in verbose-on progress");
@@ -283,28 +294,30 @@ export function buildSlackProgressCommentaryRun(
           fail("expected commentary and tool progress on one Slack draft identity");
         }
       } else if (expectation.toolProgress === "standalone") {
-        if (messages.some((message) => observedSlackText(message).includes(toolMarker))) {
-          fail("command details must stay hidden in standalone channel tool output");
-        }
-        const toolMessages = progressMessages.filter((message) =>
-          isSlackSafeExecSummary({ text: message.text.split(/\r?\n/u)[0] ?? "" }),
-        );
+        const toolMessages = progressMessages.filter(hasSlackExecHeader);
+        const hasOutputLine = (message: (typeof toolMessages)[number]) =>
+          observedSlackText(message)
+            .split(/\r?\n/u)
+            .some((line) => line.trim() === outputMarker);
         const outputTimestamps = new Set(
+          toolMessages.filter(hasOutputLine).map((message) => message.ts),
+        );
+        // The built-in runtime sends a summary at tool start and output at completion.
+        const summaryTimestamps = new Set(
           toolMessages
-            .filter((message) =>
-              observedSlackText(message)
-                .split(/\r?\n/u)
-                .some((line) => line.trim() === outputMarker),
-            )
+            .filter((message) => !hasOutputLine(message) && !/[\r\n]/u.test(message.text.trim()))
             .map((message) => message.ts),
         );
         if (
-          toolTimestamps.size !== 1 ||
           outputTimestamps.size !== 1 ||
-          outputTimestamps.has(commentaryTs) ||
-          outputTimestamps.has(finalMessage.ts)
+          summaryTimestamps.size > 1 ||
+          toolTimestamps.size !== new Set([...outputTimestamps, ...summaryTimestamps]).size ||
+          toolTimestamps.has(commentaryTs) ||
+          toolTimestamps.has(finalMessage.ts)
         ) {
-          fail("expected exact tool output in one standalone verbose message");
+          fail(
+            "expected exact tool output in one standalone verbose message and at most one summary",
+          );
         }
       } else if (toolTimestamps.size !== 0) {
         fail("expected tool progress to stay out of Slack progress messages");

--- a/extensions/qa-lab/src/live-transports/slack/slack-live.scenario-fixtures.ts
+++ b/extensions/qa-lab/src/live-transports/slack/slack-live.scenario-fixtures.ts
@@ -299,8 +299,9 @@ export function buildSlackProgressCommentaryRun(
           observedSlackText(message)
             .split(/\r?\n/u)
             .some((line) => line.trim() === outputMarker);
+        // Slack's delivery transform can strip command headers while retaining output.
         const outputTimestamps = new Set(
-          toolMessages.filter(hasOutputLine).map((message) => message.ts),
+          progressMessages.filter(hasOutputLine).map((message) => message.ts),
         );
         // The built-in runtime sends a summary at tool start and output at completion.
         const summaryTimestamps = new Set(

--- a/extensions/qa-lab/src/live-transports/slack/slack-live.scenario-fixtures.ts
+++ b/extensions/qa-lab/src/live-transports/slack/slack-live.scenario-fixtures.ts
@@ -74,7 +74,7 @@ export function renderSlackTableAccessibleText(summaryText: string) {
 
 type SlackProgressCommentaryExpectation = {
   commentary: "headline" | "lane" | "standalone";
-  toolProgress: "absent" | "draft" | "standalone";
+  toolProgress: "absent" | "draft" | "standalone" | "standalone-redacted";
 };
 
 function observedSlackText(message: { blockText?: string[]; text: string }) {
@@ -90,6 +90,11 @@ function hasSlackCommentaryLaneMarker(
   }
   const blockText = message.blockText ?? [];
   return blockText.some((text) => text.trim() === `• *Update* — ${marker}`);
+}
+
+function isSlackSafeExecSummary(message: { text: string }) {
+  // Slack history converts Unicode emoji to colon names; captured writes retain Unicode.
+  return /^(?:🛠️|:hammer_and_wrench:) Exec$/u.test(message.text.trim());
 }
 
 export function buildSlackProgressCommentaryRun(
@@ -113,11 +118,36 @@ export function buildSlackProgressCommentaryRun(
     matchText: finalMarker,
     settleObservedMs: 3_000,
     verifyObserved: ({ finalMessage, messages }) => {
+      function fail(reason: string): never {
+        const identities = new Map<string, number>();
+        // Failure artifacts may be public. Emit only closed presentation facts,
+        // never message text, platform ids, command text, or credential fields.
+        const presentation = messages.slice(-16).map((message) => {
+          if (message.ts && !identities.has(message.ts)) {
+            identities.set(message.ts, identities.size + 1);
+          }
+          const text = message.text.trim();
+          return {
+            identity: message.ts ? identities.get(message.ts) : 0,
+            final: observedSlackText(message).includes(finalMarker),
+            commentary: observedSlackText(message).includes(commentaryMarker),
+            commentaryLane: hasSlackCommentaryLaneMarker(message, commentaryMarker),
+            bareCommentary: text === commentaryMarker,
+            colonCommentary: text === `:speech_balloon: ${commentaryMarker}`,
+            typedCommentaryBlock: (message.blockText ?? []).some(
+              (line) => line.trim() === `• *Commentary* — _${commentaryMarker}_`,
+            ),
+            safeExec: isSlackSafeExecSummary(message),
+            commandMarker: observedSlackText(message).includes(toolMarker),
+          };
+        });
+        throw new Error(`${reason}; presentation=${JSON.stringify(presentation)}`);
+      }
       if (!finalMessage.ts) {
-        throw new Error("Slack progress commentary final message had no ts");
+        fail("Slack progress commentary final message had no ts");
       }
       if ((finalMessage.text ?? "").trim() !== finalMarker) {
-        throw new Error("expected the Slack final answer to contain only the final marker");
+        fail("expected the Slack final answer to contain only the final marker");
       }
       const progressMessages = messages.filter(
         (message) => !observedSlackText(message).includes(finalMarker),
@@ -128,12 +158,12 @@ export function buildSlackProgressCommentaryRun(
       const commentaryTimestamps = new Set(commentaryMessages.map((message) => message.ts));
       const [commentaryTs] = commentaryTimestamps;
       if (commentaryTimestamps.size !== 1 || commentaryTs === undefined) {
-        throw new Error(
+        fail(
           `expected exactly one Slack message identity containing commentary; got ${commentaryTimestamps.size}`,
         );
       }
       if (commentaryTs === finalMessage.ts) {
-        throw new Error("expected Slack progress commentary to stay separate from the fresh final");
+        fail("expected Slack progress commentary to stay separate from the fresh final");
       }
       // Slack prefixes durable standalone commentary with the same glyph used by
       // draft-lane rendering, so message identity—not that marker—owns dedupe proof.
@@ -147,10 +177,10 @@ export function buildSlackProgressCommentaryRun(
           expectation.commentary === "lane" &&
           (commentaryLaneTimestamps.size !== 1 || !commentaryLaneTimestamps.has(commentaryTs))
         ) {
-          throw new Error("expected commentary in the Slack progress commentary lane");
+          fail("expected commentary in the Slack progress commentary lane");
         }
         if (expectation.commentary === "headline" && commentaryLaneTimestamps.size !== 0) {
-          throw new Error("expected the preamble as the Slack progress status headline");
+          fail("expected the preamble as the Slack progress status headline");
         }
       }
       const toolTimestamps = new Set(
@@ -158,19 +188,37 @@ export function buildSlackProgressCommentaryRun(
           .filter((message) => observedSlackText(message).includes(toolMarker))
           .map((message) => message.ts),
       );
-      if (expectation.toolProgress === "draft") {
+      if (expectation.toolProgress === "standalone-redacted") {
+        if (messages.some((message) => observedSlackText(message).includes(toolMarker))) {
+          fail("command details must stay hidden in verbose-on progress");
+        }
+        const safeToolTimestamps = new Set(
+          progressMessages.filter(isSlackSafeExecSummary).map((message) => message.ts),
+        );
+        if (
+          safeToolTimestamps.size !== 1 ||
+          safeToolTimestamps.has(commentaryTs) ||
+          safeToolTimestamps.has(finalMessage.ts)
+        ) {
+          fail("expected one safe Exec summary in a standalone verbose message");
+        }
+      } else if (expectation.toolProgress === "draft") {
         if (toolTimestamps.size !== 1 || toolTimestamps.has(finalMessage.ts)) {
-          throw new Error("expected tool progress on the draft separate from the fresh final");
+          fail("expected tool progress on the draft separate from the fresh final");
         }
         if (expectation.commentary !== "standalone" && !toolTimestamps.has(commentaryTs)) {
-          throw new Error("expected commentary and tool progress on one Slack draft identity");
+          fail("expected commentary and tool progress on one Slack draft identity");
         }
       } else if (expectation.toolProgress === "standalone") {
-        if (toolTimestamps.size === 0 || toolTimestamps.has(finalMessage.ts)) {
-          throw new Error("expected tool progress only in standalone verbose messages");
+        if (
+          toolTimestamps.size === 0 ||
+          toolTimestamps.has(commentaryTs) ||
+          toolTimestamps.has(finalMessage.ts)
+        ) {
+          fail("expected tool progress only in standalone verbose messages");
         }
       } else if (toolTimestamps.size !== 0) {
-        throw new Error("expected tool progress to stay out of Slack progress messages");
+        fail("expected tool progress to stay out of Slack progress messages");
       }
       const finalTimestamps = new Set(
         messages
@@ -178,9 +226,7 @@ export function buildSlackProgressCommentaryRun(
           .map((message) => message.ts),
       );
       if (finalTimestamps.size !== 1 || !finalTimestamps.has(finalMessage.ts)) {
-        throw new Error(
-          "expected one final-marker Slack message identity matching the final answer",
-        );
+        fail("expected one final-marker Slack message identity matching the final answer");
       }
       const commentaryDetails =
         expectation.commentary === "lane"

--- a/extensions/qa-lab/src/live-transports/slack/slack-live.scenario-fixtures.ts
+++ b/extensions/qa-lab/src/live-transports/slack/slack-live.scenario-fixtures.ts
@@ -247,7 +247,12 @@ export function buildSlackProgressCommentaryRun(
       }
       const toolTimestamps = new Set(
         progressMessages
-          .filter((message) => observedSlackText(message).includes(toolMarker))
+          .filter(
+            (message) =>
+              [toolMarker, outputMarker].some((marker) =>
+                observedSlackText(message).includes(marker),
+              ) || isSlackSafeExecSummary({ text: message.text.split(/\r?\n/u)[0] ?? "" }),
+          )
           .map((message) => message.ts),
       );
       if (expectation.toolProgress === "standalone-redacted") {
@@ -285,7 +290,6 @@ export function buildSlackProgressCommentaryRun(
         const toolMessages = progressMessages.filter((message) =>
           isSlackSafeExecSummary({ text: message.text.split(/\r?\n/u)[0] ?? "" }),
         );
-        const toolMessageTimestamps = new Set(toolMessages.map((message) => message.ts));
         const outputTimestamps = new Set(
           toolMessages
             .filter((message) =>
@@ -296,7 +300,7 @@ export function buildSlackProgressCommentaryRun(
             .map((message) => message.ts),
         );
         if (
-          toolMessageTimestamps.size !== 1 ||
+          toolTimestamps.size !== 1 ||
           outputTimestamps.size !== 1 ||
           outputTimestamps.has(undefined) ||
           outputTimestamps.has(commentaryTs) ||

--- a/extensions/qa-lab/src/live-transports/slack/slack-live.scenario-fixtures.ts
+++ b/extensions/qa-lab/src/live-transports/slack/slack-live.scenario-fixtures.ts
@@ -270,7 +270,6 @@ export function buildSlackProgressCommentaryRun(
         );
         if (
           safeToolTimestamps.size !== 1 ||
-          safeToolTimestamps.has(undefined) ||
           safeToolTimestamps.has(commentaryTs) ||
           safeToolTimestamps.has(finalMessage.ts)
         ) {
@@ -302,7 +301,6 @@ export function buildSlackProgressCommentaryRun(
         if (
           toolTimestamps.size !== 1 ||
           outputTimestamps.size !== 1 ||
-          outputTimestamps.has(undefined) ||
           outputTimestamps.has(commentaryTs) ||
           outputTimestamps.has(finalMessage.ts)
         ) {

--- a/extensions/qa-lab/src/live-transports/slack/slack-live.scenario-implementations.ts
+++ b/extensions/qa-lab/src/live-transports/slack/slack-live.scenario-implementations.ts
@@ -307,6 +307,17 @@ export const slackQaProgressCommentaryVerboseDedupeScenario: SlackQaScenarioImpl
   buildRun: (sutUserId) =>
     buildSlackProgressCommentaryRun(sutUserId, {
       commentary: "standalone",
+      toolProgress: "standalone-redacted",
+    }),
+};
+
+export const slackQaProgressCommentaryVerboseFullScenario: SlackQaScenarioImplementation = {
+  configOverrides: {
+    progress: { commentary: true, toolProgress: false, verboseDefault: "full" },
+  },
+  buildRun: (sutUserId) =>
+    buildSlackProgressCommentaryRun(sutUserId, {
+      commentary: "standalone",
       toolProgress: "standalone",
     }),
 };

--- a/extensions/qa-lab/src/scenario-catalog-channels.test.ts
+++ b/extensions/qa-lab/src/scenario-catalog-channels.test.ts
@@ -3,7 +3,6 @@ import { createQaBusState } from "./bus-state.js";
 import {
   readQaScenarioById,
   readQaScenarioExecutionConfig,
-  readQaScenarioPack,
   validateQaScenarioExecutionConfig,
 } from "./scenario-catalog.js";
 import { runLoadedScenarioFlow } from "./scenario-flow-runner.test-support.js";
@@ -70,15 +69,6 @@ function runTelegramStreamingFinalScenario(params: {
 
 describe("qa scenario catalog channel contracts", () => {
   const agentRuntime = "agent-runtime";
-
-  it("classifies every current module flow intrinsically", () => {
-    const moduleFlows = readQaScenarioPack().scenarios.filter(
-      (scenario) => scenario.execution.flowKind === "module",
-    );
-
-    expect(moduleFlows).toHaveLength(146);
-    expect(moduleFlows.every((scenario) => scenario.execution.flow)).toBe(true);
-  });
 
   it("routes native command session targeting through Crabline Telegram", () => {
     const scenario = readQaScenarioById("native-command-session-target");
@@ -194,6 +184,7 @@ describe("qa scenario catalog channel contracts", () => {
       "matrix-mxid-prefixed-command-block",
       "slack-codex-approval-exec-native",
       "slack-codex-approval-plugin-native",
+      "slack-progress-commentary-verbose-full",
     ]) {
       const scenario = requireFlowScenario(readQaScenarioById(scenarioId));
       expect(scenario.execution.flowKind, scenarioId).toBe("module");

--- a/qa/scenarios/channels/slack-progress-commentary-verbose-full.yaml
+++ b/qa/scenarios/channels/slack-progress-commentary-verbose-full.yaml
@@ -1,4 +1,4 @@
-title: Slack full verbose progress retains command detail without duplicate commentary
+title: Slack full verbose progress delivers tool output without duplicate commentary
 scenario:
   id: slack-progress-commentary-verbose-full
   surface: channels

--- a/qa/scenarios/channels/slack-progress-commentary-verbose-full.yaml
+++ b/qa/scenarios/channels/slack-progress-commentary-verbose-full.yaml
@@ -1,0 +1,20 @@
+title: Slack full verbose progress retains command detail without duplicate commentary
+scenario:
+  id: slack-progress-commentary-verbose-full
+  surface: channels
+  coverage:
+    primary:
+      - agent-runtime.streaming-replies
+  execution:
+    kind: flow
+    channel: slack
+    timeoutMs: 90000
+    retryCount: 1
+    suiteIsolation: isolated
+    isolationReason: Overrides Slack progress presentation and the agent verbose default.
+flow:
+  module: ./live-transports/slack/scenario-runtime.js
+  call: runSlackScenario
+  args:
+    - { expr: slackScenarioContext }
+    - { moduleExport: slackQaProgressCommentaryVerboseFullScenario }


### PR DESCRIPTION
## What Problem This Solves

Slack release verification rejected valid progress output. Ordinary verbosity hides command details, while full verbosity forwards completed output with a runtime-dependent tool label. The commentary observer also expected an obsolete whole-block presentation, so a valid card containing multiple authored commentary rows failed despite using one Slack message identity.

## Why This Change Was Made

The ordinary verbose probe requires one safe Exec summary and rejects command/output disclosure, including unmarked metadata or output updates. The full companion runs the same command and requires its exact stdout line in one separate output identity. Slack's configured delivery transform can remove command-summary headers, so the exact stdout line identifies completed output without requiring a tool label. At most one surviving start-summary identity is allowed; duplicate summaries and duplicate output messages still fail.

The commentary matcher accepts exact current commentary rows inside a card and retains one commentary identity, a separate fresh final, and the disabled-tool checks. It rejects arbitrary marker prose and tool rows without deduplicating distinct authored commentary items by text. The catalog test verifies the new scenario through its existing module execution contract instead of pinning an inventory count; all-files and executable-flow coverage remains.

Failures retain bounded closed presentation facts, including exact-output-line and Exec-header booleans. Raw Slack messages, platform identities and credentials stay out of these diagnostics.

The exact old block matcher and non-output shell-comment probe came from [#130354](https://github.com/openclaw/openclaw/pull/130354), authored and merged by @RomneyDa on August 26. That change carried forward the old presentation contract; this investigation does not establish the date of the producer change. The full-only safe-header assumption was introduced and corrected within this PR.

## User Impact

Internal QA coverage only. Runtime redaction, default configuration, timeouts, retries and product behavior are unchanged. Full metadata is intentional under the built-in runtime; ordinary verbosity remains private. No changelog entry is needed.

## Evidence

- Four focused QA files passed 150 tests. All-extension test typecheck, scoped lint, formatting and whitespace checks passed. Fresh independent Codex review found no actionable P0–P2 defects.
- Seven controlled cases passed covering actual QA runtime selection; built-in subscriber through agent presentation, the configured Slack monitor transform, delivery and sender with only the WebClient mocked; Codex sibling projection; and commentary composition. The exact scenario command runs through a real shell. Including the configured Slack transform reproduces the live output-only fenced message: the transform removes the full command header and preserves stdout. That output failed the prior verifier and passes this correction. The ordinary summary survives; the full result still requires a distinct unique output identity. These controls are not authenticated Slack proof.
- Earlier authenticated diagnostics passed only ordinary verbosity. The subsequent [diagnostic run](https://github.com/openclaw/openclaw/actions/runs/33277685327) on `598ab18a238eb687a5f27850edb7688dee9dc118` passed commentary and ordinary verbosity but still failed full. Its terminal Slack artifact was verified before stopping remaining jobs. These were partial diagnostic runs, not full release passes.
- Final head `8683cd61c28a554a1124503ea5dbbbd8c6d6994f` passed [required CI](https://github.com/openclaw/openclaw/actions/runs/33280822050) and all three [authenticated Slack scenarios](https://github.com/openclaw/openclaw/actions/runs/33280839185): commentary enabled, ordinary verbose privacy/dedupe, and full output. The artifact confirms live Slack/provider execution on that exact target. Workflow/tooling was `bcc0b5a10c18b74c0270d9015dba30a8a2192ccc`.
- The terminal Slack artifact is `qa-live-slack-33280839185-1` (ID `9723030300`, 6,752 bytes), SHA-256 `9e1edc4a5890262590b719627dda43d0b3c11ac27cb5966969f955b620f2a57a`. It reports **3 passed, 0 failed, 0 skipped**. Remaining Matrix/WhatsApp jobs were stopped only after that artifact was downloaded and verified; this is scoped Slack proof, not a full-release success claim.
- The latest ClawSweeper review on this exact head found no actionable code defects. Its remaining CI/live checklist and request for redacted exact-head Slack evidence are satisfied by the linked run and verified artifact above.

- The later [authenticated diagnostic](https://github.com/openclaw/openclaw/actions/runs/33279782117) on `ca25033c28fc891d44cf71ee45d313bc3aa7b532` also passed commentary/on and failed full. Its bounded artifact proves the exact stdout arrived in one separate message; only the header oracle rejected it. The corrected controlled pipeline now includes the omitted configured Slack transform. The subsequent final-head run above passed all three cases.

## Source Contract

Normal live-frontier QA config authors SSE transport parameters, selecting the built-in OpenClaw runtime. `src/agents/embedded-agent-subscribe.ts` emits a full metadata summary at tool start and output at completion. Slack's configured `sanitizeSlackMonitorReplyPayload` transform removes compact command-header lines before sending, preserving fenced output; requiring the pre-transform header was invalid. A controlled configuration test verifies that runtime selection. The initial Codex-only assumption and the later pre-transform header assumption were corrected without changing product behavior to satisfy the harness. This follows the documented [verbose output contract](https://docs.openclaw.ai/tools/thinking).

The acting reviewer also directly inspected sibling Codex source at `3c062df036070ad5819a9a74160a448b414e9b92`: `codex-rs/core/src/event_mapping.rs:149`, `codex-rs/app-server-protocol/src/protocol/event_mapping.rs:362`, `codex-rs/core/src/stream_events_utils.rs:342`, and `codex-rs/core/src/session/mod.rs:3225`. The Codex-specific command metadata policy remains covered as a sibling contract, not assumed to govern the normal QA runtime.
