### PR TITLE
fix(update): fail closed when gateway service state is unknown

### DIFF
--- a/docs/cli/update.md
+++ b/docs/cli/update.md
@@ -219,11 +219,11 @@ Shell installers do not establish the same service ownership proof. If their
 service refresh is denied, they report code installation success, leave the
 service untouched, and print guidance to inspect ownership and restart manually.
 
-If service inspection is unavailable, the code update continues with a warning
-and leaves service control and definition files untouched; it does not assume
-that no service exists. Run `openclaw gateway status --deep`, then restart manually
-when access is restored. Services owned by another install remain untouched.
-`--no-restart` still skips service restart.
+If service inspection is unavailable, a restart-enabled code update refuses to
+mutate the checkout or package tree; it does not assume that no service exists.
+Run `openclaw gateway status --deep` and retry when access is restored. Use
+`--no-restart` only after manually stopping the Gateway, then restart it
+manually after the update. Services owned by another install remain untouched.
 
 Package-manager updates normally keep using the Node binary recorded in the
 managed service. If that Node cannot run the target release, but the current

--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -1726,7 +1726,7 @@ describe("update-cli", () => {
     { kind: "package", restart: false },
     { kind: "package", restart: true },
   ] as const)(
-    "updates $kind with restart=$restart when service inspection is unavailable",
+    "handles $kind with restart=$restart when service inspection is unavailable",
     async ({ kind, restart }) => {
       if (kind === "package") {
         mockPackageInstallAtCaseDir();
@@ -1738,10 +1738,28 @@ describe("update-cli", () => {
 
       await updateCommand({ yes: true, json: true, restart });
 
-      if (kind === "package") {
-        expectPackageInstallSpec("openclaw@9999.0.0");
+      if (restart) {
+        expect(runGatewayUpdate).not.toHaveBeenCalled();
+        expect(packageInstallCommandCall()).toBeUndefined();
+        expect(defaultRuntime.exit).toHaveBeenCalledWith(1);
+        expect(getErrorOutput()).toContain(
+          "Gateway service inspection is unavailable. Refusing to mutate code",
+        );
+        expect(getErrorOutput()).toContain("gateway status --deep");
+        expect(getErrorOutput()).toContain("stop the Gateway manually before the update");
+        expect(lastWriteJsonCall()).not.toMatchObject({ status: "ok" });
       } else {
-        expect(runGatewayUpdate).toHaveBeenCalledOnce();
+        if (kind === "package") {
+          expectPackageInstallSpec("openclaw@9999.0.0");
+        } else {
+          expect(runGatewayUpdate).toHaveBeenCalledOnce();
+        }
+        expect(defaultRuntime.exit).not.toHaveBeenCalledWith(1);
+        expect(getErrorOutput()).toContain(
+          "Gateway service management skipped: inspection is unavailable",
+        );
+        expect(getErrorOutput()).toContain("gateway status --deep");
+        expect(lastWriteJsonCall()).toMatchObject({ status: "ok" });
       }
       expectNoSideEffects(
         serviceStop,
@@ -1752,15 +1770,25 @@ describe("update-cli", () => {
         prepareRestartScript,
         runRestartScript,
       );
-      expect(defaultRuntime.exit).not.toHaveBeenCalledWith(1);
-      expect(getErrorOutput()).toContain(
-        "Gateway service management skipped: inspection is unavailable",
-      );
-      expect(getErrorOutput()).toContain("gateway status --deep");
       expect(getErrorOutput()).not.toContain("inspection-secret-canary");
-      expect(lastWriteJsonCall()).toMatchObject({ status: "ok" });
     },
   );
+
+  it("refuses a restart-enabled update when service load inspection is unknown", async () => {
+    mockRunningManagedGateway();
+    mockGitUpdateAfterMutation();
+    serviceLoaded.mockRejectedValue(new Error("load-state-secret-canary"));
+
+    await updateCommand({ yes: true, json: true });
+
+    expect(runGatewayUpdate).not.toHaveBeenCalled();
+    expect(serviceStop).not.toHaveBeenCalled();
+    expect(defaultRuntime.exit).toHaveBeenCalledWith(1);
+    expect(getErrorOutput()).toContain(
+      "Gateway service inspection is unavailable. Refusing to mutate code",
+    );
+    expect(getErrorOutput()).not.toContain("load-state-secret-canary");
+  });
 
   it.each([
     { kind: "git", restart: false, capability: "sealed" },
@@ -4633,6 +4661,7 @@ describe("update-cli", () => {
     serviceReadRuntime.mockResolvedValueOnce({
       status: "stopped",
       state: "stopped",
+      missingUnit: true,
     });
 
     await runWithGatewayServiceEnv({ yes: true });

--- a/src/cli/update-cli/update-command-service.ts
+++ b/src/cli/update-cli/update-command-service.ts
@@ -83,6 +83,10 @@ const SERVICE_REFRESH_TIMEOUT_MS = 60_000;
 const DEFINITION_DENIAL = /\bSERVICE_DEFINITION_(?:SEALED|UNKNOWN):[^\n]*/;
 const POST_REFRESH_ALREADY_HEALTHY_ATTEMPTS = 10;
 const POST_REFRESH_ALREADY_HEALTHY_DELAY_MS = 500;
+const GATEWAY_SERVICE_INSPECTION_UNAVAILABLE_MESSAGE =
+  "Gateway service management skipped: inspection is unavailable. Run `openclaw gateway status --deep` and restart the gateway manually when service access is restored.";
+const GATEWAY_SERVICE_INSPECTION_BLOCK_MESSAGE =
+  "Gateway service inspection is unavailable. Refusing to mutate code while automatic restart is enabled; run `openclaw gateway status --deep` and retry when service access is restored. To use `--no-restart`, stop the Gateway manually before the update, then restart it manually afterward.";
 const JSON_MODE_SERVICE_STDOUT = new Writable({
   write(_chunk, _encoding, callback) {
     callback();
@@ -146,9 +150,7 @@ async function inspectManagedGatewayServiceBeforeUpdate(params: {
   const { command } = state;
   const unavailable = (): ManagedGatewayUpdateVerdict => ({
     kind: "unavailable",
-    message:
-      "Gateway service management skipped: its owner or runtime could not be inspected. " +
-      "Code update can continue; run `openclaw gateway status --deep` and restart the gateway manually when service access is restored.",
+    message: GATEWAY_SERVICE_INSPECTION_UNAVAILABLE_MESSAGE,
   });
   if (!command) {
     return !state.installed && !state.running && state.runtime?.missingUnit
@@ -413,6 +415,17 @@ export async function maybeStopManagedServiceBeforeMutableUpdate(params: {
   timeoutMs?: number;
 }): Promise<PreManagedServiceStop> {
   const uninspected = { stopped: false, inspected: false, runtimeInspected: false, running: false };
+  const markInspectionUnavailable = (
+    base: PreManagedServiceStop,
+    message: string,
+  ): PreManagedServiceStop =>
+    params.shouldRestart
+      ? {
+          ...base,
+          serviceMutationAllowed: false,
+          blockMessage: GATEWAY_SERVICE_INSPECTION_BLOCK_MESSAGE,
+        }
+      : { ...base, serviceMutationAllowed: false, serviceMutationSkipMessage: message };
   const serviceMutationSkipMessage = resolveGatewayServiceManagementBlockMessageForUpdate(
     process.env,
   );
@@ -433,13 +446,7 @@ export async function maybeStopManagedServiceBeforeMutableUpdate(params: {
     if (err instanceof GatewayServiceUpdateOwnershipError) {
       return { ...uninspected, serviceMutationAllowed: false, blockMessage: err.message };
     }
-    return {
-      ...uninspected,
-      serviceMutationAllowed: false,
-      serviceMutationSkipMessage:
-        "Gateway service management skipped: inspection is unavailable. Code update can continue; " +
-        "run `openclaw gateway status --deep` and restart the gateway manually when service access is restored.",
-    };
+    return markInspectionUnavailable(uninspected, GATEWAY_SERVICE_INSPECTION_UNAVAILABLE_MESSAGE);
   }
   const serviceUpdateVerdict = await inspectManagedGatewayServiceBeforeUpdate({
     root: params.root,
@@ -454,11 +461,7 @@ export async function maybeStopManagedServiceBeforeMutableUpdate(params: {
     serviceUpdateVerdict,
   };
   if (serviceUpdateVerdict.kind === "unavailable") {
-    return {
-      ...inspected,
-      serviceMutationAllowed: false,
-      serviceMutationSkipMessage: serviceUpdateVerdict.message,
-    };
+    return markInspectionUnavailable(inspected, serviceUpdateVerdict.message);
   }
   if (serviceUpdateVerdict.kind === "foreign") {
     return {
@@ -596,7 +599,9 @@ export function shouldBlockMutableUpdateFromGatewayServiceEnv(params: {
     isGatewayServiceEnv(process.env) &&
     (!stopState?.inspected ||
       (!stopState.stopped &&
-        (!stopState.runtimeInspected || (stopState.running && !stopState.blockMessage))))
+        (!stopState.runtimeInspected ||
+          (stopState.running &&
+            (!stopState.blockMessage || stopState.serviceUpdateVerdict?.kind === "unavailable")))))
   );
 }
 

--- a/src/daemon/service.test.ts
+++ b/src/daemon/service.test.ts
@@ -144,7 +144,7 @@ describe("readGatewayServiceState", () => {
     { updateInstallKind: "package" as const, shouldRestart: false },
     { updateInstallKind: "package" as const, shouldRestart: true },
   ])(
-    "allows managerless Linux preflight for $updateInstallKind restart=$shouldRestart",
+    "handles managerless Linux preflight for $updateInstallKind restart=$shouldRestart",
     async ({ updateInstallKind, shouldRestart }) => {
       const { maybeStopManagedServiceBeforeMutableUpdate } =
         await import("../cli/update-cli/update-command-service.js");
@@ -181,10 +181,16 @@ describe("readGatewayServiceState", () => {
           phase: "inspect",
           timeoutMs: 2_000,
         });
-        expect(result.blockMessage).toBeUndefined();
+        if (shouldRestart) {
+          expect(result.blockMessage).toContain("Refusing to mutate code");
+          expect(result.blockMessage).toContain("stop the Gateway manually before the update");
+          expect(result.serviceMutationSkipMessage).toBeUndefined();
+        } else {
+          expect(result.blockMessage).toBeUndefined();
+          expect(result.serviceMutationSkipMessage).toContain("inspection is unavailable");
+          expect(result.serviceMutationSkipMessage).toContain("gateway status --deep");
+        }
         expect(result.serviceMutationAllowed).toBe(false);
-        expect(result.serviceMutationSkipMessage).toContain("inspection is unavailable");
-        expect(result.serviceMutationSkipMessage).toContain("gateway status --deep");
         expect(result.serviceUpdateVerdict?.kind).not.toBe("absent");
         expect(result.stopped).toBe(false);
       } finally {


### PR DESCRIPTION
## What Problem This Solves

`openclaw update` can replace the live package or checkout while Gateway service inspection is unavailable. A running Gateway can then retain imports to removed hashed `dist` chunks and fail later with `ENOENT` or `ERR_MODULE_NOT_FOUND`.

## Why This Change Was Made

The managed-service update path already stops a proven owned Gateway before mutation. Inspection failures and an explicit `unavailable` verdict instead produced a warning and allowed mutation without proving that the Gateway stopped.

This change makes restart-enabled Git and package updates fail before mutation when inspection is unavailable. It preserves known-absent services, foreign-owned services, and the explicit `--no-restart` manual-lifecycle path.

Related context: #92241, #125305, #125734, and #125896.

## User Impact

Operators now get a nonzero result with `openclaw gateway status --deep` guidance before files change. They can restore service inspection and retry. Operators who deliberately use `--no-restart` still own the manual stop and restart.

## Evidence

- Baseline `06c2dc7eb105cd0cc97c84dd9a433ca56901810d`: a disposable managed Linux Gateway received unavailable service inspection, but the update still swapped the package. The same process and health endpoint stayed live, then a new WebSocket request failed on its removed hashed message-handler import.
- Exact behavior head `38213cf1861cfeee8a36bd9dc5db95facf63ddbb`: [direct AWS proof](https://crabbox.openclaw.ai/portal/runs/run_14a92ee21e9d) built the exact commit and used two isolated managed Gateway profiles. Restart-enabled update exited before mutation with unchanged package digest, process, listener, and health. `--no-restart` performed the package swap while the same Gateway stayed live, then exposed the expected stale-import risk.
- Final guidance head `9d1d30484ae72232ed994eb2d3eb339620579df0`: [direct AWS proof](https://crabbox.openclaw.ai/portal/runs/run_c8d6b6309936) confirmed the restart-enabled update still exited before mutation and now tells operators to stop the Gateway manually before using `--no-restart`.
- `node scripts/run-vitest.mjs src/cli/update-cli.test.ts src/daemon/service.test.ts` — 59 daemon tests and 281 update CLI tests passed.
- Touched-file `oxfmt --check` and `git diff --check` passed.
- Current-main update progress, result, and planning refactors from #133622 and #133698 are preserved.
- Production delta: +21/-16. Tests: +49/-14. Docs: +5/-5.
