### PR TITLE
fix(test): isolate Vitest caches across linked checkouts

### DIFF
--- a/scripts/test-extension-batch.mts
+++ b/scripts/test-extension-batch.mts
@@ -4,6 +4,7 @@
 import path from "node:path";
 import pMap from "p-map";
 import { collectVitestExcludePatterns } from "../test/vitest/vitest.pattern-file.ts";
+import { resolveVitestFsModuleCacheRoot } from "../test/vitest/vitest.performance-config.ts";
 import {
   createExtensionTestProcessTargetChunks,
   listExtensionTestFilesForRoots,
@@ -102,9 +103,7 @@ function createGroupEnv({
   return {
     ...baseEnv,
     [FS_MODULE_CACHE_PATH_ENV_KEY]: path.join(
-      process.cwd(),
-      "node_modules",
-      ".experimental-vitest-cache",
+      resolveVitestFsModuleCacheRoot(),
       "extension-batch",
       sanitizeCacheSegment(`${groupIndex}-${group.config}`),
     ),

--- a/scripts/test-projects.test-support.mts
+++ b/scripts/test-projects.test-support.mts
@@ -60,6 +60,7 @@ import {
 import { isVoiceCallExtensionRoot } from "../test/vitest/vitest.extension-voice-call-paths.mjs";
 import { isWhatsAppExtensionRoot } from "../test/vitest/vitest.extension-whatsapp-paths.mjs";
 import { isZaloExtensionRoot } from "../test/vitest/vitest.extension-zalo-paths.mjs";
+import { resolveVitestFsModuleCacheRoot } from "../test/vitest/vitest.performance-config.ts";
 import {
   isPluginSdkLightTarget,
   pluginSdkLightTestFiles,
@@ -4146,8 +4147,7 @@ export function applyParallelVitestCachePaths<T extends VitestSpecShape>(
   const configuredCacheRoot = baseEnv[FS_MODULE_CACHE_PATH_ENV_KEY]?.trim() || undefined;
   // CI publishes a persistent cache root, not a writer-safe leaf. Every
   // concurrent Vitest process still needs its own live directory below it.
-  const cacheRoot =
-    configuredCacheRoot ?? path.join(cwd, "node_modules", ".experimental-vitest-cache");
+  const cacheRoot = configuredCacheRoot ?? resolveVitestFsModuleCacheRoot(cwd);
   return specs.map((spec, index) => {
     const specCachePath = spec.env?.[FS_MODULE_CACHE_PATH_ENV_KEY]?.trim();
     if (specCachePath && specCachePath !== configuredCacheRoot) {

--- a/src/scripts/test-projects.test.ts
+++ b/src/scripts/test-projects.test.ts
@@ -513,10 +513,10 @@ describe("test-projects args", () => {
     const firstEnv = specs[0]?.env;
     expect(firstEnv?.KEEP_ME).toBe("1");
     expect(firstEnv?.OPENCLAW_VITEST_FS_MODULE_CACHE_PATH?.replaceAll("\\", "/")).toBe(
-      "/repo/node_modules/.experimental-vitest-cache/0-test-vitest-vitest.gateway.config.ts",
+      "/repo/.cache/vitest/0-test-vitest-vitest.gateway.config.ts",
     );
     expect(specs[1]?.env.OPENCLAW_VITEST_FS_MODULE_CACHE_PATH?.replaceAll("\\", "/")).toBe(
-      "/repo/node_modules/.experimental-vitest-cache/1-test-vitest-vitest.gateway-server.config.ts",
+      "/repo/.cache/vitest/1-test-vitest-vitest.gateway-server.config.ts",
     );
   });
 

--- a/test/scripts/test-extension.test.ts
+++ b/test/scripts/test-extension.test.ts
@@ -607,8 +607,8 @@ describe("scripts/test-extension.mts", () => {
         OPENCLAW_EXTENSION_BATCH_PARALLEL: "2",
         OPENCLAW_VITEST_FS_MODULE_CACHE_PATH: path.join(
           process.cwd(),
-          "node_modules",
-          ".experimental-vitest-cache",
+          ".cache",
+          "vitest",
           "extension-batch",
           "0-heavy",
         ),

--- a/test/scripts/test-group-report.test.ts
+++ b/test/scripts/test-group-report.test.ts
@@ -1335,8 +1335,8 @@ describe("scripts/test-group-report run plans", () => {
     );
 
     expect(specs.map((spec) => spec.env.OPENCLAW_VITEST_FS_MODULE_CACHE_PATH)).toEqual([
-      path.join("/repo", "node_modules", ".experimental-vitest-cache", "0-a.ts"),
-      path.join("/repo", "node_modules", ".experimental-vitest-cache", "1-b.ts"),
+      path.join("/repo", ".cache", "vitest", "0-a.ts"),
+      path.join("/repo", ".cache", "vitest", "1-b.ts"),
     ]);
     expect(specs.map((spec) => spec.vitestArgs)).toEqual([[], []]);
   });

--- a/test/scripts/test-projects.test.ts
+++ b/test/scripts/test-projects.test.ts
@@ -4329,18 +4329,8 @@ describe("scripts/test-projects Vitest cache isolation", () => {
     );
 
     expect(specs.map((spec) => spec.env.OPENCLAW_VITEST_FS_MODULE_CACHE_PATH)).toEqual([
-      path.join(
-        "/repo",
-        "node_modules",
-        ".experimental-vitest-cache",
-        "0-test-vitest-vitest.unit-fast.config.ts",
-      ),
-      path.join(
-        "/repo",
-        "node_modules",
-        ".experimental-vitest-cache",
-        "1-test-vitest-vitest.extension-memory.config.ts",
-      ),
+      path.join("/repo", ".cache", "vitest", "0-test-vitest-vitest.unit-fast.config.ts"),
+      path.join("/repo", ".cache", "vitest", "1-test-vitest-vitest.extension-memory.config.ts"),
     ]);
   });
 

--- a/test/vitest-performance-config.test.ts
+++ b/test/vitest-performance-config.test.ts
@@ -1,5 +1,10 @@
 // Vitest performance config tests validate performance test project setup.
-import { describe, expect, it } from "vitest";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import { createRequire } from "node:module";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { useAutoCleanupTempDirTracker } from "./helpers/temp-dir.js";
 import { loadVitestExperimentalConfig } from "./vitest/vitest.performance-config.ts";
 
 describe("loadVitestExperimentalConfig", () => {
@@ -7,6 +12,7 @@ describe("loadVitestExperimentalConfig", () => {
     expect(loadVitestExperimentalConfig({}, "linux")).toEqual({
       experimental: {
         fsModuleCache: true,
+        fsModuleCachePath: path.join(process.cwd(), ".cache", "vitest", "default"),
       },
     });
   });
@@ -22,6 +28,7 @@ describe("loadVitestExperimentalConfig", () => {
     ).toEqual({
       experimental: {
         fsModuleCache: true,
+        fsModuleCachePath: path.join(process.cwd(), ".cache", "vitest", "default"),
       },
     });
   });
@@ -57,6 +64,7 @@ describe("loadVitestExperimentalConfig", () => {
     ).toEqual({
       experimental: {
         fsModuleCache: true,
+        fsModuleCachePath: path.join(process.cwd(), ".cache", "vitest", "default"),
       },
     });
   });
@@ -84,6 +92,7 @@ describe("loadVitestExperimentalConfig", () => {
     ).toEqual({
       experimental: {
         fsModuleCache: true,
+        fsModuleCachePath: path.join(process.cwd(), ".cache", "vitest", "default"),
         importDurations: { print: true },
         printImportBreakdown: true,
       },
@@ -92,5 +101,75 @@ describe("loadVitestExperimentalConfig", () => {
 
   it("uses RUNNER_OS to detect Windows even when the platform is not win32", () => {
     expect(loadVitestExperimentalConfig({ RUNNER_OS: "Windows" }, "linux")).toStrictEqual({});
+  });
+});
+
+describe("filesystem module cache ownership", () => {
+  const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+  it("preserves another checkout's cache when shared dependencies change", () => {
+    const root = tempDirs.make("oc-vitest-cache-ownership-");
+    const sharedModules = path.join(root, "shared", "node_modules");
+    fs.mkdirSync(path.join(sharedModules, ".pnpm"), { recursive: true });
+    const lockfile = path.join(sharedModules, ".pnpm", "lock.yaml");
+    fs.writeFileSync(lockfile, "lockfileVersion: 1\n");
+    const cli = path.join(
+      path.dirname(createRequire(import.meta.url).resolve("vitest/package.json")),
+      "vitest.mjs",
+    );
+    const prepareCheckout = (name: string) => {
+      const checkout = path.join(root, name);
+      fs.mkdirSync(checkout);
+      // Stop Vite's workspace search before it reaches this repository. The
+      // symlink points only at this fixture's dependencies and writable cache.
+      fs.writeFileSync(
+        path.join(checkout, "package.json"),
+        JSON.stringify({ name, type: "module", workspaces: [] }),
+      );
+      fs.symlinkSync(sharedModules, path.join(checkout, "node_modules"), "junction");
+      fs.writeFileSync(
+        path.join(checkout, "fixture.test.js"),
+        'test("runs the fixture", () => expect(2 + 2).toBe(4));\n',
+      );
+      const cacheConfig = loadVitestExperimentalConfig({}, "linux", checkout);
+      const config = {
+        root: checkout,
+        test: {
+          globals: true,
+          include: ["fixture.test.js"],
+          maxWorkers: 1,
+          ...cacheConfig,
+        },
+      };
+      fs.writeFileSync(
+        path.join(checkout, "vitest.config.mjs"),
+        `export default ${JSON.stringify(config)};\n`,
+      );
+      return { checkout, cacheConfig };
+    };
+    const run = (checkout: string) => {
+      const result = spawnSync(
+        process.execPath,
+        [cli, "run", "--config", path.join(checkout, "vitest.config.mjs")],
+        {
+          cwd: checkout,
+          encoding: "utf8",
+          env: { PATH: process.env.PATH, SystemRoot: process.env.SystemRoot, CI: "1", HOME: root },
+          timeout: 15_000,
+        },
+      );
+      expect(result.status, `${result.error ?? ""}\n${result.stdout}\n${result.stderr}`).toBe(0);
+    };
+    const first = prepareCheckout("first");
+    const second = prepareCheckout("second");
+    run(first.checkout);
+    const firstCache =
+      first.cacheConfig.experimental?.fsModuleCachePath ??
+      path.join(sharedModules, ".experimental-vitest-cache");
+    const sentinel = path.join(firstCache, "first-checkout-sentinel");
+    fs.writeFileSync(sentinel, "owned by first checkout");
+    fs.writeFileSync(lockfile, "lockfileVersion: 2\n");
+    run(second.checkout);
+    expect(fs.readFileSync(sentinel, "utf8")).toBe("owned by first checkout");
   });
 });

--- a/test/vitest/vitest.performance-config.ts
+++ b/test/vitest/vitest.performance-config.ts
@@ -1,4 +1,5 @@
 // Vitest performance config helper normalizes performance test environment settings.
+import path from "node:path";
 type EnvMap = Record<string, string | undefined>;
 
 const isEnabled = (value: string | undefined): boolean => {
@@ -28,9 +29,16 @@ type VitestExperimentalConfig = {
   };
 };
 
+// Linked worktrees may share node_modules; invalidating that cache would remove
+// another checkout's transforms. Keep writable cache ownership in this checkout.
+export function resolveVitestFsModuleCacheRoot(cwd = process.cwd()): string {
+  return path.join(cwd, ".cache", "vitest");
+}
+
 export function loadVitestExperimentalConfig(
   env: EnvMap = process.env,
   platform: NodeJS.Platform = process.platform,
+  cwd = process.cwd(),
 ): VitestExperimentalConfig {
   const experimental: {
     fsModuleCache?: true;
@@ -46,8 +54,12 @@ export function loadVitestExperimentalConfig(
   if (windowsEnv && isEnabled(env.OPENCLAW_VITEST_FS_MODULE_CACHE)) {
     experimental.fsModuleCache = true;
   }
-  if (experimental.fsModuleCache && env.OPENCLAW_VITEST_FS_MODULE_CACHE_PATH?.trim()) {
-    experimental.fsModuleCachePath = env.OPENCLAW_VITEST_FS_MODULE_CACHE_PATH.trim();
+  if (experimental.fsModuleCache) {
+    // The default leaf cannot contain the scheduler's concurrent cache leaves:
+    // Vitest recursively removes its selected directory when lockfiles change.
+    experimental.fsModuleCachePath =
+      env.OPENCLAW_VITEST_FS_MODULE_CACHE_PATH?.trim() ||
+      path.join(resolveVitestFsModuleCacheRoot(cwd), "default");
   }
   if (isEnabled(env.OPENCLAW_VITEST_IMPORT_DURATIONS)) {
     experimental.importDurations = { print: true };

--- a/test/vitest/vitest.shared.config.ts
+++ b/test/vitest/vitest.shared.config.ts
@@ -584,6 +584,6 @@ export const sharedVitestConfig = {
         "src/infra/tailscale.ts",
       ],
     },
-    ...loadVitestExperimentalConfig(),
+    ...loadVitestExperimentalConfig(process.env, process.platform, repoRoot),
   },
 };


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where focused tests stall before starting when linked worktrees share installed dependencies. A test in one checkout can invalidate and recursively delete another checkout's Vitest transforms.

## Why This Change Was Made

Vitest's default filesystem cache lives beneath node_modules, which is shared by linked development checkouts. Its lockfile integrity check removes the entire selected cache on a mismatch. Move the default cache into the owning checkout's .cache/vitest directory and share that root resolver across normal, parallel-project, and plugin-batch test runners. Keep the normal leaf separate from scheduler leaves so one invocation cannot clear its siblings.

Explicit cache paths, CI restored seeds, existing Windows opt-in, and cache opt-outs are unchanged. No new options, dependencies, timeouts, or retries.

## User Impact

Developers can share installed dependencies between checkouts without sharing writable default transforms. No OpenClaw product-runtime behavior changes. Independent commands using the same checkout and same cache leaf still need to be serialized or assigned separate explicit cache paths.

## Evidence

The original focused Browser test spent over 13 minutes before Vitest printed RUN. A guarded diagnostic traced ensureCacheIntegrity → clearCache → recursive removal of the linked shared cache. After this repair, the same command completed in 32.79 seconds, exposing its two intended Browser regressions. This is one observed startup recovery, not a whole-suite speedup benchmark.

The new regression launches real Vitest processes in two private package workspaces sharing only private node_modules. After changing the dependency lock, the original helper deletes the first checkout's cache sentinel; the repaired helper preserves it. The same regression source failed before the fix and passed afterward.

- All 536 focused config, scheduler, plugin-batch, and grouped-runner tests passed; the complete source-side scheduler test file adds 84 passing tests (620 total across five files).
- Independent Codex P0–P2 review: no actionable findings.
- Full changed-file gate passed, including scripts/root-test typechecks and script lint. The first attempt exposed a missing local UI dependency; restoring the already-pinned pako 3.0.1 package and its bundled declarations fixed that environment issue without changing repository dependencies.

Production runtime LOC: +0/-0. Tooling owner LOC: +19/-8; the growth provides one checkout-owned default and separates independently invalidated cache leaves. Test/support LOC: +88/-19.

The first hosted run, [33277503922](https://github.com/openclaw/openclaw/actions/runs/33277503922), caught one omitted source-side scheduler test that still asserted the old default cache path. Both stale expectations are now updated; its complete 84-test file and the actual changed-file gate, including core-test typechecks and targeted lint, pass. The eight original files and cache implementation are unchanged. A fresh independent P0–P2 review of this correction found no actionable issues.

Integration refresh: the corrected scheduler leaf passed in [33278706524](https://github.com/openclaw/openclaw/actions/runs/33278706524); its only failed leaf was the already-tracked Clipboard lifecycle error after 4,094 passing tests. After the combined Browser/Clipboard repair [#132878](https://github.com/openclaw/openclaw/pull/132878) landed, this branch was rebased once onto containing main. All nine intended file blobs and the stable patch ID are unchanged; a fresh exact-head CI run is required before merge.

Review follow-through: the latest ClawSweeper review found no patch defect and requested finished exact-head CI plus an independent dependency check. The installed Vitest 4.1.11 `FileSystemModuleCache` constructor, `clearCache`, and `ensureCacheIntegrity` were directly inspected: metadata mismatch awaits recursive removal of the selected cache directories. Fresh CI remains required before landing. These are rebuildable Vitest transform artifacts; their file format is unchanged, with no OpenClaw persistent-state schema or migration change.

A separate existing case remains: callers that explicitly force one cache path across parallel plugin-batch groups can still share a live cache. The current hosted plugin-prerelease job does not combine those options; this patch preserves explicit override semantics.


