### PR TITLE
refactor(plugins): reuse concurrency helper

### DIFF
--- a/extensions/acpx/src/pi-session-store.ts
+++ b/extensions/acpx/src/pi-session-store.ts
@@ -1,6 +1,7 @@
 import { createReadStream } from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
+import { runTasksWithConcurrency } from "openclaw/plugin-sdk/concurrency-runtime";
 import { isPathStrictlyInside } from "openclaw/plugin-sdk/file-access-runtime";
 import type { SessionCatalogSession } from "openclaw/plugin-sdk/session-catalog";
 import {
@@ -141,44 +142,30 @@ async function realpathOrResolve(value: string): Promise<string> {
   }
 }
 
-async function mapConcurrent<T, R>(
-  values: T[],
-  limit: number,
-  mapper: (value: T) => Promise<R>,
-): Promise<R[]> {
-  const results: R[] = [];
-  results.length = values.length;
-  let nextIndex = 0;
-  const workers = Array.from({ length: Math.min(limit, values.length) }, async () => {
-    while (nextIndex < values.length) {
-      const index = nextIndex++;
-      results[index] = await mapper(values[index]!);
-    }
-  });
-  await Promise.all(workers);
-  return results;
-}
-
 async function scanPiFileCandidates(env: NodeJS.ProcessEnv): Promise<PiFileCandidate[]> {
   const { root, files } = await discoverPiSessionFiles(env);
   const configuredAcpRoot = piAcpSessionStoreRoot(env);
   const acpRoot = configuredAcpRoot ? await realpathOrResolve(configuredAcpRoot) : undefined;
-  const candidates = await mapConcurrent(files, IO_CONCURRENCY, async (file) => {
-    try {
-      const stats = await fs.stat(file);
-      return stats.isFile()
-        ? {
-            file,
-            storeRoot: root,
-            identity: `${String(stats.dev)}:${String(stats.ino)}:${String(stats.birthtimeMs)}`,
-            mtimeMs: stats.mtimeMs,
-            size: stats.size,
-            resumable: acpRoot ? isPathStrictlyInside(acpRoot, file) : false,
-          }
-        : undefined;
-    } catch {
-      return undefined;
-    }
+  const { results: candidates } = await runTasksWithConcurrency({
+    tasks: files.map((file) => async () => {
+      try {
+        const stats = await fs.stat(file);
+        return stats.isFile()
+          ? {
+              file,
+              storeRoot: root,
+              identity: `${String(stats.dev)}:${String(stats.ino)}:${String(stats.birthtimeMs)}`,
+              mtimeMs: stats.mtimeMs,
+              size: stats.size,
+              resumable: acpRoot ? isPathStrictlyInside(acpRoot, file) : false,
+            }
+          : undefined;
+      } catch {
+        return undefined;
+      }
+    }),
+    limit: IO_CONCURRENCY,
+    throwOnError: true,
   });
   return candidates
     .filter((candidate): candidate is PiFileCandidate => candidate !== undefined)
@@ -460,7 +447,11 @@ export async function listPiSummaryPage(
     index += SUMMARY_SCAN_BATCH_SIZE
   ) {
     const batch = candidates.slice(index, index + SUMMARY_SCAN_BATCH_SIZE);
-    const summaries = await mapConcurrent(batch, IO_CONCURRENCY, readPiSessionSummary);
+    const { results: summaries } = await runTasksWithConcurrency({
+      tasks: batch.map((candidate) => () => readPiSessionSummary(candidate)),
+      limit: IO_CONCURRENCY,
+      throwOnError: true,
+    });
     for (const summary of summaries) {
       if (summary && summaryMatches(summary, needle)) {
         matches.push(summary);
@@ -482,11 +473,13 @@ async function findPiSummary(
 ): Promise<PiSessionSummary | undefined> {
   const candidates = await piFileCandidates(env);
   for (let index = 0; index < candidates.length; index += SUMMARY_SCAN_BATCH_SIZE) {
-    const summaries = await mapConcurrent(
-      candidates.slice(index, index + SUMMARY_SCAN_BATCH_SIZE),
-      IO_CONCURRENCY,
-      readPiSessionSummary,
-    );
+    const { results: summaries } = await runTasksWithConcurrency({
+      tasks: candidates
+        .slice(index, index + SUMMARY_SCAN_BATCH_SIZE)
+        .map((candidate) => () => readPiSessionSummary(candidate)),
+      limit: IO_CONCURRENCY,
+      throwOnError: true,
+    });
     const match = summaries.find((summary) => summary?.threadId === threadId);
     if (match) {
       return match;

--- a/extensions/anthropic/session-catalog-discovery.ts
+++ b/extensions/anthropic/session-catalog-discovery.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs/promises";
 import path from "node:path";
+import { runTasksWithConcurrency } from "openclaw/plugin-sdk/concurrency-runtime";
 import { parseDateFirstTimestampMs } from "openclaw/plugin-sdk/number-runtime";
 import type { SessionCatalogPullRequestSummary } from "openclaw/plugin-sdk/session-catalog";
 import {
@@ -16,7 +17,6 @@ import {
   desktopSessionsDir,
   type ClaudeProjectsTreeSnapshot,
   type ClaudeSessionScanContext,
-  mapConcurrent,
   projectsDir,
   readClaudeCatalogMetadata,
   readJsonFile,
@@ -283,10 +283,8 @@ async function readIndexRecords(context: ClaudeSessionScanContext): Promise<{
   if (!context.resolvedRoot) {
     return { records, sidechainIds };
   }
-  const indexes = await mapConcurrent(
-    context.projectDirectories,
-    CLAUDE_CATALOG_IO_CONCURRENCY,
-    async ({ directory, childNames }) => ({
+  const { results: indexes } = await runTasksWithConcurrency({
+    tasks: context.projectDirectories.map(({ directory, childNames }) => async () => ({
       directory,
       raw: childNames.includes("sessions-index.json")
         ? await readJsonFile(path.join(directory, "sessions-index.json"), {
@@ -295,8 +293,10 @@ async function readIndexRecords(context: ClaudeSessionScanContext): Promise<{
             },
           })
         : undefined,
-    }),
-  );
+    })),
+    limit: CLAUDE_CATALOG_IO_CONCURRENCY,
+    throwOnError: true,
+  });
   const candidates: Array<{
     directory: string;
     entry: SessionIndexEntry;
@@ -318,10 +318,8 @@ async function readIndexRecords(context: ClaudeSessionScanContext): Promise<{
       candidates.push({ directory, entry, sessionId });
     }
   }
-  const safeFiles = await mapConcurrent(
-    candidates,
-    CLAUDE_CATALOG_IO_CONCURRENCY,
-    async ({ directory, entry, sessionId }) => {
+  const { results: safeFiles } = await runTasksWithConcurrency({
+    tasks: candidates.map(({ directory, entry, sessionId }) => async () => {
       if (entry.isSidechain === true) {
         return undefined;
       }
@@ -331,8 +329,10 @@ async function readIndexRecords(context: ClaudeSessionScanContext): Promise<{
         indexedPath ?? path.join(directory, `${sessionId}.jsonl`),
         sessionId,
       );
-    },
-  );
+    }),
+    limit: CLAUDE_CATALOG_IO_CONCURRENCY,
+    throwOnError: true,
+  });
   for (const [index, candidate] of candidates.entries()) {
     const { entry, sessionId } = candidate;
     if (entry.isSidechain === true) {
@@ -425,14 +425,17 @@ async function discoverCliRecords(
       }
     }
   }
-  const safeFiles = await mapConcurrent(
-    candidates,
-    CLAUDE_CATALOG_IO_CONCURRENCY,
-    async ({ directory, name, sessionId }) =>
-      sidechainIds.has(sessionId)
-        ? undefined
-        : await safeSessionFileForScan(context, path.join(directory, name), sessionId),
-  );
+  const { results: safeFiles } = await runTasksWithConcurrency({
+    tasks: candidates.map(
+      ({ directory, name, sessionId }) =>
+        async () =>
+          sidechainIds.has(sessionId)
+            ? undefined
+            : await safeSessionFileForScan(context, path.join(directory, name), sessionId),
+    ),
+    limit: CLAUDE_CATALOG_IO_CONCURRENCY,
+    throwOnError: true,
+  });
   for (const [candidateIndex, candidate] of candidates.entries()) {
     const { sessionId } = candidate;
     // Resolve metadata concurrently, but make every semantic decision in the original directory

--- a/extensions/anthropic/session-catalog-scan.ts
+++ b/extensions/anthropic/session-catalog-scan.ts
@@ -2,6 +2,7 @@ import type { Dirent, Stats } from "node:fs";
 import fs, { type FileHandle } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { runTasksWithConcurrency } from "openclaw/plugin-sdk/concurrency-runtime";
 import { isPathInside } from "openclaw/plugin-sdk/file-access-runtime";
 
 const MAX_CATALOG_JSON_CACHE_ENTRIES = 4_000;
@@ -99,24 +100,6 @@ export type ClaudeSessionScanContext = ClaudeProjectsTreeSnapshot & {
 // Parsed index/Desktop JSON stays valid for one path+mtime+size and is LRU-bounded; read failures are
 // never cached, so transient metadata I/O cannot hide a later successful read.
 const catalogJsonCache = new Map<string, CatalogJsonCacheEntry>();
-
-export async function mapConcurrent<T, R>(
-  values: T[],
-  limit: number,
-  mapper: (value: T) => Promise<R>,
-): Promise<R[]> {
-  const results: R[] = [];
-  results.length = values.length;
-  let nextIndex = 0;
-  const workers = Array.from({ length: Math.min(limit, values.length) }, async () => {
-    while (nextIndex < values.length) {
-      const index = nextIndex++;
-      results[index] = await mapper(values[index]!);
-    }
-  });
-  await Promise.all(workers);
-  return results;
-}
 
 export function setBoundedCache<K, V>(
   cache: Map<K, V>,
@@ -246,31 +229,35 @@ export async function readProjectsTreeSnapshot(root: string): Promise<ClaudeProj
     return { root, projectDirectories: [], treeStamp: "unavailable" };
   }
   const directoryEntries = entries.filter((entry) => entry.isDirectory());
-  const [resolvedRoot, directories] = await Promise.all([
+  const [resolvedRoot, { results: directories }] = await Promise.all([
     fs.realpath(root).catch(() => undefined),
-    mapConcurrent(directoryEntries, CLAUDE_CATALOG_IO_CONCURRENCY, async (entry) => {
-      const directory = path.join(root, entry.name);
-      const [stat, children] = await Promise.all([
-        fs.stat(directory).catch(() => undefined),
-        fs.readdir(directory, { withFileTypes: true }).catch(() => undefined),
-      ]);
-      return { entry, directory, stat, children };
+    runTasksWithConcurrency({
+      tasks: directoryEntries.map((entry) => async () => {
+        const directory = path.join(root, entry.name);
+        const [stat, children] = await Promise.all([
+          fs.stat(directory).catch(() => undefined),
+          fs.readdir(directory, { withFileTypes: true }).catch(() => undefined),
+        ]);
+        return { entry, directory, stat, children };
+      }),
+      limit: CLAUDE_CATALOG_IO_CONCURRENCY,
+      throwOnError: true,
     }),
   ]);
   const childTargets = directories.flatMap(({ directory, children }, directoryIndex) =>
     (children ?? []).map((child) => ({ directoryIndex, directory, child })),
   );
-  const childSignatures = await mapConcurrent(
-    childTargets,
-    CLAUDE_CATALOG_IO_CONCURRENCY,
-    async ({ directoryIndex, directory, child }) => {
+  const { results: childSignatures } = await runTasksWithConcurrency({
+    tasks: childTargets.map(({ directoryIndex, directory, child }) => async () => {
       const childStat = await fs.stat(path.join(directory, child.name)).catch(() => undefined);
       const signature = childStat?.isFile()
         ? ([child.name, childStat.mtimeMs, childStat.size, childStat.ino] as const)
         : undefined;
       return { directoryIndex, signature };
-    },
-  );
+    }),
+    limit: CLAUDE_CATALOG_IO_CONCURRENCY,
+    throwOnError: true,
+  });
   const signaturesByDirectory = Array.from(
     { length: directories.length },
     (): ClaudeChildFileSignature[] => [],

--- a/extensions/opencode/session-upstream-activity.ts
+++ b/extensions/opencode/session-upstream-activity.ts
@@ -1,3 +1,4 @@
+import { runTasksWithConcurrency } from "openclaw/plugin-sdk/concurrency-runtime";
 import {
   isExternalUserText,
   normalizeUserText,
@@ -41,24 +42,6 @@ type OpenCodeMarker = {
 const OPENCODE_EXPORT_CONCURRENCY = 4;
 const OPENCODE_REPLAY_LOOKBACK_USER_MESSAGES = 50;
 const OPENCODE_SHELL_SENTINEL = "The following tool was executed by the user";
-
-async function mapConcurrent<T, R>(
-  values: T[],
-  limit: number,
-  mapper: (value: T) => Promise<R>,
-): Promise<R[]> {
-  const results: R[] = [];
-  results.length = values.length;
-  let nextIndex = 0;
-  const workers = Array.from({ length: Math.min(limit, values.length) }, async () => {
-    while (nextIndex < values.length) {
-      const index = nextIndex++;
-      results[index] = await mapper(values[index]!);
-    }
-  });
-  await Promise.all(workers);
-  return results;
-}
 
 function sqlString(value: string): string {
   return `'${value.replaceAll("'", "''")}'`;
@@ -409,10 +392,8 @@ export async function checkOpenCodeUpstreamActivity(
     // A failed batch read confirms nothing about whether any thread still exists.
     return [];
   }
-  const outcomes = await mapConcurrent(
-    eligible,
-    OPENCODE_EXPORT_CONCURRENCY,
-    async (probe): Promise<SessionUpstreamActivity | undefined> => {
+  const { results: outcomes } = await runTasksWithConcurrency({
+    tasks: eligible.map((probe) => async (): Promise<SessionUpstreamActivity | undefined> => {
       const indicator = indicators.get(probe.threadId);
       if (!indicator) {
         return { kind: "missing", sessionKey: probe.sessionKey };
@@ -423,7 +404,9 @@ export async function checkOpenCodeUpstreamActivity(
         // Export failures are transient reads, not evidence that a thread was deleted.
         return undefined;
       }
-    },
-  );
+    }),
+    limit: OPENCODE_EXPORT_CONCURRENCY,
+    throwOnError: true,
+  });
   return outcomes.filter((outcome): outcome is SessionUpstreamActivity => outcome !== undefined);
 }


### PR DESCRIPTION
## What Problem This Solves

ACPX, Anthropic, and OpenCode each maintained a local copy of the same ordered bounded-concurrency scheduler even though the Plugin SDK already owns that contract. The duplicate implementations could drift independently from the shared concurrency policy.

## Why This Change Was Made

Move all nine call sites to `runTasksWithConcurrency` through the existing `openclaw/plugin-sdk/concurrency-runtime` entrypoint. Each call preserves its original ordering and limit and uses `throwOnError: true`; no SDK, manifest, config, or dependency surface changes.

## User Impact

No user-visible behavior changes. Plugin session discovery and activity checks now share one maintained concurrency implementation.

## Evidence

- `node scripts/run-vitest.mjs src/utils/run-with-concurrency.test.ts extensions/acpx/src/pi-session-catalog.test.ts extensions/anthropic/session-catalog.test.ts extensions/opencode/session-upstream-activity.test.ts` (103 tests passed)
- focused format, lint, production/test type checks, and `git diff --check` passed
- autoreview: no accepted/actionable findings
- production LOC: +83/-117 (net -34); tests: unchanged
