### PR TITLE
fix(cron): allow sessions_spawn from system-event woken sessions

### DIFF
--- a/src/gateway/server-methods/agent.events-and-subagents.test-utils.ts
+++ b/src/gateway/server-methods/agent.events-and-subagents.test-utils.ts
@@ -746,7 +746,7 @@ describe("gateway agent handler", () => {
 
   it.each(
     (["channel", "replyChannel"] as const).flatMap((field) =>
-      (["heartbeat", "cron", "webhook", "voice"] as const).map(
+      (["heartbeat", "cron-event", "exec-event", "cron", "webhook", "voice"] as const).map(
         (channel) => [field, channel] as const,
       ),
     ),

--- a/src/gateway/server.agent.rpc-contracts.test.ts
+++ b/src/gateway/server.agent.rpc-contracts.test.ts
@@ -17,6 +17,7 @@ type AgentResponse = {
   type?: string;
   id?: string;
   ok?: boolean;
+  error?: { message?: string };
   payload?: {
     runId?: string;
     status?: string;
@@ -191,6 +192,45 @@ describe("gateway agent RPC contracts", () => {
       expect(agentCommandMock).toHaveBeenCalledTimes(1);
     } finally {
       second.ws.close();
+    }
+  });
+
+  test("dispatches a run woken by a cron system event instead of rejecting the channel", async () => {
+    vi.mocked(agentCommandMock).mockImplementationOnce(async () => ({
+      payloads: [{ text: "child run started" }],
+      meta: { durationMs: 1 },
+    }));
+
+    const client = await harness.openClient();
+    try {
+      const terminalPromise = onceMessage<AgentResponse>(
+        client.ws,
+        (frame) =>
+          frame.type === "res" &&
+          frame.id === "agent-cron-event" &&
+          frame.payload?.status !== "accepted",
+      );
+
+      client.ws.send(
+        JSON.stringify({
+          type: "req",
+          id: "agent-cron-event",
+          method: "agent",
+          params: {
+            message: "spawn a child run from a cron system event",
+            sessionKey: "main",
+            channel: "cron-event",
+            idempotencyKey: "gateway-agent-cron-event-channel",
+          },
+        }),
+      );
+
+      const terminal = await terminalPromise;
+      expect(terminal.error?.message ?? null).toBeNull();
+      expect(terminal.ok).toBe(true);
+      await vi.waitFor(() => expect(agentCommandMock).toHaveBeenCalledTimes(1));
+    } finally {
+      client.ws.close();
     }
   });
 });

--- a/src/utils/message-channel-constants.ts
+++ b/src/utils/message-channel-constants.ts
@@ -18,6 +18,9 @@ export function internalSessionConversationId(
 // rejected as "unknown channel".
 const INTERNAL_NON_DELIVERY_CHANNELS = [
   "heartbeat",
+  // System-event wake providers emitted by the heartbeat runner alongside "heartbeat".
+  "cron-event",
+  "exec-event",
   "cron",
   "webhook",
   "voice",


### PR DESCRIPTION
Closes #132817

## What Problem This Solves

Fixes an issue where agents woken by a cron job with `payload_kind: systemEvent` could not spawn subagents. Every `sessions_spawn` call from such a turn failed with `invalid agent params: unknown channel: cron-event`, and no child session was created. The cron run itself still recorded `status: ok`, so the failure was only visible inside the transcript.

The same applied to turns woken by an exec completion event, which run with `exec-event`.

## Why This Change Was Made

The heartbeat runner tags system-event wakeups with a provider id of `cron-event` or `exec-event` rather than `heartbeat`:

```ts
// src/infra/heartbeat-runner-execution.ts:671
Provider: hasExecCompletion ? "exec-event" : hasCronEvents ? "cron-event" : "heartbeat",
```

On the CLI agent runtime that value reaches the gateway `agent` method as the child's origin channel hint, where it is validated against `isGatewayMessageChannel() || isInternalNonDeliveryChannel()`. `INTERNAL_NON_DELIVERY_CHANNELS` listed `heartbeat` but not the two sibling system-event providers, so the hint was rejected as an unknown channel.

This adds `cron-event` and `exec-event` to that allowlist. Both are already treated as system-event providers next to `heartbeat` elsewhere in the runtime, so the allowlist was the outlier:

- `src/auto-reply/reply/session.ts:309`
- `src/channels/turn/execution.ts:68`
- `src/sessions/session-participant-input.ts:37`

The list is only used to decide whether a channel hint is a known internal non-delivery source. It is not an authorization list, and nothing about delivery behavior changes — these providers remain non-deliverable.

## User Impact

`sessions_spawn` now works from cron `systemEvent` and exec-event woken sessions, matching the behavior already available from heartbeat-woken turns and isolated `agentTurn` cron runs.

## Evidence

### Real Gateway server, over a WebSocket

`src/gateway/server.agent.rpc-contracts.test.ts` runs a real Gateway server through `startGatewayServerHarness()` and drives it over a real WebSocket client. The added case sends an actual `agent` RPC carrying `channel: "cron-event"` and asserts the run reaches dispatch. Only model execution behind `agentCommand` is stubbed; the channel validation this PR changes runs unmocked in the real server, ahead of that boundary.

Red, with the allowlist reverted to current `main` (test unchanged):

```
$ node scripts/run-vitest.mjs src/gateway/server.agent.rpc-contracts.test.ts
 ✓ gateway agent RPC contracts > preserves requested delivery status across ordered final response and replay 998ms
 × gateway agent RPC contracts > dispatches a run woken by a cron system event instead of rejecting the channel 59ms
   → expected 'invalid agent params: unknown channel…' to be null

AssertionError: expected 'invalid agent params: unknown channel…' to be null
"invalid agent params: unknown channel: cron-event"

 Test Files  1 failed (1)
      Tests  1 failed | 1 passed (2)
```

The real server returns the reported error string verbatim.

Green, with the fix applied:

```
$ node scripts/run-vitest.mjs src/gateway/server.agent.rpc-contracts.test.ts
 ✓ gateway agent RPC contracts > preserves requested delivery status across ordered final response and replay 814ms
 ✓ gateway agent RPC contracts > dispatches a run woken by a cron system event instead of rejecting the channel 66ms

 Test Files  1 passed (1)
      Tests  2 passed (2)
```

`agentCommand` is asserted to have been invoked, so the request passed validation and reached agent dispatch rather than stopping at the RPC boundary.

### Focused validation matrix

Extended the existing internal-channel acceptance case in `src/gateway/server-methods/agent.events-and-subagents.test-utils.ts` to cover both new values across `channel` and `replyChannel`.

Red, allowlist reverted to `main`:

```
$ node scripts/run-vitest.mjs src/gateway/server-methods/agent.test.ts
 ✓ accepts internal non-delivery channel hint heartbeat 208ms
 × accepts internal non-delivery channel hint cron-event 13ms
 × accepts internal non-delivery channel hint exec-event 12ms
 ✓ accepts internal non-delivery channel hint cron 216ms
 ✓ accepts internal non-delivery channel hint webhook 199ms
 ✓ accepts internal non-delivery channel hint voice 231ms
 ✓ accepts internal non-delivery replyChannel hint heartbeat 513ms
 × accepts internal non-delivery replyChannel hint cron-event 10ms
 × accepts internal non-delivery replyChannel hint exec-event 11ms
 ✓ accepts internal non-delivery replyChannel hint cron 299ms
 ✓ accepts internal non-delivery replyChannel hint webhook 251ms
 ✓ accepts internal non-delivery replyChannel hint voice 220ms
 ✓ rejects unknown channel hints 16ms

 Test Files  1 failed (1)
      Tests  4 failed | 291 passed (295)
```

Green:

```
 Test Files  1 passed (1)
      Tests  295 passed (295)
```

`rejects unknown channel hints` passes in both runs, so genuinely unknown channels are still refused.

### Formatting

```
$ npx oxfmt --check src/utils/message-channel-constants.ts src/gateway/server-methods/agent.events-and-subagents.test-utils.ts src/gateway/server.agent.rpc-contracts.test.ts
All matched files use the correct format.
```

`node --import ./scripts/tsx.mjs scripts/check-max-lines-ratchet.mts` and `scripts/check-database-first-legacy-stores.mts` both pass.

### Not validated

I do not have a live cron deployment on a `claude-cli` runtime with the MCP loopback bridge, so I have not run the reporter's full end-to-end scenario against real infrastructure. The proof above covers the Gateway validation boundary that produced the error, exercised in a real server process over a real transport. The producer side of the chain (`heartbeat-runner-execution.ts:671` emitting these ids, and the loopback preserving them) is read from source and matches the reporter's own trace; I have not independently executed it.
