### PR TITLE
fix(googlechat): delete typing placeholder when a turn delivers no reply

### DIFF
--- a/extensions/googlechat/src/monitor.ts
+++ b/extensions/googlechat/src/monitor.ts
@@ -16,7 +16,7 @@ import { normalizeOptionalLowercaseString } from "openclaw/plugin-sdk/string-coe
 import type { OpenClawConfig } from "../runtime-api.js";
 import { resolveWebhookPath } from "../runtime-api.js";
 import type { ResolvedGoogleChatAccount } from "./accounts.js";
-import { downloadGoogleChatMedia, sendGoogleChatMessage } from "./api.js";
+import { deleteGoogleChatMessage, downloadGoogleChatMedia, sendGoogleChatMessage } from "./api.js";
 import { maybeHandleGoogleChatApprovalCardClick } from "./approval-card-click.js";
 import type { GoogleChatAudienceType } from "./auth.js";
 import { applyGoogleChatInboundAccessPolicy } from "./monitor-access.js";
@@ -425,66 +425,83 @@ async function processMessageWithPipeline(params: {
     }
   }
 
-  await core.channel.inbound.run({
-    channel: "googlechat",
-    accountId: route.accountId,
-    raw: message,
-    ...(turnAdoptionLifecycle ? { turnAdoptionLifecycle } : {}),
-    adapter: {
-      ingest: () => ({
-        id: message.name ?? spaceId,
-        timestamp: timestampMs,
-        rawText: rawBody,
-        textForAgent: rawBody,
-        textForCommands: rawBody,
-        raw: message,
-      }),
-      resolveTurn: () => ({
-        cfg: config,
-        channel: "googlechat",
-        accountId: route.accountId,
-        route: { agentId: route.agentId, sessionKey: route.sessionKey },
-        ctxPayload,
-        delivery: {
-          durable: (payload, info) =>
-            resolveGoogleChatDurableReplyOptions({
-              payload,
-              infoKind: info.kind,
-              spaceId,
-              hasTypingMessage: Boolean(typingMessage),
-            }),
-          deliver: async (payload) => {
-            await deliverGoogleChatReply({
-              payload,
-              account,
-              spaceId,
-              runtime,
-              core,
-              config,
-              statusSink,
-              typingMessage,
-            });
-            // Only use typing message for first delivery
-            typingMessage = undefined;
+  try {
+    await core.channel.inbound.run({
+      channel: "googlechat",
+      accountId: route.accountId,
+      raw: message,
+      ...(turnAdoptionLifecycle ? { turnAdoptionLifecycle } : {}),
+      adapter: {
+        ingest: () => ({
+          id: message.name ?? spaceId,
+          timestamp: timestampMs,
+          rawText: rawBody,
+          textForAgent: rawBody,
+          textForCommands: rawBody,
+          raw: message,
+        }),
+        resolveTurn: () => ({
+          cfg: config,
+          channel: "googlechat",
+          accountId: route.accountId,
+          route: { agentId: route.agentId, sessionKey: route.sessionKey },
+          ctxPayload,
+          delivery: {
+            durable: (payload, info) =>
+              resolveGoogleChatDurableReplyOptions({
+                payload,
+                infoKind: info.kind,
+                spaceId,
+                hasTypingMessage: Boolean(typingMessage),
+              }),
+            deliver: async (payload) => {
+              // Only use typing message for first delivery. Claim it before awaiting so
+              // a failed delivery (which owns its own placeholder cleanup) doesn't leave
+              // it behind for the run-level finally below to double-delete.
+              const claimedTypingMessage = typingMessage;
+              typingMessage = undefined;
+              await deliverGoogleChatReply({
+                payload,
+                account,
+                spaceId,
+                runtime,
+                core,
+                config,
+                statusSink,
+                typingMessage: claimedTypingMessage,
+              });
+            },
+            onDelivered: () => {
+              statusSink?.({ lastOutboundAt: Date.now() });
+            },
+            onError: (err, info) => {
+              runtime.error?.(
+                `[${account.accountId}] Google Chat ${info.kind} reply failed: ${String(err)}`,
+              );
+            },
           },
-          onDelivered: () => {
-            statusSink?.({ lastOutboundAt: Date.now() });
+          replyPipeline: {},
+          record: {
+            onRecordError: (err) => {
+              runtime.error?.(`googlechat: failed updating session meta: ${String(err)}`);
+            },
           },
-          onError: (err, info) => {
-            runtime.error?.(
-              `[${account.accountId}] Google Chat ${info.kind} reply failed: ${String(err)}`,
-            );
-          },
-        },
-        replyPipeline: {},
-        record: {
-          onRecordError: (err) => {
-            runtime.error?.(`googlechat: failed updating session meta: ${String(err)}`);
-          },
-        },
-      }),
-    },
-  });
+        }),
+      },
+    });
+  } finally {
+    // No delivery ever claimed the placeholder (silent/no-op resolution, cancellation,
+    // or a throw before the first delivery attempt): it would otherwise persist forever.
+    if (typingMessage) {
+      const unclaimedTypingMessage = typingMessage;
+      typingMessage = undefined;
+      try {
+        await deleteGoogleChatMessage({ account, messageName: unclaimedTypingMessage.name });
+      } catch (err) {
+        runtime.error?.(`Google Chat typing cleanup failed: ${String(err)}`);
+      }
+    }
+  }
 }
 
 async function downloadAttachment(

--- a/extensions/googlechat/src/monitor.typing-cleanup.test.ts
+++ b/extensions/googlechat/src/monitor.typing-cleanup.test.ts
@@ -1,0 +1,248 @@
+// Googlechat tests cover typing placeholder custody when no reply is delivered.
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ResolvedGoogleChatAccount } from "./accounts.js";
+import type { GoogleChatIngressLifecycle } from "./monitor-ingress.js";
+import type { GoogleChatCoreRuntime, GoogleChatRuntimeEnv } from "./monitor-types.js";
+import "./monitor.js";
+import type { GoogleChatEvent } from "./types.js";
+
+const apiMocks = vi.hoisted(() => ({
+  deleteGoogleChatMessage: vi.fn(),
+  downloadGoogleChatMedia: vi.fn(),
+  sendGoogleChatMessage: vi.fn(),
+  updateGoogleChatMessage: vi.fn(),
+}));
+
+const accessMocks = vi.hoisted(() => ({
+  applyGoogleChatInboundAccessPolicy: vi.fn(),
+}));
+
+const routingMocks = vi.hoisted(() => ({
+  processEvent: undefined as
+    | ((
+        event: GoogleChatEvent,
+        target: Record<string, unknown>,
+        turnAdoptionLifecycle?: GoogleChatIngressLifecycle,
+      ) => Promise<void>)
+    | undefined,
+}));
+
+const inboundMocks = vi.hoisted(() => ({
+  buildEnvelope: vi.fn(({ body }: { body: string }) => body),
+  resolveChannelInboundRouteEnvelope: vi.fn(),
+}));
+
+vi.mock("openclaw/plugin-sdk/channel-inbound", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/channel-inbound")>();
+  return {
+    ...actual,
+    resolveChannelInboundRouteEnvelope: inboundMocks.resolveChannelInboundRouteEnvelope,
+  };
+});
+
+vi.mock("./api.js", () => ({
+  deleteGoogleChatMessage: apiMocks.deleteGoogleChatMessage,
+  downloadGoogleChatMedia: apiMocks.downloadGoogleChatMedia,
+  sendGoogleChatMessage: apiMocks.sendGoogleChatMessage,
+  updateGoogleChatMessage: apiMocks.updateGoogleChatMessage,
+}));
+
+vi.mock("./monitor-access.js", () => ({
+  applyGoogleChatInboundAccessPolicy: accessMocks.applyGoogleChatInboundAccessPolicy,
+}));
+
+vi.mock("./monitor-routing.js", () => ({
+  registerGoogleChatWebhookTarget: vi.fn(),
+  setGoogleChatWebhookEventProcessor: vi.fn(
+    (
+      processEvent: (
+        event: GoogleChatEvent,
+        target: Record<string, unknown>,
+        turnAdoptionLifecycle?: GoogleChatIngressLifecycle,
+      ) => Promise<void>,
+    ) => {
+      routingMocks.processEvent = processEvent;
+    },
+  ),
+}));
+
+beforeEach(() => {
+  apiMocks.deleteGoogleChatMessage.mockReset();
+  apiMocks.downloadGoogleChatMedia.mockReset();
+  apiMocks.sendGoogleChatMessage.mockReset().mockResolvedValue(null);
+  apiMocks.updateGoogleChatMessage.mockReset().mockResolvedValue({});
+  accessMocks.applyGoogleChatInboundAccessPolicy.mockReset().mockResolvedValue({
+    ok: true,
+    commandAuthorized: undefined,
+    effectiveWasMentioned: undefined,
+    groupBotLoopProtection: undefined,
+    groupSystemPrompt: undefined,
+  });
+  inboundMocks.buildEnvelope.mockReset().mockImplementation(({ body }: { body: string }) => body);
+  inboundMocks.resolveChannelInboundRouteEnvelope
+    .mockReset()
+    .mockImplementation(({ accountId }: { accountId: string }) => ({
+      route: {
+        agentId: "agent-1",
+        accountId,
+        sessionKey: "session-1",
+      },
+      buildEnvelope: inboundMocks.buildEnvelope,
+    }));
+});
+
+const account = {
+  accountId: "work",
+  config: {},
+  credentialSource: "inline",
+} as ResolvedGoogleChatAccount;
+
+function createTypingCleanupHarness(runTurn: ReturnType<typeof vi.fn>) {
+  return {
+    logging: { shouldLogVerbose: () => false },
+    channel: {
+      inbound: { buildContext: vi.fn((payload: unknown) => payload), run: runTurn },
+      media: { saveMediaBuffer: vi.fn() },
+    },
+  } as unknown as GoogleChatCoreRuntime;
+}
+
+function typingCleanupEvent(spaceName: string): GoogleChatEvent {
+  return {
+    type: "MESSAGE",
+    space: { name: spaceName, spaceType: "SPACE" },
+    message: {
+      name: `${spaceName}/messages/1`,
+      text: "hello",
+      sender: { name: "users/alice", displayName: "Alice", type: "HUMAN" },
+    },
+  } satisfies GoogleChatEvent;
+}
+
+async function processTypingCleanupEvent(params: {
+  event: GoogleChatEvent;
+  core: GoogleChatCoreRuntime;
+  runtime: GoogleChatRuntimeEnv;
+}): Promise<void> {
+  if (!routingMocks.processEvent) {
+    throw new Error("Expected Google Chat webhook event processor registration");
+  }
+  await routingMocks.processEvent(params.event, {
+    account,
+    config: {},
+    runtime: params.runtime,
+    core: params.core,
+    mediaMaxMb: 10,
+    path: "/googlechat",
+  });
+}
+
+describe("googlechat monitor typing placeholder custody", () => {
+  it("deletes the unclaimed placeholder when the turn resolves without delivering a reply", async () => {
+    const core = createTypingCleanupHarness(vi.fn().mockResolvedValue(undefined));
+    apiMocks.sendGoogleChatMessage.mockResolvedValueOnce({
+      messageName: "spaces/SILENT/messages/typing",
+      threadName: undefined,
+    });
+
+    await processTypingCleanupEvent({
+      event: typingCleanupEvent("spaces/SILENT"),
+      core,
+      runtime: { error: vi.fn(), log: vi.fn() },
+    });
+
+    expect(apiMocks.deleteGoogleChatMessage).toHaveBeenCalledWith({
+      account,
+      messageName: "spaces/SILENT/messages/typing",
+    });
+  });
+
+  it("deletes the unclaimed placeholder when the turn throws before delivering a reply", async () => {
+    const turnError = new Error("turn boom");
+    const core = createTypingCleanupHarness(vi.fn().mockRejectedValue(turnError));
+    apiMocks.sendGoogleChatMessage.mockResolvedValueOnce({
+      messageName: "spaces/THROW/messages/typing",
+      threadName: undefined,
+    });
+
+    await expect(
+      processTypingCleanupEvent({
+        event: typingCleanupEvent("spaces/THROW"),
+        core,
+        runtime: { error: vi.fn(), log: vi.fn() },
+      }),
+    ).rejects.toThrow(turnError);
+
+    expect(apiMocks.deleteGoogleChatMessage).toHaveBeenCalledWith({
+      account,
+      messageName: "spaces/THROW/messages/typing",
+    });
+  });
+
+  it("keeps the original turn failure when placeholder cleanup also fails", async () => {
+    const turnError = new Error("turn boom");
+    const core = createTypingCleanupHarness(vi.fn().mockRejectedValue(turnError));
+    const runtime = { error: vi.fn(), log: vi.fn() } satisfies GoogleChatRuntimeEnv;
+    apiMocks.sendGoogleChatMessage.mockResolvedValueOnce({
+      messageName: "spaces/CLEANUPFAIL/messages/typing",
+      threadName: undefined,
+    });
+    apiMocks.deleteGoogleChatMessage.mockRejectedValue(new Error("delete boom"));
+
+    await expect(
+      processTypingCleanupEvent({
+        event: typingCleanupEvent("spaces/CLEANUPFAIL"),
+        core,
+        runtime,
+      }),
+    ).rejects.toThrow(turnError);
+
+    expect(runtime.error).toHaveBeenCalledWith(
+      expect.stringContaining("Google Chat typing cleanup failed"),
+    );
+  });
+
+  it("leaves placeholder deletion to delivery once a reply claims it", async () => {
+    const core = {
+      logging: { shouldLogVerbose: () => false },
+      channel: {
+        inbound: {
+          buildContext: vi.fn((payload: unknown) => payload),
+          run: vi.fn(
+            async (params: {
+              adapter: {
+                resolveTurn: () => {
+                  delivery: { deliver: (payload: { text: string }) => Promise<void> };
+                };
+              };
+            }) => {
+              await params.adapter.resolveTurn().delivery.deliver({ text: "answer" });
+            },
+          ),
+        },
+        media: { saveMediaBuffer: vi.fn() },
+        text: {
+          resolveChunkMode: vi.fn(() => "markdown"),
+          chunkMarkdownTextWithMode: vi.fn(() => ["answer"]),
+        },
+      },
+    } as unknown as GoogleChatCoreRuntime;
+    apiMocks.sendGoogleChatMessage.mockResolvedValueOnce({
+      messageName: "spaces/CLAIMED/messages/typing",
+      threadName: undefined,
+    });
+
+    await processTypingCleanupEvent({
+      event: typingCleanupEvent("spaces/CLAIMED"),
+      core,
+      runtime: { error: vi.fn(), log: vi.fn() },
+    });
+
+    expect(apiMocks.updateGoogleChatMessage).toHaveBeenCalledWith({
+      account,
+      messageName: "spaces/CLAIMED/messages/typing",
+      text: "answer",
+    });
+    expect(apiMocks.deleteGoogleChatMessage).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Closes #127567

## What Problem This Solves

Fixes an issue where Google Chat users would see a permanent "OpenClaw is typing..." message when a turn produced no reply. In the default `typingIndicator: "message"` mode the placeholder is a real, durable message in the space, not a transient indicator. Its only owner is the reply-delivery path, so a turn that resolves silently (NO_REPLY), is cancelled, or throws before the first delivery leaves the placeholder sitting in the space with nothing left to remove it.

## Why This Change Was Made

The monitor now keeps explicit custody of the placeholder for the whole inbound run. The first delivery claims it (clearing the outer reference before awaiting), and a run-level `finally` deletes it only when no delivery ever claimed it. Claiming before the await matters: `deliverGoogleChatReply` already owns thread-mismatch deletes, media-only deletes, and ambiguous PATCH outcomes, so the outer cleanup must never second-guess a placeholder delivery has taken over — including when delivery itself fails. Cleanup failures are logged through the existing error sink and never replace the turn's own outcome.

Production +17/-6 LOC in `monitor.ts` (the rest of that file's diff is indentation from the added `try`); one new focused test file.

## User Impact

A Google Chat turn that produces no reply no longer leaves a misleading "is typing..." message behind. Normal replies are unchanged — the placeholder is still edited in place into the first chunk.

## Evidence

Red-then-green on the new tests, same commit, `extensions/googlechat/src/monitor.typing-cleanup.test.ts`:

Before the fix (production change reverted, tests kept):

```
 Test Files  1 failed (1)
      Tests  3 failed | 1 passed (4)
```

The three failures are the silent-resolution delete, the throw-before-delivery delete, and the cleanup-failure logging. The fourth test asserts unchanged claimed-delivery behavior and passes either way, which is the point of including it.

After the fix:

```
 ✓ deletes the unclaimed placeholder when the turn resolves without delivering a reply
 ✓ deletes the unclaimed placeholder when the turn throws before delivering a reply
 ✓ keeps the original turn failure when placeholder cleanup also fails
 ✓ leaves placeholder deletion to delivery once a reply claims it

 Test Files  1 passed (1)
      Tests  4 passed (4)
```

Full extension suite, `pnpm test:extension googlechat`:

```
 Test Files  34 passed (34)
      Tests  351 passed (351)
```

`pnpm check:changed` exit 0 (format, extension typecheck, extension test typecheck, lint, dead-export scan, plugin boundaries, runtime sidecar loader guard, import cycles: 0 runtime value cycles).

`pnpm build` exit 0 on this checkout.

Not validated: no live Google Chat workspace was used, so this is source-level and focused-test proof only. The cancellation path is covered through the throw-before-delivery case rather than a real cancellation signal.

<!-- gk-ai-analysis-start:58b4a79b6fab17837e83fa8e83ab7418749e3b09 -->
<!-- gk-ai-analysis-data:eyJzdW1tYXJ5IjoiRml4ZXMgYSBsZWFrIG9mIHRoZSBHb29nbGUgQ2hhdCB0eXBpbmcgcGxhY2Vob2xkZXIgbWVzc2FnZSBieSBleHBsaWNpdGx5IG1hbmFnaW5nIGl0cyBjdXN0b2R5IGFuZCBlbnN1cmluZyBpdCBpcyBkZWxldGVkIGlmIHRoZSBpbmJvdW5kIHR1cm4gY29tcGxldGVzIG9yIGZhaWxzIHdpdGhvdXQgZGVsaXZlcmluZyBhIHJlcGx5LiIsImtleUluc2lnaHRzIjpbeyJ0aXRsZSI6IlR5cGluZyBtZXNzYWdlIGNsZWFudXAgaW4gZmluYWxseSBibG9jayIsImRlc2NyaXB0aW9uIjoiV3JhcHMgdGhlIGluYm91bmQgcnVuIGV4ZWN1dGlvbiBpbiBhIHRyeS9maW5hbGx5IGJsb2NrIHRvIGRlbGV0ZSB0aGUgYHR5cGluZ01lc3NhZ2VgIHBsYWNlaG9sZGVyIGlmIGl0IGlzIGxlZnQgdW5jbGFpbWVkIGFmdGVyIHRoZSB0dXJuIGZpbmlzaGVzIG9yIGZhaWxzLiIsInNldmVyaXR5IjoibWVkaXVtIiwiZmlsZVBhdGgiOiJleHRlbnNpb25zL2dvb2dsZWNoYXQvc3JjL21vbml0b3IudHMiLCJsaW5lU3RhcnQiOjQyOH0seyJ0aXRsZSI6IkV4cGxpY2l0IGN1c3RvZHkgdHJhbnNmZXIgZm9yIHR5cGluZyBtZXNzYWdlIiwiZGVzY3JpcHRpb24iOiJJbnNpZGUgYGRlbGl2ZXJgLCB0aGUgYHR5cGluZ01lc3NhZ2VgIGlzIGNhcHR1cmVkIGludG8gYGNsYWltZWRUeXBpbmdNZXNzYWdlYCBhbmQgdGhlIG91dGVyIHJlZmVyZW5jZSBpcyBjbGVhcmVkIGJlZm9yZSBhd2FpdGluZyBgZGVsaXZlckdvb2dsZUNoYXRSZXBseWAuIFRoaXMgcHJldmVudHMgdGhlIGBmaW5hbGx5YCBibG9jayBmcm9tIGF0dGVtcHRpbmcgdG8gZG91YmxlLWRlbGV0ZSBpZiBkZWxpdmVyeSBmYWlscy4iLCJzZXZlcml0eSI6Im1lZGl1bSIsImZpbGVQYXRoIjoiZXh0ZW5zaW9ucy9nb29nbGVjaGF0L3NyYy9tb25pdG9yLnRzIiwibGluZVN0YXJ0Ijo0NTZ9LHsidGl0bGUiOiJHcmFjZWZ1bCBjbGVhbnVwIGVycm9yIGhhbmRsaW5nIiwiZGVzY3JpcHRpb24iOiJJZiBkZWxldGluZyB0aGUgdW5jbGFpbWVkIHR5cGluZyBwbGFjZWhvbGRlciB0aHJvd3MgYW4gZXJyb3IgaW4gdGhlIGBmaW5hbGx5YCBibG9jaywgdGhlIGVycm9yIGlzIGNhdWdodCBhbmQgbG9nZ2VkIHRvIGBydW50aW1lLmVycm9yYCBzbyBpdCBkb2VzIG5vdCBtYXNrIGFueSBvcmlnaW5hbCBlcnJvciBmcm9tIHRoZSB0dXJuIGV4ZWN1dGlvbi4iLCJzZXZlcml0eSI6ImxvdyIsImZpbGVQYXRoIjoiZXh0ZW5zaW9ucy9nb29nbGVjaGF0L3NyYy9tb25pdG9yLnRzIiwibGluZVN0YXJ0Ijo0OTB9XSwiaXNzdWVzIjpbXSwic3VnZ2VzdGlvbnMiOltdLCJzZWN1cml0eSI6W119 -->
<!-- gk-ai-analysis-end:58b4a79b6fab17837e83fa8e83ab7418749e3b09 -->

<!-- gitkraken-review-badge-begin -->
---
<a href="https://gitkraken.dev/review/github/openclaw/openclaw/pull/132860?source=pr_review_chip">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://gitkraken.dev/images/figures/gitkraken-review-badge-dark.svg">
    <img src="https://gitkraken.dev/images/figures/gitkraken-review-badge-light.svg" alt="Open with GitKraken">
  </picture>
</a>
<!-- gitkraken-review-badge-end -->