### PR TITLE
fix(plugins): record consent for enabled plugins

### DIFF
--- a/src/cli/plugins-cli.policy.test.ts
+++ b/src/cli/plugins-cli.policy.test.ts
@@ -127,67 +127,26 @@ describe("plugins cli policy mutations", () => {
     });
   });
 
-  it("binds explicit enablement approval to the installed artifact's reviewed surface", async () => {
-    await withTempDir("openclaw-cli-capability-review-", async (rootDir) => {
-      const fixture = createColdPluginFixture({ rootDir, pluginId: "alpha" });
-      const { recordPluginManifestInstallOwner } =
-        await import("../plugins/manifest-install-owner.js");
-      loadPluginManifestRegistryMock.mockReturnValue({
-        plugins: [
-          recordPluginManifestInstallOwner(
-            {
-              id: "alpha",
-              channels: [fixture.channelId],
-              providers: [fixture.providerId],
-              cliBackends: [],
-              skills: [],
-              hooks: [],
-              origin: "global",
-              rootDir,
-              source: fixture.runtimeSource,
-              manifestPath: `${rootDir}/openclaw.plugin.json`,
-            },
-            "alpha",
-          ),
-        ],
-        diagnostics: [],
-      });
-      const sourceConfig = {
-        plugins: { entries: { alpha: { enabled: false } } },
-      } as OpenClawConfig;
-      pluginCliConfigMock.mockReturnValue(sourceConfig);
-      setInstalledPluginIndexInstallRecords({
-        alpha: { source: "npm", spec: "@acme/alpha", installPath: rootDir },
-      });
-      mockPluginRegistry(["alpha"]);
-
-      await runPluginsCommand(["plugins", "enable", "alpha", "--accept-capabilities"]);
-
-      const { resolvePluginArtifactDeclaredSurface } =
-        await import("../plugins/capability-consent.js");
-      const { computeDeclaredSurfaceHash } = await import("../plugins/capability-summary.js");
-      const acceptedRecord =
-        writePersistedInstalledPluginIndexInstallRecordsWithLeaseMock.mock.calls[0]?.[0]?.alpha;
-      expect(acceptedRecord?.acceptedSurfaceHash).toBe(
-        computeDeclaredSurfaceHash(resolvePluginArtifactDeclaredSurface(rootDir)),
-      );
-      expect(replaceConfigFileMock).toHaveBeenCalledOnce();
-      expect(promptYesNoMock).not.toHaveBeenCalled();
-    });
-  });
-
   it.each([
     {
+      name: "binds explicit approval for a disabled installed plugin",
+      enabled: false,
+      commandArgs: ["plugins", "enable", "alpha", "--accept-capabilities"],
+      expectsConsent: true,
+    },
+    {
       name: "records explicit capability consent for an already-enabled installed plugin",
+      enabled: true,
       commandArgs: ["plugins", "enable", "alpha", "--accept-capabilities"],
       expectsConsent: true,
     },
     {
       name: "preserves no-option re-enable compatibility for an already-enabled installed plugin",
+      enabled: true,
       commandArgs: ["plugins", "enable", "alpha"],
       expectsConsent: false,
     },
-  ])("$name", async ({ commandArgs, expectsConsent }) => {
+  ])("$name", async ({ commandArgs, enabled, expectsConsent }) => {
     await withTempDir("openclaw-cli-capability-consent-enabled-", async (rootDir) => {
       const fixture = createColdPluginFixture({ rootDir, pluginId: "alpha" });
       const { recordPluginManifestInstallOwner } =
@@ -213,14 +172,14 @@ describe("plugins cli policy mutations", () => {
         diagnostics: [],
       });
       const sourceConfig = {
-        plugins: { entries: { alpha: { enabled: true } } },
+        plugins: { entries: { alpha: { enabled } } },
       } as OpenClawConfig;
       pluginCliConfigMock.mockReturnValue(sourceConfig);
       setInstalledPluginIndexInstallRecords({
         alpha: { source: "npm", spec: "@acme/alpha", installPath: rootDir },
       });
       buildPluginRegistrySnapshotReportMock.mockReturnValue({
-        plugins: [{ id: "alpha", enabled: true }],
+        plugins: [{ id: "alpha", enabled }],
         diagnostics: [],
         registrySource: "derived",
         registryDiagnostics: [],

--- a/src/cli/plugins-cli.policy.test.ts
+++ b/src/cli/plugins-cli.policy.test.ts
@@ -176,6 +176,60 @@ describe("plugins cli policy mutations", () => {
     });
   });
 
+  it("records explicit capability consent for an already-enabled installed plugin", async () => {
+    await withTempDir("openclaw-cli-capability-consent-enabled-", async (rootDir) => {
+      const fixture = createColdPluginFixture({ rootDir, pluginId: "alpha" });
+      const { recordPluginManifestInstallOwner } =
+        await import("../plugins/manifest-install-owner.js");
+      loadPluginManifestRegistryMock.mockReturnValue({
+        plugins: [
+          recordPluginManifestInstallOwner(
+            {
+              id: "alpha",
+              channels: [fixture.channelId],
+              providers: [fixture.providerId],
+              cliBackends: [],
+              skills: [],
+              hooks: [],
+              origin: "global",
+              rootDir,
+              source: fixture.runtimeSource,
+              manifestPath: `${rootDir}/openclaw.plugin.json`,
+            },
+            "alpha",
+          ),
+        ],
+        diagnostics: [],
+      });
+      const sourceConfig = {
+        plugins: { entries: { alpha: { enabled: true } } },
+      } as OpenClawConfig;
+      pluginCliConfigMock.mockReturnValue(sourceConfig);
+      setInstalledPluginIndexInstallRecords({
+        alpha: { source: "npm", spec: "@acme/alpha", installPath: rootDir },
+      });
+      buildPluginRegistrySnapshotReportMock.mockReturnValue({
+        plugins: [{ id: "alpha", enabled: true }],
+        diagnostics: [],
+        registrySource: "derived",
+        registryDiagnostics: [],
+      });
+
+      await runPluginsCommand(["plugins", "enable", "alpha", "--accept-capabilities"]);
+
+      const { resolvePluginArtifactDeclaredSurface } =
+        await import("../plugins/capability-consent.js");
+      const { computeDeclaredSurfaceHash } = await import("../plugins/capability-summary.js");
+      const acceptedRecord =
+        writePersistedInstalledPluginIndexInstallRecordsWithLeaseMock.mock.calls[0]?.[0]?.alpha;
+      expect(acceptedRecord?.acceptedSurfaceHash).toBe(
+        computeDeclaredSurfaceHash(resolvePluginArtifactDeclaredSurface(rootDir)),
+      );
+      expect(replaceConfigFileMock).toHaveBeenCalledOnce();
+      expect(promptYesNoMock).not.toHaveBeenCalled();
+    });
+  });
+
   it.each([
     {
       policy: "globally disabled plugins",

--- a/src/cli/plugins-cli.policy.test.ts
+++ b/src/cli/plugins-cli.policy.test.ts
@@ -176,7 +176,18 @@ describe("plugins cli policy mutations", () => {
     });
   });
 
-  it("records explicit capability consent for an already-enabled installed plugin", async () => {
+  it.each([
+    {
+      name: "records explicit capability consent for an already-enabled installed plugin",
+      commandArgs: ["plugins", "enable", "alpha", "--accept-capabilities"],
+      expectsConsent: true,
+    },
+    {
+      name: "preserves no-option re-enable compatibility for an already-enabled installed plugin",
+      commandArgs: ["plugins", "enable", "alpha"],
+      expectsConsent: false,
+    },
+  ])("$name", async ({ commandArgs, expectsConsent }) => {
     await withTempDir("openclaw-cli-capability-consent-enabled-", async (rootDir) => {
       const fixture = createColdPluginFixture({ rootDir, pluginId: "alpha" });
       const { recordPluginManifestInstallOwner } =
@@ -215,16 +226,22 @@ describe("plugins cli policy mutations", () => {
         registryDiagnostics: [],
       });
 
-      await runPluginsCommand(["plugins", "enable", "alpha", "--accept-capabilities"]);
+      await runPluginsCommand(commandArgs);
 
       const { resolvePluginArtifactDeclaredSurface } =
         await import("../plugins/capability-consent.js");
       const { computeDeclaredSurfaceHash } = await import("../plugins/capability-summary.js");
-      const acceptedRecord =
-        writePersistedInstalledPluginIndexInstallRecordsWithLeaseMock.mock.calls[0]?.[0]?.alpha;
-      expect(acceptedRecord?.acceptedSurfaceHash).toBe(
-        computeDeclaredSurfaceHash(resolvePluginArtifactDeclaredSurface(rootDir)),
-      );
+      if (expectsConsent) {
+        const acceptedRecord =
+          writePersistedInstalledPluginIndexInstallRecordsWithLeaseMock.mock.calls[0]?.[0]?.alpha;
+        expect(acceptedRecord?.acceptedSurfaceHash).toBe(
+          computeDeclaredSurfaceHash(resolvePluginArtifactDeclaredSurface(rootDir)),
+        );
+      } else {
+        expect(
+          writePersistedInstalledPluginIndexInstallRecordsWithLeaseMock,
+        ).not.toHaveBeenCalled();
+      }
       expect(replaceConfigFileMock).toHaveBeenCalledOnce();
       expect(promptYesNoMock).not.toHaveBeenCalled();
     });

--- a/src/cli/plugins-cli.runtime.ts
+++ b/src/cli/plugins-cli.runtime.ts
@@ -220,27 +220,24 @@ async function runPluginsEnableCommandUnlocked(
     );
     return defaultRuntime.exit(1);
   }
-  if (!plugin.enabled) {
-    const { resolvePluginCapabilityConsent } = await import("../plugins/capability-consent.js");
-    const { ManagedPluginLifecycleError } =
-      await import("../plugins/management-lifecycle-error.js");
-    const consent = resolvePluginCapabilityConsentCliOptions({
-      acceptCapabilities: opts.acceptCapabilities,
-      action: "enable",
+  const { resolvePluginCapabilityConsent } = await import("../plugins/capability-consent.js");
+  const { ManagedPluginLifecycleError } = await import("../plugins/management-lifecycle-error.js");
+  const consent = resolvePluginCapabilityConsentCliOptions({
+    acceptCapabilities: opts.acceptCapabilities,
+    action: "enable",
+  });
+  try {
+    await resolvePluginCapabilityConsent({
+      config: cfg,
+      pluginId: id,
+      ...consent,
     });
-    try {
-      await resolvePluginCapabilityConsent({
-        config: cfg,
-        pluginId: id,
-        ...consent,
-      });
-    } catch (error) {
-      if (!(error instanceof ManagedPluginLifecycleError) || !error.capabilityConsent) {
-        throw error;
-      }
-      defaultRuntime.error(error.message);
-      return defaultRuntime.exit(1);
+  } catch (error) {
+    if (!(error instanceof ManagedPluginLifecycleError) || !error.capabilityConsent) {
+      throw error;
     }
+    defaultRuntime.error(error.message);
+    return defaultRuntime.exit(1);
   }
 
   const { applySlotSelectionForPlugin } = await loadPluginSlotSelection();

--- a/src/cli/plugins-cli.runtime.ts
+++ b/src/cli/plugins-cli.runtime.ts
@@ -220,24 +220,27 @@ async function runPluginsEnableCommandUnlocked(
     );
     return defaultRuntime.exit(1);
   }
-  const { resolvePluginCapabilityConsent } = await import("../plugins/capability-consent.js");
-  const { ManagedPluginLifecycleError } = await import("../plugins/management-lifecycle-error.js");
-  const consent = resolvePluginCapabilityConsentCliOptions({
-    acceptCapabilities: opts.acceptCapabilities,
-    action: "enable",
-  });
-  try {
-    await resolvePluginCapabilityConsent({
-      config: cfg,
-      pluginId: id,
-      ...consent,
+  if (!plugin.enabled || opts.acceptCapabilities) {
+    const { resolvePluginCapabilityConsent } = await import("../plugins/capability-consent.js");
+    const { ManagedPluginLifecycleError } =
+      await import("../plugins/management-lifecycle-error.js");
+    const consent = resolvePluginCapabilityConsentCliOptions({
+      acceptCapabilities: opts.acceptCapabilities,
+      action: "enable",
     });
-  } catch (error) {
-    if (!(error instanceof ManagedPluginLifecycleError) || !error.capabilityConsent) {
-      throw error;
+    try {
+      await resolvePluginCapabilityConsent({
+        config: cfg,
+        pluginId: id,
+        ...consent,
+      });
+    } catch (error) {
+      if (!(error instanceof ManagedPluginLifecycleError) || !error.capabilityConsent) {
+        throw error;
+      }
+      defaultRuntime.error(error.message);
+      return defaultRuntime.exit(1);
     }
-    defaultRuntime.error(error.message);
-    return defaultRuntime.exit(1);
   }
 
   const { applySlotSelectionForPlugin } = await loadPluginSlotSelection();


### PR DESCRIPTION
## What Problem This Solves

`openclaw plugins enable <id> --accept-capabilities` returned success for an already-enabled managed plugin but did not record the plugin's outstanding capability consent.

## Root Cause

The CLI invoked the existing consent owner only when the plugin was disabled. The explicit acceptance option was therefore ignored when the plugin was already enabled.

## Fix

Run the same artifact-bound consent owner when the plugin is disabled or the operator explicitly supplies `--accept-capabilities`. Keep policy rejection and ordinary no-option re-enable behavior unchanged.

The regression cases share one table-driven fixture for disabled explicit acceptance, enabled explicit acceptance, and enabled no-option compatibility.

## Evidence

- Exact-main built CLI at `e1cf606abea9676a3333d8915e8277777ef2f570`: a disposable linked managed plugin was already enabled, its consent fields were cleared from disposable SQLite state, and explicit acceptance exited 0 without restoring the consent hash.
- Current main later advanced to `df29979405b` without changes to the CLI consent branch, consent owner, or regression-test owner.
- Exact-head built CLI at `d6bad802fd4f25f4cc5f3bc124716de28ab8ec1b`: the same flow restored the artifact-declared surface hash `38d65bbe36e275e7a91fb3c8f07a52ea18d0e710129854371ad94a7e744ea43e`.
- No-option re-enable exited 0 and left consent absent on both revisions.
- Duplicate explicit acceptance exited 0 and kept the same hash on the repaired head.
- Reverting only the production predicate made the new regression fail with an absent consent hash while the other 16 policy cases passed.
- Focused verification passed: 17 CLI policy tests and 34 plugin consent and SQLite commit-owner tests.
- Formatting, focused lint, conflict-marker checks, and coercion-helper guards passed.

## Scope

- Production: `+1/-1`; no schema, default, policy, or persistence-contract change.
- Tests: `+40/-10`; duplicate fixture setup was consolidated.
- AI-assisted: yes; implemented, tested, and behavior-proven with Codex.
