### PR TITLE
fix(subagents): preserve media in direct completion fallback

### DIFF
--- a/extensions/qa-lab/src/providers/mock-openai/mock-openai-contracts.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/mock-openai-contracts.ts
@@ -295,6 +295,10 @@ export const QA_WHATSAPP_REPLY_TO_BOT_TRIGGER_MARKER_RE =
 export const QA_WHATSAPP_BATCHED_FINAL_MARKER_RE = /\bWHATSAPP_QA_BATCHED_FINAL_([A-Z0-9]+)\b/u;
 export const QA_SUBAGENT_DIRECT_FALLBACK_PROMPT_RE = /subagent direct fallback qa check/i;
 export const QA_SUBAGENT_DIRECT_FALLBACK_WORKER_RE = /subagent direct fallback worker/i;
+export const QA_SUBAGENT_DIRECT_MEDIA_FALLBACK_PROMPT_RE =
+  /subagent direct fallback media qa check:[\s\S]*?media path:\s*(\S+)/i;
+export const QA_SUBAGENT_DIRECT_MEDIA_FALLBACK_WORKER_RE =
+  /subagent direct fallback media worker:[\s\S]*?media path:\s*(\S+)/i;
 // A subagent that yields on its own behalf, then finishes on a later follow-up
 // dispatched to the same paused child session. The worker regex must not match
 // the follow-up text, so the two turns carry deliberately disjoint wording: the
@@ -329,6 +333,7 @@ export function isStrandedFinalRetryFailureRequest(allInputText: string): boolea
   );
 }
 export const QA_SUBAGENT_DIRECT_FALLBACK_MARKER = "QA-SUBAGENT-DIRECT-FALLBACK-OK";
+export const QA_SUBAGENT_DIRECT_MEDIA_FALLBACK_MARKER = "QA-SUBAGENT-DIRECT-MEDIA-FALLBACK-OK";
 export const QA_SUBAGENT_SELF_YIELD_MARKER = "QA-SUBAGENT-SELF-YIELD-FOLLOW-UP-OK";
 export const QA_SUBAGENT_TERMINAL_MARKERS = {
   visible: "QA-SUBAGENT-TERMINAL-VISIBLE-OK",

--- a/extensions/qa-lab/src/providers/mock-openai/server.test.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/server.test.ts
@@ -3311,6 +3311,41 @@ Update and merge these partial structured summaries.`,
     expect(yieldDebug.plannedToolName).toBe("sessions_yield");
   });
 
+  it("drives a media-bearing subagent through the direct fallback", async () => {
+    const server = await startMockServer();
+    const mediaPath = "/tmp/qa-direct-media-fallback.png";
+    const prompt = ["Subagent direct fallback media QA check:", `media path: ${mediaPath}`].join(
+      "\n",
+    );
+
+    await expectResponsesText(server, {
+      stream: true,
+      tools: [SESSIONS_SPAWN_TOOL, SESSIONS_YIELD_TOOL],
+      input: [makeUserInput(prompt)],
+    });
+    const spawnDebug = requireRecord(
+      await (await fetch(`${server.baseUrl}/debug/last-request`)).json(),
+      "media spawn debug request",
+    );
+    expect(spawnDebug.plannedToolName).toBe("sessions_spawn");
+    expect(requireRecord(spawnDebug.plannedToolArgs, "media spawn args")).toMatchObject({
+      task: `Subagent direct fallback media worker: media path: ${mediaPath}`,
+      label: "qa-direct-media-fallback-worker",
+      thread: false,
+      mode: "run",
+    });
+
+    const worker = await expectOpenAiNonStreamingResponsesJson(server, {
+      input: [makeUserInput(`Subagent direct fallback media worker: media path: ${mediaPath}`)],
+    });
+    expect(outputText(worker)).toBe(`QA-SUBAGENT-DIRECT-MEDIA-FALLBACK-OK\nMEDIA:${mediaPath}`);
+
+    const announce = await expectOpenAiNonStreamingResponsesJson(server, {
+      input: [makeUserInput("QA-SUBAGENT-DIRECT-MEDIA-FALLBACK-OK")],
+    });
+    expect(outputText(announce)).toBe("NO_REPLY");
+  });
+
   it("returns no visible announce output for the direct fallback QA marker", async () => {
     const server = await startMockServer();
 

--- a/extensions/qa-lab/src/providers/mock-openai/server.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/server.ts
@@ -73,6 +73,8 @@ import {
   QA_WHATSAPP_AGENT_MESSAGE_ACTION_UPLOAD_PROMPT_RE,
   QA_SUBAGENT_DIRECT_FALLBACK_PROMPT_RE,
   QA_SUBAGENT_DIRECT_FALLBACK_WORKER_RE,
+  QA_SUBAGENT_DIRECT_MEDIA_FALLBACK_PROMPT_RE,
+  QA_SUBAGENT_DIRECT_MEDIA_FALLBACK_WORKER_RE,
   QA_SUBAGENT_SELF_YIELD_FOLLOW_UP_RE,
   QA_SUBAGENT_SELF_YIELD_WORKER_RE,
   QA_SUBAGENT_TERMINAL_MATRIX_PROMPT_RE,
@@ -81,6 +83,7 @@ import {
   buildStrandedFinalRetryFailureText,
   isStrandedFinalRetryFailureRequest,
   QA_SUBAGENT_DIRECT_FALLBACK_MARKER,
+  QA_SUBAGENT_DIRECT_MEDIA_FALLBACK_MARKER,
   QA_SUBAGENT_SELF_YIELD_MARKER,
   QA_SUBAGENT_TERMINAL_MARKERS,
   QA_SUBAGENT_TERMINAL_METADATA_SENTINEL,
@@ -1237,6 +1240,12 @@ async function buildResponsesPayload(
       );
     }
   }
+  const directMediaFallbackWorker = QA_SUBAGENT_DIRECT_MEDIA_FALLBACK_WORKER_RE.exec(prompt);
+  if (directMediaFallbackWorker?.[1]) {
+    return buildAssistantEvents(
+      `${QA_SUBAGENT_DIRECT_MEDIA_FALLBACK_MARKER}\nMEDIA:${directMediaFallbackWorker[1]}`,
+    );
+  }
   if (QA_SUBAGENT_DIRECT_FALLBACK_WORKER_RE.test(prompt)) {
     return buildAssistantEvents(QA_SUBAGENT_DIRECT_FALLBACK_MARKER);
   }
@@ -1350,6 +1359,23 @@ async function buildResponsesPayload(
     if (hasCompletedToolOutput) {
       // End the requester turn before the delayed worker settles. The terminal
       // result must therefore use the runtime's direct channel fallback.
+      return buildAssistantEvents("NO_REPLY");
+    }
+  }
+  if (allInputText.includes(QA_SUBAGENT_DIRECT_MEDIA_FALLBACK_MARKER)) {
+    return buildAssistantEvents("NO_REPLY");
+  }
+  const directMediaFallback = QA_SUBAGENT_DIRECT_MEDIA_FALLBACK_PROMPT_RE.exec(allInputText);
+  if (directMediaFallback?.[1]) {
+    if (!hasCompletedToolOutput && canCallSessionsSpawn) {
+      return buildToolCallEventsWithArgs("sessions_spawn", {
+        task: `Subagent direct fallback media worker: media path: ${directMediaFallback[1]}`,
+        label: "qa-direct-media-fallback-worker",
+        thread: false,
+        mode: "run",
+      });
+    }
+    if (hasCompletedToolOutput) {
       return buildAssistantEvents("NO_REPLY");
     }
   }

--- a/extensions/qa-lab/src/subagent-direct-media-fallback.e2e.test.ts
+++ b/extensions/qa-lab/src/subagent-direct-media-fallback.e2e.test.ts
@@ -1,0 +1,168 @@
+import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { startQaBusServer } from "./bus-server.js";
+import { createQaBusState } from "./bus-state.js";
+import { createQaGatewayChild } from "./gateway-child.js";
+import { startQaMockOpenAiServer } from "./providers/mock-openai/server.js";
+import { createQaChannelTransport } from "./qa-channel-transport.js";
+
+const COMPLETION_MARKER = "QA-SUBAGENT-DIRECT-MEDIA-FALLBACK-OK";
+const REQUESTER_CONVERSATION = { id: "requester-user", kind: "direct" as const };
+const REPO_ROOT = path.resolve(import.meta.dirname, "../../..");
+const PNG_BYTES = Buffer.from(
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=",
+  "base64",
+);
+
+function sha256(value: Buffer): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+describe("subagent direct media fallback", () => {
+  const cleanups: Array<() => Promise<void>> = [];
+
+  afterEach(async () => {
+    for (const cleanup of cleanups.splice(0).toReversed()) {
+      await cleanup();
+    }
+  });
+
+  it("delivers a worker MEDIA directive through the ephemeral gateway channel", async () => {
+    const state = createQaBusState();
+    const transport = createQaChannelTransport(state);
+    const bus = await startQaBusServer({ state });
+    cleanups.push(() => bus.stop());
+
+    const mock = await startQaMockOpenAiServer();
+    cleanups.push(() => mock.stop());
+
+    const gatewayOwner = createQaGatewayChild();
+    cleanups.push(async () => {
+      expect((await gatewayOwner.stop()).errors).toEqual([]);
+    });
+    const gateway = await gatewayOwner.start({
+      repoRoot: REPO_ROOT,
+      useRepoCli: false,
+      providerBaseUrl: `${mock.baseUrl}/v1`,
+      providerMode: "mock-openai",
+      transport,
+      transportBaseUrl: bus.baseUrl,
+      controlUiEnabled: false,
+    });
+    await transport.waitReady({ gateway });
+
+    const mediaPath = path.join(gateway.workspaceDir, "qa-direct-media-fallback.png");
+    await writeFile(mediaPath, PNG_BYTES);
+    const outboundStartIndex = state
+      .getSnapshot()
+      .messages.filter((message) => message.direction === "outbound").length;
+    await transport.sendInbound({
+      accountId: "default",
+      conversation: REQUESTER_CONVERSATION,
+      senderId: REQUESTER_CONVERSATION.id,
+      text: ["Subagent direct fallback media QA check:", `media path: ${mediaPath}`].join("\n"),
+    });
+
+    let completion;
+    try {
+      completion = await transport.waitForOutbound({
+        conversation: REQUESTER_CONVERSATION,
+        sinceIndex: outboundStartIndex,
+        textIncludes: COMPLETION_MARKER,
+        timeoutMs: 90_000,
+      });
+    } catch (error) {
+      throw new Error(
+        [
+          error instanceof Error ? error.message : String(error),
+          `bus=${JSON.stringify(state.getSnapshot())}`,
+          `gateway=${gateway.logs()}`,
+        ].join("\n"),
+        { cause: error },
+      );
+    }
+
+    expect(completion.text).toBe(COMPLETION_MARKER);
+    expect(completion.conversation).toEqual(REQUESTER_CONVERSATION);
+    expect(completion.attachments).toHaveLength(1);
+    const attachment = completion.attachments?.[0];
+    expect(attachment).toMatchObject({
+      kind: "image",
+      mimeType: "image/png",
+      fileName: "qa-direct-media-fallback.png",
+    });
+    const attachmentBytes = Buffer.from(attachment?.contentBase64 ?? "", "base64");
+    expect(attachmentBytes).toEqual(PNG_BYTES);
+
+    const outbound = state
+      .getSnapshot()
+      .messages.filter((message) => message.direction === "outbound");
+    const visibleCompletions = outbound.filter((message) => message.text === COMPLETION_MARKER);
+    expect(visibleCompletions).toHaveLength(1);
+    const readScenarioRequests = async () => {
+      const requests = (await fetch(`${mock.baseUrl}/debug/requests`).then((response) =>
+        response.json(),
+      )) as Array<{
+        allInputText?: string;
+        plannedToolName?: string;
+      }>;
+      return requests.filter(
+        (request) =>
+          request.allInputText?.includes("direct fallback media") ||
+          request.allInputText?.includes(COMPLETION_MARKER),
+      );
+    };
+    const scenarioRequests = await readScenarioRequests();
+    expect(scenarioRequests).toHaveLength(4);
+    expect(
+      scenarioRequests.filter((request) => request.plannedToolName === "sessions_spawn"),
+    ).toHaveLength(1);
+    expect(
+      scenarioRequests.filter((request) => request.plannedToolName === "sessions_yield"),
+    ).toHaveLength(0);
+    expect(
+      scenarioRequests.filter((request) => request.allInputText?.includes(COMPLETION_MARKER)),
+    ).toHaveLength(1);
+    await transport.waitForNoOutbound({ sinceIndex: outbound.length, quietMs: 1_000 });
+    expect(await readScenarioRequests()).toHaveLength(4);
+
+    const head = execFileSync("git", ["rev-parse", "HEAD"], {
+      cwd: REPO_ROOT,
+      encoding: "utf8",
+    }).trim();
+    const verdict = {
+      schemaVersion: 1,
+      scenario: "subagent-direct-media-fallback",
+      head,
+      status: "pass",
+      channel: "qa-channel",
+      provider: "mock-openai",
+      gateway: "ephemeral",
+      facts: {
+        directConversation: true,
+        caption: completion.text,
+        visibleCompletions: visibleCompletions.length,
+        attachmentCount: completion.attachments?.length ?? 0,
+        attachmentKind: attachment?.kind,
+        attachmentMimeType: attachment?.mimeType,
+        attachmentFileName: attachment?.fileName,
+        attachmentBytes: attachmentBytes.length,
+        attachmentSha256: sha256(attachmentBytes),
+        sourceSha256: sha256(PNG_BYTES),
+        attachmentContentMatches: attachmentBytes.equals(PNG_BYTES),
+        providerRequests: scenarioRequests.length,
+      },
+    };
+    const verdictPath = path.join(
+      REPO_ROOT,
+      ".artifacts/qa-e2e/subagent-direct-media-fallback",
+      head,
+      "verdict.json",
+    );
+    await mkdir(path.dirname(verdictPath), { recursive: true });
+    await writeFile(verdictPath, `${JSON.stringify(verdict, null, 2)}\n`, "utf8");
+  }, 180_000);
+});

--- a/src/agents/subagents/announce/subagent-announce-completion-delivery.ts
+++ b/src/agents/subagents/announce/subagent-announce-completion-delivery.ts
@@ -3,7 +3,9 @@
  */
 import { sanitizePendingFinalDeliveryText } from "../../../auto-reply/reply/pending-final-delivery.js";
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
+import { normalizeOutboundReplyPayloadCore } from "../../../infra/outbound/reply-payload-normalize.js";
 import { sourceDeliveryTargetsMatch } from "../../../infra/outbound/source-delivery-plan.js";
+import { splitMediaFromOutput } from "../../../media/parse.js";
 import { deriveSessionChatTypeFromKey } from "../../../sessions/session-chat-type-shared.js";
 import { isNonTerminalAgentRunStatus } from "../../../shared/agent-run-status.js";
 import { sanitizeAgentRunTerminalReplyText } from "../../agent-run-terminal-reply.js";
@@ -13,6 +15,7 @@ import {
   hasUnaccountedMessagingToolAggregateEvidence,
   resolveExplicitFinalSourceReplyDeliveryEvidence,
 } from "../../embedded-agent-runner/delivery-evidence.js";
+import { hasVisibleAgentPayload } from "../../embedded-agent-runner/message-visibility.js";
 import type { AgentInternalEvent } from "../../internal-events.js";
 import {
   SourceOwnerChangedError,
@@ -51,27 +54,71 @@ export function isDirectMessageDeliveryTarget(
   return deriveSessionChatTypeFromKey(requesterSessionKey) === "direct";
 }
 
-function resolveTextCompletionDirectFallback(
-  events: readonly AgentInternalEvent[] | undefined,
-  contentKind: "completed_result" | "failed_notice",
-) {
-  if (contentKind === "failed_notice") {
-    return FAILED_COMPLETION_NOTICE;
+type DirectCompletionContent = { content: string; mediaUrls: string[] };
+
+function collectDirectCompletionContent(params: {
+  agentResult?: { payloads?: unknown };
+  events: readonly AgentInternalEvent[] | undefined;
+  contentKind: "completed_result" | "failed_notice";
+}): DirectCompletionContent | undefined {
+  if (params.contentKind === "failed_notice") {
+    return { content: FAILED_COMPLETION_NOTICE, mediaUrls: [] };
   }
-  for (let index = (events?.length ?? 0) - 1; index >= 0; index -= 1) {
-    const event = events?.[index];
-    if (event?.type !== "task_completion" || event.source !== "subagent") {
+  const collect = (payloads: readonly unknown[]): DirectCompletionContent | undefined => {
+    const textParts: string[] = [];
+    const mediaUrls = new Set<string>();
+    for (const payload of payloads) {
+      if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+        continue;
+      }
+      // SAFETY: The object/array guard above narrows payload to a plain record boundary.
+      const record = payload as Record<string, unknown>;
+      if (
+        !hasVisibleAgentPayload(
+          { payloads: [record] },
+          {
+            includeErrorPayloads: false,
+            includeReasoningPayloads: false,
+            includeSilentReplyPayloads: false,
+            requireTerminalContent: true,
+          },
+        )
+      ) {
+        continue;
+      }
+      const normalized = normalizeOutboundReplyPayloadCore(record);
+      const parsed = splitMediaFromOutput(normalized.text ?? "");
+      const text = sanitizeAgentRunTerminalReplyText(sanitizePendingFinalDeliveryText(parsed.text));
+      if (text && text !== "(no output)") {
+        textParts.push(text);
+      }
+      for (const mediaUrl of [
+        ...(normalized.mediaUrl ? [normalized.mediaUrl] : []),
+        ...(normalized.mediaUrls ?? []),
+        ...(parsed.mediaUrls ?? []),
+      ]) {
+        mediaUrls.add(mediaUrl);
+      }
+    }
+    return textParts.length > 0 || mediaUrls.size > 0
+      ? { content: textParts.join("\n\n"), mediaUrls: [...mediaUrls] }
+      : undefined;
+  };
+
+  const payloadContent = Array.isArray(params.agentResult?.payloads)
+    ? collect(params.agentResult.payloads)
+    : undefined;
+  if (payloadContent && payloadContent.mediaUrls.length > 0) {
+    return payloadContent;
+  }
+  for (let index = (params.events?.length ?? 0) - 1; index >= 0; index -= 1) {
+    const event = params.events?.[index];
+    if (event?.type !== "task_completion" || event.source !== "subagent" || event.status !== "ok") {
       continue;
     }
-    if (event.status !== "ok") {
-      continue;
-    }
-    const result =
-      typeof event.result === "string"
-        ? sanitizeAgentRunTerminalReplyText(sanitizePendingFinalDeliveryText(event.result))
-        : "";
-    if (result && result !== "(no output)") {
-      return result;
+    const eventContent = collect([{ text: event.result }]);
+    if (eventContent) {
+      return eventContent;
     }
   }
   return undefined;
@@ -106,12 +153,17 @@ export async function deliverCompletionDirect(params: {
   internalEvents?: readonly AgentInternalEvent[];
   contentKind: "completed_result" | "failed_notice";
   signal?: AbortSignal;
+  agentResult?: { payloads?: unknown };
   onDeliveryResult?: (delivery: SubagentAnnounceDeliveryResult) => void;
   isSourceSessionEffectsAllowed?: () => boolean;
 }): Promise<SubagentAnnounceDeliveryResult | undefined> {
-  const content = resolveTextCompletionDirectFallback(params.internalEvents, params.contentKind);
+  const completionContent = collectDirectCompletionContent({
+    agentResult: params.agentResult,
+    events: params.internalEvents,
+    contentKind: params.contentKind,
+  });
   if (
-    !content ||
+    !completionContent ||
     !params.deliveryTarget.deliver ||
     !params.deliveryTarget.channel ||
     !params.deliveryTarget.to ||
@@ -145,7 +197,8 @@ export async function deliverCompletionDirect(params: {
       requesterSessionKey: params.requesterSessionKey,
       agentId,
       conversationType: "direct",
-      content,
+      content: completionContent.content,
+      ...(completionContent.mediaUrls.length > 0 ? { mediaUrls: completionContent.mediaUrls } : {}),
       idempotencyKey,
       skipQueue: true,
       abortSignal: params.signal,

--- a/src/agents/subagents/announce/subagent-announce-completion-delivery.ts
+++ b/src/agents/subagents/announce/subagent-announce-completion-delivery.ts
@@ -16,7 +16,7 @@ import {
   resolveExplicitFinalSourceReplyDeliveryEvidence,
 } from "../../embedded-agent-runner/delivery-evidence.js";
 import { hasVisibleAgentPayload } from "../../embedded-agent-runner/message-visibility.js";
-import type { AgentInternalEvent } from "../../internal-events.js";
+import { collectAgentInternalEventMedia, type AgentInternalEvent } from "../../internal-events.js";
 import {
   SourceOwnerChangedError,
   sourceOwnerChangedResult,
@@ -116,9 +116,14 @@ function collectDirectCompletionContent(params: {
     if (event?.type !== "task_completion" || event.source !== "subagent" || event.status !== "ok") {
       continue;
     }
-    const eventContent = collect([{ text: event.result }]);
-    if (eventContent) {
-      return eventContent;
+    const parsedEvent = collect([{ text: event.result }]);
+    const eventMediaUrls = collectAgentInternalEventMedia([event]).mediaUrls;
+    const mediaUrls = new Set([...(parsedEvent?.mediaUrls ?? []), ...eventMediaUrls]);
+    if (parsedEvent || mediaUrls.size > 0) {
+      return {
+        content: parsedEvent?.content ?? "",
+        mediaUrls: [...mediaUrls],
+      };
     }
   }
   return undefined;

--- a/src/agents/subagents/announce/subagent-announce-delivery.test.ts
+++ b/src/agents/subagents/announce/subagent-announce-delivery.test.ts
@@ -1768,6 +1768,48 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
 
   it.each([
     {
+      name: "caption plus structured and directive media",
+      payload: {
+        text: "Image ready\nMEDIA:/tmp/directive.png",
+        mediaUrls: ["/tmp/structured.png", "/tmp/directive.png"],
+      },
+      expectedContent: "Image ready",
+      expectedMediaUrls: ["/tmp/structured.png", "/tmp/directive.png"],
+    },
+    {
+      name: "directive-only media",
+      payload: { text: "MEDIA:/tmp/directive-only.png" },
+      expectedContent: "",
+      expectedMediaUrls: ["/tmp/directive-only.png"],
+    },
+    {
+      name: "structured media without a caption",
+      payload: { mediaUrls: ["/tmp/structured-only.png"] },
+      expectedContent: "",
+      expectedMediaUrls: ["/tmp/structured-only.png"],
+    },
+  ])("directly delivers $name from the announce payload", async (testCase) => {
+    const callGateway = createGatewayMock({ result: { payloads: [testCase.payload] } });
+    const sendMessage = createSendMessageMock();
+
+    const result = await deliverDiscordDirectMessageCompletion({
+      callGateway,
+      sendMessage,
+      internalEvents: taskCompletionEvents({ childSessionId: "child-session-id" }),
+    });
+
+    expectDeliveryPath(result, "direct");
+    expect(sendMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: testCase.expectedContent,
+        mediaUrls: testCase.expectedMediaUrls,
+        idempotencyKey: "announce-dm-fallback-empty:text-direct",
+      }),
+    );
+  });
+
+  it.each([
+    {
       name: "intentional suppression",
       suppressionReason: "cancelled_by_message_sending_hook",
       disposition: "intentional_non_delivery",

--- a/src/agents/subagents/announce/subagent-announce-delivery.test.ts
+++ b/src/agents/subagents/announce/subagent-announce-delivery.test.ts
@@ -2056,6 +2056,45 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
     },
   );
 
+  it("does not expose synthesis media for a failed trusted child", async () => {
+    const childSessionKey = "agent:worker:subagent:failed-media-child";
+    const privateMedia = "/tmp/private-failed-child.png";
+    const callGateway = createGatewayMock({
+      result: {
+        payloads: [
+          {
+            text: `Private failure details\nMEDIA:${privateMedia}`,
+            mediaUrls: [privateMedia],
+          },
+        ],
+      },
+    });
+    const sendMessage = createSendMessageMock();
+
+    const result = await deliverDiscordDirectMessageCompletion({
+      callGateway,
+      sendMessage,
+      sourceSessionKey: childSessionKey,
+      sourceTool: "subagent_announce",
+      internalEvents: taskCompletionEvents({
+        childSessionKey,
+        childSessionId: "failed-media-child-session-id",
+        status: "error",
+        statusLabel: "failed: private provider rejection",
+        result: `Private child output\nMEDIA:${privateMedia}`,
+      }),
+    });
+
+    expectRecordFields(result, { delivered: true, path: "direct" });
+    expect(sendMessage).toHaveBeenCalledOnce();
+    const directPayload = mockCallArg(sendMessage, 0, 0);
+    expect(directPayload.content).toBe(
+      "A delegated task failed before it could report a result. Please retry the task.",
+    );
+    expect(directPayload).not.toHaveProperty("mediaUrls");
+    expect(directPayload.content).not.toContain(privateMedia);
+  });
+
   it.each(["cancelled", "source owner changed"] as const)(
     "stops a failed-child notice when %s at platform dispatch",
     async (blockedBy) => {

--- a/src/agents/subagents/announce/subagent-announce-delivery.test.ts
+++ b/src/agents/subagents/announce/subagent-announce-delivery.test.ts
@@ -1808,6 +1808,30 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
     );
   });
 
+  it("directly delivers structured media owned by the child event", async () => {
+    const callGateway = createGatewayMock({ result: { payloads: [] } });
+    const sendMessage = createSendMessageMock();
+
+    const result = await deliverDiscordDirectMessageCompletion({
+      callGateway,
+      sendMessage,
+      internalEvents: taskCompletionEvents({
+        childSessionId: "child-session-id",
+        result: "",
+        mediaUrls: ["/tmp/child-event.png"],
+      }),
+    });
+
+    expectDeliveryPath(result, "direct");
+    expect(sendMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: "",
+        mediaUrls: ["/tmp/child-event.png"],
+        idempotencyKey: "announce-dm-fallback-empty:text-direct",
+      }),
+    );
+  });
+
   it.each([
     {
       name: "intentional suppression",

--- a/src/agents/subagents/announce/subagent-announce-direct-delivery.ts
+++ b/src/agents/subagents/announce/subagent-announce-direct-delivery.ts
@@ -226,6 +226,7 @@ export async function sendSubagentAnnounceDirectly(params: {
       };
     }
     const tryTextCompletionDirectDelivery = (
+      agentResult?: { payloads?: unknown },
       contentKind: "completed_result" | "failed_notice" = "completed_result",
     ) =>
       deliverCompletionDirect({
@@ -237,6 +238,7 @@ export async function sendSubagentAnnounceDirectly(params: {
         internalEvents: params.internalEvents,
         contentKind,
         signal: params.signal,
+        agentResult,
         onDeliveryResult: params.onDeliveryResult,
         isSourceSessionEffectsAllowed: isCompletionDeliveryAllowed,
       });
@@ -420,7 +422,10 @@ export async function sendSubagentAnnounceDirectly(params: {
         isSubagentCompletion &&
         directCompletionFallbackKind
       ) {
-        const textDelivery = await tryTextCompletionDirectDelivery(directCompletionFallbackKind);
+        const textDelivery = await tryTextCompletionDirectDelivery(
+          undefined,
+          directCompletionFallbackKind,
+        );
         if (textDelivery) {
           return textDelivery;
         }
@@ -493,7 +498,7 @@ export async function sendSubagentAnnounceDirectly(params: {
       !hasVisibleNonSilentGatewayPayload &&
       !hasMessagingToolDelivery
     ) {
-      const textDelivery = await tryTextCompletionDirectDelivery();
+      const textDelivery = await tryTextCompletionDirectDelivery(directAnnounceResult ?? undefined);
       if (textDelivery) {
         return textDelivery;
       }
@@ -536,7 +541,9 @@ export async function sendSubagentAnnounceDirectly(params: {
         };
       }
       if (subagentDirectMessageCompletionRequiresMessageTool) {
-        const textDelivery = await tryTextCompletionDirectDelivery();
+        const textDelivery = await tryTextCompletionDirectDelivery(
+          directAnnounceResult ?? undefined,
+        );
         if (textDelivery) {
           return textDelivery;
         }

--- a/src/agents/subagents/announce/subagent-announce-direct-delivery.ts
+++ b/src/agents/subagents/announce/subagent-announce-direct-delivery.ts
@@ -227,7 +227,9 @@ export async function sendSubagentAnnounceDirectly(params: {
     }
     const tryTextCompletionDirectDelivery = (
       agentResult?: { payloads?: unknown },
-      contentKind: "completed_result" | "failed_notice" = "completed_result",
+      contentKind: "completed_result" | "failed_notice" = hasFailedTrustedSubagentCompletion
+        ? "failed_notice"
+        : "completed_result",
     ) =>
       deliverCompletionDirect({
         cfg,


### PR DESCRIPTION
Closes #132780

## What Problem This Solves

When requester wake or message-tool delivery failed, the direct subagent-completion fallback reduced the completion to text. Structured `mediaUrl` / `mediaUrls` were ignored, and `MEDIA:` directives were sent as plain content rather than attachments. Caption-less media therefore disappeared completely even though generation succeeded.

The fallback now preserves media from the announce-agent payload and from the trusted child completion event, then sends it through the existing outbound `sendMessage` media contract.

## Root Cause

`deliverCompletionDirect` accepted only internal completion events and resolved one sanitized text string. It did not receive the announce-agent result, did not normalize reply payload fields, and did not parse media directives before calling the outbound sender.

## Implementation

- Reuses `normalizeOutboundReplyPayloadCore` for structured media fields.
- Reuses `splitMediaFromOutput` for canonical `MEDIA:` parsing.
- Deduplicates structured and directive media references.
- Supports caption plus media, directive-only media, structured media-only payloads, and media owned by the trusted child completion event.
- Prefers the announce-agent payload only when it actually carries media; media-free payloads retain the trusted child-result fallback.
- Keeps error, reasoning, silent, and non-terminal payloads out of direct delivery through the existing visibility contract.
- Continues to use `sendMessage` with requester session/agent ownership, so existing media roots, staging, and outbound filesystem policy remain authoritative.

## User Impact

Direct-message fallback delivery now keeps the generated attachment together with its caption. Media-only completions remain visible instead of silently disappearing.

## Evidence

Exact head: `d3ca39713e36c9e67dcbce51f2651ba8e92f0b03`

A repository-native qa-lab E2E drove the complete changed path with a mock provider, mock channel API, and real ephemeral Gateway:

1. A direct qa-channel user turn triggered `sessions_spawn`.
2. The parent returned `NO_REPLY` after spawn, forcing the detached completion path.
3. The child returned `QA-SUBAGENT-DIRECT-MEDIA-FALLBACK-OK` plus a `MEDIA:` directive pointing to a PNG inside the ephemeral Gateway workspace.
4. The completion announce returned intentional `NO_REPLY`.
5. The production direct fallback parsed the media, passed it through the existing outbound media-access contract, and qa-channel loaded and published one image attachment.
6. The test verified one visible completion, exact caption, MIME type, filename, byte length, and byte-for-byte SHA-256 equality; it also proved one spawn, zero yields, one marker-bearing announce request, exactly four provider requests, and no request growth during the quiet window.

```json
{
  "schemaVersion": 1,
  "scenario": "subagent-direct-media-fallback",
  "head": "d3ca39713e36c9e67dcbce51f2651ba8e92f0b03",
  "status": "pass",
  "channel": "qa-channel",
  "provider": "mock-openai",
  "gateway": "ephemeral",
  "facts": {
    "directConversation": true,
    "caption": "QA-SUBAGENT-DIRECT-MEDIA-FALLBACK-OK",
    "visibleCompletions": 1,
    "attachmentCount": 1,
    "attachmentKind": "image",
    "attachmentMimeType": "image/png",
    "attachmentFileName": "qa-direct-media-fallback.png",
    "attachmentBytes": 68,
    "attachmentSha256": "431ced6916a2a21a156e38701afe55bbd7f88969fbbfc56d7fe099d47f265460",
    "sourceSha256": "431ced6916a2a21a156e38701afe55bbd7f88969fbbfc56d7fe099d47f265460",
    "attachmentContentMatches": true,
    "providerRequests": 4
  }
}
```

Validation:

- Ephemeral Gateway E2E: **1/1 passed**.
- Complete announce suite: **193/193 passed**.
- Complete qa-lab mock provider suite: **276/276 passed**.
- Extension production and test typechecks passed.
- Changed conflict, format, assertion, dependency, plugin-boundary, doctor-contract, dead-code, and production type checks passed.
- Core-test type checking reaches the unrelated current-main missing `jsdom` declaration in `ui/src/test-helpers/mock-gateway-page.test-support.ts`.
- Independent review identified and then verified removal of one mock completion-agent retry; no remaining blocker was found.

Telegram Test Server proof was attempted first. The repository doctor could not lease credentials because this host lacks authenticated Convex broker project access. Per the repository real-behavior-proof policy, the mock channel API + mock provider + ephemeral Gateway verdict above covers the changed path.

## AI-Assisted Development

This change was developed with AI assistance. The implementation and E2E were independently reviewed for media trust boundaries, duplicate delivery, caption-less media, child-event media ownership, request recursion, and compatibility with existing trusted child-result behavior.