### PR TITLE
fix(ui): integrate Goal mode into the composer

### DIFF
--- a/ui/src/pages/chat/chat-responsive.browser.test.ts
+++ b/ui/src/pages/chat/chat-responsive.browser.test.ts
@@ -1856,6 +1856,46 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
     }
   });
 
+  it("renders Goal mode as an internal composer row", async () => {
+    const page = await openBrowserPage(800, 300);
+    try {
+      await page.setContent(`<!doctype html><html><head><style>${readUiCss()}</style></head><body>
+        <div class="agent-chat__composer-shell">
+          <div class="agent-chat__input">
+            <div class="agent-chat__composer-lede">
+              <div class="agent-chat__goal-mode">Goal — Enter your objective.</div>
+            </div>
+            <div class="agent-chat__composer-input-row">What should this goal accomplish?</div>
+          </div>
+        </div>
+      </body></html>`);
+      const styles = await page.evaluate(() => {
+        const composer = getComputedStyle(
+          document.querySelector<HTMLElement>(".agent-chat__input")!,
+        );
+        const goal = getComputedStyle(
+          document.querySelector<HTMLElement>(".agent-chat__goal-mode")!,
+        );
+        return {
+          composerOverflow: composer.overflow,
+          goalBorderBottomStyle: goal.borderBottomStyle,
+          goalBorderLeftStyle: goal.borderLeftStyle,
+          goalBorderRadius: goal.borderRadius,
+          goalMarginBottom: goal.marginBottom,
+        };
+      });
+      expect(styles).toEqual({
+        composerOverflow: "hidden",
+        goalBorderBottomStyle: "solid",
+        goalBorderLeftStyle: "none",
+        goalBorderRadius: "0px",
+        goalMarginBottom: "0px",
+      });
+    } finally {
+      await closeBrowserPage(page);
+    }
+  });
+
   it("keeps the desktop model picker label-to-chevron gap at 4px", async () => {
     const page = await openBrowserPage(800, 800);
     try {

--- a/ui/src/pages/chat/chat-responsive.browser.test.ts
+++ b/ui/src/pages/chat/chat-responsive.browser.test.ts
@@ -211,6 +211,7 @@ type ChatFixtureOptions = {
   composerAttachment?: boolean;
   crowdedComposerFooter?: boolean;
   direct?: boolean;
+  goalMode?: boolean;
   sessionRailBody?: string;
   slashMenu?: boolean;
 };
@@ -708,6 +709,14 @@ function chatHtml(opts: ChatFixtureOptions = {}, mobileNavLayout = false) {
                       : ""
                   }
                   <div class="agent-chat__composer-lede">
+                  ${
+                    opts.goalMode
+                      ? `<div class="agent-chat__goal-mode">
+                        <span class="agent-chat__goal-mode-label">Goal</span>
+                        <span class="agent-chat__goal-mode-hint">Enter your objective.</span>
+                      </div>`
+                      : ""
+                  }
                   ${
                     opts.composerAttachment
                       ? `<div class="chat-attachments-preview">
@@ -1851,46 +1860,6 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
       expect(sizes.effort).toEqual({ height: 14, width: 14 });
       expect(sizes.microphone).toEqual({ height: 16, width: 16 });
       expect(sizes.fast).toEqual({ height: 16, width: 16 });
-    } finally {
-      await closeBrowserPage(page);
-    }
-  });
-
-  it("renders Goal mode as an internal composer row", async () => {
-    const page = await openBrowserPage(800, 300);
-    try {
-      await page.setContent(`<!doctype html><html><head><style>${readUiCss()}</style></head><body>
-        <div class="agent-chat__composer-shell">
-          <div class="agent-chat__input">
-            <div class="agent-chat__composer-lede">
-              <div class="agent-chat__goal-mode">Goal — Enter your objective.</div>
-            </div>
-            <div class="agent-chat__composer-input-row">What should this goal accomplish?</div>
-          </div>
-        </div>
-      </body></html>`);
-      const styles = await page.evaluate(() => {
-        const composer = getComputedStyle(
-          document.querySelector<HTMLElement>(".agent-chat__input")!,
-        );
-        const goal = getComputedStyle(
-          document.querySelector<HTMLElement>(".agent-chat__goal-mode")!,
-        );
-        return {
-          composerOverflow: composer.overflow,
-          goalBorderBottomStyle: goal.borderBottomStyle,
-          goalBorderLeftStyle: goal.borderLeftStyle,
-          goalBorderRadius: goal.borderRadius,
-          goalMarginBottom: goal.marginBottom,
-        };
-      });
-      expect(styles).toEqual({
-        composerOverflow: "hidden",
-        goalBorderBottomStyle: "solid",
-        goalBorderLeftStyle: "none",
-        goalBorderRadius: "0px",
-        goalMarginBottom: "0px",
-      });
     } finally {
       await closeBrowserPage(page);
     }
@@ -3665,6 +3634,8 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
       await waitForLayoutSettled(page, ".context-usage__popover, .agent-chat__input");
       await syncFixtureComposerPopoverAnchor(page);
       await waitForLayoutSettled(page, ".context-usage__popover, .agent-chat__input");
+      await syncFixtureComposerPopoverAnchor(page);
+      await waitForLayoutSettled(page, ".context-usage__popover, .agent-chat__input");
       const composer = await getBoundingBox(
         page,
         ".agent-chat__composer-shell > .agent-chat__input",
@@ -4104,7 +4075,7 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
   });
 
   it("keeps short-landscape composer adjunct rows scroll-reachable", async () => {
-    const page = await openFixture(568, 320, { composerAttachment: true });
+    const page = await openFixture(568, 320, { composerAttachment: true, goalMode: true });
     try {
       await page
         .locator(".agent-chat__composer-combobox > textarea")
@@ -4154,6 +4125,11 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
         throw new Error("Expected scroll metrics for short-landscape composer");
       }
       expect(input.scrollHeight).toBeGreaterThan(input.clientHeight);
+      expect(
+        await page
+          .locator(".agent-chat__input")
+          .evaluate((node) => getComputedStyle(node).overflowY),
+      ).toBe("auto");
       expect(textarea.scrollHeight).toBeGreaterThan(textarea.clientHeight);
 
       const scrolled = await page.evaluate(() => {
@@ -4195,6 +4171,37 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
       const send = expectControlRect(scrolled.send, "composer send control");
       expect(send.y).toBeGreaterThanOrEqual(scrolledShell.y - 1);
       expect(send.y + send.height).toBeLessThanOrEqual(scrolledShell.y + scrolledShell.height + 1);
+    } finally {
+      await closeBrowserPage(page);
+    }
+  });
+
+  it("keeps the desktop context popover visible with Goal mode active", async () => {
+    const page = await openFixture(1366, 900, { goalMode: true });
+    try {
+      const composer = await getBoundingBox(
+        page,
+        ".agent-chat__composer-shell > .agent-chat__input",
+      );
+      await page.locator(".context-ring").evaluate((node) => {
+        node.parentElement?.setAttribute("open", "");
+      });
+      await waitForLayoutSettled(page, ".context-usage__popover, .agent-chat__input");
+      const popover = await getBoundingBox(page, ".context-usage__popover");
+      expect(popover.y).toBeGreaterThanOrEqual(0);
+      expect(popover.y).toBeLessThan(composer.y);
+      const visibleAboveComposer = await page.evaluate(
+        ({ composerTop, popoverCenterX, popoverTop }) =>
+          document
+            .elementFromPoint(popoverCenterX, Math.max(popoverTop + 1, composerTop - 1))
+            ?.closest(".context-usage__popover") !== null,
+        {
+          composerTop: composer.y,
+          popoverCenterX: popover.x + popover.width / 2,
+          popoverTop: popover.y,
+        },
+      );
+      expect(visibleAboveComposer).toBe(true);
     } finally {
       await closeBrowserPage(page);
     }

--- a/ui/src/pages/chat/chat-responsive.browser.test.ts
+++ b/ui/src/pages/chat/chat-responsive.browser.test.ts
@@ -4130,6 +4130,22 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
           .locator(".agent-chat__input")
           .evaluate((node) => getComputedStyle(node).overflowY),
       ).toBe("auto");
+      expect(
+        await page.locator(".agent-chat__goal-mode").evaluate((node) => {
+          const style = getComputedStyle(node);
+          return {
+            borderBottomStyle: style.borderBottomStyle,
+            borderLeftStyle: style.borderLeftStyle,
+            borderRadius: style.borderRadius,
+            marginBottom: style.marginBottom,
+          };
+        }),
+      ).toEqual({
+        borderBottomStyle: "solid",
+        borderLeftStyle: "none",
+        borderRadius: "0px",
+        marginBottom: "0px",
+      });
       expect(textarea.scrollHeight).toBeGreaterThan(textarea.clientHeight);
 
       const scrolled = await page.evaluate(() => {
@@ -4152,12 +4168,14 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
           input: rectFor(".agent-chat__composer-shell > .agent-chat__input"),
           meta: rectFor(".agent-chat__composer-meta"),
           model: rectFor(".chat-composer-model-control"),
+          scrollTop: composer?.scrollTop ?? 0,
           send: rectFor(".chat-send-btn"),
         };
       });
 
       const scrolledShell = expectControlRect(scrolled.shell, "scrolled composer shell");
       const scrolledInput = expectControlRect(scrolled.input, "scrolled composer");
+      expect(scrolled.scrollTop).toBeGreaterThan(0);
       for (const [label, control] of [
         ["composer metadata", scrolled.meta],
         ["composer model control", scrolled.model],
@@ -4192,9 +4210,11 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
       expect(popover.y).toBeLessThan(composer.y);
       const visibleAboveComposer = await page.evaluate(
         ({ composerTop, popoverCenterX, popoverTop }) =>
-          document
-            .elementFromPoint(popoverCenterX, Math.max(popoverTop + 1, composerTop - 1))
-            ?.closest(".context-usage__popover") !== null,
+          Boolean(
+            document
+              .elementFromPoint(popoverCenterX, Math.max(popoverTop + 1, composerTop - 1))
+              ?.closest(".context-usage__popover"),
+          ),
         {
           composerTop: composer.y,
           popoverCenterX: popover.x + popover.width / 2,

--- a/ui/src/styles/chat/composer-progress.css
+++ b/ui/src/styles/chat/composer-progress.css
@@ -233,8 +233,7 @@
   gap: 8px;
   margin: 0;
   padding: 8px 10px;
-  border-bottom: 1px solid
-    color-mix(in srgb, var(--chat-composer-hairline) 60%, transparent);
+  border-bottom: 1px solid color-mix(in srgb, var(--chat-composer-hairline) 60%, transparent);
   color: var(--text);
 }
 

--- a/ui/src/styles/chat/composer-progress.css
+++ b/ui/src/styles/chat/composer-progress.css
@@ -231,11 +231,15 @@
   display: flex;
   align-items: center;
   gap: 8px;
-  margin-bottom: 8px;
+  margin: 0;
   padding: 8px 10px;
-  border: 1px solid var(--border);
-  border-radius: 10px;
+  border-bottom: 1px solid
+    color-mix(in srgb, var(--chat-composer-hairline) 60%, transparent);
   color: var(--text);
+}
+
+.agent-chat__input:has(.agent-chat__goal-mode) {
+  overflow: hidden;
 }
 
 .agent-chat__goal-mode-label {

--- a/ui/src/styles/chat/composer-progress.css
+++ b/ui/src/styles/chat/composer-progress.css
@@ -238,10 +238,6 @@
   color: var(--text);
 }
 
-.agent-chat__input:has(.agent-chat__goal-mode) {
-  overflow: hidden;
-}
-
 .agent-chat__goal-mode-label {
   display: inline-flex;
   align-items: center;


### PR DESCRIPTION
Closes #132786

## What Problem

The `/goal` pre-prompt inside the chat composer drew its own margin, border, and rounded corners. Stacking that inner card over the composer created a visible gap and doubled upper-corner silhouette.

## Why

The composer is the architectural owner of the external card. This change turns the Goal pre-prompt into an internal row: it has no external border, radius, or spacing and retains only a subtle straight divider. The composer keeps its existing overflow behavior so responsive scrolling and popovers remain intact.

## User Impact

Goal creation and editing now read as one continuous composer card on desktop and mobile, in light and dark themes. The Goal label and close action remain unchanged; only the malformed fit is corrected.

## Evidence

### Before and after

All captures use the same Goal fixture and state. Desktop captures are 1440×1000; mobile captures are 390×844. Each was captured at 2× and visually inspected before upload.

| View | Before | After |
| --- | --- | --- |
| Desktop · light | ![Before, desktop light](https://github.com/user-attachments/assets/52638b24-af22-4f31-bd76-f8a831cf9114) | ![After, desktop light](https://github.com/user-attachments/assets/fbaaff23-3452-412a-8393-6f2feff1a37d) |
| Desktop · dark | ![Before, desktop dark](https://github.com/user-attachments/assets/d2992645-dc67-4769-98cc-6e1183e7e2ea) | ![After, desktop dark](https://github.com/user-attachments/assets/1a53156d-67fa-4149-9a23-46459bbc549a) |
| Mobile · light | ![Before, mobile light](https://github.com/user-attachments/assets/502b7cb3-aaac-4a28-b8f9-3dc239050360) | ![After, mobile light](https://github.com/user-attachments/assets/72616427-8f9c-4c89-995b-54157e9b8e56) |
| Mobile · dark | ![Before, mobile dark](https://github.com/user-attachments/assets/c7136472-03ab-4354-b22c-45e6d9ad7fa8) | ![After, mobile dark](https://github.com/user-attachments/assets/106f78c4-34e2-4f14-8a3f-3b6b6a722e20) |

This is a static geometry change; no motion evidence is applicable.

### Scope gate

- `ui/src/styles/chat/composer-progress.css`: removes only the Goal row’s external card geometry; composer overflow remains unchanged.
- `ui/src/pages/chat/chat-responsive.browser.test.ts`: extends the bounded-composer fixture with Goal mode and verifies both short-landscape reachability and desktop Context popover visibility.
- Fixture, capture instrumentation, screenshots, and worklog remain outside the commit.
- Production LOC: +3 / −3 (net neutral).
- Test LOC: +68 / −1.

### Named consumers checked

- Standard message composer: unchanged because it has no Goal row.
- Goal creation composer: integrated outer silhouette and straight internal divider.
- Goal editing composer: shares the same Goal-mode renderer and receives the same fix.
- Composer attachment/status previews: unchanged inside the existing lede.
- Session companion composer: unchanged because it has no Goal row.

### Validation

- Extended the browser fixture with Goal mode and added regressions at the real scrolling and popover boundaries.
- Verified the real `/goal` activation flow in the mock Control UI at desktop and mobile widths in both themes.
- Focused pre-fix proof: both Goal-mode cases failed with composer clipping enabled (`overflow-y: hidden`; Context content clipped).
- Focused post-fix proof: both Goal-mode cases passed (`2 passed`) with short-landscape scrolling and desktop Context visibility preserved.
- The landscape assertion proves a real scroll (`scrollTop > 0`); the Goal row also asserts zero margin/radius, no lateral border, and the internal hairline. The Context check uses a boolean hit-test above the composer.
