### PR TITLE
test(codex): drop the duplicate channel-tool-progress lane entry

### DIFF
--- a/test/vitest/vitest.extension-codex-app-server-attempt-extra.config.ts
+++ b/test/vitest/vitest.extension-codex-app-server-attempt-extra.config.ts
@@ -7,7 +7,6 @@ export function createExtensionCodexAppServerAttemptExtraVitestConfig(
   return createScopedVitestConfig(
     [
       "extensions/codex/src/app-server/run-attempt.agent-end-context.test.ts",
-      "extensions/codex/src/app-server/run-attempt.channel-tool-progress.test.ts",
       "extensions/codex/src/app-server/run-attempt-lifecycle-controller.test.ts",
       "extensions/codex/src/app-server/run-attempt-thread-cleanup.test.ts",
       "extensions/codex/src/app-server/run-attempt.channel-tool-progress.test.ts",


### PR DESCRIPTION
## What Problem This Solves

The Codex app-server attempt-extra Vitest lane listed
`extensions/codex/src/app-server/run-attempt.channel-tool-progress.test.ts`
twice. #132664 landed that test file without registering it in any enumerated
lane, which red-lined the vitest project-ownership guard, and two independent
repairs then each added the registration: #132743 (contributor fix) and a
follow-on commit inside #132737. Both landed, so the array carried the entry
twice.

Nothing breaks today — the ownership guard asserts every full-suite file is
covered *at least* once per lane and dedupes includes — so this is wasted lane
config and a stumbling block for the next person editing the list, not a
failing gate.

## Why This Change Was Made

Deleted one of the two identical strings and kept the entry in its sorted slot.
Because `-` (0x2D) sorts before `.` (0x2E), `run-attempt-thread-cleanup.test.ts`
precedes `run-attempt.channel-tool-progress.test.ts`; the copy #132743 placed
between `-thread-cleanup` and `.configured-mcp` is therefore the ordered one,
while the later copy directly after `.agent-end-context` introduced a fresh
descending step. Removing the latter restores the exact file #132743 produced
(blob `169195386a6`) and adds no new ordering anomaly. Sibling shards
(`-light`, `-support`) are plainly ASCII-sorted, which is the convention being
matched here.

Out of scope: the pre-existing `.agent-end-context` -> `-lifecycle-controller`
step in this same array is still unsorted. It predates both duplicate commits
and is left alone rather than folded into a one-line cleanup.

## User Impact

None user-visible. Test-lane configuration only; no production code, no runtime
behavior, no test file added or removed.

## Evidence

Lane-ownership guard passes on the exact head:

```
node scripts/run-vitest.mjs test/vitest-projects-config.test.ts

 ✓ test/vitest-projects-config.test.ts (23 tests) 4.7s
   ✓ covers each normal full-suite test file exactly once after configs cached filtered includes 4648ms
 Test Files  1 passed (1)
      Tests  23 passed (23)
[test] passed 1 Vitest shard in 12.03s
```

Diff is a single deletion; production LOC +0/-0, tests/config +0/-1.

```
 test/vitest/vitest.extension-codex-app-server-attempt-extra.config.ts | 1 -
 1 file changed, 1 deletion(-)
```
