### PR TITLE
fix: switching agents can show another agent's auth and quota

### DIFF
--- a/ui/src/app/app-host.chat-metadata.test.ts
+++ b/ui/src/app/app-host.chat-metadata.test.ts
@@ -156,6 +156,7 @@ it("rebinds global chat metadata immediately on agent selection and follows late
   state.connected = true;
   state.sessionKey = "global";
   state.assistantAgentId = "work";
+  state.loadAssistantIdentity = vi.fn(async () => undefined);
   state.chatMessage = "Keep this draft";
   state.chatError = "Keep this error";
   const messages = state.chatMessages;
@@ -164,7 +165,7 @@ it("rebinds global chat metadata immediately on agent selection and follows late
     expect(state.chatModelCatalog[0]?.available).toBe(false);
     applySelectedChatAgent(state, "main");
     await vi.waitFor(() =>
-      expect(request).toHaveBeenLastCalledWith("chat.metadata", {
+      expect(request).toHaveBeenCalledWith("chat.metadata", {
         agentId: "main",
         sessionKey: "global",
       }),
@@ -172,7 +173,7 @@ it("rebinds global chat metadata immediately on agent selection and follows late
     ready = true;
     invalidateChatMetadataStore(client);
     await vi.waitFor(() => expect(state.chatModelCatalog[0]?.available).toBe(true));
-    expect(request).toHaveBeenCalledTimes(3);
+    expect(request.mock.calls.filter(([method]) => method === "chat.metadata")).toHaveLength(3);
     expect(state.chatMessage).toBe("Keep this draft");
     expect(state.chatError).toBe("Keep this error");
     expect(state.chatMessages).toBe(messages);

--- a/ui/src/components/sidebar-attention.test.ts
+++ b/ui/src/components/sidebar-attention.test.ts
@@ -34,10 +34,12 @@ import "./sidebar-attention.ts";
 
 function deferred<T>() {
   let resolve!: (value: T) => void;
-  const promise = new Promise<T>((next) => {
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<T>((next, fail) => {
     resolve = next;
+    reject = fail;
   });
-  return { promise, resolve };
+  return { promise, reject, resolve };
 }
 
 function cronJob(id: string): CronJob {
@@ -73,9 +75,25 @@ type SidebarAttentionElement = HTMLElement & {
   dismissPanel: () => boolean;
   cronJobs: CronJob[];
   cronSchedulerEnabled: boolean | null;
+  dismissed: Record<string, string[]>;
+  modelAuthAgentId: string | null;
   modelAuthStatus: ModelAuthStatusResult | null;
   loadedAtMs: number;
 };
+
+function authStatus(ts: number, status: "missing" | "ok" = "missing"): ModelAuthStatusResult {
+  return {
+    ts,
+    providers: [
+      {
+        provider: "openai",
+        displayName: "OpenAI",
+        status,
+        profiles: [],
+      },
+    ],
+  };
+}
 
 function authItems(agentId: string) {
   return buildSidebarAttentionEntries({
@@ -159,7 +177,7 @@ describe("sidebar attention refresh ownership", () => {
   });
 
   async function mountAttention(
-    overrides: Partial<Pick<ApplicationContext, "gateway" | "overlays">> = {},
+    overrides: Partial<Pick<ApplicationContext, "agentSelection" | "gateway" | "overlays">> = {},
   ) {
     const provider = createApplicationContextProvider({
       gateway: {
@@ -365,230 +383,167 @@ describe("sidebar attention refresh ownership", () => {
     }
   });
 
-  it("keeps the latest refresh when an older load on the same client finishes last", async () => {
-    const firstCron = deferred<unknown>();
-    const firstAuth = deferred<unknown>();
-    const secondCron = deferred<unknown>();
-    const secondAuth = deferred<unknown>();
-    const responses = {
-      "cron.list": [firstCron, secondCron, deferred<unknown>()],
-      "cron.status": [
-        Promise.resolve({ enabled: false, triggersEnabled: true, jobs: 1 }),
-        Promise.resolve({ enabled: true, triggersEnabled: true, jobs: 1 }),
-        Promise.resolve({ enabled: true, triggersEnabled: true, jobs: 0 }),
-      ],
-      "models.authStatus": [firstAuth, secondAuth],
-    };
-    const request = vi.fn((method: keyof typeof responses, _params?: unknown) => {
-      const response = responses[method].shift();
-      if (!response) {
-        throw new Error(`Unexpected request: ${method}`);
-      }
-      return "promise" in response ? response.promise : response;
-    });
-    const client = { request } as unknown as GatewayBrowserClient;
-    const snapshot = {
-      client,
-      phase: "connected",
-      hello: null,
-      assistantAgentId: "main",
-      sessionKey: "agent:main:main",
-      lastError: null,
-      lastErrorCode: null,
-    };
-    const gateway = {
-      snapshot,
-      connection: {
-        gatewayUrl: "ws://gateway.test",
-        token: "",
-        bootstrapToken: "",
-        password: "",
-      },
-      subscribe: () => () => undefined,
-      subscribeEvents: () => () => undefined,
-    } as unknown as ApplicationGateway;
-    const overlays = {
-      snapshot: { approvalQueue: [] },
-      subscribe: () => () => undefined,
-    } as unknown as ApplicationContext["overlays"];
-    const selectionState = {
-      selectedId: "main" as string | null,
-      scopeId: "main" as string | null,
-    };
-    const selectionListeners = new Set<() => void>();
-    const agentSelection = {
-      state: selectionState,
-      subscribe: (listener: () => void) => {
-        selectionListeners.add(listener);
-        return () => selectionListeners.delete(listener);
-      },
-    } as unknown as ApplicationContext["agentSelection"];
-    const storage = createTestStorageMock();
-    vi.stubGlobal("localStorage", storage);
-    localStorage.setItem(
-      dismissalStoreKey(gateway.connection.gatewayUrl),
-      JSON.stringify({ cronFailed: ["current"] }),
-    );
-    vi.spyOn(document, "visibilityState", "get").mockReturnValue("visible");
-    let now = 120_000;
-    vi.spyOn(Date, "now").mockImplementation(() => now);
-
-    const provider = createApplicationContextProvider({
-      gateway,
-      overlays,
-      agentSelection,
-      scopeUpgrade: hiddenScopeUpgradeCapability,
-    } as unknown as ApplicationContext);
-    const element = document.createElement("openclaw-sidebar-attention") as SidebarAttentionElement;
-    provider.append(element);
-    document.body.append(provider);
-    await waitForFast(() => expect(request).toHaveBeenCalledTimes(3));
-    expect(request.mock.calls.find(([method]) => method === "models.authStatus")?.[1]).toEqual({
-      agentId: "main",
-    });
-    expect(request.mock.calls.find(([method]) => method === "cron.list")?.[1]).toMatchObject({
-      agentId: "main",
-    });
-
-    selectionState.selectedId = "writer";
-    selectionState.scopeId = "writer";
-    for (const listener of selectionListeners) {
-      listener();
-    }
-    await waitForFast(() => expect(request).toHaveBeenCalledTimes(6));
-    expect(request.mock.calls.filter(([method]) => method === "models.authStatus")[1]?.[1]).toEqual(
-      { agentId: "writer" },
-    );
-    expect(request.mock.calls.filter(([method]) => method === "cron.list")[1]?.[1]).toMatchObject({
-      agentId: "writer",
-    });
-
-    const currentAuth = { ts: 2, providers: [] } as ModelAuthStatusResult;
-    now = 200_000;
-    secondCron.resolve(cronListResponse([cronJob("current")]));
-    secondAuth.resolve(currentAuth);
-    await waitForFast(() => expect(element.loadedAtMs).toBe(200_000));
-    expect(element.cronJobs.map((job) => job.id)).toEqual(["current"]);
-    expect(element.cronSchedulerEnabled).toBe(true);
-    expect(element.modelAuthStatus).toBe(currentAuth);
-    expect(localStorage.getItem(dismissalStoreKey(gateway.connection.gatewayUrl))).not.toBeNull();
-
-    now = 300_000;
-    firstCron.resolve(cronListResponse([cronJob("stale")]));
-    firstAuth.resolve({ ts: 1, providers: [] });
-    await Promise.all([firstCron.promise, firstAuth.promise]);
-    await new Promise<void>((resolve) => {
-      globalThis.setTimeout(resolve, 0);
-    });
-    await element.updateComplete;
-
-    expect(element.cronJobs.map((job) => job.id)).toEqual(["current"]);
-    expect(element.cronSchedulerEnabled).toBe(true);
-    expect(element.modelAuthStatus).toBe(currentAuth);
-    expect(element.loadedAtMs).toBe(200_000);
-    expect(localStorage.getItem(dismissalStoreKey(gateway.connection.gatewayUrl))).not.toBeNull();
-
-    selectionState.selectedId = null;
-    selectionState.scopeId = null;
-    for (const listener of selectionListeners) {
-      listener();
-    }
-    await waitForFast(() => expect(request).toHaveBeenCalledTimes(8));
-    expect(request.mock.calls.filter(([method]) => method === "models.authStatus")).toHaveLength(2);
-    expect(element.modelAuthStatus).toBeNull();
-  });
-
-  it("finishes an agent auth refresh when a cron event arrives mid-switch", async () => {
-    const switchedCron = deferred<unknown>();
-    const switchedAuth = deferred<unknown>();
-    const writerAuth = { ts: 2, providers: [] } as ModelAuthStatusResult;
-    const responses = {
-      "cron.list": [
-        Promise.resolve(cronListResponse([])),
-        switchedCron.promise,
-        Promise.resolve(cronListResponse([])),
-      ],
-      "cron.status": [
-        Promise.resolve({ enabled: true, triggersEnabled: true, jobs: 0 }),
-        Promise.resolve({ enabled: true, triggersEnabled: true, jobs: 0 }),
-        Promise.resolve({ enabled: true, triggersEnabled: true, jobs: 0 }),
-      ],
-      "models.authStatus": [
-        Promise.resolve({ ts: 1, providers: [] }),
-        switchedAuth.promise,
-        Promise.resolve(writerAuth),
-      ],
-    };
-    const request = vi.fn((method: keyof typeof responses) => {
-      const response = responses[method].shift();
-      if (!response) {
-        throw new Error(`Unexpected request: ${method}`);
-      }
-      return response;
-    });
-    const client = { request } as unknown as GatewayBrowserClient;
-    let eventListener: Parameters<ApplicationGateway["subscribeEvents"]>[0] | undefined;
-    const gateway = {
-      snapshot: {
-        client,
-        phase: "connected",
-        hello: null,
-        assistantAgentId: "main",
-        sessionKey: "agent:main:main",
-        lastError: null,
-        lastErrorCode: null,
-      },
-      connection: {
-        gatewayUrl: "ws://gateway.test",
-        token: "",
-        bootstrapToken: "",
-        password: "",
-      },
-      subscribe: () => () => undefined,
-      subscribeEvents: (listener: NonNullable<typeof eventListener>) => {
-        eventListener = listener;
-        return () => undefined;
-      },
-    } as unknown as ApplicationGateway;
-    const selectionState = {
-      selectedId: "main" as string | null,
-      scopeId: "main" as string | null,
-    };
-    const selectionListeners = new Set<() => void>();
-    const provider = createApplicationContextProvider({
-      gateway,
-      overlays: {
-        snapshot: { approvalQueue: [] },
+  it.each(["success", "failure"] as const)(
+    "keeps writer auth ownership after a stale Main %s settles",
+    async (outcome) => {
+      const staleCron = deferred<unknown>();
+      const staleAuth = deferred<ModelAuthStatusResult>();
+      const switchedAuth = deferred<ModelAuthStatusResult>();
+      const responses = {
+        "cron.list": [
+          Promise.resolve(cronListResponse([cronJob("current")])),
+          staleCron.promise,
+          Promise.resolve(cronListResponse([cronJob("current")])),
+          Promise.resolve(cronListResponse([cronJob("current")])),
+        ],
+        "cron.status": [
+          Promise.resolve({ enabled: true, triggersEnabled: true, jobs: 1 }),
+          Promise.resolve({ enabled: true, triggersEnabled: true, jobs: 1 }),
+          Promise.resolve({ enabled: true, triggersEnabled: true, jobs: 1 }),
+          Promise.resolve({ enabled: true, triggersEnabled: true, jobs: 1 }),
+        ],
+        "models.authStatus": [
+          Promise.resolve(authStatus(1)),
+          staleAuth.promise,
+          switchedAuth.promise,
+          Promise.resolve(authStatus(2)),
+        ],
+      };
+      const request = vi.fn((method: keyof typeof responses) => {
+        const response = responses[method].shift();
+        if (!response) {
+          throw new Error(`Unexpected request: ${method}`);
+        }
+        return response;
+      });
+      const client = { request } as unknown as GatewayBrowserClient;
+      let eventListener: Parameters<ApplicationGateway["subscribeEvents"]>[0] | undefined;
+      const gateway = {
+        snapshot: {
+          client,
+          phase: "connected",
+          hello: {
+            auth: { role: "operator", scopes: ["operator.admin", "operator.read"] },
+            features: { methods: ["update.run"] },
+          },
+        },
+        connection: { gatewayUrl: "ws://gateway.test" },
         subscribe: () => () => undefined,
-      },
-      agentSelection: {
+        subscribeEvents: (listener: NonNullable<typeof eventListener>) => {
+          eventListener = listener;
+          return () => undefined;
+        },
+      } as unknown as ApplicationGateway;
+      const overlays = {
+        snapshot: {
+          approvalQueue: [{ id: "approval-1", request: { command: "echo proof" } }],
+          approvalBusy: false,
+          approvalCanGrant: true,
+          approvalErrors: new Map(),
+          updateAvailable: {
+            currentVersion: "2026.8.1",
+            latestVersion: "2026.8.2",
+            channel: "latest",
+          },
+        },
+        subscribe: () => () => undefined,
+      } as unknown as ApplicationContext["overlays"];
+      const selectionState = {
+        selectedId: "main" as string | null,
+        scopeId: null as string | null,
+      };
+      const selectionListeners = new Set<() => void>();
+      const agentSelection = {
         state: selectionState,
         subscribe: (listener: () => void) => {
           selectionListeners.add(listener);
           return () => selectionListeners.delete(listener);
         },
-      },
-      scopeUpgrade: hiddenScopeUpgradeCapability,
-    } as unknown as ApplicationContext);
-    vi.stubGlobal("localStorage", createTestStorageMock());
-    const element = document.createElement("openclaw-sidebar-attention") as SidebarAttentionElement;
-    provider.append(element);
-    document.body.append(provider);
-    await waitForFast(() => expect(request).toHaveBeenCalledTimes(3));
+      } as unknown as ApplicationContext["agentSelection"];
+      vi.stubGlobal("localStorage", createTestStorageMock());
+      localStorage.setItem(
+        dismissalStoreKey(gateway.connection.gatewayUrl),
+        JSON.stringify({
+          cronFailed: ["dismissed-cron"],
+          modelAuthExpired: ["agent:writer\nold-provider"],
+        }),
+      );
+      vi.spyOn(document, "visibilityState", "get").mockReturnValue("visible");
+      let now = 120_000;
+      vi.spyOn(Date, "now").mockImplementation(() => now);
 
-    selectionState.selectedId = "writer";
-    selectionState.scopeId = "writer";
-    for (const listener of selectionListeners) {
-      listener();
-    }
-    await waitForFast(() => expect(request).toHaveBeenCalledTimes(6));
-    eventListener?.({ type: "event", event: "cron", payload: {} });
+      const { element, trigger } = await mountAttention({ agentSelection, gateway, overlays });
+      await waitForFast(() => expect(element.modelAuthStatus?.ts).toBe(1));
+      trigger.click();
+      await waitForFast(() =>
+        expect(element.querySelector('[data-attention-kind="modelAuthExpired"]')).not.toBeNull(),
+      );
 
-    await waitForFast(() => expect(request).toHaveBeenCalledTimes(9));
-    await waitForFast(() => expect(element.modelAuthStatus).toBe(writerAuth));
-    switchedCron.resolve(cronListResponse([]));
-    switchedAuth.resolve({ ts: 3, providers: [] });
-  });
+      now = 200_000;
+      document.dispatchEvent(new Event("visibilitychange"));
+      await waitForFast(() => expect(request).toHaveBeenCalledTimes(6));
+
+      selectionState.selectedId = "writer";
+      for (const listener of selectionListeners) {
+        listener();
+      }
+
+      expect(element.modelAuthStatus).toBeNull();
+      expect(element.modelAuthAgentId).toBeNull();
+      await element.updateComplete;
+      expect(element.querySelector('[data-attention-kind="modelAuthExpired"]')).toBeNull();
+      expect(element.querySelector('[data-attention-kind="cronFailed"]')).not.toBeNull();
+      expect(element.querySelector('[data-attention-kind="updateAvailable"]')).not.toBeNull();
+      expect(element.querySelector('[data-approval-id="approval-1"]')).not.toBeNull();
+
+      await waitForFast(() => expect(request).toHaveBeenCalledTimes(9));
+      eventListener?.({ type: "event", event: "cron", payload: {} });
+      await waitForFast(() => expect(request).toHaveBeenCalledTimes(12));
+      await waitForFast(() => expect(element.modelAuthStatus?.ts).toBe(2));
+      expect(element.modelAuthAgentId).toBe("writer");
+      await waitForFast(() =>
+        expect(
+          element
+            .querySelector('[data-attention-kind="modelAuthExpired"]')
+            ?.textContent?.replace(/\s+/g, " "),
+        ).toContain("writer"),
+      );
+      const currentDismissals = structuredClone(element.dismissed);
+      const storedDismissals = localStorage.getItem(
+        dismissalStoreKey(gateway.connection.gatewayUrl),
+      );
+
+      now = 300_000;
+      staleCron.resolve(cronListResponse([cronJob("stale")]));
+      if (outcome === "success") {
+        staleAuth.resolve(authStatus(3, "ok"));
+      } else {
+        staleAuth.reject(new Error("stale Main auth"));
+      }
+      switchedAuth.resolve(authStatus(4, "ok"));
+      await Promise.allSettled([staleCron.promise, staleAuth.promise, switchedAuth.promise]);
+      await new Promise<void>((resolve) => {
+        globalThis.setTimeout(resolve, 0);
+      });
+      await element.updateComplete;
+
+      expect(element.cronJobs.map((job) => job.id)).toEqual(["current"]);
+      expect(element.modelAuthStatus?.ts).toBe(2);
+      expect(element.modelAuthAgentId).toBe("writer");
+      expect(
+        element
+          .querySelector('[data-attention-kind="modelAuthExpired"]')
+          ?.textContent?.replace(/\s+/g, " "),
+      ).toContain("writer");
+      expect(element.dismissed).toEqual(currentDismissals);
+      expect(localStorage.getItem(dismissalStoreKey(gateway.connection.gatewayUrl))).toBe(
+        storedDismissals,
+      );
+      expect(element.querySelector('[data-attention-kind="cronFailed"]')).not.toBeNull();
+      expect(element.querySelector('[data-attention-kind="updateAvailable"]')).not.toBeNull();
+      expect(element.querySelector('[data-approval-id="approval-1"]')).not.toBeNull();
+    },
+  );
 
   it("opens top-mounted attention downward and clears stale live automation alerts", async () => {
     const responses = {

--- a/ui/src/components/sidebar-attention.ts
+++ b/ui/src/components/sidebar-attention.ts
@@ -347,6 +347,10 @@ class SidebarAttention extends OpenClawLightDomElement {
     ) {
       return;
     }
+    if (loadedAgentScope && agentScope.selectedId !== loadedAgentScope.selectedId) {
+      this.modelAuthStatus = null;
+      this.modelAuthAgentId = null;
+    }
     if (loadedAgentScope && agentScope.scopeId !== loadedAgentScope.scopeId) {
       this.cronJobs = [];
     }

--- a/ui/src/e2e/chat-quota-pill-93041.e2e.test.ts
+++ b/ui/src/e2e/chat-quota-pill-93041.e2e.test.ts
@@ -1,9 +1,14 @@
 // Real-browser proof + regression for #93041: provider usage from models.authStatus remains
 // available in the desktop composer's context popover. Screenshots go to the ignored artifacts tree.
+import { mkdir } from "node:fs/promises";
 import path from "node:path";
 import type { BrowserContext, Page } from "playwright";
 import { expect, it } from "vitest";
-import { controlUiE2eWaitTimeoutMs, installMockGateway } from "../test-helpers/control-ui-e2e.ts";
+import {
+  controlUiE2eWaitTimeoutMs,
+  controlUiSessionUrl,
+  installMockGateway,
+} from "../test-helpers/control-ui-e2e.ts";
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
 const suite = createControlUiE2eSuite({
@@ -12,6 +17,13 @@ const suite = createControlUiE2eSuite({
 
 const baseTime = 1_700_000_000_000;
 const artifactDir = path.resolve(process.cwd(), ".artifacts/control-ui-e2e/chat-quota-pill-93041");
+const captureOwnershipProof = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
+const ownershipProofPhase = process.env.OPENCLAW_UI_PROOF_PHASE?.trim() || "candidate";
+const ownershipProofDir = path.resolve(
+  process.cwd(),
+  ".artifacts/ui-visual-proof/agent-quota-ownership",
+  ownershipProofPhase,
+);
 
 const authStatusWithUsage = {
   ts: baseTime,
@@ -55,6 +67,56 @@ const gatewayInjectedSessions = {
 const highPressureSessions = {
   ...gatewayInjectedSessions,
   sessions: [{ ...gatewayInjectedSessions.sessions[0], totalTokens: 190_000 }],
+};
+
+const agentsList = {
+  agents: [
+    { id: "main", name: "Main" },
+    { id: "work", name: "Work" },
+  ],
+  defaultId: "main",
+  mainKey: "main",
+  scope: "global",
+};
+
+function agentAuthStatus(agentId: "main" | "work") {
+  const isMain = agentId === "main";
+  return {
+    ts: baseTime + (isMain ? 1 : 2),
+    providers: [
+      {
+        provider: "openai",
+        displayName: isMain ? "Main OpenAI" : "Work OpenAI",
+        status: "ok",
+        profiles: [{ profileId: `${agentId}-codex`, type: "oauth", status: "ok" }],
+        usage: {
+          providerId: "openai",
+          plan: isMain ? "Main Pro" : "Work Team",
+          accountEmail: `${agentId}@example.test`,
+          windows: [
+            {
+              label: "Week",
+              usedPercent: isMain ? 81 : 24,
+              resetAt: Date.now() + 4 * 86_400_000,
+            },
+          ],
+        },
+      },
+    ],
+  };
+}
+
+const selectedGlobalSessions = {
+  ...gatewayInjectedSessions,
+  sessions: [
+    {
+      ...gatewayInjectedSessions.sessions[0],
+      displayName: "Selected global",
+      key: "global",
+      label: "Selected global",
+      modelProvider: "openai",
+    },
+  ],
 };
 
 const claudeSubscriptionAuthStatus = {
@@ -146,6 +208,85 @@ async function openChat(
 async function closeChat(fixture: { context: BrowserContext; page: Page }): Promise<void> {
   await fixture.page.close().catch(() => {});
   await fixture.context.close().catch(() => {});
+}
+
+async function setSelectedAgent(page: Page, agentId: string): Promise<void> {
+  await page.evaluate((nextAgentId) => {
+    const app = document.querySelector("openclaw-app") as HTMLElement & {
+      runtime?: { context: { agentSelection: { set: (value: string) => void } } };
+    };
+    app.runtime?.context.agentSelection.set(nextAgentId);
+  }, agentId);
+}
+
+async function visibleAuthState(page: Page) {
+  return await page.evaluate(() => {
+    const pane = document.querySelector("openclaw-chat-pane.chat-pane-cache__pane--visible") as
+      | (HTMLElement & {
+          state?: {
+            assistantAgentId?: string | null;
+            modelAuthStatusError?: string | null;
+            modelAuthStatusResult?: {
+              ts?: number;
+              providers?: Array<{
+                displayName?: string;
+                usage?: { accountEmail?: string; plan?: string };
+              }>;
+            } | null;
+          };
+        })
+      | null;
+    const provider = pane?.state?.modelAuthStatusResult?.providers?.[0];
+    return {
+      account: provider?.usage?.accountEmail ?? null,
+      agentId: pane?.state?.assistantAgentId ?? null,
+      displayName: provider?.displayName ?? null,
+      error: pane?.state?.modelAuthStatusError ?? null,
+      plan: provider?.usage?.plan ?? null,
+      ts: pane?.state?.modelAuthStatusResult?.ts ?? null,
+    };
+  });
+}
+
+async function setOwnershipProofCue(page: Page, text: string): Promise<void> {
+  await page.evaluate((label) => {
+    let cue = document.querySelector<HTMLElement>("[data-auth-ownership-proof-cue]");
+    if (!cue) {
+      cue = document.createElement("div");
+      cue.dataset.authOwnershipProofCue = "true";
+      Object.assign(cue.style, {
+        background: "#171717",
+        border: "1px solid #fafafa",
+        borderRadius: "4px",
+        color: "#fafafa",
+        font: "600 13px/1.4 system-ui, sans-serif",
+        maxWidth: "420px",
+        padding: "8px 10px",
+        position: "fixed",
+        right: "16px",
+        top: "16px",
+        zIndex: "2147483647",
+      });
+      document.body.append(cue);
+    }
+    cue.textContent = label;
+  }, text);
+}
+
+async function pauseForOwnershipProof(page: Page): Promise<void> {
+  if (captureOwnershipProof) {
+    await page.waitForTimeout(2_200);
+  }
+}
+
+async function openVisibleQuotaPopover(page: Page) {
+  const visiblePane = page.locator("openclaw-chat-pane.chat-pane-cache__pane--visible");
+  const popover = visiblePane.locator(".context-usage__popover");
+  if (!(await popover.isVisible())) {
+    await visiblePane.locator(".context-ring").click();
+  }
+  await popover.waitFor({ state: "visible" });
+  return popover;
 }
 
 suite.define(() => {
@@ -272,30 +413,190 @@ suite.define(() => {
     }
   });
 
-  it("does not expose session routing metadata while plan usage is loading", async () => {
-    // Sidebar attention and the chat pane each request auth status at startup.
-    // Hold both so the popover is observed before any quota snapshot arrives.
-    const fixture = await openChat(
-      authStatusWithUsage,
-      { "sessions.list": gatewayInjectedSessions },
-      ["models.authStatus", "models.authStatus"],
-    );
-    const { page } = fixture;
+  it("binds delayed auth and quota presentation to the selected global agent", async () => {
+    if (captureOwnershipProof) {
+      await mkdir(ownershipProofDir, { recursive: true });
+    }
+    const context = await suite.browser.newContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1280 },
+      ...(captureOwnershipProof
+        ? { recordVideo: { dir: ownershipProofDir, size: { height: 900, width: 1280 } } }
+        : {}),
+    });
+    const page = await context.newPage();
+    const video = page.video();
+    page.setDefaultTimeout(controlUiE2eWaitTimeoutMs);
     try {
-      const contextRing = page.locator(".context-ring");
-      await contextRing.waitFor({ state: "visible" });
-      await contextRing.click();
-      const popover = page.locator(".context-usage__popover");
-      await popover.waitFor({ state: "visible" });
-      await popover.screenshot({ path: path.join(artifactDir, "05-usage-loading.png") });
+      const gateway = await installMockGateway(page, {
+        assistantAgentId: "main",
+        defaultAgentId: "main",
+        deferredMethods: [
+          "models.authStatus",
+          "models.authStatus",
+          "models.authStatus",
+          "models.authStatus",
+          "agent.identity.get",
+        ],
+        methodResponses: {
+          "agent.identity.get": {
+            cases: [
+              { match: { agentId: "main" }, response: { agentId: "main", name: "Main Agent" } },
+              { match: { agentId: "work" }, response: { agentId: "work", name: "Work Agent" } },
+            ],
+          },
+          "agents.list": agentsList,
+          "models.authStatus": {
+            cases: [
+              { match: { agentId: "main" }, response: agentAuthStatus("main") },
+              { match: { agentId: "work" }, response: agentAuthStatus("work") },
+            ],
+          },
+          "sessions.list": selectedGlobalSessions,
+        },
+        sessionKey: "global",
+      });
+      await page.goto(controlUiSessionUrl(suite.server.baseUrl, "global"));
+      const connectRequest = await gateway.waitForRequest("connect");
+      const { client: connectedClient } = connectRequest.params as {
+        client: { instanceId: string };
+      };
+      await expect
+        .poll(async () => (await gateway.getRequests("models.authStatus")).length)
+        .toBe(2);
 
-      expect(await page.locator('[data-chat-provider-usage="true"]').count()).toBe(0);
-      const popoverText = (await popover.textContent()) ?? "";
-      expect(popoverText).not.toContain("openclaw");
-      expect(popoverText).not.toContain("gateway-injected");
-      expect(popoverText).not.toContain("Model:");
+      let popover = await openVisibleQuotaPopover(page);
+      expect(
+        await page
+          .locator("openclaw-chat-pane.chat-pane-cache__pane--visible")
+          .locator('[data-chat-provider-usage="true"]')
+          .count(),
+      ).toBe(0);
+      await setOwnershipProofCue(page, "Selected agent: Main | Main auth request delayed");
+      await pauseForOwnershipProof(page);
+
+      await gateway.deferNext("agent.identity.get", { agentId: "work" });
+      await setSelectedAgent(page, "work");
+      await expect.poll(async () => (await visibleAuthState(page)).agentId).toBe("work");
+      await expect
+        .poll(async () => (await gateway.getRequests("models.authStatus")).length)
+        .toBeGreaterThanOrEqual(3);
+      await gateway.emitGatewayEvent("presence", {
+        presence: [
+          {
+            instanceId: connectedClient.instanceId,
+            user: { id: "operator", name: "Operator" },
+            ts: Date.now(),
+          },
+        ],
+      });
+      await expect.poll(async () => (await visibleAuthState(page)).agentId).toBe("work");
+      popover = await openVisibleQuotaPopover(page);
+      await setOwnershipProofCue(page, "Selected agent: Work | Work auth loading");
+      await pauseForOwnershipProof(page);
+      if (captureOwnershipProof) {
+        await page.screenshot({
+          animations: "disabled",
+          fullPage: true,
+          path: path.join(ownershipProofDir, "01-work-loading.png"),
+        });
+      }
+
+      await gateway.resolveDeferred("models.authStatus");
+      await gateway.resolveDeferred("models.authStatus");
+      await gateway.resolveDeferred("agent.identity.get", {
+        agentId: "main",
+        name: "Stale Main Agent",
+      });
+      await page.waitForTimeout(100);
+      const delayedMainState = await visibleAuthState(page);
+      popover = await openVisibleQuotaPopover(page);
+      await setOwnershipProofCue(
+        page,
+        delayedMainState.account === "main@example.test"
+          ? `Visible agent: ${delayedMainState.agentId} | Displayed stale account: ${delayedMainState.account} | Plan: ${delayedMainState.plan}`
+          : delayedMainState.account
+            ? `Visible agent: ${delayedMainState.agentId} | Work result settled | Plan: ${delayedMainState.plan}`
+            : `Visible agent: ${delayedMainState.agentId} | Delayed Main ignored | Work auth loading`,
+      );
+      await pauseForOwnershipProof(page);
+      if (captureOwnershipProof) {
+        await page.screenshot({
+          animations: "disabled",
+          fullPage: true,
+          path: path.join(ownershipProofDir, "02-after-delayed-main.png"),
+        });
+      }
+
+      expect(delayedMainState.agentId).toBe("work");
+      expect(delayedMainState.error).toBeNull();
+      expect(delayedMainState.account).not.toBe("main@example.test");
+      expect(delayedMainState.displayName).not.toBe("Main OpenAI");
+      expect(delayedMainState.plan).not.toBe("Main Pro");
+      const authRequests = await gateway.getRequests("models.authStatus");
+      const workAuthRequests = authRequests.filter(
+        (request) =>
+          typeof request.params === "object" &&
+          request.params !== null &&
+          "agentId" in request.params &&
+          request.params.agentId === "work",
+      );
+      expect(workAuthRequests.length).toBeGreaterThanOrEqual(2);
+      const identityRequests = await gateway.getRequests("agent.identity.get");
+      expect(
+        identityRequests.filter(
+          (request) =>
+            typeof request.params === "object" &&
+            request.params !== null &&
+            "agentId" in request.params &&
+            request.params.agentId === "work",
+        ),
+      ).not.toHaveLength(0);
+
+      await gateway.resolveDeferred("models.authStatus");
+      await gateway.resolveDeferred("models.authStatus");
+      await gateway.resolveDeferred("agent.identity.get", {
+        agentId: "work",
+        name: "Work Agent",
+      });
+      await expect
+        .poll(() => visibleAuthState(page))
+        .toEqual({
+          account: "work@example.test",
+          agentId: "work",
+          displayName: "Work OpenAI",
+          error: null,
+          plan: "Work Team",
+          ts: baseTime + 2,
+        });
+      popover = await openVisibleQuotaPopover(page);
+      await expect.poll(async () => popover.textContent()).toContain("Work Team");
+      const settledText = (await popover.textContent()) ?? "";
+      expect(settledText).toContain("work@example.test");
+      expect(settledText).toContain("24%");
+      expect(settledText).not.toContain("Main Pro");
+      expect(settledText).not.toContain("main@example.test");
+      await setOwnershipProofCue(
+        page,
+        "Selected agent: Work | Account: work@example.test | Plan: Work Team | Quota: 24%",
+      );
+      await pauseForOwnershipProof(page);
+      if (captureOwnershipProof) {
+        await page.screenshot({
+          animations: "disabled",
+          fullPage: true,
+          path: path.join(ownershipProofDir, "03-work-settled.png"),
+        });
+      }
     } finally {
-      await closeChat(fixture);
+      await page.close().catch(() => {});
+      await context.close().catch(() => {});
+      if (captureOwnershipProof && video) {
+        await video
+          .saveAs(path.join(ownershipProofDir, `${ownershipProofPhase}.webm`))
+          .catch(() => {});
+      }
     }
   });
 });

--- a/ui/src/e2e/chat-quota-pill-93041.e2e.test.ts
+++ b/ui/src/e2e/chat-quota-pill-93041.e2e.test.ts
@@ -470,6 +470,24 @@ suite.define(() => {
       await setOwnershipProofCue(page, "Selected agent: Main | Main auth request delayed");
       await pauseForOwnershipProof(page);
 
+      await page.evaluate(() => {
+        const pane = document.querySelector("openclaw-chat-pane.chat-pane-cache__pane--visible") as
+          | (HTMLElement & {
+              state?: {
+                assistantName: string;
+                assistantAvatar: string | null;
+                chatAvatarUrl: string | null;
+                requestUpdate?: () => void;
+              };
+            })
+          | null;
+        if (pane?.state) {
+          pane.state.assistantName = "Main Agent";
+          pane.state.assistantAvatar = "M";
+          pane.state.chatAvatarUrl = "https://example.test/main-avatar.png";
+          pane.state.requestUpdate?.();
+        }
+      });
       await gateway.deferNext("models.authStatus", { agentId: "work" });
       await gateway.deferNext("models.authStatus", { agentId: "work" });
       await gateway.deferNext("agent.identity.get", { agentId: "work" });
@@ -488,6 +506,28 @@ suite.define(() => {
           plan: null,
           ts: null,
         });
+      await expect
+        .poll(() =>
+          page.evaluate(() => {
+            const pane = document.querySelector(
+              "openclaw-chat-pane.chat-pane-cache__pane--visible",
+            ) as
+              | (HTMLElement & {
+                  state?: {
+                    assistantName?: string;
+                    assistantAvatar?: string | null;
+                    chatAvatarUrl?: string | null;
+                  };
+                })
+              | null;
+            return {
+              name: pane?.state?.assistantName ?? null,
+              avatar: pane?.state?.assistantAvatar ?? null,
+              renderedAvatar: pane?.state?.chatAvatarUrl ?? null,
+            };
+          }),
+        )
+        .toEqual({ name: "", avatar: null, renderedAvatar: null });
       await gateway.deferNext("models.authStatus", { agentId: "work" });
       await gateway.emitGatewayEvent("presence", {
         presence: [

--- a/ui/src/e2e/chat-quota-pill-93041.e2e.test.ts
+++ b/ui/src/e2e/chat-quota-pill-93041.e2e.test.ts
@@ -432,13 +432,7 @@ suite.define(() => {
       const gateway = await installMockGateway(page, {
         assistantAgentId: "main",
         defaultAgentId: "main",
-        deferredMethods: [
-          "models.authStatus",
-          "models.authStatus",
-          "models.authStatus",
-          "models.authStatus",
-          "agent.identity.get",
-        ],
+        deferredMethods: ["models.authStatus", "models.authStatus", "agent.identity.get"],
         methodResponses: {
           "agent.identity.get": {
             cases: [
@@ -476,12 +470,25 @@ suite.define(() => {
       await setOwnershipProofCue(page, "Selected agent: Main | Main auth request delayed");
       await pauseForOwnershipProof(page);
 
+      await gateway.deferNext("models.authStatus", { agentId: "work" });
+      await gateway.deferNext("models.authStatus", { agentId: "work" });
       await gateway.deferNext("agent.identity.get", { agentId: "work" });
       await setSelectedAgent(page, "work");
       await expect.poll(async () => (await visibleAuthState(page)).agentId).toBe("work");
       await expect
         .poll(async () => (await gateway.getRequests("models.authStatus")).length)
         .toBeGreaterThanOrEqual(3);
+      await expect
+        .poll(() => visibleAuthState(page))
+        .toEqual({
+          account: null,
+          agentId: "work",
+          displayName: null,
+          error: null,
+          plan: null,
+          ts: null,
+        });
+      await gateway.deferNext("models.authStatus", { agentId: "work" });
       await gateway.emitGatewayEvent("presence", {
         presence: [
           {
@@ -491,8 +498,16 @@ suite.define(() => {
           },
         ],
       });
-      await expect.poll(async () => (await visibleAuthState(page)).agentId).toBe("work");
-      popover = await openVisibleQuotaPopover(page);
+      await expect
+        .poll(() => visibleAuthState(page))
+        .toEqual({
+          account: null,
+          agentId: "work",
+          displayName: null,
+          error: null,
+          plan: null,
+          ts: null,
+        });
       await setOwnershipProofCue(page, "Selected agent: Work | Work auth loading");
       await pauseForOwnershipProof(page);
       if (captureOwnershipProof) {
@@ -511,7 +526,14 @@ suite.define(() => {
       });
       await page.waitForTimeout(100);
       const delayedMainState = await visibleAuthState(page);
-      popover = await openVisibleQuotaPopover(page);
+      expect(delayedMainState).toEqual({
+        account: null,
+        agentId: "work",
+        displayName: null,
+        error: null,
+        plan: null,
+        ts: null,
+      });
       await setOwnershipProofCue(
         page,
         delayedMainState.account === "main@example.test"
@@ -554,8 +576,9 @@ suite.define(() => {
         ),
       ).not.toHaveLength(0);
 
-      await gateway.resolveDeferred("models.authStatus");
-      await gateway.resolveDeferred("models.authStatus");
+      for (let pending = workAuthRequests.length; pending > 0; pending -= 1) {
+        await gateway.resolveDeferred("models.authStatus");
+      }
       await gateway.resolveDeferred("agent.identity.get", {
         agentId: "work",
         name: "Work Agent",

--- a/ui/src/pages/chat/chat-pane-identity.test.ts
+++ b/ui/src/pages/chat/chat-pane-identity.test.ts
@@ -13,6 +13,37 @@ import {
 import type { ChatPageHost } from "./chat-state-host.ts";
 
 describe("chat pane assistant identity snapshots", () => {
+  it("rebinds agent-owned presentation when a retained fixed route changes owner", () => {
+    const client = { request: vi.fn(async () => ({})) } as unknown as GatewayBrowserClient;
+    const retireModelOverride = vi.fn();
+    const sessions = createSessionCapabilityFixture({ retireModelOverride });
+    const { pane, state } = createTestChatPane({ client, sessions });
+    state.sessionKey = "agent:main:main";
+    state.assistantAgentId = "main";
+    state.assistantName = "Main Agent";
+    state.chatAvatarUrl = "https://example.test/main-avatar.png";
+    state.modelAuthStatusResult = { ts: 1, providers: [] };
+    state.chatModelSwitchPromises = {
+      "agent:main:main": new Promise<boolean>(() => {}),
+    };
+    state.loadAssistantIdentity = vi.fn(async () => undefined);
+    pane.sessionKey = "agent:work:main";
+
+    (
+      pane as TestChatPane & {
+        willUpdate: (changedProperties: Map<PropertyKey, unknown>) => void;
+      }
+    ).willUpdate(new Map([["sessionKey", "agent:main:main"]]));
+
+    expect(state.sessionKey).toBe("agent:work:main");
+    expect(state.assistantAgentId).toBe("work");
+    expect(state.assistantName).toBe("");
+    expect(state.chatAvatarUrl).toBeNull();
+    expect(state.modelAuthStatusResult).toBeNull();
+    expect(state.loadAssistantIdentity).toHaveBeenCalledOnce();
+    expect(retireModelOverride).toHaveBeenCalledWith("agent:work:main");
+  });
+
   it("rebinds approval delivery when the selected global agent changes", async () => {
     const replacement = createDeferred<{
       key: string;

--- a/ui/src/pages/chat/chat-pane-identity.test.ts
+++ b/ui/src/pages/chat/chat-pane-identity.test.ts
@@ -102,6 +102,7 @@ describe("chat pane assistant identity snapshots", () => {
         },
       ];
 
+      pane.state.loadAssistantIdentity = vi.fn(async () => undefined);
       context.agentSelection.set("research");
 
       expect(pane.state.chatSessionApprovalQueue).toEqual([]);

--- a/ui/src/pages/chat/chat-pane-lifecycle.test.ts
+++ b/ui/src/pages/chat/chat-pane-lifecycle.test.ts
@@ -995,12 +995,12 @@ describe("chat pane connection lifecycle", () => {
     { sessionKey: "agent:work:main", mainKey: "main" },
     { sessionKey: "agent:work:home", mainKey: "home" },
   ])(
-    "retires pending global model selection state when the selected agent changes for $sessionKey",
+    "preserves owner-qualified model and identity state when global selection changes for $sessionKey",
     ({ sessionKey, mainKey }) => {
       const client = { request: vi.fn(async () => ({})) } as unknown as GatewayBrowserClient;
       const retireModelOverride = vi.fn();
       const sessions = { retireModelOverride } as unknown as SessionCapability;
-      const { pane, state } = createTestChatPane({ client, sessions });
+      const { state } = createTestChatPane({ client, sessions });
       state.sessionKey = sessionKey;
       state.agentsList = { defaultId: "main", mainKey, scope: "global", agents: [] };
       state.assistantAgentId = "work";
@@ -1008,15 +1008,12 @@ describe("chat pane connection lifecycle", () => {
       state.chatModelSwitchPromises = {
         global: new Promise<boolean>(() => {}),
       };
+      const pending = state.chatModelSwitchPromises;
       applySelectedChatAgent(state, "main");
-      expect(state.chatModelSwitchPromises).toEqual({});
-      expect(state.assistantAgentId).toBe("main");
-      expect(retireModelOverride).toHaveBeenCalledWith(sessionKey);
-      expect(retireModelOverride).toHaveBeenCalledWith("global");
-      pane.context.agentSelection.set("work");
-      applySelectedChatAgent(state, "work");
-      pane.applyGatewaySnapshot({ ...pane.context.gateway.snapshot, assistantAgentId: "main" });
+      expect(state.chatModelSwitchPromises).toBe(pending);
       expect(state.assistantAgentId).toBe("work");
+      expect(retireModelOverride).not.toHaveBeenCalled();
+      expect(state.loadAssistantIdentity).not.toHaveBeenCalled();
     },
   );
 

--- a/ui/src/pages/chat/chat-pane-lifecycle.test.ts
+++ b/ui/src/pages/chat/chat-pane-lifecycle.test.ts
@@ -1000,20 +1000,23 @@ describe("chat pane connection lifecycle", () => {
       const client = { request: vi.fn(async () => ({})) } as unknown as GatewayBrowserClient;
       const retireModelOverride = vi.fn();
       const sessions = { retireModelOverride } as unknown as SessionCapability;
-      const { state } = createTestChatPane({ client, sessions });
+      const { pane, state } = createTestChatPane({ client, sessions });
       state.sessionKey = sessionKey;
       state.agentsList = { defaultId: "main", mainKey, scope: "global", agents: [] };
       state.assistantAgentId = "work";
+      state.loadAssistantIdentity = vi.fn(async () => undefined);
       state.chatModelSwitchPromises = {
         global: new Promise<boolean>(() => {}),
       };
-
       applySelectedChatAgent(state, "main");
-
       expect(state.chatModelSwitchPromises).toEqual({});
       expect(state.assistantAgentId).toBe("main");
       expect(retireModelOverride).toHaveBeenCalledWith(sessionKey);
       expect(retireModelOverride).toHaveBeenCalledWith("global");
+      pane.context.agentSelection.set("work");
+      applySelectedChatAgent(state, "work");
+      pane.applyGatewaySnapshot({ ...pane.context.gateway.snapshot, assistantAgentId: "main" });
+      expect(state.assistantAgentId).toBe("work");
     },
   );
 

--- a/ui/src/pages/chat/chat-pane-lifecycle.ts
+++ b/ui/src/pages/chat/chat-pane-lifecycle.ts
@@ -28,7 +28,10 @@ import {
 import { sessionPullRequestsForGateway } from "../../lib/session-pull-requests.ts";
 import { parseCatalogSessionKey } from "../../lib/sessions/catalog-key.ts";
 import { resolveSessionKey } from "../../lib/sessions/index.ts";
-import { areUiSessionKeysEquivalent } from "../../lib/sessions/session-key.ts";
+import {
+  areUiSessionKeysEquivalent,
+  parseAgentSessionKey,
+} from "../../lib/sessions/session-key.ts";
 import { invalidateChatAvatarCache, refreshChatAvatar } from "./chat-avatar.ts";
 import { syncSelectedSessionMessageSubscription } from "./chat-history.ts";
 import {
@@ -59,6 +62,7 @@ import {
 import { handlePageGatewayEvent } from "./chat-state-events.ts";
 import { createPageState } from "./chat-state-page.ts";
 import {
+  applyChatAgentOwnerTransition,
   applySelectedChatAgent,
   refreshPageChat,
   retireChatMetadataRequests,
@@ -628,6 +632,10 @@ export abstract class ChatPaneLifecycle extends ChatPaneSessionCreation {
         // A retained pane owns one conversation for its lifetime. Only its
         // canonical spelling can change after Gateway defaults resolve.
         this.state.sessionKey = nextSessionKey;
+        const nextAgentId = parseAgentSessionKey(nextSessionKey)?.agentId;
+        if (nextAgentId) {
+          applyChatAgentOwnerTransition(this.state, nextAgentId);
+        }
         // A pane routed straight onto the created session never runs the switch
         // path, so its one-shot handoffs would expire unclaimed: the rejected turn
         // would vanish instead of offering a retry, and the accepted prompt would

--- a/ui/src/pages/chat/chat-pane.test.ts
+++ b/ui/src/pages/chat/chat-pane.test.ts
@@ -705,6 +705,7 @@ describe("chat pane initialization", () => {
     state.initialUserMessage = createInitialUserMessageHandoff();
     state.chatRunId = "run-reconnected";
     state.chatStream = "The response survived navigation.";
+    state.loadAssistantIdentity = vi.fn(async () => undefined);
     pane.sessionKey = canonicalSessionKey;
 
     (

--- a/ui/src/pages/chat/chat-state-host.ts
+++ b/ui/src/pages/chat/chat-state-host.ts
@@ -73,6 +73,7 @@ export type ChatPageHost = ChatHost &
     chatModelPickerOpenSessionKey?: string | null;
     chatModelCatalog: ModelCatalogEntry[];
     chatModelCatalogError: string | null;
+    modelAuthStatusRequestVersion: number;
     modelAuthStatusResult: ModelAuthStatusResult | null;
     modelAuthStatusError: string | null;
     sessionsResult: SessionsListResult | null;

--- a/ui/src/pages/chat/chat-state-page.ts
+++ b/ui/src/pages/chat/chat-state-page.ts
@@ -107,6 +107,7 @@ async function loadPageAssistantIdentity(
       !state.connected ||
       state.assistantIdentityRequestVersion !== requestVersion ||
       state.sessionKey.trim() !== expectedSessionKey ||
+      resolveAgentIdForSession(state) !== agentId ||
       !identity
     ) {
       return;
@@ -214,6 +215,7 @@ export function createPageState(
     chatModelsLoading: false,
     chatModelCatalog: [],
     chatModelCatalogError: null,
+    modelAuthStatusRequestVersion: 0,
     modelAuthStatusResult: null,
     modelAuthStatusError: null,
     sessionsResult: null,

--- a/ui/src/pages/chat/chat-state-refresh.ts
+++ b/ui/src/pages/chat/chat-state-refresh.ts
@@ -91,10 +91,15 @@ export function applySelectedChatAgent(
     return;
   }
   retireChatModelSelectionOwnership(host);
+  host.assistantIdentityRequestVersion += 1;
   host.assistantAgentId = selectedAgentId;
-  // Global chats retain their session key across agent selection. Replace the binding now;
-  // its old agent fence correctly rejects later invalidations and cannot initiate recovery.
+  host.modelAuthStatusResult = null;
+  host.modelAuthStatusError = null;
+  // Global chats retain their session key across agent selection. Replace agent-owned
+  // bindings now so their old fences reject later publications.
   void refreshChatMetadata(host);
+  void refreshChatModelAuthStatus(host).finally(() => host.requestUpdate?.());
+  void host.loadAssistantIdentity();
   host.requestUpdate?.();
 }
 
@@ -189,18 +194,26 @@ export async function refreshChatModelAuthStatus(host: ChatPageHost, opts?: { re
   }
   const client = host.client;
   const connectionEpoch = host.connectionEpoch;
+  const agentId = resolveChatAgentId(host);
+  const requestVersion = ++host.modelAuthStatusRequestVersion;
+  const ownsRequest = () =>
+    host.client === client &&
+    host.connected &&
+    host.connectionEpoch === connectionEpoch &&
+    host.modelAuthStatusRequestVersion === requestVersion &&
+    resolveChatAgentId(host) === agentId;
   try {
     const result = await loadModelAuthStatus(client, {
       ...opts,
-      agentId: resolveChatAgentId(host),
+      agentId,
     });
-    if (host.client !== client || !host.connected || host.connectionEpoch !== connectionEpoch) {
+    if (!ownsRequest()) {
       return;
     }
     host.modelAuthStatusResult = result;
     host.modelAuthStatusError = null;
   } catch (err) {
-    if (host.client !== client || !host.connected || host.connectionEpoch !== connectionEpoch) {
+    if (!ownsRequest()) {
       return;
     }
     host.modelAuthStatusResult = { ts: 0, providers: [] };

--- a/ui/src/pages/chat/chat-state-refresh.ts
+++ b/ui/src/pages/chat/chat-state-refresh.ts
@@ -14,6 +14,7 @@ import { isSessionRunActive } from "../../lib/session-run-state.ts";
 import {
   areUiSessionKeysEquivalent,
   isUiSelectedGlobalSessionKey,
+  parseAgentSessionKey,
 } from "../../lib/sessions/session-key.ts";
 import { refreshChatAvatar, resolveAgentIdForSession } from "./chat-avatar.ts";
 import { applyRemoteSlashCommandsResult, refreshSlashCommands } from "./chat-commands.ts";
@@ -86,13 +87,33 @@ export function applySelectedChatAgent(
   if (
     !host ||
     !isUiSelectedGlobalSessionKey(host, host.sessionKey) ||
+    parseAgentSessionKey(host.sessionKey)?.agentId ||
     (host.assistantAgentId ?? null) === selectedAgentId
   ) {
+    return;
+  }
+  applyChatAgentOwnerTransition(host, selectedAgentId);
+}
+
+export function applyChatAgentOwnerTransition(
+  host: ChatPageHost,
+  selectedAgentId: string | null,
+): void {
+  if ((host.assistantAgentId ?? null) === selectedAgentId) {
     return;
   }
   retireChatModelSelectionOwnership(host);
   host.assistantIdentityRequestVersion += 1;
   host.assistantAgentId = selectedAgentId;
+  host.assistantName = "";
+  host.assistantAvatar = null;
+  host.assistantAvatarSource = null;
+  host.assistantAvatarStatus = null;
+  host.assistantAvatarReason = null;
+  host.chatAvatarUrl = null;
+  host.chatAvatarSource = null;
+  host.chatAvatarStatus = null;
+  host.chatAvatarReason = null;
   host.modelAuthStatusResult = null;
   host.modelAuthStatusError = null;
   // Global chats retain their session key across agent selection. Replace agent-owned

--- a/ui/src/pages/chat/chat-state.test.ts
+++ b/ui/src/pages/chat/chat-state.test.ts
@@ -20,6 +20,7 @@ import { handlePageGatewayEvent } from "./chat-state-events.ts";
 import type { ChatPageHost } from "./chat-state-host.ts";
 import { createPageState } from "./chat-state-page.ts";
 import {
+  applySelectedChatAgent,
   refreshChatMetadata,
   refreshChatModelCatalogOnDemand,
   refreshChatModelAuthStatus,
@@ -3474,10 +3475,12 @@ describe("resolveChatAvatarUrl", () => {
 describe("loadPageAssistantIdentity", () => {
   it("memoizes identity by agent while fetching a cross-agent switch", async () => {
     const now = vi.spyOn(Date, "now").mockReturnValue(1_000);
-    const request = vi.fn(async (_method: string, params?: { agentId?: string }) => ({
-      name: params?.agentId === "other" ? "Other Agent" : "Main Agent",
-      agentId: params?.agentId ?? "main",
-    }));
+    const request = vi.fn(
+      async (_method: string, params?: { agentId?: string }): Promise<unknown> => ({
+        name: params?.agentId === "other" ? "Other Agent" : "Main Agent",
+        agentId: params?.agentId ?? "main",
+      }),
+    );
     const client = { request } as unknown as GatewayBrowserClient;
     const context = {
       agents: { state: { agentsList: null }, ensureList: vi.fn(async () => null) },
@@ -3527,6 +3530,43 @@ describe("loadPageAssistantIdentity", () => {
     await state.loadAssistantIdentity();
     expect(request).toHaveBeenCalledTimes(3);
     expect(request).toHaveBeenLastCalledWith("agent.identity.get", { agentId: "main" });
+
+    const staleIdentity = createDeferred<{ name: string; agentId: string }>();
+    assistantIdentity.invalidateAssistantIdentityCache(client);
+    let holdMainIdentity = true;
+    request.mockImplementation((method: string, params?: { agentId?: string }) => {
+      if (method === "chat.metadata") {
+        return Promise.resolve({ commands: [], models: [] });
+      }
+      if (method === "models.authStatus") {
+        return Promise.resolve({ ts: 1, providers: [] });
+      }
+      if (params?.agentId === "main" && holdMainIdentity) {
+        holdMainIdentity = false;
+        return staleIdentity.promise;
+      }
+      return Promise.resolve({
+        name: params?.agentId === "work" ? "Work Agent" : "Main Agent",
+        agentId: params?.agentId ?? "main",
+      });
+    });
+    state.agentsList = {
+      agents: [{ id: "main" }, { id: "work" }],
+      defaultId: "main",
+      mainKey: "main",
+      scope: "global",
+    };
+    state.sessionKey = "global";
+    state.assistantAgentId = "main";
+
+    const pendingMainIdentity = state.loadAssistantIdentity();
+    applySelectedChatAgent(state, "work");
+    staleIdentity.resolve({ name: "Stale Main Agent", agentId: "main" });
+    await pendingMainIdentity;
+
+    await vi.waitFor(() => expect(state.assistantName).toBe("Work Agent"));
+    expect(state.assistantAgentId).toBe("work");
+    expect(request).toHaveBeenCalledWith("agent.identity.get", { agentId: "work" });
   });
 });
 
@@ -3881,22 +3921,89 @@ describe("refreshChatMetadata", () => {
 });
 
 describe("refreshChatModelAuthStatus", () => {
-  it("scopes auth status to the selected session agent", async () => {
-    const request = vi.fn(async () => ({ ts: 1, providers: [] }));
+  it("scopes auth status to the fixed session agent", async () => {
+    const fixedStatus = { ts: 1, providers: [] };
+    const request = vi.fn(async () => fixedStatus);
     const state = {
       client: { request },
       connected: true,
       connectionEpoch: 1,
       sessionKey: "agent:work:dashboard:current",
       assistantAgentId: "main",
+      modelAuthStatusRequestVersion: 0,
       modelAuthStatusResult: null,
       modelAuthStatusError: null,
     } as unknown as ChatPageHost;
 
     await refreshChatModelAuthStatus(state);
+    applySelectedChatAgent(state, "research");
 
     expect(request).toHaveBeenCalledWith("models.authStatus", { agentId: "work" });
+    expect(request).toHaveBeenCalledOnce();
+    expect(state.assistantAgentId).toBe("main");
+    expect(state.modelAuthStatusResult).toBe(fixedStatus);
   });
+
+  it.each(["success", "failure"] as const)(
+    "rebinds selected-global auth and rejects the superseded Main %s",
+    async (outcome) => {
+      const mainResponse = createDeferred<{ ts: number; providers: never[] }>();
+      const workResponse = createDeferred<{ ts: number; providers: never[] }>();
+      const request = vi.fn((method: string, params?: { agentId?: string }) => {
+        if (method === "chat.metadata") {
+          return Promise.resolve({ commands: [], models: [] });
+        }
+        return (params?.agentId === "work" ? workResponse : mainResponse).promise;
+      });
+      const staleMainStatus = { ts: 1, providers: [] };
+      const workStatus = { ts: 2, providers: [] };
+      const state = {
+        client: { request },
+        connected: true,
+        connectionEpoch: 1,
+        sessionKey: "global",
+        assistantAgentId: "main",
+        assistantIdentityRequestVersion: 0,
+        modelAuthStatusRequestVersion: 0,
+        modelAuthStatusResult: staleMainStatus,
+        modelAuthStatusError: "stale Main error",
+        loadAssistantIdentity: vi.fn(async () => undefined),
+        requestUpdate: vi.fn(),
+        chatModelSwitchPromises: {},
+        chatModelCatalog: [],
+        chatModelCatalogError: null,
+        chatModelsLoading: false,
+        sessions: {
+          state: { modelOverrides: {} },
+          retireModelOverride: vi.fn(),
+        },
+      } as unknown as ChatPageHost;
+
+      const mainRefresh = refreshChatModelAuthStatus(state);
+      applySelectedChatAgent(state, "work");
+
+      expect(state.assistantAgentId).toBe("work");
+      expect(state.modelAuthStatusResult).toBeNull();
+      expect(state.modelAuthStatusError).toBeNull();
+      expect(request.mock.calls.filter(([method]) => method === "models.authStatus")).toEqual([
+        ["models.authStatus", { agentId: "main" }],
+        ["models.authStatus", { agentId: "work" }],
+      ]);
+
+      workResponse.resolve(workStatus);
+      await vi.waitFor(() => expect(state.modelAuthStatusResult).toBe(workStatus));
+
+      if (outcome === "success") {
+        mainResponse.resolve({ ts: 3, providers: [] });
+      } else {
+        mainResponse.reject(new Error("stale Main auth status"));
+      }
+      await mainRefresh;
+
+      expect(state.modelAuthStatusResult).toBe(workStatus);
+      expect(state.modelAuthStatusError).toBeNull();
+    },
+  );
 
   it.each(["success", "failure"] as const)(
     "ignores a stale auth status %s after reconnecting the same client",
@@ -3913,6 +4020,7 @@ describe("refreshChatModelAuthStatus", () => {
         client: { request },
         connected: true,
         connectionEpoch: 1,
+        modelAuthStatusRequestVersion: 0,
         modelAuthStatusResult: currentStatus,
         modelAuthStatusError: null,
       } as unknown as ChatPageHost;


### PR DESCRIPTION
<!--
Optional linked context:
Add a visible `Closes #<issue-number>` or `Related: #<issue-number>` line
below this comment.

Required PR title:
type: user-facing description
Use a parenthesized scope only when it adds clarity:
fix(auth): login redirect loops when session cookie is expired

Types: feat, fix, improve, refactor, docs, chore.
For fixes, describe the user-visible symptom and trigger:
fix: task list fails to load when user has no environments
Avoid implementation details such as:
fix: add null check to task query
-->

Fixes #129215

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where users switching agents in a global Control UI chat could see the previous agent's account, plan, quota, identity, or authentication warning when an earlier request completed late.

## Why This Change Was Made

Auth and identity results are now bound to the selected agent and request generation. Agent changes clear prior presentation immediately, start replacement loads, and reject stale completions while preserving fixed-session routing, reconnect fencing, and non-auth sidebar attention.

## User Impact

The selected agent's chat and sidebar now show only that agent's authentication and quota state, including during delayed responses and routine Gateway presence updates.

## Evidence

### Before

Delayed Main responses overwrite the Work view with Main identity and quota data.

![Stale Main account and quota shown after selecting Work](https://github.com/user-attachments/assets/c0a99940-7f5a-43c7-bdeb-fad2a0a3b7f2)

### After

Work remains selected and only Work account, plan, provider, and quota data appear.

![Selected Work account and quota remain correctly bound](https://github.com/user-attachments/assets/d34a7d06-2255-4bb9-9e40-0dbbc08bdaa9)

### Recording

The recording shows the Main-to-Work switch, zero-row loading state, delayed Main settlement being ignored, and the final Work result.

https://github.com/user-attachments/assets/ccc56508-6d11-4f51-b2da-4df72839e5a7

Exact candidate: `074347e2bead6c633b62f243267add778ea452b5`

Blacksmith Testbox:

- `pnpm test ui/src/pages/chat/chat-state.test.ts ui/src/e2e/chat-quota-pill-93041.e2e.test.ts`: 105 chat-state tests and 5 quota E2E tests passed.
- `pnpm test ui/src/components/sidebar-attention.test.ts`: 35 tests passed.
- `pnpm test ui/src/pages/chat/chat-pane-lifecycle.test.ts`: 29 tests passed.
- `pnpm check:changed`: UI/core changed lanes passed formatting, guards, typechecks, and lint.
- Run: https://github.com/openclaw/openclaw/actions/runs/33276465095

The regression fails on the frozen base and passes on the exact candidate. Test coverage was audited rather than duplicated: one obsolete sidebar case was absorbed into the stronger ownership matrix, six existing declarations were strengthened, and two runnable chat cases were added for stale success and failure.
