### PR TITLE
refactor(scripts): reuse dependency report CLI helpers

### DIFF
--- a/scripts/dependency-changes-report.mts
+++ b/scripts/dependency-changes-report.mts
@@ -2,9 +2,11 @@
 
 // Builds dependency change reports from lockfile and manifest diffs.
 import { execFileSync } from "node:child_process";
-import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { readFile } from "node:fs/promises";
 import path from "node:path";
 import process from "node:process";
+import { parseFlagArgs, stringFlag } from "./lib/arg-utils.mts";
+import { writeReportArtifact } from "./lib/report-cli-helpers.mts";
 import {
   collectAllResolvedPackagesFromLockfile,
   createBulkAdvisoryPayload,
@@ -251,14 +253,6 @@ function gitDiffDependencyFiles(baseRef: string, cwd: string) {
     });
 }
 
-function readRequiredValue(argv: string[], index: number, flag: string) {
-  const value = argv[index + 1];
-  if (!value || value.startsWith("-")) {
-    throw new Error(`${flag} requires a value`);
-  }
-  return value;
-}
-
 export function parseArgs(argv: string[]) {
   const options = {
     rootDir: process.cwd(),
@@ -268,51 +262,31 @@ export function parseArgs(argv: string[]) {
     jsonPath: nullableString(null),
     markdownPath: nullableString(null),
   };
-  const seen = new Set<string>();
-  const setOnce = (flag: string, key: keyof typeof options, value: string) => {
-    if (seen.has(flag)) {
-      throw new Error(`${flag} was provided more than once.`);
-    }
-    seen.add(flag);
-    Object.assign(options, { [key]: value });
-  };
-  for (let index = 0; index < argv.length; index += 1) {
-    const arg = argv[index];
-    if (arg === "--") {
-      continue;
-    }
-    if (arg === "--root") {
-      setOnce(arg, "rootDir", readRequiredValue(argv, index, "--root"));
-      index += 1;
-      continue;
-    }
-    if (arg === "--base-ref") {
-      setOnce(arg, "baseRef", readRequiredValue(argv, index, "--base-ref"));
-      index += 1;
-      continue;
-    }
-    if (arg === "--base-lockfile") {
-      setOnce(arg, "baseLockfile", readRequiredValue(argv, index, "--base-lockfile"));
-      index += 1;
-      continue;
-    }
-    if (arg === "--head-lockfile") {
-      setOnce(arg, "headLockfile", readRequiredValue(argv, index, "--head-lockfile"));
-      index += 1;
-      continue;
-    }
-    if (arg === "--json") {
-      setOnce(arg, "jsonPath", readRequiredValue(argv, index, "--json"));
-      index += 1;
-      continue;
-    }
-    if (arg === "--markdown") {
-      setOnce(arg, "markdownPath", readRequiredValue(argv, index, "--markdown"));
-      index += 1;
-      continue;
-    }
-    throw new Error(`Unsupported argument: ${arg}`);
-  }
+  const flagEntries = [
+    ["--root", "rootDir"],
+    ["--base-ref", "baseRef"],
+    ["--base-lockfile", "baseLockfile"],
+    ["--head-lockfile", "headLockfile"],
+    ["--json", "jsonPath"],
+    ["--markdown", "markdownPath"],
+  ] satisfies Array<[string, keyof typeof options]>;
+  parseFlagArgs(
+    argv,
+    options,
+    flagEntries.map(([flag, key]) =>
+      stringFlag<typeof options>(flag, key, {
+        allowInline: false,
+        missingValueMessage: `${flag} requires a value`,
+        rejectShortOptions: true,
+      }),
+    ),
+    {
+      duplicateOptionMessage: (flag) => `${flag} was provided more than once.`,
+      onUnhandledArg(arg) {
+        throw new Error(`Unsupported argument: ${arg}`);
+      },
+    },
+  );
   const { baseRef, baseLockfile } = options;
   if (baseRef && baseLockfile) {
     throw new Error("Use either --base-ref or --base-lockfile, not both.");
@@ -324,14 +298,6 @@ export function parseArgs(argv: string[]) {
     return { ...options, baseLockfile, baseRef: null };
   }
   throw new Error("Expected --base-ref <git-ref> or --base-lockfile <path>.");
-}
-
-async function writeArtifact(filePath: string | null, content: string) {
-  if (!filePath) {
-    return;
-  }
-  await mkdir(path.dirname(filePath), { recursive: true });
-  await writeFile(filePath, content, "utf8");
 }
 
 /**
@@ -360,8 +326,8 @@ async function runDependencyChangesReport(options: ReturnType<typeof parseArgs>)
 export async function main(argv = process.argv.slice(2)) {
   const options = parseArgs(argv);
   const report = await runDependencyChangesReport(options);
-  await writeArtifact(options.jsonPath, `${JSON.stringify(report, null, 2)}\n`);
-  await writeArtifact(options.markdownPath, renderMarkdownReport(report));
+  await writeReportArtifact(options.jsonPath, `${JSON.stringify(report, null, 2)}\n`);
+  await writeReportArtifact(options.markdownPath, renderMarkdownReport(report));
   const artifactHint =
     typeof options.markdownPath === "string" ? " See ".concat(options.markdownPath, ".") : "";
   process.stdout.write(

--- a/test/scripts/dependency-changes-report.test.ts
+++ b/test/scripts/dependency-changes-report.test.ts
@@ -78,6 +78,43 @@ describe("dependency-changes-report", () => {
     expect(dependencyDiffPathspecs()).toContain(".github/release/vercel-cli/package-lock.json");
   });
 
+  it.each([
+    {
+      name: "git ref",
+      baseArgs: ["--base-ref", "origin/main"],
+      expectedBaseRef: "origin/main",
+      expectedBaseLockfile: null,
+    },
+    {
+      name: "lockfile",
+      baseArgs: ["--base-lockfile", "base-lock.yaml"],
+      expectedBaseRef: null,
+      expectedBaseLockfile: "base-lock.yaml",
+    },
+  ])("parses all report options with a $name base", (testCase) => {
+    expect(
+      parseArgs([
+        "--root",
+        "/repo",
+        ...testCase.baseArgs,
+        "--head-lockfile",
+        "head-lock.yaml",
+        "--json",
+        "artifacts/report.json",
+        "--",
+        "--markdown",
+        "artifacts/report.md",
+      ]),
+    ).toEqual({
+      rootDir: "/repo",
+      baseRef: testCase.expectedBaseRef,
+      baseLockfile: testCase.expectedBaseLockfile,
+      headLockfile: "head-lock.yaml",
+      jsonPath: "artifacts/report.json",
+      markdownPath: "artifacts/report.md",
+    });
+  });
+
   it("rejects missing report artifact path option values", () => {
     for (const flag of [
       "--root",


### PR DESCRIPTION
## What Problem This Solves

The dependency change report maintained its own argument parser and artifact writer even though repository-owned helpers already implement those contracts. That duplicated policy could drift as the shared script tooling evolves.

## Why This Change Was Made

Reuse the canonical flag parser and report artifact writer while preserving the dependency report's existing defaults, errors, duplicate handling, option separator behavior, and mutually exclusive base selection.

## User Impact

No user-visible behavior changes. Maintainers get one canonical implementation for these script contracts and less duplicate tooling code.

## Evidence

- `node scripts/run-vitest.mjs test/scripts/dependency-changes-report.test.ts test/scripts/report-cli-helpers.test.ts test/scripts/arg-utils.test.ts` (84 tests passed)
- `git diff --check`
- focused formatting, lint, and semantic checks passed
- autoreview: no accepted/actionable findings
- tooling LOC: +30/-64 (net -34); tests: +37/-0
