### PR TITLE
fix: resume sessions with trusted runtime plugins absent at startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,7 @@ Docs: https://docs.openclaw.ai
 
 - **Browser extension relay:** route Runtime binding callbacks only to registered clients and preserve shared bindings during client cleanup, preventing raw callback payloads from reaching unrelated Playwright sessions.
 - **Control UI media playback:** restore inline audio and video rendition loading so readiness checks reach the Gateway instead of silently falling back to download cards. (#132832)
+- **Gateway cancellation:** route the first `chat.abort` directly to its cancellation handler without loading unrelated chat history and send workflows.
 - **Persisted agent runtimes:** prepare the trusted harness and provider selected by an existing session before Gateway, channel, and cron execution, while keeping plugin generations isolated and closed leases unusable.
 
 - **Grok web search startup:** avoid loading the full agent runtime before the first search, while preserving agent-scoped credentials and OAuth fallback behavior.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,8 @@ Docs: https://docs.openclaw.ai
 
 - **Browser extension relay:** route Runtime binding callbacks only to registered clients and preserve shared bindings during client cleanup, preventing raw callback payloads from reaching unrelated Playwright sessions.
 - **Control UI media playback:** restore inline audio and video rendition loading so readiness checks reach the Gateway instead of silently falling back to download cards. (#132832)
+- **Persisted agent runtimes:** prepare the trusted harness and provider selected by an existing session before Gateway, channel, and cron execution, while keeping plugin generations isolated and closed leases unusable.
+
 - **Grok web search startup:** avoid loading the full agent runtime before the first search, while preserving agent-scoped credentials and OAuth fallback behavior.
 - Gateway/subagents: keep plugin completion turns bound to the owning Gateway runtime so successful native subagents can finish delivery without losing the published reply runtime.
 - **Upgrade config repair:** retain plugin-owned channel configuration migrations alongside core schemas so `doctor --fix` can repair older settings before an external plugin is installed or granted capabilities, while preserving installed-plugin ownership and state-migration boundaries.

--- a/extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-runtime-e2ee-cli-account.test.ts
+++ b/extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-runtime-e2ee-cli-account.test.ts
@@ -8,10 +8,7 @@ import { startMatrixQaFaultProxy } from "../substrate/fault-proxy.js";
 import type { MatrixQaCliSession } from "./scenario-runtime-cli.js";
 import { runMatrixQaE2eeCliEncryptionSetupBootstrapFailureScenario } from "./scenario-runtime-e2ee-cli-account.js";
 import { MATRIX_QA_ROOM_KEY_BACKUP_VERSION_ENDPOINT } from "./scenario-runtime-e2ee-shared.js";
-import {
-  assertMatrixQaTestPortClosed,
-  createMatrixQaE2eeTestContext,
-} from "./scenario-runtime-e2ee.test-helpers.js";
+import { createMatrixQaE2eeTestContext } from "./scenario-runtime-e2ee.test-helpers.js";
 
 const mocks = vi.hoisted(() => ({ createRuntime: vi.fn() }));
 vi.mock("./scenario-runtime-e2ee-cli-runtime.js", () => ({
@@ -65,6 +62,8 @@ describe("Matrix CLI bootstrap failure evidence and ownership", () => {
         stop: async () => {
           await beforeProxyStop?.();
           stopping = proxy.stop().then(() => {
+            // The real stop joins this server's close event. Its released port may
+            // already belong to another worker when the scenario settles.
             closed = true;
           });
           await stopping;
@@ -128,7 +127,7 @@ describe("Matrix CLI bootstrap failure evidence and ownership", () => {
     async ({ methods }) => {
       configureCli(methods);
       await expect(run()).rejects.toThrow("did not attempt faulted room-key backup creation");
-      await assertMatrixQaTestPortClosed(proxy.baseUrl);
+      expect(closed).toBe(true);
       expect(dispose).toHaveBeenCalledOnce();
     },
   );
@@ -138,11 +137,11 @@ describe("Matrix CLI bootstrap failure evidence and ownership", () => {
     await expect(run()).resolves.toMatchObject({
       artifacts: { bootstrapSuccess: false, faultHitCount: 2 },
     });
-    await assertMatrixQaTestPortClosed(proxy.baseUrl);
+    expect(closed).toBe(true);
     closed = false;
     configureCli(["POST"], "unrelated failure");
     await expect(run()).rejects.toThrow("unexpected reason");
-    await assertMatrixQaTestPortClosed(proxy.baseUrl);
+    expect(closed).toBe(true);
   });
 
   it.each([new Error("runtime construction failed"), undefined, "construction rejected"])(
@@ -150,7 +149,7 @@ describe("Matrix CLI bootstrap failure evidence and ownership", () => {
     async (failure) => {
       mocks.createRuntime.mockRejectedValueOnce(failure);
       await expect(run()).rejects.toBe(failure);
-      await assertMatrixQaTestPortClosed(proxy.baseUrl);
+      expect(closed).toBe(true);
     },
   );
 
@@ -163,7 +162,7 @@ describe("Matrix CLI bootstrap failure evidence and ownership", () => {
         cause: failure,
         errors: [failure, proxyCleanupFailure],
       });
-      await assertMatrixQaTestPortClosed(proxy.baseUrl);
+      expect(closed).toBe(true);
     },
   );
 
@@ -173,7 +172,7 @@ describe("Matrix CLI bootstrap failure evidence and ownership", () => {
       configureCli(["POST"]);
       dispose.mockRejectedValueOnce(failure);
       await expect(run()).rejects.toBe(failure);
-      await assertMatrixQaTestPortClosed(proxy.baseUrl);
+      expect(closed).toBe(true);
     },
   );
 
@@ -186,7 +185,7 @@ describe("Matrix CLI bootstrap failure evidence and ownership", () => {
       cause: disposalFailure,
       errors: [disposalFailure, proxyCleanupFailure],
     });
-    await assertMatrixQaTestPortClosed(proxy.baseUrl);
+    expect(closed).toBe(true);
   });
 
   it("joins proxy cleanup before returning a CLI disposal failure", async () => {
@@ -212,6 +211,6 @@ describe("Matrix CLI bootstrap failure evidence and ownership", () => {
       release.resolve();
       expect(await operation).toBe(disposalFailure);
     }
-    await assertMatrixQaTestPortClosed(proxy.baseUrl);
+    expect(closed).toBe(true);
   });
 });

--- a/extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-runtime-e2ee.test-helpers.ts
+++ b/extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-runtime-e2ee.test-helpers.ts
@@ -1,4 +1,3 @@
-import { createServer } from "node:net";
 import type { MatrixVerificationBootstrapResult } from "@openclaw/matrix/test-api.js";
 import type { MatrixQaScenarioContext } from "./scenario-runtime-shared.js";
 
@@ -22,16 +21,6 @@ export function createMatrixQaE2eeTestContext(
     topology: { defaultRoomId: "!room:matrix-qa.test", defaultRoomKey: "main", rooms: [] },
     ...overrides,
   };
-}
-
-export async function assertMatrixQaTestPortClosed(baseUrl: string) {
-  const probe = createServer();
-  await new Promise<void>((resolve, reject) => {
-    probe.once("error", reject);
-    probe.listen(Number(new URL(baseUrl).port), "127.0.0.1", () => {
-      probe.close((error) => (error ? reject(error) : resolve()));
-    });
-  });
 }
 
 export function createMatrixQaBootstrapFailure(): MatrixVerificationBootstrapResult {

--- a/src/agents/agent-scope.ts
+++ b/src/agents/agent-scope.ts
@@ -55,9 +55,6 @@ export {
   tryResolveSoleAgentId,
   tryResolveDefaultAgentId,
   AgentSelectionRequiredError,
-  type AgentSelectionContext,
-  type AgentWorkspaceProvisioning,
-  type ResolvedAgentConfig,
 } from "./agent-scope-config.js";
 
 const AUTO_FALLBACK_PRIMARY_PROBE_INTERVAL_MS = 5 * 60 * 1000;
@@ -489,7 +486,7 @@ function resolveFirstModelFallbacksOverride(
   return undefined;
 }
 
-export type SubagentModelConfigSelectionSource = "subagent" | "agent" | "default-subagent";
+type SubagentModelConfigSelectionSource = "subagent" | "agent" | "default-subagent";
 
 export type SubagentModelConfigSelectionResult = {
   raw: AgentModelConfig;
@@ -542,7 +539,7 @@ export function resolveSubagentModelFallbacksOverride(
   return undefined;
 }
 
-function resolveSubagentSpawnModelFallbacksOverride(
+export function resolveSubagentSpawnModelFallbacksOverride(
   cfg: OpenClawConfig,
   agentId: string,
 ): string[] | undefined {

--- a/src/agents/command/cli-compaction.test.ts
+++ b/src/agents/command/cli-compaction.test.ts
@@ -127,6 +127,12 @@ function createPreparedRuntimeLease(input: {
       agentDir: input.agentDir,
       ...(input.workspaceDir ? { workspaceDir: input.workspaceDir } : {}),
     },
+    pluginGeneration: {
+      configuredCatalogEntries: [],
+      inlineProviderModels: [],
+      pluginMetadataSnapshot: prepared.metadataSnapshot,
+      pluginRegistry: prepared.pluginRegistry,
+    },
     release: vi.fn(),
   };
 }

--- a/src/agents/embedded-agent-runner/run-orchestrator.ts
+++ b/src/agents/embedded-agent-runner/run-orchestrator.ts
@@ -315,6 +315,7 @@ async function runEmbeddedAgentInternal(
       );
       startupStages.mark("prepared-runtime");
       const preparedModelRuntimeOwnerSnapshot = preparedModelRuntimeLease.snapshot;
+      let preparedLeaseActive = true;
       try {
         if (
           params.pluginGeneration &&
@@ -475,11 +476,13 @@ async function runEmbeddedAgentInternal(
           withPluginRuntimeGenerationScope(preparedModelRuntime, runPrepared);
         return params.pluginGeneration
           ? await withPreparedModelRuntimePluginGenerationScope(
-              params.pluginGeneration,
+              preparedModelRuntimeLease.pluginGeneration,
               runWithPreparedRuntime,
+              () => (preparedLeaseActive ? preparedModelRuntimeOwnerSnapshot : undefined),
             )
           : await runWithPreparedRuntime();
       } finally {
+        preparedLeaseActive = false;
         preparedModelRuntimeLease.release();
       }
     });

--- a/src/agents/prepared-model-registry.ts
+++ b/src/agents/prepared-model-registry.ts
@@ -101,7 +101,7 @@ function registryOwnerCandidates(
 async function loadReadSnapshot(
   input: PreparedModelRuntimeInput,
   allowConfiguredWorkspaceFallback: boolean,
-): Promise<PreparedModelRuntimeLease> {
+): Promise<Pick<PreparedModelRuntimeLease, "snapshot" | "release">> {
   for (const candidate of registryOwnerCandidates(input, allowConfiguredWorkspaceFallback)) {
     try {
       const prepared = await prepareModelRuntimeSnapshot(candidate);

--- a/src/agents/prepared-model-runtime-lease.ts
+++ b/src/agents/prepared-model-runtime-lease.ts
@@ -20,6 +20,10 @@ import {
   type PreparedModelRuntimeReplacement,
   type PreparedModelRuntimeSnapshot,
 } from "./prepared-model-runtime.owner.js";
+import {
+  preparedPluginGenerationReusesBase,
+  preparedPluginGenerationSupportsSelections,
+} from "./prepared-model-runtime.plugin-generation.js";
 import type { PreparedModelRuntimeCatalogMode } from "./prepared-model-runtime.types.js";
 
 type PreparedModelRuntimeLeaseContext = {
@@ -120,12 +124,17 @@ export async function acquirePreparedModelRuntimeLeaseFromOwners(
           !input.readOnly &&
           !input.loadRuntimePlugins &&
           !input.skipCredentials &&
-          !input.env
+          !input.env &&
+          preparedPluginGenerationSupportsSelections(options.pluginGeneration, input)
         ) {
           // A turn may finish under its still-open parent lease after reload. Its historic
           // generation must never publish over the configured owner for newly admitted work.
           throwIfLeaseAdmissionAborted(options.abortSignal);
-          return { snapshot: borrowed, release: () => {} };
+          return {
+            snapshot: borrowed,
+            pluginGeneration: options.pluginGeneration,
+            release: () => {},
+          };
         }
         throw new PreparedModelRuntimeOwnerNotPublishedError(
           `prepared model runtime plugin generation was superseded for ${input.agentDir}`,
@@ -139,8 +148,10 @@ export async function acquirePreparedModelRuntimeLeaseFromOwners(
       (existing.provenance === "run" || existing.provenance === "ephemeral");
     const pluginGenerationChanged =
       options.pluginGeneration !== undefined &&
-      (existing?.pending ? existing.pendingPluginGeneration : existing?.pluginGeneration) !==
-        options.pluginGeneration;
+      !preparedPluginGenerationReusesBase(
+        existing?.pending ? existing.pendingPluginGeneration : existing?.pluginGeneration,
+        options.pluginGeneration,
+      );
     if (existing?.pending && pluginGenerationChanged) {
       // Do not supersede active discovery. Wait for its owner to settle, then retry against
       // the published identity so same-generation callers still coalesce.
@@ -241,8 +252,9 @@ export async function acquirePreparedModelRuntimeLeaseFromOwners(
     break;
   }
   throwIfLeaseAdmissionAborted(options.abortSignal);
+  const pluginGeneration = owner.pluginGeneration!;
   if (owner.provenance !== provenance) {
-    return { snapshot, release: () => {} };
+    return { snapshot, pluginGeneration, release: () => {} };
   }
   throwIfLeaseAdmissionAborted(options.abortSignal);
   if (provenance === "run" && options.retainIdleRunOwner) {
@@ -254,6 +266,7 @@ export async function acquirePreparedModelRuntimeLeaseFromOwners(
   let released = false;
   return {
     snapshot,
+    pluginGeneration,
     release: () => {
       if (released) {
         return;

--- a/src/agents/prepared-model-runtime.build.ts
+++ b/src/agents/prepared-model-runtime.build.ts
@@ -301,17 +301,20 @@ async function buildSnapshotBatch(
   const freshGroups = new Map<string, PreparedModelRuntimeBuildCandidate[]>();
   const reusableGroups = new Map<
     PreparedModelRuntimePluginGeneration,
-    PreparedModelRuntimeBuildCandidate[]
+    Map<string, PreparedModelRuntimeBuildCandidate[]>
   >();
   for (const candidate of candidates) {
     const { input, pluginGeneration: reusablePluginGeneration } = candidate;
     if (reusablePluginGeneration) {
-      const group = reusableGroups.get(reusablePluginGeneration);
+      const workspaceGroups = reusableGroups.get(reusablePluginGeneration) ?? new Map();
+      const key = preparedModelRuntimeWorkspaceFactsKey(input);
+      const group = workspaceGroups.get(key);
       if (group) {
         group.push(candidate);
       } else {
-        reusableGroups.set(reusablePluginGeneration, [candidate]);
+        workspaceGroups.set(key, [candidate]);
       }
+      reusableGroups.set(reusablePluginGeneration, workspaceGroups);
       continue;
     }
     const ownerKind = candidate.prepareInboundPluginRegistry ? "configured" : "dynamic";
@@ -327,10 +330,12 @@ async function buildSnapshotBatch(
     groupCandidates: PreparedModelRuntimeBuildCandidate[];
     pluginGeneration?: PreparedModelRuntimePluginGeneration;
   }> = [
-    ...[...reusableGroups].map(([pluginGeneration, groupCandidates]) => ({
-      groupCandidates,
-      pluginGeneration,
-    })),
+    ...[...reusableGroups].flatMap(([pluginGeneration, workspaceGroups]) =>
+      [...workspaceGroups.values()].map((groupCandidates) => ({
+        groupCandidates,
+        pluginGeneration,
+      })),
+    ),
     ...[...freshGroups.values()].map((groupCandidates) => ({ groupCandidates })),
   ];
   const preparedInputs = new Map<PreparedModelRuntimeInput, PreparedModelRuntimeAgentFacts>();

--- a/src/agents/prepared-model-runtime.facts.ts
+++ b/src/agents/prepared-model-runtime.facts.ts
@@ -17,6 +17,7 @@ import type { ProviderCatalogOutcome } from "../plugins/provider-catalog.types.j
 import { resolveLoadedProviderRuntimePlugin } from "../plugins/provider-hook-runtime.js";
 import type { ProviderRuntimeModel } from "../plugins/provider-runtime-model.types.js";
 import { withPluginRuntimeRegistryScope } from "../plugins/runtime/gateway-request-scope.js";
+import { withPluginRuntimeGenerationScope } from "../plugins/runtime/generation-scope.js";
 import { resolveRuntimeSyntheticAuthProviderRefs } from "../plugins/synthetic-auth.runtime.js";
 import type { AgentCredentialMap } from "./agent-auth-credentials.js";
 import { resolveAmbientAgentCredentialsForDiscovery } from "./agent-auth-discovery.js";
@@ -67,10 +68,7 @@ import {
   type PreparedInboundRegistryLoader,
 } from "./prepared-model-runtime.inbound-registry.js";
 import { prepareOwnedPluginLoadContext } from "./prepared-model-runtime.plugin-context.js";
-import {
-  createPreparedPluginGeneration,
-  withPreparedPluginGenerationScope,
-} from "./prepared-model-runtime.plugin-generation.js";
+import { createPreparedPluginGeneration } from "./prepared-model-runtime.plugin-generation.js";
 import {
   listPreparedSyntheticAuthProviderRefs,
   resolvePreparedSyntheticAuth,
@@ -188,21 +186,19 @@ export async function prepareWorkspaceBuildGroup(
     ? 0
     : performance.now() - pluginMetadataStartedAt;
   const runtimePluginStartedAt = performance.now();
-  const { inboundPluginRegistry, runtimePluginRegistry } = reusablePluginGeneration
-    ? {
-        inboundPluginRegistry: reusablePluginGeneration.inboundPluginRegistry,
-        runtimePluginRegistry: reusablePluginGeneration.pluginRegistry,
-      }
-    : prepareWorkspacePluginRegistries(
-        input,
-        pluginMetadataSnapshot,
-        loadInboundPluginRegistry,
-        options.preferBuiltPluginArtifacts === true,
-      );
-  const runtimePluginMs = reusablePluginGeneration ? 0 : performance.now() - runtimePluginStartedAt;
   const preferBuiltPluginArtifacts =
     reusablePluginGeneration?.preferBuiltPluginArtifacts ??
     options.preferBuiltPluginArtifacts === true;
+  const { inboundPluginRegistry, runtimePluginRegistry } = prepareWorkspacePluginRegistries(
+    input,
+    pluginMetadataSnapshot,
+    loadInboundPluginRegistry,
+    preferBuiltPluginArtifacts,
+    reusablePluginGeneration,
+  );
+  const reuseRuntimeFacts =
+    reusablePluginGeneration && runtimePluginRegistry === reusablePluginGeneration.pluginRegistry;
+  const runtimePluginMs = performance.now() - runtimePluginStartedAt;
   prepareOwnedPluginLoadContext(
     input,
     env,
@@ -214,7 +210,7 @@ export async function prepareWorkspaceBuildGroup(
     const matchesStaticModelId = createStaticModelIdMatcher({
       manifestPlugins: pluginMetadataSnapshot.plugins,
     });
-    const mediaCapabilityProviders = reusablePluginGeneration
+    const mediaCapabilityProviders = reuseRuntimeFacts
       ? reusablePluginGeneration.mediaCapabilityProviders
       : input.readOnly || !runtimePluginRegistry
         ? undefined
@@ -223,7 +219,7 @@ export async function prepareWorkspaceBuildGroup(
             pluginMetadataSnapshot,
             registry: runtimePluginRegistry,
           });
-    const messageToolCatalog = reusablePluginGeneration
+    const messageToolCatalog = reuseRuntimeFacts
       ? reusablePluginGeneration.messageToolCatalog
       : runtimePluginRegistry
         ? getPreparedMessageToolCatalogForRegistry(runtimePluginRegistry)
@@ -273,7 +269,7 @@ export async function prepareWorkspaceBuildGroup(
       ]),
     ].toSorted((left, right) => left.localeCompare(right));
     const staticProviderCatalogStartedAt = performance.now();
-    const preparedStaticProviderCatalog = reusablePluginGeneration
+    let preparedStaticProviderCatalog = reusablePluginGeneration
       ? reusablePluginGeneration.preparedStaticProviderCatalog
       : catalogMode === "static"
         ? await prepareImplicitProviderStaticCatalog({
@@ -285,6 +281,28 @@ export async function prepareWorkspaceBuildGroup(
             ...(input.workspaceDir ? { workspaceDir: input.workspaceDir } : {}),
           })
         : undefined;
+    if (
+      catalogMode === "static" &&
+      reusablePluginGeneration &&
+      !reuseRuntimeFacts &&
+      runtimePluginRegistry?.providers.length
+    ) {
+      // Selected owners may supply synthetic auth absent from startup's configured
+      // providers. Carry those exact handles through refresh without rediscovery.
+      preparedStaticProviderCatalog = Object.freeze({
+        entries: preparedStaticProviderCatalog?.entries ?? [],
+        providers: Object.freeze([
+          ...new Map([
+            ...(preparedStaticProviderCatalog?.providers ?? []).map(
+              (provider) => [provider.id, provider] as const,
+            ),
+            ...runtimePluginRegistry.providers.map(
+              ({ provider }) => [provider.id, provider] as const,
+            ),
+          ]).values(),
+        ]),
+      });
+    }
     const staticProviderCatalogMs = reusablePluginGeneration
       ? 0
       : performance.now() - staticProviderCatalogStartedAt;
@@ -432,12 +450,14 @@ export async function prepareWorkspaceBuildGroup(
       pluginGeneration,
     };
   };
-  return reusablePluginGeneration
-    ? await withPreparedPluginGenerationScope(
-        { input, pluginGeneration: reusablePluginGeneration },
-        () => prepare(),
-      )
-    : await withPluginRuntimeRegistryScope(runtimePluginRegistry, prepare);
+  return await withPluginRuntimeGenerationScope(
+    {
+      config: input.config,
+      metadataSnapshot: pluginMetadataSnapshot,
+      pluginRegistry: runtimePluginRegistry,
+    },
+    prepare,
+  );
 }
 
 function captureModelsJsonContents(agentDir: string): string | null {

--- a/src/agents/prepared-model-runtime.inbound-registry.test.ts
+++ b/src/agents/prepared-model-runtime.inbound-registry.test.ts
@@ -8,9 +8,13 @@ import {
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createDeferred } from "../../test/helpers/promise.js";
 import { retainLegacyDefaultAgentId } from "../config/legacy.default-agent-owner.js";
+import { createPluginMetadataSnapshot } from "../config/plugin-auto-enable.test-helpers.js";
+import type { PluginManifestRecord } from "../plugins/manifest-registry.js";
 import { createEmptyPluginRegistry } from "../plugins/registry-empty.js";
 import { getPluginRuntimeGenerationRegistry } from "../plugins/runtime/generation-scope.js";
 import { getPluginRuntimeLoadContext } from "../plugins/runtime/load-context.js";
+import type { DiscoverAuthStorageOptions } from "./agent-auth-discovery.js";
+import { withPreparedModelRuntimePluginGenerationScope } from "./prepared-model-runtime-generation-scope.js";
 import {
   acquireAgentRunPreparedModelRuntime,
   getPreparedModelRuntimeSnapshot,
@@ -31,6 +35,185 @@ describe("prepared reply dispatch runtime", () => {
       loadPublishedGatewayReplyDispatchRuntime({ agentId: "default" }),
     ).resolves.toBeUndefined();
     expect(mocks.loadAgentRuntimePluginRegistryHandle).not.toHaveBeenCalled();
+  });
+
+  it("carries newly selected provider auth into a derived generation and its refresh", async () => {
+    const { resolveAmbientAgentCredentialsForDiscovery } = await vi.importActual<
+      typeof import("./agent-auth-discovery.js")
+    >("./agent-auth-discovery.js");
+    mocks.resolveAmbientCredentials.mockImplementation((options) =>
+      resolveAmbientAgentCredentialsForDiscovery(
+        options as Parameters<typeof resolveAmbientAgentCredentialsForDiscovery>[0],
+      ),
+    );
+    mocks.discoverAuthStorage.mockImplementation((_dir, options) => ({
+      getAll: () => (options as DiscoverAuthStorageOptions).ambientCredentials,
+      getOAuthProviders: () => [],
+    }));
+    mocks.configuredAgentIds = ["default"];
+    const config = { agents: { defaults: { model: "initial/model" } } };
+    const selectedRegistry = createEmptyPluginRegistry();
+    selectedRegistry.providers.push({
+      pluginId: "selected-provider",
+      source: "test",
+      provider: {
+        id: "selected",
+        label: "Selected provider",
+        auth: [],
+        resolveSyntheticAuth: () => ({
+          apiKey: "synthetic-provider-fixture",
+          source: "fixture",
+          mode: "api-key",
+        }),
+      },
+    });
+    mocks.loadAgentRuntimePluginRegistryHandle.mockImplementation((params) =>
+      params.selections?.some(
+        (selection: { provider: string }) => selection.provider === "selected",
+      )
+        ? selectedRegistry
+        : (params.reusableRegistry ?? createEmptyPluginRegistry()),
+    );
+    await refreshPreparedModelRuntimeSnapshots(config, {
+      gatewayLifecycle: true,
+      catalogMode: "static",
+    });
+    const published = (await loadPublishedGatewayReplyDispatchRuntime({ agentId: "default" }))!;
+    const input = {
+      config,
+      agentId: "default",
+      agentDir: published.agentDir,
+      workspaceDir: published.workspaceDir,
+      runtimePluginSelections: [{ provider: "selected", modelId: "model", runtime: "openclaw" }],
+    };
+    const lease = await acquireAgentRunPreparedModelRuntime(input, {
+      catalogMode: "static",
+      pluginGeneration: published.pluginGeneration,
+    });
+    expect(lease.snapshot.pluginRegistry === selectedRegistry).toBe(true);
+    expect(lease.snapshot.authModes.selected).toBe("api_key");
+    expect(published.pluginGeneration.preparedStaticProviderCatalog?.providers).toBeUndefined();
+    lease.release();
+    const publishedRefresh = createDeferred();
+    const unregister = registerPreparedModelRuntimePublicationListener((event) => {
+      if (event.phase === "published") {
+        publishedRefresh.resolve();
+      }
+    });
+    mocks.mutationListener?.({ affectsInheritedStores: true });
+    await publishedRefresh.promise;
+    unregister();
+    expect(getPreparedModelRuntimeSnapshot(input)?.authModes.selected).toBe("api_key");
+  });
+
+  it("isolates selected run owners while retaining the published generation and lease lifetime", async () => {
+    mocks.configuredAgentIds = ["default"];
+    const config = { agents: { defaults: { model: "custom/model" } } };
+    const registries = new Map(
+      ["first-harness", "second-harness"].map((runtime) => {
+        const registry = createEmptyPluginRegistry();
+        registry.agentHarnesses.push({
+          pluginId: runtime,
+          source: "test",
+          harness: {
+            id: runtime,
+            label: runtime,
+            supports: () => ({ supported: true }),
+            runAttempt: async () => {
+              throw new Error("unused");
+            },
+          },
+        });
+        return [runtime, registry] as const;
+      }),
+    );
+    mocks.loadAgentRuntimePluginRegistryHandle.mockImplementation(
+      (params) => registries.get(params.selections?.[0]?.runtime) ?? createEmptyPluginRegistry(),
+    );
+    const manifests: PluginManifestRecord[] = [...registries.keys()].map((id) => ({
+      id,
+      name: id,
+      origin: "bundled",
+      channels: [],
+      providers: [],
+      cliBackends: [],
+      skills: [],
+      hooks: [],
+      rootDir: `/plugins/${id}`,
+      source: `/plugins/${id}/index.js`,
+      manifestPath: `/plugins/${id}/openclaw.plugin.json`,
+      activation: { onStartup: false, onAgentHarnesses: [id] },
+    }));
+    await refreshPreparedModelRuntimeSnapshots(config, {
+      gatewayLifecycle: true,
+      catalogMode: "static",
+      allowGatewaySubagentBinding: true,
+      pluginMetadataSnapshot: createPluginMetadataSnapshot({
+        config,
+        manifestRegistry: { plugins: manifests, diagnostics: [] },
+      }),
+    });
+    const published = (await loadPublishedGatewayReplyDispatchRuntime({ agentId: "default" }))!;
+    const input = (runtime: string) => ({
+      config,
+      agentId: "default",
+      agentDir: published.agentDir,
+      workspaceDir: published.workspaceDir,
+      allowGatewaySubagentBinding: true,
+      runtimePluginSelections: [{ provider: "custom", modelId: "model", runtime }],
+    });
+    const options = {
+      catalogMode: "static" as const,
+      pluginGeneration: published.pluginGeneration,
+    };
+    const leases = await Promise.all(
+      [...registries.keys()].map((runtime) =>
+        acquireAgentRunPreparedModelRuntime(input(runtime), options),
+      ),
+    );
+    for (const [index, runtime] of [...registries.keys()].entries()) {
+      const lease = leases[index]!;
+      expect(lease.snapshot.pluginRegistry === registries.get(runtime)).toBe(true);
+      expect(lease.snapshot.metadataSnapshot).toBe(
+        published.pluginGeneration.pluginMetadataSnapshot,
+      );
+      expect(lease.pluginGeneration.inboundPluginRegistry).toBe(published.inboundPluginRegistry);
+      expect(Object.isFrozen(lease.pluginGeneration)).toBe(true);
+      const repeated = await acquireAgentRunPreparedModelRuntime(input(runtime), options);
+      expect(repeated.snapshot === lease.snapshot).toBe(true);
+      expect(repeated.pluginGeneration === lease.pluginGeneration).toBe(true);
+      repeated.release();
+      let active = true;
+      await withPreparedModelRuntimePluginGenerationScope(
+        lease.pluginGeneration,
+        async () => {
+          const nested = await acquireAgentRunPreparedModelRuntime(input(runtime), {
+            pluginGeneration: lease.pluginGeneration,
+          });
+          expect(nested.snapshot === lease.snapshot).toBe(true);
+          nested.release();
+          const otherRuntime = [...registries.keys()].find((candidate) => candidate !== runtime)!;
+          await expect(
+            acquireAgentRunPreparedModelRuntime(input(otherRuntime), {
+              pluginGeneration: lease.pluginGeneration,
+            }),
+          ).rejects.toThrow("plugin generation was superseded");
+          active = false;
+          lease.release();
+          await expect(
+            acquireAgentRunPreparedModelRuntime(input(runtime), {
+              pluginGeneration: lease.pluginGeneration,
+            }),
+          ).rejects.toThrow("plugin generation was superseded");
+        },
+        () => (active ? lease.snapshot : undefined),
+      );
+    }
+    expect(
+      (await loadPublishedGatewayReplyDispatchRuntime({ agentId: "default" })) === published,
+    ).toBe(true);
+    expect(published.pluginGeneration.pluginRegistry?.agentHarnesses).toEqual([]);
+    expect(mocks.loadAgentRuntimePluginRegistryHandle).toHaveBeenCalledTimes(4);
   });
 
   it("atomically replaces one complete prepared dispatch runtime across a Gateway refresh", async () => {
@@ -151,8 +334,8 @@ describe("prepared reply dispatch runtime", () => {
     const workspaceDir = "/tmp/dynamic-auth-workspace";
     const catalogGenerationRegistries: unknown[] = [];
     const dynamicPreparationRegistries: unknown[] = [];
-    mocks.loadAgentRuntimePluginRegistryHandle.mockImplementation(() =>
-      createEmptyPluginRegistry(),
+    mocks.loadAgentRuntimePluginRegistryHandle.mockImplementation(
+      (params) => params.reusableRegistry ?? createEmptyPluginRegistry(),
     );
     mocks.buildPreparedModelCatalogSnapshot.mockImplementation(async () => {
       catalogGenerationRegistries.push(getPluginRuntimeGenerationRegistry());
@@ -201,11 +384,9 @@ describe("prepared reply dispatch runtime", () => {
       preferBuiltPluginArtifacts: true,
     });
     dynamicLease.release();
-    expect(mocks.loadAgentRuntimePluginRegistryHandle).toHaveBeenCalledTimes(2);
     expect(dynamicPreparationRegistries.every(Boolean)).toBe(true);
     expect(catalogGenerationRegistries.every(Boolean)).toBe(true);
     expect(dynamicSelectedBefore).toBe(configuredSelectedBefore);
-    const registryCallsBeforeAuth = mocks.loadAgentRuntimePluginRegistryHandle.mock.calls.length;
     const authStorageCallsBeforeAuth = mocks.discoverAuthStorage.mock.calls.length;
     const modelCallsBeforeAuth = mocks.discoverModels.mock.calls.length;
     const staticCatalogCallsBeforeAuth = mocks.prepareStaticCatalog.mock.calls.length;
@@ -220,9 +401,6 @@ describe("prepared reply dispatch runtime", () => {
     await published.promise;
     unregister();
 
-    expect(mocks.loadAgentRuntimePluginRegistryHandle).toHaveBeenCalledTimes(
-      registryCallsBeforeAuth,
-    );
     expect(mocks.discoverAuthStorage.mock.calls.length - authStorageCallsBeforeAuth).toBe(2);
     expect(mocks.discoverModels.mock.calls.length - modelCallsBeforeAuth).toBe(2);
     expect(mocks.prepareStaticCatalog.mock.calls.length - staticCatalogCallsBeforeAuth).toBe(0);

--- a/src/agents/prepared-model-runtime.inbound-registry.ts
+++ b/src/agents/prepared-model-runtime.inbound-registry.ts
@@ -12,7 +12,10 @@ import {
   getActivePluginRuntimeSubagentMode,
 } from "../plugins/runtime.js";
 import { prepareOwnedPluginLoadContext } from "./prepared-model-runtime.plugin-context.js";
-import type { PreparedModelRuntimeInput } from "./prepared-model-runtime.types.js";
+import type {
+  PreparedModelRuntimeInput,
+  PreparedModelRuntimePluginGeneration,
+} from "./prepared-model-runtime.types.js";
 import { loadAgentRuntimePluginRegistryHandle } from "./runtime-plugins.js";
 
 type PreparedInboundRegistryInput = Pick<
@@ -116,6 +119,7 @@ export function prepareWorkspacePluginRegistries(
   metadataSnapshot: PluginMetadataSnapshot,
   loadInboundRegistry?: PreparedInboundRegistryLoader,
   preferBuiltPluginArtifacts = false,
+  reusableGeneration?: PreparedModelRuntimePluginGeneration,
 ): {
   runtimePluginRegistry?: PluginRegistry;
   inboundPluginRegistry?: PluginRegistry;
@@ -127,15 +131,19 @@ export function prepareWorkspacePluginRegistries(
   }
   const inboundPluginRegistry = input.readOnly
     ? undefined
-    : loadInboundRegistry?.(input, metadataSnapshot);
+    : (reusableGeneration?.inboundPluginRegistry ?? loadInboundRegistry?.(input, metadataSnapshot));
+  const baseRegistry = reusableGeneration?.pluginRegistry ?? inboundPluginRegistry;
   const runtimePluginRegistry =
-    input.runtimePluginSelections || !inboundPluginRegistry
+    input.runtimePluginSelections || !baseRegistry
       ? loadAgentRuntimePluginRegistryHandle({
           ...(input.loadRuntimePlugins
             ? { basePluginIds: [] }
-            : inboundPluginRegistry
-              ? { basePluginIds: listRuntimePluginIdsFromRegistry(inboundPluginRegistry) }
+            : baseRegistry
+              ? { basePluginIds: listRuntimePluginIdsFromRegistry(baseRegistry) }
               : {}),
+          ...(reusableGeneration?.pluginRegistry
+            ? { reusableRegistry: reusableGeneration.pluginRegistry }
+            : {}),
           config: input.config,
           env: input.env ?? process.env,
           ...(input.workspaceDir ? { workspaceDir: input.workspaceDir } : {}),
@@ -144,7 +152,7 @@ export function prepareWorkspacePluginRegistries(
           ...(preferBuiltPluginArtifacts ? { preferBuiltPluginArtifacts: true } : {}),
           selections: input.runtimePluginSelections,
         })
-      : inboundPluginRegistry;
+      : baseRegistry;
   return {
     runtimePluginRegistry,
     ...(inboundPluginRegistry ? { inboundPluginRegistry } : {}),

--- a/src/agents/prepared-model-runtime.owner.ts
+++ b/src/agents/prepared-model-runtime.owner.ts
@@ -7,14 +7,18 @@ import { isReservedSystemAgentId } from "../system-agent/agent-id.js";
 import {
   listAgentIds,
   resolveAgentDir,
-  resolveRunModelFallbacksOverride,
+  resolveSubagentSpawnModelFallbacksOverride,
   resolveAgentWorkspaceDir,
 } from "./agent-scope.js";
 import { DEFAULT_MODEL, DEFAULT_PROVIDER } from "./defaults.js";
 import { resolveSelectedAgentHarnessRuntime } from "./harness/runtime-plugin-load-plan.js";
 import { resolveLegacyInheritedAuthDir } from "./legacy-inherited-auth-dir.js";
 import { resolveModelCandidateChain } from "./model-fallback-candidates.js";
-import { resolveDefaultModelForAgent } from "./model-selection-config.js";
+import {
+  resolveDefaultModelForAgent,
+  resolveSubagentConfiguredModelSelection,
+} from "./model-selection-config.js";
+import { resolveConfiguredModelFallbacks } from "./model-selection-resolve.js";
 import { preparePublishedModelCatalogOwnerIdentity } from "./prepared-model-catalog-owner.js";
 import { copyPreparedModelRuntimeAuthBindings } from "./prepared-model-runtime-auth.js";
 import {
@@ -417,6 +421,11 @@ function resolveConfiguredRuntimePluginSelections(
   agentId: string,
 ): PreparedModelRuntimeInput["runtimePluginSelections"] {
   const configured = resolveDefaultModelForAgent({ cfg: config, agentId });
+  const subagentModel = resolveSubagentConfiguredModelSelection({
+    cfg: config,
+    agentId,
+    includeAgentPrimary: false,
+  });
   return resolveModelCandidateChain({
     cfg: config,
     agentId,
@@ -424,7 +433,13 @@ function resolveConfiguredRuntimePluginSelections(
     provider: configured.provider || DEFAULT_PROVIDER,
     model: configured.model || DEFAULT_MODEL,
     requestedRouteResolution: "resolved",
-    fallbacksOverride: resolveRunModelFallbacksOverride({ cfg: config, agentId }),
+    // Session policy can narrow either configured chain after admission waits. Prepare
+    // their owners once so nested execution never expands an already frozen generation.
+    fallbacksOverride: [
+      ...resolveConfiguredModelFallbacks({ cfg: config, agentId }),
+      ...(subagentModel ? [subagentModel] : []),
+      ...(resolveSubagentSpawnModelFallbacksOverride(config, agentId) ?? []),
+    ],
   }).map((candidate) => ({
     provider: candidate.provider,
     modelId: candidate.model,

--- a/src/agents/prepared-model-runtime.plugin-context.test.ts
+++ b/src/agents/prepared-model-runtime.plugin-context.test.ts
@@ -7,16 +7,21 @@ import * as currentPluginMetadata from "../plugins/current-plugin-metadata-snaps
 import { clearPluginMetadataLifecycleCaches } from "../plugins/plugin-metadata-lifecycle.js";
 import * as pluginMetadata from "../plugins/plugin-metadata-snapshot.js";
 import { createEmptyPluginRegistry } from "../plugins/registry-empty.js";
+import { getPluginRuntimeGenerationRegistry } from "../plugins/runtime/generation-scope.js";
 import { getPluginRuntimeLoadContext } from "../plugins/runtime/load-context.js";
+import { buildPreparedModelCatalogSnapshot } from "./model-catalog.js";
 import { prepareOwnedPluginLoadContext } from "./prepared-model-runtime.plugin-context.js";
-import { withPreparedPluginGenerationScope } from "./prepared-model-runtime.plugin-generation.js";
+import { buildPreparedPluginModelCatalog } from "./prepared-model-runtime.plugin-generation.js";
+import { AuthStorage, ModelRegistry } from "./sessions/index.js";
+
+vi.mock("./model-catalog.js", { spy: true });
 
 describe("prepared model runtime plugin metadata ownership", () => {
   afterEach(() => {
     clearPluginMetadataLifecycleCaches();
   });
 
-  it("uses one explicit Gateway metadata generation across agent workspaces", () => {
+  it("uses one explicit Gateway metadata generation across agent workspaces", async () => {
     const config = { plugins: { allow: ["synthetic"] } };
     const gatewayWorkspace = "/tmp/gateway-plugin-workspace";
     const gatewaySnapshot = createPluginMetadataSnapshot({
@@ -34,12 +39,22 @@ describe("prepared model runtime plugin metadata ownership", () => {
       inlineProviderModels: [],
       pluginMetadataSnapshot: gatewaySnapshot,
     };
+    const modelRegistry = ModelRegistry.inMemory(AuthStorage.inMemory({}));
     const resolveMetadata = vi.spyOn(pluginMetadata, "resolvePluginMetadataSnapshot");
     const getCurrentMetadata = vi.spyOn(currentPluginMetadata, "getCurrentPluginMetadataSnapshot");
+    let selectedRegistry = createEmptyPluginRegistry();
+    const buildCatalog = vi
+      .mocked(buildPreparedModelCatalogSnapshot)
+      .mockImplementation(async ({ metadataSnapshot }) => {
+        expect(metadataSnapshot).toBe(gatewaySnapshot);
+        expect(getPluginRuntimeGenerationRegistry() === selectedRegistry).toBe(true);
+        return { entries: [], routeVariants: [] };
+      });
 
     try {
       for (const input of inputs) {
         const registry = createEmptyPluginRegistry();
+        selectedRegistry = registry;
         expect(
           prepareOwnedPluginLoadContext(input, process.env, registry, gatewaySnapshot, true),
         ).toBe(gatewaySnapshot);
@@ -47,15 +62,19 @@ describe("prepared model runtime plugin metadata ownership", () => {
           metadataSnapshot: gatewaySnapshot,
           preferBuiltPluginArtifacts: true,
         });
-        expect(
-          withPreparedPluginGenerationScope({ input, pluginGeneration }, (snapshot) => snapshot),
-        ).toBe(gatewaySnapshot);
+        await buildPreparedPluginModelCatalog({
+          agentFacts: { input, credentials: {} },
+          catalogMode: "static",
+          modelRegistry,
+          pluginGeneration: { ...pluginGeneration, pluginRegistry: registry },
+        });
       }
-      expect(getCurrentMetadata).not.toHaveBeenCalled();
-      expect(resolveMetadata).not.toHaveBeenCalled();
+      expect(getCurrentMetadata.mock.calls.length).toBe(0);
+      expect(resolveMetadata.mock.calls.length).toBe(0);
     } finally {
       getCurrentMetadata.mockRestore();
       resolveMetadata.mockRestore();
+      buildCatalog.mockRestore();
     }
   });
 

--- a/src/agents/prepared-model-runtime.plugin-generation.ts
+++ b/src/agents/prepared-model-runtime.plugin-generation.ts
@@ -1,11 +1,59 @@
+import {
+  listRuntimePluginIdsFromRegistry,
+  registryContainsRuntimePluginIds,
+} from "../plugins/active-runtime-registry.js";
 import { withPluginRuntimeGenerationScope } from "../plugins/runtime/generation-scope.js";
 import { augmentPreparedModelCatalogWithAgentHarness } from "./harness/model-catalog.js";
+import {
+  resolveAgentRuntimePluginLoadPlan,
+  resolveAgentRuntimePluginSelections,
+} from "./harness/runtime-plugin-load-plan.js";
 import { buildPreparedModelCatalogSnapshot } from "./model-catalog.js";
 import type {
   PreparedModelRuntimeCatalogMode,
   PreparedModelRuntimeInput,
   PreparedModelRuntimePluginGeneration,
 } from "./prepared-model-runtime.types.js";
+
+// Lineage is cache identity only. Derived generations still require the exact open
+// parent lease at admission; they never become configured publication authority.
+const derivedGenerationBases = new WeakMap<
+  PreparedModelRuntimePluginGeneration,
+  PreparedModelRuntimePluginGeneration
+>();
+
+/** Borrowing may narrow a prepared selection, but cannot acquire a different plugin owner. */
+export function preparedPluginGenerationSupportsSelections(
+  generation: PreparedModelRuntimePluginGeneration,
+  input: PreparedModelRuntimeInput,
+): boolean {
+  if (!input.runtimePluginSelections) {
+    return true;
+  }
+  const registry = generation.pluginRegistry;
+  if (!registry) {
+    return false;
+  }
+  const plan = resolveAgentRuntimePluginLoadPlan({
+    config: input.config,
+    workspaceDir:
+      generation.pluginMetadataSnapshot.workspaceDir ?? input.workspaceDir ?? process.cwd(),
+    basePluginIds: listRuntimePluginIdsFromRegistry(registry),
+    selections: resolveAgentRuntimePluginSelections(input.config, input.runtimePluginSelections),
+    metadataSnapshot: generation.pluginMetadataSnapshot,
+  });
+  return registryContainsRuntimePluginIds(registry, plan.pluginIds);
+}
+
+export function preparedPluginGenerationReusesBase(
+  generation: PreparedModelRuntimePluginGeneration | undefined,
+  base: PreparedModelRuntimePluginGeneration,
+): boolean {
+  return (
+    generation === base ||
+    (generation !== undefined && derivedGenerationBases.get(generation) === base)
+  );
+}
 
 export function createPreparedPluginGeneration(params: {
   catalogMode: PreparedModelRuntimeCatalogMode;
@@ -23,9 +71,24 @@ export function createPreparedPluginGeneration(params: {
 }): PreparedModelRuntimePluginGeneration {
   const reusable = params.reusablePluginGeneration;
   if (reusable) {
-    return params.pluginMetadataSnapshot === reusable.pluginMetadataSnapshot
-      ? reusable
-      : Object.freeze({ ...reusable, pluginMetadataSnapshot: params.pluginMetadataSnapshot });
+    if (
+      params.pluginMetadataSnapshot === reusable.pluginMetadataSnapshot &&
+      params.runtimePluginRegistry === reusable.pluginRegistry
+    ) {
+      return reusable;
+    }
+    const derived = Object.freeze({
+      ...reusable,
+      pluginMetadataSnapshot: params.pluginMetadataSnapshot,
+      pluginRegistry: params.runtimePluginRegistry,
+      mediaCapabilityProviders: params.mediaCapabilityProviders,
+      messageToolCatalog: params.messageToolCatalog,
+      preparedStaticProviderCatalog: params.preparedStaticProviderCatalog,
+    });
+    if (params.pluginMetadataSnapshot === reusable.pluginMetadataSnapshot) {
+      derivedGenerationBases.set(derived, reusable);
+    }
+    return derived;
   }
   return Object.freeze({
     pluginMetadataSnapshot: params.pluginMetadataSnapshot,
@@ -59,9 +122,10 @@ export async function buildPreparedPluginModelCatalog(params: {
   pluginGeneration: PreparedModelRuntimePluginGeneration;
 }) {
   const { credentials, input } = params.agentFacts;
-  return await withPreparedPluginGenerationScope(
-    { input, pluginGeneration: params.pluginGeneration },
-    async (metadataSnapshot) => {
+  const { pluginMetadataSnapshot: metadataSnapshot, pluginRegistry } = params.pluginGeneration;
+  return await withPluginRuntimeGenerationScope(
+    { config: input.config, metadataSnapshot, pluginRegistry },
+    async () => {
       const snapshot = await buildPreparedModelCatalogSnapshot({
         agentDir: input.agentDir,
         authCredentials: credentials,
@@ -77,29 +141,9 @@ export async function buildPreparedPluginModelCatalog(params: {
         ? await augmentPreparedModelCatalogWithAgentHarness({
             input,
             snapshot,
-            pluginRegistry: params.pluginGeneration.pluginRegistry,
+            pluginRegistry,
           })
         : snapshot;
     },
-  );
-}
-
-/** Runs workspace preparation against one exact, reusable plugin generation. */
-export function withPreparedPluginGenerationScope<T>(
-  params: {
-    input: PreparedModelRuntimeInput;
-    pluginGeneration: PreparedModelRuntimePluginGeneration;
-  },
-  run: (metadataSnapshot: PreparedModelRuntimePluginGeneration["pluginMetadataSnapshot"]) => T,
-): T {
-  const { input, pluginGeneration } = params;
-  const metadataSnapshot = pluginGeneration.pluginMetadataSnapshot;
-  return withPluginRuntimeGenerationScope(
-    {
-      config: input.config,
-      metadataSnapshot,
-      pluginRegistry: pluginGeneration.pluginRegistry,
-    },
-    () => run(metadataSnapshot),
   );
 }

--- a/src/agents/prepared-model-runtime.reply-fallback.test.ts
+++ b/src/agents/prepared-model-runtime.reply-fallback.test.ts
@@ -1,0 +1,190 @@
+// Preserve module setup before modules that consume it.
+// oxfmt-ignore
+import {
+  getPreparedModelRuntimeMocks,
+  resetPreparedModelRuntimeHarness,
+} from "./prepared-model-runtime.test-harness.js";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { resolveModelFallbackOptions } from "../auto-reply/reply/agent-runner-run-params.js";
+import { runPreparedReply } from "../auto-reply/reply/get-reply-run.js";
+import type { RunPreparedReplyParams } from "../auto-reply/reply/get-reply-run.types.js";
+import { bindPreparedReplyDispatchRuntime } from "../auto-reply/reply/prepared-reply-dispatch-context.js";
+import type { FollowupRun } from "../auto-reply/reply/queue.js";
+import { createPluginMetadataSnapshot } from "../config/plugin-auto-enable.test-helpers.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { listRuntimePluginIdsFromRegistry } from "../plugins/active-runtime-registry.js";
+import type { PluginManifestRecord } from "../plugins/manifest-registry.js";
+import { createEmptyPluginRegistry } from "../plugins/registry-empty.js";
+import { createPluginRecord } from "../plugins/status.test-helpers.js";
+import * as agentScope from "./agent-scope.js";
+import { resolveAgentRuntimePluginLoadPlan } from "./harness/runtime-plugin-load-plan.js";
+import { resolveModelCandidateChain } from "./model-fallback-candidates.js";
+import { getPreparedModelRuntimePluginGeneration } from "./prepared-model-runtime-generation-scope.js";
+import {
+  acquireAgentRunPreparedModelRuntime,
+  loadPublishedGatewayReplyDispatchRuntime,
+  refreshPreparedModelRuntimeSnapshots,
+} from "./prepared-model-runtime.js";
+
+const reply = vi.hoisted(() => ({ context: vi.fn(), execute: vi.fn() }));
+vi.mock("../auto-reply/reply/get-reply-run-context.js", () => ({
+  prepareReplyRunContext: reply.context,
+}));
+vi.mock("../auto-reply/reply/get-reply-run-admission.js", () => ({
+  prepareReplyRunAdmission: async (context: unknown) => context,
+}));
+vi.mock("../auto-reply/reply/get-reply-run-execute.js", () => ({
+  executePreparedReplyRun: reply.execute,
+}));
+
+const mocks = getPreparedModelRuntimeMocks();
+
+describe("prepared reply fallback ownership", () => {
+  beforeEach(async () => {
+    resetPreparedModelRuntimeHarness();
+    vi.clearAllMocks();
+    const actual = await vi.importActual<typeof import("./agent-scope.js")>("./agent-scope.js");
+    vi.spyOn(agentScope, "resolveAgentConfig").mockImplementation(actual.resolveAgentConfig);
+    vi.spyOn(agentScope, "resolveAgentModelFallbacksOverride").mockImplementation(
+      actual.resolveAgentModelFallbacksOverride,
+    );
+    vi.spyOn(agentScope, "resolveEffectiveModelFallbacks").mockImplementation(
+      actual.resolveEffectiveModelFallbacks,
+    );
+    vi.spyOn(agentScope, "resolveSubagentSpawnModelFallbacksOverride").mockImplementation(
+      actual.resolveSubagentSpawnModelFallbacksOverride,
+    );
+  });
+  afterEach(() => vi.restoreAllMocks());
+
+  it.each([
+    { scope: "agent", source: "auto", locked: false },
+    { scope: "subagent", source: "auto", locked: false },
+    { scope: "per-agent subagent", source: "auto", locked: false },
+    { scope: "fallback-only subagent", source: "auto", locked: false },
+    { scope: "subagent", source: "user", locked: false },
+    { scope: "subagent", source: "auto", locked: true },
+  ] as const)(
+    "admits $scope routes with source=$source, locked=$locked without widening execution policy",
+    async ({ scope, source, locked }) => {
+      const config: OpenClawConfig = {
+        agents: {
+          entries: {
+            default:
+              scope === "per-agent subagent" || scope === "fallback-only subagent"
+                ? {
+                    subagents: {
+                      model: {
+                        ...(scope === "per-agent subagent" ? { primary: "selected/model" } : {}),
+                        fallbacks: ["fallback/model"],
+                      },
+                    },
+                  }
+                : {},
+          },
+          defaults: {
+            model: {
+              primary: "initial/model",
+              fallbacks: scope === "agent" ? ["fallback/model"] : [],
+            },
+            subagents: {
+              model: {
+                primary: "selected/model",
+                fallbacks: scope === "per-agent subagent" ? [] : ["fallback/model"],
+              },
+            },
+          },
+        },
+        plugins: { allow: ["initial", "selected", "fallback"], slots: { memory: "none" } },
+      };
+      const manifests: PluginManifestRecord[] = ["initial", "selected", "fallback"].map((id) => ({
+        id,
+        name: id,
+        origin: "bundled",
+        channels: [],
+        providers: [id],
+        cliBackends: [],
+        skills: [],
+        hooks: [],
+        rootDir: `/plugins/${id}`,
+        source: `/plugins/${id}/index.js`,
+        manifestPath: `/plugins/${id}/openclaw.plugin.json`,
+        activation: { onStartup: false, onProviders: [id] },
+      }));
+      const metadata = createPluginMetadataSnapshot({
+        config,
+        manifestRegistry: { plugins: manifests, diagnostics: [] },
+      });
+      mocks.configuredAgentIds = ["default"];
+      mocks.loadAgentRuntimePluginRegistryHandle.mockImplementation((params) => {
+        const registry = createEmptyPluginRegistry();
+        const plan = resolveAgentRuntimePluginLoadPlan({
+          config,
+          workspaceDir: "/tmp/unused-workspace",
+          metadataSnapshot: metadata,
+          basePluginIds: params.reusableRegistry
+            ? listRuntimePluginIdsFromRegistry(params.reusableRegistry)
+            : [],
+          selections: params.selections ?? [],
+        });
+        registry.plugins.push(
+          ...(plan.pluginIds ?? []).map((id) => createPluginRecord({ id, origin: "bundled" })),
+        );
+        return registry;
+      });
+      await refreshPreparedModelRuntimeSnapshots(config, {
+        gatewayLifecycle: true,
+        catalogMode: "static",
+        allowGatewaySubagentBinding: true,
+        pluginMetadataSnapshot: metadata,
+      });
+      const dispatch = (await loadPublishedGatewayReplyDispatchRuntime({ agentId: "default" }))!;
+      const run = {
+        config,
+        agentId: "default",
+        agentDir: dispatch.agentDir,
+        workspaceDir: dispatch.workspaceDir,
+        provider: "selected",
+        model: "model",
+        sessionKey: scope === "agent" ? "agent:default:main" : "agent:default:subagent:test",
+        hasSessionModelOverride: true,
+        modelOverrideSource: source,
+        modelSelectionLocked: locked,
+        hasAutoFallbackProvenance: true,
+      } as FollowupRun["run"];
+      reply.context.mockResolvedValue({ kind: "run", workspaceDir: dispatch.workspaceDir });
+      reply.execute.mockImplementation(async () => {
+        const pluginGeneration = getPreparedModelRuntimePluginGeneration()!;
+        const candidates = resolveModelCandidateChain({
+          ...resolveModelFallbackOptions(run),
+          manifestPlugins: metadata.plugins,
+        });
+        expect(candidates.map((candidate) => candidate.provider)).toEqual(
+          source === "user" || locked ? ["selected"] : ["selected", "fallback"],
+        );
+        const nested = await acquireAgentRunPreparedModelRuntime(
+          {
+            config,
+            agentId: run.agentId,
+            agentDir: run.agentDir,
+            workspaceDir: run.workspaceDir,
+            allowGatewaySubagentBinding: true,
+            runtimePluginSelections: candidates.map((candidate) => ({
+              provider: candidate.provider,
+              modelId: candidate.model,
+            })),
+          },
+          { pluginGeneration },
+        );
+        nested.release();
+        return { text: "fallback admitted" };
+      });
+      const execute = bindPreparedReplyDispatchRuntime(dispatch, () =>
+        runPreparedReply({ provider: run.provider, model: run.model } as RunPreparedReplyParams),
+      );
+
+      await expect(execute()).resolves.toEqual({ text: "fallback admitted" });
+      expect(reply.execute).toHaveBeenCalledOnce();
+    },
+  );
+});

--- a/src/agents/prepared-model-runtime.startup-static.test.ts
+++ b/src/agents/prepared-model-runtime.startup-static.test.ts
@@ -168,31 +168,11 @@ vi.mock("./legacy-inherited-auth-dir.js", () => ({
   resolveLegacyInheritedAuthDir: () => "/tmp/prepared-static-agent",
 }));
 
-const agentScopeMocks = vi.hoisted(() => ({
-  listAgentEntries: (config: { agents?: { list?: unknown[] } }) => config.agents?.list ?? [],
+vi.mock("./agent-scope-config.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./agent-scope-config.js")>()),
   listAgentIds: () => ["default"],
   resolveAgentDir: () => "/tmp/prepared-static-agent",
   resolveAgentWorkspaceDir: () => "/tmp/prepared-static-workspace",
-  tryResolveConfiguredAgentWorkspaceDir: () => "/tmp/prepared-static-workspace",
-  tryResolveSystemAgentWorkspaceDir: () => "/tmp/prepared-static-workspace",
-  resolveDefaultAgentDir: () => "/tmp/prepared-static-agent",
-  resolveDefaultAgentId: () => "default",
-  tryResolveSoleAgentId: () => "default",
-  resolveAgentEffectiveModelPrimary: () => undefined,
-  resolveAgentModelFallbacksOverride: () => undefined,
-  resolveRunModelFallbacksOverride: () => undefined,
-  resolveSessionAgentIds: ({ agentId }: { agentId?: string }) => ({
-    defaultAgentId: "default",
-    sessionAgentId: agentId ?? "default",
-  }),
-}));
-
-vi.mock("./agent-scope.js", () => agentScopeMocks);
-vi.mock("./agent-scope-config.js", async (importOriginal) => ({
-  ...(await importOriginal<typeof import("./agent-scope-config.js")>()),
-  listAgentIds: agentScopeMocks.listAgentIds,
-  resolveAgentDir: agentScopeMocks.resolveAgentDir,
-  resolveAgentWorkspaceDir: agentScopeMocks.resolveAgentWorkspaceDir,
 }));
 
 vi.mock("./auth-profiles/runtime-snapshots.js", () => ({
@@ -449,7 +429,13 @@ describe("prepared model runtime Gateway catalog mode", () => {
       gatewayLifecycle: true,
       catalogMode: "static",
     });
-    await staleHookPending;
+    // Surface refresh failures before hook entry instead of waiting for the test timeout.
+    await Promise.race([
+      staleHookPending,
+      stale.then(() => {
+        throw new Error("static catalog refresh completed before its hook");
+      }),
+    ]);
     const latest = refreshPreparedModelRuntimeSnapshots(latestConfig, {
       gatewayLifecycle: true,
       catalogMode: "static",

--- a/src/agents/prepared-model-runtime.test-harness.ts
+++ b/src/agents/prepared-model-runtime.test-harness.ts
@@ -196,6 +196,8 @@ const agentScopeMocks = vi.hoisted(() => ({
     config.agents?.list?.find((entry) => entry.id === agentId),
   resolveAgentEffectiveModelPrimary: () => undefined,
   resolveAgentModelFallbacksOverride: () => undefined,
+  resolveEffectiveModelFallbacks: () => undefined,
+  resolveSubagentSpawnModelFallbacksOverride: () => undefined,
   resolveRunModelFallbacksOverride: () => undefined,
   resolveSessionAgentIds: ({ agentId }: { agentId?: string }) => ({
     defaultAgentId: "default",

--- a/src/agents/prepared-model-runtime.types.ts
+++ b/src/agents/prepared-model-runtime.types.ts
@@ -102,6 +102,7 @@ export type PreparedModelRuntimeInput = {
 
 export type PreparedModelRuntimeLease = Readonly<{
   snapshot: PreparedModelRuntimeSnapshot;
+  pluginGeneration: PreparedModelRuntimePluginGeneration;
   release: () => void;
 }>;
 

--- a/src/agents/runtime-plugins.test.ts
+++ b/src/agents/runtime-plugins.test.ts
@@ -48,6 +48,7 @@ vi.mock("./harness/runtime-plugin-load-plan.js", () => ({
   resolveAgentRuntimePluginSelections: hoisted.resolveAgentRuntimePluginSelections,
 }));
 
+import { createPluginMetadataSnapshot } from "../config/plugin-auto-enable.test-helpers.js";
 import { createEmptyPluginRegistry } from "../plugins/registry-empty.js";
 import {
   getPluginRuntimeGatewayRequestScope,
@@ -126,6 +127,35 @@ describe("agent runtime plugin registries", () => {
     expect(hoisted.loadPluginRegistryHandle).toHaveBeenCalledWith(
       expect.not.objectContaining({ onlyPluginIds: expect.anything() }),
     );
+  });
+
+  it.each([true, false])("reuses only an imported selected owner (imported=%s)", (imported) => {
+    const base = createEmptyPluginRegistry();
+    base.plugins.push(
+      createPluginRecord({ id: "memory-core" }),
+      createPluginRecord({ id: "codex", format: "openclaw", imported }),
+    );
+    const selected = loadAgentRuntimePluginRegistryHandle({
+      config: {},
+      metadataSnapshot: createPluginMetadataSnapshot({
+        manifestRegistry: { plugins: [], diagnostics: [] },
+        workspaceDir: "/tmp/gateway-workspace",
+      }),
+      basePluginIds: ["memory-core"],
+      reusableRegistry: base,
+      selections: [{ provider: "openai", modelId: "gpt-5.5", runtime: "codex" }],
+    });
+    expect(selected === base).toBe(imported);
+    expect(hoisted.loadPluginRegistryHandle).toHaveBeenCalledTimes(imported ? 0 : 1);
+    expect(hoisted.loadPluginMetadataSnapshot).not.toHaveBeenCalled();
+    if (!imported) {
+      expect(hoisted.loadPluginRegistryHandle).toHaveBeenCalledWith(
+        expect.objectContaining({
+          activate: false,
+          onlyPluginIds: ["codex", "memory-core"],
+        }),
+      );
+    }
   });
 
   it("bounds unscoped agent loads to active runtime plugins and selected owners", async () => {

--- a/src/agents/runtime-plugins.ts
+++ b/src/agents/runtime-plugins.ts
@@ -3,6 +3,7 @@ import { adoptRuntimeContextEngineRegistrations } from "../context-engine/regist
 import {
   listLoadedRuntimePluginIds,
   listRuntimePluginIdsFromRegistry,
+  registryContainsRuntimePluginIds,
 } from "../plugins/active-runtime-registry.js";
 import { normalizePluginsConfig } from "../plugins/config-state.js";
 import { extractPluginInstallRecordsFromInstalledPluginIndex } from "../plugins/installed-plugin-index-install-records.js";
@@ -30,6 +31,8 @@ type AgentRuntimePluginRegistryParams = {
   allowGatewaySubagentBinding?: boolean;
   /** Explicit base scope for hosts without a Gateway startup registry. */
   basePluginIds?: readonly string[];
+  /** Exact registry from the supplied lifecycle metadata generation. */
+  reusableRegistry?: PluginRegistry;
   selections?: readonly AgentHarnessPluginSelection[];
   /** Lifecycle-owned selection; standalone/direct generations stay source-default. */
   preferBuiltPluginArtifacts?: boolean;
@@ -114,6 +117,13 @@ export function loadAgentRuntimePluginRegistryHandle(
   params: AgentRuntimePluginRegistryParams,
 ): PluginRegistry {
   const load = resolveAgentRuntimePluginRegistryLoad(params);
+  if (
+    params.reusableRegistry &&
+    load.loadOptions.onlyPluginIds !== undefined &&
+    registryContainsRuntimePluginIds(params.reusableRegistry, load.loadOptions.onlyPluginIds)
+  ) {
+    return params.reusableRegistry;
+  }
   // Discovery-only load: full mode can replace process-global sandbox backends.
   // Adopt full-only runtime capabilities from the matching composition-root owners.
   const pluginRegistry = loadPluginRegistryHandle({ ...load.loadOptions, activate: false });

--- a/src/agents/tools/pdf-tool.runtime-abort.test.ts
+++ b/src/agents/tools/pdf-tool.runtime-abort.test.ts
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../config/config.js";
 import * as pdfExtractModule from "../../media/pdf-extract.js";
 import * as preparedModelRuntime from "../prepared-model-runtime.js";
+import { createEmptyPluginMetadataSnapshot } from "../test-helpers/embedded-agent-runner-e2e-mocks.js";
 import { createPdfToolInfraStub, withTempPdfAgentDir } from "./pdf-tool.test-support.js";
 
 const completeMock = vi.hoisted(() => vi.fn());
@@ -73,6 +74,11 @@ describe("PDF tool prepared-runtime cancellation", () => {
           // Cancellation releases this late lease before its stores can be used.
           createStores: () => ({ authStorage: {}, modelRegistry }),
         } as never,
+        pluginGeneration: {
+          configuredCatalogEntries: [],
+          inlineProviderModels: [],
+          pluginMetadataSnapshot: createEmptyPluginMetadataSnapshot(),
+        },
         release,
       });
       await vi.waitFor(() => expect(release).toHaveBeenCalledOnce());

--- a/src/agents/tools/pdf-tool.ts
+++ b/src/agents/tools/pdf-tool.ts
@@ -166,7 +166,10 @@ async function runPdfPrompt(params: {
 }> {
   const requestedCfg = applyImageModelConfigDefaults(params.cfg, params.pdfModelConfig);
 
-  let preparedRuntimeLease: Awaited<ReturnType<typeof acquireAgentRunPreparedModelRuntime>>;
+  let preparedRuntimeLease: Pick<
+    Awaited<ReturnType<typeof acquireAgentRunPreparedModelRuntime>>,
+    "snapshot" | "release"
+  >;
   if (params.preparedModelRuntime) {
     preparedRuntimeLease = { snapshot: params.preparedModelRuntime, release: () => {} };
   } else {

--- a/src/auto-reply/reply/get-reply-run.prepared-metadata.test.ts
+++ b/src/auto-reply/reply/get-reply-run.prepared-metadata.test.ts
@@ -49,21 +49,24 @@ describe("runPreparedReply prepared metadata", () => {
       inlineProviderModels: [],
       pluginMetadataSnapshot: metadataSnapshot,
       pluginRegistry,
-    } as never;
+    };
     const release = vi.fn();
+    const selectedGeneration = { ...pluginGeneration, pluginRegistry: { selected: true } };
     mocks.prepareContext.mockResolvedValue({
       kind: "run",
-      params: { cfg: config },
+      params: { cfg: config, provider: "selected", model: "model" },
+      thinkingRuntime: "selected-harness",
       workspaceDir,
     });
     mocks.acquireRuntime.mockImplementation(async (_input, options) => ({
       snapshot: {
         config,
         metadataSnapshot: options.pluginGeneration.pluginMetadataSnapshot,
-        pluginRegistry: options.pluginGeneration.pluginRegistry,
+        pluginRegistry: selectedGeneration.pluginRegistry,
         workspaceDir,
       },
       release,
+      pluginGeneration: selectedGeneration,
     }));
     let admissionSnapshot: unknown;
     let admissionRegistry: unknown;
@@ -92,7 +95,7 @@ describe("runPreparedReply prepared metadata", () => {
         config,
         pluginGeneration,
       } as never,
-      async () => await runPreparedReply({} as never),
+      async () => await runPreparedReply({ provider: "selected", model: "model" } as never),
     );
 
     await expect(run()).resolves.toEqual({ text: "ok" });
@@ -103,15 +106,18 @@ describe("runPreparedReply prepared metadata", () => {
         agentDir: "/tmp/openclaw-reply-agent",
         allowGatewaySubagentBinding: true,
         workspaceDir,
+        runtimePluginSelections: [
+          { provider: "selected", modelId: "model", runtime: "selected-harness" },
+        ],
       },
       { catalogMode: "static", pluginGeneration },
     );
     expect(admissionSnapshot).toBe(metadataSnapshot);
     expect(executionSnapshot).toBe(metadataSnapshot);
-    expect(admissionRegistry).toBe(pluginRegistry);
-    expect(executionRegistry).toBe(pluginRegistry);
-    expect(admissionPluginGeneration).toBe(pluginGeneration);
-    expect(executionPluginGeneration).toBe(pluginGeneration);
+    expect(admissionRegistry === selectedGeneration.pluginRegistry).toBe(true);
+    expect(executionRegistry === selectedGeneration.pluginRegistry).toBe(true);
+    expect(admissionPluginGeneration === selectedGeneration).toBe(true);
+    expect(executionPluginGeneration === selectedGeneration).toBe(true);
     expect(release).toHaveBeenCalledOnce();
     expect(getCurrentPluginMetadataSnapshot({ config, workspaceDir })).toBeUndefined();
     expect(getPluginRuntimeGenerationRegistry()).toBeUndefined();

--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -42,6 +42,13 @@ export async function runPreparedReply(
       agentDir: dispatchRuntime.agentDir,
       allowGatewaySubagentBinding: true,
       workspaceDir: context.workspaceDir,
+      runtimePluginSelections: [
+        {
+          provider: params.provider,
+          modelId: params.model,
+          runtime: context.thinkingRuntime,
+        },
+      ],
     },
     {
       catalogMode: "static",
@@ -52,7 +59,7 @@ export async function runPreparedReply(
   let leaseActive = true;
   try {
     return await withPreparedModelRuntimePluginGenerationScope(
-      dispatchRuntime.pluginGeneration,
+      lease.pluginGeneration,
       () =>
         withPluginRuntimeGenerationScope(lease.snapshot, () =>
           executePreparedReplyContext(context),

--- a/src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts
@@ -4224,7 +4224,7 @@ describe("dispatchCronDelivery — double-announce guard", () => {
           },
         ]);
         setActivePluginRegistry(registry);
-        harness.loadAgentRuntimePluginRegistryHandleMock.mockReturnValue(registry);
+        harness.preparedRunPluginRegistryMock.mockReturnValue(registry);
         harness.runEmbeddedAgentMock.mockResolvedValue({
           payloads: partialSend
             ? [{ text: "First payload." }, { text: "Second payload." }]

--- a/src/cron/isolated-agent/run-prepare.ts
+++ b/src/cron/isolated-agent/run-prepare.ts
@@ -2,7 +2,13 @@
 import { isDeepStrictEqual } from "node:util";
 import { tryResolveAmbientOwnerAgentId } from "../../agents/agent-scope.js";
 import { findModelInCatalog } from "../../agents/model-catalog-lookup.js";
-import { loadAgentRuntimePluginRegistryHandle } from "../../agents/runtime-plugins.js";
+import {
+  acquireAgentRunPreparedModelRuntime,
+  loadPublishedGatewayReplyDispatchRuntime,
+  PreparedModelRuntimeOwnerNotPublishedError,
+  type PreparedModelRuntimeLease,
+} from "../../agents/prepared-model-runtime.js";
+import { preparedModelRuntimeConfigsMatch } from "../../agents/prepared-model-runtime.owner.js";
 import { resolveAgentModelPrimaryValue } from "../../config/model-input.js";
 import type { SessionEntry } from "../../config/sessions.js";
 import { resolveSessionWorkStartError } from "../../config/sessions/lifecycle.js";
@@ -131,6 +137,7 @@ export type PreparedCronRunContext = {
    */
   runTimeoutOverrideMs?: number;
   pluginRegistry?: PluginRegistry;
+  preparedModelRuntimeLease: PreparedModelRuntimeLease;
 };
 
 type CronPreparationResult =
@@ -168,6 +175,19 @@ export async function prepareCronRunContext(params: {
       : {}),
   });
   const { agentId, agentDir } = modelOwner;
+  const publishedRuntime = await loadPublishedGatewayReplyDispatchRuntime({
+    agentId,
+    abortSignal: input.abortSignal ?? input.signal,
+  });
+  if (
+    publishedRuntime &&
+    (publishedRuntime.pluginGeneration.pluginMetadataSnapshot !== modelOwner.metadataSnapshot ||
+      !preparedModelRuntimeConfigsMatch(publishedRuntime.config, modelOwner.config))
+  ) {
+    throw new PreparedModelRuntimeOwnerNotPublishedError(
+      "cron model runtime generation was superseded during preparation",
+    );
+  }
   const agentConfigOverride = requiredAgentId
     ? resolveAgentConfig(modelOwner.config, agentId)
     : undefined;
@@ -280,6 +300,7 @@ export async function prepareCronRunContext(params: {
     },
   });
 
+  let preparedModelRuntimeLease: PreparedModelRuntimeLease | undefined;
   try {
     const persistCronSessionRow = async ({
       storePath,
@@ -591,24 +612,34 @@ export async function prepareCronRunContext(params: {
       authProfileId,
       authProfileIdSource: authSelection?.source,
     };
-    const pluginRegistry = loadAgentRuntimePluginRegistryHandle({
-      config: cfgWithAgentDefaults,
-      workspaceDir,
-      allowGatewaySubagentBinding: true,
-      // The published owner already selected this run's metadata generation.
-      // Reloading it here re-hashes every installed plugin on each hook/cron run.
-      ...(modelOwner.metadataSnapshot ? { metadataSnapshot: modelOwner.metadataSnapshot } : {}),
-      selections: runtimePluginCandidates.map((candidate) => {
-        const runtime = resolveSessionRuntimeOverrideForProvider({
-          provider: candidate.provider,
-          entry: cronSession.sessionEntry,
-          cfg: cfgWithAgentDefaults,
-        });
-        return runtime
-          ? { provider: candidate.provider, modelId: candidate.model, runtime, agentId }
-          : { provider: candidate.provider, modelId: candidate.model, agentId };
-      }),
-    });
+    preparedModelRuntimeLease = await acquireAgentRunPreparedModelRuntime(
+      {
+        // Embedded execution borrows this exact per-agent config projection.
+        // Keep the published generation pinned without dropping cron's defaults.
+        config: cfgWithAgentDefaults,
+        agentId,
+        agentDir,
+        workspaceDir,
+        allowGatewaySubagentBinding: true,
+        runtimePluginSelections: runtimePluginCandidates.map((candidate) => {
+          const runtime = resolveSessionRuntimeOverrideForProvider({
+            provider: candidate.provider,
+            entry: cronSession.sessionEntry,
+            cfg: cfgWithAgentDefaults,
+          });
+          return runtime
+            ? { provider: candidate.provider, modelId: candidate.model, runtime, agentId }
+            : { provider: candidate.provider, modelId: candidate.model, agentId };
+        }),
+      },
+      {
+        catalogMode: "static",
+        ...(publishedRuntime
+          ? { pluginGeneration: publishedRuntime.pluginGeneration }
+          : { pluginMetadataSnapshot: modelOwner.metadataSnapshot }),
+        abortSignal: input.abortSignal ?? input.signal,
+      },
+    );
     const runContinuationSession = usesExactRunSession
       ? createCronRunContinuationSession({
           cronSession,
@@ -672,10 +703,12 @@ export async function prepareCronRunContext(params: {
         timeoutMs,
         preflightDiagnostics,
         runTimeoutOverrideMs,
-        ...(pluginRegistry ? { pluginRegistry } : {}),
+        pluginRegistry: preparedModelRuntimeLease.snapshot.pluginRegistry,
+        preparedModelRuntimeLease,
       },
     };
   } catch (error) {
+    preparedModelRuntimeLease?.release();
     sessionWorkAdmission.release();
     throw error;
   }

--- a/src/cron/isolated-agent/run.plugin-generation.test.ts
+++ b/src/cron/isolated-agent/run.plugin-generation.test.ts
@@ -1,25 +1,30 @@
 // Proves isolated cron/hook runs carry the published Gateway plugin generation
 // into embedded execution instead of rebuilding metadata per run (#125596 family).
 import { describe, expect, it, vi } from "vitest";
-import { getPreparedModelRuntimePluginGeneration } from "../../agents/prepared-model-runtime-generation-scope.js";
+import { createDeferred } from "../../../test/helpers/promise.js";
+import {
+  getPreparedModelRuntimePluginGeneration,
+  getPreparedModelRuntimeBorrowedSnapshot,
+} from "../../agents/prepared-model-runtime-generation-scope.js";
+import type { PreparedModelRuntimePluginGeneration } from "../../agents/prepared-model-runtime.types.js";
+import { createPluginMetadataSnapshot } from "../../config/plugin-auto-enable.test-helpers.js";
+import { createEmptyPluginRegistry } from "../../plugins/registry-empty.js";
 import { makeIsolatedAgentParamsFixture } from "./job-fixtures.js";
 import { setupRunCronIsolatedAgentTurnSuite } from "./run.suite-helpers.js";
 import {
   loadRunCronIsolatedAgentTurn,
   mockRunCronFallbackPassthrough,
   runEmbeddedAgentMock,
+  acquirePreparedModelRuntimeMock,
+  loadPublishedReplyDispatchRuntimeMock,
+  loadModelCatalogOwnerMock,
+  resolveAgentConfigMock,
 } from "./run.test-harness.js";
 
-const preparedRuntimeMocks = vi.hoisted(() => ({
-  acquireRuntime: vi.fn(),
-  loadDispatchRuntime: vi.fn(),
-}));
-
-vi.mock("../../agents/prepared-model-runtime.js", async (importOriginal) => ({
-  ...(await importOriginal<typeof import("../../agents/prepared-model-runtime.js")>()),
-  acquireAgentRunPreparedModelRuntime: preparedRuntimeMocks.acquireRuntime,
-  loadPublishedGatewayReplyDispatchRuntime: preparedRuntimeMocks.loadDispatchRuntime,
-}));
+const preparedRuntimeMocks = {
+  acquireRuntime: acquirePreparedModelRuntimeMock,
+  loadDispatchRuntime: loadPublishedReplyDispatchRuntimeMock,
+};
 
 const { PreparedModelRuntimeOwnerNotPublishedError } = await vi.importActual<
   typeof import("../../agents/prepared-model-runtime.errors.js")
@@ -31,13 +36,30 @@ describe("runCronIsolatedAgentTurn plugin generation carry", () => {
   setupRunCronIsolatedAgentTurnSuite();
 
   it("admits the published generation and keeps it active through embedded execution", async () => {
-    const metadataSnapshot = { plugins: [], index: { plugins: [] } };
+    const config = {
+      agents: { entries: { default: { thinkingDefault: "high" as const } } },
+    };
+    const metadataSnapshot = createPluginMetadataSnapshot({
+      config,
+      manifestRegistry: { plugins: [], diagnostics: [] },
+    });
     const pluginGeneration = {
       configuredCatalogEntries: [],
       inlineProviderModels: [],
       pluginMetadataSnapshot: metadataSnapshot,
-    } as never;
-    const config = {};
+    } satisfies PreparedModelRuntimePluginGeneration;
+    const { resolveAgentConfig } = await vi.importActual<
+      typeof import("../../agents/agent-scope-config.js")
+    >("../../agents/agent-scope-config.js");
+    resolveAgentConfigMock.mockImplementation(resolveAgentConfig);
+    loadModelCatalogOwnerMock.mockResolvedValue({
+      agentId: "default",
+      agentDir: "/tmp/dispatch-agent-dir",
+      workspaceDir: "/tmp/workspace",
+      config,
+      metadataSnapshot,
+      modelCatalog: { entries: [], routeVariants: [] },
+    });
     preparedRuntimeMocks.loadDispatchRuntime.mockResolvedValue({
       agentId: "default",
       agentDir: "/tmp/dispatch-agent-dir",
@@ -46,40 +68,64 @@ describe("runCronIsolatedAgentTurn plugin generation carry", () => {
       pluginGeneration,
     });
     const release = vi.fn();
+    const selectedGeneration = {
+      ...pluginGeneration,
+      pluginRegistry: createEmptyPluginRegistry(),
+    };
     preparedRuntimeMocks.acquireRuntime.mockResolvedValue({
-      snapshot: { config, metadataSnapshot },
+      snapshot: { config, metadataSnapshot, pluginRegistry: selectedGeneration.pluginRegistry },
+      pluginGeneration: selectedGeneration,
       release,
     });
     mockRunCronFallbackPassthrough();
+    const afterRun = createDeferred();
+    let borrowedAfterClose: Promise<unknown> | undefined;
     let embeddedRunGeneration: unknown = "not-captured";
-    runEmbeddedAgentMock.mockImplementation(async () => {
+    runEmbeddedAgentMock.mockImplementation(async (params) => {
+      expect(params.config).toEqual(preparedRuntimeMocks.acquireRuntime.mock.calls[0]?.[0].config);
       embeddedRunGeneration = getPreparedModelRuntimePluginGeneration();
+      borrowedAfterClose = afterRun.promise.then(() =>
+        getPreparedModelRuntimeBorrowedSnapshot(selectedGeneration),
+      );
       return { payloads: [{ text: "test output" }], meta: { agentMeta: {} } };
     });
 
-    await expect(runCronIsolatedAgentTurn(makeIsolatedAgentParamsFixture())).resolves.toMatchObject(
-      { status: "ok" },
+    const result = await runCronIsolatedAgentTurn(
+      makeIsolatedAgentParamsFixture({ cfg: config, agentId: "default" }),
     );
+    expect(result.error).toBeUndefined();
+    expect(result.status).toBe("ok");
     const dispatchAdmission = preparedRuntimeMocks.loadDispatchRuntime.mock.calls[0]?.[0] as {
       abortSignal: AbortSignal;
     };
     expect(dispatchAdmission).toMatchObject({ agentId: "default", abortSignal: expect.anything() });
     expect(preparedRuntimeMocks.acquireRuntime).toHaveBeenCalledWith(
       {
-        config,
+        config: {
+          agents: {
+            entries: config.agents.entries,
+            defaults: { thinkingDefault: "high" },
+          },
+        },
         agentId: "default",
         agentDir: "/tmp/dispatch-agent-dir",
         allowGatewaySubagentBinding: true,
         workspaceDir: "/tmp/workspace",
+        runtimePluginSelections: [
+          { provider: "openai", modelId: "gpt-5.4", agentId: "default" },
+          { provider: "openai", modelId: "gpt-5.6-sol", agentId: "default" },
+        ],
       },
       { catalogMode: "static", pluginGeneration, abortSignal: dispatchAdmission.abortSignal },
     );
-    expect(embeddedRunGeneration).toBe(pluginGeneration);
+    expect(embeddedRunGeneration === selectedGeneration).toBe(true);
     expect(release).toHaveBeenCalledOnce();
+    afterRun.resolve();
+    await expect(borrowedAfterClose).resolves.toBeUndefined();
     expect(getPreparedModelRuntimePluginGeneration()).toBeUndefined();
   });
 
-  it("runs without a generation when no Gateway publication exists", async () => {
+  it("prepares a standalone generation when no Gateway publication exists", async () => {
     preparedRuntimeMocks.loadDispatchRuntime.mockResolvedValue(undefined);
     mockRunCronFallbackPassthrough();
     let embeddedRunGeneration: unknown = "not-captured";
@@ -91,18 +137,43 @@ describe("runCronIsolatedAgentTurn plugin generation carry", () => {
     await expect(runCronIsolatedAgentTurn(makeIsolatedAgentParamsFixture())).resolves.toMatchObject(
       { status: "ok" },
     );
-    expect(preparedRuntimeMocks.acquireRuntime).not.toHaveBeenCalled();
-    expect(embeddedRunGeneration).toBeUndefined();
+    expect(preparedRuntimeMocks.acquireRuntime).toHaveBeenCalledOnce();
+    expect(embeddedRunGeneration).toBeDefined();
   });
 
-  it("falls back to generation-free execution when the owner is not published", async () => {
+  it("rejects preparation when the published owner is unavailable", async () => {
     preparedRuntimeMocks.loadDispatchRuntime.mockRejectedValue(
       new PreparedModelRuntimeOwnerNotPublishedError("owner not published"),
     );
 
-    await expect(runCronIsolatedAgentTurn(makeIsolatedAgentParamsFixture())).resolves.toMatchObject(
-      { status: "ok" },
+    await expect(runCronIsolatedAgentTurn(makeIsolatedAgentParamsFixture())).rejects.toThrow(
+      "owner not published",
     );
     expect(preparedRuntimeMocks.acquireRuntime).not.toHaveBeenCalled();
+  });
+
+  it("releases the prepared lease when continuation initialization fails", async () => {
+    const state = await import("./run-session-state.js");
+    const initialize = vi.spyOn(state, "createCronRunContinuationSession").mockReturnValue({
+      initialize: async () => {
+        throw new Error("continuation fixture failed");
+      },
+      sync: async () => {},
+      setCliExecutionProvider: async () => {},
+      seal: async () => {},
+    });
+    const release = vi.fn();
+    preparedRuntimeMocks.acquireRuntime.mockResolvedValue({
+      snapshot: { pluginRegistry: createEmptyPluginRegistry() },
+      release,
+    });
+    try {
+      await expect(runCronIsolatedAgentTurn(makeIsolatedAgentParamsFixture())).rejects.toThrow(
+        "continuation fixture failed",
+      );
+      expect(release).toHaveBeenCalledOnce();
+    } finally {
+      initialize.mockRestore();
+    }
   });
 });

--- a/src/cron/isolated-agent/run.runtime-plugins.test.ts
+++ b/src/cron/isolated-agent/run.runtime-plugins.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from "vitest";
 import { makeIsolatedAgentParamsFixture } from "./job-fixtures.js";
 import { setupRunCronIsolatedAgentTurnSuite } from "./run.suite-helpers.js";
 import {
-  loadAgentRuntimePluginRegistryHandleMock,
+  acquirePreparedModelRuntimeMock,
   loadModelCatalogOwnerMock,
   loadRunCronIsolatedAgentTurn,
 } from "./run.test-harness.js";
@@ -30,23 +30,32 @@ describe("runCronIsolatedAgentTurn runtime plugin owner", () => {
       readOnly: true,
       allowGatewaySubagentBinding: true,
     });
-    expect(loadAgentRuntimePluginRegistryHandleMock).toHaveBeenCalledWith({
-      config: { agents: { defaults: {} } },
-      workspaceDir: "/tmp/workspace",
-      allowGatewaySubagentBinding: true,
-      selections: [
-        {
-          provider: "openai",
-          modelId: "gpt-5.4",
-          agentId: "default",
-        },
-        {
-          provider: "anthropic",
-          modelId: "claude-sonnet-4-6",
-          agentId: "default",
-        },
-      ],
-    });
+    expect(acquirePreparedModelRuntimeMock).toHaveBeenCalledWith(
+      {
+        config: { agents: { defaults: {} } },
+        agentId: "default",
+        agentDir: "/tmp/agent-dir",
+        workspaceDir: "/tmp/workspace",
+        allowGatewaySubagentBinding: true,
+        runtimePluginSelections: [
+          {
+            provider: "openai",
+            modelId: "gpt-5.4",
+            agentId: "default",
+          },
+          {
+            provider: "anthropic",
+            modelId: "claude-sonnet-4-6",
+            agentId: "default",
+          },
+        ],
+      },
+      {
+        catalogMode: "static",
+        pluginMetadataSnapshot: undefined,
+        abortSignal: expect.any(AbortSignal),
+      },
+    );
   });
 
   it("reuses the published owner metadata snapshot for the run registry load", async () => {
@@ -65,9 +74,9 @@ describe("runCronIsolatedAgentTurn runtime plugin owner", () => {
     await expect(runCronIsolatedAgentTurn(makeIsolatedAgentParamsFixture())).resolves.toMatchObject(
       { status: "ok" },
     );
-    expect(loadAgentRuntimePluginRegistryHandleMock).toHaveBeenCalledOnce();
+    expect(acquirePreparedModelRuntimeMock).toHaveBeenCalledOnce();
     // Exact snapshot identity: a rebuilt copy would still re-hash every installed plugin.
-    expect(loadAgentRuntimePluginRegistryHandleMock.mock.calls[0]?.[0].metadataSnapshot).toBe(
+    expect(acquirePreparedModelRuntimeMock.mock.calls[0]?.[1].pluginMetadataSnapshot).toBe(
       metadataSnapshot,
     );
   });

--- a/src/cron/isolated-agent/run.test-harness.ts
+++ b/src/cron/isolated-agent/run.test-harness.ts
@@ -125,11 +125,15 @@ const resolveHookExternalContentSourceMock = createMock();
 const getSkillsSnapshotVersionMock = createMock();
 export const loadModelCatalogMock = createMock();
 export const loadModelCatalogOwnerMock = createMock();
-export const loadAgentRuntimePluginRegistryHandleMock = createMock();
+export const preparedRunPluginRegistryMock = createMock();
+export const acquirePreparedModelRuntimeMock = createMock();
+export const loadPublishedReplyDispatchRuntimeMock = createMock();
 const getRemoteSkillEligibilityMock = createMock();
 
-vi.mock("../../agents/runtime-plugins.js", () => ({
-  loadAgentRuntimePluginRegistryHandle: loadAgentRuntimePluginRegistryHandleMock,
+vi.mock("../../agents/prepared-model-runtime.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../agents/prepared-model-runtime.js")>()),
+  acquireAgentRunPreparedModelRuntime: acquirePreparedModelRuntimeMock,
+  loadPublishedGatewayReplyDispatchRuntime: loadPublishedReplyDispatchRuntimeMock,
 }));
 
 vi.mock("./run.runtime.js", async () => ({
@@ -579,7 +583,22 @@ function resetRunConfigMocks(): void {
   resolveHookExternalContentSourceMock.mockReturnValue(undefined);
   getSkillsSnapshotVersionMock.mockReturnValue(42);
   loadModelCatalogMock.mockResolvedValue([]);
-  loadAgentRuntimePluginRegistryHandleMock.mockReturnValue(createEmptyPluginRegistry());
+  preparedRunPluginRegistryMock.mockReturnValue(createEmptyPluginRegistry());
+  loadPublishedReplyDispatchRuntimeMock.mockResolvedValue(undefined);
+  acquirePreparedModelRuntimeMock.mockImplementation(async (input, options) => {
+    const registry = preparedRunPluginRegistryMock();
+    const metadata = options?.pluginGeneration?.pluginMetadataSnapshot ??
+      options?.pluginMetadataSnapshot ?? { plugins: [], index: { plugins: [] } };
+    return {
+      snapshot: { ...input, metadataSnapshot: metadata, pluginRegistry: registry },
+      pluginGeneration: {
+        ...options?.pluginGeneration,
+        pluginMetadataSnapshot: metadata,
+        pluginRegistry: registry,
+      },
+      release: vi.fn(),
+    };
+  });
   loadModelCatalogOwnerMock.mockImplementation(
     async (params: {
       agentId?: string;

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -1,14 +1,6 @@
 import { retireSessionMcpRuntime } from "../../agents/agent-bundle-mcp-tools.js";
 import { withPreparedModelRuntimePluginGenerationScope } from "../../agents/prepared-model-runtime-generation-scope.js";
-import {
-  PreparedModelRuntimeOwnerNotPublishedError,
-  acquireAgentRunPreparedModelRuntime,
-  loadPublishedGatewayReplyDispatchRuntime,
-} from "../../agents/prepared-model-runtime.js";
-import type {
-  PreparedModelRuntimePluginGeneration,
-  PreparedModelRuntimeSnapshot,
-} from "../../agents/prepared-model-runtime.types.js";
+import type { PreparedModelRuntimeLease } from "../../agents/prepared-model-runtime.types.js";
 import { createAgentRunRestartAbortError } from "../../agents/run-termination.js";
 import { cleanupBrowserSessionsForLifecycleEnd } from "../../browser-lifecycle-cleanup.js";
 import type { CliDeps } from "../../cli/outbound-send-deps.js";
@@ -27,7 +19,7 @@ import {
 import { isDiagnosticsEnabled } from "../../infra/diagnostic-events.js";
 import { isFastTestRuntimeEnv } from "../../infra/env.js";
 import { createDiagnosticMessageLifecycle } from "../../logging/message-lifecycle.js";
-import { withPluginRuntimeRegistryScope } from "../../plugins/runtime/gateway-request-scope.js";
+import { withPluginRuntimeGenerationScope } from "../../plugins/runtime/generation-scope.js";
 import { isCommandLaneTaskTimeoutError } from "../../process/command-queue.js";
 import { CommandLane } from "../../process/lanes.js";
 import { createLazyImportLoader } from "../../shared/lazy-promise.js";
@@ -50,66 +42,6 @@ import type { RunCronAgentTurnResult } from "./run.types.js";
 import { cleanupCronRunSessionAfterRun } from "./session-cleanup.js";
 
 const cronExecutorRuntimeLoader = createLazyImportLoader(() => import("./run-executor.runtime.js"));
-
-type CronRunPluginGenerationLease = {
-  pluginGeneration: PreparedModelRuntimePluginGeneration;
-  borrowSnapshot: () => PreparedModelRuntimeSnapshot | undefined;
-  release: () => void;
-};
-
-/**
- * Gateway-hosted isolated runs reuse the published plugin generation instead of
- * rebuilding metadata snapshots per run (#125596 carried this for the channel
- * path; hook/cron turns share the invariant). Standalone hosts (no Gateway
- * lifecycle) and startup/replacement races return undefined so the embedded
- * orchestrator admits on whatever generation is current at execution time.
- */
-async function acquireCronRunPluginGeneration(context: {
-  agentId: string;
-  workspaceDir: string;
-  abortSignal?: AbortSignal;
-}): Promise<CronRunPluginGenerationLease | undefined> {
-  try {
-    const dispatchRuntime = await loadPublishedGatewayReplyDispatchRuntime({
-      agentId: context.agentId,
-      abortSignal: context.abortSignal,
-    });
-    if (!dispatchRuntime) {
-      return undefined;
-    }
-    // Holding this static lease across the run anchors the admitted generation:
-    // a config/plugin reload mid-run lets nested embedded admissions borrow the
-    // leased snapshot instead of failing on the superseded configured owner.
-    const lease = await acquireAgentRunPreparedModelRuntime(
-      {
-        config: dispatchRuntime.config,
-        agentId: dispatchRuntime.agentId,
-        agentDir: dispatchRuntime.agentDir,
-        allowGatewaySubagentBinding: true,
-        workspaceDir: context.workspaceDir,
-      },
-      {
-        catalogMode: "static",
-        pluginGeneration: dispatchRuntime.pluginGeneration,
-        abortSignal: context.abortSignal,
-      },
-    );
-    let leaseActive = true;
-    return {
-      pluginGeneration: dispatchRuntime.pluginGeneration,
-      borrowSnapshot: () => (leaseActive ? lease.snapshot : undefined),
-      release: () => {
-        leaseActive = false;
-        lease.release();
-      },
-    };
-  } catch (error) {
-    if (error instanceof PreparedModelRuntimeOwnerNotPublishedError) {
-      return undefined;
-    }
-    throw error;
-  }
-}
 
 function isCronNestedLaneTaskTimeoutError(err: unknown): boolean {
   return isCommandLaneTaskTimeoutError(err, CommandLane.CronNested);
@@ -193,6 +125,12 @@ export async function runCronIsolatedAgentTurn(params: {
   if (!prepared.ok) {
     return { ...prepared.result, admissionDisposition: "rejected" };
   }
+  let preparedRuntimeLease: PreparedModelRuntimeLease | undefined =
+    prepared.context.preparedModelRuntimeLease;
+  const releasePreparedRuntime = () => {
+    preparedRuntimeLease?.release();
+    preparedRuntimeLease = undefined;
+  };
   // Capture the stable run id before execution can rotate its persisted session.
   const initialSessionId = prepared.context.cronSession.sessionEntry.sessionId;
   const ownsRunContext = params.job.sessionTarget === "isolated";
@@ -250,6 +188,7 @@ export async function runCronIsolatedAgentTurn(params: {
       lifecycle.markProcessing();
       return lifecycle;
     } catch (error) {
+      releasePreparedRuntime();
       prepared.context.sessionWorkAdmission.release();
       throw error;
     }
@@ -332,26 +271,21 @@ export async function runCronIsolatedAgentTurn(params: {
     const runExecutionWithAdmission = () =>
       prepared.context.sessionWorkAdmission.run(() =>
         withAgentRunLifecycleGeneration(runLifecycleGeneration, () =>
-          withPluginRuntimeRegistryScope(prepared.context.pluginRegistry, () =>
-            executeCronRun(executionParams),
+          withPluginRuntimeGenerationScope(
+            prepared.context.preparedModelRuntimeLease.snapshot,
+            () => executeCronRun(executionParams),
           ),
         ),
       );
-    const pluginGenerationLease = await acquireCronRunPluginGeneration({
-      ...prepared.context,
-      abortSignal,
-    });
     let execution: Awaited<ReturnType<typeof runExecutionWithAdmission>>;
     try {
-      execution = pluginGenerationLease
-        ? await withPreparedModelRuntimePluginGenerationScope(
-            pluginGenerationLease.pluginGeneration,
-            runExecutionWithAdmission,
-            pluginGenerationLease.borrowSnapshot,
-          )
-        : await runExecutionWithAdmission();
+      execution = await withPreparedModelRuntimePluginGenerationScope(
+        prepared.context.preparedModelRuntimeLease.pluginGeneration,
+        runExecutionWithAdmission,
+        () => preparedRuntimeLease?.snapshot,
+      );
     } finally {
-      pluginGenerationLease?.release();
+      releasePreparedRuntime();
     }
     const finalized = await finalizeCronRun({
       prepared: prepared.context,
@@ -406,6 +340,7 @@ export async function runCronIsolatedAgentTurn(params: {
       ),
     });
   } finally {
+    releasePreparedRuntime();
     try {
       await prepared.context.runContinuationSession?.seal();
     } catch (sealError) {

--- a/src/gateway/agent-turn/agent-run-admission-phase.ts
+++ b/src/gateway/agent-turn/agent-run-admission-phase.ts
@@ -395,6 +395,13 @@ export async function prepareAgentRunDispatch(params: {
         agentDir: replyDispatchRuntime.agentDir,
         allowGatewaySubagentBinding: true,
         workspaceDir: workspaceOverride ?? replyDispatchRuntime.workspaceDir,
+        runtimePluginSelections: [
+          {
+            provider: resolvedRuntime.provider,
+            modelId: resolvedRuntime.model,
+            runtime: resolvedRuntime.harness,
+          },
+        ],
       },
       {
         catalogMode: "static",
@@ -405,6 +412,10 @@ export async function prepareAgentRunDispatch(params: {
     if (!revalidateAdmission()) {
       return undefined;
     }
+    replyDispatchRuntime = Object.freeze({
+      ...replyDispatchRuntime,
+      pluginGeneration: preparedModelRuntimeLease.pluginGeneration,
+    });
   } catch (err) {
     if (!revalidateAdmission()) {
       return undefined;

--- a/src/gateway/agent-turn/agent-turn-service.ts
+++ b/src/gateway/agent-turn/agent-turn-service.ts
@@ -17,7 +17,6 @@ import { createCronContinuationController } from "../server-methods/agent-cron-c
 import { runAgentResetPhase } from "../server-methods/agent-reset-phase.js";
 import { buildAgentSessionPatch } from "../server-methods/agent-session-patch.js";
 import { prepareAgentSession } from "../server-methods/agent-session-prepare.js";
-import { handleChatAbortRequest } from "../server-methods/chat-abort-handler.js";
 import { resolveAgentRunSessionCreation } from "../server-methods/session-creation-provenance.js";
 import type { GatewayRequestHandlerOptions, RespondFn } from "../server-methods/shared-types.js";
 import { authorizeResolvedSessionMutation } from "../session-sharing.js";
@@ -710,9 +709,5 @@ export function createAgentTurnService(
     };
   };
 
-  const abortTurn = async (options: GatewayRequestHandlerOptions): Promise<void> => {
-    await handleChatAbortRequest({ ...options, context, isWebchatConnect });
-  };
-
-  return { startTurn, waitForTurn, abortTurn };
+  return { startTurn, waitForTurn };
 }

--- a/src/gateway/local-request-context.test.ts
+++ b/src/gateway/local-request-context.test.ts
@@ -71,7 +71,6 @@ describe("local gateway request context", () => {
         createAgentTurnService.mockReturnValue({
           startTurn: async ({ io }) => io.emitAcceptance([true, payload, undefined]),
           waitForTurn: vi.fn(),
-          abortTurn: vi.fn(),
         });
 
         await expect(

--- a/src/gateway/methods/core-descriptors.ts
+++ b/src/gateway/methods/core-descriptors.ts
@@ -383,7 +383,7 @@ const CORE_GATEWAY_METHOD_SPECS = [
   ["chat.startup", "chat", "operator.read", "<=2026.7", { startup: true }],
   ["chat.metadata", "chat", "operator.read", "<=2026.7", { startup: true }],
   ["chat.message.get", "chat", "operator.read", "<=2026.7", { startup: true }],
-  ["chat.abort", "chat", "operator.write", "<=2026.7"],
+  ["chat.abort", "chat-abort", "operator.write", "<=2026.7"],
   ["chat.send", "chat", "operator.write", "<=2026.7", { startup: true }],
   // Operator terminal: admin-only PTY surface. Appended to the advertised block
   // so existing advertised method indices stay stable for older clients.

--- a/src/gateway/server-methods.ts
+++ b/src/gateway/server-methods.ts
@@ -89,6 +89,11 @@ const CORE_GATEWAY_HANDLER_MODULES = {
   "channel-pairing": () =>
     import("./server-methods/channel-pairing.js").then((module) => module.channelPairingHandlers),
   chat: () => import("./server-methods/chat.js").then((module) => module.chatHandlers),
+  // Cancellation must not wait for unrelated chat history and send workflows to load.
+  "chat-abort": () =>
+    import("./server-methods/chat-abort-handler.js").then((module) => ({
+      "chat.abort": module.handleChatAbortRequest,
+    })),
   commands: () => import("./server-methods/commands.js").then((module) => module.commandsHandlers),
   config: () => import("./server-methods/config.js").then((module) => module.configHandlers),
   conversations: () =>

--- a/src/gateway/server-methods.ts
+++ b/src/gateway/server-methods.ts
@@ -260,10 +260,7 @@ function authorizeGatewayMethod(
 ) {
   // Pre-connect and health requests are allowed through; role/scope checks require the
   // authenticated connect metadata established by the gateway handshake.
-  if (!client?.connect) {
-    return null;
-  }
-  if (method === "health") {
+  if (!client?.connect || method === "health") {
     return null;
   }
   const roleRaw = client.connect.role ?? "operator";

--- a/src/gateway/server-methods/agent.abort-integration.test-utils.ts
+++ b/src/gateway/server-methods/agent.abort-integration.test-utils.ts
@@ -32,6 +32,7 @@ import {
   describe1AfterEach1,
   prime,
 } from "./agent.test-harness.js";
+import { handleChatAbortRequest } from "./chat-abort-handler.js";
 import { chatHandlers } from "./chat.js";
 import type { GatewayRequestContext } from "./types.js";
 
@@ -216,10 +217,7 @@ describe("gateway agent handler chat.abort integration", () => {
     expect(context.chatAbortControllers.has(runId)).toBe(true);
 
     const abortRespond = vi.fn();
-    await expectDefined(
-      chatHandlers["chat.abort"],
-      'chatHandlers["chat.abort"] test invariant',
-    )({
+    await handleChatAbortRequest({
       params: { sessionKey: "agent:main:main", runId },
       respond: abortRespond as never,
       context,
@@ -364,10 +362,7 @@ describe("gateway agent handler chat.abort integration", () => {
     });
 
     const abortRespond = vi.fn();
-    await expectDefined(
-      chatHandlers["chat.abort"],
-      'chatHandlers["chat.abort"] test invariant',
-    )({
+    await handleChatAbortRequest({
       params: { sessionKey: requestedSessionKey, runId },
       respond: abortRespond as never,
       context,
@@ -461,10 +456,7 @@ describe("gateway agent handler chat.abort integration", () => {
     });
 
     const abortRespond = vi.fn();
-    await expectDefined(
-      chatHandlers["chat.abort"],
-      'chatHandlers["chat.abort"] test invariant',
-    )({
+    await handleChatAbortRequest({
       params: { sessionKey: "global", agentId: "work", runId },
       respond: abortRespond as never,
       context,
@@ -620,10 +612,7 @@ describe("gateway agent handler chat.abort integration", () => {
     expect(context.chatAbortControllers.has(runId)).toBe(false);
 
     const abortRespond = vi.fn();
-    await expectDefined(
-      chatHandlers["chat.abort"],
-      'chatHandlers["chat.abort"] test invariant',
-    )({
+    await handleChatAbortRequest({
       params: { sessionKey: "agent:main:main" },
       respond: abortRespond as never,
       context,
@@ -719,10 +708,7 @@ describe("gateway agent handler chat.abort integration", () => {
     expect(context.chatAbortControllers.has(runId)).toBe(false);
 
     const abortRespond = vi.fn();
-    await expectDefined(
-      chatHandlers["chat.abort"],
-      'chatHandlers["chat.abort"] test invariant',
-    )({
+    await handleChatAbortRequest({
       params: { sessionKey: "agent:main:main", runId },
       respond: abortRespond as never,
       context,
@@ -971,10 +957,7 @@ describe("gateway agent handler chat.abort integration", () => {
     expect(context.chatAbortControllers.has(runId)).toBe(false);
 
     const abortRespond = vi.fn();
-    await expectDefined(
-      chatHandlers["chat.abort"],
-      'chatHandlers["chat.abort"] test invariant',
-    )({
+    await handleChatAbortRequest({
       params: { sessionKey: "global", agentId: "work", runId },
       respond: abortRespond as never,
       context,
@@ -1062,10 +1045,7 @@ describe("gateway agent handler chat.abort integration", () => {
     expect(context.chatAbortControllers.has(runId)).toBe(false);
 
     const abortRespond = vi.fn();
-    await expectDefined(
-      chatHandlers["chat.abort"],
-      'chatHandlers["chat.abort"] test invariant',
-    )({
+    await handleChatAbortRequest({
       params: { sessionKey: "agent:main:main", runId },
       respond: abortRespond as never,
       context,
@@ -1464,10 +1444,7 @@ describe("gateway agent handler chat.abort integration", () => {
     expect(context.chatAbortControllers.has(runId)).toBe(false);
 
     const abortRespond = vi.fn();
-    await expectDefined(
-      chatHandlers["chat.abort"],
-      'chatHandlers["chat.abort"] test invariant',
-    )({
+    await handleChatAbortRequest({
       params: { sessionKey: "agent:main:main", runId },
       respond: abortRespond as never,
       context,
@@ -1564,10 +1541,7 @@ describe("gateway agent handler chat.abort integration", () => {
     });
 
     const abortRespond = vi.fn();
-    await expectDefined(
-      chatHandlers["chat.abort"],
-      'chatHandlers["chat.abort"] test invariant',
-    )({
+    await handleChatAbortRequest({
       params: { sessionKey: "agent:main:telegram:direct:123", runId },
       respond: abortRespond as never,
       context,
@@ -1924,10 +1898,7 @@ describe("gateway agent handler chat.abort integration", () => {
     expect(capturedSignal?.aborted).toBe(false);
 
     const abortRespond = vi.fn();
-    await expectDefined(
-      chatHandlers["chat.abort"],
-      'chatHandlers["chat.abort"] test invariant',
-    )({
+    await handleChatAbortRequest({
       params: { sessionKey: "agent:main:main", runId },
       respond: abortRespond as never,
       context,
@@ -1991,10 +1962,7 @@ describe("gateway agent handler chat.abort integration", () => {
     }
 
     const abortRespond = vi.fn();
-    await expectDefined(
-      chatHandlers["chat.abort"],
-      'chatHandlers["chat.abort"] test invariant',
-    )({
+    await handleChatAbortRequest({
       params: { sessionKey: "agent:main:main", runId },
       respond: abortRespond as never,
       context,
@@ -2046,10 +2014,7 @@ describe("gateway agent handler chat.abort integration", () => {
     });
 
     const abortRespond = vi.fn();
-    await expectDefined(
-      chatHandlers["chat.abort"],
-      'chatHandlers["chat.abort"] test invariant',
-    )({
+    await handleChatAbortRequest({
       params: { sessionKey: "agent:main:main", runId },
       respond: abortRespond as never,
       context,
@@ -2093,10 +2058,7 @@ describe("gateway agent handler chat.abort integration", () => {
     );
 
     const abortRespond = vi.fn();
-    await expectDefined(
-      chatHandlers["chat.abort"],
-      'chatHandlers["chat.abort"] test invariant',
-    )({
+    await handleChatAbortRequest({
       params: { sessionKey: "agent:main:main", runId },
       respond: abortRespond as never,
       context,
@@ -2154,10 +2116,7 @@ describe("gateway agent handler chat.abort integration", () => {
     );
 
     const abortRespond = vi.fn();
-    await expectDefined(
-      chatHandlers["chat.abort"],
-      'chatHandlers["chat.abort"] test invariant',
-    )({
+    await handleChatAbortRequest({
       params: { sessionKey: "agent:main:main" },
       respond: abortRespond as never,
       context,

--- a/src/gateway/server-methods/agent.base.test-utils.ts
+++ b/src/gateway/server-methods/agent.base.test-utils.ts
@@ -1,6 +1,5 @@
 // Imported by agent.test.ts to keep its mocked suite in one Vitest module graph.
 import fs from "node:fs/promises";
-import { expectDefined } from "@openclaw/normalization-core";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { ErrorCodes } from "../../../packages/gateway-protocol/src/index.js";
 import type { CronCreatorAuthorityCapability } from "../../agents/cron-creator-authority-context.js";
@@ -40,7 +39,7 @@ import {
   invokeAgent,
   describe0AfterEach0,
 } from "./agent.test-harness.js";
-import { chatHandlers } from "./chat.js";
+import { handleChatAbortRequest } from "./chat-abort-handler.js";
 import type { GatewayRequestContext } from "./types.js";
 
 const mocks = getAgentTestMocks();
@@ -325,10 +324,7 @@ describe("gateway agent handler", () => {
     expect(context.dedupe.get(`agent:${runId}`)?.payload).not.toHaveProperty("sessionKey");
 
     const abortRespond = vi.fn();
-    await expectDefined(
-      chatHandlers["chat.abort"],
-      'chatHandlers["chat.abort"] test invariant',
-    )({
+    await handleChatAbortRequest({
       params: { sessionKey: "agent:ops:main", runId },
       respond: abortRespond as never,
       context,
@@ -825,10 +821,7 @@ describe("gateway agent handler", () => {
     expect(mocks.updateSessionStore).not.toHaveBeenCalled();
 
     const abortRespond = vi.fn();
-    await expectDefined(
-      chatHandlers["chat.abort"],
-      'chatHandlers["chat.abort"] test invariant',
-    )({
+    await handleChatAbortRequest({
       params: { sessionKey, runId },
       respond: abortRespond as never,
       context,

--- a/src/gateway/server-methods/chat.abort-authorization.test-helpers.ts
+++ b/src/gateway/server-methods/chat.abort-authorization.test-helpers.ts
@@ -1,12 +1,13 @@
-import { expectDefined } from "@openclaw/normalization-core";
 import { expect } from "vitest";
-import { handleChatAbortRequestWithLifecycle } from "./chat-abort-handler.js";
+import {
+  handleChatAbortRequest,
+  handleChatAbortRequestWithLifecycle,
+} from "./chat-abort-handler.js";
 import {
   createActiveRun,
   createChatAbortContext,
   invokeChatAbortHandler,
 } from "./chat.abort.test-helpers.js";
-import { chatHandlers } from "./chat.js";
 
 export type AbortResponsePayload = { aborted?: boolean; runIds?: string[] };
 type AbortRespond = Awaited<ReturnType<typeof invokeChatAbortHandler>>;
@@ -40,7 +41,7 @@ export async function invokeAbort({
               onAuthorizedAfterQueuedAbort,
               excludeRunIds,
             })
-        : expectDefined(chatHandlers["chat.abort"], 'chatHandlers["chat.abort"] test invariant'),
+        : handleChatAbortRequest,
     context,
     request: {
       sessionKey,

--- a/src/gateway/server-methods/chat.abort-persistence.test.ts
+++ b/src/gateway/server-methods/chat.abort-persistence.test.ts
@@ -17,6 +17,7 @@ import { onInternalSessionTranscriptUpdate } from "../../sessions/transcript-eve
 import { closeOpenClawAgentDatabasesForTest } from "../../state/openclaw-agent-db.js";
 import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db.js";
 import { createChatRunState } from "../server-chat-state.js";
+import { handleChatAbortRequest } from "./chat-abort-handler.js";
 import { persistAbortedPartials } from "./chat-abort-runtime.js";
 import {
   createActiveRun,
@@ -393,10 +394,7 @@ describe("chat abort transcript persistence", () => {
     });
 
     await invokeChatAbortHandler({
-      handler: expectDefined(
-        chatHandlers["chat.abort"],
-        'chatHandlers["chat.abort"] test invariant',
-      ),
+      handler: handleChatAbortRequest,
       context,
       request: { sessionKey: "main", runId },
       respond,
@@ -412,10 +410,7 @@ describe("chat abort transcript persistence", () => {
     retryRun.deltaSentAt = Date.now();
 
     await invokeChatAbortHandler({
-      handler: expectDefined(
-        chatHandlers["chat.abort"],
-        'chatHandlers["chat.abort"] test invariant',
-      ),
+      handler: handleChatAbortRequest,
       context,
       request: { sessionKey: "main", runId },
       respond,
@@ -476,10 +471,7 @@ describe("chat abort transcript persistence", () => {
     });
 
     await invokeChatAbortHandler({
-      handler: expectDefined(
-        chatHandlers["chat.abort"],
-        'chatHandlers["chat.abort"] test invariant',
-      ),
+      handler: handleChatAbortRequest,
       context,
       request: { sessionKey: "main", runId },
       respond,
@@ -649,10 +641,7 @@ describe("chat abort transcript persistence", () => {
     });
 
     await invokeChatAbortHandler({
-      handler: expectDefined(
-        chatHandlers["chat.abort"],
-        'chatHandlers["chat.abort"] test invariant',
-      ),
+      handler: handleChatAbortRequest,
       context,
       request: { sessionKey: "main", runId },
       respond,
@@ -689,10 +678,7 @@ describe("chat abort transcript persistence", () => {
     });
 
     await invokeChatAbortHandler({
-      handler: expectDefined(
-        chatHandlers["chat.abort"],
-        'chatHandlers["chat.abort"] test invariant',
-      ),
+      handler: handleChatAbortRequest,
       context,
       request: { sessionKey: "main" },
       respond,
@@ -735,10 +721,7 @@ describe("chat abort transcript persistence", () => {
     });
 
     await invokeChatAbortHandler({
-      handler: expectDefined(
-        chatHandlers["chat.abort"],
-        'chatHandlers["chat.abort"] test invariant',
-      ),
+      handler: handleChatAbortRequest,
       context,
       request: { sessionKey: "main" },
       respond,
@@ -951,10 +934,7 @@ describe("chat abort transcript persistence", () => {
     });
 
     try {
-      await expectDefined(
-        chatHandlers["chat.abort"],
-        'chatHandlers["chat.abort"] test invariant',
-      )({
+      await handleChatAbortRequest({
         params: { sessionKey, ...(agentId ? { agentId } : {}) },
         respond,
         context: context as never,
@@ -989,10 +969,7 @@ describe("chat abort transcript persistence", () => {
       }),
     });
 
-    await expectDefined(
-      chatHandlers["chat.abort"],
-      'chatHandlers["chat.abort"] test invariant',
-    )({
+    await handleChatAbortRequest({
       params: {
         sessionKey: "agent:main:main",
         agentId: "work",
@@ -1027,10 +1004,7 @@ describe("chat abort transcript persistence", () => {
       }),
     });
 
-    await expectDefined(
-      chatHandlers["chat.abort"],
-      'chatHandlers["chat.abort"] test invariant',
-    )({
+    await handleChatAbortRequest({
       params: {
         sessionKey: "agent:work:main",
         runId: "run-work-global",
@@ -1069,10 +1043,7 @@ describe("chat abort transcript persistence", () => {
     });
 
     await invokeChatAbortHandler({
-      handler: expectDefined(
-        chatHandlers["chat.abort"],
-        'chatHandlers["chat.abort"] test invariant',
-      ),
+      handler: handleChatAbortRequest,
       context,
       request: {
         sessionKey: "agent:work:main",
@@ -1115,10 +1086,7 @@ describe("chat abort transcript persistence", () => {
     });
 
     await invokeChatAbortHandler({
-      handler: expectDefined(
-        chatHandlers["chat.abort"],
-        'chatHandlers["chat.abort"] test invariant',
-      ),
+      handler: handleChatAbortRequest,
       context,
       request: { sessionKey: "main", ...(explicitRunId ? { runId: "run-hidden" } : {}) },
       client: { connId: "conn-hidden" },
@@ -1162,10 +1130,7 @@ describe("chat abort transcript persistence", () => {
     });
 
     await invokeChatAbortHandler({
-      handler: expectDefined(
-        chatHandlers["chat.abort"],
-        'chatHandlers["chat.abort"] test invariant',
-      ),
+      handler: handleChatAbortRequest,
       context,
       request: {
         sessionKey: "agent:work:main",
@@ -1207,10 +1172,7 @@ describe("chat abort transcript persistence", () => {
     });
 
     await invokeChatAbortHandler({
-      handler: expectDefined(
-        chatHandlers["chat.abort"],
-        'chatHandlers["chat.abort"] test invariant',
-      ),
+      handler: handleChatAbortRequest,
       context,
       request: {
         sessionKey: "global",
@@ -1236,10 +1198,7 @@ describe("chat abort transcript persistence", () => {
     });
 
     await invokeChatAbortHandler({
-      handler: expectDefined(
-        chatHandlers["chat.abort"],
-        'chatHandlers["chat.abort"] test invariant',
-      ),
+      handler: handleChatAbortRequest,
       context,
       request: {
         sessionKey: "global",
@@ -1266,10 +1225,7 @@ describe("chat abort transcript persistence", () => {
     });
 
     await invokeChatAbortHandler({
-      handler: expectDefined(
-        chatHandlers["chat.abort"],
-        'chatHandlers["chat.abort"] test invariant',
-      ),
+      handler: handleChatAbortRequest,
       context,
       request: {
         sessionKey: "global",
@@ -1307,10 +1263,7 @@ describe("chat abort transcript persistence", () => {
     });
 
     await invokeChatAbortHandler({
-      handler: expectDefined(
-        chatHandlers["chat.abort"],
-        'chatHandlers["chat.abort"] test invariant',
-      ),
+      handler: handleChatAbortRequest,
       context,
       request: { sessionKey: "global", agentId, runId: "run-main-global" },
       client: { connId: "conn-main" },
@@ -1378,10 +1331,7 @@ describe("chat abort transcript persistence", () => {
     });
 
     await invokeChatAbortHandler({
-      handler: expectDefined(
-        chatHandlers["chat.abort"],
-        'chatHandlers["chat.abort"] test invariant',
-      ),
+      handler: handleChatAbortRequest,
       context,
       request: { sessionKey: "main", runId },
       respond,
@@ -1412,10 +1362,7 @@ describe("chat abort transcript persistence", () => {
     });
 
     await invokeChatAbortHandler({
-      handler: expectDefined(
-        chatHandlers["chat.abort"],
-        'chatHandlers["chat.abort"] test invariant',
-      ),
+      handler: handleChatAbortRequest,
       context,
       request: { sessionKey: "main", runId },
       respond,
@@ -1443,10 +1390,7 @@ describe("chat.abort session identity matching", () => {
     const respond = vi.fn();
 
     await invokeChatAbortHandler({
-      handler: expectDefined(
-        chatHandlers["chat.abort"],
-        'chatHandlers["chat.abort"] test invariant',
-      ),
+      handler: handleChatAbortRequest,
       context,
       request: { sessionKey: "main" },
       respond,
@@ -1472,10 +1416,7 @@ describe("chat.abort session identity matching", () => {
     const respond = vi.fn();
 
     await invokeChatAbortHandler({
-      handler: expectDefined(
-        chatHandlers["chat.abort"],
-        'chatHandlers["chat.abort"] test invariant',
-      ),
+      handler: handleChatAbortRequest,
       context,
       request: { sessionKey: "main" },
       respond,

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -9,7 +9,6 @@ import { resolveSessionAgentId } from "../../agents/agent-scope.js";
 import { resolveSessionWorkStartError } from "../../config/sessions.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { beginSessionWorkAdmission } from "../../sessions/session-lifecycle-admission.js";
-import { createAgentTurnService } from "../agent-turn/agent-turn-service.js";
 import {
   projectChatDisplayMessage,
   resolveEffectiveChatHistoryMaxChars,
@@ -96,9 +95,6 @@ export const chatHandlers: GatewayRequestHandlers = {
       items: params.items,
     });
     respond(true, { titles });
-  },
-  "chat.abort": async (options) => {
-    await createAgentTurnService(options).abortTurn(options);
   },
   "chat.send": handleDirectExternalChatSend,
   "chat.inject": async ({ params, respond, context }) => {

--- a/src/gateway/server-methods/lazy-core-handlers.test.ts
+++ b/src/gateway/server-methods/lazy-core-handlers.test.ts
@@ -14,7 +14,33 @@ vi.mock("../session-create-service.js", () => {
   return {};
 });
 
+vi.mock("./chat.js", () => {
+  throw new Error("Cancellation must not load chat history or send handlers");
+});
+
 describe("lazy core handler families", () => {
+  it("dispatches cancellation without importing unrelated chat workflows", async () => {
+    const { coreGatewayHandlers } = await import("../server-methods.js");
+    const respond = vi.fn();
+    await expectDefined(
+      coreGatewayHandlers["chat.abort"],
+      "chat.abort lazy handler",
+    )({
+      req: { type: "req", id: "abort-light-family", method: "chat.abort" },
+      params: { sessionKey: 42 },
+      respond,
+      context: {} as never,
+      client: null,
+      isWebchatConnect: () => false,
+    });
+
+    expect(respond).toHaveBeenCalledWith(
+      false,
+      undefined,
+      expect.objectContaining({ code: "INVALID_REQUEST" }),
+    );
+  });
+
   it("loads agent identity without importing the agent run stack", async () => {
     const { coreGatewayHandlers } = await import("../server-methods.js");
     const respond = vi.fn();

--- a/src/gateway/server.agent.gateway-server-agent-auth-refresh.test.ts
+++ b/src/gateway/server.agent.gateway-server-agent-auth-refresh.test.ts
@@ -8,7 +8,6 @@ import {
   getPreparedModelRuntimePluginGeneration,
 } from "../agents/prepared-model-runtime-generation-scope.js";
 import {
-  getPreparedModelRuntimeSnapshot,
   loadPublishedGatewayReplyDispatchRuntime,
   registerPreparedModelRuntimePublicationListener,
 } from "../agents/prepared-model-runtime.js";
@@ -49,42 +48,24 @@ type AgentRpcFrame = {
   error?: { code?: string; message?: string };
 };
 
-function sendAgentRpc(socket: WebSocket, params: { agentId: string; runId: string }) {
-  const accepted = onceMessage<AgentRpcFrame>(
-    socket,
-    (frame) =>
-      frame.type === "res" && frame.id === params.runId && frame.payload?.status === "accepted",
-  );
-  const final = onceMessage<AgentRpcFrame>(
-    socket,
-    (frame) =>
-      frame.type === "res" && frame.id === params.runId && frame.payload?.status !== "accepted",
-  );
-  socket.send(
-    JSON.stringify({
-      type: "req",
-      id: params.runId,
-      method: "agent",
-      params: {
-        agentId: params.agentId,
-        message: `dispatch ${params.runId}`,
-        idempotencyKey: params.runId,
-      },
-    }),
-  );
-  return { accepted, final };
-}
+const rpcDrains: Array<Promise<PromiseSettledResult<AgentRpcFrame>[]>> = [];
 
-function sendPreacceptAgentRpc(socket: WebSocket, params: { agentId: string; runId: string }) {
-  const response = onceMessage<AgentRpcFrame>(
-    socket,
-    (frame) => frame.type === "res" && frame.id === params.runId,
-  );
+function sendAgentRpc(socket: WebSocket, params: { agentId: string; runId: string }) {
+  let responseReceived = false;
+  const response = onceMessage<AgentRpcFrame>(socket, (frame) => {
+    if (frame.type !== "res" || frame.id !== params.runId) {
+      return false;
+    }
+    responseReceived = true;
+    return true;
+  });
   const final = onceMessage<AgentRpcFrame>(
     socket,
     (frame) =>
       frame.type === "res" && frame.id === params.runId && frame.payload?.status !== "accepted",
   );
+  // Observe both listeners immediately, then drain them before the shared server resets.
+  rpcDrains.push(Promise.allSettled([response, final]));
   socket.send(
     JSON.stringify({
       type: "req",
@@ -97,7 +78,7 @@ function sendPreacceptAgentRpc(socket: WebSocket, params: { agentId: string; run
       },
     }),
   );
-  return { response, final };
+  return { response, final, hasResponse: () => responseReceived };
 }
 
 function agentCommandCallsFor(runId: string) {
@@ -129,8 +110,13 @@ describe("gateway agent auth refresh dispatch", () => {
     vi.mocked(agentCommandMock).mockClear();
   });
 
-  afterEach(() => {
-    testState.agentsConfig = undefined;
+  afterEach(async () => {
+    try {
+      const outcomes = await Promise.all(rpcDrains.splice(0));
+      expect(outcomes.flat().every((outcome) => outcome.status === "fulfilled")).toBe(true);
+    } finally {
+      testState.agentsConfig = undefined;
+    }
   });
 
   test("keeps an accepted run on its admitted runtime generation", async () => {
@@ -139,13 +125,20 @@ describe("gateway agent auth refresh dispatch", () => {
     const subsequentRunId = "idem-agent-auth-next";
     const before = await prepareAuthDispatchAgents(affectedAgentId);
     expect(before.runtime).toBeDefined();
-    const snapshotInput = {
-      agentId: affectedAgentId,
-      agentDir: before.agentDir,
-      config: before.runtime!.config,
-      workspaceDir: before.runtime!.workspaceDir,
-      allowGatewaySubagentBinding: true,
-    };
+    const preparedRuntime = await import("../agents/prepared-model-runtime.js");
+    const acquireRuntime = preparedRuntime.acquireAgentRunPreparedModelRuntime;
+    const admittedSnapshots: Array<Awaited<ReturnType<typeof acquireRuntime>>["snapshot"]> = [];
+    // Admission can derive a selected snapshot from the configured generation. Capture
+    // the actual lease before ACK, then prove refresh cannot replace that run's identity.
+    const acquireSpy = vi
+      .spyOn(preparedRuntime, "acquireAgentRunPreparedModelRuntime")
+      .mockImplementation(async (input, options) => {
+        const lease = await acquireRuntime(input, options);
+        if (input.agentId === affectedAgentId) {
+          admittedSnapshots.push(lease.snapshot);
+        }
+        return lease;
+      });
     const dispatchedSnapshots = new Map<
       string,
       ReturnType<typeof getPreparedModelRuntimeBorrowedSnapshot>
@@ -168,8 +161,6 @@ describe("gateway agent auth refresh dispatch", () => {
         published.resolve();
       }
     });
-    let admitted: ReturnType<typeof sendAgentRpc> | undefined;
-    let subsequent: ReturnType<typeof sendAgentRpc> | undefined;
     try {
       agentCommandMock.mockImplementation((options, ...args) => {
         if (
@@ -187,16 +178,20 @@ describe("gateway agent auth refresh dispatch", () => {
         );
         return originalCommand!(options, ...args);
       });
-      admitted = sendAgentRpc(gatewaySuite.ws, {
+      const admitted = sendAgentRpc(gatewaySuite.ws, {
         agentId: affectedAgentId,
         runId: admittedRunId,
       });
-      await admitted.accepted;
+      await expect(admitted.response).resolves.toMatchObject({
+        ok: true,
+        payload: { status: "accepted" },
+      });
       await expect(
         Promise.race([dispatchEntered.promise, admitted.final]),
       ).resolves.toBeUndefined();
       expect(agentCommandCallsFor(admittedRunId)).toHaveLength(0);
-      const admittedSnapshot = getPreparedModelRuntimeSnapshot(snapshotInput);
+      expect(admittedSnapshots.length).toBe(1);
+      const admittedSnapshot = admittedSnapshots[0];
       expect(admittedSnapshot).toBeDefined();
 
       setRuntimeAuthProfileStoreSnapshot(
@@ -217,10 +212,6 @@ describe("gateway agent auth refresh dispatch", () => {
         agentId: affectedAgentId,
       });
       expect(after).not.toBe(before.runtime);
-      const refreshedSnapshot = getPreparedModelRuntimeSnapshot(snapshotInput);
-      expect(refreshedSnapshot).toBeDefined();
-      // Auth refresh can reuse config and plugin identities; the leased snapshot must differ.
-      expect(refreshedSnapshot === admittedSnapshot).toBe(false);
       expect(agentCommandCallsFor(admittedRunId)).toHaveLength(0);
       releaseDispatch.resolve();
 
@@ -234,11 +225,14 @@ describe("gateway agent auth refresh dispatch", () => {
       });
       expect(dispatchedSnapshots.get(admittedRunId) === admittedSnapshot).toBe(true);
 
-      subsequent = sendAgentRpc(gatewaySuite.ws, {
+      const subsequent = sendAgentRpc(gatewaySuite.ws, {
         agentId: affectedAgentId,
         runId: subsequentRunId,
       });
-      await subsequent.accepted;
+      await expect(subsequent.response).resolves.toMatchObject({
+        ok: true,
+        payload: { status: "accepted" },
+      });
       await expect(subsequent.final).resolves.toMatchObject({
         ok: true,
         payload: { status: "ok" },
@@ -247,20 +241,16 @@ describe("gateway agent auth refresh dispatch", () => {
         config: after?.config,
         pluginGeneration: after?.pluginGeneration,
       });
-      expect(dispatchedSnapshots.get(subsequentRunId) === refreshedSnapshot).toBe(true);
+      expect(admittedSnapshots.length).toBe(2);
+      // Auth refresh may reuse metadata and plugin identities, but the next lease is new.
+      expect(admittedSnapshots[1] === admittedSnapshot).toBe(false);
+      expect(dispatchedSnapshots.get(subsequentRunId) === admittedSnapshots[1]).toBe(true);
     } finally {
       releaseDispatch.resolve();
       unregister();
-      try {
-        // Drain this test's real RPC listeners before shared-server fixtures reset.
-        await Promise.allSettled([
-          ...(admitted ? [admitted.accepted, admitted.final] : []),
-          ...(subsequent ? [subsequent.accepted, subsequent.final] : []),
-        ]);
-      } finally {
-        yieldSpy.mockRestore();
-        agentCommandMock.mockImplementation(originalCommand!);
-      }
+      yieldSpy.mockRestore();
+      acquireSpy.mockRestore();
+      agentCommandMock.mockImplementation(originalCommand!);
     }
   });
 
@@ -303,16 +293,19 @@ describe("gateway agent auth refresh dispatch", () => {
         before.agentDir,
       );
 
-      const aborted = sendPreacceptAgentRpc(gatewaySuite.ws, {
+      const aborted = sendAgentRpc(gatewaySuite.ws, {
         agentId: affectedAgentId,
         runId: abortedRunId,
       });
-      const waiting = sendPreacceptAgentRpc(gatewaySuite.ws, {
+      const waiting = sendAgentRpc(gatewaySuite.ws, {
         agentId: affectedAgentId,
         runId: waitingRunId,
       });
       const sibling = sendAgentRpc(gatewaySuite.ws, { agentId: "main", runId: siblingRunId });
-      await sibling.accepted;
+      await expect(sibling.response).resolves.toMatchObject({
+        ok: true,
+        payload: { status: "accepted" },
+      });
       await expect(sibling.final).resolves.toMatchObject({ ok: true, payload: { status: "ok" } });
       expect(agentCommandCallsFor(siblingRunId)).toHaveLength(1);
       expect(agentCommandCallsFor(abortedRunId)).toHaveLength(0);
@@ -337,9 +330,7 @@ describe("gateway agent auth refresh dispatch", () => {
           providerStarted: false,
         },
       });
-      await expect(
-        Promise.race([waiting.response.then(() => "settled"), Promise.resolve("pending")]),
-      ).resolves.toBe("pending");
+      expect(waiting.hasResponse()).toBe(false);
 
       publicationGate.resolve({ agentDir: before.agentDir, wrote: false });
       await published.promise;
@@ -363,7 +354,10 @@ describe("gateway agent auth refresh dispatch", () => {
         agentId: affectedAgentId,
         runId: subsequentRunId,
       });
-      await subsequent.accepted;
+      await expect(subsequent.response).resolves.toMatchObject({
+        ok: true,
+        payload: { status: "accepted" },
+      });
       await expect(subsequent.final).resolves.toMatchObject({
         ok: true,
         payload: { status: "ok" },
@@ -417,7 +411,7 @@ describe("gateway agent auth refresh dispatch", () => {
         `prepared reply dispatch runtime owner was not published for ${affectedAgentId}`,
       );
 
-      const rejected = sendPreacceptAgentRpc(gatewaySuite.ws, {
+      const rejected = sendAgentRpc(gatewaySuite.ws, {
         agentId: affectedAgentId,
         runId,
       });

--- a/src/gateway/server.chat.gateway-server-chat-b.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat-b.test.ts
@@ -422,8 +422,8 @@ async function callDirectChatHandler(
   method: DirectChatMethod,
   options: GatewayRequestHandlerOptions,
 ) {
-  const { chatHandlers } = await import("./server-methods/chat.js");
-  await expectDefined(chatHandlers[method], `${method} test invariant`)(options);
+  const { coreGatewayHandlers } = await import("./server-methods.js");
+  await expectDefined(coreGatewayHandlers[method], `${method} test invariant`)(options);
 }
 
 type DirectChatCallOptions = Omit<

--- a/src/gateway/worker-environments/inference-runtime.test.ts
+++ b/src/gateway/worker-environments/inference-runtime.test.ts
@@ -288,6 +288,12 @@ function setup(
     leasedPreparedModelRuntime = leased;
     return {
       snapshot: leased,
+      pluginGeneration: {
+        configuredCatalogEntries: [],
+        inlineProviderModels: [],
+        pluginMetadataSnapshot: leased.metadataSnapshot,
+        pluginRegistry: leased.pluginRegistry,
+      },
       release: releaseRuntime,
     };
   });

--- a/test/gateway-cold-agent-abort.e2e.test.ts
+++ b/test/gateway-cold-agent-abort.e2e.test.ts
@@ -1,0 +1,159 @@
+import { randomUUID } from "node:crypto";
+import { createServer } from "node:http";
+import { expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../src/config/types.openclaw.js";
+import { connectGatewayClient, disconnectGatewayClient } from "../src/gateway/test-helpers.e2e.js";
+import { buildMockOpenAiResponsesProvider } from "../src/gateway/test-openai-responses-model.js";
+import {
+  createOpenClawTestInstance,
+  type OpenClawTestInstance,
+} from "./helpers/openclaw-test-instance.js";
+import { createDeferred } from "./helpers/promise.js";
+
+it(
+  "cancels a provider request through the first chat RPC on a built Gateway",
+  { timeout: 120_000 },
+  async () => {
+    const modelId = "cold-cancel-model";
+    const runId = randomUUID();
+    const sessionKey = "agent:main:cold-agent-abort";
+    const accepted = createDeferred<unknown>();
+    const providerReceived = createDeferred<Record<string, unknown>>();
+    let providerRequests = 0;
+    let providerAborted = false;
+    const server = createServer((request, response) => {
+      void (async () => {
+        if (request.method === "GET" && request.url === "/v1/models") {
+          response.writeHead(200, { "content-type": "application/json" });
+          response.end(JSON.stringify({ data: [{ id: modelId, object: "model" }] }));
+          return;
+        }
+        if (request.method !== "POST" || request.url !== "/v1/responses") {
+          response.writeHead(404).end();
+          return;
+        }
+        const chunks: Buffer[] = [];
+        for await (const chunk of request) {
+          chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+        }
+        const body = JSON.parse(Buffer.concat(chunks).toString("utf8")) as Record<string, unknown>;
+        providerRequests += 1;
+        // Keep the provider response open: only cancellation may close it before cleanup.
+        response.once("close", () => {
+          providerAborted = !response.writableFinished;
+        });
+        providerReceived.resolve(body);
+      })().catch((error: unknown) => {
+        providerReceived.reject(error);
+        response.destroy(error instanceof Error ? error : new Error(String(error)));
+      });
+    });
+    let instance: OpenClawTestInstance | undefined;
+    let client: Awaited<ReturnType<typeof connectGatewayClient>> | undefined;
+    let final: Promise<unknown> | undefined;
+    try {
+      await new Promise<void>((resolve, reject) => {
+        server.once("error", reject);
+        server.listen(0, "127.0.0.1", resolve);
+      });
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        throw new Error("cancellation provider did not bind a loopback port");
+      }
+      const provider = buildMockOpenAiResponsesProvider(
+        `http://127.0.0.1:${address.port}/v1`,
+        modelId,
+      );
+      const config: OpenClawConfig = {
+        plugins: { slots: { memory: "none" } },
+        agents: {
+          entries: { main: {} },
+          defaults: {
+            model: { primary: provider.modelRef, fallbacks: [] },
+            models: { [provider.modelRef]: { agentRuntime: { id: "openclaw" } } },
+            skills: [],
+          },
+        },
+        tools: { profile: "minimal" },
+        models: {
+          mode: "replace",
+          providers: {
+            [provider.providerId]: {
+              ...provider.config,
+              request: { allowPrivateNetwork: true },
+            },
+          },
+        },
+      };
+      instance = await createOpenClawTestInstance({
+        name: "cold-agent-abort",
+        config,
+        env: {
+          OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1",
+          OPENCLAW_SKIP_PROVIDERS: undefined,
+          OPENCLAW_TEST_MINIMAL_GATEWAY: undefined,
+        },
+      });
+      await instance.startGateway();
+      client = await connectGatewayClient({
+        url: instance.url,
+        token: instance.gatewayToken,
+      });
+      final = client.request(
+        "agent",
+        {
+          agentId: "main",
+          sessionKey,
+          idempotencyKey: runId,
+          message: "Wait for cancellation.",
+          deliver: false,
+          timeout: 30,
+        },
+        { expectFinal: true, timeoutMs: 30_000, onAccepted: accepted.resolve },
+      );
+      await expect(
+        Promise.race([
+          Promise.all([accepted.promise, providerReceived.promise]),
+          final.then(() => {
+            throw new Error("agent completed before the cancellation request");
+          }),
+        ]),
+      ).resolves.toMatchObject([{ runId, status: "accepted" }, { model: modelId }]);
+      expect(providerAborted).toBe(false);
+
+      // Readiness uses HTTP and setup uses only agent: this is the first chat-family RPC.
+      const aborted = await client.request("chat.abort", { sessionKey, runId });
+      expect(aborted).toMatchObject({ aborted: true, runIds: [runId] });
+      const terminal = await final;
+      // resolveRunLivenessState persists a stop before any output as blocked.
+      expect(terminal).toMatchObject({
+        runId,
+        status: "error",
+        summary: "failed",
+        stopReason: "aborted",
+        result: { meta: { aborted: true, stopReason: "aborted", livenessState: "blocked" } },
+      });
+      expect(terminal).not.toHaveProperty("result.meta.error");
+      await vi.waitFor(() => expect(providerAborted).toBe(true), { timeout: 5_000 });
+      expect(providerRequests).toBe(1);
+    } finally {
+      try {
+        if (client) {
+          await disconnectGatewayClient(client);
+        }
+      } finally {
+        try {
+          await instance?.cleanup();
+        } finally {
+          if (server.listening) {
+            await new Promise<void>((resolve) => {
+              server.close(() => resolve());
+              server.closeAllConnections();
+            });
+          }
+          await Promise.allSettled(final ? [final] : []);
+        }
+      }
+    }
+  },
+);

--- a/test/gateway-copied-codex-session-resume.e2e.test.ts
+++ b/test/gateway-copied-codex-session-resume.e2e.test.ts
@@ -1,7 +1,7 @@
-// A copied persisted Codex session must reactivate its installed harness owner on Gateway startup.
+// Admission prepares the trusted harness selected by a copied persisted session.
 import fs from "node:fs/promises";
 import path from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../src/config/types.openclaw.js";
 import { connectGatewayClient, disconnectGatewayClient } from "../src/gateway/test-helpers.e2e.js";
 import { upsertSessionEntry } from "../src/plugin-sdk/session-store-runtime.js";
@@ -23,9 +23,13 @@ afterEach(async () => {
   closeOpenClawAgentDatabasesForTest();
 });
 
-function buildCopiedStateConfig(): OpenClawConfig {
+function buildCopiedStateConfig(enabled: boolean | undefined): OpenClawConfig {
   return {
-    plugins: { enabled: true, slots: { memory: "none" } },
+    plugins: {
+      enabled: true,
+      entries: enabled === undefined ? {} : { codex: { enabled } },
+      slots: { memory: "none" },
+    },
     models: {
       providers: {
         "copied-session-proof": {
@@ -143,10 +147,48 @@ async function installCodexHarnessFixture(stateDir: string, config: OpenClawConf
 }
 
 describe("Gateway copied Codex session resume", () => {
-  it(
-    "resumes a copied persisted Codex session when config no longer selects its harness",
-    async () => {
-      const config = buildCopiedStateConfig();
+  it.each([
+    {
+      name: "resumes a copied persisted Codex session when config no longer selects its harness",
+      enabled: true,
+    },
+    {
+      name: "rejects a copied session whose harness plugin is explicitly disabled",
+      enabled: false,
+    },
+    {
+      name: "rejects a copied session whose installed harness has no explicit trust",
+      enabled: undefined,
+    },
+    {
+      name: "selects a lazy harness from cron with per-agent model overrides",
+      enabled: true,
+      cron: true,
+    },
+  ])(
+    "$name",
+    async ({ enabled, cron }) => {
+      const config = buildCopiedStateConfig(enabled);
+      if (cron) {
+        config.agents!.entries = {
+          main: {
+            model: {
+              primary: "copied-session-proof/alternate-model",
+              fallbacks: ["copied-session-proof/proof-model"],
+            },
+          },
+        };
+        config.agents!.defaults!.models = {
+          "copied-session-proof/cron-model": { agentRuntime: { id: "codex" } },
+        };
+        for (const id of ["alternate-model", "cron-model"]) {
+          config.models!.providers!["copied-session-proof"]!.models.push({
+            ...config.models!.providers!["copied-session-proof"]!.models[0]!,
+            id,
+            name: id,
+          });
+        }
+      }
       const instance = await createOpenClawTestInstance({
         name: "copied-codex-session-resume",
         config,
@@ -154,6 +196,7 @@ describe("Gateway copied Codex session resume", () => {
           OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1",
           OPENCLAW_SKIP_PROVIDERS: undefined,
           OPENCLAW_TEST_MINIMAL_GATEWAY: undefined,
+          ...(cron ? { OPENCLAW_SKIP_CRON: undefined } : {}),
         },
       });
       instances.push(instance);
@@ -181,7 +224,38 @@ describe("Gateway copied Codex session resume", () => {
         requestTimeoutMs: 30_000,
       });
       try {
-        const payload = await client.request(
+        if (cron) {
+          const job = await client.request<{ id: string }>("cron.add", {
+            name: "Copied session cron runtime",
+            agentId: "main",
+            enabled: true,
+            schedule: { kind: "at", at: new Date(Date.now() + 3_600_000).toISOString() },
+            sessionTarget: "isolated",
+            wakeMode: "now",
+            payload: {
+              kind: "agentTurn",
+              message: "Resume this copied conversation from cron.",
+              model: "copied-session-proof/cron-model",
+            },
+            delivery: { mode: "none" },
+          });
+          try {
+            await client.request("cron.run", { id: job.id, mode: "force" });
+            await vi.waitFor(
+              async () => {
+                const history = await client.request<{
+                  entries: Array<{ status: string; summary?: string; error?: string }>;
+                }>("cron.runs", { id: job.id, limit: 1 });
+                expect(history.entries).toMatchObject([{ status: "ok", summary: VISIBLE_REPLY }]);
+              },
+              { timeout: 30_000, interval: 100 },
+            );
+          } finally {
+            await client.request("cron.remove", { id: job.id });
+          }
+          return;
+        }
+        const request = client.request(
           "agent",
           {
             sessionKey: SESSION_KEY,
@@ -193,7 +267,13 @@ describe("Gateway copied Codex session resume", () => {
           { expectFinal: true, timeoutMs: 30_000 },
         );
 
-        expect(payload).toMatchObject({
+        if (enabled !== true) {
+          await expect(request).rejects.toThrow(
+            "plugin registration is missing from this prepared run",
+          );
+          return;
+        }
+        expect(await request).toMatchObject({
           status: "ok",
           result: { payloads: [{ text: VISIBLE_REPLY }] },
         });

--- a/test/plugin-cron-registry-owner.e2e.test.ts
+++ b/test/plugin-cron-registry-owner.e2e.test.ts
@@ -139,7 +139,7 @@ function writeModelResponse(res: ServerResponse, sequence: number): void {
   );
 }
 
-async function startMockModelServer(): Promise<MockModelServer> {
+async function startMockModelServer(rejectModel?: string): Promise<MockModelServer> {
   const requests: MockModelRequest[] = [];
   const server = createServer((req, res) => {
     void (async () => {
@@ -153,7 +153,13 @@ async function startMockModelServer(): Promise<MockModelServer> {
         res.writeHead(404).end();
         return;
       }
-      requests.push({ body: await readJsonRequest(req) });
+      const body = await readJsonRequest(req);
+      requests.push({ body });
+      if (rejectModel && body.model === rejectModel) {
+        res.writeHead(503, { "content-type": "application/json" });
+        res.end(JSON.stringify({ error: { message: "Model temporarily unavailable" } }));
+        return;
+      }
       writeModelResponse(res, requests.length);
     })();
   });
@@ -263,6 +269,149 @@ async function listCronJobs(client: {
 }
 
 describe("plugin cron registry ownership e2e", () => {
+  it(
+    "prepares a job-selected provider and fallback under per-agent defaults",
+    async () => {
+      const fixtureDir = await mkdtemp(path.join(tmpdir(), "openclaw-cron-selection-e2e-"));
+      cleanupDirs.push(fixtureDir);
+      const bundledRoot = path.join(fixtureDir, "bundled");
+      const pluginId = "selected-cron-provider";
+      const pluginDir = path.join(bundledRoot, pluginId);
+      const provider = "selected-cron";
+      const providerMarker = "SELECTED_CRON_PROVIDER_RUNTIME";
+      await mkdir(pluginDir, { recursive: true });
+      await writeFile(
+        path.join(pluginDir, "openclaw.plugin.json"),
+        JSON.stringify({
+          id: pluginId,
+          providers: [provider],
+          activation: { onStartup: false, onProviders: [provider] },
+          configSchema: { type: "object", additionalProperties: false },
+        }),
+      );
+      await writeFile(
+        path.join(pluginDir, "index.js"),
+        `module.exports = {
+      id: ${JSON.stringify(pluginId)},
+      register(api) {
+        api.registerProvider({
+          id: ${JSON.stringify(provider)}, label: "Selected cron provider", auth: [],
+          resolveSyntheticAuth: () => ({ apiKey: "cron-fixture", source: "fixture", mode: "api-key" }),
+          transformSystemPrompt: ({ systemPrompt }) => systemPrompt + "\\n" + ${JSON.stringify(providerMarker)},
+        });
+      },
+    };\n`,
+      );
+      const server = await startMockModelServer("unavailable");
+      modelServers.push(server);
+      const model = (id: string) => ({
+        id,
+        name: id,
+        reasoning: false,
+        input: ["text"] as ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 128_000,
+        maxTokens: 4_096,
+      });
+      const config: OpenClawConfig = {
+        plugins: { entries: { [pluginId]: { enabled: true } }, slots: { memory: "none" } },
+        agents: {
+          defaults: {
+            workspace: path.join(fixtureDir, "workspace"),
+            model: { primary: "cron-owner/default" },
+            skills: [],
+          },
+          entries: { main: { model: { primary: "cron-owner/agent-default" } } },
+        },
+        tools: { profile: "minimal" },
+        models: {
+          mode: "replace",
+          providers: {
+            "cron-owner": {
+              baseUrl: `${server.baseUrl}/v1`,
+              api: "openai-responses",
+              apiKey: TEST_API_KEY,
+              request: { allowPrivateNetwork: true },
+              models: [model("default"), model("agent-default")],
+            },
+            [provider]: {
+              baseUrl: `${server.baseUrl}/v1`,
+              api: "openai-responses",
+              request: { allowPrivateNetwork: true },
+              models: [model("unavailable"), model("available")],
+            },
+          },
+        },
+      };
+      const instance = await createOpenClawTestInstance({
+        name: "cron-selected-provider",
+        config,
+        env: {
+          OPENCLAW_BUNDLED_PLUGINS_DIR: bundledRoot,
+          OPENCLAW_TEST_TRUST_BUNDLED_PLUGINS_DIR: "1",
+          OPENCLAW_DISABLE_BUNDLED_PLUGINS: undefined,
+          OPENCLAW_SKIP_CRON: undefined,
+          OPENCLAW_SKIP_PROVIDERS: undefined,
+          OPENCLAW_TEST_MINIMAL_GATEWAY: undefined,
+        },
+      });
+      instances.push(instance);
+      await instance.startGateway();
+      const client = await connectGatewayClient({
+        url: instance.url,
+        token: instance.gatewayToken,
+      });
+      let jobId: string | undefined;
+      try {
+        const job = await client.request<{ id: string }>("cron.add", {
+          name: "Selected provider fallback",
+          agentId: "main",
+          enabled: true,
+          schedule: { kind: "at", at: new Date(Date.now() + 3_600_000).toISOString() },
+          sessionTarget: "isolated",
+          wakeMode: "now",
+          delivery: { mode: "none" },
+          payload: {
+            kind: "agentTurn",
+            message: "Prove the selected provider runtime.",
+            model: `${provider}/unavailable`,
+            fallbacks: [`${provider}/available`],
+          },
+        });
+        jobId = job.id;
+        const run = await client.request<{ runId: string }>("cron.run", {
+          id: jobId,
+          mode: "force",
+        });
+        let terminal: { status?: string; summary?: string; error?: string } | undefined;
+        await expect
+          .poll(async () => {
+            const history = await client.request<{
+              entries: Array<{ status?: string; summary?: string; error?: string }>;
+            }>("cron.runs", { id: jobId, runId: run.runId, limit: 1 });
+            terminal = history.entries[0];
+            return terminal?.status;
+          }, WAIT_OPTIONS)
+          .toBeDefined();
+        expect(terminal?.error).toBeUndefined();
+        expect(terminal).toMatchObject({
+          status: "ok",
+          summary: expect.stringContaining("CRON_OWNER_RESPONSE_"),
+        });
+        const models = server.requests.map(({ body }) => body.model);
+        expect(models).toContain("unavailable");
+        expect(models.at(-1)).toBe("available");
+        expect(
+          server.requests.every((request) => requestText(request).includes(providerMarker)),
+        ).toBe(true);
+      } finally {
+        if (jobId) await client.request("cron.remove", { id: jobId });
+        await disconnectGatewayClient(client);
+      }
+    },
+    E2E_TIMEOUT_MS,
+  );
+
   it(
     "keeps recurring startup-plugin jobs through workspace registry churn",
     { timeout: E2E_TIMEOUT_MS },

--- a/test/plugin-cron-registry-owner.e2e.test.ts
+++ b/test/plugin-cron-registry-owner.e2e.test.ts
@@ -10,6 +10,8 @@ import {
   disconnectGatewayClient,
   getGatewayE2ePortBlock,
 } from "../src/gateway/test-helpers.e2e.js";
+import { upsertSessionEntry } from "../src/plugin-sdk/session-store-runtime.js";
+import { closeOpenClawAgentDatabasesForTest } from "../src/plugin-sdk/sqlite-runtime-testing.js";
 import {
   createOpenClawTestInstance,
   type OpenClawTestInstance,
@@ -269,39 +271,41 @@ async function listCronJobs(client: {
 }
 
 describe("plugin cron registry ownership e2e", () => {
-  it(
-    "prepares a job-selected provider and fallback under per-agent defaults",
-    async () => {
+  it.each(["cron", "subagent"] as const)(
+    "prepares distinct selected and fallback providers for %s under per-agent defaults",
+    async (route) => {
       const fixtureDir = await mkdtemp(path.join(tmpdir(), "openclaw-cron-selection-e2e-"));
       cleanupDirs.push(fixtureDir);
       const bundledRoot = path.join(fixtureDir, "bundled");
-      const pluginId = "selected-cron-provider";
-      const pluginDir = path.join(bundledRoot, pluginId);
       const provider = "selected-cron";
-      const providerMarker = "SELECTED_CRON_PROVIDER_RUNTIME";
-      await mkdir(pluginDir, { recursive: true });
-      await writeFile(
-        path.join(pluginDir, "openclaw.plugin.json"),
-        JSON.stringify({
-          id: pluginId,
-          providers: [provider],
-          activation: { onStartup: false, onProviders: [provider] },
-          configSchema: { type: "object", additionalProperties: false },
-        }),
-      );
-      await writeFile(
-        path.join(pluginDir, "index.js"),
-        `module.exports = {
-      id: ${JSON.stringify(pluginId)},
-      register(api) {
-        api.registerProvider({
-          id: ${JSON.stringify(provider)}, label: "Selected cron provider", auth: [],
-          resolveSyntheticAuth: () => ({ apiKey: "cron-fixture", source: "fixture", mode: "api-key" }),
-          transformSystemPrompt: ({ systemPrompt }) => systemPrompt + "\\n" + ${JSON.stringify(providerMarker)},
-        });
-      },
-    };\n`,
-      );
+      const fallbackProvider = "selected-fallback";
+      const pluginIds = [provider, fallbackProvider];
+      for (const pluginId of pluginIds) {
+        const pluginDir = path.join(bundledRoot, pluginId);
+        await mkdir(pluginDir, { recursive: true });
+        await writeFile(
+          path.join(pluginDir, "openclaw.plugin.json"),
+          JSON.stringify({
+            id: pluginId,
+            providers: [pluginId],
+            activation: { onStartup: false, onProviders: [pluginId] },
+            configSchema: { type: "object", additionalProperties: false },
+          }),
+        );
+        await writeFile(
+          path.join(pluginDir, "index.js"),
+          `module.exports = {
+        id: ${JSON.stringify(pluginId)},
+        register(api) {
+          api.registerProvider({
+            id: ${JSON.stringify(pluginId)}, label: "Selected provider", auth: [],
+            resolveSyntheticAuth: () => ({ apiKey: "cron-fixture", source: "fixture", mode: "api-key" }),
+            transformSystemPrompt: ({ systemPrompt }) => systemPrompt + "\\n" + ${JSON.stringify(`PROVIDER_HOOK_${pluginId}`)},
+          });
+        },
+      };\n`,
+        );
+      }
       const server = await startMockModelServer("unavailable");
       modelServers.push(server);
       const model = (id: string) => ({
@@ -314,12 +318,25 @@ describe("plugin cron registry ownership e2e", () => {
         maxTokens: 4_096,
       });
       const config: OpenClawConfig = {
-        plugins: { entries: { [pluginId]: { enabled: true } }, slots: { memory: "none" } },
+        plugins: {
+          entries: Object.fromEntries(pluginIds.map((id) => [id, { enabled: true }])),
+          slots: { memory: "none" },
+        },
         agents: {
           defaults: {
             workspace: path.join(fixtureDir, "workspace"),
             model: { primary: "cron-owner/default" },
             skills: [],
+            ...(route === "subagent"
+              ? {
+                  subagents: {
+                    model: {
+                      primary: `${provider}/unavailable`,
+                      fallbacks: [`${fallbackProvider}/available`],
+                    },
+                  },
+                }
+              : {}),
           },
           entries: { main: { model: { primary: "cron-owner/agent-default" } } },
         },
@@ -338,7 +355,13 @@ describe("plugin cron registry ownership e2e", () => {
               baseUrl: `${server.baseUrl}/v1`,
               api: "openai-responses",
               request: { allowPrivateNetwork: true },
-              models: [model("unavailable"), model("available")],
+              models: [model("unavailable")],
+            },
+            [fallbackProvider]: {
+              baseUrl: `${server.baseUrl}/v1`,
+              api: "openai-responses",
+              request: { allowPrivateNetwork: true },
+              models: [model("available")],
             },
           },
         },
@@ -356,6 +379,24 @@ describe("plugin cron registry ownership e2e", () => {
         },
       });
       instances.push(instance);
+      const sessionKey = "agent:main:subagent:provider-fallback";
+      if (route === "subagent") {
+        instance.state.applyEnv();
+        await upsertSessionEntry({
+          agentId: "main",
+          sessionKey,
+          entry: {
+            sessionId: randomUUID(),
+            updatedAt: Date.now(),
+            providerOverride: provider,
+            modelOverride: "unavailable",
+            modelOverrideSource: "auto",
+            modelOverrideFallbackOriginProvider: provider,
+            modelOverrideFallbackOriginModel: "unavailable",
+          },
+        });
+        closeOpenClawAgentDatabasesForTest();
+      }
       await instance.startGateway();
       const client = await connectGatewayClient({
         url: instance.url,
@@ -363,47 +404,65 @@ describe("plugin cron registry ownership e2e", () => {
       });
       let jobId: string | undefined;
       try {
-        const job = await client.request<{ id: string }>("cron.add", {
-          name: "Selected provider fallback",
-          agentId: "main",
-          enabled: true,
-          schedule: { kind: "at", at: new Date(Date.now() + 3_600_000).toISOString() },
-          sessionTarget: "isolated",
-          wakeMode: "now",
-          delivery: { mode: "none" },
-          payload: {
-            kind: "agentTurn",
-            message: "Prove the selected provider runtime.",
-            model: `${provider}/unavailable`,
-            fallbacks: [`${provider}/available`],
-          },
-        });
-        jobId = job.id;
-        const run = await client.request<{ runId: string }>("cron.run", {
-          id: jobId,
-          mode: "force",
-        });
-        let terminal: { status?: string; summary?: string; error?: string } | undefined;
-        await expect
-          .poll(async () => {
-            const history = await client.request<{
-              entries: Array<{ status?: string; summary?: string; error?: string }>;
-            }>("cron.runs", { id: jobId, runId: run.runId, limit: 1 });
-            terminal = history.entries[0];
-            return terminal?.status;
-          }, WAIT_OPTIONS)
-          .toBeDefined();
-        expect(terminal?.error).toBeUndefined();
-        expect(terminal).toMatchObject({
-          status: "ok",
-          summary: expect.stringContaining("CRON_OWNER_RESPONSE_"),
-        });
+        if (route === "subagent") {
+          expect(
+            await client.request(
+              "agent",
+              {
+                sessionKey,
+                idempotencyKey: randomUUID(),
+                message: "Prove the selected provider runtime.",
+                deliver: false,
+                timeout: 45,
+              },
+              { expectFinal: true, timeoutMs: 45_000 },
+            ),
+          ).toMatchObject({
+            status: "ok",
+            result: { payloads: [{ text: expect.stringContaining("CRON_OWNER_RESPONSE_") }] },
+          });
+        } else {
+          const job = await client.request<{ id: string }>("cron.add", {
+            name: "Selected provider fallback",
+            agentId: "main",
+            enabled: true,
+            schedule: { kind: "at", at: new Date(Date.now() + 3_600_000).toISOString() },
+            sessionTarget: "isolated",
+            wakeMode: "now",
+            delivery: { mode: "none" },
+            payload: {
+              kind: "agentTurn",
+              message: "Prove the selected provider runtime.",
+              model: `${provider}/unavailable`,
+              fallbacks: [`${fallbackProvider}/available`],
+            },
+          });
+          jobId = job.id;
+          const run = await client.request<{ runId: string }>("cron.run", {
+            id: jobId,
+            mode: "force",
+          });
+          let terminal: { status?: string; summary?: string; error?: string } | undefined;
+          await expect
+            .poll(async () => {
+              const history = await client.request<{
+                entries: Array<{ status?: string; summary?: string; error?: string }>;
+              }>("cron.runs", { id: jobId, runId: run.runId, limit: 1 });
+              terminal = history.entries[0];
+              return terminal?.status;
+            }, WAIT_OPTIONS)
+            .toBeDefined();
+          expect(terminal?.error).toBeUndefined();
+          expect(terminal).toMatchObject({
+            status: "ok",
+            summary: expect.stringContaining("CRON_OWNER_RESPONSE_"),
+          });
+        }
         const models = server.requests.map(({ body }) => body.model);
         expect(models).toContain("unavailable");
         expect(models.at(-1)).toBe("available");
-        expect(
-          server.requests.every((request) => requestText(request).includes(providerMarker)),
-        ).toBe(true);
+        expect(requestText(server.requests[0]!)).toContain(`PROVIDER_HOOK_${provider}`);
+        expect(requestText(server.requests.at(-1)!)).toContain(`PROVIDER_HOOK_${fallbackProvider}`);
       } finally {
         if (jobId) await client.request("cron.remove", { id: jobId });
         await disconnectGatewayClient(client);


### PR DESCRIPTION
## What this fixes

A resumed session could select a trusted runtime harness absent from Gateway startup and fail before execution. The same ownership gap affects selected providers and fallbacks in replies and scheduled turns. Prepare those owners before admission freezes the selected generation, then carry that exact lease through execution and cleanup. Concurrent selections remain isolated; nested work can borrow only owners already contained in an open, matching parent lease. Published inbound registry metadata stays unchanged.

Cron now acquires one lease during preparation using the executor’s per-agent configuration projection. The duplicate late acquisition and obsolete generation-scope wrapper are removed. Explicitly disabled or untrusted plugins remain unavailable.

The configured runtime owner also inventories the canonical subagent primary/fallback chain alongside ordinary configured candidates. Automatic subagent sessions can choose that separate chain after admission; ordinary fallbacks already worked. Execution policy still narrows user overrides and locked selections, and the strict borrowed-generation guard is unchanged. Copying session policy into outer admission would use stale state after queue waits.

Acceptance testing exposed another owner-boundary defect: the first `chat.abort` loaded unrelated chat history/send workflows before reaching cancellation. It now lazily dispatches directly to the existing abort handler. The old chat-map entry and single-use service wrapper are deleted; wire method, permissions, descriptor order, profile gate, and cancellation policy are unchanged. The auth-refresh fixture now captures the actual selected lease before ACK, proves it survives refresh, and proves the next lease is newer. It also records first-frame receipt directly and drains every RPC listener.

## Evidence

- Before/after reproduction: the published owner failed automatic subagent fallback with a superseded-generation error. The repair passes real Gateway RPCs using two distinct lazy provider plugins, retryable primary HTTP 503, persisted automatic-selection provenance, provider-specific prompt hooks, and the fallback response. A deterministic import-isolation regression fails the old cancellation route and passes the direct route.
- [Final Linux proof](https://github.com/openclaw/openclaw/actions/runs/33279798465): normal frozen install, full build in 3m46.6s, **8 Gateway E2Es passed in 33.53s**. Coverage includes copied-session success and disabled/untrusted rejection, cron and subagent fallback, configured cron harness selection, recurring registry ownership, and cold cancellation. Cancellation requires the exact run ID, actual provider request closure before cleanup, and exactly one provider request. These use local HTTP providers and synthetic trusted harnesses, not authenticated external Codex completion.
- Linux tested tree: `78e0c984952c3717cbb52a461a4a58cef6e4af70`. Complete tracked bytes/paths/modes were guarded through install, build, and tests; both build-stamp checks remained unchanged. The owned lease stopped after completion. The subsequent preintegration commit differed only by one changelog bullet.
- Local ownership proof: **429 passed, 1 existing platform skip across 17 files**. Cancellation/auth/persistence/registry/agent sibling proof: **586 passed across 11 files**. Canonical `check:changed` passed structural, formatting, all three unused-export scans, production/test types, lint, and ownership guards. The final test-only oracle correction also passed focused lint and E2E typechecking.
- One integration rebase onto pinned main `5b532a78ee1f697aeb484104f0aa980501b8fc1b` incorporates known shutdown/clipboard repairs. Among PR-touched paths, only changelog context and inherited pending-work dispatch code changed. Fresh integration proof at `8b56ea1875ecb07f76053f07130eb1c48b46f777`: **128 passed, 7 existing skips across 10 files**, covering generation/fallback, auth refresh, lazy dispatch, suspension/node shutdown, config snapshots, registry diagnostics, state binding, and WAL. Dependency versions and lockfile are unchanged. Upstream state/bootstrap changes mean the retained Linux build is explicitly **preintegration evidence**, not a built test of this rebased head; exact-head hosted CI remains required before landing.
- [The first integrated CI run](https://github.com/openclaw/openclaw/actions/runs/33280554480) exposed three remaining integration failures: a full agent-scope fixture mock omitted newly used canonical policy exports, a direct chat fixture still used the removed chat-family abort entry, and the integrated dispatch file exceeded its existing lint limit. The final closeout at `622760472cc6471f983458c06cb7e0c74ca6b073` removes the full policy mock, uses canonical lazy handler dispatch in the fixture, and combines identical pre-connect/health returns (net −3 production lines). **188 tests passed across 7 files**, including the full 136-case chat suite in its original order and all 8 static-startup cases. The fixture now observes a refresh failure before waiting for hook entry: the same broken-mock error surfaced in **85 ms**, instead of timing out at **120 seconds**. Assertions and timeouts are unchanged. Canonical changed-file gates and a fresh Codex P0–P2 review passed on the final repair.
- A later changelog-only merge conflict suppressed pull-request CI at `622760472cc6471f983458c06cb7e0c74ca6b073`. One justified refresh onto pinned main `4db43443acc1f636550d39fccb3017340cc42c78` resolves that conflict at `b5038f732006a54f69ea24b06c546999340f92fc`: all **45 non-changelog PR files retain identical blobs and modes**, and the 46-path PR scope is unchanged. Fresh focused integration proof passed **185 tests across 6 files in 78.71s**, covering auth ordering, prepared reply metadata and prompt bytes, configured/subagent fallback, WebSocket abort authorization, and pending-node lifecycle. Fresh Codex P0–P2 review found no actionable integration defects. The prior Linux proof remains preintegration; exact-head hosted CI is still required.
- [The next exact-head CI run](https://github.com/openclaw/openclaw/actions/runs/33282242984) passed the runtime repairs but failed two Matrix QA cleanup cases: their test helper tried to rebind a released TCP port, which another worker could already own. Final repair `454f371c1d3922c8135439e95548e0af15709227` replaces that global availability check with the fixture’s recorded fulfillment of the real proxy stop, and deletes the unused helper. A deterministic competing listener reproduces the old false `EADDRINUSE` after confirmed owner closure. Negative controls prove that omitted cleanup still fails the closure assertion and unjoined cleanup still fails the existing ordering assertion. The full canonical QA shard passed **228 files, 3,127 tests, 3 platform skips** on the final patch (279.37s Vitest; 286.34s wrapper). The local macOS private-QA artifact build completed in 4m39.5s before this two-file test-only patch; production bytes are unchanged. Scoped canonical checks, including extension-test types and lint, and fresh Codex P0–P2 review passed. This increment changes **zero production lines** and removes **12 net test/support lines**. [Final exact-head hosted CI](https://github.com/openclaw/openclaw/actions/runs/33283439682) passed on `454f371c1d3922c8135439e95548e0af15709227`: **176 successful jobs, 15 skipped, zero failures**, attempt 1. The retained Linux proof remains explicitly preintegration evidence.
- Direct Codex contract inspection: [`thread.rs:330–415`](https://github.com/openai/codex/blob/90854393966b21e9ebfd21b122334eb09a20c93d/codex-rs/app-server-protocol/src/protocol/v2/thread.rs#L330-L415) and [`thread_processor.rs:3519–3710`](https://github.com/openai/codex/blob/90854393966b21e9ebfd21b122334eb09a20c93d/codex-rs/app-server/src/request_processors/thread_processor.rs#L3519-L3710). The original failure precedes native thread resumption. Final Codex P0–P2 review and independent integration-owner audit found no actionable defects.

## Review closeout and follow-up

ClawSweeper’s latest completed review found the runtime and cancellation repairs correct. Its changelog-removal rank-up move is intentionally skipped: the maintainer explicitly requested these user-facing release-verification fixes in the changelog. All existing main entries are preserved. Its exact-head CI requirement is satisfied by run [33283439682](https://github.com/openclaw/openclaw/actions/runs/33283439682); the production-growth justification is below. The reported persistent-data heuristic points at `src/cron/isolated-agent/run.test-harness.ts`: that diff replaces Vitest registry mocks with prepared-lease snapshots and a mocked release function; it does not change a store or schema.

Named follow-up: **zero-output cancellation is reclassified as blocked failure**. Existing runtime owners record zero-output abort as blocked recovery state, and canonical terminal projection prioritizes blocked. The first cold test run passed 7/8 because its expected undispatched timeout contract was wrong. The corrected test requires the precise existing `error/failed/aborted` result, nested `aborted/blocked` metadata, no runtime error, and provider closure. No global terminal-precedence change or permissive multi-status assertion is included here.

Production: **+299/−201, net +98**; tests/support: **+1231/−355, net +876**; changelog: **+3**. Production growth supplies immutable selected-generation ownership and configured candidate inventory. The final incremental fallback repair is net +12; direct cancellation routing is net −4. Duplicate execution-policy paths and wrappers were removed. This PR adds or changes **zero config, environment, schema, protocol, or migration surfaces**.
