### PR TITLE
fix(infra): reread device pairing state inside the write transaction

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -3108,7 +3108,7 @@ src/infra/delivery-queue-sqlite.ts	4
 src/infra/delivery-queue-sqlite.types.ts	1
 src/infra/delivery-recovery.shared.ts	4
 src/infra/device-identity.ts	1
-src/infra/device-pairing-store.ts	6
+src/infra/device-pairing-store.ts	2
 src/infra/diagnostic-event-listener-presence.ts	3
 src/infra/diagnostic-events.ts	13
 src/infra/diagnostic-model-request.ts	1

--- a/src/gateway/device-pair-setup-completion.test.ts
+++ b/src/gateway/device-pair-setup-completion.test.ts
@@ -1,9 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { readDevicePairSetupCompletion } from "../infra/device-bootstrap.js";
-import {
-  persistDeviceBootstrapTokenRecords,
-  persistDevicePairingStoreState,
-} from "../infra/device-pairing-store.js";
+import { persistDeviceBootstrapTokenRecords } from "../infra/device-pairing-store.js";
+import { seedDevicePairingStoreState } from "../infra/device-pairing-store.test-support.js";
 import type { PairedDevice } from "../infra/device-pairing.types.js";
 import {
   FULL_ACCESS_PAIRING_SETUP_BOOTSTRAP_PROFILE,
@@ -43,10 +41,9 @@ describe("device pair setup completion", () => {
       createdAtMs: 1,
       approvedAtMs: 2,
     };
-    persistDevicePairingStoreState(
+    seedDevicePairingStoreState(
       { pendingById: {}, pairedByDeviceId: { [paired.deviceId]: paired } },
       baseDir,
-      "paired",
     );
     persistDeviceBootstrapTokenRecords(
       {

--- a/src/gateway/device-pairing-prune.ts
+++ b/src/gateway/device-pairing-prune.ts
@@ -2,7 +2,7 @@
 import {
   pruneSupersededSilentPairedDevices,
   type PrunedSupersededPairedDevice,
-} from "../infra/device-pairing.js";
+} from "../infra/device-pairing-prune.js";
 import { reconcileRevokedDeviceWorker } from "./device-worker-revocation.js";
 import { clearRemovedNodeRuntimeState } from "./node-runtime-state.js";
 import type { GatewayRequestContext } from "./server-methods/types.js";

--- a/src/gateway/server/ws-connection/connect-hello.setup-completion.test.ts
+++ b/src/gateway/server/ws-connection/connect-hello.setup-completion.test.ts
@@ -6,7 +6,7 @@ import {
   readDevicePairSetupCompletion,
   verifyDeviceBootstrapToken,
 } from "../../../infra/device-bootstrap.js";
-import { persistDevicePairingStoreState } from "../../../infra/device-pairing-store.js";
+import { seedDevicePairingStoreState } from "../../../infra/device-pairing-store.test-support.js";
 import type { PairedDevice } from "../../../infra/device-pairing.types.js";
 import { PAIRING_SETUP_BOOTSTRAP_PROFILE } from "../../../shared/device-bootstrap-profile.js";
 import { withOpenClawTestState } from "../../../test-utils/openclaw-test-state.js";
@@ -60,10 +60,9 @@ describe("sendGatewayHello setup completion ordering", () => {
           createdAtMs: 1,
           approvedAtMs: 2,
         };
-        persistDevicePairingStoreState(
+        seedDevicePairingStoreState(
           { pendingById: {}, pairedByDeviceId: { [paired.deviceId]: paired } },
           undefined,
-          "paired",
         );
         const issued = await issueDevicePairSetupBootstrapToken({
           profile: PAIRING_SETUP_BOOTSTRAP_PROFILE,
@@ -173,10 +172,9 @@ describe("sendGatewayHello setup completion ordering", () => {
           createdAtMs: 1,
           approvedAtMs: 2,
         };
-        persistDevicePairingStoreState(
+        seedDevicePairingStoreState(
           { pendingById: {}, pairedByDeviceId: { [paired.deviceId]: paired } },
           undefined,
-          "paired",
         );
         const issued = await issueDevicePairSetupBootstrapToken({
           profile: PAIRING_SETUP_BOOTSTRAP_PROFILE,
@@ -272,10 +270,9 @@ describe("sendGatewayHello setup completion ordering", () => {
           createdAtMs: 1,
           approvedAtMs: 2,
         };
-        persistDevicePairingStoreState(
+        seedDevicePairingStoreState(
           { pendingById: {}, pairedByDeviceId: { [paired.deviceId]: paired } },
           undefined,
-          "paired",
         );
         const issued = await issueDevicePairSetupBootstrapToken({
           profile: PAIRING_SETUP_BOOTSTRAP_PROFILE,
@@ -289,7 +286,7 @@ describe("sendGatewayHello setup completion ordering", () => {
             scopes: PAIRING_SETUP_BOOTSTRAP_PROFILE.scopes,
           }),
         ).resolves.toEqual({ ok: true });
-        persistDevicePairingStoreState(
+        seedDevicePairingStoreState(
           {
             pendingById: {},
             pairedByDeviceId: {
@@ -297,7 +294,6 @@ describe("sendGatewayHello setup completion ordering", () => {
             },
           },
           undefined,
-          "paired",
         );
         const close = vi.fn();
         const context = {
@@ -372,10 +368,9 @@ describe("sendGatewayHello setup completion ordering", () => {
           createdAtMs: 1,
           approvedAtMs: 2,
         };
-        persistDevicePairingStoreState(
+        seedDevicePairingStoreState(
           { pendingById: {}, pairedByDeviceId: { [paired.deviceId]: paired } },
           undefined,
-          "paired",
         );
         const issued = await issueDeviceBootstrapToken({
           profile: PAIRING_SETUP_BOOTSTRAP_PROFILE,

--- a/src/infra/device-pairing-approval.ts
+++ b/src/infra/device-pairing-approval.ts
@@ -10,16 +10,15 @@ import {
   resolveScopeOutsideRequestedRoles,
 } from "../shared/operator-scope-compat.js";
 import {
-  loadDevicePairingState,
   mergeDevicePairingRoles,
   mergeDevicePairingScopes,
+  mutateDevicePairingState,
   preserveDeviceRoleScopes,
   resolveRequestedDeviceRoles,
   sameDevicePairingStringSet,
   withDevicePairingLock,
 } from "./device-pairing-state.js";
-import type { DevicePairingStoreState } from "./device-pairing-store.js";
-import { persistDevicePairingStoreState as persistState } from "./device-pairing-store.js";
+import type { DevicePairingStorePersist, DevicePairingStoreState } from "./device-pairing-store.js";
 import { createDeviceAuthToken, resolveRoleTokenScopes } from "./device-pairing-tokens.js";
 import {
   clearNodePairingGenerationState,
@@ -154,9 +153,9 @@ function commitApprovedDevicePairing(params: {
   state: DevicePairingStoreState;
   requestId: string;
   device: PairedDevice;
-  baseDir?: string;
+  persist: DevicePairingStorePersist;
 }): Extract<ApproveDevicePairingResult, { status: "approved" }> {
-  const { state, requestId, device, baseDir } = params;
+  const { state, requestId, device, persist } = params;
   const existing = state.pairedByDeviceId[device.deviceId];
   // The approved device preserves nodeSurface by reference, so capture its
   // generation before cleanup mutates generation-owned fields.
@@ -169,9 +168,7 @@ function commitApprovedDevicePairing(params: {
   const installationIdentityChanged = Boolean(existing && existing.publicKey !== device.publicKey);
   delete state.pendingById[requestId];
   state.pairedByDeviceId[device.deviceId] = device;
-  persistState(
-    state,
-    baseDir,
+  persist(
     "both",
     installationIdentityChanged ? { clearApnsNodeIds: [device.deviceId] } : undefined,
   );
@@ -282,117 +279,118 @@ async function approveDevicePairingWithOptions(
   baseDir?: string,
 ): Promise<ApproveDevicePairingResult> {
   return await withDevicePairingLock(async () => {
-    const state = await loadDevicePairingState(baseDir);
-    const pendingRecord = state.pendingById[requestId];
-    if (!pendingRecord) {
-      return null;
-    }
-    const autoApproveScopes = options?.autoApproveNewDeviceScopes;
-    const requestedRoles = resolveRequestedDeviceRoles(pendingRecord);
-    const knownDevice = state.pairedByDeviceId[pendingRecord.deviceId];
-    // Trusted-proxy connects carry an SSO-authenticated user, and the connect
-    // handshake has already proven possession of the pending public key. A
-    // matching key on the paired record is therefore the same physical device
-    // re-requesting (typically a scope upgrade) and may auto-approve; a key
-    // mismatch is a real repair — possibly a deviceId squat — and stays a
-    // manual owner decision.
-    const trustedProxySameKeyDevice =
-      options?.approvedVia === "trusted-proxy" &&
-      knownDevice !== undefined &&
-      knownDevice.publicKey === pendingRecord.publicKey;
-    if (
-      autoApproveScopes &&
-      (((pendingRecord.isRepair || knownDevice) && !trustedProxySameKeyDevice) ||
-        !sameDevicePairingStringSet(requestedRoles, [OPERATOR_ROLE]))
-    ) {
-      return null;
-    }
-    const pending = autoApproveScopes
-      ? { ...pendingRecord, scopes: [...autoApproveScopes] }
-      : pendingRecord;
-    const requestedScopes = normalizeDeviceAuthScopes(pending.scopes);
-    const roleMismatchScope = resolveScopeOutsideRequestedRoles({
-      requestedRoles,
-      requestedScopes,
-    });
-    if (roleMismatchScope) {
-      return {
-        status: "forbidden",
-        reason: "scope-outside-requested-roles",
-        scope: roleMismatchScope,
-      };
-    }
-    const now = Date.now();
-    const existing = state.pairedByDeviceId[pending.deviceId];
-    const roles = mergeDevicePairingRoles(
-      existing?.roles,
-      existing?.role,
-      pending.roles,
-      pending.role,
-    );
-    const approvedScopes = mergeDevicePairingScopes(
-      existing?.approvedScopes ?? existing?.scopes,
-      pending.scopes,
-    );
-    const tokens = existing?.tokens ? { ...existing.tokens } : {};
-    const nextTokenScopesByRole = new Map<string, string[]>();
-    for (const roleForToken of requestedRoles) {
-      const existingToken = tokens[roleForToken];
-      const nextScopes = resolveApprovedTokenScopes({
-        role: roleForToken,
-        pending,
-        existingToken,
-        approvedScopes,
-        existing,
+    return mutateDevicePairingState(baseDir, (state, persist) => {
+      const pendingRecord = state.pendingById[requestId];
+      if (!pendingRecord) {
+        return null;
+      }
+      const autoApproveScopes = options?.autoApproveNewDeviceScopes;
+      const requestedRoles = resolveRequestedDeviceRoles(pendingRecord);
+      const knownDevice = state.pairedByDeviceId[pendingRecord.deviceId];
+      // Trusted-proxy connects carry an SSO-authenticated user, and the connect
+      // handshake has already proven possession of the pending public key. A
+      // matching key on the paired record is therefore the same physical device
+      // re-requesting (typically a scope upgrade) and may auto-approve; a key
+      // mismatch is a real repair — possibly a deviceId squat — and stays a
+      // manual owner decision.
+      const trustedProxySameKeyDevice =
+        options?.approvedVia === "trusted-proxy" &&
+        knownDevice !== undefined &&
+        knownDevice.publicKey === pendingRecord.publicKey;
+      if (
+        autoApproveScopes &&
+        (((pendingRecord.isRepair || knownDevice) && !trustedProxySameKeyDevice) ||
+          !sameDevicePairingStringSet(requestedRoles, [OPERATOR_ROLE]))
+      ) {
+        return null;
+      }
+      const pending = autoApproveScopes
+        ? { ...pendingRecord, scopes: [...autoApproveScopes] }
+        : pendingRecord;
+      const requestedScopes = normalizeDeviceAuthScopes(pending.scopes);
+      const roleMismatchScope = resolveScopeOutsideRequestedRoles({
+        requestedRoles,
+        requestedScopes,
       });
-      nextTokenScopesByRole.set(roleForToken, nextScopes);
-      if (roleForToken === OPERATOR_ROLE && nextScopes.length > 0) {
-        const callerRequiredScopes =
-          mergeDevicePairingScopes(
-            resolveRoleTokenScopes(roleForToken, pending.scopes),
-            nextScopes,
-          ) ?? nextScopes;
-        if (!options?.callerScopes) {
-          return {
-            status: "forbidden",
-            reason: "caller-scopes-required",
-            scope: callerRequiredScopes[0],
-          };
-        }
-        const missingScope = resolveMissingRequestedScope({
-          role: OPERATOR_ROLE,
-          requestedScopes: callerRequiredScopes,
-          allowedScopes: options.callerScopes,
+      if (roleMismatchScope) {
+        return {
+          status: "forbidden",
+          reason: "scope-outside-requested-roles",
+          scope: roleMismatchScope,
+        };
+      }
+      const now = Date.now();
+      const existing = state.pairedByDeviceId[pending.deviceId];
+      const roles = mergeDevicePairingRoles(
+        existing?.roles,
+        existing?.role,
+        pending.roles,
+        pending.role,
+      );
+      const approvedScopes = mergeDevicePairingScopes(
+        existing?.approvedScopes ?? existing?.scopes,
+        pending.scopes,
+      );
+      const tokens = existing?.tokens ? { ...existing.tokens } : {};
+      const nextTokenScopesByRole = new Map<string, string[]>();
+      for (const roleForToken of requestedRoles) {
+        const existingToken = tokens[roleForToken];
+        const nextScopes = resolveApprovedTokenScopes({
+          role: roleForToken,
+          pending,
+          existingToken,
+          approvedScopes,
+          existing,
         });
-        if (missingScope) {
-          return { status: "forbidden", reason: "caller-missing-scope", scope: missingScope };
+        nextTokenScopesByRole.set(roleForToken, nextScopes);
+        if (roleForToken === OPERATOR_ROLE && nextScopes.length > 0) {
+          const callerRequiredScopes =
+            mergeDevicePairingScopes(
+              resolveRoleTokenScopes(roleForToken, pending.scopes),
+              nextScopes,
+            ) ?? nextScopes;
+          if (!options?.callerScopes) {
+            return {
+              status: "forbidden",
+              reason: "caller-scopes-required",
+              scope: callerRequiredScopes[0],
+            };
+          }
+          const missingScope = resolveMissingRequestedScope({
+            role: OPERATOR_ROLE,
+            requestedScopes: callerRequiredScopes,
+            allowedScopes: options.callerScopes,
+          });
+          if (missingScope) {
+            return { status: "forbidden", reason: "caller-missing-scope", scope: missingScope };
+          }
         }
       }
-    }
-    for (const [roleForToken, nextScopes] of nextTokenScopesByRole) {
-      const existingToken = tokens[roleForToken];
-      const tokenNow = Date.now();
-      tokens[roleForToken] = {
-        token: generatePairingToken(),
-        role: roleForToken,
-        scopes: nextScopes,
-        createdAtMs: existingToken?.createdAtMs ?? tokenNow,
-        rotatedAtMs: existingToken ? tokenNow : undefined,
-        revokedAtMs: undefined,
-        lastUsedAtMs: existingToken?.lastUsedAtMs,
-      };
-    }
-    const device = buildApprovedPairedDevice({
-      pending,
-      existing,
-      roles,
-      approvedScopes,
-      tokens,
-      now,
-      approvedVia: options?.approvedVia ?? "owner",
-      accessMetadata: options?.accessMetadata,
+      for (const [roleForToken, nextScopes] of nextTokenScopesByRole) {
+        const existingToken = tokens[roleForToken];
+        const tokenNow = Date.now();
+        tokens[roleForToken] = {
+          token: generatePairingToken(),
+          role: roleForToken,
+          scopes: nextScopes,
+          createdAtMs: existingToken?.createdAtMs ?? tokenNow,
+          rotatedAtMs: existingToken ? tokenNow : undefined,
+          revokedAtMs: undefined,
+          lastUsedAtMs: existingToken?.lastUsedAtMs,
+        };
+      }
+      const device = buildApprovedPairedDevice({
+        pending,
+        existing,
+        roles,
+        approvedScopes,
+        tokens,
+        now,
+        approvedVia: options?.approvedVia ?? "owner",
+        accessMetadata: options?.accessMetadata,
+      });
+      return commitApprovedDevicePairing({ state, requestId, device, persist });
     });
-    return commitApprovedDevicePairing({ state, requestId, device, baseDir });
   });
 }
 
@@ -422,77 +420,78 @@ export async function approveBootstrapDevicePairing(
   const approvedRoles = mergeDevicePairingRoles(bootstrapProfile.roles) ?? [];
   const approvedScopes = resolveDeviceProfileScopes(bootstrapProfile, approvedRoles);
   return await withDevicePairingLock(async () => {
-    const state = await loadDevicePairingState(baseDir);
-    const pending = state.pendingById[requestId];
-    if (!pending) {
-      return null;
-    }
-    const requestedRoles = resolveRequestedDeviceRoles(pending);
-    const missingRole = requestedRoles.find((role) => !approvedRoles.includes(role));
-    if (missingRole) {
-      return { status: "forbidden", reason: "bootstrap-role-not-allowed", role: missingRole };
-    }
-    const requestedOperatorScopes = normalizeDeviceAuthScopes(pending.scopes).filter((scope) =>
-      scope.startsWith(OPERATOR_SCOPE_PREFIX),
-    );
-    const missingScope = resolveMissingRequestedScope({
-      role: OPERATOR_ROLE,
-      requestedScopes: requestedOperatorScopes,
-      allowedScopes: approvedScopes,
-    });
-    if (missingScope) {
-      return { status: "forbidden", reason: "bootstrap-scope-not-allowed", scope: missingScope };
-    }
-
-    const now = Date.now();
-    const existing = state.pairedByDeviceId[pending.deviceId];
-    const grantedRoles = requestedRoles;
-    const grantedScopes = resolveDeviceProfileScopes(
-      bootstrapProfile,
-      grantedRoles,
-      pending.scopes ?? [],
-    );
-    const grantedRoleSet = new Set(grantedRoles);
-    const preservedExistingScopes = (
-      mergeDevicePairingRoles(existing?.roles, existing?.role) ?? []
-    ).flatMap((existingRole) =>
-      grantedRoleSet.has(existingRole)
-        ? []
-        : preserveDeviceRoleScopes(existingRole, existing?.approvedScopes ?? existing?.scopes),
-    );
-    const roles = mergeDevicePairingRoles(
-      existing?.roles,
-      existing?.role,
-      pending.roles,
-      pending.role,
-    );
-    const nextApprovedScopes = mergeDevicePairingScopes(preservedExistingScopes, grantedScopes);
-    const tokens = existing?.tokens ? { ...existing.tokens } : {};
-    for (const roleForToken of grantedRoles) {
-      const existingToken = tokens[roleForToken];
-      const tokenScopes =
-        roleForToken === OPERATOR_ROLE
-          ? resolveDeviceProfileRoleScopes(bootstrapProfile, roleForToken, grantedScopes)
-          : [];
-      tokens[roleForToken] = createDeviceAuthToken({
-        role: roleForToken,
-        scopes: tokenScopes,
-        existing: existingToken,
-        now,
-        ...(existingToken ? { rotatedAtMs: now } : {}),
+    return mutateDevicePairingState(baseDir, (state, persist) => {
+      const pending = state.pendingById[requestId];
+      if (!pending) {
+        return null;
+      }
+      const requestedRoles = resolveRequestedDeviceRoles(pending);
+      const missingRole = requestedRoles.find((role) => !approvedRoles.includes(role));
+      if (missingRole) {
+        return { status: "forbidden", reason: "bootstrap-role-not-allowed", role: missingRole };
+      }
+      const requestedOperatorScopes = normalizeDeviceAuthScopes(pending.scopes).filter((scope) =>
+        scope.startsWith(OPERATOR_SCOPE_PREFIX),
+      );
+      const missingScope = resolveMissingRequestedScope({
+        role: OPERATOR_ROLE,
+        requestedScopes: requestedOperatorScopes,
+        allowedScopes: approvedScopes,
       });
-    }
+      if (missingScope) {
+        return { status: "forbidden", reason: "bootstrap-scope-not-allowed", scope: missingScope };
+      }
 
-    const device = buildApprovedPairedDevice({
-      pending,
-      existing,
-      roles,
-      approvedScopes: nextApprovedScopes,
-      tokens,
-      now,
-      approvedVia: "bootstrap",
-      accessMetadata: options?.accessMetadata,
+      const now = Date.now();
+      const existing = state.pairedByDeviceId[pending.deviceId];
+      const grantedRoles = requestedRoles;
+      const grantedScopes = resolveDeviceProfileScopes(
+        bootstrapProfile,
+        grantedRoles,
+        pending.scopes ?? [],
+      );
+      const grantedRoleSet = new Set(grantedRoles);
+      const preservedExistingScopes = (
+        mergeDevicePairingRoles(existing?.roles, existing?.role) ?? []
+      ).flatMap((existingRole) =>
+        grantedRoleSet.has(existingRole)
+          ? []
+          : preserveDeviceRoleScopes(existingRole, existing?.approvedScopes ?? existing?.scopes),
+      );
+      const roles = mergeDevicePairingRoles(
+        existing?.roles,
+        existing?.role,
+        pending.roles,
+        pending.role,
+      );
+      const nextApprovedScopes = mergeDevicePairingScopes(preservedExistingScopes, grantedScopes);
+      const tokens = existing?.tokens ? { ...existing.tokens } : {};
+      for (const roleForToken of grantedRoles) {
+        const existingToken = tokens[roleForToken];
+        const tokenScopes =
+          roleForToken === OPERATOR_ROLE
+            ? resolveDeviceProfileRoleScopes(bootstrapProfile, roleForToken, grantedScopes)
+            : [];
+        tokens[roleForToken] = createDeviceAuthToken({
+          role: roleForToken,
+          scopes: tokenScopes,
+          existing: existingToken,
+          now,
+          ...(existingToken ? { rotatedAtMs: now } : {}),
+        });
+      }
+
+      const device = buildApprovedPairedDevice({
+        pending,
+        existing,
+        roles,
+        approvedScopes: nextApprovedScopes,
+        tokens,
+        now,
+        approvedVia: "bootstrap",
+        accessMetadata: options?.accessMetadata,
+      });
+      return commitApprovedDevicePairing({ state, requestId, device, persist });
     });
-    return commitApprovedDevicePairing({ state, requestId, device, baseDir });
   });
 }

--- a/src/infra/device-pairing-node-facts.ts
+++ b/src/infra/device-pairing-node-facts.ts
@@ -1,7 +1,7 @@
+import { withDevicePairingLock } from "./device-pairing-state.js";
 import { updatePairedDeviceNodeSurfaceInTransaction } from "./device-pairing-store.js";
 import {
   resolveNodePairingGeneration,
-  withPairedDeviceRecords,
   type NodePairingGeneration,
   type PairedDevice,
 } from "./device-pairing.js";
@@ -15,8 +15,8 @@ async function updatePairedNodeGenerationSurface(params: {
   update: (surface: NodeSurface) => NodeSurface;
   baseDir?: string;
 }): Promise<boolean> {
-  return await withPairedDeviceRecords<boolean>(params.baseDir, () => {
-    const value = updatePairedDeviceNodeSurfaceInTransaction<boolean>(
+  return await withDevicePairingLock(async () => {
+    return updatePairedDeviceNodeSurfaceInTransaction<boolean>(
       params.nodeId,
       params.baseDir,
       (device) => {
@@ -36,9 +36,6 @@ async function updatePairedNodeGenerationSurface(params: {
         };
       },
     );
-    // The row transaction validates durable generation ownership; the shared
-    // lock also prevents a local full-snapshot writer from replaying old facts.
-    return { value, persist: false };
   });
 }
 

--- a/src/infra/device-pairing-node.test.ts
+++ b/src/infra/device-pairing-node.test.ts
@@ -21,12 +21,13 @@ import {
   requestNodePairing,
   reusePendingNodePairingForReconnect,
 } from "./device-pairing-node.js";
+import { withDevicePairingLock } from "./device-pairing-state.js";
+import { updatePairedDeviceNodeSurfaceInTransaction } from "./device-pairing-store.js";
 import {
   getPairedDevice,
   listDevicePairingReadOnly,
   requestDevicePairing,
   resolveNodePairingGeneration,
-  withPairedDeviceRecords,
 } from "./device-pairing.js";
 
 const tempDirs = createSuiteTempRootTracker({ prefix: "openclaw-node-pairing-" });
@@ -667,14 +668,13 @@ describe("node surface approvals", () => {
       if (!generation) {
         throw new Error("expected node pairing generation");
       }
-      const snapshotLoaded = createDeferred();
-      const releaseMutation = createDeferred();
-      const lockedMutation = withPairedDeviceRecords(baseDir, async () => {
-        snapshotLoaded.resolve();
-        await releaseMutation.promise;
-        return { value: undefined, persist: false };
+      const lockHeld = createDeferred();
+      const releaseLock = createDeferred();
+      const lockedMutation = withDevicePairingLock(async () => {
+        lockHeld.resolve();
+        await releaseLock.promise;
       });
-      await snapshotLoaded.promise;
+      await lockHeld.promise;
 
       let connectionCurrent = true;
       const publication = updatePairedNodeSessionHost({
@@ -685,7 +685,7 @@ describe("node surface approvals", () => {
         baseDir,
       });
       connectionCurrent = false;
-      releaseMutation.resolve();
+      releaseLock.resolve();
 
       await lockedMutation;
       await expect(publication).resolves.toBe(false);
@@ -860,19 +860,28 @@ describe("node surface approvals", () => {
     await withNodePairingDir(async (baseDir) => {
       await setupPairedNode(baseDir);
 
-      const snapshotLoaded = createDeferred();
-      const releaseMutation = createDeferred();
-      const lockedMutation = withPairedDeviceRecords(baseDir, async (pairedByDeviceId) => {
-        const device = pairedByDeviceId["node-1"];
-        if (!device?.nodeSurface) {
-          throw new Error("expected paired node surface");
-        }
-        device.nodeSurface = { ...device.nodeSurface, bins: ["ffmpeg"] };
-        snapshotLoaded.resolve();
-        await releaseMutation.promise;
-        return { value: true, persist: true };
+      const lockHeld = createDeferred();
+      const releaseLock = createDeferred();
+      const lockedMutation = withDevicePairingLock(async () => {
+        const updated = updatePairedDeviceNodeSurfaceInTransaction<boolean>(
+          "node-1",
+          baseDir,
+          (device) => {
+            if (!device?.nodeSurface) {
+              throw new Error("expected paired node surface");
+            }
+            return {
+              value: true,
+              persist: true,
+              nodeSurface: { ...device.nodeSurface, bins: ["ffmpeg"] },
+            };
+          },
+        );
+        lockHeld.resolve();
+        await releaseLock.promise;
+        return updated;
       });
-      await snapshotLoaded.promise;
+      await lockHeld.promise;
 
       let connectionSettled = false;
       const connection = recordPairedNodeConnection("node-1", 1_234, baseDir).then((result) => {
@@ -882,7 +891,7 @@ describe("node surface approvals", () => {
       await Promise.resolve();
       expect(connectionSettled).toBe(false);
 
-      releaseMutation.resolve();
+      releaseLock.resolve();
       await expect(lockedMutation).resolves.toBe(true);
       await expect(connection).resolves.toEqual({ recorded: true, firstConnection: true });
       expect(await findPairedNode("node-1", baseDir)).toMatchObject({

--- a/src/infra/device-pairing-node.ts
+++ b/src/infra/device-pairing-node.ts
@@ -4,6 +4,7 @@
 import { randomUUID } from "node:crypto";
 import { normalizeArrayBackedTrimmedStringList } from "@openclaw/normalization-core/string-normalization";
 import { resolveMissingRequestedScope } from "../shared/operator-scope-compat.js";
+import { readPairedDeviceRecords, withDevicePairingLock } from "./device-pairing-state.js";
 import { updatePairedDeviceNodeSurfaceInTransaction } from "./device-pairing-store.js";
 import {
   clearNodePairingGenerationState,
@@ -347,12 +348,9 @@ export async function listNodePairing(
   baseDir?: string,
   options?: { includePairingGeneration?: boolean },
 ): Promise<NodePairingList | NodePairingListWithGeneration> {
-  return await withPairedDeviceRecords(baseDir, (pairedByDeviceId) => {
-    return {
-      value: projectNodePairing(Object.values(pairedByDeviceId), options),
-      persist: false,
-    };
-  });
+  return await readPairedDeviceRecords(baseDir, (pairedByDeviceId) =>
+    projectNodePairing(Object.values(pairedByDeviceId), options),
+  );
 }
 
 /** Project node pairing state from an already-loaded device pairing snapshot. */
@@ -384,15 +382,12 @@ export async function beginNodePairingConnect(
   pairedNode: PairedDeviceNode | null;
   cleanupClaim?: NodePairingCleanupClaim;
 }> {
-  return await withPairedDeviceRecords<{
-    pairedNode: PairedDeviceNode | null;
-    cleanupClaim?: NodePairingCleanupClaim;
-  }>(baseDir, (pairedByDeviceId) => {
+  return await readPairedDeviceRecords(baseDir, (pairedByDeviceId) => {
     const device = nodeSurfaceDevice(pairedByDeviceId, nodeId);
     const pairedNode = device ? toPairedNode(device) : null;
     const pending = device?.pendingNodeSurface;
     if (!device || !pairedNode || !pending) {
-      return { value: { pairedNode }, persist: false };
+      return { pairedNode };
     }
     const claim: NodePairingCleanupClaim = {
       baseDir,
@@ -401,7 +396,7 @@ export async function beginNodePairingConnect(
       observed: toPendingSnapshot(device, pending),
     };
     addCleanupClaim(claim);
-    return { value: { pairedNode, cleanupClaim: claim }, persist: false };
+    return { pairedNode, cleanupClaim: claim };
   });
 }
 
@@ -493,7 +488,7 @@ export async function reusePendingNodePairingForReconnect(
   baseDir?: string,
 ): Promise<RequestNodePairingResult | null> {
   const nodeId = normalizeNodeId(req.nodeId);
-  return await withPairedDeviceRecords(baseDir, (pairedByDeviceId) => {
+  return await readPairedDeviceRecords(baseDir, (pairedByDeviceId) => {
     const device = nodeSurfaceDevice(pairedByDeviceId, nodeId);
     const pending = device?.pendingNodeSurface;
     if (
@@ -508,15 +503,12 @@ export async function reusePendingNodePairingForReconnect(
         invalidateCleanupClaimsThrough(cleanupClaim, device, pending);
       }
       return {
-        value: {
-          status: "pending" as const,
-          request: toPublicPendingRequest(device, pending),
-          created: false,
-        },
-        persist: false,
+        status: "pending" as const,
+        request: toPublicPendingRequest(device, pending),
+        created: false,
       };
     }
-    return { value: null, persist: false };
+    return null;
   });
 }
 
@@ -629,12 +621,12 @@ export async function getPendingNodePairing(
   requestId: string,
   baseDir?: string,
 ): Promise<{ requestId: string; nodeId: string } | null> {
-  return await withPairedDeviceRecords(baseDir, (pairedByDeviceId) => {
+  return await readPairedDeviceRecords(baseDir, (pairedByDeviceId) => {
     const device = findPendingNodePairingDevice(pairedByDeviceId, requestId);
     if (!device?.pendingNodeSurface) {
-      return { value: null, persist: false };
+      return null;
     }
-    return { value: { requestId, nodeId: device.deviceId }, persist: false };
+    return { requestId, nodeId: device.deviceId };
   });
 }
 
@@ -649,8 +641,8 @@ export async function recordPairedNodeConnection(
   baseDir?: string,
   expectedPairingGeneration?: NodePairingGeneration,
 ): Promise<RecordPairedNodeConnectionResult> {
-  return await withPairedDeviceRecords<RecordPairedNodeConnectionResult>(baseDir, () => {
-    const value = updatePairedDeviceNodeSurfaceInTransaction<RecordPairedNodeConnectionResult>(
+  return await withDevicePairingLock(async () => {
+    return updatePairedDeviceNodeSurfaceInTransaction<RecordPairedNodeConnectionResult>(
       nodeId,
       baseDir,
       (device) => {
@@ -685,10 +677,6 @@ export async function recordPairedNodeConnection(
         };
       },
     );
-    // The row-scoped transaction owns cross-process generation validation, while
-    // this outer shared lock prevents local full-snapshot writers from replaying
-    // node-surface state loaded before the connection metadata commit.
-    return { value, persist: false };
   });
 }
 
@@ -702,8 +690,8 @@ export async function recordPairedNodeDisconnection(params: {
   expectedPairingGeneration: NodePairingGeneration;
   baseDir?: string;
 }): Promise<RecordPairedNodeDisconnectionResult> {
-  return await withPairedDeviceRecords<RecordPairedNodeDisconnectionResult>(params.baseDir, () => {
-    const value = updatePairedDeviceNodeSurfaceInTransaction<RecordPairedNodeDisconnectionResult>(
+  return await withDevicePairingLock(async () => {
+    return updatePairedDeviceNodeSurfaceInTransaction<RecordPairedNodeDisconnectionResult>(
       params.nodeId,
       params.baseDir,
       (device) => {
@@ -730,9 +718,6 @@ export async function recordPairedNodeDisconnection(params: {
         };
       },
     );
-    // The row-scoped transaction owns cross-process generation and connection
-    // validation; the shared lock prevents stale full-snapshot replay.
-    return { value, persist: false };
   });
 }
 

--- a/src/infra/device-pairing-prune.test.ts
+++ b/src/infra/device-pairing-prune.test.ts
@@ -3,11 +3,11 @@ import { afterAll, beforeAll, describe, expect, test } from "vitest";
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
 import { createSuiteTempRootTracker } from "../test-helpers/temp-dir.js";
 import { approveBootstrapDevicePairing, approveDevicePairing } from "./device-pairing-approval.js";
+import { pruneSupersededSilentPairedDevices } from "./device-pairing-prune.js";
 import {
   getPairedDevice,
   hasPairedCardRenderer,
   listDevicePairing,
-  pruneSupersededSilentPairedDevices,
   requestDevicePairing,
   withPairedDeviceRecords,
 } from "./device-pairing.js";

--- a/src/infra/device-pairing-prune.ts
+++ b/src/infra/device-pairing-prune.ts
@@ -1,0 +1,106 @@
+import {
+  mutateDevicePairingState,
+  normalizeDevicePairingId,
+  withDevicePairingLock,
+} from "./device-pairing-state.js";
+import {
+  invalidatePairedCardRendererCache,
+  listApprovedPairedDeviceRoles,
+  type PairedDevice,
+} from "./device-pairing.js";
+
+// Silent pairings from the same client software on the same host mint a fresh
+// deviceId whenever their state dir (and thus keypair) is ephemeral. The cluster
+// key groups those records so a replacement pairing can retire its predecessors.
+function silentPairingClusterKey(
+  device: Pick<PairedDevice, "clientId" | "clientMode" | "displayName">,
+): string | null {
+  const clientId = device.clientId?.trim().toLowerCase() ?? "";
+  const clientMode = device.clientMode?.trim().toLowerCase() ?? "";
+  const displayName = device.displayName?.trim().toLowerCase() ?? "";
+  if (!clientId && !clientMode && !displayName) {
+    return null;
+  }
+  return `${clientId}\0${clientMode}\0${displayName}`;
+}
+
+/** Superseded silent pairing removed in favor of a newer record for the same client. */
+export type PrunedSupersededPairedDevice = {
+  deviceId: string;
+  roles: string[];
+};
+
+// A concurrently approved sibling may still be mid-handshake and not yet visible
+// to the connected-clients check; freshly approved records are never prune
+// candidates so parallel silent pairings cannot delete each other's rows.
+const PRUNE_RECENT_APPROVAL_GRACE_MS = 60_000;
+
+/**
+ * Remove silent-approved sibling records superseded by a newly approved silent
+ * pairing of the same client cluster. Only records whose latest approval was
+ * same-host local ("silent") are eligible, as anchor and as victim: local
+ * clients re-pair silently by construction and share the gateway host, so the
+ * metadata cluster key cannot match a different machine. Currently connected
+ * devices are skipped so concurrent sessions with distinct state dirs keep
+ * their tokens while live.
+ */
+export async function pruneSupersededSilentPairedDevices(params: {
+  deviceId: string;
+  baseDir?: string;
+  isDeviceConnected?: (deviceId: string) => boolean;
+  nowMs?: number;
+}): Promise<PrunedSupersededPairedDevice[]> {
+  return await withDevicePairingLock(async () => {
+    const removedDevices = mutateDevicePairingState(params.baseDir, (state, persist) => {
+      const anchor = state.pairedByDeviceId[normalizeDevicePairingId(params.deviceId)];
+      if (!anchor || anchor.approvedVia !== "silent") {
+        return [];
+      }
+      const anchorKey = silentPairingClusterKey(anchor);
+      if (!anchorKey) {
+        return [];
+      }
+      const nowMs = params.nowMs ?? Date.now();
+      const removed: PrunedSupersededPairedDevice[] = [];
+      for (const device of Object.values(state.pairedByDeviceId)) {
+        if (device.deviceId === anchor.deviceId) {
+          continue;
+        }
+        // Legacy records without approvedVia stay untouched (fail-safe).
+        if (device.approvedVia !== "silent") {
+          continue;
+        }
+        if (silentPairingClusterKey(device) !== anchorKey) {
+          continue;
+        }
+        if (nowMs - device.approvedAtMs < PRUNE_RECENT_APPROVAL_GRACE_MS) {
+          continue;
+        }
+        if (params.isDeviceConnected?.(device.deviceId)) {
+          continue;
+        }
+        delete state.pairedByDeviceId[device.deviceId];
+        for (const [requestId, pending] of Object.entries(state.pendingById)) {
+          if (pending.deviceId === device.deviceId) {
+            delete state.pendingById[requestId];
+          }
+        }
+        removed.push({
+          deviceId: device.deviceId,
+          roles: listApprovedPairedDeviceRoles(device),
+        });
+      }
+      if (removed.length === 0) {
+        return [];
+      }
+      persist("both", {
+        clearApnsNodeIds: removed.map((entry) => entry.deviceId),
+      });
+      return removed;
+    });
+    if (removedDevices.length > 0) {
+      invalidatePairedCardRendererCache();
+    }
+    return removedDevices;
+  });
+}

--- a/src/infra/device-pairing-state.ts
+++ b/src/infra/device-pairing-state.ts
@@ -4,6 +4,8 @@ import { normalizeUniqueSingleOrTrimmedStringList } from "@openclaw/normalizatio
 import { loadDevicePairingStoreStateReadOnly } from "./device-pairing-store-readonly.js";
 import {
   loadDevicePairingStoreState,
+  mutateDevicePairingStoreStateInTransaction,
+  type DevicePairingStorePersist,
   type DevicePairingStoreState,
 } from "./device-pairing-store.js";
 import type { DeviceAuthToken, PairedDevice } from "./device-pairing.types.js";
@@ -34,6 +36,26 @@ export async function loadDevicePairingState(baseDir?: string): Promise<DevicePa
   const state = loadDevicePairingStoreState(baseDir);
   pruneExpiredPairingState(state);
   return state;
+}
+
+export async function readPairedDeviceRecords<T>(
+  baseDir: string | undefined,
+  read: (pairedByDeviceId: Record<string, PairedDevice>) => T,
+): Promise<T> {
+  return await withLock(async () => {
+    const state = await loadDevicePairingState(baseDir);
+    return read(state.pairedByDeviceId);
+  });
+}
+
+export function mutateDevicePairingState<T>(
+  baseDir: string | undefined,
+  mutate: (state: DevicePairingStoreState, persist: DevicePairingStorePersist) => T,
+): T {
+  return mutateDevicePairingStoreStateInTransaction(baseDir, (state, persist) => {
+    pruneExpiredPairingState(state);
+    return mutate(state, persist);
+  });
 }
 
 /** Load one read-only pairing snapshot with expired pending state removed. */

--- a/src/infra/device-pairing-store-rows.ts
+++ b/src/infra/device-pairing-store-rows.ts
@@ -50,6 +50,7 @@ export function toJsonColumn(value: unknown): string | null {
 
 // oxlint-disable-next-line typescript/no-unnecessary-type-parameters -- Persisted JSON columns are typed by the receiving field.
 function fromJsonColumn<T>(value: string | null): T | undefined {
+  // SAFETY: persisted JSON columns are serialized from the receiving field's type.
   return value === null ? undefined : (JSON.parse(value) as T);
 }
 
@@ -60,6 +61,7 @@ function toBooleanColumn(value: boolean | undefined): number | null {
 // Column null means the optional record key was absent; keep it absent on read
 // so records round-trip byte-identical to the retired JSON store.
 function optional<K extends string, V>(key: K, value: V | null): { [P in K]?: V } {
+  // SAFETY: the computed property is exactly the literal key K with value V.
   return value === null ? {} : ({ [key]: value } as { [P in K]: V });
 }
 
@@ -135,6 +137,7 @@ export function toPairedRow(device: PairedDevice): DevicePairingPaired {
 }
 
 function fromApprovedViaColumn(value: string | null): PairedDeviceApprovalKind | null {
+  // SAFETY: APPROVAL_KINDS membership proves the stored string is an approval kind.
   return value !== null && APPROVAL_KINDS.has(value) ? (value as PairedDeviceApprovalKind) : null;
 }
 
@@ -149,6 +152,7 @@ const PAIRING_SETUP_ACCESS_MEMBERS = {
 const PAIRING_SETUP_ACCESS_VALUES = new Set(Object.keys(PAIRING_SETUP_ACCESS_MEMBERS));
 
 function fromSetupCompletionAccessColumn(value: string): PairingSetupAccess {
+  // SAFETY: PAIRING_SETUP_ACCESS_VALUES membership proves the stored access level.
   return PAIRING_SETUP_ACCESS_VALUES.has(value) ? (value as PairingSetupAccess) : "limited";
 }
 

--- a/src/infra/device-pairing-store-rows.ts
+++ b/src/infra/device-pairing-store-rows.ts
@@ -1,0 +1,251 @@
+import type { PairingSetupAccess } from "../shared/device-bootstrap-profile.js";
+import type {
+  DevicePairingPaired,
+  DevicePairingPending,
+  DeviceBootstrapTokens,
+  DevicePairSetupCompletions,
+} from "../state/openclaw-state-db.generated.js";
+import type {
+  DeviceAuthToken,
+  DeviceBootstrapTokenRecord,
+  DevicePairingPendingRecord,
+  DevicePairSetupCompletionRecord,
+  PairedDevice,
+  PairedDeviceApprovalKind,
+  PairedDeviceNodeSurface,
+  PairedDevicePendingNodeSurface,
+} from "./device-pairing.types.js";
+
+export const DEVICE_BOOTSTRAP_TOKEN_COLUMNS_WITHOUT_SETUP = [
+  "device_id",
+  "issued_at_ms",
+  "last_used_at_ms",
+  "pending_profile_json",
+  "profile_json",
+  "public_key",
+  "redeemed_profile_json",
+  "token",
+  "token_key",
+  "ts",
+] as const satisfies readonly (keyof DeviceBootstrapTokens)[];
+
+// Read-back allowlist for the approved_via column. The Record type forces
+// every PairedDeviceApprovalKind to appear here at compile time: omit one and
+// this object is a type error, instead of the stored provenance silently
+// dropping to undefined on load (which mergeApprovalKind treats as a legacy
+// record). Keep this in sync when adding an approval kind.
+const APPROVAL_KIND_MEMBERS = {
+  owner: true,
+  silent: true,
+  "trusted-cidr": true,
+  "trusted-proxy": true,
+  "ssh-verified": true,
+  bootstrap: true,
+} satisfies Record<PairedDeviceApprovalKind, true>;
+const APPROVAL_KINDS = new Set(Object.keys(APPROVAL_KIND_MEMBERS));
+
+export function toJsonColumn(value: unknown): string | null {
+  return value === undefined ? null : JSON.stringify(value);
+}
+
+// oxlint-disable-next-line typescript/no-unnecessary-type-parameters -- Persisted JSON columns are typed by the receiving field.
+function fromJsonColumn<T>(value: string | null): T | undefined {
+  return value === null ? undefined : (JSON.parse(value) as T);
+}
+
+function toBooleanColumn(value: boolean | undefined): number | null {
+  return value === undefined ? null : value ? 1 : 0;
+}
+
+// Column null means the optional record key was absent; keep it absent on read
+// so records round-trip byte-identical to the retired JSON store.
+function optional<K extends string, V>(key: K, value: V | null): { [P in K]?: V } {
+  return value === null ? {} : ({ [key]: value } as { [P in K]: V });
+}
+
+export function toPendingRow(record: DevicePairingPendingRecord): DevicePairingPending {
+  return {
+    request_id: record.requestId,
+    device_id: record.deviceId,
+    public_key: record.publicKey,
+    display_name: record.displayName ?? null,
+    platform: record.platform ?? null,
+    device_family: record.deviceFamily ?? null,
+    client_id: record.clientId ?? null,
+    client_mode: record.clientMode ?? null,
+    browser_origin: record.browserOrigin ?? null,
+    role: record.role ?? null,
+    roles_json: toJsonColumn(record.roles),
+    scopes_json: toJsonColumn(record.scopes),
+    remote_ip: record.remoteIp ?? null,
+    silent: toBooleanColumn(record.silent),
+    is_repair: toBooleanColumn(record.isRepair),
+    ts: record.ts,
+    refreshed_at_ms: record.refreshedAtMs ?? null,
+  };
+}
+
+export function fromPendingRow(row: DevicePairingPending): DevicePairingPendingRecord {
+  return {
+    requestId: row.request_id,
+    deviceId: row.device_id,
+    publicKey: row.public_key,
+    ...optional("displayName", row.display_name),
+    ...optional("platform", row.platform),
+    ...optional("deviceFamily", row.device_family),
+    ...optional("clientId", row.client_id),
+    ...optional("clientMode", row.client_mode),
+    ...optional("browserOrigin", row.browser_origin),
+    ...optional("role", row.role),
+    ...optional("roles", fromJsonColumn<string[]>(row.roles_json) ?? null),
+    ...optional("scopes", fromJsonColumn<string[]>(row.scopes_json) ?? null),
+    ...optional("remoteIp", row.remote_ip),
+    ...optional("silent", row.silent === null ? null : row.silent !== 0),
+    ...optional("isRepair", row.is_repair === null ? null : row.is_repair !== 0),
+    ts: row.ts,
+    ...optional("refreshedAtMs", row.refreshed_at_ms),
+  };
+}
+
+export function toPairedRow(device: PairedDevice): DevicePairingPaired {
+  return {
+    device_id: device.deviceId,
+    public_key: device.publicKey,
+    display_name: device.displayName ?? null,
+    operator_label: device.operatorLabel ?? null,
+    platform: device.platform ?? null,
+    device_family: device.deviceFamily ?? null,
+    client_id: device.clientId ?? null,
+    client_mode: device.clientMode ?? null,
+    browser_origin: device.browserOrigin ?? null,
+    role: device.role ?? null,
+    roles_json: toJsonColumn(device.roles),
+    scopes_json: toJsonColumn(device.scopes),
+    approved_scopes_json: toJsonColumn(device.approvedScopes),
+    remote_ip: device.remoteIp ?? null,
+    tokens_json: toJsonColumn(device.tokens),
+    approved_via: device.approvedVia ?? null,
+    node_surface_json: toJsonColumn(device.nodeSurface),
+    pending_node_surface_json: toJsonColumn(device.pendingNodeSurface),
+    created_at_ms: device.createdAtMs,
+    approved_at_ms: device.approvedAtMs,
+    last_seen_at_ms: device.lastSeenAtMs ?? null,
+    last_seen_reason: device.lastSeenReason ?? null,
+  };
+}
+
+function fromApprovedViaColumn(value: string | null): PairedDeviceApprovalKind | null {
+  return value !== null && APPROVAL_KINDS.has(value) ? (value as PairedDeviceApprovalKind) : null;
+}
+
+// Same compile-time exhaustiveness contract as APPROVAL_KIND_MEMBERS: the
+// completion access level is presented to the operator, so an unrecognized
+// stored value must fall back to the least-privilege label, never leak through.
+const PAIRING_SETUP_ACCESS_MEMBERS = {
+  full: true,
+  limited: true,
+  node: true,
+} satisfies Record<PairingSetupAccess, true>;
+const PAIRING_SETUP_ACCESS_VALUES = new Set(Object.keys(PAIRING_SETUP_ACCESS_MEMBERS));
+
+function fromSetupCompletionAccessColumn(value: string): PairingSetupAccess {
+  return PAIRING_SETUP_ACCESS_VALUES.has(value) ? (value as PairingSetupAccess) : "limited";
+}
+
+function fromSetupCompletionDeliveryStateColumn(
+  value: string,
+): DevicePairSetupCompletionRecord["deliveryState"] {
+  return value === "confirmed" ? "confirmed" : "uncertain";
+}
+
+export function fromPairedRow(row: DevicePairingPaired): PairedDevice {
+  return {
+    deviceId: row.device_id,
+    publicKey: row.public_key,
+    ...optional("displayName", row.display_name),
+    ...optional("operatorLabel", row.operator_label),
+    ...optional("platform", row.platform),
+    ...optional("deviceFamily", row.device_family),
+    ...optional("clientId", row.client_id),
+    ...optional("clientMode", row.client_mode),
+    ...optional("browserOrigin", row.browser_origin),
+    ...optional("role", row.role),
+    ...optional("roles", fromJsonColumn<string[]>(row.roles_json) ?? null),
+    ...optional("scopes", fromJsonColumn<string[]>(row.scopes_json) ?? null),
+    ...optional("approvedScopes", fromJsonColumn<string[]>(row.approved_scopes_json) ?? null),
+    ...optional("remoteIp", row.remote_ip),
+    ...optional("tokens", fromJsonColumn<Record<string, DeviceAuthToken>>(row.tokens_json) ?? null),
+    ...optional("approvedVia", fromApprovedViaColumn(row.approved_via)),
+    ...optional(
+      "nodeSurface",
+      fromJsonColumn<PairedDeviceNodeSurface>(row.node_surface_json) ?? null,
+    ),
+    ...optional(
+      "pendingNodeSurface",
+      fromJsonColumn<PairedDevicePendingNodeSurface>(row.pending_node_surface_json) ?? null,
+    ),
+    createdAtMs: row.created_at_ms,
+    approvedAtMs: row.approved_at_ms,
+    ...optional("lastSeenAtMs", row.last_seen_at_ms),
+    ...optional("lastSeenReason", row.last_seen_reason),
+  };
+}
+
+export function toBootstrapRow(
+  tokenKey: string,
+  record: DeviceBootstrapTokenRecord,
+): DeviceBootstrapTokens {
+  return {
+    token_key: tokenKey,
+    token: record.token,
+    setup_id: record.setupId ?? null,
+    ts: record.ts,
+    device_id: record.deviceId ?? null,
+    public_key: record.publicKey ?? null,
+    profile_json: toJsonColumn(record.profile),
+    redeemed_profile_json: toJsonColumn(record.redeemedProfile),
+    pending_profile_json: toJsonColumn(record.pendingProfile),
+    issued_at_ms: record.issuedAtMs,
+    last_used_at_ms: record.lastUsedAtMs ?? null,
+  };
+}
+
+export function fromBootstrapRow(row: DeviceBootstrapTokens): DeviceBootstrapTokenRecord {
+  return {
+    token: row.token,
+    ...optional("setupId", row.setup_id),
+    ts: row.ts,
+    ...optional("deviceId", row.device_id),
+    ...optional("publicKey", row.public_key),
+    ...optional(
+      "profile",
+      fromJsonColumn<DeviceBootstrapTokenRecord["profile"]>(row.profile_json) ?? null,
+    ),
+    ...optional(
+      "redeemedProfile",
+      fromJsonColumn<DeviceBootstrapTokenRecord["redeemedProfile"]>(row.redeemed_profile_json) ??
+        null,
+    ),
+    ...optional(
+      "pendingProfile",
+      fromJsonColumn<DeviceBootstrapTokenRecord["pendingProfile"]>(row.pending_profile_json) ??
+        null,
+    ),
+    issuedAtMs: row.issued_at_ms,
+    ...optional("lastUsedAtMs", row.last_used_at_ms),
+  };
+}
+
+export function fromSetupCompletionRow(
+  row: DevicePairSetupCompletions,
+): DevicePairSetupCompletionRecord {
+  return {
+    setupId: row.setup_id,
+    deviceId: row.device_id,
+    ...optional("deviceName", row.device_name),
+    access: fromSetupCompletionAccessColumn(row.access),
+    completedAtMs: row.completed_at_ms,
+    deliveryState: fromSetupCompletionDeliveryStateColumn(row.delivery_state),
+    retainUntilMs: row.retain_until_ms,
+  };
+}

--- a/src/infra/device-pairing-store.test-support.ts
+++ b/src/infra/device-pairing-store.test-support.ts
@@ -1,0 +1,16 @@
+import {
+  mutateDevicePairingStoreStateInTransaction,
+  type DevicePairingStoreState,
+} from "./device-pairing-store.js";
+
+export function seedDevicePairingStoreState(
+  state: DevicePairingStoreState,
+  baseDir?: string,
+  options?: { clearApnsNodeIds?: readonly string[] },
+): void {
+  mutateDevicePairingStoreStateInTransaction(baseDir, (current, persist) => {
+    current.pendingById = state.pendingById;
+    current.pairedByDeviceId = state.pairedByDeviceId;
+    persist("both", options);
+  });
+}

--- a/src/infra/device-pairing-store.ts
+++ b/src/infra/device-pairing-store.ts
@@ -1,10 +1,6 @@
 // SQLite row mapping for device pairing and bootstrap-token snapshots.
-// Immediate transactions preserve last-writer-wins semantics across Gateway and CLI processes.
 import type { DatabaseSync } from "node:sqlite";
-import {
-  resolvePairingSetupAccess,
-  type PairingSetupAccess,
-} from "../shared/device-bootstrap-profile.js";
+import { resolvePairingSetupAccess } from "../shared/device-bootstrap-profile.js";
 import {
   ensureDevicePairSetupBootstrapSchema,
   ensureDevicePairSetupCompletionSchema,
@@ -12,8 +8,6 @@ import {
 import { tableExists, tableHasColumn } from "../state/openclaw-state-db-schema-helpers.js";
 import type {
   DB as OpenClawStateKyselyDatabase,
-  DevicePairingPaired,
-  DevicePairingPending,
   DeviceBootstrapTokens,
 } from "../state/openclaw-state-db.generated.js";
 import {
@@ -23,15 +17,23 @@ import {
   type OpenClawStateDatabaseOptions,
 } from "../state/openclaw-state-db.js";
 import { bindCloudWorkerSetupCompletion } from "./device-pairing-cloud-worker.js";
+import {
+  DEVICE_BOOTSTRAP_TOKEN_COLUMNS_WITHOUT_SETUP,
+  fromBootstrapRow,
+  fromPairedRow,
+  fromPendingRow,
+  fromSetupCompletionRow,
+  toBootstrapRow,
+  toJsonColumn,
+  toPairedRow,
+  toPendingRow,
+} from "./device-pairing-store-rows.js";
 import type {
-  DeviceAuthToken,
   DeviceBootstrapTokenRecord,
   DevicePairingPendingRecord,
   DevicePairSetupCompletionRecord,
   PairedDevice,
-  PairedDeviceApprovalKind,
   PairedDeviceNodeSurface,
-  PairedDevicePendingNodeSurface,
 } from "./device-pairing.types.js";
 import {
   executeSqliteQuerySync,
@@ -45,20 +47,14 @@ export type DevicePairingStoreState = {
   pairedByDeviceId: Record<string, PairedDevice>;
 };
 
-const DEVICE_BOOTSTRAP_TOKEN_COLUMNS_WITHOUT_SETUP = [
-  "device_id",
-  "issued_at_ms",
-  "last_used_at_ms",
-  "pending_profile_json",
-  "profile_json",
-  "public_key",
-  "redeemed_profile_json",
-  "token",
-  "token_key",
-  "ts",
-] as const satisfies readonly (keyof DeviceBootstrapTokens)[];
-
 type DevicePairingStoreTarget = "pending" | "paired" | "both";
+
+type DevicePairingStorePersistOptions = { clearApnsNodeIds?: readonly string[] };
+
+export type DevicePairingStorePersist = (
+  target: DevicePairingStoreTarget,
+  options?: DevicePairingStorePersistOptions,
+) => void;
 
 type DevicePairingStoreValidityToken = {
   dataVersion: number;
@@ -152,213 +148,6 @@ function runDevicePairingStoreMutation<T>(
     invalidateDevicePairingStoreCache(database);
   }
   return result.value;
-}
-
-// Read-back allowlist for the approved_via column. The Record type forces
-// every PairedDeviceApprovalKind to appear here at compile time: omit one and
-// this object is a type error, instead of the stored provenance silently
-// dropping to undefined on load (which mergeApprovalKind treats as a legacy
-// record). Keep this in sync when adding an approval kind.
-const APPROVAL_KIND_MEMBERS = {
-  owner: true,
-  silent: true,
-  "trusted-cidr": true,
-  "trusted-proxy": true,
-  "ssh-verified": true,
-  bootstrap: true,
-} satisfies Record<PairedDeviceApprovalKind, true>;
-const APPROVAL_KINDS = new Set(Object.keys(APPROVAL_KIND_MEMBERS));
-
-function toJsonColumn(value: unknown): string | null {
-  return value === undefined ? null : JSON.stringify(value);
-}
-
-// oxlint-disable-next-line typescript/no-unnecessary-type-parameters -- Persisted JSON columns are typed by the receiving field.
-function fromJsonColumn<T>(value: string | null): T | undefined {
-  return value === null ? undefined : (JSON.parse(value) as T);
-}
-
-function toBooleanColumn(value: boolean | undefined): number | null {
-  return value === undefined ? null : value ? 1 : 0;
-}
-
-// Column null means the optional record key was absent; keep it absent on read
-// so records round-trip byte-identical to the retired JSON store.
-function optional<K extends string, V>(key: K, value: V | null): { [P in K]?: V } {
-  return value === null ? {} : ({ [key]: value } as { [P in K]: V });
-}
-
-function toPendingRow(record: DevicePairingPendingRecord): DevicePairingPending {
-  return {
-    request_id: record.requestId,
-    device_id: record.deviceId,
-    public_key: record.publicKey,
-    display_name: record.displayName ?? null,
-    platform: record.platform ?? null,
-    device_family: record.deviceFamily ?? null,
-    client_id: record.clientId ?? null,
-    client_mode: record.clientMode ?? null,
-    browser_origin: record.browserOrigin ?? null,
-    role: record.role ?? null,
-    roles_json: toJsonColumn(record.roles),
-    scopes_json: toJsonColumn(record.scopes),
-    remote_ip: record.remoteIp ?? null,
-    silent: toBooleanColumn(record.silent),
-    is_repair: toBooleanColumn(record.isRepair),
-    ts: record.ts,
-    refreshed_at_ms: record.refreshedAtMs ?? null,
-  };
-}
-
-function fromPendingRow(row: DevicePairingPending): DevicePairingPendingRecord {
-  return {
-    requestId: row.request_id,
-    deviceId: row.device_id,
-    publicKey: row.public_key,
-    ...optional("displayName", row.display_name),
-    ...optional("platform", row.platform),
-    ...optional("deviceFamily", row.device_family),
-    ...optional("clientId", row.client_id),
-    ...optional("clientMode", row.client_mode),
-    ...optional("browserOrigin", row.browser_origin),
-    ...optional("role", row.role),
-    ...optional("roles", fromJsonColumn<string[]>(row.roles_json) ?? null),
-    ...optional("scopes", fromJsonColumn<string[]>(row.scopes_json) ?? null),
-    ...optional("remoteIp", row.remote_ip),
-    ...optional("silent", row.silent === null ? null : row.silent !== 0),
-    ...optional("isRepair", row.is_repair === null ? null : row.is_repair !== 0),
-    ts: row.ts,
-    ...optional("refreshedAtMs", row.refreshed_at_ms),
-  };
-}
-
-function toPairedRow(device: PairedDevice): DevicePairingPaired {
-  return {
-    device_id: device.deviceId,
-    public_key: device.publicKey,
-    display_name: device.displayName ?? null,
-    operator_label: device.operatorLabel ?? null,
-    platform: device.platform ?? null,
-    device_family: device.deviceFamily ?? null,
-    client_id: device.clientId ?? null,
-    client_mode: device.clientMode ?? null,
-    browser_origin: device.browserOrigin ?? null,
-    role: device.role ?? null,
-    roles_json: toJsonColumn(device.roles),
-    scopes_json: toJsonColumn(device.scopes),
-    approved_scopes_json: toJsonColumn(device.approvedScopes),
-    remote_ip: device.remoteIp ?? null,
-    tokens_json: toJsonColumn(device.tokens),
-    approved_via: device.approvedVia ?? null,
-    node_surface_json: toJsonColumn(device.nodeSurface),
-    pending_node_surface_json: toJsonColumn(device.pendingNodeSurface),
-    created_at_ms: device.createdAtMs,
-    approved_at_ms: device.approvedAtMs,
-    last_seen_at_ms: device.lastSeenAtMs ?? null,
-    last_seen_reason: device.lastSeenReason ?? null,
-  };
-}
-
-function fromApprovedViaColumn(value: string | null): PairedDeviceApprovalKind | null {
-  return value !== null && APPROVAL_KINDS.has(value) ? (value as PairedDeviceApprovalKind) : null;
-}
-
-// Same compile-time exhaustiveness contract as APPROVAL_KIND_MEMBERS: the
-// completion access level is presented to the operator, so an unrecognized
-// stored value must fall back to the least-privilege label, never leak through.
-const PAIRING_SETUP_ACCESS_MEMBERS = {
-  full: true,
-  limited: true,
-  node: true,
-} satisfies Record<PairingSetupAccess, true>;
-const PAIRING_SETUP_ACCESS_VALUES = new Set(Object.keys(PAIRING_SETUP_ACCESS_MEMBERS));
-
-function fromSetupCompletionAccessColumn(value: string): PairingSetupAccess {
-  return PAIRING_SETUP_ACCESS_VALUES.has(value) ? (value as PairingSetupAccess) : "limited";
-}
-
-function fromSetupCompletionDeliveryStateColumn(
-  value: string,
-): DevicePairSetupCompletionRecord["deliveryState"] {
-  return value === "confirmed" ? "confirmed" : "uncertain";
-}
-
-function fromPairedRow(row: DevicePairingPaired): PairedDevice {
-  return {
-    deviceId: row.device_id,
-    publicKey: row.public_key,
-    ...optional("displayName", row.display_name),
-    ...optional("operatorLabel", row.operator_label),
-    ...optional("platform", row.platform),
-    ...optional("deviceFamily", row.device_family),
-    ...optional("clientId", row.client_id),
-    ...optional("clientMode", row.client_mode),
-    ...optional("browserOrigin", row.browser_origin),
-    ...optional("role", row.role),
-    ...optional("roles", fromJsonColumn<string[]>(row.roles_json) ?? null),
-    ...optional("scopes", fromJsonColumn<string[]>(row.scopes_json) ?? null),
-    ...optional("approvedScopes", fromJsonColumn<string[]>(row.approved_scopes_json) ?? null),
-    ...optional("remoteIp", row.remote_ip),
-    ...optional("tokens", fromJsonColumn<Record<string, DeviceAuthToken>>(row.tokens_json) ?? null),
-    ...optional("approvedVia", fromApprovedViaColumn(row.approved_via)),
-    ...optional(
-      "nodeSurface",
-      fromJsonColumn<PairedDeviceNodeSurface>(row.node_surface_json) ?? null,
-    ),
-    ...optional(
-      "pendingNodeSurface",
-      fromJsonColumn<PairedDevicePendingNodeSurface>(row.pending_node_surface_json) ?? null,
-    ),
-    createdAtMs: row.created_at_ms,
-    approvedAtMs: row.approved_at_ms,
-    ...optional("lastSeenAtMs", row.last_seen_at_ms),
-    ...optional("lastSeenReason", row.last_seen_reason),
-  };
-}
-
-function toBootstrapRow(
-  tokenKey: string,
-  record: DeviceBootstrapTokenRecord,
-): DeviceBootstrapTokens {
-  return {
-    token_key: tokenKey,
-    token: record.token,
-    setup_id: record.setupId ?? null,
-    ts: record.ts,
-    device_id: record.deviceId ?? null,
-    public_key: record.publicKey ?? null,
-    profile_json: toJsonColumn(record.profile),
-    redeemed_profile_json: toJsonColumn(record.redeemedProfile),
-    pending_profile_json: toJsonColumn(record.pendingProfile),
-    issued_at_ms: record.issuedAtMs,
-    last_used_at_ms: record.lastUsedAtMs ?? null,
-  };
-}
-
-function fromBootstrapRow(row: DeviceBootstrapTokens): DeviceBootstrapTokenRecord {
-  return {
-    token: row.token,
-    ...optional("setupId", row.setup_id),
-    ts: row.ts,
-    ...optional("deviceId", row.device_id),
-    ...optional("publicKey", row.public_key),
-    ...optional(
-      "profile",
-      fromJsonColumn<DeviceBootstrapTokenRecord["profile"]>(row.profile_json) ?? null,
-    ),
-    ...optional(
-      "redeemedProfile",
-      fromJsonColumn<DeviceBootstrapTokenRecord["redeemedProfile"]>(row.redeemed_profile_json) ??
-        null,
-    ),
-    ...optional(
-      "pendingProfile",
-      fromJsonColumn<DeviceBootstrapTokenRecord["pendingProfile"]>(row.pending_profile_json) ??
-        null,
-    ),
-    issuedAtMs: row.issued_at_ms,
-    ...optional("lastUsedAtMs", row.last_used_at_ms),
-  };
 }
 
 export function readDevicePairingStoreStateFromDatabase(db: DatabaseSync): DevicePairingStoreState {
@@ -494,33 +283,69 @@ export function updatePairedDevicePresenceInTransaction<T>(
   });
 }
 
+function writeDevicePairingStoreTables(
+  db: DatabaseSync,
+  state: DevicePairingStoreState,
+  target: DevicePairingStoreTarget,
+  options?: DevicePairingStorePersistOptions,
+): void {
+  const kysely = getNodeSqliteKysely<OpenClawStateKyselyDatabase>(db);
+  if (target !== "paired") {
+    executeSqliteQuerySync(db, kysely.deleteFrom("device_pairing_pending"));
+    const rows = Object.values(state.pendingById).map(toPendingRow);
+    if (rows.length > 0) {
+      executeSqliteQuerySync(db, kysely.insertInto("device_pairing_pending").values(rows));
+    }
+  }
+  if (target !== "pending") {
+    executeSqliteQuerySync(db, kysely.deleteFrom("device_pairing_paired"));
+    const rows = Object.values(state.pairedByDeviceId).map(toPairedRow);
+    if (rows.length > 0) {
+      executeSqliteQuerySync(db, kysely.insertInto("device_pairing_paired").values(rows));
+    }
+  }
+  for (const nodeId of new Set(options?.clearApnsNodeIds ?? [])) {
+    clearApnsRegistrationFromDatabase(db, nodeId);
+  }
+}
+
 /** Replace the pending and/or paired table contents with the given snapshot. */
 export function persistDevicePairingStoreState(
   state: DevicePairingStoreState,
   baseDir: string | undefined,
   target: DevicePairingStoreTarget,
-  options?: { clearApnsNodeIds?: readonly string[] },
+  options?: DevicePairingStorePersistOptions,
 ): void {
   runDevicePairingStoreMutation(baseDir, ({ db }) => {
-    const kysely = getNodeSqliteKysely<OpenClawStateKyselyDatabase>(db);
-    if (target !== "paired") {
-      executeSqliteQuerySync(db, kysely.deleteFrom("device_pairing_pending"));
-      const rows = Object.values(state.pendingById).map(toPendingRow);
-      if (rows.length > 0) {
-        executeSqliteQuerySync(db, kysely.insertInto("device_pairing_pending").values(rows));
-      }
-    }
-    if (target !== "pending") {
-      executeSqliteQuerySync(db, kysely.deleteFrom("device_pairing_paired"));
-      const rows = Object.values(state.pairedByDeviceId).map(toPairedRow);
-      if (rows.length > 0) {
-        executeSqliteQuerySync(db, kysely.insertInto("device_pairing_paired").values(rows));
-      }
-    }
-    for (const nodeId of new Set(options?.clearApnsNodeIds ?? [])) {
-      clearApnsRegistrationFromDatabase(db, nodeId);
-    }
+    writeDevicePairingStoreTables(db, state, target, options);
     return { mutated: true, value: undefined };
+  });
+}
+
+export function mutateDevicePairingStoreStateInTransaction<T>(
+  baseDir: string | undefined,
+  mutate: (state: DevicePairingStoreState, persist: DevicePairingStorePersist) => T,
+): T {
+  return runDevicePairingStoreMutation(baseDir, ({ db }) => {
+    const state = readDevicePairingStoreStateFromDatabase(db);
+    let requested: { target: DevicePairingStoreTarget; clearApnsNodeIds: string[] } | undefined;
+    const persist: DevicePairingStorePersist = (target, options) => {
+      requested = {
+        target: requested && requested.target !== target ? "both" : target,
+        clearApnsNodeIds: [
+          ...(requested?.clearApnsNodeIds ?? []),
+          ...(options?.clearApnsNodeIds ?? []),
+        ],
+      };
+    };
+    const value = mutate(state, persist);
+    if (!requested) {
+      return { mutated: false, value };
+    }
+    writeDevicePairingStoreTables(db, state, requested.target, {
+      clearApnsNodeIds: requested.clearApnsNodeIds,
+    });
+    return { mutated: true, value };
   });
 }
 
@@ -703,15 +528,7 @@ export function confirmDevicePairSetupCompletionDeliveryInTransaction(params: {
         .where("setup_id", "=", setupId)
         .where("device_id", "=", deviceId),
     );
-    return {
-      setupId: row.setup_id,
-      deviceId: row.device_id,
-      ...optional("deviceName", row.device_name),
-      access: fromSetupCompletionAccessColumn(row.access),
-      completedAtMs: row.completed_at_ms,
-      deliveryState: fromSetupCompletionDeliveryStateColumn(row.delivery_state),
-      retainUntilMs: row.retain_until_ms,
-    };
+    return fromSetupCompletionRow(row);
   }, resolveDevicePairingStateDbOptions(params.baseDir));
 }
 
@@ -761,17 +578,7 @@ export function loadDevicePairSetupCompletionRecord(
           .selectAll()
           .where("setup_id", "=", setupId),
       );
-      return row
-        ? {
-            setupId: row.setup_id,
-            deviceId: row.device_id,
-            ...optional("deviceName", row.device_name),
-            access: fromSetupCompletionAccessColumn(row.access),
-            completedAtMs: row.completed_at_ms,
-            deliveryState: fromSetupCompletionDeliveryStateColumn(row.delivery_state),
-            retainUntilMs: row.retain_until_ms,
-          }
-        : null;
+      return row ? fromSetupCompletionRow(row) : null;
     },
     { ...databaseOptions, database },
   );

--- a/src/infra/device-pairing-store.ts
+++ b/src/infra/device-pairing-store.ts
@@ -283,50 +283,12 @@ export function updatePairedDevicePresenceInTransaction<T>(
   });
 }
 
-function writeDevicePairingStoreTables(
-  db: DatabaseSync,
-  state: DevicePairingStoreState,
-  target: DevicePairingStoreTarget,
-  options?: DevicePairingStorePersistOptions,
-): void {
-  const kysely = getNodeSqliteKysely<OpenClawStateKyselyDatabase>(db);
-  if (target !== "paired") {
-    executeSqliteQuerySync(db, kysely.deleteFrom("device_pairing_pending"));
-    const rows = Object.values(state.pendingById).map(toPendingRow);
-    if (rows.length > 0) {
-      executeSqliteQuerySync(db, kysely.insertInto("device_pairing_pending").values(rows));
-    }
-  }
-  if (target !== "pending") {
-    executeSqliteQuerySync(db, kysely.deleteFrom("device_pairing_paired"));
-    const rows = Object.values(state.pairedByDeviceId).map(toPairedRow);
-    if (rows.length > 0) {
-      executeSqliteQuerySync(db, kysely.insertInto("device_pairing_paired").values(rows));
-    }
-  }
-  for (const nodeId of new Set(options?.clearApnsNodeIds ?? [])) {
-    clearApnsRegistrationFromDatabase(db, nodeId);
-  }
-}
-
-/** Replace the pending and/or paired table contents with the given snapshot. */
-export function persistDevicePairingStoreState(
-  state: DevicePairingStoreState,
-  baseDir: string | undefined,
-  target: DevicePairingStoreTarget,
-  options?: DevicePairingStorePersistOptions,
-): void {
-  runDevicePairingStoreMutation(baseDir, ({ db }) => {
-    writeDevicePairingStoreTables(db, state, target, options);
-    return { mutated: true, value: undefined };
-  });
-}
-
 export function mutateDevicePairingStoreStateInTransaction<T>(
   baseDir: string | undefined,
   mutate: (state: DevicePairingStoreState, persist: DevicePairingStorePersist) => T,
 ): T {
   return runDevicePairingStoreMutation(baseDir, ({ db }) => {
+    const kysely = getNodeSqliteKysely<OpenClawStateKyselyDatabase>(db);
     const state = readDevicePairingStoreStateFromDatabase(db);
     let requested: { target: DevicePairingStoreTarget; clearApnsNodeIds: string[] } | undefined;
     const persist: DevicePairingStorePersist = (target, options) => {
@@ -342,9 +304,23 @@ export function mutateDevicePairingStoreStateInTransaction<T>(
     if (!requested) {
       return { mutated: false, value };
     }
-    writeDevicePairingStoreTables(db, state, requested.target, {
-      clearApnsNodeIds: requested.clearApnsNodeIds,
-    });
+    if (requested.target !== "paired") {
+      executeSqliteQuerySync(db, kysely.deleteFrom("device_pairing_pending"));
+      const rows = Object.values(state.pendingById).map(toPendingRow);
+      if (rows.length > 0) {
+        executeSqliteQuerySync(db, kysely.insertInto("device_pairing_pending").values(rows));
+      }
+    }
+    if (requested.target !== "pending") {
+      executeSqliteQuerySync(db, kysely.deleteFrom("device_pairing_paired"));
+      const rows = Object.values(state.pairedByDeviceId).map(toPairedRow);
+      if (rows.length > 0) {
+        executeSqliteQuerySync(db, kysely.insertInto("device_pairing_paired").values(rows));
+      }
+    }
+    for (const nodeId of new Set(requested.clearApnsNodeIds)) {
+      clearApnsRegistrationFromDatabase(db, nodeId);
+    }
     return { mutated: true, value };
   });
 }

--- a/src/infra/device-pairing-tokens.ts
+++ b/src/infra/device-pairing-tokens.ts
@@ -3,15 +3,12 @@ import { normalizeDeviceAuthScopes } from "../shared/device-auth.js";
 import { resolveMissingRequestedScope, roleScopesAllow } from "../shared/operator-scope-compat.js";
 import {
   cloneDevicePairingTokens,
-  loadDevicePairingState,
+  mutateDevicePairingState,
   normalizeDevicePairingId,
   normalizeDevicePairingRole,
   withDevicePairingLock,
 } from "./device-pairing-state.js";
-import {
-  persistDevicePairingStoreState as persistState,
-  type DevicePairingStoreState,
-} from "./device-pairing-store.js";
+import type { DevicePairingStoreState } from "./device-pairing-store.js";
 import {
   clearNodePairingGenerationState,
   listApprovedPairedDeviceRoles,
@@ -164,61 +161,62 @@ export async function verifyDeviceToken(params: {
   baseDir?: string;
 }): Promise<{ ok: boolean; reason?: string; issuer?: DeviceAuthToken["issuer"] }> {
   return await withDevicePairingLock(async () => {
-    const state = await loadDevicePairingState(params.baseDir);
-    const device = getPairedDeviceFromState(state, params.deviceId);
-    if (!device) {
-      return { ok: false, reason: "device-not-paired" };
-    }
-    const role = normalizeDevicePairingRole(params.role);
-    if (!role) {
-      return { ok: false, reason: "role-missing" };
-    }
-    const entry = device.tokens?.[role];
-    if (!entry) {
-      return { ok: false, reason: "token-missing" };
-    }
-    if (entry.revokedAtMs) {
-      return { ok: false, reason: "token-revoked" };
-    }
-    if (!verifyPairingToken(params.token, entry.token)) {
-      return { ok: false, reason: "token-mismatch" };
-    }
-    if (
-      entry.issuer?.kind === SHARED_GATEWAY_AUTH_ISSUER_KIND &&
-      entry.issuer.generation !== params.requiredSharedGatewaySessionGeneration
-    ) {
-      return { ok: false, reason: "issuer-generation-stale" };
-    }
-    if (
-      !entry.issuer &&
-      params.requiredSharedGatewaySessionGeneration !== undefined &&
-      isBrowserRelatedPairedDevice(device)
-    ) {
-      return { ok: false, reason: "legacy-browser-token" };
-    }
-    const approvedScopes = resolveApprovedDeviceScopeBaseline(device);
-    if (
-      !scopesWithinApprovedDeviceBaseline({
-        role,
-        scopes: entry.scopes,
-        approvedScopes,
-      })
-    ) {
-      return { ok: false, reason: "scope-mismatch" };
-    }
-    const requestedScopes = normalizeDeviceAuthScopes(params.scopes);
-    if (!roleScopesAllow({ role, requestedScopes, allowedScopes: entry.scopes })) {
-      return { ok: false, reason: "scope-mismatch" };
-    }
-    const now = Date.now();
-    entry.lastUsedAtMs = now;
-    device.tokens ??= {};
-    device.tokens[role] = entry;
-    device.lastSeenAtMs = now;
-    device.lastSeenReason = "device-token-auth";
-    state.pairedByDeviceId[device.deviceId] = device;
-    persistState(state, params.baseDir, "paired");
-    return entry.issuer ? { ok: true, issuer: entry.issuer } : { ok: true };
+    return mutateDevicePairingState(params.baseDir, (state, persist) => {
+      const device = getPairedDeviceFromState(state, params.deviceId);
+      if (!device) {
+        return { ok: false, reason: "device-not-paired" };
+      }
+      const role = normalizeDevicePairingRole(params.role);
+      if (!role) {
+        return { ok: false, reason: "role-missing" };
+      }
+      const entry = device.tokens?.[role];
+      if (!entry) {
+        return { ok: false, reason: "token-missing" };
+      }
+      if (entry.revokedAtMs) {
+        return { ok: false, reason: "token-revoked" };
+      }
+      if (!verifyPairingToken(params.token, entry.token)) {
+        return { ok: false, reason: "token-mismatch" };
+      }
+      if (
+        entry.issuer?.kind === SHARED_GATEWAY_AUTH_ISSUER_KIND &&
+        entry.issuer.generation !== params.requiredSharedGatewaySessionGeneration
+      ) {
+        return { ok: false, reason: "issuer-generation-stale" };
+      }
+      if (
+        !entry.issuer &&
+        params.requiredSharedGatewaySessionGeneration !== undefined &&
+        isBrowserRelatedPairedDevice(device)
+      ) {
+        return { ok: false, reason: "legacy-browser-token" };
+      }
+      const approvedScopes = resolveApprovedDeviceScopeBaseline(device);
+      if (
+        !scopesWithinApprovedDeviceBaseline({
+          role,
+          scopes: entry.scopes,
+          approvedScopes,
+        })
+      ) {
+        return { ok: false, reason: "scope-mismatch" };
+      }
+      const requestedScopes = normalizeDeviceAuthScopes(params.scopes);
+      if (!roleScopesAllow({ role, requestedScopes, allowedScopes: entry.scopes })) {
+        return { ok: false, reason: "scope-mismatch" };
+      }
+      const now = Date.now();
+      entry.lastUsedAtMs = now;
+      device.tokens ??= {};
+      device.tokens[role] = entry;
+      device.lastSeenAtMs = now;
+      device.lastSeenReason = "device-token-auth";
+      state.pairedByDeviceId[device.deviceId] = device;
+      persist("paired");
+      return entry.issuer ? { ok: true, issuer: entry.issuer } : { ok: true };
+    });
   });
 }
 
@@ -231,58 +229,59 @@ export async function ensureDeviceToken(params: {
   baseDir?: string;
 }): Promise<DeviceAuthToken | null> {
   return await withDevicePairingLock(async () => {
-    const state = await loadDevicePairingState(params.baseDir);
-    const requestedScopes = normalizeDeviceAuthScopes(params.scopes);
-    const context = resolveDeviceTokenUpdateContext({
-      state,
-      deviceId: params.deviceId,
-      role: params.role,
-    });
-    if (!context) {
-      return null;
-    }
-    const { device, role, tokens, existing } = context;
-    const previousNodeGeneration = resolveNodePairingGeneration(device);
-    const approvedScopes = resolveApprovedDeviceScopeBaseline(device);
-    if (
-      !scopesWithinApprovedDeviceBaseline({
+    return mutateDevicePairingState(params.baseDir, (state, persist) => {
+      const requestedScopes = normalizeDeviceAuthScopes(params.scopes);
+      const context = resolveDeviceTokenUpdateContext({
+        state,
+        deviceId: params.deviceId,
+        role: params.role,
+      });
+      if (!context) {
+        return null;
+      }
+      const { device, role, tokens, existing } = context;
+      const previousNodeGeneration = resolveNodePairingGeneration(device);
+      const approvedScopes = resolveApprovedDeviceScopeBaseline(device);
+      if (
+        !scopesWithinApprovedDeviceBaseline({
+          role,
+          scopes: requestedScopes,
+          approvedScopes,
+        })
+      ) {
+        return null;
+      }
+      if (existing && !existing.revokedAtMs) {
+        const existingWithinApproved = scopesWithinApprovedDeviceBaseline({
+          role,
+          scopes: existing.scopes,
+          approvedScopes,
+        });
+        const issuerAllowsReuse = deviceTokenIssuerMatches(existing, params.issuer);
+        if (
+          existingWithinApproved &&
+          issuerAllowsReuse &&
+          roleScopesAllow({ role, requestedScopes, allowedScopes: existing.scopes })
+        ) {
+          return existing;
+        }
+      }
+      const now = Date.now();
+      const next = createDeviceAuthToken({
         role,
         scopes: requestedScopes,
-        approvedScopes,
-      })
-    ) {
-      return null;
-    }
-    if (existing && !existing.revokedAtMs) {
-      const existingWithinApproved = scopesWithinApprovedDeviceBaseline({
-        role,
-        scopes: existing.scopes,
-        approvedScopes,
+        issuer: params.issuer,
+        existing,
+        now,
+        rotatedAtMs: existing ? now : undefined,
       });
-      const issuerAllowsReuse = deviceTokenIssuerMatches(existing, params.issuer);
-      if (
-        existingWithinApproved &&
-        issuerAllowsReuse &&
-        roleScopesAllow({ role, requestedScopes, allowedScopes: existing.scopes })
-      ) {
-        return existing;
-      }
-    }
-    const now = Date.now();
-    const next = createDeviceAuthToken({
-      role,
-      scopes: requestedScopes,
-      issuer: params.issuer,
-      existing,
-      now,
-      rotatedAtMs: existing ? now : undefined,
+      tokens[role] = next;
+      device.tokens = tokens;
+      clearNodePairingGenerationState(device, previousNodeGeneration);
+      state.pairedByDeviceId[device.deviceId] = device;
+      persist("paired");
+      return next;
     });
-    tokens[role] = next;
-    device.tokens = tokens;
-    clearNodePairingGenerationState(device, previousNodeGeneration);
-    state.pairedByDeviceId[device.deviceId] = device;
-    persistState(state, params.baseDir, "paired");
-    return next;
   });
 }
 
@@ -323,58 +322,59 @@ export async function rotateDeviceToken(params: {
   baseDir?: string;
 }): Promise<RotateDeviceTokenResult> {
   return await withDevicePairingLock(async () => {
-    const state = await loadDevicePairingState(params.baseDir);
-    const context = resolveDeviceTokenUpdateContext({
-      state,
-      deviceId: params.deviceId,
-      role: params.role,
-    });
-    if (!context) {
-      return { ok: false, reason: "unknown-device-or-role" };
-    }
-    const { device, role, tokens, existing } = context;
-    const previousNodeGeneration = resolveNodePairingGeneration(device);
-    const requestedScopes = normalizeDeviceAuthScopes(
-      params.scopes ?? existing?.scopes ?? device.scopes,
-    );
-    const approvedScopes = resolveApprovedDeviceScopeBaseline(device);
-    if (!approvedScopes) {
-      return { ok: false, reason: "missing-approved-scope-baseline" };
-    }
-    if (
-      !scopesWithinApprovedDeviceBaseline({
+    return mutateDevicePairingState(params.baseDir, (state, persist) => {
+      const context = resolveDeviceTokenUpdateContext({
+        state,
+        deviceId: params.deviceId,
+        role: params.role,
+      });
+      if (!context) {
+        return { ok: false, reason: "unknown-device-or-role" };
+      }
+      const { device, role, tokens, existing } = context;
+      const previousNodeGeneration = resolveNodePairingGeneration(device);
+      const requestedScopes = normalizeDeviceAuthScopes(
+        params.scopes ?? existing?.scopes ?? device.scopes,
+      );
+      const approvedScopes = resolveApprovedDeviceScopeBaseline(device);
+      if (!approvedScopes) {
+        return { ok: false, reason: "missing-approved-scope-baseline" };
+      }
+      if (
+        !scopesWithinApprovedDeviceBaseline({
+          role,
+          scopes: requestedScopes,
+          approvedScopes,
+        })
+      ) {
+        return { ok: false, reason: "scope-outside-approved-baseline" };
+      }
+      if (params.callerScopes) {
+        const missingScope = resolveMissingRequestedScope({
+          role,
+          requestedScopes,
+          allowedScopes: params.callerScopes,
+        });
+        if (missingScope) {
+          return { ok: false, reason: "caller-missing-scope", scope: missingScope };
+        }
+      }
+      const now = Date.now();
+      const next = createDeviceAuthToken({
         role,
         scopes: requestedScopes,
-        approvedScopes,
-      })
-    ) {
-      return { ok: false, reason: "scope-outside-approved-baseline" };
-    }
-    if (params.callerScopes) {
-      const missingScope = resolveMissingRequestedScope({
-        role,
-        requestedScopes,
-        allowedScopes: params.callerScopes,
+        existing,
+        preserveExistingIssuer: true,
+        now,
+        rotatedAtMs: now,
       });
-      if (missingScope) {
-        return { ok: false, reason: "caller-missing-scope", scope: missingScope };
-      }
-    }
-    const now = Date.now();
-    const next = createDeviceAuthToken({
-      role,
-      scopes: requestedScopes,
-      existing,
-      preserveExistingIssuer: true,
-      now,
-      rotatedAtMs: now,
+      tokens[role] = next;
+      device.tokens = tokens;
+      clearNodePairingGenerationState(device, previousNodeGeneration);
+      state.pairedByDeviceId[device.deviceId] = device;
+      persist("paired");
+      return { ok: true, entry: next };
     });
-    tokens[role] = next;
-    device.tokens = tokens;
-    clearNodePairingGenerationState(device, previousNodeGeneration);
-    state.pairedByDeviceId[device.deviceId] = device;
-    persistState(state, params.baseDir, "paired");
-    return { ok: true, entry: next };
   });
 }
 
@@ -386,36 +386,37 @@ export async function revokeDeviceToken(params: {
   baseDir?: string;
 }): Promise<RevokeDeviceTokenResult> {
   return await withDevicePairingLock(async () => {
-    const state = await loadDevicePairingState(params.baseDir);
-    const context = resolveDeviceTokenUpdateContext({
-      state,
-      deviceId: params.deviceId,
-      role: params.role,
-    });
-    if (!context || !context.existing) {
-      return { ok: false, reason: "unknown-device-or-role" };
-    }
-    const { device, role, tokens, existing } = context;
-    const previousNodeGeneration = resolveNodePairingGeneration(device);
-    const targetScopes = normalizeDeviceAuthScopes(
-      Array.isArray(existing.scopes) ? existing.scopes : device.scopes,
-    );
-    if (params.callerScopes) {
-      const missingScope = resolveMissingRequestedScope({
-        role,
-        requestedScopes: targetScopes,
-        allowedScopes: params.callerScopes,
+    return mutateDevicePairingState(params.baseDir, (state, persist) => {
+      const context = resolveDeviceTokenUpdateContext({
+        state,
+        deviceId: params.deviceId,
+        role: params.role,
       });
-      if (missingScope) {
-        return { ok: false, reason: "caller-missing-scope", scope: missingScope };
+      if (!context || !context.existing) {
+        return { ok: false, reason: "unknown-device-or-role" };
       }
-    }
-    const entry = { ...existing, revokedAtMs: Date.now() };
-    tokens[role] = entry;
-    device.tokens = tokens;
-    clearNodePairingGenerationState(device, previousNodeGeneration);
-    state.pairedByDeviceId[device.deviceId] = device;
-    persistState(state, params.baseDir, "paired");
-    return { ok: true, entry };
+      const { device, role, tokens, existing } = context;
+      const previousNodeGeneration = resolveNodePairingGeneration(device);
+      const targetScopes = normalizeDeviceAuthScopes(
+        Array.isArray(existing.scopes) ? existing.scopes : device.scopes,
+      );
+      if (params.callerScopes) {
+        const missingScope = resolveMissingRequestedScope({
+          role,
+          requestedScopes: targetScopes,
+          allowedScopes: params.callerScopes,
+        });
+        if (missingScope) {
+          return { ok: false, reason: "caller-missing-scope", scope: missingScope };
+        }
+      }
+      const entry = { ...existing, revokedAtMs: Date.now() };
+      tokens[role] = entry;
+      device.tokens = tokens;
+      clearNodePairingGenerationState(device, previousNodeGeneration);
+      state.pairedByDeviceId[device.deviceId] = device;
+      persist("paired");
+      return { ok: true, entry };
+    });
   });
 }

--- a/src/infra/device-pairing.test.ts
+++ b/src/infra/device-pairing.test.ts
@@ -16,10 +16,10 @@ import { approveBootstrapDevicePairing, approveDevicePairing } from "./device-pa
 import { updatePairedNodeBins, updatePairedNodeSessionHost } from "./device-pairing-node-facts.js";
 import { approveNodePairing, requestNodePairing } from "./device-pairing-node.js";
 import {
-  loadDevicePairingStoreState,
+  mutateDevicePairingStoreStateInTransaction,
   persistDeviceBootstrapTokenRecords,
-  persistDevicePairingStoreState,
 } from "./device-pairing-store.js";
+import { seedDevicePairingStoreState } from "./device-pairing-store.test-support.js";
 import {
   ensureDeviceToken,
   revokeDeviceToken,
@@ -180,10 +180,11 @@ function mutatePendingRequest(
   requestId: string,
   mutate: (pending: { ts: number; refreshedAtMs?: number; scopes?: string[] }) => void,
 ) {
-  const state = loadDevicePairingStoreState(baseDir);
-  const pending = requireValue(state.pendingById[requestId], "expected pending pairing request");
-  mutate(pending);
-  persistDevicePairingStoreState(state, baseDir, "pending");
+  mutateDevicePairingStoreStateInTransaction(baseDir, (state, persist) => {
+    const pending = requireValue(state.pendingById[requestId], "expected pending pairing request");
+    mutate(pending);
+    persist("pending");
+  });
 }
 
 async function clearPairedOperatorApprovalBaseline(baseDir: string) {
@@ -209,7 +210,7 @@ describe("device pairing tokens", () => {
   });
 
   beforeEach(() => {
-    persistDevicePairingStoreState({ pendingById: {}, pairedByDeviceId: {} }, suiteBaseDir, "both");
+    seedDevicePairingStoreState({ pendingById: {}, pairedByDeviceId: {} }, suiteBaseDir);
     persistDeviceBootstrapTokenRecords({}, suiteBaseDir);
   });
 

--- a/src/infra/device-pairing.test.ts
+++ b/src/infra/device-pairing.test.ts
@@ -1,11 +1,15 @@
 // Covers device pairing, token, and role lifecycle behavior.
+import { DatabaseSync } from "node:sqlite";
 import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
 import { afterAll, beforeAll, beforeEach, describe, expect, test } from "vitest";
 import {
   FULL_ACCESS_PAIRING_SETUP_BOOTSTRAP_PROFILE,
   PAIRING_SETUP_BOOTSTRAP_PROFILE,
 } from "../shared/device-bootstrap-profile.js";
-import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
+import {
+  closeOpenClawStateDatabaseForTest,
+  openOpenClawStateDatabase,
+} from "../state/openclaw-state-db.js";
 import { createSuiteTempRootTracker } from "../test-helpers/temp-dir.js";
 import { issueDeviceBootstrapToken, verifyDeviceBootstrapToken } from "./device-bootstrap.js";
 import { approveBootstrapDevicePairing, approveDevicePairing } from "./device-pairing-approval.js";
@@ -2413,6 +2417,39 @@ describe("device pairing tokens", () => {
       ),
     ).resolves.toBeNull();
     await expect(getPairedDevice("device-1", baseDir)).resolves.toBeNull();
+  });
+
+  test("full-snapshot persist keeps rows committed by another process mid-mutation", async () => {
+    const baseDir = await makeDevicePairingDir();
+    await setupPairedOperatorDevice(baseDir, ["operator.read"]);
+    const database = openOpenClawStateDatabase({
+      env: { ...process.env, OPENCLAW_STATE_DIR: baseDir },
+    });
+    const rival = new DatabaseSync(database.path);
+    let rivalWrite: "committed" | "rejected";
+    try {
+      rivalWrite = await withPairedDeviceRecords(baseDir, (pairedByDeviceId) => {
+        let outcome: "committed" | "rejected";
+        try {
+          rival
+            .prepare(
+              "INSERT INTO device_pairing_paired (device_id, public_key, created_at_ms, approved_at_ms) VALUES (?, ?, ?, ?)",
+            )
+            .run("node-host", "public-key-node-host", 1, 1);
+          outcome = "committed";
+        } catch {
+          outcome = "rejected";
+        }
+        const device = requireValue(pairedByDeviceId["device-1"], "expected paired device");
+        device.lastSeenAtMs = 4_242;
+        return { value: outcome, persist: true };
+      });
+    } finally {
+      rival.close();
+    }
+    const survivor = await getPairedDevice("node-host", baseDir);
+    expect(rivalWrite === "committed" && survivor === null).toBe(false);
+    expect((await getPairedDevice("device-1", baseDir))?.lastSeenAtMs).toBe(4_242);
   });
 });
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/src/infra/device-pairing.ts
+++ b/src/infra/device-pairing.ts
@@ -12,6 +12,7 @@ import {
   loadDevicePairingStateReadOnly,
   mergeDevicePairingRoles,
   mergeDevicePairingScopes,
+  mutateDevicePairingState,
   normalizeDevicePairingId,
   normalizeDevicePairingRole,
   preserveDeviceRoleScopes,
@@ -23,8 +24,9 @@ import {
 } from "./device-pairing-state.js";
 import {
   loadPairedDevicePairingStoreRecord,
-  persistDevicePairingStoreState,
   updatePairedDevicePresenceInTransaction,
+  type DevicePairingStorePersist,
+  type DevicePairingStoreState,
 } from "./device-pairing-store.js";
 import type {
   DeviceAuthToken,
@@ -106,9 +108,21 @@ export function hasPairedCardRenderer(baseDir?: string): Promise<boolean> {
   return pairedCardRendererCache.value;
 }
 
-function persistState(...args: Parameters<typeof persistDevicePairingStoreState>): void {
-  persistDevicePairingStoreState(...args);
-  invalidatePairedCardRendererCache();
+function mutatePairingState<T>(
+  baseDir: string | undefined,
+  mutate: (state: DevicePairingStoreState, persist: DevicePairingStorePersist) => T,
+): T {
+  let persisted = false;
+  const value = mutateDevicePairingState(baseDir, (state, persist) =>
+    mutate(state, (target, options) => {
+      persisted = true;
+      persist(target, options);
+    }),
+  );
+  if (persisted) {
+    invalidatePairedCardRendererCache();
+  }
+  return value;
 }
 
 /**
@@ -120,18 +134,17 @@ function persistState(...args: Parameters<typeof persistDevicePairingStoreState>
  */
 export async function withPairedDeviceRecords<T>(
   baseDir: string | undefined,
-  operate: (
-    pairedByDeviceId: Record<string, PairedDevice>,
-  ) => { value: T; persist: boolean } | Promise<{ value: T; persist: boolean }>,
+  operate: (pairedByDeviceId: Record<string, PairedDevice>) => { value: T; persist: boolean },
 ): Promise<T> {
-  return await withLock(async () => {
-    const state = await loadDevicePairingState(baseDir);
-    const outcome = await operate(state.pairedByDeviceId);
-    if (outcome.persist) {
-      persistState(state, baseDir, "paired");
-    }
-    return outcome.value;
-  });
+  return await withLock(async () =>
+    mutatePairingState(baseDir, (state, persist) => {
+      const outcome = operate(state.pairedByDeviceId);
+      if (outcome.persist) {
+        persist("paired");
+      }
+      return outcome.value;
+    }),
+  );
 }
 
 function listActiveTokenRoles(
@@ -452,67 +465,68 @@ export async function requestDevicePairing(
   baseDir?: string,
 ): Promise<RequestDevicePairingResult> {
   return await withLock(async () => {
-    const state = await loadDevicePairingState(baseDir);
-    const deviceId = normalizeDevicePairingId(req.deviceId);
-    if (!deviceId) {
-      throw new Error("deviceId required");
-    }
-    const isRepair = Boolean(state.pairedByDeviceId[deviceId]);
-    const pendingForDevice = Object.values(state.pendingById)
-      .filter((pending) => pending.deviceId === deviceId)
-      .toSorted((left, right) => right.ts - left.ts);
-    const result = reconcilePendingPairingRequests({
-      pendingById: state.pendingById,
-      existing: pendingForDevice,
-      incoming: req,
-      canRefreshSingle: (existing, incoming) =>
-        samePendingApprovalSnapshot(existing, incoming) ||
-        incomingApprovalCoveredByExisting(existing, incoming),
-      refreshSingle: (existing, incoming) =>
-        refreshPendingDevicePairingRequest(existing, incoming, isRepair),
-      buildReplacement: ({ existing, incoming }) => {
-        const latestPending = existing[0];
-        const mergedRoles = mergeDevicePairingRoles(
-          ...existing.flatMap((pending) => [pending.roles, pending.role]),
-          incoming.roles,
-          incoming.role,
-        );
-        const mergedScopes = mergeDevicePairingScopes(
-          ...existing.map((pending) => pending.scopes),
-          incoming.scopes,
-        );
-        return buildPendingDevicePairingRequest({
-          deviceId,
-          isRepair,
-          req: {
-            ...incoming,
-            role: normalizeDevicePairingRole(incoming.role) ?? latestPending?.role,
-            roles: mergedRoles,
-            scopes: mergedScopes,
-            // Preserve interactive visibility when superseding pending requests:
-            // if any previous pending request was interactive, keep this one interactive.
-            silent: resolveSupersededPendingSilent({
-              existing,
-              incomingSilent: incoming.silent,
-            }),
-          },
-        });
-      },
-      persist: () => persistState(state, baseDir, "pending"),
+    return mutatePairingState(baseDir, (state, persist) => {
+      const deviceId = normalizeDevicePairingId(req.deviceId);
+      if (!deviceId) {
+        throw new Error("deviceId required");
+      }
+      const isRepair = Boolean(state.pairedByDeviceId[deviceId]);
+      const pendingForDevice = Object.values(state.pendingById)
+        .filter((pending) => pending.deviceId === deviceId)
+        .toSorted((left, right) => right.ts - left.ts);
+      const result = reconcilePendingPairingRequests({
+        pendingById: state.pendingById,
+        existing: pendingForDevice,
+        incoming: req,
+        canRefreshSingle: (existing, incoming) =>
+          samePendingApprovalSnapshot(existing, incoming) ||
+          incomingApprovalCoveredByExisting(existing, incoming),
+        refreshSingle: (existing, incoming) =>
+          refreshPendingDevicePairingRequest(existing, incoming, isRepair),
+        buildReplacement: ({ existing, incoming }) => {
+          const latestPending = existing[0];
+          const mergedRoles = mergeDevicePairingRoles(
+            ...existing.flatMap((pending) => [pending.roles, pending.role]),
+            incoming.roles,
+            incoming.role,
+          );
+          const mergedScopes = mergeDevicePairingScopes(
+            ...existing.map((pending) => pending.scopes),
+            incoming.scopes,
+          );
+          return buildPendingDevicePairingRequest({
+            deviceId,
+            isRepair,
+            req: {
+              ...incoming,
+              role: normalizeDevicePairingRole(incoming.role) ?? latestPending?.role,
+              roles: mergedRoles,
+              scopes: mergedScopes,
+              // Preserve interactive visibility when superseding pending requests:
+              // if any previous pending request was interactive, keep this one interactive.
+              silent: resolveSupersededPendingSilent({
+                existing,
+                incomingSilent: incoming.silent,
+              }),
+            },
+          });
+        },
+        persist: () => persist("pending"),
+      });
+      // Surface superseded requestIds so callers can broadcast their resolution;
+      // clients otherwise keep prompting for requests that can no longer be approved.
+      const superseded = result.created
+        ? pendingForDevice
+            .filter((pending) => pending.requestId !== result.request.requestId)
+            .map((pending) => ({ requestId: pending.requestId, deviceId: pending.deviceId }))
+        : [];
+      const publicResult = {
+        ...result,
+        request: toPublicPendingDevicePairingRequest(result.request),
+        expiresAtMs: resolvePairingRequestExpiry(result.request.refreshedAtMs ?? result.request.ts),
+      };
+      return superseded.length > 0 ? { ...publicResult, superseded } : publicResult;
     });
-    // Surface superseded requestIds so callers can broadcast their resolution;
-    // clients otherwise keep prompting for requests that can no longer be approved.
-    const superseded = result.created
-      ? pendingForDevice
-          .filter((pending) => pending.requestId !== result.request.requestId)
-          .map((pending) => ({ requestId: pending.requestId, deviceId: pending.deviceId }))
-      : [];
-    const publicResult = {
-      ...result,
-      request: toPublicPendingDevicePairingRequest(result.request),
-      expiresAtMs: resolvePairingRequestExpiry(result.request.refreshedAtMs ?? result.request.ts),
-    };
-    return superseded.length > 0 ? { ...publicResult, superseded } : publicResult;
   });
 }
 
@@ -522,19 +536,24 @@ export async function rejectDevicePairing(
   baseDir?: string,
 ): Promise<{ requestId: string; deviceId: string } | null> {
   return await withLock(async () => {
-    const state = await loadDevicePairingState(baseDir);
-    const pending = state.pendingById[requestId];
-    if (!pending) {
+    const removed = mutatePairingState(baseDir, (state, persist) => {
+      const pending = state.pendingById[requestId];
+      if (!pending) {
+        return null;
+      }
+      delete state.pendingById[requestId];
+      persist("pending");
+      return { deviceId: pending.deviceId, publicKey: pending.publicKey };
+    });
+    if (!removed) {
       return null;
     }
-    delete state.pendingById[requestId];
-    persistState(state, baseDir, "pending");
     await revokeDeviceBootstrapTokensForDevice({
-      deviceId: pending.deviceId,
-      publicKey: pending.publicKey,
+      deviceId: removed.deviceId,
+      publicKey: removed.publicKey,
       baseDir,
     });
-    return { requestId, deviceId: pending.deviceId };
+    return { requestId, deviceId: removed.deviceId };
   });
 }
 
@@ -544,110 +563,20 @@ export async function removePairedDevice(
   baseDir?: string,
 ): Promise<{ deviceId: string } | null> {
   return await withLock(async () => {
-    const state = await loadDevicePairingState(baseDir);
-    const normalized = normalizeDevicePairingId(deviceId);
-    if (!normalized || !state.pairedByDeviceId[normalized]) {
-      return null;
-    }
-    delete state.pairedByDeviceId[normalized];
-    for (const [requestId, pending] of Object.entries(state.pendingById)) {
-      if (pending.deviceId === normalized) {
-        delete state.pendingById[requestId];
+    return mutatePairingState(baseDir, (state, persist) => {
+      const normalized = normalizeDevicePairingId(deviceId);
+      if (!normalized || !state.pairedByDeviceId[normalized]) {
+        return null;
       }
-    }
-    persistState(state, baseDir, "both", { clearApnsNodeIds: [normalized] });
-    return { deviceId: normalized };
-  });
-}
-
-// Silent pairings from the same client software on the same host mint a fresh
-// deviceId whenever their state dir (and thus keypair) is ephemeral. The cluster
-// key groups those records so a replacement pairing can retire its predecessors.
-function silentPairingClusterKey(
-  device: Pick<PairedDevice, "clientId" | "clientMode" | "displayName">,
-): string | null {
-  const clientId = device.clientId?.trim().toLowerCase() ?? "";
-  const clientMode = device.clientMode?.trim().toLowerCase() ?? "";
-  const displayName = device.displayName?.trim().toLowerCase() ?? "";
-  if (!clientId && !clientMode && !displayName) {
-    return null;
-  }
-  return `${clientId}\0${clientMode}\0${displayName}`;
-}
-
-/** Superseded silent pairing removed in favor of a newer record for the same client. */
-export type PrunedSupersededPairedDevice = {
-  deviceId: string;
-  roles: string[];
-};
-
-// A concurrently approved sibling may still be mid-handshake and not yet visible
-// to the connected-clients check; freshly approved records are never prune
-// candidates so parallel silent pairings cannot delete each other's rows.
-const PRUNE_RECENT_APPROVAL_GRACE_MS = 60_000;
-
-/**
- * Remove silent-approved sibling records superseded by a newly approved silent
- * pairing of the same client cluster. Only records whose latest approval was
- * same-host local ("silent") are eligible, as anchor and as victim: local
- * clients re-pair silently by construction and share the gateway host, so the
- * metadata cluster key cannot match a different machine. Currently connected
- * devices are skipped so concurrent sessions with distinct state dirs keep
- * their tokens while live.
- */
-export async function pruneSupersededSilentPairedDevices(params: {
-  deviceId: string;
-  baseDir?: string;
-  isDeviceConnected?: (deviceId: string) => boolean;
-  nowMs?: number;
-}): Promise<PrunedSupersededPairedDevice[]> {
-  return await withLock(async () => {
-    const state = await loadDevicePairingState(params.baseDir);
-    const anchor = state.pairedByDeviceId[normalizeDevicePairingId(params.deviceId)];
-    if (!anchor || anchor.approvedVia !== "silent") {
-      return [];
-    }
-    const anchorKey = silentPairingClusterKey(anchor);
-    if (!anchorKey) {
-      return [];
-    }
-    const nowMs = params.nowMs ?? Date.now();
-    const removed: PrunedSupersededPairedDevice[] = [];
-    for (const device of Object.values(state.pairedByDeviceId)) {
-      if (device.deviceId === anchor.deviceId) {
-        continue;
-      }
-      // Legacy records without approvedVia stay untouched (fail-safe).
-      if (device.approvedVia !== "silent") {
-        continue;
-      }
-      if (silentPairingClusterKey(device) !== anchorKey) {
-        continue;
-      }
-      if (nowMs - device.approvedAtMs < PRUNE_RECENT_APPROVAL_GRACE_MS) {
-        continue;
-      }
-      if (params.isDeviceConnected?.(device.deviceId)) {
-        continue;
-      }
-      delete state.pairedByDeviceId[device.deviceId];
+      delete state.pairedByDeviceId[normalized];
       for (const [requestId, pending] of Object.entries(state.pendingById)) {
-        if (pending.deviceId === device.deviceId) {
+        if (pending.deviceId === normalized) {
           delete state.pendingById[requestId];
         }
       }
-      removed.push({
-        deviceId: device.deviceId,
-        roles: listApprovedPairedDeviceRoles(device),
-      });
-    }
-    if (removed.length === 0) {
-      return [];
-    }
-    persistState(state, params.baseDir, "both", {
-      clearApnsNodeIds: removed.map((entry) => entry.deviceId),
+      persist("both", { clearApnsNodeIds: [normalized] });
+      return { deviceId: normalized };
     });
-    return removed;
   });
 }
 
@@ -658,80 +587,83 @@ export async function removePairedDeviceRole(params: {
   baseDir?: string;
 }): Promise<{ deviceId: string; role: string; removedDevice: boolean } | null> {
   return await withLock(async () => {
-    const state = await loadDevicePairingState(params.baseDir);
-    const normalizedDeviceId = normalizeDevicePairingId(params.deviceId);
-    const role = normalizeDevicePairingRole(params.role);
-    const device = state.pairedByDeviceId[normalizedDeviceId];
-    if (!device || !role || !listApprovedPairedDeviceRoles(device).includes(role)) {
-      return null;
-    }
+    return mutatePairingState(params.baseDir, (state, persist) => {
+      const normalizedDeviceId = normalizeDevicePairingId(params.deviceId);
+      const role = normalizeDevicePairingRole(params.role);
+      const device = state.pairedByDeviceId[normalizedDeviceId];
+      if (!device || !role || !listApprovedPairedDeviceRoles(device).includes(role)) {
+        return null;
+      }
 
-    const tokens = cloneDevicePairingTokens(device);
-    delete tokens[role];
-    const remainingRoles = listApprovedPairedDeviceRoles(device).filter((entry) => entry !== role);
-    if (remainingRoles.length === 0) {
-      for (const [requestId, pending] of Object.entries(state.pendingById)) {
-        if (pending.deviceId === normalizedDeviceId) {
-          delete state.pendingById[requestId];
+      const tokens = cloneDevicePairingTokens(device);
+      delete tokens[role];
+      const remainingRoles = listApprovedPairedDeviceRoles(device).filter(
+        (entry) => entry !== role,
+      );
+      if (remainingRoles.length === 0) {
+        for (const [requestId, pending] of Object.entries(state.pendingById)) {
+          if (pending.deviceId === normalizedDeviceId) {
+            delete state.pendingById[requestId];
+          }
         }
+        delete state.pairedByDeviceId[normalizedDeviceId];
+        persist("both", {
+          clearApnsNodeIds: [normalizedDeviceId],
+        });
+        return { deviceId: normalizedDeviceId, role, removedDevice: true };
       }
-      delete state.pairedByDeviceId[normalizedDeviceId];
-      persistState(state, params.baseDir, "both", {
-        clearApnsNodeIds: [normalizedDeviceId],
-      });
-      return { deviceId: normalizedDeviceId, role, removedDevice: true };
-    }
 
-    for (const [requestId, pending] of Object.entries(state.pendingById)) {
-      if (pending.deviceId !== normalizedDeviceId) {
-        continue;
+      for (const [requestId, pending] of Object.entries(state.pendingById)) {
+        if (pending.deviceId !== normalizedDeviceId) {
+          continue;
+        }
+        const pendingRoles = resolveRequestedDeviceRoles(pending);
+        if (!pendingRoles.includes(role)) {
+          continue;
+        }
+        const nextPendingRoles = pendingRoles.filter((entry) => entry !== role);
+        if (nextPendingRoles.length === 0) {
+          delete state.pendingById[requestId];
+          continue;
+        }
+        const pendingScopes = Array.isArray(pending.scopes)
+          ? mergeDevicePairingScopes(
+              ...nextPendingRoles.map((entry) => preserveDeviceRoleScopes(entry, pending.scopes)),
+            )
+          : undefined;
+        state.pendingById[requestId] = {
+          ...pending,
+          role: nextPendingRoles[0],
+          roles: nextPendingRoles,
+          scopes: pendingScopes,
+        };
       }
-      const pendingRoles = resolveRequestedDeviceRoles(pending);
-      if (!pendingRoles.includes(role)) {
-        continue;
-      }
-      const nextPendingRoles = pendingRoles.filter((entry) => entry !== role);
-      if (nextPendingRoles.length === 0) {
-        delete state.pendingById[requestId];
-        continue;
-      }
-      const pendingScopes = Array.isArray(pending.scopes)
+
+      const scopeBaseline = device.approvedScopes ?? device.scopes;
+      const preservedScopes = Array.isArray(scopeBaseline)
         ? mergeDevicePairingScopes(
-            ...nextPendingRoles.map((entry) => preserveDeviceRoleScopes(entry, pending.scopes)),
+            ...remainingRoles.map((entry) => preserveDeviceRoleScopes(entry, scopeBaseline)),
           )
         : undefined;
-      state.pendingById[requestId] = {
-        ...pending,
-        role: nextPendingRoles[0],
-        roles: nextPendingRoles,
-        scopes: pendingScopes,
+      const next: PairedDevice = {
+        ...device,
+        role: remainingRoles[0],
+        roles: remainingRoles,
+        ...(preservedScopes !== undefined
+          ? { scopes: preservedScopes, approvedScopes: preservedScopes }
+          : {}),
+        tokens: Object.keys(tokens).length > 0 ? tokens : undefined,
       };
-    }
-
-    const scopeBaseline = device.approvedScopes ?? device.scopes;
-    const preservedScopes = Array.isArray(scopeBaseline)
-      ? mergeDevicePairingScopes(
-          ...remainingRoles.map((entry) => preserveDeviceRoleScopes(entry, scopeBaseline)),
-        )
-      : undefined;
-    const next: PairedDevice = {
-      ...device,
-      role: remainingRoles[0],
-      roles: remainingRoles,
-      ...(preservedScopes !== undefined
-        ? { scopes: preservedScopes, approvedScopes: preservedScopes }
-        : {}),
-      tokens: Object.keys(tokens).length > 0 ? tokens : undefined,
-    };
-    if (role === "node") {
-      // The node capability surface is bound to the node role; revoking the
-      // role must revoke approved command exposure with it.
-      delete next.nodeSurface;
-      delete next.pendingNodeSurface;
-    }
-    state.pairedByDeviceId[normalizedDeviceId] = next;
-    persistState(state, params.baseDir, "both");
-    return { deviceId: normalizedDeviceId, role, removedDevice: false };
+      if (role === "node") {
+        // The node capability surface is bound to the node role; revoking the
+        // role must revoke approved command exposure with it.
+        delete next.nodeSurface;
+        delete next.pendingNodeSurface;
+      }
+      state.pairedByDeviceId[normalizedDeviceId] = next;
+      persist("both");
+      return { deviceId: normalizedDeviceId, role, removedDevice: false };
+    });
   });
 }
 
@@ -742,40 +674,41 @@ export async function updatePairedDeviceMetadata(
   baseDir?: string,
 ): Promise<boolean> {
   return await withLock(async () => {
-    const state = await loadDevicePairingState(baseDir);
-    const normalizedDeviceId = normalizeDevicePairingId(deviceId);
-    const existing = state.pairedByDeviceId[normalizedDeviceId];
-    if (!existing) {
-      return false;
-    }
-    const next = { ...existing };
-    if ("displayName" in patch) {
-      next.displayName = patch.displayName;
-    }
-    if ("operatorLabel" in patch) {
-      next.operatorLabel = patch.operatorLabel;
-    }
-    if ("platform" in patch) {
-      next.platform = patch.platform;
-    }
-    if ("clientId" in patch) {
-      next.clientId = patch.clientId;
-    }
-    if ("clientMode" in patch) {
-      next.clientMode = patch.clientMode;
-    }
-    if ("remoteIp" in patch) {
-      next.remoteIp = patch.remoteIp;
-    }
-    if ("lastSeenAtMs" in patch) {
-      next.lastSeenAtMs = patch.lastSeenAtMs;
-    }
-    if ("lastSeenReason" in patch) {
-      next.lastSeenReason = patch.lastSeenReason;
-    }
-    state.pairedByDeviceId[normalizedDeviceId] = next;
-    persistState(state, baseDir, "paired");
-    return true;
+    return mutatePairingState(baseDir, (state, persist) => {
+      const normalizedDeviceId = normalizeDevicePairingId(deviceId);
+      const existing = state.pairedByDeviceId[normalizedDeviceId];
+      if (!existing) {
+        return false;
+      }
+      const next = { ...existing };
+      if ("displayName" in patch) {
+        next.displayName = patch.displayName;
+      }
+      if ("operatorLabel" in patch) {
+        next.operatorLabel = patch.operatorLabel;
+      }
+      if ("platform" in patch) {
+        next.platform = patch.platform;
+      }
+      if ("clientId" in patch) {
+        next.clientId = patch.clientId;
+      }
+      if ("clientMode" in patch) {
+        next.clientMode = patch.clientMode;
+      }
+      if ("remoteIp" in patch) {
+        next.remoteIp = patch.remoteIp;
+      }
+      if ("lastSeenAtMs" in patch) {
+        next.lastSeenAtMs = patch.lastSeenAtMs;
+      }
+      if ("lastSeenReason" in patch) {
+        next.lastSeenReason = patch.lastSeenReason;
+      }
+      state.pairedByDeviceId[normalizedDeviceId] = next;
+      persist("paired");
+      return true;
+    });
   });
 }
 

--- a/src/infra/push-apns.store.test.ts
+++ b/src/infra/push-apns.store.test.ts
@@ -9,7 +9,7 @@ import {
   runOpenClawStateWriteTransaction,
 } from "../state/openclaw-state-db.js";
 import { createTrackedTempDirs } from "../test-utils/tracked-temp-dirs.js";
-import { persistDevicePairingStoreState } from "./device-pairing-store.js";
+import { seedDevicePairingStoreState } from "./device-pairing-store.test-support.js";
 import { resolveNodePairingGeneration, type PairedDevice } from "./device-pairing.js";
 import { executeSqliteQuerySync, getNodeSqliteKysely } from "./kysely-sync.js";
 import {
@@ -271,10 +271,9 @@ describe("push APNs registration store", () => {
       createdAtMs: 50,
       approvedAtMs: 300,
     };
-    persistDevicePairingStoreState(
+    seedDevicePairingStoreState(
       { pendingById: {}, pairedByDeviceId: { [nodeId]: pairedDevice } },
       baseDir,
-      "paired",
     );
     const generation = resolveNodePairingGeneration(pairedDevice);
     if (!generation) {
@@ -286,7 +285,7 @@ describe("push APNs registration store", () => {
       expectedPairingGeneration: generation.key,
       baseDir,
     });
-    persistDevicePairingStoreState({ pendingById: {}, pairedByDeviceId: {} }, baseDir, "paired", {
+    seedDevicePairingStoreState({ pendingById: {}, pairedByDeviceId: {} }, baseDir, {
       clearApnsNodeIds: [nodeId],
     });
     await expect(loadApnsRegistration(nodeId, baseDir)).resolves.toBeNull();
@@ -308,10 +307,9 @@ describe("push APNs registration store", () => {
         approvedAtMs: 301,
       },
     };
-    persistDevicePairingStoreState(
+    seedDevicePairingStoreState(
       { pendingById: {}, pairedByDeviceId: { [nodeId]: replacementDevice } },
       baseDir,
-      "paired",
     );
     const replacementGeneration = resolveNodePairingGeneration(replacementDevice);
     if (!replacementGeneration) {

--- a/test/scripts/lint-suppressions.test.ts
+++ b/test/scripts/lint-suppressions.test.ts
@@ -217,7 +217,7 @@ describe("production lint suppressions", () => {
         "src/commands/backup-restore.ts|preserve-caught-error|1",
         "src/gateway/test-helpers.server.ts|typescript/no-unnecessary-type-parameters|1",
         "src/hooks/module-loader.ts|typescript/no-unnecessary-type-parameters|1",
-        "src/infra/device-pairing-store.ts|typescript/no-unnecessary-type-parameters|1",
+        "src/infra/device-pairing-store-rows.ts|typescript/no-unnecessary-type-parameters|1",
         "src/infra/exec-approvals-effective.ts|typescript/no-unnecessary-type-parameters|1",
         "src/infra/json-file.ts|typescript-eslint/no-unnecessary-type-parameters|1",
         "src/infra/outbound/send-deps.ts|typescript/no-unnecessary-type-parameters|1",


### PR DESCRIPTION
## What Problem This Solves

A just-approved paired device (typically a freshly approved Node Host) silently disappears from `device_pairing_paired` when any other OpenClaw process performs a routine pairing write from a snapshot taken before that approval. The device pairing lock is process-local, but the Gateway and CLI share `state/openclaw.sqlite`, so a token last-used write in one process could delete a row another process had just committed. To the operator the node simply reconnects as unpaired, with no error anywhere.

## Why This Change Was Made

Root cause, `src/infra/device-pairing-store.ts` (`persistDevicePairingStoreState`):

```ts
executeSqliteQuerySync(db, kysely.deleteFrom("device_pairing_paired"));
const rows = Object.values(state.pairedByDeviceId).map(toPairedRow);
if (rows.length > 0) {
  executeSqliteQuerySync(db, kysely.insertInto("device_pairing_paired").values(rows));
}
```

Every pairing persist replaced the whole pending and/or paired table with an in-memory snapshot that was loaded before the write transaction began, and nothing reread the authoritative rows inside the transaction. The channel pairing store already does this correctly (`readChannelPairingStateFromDatabase` inside `runOpenClawStateWriteTransaction` in `src/pairing/pairing-store.ts`); device pairing did not.

The fix gives the device pairing store the same shape. A new `mutateDevicePairingStoreStateInTransaction` seam reads the snapshot inside the immediate transaction, applies the synchronous mutation, and rewrites the target tables in the same commit. Every pairing mutation flow now runs through it: token verify/ensure/rotate/revoke, owner and bootstrap approval, request/reject/remove/role removal/metadata updates, the node-surface flows behind `withPairedDeviceRecords`, and superseded-silent-pairing pruning. `withPairedDeviceRecords` callbacks become synchronous, matching the repo rule that SQLite write transactions are synchronous commit sections.

Related cleanups in the same boundary:

- Row-scoped node-surface updates (`recordPairedNodeConnection`/`Disconnection`, node facts) already reread inside their own row transaction; they keep the pairing lock and drop the now-redundant full-snapshot load they never used.
- Read-only node flows (`listNodePairing`, `beginNodePairingConnect`, `reusePendingNodePairingForReconnect`, `getPendingNodePairing`) move to a `readPairedDeviceRecords` helper that keeps the cached snapshot read, so list/catalog paths do not start taking the SQLite write lock.
- Two files crossed the 700-line cap from the new seam, so cohesive sections moved out as pure moves: SQLite row mapping to `src/infra/device-pairing-store-rows.ts` (the duplicated setup-completion record builder deduped into `fromSetupCompletionRow`), and silent-pairing pruning to `src/infra/device-pairing-prune.ts`.
- `persistDevicePairingStoreState` is deleted: no production path performs a snapshot-replace write anymore. Suites that seeded fixtures through it now use `seedDevicePairingStoreState` in `device-pairing-store.test-support.ts`, which runs through the same transactional seam.

Sibling surfaces: channel pairing already rereads in-transaction. The device bootstrap token table (`persistDeviceBootstrapTokenRecords`, `src/infra/device-bootstrap.ts` flows) still uses load-then-full-replace; it shares the write shape but holds only short-lived bootstrap credentials, so it is called out here as a named follow-up rather than folded into this fix. Open PR #132831 (pending node-surface TTL, a different defect) edits neighboring lines in `device-pairing-state.ts` and `device-pairing.ts`; there is no logical overlap, only possible rebase overlap.

## User Impact

Approving a device from the CLI while the Gateway is running (or vice versa) can no longer silently unpair another device. Concurrent cross-process pairing writes now serialize on the SQLite write lock: the later writer sees the earlier writer's rows before rewriting the table, so nothing committed is lost.

## Verification

- `node scripts/run-vitest.mjs src/infra/device-pairing.test.ts src/infra/device-pairing-prune.test.ts src/infra/device-pairing-node.test.ts src/infra/device-pairing-churn.test.ts src/infra/device-bootstrap.test.ts src/infra/node-pairing-authz.test.ts src/infra/device-pairing-migration.test.ts src/infra/node-pairing-migration.test.ts src/infra/push-apns.store.test.ts src/gateway/server.node-pairing-memo.test.ts src/gateway/device-pair-setup-completion.test.ts src/gateway/watch-node-http.test.ts src/gateway/server/ws-connection/connect-hello.setup-completion.test.ts src/gateway/server.auth.control-ui.pairing.suite.ts` - all pass (270 tests).
- New regression test `full-snapshot persist keeps rows committed by another process mid-mutation` fails on pristine main (`expected true to be false`, the second process's row is wiped) and passes with this patch.
- `node scripts/run-oxlint.mjs` and `oxfmt --check` on all changed files - clean.
- `node scripts/run-tsgo.mjs -p tsconfig.core.json` and `-p test/tsconfig/tsconfig.core.test.json` - clean.
- `pnpm check:import-cycles` - 0 runtime value cycles.
- Knip production unused-export scan clean after deleting the orphaned export; assertion-safety ratchet green (the four row-mapping assertions moved to `device-pairing-store-rows.ts` carry SAFETY notes, and `config/assertion-safety-baseline.txt` records the shrink of `device-pairing-store.ts` from 6 to 2 grandfathered assertions).
- Two async `withPairedDeviceRecords` test callbacks were rewritten to hold the pairing lock explicitly; they protect the same serialization behavior under the synchronous-callback contract.

## Real behavior proof
Behavior addressed: a device approved by a second OpenClaw process is silently deleted from the shared paired table when the first process performs a routine pairing write from its earlier snapshot.
Real environment tested: the real device pairing runtime (`requestDevicePairing`, `approveDevicePairing`, `withPairedDeviceRecords`) driven as two separate node processes sharing one isolated `OPENCLAW_STATE_DIR` and its real `openclaw.sqlite`, on pristine main f9b3bcccdba3dc159c6484c30f56974b90a6d938 and on the patched tree at 0f42cad0ef4 with identical inputs; on-disk SQLite state, transactions, and both processes are real, with nothing substituted.
Exact steps or command run after this patch: `node_modules/.bin/tsx driver.mts` - the driver pairs and approves `cli-mac`, then performs `cli-mac`'s paired-record write through the production mutation seam while spawning a second real node process that requests and approves `node-host` against the same state dir at that exact moment, then prints the paired table as seen by an independent connection.
Evidence after fix:
```
# BEFORE (pristine main f9b3bcccdba)
paired table after first approval: ["cli-mac"]
during gateway write, second process approved node-host
paired table observed by second connection mid-write: ["cli-mac","node-host"]
paired table after gateway full-snapshot write: ["cli-mac"]
node-host lost: true

# AFTER (this patch, identical inputs)
paired table after first approval: ["cli-mac"]
during gateway write, second process approval failed: Error: database is locked
paired table observed by second connection mid-write: ["cli-mac"]
after gateway write completed, retry: second process approved node-host
paired table after gateway full-snapshot write: ["cli-mac","node-host"]
node-host lost: false
```
Observed result after fix: the concurrent approval is serialized behind the in-flight pairing write instead of interleaving with it, its retry lands once the write commits, and the just-approved node-host row survives the other process's pairing write instead of being silently deleted.
What was not tested: no live Gateway daemon or real device handshake was driven; the cross-process race was staged deterministically by spawning the second process inside the first process's mutation window; full package build not run.
