### PR TITLE
fix(slack): admit interactive payloads durably before acking Slack

### DIFF
--- a/extensions/slack/src/monitor/ingress.interaction.test.ts
+++ b/extensions/slack/src/monitor/ingress.interaction.test.ts
@@ -1,0 +1,151 @@
+import type { ReceiverEvent } from "@slack/bolt";
+import { closeOpenClawStateDatabaseForTest } from "openclaw/plugin-sdk/channel-ingress-test-runtime";
+import type { ChannelIngressQueue } from "openclaw/plugin-sdk/channel-outbound";
+import type { PluginJsonValue } from "openclaw/plugin-sdk/plugin-entry";
+import { resetSystemEventsForTest } from "openclaw/plugin-sdk/system-event-runtime";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { attachIngress, withQueue, type SlackIngressPayload } from "./ingress.test-harness.js";
+
+describe("Slack interaction durable ingress", () => {
+  afterEach(() => {
+    closeOpenClawStateDatabaseForTest();
+    resetSystemEventsForTest();
+  });
+
+  function createSlackBlockActionsBody(): Record<string, PluginJsonValue> {
+    return {
+      type: "block_actions",
+      team: { id: "T_TEST", domain: "test" },
+      user: { id: "U_TEST", username: "alice", team_id: "T_TEST" },
+      api_app_id: "A_TEST",
+      token: "legacy-verification-token",
+      trigger_id: "trigger-1",
+      container: { type: "message", channel_id: "C_TEST", message_ts: "1700000000.000200" },
+      channel: { id: "C_TEST", name: "general" },
+      response_url: "https://slack.test/response/1",
+      actions: [
+        {
+          type: "button",
+          action_id: "openclaw:verify",
+          block_id: "b1",
+          action_ts: "1700000000.000300",
+        },
+      ],
+    };
+  }
+
+  it("does not acknowledge an interaction when the durable append fails", async () => {
+    await withQueue(async (queue) => {
+      const enqueue = vi.fn(async () => {
+        throw new Error("database unavailable");
+      });
+      const failingQueue = { ...queue, enqueue } as ChannelIngressQueue<SlackIngressPayload>;
+      const processEvent = vi.fn(async () => {});
+      const { ingress, receive } = attachIngress(failingQueue, processEvent);
+      const ack = vi.fn(async () => {});
+
+      await expect(receive({ body: createSlackBlockActionsBody(), ack })).rejects.toThrow(
+        "database unavailable",
+      );
+
+      expect(enqueue).toHaveBeenCalledTimes(1);
+      expect(ack).not.toHaveBeenCalled();
+      expect(processEvent).not.toHaveBeenCalled();
+      await ingress.stop();
+    });
+  });
+
+  it("acknowledges an interaction only after durable admission and replays it after restart", async () => {
+    await withQueue(async (queue) => {
+      const preRestartDispatch = vi.fn(async () => {});
+      const first = attachIngress(queue, preRestartDispatch);
+      const ack = vi.fn(async () => {});
+
+      await first.receive({ body: createSlackBlockActionsBody(), ack });
+
+      expect(ack).toHaveBeenCalledTimes(1);
+      expect(preRestartDispatch).not.toHaveBeenCalled();
+      await first.ingress.stop();
+
+      const dispatch = vi.fn(async (_event: ReceiverEvent) => {});
+      const restarted = attachIngress(queue, dispatch);
+      restarted.ingress.start();
+      await restarted.ingress.waitForIdle();
+
+      expect(dispatch).toHaveBeenCalledTimes(1);
+      const expected = createSlackBlockActionsBody();
+      delete expected.token;
+      expect(dispatch.mock.calls[0]?.[0]?.body).toEqual(expected);
+      await restarted.ingress.stop();
+    });
+  });
+
+  it("does not persist the legacy verification token in the interaction row", async () => {
+    await withQueue(async (queue) => {
+      const payloads: SlackIngressPayload[] = [];
+      const enqueue = vi.fn(async (...args: Parameters<typeof queue.enqueue>) => {
+        payloads.push(args[1]);
+        return await queue.enqueue(...args);
+      }) as ChannelIngressQueue<SlackIngressPayload>["enqueue"];
+      const spyQueue = { ...queue, enqueue } as ChannelIngressQueue<SlackIngressPayload>;
+      const { ingress, receive } = attachIngress(spyQueue, async () => {});
+
+      await receive({ body: createSlackBlockActionsBody(), ack: vi.fn(async () => {}) });
+
+      expect(payloads).toHaveLength(1);
+      const stored = payloads[0] as { kind: string; body: Record<string, unknown> };
+      expect(stored.kind).toBe("interaction");
+      expect(stored.body.token).toBeUndefined();
+      expect(stored.body.response_url).toBe("https://slack.test/response/1");
+      await ingress.stop();
+    });
+  });
+
+  it("admits every empty-acknowledgement interaction type durably", async () => {
+    await withQueue(async (queue) => {
+      const admitted: string[] = [];
+      const enqueue = vi.fn(async (...args: Parameters<typeof queue.enqueue>) => {
+        admitted.push(args[0]);
+        return await queue.enqueue(...args);
+      }) as ChannelIngressQueue<SlackIngressPayload>["enqueue"];
+      const spyQueue = { ...queue, enqueue } as ChannelIngressQueue<SlackIngressPayload>;
+      const processEvent = vi.fn(async () => {});
+      const { ingress, receive } = attachIngress(spyQueue, processEvent);
+
+      for (const type of ["shortcut", "message_action", "view_submission", "view_closed"]) {
+        const ack = vi.fn(async () => {});
+        await receive({ body: { type, user: { id: "U_TEST" }, team: { id: "T_TEST" } }, ack });
+        expect(ack).toHaveBeenCalledTimes(1);
+      }
+
+      expect(admitted).toHaveLength(4);
+      expect(admitted.every((id) => id.startsWith("interaction:"))).toBe(true);
+      expect(processEvent).not.toHaveBeenCalled();
+      await ingress.stop();
+    });
+  });
+
+  it("keeps payload-bearing acknowledgement types on the synchronous path", async () => {
+    await withQueue(async (queue) => {
+      const enqueue = vi.fn(async () => {
+        throw new Error("unexpected durable admission");
+      });
+      const spyQueue = { ...queue, enqueue } as ChannelIngressQueue<SlackIngressPayload>;
+      const processEvent = vi.fn(async () => {});
+      const { ingress, receive } = attachIngress(spyQueue, processEvent);
+
+      await receive({
+        body: { type: "block_suggestion", action_id: "openclaw:cmdarg", value: "he" },
+        ack: vi.fn(async () => {}),
+      });
+      await receive({
+        body: { command: "/openclaw", user_id: "U_TEST", channel_id: "C_TEST" },
+        ack: vi.fn(async () => {}),
+      });
+
+      expect(processEvent).toHaveBeenCalledTimes(2);
+      expect(enqueue).not.toHaveBeenCalled();
+      await ingress.stop();
+    });
+  });
+});

--- a/extensions/slack/src/monitor/ingress.test-harness.ts
+++ b/extensions/slack/src/monitor/ingress.test-harness.ts
@@ -1,0 +1,70 @@
+import crypto from "node:crypto";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import type { App, Receiver, ReceiverEvent } from "@slack/bolt";
+import {
+  closeOpenClawStateDatabaseForTest,
+  createChannelIngressQueueForTests,
+} from "openclaw/plugin-sdk/channel-ingress-test-runtime";
+import type { ChannelIngressQueue } from "openclaw/plugin-sdk/channel-outbound";
+import { createSlackDurableIngress } from "./ingress.js";
+
+type SlackIngressQueue = NonNullable<Parameters<typeof createSlackDurableIngress>[0]["queue"]>;
+export type SlackIngressPayload = Parameters<SlackIngressQueue["enqueue"]>[1];
+
+export function createReceiverHarness() {
+  let receive: ((event: ReceiverEvent) => Promise<void>) | undefined;
+  const receiver: Receiver = {
+    init: (app) => {
+      receive = async (event) => await app.processEvent(event);
+    },
+    start: async () => undefined,
+    stop: async () => undefined,
+  };
+  return {
+    receiver,
+    receive: async (event: ReceiverEvent) => {
+      if (!receive) {
+        throw new Error("Receiver not initialized");
+      }
+      await receive(event);
+    },
+  };
+}
+
+export function attachIngress(
+  queue: ChannelIngressQueue<SlackIngressPayload>,
+  processEvent: (event: ReceiverEvent) => Promise<void>,
+  options: { adoptionStallTimeoutMs?: number; pollIntervalMs?: number } = {},
+) {
+  const ingress = createSlackDurableIngress({
+    accountId: "default",
+    queue,
+    pollIntervalMs: options.pollIntervalMs ?? 60_000,
+    adoptionStallTimeoutMs: options.adoptionStallTimeoutMs ?? 5_000,
+  });
+  const harness = createReceiverHarness();
+  ingress.wrapReceiver(harness.receiver).init({ processEvent } as App);
+  return { ingress, receive: harness.receive };
+}
+
+export async function withQueue(
+  fn: (queue: ChannelIngressQueue<SlackIngressPayload>) => Promise<void>,
+): Promise<void> {
+  const rawRoot = await fs.mkdtemp(
+    path.join(os.tmpdir(), `openclaw-slack-ingress-${crypto.randomUUID()}-`),
+  );
+  const stateDir = await fs.realpath(rawRoot);
+  const queue = createChannelIngressQueueForTests<SlackIngressPayload>({
+    channelId: "slack",
+    accountId: "default",
+    stateDir,
+  });
+  try {
+    await fn(queue);
+  } finally {
+    closeOpenClawStateDatabaseForTest();
+    await fs.rm(stateDir, { recursive: true, force: true });
+  }
+}

--- a/extensions/slack/src/monitor/ingress.test.ts
+++ b/extensions/slack/src/monitor/ingress.test.ts
@@ -1,14 +1,7 @@
 // Slack tests cover durable Events API admission, replay, and tombstones.
-import crypto from "node:crypto";
-import fs from "node:fs/promises";
-import os from "node:os";
-import path from "node:path";
-import { App, type Receiver, type ReceiverEvent } from "@slack/bolt";
+import { App, type ReceiverEvent } from "@slack/bolt";
 import type { WebClientOptions } from "@slack/web-api";
-import {
-  closeOpenClawStateDatabaseForTest,
-  createChannelIngressQueueForTests,
-} from "openclaw/plugin-sdk/channel-ingress-test-runtime";
+import { closeOpenClawStateDatabaseForTest } from "openclaw/plugin-sdk/channel-ingress-test-runtime";
 import type {
   ChannelIngressMonitorLifecycle,
   ChannelIngressQueue,
@@ -25,10 +18,13 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { createSlackMonitorContext } from "./context.js";
 import { registerSlackMemberEvents } from "./events/members.js";
 import { createSlackDurableIngress, resolveSlackIngressTurnLifecycle } from "./ingress.js";
+import {
+  attachIngress,
+  createReceiverHarness,
+  withQueue,
+  type SlackIngressPayload,
+} from "./ingress.test-harness.js";
 import { claimSlackMessageDispatchReplay } from "./message-dispatch-dedupe.js";
-
-type SlackIngressQueue = NonNullable<Parameters<typeof createSlackDurableIngress>[0]["queue"]>;
-type SlackIngressPayload = Parameters<SlackIngressQueue["enqueue"]>[1];
 
 function createSlackEnvelope(
   eventId: string,
@@ -67,26 +63,6 @@ function createChannelIdChangedEnvelope(
       type: "channel_id_changed",
       old_channel_id: oldChannelId,
       new_channel_id: newChannelId,
-    },
-  };
-}
-
-function createReceiverHarness() {
-  let receive: ((event: ReceiverEvent) => Promise<void>) | undefined;
-  const receiver: Receiver = {
-    init: (app) => {
-      receive = async (event) => await app.processEvent(event);
-    },
-    start: async () => undefined,
-    stop: async () => undefined,
-  };
-  return {
-    receiver,
-    receive: async (event: ReceiverEvent) => {
-      if (!receive) {
-        throw new Error("Receiver not initialized");
-      }
-      await receive(event);
     },
   };
 }
@@ -210,42 +186,6 @@ function attachBoltMemberIngress(params: {
 
 function createReceiverEventWithBody(body: Record<string, unknown>): ReceiverEvent {
   return { body, ack: vi.fn(async () => {}) };
-}
-
-function attachIngress(
-  queue: ChannelIngressQueue<SlackIngressPayload>,
-  processEvent: (event: ReceiverEvent) => Promise<void>,
-  options: { adoptionStallTimeoutMs?: number; pollIntervalMs?: number } = {},
-) {
-  const ingress = createSlackDurableIngress({
-    accountId: "default",
-    queue,
-    pollIntervalMs: options.pollIntervalMs ?? 60_000,
-    adoptionStallTimeoutMs: options.adoptionStallTimeoutMs ?? 5_000,
-  });
-  const harness = createReceiverHarness();
-  ingress.wrapReceiver(harness.receiver).init({ processEvent } as App);
-  return { ingress, receive: harness.receive };
-}
-
-async function withQueue(
-  fn: (queue: ChannelIngressQueue<SlackIngressPayload>) => Promise<void>,
-): Promise<void> {
-  const rawRoot = await fs.mkdtemp(
-    path.join(os.tmpdir(), `openclaw-slack-ingress-${crypto.randomUUID()}-`),
-  );
-  const stateDir = await fs.realpath(rawRoot);
-  const queue = createChannelIngressQueueForTests<SlackIngressPayload>({
-    channelId: "slack",
-    accountId: "default",
-    stateDir,
-  });
-  try {
-    await fn(queue);
-  } finally {
-    closeOpenClawStateDatabaseForTest();
-    await fs.rm(stateDir, { recursive: true, force: true });
-  }
 }
 
 describe("Slack durable ingress", () => {

--- a/extensions/slack/src/monitor/ingress.ts
+++ b/extensions/slack/src/monitor/ingress.ts
@@ -1,4 +1,5 @@
 // Slack plugin module owns durable Events API admission and replay.
+import { randomUUID } from "node:crypto";
 import type { App, Receiver, ReceiverEvent } from "@slack/bolt";
 import {
   createChannelIngressError,
@@ -47,6 +48,7 @@ type SlackIngressPayload = {
   // key space — instead of a router delivery id whose redelivery stability
   // is not a documented contract.
   | { kind: "relay"; message: PluginJsonValue }
+  | { kind: "interaction"; body: PluginJsonValue }
 );
 
 type SlackRelayIngressEvent = {
@@ -66,6 +68,12 @@ type SlackIngressRawEvent =
       kind: "relay";
       deliveryId: string;
       message: PluginJsonValue;
+    }
+  | {
+      kind: "interaction";
+      id: string;
+      body: PluginJsonValue;
+      afterDurableAdmission?: () => Promise<void>;
     };
 
 type SlackIngressBody =
@@ -76,7 +84,8 @@ type SlackIngressBody =
       retryNum?: number;
       retryReason?: string;
     }
-  | { receivedAt: number; kind: "relay"; message: PluginJsonValue };
+  | { receivedAt: number; kind: "relay"; message: PluginJsonValue }
+  | { receivedAt: number; kind: "interaction"; body: PluginJsonValue };
 
 type SlackRelayIngressDispatch = (
   message: PluginJsonValue,
@@ -125,6 +134,7 @@ function resolveSlackIngressLane(body: unknown, eventId: string): string {
   const event = asOptionalRecord(envelope?.event);
   const item = asOptionalRecord(event?.item);
   const assistantThread = asOptionalRecord(event?.assistant_thread);
+  const container = asOptionalRecord(envelope?.container);
   const team = asOptionalRecord(envelope?.team);
   const teamId =
     [envelope?.team_id, team?.id, event?.team]
@@ -139,6 +149,8 @@ function resolveSlackIngressLane(body: unknown, eventId: string): string {
     event?.new_channel_id,
     item?.channel,
     assistantThread?.channel_id,
+    asOptionalRecord(envelope?.channel)?.id,
+    container?.channel_id,
   ]
     .find((value) => typeof value === "string" && value.trim())
     ?.toString()
@@ -146,7 +158,7 @@ function resolveSlackIngressLane(body: unknown, eventId: string): string {
   if (channelId) {
     return `team:${teamId}:conversation:${channelId}`;
   }
-  const userId = [event?.user, event?.user_id]
+  const userId = [event?.user, event?.user_id, asOptionalRecord(envelope?.user)?.id]
     .find((value) => typeof value === "string" && value.trim())
     ?.toString()
     .trim();
@@ -155,6 +167,30 @@ function resolveSlackIngressLane(body: unknown, eventId: string): string {
 
 function isSlackEventCallback(body: unknown): boolean {
   return asOptionalRecord(body)?.type === "event_callback";
+}
+
+const SLACK_INTERACTION_INGRESS_ID_PREFIX = "interaction:";
+
+const SLACK_INTERACTION_CALLBACK_TYPES = new Set([
+  "block_actions",
+  "shortcut",
+  "message_action",
+  "view_submission",
+  "view_closed",
+]);
+
+function isSlackInteractionCallback(body: unknown): boolean {
+  const type = asOptionalRecord(body)?.type;
+  return typeof type === "string" && SLACK_INTERACTION_CALLBACK_TYPES.has(type);
+}
+
+function sanitizeSlackInteractionIngressBody(body: PluginJsonValue): PluginJsonValue {
+  if (!body || typeof body !== "object" || Array.isArray(body) || body.token === undefined) {
+    return body;
+  }
+  const sanitized = { ...body };
+  delete sanitized.token;
+  return sanitized;
 }
 
 function decodeSlackIngressPayload(
@@ -167,6 +203,14 @@ function decodeSlackIngressPayload(
     }
     return { version: payload.version, body: payload };
   }
+  if (payload.kind === "interaction") {
+    if (!asOptionalRecord(payload.body)) {
+      throw new SlackIngressPayloadError(
+        `Slack interaction ingress payload ${eventId} was invalid.`,
+      );
+    }
+    return { version: payload.version, body: payload };
+  }
   if (!asOptionalRecord(payload.body) || resolveSlackEventId(payload.body) !== eventId) {
     throw new SlackIngressPayloadError(`Slack ingress payload ${eventId} was invalid.`);
   }
@@ -174,6 +218,10 @@ function decodeSlackIngressPayload(
 }
 
 function inspectSlackIngress(raw: SlackIngressRawEvent): { eventId: string; laneKey: string } {
+  if (raw.kind === "interaction") {
+    const eventId = `${SLACK_INTERACTION_INGRESS_ID_PREFIX}${raw.id}`;
+    return { eventId, laneKey: resolveSlackIngressLane(raw.body, eventId) };
+  }
   if (raw.kind === "relay") {
     const eventId = resolveSlackRelayIngressEventId({
       deliveryId: raw.deliveryId,
@@ -244,29 +292,45 @@ export function createSlackDurableIngress(
     inspect: inspectSlackIngress,
     payload: {
       version: SLACK_INGRESS_PAYLOAD_VERSION,
-      serialize: (raw, { receivedAt }) =>
-        raw.kind === "relay"
-          ? { kind: "relay", receivedAt, message: raw.message }
-          : {
-              kind: "events-api",
-              receivedAt,
-              body: raw.body,
-              ...(raw.retryNum === undefined ? {} : { retryNum: raw.retryNum }),
-              ...(raw.retryReason === undefined ? {} : { retryReason: raw.retryReason }),
-            },
-      deserialize: (body, { claim }) =>
-        body.kind === "relay"
-          ? {
-              kind: "relay",
-              deliveryId: claim.id.startsWith("relay:") ? claim.id.slice(6) : claim.id,
-              message: body.message,
-            }
-          : {
-              kind: "events-api",
-              body: body.body,
-              ...(body.retryNum === undefined ? {} : { retryNum: body.retryNum }),
-              ...(body.retryReason === undefined ? {} : { retryReason: body.retryReason }),
-            },
+      serialize: (raw, { receivedAt }) => {
+        if (raw.kind === "relay") {
+          return { kind: "relay", receivedAt, message: raw.message };
+        }
+        if (raw.kind === "interaction") {
+          return { kind: "interaction", receivedAt, body: raw.body };
+        }
+        return {
+          kind: "events-api",
+          receivedAt,
+          body: raw.body,
+          ...(raw.retryNum === undefined ? {} : { retryNum: raw.retryNum }),
+          ...(raw.retryReason === undefined ? {} : { retryReason: raw.retryReason }),
+        };
+      },
+      deserialize: (body, { claim }) => {
+        if (body.kind === "relay") {
+          return {
+            kind: "relay",
+            deliveryId: claim.id.startsWith("relay:") ? claim.id.slice(6) : claim.id,
+            message: body.message,
+          };
+        }
+        if (body.kind === "interaction") {
+          return {
+            kind: "interaction",
+            id: claim.id.startsWith(SLACK_INTERACTION_INGRESS_ID_PREFIX)
+              ? claim.id.slice(SLACK_INTERACTION_INGRESS_ID_PREFIX.length)
+              : claim.id,
+            body: body.body,
+          };
+        }
+        return {
+          kind: "events-api",
+          body: body.body,
+          ...(body.retryNum === undefined ? {} : { retryNum: body.retryNum }),
+          ...(body.retryReason === undefined ? {} : { retryReason: body.retryReason }),
+        };
+      },
       encode: ({ body }) => ({ version: SLACK_INGRESS_PAYLOAD_VERSION, ...body }),
       decode: (payload, { claim }) => decodeSlackIngressPayload(payload, claim.id),
       createClaimError: (_kind, claim) =>
@@ -275,7 +339,7 @@ export function createSlackDurableIngress(
     // Slack's HTTP acknowledgement is transport-private and must complete after
     // durable append but before the shared monitor makes the row drainable.
     onDurableAdmission: async (raw) => {
-      if (raw.kind === "events-api") {
+      if (raw.kind !== "relay") {
         await raw.afterDurableAdmission?.();
       }
     },
@@ -404,11 +468,12 @@ export function createSlackDurableIngress(
           if (!app) {
             throw new Error("Slack ingress receiver is not attached to a Bolt app.");
           }
+          const retry = raw.kind === "events-api" ? raw : undefined;
           await app.processEvent({
             body: raw.body as ReceiverEvent["body"],
             ack: async () => {},
-            ...(raw.retryNum === undefined ? {} : { retryNum: raw.retryNum }),
-            ...(raw.retryReason === undefined ? {} : { retryReason: raw.retryReason }),
+            ...(retry?.retryNum === undefined ? {} : { retryNum: retry.retryNum }),
+            ...(retry?.retryReason === undefined ? {} : { retryReason: retry.retryReason }),
             customProperties: {
               [SLACK_INGRESS_LIFECYCLE_CONTEXT_KEY]: routedLifecycle,
             },
@@ -443,20 +508,30 @@ export function createSlackDurableIngress(
   });
 
   const acceptReceiverEvent = async (event: ReceiverEvent): Promise<void> => {
-    if (!isSlackEventCallback(event.body)) {
-      if (!app) {
-        throw new Error("Slack ingress receiver is not attached to a Bolt app.");
-      }
-      await app.processEvent(event);
+    const body = event.body as PluginJsonValue;
+    if (isSlackEventCallback(body)) {
+      await monitor.admit({
+        kind: "events-api",
+        body,
+        ...(event.retryNum === undefined ? {} : { retryNum: event.retryNum }),
+        ...(event.retryReason === undefined ? {} : { retryReason: event.retryReason }),
+        afterDurableAdmission: () => event.ack(),
+      });
       return;
     }
-    await monitor.admit({
-      kind: "events-api",
-      body: event.body as PluginJsonValue,
-      ...(event.retryNum === undefined ? {} : { retryNum: event.retryNum }),
-      ...(event.retryReason === undefined ? {} : { retryReason: event.retryReason }),
-      afterDurableAdmission: () => event.ack(),
-    });
+    if (isSlackInteractionCallback(body)) {
+      await monitor.admit({
+        kind: "interaction",
+        id: randomUUID(),
+        body: sanitizeSlackInteractionIngressBody(body),
+        afterDurableAdmission: () => event.ack(),
+      });
+      return;
+    }
+    if (!app) {
+      throw new Error("Slack ingress receiver is not attached to a Bolt app.");
+    }
+    await app.processEvent(event);
   };
 
   const acceptRelayEvent = async (event: SlackRelayIngressEvent): Promise<void> => {


### PR DESCRIPTION
## What Problem This Solves

When a user taps an OpenClaw-rendered Block Kit button (or triggers a shortcut, message action, or modal submit/close), the Slack monitor acknowledges Slack with HTTP 200 immediately and only then parks the interaction in the in-memory system-event queue. If the gateway restarts, crashes, or the handler throws after that 200, the click is gone: Slack does not redeliver acknowledged interactive payloads, there is no ingress row, and there is no transcript entry. The button UI may even be rewritten to look handled while the agent never saw the click.

The message path already gets this right: Events API callbacks are appended to the durable ingress queue first and the transport ack runs in `afterDurableAdmission`. Interactive payloads (`block_actions`, `shortcut`, `message_action`, `view_submission`, `view_closed`) bypassed that admission entirely in `acceptReceiverEvent` and went straight to `app.processEvent`, where every handler acks before enqueueing. That is still the shape on current `main`:

```ts
const acceptReceiverEvent = async (event: ReceiverEvent): Promise<void> => {
  if (!isSlackEventCallback(event.body)) {
    if (!app) {
      throw new Error("Slack ingress receiver is not attached to a Bolt app.");
    }
    await app.processEvent(event);
    return;
  }
  await monitor.admit({
    kind: "events-api",
    body: event.body as PluginJsonValue,
    afterDurableAdmission: () => event.ack(),
  });
};
```

This is default-on: `registerSlackInteractionEvents` is always registered and `app.action(/.+/)` is unconditional, so any Slack-enabled gateway is exposed with no extra configuration.

## Why This Change Was Made

Interactive callbacks now flow through the same durable admission contract as Events API messages. A new `interaction` ingress kind carries the payload with an admission-time unique id (interactives have no `event_id`, and `view_closed` has no `trigger_id`, so no payload field can serve as a stable durable key; Slack never redelivers interactives, so the id only needs uniqueness). The transport ack completes only after the durable append, and claimed rows replay through the Bolt app after a restart with the same no-op-ack dispatch the message replay path already uses. A throwing interaction handler now lands in the drain's retry policy instead of being lost behind an already-sent 200.

The lane resolver learned the interactive payload shapes (`channel.id`, `container.channel_id`, `user.id` at the envelope level) as trailing candidates, so interactions serialize behind the same team/conversation lanes as messages without touching existing lane derivation for Events API bodies.

Secrets at rest: the legacy verification `token` field is stripped from interaction bodies before serialization; nothing in the plugin or in Bolt consumes it, and it is the only long-lived credential in these payloads. `response_url` and `trigger_id` are retained because production handlers consume them during the immediate drain (ephemeral responses, legacy button updates, context keys), and both are short-TTL capabilities (about 30 minutes and 3 seconds respectively). Completed rows already clear `payload_json` in the shared queue's `complete()` (`src/channels/message/ingress-queue.ts`), so only transient in-flight rows and dead-lettered failed rows ever hold a payload. Events API envelopes carry the same legacy `token` field in their pre-existing durable rows; that shipped behavior is unchanged here.

Retry and dedupe contract for the admission-time id: Slack retries only Events API deliveries (its documented retry policy with `x-slack-retry-num`, which is why that path dedupes on `event_id`); interactive payload POSTs are delivered once, and a failed delivery surfaces as an error to the clicking user rather than a redelivery, so a fresh unique id cannot double-admit a click. Bolt performs no deduplication of its own on either path.

Those Bolt-specific assertions were re-checked by hand against the `@slack/bolt` package present in this checkout, since an earlier review round could not resolve them:

- No deduplication exists in the library. There is no event-id cache, no seen-set, and no duplicate suppression anywhere in `dist/App.js` or `dist/receivers/`.
- `retryNum` and `retryReason` are populated only from the `x-slack-retry-num` / `x-slack-retry-reason` HTTP headers (`dist/receivers/HTTPModuleFunctions.js`, `HTTPReceiver.js`, `ExpressReceiver.js`, `AwsLambdaReceiver.js`) and from Socket Mode's `retry_num` / `retry_reason` frame fields (`dist/receivers/SocketModeReceiver.js`). They are Events API delivery semantics, and no interactive path sets them.
- Request authenticity comes from the signing-secret HMAC in `dist/receivers/verify-request.js`. `dist/App.js` never reads `body.token`, which is what makes stripping the legacy verification token safe rather than merely unused-looking.

Deliberately excluded from durable admission, on purpose and covered by a regression test: `block_suggestion` (external select menus) and slash commands, because their acks carry response payloads Slack renders synchronously (`ack({ options })`, `ack({ text })`). Every handler for the five admitted types acks with an empty body, so the early empty 200 from `afterDurableAdmission` is byte-identical to what production already sends. Slash commands are also opt-in, unlike block actions.

Scope of the invariant this PR repairs: no interaction may be acknowledged to Slack before a durable record of it exists. Before this change an acknowledged click could vanish with zero durable trace anywhere. After it, the click is admitted, replayed after a crash, and handed to the production handlers exactly like every other durably admitted Slack event (member joins, reactions, messages that resolve to system events).

## Maintainer decisions required

Two review items are deliberate tradeoffs rather than defects in this diff. Neither is author-actionable without changing a contract that is shared far beyond Slack, so both are put here explicitly for a maintainer to accept or reject.

**1. Downstream custody stops at the shared in-memory system-event queue (merge-risk: message-delivery).**

The review is factually right: the interaction handlers return after `enqueueRoutedSystemEvent`, the drain then takes its default completion path, and a crash between that completion and the next heartbeat still loses the click. What the finding does not distinguish is that this window is not introduced by this PR. It is the contract every durably admitted Slack event already lives under on `main` today: reactions, pins, member joins, channel events and messages that resolve to system events all deposit into the same intentionally transient queue and all complete their ingress row the same way. This PR moves interactions from "no durable record ever exists, and the click is unrecoverable from the moment the 200 is sent" to "identical custody to every other Slack event". Closing the remaining window means making the shared system-event queue durable, which is a persistent-store product decision (database-first doctrine plus the SQLite change approval gate) affecting every producer on every channel, not a Slack fix. It is filed as #132842, still open. Widening this PR to carry a private durable handoff for interactions only would fork that shared contract and make the change unreviewable, so it is deliberately not attempted here. This corresponds to the review's own merge-risk option 2, accept narrow ingress durability.

**2. The persisted interaction row retains `response_url` and `trigger_id` (merge-risk: security-boundary).**

The sanitizer is a denylist that removes the legacy verification `token` and keeps the rest. A minimized allowlist envelope was considered and rejected as incorrect, not as extra work: the replay path hands the stored body back to the unmodified production Bolt handlers, and those handlers consume `response_url` directly (`interactions.block-actions.ts`, `interactions.shortcuts.ts`). `view_submission` replay additionally needs `view.state.values`, which is arbitrary user-authored form content with no fixed field set to allowlist. Dropping those fields would not minimize the envelope, it would break the replay this PR exists to provide.

What is new this round is a sharper bound on the dead-letter half of the concern, read off the shared retry policy rather than asserted. `resolveIngressFailureDisposition` in `src/channels/message/ingress-retry-policy.ts` reaches the `retry-limit-exceeded` dead letter only through `shouldDeadLetterRetryableIngressEvent`, which requires **both** `attempt >= maxAttempts` and `now - receivedAt >= deadLetterMinAgeMs`, with defaults of 8 attempts and 24 hours. So a row that dead-letters on the ordinary retry path cannot be younger than 24 hours, and the `response_url` (about 30 minutes) and `trigger_id` (about 3 seconds) it carries expired at least 23.5 hours before the row became a dead letter. Retained is the right word; capability is not.

The honest exception, which is the part a maintainer should actually rule on: Slack ingress also passes `resolveNonRetryableFailure`, so a payload decode error (`SlackIngressPayloadError`, `SyntaxError`) or a non-recoverable Slack auth error fails the row immediately, with no age floor. In that narrow case a dead-lettered interaction row can hold a `response_url` that is still live for up to about 30 minutes, alongside whatever the user typed into a modal. Accepting this PR means accepting that window. If it is not acceptable, the correct fix is a protected storage boundary for ingress payloads across all channels, which is again not a Slack change.

## Sibling surfaces

Within the durable ingress monitors, Slack is the only channel with a synchronous transport acknowledgement to order against the durable append: `afterDurableAdmission` appears nowhere else in `extensions/`, and the other ingress monitors (`extensions/discord/src/monitor/ingress.ts`, `extensions/imessage/src/monitor/ingress.ts`, `extensions/tlon/src/monitor/ingress.ts`) admit from pull or socket sources with no HTTP ack to reorder. So there is no ack-before-admit sibling to fix inside this seam.

The same defect class does exist on two other channels, but at different seams with different transport contracts, so each needs its own bounded change rather than a copy of this one: Mattermost button clicks respond 200 from a custom HTTP handler and dispatch from RAM (`extensions/mattermost/src/mattermost/interactions.ts`), and Discord native command interactions ack via `interaction.defer()` with no durable admit (`extensions/discord/src/monitor/native-command.ts`). Both are message-only ingress pipelines whose interaction endpoints sit outside the ingress monitor entirely, and both return dynamic bodies or own a defer/token lifecycle that this Slack-shaped fix does not model. They are filed separately as #132840 (Mattermost) and #132841 (Discord), both still open. Related but distinct existing reports: #102380, #91888, #99544 concern heartbeat injection of an already-queued click, not crash-after-ack; #117763 is the same RAM-queue class on a different channel; #127516 is Discord gateway sequence handling.

## User Impact

A Slack button click, shortcut, message action, or modal submit that arrives just before a gateway restart or crash is now executed after the restart instead of silently vanishing. No configuration changes, no new options, and no behavior change for slash commands, select-menu typeahead, or Events API messages.

## Verification

Run on the rebased tree, head `dfa262ac5909e8e3fe8b19b541f308f33cf111b2`, base `main` at `fe565dd968a34be3b2abc2fb295eb1da338613d6`.

- `node scripts/run-vitest.mjs extensions/slack/src/monitor/ingress.test.ts extensions/slack/src/monitor/ingress.interaction.test.ts`: 26 passed, including 5 regression cases for this fix (durable-append failure blocks the ack, ack-then-restart replay, all five types admitted, payload-bearing acks stay synchronous, and the persisted interaction row carries no legacy verification token). With `ingress.ts` reverted to `origin/main` the durability cases fail (interaction acked with no durable row, nothing replays after restart) and the synchronous-passthrough guard still passes, as intended.
- `node scripts/run-vitest.mjs extensions/slack/src/monitor/events/interactions.test.ts extensions/slack/src/monitor/events.enterprise.test.ts extensions/slack/src/monitor/relay-source.test.ts`: 93 passed.
- `oxfmt --check` on all four changed files: clean.
- This rebase was not a fast-forward. `extensions/slack/src/monitor/ingress.test.ts` conflicted with two landed changes and both were kept rather than reasserted: the `claimSlackMessageDispatchReplay` import and its two new duplicate-lane cases from #143661, and the `pollIntervalMs` option that landed on the in-file `attachIngress` helper, which this branch had moved to `ingress.test-harness.ts` and which now carries that option. `extensions/slack/src/monitor/ingress.ts` merged without conflict.
- Not run on this host, which is memory constrained: `tsgo`, `oxlint`, `pnpm check`, `pnpm build`, and the full suite. A type error in the new or moved test code would surface only in CI. The local evidence above is the targeted suites, the formatter, and the runtime proof below; please do not read it as a green local gate run.

## Real behavior proof

Behavior addressed: a Slack Block Kit button click is acknowledged with HTTP 200 and then lost forever if the gateway process dies before consuming it, because Slack never redelivers an acknowledged interactive payload.
Real environment tested: two real gateway processes on pristine main `fe565dd968a34be3b2abc2fb295eb1da338613d6` and on the patched tree at `dfa262ac5909e8e3fe8b19b541f308f33cf111b2`, each built by the production `createSlackBoltApp` factory in http mode, running the real Bolt `HTTPReceiver` on 127.0.0.1 with Slack request-signature verification enabled, wrapped by the production `createSlackDurableIngress`, over the production `createChannelIngressQueue` writing real on-disk SQLite in the process state directory, with a production `createSlackMonitorContext` and the production `registerSlackInteractionEvents` handlers registered; the click was delivered as a genuinely signed `application/x-www-form-urlencoded` HTTP POST exactly as Slack's edge sends it, the first process was killed with SIGKILL after its HTTP 200 and before its drain consumed the row, and a second process recovered from the same state directory through the real drain, real event-scope resolution, and real block-action authorization; the only substituted seam was the outbound Slack Web API host (`conversations.info`, `users.info`, `auth.test`), pointed at a loopback endpoint returning canned identities.
Exact steps or command run after this patch: start the gateway process, POST one signed `block_actions` payload for `openclaw:verify` in channel C_TEST to `/slack/events` on the loopback receiver port, SIGKILL the gateway after the HTTP 200 and before its drain consumed the row, then start a fresh gateway on the same state directory and read the owner-facing system-event queue.
Evidence after fix:
```
# BEFORE (pristine main fe565dd968a3)
gateway serve: real Bolt HTTPReceiver listening on 127.0.0.1:18967 with Slack signature verification enabled
gateway serve: ready
gateway serve: slack web api call /api/auth.test
slack edge: signed block_actions POST -> HTTP 200 body="" after 191ms (signature verified by Bolt HTTPReceiver)
slack edge: gateway process SIGKILLed after the HTTP 200, before its drain consumed the click (RAM gone; Slack never redelivers an acked interaction)
gateway serve: slack web api call /api/conversations.info
gateway recover: real Bolt HTTPReceiver constructed on 127.0.0.1:18967 with Slack signature verification enabled
gateway recover: owner-facing system events for session agent:main:slack:channel:c_test: (none)
gateway recover: RESULT replayedInteractions=0

# AFTER (this patch dfa262ac5909, identical signed POST)
gateway serve: real Bolt HTTPReceiver listening on 127.0.0.1:18957 with Slack signature verification enabled
gateway serve: ready
gateway serve: durable ingress row appended id=interaction:242ea2b8-eb45-4981-866d-09cedf22ea27 at t=1789242612785
slack edge: signed block_actions POST -> HTTP 200 body="" after 402ms (signature verified by Bolt HTTPReceiver)
slack edge: gateway process SIGKILLed after the HTTP 200, before its drain consumed the click (RAM gone; Slack never redelivers an acked interaction)
gateway recover: real Bolt HTTPReceiver constructed on 127.0.0.1:18957 with Slack signature verification enabled
gateway recover: slack web api call /api/auth.test
gateway recover: slack web api call /api/conversations.info
gateway recover: slack web api call /api/users.info
gateway recover: owner-facing system events for session agent:main:slack:channel:c_test:
gateway recover:   "Slack interaction: {\"interactionType\":\"block_action\",\"actionId\":\"openclaw:verify\",\"blockId\":\"b1\",\"actionType\":\"button\",\"userId\":\"U_TEST\",\"teamId\":\"T_TEST\",\"triggerId\":\"[redacted]\",\
gateway recover: RESULT replayedInteractions=1
```
Observed result after fix: on pristine main the signed click got its HTTP 200 and the handler ran only in RAM, with no durable row ever written, so the restarted gateway recovered nothing; with this patch the durable row was appended before the HTTP 200 left the socket, the SIGKILLed click survived, and the restarted gateway delivered it through the production block-action pipeline into the owner-facing queue for the C_TEST session.
What was not tested: no live slack.com workspace was driven end to end (the loopback HTTP edge carried real signed Slack-shaped requests instead); the heartbeat turn that consumes the recovered system event into an agent reply was not driven; the crash window after a handler returns and before the heartbeat drains the shared in-memory system-event queue is unchanged by this PR and is not exercised here (see Maintainer decisions required, item 1, and #132842); the Mattermost and Discord sibling surfaces are unchanged by this PR; type checking, linting and the full build were not run on this host.
