### PR TITLE
fix(ui): unify connected composer stack surface

### DIFF
--- a/ui/src/pages/chat/chat-responsive.browser.test.ts
+++ b/ui/src/pages/chat/chat-responsive.browser.test.ts
@@ -4489,6 +4489,13 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
       await page.setContent(`<!doctype html><html><head><style>${readUiCss()}
         body { margin: 0; padding: 32px; background: var(--bg); }
         .agent-chat__composer-shell { width: 760px; margin: 0 auto; }
+        .session-progress-card__summary :is(
+          .session-progress-card__summary-title,
+          .session-progress-card__heading-actions,
+          .session-progress-card__current,
+          .session-progress-card__summary-count,
+          .session-progress-card__summary-chevron
+        ) { transition: none; }
       </style></head><body>
         <div class="agent-chat__composer-shell">
           <div class="agent-chat__progress-float">
@@ -4539,6 +4546,9 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
         <span id="failed-outcome-probe" class="session-progress-card__summary-count" data-outcome="failed">Failed</span>
         <span id="danger-color-probe" style="color: var(--danger)">Danger</span>
       </body></html>`);
+      await page.evaluate(() => {
+        document.documentElement.dataset.themeMode = "light";
+      });
 
       const summary = page.locator(".session-progress-card__summary");
       const card = page.locator(".session-progress-card--composer");
@@ -4566,42 +4576,92 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
             y: bounds(".session-progress-card__summary").y,
           };
         });
-      const waitForSummaryColors = async (
-        selectors: string[],
-        colors: string[],
-        comparison: "equal" | "different",
-      ) => {
-        const match = await page.waitForFunction(
-          ({ expectedColors, expectedComparison, targetSelectors }) =>
-            targetSelectors.every((selector, index) => {
-              const current = getComputedStyle(
-                document.querySelector<HTMLElement>(selector)!,
-              ).color;
-              return (current === expectedColors[index]) === (expectedComparison === "equal");
-            }),
-          {
-            expectedColors: colors,
-            expectedComparison: comparison,
-            targetSelectors: selectors,
-          },
+      const setSummaryHover = async (hovered: boolean) => {
+        if (hovered) {
+          await summary.hover();
+        } else {
+          await page.mouse.move(0, 0);
+        }
+        const state = await page.waitForFunction(
+          (expected) =>
+            document
+              .querySelector<HTMLElement>(".session-progress-card__summary")!
+              .matches(":hover") === expected,
+          hovered,
         );
-        await match.dispose();
+        await state.dispose();
       };
       const expandedBefore = await readSummaryState();
-      await summary.hover();
-      await waitForSummaryColors(
-        [
-          ".session-progress-card__summary-title",
-          ".session-progress-card__heading-actions",
-          ".session-progress-card__summary-chevron",
-        ],
-        [expandedBefore.titleColor, expandedBefore.actionsColor, expandedBefore.chevronColor],
-        "different",
-      );
+      const { shellBounds, stackSurfaces, warnGoalSurfaces } = await page.evaluate(() => {
+        const snapshot = (selector: string) => {
+          const node = document.querySelector<HTMLElement>(selector)!;
+          const bounds = node.getBoundingClientRect();
+          return {
+            background: getComputedStyle(node).backgroundColor,
+            borderColor: getComputedStyle(node).borderColor,
+            boxShadow: getComputedStyle(node).boxShadow,
+            left: bounds.left,
+            right: bounds.right,
+            topLeftRadius: getComputedStyle(node).borderTopLeftRadius,
+            topRightRadius: getComputedStyle(node).borderTopRightRadius,
+          };
+        };
+        const goal = document.querySelector<HTMLElement>(".agent-chat__goal")!;
+        const activeSurface = snapshot(".agent-chat__goal");
+        const warnSurfaces = ["blocked", "budget_limited", "usage_limited"].map((state) => {
+          goal.className = `agent-chat__goal agent-chat__goal--${state}`;
+          return { state, surface: snapshot(".agent-chat__goal") };
+        });
+        goal.className = "agent-chat__goal agent-chat__goal--active";
+        const shell = document
+          .querySelector<HTMLElement>(".agent-chat__composer-shell")!
+          .getBoundingClientRect();
+        return {
+          shellBounds: { left: shell.left, right: shell.right },
+          stackSurfaces: [
+            snapshot(".session-progress-card--composer"),
+            snapshot(".chat-queue"),
+            activeSurface,
+            snapshot(".agent-chat__input"),
+          ],
+          warnGoalSurfaces: warnSurfaces,
+        };
+      });
+      await setSummaryHover(true);
       const widthAfter = (await card.boundingBox())?.width;
       const expandedAfter = await readSummaryState();
       expect(widthBefore).toBeCloseTo(760, 1);
       expect(widthAfter).toBeCloseTo(widthBefore ?? 0, 1);
+      for (const surface of stackSurfaces) {
+        expect(surface.left).toBeCloseTo(shellBounds.left, 1);
+        expect(surface.right).toBeCloseTo(shellBounds.right, 1);
+      }
+      expect(new Set(stackSurfaces.slice(0, 3).map(({ background }) => background))).toHaveProperty(
+        "size",
+        1,
+      );
+      expect(stackSurfaces.map(({ topLeftRadius }) => topLeftRadius)).toEqual([
+        "25px",
+        "25px",
+        "0px",
+        "25px",
+      ]);
+      expect(stackSurfaces.map(({ topRightRadius }) => topRightRadius)).toEqual([
+        "25px",
+        "25px",
+        "0px",
+        "25px",
+      ]);
+      expect(stackSurfaces[2]?.borderColor).toBe(stackSurfaces[1]?.borderColor);
+      expect(stackSurfaces[2]?.boxShadow).toBe(stackSurfaces[1]?.boxShadow.split(", rgba")[0]);
+      for (const { state, surface } of warnGoalSurfaces) {
+        expect(surface.background, state).not.toBe(stackSurfaces[2]?.background);
+        expect(surface.borderColor, state).not.toBe(stackSurfaces[2]?.borderColor);
+      }
+      expect(new Set(warnGoalSurfaces.map(({ surface }) => surface.borderColor))).toHaveProperty(
+        "size",
+        1,
+      );
       expect(expandedBefore.titleLeft).toBeCloseTo(expandedBefore.firstMarkerLeft, 1);
       expect(expandedAfter.cardBackground).toBe(expandedBefore.cardBackground);
       expect(expandedAfter.summaryBackground).toBe(expandedBefore.summaryBackground);
@@ -4685,25 +4745,18 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
         });
       }
 
-      await page.mouse.move(0, 0);
+      await setSummaryHover(false);
       await card.evaluate((node) => node.removeAttribute("open"));
-      const collapsedColorSelectors = [
-        ".session-progress-card__current",
-        ".session-progress-card__summary-count--collapsed",
-        ".session-progress-card__summary-chevron",
-      ];
-      await waitForSummaryColors(
-        collapsedColorSelectors,
-        [expandedBefore.currentColor, expandedBefore.countColor, expandedBefore.chevronColor],
-        "equal",
+      const collapsedState = await page.waitForFunction(
+        () =>
+          !document.querySelector(".session-progress-card--composer")!.hasAttribute("open") &&
+          getComputedStyle(
+            document.querySelector<HTMLElement>(".session-progress-card__summary-collapsed")!,
+          ).display !== "none",
       );
+      await collapsedState.dispose();
       const collapsedBefore = await readSummaryState();
-      await summary.hover();
-      await waitForSummaryColors(
-        collapsedColorSelectors,
-        [collapsedBefore.currentColor, collapsedBefore.countColor, collapsedBefore.chevronColor],
-        "different",
-      );
+      await setSummaryHover(true);
       const collapsedAfter = await readSummaryState();
       expect(collapsedAfter.cardBackground).toBe(collapsedBefore.cardBackground);
       expect(collapsedAfter.summaryBackground).toBe(collapsedBefore.summaryBackground);

--- a/ui/src/styles/chat/composer-progress.css
+++ b/ui/src/styles/chat/composer-progress.css
@@ -627,14 +627,6 @@
   color: var(--muted);
 }
 
-.agent-chat__goal--blocked,
-.agent-chat__goal--budget_limited,
-.agent-chat__goal--usage_limited {
-  color: var(--warn);
-  background: color-mix(in srgb, var(--warn) 10%, var(--card));
-  border-color: color-mix(in srgb, var(--warn) 30%, var(--border));
-}
-
 .agent-chat__goal--complete {
   color: color-mix(in srgb, var(--ok) 72%, var(--text));
 }
@@ -662,6 +654,17 @@
   background: var(--composer-attached-surface, var(--chat-composer-surface, var(--card)));
   -webkit-backdrop-filter: blur(8px);
   backdrop-filter: blur(8px);
+}
+
+.agent-chat__goal-float
+  :is(
+    .agent-chat__goal--blocked,
+    .agent-chat__goal--budget_limited,
+    .agent-chat__goal--usage_limited
+  ) {
+  color: var(--warn);
+  background: color-mix(in srgb, var(--warn) 10%, var(--card));
+  border-color: color-mix(in srgb, var(--warn) 30%, var(--border));
 }
 
 .agent-chat__goal-float .agent-chat__goal-row {
@@ -904,8 +907,8 @@
 :root[data-theme-mode="light"] .session-progress-card--composer {
   border-color: transparent;
   box-shadow:
-    0 0 0 1px rgb(0 0 0 / 6%),
-    0 1px 2px -1px rgb(0 0 0 / 6%),
+    0 0 0 1px var(--chat-composer-light-outline),
+    0 1px 2px -1px var(--chat-composer-light-outline),
     0 4px 14px rgb(0 0 0 / 7%);
 }
 

--- a/ui/src/styles/chat/composer-queue.css
+++ b/ui/src/styles/chat/composer-queue.css
@@ -11,7 +11,6 @@
 .chat-queue {
   --chat-queue-underlap: 18px;
   --chat-queue-row-height: 42px;
-  --chat-queue-hairline: color-mix(in srgb, var(--text-strong) 16%, transparent);
 
   position: relative;
   z-index: 0;
@@ -22,7 +21,7 @@
   margin-bottom: calc(0px - var(--chat-composer-shell-gap) - var(--chat-queue-underlap));
   padding-bottom: 0;
   overflow: hidden;
-  border: 1px solid var(--chat-queue-hairline);
+  border: 1px solid var(--chat-composer-hairline);
   border-bottom: 0;
   border-radius: calc(20px * var(--openclaw-corner-radius-scale))
     calc(20px * var(--openclaw-corner-radius-scale)) 0 0;
@@ -107,16 +106,22 @@
   background: color-mix(in srgb, var(--muted) 34%, transparent);
 }
 
-:root[data-theme-mode="dark"] .chat-queue {
-  --chat-queue-hairline: color-mix(in srgb, var(--text-strong) 9%, transparent);
-}
-
 :root[data-theme-mode="light"] .chat-queue {
   border-color: transparent;
   box-shadow:
-    0 0 0 1px rgb(0 0 0 / 6%),
-    0 1px 2px -1px rgb(0 0 0 / 6%),
+    0 0 0 1px var(--chat-composer-light-outline),
+    0 1px 2px -1px var(--chat-composer-light-outline),
     0 2px 4px rgb(0 0 0 / 4%);
+}
+
+/* Connected rows share one outline contract. An opaque Goal border or a
+   side-only shadow makes its edge read independently from the queue above. */
+:root[data-theme-mode="light"]
+  :is(.chat-queue, .agent-chat__progress-float)
+  + .agent-chat__goal-float
+  .agent-chat__goal--active {
+  border-color: transparent;
+  box-shadow: 0 0 0 1px var(--chat-composer-light-outline);
 }
 
 .chat-queue__item {

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -3211,6 +3211,7 @@ button.chat-pr__diff {
 .agent-chat__composer-shell,
 .agent-chat__input {
   --chat-composer-surface: var(--popover);
+  --chat-composer-light-outline: rgb(0 0 0 / 6%);
   --composer-attached-surface: color-mix(
     in srgb,
     var(--chat-composer-surface) 60%,
@@ -3324,8 +3325,8 @@ button.chat-pr__diff {
 :root[data-theme-mode="light"] .agent-chat__input {
   border-color: transparent;
   box-shadow:
-    0 0 0 1px rgb(0 0 0 / 6%),
-    0 1px 2px -1px rgb(0 0 0 / 6%),
+    0 0 0 1px var(--chat-composer-light-outline),
+    0 1px 2px -1px var(--chat-composer-light-outline),
     0 2px 4px rgb(0 0 0 / 4%);
 }
 


### PR DESCRIPTION
Closes #132796

## What Problem This Solves

Fixes an issue where the running Goal row used a different border treatment from task progress and the message queue, making it read wider and as a separate surface in the composer stack.

## Why This Change Was Made

The layout rectangles were already identical; the mismatch came from local/duplicated border treatments. The fix centralizes the light outline token, removes the queue's local hairline duplicate, and makes connected Goal use the same attached background, transparent light border, and full 1 px outline contract as task/queue/composer. The internal Goal pre-prompt is untouched.

## User Impact

Progress, neutral queued messages, Goal, and composer now read as one aligned stack in the light theme. Dark-theme rendering is unchanged.

## Evidence

Equivalent neutral/pending queue state. “Before” restores the previous Goal border/side-only shadow; “after” uses the shared production tokens. Every image was visually inspected before upload.

| Viewport/theme | Before | After |
| --- | --- | --- |
| Desktop/light | ![Desktop light before, full composer and transcript](https://github.com/user-attachments/assets/66515f8a-d422-4f66-87b7-8db846a279e3) | ![Desktop light after, full composer and transcript](https://github.com/user-attachments/assets/9c005dca-87a6-4465-a637-c2202ed52228) |
| Mobile/light | ![Mobile light before, full composer and transcript](https://github.com/user-attachments/assets/38d2ab5d-71f7-447d-bbe2-e7f5bf4d72ab) | ![Mobile light after, full composer and transcript](https://github.com/user-attachments/assets/75e34391-8dd6-45c1-b757-cf7d97c7d7ab) |
| Desktop/dark | ![Desktop dark before, full composer and transcript](https://github.com/user-attachments/assets/d94ff70e-2a71-40c9-a3ca-f2c34935591a) | ![Desktop dark after, full composer and transcript](https://github.com/user-attachments/assets/1f26999b-dadf-4d51-9b5b-edfc9a3e5dc6) |
| Mobile/dark | ![Mobile dark before, full composer and transcript](https://github.com/user-attachments/assets/a45549ba-135b-49d3-9185-aa26433dd249) | ![Mobile dark after, full composer and transcript](https://github.com/user-attachments/assets/56833894-887c-47a4-9982-4e13f88663c9) |

Measured together after the fix:

- Desktop 1440×1000: task progress, queue border owner, Goal, composer = `left=465`, `right=1233`, `width=768`.
- Mobile 390×844: all four = `left=8`, `right=382`, `width=374`.
- Queue rows themselves are correctly inside their container's 1 px border (`466..1232` desktop; `9..381` mobile); `.chat-queue` is their visible border owner.
- Task, queue, and Goal compute the same attached background. Queue and Goal compute the same transparent light border and the same shared 1 px outline color.
- Focused regression proof: the pre-fix assertion failed with measured edges `110..870` versus hard-coded `32..792`; the corrected test compares every surface to the measured shell and passes.
- Light-theme state coverage confirms `blocked`, `budget_limited`, and `usage_limited` retain warn backgrounds and borders distinct from the active surface.
- Reliability proof on exact head: the focused browser case passed three consecutive runs after synchronization moved from animated color polling to deterministic `:hover`, disclosure state, and collapsed-content visibility.

## Scope Gate

- `ui/src/styles/chat/layout.css`: owns the shared composer surface tokens; adds the canonical light outline token and migrates composer to it.
- `ui/src/styles/chat/composer-queue.css`: owns queue/Goal connection; removes its duplicate hairline and applies the shared border/outline contract only to active Goal.
- `ui/src/styles/chat/composer-progress.css`: migrates task progress to the same outline token and places all three warn-state surfaces after the structural Goal owner so their semantics win the cascade.
- `ui/src/pages/chat/chat-responsive.browser.test.ts`: asserts shell-relative bounds, radii, attached backgrounds, active border/outline parity, and warn semantics for `blocked`, `budget_limited`, and `usage_limited`.
- No harness, snapshot, generated, lockfile, config, or documentation files are included.
- Production LOC: `+29/-20` (net +9). Test LOC: `+98/-45` (net +53).

## Shared Producer / Named Consumers

Shared producer `--chat-composer-light-outline` is consumed by `.agent-chat__input`, `.session-progress-card--composer`, `.chat-queue`, and connected `.agent-chat__goal`. Width/background consumers checked together: task progress, queue border owner/rows, external Goal bar, and composer. Standalone Goal and the internal Goal pre-prompt are untouched.

## Test-Audit Gate

- Observable invariant: all attached composer surfaces share outer left/right edges and computed background.
- Credible regression: changing any peer away from the measured shell edges, assigning a divergent attached surface, or allowing the active light override to consume warn states fails these assertions.
- Existing coverage gap: it checked only progress width and icon axes, not shell-relative peer bounds or the three warn-state surfaces.
- Production seam: none.
