### PR TITLE
perf: reduce redundant cloud workspace transfer work

### DIFF
--- a/src/auto-reply/reply/stage-sandbox-media.ts
+++ b/src/auto-reply/reply/stage-sandbox-media.ts
@@ -107,9 +107,6 @@ export async function stageSandboxMedia(params: {
       continue;
     }
     const fileName = allocateStagedFileName(source.pathForFileName, usedNames);
-    if (!fileName) {
-      continue;
-    }
     const stageIntoSandboxMediaDir = Boolean(sandbox);
     const relativeDest = path.join(inputDirectory, fileName);
     const dest = path.join(effectiveWorkspaceDir, relativeDest);
@@ -357,11 +354,8 @@ async function isAllowedSourcePath(params: {
   }
 }
 
-function allocateStagedFileName(source: string, usedNames: Set<string>): string | null {
+function allocateStagedFileName(source: string, usedNames: Set<string>): string {
   const baseName = stagedInputFileName(path.basename(source));
-  if (!baseName) {
-    return null;
-  }
   const parsed = path.parse(baseName);
   let fileName = baseName;
   let suffix = 1;

--- a/src/gateway/worker-environments/node-workspace-upload-reader.test.ts
+++ b/src/gateway/worker-environments/node-workspace-upload-reader.test.ts
@@ -1,0 +1,58 @@
+import type { IncomingMessage } from "node:http";
+import { Readable } from "node:stream";
+import { describe, expect, it } from "vitest";
+import { RequestByteReader } from "./node-workspace-upload-reader.js";
+
+function createReader(chunks: Buffer[]): RequestByteReader {
+  const request = Readable.from(chunks) as unknown as IncomingMessage;
+  return new RequestByteReader(request, new AbortController().signal, () => {});
+}
+
+describe("workspace upload byte stream", () => {
+  it.each(["coalesced", "fragmented"])(
+    "preserves consecutive headers and bodies in %s chunks",
+    async (chunking) => {
+      const bodies = [
+        Buffer.from("base manifest"),
+        Buffer.from("current manifest"),
+        Buffer.from("file\0bytes"),
+      ];
+      const headers = bodies.map((body, index) => {
+        const header = Buffer.alloc(index === 2 ? 8 : 4);
+        if (header.length === 8) {
+          header.writeBigUInt64BE(BigInt(body.length));
+        } else {
+          header.writeUInt32BE(body.length);
+        }
+        return header;
+      });
+      const parts = bodies.flatMap((body, index) => [headers[index]!, body]);
+      const payload = Buffer.concat(parts);
+      const chunks =
+        chunking === "coalesced" ? [payload] : Array.from(payload, (byte) => Buffer.from([byte]));
+      const reader = createReader(chunks);
+
+      for (const part of parts) {
+        await expect(reader.readExactly(part.length)).resolves.toEqual(part);
+      }
+      await expect(reader.readExactly(0)).resolves.toEqual(Buffer.alloc(0));
+      await expect(reader.assertEnd()).resolves.toBeUndefined();
+      expect(reader.bytesRead).toBe(payload.length);
+    },
+  );
+
+  it("rejects premature EOF across chunk boundaries", async () => {
+    const reader = createReader([Buffer.from("ab"), Buffer.from("c")]);
+
+    await expect(reader.readExactly(4)).rejects.toThrow("ended before its declared payload");
+  });
+
+  it.each(["buffered", "next chunk"])("rejects trailing bytes in the %s suffix", async (suffix) => {
+    const reader = createReader(
+      suffix === "buffered" ? [Buffer.from("abc!")] : [Buffer.from("abc"), Buffer.from("!")],
+    );
+
+    await expect(reader.readExactly(3)).resolves.toEqual(Buffer.from("abc"));
+    await expect(reader.assertEnd()).rejects.toThrow("contains trailing bytes");
+  });
+});

--- a/src/gateway/worker-environments/node-workspace-upload-reader.ts
+++ b/src/gateway/worker-environments/node-workspace-upload-reader.ts
@@ -58,7 +58,10 @@ export class RequestByteReader {
     }
     const count = Math.min(maxBytes, this.#pending.length);
     const value = this.#pending.subarray(0, count);
-    this.#pending = Buffer.from(this.#pending.subarray(count));
+    // Coalesced records must not repeatedly copy the unread suffix.
+    // Release exhausted chunks rather than retaining their backing storage.
+    this.#pending =
+      count === this.#pending.length ? Buffer.alloc(0) : this.#pending.subarray(count);
     this.bytesRead += value.byteLength;
     if (this.bytesRead > MAX_UPLOAD_BYTES) {
       throw new NodeWorkspaceTransferLimitError("Workspace transfer upload exceeds its byte limit");

--- a/src/gateway/worker-environments/workspace-manifest.ts
+++ b/src/gateway/worker-environments/workspace-manifest.ts
@@ -193,22 +193,19 @@ function validateAndProjectEntries(values: unknown[]): {
 export function serializeWorkerWorkspaceManifest(manifest: WorkerWorkspaceManifest): string {
   const stagedInputs = stagedInputDirectoriesFromEntries(manifest.entries);
   const entries = [
-    ...(manifest.directories ?? [])
-      .filter(
-        (entryPath) =>
-          !isDerivedWorkspacePath(entryPath, isStagedInputPath(entryPath, stagedInputs)),
-      )
-      .map((entryPath) => ({
-        path: entryPath,
-        type: "directory" as const,
-        // Phase 1 projects directory permissions away. Keep recomputed
-        // manifests deterministic without creating a new mode contract.
-        mode: 0o700,
-      })),
-    ...manifest.entries.filter(
+    ...(manifest.directories ?? []).map((entryPath) => ({
+      path: entryPath,
+      type: "directory" as const,
+      // Phase 1 projects directory permissions away. Keep recomputed
+      // manifests deterministic without creating a new mode contract.
+      mode: 0o700,
+    })),
+    ...manifest.entries,
+  ]
+    .filter(
       (entry) => !isDerivedWorkspacePath(entry.path, isStagedInputPath(entry.path, stagedInputs)),
-    ),
-  ].toSorted(compareManifestPaths);
+    )
+    .toSorted(compareManifestPaths);
   if (entries.length > MAX_WORKSPACE_INVENTORY_ENTRIES) {
     throw new Error("Worker workspace manifest has too many entries");
   }

--- a/src/gateway/worker-environments/workspace-sync-inventory.test.ts
+++ b/src/gateway/worker-environments/workspace-sync-inventory.test.ts
@@ -2,6 +2,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../../test/helpers/promise.js";
 import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
 import { runCommandWithTimeout } from "../../process/exec.js";
 import {
@@ -142,6 +143,63 @@ describe("runWorkspaceInventoryCommandToFile", () => {
       Buffer.from("alpha.txt\0nested/beta.txt\0"),
     );
   });
+
+  it.each(["ignored", "selected"] as const)(
+    "settles both Git writers when %s fails first",
+    async (firstFailure) => {
+      const root = await fs.realpath(tempDirs.make("openclaw-workspace-list-writers-"));
+      const workspace = path.join(root, "workspace");
+      const temporaryDirectory = path.join(root, "transfer");
+      await fs.mkdir(workspace);
+      await git(workspace, "init", "--quiet");
+      await fs.writeFile(path.join(workspace, ".worktreeinclude"), "selected.txt\n");
+      const started = createDeferred();
+      const release = { ignored: createDeferred(), selected: createDeferred() };
+      const errors = {
+        ignored: new Error("ignored inventory writer failed"),
+        selected: new Error("selected inventory writer failed"),
+      };
+      const observed = new Set<string>();
+      const originalOpen = fs.open.bind(fs);
+      vi.spyOn(fs, "open").mockImplementation(async (...args) => {
+        const target = args[0];
+        if (typeof target === "string" && path.dirname(target) === temporaryDirectory) {
+          const name = path.basename(target);
+          if (name === "ignored" || name === "selected") {
+            observed.add(name);
+            started.resolve();
+            await release[name].promise;
+            throw errors[name];
+          }
+        }
+        return await originalOpen(...args);
+      });
+      const operation = createWorkspaceGitTransferList({
+        gitRoot: workspace,
+        temporaryDirectory,
+        signal: new AbortController().signal,
+        timeoutMs: 10_000,
+      });
+      const settled = vi.fn();
+      void operation.then(settled, settled);
+      try {
+        await Promise.race([started.promise, operation]);
+        expect(observed).toEqual(new Set(["ignored", "selected"]));
+        release[firstFailure].resolve();
+        await new Promise<void>((resolve) => {
+          setImmediate(resolve);
+        });
+        expect(settled).not.toHaveBeenCalled();
+        release.ignored.resolve();
+        release.selected.resolve();
+        await expect(operation).rejects.toBe(errors.ignored);
+      } finally {
+        release.ignored.resolve();
+        release.selected.resolve();
+        await operation.catch(() => undefined);
+      }
+    },
+  );
 
   it("fully persists a filtered Git transfer list after a positive short write", async () => {
     const root = tempDirs.make("openclaw-workspace-filter-short-write-");

--- a/src/gateway/worker-environments/workspace-sync-inventory.ts
+++ b/src/gateway/worker-environments/workspace-sync-inventory.ts
@@ -515,25 +515,11 @@ export async function createWorkspaceGitTransferList(params: {
     }
     throw error;
   });
-  await runWorkspaceInventoryCommandToFile({
-    argv: [
-      "git",
-      "-C",
-      params.gitRoot,
-      "ls-files",
-      "--full-name",
-      "--others",
-      "--ignored",
-      "--exclude-standard",
-      "-z",
-      ...(worktreeInclude?.isFile() ? [] : ["--", STAGED_INPUT_GIT_PATHSPEC]),
-    ],
-    outputPath: ignoredPath,
-    signal: params.signal,
-    timeoutMs: params.timeoutMs,
-  });
-  if (worktreeInclude?.isFile()) {
-    await runWorkspaceInventoryCommandToFile({
+  const hasWorktreeInclude = worktreeInclude?.isFile() === true;
+  // Both producers write into the same scratch directory. Join them before
+  // reporting either error so caller cleanup cannot race the remaining writer.
+  const results = await Promise.allSettled([
+    runWorkspaceInventoryCommandToFile({
       argv: [
         "git",
         "-C",
@@ -542,15 +528,37 @@ export async function createWorkspaceGitTransferList(params: {
         "--full-name",
         "--others",
         "--ignored",
-        `--exclude-from=${worktreeIncludePath}`,
+        "--exclude-standard",
         "-z",
+        ...(hasWorktreeInclude ? [] : ["--", STAGED_INPUT_GIT_PATHSPEC]),
       ],
-      outputPath: selectedPath,
+      outputPath: ignoredPath,
       signal: params.signal,
       timeoutMs: params.timeoutMs,
-    });
-  } else {
-    await fs.writeFile(selectedPath, "", { mode: 0o600 });
+    }),
+    hasWorktreeInclude
+      ? runWorkspaceInventoryCommandToFile({
+          argv: [
+            "git",
+            "-C",
+            params.gitRoot,
+            "ls-files",
+            "--full-name",
+            "--others",
+            "--ignored",
+            `--exclude-from=${worktreeIncludePath}`,
+            "-z",
+          ],
+          outputPath: selectedPath,
+          signal: params.signal,
+          timeoutMs: params.timeoutMs,
+        })
+      : fs.writeFile(selectedPath, "", { mode: 0o600 }),
+  ]);
+  for (const result of results) {
+    if (result.status === "rejected") {
+      throw result.reason;
+    }
   }
   await writeEligibleGitFiles({
     gitRoot: params.gitRoot,

--- a/src/infra/agent-run-registry.ts
+++ b/src/infra/agent-run-registry.ts
@@ -3,6 +3,7 @@ import { randomUUID } from "node:crypto";
 import type { VerboseLevel } from "../auto-reply/thinking.js";
 import { normalizeAgentId, parseAgentSessionKey } from "../routing/session-key.js";
 import { resolveGlobalSingleton } from "../shared/global-singleton.js";
+import { notifyListeners, registerListener } from "../shared/listeners.js";
 import { clearAgentRunUsage, resetAgentRunUsageForTest } from "./agent-run-usage.js";
 
 /** Per-run metadata used to stamp events and gate Control UI visibility. */
@@ -107,13 +108,8 @@ function notifyDelegatedAuthorityClosed(
   state: AgentRunRegistryState,
   authority: AgentRunDelegatedAuthority,
 ): void {
-  for (const handler of state.delegatedAuthorityClosedHandlers ?? []) {
-    try {
-      handler(authority);
-    } catch {
-      // One observer cannot block closure or prevent other owners from cancelling work.
-    }
-  }
+  // One observer cannot block closure or prevent other owners from canceling work.
+  notifyListeners(state.delegatedAuthorityClosedHandlers ?? [], authority);
 }
 
 /** Observe exact delegated-authority closure without displacing other lifecycle owners. */
@@ -121,10 +117,7 @@ export function registerAgentRunDelegatedAuthorityClosedHandler(
   handler: (authority: AgentRunDelegatedAuthority) => void,
 ): () => void {
   const handlers = (getAgentRunRegistryState().delegatedAuthorityClosedHandlers ??= new Set());
-  handlers.add(handler);
-  return () => {
-    handlers.delete(handler);
-  };
+  return registerListener(handlers, handler);
 }
 
 /** Connects registry cleanup to the event sequencer without reversing ownership. */


### PR DESCRIPTION
Related: https://github.com/openclaw/openclaw/pull/132114 (cloud-session image support).

## What Problem This Solves

Cloud workspace uploads can perform repeated copies of the unread portion of a network chunk when several small records arrive together. The image-support repair also left independent Git inventory commands serialized and small pieces of duplicate control flow. This is the maintainer-requested performance and simplification follow-up, not a new image-input feature.

## Why This Change Was Made

Retain unread upload bytes as a view and release exhausted chunks. Run the independent ignored/selected Git inventories concurrently, but join both before reporting either failure so caller cleanup cannot race a remaining writer. Reuse the shared synchronous listener helpers, remove the staging filename branch already excluded by the nonempty sanitizer contract, and apply the manifest exclusion predicate through one shared path.

Marker-backed input ownership, receiver admission placement, deterministic manifest bytes, authority cancellation, stream limits, exclusive file creation, and the documented fs-safe cancellation limitation are unchanged. The tempting lazy marker lookup and merged cancellation-controller alternatives were deliberately rejected because they would change observation or lifecycle semantics.

## User Impact

Less allocation work for small-record-heavy cloud workspace uploads and less avoidable serialization during Git inventory. No new configuration, dependency, database schema, protocol, model route, or operator action. No UI or chat presentation change.

Release-note context: reduce redundant copying and inventory work in cloud workspace transfers while retaining private image/file inputs and their publication exclusions.

## Evidence

- Actual `RequestByteReader` probe: a 65,536-byte input containing 128 records previously caused 255 unread-suffix copies totaling 8,387,584 bytes; the candidate causes zero. Both runs verified all headers, bodies, and total byte count. This is copy-count evidence, not an end-to-end speedup claim.
- The two new writer-settlement cases fail on the serial implementation and pass on the candidate. They require both producers to start, neither failure to escape while its sibling is pending, and deterministic final error selection.
- Five reader cases cover coalesced and byte-fragmented framing, premature EOF, and buffered/next-chunk trailing bytes. No test-only production seam was added.
- Production LOC: +53/-58 (net -5). Tests: +116/-0.
- Full current-base `check-changed` passed: core/test types, typed lint, formatting, all three hard-zero export scans, boundaries, cycles, and selected storage/media/auth guards.
- Final uninstrumented Gateway proof: **39/39 passed** in one shared worker, explicitly sequenced service → inventory → manifest → retention → reader. All five Git/plain retention modes passed. The temporary config extends the canonical Gateway config and inherits its existing watchdog policy; no test or subprocess deadline was changed.
- Staging: **25/25 passed**. Delegated-authority lifecycle/observer coverage: **5/5 passed**.
- Fresh isolated Codex autoreview: scoped-clean at the required P0 threshold. All seven files were hash-verified unchanged after review and the move onto current main.

Local proof used Node 24.20.0 and the repository-pinned pnpm 12.0.0. Exact scoped commands:

```bash
node scripts/check-changed.mjs --base HEAD -- src/auto-reply/reply/stage-sandbox-media.ts src/gateway/worker-environments/node-workspace-upload-reader.test.ts src/gateway/worker-environments/node-workspace-upload-reader.ts src/gateway/worker-environments/workspace-manifest.ts src/gateway/worker-environments/workspace-sync-inventory.test.ts src/gateway/worker-environments/workspace-sync-inventory.ts src/infra/agent-run-registry.ts
```

```bash
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/auto-reply/reply.triggers.trigger-handling.stages-inbound-media-into-sandbox-workspace.test.ts src/auto-reply/reply.stage-sandbox-media.scp-remote-path.test.ts src/infra/agent-run-delegated-authority.test.ts -- --maxWorkers=1 --fileParallelism=false --reporter=verbose
```

```bash
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs run --config .artifacts/cloud-image-simplify/ordered-gateway.config.mjs --configLoader runner --maxWorkers=1 --fileParallelism=false --outputFile.json .artifacts/cloud-image-simplify/final-gateway.json src/gateway/worker-environments/node-workspace-transfer-service.test.ts src/gateway/worker-environments/workspace-sync-inventory.test.ts src/gateway/worker-environments/workspace-sync-manifest.test.ts src/gateway/worker-environments/node-workspace-transfer-retention.test.ts src/gateway/worker-environments/node-workspace-upload-reader.test.ts
```

The last command's diagnostic launcher derives `OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS` directly from `resolveDefaultVitestNoOutputTimeoutMs` for `test/vitest/vitest.gateway-core.config.ts`; it does not invent a new timeout. Its custom `BaseSequencer` only orders those five files and its reporters record results. Test sources are uninstrumented.

Validation history: earlier local runs encountered a lost temporary namespace, missing installed TypeBox files, and subprocess/test deadline failures. One frozen-lockfile install restored the missing dependency files and applied current main's already-approved Vitest patch. Temporary phase timing passed and was removed; the final uninstrumented original-order run passed all 39 cases. The original namespace deletion was not attributed, and the failed attempts are not counted as passing proof. No assertions, deadlines, isolation boundary, production environment, dependency declaration, or baseline was weakened.

AI-assisted; maintainer-requested. This follow-up changes no UI or chat presentation and makes no new external-provider/API claim; runtime proof exercises the actual local HTTP transfer and filesystem/Git boundaries. Exact-head CI and native landing evidence follow on this PR.
