### PR TITLE
fix(auto-reply): preserve code indentation before inference

### DIFF
--- a/docs/tools/slash-commands.md
+++ b/docs/tools/slash-commands.md
@@ -38,6 +38,10 @@ command handling is enabled for the surface.
 <AccordionGroup>
   <Accordion title="Directive behavior details">
     - Directives are stripped from the message before the model sees it.
+      Removal leaves the remaining text's spacing and line endings intact,
+      including code indentation. Only the recognized directive, its arguments,
+      and an adjacent separator (or its own line ending when alone on a line)
+      are removed. Text with no recognized directive is unchanged.
     - In **directive-only** messages (the message is only directives), they
       persist to the session and reply with an acknowledgement.
     - In **normal chat** messages with other text, they act as inline hints and

--- a/src/auto-reply/model.ts
+++ b/src/auto-reply/model.ts
@@ -3,6 +3,7 @@ import { normalizeStringEntries } from "@openclaw/normalization-core/string-norm
 import { splitTrailingAuthProfile } from "../agents/model-ref-profile.js";
 import type { ModelSelectionScope } from "../config/types.agent-defaults.js";
 import { escapeRegExp } from "../utils.js";
+import { removeDirectiveSpan } from "./reply/directive-parsing.js";
 
 export type { ModelSelectionScope } from "../config/types.agent-defaults.js";
 
@@ -14,11 +15,11 @@ const MODEL_RUNTIME_OPTION_PATTERN = String.raw`(?:--runtime|runtime=|harness=)\
 // Captures 2/3 are runtime-first; 4/5 are scope-first so duplicates stay unconsumed.
 const MODEL_TRAILING_OPTIONS_PATTERN = String.raw`(?:(?:\s+(?:--runtime|runtime=|harness=)\s*((?!${MODEL_OPTION_PATTERN})${MODEL_RUNTIME_VALUE_PATTERN}))(\s+${MODEL_SCOPE_OPTION_PATTERN})?|(\s+${MODEL_SCOPE_OPTION_PATTERN})(?:\s+(?:--runtime|runtime=|harness=)\s*((?!${MODEL_OPTION_PATTERN})${MODEL_RUNTIME_VALUE_PATTERN}))?)?`;
 const MODEL_OPTIONS_ONLY_DIRECTIVE_PATTERN = new RegExp(
-  String.raw`(?:^|\s)\/model(?=$|\s|:)\s*:?\s*(?:${MODEL_RUNTIME_OPTION_PATTERN}(\s+${MODEL_SCOPE_OPTION_PATTERN})?|(${MODEL_SCOPE_OPTION_PATTERN})(?:\s+${MODEL_RUNTIME_OPTION_PATTERN})?)`,
+  String.raw`(?<!\S)\/model(?=$|\s|:)\s*:?\s*(?:${MODEL_RUNTIME_OPTION_PATTERN}(\s+${MODEL_SCOPE_OPTION_PATTERN})?|(${MODEL_SCOPE_OPTION_PATTERN})(?:\s+${MODEL_RUNTIME_OPTION_PATTERN})?)`,
   "i",
 );
 const MODEL_DIRECTIVE_PATTERN = new RegExp(
-  String.raw`(?:^|\s)\/model(?=$|\s|:)\s*:?\s*((?!${MODEL_OPTION_PATTERN})${MODEL_REF_PATTERN})?${MODEL_TRAILING_OPTIONS_PATTERN}`,
+  String.raw`(?<!\S)\/model(?=$|\s|:)(?:\s*:)?(?:\s*((?!${MODEL_OPTION_PATTERN})${MODEL_REF_PATTERN}))?${MODEL_TRAILING_OPTIONS_PATTERN}`,
   "i",
 );
 
@@ -72,19 +73,17 @@ export function extractModelDirective(
     return { cleaned: "", scopeConflict: false, hasDirective: false };
   }
 
-  const modelOptionsOnlyMatch = body.match(MODEL_OPTIONS_ONLY_DIRECTIVE_PATTERN);
-  const modelMatch = modelOptionsOnlyMatch ?? body.match(MODEL_DIRECTIVE_PATTERN);
+  const modelOptionsOnlyMatch = MODEL_OPTIONS_ONLY_DIRECTIVE_PATTERN.exec(body);
+  const modelMatch = modelOptionsOnlyMatch ?? MODEL_DIRECTIVE_PATTERN.exec(body);
 
   const aliases = normalizeStringEntries(options?.aliases);
   const aliasMatch =
     modelMatch || aliases.length === 0
       ? null
-      : body.match(
-          new RegExp(
-            String.raw`(?:^|\s)\/(${aliases.map(escapeRegExp).join("|")})(?=$|\s|:)(?:\s*:)?${MODEL_TRAILING_OPTIONS_PATTERN}`,
-            "i",
-          ),
-        );
+      : new RegExp(
+          String.raw`(?<!\S)\/(${aliases.map(escapeRegExp).join("|")})(?=$|\s|:)(?:\s*:)?${MODEL_TRAILING_OPTIONS_PATTERN}`,
+          "i",
+        ).exec(body);
 
   const match = modelMatch ?? aliasMatch;
   const parsed = modelOptionsOnlyMatch
@@ -104,7 +103,9 @@ export function extractModelDirective(
     rawProfile = split.profile;
   }
 
-  const cleaned = match ? body.replace(match[0], " ").replace(/\s+/g, " ").trim() : body.trim();
+  const cleaned = match
+    ? removeDirectiveSpan(body, match.index, match.index + match[0].length)
+    : body;
 
   return {
     cleaned,

--- a/src/auto-reply/reply.directive.parse.test.ts
+++ b/src/auto-reply/reply.directive.parse.test.ts
@@ -15,6 +15,78 @@ import { extractQueueDirective } from "./reply/queue/directive.js";
 import { extractReplyToTag } from "./reply/reply-tags.js";
 
 describe("directive parsing", () => {
+  it.each([
+    "  ordinary\t text\r\n    if ready:\r\n        run('a  b')  \r\n",
+    "\n    /thinkingish  /models\t /unknown\r\n",
+    " \t\r\n",
+  ])("preserves all bytes when no directive is recognized: %j", (body) => {
+    expect(parseInlineSessionDirectives(body).cleaned).toBe(body);
+  });
+
+  it.each([
+    "/think high",
+    "/verbose on",
+    "/trace on",
+    "/fast auto",
+    "/reasoning off",
+    "/elevated ask",
+    "/exec host=auto security=deny",
+    "/queue collect debounce:2s cap:5",
+    "/model example/model -s",
+    "/sample --runtime openclaw -s",
+    "/status:",
+  ])("preserves code and significant spacing around %s", (directive) => {
+    const code =
+      "\r\n```python\r\n    if ready:\r\n        run('a  b')\r\n\t\tfinish()  \r\n```\r\n";
+    const parsed = parseInlineSessionDirectives(`  Keep\t spacing ${directive} here  too${code}`, {
+      modelAliases: ["sample"],
+    });
+    expect(parsed.cleaned).toBe(`  Keep\t spacing here  too${code}`);
+  });
+
+  it.each([
+    "/think high",
+    "/verbose",
+    "/exec host=auto",
+    "/queue collect",
+    "/model sample -s",
+    "/sample",
+  ])("does not consume indentation after the last argument of %s", (directive) => {
+    const code = "    if ready:\r\n        run()  \r\n";
+    expect(
+      parseInlineSessionDirectives(`${directive}\r\n${code}`, {
+        modelAliases: ["sample"],
+      }).cleaned,
+    ).toBe(code);
+  });
+
+  it.each([
+    ["/exec\n host=auto\n security=deny\r\n", { execHost: "auto", execSecurity: "deny" }],
+    ["/queue\n collect\n cap:5\r\n", { queueMode: "collect", cap: 5 }],
+    ["/think\n high\r\n", { thinkLevel: "high" }],
+    [
+      "/model\n example/model\n -s\r\n",
+      { rawModelDirective: "example/model", modelScope: "session" },
+    ],
+  ])(
+    "keeps cross-line argument grammar without consuming the following code: %j",
+    (directive, fields) => {
+      const code = "    print('a  b')\r\n";
+      const parsed = parseInlineSessionDirectives(`${directive}${code}`);
+      expect(parsed).toMatchObject(fields);
+      expect(parsed.cleaned).toBe(code);
+    },
+  );
+
+  it("keeps first-match precedence while removing different directive kinds", () => {
+    const parsed = parseInlineSessionDirectives(
+      "/think high /think low /verbose on\r\n    code  here",
+    );
+    expect(parsed.thinkLevel).toBe("high");
+    expect(parsed.verboseLevel).toBe("on");
+    expect(parsed.cleaned).toBe("/think low\r\n    code  here");
+  });
+
   it("ignores verbose directive inside URL", () => {
     const body = "https://x.com/verioussmith/status/1997066835133669687";
     const res = extractVerboseDirective(body);

--- a/src/auto-reply/reply/directive-handling.parse.ts
+++ b/src/auto-reply/reply/directive-handling.parse.ts
@@ -174,7 +174,7 @@ export function parseInlineSessionDirectives(
   const queue = parseScopedDirective("queue", extractQueueDirective);
   // Later directives see text cleaned by earlier directives; preserve that ordering.
   return {
-    cleaned: hasAnyDirective ? cleaned : body.trim(),
+    cleaned,
     ...(nativeCommand && hasAnyDirective
       ? {
           nativeCommand: {

--- a/src/auto-reply/reply/directive-parsing.ts
+++ b/src/auto-reply/reply/directive-parsing.ts
@@ -1,20 +1,34 @@
-/** Low-level token scanning helpers for inline directive parsers. */
-export function skipDirectiveArgPrefix(raw: string): number {
-  let i = 0;
-  const len = raw.length;
-  while (i < len && /\s/.test(raw.charAt(i))) {
-    i += 1;
+/** Remove a recognized span without rewriting unrelated prompt bytes. */
+export function removeDirectiveSpan(body: string, start: number, end: number): string {
+  let removalStart = start;
+  let removalEnd = end;
+  const lineStart = body.lastIndexOf("\n", start - 1) + 1;
+  const beforeOnLine = body.slice(lineStart, start);
+  const lineEnding = /^[ \t]*(?:\r?\n|$)/.exec(body.slice(end));
+  // A directive-only line owns its line ending, never the next line's indentation.
+  // Inline directives own at most one separator; the remaining spacing is user text.
+  if (/^[ \t]*$/.test(beforeOnLine) && lineEnding) {
+    removalStart = lineStart;
+    removalEnd += lineEnding[0].length;
+  } else if (/[ \t]/.test(body.charAt(end))) {
+    removalEnd += 1;
+  } else if (
+    (end === body.length || /[\r\n]/.test(body.charAt(end))) &&
+    /\S/.test(beforeOnLine) &&
+    /[ \t]/.test(body.charAt(start - 1))
+  ) {
+    removalStart -= 1;
   }
-  if (raw[i] === ":") {
-    i += 1;
-    while (i < len && /\s/.test(raw.charAt(i))) {
-      i += 1;
-    }
-  }
-  return i;
+  const cleaned = body.slice(0, removalStart) + body.slice(removalEnd);
+  return cleaned.trim() ? cleaned : "";
 }
 
-/** Reads the next non-whitespace directive token and returns the next scan index. */
+/** Only a colon commits an argument prefix; whitespace belongs to the next accepted token. */
+export function skipDirectiveArgPrefix(raw: string): number {
+  return /^\s*:/.exec(raw)?.[0].length ?? 0;
+}
+
+/** Stops at the token end; following whitespace is consumed only with another accepted token. */
 export function takeDirectiveToken(
   raw: string,
   startIndex: number,
@@ -31,12 +45,6 @@ export function takeDirectiveToken(
   while (i < len && !/\s/.test(raw.charAt(i))) {
     i += 1;
   }
-  if (start === i) {
-    return { token: null, nextIndex: i };
-  }
   const token = raw.slice(start, i);
-  while (i < len && /\s/.test(raw.charAt(i))) {
-    i += 1;
-  }
   return { token, nextIndex: i };
 }

--- a/src/auto-reply/reply/directives.ts
+++ b/src/auto-reply/reply/directives.ts
@@ -13,6 +13,7 @@ import {
   type ThinkLevel,
   type VerboseLevel,
 } from "../thinking.js";
+import { removeDirectiveSpan, skipDirectiveArgPrefix } from "./directive-parsing.js";
 
 type ExtractedLevel<T> = {
   cleaned: string;
@@ -25,12 +26,10 @@ type LevelDirectiveParseOptions = {
   strict?: boolean;
 };
 
-const compileDirectivePattern = (names: readonly string[], suffix = ""): RegExp => {
+const compileDirectivePattern = (names: readonly string[]): RegExp => {
   const namePattern = names.map(escapeRegExp).join("|");
-  return new RegExp(`(?:^|\\s)\\/(?:${namePattern})(?=$|\\s|:)${suffix}`, "i");
+  return new RegExp(`(?<!\\S)\\/(?:${namePattern})(?=$|\\s|:)`, "i");
 };
-
-const STATUS_DIRECTIVE_PATTERN = compileDirectivePattern(["status"], `(?:\\s*:\\s*)?`);
 
 const matchLevelDirective = (
   body: string,
@@ -43,15 +42,11 @@ const matchLevelDirective = (
     return null;
   }
   const start = match.index;
-  let i = match.index + match[0].length;
+  const directiveEnd = match.index + match[0].length;
+  const prefixEnd = directiveEnd + skipDirectiveArgPrefix(body.slice(directiveEnd));
+  let i = prefixEnd;
   while (i < body.length && /\s/.test(body.charAt(i))) {
     i += 1;
-  }
-  if (body[i] === ":") {
-    i += 1;
-    while (i < body.length && /\s/.test(body.charAt(i))) {
-      i += 1;
-    }
   }
   const argStart = i;
   while (
@@ -67,7 +62,7 @@ const matchLevelDirective = (
   ) {
     return { start, end: i, rawLevel: candidate };
   }
-  return { start, end: argStart };
+  return { start, end: prefixEnd };
 };
 
 const extractLevelDirective = <T>(
@@ -78,13 +73,11 @@ const extractLevelDirective = <T>(
 ): ExtractedLevel<T> => {
   const match = matchLevelDirective(body, pattern, normalize, options);
   if (!match) {
-    return { cleaned: body.trim(), hasDirective: false };
+    return { cleaned: body, hasDirective: false };
   }
   const rawLevel = match.rawLevel;
   const level = normalize(rawLevel);
-  const cleaned = `${body.slice(0, match.start)} ${body.slice(match.end)}`
-    .replace(/\s+/g, " ")
-    .trim();
+  const cleaned = removeDirectiveSpan(body, match.start, match.end);
   return {
     cleaned,
     level,
@@ -148,19 +141,6 @@ export const extractReasoningDirective = createLevelDirectiveExtractor(
   normalizeReasoningLevel,
 );
 
-export function extractStatusDirective(body?: string): {
-  cleaned: string;
-  hasDirective: boolean;
-} {
-  if (!body) {
-    return { cleaned: "", hasDirective: false };
-  }
-  const match = body.match(STATUS_DIRECTIVE_PATTERN);
-  return {
-    cleaned: match ? body.replace(match[0], " ").replace(/\s+/g, " ").trim() : body.trim(),
-    hasDirective: Boolean(match),
-  };
-}
-
 export type { ElevatedLevel, ReasoningLevel, ThinkLevel, TraceLevel, VerboseLevel };
 export { extractExecDirective } from "./exec/directive.js";
+export { extractStatusDirective } from "./reply-inline.js";

--- a/src/auto-reply/reply/exec/directive.ts
+++ b/src/auto-reply/reply/exec/directive.ts
@@ -6,7 +6,11 @@ import {
   type ExecTarget,
   normalizeExecTarget,
 } from "../../../infra/exec-approvals.js";
-import { skipDirectiveArgPrefix, takeDirectiveToken } from "../directive-parsing.js";
+import {
+  removeDirectiveSpan,
+  skipDirectiveArgPrefix,
+  takeDirectiveToken,
+} from "../directive-parsing.js";
 
 /** Parsed `/exec` directive state used to override execution policy for one turn. */
 type ExecDirectiveParse = {
@@ -176,11 +180,11 @@ export function extractExecDirective(body?: string): ExecDirectiveParse {
       invalidNode: false,
     };
   }
-  const re = /(?:^|\s)\/exec(?=$|\s|:)/i;
+  const re = /(?<!\S)\/exec(?=$|\s|:)/i;
   const match = re.exec(body);
   if (!match) {
     return {
-      cleaned: body.trim(),
+      cleaned: body,
       hasDirective: false,
       hasExecOptions: false,
       invalidHost: false,
@@ -189,12 +193,11 @@ export function extractExecDirective(body?: string): ExecDirectiveParse {
       invalidNode: false,
     };
   }
-  const start = match.index + match[0].indexOf("/exec");
+  const start = match.index;
   const argsStart = start + "/exec".length;
   const parsed = parseExecDirectiveArgs(body.slice(argsStart));
   // Remove only consumed key/value options so remaining text still reaches the agent.
-  const cleanedRaw = `${body.slice(0, start)} ${body.slice(argsStart + parsed.consumed)}`;
-  const cleaned = cleanedRaw.replace(/\s+/g, " ").trim();
+  const cleaned = removeDirectiveSpan(body, start, argsStart + parsed.consumed);
   return {
     cleaned,
     hasDirective: true,

--- a/src/auto-reply/reply/get-reply-run-admission.ts
+++ b/src/auto-reply/reply/get-reply-run-admission.ts
@@ -24,6 +24,7 @@ import {
   normalizeThinkLevel,
   resolveSupportedThinkingLevel,
 } from "../thinking.js";
+import { removeDirectiveSpan } from "./directive-parsing.js";
 import type { PreparedReplyRunContext } from "./get-reply-run-context.js";
 import {
   loadAgentRunnerRuntime,
@@ -102,11 +103,11 @@ export async function prepareReplyRunAdmission(context: PreparedReplyRunContext)
   let { resolvedThinkLevel } = params;
 
   // Extract first-token think hint from the user body BEFORE prepending system events.
-  // If done after, the System: prefix becomes parts[0] and silently shadows any
+  // If done after, the System: prefix becomes the first token and silently shadows any
   // low|medium|high shorthand the user typed.
   if (!resolvedThinkLevel && prefixedBodyBase) {
-    const parts = prefixedBodyBase.split(/\s+/);
-    const maybeLevel = normalizeThinkLevel(parts[0]);
+    const firstToken = prefixedBodyBase.split(/\s+/, 1)[0] ?? "";
+    const maybeLevel = normalizeThinkLevel(firstToken);
     const thinkingCatalog = maybeLevel
       ? await traceRunPhase("reply.resolve_thinking_catalog_for_hint", () =>
           modelState.resolveThinkingCatalog({ provider, model }),
@@ -123,7 +124,7 @@ export async function prepareReplyRunAdmission(context: PreparedReplyRunContext)
       })
     ) {
       resolvedThinkLevel = maybeLevel;
-      prefixedBodyBase = parts.slice(1).join(" ").trim();
+      prefixedBodyBase = removeDirectiveSpan(prefixedBodyBase, 0, firstToken.length);
     }
   }
   const prefixedBodyCore = prefixedBodyBase;

--- a/src/auto-reply/reply/get-reply-run-context.ts
+++ b/src/auto-reply/reply/get-reply-run-context.ts
@@ -33,7 +33,6 @@ import {
   hasReplyTargetContext,
   resolvePromptSessionContextForSystemEvent,
   resolvePromptSilentReplyConversationType,
-  stripPromptThinkingDirectives,
 } from "./get-reply-run-helpers.js";
 import { resolvePromptSourceReplyMode } from "./get-reply-run-source-mode.js";
 import type { RunPreparedReplyParams } from "./get-reply-run.types.js";
@@ -351,11 +350,8 @@ export async function prepareReplyRunContext(params: RunPreparedReplyParams) {
     shouldApplyStartupContext({ cfg, action: startupAction })
       ? await buildSessionStartupContextPrelude({ workspaceDir, cfg })
       : null;
-  const baseBodyFinal = isBareSessionReset
-    ? (bareResetPromptState?.prompt ?? "")
-    : canInterpretCommands
-      ? stripPromptThinkingDirectives(baseBody)
-      : baseBody;
+  // Directive routing already owns stripping and authorization; prepared text is final.
+  const baseBodyFinal = isBareSessionReset ? (bareResetPromptState?.prompt ?? "") : baseBody;
   const hasUserBody =
     baseBodyFinal.trim().length > 0 ||
     softResetTail.length > 0 ||

--- a/src/auto-reply/reply/get-reply-run-helpers.ts
+++ b/src/auto-reply/reply/get-reply-run-helpers.ts
@@ -316,18 +316,6 @@ export function loadSessionUpdatesRuntime() {
   return sessionUpdatesRuntimeLoader.load();
 }
 
-export function stripPromptThinkingDirectives(body: string): string {
-  return body
-    .split("\n")
-    .map((line) =>
-      line
-        .replace(/(^|\s)\/(?:thinking|think|t)(?=$|\s|:)(?:\s*:\s*|\s+)?[A-Za-z-]*/gi, "$1")
-        .replace(/[ \t]{2,}/g, " ")
-        .trimEnd(),
-    )
-    .join("\n");
-}
-
 export function hasInboundHistoryBody(ctx: TemplateContext): boolean {
   return (
     Array.isArray(ctx.InboundHistory) &&

--- a/src/auto-reply/reply/get-reply-run.media-only.test.ts
+++ b/src/auto-reply/reply/get-reply-run.media-only.test.ts
@@ -13,6 +13,7 @@ import { beginSessionWorkAdmission } from "../../sessions/session-lifecycle-admi
 import { normalizeSessionDeliveryState } from "../../utils/delivery-context.shared.js";
 import { hasControlCommand } from "../command-detection.js";
 import { runReplyAgent } from "./agent-runner.runtime.js";
+import { resolveReplyDirectiveRouting } from "./get-reply-directives-routing.js";
 import { prepareReplyRunContext } from "./get-reply-run-context.js";
 import {
   loadAgentRunnerRuntime,
@@ -21,7 +22,7 @@ import {
 } from "./get-reply-run-helpers.js";
 import { runPreparedReply } from "./get-reply-run.js";
 import { buildDirectChatContext, buildGroupChatContext, buildGroupIntro } from "./groups.js";
-import { finalizeInboundContextForSdk } from "./inbound-context.js";
+import { finalizeInboundContext, finalizeInboundContextForSdk } from "./inbound-context.js";
 import {
   buildInboundUserContextPrefix,
   resolveInboundUserContextPromptJoiner,
@@ -1366,6 +1367,59 @@ describe("runPreparedReply media-only handling", () => {
       expect(result).toEqual({ text: "ok" });
       expect(requireRunReplyAgentCall().followupRun.prompt).toBe(body);
       expect(onDeliberateSilentTerminalReply).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each([
+    { name: "ordinary code", directive: "", authorized: true, enabled: true },
+    { name: "authorized directive", directive: "/think high\r\n", authorized: true, enabled: true },
+    {
+      name: "unauthorized directive",
+      directive: "/think high\r\n",
+      authorized: false,
+      enabled: true,
+    },
+    {
+      name: "disabled text commands",
+      directive: "/think high\r\n",
+      authorized: true,
+      enabled: false,
+    },
+  ])(
+    "preserves prompt bytes through routing and preparation: $name",
+    async ({ directive, authorized, enabled }) => {
+      const code =
+        "Run  this:\r\n```python\r\n    if True:\r\n        print('a  b')\r\n\t\t# tabs  stay\r\n```";
+      const body = `${directive}${code}`;
+      const params = baseParams({
+        ctx: createInboundTurn(body, "slack", "direct"),
+        sessionCtx: createSessionTurn(body, "slack", "direct"),
+        isNewSession: false,
+        commandAuthorized: authorized,
+        allowTextCommands: enabled,
+      });
+      params.command = { ...params.command, isAuthorizedSender: authorized };
+      const routed = resolveReplyDirectiveRouting({
+        commandText: body,
+        agentText: body,
+        modelAliases: [],
+        canInterpretTextDirectives: authorized && enabled,
+        isAuthorizedSender: authorized,
+        isGroup: false,
+        wasMentioned: false,
+        ctx: finalizeInboundContext(params.ctx),
+        cfg: params.cfg,
+        agentId: params.agentId,
+        resetTriggered: false,
+      });
+      params.directives = routed.directives;
+      params.sessionCtx.agentText = routed.cleanedBody;
+      await runPreparedReply(params);
+
+      const expected = authorized && enabled ? code : body;
+      const call = requireRunReplyAgentCall();
+      expect(call.commandBody).toBe(expected);
+      expect(call.followupRun.prompt).toBe(expected);
     },
   );
 
@@ -4409,9 +4463,10 @@ describe("runPreparedReply media-only handling", () => {
     // does not shadow the low|medium|high shorthand.
     vi.mocked(drainFormattedSystemEvents).mockResolvedValueOnce("System: [t] Node connected.");
 
+    const code = "Run  this:\r\n    if True:\r\n        print('a  b')";
     await runPrepared({
-      ctx: { Body: "low tell me about cats", RawBody: "low tell me about cats" },
-      sessionCtx: { Body: "low tell me about cats", BodyStripped: "low tell me about cats" },
+      ctx: createInboundBody(`low ${code}`),
+      sessionCtx: createSessionBody(`low ${code}`),
       resolvedThinkLevel: undefined,
     });
 
@@ -4419,7 +4474,7 @@ describe("runPreparedReply media-only handling", () => {
     // Think hint extracted before events arrived — level must be "low", not the model default.
     expect(call.followupRun.run.thinkLevel).toBe("low");
     // The stripped user text (no "low" token) must still appear after the event block.
-    expect(call.commandBody).toContain("tell me about cats");
+    expect(call.commandBody).toBe(`System: [t] Node connected.\n\n${code}`);
     expect(call.commandBody).not.toMatch(/^low\b/);
     // System events are still present in the body.
     expect(call.commandBody).toContain("System: [t] Node connected.");

--- a/src/auto-reply/reply/queue/directive.ts
+++ b/src/auto-reply/reply/queue/directive.ts
@@ -3,7 +3,11 @@ import { parseStrictPositiveInteger } from "@openclaw/normalization-core/number-
 import { normalizeOptionalLowercaseString } from "@openclaw/normalization-core/string-coerce";
 import type { QueueMode } from "../../../../packages/gateway-protocol/src/schema/logs-chat.js";
 import { parseDurationMs } from "../../../cli/parse-duration.js";
-import { skipDirectiveArgPrefix, takeDirectiveToken } from "../directive-parsing.js";
+import {
+  removeDirectiveSpan,
+  skipDirectiveArgPrefix,
+  takeDirectiveToken,
+} from "../directive-parsing.js";
 import { normalizeQueueDropPolicy, normalizeQueueMode } from "./normalize.js";
 import type { QueueDropPolicy } from "./types.js";
 
@@ -151,23 +155,22 @@ export function extractQueueDirective(body?: string): {
       hasOptions: false,
     };
   }
-  const re = /(?:^|\s)\/queue(?=$|\s|:)/i;
+  const re = /(?<!\S)\/queue(?=$|\s|:)/i;
   const match = re.exec(body);
   if (!match) {
     return {
-      cleaned: body.trim(),
+      cleaned: body,
       hasDirective: false,
       queueReset: false,
       hasOptions: false,
     };
   }
-  const start = match.index + match[0].indexOf("/queue");
+  const start = match.index;
   const argsStart = start + "/queue".length;
   const args = body.slice(argsStart);
   const parsed = parseQueueDirectiveArgs(args);
   // Remove only the directive and consumed options; leave the rest as agent input.
-  const cleanedRaw = `${body.slice(0, start)} ${body.slice(argsStart + parsed.consumed)}`;
-  const cleaned = cleanedRaw.replace(/\s+/g, " ").trim();
+  const cleaned = removeDirectiveSpan(body, start, argsStart + parsed.consumed);
   return {
     cleaned,
     queueMode: parsed.queueMode,

--- a/src/auto-reply/reply/reply-inline.test.ts
+++ b/src/auto-reply/reply/reply-inline.test.ts
@@ -21,17 +21,19 @@ describe("stripInlineStatus", () => {
     expect(result.didStrip).toBe(true);
   });
 
-  it("collapses horizontal whitespace but keeps newlines", () => {
-    const result = stripInlineStatus("hello \t  world\n\t indented  line");
-    expect(result.cleaned).toBe("hello world\n indented line");
-    // didStrip is true because whitespace normalization changed the string
-    expect(result.didStrip).toBe(true);
-  });
+  it.each(["hello \t  world\r\n\t indented  line  \r\n", "   ", "\n    code\n"])(
+    "leaves unrecognized text byte-identical: %j",
+    (body) => {
+      expect(stripInlineStatus(body)).toEqual({ cleaned: body, didStrip: false });
+    },
+  );
 
-  it("returns empty string for whitespace-only input", () => {
-    const result = stripInlineStatus("   ");
-    expect(result.cleaned).toBe("");
-    expect(result.didStrip).toBe(false);
+  it.each([
+    ["/status:\r\n    if ready:\r\n        run()  \r\n", "    if ready:\r\n        run()  \r\n"],
+    ["start  here /status and\tthere /STATUS\r\n    code", "start  here and\tthere\r\n    code"],
+    ["before\n\n/status\n\n    after", "before\n\n\n    after"],
+  ])("removes only status spans and their separators: %j", (body, cleaned) => {
+    expect(stripInlineStatus(body)).toEqual({ cleaned, didStrip: true });
   });
 });
 
@@ -47,6 +49,14 @@ describe("extractInlineSimpleCommand", () => {
     expect(result?.command).toBe("/help");
     expect(result?.cleaned).toBe("first line\nsecond line");
   });
+
+  it.each(["/help", "/commands", "/whoami", "/id"])(
+    "preserves code bytes when extracting %s",
+    (command) => {
+      const code = "    if ready:\r\n\t\trun('a  b')  \r\n";
+      expect(extractInlineSimpleCommand(`${command}\r\n${code}`)?.cleaned).toBe(code);
+    },
+  );
 
   it("returns null for empty body", () => {
     expect(extractInlineSimpleCommand("")).toBeNull();

--- a/src/auto-reply/reply/reply-inline.ts
+++ b/src/auto-reply/reply/reply-inline.ts
@@ -3,12 +3,7 @@ import {
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalLowercaseString,
 } from "@openclaw/normalization-core/string-coerce";
-
-const INLINE_HORIZONTAL_WHITESPACE_RE = /[^\S\n]+/g;
-
-function collapseInlineHorizontalWhitespace(value: string): string {
-  return value.replace(INLINE_HORIZONTAL_WHITESPACE_RE, " ");
-}
+import { removeDirectiveSpan } from "./directive-parsing.js";
 
 const INLINE_SIMPLE_COMMAND_ALIASES = new Map<string, string>([
   ["/help", "/help"],
@@ -16,9 +11,9 @@ const INLINE_SIMPLE_COMMAND_ALIASES = new Map<string, string>([
   ["/whoami", "/whoami"],
   ["/id", "/whoami"],
 ]);
-const INLINE_SIMPLE_COMMAND_RE = /(?:^|\s)\/(help|commands|whoami|id)(?=$|\s|:)/i;
+const INLINE_SIMPLE_COMMAND_RE = /(?<!\S)\/(help|commands|whoami|id)(?=$|\s|:)/i;
+const INLINE_STATUS_RE = /(?<!\S)\/status(?=$|\s|:)(?:\s*:)?/i;
 
-const INLINE_STATUS_RE = /(?:^|\s)\/status(?=$|\s|:)(?:\s*:\s*)?/gi;
 export function getStandaloneSlashCommandName(body: string): string | null {
   const match = body.trim().match(/^\/([^\s/:]+)(?::|\s|$)/u);
   return normalizeOptionalLowercaseString(match?.[1]) ?? null;
@@ -40,20 +35,31 @@ export function extractInlineSimpleCommand(body?: string): {
   if (!command) {
     return null;
   }
-  const cleaned = collapseInlineHorizontalWhitespace(body.replace(match[0], " ")).trim();
+  const cleaned = removeDirectiveSpan(body, match.index, match.index + match[0].length);
   return { command, cleaned };
+}
+
+export function extractStatusDirective(body = ""): {
+  cleaned: string;
+  hasDirective: boolean;
+} {
+  const match = INLINE_STATUS_RE.exec(body);
+  return {
+    cleaned: match ? removeDirectiveSpan(body, match.index, match.index + match[0].length) : body,
+    hasDirective: Boolean(match),
+  };
 }
 
 export function stripInlineStatus(body: string): {
   cleaned: string;
   didStrip: boolean;
 } {
-  const trimmed = body.trim();
-  if (!trimmed) {
-    return { cleaned: "", didStrip: false };
+  let cleaned = body;
+  for (;;) {
+    const parsed = extractStatusDirective(cleaned);
+    if (!parsed.hasDirective) {
+      return { cleaned, didStrip: cleaned !== body };
+    }
+    cleaned = parsed.cleaned;
   }
-  // Use [^\S\n]+ instead of \s+ to only collapse horizontal whitespace,
-  // preserving newlines so multi-line messages keep their paragraph structure.
-  const cleaned = collapseInlineHorizontalWhitespace(trimmed.replace(INLINE_STATUS_RE, " ")).trim();
-  return { cleaned, didStrip: cleaned !== trimmed };
 }

--- a/test/e2e/qa-lab/runtime/gateway-rpc-chat.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/gateway-rpc-chat.e2e.test.ts
@@ -1,7 +1,15 @@
 import { randomUUID } from "node:crypto";
 import { setTimeout as sleep } from "node:timers/promises";
+import { expectDefined } from "@openclaw/normalization-core";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { z } from "zod";
 import { createQaLiveLaneGateway } from "../../../../extensions/qa-lab/runtime-api.js";
+import {
+  INTERNAL_RUNTIME_CONTEXT_BEGIN,
+  INTERNAL_RUNTIME_CONTEXT_END,
+  OPENCLAW_NEXT_TURN_RUNTIME_CONTEXT_HEADER,
+  OPENCLAW_RUNTIME_CONTEXT_NOTICE,
+} from "../../../../src/agents/internal-runtime-context.js";
 import { stopQaGatewayFixture } from "../../../helpers/qa-gateway-cleanup.js";
 
 type GatewayChatMessage = {
@@ -27,6 +35,46 @@ const HISTORY_RETRY_TIMEOUT_MS = 10_000;
 const HISTORY_RETRY_DEFAULT_MS = 250;
 const HISTORY_RETRY_MIN_MS = 100;
 const HISTORY_RETRY_MAX_MS = 5_000;
+const requestSnapshotsSchema = z.array(
+  z.object({ cursor: z.number().int(), model: z.string(), raw: z.string() }),
+);
+const responsesInputSchema = z.object({
+  input: z.array(
+    z.object({
+      role: z.string().optional(),
+      content: z.array(z.object({ type: z.string(), text: z.string().optional() })).optional(),
+    }),
+  ),
+});
+const historyTextSchema = z.union([
+  z.string(),
+  z.array(z.object({ type: z.literal("text"), text: z.string() })).length(1),
+]);
+const runtimeCarrierPrefix = [
+  OPENCLAW_NEXT_TURN_RUNTIME_CONTEXT_HEADER,
+  OPENCLAW_RUNTIME_CONTEXT_NOTICE,
+  "",
+  INTERNAL_RUNTIME_CONTEXT_BEGIN,
+  "",
+].join("\n");
+
+function expectWhitespaceInterior(
+  texts: string[],
+  owner: string,
+  marker: string,
+  interior: string,
+) {
+  const begin = `BEGIN_${marker}`;
+  const end = `END_${marker}`;
+  for (const token of [begin, end]) {
+    expect(texts.reduce((count, text) => count + text.split(token).length - 1, 0)).toBe(1);
+  }
+  const start = owner.indexOf(begin);
+  const finish = owner.indexOf(end);
+  expect(start).toBeGreaterThanOrEqual(0);
+  expect(finish).toBeGreaterThan(start);
+  expect(Buffer.from(owner.slice(start + begin.length, finish))).toEqual(Buffer.from(interior));
+}
 
 let gatewayOwner: ReturnType<typeof createQaLiveLaneGateway> | undefined;
 let harness: Awaited<ReturnType<ReturnType<typeof createQaLiveLaneGateway>["start"]>> | undefined;
@@ -178,7 +226,7 @@ describe("Gateway chat RPCs", () => {
   });
 
   it(
-    "runs chat.send through agent.wait and persists both sides in chat.history",
+    "preserves model-input whitespace independently from canonical chat history",
     { timeout: 120_000 },
     async () => {
       gatewayOwner = createQaLiveLaneGateway();
@@ -195,50 +243,101 @@ describe("Gateway chat RPCs", () => {
         controlUiEnabled: false,
       });
       const { gateway } = harness;
-
-      const expectedReply = "GATEWAY_RPC_CHAT_OK";
-      const prompt = `Gateway chat RPC QA. Reply exactly \`${expectedReply}\`.`;
+      const mock = expectDefined(harness.mock, "mock provider");
       const sessionKey = `agent:qa:gateway-rpc-chat-${randomUUID()}`;
-      const started = (await gateway.call(
-        "chat.send",
-        {
-          sessionKey,
-          message: prompt,
-          deliver: false,
-          idempotencyKey: randomUUID(),
-        },
-        { timeoutMs: 30_000 },
-      )) as GatewayChatRun;
-
-      expect(started.status).toBe("started");
-      expect(typeof started.runId).toBe("string");
-
-      const terminal = (await gateway.call(
-        "agent.wait",
-        {
-          runId: started.runId,
-          timeoutMs: 30_000,
-        },
-        { timeoutMs: 35_000 },
-      )) as GatewayChatRun;
-      expect(terminal.status).toBe("ok");
-
-      const history = await waitForChatHistory({
-        gateway,
-        sessionKey,
-        expectedUser: prompt,
-        expectedAssistant: expectedReply,
+      const turns = ["/think high\n", ""].map((directive, index) => {
+        const marker = randomUUID();
+        const reply = `GATEWAY_RPC_CHAT_OK_${index}`;
+        const interior =
+          "\n```python\nif True:\n    value = 'a  b'\n    if value:\n        print(value)\n\t\t# tabs stay  \n \t \n```\n";
+        return {
+          marker,
+          reply,
+          interior,
+          prompt: `${directive}Gateway chat RPC QA. Reply exactly \`${reply}\`.\nBEGIN_${marker}${interior}END_${marker}`,
+        };
       });
-      const messages = history.messages ?? [];
 
-      expect(
-        messages.some((message) => message.role === "user" && messageContains(message, prompt)),
-      ).toBe(true);
-      expect(
-        messages.some(
-          (message) => message.role === "assistant" && messageContains(message, expectedReply),
-        ),
-      ).toBe(true);
+      for (const [index, turn] of turns.entries()) {
+        const cursorResponse = await fetch(`${mock.baseUrl}/debug/request-cursor`);
+        expect(cursorResponse.ok).toBe(true);
+        const { cursor } = z
+          .object({ cursor: z.number().int() })
+          .parse(await cursorResponse.json());
+        const started = (await gateway.call(
+          "chat.send",
+          {
+            sessionKey,
+            message: turn.prompt,
+            deliver: false,
+            idempotencyKey: randomUUID(),
+          },
+          { timeoutMs: 30_000 },
+        )) as GatewayChatRun;
+        expect(started.status).toBe("started");
+        expect(typeof started.runId).toBe("string");
+        const terminal = (await gateway.call(
+          "agent.wait",
+          { runId: started.runId, timeoutMs: 30_000 },
+          { timeoutMs: 35_000 },
+        )) as GatewayChatRun;
+        expect(terminal.status).toBe("ok");
+
+        const response = await fetch(`${mock.baseUrl}/debug/requests?after=${cursor}`);
+        expect(response.ok).toBe(true);
+        const requests = requestSnapshotsSchema.parse(await response.json());
+        // Pin by request identity before checking content: a later retry must not
+        // hide a damaged initial prompt, and mock convenience fields trim text.
+        const request = expectDefined(
+          requests
+            .filter((entry) => entry.model === "gpt-5.6-luna")
+            .toSorted((a, b) => a.cursor - b.cursor)[0],
+          "first provider request",
+        );
+        const { input } = responsesInputSchema.parse(JSON.parse(request.raw));
+        const inputTexts = input.flatMap((item) =>
+          (item.content ?? [])
+            .filter((part) => part.type === "input_text")
+            .map((part) => expectDefined(part.text, "provider input text")),
+        );
+        const userTexts = input
+          .filter((item) => item.role === "user")
+          .map((item) => {
+            expect(item.content).toHaveLength(1);
+            const part = expectDefined(item.content?.[0], "user content");
+            expect(part.type).toBe("input_text");
+            return expectDefined(part.text, "user text");
+          })
+          .filter(
+            (text) =>
+              !(
+                text.startsWith(runtimeCarrierPrefix) &&
+                text.endsWith(`\n${INTERNAL_RUNTIME_CONTEXT_END}`)
+              ),
+          );
+        expect(userTexts).toHaveLength(index + 1);
+        const history = await waitForChatHistory({
+          gateway,
+          sessionKey,
+          expectedUser: `BEGIN_${turn.marker}`,
+          expectedAssistant: turn.reply,
+        });
+        const userMessages = (history.messages ?? []).filter((message) => message.role === "user");
+        expect(userMessages).toHaveLength(index + 1);
+        for (const [turnIndex, expected] of turns.slice(0, index + 1).entries()) {
+          const modelText = expectDefined(userTexts[turnIndex], "model user turn");
+          expectWhitespaceInterior(inputTexts, modelText, expected.marker, expected.interior);
+          const content = historyTextSchema.parse(userMessages[turnIndex]?.content);
+          const recorded =
+            typeof content === "string" ? content : expectDefined(content[0], "history text").text;
+          expectWhitespaceInterior([recorded], recorded, expected.marker, expected.interior);
+        }
+        if (index === 0) {
+          expect(userTexts[0]).not.toContain("/think high");
+        } else {
+          expect(userTexts[0]).toContain("/think high");
+        }
+      }
     },
   );
 });


### PR DESCRIPTION
Closes https://github.com/openclaw/openclaw/issues/132373 — directive preprocessing destroys code indentation before inference.

<details>
<summary>Additional instructions</summary>

Maintainers can update this repository-owned branch. AI-assisted implementation and independent Codex review; the maintainer verified source, failing/passing regressions, raw provider requests, and authenticated execution. No agent transcript is attached.

</details>

## What Problem This Solves

Fixes an issue where users sending indented code would have its whitespace changed before inference, even without a slash command. Canonical chat history retained the original text, concealing the damage to the separate model prompt. The reported AWS cloud-worker turn generated invalid Python with one-space indentation in place of four/eight-space nesting.

## Why This Change Was Made

Directive parsing now removes recognized spans and their local separators rather than normalizing the remaining prompt. The existing low-level parser owns this rule across thinking/level, model/alias, exec, queue, status, and simple inline commands; argument scanning commits whitespace only with accepted tokens.

Preparation trusts the already-authorized directive projection. The duplicate late thinking cleaner is deleted, and the existing first-token thinking shorthand no longer splits and rejoins the whole body. Reconstructing indentation in workers cannot recover lost bytes; substituting canonical history for the prepared prompt would bypass intentional directive/context processing. The repair therefore stays at the shared producer, not a provider or worker workaround.

## User Impact

Code indentation, tabs, significant spaces, and line endings survive directive preprocessing, including ordinary messages without directives. Recognized directives retain their existing argument grammar, aliases, scope/runtime options, authorization, first-match precedence, and directive-only outcomes. Preserved historical or unauthorized text is no longer reparsed by a late cleaner.

There is no new Markdown/fence recognition policy, dependency, config option, schema, persistence contract, or provider-specific branch. Whole-message ingress trimming/NFC normalization is unchanged; the fidelity contract here concerns directive removal, not arbitrary byte identity across every ingress transform. The [slash-command reference](https://docs.openclaw.ai/tools/slash-commands) documents the rule.

## Evidence

- **Exact-head CI:** [run 33280097934](https://github.com/openclaw/openclaw/actions/runs/33280097934) completed successfully for `ab303cfbfe133c1d3eff2f99cc1fdedae15d951c`; the exact-head watcher returned `GREEN`. [ClawSweeper's review](https://github.com/openclaw/openclaw/pull/132900#issuecomment-5465430538) found no correctness/security issue and requested only ordinary CI plus maintainer handling.
- **Before:** new regressions produced 35 parser failures and five routing/preparation failures on the pre-fix source. These captured indentation/CRLF/space loss, late stripping of preserved directive text, and first-token shorthand flattening.
- **After:** 480 distinct focused/sibling tests passed. The real routing/preparation tests assert both `commandBody` and `followupRun.prompt`, including authorized, unauthorized, and command-disabled cases. Initial repair exposed four adjacent-path separator regressions; the shared remover was corrected without dropping assertions.
- **Real Gateway / raw request:** the existing Gateway RPC E2E passed both tests, including two marked user turns. It pins the first provider request after each cursor, decodes the raw Responses body rather than trimmed mock convenience fields, compares exact interior bytes, and checks canonical history independently. The prior directive remains historical on the second turn. Test execution took 50.24s; the first invocation also rebuilt the candidate and missing private QA assets, so its 1272.65s total is not turn latency or a pre-fix binary run.
- **Authenticated OpenAI / actual execution:** the compiled candidate ran an isolated local Gateway with the built-in OpenClaw runtime and `openai/gpt-5.6-luna`, using an API key, no mock and no alternate-model fallback. A `/think high` turn and an ordinary warm turn each executed exactly one supplied Python heredoc verbatim, with four/eight-space nesting and `a  b`. Exact linked tool output, actual workspace-file bytes, final replies, provider/model metadata, and unchanged prior history were verified. Turns took 7.549s and 3.912s; this is local Gateway proof, not an AWS latency comparison or a new cloud-worker run.
- **Cleanup:** the live Gateway owner reported `confirmed-stopped` with no errors; its PID, process group, and listener were independently absent, and the temporary API key was deleted. Two empty directories reappeared after driver shutdown; they were inspected and removed separately, and that QA lifecycle residue is recorded as a separate follow-up. No credential files survived in that residue.
- **Review:** fresh full-candidate read-only Codex autoreview reported no actionable P0 findings, confidence 0.98. Lower-priority findings were outside that review threshold; manual owner/sibling review and executable proof remain separate evidence.

Exact focused commands:

```bash
node scripts/run-vitest.mjs src/auto-reply/reply.directive.parse.test.ts src/auto-reply/model.test.ts src/auto-reply/reply/reply-inline.test.ts src/auto-reply/reply/get-reply-run.media-only.test.ts
```

```bash
node scripts/run-vitest.mjs src/auto-reply/model.test.ts src/auto-reply/reply/get-reply-inline-actions.skip-when-config-empty.test.ts src/auto-reply/reply/get-reply-native-slash-fast-path.test.ts src/auto-reply/reply/directive-handling.mixed-inline.test.ts
```

```bash
node scripts/run-vitest.mjs run --config test/vitest/vitest.e2e.config.ts test/e2e/qa-lab/runtime/gateway-rpc-chat.e2e.test.ts --reporter=verbose
```

The final 15-file `node scripts/check-changed.mjs -- <changed paths>` run passed: formatting, all three unused-export scans, core/core-test/root-test typechecks, core/scripts lint, and the remaining architecture/schema/security guards. Earlier aggregate validation caught four `no-param-reassign` diagnostics; local removal indexes fixed them before this clean full rerun. One frozen-lockfile install repaired missing installed OpenAI package files before the sibling rerun; manifests and lockfiles are unchanged.

**Source identity and size:** candidate commit `ab303cfbfe133c1d3eff2f99cc1fdedae15d951c` contains the exact tested tree: base `d3c07b02e244e73470df4a930911e8d58c4e456d` plus the frozen candidate patch SHA-256 `2ba7cc6064c051f3d455da56921a47ed6f36fccd661feec6c645a7c30b5a7154`. Production **+98/-112 (net −14)**; tests/support **+292/-56**; docs **+4/-0**. No generated or lockfile changes.

Supplemental pre-fix package replay was attempted with the retained, checksum-verified `3093ea7cb73` archive, but pnpm installation stopped at `ERR_PNPM_IGNORED_BUILDS`. No dependency-build approval policy was changed, and no binary before-proof is claimed. The fail-first source tests and original cloud failure remain the before evidence.

**History limits:** [the earlier newline-preservation repair](https://github.com/openclaw/openclaw/pull/32224) narrowed a pre-existing normalizer but left horizontal whitespace loss; [the reply-orchestration split](https://github.com/openclaw/openclaw/pull/113881) carried the late cleaner forward. Shallow blame does not establish original introduction or a first affected stable release. The separate thinking-route repair did not touch these owners and is not blamed for this defect.

**Proof gaps:** no new AWS/provider provisioning run or live Codex-runtime claim is made by this PR. The original cloud failure and shared local/worker consumer contracts are documented in the issue. No screenshot/video is claimed: the required real-Chrome extension relay was checked again and returned `network-error`; no alternate browser attachment or operator Gateway was used. Exact request/command/history evidence above covers the changed prompt boundary.
