### PR TITLE
fix: git updates fail while restarted gateway is starting

### DIFF
--- a/src/cli/daemon-cli/restart-health-probe.ts
+++ b/src/cli/daemon-cli/restart-health-probe.ts
@@ -26,7 +26,7 @@ export type GatewayRestartProbeAuth = {
 export type GatewayReachability = {
   reachable: boolean;
   gatewayVersion: string | null;
-  gatewayBuildId: string | null;
+  gatewayBuildId: string | null | undefined;
   activatedPluginErrors: PluginHealthErrorSummary[];
   channelProbeErrors: Array<{ id: string; error: string }>;
   probeError?: string;
@@ -184,7 +184,11 @@ export async function confirmGatewayReachable(params: {
     return {
       reachable: reachedGateway,
       gatewayVersion: probe.server?.version ?? null,
-      gatewayBuildId: probe.server?.buildId ?? null,
+      gatewayBuildId:
+        probe.server?.buildId ??
+        (reachedGateway || probe.server?.version != null || probe.server?.connId != null
+          ? null
+          : undefined),
       activatedPluginErrors: readActivatedPluginErrors(probe.health),
       channelProbeErrors: readChannelProbeErrors(probe.health),
       ...(!reachedGateway && probe.error
@@ -195,7 +199,7 @@ export async function confirmGatewayReachable(params: {
     return {
       reachable: false,
       gatewayVersion: null,
-      gatewayBuildId: null,
+      gatewayBuildId: undefined,
       activatedPluginErrors: [],
       channelProbeErrors: [],
       probeError: formatGatewayRestartProbeError(error),

--- a/src/cli/daemon-cli/restart-health-wait.test.ts
+++ b/src/cli/daemon-cli/restart-health-wait.test.ts
@@ -364,6 +364,131 @@ describe("restart health", () => {
     expect(sleep).toHaveBeenCalledTimes(1);
   });
 
+  it("keeps waiting when the expected gateway build identity is not available yet", async () => {
+    const service = makeGatewayService({ status: "running", pid: 8000 });
+    inspectPortUsage
+      .mockResolvedValueOnce({
+        port: 18789,
+        status: "free",
+        listeners: [],
+        hints: [],
+      })
+      .mockResolvedValueOnce({
+        port: 18789,
+        status: "busy",
+        listeners: [{ pid: 8000, commandLine: "openclaw-gateway" }],
+        hints: [],
+      });
+    probeGateway.mockResolvedValue({
+      ok: true,
+      close: null,
+      server: { version: "2026.4.26", buildId: "new-build", connId: "new" },
+    });
+
+    const { waitForGatewayHealthyRestart } = await import("./restart-health.js");
+    const snapshot = await waitForGatewayHealthyRestart({
+      service,
+      port: 18789,
+      expectedBuildId: "new-build",
+      attempts: 4,
+      delayMs: 1_000,
+    });
+
+    expect(snapshot.healthy).toBe(true);
+    expect(snapshot.gatewayBuildId).toBe("new-build");
+    expect(snapshot.expectedBuildId).toBe("new-build");
+    expect(snapshot.waitOutcome).toBe("healthy");
+    expect(snapshot.buildIdMismatch).toBeUndefined();
+    expect(sleep).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps waiting when the gateway probe cannot report build identity yet", async () => {
+    const service = makeGatewayService({ status: "running", pid: 8000 });
+    inspectPortUsage.mockResolvedValue({
+      port: 18789,
+      status: "busy",
+      listeners: [{ pid: 8000, commandLine: "openclaw-gateway" }],
+      hints: [],
+    });
+    probeGateway
+      .mockResolvedValueOnce({ ok: false, close: null, error: "connect ECONNREFUSED" })
+      .mockResolvedValueOnce({
+        ok: true,
+        close: null,
+        server: { version: "2026.4.26", buildId: "new-build", connId: "new" },
+      });
+
+    const { waitForGatewayHealthyRestart } = await import("./restart-health.js");
+    const snapshot = await waitForGatewayHealthyRestart({
+      service,
+      port: 18789,
+      expectedBuildId: "new-build",
+      attempts: 4,
+      delayMs: 1_000,
+    });
+
+    expect(snapshot.healthy).toBe(true);
+    expect(snapshot.gatewayBuildId).toBe("new-build");
+    expect(snapshot.waitOutcome).toBe("healthy");
+    expect(snapshot.buildIdMismatch).toBeUndefined();
+    expect(sleep).toHaveBeenCalledTimes(1);
+  });
+
+  it("fails closed when build identity remains unavailable through the wait deadline", async () => {
+    const service = makeGatewayService({ status: "running", pid: 8000 });
+    inspectPortUsage.mockResolvedValue({
+      port: 18789,
+      status: "free",
+      listeners: [],
+      hints: [],
+    });
+
+    const { waitForGatewayHealthyRestart } = await import("./restart-health.js");
+    const snapshot = await waitForGatewayHealthyRestart({
+      service,
+      port: 18789,
+      expectedBuildId: "new-build",
+      attempts: 4,
+      delayMs: 1_000,
+    });
+
+    expect(snapshot.healthy).toBe(false);
+    expect(snapshot.waitOutcome).toBe("timeout");
+    expect(snapshot.elapsedMs).toBe(4_000);
+    expect(snapshot.buildIdMismatch).toEqual({ expected: "new-build", actual: null });
+    expect(sleep).toHaveBeenCalledTimes(4);
+  });
+
+  it("fails immediately when a reachable gateway omits build identity", async () => {
+    const service = makeGatewayService({ status: "running", pid: 8000 });
+    inspectPortUsage.mockResolvedValue({
+      port: 18789,
+      status: "busy",
+      listeners: [{ pid: 8000, commandLine: "openclaw-gateway" }],
+      hints: [],
+    });
+    probeGateway.mockResolvedValue({
+      ok: true,
+      close: null,
+      server: { version: "2026.4.26", connId: "legacy" },
+    });
+
+    const { waitForGatewayHealthyRestart } = await import("./restart-health.js");
+    const snapshot = await waitForGatewayHealthyRestart({
+      service,
+      port: 18789,
+      expectedBuildId: "new-build",
+      attempts: 4,
+      delayMs: 1_000,
+    });
+
+    expect(snapshot.healthy).toBe(false);
+    expect(snapshot.waitOutcome).toBe("build-id-mismatch");
+    expect(snapshot.elapsedMs).toBe(0);
+    expect(snapshot.buildIdMismatch).toEqual({ expected: "new-build", actual: null });
+    expect(sleep).not.toHaveBeenCalled();
+  });
+
   it("annotates timeout waits when the health loop exhausts all attempts", async () => {
     const service = makeGatewayService({ status: "running", pid: 8000 });
     inspectPortUsage.mockResolvedValue({

--- a/src/cli/daemon-cli/restart-health-wait.test.ts
+++ b/src/cli/daemon-cli/restart-health-wait.test.ts
@@ -455,7 +455,7 @@ describe("restart health", () => {
     expect(snapshot.healthy).toBe(false);
     expect(snapshot.waitOutcome).toBe("timeout");
     expect(snapshot.elapsedMs).toBe(4_000);
-    expect(snapshot.buildIdMismatch).toEqual({ expected: "new-build", actual: null });
+    expect(snapshot.buildIdMismatch).toBeUndefined();
     expect(sleep).toHaveBeenCalledTimes(4);
   });
 

--- a/src/cli/daemon-cli/restart-health.ts
+++ b/src/cli/daemon-cli/restart-health.ts
@@ -314,26 +314,7 @@ function withWaitContext(
   waitOutcome: GatewayRestartWaitOutcome,
   elapsedMs: number,
 ): GatewayRestartSnapshot {
-  const settledSnapshot = waitOutcome === "healthy" ? snapshot : settleUnprovenBuildId(snapshot);
-  return { ...settledSnapshot, waitOutcome, elapsedMs };
-}
-
-function settleUnprovenBuildId(snapshot: GatewayRestartSnapshot): GatewayRestartSnapshot {
-  if (
-    !snapshot.expectedBuildId ||
-    snapshot.buildIdMismatch ||
-    snapshot.gatewayBuildId === snapshot.expectedBuildId
-  ) {
-    return snapshot;
-  }
-  return {
-    ...snapshot,
-    healthy: false,
-    buildIdMismatch: {
-      expected: snapshot.expectedBuildId,
-      actual: snapshot.gatewayBuildId ?? null,
-    },
-  };
+  return { ...snapshot, waitOutcome, elapsedMs };
 }
 
 export async function waitForGatewayHealthyRestart(params: {

--- a/src/cli/daemon-cli/restart-health.ts
+++ b/src/cli/daemon-cli/restart-health.ts
@@ -80,6 +80,9 @@ function applyExpectedBuildId(
   if (snapshot.gatewayBuildId === expectedBuildId) {
     return { ...snapshot, expectedBuildId };
   }
+  if (snapshot.gatewayBuildId === undefined) {
+    return { ...snapshot, healthy: false, expectedBuildId };
+  }
   return {
     ...snapshot,
     healthy: false,
@@ -311,7 +314,26 @@ function withWaitContext(
   waitOutcome: GatewayRestartWaitOutcome,
   elapsedMs: number,
 ): GatewayRestartSnapshot {
-  return { ...snapshot, waitOutcome, elapsedMs };
+  const settledSnapshot = waitOutcome === "healthy" ? snapshot : settleUnprovenBuildId(snapshot);
+  return { ...settledSnapshot, waitOutcome, elapsedMs };
+}
+
+function settleUnprovenBuildId(snapshot: GatewayRestartSnapshot): GatewayRestartSnapshot {
+  if (
+    !snapshot.expectedBuildId ||
+    snapshot.buildIdMismatch ||
+    snapshot.gatewayBuildId === snapshot.expectedBuildId
+  ) {
+    return snapshot;
+  }
+  return {
+    ...snapshot,
+    healthy: false,
+    buildIdMismatch: {
+      expected: snapshot.expectedBuildId,
+      actual: snapshot.gatewayBuildId ?? null,
+    },
+  };
 }
 
 export async function waitForGatewayHealthyRestart(params: {

--- a/src/cli/update-cli/update-command-service.test.ts
+++ b/src/cli/update-cli/update-command-service.test.ts
@@ -93,6 +93,44 @@ describe("maybeRestartService", () => {
     );
   });
 
+  it("rejects a Git restart when the expected build is never observed", async () => {
+    mocks.waitForGatewayHealthyRestart.mockResolvedValue({
+      runtime: { status: "stopped" },
+      portUsage: {
+        port: 18789,
+        status: "free",
+        listeners: [],
+        hints: [],
+      },
+      healthy: false,
+      staleGatewayPids: [],
+      expectedBuildId: "new-build",
+      waitOutcome: "timeout",
+    });
+
+    await expect(
+      maybeRestartService({
+        shouldRestart: true,
+        result: {
+          status: "ok",
+          mode: "git",
+          root: "/tmp/openclaw-configured-ui-update",
+          after: { buildId: "new-build" },
+          steps: [],
+          durationMs: 0,
+        },
+        channel: "dev",
+        opts: { json: true },
+        refreshServiceEnv: false,
+        serviceEnv: { HOME: "/home/operator" },
+        serviceInstallEnv: {},
+        gatewayPort: 18789,
+        restartScriptPath: "/tmp/openclaw-configured-ui-restart.sh",
+        timeoutMs: 1_000,
+      }),
+    ).resolves.toBe(false);
+  });
+
   it.each(["stable", "beta"] as const)(
     "does not enforce Git build identity for the %s channel",
     async (channel) => {

--- a/src/cli/update-cli/update-command-service.ts
+++ b/src/cli/update-cli/update-command-service.ts
@@ -1220,7 +1220,7 @@ export async function maybeRestartService(params: {
       }
     }
 
-    if (requiresVerifiedRestart() || opts.requireRunningService) {
+    if (requiresVerifiedRestart() || opts.requireRunningService || expectedGatewayBuildId) {
       return false;
     }
 


### PR DESCRIPTION
Closes #132864

## What Problem This Solves

Restart-enabled Git updates could report an immediate stale-build failure while the detached replacement Gateway was still starting. This violated the updater contract: it must verify the restarted Gateway before reporting success, and it must not reject a normal pending restart as stale.

## Root cause

The restart probe converted both states to `null`:

- no Gateway identity had been observed yet;
- a reachable Gateway omitted build metadata.

The expected-build check treated that shared value as a terminal mismatch. The bounded restart loop therefore stopped before the detached replacement could become observable.

## Fix

- Keep unobserved build identity as `undefined` so the existing bounded restart wait continues.
- Keep observed missing metadata as `null` so a reachable unverifiable Gateway still fails immediately.
- Keep timeout as timeout instead of inventing a build-mismatch fact.
- Make the updater reject any non-healthy dev-Git restart when an expected build ID remains unproven.

## Evidence

### Tests

- Focused restart-health and updater tests: 142 passed.
- The new updater regression failed before the final decision repair because the timeout returned `true`.
- Targeted format, lint, conflict-marker, max-lines, assertion-safety, and diff checks passed.

### Live proof

Used one isolated Linux systemd Gateway and one detached helper that started it after two seconds.

- Exact main `b30cef73edae8daec41c0ba36bfbe24f02701325` rejected the restart in 574 ms, before the replacement was observable.
- Original PR head `480b070dae49d17bc9f1e4e22411d2404456fffb` waited and verified the matching replacement.
- Final head `322d39e33a11606505c7022281ea6309324ef45c` waited 6.16 seconds and returned verified success.
- An independent deep status check reported the service running, RPC healthy, and the exact expected build ID.

Stale builds, reachable Gateways without build metadata, and replacements that never become observable still fail closed.
