### PR TITLE
fix: preserve cloud turns when follow-up input arrives

### DIFF
--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -20773,6 +20773,7 @@ public struct ChatHistoryParams: Codable, Sendable {
     public let cursor: String?
     public let limit: Int?
     public let offset: Int?
+    public let pendingbefore: Int?
     public let messageid: String?
     public let sessionid: String?
     public let maxchars: Int?
@@ -20783,6 +20784,7 @@ public struct ChatHistoryParams: Codable, Sendable {
         cursor: String? = nil,
         limit: Int? = nil,
         offset: Int? = nil,
+        pendingbefore: Int? = nil,
         messageid: String? = nil,
         sessionid: String? = nil,
         maxchars: Int? = nil)
@@ -20792,6 +20794,7 @@ public struct ChatHistoryParams: Codable, Sendable {
         self.cursor = cursor
         self.limit = limit
         self.offset = offset
+        self.pendingbefore = pendingbefore
         self.messageid = messageid
         self.sessionid = sessionid
         self.maxchars = maxchars
@@ -20803,6 +20806,7 @@ public struct ChatHistoryParams: Codable, Sendable {
         case cursor
         case limit
         case offset
+        case pendingbefore = "pendingBefore"
         case messageid = "messageId"
         case sessionid = "sessionId"
         case maxchars = "maxChars"
@@ -20817,6 +20821,7 @@ public struct ChatHistoryDeltaResult: Codable, Sendable {
     public let agentslist: AnyCodable?
     public let inflightrun: AnyCodable?
     public let metadata: AnyCodable?
+    public let pendinginputs: [String: AnyCodable]?
 
     public init(
         kind: String,
@@ -20825,7 +20830,8 @@ public struct ChatHistoryDeltaResult: Codable, Sendable {
         sessioninfo: AnyCodable,
         agentslist: AnyCodable? = nil,
         inflightrun: AnyCodable? = nil,
-        metadata: AnyCodable? = nil)
+        metadata: AnyCodable? = nil,
+        pendinginputs: [String: AnyCodable]? = nil)
     {
         self.kind = kind
         self.messages = messages
@@ -20834,6 +20840,7 @@ public struct ChatHistoryDeltaResult: Codable, Sendable {
         self.agentslist = agentslist
         self.inflightrun = inflightrun
         self.metadata = metadata
+        self.pendinginputs = pendinginputs
     }
 
     private enum CodingKeys: String, CodingKey {
@@ -20844,6 +20851,7 @@ public struct ChatHistoryDeltaResult: Codable, Sendable {
         case agentslist = "agentsList"
         case inflightrun = "inFlightRun"
         case metadata
+        case pendinginputs = "pendingInputs"
     }
 }
 

--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -3672,7 +3672,7 @@ src/sessions/session-upstream-links.ts	2
 src/sessions/session-upstream-monitor.ts	2
 src/sessions/user-turn-transcript-runtime-context.ts	2
 src/sessions/user-turn-transcript.media-normalize.ts	2
-src/sessions/user-turn-transcript.ts	11
+src/sessions/user-turn-transcript.ts	5
 src/shared/account-enabled.ts	1
 src/shared/assistant-error-format.ts	3
 src/shared/bounded-serial-queue.ts	1

--- a/docs/concepts/session-tool.md
+++ b/docs/concepts/session-tool.md
@@ -51,8 +51,9 @@ Gateway sharing operations are outside this run-audit boundary.
 
 `sessions_history` fetches the conversation transcript for a specific session. By default, tool results are excluded; pass `includeTools: true` to see them. Use `limit` for the newest bounded tail. Pass `offset: 0` when you need pagination metadata, then pass returned `nextOffset` values to page backward through older OpenClaw transcript windows without reading raw transcript files. Explicit offset pages do not merge external CLI fallback imports; use the default newest-tail view (no `offset`) when you need that merged display history.
 
-Accepted inputs waiting for their turn appear separately in `pendingInputs`, not
-in transcript `messages`. Each row records `queued`, `cancelled`, or `interrupted`.
+Durably admitted inputs from `sessions_send` or the Gateway `agent` method
+appear separately in `pendingInputs`, not in transcript `messages`. Each row
+records `queued`, `cancelled`, or `interrupted`.
 Cancelled and interrupted inputs are retained for inspection and never run
 automatically. Use `pendingBefore` with the page's `nextBefore` to read older
 inputs; `limit` bounds both pages. Pending previews share a 4 KB budget within

--- a/docs/concepts/session-tool.md
+++ b/docs/concepts/session-tool.md
@@ -51,6 +51,13 @@ Gateway sharing operations are outside this run-audit boundary.
 
 `sessions_history` fetches the conversation transcript for a specific session. By default, tool results are excluded; pass `includeTools: true` to see them. Use `limit` for the newest bounded tail. Pass `offset: 0` when you need pagination metadata, then pass returned `nextOffset` values to page backward through older OpenClaw transcript windows without reading raw transcript files. Explicit offset pages do not merge external CLI fallback imports; use the default newest-tail view (no `offset`) when you need that merged display history.
 
+Accepted inputs waiting for their turn appear separately in `pendingInputs`, not
+in transcript `messages`. Each row records `queued`, `cancelled`, or `interrupted`.
+Cancelled and interrupted inputs are retained for inspection and never run
+automatically. Use `pendingBefore` with the page's `nextBefore` to read older
+inputs; `limit` bounds both pages. Pending previews share a 4 KB budget within
+the overall 80 KB response budget, so use a smaller `limit` for richer previews.
+
 The returned view is intentionally bounded and redacted:
 
 - credential/token-like text is redacted even when general-purpose log redaction is disabled

--- a/docs/web/control-ui.md
+++ b/docs/web/control-ui.md
@@ -124,14 +124,18 @@ On the first identified connection, the Control UI uploads existing browser-loca
 
 When a remote project session starts before its repository finishes cloning, chat shows workspace preparation progress. If preparation fails, opening or reloading chat restores the session's failure summary. Correct the reported problem, then send a new message in the same session to retry preparation.
 
-Inputs accepted while a cloud turn is running remain visible with a waiting
-notice until their own turn starts. They are stored separately from the active
-model transcript. If cancellation or a Gateway restart interrupts that wait,
+Inputs accepted through `sessions_send` or the Gateway `agent` method while a
+cloud turn is running remain visible with a waiting notice until their own turn
+starts. They are stored separately from the active model transcript. If
+cancellation or a Gateway restart interrupts that wait,
 the input stays readable with its recorded disposition and is never resent
 automatically. Copy it into the composer to start a new attempt. **Earlier
 accepted inputs** pages through retained inputs; **Latest accepted inputs**
 returns to the newest page. Long accepted input uses the normal full-message
 reader without becoming a transcript reply, fork, or rewind target.
+
+Ordinary browser follow-ups still use the existing chat queue, including collect
+mode; they do not yet have this durable pending-input custody.
 
 ## Personal identity
 

--- a/docs/web/control-ui.md
+++ b/docs/web/control-ui.md
@@ -124,6 +124,15 @@ On the first identified connection, the Control UI uploads existing browser-loca
 
 When a remote project session starts before its repository finishes cloning, chat shows workspace preparation progress. If preparation fails, opening or reloading chat restores the session's failure summary. Correct the reported problem, then send a new message in the same session to retry preparation.
 
+Inputs accepted while a cloud turn is running remain visible with a waiting
+notice until their own turn starts. They are stored separately from the active
+model transcript. If cancellation or a Gateway restart interrupts that wait,
+the input stays readable with its recorded disposition and is never resent
+automatically. Copy it into the composer to start a new attempt. **Earlier
+accepted inputs** pages through retained inputs; **Latest accepted inputs**
+returns to the newest page. Long accepted input uses the normal full-message
+reader without becoming a transcript reply, fork, or rewind target.
+
 ## Personal identity
 
 Authenticated people have a durable Gateway profile with a display name, avatar, linked emails, and optional verified GitHub identity. Open **Settings → Profile → Identity** to update the editable fields. The profile follows the authenticated person across browsers; clearing browser site data does not delete it.

--- a/packages/gateway-protocol/src/schema/chat-history-constants.ts
+++ b/packages/gateway-protocol/src/schema/chat-history-constants.ts
@@ -1,2 +1,4 @@
 /** Largest history page accepted by the Gateway wire contract. */
 export const CHAT_HISTORY_MAX_ENTRIES = 1000;
+/** Display-only custody records; never transcript branch entry IDs. */
+export const CHAT_PENDING_INPUT_MESSAGE_PREFIX = "pending:";

--- a/packages/gateway-protocol/src/schema/logs-chat.ts
+++ b/packages/gateway-protocol/src/schema/logs-chat.ts
@@ -29,10 +29,28 @@ export const ChatHistoryParamsSchema = closedObject({
   cursor: Type.Optional(Type.String()),
   limit: Type.Optional(Type.Integer({ minimum: 1, maximum: CHAT_HISTORY_MAX_ENTRIES })),
   offset: Type.Optional(Type.Integer({ minimum: 0 })),
+  pendingBefore: Type.Optional(Type.Integer({ minimum: 1 })),
   messageId: Type.Optional(NonEmptyString),
   sessionId: Type.Optional(NonEmptyString),
   maxChars: Type.Optional(Type.Integer({ minimum: 1, maximum: 500_000 })),
 });
+
+/** Accepted input awaiting a turn, separate from canonical model history. */
+export const ChatPendingInputsPageSchema = closedObject({
+  items: Type.Array(
+    closedObject({
+      id: NonEmptyString,
+      runId: Type.Optional(Type.String({ minLength: 1, maxLength: 256 })),
+      message: Type.Unknown(),
+      acceptedAt: Type.Number(),
+      state: Type.String({ enum: ["queued", "cancelled", "interrupted"] }),
+    }),
+    { maxItems: 20 },
+  ),
+  total: Type.Integer({ minimum: 0 }),
+  nextBefore: Type.Optional(Type.Integer({ minimum: 1 })),
+});
+export type ChatPendingInputsPage = Static<typeof ChatPendingInputsPageSchema>;
 
 /**
  * Bounded forward catch-up response. Clients replay `messages` as `session.message`
@@ -47,6 +65,7 @@ export const ChatHistoryDeltaResultSchema = closedObject({
   agentsList: Type.Optional(Type.Unknown()),
   inFlightRun: Type.Optional(Type.Unknown()),
   metadata: Type.Optional(Type.Unknown()),
+  pendingInputs: Type.Optional(ChatPendingInputsPageSchema),
 });
 
 /** Normal cursor discontinuity; clients recover with a fresh tail request. */

--- a/src/agents/agent-command.live-model-switch.test.ts
+++ b/src/agents/agent-command.live-model-switch.test.ts
@@ -2592,51 +2592,56 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
     expect(sessionStore["agent:main:main"]?.restartRecoveryDeliveryRunId).toBe("session-1");
   });
 
-  it("persists only the CLI assistant reply after the runner persists the current user turn", async () => {
-    type AttemptCall = {
-      onUserMessagePersisted?: () => void;
-      userTurnTranscriptRecorder: UserTurnTranscriptRecorder;
-    };
-    setupSingleAttemptFallback();
-    setupStoredSession();
-    const result = makeSuccessResult("openai", "gpt-5.4") as ReturnType<
-      typeof makeSuccessResult
-    > & {
-      meta: Record<string, unknown> & { executionTrace: Record<string, unknown> };
-    };
-    result.meta.executionTrace = {
-      runner: "cli",
-      fallbackUsed: false,
-      winnerProvider: "openai",
-      winnerModel: "gpt-5.4",
-    };
-    state.runAgentAttemptMock.mockImplementation(async (attemptParams: AttemptCall) => {
-      attemptParams.userTurnTranscriptRecorder.markRuntimePersisted();
-      attemptParams.onUserMessagePersisted?.();
-      return result;
-    });
-    state.persistCliTurnTranscriptMock.mockResolvedValue({
-      kind: "persisted",
-      sessionEntry: state.sessionEntryMock,
-    });
-    const userTurnTranscriptRecorder = createUserTurnTranscriptRecorder({
-      input: { text: "hello", idempotencyKey: "canonical-user:user" },
-      target: () => undefined,
-    });
+  it.each([true, false])(
+    "does not duplicate a recorder-owned CLI input after completion (persisted=%s)",
+    async (persisted) => {
+      type AttemptCall = {
+        onUserMessagePersisted?: () => void;
+        userTurnTranscriptRecorder: UserTurnTranscriptRecorder;
+      };
+      setupSingleAttemptFallback();
+      setupStoredSession();
+      const result = makeSuccessResult("openai", "gpt-5.4") as ReturnType<
+        typeof makeSuccessResult
+      > & {
+        meta: Record<string, unknown> & { executionTrace: Record<string, unknown> };
+      };
+      result.meta.executionTrace = {
+        runner: "cli",
+        fallbackUsed: false,
+        winnerProvider: "openai",
+        winnerModel: "gpt-5.4",
+      };
+      state.runAgentAttemptMock.mockImplementation(async (attemptParams: AttemptCall) => {
+        if (persisted) {
+          attemptParams.userTurnTranscriptRecorder.markRuntimePersisted();
+          attemptParams.onUserMessagePersisted?.();
+        }
+        return result;
+      });
+      state.persistCliTurnTranscriptMock.mockResolvedValue({
+        kind: "persisted",
+        sessionEntry: state.sessionEntryMock,
+      });
+      const userTurnTranscriptRecorder = createUserTurnTranscriptRecorder({
+        input: { text: "hello", idempotencyKey: "canonical-user:user" },
+        target: () => undefined,
+      });
 
-    await agentCommand({
-      message: "hello",
-      to: "+1234567890",
-      userTurnTranscriptRecorder,
-    });
+      await agentCommand({
+        message: "hello",
+        to: "+1234567890",
+        userTurnTranscriptRecorder,
+      });
 
-    expect(mockCallArg(state.runAgentAttemptMock)).toMatchObject({
-      userTurnTranscriptRecorder,
-    });
-    expect(mockCallArg(state.persistCliTurnTranscriptMock)).toMatchObject({
-      skipUserTurn: true,
-    });
-  });
+      expect(mockCallArg(state.runAgentAttemptMock)).toMatchObject({
+        userTurnTranscriptRecorder,
+      });
+      expect(mockCallArg(state.persistCliTurnTranscriptMock)).toMatchObject({
+        skipUserTurn: true,
+      });
+    },
+  );
 
   it("does not treat backend CLI session id as OpenClaw session identity", async () => {
     setupSingleAttemptFallback();
@@ -5184,12 +5189,12 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
     const onExecutionStarted = vi.fn();
     state.acpRunTurnMock.mockImplementationOnce(async (params: unknown) => {
       const callbacks = params as {
-        onBeforePrompt?: () => void;
+        onBeforePrompt?: () => Promise<void> | void;
         onLifecycle?: (event: { type: string; at: number }) => void;
         onEvent?: (event: unknown) => void;
       };
       expect(onExecutionStarted).not.toHaveBeenCalled();
-      callbacks.onBeforePrompt?.();
+      await callbacks.onBeforePrompt?.();
       expect(onExecutionStarted).toHaveBeenCalledOnce();
       callbacks.onLifecycle?.({ type: "prompt_submitted", at: Date.now() });
       callbacks.onEvent?.({ type: "done", stopReason: "end_turn" });
@@ -5202,6 +5207,34 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
     });
 
     expect(onExecutionStarted).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects an ACP prompt before execution when its accepted input cannot enter the transcript", async () => {
+    setupAcpSession();
+    const recorder = createUserTurnTranscriptRecorder({
+      input: { text: "accepted ACP input", idempotencyKey: "acp-input:user" },
+      target: () => undefined,
+    });
+    const onExecutionStarted = vi.fn();
+    const submitPrompt = vi.fn();
+    state.acpRunTurnMock.mockImplementationOnce(async (params: unknown) => {
+      const callbacks = params as { onBeforePrompt?: () => Promise<void> | void };
+      await callbacks.onBeforePrompt?.();
+      submitPrompt();
+    });
+
+    await expect(
+      agentCommand({
+        message: "accepted ACP input",
+        sessionKey: "agent:main:main",
+        userTurnTranscriptRecorder: recorder,
+        onExecutionStarted,
+      }),
+    ).rejects.toThrow("ACP input could not enter the session transcript");
+
+    expect(onExecutionStarted).not.toHaveBeenCalled();
+    expect(submitPrompt).not.toHaveBeenCalled();
+    expect(state.persistAcpTurnTranscriptMock).not.toHaveBeenCalled();
   });
 
   it("keeps session provenance for internal ACP turns", async () => {

--- a/src/agents/agent-tool-definition-adapter.after-tool-call.fires-once.test.ts
+++ b/src/agents/agent-tool-definition-adapter.after-tool-call.fires-once.test.ts
@@ -93,7 +93,8 @@ async function loadFreshAfterToolCallModulesForTest() {
   vi.doMock("../plugins/hook-runner-global.js", () => ({
     getGlobalHookRunner: () => hookMocks.runner,
   }));
-  vi.doMock("../infra/agent-events.js", () => ({
+  vi.doMock("../infra/agent-events.js", async (importOriginal) => ({
+    ...(await importOriginal<typeof import("../infra/agent-events.js")>()),
     emitAgentCommandOutputEvent: vi.fn(),
     emitAgentEvent: vi.fn(),
     emitAgentItemEvent: vi.fn(),

--- a/src/agents/command/acp-execution.ts
+++ b/src/agents/command/acp-execution.ts
@@ -162,7 +162,13 @@ export async function runAcpAgentCommand(params: {
       requestId: params.runId,
       signal: params.opts.abortSignal,
       onElicitation,
-      onBeforePrompt: params.opts.onExecutionStarted,
+      onBeforePrompt: async () => {
+        const recorder = params.opts.userTurnTranscriptRecorder;
+        if (recorder && !recorder.hasPersisted() && !(await recorder.persistApproved())) {
+          throw new Error("ACP input could not enter the session transcript");
+        }
+        params.opts.onExecutionStarted?.();
+      },
       onLifecycle: (event) => {
         if (event.type === "prompt_submitted") {
           attemptExecutionRuntime.emitAcpPromptSubmitted({
@@ -255,7 +261,10 @@ export async function runAcpAgentCommand(params: {
     const transcriptResult = await attemptExecutionRuntime.persistAcpTurnTranscript({
       body: params.body,
       transcriptBody: params.transcriptBody,
-      ...(params.opts.suppressPromptPersistence !== true && params.opts.transcriptMedia?.length
+      userTurnTranscriptRecorder: params.opts.userTurnTranscriptRecorder,
+      ...(!params.opts.userTurnTranscriptRecorder &&
+      params.opts.suppressPromptPersistence !== true &&
+      params.opts.transcriptMedia?.length
         ? {
             userInput: {
               text: params.transcriptBody,

--- a/src/agents/command/post-run.ts
+++ b/src/agents/command/post-run.ts
@@ -214,6 +214,9 @@ export async function finalizeEmbeddedAgentCommand(params: {
           skipAssistantTurn: assistantTranscriptOwned,
           skipUserTurn:
             suppressUserTurnPersistence ||
+            // A supplied recorder owns input admission; the terminal mirror must
+            // not synthesize an unkeyed copy when that input never reached execution.
+            params.opts.userTurnTranscriptRecorder !== undefined ||
             userTurnTranscriptRecorder.hasPersisted() ||
             userTurnTranscriptRecorder.isBlocked(),
         });

--- a/src/agents/subagents/registry/subagent-registry-sweeper-recovery.test.ts
+++ b/src/agents/subagents/registry/subagent-registry-sweeper-recovery.test.ts
@@ -32,10 +32,12 @@ vi.mock("./subagent-registry-restart-recovery.js", async (importOriginal) => {
     recoverInterruptedSubagentRow: recoverRow,
   };
 });
-vi.mock("../../../infra/agent-events.js", () => ({
+vi.mock("../../../infra/agent-events.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../../infra/agent-events.js")>()),
   isAgentEventLifecycleGenerationCurrent: () => true,
 }));
-vi.mock("../../../infra/agent-run-registry.js", () => ({
+vi.mock("../../../infra/agent-run-registry.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../../infra/agent-run-registry.js")>()),
   getAgentRunContext,
 }));
 vi.mock("../../internal-session-effects.js", () => ({

--- a/src/agents/tool-description-presets.test.ts
+++ b/src/agents/tool-description-presets.test.ts
@@ -33,7 +33,7 @@ const SESSION_DESCRIPTIONS = [
     tool: "sessions_history",
     describe: describeSessionsHistoryTool,
     original:
-      "Read sanitized visible-session history. Before reply/debug/resume. Supports limit, offset, search-result sessionId/messageId anchors, and tool messages.",
+      "Read sanitized visible-session history. Before reply/debug/resume. Supports limit, offset, search-result sessionId/messageId anchors, and tool messages. pendingInputs are accepted inputs outside model history; page with pendingBefore=nextBefore. Cancelled/interrupted inputs never replay automatically. Lower limit for richer pending previews.",
   },
   {
     tool: "sessions_search",

--- a/src/agents/tool-description-presets.ts
+++ b/src/agents/tool-description-presets.ts
@@ -78,6 +78,7 @@ export function describeSessionsHistoryTool(options?: SessionLinkDescriptionOpti
   return [
     "Read sanitized visible-session history.",
     "Before reply/debug/resume. Supports limit, offset, search-result sessionId/messageId anchors, and tool messages.",
+    "pendingInputs are accepted inputs outside model history; page with pendingBefore=nextBefore. Cancelled/interrupted inputs never replay automatically. Lower limit for richer pending previews.",
     ...(options?.sessionLinkBase ? [describeSessionLinkRule(options.sessionLinkBase)] : []),
   ].join(" ");
 }

--- a/src/agents/tools/sessions-history-tool.test.ts
+++ b/src/agents/tools/sessions-history-tool.test.ts
@@ -152,7 +152,7 @@ describe("sessions_history redaction", () => {
       Value.Check(tool.outputSchema!, { status: "forbidden", error: "hidden", extra: true }),
     ).toBe(false);
     expect(compactToolOutputHint(tool.outputSchema)).toBe(
-      '{ bytes: number; contentRedacted: boolean; contentTruncated: boolean; droppedMessages: boolean; messages: Array<unknown>; sessionKey: string; truncated: boolean; hasMore?: boolean; nextOffset?: number; offset?: number; sessionLinkRule?: string; totalMessages?: number } | { error: string; status: "error" | "forbidden" }',
+      '{ bytes: number; contentRedacted: boolean; contentTruncated: boolean; droppedMessages: boolean; messages: Array<unknown>; sessionKey: string; truncated: boolean; hasMore?: boolean; nextOffset?: number; offset?: number; pendingInputs?: { items: Array<{ acceptedAt: number; id: string; message: unknown; state: "queued" | "cancelled" | "interrupted" }>; total: number; nextBefore?: number }; sessionLinkRule?: string; totalMessages?: number } | { error: string; status: "error" | "forbidden" }',
     );
   });
 
@@ -234,6 +234,50 @@ describe("sessions_history redaction", () => {
     expect(serialized).not.toContain("sk-or-v1-abcdef0123456789");
     expect(serialized).toContain("OPENROUTER_API_KEY=");
     expect((result.details as { contentRedacted?: unknown }).contentRedacted).toBe(true);
+  });
+
+  it("keeps accepted inputs separate, redacted, bounded, and addressable by their own cursor", async () => {
+    useLoggingConfig("pending-redaction-off.json", { redactSensitive: "off" });
+    const requests: CallGatewayRequest[] = [];
+    const items = Array.from({ length: 20 }, (_, index) => ({
+      id: `00000000-0000-0000-0000-${String(index).padStart(12, "0")}`,
+      runId: "do-not-expose-correlation",
+      state: "interrupted",
+      acceptedAt: 1_700_000_000_000,
+      message: {
+        role: "user",
+        content: `OPENROUTER_API_KEY=sk-or-v1-abcdef0123456789 ${"queued input ".repeat(1000)}`,
+      },
+    }));
+    const tool = createSessionsHistoryTool({
+      config: {},
+      callGateway: async <T = Record<string, unknown>>(request: CallGatewayRequest): Promise<T> => {
+        requests.push(request);
+        return {
+          messages: [{ role: "assistant", content: "Canonical reply" }],
+          pendingInputs: { items, total: 23, nextBefore: 4 },
+        } as T;
+      },
+    });
+    const result = await tool.execute("pending-cursor", { sessionKey: "main", pendingBefore: 24 });
+    const details = result.details as {
+      messages: unknown[];
+      pendingInputs: { items: unknown[]; total: number; nextBefore: number };
+      contentRedacted: boolean;
+      bytes: number;
+    };
+    expect(requireGatewayRequest(requests, "chat.history").params).toMatchObject({
+      pendingBefore: 24,
+    });
+    expect(details.messages).toEqual([{ role: "assistant", content: "Canonical reply" }]);
+    expect(details.pendingInputs).toMatchObject({ total: 23, nextBefore: 4 });
+    expect(details.pendingInputs.items).toHaveLength(20);
+    expect(Buffer.byteLength(JSON.stringify(details.pendingInputs))).toBeLessThanOrEqual(4096);
+    expect(JSON.stringify(details.pendingInputs)).not.toContain("sk-or-v1-abcdef0123456789");
+    expect(JSON.stringify(details.pendingInputs)).not.toContain("do-not-expose-correlation");
+    expect(details.contentRedacted).toBe(true);
+    expect(details.bytes).toBeLessThanOrEqual(80 * 1024);
+    expect(Value.Check(tool.outputSchema!, details)).toBe(true);
   });
 
   it("applies custom redaction patterns to recalled session text", async () => {

--- a/src/agents/tools/sessions-history-tool.ts
+++ b/src/agents/tools/sessions-history-tool.ts
@@ -4,7 +4,9 @@
  * Reads bounded, redacted session transcript history after session visibility filtering.
  */
 import { asPositiveSafeInteger } from "@openclaw/normalization-core/number-coercion";
+import { asOptionalRecord } from "@openclaw/normalization-core/record-coerce";
 import { Type } from "typebox";
+import type { ChatPendingInputsPage } from "../../../packages/gateway-protocol/src/schema/logs-chat.js";
 import { resolvePersistedSessionStoreOwnerForKey } from "../../config/sessions/session-store-owner.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { capArrayByJsonBytes } from "../../gateway/session-transcript-readers.js";
@@ -50,6 +52,7 @@ const SessionsHistoryToolSchema = Type.Object({
   sessionKey: Type.String(),
   limit: optionalPositiveIntegerSchema(),
   offset: Type.Optional(Type.Integer({ minimum: 0 })),
+  pendingBefore: optionalPositiveIntegerSchema(),
   messageId: Type.Optional(Type.String({ minLength: 1 })),
   sessionId: Type.Optional(Type.String({ minLength: 1 })),
   includeTools: Type.Optional(Type.Boolean()),
@@ -74,6 +77,26 @@ const SessionsHistoryOutputSchema = Type.Union([
       nextOffset: Type.Optional(Type.Number()),
       hasMore: Type.Optional(Type.Boolean()),
       totalMessages: Type.Optional(Type.Number()),
+      pendingInputs: Type.Optional(
+        Type.Object(
+          {
+            items: Type.Array(
+              Type.Object(
+                {
+                  id: Type.String(),
+                  acceptedAt: Type.Number(),
+                  state: Type.String({ enum: ["queued", "cancelled", "interrupted"] }),
+                  message: Type.Unknown(),
+                },
+                { additionalProperties: false },
+              ),
+            ),
+            total: Type.Number(),
+            nextBefore: Type.Optional(Type.Number()),
+          },
+          { additionalProperties: false },
+        ),
+      ),
     },
     { additionalProperties: false },
   ),
@@ -88,6 +111,7 @@ const SessionsHistoryOutputSchema = Type.Union([
 
 const SESSIONS_HISTORY_MAX_BYTES = 80 * 1024;
 const SESSIONS_HISTORY_TEXT_MAX_CHARS = 4000;
+const SESSIONS_HISTORY_PENDING_MAX_BYTES = 4096;
 type GatewayCaller = AgentToolGatewayRequestCaller;
 type ChatHistoryPaginationMetadata = {
   offset?: number;
@@ -106,7 +130,10 @@ function readOffsetParam(params: Record<string, unknown>): number | undefined {
 
 // sandbox policy handling is shared with sessions-list-tool via sessions-helpers.ts
 
-function truncateHistoryText(text: string): {
+function truncateHistoryText(
+  text: string,
+  maxChars = SESSIONS_HISTORY_TEXT_MAX_CHARS,
+): {
   text: string;
   truncated: boolean;
   redacted: boolean;
@@ -115,14 +142,17 @@ function truncateHistoryText(text: string): {
   // when operators disable general-purpose log redaction.
   const sanitized = redactToolPayloadText(text);
   const redacted = sanitized !== text;
-  if (sanitized.length <= SESSIONS_HISTORY_TEXT_MAX_CHARS) {
+  if (sanitized.length <= maxChars) {
     return { text: sanitized, truncated: false, redacted };
   }
-  const cut = truncateUtf16Safe(sanitized, SESSIONS_HISTORY_TEXT_MAX_CHARS);
+  const cut = truncateUtf16Safe(sanitized, maxChars);
   return { text: `${cut}\n…(truncated)…`, truncated: true, redacted };
 }
 
-function sanitizeHistoryContentBlock(block: unknown): {
+function sanitizeHistoryContentBlock(
+  block: unknown,
+  maxChars: number,
+): {
   block: unknown;
   truncated: boolean;
   redacted: boolean;
@@ -134,19 +164,19 @@ function sanitizeHistoryContentBlock(block: unknown): {
   let truncated = false;
   let redacted = false;
   if (typeof entry.text === "string") {
-    const res = truncateHistoryText(entry.text);
+    const res = truncateHistoryText(entry.text, maxChars);
     entry.text = res.text;
     truncated ||= res.truncated;
     redacted ||= res.redacted;
   }
   if (entry.type === "thinking" && typeof entry.thinking === "string") {
-    const res = truncateHistoryText(entry.thinking);
+    const res = truncateHistoryText(entry.thinking, maxChars);
     entry.thinking = res.text;
     truncated ||= res.truncated;
     redacted ||= res.redacted;
   }
   if (typeof entry.partialJson === "string") {
-    const res = truncateHistoryText(entry.partialJson);
+    const res = truncateHistoryText(entry.partialJson, maxChars);
     entry.partialJson = res.text;
     truncated ||= res.truncated;
     redacted ||= res.redacted;
@@ -154,7 +184,10 @@ function sanitizeHistoryContentBlock(block: unknown): {
   return { block: entry, truncated, redacted };
 }
 
-function sanitizeHistoryMessage(message: unknown): {
+function sanitizeHistoryMessage(
+  message: unknown,
+  maxChars = SESSIONS_HISTORY_TEXT_MAX_CHARS,
+): {
   message: unknown;
   truncated: boolean;
   redacted: boolean;
@@ -180,23 +213,56 @@ function sanitizeHistoryMessage(message: unknown): {
   }
 
   if (typeof entry.content === "string") {
-    const res = truncateHistoryText(entry.content);
+    const res = truncateHistoryText(entry.content, maxChars);
     entry.content = res.text;
     truncated ||= res.truncated;
     redacted ||= res.redacted;
   } else if (Array.isArray(entry.content)) {
-    const updated = entry.content.map((block) => sanitizeHistoryContentBlock(block));
+    const updated = entry.content.map((block) => sanitizeHistoryContentBlock(block, maxChars));
     entry.content = updated.map((item) => item.block);
     truncated ||= updated.some((item) => item.truncated);
     redacted ||= updated.some((item) => item.redacted);
   }
   if (typeof entry.text === "string") {
-    const res = truncateHistoryText(entry.text);
+    const res = truncateHistoryText(entry.text, maxChars);
     entry.text = res.text;
     truncated ||= res.truncated;
     redacted ||= res.redacted;
   }
   return { message: entry, truncated, redacted };
+}
+
+function boundPendingInputs(page: ChatPendingInputsPage) {
+  // Pending input is context for an intentional next action, never executable
+  // history. Keep the whole page addressable while sharing one hard byte cap.
+  const metadata = page.items.map(({ id, state, acceptedAt }) => ({ id, state, acceptedAt }));
+  const messageBudget = Math.floor(
+    (SESSIONS_HISTORY_PENDING_MAX_BYTES -
+      jsonUtf8Bytes({ ...page, items: metadata }) -
+      page.items.length * 12) /
+      Math.max(page.items.length, 1),
+  );
+  let truncated = false;
+  let redacted = false;
+  const items = page.items.map((item, index) => {
+    const result = sanitizeHistoryMessage(item.message, Math.max(1, Math.floor(messageBudget / 8)));
+    redacted ||= result.redacted;
+    const record = asOptionalRecord(result.message);
+    const media = asOptionalRecord(record?.__openclaw)?.media;
+    const message = { role: "user", content: record?.content, ...(media ? { media } : {}) };
+    const oversized = jsonUtf8Bytes(message) > messageBudget;
+    truncated ||= result.truncated || oversized;
+    return {
+      ...metadata[index],
+      message: oversized ? { role: "user", content: "[Input omitted; request limit: 1]" } : message,
+    };
+  });
+  const pendingInputs = {
+    items,
+    total: page.total,
+    ...(page.nextBefore !== undefined ? { nextBefore: page.nextBefore } : {}),
+  };
+  return { pendingInputs, bytes: jsonUtf8Bytes(pendingInputs), truncated, redacted };
 }
 
 function enforceSessionsHistoryHardCap(params: {
@@ -382,6 +448,7 @@ export function createSessionsHistoryTool(opts?: {
       });
       const limit = readPositiveIntegerParam(params, "limit");
       const offset = readOffsetParam(params);
+      const pendingBefore = readPositiveIntegerParam(params, "pendingBefore");
       const messageId = readToolStringParam(params, "messageId");
       const sessionId = readToolStringParam(params, "sessionId");
       if (offset !== undefined && messageId) {
@@ -511,6 +578,7 @@ export function createSessionsHistoryTool(opts?: {
             nextOffset?: number;
             hasMore?: boolean;
             totalMessages?: number;
+            pendingInputs?: ChatPendingInputsPage;
           }>({
             method: "chat.history",
             params: {
@@ -518,25 +586,30 @@ export function createSessionsHistoryTool(opts?: {
               agentId: targetAgentId,
               limit,
               ...(offset !== undefined ? { offset } : {}),
+              ...(pendingBefore !== undefined ? { pendingBefore } : {}),
               ...(messageId ? { messageId } : {}),
               ...(sessionId ? { sessionId } : {}),
             },
           }),
       });
       const rawMessages = Array.isArray(result?.messages) ? result.messages : [];
+      const pending = result?.pendingInputs ? boundPendingInputs(result.pendingInputs) : undefined;
+      const transcriptBudget = SESSIONS_HISTORY_MAX_BYTES - (pending?.bytes ?? 0);
       const selectedMessages = includeTools ? rawMessages : stripToolMessages(rawMessages);
       const sanitizedMessages = selectedMessages.map((message) => sanitizeHistoryMessage(message));
-      const contentTruncated = sanitizedMessages.some((entry) => entry.truncated);
-      const contentRedacted = sanitizedMessages.some((entry) => entry.redacted);
+      const contentTruncated =
+        sanitizedMessages.some((entry) => entry.truncated) || pending?.truncated === true;
+      const contentRedacted =
+        sanitizedMessages.some((entry) => entry.redacted) || pending?.redacted === true;
       const sanitizedItems = sanitizedMessages.map((entry) => entry.message);
       const cappedMessages = messageId
-        ? capSessionsHistoryAroundMessage(sanitizedItems, messageId, SESSIONS_HISTORY_MAX_BYTES)
-        : capArrayByJsonBytes(sanitizedItems, SESSIONS_HISTORY_MAX_BYTES);
+        ? capSessionsHistoryAroundMessage(sanitizedItems, messageId, transcriptBudget)
+        : capArrayByJsonBytes(sanitizedItems, transcriptBudget);
       const droppedMessages = cappedMessages.items.length < selectedMessages.length;
       const hardened = enforceSessionsHistoryHardCap({
         items: cappedMessages.items,
         bytes: cappedMessages.bytes,
-        maxBytes: SESSIONS_HISTORY_MAX_BYTES,
+        maxBytes: transcriptBudget,
       });
       const pagination = resolveSessionsHistoryPaginationMetadata({
         messages: hardened.items,
@@ -551,7 +624,8 @@ export function createSessionsHistoryTool(opts?: {
         droppedMessages: droppedMessages || hardened.hardCapped,
         contentTruncated,
         contentRedacted,
-        bytes: hardened.bytes,
+        bytes: hardened.bytes + (pending?.bytes ?? 0),
+        ...(pending ? { pendingInputs: pending.pendingInputs } : {}),
         ...(opts?.sessionLinkBase
           ? { sessionLinkRule: describeSessionLinkRule(opts.sessionLinkBase) }
           : {}),

--- a/src/agents/tools/sessions-history-tool.ts
+++ b/src/agents/tools/sessions-history-tool.ts
@@ -248,7 +248,7 @@ function boundPendingInputs(page: ChatPendingInputsPage) {
     const result = sanitizeHistoryMessage(item.message, Math.max(1, Math.floor(messageBudget / 8)));
     redacted ||= result.redacted;
     const record = asOptionalRecord(result.message);
-    const media = asOptionalRecord(record?.__openclaw)?.media;
+    const media = asOptionalRecord(record?.["__openclaw"])?.media;
     const message = { role: "user", content: record?.content, ...(media ? { media } : {}) };
     const oversized = jsonUtf8Bytes(message) > messageBudget;
     truncated ||= result.truncated || oversized;

--- a/src/config/sessions/session-accessor.pending-inputs.test.ts
+++ b/src/config/sessions/session-accessor.pending-inputs.test.ts
@@ -78,7 +78,7 @@ describe("accepted input custody", () => {
     const before = await loadTranscriptEvents(scope());
     const prepare = vi.fn((input: PersistedUserTurnMessage) => ({
       ...input,
-      content: `${input.content} (approved)`,
+      content: typeof input.content === "string" ? `${input.content} (approved)` : input.content,
     }));
     const receipt = await stage("queued", { prepareMessageAfterIdempotencyCheck: prepare });
     await expect(

--- a/src/config/sessions/session-accessor.pending-inputs.test.ts
+++ b/src/config/sessions/session-accessor.pending-inputs.test.ts
@@ -1,0 +1,391 @@
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../../test/helpers/promise.js";
+import { MAX_PAYLOAD_BYTES } from "../../gateway/server-constants.js";
+import { rotateAgentEventLifecycleGeneration } from "../../infra/agent-events.js";
+import type { PersistedUserTurnMessage } from "../../sessions/user-turn-transcript.types.js";
+import {
+  closeOpenClawAgentDatabasesForTest,
+  openOpenClawAgentDatabase,
+  runOpenClawAgentWriteTransaction,
+} from "../../state/openclaw-agent-db.js";
+import {
+  appendTranscriptMessage,
+  deleteSessionEntryLifecycle,
+  loadTranscriptEvents,
+  readActiveTranscriptEntryAnchor,
+  replaceTranscriptEvents,
+  upsertSessionEntryCore,
+} from "./session-accessor.js";
+import {
+  listSessionPendingInputs,
+  readSessionPendingInput,
+  stageSessionPendingInput,
+  type SessionPendingInputReceipt,
+} from "./session-accessor.pending-inputs.js";
+import { copySessionNodeArtifactsForRepair } from "./session-accessor.sqlite-node-artifacts.js";
+import {
+  resolveSqliteScope,
+  runExclusiveSqliteSessionWrite,
+  toDatabaseOptions,
+} from "./session-accessor.sqlite-scope.js";
+import { waitForSessionTranscriptProjection } from "./session-transcript-reconcile.js";
+import { useTempSessionsFixture } from "./test-helpers.js";
+
+describe("accepted input custody", () => {
+  const fixture = useTempSessionsFixture("openclaw-pending-inputs-");
+  const sessionKey = "agent:main:pending-inputs";
+  const sessionId = "pending-session";
+  const receipts: SessionPendingInputReceipt[] = [];
+  const scope = () => ({ agentId: "main", sessionKey, sessionId, storePath: fixture.storePath() });
+  const database = () => openOpenClawAgentDatabase(toDatabaseOptions(resolveSqliteScope(scope())));
+  const message = (runId: string, content = "Continue the task"): PersistedUserTurnMessage => ({
+    role: "user",
+    content,
+    timestamp: 100,
+    idempotencyKey: `${runId}:user`,
+  });
+  const stage = async (
+    runId: string,
+    options: Partial<Parameters<typeof stageSessionPendingInput>[1]> = {},
+  ) => {
+    const receipt = await stageSessionPendingInput(scope(), {
+      runId,
+      message: message(runId),
+      assertCurrent: () => {},
+      ...options,
+    });
+    if (receipt) {
+      receipts.push(receipt);
+    }
+    return receipt!;
+  };
+  const promote = (receipt: SessionPendingInputReceipt) =>
+    receipt.run(() => appendTranscriptMessage(scope(), { message: receipt.message }));
+
+  beforeEach(async () => {
+    await upsertSessionEntryCore(scope(), { sessionId, updatedAt: 1 });
+  });
+  afterEach(() => {
+    for (const receipt of receipts.splice(0)) {
+      receipt.finish("interrupted");
+    }
+    closeOpenClawAgentDatabasesForTest();
+  });
+
+  it("keeps accepted input outside the active transcript and applies its hook once across replay and promotion", async () => {
+    await appendTranscriptMessage(scope(), { message: message("active", "First task") });
+    const before = await loadTranscriptEvents(scope());
+    const prepare = vi.fn((input: PersistedUserTurnMessage) => ({
+      ...input,
+      content: `${input.content} (approved)`,
+    }));
+    const receipt = await stage("queued", { prepareMessageAfterIdempotencyCheck: prepare });
+    await expect(
+      stage("queued", {
+        message: { ...message("queued"), timestamp: 200 },
+        prepareMessageAfterIdempotencyCheck: prepare,
+      }),
+    ).rejects.toThrow("already admitted");
+    expect(prepare).toHaveBeenCalledOnce();
+    expect(await loadTranscriptEvents(scope())).toEqual(before);
+    expect(listSessionPendingInputs(scope())).toMatchObject({
+      total: 1,
+      items: [{ id: receipt.inputId, state: "queued", message: receipt.message }],
+    });
+    await expect(stage("queued", { message: message("queued", "Changed input") })).rejects.toThrow(
+      "conflicts",
+    );
+    await expect(appendTranscriptMessage(scope(), { message: receipt.message })).rejects.toThrow(
+      "outside its admitted turn",
+    );
+    const secondHook = vi.fn(() => undefined);
+    const appended = await receipt.run(() =>
+      appendTranscriptMessage(scope(), {
+        message: receipt.message,
+        prepareMessageAfterIdempotencyCheck: secondHook,
+      }),
+    );
+    expect(secondHook).not.toHaveBeenCalled();
+    expect(appended).toMatchObject({
+      appended: true,
+      messageId: receipt.inputId,
+      message: receipt.message,
+    });
+    expect(listSessionPendingInputs(scope())).toEqual({ total: 0, items: [] });
+    const committedReplay = await stage("queued", { prepareMessageAfterIdempotencyCheck: prepare });
+    expect(committedReplay.message).toEqual(receipt.message);
+    expect(prepare).toHaveBeenCalledOnce();
+    receipt.finish("interrupted");
+    expect(() => receipt.run(() => {})).toThrow("ownership ended");
+  });
+
+  it("rolls transcript promotion and custody consumption back together", async () => {
+    const receipt = await stage("atomic");
+    const before = await loadTranscriptEvents(scope());
+    database().db.exec(
+      "CREATE TRIGGER reject_pending_consume BEFORE DELETE ON session_pending_inputs BEGIN SELECT RAISE(ABORT, 'consume failed'); END",
+    );
+    await expect(promote(receipt)).rejects.toThrow("consume failed");
+    expect(await loadTranscriptEvents(scope())).toEqual(before);
+    expect(readSessionPendingInput(scope(), receipt.inputId)?.state).toBe("queued");
+    database().db.exec("DROP TRIGGER reject_pending_consume");
+    expect(await promote(receipt)).toMatchObject({ appended: true, messageId: receipt.inputId });
+    expect(readSessionPendingInput(scope(), receipt.inputId)).toBeUndefined();
+  });
+
+  it("promotes a queued input with its own custody after another receipt releases the writer", async () => {
+    const first = await stage("writer-first");
+    const second = await stage("writer-second");
+    const gate = createDeferred();
+    const held = first.run(() =>
+      runExclusiveSqliteSessionWrite(resolveSqliteScope(scope()), async () => gate.promise),
+    );
+    const queued = promote(second);
+    gate.resolve();
+    await held;
+    expect(await queued).toMatchObject({ appended: true, messageId: second.inputId });
+    expect(listSessionPendingInputs(scope()).items.map((input) => input.id)).toEqual([
+      first.inputId,
+    ]);
+  });
+
+  it.each(["cancelled", "interrupted"] as const)(
+    "retains %s input visibly without permitting the old run to execute",
+    async (disposition) => {
+      const receipt = await stage("closed");
+      receipt.finish(disposition);
+      expect(readSessionPendingInput(scope(), receipt.inputId)?.state).toBe(disposition);
+      expect(() => promote(receipt)).toThrow("ownership ended");
+      await expect(stage("closed")).rejects.toThrow("submit a new turn");
+      await expect(appendTranscriptMessage(scope(), { message: receipt.message })).rejects.toThrow(
+        "outside its admitted turn",
+      );
+      expect(await promote(await stage("new-authorized-run"))).toMatchObject({ appended: true });
+    },
+  );
+
+  it("fences authority loss after an await without overriding the owner's terminal disposition", async () => {
+    let current = true;
+    const receipt = await stage("authority", {
+      assertCurrent: () => {
+        if (!current) {
+          throw new Error("run authority closed");
+        }
+      },
+    });
+    await expect(
+      receipt.run(async () => {
+        await Promise.resolve();
+        current = false;
+        return appendTranscriptMessage(scope(), { message: receipt.message });
+      }),
+    ).rejects.toThrow("run authority closed");
+    expect(listSessionPendingInputs(scope()).items[0]?.state).toBe("queued");
+    receipt.finish("cancelled");
+    expect(listSessionPendingInputs(scope()).items[0]?.state).toBe("cancelled");
+    expect(database().db.prepare("SELECT state FROM session_pending_inputs").get()).toEqual({
+      state: "cancelled",
+    });
+  });
+
+  it("retires current-process custody on lifecycle rotation and never replays it after reopening", async () => {
+    const receipt = await stage("restart");
+    rotateAgentEventLifecycleGeneration();
+    closeOpenClawAgentDatabasesForTest();
+    expect(readSessionPendingInput(scope(), receipt.inputId)?.state).toBe("interrupted");
+    expect(await loadTranscriptEvents(scope())).toEqual([]);
+    expect(() => promote(receipt)).toThrow("ownership ended");
+  });
+
+  it("allows terminal mirroring to read a promoted user after cancellation without a new append", async () => {
+    const receipt = await stage("terminal-mirror");
+    await receipt.run(async () => {
+      await appendTranscriptMessage(scope(), { message: receipt.message });
+      const before = await loadTranscriptEvents(scope());
+      receipt.finish("cancelled");
+      expect(await appendTranscriptMessage(scope(), { message: receipt.message })).toMatchObject({
+        appended: false,
+      });
+      expect(await loadTranscriptEvents(scope())).toEqual(before);
+    });
+  });
+
+  it.each(["deleted", "rebound", "replaced"] as const)(
+    "rejects terminal mirroring after the promoted transcript is %s",
+    async (change) => {
+      const receipt = await stage(`terminal-${change}`);
+      await receipt.run(async () => {
+        await appendTranscriptMessage(scope(), { message: receipt.message });
+        if (change === "deleted") {
+          await replaceTranscriptEvents(scope(), []);
+        } else if (change === "rebound") {
+          await upsertSessionEntryCore(scope(), { sessionId: "replacement-session", updatedAt: 2 });
+        } else {
+          await replaceTranscriptEvents(scope(), [
+            {
+              type: "message",
+              id: "rewritten-user",
+              parentId: null,
+              timestamp: new Date(100).toISOString(),
+              message: receipt.message,
+            },
+          ]);
+          expect(
+            readActiveTranscriptEntryAnchor({ ...scope(), entryId: "rewritten-user" }),
+          ).toMatchObject({ entryId: "rewritten-user" });
+        }
+        receipt.finish("cancelled");
+        const before = await loadTranscriptEvents(scope());
+        await expect(
+          appendTranscriptMessage(scope(), { message: receipt.message }),
+        ).rejects.toThrow(
+          change === "deleted"
+            ? "custody ended"
+            : change === "rebound"
+              ? "session changed"
+              : "conflicts",
+        );
+        expect(await loadTranscriptEvents(scope())).toEqual(before);
+      });
+    },
+  );
+
+  it("rejects retained custody on an inactive branch without changing ordinary historical replay", async () => {
+    const receipt = await stage("terminal-off-path");
+    let replacementId: string;
+    await receipt.run(async () => {
+      await appendTranscriptMessage(scope(), { message: receipt.message });
+      const replacement = await appendTranscriptMessage(scope(), {
+        message: message("replacement"),
+        parentId: null,
+      });
+      replacementId = replacement.messageId;
+      expect(replacement.effectiveParentId).toBeNull();
+      expect(
+        readActiveTranscriptEntryAnchor({ ...scope(), entryId: receipt.inputId }),
+      ).toBeUndefined();
+      expect(
+        readActiveTranscriptEntryAnchor({ ...scope(), entryId: replacementId }),
+      ).toBeUndefined();
+      receipt.finish("cancelled");
+      await expect(appendTranscriptMessage(scope(), { message: receipt.message })).rejects.toThrow(
+        "no longer active",
+      );
+    });
+    await waitForSessionTranscriptProjection(scope());
+    expect(
+      readActiveTranscriptEntryAnchor({ ...scope(), entryId: receipt.inputId }),
+    ).toBeUndefined();
+    expect(readActiveTranscriptEntryAnchor({ ...scope(), entryId: replacementId! })).toMatchObject({
+      entryId: replacementId!,
+    });
+    expect(await appendTranscriptMessage(scope(), { message: receipt.message })).toMatchObject({
+      appended: false,
+    });
+  });
+
+  it("retains repaired pending input as interrupted and never transfers live custody", async () => {
+    const receipt = await stage("repair");
+    const canonical = "agent:main:repaired-pending";
+    await upsertSessionEntryCore(
+      { ...scope(), sessionKey: canonical },
+      { sessionId, updatedAt: 2 },
+    );
+    const current = database();
+    copySessionNodeArtifactsForRepair(current, current, [sessionKey], canonical);
+    expect(listSessionPendingInputs({ ...scope(), sessionKey: canonical })).toMatchObject({
+      total: 1,
+      items: [{ id: receipt.inputId, state: "interrupted", message: receipt.message }],
+    });
+    await expect(
+      receipt.run(() =>
+        appendTranscriptMessage(
+          { ...scope(), sessionKey: canonical },
+          { message: receipt.message },
+        ),
+      ),
+    ).rejects.toThrow("outside its admitted turn");
+  });
+
+  it("copies accepted input across agent stores only as interrupted historical custody", async () => {
+    const receipt = await stage("cross-agent");
+    const source = database();
+    const destinationScope = {
+      agentId: "other",
+      sessionKey: "agent:other:repaired-pending",
+      sessionId,
+      storePath: path.join(path.dirname(source.path), "other-agent.sqlite"),
+    };
+    await upsertSessionEntryCore(destinationScope, { sessionId, updatedAt: 2 });
+    const destinationOptions = toDatabaseOptions(resolveSqliteScope(destinationScope));
+    runOpenClawAgentWriteTransaction((destination) => {
+      copySessionNodeArtifactsForRepair(
+        source,
+        destination,
+        [sessionKey],
+        destinationScope.sessionKey,
+      );
+      copySessionNodeArtifactsForRepair(
+        source,
+        destination,
+        [sessionKey],
+        destinationScope.sessionKey,
+      );
+    }, destinationOptions);
+    expect(listSessionPendingInputs(destinationScope)).toMatchObject({
+      total: 1,
+      items: [{ state: "interrupted", message: receipt.message }],
+    });
+    await expect(
+      receipt.run(() => appendTranscriptMessage(destinationScope, { message: receipt.message })),
+    ).rejects.toThrow("outside its admitted turn");
+  });
+
+  it("rejects a reset target and removes custody on logical deletion that retains transcript windows", async () => {
+    const receipt = await stage("reset");
+    await upsertSessionEntryCore(scope(), { sessionId: "replacement-session", updatedAt: 2 });
+    await expect(promote(receipt)).rejects.toThrow("session changed");
+    expect(readSessionPendingInput(scope(), receipt.inputId)?.state).toBe("interrupted");
+    await deleteSessionEntryLifecycle({
+      archiveTranscript: false,
+      storePath: fixture.storePath(),
+      target: { canonicalKey: sessionKey, storeKeys: [sessionKey] },
+    });
+    expect(listSessionPendingInputs(scope())).toEqual({ items: [], total: 0 });
+    expect(
+      database().db.prepare("SELECT count(*) AS total FROM session_pending_inputs").get(),
+    ).toEqual({ total: 0 });
+  });
+
+  it("paginates retained inputs with stable cursors while another input is promoted", async () => {
+    const first = await stage("first");
+    const second = await stage("second");
+    const third = await stage("third");
+    const page = listSessionPendingInputs(scope(), { limit: 2 });
+    expect(page.items.map((input) => input.id)).toEqual([second.inputId, third.inputId]);
+    expect(page.total).toBe(3);
+    expect(page.nextBefore).toBeDefined();
+    await promote(third);
+    const older = listSessionPendingInputs(scope(), { limit: 2, before: page.nextBefore });
+    expect(older.items.map((input) => input.id)).toEqual([first.inputId]);
+    expect(
+      readSessionPendingInput({ ...scope(), sessionId: "other-session" }, first.inputId),
+    ).toBeUndefined();
+  });
+
+  it("bounds materialized pending pages by bytes without truncating input or skipping its cursor", async () => {
+    const content = "x".repeat(Math.floor(MAX_PAYLOAD_BYTES / 2));
+    const first = await stage("large-first", { message: message("large-first", content) });
+    const second = await stage("large-second", { message: message("large-second", content) });
+    const page = listSessionPendingInputs(scope());
+    expect(page.items.map((input) => input.id)).toEqual([second.inputId]);
+    expect(page.items[0]?.message.content === content).toBe(true);
+    expect(page.total).toBe(2);
+    expect(page.nextBefore).toBeDefined();
+    const older = listSessionPendingInputs(scope(), { before: page.nextBefore });
+    expect(older.items.map((input) => input.id)).toEqual([first.inputId]);
+    expect(older.items[0]?.message.content === content).toBe(true);
+    expect(older.nextBefore).toBeUndefined();
+  });
+});

--- a/src/config/sessions/session-accessor.pending-inputs.ts
+++ b/src/config/sessions/session-accessor.pending-inputs.ts
@@ -1,0 +1,317 @@
+import { createHash, randomUUID } from "node:crypto";
+import { stableStringify } from "@openclaw/normalization-core/stable-stringify";
+import { sql } from "kysely";
+import { MAX_PAYLOAD_BYTES } from "../../gateway/server-constants.js";
+import { getAgentEventLifecycleGeneration } from "../../infra/agent-events.js";
+import {
+  executeSqliteQuerySync,
+  executeSqliteQueryTakeFirstSync,
+} from "../../infra/kysely-sync.js";
+import type { PersistedUserTurnMessage } from "../../sessions/user-turn-transcript.types.js";
+import { withOpenClawAgentDatabaseReadOnly } from "../../state/openclaw-agent-db-readonly.js";
+import {
+  openOpenClawAgentDatabase,
+  runOpenClawAgentWriteTransaction,
+} from "../../state/openclaw-agent-db.js";
+import {
+  ensureSessionPendingInputsSchema,
+  hasSessionPendingInputsSchema,
+} from "../../state/openclaw-agent-pending-inputs-schema.js";
+import type { OpenClawConfig } from "../types.openclaw.js";
+import type { SessionAccessScope } from "./session-accessor.sqlite-contract.js";
+import { readSessionEntryRow } from "./session-accessor.sqlite-entry-store.js";
+import {
+  hasSessionPendingInputOwner,
+  isSessionPendingInputRowLive,
+  parseSessionPendingInputMessage,
+  projectSessionPendingInput,
+  readSessionPendingInputByKey,
+  registerSessionPendingInputOwner,
+  releaseSessionPendingInputOwner,
+  runWithSessionPendingInput,
+  type SessionPendingInput,
+  type SessionPendingInputOwner,
+  type SessionPendingInputPage,
+  type SessionPendingInputRow,
+  type SessionPendingInputState,
+} from "./session-accessor.sqlite-pending-inputs.js";
+import {
+  getSessionKysely,
+  resolveSqliteTranscriptScope,
+  runExclusiveSqliteSessionWrite,
+  toDatabaseOptions,
+} from "./session-accessor.sqlite-scope.js";
+import {
+  readMessageIdempotencyKey,
+  readTranscriptMessageByScopedIdempotencyKey,
+  redactTranscriptMessageForStorage,
+} from "./session-accessor.sqlite-transcript-store.js";
+
+export type { SessionPendingInput, SessionPendingInputPage };
+type PendingInputScope = SessionAccessScope & { agentId: string; sessionId: string };
+export type SessionPendingInputReceipt = {
+  inputId: string;
+  message: PersistedUserTurnMessage;
+  run: <T>(operation: () => T) => T;
+  finish: (disposition: Exclude<SessionPendingInputState, "queued">) => void;
+};
+
+function ownerReceipt(owner: SessionPendingInputOwner): SessionPendingInputReceipt {
+  return {
+    inputId: owner.inputId,
+    message: parseSessionPendingInputMessage(owner.messageJson),
+    run: (operation) => runWithSessionPendingInput(owner, operation),
+    finish: owner.finish,
+  };
+}
+
+/** Accept durable input without changing the active transcript or scheduling execution. */
+export async function stageSessionPendingInput(
+  scope: PendingInputScope,
+  options: {
+    runId: string;
+    message: PersistedUserTurnMessage;
+    prepareMessageAfterIdempotencyCheck?: (
+      message: PersistedUserTurnMessage,
+    ) => PersistedUserTurnMessage | undefined;
+    config?: OpenClawConfig;
+    assertCurrent: () => void;
+  },
+): Promise<SessionPendingInputReceipt | undefined> {
+  const resolved = resolveSqliteTranscriptScope(scope);
+  const databaseOptions = toDatabaseOptions(resolved);
+  const idempotencyKey = readMessageIdempotencyKey(options.message);
+  if (!idempotencyKey || !options.runId) {
+    throw new Error("Pending input requires an exact run and message idempotency key");
+  }
+  const { timestamp: _timestamp, ...stableMessage } = options.message;
+  if (Buffer.byteLength(JSON.stringify(stableMessage), "utf8") > MAX_PAYLOAD_BYTES) {
+    throw new Error("Pending input exceeds the Gateway payload limit");
+  }
+  const requestHash = createHash("sha256").update(stableStringify(stableMessage)).digest("hex");
+  return runExclusiveSqliteSessionWrite(resolved, async () => {
+    options.assertCurrent();
+    const database = openOpenClawAgentDatabase(databaseOptions);
+    if (readSessionEntryRow(database, resolved.sessionKey)?.entry.sessionId !== scope.sessionId) {
+      return undefined;
+    }
+    const existing = readSessionPendingInputByKey(database, resolved, idempotencyKey);
+    if (existing) {
+      if (existing.request_hash !== requestHash || existing.run_id !== options.runId) {
+        throw new Error("Pending input idempotency key conflicts with the accepted input");
+      }
+      if (existing.state !== "queued" || !isSessionPendingInputRowLive(database, existing)) {
+        throw new Error("Pending input ownership ended; submit a new turn to continue");
+      }
+      throw new Error("Pending input is already admitted; wait for its current turn");
+    }
+    const committed = readTranscriptMessageByScopedIdempotencyKey(
+      database,
+      resolved,
+      idempotencyKey,
+      "scan",
+    );
+    if (committed) {
+      // Committed transcript replay keeps its existing contract and never creates new custody.
+      return {
+        inputId: committed.messageId,
+        message: parseSessionPendingInputMessage(JSON.stringify(committed.message)),
+        run: (operation) => operation(),
+        finish: () => {},
+      };
+    }
+    const prepared = options.prepareMessageAfterIdempotencyCheck
+      ? options.prepareMessageAfterIdempotencyCheck(options.message)
+      : options.message;
+    if (!prepared) {
+      return undefined;
+    }
+    const message = redactTranscriptMessageForStorage(prepared, { config: options.config });
+    const messageJson = JSON.stringify(message);
+    if (Buffer.byteLength(messageJson, "utf8") > MAX_PAYLOAD_BYTES) {
+      throw new Error("Approved pending input exceeds the Gateway payload limit");
+    }
+    const inputId = randomUUID();
+    const lifecycleGeneration = getAgentEventLifecycleGeneration();
+    ensureSessionPendingInputsSchema(database.db);
+    const inserted = runOpenClawAgentWriteTransaction((current) => {
+      options.assertCurrent();
+      if (readSessionEntryRow(current, resolved.sessionKey)?.entry.sessionId !== scope.sessionId) {
+        return false;
+      }
+      executeSqliteQuerySync(
+        current.db,
+        getSessionKysely(current.db).insertInto("session_pending_inputs").values({
+          input_id: inputId,
+          session_key: resolved.sessionKey,
+          session_id: scope.sessionId,
+          idempotency_key: idempotencyKey,
+          run_id: options.runId,
+          request_hash: requestHash,
+          message_json: messageJson,
+          lifecycle_generation: lifecycleGeneration,
+          state: "queued",
+          accepted_at: Date.now(),
+        }),
+      );
+      return true;
+    }, databaseOptions);
+    if (!inserted) {
+      return undefined;
+    }
+    let finished = false;
+    const owner: SessionPendingInputOwner = {
+      inputId,
+      sessionId: scope.sessionId,
+      sessionKey: resolved.sessionKey,
+      databasePath: database.path,
+      idempotencyKey,
+      lifecycleGeneration,
+      messageJson,
+      assertCurrent: options.assertCurrent,
+      finish: (disposition) => {
+        if (finished) {
+          return;
+        }
+        finished = true;
+        // Release authority even if recording the terminal disposition fails.
+        releaseSessionPendingInputOwner(owner);
+        runOpenClawAgentWriteTransaction((current) => {
+          executeSqliteQuerySync(
+            current.db,
+            getSessionKysely(current.db)
+              .updateTable("session_pending_inputs")
+              .set({ state: disposition })
+              .where("input_id", "=", inputId)
+              .where("state", "=", "queued"),
+          );
+        }, databaseOptions);
+      },
+    };
+    registerSessionPendingInputOwner(owner);
+    return ownerReceipt(owner);
+  });
+}
+
+/** Record lost custody at its read boundary without resuming a pre-restart execution. */
+function readPendingInputRows(
+  scope: PendingInputScope,
+  options: { limit?: number; before?: number; id?: string },
+): { rows: SessionPendingInputRow[]; total: number; nextBefore?: number } {
+  const resolved = resolveSqliteTranscriptScope(scope);
+  const databaseOptions = toDatabaseOptions(resolved);
+  const limit = Math.max(1, Math.min(20, Math.trunc(options.limit ?? 20)));
+  const result = withOpenClawAgentDatabaseReadOnly((database) => {
+    if (!hasSessionPendingInputsSchema(database.db)) {
+      return { rows: [], total: 0, staleIds: [], nextBefore: undefined };
+    }
+    const db = getSessionKysely(database.db);
+    const base = db
+      .selectFrom("session_pending_inputs")
+      .where("session_key", "=", resolved.sessionKey)
+      .where("session_id", "=", scope.sessionId);
+    const total =
+      executeSqliteQueryTakeFirstSync(
+        database.db,
+        base.select(db.fn.count<number>("input_id").as("total")),
+      )?.total ?? 0;
+    let query = base.orderBy("seq", "desc").limit(limit + 1);
+    if (options.before !== undefined) {
+      query = query.where("seq", "<", options.before);
+    }
+    if (options.id !== undefined) {
+      query = query.where("input_id", "=", options.id);
+    }
+    const metadata = executeSqliteQuerySync(
+      database.db,
+      query.select([
+        "seq",
+        /* kysely-allow-raw: Bound the page before fetching accepted message JSON. */
+        sql<number>`OCTET_LENGTH(message_json)`.as("serialized_bytes"),
+      ]),
+    ).rows;
+    const selected: number[] = [];
+    let bytes = 0;
+    for (const row of metadata) {
+      if (selected.length === limit || bytes + row.serialized_bytes > MAX_PAYLOAD_BYTES) {
+        break;
+      }
+      selected.push(row.seq);
+      bytes += row.serialized_bytes;
+    }
+    if (metadata.length && !selected.length) {
+      throw new Error("Stored pending input exceeds the Gateway payload limit");
+    }
+    const rows = selected.length
+      ? executeSqliteQuerySync(
+          database.db,
+          base.selectAll().where("seq", "in", selected).orderBy("seq", "desc"),
+        ).rows
+      : [];
+    // An aborted but registered owner still owns the terminal disposition. Reads
+    // must not race its finish(cancelled) by recording an inferred interruption.
+    const staleIds = rows
+      .filter((row) => row.state === "queued" && !hasSessionPendingInputOwner(database, row))
+      .map((row) => row.input_id);
+    return {
+      rows,
+      total,
+      staleIds,
+      nextBefore: selected.length < metadata.length ? selected.at(-1) : undefined,
+    };
+  }, databaseOptions);
+  if (!result.found) {
+    return { rows: [], total: 0 };
+  }
+  const snapshot = result.value;
+  if (snapshot.staleIds.length) {
+    const interrupted = runOpenClawAgentWriteTransaction((database) => {
+      const db = getSessionKysely(database.db);
+      const candidates = executeSqliteQuerySync(
+        database.db,
+        db
+          .selectFrom("session_pending_inputs")
+          .selectAll()
+          .where("input_id", "in", snapshot.staleIds)
+          .where("state", "=", "queued"),
+      ).rows.filter((row) => !hasSessionPendingInputOwner(database, row));
+      const ids = candidates.map((row) => row.input_id);
+      if (ids.length) {
+        executeSqliteQuerySync(
+          database.db,
+          db
+            .updateTable("session_pending_inputs")
+            .set({ state: "interrupted" })
+            .where("input_id", "in", ids),
+        );
+      }
+      return new Set(ids);
+    }, databaseOptions);
+    for (const row of snapshot.rows) {
+      if (interrupted.has(row.input_id)) {
+        row.state = "interrupted";
+      }
+    }
+  }
+  return { rows: snapshot.rows, total: snapshot.total, nextBefore: snapshot.nextBefore };
+}
+
+export function listSessionPendingInputs(
+  scope: PendingInputScope,
+  options: { limit?: number; before?: number } = {},
+): SessionPendingInputPage {
+  const { rows, total, nextBefore } = readPendingInputRows(scope, options);
+  return {
+    items: rows.toReversed().map(projectSessionPendingInput),
+    total,
+    ...(nextBefore !== undefined ? { nextBefore } : {}),
+  };
+}
+
+export function readSessionPendingInput(
+  scope: PendingInputScope,
+  id: string,
+): SessionPendingInput | undefined {
+  const row = readPendingInputRows(scope, { id, limit: 1 }).rows[0];
+  return row ? projectSessionPendingInput(row) : undefined;
+}

--- a/src/config/sessions/session-accessor.sqlite-node-artifacts.ts
+++ b/src/config/sessions/session-accessor.sqlite-node-artifacts.ts
@@ -6,6 +6,10 @@ import {
 import type { OpenClawAgentDatabase } from "../../state/openclaw-agent-db.js";
 import { ensureOpenClawAgentProgressCardSchemaInTransaction } from "../../state/openclaw-agent-progress-card-schema.js";
 import { ensureSessionParticipantsSchema } from "../../state/openclaw-agent-session-participants-schema.js";
+import {
+  copySessionPendingInputsForRepair,
+  deleteSessionPendingInputs,
+} from "./session-accessor.sqlite-pending-inputs.js";
 import { getSessionKysely } from "./session-accessor.sqlite-scope.js";
 import { mergeParticipantAggregate } from "./session-participant-identity.js";
 import { normalizeStoreSessionKey } from "./store-entry.js";
@@ -43,6 +47,7 @@ export function copySessionNodeArtifactsForRepair(
   if (keys.length === 0) {
     return;
   }
+  copySessionPendingInputsForRepair(source, destination, keys, canonicalKey);
   const sourceDb = getSessionKysely(source.db);
   const destinationDb = getSessionKysely(destination.db);
   const sourceKeyReferences = new Set(keys.flatMap((key) => [key, key.trim()]));
@@ -320,6 +325,7 @@ export function deleteSessionNodeArtifacts(
   database: OpenClawAgentDatabase,
   sessionKey: string,
 ): void {
+  deleteSessionPendingInputs(database, sessionKey);
   const db = getSessionKysely(database.db);
   const presentTables = readSessionNodeArtifactTables(database);
   if (presentTables.has("board_tabs") && presentTables.has("board_widgets")) {

--- a/src/config/sessions/session-accessor.sqlite-pending-inputs.ts
+++ b/src/config/sessions/session-accessor.sqlite-pending-inputs.ts
@@ -1,0 +1,342 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+import { asOptionalRecord } from "@openclaw/normalization-core/record-coerce";
+import type { Selectable } from "kysely";
+import {
+  isAgentEventLifecycleGenerationCurrent,
+  registerAgentEventLifecycleRotationHandler,
+} from "../../infra/agent-events.js";
+import {
+  executeSqliteQuerySync,
+  executeSqliteQueryTakeFirstSync,
+} from "../../infra/kysely-sync.js";
+import type { PersistedUserTurnMessage } from "../../sessions/user-turn-transcript.types.js";
+import { resolveGlobalSingleton } from "../../shared/global-singleton.js";
+import type { SessionPendingInputs } from "../../state/openclaw-agent-db.generated.js";
+import type { OpenClawAgentDatabase } from "../../state/openclaw-agent-db.js";
+import {
+  ensureSessionPendingInputsSchema,
+  hasSessionPendingInputsSchema,
+} from "../../state/openclaw-agent-pending-inputs-schema.js";
+import { getSessionKysely, type ResolvedTranscriptScope } from "./session-accessor.sqlite-scope.js";
+
+export type SessionPendingInputState = "queued" | "interrupted" | "cancelled";
+export type SessionPendingInput = {
+  id: string;
+  runId: string;
+  message: PersistedUserTurnMessage;
+  acceptedAt: number;
+  state: SessionPendingInputState;
+};
+export type SessionPendingInputPage = {
+  items: SessionPendingInput[];
+  total: number;
+  nextBefore?: number;
+};
+export type SessionPendingInputRow = Selectable<SessionPendingInputs>;
+type PendingInputDatabase = Pick<OpenClawAgentDatabase, "db" | "path">;
+
+export type SessionPendingInputOwner = {
+  inputId: string;
+  sessionId: string;
+  sessionKey: string;
+  databasePath: string;
+  idempotencyKey: string;
+  lifecycleGeneration: string;
+  messageJson: string;
+  assertCurrent: () => void;
+  finish: (disposition: Exclude<SessionPendingInputState, "queued">) => void;
+};
+
+const owners = resolveGlobalSingleton(Symbol.for("openclaw.sessionPendingInputOwners"), () => ({
+  live: new Map<string, SessionPendingInputOwner>(),
+  current: new AsyncLocalStorage<SessionPendingInputOwner>(),
+}));
+
+registerAgentEventLifecycleRotationHandler("session-pending-inputs", () => {
+  const failures: unknown[] = [];
+  for (const owner of owners.live.values()) {
+    try {
+      owner.finish("interrupted");
+    } catch (error) {
+      failures.push(error);
+    }
+  }
+  if (failures.length) {
+    throw new AggregateError(failures, "Failed to record interrupted pending inputs");
+  }
+});
+
+export function registerSessionPendingInputOwner(owner: SessionPendingInputOwner): void {
+  if (owners.live.has(owner.inputId)) {
+    throw new Error("Pending input already has a live owner");
+  }
+  owners.live.set(owner.inputId, owner);
+}
+
+export function releaseSessionPendingInputOwner(owner: SessionPendingInputOwner): void {
+  if (owners.live.get(owner.inputId) === owner) {
+    owners.live.delete(owner.inputId);
+  }
+}
+
+function assertPendingInputOwnerCurrent(owner: SessionPendingInputOwner): void {
+  if (
+    owners.live.get(owner.inputId) !== owner ||
+    !isAgentEventLifecycleGenerationCurrent(owner.lifecycleGeneration)
+  ) {
+    throw new Error("Pending input ownership ended; submit a new turn to continue");
+  }
+  owner.assertCurrent();
+}
+
+export function runWithSessionPendingInput<T>(owner: SessionPendingInputOwner, run: () => T): T {
+  assertPendingInputOwnerCurrent(owner);
+  return owners.current.run(owner, run);
+}
+
+export function isSessionPendingInputRowLive(
+  database: PendingInputDatabase,
+  row: SessionPendingInputRow,
+): boolean {
+  const owner = readSessionPendingInputOwner(database, row);
+  if (!owner) {
+    return false;
+  }
+  try {
+    assertPendingInputOwnerCurrent(owner);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function hasSessionPendingInputOwner(
+  database: PendingInputDatabase,
+  row: SessionPendingInputRow,
+): boolean {
+  return readSessionPendingInputOwner(database, row) !== undefined;
+}
+
+function readSessionPendingInputOwner(
+  database: PendingInputDatabase,
+  row: SessionPendingInputRow,
+): SessionPendingInputOwner | undefined {
+  const owner = owners.live.get(row.input_id);
+  if (
+    !owner ||
+    owner.databasePath !== database.path ||
+    owner.sessionId !== row.session_id ||
+    owner.sessionKey !== row.session_key ||
+    owner.lifecycleGeneration !== row.lifecycle_generation ||
+    !isAgentEventLifecycleGenerationCurrent(owner.lifecycleGeneration)
+  ) {
+    return undefined;
+  }
+  const session = executeSqliteQueryTakeFirstSync(
+    database.db,
+    getSessionKysely(database.db)
+      .selectFrom("session_nodes")
+      .select("current_session_id")
+      .where("session_key", "=", row.session_key),
+  );
+  if (session?.current_session_id !== row.session_id) {
+    return undefined;
+  }
+  return owner;
+}
+
+export function parseSessionPendingInputMessage(messageJson: string): PersistedUserTurnMessage {
+  const value: unknown = JSON.parse(messageJson);
+  if (asOptionalRecord(value)?.role !== "user") {
+    throw new Error("Pending input has an invalid persisted user message");
+  }
+  // SAFETY: only typed admission writes this JSON; parsing preserves its canonical message shape.
+  return value as PersistedUserTurnMessage;
+}
+
+export function projectSessionPendingInput(row: SessionPendingInputRow): SessionPendingInput {
+  if (row.state !== "queued" && row.state !== "interrupted" && row.state !== "cancelled") {
+    throw new Error("Pending input has an invalid disposition");
+  }
+  return {
+    id: row.input_id,
+    runId: row.run_id,
+    message: parseSessionPendingInputMessage(row.message_json),
+    acceptedAt: row.accepted_at,
+    state: row.state,
+  };
+}
+
+/** Query only the exact physical transcript; copied keys cannot adopt another generation. */
+export function readSessionPendingInputByKey(
+  database: PendingInputDatabase,
+  scope: Pick<ResolvedTranscriptScope, "sessionId" | "sessionKey">,
+  idempotencyKey: string,
+): SessionPendingInputRow | undefined {
+  if (!hasSessionPendingInputsSchema(database.db)) {
+    return undefined;
+  }
+  return executeSqliteQueryTakeFirstSync(
+    database.db,
+    getSessionKysely(database.db)
+      .selectFrom("session_pending_inputs")
+      .selectAll()
+      .where("session_id", "=", scope.sessionId)
+      .where("session_key", "=", scope.sessionKey)
+      .where("idempotency_key", "=", idempotencyKey),
+  );
+}
+
+export type SessionPendingInputAppend = {
+  inputId: string;
+  message: PersistedUserTurnMessage;
+  alreadyPromoted: boolean;
+};
+
+/** The private call-path owner, not a copied id or durable row, permits promotion. */
+export function resolveSessionPendingInputAppend(
+  database: PendingInputDatabase,
+  scope: ResolvedTranscriptScope,
+  message: unknown,
+): SessionPendingInputAppend | undefined {
+  const record = asOptionalRecord(message);
+  if (record?.role !== "user" || typeof record.idempotencyKey !== "string") {
+    return undefined;
+  }
+  const idempotencyKey = record.idempotencyKey.trim();
+  const row = readSessionPendingInputByKey(database, scope, idempotencyKey);
+  const owner = owners.current.getStore();
+  const ownsInput = owner?.idempotencyKey === idempotencyKey;
+  if (!row && !ownsInput) {
+    return undefined;
+  }
+  if (
+    !owner ||
+    !ownsInput ||
+    owner.databasePath !== database.path ||
+    owner.sessionId !== scope.sessionId ||
+    owner.sessionKey !== scope.sessionKey ||
+    (row &&
+      (row.input_id !== owner.inputId ||
+        row.state !== "queued" ||
+        row.lifecycle_generation !== owner.lifecycleGeneration))
+  ) {
+    throw new Error("Pending input cannot be appended outside its admitted turn");
+  }
+  // Terminal mirroring may replay a consumed input after cancellation. The caller
+  // must prove the existing message; this never permits a new append.
+  if (row) {
+    assertPendingInputOwnerCurrent(owner);
+  }
+  return {
+    inputId: owner.inputId,
+    message: parseSessionPendingInputMessage(row?.message_json ?? owner.messageJson),
+    alreadyPromoted: !row,
+  };
+}
+
+export function consumeSessionPendingInput(
+  database: PendingInputDatabase,
+  pending: SessionPendingInputAppend,
+): void {
+  if (!pending.alreadyPromoted) {
+    executeSqliteQuerySync(
+      database.db,
+      getSessionKysely(database.db)
+        .deleteFrom("session_pending_inputs")
+        .where("input_id", "=", pending.inputId)
+        .where("state", "=", "queued"),
+    );
+  }
+}
+
+/** Logical deletion also clears custody when transcript windows are retained. */
+export function deleteSessionPendingInputs(
+  database: PendingInputDatabase,
+  sessionKey: string,
+): void {
+  if (hasSessionPendingInputsSchema(database.db)) {
+    executeSqliteQuerySync(
+      database.db,
+      getSessionKysely(database.db)
+        .deleteFrom("session_pending_inputs")
+        .where("session_key", "=", sessionKey),
+    );
+  }
+}
+
+/** Canonical repair preserves accepted text without transferring its old execution authority. */
+export function copySessionPendingInputsForRepair(
+  source: PendingInputDatabase,
+  destination: PendingInputDatabase,
+  sourceKeys: readonly string[],
+  canonicalKey: string,
+): void {
+  if (!hasSessionPendingInputsSchema(source.db)) {
+    return;
+  }
+  const rows = executeSqliteQuerySync(
+    source.db,
+    getSessionKysely(source.db)
+      .selectFrom("session_pending_inputs")
+      .selectAll()
+      .where("session_key", "in", sourceKeys)
+      .orderBy("seq", "asc"),
+  ).rows;
+  if (!rows.length) {
+    return;
+  }
+  ensureSessionPendingInputsSchema(destination.db);
+  const db = getSessionKysely(destination.db);
+  for (const row of rows) {
+    if (source.db === destination.db) {
+      executeSqliteQuerySync(
+        destination.db,
+        db
+          .updateTable("session_pending_inputs")
+          .set({
+            session_key: canonicalKey,
+            state: row.state === "cancelled" ? "cancelled" : "interrupted",
+          })
+          .where("input_id", "=", row.input_id),
+      );
+      continue;
+    }
+    const existing = readSessionPendingInputByKey(
+      destination,
+      { sessionKey: canonicalKey, sessionId: row.session_id },
+      row.idempotency_key,
+    );
+    if (existing) {
+      if (
+        existing.request_hash !== row.request_hash ||
+        existing.message_json !== row.message_json ||
+        existing.run_id !== row.run_id
+      ) {
+        throw new Error("Canonical repair found conflicting accepted inputs");
+      }
+      executeSqliteQuerySync(
+        destination.db,
+        db
+          .updateTable("session_pending_inputs")
+          .set({
+            state:
+              existing.state === "cancelled" || row.state === "cancelled"
+                ? "cancelled"
+                : "interrupted",
+          })
+          .where("input_id", "=", existing.input_id),
+      );
+      continue;
+    }
+    const { seq: _seq, ...record } = row;
+    executeSqliteQuerySync(
+      destination.db,
+      db.insertInto("session_pending_inputs").values({
+        ...record,
+        session_key: canonicalKey,
+        state: row.state === "cancelled" ? "cancelled" : "interrupted",
+      }),
+    );
+  }
+}

--- a/src/config/sessions/session-accessor.sqlite-scope.ts
+++ b/src/config/sessions/session-accessor.sqlite-scope.ts
@@ -43,6 +43,7 @@ type SessionSqliteDatabase = Pick<
   | "session_members"
   | "session_nodes"
   | "session_participants"
+  | "session_pending_inputs"
   | "session_progress_cards"
   | "session_suggestions"
   | "session_transcript_archives"

--- a/src/config/sessions/session-accessor.sqlite-transcript-anchor.ts
+++ b/src/config/sessions/session-accessor.sqlite-transcript-anchor.ts
@@ -10,6 +10,7 @@ import {
   type ResolvedTranscriptScope,
 } from "./session-accessor.sqlite-scope.js";
 import { readMessageIdempotencyKey } from "./session-accessor.sqlite-transcript-store.js";
+import { sessionTranscriptIndexNeedsReconcile } from "./session-transcript-index.js";
 import type { TranscriptEntryAnchor } from "./transcript-entry-anchor.js";
 
 /** Reads one active message identity from the caller's current SQLite transaction. */
@@ -19,6 +20,11 @@ export function readActiveTranscriptEntryAnchorInTransaction(params: {
   entryId: string;
   message?: unknown;
 }): TranscriptEntryAnchor | undefined {
+  // Branch changes retain old projection rows until deferred reconciliation.
+  // An anchor must never certify those rows as the current active path.
+  if (sessionTranscriptIndexNeedsReconcile(params.database.db, params.resolved.sessionId)) {
+    return undefined;
+  }
   const db = getSessionKysely(params.database.db);
   const row = executeSqliteQueryTakeFirstSync(
     params.database.db,

--- a/src/config/sessions/session-accessor.sqlite-transcript-message-append.ts
+++ b/src/config/sessions/session-accessor.sqlite-transcript-message-append.ts
@@ -7,6 +7,11 @@ import type {
   TranscriptMessageAppendOptions,
   TranscriptMessageAppendResult,
 } from "./session-accessor.sqlite-contract.js";
+import { readSessionEntryRow } from "./session-accessor.sqlite-entry-store.js";
+import {
+  consumeSessionPendingInput,
+  resolveSessionPendingInputAppend,
+} from "./session-accessor.sqlite-pending-inputs.js";
 import type { ResolvedTranscriptScope } from "./session-accessor.sqlite-scope.js";
 import { readActiveTranscriptEntryAnchorInTransaction } from "./session-accessor.sqlite-transcript-anchor.js";
 import { resolveTranscriptMessageAppendParent } from "./session-accessor.sqlite-transcript-parent.js";
@@ -44,6 +49,13 @@ export function appendTranscriptMessageInTransaction<TMessage>(
   resolved: ResolvedTranscriptScope,
   options: TranscriptMessageAppendOptions<TMessage> & { messageAlreadyRedacted?: boolean },
 ): TranscriptMessageAppendResult<TMessage> | undefined {
+  const pending = resolveSessionPendingInputAppend(database, resolved, options.message);
+  if (
+    pending &&
+    readSessionEntryRow(database, resolved.sessionKey)?.entry.sessionId !== resolved.sessionId
+  ) {
+    throw new Error("Pending input session changed before transcript promotion");
+  }
   const serializeForStorage = (message: TMessage): TMessage =>
     options.messageAlreadyRedacted ? message : redactTranscriptMessageForStorage(message, options);
   const readAnchor = (params: {
@@ -58,6 +70,20 @@ export function appendTranscriptMessageInTransaction<TMessage>(
     });
   const existingAppendResult = (found: { message: unknown; messageId: string }) => {
     const anchor = readAnchor(found);
+    if (pending) {
+      if (
+        found.messageId !== pending.inputId ||
+        !messagesMatchForIdempotentReplay(found.message, pending.message)
+      ) {
+        throw new TranscriptTurnAdmissionConflictError(pending.inputId);
+      }
+      // A consumed receipt permits terminal mirroring only while its exact user
+      // remains on the active path; it cannot revive a replaced transcript branch.
+      if (!anchor) {
+        throw new Error("Pending input is no longer active in its admitted transcript");
+      }
+      consumeSessionPendingInput(database, pending);
+    }
     return {
       appended: false as const,
       ...(anchor ? { anchor } : {}),
@@ -87,16 +113,26 @@ export function appendTranscriptMessageInTransaction<TMessage>(
     }
   }
 
-  const prepared = options.prepareMessageAfterIdempotencyCheck
-    ? options.prepareMessageAfterIdempotencyCheck(options.message)
-    : options.message;
+  if (pending?.alreadyPromoted) {
+    const committed = readTranscriptMessageByEventId(database, resolved, pending.inputId);
+    if (!committed) {
+      throw new Error("Pending input custody ended before transcript promotion");
+    }
+    return existingAppendResult(committed);
+  }
+  // Pending input already passed the hook and redaction before acknowledgment.
+  const prepared = pending
+    ? (pending.message as TMessage) // SAFETY: exact private custody supplies this keyed user's approved storage bytes.
+    : options.prepareMessageAfterIdempotencyCheck
+      ? options.prepareMessageAfterIdempotencyCheck(options.message)
+      : options.message;
   if (prepared === undefined) {
     return undefined;
   }
 
-  const messageId = options.eventId ?? randomUUID();
+  const messageId = pending?.inputId ?? options.eventId ?? randomUUID();
   const now = options.now ?? Date.now();
-  const finalMessage = serializeForStorage(prepared);
+  const finalMessage = pending ? prepared : serializeForStorage(prepared);
   ensureTranscriptHeader(database, resolved, options.cwd);
   const parentId = resolveTranscriptMessageAppendParent(database, resolved.sessionId, options);
   const event = {
@@ -144,6 +180,9 @@ export function appendTranscriptMessageInTransaction<TMessage>(
     throw new Error(`SQLite transcript append did not insert message ${messageId}.`);
   }
   const anchor = readAnchor({ message: finalMessage, messageId });
+  if (pending) {
+    consumeSessionPendingInput(database, pending);
+  }
   return {
     appended: true,
     ...(anchor ? { anchor } : {}),

--- a/src/config/sessions/session-accessor.ts
+++ b/src/config/sessions/session-accessor.ts
@@ -5,6 +5,14 @@
  * Runtime callers import this barrel instead of storage-specific modules.
  */
 export * from "./session-history.js";
+export {
+  listSessionPendingInputs,
+  readSessionPendingInput,
+  stageSessionPendingInput,
+  type SessionPendingInput,
+  type SessionPendingInputPage,
+  type SessionPendingInputReceipt,
+} from "./session-accessor.pending-inputs.js";
 export type {
   BranchSessionFromCompactionCheckpointParams,
   DeleteSessionEntryLifecycleParams,

--- a/src/gateway/agent-turn/agent-run-admission-phase.ts
+++ b/src/gateway/agent-turn/agent-run-admission-phase.ts
@@ -30,6 +30,7 @@ import { resolveEffectiveAgentRuntime } from "../../agents/thinking-runtime.js";
 import { resolveAgentTimeoutMs } from "../../agents/timeout.js";
 import type { SessionEntry } from "../../config/sessions.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { assertAgentRunLifecycleGenerationCurrent } from "../../infra/agent-events.js";
 import { claimAgentRunContext } from "../../infra/agent-run-registry.js";
 import type { InputProvenance } from "../../sessions/input-provenance.js";
 import type { SessionWorkAdmissionLease } from "../../sessions/session-lifecycle-admission.js";
@@ -554,6 +555,19 @@ export async function prepareAgentRunDispatch(params: {
   let userTurn: PreparedAgentRunUserTurn;
   try {
     userTurn = await prepareAgentRunUserTurn({
+      assertCurrent: () => {
+        assertAgentRunLifecycleGenerationCurrent(params.lifecycleGeneration);
+        activeRunAbort.controller.signal.throwIfAborted();
+        const entry = params.context.chatAbortControllers.get(params.runId);
+        if (
+          !entry ||
+          entry !== activeRunAbort.entry ||
+          entry.operationalRunInstance !== operationalRunInstance ||
+          entry.registrationCleanupRequested
+        ) {
+          throw new Error("agent input admission no longer owns this run");
+        }
+      },
       request: params.request,
       cfg: params.cfg,
       cfgForAgent: params.cfgForAgent,
@@ -578,8 +592,8 @@ export async function prepareAgentRunDispatch(params: {
       context: params.context,
     });
     if (userTurn.recorder) {
-      // The recorder already persisted the media references, so later admission
-      // rejection must preserve the files now owned by durable history.
+      // Accepted input owns these media references before it enters the transcript.
+      // Later admission rejection must preserve the files retained by that custody.
       params.onUserTurnMediaPersisted();
     }
   } catch (err) {

--- a/src/gateway/agent-turn/agent-run-execution-phase.ts
+++ b/src/gateway/agent-turn/agent-run-execution-phase.ts
@@ -117,6 +117,19 @@ export function startAgentRunExecution(params: {
   const cleanupAdmittedRun: typeof prepared.activeRunAbort.cleanup = (options) => {
     const refsToDiscard = unpersistedOffloadedRefs;
     unpersistedOffloadedRefs = [];
+    try {
+      releasePreparedAgentRunUserTurn(
+        prepared.userTurn,
+        prepared.activeRunAbort.controller.signal.aborted &&
+          prepared.activeRunAbort.entry?.abortStopReason !== "restart"
+          ? "cancelled"
+          : "interrupted",
+      );
+    } catch (error) {
+      params.context.logGateway.warn(
+        `failed to settle pending agent input: ${formatForLog(error)}`,
+      );
+    }
     prepared.activeRunAbort.cleanup(options);
     prepared.activeGatewayWorkAdmission.release();
     const runtimeLease = preparedModelRuntimeLease;
@@ -125,13 +138,26 @@ export function startAgentRunExecution(params: {
     releaseGatewayRootContinuation?.();
     releaseGatewayRootContinuation = undefined;
     void discardPreparedInboundMedia(refsToDiscard, params.context.logGateway);
+    if (prepared.userTurn.recorder && params.resolvedSessionKey) {
+      emitSessionsChanged(params.context, {
+        sessionKey: params.resolvedSessionKey,
+        agentId: params.activeSessionAgentId,
+        reason: "agent.input.settled",
+      });
+    }
   };
-  const dispatchAdmittedAgentRun = (dispatch: Parameters<typeof dispatchAgentRunFromGateway>[0]) =>
-    withPreparedModelRuntimePluginGenerationScope(
-      prepared.replyDispatchRuntime.pluginGeneration,
-      () => dispatchAgentRunFromGateway(dispatch),
-      () => preparedModelRuntimeLease?.snapshot,
-    );
+  const dispatchAdmittedAgentRun = (
+    dispatch: Parameters<typeof dispatchAgentRunFromGateway>[0],
+  ) => {
+    const run = () =>
+      withPreparedModelRuntimePluginGenerationScope(
+        prepared.replyDispatchRuntime.pluginGeneration,
+        () => dispatchAgentRunFromGateway(dispatch),
+        () => preparedModelRuntimeLease?.snapshot,
+      );
+    const recorder = prepared.userTurn.recorder;
+    return recorder?.withPendingInput ? recorder.withPendingInput(run) : run();
+  };
   void prepared.activeGatewayWorkAdmission.run(async () => {
     await yieldAfterAgentAcceptedAck();
     let dispatched = false;
@@ -488,7 +514,6 @@ export function startAgentRunExecution(params: {
       });
     } finally {
       if (!dispatched) {
-        releasePreparedAgentRunUserTurn(prepared.userTurn);
         try {
           const restoreAdmittedRecovery = prepared.restoreAdmittedRestartRecoveryInterrupted;
           if (restoreAdmittedRecovery) {

--- a/src/gateway/agent-turn/agent-run-user-turn.test.ts
+++ b/src/gateway/agent-turn/agent-run-user-turn.test.ts
@@ -68,6 +68,7 @@ describe("prepareAgentRunUserTurn", () => {
 
     await expect(
       prepareAgentRunUserTurn({
+        assertCurrent: () => {},
         request: {
           message: "must not reach the stale session",
           idempotencyKey: "disappeared-session-run",

--- a/src/gateway/agent-turn/agent-run-user-turn.ts
+++ b/src/gateway/agent-turn/agent-run-user-turn.ts
@@ -52,6 +52,7 @@ export type PreparedAgentRunUserTurn = {
 };
 
 export async function prepareAgentRunUserTurn(params: {
+  assertCurrent: () => void;
   request: AgentRunRequest;
   cfg: OpenClawConfig;
   cfgForAgent?: OpenClawConfig;
@@ -202,7 +203,12 @@ export async function prepareAgentRunUserTurn(params: {
           );
         },
       });
-      if (!(await recorder.persistApproved())) {
+      if (
+        !(await recorder.stageApproved!({
+          runId: params.runId,
+          assertCurrent: params.assertCurrent,
+        }))
+      ) {
         throw new Error("agent turn was not durably admitted");
       }
     }
@@ -247,9 +253,16 @@ export function finalizePreparedAgentRunUserTurn(prepared: PreparedAgentRunUserT
   }
 }
 
-export function releasePreparedAgentRunUserTurn(prepared: PreparedAgentRunUserTurn): void {
-  releaseExecApprovalFollowupRuntimeHandoff({
-    handoffId: prepared.claimedExecApprovalFollowupHandoffId,
-    claimId: prepared.execApprovalFollowupHandoffClaimId,
-  });
+export function releasePreparedAgentRunUserTurn(
+  prepared: PreparedAgentRunUserTurn,
+  disposition: "cancelled" | "interrupted" = "interrupted",
+): void {
+  try {
+    prepared.recorder?.finishPendingInput?.(disposition);
+  } finally {
+    releaseExecApprovalFollowupRuntimeHandoff({
+      handoffId: prepared.claimedExecApprovalFollowupHandoffId,
+      claimId: prepared.execApprovalFollowupHandoffClaimId,
+    });
+  }
 }

--- a/src/gateway/server-methods/agent.base.test-utils.ts
+++ b/src/gateway/server-methods/agent.base.test-utils.ts
@@ -1187,8 +1187,19 @@ describe("gateway agent handler", () => {
     expect(store["agent:main:main"]).toBeUndefined();
   });
 
-  it("does not re-persist an admitted gateway user turn after the session key is rebound", async () => {
+  it("does not re-persist a committed gateway user turn after the session key is rebound", async () => {
     primeMainAgentRun({ sessionId: "accepted-session-id" });
+    mocks.agentCommand.mockImplementationOnce(
+      async (opts: {
+        userTurnTranscriptRecorder?: { persistApproved: () => Promise<unknown> };
+      }) => {
+        await requireValue(
+          opts.userTurnTranscriptRecorder,
+          "user turn recorder missing",
+        ).persistApproved();
+        return { payloads: [{ text: "ok" }], meta: { durationMs: 100 } };
+      },
+    );
 
     await runMainAgent("stale after reset", "idem-user-turn-rebound");
 
@@ -1271,7 +1282,7 @@ describe("gateway agent handler", () => {
       const call = await waitForAgentCommandCall<
         AgentCommandCall & {
           userTurnTranscriptRecorder?: {
-            getPersistedMessage: () => { __openclaw?: Record<string, unknown> } | undefined;
+            message?: { __openclaw?: Record<string, unknown> };
             hasPersisted: () => boolean;
           };
         }
@@ -1282,8 +1293,9 @@ describe("gateway agent handler", () => {
           mimeType: "image/png",
         }),
       ]);
-      expect(call.userTurnTranscriptRecorder?.hasPersisted()).toBe(true);
-      expect(call.userTurnTranscriptRecorder?.getPersistedMessage()?.["__openclaw"]).toMatchObject({
+      expect(call.userTurnTranscriptRecorder?.hasPersisted()).toBe(false);
+      expect(mocks.persistSessionTranscriptTurn).not.toHaveBeenCalled();
+      expect(call.userTurnTranscriptRecorder?.message?.["__openclaw"]).toMatchObject({
         media: [expect.objectContaining({ contentType: "image/png", kind: "image" })],
         mediaImageLayout: { slots: [{ kind: "inline", factIndex: 0 }] },
       });
@@ -1339,7 +1351,7 @@ describe("gateway agent handler", () => {
       const call = await waitForAgentCommandCall<
         AgentCommandCall & {
           userTurnTranscriptRecorder?: {
-            getPersistedMessage: () => { __openclaw?: Record<string, unknown> } | undefined;
+            message?: { __openclaw?: Record<string, unknown> };
             hasPersisted: () => boolean;
           };
         }
@@ -1347,8 +1359,9 @@ describe("gateway agent handler", () => {
       expect(call.images).toEqual([]);
       expect(call.imageOrder).toEqual(["offloaded"]);
       expect(call.message).toContain("[media attached: media://inbound/");
-      expect(call.userTurnTranscriptRecorder?.hasPersisted()).toBe(true);
-      expect(call.userTurnTranscriptRecorder?.getPersistedMessage()?.["__openclaw"]).toMatchObject({
+      expect(call.userTurnTranscriptRecorder?.hasPersisted()).toBe(false);
+      expect(mocks.persistSessionTranscriptTurn).not.toHaveBeenCalled();
+      expect(call.userTurnTranscriptRecorder?.message?.["__openclaw"]).toMatchObject({
         media: [expect.objectContaining({ contentType: "image/png", kind: "image" })],
         mediaImageLayout: { slots: [{ kind: "offloaded", factIndex: 0 }] },
       });

--- a/src/gateway/server-methods/agent.events-and-subagents.test-utils.ts
+++ b/src/gateway/server-methods/agent.events-and-subagents.test-utils.ts
@@ -1099,13 +1099,13 @@ describe("gateway agent handler", () => {
       lastChannel: "telegram",
       lastTo: "123",
     });
-    const persistTranscriptTurn = mocks.persistSessionTranscriptTurn.getMockImplementation();
-    if (!persistTranscriptTurn) {
-      throw new Error("expected transcript persistence implementation");
+    const stagePendingInput = mocks.stageSessionPendingInput.getMockImplementation();
+    if (!stagePendingInput) {
+      throw new Error("expected pending input staging implementation");
     }
-    mocks.persistSessionTranscriptTurn.mockImplementationOnce(async (...args) => {
+    mocks.stageSessionPendingInput.mockImplementationOnce(async (...args) => {
       await vi.advanceTimersByTimeAsync(5 * 60 * 1000 + 1);
-      return await persistTranscriptTurn(...args);
+      return await stagePendingInput(...args);
     });
     mocks.agentCommand.mockResolvedValue({
       payloads: [{ text: "must not dispatch" }],

--- a/src/gateway/server-methods/agent.sessions-and-models.test-utils.ts
+++ b/src/gateway/server-methods/agent.sessions-and-models.test-utils.ts
@@ -1747,7 +1747,7 @@ describe("gateway agent handler", () => {
       vi.advanceTimersByTime(100);
       expect(broadcastToConnIds.mock.calls.map((callValue) => callValue[1]?.reason)).toEqual([
         "create",
-        "send",
+        "agent.input.settled",
       ]);
     } finally {
       vi.useRealTimers();
@@ -2098,7 +2098,7 @@ describe("gateway agent handler", () => {
       vi.advanceTimersByTime(100);
       expect(broadcastToConnIds.mock.calls.map((callLocal) => callLocal[1]?.reason)).toEqual([
         "create",
-        "send",
+        "agent.input.settled",
       ]);
     } finally {
       vi.useRealTimers();

--- a/src/gateway/server-methods/agent.test-harness.ts
+++ b/src/gateway/server-methods/agent.test-harness.ts
@@ -13,6 +13,7 @@ import type {
   SessionTranscriptStats,
   recordSessionParticipant,
   listSessionParticipantsReadOnly,
+  stageSessionPendingInput,
 } from "../../config/sessions/session-accessor.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { resetDiagnosticEventsForTest } from "../../infra/diagnostic-events.js";
@@ -44,6 +45,7 @@ const mocks = vi.hoisted(() => ({
   applySessionEntryReplacements: vi.fn(),
   patchSessionEntryTarget: vi.fn(),
   persistSessionTranscriptTurn: vi.fn(),
+  stageSessionPendingInput: vi.fn<typeof stageSessionPendingInput>(),
   recordSessionParticipant: vi.fn<typeof recordSessionParticipant>(() => "inserted"),
   listSessionParticipantsReadOnly: vi.fn<typeof listSessionParticipantsReadOnly>(() => new Map()),
   readTranscriptStatsSync: vi.fn<() => SessionTranscriptStats>(() => ({
@@ -152,6 +154,7 @@ vi.mock("../../config/sessions/session-accessor.js", async () => {
     applySessionEntryReplacements: mocks.applySessionEntryReplacements,
     patchSessionEntryTarget: mocks.patchSessionEntryTarget,
     persistSessionTranscriptTurn: mocks.persistSessionTranscriptTurn,
+    stageSessionPendingInput: mocks.stageSessionPendingInput,
     // These handler fixtures own an in-memory store; participant access must not reach shared /tmp SQLite.
     recordSessionParticipant: mocks.recordSessionParticipant,
     listSessionParticipantsReadOnly: mocks.listSessionParticipantsReadOnly,
@@ -601,6 +604,22 @@ function selectFreshestTargetFixtureEntry(
 }
 
 function resetSessionAccessorMocks() {
+  // These handler fixtures own an in-memory store. Real admission durability
+  // and execution-time promotion are covered by the gateway-server suites.
+  mocks.stageSessionPendingInput.mockReset().mockImplementation(async (_scope, options) => {
+    options.assertCurrent();
+    const message = options.prepareMessageAfterIdempotencyCheck
+      ? options.prepareMessageAfterIdempotencyCheck(options.message)
+      : options.message;
+    return message
+      ? {
+          inputId: "test-user-turn",
+          message,
+          run: (operation) => operation(),
+          finish: vi.fn(),
+        }
+      : undefined;
+  });
   mocks.recordSessionParticipant.mockReset().mockReturnValue("inserted");
   mocks.listSessionParticipantsReadOnly.mockReset().mockReturnValue(new Map());
   mocks.readTranscriptStatsSync.mockReset().mockReturnValue({

--- a/src/gateway/server-methods/chat-history-handler.ts
+++ b/src/gateway/server-methods/chat-history-handler.ts
@@ -59,6 +59,7 @@ import {
   shouldReplayOldestChatHistoryRecord,
 } from "./chat-history-pages.js";
 import { resolveRequestedChatAgentId, validateChatSelectedAgent } from "./chat-origin-routing.js";
+import { readChatPendingInputs } from "./chat-pending-inputs.js";
 import { normalizeOptionalChatText as normalizeOptionalText } from "./chat-text-normalization.js";
 import { resolveVisibleActiveSessionRunState } from "./session-active-runs.js";
 import { readSessionPlacementFields } from "./session-placement-read-projection.js";
@@ -183,6 +184,7 @@ async function handleChatHistoryRequest({
     messageId,
     sessionId: requestedSessionId,
     maxChars,
+    pendingBefore,
   } = params as {
     sessionKey: string;
     agentId?: string;
@@ -192,6 +194,7 @@ async function handleChatHistoryRequest({
     messageId?: string;
     sessionId?: string;
     maxChars?: number;
+    pendingBefore?: number;
   };
   if (offset !== undefined && messageId !== undefined) {
     respond(
@@ -318,6 +321,18 @@ async function handleChatHistoryRequest({
   const max = Math.min(CHAT_HISTORY_MAX_ENTRIES, requested);
   const maxHistoryBytes = getMaxChatHistoryMessagesBytes();
   const effectiveMaxChars = resolveEffectiveChatHistoryMaxChars(cfg, maxChars);
+  const pendingInputs =
+    sessionId && sessionId === entry?.sessionId
+      ? readChatPendingInputs(
+          {
+            agentId: sessionAgentId,
+            sessionKey: canonicalKey,
+            sessionId,
+            storePath,
+          },
+          { before: pendingBefore, limit: max, maxChars: effectiveMaxChars },
+        )
+      : { items: [], total: 0 };
   let historyPage: Awaited<ReturnType<typeof readChatHistoryPage>>;
   try {
     historyPage = cursor
@@ -554,6 +569,7 @@ async function handleChatHistoryRequest({
       kind: "delta",
       messages: delta.messages,
       deltaCursor: delta.deltaCursor,
+      pendingInputs,
       sessionInfo,
       ...(boundedInFlightRun ? { inFlightRun: boundedInFlightRun } : {}),
       ...(startupMetadata ? { metadata: startupMetadata } : {}),
@@ -569,6 +585,7 @@ async function handleChatHistoryRequest({
     sessionKey,
     sessionId,
     messages: composeTranscriptDisplay(capped),
+    pendingInputs,
     ...(historyPage.deltaCursor ? { deltaCursor: historyPage.deltaCursor } : {}),
     ...(historyPage.responseOffset !== undefined ? { offset: historyPage.responseOffset } : {}),
     ...(hasMore ? { nextOffset } : {}),

--- a/src/gateway/server-methods/chat-message-get-handler.ts
+++ b/src/gateway/server-methods/chat-message-get-handler.ts
@@ -4,8 +4,11 @@ import {
   errorShape,
   validateChatMessageGetParams,
 } from "../../../packages/gateway-protocol/src/index.js";
+import { CHAT_PENDING_INPUT_MESSAGE_PREFIX } from "../../../packages/gateway-protocol/src/schema/chat-history-constants.js";
 import { resolveSessionAgentId } from "../../agents/agent-scope.js";
+import { readSessionPendingInput } from "../../config/sessions/session-accessor.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { jsonUtf8Bytes } from "../../infra/json-utf8-bytes.js";
 import {
   augmentChatHistoryWithCanvasBlocks,
   dropPreSessionStartAnnouncePairs,
@@ -18,6 +21,7 @@ import { readSessionMessageByIdAsync } from "../session-transcript-readers.js";
 import { loadGatewaySessionEntryReadOnly } from "../session-utils.js";
 import { readChatHistoryMessageId } from "./chat-history-pages.js";
 import { resolveRequestedChatAgentId, validateChatSelectedAgent } from "./chat-origin-routing.js";
+import { projectPendingInputMessage } from "./chat-pending-inputs.js";
 import { normalizeOptionalChatText as normalizeOptionalText } from "./chat-text-normalization.js";
 import type { GatewayRequestHandlers } from "./types.js";
 import { assertValidParams } from "./validation.js";
@@ -79,7 +83,7 @@ export const chatMessageGetHandlers: GatewayRequestHandlers = {
     }
     const requestedAgentId = requestedAgent.agentId;
     const sessionLoadOptions = requestedAgentId ? { agentId: requestedAgentId } : undefined;
-    const { cfg, storePath, entry } = loadGatewaySessionEntryReadOnly(
+    const { cfg, storePath, entry, canonicalKey } = loadGatewaySessionEntryReadOnly(
       sessionKey,
       sessionLoadOptions,
     );
@@ -103,6 +107,37 @@ export const chatMessageGetHandlers: GatewayRequestHandlers = {
       config: cfg,
       agentId: selectedAgent.agentId,
     });
+    const effectiveMaxChars =
+      typeof maxChars === "number" ? maxChars : Math.min(MAX_PAYLOAD_BYTES, 1_000_000);
+    if (messageId.startsWith(CHAT_PENDING_INPUT_MESSAGE_PREFIX)) {
+      // Pending IDs have their own owner. A transcript miss must never widen
+      // into pending custody or an archived physical session.
+      const pending = readSessionPendingInput(
+        {
+          agentId: sessionAgentId,
+          sessionKey: canonicalKey,
+          sessionId,
+          storePath,
+        },
+        messageId.slice(CHAT_PENDING_INPUT_MESSAGE_PREFIX.length),
+      );
+      if (!pending) {
+        respond(true, { ok: false, unavailableReason: "not_found" });
+        return;
+      }
+      const message = projectPendingInputMessage(pending, effectiveMaxChars);
+      if (!message) {
+        respond(true, { ok: false, unavailableReason: "not_visible" });
+        return;
+      }
+      respond(
+        true,
+        jsonUtf8Bytes(message) > MAX_PAYLOAD_BYTES - 1024
+          ? { ok: false, unavailableReason: "oversized" }
+          : { ok: true, message },
+      );
+      return;
+    }
     const resolved = await readSessionMessageByIdAsync(
       {
         agentId: sessionAgentId,
@@ -138,8 +173,6 @@ export const chatMessageGetHandlers: GatewayRequestHandlers = {
       return;
     }
 
-    const effectiveMaxChars =
-      typeof maxChars === "number" ? maxChars : Math.min(MAX_PAYLOAD_BYTES, 1_000_000);
     const projectedMessage = resolved.message
       ? projectChatDisplayMessage(resolved.message, {
           maxChars: effectiveMaxChars,

--- a/src/gateway/server-methods/chat-pending-inputs.test.ts
+++ b/src/gateway/server-methods/chat-pending-inputs.test.ts
@@ -1,0 +1,133 @@
+import { expectDefined } from "@openclaw/normalization-core";
+import { describe, expect, it, vi } from "vitest";
+import {
+  stageSessionPendingInput,
+  upsertSessionEntryCore,
+  loadTranscriptEvents,
+} from "../../config/sessions/session-accessor.js";
+import { withOpenClawTestState } from "../../test-utils/openclaw-test-state.js";
+import { chatMessageGetHandlers } from "./chat-message-get-handler.js";
+import { readChatPendingInputs } from "./chat-pending-inputs.js";
+import type { GatewayRequestContext } from "./types.js";
+
+describe("pending input read boundary", () => {
+  it("keeps cancelled input readable and sanitized without changing the transcript or crossing a reset", async () => {
+    await withOpenClawTestState({ scenario: "minimal" }, async () => {
+      const scope = {
+        agentId: "main",
+        sessionKey: "agent:main:accepted",
+        sessionId: "accepted-session",
+      };
+      await upsertSessionEntryCore(scope, { sessionId: scope.sessionId, updatedAt: 1 });
+      const receipt = expectDefined(
+        await stageSessionPendingInput(scope, {
+          runId: "r".repeat(300),
+          assertCurrent: () => {},
+          message: {
+            role: "user",
+            content: "Accepted input ".repeat(2000),
+            timestamp: 1,
+            idempotencyKey: "queued:user",
+            __openclaw: {
+              media: [
+                {
+                  kind: "image",
+                  data: "synthetic-inline-payload",
+                  url: "https://example.test/image?credential=synthetic",
+                },
+              ],
+            },
+          },
+        }),
+        "pending receipt",
+      );
+      try {
+        receipt.finish("cancelled");
+        const page = readChatPendingInputs(scope, { limit: 1, maxChars: 50 });
+        const displayId = `pending:${receipt.inputId}`;
+        expect(page).toMatchObject({
+          total: 1,
+          items: [
+            { state: "cancelled", message: { __openclaw: { id: displayId, truncated: true } } },
+          ],
+        });
+        expect(page.items[0]).not.toHaveProperty("runId");
+        expect(JSON.stringify(page)).not.toContain("synthetic-inline-payload");
+        expect(JSON.stringify(page)).not.toContain("credential=");
+        expect(await loadTranscriptEvents(scope)).toEqual([]);
+        const respond = vi.fn();
+        const lookup = () =>
+          expectDefined(
+            chatMessageGetHandlers["chat.message.get"],
+            "message handler",
+          )({
+            params: { sessionKey: scope.sessionKey, messageId: displayId },
+            respond,
+            context: { getRuntimeConfig: () => ({}) } as unknown as GatewayRequestContext,
+            req: {} as never,
+            client: null,
+            isWebchatConnect: () => false,
+          });
+        await lookup();
+        expect(respond).toHaveBeenLastCalledWith(
+          true,
+          expect.objectContaining({
+            ok: true,
+            message: expect.objectContaining({ content: receipt.message.content }),
+          }),
+        );
+        await upsertSessionEntryCore(scope, { sessionId: "replacement-session", updatedAt: 2 });
+        await lookup();
+        expect(respond).toHaveBeenLastCalledWith(true, {
+          ok: false,
+          unavailableReason: "not_found",
+        });
+      } finally {
+        receipt.finish("interrupted");
+      }
+    });
+  });
+
+  it("does not reveal an input hidden by the canonical history visibility policy", async () => {
+    await withOpenClawTestState({ scenario: "minimal" }, async () => {
+      const scope = {
+        agentId: "main",
+        sessionKey: "agent:main:hidden-input",
+        sessionId: "hidden-session",
+      };
+      await upsertSessionEntryCore(scope, { sessionId: scope.sessionId, updatedAt: 1 });
+      const receipt = expectDefined(
+        await stageSessionPendingInput(scope, {
+          runId: "hidden-run",
+          assertCurrent: () => {},
+          message: {
+            role: "user",
+            display: false,
+            content: "Internal continuation",
+            timestamp: 1,
+            idempotencyKey: "hidden:user",
+          },
+        }),
+        "hidden pending receipt",
+      );
+      try {
+        expect(readChatPendingInputs(scope, { limit: 20, maxChars: 100 }).items).toEqual([]);
+        const respond = vi.fn();
+        await expectDefined(
+          chatMessageGetHandlers["chat.message.get"],
+          "message handler",
+        )({
+          params: { sessionKey: scope.sessionKey, messageId: `pending:${receipt.inputId}` },
+          respond,
+          context: { getRuntimeConfig: () => ({}) } as unknown as GatewayRequestContext,
+          req: {} as never,
+          client: null,
+          isWebchatConnect: () => false,
+        });
+        expect(respond).toHaveBeenCalledWith(true, { ok: false, unavailableReason: "not_visible" });
+      } finally {
+        receipt.finish("interrupted");
+      }
+    });
+  });
+});

--- a/src/gateway/server-methods/chat-pending-inputs.ts
+++ b/src/gateway/server-methods/chat-pending-inputs.ts
@@ -22,7 +22,7 @@ export function projectPendingInputMessage(input: SessionPendingInput, maxChars:
   if (!message) {
     return undefined;
   }
-  const metadata = { ...asOptionalRecord(message?.__openclaw) };
+  const metadata = { ...asOptionalRecord(message["__openclaw"]) };
   delete metadata.idempotencyKey;
   delete metadata.runId;
   return {
@@ -52,12 +52,17 @@ export function readChatPendingInputs(
   }).messages;
   return {
     ...page,
-    items: visible.map(({ input: item }, index) => ({
-      id: item.id,
-      ...(item.runId.length <= PENDING_INPUT_CORRELATION_MAX_CHARS ? { runId: item.runId } : {}),
-      acceptedAt: item.acceptedAt,
-      state: item.state,
-      message: messages[index],
-    })),
+    items: visible.map(({ input: item }, index) => {
+      const display: ChatPendingInputsPage["items"][number] = {
+        id: item.id,
+        acceptedAt: item.acceptedAt,
+        state: item.state,
+        message: messages[index],
+      };
+      if (item.runId.length <= PENDING_INPUT_CORRELATION_MAX_CHARS) {
+        display.runId = item.runId;
+      }
+      return display;
+    }),
   };
 }

--- a/src/gateway/server-methods/chat-pending-inputs.ts
+++ b/src/gateway/server-methods/chat-pending-inputs.ts
@@ -1,0 +1,63 @@
+import { asOptionalRecord } from "@openclaw/normalization-core/record-coerce";
+import { CHAT_PENDING_INPUT_MESSAGE_PREFIX } from "../../../packages/gateway-protocol/src/schema/chat-history-constants.js";
+import type { ChatPendingInputsPage } from "../../../packages/gateway-protocol/src/schema/logs-chat.js";
+import {
+  listSessionPendingInputs,
+  type SessionPendingInput,
+} from "../../config/sessions/session-accessor.js";
+import { projectChatDisplayMessage } from "../chat-display-projection.js";
+import { resolveCurrentUserProfileDisplay } from "../current-user-profile-display.js";
+import { replaceOversizedChatHistoryMessages } from "./chat-history-budget.js";
+
+const PENDING_INPUT_DISPLAY_MAX_BYTES = 128 * 1024;
+// Correlation is useful for browser UUIDs, but arbitrary external run IDs must
+// not turn a bounded display page into an unbounded payload. Never truncate IDs.
+const PENDING_INPUT_CORRELATION_MAX_CHARS = 256;
+
+export function projectPendingInputMessage(input: SessionPendingInput, maxChars: number) {
+  const message = projectChatDisplayMessage(input.message, {
+    maxChars,
+    resolveCurrentUserProfileDisplay,
+  });
+  if (!message) {
+    return undefined;
+  }
+  const metadata = { ...asOptionalRecord(message?.__openclaw) };
+  delete metadata.idempotencyKey;
+  delete metadata.runId;
+  return {
+    ...message,
+    idempotencyKey: undefined,
+    __openclaw: { ...metadata, id: `${CHAT_PENDING_INPUT_MESSAGE_PREFIX}${input.id}` },
+  };
+}
+
+export function readChatPendingInputs(
+  scope: Parameters<typeof listSessionPendingInputs>[0],
+  options: { before?: number; limit: number; maxChars: number },
+): ChatPendingInputsPage {
+  const page = listSessionPendingInputs(scope, {
+    before: options.before,
+    limit: Math.min(options.limit, 20),
+  });
+  const visible = page.items.flatMap((input) => {
+    const message = projectPendingInputMessage(input, options.maxChars);
+    return message ? [{ input, message }] : [];
+  });
+  const messages = replaceOversizedChatHistoryMessages({
+    messages: visible.map(({ message }) => message),
+    maxSingleMessageBytes: Math.floor(
+      PENDING_INPUT_DISPLAY_MAX_BYTES / Math.max(page.items.length, 1),
+    ),
+  }).messages;
+  return {
+    ...page,
+    items: visible.map(({ input: item }, index) => ({
+      id: item.id,
+      ...(item.runId.length <= PENDING_INPUT_CORRELATION_MAX_CHARS ? { runId: item.runId } : {}),
+      acceptedAt: item.acceptedAt,
+      state: item.state,
+      message: messages[index],
+    })),
+  };
+}

--- a/src/gateway/server.agent.gateway-server-agent-a.test.ts
+++ b/src/gateway/server.agent.gateway-server-agent-a.test.ts
@@ -11,7 +11,7 @@ import {
   type OperationalRunInstanceRef,
 } from "../agents/admitted-run-context.js";
 import type { ChannelPlugin } from "../channels/plugins/types.public.js";
-import { loadSessionEntry } from "../config/sessions/session-accessor.js";
+import { listSessionPendingInputs, loadSessionEntry } from "../config/sessions/session-accessor.js";
 import { createAbortError } from "../infra/abort-signal.js";
 import {
   type AgentRunDelegatedAuthority,
@@ -892,21 +892,19 @@ describe("gateway server agent", () => {
     await expect(fs.stat(media?.[0]?.path ?? "")).resolves.toMatchObject({
       isFile: expect.any(Function),
     });
-    const transcript = await readSessionMessagesAsync(
-      {
-        agentId: "main",
-        sessionId: "sess-main-offloaded-media",
-        sessionKey: String(call.sessionKey),
-        storePath: gatewaySuite.sessionStorePath,
-      },
-      { mode: "full", reason: "durable agent media custody regression" },
-    );
+    const pending = listSessionPendingInputs({
+      agentId: "main",
+      sessionId: "sess-main-offloaded-media",
+      sessionKey: String(call.sessionKey),
+      storePath: gatewaySuite.sessionStorePath,
+    });
+    expect(pending.items).toHaveLength(1);
     // Inbound ids are random; compare the durable fact against its public
     // redaction contract because an id can resemble sensitive text.
     const transcriptMediaUrl = media?.[0]?.url ? redactSensitiveText(media[0].url) : undefined;
-    expect(
-      (transcript[0] as { __openclaw?: { media?: Array<{ url?: string }> } })["__openclaw"]?.media,
-    ).toEqual(expect.arrayContaining([expect.objectContaining({ url: transcriptMediaUrl })]));
+    expect(pending.items[0]?.message["__openclaw"]?.media).toEqual(
+      expect.arrayContaining([expect.objectContaining({ url: transcriptMediaUrl })]),
+    );
     const inboundAfter = await listInboundMedia();
     expect([...inboundAfter].filter((entry) => !inboundBefore.has(entry))).toHaveLength(1);
   });

--- a/src/gateway/server.agent.gateway-server-agent-b.test.ts
+++ b/src/gateway/server.agent.gateway-server-agent-b.test.ts
@@ -7,11 +7,16 @@ import { createDeferred } from "../../test/helpers/promise.js";
 import { cleanupTempDirs, makeTempDir } from "../../test/helpers/temp-dir.js";
 import { AcpRuntimeError } from "../acp/runtime/errors.js";
 import type { ChannelPlugin } from "../channels/plugins/types.public.js";
-import { loadSessionEntry, loadTranscriptEventsSync } from "../config/sessions/session-accessor.js";
+import {
+  listSessionPendingInputs,
+  loadSessionEntry,
+  loadTranscriptEventsSync,
+} from "../config/sessions/session-accessor.js";
 import { resolveSqliteTargetFromSessionStorePath } from "../config/sessions/session-sqlite-target.js";
 import { emitAgentEvent } from "../infra/agent-events.js";
 import { registerAgentRunContext } from "../infra/agent-run-registry.js";
 import { openOpenClawAgentDatabase } from "../state/openclaw-agent-db.js";
+import { ensureSessionPendingInputsSchema } from "../state/openclaw-agent-pending-inputs-schema.js";
 import {
   createChannelTestPluginBase,
   createDirectOutboundTestAdapter,
@@ -510,40 +515,44 @@ describe("gateway server agent", () => {
         message.type === "res" && message.id === runId && message.payload?.status !== "accepted",
     );
 
-    await sendAgentWsRequest(ws, {
-      reqId: runId,
-      message: "persist this agent turn before ACK",
-      sessionKey: "main",
-      idempotencyKey: runId,
-    });
-    await ackP;
+    try {
+      await sendAgentWsRequest(ws, {
+        reqId: runId,
+        message: "persist this agent turn before ACK",
+        sessionKey: "main",
+        idempotencyKey: runId,
+      });
+      await ackP;
 
-    const storePath = testState.sessionStorePath;
-    if (!storePath) {
-      throw new Error("expected session store path");
-    }
-    expect(
-      loadTranscriptEventsSync({
+      const storePath = testState.sessionStorePath;
+      if (!storePath) {
+        throw new Error("expected session store path");
+      }
+      const scope = {
         agentId: "main",
         sessionId: "sess-durable-agent-ack",
         sessionKey: "agent:main:main",
         storePath,
-      }),
-    ).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          type: "message",
-          message: expect.objectContaining({
-            role: "user",
-            content: "persist this agent turn before ACK",
-            idempotencyKey: `${runId}:user`,
-          }),
-        }),
-      ]),
-    );
-
-    dispatch.resolve({ payloads: [{ text: "ok" }], meta: { durationMs: 1 } });
-    await finalP;
+      };
+      expect(loadTranscriptEventsSync(scope)).toEqual([]);
+      expect(listSessionPendingInputs(scope)).toMatchObject({
+        total: 1,
+        items: [
+          {
+            runId,
+            state: "queued",
+            message: {
+              role: "user",
+              content: "persist this agent turn before ACK",
+              idempotencyKey: `${runId}:user`,
+            },
+          },
+        ],
+      });
+    } finally {
+      dispatch.resolve({ payloads: [{ text: "ok" }], meta: { durationMs: 1 } });
+      await finalP;
+    }
   });
 
   test("an aborted hanging agent dispatch leaves its acknowledged turn queryable", async () => {
@@ -578,6 +587,7 @@ describe("gateway server agent", () => {
       idempotencyKey: runId,
     });
     await ackP;
+    await readAgentCommandCall({ runId });
     await rpcReq(ws, "chat.abort", { runId, sessionKey: "main" });
     const final = await finalP;
     expect(final.payload).toMatchObject({ runId, status: "timeout", stopReason: "rpc" });
@@ -586,23 +596,26 @@ describe("gateway server agent", () => {
     if (!storePath) {
       throw new Error("expected session store path");
     }
-    expect(
-      loadTranscriptEventsSync({
-        agentId: "main",
-        sessionId: "sess-durable-agent-abort",
-        sessionKey: "agent:main:main",
-        storePath,
-      }),
-    ).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          message: expect.objectContaining({
+    const scope = {
+      agentId: "main",
+      sessionId: "sess-durable-agent-abort",
+      sessionKey: "agent:main:main",
+      storePath,
+    };
+    expect(loadTranscriptEventsSync(scope)).toEqual([]);
+    expect(listSessionPendingInputs(scope)).toMatchObject({
+      total: 1,
+      items: [
+        {
+          runId,
+          state: "cancelled",
+          message: {
             role: "user",
             content: "keep this aborted agent turn queryable",
-          }),
-        }),
-      ]),
-    );
+          },
+        },
+      ],
+    });
   });
 
   test("agent returns a wire error when durable user-turn admission fails", async () => {
@@ -613,9 +626,10 @@ describe("gateway server agent", () => {
     }
     const target = resolveSqliteTargetFromSessionStorePath(storePath, { agentId: "main" });
     const database = openOpenClawAgentDatabase({ agentId: "main", path: target.path }).db;
+    ensureSessionPendingInputsSchema(database);
     database.exec(`
       CREATE TEMP TRIGGER fail_agent_turn_admission
-      BEFORE INSERT ON transcript_events
+      BEFORE INSERT ON session_pending_inputs
       BEGIN
         SELECT RAISE(ABORT, 'injected agent transcript admission failure');
       END;

--- a/src/gateway/worker-environments/transcript-commit.test.ts
+++ b/src/gateway/worker-environments/transcript-commit.test.ts
@@ -9,6 +9,7 @@ import type {
 } from "../../../packages/gateway-protocol/src/schema/worker-admission.js";
 import { createNoisyPngBuffer } from "../../../test/helpers/image-fixtures.js";
 import { SessionManager } from "../../agents/sessions/session-manager.js";
+import { clearRuntimeConfigSnapshot, setRuntimeConfigSnapshot } from "../../config/io.js";
 import {
   loadSessionEntry,
   loadTranscriptEvents,
@@ -22,6 +23,8 @@ import {
   closeOpenClawStateDatabaseForTest,
   openOpenClawStateDatabase,
 } from "../../state/openclaw-state-db.js";
+import { prepareAgentRunUserTurn } from "../agent-turn/agent-run-user-turn.js";
+import type { AgentTurnContext } from "../agent-turn/types.js";
 import type { WorkerConnectionIdentity } from "./connection-identity.js";
 import {
   createWorkerTranscriptCommitStore,
@@ -209,6 +212,7 @@ describe("worker transcript commit application", () => {
 
   afterEach(async () => {
     unsubscribe?.();
+    clearRuntimeConfigSnapshot();
     closeOpenClawStateDatabaseForTest();
     await fs.rm(root, { recursive: true, force: true });
   });
@@ -386,6 +390,70 @@ describe("worker transcript commit application", () => {
     const reopened = SessionManager.open(sessionTarget);
     expect(reopened.getEntries()).toHaveLength(3);
     expect(reopened.getLeafId()).toBe(first.result.newLeafId);
+  });
+
+  it("admits an overlapping agent input without invalidating the active worker transcript", async () => {
+    setRuntimeConfigSnapshot(cfg);
+    const admit = (runId: string, text: string) =>
+      prepareAgentRunUserTurn({
+        assertCurrent: () => {},
+        request: { message: text, idempotencyKey: runId },
+        cfg,
+        resolvedSessionKey: SESSION_KEY,
+        admittedSessionId: SESSION_ID,
+        activeSessionAgentId: "main",
+        suppressVisibleSessionEffects: false,
+        requestedPromptPersistenceSuppression: false,
+        canUseInternalRuntimeHandoff: false,
+        message: text,
+        effectiveTranscriptInputText: text,
+        images: [],
+        offloadedRefs: [],
+        runId,
+        client: null,
+        context: { logGateway: { warn: vi.fn() } } as unknown as AgentTurnContext,
+      });
+
+    const first = await admit(IDENTITY.runId!, "First input");
+    const firstUser = await (first.recorder?.withPendingInput
+      ? first.recorder.withPendingInput(() => first.recorder!.persistApproved())
+      : first.recorder?.persistApproved());
+    if (!firstUser) {
+      throw new Error("expected the active worker's canonical user input");
+    }
+
+    // Admission happens before the next turn can take the session lane. It must
+    // not move the active worker's base while that worker is still producing output.
+    const second = await admit("next-worker-run", "Second input");
+    const completed = await committer.commit({
+      identity: IDENTITY,
+      request: createRequest({
+        baseLeafId: firstUser.messageId,
+        messages: createTurnMessages().slice(1),
+      }),
+    });
+    if (!completed.ok) {
+      throw new Error(`active worker commit rejected: ${completed.reason}`);
+    }
+
+    const secondUser = await (second.recorder?.withPendingInput
+      ? second.recorder.withPendingInput(() => second.recorder!.persistApproved())
+      : second.recorder?.persistApproved());
+    expect(secondUser).toBeDefined();
+    const branch = SessionManager.open(sessionTarget).getBranch();
+    expect(branch.map((entry) => [entry.id, entry.parentId])).toEqual([
+      [firstUser.messageId, null],
+      [completed.result.entryIds[0], firstUser.messageId],
+      [completed.result.entryIds[1], completed.result.entryIds[0]],
+      [secondUser?.messageId, completed.result.newLeafId],
+    ]);
+    expect(
+      branch.flatMap((entry) =>
+        entry.type === "message" && entry.message.role === "user" ? [entry.message.content] : [],
+      ),
+    ).toEqual(["First input", "Second input"]);
+    first.recorder?.finishPendingInput?.("interrupted");
+    second.recorder?.finishPendingInput?.("interrupted");
   });
 
   it("rejects a commit when lifecycle ownership changes in the writer queue", async () => {

--- a/src/infra/state-migrations.media-persistence.historical-schema.test-support.ts
+++ b/src/infra/state-migrations.media-persistence.historical-schema.test-support.ts
@@ -29,9 +29,9 @@ function restoreHistoricalAgentLeaseSchema(sql: string): string {
   return sql.replace(marker, `${HISTORICAL_AGENT_LEASE_SCHEMA}${marker}`);
 }
 
-function removeSchemaRange(sql: string, startMarker: string, endMarker: string): string {
+function removeSchemaRange(sql: string, startMarker: string, endMarker?: string): string {
   const start = sql.indexOf(startMarker);
-  const end = sql.indexOf(endMarker, start);
+  const end = endMarker === undefined ? sql.length : sql.indexOf(endMarker, start);
   if (start === -1 || end === -1) {
     throw new Error(`Historical agent schema marker is missing: ${startMarker}`);
   }
@@ -40,7 +40,11 @@ function removeSchemaRange(sql: string, startMarker: string, endMarker: string):
 
 /** Exact schema bytes from 509a5f0373764, derived from current SQL with later additions removed. */
 export function historicalV15AgentSchemaSql(): string {
-  let sql = restoreHistoricalAgentLeaseSchema(OPENCLAW_AGENT_SCHEMA_SQL)
+  const withoutPendingInputs = removeSchemaRange(
+    OPENCLAW_AGENT_SCHEMA_SQL,
+    "\n-- Accepted input stays outside the active transcript until its exact turn owns execution.",
+  );
+  let sql = restoreHistoricalAgentLeaseSchema(withoutPendingInputs)
     .replace("  entry_valid INTEGER NOT NULL DEFAULT 0 CHECK (entry_valid IN (-1, 0, 1)),\n", "")
     .replace("  project_id TEXT,\n", "")
     .replace("  route_context_json TEXT,\n", "")

--- a/src/sessions/user-turn-transcript.message.ts
+++ b/src/sessions/user-turn-transcript.message.ts
@@ -1,0 +1,205 @@
+// Canonical user input shape and runtime/display projections share the same media metadata.
+import { mimeTypeFromFilePath } from "@openclaw/media-core/mime";
+import { asOptionalRecord } from "@openclaw/normalization-core/record-coerce";
+import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import type { AgentMessage } from "../../packages/agent-core/src/types.js";
+import { readPersistedMediaFacts, type MediaFact } from "../media/media-facts.js";
+import { applyInputProvenanceToUserMessage } from "./input-provenance.js";
+import {
+  normalizeStructuredMediaEntryForTranscript,
+  resolveTranscriptMediaPath,
+} from "./user-turn-transcript.media-normalize.js";
+import { buildPersistedUserTurnMetadata } from "./user-turn-transcript.metadata.js";
+import type {
+  PersistedUserTurnMediaInput,
+  PersistedUserTurnMessage,
+  UserTurnInput,
+  UserTurnMessagePersistenceParams,
+} from "./user-turn-transcript.types.js";
+
+// Select normalized text for persisted user turns.
+export function resolvePersistedUserTurnText(value: string | null | undefined): string | undefined {
+  return normalizeOptionalString(value);
+}
+
+function resolveTranscriptMediaType(params: {
+  explicitType: string | undefined;
+  mediaPath: string | undefined;
+  mediaUrl: string | undefined;
+}): string | undefined {
+  return params.explicitType ?? mimeTypeFromFilePath(params.mediaPath ?? params.mediaUrl);
+}
+
+export function buildPersistedUserTurnMediaInputsFromFields(
+  fields: PersistedUserTurnMessage | null | undefined,
+): PersistedUserTurnMediaInput[] {
+  const facts = fields ? (readPersistedMediaFacts(fields) ?? []) : [];
+  const normalizedMedia = facts.map((fact) => {
+    const rawPath = normalizeOptionalString(fact.path);
+    const mediaPath = rawPath
+      ? resolveTranscriptMediaPath(rawPath, normalizeOptionalString(fact.workspaceDir))
+      : undefined;
+    const url = normalizeOptionalString(fact.url);
+    if (!mediaPath && !url) {
+      return {};
+    }
+    const contentType = resolveTranscriptMediaType({
+      explicitType: normalizeOptionalString(fact.contentType),
+      mediaPath,
+      mediaUrl: url,
+    });
+    const media: PersistedUserTurnMediaInput = { contentType };
+    if (mediaPath) {
+      media.path = mediaPath;
+    }
+    if (url) {
+      media.url = url;
+    }
+    if (fact.kind) {
+      media.kind = fact.kind;
+    }
+    if (fact.fileName) {
+      media.fileName = fact.fileName;
+    }
+    if (fact.sizeBytes !== undefined) {
+      media.sizeBytes = fact.sizeBytes;
+    }
+    if (fact.durationMs !== undefined) {
+      media.durationMs = fact.durationMs;
+    }
+    if (fact.width !== undefined) {
+      media.width = fact.width;
+    }
+    if (fact.height !== undefined) {
+      media.height = fact.height;
+    }
+    return media;
+  });
+  return normalizedMedia.some((entry) => entry.path || entry.url) ? normalizedMedia : [];
+}
+
+export function buildLateMediaAttachedProjection(message: AgentMessage): {
+  text?: string;
+  media: MediaFact[];
+} {
+  const isLateMedia = readOpenClawMessageMeta(message)?.lateMedia === true;
+  const media = isLateMedia ? (readPersistedMediaFacts(message) ?? []) : [];
+  const text = media
+    .flatMap((fact) => {
+      const mediaRef = fact.path ?? fact.url;
+      return mediaRef ? [`[media attached: ${mediaRef}]`] : [];
+    })
+    .join("\n");
+  return { ...(text ? { text } : {}), media };
+}
+
+function readOpenClawMessageMeta(message: AgentMessage): Record<string, unknown> | undefined {
+  return asOptionalRecord(Reflect.get(message, "__openclaw"));
+}
+export function buildPersistedUserTurnMessage(params: UserTurnInput): PersistedUserTurnMessage {
+  const normalizedMedia = (params.media ?? []).map(normalizeStructuredMediaEntryForTranscript);
+  const text = params.text ?? "";
+  // Storage is BARE (no timestamp prefix). The per-message timestamp is added
+  // at the single LLM-boundary stamping site (normalizeMessagesForLlmBoundary),
+  // derived from each message's own `timestamp` field, so the current turn and
+  // every historical turn serialize identically on the wire. Persisting a stamp
+  // here would NOT match the bare-current arrival (the gateway no longer stamps
+  // the live turn) — see https://github.com/openclaw/openclaw/issues/3658.
+  const openClawMeta = buildPersistedUserTurnMetadata(params, normalizedMedia);
+  const message: PersistedUserTurnMessage = {
+    role: "user",
+    ...(params.display === false ? { display: false } : {}),
+    content: text,
+    timestamp: params.timestamp ?? Date.now(),
+    ...(params.idempotencyKey ? { idempotencyKey: params.idempotencyKey } : {}),
+    ...(Object.keys(openClawMeta).length > 0 ? { __openclaw: openClawMeta } : {}),
+  };
+  // SAFETY: Provenance attachment preserves the input message's user role and content.
+  return applyInputProvenanceToUserMessage(message, params.provenance) as PersistedUserTurnMessage;
+}
+
+export function resolvePersistedUserTurnMessage(
+  params: Pick<UserTurnMessagePersistenceParams, "input" | "message">,
+): PersistedUserTurnMessage | undefined {
+  return params.message ?? (params.input ? buildPersistedUserTurnMessage(params.input) : undefined);
+}
+
+export function isUserMessage(message: unknown): message is PersistedUserTurnMessage {
+  return asOptionalRecord(message)?.role === "user";
+}
+
+export function buildLateResolvedMediaMessage(params: {
+  admittedMessage?: PersistedUserTurnMessage;
+  resolvedMessage: PersistedUserTurnMessage;
+}): PersistedUserTurnMessage | undefined {
+  const admittedMedia = buildPersistedUserTurnMediaInputsFromFields(params.admittedMessage);
+  const resolvedMedia = buildPersistedUserTurnMediaInputsFromFields(params.resolvedMessage);
+  if (
+    resolvedMedia.length === 0 ||
+    JSON.stringify(resolvedMedia) === JSON.stringify(admittedMedia)
+  ) {
+    return undefined;
+  }
+  const resolvedIdempotencyKey = Reflect.get(params.resolvedMessage, "idempotencyKey");
+  const resolvedTimestamp = Reflect.get(params.resolvedMessage, "timestamp");
+  const admittedContent = params.admittedMessage?.content;
+  const resolvedContent = params.resolvedMessage.content;
+  let content = resolvedContent;
+  if (resolvedContent === admittedContent) {
+    content = "";
+  } else if (Array.isArray(resolvedContent) && typeof admittedContent === "string") {
+    content = resolvedContent.filter((block) => {
+      const textBlock = asOptionalRecord(block);
+      return textBlock?.type !== "text" || textBlock.text !== admittedContent;
+    });
+  }
+  const idempotencyKey =
+    typeof resolvedIdempotencyKey === "string" && resolvedIdempotencyKey.length > 0
+      ? `${resolvedIdempotencyKey}:late-media`
+      : `late-media:${typeof resolvedTimestamp === "number" ? resolvedTimestamp : Date.now()}`;
+  // Like #111204, mark late-media scaffolding as wire-only so UIs never render it.
+  return {
+    ...params.resolvedMessage,
+    content,
+    idempotencyKey,
+    __openclaw: { ...readOpenClawMessageMeta(params.resolvedMessage), lateMedia: true },
+  };
+}
+
+function isBeforeAgentRunBlockedMessage(message: AgentMessage): boolean {
+  const marker = readOpenClawMessageMeta(message)?.beforeAgentRunBlocked;
+  return marker !== undefined;
+}
+
+function userMessageHasImageContent(message: AgentMessage): boolean {
+  return (
+    isUserMessage(message) &&
+    Array.isArray(message.content) &&
+    message.content.some((block) => asOptionalRecord(block)?.type === "image")
+  );
+}
+
+// Runtime messages may lack transcript metadata because channel adapters prepare
+// display text separately. Merge only safe user messages, never block markers.
+export function mergePreparedUserTurnMessageForRuntime(params: {
+  runtimeMessage: AgentMessage;
+  preparedMessage?: PersistedUserTurnMessage;
+}): AgentMessage {
+  if (
+    !params.preparedMessage ||
+    !isUserMessage(params.runtimeMessage) ||
+    isBeforeAgentRunBlockedMessage(params.runtimeMessage)
+  ) {
+    return params.runtimeMessage;
+  }
+  const runtimeMeta = readOpenClawMessageMeta(params.runtimeMessage);
+  const preparedMeta = readOpenClawMessageMeta(params.preparedMessage);
+  return {
+    ...params.runtimeMessage,
+    ...params.preparedMessage,
+    ...(preparedMeta ? { __openclaw: { ...runtimeMeta, ...preparedMeta } } : {}),
+    ...(userMessageHasImageContent(params.runtimeMessage)
+      ? { content: params.runtimeMessage.content }
+      : {}),
+  };
+}

--- a/src/sessions/user-turn-transcript.ts
+++ b/src/sessions/user-turn-transcript.ts
@@ -1,11 +1,8 @@
 // User turn transcript helpers extract user-turn text from session transcripts.
 import { randomUUID } from "node:crypto";
-import { mimeTypeFromFilePath } from "@openclaw/media-core/mime";
-import { asOptionalRecord } from "@openclaw/normalization-core/record-coerce";
-import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
-import type { AgentMessage } from "../../packages/agent-core/src/types.js";
 import {
   persistSessionTranscriptTurn,
+  stageSessionPendingInput,
   publishTranscriptUpdate,
   readActiveTranscriptEntryAnchor,
   rewriteTranscriptMessageAtAnchor,
@@ -13,15 +10,13 @@ import {
   type SessionTranscriptTurnPersistOptions,
 } from "../config/sessions/session-accessor.js";
 import { waitForSessionTranscriptProjection } from "../config/sessions/session-transcript-reconcile.js";
-import { readPersistedMediaFacts, type MediaFact } from "../media/media-facts.js";
-import { applyInputProvenanceToUserMessage } from "./input-provenance.js";
 import { resolveUserTurnTranscriptAdmission } from "./user-turn-transcript-admission.js";
 import {
-  normalizeStructuredMediaEntryForTranscript,
-  resolveTranscriptMediaPath,
-} from "./user-turn-transcript.media-normalize.js";
+  buildLateResolvedMediaMessage,
+  isUserMessage,
+  resolvePersistedUserTurnMessage,
+} from "./user-turn-transcript.message.js";
 import {
-  buildPersistedUserTurnMetadata,
   normalizePersistedSteerTargetRunId,
   preparePersistedUserTurnMessageForTranscriptWrite,
   restorePreparedUserTurnOperationalMetaForRuntime,
@@ -30,10 +25,7 @@ import {
 import type {
   CreateUserTurnTranscriptRecorderParams,
   PersistUserTurnTranscriptParams,
-  PersistedUserTurnMediaInput,
   PersistedUserTurnMessage,
-  UserTurnMessagePersistenceParams,
-  UserTurnInput,
   UserTurnTranscriptAdmissionReceipt,
   UserTurnTranscriptPersistResult,
   UserTurnTranscriptRecorder,
@@ -49,204 +41,20 @@ export type {
 } from "./user-turn-transcript.types.js";
 
 export {
+  buildLateMediaAttachedProjection,
+  buildPersistedUserTurnMediaInputsFromFields,
+  buildPersistedUserTurnMessage,
+  mergePreparedUserTurnMessageForRuntime,
+  resolvePersistedUserTurnText,
+} from "./user-turn-transcript.message.js";
+
+export {
   preparePersistedUserTurnMessageForTranscriptWrite,
   restorePreparedUserTurnOperationalMetaForRuntime,
 };
 
 export function buildRunUserTurnIdempotencyKey(runId: string): string {
   return `${runId}:user`;
-}
-
-// Select normalized text for persisted user turns.
-export function resolvePersistedUserTurnText(value: string | null | undefined): string | undefined {
-  return normalizeOptionalString(value);
-}
-
-function resolveTranscriptMediaType(params: {
-  explicitType: string | undefined;
-  mediaPath: string | undefined;
-  mediaUrl: string | undefined;
-}): string | undefined {
-  return params.explicitType ?? mimeTypeFromFilePath(params.mediaPath ?? params.mediaUrl);
-}
-
-export function buildPersistedUserTurnMediaInputsFromFields(
-  fields: PersistedUserTurnMessage | null | undefined,
-): PersistedUserTurnMediaInput[] {
-  const facts = fields ? (readPersistedMediaFacts(fields) ?? []) : [];
-  const normalizedMedia = facts.map((fact) => {
-    const rawPath = normalizeOptionalString(fact.path);
-    const mediaPath = rawPath
-      ? resolveTranscriptMediaPath(rawPath, normalizeOptionalString(fact.workspaceDir))
-      : undefined;
-    const url = normalizeOptionalString(fact.url);
-    if (!mediaPath && !url) {
-      return {};
-    }
-    const contentType = resolveTranscriptMediaType({
-      explicitType: normalizeOptionalString(fact.contentType),
-      mediaPath,
-      mediaUrl: url,
-    });
-    const media: PersistedUserTurnMediaInput = { contentType };
-    if (mediaPath) {
-      media.path = mediaPath;
-    }
-    if (url) {
-      media.url = url;
-    }
-    if (fact.kind) {
-      media.kind = fact.kind;
-    }
-    if (fact.fileName) {
-      media.fileName = fact.fileName;
-    }
-    if (fact.sizeBytes !== undefined) {
-      media.sizeBytes = fact.sizeBytes;
-    }
-    if (fact.durationMs !== undefined) {
-      media.durationMs = fact.durationMs;
-    }
-    if (fact.width !== undefined) {
-      media.width = fact.width;
-    }
-    if (fact.height !== undefined) {
-      media.height = fact.height;
-    }
-    return media;
-  });
-  return normalizedMedia.some((entry) => entry.path || entry.url) ? normalizedMedia : [];
-}
-
-export function buildLateMediaAttachedProjection(message: AgentMessage): {
-  text?: string;
-  media: MediaFact[];
-} {
-  const isLateMedia = readOpenClawMessageMeta(message)?.lateMedia === true;
-  const media = isLateMedia ? (readPersistedMediaFacts(message) ?? []) : [];
-  const text = media
-    .flatMap((fact) => {
-      const mediaRef = fact.path ?? fact.url;
-      return mediaRef ? [`[media attached: ${mediaRef}]`] : [];
-    })
-    .join("\n");
-  return { ...(text ? { text } : {}), media };
-}
-
-function readOpenClawMessageMeta(message: AgentMessage): Record<string, unknown> | undefined {
-  return asOptionalRecord(Reflect.get(message, "__openclaw"));
-}
-export function buildPersistedUserTurnMessage(params: UserTurnInput): PersistedUserTurnMessage {
-  const normalizedMedia = (params.media ?? []).map(normalizeStructuredMediaEntryForTranscript);
-  const text = params.text ?? "";
-  // Storage is BARE (no timestamp prefix). The per-message timestamp is added
-  // at the single LLM-boundary stamping site (normalizeMessagesForLlmBoundary),
-  // derived from each message's own `timestamp` field, so the current turn and
-  // every historical turn serialize identically on the wire. Persisting a stamp
-  // here would NOT match the bare-current arrival (the gateway no longer stamps
-  // the live turn) — see https://github.com/openclaw/openclaw/issues/3658.
-  const openClawMeta = buildPersistedUserTurnMetadata(params, normalizedMedia);
-  const message = {
-    role: "user",
-    ...(params.display === false ? { display: false } : {}),
-    content: text,
-    timestamp: params.timestamp ?? Date.now(),
-    ...(params.idempotencyKey ? { idempotencyKey: params.idempotencyKey } : {}),
-    ...(Object.keys(openClawMeta).length > 0 ? { __openclaw: openClawMeta } : {}),
-  } as PersistedUserTurnMessage;
-  return applyInputProvenanceToUserMessage(message, params.provenance) as PersistedUserTurnMessage;
-}
-
-function resolvePersistedUserTurnMessage(
-  params: Pick<UserTurnMessagePersistenceParams, "input" | "message">,
-): PersistedUserTurnMessage | undefined {
-  return params.message ?? (params.input ? buildPersistedUserTurnMessage(params.input) : undefined);
-}
-
-function isUserMessage(message: unknown): message is PersistedUserTurnMessage {
-  return asOptionalRecord(message)?.role === "user";
-}
-
-function buildLateResolvedMediaMessage(params: {
-  admittedMessage?: PersistedUserTurnMessage;
-  resolvedMessage: PersistedUserTurnMessage;
-}): PersistedUserTurnMessage | undefined {
-  const admittedMedia = buildPersistedUserTurnMediaInputsFromFields(params.admittedMessage);
-  const resolvedMedia = buildPersistedUserTurnMediaInputsFromFields(params.resolvedMessage);
-  if (
-    resolvedMedia.length === 0 ||
-    JSON.stringify(resolvedMedia) === JSON.stringify(admittedMedia)
-  ) {
-    return undefined;
-  }
-  const resolvedIdempotencyKey = Reflect.get(params.resolvedMessage, "idempotencyKey");
-  const resolvedTimestamp = Reflect.get(params.resolvedMessage, "timestamp");
-  const admittedContent = params.admittedMessage?.content;
-  const resolvedContent = params.resolvedMessage.content;
-  let content = resolvedContent;
-  if (resolvedContent === admittedContent) {
-    content = "";
-  } else if (Array.isArray(resolvedContent) && typeof admittedContent === "string") {
-    content = resolvedContent.filter((block) => {
-      const textBlock = block as { type?: unknown; text?: unknown } | null;
-      return textBlock?.type !== "text" || textBlock.text !== admittedContent;
-    });
-  }
-  const idempotencyKey =
-    typeof resolvedIdempotencyKey === "string" && resolvedIdempotencyKey.length > 0
-      ? `${resolvedIdempotencyKey}:late-media`
-      : `late-media:${typeof resolvedTimestamp === "number" ? resolvedTimestamp : Date.now()}`;
-  // Like #111204, mark late-media scaffolding as wire-only so UIs never render it.
-  return {
-    ...params.resolvedMessage,
-    content,
-    idempotencyKey,
-    __openclaw: { ...readOpenClawMessageMeta(params.resolvedMessage), lateMedia: true },
-  } as PersistedUserTurnMessage;
-}
-
-function isBeforeAgentRunBlockedMessage(message: AgentMessage): boolean {
-  const marker = (message as { __openclaw?: { beforeAgentRunBlocked?: unknown } })["__openclaw"]
-    ?.beforeAgentRunBlocked;
-  return marker !== undefined;
-}
-
-function userMessageHasImageContent(message: AgentMessage): boolean {
-  return (
-    isUserMessage(message) &&
-    Array.isArray(message.content) &&
-    message.content.some(
-      (block) =>
-        typeof block === "object" &&
-        block !== null &&
-        (block as { type?: unknown }).type === "image",
-    )
-  );
-}
-
-// Runtime messages may lack transcript metadata because channel adapters prepare
-// display text separately. Merge only safe user messages, never block markers.
-export function mergePreparedUserTurnMessageForRuntime(params: {
-  runtimeMessage: AgentMessage;
-  preparedMessage?: PersistedUserTurnMessage;
-}): AgentMessage {
-  if (
-    !params.preparedMessage ||
-    !isUserMessage(params.runtimeMessage) ||
-    isBeforeAgentRunBlockedMessage(params.runtimeMessage)
-  ) {
-    return params.runtimeMessage;
-  }
-  const runtimeMeta = readOpenClawMessageMeta(params.runtimeMessage);
-  const preparedMeta = readOpenClawMessageMeta(params.preparedMessage);
-  return {
-    ...params.runtimeMessage,
-    ...params.preparedMessage,
-    ...(preparedMeta ? { __openclaw: { ...runtimeMeta, ...preparedMeta } } : {}),
-    ...(userMessageHasImageContent(params.runtimeMessage)
-      ? { content: params.runtimeMessage.content }
-      : {}),
-  } as AgentMessage;
 }
 
 // Store-backed persistence resolves the current session transcript file lazily
@@ -387,6 +195,8 @@ export function createUserTurnTranscriptRecorder(
   let resolvedBeforeProvider = false;
   let replacementText: string | undefined;
   let confirmedSteerTargetRunId: string | undefined;
+  let pendingInput: Awaited<ReturnType<typeof stageSessionPendingInput>>;
+  let staging: Promise<boolean> | undefined;
 
   const applyReplacementText = (
     candidate: PersistedUserTurnMessage | undefined,
@@ -605,8 +415,36 @@ export function createUserTurnTranscriptRecorder(
       return message;
     },
     resolveMessage: resolveMessageForPersistence,
+    stageApproved: (options) => {
+      staging ??= (async () => {
+        const candidate = await resolveMessageForPersistence();
+        const target = await resolveUserTurnTranscriptTarget(params.target);
+        if (!candidate || !target || persisted || runtimePersisted) {
+          return false;
+        }
+        pendingInput = await stageSessionPendingInput(target, {
+          ...options,
+          message: candidate,
+          config: target.config as SessionTranscriptTurnPersistOptions["config"],
+          prepareMessageAfterIdempotencyCheck: (next) =>
+            preparePersistedUserTurnMessageForTranscriptWrite(next, {
+              ...target,
+              beforeMessageWrite: params.beforeMessageWrite ?? target.beforeMessageWrite,
+            }),
+        });
+        if (!pendingInput) {
+          return false;
+        }
+        message = pendingInput.message;
+        resolvedMessagePromise = Promise.resolve(message);
+        return true;
+      })();
+      return staging;
+    },
+    withPendingInput: (run) => (pendingInput ? pendingInput.run(run) : run()),
+    finishPendingInput: (disposition) => pendingInput?.finish(disposition),
     replaceTextBeforePersistence: (text) => {
-      if (persisted || runtimePersisted || sentToProvider) {
+      if (pendingInput || persisted || runtimePersisted || sentToProvider) {
         return;
       }
       replacementText = text;

--- a/src/sessions/user-turn-transcript.types.ts
+++ b/src/sessions/user-turn-transcript.types.ts
@@ -37,6 +37,8 @@ export type PersistedUserTurnMediaInput = Pick<
 
 export type PersistedUserTurnMessage = Extract<AgentMessage, { role: "user" }> & {
   display?: false;
+  /** Private transcript correlation; never authorizes an execution. */
+  idempotencyKey?: string;
   __openclaw?: Record<string, unknown>;
 };
 
@@ -174,6 +176,10 @@ export type CreateUserTurnTranscriptRecorderParams = {
 export type UserTurnTranscriptRecorder = {
   readonly message: PersistedUserTurnMessage | undefined;
   resolveMessage: () => Promise<PersistedUserTurnMessage | undefined>;
+  /** Durable input custody leaves the active transcript unchanged until execution owns it. */
+  stageApproved?: (options: { runId: string; assertCurrent: () => void }) => Promise<boolean>;
+  withPendingInput?: <T>(run: () => T) => T;
+  finishPendingInput?: (disposition: "cancelled" | "interrupted") => void;
   /** Replaces generated current-turn text before runtime persistence/provider submission. */
   replaceTextBeforePersistence?: (text: string) => void;
   /** Confirms exact-run steering provenance after transcript commitment is proven. */

--- a/src/shared/store-writer-queue.test.ts
+++ b/src/shared/store-writer-queue.test.ts
@@ -1,7 +1,38 @@
 // Verifies queue ownership and reentrancy across separately loaded runtime chunks.
+import { AsyncLocalStorage } from "node:async_hooks";
 import { importFreshModule } from "openclaw/plugin-sdk/test-fixtures";
 import { expect, it } from "vitest";
-import type { StoreWriterQueue } from "./store-writer-queue.js";
+import { createDeferred } from "../../test/helpers/promise.js";
+import { runQueuedStoreWrite, type StoreWriterQueue } from "./store-writer-queue.js";
+
+it("retains each queued writer's caller context through async and reentrant work", async () => {
+  const contexts = new AsyncLocalStorage<string>();
+  const queues = new Map<string, StoreWriterQueue>();
+  const gate = createDeferred();
+  const write = (owner: string, wait: Promise<void>) =>
+    contexts.run(owner, () =>
+      runQueuedStoreWrite({
+        queues,
+        storePath: "shared-store",
+        label: owner,
+        fn: async () => {
+          await wait;
+          return runQueuedStoreWrite({
+            queues,
+            storePath: "shared-store",
+            label: "reentrant",
+            reentrant: true,
+            fn: async () => contexts.getStore(),
+          });
+        },
+      }),
+    );
+  const first = write("first-owner", gate.promise);
+  const second = write("second-owner", Promise.resolve());
+  gate.resolve();
+  expect(await Promise.all([first, second])).toEqual(["first-owner", "second-owner"]);
+  expect(queues.size).toBe(0);
+});
 
 it("shares reentrant writer context across duplicate module instances", async () => {
   const first = await importFreshModule<typeof import("./store-writer-queue.js")>(

--- a/src/shared/store-writer-queue.ts
+++ b/src/shared/store-writer-queue.ts
@@ -140,10 +140,14 @@ export async function runQueuedStoreWrite<T>(params: {
   if (params.reentrant === true && isActiveStoreWriter(params.queues, params.storePath)) {
     return await params.fn();
   }
+  // A queued writer retains its caller's authority, never the preceding writer's
+  // async context. The active-writer scope still belongs to actual execution.
+  const runInAsyncContext = AsyncLocalStorage.snapshot();
   const queue = getOrCreateStoreWriterQueue(params.queues, params.storePath);
   return await new Promise<T>((resolve, reject) => {
     const task: StoreWriterTask = {
-      fn: async () => await runActiveStoreWriter(params.queues, params.storePath, params.fn),
+      fn: async () =>
+        await runInAsyncContext(runActiveStoreWriter, params.queues, params.storePath, params.fn),
       resolve: (value) => resolve(value as T),
       reject,
     };

--- a/src/state/openclaw-agent-db-schema-helpers.ts
+++ b/src/state/openclaw-agent-db-schema-helpers.ts
@@ -37,6 +37,7 @@ import {
 import { SESSION_GOAL_OPERATIONS_TABLE } from "./openclaw-agent-goal-operations-schema.js";
 import { MESSAGE_TOOL_RUN_OUTCOMES_TABLE } from "./openclaw-agent-message-tool-outcome-schema.js";
 import { LEGACY_PARTICIPANT_OPTIONAL_COLUMNS } from "./openclaw-agent-participants-migration.js";
+import { SESSION_PENDING_INPUTS_TABLE } from "./openclaw-agent-pending-inputs-schema.js";
 import {
   ensureOpenClawAgentProgressCardSchemaInTransaction,
   AGENT_PROGRESS_CARD_SCHEMA_SQL,
@@ -72,6 +73,7 @@ const AGENT_SCHEMA_COMPATIBILITY = {
     CONTEXT_ENGINE_TURN_OUTBOX_TABLE,
     MESSAGE_TOOL_RUN_OUTCOMES_TABLE,
     SESSION_GOAL_OPERATIONS_TABLE,
+    SESSION_PENDING_INPUTS_TABLE,
     SESSION_PARTICIPANTS_TABLE,
     SESSION_PROGRESS_CARDS_TABLE,
     SESSION_TRANSCRIPT_ARCHIVES_TABLE,

--- a/src/state/openclaw-agent-db.generated.d.ts
+++ b/src/state/openclaw-agent-db.generated.d.ts
@@ -305,6 +305,20 @@ export interface SessionParticipants {
   session_key: string;
 }
 
+export interface SessionPendingInputs {
+  accepted_at: number;
+  idempotency_key: string;
+  input_id: string;
+  lifecycle_generation: string;
+  message_json: string;
+  request_hash: string;
+  run_id: string;
+  seq: Generated<number>;
+  session_id: string;
+  session_key: string;
+  state: string;
+}
+
 export interface SessionProgressCards {
   created_at: number;
   markdown: string | null;
@@ -531,6 +545,7 @@ export interface DB {
   session_members: SessionMembers;
   session_nodes: SessionNodes;
   session_participants: SessionParticipants;
+  session_pending_inputs: SessionPendingInputs;
   session_progress_cards: SessionProgressCards;
   session_suggestions: SessionSuggestions;
   session_transcript_active_events: SessionTranscriptActiveEvents;

--- a/src/state/openclaw-agent-db.test.ts
+++ b/src/state/openclaw-agent-db.test.ts
@@ -303,6 +303,7 @@ function downgradeCurrentAgentDatabaseToV13(databasePath: string): void {
       PRAGMA foreign_keys = OFF;
       PRAGMA legacy_alter_table = OFF;
       DROP TABLE session_participants;
+      DROP TABLE session_pending_inputs;
       DROP INDEX IF EXISTS idx_agent_session_windows_updated_at;
       DROP INDEX IF EXISTS idx_agent_session_windows_created_at;
       DROP INDEX IF EXISTS idx_agent_session_windows_conversation;

--- a/src/state/openclaw-agent-pending-inputs-schema.test.ts
+++ b/src/state/openclaw-agent-pending-inputs-schema.test.ts
@@ -1,0 +1,100 @@
+import { DatabaseSync } from "node:sqlite";
+import { afterEach, describe, expect, it } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { upsertSessionEntryCore } from "../config/sessions/session-accessor.js";
+import {
+  listSessionPendingInputs,
+  stageSessionPendingInput,
+} from "../config/sessions/session-accessor.pending-inputs.js";
+import { assertSqliteSchemaContains } from "../infra/sqlite-schema-contract.js";
+import {
+  closeOpenClawAgentDatabasesForTest,
+  openOpenClawAgentDatabase,
+} from "./openclaw-agent-db.js";
+import { ensureSessionPendingInputsSchema } from "./openclaw-agent-pending-inputs-schema.js";
+import { OPENCLAW_AGENT_SCHEMA_SQL } from "./openclaw-agent-schema.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+afterEach(() => closeOpenClawAgentDatabasesForTest());
+
+describe("pending input additive schema", () => {
+  it("leaves old stores table-free on reads and preserves accepted input through older-reader use and reopen", async () => {
+    const options = {
+      agentId: "main",
+      env: { OPENCLAW_STATE_DIR: tempDirs.make("openclaw-input-schema-") },
+    };
+    const scope = {
+      ...options,
+      sessionKey: "agent:main:pending-schema",
+      sessionId: "pending-schema-session",
+    };
+    await upsertSessionEntryCore(scope, { sessionId: scope.sessionId, updatedAt: 1 });
+    const filename = openOpenClawAgentDatabase(options).path;
+    closeOpenClawAgentDatabasesForTest();
+    const previous = new DatabaseSync(filename);
+    previous.exec("DROP TABLE session_pending_inputs");
+    const version = previous.prepare("PRAGMA user_version").get();
+    const metadata = previous
+      .prepare("SELECT schema_version, updated_at FROM schema_meta WHERE meta_key = 'primary'")
+      .get();
+    previous.close();
+    expect(listSessionPendingInputs(scope)).toEqual({ items: [], total: 0 });
+    const candidate = openOpenClawAgentDatabase(options);
+    expect(
+      candidate.db
+        .prepare("SELECT 1 FROM sqlite_schema WHERE name = 'session_pending_inputs'")
+        .get(),
+    ).toBeUndefined();
+    const receipt = await stageSessionPendingInput(scope, {
+      runId: "schema-run",
+      message: {
+        role: "user",
+        content: "Retain this accepted input",
+        timestamp: 1,
+        idempotencyKey: "schema-run:user",
+      },
+      assertCurrent: () => {},
+    });
+    receipt!.finish("interrupted");
+    ensureSessionPendingInputsSchema(candidate.db);
+    closeOpenClawAgentDatabasesForTest();
+    const older = new DatabaseSync(filename);
+    const previousSql = OPENCLAW_AGENT_SCHEMA_SQL.slice(
+      0,
+      OPENCLAW_AGENT_SCHEMA_SQL.indexOf("CREATE TABLE IF NOT EXISTS session_pending_inputs ("),
+    );
+    assertSqliteSchemaContains(older, filename, previousSql);
+    older
+      .prepare("UPDATE schema_meta SET updated_at = updated_at WHERE meta_key = 'primary'")
+      .run();
+    expect(older.prepare("PRAGMA user_version").get()).toEqual(version);
+    expect(
+      older
+        .prepare("SELECT schema_version, updated_at FROM schema_meta WHERE meta_key = 'primary'")
+        .get(),
+    ).toEqual(metadata);
+    older.close();
+    expect(listSessionPendingInputs(scope)).toMatchObject({
+      total: 1,
+      items: [{ state: "interrupted", message: { content: "Retain this accepted input" } }],
+    });
+    expect(openOpenClawAgentDatabase(options).db.prepare("PRAGMA user_version").get()).toEqual(
+      version,
+    );
+  });
+
+  it("rejects a drifted optional table rather than treating it as absent", () => {
+    const options = {
+      agentId: "main",
+      env: { OPENCLAW_STATE_DIR: tempDirs.make("openclaw-input-schema-drift-") },
+    };
+    const filename = openOpenClawAgentDatabase(options).path;
+    closeOpenClawAgentDatabasesForTest();
+    const drifted = new DatabaseSync(filename);
+    drifted.exec(
+      "DROP TABLE session_pending_inputs; CREATE TABLE session_pending_inputs (input_id TEXT NOT NULL PRIMARY KEY) STRICT",
+    );
+    drifted.close();
+    expect(() => openOpenClawAgentDatabase(options)).toThrow(/session_pending_inputs|schema/u);
+  });
+});

--- a/src/state/openclaw-agent-pending-inputs-schema.ts
+++ b/src/state/openclaw-agent-pending-inputs-schema.ts
@@ -1,0 +1,48 @@
+import type { DatabaseSync } from "node:sqlite";
+import { runSqliteImmediateTransactionSync } from "../infra/sqlite-transaction.js";
+import { OPENCLAW_AGENT_SCHEMA_SQL } from "./openclaw-agent-schema.js";
+
+export const SESSION_PENDING_INPUTS_TABLE = "session_pending_inputs";
+const presentDatabases = new WeakSet<DatabaseSync>();
+let absentDatabases = new WeakSet<DatabaseSync>();
+
+/** Cache feature-table presence per connection; first use invalidates earlier absence checks. */
+export function hasSessionPendingInputsSchema(db: DatabaseSync): boolean {
+  if (presentDatabases.has(db)) {
+    return true;
+  }
+  if (!db.isTransaction && absentDatabases.has(db)) {
+    return false;
+  }
+  // sqlite-allow-raw -- Feature-local schema discovery, never application data.
+  const present = Boolean(
+    db
+      .prepare("SELECT 1 FROM sqlite_schema WHERE type = 'table' AND name = ?")
+      .get(SESSION_PENDING_INPUTS_TABLE),
+  );
+  if (!db.isTransaction) {
+    (present ? presentDatabases : absentDatabases).add(db);
+  }
+  return present;
+}
+
+/** Lazily installs accepted-input custody without changing either schema version marker. */
+export function ensureSessionPendingInputsSchema(db: DatabaseSync): void {
+  if (hasSessionPendingInputsSchema(db)) {
+    return;
+  }
+  const start = OPENCLAW_AGENT_SCHEMA_SQL.indexOf(
+    `CREATE TABLE IF NOT EXISTS ${SESSION_PENDING_INPUTS_TABLE} (`,
+  );
+  if (start < 0) {
+    throw new Error("OpenClaw pending-input schema marker is missing.");
+  }
+  const nested = db.isTransaction;
+  runSqliteImmediateTransactionSync(db, () => {
+    db.exec(OPENCLAW_AGENT_SCHEMA_SQL.slice(start)); // sqlite-allow-raw -- Canonical additive DDL only.
+  });
+  absentDatabases = new WeakSet();
+  if (!nested) {
+    presentDatabases.add(db);
+  }
+}

--- a/src/state/openclaw-agent-pending-inputs-schema.ts
+++ b/src/state/openclaw-agent-pending-inputs-schema.ts
@@ -14,8 +14,8 @@ export function hasSessionPendingInputsSchema(db: DatabaseSync): boolean {
   if (!db.isTransaction && absentDatabases.has(db)) {
     return false;
   }
-  // sqlite-allow-raw -- Feature-local schema discovery, never application data.
   const present = Boolean(
+    // sqlite-allow-raw -- Feature-local schema discovery, never application data.
     db
       .prepare("SELECT 1 FROM sqlite_schema WHERE type = 'table' AND name = ?")
       .get(SESSION_PENDING_INPUTS_TABLE),

--- a/src/state/openclaw-agent-schema.sql
+++ b/src/state/openclaw-agent-schema.sql
@@ -752,3 +752,24 @@ CREATE INDEX IF NOT EXISTS idx_memory_index_chunks_path
 
 CREATE INDEX IF NOT EXISTS idx_memory_index_chunks_source
   ON memory_index_chunks(source);
+
+-- Accepted input stays outside the active transcript until its exact turn owns execution.
+CREATE TABLE IF NOT EXISTS session_pending_inputs (
+  seq INTEGER PRIMARY KEY AUTOINCREMENT,
+  input_id TEXT NOT NULL UNIQUE,
+  session_key TEXT NOT NULL,
+  session_id TEXT NOT NULL,
+  idempotency_key TEXT NOT NULL,
+  run_id TEXT NOT NULL,
+  request_hash TEXT NOT NULL,
+  message_json TEXT NOT NULL,
+  lifecycle_generation TEXT NOT NULL,
+  state TEXT NOT NULL CHECK (state IN ('queued', 'interrupted', 'cancelled')),
+  accepted_at INTEGER NOT NULL,
+  UNIQUE (session_id, idempotency_key),
+  FOREIGN KEY (session_key) REFERENCES session_nodes(session_key) ON DELETE CASCADE,
+  FOREIGN KEY (session_id) REFERENCES session_windows(session_id) ON DELETE CASCADE
+) STRICT;
+
+CREATE INDEX IF NOT EXISTS idx_agent_session_pending_inputs_session
+  ON session_pending_inputs(session_key, session_id, seq DESC);

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.telegram-direct.json
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.telegram-direct.json
@@ -1053,7 +1053,7 @@
       },
       {
         "deferLoading": true,
-        "description": "Read sanitized visible-session history. Before reply/debug/resume. Supports limit, offset, search-result sessionId/messageId anchors, and tool messages.",
+        "description": "Read sanitized visible-session history. Before reply/debug/resume. Supports limit, offset, search-result sessionId/messageId anchors, and tool messages. pendingInputs are accepted inputs outside model history; page with pendingBefore=nextBefore. Cancelled/interrupted inputs never replay automatically. Lower limit for richer pending previews.",
         "inputSchema": {
           "properties": {
             "includeTools": {
@@ -1069,6 +1069,10 @@
             },
             "offset": {
               "minimum": 0,
+              "type": "integer"
+            },
+            "pendingBefore": {
+              "minimum": 1,
               "type": "integer"
             },
             "sessionId": {

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/discord-group-codex-message-tool.md.diff
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/discord-group-codex-message-tool.md.diff
@@ -1,5 +1,5 @@
---- telegram-direct-codex-message-tool.md	sha256=aade02aeb586f68c2768913e2a055afbd38d022d3559bba23eec9fa7bc6889f6
-+++ discord-group-codex-message-tool.md	sha256=1c94c966be8fdefaa4f0a4831e13dde1e6a20445cda04dc4e8a17b8e0bdebb85
+--- telegram-direct-codex-message-tool.md	sha256=e5aff3fdc2afe35a12bd45977cd039e03c5b860ea1064e6ae668c3aa66d885f6
++++ discord-group-codex-message-tool.md	sha256=a88fffc2a2afc0daacc06878c824fb80479381bbd4d2115401904fcf2d709ca4
 @@ -1,1 +1,1 @@
 -# Telegram Direct Codex Message Tool Turn
 +# Discord Group Codex Message Tool Turn
@@ -29,10 +29,10 @@
 -    "dynamicToolsFrom": "codex-dynamic-tools.telegram-direct.json",
 +    "dynamicToolsFrom": "codex-dynamic-tools.discord-group.json",
 @@ -235,2 +235,2 @@
--    "chars": 55956,
--    "roughTokens": 13989
-+    "chars": 56536,
-+    "roughTokens": 14134
+-    "chars": 56253,
+-    "roughTokens": 14064
++    "chars": 56833,
++    "roughTokens": 14209
 @@ -239,2 +239,2 @@
 -    "chars": 3518,
 -    "roughTokens": 880
@@ -44,10 +44,10 @@
 +    "chars": 28944,
 +    "roughTokens": 7236
 @@ -247,2 +247,2 @@
--    "chars": 83422,
--    "roughTokens": 20856
-+    "chars": 85482,
-+    "roughTokens": 21371
+-    "chars": 83719,
+-    "roughTokens": 20930
++    "chars": 85779,
++    "roughTokens": 21445
 @@ -251,2 +251,2 @@
 -    "chars": 863,
 -    "roughTokens": 216

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-direct-codex-message-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-direct-codex-message-tool.md
@@ -232,8 +232,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 0
   },
   "dynamicToolsJson": {
-    "chars": 55956,
-    "roughTokens": 13989
+    "chars": 56253,
+    "roughTokens": 14064
   },
   "openClawDeveloperInstructions": {
     "chars": 3518,
@@ -244,8 +244,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 6866
   },
   "totalWithDynamicToolsJson": {
-    "chars": 83422,
-    "roughTokens": 20856
+    "chars": 83719,
+    "roughTokens": 20930
   },
   "userInputText": {
     "chars": 863,

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-heartbeat-codex-tool.md.diff
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-heartbeat-codex-tool.md.diff
@@ -1,5 +1,5 @@
---- telegram-direct-codex-message-tool.md	sha256=aade02aeb586f68c2768913e2a055afbd38d022d3559bba23eec9fa7bc6889f6
-+++ telegram-heartbeat-codex-tool.md	sha256=83a9b8ca8a1f29c6e0d2435212cf0959619499d3db5d42149da5d30e20a03780
+--- telegram-direct-codex-message-tool.md	sha256=e5aff3fdc2afe35a12bd45977cd039e03c5b860ea1064e6ae668c3aa66d885f6
++++ telegram-heartbeat-codex-tool.md	sha256=6bea76a1504d7bc539fff77a4add25738e958071fb600702c1ebe559e7b96501
 @@ -1,1 +1,1 @@
 -# Telegram Direct Codex Message Tool Turn
 +# Telegram Direct Codex Heartbeat Tool Turn
@@ -32,20 +32,20 @@
 -    "dynamicToolsFrom": "codex-dynamic-tools.telegram-direct.json",
 +    "dynamicToolsFrom": "codex-dynamic-tools.heartbeat-turn.json",
 @@ -235,2 +230,2 @@
--    "chars": 55956,
--    "roughTokens": 13989
-+    "chars": 57449,
-+    "roughTokens": 14363
+-    "chars": 56253,
+-    "roughTokens": 14064
++    "chars": 57746,
++    "roughTokens": 14437
 @@ -243,2 +238,2 @@
 -    "chars": 27464,
 -    "roughTokens": 6866
 +    "chars": 27806,
 +    "roughTokens": 6952
 @@ -247,2 +242,2 @@
--    "chars": 83422,
--    "roughTokens": 20856
-+    "chars": 85257,
-+    "roughTokens": 21315
+-    "chars": 83719,
+-    "roughTokens": 20930
++    "chars": 85554,
++    "roughTokens": 21389
 @@ -251,2 +246,2 @@
 -    "chars": 863,
 -    "roughTokens": 216

--- a/test/scripts/openclaw-e2e-instance.test.ts
+++ b/test/scripts/openclaw-e2e-instance.test.ts
@@ -591,11 +591,12 @@ describe("scripts/lib/openclaw-e2e-instance.sh", () => {
           childPath,
           [
             "const fs = require('node:fs');",
-            "fs.writeFileSync(process.argv[2], String(process.pid));",
-            "fs.writeFileSync(process.argv[3], String(process.ppid));",
             "process.on('SIGTERM', () => {});",
             "process.on('SIGHUP', () => {});",
             "setInterval(() => {}, 1000);",
+            // PID publication lets the shell signal us; install handlers first.
+            "fs.writeFileSync(process.argv[2], String(process.pid));",
+            "fs.writeFileSync(process.argv[3], String(process.ppid));",
             "",
           ].join("\n"),
         );
@@ -687,12 +688,13 @@ fi
         childPath,
         [
           "const fs = require('node:fs');",
-          "fs.writeFileSync(process.argv[2], String(process.pid));",
           "process.on('SIGTERM', () => {",
           "  fs.writeFileSync(process.argv[3], 'terminated');",
           "  process.exit(0);",
           "});",
           "setInterval(() => {}, 1000);",
+          // Both PID files announce readiness for immediate group termination.
+          "fs.writeFileSync(process.argv[2], String(process.pid));",
           "",
         ].join("\n"),
       );
@@ -701,13 +703,13 @@ fi
         [
           "const fs = require('node:fs');",
           "const { spawn } = require('node:child_process');",
-          "fs.writeFileSync(process.argv[3], String(process.pid));",
           "const child = spawn(process.execPath, [process.argv[2], process.argv[4], process.argv[5]], {",
           "  stdio: 'ignore',",
           "});",
           "child.unref();",
           "process.on('SIGTERM', () => process.exit(0));",
           "setInterval(() => {}, 1000);",
+          "fs.writeFileSync(process.argv[3], String(process.pid));",
           "",
         ].join("\n"),
       );

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -6123,6 +6123,16 @@ export const en: TranslationMap = {
       loadingEarlier: "Loading earlier history…",
       noMatches: "No matching messages",
     },
+    pendingInputs: {
+      count: "Retained accepted inputs: {count}",
+      queued: "Accepted by the Gateway. Waiting for its turn.",
+      cancelled:
+        "Cancelled before its turn. This input will not run automatically; copy it to send a new message.",
+      interrupted:
+        "Interrupted before its turn. This input will not run automatically; copy it to send a new message.",
+      earlier: "Earlier accepted inputs",
+      latest: "Latest accepted inputs",
+    },
     pairingQrExpired: {
       title: "Pairing QR expired",
       reason: "Run /pair qr again to generate a fresh setup code.",

--- a/ui/src/pages/chat/chat-history.ts
+++ b/ui/src/pages/chat/chat-history.ts
@@ -1,5 +1,6 @@
 import { readSessionMessageSequence } from "@openclaw/gateway-client/browser";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
+import type { ChatPendingInputsPage } from "../../../../packages/gateway-protocol/src/schema/logs-chat.js";
 import { GatewayRequestError, type GatewayBrowserClient } from "../../api/gateway.ts";
 import type {
   AgentsListResult,
@@ -47,6 +48,7 @@ import {
   resolveStartupRetryDelayMs,
   sleep,
 } from "./chat-history-retry.ts";
+import { applyChatPendingInputs, clearChatPendingInputs } from "./chat-pending-inputs.ts";
 import type { ChatRunStartupPhase } from "./chat-run-startup.ts";
 import type { ChatState } from "./chat-state-contract.ts";
 import { persistChatComposerState } from "./composer-persistence.ts";
@@ -242,6 +244,7 @@ function shouldApplyChatHistoryResult(
 }
 
 export function resetChatHistoryProjection(state: ChatState, agentId?: string): void {
+  clearChatPendingInputs(state);
   const requests = getChatHistoryPaneRequests(state);
   // A destructive reset keeps the session key, so invalidate both the old
   // snapshot owner and its coalesced request before creating the next epoch.
@@ -348,6 +351,7 @@ type ChatSessionMessageSubscriptionState = ChatState & {
 };
 
 export type ChatHistoryResult = {
+  pendingInputs?: ChatPendingInputsPage;
   sourceCanonicalListRevision?: number;
   deltaCursor?: string;
   messages?: Array<unknown>;
@@ -381,6 +385,7 @@ export type ChatHistoryResult = {
 };
 
 type ChatHistoryDeltaResult = {
+  pendingInputs?: ChatPendingInputsPage;
   kind: "delta";
   messages: unknown[];
   deltaCursor: string;
@@ -2006,6 +2011,7 @@ async function loadChatHistoryUncached(
         state.chatDisplayedLeafEntryId = response.sessionInfo.activeLeafEntryId?.trim() || null;
       }
       state.currentSessionId = response.sessionInfo.sessionId?.trim() || previousSessionId;
+      applyChatPendingInputs(state, response.pendingInputs);
       // An accepted delta advances the same transcript generation, not a branch replacement.
       // Carry ownership across its leaf advance; reseeding loses attributed pending sends and runs.
       setChatSessionProjection(state, {
@@ -2037,6 +2043,7 @@ async function loadChatHistoryUncached(
       return {
         messages: state.chatMessages,
         deltaCursor: response.deltaCursor,
+        pendingInputs: response.pendingInputs,
         sessionInfo: response.sessionInfo,
         ...(response.inFlightRun ? { inFlightRun: response.inFlightRun } : {}),
         ...(response.metadata ? { metadata: response.metadata } : {}),
@@ -2110,6 +2117,7 @@ async function loadChatHistoryUncached(
     }
     state.chatHistoryPagination = reconciledHistory?.pagination ?? nextPagination;
     state.currentSessionId = nextSessionId;
+    applyChatPendingInputs(state, res.pendingInputs);
     commitCurrentChatHistorySnapshot(state, res.deltaCursor ?? null);
     if (
       state.reconnectResumeSessionId &&

--- a/ui/src/pages/chat/chat-pending-inputs.test.ts
+++ b/ui/src/pages/chat/chat-pending-inputs.test.ts
@@ -1,8 +1,9 @@
 /* @vitest-environment jsdom */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ChatPendingInputsPage } from "../../../../packages/gateway-protocol/src/schema/logs-chat.js";
+import { createDeferred } from "../../../../test/helpers/promise.js";
 import { createStorageMock } from "../../test-helpers/storage.ts";
-import { loadChatHistory } from "./chat-history.ts";
+import { getChatHistoryLoadState, loadChatHistory } from "./chat-history.ts";
 import { makeChatHost } from "./chat-host.test-support.ts";
 import {
   applyChatPendingInputs,
@@ -10,6 +11,8 @@ import {
   loadChatPendingInputs,
 } from "./chat-pending-inputs.ts";
 import { admitQueuedMessageForSession, readChatQueueForScope } from "./chat-queue.ts";
+import { handlePageGatewayEvent } from "./chat-state-events.ts";
+import type { ChatPageHost } from "./chat-state-host.ts";
 import { buildChatItems } from "./chat-thread-build.ts";
 import { resetChatThreadState } from "./chat-thread.ts";
 
@@ -36,6 +39,134 @@ afterEach(() => {
 });
 
 describe("server-owned pending input display", () => {
+  it.each(["send", "agent.run.started", "agent.input.settled"])(
+    "refreshes accepted inputs on %s while a retained pane is running",
+    async (reason) => {
+      const host = makeChatHost({
+        sessionKey,
+        currentSessionId: sessionId,
+        chatRunId: "active-run",
+        chatStream: "Live output",
+        requestHandlers: {
+          "chat.history": {
+            sessionId,
+            messages: [],
+            pendingInputs: page,
+            sessionInfo: { key: sessionKey, sessionId, hasActiveRun: true, status: "running" },
+          },
+        },
+      });
+      applyChatPendingInputs(host, { items: [], total: 0 });
+      // SAFETY: This event path uses the chat/session owners supplied by makeChatHost.
+      const state = host as ChatPageHost;
+      handlePageGatewayEvent(
+        state,
+        {
+          type: "event",
+          event: "sessions.changed",
+          payload: { sessionKey, agentId: "main", reason, hasActiveRun: true },
+        },
+        () => false,
+      );
+      await vi.waitFor(() => expect(getChatPendingInputs(host)?.page).toEqual(page));
+      expect(host.chatRunId).toBe("active-run");
+      expect(host.chatStream).toBe("Live output");
+      expect(host.request.mock.calls.filter(([method]) => method === "chat.history")).toHaveLength(
+        1,
+      );
+    },
+  );
+
+  it.each(["active-run", null])(
+    "supersedes a stale custody read when a user input promotes with local run %s",
+    async (runId) => {
+      const stale = createDeferred<unknown>();
+      const initialUser = {
+        role: "user",
+        content: "First turn",
+        __openclaw: { id: "first", seq: 1 },
+      };
+      const promoted = {
+        role: "user",
+        content: "Keep my accepted input",
+        __openclaw: { id: input.id, seq: 2 },
+      };
+      const toolMessage = { role: "assistant", runId: "active-run", toolCallId: "live-tool" };
+      let historyReads = 0;
+      const host = makeChatHost({
+        sessionKey,
+        currentSessionId: sessionId,
+        chatRunId: runId,
+        chatStream: runId ? "Live output" : null,
+        chatMessages: [initialUser],
+        chatHistoryPagination: { hasMore: false, totalMessages: 1 },
+        chatToolMessages: [toolMessage],
+        toolStreamOrder: ["live-tool"],
+        toolStreamById: new Map([
+          [
+            "live-tool",
+            {
+              toolCallId: "live-tool",
+              runId: "active-run",
+              name: "exec",
+              startedAt: 1,
+              receivedAt: 1,
+              message: toolMessage,
+            },
+          ],
+        ]),
+        requestHandlers: {
+          "chat.history": () =>
+            ++historyReads === 1
+              ? stale.promise
+              : {
+                  sessionId,
+                  messages: [initialUser, promoted],
+                  pendingInputs: { items: [], total: 0 },
+                  sessionInfo: {
+                    key: sessionKey,
+                    sessionId,
+                    hasActiveRun: true,
+                    status: "running",
+                  },
+                },
+        },
+      });
+      applyChatPendingInputs(host, page);
+      const loading = loadChatHistory(host);
+      // SAFETY: This event path uses the chat/session owners supplied by makeChatHost.
+      const state = host as ChatPageHost;
+      handlePageGatewayEvent(state, {
+        type: "event",
+        event: "session.message",
+        payload: {
+          sessionKey,
+          agentId: "main",
+          sessionId,
+          hasActiveRun: true,
+          messageId: input.id,
+          messageSeq: 2,
+          message: promoted,
+        },
+      });
+      expect(historyReads).toBe(2);
+      const refreshed = await loadChatHistory(host);
+      expect(host.lastError).toBeNull();
+      expect(getChatHistoryLoadState(host).phase).toBe("committed");
+      expect(refreshed).toMatchObject({ pendingInputs: { items: [], total: 0 } });
+      expect(getChatPendingInputs(host)?.page.total).toBe(0);
+      stale.resolve({ sessionId, messages: [initialUser], pendingInputs: page });
+      await loading;
+      expect(getChatPendingInputs(host)?.page.total).toBe(0);
+      expect(host.chatMessages).toEqual([initialUser, promoted]);
+      expect(host.chatRunId).toBe(runId);
+      expect(host.chatStream).toBe(runId ? "Live output" : null);
+      expect(host.chatToolMessages).toEqual([toolMessage]);
+      expect(host.toolStreamById.has("live-tool")).toBe(true);
+      expect(historyReads).toBe(2);
+    },
+  );
+
   it("retires browser retry custody while keeping accepted input separate from history", async () => {
     const history = [
       { role: "assistant", content: "Still working", __openclaw: { id: "reply-1", seq: 1 } },

--- a/ui/src/pages/chat/chat-pending-inputs.test.ts
+++ b/ui/src/pages/chat/chat-pending-inputs.test.ts
@@ -1,0 +1,156 @@
+/* @vitest-environment jsdom */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ChatPendingInputsPage } from "../../../../packages/gateway-protocol/src/schema/logs-chat.js";
+import { createStorageMock } from "../../test-helpers/storage.ts";
+import { loadChatHistory } from "./chat-history.ts";
+import { makeChatHost } from "./chat-host.test-support.ts";
+import {
+  applyChatPendingInputs,
+  getChatPendingInputs,
+  loadChatPendingInputs,
+} from "./chat-pending-inputs.ts";
+import { admitQueuedMessageForSession, readChatQueueForScope } from "./chat-queue.ts";
+import { buildChatItems } from "./chat-thread-build.ts";
+import { resetChatThreadState } from "./chat-thread.ts";
+
+const sessionKey = "agent:main:accepted-inputs";
+const sessionId = "accepted-input-session";
+const input: ChatPendingInputsPage["items"][number] = {
+  id: "input-1",
+  runId: "run-queued",
+  acceptedAt: 100,
+  state: "interrupted",
+  message: {
+    role: "user",
+    content: "Keep my accepted input",
+    __openclaw: { id: "pending:input-1" },
+  },
+};
+const page: ChatPendingInputsPage = { items: [input], total: 2, nextBefore: 2 };
+beforeEach(() => {
+  vi.stubGlobal("sessionStorage", createStorageMock());
+});
+afterEach(() => {
+  resetChatThreadState();
+  vi.unstubAllGlobals();
+});
+
+describe("server-owned pending input display", () => {
+  it("retires browser retry custody while keeping accepted input separate from history", async () => {
+    const history = [
+      { role: "assistant", content: "Still working", __openclaw: { id: "reply-1", seq: 1 } },
+    ];
+    const host = makeChatHost({
+      sessionKey,
+      currentSessionId: sessionId,
+      requestHandlers: { "chat.history": { messages: history, sessionId, pendingInputs: page } },
+    });
+    const queued = {
+      id: "outbox-1",
+      text: "Keep my accepted input",
+      createdAt: 100,
+      sessionKey,
+      sendRunId: input.runId,
+      sendState: "waiting-reconnect" as const,
+    };
+    expect(admitQueuedMessageForSession(host, sessionKey, queued)).toBe(true);
+    await loadChatHistory(host);
+    expect(readChatQueueForScope(host, sessionKey)).toEqual([]);
+    expect(host.chatMessages).toEqual(history);
+    expect(getChatPendingInputs(host)?.page).toEqual(page);
+    const items = buildChatItems({
+      paneId: "pending-pane",
+      sessionKey,
+      messages: host.chatMessages,
+      pendingInputs: page.items,
+      queue: host.chatQueue,
+      toolMessages: [],
+      streamSegments: [],
+      stream: null,
+      streamStartedAt: null,
+      showToolCalls: true,
+    });
+    expect(items.filter((item) => item.kind === "group" && item.role === "user")).toHaveLength(1);
+    expect(items).toContainEqual(
+      expect.objectContaining({
+        kind: "notice",
+        text: expect.stringContaining("will not run automatically"),
+      }),
+    );
+    expect(host.request.mock.calls.some(([method]) => method === "chat.send")).toBe(false);
+  });
+
+  it("pages custody without replacing transcript or applying a stale physical-session response", async () => {
+    let resolve!: (value: unknown) => void;
+    const response = new Promise((done) => {
+      resolve = done;
+    });
+    const host = makeChatHost({
+      sessionKey,
+      currentSessionId: sessionId,
+      requestHandlers: { "chat.history": () => response },
+    });
+    const history = [{ role: "user", content: "Canonical history" }];
+    host.chatMessages = history;
+    applyChatPendingInputs(host, page);
+    const loading = loadChatPendingInputs(host, 2);
+    expect(host.request).toHaveBeenCalledWith(
+      "chat.history",
+      expect.objectContaining({ pendingBefore: 2 }),
+    );
+    host.currentSessionId = "replacement-session";
+    resolve({ sessionId, pendingInputs: { items: [], total: 2 } });
+    await loading;
+    expect(host.chatMessages).toBe(history);
+    expect(getChatPendingInputs(host)).toBeUndefined();
+    expect(host.request).toHaveBeenCalledTimes(1);
+  });
+
+  it("replaces a server pending bubble with canonical persistence exactly once", () => {
+    const promoted = {
+      role: "user",
+      content: "Keep my accepted input",
+      __openclaw: { id: "input-1", seq: 2, idempotencyKey: "run-queued:user" },
+    };
+    const items = buildChatItems({
+      paneId: "promoted-pane",
+      sessionKey,
+      messages: [promoted],
+      pendingInputs: page.items,
+      queue: [],
+      toolMessages: [],
+      streamSegments: [],
+      stream: null,
+      streamStartedAt: null,
+      showToolCalls: true,
+    });
+    expect(items).toHaveLength(1);
+    expect(items[0]).toMatchObject({
+      kind: "group",
+      role: "user",
+      messages: [{ message: promoted }],
+    });
+  });
+
+  it("does not treat another message sharing the run correlation as input promotion", () => {
+    const items = buildChatItems({
+      paneId: "correlated-pane",
+      sessionKey,
+      messages: [
+        {
+          role: "assistant",
+          content: "Earlier result",
+          __openclaw: { id: "another-entry", runId: input.runId },
+        },
+      ],
+      pendingInputs: page.items,
+      queue: [],
+      toolMessages: [],
+      streamSegments: [],
+      stream: null,
+      streamStartedAt: null,
+      showToolCalls: true,
+    });
+    expect(items.filter((item) => item.kind === "group" && item.role === "user")).toHaveLength(1);
+  });
+});

--- a/ui/src/pages/chat/chat-pending-inputs.test.ts
+++ b/ui/src/pages/chat/chat-pending-inputs.test.ts
@@ -5,6 +5,7 @@ import { createDeferred } from "../../../../test/helpers/promise.js";
 import { createStorageMock } from "../../test-helpers/storage.ts";
 import { getChatHistoryLoadState, loadChatHistory } from "./chat-history.ts";
 import { makeChatHost } from "./chat-host.test-support.ts";
+import { createInitializationContext } from "./chat-pane.test-support.ts";
 import {
   applyChatPendingInputs,
   getChatPendingInputs,
@@ -13,6 +14,7 @@ import {
 import { admitQueuedMessageForSession, readChatQueueForScope } from "./chat-queue.ts";
 import { handlePageGatewayEvent } from "./chat-state-events.ts";
 import type { ChatPageHost } from "./chat-state-host.ts";
+import { createPageState } from "./chat-state-page.ts";
 import { buildChatItems } from "./chat-thread-build.ts";
 import { resetChatThreadState } from "./chat-thread.ts";
 
@@ -30,6 +32,22 @@ const input: ChatPendingInputsPage["items"][number] = {
   },
 };
 const page: ChatPendingInputsPage = { items: [input], total: 2, nextBefore: 2 };
+
+function makeChatPageHost({
+  requestHandlers,
+  ...overrides
+}: Partial<ChatPageHost> & { requestHandlers: Record<string, unknown> }) {
+  const { client, hello, request, sessions } = makeChatHost({ requestHandlers });
+  const context = { ...createInitializationContext(), sessions };
+  const host = createPageState(
+    context,
+    { invalidate: vi.fn(), afterCommit: () => () => {} },
+    { querySelector: () => null },
+  );
+  Object.assign(host, { client, hello, connected: true }, overrides);
+  return Object.assign(host, { request });
+}
+
 beforeEach(() => {
   vi.stubGlobal("sessionStorage", createStorageMock());
 });
@@ -42,7 +60,7 @@ describe("server-owned pending input display", () => {
   it.each(["send", "agent.run.started", "agent.input.settled"])(
     "refreshes accepted inputs on %s while a retained pane is running",
     async (reason) => {
-      const host = makeChatHost({
+      const host = makeChatPageHost({
         sessionKey,
         currentSessionId: sessionId,
         chatRunId: "active-run",
@@ -57,10 +75,8 @@ describe("server-owned pending input display", () => {
         },
       });
       applyChatPendingInputs(host, { items: [], total: 0 });
-      // SAFETY: This event path uses the chat/session owners supplied by makeChatHost.
-      const state = host as ChatPageHost;
       handlePageGatewayEvent(
-        state,
+        host,
         {
           type: "event",
           event: "sessions.changed",
@@ -93,7 +109,7 @@ describe("server-owned pending input display", () => {
       };
       const toolMessage = { role: "assistant", runId: "active-run", toolCallId: "live-tool" };
       let historyReads = 0;
-      const host = makeChatHost({
+      const host = makeChatPageHost({
         sessionKey,
         currentSessionId: sessionId,
         chatRunId: runId,
@@ -134,9 +150,7 @@ describe("server-owned pending input display", () => {
       });
       applyChatPendingInputs(host, page);
       const loading = loadChatHistory(host);
-      // SAFETY: This event path uses the chat/session owners supplied by makeChatHost.
-      const state = host as ChatPageHost;
-      handlePageGatewayEvent(state, {
+      handlePageGatewayEvent(host, {
         type: "event",
         event: "session.message",
         payload: {

--- a/ui/src/pages/chat/chat-pending-inputs.ts
+++ b/ui/src/pages/chat/chat-pending-inputs.ts
@@ -1,0 +1,133 @@
+import { readSessionMessageIdentity } from "@openclaw/gateway-client/browser";
+import type { ChatPendingInputsPage } from "../../../../packages/gateway-protocol/src/schema/logs-chat.js";
+import { t } from "../../i18n/index.ts";
+import type { ChatItem } from "../../lib/chat/chat-types.ts";
+import { formatUiError } from "../../lib/format-error.ts";
+import { resolveUiSelectedSessionAgentId } from "../../lib/sessions/session-key.ts";
+import { removeQueuedMessage } from "./chat-queue.ts";
+import type { ChatState } from "./chat-state-contract.ts";
+import { messageMatchesSearchQuery } from "./chat-thread-items.ts";
+
+type PendingInputView = {
+  sessionKey: string;
+  sessionId: string | null;
+  agentId: string | undefined;
+  page: ChatPendingInputsPage;
+  before?: number;
+  loading: boolean;
+  error?: string;
+};
+const pendingInputViews = new WeakMap<ChatState, PendingInputView>();
+
+export function buildPendingInputItems(
+  inputs: ChatPendingInputsPage["items"],
+  history: unknown[],
+  searchQuery?: string,
+): ChatItem[] {
+  // Custody records stay outside active-run ordering until the writer promotes them.
+  const items: ChatItem[] = [];
+  for (const input of inputs) {
+    if (
+      history.some((message) => {
+        const identity = readSessionMessageIdentity(message);
+        return identity?.role === "user" && identity.id === input.id;
+      })
+    ) {
+      continue;
+    }
+    if (searchQuery?.trim() && !messageMatchesSearchQuery(input.message, searchQuery)) {
+      continue;
+    }
+    items.push({ kind: "message", key: `pending-input:${input.id}`, message: input.message });
+    items.push({
+      kind: "notice",
+      key: `pending-input:${input.id}:state`,
+      timestamp: input.acceptedAt,
+      text: t(
+        input.state === "queued"
+          ? "chat.pendingInputs.queued"
+          : input.state === "cancelled"
+            ? "chat.pendingInputs.cancelled"
+            : "chat.pendingInputs.interrupted",
+      ),
+    });
+  }
+  return items;
+}
+
+export function getChatPendingInputs(state: ChatState): PendingInputView | undefined {
+  const view = pendingInputViews.get(state);
+  return view?.sessionKey === state.sessionKey &&
+    view.sessionId === (state.currentSessionId ?? null) &&
+    view.agentId === resolveUiSelectedSessionAgentId(state)
+    ? view
+    : undefined;
+}
+
+export function clearChatPendingInputs(state: ChatState): void {
+  pendingInputViews.delete(state);
+}
+
+export function applyChatPendingInputs(
+  state: ChatState,
+  page: ChatPendingInputsPage | undefined,
+  before?: number,
+): void {
+  pendingInputViews.set(state, {
+    sessionKey: state.sessionKey,
+    sessionId: state.currentSessionId ?? null,
+    agentId: resolveUiSelectedSessionAgentId(state),
+    page: page ?? { items: [], total: 0 },
+    before,
+    loading: false,
+  });
+  const acceptedRunIds = new Set(page?.items.flatMap((item) => (item.runId ? [item.runId] : [])));
+  // The server owns accepted input even after an interruption. Retiring the
+  // outbox copy prevents reconnect from silently submitting it a second time.
+  for (const item of state.chatQueue) {
+    if (item.sendRunId && acceptedRunIds.has(item.sendRunId)) {
+      removeQueuedMessage(state, item.id);
+    }
+  }
+  state.requestUpdate?.();
+}
+
+export async function loadChatPendingInputs(state: ChatState, before?: number): Promise<void> {
+  const view = getChatPendingInputs(state);
+  const client = state.client;
+  if (!view || view.loading || !client || !state.connected) {
+    return;
+  }
+  const connectionEpoch = state.connectionEpoch;
+  view.loading = true;
+  view.error = undefined;
+  state.requestUpdate?.();
+  const current = () =>
+    getChatPendingInputs(state) === view &&
+    state.client === client &&
+    state.connected &&
+    state.connectionEpoch === connectionEpoch;
+  try {
+    const result = await client.request<{
+      sessionId?: string;
+      pendingInputs?: ChatPendingInputsPage;
+    }>("chat.history", {
+      sessionKey: state.sessionKey,
+      agentId: view.agentId,
+      limit: 20,
+      ...(before === undefined ? {} : { pendingBefore: before }),
+    });
+    if (current() && result.sessionId === view.sessionId) {
+      applyChatPendingInputs(state, result.pendingInputs, before);
+    }
+  } catch (error) {
+    if (current()) {
+      view.error = formatUiError(error);
+    }
+  } finally {
+    view.loading = false;
+    if (current()) {
+      state.requestUpdate?.();
+    }
+  }
+}

--- a/ui/src/pages/chat/chat-state-events.ts
+++ b/ui/src/pages/chat/chat-state-events.ts
@@ -1,3 +1,4 @@
+import { readSessionMessageIdentity } from "@openclaw/gateway-client/browser";
 import { asNullableRecord } from "@openclaw/normalization-core/record-coerce";
 import type { SessionObserverDigest } from "../../../../packages/gateway-protocol/src/schema/sessions.js";
 import type { GatewayEventFrame } from "../../api/gateway.ts";
@@ -72,6 +73,7 @@ import { readTerminalReplyRecoveryState } from "./terminal-reply-recovery.ts";
 import { handleAgentEvent, handleSessionOperationEvent } from "./tool-stream.ts";
 
 const BRANCH_TOPOLOGY_REASONS = new Set(["rewind", "branch-switch", "fork", "reset", "new"]);
+const PENDING_INPUT_REASONS = new Set(["send", "agent.run.started", "agent.input.settled"]);
 const MISSING_TERMINAL_HISTORY_RETRY_DELAYS_MS = [100, 400, 1_500, 3_000] as const;
 const MAX_REMEMBERED_TERMINAL_RECOVERY_CLAIMS = 64;
 type ChatPanePresentation = () => boolean;
@@ -154,6 +156,8 @@ function handleSessionMessageEvent(
     return;
   }
   const matchesChat = sessionMessageMatchesChat(state, event);
+  const isUserMessage =
+    readSessionMessageIdentity(asNullableRecord(payload)?.message)?.role === "user";
   if (matchesChat) {
     // A previous run can persist its final after the next local run starts.
     // Admit that sequenced row now so the later unsequenced chat.final replay
@@ -173,6 +177,13 @@ function handleSessionMessageEvent(
     const runId = event.clientRunId ?? event.runId ?? runIdBeforeApply;
     state.pendingSessionMessageReloadSessionKey = event.key;
     if (event.hasActiveRun === true) {
+      if (isUserMessage) {
+        // Promotion changes pending custody even while the next turn is active.
+        void loadChatHistory(state, {
+          deferBranches: !presentation(),
+          supersedeInFlight: true,
+        }).finally(() => state.requestUpdate?.());
+      }
       return;
     }
     if (finishSessionMessageRunReconcile(state, event.key, runId, result.row, presentation)) {
@@ -199,9 +210,10 @@ function handleSessionMessageEvent(
   }
   if (matchesChat) {
     state.pendingSessionMessageReloadSessionKey = null;
-    void loadChatHistory(state, { deferBranches: !presentation() }).finally(() =>
-      state.requestUpdate?.(),
-    );
+    void loadChatHistory(state, {
+      deferBranches: !presentation(),
+      supersedeInFlight: isUserMessage && event.hasActiveRun === true,
+    }).finally(() => state.requestUpdate?.());
   }
 }
 
@@ -415,6 +427,18 @@ function handleSessionsChangedEvent(
       state.requestUpdate?.(),
     );
     return;
+  }
+  if (
+    matchesChat &&
+    typeof source?.reason === "string" &&
+    PENDING_INPUT_REASONS.has(source.reason)
+  ) {
+    // Custody can change without a transcript append. A read begun before this
+    // event must not hide accepted input until the active run ends.
+    void loadChatHistory(state, {
+      deferBranches: !presented,
+      supersedeInFlight: true,
+    }).finally(() => state.requestUpdate?.());
   }
   if (
     result.applied &&

--- a/ui/src/pages/chat/chat-thread-build.ts
+++ b/ui/src/pages/chat/chat-thread-build.ts
@@ -63,6 +63,7 @@ import {
   userTurnSendIdentity,
 } from "./chat-thread-items.ts";
 import {
+  applyPersistedToolInvocationBounds,
   findCurrentTurnBounds,
   findRunTurnBounds,
   isKeyedAssistantStreamFallbackMessage,
@@ -606,9 +607,9 @@ export function buildChatItems(props: BuildChatItemsProps): Array<ChatItem | Mes
     }
   }
 
-  // Merge timestamped transient projections into the stable transcript order.
-  // The latest user row is a causal floor: current-run items must not jump
-  // above it under clock skew, then jump back when history materializes them.
+  // Unowned projections keep their user-turn floor despite clock skew;
+  // identified live tools stay in the canonical invocation's interval.
+  applyPersistedToolInvocationBounds(items, toolItems, projectionInsertionBounds);
   insertChatItemsByTimestamp(
     items,
     timestampedProjectionItems,

--- a/ui/src/pages/chat/chat-thread-build.ts
+++ b/ui/src/pages/chat/chat-thread-build.ts
@@ -1,5 +1,10 @@
+import {
+  isLocallyOptimisticSessionMessage,
+  readSessionMessageIdentity,
+} from "@openclaw/gateway-client/browser";
 import { asNullableRecord as asRecord } from "@openclaw/normalization-core/record-coerce";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import type { ChatPendingInputsPage } from "../../../../packages/gateway-protocol/src/schema/logs-chat.js";
 import { composeTranscriptDisplay } from "../../../../src/chat/transcript-display-position.js";
 import type { QuestionPrompt } from "../../app/question-prompt.ts";
 import { t } from "../../i18n/index.ts";
@@ -22,6 +27,7 @@ import {
 import { extractTextCached } from "../../lib/chat/message-extract.ts";
 import { normalizeRoleForGrouping } from "../../lib/chat/message-normalizer.ts";
 import { areUiSessionKeysEquivalent } from "../../lib/sessions/session-key.ts";
+import { buildPendingInputItems } from "./chat-pending-inputs.ts";
 import {
   buildCompactionDividerItem,
   buildGuardianNoticeItem,
@@ -84,6 +90,7 @@ export type BuildChatItemsProps = {
   stream: string | null;
   streamStartedAt: number | null;
   queue?: ChatQueueItem[];
+  pendingInputs?: ChatPendingInputsPage["items"];
   showToolCalls: boolean;
   persistCommentary?: boolean;
   /** True while the agent is visibly working (isChatRunWorking). */
@@ -100,10 +107,16 @@ export type BuildChatItemsProps = {
 export function buildChatItems(props: BuildChatItemsProps): Array<ChatItem | MessageGroup> {
   let items: ChatItem[] = [];
   const tools = props.toolMessages.filter((message) => asRecord(message) !== null);
+  const pendingInputs = props.pendingInputs ?? [];
+  const acceptedRunIds = new Set(pendingInputs.map((input) => input.runId));
   const history = composeTranscriptDisplay(
     props.messages.filter(
       (message) =>
         !isAssistantHeartbeatAckForDisplay(message) &&
+        !(
+          isLocallyOptimisticSessionMessage(message) &&
+          acceptedRunIds.has(readSessionMessageIdentity(message)?.runId ?? "")
+        ) &&
         (props.persistCommentary !== false || !isKeyedAssistantStreamFallbackMessage(message)),
     ),
   );
@@ -214,7 +227,9 @@ export function buildChatItems(props: BuildChatItemsProps): Array<ChatItem | Mes
   // Once authoritative history carries the send id, that message owns the bubble.
   // Keep the queue row for run progress and delivery retirement, but do not render both copies.
   const threadQueuedSends = queuedSends.filter(
-    (queued) => !chatMessagesContainQueuedSend(history, queued, true),
+    (queued) =>
+      !acceptedRunIds.has(queued.sendRunId ?? "") &&
+      !chatMessagesContainQueuedSend(history, queued, true),
   );
   const currentRunQueuedSends = threadQueuedSends.filter(
     (queued) =>
@@ -673,5 +688,12 @@ export function buildChatItems(props: BuildChatItemsProps): Array<ChatItem | Mes
     appendQueuedSend(queued);
   }
 
+  items.push(
+    ...buildPendingInputItems(
+      pendingInputs,
+      history,
+      props.searchOpen ? props.searchQuery : undefined,
+    ),
+  );
   return groupMessages(collapseSequentialDuplicateMessages(coalesceToolActivityMessages(items)));
 }

--- a/ui/src/pages/chat/chat-thread-items.ts
+++ b/ui/src/pages/chat/chat-thread-items.ts
@@ -243,13 +243,7 @@ export function findNearestAssistantMessageIndex(
     const nextDelta = next.timestamp - toolTimestamp;
     return nextDelta < previousDelta ? next.index : previous.index;
   }
-  if (previous) {
-    return previous.index;
-  }
-  if (next) {
-    return next.index;
-  }
-  return assistantEntries[assistantEntries.length - 1]?.index ?? null;
+  return previous?.index ?? next?.index ?? assistantEntries.at(-1)?.index ?? null;
 }
 
 export function findCanvasInsertionIndex(

--- a/ui/src/pages/chat/chat-thread-items.ts
+++ b/ui/src/pages/chat/chat-thread-items.ts
@@ -2,6 +2,7 @@ import { readSessionMessageIdentity } from "@openclaw/gateway-client/browser";
 import { asFiniteNumber } from "@openclaw/normalization-core/number-coercion";
 import { asNullableRecord as asRecord } from "@openclaw/normalization-core/record-coerce";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
+import { CHAT_PENDING_INPUT_MESSAGE_PREFIX } from "../../../../packages/gateway-protocol/src/schema/chat-history-constants.js";
 import { resolveToolUseId } from "../../../../src/chat/tool-content.js";
 import { escapeRegExp } from "../../../../src/shared/regexp.js";
 import type { ChatItem, ChatQueueItem, ToolCard } from "../../lib/chat/chat-types.ts";
@@ -339,9 +340,10 @@ export function userTurnSendIdentity(message: unknown): string | null {
 }
 
 export function persistedMessageEntryId(message: unknown): string | null {
-  return isPendingSendMessage(message)
+  const id = readChatThreadMessageIdentity(message)?.id;
+  return isPendingSendMessage(message) || id?.startsWith(CHAT_PENDING_INPUT_MESSAGE_PREFIX)
     ? null
-    : (readChatThreadMessageIdentity(message)?.id ?? null);
+    : (id ?? null);
 }
 
 function transcriptMessageSourceKey(message: unknown): string | null {

--- a/ui/src/pages/chat/chat-thread-run-identity.ts
+++ b/ui/src/pages/chat/chat-thread-run-identity.ts
@@ -7,8 +7,9 @@ import {
 import type { ChatItem } from "../../lib/chat/chat-types.ts";
 import { normalizeRoleForGrouping } from "../../lib/chat/message-normalizer.ts";
 import { userTurnSendIdentity, type TurnInsertionBounds } from "./chat-thread-items.ts";
-import { safeNormalizeMessage } from "./chat-turn-boundary.ts";
+import { chatItemStartsUserTurn, safeNormalizeMessage } from "./chat-turn-boundary.ts";
 import { readLiveTerminalRunId } from "./terminal-message-identity.ts";
+import { buildToolStreamIdentity, extractToolMessageRefs } from "./tool-stream-identity.ts";
 
 export function transcriptRunId(message: unknown): string | undefined {
   const identity = readSessionMessageIdentity(message);
@@ -111,4 +112,45 @@ export function resolveRunInsertionBounds(
   // Legacy rows may lack the user-run identity needed for exact bounds. Keep
   // them ordered before the current prompt instead of attaching them to it.
   return currentTurnBounds?.afterKey ? { beforeKey: currentTurnBounds.afterKey } : null;
+}
+
+/** A persisted invocation owns its live echo's interval even without a user send key. */
+export function applyPersistedToolInvocationBounds(
+  items: ChatItem[],
+  tools: Array<{ key: string; message: unknown }>,
+  insertionBounds: Map<string, TurnInsertionBounds>,
+): void {
+  const invocations = new Map<string, TurnInsertionBounds | null>();
+  let bounds: TurnInsertionBounds = {};
+  for (const item of items) {
+    if (item.kind === "divider") {
+      invocations.clear();
+    }
+    if (chatItemStartsUserTurn(item) || item.kind === "divider") {
+      bounds.beforeKey = item.key;
+      bounds = { afterKey: item.key };
+    } else if (item.kind === "message") {
+      for (const ref of extractToolMessageRefs(item.message)) {
+        if (!ref.runId) {
+          continue;
+        }
+        const key = buildToolStreamIdentity(ref.runId, ref.id);
+        // Reused identities on opposite sides of a user/reset remain ambiguous.
+        invocations.set(
+          key,
+          invocations.has(key) && invocations.get(key) !== bounds ? null : bounds,
+        );
+      }
+    }
+  }
+  for (const tool of tools) {
+    const refs = extractToolMessageRefs(tool.message);
+    const matching = refs.map((ref) =>
+      ref.runId ? invocations.get(buildToolStreamIdentity(ref.runId, ref.id)) : undefined,
+    );
+    const [first] = matching;
+    if (first && matching.every((candidate) => candidate === first)) {
+      insertionBounds.set(tool.key, first);
+    }
+  }
 }

--- a/ui/src/pages/chat/chat-thread.test.ts
+++ b/ui/src/pages/chat/chat-thread.test.ts
@@ -2474,6 +2474,76 @@ describe("buildCachedChatItems", () => {
       },
     );
 
+    it.each([false, true])(
+      "keeps one invocation before an optimistic steer (completed=%s)",
+      (completed) => {
+        const history = [
+          userMessage("Original request", 1, {
+            __openclaw: { id: "user-entry", seq: 1 },
+          }),
+          call("exec-1"),
+          ...(completed ? [result("exec-1")] : []),
+          userMessage("Follow up after the command", 15, {
+            __openclaw: { idempotencyKey: "steer-send:user" },
+          }),
+        ];
+        const before = structuredClone(history);
+        const groups = messageGroups({
+          runId: "run-a",
+          messages: history,
+          toolMessages: [snapshot("exec-1", completed)],
+        });
+        const visible = groups.flatMap((group) =>
+          group.messages.flatMap((entry) => {
+            const cards = extractToolCards(entry.message, entry.key);
+            return cards.length ? cards : [requireRecord(entry.message).content];
+          }),
+        );
+
+        expect(visible).toEqual([
+          "Original request",
+          expect.objectContaining({
+            callId: "exec-1",
+            completed,
+            outputText: completed ? "ready" : "working",
+          }),
+          "Follow up after the command",
+        ]);
+        expect(history).toEqual(before);
+      },
+    );
+
+    it.each(["different run", "unknown history run", "unknown live run", "reset", "reused"])(
+      "does not relocate a live invocation across a boundary with %s ownership",
+      (ownership) => {
+        const persisted = call("exec-1");
+        const live = snapshot("exec-1", false);
+        if (ownership === "different run") {
+          persisted.runId = "run-b";
+        } else if (ownership === "unknown history run") {
+          persisted.runId = undefined;
+        } else if (ownership === "unknown live run") {
+          live.runId = undefined;
+        }
+        const groups = messageGroups({
+          runId: "run-a",
+          messages: [
+            userMessage("Original request", 1),
+            persisted,
+            ...(ownership === "reset" ? [resetMessage("reset-invocation")] : []),
+            userMessage("Next request", 15),
+            ...(ownership === "reused" ? [call("exec-1")] : []),
+          ],
+          toolMessages: [live],
+        });
+        const cards = groups.flatMap((group) =>
+          group.messages.flatMap((entry) => extractToolCards(entry.message, entry.key)),
+        );
+        expect(cards).toHaveLength(2);
+        expect(cards.filter((card) => card.outputText === "working")).toHaveLength(1);
+      },
+    );
+
     it("keeps run ownership, conflicting names, anonymous calls, and nested identities distinct", () => {
       const nested = ["nested:exec-1:read:1", "nested:exec-1:read:2", "nested:exec-1:read:3"];
       const cards = cardsFor([

--- a/ui/src/pages/chat/chat-thread.test.ts
+++ b/ui/src/pages/chat/chat-thread.test.ts
@@ -2426,6 +2426,10 @@ describe("buildCachedChatItems", () => {
       });
     const result = (id: string, text = "ready", runId: string | undefined = "run-a") =>
       toolResultMessage(id, "exec", [{ type: "text", text }], 20, { runId });
+    const canonical = ({ runId, ...message }: Record<string, unknown>, seq: number) => ({
+      ...message,
+      __openclaw: { id: `tool-entry-${seq}`, seq, runId },
+    });
     const snapshot = (id: string, completed = true) =>
       assistantMessage(
         [
@@ -2474,15 +2478,21 @@ describe("buildCachedChatItems", () => {
       },
     );
 
-    it.each([false, true])(
-      "keeps one invocation before an optimistic steer (completed=%s)",
-      (completed) => {
+    it.each(
+      [false, true].flatMap((completed) =>
+        ["live", "canonical"].map((owner) => ({ completed, owner })),
+      ),
+    )(
+      "keeps one invocation before an optimistic steer ($owner ownership, completed=$completed)",
+      ({ completed, owner }) => {
+        const persisted = [call("exec-1"), ...(completed ? [result("exec-1")] : [])].map(
+          (message, index) => (owner === "canonical" ? canonical(message, index + 2) : message),
+        );
         const history = [
           userMessage("Original request", 1, {
             __openclaw: { id: "user-entry", seq: 1 },
           }),
-          call("exec-1"),
-          ...(completed ? [result("exec-1")] : []),
+          ...persisted,
           userMessage("Follow up after the command", 15, {
             __openclaw: { idempotencyKey: "steer-send:user" },
           }),
@@ -2512,6 +2522,21 @@ describe("buildCachedChatItems", () => {
         expect(history).toEqual(before);
       },
     );
+
+    it("keeps canonical sibling invocation owners when live runs reuse a call id", () => {
+      const cards = cardsFor(
+        [
+          canonical(call("shared"), 1),
+          canonical(result("shared", "first result"), 2),
+          canonical(call("shared", "exec", "run-b"), 3),
+          canonical(result("shared", "second result", "run-b"), 4),
+        ],
+        [snapshot("shared", false), { ...snapshot("shared", false), runId: "run-b" }],
+      );
+      expect(cards).toHaveLength(2);
+      expect(cards.map((card) => card.outputText)).toEqual(["first result", "second result"]);
+      expect(cards.every((card) => card.completed)).toBe(true);
+    });
 
     it.each(["different run", "unknown history run", "unknown live run", "reset", "reused"])(
       "does not relocate a live invocation across a boundary with %s ownership",

--- a/ui/src/pages/chat/chat-thread.ts
+++ b/ui/src/pages/chat/chat-thread.ts
@@ -251,6 +251,7 @@ function sameChatItemsStructuralInput(
     previous.streamSegments === next.streamSegments &&
     previous.streamStartedAt === next.streamStartedAt &&
     previous.queue === next.queue &&
+    previous.pendingInputs === next.pendingInputs &&
     previous.showToolCalls === next.showToolCalls &&
     previous.persistCommentary === next.persistCommentary &&
     previous.runWorking === next.runWorking &&

--- a/ui/src/pages/chat/chat-tool-activity-coalesce.ts
+++ b/ui/src/pages/chat/chat-tool-activity-coalesce.ts
@@ -1,5 +1,6 @@
 // Reconcile invocation projections before grouping so summaries and expanded
 // cards consume the same calls, regardless of history/live delivery order.
+import { readSessionMessageIdentity } from "@openclaw/gateway-client/browser";
 import { asNullableRecord as asRecord } from "@openclaw/normalization-core/record-coerce";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import {
@@ -124,7 +125,10 @@ function readProjections(item: MessageItem, index: number): Projection[] {
       source,
       id,
       call,
-      runId: normalizeOptionalString(raw.runId) ?? normalizeOptionalString(message.runId),
+      runId:
+        normalizeOptionalString(raw.runId) ??
+        readSessionMessageIdentity(message)?.runId ??
+        normalizeOptionalString(message.runId),
       name:
         normalizeOptionalString(raw.name) ??
         normalizeOptionalString(message.toolName) ??

--- a/ui/src/pages/chat/chat-view.ts
+++ b/ui/src/pages/chat/chat-view.ts
@@ -40,6 +40,7 @@ import type { ProviderUsageDisplayProps } from "../../lib/provider-quota-summary
 import type { SessionToolOverrides } from "../../lib/sessions/patch.ts";
 import type { UiSessionDefaultsHost } from "../../lib/sessions/session-key.ts";
 import { getChatHistoryLoadState, retryChatHistoryLoad } from "./chat-history.ts";
+import { getChatPendingInputs, loadChatPendingInputs } from "./chat-pending-inputs.ts";
 import { chatStartupStatusLabel, type ChatRunStartupStatus } from "./chat-run-startup.ts";
 import type { ChatState } from "./chat-state-contract.ts";
 import {
@@ -307,11 +308,13 @@ export type ChatProps = ChatTaskSuggestionTrayProps &
   };
 
 export function renderChat(props: ChatProps) {
+  const pendingInputs = props.historyState ? getChatPendingInputs(props.historyState) : undefined;
   const requestUpdate = props.onRequestUpdate ?? (() => {});
   const canCompose = props.canSend;
   const showModelSetupSplash =
     props.modelSetupRequired === true &&
     props.messages.length === 0 &&
+    (pendingInputs?.page.items.length ?? 0) === 0 &&
     props.toolMessages.length === 0 &&
     props.streamSegments.length === 0 &&
     !props.stream &&
@@ -352,6 +355,7 @@ export function renderChat(props: ChatProps) {
       runOutputTokens: props.runOutputTokens,
       runStatus: props.runStatus,
       queue,
+      pendingInputs: pendingInputs?.page.items,
       showThinking: props.showThinking,
       showToolCalls: props.showToolCalls,
       persistCommentary: props.persistCommentary,
@@ -465,6 +469,7 @@ export function renderChat(props: ChatProps) {
   const transcriptEmpty =
     !runWorking &&
     props.messages.length === 0 &&
+    (pendingInputs?.page.items.length ?? 0) === 0 &&
     props.toolMessages.length === 0 &&
     props.streamSegments.length === 0 &&
     !props.stream &&
@@ -538,6 +543,43 @@ export function renderChat(props: ChatProps) {
                 ${renderTranscriptSearch(props.paneId, requestUpdate)}
                 <div class="chat-main__conversation">
                   ${historyRefreshNotice} ${historyError === nothing ? thread : historyError}
+                  ${pendingInputs &&
+                  (pendingInputs.page.total > 0 || pendingInputs.before !== undefined)
+                    ? html`<div class="chat-history-error chat-history-error--inline" role="status">
+                        <span
+                          >${t("chat.pendingInputs.count", {
+                            count: String(pendingInputs.page.total),
+                          })}</span
+                        >
+                        ${pendingInputs.error ? html`<span>${pendingInputs.error}</span>` : nothing}
+                        ${pendingInputs.page.nextBefore !== undefined
+                          ? html`<button
+                              class="btn btn--sm"
+                              type="button"
+                              ?disabled=${pendingInputs.loading}
+                              @click=${() =>
+                                props.historyState &&
+                                loadChatPendingInputs(
+                                  props.historyState,
+                                  pendingInputs.page.nextBefore,
+                                )}
+                            >
+                              ${t("chat.pendingInputs.earlier")}
+                            </button>`
+                          : nothing}
+                        ${pendingInputs.before !== undefined
+                          ? html`<button
+                              class="btn btn--sm"
+                              type="button"
+                              ?disabled=${pendingInputs.loading}
+                              @click=${() =>
+                                props.historyState && loadChatPendingInputs(props.historyState)}
+                            >
+                              ${t("chat.pendingInputs.latest")}
+                            </button>`
+                          : nothing}
+                      </div>`
+                    : nothing}
                   ${scrollToBottomButton}
                   ${props.inlineApproval && props.onApprovalDecision
                     ? html`<div class="chat-inline-approval">

--- a/ui/src/pages/chat/components/chat-message-bubble.ts
+++ b/ui/src/pages/chat/components/chat-message-bubble.ts
@@ -308,7 +308,8 @@ export function renderGroupedMessage(
   const extractedThinking =
     opts.showReasoning && role === "assistant" ? extractThinkingCached(message) : null;
   const reasoningMarkdown = extractedThinking ? formatReasoningMarkdown(extractedThinking) : null;
-  const markdown = displayMarkdown ? displayMarkdown : null;
+  const markdown =
+    (normalizedRole === "user" ? opts.actionMarkdown : undefined) ?? (displayMarkdown || null);
   const markdownRenderOptions: MarkdownRenderOptions = {
     assistantTranscriptRoleHeaders: role === "assistant",
     codeBlockChrome: role === "user" ? "none" : "copy",

--- a/ui/src/pages/chat/components/chat-message-group.ts
+++ b/ui/src/pages/chat/components/chat-message-group.ts
@@ -512,7 +512,11 @@ export function renderMessageGroup(group: MessageGroup, opts: RenderMessageGroup
     : group.messages[lastMessageIndex]?.key;
   const hasUserFooterActions =
     normalizedRole === "user" &&
-    Boolean((footerActionDetails?.replyTarget && opts.onReply) || opts.onRewind);
+    Boolean(
+      (footerActionDetails?.replyTarget && opts.onReply) ||
+      opts.onRewind ||
+      footerActionDetails?.markdown,
+    );
   const userFooterActions = hasUserFooterActions
     ? html`
         <div
@@ -524,6 +528,9 @@ export function renderMessageGroup(group: MessageGroup, opts: RenderMessageGroup
             : nothing}
           ${opts.onRewind
             ? renderRewindButton(opts.onRewind, Boolean(opts.rewindDisabled))
+            : nothing}
+          ${footerActionDetails?.markdown
+            ? renderMessageActionButtons(footerActionDetails, {})
             : nothing}
         </div>
       `

--- a/ui/src/pages/chat/components/chat-message-markdown.test.ts
+++ b/ui/src/pages/chat/components/chat-message-markdown.test.ts
@@ -1,22 +1,24 @@
 /* @vitest-environment jsdom */
 // Contract for the full-message fetch flag: the Gateway marks every display-
-// capped projection (user rows included), but the expander that consumes this
-// flag renders loaded content for assistant rows alone.
+// capped projection; pending inputs share assistant expansion without gaining
+// transcript mutation actions.
 import { render } from "lit";
 import { describe, expect, it, vi } from "vitest";
+import { persistedMessageEntryId } from "../chat-thread-items.ts";
 import { renderUserMessageMarkdown, resolveMessageActionDetails } from "./chat-message-markdown.ts";
 
 const cappedMeta = { id: "msg-1", truncated: true, reason: "display-cap" };
 
 describe("resolveMessageActionDetails full-message fetch flag", () => {
   it.each([
-    { role: "assistant", shouldFetch: true },
-    { role: "user", shouldFetch: false },
+    { role: "assistant", id: "msg-1", shouldFetch: true },
+    { role: "user", id: "msg-1", shouldFetch: false },
+    { role: "user", id: "pending:input-1", shouldFetch: true },
   ])(
     "role=$role capped by metadata -> shouldFetchFullMessage=$shouldFetch",
-    ({ role, shouldFetch }) => {
+    ({ role, id, shouldFetch }) => {
       const details = resolveMessageActionDetails({
-        message: { role, content: "Preview\n...(truncated)...", __openclaw: cappedMeta },
+        message: { role, content: "Preview\n...(truncated)...", __openclaw: { ...cappedMeta, id } },
         messageId: "msg-1",
         canFetchFullMessage: true,
         onReply: () => {},
@@ -25,6 +27,29 @@ describe("resolveMessageActionDetails full-message fetch flag", () => {
       expect(details?.shouldFetchFullMessage).toBe(shouldFetch);
     },
   );
+
+  it("expands accepted user text without granting transcript reply or rewind identity", () => {
+    const message = {
+      role: "user",
+      content: "Preview",
+      __openclaw: { ...cappedMeta, id: "pending:input-1" },
+    };
+    const details = resolveMessageActionDetails({
+      message,
+      messageId: "pending-render",
+      canFetchFullMessage: true,
+      getAssistantMessageExpansion: () => ({
+        status: "loaded",
+        markdown: "<think>literal user input</think>",
+        revision: 1,
+      }),
+      onReply: vi.fn(),
+      senderLabel: "user",
+    });
+    expect(details?.markdown).toBe("<think>literal user input</think>");
+    expect(details?.replyTarget).toBeUndefined();
+    expect(persistedMessageEntryId(message)).toBeNull();
+  });
 
   it("does not fetch an assistant message that merely contains the sentinel text", () => {
     // The in-band "...(truncated)..." is ordinary Markdown to the UI; without the

--- a/ui/src/pages/chat/components/chat-message-markdown.ts
+++ b/ui/src/pages/chat/components/chat-message-markdown.ts
@@ -3,6 +3,7 @@ import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { html, nothing } from "lit";
 import { ref } from "lit/directives/ref.js";
 import { unsafeHTML } from "lit/directives/unsafe-html.js";
+import { CHAT_PENDING_INPUT_MESSAGE_PREFIX } from "../../../../../packages/gateway-protocol/src/schema/chat-history-constants.js";
 import { renderCopyAsMarkdownButton } from "../../../components/copy-button.ts";
 import { icons } from "../../../components/icons.ts";
 import type { MarkdownRenderOptions } from "../../../components/markdown-render-options.ts";
@@ -140,27 +141,29 @@ export function resolveMessageActionDetails(params: {
         : undefined;
   const normalizedMessage = normalizeMessage(message);
   const role = normalizeRoleForGrouping(normalizedMessage.role);
+  const pendingInput = messageId?.startsWith(CHAT_PENDING_INPUT_MESSAGE_PREFIX) === true;
   const previewMarkdown = resolveMessageDisplayMarkdown(message, normalizedMessage);
   // The Gateway records every display-cap truncation as __openclaw.truncated, so
   // that marker is the whole contract: sniffing the in-band sentinel would fetch
-  // for any reply that merely contains the text. Assistant-only because the
-  // expander renders loaded content for assistant rows alone.
+  // for any reply that merely contains the text. Pending user inputs share the
+  // same read-only expansion, without becoming transcript reply/rewind targets.
   const shouldFetchFullMessage = Boolean(
-    role === "assistant" &&
+    (role === "assistant" || pendingInput) &&
     canFetchFullMessage &&
     messageId &&
     !record.openclawMessageToolMirror &&
     transcriptMeta?.truncated === true,
   );
   const expansion =
-    role === "assistant" && shouldFetchFullMessage && messageId
+    shouldFetchFullMessage && messageId
       ? params.getAssistantMessageExpansion?.(messageId)
       : undefined;
+  const expandedMarkdown = expansion?.status === "loaded" ? expansion.markdown : previewMarkdown;
   const visibleMarkdown =
-    expansion?.status === "loaded" ? stripThinkingTags(expansion.markdown).trim() : previewMarkdown;
-  const markdown = role === "assistant" ? visibleMarkdown : undefined;
-  const replyText = onReply ? truncateUtf16Safe(visibleMarkdown, 500) : "";
-  if (!markdown && !replyText && !(role === "assistant" && shouldFetchFullMessage)) {
+    role === "assistant" ? stripThinkingTags(expandedMarkdown).trim() : expandedMarkdown;
+  const markdown = role === "assistant" || pendingInput ? visibleMarkdown : undefined;
+  const replyText = onReply && !pendingInput ? truncateUtf16Safe(visibleMarkdown, 500) : "";
+  if (!markdown && !replyText && !shouldFetchFullMessage) {
     return null;
   }
   const sourceMessageId = persistedMessageEntryId(message);
@@ -262,10 +265,20 @@ export function renderUserMessageMarkdown(
     isStreaming: boolean;
     isUserMessageExpanded?: (messageId: string) => boolean;
     onToggleUserMessageExpanded?: (messageId: string) => void;
+    assistantMessageDisclosure?: AssistantMessageDisclosure;
   },
   markdownRenderOptions: MarkdownRenderOptions,
   duplicateSuffix?: DuplicateSuffix,
 ) {
+  if (opts.assistantMessageDisclosure?.onRetryFullMessage) {
+    return renderAssistantMessageMarkdown(
+      markdown,
+      opts.isStreaming,
+      opts.assistantMessageDisclosure,
+      markdownRenderOptions,
+      duplicateSuffix,
+    );
+  }
   if (!opts.onToggleUserMessageExpanded || !shouldCollapseUserMessage(markdown)) {
     return renderMarkdownText(markdown, opts.isStreaming, markdownRenderOptions, duplicateSuffix);
   }

--- a/ui/src/pages/chat/components/chat-thread-interactions.ts
+++ b/ui/src/pages/chat/components/chat-thread-interactions.ts
@@ -2,6 +2,7 @@
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { html, nothing, type TemplateResult } from "lit";
 import { ref } from "lit/directives/ref.js";
+import type { ChatPendingInputsPage } from "../../../../../packages/gateway-protocol/src/schema/logs-chat.js";
 import type { SessionsListResult } from "../../../api/types.ts";
 import type { QuestionPrompt } from "../../../app/question-prompt.ts";
 import { copyMarkdownLabel, handleCopyButton } from "../../../components/copy-button.ts";
@@ -81,6 +82,7 @@ export type ChatThreadProps = {
   runOutputTokens?: number | null;
   runStatus?: ChatRunUiStatus | null;
   queue: ChatQueueItem[];
+  pendingInputs?: ChatPendingInputsPage["items"];
   showThinking: boolean;
   showToolCalls: boolean;
   persistCommentary?: boolean;

--- a/ui/src/pages/chat/components/chat-transcript-projection.ts
+++ b/ui/src/pages/chat/components/chat-transcript-projection.ts
@@ -166,6 +166,7 @@ export function projectChatTranscript(
     stream: displayStream,
     streamStartedAt: props.streamStartedAt,
     queue: props.queue,
+    pendingInputs: props.pendingInputs,
     showToolCalls: props.showToolCalls,
     persistCommentary: props.persistCommentary,
     runWorking: Boolean(props.runWorking),

--- a/ui/src/pages/chat/tool-stream-identity.ts
+++ b/ui/src/pages/chat/tool-stream-identity.ts
@@ -1,3 +1,4 @@
+import { readSessionMessageIdentity } from "@openclaw/gateway-client/browser";
 import { asNullableRecord as asToolRecord } from "@openclaw/normalization-core/record-coerce";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import {
@@ -66,7 +67,8 @@ export function extractToolMessageRefs(message: unknown): ToolMessageRef[] {
       )
     : [];
   const topLevelToolId = resolveToolUseId({ ...record, id: undefined });
-  const topLevelRunId = normalizeOptionalString(record.runId);
+  const topLevelRunId =
+    readSessionMessageIdentity(record)?.runId ?? normalizeOptionalString(record.runId);
   const role = record.role;
   const messageHasToolShape =
     (typeof role === "string" && normalizeRoleForGrouping(role).toLowerCase() === "tool") ||


### PR DESCRIPTION
Closes #132547

## Why

An agent follow-up could append to a cloud session's transcript while its first worker turn was still running. That changed the worker's expected base and caused `stale-base-leaf`. The same input-ownership gap could duplicate CLI input or let an ACP prompt start before its canonical input existed.

## What changes

Gateway `agent` admission, including `sessions_send`, retains approved input in per-agent SQLite before ACK without changing the active transcript. The existing execution owner appends the exact input and consumes its pending record in one transaction when its turn starts. Worker transcript fencing and the existing queues/scheduler remain unchanged.

Pending rows retain text and existing media metadata after cancellation or restart, but grant no execution authority. Promotion requires the original private live closure, physical session, lifecycle, run and current transcript anchor. Cancelled/interrupted input is readable in bounded Control UI and `sessions_history` projections, separately from model history, and requires an explicit new send. The writer queue preserves caller async context; stale branch projections cannot replace active anchors. Native, CLI and ACP execution use the canonical recorder, and terminal mirrors cannot synthesize replacement input.

Live testing also repaired two UI defects: pending input now refreshes through the existing session/connection-fenced history owner without a reload, and canonical/live tool echoes coalesce using the actual `__openclaw.runId` history identity. The original top-level-only fixtures missed that payload shape; three corrected regressions fail before the final repair.

The additive custody design was [explicitly accepted before implementation](https://github.com/openclaw/openclaw/issues/132547#issuecomment-5464989695). Schema version stays 19, with lazy first-use creation and older-reader compatibility. No new configuration option, dependency, protocol version, scheduler or automatic replay path.

## Verification

**Live-tested head `f4919de936b9fd7aec9439124e2e6737cde43d86`: [full CI passed](https://github.com/openclaw/openclaw/actions/runs/33284848787), normal package/UI build passed, and real Chrome/cloud proof passed using an OpenAI API-key profile and `openai-responses`.**

Main advanced during live testing, so the branch was rebased to `ea11b879f12498b718024d4df4f8de61ef6d1d2f`. Range-diff confirms all production commits are unchanged; only three generated prompt snapshot hashes/counts changed. Canonical generation and independent snapshot verification passed, and the resolution passed Codex review. The rebased CI run passed all jobs except a pre-existing process-fixture readiness race: the fixture published its PID before installing its SIGTERM handler. Commit `3d4cfe67478c2f26ddf392fda347cf95c7dd5a82` fixes that ordering in the tracked-process and sibling watchdog fixtures, without changing assertions, timeouts or production code. Forced-interleaving proof fails before and passes after; all 34 tests in the file, the changed-file gate and Codex review pass. [Final-head CI passed](https://github.com/openclaw/openclaw/actions/runs/33286890304): 193 successful jobs and seven intentional skips, including the required aggregate gate. No additional production behavior was introduced by the rebase or fixture correction.

The final UI-created AWS cloud session ran one 120-second command. While it was active, a browser follow-up and a Gateway agent follow-up were submitted. The active command appeared once; the agent input appeared as one retained pending row without a reload.

| Observed boundary | UTC time / canonical position |
| --- | --- |
| Input `dae3095b-818f-4a9b-884f-d8688b9a88e4` accepted while first turn active | 01:23:59.320 |
| First reply committed | 01:25:25.373 / seq 14 |
| Exact input ID and text promoted once | 01:25:35.277 / seq 15 |
| Second reply committed | 01:25:40.041 / seq 16 |
| Settled state | One canonical exec invocation; pending 0; execution claim cleared |

The pending indicator retired without a reload. The ordinary browser follow-up also completed afterward. Earlier real flows additionally covered Control UI parent creation → actual `sessions_spawn` → `sessions_send`, with direct AWS filesystem marker verification. The worker's content-addressed production bundle is unchanged across these UI/test follow-ups; final Gateway/UI build is the exact head above.

**Abrupt restart proof:** a separate accepted input was captured while an API-backed cloud command was active, then only the isolated Gateway was SIGKILLed. After restart and a normal authenticated history read, the exact input ID/text/acceptance timestamp remained, its state was `interrupted`, the old execution claim was cleared, and no canonical event or output replayed that pending input. The UI explicitly says it will not run automatically. The earlier graceful-stop attempt raced promotion; the final abrupt test captures both sides of the actual crash.

Focused verification includes 335 initial owner tests, 68 shared-owner siblings, 267 follow-up tests (4 platform skips), 580 native/script tests, 291 Gateway handler tests, 112 UI invalidation tests and the final 364 UI ownership/history/stream/pending tests. Core/UI/full core-test types, type-aware lint and complete changed-file gates pass. The earlier CI timeout cascade came from obsolete eager-write mocks; the handler suite now uses the admission boundary. Required P0-only independent Codex reviews reported no findings.

Frozen pre-fix tests reproduce stale-base-leaf in the original execution order, CLI duplication and ACP pre-prompt omission. Repeated on final head `3d4cfe67478c2f26ddf392fda347cf95c7dd5a82`, the actual three-process candidate → frozen older-reader `d3c07b02e244e73470df4a930911e8d58c4e456d` append → candidate reopen proof passed. It preserves the exact pending ID/message bytes/interrupted disposition, schema 19 and schema metadata. All 13 frozen source/loader hashes match the original baseline receipt; the older accessor performs an ordinary append and the candidate still displays the retained pending input. Storage tests cover atomic rollback, cancellation, lifecycle/physical-session replacement, exact identity and bounded pages.

Direct Codex contract inspection: [`codex-rs/core/src/session/inject.rs:15`](https://github.com/openai/codex/blob/2181224dad147a9ed37e698b66487aba54acdb65/codex-rs/core/src/session/inject.rs#L15), including active queuing, idle recording and no-new-turn injection. No Codex protocol change. Shallow OpenClaw history does not establish the original introducing PR.

Production LOC: +1708/-278, **net +1430**; tests net +1276; generated +27; docs +21. Growth implements the accepted custody, lifecycle cleanup and bounded visibility contract. Moving append alone would lose accepted input after interruption; the existing execution and transcript owners are reused.

## Scope and follow-ups

- Ordinary browser `chat.send` still uses its existing collect/follow-up queue and does not yet receive exact-input durable custody. Docs explicitly state this. These existing surfaces do not promise global FIFO; durable source-to-aggregate collection needs a separately accepted persistence design.
- Provisioning/cancellation and released-worker cleanup delays remain tracked in #132514/#132550. The isolated shutdown stall is already fixed on main by #132877.
- Restart exposed the existing memory diagnostic's premature auth-profile SecretRef lookup; open PR #132122 already contains its owner repair. This proof used the documented `memory.search.remote.apiKey` reference to the same environment key, preserving the index and pending state. It does not claim the auth-profile-only startup bug is fixed.
- Doctor's distinct misclassification of valid main-agent local auth order is tracked in #132979. No unrelated migration or credential-state changes were made here.

ClawSweeper rank-up follow-through: the reported merge conflict is resolved by the generated-only rebase, with final-head CI passed after the verified fixture correction; live pending/promotion and single-card proof for the unchanged production patch is supplied; the accepted storage design, older-reader proof and direct Codex inspection are recorded above. No access check, reviewer isolation or native workflow guard was bypassed.

## Before and after

Before the final metadata repair: duplicate command around the browser follow-up.

![Before: duplicate live command](https://github.com/user-attachments/assets/6ed68413-c239-4789-a0dc-c7c69b827646)

After: one command, separate retained input, no reload.

![After: one command and one pending input](https://github.com/user-attachments/assets/bdb325f7-2df2-456e-9665-87f86b54f8aa)

Completed: replies in canonical order and no pending indicator.

![Completed cloud flow](https://github.com/user-attachments/assets/5b7d22dd-3d44-4e9c-a3c5-44cf0478669e)

After abrupt restart: retained input is explicitly interrupted and non-executable.

![Retained interrupted input](https://github.com/user-attachments/assets/7d064646-4b5f-469d-90cf-814f0391a2da)

All six task-owned cloud leases were verified released. The isolated Gateway, tunnels, package server and test tab are stopped; the temporary API-key file, private runtime state and task dependencies were removed.
