### PR TITLE
refactor(auth): consolidate provider compatibility checks

### DIFF
--- a/src/agents/auth-profiles/order.test.ts
+++ b/src/agents/auth-profiles/order.test.ts
@@ -934,4 +934,59 @@ describe("resolveAuthProfileOrder", () => {
       }),
     ).toBe(false);
   });
+
+  it.each([
+    [{ type: "api_key", provider: "openai", key: "test-key" }, "oauth", "mode_mismatch"],
+    [{ type: "token", provider: "openai", token: "test-token" }, "oauth", "ok"],
+    [
+      {
+        type: "oauth",
+        provider: "openai",
+        access: "test-access",
+        refresh: "test-refresh",
+        expires: 2_000_000_000_000,
+      },
+      "api_key",
+      "mode_mismatch",
+    ],
+  ] as const)(
+    "keeps provider identity and configured mode distinct for %j",
+    (credential, configuredMode, expectedModeReason) => {
+      const authAliasLookupParams = { metadataSnapshot: { plugins: [] } };
+      const store: AuthProfileStore = { version: 1, profiles: { fixture: credential } };
+      const params = {
+        store,
+        profileId: "fixture",
+        provider: "openai",
+        authAliasLookupParams,
+        now: 1_700_000_000_000,
+      };
+
+      expect(
+        isStoredCredentialCompatibleWithAuthProvider({
+          provider: "other-provider",
+          credential,
+          authAliasLookupParams,
+        }),
+      ).toBe(false);
+      expect(
+        resolveAuthProfileEligibility({
+          ...params,
+          cfg: {
+            auth: {
+              profiles: { fixture: { provider: "other-provider", mode: credential.type } },
+            },
+          },
+        }),
+      ).toEqual({ eligible: false, reasonCode: "provider_mismatch" });
+      expect(
+        resolveAuthProfileEligibility({
+          ...params,
+          cfg: {
+            auth: { profiles: { fixture: { provider: "openai", mode: configuredMode } } },
+          },
+        }),
+      ).toEqual({ eligible: expectedModeReason === "ok", reasonCode: expectedModeReason });
+    },
+  );
 });

--- a/src/agents/auth-profiles/order.ts
+++ b/src/agents/auth-profiles/order.ts
@@ -39,49 +39,18 @@ type AuthProfileEligibility = {
 };
 
 const OPENAI_PROVIDER_ID = "openai";
-const OPENAI_CODEX_PROVIDER_ID = "openai";
 
-// OpenAI Codex auth can reuse OpenAI API-key credentials. Keep this special
-// case local so generic provider alias resolution stays provider-owned.
-function isOpenAIApiKeyCompatibleWithCodexAuth(params: {
+function isProfileProviderCompatibleWithAuthProvider(params: {
   cfg?: OpenClawConfig;
   authAliasLookupParams?: ProviderAuthAliasLookupParams;
   providerAuthKey: string;
-  credential?: AuthProfileCredential;
-  profileProvider?: string;
-  profileMode?: string;
+  provider: string;
 }): boolean {
-  if (params.providerAuthKey !== OPENAI_CODEX_PROVIDER_ID) {
-    return false;
-  }
-  const providerKey = resolveProviderIdForAuth(params.profileProvider ?? "", {
+  const providerKey = resolveProviderIdForAuth(params.provider, {
     config: params.cfg,
     ...params.authAliasLookupParams,
   });
-  const mode = params.credential?.type ?? params.profileMode;
-  return providerKey === OPENAI_PROVIDER_ID && mode === "api_key";
-}
-
-function isCredentialProviderCompatibleWithAuthProvider(params: {
-  cfg?: OpenClawConfig;
-  authAliasLookupParams?: ProviderAuthAliasLookupParams;
-  providerAuthKey: string;
-  credential: AuthProfileCredential;
-}): boolean {
-  const credentialProviderKey = resolveProviderIdForAuth(params.credential.provider, {
-    config: params.cfg,
-    ...params.authAliasLookupParams,
-  });
-  return (
-    credentialProviderKey === params.providerAuthKey ||
-    isOpenAIApiKeyCompatibleWithCodexAuth({
-      cfg: params.cfg,
-      authAliasLookupParams: params.authAliasLookupParams,
-      providerAuthKey: params.providerAuthKey,
-      credential: params.credential,
-      profileProvider: params.credential.provider,
-    })
-  );
+  return providerKey === params.providerAuthKey;
 }
 
 /** Returns true when a stored credential can authenticate the requested provider. */
@@ -91,40 +60,15 @@ export function isStoredCredentialCompatibleWithAuthProvider(params: {
   provider: string;
   credential: AuthProfileCredential;
 }): boolean {
-  return isCredentialProviderCompatibleWithAuthProvider({
+  return isProfileProviderCompatibleWithAuthProvider({
     cfg: params.cfg,
     authAliasLookupParams: params.authAliasLookupParams,
     providerAuthKey: resolveProviderIdForAuth(params.provider, {
       config: params.cfg,
       ...params.authAliasLookupParams,
     }),
-    credential: params.credential,
+    provider: params.credential.provider,
   });
-}
-
-function isConfiguredProfileCompatibleWithAuthProvider(params: {
-  cfg?: OpenClawConfig;
-  authAliasLookupParams?: ProviderAuthAliasLookupParams;
-  providerAuthKey: string;
-  provider: string;
-  mode?: string;
-  credential?: AuthProfileCredential;
-}): boolean {
-  const configProviderKey = resolveProviderIdForAuth(params.provider, {
-    config: params.cfg,
-    ...params.authAliasLookupParams,
-  });
-  return (
-    configProviderKey === params.providerAuthKey ||
-    isOpenAIApiKeyCompatibleWithCodexAuth({
-      cfg: params.cfg,
-      authAliasLookupParams: params.authAliasLookupParams,
-      providerAuthKey: params.providerAuthKey,
-      credential: params.credential,
-      profileProvider: params.provider,
-      profileMode: params.mode,
-    })
-  );
 }
 
 function listProfilesCompatibleWithAuthProvider(params: {
@@ -134,16 +78,16 @@ function listProfilesCompatibleWithAuthProvider(params: {
   provider: string;
   providerAuthKey: string;
 }): string[] {
-  if (params.providerAuthKey !== OPENAI_CODEX_PROVIDER_ID) {
+  if (params.providerAuthKey !== OPENAI_PROVIDER_ID) {
     return listProfilesForProvider(params.store, params.provider);
   }
   return Object.entries(params.store.profiles)
     .filter(([, credential]) =>
-      isCredentialProviderCompatibleWithAuthProvider({
+      isProfileProviderCompatibleWithAuthProvider({
         cfg: params.cfg,
         authAliasLookupParams: params.authAliasLookupParams,
         providerAuthKey: params.providerAuthKey,
-        credential,
+        provider: credential.provider,
       }),
     )
     .map(([profileId]) => profileId);
@@ -221,11 +165,11 @@ export function resolveAuthProfileEligibility(params: {
     return { eligible: false, reasonCode: "profile_missing" };
   }
   if (
-    !isCredentialProviderCompatibleWithAuthProvider({
+    !isProfileProviderCompatibleWithAuthProvider({
       cfg: params.cfg,
       authAliasLookupParams: params.authAliasLookupParams,
       providerAuthKey,
-      credential: cred,
+      provider: cred.provider,
     })
   ) {
     return { eligible: false, reasonCode: "provider_mismatch" };
@@ -233,13 +177,11 @@ export function resolveAuthProfileEligibility(params: {
   const profileConfig = params.cfg?.auth?.profiles?.[params.profileId];
   if (profileConfig) {
     if (
-      !isConfiguredProfileCompatibleWithAuthProvider({
+      !isProfileProviderCompatibleWithAuthProvider({
         cfg: params.cfg,
         authAliasLookupParams: params.authAliasLookupParams,
         providerAuthKey,
         provider: profileConfig.provider,
-        mode: profileConfig.mode,
-        credential: cred,
       })
     ) {
       return { eligible: false, reasonCode: "provider_mismatch" };
@@ -328,14 +270,12 @@ export function resolveAuthProfileOrderWithMetadata(
     });
   const explicitProfiles = cfg?.auth?.profiles
     ? Object.entries(cfg.auth.profiles)
-        .filter(([profileId, profile]) =>
-          isConfiguredProfileCompatibleWithAuthProvider({
+        .filter(([, profile]) =>
+          isProfileProviderCompatibleWithAuthProvider({
             cfg,
             authAliasLookupParams: params.authAliasLookupParams,
             providerAuthKey,
             provider: profile.provider,
-            mode: profile.mode,
-            credential: store.profiles[profileId],
           }),
         )
         .map(([profileId]) => profileId)


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

This branch is in the upstream repository and remains editable by repository maintainers.

</details>

## What Problem This Solves

Auth-profile selection carried duplicate provider comparisons and an obsolete special case after both OpenAI identifiers became `openai`. That branch could not accept a canonical provider pair that the preceding equality check had rejected, but its credential-mode plumbing made the provider-selection policy harder to audit.

## Why This Change Was Made

Consolidate configured-profile and stored-credential provider matching in one private helper in `src/agents/auth-profiles/order.ts`. Remove the redundant constant, unreachable additional acceptance branch, and unused credential/mode arguments. Keep the existing public helpers and the separate eligibility checks for credential mode, expiry, unresolved references, profile ordering, preferred profiles, and cooldowns unchanged.

The OpenAI-specific enumeration path is deliberately retained because it carries the supplied alias-lookup context. Replacing it with the generic profile-list helper would be a different change. Provider identity equality is not a claim that API-key and OAuth credentials are interchangeable; the existing mode check, including its token-under-OAuth exception, remains authoritative.

## User Impact

No intended user-visible behavior, configuration, storage, protocol, plugin SDK, or authentication-transport change. This is a maintainer-requested behavior-preserving cleanup.

Production: **+14 / −74 = 60 lines removed**. Tests: **+55 / −0**. Whole PR: **5 lines removed**. All existing cases and assertions remain; three characterization cases make provider identity and credential mode independently observable.

## Evidence

Using Node 24.19.0 and the repository's normal test entrypoint:

```sh
node scripts/run-vitest.mjs src/agents/auth-profiles/order.test.ts src/agents/provider-auth-aliases.test.ts src/agents/auth-profiles/credential-state.test.ts src/secrets/runtime-auth-store-inline-refs.test.ts src/secrets/runtime-auth-profiles-oauth-policy.test.ts --reporter=verbose
node scripts/run-vitest.mjs src/plugin-sdk/provider-auth.test.ts src/agents/model-auth.profiles.test.ts --reporter=verbose
node scripts/check-changed.mjs -- src/agents/auth-profiles/order.ts src/agents/auth-profiles/order.test.ts
```

The first command passed the same **64 cases across five files** before and after the production cleanup. The three new characterization cases exercise nine observations across provider mismatch and configured-mode boundaries; this is paired preservation evidence, not a failing-before bug reproduction. The second command passed **159 additional SDK/model-auth cases**; some use mocked ordering, so those cases are sibling coverage rather than independent execution of the changed comparison.

The full **29-stage changed-code gate passed**, including core and core-test type checks, lint, all three unused-export scans, and storage/architecture guards. The normal isolated Codex precommit review completed with no accepted P0 findings in its selected scope. Its safe context excludes credential/secret-named files; those owner contracts were read directly, with separate independent source analysis. No live authenticated-provider or packaged-runtime proof is claimed: provider transport, imports, public exports, and package boundaries are unchanged. Exact-head hosted CI and current-main composition remain separate landing gates.

Pre-merge update: the separate authenticated committed-head Codex review also completed with no accepted P0 findings. [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/33280970337) succeeded on `dfc9aa4a7ee443f8b4fa890fc7705dbada0bd72a`. The [completed ClawSweeper review](https://github.com/openclaw/openclaw/pull/132911#issuecomment-5465521188) found no actionable issue; its ordinary review/CI next step is satisfied. Current-main inspection through `4f92bd506` found no auth-owner or caller drift. The original post-review config audit refusal remains recorded: native PR initialization had added only its temporary branch-tracking stanza, verified by reconstructing the exact prior config hash. No source changed and no review was rerun for that bookkeeping delta. Normal hosted native preparation and actual-parent landing verification still follow.

Landed as [e3ae1752a5a8](https://github.com/openclaw/openclaw/commit/e3ae1752a5a8c15399eadfedaf5b17225f65c144). Native hosted preparation and merge both returned success with no rebase or additional push. The whole landed tree (35,292 leaves and modes) exactly equals actual parent `d8c8f1adf1515aa125b6b7a900eed46078197c8f` plus the two reviewed after-images; the complete patch and **−60 production / +55 tests / −5 total** count match. Main ancestry, clean retained source, remote-branch deletion and native worktree/ref/lock cleanup were verified. The intentional merge-outcome receipt is retained. An initial review-artifact validation refusal was corrected by adding the required branch-level entries for the already-run proof; its failed result and exact-token lock recovery remain recorded. Native main-drift warnings concerned dependency-install/cache/packaging tooling, not the unchanged auth owner; the actual six-file tooling delta was inspected without rebasing or claiming new runtime proof.
