### PR TITLE
perf(agents): defer unused Code Mode runtimes

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -1725,7 +1725,6 @@ src/agents/cli-runner/execute.ts	3
 src/agents/cli-runner/helpers.ts	1
 src/agents/cli-runner/prepare.ts	5
 src/agents/cli-runner/session-history.ts	3
-src/agents/code-mode-bridge.ts	1
 src/agents/code-mode-namespaces.ts	5
 src/agents/code-mode-runtime.ts	4
 src/agents/code-mode-script-syntax.ts	1
@@ -2989,7 +2988,6 @@ src/gateway/server-reload-utils.ts	1
 src/gateway/server-restart-sentinel-agent-delivery.ts	2
 src/gateway/server-runtime-handles.ts	9
 src/gateway/server-runtime-state-prepare.ts	2
-src/gateway/server-session-events.ts	1
 src/gateway/server-startup-bootstrap.ts	1
 src/gateway/server-startup-config-helpers.ts	1
 src/gateway/server-startup-config.ts	1

--- a/src/agents/agent-tools.before-tool-call.diagnostics.ts
+++ b/src/agents/agent-tools.before-tool-call.diagnostics.ts
@@ -46,7 +46,7 @@ import type {
 } from "./agent-tools.before-tool-call.types.js";
 import { normalizeFileToolPathParam } from "./agent-tools.params.js";
 import { getBeforeToolCallSourceTool } from "./before-tool-call-metadata.js";
-import { getChannelAgentToolMeta } from "./channel-tools.js";
+import { getChannelAgentToolMeta } from "./channel-tool-metadata.js";
 import { resolveAgentRunAbortLifecycleFields } from "./run-termination.js";
 import { normalizeToolPolicyName } from "./tool-policy.js";
 import {

--- a/src/agents/agent-tools.before-tool-call.wrapper.ts
+++ b/src/agents/agent-tools.before-tool-call.wrapper.ts
@@ -77,7 +77,7 @@ import {
   getBeforeToolCallSourceTool,
   type BeforeToolCallDiagnosticOptions,
 } from "./before-tool-call-metadata.js";
-import { getChannelAgentToolMeta } from "./channel-tools.js";
+import { getChannelAgentToolMeta } from "./channel-tool-metadata.js";
 import {
   getCodeModeExecBeforeHookMetadata,
   normalizeCodeModeExecBeforeHookParams,

--- a/src/agents/code-mode-bridge.ts
+++ b/src/agents/code-mode-bridge.ts
@@ -1,10 +1,9 @@
 import { createHash, randomUUID } from "node:crypto";
 import { setTimeout as sleep } from "node:timers/promises";
-import { stableStringify } from "@openclaw/normalization-core";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { formatErrorMessage } from "../infra/errors.js";
 import { NODE_FS_LIST_DIR_COMMAND } from "../infra/node-commands.js";
-import { emitSessionLifecycleEvent } from "../sessions/session-lifecycle-events.js";
+import { createLazyRuntimeNamedExport } from "../shared/lazy-runtime.js";
 import { parseNodeList } from "../shared/node-list-parse.js";
 import type { NodeListNode } from "../shared/node-list-types.js";
 import { resolveEligibleNodeFromList } from "../shared/node-resolve.js";
@@ -16,15 +15,6 @@ import type { PendingBridgeRequest, SettledBridgeRequest } from "./code-mode-run
 import { readCodeModeSkill } from "./code-mode-skills.js";
 import { consumeMcpCodeModeGuestResult } from "./mcp-content.js";
 import type { AgentToolUpdateCallback } from "./runtime/index.js";
-import {
-  getSwarmRunByLaunchReplayKey,
-  initSubagentRegistry,
-} from "./subagents/registry/subagent-registry.js";
-import type { SubagentRunRecord } from "./subagents/registry/subagent-registry.types.js";
-import {
-  SWARM_CODE_MODE_IDEMPOTENCY_KEY,
-  SWARM_CODE_MODE_REQUEST_FINGERPRINT,
-} from "./subagents/swarm/swarm-code-mode.js";
 import { resolveSwarmConfig } from "./subagents/swarm/swarm-config.js";
 import {
   consumeToolEffectReceipt,
@@ -36,13 +26,14 @@ import {
   consumeTrustedToolNoStartError,
   registerTrustedToolNoStartError,
 } from "./tool-result-error.js";
-import { ToolSearchRuntime, type ToolSearchToolContext } from "./tool-search.js";
-import {
-  waitForCollectorCompletion,
-  type CollectorCompletionResult,
-} from "./tools/agents-wait-tool.js";
+import type { ToolSearchRuntime } from "./tool-search-runtime.js";
+import type { ToolSearchToolContext } from "./tool-search-types.js";
 import { ToolInputError } from "./tools/common.js";
-import { resolveInternalSessionKey, resolveMainSessionAlias } from "./tools/sessions-helpers.js";
+
+const loadSwarmHandlers = createLazyRuntimeNamedExport(
+  () => import("./code-mode-swarm.runtime.js"),
+  "codeModeSwarmHandlers",
+);
 
 export const CODE_MODE_NODES_TOOL_ID = "openclaw:core:nodes";
 
@@ -196,197 +187,6 @@ function requireCodeModeSwarmEnabled(ctx: ToolSearchToolContext): void {
   if (ctx.toolExecutionAllow && !isToolExecutionAllowed(ctx.toolExecutionAllow, "sessions_spawn")) {
     throw new ToolInputError(TOOL_EXECUTION_GATED_MESSAGE);
   }
-}
-
-function resolveCodeModeRequesterSessionKey(ctx: ToolSearchToolContext): string {
-  const sessionKey = ctx.sessionKey?.trim();
-  if (!sessionKey) {
-    throw new ToolInputError("code mode swarm globals require session and run identity.");
-  }
-  const { mainKey, alias } = resolveMainSessionAlias(ctx.runtimeConfig ?? ctx.config ?? {});
-  return resolveInternalSessionKey({ key: sessionKey, alias, mainKey });
-}
-
-function resolveCodeModeSwarmGroupId(ctx: ToolSearchToolContext): string {
-  const sessionKey = resolveCodeModeRequesterSessionKey(ctx);
-  const runId = ctx.runId?.trim();
-  if (!runId) {
-    throw new ToolInputError("code mode swarm globals require session and run identity.");
-  }
-  return `swarm:${sessionKey}:${runId}`;
-}
-
-function replayedSpawnResult(entry: SubagentRunRecord) {
-  return {
-    status: "accepted",
-    runId: entry.swarmRunId ?? entry.runId,
-    sessionKey: entry.childSessionKey,
-    ...(entry.label ? { label: entry.label } : {}),
-  };
-}
-
-function readOptionalStringOption(
-  options: Record<string, unknown>,
-  key: "label" | "model" | "thinking" | "agentId",
-): string | undefined {
-  const value = options[key];
-  if (value === undefined) {
-    return undefined;
-  }
-  if (typeof value !== "string" || !value.trim()) {
-    throw new ToolInputError(`agents.run ${key} must be a non-empty string.`);
-  }
-  return value.trim();
-}
-
-async function runAgentSpawnBridge(params: {
-  runtime: ToolSearchRuntime;
-  parentToolCallId: string;
-  request: PendingBridgeRequest;
-  codeModeRunId: string;
-  ctx: ToolSearchToolContext;
-  signal?: AbortSignal;
-  onUpdate?: AgentToolUpdateCallback;
-}) {
-  requireCodeModeSwarmEnabled(params.ctx);
-  const prompt = params.request.args[0];
-  const options = isRecord(params.request.args[1]) ? params.request.args[1] : {};
-  if (typeof prompt !== "string" || !prompt.trim()) {
-    throw new ToolInputError("agents.run prompt must be a non-empty string.");
-  }
-  const fastMode = options.fastMode;
-  if (fastMode !== undefined && fastMode !== true && fastMode !== false && fastMode !== "auto") {
-    throw new ToolInputError('agents.run fastMode must be boolean or "auto".');
-  }
-  const schema = options.schema;
-  if (schema !== undefined && !isRecord(schema)) {
-    throw new ToolInputError("agents.run schema must be a JSON schema object.");
-  }
-  const label = readOptionalStringOption(options, "label");
-  const model = readOptionalStringOption(options, "model");
-  const thinking = readOptionalStringOption(options, "thinking");
-  const agentId = readOptionalStringOption(options, "agentId");
-  const spawnEntry = params.runtime
-    .namespaceEntries()
-    .find((entry) => entry.source === "openclaw" && entry.name === "sessions_spawn");
-  if (!spawnEntry) {
-    throw new ToolInputError("agents.run requires the sessions_spawn tool.");
-  }
-  const spawnInput: Record<PropertyKey, unknown> = {
-    task: prompt.trim(),
-    collect: true,
-    groupId: resolveCodeModeSwarmGroupId(params.ctx),
-    ...(label ? { label } : {}),
-    ...(model ? { model } : {}),
-    ...(thinking ? { thinking } : {}),
-    ...(agentId ? { agentId } : {}),
-    ...(fastMode !== undefined ? { fastMode } : {}),
-    ...(schema ? { outputSchema: schema } : {}),
-  };
-  const requestFingerprint = `sha256:${createHash("sha256")
-    .update(stableStringify(spawnInput))
-    .digest("hex")}`;
-  // The registry persists this exact tuple and payload hash before launch.
-  const idempotencyKey = `${params.codeModeRunId}:${params.request.id}`;
-  const requesterSessionKey = resolveCodeModeRequesterSessionKey(params.ctx);
-  let existing = getSwarmRunByLaunchReplayKey(
-    idempotencyKey,
-    requesterSessionKey,
-    params.ctx.agentId,
-  );
-  if (existing) {
-    if (existing.swarmLaunchRequestFingerprint !== requestFingerprint) {
-      throw new ToolInputError("agents.run replay request does not match the persisted collector.");
-    }
-    if (existing.swarmLaunchPending === true) {
-      if (!existing.queuedLaunch) {
-        throw new ToolInputError("agents.run persisted launch reservation cannot be recovered.");
-      }
-      // Cold-start restore idempotently re-enqueues this durable launch before agentWait parks.
-      initSubagentRegistry();
-      existing =
-        getSwarmRunByLaunchReplayKey(idempotencyKey, requesterSessionKey, params.ctx.agentId) ??
-        existing;
-      if (existing.swarmLaunchPending === true && !existing.queuedLaunch) {
-        throw new ToolInputError("agents.run persisted launch reservation cannot be recovered.");
-      }
-    }
-    return replayedSpawnResult(existing);
-  }
-  Object.defineProperty(spawnInput, SWARM_CODE_MODE_IDEMPOTENCY_KEY, {
-    value: idempotencyKey,
-  });
-  Object.defineProperty(spawnInput, SWARM_CODE_MODE_REQUEST_FINGERPRINT, {
-    value: requestFingerprint,
-  });
-  const called = await params.runtime.callExactId(spawnEntry.id, spawnInput, {
-    parentToolCallId: params.parentToolCallId,
-    signal: params.signal,
-    onUpdate: params.onUpdate,
-  });
-  const value =
-    isRecord(called.result) && "details" in called.result ? called.result.details : called.result;
-  if (!isRecord(value) || value.status !== "accepted" || typeof value.runId !== "string") {
-    const detail =
-      isRecord(value) && typeof value.error === "string"
-        ? value.error
-        : "collector spawn was not accepted";
-    throw new ToolInputError(`agents.run spawn failed: ${detail}`);
-  }
-  return value;
-}
-
-async function runAgentWaitBridge(params: {
-  request: PendingBridgeRequest;
-  ctx: ToolSearchToolContext;
-  signal?: AbortSignal;
-}): Promise<CollectorCompletionResult> {
-  requireCodeModeSwarmEnabled(params.ctx);
-  const runId = params.request.args[0];
-  if (typeof runId !== "string" || !runId.trim()) {
-    throw new ToolInputError("agentWait run id must be a non-empty string.");
-  }
-  const rawSessionKey = params.ctx.sessionKey?.trim();
-  if (!rawSessionKey) {
-    throw new ToolInputError("agents.run wait requires session identity.");
-  }
-  const requesterSessionKey = resolveCodeModeRequesterSessionKey(params.ctx);
-  return await waitForCollectorCompletion({
-    runId: runId.trim(),
-    currentSessionKeys: new Set([rawSessionKey, requesterSessionKey]),
-    currentAgentId: params.ctx.agentId,
-    config: params.ctx.runtimeConfig ?? params.ctx.config,
-    signal: params.signal,
-  });
-}
-
-function runSwarmNoteBridge(params: {
-  request: PendingBridgeRequest;
-  ctx: ToolSearchToolContext;
-}): { ok: true } {
-  requireCodeModeSwarmEnabled(params.ctx);
-  const note = isRecord(params.request.args[0]) ? params.request.args[0] : undefined;
-  const kind = note?.kind;
-  const text = note?.text;
-  if ((kind !== "phase" && kind !== "log") || typeof text !== "string" || !text.trim()) {
-    throw new ToolInputError("swarmNote requires phase/log kind and non-empty text.");
-  }
-  const sessionKey = params.ctx.sessionKey?.trim();
-  if (!sessionKey) {
-    throw new ToolInputError("swarmNote requires session identity.");
-  }
-  emitSessionLifecycleEvent({
-    sessionKey,
-    reason: "swarm-note",
-    swarmGroupId: resolveCodeModeSwarmGroupId(params.ctx),
-    kind,
-    text: text.trim(),
-  } as Parameters<typeof emitSessionLifecycleEvent>[0] & {
-    swarmGroupId: string;
-    kind: "phase" | "log";
-    text: string;
-  });
-  return { ok: true };
 }
 
 export async function runBridgeRequest(params: {
@@ -548,12 +348,18 @@ export async function runBridgeRequest(params: {
         effectReceipt ??= consumeToolEffectReceipt(value);
         break;
       }
-      case "agentSpawn": {
-        value = await runAgentSpawnBridge(params);
-        break;
-      }
-      case "agentWait": {
-        value = await runAgentWaitBridge(params);
+      case "agentSpawn":
+      case "agentWait":
+      case "swarmNote": {
+        const { signal } = params;
+        requireCodeModeSwarmEnabled(params.ctx);
+        signal?.throwIfAborted();
+        const handlers = await loadSwarmHandlers();
+        // Loading can outlive the cell. Reject before replay recovery, collector
+        // reads, or note publication, even when the cancellation race has settled.
+        signal?.throwIfAborted();
+        requireCodeModeSwarmEnabled(params.ctx);
+        value = await handlers[params.request.method](params);
         break;
       }
       case "skillsList": {
@@ -586,10 +392,6 @@ export async function runBridgeRequest(params: {
         value = await sleep(resolveSafeTimeoutDelayMs(delay, { minMs: 0 }), null, {
           signal: params.signal,
         });
-        break;
-      }
-      case "swarmNote": {
-        value = runSwarmNoteBridge(params);
         break;
       }
     }

--- a/src/agents/code-mode-execution.ts
+++ b/src/agents/code-mode-execution.ts
@@ -56,7 +56,8 @@ import {
 import { normalizeCodeModeWorkerResult, runCodeModeWorker } from "./code-mode-worker.js";
 import type { AgentToolUpdateCallback } from "./runtime/index.js";
 import { resolveSwarmConfig } from "./subagents/swarm/swarm-config.js";
-import { ToolSearchRuntime, type ToolSearchToolContext } from "./tool-search.js";
+import { ToolSearchRuntime } from "./tool-search-runtime.js";
+import type { ToolSearchToolContext } from "./tool-search-types.js";
 import { ToolInputError } from "./tools/common.js";
 
 export async function runCodeModeExec(params: {

--- a/src/agents/code-mode-headless.ts
+++ b/src/agents/code-mode-headless.ts
@@ -44,7 +44,8 @@ import {
   normalizeCodeModeWorkerResult,
   runCodeModeWorker,
 } from "./code-mode-worker.js";
-import { ToolSearchRuntime, type ToolSearchToolContext } from "./tool-search.js";
+import { ToolSearchRuntime } from "./tool-search-runtime.js";
+import type { ToolSearchToolContext } from "./tool-search-types.js";
 import { ToolInputError } from "./tools/common.js";
 
 function createHeadlessAbortScope(

--- a/src/agents/code-mode-state.ts
+++ b/src/agents/code-mode-state.ts
@@ -22,7 +22,8 @@ import {
   type ToolEffectReceipt,
 } from "./tool-effect-receipt.js";
 import { consumeTrustedToolNoStartError } from "./tool-result-error.js";
-import { ToolSearchRuntime, type ToolSearchToolContext } from "./tool-search.js";
+import type { ToolSearchRuntime } from "./tool-search-runtime.js";
+import type { ToolSearchToolContext } from "./tool-search-types.js";
 import { ToolInputError } from "./tools/common.js";
 
 export type CodeModeBridgeDispatchState = {

--- a/src/agents/code-mode-swarm.lazy.test.ts
+++ b/src/agents/code-mode-swarm.lazy.test.ts
@@ -1,0 +1,252 @@
+import { createHash } from "node:crypto";
+import { stableStringify } from "@openclaw/normalization-core";
+import { expect, it, vi } from "vitest";
+import { createDeferred } from "../../test/helpers/promise.js";
+import type { PendingBridgeRequest, SettledBridgeRequest } from "./code-mode-worker-types.js";
+import type { SubagentRunRecord } from "./subagents/registry/subagent-registry.types.js";
+import type { ToolSearchToolContext } from "./tool-search-types.js";
+import type { AnyAgentTool } from "./tools/common.js";
+
+it("fences swarm effects after owner or policy loss during a shared runtime import", async () => {
+  vi.resetModules();
+  const entered = createDeferred();
+  const release = createDeferred();
+  const bridgeCalls: Promise<SettledBridgeRequest>[] = [];
+  const cleanups: Array<() => void> = [];
+  const lookup =
+    vi.fn<
+      typeof import("./subagents/registry/subagent-registry.js").getSwarmRunByLaunchReplayKey
+    >();
+  const initialize = vi.fn();
+  const readCollectors =
+    vi.fn<typeof import("./subagents/registry/subagent-registry.js").getSubagentRunsByRunIds>();
+  const wait = vi.fn<typeof import("./tools/agents-wait-tool.js").waitForCollectorCompletion>();
+  const subscribe =
+    vi.fn<
+      typeof import("./subagents/registry/subagent-registry-state.js").onSubagentRegistryPersisted
+    >();
+  const emit =
+    vi.fn<typeof import("../sessions/session-lifecycle-events.js").emitSessionLifecycleEvent>();
+  const load = vi.fn(
+    async (importOriginal: () => Promise<typeof import("./code-mode-swarm.runtime.js")>) => {
+      const actual = await importOriginal();
+      entered.resolve();
+      await release.promise;
+      return actual;
+    },
+  );
+  vi.doMock("./code-mode-swarm.runtime.js", load);
+  vi.doMock("./subagents/registry/subagent-registry.js", async (importOriginal) => ({
+    ...(await importOriginal<typeof import("./subagents/registry/subagent-registry.js")>()),
+    getSwarmRunByLaunchReplayKey: lookup,
+    initSubagentRegistry: initialize,
+    getSubagentRunsByRunIds: readCollectors,
+  }));
+  vi.doMock("./tools/agents-wait-tool.js", async (importOriginal) => {
+    const actual = await importOriginal<typeof import("./tools/agents-wait-tool.js")>();
+    wait.mockImplementation(actual.waitForCollectorCompletion);
+    return { ...actual, waitForCollectorCompletion: wait };
+  });
+  vi.doMock("./subagents/registry/subagent-registry-state.js", async (importOriginal) => {
+    const actual =
+      await importOriginal<typeof import("./subagents/registry/subagent-registry-state.js")>();
+    subscribe.mockImplementation(actual.onSubagentRegistryPersisted);
+    return { ...actual, onSubagentRegistryPersisted: subscribe };
+  });
+  vi.doMock("../sessions/session-lifecycle-events.js", async (importOriginal) => {
+    const actual = await importOriginal<typeof import("../sessions/session-lifecycle-events.js")>();
+    emit.mockImplementation(actual.emitSessionLifecycleEvent);
+    return { ...actual, emitSessionLifecycleEvent: emit };
+  });
+  try {
+    const { applyCodeModeCatalog, createCodeModeTools, resolveCodeModeConfig } =
+      await import("./code-mode.js");
+    const { clearToolSearchCatalog, createToolSearchCatalogRef } =
+      await import("./tool-search-catalog.js");
+    const { ToolSearchRuntime } = await import("./tool-search-runtime.js");
+    const { toToolSearchConfig } = await import("./code-mode-runtime.js");
+    const { createCodeModeCatalogProjection } = await import("./code-mode-catalog.js");
+    const { createCodeModeNamespaceRuntime } = await import("./code-mode-namespaces.js");
+    const bridge = await import("./code-mode-bridge.js");
+    const originalBridge = bridge.runBridgeRequest;
+    vi.spyOn(bridge, "runBridgeRequest").mockImplementation((params) => {
+      const call = originalBridge(params);
+      bridgeCalls.push(call);
+      return call;
+    });
+    const { createCodeModeRunOwner, createPendingBridgeStates, createCodeModeBridgeDispatchState } =
+      await import("./code-mode-state.js");
+    const spawn = vi.fn(async () => ({
+      content: [],
+      details: { status: "accepted", runId: "collector" },
+    }));
+    const requests: PendingBridgeRequest[] = [
+      { id: "spawn", method: "agentSpawn", args: ["Research"] },
+      { id: "wait", method: "agentWait", args: ["collector"] },
+      { id: "note", method: "swarmNote", args: [{ kind: "phase", text: "Plan" }] },
+    ];
+    const reservation: SubagentRunRecord = {
+      runId: "collector",
+      childSessionKey: "agent:main:subagent:collector",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "agent:main:main",
+      swarmRequesterSessionKey: "agent:main:main",
+      task: "Research",
+      collect: true,
+      cleanup: "delete",
+      createdAt: 1,
+      execution: { status: "running" },
+      swarmLaunchReplayKey: "replay:spawn",
+      swarmLaunchPending: true,
+      swarmLaunchRequestFingerprint: `sha256:${createHash("sha256")
+        .update(
+          stableStringify({
+            task: "Research",
+            collect: true,
+            groupId: "swarm:agent:main:main:run-swarm",
+          }),
+        )
+        .digest("hex")}`,
+      queuedLaunch: { request: {}, timeoutMs: 1, schedulerGroupKey: "group", maxConcurrent: 1 },
+    };
+    lookup.mockReturnValue(reservation);
+    readCollectors.mockReturnValue({
+      entries: new Map([
+        [
+          "collector",
+          {
+            ...reservation,
+            collectorCompletion: { status: "done", structured: { answer: 42 } },
+          },
+        ],
+      ]),
+    });
+
+    function createRun() {
+      const catalogRef = createToolSearchCatalogRef();
+      const config = { tools: { codeMode: true, swarm: { enabled: true } } };
+      const ctx: ToolSearchToolContext = {
+        config,
+        runtimeConfig: config,
+        catalogRef,
+        sessionKey: "agent:main:main",
+        sessionId: "session-swarm",
+        runId: "run-swarm",
+      };
+      const spawnTool: AnyAgentTool = {
+        name: "sessions_spawn",
+        label: "Spawn",
+        description: "Spawn a collector",
+        parameters: { type: "object", properties: {} },
+        execute: spawn,
+      };
+      applyCodeModeCatalog({ ...ctx, tools: [...createCodeModeTools(ctx), spawnTool] });
+      const owner = createCodeModeRunOwner(ctx);
+      cleanups.push(() => {
+        owner.close();
+        clearToolSearchCatalog(ctx);
+      });
+      const limits = resolveCodeModeConfig(config);
+      const runtime = new ToolSearchRuntime(ctx, toToolSearchConfig(limits));
+      return {
+        ctx,
+        config,
+        owner,
+        dispatch: (pendingRequests = requests) =>
+          createPendingBridgeStates({
+            pendingRequests,
+            config: limits,
+            runtime,
+            ctx,
+            catalogProjection: createCodeModeCatalogProjection(runtime.all({ includeMcp: false })),
+            namespaceRuntime: createCodeModeNamespaceRuntime(runtime.namespaceEntries()),
+            parentToolCallId: "swarm-call",
+            codeModeRunId: "replay",
+            remainingMs: 10_000,
+            signal: owner.signal,
+            bridgeDispatch: createCodeModeBridgeDispatchState(),
+          }),
+      };
+    }
+
+    // Cheap refusals must not start the shared load at all.
+    for (const gate of ["disabled", "allowlist"] as const) {
+      const run = createRun();
+      if (gate === "disabled") {
+        run.config.tools.swarm.enabled = false;
+      } else {
+        run.ctx.toolExecutionAllow = ["skill_workshop"];
+      }
+      const settled = await Promise.all(run.dispatch().map((entry) => entry.promise));
+      expect(settled.every((entry) => !entry.ok)).toBe(true);
+      expect(load).not.toHaveBeenCalled();
+    }
+
+    const closedRuns = ["owner", "catalog", "disabled", "allowlist"].map((kind) => {
+      const run = createRun();
+      return { kind, run, pending: run.dispatch() };
+    });
+    const survivor = createRun();
+    const live = survivor.dispatch([
+      { id: "live-note", method: "swarmNote", args: [{ kind: "log", text: "Still live" }] },
+    ]);
+    await entered.promise;
+    for (const { kind, run, pending } of closedRuns) {
+      if (kind === "owner") {
+        run.owner.close(new Error("owner closed"));
+      } else if (kind === "catalog") {
+        clearToolSearchCatalog(run.ctx);
+      } else if (kind === "disabled") {
+        run.config.tools.swarm.enabled = false;
+      } else {
+        run.ctx.toolExecutionAllow = ["skill_workshop"];
+      }
+      if (kind === "owner" || kind === "catalog") {
+        expect(run.owner.signal.aborted).toBe(true);
+        for (const entry of pending) {
+          expect(await entry.promise).toMatchObject({ ok: false });
+        }
+      }
+    }
+    release.resolve();
+    // The cancellation race settles first; join the original work before checking effects.
+    for (const { pending } of closedRuns) {
+      for (const entry of pending) {
+        expect(await entry.promise).toMatchObject({ ok: false });
+      }
+    }
+    expect(await Promise.all(live.map((entry) => entry.promise))).toEqual([
+      { id: "live-note", ok: true, value: { ok: true } },
+    ]);
+    const originals = await Promise.all(bridgeCalls);
+    expect(originals).toHaveLength(requests.length * (2 + closedRuns.length) + live.length);
+    expect(originals.filter((entry) => entry.id !== "live-note").every((entry) => !entry.ok)).toBe(
+      true,
+    );
+    expect(load).toHaveBeenCalledOnce();
+    expect(lookup).not.toHaveBeenCalled();
+    expect(initialize).not.toHaveBeenCalled();
+    expect(spawn).not.toHaveBeenCalled();
+    expect(wait).not.toHaveBeenCalled();
+    expect(readCollectors).not.toHaveBeenCalled();
+    expect(subscribe).not.toHaveBeenCalled();
+    expect(emit).toHaveBeenCalledExactlyOnceWith({
+      sessionKey: "agent:main:main",
+      reason: "swarm-note",
+      swarmGroupId: "swarm:agent:main:main:run-swarm",
+      kind: "log",
+      text: "Still live",
+    });
+  } finally {
+    cleanups.forEach((cleanup) => cleanup());
+    release.resolve();
+    await Promise.allSettled(bridgeCalls);
+    vi.restoreAllMocks();
+    vi.doUnmock("./code-mode-swarm.runtime.js");
+    vi.doUnmock("./subagents/registry/subagent-registry.js");
+    vi.doUnmock("./subagents/registry/subagent-registry-state.js");
+    vi.doUnmock("./tools/agents-wait-tool.js");
+    vi.doUnmock("../sessions/session-lifecycle-events.js");
+    vi.resetModules();
+  }
+});

--- a/src/agents/code-mode-swarm.runtime.ts
+++ b/src/agents/code-mode-swarm.runtime.ts
@@ -1,0 +1,213 @@
+import { createHash } from "node:crypto";
+import { stableStringify } from "@openclaw/normalization-core";
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
+import { emitSessionLifecycleEvent } from "../sessions/session-lifecycle-events.js";
+import type { PendingBridgeRequest } from "./code-mode-worker-types.js";
+import type { AgentToolUpdateCallback } from "./runtime/index.js";
+import {
+  getSwarmRunByLaunchReplayKey,
+  initSubagentRegistry,
+} from "./subagents/registry/subagent-registry.js";
+import type { SubagentRunRecord } from "./subagents/registry/subagent-registry.types.js";
+import {
+  SWARM_CODE_MODE_IDEMPOTENCY_KEY,
+  SWARM_CODE_MODE_REQUEST_FINGERPRINT,
+} from "./subagents/swarm/swarm-code-mode.js";
+import type { ToolSearchRuntime } from "./tool-search-runtime.js";
+import type { ToolSearchToolContext } from "./tool-search-types.js";
+import {
+  waitForCollectorCompletion,
+  type CollectorCompletionResult,
+} from "./tools/agents-wait-tool.js";
+import { ToolInputError } from "./tools/common.js";
+import { resolveInternalSessionKey, resolveMainSessionAlias } from "./tools/sessions-resolution.js";
+
+function resolveCodeModeRequesterSessionKey(ctx: ToolSearchToolContext): string {
+  const sessionKey = ctx.sessionKey?.trim();
+  if (!sessionKey) {
+    throw new ToolInputError("code mode swarm globals require session and run identity.");
+  }
+  const { mainKey, alias } = resolveMainSessionAlias(ctx.runtimeConfig ?? ctx.config ?? {});
+  return resolveInternalSessionKey({ key: sessionKey, alias, mainKey });
+}
+
+function resolveCodeModeSwarmGroupId(ctx: ToolSearchToolContext): string {
+  const sessionKey = resolveCodeModeRequesterSessionKey(ctx);
+  const runId = ctx.runId?.trim();
+  if (!runId) {
+    throw new ToolInputError("code mode swarm globals require session and run identity.");
+  }
+  return `swarm:${sessionKey}:${runId}`;
+}
+
+function replayedSpawnResult(entry: SubagentRunRecord) {
+  return {
+    status: "accepted",
+    runId: entry.swarmRunId ?? entry.runId,
+    sessionKey: entry.childSessionKey,
+    ...(entry.label ? { label: entry.label } : {}),
+  };
+}
+
+function readOptionalStringOption(
+  options: Record<string, unknown>,
+  key: "label" | "model" | "thinking" | "agentId",
+): string | undefined {
+  const value = options[key];
+  if (value === undefined) {
+    return undefined;
+  }
+  if (typeof value !== "string" || !value.trim()) {
+    throw new ToolInputError(`agents.run ${key} must be a non-empty string.`);
+  }
+  return value.trim();
+}
+
+async function runAgentSpawnBridge(params: {
+  runtime: ToolSearchRuntime;
+  parentToolCallId: string;
+  request: PendingBridgeRequest;
+  codeModeRunId: string;
+  ctx: ToolSearchToolContext;
+  signal?: AbortSignal;
+  onUpdate?: AgentToolUpdateCallback;
+}) {
+  const prompt = params.request.args[0];
+  const options = isRecord(params.request.args[1]) ? params.request.args[1] : {};
+  if (typeof prompt !== "string" || !prompt.trim()) {
+    throw new ToolInputError("agents.run prompt must be a non-empty string.");
+  }
+  const fastMode = options.fastMode;
+  if (fastMode !== undefined && fastMode !== true && fastMode !== false && fastMode !== "auto") {
+    throw new ToolInputError('agents.run fastMode must be boolean or "auto".');
+  }
+  const schema = options.schema;
+  if (schema !== undefined && !isRecord(schema)) {
+    throw new ToolInputError("agents.run schema must be a JSON schema object.");
+  }
+  const label = readOptionalStringOption(options, "label");
+  const model = readOptionalStringOption(options, "model");
+  const thinking = readOptionalStringOption(options, "thinking");
+  const agentId = readOptionalStringOption(options, "agentId");
+  const spawnEntry = params.runtime
+    .namespaceEntries()
+    .find((entry) => entry.source === "openclaw" && entry.name === "sessions_spawn");
+  if (!spawnEntry) {
+    throw new ToolInputError("agents.run requires the sessions_spawn tool.");
+  }
+  const spawnInput: Record<PropertyKey, unknown> = {
+    task: prompt.trim(),
+    collect: true,
+    groupId: resolveCodeModeSwarmGroupId(params.ctx),
+    ...(label ? { label } : {}),
+    ...(model ? { model } : {}),
+    ...(thinking ? { thinking } : {}),
+    ...(agentId ? { agentId } : {}),
+    ...(fastMode !== undefined ? { fastMode } : {}),
+    ...(schema ? { outputSchema: schema } : {}),
+  };
+  const requestFingerprint = `sha256:${createHash("sha256")
+    .update(stableStringify(spawnInput))
+    .digest("hex")}`;
+  // The registry persists this exact tuple and payload hash before launch.
+  const idempotencyKey = `${params.codeModeRunId}:${params.request.id}`;
+  const requesterSessionKey = resolveCodeModeRequesterSessionKey(params.ctx);
+  let existing = getSwarmRunByLaunchReplayKey(
+    idempotencyKey,
+    requesterSessionKey,
+    params.ctx.agentId,
+  );
+  if (existing) {
+    if (existing.swarmLaunchRequestFingerprint !== requestFingerprint) {
+      throw new ToolInputError("agents.run replay request does not match the persisted collector.");
+    }
+    if (existing.swarmLaunchPending === true) {
+      if (!existing.queuedLaunch) {
+        throw new ToolInputError("agents.run persisted launch reservation cannot be recovered.");
+      }
+      // Cold-start restore idempotently re-enqueues this durable launch before agentWait parks.
+      initSubagentRegistry();
+      existing =
+        getSwarmRunByLaunchReplayKey(idempotencyKey, requesterSessionKey, params.ctx.agentId) ??
+        existing;
+      if (existing.swarmLaunchPending === true && !existing.queuedLaunch) {
+        throw new ToolInputError("agents.run persisted launch reservation cannot be recovered.");
+      }
+    }
+    return replayedSpawnResult(existing);
+  }
+  Object.defineProperty(spawnInput, SWARM_CODE_MODE_IDEMPOTENCY_KEY, {
+    value: idempotencyKey,
+  });
+  Object.defineProperty(spawnInput, SWARM_CODE_MODE_REQUEST_FINGERPRINT, {
+    value: requestFingerprint,
+  });
+  const called = await params.runtime.callExactId(spawnEntry.id, spawnInput, {
+    parentToolCallId: params.parentToolCallId,
+    signal: params.signal,
+    onUpdate: params.onUpdate,
+  });
+  const value =
+    isRecord(called.result) && "details" in called.result ? called.result.details : called.result;
+  if (!isRecord(value) || value.status !== "accepted" || typeof value.runId !== "string") {
+    const detail =
+      isRecord(value) && typeof value.error === "string"
+        ? value.error
+        : "collector spawn was not accepted";
+    throw new ToolInputError(`agents.run spawn failed: ${detail}`);
+  }
+  return value;
+}
+
+async function runAgentWaitBridge(params: {
+  request: PendingBridgeRequest;
+  ctx: ToolSearchToolContext;
+  signal?: AbortSignal;
+}): Promise<CollectorCompletionResult> {
+  const runId = params.request.args[0];
+  if (typeof runId !== "string" || !runId.trim()) {
+    throw new ToolInputError("agentWait run id must be a non-empty string.");
+  }
+  const rawSessionKey = params.ctx.sessionKey?.trim();
+  if (!rawSessionKey) {
+    throw new ToolInputError("agents.run wait requires session identity.");
+  }
+  const requesterSessionKey = resolveCodeModeRequesterSessionKey(params.ctx);
+  return await waitForCollectorCompletion({
+    runId: runId.trim(),
+    currentSessionKeys: new Set([rawSessionKey, requesterSessionKey]),
+    currentAgentId: params.ctx.agentId,
+    config: params.ctx.runtimeConfig ?? params.ctx.config,
+    signal: params.signal,
+  });
+}
+
+function runSwarmNoteBridge(params: {
+  request: PendingBridgeRequest;
+  ctx: ToolSearchToolContext;
+}): { ok: true } {
+  const note = isRecord(params.request.args[0]) ? params.request.args[0] : undefined;
+  const kind = note?.kind;
+  const text = note?.text;
+  if ((kind !== "phase" && kind !== "log") || typeof text !== "string" || !text.trim()) {
+    throw new ToolInputError("swarmNote requires phase/log kind and non-empty text.");
+  }
+  const sessionKey = params.ctx.sessionKey?.trim();
+  if (!sessionKey) {
+    throw new ToolInputError("swarmNote requires session identity.");
+  }
+  emitSessionLifecycleEvent({
+    sessionKey,
+    reason: "swarm-note",
+    swarmGroupId: resolveCodeModeSwarmGroupId(params.ctx),
+    kind,
+    text: text.trim(),
+  });
+  return { ok: true };
+}
+
+export const codeModeSwarmHandlers = {
+  agentSpawn: runAgentSpawnBridge,
+  agentWait: runAgentWaitBridge,
+  swarmNote: runSwarmNoteBridge,
+};

--- a/src/agents/code-mode-worker-lifecycle.test.ts
+++ b/src/agents/code-mode-worker-lifecycle.test.ts
@@ -24,11 +24,11 @@ import {
 import { runCodeModeWorker } from "./code-mode-worker.js";
 import { applyCodeModeCatalog } from "./code-mode.js";
 import { createCodeModeHarness, resultDetails } from "./code-mode.test-support.js";
+import { ToolSearchRuntime } from "./tool-search-runtime.js";
 import {
   createToolSearchCatalogRef,
   clearToolSearchCatalog,
   registerHeadlessToolSearchCatalog,
-  ToolSearchRuntime,
 } from "./tool-search.js";
 
 function parkExpiringRun(method: "callValue" | "agentWait") {

--- a/src/agents/code-mode.import-boundary.test.ts
+++ b/src/agents/code-mode.import-boundary.test.ts
@@ -1,0 +1,52 @@
+import { expect, it, vi } from "vitest";
+import type { AnyAgentTool } from "./tools/common.js";
+
+vi.mock("./subagents/registry/subagent-registry.js", () => {
+  throw new Error("ordinary Code Mode must not load the subagent registry");
+});
+
+vi.mock("./tools/agents-wait-tool.js", () => {
+  throw new Error("ordinary Code Mode must not load the collector waiter");
+});
+
+vi.mock("../skills/workshop/service-query.js", () => {
+  throw new Error("ordinary Code Mode must not load Skill Workshop proposal queries");
+});
+
+it.each([false, true])(
+  "executes ordinary tools without optional runtime imports (swarm=%s)",
+  async (enabled) => {
+    const { applyCodeModeCatalog, createCodeModeTools } = await import("./code-mode.js");
+    const { runUntilCompleted } = await import("./code-mode.test-support.js");
+    const { createToolSearchCatalogRef, clearToolSearchCatalog } =
+      await import("./tool-search-catalog.js");
+    const catalogRef = createToolSearchCatalogRef();
+    const config = { tools: { codeMode: true, swarm: { enabled } } };
+    const ctx = { config, runtimeConfig: config, catalogRef };
+    const tools = createCodeModeTools(ctx);
+    const execute = vi.fn(async () => ({ content: [], details: { answer: 42 } }));
+    const ordinary: AnyAgentTool = {
+      name: "ordinary",
+      label: "Ordinary",
+      description: "Return a structured answer.",
+      parameters: { type: "object", properties: {} },
+      execute,
+    };
+    try {
+      applyCodeModeCatalog({ tools: [...tools, ordinary], config, catalogRef });
+      const [execTool, waitTool] = tools;
+      if (!execTool || !waitTool) {
+        throw new Error("expected Code Mode controls");
+      }
+      const result = await runUntilCompleted({
+        execTool,
+        waitTool,
+        code: "return await ordinary({});",
+      });
+      expect(result).toMatchObject({ status: "completed", value: { answer: 42 } });
+      expect(execute).toHaveBeenCalledOnce();
+    } finally {
+      clearToolSearchCatalog({ catalogRef });
+    }
+  },
+);

--- a/src/agents/code-mode.test.ts
+++ b/src/agents/code-mode.test.ts
@@ -19,6 +19,7 @@ import {
   mcpTool,
   createCodeModeHarness,
 } from "./code-mode.test-support.js";
+import { ToolSearchRuntime } from "./tool-search-runtime.js";
 import {
   createToolSearchCatalogRef,
   TOOL_CALL_RAW_TOOL_NAME,
@@ -26,7 +27,6 @@ import {
   TOOL_SEARCH_CODE_MODE_TOOL_NAME,
   TOOL_SEARCH_RAW_TOOL_NAME,
   resolveToolSearchConfig,
-  ToolSearchRuntime,
 } from "./tool-search.js";
 import { jsonResult } from "./tools/common.js";
 

--- a/src/agents/code-mode.ts
+++ b/src/agents/code-mode.ts
@@ -39,12 +39,14 @@ import type { AgentToolUpdateCallback } from "./runtime/index.js";
 import { optionalStringEnum } from "./schema/typebox.js";
 import type { ToolDefinition } from "./sessions/index.js";
 import { resolveSwarmConfig } from "./subagents/swarm/swarm-config.js";
-import { isDirectVisibleCatalogTool } from "./tool-search-catalog.js";
-import { formatToolSearchControlResult, type ToolSearchRuntime } from "./tool-search-runtime.js";
 import {
   addClientToolsToToolCatalog,
   applyToolCatalogCompaction,
   compactToolSearchCatalogEntry,
+  isDirectVisibleCatalogTool,
+} from "./tool-search-catalog.js";
+import { formatToolSearchControlResult, type ToolSearchRuntime } from "./tool-search-runtime.js";
+import {
   TOOL_CALL_RAW_TOOL_NAME,
   TOOL_DESCRIBE_RAW_TOOL_NAME,
   TOOL_SEARCH_CODE_MODE_TOOL_NAME,
@@ -52,7 +54,7 @@ import {
   type ToolSearchCatalogEntry,
   type ToolSearchCatalogRef,
   type ToolSearchToolContext,
-} from "./tool-search.js";
+} from "./tool-search-types.js";
 import type { AnyAgentTool } from "./tools/common.js";
 
 export { CODE_MODE_EXEC_TOOL_NAME, CODE_MODE_WAIT_TOOL_NAME };

--- a/src/agents/embedded-agent-runner/run/attempt-client-tools.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-client-tools.test.ts
@@ -10,10 +10,10 @@ import { runUntilCompleted } from "../../code-mode.test-support.js";
 import { createAgentHarnessPromptToolPolicy } from "../../harness/prompt-tool-policy.js";
 import { wrapToolDefinition } from "../../sessions/tools/tool-definition-wrapper.js";
 import { createStubTool } from "../../test-helpers/agent-tool-stubs.js";
+import { compactToolSearchCatalogEntry } from "../../tool-search-catalog.js";
 import {
   applyToolSearchCatalog,
   clearToolSearchCatalog,
-  compactToolSearchCatalogEntry,
   createToolSearchCatalogRef,
   TOOL_SEARCH_RAW_TOOL_NAME,
 } from "../../tool-search.js";

--- a/src/agents/node-plugin-tools.test.ts
+++ b/src/agents/node-plugin-tools.test.ts
@@ -13,7 +13,8 @@ import { applyCodeModeCatalog, createCodeModeTools } from "./code-mode.js";
 import { testing } from "./code-mode.test-support.js";
 import { createNodePluginTools } from "./node-plugin-tools.js";
 import { isToolResultError } from "./tool-result-error.js";
-import { compactToolSearchCatalogEntry, createToolSearchCatalogRef } from "./tool-search.js";
+import { compactToolSearchCatalogEntry } from "./tool-search-catalog.js";
+import { createToolSearchCatalogRef } from "./tool-search.js";
 import { jsonResult, type AnyAgentTool } from "./tools/common.js";
 import { callGatewayTool } from "./tools/gateway.js";
 

--- a/src/agents/tool-search-runtime.test.ts
+++ b/src/agents/tool-search-runtime.test.ts
@@ -23,15 +23,18 @@ import {
 import { wrapToolWithBeforeToolCallHook } from "./agent-tools.before-tool-call.js";
 import { createCodeModeCatalogProjection } from "./code-mode-catalog.js";
 import {
+  addClientToolsToToolCatalog,
+  compactToolSearchCatalogEntry,
+} from "./tool-search-catalog.js";
+import {
   formatToolSearchControlError,
   formatToolSearchControlResult,
   prepareToolSearchDispatcherArguments,
   readToolSearchCallArgs,
+  ToolSearchRuntime,
 } from "./tool-search-runtime.js";
 import type { ToolSearchCatalogEntry } from "./tool-search-types.js";
 import {
-  addClientToolsToToolCatalog,
-  compactToolSearchCatalogEntry,
   createToolSearchCatalogRef,
   createToolSearchTools,
   registerHeadlessToolSearchCatalog,
@@ -39,7 +42,6 @@ import {
   TOOL_CALL_RAW_TOOL_NAME,
   TOOL_DESCRIBE_RAW_TOOL_NAME,
   TOOL_SEARCH_CODE_MODE_TOOL_NAME,
-  ToolSearchRuntime,
 } from "./tool-search.js";
 import { jsonResult, type AnyAgentTool } from "./tools/common.js";
 import { createWebSearchTool } from "./tools/web-search.js";

--- a/src/agents/tool-search.stream-errors.test.ts
+++ b/src/agents/tool-search.stream-errors.test.ts
@@ -32,6 +32,7 @@ vi.mock("node:child_process", async () => {
 
 const spawnMock = vi.mocked(spawn);
 let toolSearch: typeof import("./tool-search.js");
+let toolSearchRuntime: typeof import("./tool-search-runtime.js");
 let testing: (typeof import("./tool-search.test-support.js"))["testing"];
 
 async function rejectedMessage(promise: Promise<unknown>): Promise<string> {
@@ -50,6 +51,7 @@ async function rejectedMessage(promise: Promise<unknown>): Promise<string> {
 describe("tool-search code-mode stream errors", () => {
   beforeAll(async () => {
     toolSearch = await import("./tool-search.js");
+    toolSearchRuntime = await import("./tool-search-runtime.js");
     testing = (await import("./tool-search.test-support.js")).testing;
   });
 
@@ -59,7 +61,7 @@ describe("tool-search code-mode stream errors", () => {
     const { child, stderr } = createMockSpawnChild();
     spawnMock.mockReturnValueOnce(child as unknown as ChildProcess);
     const config = { ...toolSearch.resolveToolSearchConfig({}), codeTimeoutMs: 1000 };
-    const runtime = new toolSearch.ToolSearchRuntime({}, config);
+    const runtime = new toolSearchRuntime.ToolSearchRuntime({}, config);
     const promise = testing.runCodeModeChild({
       code: "return 7;",
       config,

--- a/src/agents/tool-search.test-support.ts
+++ b/src/agents/tool-search.test-support.ts
@@ -1,4 +1,5 @@
-import type { ToolSearchConfig, ToolSearchRuntime } from "./tool-search.js";
+import type { ToolSearchRuntime } from "./tool-search-runtime.js";
+import type { ToolSearchConfig } from "./tool-search.js";
 import "./tool-search.js";
 
 type ToolSearchTestApi = {

--- a/src/agents/tool-search.test.ts
+++ b/src/agents/tool-search.test.ts
@@ -27,13 +27,14 @@ import {
   formatToolExecutionErrorMessage,
   resolveToolExecutionErrorKind,
 } from "./tool-result-error.js";
+import { compactToolSearchCatalogEntry } from "./tool-search-catalog.js";
+import { ToolSearchRuntime } from "./tool-search-runtime.js";
 import {
   addClientToolsToToolSearchCatalog as addRunClientToolsToToolSearchCatalog,
   applyToolSearchCatalog as applyRunToolSearchCatalog,
   applyToolSchemaDirectoryCatalog as applyRunToolSchemaDirectoryCatalog,
   buildToolSchemaDirectoryPrompt as buildRunToolSchemaDirectoryPrompt,
   clearToolSearchCatalog as clearRunToolSearchCatalog,
-  compactToolSearchCatalogEntry,
   createToolSearchCatalogRef,
   createToolSearchTools as createRunToolSearchTools,
   registerHeadlessToolSearchCatalog,
@@ -45,7 +46,6 @@ import {
   TOOL_SEARCH_CODE_MODE_TOOL_NAME,
   TOOL_SEARCH_RAW_TOOL_NAME,
   type ToolSearchCatalogRef,
-  ToolSearchRuntime,
 } from "./tool-search.js";
 import { testing } from "./tool-search.test-support.js";
 import { jsonResult, type AnyAgentTool } from "./tools/common.js";

--- a/src/agents/tool-search.ts
+++ b/src/agents/tool-search.ts
@@ -51,11 +51,8 @@ import {
 import { jsonResult, type AnyAgentTool } from "./tools/common.js";
 
 export {
-  addClientToolsToToolCatalog,
-  applyToolCatalogCompaction,
   clearToolSearchCatalog,
   collectUniqueCatalogToolNames,
-  compactToolSearchCatalogEntry,
   createToolSearchCatalogRef,
   registerHeadlessToolSearchCatalog,
   restrictToolSearchCatalog,
@@ -65,7 +62,6 @@ export {
   buildToolSchemaDirectoryPrompt,
   resolveToolSearchCatalogTool,
 } from "./tool-search-directory.js";
-export { ToolSearchRuntime } from "./tool-search-runtime.js";
 export {
   TOOL_CALL_RAW_TOOL_NAME,
   TOOL_DESCRIBE_RAW_TOOL_NAME,

--- a/src/cron/trigger-script.preparation.test.ts
+++ b/src/cron/trigger-script.preparation.test.ts
@@ -8,7 +8,8 @@ import {
   loadPreparedInboundPluginRegistry,
 } from "../agents/prepared-model-runtime.inbound-registry.js";
 import { prepareOwnedPluginLoadContext } from "../agents/prepared-model-runtime.plugin-context.js";
-import { resolveToolSearchConfig, ToolSearchRuntime } from "../agents/tool-search.js";
+import { ToolSearchRuntime } from "../agents/tool-search-runtime.js";
+import { resolveToolSearchConfig } from "../agents/tool-search.js";
 import { clearRuntimeConfigSnapshot, setRuntimeConfigSnapshot } from "../config/config.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { setCurrentPluginMetadataSnapshot } from "../plugins/current-plugin-metadata.test-support.js";

--- a/src/gateway/server-session-events.ts
+++ b/src/gateway/server-session-events.ts
@@ -416,11 +416,6 @@ export function createLifecycleEventBroadcastHandler(params: {
   chatAbortControllers: Map<string, ChatAbortControllerEntry>;
 }) {
   return (event: SessionLifecycleEvent): void => {
-    const swarmEvent = event as SessionLifecycleEvent & {
-      swarmGroupId?: string;
-      kind?: "phase" | "log";
-      text?: string;
-    };
     const connIds = params.sessionEventSubscribers.getAll();
     if (!hasSessionChangeReceivers(connIds)) {
       return;
@@ -489,11 +484,11 @@ export function createLifecycleEventBroadcastHandler(params: {
           parentSessionKey: event.parentSessionKey,
           activeRunState,
         }),
-        ...(swarmEvent.swarmGroupId
+        ...(event.swarmGroupId
           ? {
-              swarmGroupId: swarmEvent.swarmGroupId,
-              kind: swarmEvent.kind,
-              text: swarmEvent.text,
+              swarmGroupId: event.swarmGroupId,
+              kind: event.kind,
+              text: event.text,
             }
           : {}),
       },

--- a/src/gateway/server-session-lifecycle-events.test.ts
+++ b/src/gateway/server-session-lifecycle-events.test.ts
@@ -38,7 +38,7 @@ describe("createLifecycleEventBroadcastHandler", () => {
     expect(loadGatewaySessionRowMock).not.toHaveBeenCalled();
   });
 
-  it("projects swarm phase and log payload fields", () => {
+  it.each(["phase", "log"] as const)("projects swarm %s payload fields", (kind) => {
     const broadcastToConnIds = vi.fn();
     const handler = createLifecycleEventBroadcastHandler({
       broadcastToConnIds,
@@ -50,15 +50,15 @@ describe("createLifecycleEventBroadcastHandler", () => {
       sessionKey: "agent:main:main",
       reason: "swarm-note",
       swarmGroupId: "swarm:agent:main:main:run-1",
-      kind: "phase",
+      kind,
       text: "Research",
-    } as never);
+    });
 
     expect(broadcastToConnIds).toHaveBeenCalledWith(
       "sessions.changed",
       expect.objectContaining({
         swarmGroupId: "swarm:agent:main:main:run-1",
-        kind: "phase",
+        kind,
         text: "Research",
       }),
       new Set(["conn-1"]),

--- a/src/sessions/session-lifecycle-events.ts
+++ b/src/sessions/session-lifecycle-events.ts
@@ -4,11 +4,13 @@ import { notifyListeners, registerListener } from "../shared/listeners.js";
 export type SessionLifecycleEvent = {
   sessionKey: string;
   agentId?: string;
-  reason: string;
   parentSessionKey?: string;
   label?: string;
   displayName?: string;
-};
+} & (
+  | { reason: string; swarmGroupId?: never; kind?: never; text?: never }
+  | { reason: "swarm-note"; swarmGroupId: string; kind: "phase" | "log"; text: string }
+);
 
 export type SessionIdentityMutationTarget = {
   sessionId?: string;

--- a/src/skills/workshop/policy.runtime.ts
+++ b/src/skills/workshop/policy.runtime.ts
@@ -1,0 +1,1 @@
+export { resolvePendingSkillProposal } from "./service-query.js";

--- a/src/skills/workshop/policy.ts
+++ b/src/skills/workshop/policy.ts
@@ -7,8 +7,14 @@ import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { PLUGIN_APPROVAL_DESCRIPTION_MAX_LENGTH } from "../../infra/plugin-approvals.js";
 import { logDebug } from "../../logger.js";
 import type { PluginHookBeforeToolCallResult } from "../../plugins/hook-before-tool-call-result.js";
+import { createLazyRuntimeNamedExport } from "../../shared/lazy-runtime.js";
 import { resolveSkillWorkshopConfig } from "./config.js";
-import { resolvePendingSkillProposal } from "./service.js";
+
+// Proposal reconciliation and skill-install dependencies belong to actual approval-detail lookup.
+const loadPendingSkillProposalResolver = createLazyRuntimeNamedExport(
+  () => import("./policy.runtime.js"),
+  "resolvePendingSkillProposal",
+);
 
 const SKILL_WORKSHOP_LIFECYCLE_ACTIONS = new Set([
   "apply",
@@ -118,6 +124,7 @@ async function resolveLifecycleApprovalDescription(params: {
   }
   const toolParams = asNullableRecord(params.toolParams);
   try {
+    const resolvePendingSkillProposal = await loadPendingSkillProposalResolver();
     const proposal = await resolvePendingSkillProposal({
       proposalId: normalizeOptionalString(toolParams?.proposal_id),
       name: normalizeOptionalString(toolParams?.name),


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where ordinary Code Mode cold loading pulled in unused Swarm registry/collector and Skill Workshop proposal/installation machinery. This imposed avoidable startup work and made the existing cached-plugin network-protection/turn-taint integration particularly sensitive to a busy development host.

This is a maintainer-requested performance repair, not a defect in the security assertions. The original `src/plugins/tools.optional.test.ts` integration is not rewritten, preloaded, weakened, or given a larger timeout.

Context only: [store SecretRef default-alias inspection repair](https://github.com/openclaw/openclaw/pull/132696), whose validation exposed the cold-run cost. That separate repair is not changed or superseded here.

## Why This Change Was Made

Move the existing Swarm handlers behind a cached `code-mode-swarm.runtime.ts` boundary, loaded only for actual Swarm bridge operations. Keep cheap enablement/allowlist checks before loading and revalidate the captured cell-owned signal plus policy immediately after the new await, before replay recovery, collector access, or note publication. Preserve the existing identity, replay fingerprint, pending-reservation recovery, collector scope, and guest results.

The second measured eager path is removed by loading the existing Workshop proposal resolver only when approval-detail lookup actually needs it. Query/reconciliation, storage, approval decisions, and fallback text are unchanged. Reuse existing narrow catalog/runtime/type/channel-metadata owners and remove four obsolete internal Tool Search forwarding exports, updating their test consumers without moving work across timeout boundaries.

Declare the already-emitted Swarm lifecycle fields on the authoritative event type instead of carrying emitter/projection casts. The runtime payload and broadcast conditions are unchanged; the existing test now covers both phase and log. Two retired assertion-baseline entries are removed, with no new allowance.

## User Impact

Ordinary Code Mode no longer pays to load these optional runtime graphs. Swarm and Workshop capabilities remain available when used, with cancellation and policy fencing preserved across the lazy-load boundary. No configuration, public SDK, wire protocol, storage schema, or external API change.

This does not claim to eliminate every host-induced timeout or deliver a fixed speedup. The security integration remains intact. There is no visual/UI behavior change; proof exercises real Code Mode guests and lifecycle boundaries in isolated local tests.

## Evidence

Pre-publication proof used the unchanged full-file command in its original order:

```bash
node scripts/run-vitest.mjs src/plugins/tools.optional.test.ts
```

Each cold run used a new credential-free HOME/state/config/tmp namespace, `OPENCLAW_VITEST_MAX_WORKERS=2`, and an empty private transform cache. The pre-edit baseline on `cddf5165ee8f153c3e4fefb6181ed0928da141e6` hit the target's existing 120-second limit (120.010s; 85 other cases passed). The completed local candidate passed all 86 cases twice: target 7.850s normally and 6.290s under observation, whole-command wall 17.675s and 13.618s. Earlier repaired runs took 29.6–53.0s; an unchanged setup hook also timed out on the loaded host. These are observed samples, not a controlled speedup estimate, and aggregate Vitest transform intervals are not exclusive CPU time.

The completed trace recorded 827 additional evaluated modules, with the Swarm runtime, subagent registry, collector waiter, Workshop query/runtime, and ClawHub installer absent before and after the case. The earlier investigation at a different main anchor recorded 1,829; the count comparison is qualified by that anchor difference. A [separate-head clean-runner result](https://github.com/openclaw/openclaw/pull/132696#issuecomment-5463619015) passed the security case in 5.027s and corroborates host sensitivity, not this patch's validation.

- Executable ordinary-tool import guards fail at the original eager registry edge and the pre-Workshop-repair query edge; final standalone Swarm-disabled/enabled-but-unused cases both pass, without another test preloading Code Mode.
- Held-import lifecycle regression joins all 19 original bridge promises, rejects closed/disposed/revoked callers without late effects, and permits a live sibling. Removing the post-load checks caused the expected late accepted-spawn failure; the production checks were restored.
- 328 affected/sibling cases passed across 12 full test files, with no skips, covering migrated Tool Search/Code Mode/node/client/cron consumers, real worker cancellation, Swarm replay/reservation recovery, and lifecycle projection. Additional focused headless/replay, metadata/network-error, Workshop policy, and embedded-approval proof passed.
- Exact-candidate `pnpm build` passed; both lazy runtime chunks were emitted with no `INEFFECTIVE_DYNAMIC_IMPORT` diagnostics.
- Complete changed-file gates passed all 26 paths: formatting, ratchets, three dead-export scans, core/test typechecks, core/scripts lint, runtime-sidecar guards, zero runtime value import cycles, and the remaining selected guards. Obsolete-export and test-brace lint failures were fixed rather than waived.

Production LOC: +263/-242, net **+21**. Tests: +325/-15; test support: +2/-1; assertion baseline: 0/-2. Most runtime code is moved existing handler logic. The remaining production growth provides the lazy ownership boundaries, post-await cancellation/policy fencing, narrow imports, and accurate event type; no custom cache or parallel implementation was added.

Proof limits: no full repository suite, cross-platform/Bun run, external live provider/channel, or packaged-Gateway startup benchmark. A separate follow-up is the client-tool-preparation test's cold collection cost; it is not addressed by widening this repair.

AI-assisted. Fresh pre-publication Codex autoreview returned `scoped-clean` with no P0 findings. Current exact-head CI and merge-tree proof follow below.

### Current landing validation

Required CI is green: [run 33281577278, attempt 1](https://github.com/openclaw/openclaw/actions/runs/33281577278), a `pull_request` run for full head `4579f96749bffbb71371b4f2908a83a2be5c7c66`, completed with 168 successful jobs and 17 skips. Both the [previously failing shutdown shard](https://github.com/openclaw/openclaw/actions/runs/33281577278/job/99177608303) and [openclaw/ci-gate](https://github.com/openclaw/openclaw/actions/runs/33281577278/job/99178351582) passed. The [checkout job log](https://github.com/openclaw/openclaw/actions/runs/33281577278/job/99177606989) confirms merge commit `73797c298821d81a7a949e153ed8e3ed62439e9c`, tree `44a41fc85de63e2450da93dec2a485846160e0ed`, with main parent `e3ae1752a5a8c15399eadfedaf5b17225f65c144` and the reviewed head as its second parent.

The complete changed-file gates also passed in 2861.477s: formatting/ratchets, three dead-export scans, core and test typechecks, core/scripts lint, storage and runtime-sidecar guards, zero runtime value import cycles, webhook and pairing guards. All 26 reviewed source hashes remained unchanged.

ClawSweeper's fresh review of this exact head at 23:48 UTC found no introduced code/security defect. Its Before merge and Rank-up moves are addressed: current required CI is green; production scope remains the reviewed +21 lines with no further expansion; the maintainer explicitly authorized this bounded repair and its native landing. The retained post-await fence and shared lazy owners are accepted. Live applicable rules require `openclaw/ci-gate` and do not require an independent approval; there are no formal review objections or unresolved review comments. No protection bypass is used.

Current integrated candidate: `4579f96749bffbb71371b4f2908a83a2be5c7c66`, rebased onto `19558a78f6497fa62f4b78c164fe65e9fd38bd25`. The rebase is conflict-free and preserves the reviewed patch plus upstream Code Mode output accounting. The original optional-tools file remains byte-identical to that main baseline (87 cases; SHA256 `17cffc4f90fe51a4bad31135e4a101cd5dacedc39f390309a126f4f4233a589a`).

The old CI failure was the profiler/shutdown-fixture contract mismatch in [run 33271814278](https://github.com/openclaw/openclaw/actions/runs/33271814278). Its canonical fixes are merged in [#132820](https://github.com/openclaw/openclaw/pull/132820) (`f9b3bcccdba3dc159c6484c30f56974b90a6d938`) and [#132824](https://github.com/openclaw/openclaw/pull/132824) (`3cc47ae2f33c76bc79aeaf061678c6b6ecd85d55`); both are ancestors of the pinned base. The old merge ref was not rerun.

Fresh candidate proof passed 244 cases across 14 files: the complete 87-case optional-tools file in original order, 2 standalone import-boundary cases, 143 Swarm/guest/cancellation/network-error/Workshop/lifecycle/output-accounting sibling cases, and all 12 shutdown-fixture cases. Each command used a fresh credential-free HOME/state/config/tmp/XDG namespace and empty private transform cache, with `OPENCLAW_VITEST_MAX_WORKERS=2`. No timeout, assertion, mock, preload, or protected integration change was made.

```bash
node scripts/run-vitest.mjs src/plugins/tools.optional.test.ts
node scripts/run-vitest.mjs src/agents/code-mode.import-boundary.test.ts
node scripts/run-vitest.mjs src/agents/code-mode-swarm.lazy.test.ts src/agents/code-mode-swarm.test.ts src/agents/tool-result-error.test.ts src/agents/code-mode.guest.test.ts src/agents/code-mode-headless.cancellation.test.ts src/agents/agent-tools.before-tool-call.network-error.test.ts src/skills/workshop/policy.test.ts src/agents/agent-tools.before-tool-call.embedded-mode.test.ts src/gateway/server-session-lifecycle-events.test.ts src/agents/code-mode.output.test.ts src/agents/code-mode-worker-lifecycle.test.ts
node scripts/run-vitest.mjs test/scripts/vitest-fork-shutdown.test.ts
pnpm build
node scripts/check-changed.mjs --timed --base 19558a78f6497fa62f4b78c164fe65e9fd38bd25
```

The real cached-network Code Mode/turn-taint case took 65.039s on this busy host; that is an observed sample, not a fixed speedup or universal timeout-elimination claim. The fresh build passed in 631.739s, emitted both lazy runtime chunks, and had zero `UNRESOLVED_IMPORT` and zero `INEFFECTIVE_DYNAMIC_IMPORT` diagnostics. Other existing build warnings are not claimed absent. Normal `pnpm install --frozen-lockfile` reconciled the already-declared Vitest shutdown patch; all four math-intrinsics subpaths and the get-intrinsic runtime smoke pass. No dependency source, version, override, or lockfile was changed. Missing/interrupted historical build logs are not relied upon.

Fresh isolated structured Codex autoreview of this head against the pinned base returned no actionable P0 findings. This is the requested P0 scope, not a claim of an unrestricted audit; the reviewer did not run tests. The initial helper output-location refusal occurred before inference and was corrected using its required isolated staging. No source edits followed the completed review.

ClawSweeper's stored-data heuristic does not apply: diagnostics/wrapper changes select the canonical metadata import, while the lifecycle type declares fields already emitted. No stored shape, schema, migration, protocol, configuration, or external API changes. The new cancellation regression protects the newly introduced await; no pre-existing vulnerability is claimed.

Production +263/-242 (net +21); tests +325/-15; support +2/-1; baseline 0/-2. Most handlers move unchanged. Remaining growth owns cached lazy loading and post-await fencing with the existing helper, plus narrow imports and the accurate event type; no parallel implementation or custom cache. Proof limits: no full local repository suite, cross-platform/Bun run, external authenticated provider/channel, or packaged-Gateway startup benchmark. Existing client-tool-preparation cold collection cost remains a separate follow-up.

The completed run-log archive download failed with an HTTP stream error; the direct single-job log download succeeded and supplied the checkout proof above. Native review initialization, the required baseline/PR-head sequence, PR-head artifact validation, OPENCLAW_TESTBOX=1 prepare-run, and merge-run all completed successfully. The exact prepared head was squash-merged as `7cbc7db126938bd910437ae5593f1e357c8b0d01`, tree `5d9e35b23aad79d5dd01553f322616e902f997b5`; the [native completion receipt](https://github.com/openclaw/openclaw/pull/132802#issuecomment-5465626875) links the result. The landed patch ID and all 26 changed-file hashes match the reviewed candidate. Native merge reported intervening mainline infrastructure drift as advisory under current policy; required hosted/server gates passed, with no strict-drift override or protection bypass.
