### PR TITLE
fix: worker sessions cannot message Gateway parents or siblings

### DIFF
--- a/docs/concepts/session-tool.md
+++ b/docs/concepts/session-tool.md
@@ -95,6 +95,8 @@ In Code Mode, the conversation tools reuse their exact Gateway output contracts.
 
 `sessions_send` runs another session on the same Gateway and optionally waits for the response. Its `sessionKey`, `label`, or `agentId` selects local model context, not an external destination. The resulting reply can still be announced through the established requester or target delivery context; that existing behavior is unchanged. For exact external delivery, use a conversation tool or `message` with an explicit channel and target.
 
+Sessions keep their addresses when execution moves between the Gateway, a paired device, and a cloud worker. An OpenClaw worker can send to an authorized parent, child, or sibling using its exact session key, including a target running on the Gateway. The Gateway validates the current session identities and normal visibility policy before admitting the target turn; target placement does not grant messaging access. Cross-tree, archived, and replaced session targets remain denied.
+
 - **Fire-and-forget:** set `timeoutSeconds: 0` to enqueue and return immediately.
 - **Wait for reply:** set a timeout and get the response inline.
 

--- a/src/gateway/worker-environments/worker-session-tool-executor.test.ts
+++ b/src/gateway/worker-environments/worker-session-tool-executor.test.ts
@@ -10,6 +10,7 @@ import {
   releaseAgentRunDelegatedAuthority,
   type AgentRunDelegatedAuthority,
 } from "../../infra/agent-run-registry.js";
+import { parseAgentSessionKey } from "../../routing/session-key.js";
 import {
   closeOpenClawStateDatabaseForTest,
   openOpenClawStateDatabase,
@@ -43,6 +44,7 @@ vi.mock("../session-utils.js", async (importOriginal) => {
   return {
     ...actual,
     loadGatewaySessionEntryReadOnly: (sessionKey: string) => ({
+      agentId: parseAgentSessionKey(sessionKey)?.agentId,
       canonicalKey: sessionKey,
       entry: structuredClone(sessionEntries.get(sessionKey)),
     }),
@@ -430,6 +432,10 @@ describe("worker session tool topology", () => {
     });
   }
 
+  function spawn(toolCallId: string, task = "start the child") {
+    return execute({ identity, toolName: "sessions_spawn", request: { toolCallId, task } });
+  }
+
   it.each([false, true])(
     "creates and replays a cloud child with inherited required isolation (%s)",
     async (required) => {
@@ -440,16 +446,8 @@ describe("worker session tool topology", () => {
         ...(required ? { sandbox: "required" as const } : {}),
       });
 
-      const request = {
-        identity,
-        toolName: "sessions_spawn" as const,
-        request: {
-          toolCallId: "spawn-cloud-child",
-          task: "run in the nested cloud session",
-        },
-      };
-      const first = await execute(request);
-      const replay = await execute(request);
+      const first = await spawn("spawn-cloud-child", "run in the nested cloud session");
+      const replay = await spawn("spawn-cloud-child", "run in the nested cloud session");
 
       expect(childSessionKey).toMatch(/^agent:main:dashboard:cloud-[a-f0-9]{32}$/u);
       expect(spawnOrder).toEqual(["create", "dispatch", "send"]);
@@ -520,11 +518,7 @@ describe("worker session tool topology", () => {
       sessionEntries.get(SOURCE.sessionKey)!.permissionMode = mode;
     }
 
-    await execute({
-      identity,
-      toolName: "sessions_spawn",
-      request: { toolCallId: "spawn-cloud-child-with-permissions", task: "start the child" },
-    });
+    await spawn("spawn-cloud-child-with-permissions");
 
     const createParams = gatewayCreate.mock.calls[0]?.[0]?.params;
     expect(createParams).toMatchObject({ worktree: true });
@@ -538,11 +532,7 @@ describe("worker session tool topology", () => {
   it("carries the exact admitted parent identity into a worker-hosted child spawn", async () => {
     setEntry(SOURCE.sessionKey, SOURCE.sessionId);
 
-    await execute({
-      identity,
-      toolName: "sessions_spawn",
-      request: { toolCallId: "spawn-with-parent-identity", task: "start the child" },
-    });
+    await spawn("spawn-with-parent-identity");
 
     expect(spawnCallerIdentity).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -596,13 +586,7 @@ describe("worker session tool topology", () => {
       });
       return await create(request);
     });
-    const request = {
-      identity,
-      toolName: "sessions_spawn" as const,
-      request: { toolCallId: "concurrent-spawn", task: "start one child" },
-    };
-
-    const retries = Array.from({ length: 32 }, () => execute(request));
+    const retries = Array.from({ length: 32 }, () => spawn("concurrent-spawn"));
     await vi.waitFor(() => expect(gatewayCreate).toHaveBeenCalledOnce());
     finishCreate?.();
     const results = await Promise.all(retries);
@@ -626,17 +610,8 @@ describe("worker session tool topology", () => {
         throw new Error("session creation response was lost");
       },
     );
-    const request = {
-      identity,
-      toolName: "sessions_spawn" as const,
-      request: {
-        toolCallId: "spawn-response-loss",
-        task: "continue after ambiguous session creation",
-      },
-    };
-
-    const first = await execute(request);
-    const replay = await execute(request);
+    const first = await spawn("spawn-response-loss");
+    const replay = await spawn("spawn-response-loss");
 
     expect(spawnOrder).toEqual(["create", "dispatch", "send"]);
     expect(gatewayCreate).toHaveBeenCalledOnce();
@@ -664,14 +639,7 @@ describe("worker session tool topology", () => {
       },
     );
 
-    const result = await execute({
-      identity,
-      toolName: "sessions_spawn",
-      request: {
-        toolCallId: "spawn-dispatch-response-loss",
-        task: "continue after ambiguous cloud dispatch",
-      },
-    });
+    const result = await spawn("spawn-dispatch-response-loss");
 
     expect(result.resultJson).not.toContain('"status":"error"');
     expect(spawnOrder).toEqual(["create", "dispatch", "send"]);
@@ -696,14 +664,7 @@ describe("worker session tool topology", () => {
       },
     );
 
-    const result = await execute({
-      identity,
-      toolName: "sessions_spawn",
-      request: {
-        toolCallId: "spawn-initial-task-response-loss",
-        task: "continue exactly once after response loss",
-      },
-    });
+    const result = await spawn("spawn-initial-task-response-loss");
 
     expect(result.resultJson).not.toContain('"status":"error"');
     expect(spawnOrder).toEqual(["create", "dispatch", "send", "send"]);
@@ -713,11 +674,7 @@ describe("worker session tool topology", () => {
 
   it("spawns a grandchild from the child cloud turn and communicates across both levels", async () => {
     setEntry(SOURCE.sessionKey, SOURCE.sessionId);
-    await execute({
-      identity,
-      toolName: "sessions_spawn",
-      request: { toolCallId: "spawn-child-for-nesting", task: "start the child" },
-    });
+    await spawn("spawn-child-for-nesting");
     const spawnedChildKey = childSessionKey!;
     const childClaim = placements.claimTurn({
       sessionId: CHILD.sessionId,
@@ -858,17 +815,8 @@ describe("worker session tool topology", () => {
         throw new Error("session creation response was lost");
       },
     );
-    const request = {
-      identity,
-      toolName: "sessions_spawn" as const,
-      request: {
-        toolCallId: "spawn-unknown-owner",
-        task: "do not replay an unowned child",
-      },
-    };
-
-    const first = await execute(request);
-    const replay = await execute(request);
+    const first = await spawn("spawn-unknown-owner");
+    const replay = await spawn("spawn-unknown-owner");
 
     expect(first.resultJson).toContain("outcome is unknown");
     expect(replay.resultJson).toContain("prior operation outcome is unknown");
@@ -915,6 +863,52 @@ describe("worker session tool topology", () => {
       }),
     );
   });
+
+  it.each([
+    { relation: "parent", placement: "unplaced" },
+    { relation: "parent", placement: "local" },
+    { relation: "sibling", placement: "unplaced" },
+    { relation: "sibling", placement: "local" },
+  ] as const)(
+    "delivers to an authorized Gateway $relation with $placement placement",
+    async ({ relation, placement }) => {
+      setEntry(TARGET.sessionKey, TARGET.sessionId);
+      setEntry(SOURCE.sessionKey, SOURCE.sessionId, relation === "parent" ? PARENT : TARGET);
+      setEntry(PARENT.sessionKey, PARENT.sessionId, relation === "sibling" ? TARGET : undefined);
+      if (placement === "local") {
+        const claim = placements.claimTurn({
+          ...PARENT,
+          agentId: SOURCE.agentId,
+          claimId: "gateway-target-claim",
+          runId: "gateway-target-run",
+          owner: { kind: "local" },
+        });
+        placements.releaseTurn(claim);
+        expect(placements.get(PARENT.sessionId)?.state).toBe("local");
+      } else {
+        expect(placements.get(PARENT.sessionId)).toBeUndefined();
+      }
+
+      const result = await execute({
+        identity,
+        toolName: "sessions_send",
+        request: {
+          toolCallId: "send-to-gateway",
+          sessionKey: PARENT.sessionKey,
+          message: "Report the Gateway result",
+          timeoutSeconds: 30,
+        },
+      });
+
+      expect(JSON.parse(result.resultJson)).toMatchObject({ details: { status: "ok" } });
+      expect(delivered).toHaveBeenCalledExactlyOnceWith(
+        expect.objectContaining({
+          args: expect.objectContaining({ sessionKey: PARENT.sessionKey }),
+          options: expect.objectContaining({ expectedTargetSessionId: PARENT.sessionId }),
+        }),
+      );
+    },
+  );
 
   it("deduplicates retries without collapsing distinct identical sends", async () => {
     setEntry(SOURCE.sessionKey, SOURCE.sessionId);
@@ -1047,15 +1041,29 @@ describe("worker session tool topology", () => {
     expect(delivered).not.toHaveBeenCalled();
   });
 
-  it("denies a target key rebound to a replacement session id", async () => {
-    setEntry(SOURCE.sessionKey, SOURCE.sessionId);
-    setEntry(TARGET.sessionKey, "replacement-target", {
-      sessionKey: SOURCE.sessionKey,
-      sessionId: SOURCE.sessionId,
-    });
+  it.each(["target", "shared parent"] as const)(
+    "denies a replaced %s incarnation after awaiting sibling admission",
+    async (replaced) => {
+      setEntry(PARENT.sessionKey, PARENT.sessionId);
+      setEntry(SOURCE.sessionKey, SOURCE.sessionId, PARENT);
+      setEntry(TARGET.sessionKey, TARGET.sessionId, PARENT);
+      scopedSessionAccess.mockImplementationOnce(async (params) => {
+        if (replaced === "target") {
+          setEntry(TARGET.sessionKey, "replacement-target", PARENT);
+          activate({ ...TARGET, sessionId: "replacement-target" });
+        } else {
+          setEntry(PARENT.sessionKey, "replacement-parent");
+        }
+        return await params.run();
+      });
 
-    const result = await send("stale-target");
-    expect(result.resultJson).toContain("not an active cloud session incarnation");
-    expect(delivered).not.toHaveBeenCalled();
-  });
+      const result = await send("replaced-during-admission");
+      expect(result.resultJson).toContain(
+        replaced === "target"
+          ? "target incarnation changed"
+          : "outside the authorized session tree",
+      );
+      expect(delivered).not.toHaveBeenCalled();
+    },
+  );
 });

--- a/src/gateway/worker-environments/worker-session-tool-executor.ts
+++ b/src/gateway/worker-environments/worker-session-tool-executor.ts
@@ -462,7 +462,6 @@ export function createWorkerSessionToolExecutor(params: {
         const target = exactAuthorizedTarget({
           source: operation.source,
           requestedSessionKey: operation.request.sessionKey,
-          placements: params.placements,
         });
         if (
           target.sessionId !== operation.target.sessionId ||
@@ -619,7 +618,6 @@ export function createWorkerSessionToolExecutor(params: {
             ? exactAuthorizedTarget({
                 source,
                 requestedSessionKey: request.request.sessionKey,
-                placements: params.placements,
               })
             : undefined;
         let childKey = started.childSessionKey;

--- a/src/gateway/worker-environments/worker-session-tool-topology.ts
+++ b/src/gateway/worker-environments/worker-session-tool-topology.ts
@@ -69,7 +69,6 @@ export function resolveWorkerSessionToolSource(params: {
 export function resolveWorkerSessionToolTarget(params: {
   source: WorkerSessionToolSource;
   requestedSessionKey: string;
-  placements: WorkerSessionPlacementStore;
 }): WorkerSessionToolTarget {
   const loaded = loadGatewaySessionEntryReadOnly(params.requestedSessionKey);
   const entry = loaded.entry;
@@ -110,18 +109,12 @@ export function resolveWorkerSessionToolTarget(params: {
   if (!parentToChild && !childToParent && !siblingToSibling) {
     throw new Error("Worker sessions_send target is outside the authorized session tree");
   }
-  const targetPlacement = params.placements.get(targetSessionId);
-  if (
-    !targetPlacement ||
-    targetPlacement.state !== "active" ||
-    targetPlacement.sessionKey !== loaded.canonicalKey
-  ) {
-    throw new Error("Worker sessions_send target is not an active cloud session incarnation");
-  }
+  // Session identity owns messaging authority. Target turn admission chooses
+  // its execution placement, including Gateway-local or reclaimed workers.
   return {
-    agentId: targetPlacement.agentId,
-    sessionKey: targetPlacement.sessionKey,
-    sessionId: targetPlacement.sessionId,
+    agentId: loaded.agentId,
+    sessionKey: loaded.canonicalKey,
+    sessionId: targetSessionId,
     ...(siblingToSibling && sourceParent && sourceParentId
       ? { topologyParent: { sessionKey: sourceParent, sessionId: sourceParentId } }
       : {}),

--- a/src/worker/worker-session-tools.ts
+++ b/src/worker/worker-session-tools.ts
@@ -96,7 +96,7 @@ export function createWorkerSessionTools(client: WorkerSessionRpcClient): AnyAge
       label: "Session Send",
       name: "sessions_send",
       description:
-        'Send a message to an authorized parent, child, or sibling cloud session. Cross-tree and stale-incarnation targets are denied by the Gateway. Status "no_reply" is terminal; do not wait for another result.',
+        'Send a message to an authorized parent, child, or sibling session on this Gateway, whether it runs on the Gateway, a paired device, or a cloud worker. Cross-tree and stale-incarnation targets are denied by the Gateway. Status "no_reply" is terminal; do not wait for another result.',
       parameters: Type.Object({
         sessionKey: Type.String({ minLength: 1, maxLength: 1_024 }),
         message: Type.String({ minLength: 1, maxLength: WORKER_SESSION_TOOL_MAX_TEXT_LENGTH }),


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

Keep **Allow edits from maintainers** enabled so maintainers can help update the branch.

</details>

## What Problem This Solves

Fixes an issue where users asking a session on a paired device or cloud worker to message an authorized Gateway session would receive `Worker sessions_send target is not an active cloud session incarnation` instead of a reply. The failure affected valid parent and sibling targets simply because their work ran on the Gateway.

## Why This Change Was Made

Session identity and exact parent/child/sibling relationships determine messaging authority; target turn admission determines where the recipient runs. This change removes the duplicate requirement for an active remote target placement and resolves the recipient from the authoritative session store, while preserving source turn claims, exact-incarnation checks, sibling-parent fencing, and ordinary visibility policy. Worker tool guidance and session-tool documentation now describe messaging across Gateway, paired-device, and cloud placements.

Production code shrinks by **9 lines**; tests grow by **8 lines**. No configuration, protocol, or SQLite schema changes.

## User Impact

An authorized worker can send to a Gateway parent or sibling without moving the recipient to a remote machine. Existing target turn admission still owns execution and recovery; cross-tree access and stale session incarnations remain denied. This does not enable messaging between independent Gateways or widen session visibility.

## Evidence

- **Live before/after:** on an isolated development Gateway with a real OpenAI API key and `openai/gpt-5.6-luna`, the paired-node sender initially received `not an active cloud session incarnation`. After the fix, the same node-to-Gateway flow returned the recipient's exact reply, `ACK_NODE_GATEWAY_1845a55d`.
- **Other completed live cases:** Gateway-to-Gateway and Gateway-to-node messaging passed; intentional empty replies returned terminal `no_reply`; cross-tree sends were denied; fire-and-forget sends returned `accepted` and the recipient transcript confirmed the message committed.
- **Regression proof:** `node scripts/run-vitest.mjs src/gateway/worker-environments/worker-session-tool-executor.test.ts` produced **4 failed / 25 passed before the fix**, then **29 passed after the fix**. The four failures cover Gateway parent/sibling recipients with absent or canonical local placement records. Actual target and shared-parent replacement during awaited admission remain denied; existing remote messaging, source authority, and deduplication coverage passes.
- **Worker tool suite:** `src/worker/worker-session-tools.test.ts` passed **2/2**. Runtime build, package integrity, formatting, and `git diff --check` passed. Mandatory autoreview completed clean, with no P0 findings.
- **Live cloud matrix:** an AWS Crabbox worker installed the checksum-verified custom node package and enrolled over outbound TLS. Gateway-to-cloud, cloud-to-Gateway, node-to-cloud, and cloud-to-node all returned the exact unique ACK, with successful tool results recorded in the sender transcripts. Cloud-to-Gateway returned `ACK_CLOUD_GATEWAY_a7b724f1`; device/cloud sibling sends returned `ACK_NODE_CLOUD_d646666e` and `ACK_CLOUD_NODE_d76d8fee`. All used the explicit Platform API-key route. The fixture enables existing `tools.sessions.visibility: all`; this fix does not change the default visibility policy.
- **UI proof is blocked:** the real Chrome relay Control UI did not mount, so no valid screenshot or video proof was captured. The completed behavioral evidence above comes from live tool results and committed session transcripts, not a rendered UI.

The first test attempt was interrupted during startup while shared workspace dependency links were being repaired. An initial combined post-fix invocation passed the worker tool suite but was interrupted before the executor suite completed; the subsequent isolated single-file executor run completed successfully in 66.28 seconds. These interrupted attempts are not counted as successful executor proof.

The test-file lint limit was resolved by consolidating repeated spawn request setup; all 29 cases remain and passed again.

Separate follow-up found during cleanup: #132819 tracks restart/shutdown rejecting pending node completion replies. It is not changed by this messaging repair.


CI follow-through: the first run failed only pre-existing Vitest shutdown fixtures that sent unsupported pool types through the Inspector profiler. The native-profile repair landed in #132820; the messaging patch is unchanged and rebased onto it for new exact-head CI. The final changed-file gate passed, including core/test types and lint.
