### PR TITLE
fix(gateway): honor native Stop run ownership

### DIFF
--- a/src/gateway/server-methods/sessions-abort.ts
+++ b/src/gateway/server-methods/sessions-abort.ts
@@ -308,7 +308,8 @@ export const sessionAbortHandlers: GatewayRequestHandlers = {
     const abortSessionKey =
       canonicalKey === "global" && requestedGlobalAgentId ? "global" : resolvedAbortSessionKey;
     const abortAgentId = requestedGlobalAgentId ?? activeRunAgentId;
-    if (embeddedRun) {
+    // Controller-backed runs must keep the requester checks and lifecycle cleanup below.
+    if (embeddedRun && !activeRun) {
       const aborted = embeddedRun.abort();
       respond(true, {
         ok: true,
@@ -324,11 +325,8 @@ export const sessionAbortHandlers: GatewayRequestHandlers = {
       }
       return;
     }
-    // Capture run kinds before the abort because abortChatRunById deletes entries
-    // from chatAbortControllers synchronously. We use this snapshot to choose the
-    // correct dedupe namespace: agent-kind runs use "agent:" (their runId equals
-    // their idempotency key), while chat-send runs use "chat:" so the abort
-    // snapshot does not collide with the agent RPC dedupe cache.
+    // Snapshot before abort can remove controllers. Agent run IDs are idempotency
+    // keys, so preserve their dedupe namespace instead of colliding with chat.send.
     const preAbortRunKinds = new Map<string, "chat-send" | "agent" | undefined>();
     if (requestedRunId) {
       preAbortRunKinds.set(requestedRunId, activeRun?.kind);

--- a/src/gateway/server.sessions.abort-authorization.test.ts
+++ b/src/gateway/server.sessions.abort-authorization.test.ts
@@ -1,0 +1,310 @@
+import path from "node:path";
+import { rawDataToString } from "@openclaw/gateway-client/websocket-data";
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+  vi,
+  type MockInstance,
+} from "vitest";
+import type { RawData } from "ws";
+import type { HelloOk } from "../../packages/gateway-protocol/src/index.js";
+import { createDeferred } from "../../test/helpers/promise.js";
+import type { AgentCommandOpts } from "../agents/command/types.js";
+import {
+  clearActiveEmbeddedRun,
+  resolveActiveEmbeddedRunOwnerByRunId,
+  setActiveEmbeddedRun,
+} from "../agents/embedded-agent-runner/runs.js";
+import * as subagentControl from "../agents/subagents/registry/subagent-control.js";
+import { createQueueTestRun } from "../auto-reply/reply/queue.test-helpers.js";
+import * as queueCleanup from "../auto-reply/reply/queue/cleanup.js";
+import { enqueueFollowupRun } from "../auto-reply/reply/queue/enqueue.js";
+import { getExistingFollowupQueue } from "../auto-reply/reply/queue/state.js";
+import { loadOrCreateDeviceIdentity } from "../infra/device-identity.js";
+import * as chatAbort from "./chat-abort.js";
+import { flushPendingSessionsChangedEvents } from "./server-methods/session-change-event.js";
+import { startGatewayServerHarness, type GatewayServerHarness } from "./server.e2e-ws-harness.js";
+import {
+  agentCommandMock,
+  installGatewayTestHooks,
+  onceMessage,
+  prepareGatewayReplyRuntimeForTest,
+  rpcReq,
+} from "./test-helpers.js";
+
+installGatewayTestHooks({ scope: "suite" });
+
+let harness: GatewayServerHarness;
+let registration: MockInstance<typeof chatAbort.registerChatAbortController>;
+let childCancellation: MockInstance<typeof subagentControl.killAllControlledSubagentRuns>;
+let queueClearing: MockInstance<typeof queueCleanup.clearSessionQueues>;
+
+beforeAll(async () => {
+  harness = await startGatewayServerHarness();
+  // Observe production admission and effects without replacing their implementations.
+  registration = vi.spyOn(chatAbort, "registerChatAbortController");
+  childCancellation = vi.spyOn(subagentControl, "killAllControlledSubagentRuns");
+  queueClearing = vi.spyOn(queueCleanup, "clearSessionQueues");
+});
+
+beforeEach(async () => {
+  agentCommandMock.mockReset();
+  registration.mockClear();
+  childCancellation.mockClear();
+  queueClearing.mockClear();
+  await prepareGatewayReplyRuntimeForTest();
+});
+
+afterAll(async () => {
+  registration.mockRestore();
+  childCancellation.mockRestore();
+  queueClearing.mockRestore();
+  await harness.close();
+});
+
+async function openOperator(device: string, scopes = ["operator.write"]) {
+  const deviceIdentityPath = path.join(process.env.OPENCLAW_STATE_DIR!, `${device}.sqlite`);
+  const client = await harness.openClient({
+    scopes,
+    deviceIdentityPath,
+    prePairDevice: true,
+  });
+  expect(client.hello).toMatchObject({ auth: { role: "operator", scopes } });
+  return {
+    ...client,
+    hello: client.hello as HelloOk,
+    deviceId: loadOrCreateDeviceIdentity({ path: deviceIdentityPath }).deviceId,
+  };
+}
+
+async function startNativeRun(owner: Awaited<ReturnType<typeof openOperator>>, name: string) {
+  const runId = `native-abort-${name}`;
+  const sessionKey = `agent:main:${name}`;
+  const started = createDeferred();
+  const finish = createDeferred();
+  const nativeAbort = vi.fn();
+  let command: AgentCommandOpts;
+  let handle: Parameters<typeof setActiveEmbeddedRun>[1];
+  agentCommandMock.mockImplementationOnce(async (input) => {
+    command = input as AgentCommandOpts;
+    expect(command.abortSignal).toBeInstanceOf(AbortSignal);
+    const runController = new AbortController();
+    const abort = () => {
+      nativeAbort();
+      runController.abort();
+    };
+    handle = {
+      runId,
+      abort,
+      cancel: abort,
+      isAborted: () => runController.signal.aborted,
+      isStreaming: () => !runController.signal.aborted,
+      isCompacting: () => false,
+      queueMessage: async () => {},
+    };
+    // Production relays the admitted controller signal into the native attempt.
+    command.abortSignal!.addEventListener("abort", abort, { once: true });
+    setActiveEmbeddedRun(command.sessionId!, handle, sessionKey);
+    command.onExecutionStarted?.();
+    started.resolve();
+    try {
+      await finish.promise;
+    } finally {
+      command.abortSignal!.removeEventListener("abort", abort);
+      clearActiveEmbeddedRun(command.sessionId!, handle, sessionKey);
+    }
+  });
+  const accepted = onceMessage(owner.ws, (frame) => frame.type === "res" && frame.id === runId);
+  owner.ws.send(
+    JSON.stringify({
+      type: "req",
+      id: runId,
+      method: "agent",
+      params: { message: "Keep this native run active", sessionKey, idempotencyKey: runId },
+    }),
+  );
+  try {
+    expect(await accepted).toMatchObject({ ok: true, payload: { runId, status: "accepted" } });
+    await started.promise;
+    const admission = registration.mock.calls.find(([input]) => input.runId === runId)?.[0];
+    expect(admission).toBeDefined();
+    const entry = admission!.chatAbortControllers.get(runId)!;
+    expect(entry).toMatchObject({
+      ownerConnId: owner.hello.server.connId,
+      ownerDeviceId: owner.deviceId,
+      kind: "agent",
+      sessionKey,
+    });
+    expect(resolveActiveEmbeddedRunOwnerByRunId(runId)).toMatchObject({
+      runId,
+      sessionKey,
+      sessionId: entry.sessionId,
+    });
+    return {
+      runId,
+      sessionKey,
+      entry,
+      nativeAbort,
+      finish: async () => {
+        // The modeled command cannot finish until released. Start its response
+        // deadline here, not while the test deliberately holds execution open.
+        const terminal = onceMessage(
+          owner.ws,
+          (frame) =>
+            frame.type === "res" && frame.id === runId && frame.payload?.status !== "accepted",
+        );
+        finish.resolve();
+        await terminal;
+      },
+    };
+  } catch (error) {
+    finish.resolve();
+    owner.ws.close();
+    throw new Error("Native run admission fixture failed", { cause: error });
+  }
+}
+
+describe("native sessions.abort requester authorization over WebSocket", () => {
+  test("rejects a foreign write-only device without cancellation effects", async () => {
+    const owner = await openOperator("owner", ["operator.read", "operator.write"]);
+    const foreign = await openOperator("foreign");
+    expect(foreign.hello.server.connId).not.toBe(owner.hello.server.connId);
+    expect(foreign.deviceId).not.toBe(owner.deviceId);
+    const run = await startNativeRun(owner, "foreign");
+    expect(await rpcReq(owner.ws, "sessions.subscribe", {})).toMatchObject({
+      ok: true,
+      payload: { subscribed: true },
+    });
+    const events: string[] = [];
+    const record = (data: RawData) => {
+      const frame = JSON.parse(rawDataToString(data)) as {
+        type?: string;
+        event?: string;
+        payload?: { sessionKey?: string; state?: string; reason?: string };
+      };
+      if (
+        frame.type === "event" &&
+        frame.payload?.sessionKey === run.sessionKey &&
+        ((frame.event === "chat" && frame.payload.state === "aborted") ||
+          (frame.event === "sessions.changed" && frame.payload.reason === "abort"))
+      ) {
+        events.push(frame.event);
+      }
+    };
+    owner.ws.on("message", record);
+    const queued = createQueueTestRun({ prompt: "preserve queued followup" });
+    enqueueFollowupRun(run.sessionKey, queued, { mode: "collect" });
+    const queue = getExistingFollowupQueue(run.sessionKey)!;
+    try {
+      // A no-op on this same method proves that scope/participation gates admit
+      // this client before the live controller's separate ownership check.
+      expect(
+        await rpcReq(foreign.ws, "sessions.abort", {
+          key: run.sessionKey,
+          runId: "no-such-native-run",
+        }),
+      ).toMatchObject({ ok: true, payload: { status: "no-active-run" } });
+      expect(
+        await rpcReq(foreign.ws, "chat.abort", { sessionKey: run.sessionKey, runId: run.runId }),
+      ).toMatchObject({
+        ok: false,
+        error: { code: "INVALID_REQUEST", message: "unauthorized" },
+      });
+      const result = await rpcReq(foreign.ws, "sessions.abort", {
+        key: run.sessionKey,
+        runId: run.runId,
+        clearQueued: true,
+      });
+      // Drain the real publisher, then cross a same-socket response barrier.
+      flushPendingSessionsChangedEvents();
+      expect(await rpcReq(owner.ws, "sessions.subscribe", {})).toMatchObject({
+        ok: true,
+        payload: { subscribed: true },
+      });
+      expect
+        .soft(result)
+        .toMatchObject({ ok: false, error: { code: "INVALID_REQUEST", message: "unauthorized" } });
+      expect.soft(run.entry.controller.signal.aborted).toBe(false);
+      expect.soft(run.nativeAbort).not.toHaveBeenCalled();
+      expect.soft(childCancellation).not.toHaveBeenCalled();
+      expect.soft(queueClearing).not.toHaveBeenCalled();
+      expect.soft(getExistingFollowupQueue(run.sessionKey)).toBe(queue);
+      expect.soft(queue.items).toEqual([queued]);
+      expect.soft(queue.abortController.signal.aborted).toBe(false);
+      expect.soft(events).toEqual([]);
+      // Witness the same subscription receiving a legitimate abort so the
+      // preceding absence check cannot pass merely because nothing was subscribed.
+      expect(
+        await rpcReq(owner.ws, "sessions.abort", { key: run.sessionKey, runId: run.runId }),
+      ).toMatchObject({ ok: true, payload: { status: "aborted", abortedRunId: run.runId } });
+      await expect.poll(() => events).toContain("sessions.changed");
+    } finally {
+      owner.ws.off("message", record);
+      queueCleanup.clearSessionQueues([run.sessionKey]);
+      await run.finish();
+      owner.ws.close();
+      foreign.ws.close();
+    }
+  });
+
+  test.each(["owner", "same-device", "admin"])("preserves Stop by %s", async (requester) => {
+    const owner = await openOperator(`owner-${requester}`);
+    const stopper =
+      requester === "owner"
+        ? owner
+        : await openOperator(
+            requester === "same-device" ? `owner-${requester}` : "admin",
+            requester === "admin" ? ["operator.admin"] : ["operator.write"],
+          );
+    if (requester !== "owner") {
+      expect(stopper.hello.server.connId).not.toBe(owner.hello.server.connId);
+    }
+    if (requester === "same-device") {
+      expect(stopper.deviceId).toBe(owner.deviceId);
+    }
+    const run = await startNativeRun(owner, requester);
+    try {
+      expect(
+        await rpcReq(stopper.ws, "sessions.abort", { key: run.sessionKey, runId: run.runId }),
+      ).toMatchObject({
+        ok: true,
+        payload: { status: "aborted", abortedRunId: run.runId },
+      });
+      expect(run.entry.controller.signal.aborted).toBe(true);
+      expect(run.nativeAbort).toHaveBeenCalledTimes(1);
+    } finally {
+      await run.finish();
+      owner.ws.close();
+      stopper.ws.close();
+    }
+  });
+
+  test("preserves controller-less native Stop", async () => {
+    const owner = await openOperator("recovered-owner");
+    const sessionKey = "agent:main:recovered";
+    const runId = "native-recovered";
+    const abort = vi.fn();
+    const handle = {
+      runId,
+      abort,
+      isStreaming: () => true,
+      isCompacting: () => false,
+      queueMessage: async () => {},
+    };
+    setActiveEmbeddedRun("recovered-session", handle, sessionKey);
+    try {
+      expect(await rpcReq(owner.ws, "sessions.abort", { key: sessionKey, runId })).toMatchObject({
+        ok: true,
+        payload: { status: "aborted", abortedRunId: runId },
+      });
+      expect(abort).toHaveBeenCalledTimes(1);
+    } finally {
+      clearActiveEmbeddedRun("recovered-session", handle, sessionKey);
+      owner.ws.close();
+    }
+  });
+});


### PR DESCRIPTION
Related: #131553 — stopping an exact parent run leaves Swarm collectors running or queued. This focused ownership repair does not close the broader collector-cancellation issue.

<details>
<summary>Additional instructions</summary>

Maintainers can update this branch in the main repository.

</details>

## What Problem This Solves

Fixes an issue where a non-admin client could stop a native run started by another connection even though the normal chat Stop request rejected the same action. The inconsistency affected the native `sessions.abort` path used by SDK cancellation.

This is an existing run-ownership guard within one trusted Gateway domain, not a claim of adversarial multi-tenant isolation.

## Why This Change Was Made

A native run can have both an embedded execution handle and a Gateway controller. Controller-backed runs now use the existing requester checks and cancellation lifecycle; the direct embedded path remains available for controller-less recovered runs. This reuses the canonical policy rather than duplicating checks or making Stop admin-only.

## User Impact

Native Stop consistently honors connection/device ownership. The owning connection, a reconnect from the same paired device, and administrators retain Stop access; recovered native runs without a Gateway controller remain stoppable. No configuration or protocol change is required.

## Evidence

- Public WebSocket regression: the old branch fails four cases while the controller-less control passes. The corrected branch passes all five. It uses real negotiated scopes, ordinary agent admission, controller ownership, native registration, queued-work observation, and actual session-change publication; only model execution is simulated.
- The focused regression plus existing authorization/session-scope suites passed 82 tests across four files. A final five-case replay passed after type-declaration corrections; those corrections produce byte-identical runtime JavaScript.
- Full changed formatting/type/lint/ownership gates passed. The complete runtime build and the separate SDK package build passed; no ineffective dynamic-import warning.
- Independent managed Codex review found no actionable P0–P2 findings. The only subsequent source changes were the runtime-identical test type corrections verified by the static gate.
- **Real SDK/provider proof passed:** OpenAI `gpt-5.6-luna`, native OpenClaw Code Mode, one ordinary parent executing the exact bounded 30-second timer. Both foreign `chat.abort` and `sessions.abort` requests were refused without stopping the parent. Actual SDK `Run.cancel()` over the same admitting read/write-only connection acknowledged that exact parent in 96 ms. Public quiescence was observed 285 ms after acknowledgment; the same parent task remained present as `cancelled`, with retained `stopReason: "rpc"`. No admin rescue mutation was needed, and all probe clients/event pumps closed cleanly. This live case uses distinct connections without device identities; paired-device reconnect behavior is covered by the public WebSocket regression.

```json
{
  "proofPassed": true,
  "foreignChatAbortDenied": true,
  "foreignSessionsAbortDenied": true,
  "sdkCall": "Run.cancel()",
  "sameAdmittingConnection": true,
  "acknowledgmentMs": 96,
  "publicQuiescenceAfterAckMs": 285,
  "sameTaskRetained": true,
  "taskStatus": "cancelled",
  "retainedStopReason": "rpc",
  "adminRescueMutations": 0,
  "cleanupOk": true
}
```

Production LOC: +4/-6 (net -2). Tests: +310/-0. No new authorization policy, persistent field, schema, dependency, or configuration surface.

### Commands

```bash
node scripts/run-vitest.mjs src/gateway/server.sessions.abort-authorization.test.ts src/gateway/server-methods/chat.abort-authorization.test.ts src/gateway/server-methods/sessions-abort.test.ts src/gateway/server-methods/sessions.abort-agent-scope.test.ts
```

```bash
node scripts/run-vitest.mjs src/gateway/server.sessions.abort-authorization.test.ts
```

```bash
node scripts/check-changed.mjs --base a9978c1c6edd570b8bbe34c7276df54aabcf639b -- src/gateway/server-methods/sessions-abort.ts src/gateway/server.sessions.abort-authorization.test.ts
```

```bash
pnpm build
```

```bash
pnpm --filter @openclaw/sdk build
```

### Proof limits

No Control UI recording was captured. The authorized installed-profile browser route is unavailable: the installed Store extension differs from the repaired development copy, its native-host registration points to a removed runtime, and its installed CLI cannot open the current state schema. Repairing that setup would change browser access identity/registration outside this task's permission boundary. The SDK/Gateway proof is not presented as UI-video proof.

An early local recovery invocation failed in fixture setup/cleanup, not the product regression. The fixture now starts its terminal-response deadline only when releasing the deliberately held native command and releases on admission failure; timeouts were not increased. The original public-RPC regression then failed and passed for the intended reasons. Preliminary live-driver contract issues are kept separate from production outcomes.

AI-assisted: yes. Source behavior, ownership boundaries, and verification results were reviewed directly.
