### PR TITLE
fix(test): isolate legacy agent directory overrides

### DIFF
--- a/src/test-utils/openclaw-test-state.test.ts
+++ b/src/test-utils/openclaw-test-state.test.ts
@@ -62,6 +62,7 @@ describe("openclaw test state", () => {
       await withEnvAsync(
         {
           OPENCLAW_AGENT_DIR: path.join(parent, "previous-agent"),
+          PI_CODING_AGENT_DIR: path.join(parent, "previous-legacy-agent"),
           OPENCLAW_ACQUISITION_EMPTY: "",
           OPENCLAW_ACQUISITION_ABSENT: undefined,
         },
@@ -75,6 +76,7 @@ describe("openclaw test state", () => {
             "OPENCLAW_STATE_DIR",
             "OPENCLAW_CONFIG_PATH",
             "OPENCLAW_AGENT_DIR",
+            "PI_CODING_AGENT_DIR",
             "OPENCLAW_ACQUISITION_EMPTY",
             "OPENCLAW_ACQUISITION_ABSENT",
           ];
@@ -227,49 +229,71 @@ describe("openclaw test state", () => {
     );
   });
 
-  it("clears inherited agent-dir overrides by default", async () => {
-    await withEnvAsync({ OPENCLAW_AGENT_DIR: "/tmp/outside-openclaw-agent" }, async () => {
-      const state = await createOpenClawTestState({
-        layout: "state-only",
+  it.each([
+    { agentEnv: undefined, applyEnv: true },
+    { agentEnv: undefined, applyEnv: false },
+    { agentEnv: "main", applyEnv: true },
+    { agentEnv: "main", applyEnv: false },
+  ] as const)(
+    "isolates inherited agent selectors with $agentEnv and applyEnv=$applyEnv",
+    async ({ agentEnv, applyEnv }) => {
+      const inherited = {
+        OPENCLAW_AGENT_DIR: "/tmp/outside-openclaw-agent",
+        PI_CODING_AGENT_DIR: "/tmp/outside-legacy-agent",
+      };
+      await withEnvAsync(inherited, async () => {
+        const state = await createOpenClawTestState({
+          layout: agentEnv === "main" ? "home" : "state-only",
+          agentEnv,
+          applyEnv,
+        });
+
+        try {
+          const expectedAgentDir = agentEnv === "main" ? state.agentDir() : undefined;
+          expect(state.env.OPENCLAW_AGENT_DIR).toBe(expectedAgentDir);
+          expect(state.env.PI_CODING_AGENT_DIR).toBeUndefined();
+          expect(process.env.OPENCLAW_AGENT_DIR).toBe(
+            applyEnv ? expectedAgentDir : inherited.OPENCLAW_AGENT_DIR,
+          );
+          expect(process.env.PI_CODING_AGENT_DIR).toBe(
+            applyEnv ? undefined : inherited.PI_CODING_AGENT_DIR,
+          );
+          expect(state.agentDir()).toBe(path.join(state.stateDir, "agents", "main", "agent"));
+        } finally {
+          await state.cleanup();
+        }
+
+        expect(process.env.OPENCLAW_AGENT_DIR).toBe(inherited.OPENCLAW_AGENT_DIR);
+        expect(process.env.PI_CODING_AGENT_DIR).toBe(inherited.PI_CODING_AGENT_DIR);
       });
+    },
+  );
 
-      try {
-        expect(process.env.OPENCLAW_AGENT_DIR).toBeUndefined();
-        expect(state.env.OPENCLAW_AGENT_DIR).toBeUndefined();
-        expect(state.agentDir()).toBe(path.join(state.stateDir, "agents", "main", "agent"));
-      } finally {
-        await state.cleanup();
-      }
-
-      expect(process.env.OPENCLAW_AGENT_DIR).toBe("/tmp/outside-openclaw-agent");
-    });
-  });
-
-  it("allows explicit agent-dir overrides when a test needs them", async () => {
-    await withOpenClawTestState(
-      {
-        env: {
+  it.each([undefined, "main"] as const)(
+    "allows explicit agent-dir overrides with agentEnv=%s and restores absent or empty selectors",
+    async (agentEnv) => {
+      await withEnvAsync({ OPENCLAW_AGENT_DIR: undefined, PI_CODING_AGENT_DIR: "" }, async () => {
+        const overrides = {
           OPENCLAW_AGENT_DIR: "/tmp/explicit-openclaw-agent",
-        },
-      },
-      async (state) => {
-        expect(process.env.OPENCLAW_AGENT_DIR).toBe("/tmp/explicit-openclaw-agent");
-        expect(state.env.OPENCLAW_AGENT_DIR).toBe("/tmp/explicit-openclaw-agent");
-      },
-    );
-  });
-
-  it("can route agent-dir env vars to the isolated main agent store", async () => {
-    await withOpenClawTestState(
-      {
-        agentEnv: "main",
-      },
-      async (state) => {
-        expect(process.env.OPENCLAW_AGENT_DIR).toBe(state.agentDir());
-        expect(state.env.OPENCLAW_AGENT_DIR).toBe(state.agentDir());
-      },
-    );
-  });
+          PI_CODING_AGENT_DIR: "/tmp/explicit-legacy-agent",
+        };
+        const state = await createOpenClawTestState({ agentEnv, applyEnv: false, env: overrides });
+        try {
+          expect(state.env.OPENCLAW_AGENT_DIR).toBe(overrides.OPENCLAW_AGENT_DIR);
+          expect(state.env.PI_CODING_AGENT_DIR).toBe(overrides.PI_CODING_AGENT_DIR);
+          expect(process.env.OPENCLAW_AGENT_DIR).toBeUndefined();
+          expect(process.env.PI_CODING_AGENT_DIR).toBe("");
+          state.applyEnv();
+          expect(process.env.OPENCLAW_AGENT_DIR).toBe(overrides.OPENCLAW_AGENT_DIR);
+          expect(process.env.PI_CODING_AGENT_DIR).toBe(overrides.PI_CODING_AGENT_DIR);
+        } finally {
+          await state.cleanup();
+        }
+        expect(process.env.OPENCLAW_AGENT_DIR).toBeUndefined();
+        expect(process.env.PI_CODING_AGENT_DIR).toBe("");
+      });
+    },
+  );
 
   it("writes scenario configs and auth profile stores", async () => {
     await withOpenClawTestState(

--- a/src/test-utils/openclaw-test-state.ts
+++ b/src/test-utils/openclaw-test-state.ts
@@ -237,6 +237,7 @@ function buildEnvVars(params: {
     OPENCLAW_STATE_DIR: params.stateDir,
     OPENCLAW_CONFIG_PATH: params.configPath,
     ...agentDirEnv,
+    PI_CODING_AGENT_DIR: undefined,
     ...params.scenarioEnv,
     ...params.extraEnv,
   };

--- a/test/non-isolated-runner.test.ts
+++ b/test/non-isolated-runner.test.ts
@@ -100,6 +100,7 @@ function fixtureFiles(): Record<string, string> {
   const agentEventsPath = JSON.stringify(path.join(repoRoot, "src", "infra", "agent-events.ts"));
   const loggingConsolePath = JSON.stringify(path.join(repoRoot, "src", "logging", "console.ts"));
   const loggingStatePath = JSON.stringify(path.join(repoRoot, "src", "logging", "state.ts"));
+  const testEnvPath = JSON.stringify(path.join(repoRoot, "src", "test-utils", "env.ts"));
   const payloadImports = [
     'import { createRequire } from "node:module";',
     'import { queryObjects } from "node:v8";',
@@ -142,6 +143,29 @@ function fixtureFiles(): Record<string, string> {
       'it("restores gateway helper env", () => {',
       "  expect(process.env.OPENCLAW_SKIP_CHANNELS).toBeUndefined();",
       "  expect(process.env.OPENCLAW_SKIP_CRON).toBeUndefined();",
+      "});",
+      "",
+    ].join("\n"),
+    "02-c-agent-env.test.ts": [
+      `import { setTestEnvValue } from ${testEnvPath};`,
+      'import { expect, it, vi } from "vitest";',
+      'it("leaves agent selectors for file-completion env unstub", () => {',
+      "  expect(process.env.HOME).toBe(process.env.OPENCLAW_TEST_HOME);",
+      "  expect(process.env.OPENCLAW_TEST_HOME).toBeTruthy();",
+      '  for (const key of ["OPENCLAW_AGENT_DIR", "PI_CODING_AGENT_DIR"]) {',
+      "    setTestEnvValue(key, `/tmp/inherited-${key}`);",
+      "    vi.stubEnv(key, undefined);",
+      "    expect(process.env[key]).toBeUndefined();",
+      "  }",
+      "});",
+      "",
+    ].join("\n"),
+    "02-d-agent-env.test.ts": [
+      'import { expect, it } from "vitest";',
+      'it("clears restored agent selectors before the next file", () => {',
+      "  expect(process.env.HOME).toBe(process.env.OPENCLAW_TEST_HOME);",
+      "  expect(process.env.OPENCLAW_AGENT_DIR).toBeUndefined();",
+      "  expect(process.env.PI_CODING_AGENT_DIR).toBeUndefined();",
       "});",
       "",
     ].join("\n"),
@@ -434,7 +458,7 @@ it("cleans every shared runner surface between files", async () => {
     // The collection failure is intentional. Every behavior test after it must
     // pass; any leaked surface turns the summary into a second failure.
     expect(output).toContain("synthetic collect failure");
-    expect(output).toContain("1 failed | 32 passed");
+    expect(output).toContain("1 failed | 34 passed");
     expect(output).not.toContain("first-file");
   } finally {
     await fs.rm(root, { recursive: true, force: true });

--- a/test/non-isolated-runner.ts
+++ b/test/non-isolated-runner.ts
@@ -104,6 +104,7 @@ function restoreSharedTestHomeAfterEnvUnstub(testHomeRaw: string | undefined): v
   delete process.env.OPENCLAW_CONFIG_PATH;
   delete process.env.OPENCLAW_STATE_DIR;
   delete process.env.OPENCLAW_AGENT_DIR;
+  delete process.env.PI_CODING_AGENT_DIR;
   process.env.XDG_CONFIG_HOME = path.join(testHome, ".config");
   process.env.XDG_DATA_HOME = path.join(testHome, ".local", "share");
   process.env.XDG_STATE_HOME = path.join(testHome, ".local", "state");

--- a/test/test-env.test.ts
+++ b/test/test-env.test.ts
@@ -117,6 +117,8 @@ describe("installTestEnv", () => {
           OPENCLAW_HOME: realHome,
           OPENCLAW_STATE_DIR: path.join(realHome, ".openclaw"),
           OPENCLAW_CONFIG_PATH: configPath,
+          OPENCLAW_AGENT_DIR: path.join(realHome, "caller-agent"),
+          PI_CODING_AGENT_DIR: path.join(realHome, "caller-legacy-agent"),
           OPENCLAW_LIVE_TEST: "1",
           OPENCLAW_LIVE_USE_REAL_HOME: undefined,
           OPENCLAW_LIVE_TEST_QUIET: "1",
@@ -161,6 +163,8 @@ describe("installTestEnv", () => {
           const next = installTestEnv();
           cleanupFns.push(next.cleanup);
           expect(next.tempHome).not.toBe(failedHome);
+          expect(process.env.OPENCLAW_AGENT_DIR).toBeUndefined();
+          expect(process.env.PI_CODING_AGENT_DIR).toBeUndefined();
           expect(process.env.ACQUISITION_PROFILE_ADDED).toBe("from-profile");
           expect(process.env.ACQUISITION_PROFILE_EMPTY).toBe("from-profile");
           expect(
@@ -168,6 +172,8 @@ describe("installTestEnv", () => {
           ).toBe("{}\n");
           next.cleanup();
           expect(process.env.HOME).toBe(realHome);
+          expect(process.env.OPENCLAW_AGENT_DIR).toBe(callerEnv.OPENCLAW_AGENT_DIR);
+          expect(process.env.PI_CODING_AGENT_DIR).toBe(callerEnv.PI_CODING_AGENT_DIR);
           expect(process.env.OPENCLAW_TEST_FAST).toBe("from-profile");
           expect(process.env.ACQUISITION_PROFILE_ADDED).toBe("from-profile");
           expect(fs.readdirSync(sandbox)).toEqual([]);
@@ -420,12 +426,21 @@ describe("installTestEnv", () => {
     setTestEnvValue("OPENCLAW_LIVE_TEST", "1");
     setTestEnvValue("OPENCLAW_LIVE_USE_REAL_HOME", "1");
     setTestEnvValue("OPENCLAW_LIVE_TEST_QUIET", "1");
+    const agentDir = path.join(realHome, "caller-agent");
+    const legacyAgentDir = path.join(realHome, "caller-legacy-agent");
+    setTestEnvValue("OPENCLAW_AGENT_DIR", agentDir);
+    setTestEnvValue("PI_CODING_AGENT_DIR", legacyAgentDir);
 
     const testEnv = installTestEnv();
 
     expect(testEnv.tempHome).toBe(realHome);
     expect(process.env.HOME).toBe(realHome);
     expect(process.env.TEST_PROFILE_ONLY).toBe("from-profile");
+    expect(process.env.OPENCLAW_AGENT_DIR).toBe(agentDir);
+    expect(process.env.PI_CODING_AGENT_DIR).toBe(legacyAgentDir);
+    testEnv.cleanup();
+    expect(process.env.OPENCLAW_AGENT_DIR).toBe(agentDir);
+    expect(process.env.PI_CODING_AGENT_DIR).toBe(legacyAgentDir);
   });
 
   it("keeps hermetic mode isolated when live flags request the real HOME", () => {
@@ -445,6 +460,8 @@ describe("installTestEnv", () => {
     setTestEnvValue("OPENCLAW_TEST_TRUST_BUNDLED_PLUGINS_DIR", "1");
     setTestEnvValue("OPENCLAW_DISABLE_BUNDLED_PLUGINS", "1");
     setTestEnvValue("OPENCLAW_HOME", realHome);
+    setTestEnvValue("OPENCLAW_AGENT_DIR", path.join(realHome, "caller-agent"));
+    setTestEnvValue("PI_CODING_AGENT_DIR", path.join(realHome, "caller-legacy-agent"));
 
     const testEnv = installTestEnv({ mode: "hermetic" });
     cleanupFns.push(testEnv.cleanup);
@@ -461,27 +478,34 @@ describe("installTestEnv", () => {
     expect(process.env.OPENCLAW_TEST_TRUST_BUNDLED_PLUGINS_DIR).toBe("1");
     expect(process.env.OPENCLAW_DISABLE_BUNDLED_PLUGINS).toBeUndefined();
     expect(process.env.OPENCLAW_HOME).toBeUndefined();
+    expect(process.env.OPENCLAW_AGENT_DIR).toBeUndefined();
+    expect(process.env.PI_CODING_AGENT_DIR).toBeUndefined();
     expect(fs.existsSync(path.join(testEnv.tempHome, ".openclaw", "openclaw.json"))).toBe(false);
     expect(
       fs.existsSync(path.join(testEnv.tempHome, ".openclaw", "credentials", "token.txt")),
     ).toBe(false);
   });
 
-  it("clears and restores OPENCLAW_HOME for normal isolated test runs", () => {
-    const realHome = createTempHome();
-    const configuredOpenClawHome = path.join(realHome, "custom-openclaw-home");
-    setTestEnvValue("HOME", realHome);
-    setTestEnvValue("USERPROFILE", realHome);
-    setTestEnvValue("OPENCLAW_HOME", configuredOpenClawHome);
+  it.each(["OPENCLAW_HOME", "OPENCLAW_AGENT_DIR", "PI_CODING_AGENT_DIR"])(
+    "clears and restores %s for normal isolated test runs",
+    (key) => {
+      const realHome = createTempHome();
+      const callerPath = path.join(realHome, "caller-override");
+      setTestEnvValue("HOME", realHome);
+      setTestEnvValue("USERPROFILE", realHome);
+      setTestEnvValue(key, callerPath);
 
-    const testEnv = installTestEnv();
+      const testEnv = installTestEnv();
+      cleanupFns.push(testEnv.cleanup);
 
-    expect(testEnv.tempHome).not.toBe(realHome);
-    expect(process.env.OPENCLAW_HOME).toBeUndefined();
+      expect(testEnv.tempHome).not.toBe(realHome);
+      expect(process.env[key]).toBeUndefined();
+      setTestEnvValue(key, path.join(testEnv.tempHome, "explicit-override"));
 
-    testEnv.cleanup();
-    expect(process.env.OPENCLAW_HOME).toBe(configuredOpenClawHome);
-  });
+      testEnv.cleanup();
+      expect(process.env[key]).toBe(callerPath);
+    },
+  );
 
   it.each([
     "TWILIO_ACCOUNT_SID",

--- a/test/test-env.ts
+++ b/test/test-env.ts
@@ -219,6 +219,7 @@ function resolveRestoreEntries(): RestoreEntry[] {
     { key: "OPENCLAW_CANVAS_HOST_PORT", value: process.env.OPENCLAW_CANVAS_HOST_PORT },
     { key: "OPENCLAW_TEST_HOME", value: process.env.OPENCLAW_TEST_HOME },
     { key: "OPENCLAW_AGENT_DIR", value: process.env.OPENCLAW_AGENT_DIR },
+    { key: "PI_CODING_AGENT_DIR", value: process.env.PI_CODING_AGENT_DIR },
     ...ISOLATED_TEST_CREDENTIAL_ENV_KEYS.map((key) => ({ key, value: process.env[key] })),
     { key: "NODE_OPTIONS", value: process.env.NODE_OPTIONS },
   ];
@@ -239,7 +240,9 @@ function initializeIsolatedTestEnv(tempHome: string): void {
   // Derive all state, including SQLite, from this unique HOME so cleanup owns it.
   // Leave the override unset so nested HOME scopes also isolate their state.
   deleteTestEnvValue("OPENCLAW_STATE_DIR");
+  // Model status still honors the shipped legacy selector; isolate both agent-dir keys.
   deleteTestEnvValue("OPENCLAW_AGENT_DIR");
+  deleteTestEnvValue("PI_CODING_AGENT_DIR");
   // Prefer test-controlled ports over developer overrides (avoid port collisions across tests/workers).
   deleteTestEnvValue("OPENCLAW_GATEWAY_PORT");
   deleteTestEnvValue("OPENCLAW_BRIDGE_ENABLED");


### PR DESCRIPTION
## What Problem This Solves

Fixes model-status tests failing when the parent process exports `PI_CODING_AGENT_DIR`. The shared test environment cleared `OPENCLAW_AGENT_DIR` but left its still-supported legacy selector active, so an otherwise isolated status invocation selected the inherited directory instead of the fixture's mocked directory.

The three recorded failures looked like masking, runtime-quarantine, and mixed-auth-route problems. Native assertion diffs instead showed one missing default-directory resolver call and two mismatched auth-store display paths.

## Why This Change Was Made

Restore legacy-selector isolation at the three existing test lifetime owners: shared test-home setup/restore, shared-worker file cleanup, and integration test-state/spawn environment construction. Explicit fixture overrides retain precedence, including `agentEnv: "main"`, and cleanup restores absent, empty, and populated caller values.

The runtime-internalization change in #85341 removed this test cleanup while model status retained the selector. The alias is also present in stable tag `v2026.7.1-2`; this repair deliberately leaves production model-status behavior and assertions unchanged rather than removing the alias or teaching tests to accept leaked paths.

Production LOC: **+0/-0**. Test support: **+5/-0**. Tests: **+124/-52**, extending existing tables and the real shared-worker producer/observer fixture rather than adding a production test seam.

## User Impact

No production behavior, public configuration, schema, dependency, or persistence changes. Isolated tests no longer borrow the launcher's legacy agent directory. The existing explicitly allowed real-home test mode and explicit fixture overrides remain intact. All validation used synthetic, task-owned state; no operator Gateway, service, config, or credential state was changed.

## Evidence

Current retained native proof on base `8cd61f02bf48c190a439ccb53d56e9f47a87a110`, then the six-file repair, using Node **24.15.0** and Vitest **4.1.11**:

| Native scope | Before | After |
| --- | --- | --- |
| Original `commands-light` partition, 19 files | 539 passed / the original 3 failures | **542 passed** |
| `test/test-env.test.ts` | 11 passed / 4 legacy-selector failures | **15 passed** |
| `src/test-utils/openclaw-test-state.test.ts` | 16 passed / 4 legacy-selector failures | **20 passed** |
| `test/non-isolated-runner.test.ts` | Native child observer failed on inherited `PI_CODING_AGENT_DIR` | **1 outer boundary test passed**; its unchanged child contract requires 34 passing cases plus the intentional collection failure |

Native commands, each run with a fresh private HOME/state/provider environment, a seeded `PI_CODING_AGENT_DIR`, one worker, and verbose plus JSON reporters:

```sh
node scripts/run-vitest.mjs run --config test/vitest/vitest.commands-light.config.ts --passWithNoTests=false
node scripts/run-vitest.mjs test/test-env.test.ts
node scripts/run-vitest.mjs src/test-utils/openclaw-test-state.test.ts
node scripts/run-vitest.mjs test/non-isolated-runner.test.ts
```

The complete model-status file retains its original assertion order and both explicit environment-override cases. The full original partition was replayed, not just three selected assertions; native file scheduling differed after prior failures. Every retained run records an unchanged source diff during execution.

**Execution limitations, not hidden passes:** cache-enabled original-partition attempts stalled before assertions. A PID/birth-bound native sample observed a libuv filesystem worker waiting in `rename`, without identifying the pathname or establishing the cause of every timeout. The retained original-partition before/after runs used the existing **outer** `OPENCLAW_VITEST_FS_MODULE_CACHE=0` option. The environment and test-state owner proofs used the default outer cache setting.

The shared-worker semantic runs also disabled that optional cache on the outer runner only. Its child builder intentionally drops parent `VITEST*`/`OPENCLAW_VITEST*` variables and keeps its existing one-worker, `isolate: false`, native configuration. The installed Vitest default is the forks pool; its optional module cache is unset/default-false, but temporary transformed-module copies can still be written. No nested defaults, pool, deadlines, or assertions were changed. A positive shared-worker attempt timed out at its existing 120-second test deadline; after exact cleanup and the static gates, the one bounded unchanged retry passed. No blanket signals, raised deadlines, or retries beyond the bounded attempts described above were used. Earlier lost temporary QA artifacts are not counted as current proof.

Also passed:

```sh
node scripts/check-changed.mjs -- test/test-env.ts test/test-env.test.ts test/non-isolated-runner.ts test/non-isolated-runner.test.ts src/test-utils/openclaw-test-state.ts src/test-utils/openclaw-test-state.test.ts
git diff --check
```

The selected gate included core/core-test/root-test typechecks, core and script lint, format and architecture guards. Fresh isolated **Codex P0 autoreview** returned no findings. The committed patch is byte-identical to the patch used for the successful static gate and final native proof. Exact-head CI will be recorded after this PR is ready; no CI or live-provider success is claimed here yet.

Out of scope: the separately owned post-update service-identity fixture repair; the shell test-state helper's separate selector-cleanup gap; invocation-local strengthening of model-status mock-call assertions; and diagnosis of the host filesystem wait itself.

AI-assisted. Awaiting maintainer source/proof judgment before merge.
