### PR TITLE
perf(checks): scan deprecated API inputs once

### DIFF
--- a/scripts/check-deprecated-api-usage.mts
+++ b/scripts/check-deprecated-api-usage.mts
@@ -27,29 +27,24 @@ const skippedFilePatterns = [
   /\.d\.ts$/u,
 ];
 
+type RuleSource = { repoPath: string; source: string };
+
 type DeprecatedRule = {
   allowedFiles?: string[];
   collect?: () => string[];
+  collectFile?: (file: RuleSource) => string[];
   id?: string;
   message?: string;
   moduleSpecifiers?: string[];
   names?: string[];
   roots?: string[];
-  skippedFilePatterns?: RegExp[];
 };
 
 function toRepoPath(filePath: string) {
   return path.relative(repoRoot, filePath).split(path.sep).join("/");
 }
 
-function shouldSkipFile(filePath: string, rule: DeprecatedRule) {
-  const repoPath = toRepoPath(filePath);
-  return (rule.skippedFilePatterns ?? skippedFilePatterns).some((pattern) =>
-    pattern.test(repoPath),
-  );
-}
-
-function* walk(dir: string, rule: DeprecatedRule): Generator<string> {
+function* walk(dir: string): Generator<string> {
   if (!fs.existsSync(dir)) {
     return;
   }
@@ -59,45 +54,35 @@ function* walk(dir: string, rule: DeprecatedRule): Generator<string> {
     }
     const entryPath = path.join(dir, entry.name);
     if (entry.isDirectory()) {
-      yield* walk(entryPath, rule);
+      yield* walk(entryPath);
       continue;
     }
     if (!entry.isFile() || !sourceExtensions.has(path.extname(entry.name))) {
       continue;
     }
-    if (!shouldSkipFile(entryPath, rule)) {
+    const repoPath = toRepoPath(entryPath);
+    if (!skippedFilePatterns.some((pattern) => pattern.test(repoPath))) {
       yield entryPath;
     }
   }
 }
 
-function collectIdentifierRuleViolations(rule: DeprecatedRule) {
-  const allowedFiles = new Set(rule.allowedFiles ?? []);
+function createIdentifierRuleCollector(rule: DeprecatedRule) {
   const pattern = new RegExp(
     `\\b(?:${(rule.names ?? []).map((name) => escapeRegExp(name)).join("|")})\\b`,
     "gu",
   );
-  const violations: string[] = [];
-
-  for (const root of rule.roots ?? []) {
-    for (const filePath of walk(path.join(repoRoot, root), rule)) {
-      const repoPath = toRepoPath(filePath);
-      if (allowedFiles.has(repoPath)) {
-        continue;
-      }
-      const source = fs.readFileSync(filePath, "utf8");
-      for (const match of source.matchAll(pattern)) {
-        const line = source.slice(0, match.index).split("\n").length;
-        violations.push(`${repoPath}:${line}: ${match[0]} (${rule.message ?? "deprecated API"})`);
-      }
+  return ({ repoPath, source }: RuleSource) => {
+    const violations: string[] = [];
+    for (const match of source.matchAll(pattern)) {
+      const line = source.slice(0, match.index).split("\n").length;
+      violations.push(`${repoPath}:${line}: ${match[0]} (${rule.message ?? "deprecated API"})`);
     }
-  }
-
-  return violations;
+    return violations;
+  };
 }
 
-function collectModuleSpecifierRuleViolations(rule: DeprecatedRule) {
-  const allowedFiles = new Set(rule.allowedFiles ?? []);
+function createModuleSpecifierRuleCollector(rule: DeprecatedRule) {
   const specifierPattern = (rule.moduleSpecifiers ?? [])
     .map((specifier) => escapeRegExp(specifier))
     .join("|");
@@ -112,35 +97,16 @@ function collectModuleSpecifierRuleViolations(rule: DeprecatedRule) {
     ),
     new RegExp(`\\bimport\\s*\\(\\s*["'](${specifierPattern})["']\\s*[,)]`, "gu"),
   ];
-  const violations: string[] = [];
-
-  for (const root of rule.roots ?? []) {
-    for (const filePath of walk(path.join(repoRoot, root), rule)) {
-      const repoPath = toRepoPath(filePath);
-      if (allowedFiles.has(repoPath)) {
-        continue;
-      }
-      const source = fs.readFileSync(filePath, "utf8");
-      for (const pattern of patterns) {
-        for (const match of source.matchAll(pattern)) {
-          const line = source.slice(0, match.index).split("\n").length;
-          violations.push(`${repoPath}:${line}: ${match[1]} (${rule.message})`);
-        }
+  return ({ repoPath, source }: RuleSource) => {
+    const violations: string[] = [];
+    for (const pattern of patterns) {
+      for (const match of source.matchAll(pattern)) {
+        const line = source.slice(0, match.index).split("\n").length;
+        violations.push(`${repoPath}:${line}: ${match[1]} (${rule.message})`);
       }
     }
-  }
-
-  return violations;
-}
-
-function collectRuleViolations(rule: DeprecatedRule) {
-  if (rule.collect) {
-    return rule.collect();
-  }
-  if (rule.moduleSpecifiers) {
-    return collectModuleSpecifierRuleViolations(rule);
-  }
-  return collectIdentifierRuleViolations(rule);
+    return violations;
+  };
 }
 
 const internalFacadeImportPatterns = [
@@ -166,30 +132,25 @@ function resolveInternalFacadeModulePath(repoPath: string, specifier: string) {
   return path.posix.normalize(path.posix.join(path.posix.dirname(repoPath), stripped));
 }
 
-function collectBannedInternalFacadeImportViolations(rule: DeprecatedRule) {
-  const bansByModulePath = new Map(
-    BANNED_INTERNAL_PLUGIN_SDK_FACADE_MODULES.map((ban) => [ban.modulePath, ban]),
-  );
+const bansByModulePath = new Map(
+  BANNED_INTERNAL_PLUGIN_SDK_FACADE_MODULES.map((ban) => [ban.modulePath, ban]),
+);
+
+function collectBannedInternalFacadeImportViolations({ repoPath, source }: RuleSource) {
   const violations: string[] = [];
-  for (const root of rule.roots ?? []) {
-    for (const filePath of walk(path.join(repoRoot, root), rule)) {
-      const repoPath = toRepoPath(filePath);
-      const source = fs.readFileSync(filePath, "utf8");
-      for (const pattern of internalFacadeImportPatterns) {
-        for (const match of source.matchAll(pattern)) {
-          const specifier = match[1];
-          if (!specifier) {
-            continue;
-          }
-          const resolved = resolveInternalFacadeModulePath(repoPath, specifier);
-          const ban = resolved ? bansByModulePath.get(resolved) : undefined;
-          if (!ban || (ban.allowedImporters ?? []).includes(repoPath)) {
-            continue;
-          }
-          const line = source.slice(0, match.index).split("\n").length;
-          violations.push(`${repoPath}:${line}: ${match[1]} (use ${ban.canonical})`);
-        }
+  for (const pattern of internalFacadeImportPatterns) {
+    for (const match of source.matchAll(pattern)) {
+      const specifier = match[1];
+      if (!specifier) {
+        continue;
       }
+      const resolved = resolveInternalFacadeModulePath(repoPath, specifier);
+      const ban = resolved ? bansByModulePath.get(resolved) : undefined;
+      if (!ban || (ban.allowedImporters ?? []).includes(repoPath)) {
+        continue;
+      }
+      const line = source.slice(0, match.index).split("\n").length;
+      violations.push(`${repoPath}:${line}: ${match[1]} (use ${ban.canonical})`);
     }
   }
   return violations;
@@ -216,7 +177,8 @@ const rules: Array<DeprecatedRule & { id: string }> = [
     // Deprecated facades stay exported for third-party plugins, but internal code
     // must not reach them via package specifier or relative import.
     id: "facade-internal-imports",
-    collect: () => collectBannedInternalFacadeImportViolations({ roots: ["src", "extensions"] }),
+    roots: ["src", "extensions"],
+    collectFile: collectBannedInternalFacadeImportViolations,
   },
   {
     id: "message-api",
@@ -248,8 +210,36 @@ if (unknownRuleIds.length > 0) {
   process.exit(1);
 }
 
-const violations = selectedRules.flatMap((rule) =>
-  collectRuleViolations(rule).map((violation) => `${rule.id}: ${violation}`),
+const scans = selectedRules.map((rule) => ({
+  rule,
+  violations: rule.collect?.(),
+  byRoot: new Map<string, string[]>((rule.roots ?? []).map((root) => [root, []])),
+  allowedFiles: new Set(rule.allowedFiles ?? []),
+  collectFile:
+    rule.collectFile ??
+    (rule.moduleSpecifiers
+      ? createModuleSpecifierRuleCollector(rule)
+      : createIdentifierRuleCollector(rule)),
+}));
+
+for (const root of new Set(scans.flatMap((scan) => [...scan.byRoot.keys()]))) {
+  const rootScans = scans.filter((scan) => scan.byRoot.has(root));
+  for (const filePath of walk(path.join(repoRoot, root))) {
+    const repoPath = toRepoPath(filePath);
+    const fileScans = rootScans.filter((scan) => !scan.allowedFiles.has(repoPath));
+    if (fileScans.length === 0) {
+      continue;
+    }
+    const source = fs.readFileSync(filePath, "utf8");
+    for (const scan of fileScans) {
+      scan.byRoot.get(root)!.push(...scan.collectFile({ repoPath, source }));
+    }
+  }
+}
+
+// Keep rule and root diagnostic order while each source is read only once.
+const violations = scans.flatMap(({ rule, violations: collected, byRoot }) =>
+  (collected ?? [...byRoot.values()].flat()).map((violation) => `${rule.id}: ${violation}`),
 );
 
 if (violations.length > 0) {

--- a/test/scripts/check-deprecated-api-usage.test.ts
+++ b/test/scripts/check-deprecated-api-usage.test.ts
@@ -3,7 +3,7 @@ import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import { describe, expect, it } from "vitest";
 import {
   BANNED_INTERNAL_PLUGIN_SDK_FACADE_MODULES,
@@ -16,7 +16,7 @@ const GUARD_SCRIPT_PATH = path.resolve(
   "../../scripts/check-deprecated-api-usage.mts",
 );
 
-function runFacadeImportRule(sourceByRepoPath: Record<string, string>) {
+function runRules(sourceByRepoPath: Record<string, string>, ruleIds = ["facade-internal-imports"]) {
   // realpath first: macOS os.tmpdir() is a /var -> /private/var symlink and the
   // script reports repo-relative paths from its resolved cwd.
   const fixtureRoot = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "deprecated-guard-")));
@@ -26,10 +26,46 @@ function runFacadeImportRule(sourceByRepoPath: Record<string, string>) {
       fs.mkdirSync(path.dirname(filePath), { recursive: true });
       fs.writeFileSync(filePath, source);
     }
-    return spawnSync(process.execPath, [GUARD_SCRIPT_PATH, "--rule=facade-internal-imports"], {
-      cwd: fixtureRoot,
-      encoding: "utf8",
-    });
+    const accountingPath = path.join(fixtureRoot, "account-source-io.mjs");
+    fs.writeFileSync(
+      accountingPath,
+      `import fs from "node:fs";
+import path from "node:path";
+import { syncBuiltinESMExports } from "node:module";
+const counts = { files: {}, directories: {} };
+const root = process.cwd();
+function count(kind, file) {
+  if (typeof file !== "string") return;
+  const relative = path.relative(root, file).split(path.sep).join("/");
+  if (!/^(src|extensions|packages)(\\/|$)/.test(relative)) return;
+  counts[kind][relative] = (counts[kind][relative] ?? 0) + 1;
+}
+for (const [method, kind] of [["readFileSync", "files"], ["readdirSync", "directories"]]) {
+  const original = fs[method];
+  fs[method] = function (file, ...args) {
+    const result = original.call(this, file, ...args);
+    count(kind, file);
+    return result;
+  };
+}
+syncBuiltinESMExports();
+process.on("exit", () => fs.writeFileSync("source-io.json", JSON.stringify(counts)));
+`,
+    );
+    const result = spawnSync(
+      process.execPath,
+      [
+        "--import",
+        pathToFileURL(accountingPath).href,
+        GUARD_SCRIPT_PATH,
+        ...ruleIds.map((id) => `--rule=${id}`),
+      ],
+      { cwd: fixtureRoot, encoding: "utf8" },
+    );
+    const io: { files: Record<string, number>; directories: Record<string, number> } = JSON.parse(
+      fs.readFileSync(path.join(fixtureRoot, "source-io.json"), "utf8"),
+    );
+    return { ...result, io };
   } finally {
     fs.rmSync(fixtureRoot, { recursive: true, force: true });
   }
@@ -90,7 +126,7 @@ describe("scripts/check-deprecated-api-usage", () => {
   });
 
   it("flags internal facade imports across static, relative, scoped, and dynamic forms", () => {
-    const result = runFacadeImportRule({
+    const result = runRules({
       "src/channels/probe.ts": [
         'import { createChannelReplyPipeline } from "openclaw/plugin-sdk/channel-reply-pipeline";',
         'export { runChannelInboundEvent } from "../plugin-sdk/inbound-reply-dispatch.js";',
@@ -109,7 +145,7 @@ describe("scripts/check-deprecated-api-usage", () => {
   });
 
   it("allows canonical compat re-exports and test files", () => {
-    const result = runFacadeImportRule({
+    const result = runRules({
       "src/plugin-sdk/inbound-reply-dispatch.ts":
         'export { runChannelInboundEvent } from "./channel-inbound.js";',
       "src/plugin-sdk/channel-message.test.ts":
@@ -118,5 +154,76 @@ describe("scripts/check-deprecated-api-usage", () => {
 
     expect(result.stderr).toBe("");
     expect(result.status).toBe(0);
+  });
+
+  it("reads overlapping rule inputs once while preserving complete diagnostic order", () => {
+    const result = runRules(
+      {
+        "src/a.ts":
+          'import { x } from "openclaw/plugin-sdk/channel-message";\ndeliverOutboundPayloads();',
+        "extensions/probe/src/a.ts":
+          'export { x } from "openclaw/plugin-sdk/channel-reply-pipeline";\ndeliverOutboundPayloads();',
+        "packages/a.ts":
+          'import { x } from "openclaw/plugin-sdk/command-auth";\ndeliverOutboundPayloads();',
+        "src/infra/outbound/deliver.ts": "deliverOutboundPayloads();",
+        "src/a.test.ts": "deliverOutboundPayloads();",
+      },
+      [
+        "message-api",
+        "facade-internal-imports",
+        "extension-plugin-sdk-compat-subpaths",
+        "plugin-sdk-compat-subpaths",
+      ],
+    );
+
+    expect(result.status).toBe(1);
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toBe(
+      [
+        "Deprecated API usage guard failed:",
+        "- plugin-sdk-compat-subpaths: src/a.ts:1: openclaw/plugin-sdk/channel-message (use focused non-deprecated plugin SDK subpaths)",
+        "- plugin-sdk-compat-subpaths: packages/a.ts:1: openclaw/plugin-sdk/command-auth (use focused non-deprecated plugin SDK subpaths)",
+        "- extension-plugin-sdk-compat-subpaths: extensions/probe/src/a.ts:1: openclaw/plugin-sdk/channel-reply-pipeline (extensions must use focused non-deprecated plugin SDK subpaths)",
+        "- facade-internal-imports: src/a.ts:1: openclaw/plugin-sdk/channel-message (use openclaw/plugin-sdk/channel-outbound)",
+        "- facade-internal-imports: extensions/probe/src/a.ts:1: openclaw/plugin-sdk/channel-reply-pipeline (use openclaw/plugin-sdk/channel-outbound)",
+        "- message-api: src/a.ts:2: deliverOutboundPayloads (use sendDurableMessageBatch or deliverInboundReplyWithMessageSendContext)",
+        "- message-api: extensions/probe/src/a.ts:2: deliverOutboundPayloads (use sendDurableMessageBatch or deliverInboundReplyWithMessageSendContext)",
+        "- message-api: packages/a.ts:2: deliverOutboundPayloads (use sendDurableMessageBatch or deliverInboundReplyWithMessageSendContext)",
+        "",
+      ].join("\n"),
+    );
+    expect(result.io.files).toEqual({
+      "src/a.ts": 1,
+      "src/infra/outbound/deliver.ts": 1,
+      "packages/a.ts": 1,
+      "extensions/probe/src/a.ts": 1,
+    });
+    expect(result.io.directories).toEqual({
+      src: 1,
+      "src/infra": 1,
+      "src/infra/outbound": 1,
+      packages: 1,
+      extensions: 1,
+      "extensions/probe": 1,
+      "extensions/probe/src": 1,
+    });
+  });
+
+  it("does not read a file allowed by the only selected rule", () => {
+    const result = runRules({ "src/infra/outbound/deliver.ts": "deliverOutboundPayloads();" }, [
+      "message-api",
+    ]);
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(result.io.files).toEqual({});
+  });
+
+  it("rejects unknown rules before reading any source directories", () => {
+    const result = runRules({ "src/a.ts": "deliverOutboundPayloads();" }, ["unknown"]);
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toBe("Unknown deprecated API usage rule(s): unknown\n");
+    expect(result.io).toEqual({ files: {}, directories: {} });
   });
 });


### PR DESCRIPTION
## What Problem This Solves

Release verification repeatedly reads the same source tree while checking deprecated APIs. The identifier, SDK import, and internal-facade rules each walked overlapping roots and reopened their files, adding unnecessary filesystem work when maintainers verify fixes in parallel.

## Why This Change Was Made

Compile each selected rule once, walk each selected CLI root once, and feed each source string to every applicable rule before discarding it. Keep diagnostics grouped in the existing rule/root order. Exclusions, allowlists, module spellings, rule selection, and failures stay intact. The separate config-boundary collector keeps its broader source scope unchanged.

This removes the repeated scanner loops without a retained source-content cache, new flag, dependency, or skipped coverage. Tooling is +73/-83 lines (net −10); tests are +115/-8. Runtime production code is unchanged.

## User Impact

Maintainer checks perform less filesystem work while enforcing the same deprecated-API policy. There is no OpenClaw runtime or configuration change.

## Evidence

A sequential full-repository baseline/candidate comparison returned the same successful status, stdout, and stderr. All 26,221 distinct read-source hashes and 832 directory-inventory hashes matched with no drift. Source-read calls fell from 68,315 to 40,414, and directory-enumeration calls from 3,337 to 2,002. These are measured filesystem-call reductions; one instrumented sequential timing pair is not a general wall-time speedup claim.

The new real-CLI regression fails against the old owner because source/plugin files are read three times and package files twice. The full expected diagnostic output already matches there. With the streaming owner, each eligible input is read once and all 10 CLI tests pass. Six config-boundary sibling tests also pass. The fixture also checks narrow-rule allowlists, unknown-rule refusal before scanning, and existing import/exclusion behavior.

Validation used `node scripts/run-vitest.mjs run test/scripts/check-deprecated-api-usage.test.ts src/plugins/contracts/config-boundary-guard.test.ts` and the canonical changed-check plan for the two touched files. The latter passed its guards, full deprecated-API scan, script typecheck, and root-test typecheck, then found a shadowed local variable name. After that binding-only rename, focused script lint and all 10 CLI tests passed, and both previously unexecuted Docker E2E and raw-HTTP/2 boundary checks passed. Fresh P0–P2 autoreview found no actionable issues.

Named follow-up: the unchanged config-boundary helper has a pre-existing module-global content cache, so a second call in the same Node process can miss a source edit. A bounded clean-then-edit reproduction confirms it. Fresh CLI processes are unaffected; correcting that helper's invocation lifetime remains separate work.

AI-assisted with Codex.

Final landing proof: [CI run 33280391296](https://github.com/openclaw/openclaw/actions/runs/33280391296) passed on exact head `bc61d5fd7e99ca84e924de1d72f7d0f80a4dc655`. The latest [ClawSweeper review](https://github.com/openclaw/openclaw/pull/132902#issuecomment-5465459688) has no findings; its only rank-up request, completion of exact-head CI, is satisfied. Native review guards and review-artifact validation passed without changing the two reviewed file blobs.

