### PR TITLE
docs: clarify agent ownership in session monitoring

### DIFF
--- a/docs/concepts/session-state.md
+++ b/docs/concepts/session-state.md
@@ -115,7 +115,7 @@ Current limits:
 - Paired-node Claude history reads do not expose a definitive thread-not-found result, so remote Claude deletions are not classified as `upstream_missing` in v1.
 - Catalog sessions that have not been adopted remain outside the awareness layer in v1.
 - Sessions adopted before this feature carry no upstream link; continue them from the catalog once to start upstream monitoring.
-- Upstream links assume each adopted session key maps to one owning agent (adoption uses the default store agent). Multi-agent adoption of the same external thread is not monitored in v1.
+- Upstream monitoring requires one owning agent per adopted session key. Adoption uses the resolved agent and returns an agent-qualified key; distinct watched keys can monitor the same native thread. Links that reuse the exact same key under multiple agent IDs are skipped as ambiguous.
 
 ## Related
 

--- a/src/gateway/server-methods/session-catalog.ts
+++ b/src/gateway/server-methods/session-catalog.ts
@@ -650,10 +650,8 @@ export const sessionCatalogHandlers: GatewayRequestHandlers = {
           afterBind: result.afterConversationBound,
         });
       }
-      // Adopted sessions are created under the resolved default store agent, so the
-      // key-derived agent matches the owning agent. Provider-authoritative agent
-      // identity (a `SessionCatalogContinueProviderResult.agentId`) is a follow-up
-      // that would let adapters adopt under non-default agents; see issue tracker.
+      // Session creation canonicalizes the adopted key with its resolved agent,
+      // including non-default agents. Use the returned key's owner for links and events.
       const agentId = resolveAgentIdFromSessionKey(result.sessionKey);
       if (result.upstream) {
         // Links exist only for adoptions made on this version: pre-upgrade adopted

--- a/src/sessions/session-upstream-links.ts
+++ b/src/sessions/session-upstream-links.ts
@@ -226,11 +226,9 @@ export function listWatchedSessionUpstreamLinks(
   const grouped = new Map<string, SessionUpstreamLink[]>();
   try {
     const { db } = openOpenClawStateDatabase(options);
-    // Watch cursors own demand. Unwatched adopted sessions stay out of the polling hot path.
-    // The join matches on session_key only, which is unambiguous because adoption creates
-    // links under the single resolved store agent (one row per session_key). The seen-key
-    // guard below fails closed if a future multi-agent adoption ever breaks that invariant,
-    // so a cross-agent link can never be probed against another agent's watch cursor.
+    // Watch cursors own demand. Their key-only join relies on one owning agent per
+    // adopted session key, not one agent per native thread. Agent-qualified keys
+    // keep separate adoptions of the same thread distinct.
     const rows = executeSqliteQuerySync(
       db,
       getSessionUpstreamKysely(db)
@@ -247,8 +245,8 @@ export function listWatchedSessionUpstreamLinks(
     ).rows;
     const links = rows.map(rowToSessionUpstreamLink);
     // Fail closed on the single-agent-per-key invariant: the key-only cursor join
-    // cannot disambiguate two agents sharing a bare adopted key, so drop EVERY link
-    // for any duplicated key rather than probe an arbitrary agent's upstream.
+    // cannot disambiguate multiple agents sharing the exact same adopted key.
+    // Drop every link for that key rather than probe an arbitrary agent's upstream.
     const keyCounts = new Map<string, number>();
     for (const link of links) {
       keyCounts.set(link.sessionKey, (keyCounts.get(link.sessionKey) ?? 0) + 1);


### PR DESCRIPTION
Related: #107215 (provider-authoritative identity follow-up for adopted catalog sessions).

## What Problem This Solves

Resolves a documentation problem where session-state guidance says catalog adoption uses only the default store agent and that multiple agents adopting the same native thread cannot be monitored. The Gateway and upstream-link comments repeat the same stale premise.

## Why This Change Was Made

Current Pi and OpenCode consumers pass the resolved agent into `runtime.agent.session.createSessionEntry`, and session creation returns an agent-qualified key. The monitor's restriction is **one owning agent per adopted session key**, not one agent per native thread. Distinct watched keys can reference the same native thread; the existing ambiguity guard skips every link only when the exact same key is stored under multiple agent IDs.

This changes documentation and comments only. It does not change runtime behavior, storage/schema, names, or the Plugin SDK. The separate shared-family in-flight coordination repair is untouched. It does not claim complete cross-adoption provenance isolation or introduce the additional provider-result field proposed in the related issue.

## User Impact

Operators and maintainers get an accurate explanation of adoption ownership and the remaining monitoring restriction, without a behavior or configuration change. The existing per-adoption self-echo limitation remains: matching uses that adoption's own recent OpenClaw-side history.

## Evidence

AI-assisted, source-audited documentation correction. The trace covered agent resolution and canonical session creation, upstream-link persistence and watcher selection, provider probes, per-key result correlation, marker/dedupe updates, state events and notices, reconciliation, restart recovery, and deletion cleanup.

Key source evidence:

- `extensions/acpx/src/pi-session-catalog-runtime.ts:103` and `extensions/opencode/session-catalog-plugin.ts:167`: explicit resolved agent passed to creation; returned canonical key retained.
- `src/gateway/session-create-service.ts:441` and `src/routing/session-key.ts:118`: agent-qualified creation keys.
- `src/sessions/session-upstream-links.ts`: composite link identity, key-based watcher join, and duplicate-key rejection.
- `src/sessions/session-upstream-monitor.ts:208`: each link supplies its agent, key, marker, and own-user history; outcomes correlate by key and writes retain the agent.
- Pi processes each probe separately; OpenCode deduplicates native thread IDs only for its indicator query, then classifies each probe separately.

Existing focused tests: **163 passed across 13 files / 8 Vitest shards**:

```bash
node scripts/run-vitest.mjs src/sessions/session-upstream-links.test.ts src/sessions/session-upstream-monitor.test.ts src/sessions/session-state-events.test.ts src/sessions/session-state-notices.test.ts src/gateway/server-methods/session-catalog.test.ts src/plugins/runtime/runtime-agent.acp-binding.test.ts src/plugin-sdk/session-catalog.test.ts extensions/acpx/src/pi-session-catalog-continuation.test.ts extensions/acpx/src/pi-session-upstream-activity.test.ts extensions/opencode/session-catalog.test.ts extensions/opencode/session-upstream-activity.test.ts extensions/anthropic/session-upstream-activity.test.ts extensions/codex/src/session-upstream-activity.test.ts
```

Additional checks passed:

```bash
pnpm docs:list
```

```bash
node scripts/check-docs-mdx.mjs docs/concepts/session-state.md
```

```bash
node_modules/.bin/oxfmt --check src/gateway/server-methods/session-catalog.ts src/sessions/session-upstream-links.ts
```

```bash
git diff --check
```

Every changed TypeScript line was verified to be a comment. Production executable LOC: +0/-0. Source comments: +7/-11 (net -4). Tests/test support: +0/-0. Documentation: +1/-1.

Proof boundary: the existing tests cover adoption coordination and the individual monitoring/watcher owners, but not a complete two-agent/same-native-thread monitoring scenario. No new tests or live Gateway flow were added because this patch changes only explanatory text; it does not establish complete cross-adoption self-echo isolation.

Public documentation: https://docs.openclaw.ai/concepts/session-state
