### PR TITLE
fix(gateway): reject stale node work before enqueue

### DIFF
--- a/src/gateway/server-methods/nodes.pending-work.test.ts
+++ b/src/gateway/server-methods/nodes.pending-work.test.ts
@@ -356,6 +356,46 @@ describe("node.pending handlers", () => {
     expect(call?.[2]).toBeUndefined();
   });
 
+  it("does not enqueue work when pairing invalidates during the generation check", async () => {
+    const lifecycleController = new AbortController();
+    mocks.captureNodeWakeLifecycle.mockReturnValue(lifecycleController.signal);
+    mocks.isNodePairingGenerationCurrent.mockImplementation(async () => {
+      lifecycleController.abort();
+      return true;
+    });
+    mocks.enqueueNodePendingWork.mockReturnValue({
+      revision: 5,
+      deduped: false,
+      item: {
+        id: "pending-stale-generation",
+        type: "location.request",
+        priority: "default",
+        createdAtMs: 100,
+        expiresAtMs: null,
+      },
+    });
+    const respond = vi.fn();
+
+    await expectDefined(
+      nodePendingWorkHandlers["node.pending.enqueue"],
+      'nodePendingWorkHandlers["node.pending.enqueue"] test invariant',
+    )({
+      params: { nodeId: "node-stale-generation", type: "location.request", wake: false },
+      respond: respond as never,
+      client: null,
+      context: makeContext() as never,
+      req: { type: "req", id: "req-node-stale-generation", method: "node.pending.enqueue" },
+      isWebchatConnect: () => false,
+    });
+
+    expect(mocks.enqueueNodePendingWork).not.toHaveBeenCalled();
+    expect(respondCall(respond)).toMatchObject([
+      false,
+      undefined,
+      { details: { code: "PAIRING_CHANGED" } },
+    ]);
+  });
+
   it("returns unavailable when pairing removal invalidates an enqueued item", async () => {
     const lifecycleController = new AbortController();
     const wakeLifecycle = lifecycleController.signal;

--- a/src/gateway/server-methods/nodes.pending-work.ts
+++ b/src/gateway/server-methods/nodes.pending-work.ts
@@ -9,7 +9,6 @@ import {
 import {
   captureNodePairingGeneration,
   isNodePairingGenerationCurrent,
-  type NodePairingGeneration,
 } from "../../infra/device-pairing-node-state.js";
 import {
   drainNodePendingWork,
@@ -20,12 +19,12 @@ import {
 } from "../node-pending-work.js";
 import {
   captureNodeWakeLifecycle,
-  isNodeWakeLifecycleCurrent,
   NODE_WAKE_RECONNECT_RETRY_WAIT_MS,
   NODE_WAKE_RECONNECT_WAIT_MS,
   releaseNodeWakeLifecycle,
 } from "../node-wake-state.js";
 import { respondUnavailableOnThrow } from "./nodes.helpers.js";
+import { isNodePairingWorkCurrent } from "./nodes.shared.js";
 import {
   maybeSendNodeWakeNudge,
   maybeWakeNodeWithApns,
@@ -43,17 +42,6 @@ function respondPairingChanged(respond: RespondFn) {
       retryable: true,
       details: { code: "PAIRING_CHANGED" },
     }),
-  );
-}
-
-async function isPendingGenerationCurrent(params: {
-  nodeId: string;
-  generation: NodePairingGeneration;
-  lifecycle: AbortSignal;
-}): Promise<boolean> {
-  return (
-    isNodeWakeLifecycleCurrent(params.nodeId, params.lifecycle, params.generation.key) &&
-    (await isNodePairingGenerationCurrent(params.generation))
   );
 }
 
@@ -127,7 +115,7 @@ export const nodePendingWorkHandlers: GatewayRequestHandlers = {
       }
       const wakeLifecycle = captureNodeWakeLifecycle(nodeId, generation.key);
       try {
-        if (!(await isPendingGenerationCurrent({ nodeId, generation, lifecycle: wakeLifecycle }))) {
+        if (!(await isNodePairingWorkCurrent({ nodeId, generation, lifecycle: wakeLifecycle }))) {
           respondPairingChanged(respond);
           return;
         }
@@ -178,7 +166,7 @@ export const nodePendingWorkHandlers: GatewayRequestHandlers = {
             );
           }
           if (
-            (await isPendingGenerationCurrent({
+            (await isNodePairingWorkCurrent({
               nodeId,
               generation,
               lifecycle: wakeLifecycle,
@@ -216,7 +204,7 @@ export const nodePendingWorkHandlers: GatewayRequestHandlers = {
             }
           }
           if (
-            (await isPendingGenerationCurrent({
+            (await isNodePairingWorkCurrent({
               nodeId,
               generation,
               lifecycle: wakeLifecycle,
@@ -237,7 +225,7 @@ export const nodePendingWorkHandlers: GatewayRequestHandlers = {
               `node pending wake done node=${nodeId} req=${wakeReqId} connected=false reason=not_connected`,
             );
           } else if (
-            await isPendingGenerationCurrent({
+            await isNodePairingWorkCurrent({
               nodeId,
               generation,
               lifecycle: wakeLifecycle,
@@ -248,7 +236,7 @@ export const nodePendingWorkHandlers: GatewayRequestHandlers = {
             );
           }
         }
-        if (!(await isPendingGenerationCurrent({ nodeId, generation, lifecycle: wakeLifecycle }))) {
+        if (!(await isNodePairingWorkCurrent({ nodeId, generation, lifecycle: wakeLifecycle }))) {
           if (!queued.deduped) {
             removeNodePendingWorkItem({
               nodeId,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where node pending work could be briefly enqueued after the node was re-paired or removed while the Gateway was checking its pairing generation.

## Why This Change Was Made

Pending-work enqueue and wake stages now use the existing shared pairing-work liveness check. That check validates the wake lifecycle both before and after the asynchronous pairing-generation lookup, so invalidation during the lookup is rejected before any queue mutation.

## User Impact

Operators no longer get stale node work inserted and then cleaned up when pairing changes during the initial enqueue check. The request instead returns the existing retryable `PAIRING_CHANGED` result without mutating the queue.

## Evidence

- Pre-fix regression: lifecycle invalidation inside `isNodePairingGenerationCurrent` still called `enqueueNodePendingWork` once
- Post-fix regression: no enqueue occurs and the handler returns `PAIRING_CHANGED`
- `node scripts/run-vitest.mjs src/gateway/server-methods/nodes.pending-work.test.ts` — 9 tests passed
- focused formatting and oxlint passed
- `pnpm tsgo:core` passed
- autoreview: clean, no actionable findings
- production delta: `+6/-18` (net `-12`); tests: `+40`
- `pnpm tsgo:core:test` reached the unrelated linked-install error for missing `pako` declarations in `ui/vite.config.ts`
