### PR TITLE
fix(sessions): scope the outbound transcript mirror fence to its destination

### DIFF
--- a/src/config/sessions/transcript-write-context.test.ts
+++ b/src/config/sessions/transcript-write-context.test.ts
@@ -12,8 +12,10 @@ import {
   type SessionTranscriptRuntimeTarget,
 } from "./session-accessor.js";
 import {
+  getOwnedSessionTranscriptWriterFence,
   SessionTranscriptWriterClaimReboundError,
   withOwnedSessionTranscriptWrites,
+  type OwnedSessionTranscriptWriteContext,
 } from "./transcript-write-context.js";
 
 async function withWriteTarget(run: (target: SessionTranscriptRuntimeTarget) => Promise<void>) {
@@ -133,4 +135,69 @@ describe("owned transcript commit boundary", () => {
       });
     },
   );
+});
+
+const passthroughWrite = async <T>(run: () => Promise<T> | T) => await run();
+
+const ownedRunContext = (sessionKey: string): OwnedSessionTranscriptWriteContext => ({
+  sessionFile: `/tmp/sessions/${sessionKey}.jsonl`,
+  sessionKey,
+  sessionTarget: {
+    agentId: "main",
+    sessionId: `session-${sessionKey}`,
+    sessionKey,
+    storePath: "/tmp/agents/main/agent/openclaw-agent.sqlite",
+    expectedLifecycleRevision: "rev-1",
+    expectedWriterRunId: `run-${sessionKey}`,
+  },
+  withTranscriptWrite: passthroughWrite,
+});
+
+describe("owned transcript writer fence destination matching", () => {
+  it("returns the admitted run claim for the owning session key", async () => {
+    await withOwnedSessionTranscriptWrites(ownedRunContext("agent:main:discord:c:1"), async () => {
+      expect(
+        getOwnedSessionTranscriptWriterFence({ sessionKey: "agent:main:discord:c:1" }),
+      ).toEqual({
+        expectedLifecycleRevision: "rev-1",
+        expectedWriterRunId: "run-agent:main:discord:c:1",
+      });
+    });
+  });
+
+  it("returns no claim for a different destination session key", async () => {
+    await withOwnedSessionTranscriptWrites(ownedRunContext("agent:main:discord:c:1"), async () => {
+      expect(
+        getOwnedSessionTranscriptWriterFence({ sessionKey: "agent:main:discord:c:2" }),
+      ).toBeUndefined();
+    });
+  });
+
+  it("keeps matching the full store identity when the caller supplies a target", async () => {
+    await withOwnedSessionTranscriptWrites(ownedRunContext("agent:main:discord:c:1"), async () => {
+      expect(
+        getOwnedSessionTranscriptWriterFence({
+          sessionKey: "agent:main:discord:c:1",
+          sessionTarget: {
+            agentId: "main",
+            sessionId: "session-agent:main:discord:c:1",
+            sessionKey: "agent:main:discord:c:1",
+            storePath: "/tmp/agents/main/agent/openclaw-agent.sqlite",
+          },
+        }),
+      ).toEqual({
+        expectedLifecycleRevision: "rev-1",
+        expectedWriterRunId: "run-agent:main:discord:c:1",
+      });
+      expect(
+        getOwnedSessionTranscriptWriterFence({
+          sessionKey: "agent:main:discord:c:1",
+          sessionTarget: {
+            sessionKey: "agent:main:discord:c:1",
+            storePath: "/tmp/agents/other/agent/openclaw-agent.sqlite",
+          },
+        }),
+      ).toBeUndefined();
+    });
+  });
 });

--- a/src/config/sessions/transcript-write-context.ts
+++ b/src/config/sessions/transcript-write-context.ts
@@ -65,7 +65,11 @@ function contextMatches(params: {
   };
   const contextTarget = normalizeTarget(params.context.sessionTarget);
   const requestedTarget = normalizeTarget(params.sessionTarget);
-  if (params.context.sessionTarget || params.sessionTarget) {
+  // A caller that passes a session target owns the full store identity, so an
+  // unresolvable target never matches. Callers that pass only a session key --
+  // outbound delivery mirrors naming their destination session -- fall through
+  // to session-identity matching instead of inheriting the ambient claim.
+  if (params.sessionTarget !== undefined) {
     return Boolean(
       contextTarget &&
       requestedTarget &&
@@ -85,7 +89,9 @@ function contextMatches(params: {
     return contextSessionFile === sessionFile;
   }
 
-  const contextSessionKey = params.context.sessionKey?.trim();
+  const contextSessionKey = (
+    params.context.sessionTarget?.sessionKey ?? params.context.sessionKey
+  )?.trim();
   const sessionKey = params.sessionKey?.trim();
   return Boolean(contextSessionKey && sessionKey && contextSessionKey === sessionKey);
 }

--- a/src/gateway/internal-source-reply-persistence.ts
+++ b/src/gateway/internal-source-reply-persistence.ts
@@ -171,7 +171,8 @@ export async function persistInternalSourceReply(params: {
         ...(params.payload.text ? [{ type: "text", text: params.payload.text }] : []),
         ...mediaBlocks,
       ];
-      const writerFence = getOwnedSessionTranscriptWriterFence();
+      // Fence against the mirror destination, not the sending run's own session.
+      const writerFence = getOwnedSessionTranscriptWriterFence({ sessionKey: params.sessionKey });
       const appended = await appendAssistantMessageToSessionTranscript({
         agentId: params.agentId,
         sessionKey: params.sessionKey,

--- a/src/infra/outbound/deliver-transcript.test.ts
+++ b/src/infra/outbound/deliver-transcript.test.ts
@@ -1,0 +1,93 @@
+// Boundary proof: the outbound delivery mirror fences its transcript write
+// against the DESTINATION session, never against the ambient admitted run.
+import { expectDefined } from "@openclaw/normalization-core";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { withOwnedSessionTranscriptWrites } from "../../config/sessions/transcript-write-context.js";
+import type { OwnedSessionTranscriptWriteContext } from "../../config/sessions/transcript-write-context.js";
+
+const appendAssistantMessageToSessionTranscriptMock = vi.hoisted(() =>
+  vi.fn(
+    async (_params: {
+      sessionKey?: string;
+      expectedWriterRunId?: string;
+      expectedLifecycleRevision?: string;
+    }) => ({
+      ok: true,
+      target: { sessionId: "session-b", sessionKey: "session-b", storePath: "/tmp/store.sqlite" },
+    }),
+  ),
+);
+
+vi.mock("../../config/sessions/transcript.runtime.js", () => ({
+  appendAssistantMessageToSessionTranscript: appendAssistantMessageToSessionTranscriptMock,
+}));
+
+const deliverTranscript = async () =>
+  await import("./deliver-transcript.js").then((module) => module.mirrorDeliveredPayloads);
+
+const passthroughWrite = async <T>(run: () => Promise<T> | T) => await run();
+
+const ownedRunContext = (sessionKey: string): OwnedSessionTranscriptWriteContext => ({
+  sessionFile: `/tmp/sessions/${sessionKey}.jsonl`,
+  sessionKey,
+  sessionTarget: {
+    agentId: "main",
+    sessionId: `session-${sessionKey}`,
+    sessionKey,
+    storePath: "/tmp/agents/main/agent/openclaw-agent.sqlite",
+    expectedLifecycleRevision: "rev-1",
+    expectedWriterRunId: `run-${sessionKey}`,
+  },
+  withTranscriptWrite: passthroughWrite,
+});
+
+const mirrorParams = (sessionKey: string) => ({
+  delivery: {
+    cfg: undefined,
+    mirror: {
+      agentId: "main",
+      sessionKey,
+      expectedSessionId: `session-${sessionKey}`,
+      idempotencyKey: `mirror-${sessionKey}`,
+    },
+  },
+  payloads: [{ text: "delivered", mediaUrls: [] }],
+  channel: "discord",
+  to: "channel:1",
+});
+
+describe("outbound delivery transcript mirror", () => {
+  beforeEach(() => {
+    appendAssistantMessageToSessionTranscriptMock.mockClear();
+  });
+
+  it("does not inherit the sending run's writer claim for another session", async () => {
+    const mirrorDeliveredPayloads = await deliverTranscript();
+    await withOwnedSessionTranscriptWrites(
+      ownedRunContext("agent:main:discord:c:1"),
+      async () => await mirrorDeliveredPayloads(mirrorParams("agent:main:discord:c:2") as never),
+    );
+    expect(appendAssistantMessageToSessionTranscriptMock).toHaveBeenCalledTimes(1);
+    const appendParams = expectDefined(
+      appendAssistantMessageToSessionTranscriptMock.mock.calls[0]?.[0],
+      "transcript append call",
+    );
+    expect(appendParams.sessionKey).toBe("agent:main:discord:c:2");
+    expect(appendParams.expectedWriterRunId).toBeUndefined();
+    expect(appendParams.expectedLifecycleRevision).toBeUndefined();
+  });
+
+  it("keeps the sending run's writer claim when mirroring into its own session", async () => {
+    const mirrorDeliveredPayloads = await deliverTranscript();
+    await withOwnedSessionTranscriptWrites(
+      ownedRunContext("agent:main:discord:c:1"),
+      async () => await mirrorDeliveredPayloads(mirrorParams("agent:main:discord:c:1") as never),
+    );
+    const appendParams = expectDefined(
+      appendAssistantMessageToSessionTranscriptMock.mock.calls[0]?.[0],
+      "transcript append call",
+    );
+    expect(appendParams.expectedWriterRunId).toBe("run-agent:main:discord:c:1");
+    expect(appendParams.expectedLifecycleRevision).toBe("rev-1");
+  });
+});

--- a/src/infra/outbound/deliver-transcript.ts
+++ b/src/infra/outbound/deliver-transcript.ts
@@ -40,7 +40,8 @@ export async function mirrorDeliveredPayloads(params: {
   // Keep mirror failures non-fatal so callers do not retry an already-sent payload.
   try {
     const { appendAssistantMessageToSessionTranscript } = await loadTranscriptRuntime();
-    const writerFence = getOwnedSessionTranscriptWriterFence();
+    // Fence against the mirror destination, not the sending run's own session.
+    const writerFence = getOwnedSessionTranscriptWriterFence({ sessionKey: mirror.sessionKey });
     const mirrorResult = await appendAssistantMessageToSessionTranscript({
       agentId: mirror.agentId,
       sessionKey: mirror.sessionKey,

--- a/src/infra/outbound/outbound-send-service.ts
+++ b/src/infra/outbound/outbound-send-service.ts
@@ -446,7 +446,10 @@ export async function executeSendAction(params: {
             params.mediaUrls ??
             (params.mediaUrl ? [params.mediaUrl] : undefined);
           try {
-            const writerFence = getOwnedSessionTranscriptWriterFence();
+            // Fence against the mirror destination, not the sending run's own session.
+            const writerFence = getOwnedSessionTranscriptWriterFence({
+              sessionKey: params.ctx.mirror.sessionKey,
+            });
             const mirrorResult = await appendAssistantMessageToSessionTranscript({
               agentId: params.ctx.mirror.agentId,
               sessionKey: params.ctx.mirror.sessionKey,

--- a/src/infra/outbound/source-reply-mirror.ts
+++ b/src/infra/outbound/source-reply-mirror.ts
@@ -594,7 +594,8 @@ export async function mirrorDeliveredSourceReplyToTranscript(
     return false;
   }
   const sourceTurnId = resolveCurrentSourceTurnId(params.toolContext);
-  const writerFence = getOwnedSessionTranscriptWriterFence();
+  // Fence against the mirror destination, not the sending run's own session.
+  const writerFence = getOwnedSessionTranscriptWriterFence({ sessionKey: params.sessionKey });
   const result = await appendAssistantMessageToSessionTranscript({
     agentId: params.agentId,
     sessionKey: params.sessionKey,


### PR DESCRIPTION
## What Problem This Solves

`mirrorDeliveredPayloads` and its three sibling mirror boundaries write a delivered payload into the **destination** session's transcript, but acquired their transcript writer fence by calling `getOwnedSessionTranscriptWriterFence()` with **no arguments**.

That function only runs its `contextMatches` gate when it was given parameters, so the zero-arg call skipped the gate and returned the *ambient* admitted run's `expectedWriterRunId` / `expectedLifecycleRevision` — a writer claim about the sending run's session, not the session receiving the mirror. The transcript guards then refused the append as `session rebound`, the refusal was `warn`-only, and the channel send had already succeeded, so the mirror was never retried. The receiving session kept answering while having silently lost every mirrored delivery.

Reported with 18 occurrences across 5 session keys and 3 agents in a real multi-agent gateway, including 8 of 8 deliveries on one channel across four consecutive days. A `sessions.reset` on the target key (rotating `lifecycleRevision`, clearing `activeWriterRunId`) restored mirroring on the very next delivery, which is what isolated the mechanism.

## Why This Change Was Made

Two connected defects share one invariant: a transcript write may only inherit the admitted run's writer claim when the write's destination *is* that run's session.

1. The four mirror boundaries looked the fence up with no destination identity at all, so they could not be scoped. Affected: `src/infra/outbound/deliver-transcript.ts`, `src/infra/outbound/outbound-send-service.ts`, `src/infra/outbound/source-reply-mirror.ts`, and `src/gateway/internal-source-reply-persistence.ts` (the fourth zero-arg call site, same invariant, found while reading the fence's consumers).
2. `contextMatches` rejected a session-key-only request outright whenever the ambient context carried a `sessionTarget`: the branch condition was `params.context.sessionTarget || params.sessionTarget`, so a request without a target produced `requestedTarget === undefined` and returned `false` for *every* destination, including the correct one. Fixing only (1) would have stripped the fence from same-session mirrors too.

The fix names the destination session at all four boundaries and teaches the gate to match session-key-only requests against the owning run's session identity. Callers that pass a full `sessionTarget` still require the exact store identity (`sessionKey` + `storePath`), so the SQLite write scopes (`withOwnedSessionTranscriptWriterFence` at the four sync write sites and `runWithOwnedSessionTranscriptWrite` at the turn boundaries) are byte-for-byte unaffected.

## User Impact

Cross-session outbound mirrors (announce/handoff from another session, `message` sends into another session key) now land in the destination session's transcript instead of being silently discarded. Same-session mirrors keep their writer-claim protection, so a concurrent writer change is still detected. No config, default, or operator action changes.

## Evidence

Reproduction and regression tests (pre-fix failure confirmed by running before the fix):

- `src/infra/outbound/deliver-transcript.test.ts` — drives the real `mirrorDeliveredPayloads` under an ambient admitted-run context for session A while mirroring into session B. Pre-fix, the append received `expectedWriterRunId: "run-agent:main:discord:c:1"` (session A's claim) for a write into session B. Post-fix it receives no claim. The companion case pins that a mirror into the run's *own* session still forwards `expectedWriterRunId` and `expectedLifecycleRevision`, guarding against over-correction.
- `src/config/sessions/transcript-write-context.test.ts` — pins the gate invariant: session-key-only requests match the owning session, reject a different destination, and full-target requests still require an exact store-identity match. The third case failed before the gate change for the owning session too, which is why the gate relaxation is part of this fix rather than an optional extra.

Sibling coverage (no regression):

- `node scripts/run-vitest.mjs run src/infra/outbound/` — 100 files, 1653 tests passed. Covers `message-action-runner`, which is the sole consumer of `persistInternalSourceReply`.
- `node scripts/run-vitest.mjs run src/config/sessions/session-accessor.conformance.test.ts src/config/sessions/transcript.test.ts` — 111 tests passed.
- `node scripts/run-vitest.mjs run src/agents/tools/sessions.test.ts` — 95 tests passed.
- `node scripts/run-vitest.mjs run src/infra/heartbeat-wake.transcript-context.test.ts` — passed (ambient-context isolation).
- `node scripts/run-tsgo.mjs -p tsconfig.core.json` clean; `oxlint` and `oxfmt --check` clean on all touched files.

Production diff: 5 files, +18/−6. The growth is the destination identity threaded into four independent mirror boundaries plus the gate's session-identity branch and its invariant comment; there is no wrapper or helper that absorbs it, and deleting the same-session fence (the only way to reach net zero) would remove real writer-claim protection.

### Rebase onto current main (2026-08-30)

`main` (b4f85100f72) has since introduced the initial-writer lease (`InitialSessionTranscriptWriter` + `assertCommitAllowed`) as the custody mechanism around these same boundaries. This branch was rewritten onto that baseline as a single commit (f6124437211); the CONFLICTING state is resolved.

- The two gate semantics from this PR are unchanged and land cleanly on the new mechanism; the lease revalidation composes with the destination-scoped fence lookup.
- The four destination-scoped call sites are re-applied. `persistInternalSourceReply` now sits inside `main`'s media-cleanup `try/finally`; the read-side zero-arg fence lookup at the replay/idempotency probe is intentionally untouched, matching the original scope.
- Pre-fix failure on the rewritten baseline (gate revert only): `AssertionError: expected undefined to deeply equal { …(2) }` — with the old gate, the owning session key resolves **no** claim whenever the ambient context carries a session target (1 failed | 12 passed; post-fix 13 passed). This pins why the gate relaxation is part of the fix rather than an optional extra.
- Sibling coverage on the rewritten baseline: `transcript-write-context.test.ts` 13 passed, `internal-source-reply-persistence.test.ts` 47 passed, `source-reply-mirror.test.ts` 10 passed, `outbound-send-service` + `message-action-send.mirror-order` passed, `deliver-transcript.test.ts` 2 passed. `oxlint` clean on all touched files.
