### PR TITLE
fix(qa): retain debug logs across cleanup retries

### DIFF
--- a/docs/concepts/qa-e2e-automation.md
+++ b/docs/concepts/qa-e2e-automation.md
@@ -1119,6 +1119,13 @@ or staging directory. The caller retains the lifecycle owner and always calls
 caller's artifact policy, so failure reports can preserve sanitized Gateway logs
 before temporary runtime state is removed.
 
+After confirmed shutdown, a successful export (or choosing no export) finalizes
+the artifact policy before temporary state removal. Cleanup retries retain that
+export without rewriting it or using a later destination, while RPC and staging
+cleanup still retry. Failed exports remain retryable. Unconfirmed stops refresh
+requested snapshots, and the final confirmed snapshot includes later output.
+Keeping temporary state leaves its logs available for a later cleanup retry.
+
 If termination cannot be confirmed, the suite reports a cleanup failure, keeps
 the runtime directory, and leaves the adapter's lease and heartbeat owned.
 Inspect the reported process group and retained runtime before reusing those

--- a/extensions/qa-lab/src/gateway-child-lifecycle.test.ts
+++ b/extensions/qa-lab/src/gateway-child-lifecycle.test.ts
@@ -2,11 +2,13 @@ import { readFileSync } from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { resolveQaStagedBundledPluginsRoot } from "./bundled-plugin-staging.js";
 import { createQaGatewayChild } from "./gateway-child.js";
 import { isQaPosixProcessGroupAlive, signalQaPosixProcessGroup } from "./posix-process-group.js";
 import { createTempDirHarness } from "./temp-dir.test-helper.js";
 
 const boundary = vi.hoisted(() => ({ create: vi.fn() }));
+const rpcStop = vi.hoisted(() => vi.fn<() => Promise<void>>());
 vi.mock("./gateway-process-boundary.js", async (original) => ({
   ...(await original<typeof import("./gateway-process-boundary.js")>()),
   createQaGatewayProcessBoundaryController: boundary.create,
@@ -14,13 +16,15 @@ vi.mock("./gateway-process-boundary.js", async (original) => ({
 // These tests own child lifetime, not the Gateway WebSocket protocol. HTTP
 // readiness, spawning, termination, liveness probes, and artifacts stay real.
 vi.mock("./gateway-rpc-client.js", () => ({
-  startQaGatewayRpcClient: async () => ({ request: async () => ({}), stop: async () => {} }),
+  startQaGatewayRpcClient: async () => ({ request: async () => ({}), stop: rpcStop }),
 }));
 
 const dirs = createTempDirHarness();
 const owners: ReturnType<typeof createQaGatewayChild>[] = [];
 const groups: number[] = [];
+const artifactDirs: string[] = [];
 beforeEach(() => {
+  rpcStop.mockReset().mockResolvedValue(undefined);
   vi.stubEnv("OPENCLAW_QA_LIVE_ANTHROPIC_SETUP_TOKEN", undefined);
   vi.stubEnv("OPENCLAW_LIVE_SETUP_TOKEN_VALUE", undefined);
 });
@@ -39,7 +43,26 @@ afterEach(async () => {
   owners.length = 0;
   groups.length = 0;
   await dirs.cleanup();
+  await Promise.all(
+    artifactDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })),
+  );
 });
+
+async function makeArtifactDir() {
+  const root = path.join(process.cwd(), ".artifacts/qa-e2e/artifact-retry-fix");
+  await fs.mkdir(root, { recursive: true });
+  const dir = await fs.mkdtemp(path.join(root, "preserved-log-"));
+  artifactDirs.push(dir);
+  return dir;
+}
+
+async function readArtifacts(dir: string) {
+  return Promise.all(
+    ["gateway.stdout.log", "gateway.stderr.log", "README.txt"].map((file) =>
+      fs.readFile(path.join(dir, file), "utf8"),
+    ),
+  );
+}
 
 async function fixture(failReplacement: boolean | "descendant" = false) {
   const root = await dirs.makeTempDir("qa-lifetime-");
@@ -56,10 +79,14 @@ const [record, failReplacement, command, ...args] = process.argv.slice(2);
 if (command === "descendant") {
   process.on("SIGTERM", () => {});
   setTimeout(() => process.exit(0), 30_000);
-  const output = setInterval(() => {
+  let lastOutput;
+  setInterval(() => {
     if (fs.existsSync(record + ".emit")) {
-      console.log("QA_DESCENDANT_STILL_OWNED");
-      clearInterval(output);
+      const output = fs.readFileSync(record + ".emit", "utf8");
+      if (output !== lastOutput) {
+        console.log("QA_DESCENDANT_" + output);
+        lastOutput = output;
+      }
     }
   }, 25);
   process.send("ready");
@@ -71,6 +98,7 @@ if (command === "gateway") {
 const previous = fs.existsSync(record) ? JSON.parse(fs.readFileSync(record, "utf8")) : [];
 fs.writeFileSync(record, JSON.stringify([...previous, process.pid]));
 fs.writeSync(1, "QA_GATEWAY_ATTEMPT_" + (previous.length + 1) + " apiKey=synthetic-fixture-secret\\n");
+fs.writeSync(2, "QA_GATEWAY_STDERR apiKey=synthetic-fixture-secret\\n");
 if (previous.length && failReplacement !== "false") {
   if (failReplacement === "descendant") {
     const descendant = spawn(process.execPath, [process.argv[1], record, "false", "descendant"], { stdio: ["ignore", "inherit", "inherit", "ipc"] });
@@ -102,7 +130,12 @@ http.createServer((_request, response) => response.end("ok")).listen(Number(args
     }
     return children;
   };
-  return { root, params, pids, emitOutput: () => fs.writeFile(record + ".emit", "") };
+  return {
+    root,
+    params,
+    pids,
+    emitOutput: (text = "STILL_OWNED") => fs.writeFile(record + ".emit", text),
+  };
 }
 
 function own(params: Parameters<ReturnType<typeof createQaGatewayChild>["start"]>[0]) {
@@ -249,10 +282,115 @@ describe.skipIf(process.platform === "win32")("QA gateway lifetime ownership", (
     },
   );
 
-  it("retains a failed replacement group until a later stop confirms termination", async () => {
+  it.each([
+    { failurePhase: "RPC stop", destination: "same" },
+    { failurePhase: "RPC stop", destination: "changed" },
+    { failurePhase: "staging removal", destination: "same" },
+  ])(
+    "retains finalized artifacts when $failurePhase fails and retries with $destination destination",
+    async ({ failurePhase, destination }) => {
+      const { params, pids } = await fixture();
+      const failsStaging = failurePhase === "staging removal";
+      const owner = own({
+        ...params,
+        command: { ...params.command, usePackagedPlugins: !failsStaging },
+      });
+      const gateway = await owner.start();
+      pids();
+      const preserveToDir = await makeArtifactDir();
+      const failure = new Error("gateway RPC close failed");
+      const stagedRoot = resolveQaStagedBundledPluginsRoot({
+        repoRoot: params.repoRoot,
+        tempRoot: gateway.tempRoot,
+      });
+      if (failsStaging) {
+        await expect(fs.stat(stagedRoot)).resolves.toBeDefined();
+        const originalRm = fs.rm;
+        let failed = false;
+        vi.spyOn(fs, "rm").mockImplementation(async (target, options) => {
+          if (target === stagedRoot && !failed) {
+            failed = true;
+            throw Object.assign(new Error("EACCES: staging removal denied"), { code: "EACCES" });
+          }
+          return originalRm(target, options);
+        });
+      } else {
+        rpcStop.mockRejectedValueOnce(failure);
+      }
+      const stopped = await owner.stop({ preserveToDir });
+      expect(stopped.process).toBe("confirmed-stopped");
+      expect(pids().every((pid) => !isQaPosixProcessGroupAlive(pid))).toBe(true);
+      if (failsStaging) {
+        expect(stopped.errors).toHaveLength(1);
+        expect(String(stopped.errors[0])).toContain(
+          "stagedBundledPluginsRoot: EACCES: staging removal denied",
+        );
+        await expect(fs.stat(stagedRoot)).resolves.toBeDefined();
+      } else {
+        expect(stopped.errors).toEqual([failure]);
+      }
+      await expect(fs.stat(gateway.tempRoot)).rejects.toMatchObject({ code: "ENOENT" });
+      const artifacts = await readArtifacts(preserveToDir);
+      expect(artifacts[0]).toContain("QA_GATEWAY_ATTEMPT_1 apiKey=<redacted>");
+      expect(artifacts[1]).toContain("QA_GATEWAY_STDERR apiKey=<redacted>");
+      expect(artifacts[2]).toContain("Only sanitized gateway debug artifacts");
+      expect(artifacts.join("\n")).not.toContain("synthetic-fixture-secret");
+      const retryDir = destination === "same" ? preserveToDir : await makeArtifactDir();
+      await expect(owner.stop({ preserveToDir: retryDir })).resolves.toEqual({
+        process: "confirmed-stopped",
+        errors: [],
+      });
+      expect(rpcStop).toHaveBeenCalledTimes(2);
+      if (failsStaging) {
+        await expect(fs.stat(stagedRoot)).rejects.toMatchObject({ code: "ENOENT" });
+      }
+      expect(await readArtifacts(preserveToDir)).toEqual(artifacts);
+      if (destination === "changed") {
+        expect(await fs.readdir(retryDir)).toEqual([]);
+      }
+      expect(pids().every((pid) => !isQaPosixProcessGroupAlive(pid))).toBe(true);
+    },
+  );
+
+  it.each([true, false])(
+    "only exports on retry if the first stop retained temporary logs (keepTemp=%s)",
+    async (keepTemp) => {
+      const { params, pids } = await fixture();
+      const owner = own(params);
+      const gateway = await owner.start();
+      pids();
+      const preserveToDir = await makeArtifactDir();
+      const failure = new Error("gateway RPC close failed");
+      rpcStop.mockRejectedValueOnce(failure);
+      await expect(
+        owner.stop({ keepTemp, preserveToDir: keepTemp ? preserveToDir : undefined }),
+      ).resolves.toEqual({ process: "confirmed-stopped", errors: [failure] });
+      expect(await fs.readdir(preserveToDir)).toEqual([]);
+      if (keepTemp) {
+        await expect(fs.stat(gateway.tempRoot)).resolves.toBeDefined();
+      } else {
+        await expect(fs.stat(gateway.tempRoot)).rejects.toMatchObject({ code: "ENOENT" });
+      }
+      await expect(owner.stop({ keepTemp: false, preserveToDir })).resolves.toEqual({
+        process: "confirmed-stopped",
+        errors: [],
+      });
+      if (keepTemp) {
+        expect((await readArtifacts(preserveToDir))[0]).toContain(
+          "QA_GATEWAY_ATTEMPT_1 apiKey=<redacted>",
+        );
+      } else {
+        expect(await fs.readdir(preserveToDir)).toEqual([]);
+      }
+      await expect(fs.stat(gateway.tempRoot)).rejects.toMatchObject({ code: "ENOENT" });
+    },
+  );
+
+  it("refreshes artifacts while a failed replacement group awaits confirmed termination", async () => {
     const { params, pids, emitOutput } = await fixture("descendant");
     const owner = own(params);
     const gateway = await owner.start();
+    const preserveToDir = await makeArtifactDir();
     const [predecessor] = pids();
     const realKill = process.kill.bind(process);
     let terminationPending = false;
@@ -274,23 +412,41 @@ describe.skipIf(process.platform === "win32")("QA gateway lifetime ownership", (
       await expect(gateway.restartAfterStateMutation(async () => {})).rejects.toBeInstanceOf(
         AggregateError,
       );
-      const [stopped] = await Promise.all([owner.stop(), owner.stop()]);
+      const [stopped] = await Promise.all([
+        owner.stop({ preserveToDir }),
+        owner.stop({ preserveToDir }),
+      ]);
       expect(overlappingTermination).toBe(false);
       expect(stopped.process).toBe("unconfirmed");
       expect(stopped.errors.length).toBeGreaterThan(0);
       expect(isQaPosixProcessGroupAlive(predecessor!)).toBe(false);
       expect(isQaPosixProcessGroupAlive(pids()[1]!)).toBe(true);
       await expect(fs.stat(gateway.tempRoot)).resolves.toBeDefined();
+      expect((await readArtifacts(preserveToDir))[0]).not.toContain("QA_DESCENDANT_STILL_OWNED");
       await emitOutput();
       await vi.waitFor(async () =>
         expect(
           await fs.readFile(path.join(gateway.tempRoot, "gateway.stdout.log"), "utf8"),
         ).toContain("QA_DESCENDANT_STILL_OWNED"),
       );
+      expect((await owner.stop({ preserveToDir })).process).toBe("unconfirmed");
+      expect((await readArtifacts(preserveToDir))[0]).toContain("QA_DESCENDANT_STILL_OWNED");
+      await emitOutput("FINAL_OUTPUT");
+      await vi.waitFor(async () =>
+        expect(
+          await fs.readFile(path.join(gateway.tempRoot, "gateway.stdout.log"), "utf8"),
+        ).toContain("QA_DESCENDANT_FINAL_OUTPUT"),
+      );
     } finally {
       signalFault.mockRestore();
     }
-    await expect(owner.stop()).resolves.toEqual({ process: "confirmed-stopped", errors: [] });
+    await expect(owner.stop({ preserveToDir })).resolves.toEqual({
+      process: "confirmed-stopped",
+      errors: [],
+    });
+    const [log] = await readArtifacts(preserveToDir);
+    expect(log).toContain("QA_DESCENDANT_STILL_OWNED");
+    expect(log).toContain("QA_DESCENDANT_FINAL_OUTPUT");
     expect(pids().every((pid) => !isQaPosixProcessGroupAlive(pid))).toBe(true);
   });
 
@@ -340,17 +496,30 @@ describe.skipIf(process.platform === "win32")("QA gateway lifetime ownership", (
     await expect(fs.stat(gateway.tempRoot)).rejects.toMatchObject({ code: "ENOENT" });
   });
 
-  it("reports artifact failure while still confirming process shutdown", async () => {
+  it("retries failed preservation after confirming process shutdown", async () => {
     const { params, pids } = await fixture();
     const owner = own(params);
     const gateway = await owner.start();
     pids();
-    const result = await owner.stop({
+    const invalidOptions = {
       preserveToDir: path.resolve(process.cwd(), "../qa-artifacts-outside-repo"),
+    };
+    for (let attempt = 0; attempt < 2; attempt++) {
+      const result = await owner.stop(invalidOptions);
+      expect(result.process).toBe("confirmed-stopped");
+      expect(result.errors.length).toBeGreaterThan(0);
+      expect(await fs.stat(gateway.tempRoot)).toBeDefined();
+    }
+    const preserveToDir = await makeArtifactDir();
+    await expect(owner.stop({ preserveToDir })).resolves.toEqual({
+      process: "confirmed-stopped",
+      errors: [],
     });
-    expect(result.process).toBe("confirmed-stopped");
-    expect(result.errors.length).toBeGreaterThan(0);
+    const [stdout, stderr, readme] = await readArtifacts(preserveToDir);
+    expect(stdout).toContain("QA_GATEWAY_ATTEMPT_1 apiKey=<redacted>");
+    expect(stderr).toContain("QA_GATEWAY_STDERR apiKey=<redacted>");
+    expect(readme).toContain("Only sanitized gateway debug artifacts");
     expect(pids().every((pid) => !isQaPosixProcessGroupAlive(pid))).toBe(true);
-    expect(await fs.stat(gateway.tempRoot)).toBeDefined();
+    await expect(fs.stat(gateway.tempRoot)).rejects.toMatchObject({ code: "ENOENT" });
   });
 });

--- a/extensions/qa-lab/src/gateway-child-lifecycle.ts
+++ b/extensions/qa-lab/src/gateway-child-lifecycle.ts
@@ -51,6 +51,7 @@ export class QaGatewayChildLifecycle {
   private current: OwnedProcess | null = null;
   private operation: Promise<unknown> | null = null;
   private stopping: Promise<QaGatewayStopResult> | null = null;
+  private artifactsFinalized = false;
   private readonly keepTemp = process.env.OPENCLAW_QA_KEEP_TEMP === "1";
 
   repoRoot?: string;
@@ -244,7 +245,7 @@ export class QaGatewayChildLifecycle {
     const tempRoot = this.tempRoot;
     const keepTemp = opts?.keepTemp ?? this.keepTemp;
     let artifactsPreserved = true;
-    if (tempRoot && opts?.preserveToDir && !keepTemp) {
+    if (tempRoot && opts?.preserveToDir && !keepTemp && !this.artifactsFinalized) {
       try {
         await preserveQaGatewayDebugArtifacts({
           preserveToDir: opts.preserveToDir,
@@ -263,6 +264,9 @@ export class QaGatewayChildLifecycle {
       }
     }
     if (tempRoot && stopped.process !== "unconfirmed" && artifactsPreserved && !keepTemp) {
+      // Finalize artifact policy before cleanup can delete its log sources.
+      // Unconfirmed stops must keep refreshing their still-writable snapshots.
+      this.artifactsFinalized = true;
       await attempt(() =>
         cleanupQaGatewayTempRoots({
           tempRoot,


### PR DESCRIPTION
Closes #132826.

Related: [temporary-directory cleanup diagnostics](https://github.com/openclaw/openclaw/pull/132676) and [packaged bootstrap lifetime ownership](https://github.com/openclaw/openclaw/pull/132659), both already on main.

<details>
<summary>Additional instructions</summary>

This is a same-repository branch that maintainers can update.

</details>

## What Problem This Solves

Fixes an issue where QA operators retrying Gateway cleanup would lose previously preserved debug logs when the first stop removed the runtime directory but reported an independent RPC-stop or staged-plugin-directory removal error. The retry could succeed while replacing both saved logs with empty files.

## Why This Change Was Made

The lifecycle now records completed artifact policy before cleanup can delete the log sources, independently of overall cleanup success. RPC and filesystem cleanup remain retryable, while finalized exports are not replayed or redirected; unconfirmed stops keep refreshing snapshots, and failed preservation remains retryable.

This is the lifecycle-owned fix rather than a missing-file fallback in the artifact writer: the writer cannot distinguish an intentionally absent first-run log from a source already consumed by an earlier stop. Clearing the temp-root owner would also lose the ability to retry external staging cleanup. Process-group confirmation, CLI completion, log sink ownership, credential-release gates, and the landed cleanup helper's redaction are unchanged.

Production LOC: +5/-1 (net +4, including two invariant-comment lines). Tests: +182/-13 (net +169). Docs: +7/-0. The one lifecycle completion bit is necessary because artifact completion and cleanup completion are independent states; no dependency, config, environment, protocol, or persistence surface is added.

## User Impact

QA failure diagnostics survive cleanup retries. A still-running child group continues to contribute to subsequent snapshots, and the final confirmed snapshot includes its later output. Successful finalization keeps the original export destination; an error-recovery retry with `keepTemp` can still export retained logs later. Production channel delivery and credential storage behavior are unchanged.

The source [QA overview](https://docs.openclaw.ai/concepts/qa-e2e-automation) now documents these retry semantics. AI-assisted implementation and review.

## Evidence

Real local process/filesystem boundary proof on macOS with synthetic inputs—not a live-provider or live-channel run:

- Against main snapshot `86b9cf728895fed2a227316a98f0ad2f35261543` with only the lifecycle fix removed, the three focused regressions failed. RPC-stop and staging-removal retries replaced nonempty sanitized stdout/stderr with empty strings; a changed-destination retry manufactured an empty export.
- Restoring the exact lifecycle fix, without changing the tests or fixtures, passed all three focused cases.
- The staging case creates actual nonpackaged plugin staging, injects one removal failure for that exact root, confirms the first stop removed the runtime root but retained staging, and verifies the retry deletes staging, clears its diagnostic, and preserves stdout/stderr/README byte-for-byte.
- The RPC-only case has no filesystem fault. The live-descendant case verifies repeated unconfirmed snapshots and the final confirmed snapshot include later output. Existing credential-gate integration tests remain green.
- Combined six-file run: **165 passed, 1 existing platform skip**. Full changed-file checks passed, including production/test TypeScript, lint, formatting, doctor contract tests, export scans, and runtime import-cycle guards. Windows was not exercised locally.
- Fresh pre-publication Codex autoreview returned `scoped-clean` with no actionable findings at its default P0 scope.

Focused before/after command:

```bash
OPENCLAW_VITEST_MAX_WORKERS=2 node scripts/run-vitest.mjs extensions/qa-lab/src/gateway-child-lifecycle.test.ts -t 'retains finalized artifacts'
```

Combined owner/sibling proof:

```bash
OPENCLAW_VITEST_MAX_WORKERS=2 node scripts/run-vitest.mjs extensions/qa-lab/src/gateway-child-lifecycle.test.ts extensions/qa-lab/src/gateway-child-artifacts.test.ts extensions/qa-lab/src/gateway-child.test.ts extensions/qa-lab/src/gateway-child-bootstrap.test.ts extensions/qa-lab/src/gateway-startup-lease.integration.test.ts extensions/qa-lab/src/suite.test.ts
```

Changed-file gate:

```bash
node scripts/check-changed.mjs -- extensions/qa-lab/src/gateway-child-lifecycle.ts extensions/qa-lab/src/gateway-child-lifecycle.test.ts docs/concepts/qa-e2e-automation.md
```

An earlier pre-integration run hit a Crabline local-probe timeout and a dependency metadata change during lint preparation; unchanged reruns passed. The final integrated six-file run and full changed gate passed without those retries. No timeout, assertion, mock, or baseline was weakened. No UI or external provider API behavior changes, so screenshots and authenticated provider/channel proof are not applicable to this artifact-owner repair.
