### PR TITLE
fix(release): unblock historical upgrade transcript and plugin checks

### DIFF
--- a/scripts/e2e/lib/upgrade-survivor/assertions.mjs
+++ b/scripts/e2e/lib/upgrade-survivor/assertions.mjs
@@ -873,7 +873,10 @@ function assertMeetingTranscriptsMigrated(stateDir, stage) {
   } finally {
     db.close();
   }
+}
 
+function assertMeetingTranscriptExport(stateDir) {
+  const legacySessionDir = path.join(stateDir, "transcripts", "2026-07-01", "design-review");
   const exportedDir = execFileSync(
     "openclaw",
     ["transcripts", "path", "2026-07-01/design-review", "--dir"],
@@ -1515,6 +1518,12 @@ if (command === "list-scenarios") {
 } else if (command === "assert-state") {
   assertStateSurvived();
   assertConfiguredPluginInstalls();
+} else if (command === "assert-meeting-transcript-export") {
+  assert(
+    getScenario() === "meeting-transcripts-sqlite",
+    "transcript export requires the meeting scenario",
+  );
+  assertMeetingTranscriptExport(requireEnv("OPENCLAW_STATE_DIR"));
 } else if (command === "assert-companion-installs") {
   assertCompanionPluginInstalls(process.argv.slice(3));
 } else if (command === "assert-recovered-plugin-installs") {

--- a/scripts/e2e/lib/upgrade-survivor/assertions.mjs
+++ b/scripts/e2e/lib/upgrade-survivor/assertions.mjs
@@ -1266,9 +1266,9 @@ function assertRecoverableUpdateJson([file, expectedVersion, observationRoot, ba
     result.status === "error" ? "post-plugin-doctor-invalid-config" : undefined,
   );
   assertStrict.deepEqual(plugins.integrityDrifts, []);
-  // These are the reviewed packages in the base and configured-plugin recipes.
+  // These are the reviewed packages in the base and scenario recipes.
   // Any other plugin or failure needs investigation before accepting it.
-  const reviewed = new Set(["codex", "discord", "whatsapp", "matrix", "brave"]);
+  const reviewed = new Set(["acpx", "brave", "codex", "discord", "feishu", "matrix", "whatsapp"]);
   const denied = new Set();
   assertStrict.ok(Array.isArray(plugins.npm?.outcomes));
   for (const outcome of plugins.npm.outcomes) {

--- a/scripts/e2e/lib/upgrade-survivor/config-recipe.mts
+++ b/scripts/e2e/lib/upgrade-survivor/config-recipe.mts
@@ -16,6 +16,7 @@ type ConfigStep = {
   id: string;
   intent: string;
   argv: string[];
+  prepublishPluginPackages?: string[];
 };
 
 type BaselineAdaptationSummary = { skippedIntents: string[] };
@@ -178,12 +179,16 @@ const scenarioConfigSteps = new Map<string, ConfigStep[]>([
   [
     "acpx-openclaw-tools-bridge",
     [
-      configSetJsonFile(
-        "plugins-acpx-openclaw-tools-bridge",
-        "acpx-openclaw-tools-bridge",
-        "plugins",
-        "plugins-acpx-openclaw-tools-bridge.json",
-      ),
+      {
+        ...configSetJsonFile(
+          "plugins-acpx-openclaw-tools-bridge",
+          "acpx-openclaw-tools-bridge",
+          "plugins",
+          "plugins-acpx-openclaw-tools-bridge.json",
+        ),
+        // The candidate externalizes this runtime even when the baseline bundles it.
+        prepublishPluginPackages: ["@openclaw/acpx"],
+      },
     ],
   ],
   [

--- a/scripts/e2e/lib/upgrade-survivor/run.sh
+++ b/scripts/e2e/lib/upgrade-survivor/run.sh
@@ -1428,6 +1428,11 @@ if [ "$SCENARIO" = "sqlite-volume" ]; then
   phase assert-volume-idempotence assert_volume_idempotence
 fi
 phase fixture-plugin-consent repair_fixture_plugin_consent
+if [ "$SCENARIO" = "meeting-transcripts-sqlite" ]; then
+  # Export recreates the archived source path. Finish every repeated survival
+  # check before exercising the explicit artifact materialization command.
+  phase transcript-export node scripts/e2e/lib/upgrade-survivor/assertions.mjs assert-meeting-transcript-export
+fi
 phase gateway-start ensure_gateway_started
 phase gateway-probes check_gateway_probes
 phase gateway-status check_gateway_status

--- a/scripts/lib/docker-e2e-plan.mts
+++ b/scripts/lib/docker-e2e-plan.mts
@@ -528,26 +528,6 @@ function upgradeSurvivorBaselineVersionForLane(poolLane: DockerE2eLane): string 
   return /(?:^|\/|@)(\d{4}\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?)$/u.exec(spec ?? "")?.[1] ?? null;
 }
 
-function configuredChannelIdsForLane(poolLane: DockerE2eLane, scenario: string): Set<string> {
-  const channelIds = new Set<string>();
-  const baselineVersion = upgradeSurvivorBaselineVersionForLane(poolLane);
-  const resolveConfigSteps = resolveUpgradeSurvivorConfigStepsForBaseline as (
-    scenario: string,
-    baselineVersion: string | null,
-  ) => ReturnType<typeof resolveUpgradeSurvivorConfigStepsForBaseline>;
-  for (const step of resolveConfigSteps(scenario, baselineVersion)) {
-    if (step.argv?.[0] !== "config" || step.argv?.[1] !== "set") {
-      continue;
-    }
-    const match = /^channels\.([a-z0-9][a-z0-9-]*)$/u.exec(step.argv[2] ?? "");
-    const channelId = match?.[1];
-    if (channelId) {
-      channelIds.add(channelId);
-    }
-  }
-  return channelIds;
-}
-
 export function requiredPrepublishPluginPackagesForLanes(poolLanes: DockerE2eLane[]): string[] {
   const configuredChannelIds = new Set<string>();
   const requiredPackages = new Set<string>();
@@ -562,8 +542,21 @@ export function requiredPrepublishPluginPackagesForLanes(poolLanes: DockerE2eLan
     for (const packageName of UPGRADE_SURVIVOR_RUNTIME_COMPANION_PACKAGES) {
       requiredPackages.add(packageName);
     }
-    for (const channelId of configuredChannelIdsForLane(poolLane, scenario)) {
-      configuredChannelIds.add(channelId);
+    const steps = resolveUpgradeSurvivorConfigStepsForBaseline(
+      scenario,
+      upgradeSurvivorBaselineVersionForLane(poolLane),
+    );
+    for (const step of steps) {
+      for (const packageName of step.prepublishPluginPackages ?? []) {
+        requiredPackages.add(packageName);
+      }
+      if (step.argv[0] !== "config" || step.argv[1] !== "set") {
+        continue;
+      }
+      const channelId = /^channels\.([a-z0-9][a-z0-9-]*)$/u.exec(step.argv[2] ?? "")?.[1];
+      if (channelId) {
+        configuredChannelIds.add(channelId);
+      }
     }
   }
   for (const packageName of (officialExternalChannelCatalog.entries ?? [])

--- a/test/scripts/docker-build-helper.test.ts
+++ b/test/scripts/docker-build-helper.test.ts
@@ -5029,6 +5029,7 @@ if (starts === 1) {
       "phase doctor run_doctor",
       "phase assert-survival assert_survival",
       "phase fixture-plugin-consent repair_fixture_plugin_consent",
+      "phase transcript-export node scripts/e2e/lib/upgrade-survivor/assertions.mjs assert-meeting-transcript-export",
       "phase gateway-start ensure_gateway_started",
     ]);
     expect(publishedRunner).not.toContain("systemctl --user restart openclaw-gateway.service");

--- a/test/scripts/docker-e2e-plan.test.ts
+++ b/test/scripts/docker-e2e-plan.test.ts
@@ -1735,6 +1735,24 @@ describe("scripts/lib/docker-e2e-plan", () => {
     expect(requiredPrepublishPluginPackagesForLanes([selfUpgradeLane!])).toEqual([]);
   });
 
+  it.each([
+    {
+      baseline: "2026.4.23",
+      packages: ["@openclaw/acpx", "@openclaw/codex", "@openclaw/discord", "@openclaw/whatsapp"],
+    },
+    { baseline: "2026.4.15", packages: [] },
+  ])(
+    "stages the ACP recipe companion only for supported baseline $baseline",
+    ({ baseline, packages }) => {
+      const plan = planFor({
+        selectedLaneNames: ["published-upgrade-survivor"],
+        upgradeSurvivorBaselines: baseline,
+        upgradeSurvivorScenarios: "acpx-openclaw-tools-bridge",
+      });
+      expect(plan.requiredPrepublishPluginPackages).toEqual(packages);
+    },
+  );
+
   it("does not request a prerelease plugin registry for unrelated lanes", () => {
     const plan = planFor({ selectedLaneNames: ["doctor-switch"] });
     expect(plan.requiredPrepublishPluginPackages).toEqual([]);

--- a/test/scripts/upgrade-survivor-assertions.test.ts
+++ b/test/scripts/upgrade-survivor-assertions.test.ts
@@ -3,7 +3,7 @@ import { execFileSync, spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import { mkdtempSync, mkdirSync, readFileSync, realpathSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { delimiter, join } from "node:path";
 import { DatabaseSync } from "node:sqlite";
 import { describe, expect, it } from "vitest";
 
@@ -470,7 +470,10 @@ function writeLegacySessionEntriesState(stateDir: string): void {
   }
 }
 
-function runSessionStateAssertion(setup: (stateDir: string) => void): void {
+function runSessionStateAssertion(
+  setup: (stateDir: string) => void | NodeJS.ProcessEnv,
+  options: { scenario?: string; commands?: string[] } = {},
+): void {
   const root = mkdtempSync(join(tmpdir(), "openclaw-upgrade-survivor-session-state-"));
   try {
     const stateDir = join(root, "state");
@@ -481,17 +484,19 @@ function runSessionStateAssertion(setup: (stateDir: string) => void): void {
     writeJson(join(stateDir, "agents", "main", "sessions", "legacy-session.json"), {
       id: "legacy-session",
     });
-    setup(stateDir);
-
-    execFileSync(process.execPath, [ASSERTIONS_PATH, "assert-state"], {
-      env: {
-        ...process.env,
-        OPENCLAW_STATE_DIR: stateDir,
-        OPENCLAW_TEST_WORKSPACE_DIR: workspace,
-        OPENCLAW_UPGRADE_SURVIVOR_SCENARIO: "base",
-      },
-      stdio: "pipe",
-    });
+    const fixtureEnv = setup(stateDir);
+    for (const command of options.commands ?? ["assert-state"]) {
+      execFileSync(process.execPath, [ASSERTIONS_PATH, command], {
+        env: {
+          ...process.env,
+          ...(fixtureEnv ?? {}),
+          OPENCLAW_STATE_DIR: stateDir,
+          OPENCLAW_TEST_WORKSPACE_DIR: workspace,
+          OPENCLAW_UPGRADE_SURVIVOR_SCENARIO: options.scenario ?? "base",
+        },
+        stdio: "pipe",
+      });
+    }
   } finally {
     rmSync(root, { force: true, recursive: true });
   }
@@ -814,6 +819,67 @@ function assertUpdateRunSelfUpgrade(summary: ReturnType<typeof createUpdateRunSe
 }
 
 describe("upgrade survivor assertions", () => {
+  it.runIf(process.platform !== "win32")(
+    "rechecks migrated meeting state before materializing transcript exports",
+    () => {
+      expect(() =>
+        runSessionStateAssertion(
+          (stateDir) => {
+            writeMigratedSessionState(stateDir);
+            const archive = join(
+              stateDir,
+              "transcripts.migrated-fixture",
+              "2026-07-01",
+              "design-review",
+            );
+            mkdirSync(archive, { recursive: true });
+            writeFileSync(
+              join(archive, "transcript.jsonl"),
+              ["legacy-u-1", "legacy-u-2"].map((id) => JSON.stringify({ id })).join("\n") + "\n",
+            );
+            writeFileSync(join(archive, "summary.md"), "Shipped transcript summary\n");
+            mkdirSync(join(stateDir, "state"), { recursive: true });
+            const db = new DatabaseSync(join(stateDir, "state", "openclaw.sqlite"));
+            try {
+              db.exec(`
+              CREATE TABLE meeting_transcript_sessions (session_id, started_at, next_utterance_seq);
+              INSERT INTO meeting_transcript_sessions VALUES ('design-review', '2026-07-01T10:00:00.000Z', 2);
+              CREATE TABLE meeting_transcript_utterances (session_id, sequence, utterance_id, text);
+              INSERT INTO meeting_transcript_utterances VALUES ('design-review', 0, 'legacy-u-1', 'First shipped transcript line');
+              INSERT INTO meeting_transcript_utterances VALUES ('design-review', 1, 'legacy-u-2', 'Second shipped transcript line');
+              CREATE TABLE migration_sources (migration_kind, status, removed_source, source_record_count);
+              INSERT INTO migration_sources VALUES ('meeting-transcripts-files-v1', 'archived', 1, 2);
+            `);
+            } finally {
+              db.close();
+            }
+            const binDir = join(stateDir, "bin");
+            mkdirSync(binDir);
+            writeFileSync(
+              join(binDir, "openclaw"),
+              `#!/usr/bin/env node
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+assert.deepEqual(process.argv.slice(2), ["transcripts", "path", "2026-07-01/design-review", "--dir"]);
+const root = process.env.OPENCLAW_STATE_DIR;
+const sessionDir = path.join(root, "transcripts", "2026-07-01", "design-review");
+fs.cpSync(path.join(root, "transcripts.migrated-fixture", "2026-07-01", "design-review"), sessionDir, { recursive: true });
+process.stdout.write(sessionDir + "\\n");
+`,
+              { mode: 0o755 },
+            );
+            return { PATH: `${binDir}${delimiter}${process.env.PATH}` };
+          },
+          {
+            scenario: "meeting-transcripts-sqlite",
+            commands: ["assert-state", "assert-state", "assert-meeting-transcript-export"],
+          },
+        ),
+      ).not.toThrow();
+    },
+  );
+
   it("lists the dependency-free scenario contract", () => {
     const scenarios = JSON.parse(
       execFileSync(process.execPath, [ASSERTIONS_PATH, "list-scenarios"], {

--- a/test/scripts/upgrade-survivor-update-result.test.ts
+++ b/test/scripts/upgrade-survivor-update-result.test.ts
@@ -88,6 +88,37 @@ function check(result: unknown, prefix = "") {
 }
 
 describe("published upgrade survivor consent recovery", () => {
+  it.each(
+    ["acpx", "feishu"].flatMap((pluginId) =>
+      ["error", "ok"].map((status) => ({ pluginId, status })),
+    ),
+  )("admits $pluginId fixture consent after a $status update", ({ pluginId, status }) => {
+    const update = deniedUpdate();
+    const reason = `Plugin "${pluginId}" requires capability consent. Use openclaw plugins install or openclaw plugins enable with --accept-capabilities, then retry.`;
+    update.postUpdate.plugins.warnings.push({ reason, message: reason });
+    const result = check({
+      ...update,
+      status,
+      reason: status === "error" ? update.reason : undefined,
+      postUpdate: {
+        plugins: {
+          ...update.postUpdate.plugins,
+          status: status === "error" ? "error" : "warning",
+          reason: status === "error" ? update.postUpdate.plugins.reason : undefined,
+        },
+      },
+    });
+    expect(result.status, result.stderr).toBe(0);
+  });
+
+  it.each(["acpx", "feishu"])("rejects non-consent failures from reviewed %s", (pluginId) => {
+    const update = deferredUpdate();
+    const outcome = expectDefined(update.postUpdate.plugins.npm.outcomes[0], "plugin outcome");
+    outcome.pluginId = pluginId;
+    outcome.code = "INSTALL_FAILED";
+    expect(check(update).status).not.toBe(0);
+  });
+
   it("repairs capability deferrals even when retaining the old plugin makes core update successful", () => {
     const result = check(deferredUpdate());
     expect(result.status, result.stderr).toBe(0);


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where historical upgrade verification rejected successful migration and expected fixture consent recovery. In the [frozen full release run](https://github.com/openclaw/openclaw/actions/runs/33256244523), seven meeting-transcript cases rejected their own exported artifact, and thirteen Feishu/ACP cases stopped before Gateway startup because their explicitly configured fixture plugins were absent from the harness's reviewed recovery set.

## Why This Change Was Made

Migration checks now stay observational through every repeated survival check. The unchanged explicit transcript export assertions run once, after consent recovery finishes, so exporting the expected user artifact cannot invalidate a later migration assertion.

The ACP recipe now also declares its candidate package requirement. The planner collects that requirement during the same baseline-filtered recipe traversal it uses for channels, so unsupported baselines and unrelated scenarios do not stage ACP. This fixes the older-package selection exposed after consent admission was repaired; the exact version assertion remains intact.

The finite reviewed fixture set now includes `acpx` and `feishu`, which the scenario recipes already configure. The harness still requires the exact consent error codes/messages, a completed core swap, the expected baseline and installed versions, no integrity drift, and no unrelated plugin failures. It still rejects unknown plugins; it does not trust arbitrary configured entries.

The repeated meeting survival calls became visible in #132470 and were carried forward in #132529. The incomplete finite consent list originated in #132529. Blamed commits are `56ffe5bc2efbc73eeb5f90f8d4d10ad0ce7488c2` and `21890efc87fd3c3678f01c602ed4d2db57d5a133`, both authored by Peter Steinberger; the former credits Dallin Romney. The channel-only companion planner was introduced in #120107 (`a0deb8edae1a72acc8d70d2b98298fc1de3376c0`, authored by Vincent Koc), after ACP had already been externalized by `010f7a58a1aaa0efff541a6844c7b3d684a2bacc`. These are harness lifecycle/fixture omissions, not product migration or consent-policy defects.

## User Impact

No runtime, SQLite schema, persistence policy, configuration, timeout, or retry behavior changes. Release verification keeps the same migration, archive, export, recovery, and Gateway assertions without failing because of its own fixture ordering or incomplete fixture inventory.

Production LOC: +0/-0. Test infrastructure and tests: +171/-43 across eight files.

## Evidence

- The original-order meeting regression fails before the export phase split and passes afterward.
- Replayed all thirteen captured full update reports from the failed release jobs: 13/13 rejected before the fixture-set correction, 13/13 admitted afterward. Historical split reports retain their actual result/exit-code fields; only the artifact-root path was relocated for replay.
- Four new `error`/`ok` consent cases fail before and pass after; negatives preserve rejection of unreviewed plugins, non-consent codes, unrelated failures, integrity drift, wrong versions, and incomplete updates.
- Focused tests: four files, 329 passing tests across both canonical runner projects. Full changed-file gate passed. Independent Codex reviews reported no actionable findings.
- The new planner regression failed before the fix; the original six-package artifact is explicitly rejected when ACP is required. Planner, recipe, and registry tests: 96 passed; combined changed-file gate and independent review passed.
- [Testbox proof](https://github.com/openclaw/openclaw/actions/runs/33269141443), harness `e5dc9df95928012aca0b5b519a7690d4bcacd4ca`: real packaged 2026.4.15 meeting and 2026.4.23 Feishu scenarios passed against the sealed candidate. ACP reached completed repair, then exposed the missing companion artifact through the unchanged exact-version assertion.
- [Final ACP Testbox proof](https://github.com/openclaw/openclaw/actions/runs/33270923042), exact harness `50a14d6c2dad7ce10f82a8cec037f882522a238d`: the ordinary 2026.4.23 ACP upgrade passed in 193.876 seconds, including explicit repair, exact package-version and artifact-bound consent checks, four complete ClawHub audit cycles, and Gateway health/status. It uses the unchanged sealed `d9fe780239a2cb7158aad437112156605e8d375c` core candidate with the final harness source and an explicitly composed new registry: the original six tarballs remain byte-identical, and ACP is normally built and packed from the exact frozen candidate source. The canonical validator checks all seven packages; this is a new manifest identity, not the original artifact seal or a single-producer attestation. The next full release run will use the fixed planner to build the complete registry normally. This is not a claim that the full historical matrix or full release verification is green.

The final proof verifies all 35,205 tracked source paths, bytes, executable/symlink modes, and the Git tree before installation and afterward. The fixed planner requests ACP only for its supported recipe. Both proof leases were stopped and verified completed. The composed registry manifest is `003a8318377e78547525c97697ce25d6d71a18dc73294f37417f0d504e36d4dc`; the newly built ACP tarball is `a19133a6b0cdfe350126a538cbe725a38fb12b2fcf333651b6662c5a4b55cc80`.

The linked Actions pages identify the Testbox leases. The recorded wrapper command exits and source guards are the proof results; lease cleanup can leave the hydration workflow cancelled.
