### PR TITLE
fix(ui): keep Review file previews within panel

### DIFF
--- a/ui/src/pages/chat/components/chat-sidebar-file-view.browser.test.ts
+++ b/ui/src/pages/chat/components/chat-sidebar-file-view.browser.test.ts
@@ -72,6 +72,24 @@ afterEach(() => {
 });
 
 describe.runIf(browserMode)("chat file editor", () => {
+  it("keeps long lines inside Review and gives horizontal scroll to the editor", async () => {
+    const panel = await mountFile({
+      kind: "file",
+      path: "src/long-line.ts",
+      name: "long-line.ts",
+      content: `export const value = "${"long-content-".repeat(80)}";`,
+    });
+    panel.style.width = "320px";
+
+    const fileView = panel.querySelector<HTMLElement>(".file-view")!;
+    const scroller = panel.querySelector<HTMLElement>(".cm-scroller")!;
+    await expect.poll(() => fileView.clientWidth).toBeGreaterThan(0);
+    expect(fileView.clientWidth).toBeLessThanOrEqual(panel.clientWidth);
+    expect(fileView.scrollWidth).toBe(fileView.clientWidth);
+    expect(scroller.scrollWidth).toBeGreaterThan(scroller.clientWidth);
+    expect(getComputedStyle(scroller).overflowX).toBe("auto");
+  });
+
   it("renders content and decorates the requested line", async () => {
     const panel = await mountFile({
       kind: "file",

--- a/ui/src/pages/chat/components/chat-sidebar-file-view.browser.test.ts
+++ b/ui/src/pages/chat/components/chat-sidebar-file-view.browser.test.ts
@@ -1,6 +1,7 @@
 import { expectDefined } from "@openclaw/normalization-core";
 import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import "../../../styles.css";
+import "../../../styles/chat.css";
 import "./chat-sidebar.ts";
 
 // The root jsdom ui shard also collects *.browser.test.ts files; CodeMirror
@@ -42,13 +43,23 @@ type DetailPanel = HTMLElement & {
   updateComplete: Promise<unknown>;
 };
 
-const mounted: DetailPanel[] = [];
+const mounted: HTMLElement[] = [];
 
-async function mountFile(content: FileSidebarContent): Promise<DetailPanel> {
+async function mountFile(content: FileSidebarContent, width?: number): Promise<DetailPanel> {
   const panel = document.createElement("openclaw-chat-detail-panel") as DetailPanel;
   panel.content = content;
-  document.body.append(panel);
-  mounted.push(panel);
+  if (width === undefined) {
+    document.body.append(panel);
+    mounted.push(panel);
+  } else {
+    const container = document.createElement("div");
+    container.className = "side-panel__panel";
+    container.style.cssText = `display:flex;width:${width}px;height:320px;`;
+    panel.className = "chat-sidebar";
+    container.append(panel);
+    document.body.append(container);
+    mounted.push(container);
+  }
   await panel.updateComplete;
   await expect.poll(() => panel.querySelector(".cm-editor"), { timeout: 5_000 }).not.toBeNull();
   return panel;
@@ -73,18 +84,20 @@ afterEach(() => {
 
 describe.runIf(browserMode)("chat file editor", () => {
   it("keeps long lines inside Review and gives horizontal scroll to the editor", async () => {
-    const panel = await mountFile({
-      kind: "file",
-      path: "src/long-line.ts",
-      name: "long-line.ts",
-      content: `export const value = "${"long-content-".repeat(80)}";`,
-    });
-    panel.style.width = "320px";
+    const panel = await mountFile(
+      {
+        kind: "file",
+        path: "src/long-line.ts",
+        name: "long-line.ts",
+        content: `export const value = "${"long-content-".repeat(80)}";`,
+      },
+      320,
+    );
 
     const fileView = panel.querySelector<HTMLElement>(".file-view")!;
     const scroller = panel.querySelector<HTMLElement>(".cm-scroller")!;
     await expect.poll(() => fileView.clientWidth).toBeGreaterThan(0);
-    expect(fileView.clientWidth).toBeLessThanOrEqual(panel.clientWidth);
+    expect(fileView.clientWidth).toBeLessThanOrEqual(panel.parentElement!.clientWidth);
     expect(fileView.scrollWidth).toBe(fileView.clientWidth);
     expect(scroller.scrollWidth).toBeGreaterThan(scroller.clientWidth);
     expect(getComputedStyle(scroller).overflowX).toBe("auto");

--- a/ui/src/styles/chat/sidebar.css
+++ b/ui/src/styles/chat/sidebar.css
@@ -1564,6 +1564,7 @@ openclaw-chat-sidebar-region,
   display: flex;
   flex: 1;
   flex-direction: column;
+  min-width: 0;
   min-height: 0;
 }
 


### PR DESCRIPTION
Closes #132797

## What Problem This Solves

Fixes an issue where users opening a file with a long unwrapped line in the Control UI Review panel would see the file preview expand beyond the panel width on narrow screens. The outer panel clipped the excess, hiding path-bar actions and preventing the editor from owning horizontal navigation.

## Why This Change Was Made

The shared full-height panel wrapper already owns the shrink-and-scroll boundary for Review content, but only released its vertical minimum size. Releasing its horizontal minimum size as well keeps the wrapper within the Review slot and lets the existing CodeMirror scroller handle long lines. Animation, focus, tab labels, panel geometry, and wrapping behavior are unchanged.

## User Impact

Review file previews now stay within the available panel width. On narrow screens, the file path truncates as designed, all toolbar actions remain reachable, and long lines scroll horizontally inside the editor.

Shared wrapper consumers checked:

- File editor: constrained; CodeMirror owns horizontal overflow.
- Markdown preview: remains bounded by the same wrapper and its existing reader scroll behavior.
- Files attachment preview: remains bounded across audio (audio player), video (video player), image (scaled image), document (compact download card), and unavailable-source (visible unavailable state) variants; their existing presentation behavior is unchanged.
- Session diff: remains bounded; its own wrapping and diff scrolling controls are unchanged.

Scope gate:

- `ui/src/styles/chat/sidebar.css`: fixes the shared fill-wrapper invariant with one production line.
- `ui/src/pages/chat/components/chat-sidebar-file-view.browser.test.ts`: protects the visible narrow-panel behavior and scroll ownership with a long-line browser regression.

Production LOC: +1. Test LOC: +35/-4. No generated, dependency, config, protocol, or persistent-state changes.

## Evidence

Deterministic mocked Control UI reproduction at 390×844 and 1440×900:

- Before: Review was 381 px wide, while its fill wrapper grew to 576 px and the file view to 542 px. Toolbar actions were clipped.
- After: the fill wrapper remains 381 px, the file view is 347 px, and CodeMirror owns the overflow (`clientWidth=347`, `scrollWidth=542`, `overflow-x=auto`).

### Mobile (390×844)

| Theme | Before | After |
| --- | --- | --- |
| Light | ![Light theme before: Review toolbar actions clipped by wide file content](https://github.com/user-attachments/assets/a98b0126-298d-42f3-ad6d-ae27b28f7587) | ![Light theme after: Review path truncates and all toolbar actions remain visible](https://github.com/user-attachments/assets/00398b36-455c-45f0-b576-35518efd69ea) |
| Dark | ![Dark theme before: Review toolbar actions clipped by wide file content](https://github.com/user-attachments/assets/71d881df-2d6f-42bd-87f9-ea37d38fd1d1) | ![Dark theme after: Review path truncates and all toolbar actions remain visible](https://github.com/user-attachments/assets/7945d8e1-25ca-4975-b6da-24b3b5d6c5a6) |

### Desktop (1440×900)

| Theme | Before | After |
| --- | --- | --- |
| Light | ![Desktop light theme before: Review toolbar actions clipped by wide file content](https://github.com/user-attachments/assets/6b28508b-1fdf-4929-ae8f-18954d738ead) | ![Desktop light theme after: Review content and toolbar actions remain within the panel](https://github.com/user-attachments/assets/cd08cabd-7377-4cd1-bea4-ace99eaa3819) |
| Dark | ![Desktop dark theme before: Review toolbar actions clipped by wide file content](https://github.com/user-attachments/assets/8f2b7a6a-8274-4cd0-b9a5-02d76d6cc642) | ![Desktop dark theme after: Review content and toolbar actions remain within the panel](https://github.com/user-attachments/assets/bde090ba-e3c3-482f-a2d3-9d54bf5bdc43) |

The captures use the same harness data, selected file, and editor state within each viewport. The before condition applies the exact pre-fix `min-width: auto`; the after condition uses the committed CSS. Each image was inspected before upload. This fix does not change motion, so video evidence is not applicable.

The focused Chromium regression loads the production chat stylesheet and mounts the file panel under the real `.side-panel__panel` flex boundary at 320 px. It fails without the production rule (`fileView.clientWidth=7905`, container width `320`) and passes with `min-width: 0`; the complete file passes all 10 browser tests with the fix. No broader local suite was run.

## ClawSweeper Rank-up Moves

- Applied: marked the PR ready for review and obtained green required CI, including the focused Chromium coverage, on exact head `77a481303dbf427e35b16d559861da14259d56b8`.
