### PR TITLE
fix(browser): avoid missing-directory diagnosis after native-host refusals

### DIFF
--- a/docs/tools/chrome-extension.md
+++ b/docs/tools/chrome-extension.md
@@ -373,6 +373,11 @@ openclaw browser doctor --browser-profile chrome
 openclaw doctor
 ```
 
+- **No native host was pre-registered:** check the preceding per-browser refusal
+  diagnostics and resolve the reported path, ownership, or permission issue. This
+  summary does not mean that Chrome's user-data directory is missing. If Chrome
+  has never been launched, launch it first, then rerun `extension install` before
+  adding the extension.
 - **No extension ID detected:** keep Chrome running, rerun `extension install`,
   then add the official Store extension. Use **Load unpacked** only as a
   development fallback after the command says native bootstrap is ready.

--- a/extensions/browser/src/browser/extension-install.test.ts
+++ b/extensions/browser/src/browser/extension-install.test.ts
@@ -52,6 +52,28 @@ afterEach(() => {
 });
 
 describe("native host registration", () => {
+  it("guides first-time setup when no browser user-data directory exists", async () => {
+    const value = await fixture();
+    let now = 0;
+    const status = await installChromeExtensionBootstrap({
+      bundledDir: value.bundledDir,
+      pluginRoot: value.pluginRoot,
+      waitMs: 1_000,
+      deps: {
+        ...value.deps,
+        now: () => now,
+        sleep: async (ms) => {
+          now += ms;
+        },
+      },
+    });
+
+    expect(status.manualSetupRequired).toBe(true);
+    expect(status.registrations.every((entry) => entry.state === "missing")).toBe(true);
+    expect(status.issues).toEqual([expect.stringContaining("No native host was pre-registered.")]);
+    expect(status.issues[0]).toContain("if Chrome has not been launched yet, launch it first");
+  });
+
   it("pre-registers predicted IDs before waiting, then verifies Chrome's recorded ID", async () => {
     const value = await fixture();
     const installed = stableChromeExtensionDir(value.deps);
@@ -192,6 +214,8 @@ describe("native host registration", () => {
     });
     expect(status.manualSetupRequired).toBe(true);
     expect(status.issues.join("\n")).toContain("pre-registration refused");
+    expect(status.issues.join("\n")).toContain("No native host was pre-registered.");
+    expect(status.issues.join("\n")).not.toContain("No existing Chrome-family user-data directory");
     const repair = await repairOwnedChromeExtensionNativeHosts({
       bundledDir: value.bundledDir,
       pluginRoot: value.pluginRoot,
@@ -621,7 +645,7 @@ describe("native host registration", () => {
       } else {
         await fs.chmod(
           registeredTarget,
-          failure === "non-executable" ? 0o600 : failure === "unreadable" ? 0o000 : 0o666,
+          failure === "non-executable" ? 0o600 : failure === "unreadable" ? 0o000 : 0o664,
         );
       }
 
@@ -644,7 +668,7 @@ describe("native host registration", () => {
       expect(await fs.readFile(manifest.path, "utf8")).toBe(launcherBytes);
       expect(existsSync(executed)).toBe(false);
 
-      if (failure === "non-executable" || failure === "unreadable") {
+      if (failure === "non-executable" || failure === "unreadable" || failure === "unsafe-mode") {
         const onProgress = vi.fn();
         const reinstall = await installChromeExtensionBootstrap({
           ...params,
@@ -656,6 +680,10 @@ describe("native host registration", () => {
           expect.stringContaining("Native bootstrap is ready"),
         );
         expect(reinstall.issues.join("\n")).toContain("pre-registration refused");
+        expect(reinstall.issues.join("\n")).toContain("No native host was pre-registered.");
+        expect(reinstall.issues.join("\n")).not.toContain(
+          "No existing Chrome-family user-data directory",
+        );
         expect(await fs.readFile(registration.manifestPath, "utf8")).toBe(manifestBytes);
         expect(await fs.readFile(manifest.path, "utf8")).toBe(launcherBytes);
       }

--- a/extensions/browser/src/browser/extension-install.ts
+++ b/extensions/browser/src/browser/extension-install.ts
@@ -469,7 +469,7 @@ export async function installChromeExtensionBootstrap(params: {
     );
   } else {
     preRegistrationIssues.push(
-      "No existing Chrome-family user-data directory was available for native host pre-registration. Launch Chrome, then run install again before loading the extension.",
+      "No native host was pre-registered. Resolve any pre-registration refusals above; if Chrome has not been launched yet, launch it first. Then run install again before loading the extension.",
     );
   }
   const waitMs = normalizeExtensionInstallWaitMs(params.waitMs);


### PR DESCRIPTION
Closes #132889

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers can help update the branch when needed. This PR uses a branch in the canonical repository.

</details>

## What Problem This Solves

Fixes an issue where users running `openclaw browser extension install` would receive a false missing-directory diagnosis when native-host pre-registration was refused despite existing Chrome-family user-data directories. The preceding refusal could identify a foreign manifest or an unsafe/unavailable target, but the summary still told users to launch Chrome.

## Why This Change Was Made

The browser installer owns this diagnostic, and `preRegisteredRoots` counts successful `installRegistration` calls rather than discovered directories. Report the known fact—no native host was pre-registered—and direct operators to the preceding refusals, keeping first-launch advice conditional. Security checks, control flow, counters, API, registration readiness, and exit behavior are unchanged; no additional discovery counter or downstream filtering is needed.

The incorrect inference appears in `fada06727788` (zero-click bootstrap PR #121586, authored by Peter Steinberger on 2026-08-10). This identifies source authorship, not merger identity. No legacy path or compatibility surface is added or removed. Separate Chromium fixture repair PR #132585 is untouched.

## User Impact

Operators can act on the actual refusal instead of assuming their browser profile directory is missing. First-time users still receive guidance to launch Chrome and rerun install before adding the extension. The troubleshooting guide explains the distinction: https://docs.openclaw.ai/tools/chrome-extension#troubleshooting.

## Evidence

AI-assisted. Production LOC: **+1/-1 (net 0)**; tests **+30/-2 (net +28)**; docs **+5/-0**. The single production change replaces diagnostic text.

Before the production edit, the foreign-manifest, non-executable, unreadable, and mode-`0664` native-target cases failed the new diagnostic assertion; the first-time setup assertion also failed. Six unaffected table cases passed. Those pre-fix observations were recorded in the original task session; its temporary raw logs were lost during a host interruption.

Focused installer/layout/CLI proof:

```sh
node scripts/run-vitest.mjs extensions/browser/src/browser/extension-install.test.ts extensions/browser/src/browser/extension-install-layout.test.ts extensions/browser/src/cli/browser-cli-extension.test.ts
```

The complete changed gate already passed against the unchanged reviewed source (production/test tsgo, lint/format, contracts, Knip exports, ownership boundaries, and import cycles):

```sh
node scripts/check-changed.mjs -- extensions/browser/src/browser/extension-install.ts extensions/browser/src/browser/extension-install.test.ts docs/tools/chrome-extension.md
```

`pnpm docs:list` and `git diff --check` passed. Two prior Codex autoreview passes returned scoped-clean at the configured **P0 threshold**; this is not a claim of review coverage at broader priorities. The reviewed context remains byte-identical.

Original user-report context: https://github.com/openclaw/openclaw/actions/runs/33260381463. That run was cancelled and its interactive shell observation is absent from downloadable logs; it is **not** passing proof.

Fresh local validation after dependency repair: **64/64 focused tests passed**, `pnpm build` passed in **14m38s**, and `git diff --check` passed. The initial build had failed because the local `date-fns` install was incomplete; repository-prescribed `pnpm install --frozen-lockfile` repaired the installation without version, manifest, or lockfile changes, and the single build retry passed.

Real dist-backed CLI filesystem proof on macOS 27.0 / Node v26.8.1:

```sh
node openclaw.mjs browser extension install --wait-ms 1000 --json
```

The child process received synthetic `HOME`, `OPENCLAW_STATE_DIR`, `OPENCLAW_CONFIG_PATH`, `XDG_CONFIG_HOME`, `CHROME_CONFIG_HOME`, and `TMPDIR`. Chrome for Testing and Chromium directories were created only under that HOME. Only the task-built `dist/extensions/browser/native-host-entry.js` was temporarily changed to mode `0664`, with original mode `0644` restored in `finally` and file bytes verified unchanged. Host Node and installed dependencies were not chmodded.

Observed unsafe-entry result (paths shortened to `<checkout>`):

```text
Google Chrome for Testing: native host pre-registration refused (Refusing group/world-writable path at <checkout>/dist/extensions/browser/native-host-entry.js)
Google Chrome for Testing (documented host root): native host pre-registration refused (Refusing group/world-writable path at <checkout>/dist/extensions/browser/native-host-entry.js)
Chromium: native host pre-registration refused (Refusing group/world-writable path at <checkout>/dist/extensions/browser/native-host-entry.js)
No native host was pre-registered. Resolve any pre-registration refusals above; if Chrome has not been launched yet, launch it first. Then run install again before loading the extension.
manualSetupRequired: true
exit: 1
```

The old false missing-directory text was absent. A second fresh HOME with no browser directories produced only the new summary, retained conditional first-launch guidance, and also returned `manualSetupRequired: true` / exit 1. All registrations remained missing in both cases.

Scope of this proof: actual built CLI and filesystem checks, **not a running Chrome session**. No browser, Gateway, or operator state was used. Native bootstrap/pairing, browser UI, and a cross-OS live browser round trip were not exercised; the change does not alter those paths. Exact-head pull-request [CI run 33279648083](https://github.com/openclaw/openclaw/actions/runs/33279648083) passed (attempt 1); the required [openclaw/ci-gate check](https://github.com/openclaw/openclaw/actions/runs/33279648083/job/99173347736) also passed on `9a382da0e9260d6cb0fa8cad6502ff26b94ce6f9`.

The [latest ClawSweeper review](https://github.com/openclaw/openclaw/pull/132891#issuecomment-5465379230) has no actionable or security findings. Its remaining exact-head CI condition is now satisfied; it contains no additional Rank-up moves requiring code changes. Native main-baseline/PR-head review artifacts validated with zero findings. No review threads require resolution. No prepare or merge has been run.
