### PR TITLE
fix(test): route unprofilable pools past the vitest profiling runner

### DIFF
--- a/test/fixtures/vitest-fork-shutdown.mjs
+++ b/test/fixtures/vitest-fork-shutdown.mjs
@@ -252,8 +252,12 @@ it("completes the test before worker shutdown", () => {
 });
 `,
   );
+  // The profiling runner rejects any pool other than forks/threads
+  // (scripts/lib/vitest-profiler.mts), so vmForks and custom-pool scenarios must
+  // run through the plain runner or the inner run dies during global setup.
+  const profilerSupportsPool = !custom && scenario !== "vmForks";
   const args =
-    scenario === "plain" || scenario === "custom"
+    scenario === "plain" || !profilerSupportsPool
       ? [
           path.join(repo, "scripts/run-vitest.mjs"),
           "run",
@@ -315,6 +319,7 @@ it("completes the test before worker shutdown", () => {
       code,
       output,
       workerStopped,
+      profiled: profilerSupportsPool && scenario !== "plain",
       profiles: counts,
       homeRemoved: !fs.existsSync(state.home),
       callerPreserved: fs.readFileSync(path.join(root, "home", "caller"), "utf8") === "keep",

--- a/test/scripts/vitest-fork-shutdown.test.ts
+++ b/test/scripts/vitest-fork-shutdown.test.ts
@@ -68,8 +68,14 @@ it.each([
     );
     expect(result.events).toContainEqual({ event: "terminate", signal: "SIGTERM" });
   } else if (scenario !== "plain") {
-    expect(result.profiles.cpu, result.output).toBeGreaterThan(0);
-    expect(result.profiles.heap, result.output).toBeGreaterThan(0);
+    // Only runs routed through the profiling runner emit profiles; the fixture
+    // reports that, since the profiler rejects vmForks and custom pools.
+    if (result.profiled) {
+      expect(result.profiles.cpu, result.output).toBeGreaterThan(0);
+      expect(result.profiles.heap, result.output).toBeGreaterThan(0);
+    } else {
+      expect(result.output, result.output).toContain("1 passed");
+    }
     expect(result.events.some((event: { event: string }) => event.event === "terminate")).toBe(
       false,
     );


### PR DESCRIPTION
## What Problem This Solves

`test/scripts/vitest-fork-shutdown.test.ts` fails deterministically on `main` for two scenarios — `vmForks/raw` and `custom-opt-in/raw` — turning the `checks-node-compact-small-*` shard and the CI gate red. It reproduces on a pristine `main` checkout with no other changes:

```
Tests  2 failed | 10 passed (12)
Error: ENOENT: no such file or directory, open '.../receipt.json'
```

Root cause: `scripts/lib/vitest-profiler.mts` rejects any pool other than `forks`/`threads` ("Runner profiling supports the forks and threads pools only"), but the fixture routed every scenario except `plain`/`custom` through `run-vitest-profile.mts`. For `vmForks` (pool `vmForks`) and `custom-opt-in` (a custom `custom-fork` pool), the inner Vitest run therefore died during global setup, never ran the fixture test, and never wrote `receipt.json` — so the outer fixture crashed on an unconditional `readFileSync` instead of reporting a usable failure. On CI the same two scenarios surfaced with a misleading "Timeout waiting for worker to respond".

## Why This Change Was Made

Two small, matched changes:

1. The fixture now picks its runner from pool compatibility rather than a hardcoded scenario list: pools the profiler cannot accept run through the plain runner. `plain` and `custom` keep their existing routing, so no currently-passing scenario changes path.
2. The fixture reports whether it actually profiled (`profiled`), and the test asserts CPU/heap profile artifacts only for those runs — instead of duplicating pool knowledge in a second file. Unprofiled runs still assert the inner run passed.

Worker-shutdown assertions — the point of the test — are untouched: `workerStopped`, terminate/deadline events, home cleanup, and exit codes all still apply to every scenario.

## User Impact

None at runtime; test infrastructure only. Unblocks `main` and every PR whose merge ref includes this test.

## Evidence

- Before, on pristine `main` (`cfa802d73e5`): `Tests 2 failed | 10 passed (12)`, both failures ENOENT on `receipt.json`.
- After: `Tests 12 passed (12)`.
- The repaired path still proves real shutdown, not a weakened assertion — running the `vmForks` fixture directly reports `code: 0 workerStopped: true profiled: false`, so the test's core invariant remains asserted.
- Root cause confirmed by running the inner command manually: `Error: Runner profiling supports the forks and threads pools only` at `scripts/lib/vitest-profiler.mts:46`.

Found while landing an unrelated PR (#132740) whose merge ref inherited this failure; filed separately so the CI repair lands on its own rather than riding along with an exec-policy change.
