### PR TITLE
refactor(tasks): share status cell formatting

### DIFF
--- a/src/commands/flows.ts
+++ b/src/commands/flows.ts
@@ -17,7 +17,6 @@ import {
   isTerminalTaskFlow,
   TASK_FLOW_STATUSES,
   type TaskFlowRecord,
-  type TaskFlowStatus,
 } from "../tasks/task-flow-registry.types.js";
 import {
   getTaskFlowById,
@@ -29,9 +28,9 @@ import {
   formatTaskStatusDetail,
   isTaskStatusIssue,
 } from "../tasks/task-status.js";
+import { formatTaskStatusCell, TASK_STATUS_CELL_WIDTH } from "./task-status-cell.js";
 
 const ID_PAD = 10;
-const STATUS_PAD = 10;
 const MODE_PAD = 14;
 const REV_PAD = 6;
 const CTRL_PAD = 20;
@@ -72,31 +71,11 @@ function formatFlowTimestamp(value: number | undefined | null): string {
   return timestampMsToIsoString(value) ?? "n/a";
 }
 
-function formatFlowStatusCell(status: TaskFlowStatus, rich: boolean) {
-  const padded = status.padEnd(STATUS_PAD);
-  if (!rich) {
-    return padded;
-  }
-  if (status === "succeeded") {
-    return theme.success(padded);
-  }
-  if (status === "failed" || status === "lost") {
-    return theme.error(padded);
-  }
-  if (status === "running") {
-    return theme.accentBright(padded);
-  }
-  if (status === "blocked") {
-    return theme.warn(padded);
-  }
-  return theme.muted(padded);
-}
-
 function formatFlowRows(flows: TaskFlowRecord[], rich: boolean) {
   const header = [
     "TaskFlow".padEnd(ID_PAD),
     "Mode".padEnd(MODE_PAD),
-    "Status".padEnd(STATUS_PAD),
+    "Status".padEnd(TASK_STATUS_CELL_WIDTH),
     "Rev".padEnd(REV_PAD),
     "Controller".padEnd(CTRL_PAD),
     "Tasks".padEnd(14),
@@ -110,7 +89,7 @@ function formatFlowRows(flows: TaskFlowRecord[], rich: boolean) {
       [
         shortToken(flow.flowId).padEnd(ID_PAD),
         flow.syncMode.padEnd(MODE_PAD),
-        formatFlowStatusCell(flow.status, rich),
+        formatTaskStatusCell(flow.status, rich),
         String(flow.revision).padEnd(REV_PAD),
         formatFlowTableCell(flow.controllerId, CTRL_PAD),
         counts.padEnd(14),

--- a/src/commands/task-status-cell.test.ts
+++ b/src/commands/task-status-cell.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("../../packages/terminal-core/src/theme.js", () => ({
+  theme: {
+    success: (value: string) => `success(${value})`,
+    error: (value: string) => `error(${value})`,
+    accentBright: (value: string) => `accentBright(${value})`,
+    warn: (value: string) => `warn(${value})`,
+    muted: (value: string) => `muted(${value})`,
+  },
+}));
+
+import { formatTaskStatusCell, TASK_STATUS_CELL_WIDTH } from "./task-status-cell.js";
+
+describe("formatTaskStatusCell", () => {
+  it.each(["succeeded", "timed_out", "blocked", "future_status"])(
+    "pads plain %s status cells to the shared width",
+    (status) => {
+      expect(formatTaskStatusCell(status, false)).toBe(status.padEnd(TASK_STATUS_CELL_WIDTH));
+    },
+  );
+
+  it.each([
+    ["succeeded", "success"],
+    ["failed", "error"],
+    ["lost", "error"],
+    ["timed_out", "error"],
+    ["running", "accentBright"],
+    ["blocked", "warn"],
+    ["queued", "muted"],
+    ["future_status", "muted"],
+  ])("renders rich %s status cells with the %s theme", (status, marker) => {
+    expect(formatTaskStatusCell(status, true)).toBe(
+      `${marker}(${status.padEnd(TASK_STATUS_CELL_WIDTH)})`,
+    );
+  });
+});

--- a/src/commands/task-status-cell.ts
+++ b/src/commands/task-status-cell.ts
@@ -1,0 +1,23 @@
+import { theme } from "../../packages/terminal-core/src/theme.js";
+
+export const TASK_STATUS_CELL_WIDTH = 10;
+
+export function formatTaskStatusCell(status: string, rich: boolean): string {
+  const padded = status.padEnd(TASK_STATUS_CELL_WIDTH);
+  if (!rich) {
+    return padded;
+  }
+  if (status === "succeeded") {
+    return theme.success(padded);
+  }
+  if (status === "failed" || status === "lost" || status === "timed_out") {
+    return theme.error(padded);
+  }
+  if (status === "running") {
+    return theme.accentBright(padded);
+  }
+  if (status === "blocked") {
+    return theme.warn(padded);
+  }
+  return theme.muted(padded);
+}

--- a/src/commands/tasks.ts
+++ b/src/commands/tasks.ts
@@ -56,6 +56,7 @@ import {
   type TaskSystemAuditCode,
   type TaskSystemAuditSeverity,
 } from "../tasks/task-system-audit.types.js";
+import { formatTaskStatusCell, TASK_STATUS_CELL_WIDTH } from "./task-status-cell.js";
 import {
   buildTaskSystemAuditJsonPayload,
   buildTaskSystemAuditFindings,
@@ -64,7 +65,6 @@ import {
 import { runSessionRegistryMaintenance } from "./tasks-session-registry-maintenance.js";
 
 const RUNTIME_PAD = 8;
-const STATUS_PAD = 10;
 const DELIVERY_PAD = 14;
 const ID_PAD = 10;
 const RUN_PAD = 10;
@@ -149,31 +149,11 @@ function shortToken(value: string | undefined, maxChars = ID_PAD): string {
   return truncate(sanitized, maxChars);
 }
 
-function formatTaskStatusCell(status: string, rich: boolean) {
-  const padded = status.padEnd(STATUS_PAD);
-  if (!rich) {
-    return padded;
-  }
-  if (status === "succeeded") {
-    return theme.success(padded);
-  }
-  if (status === "failed" || status === "lost" || status === "timed_out") {
-    return theme.error(padded);
-  }
-  if (status === "running") {
-    return theme.accentBright(padded);
-  }
-  if (status === "blocked") {
-    return theme.warn(padded);
-  }
-  return theme.muted(padded);
-}
-
 function formatTaskRows(tasks: TaskRecord[], rich: boolean) {
   const header = [
     "Task".padEnd(ID_PAD),
     "Kind".padEnd(RUNTIME_PAD),
-    "Status".padEnd(STATUS_PAD),
+    "Status".padEnd(TASK_STATUS_CELL_WIDTH),
     "Delivery".padEnd(DELIVERY_PAD),
     "Run".padEnd(RUN_PAD),
     "Child Session",
@@ -232,7 +212,7 @@ function formatAuditRows(findings: TaskSystemAuditFinding[], rich: boolean) {
     "Severity".padEnd(8),
     "Code".padEnd(22),
     "Item".padEnd(ID_PAD),
-    "Status".padEnd(STATUS_PAD),
+    "Status".padEnd(TASK_STATUS_CELL_WIDTH),
     "Age".padEnd(8),
     "Detail",
   ].join(" ");


### PR DESCRIPTION
## What Problem This Solves

Task and TaskFlow tables maintained duplicate status-cell width and color policy, allowing the two command surfaces to drift.

## Why This Change Was Made

Move the shared status-cell contract into one command-owned formatter and use it from task list, task audit, and TaskFlow rows. The formatter preserves every existing status mapping and the 10-column layout.

## User Impact

No intended user-visible behavior change. Task status columns keep the same padding and rich-terminal colors while sharing one implementation.

## Evidence

- `node scripts/run-vitest.mjs src/commands/task-status-cell.test.ts src/commands/flows.test.ts src/commands/tasks.test.ts src/commands/tasks-json.test.ts` (74 passed)
- `pnpm tsgo:core`
- focused `oxlint`, `oxfmt --check`, and `git diff --check`
- Sol-high autoreview: no accepted/actionable findings
- production +29/-47 (net -18); tests +37
- exact-head CI: 121 successful, 0 failing/pending, including `openclaw/ci-gate`
- `OPENCLAW_TESTBOX=1 scripts/pr prepare-run 132882`

The local shared install's `pnpm tsgo:core:test` reached an unchanged `ui/vite.config.ts` TS7016 error for missing `pako` declarations. Exact-head hosted test-type lanes passed, confirming it was install-specific rather than patch-specific.
