### PR TITLE
test: restore native worker shutdown profiling coverage

### DIFF
--- a/test/fixtures/vitest-fork-shutdown.mjs
+++ b/test/fixtures/vitest-fork-shutdown.mjs
@@ -1,3 +1,4 @@
+import assert from "node:assert/strict";
 import fs from "node:fs";
 import path from "node:path";
 import { PassThrough } from "node:stream";
@@ -244,37 +245,35 @@ export default {
     `
 import fs from "node:fs";
 import { it, expect } from "vitest";
+import { threadId } from "node:worker_threads";
 ${scenario === "hung-exit" ? `process.once("exit", () => { fs.writeFileSync(${JSON.stringify(ready)}, "exit"); Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0); });` : ""}
 ${scenario === "bad-exit" ? 'process.once("exit", () => { process.exitCode = 23; });' : ""}
 it("completes the test before worker shutdown", () => {
-  fs.writeFileSync(${JSON.stringify(receipt)}, JSON.stringify({ pid: process.pid, home: process.env.HOME }));
+  fs.writeFileSync(${JSON.stringify(receipt)}, JSON.stringify({ pid: process.pid, threadId, home: process.env.HOME }));
   ${fail ? 'expect.fail("intentional fixture failure");' : "expect(true).toBe(true);"}
 });
 `,
   );
-  const args =
-    scenario === "plain" || scenario === "custom"
-      ? [
-          path.join(repo, "scripts/run-vitest.mjs"),
-          "run",
-          "--config",
-          config,
-          "--root",
-          root,
-          "--configLoader",
-          "native",
-        ]
-      : [
-          path.join(repo, "scripts/run-vitest-profile.mts"),
-          "runner",
-          "--output-dir",
-          profiles,
-          "--",
-          "--root",
-          root,
-          "--configLoader",
-          "native",
-        ];
+  const args = [
+    path.join(repo, "scripts/run-vitest.mjs"),
+    "run",
+    "--config",
+    config,
+    "--root",
+    root,
+    "--configLoader",
+    "native",
+  ];
+  if (scenario !== "plain" && scenario !== "custom") {
+    // This shutdown contract covers Node's exit-time writes, not the Inspector
+    // profiler's awaited cleanup. Pass native flags only to the actual worker.
+    args.push(
+      "--execArgv=--cpu-prof",
+      `--execArgv=--cpu-prof-dir=${profiles}`,
+      "--execArgv=--heap-prof",
+      `--execArgv=--heap-prof-dir=${profiles}`,
+    );
+  }
   const { child, completion } = spawnOwnedVitestProcess({
     command: process.execPath,
     args,
@@ -289,6 +288,10 @@ it("completes the test before worker shutdown", () => {
     output += chunk;
   });
   const { code } = await completion.finally(detachCleanup);
+  assert.ok(
+    fs.existsSync(receipt),
+    `Vitest exited before the fixture test (code ${code}):\n${output}`,
+  );
   const state = JSON.parse(fs.readFileSync(receipt, "utf8"));
   let workerStopped = false;
   try {
@@ -302,6 +305,12 @@ it("completes the test before worker shutdown", () => {
   }
   const counts = { cpu: 0, heap: 0 };
   for (const file of fs.readdirSync(profiles)) {
+    // Native profile names contain PID/thread ID. A launcher profile cannot
+    // establish that the worker's exit-time writes completed.
+    const [, , , pid, workerThreadId] = file.split(".");
+    if (pid !== String(state.pid) || workerThreadId !== String(state.threadId)) {
+      continue;
+    }
     const profile = JSON.parse(fs.readFileSync(path.join(profiles, file), "utf8"));
     if (file.endsWith(".cpuprofile") && profile.nodes?.length) {
       counts.cpu++;
@@ -314,6 +323,7 @@ it("completes the test before worker shutdown", () => {
     JSON.stringify({
       code,
       output,
+      worker: { pid: state.pid, threadId: state.threadId },
       workerStopped,
       profiles: counts,
       homeRemoved: !fs.existsSync(state.home),

--- a/test/scripts/vitest-fork-shutdown.test.ts
+++ b/test/scripts/vitest-fork-shutdown.test.ts
@@ -45,6 +45,11 @@ it.each([
     expect(result.output).toContain("intentional fixture failure");
   }
   expect(result.workerStopped).toBe(true);
+  if (scenario === "threads") {
+    expect(result.worker.threadId).toBeGreaterThan(0);
+  } else {
+    expect(result.worker.threadId).toBe(0);
+  }
   if (setup !== "raw") {
     // Windows has no wrapper-owned group cleanup after a forced termination.
     // Its unfinished home remains inside this test's auto-cleaned fixture root.


### PR DESCRIPTION
## What Problem This Solves

Two shutdown regression cases fail on current main before their test body runs: `vmForks` and the custom fork transport that opts into graceful exit. The fixture invokes the general profiling wrapper, which now uses an Inspector profiler restricted to forks and threads. Its startup error is then hidden by an unconditional read of the missing test receipt. This blocked unrelated Slack and E2E-runner CI on their merge refs.

## Why This Change Was Made

Run the shutdown fixture through the existing Vitest launcher and pass native CPU/heap profiling flags only through worker `execArgv`. The dependency patch's contract is native exit-time flushing; testing it through the newer awaited Inspector profiler mixes two different owners. The production profiler and its supported-pool restrictions remain unchanged.

Keep all twelve cases, existing deadlines, failure assertions, and cleanup checks. Match valid native profiles to the PID and thread ID recorded by the actual test worker, so a launcher profile cannot satisfy the proof. Missing receipts now report the captured child output instead of hiding the startup failure.

## Evidence

- Exact combined revision `86b9cf728895`: baseline **10 passed, 2 failed**, reproducing both CI failures. Captured child stderr confirms the unsupported-pool error before the missing receipt.
- Corrected fixture: **12/12 passed**, including vmForks, custom transport opt-in, threads, delayed cleanup, abnormal exit, and forced shutdown.
- Actual Node 24 worker profiling verified valid CPU/heap files with the recorded PID/thread ID; installed Vitest 4.1.11 source confirms worker `execArgv` forwarding for forks, threads, and vmForks.
- Sibling profiler/state-cleanup run: **45/46 passed**; one unchanged nested SQLite test exceeded its existing five-second timeout on the loaded host. That exact case passed alone without edits. The failed run remains recorded; no timeout was increased.
- Mandatory Codex review reported no actionable findings. Final changed-file gate passed, including test-root types and scripts lint.

Production/runtime delta: **0**. Tests and test support: **+39/-24** (net +15). No dependency patch, product configuration, timeout, or profiler-policy change.

Provenance: the native shutdown fixture was introduced in #132403 (`0f221129474`); the Inspector profiling implementation arrived in #132224 (`81a74b23eb1`). This repairs their combined test contract rather than reverting either owner.
