### PR TITLE
improve(tasks): bound task list page selection

### DIFF
--- a/src/gateway/gateway-access-revision.ts
+++ b/src/gateway/gateway-access-revision.ts
@@ -1,0 +1,10 @@
+let revision = 0;
+
+/** Marks Gateway access decisions stale across asynchronously yielded reads. */
+export function bumpGatewayAccessRevision(): void {
+  revision += 1;
+}
+
+export function readGatewayAccessRevision(): number {
+  return revision;
+}

--- a/src/gateway/operator-role-policy.ts
+++ b/src/gateway/operator-role-policy.ts
@@ -8,6 +8,7 @@ import type { GatewayOperatorRoleDefinition } from "../config/types.gateway.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { getUserProfileRole } from "../state/user-profiles.js";
+import { bumpGatewayAccessRevision } from "./gateway-access-revision.js";
 import { gatewayClientSessionCreator } from "./server-methods/gateway-client-identity.js";
 import {
   resolveOperatorSessionCreation,
@@ -56,6 +57,7 @@ function readOperatorRoleAssignment(profileId: string): string | null {
 
 /** Drops a changed assignment so subsequent authorization reads the durable owner. */
 export function invalidateOperatorRolePolicy(profileId: string): void {
+  bumpGatewayAccessRevision();
   operatorRoleAssignments.delete(profileId);
   for (const reported of reportedUnknownAssignments) {
     if (reported.startsWith(`${profileId}:`)) {

--- a/src/gateway/server-methods/tasks.test.ts
+++ b/src/gateway/server-methods/tasks.test.ts
@@ -21,7 +21,6 @@ import { ensureProfileForEmail } from "../../state/user-profiles.js";
 import {
   createTaskRecord as createTaskRecordOrNull,
   getTaskById,
-  listTaskRecordPage,
   markTaskTerminalById,
   recordTaskProgressByRunId,
 } from "../../tasks/runtime-internal.js";
@@ -246,49 +245,6 @@ describe("tasks gateway handlers", () => {
 
     expect(calls[0]?.[0]).toBe(true);
     expect(payload?.tasks?.map((entry) => entry.taskId)).toEqual([task.taskId]);
-  });
-
-  it("does not use the executor as the requester owner for a legacy bare task", () => {
-    const task = createTaskRecord({
-      runtime: "subagent",
-      requesterSessionKey: "global",
-      ownerKey: "global",
-      scopeKind: "session",
-      childSessionKey: "agent:research:subagent:child",
-      agentId: "research",
-      runId: "run-legacy-owner",
-      task: "Owned by ops, executed by research",
-      status: "running",
-      deliveryStatus: "pending",
-    });
-    expect(task.requesterAgentId).toBeUndefined();
-    const cfg = {
-      session: { scope: "global", store: "/tmp/shared-sessions.sqlite" },
-      agents: {
-        ownership: "explicit",
-        defaults: { sessionStore: { agentId: "ops" } },
-        entries: { ops: {}, research: {} },
-      },
-    } satisfies OpenClawConfig;
-
-    expect(
-      listTaskRecordPage({
-        offset: 0,
-        limit: 10,
-        sessionKey: "global",
-        sessionAgentId: "ops",
-        cfg,
-      }).tasks.map((entry) => entry.taskId),
-    ).toEqual([task.taskId]);
-    expect(
-      listTaskRecordPage({
-        offset: 0,
-        limit: 10,
-        sessionKey: "global",
-        sessionAgentId: "research",
-        cfg,
-      }).tasks,
-    ).toEqual([]);
   });
 
   it("orders the ledger by last activity, not creation time", async () => {
@@ -588,32 +544,6 @@ describe("tasks gateway handlers", () => {
       expect(admin.payload?.task?.taskId).toBe(taskId);
     },
   );
-
-  it("returns page records isolated from the registry", () => {
-    const created = createTaskRecord({
-      runtime: "cli",
-      requesterSessionKey: "agent:main:main",
-      ownerKey: "agent:main:main",
-      scopeKind: "session",
-      task: "Isolated task",
-      status: "running",
-      deliveryStatus: "pending",
-      detail: { nested: { value: "original" } },
-    });
-
-    const page = listTaskRecordPage({ offset: 0, limit: 1 });
-    const detail = page.tasks[0]?.detail as { nested: { value: string } } | undefined;
-    expect(detail).toBeDefined();
-    if (detail) {
-      detail.nested.value = "mutated";
-    }
-
-    const current = expectDefined(
-      getTaskById(created.taskId),
-      "page mutation must not change the registry record",
-    );
-    expect((current.detail as { nested: { value: string } }).nested.value).toBe("original");
-  });
 
   it("treats explicit task agentId as authoritative over the session-key fallback", async () => {
     // Cross-agent subagent task: the registry derives agentId=worker from the

--- a/src/gateway/server-methods/tasks.ts
+++ b/src/gateway/server-methods/tasks.ts
@@ -62,7 +62,7 @@ function parseCursor(cursor: string | undefined): number | null {
 // Control UI task methods expose the stable gateway protocol shape; helpers
 // above keep runtime registry details out of the wire result.
 export const tasksHandlers: GatewayRequestHandlers = {
-  "tasks.list": ({ params, respond, context, client }) => {
+  "tasks.list": async ({ params, respond, context, client }) => {
     if (!assertValidParams(params, validateTasksListParams, "tasks.list", respond)) {
       return;
     }
@@ -101,7 +101,7 @@ export const tasksHandlers: GatewayRequestHandlers = {
     // The ledger pages by last activity so an old long-running task that just
     // finished still surfaces first. Selection stays inside the registry so
     // only the bounded wire page pays for defensive record cloning.
-    const page = listTaskRecordPage({
+    const page = await listTaskRecordPage({
       offset: cursor,
       limit,
       statuses: statusFilter ? [...statusFilter] : undefined,

--- a/src/gateway/server-methods/tasks.ts
+++ b/src/gateway/server-methods/tasks.ts
@@ -17,7 +17,8 @@ import {
 } from "../../agents/subagents/completion/subagent-completion-delivery.js";
 import { canonicalizeMainSessionAlias } from "../../config/sessions.js";
 import { getTaskById, listTaskRecordPage } from "../../tasks/runtime-internal.js";
-import type { TaskStatus } from "../../tasks/task-registry.types.js";
+import type { TaskRecord, TaskStatus } from "../../tasks/task-registry.types.js";
+import { readGatewayAccessRevision } from "../gateway-access-revision.js";
 import { resolveRequestedSessionAgentId } from "../session-request-agent.js";
 import { canAccessTaskRequesterSession } from "../task-session-access.js";
 import { mapTaskSummary } from "./task-summary.js";
@@ -26,6 +27,7 @@ import { assertValidParams } from "./validation.js";
 
 const DEFAULT_TASKS_LIST_LIMIT = 100;
 const MAX_TASKS_LIST_LIMIT = 500;
+const TASKS_LIST_MAX_ATTEMPTS = 3;
 
 type TaskLedgerStatus = TaskSummary["status"];
 
@@ -101,7 +103,9 @@ export const tasksHandlers: GatewayRequestHandlers = {
     // The ledger pages by last activity so an old long-running task that just
     // finished still surfaces first. Selection stays inside the registry so
     // only the bounded wire page pays for defensive record cloning.
-    const page = await listTaskRecordPage({
+    const canReadTask = (task: Readonly<TaskRecord>) =>
+      canAccessTaskRequesterSession({ cfg, client, task });
+    const pageParams = {
       offset: cursor,
       limit,
       statuses: statusFilter ? [...statusFilter] : undefined,
@@ -109,13 +113,40 @@ export const tasksHandlers: GatewayRequestHandlers = {
       sessionKey,
       sessionAgentId,
       cfg,
-      filter: (task) => canAccessTaskRequesterSession({ cfg, client, task }),
-    });
-    const nextOffset = cursor + page.tasks.length;
-    respond(true, {
-      tasks: page.tasks.map((task) => mapTaskSummary(task)),
-      ...(page.hasMore ? { nextCursor: String(nextOffset) } : {}),
-    });
+      filter: canReadTask,
+    };
+    for (let attempt = 0; attempt < TASKS_LIST_MAX_ATTEMPTS; attempt += 1) {
+      const accessRevision = readGatewayAccessRevision();
+      const pageResult = await listTaskRecordPage(pageParams);
+      if (!pageResult.ok) {
+        respond(
+          false,
+          undefined,
+          errorShape(ErrorCodes.UNAVAILABLE, "task registry changed during tasks.list; retry"),
+        );
+        return;
+      }
+      const page = pageResult.value;
+      // Sharing changes invalidate every access decision made before a yield.
+      // Recheck selected rows in the final synchronous response turn as well.
+      if (
+        accessRevision !== readGatewayAccessRevision() ||
+        page.tasks.some((task) => !canReadTask(task))
+      ) {
+        continue;
+      }
+      const nextOffset = cursor + page.tasks.length;
+      respond(true, {
+        tasks: page.tasks.map((task) => mapTaskSummary(task)),
+        ...(page.hasMore ? { nextCursor: String(nextOffset) } : {}),
+      });
+      return;
+    }
+    respond(
+      false,
+      undefined,
+      errorShape(ErrorCodes.UNAVAILABLE, "task access changed during tasks.list; retry"),
+    );
   },
   "tasks.get": ({ params, respond, context, client }) => {
     if (!assertValidParams(params, validateTasksGetParams, "tasks.get", respond)) {

--- a/src/gateway/server.tasks-list-performance.test.ts
+++ b/src/gateway/server.tasks-list-performance.test.ts
@@ -1,0 +1,268 @@
+import path from "node:path";
+import { afterAll, describe, expect, test, vi } from "vitest";
+import type { TasksListResult } from "../../packages/gateway-protocol/src/index.js";
+import { writeConfigFile } from "../config/config.js";
+import { upsertSessionEntryCore } from "../config/sessions/session-accessor.js";
+import { ensureProfileForEmail, setUserProfileRole } from "../state/user-profiles.js";
+import { configureTaskRegistryRuntime } from "../tasks/task-registry.store.js";
+import type { TaskRecord } from "../tasks/task-registry.types.js";
+import { resetTaskRegistryForTests } from "../tasks/task-runtime.test-helpers.js";
+import { invalidateOperatorRolePolicy } from "./operator-role-policy.js";
+import {
+  connectReq,
+  CONTROL_UI_CLIENT,
+  installGatewayTestHooks,
+  onceMessage,
+  openWs,
+  testState,
+  withGatewayServer,
+} from "./server.auth.test-helpers.js";
+
+installGatewayTestHooks({ scope: "suite" });
+
+const BROWSER_ORIGIN = "https://control.example.com";
+const TASK_COUNT = 10_000;
+const OWNED_SESSION_KEY = "agent:main:tasks-owned";
+const FOREIGN_SESSION_KEY = "agent:main:tasks-foreign";
+
+type RpcResponse<T> = {
+  type: "res";
+  id: string;
+  ok: boolean;
+  payload?: T;
+  error?: { message?: string };
+};
+
+function sendRpc<T>(
+  ws: Awaited<ReturnType<typeof openWs>>,
+  id: string,
+  method: string,
+  params?: unknown,
+): Promise<RpcResponse<T>> {
+  const response = onceMessage<RpcResponse<T>>(
+    ws,
+    (message) => message.type === "res" && message.id === id,
+    60_000,
+  );
+  ws.send(JSON.stringify({ type: "req", id, method, params }));
+  return response;
+}
+
+function taskUpdatedAt(task: TaskRecord): number {
+  return task.lastEventAt ?? task.endedAt ?? task.startedAt ?? task.createdAt;
+}
+
+function expectedTaskIds(tasks: Iterable<TaskRecord>, offset: number, limit: number): string[] {
+  return [...tasks]
+    .toSorted(
+      (left, right) =>
+        taskUpdatedAt(right) - taskUpdatedAt(left) || left.taskId.localeCompare(right.taskId),
+    )
+    .slice(offset, offset + limit)
+    .map((task) => task.taskId);
+}
+
+function createTaskSnapshot(): Map<string, TaskRecord> {
+  const tasks = new Map<string, TaskRecord>();
+  for (let index = 0; index < TASK_COUNT; index += 1) {
+    const taskId = `task-${String(index).padStart(5, "0")}`;
+    const requesterSessionKey = index % 2 === 0 ? OWNED_SESSION_KEY : FOREIGN_SESSION_KEY;
+    tasks.set(taskId, {
+      taskId,
+      runtime: "cli",
+      requesterSessionKey,
+      requesterAgentId: "main",
+      ownerKey: requesterSessionKey,
+      scopeKind: "session",
+      runId: `run-${index}`,
+      task: `Task ${index}`,
+      status: "succeeded",
+      deliveryStatus: "not_applicable",
+      notifyPolicy: "done_only",
+      createdAt: 0,
+      startedAt: 0,
+      lastEventAt: Math.floor(((index * 7_919) % TASK_COUNT) / 4),
+    });
+  }
+  return tasks;
+}
+
+afterAll(() => {
+  resetTaskRegistryForTests({ persist: false });
+});
+
+describe("tasks.list Gateway performance", () => {
+  test("keeps authenticated task pages bounded without blocking other RPCs", async () => {
+    const adminProfile = ensureProfileForEmail("admin@example.com");
+    const viewerProfile = ensureProfileForEmail("viewer@example.com");
+    const foreignProfile = ensureProfileForEmail("foreign@example.com");
+    setUserProfileRole(adminProfile.id, "maintainer");
+    setUserProfileRole(viewerProfile.id, "restricted");
+    const auth = {
+      mode: "trusted-proxy" as const,
+      identityScopes: {
+        "admin@example.com": ["operator.admin"],
+        "viewer@example.com": ["operator.read"],
+      },
+      trustedProxy: {
+        userHeader: "x-forwarded-user",
+        requiredHeaders: ["x-forwarded-proto"],
+        allowLoopback: true,
+      },
+    };
+    testState.gatewayAuth = auth;
+    testState.gatewayControlUi = { allowedOrigins: [BROWSER_ORIGIN] };
+    await writeConfigFile({
+      gateway: {
+        auth,
+        trustedProxies: ["127.0.0.1"],
+        roles: {
+          default: "restricted",
+          definitions: {
+            restricted: {
+              sessions: { others: "none" },
+              agents: "*",
+              scopes: ["operator.read"],
+            },
+            maintainer: {
+              sessions: { others: "write" },
+              agents: "*",
+              scopes: ["operator.admin"],
+            },
+          },
+        },
+        controlUi: { allowedOrigins: [BROWSER_ORIGIN] },
+      },
+    });
+
+    const tasks = createTaskSnapshot();
+    const adminExpected = expectedTaskIds(tasks.values(), 13, 7);
+    const ownedTasks = [...tasks.values()].filter(
+      (task) => task.requesterSessionKey === OWNED_SESSION_KEY,
+    );
+    const viewerExpected = expectedTaskIds(ownedTasks, 10, 25);
+
+    try {
+      await withGatewayServer(async ({ port }) => {
+        await upsertSessionEntryCore(
+          { agentId: "main", sessionKey: OWNED_SESSION_KEY },
+          {
+            sessionId: "session-owned",
+            updatedAt: 1,
+            createdActor: { type: "human", source: "profile", id: viewerProfile.id },
+            visibility: "shared",
+          },
+        );
+        await upsertSessionEntryCore(
+          { agentId: "main", sessionKey: FOREIGN_SESSION_KEY },
+          {
+            sessionId: "session-foreign",
+            updatedAt: 1,
+            createdActor: { type: "human", source: "profile", id: foreignProfile.id },
+            visibility: "shared",
+          },
+        );
+        resetTaskRegistryForTests({ persist: false });
+        let onSnapshotLoad: (() => void) | undefined;
+        configureTaskRegistryRuntime({
+          store: {
+            loadSnapshot: () => {
+              onSnapshotLoad?.();
+              return { tasks, deliveryStates: new Map() };
+            },
+            saveSnapshot: () => {},
+          },
+        });
+
+        const stateDir = process.env.OPENCLAW_STATE_DIR;
+        if (!stateDir) {
+          throw new Error("OPENCLAW_STATE_DIR is required for the Gateway proof");
+        }
+        const connect = async (email: string, scopes: string[], identityLabel = email) => {
+          const ws = await openWs(port, {
+            origin: BROWSER_ORIGIN,
+            "x-forwarded-for": "203.0.113.50",
+            "x-forwarded-proto": "https",
+            "x-forwarded-user": email,
+          });
+          const connected = await connectReq(ws, {
+            skipDefaultAuth: true,
+            prePairDevice: true,
+            scopes,
+            client: CONTROL_UI_CLIENT,
+            deviceIdentityPath: path.join(stateDir, `${identityLabel}.sqlite`),
+            browserOrigin: BROWSER_ORIGIN,
+          });
+          expect(connected.ok, JSON.stringify(connected.error)).toBe(true);
+          return ws;
+        };
+        const admin = await connect("admin@example.com", ["operator.admin"]);
+        const healthClient = await connect("admin@example.com", ["operator.admin"], "admin-health");
+        const viewer = await connect("viewer@example.com", ["operator.read"]);
+        const sortedInputLengths: number[] = [];
+        const originalToSorted = Array.prototype.toSorted;
+        const sortSpy = vi.spyOn(Array.prototype, "toSorted").mockImplementation(function <T>(
+          this: T[],
+          compareFn?: (left: T, right: T) => number,
+        ): T[] {
+          const first = this[0];
+          if (first && typeof first === "object" && "taskId" in first) {
+            sortedInputLengths.push(this.length);
+          }
+          return Reflect.apply(originalToSorted, this, [compareFn]) as T[];
+        });
+        try {
+          const completionOrder: string[] = [];
+          let healthPromise: Promise<RpcResponse<Record<string, unknown>>> | undefined;
+          onSnapshotLoad = () => {
+            healthPromise = sendRpc<Record<string, unknown>>(healthClient, "health", "health").then(
+              (response) => {
+                completionOrder.push("health");
+                return response;
+              },
+            );
+          };
+          const restrictedPromise = sendRpc<TasksListResult>(viewer, "tasks-owned", "tasks.list", {
+            cursor: "10",
+            limit: 25,
+          }).then((response) => {
+            completionOrder.push("tasks.list");
+            return response;
+          });
+          const restricted = await restrictedPromise;
+          const health = await healthPromise;
+
+          expect(health?.ok).toBe(true);
+          expect(restricted.ok, JSON.stringify(restricted.error)).toBe(true);
+          expect(restricted.payload?.tasks.map((task) => task.id)).toEqual(viewerExpected);
+          expect(restricted.payload?.tasks).toHaveLength(25);
+          expect(
+            restricted.payload?.tasks.every((task) => task.sessionKey === OWNED_SESSION_KEY),
+          ).toBe(true);
+          expect(restricted.payload?.nextCursor).toBe("35");
+          expect(completionOrder[0]).toBe("health");
+          expect(Math.max(0, ...sortedInputLengths)).toBeLessThanOrEqual(35);
+
+          sortedInputLengths.length = 0;
+          const list = await sendRpc<TasksListResult>(admin, "tasks-list", "tasks.list", {
+            cursor: "13",
+            limit: 7,
+          });
+          expect(list.ok, JSON.stringify(list.error)).toBe(true);
+          expect(list.payload?.tasks.map((task) => task.id)).toEqual(adminExpected);
+          expect(list.payload?.nextCursor).toBe("20");
+          expect(Math.max(0, ...sortedInputLengths)).toBeLessThanOrEqual(20);
+        } finally {
+          sortSpy.mockRestore();
+          admin.close();
+          healthClient.close();
+          viewer.close();
+          resetTaskRegistryForTests({ persist: false });
+        }
+      });
+    } finally {
+      invalidateOperatorRolePolicy(adminProfile.id);
+      invalidateOperatorRolePolicy(viewerProfile.id);
+    }
+  }, 60_000);
+});

--- a/src/gateway/server.tasks-list-performance.test.ts
+++ b/src/gateway/server.tasks-list-performance.test.ts
@@ -3,7 +3,13 @@ import { afterAll, describe, expect, test, vi } from "vitest";
 import type { TasksListResult } from "../../packages/gateway-protocol/src/index.js";
 import { writeConfigFile } from "../config/config.js";
 import { upsertSessionEntryCore } from "../config/sessions/session-accessor.js";
+import type { GatewayAuthConfig } from "../config/types.gateway.js";
 import { ensureProfileForEmail, setUserProfileRole } from "../state/user-profiles.js";
+import {
+  createTaskRecord,
+  deleteTaskRecordById,
+  markTaskTerminalById,
+} from "../tasks/runtime-internal.js";
 import { configureTaskRegistryRuntime } from "../tasks/task-registry.store.js";
 import type { TaskRecord } from "../tasks/task-registry.types.js";
 import { resetTaskRegistryForTests } from "../tasks/task-runtime.test-helpers.js";
@@ -25,15 +31,16 @@ const TASK_COUNT = 10_000;
 const OWNED_SESSION_KEY = "agent:main:tasks-owned";
 const FOREIGN_SESSION_KEY = "agent:main:tasks-foreign";
 
-type RpcResponse<T> = {
+type RpcResponse<T extends Record<string, unknown>> = {
   type: "res";
   id: string;
   ok: boolean;
   payload?: T;
   error?: { message?: string };
+  [key: string]: unknown;
 };
 
-function sendRpc<T>(
+function sendRpc<T extends Record<string, unknown>>(
   ws: Awaited<ReturnType<typeof openWs>>,
   id: string,
   method: string,
@@ -98,7 +105,7 @@ describe("tasks.list Gateway performance", () => {
     const foreignProfile = ensureProfileForEmail("foreign@example.com");
     setUserProfileRole(adminProfile.id, "maintainer");
     setUserProfileRole(viewerProfile.id, "restricted");
-    const auth = {
+    const auth: GatewayAuthConfig = {
       mode: "trusted-proxy" as const,
       identityScopes: {
         "admin@example.com": ["operator.admin"],
@@ -136,11 +143,15 @@ describe("tasks.list Gateway performance", () => {
     });
 
     const tasks = createTaskSnapshot();
-    const adminExpected = expectedTaskIds(tasks.values(), 13, 7);
     const ownedTasks = [...tasks.values()].filter(
       (task) => task.requesterSessionKey === OWNED_SESSION_KEY,
     );
     const viewerExpected = expectedTaskIds(ownedTasks, 10, 25);
+    const deletedTaskId = viewerExpected[0];
+    const updatedTask = ownedTasks.find((task) => !viewerExpected.includes(task.taskId));
+    if (!deletedTaskId || !updatedTask) {
+      throw new Error("expected selected and unselected owned task fixtures");
+    }
 
     try {
       await withGatewayServer(async ({ port }) => {
@@ -214,13 +225,38 @@ describe("tasks.list Gateway performance", () => {
         try {
           const completionOrder: string[] = [];
           let healthPromise: Promise<RpcResponse<Record<string, unknown>>> | undefined;
+          let mutationsApplied = false;
           onSnapshotLoad = () => {
-            healthPromise = sendRpc<Record<string, unknown>>(healthClient, "health", "health").then(
-              (response) => {
+            setImmediate(() => {
+              const updated = markTaskTerminalById({
+                taskId: updatedTask.taskId,
+                status: "succeeded",
+                endedAt: TASK_COUNT + 1,
+                lastEventAt: TASK_COUNT + 1,
+              });
+              const deleted = deleteTaskRecordById(deletedTaskId);
+              const created = createTaskRecord({
+                runtime: "cli",
+                requesterSessionKey: OWNED_SESSION_KEY,
+                requesterAgentId: "main",
+                ownerKey: OWNED_SESSION_KEY,
+                scopeKind: "session",
+                runId: "run-created-during-scan",
+                task: "Created during scan",
+                status: "running",
+                deliveryStatus: "pending",
+                lastEventAt: TASK_COUNT + 2,
+              });
+              mutationsApplied = updated !== null && deleted && created !== null;
+              healthPromise = sendRpc<Record<string, unknown>>(
+                healthClient,
+                "health",
+                "health",
+              ).then((response) => {
                 completionOrder.push("health");
                 return response;
-              },
-            );
+              });
+            });
           };
           const restrictedPromise = sendRpc<TasksListResult>(viewer, "tasks-owned", "tasks.list", {
             cursor: "10",
@@ -240,18 +276,9 @@ describe("tasks.list Gateway performance", () => {
             restricted.payload?.tasks.every((task) => task.sessionKey === OWNED_SESSION_KEY),
           ).toBe(true);
           expect(restricted.payload?.nextCursor).toBe("35");
+          expect(mutationsApplied).toBe(true);
           expect(completionOrder[0]).toBe("health");
           expect(Math.max(0, ...sortedInputLengths)).toBeLessThanOrEqual(35);
-
-          sortedInputLengths.length = 0;
-          const list = await sendRpc<TasksListResult>(admin, "tasks-list", "tasks.list", {
-            cursor: "13",
-            limit: 7,
-          });
-          expect(list.ok, JSON.stringify(list.error)).toBe(true);
-          expect(list.payload?.tasks.map((task) => task.id)).toEqual(adminExpected);
-          expect(list.payload?.nextCursor).toBe("20");
-          expect(Math.max(0, ...sortedInputLengths)).toBeLessThanOrEqual(20);
         } finally {
           sortSpy.mockRestore();
           admin.close();

--- a/src/gateway/server.tasks-list-performance.test.ts
+++ b/src/gateway/server.tasks-list-performance.test.ts
@@ -8,6 +8,7 @@ import { ensureProfileForEmail, setUserProfileRole } from "../state/user-profile
 import {
   createTaskRecord,
   deleteTaskRecordById,
+  listTaskRecordsUnsorted,
   markTaskTerminalById,
 } from "../tasks/runtime-internal.js";
 import { configureTaskRegistryRuntime } from "../tasks/task-registry.store.js";
@@ -36,7 +37,7 @@ type RpcResponse<T extends Record<string, unknown>> = {
   id: string;
   ok: boolean;
   payload?: T;
-  error?: { message?: string };
+  error?: { code?: string; message?: string };
   [key: string]: unknown;
 };
 
@@ -127,7 +128,7 @@ describe("tasks.list Gateway performance", () => {
           default: "restricted",
           definitions: {
             restricted: {
-              sessions: { others: "none" },
+              sessions: { others: "view" },
               agents: "*",
               scopes: ["operator.read"],
             },
@@ -146,9 +147,9 @@ describe("tasks.list Gateway performance", () => {
     const ownedTasks = [...tasks.values()].filter(
       (task) => task.requesterSessionKey === OWNED_SESSION_KEY,
     );
-    const viewerExpected = expectedTaskIds(ownedTasks, 10, 25);
-    const deletedTaskId = viewerExpected[0];
-    const updatedTask = ownedTasks.find((task) => !viewerExpected.includes(task.taskId));
+    const initialOwnedPage = expectedTaskIds(ownedTasks, 10, 25);
+    const deletedTaskId = initialOwnedPage[0];
+    const updatedTask = ownedTasks.find((task) => !initialOwnedPage.includes(task.taskId));
     if (!deletedTaskId || !updatedTask) {
       throw new Error("expected selected and unselected owned task fixtures");
     }
@@ -208,7 +209,6 @@ describe("tasks.list Gateway performance", () => {
           return ws;
         };
         const admin = await connect("admin@example.com", ["operator.admin"]);
-        const healthClient = await connect("admin@example.com", ["operator.admin"], "admin-health");
         const viewer = await connect("viewer@example.com", ["operator.read"]);
         const sortedInputLengths: number[] = [];
         const originalToSorted = Array.prototype.toSorted;
@@ -223,8 +223,6 @@ describe("tasks.list Gateway performance", () => {
           return Reflect.apply(originalToSorted, this, [compareFn]) as T[];
         });
         try {
-          const completionOrder: string[] = [];
-          let healthPromise: Promise<RpcResponse<Record<string, unknown>>> | undefined;
           let mutationsApplied = false;
           onSnapshotLoad = () => {
             setImmediate(() => {
@@ -248,27 +246,61 @@ describe("tasks.list Gateway performance", () => {
                 lastEventAt: TASK_COUNT + 2,
               });
               mutationsApplied = updated !== null && deleted && created !== null;
-              healthPromise = sendRpc<Record<string, unknown>>(
-                healthClient,
-                "health",
-                "health",
-              ).then((response) => {
-                completionOrder.push("health");
-                return response;
-              });
             });
           };
+          const listPromise = sendRpc<TasksListResult>(admin, "tasks-list", "tasks.list", {
+            cursor: "13",
+            limit: 7,
+          });
+          const list = await listPromise;
+
+          const listMaxSortedInput = Math.max(0, ...sortedInputLengths);
+          const currentTasks = listTaskRecordsUnsorted();
+          const adminExpected = expectedTaskIds(currentTasks, 13, 7);
+          expect(mutationsApplied).toBe(true);
+          expect(list.ok, JSON.stringify(list.error)).toBe(true);
+          expect(list.payload?.tasks.map((task) => task.id)).toEqual(adminExpected);
+          expect(list.payload?.nextCursor).toBe("20");
+          expect(listMaxSortedInput).toBeLessThanOrEqual(20);
+
+          const viewerExpected = expectedTaskIds(
+            currentTasks.filter((task) => task.requesterSessionKey === OWNED_SESSION_KEY),
+            10,
+            25,
+          );
+          sortedInputLengths.length = 0;
+          const accessOrder: string[] = [];
+          const visibilityPromise = new Promise<RpcResponse<Record<string, unknown>>>(
+            (resolve, reject) => {
+              setTimeout(() => {
+                void sendRpc<Record<string, unknown>>(
+                  admin,
+                  "session-visibility",
+                  "session.visibility.set",
+                  {
+                    sessionKey: FOREIGN_SESSION_KEY,
+                    agentId: "main",
+                    visibility: "draft",
+                  },
+                ).then((response) => {
+                  accessOrder.push("visibility");
+                  resolve(response);
+                }, reject);
+              }, 50);
+            },
+          );
           const restrictedPromise = sendRpc<TasksListResult>(viewer, "tasks-owned", "tasks.list", {
             cursor: "10",
             limit: 25,
           }).then((response) => {
-            completionOrder.push("tasks.list");
+            accessOrder.push("tasks.list");
             return response;
           });
-          const restricted = await restrictedPromise;
-          const health = await healthPromise;
-
-          expect(health?.ok).toBe(true);
+          const [restricted, visibility] = await Promise.all([
+            restrictedPromise,
+            visibilityPromise,
+          ]);
+          expect(visibility.ok, JSON.stringify(visibility.error)).toBe(true);
           expect(restricted.ok, JSON.stringify(restricted.error)).toBe(true);
           expect(restricted.payload?.tasks.map((task) => task.id)).toEqual(viewerExpected);
           expect(restricted.payload?.tasks).toHaveLength(25);
@@ -276,13 +308,107 @@ describe("tasks.list Gateway performance", () => {
             restricted.payload?.tasks.every((task) => task.sessionKey === OWNED_SESSION_KEY),
           ).toBe(true);
           expect(restricted.payload?.nextCursor).toBe("35");
-          expect(mutationsApplied).toBe(true);
-          expect(completionOrder[0]).toBe("health");
+          expect(accessOrder[0]).toBe("visibility");
           expect(Math.max(0, ...sortedInputLengths)).toBeLessThanOrEqual(35);
+
+          const churnTasks = createTaskSnapshot();
+          const churnTaskId = churnTasks.keys().next().value;
+          if (!churnTaskId) {
+            throw new Error("expected a task churn fixture");
+          }
+          resetTaskRegistryForTests({ persist: false });
+          let taskChurnActive = true;
+          let taskChurnStarted = false;
+          let taskChurnRevision = 0;
+          const churnTask = () => {
+            if (!taskChurnActive) {
+              return;
+            }
+            taskChurnRevision += 1;
+            markTaskTerminalById({
+              taskId: churnTaskId,
+              status: "succeeded",
+              endedAt: TASK_COUNT + 100 + taskChurnRevision,
+            });
+            setImmediate(churnTask);
+          };
+          configureTaskRegistryRuntime({
+            store: {
+              loadSnapshot: () => {
+                if (!taskChurnStarted) {
+                  taskChurnStarted = true;
+                  setImmediate(churnTask);
+                }
+                return { tasks: churnTasks, deliveryStates: new Map() };
+              },
+              saveSnapshot: () => {},
+            },
+          });
+          const unstableRegistry = await sendRpc<Record<string, unknown>>(
+            admin,
+            "tasks-unstable-registry",
+            "tasks.list",
+            { limit: 1 },
+          );
+          taskChurnActive = false;
+          await new Promise<void>((resolve) => {
+            setImmediate(resolve);
+          });
+          expect(taskChurnRevision).toBeGreaterThanOrEqual(3);
+          expect(unstableRegistry).toMatchObject({
+            ok: false,
+            error: { code: "UNAVAILABLE", message: expect.stringContaining("retry") },
+          });
+
+          const accessTasks = new Map([...createTaskSnapshot()].slice(0, 1_000));
+          resetTaskRegistryForTests({ persist: false });
+          configureTaskRegistryRuntime({
+            store: {
+              loadSnapshot: () => ({ tasks: accessTasks, deliveryStates: new Map() }),
+              saveSnapshot: () => {},
+            },
+          });
+          let accessChurnActive = true;
+          let accessMutationCount = 0;
+          const accessChurn = async () => {
+            while (true) {
+              if (!accessChurnActive) {
+                return;
+              }
+              const nextVisibility = accessMutationCount % 2 === 0 ? "shared" : "draft";
+              const response = await sendRpc<Record<string, unknown>>(
+                admin,
+                `visibility-churn-${accessMutationCount}`,
+                "session.visibility.set",
+                {
+                  sessionKey: FOREIGN_SESSION_KEY,
+                  agentId: "main",
+                  visibility: nextVisibility,
+                },
+              );
+              if (!response.ok) {
+                throw new Error(`visibility churn failed: ${response.error?.message}`);
+              }
+              accessMutationCount += 1;
+            }
+          };
+          const accessChurnPromise = accessChurn();
+          const unstableAccess = await sendRpc<Record<string, unknown>>(
+            viewer,
+            "tasks-unstable-access",
+            "tasks.list",
+            { limit: 1 },
+          );
+          accessChurnActive = false;
+          await accessChurnPromise;
+          expect(accessMutationCount).toBeGreaterThanOrEqual(3);
+          expect(unstableAccess).toMatchObject({
+            ok: false,
+            error: { code: "UNAVAILABLE", message: expect.stringContaining("retry") },
+          });
         } finally {
           sortSpy.mockRestore();
           admin.close();
-          healthClient.close();
           viewer.close();
           resetTaskRegistryForTests({ persist: false });
         }

--- a/src/gateway/session-sharing-snapshot-cache.ts
+++ b/src/gateway/session-sharing-snapshot-cache.ts
@@ -1,5 +1,6 @@
 import type { SessionVisibility } from "../../packages/gateway-protocol/src/index.js";
 import type { SessionCreatedActor } from "../config/sessions/session-entry-provenance.js";
+import { bumpGatewayAccessRevision } from "./gateway-access-revision.js";
 
 const SNAPSHOT_CACHE_LIMIT = 2_048;
 
@@ -87,6 +88,7 @@ function rememberSnapshotAlias(alias: string, canonical: string): void {
 }
 
 export function invalidateSessionSharingSnapshot(sessionKey?: string): void {
+  bumpGatewayAccessRevision();
   if (sessionKey) {
     // Mutation events carry the logical key without an agent id. These reverse indexes
     // preserve that cross-agent invalidation contract while keeping work proportional to

--- a/src/tasks/task-registry-mutation.ts
+++ b/src/tasks/task-registry-mutation.ts
@@ -21,6 +21,7 @@ import {
   addOwnerKeyIndex,
   addParentFlowIdIndex,
   addRelatedSessionKeyIndex,
+  bumpTaskRegistryRevision,
   deleteOwnerKeyIndex,
   deleteParentFlowIdIndex,
   deleteRelatedSessionKeyIndex,
@@ -189,6 +190,7 @@ export function updateTask(taskId: string, patch: Partial<TaskRecord>): TaskReco
     return null;
   }
   tasks.set(taskId, next);
+  bumpTaskRegistryRevision();
   if (becomesTerminal) {
     clearTaskActivity(taskId);
   }
@@ -240,6 +242,7 @@ export function publishTaskRecordAfterAtomicStore(record: TaskRecord): TaskRecor
     deleteRelatedSessionKeyIndex(next.taskId, current);
   }
   tasks.set(next.taskId, next);
+  bumpTaskRegistryRevision();
   if (becomesTerminal) {
     clearTaskActivity(next.taskId);
   }

--- a/src/tasks/task-registry-query.test.ts
+++ b/src/tasks/task-registry-query.test.ts
@@ -1,5 +1,10 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { listTaskRecordPage, resetTaskRegistryForTests } from "./task-registry-query.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import {
+  getTaskById,
+  listTaskRecordPage,
+  resetTaskRegistryForTests,
+} from "./task-registry-query.js";
 import { configureTaskRegistryRuntime } from "./task-registry.store.js";
 import type { TaskRecord } from "./task-registry.types.js";
 
@@ -7,19 +12,25 @@ afterEach(() => {
   resetTaskRegistryForTests({ persist: false });
 });
 
+function configureTaskSnapshot(tasks: Iterable<TaskRecord>): void {
+  const snapshotTasks = new Map([...tasks].map((task) => [task.taskId, task]));
+  configureTaskRegistryRuntime({
+    store: {
+      loadSnapshot: () => ({ tasks: snapshotTasks, deliveryStates: new Map() }),
+      saveSnapshot: () => {},
+    },
+  });
+}
+
 describe("listTaskRecordPage", () => {
-  it("sorts only the requested task page window", () => {
+  it("keeps large page scans responsive and sorts only the selected window", async () => {
     const total = 10_000;
+    const offset = 13;
+    const limit = 7;
     const snapshotTasks = new Map<string, TaskRecord>();
-    let expectedNewestTaskId = "";
-    let expectedNewestAt = -1;
     for (let index = 0; index < total; index += 1) {
       const taskId = `task-${String(index).padStart(5, "0")}`;
-      const lastEventAt = (index * 7_919) % total;
-      if (lastEventAt > expectedNewestAt) {
-        expectedNewestAt = lastEventAt;
-        expectedNewestTaskId = taskId;
-      }
+      const lastEventAt = Math.floor(((index * 7_919) % total) / 4);
       snapshotTasks.set(taskId, {
         taskId,
         runtime: "cli",
@@ -31,35 +42,133 @@ describe("listTaskRecordPage", () => {
         status: "succeeded",
         deliveryStatus: "not_applicable",
         notifyPolicy: "done_only",
-        createdAt: index,
-        startedAt: index,
+        createdAt: 0,
+        startedAt: 0,
         lastEventAt,
       });
     }
-    configureTaskRegistryRuntime({
-      store: {
-        loadSnapshot: () => ({ tasks: snapshotTasks, deliveryStates: new Map() }),
-        saveSnapshot: () => {},
-      },
-    });
+    const expectedTaskIds = [...snapshotTasks.values()]
+      .toSorted(
+        (left, right) =>
+          (right.lastEventAt ?? 0) - (left.lastEventAt ?? 0) ||
+          left.taskId.localeCompare(right.taskId),
+      )
+      .slice(offset, offset + limit)
+      .map((task) => task.taskId);
+    configureTaskSnapshot(snapshotTasks.values());
 
-    const originalToSorted = Array.prototype.toSorted;
-    const sortedInputLengths: number[] = [];
-    const sortSpy = vi.spyOn(Array.prototype, "toSorted").mockImplementation(function (
-      this: unknown[],
-      compareFn?: (left: unknown, right: unknown) => number,
-    ) {
-      sortedInputLengths.push(this.length);
-      return Reflect.apply(originalToSorted, this, [compareFn]) as unknown[];
-    } as typeof Array.prototype.toSorted);
+    let eventLoopTurnRan = false;
+    const sortSpy = vi.spyOn(Array.prototype, "toSorted");
     try {
-      const page = listTaskRecordPage({ offset: 0, limit: 1 });
+      setImmediate(() => {
+        eventLoopTurnRan = true;
+      });
+      const page = await listTaskRecordPage({ offset, limit });
 
-      expect(page.tasks.map((task) => task.taskId)).toEqual([expectedNewestTaskId]);
+      expect(page.tasks.map((task) => task.taskId)).toEqual(expectedTaskIds);
       expect(page.hasMore).toBe(true);
-      expect(sortedInputLengths).toEqual([1]);
+      expect(eventLoopTurnRan).toBe(true);
+      const taskSortSizes = sortSpy.mock.instances
+        .filter(
+          (values) =>
+            values.length > 0 &&
+            typeof values[0] === "object" &&
+            values[0] !== null &&
+            "taskId" in values[0],
+        )
+        .map((values) => values.length);
+      expect(Math.max(0, ...taskSortSizes)).toBeLessThanOrEqual(offset + limit);
+
+      sortSpy.mockClear();
+      const emptyPage = await listTaskRecordPage({ offset: total + 1, limit: 1 });
+      expect(emptyPage).toEqual({ tasks: [], hasMore: false });
+      expect(
+        sortSpy.mock.instances.filter(
+          (values) =>
+            values.length > 0 &&
+            typeof values[0] === "object" &&
+            values[0] !== null &&
+            "taskId" in values[0],
+        ),
+      ).toEqual([]);
     } finally {
       sortSpy.mockRestore();
     }
+  });
+
+  it("does not use the executor as the requester owner for a legacy bare task", async () => {
+    const task: TaskRecord = {
+      taskId: "task-legacy-owner",
+      runtime: "subagent",
+      requesterSessionKey: "global",
+      ownerKey: "global",
+      scopeKind: "session",
+      childSessionKey: "agent:research:subagent:child",
+      agentId: "research",
+      runId: "run-legacy-owner",
+      task: "Owned by ops, executed by research",
+      status: "running",
+      deliveryStatus: "pending",
+      notifyPolicy: "done_only",
+      createdAt: 1,
+    };
+    configureTaskSnapshot([task]);
+    const cfg = {
+      session: { scope: "global", store: "/tmp/shared-sessions.sqlite" },
+      agents: {
+        ownership: "explicit",
+        defaults: { sessionStore: { agentId: "ops" } },
+        entries: { ops: {}, research: {} },
+      },
+    } satisfies OpenClawConfig;
+
+    expect(
+      (
+        await listTaskRecordPage({
+          offset: 0,
+          limit: 10,
+          sessionKey: "global",
+          sessionAgentId: "ops",
+          cfg,
+        })
+      ).tasks.map((entry) => entry.taskId),
+    ).toEqual([task.taskId]);
+    expect(
+      (
+        await listTaskRecordPage({
+          offset: 0,
+          limit: 10,
+          sessionKey: "global",
+          sessionAgentId: "research",
+          cfg,
+        })
+      ).tasks,
+    ).toEqual([]);
+  });
+
+  it("returns page records isolated from the registry", async () => {
+    const task: TaskRecord = {
+      taskId: "task-isolated",
+      runtime: "cli",
+      requesterSessionKey: "agent:main:main",
+      ownerKey: "agent:main:main",
+      scopeKind: "session",
+      task: "Isolated task",
+      status: "running",
+      deliveryStatus: "pending",
+      notifyPolicy: "done_only",
+      createdAt: 1,
+      detail: { nested: { value: "original" } },
+    };
+    configureTaskSnapshot([task]);
+
+    const page = await listTaskRecordPage({ offset: 0, limit: 1 });
+    const detail = page.tasks[0]?.detail as { nested: { value: string } } | undefined;
+    expect(detail).toBeDefined();
+    if (detail) {
+      detail.nested.value = "mutated";
+    }
+
+    expect(getTaskById(task.taskId)?.detail).toEqual({ nested: { value: "original" } });
   });
 });

--- a/src/tasks/task-registry-query.test.ts
+++ b/src/tasks/task-registry-query.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { listTaskRecordPage, resetTaskRegistryForTests } from "./task-registry-query.js";
+import { configureTaskRegistryRuntime } from "./task-registry.store.js";
+import type { TaskRecord } from "./task-registry.types.js";
+
+afterEach(() => {
+  resetTaskRegistryForTests({ persist: false });
+});
+
+describe("listTaskRecordPage", () => {
+  it("sorts only the requested task page window", () => {
+    const total = 10_000;
+    const snapshotTasks = new Map<string, TaskRecord>();
+    let expectedNewestTaskId = "";
+    let expectedNewestAt = -1;
+    for (let index = 0; index < total; index += 1) {
+      const taskId = `task-${String(index).padStart(5, "0")}`;
+      const lastEventAt = (index * 7_919) % total;
+      if (lastEventAt > expectedNewestAt) {
+        expectedNewestAt = lastEventAt;
+        expectedNewestTaskId = taskId;
+      }
+      snapshotTasks.set(taskId, {
+        taskId,
+        runtime: "cli",
+        requesterSessionKey: "agent:main:main",
+        ownerKey: "agent:main:main",
+        scopeKind: "session",
+        runId: `run-${index}`,
+        task: "Bounded page selection",
+        status: "succeeded",
+        deliveryStatus: "not_applicable",
+        notifyPolicy: "done_only",
+        createdAt: index,
+        startedAt: index,
+        lastEventAt,
+      });
+    }
+    configureTaskRegistryRuntime({
+      store: {
+        loadSnapshot: () => ({ tasks: snapshotTasks, deliveryStates: new Map() }),
+        saveSnapshot: () => {},
+      },
+    });
+
+    const originalToSorted = Array.prototype.toSorted;
+    const sortedInputLengths: number[] = [];
+    const sortSpy = vi.spyOn(Array.prototype, "toSorted").mockImplementation(function (
+      this: unknown[],
+      compareFn?: (left: unknown, right: unknown) => number,
+    ) {
+      sortedInputLengths.push(this.length);
+      return Reflect.apply(originalToSorted, this, [compareFn]) as unknown[];
+    } as typeof Array.prototype.toSorted);
+    try {
+      const page = listTaskRecordPage({ offset: 0, limit: 1 });
+
+      expect(page.tasks.map((task) => task.taskId)).toEqual([expectedNewestTaskId]);
+      expect(page.hasMore).toBe(true);
+      expect(sortedInputLengths).toEqual([1]);
+    } finally {
+      sortSpy.mockRestore();
+    }
+  });
+});

--- a/src/tasks/task-registry-query.test.ts
+++ b/src/tasks/task-registry-query.test.ts
@@ -58,7 +58,18 @@ describe("listTaskRecordPage", () => {
     configureTaskSnapshot(snapshotTasks.values());
 
     let eventLoopTurnRan = false;
-    const sortSpy = vi.spyOn(Array.prototype, "toSorted");
+    const sortedInputLengths: number[] = [];
+    const originalToSorted = Array.prototype.toSorted;
+    const sortSpy = vi.spyOn(Array.prototype, "toSorted").mockImplementation(function <T>(
+      this: T[],
+      compareFn?: (left: T, right: T) => number,
+    ): T[] {
+      const first = this[0];
+      if (first && typeof first === "object" && "taskId" in first) {
+        sortedInputLengths.push(this.length);
+      }
+      return Reflect.apply(originalToSorted, this, [compareFn]) as T[];
+    });
     try {
       setImmediate(() => {
         eventLoopTurnRan = true;
@@ -68,29 +79,12 @@ describe("listTaskRecordPage", () => {
       expect(page.tasks.map((task) => task.taskId)).toEqual(expectedTaskIds);
       expect(page.hasMore).toBe(true);
       expect(eventLoopTurnRan).toBe(true);
-      const taskSortSizes = sortSpy.mock.instances
-        .filter(
-          (values) =>
-            values.length > 0 &&
-            typeof values[0] === "object" &&
-            values[0] !== null &&
-            "taskId" in values[0],
-        )
-        .map((values) => values.length);
-      expect(Math.max(0, ...taskSortSizes)).toBeLessThanOrEqual(offset + limit);
+      expect(Math.max(0, ...sortedInputLengths)).toBeLessThanOrEqual(offset + limit);
 
-      sortSpy.mockClear();
+      sortedInputLengths.length = 0;
       const emptyPage = await listTaskRecordPage({ offset: total + 1, limit: 1 });
       expect(emptyPage).toEqual({ tasks: [], hasMore: false });
-      expect(
-        sortSpy.mock.instances.filter(
-          (values) =>
-            values.length > 0 &&
-            typeof values[0] === "object" &&
-            values[0] !== null &&
-            "taskId" in values[0],
-        ),
-      ).toEqual([]);
+      expect(sortedInputLengths).toEqual([]);
     } finally {
       sortSpy.mockRestore();
     }

--- a/src/tasks/task-registry-query.test.ts
+++ b/src/tasks/task-registry-query.test.ts
@@ -22,6 +22,15 @@ function configureTaskSnapshot(tasks: Iterable<TaskRecord>): void {
   });
 }
 
+async function readTaskPage(params: Parameters<typeof listTaskRecordPage>[0]) {
+  const result = await listTaskRecordPage(params);
+  expect(result.ok).toBe(true);
+  if (!result.ok) {
+    throw new Error(`task page failed: ${result.error}`);
+  }
+  return result.value;
+}
+
 describe("listTaskRecordPage", () => {
   it("keeps large page scans responsive and sorts only the selected window", async () => {
     const total = 10_000;
@@ -74,7 +83,7 @@ describe("listTaskRecordPage", () => {
       setImmediate(() => {
         eventLoopTurnRan = true;
       });
-      const page = await listTaskRecordPage({ offset, limit });
+      const page = await readTaskPage({ offset, limit });
 
       expect(page.tasks.map((task) => task.taskId)).toEqual(expectedTaskIds);
       expect(page.hasMore).toBe(true);
@@ -82,7 +91,7 @@ describe("listTaskRecordPage", () => {
       expect(Math.max(0, ...sortedInputLengths)).toBeLessThanOrEqual(offset + limit);
 
       sortedInputLengths.length = 0;
-      const emptyPage = await listTaskRecordPage({ offset: total + 1, limit: 1 });
+      const emptyPage = await readTaskPage({ offset: total + 1, limit: 1 });
       expect(emptyPage).toEqual({ tasks: [], hasMore: false });
       expect(sortedInputLengths).toEqual([]);
     } finally {
@@ -118,7 +127,7 @@ describe("listTaskRecordPage", () => {
 
     expect(
       (
-        await listTaskRecordPage({
+        await readTaskPage({
           offset: 0,
           limit: 10,
           sessionKey: "global",
@@ -129,7 +138,7 @@ describe("listTaskRecordPage", () => {
     ).toEqual([task.taskId]);
     expect(
       (
-        await listTaskRecordPage({
+        await readTaskPage({
           offset: 0,
           limit: 10,
           sessionKey: "global",
@@ -156,7 +165,7 @@ describe("listTaskRecordPage", () => {
     };
     configureTaskSnapshot([task]);
 
-    const page = await listTaskRecordPage({ offset: 0, limit: 1 });
+    const page = await readTaskPage({ offset: 0, limit: 1 });
     const detail = page.tasks[0]?.detail as { nested: { value: string } } | undefined;
     expect(detail).toBeDefined();
     if (detail) {

--- a/src/tasks/task-registry-query.ts
+++ b/src/tasks/task-registry-query.ts
@@ -1,4 +1,5 @@
 import { setImmediate as yieldToEventLoop } from "node:timers/promises";
+import { err, ok, type Result } from "@openclaw/normalization-core/result";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { clearTaskActivity } from "./task-registry-activity.js";
@@ -8,6 +9,7 @@ import { cloneTaskRecord, normalizeTaskTimestamps } from "./task-registry-record
 import {
   TASK_REGISTRY_CONTROL_RUNTIME_OVERRIDE_KEY,
   TASK_REGISTRY_DELIVERY_RUNTIME_OVERRIDE_KEY,
+  bumpTaskRegistryRevision,
   clearTaskRegistryMemory,
   compareTasksNewestFirst,
   controlRuntimeLoader,
@@ -21,6 +23,7 @@ import {
   taskRegistryLog,
   persistTaskRegistry,
   pickPreferredRunIdTask,
+  readTaskRegistryRevision,
   rebuildRunIdIndex,
   resetTaskRegistryListenerState,
   resetTaskRegistryRestoreState,
@@ -133,6 +136,8 @@ function heapifyWorstTaskFirst(heap: TaskRecord[]): void {
   }
 }
 
+const TASK_PAGE_MAX_ATTEMPTS = 3;
+
 export async function listTaskRecordPage(params: {
   offset: number;
   limit: number;
@@ -142,7 +147,7 @@ export async function listTaskRecordPage(params: {
   sessionAgentId?: string;
   cfg?: OpenClawConfig;
   filter?: (task: Readonly<TaskRecord>) => boolean;
-}): Promise<{ tasks: TaskRecord[]; hasMore: boolean }> {
+}): Promise<Result<{ tasks: TaskRecord[]; hasMore: boolean }, "registry_changed">> {
   ensureTaskRegistryReady();
   const statuses = params.statuses ? new Set(params.statuses) : null;
   const agentId = normalizeOptionalString(params.agentId);
@@ -150,54 +155,62 @@ export async function listTaskRecordPage(params: {
   // Filtering and ordering stay registry-owned so authoritative records never
   // cross the boundary; only the bounded selected page is defensively cloned.
   const windowSize = params.offset + params.limit;
-  const window: TaskRecord[] = [];
-  let matchingCount = 0;
-  let heapReady = false;
-  let scannedCount = 0;
-  // Registry updates replace records. Freeze references before yielding so one
-  // page sees stable membership and values without cloning or sorting them all.
-  const taskSnapshot = [...tasks.values()];
-  for (const task of taskSnapshot) {
-    scannedCount += 1;
-    // Yield large scans in small deterministic slices so task history cannot
-    // monopolize the Gateway event loop while other requests are waiting.
-    if (scannedCount % 32 === 0) {
-      await yieldToEventLoop();
+  for (let attempt = 0; attempt < TASK_PAGE_MAX_ATTEMPTS; attempt += 1) {
+    const revision = readTaskRegistryRevision();
+    const scanLimit = tasks.size;
+    const window: TaskRecord[] = [];
+    let matchingCount = 0;
+    let heapReady = false;
+    let scannedCount = 0;
+    for (const task of tasks.values()) {
+      if (scannedCount >= scanLimit) {
+        break;
+      }
+      scannedCount += 1;
+      // Yield large scans in small deterministic slices so task history cannot
+      // monopolize the Gateway event loop while other requests are waiting.
+      if (scannedCount % 32 === 0) {
+        await yieldToEventLoop();
+      }
+      if (
+        (statuses && !statuses.has(task.status)) ||
+        !taskMatchesAgent(task, agentId, params.cfg) ||
+        !taskMatchesRelatedSession(task, sessionKey, params.sessionAgentId, params.cfg) ||
+        (params.filter && !params.filter(task))
+      ) {
+        continue;
+      }
+      matchingCount += 1;
+      if (windowSize <= 0) {
+        continue;
+      }
+      if (window.length < windowSize) {
+        window.push(task);
+        continue;
+      }
+      if (!heapReady) {
+        heapifyWorstTaskFirst(window);
+        heapReady = true;
+      }
+      const cutoff = window[0];
+      if (cutoff && compareTaskPageOrder(task, cutoff) < 0) {
+        window[0] = task;
+        siftWorstTaskDown(window, 0);
+      }
     }
-    if (
-      (statuses && !statuses.has(task.status)) ||
-      !taskMatchesAgent(task, agentId, params.cfg) ||
-      !taskMatchesRelatedSession(task, sessionKey, params.sessionAgentId, params.cfg) ||
-      (params.filter && !params.filter(task))
-    ) {
+    if (revision !== readTaskRegistryRevision()) {
       continue;
     }
-    matchingCount += 1;
-    if (windowSize <= 0) {
-      continue;
+    if (params.offset >= matchingCount) {
+      return ok({ tasks: [], hasMore: false });
     }
-    if (window.length < windowSize) {
-      window.push(task);
-      continue;
-    }
-    if (!heapReady) {
-      heapifyWorstTaskFirst(window);
-      heapReady = true;
-    }
-    const cutoff = window[0];
-    if (cutoff && compareTaskPageOrder(task, cutoff) < 0) {
-      window[0] = task;
-      siftWorstTaskDown(window, 0);
-    }
+    const selected = window.toSorted(compareTaskPageOrder).slice(params.offset);
+    return ok({
+      tasks: selected.map((task) => cloneTaskRecord(task)),
+      hasMore: params.offset + selected.length < matchingCount,
+    });
   }
-  if (params.offset >= matchingCount) {
-    return { tasks: [], hasMore: false };
-  }
-  const selected = window.toSorted(compareTaskPageOrder).slice(params.offset);
-  return {
-    tasks: selected.map((task) => cloneTaskRecord(task)),
-    hasMore: params.offset + selected.length < matchingCount,
-  };
+  return err("registry_changed");
 }
 
 export function listTaskRecords(filter?: (task: Readonly<TaskRecord>) => boolean): TaskRecord[] {
@@ -384,6 +397,7 @@ export function deleteTaskRecordById(taskId: string): boolean {
   deleteRelatedSessionKeyIndex(taskId, current);
   clearTaskActivity(taskId);
   tasks.delete(taskId);
+  bumpTaskRegistryRevision();
   taskDeliveryStates.delete(taskId);
   rebuildRunIdIndex();
   emitTaskRegistryObserverEvent(() => ({

--- a/src/tasks/task-registry-query.ts
+++ b/src/tasks/task-registry-query.ts
@@ -154,13 +154,10 @@ export async function listTaskRecordPage(params: {
   let matchingCount = 0;
   let heapReady = false;
   let scannedCount = 0;
-  // Freeze the scan length so tasks appended while this request yields cannot
-  // extend one bounded page request indefinitely.
-  const scanLimit = tasks.size;
-  for (const task of tasks.values()) {
-    if (scannedCount >= scanLimit) {
-      break;
-    }
+  // Registry updates replace records. Freeze references before yielding so one
+  // page sees stable membership and values without cloning or sorting them all.
+  const taskSnapshot = [...tasks.values()];
+  for (const task of taskSnapshot) {
     scannedCount += 1;
     // Yield large scans in small deterministic slices so task history cannot
     // monopolize the Gateway event loop while other requests are waiting.

--- a/src/tasks/task-registry-query.ts
+++ b/src/tasks/task-registry-query.ts
@@ -1,3 +1,4 @@
+import { setImmediate as yieldToEventLoop } from "node:timers/promises";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { clearTaskActivity } from "./task-registry-activity.js";
@@ -132,7 +133,7 @@ function heapifyWorstTaskFirst(heap: TaskRecord[]): void {
   }
 }
 
-export function listTaskRecordPage(params: {
+export async function listTaskRecordPage(params: {
   offset: number;
   limit: number;
   statuses?: readonly TaskStatus[];
@@ -141,7 +142,7 @@ export function listTaskRecordPage(params: {
   sessionAgentId?: string;
   cfg?: OpenClawConfig;
   filter?: (task: Readonly<TaskRecord>) => boolean;
-}): { tasks: TaskRecord[]; hasMore: boolean } {
+}): Promise<{ tasks: TaskRecord[]; hasMore: boolean }> {
   ensureTaskRegistryReady();
   const statuses = params.statuses ? new Set(params.statuses) : null;
   const agentId = normalizeOptionalString(params.agentId);
@@ -152,7 +153,20 @@ export function listTaskRecordPage(params: {
   const window: TaskRecord[] = [];
   let matchingCount = 0;
   let heapReady = false;
+  let scannedCount = 0;
+  // Freeze the scan length so tasks appended while this request yields cannot
+  // extend one bounded page request indefinitely.
+  const scanLimit = tasks.size;
   for (const task of tasks.values()) {
+    if (scannedCount >= scanLimit) {
+      break;
+    }
+    scannedCount += 1;
+    // Yield large scans in small deterministic slices so task history cannot
+    // monopolize the Gateway event loop while other requests are waiting.
+    if (scannedCount % 32 === 0) {
+      await yieldToEventLoop();
+    }
     if (
       (statuses && !statuses.has(task.status)) ||
       !taskMatchesAgent(task, agentId, params.cfg) ||
@@ -178,6 +192,9 @@ export function listTaskRecordPage(params: {
       window[0] = task;
       siftWorstTaskDown(window, 0);
     }
+  }
+  if (params.offset >= matchingCount) {
+    return { tasks: [], hasMore: false };
   }
   const selected = window.toSorted(compareTaskPageOrder).slice(params.offset);
   return {

--- a/src/tasks/task-registry-query.ts
+++ b/src/tasks/task-registry-query.ts
@@ -90,6 +90,48 @@ function taskUpdatedAt(task: TaskRecord): number {
   return task.lastEventAt ?? task.endedAt ?? task.startedAt ?? task.createdAt;
 }
 
+function compareTaskPageOrder(left: TaskRecord, right: TaskRecord): number {
+  const updatedDiff = taskUpdatedAt(right) - taskUpdatedAt(left);
+  if (updatedDiff !== 0) {
+    return updatedDiff;
+  }
+  return left.taskId < right.taskId ? -1 : left.taskId > right.taskId ? 1 : 0;
+}
+
+function siftWorstTaskDown(heap: TaskRecord[], startIndex: number): void {
+  let index = startIndex;
+  while (true) {
+    const leftIndex = index * 2 + 1;
+    if (leftIndex >= heap.length) {
+      return;
+    }
+    const left = heap[leftIndex];
+    const current = heap[index];
+    if (!left || !current) {
+      return;
+    }
+    const rightIndex = leftIndex + 1;
+    let worstIndex = leftIndex;
+    const right = heap[rightIndex];
+    if (right && compareTaskPageOrder(right, left) > 0) {
+      worstIndex = rightIndex;
+    }
+    const worst = heap[worstIndex];
+    if (!worst || compareTaskPageOrder(worst, current) <= 0) {
+      return;
+    }
+    heap[index] = worst;
+    heap[worstIndex] = current;
+    index = worstIndex;
+  }
+}
+
+function heapifyWorstTaskFirst(heap: TaskRecord[]): void {
+  for (let index = Math.floor(heap.length / 2) - 1; index >= 0; index -= 1) {
+    siftWorstTaskDown(heap, index);
+  }
+}
+
 export function listTaskRecordPage(params: {
   offset: number;
   limit: number;
@@ -106,25 +148,41 @@ export function listTaskRecordPage(params: {
   const sessionKey = normalizeOptionalString(params.sessionKey);
   // Filtering and ordering stay registry-owned so authoritative records never
   // cross the boundary; only the bounded selected page is defensively cloned.
-  const matching = [...tasks.values()]
-    .filter(
-      (task) =>
-        (!statuses || statuses.has(task.status)) &&
-        taskMatchesAgent(task, agentId, params.cfg) &&
-        taskMatchesRelatedSession(task, sessionKey, params.sessionAgentId, params.cfg) &&
-        (!params.filter || params.filter(task)),
-    )
-    .toSorted((left, right) => {
-      const updatedDiff = taskUpdatedAt(right) - taskUpdatedAt(left);
-      if (updatedDiff !== 0) {
-        return updatedDiff;
-      }
-      return left.taskId < right.taskId ? -1 : left.taskId > right.taskId ? 1 : 0;
-    });
-  const selected = matching.slice(params.offset, params.offset + params.limit);
+  const windowSize = params.offset + params.limit;
+  const window: TaskRecord[] = [];
+  let matchingCount = 0;
+  let heapReady = false;
+  for (const task of tasks.values()) {
+    if (
+      (statuses && !statuses.has(task.status)) ||
+      !taskMatchesAgent(task, agentId, params.cfg) ||
+      !taskMatchesRelatedSession(task, sessionKey, params.sessionAgentId, params.cfg) ||
+      (params.filter && !params.filter(task))
+    ) {
+      continue;
+    }
+    matchingCount += 1;
+    if (windowSize <= 0) {
+      continue;
+    }
+    if (window.length < windowSize) {
+      window.push(task);
+      continue;
+    }
+    if (!heapReady) {
+      heapifyWorstTaskFirst(window);
+      heapReady = true;
+    }
+    const cutoff = window[0];
+    if (cutoff && compareTaskPageOrder(task, cutoff) < 0) {
+      window[0] = task;
+      siftWorstTaskDown(window, 0);
+    }
+  }
+  const selected = window.toSorted(compareTaskPageOrder).slice(params.offset);
   return {
     tasks: selected.map((task) => cloneTaskRecord(task)),
-    hasMore: params.offset + selected.length < matching.length,
+    hasMore: params.offset + selected.length < matchingCount,
   };
 }
 

--- a/src/tasks/task-registry-record-api.ts
+++ b/src/tasks/task-registry-record-api.ts
@@ -34,6 +34,7 @@ import {
   addParentFlowIdIndex,
   addRelatedSessionKeyIndex,
   addRunIdIndex,
+  bumpTaskRegistryRevision,
   emitTaskRegistryObserverEvent,
   ensureTaskRegistryReady,
   getTasksByRunScope,
@@ -280,6 +281,7 @@ export function createTaskRecord(params: {
     return null;
   }
   tasks.set(taskId, record);
+  bumpTaskRegistryRevision();
   if (requesterOrigin) {
     taskDeliveryStates.set(taskId, deliveryState!);
   }

--- a/src/tasks/task-registry-state.ts
+++ b/src/tasks/task-registry-state.ts
@@ -22,6 +22,24 @@ export const taskRegistryLog = createSubsystemLogger("tasks/registry");
 export const TASK_FLOW_SYNC_RETRY_DELAYS_MS = [1_000, 5_000, 25_000, 120_000, 600_000] as const;
 
 const taskRegistryProcessState = getTaskRegistryProcessState();
+const TASK_REGISTRY_REVISION_KEY = Symbol.for("openclaw.taskRegistry.revision");
+type TaskRegistryRevisionGlobal = typeof globalThis & {
+  [TASK_REGISTRY_REVISION_KEY]?: { value: number };
+};
+// SAFETY: This symbol owns the process-global revision cell assigned below.
+const taskRegistryRevisionGlobal = globalThis as TaskRegistryRevisionGlobal;
+const taskRegistryRevisionState = (taskRegistryRevisionGlobal[TASK_REGISTRY_REVISION_KEY] ??= {
+  value: 0,
+});
+
+export function readTaskRegistryRevision(): number {
+  return taskRegistryRevisionState.value;
+}
+
+export function bumpTaskRegistryRevision(): void {
+  taskRegistryRevisionState.value += 1;
+}
+
 export const tasks = taskRegistryProcessState.tasks;
 export const taskDeliveryStates = taskRegistryProcessState.taskDeliveryStates;
 const taskIdsByRunId = taskRegistryProcessState.taskIdsByRunId;
@@ -259,6 +277,7 @@ export function clearTaskRegistryMemory(): void {
   }
   taskActivityByTaskId.clear();
   tasks.clear();
+  bumpTaskRegistryRevision();
   taskDeliveryStates.clear();
   taskIdsByRunId.clear();
   taskIdsByOwnerKey.clear();


### PR DESCRIPTION
Related: #101716

Alternative considered: #132709

## What Problem This Solves

Large task histories can make every bounded `tasks.list` request filter and sort the full matching registry before returning one small page. That work can block the Gateway event loop and delay unrelated requests.

## Why This Change Was Made

The task registry scans the live Map directly under a revision fence and feeds only the best `offset + limit` records into a bounded worst-first heap. If the revision changes, it retries the bounded scan. It does not clone, materialize, or sort the full matching history.

The repair preserves the existing last-activity order, task-ID tie break, access checks, filter shapes, offset cursor, `hasMore`, and response schema. A past-end cursor returns without sorting. Each capture attempt freezes its scan length so appended tasks cannot extend one attempt indefinitely.

Gateway access invalidations also carry a revision. If session sharing or an operator role changes during the scan, `tasks.list` reruns selection and synchronously revalidates the selected rows before responding.

Both revision paths stop after three unstable attempts. Sustained task or access churn returns an explicit `UNAVAILABLE` result that tells the caller to retry instead of leaving the request pending.

This keeps selection and ordering in the registry owner. It does not add configuration, protocol fields, SQLite schema, or persistent state.

## User Impact

Small task pages stay responsive with large histories. Operators see the same tasks in the same order with the same cursors and access rules.

## Evidence

- Exact current-main red revision at repair start: `eed74eefd336804f7f09ff52ff2fa15fbca244c0`
- Exact authenticated-WebSocket red revision: `b057afec5e82814f0f7d4d9cfff535c7c2fde8f1`
- Exact repaired head: `0bedf75b8dbe5a96b8ca214e8aa0a860bc879e0a`
- Product path: authenticated Gateway WebSocket `tasks.list`, with `health` sent by a second authenticated client while the task page is scanned
- Current-main owner change `d56aacd6991b4c552fe1bd71b3d061034a70906b` was absorbed before the final proof
- Dataset: 10,000 deterministic task records with every status, two agents, related sessions, four-row activity ties, timestamp fallbacks, nonzero offsets, and restricted session access
- First page, `limit=1`: main sorted 10,000 records with 105,539 comparator calls and did not yield; head sorted 1 record with 0 comparator calls and yielded before response
- Nonzero page, `cursor=13`, `limit=7`: main sorted 10,000 records; head sorted 20 records; IDs and `nextCursor=20` matched
- Restricted page, `cursor=10`, `limit=25`: 5,000 records were authorized; main sorted all 5,000; head sorted 35; both returned the same 25 IDs and `nextCursor=35`; zero foreign rows crossed the filter; head yielded before response
- Past-end page: main sorted 10,000 records; head sorted 0
- 100,000-record head probe: 100,000 filter calls, largest sort 20, 63 comparator calls, exact page result, and an event-loop turn before response
- Authenticated WebSocket regression on main: failed because `tasks.list` completed before the second client’s `health` response
- Authenticated WebSocket regression on head: passed; `health` completed first while the task page kept the same authorized rows, ordering, and cursor
- Interleaving regression: the previous yielded head mixed task generations when one row updated, one selected row was deleted, and one newer row was created; the repaired head preserves the original 25-row page while those mutations and the health request run
- Access-revocation regression: a foreign shared session becomes draft during the scan; the visibility change completes before `tasks.list`, and the response contains only the currently authorized rows with the correct cursor
- Sustained-churn regressions: continuous task revisions and continuous authenticated visibility changes both finish with bounded `UNAVAILABLE` retry results instead of hanging
- Focused tests on head: 34 passed
- Focused Oxlint and Oxfmt checks: passed
- Conflict-marker, max-lines, assertion-safety, coercion-helper, and import-cycle ratchets: passed
- Production delta: +155 lines; the heap, finite revision-fenced scan, access revalidation, explicit churn failure, and bounded event-loop scheduling are the new capability and no existing helper or dependency provides this owner-specific selection contract
- Tests and test-owner cleanup: +528 net lines; the authenticated WebSocket regression covers dispatch, auth, access revocation, ordering, pagination, finite sustained churn, mutation interleaving, and event-loop availability; two direct registry tests moved out of the oversized Gateway test file

<details>
<summary>AI assistance</summary>

This PR was prepared with Codex assistance. The exact-main reproduction, deterministic handler matrix, focused tests, lint checks, repository ratchets, overlap comparison, and proof artifacts were verified directly.

</details>
