### PR TITLE
fix(usage): preserve MiniMax reset alias order

### DIFF
--- a/src/infra/provider-usage.fetch.minimax.test.ts
+++ b/src/infra/provider-usage.fetch.minimax.test.ts
@@ -235,6 +235,36 @@ describe("fetchMinimaxUsage", () => {
       },
     },
     {
+      name: "skips an invalid early reset alias in a nested usage record",
+      payload: {
+        data: {
+          nested: [
+            {
+              usage_ratio: 0.4,
+              reset_at: "not-a-date",
+              expires_at: "2026-09-01T00:00:00Z",
+            },
+          ],
+        },
+      },
+      expected: {
+        windows: [{ label: "5h", usedPercent: 40, resetAt: 1_788_220_800_000 }],
+      },
+    },
+    {
+      name: "preserves reset alias order across numeric and date values",
+      payload: {
+        data: {
+          reset_at: 1_800_000_000,
+          resetTime: "2030-01-01T00:00:00Z",
+          nested: [{ usage_ratio: 0.4 }],
+        },
+      },
+      expected: {
+        windows: [{ label: "5h", usedPercent: 40, resetAt: 1_800_000_000_000 }],
+      },
+    },
+    {
       name: "drops Date-invalid reset timestamps",
       payload: {
         data: {

--- a/src/infra/provider-usage.fetch.minimax.ts
+++ b/src/infra/provider-usage.fetch.minimax.ts
@@ -590,11 +590,7 @@ export async function fetchMinimaxUsage(
       };
     }
 
-    const resetAt =
-      parseEpoch(pickString(usageRecord, RESET_KEYS)) ??
-      parseEpoch(pickNumber(usageRecord, RESET_KEYS)) ??
-      parseEpoch(pickString(payload, RESET_KEYS)) ??
-      parseEpoch(pickNumber(payload, RESET_KEYS));
+    const resetAt = pickEpoch(usageRecord, RESET_KEYS) ?? pickEpoch(payload, RESET_KEYS);
     windows = [
       {
         label: deriveWindowLabel(usageRecord),


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where MiniMax usage responses containing multiple reset-time aliases could lose a valid reset timestamp or select a lower-priority alias when the aliases used different value types.

## Why This Change Was Made

MiniMax reset timestamps now use the existing epoch picker, which scans the declared alias list once in provider order. Nested usage data still takes precedence over the outer payload, while an invalid early alias no longer prevents a valid later alias from being used.

## User Impact

Operators see MiniMax quota reset times that follow the provider alias priority and recover correctly when an earlier alias contains an invalid value.

## Evidence

- Pre-fix reproduction:
  - invalid `reset_at` followed by valid `expires_at`: `resetAt` was missing
  - numeric `reset_at` followed by date `resetTime`: the lower-priority date was selected
- Post-fix reproduction:
  - invalid early alias resolves to the valid later timestamp (`1788220800000`)
  - numeric first alias keeps priority (`1800000000000`)
- `node scripts/run-vitest.mjs src/infra/provider-usage.fetch.minimax.test.ts` — 27 tests passed
- focused formatting and oxlint passed
- `pnpm tsgo:core` passed
- autoreview: clean, no actionable findings
- production delta: `+1/-5` (net `-4`); tests: `+30`
- live `status --usage` smoke could not reach provider execution because the linked local install failed first on an unrelated Anthropic contract export mismatch
- `pnpm tsgo:core:test` reached an unrelated linked-install error: missing `pako` declarations in `ui/vite.config.ts`
