### PR TITLE
fix: isolate browser bindings and clipboard teardown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Browser extension relay:** route Runtime binding callbacks only to registered clients and preserve shared bindings during client cleanup, preventing raw callback payloads from reaching unrelated Playwright sessions.
 - **Grok web search startup:** avoid loading the full agent runtime before the first search, while preserving agent-scoped credentials and OAuth fallback behavior.
 - Gateway/subagents: keep plugin completion turns bound to the owning Gateway runtime so successful native subagents can finish delivery without losing the published reply runtime.
 - **Upgrade config repair:** retain plugin-owned channel configuration migrations alongside core schemas so `doctor --fix` can repair older settings before an external plugin is installed or granted capabilities, while preserving installed-plugin ownership and state-migration boundaries.

--- a/docs/tools/chrome-extension.md
+++ b/docs/tools/chrome-extension.md
@@ -258,6 +258,13 @@ enables Runtime, the extension checks current tab access before the relay
 replays existing execution contexts to that new subscriber. This does not
 reset another client's Runtime session.
 
+Runtime binding callbacks go only to logical sessions that successfully registered
+the binding name, independently of `Runtime.enable` and `Runtime.disable`.
+Removing a binding or disconnecting a client preserves other clients' registrations
+of the same name. Context-specific registrations with the same name still share
+the underlying native Runtime; use distinct names when clients need separate
+context selection.
+
 Fetch request interception has one owner per native target session. Another
 client can use other CDP domains, but cannot replace that owner's interception
 settings or resolve its paused requests. Competing interception requests return

--- a/extensions/browser/chrome-extension/bootstrap.chromium.test.ts
+++ b/extensions/browser/chrome-extension/bootstrap.chromium.test.ts
@@ -512,14 +512,22 @@ describe.runIf(runE2E)("Chrome native bootstrap Chromium E2E", () => {
           relayPlaywrightContext = relayPage.context();
           expect(connectOverCdp).not.toHaveBeenCalled();
           const bindingSession = await relayPlaywrightContext.newCDPSession(relayPage);
+          const observerSession = await relayPlaywrightContext.newCDPSession(relayPage);
           const bindingName = "__openclawRelayBindingProof";
           const bindingPayloads: string[] = [];
+          const observerPayloads: string[] = [];
+          observerSession.on("Runtime.bindingCalled", (event) => {
+            if (event.name === bindingName) {
+              observerPayloads.push(event.payload);
+            }
+          });
           bindingSession.on("Runtime.bindingCalled", (event) => {
             if (event.name === bindingName) {
               bindingPayloads.push(event.payload);
             }
           });
           try {
+            await observerSession.send("Runtime.enable");
             await bindingSession.send("Runtime.addBinding", { name: bindingName });
             await bindingSession.send("Runtime.evaluate", {
               expression: "globalThis.__openclawRelayBindingProof('before-enable')",
@@ -531,11 +539,13 @@ describe.runIf(runE2E)("Chrome native bootstrap Chromium E2E", () => {
               expression: "globalThis.__openclawRelayBindingProof('after-disable')",
             });
             await expect.poll(() => bindingPayloads).toEqual(["before-enable", "after-disable"]);
+            expect(observerPayloads).toEqual([]);
           } finally {
             await bindingSession
               .send("Runtime.removeBinding", { name: bindingName })
               .catch(() => {});
             await bindingSession.detach().catch(() => {});
+            await observerSession.detach().catch(() => {});
           }
         } finally {
           connectOverCdp.mockRestore();

--- a/extensions/browser/src/browser/extension-relay/relay-bridge.ts
+++ b/extensions/browser/src/browser/extension-relay/relay-bridge.ts
@@ -881,7 +881,9 @@ export class ExtensionRelayBridge {
     const result =
       request.method === "Runtime.enable"
         ? await runtime.enable(session, emit, send)
-        : await send();
+        : request.method === "Runtime.addBinding" || request.method === "Runtime.removeBinding"
+          ? await runtime.binding(session, emit, request.method, request.params)
+          : await send();
     if (client.sessions.get(sessionId) !== session) {
       throw new Error(`Session detached: ${sessionId}`);
     }

--- a/extensions/browser/src/browser/extension-relay/relay-runtime.test.ts
+++ b/extensions/browser/src/browser/extension-relay/relay-runtime.test.ts
@@ -24,7 +24,7 @@ function fixture() {
   onTestFinished(() => bridge.dispose());
   const enabled = new Set<string>();
   const held: number[] = [];
-  let hold = false;
+  let heldMethod: string | undefined;
   let accessAllowed = true;
   let contextOffset = -10;
   const extension = wireExtension(bridge, (msg) => {
@@ -51,13 +51,13 @@ function fixture() {
             msg.sessionId,
           );
         }
-        if (hold) {
-          held.push(msg.seq);
-          return null;
-        }
       }
       if (msg.method === "Runtime.disable") {
         enabled.delete(key);
+      }
+      if (msg.method === heldMethod) {
+        held.push(msg.seq);
+        return null;
       }
     }
     return { type: "result", seq: msg.seq, result: {} };
@@ -136,11 +136,11 @@ function fixture() {
     revokeAccess: () => {
       accessAllowed = false;
     },
-    hold: () => {
-      hold = true;
+    hold: (method = "Runtime.enable") => {
+      heldMethod = method;
     },
     release: () => {
-      hold = false;
+      heldMethod = undefined;
       for (const seq of held.splice(0)) {
         extension.handlers.onMessage(JSON.stringify({ type: "result", seq, result: {} }));
       }
@@ -739,7 +739,9 @@ describe("relay logical Runtime subscriptions", () => {
       const f = fixture();
       const client = f.client();
       const root = await client.attach();
-      await f.client().attach();
+      const peer = f.client();
+      const peerRoot = await peer.attach();
+      await peer.request("Runtime.enable", peerRoot);
       expect(
         (await client.request("Runtime.addBinding", root, { name: "relayBinding" })).error,
       ).toBeUndefined();
@@ -754,12 +756,157 @@ describe("relay logical Runtime subscriptions", () => {
         method: "Runtime.bindingCalled",
         params,
       });
+      expect(
+        peer.socket.frames().filter((frame) => frame.method === "Runtime.bindingCalled"),
+      ).toEqual([]);
       await client.request("Target.detachFromTarget", undefined, { sessionId: root });
       const before = client.socket.frames().length;
       f.event("Runtime.bindingCalled", params);
       expect(client.socket.frames()).toHaveLength(before);
     },
   );
+
+  it.each(["Runtime.removeBinding", "Target.detachFromTarget", "socket close"])(
+    "preserves a peer's same-name binding after %s and removes the final native registration",
+    async (operation) => {
+      const f = fixture();
+      const first = f.client();
+      const firstRoot = await first.attach();
+      const second = f.client();
+      const secondRoot = await second.attach();
+      const observer = f.client();
+      const observerRoot = await observer.attach();
+      const name = "sharedBinding";
+      for (const [client, root] of [
+        [first, firstRoot],
+        [second, secondRoot],
+      ] as const) {
+        expect((await client.request("Runtime.addBinding", root, { name })).error).toBeUndefined();
+      }
+      await observer.request("Runtime.removeBinding", observerRoot, { name });
+      expect(f.commands("Runtime.removeBinding")).toHaveLength(0);
+      if (operation === "socket close") {
+        first.handlers.onClose();
+        await flush();
+      } else if (operation === "Target.detachFromTarget") {
+        await first.request(operation, undefined, { sessionId: firstRoot });
+      } else {
+        await first.request(operation, firstRoot, { name });
+      }
+      expect(f.commands("Runtime.removeBinding")).toHaveLength(0);
+      const params = { name, payload: "still-owned", executionContextId: 1 };
+      f.event("Runtime.bindingCalled", params);
+      expect(
+        first.socket.frames().filter((frame) => frame.method === "Runtime.bindingCalled"),
+      ).toEqual([]);
+      expect(
+        observer.socket.frames().filter((frame) => frame.method === "Runtime.bindingCalled"),
+      ).toEqual([]);
+      expect(
+        second.socket.frames().filter((frame) => frame.method === "Runtime.bindingCalled"),
+      ).toEqual([{ sessionId: secondRoot, method: "Runtime.bindingCalled", params }]);
+      await second.request("Runtime.removeBinding", secondRoot, { name });
+      expect(f.commands("Runtime.removeBinding").map((frame) => frame.params)).toEqual([{ name }]);
+      f.event("Runtime.bindingCalled", params);
+      expect(
+        second.socket.frames().filter((frame) => frame.method === "Runtime.bindingCalled"),
+      ).toHaveLength(1);
+    },
+  );
+
+  it.each([false, true])(
+    "cleans up a native add admitted after logical close (peer owns same name=%s)",
+    async (sameName) => {
+      const f = fixture();
+      const first = f.client();
+      const firstRoot = await first.attach();
+      const second = f.client();
+      const secondRoot = await second.attach();
+      const name = "pendingBinding";
+      if (sameName) {
+        await second.request("Runtime.addBinding", secondRoot, { name });
+      }
+      f.hold("Runtime.addBinding");
+      const pending = first.send("Runtime.addBinding", firstRoot, { name });
+      await flush();
+      first.handlers.onClose();
+      f.release();
+      await flush();
+      expect(first.socket.frames().find((frame) => frame.id === pending)).toBeUndefined();
+      expect(f.commands("Runtime.removeBinding")).toHaveLength(sameName ? 0 : 1);
+      const params = { name, payload: "after-close", executionContextId: 1 };
+      f.event("Runtime.bindingCalled", params);
+      expect(
+        first.socket.frames().filter((frame) => frame.method === "Runtime.bindingCalled"),
+      ).toEqual([]);
+      expect(
+        second.socket.frames().filter((frame) => frame.method === "Runtime.bindingCalled"),
+      ).toHaveLength(sameName ? 1 : 0);
+    },
+  );
+
+  it.each(["Runtime.addBinding", "Runtime.removeBinding"])(
+    "preserves acknowledged binding ownership when native %s fails",
+    async (method) => {
+      const f = fixture();
+      const client = f.client();
+      const root = await client.attach();
+      const name = "failedBinding";
+      if (method === "Runtime.removeBinding") {
+        await client.request("Runtime.addBinding", root, { name });
+      }
+      f.hold(method);
+      const pending = client.send(method, root, { name });
+      await flush();
+      f.extension.handlers.onMessage(
+        JSON.stringify({
+          type: "error",
+          seq: f.commands(method).at(-1)!.seq,
+          message: "native binding command failed",
+        }),
+      );
+      await flush();
+      expect(client.socket.frames().find((frame) => frame.id === pending)?.error).toBeDefined();
+      f.release();
+      f.event("Runtime.bindingCalled", { name, payload: "failure", executionContextId: 1 });
+      expect(
+        client.socket.frames().filter((frame) => frame.method === "Runtime.bindingCalled"),
+      ).toHaveLength(method === "Runtime.removeBinding" ? 1 : 0);
+      expect((await client.request(method, root, { name })).error).toBeUndefined();
+      f.event("Runtime.bindingCalled", { name, payload: "retry", executionContextId: 1 });
+      expect(
+        client.socket.frames().filter((frame) => frame.method === "Runtime.bindingCalled"),
+      ).toHaveLength(1);
+    },
+  );
+
+  it("keeps a replacement physical session independent of pending retired bindings", async () => {
+    const f = fixture();
+    const client = f.client();
+    const root = await client.attach();
+    const name = "retiredBinding";
+    f.hold("Runtime.addBinding");
+    client.send("Runtime.addBinding", root, { name });
+    await flush();
+    f.extension.handlers.onMessage(
+      JSON.stringify({ type: "detached", tabId: 1, reason: "revoked" }),
+    );
+    f.release();
+    await flush();
+    const next = await client.attach();
+    expect(next).not.toBe(root);
+    const params = { name, payload: "replacement", executionContextId: 11 };
+    f.event("Runtime.bindingCalled", params);
+    expect(
+      client.socket.frames().filter((frame) => frame.method === "Runtime.bindingCalled"),
+    ).toEqual([]);
+    await client.request("Runtime.addBinding", next, { name });
+    f.event("Runtime.bindingCalled", params);
+    expect(
+      client.socket.frames().filter((frame) => frame.method === "Runtime.bindingCalled"),
+    ).toEqual([{ sessionId: next, method: "Runtime.bindingCalled", params }]);
+    expect(f.commands("Runtime.removeBinding")).toHaveLength(0);
+  });
 
   it("keeps a concurrent admission alive when another enable for the same logical owner fails", async () => {
     const f = fixture();

--- a/extensions/browser/src/browser/extension-relay/relay-runtime.ts
+++ b/extensions/browser/src/browser/extension-relay/relay-runtime.ts
@@ -6,12 +6,108 @@ type Subscription = {
   delivered?: Set<number>;
 };
 
+type BindingOwner = {
+  send: Subscription["send"];
+  names: Set<string>;
+  retired: boolean;
+};
+
 /** One physical Runtime, subscribed by the same exact logical owners as Fetch. */
 export class RelayRuntime {
   private readonly contexts = new Map<number, unknown>();
   private readonly subscribers = new Map<object, Subscription>();
+  // Context selectors still share the native Runtime; callback ownership is by
+  // registered name and does not depend on Runtime.enable subscriptions.
+  private readonly bindings = new Map<object, BindingOwner>();
+  private bindingQueue: Promise<unknown> = Promise.resolve();
 
-  constructor(private readonly active: AbortSignal) {}
+  constructor(
+    private readonly active: AbortSignal,
+    private readonly sendBinding: (
+      method: string,
+      params: Record<string, unknown>,
+    ) => Promise<unknown>,
+  ) {}
+
+  binding(
+    owner: object,
+    send: Subscription["send"],
+    method: "Runtime.addBinding" | "Runtime.removeBinding",
+    params: Record<string, unknown> | undefined,
+  ): Promise<unknown> {
+    if (!params || typeof params.name !== "string") {
+      return Promise.reject(new Error("Binding name must be a string"));
+    }
+    const name = params.name;
+    let state = this.bindings.get(owner);
+    if (!state) {
+      state = { send, names: new Set(), retired: false };
+      this.bindings.set(owner, state);
+    }
+    const binding = state;
+    return this.enqueueBinding(async () => {
+      if (binding.retired) {
+        throw new Error("Runtime session detached");
+      }
+      if (method === "Runtime.removeBinding") {
+        return this.removeBinding(binding, name);
+      }
+      const result = await this.sendBinding(method, params);
+      this.active.throwIfAborted();
+      // A successful native add must remain owned until queued detach cleanup,
+      // even when the logical session closes while worker admission awaits.
+      binding.names.add(name);
+      if (binding.retired) {
+        throw new Error("Runtime session detached");
+      }
+      return result;
+    });
+  }
+
+  private enqueueBinding<T>(operation: () => Promise<T>): Promise<T> {
+    const result = this.bindingQueue.then(() => {
+      this.active.throwIfAborted();
+      return operation();
+    });
+    this.bindingQueue = result.catch(() => {});
+    return result;
+  }
+
+  private async removeBinding(binding: BindingOwner, name: string): Promise<unknown> {
+    if (!binding.names.has(name)) {
+      return {};
+    }
+    let result: unknown = {};
+    // Native removal affects every logical session on the physical debugger.
+    // Retired peers still own their native registrations until their cleanup runs.
+    if (![...this.bindings.values()].some((peer) => peer !== binding && peer.names.has(name))) {
+      result = await this.sendBinding("Runtime.removeBinding", { name });
+      this.active.throwIfAborted();
+    }
+    binding.names.delete(name);
+    return result;
+  }
+
+  retire(owner: object): void {
+    this.disable(owner);
+    const binding = this.bindings.get(owner);
+    if (binding) {
+      binding.retired = true;
+    }
+  }
+
+  close(owner: object): Promise<void> {
+    const binding = this.bindings.get(owner);
+    if (!binding) {
+      return Promise.resolve();
+    }
+    return this.enqueueBinding(async () => {
+      for (const name of binding.names) {
+        await this.removeBinding(binding, name);
+      }
+      this.bindings.delete(owner);
+    });
+  }
 
   async enable(
     owner: object,
@@ -63,6 +159,17 @@ export class RelayRuntime {
     if (this.active.aborted) {
       return;
     }
+    if (method === "Runtime.bindingCalled") {
+      const name = asOptionalRecord(params)?.name;
+      if (typeof name === "string") {
+        for (const binding of this.bindings.values()) {
+          if (!binding.retired && binding.names.has(name)) {
+            binding.send(method, params);
+          }
+        }
+      }
+      return;
+    }
     const createdId = asOptionalRecord(asOptionalRecord(params)?.context)?.id;
     const destroyedId = asOptionalRecord(params)?.executionContextId;
     if (method === "Runtime.executionContextCreated" && typeof createdId === "number") {
@@ -92,5 +199,6 @@ export class RelayRuntime {
   dispose(): void {
     this.contexts.clear();
     this.subscribers.clear();
+    this.bindings.clear();
   }
 }

--- a/extensions/browser/src/browser/extension-relay/relay-session-owner.ts
+++ b/extensions/browser/src/browser/extension-relay/relay-session-owner.ts
@@ -44,7 +44,7 @@ export type RelaySessionClient = {
 
 // Cleanup must not wait for a hung body read/evaluation. After one second the
 // native owner detaches even if cleanup is incomplete; detach can resume unseen requests.
-const FETCH_RETIREMENT_MS = 1_000;
+const SESSION_RETIREMENT_MS = 1_000;
 
 /** Owns physical debugger lifetimes and their per-connection logical sessions. */
 export class RelaySessionOwner {
@@ -77,7 +77,9 @@ export class RelaySessionOwner {
     const physical: PhysicalSession = {
       ...scope,
       id: scope.childSessionId ?? scope.rootSessionId,
-      runtime: new RelayRuntime(active.signal),
+      runtime: new RelayRuntime(active.signal, (method, params) =>
+        this.send(physical, method, params),
+      ),
       target: new RelayTarget(
         (params) => this.send(physical, "Target.setAutoAttach", params, "target"),
         () => this.reconcileChildren(physical),
@@ -296,7 +298,7 @@ export class RelaySessionOwner {
     if (!session) {
       return [];
     }
-    session.physical.runtime.disable(session);
+    session.physical.runtime.retire(session);
     client.sessions.delete(sessionId);
     session.physical.subscribers.delete(session);
     session.parent?.children.delete(session.physical);
@@ -356,11 +358,11 @@ export class RelaySessionOwner {
           await Promise.all([
             targetCleanup,
             Promise.race([
-              physical.fetch.close(session),
+              Promise.all([physical.fetch.close(session), physical.runtime.close(session)]),
               new Promise<never>((_resolve, reject) => {
                 timer = setTimeout(
-                  () => reject(new Error("Fetch owner cleanup timed out")),
-                  FETCH_RETIREMENT_MS,
+                  () => reject(new Error("Session owner cleanup timed out")),
+                  SESSION_RETIREMENT_MS,
                 );
                 timer.unref?.();
               }),
@@ -419,7 +421,9 @@ export class RelaySessionOwner {
     if (physical.retiring) {
       return physical.retiring;
     }
-    const preparations = scopes.map((scope) => scope.fetch.prepareRetirement(FETCH_RETIREMENT_MS));
+    const preparations = scopes.map((scope) =>
+      scope.fetch.prepareRetirement(SESSION_RETIREMENT_MS),
+    );
     return (physical.retiring = (async () => {
       try {
         const results = await Promise.all(preparations);
@@ -471,9 +475,7 @@ export class RelaySessionOwner {
     if (physical.fetch.event(method, params)) {
       return;
     }
-    // V8 binding callbacks depend on add/removeBinding, not Runtime.enable.
-    // Preserve their native forwarding independently of Runtime subscriptions.
-    if (method.startsWith("Runtime.") && method !== "Runtime.bindingCalled") {
+    if (method.startsWith("Runtime.")) {
       physical.runtime.event(method, params);
       return;
     }

--- a/ui/src/lib/clipboard.test.ts
+++ b/ui/src/lib/clipboard.test.ts
@@ -85,24 +85,55 @@ describe("copyToClipboard", () => {
     expect(document.querySelector("textarea")).toBeNull();
   });
 
-  it("restores focus after the execCommand fallback", async () => {
+  it("keeps deferred focus restoration bound to its document after globals retire", async () => {
     vi.stubGlobal("navigator", {});
-    mockExecCommand(true);
-    const button = document.createElement("button");
-    document.body.append(button);
-    button.focus();
-    const focus = vi.spyOn(button, "focus");
-    button.disabled = true;
-
-    expect(await copyToClipboard("hello")).toBe(true);
-    button.disabled = false;
-    button.blur();
-    await new Promise<void>((resolve) => {
-      window.setTimeout(resolve, 0);
-    });
-    expect(document.activeElement).toBe(button);
-    expect(focus).toHaveBeenCalledWith({ preventScroll: true });
-
-    button.remove();
+    mockExecCommand(false);
+    vi.useFakeTimers();
+    try {
+      expect(await copyToClipboard("hello")).toBe(false);
+      expect(vi.getTimerCount()).toBeGreaterThan(0);
+      vi.stubGlobal("document", undefined);
+      expect(() => vi.runAllTimers()).not.toThrow();
+    } finally {
+      vi.unstubAllGlobals();
+      vi.useRealTimers();
+    }
   });
+
+  it.each(["restore", "newer focus", "removed target"] as const)(
+    "restores focus only when still appropriate after the fallback: %s",
+    async (state) => {
+      vi.stubGlobal("navigator", {});
+      mockExecCommand(true);
+      const button = document.createElement("button");
+      const input = document.createElement("input");
+      document.body.append(button);
+      button.focus();
+      const focus = vi.spyOn(button, "focus");
+      button.disabled = true;
+
+      expect(await copyToClipboard("hello")).toBe(true);
+      button.disabled = false;
+      button.blur();
+      if (state === "newer focus") {
+        document.body.append(input);
+        input.focus();
+      } else if (state === "removed target") {
+        button.remove();
+      }
+      await new Promise<void>((resolve) => {
+        window.setTimeout(resolve, 0);
+      });
+      if (state === "restore") {
+        expect(document.activeElement).toBe(button);
+        expect(focus).toHaveBeenCalledWith({ preventScroll: true });
+      } else {
+        expect(document.activeElement).toBe(state === "newer focus" ? input : document.body);
+        expect(focus).not.toHaveBeenCalled();
+      }
+
+      button.remove();
+      input.remove();
+    },
+  );
 });

--- a/ui/src/lib/clipboard.ts
+++ b/ui/src/lib/clipboard.ts
@@ -46,9 +46,11 @@ function copyWithExecCommand(text: string): boolean {
   } finally {
     document.body.removeChild(textarea);
     if (previouslyFocused?.isConnected) {
+      // Deferred focus must retain its document after that environment's globals retire.
+      const ownerDocument = textarea.ownerDocument;
       window.setTimeout(() => {
-        const activeElement = document.activeElement;
-        if (previouslyFocused.isConnected && (!activeElement || activeElement === document.body)) {
+        const { activeElement, body } = ownerDocument;
+        if (previouslyFocused.isConnected && (!activeElement || activeElement === body)) {
           previouslyFocused.focus({ preventScroll: true });
         }
       }, 0);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where clients sharing the browser extension relay receive Runtime binding callbacks they never registered. Raw callback payloads can reach an unrelated Playwright client, and removing a binding from one client can disable another client's registration.

## Why This Change Was Made

The relay's Runtime owner now tracks binding names for each logical CDP session. Native add/remove operations are serialized; ownership is recorded only after successful registration. Removing a binding preserves registrations used by peers. Closing a client immediately stops callback delivery, then removes its native registrations after any in-flight add completes. Physical debugger retirement fences queued work, and cleanup shares the existing bounded session-retirement path with Fetch.

Binding callbacks remain independent of Runtime.enable and Runtime.disable. The old broad callback forwarding path is removed. No payload rewriting, new settings, retries, or longer timeouts are introduced.

Provenance: the broad binding callback exception was introduced in #132504 (2a6fc9b92f89), authored and merged by @steipete on 2026-08-29. The direct native-observer regression identifies the failing dispatch boundary.

## User Impact

OpenClaw and external CDP clients can share the extension relay without receiving callbacks for unregistered binding names or removing a peer's same-name binding. This does not provide complete per-client CDP isolation: registrations using the same binding name with different execution-context selectors still share the underlying native Runtime. That existing limit is documented explicitly.

## Evidence

The existing real Chromium bootstrap flow now includes an unregistered, Runtime-enabled CDP observer. Before the fix, the observer receives both literal before-enable and after-disable payloads and fails the empty-observer assertion. After the fix, the registered client still receives both payloads and the observer receives neither. The actual Chrome extension, Gateway relay, Playwright, native bootstrap, reconnect, tab creation, and revocation checks all pass: 41 tests across the Runtime regression file and full Chromium flow, with no unhandled errors.

The logical-session regression file exposed nine failures before the repair, covering foreign callback delivery, peer removal, failed registration/removal, pending adds during close, and physical-session replacement. Runtime/Target/Fetch sibling coverage passed all 80 tests after the fix.

Production LOC: +124/-12 (net +112). Tests/support: +166/-9. Documentation/changelog: +8/-0. The added runtime state represents independently owned binding registrations, serialized native mutations, and cleanup across pending admission; enable subscriptions cannot own it because bindings survive Runtime.disable.

A local canonical QA-runtime build created the native-host artifact used by the browser proof but failed separate plugin control-plane checks against stale shared workspace AI exports. This is not a claim of a green full build. Exact-head hosted CI remains required before landing. Independent Codex P0–P2 review passed with no actionable findings. The full changed-file gate passed, including extension production/test type checks, lint, all three dead-code scans, and the runtime import-cycle guard.


## Clipboard teardown integration

This PR also incorporates the exact reviewed fix from #132803. Fresh hosted CI on the Browser-only head passed 4,094 UI tests but failed afterward when a deferred clipboard focus callback read the retired global document. Conversely, the clipboard branch needed the Browser repair for its own full CI. Combining the two proven fixes breaks that integration dependency without skipping either gate; #132803 will be closed as superseded only after this PR is verified on main.

The clipboard helper captures the textarea's owning document before scheduling focus restoration. It preserves the existing connected-target and newer-focus checks, timing, and copy feedback. Actual installed Vitest teardown reproduces the original ReferenceError and passes with the fix; 21 focused owner/caller tests and three bundled Chromium copy flows passed, as did its full changed gate. The two clipboard source/test blobs are byte-identical to e569965ea1194657ad0088bf82648ea2c8501251. Fresh combined P0–P2 review passed with no actionable findings, and the combined owner/caller run passed all 101 tests (21 UI and 80 Browser siblings).

Clipboard production delta: +4/-2 (net +2); tests: +49/-18. Combined production delta: +128/-14 (net +114); tests: +215/-27. No configuration, schema, protocol or ownership-policy change is needed. The repository's existing linear-history and exact-head CI requirements remain intact.
