### PR TITLE
fix(cli): reduce gateway status memory on constrained hosts

### DIFF
--- a/src/cli/cli-utils.test.ts
+++ b/src/cli/cli-utils.test.ts
@@ -113,8 +113,12 @@ describe("shouldSkipRespawnForArgv", () => {
     { argv: ["node", "openclaw", "gateway"] },
     { argv: ["node", "openclaw", "gateway", "--port", "14720", "--bind", "loopback"] },
     { argv: ["node", "openclaw", "gateway", "run", "--port=14720", "--bind", "loopback"] },
+    { argv: ["node", "openclaw", "gateway", "status"] },
     {
       argv: ["node", "openclaw", "--profile", "server", "gateway", "run", "--allow-unconfigured"],
+    },
+    {
+      argv: ["node", "openclaw", "--profile", "server", "gateway", "status", "--json"],
     },
   ] as const)("skips respawn for argv %j", ({ argv }) => {
     expect(shouldSkipRespawnForArgv([...argv]), argv.join(" ")).toBe(true);
@@ -122,7 +126,6 @@ describe("shouldSkipRespawnForArgv", () => {
 
   it.each([
     { argv: ["node", "openclaw", "status"] },
-    { argv: ["node", "openclaw", "gateway", "status"] },
     { argv: ["node", "openclaw", "gateway", "call", "health"] },
   ] as const)("keeps respawn path for argv %j", ({ argv }) => {
     expect(shouldSkipRespawnForArgv([...argv]), argv.join(" ")).toBe(false);

--- a/src/cli/gateway-backed-exit.process.test.ts
+++ b/src/cli/gateway-backed-exit.process.test.ts
@@ -490,6 +490,72 @@ describe("gateway-backed CLI process exit", () => {
     },
   );
 
+  it.runIf(process.platform !== "win32")(
+    "runs gateway status through one OpenClaw entry process",
+    async () => {
+      const root = tempDirs.make("openclaw-gateway-status-entry-process-");
+      const stateDir = path.join(root, "state");
+      const configPath = path.join(stateDir, "openclaw.json");
+      const pidLogPath = path.join(root, "entry-pids");
+      const preloadPath = path.join(root, "track-entry-pid.mjs");
+      const token = "configured-token";
+      const gateway = await startGatewayStabilityRpcServer(token, "issued-device-token");
+      await fs.mkdir(stateDir, { recursive: true });
+      await fs.writeFile(
+        configPath,
+        JSON.stringify({ gateway: { mode: "remote", remote: { url: gateway.url, token } } }),
+      );
+      await fs.writeFile(
+        preloadPath,
+        [
+          'import fs from "node:fs";',
+          'const entry = process.argv[1]?.replaceAll("\\\\", "/");',
+          'if (entry?.endsWith("/src/entry.ts")) {',
+          "  fs.appendFileSync(process.env.OPENCLAW_ENTRY_PID_LOG, `${process.pid}\\n`);",
+          "}",
+          "",
+        ].join("\n"),
+      );
+
+      const result = await runIsolatedGatewayCli({
+        args: [
+          "gateway",
+          "status",
+          "--url",
+          gateway.url,
+          "--token",
+          token,
+          "--require-rpc",
+          "--json",
+          "--timeout",
+          "2000",
+        ],
+        root,
+        stateDir,
+        configPath,
+        env: {
+          NODE_OPTIONS: `--import=${pathToFileURL(preloadPath).href}`,
+          OPENCLAW_ENTRY_PID_LOG: pidLogPath,
+          OPENCLAW_NODE_EXTRA_CA_CERTS_READY: "1",
+          OPENCLAW_NODE_OPTIONS_READY: undefined,
+          OPENCLAW_NO_RESPAWN: undefined,
+        },
+      });
+
+      expect(result, result.stderr).toMatchObject({ code: 0, signal: null, stderr: "" });
+      expect(JSON.parse(result.stdout)).toMatchObject({
+        rpc: { ok: true, kind: "read" },
+      });
+      const entryPids = new Set(
+        (await fs.readFile(pidLogPath, "utf8"))
+          .trim()
+          .split(/\s+/u)
+          .map((value) => Number.parseInt(value, 10)),
+      );
+      expect(entryPids.size).toBe(1);
+    },
+  );
+
   it.each([
     { label: "list", args: ["devices", "list", "--timeout", "250"] },
     { label: "join-code", args: ["devices", "join-code", "--timeout", "250"] },

--- a/src/cli/respawn-policy.ts
+++ b/src/cli/respawn-policy.ts
@@ -79,11 +79,18 @@ export function shouldSkipRespawnForArgv(
   platform: NodeJS.Platform = process.platform,
 ): boolean {
   const invocation = resolveCliArgvInvocation(argv);
+  const isGatewayStatus =
+    invocation.commandPath.length === 2 &&
+    invocation.commandPath[0] === "gateway" &&
+    invocation.commandPath[1] === "status";
   return (
     invocation.hasHelpOrVersion ||
     isInteractiveTtyCommandArgv(argv) ||
     isForegroundGmailRunArgv(argv) ||
     shouldKeepNativeHookRelayInProcess(argv, platform) ||
+    // Status commonly overlaps the running Gateway; a warning-only wrapper doubles
+    // transient CLI memory. Startup-environment respawn remains separately owned.
+    isGatewayStatus ||
     (invocation.primary === "gateway" && isForegroundGatewayRunArgv(argv))
   );
 }

--- a/src/entry.respawn.test.ts
+++ b/src/entry.respawn.test.ts
@@ -95,6 +95,35 @@ describe("buildCliRespawnPlan", () => {
     expect(respawnPlan.detachForProcessTree).toBe(true);
   });
 
+  it("does not respawn gateway status only to suppress warnings", () => {
+    expect(
+      buildCliRespawnPlan({
+        argv: ["node", "openclaw", "gateway", "status", "--json"],
+        env: {},
+        execArgv: [],
+        autoNodeExtraCaCerts: undefined,
+        platform: "linux",
+      }),
+    ).toBeNull();
+  });
+
+  it("preserves NODE_EXTRA_CA_CERTS respawn for gateway status", () => {
+    const plan = buildCliRespawnPlan({
+      argv: ["node", "openclaw", "gateway", "status", "--json"],
+      env: {},
+      execArgv: [],
+      autoNodeExtraCaCerts: "/etc/ssl/certs/ca-certificates.crt",
+      platform: "linux",
+    });
+
+    const respawnPlan = expectCliRespawnPlan(plan);
+    expect(respawnPlan.argv).toEqual(["openclaw", "gateway", "status", "--json"]);
+    expect(respawnPlan.env.NODE_EXTRA_CA_CERTS).toBe("/etc/ssl/certs/ca-certificates.crt");
+    expect(respawnPlan.env[OPENCLAW_NODE_EXTRA_CA_CERTS_READY]).toBe("1");
+    expect(respawnPlan.env[OPENCLAW_NODE_OPTIONS_READY]).toBeUndefined();
+    expect(respawnPlan.detachForProcessTree).toBe(true);
+  });
+
   it.each(["tui", "terminal", "chat"] as const)(
     "preserves NODE_EXTRA_CA_CERTS respawn for interactive %s",
     (command) => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators running `openclaw gateway status` on constrained hosts could hit an out-of-memory kill while the status command overlapped the running Gateway. The transient warning-suppression respawn created two full OpenClaw status entry processes during the highest-memory phase.

In the prior ARM64 low-memory matrix, 1 GB without swap passed only 1 of 2 runs and recorded one OOM kill.

## Why This Change Was Made

The CLI now skips the general warning-suppression respawn only for the exact `gateway status` command path. Root `status`, `gateway call health`, automatic CA-certificate startup respawn, and Windows startup behavior retain their existing contracts.

The classifier uses the existing canonical argv parser and requires the exact two-component command path. No configuration, environment, heap-limit, Gateway startup, or status-gathering behavior changes.

## User Impact

`openclaw gateway status` uses one OpenClaw entry process instead of briefly duplicating the status process, reducing peak overlap memory on constrained hosts. Output and RPC behavior are unchanged.

## Evidence

- Pre-fix process regression reproduced two unique OpenClaw entry PIDs; the fixed regression records one.
- Focused policy and respawn-plan tests: 17 passed assertions across two Vitest shards.
- POSIX process regression: 1 passed, 37 filtered; valid JSON, zero exit, and clean stderr.
- Local process-tree A/B, five repetitions per mode:
  - Default median: 472.11 MiB.
  - `OPENCLAW_NO_RESPAWN=1` median: 474.16 MiB.
  - Median delta: 2.05 MiB; maximum OpenClaw entry processes: one in both modes.
- Publish-equivalent package built from commit `927cd95a211a2d1b91e44b50af0c4d43bec74076`.
  - Package SHA256: `c184f3216ee594b21e98f25e2445c3a62f4c0101ac0238c16d8d409a742fbf0e`.
  - Landing head `13e1cdce72f1166ed019dc8b31e088a2ea387817` removes only the release-owned changelog line and rebases the identical runtime/test patch onto fixed main `3cc47ae2f33c76bc79aeaf061678c6b6ecd85d55`.
- Controlled base refresh:
  - Range-diff: unchanged (`=`).
  - Stable patch ID before/after: `dbf35922570ce3451a6615df8967cba130a10fc8`.
  - Post-refresh focused tests: 80 passed across `cli-utils` and respawn-plan coverage.
  - Post-refresh process regression: 1 passed, 37 skipped.
- Fresh ARM64 AWS constrained-memory matrix: 12/12 passed with zero OOM kills.
  - 1 GB, no swap: 5/5.
  - 1 GB, 2 GB swap: 2/2.
  - 2 GB controls: 3/3.
  - 4 GB controls: 2/2.
  - Every status invocation returned valid JSON, kept stderr empty, left the Gateway alive, and ran one OpenClaw entry process.
  - Maximum 1 GB swap usage fell from 182.9 MiB in the prior matrix to 111.1 MiB.
- Formatting, changed-file gates, and `git diff --check`: passed.
- Autoreview: Codex Sol/high, no findings; patch rated correct with 0.99 confidence.

Production LOC: +7/-0 (net +7) | Tests: +99/-1 (net +98)

The production growth is the exact-path classification and its ownership comment; startup-environment respawn remains a separate existing policy.

## ClawSweeper Disposition

- Applied the changelog finding and rank-up move: the release-owned `CHANGELOG.md` entry was removed.
- Accepted the +7 production LOC risk: the exact named predicate belongs in the canonical respawn-policy owner, no reusable status predicate exists, and removing or inlining it would obscure the invariant that only exact `gateway status` skips the warning-only respawn.

## Residual Limits

- AWS ARM64 guests approximate but do not exactly reproduce Raspberry Pi storage and kernel behavior.
- The cloud matrix exercised one status invocation per fresh guest rather than sustained polling.
- Hosts requiring automatic CA-certificate injection still perform the intentionally preserved startup respawn; that contract has focused test coverage but was not separately profiled in the constrained cloud matrix.

## AI Assistance

- [x] AI-assisted implementation and validation.
- [x] The change and its ownership boundaries were reviewed and understood.
- [x] Project autoreview completed with no actionable findings.
