### PR TITLE
test(tasks): avoid redundant registry fixture initialization

### DIFF
--- a/src/tasks/task-registry.store.test.ts
+++ b/src/tasks/task-registry.store.test.ts
@@ -476,7 +476,7 @@ describe("task-registry store runtime", () => {
       await withOpenClawTestState(
         { layout: "state-only", prefix: "openclaw-task-invalid-notify-" },
         async () => {
-          resetTaskRegistryForTests();
+          resetTaskRegistryForTests({ persist: false });
           const created = createTaskRecord({
             runtime: "acp",
             ownerKey: "agent:main:main",
@@ -553,7 +553,7 @@ describe("task-registry store runtime", () => {
       await withOpenClawTestState(
         { layout: "state-only", prefix: "openclaw-task-valid-notify-" },
         async () => {
-          resetTaskRegistryForTests();
+          resetTaskRegistryForTests({ persist: false });
           const created = createTaskRecord({
             runtime: "acp",
             ownerKey: "agent:main:main",
@@ -580,7 +580,7 @@ describe("task-registry store runtime", () => {
     await withOpenClawTestState(
       { layout: "state-only", prefix: "openclaw-task-store-corrupt-" },
       async () => {
-        resetTaskRegistryForTests();
+        resetTaskRegistryForTests({ persist: false });
         const created = createTaskRecord({
           runtime: "cron",
           ownerKey: "agent:main:main",
@@ -609,7 +609,7 @@ describe("task-registry store runtime", () => {
     await withOpenClawTestState(
       { layout: "state-only", prefix: "openclaw-task-store-invalid-origin-" },
       async () => {
-        resetTaskRegistryForTests();
+        resetTaskRegistryForTests({ persist: false });
         const created = createTaskRecord({
           runtime: "acp",
           ownerKey: "agent:main:main",
@@ -690,7 +690,7 @@ describe("task-registry store runtime", () => {
     await withOpenClawTestState(
       { layout: "state-only", prefix: "openclaw-task-store-read-snapshot-" },
       async () => {
-        resetTaskRegistryForTests();
+        resetTaskRegistryForTests({ persist: false });
         const created = createTaskRecord({
           runtime: "acp",
           ownerKey: "agent:main:main",
@@ -746,7 +746,7 @@ describe("task-registry store runtime", () => {
     await withOpenClawTestState(
       { layout: "state-only", prefix: "openclaw-task-store-owner-index-" },
       async () => {
-        resetTaskRegistryForTests();
+        resetTaskRegistryForTests({ persist: false });
         const ownerKey = "agent:main:main";
         const target = createTaskRecord({
           runtime: "cron",

--- a/src/tasks/task-registry.test.ts
+++ b/src/tasks/task-registry.test.ts
@@ -472,13 +472,6 @@ function configureInMemoryTaskStoresForTests() {
   });
 }
 
-function resetTaskRegistryMemoryForTest(opts?: { persist?: boolean }) {
-  resetTaskRegistryForTests(opts);
-  configureTaskRegistryRuntime({
-    store: createInMemoryTaskRegistryStore(),
-  });
-}
-
 async function withTaskRegistryTempDir<T>(
   run: (root: string) => Promise<T>,
   options?: { durableStore?: boolean },
@@ -625,8 +618,6 @@ describe("task-registry", () => {
 
   it("updates task status from lifecycle events", async () => {
     await withTaskRegistryTempDir(async () => {
-      resetTaskRegistryMemoryForTest();
-
       createTaskFixture("acp", {
         childSessionKey: "agent:main:acp:child",
         runId: "run-1",
@@ -660,7 +651,6 @@ describe("task-registry", () => {
 
   it("bounds durable liveness writes for live activity deltas", async () => {
     await withTaskRegistryTempDir(async () => {
-      resetTaskRegistryMemoryForTest();
       const store = createInMemoryTaskRegistryStore();
       const upsert = vi.spyOn(store, "upsertTaskWithDeliveryState");
       configureTaskRegistryRuntime({ store });
@@ -728,7 +718,6 @@ describe("task-registry", () => {
 
   it("fills terminal lastEventAt from endedAt when a finalize omits the progress timestamp", async () => {
     await withTaskRegistryTempDir(async () => {
-      resetTaskRegistryMemoryForTest();
       createTaskFixture("subagent", {
         childSessionKey: "agent:main:subagent:terminal-timestamp",
         runId: "run-terminal-timestamp",
@@ -749,7 +738,6 @@ describe("task-registry", () => {
 
   it("keeps a newer terminal progress timestamp when endedAt trails it", async () => {
     await withTaskRegistryTempDir(async () => {
-      resetTaskRegistryMemoryForTest();
       createTaskFixture("subagent", {
         childSessionKey: "agent:main:subagent:monotonic-timestamp",
         runId: "run-monotonic-timestamp",
@@ -855,8 +843,6 @@ describe("task-registry", () => {
 
   it("tracks tool activity from tool-start events", async () => {
     await withTaskRegistryTempDir(async () => {
-      resetTaskRegistryMemoryForTest();
-
       createTaskFixture("subagent", {
         childSessionKey: "agent:main:subagent:tools",
         runId: "run-tools",
@@ -905,7 +891,6 @@ describe("task-registry", () => {
 
   it("folds Codex native child activity under its canonical thread run id", async () => {
     await withTaskRegistryTempDir(async () => {
-      resetTaskRegistryMemoryForTest();
       const runId = "codex-thread:019fef4-native-child";
       const task = createTaskFixture("subagent", {
         childSessionKey: runId,
@@ -966,7 +951,6 @@ describe("task-registry", () => {
 
   it("keeps subagent abort lifecycle projections provisional", async () => {
     await withTaskRegistryTempDir(async () => {
-      resetTaskRegistryMemoryForTest();
       createTaskFixture("subagent", {
         childSessionKey: "agent:main:subagent:abort-race",
         runId: "run-subagent-abort-race",
@@ -1002,7 +986,6 @@ describe("task-registry", () => {
 
   it("keeps a superseded subagent terminal outcome sticky over late success", async () => {
     await withTaskRegistryTempDir(async () => {
-      resetTaskRegistryMemoryForTest();
       createTaskFixture("subagent", {
         childSessionKey: "agent:main:subagent:superseded",
         runId: "run-subagent-superseded",
@@ -1044,7 +1027,6 @@ describe("task-registry", () => {
 
   it("clears a provisional child session when the terminal outcome has none", async () => {
     await withTaskRegistryTempDir(async () => {
-      resetTaskRegistryMemoryForTest();
       createTaskFixture("cron", {
         ownerKey: "",
         scopeKind: "system",
@@ -1070,7 +1052,6 @@ describe("task-registry", () => {
 
   it("reuses an ACP run task when a derived flow id is linked before a duplicate create", async () => {
     await withTaskRegistryTempDir(async () => {
-      resetTaskRegistryMemoryForTest({ persist: false });
       resetTaskFlowRegistryForTests({ persist: false });
       configureInMemoryTaskStoresForTests();
 
@@ -1106,8 +1087,6 @@ describe("task-registry", () => {
 
   it("ignores late agent events for operator-cancelled tasks", async () => {
     await withTaskRegistryTempDir(async () => {
-      resetTaskRegistryMemoryForTest();
-
       const task = createTaskFixture("cli", {
         childSessionKey: "agent:main:main",
         runId: "run-cancel-then-end",
@@ -1253,8 +1232,6 @@ describe("task-registry", () => {
 
   it("keeps signal-only cancellation when a late success arrives", async () => {
     await withTaskRegistryTempDir(async () => {
-      resetTaskRegistryMemoryForTest();
-
       createTaskFixture("cli", {
         childSessionKey: "agent:main:main",
         runId: "run-timeout-then-success",
@@ -1288,8 +1265,6 @@ describe("task-registry", () => {
 
   it("uses shared agent terminal precedence for lifecycle task projection", async () => {
     await withTaskRegistryTempDir(async () => {
-      resetTaskRegistryMemoryForTest();
-
       createTaskFixture("cli", {
         childSessionKey: "agent:main:main",
         runId: "run-hard-timeout-task",
@@ -1403,8 +1378,6 @@ describe("task-registry", () => {
 
   it("does not downgrade failed run-scoped tasks when a late success arrives", async () => {
     await withTaskRegistryTempDir(async () => {
-      resetTaskRegistryMemoryForTest();
-
       createTaskFixture("cli", {
         childSessionKey: "agent:main:main",
         runId: "run-fail-then-success",
@@ -1437,8 +1410,6 @@ describe("task-registry", () => {
 
   it("lets delivery failure upgrade a lifecycle success", async () => {
     await withTaskRegistryTempDir(async () => {
-      resetTaskRegistryMemoryForTest();
-
       createTaskFixture("cli", {
         childSessionKey: "agent:main:main",
         runId: "run-success-then-fail",
@@ -1472,8 +1443,6 @@ describe("task-registry", () => {
 
   it("summarizes task pressure by status and runtime", async () => {
     await withTaskRegistryTempDir(async () => {
-      resetTaskRegistryMemoryForTest();
-
       createTaskFixture("acp", {
         runId: "run-summary-acp",
         task: "Investigate issue",
@@ -1543,7 +1512,6 @@ describe("task-registry", () => {
     },
   ])("$name", async ({ runtime, params, error }) => {
     await withTaskRegistryTempDir(async () => {
-      resetTaskRegistryMemoryForTest({ persist: false });
       resetTaskFlowRegistryForTests({ persist: false });
       configureInMemoryTaskStoresForTests();
       const flow = createManagedTaskFlow({
@@ -1560,7 +1528,6 @@ describe("task-registry", () => {
 
   it("rejects cross-owner flow links for existing tasks", async () => {
     await withTaskRegistryTempDir(async () => {
-      resetTaskRegistryMemoryForTest({ persist: false });
       resetTaskFlowRegistryForTests({ persist: false });
       configureInMemoryTaskStoresForTests();
 
@@ -1591,7 +1558,6 @@ describe("task-registry", () => {
 
   it("does not persist linked task changes while task-flow restore is failed", async () => {
     await withTaskRegistryTempDir(async () => {
-      resetTaskRegistryMemoryForTest({ persist: false });
       resetTaskFlowRegistryForTests({ persist: false });
       const taskStore = createInMemoryTaskRegistryStore();
       const taskUpsert = vi.spyOn(taskStore, "upsertTaskWithDeliveryState");
@@ -1671,7 +1637,6 @@ describe("task-registry", () => {
 
   it("restores task-flow state before activating the task registry", async () => {
     await withTaskRegistryTempDir(async () => {
-      resetTaskRegistryMemoryForTest({ persist: false });
       resetTaskFlowRegistryForTests({ persist: false });
       const loadTaskSnapshot = vi.fn(() => ({
         tasks: new Map<string, TaskRecord>(),
@@ -1701,7 +1666,6 @@ describe("task-registry", () => {
 
   it("propagates task registry restore failures through the runtime gate", async () => {
     await withTaskRegistryTempDir(async () => {
-      resetTaskRegistryMemoryForTest({ persist: false });
       resetTaskFlowRegistryForTests({ persist: false });
       configureTaskFlowRegistryRuntime({
         store: createInMemoryTaskFlowRegistryStore(),
@@ -1724,7 +1688,6 @@ describe("task-registry", () => {
   it("reports task update success and retries when task-mirrored flow sync persistence fails", async () => {
     await withTaskRegistryTempDir(async () => {
       vi.useFakeTimers();
-      resetTaskRegistryMemoryForTest({ persist: false });
       resetTaskFlowRegistryForTests({ persist: false });
       configureInMemoryTaskStoresForTests();
 
@@ -1803,7 +1766,6 @@ describe("task-registry", () => {
   it("does not let a delayed task-mirrored flow sync retry overwrite a newer linked task", async () => {
     await withTaskRegistryTempDir(async () => {
       vi.useFakeTimers();
-      resetTaskRegistryMemoryForTest({ persist: false });
       resetTaskFlowRegistryForTests({ persist: false });
       configureInMemoryTaskStoresForTests();
 
@@ -1868,7 +1830,6 @@ describe("task-registry", () => {
 
   it("rejects parent flow links once cancellation has been requested", async () => {
     await withTaskRegistryTempDir(async () => {
-      resetTaskRegistryMemoryForTest({ persist: false });
       resetTaskFlowRegistryForTests({ persist: false });
       configureInMemoryTaskStoresForTests();
 
@@ -1938,7 +1899,6 @@ describe("task-registry", () => {
     { status: "blocked" as const, endedAt: 42 },
   ])("rejects parent flow links for $status flows", async ({ status, endedAt }) => {
     await withTaskRegistryTempDir(async () => {
-      resetTaskRegistryMemoryForTest({ persist: false });
       resetTaskFlowRegistryForTests({ persist: false });
       configureInMemoryTaskStoresForTests();
 
@@ -1964,7 +1924,6 @@ describe("task-registry", () => {
 
   it("queues delegated ACP completion to the requester session when a delivery origin exists", async () => {
     await withTaskRegistryTempDir(async () => {
-      resetTaskRegistryMemoryForTest();
       const resolveTaskControlUiSessionUrl = vi.fn(() => "https://dashboard.example/chat/task");
       setTaskRegistryDeliveryRuntimeForTests({
         sendMessage: hoisted.sendMessageMock,
@@ -2069,7 +2028,6 @@ describe("task-registry", () => {
     },
   ])("delivers ACP completion directly to a requester thread $name", async (testCase) => {
     await withTaskRegistryTempDir(async () => {
-      resetTaskRegistryMemoryForTest();
       const resolveTaskControlUiSessionUrl = vi.fn(() => testCase.inspectUrl);
       setTaskRegistryDeliveryRuntimeForTests({
         sendMessage: hoisted.sendMessageMock,
@@ -2394,7 +2352,6 @@ describe("task-registry", () => {
 
   it("records delivery failure and queues a session fallback when direct delivery misses", async () => {
     await withTaskRegistryTempDir(async () => {
-      resetTaskRegistryMemoryForTest();
       hoisted.sendMessageMock.mockRejectedValueOnce(new Error("notifychat unavailable"));
 
       createAcpTaskRecord({
@@ -2466,7 +2423,6 @@ describe("task-registry", () => {
 
   it("still wakes the parent when blocked delivery misses the outward channel", async () => {
     await withTaskRegistryTempDir(async () => {
-      resetTaskRegistryMemoryForTest();
       hoisted.sendMessageMock.mockRejectedValueOnce(new Error("notifychat unavailable"));
 
       createAcpTaskRecord({
@@ -2496,8 +2452,6 @@ describe("task-registry", () => {
 
   it("marks internal fallback delivery as session queued instead of delivered", async () => {
     await withTaskRegistryTempDir(async () => {
-      resetTaskRegistryMemoryForTest();
-
       createAcpTaskRecord({
         runId: "run-session-queued",
         task: "Investigate issue",
@@ -2528,8 +2482,6 @@ describe("task-registry", () => {
 
   it("wakes the parent for blocked tasks even when delivery falls back to the session", async () => {
     await withTaskRegistryTempDir(async () => {
-      resetTaskRegistryMemoryForTest();
-
       createAcpTaskRecord({
         runId: "run-session-blocked",
         task: "Port the repo changes",
@@ -2556,7 +2508,6 @@ describe("task-registry", () => {
 
   it("does not include internal progress detail in the terminal channel message", async () => {
     await withTaskRegistryTempDir(async () => {
-      resetTaskRegistryMemoryForTest();
       hoisted.sendMessageMock.mockResolvedValue({
         channel: "notifychat",
         to: "notifychat:123",
@@ -2601,7 +2552,6 @@ describe("task-registry", () => {
 
   it("surfaces blocked outcomes separately from completed tasks", async () => {
     await withTaskRegistryTempDir(async () => {
-      resetTaskRegistryMemoryForTest();
       hoisted.sendMessageMock.mockResolvedValue({
         channel: "notifychat",
         to: "notifychat:123",
@@ -2633,7 +2583,6 @@ describe("task-registry", () => {
 
   it("does not queue an unblock follow-up for ordinary completed tasks", async () => {
     await withTaskRegistryTempDir(async () => {
-      resetTaskRegistryMemoryForTest();
       hoisted.sendMessageMock.mockResolvedValue({
         channel: "notifychat",
         to: "notifychat:123",
@@ -2667,8 +2616,6 @@ describe("task-registry", () => {
 
   it("keeps distinct task records when different producers share a runId", async () => {
     await withTaskRegistryTempDir(async () => {
-      resetTaskRegistryMemoryForTest();
-
       createTaskFixture("cli", {
         ownerKey: "agent:codex:acp:child",
         childSessionKey: "agent:codex:acp:child",
@@ -2693,8 +2640,6 @@ describe("task-registry", () => {
 
   it("scopes shared-run lifecycle events to the matching session", async () => {
     await withTaskRegistryTempDir(async () => {
-      resetTaskRegistryMemoryForTest();
-
       const victimTask = createTaskFixture("acp", {
         ownerKey: "agent:victim:main",
         childSessionKey: "agent:victim:acp:child",
@@ -2736,7 +2681,6 @@ describe("task-registry", () => {
 
   it("suppresses duplicate ACP delivery when a preferred spawned task shares the runId", async () => {
     await withTaskRegistryTempDir(async () => {
-      resetTaskRegistryMemoryForTest();
       hoisted.sendMessageMock.mockResolvedValue({
         channel: "notifychat",
         to: "notifychat:123",
@@ -2777,8 +2721,6 @@ describe("task-registry", () => {
 
   it("does not suppress ACP delivery across different requester scopes when runIds collide", async () => {
     await withTaskRegistryTempDir(async () => {
-      resetTaskRegistryMemoryForTest();
-
       const victimTask = createTaskFixture("acp", {
         ownerKey: "agent:victim:main",
         childSessionKey: "agent:victim:acp:child",
@@ -2822,8 +2764,6 @@ describe("task-registry", () => {
 
   it("adopts preferred ACP spawn metadata when collapsing onto an earlier direct record", async () => {
     await withTaskRegistryTempDir(async () => {
-      resetTaskRegistryMemoryForTest();
-
       const directTask = createAcpTaskRecord({
         requesterOrigin: NOTIFYCHAT_ORIGIN,
         runId: "run-collapse-preferred",
@@ -2849,8 +2789,6 @@ describe("task-registry", () => {
 
   it("collapses ACP run-owned task creation onto the existing spawned task", async () => {
     await withTaskRegistryTempDir(async () => {
-      resetTaskRegistryMemoryForTest();
-
       const spawnedTask = createAcpTaskRecord({
         requesterOrigin: NOTIFYCHAT_ORIGIN,
         runId: "run-collapse",
@@ -2875,7 +2813,6 @@ describe("task-registry", () => {
 
   it("delivers a terminal ACP update only once when multiple notifiers race", async () => {
     await withTaskRegistryTempDir(async () => {
-      resetTaskRegistryMemoryForTest();
       hoisted.sendMessageMock.mockResolvedValue({
         channel: "notifychat",
         to: "notifychat:123",
@@ -2911,7 +2848,6 @@ describe("task-registry", () => {
 
   it("keeps detached terminal delivery root-admitted through mirror persistence", async () => {
     await withTaskRegistryTempDir(async () => {
-      resetTaskRegistryMemoryForTest();
       let releaseSend = () => {};
       hoisted.sendMessageMock.mockImplementationOnce(
         () =>
@@ -2941,7 +2877,6 @@ describe("task-registry", () => {
 
   it("drains an admitted task through terminal delivery without admitting unrelated work", async () => {
     await withTaskRegistryTempDir(async () => {
-      resetTaskRegistryMemoryForTest();
       let releaseSend = () => {};
       hoisted.sendMessageMock.mockImplementationOnce(
         () =>
@@ -3049,7 +2984,6 @@ describe("task-registry", () => {
 
   it("indexes tasks by session key for latest and list lookups", async () => {
     await withTaskRegistryTempDir(async () => {
-      resetTaskRegistryMemoryForTest({ persist: false });
       const nowSpy = vi.spyOn(Date, "now");
       nowSpy.mockReturnValue(1_700_000_000_000);
 
@@ -3082,8 +3016,6 @@ describe("task-registry", () => {
 
   it("infers agent ids for session-scoped tasks", async () => {
     await withTaskRegistryTempDir(async () => {
-      resetTaskRegistryMemoryForTest({ persist: false });
-
       const created = createTaskFixture("cli", {
         ownerKey: undefined,
         scopeKind: undefined,
@@ -3103,8 +3035,6 @@ describe("task-registry", () => {
 
   it("uses the child session agent for cross-agent background task attribution", async () => {
     await withTaskRegistryTempDir(async () => {
-      resetTaskRegistryMemoryForTest({ persist: false });
-
       const created = createTaskFixture("subagent", {
         childSessionKey: "agent:worker:subagent:child",
         runId: "run-worker-subagent",
@@ -3133,7 +3063,6 @@ describe("task-registry", () => {
     resetProcessRegistryForTests();
     try {
       await withTaskRegistryTempDir(async () => {
-        resetTaskRegistryMemoryForTest();
         const session = createProcessSessionFixture({ id: "amber-reef" });
         addSession(session);
         markBackgrounded(session);
@@ -3209,7 +3138,6 @@ describe("task-registry", () => {
 
   it("projects inspection-time orphaned tasks as lost without mutating the registry", async () => {
     await withTaskRegistryTempDir(async () => {
-      resetTaskRegistryMemoryForTest();
       configureTaskRegistryMaintenance({ runtimeAuthoritative: true });
 
       const task = createTaskFixture("acp", {
@@ -3235,7 +3163,6 @@ describe("task-registry", () => {
 
   it("keeps zero-argument inspection helpers fresh", async () => {
     await withTaskRegistryTempDir(async () => {
-      resetTaskRegistryMemoryForTest();
       vi.useFakeTimers();
       vi.setSystemTime(new Date("2026-06-16T00:00:00Z"));
 
@@ -3262,7 +3189,6 @@ describe("task-registry", () => {
 
   it("marks orphaned tasks lost with cleanupAfter in a single maintenance pass", async () => {
     await withTaskRegistryTempDir(async () => {
-      resetTaskRegistryMemoryForTest();
       configureTaskRegistryMaintenance({ runtimeAuthoritative: true });
       const now = Date.now();
 
@@ -3418,7 +3344,6 @@ describe("task-registry", () => {
       checksSummary,
     }) => {
       await withTaskRegistryTempDir(async () => {
-        resetTaskRegistryMemoryForTest();
         const now = Date.now();
         const parentSessionKey = "agent:main:telegram:direct:owner";
         const task = createTaskFixture("acp", {
@@ -3481,7 +3406,6 @@ describe("task-registry", () => {
 
   it("does not relist task records for each terminal ACP cleanup check", async () => {
     await withTaskRegistryTempDir(async () => {
-      resetTaskRegistryMemoryForTest();
       const now = Date.now();
       const tasks = Array.from({ length: 20 }, (_, index) => {
         const task = createTaskFixture("acp", {
@@ -3518,7 +3442,6 @@ describe("task-registry", () => {
 
   it("keeps terminal ACP cleanup from closing a child session with fresh active work", async () => {
     await withTaskRegistryTempDir(async () => {
-      resetTaskRegistryMemoryForTest();
       const now = Date.now();
       const parentSessionKey = "agent:main:telegram:direct:owner";
       const childSessionKey = "agent:claude:acp:shared-child";
@@ -3590,7 +3513,6 @@ describe("task-registry", () => {
     },
   ])("$name", async ({ mode, childSessionKey, bound, closes }) => {
     await withTaskRegistryTempDir(async () => {
-      resetTaskRegistryMemoryForTest();
       const parentSessionKey = "agent:main:telegram:direct:owner";
       const closeAcpSession = vi.fn().mockResolvedValue(undefined);
       const unbindSessionBindings = vi.fn().mockResolvedValue([]);
@@ -3628,8 +3550,6 @@ describe("task-registry", () => {
 
   it("prunes old terminal tasks during maintenance sweeps", async () => {
     await withTaskRegistryTempDir(async () => {
-      resetTaskRegistryMemoryForTest();
-
       createTaskFixture("cli", {
         childSessionKey: "agent:main:main",
         runId: "run-prune",
@@ -3658,7 +3578,6 @@ describe("task-registry", () => {
 
   it("previews and repairs missing cleanup timestamps during maintenance", async () => {
     await withTaskRegistryTempDir(async () => {
-      resetTaskRegistryMemoryForTest();
       const now = Date.now();
       configureTaskRegistryRuntime({
         store: {
@@ -3709,7 +3628,6 @@ describe("task-registry", () => {
   it("cancels the deferred maintenance sweep during test teardown", async () => {
     await withTaskRegistryTempDir(async () => {
       vi.useFakeTimers();
-      resetTaskRegistryMemoryForTest();
       const now = Date.now();
 
       const task = createTaskFixture("acp", {
@@ -3764,7 +3682,6 @@ describe("task-registry", () => {
   it("keeps scheduled maintenance root-admitted until session cleanup inspection settles", async () => {
     await withTaskRegistryTempDir(async () => {
       vi.useFakeTimers();
-      resetTaskRegistryMemoryForTest();
       let releaseInspection = (_entries: AcpSessionStoreEntry[]) => {};
       const inspection = new Promise<AcpSessionStoreEntry[]>((resolve) => {
         releaseInspection = resolve;
@@ -3788,7 +3705,6 @@ describe("task-registry", () => {
   it("does not leak unhandled rejections when the scheduled maintenance sweep fails", async () => {
     await withTaskRegistryTempDir(async () => {
       vi.useFakeTimers();
-      resetTaskRegistryMemoryForTest();
 
       const unhandled: unknown[] = [];
       const onUnhandledRejection = (reason: unknown) => {
@@ -3943,7 +3859,6 @@ describe("task-registry", () => {
 
   it("backdates createdAt when a task is created with an earlier startedAt", async () => {
     await withTaskRegistryTempDir(async () => {
-      resetTaskRegistryMemoryForTest();
       const nowSpy = vi.spyOn(Date, "now").mockReturnValue(1_700_000_000_000);
 
       const task = createTaskFixture("acp", {
@@ -3966,7 +3881,6 @@ describe("task-registry", () => {
 
   it("keeps timestamps monotonic when an update supplies an earlier startedAt", async () => {
     await withTaskRegistryTempDir(async () => {
-      resetTaskRegistryMemoryForTest();
       const nowSpy = vi.spyOn(Date, "now").mockReturnValue(1_700_000_000_000);
 
       const task = createTaskFixture("acp", {
@@ -3995,7 +3909,6 @@ describe("task-registry", () => {
 
   it("normalizes restored task timestamps before exposing them", async () => {
     await withTaskRegistryTempDir(async () => {
-      resetTaskRegistryMemoryForTest();
       configureTaskRegistryRuntime({
         store: {
           loadSnapshot: () => ({
@@ -4035,7 +3948,6 @@ describe("task-registry", () => {
 
   it("reloads from durable state instead of preserving stale in-memory tasks", async () => {
     await withTaskRegistryTempDir(async () => {
-      resetTaskRegistryMemoryForTest();
       const now = Date.now();
       let durableTasks = new Map<string, ReturnType<typeof createTaskFixture>>();
       configureTaskRegistryRuntime({
@@ -4096,7 +4008,6 @@ describe("task-registry", () => {
 
   it("reattaches the lifecycle listener after recovering from an initial restore failure", async () => {
     await withTaskRegistryTempDir(async () => {
-      resetTaskRegistryMemoryForTest();
       const runId = "run-restore-listener";
       const storedTask: TaskRecord = {
         taskId: "task-restore-listener",
@@ -4153,7 +4064,6 @@ describe("task-registry", () => {
 
   it("does not hide a failed reload behind the restart-draining delivery fallback", async () => {
     await withTaskRegistryTempDir(async () => {
-      resetTaskRegistryMemoryForTest();
       const storedTask: TaskRecord = {
         taskId: "task-reload-failure",
         runtime: "acp",
@@ -4204,7 +4114,6 @@ describe("task-registry", () => {
 
   it("summarizes inspectable task audit findings", async () => {
     await withTaskRegistryTempDir(async () => {
-      resetTaskRegistryMemoryForTest();
       const now = Date.now();
       configureTaskRegistryRuntime({
         store: {
@@ -4253,7 +4162,6 @@ describe("task-registry", () => {
 
   it("delivers concise state-change updates only when notify policy requests them", async () => {
     await withTaskRegistryTempDir(async () => {
-      resetTaskRegistryMemoryForTest();
       hoisted.sendMessageMock.mockResolvedValue({
         channel: "guildchat",
         to: "guildchat:123",
@@ -4338,7 +4246,6 @@ describe("task-registry", () => {
 
   it("keeps background ACP progress off the foreground lane and only sends a terminal notify", async () => {
     await withTaskRegistryTempDir(async () => {
-      resetTaskRegistryMemoryForTest();
       resetSystemEventsForTest();
       hoisted.sendMessageMock.mockResolvedValue({
         channel: "guildchat",
@@ -4401,7 +4308,6 @@ describe("task-registry", () => {
 
   it("delivers a concise terminal failure message without internal ACP chatter", async () => {
     await withTaskRegistryTempDir(async () => {
-      resetTaskRegistryMemoryForTest();
       resetSystemEventsForTest();
       hoisted.sendMessageMock.mockResolvedValue({
         channel: "guildchat",
@@ -4442,7 +4348,6 @@ describe("task-registry", () => {
 
   it("emits concise state-change updates without surfacing raw ACP chatter", async () => {
     await withTaskRegistryTempDir(async () => {
-      resetTaskRegistryMemoryForTest();
       resetSystemEventsForTest();
       hoisted.sendMessageMock.mockResolvedValue({
         channel: "guildchat",


### PR DESCRIPTION
## What Problem This Solves

Task registry tests spend time initializing and closing empty SQLite databases even when their enclosing fixture already installed fresh in-memory stores. This slows ordinary test execution without adding persistence coverage.

## Why This Change Was Made

Remove the redundant test-local memory reset helper and its 70 calls. The enclosing fixture remains the sole initialization and cleanup owner. In six fresh SQLite fixture callbacks, use the existing non-persisting reset so the first real task write initializes the database once.

The 63 generated memory cases that previously persisted an empty reset no longer create that unused database. Eleven real SQLite cases avoid an empty initialization/reopen cycle. All assertions, durable-store choices, cleanup hooks, production reset defaults, sharding, and concurrency remain unchanged. Production LOC: 0. Tests: +6/-101.

## User Impact

Faster developer tests; no product behavior or storage/schema changes. This is a maintainer-requested, AI-assisted performance improvement.

## Evidence

Two alternating before/after runs on the same main baseline, Node 26.5.0/macOS, same 182 tests and routing:

| Test file | Before execution | After execution |
| --- | --- | --- |
| task-registry.test.ts (135 cases) | 21.79s / 14.02s | 7.46s / 7.84s |
| task-registry.store.test.ts (47 cases) | 7.00s / 5.00s | 3.40s / 4.13s |

Combined test execution dropped from 28.79s / 19.02s to 10.86s / 11.96s (37–62%). These include case setup/cleanup; no work moved into beforeAll. Host variation is visible, so this is a focused improvement, not a claimed whole-repository wall-time result.

- `node scripts/run-vitest.mjs src/tasks/task-registry.test.ts src/tasks/task-registry.store.test.ts`: 182 passed in each before/after run.
- `node scripts/run-vitest.mjs --config test/vitest/vitest.tasks.config.ts`: 307 passed across 12 files, before and after.
- Temporary mechanism probe: absence of the SQLite file in the first memory lifecycle case fails on baseline and passes on candidate.
- Temporary failure-isolation probe: deliberately fail after creating the first task; the next case asserts that run is absent and passes. Exactly one intentional failure, no leaked state. All probe edits removed.
- Real disk restore, notification-policy validation, corrupt rows/index, two-connection snapshot race, modes, and task-flow persistence assertions remain.
- Independent Codex autoreview: no actionable findings.
- `env -u OPENCLAW_TESTBOX node scripts/check-changed.mjs -- src/tasks/task-registry.test.ts src/tasks/task-registry.store.test.ts`: full selected formatting, typecheck, lint, and guards passed.
