### PR TITLE
fix(ui): prevent dark flash on light-system reload

### DIFF
--- a/ui/index.html
+++ b/ui/index.html
@@ -40,8 +40,7 @@
               if (raw) break;
             }
           }
-          if (!raw) return;
-          var s = JSON.parse(raw);
+          var s = raw ? JSON.parse(raw) : null;
           var t = s && s.theme;
           var m = s && s.themeMode;
           if (typeof t !== "string") t = "";


### PR DESCRIPTION
Closes #132785

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where users opening the Control UI on a light system with no saved theme settings would see a full-window dark flash during a hard reload.

## Why This Change Was Made

The synchronous head bootstrap previously stopped when no persisted settings record existed, while the later application bootstrap correctly treated that state as the default `claw` theme in `system` mode. The head bootstrap now resolves that same default before first paint, keeping one canonical theme decision without hiding the page or adding another fallback.

## User Impact

Fresh Control UI origins now paint the system-selected light theme immediately. Persisted theme choices, explicit light/dark modes, and built-in theme palettes continue through their existing paths.

## Evidence

### Before — reproduced live (hard refresh on a synced deployment)

The flash as experienced in a real environment where theme settings are profile-synced through the gateway and no browser-local settings record exists:

https://github.com/user-attachments/assets/cf840ff1-c3be-4799-9a33-834304a53aae


All four Playwright `recordVideo` captures run continuously at real speed for about 10.4 seconds. They use the same mocked Control UI route, 1440×900 viewport, fresh Chromium context, cleared local storage, disabled network cache, and a real page reload. Each recording waits for the visible application shell and expected resolved theme, holds the fully settled app on screen for 3.5 seconds, reloads, then holds the final settled state for 5 seconds.

### Light system — before

Pre-fix commit `8a2f6c3c770`: the reload sequence visibly changes light → dark → light. Decoded video samples at the center are `rgb(242,242,242)` → `rgb(11,16,23)` → `rgb(247,247,247)`.

https://github.com/user-attachments/assets/f38ffd3a-2639-4424-8174-6628c412a87e

![Light system before: settled app, reload, dark flash, and restored light app](https://github.com/user-attachments/assets/a7c64f40-9557-4891-88e4-56826bcdb7d6)

### Light system — after

Fixed commit `3ab4d32db8aea5b8e0d3363cc07051633d26e376`: the reload remains light from the first document paint. Equivalent decoded samples are `rgb(242,242,242)` → `rgb(247,247,247)` → `rgb(247,247,247)`.

https://github.com/user-attachments/assets/bf411508-901d-49dc-932e-053d84848efd

![Light system after: settled app and reload remain light](https://github.com/user-attachments/assets/7848bf96-34e8-47a5-94a5-ebb7c92f1052)

### Dark system — before

Pre-fix commit `8a2f6c3c770`: the reload starts dark and remains dark. Decoded samples are `rgb(16,13,17)` → `rgb(13,15,23)` → `rgb(13,15,20)`.

https://github.com/user-attachments/assets/d30fddf5-d6b5-4178-ad74-ce91d5c74523

![Dark system before: settled app and reload remain dark](https://github.com/user-attachments/assets/6c9e4225-0b07-4fc1-9f65-7bbafe37a8e3)

### Dark system — after

Fixed commit `3ab4d32db8aea5b8e0d3363cc07051633d26e376`: the reload still starts dark and remains dark, proving the fix does not invert the system preference. Decoded samples are `rgb(16,13,17)` → `rgb(13,15,23)` → `rgb(13,15,20)`.

https://github.com/user-attachments/assets/293c7bca-124e-40eb-afd2-8dff9c8d8daf

![Dark system after: settled app and reload remain dark](https://github.com/user-attachments/assets/f1d594a8-1b46-4883-8750-04f228e67742)

### Scope and consumers

- Tracked scope: `ui/index.html` only; it owns synchronous pre-paint theme selection.
- Production LOC: +1/-2 (net -1). Tests: +0/-0.
- Consumers checked: the initial HTML canvas; the claw dark and light token sets; persisted `claw/system`; persisted explicit light/dark modes; built-in palette families; and the later application bootstrap. All converge on the same existing resolved-theme attributes.
- No automated test was added because the regression is the ordering of the browser's first paint relative to module bootstrap. The deterministic Chromium screencast reproduces and verifies that boundary directly; repository CI remains the code gate.

