### PR TITLE
fix: allow subagent spawns from system events

### DIFF
--- a/src/gateway/server-methods/agent.events-and-subagents.test-utils.ts
+++ b/src/gateway/server-methods/agent.events-and-subagents.test-utils.ts
@@ -746,7 +746,7 @@ describe("gateway agent handler", () => {
 
   it.each(
     (["channel", "replyChannel"] as const).flatMap((field) =>
-      (["heartbeat", "cron", "webhook", "voice"] as const).map(
+      (["heartbeat", "cron", "cron-event", "exec-event", "webhook", "voice"] as const).map(
         (channel) => [field, channel] as const,
       ),
     ),

--- a/src/utils/message-channel-constants.ts
+++ b/src/utils/message-channel-constants.ts
@@ -19,6 +19,8 @@ export function internalSessionConversationId(
 const INTERNAL_NON_DELIVERY_CHANNELS = [
   "heartbeat",
   "cron",
+  "cron-event",
+  "exec-event",
   "webhook",
   "voice",
   "sessions_send",

--- a/src/utils/message-channel.test.ts
+++ b/src/utils/message-channel.test.ts
@@ -18,6 +18,8 @@ import {
 const INTERNAL_NON_DELIVERY_CHANNELS = [
   "heartbeat",
   "cron",
+  "cron-event",
+  "exec-event",
   "webhook",
   "voice",
   "sessions_send",


### PR DESCRIPTION
Closes #132817

## What Problem This Solves

Fixes an issue where cron and exec-completion system-event turns could not start subagents on CLI-backed agent runtimes because their internal source identifiers were rejected as unknown channels.

## Why This Change Was Made

The shared internal non-delivery channel policy now recognizes the existing `cron-event` and `exec-event` source identifiers. This preserves event provenance while allowing the existing Gateway validation path to accept child runs; delivery routing and external channel behavior are unchanged.

## User Impact

Cron system-event and exec-completion turns can use `sessions_spawn` without failing with an unknown-channel error.

## Evidence

- Pre-fix owner-boundary reproduction: `cron-event: false`, `exec-event: false`.
- Post-fix owner-boundary reproduction: `cron-event: true`, `exec-event: true`.
- Existing classification table extended for both source identifiers.
- Existing Gateway acceptance table extended for both `channel` and `replyChannel`.
- Targeted formatting and `git diff --check`: passed.
