### PR TITLE
fix(tasks): clear stale blocked state after requester delivery

### DIFF
--- a/src/agents/subagents/registry/subagent-registry-lifecycle-delivery.ts
+++ b/src/agents/subagents/registry/subagent-registry-lifecycle-delivery.ts
@@ -13,6 +13,7 @@ import type { DetachedTaskFindResult } from "../../../tasks/detached-task-runtim
 import {
   completeTaskRunByRunId,
   failTaskRunByRunId,
+  finalizeTaskRunByRunId,
   setDetachedTaskDeliveryStatusByRunId,
 } from "../../../tasks/detached-task-runtime.js";
 import { resolveRequiredCompletionDeliveryFailureTerminalResult } from "../../../tasks/task-completion-contract.js";
@@ -242,6 +243,33 @@ export const safeSetSubagentTaskDeliveryStatus = (
       runId: maskLifecycleIdentifier(target.runId, "run"),
       childSessionKey: maskLifecycleIdentifier(target.sessionKey, "session"),
       deliveryStatus: args.deliveryStatus,
+    });
+  }
+};
+
+export const safeReconcileSubagentTaskAfterRequesterSettle = (
+  params: SubagentLifecycleOptions,
+  entry: SubagentRunRecord,
+) => {
+  safeSetSubagentTaskDeliveryStatus(params, { entry, deliveryStatus: "delivered" });
+  const terminal = resolveFinalizedSubagentTaskState(entry);
+  if (!terminal || terminal.status !== "succeeded") {
+    return;
+  }
+  const target = resolveSubagentTaskTarget(params, entry);
+  try {
+    finalizeTaskRunByRunId({
+      runId: target.runId,
+      runtime: "subagent",
+      sessionKey: target.sessionKey,
+      ...terminal,
+      clearError: true,
+    });
+  } catch (err) {
+    params.warn("failed to finalize requester-settled subagent task", {
+      error: buildSafeLifecycleErrorMeta(err),
+      runId: maskLifecycleIdentifier(target.runId, "run"),
+      childSessionKey: maskLifecycleIdentifier(target.sessionKey, "session"),
     });
   }
 };

--- a/src/agents/subagents/registry/subagent-registry-lifecycle-wake.ts
+++ b/src/agents/subagents/registry/subagent-registry-lifecycle-wake.ts
@@ -18,6 +18,7 @@ import type {
 import {
   buildSafeLifecycleErrorMeta,
   maskLifecycleIdentifier,
+  safeReconcileSubagentTaskAfterRequesterSettle,
   safeMarkRequiredCompletionDeliveryBlocked,
   safeSetSubagentTaskDeliveryStatus,
 } from "./subagent-registry-lifecycle-delivery.js";
@@ -138,10 +139,7 @@ const completeRequesterSettleWakeBatch = (
   }
   for (const entry of settledDeliveries) {
     if (outcome?.delivered) {
-      safeSetSubagentTaskDeliveryStatus(params, {
-        entry,
-        deliveryStatus: "delivered",
-      });
+      safeReconcileSubagentTaskAfterRequesterSettle(params, entry);
     } else if (outcome) {
       const error = outcome.error ?? outcome.reason ?? "requester settle wake failed";
       safeSetSubagentTaskDeliveryStatus(params, {

--- a/src/agents/subagents/registry/subagent-registry-lifecycle.test.ts
+++ b/src/agents/subagents/registry/subagent-registry-lifecycle.test.ts
@@ -91,6 +91,7 @@ function waitForLifecycleState<T>(assertion: () => T | Promise<T>): Promise<T> {
 const taskExecutorMocks = vi.hoisted(() => ({
   completeTaskRunByRunId: vi.fn(),
   failTaskRunByRunId: vi.fn(),
+  finalizeTaskRunByRunId: vi.fn(),
   setDetachedTaskDeliveryStatusByRunId: vi.fn(),
 }));
 
@@ -131,6 +132,7 @@ const sessionReconciliationMocks = vi.hoisted(() => ({
 vi.mock("../../../tasks/detached-task-runtime.js", () => ({
   completeTaskRunByRunId: taskExecutorMocks.completeTaskRunByRunId,
   failTaskRunByRunId: taskExecutorMocks.failTaskRunByRunId,
+  finalizeTaskRunByRunId: taskExecutorMocks.finalizeTaskRunByRunId,
   setDetachedTaskDeliveryStatusByRunId: taskExecutorMocks.setDetachedTaskDeliveryStatusByRunId,
 }));
 
@@ -480,6 +482,7 @@ describe("subagent registry lifecycle hardening", () => {
     vi.clearAllMocks();
     taskExecutorMocks.completeTaskRunByRunId.mockReset();
     taskExecutorMocks.failTaskRunByRunId.mockReset();
+    taskExecutorMocks.finalizeTaskRunByRunId.mockReset();
     taskExecutorMocks.setDetachedTaskDeliveryStatusByRunId.mockReset();
     gatewayMocks.callGateway.mockReset();
     gatewayMocks.callGateway.mockResolvedValue({});
@@ -4848,6 +4851,15 @@ describe("requester settle wake trigger", () => {
     });
     expect(taskExecutorMocks.setDetachedTaskDeliveryStatusByRunId).toHaveBeenCalledWith(
       expect.objectContaining({ deliveryStatus: "delivered" }),
+    );
+    expect(taskExecutorMocks.finalizeTaskRunByRunId).toHaveBeenCalledWith(
+      expect.objectContaining({
+        runId: entry.runId,
+        runtime: "subagent",
+        sessionKey: entry.childSessionKey,
+        status: "succeeded",
+        clearError: true,
+      }),
     );
   });
 


### PR DESCRIPTION
Related: #121195

## What Problem This Solves

Fixes an issue where users who yield for required child work can receive the child completion visibly while the completed task remains falsely marked as delivery failed and blocked.

Reproduction:

1. A requester starts a required child task and yields.
2. The child succeeds.
3. The requester-settle wake produces a visible final reply.
4. Delivery changes to `delivered`, but an earlier delivery failure error and blocked terminal projection can remain on the task.

Expected: after the visible requester settlement succeeds, the same task is `succeeded` and `delivered`, with no stale error or blocked terminal outcome.

Actual before this change: the final reply is visible, but task audit still reports `delivery_failed` for that run.

## Why This Change Was Made

`minimum path: existing requester-settle lifecycle + native task finalizer; new durable machinery: none`

The successful requester-settle branch now reuses the existing finalized child state and native task finalizer with `clearError: true` after marking delivery complete. Failure, timeout, cancellation, and missing-visible-reply behavior is unchanged.

This does not change the current visible-final requirement or adopt the intentional-quiet policy discussed in #121195.

## User Impact

When a yielded child completion visibly reaches its requester, Task and Flow state now agree with what the user received. Operators no longer see a false blocked task or a new `delivery_failed` audit warning for that successful handoff.

## Evidence

Live QA on OpenClaw `2026.9.1-beta.1` with the equivalent patch:

- requester turn visibly ended with `Requester settlement QA started.`
- LifeOS later projected exactly one `Requester settlement QA completed visibly once.`
- task `b802568a-3418-47bf-8e80-08f089b75aab` ended `status: succeeded`, `deliveryStatus: delivered`, `error: null`
- LifeOS task activity reported zero active tasks and zero failures
- the audit retained the same 29 historical warnings and added no warning for the repaired run

Current-main validation at `73bc39dae8`:

- `src/agents/subagents/registry/subagent-registry-lifecycle.test.ts`: 320 passed across `agents-core` and `agents-support`
- changed files pass `oxfmt --check`
- `git diff --check origin/main...HEAD` passes

The exact beta patch also passed the 314-test focused lifecycle file, OpenClaw changed-file checks, and a full package build before live deployment.

AI-assisted: yes. The author reviewed the lifecycle and terminal-state ownership directly and understands the change. The repository autoreview helper was attempted, but a local safety policy blocked external transmission before any patch data was sent; the complete diff and adjacent finalization paths were reviewed locally instead.
