### PR TITLE
fix(compaction): keep latest ask canonical

### DIFF
--- a/src/agents/agent-hooks/compaction-safeguard-quality.ts
+++ b/src/agents/agent-hooks/compaction-safeguard-quality.ts
@@ -146,6 +146,11 @@ function parsePendingUserAskSections(summary: string): string[] {
     .map((section) => section.split(/^##[ \t]+\S.*$/mu, 1)[0]?.trim() ?? "");
 }
 
+function extractLeadingPendingAskLine(summary: string): string {
+  const pendingAskSection = parsePendingUserAskSections(summary).at(-1) ?? "";
+  return pendingAskSection.split(/\r?\n/u).find((line) => line.trim().length > 0) ?? "";
+}
+
 /**
  * Plan truncation that keeps the audit facts and lets everything else shrink.
  * Only the headings, the bounded latest-ask context, and the audited source
@@ -171,10 +176,6 @@ export function createSummaryQualityRetentionPlan(
     return null;
   }
   const enforceIdentifiers = (params.identifierPolicy ?? "strict") === "strict";
-  const auditSummary = params.auditSummary ?? summary;
-  if (!hasAskOverlap(auditSummary, params.latestAsk)) {
-    return null;
-  }
   const requiredAskContext = params.requiredAskContext?.trim() ?? "";
   const auditedIdentifiers = enforceIdentifiers ? params.identifiers : [];
   const marker = truncatedMarker.trim();
@@ -194,6 +195,10 @@ export function createSummaryQualityRetentionPlan(
   const bodyHasIdentifiers = auditedIdentifiers.every((identifier) =>
     summaryIncludesIdentifier(summary, identifier),
   );
+  const bodyHasRequiredAskContext = !requiredAskContext || summary.includes(requiredAskContext);
+  const bodyHasCanonicalAsk = params.latestAskCompleted
+    ? bodyHasRequiredAskContext
+    : hasAskOverlap(extractLeadingPendingAskLine(summary), params.latestAsk);
   const renderSections = (sectionContents: string[]) =>
     REQUIRED_SUMMARY_SECTIONS.map((heading, index) => {
       const content = sectionContents[index];
@@ -204,8 +209,13 @@ export function createSummaryQualityRetentionPlan(
     if (!tail) {
       return optional;
     }
-    if (index === PENDING_ASK_SECTION_INDEX && optional.includes(tail)) {
-      return optional;
+    if (index === PENDING_ASK_SECTION_INDEX) {
+      const leadingAsk = extractLeadingPendingAskLine(
+        `${REQUIRED_SUMMARY_SECTIONS[PENDING_ASK_SECTION_INDEX]}\n${optional}`,
+      );
+      return hasAskOverlap(leadingAsk, params.latestAsk)
+        ? optional
+        : [tail, optional].filter(Boolean).join("\n");
     }
     if (index === EXACT_IDENTIFIERS_SECTION_INDEX) {
       const missing = auditedIdentifiers.filter(
@@ -238,12 +248,12 @@ export function createSummaryQualityRetentionPlan(
 
   return {
     minimumChars: minimumSummary.length,
-    needsRebuild: (maxChars) => !bodyHasIdentifiers || !protectedWithinCap(maxChars),
+    needsRebuild: (maxChars) =>
+      !bodyHasIdentifiers || !bodyHasCanonicalAsk || !protectedWithinCap(maxChars),
     render(maxChars) {
-      const bodyHasRequiredAskContext = !requiredAskContext || summary.includes(requiredAskContext);
       if (
         summary.length <= maxChars &&
-        bodyHasRequiredAskContext &&
+        bodyHasCanonicalAsk &&
         bodyHasIdentifiers &&
         protectedWithinCap(maxChars)
       ) {
@@ -438,7 +448,17 @@ export function auditSummaryQuality(params: {
       reasons.push(`missing_identifiers:${missingIdentifiers.slice(0, 3).join(",")}`);
     }
   }
-  if (!hasAskOverlap(params.summary, params.latestAsk)) {
+  if (!params.latestAskCompleted) {
+    const pendingAskSections = parsePendingUserAskSections(params.structuralSummary);
+    const pendingAsks = pendingAskSections.at(-1) ?? "";
+    if (!hasAskOverlap(pendingAsks, params.latestAsk)) {
+      reasons.push("latest_user_ask_not_reflected");
+    } else if (
+      !hasAskOverlap(extractLeadingPendingAskLine(params.structuralSummary), params.latestAsk)
+    ) {
+      reasons.push("latest_user_ask_not_leading_in_pending_asks");
+    }
+  } else if (!hasAskOverlap(params.summary, params.latestAsk)) {
     reasons.push("latest_user_ask_not_reflected");
   }
   if (params.latestAskCompleted) {

--- a/src/agents/agent-hooks/compaction-safeguard.test.ts
+++ b/src/agents/agent-hooks/compaction-safeguard.test.ts
@@ -725,7 +725,7 @@ describe("compaction-safeguard summary budgets", () => {
 
     expect(finalized.summary.length).toBeLessThanOrEqual(MAX_COMPACTION_SUMMARY_CHARS);
     expect(finalized.structuralSummary).toContain(
-      `## Pending user asks\nContinue the active work.\n${latestAsk}`,
+      `## Pending user asks\n${latestAsk}\nContinue the active work.`,
     );
     expect(
       auditSummaryQuality({ summary: finalized.summary, identifiers: [identifier], latestAsk }).ok,
@@ -1457,6 +1457,32 @@ describe("compaction-safeguard recent-turn preservation", () => {
 
     expect(quality.ok).toBe(false);
     expect(quality.reasons).toContain("missing_section:## Decisions");
+  });
+
+  it("rejects a superseded task foregrounded ahead of the latest pending ask", () => {
+    const latestAsk = "diagnose why the scheduled session reset did not occur";
+    const quality = auditSummaryQuality({
+      summary: [
+        "## Decisions",
+        `The user switched to: ${latestAsk}.`,
+        "## Open TODOs",
+        "Continue removing the retired agents.",
+        "## Constraints/Rules",
+        "Preserve unrelated work.",
+        "## Pending user asks",
+        "Remove the retired agents.",
+        latestAsk,
+        "## Exact identifiers",
+        "None.",
+      ].join("\n"),
+      identifiers: [],
+      latestAsk,
+    });
+
+    expect(quality).toEqual({
+      ok: false,
+      reasons: ["latest_user_ask_not_leading_in_pending_asks"],
+    });
   });
 
   it("does not enforce identifier retention when policy is off", () => {


### PR DESCRIPTION
## What Problem This Solves

After context compaction, an older pending task can remain foregrounded ahead of the user's latest active request. That can cause the resumed agent to continue superseded work.

## Why This Change Was Made

- Treat the leading non-empty line in `Pending user asks` as the canonical active request.
- Rebuild retained summaries when that leading request does not overlap the latest unfinished ask.
- Keep completed asks eligible for evidence elsewhere in the summary.
- Add regression coverage for a superseded task appearing before the latest pending ask.

## User Impact

Compacted sessions resume the user's latest unfinished request instead of an older superseded task.

## Evidence

Exact head: `1819620cefa15fb6b031565fbe3402957ba251b2`

Changed paths:
- `src/agents/agent-hooks/compaction-safeguard-quality.ts`
- `src/agents/agent-hooks/compaction-safeguard.test.ts`

Validation:
- `corepack pnpm exec vitest run src/agents/agent-hooks/compaction-safeguard.test.ts` — PASS (2 files, 298 tests)

Risk is limited to ordering and auditing unfinished asks in generated compaction summaries. Rollback is reverting commit `1819620cefa15fb6b031565fbe3402957ba251b2`.

Implementer: Forge

Kim: not run in this publication lane.

Jason: not required; no secrets, auth, infrastructure, deployment, migration, or production configuration changes.

## Worked on by

- Forge
