### PR TITLE
test(cron): preserve Date-domain corruption fixtures

### DIFF
--- a/src/cron/service/store.test.ts
+++ b/src/cron/service/store.test.ts
@@ -240,15 +240,18 @@ describe("cron service store seam coverage", () => {
       ],
     });
     const db = openOpenClawStateDatabase().db;
+    // Number bindings become SQLite FLOATs; JSON formatting can round max + 1
+    // back into the valid Date domain. Inject exact numeric JSON instead.
+    const invalidTimestampJson = JSON.stringify(MAX_DATE_TIMESTAMP_MS + 1);
     db.prepare(
-      "UPDATE cron_jobs SET job_json = json_set(job_json, '$.schedule.everyMs', ?) WHERE job_id = ?",
-    ).run(MAX_DATE_TIMESTAMP_MS + 1, invalidInterval.id);
+      "UPDATE cron_jobs SET job_json = json_set(job_json, '$.schedule.everyMs', json(?)) WHERE job_id = ?",
+    ).run(invalidTimestampJson, invalidInterval.id);
     db.prepare(
-      "UPDATE cron_jobs SET job_json = json_set(job_json, '$.schedule.anchorMs', ?) WHERE job_id = ?",
-    ).run(MAX_DATE_TIMESTAMP_MS + 1, invalidAnchor.id);
+      "UPDATE cron_jobs SET job_json = json_set(job_json, '$.schedule.anchorMs', json(?)) WHERE job_id = ?",
+    ).run(invalidTimestampJson, invalidAnchor.id);
     db.prepare(
-      "UPDATE cron_jobs SET job_json = json_set(job_json, '$.schedule.staggerMs', ?) WHERE job_id = ?",
-    ).run(MAX_DATE_TIMESTAMP_MS + 1, invalidStagger.id);
+      "UPDATE cron_jobs SET job_json = json_set(job_json, '$.schedule.staggerMs', json(?)) WHERE job_id = ?",
+    ).run(invalidTimestampJson, invalidStagger.id);
     const state = createStoreTestState(storePath);
 
     await ensureLoaded(state, { skipRecompute: true });
@@ -261,11 +264,19 @@ describe("cron service store seam coverage", () => {
     expect(cronStoreModule.loadCronQuarantinedJobs(storePath)).toEqual([
       expect.objectContaining({
         sourceIndex: 0,
-        job: expect.objectContaining({ id: invalidInterval.id }),
+        reason: "invalid-schedule",
+        job: expect.objectContaining({
+          id: invalidInterval.id,
+          schedule: expect.objectContaining({ everyMs: MAX_DATE_TIMESTAMP_MS + 1 }),
+        }),
       }),
       expect.objectContaining({
         sourceIndex: 1,
-        job: expect.objectContaining({ id: invalidAnchor.id }),
+        reason: "invalid-schedule",
+        job: expect.objectContaining({
+          id: invalidAnchor.id,
+          schedule: expect.objectContaining({ anchorMs: MAX_DATE_TIMESTAMP_MS + 1 }),
+        }),
       }),
       expect.objectContaining({
         sourceIndex: 2,
@@ -274,7 +285,11 @@ describe("cron service store seam coverage", () => {
       }),
       expect.objectContaining({
         sourceIndex: 4,
-        job: expect.objectContaining({ id: invalidStagger.id }),
+        reason: "invalid-schedule",
+        job: expect.objectContaining({
+          id: invalidStagger.id,
+          schedule: expect.objectContaining({ staggerMs: MAX_DATE_TIMESTAMP_MS + 1 }),
+        }),
       }),
     ]);
   });
@@ -286,9 +301,9 @@ describe("cron service store seam coverage", () => {
     await saveCronStore(storePath, { version: 1, jobs: [invalidState, surviving] });
     openOpenClawStateDatabase()
       .db.prepare(
-        "UPDATE cron_jobs SET state_json = json_set(state_json, '$.lastRunAtMs', ?) WHERE job_id = ?",
+        "UPDATE cron_jobs SET state_json = json_set(state_json, '$.lastRunAtMs', json(?)) WHERE job_id = ?",
       )
-      .run(MAX_DATE_TIMESTAMP_MS + 1, invalidState.id);
+      .run(JSON.stringify(MAX_DATE_TIMESTAMP_MS + 1), invalidState.id);
     const state = createStoreTestState(storePath);
 
     await ensureLoaded(state, { skipRecompute: true });


### PR DESCRIPTION
Related: #130466 — schema v13 consolidation made cron job and runtime JSON canonical.

## What Problem This Solves

Resolves a problem where two cron Date-domain quarantine regression tests fail on supported Node 24.15.0 / SQLite 3.51.3 even though production Date-domain validation is correct. This is a maintainer-requested test-fixture repair, not a production scheduling or persistence change.

## Why This Change Was Made

The four corruption writes bound `8640000000000001` as a JavaScript Number. Node binds Numbers as SQLite FLOATs, and SQLite 3.51.3's JSON formatting emits `8.64e+15`, which is the valid inclusive Date maximum. The fixtures now pass `JSON.stringify(value)` through `json(?)`, preserving the exact JSON number rather than introducing either a rounded number or a JSON string. Existing quarantine readback assertions now also check the exact schedule values and rejection reasons; the runtime-state assertion already checks its exact numeric value.

Production already uses `JSON.stringify` for these JSON columns. No production guards, storage code, schemas, dependencies, configuration, deadlines, or expected survivor lists change. Production LOC: +0/-0. Tests: +26/-11 in one file.

## User Impact

No user-visible runtime change. Developers regain reliable regression coverage for quarantining genuinely out-of-range numeric schedules and runtime timestamps while retaining valid boundary values and disabled unsatisfiable schedules.

## Evidence

On Node 24.15.0 / SQLite 3.51.3, with private lifetime-owned HOME/USERPROFILE, state/config, temporary and provider directories, and a distinct native module cache:

- Before: both original selected tests failed; invalid anchor, stagger, and runtime-state records remained active.
- After: the same command passed both selected tests (22 unrelated cases filtered out).

```sh
node scripts/run-vitest.mjs src/cron/service/store.test.ts \
  -t 'quarantines persisted (every schedules|runtime timestamps)' --reporter=verbose
```

Full sibling proof passed **263 tests across eight files**, including all 24 cases in the repaired file, storage round-trips, invalid-job loading, normalization, schedule computation, stagger bounds, and the inclusive Date boundary. Test processes used `OPENCLAW_VITEST_MAX_WORKERS=1`; no cache-disable or timeout override was used.

```sh
node scripts/run-vitest.mjs \
  src/cron/service/store.test.ts src/cron/store.test.ts \
  src/cron/store/row-codec.schedule.test.ts \
  src/cron/service.store-load-invalid-main-job.test.ts \
  src/cron/normalize.test.ts src/cron/schedule.test.ts src/cron/stagger.test.ts \
  packages/normalization-core/src/number-coercion.test.ts --reporter=verbose
node scripts/check-changed.mjs --dry-run -- src/cron/service/store.test.ts
node scripts/check-changed.mjs -- src/cron/service/store.test.ts
git diff --check
```

The classified `coreTests` check gate passed, including all dead-export scans, core test typechecking, changed-file formatting/lint, and boundary guards. `git diff --check` passed.

The native in-memory dependency probe independently confirmed that Number binding rounds on SQLite 3.51.3, `json(?)` plus canonical serialization preserves the exact number, and plain string binding produces a different JSON type. Node 24.20.0 / SQLite 3.53.4 already preserves the Number, so the older supported runtime was used for the before/after proof rather than substituted silently. Upstream contracts inspected: [Node Number binding](https://github.com/nodejs/node/blob/v24.15.0/src/node_sqlite.cc#L2532-L2577) and [SQLite JSON scalar formatting](https://github.com/nodejs/node/blob/v24.15.0/deps/sqlite/sqlite3.c#L210928-L210954).

Fresh isolated Codex autoreview completed with no findings in its default P0 scope. AI-assisted; the fixture and production boundary were manually inspected. No live services or operator databases were used; this test-only change needs no application/UI rollout proof.
