### PR TITLE
fix: running Gateway can report a checkout commit it never loaded

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -3133,7 +3133,7 @@ src/infra/fs-safe-remove.ts	4
 src/infra/gateway-lock.ts	4
 src/infra/gateway-processes.ts	1
 src/infra/gemini-auth.ts	1
-src/infra/git-commit.ts	2
+src/infra/git-commit.ts	1
 src/infra/heartbeat-outcome-store.ts	1
 src/infra/heartbeat-runner-config.ts	1
 src/infra/heartbeat-visibility.ts	1

--- a/docs/reference/database-schemas.md
+++ b/docs/reference/database-schemas.md
@@ -260,7 +260,7 @@ A newer OpenClaw build wrote your databases, and the running build is older. The
 
 Act on the install root, not the version. One release version string spans many `main` commits, schema levels, and same-version schema shapes, so two installs can both call themselves `2026.7.2` and still disagree about a database. A prerelease version may not exist on the `latest` npm tag at all: check `npm view openclaw dist-tags` before reinstalling, because the tag carrying the schema you need may be `beta`, and reinstalling from `latest` can move you further away.
 
-A linked source checkout is the case where the commit misleads: `openclaw --version` reports the checkout's git HEAD, but the code actually executing is whatever `dist/` was last built. If the install root is a checkout, rebuild it (`pnpm build`) before concluding the version is wrong.
+When a Gateway runs from a linked source checkout, its status and schema-refusal diagnostics report the commit captured when `dist/` was built, not the checkout's current Git HEAD. If that build identity is unknown, rebuild the checkout (`pnpm build`) before concluding the version is wrong.
 
 Open the database with a build that supports its schema, or point the older build at a separate `OPENCLAW_STATE_DIR`. Do not edit the database to silence the error.
 

--- a/src/cli/run-main.exit.test.ts
+++ b/src/cli/run-main.exit.test.ts
@@ -258,6 +258,7 @@ vi.mock("./command-execution-startup.js", () => ({
 
 vi.mock("../version.js", () => ({
   VERSION: "9.9.9-test",
+  resolveRuntimeServiceCommit: () => null,
 }));
 
 vi.mock("./banner.js", () => ({

--- a/src/infra/git-commit.test.ts
+++ b/src/infra/git-commit.test.ts
@@ -76,13 +76,14 @@ function limitPositionalReads(maxBytes: number) {
 
 describe("git commit resolution", () => {
   let resolveCommitHash: (typeof import("./git-commit.js"))["resolveCommitHash"];
+  let resolveLoadedCommitHash: (typeof import("./git-commit.js"))["resolveLoadedCommitHash"];
 
   beforeEach(async () => {
     vi.restoreAllMocks();
     vi.doUnmock("node:fs");
     vi.doUnmock("node:module");
     vi.resetModules();
-    ({ resolveCommitHash } = await import("./git-commit.js"));
+    ({ resolveCommitHash, resolveLoadedCommitHash } = await import("./git-commit.js"));
   });
 
   afterEach(async () => {
@@ -127,6 +128,94 @@ describe("git commit resolution", () => {
         },
       }),
     ).toBe(repoCommit.slice(0, 7));
+  });
+
+  it.each([
+    {
+      name: "uses matching local build stamps",
+      buildCommit: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      runtimeCommit: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      expected: "aaaaaaa",
+    },
+    {
+      name: "rejects conflicting local build stamps",
+      buildCommit: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      runtimeCommit: "cccccccccccccccccccccccccccccccccccccccc",
+      expected: null,
+    },
+  ])(
+    "$name instead of mutable checkout metadata",
+    async ({ buildCommit, runtimeCommit, expected }) => {
+      const root = await makeTempDir("git-commit-loaded-build");
+      const dist = path.join(root, "dist");
+      await makeFakeGitRepo(root, {
+        head: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\n",
+      });
+      await fs.mkdir(dist, { recursive: true });
+      await fs.writeFile(path.join(dist, ".buildstamp"), JSON.stringify({ head: buildCommit }));
+      await fs.writeFile(
+        path.join(dist, ".runtime-postbuildstamp"),
+        JSON.stringify({ head: runtimeCommit }),
+      );
+
+      expect(
+        resolveLoadedCommitHash({
+          env: { GIT_COMMIT: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb" },
+          moduleUrl: pathToFileURL(path.join(dist, "version-chunk.js")).href,
+        }),
+      ).toBe(expected);
+    },
+  );
+
+  it("uses build info when source-archive stamps have no Git head", async () => {
+    const root = await makeTempDir("git-commit-headless-build");
+    const dist = path.join(root, "dist");
+    await fs.mkdir(dist, { recursive: true });
+    await fs.writeFile(path.join(dist, ".buildstamp"), JSON.stringify({ head: null }));
+    await fs.writeFile(path.join(dist, ".runtime-postbuildstamp"), JSON.stringify({}));
+    await fs.writeFile(
+      path.join(dist, "build-info.json"),
+      JSON.stringify({ commit: "0123456789abcdef0123456789abcdef01234567" }),
+    );
+
+    expect(
+      resolveLoadedCommitHash({
+        env: {},
+        moduleUrl: pathToFileURL(path.join(dist, "version-chunk.js")).href,
+      }),
+    ).toBe("0123456");
+  });
+
+  it("does not guess when commitless build stamps lack build info", async () => {
+    const root = await makeTempDir("git-commit-headless-build-no-info");
+    const dist = path.join(root, "dist");
+    await makeFakeGitRepo(root, {
+      head: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\n",
+    });
+    await fs.mkdir(dist, { recursive: true });
+    await fs.writeFile(path.join(dist, ".buildstamp"), JSON.stringify({ head: null }));
+    await fs.writeFile(path.join(dist, ".runtime-postbuildstamp"), JSON.stringify({}));
+
+    expect(
+      resolveLoadedCommitHash({
+        env: { GIT_COMMIT: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb" },
+        moduleUrl: pathToFileURL(path.join(dist, "version-chunk.js")).href,
+      }),
+    ).toBeNull();
+  });
+
+  it("falls back to Git for true source execution without build metadata", async () => {
+    const root = await makeTempDir("git-commit-source-runtime");
+    await makeFakeGitRepo(root, {
+      head: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\n",
+    });
+
+    expect(
+      resolveLoadedCommitHash({
+        env: {},
+        moduleUrl: pathToFileURL(path.join(root, "src", "version.ts")).href,
+      }),
+    ).toBe("bbbbbbb");
   });
 
   it("caches build-info fallback results per resolved search directory", async () => {

--- a/src/infra/git-commit.ts
+++ b/src/infra/git-commit.ts
@@ -3,6 +3,7 @@ import fs from "node:fs";
 import { createRequire } from "node:module";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { asNullableRecord } from "@openclaw/normalization-core/record-coerce";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import { isMissingPathError } from "./errors.js";
 import { readFileWindowFullySync } from "./file-read.js";
@@ -184,27 +185,54 @@ const readCommitFromPackageJson = () => {
   }
 };
 
-const readCommitFromBuildInfo = () => {
+const readCommitProbe = (
+  moduleUrl: string,
+  candidates: readonly string[],
+  field: "commit" | "head",
+): string | null | undefined => {
   try {
-    const require = createRequire(import.meta.url);
-    const candidates = ["../build-info.json", "./build-info.json"];
     for (const candidate of candidates) {
+      const filePath = fileURLToPath(new URL(candidate, moduleUrl));
+      let raw: string;
       try {
-        const info = require(candidate) as {
-          commit?: string | null;
-        };
-        const formatted = formatCommit(info.commit ?? null);
-        if (formatted) {
-          return formatted;
+        raw = safeReadFilePrefix(filePath, 1024);
+      } catch (error) {
+        if (isMissingPathError(error)) {
+          continue;
         }
+        return null;
+      }
+      try {
+        const value = asNullableRecord(JSON.parse(raw))?.[field];
+        return typeof value === "string" ? formatCommit(value) : null;
       } catch {
-        // ignore missing candidate
+        return null;
       }
     }
-    return null;
   } catch {
-    return null;
+    // Invalid module URL means no loaded build metadata is available.
   }
+  return undefined;
+};
+
+const readCommitFromBuildInfo = (moduleUrl = import.meta.url) => {
+  return readCommitProbe(moduleUrl, ["../build-info.json", "./build-info.json"], "commit") ?? null;
+};
+
+const readLoadedCommit = (moduleUrl: string): string | null | undefined => {
+  const buildStamp = readCommitProbe(moduleUrl, ["../.buildstamp", "./.buildstamp"], "head");
+  const runtimeStamp = readCommitProbe(
+    moduleUrl,
+    ["../.runtime-postbuildstamp", "./.runtime-postbuildstamp"],
+    "head",
+  );
+  if (buildStamp !== undefined || runtimeStamp !== undefined) {
+    if (buildStamp || runtimeStamp) {
+      return buildStamp && buildStamp === runtimeStamp ? buildStamp : null;
+    }
+    return readCommitFromBuildInfo(moduleUrl);
+  }
+  return readCommitProbe(moduleUrl, ["../build-info.json", "./build-info.json"], "commit");
 };
 
 export const resolveCommitHash = (
@@ -258,3 +286,14 @@ export const resolveCommitHash = (
     return cacheGitCommit(searchDir, null);
   }
 };
+
+/** Resolve the commit that produced the loaded artifact, not the checkout's current revision. */
+export function resolveLoadedCommitHash(
+  options: { env?: NodeJS.ProcessEnv; moduleUrl?: string } = {},
+): string | null {
+  const moduleUrl = options.moduleUrl ?? import.meta.url;
+  const loaded = readLoadedCommit(moduleUrl);
+  return loaded === undefined
+    ? resolveCommitHash({ moduleUrl, ...(options.env ? { env: options.env } : {}) })
+    : loaded;
+}

--- a/src/infra/restart-sentinel.test.ts
+++ b/src/infra/restart-sentinel.test.ts
@@ -30,6 +30,11 @@ vi.mock("../state/openclaw-state-db.js", async (importOriginal) => {
   };
 });
 
+vi.mock("../version.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../version.js")>();
+  return { ...actual, resolveRuntimeServiceCommit: () => "aaaaaaa" };
+});
+
 import type { DB as OpenClawStateKyselyDatabase } from "../state/openclaw-state-db.generated.js";
 import {
   closeOpenClawStateDatabaseForTest,
@@ -506,6 +511,27 @@ describe("restart sentinel", () => {
             },
           },
         },
+      });
+    });
+  });
+
+  it("uses the loaded build commit when finalizing an update", async () => {
+    await withRestartSentinelStateDir(async () => {
+      await writeRestartSentinel({
+        kind: "update",
+        status: "ok",
+        ts: Date.now(),
+        stats: {
+          mode: "git",
+          root: process.cwd(),
+          after: { sha: "aaaaaaa", version: "actual-version" },
+        },
+      });
+
+      await finalizeUpdateRestartSentinelRunningVersion("actual-version");
+
+      await expect(readRestartSentinel()).resolves.toMatchObject({
+        payload: { status: "ok" },
       });
     });
   });

--- a/src/infra/restart-sentinel.ts
+++ b/src/infra/restart-sentinel.ts
@@ -8,9 +8,8 @@ import {
   openOpenClawStateDatabase,
   runOpenClawStateWriteTransaction,
 } from "../state/openclaw-state-db.js";
-import { resolveRuntimeServiceVersion } from "../version.js";
+import { resolveRuntimeServiceCommit, resolveRuntimeServiceVersion } from "../version.js";
 import { formatErrorMessage } from "./errors.js";
-import { resolveCommitHash } from "./git-commit.js";
 import { resolveOpenClawPackageRoot } from "./openclaw-root.js";
 import {
   deleteRestartSentinelRowSync,
@@ -97,7 +96,7 @@ function commitsMatch(expected: string, actual: string): boolean {
 export async function finalizeUpdateRestartSentinelRunningVersion(
   version = resolveRuntimeServiceVersion(process.env),
   env: NodeJS.ProcessEnv = process.env,
-  commit = resolveCommitHash({ env, moduleUrl: import.meta.url }),
+  commit = resolveRuntimeServiceCommit(),
   runningRoot?: string | null,
 ): Promise<RestartSentinel | null> {
   const snapshot = await readRestartSentinel(env);

--- a/src/infra/sqlite-user-version.test.ts
+++ b/src/infra/sqlite-user-version.test.ts
@@ -1,5 +1,10 @@
 // Tests for SQLite user_version pragma helper.
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("../version.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../version.js")>();
+  return { ...actual, resolveRuntimeServiceCommit: () => "aaaaaaa" };
+});
 import { VERSION } from "../version.js";
 import {
   createNewerSqliteSchemaVersionError,
@@ -84,5 +89,9 @@ describe("describeRunningOpenClawBuild", () => {
 
     expect(described).toContain(VERSION);
     expect(described).toContain("installed at ");
+  });
+
+  it("reports the loaded build commit", () => {
+    expect(describeRunningOpenClawBuild()).toContain("(aaaaaaa)");
   });
 });

--- a/src/infra/sqlite-user-version.ts
+++ b/src/infra/sqlite-user-version.ts
@@ -1,6 +1,5 @@
 import { OPENCLAW_DATABASE_SCHEMA_DOCS_URL } from "../state/openclaw-state-db-contract.js";
-import { VERSION } from "../version.js";
-import { resolveCommitHash } from "./git-commit.js";
+import { resolveRuntimeServiceCommit, VERSION } from "../version.js";
 import { resolveOpenClawPackageRootSync } from "./openclaw-root.js";
 
 type SqliteUserVersionReader = {
@@ -26,15 +25,12 @@ export function readSqliteUserVersion(db: SqliteUserVersionReader): number {
 }
 
 /**
- * Name the refusing install the way `--version` does, plus the root it runs from.
- * The path is the only part an operator can always act on: one release version
- * string spans many commits, and a linked source checkout reports its git HEAD
- * even when the built output actually executing is older.
+ * Name the refusing build from immutable loaded metadata, plus its install root.
+ * The path remains actionable when multiple installs share a version or build.
  */
 export function describeRunningOpenClawBuild(): string {
-  const moduleUrl = import.meta.url;
-  const commit = resolveCommitHash({ moduleUrl });
-  const root = resolveOpenClawPackageRootSync({ moduleUrl });
+  const commit = resolveRuntimeServiceCommit();
+  const root = resolveOpenClawPackageRootSync({ moduleUrl: import.meta.url });
   const identity = commit ? `OpenClaw ${VERSION} (${commit})` : `OpenClaw ${VERSION}`;
   return root ? `${identity} installed at ${root}` : identity;
 }
@@ -48,7 +44,7 @@ export function createNewerSqliteSchemaVersionError(
   return new SqliteSchemaVersionError(
     `${databaseLabel} ${pathname} uses newer schema version ${schemaVersion}; this build supports ${supportedVersion}. ` +
       `Refused by ${describeRunningOpenClawBuild()}. ` +
-      "Identify installs by that path: one version string spans many builds, and a linked source checkout reports its git HEAD even when its built output is older. " +
+      "Identify installs by that path when multiple installs share a version or build. " +
       `Run a build that supports schema ${schemaVersion} or newer against this state directory — rebuild or update the install above — or point this build at a different OPENCLAW_STATE_DIR. ` +
       `See ${OPENCLAW_DATABASE_SCHEMA_DOCS_URL}.`,
   );

--- a/src/status/status-message.test.ts
+++ b/src/status/status-message.test.ts
@@ -1,8 +1,13 @@
 // Status message tests cover status message formatting and persistence.
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { testing as cliBackendsTesting } from "../agents/cli-backends.test-support.js";
 import { SESSION_TOTAL_TOKENS_VERSION } from "../config/sessions/types.js";
 import type { ModelDefinitionConfig } from "../config/types.models.js";
+
+vi.mock("../version.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../version.js")>();
+  return { ...actual, resolveRuntimeServiceCommit: () => "aaaaaaa" };
+});
 import { buildStatusMessage, buildStatusMessageParts } from "./status-message.js";
 
 function statusTestModel(id: string, name: string, contextWindow: number): ModelDefinitionConfig {
@@ -42,6 +47,20 @@ describe("buildStatusMessage current time", () => {
 });
 
 describe("buildStatusMessageParts presentation", () => {
+  it("reports the loaded build commit", () => {
+    const parts = buildStatusMessageParts({
+      now: 1_751_529_600_000,
+      config: { agents: { defaults: { userTimezone: "UTC", timeFormat: "24" } } },
+      agent: { model: "anthropic/claude-haiku-4-5" },
+      sessionKey: "agent:main:main",
+      sessionScope: "per-sender",
+      queue: { mode: "steer", depth: 0 },
+      modelAuth: "api-key",
+    });
+
+    expect(parts.presentation.title).toContain("(aaaaaaa)");
+  });
+
   it("mirrors the text body as a titled status table with context lines", () => {
     const parts = buildStatusMessageParts({
       now: 1_751_529_600_000,

--- a/src/status/status-message.ts
+++ b/src/status/status-message.ts
@@ -53,7 +53,6 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { readRecentSessionUsageFromTranscript } from "../gateway/session-transcript-readers.js";
 import { formatDurationCompact } from "../infra/format-time/format-duration.ts";
 import { formatTimeAgo } from "../infra/format-time/format-relative.ts";
-import { resolveCommitHash } from "../infra/git-commit.js";
 import type {
   MessagePresentation,
   MessagePresentationBlock,
@@ -74,7 +73,7 @@ import {
   formatUsd,
   resolveModelCostConfig,
 } from "../utils/usage-format.js";
-import { VERSION } from "../version.js";
+import { resolveRuntimeServiceCommit, VERSION } from "../version.js";
 import { resolveAgentRuntimeLabel } from "./agent-runtime-label.js";
 import { resolveActiveFallbackState } from "./fallback-notice-state.js";
 
@@ -1001,7 +1000,7 @@ export function buildStatusMessageParts(args: StatusArgs): StatusMessageParts {
       } (${fallbackState.reason ?? "selected model unavailable"})`
     : null;
   const fallbackLine = fallbackValue ? `↪️ Fallback: ${fallbackValue}` : null;
-  const commit = resolveCommitHash({ moduleUrl: import.meta.url });
+  const commit = resolveRuntimeServiceCommit();
   const versionLine = `🦞 OpenClaw ${VERSION}${commit ? ` (${commit})` : ""}`;
   const tokensValue = formatTokensPairValue(inputTokens, outputTokens);
   const usagePair = tokensValue ? `🧮 Tokens: ${tokensValue}` : null;

--- a/src/trajectory/metadata.test.ts
+++ b/src/trajectory/metadata.test.ts
@@ -13,7 +13,8 @@ type ResolvedSkillEntry = NonNullable<SkillSnapshot["resolvedSkills"]>[number];
 
 const loadPluginManifestRegistry = vi.hoisted(() => vi.fn(() => ({ plugins: [] })));
 
-vi.mock("../infra/git-commit.js", () => ({
+vi.mock("../infra/git-commit.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../infra/git-commit.js")>()),
   resolveCommitHash: () => "abcdef0",
 }));
 

--- a/src/version.test.ts
+++ b/src/version.test.ts
@@ -2,7 +2,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import { createSuiteTempRootTracker } from "./test-helpers/temp-dir.js";
 import {
   VERSION,
@@ -94,6 +94,23 @@ describe("version resolution", () => {
       await writeJsonFixture(root, "build-info.json", { buildId: "x".repeat(97) });
       expect(readBuildIdFromBuildInfoForModuleUrl(moduleUrl)).toBeNull();
     });
+  });
+
+  it("captures the runtime commit from startup provenance once", async () => {
+    let startupCommit = "aaaaaaa";
+    vi.doMock("./infra/git-commit.js", () => ({
+      resolveLoadedCommitHash: () => startupCommit,
+    }));
+    vi.resetModules();
+    try {
+      const runtimeVersion = await import("./version.js");
+      expect(runtimeVersion.resolveRuntimeServiceCommit()).toBe("aaaaaaa");
+      startupCommit = "bbbbbbb";
+      expect(runtimeVersion.resolveRuntimeServiceCommit()).toBe("aaaaaaa");
+    } finally {
+      vi.doUnmock("./infra/git-commit.js");
+      vi.resetModules();
+    }
   });
 
   it("returns null when no version metadata exists", async () => {

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,6 +1,7 @@
 // Resolves package version metadata for CLI and library callers.
 import { createRequire } from "node:module";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import { resolveLoadedCommitHash } from "./infra/git-commit.js";
 
 const CORE_PACKAGE_NAME = "openclaw";
 
@@ -153,12 +154,17 @@ export function resolveRuntimeServiceVersion(
   });
 }
 
-// Generated build provenance is immutable for a process. Resolve it once so
-// handshakes never poll the filesystem on the connection hot path.
+// Loaded build provenance is immutable for a process. Resolve it once so a
+// checkout update cannot change the identity reported by the running service.
 const RUNTIME_SERVICE_BUILD_ID = readBuildIdFromBuildInfoForModuleUrl(import.meta.url);
+const RUNTIME_SERVICE_COMMIT = resolveLoadedCommitHash({ moduleUrl: import.meta.url });
 
 export function resolveRuntimeServiceBuildId(): string | null {
   return RUNTIME_SERVICE_BUILD_ID;
+}
+
+export function resolveRuntimeServiceCommit(): string | null {
+  return RUNTIME_SERVICE_COMMIT;
 }
 
 export function resolveCompatibilityHostVersion(


### PR DESCRIPTION
## What Problem This Solves

A built OpenClaw process could report the current source-checkout commit instead of the commit that produced its loaded code. If the checkout moved while the Gateway kept running, status output and SQLite refusal diagnostics changed identity. Update restart validation could also reject the correct running build.

## Root cause

The three runtime diagnostics called the mutable Git resolver when they rendered or finalized. OpenClaw already records loaded build provenance, but no process-lifetime commit owner consumed its three real forms:

- matching local build stamps for incremental source builds;
- `build-info.json` for packaged or source-archive builds;
- Git only for true source execution without build metadata.

## Fix

`src/version.ts` now snapshots the loaded commit once beside the existing loaded build ID. Status, SQLite diagnostics, and restart finalization use that owner. Incomplete or conflicting loaded metadata returns an unknown commit instead of guessing from a mutable checkout. Workspace and trajectory provenance keep the live Git resolver.

The repair preserves the current `SqliteSchemaVersionError` contract and updates the database troubleshooting guide.

## Evidence

Current-main red at `49a8b1cb2138b5545465d10f866962157bb49529`:

1. Built and started the real Gateway.
2. Moved the source checkout to `357078cf7087534443dac92eb86e8aa32abb7b08` without rebuilding or restarting.
3. Status and SQLite diagnostics incorrectly reported `357078c`.
4. Restart finalization changed `ok` to `restart-revision-mismatch`.

Exact-head green at `256d643ae63b17bc31ad967acefbdd28a8060fb8`:

1. Built and started the real Gateway from the repaired head.
2. Moved the source checkout to `c9476275b86cd7b037ac9a33d762d0c6032b5d2f` without rebuilding or restarting.
3. CLI version, status, and SQLite diagnostics kept reporting loaded head `256d643`.
4. The live Gateway status RPC stayed healthy.
5. Restart finalization stayed `ok` with no mismatch reason.

The changed checkout commit is the anti-cache probe: it differs from the loaded build while every diagnostic remains bound to the build metadata.

### Sanitized terminal evidence

```text
current-main red
builtCommit=49a8b1cb2138b5545465d10f866962157bb49529
checkoutCommitAfterStart=357078cf7087534443dac92eb86e8aa32abb7b08
statusTitle="OpenClaw 2026.8.1 (357078c)"
sqliteDescriptionCommit=357078c
restartStatus=error
restartReason=restart-revision-mismatch

exact-head green
builtCommit=256d643ae63b17bc31ad967acefbdd28a8060fb8
checkoutCommitAfterStart=c9476275b86cd7b037ac9a33d762d0c6032b5d2f
cliVersion="OpenClaw 2026.8.1 (256d643)"
gatewayStatusRpc=ok
gatewayRuntimeVersion=2026.8.1
statusTitle="OpenClaw 2026.8.1 (256d643)"
sqliteDescriptionCommit=256d643
restartStatus=ok
restartReason=null
```

## Validation

- 362 focused tests passed across the runtime owner, three consumers, and two sibling suites.
- The new owner regression failed on current main because no process-bound commit owner existed.
- Exact-main and exact-head production builds passed.
- Focused Oxlint, Oxfmt, docs checks, import-cycle checks, and changed-scope repository ratchets passed.
- Production: +69/-30, net +39. The added lines encode the closed loaded-artifact modes; three consumer-side Git lookups were removed. The contributor candidate was net +70 production lines.
- Tests: +167/-5, net +162.
- No configuration, protocol, or database schema changed.

AI-assisted: yes (Codex).
