### PR TITLE
fix(ci): restore post-update service fixture isolation

### DIFF
--- a/src/cli/update-cli/update-command-post-update.test.ts
+++ b/src/cli/update-cli/update-command-post-update.test.ts
@@ -3,8 +3,10 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
+import { GATEWAY_SERVICE_SELECTOR_ENV_KEYS } from "../../daemon/constants.js";
 import type { UpdateRunResult } from "../../infra/update-runner.js";
 import { defaultRuntime } from "../../runtime.js";
+import { captureEnv } from "../../test-utils/env.js";
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 const mocks = vi.hoisted(() => ({
@@ -135,6 +137,32 @@ const successfulPluginUpdate = {
   integrityDrifts: [],
   warnings: [],
 };
+
+function createManagedServiceIdentityFixture() {
+  const home = tempDirs.make("openclaw-post-update-service-home-");
+  const keys = [
+    "HOME",
+    "USERPROFILE",
+    "OPENCLAW_HOME",
+    "OPENCLAW_SUPERVISOR_MODE",
+    ...GATEWAY_SERVICE_SELECTOR_ENV_KEYS,
+  ];
+  const env = captureEnv(keys);
+  // A private HOME does not change the OS account home checked by the real service guard.
+  const userInfo = vi.spyOn(os, "userInfo").mockReturnValue({ ...os.userInfo(), homedir: home });
+  for (const key of keys) {
+    delete process.env[key];
+  }
+  process.env.HOME = home;
+  process.env.USERPROFILE = home;
+  return {
+    home,
+    restore: () => {
+      userInfo.mockRestore();
+      env.restore();
+    },
+  };
+}
 
 async function finishSuccessfulPackageSwitch(params: {
   previousRoot: string;
@@ -573,6 +601,7 @@ describe("successful update finalization ordering", () => {
   });
 
   it("removes operator overrides and process identity from the managed install environment", async () => {
+    const identity = createManagedServiceIdentityFixture();
     const programArguments = ["/usr/bin/node", "/tmp/openclaw-update/dist/index.js", "gateway"];
     const managedEnvironment = {
       ANTHROPIC_API_KEY: "managed-provider",
@@ -603,10 +632,8 @@ describe("successful update finalization ordering", () => {
     vi.stubEnv("OPENAI_API_KEY", effectiveEnvironment.OPENAI_API_KEY);
     vi.stubEnv("UNSET_PROVIDER_KEY", "removed-by-drop-in");
     vi.stubEnv("GEMINI_API_KEY", "allowed-runtime-credential");
-    vi.stubEnv("HOME", os.homedir());
-    vi.stubEnv("OPENCLAW_HOME", "");
     vi.stubEnv("OPENCLAW_PROFILE", "caller-only-profile");
-    const callerStateDir = path.join(os.homedir(), ".openclaw-caller-only-profile");
+    const callerStateDir = path.join(identity.home, ".openclaw-caller-only-profile");
     vi.stubEnv("OPENCLAW_STATE_DIR", callerStateDir);
     vi.stubEnv("OPENCLAW_CONFIG_PATH", path.join(callerStateDir, "openclaw.json"));
     try {
@@ -634,6 +661,7 @@ describe("successful update finalization ordering", () => {
       expect(installEnv?.OPENCLAW_LAUNCHD_LABEL).toBe("ai.openclaw.work");
     } finally {
       vi.unstubAllEnvs();
+      identity.restore();
     }
   });
 
@@ -662,14 +690,14 @@ describe("successful update finalization ordering", () => {
   });
 
   describe("managed service finalization", () => {
+    let identity: ReturnType<typeof createManagedServiceIdentityFixture>;
     beforeEach(() => {
-      vi.stubEnv("HOME", os.homedir());
-      vi.stubEnv("OPENCLAW_PROFILE", "default");
-      for (const key of ["OPENCLAW_HOME", "OPENCLAW_STATE_DIR", "OPENCLAW_CONFIG_PATH"]) {
-        vi.stubEnv(key, "");
-      }
+      identity = createManagedServiceIdentityFixture();
     });
-    afterEach(() => vi.unstubAllEnvs());
+    afterEach(() => {
+      vi.unstubAllEnvs();
+      identity.restore();
+    });
 
     it.each([
       ["unknown", true],
@@ -720,7 +748,7 @@ describe("successful update finalization ordering", () => {
       { source: "preserved config", sealed: true, args: [], expected: 19304 },
       { source: "writable refresh", sealed: false, args: ["--port=19301"], expected: 19303 },
     ])("verifies the CLI service port for $source", async ({ sealed, args, expected }) => {
-      const serviceEnv = { HOME: os.homedir() };
+      const serviceEnv = { HOME: identity.home };
       mocks.readServiceState.mockResolvedValue({
         installed: true,
         loadState: { status: "loaded" },
@@ -870,6 +898,28 @@ describe("successful update finalization ordering", () => {
         expect(mocks.printResult).not.toHaveBeenCalled();
         expect(defaultRuntime.exit).toHaveBeenCalledWith(1);
       }
+    });
+
+    it("leaves native service management blocked when HOME is relocated", async () => {
+      const home = tempDirs.make("openclaw-post-update-relocated-home-");
+      process.env.HOME = home;
+      process.env.USERPROFILE = home;
+
+      await finishSuccessfulPackageSwitch({
+        previousRoot: home,
+        packageRoot: home,
+        restartEnvironment: { ...process.env },
+        stoppedForUpdate: false,
+      });
+
+      expect(mocks.readServiceState).not.toHaveBeenCalled();
+      expect(mocks.revalidateService).not.toHaveBeenCalled();
+      expect(mocks.restartService).toHaveBeenCalledWith(
+        expect.objectContaining({
+          shouldRestart: false,
+          serviceMutationSkipMessage: expect.stringContaining("HOME set to the OS account home"),
+        }),
+      );
     });
   });
 });


### PR DESCRIPTION
Related: #129170 (effective systemd drop-in ownership) and #131021 (sealed-service update preservation).

## What Problem This Solves

Resolves a problem where the post-update regression suite rejects its mocked managed services under an isolated test home, producing 12 failures because the intended service ownership, restart-port, and activation paths are never reached.

## Why This Change Was Made

`os.homedir()` follows the test environment, but `os.userInfo().homedir` remains the OS account home. The real service-scope guard correctly distinguishes them. Reuse the established sibling fixture pattern: give the managed-service cases one canonical private home, scope the native account-home fact to it, capture and restore the canonical service selectors, and restore the native spy afterward. A relocated-HOME case verifies that the real guard still refuses service inspection.

The repair stays in the fixture that produces these facts. It does not weaken the production guard, globally spoof account identity, or change test deadlines.

## User Impact

No production behavior or public contract changes. Maintainers regain meaningful isolated coverage for post-update managed-service finalization. Existing assertions and their order are preserved.

## Evidence

Validation uses Node 24.15.0, the task-owned frozen dependencies, one native Vitest worker, and lifetime-private home/state/config/temp/cache roots. Additional JSON reporting flags and local destinations are omitted from the commands below.

- Before, on `3506cf9d1a6735a03631000c7237c05ebe2ba83f`: the full post-update file reported **16 passed, 12 failed**, with the non-default-install diagnostic. The exact baseline result was recovered from the local task record after temporary evidence was lost during a session restart.
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.cli.config.ts src/cli/update-cli/update-command-service.integration.test.ts src/cli/update-cli/update-command-post-update.test.ts --reporter=verbose`: **102 passed** — 73 integration cases followed by all 29 post-update cases, preserving the original relative file order in one non-isolated worker.
- `node scripts/run-vitest.mjs src/config/paths.test.ts --reporter=verbose`: **52 passed**, including canonical paths, relocated homes, and named-profile restrictions.
- Fresh isolated Codex autoreview: **clean**, no findings at the default P0 threshold.
- `node scripts/check-changed.mjs --base 3506cf9d1a6735a03631000c7237c05ebe2ba83f -- src/cli/update-cli/update-command-post-update.test.ts`: **passed**, including formatting, all selected static guards, dead-export scans, core test typing, and targeted lint.
- Exact-head [CI run 33276463649](https://github.com/openclaw/openclaw/actions/runs/33276463649): **passed** for `2b629e7cd851ad02549120afafe37902da3a36e2`. Changed Node tests, changed boundary checks, and the required `openclaw/ci-gate` all passed; the native exact-head watcher completed successfully.

All current proof has been rerun into persistent private evidence. Earlier silent-reporter attempts terminated at the unchanged 120-second no-output watchdog and are not credited as proof; their cause is a separate finding. Native service/process I/O remains mocked at the existing integration boundaries, so this is deterministic boundary proof, not a live service restart. No operator state or service was used.

Production LOC: **+0/-0**. Tests: **+60/-10** in one existing file. No dependency, configuration-contract, schema, baseline, or documentation changes.

Maintainer-directed, AI-assisted repair.
