### PR TITLE
fix(ui): keep Inbox tabs stable across empty categories

### DIFF
--- a/ui/src/components/sidebar-attention-layout.browser.test.ts
+++ b/ui/src/components/sidebar-attention-layout.browser.test.ts
@@ -1,4 +1,6 @@
+import { render } from "lit";
 import { afterEach, describe, expect, it } from "vitest";
+import type { ApplicationContext } from "../app/context.ts";
 import "../test-helpers/load-styles.ts";
 import "../styles/hub-tabs.css";
 import "../styles/sidebar-attention-floating.css";
@@ -7,6 +9,8 @@ import "./web-awesome-tabs.ts";
 // Upgrade the real element: the floating layout once regressed because a base
 // class stamped inline `display: contents`, which only a live upgrade reveals.
 import "./sidebar-attention.ts";
+import type { SidebarInboxEntry } from "./sidebar-attention-entries.ts";
+import { renderSidebarAttentionPanel } from "./sidebar-attention-panel.runtime.ts";
 
 afterEach(() => {
   document.body.replaceChildren();
@@ -18,6 +22,75 @@ afterEach(() => {
 });
 
 describe.runIf("__vitest_browser__" in globalThis)("Inbox panel layout", () => {
+  it("keeps the header and tabs fixed when the selected category is empty", async () => {
+    const entry: SidebarInboxEntry = {
+      type: "attention",
+      category: "system",
+      dismissal: { kind: "modelAuthExpired", signature: "expired-profile" },
+      requiresAction: true,
+      severity: "warning",
+      kind: "modelAuthExpired",
+      icon: "plug",
+      label: "Auth expired",
+      detail: "Reconnect the provider.",
+      action: { kind: "navigate", routeId: "config" },
+      signature: "expired-profile",
+    };
+    const context = {
+      basePath: "",
+      gateway: { snapshot: undefined },
+    } as unknown as ApplicationContext;
+
+    for (const mobile of [false, true]) {
+      const shell = document.createElement("div");
+      shell.className = mobile ? "shell shell--mobile-nav" : "shell";
+      document.body.append(shell);
+      const renderPanel = (selectedTab: "all" | "approvals") => {
+        render(
+          renderSidebarAttentionPanel({
+            context,
+            entries: [entry],
+            onApprovalDecision: () => {},
+            onClose: () => {},
+            onDismiss: () => {},
+            onKeydown: () => {},
+            onNavigate: () => {},
+            onOpen: () => {},
+            onScroll: () => {},
+            onSelectTab: () => {},
+            overflowAbove: false,
+            overflowBelow: false,
+            panelPosition: { left: 0, anchor: "top", top: 0 },
+            selectedTab,
+          }),
+          shell,
+        );
+      };
+
+      renderPanel("all");
+      await customElements.whenDefined("wa-tab-group");
+      const populatedHeader = shell.querySelector<HTMLElement>(".sidebar-issues-panel__header")!;
+      const populatedTabs = shell.querySelector<HTMLElement>(".sidebar-issues-panel__tabs")!;
+      const headerHeight = populatedHeader.getBoundingClientRect().height;
+      const tabsTop = populatedTabs.getBoundingClientRect().top;
+
+      renderPanel("approvals");
+      const placeholder = shell.querySelector<HTMLButtonElement>(
+        ".sidebar-issues-panel__dismiss-shown",
+      )!;
+      expect(placeholder.disabled).toBe(true);
+      expect(placeholder.getAttribute("aria-hidden")).toBe("true");
+      expect(getComputedStyle(placeholder).visibility).toBe("hidden");
+      expect(
+        shell.querySelector(".sidebar-issues-panel__header")!.getBoundingClientRect().height,
+      ).toBe(headerHeight);
+      expect(shell.querySelector(".sidebar-issues-panel__tabs")!.getBoundingClientRect().top).toBe(
+        tabsTop,
+      );
+      shell.remove();
+    }
+  });
+
   it("positions collapsed sidebar attention beyond chrome controls", () => {
     const shell = document.createElement("div");
     shell.className = "shell shell--nav-collapsed";

--- a/ui/src/components/sidebar-attention-panel.runtime.ts
+++ b/ui/src/components/sidebar-attention-panel.runtime.ts
@@ -64,6 +64,7 @@ export function renderSidebarAttentionPanel(params: SidebarAttentionPanelParams)
   const visibleDismissals = visibleEntries.flatMap((entry) =>
     entry.dismissal ? [entry.dismissal] : [],
   );
+  const hasVisibleDismissals = visibleDismissals.length > 0;
   const tabCounts = sidebarInboxTabCounts(params.entries);
   const custodianItems = params.entries.filter(
     (entry) => entry.type === "attention" && entry.action.kind === "askCustodian",
@@ -136,19 +137,20 @@ export function renderSidebarAttentionPanel(params: SidebarAttentionPanelParams)
             ${t("attention.issues")}
           </h2>
           <div class="sidebar-issues-panel__header-actions">
-            ${visibleDismissals.length > 0
-              ? html`<button
-                  type="button"
-                  class="btn btn--xs btn--ghost sidebar-issues-panel__dismiss-shown"
-                  @click=${() => {
-                    for (const dismissal of visibleDismissals) {
-                      params.onDismiss(dismissal);
-                    }
-                  }}
-                >
-                  ${t("attention.dismissShown")}
-                </button>`
-              : nothing}
+            <button
+              type="button"
+              class="btn btn--xs btn--ghost sidebar-issues-panel__dismiss-shown"
+              style=${hasVisibleDismissals ? nothing : "visibility:hidden"}
+              ?disabled=${!hasVisibleDismissals}
+              aria-hidden=${hasVisibleDismissals ? nothing : "true"}
+              @click=${() => {
+                for (const dismissal of visibleDismissals) {
+                  params.onDismiss(dismissal);
+                }
+              }}
+            >
+              ${t("attention.dismissShown")}
+            </button>
             ${renderSidebarAskOpenClawButton({
               count: custodianItems.length,
               severity: custodianSeverity,

--- a/ui/src/styles/sidebar-issues.css
+++ b/ui/src/styles/sidebar-issues.css
@@ -82,7 +82,7 @@
   align-items: center;
   justify-content: space-between;
   gap: 8px;
-  padding: 8px 12px;
+  padding: 12px;
   background: var(--secondary);
 }
 
@@ -182,6 +182,10 @@
 /* Hub-tab strip (shared hub-tabs.css owns the tab look); this block only
    places it in the popover: the track hairline doubles as the header/list
    separator, so it must span the full panel width. */
+:root[data-theme-mode="dark"] .sidebar-issues-panel__tabs.hub-tabs {
+  --track-color: color-mix(in srgb, var(--border-strong) 60%, transparent);
+}
+
 .sidebar-issues-panel__tabs {
   display: block;
   flex: none;
@@ -213,7 +217,7 @@
 .sidebar-issues-panel__tabs wa-tab.hub-tab::part(base) {
   /* Popover tabs are tap targets (mobile sheet); keep a taller hit area than
      the page-hub sub tabs. */
-  padding-block: 6px 9px;
+  padding-block: 8px 11px;
 }
 
 .sidebar-issues-panel__list-wrap {


### PR DESCRIPTION
Closes #132795

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Switching from an Inbox category with dismissible items to an empty category removed the conditional “Dismiss shown” control. Without another header action, the title row collapsed and moved the tab strip by 12 px on desktop and 4 px on narrow layouts. The compact title/tab block and very faint dark-theme hairline made the movement and separation harder to read.

## Why This Change Was Made

The panel renderer now owns a stable action slot at every width. “Dismiss shown” remains rendered when the selected category has no dismissible entries, but is hidden, disabled, and excluded from the accessibility tree. Its localized box keeps the exact layout footprint without exposing an action.

The Inbox title row and tabs receive balanced additional vertical padding. The Inbox tab track alone uses the existing `--border-strong` token in its 60% hairline mix. Global border tokens and their normal-to-strong hover/focus transitions remain unchanged.

The browser regression test renders the real panel and checks populated All against empty Approvals in both desktop and mobile shells.

## User Impact

Inbox title and tabs stay pixel-stable while switching among All, Approvals, Automations, and System, with or without Ask OpenClaw. The header has more breathing room, and its dark-theme bottom hairline is easier to distinguish. Dismissal behavior is unchanged.

## Evidence

Canonical mocked Control UI flow with Ask OpenClaw hidden. Every composite shows All on the left and Approvals on the right under equivalent conditions. All eight composites were visually inspected before upload.

Before: desktop header `44 px → 32 px`; narrow header `56 px → 52 px`.

After: desktop header `52 px → 52 px`; narrow header `64 px → 64 px`. Header and tab positions remain identical between categories at each width.

### Desktop — light, 1280×900

| Before | After |
| --- | --- |
| ![Desktop light before: All and Approvals have different header heights](https://github.com/user-attachments/assets/46b61aa3-b334-412d-aeee-e368a5f5160f) | ![Desktop light after: All and Approvals have stable, roomier headers with the original light track](https://github.com/user-attachments/assets/5d48fae0-802e-43fa-a421-37b0d8fc0e45) |

### Desktop — dark, 1280×900

The Inbox tab track changes from the default border mix (`#1e2028` at 60%) to a local mix of the existing strong token (`#2e3040` at 60%).

| Before | After |
| --- | --- |
| ![Desktop dark before: compact shifting header and faint hairline](https://github.com/user-attachments/assets/8b3fc2d5-11e8-4810-99bc-e1a1363f5f8b) | ![Desktop dark after: stable roomier header and dark-only strong-token hairline](https://github.com/user-attachments/assets/bf37c3a2-edcb-46fa-a8aa-cc403e9df6ac) |

### Narrow — light, 390×844

| Before | After |
| --- | --- |
| ![Narrow light before: All and Approvals move by four pixels](https://github.com/user-attachments/assets/4bf931a0-c274-4345-b944-2f221728eee0) | ![Narrow light after: All and Approvals remain aligned with more breathing room](https://github.com/user-attachments/assets/e5960ff9-4ec1-49ab-947d-56f14b5acbd8) |

### Narrow — dark, 390×844

| Before | After |
| --- | --- |
| ![Narrow dark before: shifting compact header and faint hairline](https://github.com/user-attachments/assets/421e836b-00d5-4f88-80fe-eb13b8da95ab) | ![Narrow dark after: stable roomier header and locally scoped strong-token hairline](https://github.com/user-attachments/assets/19d653a7-0caf-41e6-991e-a4ec53c906ce) |

## Scope and Validation

- `ui/src/components/sidebar-attention-panel.runtime.ts`: shared producer for the Inbox title/action row; preserves the action slot.
- `ui/src/styles/sidebar-issues.css`: Inbox layout owner; adjusts title-row/tab vertical padding and scopes the strong-token hairline to the dark-theme Inbox tab track.
- `ui/src/components/sidebar-attention-layout.browser.test.ts`: real-renderer regression coverage for populated-to-empty transitions in desktop and mobile shells.
- Nominal consumers checked: desktop Inbox panel, narrow Inbox drawer, All/Approvals/Automations/System category renders, and the Inbox tab track in light and dark. Global border consumers are unaffected because `base.css` is unchanged.
- The mock fixture and Ask OpenClaw tuner are not included in the commit.
- Production LOC: +21/-15 (net +6). Tests: +73/-0.
- Local suites, build, and typecheck were intentionally not run under the mock-only workstation policy. Exact-head CI remains the executable gate.
- Codex autoreview against `origin/main`: clean, zero accepted/actionable findings (0.99 confidence).

### ClawSweeper rank-up moves

- **Resolve merge risk — applied:** the production growth is limited to the renderer-owned inert action slot plus the maintainer-approved Inbox spacing and dark-only track override. The global border-token attempt was removed; `base.css` is unchanged.
- **Complete next step — applied:** maintainer design review and the final adversarial re-audit are complete and clean; the PR is proceeding through the normal ready, exact-head CI, and native landing path.
