### PR TITLE
improve(memory-lancedb): reduce plugin startup memory

### DIFF
--- a/extensions/memory-lancedb/index.ts
+++ b/extensions/memory-lancedb/index.ts
@@ -1,11 +1,7 @@
 import {
   resolveAgentConfig,
   resolveDefaultAgentId as resolveConfiguredDefaultAgentId,
-} from "openclaw/plugin-sdk/agent-runtime";
-import {
-  optionalFiniteNumberSchema,
-  optionalPositiveIntegerSchema,
-} from "openclaw/plugin-sdk/channel-actions";
+} from "openclaw/plugin-sdk/agent-scope-runtime";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
@@ -232,7 +228,12 @@ export default definePluginEntry({
             "Search through long-term memories. Use when you need context about user preferences, past decisions, or previously discussed topics.",
           parameters: Type.Object({
             query: Type.String({ description: "Search query" }),
-            limit: optionalPositiveIntegerSchema({ description: "Max results (default: 5)" }),
+            limit: Type.Optional(
+              Type.Integer({
+                description: "Max results (default: 5)",
+                minimum: 1,
+              }),
+            ),
           }),
           async execute(_toolCallId, params) {
             // Tool definitions outlive hot config reloads; revalidate before memory I/O.
@@ -353,11 +354,13 @@ export default definePluginEntry({
             "Save important information in long-term memory. Text over the configured capture limit is rejected. Success means the exact text already exists or the database commit completed; it does not guarantee semantic recall.",
           parameters: Type.Object({
             text: Type.String({ description: "Information to remember" }),
-            importance: optionalFiniteNumberSchema({
-              description: "Importance 0-1 (default: 0.7)",
-              minimum: 0,
-              maximum: 1,
-            }),
+            importance: Type.Optional(
+              Type.Number({
+                description: "Importance 0-1 (default: 0.7)",
+                minimum: 0,
+                maximum: 1,
+              }),
+            ),
             category: Type.Optional(Type.Enum(MEMORY_CATEGORIES, { type: "string" })),
           }),
           async execute(_toolCallId, params) {

--- a/extensions/memory-lancedb/startup-imports.test.ts
+++ b/extensions/memory-lancedb/startup-imports.test.ts
@@ -1,0 +1,24 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+describe("memory-lancedb startup imports", () => {
+  afterEach(() => {
+    vi.doUnmock("openclaw/plugin-sdk/agent-runtime");
+    vi.doUnmock("openclaw/plugin-sdk/channel-actions");
+    vi.resetModules();
+  });
+
+  it("loads the plugin entrypoint without broad SDK barrels", async () => {
+    let broadImports = 0;
+    const rejectBroadImport = () => {
+      broadImports += 1;
+      throw new Error("Memory startup must use focused SDK entrypoints");
+    };
+    vi.doMock("openclaw/plugin-sdk/agent-runtime", rejectBroadImport);
+    vi.doMock("openclaw/plugin-sdk/channel-actions", rejectBroadImport);
+
+    const pluginModule = await import("./index.js");
+
+    expect(pluginModule.default.id).toBe("memory-lancedb");
+    expect(broadImports).toBe(0);
+  });
+});


### PR DESCRIPTION
## What Problem This Solves

Loading the selected, enabled bundled `memory-lancedb` plugin through OpenClaw's production plugin loader imported broad plugin SDK barrels. In a controlled cold-process trace, that raised median peak RSS to 674.4 MiB before any database, embedding request, automatic capture, recall, or dreaming work ran.

## Why This Change Was Made

The plugin now imports agent-selection helpers from the focused `agent-scope-runtime` entrypoint and expresses its two existing numeric TypeBox schemas directly. The underlying agent-scope functions, validation constraints, tool handlers, storage behavior, and security checks are unchanged.

## User Impact

The controlled production-loader trace reduced three-run median peak RSS from 690,600 kB (674.4 MiB) to 414,036 kB (404.3 MiB): 270.1 MiB less, or 40.0%. The plugin still loads from its built runtime artifact and registers all three memory tools.

## Reproducible Production-Loader Proof

Exact revisions:

- Before: `8cd61f02bf48c190a439ccb53d56e9f47a87a110`
- After: `109349c351a246f153df106f18d31efe82f62ea8`
- Host: Node `v24.19.0`, pnpm `12.0.0`, Linux `7.0.12+kali-amd64` x86_64

At each revision, build the same production runtime graph and stage its runtime artifacts:

```sh
OPENCLAW_RUN_NODE_SKIP_DTS_BUILD=1 node --import ./scripts/tsx.mjs scripts/tsdown-build.mts \
  --config tsdown.config.ts --filter openclaw-unified --no-dts
node scripts/runtime-postbuild.mjs
```

Save this as `bench-memory-lancedb-loader.mjs` at the repository root:

```js
import { loadOpenClawPlugins } from "./dist/plugins/loader.js";

const config = {
  plugins: {
    enabled: true,
    allow: ["memory-lancedb"],
    slots: { memory: "memory-lancedb" },
    entries: {
      "memory-lancedb": {
        enabled: true,
        config: {
          embedding: { provider: "openai", model: "text-embedding-3-small" },
          dbPath: "/tmp/openclaw-memory-lancedb-loader-bench",
          autoCapture: false,
          autoRecall: false,
          dreaming: { enabled: false },
        },
      },
    },
  },
};

const registry = loadOpenClawPlugins({
  cache: false,
  activate: false,
  onlyPluginIds: ["memory-lancedb"],
  config,
  throwOnLoadError: true,
});
const plugin = registry.plugins.find((entry) => entry.id === "memory-lancedb");
console.log(JSON.stringify({
  id: plugin?.id,
  status: plugin?.status,
  source: plugin?.source,
  tools: plugin?.toolNames,
  rssBytes: process.memoryUsage().rss,
}));
```

The config deliberately selects and explicitly enables the plugin while disabling network-adjacent automatic hooks and dreaming. It contains no credential. Run each sample in a separate cold Node process:

```sh
OPENCLAW_DIAGNOSTICS=plugin.load-profile \
  /usr/bin/time -f 'maxRSS_kB=%M elapsed_s=%e exit=%x' \
  node bench-memory-lancedb-loader.mjs
```

Raw before output, three runs:

```text
phase=discovery elapsedMs=3642.8; phase=discovery:register elapsedMs=27.8
{"id":"memory-lancedb","status":"loaded","source":"/home/rev/openclaw/dist/extensions/memory-lancedb/index.js","tools":["memory_recall","memory_store","memory_forget"],"rssBytes":699301888}
maxRSS_kB=682912 elapsed_s=4.88 exit=0

phase=discovery elapsedMs=3654.7; phase=discovery:register elapsedMs=24.5
{"id":"memory-lancedb","status":"loaded","source":"/home/rev/openclaw/dist/extensions/memory-lancedb/index.js","tools":["memory_recall","memory_store","memory_forget"],"rssBytes":707174400}
maxRSS_kB=690600 elapsed_s=4.87 exit=0

phase=discovery elapsedMs=3651.3; phase=discovery:register elapsedMs=20.7
{"id":"memory-lancedb","status":"loaded","source":"/home/rev/openclaw/dist/extensions/memory-lancedb/index.js","tools":["memory_recall","memory_store","memory_forget"],"rssBytes":702291968}
maxRSS_kB=690600 elapsed_s=5.11 exit=0
```

Raw after output, three primary runs plus two additional confirmations after a transient GNU-time peak in run 3:

```text
phase=discovery elapsedMs=1168.5; phase=discovery:register elapsedMs=25.0
{"id":"memory-lancedb","status":"loaded","source":"/home/rev/openclaw/dist/extensions/memory-lancedb/index.js","tools":["memory_recall","memory_store","memory_forget"],"rssBytes":422895616}
maxRSS_kB=412984 elapsed_s=2.46 exit=0

phase=discovery elapsedMs=969.8; phase=discovery:register elapsedMs=32.7
{"id":"memory-lancedb","status":"loaded","source":"/home/rev/openclaw/dist/extensions/memory-lancedb/index.js","tools":["memory_recall","memory_store","memory_forget"],"rssBytes":423972864}
maxRSS_kB=414036 elapsed_s=2.51 exit=0

phase=discovery elapsedMs=994.3; phase=discovery:register elapsedMs=32.9
{"id":"memory-lancedb","status":"loaded","source":"/home/rev/openclaw/dist/extensions/memory-lancedb/index.js","tools":["memory_recall","memory_store","memory_forget"],"rssBytes":421548032}
maxRSS_kB=601604 elapsed_s=2.28 exit=0

phase=discovery elapsedMs=1054.8; phase=discovery:register elapsedMs=21.6
{"id":"memory-lancedb","status":"loaded","source":"/home/rev/openclaw/dist/extensions/memory-lancedb/index.js","tools":["memory_recall","memory_store","memory_forget"],"rssBytes":423923712}
maxRSS_kB=413988 elapsed_s=2.43 exit=0

phase=discovery elapsedMs=1140.1; phase=discovery:register elapsedMs=22.7
{"id":"memory-lancedb","status":"loaded","source":"/home/rev/openclaw/dist/extensions/memory-lancedb/index.js","tools":["memory_recall","memory_store","memory_forget"],"rssBytes":421261312}
maxRSS_kB=413988 elapsed_s=2.50 exit=0
```

The primary three-run medians are 690,600 kB before and 414,036 kB after. The two additional head runs both measured 413,988 kB; the five-run head median is also 413,988 kB. The loader trace, built source path, loaded status, registered tool list, and zero exit status bind the measurement to the production loader path and prove feature registration remained intact.

## Evidence

- `pnpm test extensions/memory-lancedb/startup-imports.test.ts extensions/memory-lancedb/index.test.ts` — 147/147 tests passed.
- Post-rebase `pnpm test extensions/memory-lancedb/startup-imports.test.ts` — passed.
- `pnpm build` — passed.
- `pnpm check:changed` — passed, including extension typechecks, lint, plugin contracts, boundary checks, storage guards, and import-cycle checks.
- Security diff review of the exact patch — no findings; the focused SDK entrypoint resolves the same agent-scope implementations, and the direct TypeBox schemas preserve the prior constraints exactly.

AI-assisted: yes. I reviewed the implementation and validation evidence.

