### PR TITLE
fix: prevent restart after dirty rollback builds

### DIFF
--- a/src/cli/update-cli/update-command-post-update.test.ts
+++ b/src/cli/update-cli/update-command-post-update.test.ts
@@ -886,12 +886,15 @@ function failedResult(recovery: UpdateRunResult["recovery"]): UpdateRunResult {
   };
 }
 
-async function finishFailedUpdate(result: UpdateRunResult, json = false): Promise<void> {
+async function finishFailedUpdate(
+  result: UpdateRunResult,
+  options: { json?: boolean; stopped?: boolean } = {},
+): Promise<void> {
   await finishUpdate({
     result,
-    opts: { json },
+    opts: { json: options.json },
     showProgress: false,
-    preManagedServiceStop: { stopped: true, serviceEnv: {} },
+    preManagedServiceStop: { stopped: options.stopped ?? true, serviceEnv: {} },
     controlPlaneUpdateSentinelMeta: undefined,
   } as unknown as FinishUpdateParams);
 }
@@ -973,9 +976,24 @@ describe("failed Git update recovery restart", () => {
     expect(mocks.restart).not.toHaveBeenCalled();
     expect(output).toContain("From the update root shown above");
     expect(output).toContain("git status --short");
-    expect(output).toContain("resolve the tracked changes");
+    expect(output).toContain("resolve the reported changes");
     expect(output).toContain("rerun `openclaw update`");
     expect(output).toContain("Keep the gateway stopped until the update succeeds");
+  });
+
+  it("does not claim an unsafe recovery stopped a service that was already down", async () => {
+    const log = vi.spyOn(defaultRuntime, "log").mockImplementation(() => undefined);
+
+    await finishFailedUpdate(
+      failedResult({ serviceRestartSafe: false, reason: "rollback-checkout-dirty" }),
+      { stopped: false },
+    );
+
+    const output = log.mock.calls.flat().map(String).join("\n");
+    expect(output).toContain("Update recovery could not prove a runnable installation");
+    expect(output).toContain("resolve the reported changes");
+    expect(output).not.toContain("remains stopped");
+    expect(output).not.toContain("Keep the gateway stopped");
   });
 
   it("keeps structured JSON recovery free of prose guidance", async () => {
@@ -985,7 +1003,7 @@ describe("failed Git update recovery restart", () => {
       reason: "rollback-checkout-dirty",
     });
 
-    await finishFailedUpdate(result, true);
+    await finishFailedUpdate(result, { json: true });
 
     expect(mocks.printResult).toHaveBeenCalledWith(result, expect.objectContaining({ json: true }));
     expect(mocks.restart).not.toHaveBeenCalled();

--- a/src/cli/update-cli/update-command-post-update.test.ts
+++ b/src/cli/update-cli/update-command-post-update.test.ts
@@ -103,6 +103,7 @@ type FinishUpdateParams = Parameters<typeof finishUpdate>[0];
 const stdinIsTTYDescriptor = Object.getOwnPropertyDescriptor(process.stdin, "isTTY");
 
 afterEach(() => {
+  vi.unstubAllEnvs();
   if (stdinIsTTYDescriptor) {
     Object.defineProperty(process.stdin, "isTTY", stdinIsTTYDescriptor);
   } else {
@@ -979,6 +980,19 @@ describe("failed Git update recovery restart", () => {
     expect(output).toContain("resolve the reported changes");
     expect(output).toContain("rerun `openclaw update`");
     expect(output).toContain("Keep the gateway stopped until the update succeeds");
+  });
+
+  it("preserves the active profile in unsafe recovery guidance", async () => {
+    vi.stubEnv("OPENCLAW_PROFILE", "work");
+    const log = vi.spyOn(defaultRuntime, "log").mockImplementation(() => undefined);
+
+    await finishFailedUpdate(
+      failedResult({ serviceRestartSafe: false, reason: "rollback-checkout-dirty" }),
+    );
+
+    const output = log.mock.calls.flat().map(String).join("\n");
+    expect(output).toContain("rerun `openclaw --profile work update`");
+    expect(output).not.toContain("rerun `openclaw update`");
   });
 
   it("does not claim an unsafe recovery stopped a service that was already down", async () => {

--- a/src/cli/update-cli/update-command-post-update.test.ts
+++ b/src/cli/update-cli/update-command-post-update.test.ts
@@ -886,10 +886,10 @@ function failedResult(recovery: UpdateRunResult["recovery"]): UpdateRunResult {
   };
 }
 
-async function finishFailedUpdate(result: UpdateRunResult): Promise<void> {
+async function finishFailedUpdate(result: UpdateRunResult, json = false): Promise<void> {
   await finishUpdate({
     result,
-    opts: {},
+    opts: { json },
     showProgress: false,
     preManagedServiceStop: { stopped: true, serviceEnv: {} },
     controlPlaneUpdateSentinelMeta: undefined,
@@ -971,9 +971,24 @@ describe("failed Git update recovery restart", () => {
 
     const output = log.mock.calls.flat().map(String).join("\n");
     expect(mocks.restart).not.toHaveBeenCalled();
+    expect(output).toContain("From the update root shown above");
     expect(output).toContain("git status --short");
     expect(output).toContain("resolve the tracked changes");
     expect(output).toContain("rerun `openclaw update`");
     expect(output).toContain("Keep the gateway stopped until the update succeeds");
+  });
+
+  it("keeps structured JSON recovery free of prose guidance", async () => {
+    const log = vi.spyOn(defaultRuntime, "log").mockImplementation(() => undefined);
+    const result = failedResult({
+      serviceRestartSafe: false,
+      reason: "rollback-checkout-dirty",
+    });
+
+    await finishFailedUpdate(result, true);
+
+    expect(mocks.printResult).toHaveBeenCalledWith(result, expect.objectContaining({ json: true }));
+    expect(mocks.restart).not.toHaveBeenCalled();
+    expect(log).not.toHaveBeenCalled();
   });
 });

--- a/src/cli/update-cli/update-command-post-update.test.ts
+++ b/src/cli/update-cli/update-command-post-update.test.ts
@@ -956,5 +956,24 @@ describe("failed Git update recovery restart", () => {
 
     expect(mocks.restart).not.toHaveBeenCalled();
     expect(log).toHaveBeenCalledWith(expect.stringContaining("Managed gateway remains stopped"));
+    expect(log).toHaveBeenCalledWith(
+      expect.stringContaining("repair the checkout or installation"),
+    );
+    expect(log).toHaveBeenCalledWith(expect.stringContaining("rerun `openclaw update`"));
+  });
+
+  it("explains how to recover from a dirty rollback checkout", async () => {
+    const log = vi.spyOn(defaultRuntime, "log").mockImplementation(() => undefined);
+
+    await finishFailedUpdate(
+      failedResult({ serviceRestartSafe: false, reason: "rollback-checkout-dirty" }),
+    );
+
+    const output = log.mock.calls.flat().map(String).join("\n");
+    expect(mocks.restart).not.toHaveBeenCalled();
+    expect(output).toContain("git status --short");
+    expect(output).toContain("resolve the tracked changes");
+    expect(output).toContain("rerun `openclaw update`");
+    expect(output).toContain("Keep the gateway stopped until the update succeeds");
   });
 });

--- a/src/cli/update-cli/update-command-post-update.ts
+++ b/src/cli/update-cli/update-command-post-update.ts
@@ -129,6 +129,19 @@ export async function finishUpdate(params: {
             `Managed gateway remains stopped because update recovery could not prove a runnable installation (${params.result.recovery.reason}).`,
           ),
         );
+        if (params.result.recovery.reason === "rollback-checkout-dirty") {
+          defaultRuntime.log(
+            theme.muted(
+              "Inspect the checkout with `git status --short`, resolve the tracked changes, then rerun `openclaw update`. Keep the gateway stopped until the update succeeds.",
+            ),
+          );
+        } else {
+          defaultRuntime.log(
+            theme.muted(
+              "Review the failed recovery step above, repair the checkout or installation, then rerun `openclaw update`. Keep the gateway stopped until the update succeeds.",
+            ),
+          );
+        }
       }
     } else {
       await maybeRestartServiceAfterFailedMutableUpdate({

--- a/src/cli/update-cli/update-command-post-update.ts
+++ b/src/cli/update-cli/update-command-post-update.ts
@@ -125,14 +125,20 @@ export async function finishUpdate(params: {
     });
     if (params.result.recovery?.serviceRestartSafe === false) {
       if (!params.opts.json) {
+        const managedGatewayStopped = params.preManagedServiceStop?.stopped === true;
         defaultRuntime.log(
           theme.warn(
-            `Managed gateway remains stopped because update recovery could not prove a runnable installation (${params.result.recovery.reason}).`,
+            managedGatewayStopped
+              ? `Managed gateway remains stopped because update recovery could not prove a runnable installation (${params.result.recovery.reason}).`
+              : `Update recovery could not prove a runnable installation (${params.result.recovery.reason}).`,
           ),
         );
         defaultRuntime.log(
           theme.muted(resolveUnsafeUpdateRecoveryGuidance(params.result.recovery.reason)),
         );
+        if (managedGatewayStopped) {
+          defaultRuntime.log(theme.muted("Keep the gateway stopped until the update succeeds."));
+        }
       }
     } else {
       await maybeRestartServiceAfterFailedMutableUpdate({

--- a/src/cli/update-cli/update-command-post-update.ts
+++ b/src/cli/update-cli/update-command-post-update.ts
@@ -57,6 +57,7 @@ import {
   tryInstallShellCompletion,
   type PreManagedServiceStop,
 } from "./update-command-service.js";
+import { resolveUnsafeUpdateRecoveryGuidance } from "./update-recovery-guidance.js";
 
 const CLI_NAME = resolveCliName();
 
@@ -129,19 +130,9 @@ export async function finishUpdate(params: {
             `Managed gateway remains stopped because update recovery could not prove a runnable installation (${params.result.recovery.reason}).`,
           ),
         );
-        if (params.result.recovery.reason === "rollback-checkout-dirty") {
-          defaultRuntime.log(
-            theme.muted(
-              "Inspect the checkout with `git status --short`, resolve the tracked changes, then rerun `openclaw update`. Keep the gateway stopped until the update succeeds.",
-            ),
-          );
-        } else {
-          defaultRuntime.log(
-            theme.muted(
-              "Review the failed recovery step above, repair the checkout or installation, then rerun `openclaw update`. Keep the gateway stopped until the update succeeds.",
-            ),
-          );
-        }
+        defaultRuntime.log(
+          theme.muted(resolveUnsafeUpdateRecoveryGuidance(params.result.recovery.reason)),
+        );
       }
     } else {
       await maybeRestartServiceAfterFailedMutableUpdate({

--- a/src/cli/update-cli/update-recovery-guidance.ts
+++ b/src/cli/update-cli/update-recovery-guidance.ts
@@ -9,7 +9,7 @@ export function resolveUnsafeUpdateRecoveryGuidance(
   reason: UnsafeUpdateRecovery["reason"],
 ): string {
   if (reason === "rollback-checkout-dirty") {
-    return "From the update root shown above, run `git status --short`, resolve the tracked changes, then rerun `openclaw update`. Keep the gateway stopped until the update succeeds.";
+    return "From the update root shown above, run `git status --short`, resolve the reported changes, then rerun `openclaw update`.";
   }
-  return "Review the failed recovery step above, repair the checkout or installation, then rerun `openclaw update`. Keep the gateway stopped until the update succeeds.";
+  return "Review the failed recovery step above, repair the checkout or installation, then rerun `openclaw update`.";
 }

--- a/src/cli/update-cli/update-recovery-guidance.ts
+++ b/src/cli/update-cli/update-recovery-guidance.ts
@@ -1,4 +1,5 @@
 import type { UpdateRunResult } from "../../infra/update-runner.js";
+import { formatCliCommand } from "../command-format.js";
 
 type UnsafeUpdateRecovery = Extract<
   NonNullable<UpdateRunResult["recovery"]>,
@@ -8,8 +9,9 @@ type UnsafeUpdateRecovery = Extract<
 export function resolveUnsafeUpdateRecoveryGuidance(
   reason: UnsafeUpdateRecovery["reason"],
 ): string {
+  const updateCommand = formatCliCommand("openclaw update");
   if (reason === "rollback-checkout-dirty") {
-    return "From the update root shown above, run `git status --short`, resolve the reported changes, then rerun `openclaw update`.";
+    return `From the update root shown above, run \`git status --short\`, resolve the reported changes, then rerun \`${updateCommand}\`.`;
   }
-  return "Review the failed recovery step above, repair the checkout or installation, then rerun `openclaw update`.";
+  return `Review the failed recovery step above, repair the checkout or installation, then rerun \`${updateCommand}\`.`;
 }

--- a/src/cli/update-cli/update-recovery-guidance.ts
+++ b/src/cli/update-cli/update-recovery-guidance.ts
@@ -1,0 +1,15 @@
+import type { UpdateRunResult } from "../../infra/update-runner.js";
+
+type UnsafeUpdateRecovery = Extract<
+  NonNullable<UpdateRunResult["recovery"]>,
+  { serviceRestartSafe: false }
+>;
+
+export function resolveUnsafeUpdateRecoveryGuidance(
+  reason: UnsafeUpdateRecovery["reason"],
+): string {
+  if (reason === "rollback-checkout-dirty") {
+    return "From the update root shown above, run `git status --short`, resolve the tracked changes, then rerun `openclaw update`. Keep the gateway stopped until the update succeeds.";
+  }
+  return "Review the failed recovery step above, repair the checkout or installation, then rerun `openclaw update`. Keep the gateway stopped until the update succeeds.";
+}

--- a/src/commands/doctor-update.test.ts
+++ b/src/commands/doctor-update.test.ts
@@ -163,6 +163,7 @@ beforeEach(async () => {
 });
 
 afterEach(() => {
+  vi.unstubAllEnvs();
   vi.restoreAllMocks();
   if (originalStdinIsTtyDescriptor) {
     Object.defineProperty(process.stdin, "isTTY", originalStdinIsTtyDescriptor);
@@ -812,6 +813,27 @@ describe("maybeOfferUpdateBeforeDoctor", () => {
     expect(recoveryNote).toContain("resolve the reported changes");
     expect(recoveryNote).not.toContain("remains stopped");
     expect(recoveryNote).not.toContain("Keep the gateway stopped");
+  });
+
+  it("preserves the active profile in unsafe recovery guidance", async () => {
+    vi.stubEnv("OPENCLAW_PROFILE", "work");
+    mockGitCheckout();
+    mockManagedService({
+      verdict: { kind: "owned", refreshDefinition: true, fingerprint: "opaque" },
+    });
+    mockUpdateResult({
+      status: "error",
+      mode: "git",
+      root: "/repo/link",
+      recovery: { serviceRestartSafe: false, reason: "rollback-checkout-dirty" },
+    });
+
+    await runOffer({ confirm: vi.fn().mockResolvedValue(true) });
+
+    expect(mocks.note).toHaveBeenCalledWith(
+      expect.stringContaining("rerun `openclaw --profile work update`"),
+      "Update",
+    );
   });
 
   it("leaves a running gateway alone when service repair is externally managed", async () => {

--- a/src/commands/doctor-update.test.ts
+++ b/src/commands/doctor-update.test.ts
@@ -785,6 +785,33 @@ describe("maybeOfferUpdateBeforeDoctor", () => {
       expect.stringContaining("rerun `openclaw update`"),
       "Update",
     );
+    expect(mocks.note).toHaveBeenCalledWith(
+      expect.stringContaining("Keep the gateway stopped until the update succeeds"),
+      "Update",
+    );
+  });
+
+  it("shows repair guidance without claiming an already-stopped service changed state", async () => {
+    mockGitCheckout();
+    mockManagedService({
+      verdict: { kind: "owned", refreshDefinition: true, fingerprint: "opaque" },
+      running: false,
+    });
+    mockUpdateResult({
+      status: "error",
+      mode: "git",
+      root: "/repo/link",
+      recovery: { serviceRestartSafe: false, reason: "rollback-checkout-dirty" },
+    });
+
+    await runOffer({ confirm: vi.fn().mockResolvedValue(true) });
+
+    const recoveryNote = mocks.note.mock.calls.find((call) =>
+      String(call[0]).includes("rollback-checkout-dirty"),
+    )?.[0];
+    expect(recoveryNote).toContain("resolve the reported changes");
+    expect(recoveryNote).not.toContain("remains stopped");
+    expect(recoveryNote).not.toContain("Keep the gateway stopped");
   });
 
   it("leaves a running gateway alone when service repair is externally managed", async () => {

--- a/src/commands/doctor-update.test.ts
+++ b/src/commands/doctor-update.test.ts
@@ -239,7 +239,10 @@ describe("maybeOfferUpdateBeforeDoctor", () => {
     mode: "git";
     root: string;
     after?: { version: string; buildId?: string };
-    recovery?: { serviceRestartSafe: false; reason: "source-rollback-failed" };
+    recovery?: {
+      serviceRestartSafe: false;
+      reason: "source-rollback-failed" | "rollback-checkout-dirty";
+    };
   }) {
     mocks.runGatewayUpdate.mockImplementation(
       async ({
@@ -750,7 +753,16 @@ describe("maybeOfferUpdateBeforeDoctor", () => {
     });
   });
 
-  it("does not restart a stopped service when source rollback could not be verified", async () => {
+  it.each([
+    {
+      reason: "source-rollback-failed" as const,
+      guidance: "repair the checkout or installation",
+    },
+    {
+      reason: "rollback-checkout-dirty" as const,
+      guidance: "From the update root shown above",
+    },
+  ])("does not restart a stopped service after $reason", async ({ reason, guidance }) => {
     mockGitCheckout();
     mockManagedService({
       verdict: { kind: "owned", refreshDefinition: true, fingerprint: "opaque" },
@@ -759,7 +771,7 @@ describe("maybeOfferUpdateBeforeDoctor", () => {
       status: "error",
       mode: "git",
       root: "/repo/link",
-      recovery: { serviceRestartSafe: false, reason: "source-rollback-failed" },
+      recovery: { serviceRestartSafe: false, reason },
     });
 
     await runOffer({ confirm: vi.fn().mockResolvedValue(true) });
@@ -767,6 +779,12 @@ describe("maybeOfferUpdateBeforeDoctor", () => {
     expect(mocks.stopGatewayService).toHaveBeenCalledOnce();
     expect(mocks.maybeRestartServiceAfterFailedMutableUpdate).not.toHaveBeenCalled();
     expect(mocks.restartUpdatedGateway).not.toHaveBeenCalled();
+    expect(mocks.note).toHaveBeenCalledWith(expect.stringContaining(`(${reason})`), "Update");
+    expect(mocks.note).toHaveBeenCalledWith(expect.stringContaining(guidance), "Update");
+    expect(mocks.note).toHaveBeenCalledWith(
+      expect.stringContaining("rerun `openclaw update`"),
+      "Update",
+    );
   });
 
   it("leaves a running gateway alone when service repair is externally managed", async () => {

--- a/src/commands/doctor-update.ts
+++ b/src/commands/doctor-update.ts
@@ -5,6 +5,7 @@ import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/st
 import { note } from "../../packages/terminal-core/src/note.js";
 import { formatCliCommand } from "../cli/command-format.js";
 import { createUpdateProgress } from "../cli/update-cli/progress.js";
+import { resolveUnsafeUpdateRecoveryGuidance } from "../cli/update-cli/update-recovery-guidance.js";
 import { isDefaultInstallIdentity } from "../config/paths.js";
 import { readGatewayServiceState, resolveGatewayService } from "../daemon/service.js";
 import { isTruthyEnvValue } from "../infra/env.js";
@@ -156,7 +157,14 @@ export async function maybeOfferUpdateBeforeDoctor(params: {
     ].filter(Boolean);
     note(resultDetails.join("\n"), "Update result");
     if (result.status !== "ok") {
-      if (result.recovery?.serviceRestartSafe !== false) {
+      if (result.recovery?.serviceRestartSafe === false) {
+        if (inspection?.stopped) {
+          note(
+            `Managed gateway remains stopped because update recovery could not prove a runnable installation (${result.recovery.reason}).\n${resolveUnsafeUpdateRecoveryGuidance(result.recovery.reason)}`,
+            "Update",
+          );
+        }
+      } else {
         await serviceLifecycle?.maybeRestartServiceAfterFailedMutableUpdate({
           root: result.root,
           preManagedServiceStop: inspection,

--- a/src/commands/doctor-update.ts
+++ b/src/commands/doctor-update.ts
@@ -158,12 +158,17 @@ export async function maybeOfferUpdateBeforeDoctor(params: {
     note(resultDetails.join("\n"), "Update result");
     if (result.status !== "ok") {
       if (result.recovery?.serviceRestartSafe === false) {
-        if (inspection?.stopped) {
-          note(
-            `Managed gateway remains stopped because update recovery could not prove a runnable installation (${result.recovery.reason}).\n${resolveUnsafeUpdateRecoveryGuidance(result.recovery.reason)}`,
-            "Update",
-          );
-        }
+        const managedGatewayStopped = inspection?.stopped === true;
+        const summary = managedGatewayStopped
+          ? `Managed gateway remains stopped because update recovery could not prove a runnable installation (${result.recovery.reason}).`
+          : `Update recovery could not prove a runnable installation (${result.recovery.reason}).`;
+        const keepStopped = managedGatewayStopped
+          ? "\nKeep the gateway stopped until the update succeeds."
+          : "";
+        note(
+          `${summary}\n${resolveUnsafeUpdateRecoveryGuidance(result.recovery.reason)}${keepStopped}`,
+          "Update",
+        );
       } else {
         await serviceLifecycle?.maybeRestartServiceAfterFailedMutableUpdate({
           root: result.root,

--- a/src/infra/update-runner-git-commands.ts
+++ b/src/infra/update-runner-git-commands.ts
@@ -38,6 +38,10 @@ export function resolveBuildEnv(
   };
 }
 
+export function gitCleanCheckArgs(gitRoot: string): string[] {
+  return ["git", "-C", gitRoot, "status", "--porcelain", "--", ":!dist/control-ui/"];
+}
+
 async function hasExplicitPnpmPreferOfflineConfig(params: {
   runCommand: CommandRunner;
   cwd: string;

--- a/src/infra/update-runner-git-recovery.ts
+++ b/src/infra/update-runner-git-recovery.ts
@@ -11,6 +11,7 @@ import { runStep } from "./update-runner-command.js";
 import {
   resolveBuildEnv,
   resolveInstallEnv,
+  gitCleanCheckArgs,
   shouldInstallWithoutScriptsOnWindows,
 } from "./update-runner-git-commands.js";
 import type { CommandRunner, UpdateStepResult } from "./update-runner-types.js";
@@ -106,6 +107,25 @@ export async function rebuildRolledBackGitRuntime(params: {
     );
     if (!built) {
       return appendFailure("build-failed", "failed to rebuild the original checkout");
+    }
+
+    const cleanCheck = await runStep({
+      runCommand: params.runCommand,
+      name: "git rollback build clean check",
+      argv: gitCleanCheckArgs(params.gitRoot),
+      cwd: params.gitRoot,
+      timeoutMs: params.timeoutMs,
+      stepIndex: 0,
+      totalSteps: 1,
+      results: params.steps,
+    });
+    if (cleanCheck.exitCode !== 0 || cleanCheck.stdoutTail?.trim()) {
+      return appendFailure(
+        "runtime-verification-failed",
+        cleanCheck.exitCode !== 0
+          ? "failed to verify rollback checkout cleanliness"
+          : `rollback build left checkout dirty: ${cleanCheck.stdoutTail?.trim()}`,
+      );
     }
 
     const runtimeErrors = await collectGitRuntimeErrors({

--- a/src/infra/update-runner-git-recovery.ts
+++ b/src/infra/update-runner-git-recovery.ts
@@ -20,6 +20,7 @@ type RecoveryReason =
   | "manager-unavailable"
   | "deps-install-failed"
   | "build-failed"
+  | "rollback-checkout-dirty"
   | "runtime-verification-failed";
 
 type GitRuntimeRecovery =
@@ -119,12 +120,16 @@ export async function rebuildRolledBackGitRuntime(params: {
       totalSteps: 1,
       results: params.steps,
     });
-    if (cleanCheck.exitCode !== 0 || cleanCheck.stdoutTail?.trim()) {
+    if (cleanCheck.exitCode !== 0) {
       return appendFailure(
         "runtime-verification-failed",
-        cleanCheck.exitCode !== 0
-          ? "failed to verify rollback checkout cleanliness"
-          : `rollback build left checkout dirty: ${cleanCheck.stdoutTail?.trim()}`,
+        "failed to verify rollback checkout cleanliness",
+      );
+    }
+    if (cleanCheck.stdoutTail?.trim()) {
+      return appendFailure(
+        "rollback-checkout-dirty",
+        `rollback build left checkout dirty: ${cleanCheck.stdoutTail.trim()}`,
       );
     }
 

--- a/src/infra/update-runner-git.ts
+++ b/src/infra/update-runner-git.ts
@@ -21,6 +21,7 @@ import {
 } from "./update-runner-doctor.js";
 import {
   findBlockingGitFailure,
+  gitCleanCheckArgs,
   resolveBuildEnv,
   resolveInstallEnv,
   shouldInstallWithoutScriptsOnWindows,
@@ -269,13 +270,7 @@ export async function updateGitCheckout(params: {
     return buildError(reason);
   };
 
-  const statusCheck = await runStep(
-    step(
-      "clean check",
-      ["git", "-C", gitRoot, "status", "--porcelain", "--", ":!dist/control-ui/"],
-      gitRoot,
-    ),
-  );
+  const statusCheck = await runStep(step("clean check", gitCleanCheckArgs(gitRoot), gitRoot));
   if (statusCheck.stdoutTail?.trim()) {
     return buildError("dirty", "skipped");
   }
@@ -457,11 +452,7 @@ export async function updateGitCheckout(params: {
       return await rollbackError("build-failed");
     }
     const buildCleanCheck = await runStep(
-      step(
-        "build clean check",
-        ["git", "-C", gitRoot, "status", "--porcelain", "--", ":!dist/control-ui/"],
-        gitRoot,
-      ),
+      step("build clean check", gitCleanCheckArgs(gitRoot), gitRoot),
     );
     if (buildCleanCheck.exitCode !== 0) {
       return await rollbackError("build-failed");

--- a/src/infra/update-runner-types.ts
+++ b/src/infra/update-runner-types.ts
@@ -44,6 +44,7 @@ export type UpdateRunResult = {
           | "manager-unavailable"
           | "deps-install-failed"
           | "build-failed"
+          | "rollback-checkout-dirty"
           | "runtime-verification-failed";
       };
   postUpdate?: {

--- a/src/infra/update-runner.test.ts
+++ b/src/infra/update-runner.test.ts
@@ -3496,7 +3496,12 @@ describe("runGatewayUpdate", () => {
         reason: "doctor-failed",
         recovery: serviceRestartSafe
           ? { serviceRestartSafe: true }
-          : { serviceRestartSafe: false, reason: "runtime-verification-failed" },
+          : {
+              serviceRestartSafe: false,
+              reason: rollbackBuildDirty
+                ? "rollback-checkout-dirty"
+                : "runtime-verification-failed",
+            },
       });
       expect(buildCount).toBe(2);
       expect(buildEnvs).toEqual([

--- a/src/infra/update-runner.test.ts
+++ b/src/infra/update-runner.test.ts
@@ -2031,7 +2031,7 @@ describe("runGatewayUpdate", () => {
           " M extensions/browser/chrome-extension/modules/copilot-runtime.js\n?? generated-build-output.tmp",
       }),
     );
-    expect(calls.filter((call) => call === statusCommand)).toHaveLength(2);
+    expect(calls.filter((call) => call === statusCommand)).toHaveLength(3);
     expect(calls).not.toContain("pnpm ui:build");
     expect(calls).toContain(`git -C ${tempDir} reset --hard`);
     expect(calls).toContain(`git -C ${tempDir} clean -fd -e dist/control-ui/`);
@@ -3364,11 +3364,27 @@ describe("runGatewayUpdate", () => {
   });
 
   it.each([
-    { bundle: "complete", missingRollbackStartupAsset: false, serviceRestartSafe: true },
-    { bundle: "incomplete", missingRollbackStartupAsset: true, serviceRestartSafe: false },
+    {
+      bundle: "complete",
+      missingRollbackStartupAsset: false,
+      rollbackBuildDirty: false,
+      serviceRestartSafe: true,
+    },
+    {
+      bundle: "incomplete",
+      missingRollbackStartupAsset: true,
+      rollbackBuildDirty: false,
+      serviceRestartSafe: false,
+    },
+    {
+      bundle: "dirty rollback build",
+      missingRollbackStartupAsset: false,
+      rollbackBuildDirty: true,
+      serviceRestartSafe: false,
+    },
   ])(
     "rolls pnpm 12 back to 11 and allows restart only with a $bundle startup bundle",
-    async ({ missingRollbackStartupAsset, serviceRestartSafe }) => {
+    async ({ missingRollbackStartupAsset, rollbackBuildDirty, serviceRestartSafe }) => {
       await setupGitCheckout({ packageManager: "pnpm@11.22.0" });
       const beforeSha = "a".repeat(40);
       const targetSha = "b".repeat(40);
@@ -3378,6 +3394,7 @@ describe("runGatewayUpdate", () => {
       const calls: string[] = [];
       const buildEnvs: NodeJS.ProcessEnv[] = [];
       const managerVersions: string[] = [];
+      const statusCommand = `git -C ${tempDir} status --porcelain -- :!dist/control-ui/`;
       const doctorNodePath = await resolveStableNodePath(process.execPath);
       const doctorCommand = `${doctorNodePath} ${path.join(tempDir, "openclaw.mjs")} doctor --non-interactive --fix`;
       const writeRuntime = async (head: string) => {
@@ -3452,6 +3469,9 @@ describe("runGatewayUpdate", () => {
           await writeRuntime(currentHead);
           return toCommandResult();
         }
+        if (key === statusCommand && rollbackBuildDirty && buildCount >= 2) {
+          return toCommandResult({ stdout: " M pnpm-lock.yaml\n" });
+        }
         if (key === doctorCommand) {
           return toCommandResult({ code: 1, stderr: "doctor failed after build" });
         }
@@ -3491,6 +3511,15 @@ describe("runGatewayUpdate", () => {
         name: "git rollback runtime verify",
         exitCode: serviceRestartSafe ? 0 : 1,
       });
+      if (rollbackBuildDirty) {
+        expect(result.steps).toContainEqual(
+          expect.objectContaining({
+            name: "git rollback build clean check",
+            exitCode: 0,
+            stdoutTail: " M pnpm-lock.yaml",
+          }),
+        );
+      }
       expect(calls.indexOf(doctorCommand)).toBeLessThan(
         calls.lastIndexOf(`git -C ${tempDir} rev-parse HEAD`),
       );

--- a/src/infra/update-runner.test.ts
+++ b/src/infra/update-runner.test.ts
@@ -3367,24 +3367,30 @@ describe("runGatewayUpdate", () => {
     {
       bundle: "complete",
       missingRollbackStartupAsset: false,
-      rollbackBuildDirty: false,
+      rollbackBuildStatus: null,
       serviceRestartSafe: true,
     },
     {
       bundle: "incomplete",
       missingRollbackStartupAsset: true,
-      rollbackBuildDirty: false,
+      rollbackBuildStatus: null,
       serviceRestartSafe: false,
     },
     {
       bundle: "dirty rollback build",
       missingRollbackStartupAsset: false,
-      rollbackBuildDirty: true,
+      rollbackBuildStatus: " M pnpm-lock.yaml\n",
+      serviceRestartSafe: false,
+    },
+    {
+      bundle: "untracked rollback output",
+      missingRollbackStartupAsset: false,
+      rollbackBuildStatus: "?? generated.tmp\n",
       serviceRestartSafe: false,
     },
   ])(
     "rolls pnpm 12 back to 11 and allows restart only with a $bundle startup bundle",
-    async ({ missingRollbackStartupAsset, rollbackBuildDirty, serviceRestartSafe }) => {
+    async ({ missingRollbackStartupAsset, rollbackBuildStatus, serviceRestartSafe }) => {
       await setupGitCheckout({ packageManager: "pnpm@11.22.0" });
       const beforeSha = "a".repeat(40);
       const targetSha = "b".repeat(40);
@@ -3469,8 +3475,8 @@ describe("runGatewayUpdate", () => {
           await writeRuntime(currentHead);
           return toCommandResult();
         }
-        if (key === statusCommand && rollbackBuildDirty && buildCount >= 2) {
-          return toCommandResult({ stdout: " M pnpm-lock.yaml\n" });
+        if (key === statusCommand && rollbackBuildStatus && buildCount >= 2) {
+          return toCommandResult({ stdout: rollbackBuildStatus });
         }
         if (key === doctorCommand) {
           return toCommandResult({ code: 1, stderr: "doctor failed after build" });
@@ -3498,7 +3504,7 @@ describe("runGatewayUpdate", () => {
           ? { serviceRestartSafe: true }
           : {
               serviceRestartSafe: false,
-              reason: rollbackBuildDirty
+              reason: rollbackBuildStatus
                 ? "rollback-checkout-dirty"
                 : "runtime-verification-failed",
             },
@@ -3516,12 +3522,12 @@ describe("runGatewayUpdate", () => {
         name: "git rollback runtime verify",
         exitCode: serviceRestartSafe ? 0 : 1,
       });
-      if (rollbackBuildDirty) {
+      if (rollbackBuildStatus) {
         expect(result.steps).toContainEqual(
           expect.objectContaining({
             name: "git rollback build clean check",
             exitCode: 0,
-            stdoutTail: " M pnpm-lock.yaml",
+            stdoutTail: rollbackBuildStatus.trimEnd(),
           }),
         );
       }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where an updater rollback could report the service as safe to restart even when the rollback install/build left the checkout dirty.

## Why This Change Was Made

The rollback path now reuses the updater's scoped Git cleanliness check after dependency installation and build. Tracked or untracked changes in that scoped surface produce a distinct unsafe-recovery result; unrelated generated UI output remains excluded. CLI and Doctor flows share actionable recovery guidance without claiming a service was stopped unless this update actually stopped it.

## User Impact

Rollback no longer restarts a managed Gateway from a checkout modified by the rollback build. Operators receive the update root, a scoped status trace, and guidance to inspect and repair the reported changes before retrying in the active named profile. A managed Gateway stopped for the update remains stopped; an already-down or externally managed service is not described as having changed state.

## Evidence

- Reviewed and exercised at exact PR head `84f1b22af0607f8ee670ede15ed53ce0b3414c53`.
- Real environment: a disposable Git clone, the real exact-head OpenClaw CLI and command runner, real Git/pnpm/build commands, and an isolated profile-scoped macOS LaunchAgent listening on loopback port 19843. No mocked command runner or mocked service was used.
- A real target preflight build passed. The fixture then forced only the live target build to exit 42, allowing the production updater to enter rollback recovery. The rollback dependency install and build both ran normally and passed; after that successful rollback build, the fixture dirtied tracked `pnpm-lock.yaml` to reproduce the defect.
- Sanitized observed trace after the fix:

```text
service before: loaded=true, runtime=running, port=busy, listeners=1
target preflight build: exit 0
live target build: exit 42 (fixture-injected failure)
rollback HEAD: 84f1b22af0607f8ee670ede15ed53ce0b3414c53
rollback dependency install: exit 0
rollback build: exit 0
rollback Git clean check: exit 0, stdout=" M pnpm-lock.yaml"
rollback runtime verification: exit 1, "rollback build left checkout dirty"
recovery result: serviceRestartSafe=false, reason=rollback-checkout-dirty
service after: loaded=false, runtime=stopped, port=free, listeners=0
```

- The proof fixture removed its disposable checkout, isolated state directory, LaunchAgent, and listener after the run. The production Gateway and production state were not touched.
- Focused exact-head suites: updater 118/118, CLI post-update 32/32, Doctor update 30/30, and CLI profile/formatter 79/79 passed. Formatting, type-aware lint, production TypeScript, `git diff --check`, and a fresh independent exact-snapshot review also passed.
- Coverage includes tracked and untracked rollback changes, stopped versus already-down service state, shared CLI/Doctor recovery guidance, named-profile retry commands, and structured JSON output remaining prose-free.
- Hosted exact-head CI completed successfully with no failed or pending checks. This rebased head includes the already-merged upstream repair for the unrelated fork-shutdown receipt test that failed on the previous run.
- Full local build/check reached the existing UI `pako` CommonJS/type-declaration failure on main; core and plugin build phases completed.
- AI-assisted contribution: implemented and reviewed with Codex.

## Owner Acceptance

- Intended behavior: dirty rollback-build source prevents `serviceRestartSafe=true` and leaves the managed Gateway stopped.
- Boundary: shared scoped updater cleanliness check; no transactionality or pnpm/preflight redesign.
- Rollback: revert the five PR commits ending at `84f1b22af0607f8ee670ede15ed53ce0b3414c53`.
- Reviewability: ten files, 259 additions and 25 deletions, covering the recovery invariant, distinct reason, shared profile-aware operator guidance, and their focused tests.

## Worked on by

- PollyBot13


## Maintainer verification (2026-08-30)

- Current `main` at `46c1eef6e6d4118dba29cf11285601e8b5e35a5b`: a fresh real Git checkout ran the real npm install and build commands, wrote runtime stamps for the exact fixture commit, left one tracked source file dirty, and incorrectly returned `serviceRestartSafe: true`.
- Exact PR head `84f1b22af0607f8ee670ede15ed53ce0b3414c53`: the same deterministic fixture and commands recorded `M tracked.txt` and returned `serviceRestartSafe: false` with `rollback-checkout-dirty`.
- The build marker matched the fixture Git SHA on both runs. Focused exact-head suites passed: updater 118/118, CLI post-update 32/32, and Doctor update 30/30.
- Maintainer policy acceptance: a dirty rebuilt rollback runtime must remain stopped until the operator repairs the checkout and retries the update.
