### PR TITLE
fix(ui): keep native catalog continuations on the selected agent

### DIFF
--- a/docs/web/urls.md
+++ b/docs/web/urls.md
@@ -119,6 +119,21 @@ own `?session=` parameter because that parameter expands a row; it is not a
 session deep link. The one-shot composer value `?draft=` remains supported on
 chat and dashboard session paths.
 
+### Native catalog links
+
+Native catalog threads use the agent path with a source query:
+
+```text
+/chat/<agentId>?catalog=<catalogId>&host=<hostId>&thread=<threadId>
+```
+
+URL-encode each query value. The agent in the path owns the OpenClaw pane,
+including catalog reads and continuation; `catalog`, `host`, and `thread`
+identify the native source. Opening the same source under different agents
+keeps their panes and drafts separate, including in split view. Continuing a
+thread navigates to the adopted OpenClaw session link. The same catalog query
+also works under `/dashboard/<agentId>`.
+
 ## Focus presentation routes
 
 A focus route renders one supported content surface without the normal Control

--- a/ui/src/components/app-sidebar-session-catalog-render.ts
+++ b/ui/src/components/app-sidebar-session-catalog-render.ts
@@ -494,7 +494,9 @@ function renderCatalogSessionRow(
     mainKey: params.mainKey,
   });
   const { href, options: navigation } = target;
-  const active = params.routeSessionKey !== "" && key === params.routeSessionKey;
+  const paneKey =
+    session.sessionKey ?? buildCatalogSessionKey(catalogKey, params.newSessionAgentId);
+  const active = paneKey === params.routeSessionKey;
   const running = session.status === "active" || session.status === "running";
   const stateDescription = running ? t("sessionsView.activeRun") : "";
   const stateId = running ? sidebarSessionStateId(key) : undefined;

--- a/ui/src/e2e/external-session-catalogs.e2e.test.ts
+++ b/ui/src/e2e/external-session-catalogs.e2e.test.ts
@@ -1,7 +1,8 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { expect, it } from "vitest";
-import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
+import type { ApplicationContext } from "../app/context.ts";
+import { installMockGateway, waitForControlUiRoute } from "../test-helpers/control-ui-e2e.ts";
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
 const suite = createControlUiE2eSuite({
@@ -11,6 +12,304 @@ const suite = createControlUiE2eSuite({
 });
 
 suite.define(() => {
+  it.each(["sidebar", "cold link"])(
+    "preserves catalog pane ownership from %s through retention, split focus, reconnect and adoption",
+    async (entrance) => {
+      await suite.withPage({ viewport: { width: 1440, height: 900 } }, async ({ page }) => {
+        const source = {
+          catalogId: "fixture-catalog",
+          hostId: "node:DevBox",
+          threadId: "Thread:A/B",
+        };
+        const search = `?${new URLSearchParams({ catalog: source.catalogId, host: source.hostId, thread: source.threadId })}`;
+        const owners = ["main", "other"];
+        const gateway = await installMockGateway(page, {
+          agentModel: "openai/gpt-5.6-luna",
+          featureMethods: [
+            "chat.metadata",
+            "chat.startup",
+            "sessions.catalog.list",
+            "sessions.catalog.read",
+            "sessions.catalog.continue",
+          ],
+          methodResponses: {
+            "agents.list": {
+              defaultId: "main",
+              mainKey: "main",
+              scope: "agent",
+              agents: owners.map((id) => ({ id, name: id === "main" ? "Main" : "Other" })),
+            },
+            "agent.identity.get": {
+              cases: owners.map((agentId) => ({
+                match: { agentId },
+                response: { agentId, name: agentId === "main" ? "Main" : "Other", avatar: "" },
+              })),
+            },
+            "sessions.catalog.list": {
+              cases: owners.map((agentId) => ({
+                match: { agentId },
+                response: {
+                  catalogs: [
+                    {
+                      id: source.catalogId,
+                      label: "Native fixture",
+                      capabilities: { continueSession: true, archive: false },
+                      hosts: [
+                        {
+                          hostId: source.hostId,
+                          label: "Dev Box",
+                          kind: "node",
+                          connected: true,
+                          sessions: [
+                            {
+                              threadId: source.threadId,
+                              name: `${agentId} native thread`,
+                              status: "stored",
+                              canContinue: true,
+                              canArchive: false,
+                              sourceHomeId: `${agentId}-home`,
+                            },
+                          ],
+                        },
+                      ],
+                    },
+                  ],
+                },
+              })),
+            },
+            "sessions.catalog.read": {
+              cases: owners.map((agentId) => ({
+                match: { ...source, agentId, sourceHomeId: `${agentId}-home` },
+                response: {
+                  ...source,
+                  items: [{ type: "agentMessage", text: `${agentId} native transcript` }],
+                },
+              })),
+            },
+            "sessions.catalog.continue": {
+              cases: owners.map((agentId) => ({
+                match: { ...source, agentId, sourceHomeId: `${agentId}-home` },
+                response: { sessionKey: `agent:${agentId}:adopted-native` },
+              })),
+            },
+          },
+        });
+        const activePane = page.locator(
+          "openclaw-chat-pane.chat-pane-cache__pane--active:not([inert])",
+        );
+        const composer = () => activePane.locator(".agent-chat__composer-combobox > textarea");
+        const navigate = async (agentId: string, catalog = true) => {
+          await page.evaluate(
+            ({ agentId: routeAgentId, search: routeSearch }) => {
+              const app = document.querySelector("openclaw-app") as HTMLElement & {
+                runtime: { context: ApplicationContext };
+              };
+              app.runtime.context.navigate("chat", {
+                pathname: `/chat/${routeAgentId}`,
+                search: routeSearch,
+              });
+            },
+            { agentId, search: catalog ? search : "" },
+          );
+          await waitForControlUiRoute(page, {
+            routeId: "chat",
+            pathname: `/chat/${agentId}`,
+            search: catalog ? search : "",
+          });
+        };
+        const assertOwner = async (agentId: string) => {
+          await expect
+            .poll(() =>
+              page.evaluate(() => {
+                const app = document.querySelector("openclaw-app") as HTMLElement & {
+                  runtime: { context: ApplicationContext };
+                };
+                return app.runtime.context.agentSelection.state.selectedId;
+              }),
+            )
+            .toBe(agentId);
+          await expect
+            .poll(() =>
+              activePane.evaluateAll((panes) =>
+                panes.map((pane) => {
+                  const chat = pane as HTMLElement & {
+                    active: boolean;
+                    presented: boolean;
+                    state: { assistantAgentId: string };
+                  };
+                  return {
+                    active: chat.active,
+                    presented: chat.presented,
+                    owner: chat.state.assistantAgentId,
+                  };
+                }),
+              ),
+            )
+            .toEqual([{ active: true, presented: true, owner: agentId }]);
+        };
+
+        await page.goto(
+          `${suite.server.baseUrl}chat/${entrance === "cold link" ? `other${search}` : "main"}`,
+        );
+        const sidebar = page.locator("openclaw-app-sidebar");
+        if (entrance === "sidebar") {
+          await sidebar.getByRole("button", { name: /Switch agent/ }).click();
+          await sidebar
+            .locator("wa-dropdown.sidebar-agent-menu")
+            .getByRole("menuitemradio", { name: "Other", exact: true })
+            .click();
+          await waitForControlUiRoute(page, {
+            routeId: "chat",
+            pathname: "/chat/other",
+            search: "",
+          });
+          await assertOwner("other");
+          await sidebar.getByText("other native thread", { exact: true }).click();
+        }
+        await waitForControlUiRoute(page, { routeId: "chat", pathname: "/chat/other", search });
+        expect((await gateway.waitForRequest("sessions.catalog.read")).params).toMatchObject({
+          ...source,
+          agentId: "other",
+          sourceHomeId: "other-home",
+        });
+        await activePane.getByText("other native transcript", { exact: true }).waitFor();
+        await assertOwner("other");
+        await expect
+          .poll(() =>
+            sidebar
+              .locator('[data-session-section="catalog:fixture-catalog"] a[aria-current="page"]')
+              .textContent(),
+          )
+          .toContain("other native thread");
+        await composer().fill("other retained draft");
+
+        // Same source, different route owner: no intervening ordinary session may hide a key collision.
+        await navigate("main");
+        await activePane.getByText("main native transcript", { exact: true }).waitFor();
+        await assertOwner("main");
+        expect(await composer().inputValue()).toBe("");
+        await composer().fill("main retained draft");
+        await navigate("other");
+        await assertOwner("other");
+        expect(await composer().inputValue()).toBe("other retained draft");
+        expect(
+          await page
+            .locator("openclaw-chat-pane")
+            .filter({ hasText: "main native transcript" })
+            .count(),
+        ).toBe(1);
+        const readsBeforeReturn = (await gateway.getRequests("sessions.catalog.read")).length;
+        await navigate("other", false);
+        await sidebar.getByText("other native thread", { exact: true }).click();
+        await waitForControlUiRoute(page, { routeId: "chat", pathname: "/chat/other", search });
+        await assertOwner("other");
+        expect(await composer().inputValue()).toBe("other retained draft");
+        expect(await gateway.getRequests("sessions.catalog.read")).toHaveLength(readsBeforeReturn);
+
+        await activePane.getByRole("button", { name: "Open split view" }).click();
+        await navigate("main");
+        const visiblePanes = page.locator(
+          "openclaw-chat-pane.chat-pane-cache__pane--visible:not([inert])",
+        );
+        await expect.poll(() => visiblePanes.count()).toBe(2);
+        await visiblePanes.getByText("other native transcript", { exact: true }).click();
+        await waitForControlUiRoute(page, { routeId: "chat", pathname: "/chat/other", search });
+        await assertOwner("other");
+        await visiblePanes.getByText("main native transcript", { exact: true }).click();
+        await waitForControlUiRoute(page, { routeId: "chat", pathname: "/chat/main", search });
+        await assertOwner("main");
+
+        // Ordinary Gateway publication and transport reconnect must retain each pane's owner.
+        const instanceId = await page.evaluate(() => {
+          const app = document.querySelector("openclaw-app") as HTMLElement & {
+            runtime: { context: ApplicationContext };
+          };
+          return app.runtime.context.gateway.snapshot.client?.instanceId;
+        });
+        await gateway.emitGatewayEvent("presence", {
+          presence: [{ instanceId, user: { id: "fixture-user", name: "Fixture User" } }],
+        });
+        await expect
+          .poll(() =>
+            visiblePanes.evaluateAll((panes) =>
+              panes.map((pane) => {
+                const chat = pane as HTMLElement & {
+                  state: { selfUser: { id: string } | null; assistantAgentId: string };
+                };
+                return [chat.state.selfUser?.id, chat.state.assistantAgentId];
+              }),
+            ),
+          )
+          .toEqual([
+            ["fixture-user", "other"],
+            ["fixture-user", "main"],
+          ]);
+        await assertOwner("main");
+        await gateway.closeLatest();
+        await expect.poll(() => gateway.getSocketCount()).toBeGreaterThan(1);
+        await expect
+          .poll(() =>
+            visiblePanes.evaluateAll((panes) =>
+              panes.map((pane) => {
+                const chat = pane as HTMLElement & {
+                  state: { connected: boolean; assistantAgentId: string };
+                };
+                return [chat.state.connected, chat.state.assistantAgentId];
+              }),
+            ),
+          )
+          .toEqual([
+            [true, "other"],
+            [true, "main"],
+          ]);
+        await visiblePanes.getByText("other native transcript", { exact: true }).click();
+        await waitForControlUiRoute(page, { routeId: "chat", pathname: "/chat/other", search });
+        await assertOwner("other");
+        await composer().fill("Continue under Other");
+        await activePane.getByRole("button", { name: "Send message", exact: true }).click();
+        expect((await gateway.waitForRequest("sessions.catalog.continue")).params).toMatchObject({
+          ...source,
+          agentId: "other",
+          sourceHomeId: "other-home",
+        });
+        const sent = await gateway.waitForRequest("chat.send");
+        expect(sent.params).toMatchObject({
+          sessionKey: "agent:other:adopted-native",
+          message: "Continue under Other",
+        });
+        await waitForControlUiRoute(page, {
+          routeId: "chat",
+          pathname: "/chat/other/adopted-native",
+          search: "",
+        });
+        await assertOwner("other");
+        await gateway.emitChatFinal({
+          runId: (sent.params as { idempotencyKey: string }).idempotencyKey,
+          sessionKey: "agent:other:adopted-native",
+          text: "Other continuation completed",
+        });
+        await activePane
+          .locator("p")
+          .getByText("Other continuation completed", { exact: true })
+          .waitFor();
+        const adoptedRow = sidebar.locator('[data-session-key="agent:other:adopted-native"]');
+        await navigate("other", false);
+        await adoptedRow.locator("a").click();
+        await waitForControlUiRoute(page, {
+          routeId: "chat",
+          pathname: "/chat/other/adopted-native",
+          search: "",
+        });
+        await assertOwner("other");
+        for (const request of await gateway.getRequests("sessions.catalog.read")) {
+          expect(request.params).toMatchObject(source);
+          const params = request.params as { agentId: string; sourceHomeId: string };
+          expect(params.sourceHomeId).toBe(`${params.agentId}-home`);
+        }
+      });
+    },
+  );
+
   it("shows both paired-node catalogs and opens their view-only transcripts", async () => {
     const page = await suite.browser.newPage({ viewport: { width: 1440, height: 900 } });
     const gateway = await installMockGateway(page, {

--- a/ui/src/lib/sessions/catalog-key.test.ts
+++ b/ui/src/lib/sessions/catalog-key.test.ts
@@ -8,9 +8,9 @@ import {
 } from "./catalog-key.ts";
 
 describe("catalog session keys", () => {
-  it("round-trips encoded host and thread ids", () => {
-    const key = { catalogId: "claude", hostId: "node:abc", threadId: "thread:a/b" };
-    expect(parseCatalogSessionKey(buildCatalogSessionKey(key))).toEqual(key);
+  it.each([undefined, "main", "other"])("round-trips opaque source ids for owner %s", (agentId) => {
+    const key = { catalogId: "fixture", hostId: "node:DevBox", threadId: "Thread:A/B" };
+    expect(parseCatalogSessionKey(buildCatalogSessionKey(key, agentId))).toEqual(key);
   });
 
   it.each(["", "catalog:", "catalog:a:b", "catalog:a:b:c:d", "catalog:a:%:c"])(

--- a/ui/src/lib/sessions/catalog-key.ts
+++ b/ui/src/lib/sessions/catalog-key.ts
@@ -4,6 +4,7 @@ import type {
   SessionsCatalogListResult,
 } from "../../../../packages/gateway-protocol/src/index.ts";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
+import { normalizeAgentId } from "./session-key.ts";
 
 export type CatalogSessionKey = {
   catalogId: string;
@@ -75,8 +76,10 @@ export async function lookupCatalogSession(params: {
   return { host, session: null };
 }
 
-export function buildCatalogSessionKey(key: CatalogSessionKey): string {
-  return `catalog:${encodeURIComponent(key.catalogId)}:${encodeURIComponent(key.hostId)}:${encodeURIComponent(key.threadId)}`;
+export function buildCatalogSessionKey(key: CatalogSessionKey, agentId?: string): string {
+  const source = `catalog:${encodeURIComponent(key.catalogId)}:${encodeURIComponent(key.hostId)}:${encodeURIComponent(key.threadId)}`;
+  // Source rows are ownerless; routed panes carry the agent through retention and split focus.
+  return agentId ? `agent:${normalizeAgentId(agentId)}:${source}` : source;
 }
 
 export function catalogSessionSearch(key: CatalogSessionKey): string {
@@ -96,10 +99,12 @@ export function catalogSessionKeyFromSearch(search: string): CatalogSessionKey |
 }
 
 export function parseCatalogSessionKey(value: string | null | undefined): CatalogSessionKey | null {
-  if (!value?.startsWith("catalog:")) {
+  // Strip only the owner prefix: native source identifiers are case-sensitive.
+  const source = value?.replace(/^agent:[^:]+:/u, "");
+  if (!source?.startsWith("catalog:")) {
     return null;
   }
-  const parts = value.slice("catalog:".length).split(":");
+  const parts = source.slice("catalog:".length).split(":");
   if (parts.length !== 3 || parts.some((part) => !part)) {
     return null;
   }

--- a/ui/src/lib/sessions/route-navigation.test.ts
+++ b/ui/src/lib/sessions/route-navigation.test.ts
@@ -52,8 +52,8 @@ describe("sessionNavigationTarget", () => {
     };
     const target = sessionNavigationTarget({
       face: "dashboard",
-      sessionKey: buildCatalogSessionKey(catalogKey),
-      fallbackAgentId: "research",
+      sessionKey: buildCatalogSessionKey(catalogKey, "research"),
+      fallbackAgentId: "main",
       basePath: "/admin/openclaw/",
       mainKey: "workspace",
     });

--- a/ui/src/lib/sessions/route-navigation.ts
+++ b/ui/src/lib/sessions/route-navigation.ts
@@ -169,7 +169,10 @@ export function sessionNavigationTarget<TRouteId extends string>(
 
   const catalogKey = parseCatalogSessionKey(row?.key ?? sessionKey);
   const targetKey = catalogKey
-    ? buildAgentMainSessionKey({ agentId: fallbackAgentId, mainKey: mainKey ?? "main" })
+    ? buildAgentMainSessionKey({
+        agentId: parseAgentSessionKey(sessionKey)?.agentId ?? fallbackAgentId,
+        mainKey: mainKey ?? "main",
+      })
     : (row?.key ?? sessionKey);
   const pathname = pathForNonCatalogSessionKey({
     face: params.face,

--- a/ui/src/lib/sessions/session-key.test.ts
+++ b/ui/src/lib/sessions/session-key.test.ts
@@ -74,6 +74,12 @@ describe("parseSessionKeyParts", () => {
 describe("UI session identity", () => {
   it.each([
     {
+      name: "native catalog source IDs",
+      selectedKey: "agent:ops:catalog:fixture:node%3ADevBox:Thread%3AA",
+      structuralAlias: "Agent:Ops:catalog:fixture:node%3ADevBox:Thread%3AA",
+      distinctKey: "agent:ops:catalog:fixture:node%3ADevBox:thread%3Aa",
+    },
+    {
       name: "Matrix room IDs",
       selectedKey: "agent:ops:matrix:channel:!Room:Example.Org",
       structuralAlias: "Agent:Ops:Matrix:Channel:!Room:Example.Org",

--- a/ui/src/lib/sessions/session-key.ts
+++ b/ui/src/lib/sessions/session-key.ts
@@ -83,6 +83,10 @@ export function normalizeSessionKeyForUiComparison(sessionKey: string | undefine
     bodyStart += 1;
   }
   const channel = parts[bodyStart]?.toLowerCase();
+  // Catalog source identifiers are opaque; only the agent prefix is normalized.
+  if (channel === "catalog") {
+    return parts.join(":");
+  }
   const peerKind = parts[bodyStart + 1]?.toLowerCase();
   const preservesMatrixTail =
     channel === "matrix" && (peerKind === "channel" || peerKind === "group");

--- a/ui/src/pages/chat/chat-page.test.ts
+++ b/ui/src/pages/chat/chat-page.test.ts
@@ -42,7 +42,7 @@ const CATALOG_KEY = {
   hostId: "gateway:local",
   threadId: "thread-1",
 } satisfies CatalogSessionKey;
-const CATALOG_SESSION_KEY = buildCatalogSessionKey(CATALOG_KEY);
+const CATALOG_SESSION_KEY = buildCatalogSessionKey(CATALOG_KEY, "research");
 const sessionPath = (sessionKey: string) =>
   sessionNavigationTarget({ face: "chat", sessionKey, fallbackAgentId: "main" }).options.pathname;
 import type { ChatMessageCache } from "./session-message-cache.ts";
@@ -255,7 +255,7 @@ describe("chat page split layout host", () => {
     const page = new ChatPage();
     const { setAgent } = setNavigationContext(page);
     page.data = {
-      sessionKey: "catalog:claude:gateway%3Alocal:thread-1",
+      sessionKey: CATALOG_SESSION_KEY,
       agentId: "research",
     };
 

--- a/ui/src/pages/chat/chat-pane-catalog.test.ts
+++ b/ui/src/pages/chat/chat-pane-catalog.test.ts
@@ -23,7 +23,7 @@ function createCatalogContinuationPane(request: ReturnType<typeof vi.fn>) {
     hostId: "gateway:local",
     threadId: "thread-101",
   } satisfies CatalogSessionKey;
-  const sourceSessionKey = buildCatalogSessionKey(key);
+  const sourceSessionKey = buildCatalogSessionKey(key, "main");
   state.sessionKey = sourceSessionKey;
   pane.sessionKey = sourceSessionKey;
   state.chatMessage = "Continue the original catalog conversation";
@@ -43,6 +43,32 @@ function createCatalogContinuationPane(request: ReturnType<typeof vi.fn>) {
 }
 
 describe("chat pane catalog session lifecycle", () => {
+  it.each(["global", "agent:other:main", "agent:other:catalog:fixture:gateway:Thread"])(
+    "preserves the pane owner and pending model selection across ordinary snapshots for %s",
+    (sessionKey) => {
+      const client = { request: vi.fn() } as unknown as GatewayBrowserClient;
+      const retireModelOverride = vi.fn();
+      const sessions = { retireModelOverride } as unknown as SessionCapability;
+      const { pane, state } = createTestChatPane({ client, sessions });
+      pane.sessionKey = state.sessionKey = sessionKey;
+      pane.context.agentSelection.set("other");
+      state.assistantAgentId = "other";
+      const pending = { [sessionKey]: new Promise<boolean>(() => {}) };
+      state.chatModelSwitchPromises = pending;
+
+      pane.applyGatewaySnapshot({
+        ...pane.context.gateway.snapshot,
+        assistantAgentId: "main",
+        selfUser: { id: "fixture-user", name: "Fixture User" },
+      });
+
+      expect(state.selfUser?.id).toBe("fixture-user");
+      expect(state.assistantAgentId).toBe("other");
+      expect(state.chatModelSwitchPromises).toBe(pending);
+      expect(retireModelOverride).not.toHaveBeenCalled();
+    },
+  );
+
   it("finds continuation metadata on a later catalog page", async () => {
     const key = {
       catalogId: "codex",
@@ -96,7 +122,7 @@ describe("chat pane catalog session lifecycle", () => {
       .mockResolvedValueOnce(transcript);
     const client = { request } as unknown as GatewayBrowserClient;
     const { pane } = createTestChatPane({ client, sessions: {} as SessionCapability });
-    pane.sessionKey = buildCatalogSessionKey(key);
+    pane.sessionKey = buildCatalogSessionKey(key, "main");
 
     await pane.loadCatalogSession(key, false);
 
@@ -118,7 +144,7 @@ describe("chat pane catalog session lifecycle", () => {
     expect(pane.catalogSession).toEqual(selectedSession);
   });
 
-  it("discards a catalog read when the selected agent changes", async () => {
+  it("discards a catalog read when the pane owner changes", async () => {
     const key = {
       catalogId: "codex",
       hostId: "gateway:local",
@@ -156,13 +182,14 @@ describe("chat pane catalog session lifecycle", () => {
       .mockImplementationOnce(() => read.promise);
     const client = { request } as unknown as GatewayBrowserClient;
     const { pane, state } = createTestChatPane({ client, sessions: {} as SessionCapability });
-    pane.sessionKey = buildCatalogSessionKey(key);
+    pane.sessionKey = buildCatalogSessionKey(key, "main");
     state.sessionKey = pane.sessionKey;
     state.assistantAgentId = "main";
 
     const pending = pane.loadCatalogSession(key, false);
     await vi.waitFor(() => expect(request).toHaveBeenCalledTimes(2));
-    state.assistantAgentId = "jarvis";
+    state.sessionKey = buildCatalogSessionKey(key, "other");
+    pane.sessionKey = state.sessionKey;
     read.resolve({
       hostId: key.hostId,
       threadId: key.threadId,
@@ -244,7 +271,7 @@ describe("chat pane catalog session lifecycle", () => {
       request: vi.fn(async () => readPage),
     } as unknown as GatewayBrowserClient;
     const { pane, state } = createTestChatPane({ client, sessions: {} as SessionCapability });
-    const key = "catalog:claude:gateway%3Alocal:thread-1";
+    const key = "agent:main:catalog:claude:gateway%3Alocal:thread-1";
     state.sessionKey = key;
     pane.sessionKey = key;
     pane.catalogCursor = "cursor-1";
@@ -269,7 +296,7 @@ describe("chat pane catalog session lifecycle", () => {
       request: vi.fn(async () => readPage),
     } as unknown as GatewayBrowserClient;
     const { pane, state } = createTestChatPane({ client, sessions: {} as SessionCapability });
-    const key = "catalog:claude:gateway%3Alocal:thread-1";
+    const key = "agent:main:catalog:claude:gateway%3Alocal:thread-1";
     state.sessionKey = key;
     pane.sessionKey = key;
     pane.catalogCursor = "final-page";
@@ -297,7 +324,7 @@ describe("chat pane catalog session lifecycle", () => {
       request: vi.fn(async () => readPage),
     } as unknown as GatewayBrowserClient;
     const { pane, state } = createTestChatPane({ client, sessions: {} as SessionCapability });
-    const key = "catalog:claude:gateway%3Alocal:thread-1";
+    const key = "agent:main:catalog:claude:gateway%3Alocal:thread-1";
     state.sessionKey = key;
     pane.sessionKey = key;
     pane.catalogCursor = "cursor-1";
@@ -324,7 +351,7 @@ describe("chat pane catalog session lifecycle", () => {
       request: vi.fn(async () => readPage),
     } as unknown as GatewayBrowserClient;
     const { pane, state } = createTestChatPane({ client, sessions: {} as SessionCapability });
-    const key = "catalog:claude:gateway%3Alocal:thread-1";
+    const key = "agent:main:catalog:claude:gateway%3Alocal:thread-1";
     state.sessionKey = key;
     pane.sessionKey = key;
     pane.catalogCursor = "cursor-2";
@@ -465,14 +492,15 @@ describe("chat pane catalog continuation lifecycle", () => {
     expect(state.chatSending).toBe(false);
   });
 
-  it("does not apply a catalog continuation after the selected agent changes", async () => {
+  it("does not apply a catalog continuation after the pane owner changes", async () => {
     const continued = createDeferred<{ sessionKey: string }>();
     const request = vi.fn(() => continued.promise);
     const { key, pane, state } = createCatalogContinuationPane(request);
     state.assistantAgentId = "main";
 
     const pending = pane.continueCatalogSession(key);
-    state.assistantAgentId = "jarvis";
+    state.sessionKey = buildCatalogSessionKey(key, "other");
+    pane.sessionKey = state.sessionKey;
     continued.resolve({ sessionKey: "agent:main:stale-owner" });
     await pending;
 

--- a/ui/src/pages/chat/chat-pane-context.ts
+++ b/ui/src/pages/chat/chat-pane-context.ts
@@ -231,6 +231,11 @@ export abstract class ChatPaneContext extends ChatPaneLifecycle {
     const previousMediaAuthToken = resolveAssistantAttachmentAuthToken(state);
     const wasConnected = state.connected;
     const previousAssistantAgentId = state.assistantAgentId;
+    // Gateway identity is its default, while each retained pane owns its routed agent.
+    const assistantAgentId =
+      parseAgentSessionKey(state.sessionKey)?.agentId ??
+      this.context.agentSelection.state.selectedId ??
+      snapshot.assistantAgentId;
     const previousSidebarSessionKey = canonicalUiSessionKeyForPersistence(state, state.sessionKey);
     const connectionLifecycle = (this.gatewayConnectionLifecycle ??=
       createGatewayConnectionLifecycle({
@@ -295,7 +300,7 @@ export abstract class ChatPaneContext extends ChatPaneLifecycle {
     }
     if (
       sourceChanged ||
-      (previousAssistantAgentId !== snapshot.assistantAgentId &&
+      (previousAssistantAgentId !== assistantAgentId &&
         isUiSelectedGlobalSessionKey(state, state.sessionKey))
     ) {
       retireChatModelSelectionOwnership(state);
@@ -308,7 +313,7 @@ export abstract class ChatPaneContext extends ChatPaneLifecycle {
     state.connectionEpoch = this.connectionGeneration;
     state.hello = snapshot.hello;
     state.selfUser = snapshot.selfUser ?? null;
-    state.assistantAgentId = snapshot.assistantAgentId;
+    state.assistantAgentId = assistantAgentId;
     if (wasConnected && !state.connected) {
       // Only the connected->disconnected transition may reshape loading state;
       // repeated disconnected snapshots must stay no-ops for pane ownership.
@@ -360,7 +365,15 @@ export abstract class ChatPaneContext extends ChatPaneLifecycle {
     if (state.connected && state.pendingAbort) {
       void replayPendingChatAbort(state).finally(() => state.requestUpdate?.());
     }
-    if (sourceChanged && snapshot.phase === "connected" && state.sessionKey && !clientChanged) {
+    const routeSessionKey = this.sessionKey.trim();
+    const catalogRouteKey = parseCatalogSessionKey(routeSessionKey);
+    if (
+      sourceChanged &&
+      snapshot.phase === "connected" &&
+      state.sessionKey &&
+      !clientChanged &&
+      !catalogRouteKey
+    ) {
       // A logical reconnect can retain the browser client and skip full startup.
       // Disconnect cleanup drops transient tool rows, so reload this pane's
       // active-run snapshot before secondary session surfaces hydrate.
@@ -375,8 +388,6 @@ export abstract class ChatPaneContext extends ChatPaneLifecycle {
         historyRefresh.then(() => getChatHistoryLoadState(state).phase === "committed"),
       );
     }
-    const routeSessionKey = this.sessionKey.trim();
-    const catalogRouteKey = parseCatalogSessionKey(routeSessionKey);
     const canonicalRouteSessionKey =
       routeSessionKey && !catalogRouteKey
         ? resolveSessionKey(routeSessionKey, snapshot.hello)
@@ -420,7 +431,7 @@ export abstract class ChatPaneContext extends ChatPaneLifecycle {
       return;
     }
     this.refreshSwarmRoster();
-    if (clientChanged && snapshot.client) {
+    if ((clientChanged || (sourceChanged && catalogRouteKey)) && snapshot.client) {
       const startupClient = snapshot.client;
       const startupGeneration = this.connectionGeneration;
       const startupSessionKey = state.sessionKey;

--- a/ui/src/pages/chat/chat-pane-session.ts
+++ b/ui/src/pages/chat/chat-pane-session.ts
@@ -17,7 +17,6 @@ import {
   sessionPullRequestsForGateway,
 } from "../../lib/session-pull-requests.ts";
 import {
-  buildCatalogSessionKey,
   lookupCatalogSession,
   parseCatalogSessionKey,
   type CatalogSessionKey,
@@ -372,7 +371,7 @@ export abstract class ChatPaneSession extends ChatPaneTaskSuggestions {
   }
 
   protected openCatalogSession(key: CatalogSessionKey, state: ChatPageHost) {
-    this.catalogRequestedSessionKey = buildCatalogSessionKey(key);
+    this.catalogRequestedSessionKey = this.sessionKey;
     this.catalogMessages = [];
     this.catalogCursor = undefined;
     this.catalogSession = null;
@@ -476,7 +475,7 @@ export abstract class ChatPaneSession extends ChatPaneTaskSuggestions {
     }
     const agentId = resolveChatAgentId(state);
     const generation = older ? this.catalogLoadGeneration : ++this.catalogLoadGeneration;
-    const requestedSessionKey = buildCatalogSessionKey(key);
+    const requestedSessionKey = this.sessionKey;
     const isCurrent = () =>
       generation === this.catalogLoadGeneration &&
       this.sessionKey === requestedSessionKey &&

--- a/ui/src/pages/chat/route-loader.ts
+++ b/ui/src/pages/chat/route-loader.ts
@@ -334,7 +334,7 @@ export async function loadChatRoute(
     }
     return {
       kind: "session",
-      sessionKey,
+      sessionKey: buildCatalogSessionKey(catalogKey, target.agentId),
       agentId: target.agentId,
       ...draftRouteDataFromLocation(routeLocation),
       face: resolvedFace,

--- a/ui/src/pages/chat/route-resolution.test.ts
+++ b/ui/src/pages/chat/route-resolution.test.ts
@@ -259,7 +259,7 @@ describe("gateway-backed session route resolution", () => {
       loadChatRoute(context, targetLocation(target), "chat", new AbortController().signal),
     ).resolves.toEqual({
       kind: "session",
-      sessionKey: catalogKey,
+      sessionKey: `agent:roboclaw:${catalogKey}`,
       agentId: "roboclaw",
       draft: undefined,
       face: "dashboard",

--- a/ui/src/pages/chat/route.test.ts
+++ b/ui/src/pages/chat/route.test.ts
@@ -498,7 +498,7 @@ describe("loadChatRoute", () => {
       ),
     ).resolves.toEqual({
       kind: "session",
-      sessionKey: "catalog:claude:gateway%3Alocal:thread-2",
+      sessionKey: "agent:main:catalog:claude:gateway%3Alocal:thread-2",
       agentId: "main",
       draft: undefined,
       face: "chat",
@@ -521,7 +521,7 @@ describe("loadChatRoute", () => {
       ),
     ).resolves.toMatchObject({
       kind: "session",
-      sessionKey: "catalog:claude:gateway%3Alocal:thread-2",
+      sessionKey: "agent:research:catalog:claude:gateway%3Alocal:thread-2",
       agentId: "research",
     });
   });
@@ -541,7 +541,7 @@ describe("loadChatRoute", () => {
       ),
     ).resolves.toEqual({
       kind: "session",
-      sessionKey: "catalog:claude:gateway%3Alocal:thread-2",
+      sessionKey: "agent:research:catalog:claude:gateway%3Alocal:thread-2",
       agentId: "research",
       draft: undefined,
       face: "dashboard",

--- a/ui/src/test-helpers/app-sidebar-cases/interactions.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/interactions.ts
@@ -670,7 +670,7 @@ describe("AppSidebar catalog session rows", () => {
         ["agent:main:main"],
       );
       (sidebar as unknown as { activeRouteId: string }).activeRouteId = "chat";
-      sidebar.sessionKey = "catalog:codex:gateway%3Alocal:thread-1";
+      sidebar.sessionKey = "agent:main:catalog:codex:gateway%3Alocal:thread-1";
       await sidebar.updateComplete;
 
       const active = sidebar.querySelectorAll(".sidebar-recent-session--active");
@@ -691,7 +691,7 @@ describe("AppSidebar catalog session rows", () => {
       ]
         .filter((row) => !row.closest('[data-session-section^="catalog:"]'))
         .map((row) => row.getAttribute("data-session-key"));
-      expect(chatRows).not.toContain("catalog:codex:gateway%3Alocal:thread-1");
+      expect(chatRows).not.toContain(sidebar.sessionKey);
     } finally {
       vi.useRealTimers();
     }


### PR DESCRIPTION
AI-assisted.

Closes #132869 — native catalog continuation uses the default agent after selecting another agent.
Related: #132734 — already-merged backend cross-agent adoption single-flight repair; unchanged here.

## What Problem This Solves

Fixes an issue where users opening a native catalog thread under a non-default agent could read and continue it as the Gateway's default agent. In the reproduced flow, the sidebar and settled `/chat/other` URL both identified Other, but Send issued `sessions.catalog.continue` with `agentId: "main"` and opened a Main-owned session.

The original proof driver had insufficient navigation assertions. A fresh, strictly asserted sidebar run and a separate cold-link run established that the UI defect remained after the intended agent and visible pane were verified. The backend correctly honored the actual Main request; this does not duplicate or expand #132734.

## Why This Change Was Made

The route carried the agent separately while retained panes, split layout, drafts, and caches used a source-only catalog key. Gateway snapshots then replaced pane identity with the default agent. Catalog routes now use the existing agent-qualified internal key convention, so each pane carries its owner through those existing mechanisms. Snapshots preserve that owner, and native catalog reconnects reload through the catalog path rather than ordinary Chat history.

This removes source-only pane identity and source-key reconstruction from the catalog load fence. Native catalog/host/thread identifiers retain their case, sidebar highlighting follows the qualified pane, and public catalog URLs remain unchanged. A guard in Continue would leave wrong reads and shared drafts intact; another global selection field would still allow retained panes to overwrite one another.

**Production LOC: +40/-16 (net +24). Tests/test support: +358/-25 (net +333). Docs: +15/-0.** The production growth carries the missing owner through existing key-based machinery and separates reconnect hydration; there is no new store, parallel owner field, schema, configuration surface, SDK, dependency, or backend change.

## User Impact

Native catalog reads and continuation stay with the selected route agent. Opening the same native thread under Main and Other retains distinct panes and drafts, including split focus and reconnect. Adoption opens the correctly owned OpenClaw session and delivers the draft there. Existing `/chat/<agent>?catalog=…&host=…&thread=…` and dashboard URLs remain supported; their ownership contract is documented in the URL guide.

## Evidence

### Before and after, real Gateway

A real OpenCode 1.18.20 CLI imported a synthetic thread into a fresh native store. The Gateway used its own HOME, XDG roots, state, workspaces, and loopback port. Browser automation asserted the selected agent, settled route, active/presented/non-inert pane, visible transcript, and catalog-read wire owner before Send. No handler mocks, route interception, response injection, operator state, or stopped Testbox were used.

**Before:** the settled Other route sent Main and navigated to Main.

![Before: an Other-intended native continuation opens a Main-owned session](https://github.com/user-attachments/assets/0813b902-6894-44bd-bb99-65f9fa2a3b53)

**After:** Other remains selected and owns the adopted session and delivered draft.

![After: the native continuation stays in the Other-owned session](https://github.com/user-attachments/assets/6945c608-f4a5-475d-93e5-3ec0a90e0ae7)

**Inspected 29-second repaired flow:** Other then Main adoption, followed by reopening Other through its sidebar row.

https://github.com/user-attachments/assets/a9bc351b-f8ce-4d9c-b646-bee12020d536

The two actual continuation requests sent `other` and `main`. They returned distinct `agent:other:plugin:opencode:catalog-adopt:…` and `agent:main:plugin:opencode:catalog-adopt:…` keys with the same source-derived suffix. Both drafts reached `chat.send` for the correct destination. Reopening Other caused no additional continuation; a fresh browser context opening its catalog URL also read under Other. No unqualified-owner RPC error occurred.

The post-action baseline owner error was in the hidden retained catalog pane, not a backend cross-agent result. The driver also learned to wait for `/readyz` and to select the desired session row after switching agents rather than assume the chip opens a particular adopted thread. No production guard or increased timeout was added for those driver corrections.

**Proof boundary:** no provider credentials were supplied. Subsequent model calls returned HTTP 401, so the live result proves ownership, navigation, adoption, and draft delivery—not successful inference. All isolated proof processes were stopped.

### Regression and local checks

The two new owner-sensitive browser scenarios failed on the original UI with Main instead of Other, including incorrect source-home metadata; the existing catalog control passed. The repaired suite passes sidebar/cold-link entry, owner-only source changes, retained drafts, split focus, snapshot publication, reconnect, adoption, and adopted-row navigation.

- 528 focused unit/sibling tests passed across route/key, pane lifecycle, retained panes, agent selection, and the full sidebar suite.
- All 3 external-catalog browser E2E scenarios passed.
- Changed-file formatting, types, lint, i18n, dead-export, and guard checks passed.
- Full build and `git diff --check` passed. A reboot-stale build lock and missing installed SDK files were repaired locally; the frozen dependency install changed no lockfile.
- Fresh pre-commit Codex autoreview reported no actionable findings at the configured P0-only threshold.

```bash
OPENCLAW_VITEST_MAX_WORKERS=4 node scripts/run-vitest.mjs ui/src/lib/sessions/catalog-key.test.ts ui/src/lib/sessions/route-navigation.test.ts ui/src/lib/sessions/session-key.test.ts ui/src/pages/chat/chat-page.test.ts ui/src/pages/chat/chat-pane-catalog.test.ts ui/src/pages/chat/chat-pane-lifecycle.test.ts ui/src/pages/chat/route-resolution.test.ts ui/src/pages/chat/route.test.ts ui/src/components/app-sidebar.test.ts ui/src/pages/chat/chat-page-retained-sessions.test.ts ui/src/app/agent-selection.test.ts
```

```bash
node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/external-session-catalogs.e2e.test.ts
```

```bash
git diff --name-only -z | xargs -0 node scripts/check-changed.mjs --
```

```bash
pnpm build
```

The live candidate was built from base `86b9cf728895fed2a227316a98f0ad2f35261543` plus this UI diff and committed without source changes as [`4fa8f294a8d`](https://github.com/openclaw/openclaw/commit/4fa8f294a8d83f17ae3a813f88dafdeec48cd69f); production hashes remained unchanged through final verification and commit. No last-known-good stable release was established, so this is not labeled a shipped stable regression.

### CI prerequisite and rebased candidate

The first hosted run failed in [the Chrome bootstrap shard](https://github.com/openclaw/openclaw/actions/runs/33278170013/job/99168569399), which delivered valid CDP binding strings to an unrelated Playwright logical session. This was independently traced to relay registration ownership, not malformed fixture data. No marker rewriting, unhandled-error suppression, or duplicate browser patch was added here. [Browser binding isolation and clipboard teardown #132878](https://github.com/openclaw/openclaw/pull/132878) repaired that separate boundary and merged as `0dcbb900559944775bcca61452280e2f7383f007`.

The catalog branch rebased onto main `90c1d798cad44f0d1901524a613acef33a4e42b6` as `dc1933db1d8d14de14975576afb611bd72c9643e`. Git range-diff reports the catalog commit patch-identical. Six production owner modules remain byte-identical to the live proof; the sidebar renderer also includes main's disjoint session-color presentation. Fresh rebased verification passed **530 unit/sibling tests**, **3 browser scenarios**, changed-file gates, a Control UI build, and independent P0-threshold Codex review with no findings. The full real-Gateway evidence above is from the original patch-identical candidate, not a claim of a second post-rebase live run.

```bash
git diff --name-only -z 90c1d798cad44f0d1901524a613acef33a4e42b6...HEAD | xargs -0 node scripts/check-changed.mjs --
```

```bash
pnpm ui:build
```

Final exact-head hosted CI and native prepare/merge validation remain required before landing.
