### PR TITLE
fix(ui): reveal full sidebar session titles on hover

### DIFF
--- a/ui/src/e2e/chat-flow.sidebar-presentation.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.sidebar-presentation.e2e.test.ts
@@ -325,6 +325,48 @@ suite.define(() => {
     }
   });
 
+  it("reveals a long sidebar title through a physical hover with reduced motion enabled", async () => {
+    const context = await suite.newBrowserContext({
+      locale: "en-US",
+      reducedMotion: "reduce",
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1280 },
+    });
+    const page = await context.newPage();
+    const sessions = chatSessionListResponse();
+    const secondSession = expectDefined(sessions.sessions[1], "second chat session fixture");
+    secondSession.label =
+      "Review and repair the intentionally overlong sidebar session title before navigation";
+    await installMockGateway(page, {
+      methodResponses: { "sessions.list": sessions },
+      sessionKey: "agent:main:session-a",
+    });
+
+    try {
+      await page.goto(`${suite.server.baseUrl}chat`);
+      const row = page.locator('.sidebar-recent-session[data-session-key="agent:main:session-b"]');
+      const label = row.locator(".sidebar-recent-session__name");
+      await label.waitFor({ state: "visible", timeout: 10_000 });
+      const box = await row.boundingBox();
+      expect(box).not.toBeNull();
+      if (!box) {
+        return;
+      }
+      await page.mouse.move(box.x + box.width + 40, box.y + box.height / 2);
+      await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2, { steps: 12 });
+
+      await expect
+        .poll(
+          () =>
+            label.evaluate((element) => Number.parseFloat(getComputedStyle(element).textIndent)),
+          { timeout: 2_000 },
+        )
+        .toBeLessThan(-1);
+    } finally {
+      await suite.closeBrowserContext(context);
+    }
+  });
+
   it("keeps session titles on the first line and collapses rows that have no second line", async () => {
     if (captureUiProofEnabled) {
       await mkdir(sessionSecondRowProofDir, { recursive: true });

--- a/ui/src/e2e/chat-flow.sidebar-presentation.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.sidebar-presentation.e2e.test.ts
@@ -5,10 +5,10 @@ import {
   captureUiProofEnabled,
   chatSessionListResponse,
   createChatFlowE2eSuite,
+  controlUiSessionUrl,
   expectDefined,
   expectRequestCountStable,
   installMockGateway,
-  pauseVirtualClock,
   requireRecord,
 } from "./chat-flow.test-support.ts";
 
@@ -79,7 +79,7 @@ suite.define(() => {
     });
 
     try {
-      await page.goto(`${suite.server.baseUrl}chat`);
+      await page.goto(controlUiSessionUrl(suite.server.baseUrl, firstKey));
       const secondRow = page.locator(`.sidebar-recent-session[data-session-key="${secondKey}"]`);
       await expect
         .poll(async () =>
@@ -191,7 +191,7 @@ suite.define(() => {
     });
 
     try {
-      await page.goto(`${suite.server.baseUrl}chat`);
+      await page.goto(controlUiSessionUrl(suite.server.baseUrl, key));
       const row = page.locator(`.sidebar-recent-session[data-session-key="${key}"]`);
       await row.getByText("Implementing the repair").waitFor();
       if (captureUiProofEnabled) {
@@ -239,7 +239,6 @@ suite.define(() => {
       viewport: { height: 900, width: 1280 },
     });
     const page = await context.newPage();
-    await page.clock.install();
     const sessions = chatSessionListResponse();
     const firstSession = expectDefined(sessions.sessions[0], "first chat session fixture");
     const secondSession = expectDefined(sessions.sessions[1], "second chat session fixture");
@@ -254,7 +253,7 @@ suite.define(() => {
     });
 
     try {
-      await page.goto(`${suite.server.baseUrl}chat`);
+      await page.goto(controlUiSessionUrl(suite.server.baseUrl, "agent:main:session-a"));
       const recentRow = page.locator(
         '.sidebar-recent-session[data-session-key="agent:main:session-b"]',
       );
@@ -269,30 +268,36 @@ suite.define(() => {
       }));
       expect(layout.scrollWidth, JSON.stringify(layout)).toBeGreaterThan(layout.clientWidth);
 
-      // Freeze the clock so the 500ms hover-intent delay elapses only via
-      // runFor; a ticking clock let slow runners start the marquee before the
-      // "not yet scrolling" asserts below.
-      await pauseVirtualClock(page);
-      await recentRow.dispatchEvent("mouseenter");
-      await page.clock.runFor(250);
+      const rowBox = await recentRow.boundingBox();
+      expect(rowBox).not.toBeNull();
+      if (!rowBox) {
+        return;
+      }
+      await page.mouse.move(rowBox.x + rowBox.width + 40, rowBox.y + rowBox.height / 2);
+      await page.mouse.move(rowBox.x + rowBox.width / 2, rowBox.y + rowBox.height / 2, {
+        steps: 12,
+      });
+      await page.waitForTimeout(250);
       expect(await recentLabel.evaluate((label) => label.classList.value)).not.toContain(
         "hover-marquee--scrolling",
       );
-      await recentRow.dispatchEvent("mouseleave");
+      await page.mouse.move(rowBox.x + rowBox.width + 40, rowBox.y + rowBox.height / 2, {
+        steps: 12,
+      });
       // 250 + 300 exceeds the hover delay: only the leave-cancel keeps it off.
-      await page.clock.runFor(300);
+      await page.waitForTimeout(300);
       expect(await recentLabel.evaluate((label) => label.classList.value)).not.toContain(
         "hover-marquee--scrolling",
       );
-      await recentRow.dispatchEvent("mouseenter");
-      await page.clock.runFor(500);
+      await page.mouse.move(rowBox.x + rowBox.width / 2, rowBox.y + rowBox.height / 2, {
+        steps: 12,
+      });
       await expect
         .poll(() => recentLabel.evaluate((label) => label.classList.value), { timeout: 1_500 })
         .toContain("hover-marquee--scrolling");
-      // Resume real time: the snap-back below is a compositor-driven CSS
-      // transition, not a fake-timer callback.
-      await page.clock.resume();
-      await recentRow.dispatchEvent("mouseleave");
+      await page.mouse.move(rowBox.x + rowBox.width + 40, rowBox.y + rowBox.height / 2, {
+        steps: 12,
+      });
       await expect
         .poll(
           () =>
@@ -302,7 +307,7 @@ suite.define(() => {
             })),
           { timeout: 1_500 },
         )
-        .toEqual({ textIndent: "0px", textOverflow: "ellipsis" });
+        .toEqual({ textIndent: "0px", textOverflow: "clip" });
 
       await recentRow.locator("a.sidebar-recent-session__link").dispatchEvent("click", {
         button: 0,
@@ -319,13 +324,13 @@ suite.define(() => {
           textIndent: getComputedStyle(label).textIndent,
           textOverflow: getComputedStyle(label).textOverflow,
         })),
-      ).toEqual({ textIndent: "0px", textOverflow: "ellipsis" });
+      ).toEqual({ textIndent: "0px", textOverflow: "clip" });
     } finally {
       await suite.closeBrowserContext(context);
     }
   });
 
-  it("reveals a long sidebar title through a physical hover with reduced motion enabled", async () => {
+  it("keeps a long sidebar title static with reduced motion enabled", async () => {
     const context = await suite.newBrowserContext({
       locale: "en-US",
       reducedMotion: "reduce",
@@ -343,7 +348,7 @@ suite.define(() => {
     });
 
     try {
-      await page.goto(`${suite.server.baseUrl}chat`);
+      await page.goto(controlUiSessionUrl(suite.server.baseUrl, "agent:main:session-a"));
       const row = page.locator('.sidebar-recent-session[data-session-key="agent:main:session-b"]');
       const label = row.locator(".sidebar-recent-session__name");
       await label.waitFor({ state: "visible", timeout: 10_000 });
@@ -355,13 +360,23 @@ suite.define(() => {
       await page.mouse.move(box.x + box.width + 40, box.y + box.height / 2);
       await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2, { steps: 12 });
 
-      await expect
-        .poll(
-          () =>
-            label.evaluate((element) => Number.parseFloat(getComputedStyle(element).textIndent)),
-          { timeout: 2_000 },
-        )
-        .toBeLessThan(-1);
+      await page.waitForTimeout(700);
+      expect(
+        await label.evaluate((element) => {
+          const style = getComputedStyle(element);
+          return {
+            maskImage: style.maskImage,
+            textIndent: style.textIndent,
+            textOverflow: style.textOverflow,
+            webkitMaskImage: style.webkitMaskImage,
+          };
+        }),
+      ).toEqual({
+        maskImage: "none",
+        textIndent: "0px",
+        textOverflow: "ellipsis",
+        webkitMaskImage: "none",
+      });
     } finally {
       await suite.closeBrowserContext(context);
     }
@@ -440,7 +455,7 @@ suite.define(() => {
     });
 
     try {
-      await page.goto(`${suite.server.baseUrl}chat`);
+      await page.goto(controlUiSessionUrl(suite.server.baseUrl, busyKey));
       const busyRow = page.locator(`.sidebar-recent-session[data-session-key="${busyKey}"]`);
       const plainRow = page.locator(`.sidebar-recent-session[data-session-key="${plainKey}"]`);
       await busyRow.locator(".session-row-badges").waitFor();
@@ -703,7 +718,7 @@ suite.define(() => {
     });
 
     try {
-      await page.goto(`${suite.server.baseUrl}chat`);
+      await page.goto(controlUiSessionUrl(suite.server.baseUrl, "agent:main:session-a"));
       const documentMarker = await page.evaluate(() => {
         const marker = crypto.randomUUID();
         (window as Window & { __openclawAvatarTestDocument?: string })[

--- a/ui/src/lib/hover-marquee.test.ts
+++ b/ui/src/lib/hover-marquee.test.ts
@@ -11,6 +11,10 @@ function leave(row: HTMLElement) {
   row.dispatchEvent(new MouseEvent("mouseleave"));
 }
 
+function settleHoverLayout() {
+  vi.advanceTimersToNextTimer();
+}
+
 function buildRow(params: { textWidth: number; labelWidth: number }) {
   const row = document.createElement("div");
   const label = document.createElement("span");
@@ -18,7 +22,10 @@ function buildRow(params: { textWidth: number; labelWidth: number }) {
   label.textContent = "Fix stale iMessage group-allowlist warning copy";
   row.append(label);
   document.body.append(row);
-  Object.defineProperty(label, "clientWidth", { value: params.labelWidth });
+  Object.defineProperty(row, "matches", {
+    value: (selector: string) => selector === ":hover" || selector === ":focus-within",
+  });
+  Object.defineProperty(label, "clientWidth", { configurable: true, value: params.labelWidth });
   Object.defineProperty(label, "scrollWidth", { value: params.textWidth });
   return { row, label };
 }
@@ -35,6 +42,7 @@ describe("hover marquee", () => {
   it("waits before scrolling overflowing labels by the clipped distance", () => {
     const { row, label } = buildRow({ textWidth: 320, labelWidth: 180 });
     enter(row);
+    settleHoverLayout();
     expect(label.style.getPropertyValue("--hover-marquee-shift")).toBe("-140px");
     expect(label.style.getPropertyValue("--hover-marquee-duration")).toBe("1750ms");
     vi.advanceTimersByTime(499);
@@ -57,6 +65,7 @@ describe("hover marquee", () => {
   it("keeps short scroll distances readable with a minimum duration", () => {
     const { row, label } = buildRow({ textWidth: 190, labelWidth: 180 });
     enter(row);
+    settleHoverLayout();
     expect(label.style.getPropertyValue("--hover-marquee-shift")).toBe("-10px");
     expect(label.style.getPropertyValue("--hover-marquee-duration")).toBe("300ms");
   });
@@ -66,6 +75,7 @@ describe("hover marquee", () => {
     label.dataset.hoverMarqueeDelay = "250";
     label.dataset.hoverMarqueeExtraShift = "18";
     enter(row);
+    settleHoverLayout();
     expect(label.style.getPropertyValue("--hover-marquee-shift")).toBe("-158px");
     expect(label.style.getPropertyValue("--hover-marquee-duration")).toBe("1975ms");
     vi.advanceTimersByTime(249);
@@ -77,6 +87,7 @@ describe("hover marquee", () => {
   it("leaves labels that fit untouched", () => {
     const { row, label } = buildRow({ textWidth: 120, labelWidth: 180 });
     enter(row);
+    settleHoverLayout();
     expect(label.classList.contains("hover-marquee--scrolling")).toBe(false);
     expect(label.style.getPropertyValue("--hover-marquee-shift")).toBe("");
   });
@@ -121,6 +132,7 @@ describe("hover marquee", () => {
     Object.defineProperty(label, "scrollWidth", { value: 320 });
 
     enter(row);
+    settleHoverLayout();
     vi.advanceTimersByTime(500);
     expect(label.style.getPropertyValue("--hover-marquee-shift")).toBe("-140px");
     expect(label.classList.contains("hover-marquee--scrolling")).toBe(true);
@@ -138,9 +150,22 @@ describe("hover marquee", () => {
     }
     resizeCallback([resizeEntry], callbackObserver);
 
+    settleHoverLayout();
     expect(label.style.getPropertyValue("--hover-marquee-shift")).toBe("-200px");
     expect(label.classList.contains("hover-marquee--scrolling")).toBe(false);
     vi.advanceTimersByTime(500);
     expect(label.classList.contains("hover-marquee--scrolling")).toBe(true);
+  });
+
+  it("measures after hover actions reduce the available title width", () => {
+    let labelWidth = 180;
+    const { row, label } = buildRow({ textWidth: 320, labelWidth });
+    Object.defineProperty(label, "clientWidth", { configurable: true, get: () => labelWidth });
+
+    enter(row);
+    labelWidth = 128;
+    settleHoverLayout();
+
+    expect(label.style.getPropertyValue("--hover-marquee-shift")).toBe("-192px");
   });
 });

--- a/ui/src/lib/hover-marquee.test.ts
+++ b/ui/src/lib/hover-marquee.test.ts
@@ -62,6 +62,18 @@ describe("hover marquee", () => {
     expect(label.classList.contains("hover-marquee--scrolling")).toBe(false);
   });
 
+  it("preserves the original hover delay when an active label ref reconnects", () => {
+    const { row, label } = buildRow({ textWidth: 320, labelWidth: 180 });
+    enter(row);
+    settleHoverLayout();
+    vi.advanceTimersByTime(250);
+    enter(row);
+    vi.advanceTimersByTime(249);
+    expect(label.classList.contains("hover-marquee--scrolling")).toBe(false);
+    vi.advanceTimersByTime(1);
+    expect(label.classList.contains("hover-marquee--scrolling")).toBe(true);
+  });
+
   it("keeps short scroll distances readable with a minimum duration", () => {
     const { row, label } = buildRow({ textWidth: 190, labelWidth: 180 });
     enter(row);

--- a/ui/src/lib/hover-marquee.test.ts
+++ b/ui/src/lib/hover-marquee.test.ts
@@ -102,12 +102,15 @@ describe("hover marquee", () => {
 
   it("remeasures an active marquee when its available width changes", () => {
     let resizeCallback: ResizeObserverCallback | undefined;
+    let observeCount = 0;
     class TestResizeObserver implements ResizeObserver {
       constructor(callback: ResizeObserverCallback) {
         resizeCallback = callback;
       }
 
-      observe() {}
+      observe() {
+        observeCount += 1;
+      }
       unobserve() {}
       disconnect() {}
     }
@@ -155,6 +158,12 @@ describe("hover marquee", () => {
     expect(label.classList.contains("hover-marquee--scrolling")).toBe(false);
     vi.advanceTimersByTime(500);
     expect(label.classList.contains("hover-marquee--scrolling")).toBe(true);
+    resizeCallback([resizeEntry], callbackObserver);
+    resizeCallback([resizeEntry], callbackObserver);
+
+    expect(observeCount).toBe(1);
+    expect(label.classList.contains("hover-marquee--scrolling")).toBe(true);
+    expect(label.style.getPropertyValue("--hover-marquee-shift")).toBe("-200px");
   });
 
   it("measures after hover actions reduce the available title width", () => {

--- a/ui/src/lib/hover-marquee.ts
+++ b/ui/src/lib/hover-marquee.ts
@@ -77,10 +77,9 @@ function startHoverMarquee(host: HTMLElement): void {
     return;
   }
   observeMarquee(label);
-  if (label.classList.contains("hover-marquee--scrolling")) {
+  if (label.classList.contains("hover-marquee--scrolling") || pendingMarquees.has(label)) {
     return;
   }
-  clearPendingMarquee(label);
   // Hover-only row actions change the title width in CSS after mouseenter.
   // Measure on the next frame so the animation owns the visible width instead
   // of depending on a later ResizeObserver notification to correct it.

--- a/ui/src/lib/hover-marquee.ts
+++ b/ui/src/lib/hover-marquee.ts
@@ -1,12 +1,14 @@
 // Hover marquee for truncated single-line labels: on pointer enter, animate
 // text-indent to slide the clipped tail into view; on leave, the base
 // transition in styles/components.css (.hover-marquee) snaps it back quickly.
-// text-indent (not an inner transform wrapper) because text-overflow renders
-// no ellipsis for atomic inline children, which would lose the resting "…".
+// text-indent keeps the clipped text inside the same soft-edge viewport while
+// avoiding the extra wrapper an inner transform would require.
 const MARQUEE_SPEED_PX_PER_SEC = 80;
 const MARQUEE_MIN_DURATION_MS = 300;
 const MARQUEE_HOVER_DELAY_MS = 500;
-const pendingMarquees = new WeakMap<HTMLElement, number>();
+type PendingMarquee = { frame: number; timer?: number };
+
+const pendingMarquees = new WeakMap<HTMLElement, PendingMarquee>();
 let marqueeResizeObserver: ResizeObserver | undefined;
 
 function isMarqueeHostActive(host: HTMLElement): boolean {
@@ -24,7 +26,10 @@ function clearPendingMarquee(label: HTMLElement): void {
   if (pending === undefined) {
     return;
   }
-  window.clearTimeout(pending);
+  window.cancelAnimationFrame(pending.frame);
+  if (pending.timer !== undefined) {
+    window.clearTimeout(pending.timer);
+  }
   pendingMarquees.delete(label);
 }
 
@@ -62,36 +67,44 @@ function startHoverMarquee(host: HTMLElement): void {
     return;
   }
   clearPendingMarquee(label);
-  // Measure at hover time: labels resize with the sidebar and with hover-only
-  // row actions, so a cached width would drift. A negative mid-transition
-  // indent (re-hover while snapping back) shrinks scrollWidth; add it back.
-  const indent = Number.parseFloat(getComputedStyle(label).textIndent) || 0;
-  const overflow = label.scrollWidth - indent - label.clientWidth;
-  if (overflow <= 1) {
-    label.style.removeProperty("--hover-marquee-shift");
-    label.style.removeProperty("--hover-marquee-duration");
-    return;
-  }
-  const extraShift = Number(label.dataset.hoverMarqueeExtraShift ?? 0);
-  const shift = overflow + (Number.isFinite(extraShift) ? Math.max(0, extraShift) : 0);
-  const durationMs = Math.max(
-    MARQUEE_MIN_DURATION_MS,
-    Math.round((shift / MARQUEE_SPEED_PX_PER_SEC) * 1000),
-  );
-  label.style.setProperty("--hover-marquee-shift", `${-shift}px`);
-  label.style.setProperty("--hover-marquee-duration", `${durationMs}ms`);
-  // Keep quick pointer passes quiet; leaving before the timer fires cancels it.
-  const hoverDelay = Number(label.dataset.hoverMarqueeDelay);
-  pendingMarquees.set(
-    label,
-    window.setTimeout(
-      () => {
+  // Hover-only row actions change the title width in CSS after mouseenter.
+  // Measure on the next frame so the animation owns the visible width instead
+  // of depending on a later ResizeObserver notification to correct it.
+  const pending: PendingMarquee = {
+    frame: window.requestAnimationFrame(() => {
+      if (pendingMarquees.get(label) !== pending || !isMarqueeHostActive(host)) {
+        return;
+      }
+      // A negative mid-transition indent (re-hover while snapping back) shrinks
+      // scrollWidth; add it back when calculating the clipped distance.
+      const indent = Number.parseFloat(getComputedStyle(label).textIndent) || 0;
+      const overflow = label.scrollWidth - indent - label.clientWidth;
+      if (overflow <= 1) {
         pendingMarquees.delete(label);
-        label.classList.add("hover-marquee--scrolling");
-      },
-      Number.isFinite(hoverDelay) ? Math.max(0, hoverDelay) : MARQUEE_HOVER_DELAY_MS,
-    ),
-  );
+        label.style.removeProperty("--hover-marquee-shift");
+        label.style.removeProperty("--hover-marquee-duration");
+        return;
+      }
+      const extraShift = Number(label.dataset.hoverMarqueeExtraShift ?? 0);
+      const shift = overflow + (Number.isFinite(extraShift) ? Math.max(0, extraShift) : 0);
+      const durationMs = Math.max(
+        MARQUEE_MIN_DURATION_MS,
+        Math.round((shift / MARQUEE_SPEED_PX_PER_SEC) * 1000),
+      );
+      label.style.setProperty("--hover-marquee-shift", `${-shift}px`);
+      label.style.setProperty("--hover-marquee-duration", `${durationMs}ms`);
+      // Keep quick pointer passes quiet; leaving before the timer fires cancels it.
+      const hoverDelay = Number(label.dataset.hoverMarqueeDelay);
+      pending.timer = window.setTimeout(
+        () => {
+          pendingMarquees.delete(label);
+          label.classList.add("hover-marquee--scrolling");
+        },
+        Number.isFinite(hoverDelay) ? Math.max(0, hoverDelay) : MARQUEE_HOVER_DELAY_MS,
+      );
+    }),
+  };
+  pendingMarquees.set(label, pending);
 }
 
 function stopHoverMarquee(host: HTMLElement): void {

--- a/ui/src/lib/hover-marquee.ts
+++ b/ui/src/lib/hover-marquee.ts
@@ -9,6 +9,8 @@ const MARQUEE_HOVER_DELAY_MS = 500;
 type PendingMarquee = { frame: number; timer?: number };
 
 const pendingMarquees = new WeakMap<HTMLElement, PendingMarquee>();
+const marqueeWidths = new WeakMap<HTMLElement, number>();
+const observedMarquees = new WeakSet<HTMLElement>();
 let marqueeResizeObserver: ResizeObserver | undefined;
 
 function isMarqueeHostActive(host: HTMLElement): boolean {
@@ -46,15 +48,27 @@ function observeMarquee(label: HTMLElement): void {
         const host = resizedLabel.closest<HTMLElement>(".session-row-host");
         if (!host || !isMarqueeHostActive(host)) {
           marqueeResizeObserver?.unobserve(resizedLabel);
+          observedMarquees.delete(resizedLabel);
+          marqueeWidths.delete(resizedLabel);
           continue;
         }
+        const width = resizedLabel.clientWidth;
+        // ResizeObserver can redeliver unchanged geometry. Restarting for that
+        // no-op would remove the scrolling class on every animation frame.
+        if (marqueeWidths.get(resizedLabel) === width) {
+          continue;
+        }
+        marqueeWidths.set(resizedLabel, width);
         clearPendingMarquee(resizedLabel);
         resizedLabel.classList.remove("hover-marquee--scrolling");
         startHoverMarquee(host);
       }
     });
   }
-  marqueeResizeObserver?.observe(label);
+  if (marqueeResizeObserver && !observedMarquees.has(label)) {
+    observedMarquees.add(label);
+    marqueeResizeObserver.observe(label);
+  }
 }
 
 function startHoverMarquee(host: HTMLElement): void {
@@ -78,6 +92,7 @@ function startHoverMarquee(host: HTMLElement): void {
       // A negative mid-transition indent (re-hover while snapping back) shrinks
       // scrollWidth; add it back when calculating the clipped distance.
       const indent = Number.parseFloat(getComputedStyle(label).textIndent) || 0;
+      marqueeWidths.set(label, label.clientWidth);
       const overflow = label.scrollWidth - indent - label.clientWidth;
       if (overflow <= 1) {
         pendingMarquees.delete(label);
@@ -115,6 +130,8 @@ function stopHoverMarquee(host: HTMLElement): void {
   clearPendingMarquee(label);
   label.classList.remove("hover-marquee--scrolling");
   marqueeResizeObserver?.unobserve(label);
+  observedMarquees.delete(label);
+  marqueeWidths.delete(label);
 }
 
 export function startHoverMarqueeFromEvent(event: Event): void {

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -5962,13 +5962,10 @@ td.data-table-key-col {
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .hover-marquee {
-    transition: none;
-  }
-
   .hover-marquee--scrolling {
-    mask-image: linear-gradient(to right, black calc(100% - 16px), transparent);
-    text-indent: 0;
+    /* This operator-triggered transition is the only path to the clipped tail.
+       Keep its measured pace despite base.css's blanket motion suppression. */
+    transition-duration: var(--hover-marquee-duration, 600ms) !important;
   }
 }
 

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -5945,18 +5945,17 @@ td.data-table-key-col {
 
 /* Truncated single-line labels that slide on hover to reveal the clipped
    tail. lib/hover-marquee.ts measures the overflow and sets the custom
-   properties; without it the label stays a plain ellipsized span. Animates
-   text-indent so the resting ellipsis keeps rendering (text-overflow shows
-   no "…" for atomic inline children, ruling out a transformed wrapper). */
+   properties; without it the label stays clipped behind a soft edge. */
 .hover-marquee {
   overflow: hidden;
-  text-overflow: ellipsis;
+  text-overflow: clip;
   white-space: nowrap;
+  mask-image: linear-gradient(to right, black calc(100% - 16px), transparent);
   transition: text-indent 180ms ease-out;
 }
 
 .hover-marquee--scrolling {
-  text-overflow: clip;
+  mask-image: none;
   text-indent: var(--hover-marquee-shift, 0);
   transition-duration: var(--hover-marquee-duration, 600ms);
   transition-timing-function: linear;
@@ -5968,7 +5967,7 @@ td.data-table-key-col {
   }
 
   .hover-marquee--scrolling {
-    text-overflow: ellipsis;
+    mask-image: linear-gradient(to right, black calc(100% - 16px), transparent);
     text-indent: 0;
   }
 }

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -5950,11 +5950,13 @@ td.data-table-key-col {
   overflow: hidden;
   text-overflow: clip;
   white-space: nowrap;
+  -webkit-mask-image: linear-gradient(to right, black calc(100% - 16px), transparent);
   mask-image: linear-gradient(to right, black calc(100% - 16px), transparent);
   transition: text-indent 180ms ease-out;
 }
 
 .hover-marquee--scrolling {
+  -webkit-mask-image: none;
   mask-image: none;
   text-indent: var(--hover-marquee-shift, 0);
   transition-duration: var(--hover-marquee-duration, 600ms);
@@ -5962,10 +5964,12 @@ td.data-table-key-col {
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .hover-marquee--scrolling {
-    /* This operator-triggered transition is the only path to the clipped tail.
-       Keep its measured pace despite base.css's blanket motion suppression. */
-    transition-duration: var(--hover-marquee-duration, 600ms) !important;
+  .hover-marquee {
+    text-overflow: ellipsis;
+    text-indent: 0;
+    transition: none;
+    -webkit-mask-image: none;
+    mask-image: none;
   }
 }
 


### PR DESCRIPTION
Closes #132790

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where users hovering a long session title in the Control UI sidebar could see it flicker in place because repeated resize observations restarted the marquee after the pin and overflow-menu controls appeared. Resting titles also ended abruptly with an ellipsis instead of a softer edge.

## Why This Change Was Made

The shared hover-marquee owner now measures on the next animation frame, after hover-only controls have claimed their space. Each label is observed once per hover, and resize delivery restarts the animation only when the measured `clientWidth` actually changes. Resting overflow uses a right-edge mask fade; the mask clears only while the title is scrolling and remains in reduced-motion mode.

The production increase is +69/-40 (net +29). The added state makes layout-frame measurement cancellable and records the authoritative observed width, preventing same-geometry notifications from toggling the scrolling class while retaining one restart for a real resize.

### Scope gate

- `ui/src/lib/hover-marquee.ts`: owns hover timing, geometry measurement, cancellation, and shared marquee state.
- `ui/src/styles/components.css`: owns the shared resting fade and scrolling/reduced-motion presentation.
- `ui/src/lib/hover-marquee.test.ts`: covers the width change between pointer entry and the settled hover layout.

The mock fixture, screenshots, video, worklog, and lane marker are not part of the commit.

### Shared consumers checked

- Sidebar recent session rows (`app-sidebar-session-row-render.ts`): corrected post-action width and full travel.
- Sidebar catalog session rows (`app-sidebar-session-catalog-render.ts`): continues through the same shared helper and styles.
- Person activity hovercard session title (`person-activity-card.ts`): retains its shorter delay and extra fade travel through the shared helper.

## User Impact

Long session names now slide far enough to reveal their full tail while pin and menu controls remain available. Without hover, clipped names end in a theme-independent fade instead of an ellipsis. Typography and sizing are unchanged.

## Evidence

Canonical mock harness: `node --import ./scripts/tsx.mjs scripts/control-ui-mock-dev.ts -- --host 127.0.0.1 --port 6007`

Equivalent 1280×900 viewport, same sidebar fixture and crop:

| Theme | Before: ellipsis | After: fade |
| --- | --- | --- |
| Light | ![Light theme before: session titles end with ellipses](https://github.com/user-attachments/assets/87fe2621-21f6-4693-9187-918d2f09aaf2) | ![Light theme after: session titles end with a soft fade](https://github.com/user-attachments/assets/71de09f9-243f-49bb-b400-32d6487bd234) |
| Dark | ![Dark theme before: session titles end with ellipses](https://github.com/user-attachments/assets/e8292501-dd3f-447a-9b96-a0bbbdf16ef9) | ![Dark theme after: session titles end with a soft fade](https://github.com/user-attachments/assets/55838d0d-7e64-45a0-9665-09abe1b20bf2) |

Marquee recording with long and CJK titles while pin/menu controls are visible:

https://github.com/user-attachments/assets/06e06fe0-8a0e-4d5c-bde9-26c64984e214

Browser geometry proof on the fixed observer path: 403 px content, 129 px settled hover viewport, one scrolling-class transition, and continuous travel from `0` to the requested/final `-274px` through the last word, with pin/menu controls visible.

A focused regression test covers the width shrinking between pointer entry and the next animation frame. Per workstation policy, no local suite/build/typecheck was run; exact-head CI is the validation owner.

Fresh Codex autoreview of head `23d9193fb7922b31ea9d622a4a54040a23ebfabe` against `origin/main`: clean, with no accepted or actionable findings.
