### PR TITLE
fix(agents): report early Bash output spill failures without crashing

### DIFF
--- a/src/agents/sessions/bash-executor.test.ts
+++ b/src/agents/sessions/bash-executor.test.ts
@@ -2,6 +2,10 @@
 import { readFile, rm, stat } from "node:fs/promises";
 import { describe, expect, it } from "vitest";
 import { executeBashWithOperations } from "./bash-executor.js";
+import {
+  expectNativeBashSpill,
+  nativeBashSpillScenarios,
+} from "./bash-output-spill.test-support.js";
 import type { BashOperations } from "./tools/bash-operations.js";
 import { DEFAULT_MAX_BYTES } from "./tools/truncate.js";
 
@@ -21,6 +25,13 @@ function operationsForChunks(chunks: readonly OutputChunk[]): BashOperations {
 }
 
 describe("executeBashWithOperations", () => {
+  it.runIf(process.platform !== "win32").each(nativeBashSpillScenarios)(
+    "settles real Bash output for %s",
+    async (scenario) => {
+      await expectNativeBashSpill("executor", scenario);
+    },
+  );
+
   it("stores truncated full output in an owner-only temp file", async () => {
     const sanitizedOutput = "secret output\n".repeat(9000);
     const operations: BashOperations = {

--- a/src/agents/sessions/bash-output-spill.test-support.ts
+++ b/src/agents/sessions/bash-output-spill.test-support.ts
@@ -250,10 +250,12 @@ export async function expectNativeBashSpill(
     try {
       await writeFile(join(root, "release"), "release", { flag: "wx", mode: 0o600 });
     } catch (error) {
-      if (!(error instanceof Error && "code" in error && error.code === "EEXIST")) throw error;
+      if (!(error instanceof Error && "code" in error && error.code === "EEXIST")) {
+        throw error;
+      }
     }
     const producer = JSON.parse(
-      await readFile(join(root, "producer.json"), "utf8").catch((error) => {
+      await readFile(join(root, "producer.json"), "utf8").catch((error: unknown) => {
         throw new Error(
           `Missing producer receipt after child status ${result.status}: ${result.stderr}`,
           { cause: error },

--- a/src/agents/sessions/bash-output-spill.test-support.ts
+++ b/src/agents/sessions/bash-output-spill.test-support.ts
@@ -1,0 +1,288 @@
+import { mkdir, mkdtemp, readFile, realpath, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { expect, vi } from "vitest";
+import { spawnNodeEvalSync } from "../../test-utils/node-process.js";
+import { waitForPidToExit } from "../../test-utils/process-tree.js";
+
+export const nativeBashSpillScenarios = ["fault-large", "writable-large", "fault-small"] as const;
+
+const producerSource = String.raw`
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+const [control, size, tracePath] = process.argv.slice(2);
+let traceCount = 0;
+function trace(phase, fields = {}) {
+  const line = JSON.stringify({ actor: "producer", phase, at: Date.now(), ...fields }) + "\n";
+  assert(++traceCount <= 32 && Buffer.byteLength(line) <= 512, "producer trace exceeded bound");
+  fs.appendFileSync(tracePath, line);
+}
+let written = false;
+let finished = false;
+const timer = setTimeout(() => {
+  fs.writeFileSync(path.join(control, "deadline"), "deadline");
+  trace("deadline", { written, finished, releasePresent: fs.existsSync(path.join(control, "release")) });
+  process.exit(92);
+}, 5000);
+function advance() {
+  if (!written || finished || !fs.existsSync(path.join(control, "release"))) return;
+  finished = true;
+  trace("release-observed");
+  trace("final-write-started");
+  process.stdout.write("FINAL: preserve Ω🙂\n", () => {
+    fs.writeFileSync(path.join(control, "completed"), "completed");
+    trace("completed");
+    clearTimeout(timer);
+    clearInterval(readiness);
+  });
+}
+// Read the owned marker: filesystem notifications can miss a release entirely.
+const readiness = setInterval(advance, 5);
+const pgid = Number(execFileSync("/bin/ps", ["-p", String(process.pid), "-o", "pgid="], {
+  encoding: "utf8", timeout: 1000, env: { PATH: "/usr/bin:/bin", LC_ALL: "C" },
+}).trim());
+assert.equal(pgid, process.pid);
+fs.writeFileSync(path.join(control, "producer.json"), JSON.stringify({
+  pid: process.pid, ppid: process.ppid, pgid, control,
+}), { flag: "wx", mode: 0o600 });
+trace("ready", { pid: process.pid, ppid: process.ppid, pgid });
+const prefix = size === "large" ? "BEGIN:large\n" + "x".repeat(60 * 1024) + "\n" : "BEGIN:small\n";
+trace("prefix-write-started", { bytes: Buffer.byteLength(prefix) });
+process.stdout.write(prefix, () => { written = true; trace("prefix-written"); advance(); });
+`;
+
+const caseSource = String.raw`
+import assert from "node:assert/strict";
+import { errorMonitor } from "node:events";
+import fs from "node:fs";
+import { syncBuiltinESMExports } from "node:module";
+import os from "node:os";
+import path from "node:path";
+const { root, tracePath, entrypoint, scenario, toolUrl, executorUrl } = fixture;
+let traceCount = 0;
+function trace(phase, fields = {}) {
+  const line = JSON.stringify({ actor: "runner", phase, at: Date.now(), ...fields }) + "\n";
+  assert(++traceCount <= 32 && Buffer.byteLength(line) <= 512, "runner trace exceeded bound");
+  fs.appendFileSync(tracePath, line);
+}
+const { createBashTool, createLocalBashOperations } = await import(toolUrl);
+const { executeBashWithOperations } = await import(executorUrl);
+trace("imports-ready");
+assert.equal(process.listenerCount("uncaughtException"), 0);
+assert.equal(process.listenerCount("unhandledRejection"), 0);
+assert.equal(process.hasUncaughtExceptionCaptureCallback(), false);
+const fault = scenario.startsWith("fault");
+const small = scenario.endsWith("small");
+const spillRoot = path.join(root, fault ? "missing" : "spill");
+if (!fault) fs.mkdirSync(spillRoot, { mode: 0o700 });
+process.env.TMPDIR = process.env.TMP = process.env.TEMP = spillRoot;
+assert.equal(os.tmpdir(), spillRoot);
+assert.equal(fs.existsSync(spillRoot), !fault);
+let released = false;
+let settled = false;
+let nativeError;
+let observerFailed = false;
+let creations = 0;
+let prefix = "";
+function release() {
+  if (released) return;
+  fs.writeFileSync(path.join(root, "release"), "release", { flag: "wx", mode: 0o600 });
+  released = true;
+  trace("release-created");
+}
+function observe(action) {
+  // A receipt failure must not replace the native stream error under test.
+  try { action(); } catch { observerFailed = true; }
+}
+function producerAlive() {
+  const producer = JSON.parse(fs.readFileSync(path.join(root, "producer.json"), "utf8"));
+  assert.equal(producer.control, root);
+  assert.equal(producer.ppid, process.pid);
+  assert.equal(producer.pgid, producer.pid);
+  process.kill(producer.pid, 0);
+  assert.equal(settled, false);
+  return producer.pid;
+}
+function onText(text) {
+  prefix = (prefix + text).slice(-64);
+  if (small && prefix.includes("BEGIN:small")) release();
+}
+const createWriteStream = fs.createWriteStream;
+fs.createWriteStream = function (...args) {
+  const stream = Reflect.apply(createWriteStream, this, args);
+  creations++;
+  observe(() => {
+    assert(stream instanceof fs.WriteStream);
+    assert.equal(path.dirname(String(args[0])), spillRoot);
+    trace("stream-created", { creations, settled });
+  });
+  stream.once(errorMonitor, (error) => observe(() => {
+    nativeError = error;
+    const producerPid = producerAlive();
+    trace("native-error", { code: error.code, syscall: error.syscall, producerPid, settled });
+    release();
+    console.log(JSON.stringify({ phase: "native-error", code: error.code, syscall: error.syscall,
+      producerPid, settled, observerFailed }));
+  }));
+  if (!fault) stream.once("open", () => observe(() => {
+    trace("stream-open", { producerPid: producerAlive(), settled });
+    release();
+  }));
+  return stream;
+};
+syncBuiltinESMExports();
+const quote = (value) => "'" + value.replaceAll("'", "'\\''") + "'";
+const command = "exec " + quote(process.execPath) + " " + quote(path.join(root, "producer.mjs")) +
+  " " + quote(root) + " " + (small ? "small" : "large") + " " + quote(tracePath);
+try {
+  let result;
+  let rejection;
+  trace("call-started");
+  try {
+    result = entrypoint === "tool"
+      ? await createBashTool(root, { shellPath: "/bin/bash" }).execute("native-spill", { command }, undefined,
+          (update) => onText(update.content.filter((block) => block.type === "text").map((block) => block.text).join("")))
+      : await executeBashWithOperations(command, root, createLocalBashOperations({ shellPath: "/bin/bash" }), { onChunk: onText });
+  } catch (error) { rejection = error; }
+  settled = true;
+  trace("call-settled", { rejected: rejection !== undefined, observerFailed, creations });
+  assert.equal(observerFailed, false);
+  assert.equal(fs.existsSync(path.join(root, "deadline")), false);
+  assert.equal(fs.existsSync(path.join(root, "completed")), true);
+  if (fault && !small) {
+    assert.equal(nativeError?.code, "ENOENT");
+    assert.equal(nativeError.syscall, "open");
+    assert.equal(path.dirname(nativeError.path), spillRoot);
+    assert.equal(rejection, nativeError);
+    assert.equal(result, undefined);
+  } else {
+    assert.equal(rejection, undefined);
+    assert.equal(nativeError, undefined);
+    const text = entrypoint === "tool" ? result.content.filter((block) => block.type === "text").map((block) => block.text).join("") : result.output;
+    const fullOutputPath = entrypoint === "tool" ? result.details?.fullOutputPath : result.fullOutputPath;
+    if (small) {
+      assert.equal(creations, 0);
+      assert.equal(fullOutputPath, undefined);
+      assert.equal(text, "BEGIN:small\nFINAL: preserve Ω🙂\n");
+      if (entrypoint === "tool") assert.equal(result.details?.truncation, undefined);
+      else assert.equal(result.truncated, false);
+    } else {
+      assert.equal(path.dirname(fullOutputPath), spillRoot);
+      assert.equal(fs.readFileSync(fullOutputPath, "utf8"), "BEGIN:large\n" + "x".repeat(60 * 1024) + "\nFINAL: preserve Ω🙂\n");
+      assert.equal(fs.statSync(fullOutputPath).mode & 0o777, 0o600);
+      if (entrypoint === "tool") {
+        const footer = text.indexOf("\n\n[Showing ");
+        assert(footer >= 0);
+        assert.equal(text.slice(0, footer), "FINAL: preserve Ω🙂");
+        assert(text.includes("Full output: " + fullOutputPath));
+        assert.equal(result.details.truncation.truncated, true);
+        assert(result.details.truncation.outputBytes <= 50 * 1024);
+      } else {
+        assert.equal(text, "FINAL: preserve Ω🙂");
+        assert.equal(result.truncated, true);
+        assert.equal(result.exitCode, 0);
+        assert(Buffer.byteLength(text) <= 50 * 1024);
+      }
+    }
+  }
+  console.log("native Bash spill case passed");
+} finally {
+  fs.createWriteStream = createWriteStream;
+  syncBuiltinESMExports();
+}
+`;
+
+export async function expectNativeBashSpill(
+  entrypoint: "tool" | "executor",
+  scenario: (typeof nativeBashSpillScenarios)[number],
+): Promise<void> {
+  // Detached producers must outlive neither their fixture nor its cleanup proof.
+  // Keep failure evidence outside the runner's auto-cleaned oc-vt namespace.
+  const artifactRoot = fileURLToPath(new URL("../../../.local/", import.meta.url));
+  await mkdir(artifactRoot, { recursive: true, mode: 0o700 });
+  const root = await realpath(await mkdtemp(join(artifactRoot, "bash-spill-test-")));
+  const tracePath = `${root}.trace`;
+  let producerStopped = false;
+  let childResult: ReturnType<typeof spawnNodeEvalSync> | undefined;
+  const diagnostics = async () => ({
+    entrypoint,
+    scenario,
+    fixture: root,
+    status: childResult?.status,
+    signal: childResult?.signal,
+    spawnError: childResult?.error?.message,
+    stdout: childResult?.stdout,
+    stderr: childResult?.stderr,
+    trace: await readFile(tracePath, "utf8").catch(() => "trace unavailable"),
+  });
+  try {
+    await writeFile(tracePath, "", { flag: "wx", mode: 0o600 });
+    await writeFile(join(root, "producer.mjs"), producerSource, { mode: 0o600 });
+    const fixture = {
+      root,
+      tracePath,
+      entrypoint,
+      scenario,
+      toolUrl: new URL("./tools/bash.ts", import.meta.url).href,
+      executorUrl: new URL("./bash-executor.ts", import.meta.url).href,
+    };
+    const result = spawnNodeEvalSync(`const fixture = ${JSON.stringify(fixture)};\n${caseSource}`, {
+      imports: ["tsx"],
+      timeout: 20_000,
+      maxBuffer: 64 * 1024,
+      env: {
+        PATH: process.env.PATH,
+        HOME: root,
+        USERPROFILE: root,
+        TMPDIR: root,
+        TMP: root,
+        TEMP: root,
+        OPENCLAW_STATE_DIR: join(root, "state"),
+        OPENCLAW_OFFLINE: "1",
+        NODE_DISABLE_COMPILE_CACHE: "1",
+        TSX_DISABLE_CACHE: "1",
+      },
+    });
+    childResult = result;
+    // The observed child is closed; release a surviving command before joining it.
+    try {
+      await writeFile(join(root, "release"), "release", { flag: "wx", mode: 0o600 });
+    } catch (error) {
+      if (!(error instanceof Error && "code" in error && error.code === "EEXIST")) throw error;
+    }
+    const producer = JSON.parse(
+      await readFile(join(root, "producer.json"), "utf8").catch((error) => {
+        throw new Error(
+          `Missing producer receipt after child status ${result.status}: ${result.stderr}`,
+          { cause: error },
+        );
+      }),
+    );
+    expect(producer.control).toBe(root);
+    expect(producer.ppid).toBe(result.pid);
+    expect(Number.isSafeInteger(producer.pid) && producer.pid > 0).toBe(true);
+    expect(producer.pgid).toBe(producer.pid);
+    expect(await waitForPidToExit(producer.pid, 5_000)).toBe(true);
+    await vi.waitFor(() => {
+      expect(() => process.kill(-producer.pgid, 0)).toThrowError(
+        expect.objectContaining({ code: "ESRCH" }),
+      );
+    });
+    producerStopped = true;
+    console.log(JSON.stringify(await diagnostics()));
+    expect(result.error).toBeUndefined();
+    expect(result.signal).toBeNull();
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).toContain("native Bash spill case passed");
+  } catch (error) {
+    throw new Error(JSON.stringify(await diagnostics()), { cause: error });
+  } finally {
+    // A missing producer receipt or uncertain teardown must retain its files.
+    if (producerStopped) {
+      await rm(root, { recursive: true, force: true });
+      await rm(tracePath, { force: true });
+    }
+  }
+}

--- a/src/agents/sessions/tools/bash.test.ts
+++ b/src/agents/sessions/tools/bash.test.ts
@@ -4,6 +4,10 @@ import path from "node:path";
 import { MAX_TIMER_TIMEOUT_MS } from "@openclaw/normalization-core/number-coercion";
 import { describe, expect, it, vi } from "vitest";
 import { buildShellCommandInvocation } from "../../shell-utils.js";
+import {
+  expectNativeBashSpill,
+  nativeBashSpillScenarios,
+} from "../bash-output-spill.test-support.js";
 import type { BashOperations } from "./bash-operations.js";
 import { createBashTool, createLocalBashOperations } from "./bash.js";
 import { resolveBashTimeoutMs } from "./bash.test-support.js";
@@ -56,6 +60,13 @@ describe("bash tool timeout helpers", () => {
 });
 
 describe("bash tool output lifecycle", () => {
+  it.runIf(process.platform !== "win32").each(nativeBashSpillScenarios)(
+    "settles real Bash output for %s",
+    async (scenario) => {
+      await expectNativeBashSpill("tool", scenario);
+    },
+  );
+
   it.runIf(process.platform !== "win32")("surfaces a configured shell launch error", async () => {
     const operations = createLocalBashOperations({
       shellPath: path.join(process.cwd(), "package.json"),

--- a/src/agents/sessions/tools/output-accumulator.test.ts
+++ b/src/agents/sessions/tools/output-accumulator.test.ts
@@ -1,6 +1,9 @@
 // OutputAccumulator tests cover bounded UTF-8 tails and private spill files.
-import { readFile, rm, stat } from "node:fs/promises";
+import { mkdtemp, readFile, realpath, rm, stat } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { describe, expect, it } from "vitest";
+import { spawnNodeEvalSync } from "../../../test-utils/node-process.js";
 import { OutputAccumulator } from "./output-accumulator.js";
 
 describe("OutputAccumulator", () => {
@@ -15,6 +18,7 @@ describe("OutputAccumulator", () => {
     accumulator.finish();
     const snapshot = accumulator.snapshot({ persistIfTruncated: true });
     await accumulator.closeTempFile();
+    await accumulator.closeTempFile();
 
     expect(snapshot.fullOutputPath).toBeDefined();
     // Spilled output can include command secrets, so temp files must be
@@ -22,6 +26,76 @@ describe("OutputAccumulator", () => {
     const mode = (await stat(snapshot.fullOutputPath!)).mode & 0o777;
     expect(mode & 0o077).toBe(0);
     await rm(snapshot.fullOutputPath!, { force: true });
+  });
+
+  it("reports an early native spill error when closed later and again", async () => {
+    const root = await realpath(await mkdtemp(join(tmpdir(), "openclaw-output-error-")));
+    const ownerUrl = new URL("./output-accumulator.ts", import.meta.url).href;
+    try {
+      const result = spawnNodeEvalSync(
+        `import assert from "node:assert/strict";
+         import { errorMonitor } from "node:events";
+         import fs from "node:fs";
+         import { syncBuiltinESMExports } from "node:module";
+         import { tmpdir } from "node:os";
+         import { dirname, join } from "node:path";
+         import { setImmediate } from "node:timers/promises";
+         const { OutputAccumulator } = await import(${JSON.stringify(ownerUrl)});
+         assert.equal(process.listenerCount("uncaughtException"), 0);
+         assert.equal(process.listenerCount("unhandledRejection"), 0);
+         assert.equal(process.hasUncaughtExceptionCaptureCallback(), false);
+         const missing = join(${JSON.stringify(root)}, "missing");
+         process.env.TMPDIR = process.env.TMP = process.env.TEMP = missing;
+         assert.equal(tmpdir(), missing);
+         assert.equal(fs.existsSync(missing), false);
+         const createWriteStream = fs.createWriteStream;
+         let observeFailure;
+         const failure = new Promise((resolve) => { observeFailure = resolve; });
+         fs.createWriteStream = function (...args) {
+           const stream = Reflect.apply(createWriteStream, this, args);
+           stream.once(errorMonitor, observeFailure);
+           return stream;
+         };
+         syncBuiltinESMExports();
+         try {
+           const output = new OutputAccumulator({ maxBytes: 8, tempFilePrefix: "openclaw-output-test" });
+           output.append(Buffer.from("output before finalization"), "stdout");
+           const error = await failure;
+           await setImmediate();
+           assert.equal(error.code, "ENOENT");
+           assert.equal(error.syscall, "open");
+           assert.equal(dirname(error.path), missing);
+           output.finish();
+           await assert.rejects(output.closeTempFile(), (actual) => actual === error);
+           await assert.rejects(output.closeTempFile(), (actual) => actual === error);
+           console.log("native spill error retained through repeated close");
+         } finally {
+           fs.createWriteStream = createWriteStream;
+           syncBuiltinESMExports();
+         }`,
+        {
+          imports: ["tsx"],
+          timeout: 20_000,
+          maxBuffer: 64 * 1024,
+          env: {
+            PATH: process.env.PATH,
+            SystemRoot: process.env.SystemRoot,
+            HOME: root,
+            TMPDIR: root,
+            TMP: root,
+            TEMP: root,
+            NODE_DISABLE_COMPILE_CACHE: "1",
+            TSX_DISABLE_CACHE: "1",
+          },
+        },
+      );
+      expect(result.error).toBeUndefined();
+      expect(result.signal).toBeNull();
+      expect(result.status, result.stderr).toBe(0);
+      expect(result.stdout).toContain("native spill error retained through repeated close");
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
   });
 
   it("keeps complete UTF-8 characters in a byte-bounded tail", async () => {

--- a/src/agents/sessions/tools/output-accumulator.ts
+++ b/src/agents/sessions/tools/output-accumulator.ts
@@ -3,7 +3,7 @@
  *
  * Keeps bounded display tails in memory while spilling full output to private temp files when needed.
  */
-import type { WriteStream } from "node:fs";
+import { finished } from "node:stream/promises";
 import { createPrivateTempWriteStream } from "./private-temp-file.js";
 import {
   DEFAULT_MAX_BYTES,
@@ -69,8 +69,9 @@ export class OutputAccumulator {
   private hasOpenLine = false;
   private finished = false;
 
-  private tempFilePath: string | undefined;
-  private tempFileStream: WriteStream | undefined;
+  private tempFile:
+    | (ReturnType<typeof createPrivateTempWriteStream> & { completion: Promise<void> })
+    | undefined;
 
   constructor(options: OutputAccumulatorOptions = {}) {
     this.maxLines = options.maxLines ?? DEFAULT_MAX_LINES;
@@ -108,7 +109,7 @@ export class OutputAccumulator {
 
     // Decoded/transformed output must spill exactly what callers see.
     const spillChunk = lane.spillDecoded ? Buffer.from(text, "utf-8") : data;
-    if (this.tempFileStream || this.shouldUseTempFile()) {
+    if (this.tempFile || this.shouldUseTempFile()) {
       this.ensureTempFile();
     }
     this.appendSpillChunk(spillChunk);
@@ -166,31 +167,18 @@ export class OutputAccumulator {
     return {
       content: truncation.content,
       truncation,
-      fullOutputPath: this.tempFilePath,
+      fullOutputPath: this.tempFile?.path,
     };
   }
 
   async closeTempFile(): Promise<void> {
-    if (!this.tempFileStream) {
+    const tempFile = this.tempFile;
+    if (!tempFile) {
       return;
     }
 
-    const stream = this.tempFileStream;
-    this.tempFileStream = undefined;
-
-    await new Promise<void>((resolve, reject) => {
-      const onError = (error: Error) => {
-        stream.off("finish", onFinish);
-        reject(error);
-      };
-      const onFinish = () => {
-        stream.off("error", onError);
-        resolve();
-      };
-      stream.once("error", onError);
-      stream.once("finish", onFinish);
-      stream.end();
-    });
+    tempFile.stream.end();
+    await tempFile.completion;
   }
 
   getLastLineBytes(): number {
@@ -271,22 +259,25 @@ export class OutputAccumulator {
     if (chunk.length === 0) {
       return;
     }
-    if (this.tempFileStream) {
-      this.tempFileStream.write(chunk);
+    if (this.tempFile) {
+      this.tempFile.stream.write(chunk);
     } else {
       this.spillChunks.push(chunk);
     }
   }
 
   private ensureTempFile(): void {
-    if (this.tempFilePath) {
+    if (this.tempFile) {
       return;
     }
     const tempFile = createPrivateTempWriteStream(this.tempFilePrefix);
-    this.tempFilePath = tempFile.path;
-    this.tempFileStream = tempFile.stream;
+    // Own stream errors before the first write, retaining finished()'s listeners.
+    // Handle early rejection now; closeTempFile still awaits the original promise.
+    const completion = finished(tempFile.stream);
+    void completion.catch(() => undefined);
+    this.tempFile = { ...tempFile, completion };
     for (const chunk of this.spillChunks) {
-      this.tempFileStream.write(chunk);
+      tempFile.stream.write(chunk);
     }
     this.spillChunks = [];
   }


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

This branch must remain editable by maintainers.

</details>

## What Problem This Solves

Fixes an issue where users running commands with large output could lose the hosting process when its temporary output file failed to open before the command finished. Both the model-facing Bash tool and interactive Bash execution share this failure.

## Why This Change Was Made

The accumulator now owns stream completion from creation using Node's `finished()`, before buffered or new writes. It immediately observes early rejection while preserving the original promise and native error for finalization, including repeated close calls.

One path/stream/completion record replaces parallel state and late error/finish listeners. Production changes are +19/-28 (net -9); tests and shared test support are +387/-1. There is no caller fallback, global error handler, dependency, configuration, authentication, or spill-retention change.

Provenance: introduction is unknown because available local blame stops at a shallow-history boundary. Stable `v2026.7.1` already has the late-listener structure; the later independent decode-lane repair in #112325 carried it forward. Neither that repair nor the unrelated boundary commit is claimed to have introduced this defect.

## User Impact

A failed output spill reaches the existing Bash error path instead of becoming an uncaught stream error. Successful large output still retains its complete private file and bounded Unicode display tail; below-threshold output still avoids a spill file.

## Evidence

The original owner failed a real native stream replay before finish/close; the repaired owner passed with healthy large-output and below-threshold controls. The tracked owner regression waits an event-loop turn before finalization and preserves the original error through two failed close calls. Repeated successful close is covered too.

Real explicit `/bin/bash` scenarios across both public callers produced two native-error failures and four passing controls before repair, then six passes with the repair. The assertions check native error identity and ordering, a live producer, exact full output, private mode 0600, bounded Unicode tail/footer, and no spill below the threshold.

The historical macOS three-file run passed all 38 tests with zero skips: five accumulator tests, 17 Bash-tool tests and 16 executor tests. Command:

```sh
node scripts/run-vitest.mjs run --config test/vitest/vitest.agents-support.config.ts --configLoader runner src/agents/sessions/tools/bash.test.ts src/agents/sessions/bash-executor.test.ts src/agents/sessions/tools/output-accumulator.test.ts --reporter=verbose --cache=false
```

Two earlier six-case observations remain inconclusive because a control reached its deadline. Bounded diagnostics identified a missed filesystem notification in the second attempt; they did not retroactively explain the first. The shared test fixture now uses the existing bounded marker-readiness pattern, retaining its original deadlines and assertions. The clean paired proof above followed that test-only correction.

Those historical macOS observations used mixed installed tooling. Historical original temporary logs are no longer retained; the complete 38-test log, outcome and provenance survive as hash-identical copies, and the original owner-only before/after replay retains complete output.

A fresh [Linux Blacksmith Testbox run](https://github.com/openclaw/openclaw/actions/runs/33283598643) passed the normal frozen install, formatting on all five changed files, core lint with zero warnings/errors, and all 38 tests with zero skips. It included the helper's two CI lint corrections, exact Vitest 4.1.11/Vite 8.2.2/tsx 4.23.12 dependencies and the expected runner patch, on Node 24.19.0/pnpm 12.0.0. The complete synchronized source and selected dependency hashes matched before and after execution. All six real Bash scenarios passed through the two callers. The one-shot lease stopped and an independent exact status check confirmed completion; delegated Actions cancellation during cleanup is not the command result.

The first fresh Linux attempt stopped after formatting because the task proof adapter inspected ChildProcess.close before its event had been delivered. Lint/tests had not started. The corrected adapter awaits that actual event inside the original deadline; product code, tests, assertions and deadlines were unchanged. Both receipts are retained. The local launcher's JavaScript package directories were pinned before/after, but its sibling native esbuild binary was checked only afterward, matching the package's declared hash; this is not a complete pre-run attestation of every local launcher byte.

A fresh complete five-file Codex P2 review after the two lint corrections found no actionable findings in two complementary passes. This is native Bash/stream proof with a closed test-child environment on a credential-hydrated backend, not Windows, operator-default shell selection, live-provider or Gateway proof.

Main `10da9ac921948d2454f34610596c46c6e7c9723a` contains the identical pre-fix owner. The initial signed commit `33f65ac1ef64ad8c79a0cd8187ceca0d16b39054` passed the normal pre-commit hook and signature verification. Its [hosted CI run](https://github.com/openclaw/openclaw/actions/runs/33280590107) found the two now-corrected test-helper lint errors and a separate Matrix port-rebind assertion failure; the Matrix diagnostic is tracked separately and is not mixed into this five-file repair. Signed follow-up `5aea47e6034ea35fe50457597a5d591bad0440ad` contains only those two lint corrections, passed the normal hook and signature verification, and preserves every reviewed/tested source hash. The successful Linux proof does not replace exact-head hosted CI. Exact-head hosted CI is still required; no merge readiness is claimed by this proof update.

Separate test-first follow-up: inspect the Bash tool's whole progress-callback/finalization lifecycle for custom synchronous callbacks that throw, including stdout, timer and final updates. The default agent sink is asynchronous; this is a preexisting source hypothesis, not a reproduced default-path defect. Stream error delivery is not claimed to be a universal descriptor-close barrier; these callers do not delete or reuse failed spill paths.

AI-assisted with Codex; source, dependency contracts and actual evidence were independently inspected.
