### PR TITLE
fix(ui): stabilize readiness verification and media playback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - **Browser extension relay:** route Runtime binding callbacks only to registered clients and preserve shared bindings during client cleanup, preventing raw callback payloads from reaching unrelated Playwright sessions.
+- **Control UI media playback:** restore inline audio and video rendition loading so readiness checks reach the Gateway instead of silently falling back to download cards. (#132832)
 - **Grok web search startup:** avoid loading the full agent runtime before the first search, while preserving agent-scoped credentials and OAuth fallback behavior.
 - Gateway/subagents: keep plugin completion turns bound to the owning Gateway runtime so successful native subagents can finish delivery without losing the published reply runtime.
 - **Upgrade config repair:** retain plugin-owned channel configuration migrations alongside core schemas so `doctor --fix` can repair older settings before an external plugin is installed or granted capabilities, while preserving installed-plugin ownership and state-migration boundaries.

--- a/docs/nodes/media-playback.md
+++ b/docs/nodes/media-playback.md
@@ -58,6 +58,10 @@ Playback conversion is lazy:
    route falls back to the original bytes. The client can then show its
    unplayable-media fallback and keep the download action available.
 
+The Control UI checks rendition readiness with `HEAD` before loading the inline
+player. It shows **Preparing playback** while conversion is pending and keeps
+the download action available when playback is unavailable.
+
 Transcoding accepts sources up to 20 minutes and never raises the normal audio
 or video byte cap. Cached playback renditions use a fixed seven-day retention
 that Gateway maintenance enforces at startup and hourly, independently of

--- a/ui/src/app/app-host-pairing-access.test.ts
+++ b/ui/src/app/app-host-pairing-access.test.ts
@@ -1,7 +1,7 @@
 /* @vitest-environment jsdom */
 
 import { render, type TemplateResult } from "lit";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, onTestFinished, vi } from "vitest";
 import type { GatewayBrowserClient } from "../api/gateway.ts";
 import "../components/app-sidebar.ts";
 import { waitForFast } from "../test-helpers/wait-for.ts";
@@ -109,6 +109,9 @@ function createPairingShell(params: {
     location: { pathname: "/chat", search: "", hash: "" },
   };
   const container = document.createElement("div");
+  onTestFinished(() => {
+    render(null, container);
+  });
 
   const renderSidebar = () => {
     render(shell.render(), container);
@@ -123,6 +126,7 @@ function createPairingShell(params: {
   // replaces the eager loading shell with the full dialog.
   const renderPairingDialog = async () => {
     renderSidebar();
+    await vi.dynamicImportSettled();
     return await waitForFast(() => {
       render(shell.render(), container);
       const dialog = container.querySelector<HTMLElement>(
@@ -146,7 +150,8 @@ function createPairingShell(params: {
   };
 }
 
-afterEach(() => {
+afterEach(async () => {
+  await vi.dynamicImportSettled();
   vi.useRealTimers();
   document.body.replaceChildren();
   vi.unstubAllGlobals();
@@ -329,6 +334,7 @@ describe("application shell pairing access", () => {
     });
 
     renderSidebar();
+    await vi.dynamicImportSettled();
     await waitForFast(() => {
       render(shell.render(), container);
       expect(container.querySelector('[role="timer"]')?.textContent).toContain("0:01");

--- a/ui/src/app/lazy-shell-action.test.ts
+++ b/ui/src/app/lazy-shell-action.test.ts
@@ -56,7 +56,8 @@ async function withConnectedShell(shell: ShellLifecycle, run: () => void | Promi
   }
 }
 
-afterEach(() => {
+afterEach(async () => {
+  await vi.dynamicImportSettled();
   resetAppHostTestGlobals();
   vi.restoreAllMocks();
   recovery.reload.mockClear();
@@ -244,10 +245,13 @@ describe("shell lazy events", () => {
 
     try {
       await withConnectedShell(shell, async () => {
+        input.focus();
+        expect(document.activeElement).toBe(input);
         input.dispatchEvent(shortcut);
 
         expect(shortcut.defaultPrevented).toBe(true);
         expect(requested).toHaveBeenCalledOnce();
+        await vi.dynamicImportSettled();
         await vi.waitFor(() => expect(toggled).toHaveBeenCalledOnce());
 
         input.dispatchEvent(
@@ -289,6 +293,7 @@ describe("shell lazy events", () => {
     await withConnectedShell(shell, async () => {
       shell.handleDocumentKeydown(shortcut);
       expect(shortcut.defaultPrevented).toBe(true);
+      await vi.dynamicImportSettled();
       await vi.waitFor(() => expect(toggled).toHaveBeenCalledOnce());
 
       const input = document.body.appendChild(document.createElement("input"));

--- a/ui/src/pages/chat/chat-responsive.browser.test.ts
+++ b/ui/src/pages/chat/chat-responsive.browser.test.ts
@@ -92,6 +92,16 @@ async function createSharedAppPage(): Promise<Page> {
     page.on("pageerror", (error) => sharedAppPageErrors.push(error.message));
     await page.route("https://cdn.example/**", async (route) => {
       const request = route.request();
+      if (request.url() === SHARED_APP_IMAGE_URL) {
+        await route.fulfill({
+          contentType: "image/png",
+          body: Buffer.from(
+            "iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAHElEQVR4nGP4z8DwnxLMMGrAsDCAQv2jBgwPAwAxtf4Q24P5oAAAAABJRU5ErkJggg==",
+            "base64",
+          ),
+        });
+        return;
+      }
       const fileName = decodeURIComponent(new URL(request.url()).pathname.split("/").at(-1) ?? "");
       const media = SHARED_APP_PLAYBACK_MEDIA.find(([candidate]) => candidate === fileName);
       if (!media) {
@@ -2657,8 +2667,8 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
         await messageText.waitFor({ timeout: APP_FIRST_RENDER_TIMEOUT_MS });
         expect(await context.isVisible()).toBe(false);
 
-        // The shared group also contains an aborted image; finish its fallback
-        // layout before measuring whether opening the tooltip moves the row.
+        // Finish the shared image layout before measuring whether opening the
+        // tooltip moves the row.
         await messageText.hover();
         await page.waitForFunction(
           () => document.querySelector<HTMLImageElement>(".chat-message-image")?.complete,
@@ -2792,17 +2802,33 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
       );
       const card = player.locator(".chat-assistant-attachment-card");
       await card.waitFor({ state: "visible", timeout: 10_000 });
-      await card.scrollIntoViewIfNeeded();
+      await player.evaluate((element) => {
+        element
+          .querySelector(".chat-assistant-attachment-card")!
+          .scrollIntoView({ block: "center" });
+      });
+      const requireMetadata = fileName !== "reply.m4a" && fileName !== "reply.mp4";
+      // Read the stable player: an error replaces its media child and card.
+      // Only AAC/H.264 fixtures may fall back; other codecs must actually load.
+      await expect
+        .poll(
+          () =>
+            player.evaluate(
+              (element, { type: mediaType, requireMetadata: needsMetadata }) => {
+                const media = element.querySelector<HTMLMediaElement>(mediaType);
+                return (
+                  (!needsMetadata &&
+                    element.querySelector(".chat-assistant-attachment-card--compact") !== null) ||
+                  (media !== null && (!needsMetadata || media.readyState >= 1))
+                );
+              },
+              { type, requireMetadata },
+            ),
+          { timeout: 10_000 },
+        )
+        .toBe(true);
       const compactFallback =
         (await player.locator(".chat-assistant-attachment-card--compact").count()) > 0;
-      if (!compactFallback && fileName !== "reply.m4a" && fileName !== "reply.mp4") {
-        const media = player.locator(type);
-        await expect
-          .poll(() => media.evaluate((element) => (element as HTMLMediaElement).readyState), {
-            timeout: 10_000,
-          })
-          .toBeGreaterThanOrEqual(1);
-      }
       if (!compactFallback) {
         expect(
           sharedAppPlaybackRequests.some((url) => {

--- a/ui/src/pages/chat/components/chat-media-playback.ts
+++ b/ui/src/pages/chat/components/chat-media-playback.ts
@@ -53,6 +53,7 @@ async function fetchPlaybackHead(params: {
   timeoutMs: number;
   fetchImpl: typeof fetch;
 }): Promise<Response> {
+  const { fetchImpl } = params;
   const controller = new AbortController();
   let rejectDeadline: ((error: Error) => void) | undefined;
   const deadline = new Promise<never>((_resolve, reject) => {
@@ -74,7 +75,7 @@ async function fetchPlaybackHead(params: {
   }, params.timeoutMs);
   try {
     return await Promise.race([
-      params.fetchImpl(params.source, {
+      fetchImpl(params.source, {
         method: "HEAD",
         headers: params.headers,
         credentials: "same-origin",

--- a/ui/src/pages/chat/components/chat-tool-cards.highlight.test.ts
+++ b/ui/src/pages/chat/components/chat-tool-cards.highlight.test.ts
@@ -1,7 +1,7 @@
 /* @vitest-environment jsdom */
 
 import { render } from "lit";
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it, onTestFinished, vi } from "vitest";
 import { renderToolCard } from "./chat-tool-cards.ts";
 
 describe("tool-card source highlighting", () => {
@@ -40,10 +40,15 @@ describe("tool-card source highlighting", () => {
     },
   ])("highlights $name previews using their file languages", async (card) => {
     const container = document.createElement("div");
+    onTestFinished(async () => {
+      await vi.dynamicImportSettled();
+      render(null, container);
+    });
     render(
       renderToolCard({ id: "highlight", ...card }, { expanded: true, onToggleExpanded: vi.fn() }),
       container,
     );
+    await vi.dynamicImportSettled();
     await vi.waitFor(() =>
       expect(container.querySelector(".tok-keyword")?.textContent).toBe("const"),
     );
@@ -54,7 +59,6 @@ describe("tool-card source highlighting", () => {
       ).toContain("def");
       expect(container.querySelector(".chat-diff__row--file .tok-keyword")).toBeNull();
     }
-    render(null, container);
   });
 
   it.each([
@@ -102,6 +106,10 @@ describe("tool-card source highlighting", () => {
               ],
             };
       const container = document.createElement("div");
+      onTestFinished(async () => {
+        await vi.dynamicImportSettled();
+        render(null, container);
+      });
       render(
         renderToolCard(
           {
@@ -115,6 +123,7 @@ describe("tool-card source highlighting", () => {
         container,
       );
 
+      await vi.dynamicImportSettled();
       await vi.waitFor(() => {
         expect(container.querySelector(".chat-diff__row--del .tok-propertyName")?.textContent).toBe(
           "data-mode",
@@ -134,7 +143,6 @@ describe("tool-card source highlighting", () => {
           [...container.querySelectorAll(".tok-keyword")].map((node) => node.textContent),
         ).toContain("def");
       }
-      render(null, container);
     },
   );
 });

--- a/ui/src/test-helpers/app-sidebar-cases/group-mutations.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/group-mutations.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import type { ApplicationGatewaySnapshot } from "../../app/context.ts";
 import {
@@ -98,7 +98,7 @@ describe("AppSidebar group mutation collapsed state", () => {
     return menu;
   }
 
-  function selectGroupMenuAction(menu: Element, value: string) {
+  async function selectGroupMenuAction(menu: Element, value: string) {
     const item = menu.querySelector(`[value="${value}"]`);
     if (!item) {
       throw new Error(`expected ${value} group action`);
@@ -110,11 +110,12 @@ describe("AppSidebar group mutation collapsed state", () => {
         detail: { item: { value } },
       }),
     );
+    await vi.dynamicImportSettled();
   }
 
   async function renameGroupThroughDialog(sidebar: SidebarLifecycleState, name: string) {
     const menu = await openGroupMenu(sidebar);
-    selectGroupMenuAction(menu, "rename-group");
+    await selectGroupMenuAction(menu, "rename-group");
     await waitForFast(() => {
       const input = document.body.querySelector('openclaw-modal-dialog input[name="value"]');
       if (!(input instanceof HTMLInputElement)) {
@@ -123,11 +124,12 @@ describe("AppSidebar group mutation collapsed state", () => {
       return input;
     });
     await submitInputDialog(name);
+    await vi.dynamicImportSettled();
   }
 
   async function deleteGroupThroughConfirm(sidebar: SidebarLifecycleState) {
     const menu = await openGroupMenu(sidebar);
-    selectGroupMenuAction(menu, "delete-group");
+    await selectGroupMenuAction(menu, "delete-group");
     const confirm = await waitForFast(() => {
       const button = document.body.querySelector<HTMLButtonElement>(
         "openclaw-modal-dialog .exec-approval-actions .btn.danger",
@@ -215,7 +217,7 @@ describe("AppSidebar group mutation collapsed state", () => {
     const toast = document.body.appendChild(document.createElement("openclaw-toast-host"));
     await toast.updateComplete;
     const menu = await openGroupMenu(sidebar);
-    selectGroupMenuAction(menu, "delete-group");
+    await selectGroupMenuAction(menu, "delete-group");
     const confirm = await waitForFast(() => {
       const button = document.body.querySelector<HTMLButtonElement>(
         "openclaw-modal-dialog .exec-approval-actions .btn.danger",
@@ -312,7 +314,7 @@ describe("AppSidebar group mutation collapsed state", () => {
   it("leaves the catalog alone when the delete confirm is cancelled", async () => {
     const { sidebar, harness } = await mountCollapsedGroup({});
     const menu = await openGroupMenu(sidebar);
-    selectGroupMenuAction(menu, "delete-group");
+    await selectGroupMenuAction(menu, "delete-group");
     // Cancel is the focused default; answering it must end the flow with the
     // group, its members and the collapsed key untouched.
     const cancel = await waitForFast(() => {

--- a/ui/src/test-helpers/app-sidebar.ts
+++ b/ui/src/test-helpers/app-sidebar.ts
@@ -674,9 +674,15 @@ export function setupSidebarTest() {
     localStorage.setItem("openclaw:sidebar:sessions:collapsed-sections", JSON.stringify([]));
   });
 
-  afterEach(() => {
-    document.body.replaceChildren();
+  afterEach(async () => {
     vi.useRealTimers();
+    await vi.dynamicImportSettled();
+    // Removing a prompt's DOM does not settle its promise or release its reentrancy guard.
+    for (const modal of document.body.querySelectorAll("openclaw-modal-dialog")) {
+      modal.dispatchEvent(new CustomEvent("modal-cancel", { cancelable: true }));
+    }
+    await vi.dynamicImportSettled();
+    document.body.replaceChildren();
     if (originalLocalStorage) {
       Object.defineProperty(globalThis, "localStorage", originalLocalStorage);
     } else {


### PR DESCRIPTION
## Summary

Release verification could race lazy dialog/highlighting imports, leave unresolved sidebar dialogs across fixtures, and stall while a media child disappeared. This change joins the actual import and dialog lifecycles, then checks playback state through its stable player element.

The stronger browser check exposed a product defect: the rendition readiness helper called native `fetch` as a property of its parameters object. Chromium rejected that receiver before any HEAD request, silently reducing transcode attachments to download cards. Calling the existing fetch reference as a free function restores the default browser path without changing retries, deadlines, abort handling, configuration, or authentication.

The shared browser fixture now serves valid image bytes instead of aborting an image it expects to remain visible. MP3, Ogg, FLAC, and WebM must load metadata; the existing AAC/H.264 platform-codec exemptions remain. No timeout was raised, assertion weakened, or browser boot added.

## Validation

- Existing delivered-playback browser test, with valid image fixture: unfixed producer fails its metadata assertion; fixed producer passes in the complete responsive file, 111/111 tests in original order (43.76 s), repeated after callback-name lint cleanup (41.03 s).
- Dialog, lazy element, sidebar, playback owner, and audio/video sibling tests: 409/409 across 10 files (29.55 s).
- Real Chromium default-fetch controls: pre-fix owner makes no HTTP request and returns unavailable; free-call repair produces HEAD then GET and loaded metadata. Valid and delayed-GET-failure paths cover MP3/Ogg/WebM; HEAD 503 and network failure cover Ogg/WebM and preserve download fallback.
- Installed Playwright and Vitest implementations were inspected: a locator waits up to 30 s for a vanished media child, while poll cannot cancel that in-flight callback. The new poll reads the persistent player instead.
- Complete UI suite: 827 files, 12,508 passing tests and one skip in 113.34 s.
- Independent Codex review at P2: no actionable findings.
- Production UI build and performance budgets pass: 3,094 modules and 796 finalized sidecars.
- Actual production bundle in Chromium: Ogg/WebM readiness succeeds via HEAD then GET; HEAD 503 preserves download fallback; clicking audio Play advances playback; zero page errors.
- Full changed gate passes, including Knip, all core-test/UI type checks, lint, stylelint, i18n, and formatting. The initial run caught two shadowed test callback names; after renaming them, the complete gate and final P2 review pass.

Before/after media show a synthetic Ogg attachment in the actual source component. Before: download card, no readiness request. After: HEAD/GET, loaded metadata, inline controls. These are isolated fixture screenshots, not a packaged Gateway deployment.

![Before: synthetic Ogg attachment falls back to a download card](https://github.com/user-attachments/assets/58ced42b-e4ab-4c81-b1e6-ed7f93ad1997)

![After: the same synthetic Ogg attachment has inline playback controls](https://github.com/user-attachments/assets/b4b9c6f4-1549-45b1-9a9b-a14cecc11f6a)

## Scope and review follow-through

Runtime production delta: +2/-1 (net +1) in the readiness helper. The local fetch reference is required to retain the native Window receiver contract; there is no new wrapper or branch. Everything else is tests/test support or documentation. No stored data model, schema, or compatibility behavior changes.

The previous ClawSweeper sequencing request is satisfied: Browser PR #132878 landed the clipboard repair on main, and #132803 was closed as superseded. This PR was rebased onto main without replaying the absorbed parent. Seven reviewed code/doc blobs remain identical; the sidebar helper also retains main's unrelated optional catalog color field, and its full test file passes after rebase. Exact-head CI is still required before merge. The prior reviewer could not inspect Vitest in its dependency-free environment; that dependency-contract gap is now closed. The new playback repair extends behavior beyond that test-only review; a fresh review is requested for the published head.

The earlier local full-UI run was not green. Its single playback timeout is not asserted to have exactly the same cause as every controlled failure here; the hosted failure was a separate shutdown fixture already repaired.
