### PR TITLE
fix(gateway): avoid shutdown stalls with paired workers

### DIFF
--- a/docs/gateway/restart-recovery.md
+++ b/docs/gateway/restart-recovery.md
@@ -54,6 +54,12 @@ gateway stops accepting new work, then waits for active agent turns and
 background tasks to finish, up to a drain budget (5 minutes by default). Most
 restarts therefore interrupt nothing at all.
 
+Replies to pending node commands remain accepted during the drain, including
+worker cleanup started by shutdown. Each reply must still match its live
+invocation, node connection, pairing generation, and owning lifecycle. This
+lets cleanup finish without waiting for a command timeout; it does not reopen
+admission for new requests.
+
 Only work that cannot finish inside the drain budget (or any run interrupted
 by a forced restart or a crash) is aborted — and before that happens, each
 affected session is marked for recovery.

--- a/src/gateway/node-registry-private.ts
+++ b/src/gateway/node-registry-private.ts
@@ -384,6 +384,8 @@ async function invokeNodeRegistryCore(
       progressChunks: new Map(),
       nextInputSeq: 0,
       ...(params.onProgress ? { onProgress: params.onProgress } : {}),
+      // Private transport retains its exact lifecycle owner through reply settlement.
+      ...(allowPrivateCommand ? { isCompletionAuthorized: params.isDispatchAuthorized } : {}),
     };
     const generationController = params.expectedPairingGeneration
       ? new AbortController()

--- a/src/gateway/node-registry.invoke-stream.ts
+++ b/src/gateway/node-registry.invoke-stream.ts
@@ -1,5 +1,6 @@
 import {
   captureGatewayRootWorkAdmissionContinuationScope,
+  isGatewayRestartDraining,
   type GatewayRootWorkAdmissionContinuationScope,
 } from "../process/gateway-work-admission.js";
 import { NODE_INVOKE_PAIRING_CHANGED_ABORT } from "./node-registry-private-token.js";
@@ -36,6 +37,7 @@ export type PendingInvoke = {
   nextInputSeq: number;
   removeAbortListener?: () => void;
   admissionContinuation?: GatewayRootWorkAdmissionContinuationScope;
+  isCompletionAuthorized?: () => boolean;
 };
 
 export type NodeInvokeProgressParams = {
@@ -119,19 +121,8 @@ export class NodeInvokeStreamController {
   }
 
   handleResult(params: NodeInvokeResultParams): boolean {
-    const pending = this.options.pendingInvokes.get(params.id);
-    if (
-      !pending ||
-      pending.nodeId !== params.nodeId ||
-      pending.connId !== params.connId ||
-      !this.options.isConnectionActive(pending)
-    ) {
-      return false;
-    }
-    if (this.settleIfExpired(params.id, pending)) {
-      return false;
-    }
-    if (!this.takePending(params.id, pending)) {
+    const pending = this.getPending(params.id, params.nodeId, params.connId);
+    if (!pending || !this.takePending(params.id, pending)) {
       return false;
     }
     if (!params.ok) {
@@ -203,17 +194,8 @@ export class NodeInvokeStreamController {
   }
 
   handleProgress(params: NodeInvokeProgressParams): boolean {
-    const pending = this.options.pendingInvokes.get(params.invokeId);
-    if (
-      !pending ||
-      pending.nodeId !== params.nodeId ||
-      pending.connId !== params.connId ||
-      !this.options.isConnectionActive(pending) ||
-      params.seq < pending.nextProgressSeq
-    ) {
-      return false;
-    }
-    if (this.settleIfExpired(params.invokeId, pending)) {
+    const pending = this.getPending(params.invokeId, params.nodeId, params.connId);
+    if (!pending || params.seq < pending.nextProgressSeq) {
       return false;
     }
     // Receipt proves execution even without a stream consumer. Keep ignored
@@ -243,7 +225,7 @@ export class NodeInvokeStreamController {
       if (chunk === undefined) {
         break;
       }
-      if (this.settleIfExpired(params.invokeId, pending)) {
+      if (!this.getPending(params.invokeId, params.nodeId, params.connId)) {
         break;
       }
       pending.progressChunks.delete(pending.nextProgressSeq);
@@ -263,12 +245,50 @@ export class NodeInvokeStreamController {
         pending.progressChunks.clear();
         break;
       }
-      if (this.settleIfExpired(params.invokeId, pending)) {
+      if (!this.getPending(params.invokeId, params.nodeId, params.connId)) {
         break;
       }
       this.resetIdleTimer(params.invokeId, pending);
     }
     return true;
+  }
+
+  runPendingContinuation<T>(params: {
+    invokeId: string;
+    nodeId: string;
+    connId: string | undefined;
+    run: () => Promise<T>;
+  }): Promise<T> | null {
+    const pending = this.getPending(params.invokeId, params.nodeId, params.connId);
+    if (!pending) {
+      return null;
+    }
+    if (pending.admissionContinuation) {
+      return pending.admissionContinuation.run(params.run);
+    }
+    // Shutdown cleanup has no request root. Its live private owner grants only
+    // settlement; do not mint admission or revive a released captured root.
+    return isGatewayRestartDraining() && pending.isCompletionAuthorized ? params.run() : null;
+  }
+
+  private getPending(id: string, nodeId: string, connId: string | undefined) {
+    const pending = this.options.pendingInvokes.get(id);
+    if (
+      !pending ||
+      pending.nodeId !== nodeId ||
+      pending.connId !== connId ||
+      !this.options.isConnectionActive(pending) ||
+      this.settleIfExpired(id, pending)
+    ) {
+      return undefined;
+    }
+    // Recheck at settlement as handler loading may await after router admission.
+    // Some lifecycle owners assert by throwing; either form must fail closed.
+    try {
+      return pending.isCompletionAuthorized?.() === false ? undefined : pending;
+    } catch {
+      return undefined;
+    }
   }
 
   clearTimers(pending: PendingInvoke): void {

--- a/src/gateway/node-registry.ts
+++ b/src/gateway/node-registry.ts
@@ -1132,27 +1132,14 @@ export class NodeRegistry {
     return this.invokeStreams.handleProgress(params);
   }
 
-  /** Re-enters only the root that owns this exact live node invocation. */
+  /** Continues only the exact live owner of a pending node invocation. */
   runPendingInvokeContinuation<T>(params: {
     invokeId: string;
     nodeId: string;
     connId: string | undefined;
     run: () => Promise<T>;
   }): Promise<T> | null {
-    const pending = this.pendingInvokes.get(params.invokeId);
-    if (
-      !pending?.admissionContinuation ||
-      pending.nodeId !== params.nodeId ||
-      pending.connId !== params.connId ||
-      !isNodeRegistryPendingInvokeConnectionActive({
-        registry: this,
-        pending,
-        currentNode: this.nodesById.get(params.nodeId),
-      })
-    ) {
-      return null;
-    }
-    return pending.admissionContinuation.run(params.run);
+    return this.invokeStreams.runPendingContinuation(params);
   }
 
   /** Authorize an inbound system.run event against a recently issued node invoke. */

--- a/src/gateway/server-methods.suspension-continuations.test.ts
+++ b/src/gateway/server-methods.suspension-continuations.test.ts
@@ -1,6 +1,11 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { GATEWAY_CLIENT_IDS } from "../../packages/gateway-protocol/src/client-info.js";
+import { NODE_WORKER_ENVIRONMENT_STOP_COMMAND } from "../infra/node-commands.js";
+import { NODE_WORKER_SUPERVISOR_PROTOCOL_FEATURE } from "../infra/node-runner-inventory.js";
 import {
+  beginGatewayRestartSignalAdmission,
   getActiveGatewayRootWorkCount,
+  markGatewayRestartDraining,
   resetGatewayWorkAdmission,
   tryBeginGatewayRootWorkAdmission,
   tryBeginGatewaySuspendAdmission,
@@ -8,6 +13,7 @@ import {
 import { ExecApprovalManager } from "./exec-approval-manager.js";
 import { createPluginGatewayMethodDescriptor } from "./methods/descriptor.js";
 import { createGatewayMethodRegistry } from "./methods/registry.js";
+import { createNodeRegistryRuntime, updateNodeRunnerInventory } from "./node-registry-private.js";
 import { NodeRegistry } from "./node-registry.js";
 import { QuestionManager } from "./question-manager.js";
 import { handleGatewayRequest } from "./server-methods.js";
@@ -17,6 +23,22 @@ import type { GatewayRequestContext, GatewayRequestHandler } from "./server-meth
 import type { GatewayWsClient } from "./server/ws-types.js";
 
 afterEach(resetGatewayWorkAdmission);
+
+const completionDrainModes = ["suspension", "restart signal", "restart drain"] as const;
+
+function closeAdmission(mode: (typeof completionDrainModes)[number]) {
+  if (mode === "restart signal") {
+    expect(beginGatewayRestartSignalAdmission()).not.toBeNull();
+    return;
+  }
+  if (mode === "restart drain") {
+    markGatewayRestartDraining();
+    return;
+  }
+  const suspension = tryBeginGatewaySuspendAdmission(() => {});
+  expect(suspension?.drain()).toBe(true);
+  return suspension;
+}
 
 function deferred<T = void>() {
   let resolve!: (value: T) => void;
@@ -102,6 +124,86 @@ async function dispatch(params: {
     ]),
   });
   return respond;
+}
+
+async function createLifecycleInvoke() {
+  const client = createClient("node");
+  client.connect.client.id = GATEWAY_CLIENT_IDS.NODE_HOST;
+  client.connect.commands = [NODE_WORKER_ENVIRONMENT_STOP_COMMAND];
+  let generation = "generation-live";
+  let ownerActive = true;
+  const { nodeRegistry: registry, nodeWorkerSupervisorTransport: transport } =
+    createNodeRegistryRuntime(
+      () =>
+        new NodeRegistry({
+          resolveCurrentPairingState: async () => ({ identity: "paired", generation }),
+        }),
+    );
+  registry.register(client, { pairingIdentity: "paired", pairingGeneration: generation });
+  updateNodeRunnerInventory({
+    registry,
+    nodeId: "node-1",
+    connId: client.connId,
+    declaration: {
+      protocolFeatures: [NODE_WORKER_SUPERVISOR_PROTOCOL_FEATURE],
+      workerHost: { enabled: true, capacity: { total: 1, available: 1 }, environmentSession: 1 },
+    },
+  });
+  const [node] = await transport.listCurrentNodes();
+  if (!node) {
+    throw new Error("expected current worker supervisor");
+  }
+  const ready = deferred<string>();
+  const abort = new AbortController();
+  const result = transport.invoke({
+    node,
+    command: NODE_WORKER_ENVIRONMENT_STOP_COMMAND,
+    params: { environmentId: "environment-owned", sessionId: "session-owned", ownerEpoch: 1 },
+    timeoutMs: 60_000,
+    signal: abort.signal,
+    isDispatchAuthorized: () => ownerActive,
+    onDispatchReady: ready.resolve,
+  });
+  const invokeId = await Promise.race([
+    ready.promise,
+    result.then(() => {
+      throw new Error("lifecycle invocation finished before dispatch");
+    }),
+  ]);
+  const context = createContext({ nodeRegistry: registry });
+  return {
+    client,
+    context,
+    invokeId,
+    registry,
+    result,
+    closeOwner: () => {
+      ownerActive = false;
+    },
+    rotatePairing: () => {
+      const previous = generation;
+      generation = "generation-next";
+      registry.updateSurface(
+        "node-1",
+        { commands: [NODE_WORKER_ENVIRONMENT_STOP_COMMAND] },
+        {
+          expectedConnId: client.connId,
+          expectedPairingIdentity: "paired",
+          expectedPairingGeneration: previous,
+          nextPairingGeneration: generation,
+        },
+      );
+    },
+    finish: async () => {
+      abort.abort();
+      registry.unregister(client.connId);
+      await result;
+    },
+  };
+}
+
+function resultRequest(invokeId: string) {
+  return { id: invokeId, nodeId: "node-1", ok: true, payloadJSON: "null" };
 }
 
 describe("draining Gateway completion ownership", () => {
@@ -236,100 +338,247 @@ describe("draining Gateway completion ownership", () => {
     manager.reset();
   });
 
-  it("admits only the registered node's exact live progress and result while delivery remains active", async () => {
-    const node = createClient("node");
-    const registry = new NodeRegistry({
-      resolveCurrentPairingState: async () => ({
-        identity: "paired",
-        generation: "generation-live",
-      }),
-    });
-    registry.register(node, {
-      pairingIdentity: "paired",
-      pairingGeneration: "generation-live",
-    });
-    const context = createContext({ nodeRegistry: registry });
-    const invokeReady = deferred<string>();
-    const finishDelivery = deferred();
-    const chunks: string[] = [];
-    const root = tryBeginGatewayRootWorkAdmission();
-    if (!root) {
-      throw new Error("expected admitted node invocation owner");
-    }
-    const owner = root
-      .run(async () => {
-        const result = await registry.invoke({
-          nodeId: "node-1",
-          command: "debug.ping",
-          timeoutMs: 60_000,
-          onProgress: (chunk) => chunks.push(chunk),
-          onDispatchReady: invokeReady.resolve,
+  it.each(completionDrainModes)(
+    "admits only the registered node's exact live progress and result during %s",
+    async (mode) => {
+      const node = createClient("node");
+      const registry = new NodeRegistry({
+        resolveCurrentPairingState: async () => ({
+          identity: "paired",
+          generation: "generation-live",
+        }),
+      });
+      registry.register(node, {
+        pairingIdentity: "paired",
+        pairingGeneration: "generation-live",
+      });
+      const context = createContext({ nodeRegistry: registry });
+      const invokeReady = deferred<string>();
+      const finishDelivery = deferred();
+      const chunks: string[] = [];
+      const root = tryBeginGatewayRootWorkAdmission();
+      if (!root) {
+        throw new Error("expected admitted node invocation owner");
+      }
+      const owner = root
+        .run(async () => {
+          const result = await registry.invoke({
+            nodeId: "node-1",
+            command: "debug.ping",
+            timeoutMs: 60_000,
+            onProgress: (chunk) => chunks.push(chunk),
+            onDispatchReady: invokeReady.resolve,
+          });
+          await finishDelivery.promise;
+          return result;
+        })
+        .finally(root.release);
+      const invokeId = await Promise.race([
+        invokeReady.promise,
+        owner.then(() => {
+          throw new Error("node invocation finished before its dispatch became ready");
+        }),
+      ]);
+      expect(getActiveGatewayRootWorkCount()).toBe(1);
+      const suspension = closeAdmission(mode);
+
+      try {
+        const ignored = await dispatch({
+          method: "node.invoke.result",
+          requestParams: { id: "unrelated-invoke", nodeId: "node-1", ok: true },
+          context,
+          client: node,
+          handler: vi.fn(),
         });
-        await finishDelivery.promise;
-        return result;
-      })
-      .finally(root.release);
-    const invokeId = await Promise.race([
-      invokeReady.promise,
-      owner.then(() => {
-        throw new Error("node invocation finished before its dispatch became ready");
-      }),
-    ]);
-    expect(getActiveGatewayRootWorkCount()).toBe(1);
-    const suspension = tryBeginGatewaySuspendAdmission(() => {});
-    expect(suspension?.drain()).toBe(true);
+        expect(ignored).toHaveBeenCalledWith(
+          false,
+          undefined,
+          expect.objectContaining({ code: "UNAVAILABLE" }),
+        );
 
-    const ignored = await dispatch({
-      method: "node.invoke.result",
-      requestParams: { id: "unrelated-invoke", nodeId: "node-1", ok: true },
-      context,
-      client: node,
-      handler: vi.fn(),
-    });
-    expect(ignored).toHaveBeenCalledWith(
-      false,
-      undefined,
-      expect.objectContaining({ code: "UNAVAILABLE" }),
-    );
+        const malformed = await dispatch({
+          method: "node.invoke.progress",
+          requestParams: { invokeId, nodeId: "node-1", seq: -1, chunk: "invalid" },
+          context,
+          client: node,
+          handler: handleNodeInvokeProgress,
+        });
+        expect(malformed).toHaveBeenCalledWith(
+          false,
+          undefined,
+          expect.objectContaining({ code: "INVALID_REQUEST" }),
+        );
+        expect(chunks).toEqual([]);
+        expect(getActiveGatewayRootWorkCount()).toBe(1);
 
-    const malformed = await dispatch({
-      method: "node.invoke.progress",
-      requestParams: { invokeId, nodeId: "node-1", seq: -1, chunk: "invalid" },
-      context,
-      client: node,
-      handler: handleNodeInvokeProgress,
-    });
-    expect(malformed).toHaveBeenCalledWith(
-      false,
-      undefined,
-      expect.objectContaining({ code: "INVALID_REQUEST" }),
-    );
-    expect(chunks).toEqual([]);
-    expect(getActiveGatewayRootWorkCount()).toBe(1);
+        const progressed = await dispatch({
+          method: "node.invoke.progress",
+          requestParams: { invokeId, nodeId: "node-1", seq: 0, chunk: "working" },
+          context,
+          client: node,
+          handler: handleNodeInvokeProgress,
+        });
+        expect(progressed).toHaveBeenCalledWith(true, { ok: true, ignored: false }, undefined);
+        expect(chunks).toEqual(["working"]);
 
-    const progressed = await dispatch({
-      method: "node.invoke.progress",
-      requestParams: { invokeId, nodeId: "node-1", seq: 0, chunk: "working" },
-      context,
-      client: node,
-      handler: handleNodeInvokeProgress,
-    });
-    expect(progressed).toHaveBeenCalledWith(true, { ok: true, ignored: false }, undefined);
-    expect(chunks).toEqual(["working"]);
+        const completed = await dispatch({
+          method: "node.invoke.result",
+          requestParams: {
+            id: invokeId,
+            nodeId: "node-1",
+            ok: true,
+            payloadJSON: null,
+            error: null,
+          },
+          context,
+          client: node,
+          handler: handleNodeInvokeResult,
+        });
+        expect(completed).toHaveBeenCalledWith(true, { ok: true }, undefined);
+        expect(getActiveGatewayRootWorkCount()).toBe(1);
+        finishDelivery.resolve();
+        await expect(owner).resolves.toMatchObject({ ok: true, payloadJSON: null, error: null });
+        expect(getActiveGatewayRootWorkCount()).toBe(0);
+        if (suspension) {
+          expect(suspension.release()).toBe(true);
+        }
+      } finally {
+        finishDelivery.resolve();
+        registry.unregister(node.connId);
+        await owner;
+      }
+    },
+  );
+});
 
-    const completed = await dispatch({
-      method: "node.invoke.result",
-      requestParams: { id: invokeId, nodeId: "node-1", ok: true, payloadJSON: null, error: null },
-      context,
-      client: node,
-      handler: handleNodeInvokeResult,
-    });
-    expect(completed).toHaveBeenCalledWith(true, { ok: true }, undefined);
-    expect(getActiveGatewayRootWorkCount()).toBe(1);
-    finishDelivery.resolve();
-    await expect(owner).resolves.toMatchObject({ ok: true, payloadJSON: null, error: null });
-    expect(getActiveGatewayRootWorkCount()).toBe(0);
-    expect(suspension?.release()).toBe(true);
-    registry.unregister(node.connId);
+describe("restart lifecycle completion ownership", () => {
+  it.each(["restart signal", "restart drain"] as const)(
+    "settles newly dispatched lifecycle cleanup during %s without admitting another root",
+    async (mode) => {
+      closeAdmission(mode);
+      const invoke = await createLifecycleInvoke();
+      try {
+        expect(getActiveGatewayRootWorkCount()).toBe(0);
+        const progressed = await dispatch({
+          method: "node.invoke.progress",
+          requestParams: { invokeId: invoke.invokeId, nodeId: "node-1", seq: 0, chunk: "stopped" },
+          context: invoke.context,
+          client: invoke.client,
+          handler: handleNodeInvokeProgress,
+        });
+        // Lifecycle invokes have no stream consumer, but authenticated progress
+        // still records execution and prevents a contradictory not-ready replay.
+        expect(progressed).toHaveBeenCalledWith(true, { ok: true, ignored: true }, undefined);
+        expect(getActiveGatewayRootWorkCount()).toBe(0);
+        expect(tryBeginGatewayRootWorkAdmission()).toBeNull();
+        const completed = await dispatch({
+          method: "node.invoke.result",
+          requestParams: {
+            ...resultRequest(invoke.invokeId),
+            ok: false,
+            error: { code: "NODE_NOT_READY", message: "not ready" },
+          },
+          context: invoke.context,
+          client: invoke.client,
+          handler: handleNodeInvokeResult,
+        });
+        expect(completed).toHaveBeenCalledWith(true, { ok: true }, undefined);
+        await expect(invoke.result).resolves.toMatchObject({
+          ok: false,
+          error: {
+            code: "UNAVAILABLE",
+            message: "node reported not-ready after invocation progress",
+          },
+        });
+        const replayed = await dispatch({
+          method: "node.invoke.result",
+          requestParams: resultRequest(invoke.invokeId),
+          context: invoke.context,
+          client: invoke.client,
+          handler: handleNodeInvokeResult,
+        });
+        expect(replayed).toHaveBeenCalledWith(
+          false,
+          undefined,
+          expect.objectContaining({ code: "UNAVAILABLE" }),
+        );
+        expect(getActiveGatewayRootWorkCount()).toBe(0);
+        expect(tryBeginGatewayRootWorkAdmission()).toBeNull();
+      } finally {
+        await invoke.finish();
+      }
+    },
+  );
+
+  it.each(["invoke", "node", "connection", "pairing", "owner"] as const)(
+    "rejects lifecycle completion after its %s identity no longer matches",
+    async (changed) => {
+      closeAdmission("restart drain");
+      const invoke = await createLifecycleInvoke();
+      try {
+        const request = resultRequest(invoke.invokeId);
+        let client = invoke.client;
+        if (changed === "invoke") {
+          request.id = "unrelated-invoke";
+        } else if (changed === "node") {
+          request.nodeId = "unrelated-node";
+        } else if (changed === "connection") {
+          client = { ...invoke.client, connId: "replaced-connection" };
+        } else if (changed === "pairing") {
+          invoke.rotatePairing();
+        } else {
+          invoke.closeOwner();
+        }
+        const rejected = await dispatch({
+          method: "node.invoke.result",
+          requestParams: request,
+          context: invoke.context,
+          client,
+          handler: handleNodeInvokeResult,
+        });
+        expect(rejected).toHaveBeenCalledWith(
+          false,
+          undefined,
+          expect.objectContaining({ code: "UNAVAILABLE" }),
+        );
+        expect(getActiveGatewayRootWorkCount()).toBe(0);
+      } finally {
+        await invoke.finish();
+      }
+    },
+  );
+
+  it("rechecks the lifecycle owner at result settlement after awaited dispatch work", async () => {
+    closeAdmission("restart drain");
+    const invoke = await createLifecycleInvoke();
+    const enteredHandler = deferred();
+    const resumeHandler = deferred();
+    try {
+      const response = dispatch({
+        method: "node.invoke.result",
+        requestParams: resultRequest(invoke.invokeId),
+        context: invoke.context,
+        client: invoke.client,
+        handler: async (options) => {
+          enteredHandler.resolve();
+          await resumeHandler.promise;
+          expect(tryBeginGatewayRootWorkAdmission()).toBeNull();
+          await handleNodeInvokeResult(options);
+        },
+      });
+      await Promise.race([
+        enteredHandler.promise,
+        response.then(() => {
+          throw new Error("lifecycle completion was rejected before reaching its handler");
+        }),
+      ]);
+      invoke.closeOwner();
+      resumeHandler.resolve();
+      expect(await response).toHaveBeenCalledWith(true, { ok: true, ignored: true }, undefined);
+      expect(getActiveGatewayRootWorkCount()).toBe(0);
+    } finally {
+      resumeHandler.resolve();
+      await invoke.finish();
+    }
   });
 });

--- a/src/gateway/server-methods.suspension-continuations.test.ts
+++ b/src/gateway/server-methods.suspension-continuations.test.ts
@@ -29,11 +29,11 @@ const completionDrainModes = ["suspension", "restart signal", "restart drain"] a
 function closeAdmission(mode: (typeof completionDrainModes)[number]) {
   if (mode === "restart signal") {
     expect(beginGatewayRestartSignalAdmission()).not.toBeNull();
-    return;
+    return undefined;
   }
   if (mode === "restart drain") {
     markGatewayRestartDraining();
-    return;
+    return undefined;
   }
   const suspension = tryBeginGatewaySuspendAdmission(() => {});
   expect(suspension?.drain()).toBe(true);

--- a/src/gateway/server-methods.ts
+++ b/src/gateway/server-methods.ts
@@ -315,11 +315,14 @@ function runGatewayPendingWorkContinuation<T>(params: {
   context: GatewayRequestContext;
   run: () => Promise<T>;
 }): Promise<T> | null {
-  if (getGatewaySuspendAdmissionPhase() !== "draining" || !isRecord(params.requestParams)) {
+  if (!isRecord(params.requestParams)) {
     return null;
   }
   const request = params.requestParams;
   if (params.client?.connect.role === "node") {
+    if (getGatewaySuspendAdmissionPhase() !== "draining" && !isGatewayRestartDraining()) {
+      return null;
+    }
     const invokeId =
       params.method === "node.invoke.progress"
         ? request.invokeId
@@ -336,7 +339,11 @@ function runGatewayPendingWorkContinuation<T>(params: {
       run: params.run,
     });
   }
-  if (params.client?.connect.role !== "operator" || typeof request.id !== "string") {
+  if (
+    getGatewaySuspendAdmissionPhase() !== "draining" ||
+    params.client?.connect.role !== "operator" ||
+    typeof request.id !== "string"
+  ) {
     return null;
   }
   if (params.method === "question.resolve" || params.method === "question.get") {
@@ -574,14 +581,14 @@ export async function runWithGatewayRequestEnvelope<T>(
       ? tryBeginGatewayPreparedRestartRootWorkAdmission()
       : null);
   if (!rootWorkAdmission) {
-    // Completion frames arrive on their own socket chains. Only their exact
-    // live owner can re-enter the already-admitted root that is waiting for them.
+    // Completion frames arrive on separate socket chains. Their exact pending owner
+    // may settle them without admitting a new root, including rootless shutdown cleanup.
     const continuation = runGatewayPendingWorkContinuation({
       method,
       client,
       requestParams: options.requestParams,
       context: options.context,
-      run: () => runWithGatewayRequestEnvelope(method, client, fn, options),
+      run: invokeWithRequestScope,
     });
     if (continuation) {
       return await continuation;
@@ -616,19 +623,15 @@ export async function runWithGatewayRequestEnvelope<T>(
       ),
     );
   }
-  const postAdmissionRateLimitError = isSuspendPrepare
-    ? undefined
-    : rejectRateLimitedControlPlaneWrite();
-  if (postAdmissionRateLimitError) {
+  async function invokeWithRequestScope() {
+    const postAdmissionRateLimitError = isSuspendPrepare
+      ? undefined
+      : rejectRateLimitedControlPlaneWrite();
     // A closed admission must reject first so refused writes do not exhaust the controller's
     // budget and strand it behind rate limiting after suspension resumes.
-    try {
+    if (postAdmissionRateLimitError) {
       return await options.reject(postAdmissionRateLimitError);
-    } finally {
-      rootWorkAdmission?.release();
     }
-  }
-  const invokeWithRequestScope = async () => {
     try {
       const pluginRegistry =
         (options.methodRegistry.pluginRegistry as
@@ -665,7 +668,7 @@ export async function runWithGatewayRequestEnvelope<T>(
       }
       throw error;
     }
-  };
+  }
   if (!rootWorkAdmission) {
     return await invokeWithRequestScope();
   }

--- a/src/gateway/server.node-shutdown.test.ts
+++ b/src/gateway/server.node-shutdown.test.ts
@@ -1,0 +1,205 @@
+import path from "node:path";
+import { expect, test } from "vitest";
+import { WORKER_EXECUTION_CONTEXT_PROTOCOL_FEATURE } from "../../packages/gateway-protocol/src/schema/worker-admission.js";
+import { approveNodePairing, requestNodePairing } from "../infra/device-pairing-node.js";
+import { withTimeout } from "../infra/fs-safe.js";
+import {
+  NODE_WORKER_ENVIRONMENT_STOP_COMMAND,
+  NODE_WORKER_WORKSPACE_RETAIN_COMMAND,
+} from "../infra/node-commands.js";
+import { NODE_WORKER_SUPERVISOR_PROTOCOL_FEATURE } from "../infra/node-runner-inventory.js";
+import { markGatewayRestartDraining } from "../process/gateway-work-admission.js";
+import { createDeferredCore } from "../shared/deferred.js";
+import { GATEWAY_CLIENT_MODES, GATEWAY_CLIENT_NAMES } from "../utils/message-channel.js";
+import { pairDeviceIdentity } from "./device-authz.test-helpers.js";
+import { connectGatewayClient } from "./test-helpers.e2e.js";
+import { installGatewayTestHooks, startServer, writeSessionStore } from "./test-helpers.js";
+import { testState } from "./test-helpers.runtime-state.js";
+import { sessionStoreEntry } from "./test/server-sessions.test-helpers.js";
+import { hashWorkerCredential } from "./worker-environments/credential.js";
+import { DEVICE_WORKER_PROVIDER_ID } from "./worker-environments/device-provider-identity.js";
+import {
+  BUNDLE_HASH,
+  REQUEST,
+  seedActivePlacement,
+} from "./worker-environments/placement-dispatch-test-fixtures.js";
+import { createWorkerSessionPlacementStore } from "./worker-environments/placement-store.js";
+import { createWorkerEnvironmentStore } from "./worker-environments/store.js";
+
+installGatewayTestHooks({ scope: "suite" });
+
+test("settles an idle paired worker's rootless stop reply during Gateway shutdown", async () => {
+  const stateDir = process.env.OPENCLAW_STATE_DIR;
+  if (!stateDir) {
+    throw new Error("node shutdown proof requires an isolated Gateway state directory");
+  }
+  testState.sessionStorePath = path.join(stateDir, "node-shutdown-sessions.json");
+  const pairedNode = await pairDeviceIdentity({
+    name: "node-shutdown",
+    role: "node",
+    scopes: [],
+    clientId: GATEWAY_CLIENT_NAMES.NODE_HOST,
+    clientMode: GATEWAY_CLIENT_MODES.NODE,
+  });
+  const pairing = await requestNodePairing({
+    nodeId: pairedNode.identity.deviceId,
+    platform: "linux",
+    deviceFamily: "Linux",
+    commands: [],
+  });
+  await approveNodePairing(pairing.request.requestId, {
+    callerScopes: ["operator.pairing", "operator.write"],
+  });
+
+  const previousMinimalGateway = process.env.OPENCLAW_TEST_MINIMAL_GATEWAY;
+  let started: Awaited<ReturnType<typeof startServer>>;
+  try {
+    delete process.env.OPENCLAW_TEST_MINIMAL_GATEWAY;
+    started = await startServer("secret");
+  } finally {
+    if (previousMinimalGateway === undefined) {
+      delete process.env.OPENCLAW_TEST_MINIMAL_GATEWAY;
+    } else {
+      process.env.OPENCLAW_TEST_MINIMAL_GATEWAY = previousMinimalGateway;
+    }
+  }
+  const { port, server } = started;
+  let node: Awaited<ReturnType<typeof connectGatewayClient>> | undefined;
+  let closing: Promise<void> | undefined;
+  const stopped = createDeferredCore<unknown>();
+  const stopRequests: unknown[] = [];
+  void stopped.promise.catch(() => undefined);
+
+  try {
+    await server.startupSettled;
+    node = await connectGatewayClient({
+      url: `ws://127.0.0.1:${port}`,
+      token: "secret",
+      role: "node",
+      clientName: GATEWAY_CLIENT_NAMES.NODE_HOST,
+      clientDisplayName: "shutdown worker node",
+      mode: GATEWAY_CLIENT_MODES.NODE,
+      platform: "linux",
+      deviceFamily: "Linux",
+      scopes: [],
+      commands: [],
+      deviceIdentity: pairedNode.identity,
+      onEvent: (event) => {
+        if (event.event !== "node.invoke.request" || !event.payload) {
+          return;
+        }
+        const frame = event.payload as {
+          id: string;
+          nodeId: string;
+          command: string;
+          paramsJSON: string;
+        };
+        const isStop = frame.command === NODE_WORKER_ENVIRONMENT_STOP_COMMAND;
+        if (!isStop && frame.command !== NODE_WORKER_WORKSPACE_RETAIN_COMMAND) {
+          stopped.reject(new Error(`unexpected shutdown command: ${frame.command}`));
+          return;
+        }
+        if (isStop) {
+          stopRequests.push(JSON.parse(frame.paramsJSON));
+        }
+        const result = node!.request(
+          "node.invoke.result",
+          {
+            id: frame.id,
+            nodeId: frame.nodeId,
+            ok: true,
+            payloadJSON: JSON.stringify(
+              isStop ? null : { applied: true, deleted: 0, hasMore: false },
+            ),
+          },
+          { timeoutMs: 5_000 },
+        );
+        if (isStop) {
+          void result.then(stopped.resolve, stopped.reject);
+        } else {
+          void result.catch(() => undefined);
+        }
+      },
+    });
+    await node.request("node.runnerInventory.update", {
+      protocolFeatures: [NODE_WORKER_SUPERVISOR_PROTOCOL_FEATURE],
+      workerHost: {
+        enabled: true,
+        capacity: { total: 1, available: 1 },
+        environmentSession: 1,
+      },
+    });
+    await writeSessionStore({
+      entries: { [REQUEST.sessionKey]: sessionStoreEntry(REQUEST.sessionId) },
+    });
+    const environmentId = "environment-node-shutdown";
+    const environments = createWorkerEnvironmentStore();
+    environments.createIntent({
+      environmentId,
+      providerId: DEVICE_WORKER_PROVIDER_ID,
+      profileId: `device:${pairedNode.identity.deviceId}`,
+      profileSnapshot: { install: "bundle", settings: { device: pairedNode.identity.deviceId } },
+      provisionOperationId: "provision-node-shutdown",
+    });
+    environments.transition({ environmentId, from: "requested", to: "provisioning" });
+    environments.transition({
+      environmentId,
+      from: "provisioning",
+      to: "ready",
+      patch: {
+        leaseId: "lease-node-shutdown",
+        nodeDeviceId: pairedNode.identity.deviceId,
+        sharedHost: true,
+        bootstrapReceipt: {
+          bundleHash: BUNDLE_HASH,
+          openclawVersion: "2026.8.19",
+          protocolFeatures: [WORKER_EXECUTION_CONTEXT_PROTOCOL_FEATURE],
+          installKind: "bundle",
+        },
+        credential: {
+          credentialHash: hashWorkerCredential("node-shutdown-ready-fixture"),
+          sessionId: null,
+          rpcSetVersion: 1,
+          expiresAtMs: Date.now() + 60_000,
+        },
+      },
+    });
+    const attached = environments.transition({
+      environmentId,
+      from: "ready",
+      to: "attached",
+      patch: {
+        attachedSessionIds: [REQUEST.sessionId],
+        credential: {
+          credentialHash: hashWorkerCredential("node-shutdown-fixture"),
+          sessionId: REQUEST.sessionId,
+          rpcSetVersion: 1,
+          expiresAtMs: Date.now() + 60_000,
+        },
+      },
+    });
+    const placements = createWorkerSessionPlacementStore();
+    seedActivePlacement(placements, { environmentId, ownerEpoch: attached.ownerEpoch });
+    expect(placements.get(REQUEST.sessionId)).toMatchObject({ state: "active", turnClaim: null });
+
+    // Stop has no request root: it is admitted only by the exact environment cleanup owner.
+    markGatewayRestartDraining();
+    closing = server.close({ reason: "gateway stopping" });
+    await expect(withTimeout(stopped.promise, 5_000, "node shutdown reply")).resolves.toEqual({
+      ok: true,
+    });
+    await withTimeout(closing, 5_000, "Gateway shutdown");
+    expect(stopRequests).toEqual([
+      {
+        gatewayNamespace: expect.any(String),
+        environmentId,
+        sessionId: REQUEST.sessionId,
+        ownerEpoch: attached.ownerEpoch,
+      },
+    ]);
+  } finally {
+    // Disconnect also settles the pending invoke on the failing baseline; no 60s cleanup wait.
+    await node?.stopAndWait({ timeoutMs: 1_000 });
+    await (closing ?? server.close());
+  }
+});

--- a/ui/src/pages/chat/chat-pane-task-suggestions.test.ts
+++ b/ui/src/pages/chat/chat-pane-task-suggestions.test.ts
@@ -45,6 +45,10 @@ describe("chat pane task suggestion lifecycle", () => {
     try {
       await pane.copyTaskSuggestionPrompt(suggestion);
     } finally {
+      // The fallback restores focus on the next turn; drain it before jsdom teardown.
+      await new Promise<void>((resolve) => {
+        window.setTimeout(resolve, 0);
+      });
       if (originalClipboard) {
         Object.defineProperty(navigator, "clipboard", originalClipboard);
       } else {


### PR DESCRIPTION
Closes #132819

## What Problem This Solves

Fixes an issue where operators stopping or restarting a Gateway with paired workers could wait through node-command deadlines even though the node had already replied. Shutdown rejected the completion frames that its own maintenance and worker cleanup were waiting for.

## Why This Change Was Made

The RPC router now lets an exact pending node owner execute its completion handler during restart without recursively requesting new root admission. The invocation-stream owner centralizes connection, deadline, and lifecycle checks for admission, progress, and result settlement. Private worker commands retain their existing live lifecycle predicate and recheck it after asynchronous handler dispatch; cleanup never mints a request root or revives a released one. Duplicate validation in the registry and stream handlers is removed.

New work remains fenced. Unrelated, replayed, disconnected, re-paired, expired, and owner-revoked replies cannot settle another invocation. Approval/question continuation policy remains suspension-only. No configuration, database schema, protocol version, or worker timeout changes.

Provenance: the suspension-only continuation path was introduced in #130003 (093166c7d94f, August 26), and worker environment-stop replies made the shutdown gap visible in #130733 (e4d602c6f374, August 27). Both were authored and merged by @steipete. The focused reproduction is against current main at 10da9ac92194; this does not establish an older stable-release regression.

Production LOC: +68/-56 (net +12). The added capability is closure-bound completion for rootless private lifecycle cleanup; consolidating existing validation absorbs the rest of the repair. Tests and documentation are separate.

## User Impact

Responsive paired workers can complete Gateway shutdown without waiting out their command budgets. Cleanup still targets the exact environment/session/owner epoch, and node-side physical teardown remains authoritative. The same private node transport serves device and cloud workers; remote-exec process ownership is unchanged.

## Evidence

- Before the production change, five continuation regression cases failed. The real Gateway/paired-node WebSocket test independently reproduced `node.invoke.result unavailable during gateway restart` while shutdown awaited its rootless environment-stop reply.
- After the change, all 217 tests across eight focused files pass: restart signal/drain, suspension admission, invocation timeouts and streaming, node pairing/socket lifecycle, worker tunnel cleanup, and process admission.
- The real-socket shutdown regression requires the cleanup acknowledgement and prompt Gateway close, without advancing command deadlines. It disconnects the node only during failure cleanup.
- Independent Codex autoreview completed with no actionable findings at its default P0 threshold.
- Fresh full build and all changed-scope checks completed successfully. Exact-head [CI run33279493380](https://github.com/openclaw/openclaw/actions/runs/33279493380) passed at4738d6cfe7cd12299a2a07ee1b346b4bc2167fd9, including the required openclaw/ci-gate.
- Separate process-level proof used an isolated real Gateway, authenticated paired headless node, an active idle worker placement, and SIGTERM. No model inference or provider credentials were needed. Baseline main stayed running after 115.01 seconds, with repeated rejected node completion frames, until harness cleanup disconnected its node. With this patch, the Gateway exited normally in 0.466 seconds while the node remained connected. All owned processes and temporary state/credentials were cleaned up.

Sanitized process-probe results (same fixture and shutdown order):

```text
baseline: active placement -> SIGTERM -> node.invoke.result unavailable during gateway restart
baseline: still running after 115.01s; node disconnect during failure cleanup allowed exit
fixed:    active placement -> SIGTERM -> exitCode=0, seconds=0.466, forced=false
fixed:    processesStopped=true, ephemeralCredentialsDeleted=true
```

The initial CI run found a return-style lint error in the new test helper (fixed; no runtime change) and an unrelated Codex child-startup diagnostic race, tracked separately in #132884. The latter is in unchanged code; no startup retry assertions or process inspection policy were relaxed here. The 15 tests in the two edited Gateway test files passed again after the lint correction. A subsequent UI shard passed all4,094 assertions but reported a deferred clipboard-focus callback after jsdom teardown. This PR includes a bounded test-only cleanup: drain that callback before restoring DOM mocks. Both clipboard/task-suggestion suites pass(12 tests); no UI production behavior or assertion changed.

Latest ClawSweeper review and rank-up moves read: its exact pending/lifecycle boundary is retained, and the +12 production lines are justified above. The maintainer-directed repair preserves that boundary. Required exact-head checks are green; both rank-up moves are satisfied and there are no outstanding review findings.
