### PR TITLE
fix(ui): prevent clipboard callbacks from failing after teardown

### DIFF
--- a/ui/src/lib/clipboard.test.ts
+++ b/ui/src/lib/clipboard.test.ts
@@ -85,24 +85,55 @@ describe("copyToClipboard", () => {
     expect(document.querySelector("textarea")).toBeNull();
   });
 
-  it("restores focus after the execCommand fallback", async () => {
+  it("keeps deferred focus restoration bound to its document after globals retire", async () => {
     vi.stubGlobal("navigator", {});
-    mockExecCommand(true);
-    const button = document.createElement("button");
-    document.body.append(button);
-    button.focus();
-    const focus = vi.spyOn(button, "focus");
-    button.disabled = true;
-
-    expect(await copyToClipboard("hello")).toBe(true);
-    button.disabled = false;
-    button.blur();
-    await new Promise<void>((resolve) => {
-      window.setTimeout(resolve, 0);
-    });
-    expect(document.activeElement).toBe(button);
-    expect(focus).toHaveBeenCalledWith({ preventScroll: true });
-
-    button.remove();
+    mockExecCommand(false);
+    vi.useFakeTimers();
+    try {
+      expect(await copyToClipboard("hello")).toBe(false);
+      expect(vi.getTimerCount()).toBeGreaterThan(0);
+      vi.stubGlobal("document", undefined);
+      expect(() => vi.runAllTimers()).not.toThrow();
+    } finally {
+      vi.unstubAllGlobals();
+      vi.useRealTimers();
+    }
   });
+
+  it.each(["restore", "newer focus", "removed target"] as const)(
+    "restores focus only when still appropriate after the fallback: %s",
+    async (state) => {
+      vi.stubGlobal("navigator", {});
+      mockExecCommand(true);
+      const button = document.createElement("button");
+      const input = document.createElement("input");
+      document.body.append(button);
+      button.focus();
+      const focus = vi.spyOn(button, "focus");
+      button.disabled = true;
+
+      expect(await copyToClipboard("hello")).toBe(true);
+      button.disabled = false;
+      button.blur();
+      if (state === "newer focus") {
+        document.body.append(input);
+        input.focus();
+      } else if (state === "removed target") {
+        button.remove();
+      }
+      await new Promise<void>((resolve) => {
+        window.setTimeout(resolve, 0);
+      });
+      if (state === "restore") {
+        expect(document.activeElement).toBe(button);
+        expect(focus).toHaveBeenCalledWith({ preventScroll: true });
+      } else {
+        expect(document.activeElement).toBe(state === "newer focus" ? input : document.body);
+        expect(focus).not.toHaveBeenCalled();
+      }
+
+      button.remove();
+      input.remove();
+    },
+  );
 });

--- a/ui/src/lib/clipboard.ts
+++ b/ui/src/lib/clipboard.ts
@@ -46,9 +46,11 @@ function copyWithExecCommand(text: string): boolean {
   } finally {
     document.body.removeChild(textarea);
     if (previouslyFocused?.isConnected) {
+      // Deferred focus must retain its document after that environment's globals retire.
+      const ownerDocument = textarea.ownerDocument;
       window.setTimeout(() => {
-        const activeElement = document.activeElement;
-        if (previouslyFocused.isConnected && (!activeElement || activeElement === document.body)) {
+        const { activeElement, body } = ownerDocument;
+        if (previouslyFocused.isConnected && (!activeElement || activeElement === body)) {
           previouslyFocused.focus({ preventScroll: true });
         }
       }, 0);


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where Control UI verification could finish every assertion successfully and then fail with an unhandled `ReferenceError: document is not defined` during environment teardown. This caused unnecessary reruns in release verification; [this CI job](https://github.com/openclaw/openclaw/actions/runs/33268472489/job/99142750094) passed all 4,093 assertions before failing in the clipboard callback.

## Why This Change Was Made

The shared clipboard fallback now retains the scratch textarea's owning document for deferred focus restoration. Vitest's JSDOM environment can remove the global document before the native timer fires; the callback must use its original owner. The zero-delay restoration, connected-target check, newer-focus protection, and `preventScroll` behavior remain intact. No retries, timeout changes, caller workarounds, or swallowed exceptions were added.

## User Impact

No intended visual or clipboard behavior change. Copy controls still restore focus after being re-enabled, preserve newly focused inputs, and ignore removed targets. Release verification no longer fails because this callback outlives its environment's global document.

## Evidence

- Reproduced on Node 24.20.0 with actual Vitest 4.1.11 JSDOM 29.1.1 setup, clipboard fallback, environment teardown, then native timer execution: baseline throws at `clipboard.ts:50`; fixed code exits successfully.
- The added owner regression fails before the production change. The existing real-timer focus test now also covers newer focus and removed targets.
- Final focused run covered `clipboard.test.ts`, the original `chat-pane-task-suggestions.test.ts` caller, and the three broader-suite failure files: all 53 assertions passed across five files.
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/chat-flow.clipboard.e2e.test.ts -t 'message-copy failure|assistant code cannot be copied'`: all three selected Chromium checks passed against the bundled Control UI, including desktop/mobile copy feedback. No visual behavior changed.

- Changed-gate guards, dead-code checks, and i18n checks passed. Its first typecheck caught a cross-runtime timer-handle mock in the new regression; that mock was replaced with Vitest fake timers. The final core-test and UI typechecks, targeted Oxlint, Stylelint, formatting, and diff checks all passed. This is composed gate evidence, not an uninterrupted changed-gate pass.
- The broader UI run passed 11,862 assertions and failed four 1-second lazy-module readiness assertions in `app-host-pairing-access.test.ts`, `lazy-shell-action.test.ts`, and `chat-tool-cards.highlight.test.ts`, without a clipboard teardown exception. Those files pass in bounded runs on both the original helper and this fix. Full-suite ordering/load diagnosis is a separate follow-up; this PR does not weaken those assertions or claim the full suite is green.

Production delta: +4/-2 (one document binding and its ownership comment); tests: +49/-18. The deferred global lookup is removed rather than guarded. Dependency source confirms Vitest teardown deletes populated globals while the native timer can remain pending. Codex autoreview completed with no findings. AI-assisted.
