### PR TITLE
fix(test): join tsx fixture children before cleanup

### DIFF
--- a/test/helpers/bounded-child-output.ts
+++ b/test/helpers/bounded-child-output.ts
@@ -35,7 +35,7 @@ export function createBoundedChildOutput(maxBytes = DEFAULT_CHILD_OUTPUT_TAIL_BY
   };
 
   return {
-    append(chunk: unknown): void {
+    append(this: void, chunk: unknown): void {
       const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(String(chunk));
       if (buffer.byteLength >= limit) {
         chunks = [Buffer.from(buffer.subarray(buffer.byteLength - limit))];

--- a/test/helpers/run-node-script.ts
+++ b/test/helpers/run-node-script.ts
@@ -1,7 +1,12 @@
 import { runManagedCommand } from "../../scripts/lib/managed-child-process.mts";
 import { createBoundedChildOutput } from "./bounded-child-output.js";
 
-export async function runNodeScript(scriptPath: string, env: NodeJS.ProcessEnv, timeoutMs: number) {
+export async function runNodeScript(
+  scriptPathOrArgs: string | string[],
+  env: NodeJS.ProcessEnv,
+  timeoutMs: number,
+  { cwd }: { cwd?: string } = {},
+) {
   const stdout = createBoundedChildOutput();
   const stderr = createBoundedChildOutput();
   let status: number | null = null;
@@ -9,7 +14,8 @@ export async function runNodeScript(scriptPath: string, env: NodeJS.ProcessEnv, 
   try {
     status = await runManagedCommand({
       bin: process.execPath,
-      args: [scriptPath],
+      args: typeof scriptPathOrArgs === "string" ? [scriptPathOrArgs] : scriptPathOrArgs,
+      cwd,
       env,
       timeoutMs,
       shell: false,

--- a/test/scripts/direct-run-entrypoints.test-support.ts
+++ b/test/scripts/direct-run-entrypoints.test-support.ts
@@ -1,0 +1,101 @@
+import { copyFileSync, mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { inspect } from "node:util";
+import { runNodeScript } from "../helpers/run-node-script.js";
+
+type NodeResult = Awaited<ReturnType<typeof runNodeScript>>;
+
+export function formatShimResult(result: NodeResult) {
+  return `status: ${result.status}\nerror: ${inspect(result.error)}\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`;
+}
+
+function hasUnjoinedTree(error: unknown) {
+  return (
+    error &&
+    typeof error === "object" &&
+    "processTreeState" in error &&
+    error.processTreeState !== "terminated"
+  );
+}
+
+export const TSX_SHIM_WRAPPERS = [
+  "scripts/run-vitest.mjs",
+  "scripts/lib/plugin-npm-package-manifest.mjs",
+  "scripts/e2e/kitchen-sink-rpc-walk.mjs",
+  "scripts/perf/summarize-cpuprofile.mjs",
+] as const;
+
+export async function withShimFixture<T>(
+  wrapper: (typeof TSX_SHIM_WRAPPERS)[number],
+  run: (paths: {
+    checkoutRoot: string;
+    fixtureRoot: string;
+    implementationPath: string;
+    wrapperPath: string;
+    runNode: (args: string[], env: NodeJS.ProcessEnv, cwd: string) => Promise<NodeResult>;
+  }) => T,
+) {
+  // spawnOwnedVitestProcess gives POSIX Vitest a disposable temp namespace.
+  // Own a sibling so unverified writers survive its cleanup, outside repo module resolution.
+  // Windows has no enclosing namespace and keeps the ordinary temporary root.
+  const fixtureParent = process.platform === "win32" ? tmpdir() : path.dirname(tmpdir());
+  const fixtureRoot = realpathSync(mkdtempSync(path.join(fixtureParent, "openclaw-tsx-cli-shim-")));
+  const checkoutRoot = path.join(fixtureRoot, "checkout");
+  const wrapperPath = path.join(checkoutRoot, wrapper);
+  const implementationPath = wrapperPath.replace(/\.mjs$/u, ".mts");
+  const commands: Array<Promise<NodeResult>> = [];
+  let outcome: { value: Awaited<T> } | { error: unknown };
+  try {
+    mkdirSync(path.dirname(wrapperPath), { recursive: true });
+    mkdirSync(path.join(checkoutRoot, "scripts", "lib"), { recursive: true });
+    copyFileSync(wrapper, wrapperPath);
+    copyFileSync("scripts/tsx.mjs", path.join(checkoutRoot, "scripts", "tsx.mjs"));
+    copyFileSync(
+      "scripts/lib/tsx-cli-shim.mjs",
+      path.join(checkoutRoot, "scripts", "lib", "tsx-cli-shim.mjs"),
+    );
+    copyFileSync(
+      "scripts/lib/local-check-runtime.mts",
+      path.join(checkoutRoot, "scripts", "lib", "local-check-runtime.mts"),
+    );
+    writeFileSync(path.join(checkoutRoot, "pnpm-lock.yaml"), "lockfileVersion: '9.0'\n");
+    outcome = {
+      value: await run({
+        checkoutRoot,
+        fixtureRoot,
+        implementationPath,
+        wrapperPath,
+        runNode(args, env, cwd) {
+          const command = runNodeScript(args, env, 10_000, { cwd });
+          commands.push(command);
+          return command;
+        },
+      }),
+    };
+  } catch (error) {
+    outcome = { error };
+  }
+  const callbackError = "error" in outcome ? outcome.error : undefined;
+  // Callback rejection must not release files still owned by an in-flight command.
+  const results = await Promise.all(commands);
+  const unjoined = [callbackError, ...results.map((result) => result.error)].find(hasUnjoinedTree);
+  if (unjoined) {
+    const outputPath = path.join(fixtureRoot, "command-output.log");
+    writeFileSync(outputPath, results.map(formatShimResult).join("\n\n"));
+    throw new Error(
+      `Child cleanup unverified; retained fixture ${fixtureRoot} and output ${outputPath}. Stop remaining writers before removing this directory.`,
+      {
+        cause:
+          callbackError && callbackError !== unjoined
+            ? new AggregateError([callbackError, unjoined])
+            : unjoined,
+      },
+    );
+  }
+  rmSync(fixtureRoot, { recursive: true, force: true });
+  if ("error" in outcome) {
+    throw outcome.error;
+  }
+  return outcome.value;
+}

--- a/test/scripts/direct-run-entrypoints.test.ts
+++ b/test/scripts/direct-run-entrypoints.test.ts
@@ -563,6 +563,7 @@ it("joins owned descendants and captures timeout output before deleting a reject
   );
   const failure = new Error("fixture callback rejected while the command was running");
   let root = "";
+  let fixturePresentAtCommandSettlement: boolean | undefined;
   let command: ReturnType<typeof runNodeScript> | undefined;
   await runQaGatewayFixture(
     async () => {
@@ -606,7 +607,10 @@ child.once("message", () => fs.writeFileSync(${JSON.stringify(pidPaths[1])}, Str
           ["--import", pathToFileURL(wrapperPidProbe).href, wrapperPath],
           env,
           fixtureRoot,
-        );
+        ).then((result) => {
+          fixturePresentAtCommandSettlement = existsSync(fixtureRoot);
+          return result;
+        });
         const implementationPid = await waitForPidFile(pidPaths[1]!, 5_000);
         expect(isProcessAlive(implementationPid)).toBe(true);
         throw failure;
@@ -619,6 +623,9 @@ child.once("message", () => fs.writeFileSync(${JSON.stringify(pidPaths[1])}, Str
         message: "Managed command timed out after 10000ms",
       });
       expect(result.status).toBeNull();
+      expect(fixturePresentAtCommandSettlement, "command teardown still owns its fixture").toBe(
+        true,
+      );
       expect(result.stdout).toContain("transformed");
       expect(result.stdout).toContain("descendant stdout");
       expect(result.stderr).toContain("descendant stderr");

--- a/test/scripts/direct-run-entrypoints.test.ts
+++ b/test/scripts/direct-run-entrypoints.test.ts
@@ -1,12 +1,10 @@
 import { spawnSync } from "node:child_process";
 import {
-  copyFileSync,
   existsSync,
   mkdirSync,
   mkdtempSync,
   readFileSync,
   readdirSync,
-  realpathSync,
   rmSync,
   writeFileSync,
 } from "node:fs";
@@ -14,9 +12,19 @@ import { createRequire } from "node:module";
 import { tmpdir, userInfo } from "node:os";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { detectChangedScope } from "../../scripts/ci-changed-scope.mjs";
 import { isDirectRunPath } from "../../scripts/lib/direct-run.mjs";
+import * as managedChild from "../../scripts/lib/managed-child-process.mts";
+import { isProcessAlive, waitForDead, waitForPidFile } from "../helpers/process-wait.js";
+import { createDeferred } from "../helpers/promise.js";
+import { runQaGatewayFixture } from "../helpers/qa-gateway-cleanup.js";
+import type { runNodeScript } from "../helpers/run-node-script.js";
+import {
+  formatShimResult,
+  TSX_SHIM_WRAPPERS,
+  withShimFixture,
+} from "./direct-run-entrypoints.test-support.js";
 
 const DIRECT_RUN_SCRIPTS = [
   "scripts/android-app-i18n.ts",
@@ -96,13 +104,6 @@ function runEntrypoint(entrypoint: (typeof EXECUTABLE_ENTRYPOINTS)[number]) {
   });
 }
 
-const TSX_SHIM_WRAPPERS = [
-  "scripts/run-vitest.mjs",
-  "scripts/lib/plugin-npm-package-manifest.mjs",
-  "scripts/e2e/kitchen-sink-rpc-walk.mjs",
-  "scripts/perf/summarize-cpuprofile.mjs",
-] as const;
-
 type ModulesEnv = Partial<Record<"PNPM_CONFIG_MODULES_DIR" | "npm_config_modules_dir", string>>;
 
 function writeTsxFixture(modulesDir: string, marker: string) {
@@ -125,39 +126,6 @@ function writeTsxFixture(modulesDir: string, marker: string) {
   writeFileSync(path.join(dependencyDir, "index.js"), 'export const value = "loaded";\n');
 }
 
-function withShimFixture<T>(
-  wrapper: (typeof TSX_SHIM_WRAPPERS)[number],
-  run: (paths: {
-    checkoutRoot: string;
-    fixtureRoot: string;
-    implementationPath: string;
-    wrapperPath: string;
-  }) => T,
-) {
-  const fixtureRoot = realpathSync(mkdtempSync(path.join(tmpdir(), "openclaw-tsx-cli-shim-")));
-  const checkoutRoot = path.join(fixtureRoot, "checkout");
-  const wrapperPath = path.join(checkoutRoot, wrapper);
-  const implementationPath = wrapperPath.replace(/\.mjs$/u, ".mts");
-  try {
-    mkdirSync(path.dirname(wrapperPath), { recursive: true });
-    mkdirSync(path.join(checkoutRoot, "scripts", "lib"), { recursive: true });
-    copyFileSync(wrapper, wrapperPath);
-    copyFileSync("scripts/tsx.mjs", path.join(checkoutRoot, "scripts", "tsx.mjs"));
-    copyFileSync(
-      "scripts/lib/tsx-cli-shim.mjs",
-      path.join(checkoutRoot, "scripts", "lib", "tsx-cli-shim.mjs"),
-    );
-    copyFileSync(
-      "scripts/lib/local-check-runtime.mts",
-      path.join(checkoutRoot, "scripts", "lib", "local-check-runtime.mts"),
-    );
-    writeFileSync(path.join(checkoutRoot, "pnpm-lock.yaml"), "lockfileVersion: '9.0'\n");
-    return run({ checkoutRoot, fixtureRoot, implementationPath, wrapperPath });
-  } finally {
-    rmSync(fixtureRoot, { recursive: true, force: true });
-  }
-}
-
 function runShimFixture(
   wrapper: (typeof TSX_SHIM_WRAPPERS)[number],
   configureModules: (paths: {
@@ -167,7 +135,7 @@ function runShimFixture(
 ) {
   return withShimFixture(
     wrapper,
-    ({ checkoutRoot, fixtureRoot, implementationPath, wrapperPath }) => {
+    ({ checkoutRoot, fixtureRoot, implementationPath, wrapperPath, runNode }) => {
       writeFileSync(
         implementationPath,
         'import { value } from "shim-dependency";\nprocess.stdout.write(JSON.stringify({ loader: process.env.OPENCLAW_TSX_FIXTURE_LOADER, dependency: value, args: process.argv.slice(2) }));\n',
@@ -181,19 +149,14 @@ function runShimFixture(
       delete env.PNPM_CONFIG_MODULES_DIR;
       delete env.npm_config_modules_dir;
       Object.assign(env, modulesEnv);
-      return spawnSync(process.execPath, [wrapperPath, "--hydrated-proof"], {
-        cwd: fixtureRoot,
-        encoding: "utf8",
-        env,
-        timeout: 10_000,
-      });
+      return runNode([wrapperPath, "--hydrated-proof"], env, fixtureRoot);
     },
   );
 }
 
-function expectShimLoader(result: ReturnType<typeof runShimFixture>, loader: string) {
-  expect(result.error).toBeUndefined();
-  expect(result.status, result.stderr).toBe(0);
+function expectShimLoader(result: Awaited<ReturnType<typeof runShimFixture>>, loader: string) {
+  expect(result.error, formatShimResult(result)).toBeUndefined();
+  expect(result.status, formatShimResult(result)).toBe(0);
   expect(JSON.parse(result.stdout)).toEqual({
     loader,
     dependency: "loaded",
@@ -204,8 +167,9 @@ function expectShimLoader(result: ReturnType<typeof runShimFixture>, loader: str
 describe("script direct-run entrypoints", () => {
   it.each([false, true])(
     "preserves preloads when forking into another cwd (equals=%s)",
-    (equals) => {
-      withShimFixture(TSX_SHIM_WRAPPERS[0], ({ checkoutRoot, fixtureRoot, implementationPath }) => {
+    async (equals) => {
+      await withShimFixture(TSX_SHIM_WRAPPERS[0], async (fixture) => {
+        const { checkoutRoot, fixtureRoot, implementationPath, runNode } = fixture;
         const forkCwd = path.join(fixtureRoot, "child cwd");
         mkdirSync(forkCwd);
         const childPath = path.join(fixtureRoot, "fork-child.mts");
@@ -246,8 +210,7 @@ process.exitCode = await new Promise((resolve, reject) => {
         };
         delete env.TSX_DISABLE_CACHE;
         delete env.NODE_OPTIONS;
-        const result = spawnSync(
-          process.execPath,
+        const result = await runNode(
           [
             ...nodeFlags,
             ...preload,
@@ -256,15 +219,11 @@ process.exitCode = await new Promise((resolve, reject) => {
             "argument with spaces",
             "--fork-proof",
           ],
-          {
-            cwd: checkoutRoot,
-            encoding: "utf8",
-            env,
-            timeout: 10_000,
-          },
+          env,
+          checkoutRoot,
         );
-        expect(result.error).toBeUndefined();
-        expect(result.status, result.stderr).toBe(17);
+        expect(result.error, formatShimResult(result)).toBeUndefined();
+        expect(result.status, formatShimResult(result)).toBe(17);
         expect(
           result.stdout
             .trim()
@@ -285,8 +244,9 @@ process.exitCode = await new Promise((resolve, reject) => {
 
   it.each(["wrapper", "root package preloads"])(
     "keeps %s and raw tsx children off disk caches without changing other cache settings",
-    (entrypoint) => {
-      withShimFixture(TSX_SHIM_WRAPPERS[0], ({ fixtureRoot, implementationPath, wrapperPath }) => {
+    async (entrypoint) => {
+      await withShimFixture(TSX_SHIM_WRAPPERS[0], async (fixture) => {
+        const { fixtureRoot, implementationPath, wrapperPath, runNode } = fixture;
         const require = createRequire(import.meta.url);
         const modulesDir = path.dirname(path.dirname(require.resolve("tsx/package.json")));
         const tempRoot = path.join(fixtureRoot, "temp");
@@ -374,18 +334,13 @@ process.exitCode = child.status ?? 1;
             env.TSX_DISABLE_CACHE = cacheFlag;
           }
           for (const launch of launches) {
-            const result = spawnSync(
-              process.execPath,
+            const result = await runNode(
               [...launch, "argument with spaces", "--proof"],
-              {
-                cwd: process.cwd(),
-                encoding: "utf8",
-                env,
-                timeout: 10_000,
-              },
+              env,
+              process.cwd(),
             );
-            expect(result.error).toBeUndefined();
-            expect(result.status, result.stderr).toBe(17);
+            expect(result.error, formatShimResult(result)).toBeUndefined();
+            expect(result.status, formatShimResult(result)).toBe(17);
             expect(
               result.stdout
                 .trim()
@@ -427,8 +382,8 @@ process.exitCode = child.status ?? 1;
     { envKey: "npm_config_modules_dir", mode: "relative", wrapper: TSX_SHIM_WRAPPERS[1] },
     { envKey: "PNPM_CONFIG_MODULES_DIR", mode: "relative", wrapper: TSX_SHIM_WRAPPERS[2] },
     { envKey: "npm_config_modules_dir", mode: "absolute", wrapper: TSX_SHIM_WRAPPERS[3] },
-  ] as const)("boots $wrapper from a $mode $envKey", ({ envKey, mode, wrapper }) => {
-    const result = runShimFixture(wrapper, ({ checkoutRoot, fixtureRoot }) => {
+  ] as const)("boots $wrapper from a $mode $envKey", async ({ envKey, mode, wrapper }) => {
+    const result = await runShimFixture(wrapper, ({ checkoutRoot, fixtureRoot }) => {
       const modulesDir = path.join(fixtureRoot, "hydrated-modules");
       writeTsxFixture(modulesDir, "hydrated");
       const configuredDir =
@@ -438,8 +393,8 @@ process.exitCode = child.status ?? 1;
     expectShimLoader(result, "hydrated");
   });
 
-  it("prefers PNPM_CONFIG_MODULES_DIR over npm_config_modules_dir", () => {
-    const result = runShimFixture(TSX_SHIM_WRAPPERS[2], ({ fixtureRoot }) => {
+  it("prefers PNPM_CONFIG_MODULES_DIR over npm_config_modules_dir", async () => {
+    const result = await runShimFixture(TSX_SHIM_WRAPPERS[2], ({ fixtureRoot }) => {
       const preferredDir = path.join(fixtureRoot, "preferred-modules");
       const fallbackDir = path.join(fixtureRoot, "fallback-modules");
       writeTsxFixture(preferredDir, "preferred");
@@ -452,14 +407,14 @@ process.exitCode = child.status ?? 1;
     expectShimLoader(result, "preferred");
   });
 
-  it("falls back to checkout dependencies without an external modules directory", () => {
-    expectShimLoader(runShimFixture(TSX_SHIM_WRAPPERS[3]), "checkout");
+  it("falls back to checkout dependencies without an external modules directory", async () => {
+    expectShimLoader(await runShimFixture(TSX_SHIM_WRAPPERS[3]), "checkout");
   });
 
   it.each(["hydrated", "primary"] as const)(
     "resolves implementation dependencies from the %s toolchain without local modules",
-    (source) => {
-      const result = runShimFixture(TSX_SHIM_WRAPPERS[0], ({ checkoutRoot, fixtureRoot }) => {
+    async (source) => {
+      const result = await runShimFixture(TSX_SHIM_WRAPPERS[0], ({ checkoutRoot, fixtureRoot }) => {
         rmSync(path.join(checkoutRoot, "node_modules"), { recursive: true });
         const primaryRoot = path.join(fixtureRoot, "primary");
         const modulesDir = path.join(primaryRoot, "node_modules");
@@ -507,4 +462,202 @@ process.exitCode = child.status ?? 1;
   ])("routes %s through Windows CI", (changedPath) => {
     expect(detectChangedScope([changedPath]).runWindows).toBe(true);
   });
+});
+
+it.each([false, true])(
+  "keeps the fixture until its callback settles (reject=%s)",
+  async (reject) => {
+    const release = createDeferred();
+    const failure = new Error("callback rejected after its final write");
+    let root = "";
+    let finalWrite = "";
+    const completion = Promise.resolve(
+      withShimFixture(TSX_SHIM_WRAPPERS[0], async ({ fixtureRoot }) => {
+        root = fixtureRoot;
+        await release.promise;
+        const marker = path.join(fixtureRoot, "callback-finished");
+        writeFileSync(marker, "finished");
+        finalWrite = readFileSync(marker, "utf8");
+        if (reject) {
+          throw failure;
+        }
+        return "callback result";
+      }),
+    ).then(
+      (value) => ({ value }),
+      (error: unknown) => ({ error }),
+    );
+    try {
+      expect(existsSync(root), "pending callbacks still own their fixture").toBe(true);
+    } finally {
+      release.resolve();
+      await completion;
+    }
+    expect(await completion).toEqual(reject ? { error: failure } : { value: "callback result" });
+    expect(finalWrite).toBe("finished");
+    expect(existsSync(root)).toBe(false);
+  },
+);
+
+it.each(["callback", "command"])(
+  "retains fixture evidence when %s cleanup is unconfirmed",
+  async (source) => {
+    // Fault injection is limited to the receipt: real OS cleanup failure is unsafe to force.
+    const failure = Object.assign(new Error("child cleanup unverified"), {
+      code: "EPROCESSGROUP_CLEANUP_FAILED",
+      processTreeState: "indeterminate",
+    });
+    const runManaged = managedChild.runManagedCommand;
+    const spy = vi
+      .spyOn(managedChild, "runManagedCommand")
+      .mockImplementationOnce(async (options) => {
+        await runManaged(options);
+        throw failure;
+      });
+    let root = "";
+    try {
+      const error = await withShimFixture(
+        TSX_SHIM_WRAPPERS[0],
+        async ({ fixtureRoot, runNode }) => {
+          root = fixtureRoot;
+          writeFileSync(path.join(root, "evidence"), "keep");
+          if (source === "callback") {
+            throw failure;
+          }
+          await runNode(
+            [
+              "-e",
+              'process.stdout.write("retained stdout"); process.stderr.write("retained stderr");',
+            ],
+            process.env,
+            root,
+          );
+        },
+      ).catch((cause: unknown) => cause);
+      expect(existsSync(root), "unverified writers still own the fixture").toBe(true);
+      expect(readFileSync(path.join(root, "evidence"), "utf8")).toBe("keep");
+      expect(error).toMatchObject({ message: expect.stringContaining(root), cause: failure });
+      if (source === "command") {
+        const output = readFileSync(path.join(root, "command-output.log"), "utf8");
+        expect(output).toContain("retained stdout");
+        expect(output).toContain("retained stderr");
+        expect(output).toContain("EPROCESSGROUP_CLEANUP_FAILED");
+      }
+    } finally {
+      spy.mockRestore();
+      // The real command has joined; only the injected receipt prevents removal.
+      rmSync(root, { recursive: true, force: true });
+    }
+  },
+);
+
+it("joins owned descendants and captures timeout output before deleting a rejected fixture", async () => {
+  const evidence = mkdtempSync(path.join(tmpdir(), "openclaw-shim-owned-pids-"));
+  const pidPaths = ["wrapper", "implementation", "descendant"].map((role) =>
+    path.join(evidence, `${role}.pid`),
+  );
+  const wrapperPidProbe = path.join(evidence, "wrapper-pid.mjs");
+  writeFileSync(
+    wrapperPidProbe,
+    `import fs from "node:fs"; fs.writeFileSync(${JSON.stringify(pidPaths[0])}, String(process.pid));`,
+  );
+  const failure = new Error("fixture callback rejected while the command was running");
+  let root = "";
+  let command: ReturnType<typeof runNodeScript> | undefined;
+  await runQaGatewayFixture(
+    async () => {
+      const error = await withShimFixture(TSX_SHIM_WRAPPERS[0], async (fixture) => {
+        const { fixtureRoot, implementationPath, wrapperPath, runNode } = fixture;
+        root = fixtureRoot;
+        const descendant = `
+const fs = require("node:fs");
+const timer = setInterval(() => {}, 1000);
+process.on("SIGTERM", () => {
+  fs.writeFileSync(${JSON.stringify(path.join(evidence, "shutdown-root-present"))}, String(fs.existsSync(${JSON.stringify(root)})));
+  process.stdout.write("shutdown stdout\\n");
+  process.stderr.write("shutdown stderr\\n");
+  clearInterval(timer);
+});
+fs.writeFileSync(${JSON.stringify(pidPaths[2])}, String(process.pid));
+process.stdout.write("descendant stdout\\n");
+process.stderr.write("descendant stderr\\n");
+process.send("ready");
+process.disconnect();
+`;
+        writeFileSync(
+          implementationPath,
+          `
+import fs from "node:fs";
+import { spawn } from "node:child_process";
+enum Transformed { Value = "transformed" }
+console.log(Transformed.Value);
+const child = spawn(process.execPath, ["-e", ${JSON.stringify(descendant)}], { stdio: ["ignore", "inherit", "inherit", "ipc"] });
+child.once("message", () => fs.writeFileSync(${JSON.stringify(pidPaths[1])}, String(process.pid)));
+`,
+        );
+        const env: NodeJS.ProcessEnv = {
+          ...process.env,
+          PNPM_CONFIG_MODULES_DIR: path.dirname(
+            path.dirname(createRequire(import.meta.url).resolve("tsx/package.json")),
+          ),
+        };
+        delete env.NODE_OPTIONS;
+        command = runNode(
+          ["--import", pathToFileURL(wrapperPidProbe).href, wrapperPath],
+          env,
+          fixtureRoot,
+        );
+        const implementationPid = await waitForPidFile(pidPaths[1]!, 5_000);
+        expect(isProcessAlive(implementationPid)).toBe(true);
+        throw failure;
+      }).catch((cause: unknown) => cause);
+      expect(error).toBe(failure);
+      expect(command).toBeDefined();
+      const result = await command!;
+      expect(result.error, formatShimResult(result)).toMatchObject({
+        code: "ETIMEDOUT",
+        message: "Managed command timed out after 10000ms",
+      });
+      expect(result.status).toBeNull();
+      expect(result.stdout).toContain("transformed");
+      expect(result.stdout).toContain("descendant stdout");
+      expect(result.stderr).toContain("descendant stderr");
+      for (const pidPath of pidPaths) {
+        expect(isProcessAlive(Number(readFileSync(pidPath, "utf8"))), pidPath).toBe(false);
+      }
+      if (process.platform !== "win32") {
+        expect(readFileSync(path.join(evidence, "shutdown-root-present"), "utf8")).toBe("true");
+        expect(result.stdout).toContain("shutdown stdout");
+        expect(result.stderr).toContain("shutdown stderr");
+      }
+      expect(existsSync(root)).toBe(false);
+    },
+    async () => {
+      await command;
+    },
+    ...pidPaths.toReversed().map((pidPath) => async () => {
+      // Independent recovery also runs after a failed assertion; never rely on the fixture under test.
+      if (existsSync(pidPath)) {
+        const pid = Number(readFileSync(pidPath, "utf8"));
+        if (isProcessAlive(pid)) {
+          managedChild.terminateManagedChild(
+            { pid, kill: (signal) => process.kill(pid, signal) },
+            "SIGKILL",
+            { useProcessGroup: false },
+          );
+        }
+        await waitForDead(pid, 5_000);
+      }
+    }),
+    () => {
+      if (
+        pidPaths.some(
+          (pidPath) => existsSync(pidPath) && isProcessAlive(Number(readFileSync(pidPath, "utf8"))),
+        )
+      ) {
+        throw new Error(`Owned proof children remain; retained PID evidence ${evidence}`);
+      }
+      rmSync(evidence, { recursive: true, force: true });
+    },
+  );
 });


### PR DESCRIPTION
Related: #132713 — paired-Mac catalog repair whose broad fallback CI exposed this independent test-fixture weakness.

## What Problem This Solves

Resolves a problem where a timed-out tsx wrapper fixture could delete its temporary checkout without owning descendant teardown, and the failing assertion discarded captured stdout/stderr. This is a maintainer-requested test-infrastructure repair, not a production cache change.

The [original Windows job](https://github.com/openclaw/openclaw/actions/runs/33265850684/job/99135918603) hit the unchanged 10-second `spawnSync` deadline at head `6ae2b5a8df4a0d9872c622b053f42619e3486ad6`. It actually ran Windows 2025 and Node 22.23.2. Its [unchanged-code rerun](https://github.com/openclaw/openclaw/actions/runs/33265850684/job/99139018055) passed. Neither result establishes the initial timeout cause or a tsx cache regression.

## Why This Change Was Made

The fixture now awaits its callback and every registered command through the existing `runNodeScript` / `runManagedCommand` ownership path before deletion. Unconfirmed cleanup retains the original fixture and bounded command output, with an explicit recovery path. POSIX fixtures sit outside the outer Vitest disposable namespace and outside repository module resolution; Windows keeps the ordinary temporary root.

The shared test runner gains argv/cwd support rather than duplicating subprocess capture or process-tree policy. Its bounded output callback now explicitly declares its existing receiver-independent `this: void` contract. Production runtime, tsx/esbuild dependencies, worker settings, and cache policy are unchanged. Increasing timeouts or disabling esbuild workers would not repair fixture ownership and was deliberately avoided.

## User Impact

No product behavior change. Developers get managed timeout teardown and useful failure diagnostics without changing the 10,000 ms command budget. All existing cache sentinels and scan guard, environment preservation, transformed snapshots, preload/fork behavior, exit-17 assertions, and failure-trailer assertions remain intact.

Production LOC: +0/-0. Tests and test support: +355/-88 (net +267), including the extracted fixture setup and five failure/lifecycle cases. No configuration, schema, persistence, package, or public API surface changes.

## Evidence

- Before repair, three new lifecycle cases failed against the unchanged extracted fixture: both pending callback cases lost their directory before settlement, and unconfirmed cleanup lost its evidence.
- A real wrapper → transformed implementation → descendant proof rejects the callback while the command is active, reaches the unchanged 10-second timeout, checks all recorded PIDs are dead, and checks captured stdout/stderr. All platforms also check that the directory still exists at managed-command settlement; POSIX additionally checks during the descendant's final shutdown write. Negative controls removing only the teardown wait failed both observations (`false`, expected `true`), including the platform-neutral assertion added for Windows. Independent PID-based recovery prevents the regression proof from relying on the broken fixture for cleanup.
- Cleanup-failure injection replaces only the owner's receipt after a real child has joined; it proves fixture retention and diagnostics, not Windows OS termination.
- Directly inspected installed tsx 4.23.12 cache/transform implementation and esbuild 0.28.2 worker/service spawn and stop contracts. Workers remain enabled. Also inspected Node's documented Windows signal and close/exit behavior.
- Full focused local owner/sibling proof on macOS Node 26.8.1: **101 passed, one Linux-only skip**. Independent macOS Node 24.20.0 run of the fixture and shared output helpers: **52 passed**.
- Scoped changed gate, root test typecheck, direct type-aware lint, formatting, and `git diff --check` passed. Fresh isolated Codex autoreview found no actionable findings at its default P0 scope.
- Earlier local validation had two unchanged-deadline timeouts; the improved diagnostics captured both transformed snapshots. A temporary in-repository fixture placement also exposed dependency-resolution contamination and was removed. Those failed runs are not described as green and did not cause timeout or assertion weakening.

Commands:

```bash
node scripts/run-vitest.mjs test/scripts/direct-run-entrypoints.test.ts test/helpers/run-node-script.test.ts test/helpers/bounded-child-output.test.ts test/scripts/managed-child-process.test.ts test/scripts/vitest-fork-shutdown.test.ts
```

```bash
node scripts/check-changed.mjs -- test/helpers/bounded-child-output.ts test/helpers/run-node-script.ts test/scripts/direct-run-entrypoints.test.ts test/scripts/direct-run-entrypoints.test-support.ts
```

```bash
node scripts/run-oxlint.mjs --tsconfig test/tsconfig/tsconfig.test.root.json test/helpers/bounded-child-output.ts test/helpers/run-node-script.ts test/scripts/direct-run-entrypoints.test.ts test/scripts/direct-run-entrypoints.test-support.ts
```

**Pre-rebase Windows proof passed** at `a938555a9c0347f41bfebd6a6aaac6f5977842b4`, [run 33271666117](https://github.com/openclaw/openclaw/actions/runs/33271666117), attempt 1: [test-1](https://github.com/openclaw/openclaw/actions/runs/33271666117/job/99151297353) and [test-2](https://github.com/openclaw/openclaw/actions/runs/33271666117/job/99151297378). The actual runner was Blacksmith Windows 2025 with Node 22.23.2. The inspected test-1 log confirms both original cache cases and all five lifecycle/failure cases passed, including the real descendant timeout with the platform-neutral ordering assertion (10,122 ms). Both Windows jobs also passed the initial repair head. The assertion-only follow-up was revalidated locally (52 tests, root test types, direct lint, and fresh isolated autoreview all passed).

The previous aggregate CI failure was isolated to the untouched Linux shutdown fixture. The canonical repair landed separately in #132820 at `f9b3bcccdba3dc159c6484c30f56974b90a6d938`, switching that fixture to native worker CPU/heap profiles. This branch was mechanically rebased onto that repair; it does not duplicate or modify it. Range-diff confirms both original commits are patch-equivalent and the delta remains the same four test/support files (+355/-88; production +0/-0).

Fresh post-rebase local proof on macOS Node 24.20.0 passed **113 tests with one Linux-only skip**, including all 12 canonical shutdown-fixture cases and the real descendant timeout (10,767 ms). Root test types, direct type-aware lint, changed-file gates, formatting, and whitespace checks passed. A fresh isolated Codex autoreview of the complete branch diff found no actionable findings at its default P0 scope. No source edits, timeout increases, assertion weakening, or production changes were made during landing recovery.

The focused command above is the final five-file recovery command. The original Windows timeout cause remains unknown; this PR repairs fixture ownership and diagnostics, not an established tsx cache regression.

**Final exact-head CI is green** at `b0354de3e6462136d160f69b9d67bf4786ad6203`: [run 33275896095](https://github.com/openclaw/openclaw/actions/runs/33275896095), attempt 1, and [aggregate gate 99163257204](https://github.com/openclaw/openclaw/actions/runs/33275896095/job/99163257204). Both [Windows test-1](https://github.com/openclaw/openclaw/actions/runs/33275896095/job/99162530430) and [Windows test-2](https://github.com/openclaw/openclaw/actions/runs/33275896095/job/99162530451) passed. The inspected Windows 2025 / Node 22.23.2 test-1 log confirms all 46 direct-run cases passed, including both cache cases, all five lifecycle cases, and the real descendant timeout with fixture-presence-at-settlement proof (10,117 ms). The normal exact-head watcher finished `GREEN`; no CI retry or bypass was needed.

The [latest ClawSweeper review](https://github.com/openclaw/openclaw/pull/132808#issuecomment-5464567853), reviewed at 21:28 UTC on this exact head, has no code findings. Its rank-up move to complete required exact-head CI is now satisfied. Native review artifacts are complete and validated. The maintainer has reviewed the complete evidence and accepted this fixture-owner repair for landing through the native workflow.

AI-assisted; implementation and evidence independently reviewed.
