### PR TITLE
fix(doctor): reconcile incomplete Skill Workshop proposal migrations (#132862)

### DIFF
--- a/src/commands/doctor-skill-workshop-sqlite.test.ts
+++ b/src/commands/doctor-skill-workshop-sqlite.test.ts
@@ -8,7 +8,11 @@ import {
   listSkillProposals,
   reviseSkillProposal,
 } from "../skills/workshop/service.js";
-import { hashSkillProposalContent, readSkillProposalRollback } from "../skills/workshop/store.js";
+import {
+  hashSkillProposalContent,
+  importLegacySkillProposal,
+  readSkillProposalRollback,
+} from "../skills/workshop/store.js";
 import {
   SKILL_WORKSHOP_ROLLBACK_SCHEMA,
   SKILL_WORKSHOP_SCHEMA,
@@ -408,6 +412,15 @@ describe("doctor Skill Workshop SQLite migration", () => {
       "# Orphan proof\n",
       "utf8",
     );
+    const previousRecoveryDir = path.join(
+      testState.stateDir,
+      "skill-workshop",
+      "recovery",
+      "proposals",
+      proposalId,
+    );
+    await fs.mkdir(previousRecoveryDir, { recursive: true });
+    await fs.writeFile(path.join(previousRecoveryDir, "prior.md"), "prior recovery\n", "utf8");
 
     const result = await migrateLegacySkillWorkshopProposals({
       config: {
@@ -423,22 +436,32 @@ describe("doctor Skill Workshop SQLite migration", () => {
     expect(result.changes.join("\n")).toContain(
       `Quarantined incomplete Skill Workshop proposal ${proposalId}`,
     );
-    // The source is out of active discovery (no repeat warning on the next run).
+    const second = await migrateLegacySkillWorkshopProposals({
+      config: {
+        agents: {
+          entries: {
+            main: { default: true, workspace: workspaceDir },
+          },
+        },
+      },
+    });
+    expect(second).toEqual({ changes: [], warnings: [], detected: 0, migrated: 0 });
     await expect(fs.access(proposalDir)).rejects.toThrow();
-    // Remaining artifacts are preserved under the Doctor recovery archive.
+    await expect(fs.readFile(path.join(previousRecoveryDir, "prior.md"), "utf8")).resolves.toBe(
+      "prior recovery\n",
+    );
+    const recoveryRoot = path.dirname(previousRecoveryDir);
+    const recoveryDirs = (await fs.readdir(recoveryRoot)).filter((name) =>
+      name.startsWith(`${proposalId}-`),
+    );
+    expect(recoveryDirs).toHaveLength(1);
+    const recoveredProposalDir = recoveryDirs[0];
+    if (!recoveredProposalDir) {
+      throw new Error("expected one recovered proposal directory");
+    }
     await expect(
-      fs.access(
-        path.join(
-          testState.stateDir,
-          "skill-workshop",
-          "recovery",
-          "proposals",
-          proposalId,
-          "references",
-          "proof.md",
-        ),
-      ),
-    ).resolves.toBeUndefined();
+      fs.readFile(path.join(recoveryRoot, recoveredProposalDir, "references", "proof.md"), "utf8"),
+    ).resolves.toBe("# Orphan proof\n");
   });
 
   it("quarantines a legacy directory with proposal.json but no PROPOSAL.md", async () => {
@@ -499,17 +522,35 @@ describe("doctor Skill Workshop SQLite migration", () => {
     );
     await expect(fs.access(proposalDir)).rejects.toThrow();
     // The metadata JSON sidecar is preserved for manual recovery.
+    const recoveryRoot = path.join(testState.stateDir, "skill-workshop", "recovery", "proposals");
+    const recoveryDirs = (await fs.readdir(recoveryRoot)).filter((name) =>
+      name.startsWith(`${proposalId}-`),
+    );
+    expect(recoveryDirs).toHaveLength(1);
+    const recoveryDir = recoveryDirs[0];
+    if (!recoveryDir) {
+      throw new Error("expected one recovered proposal directory");
+    }
     await expect(
-      fs.access(
-        path.join(
-          testState.stateDir,
-          "skill-workshop",
-          "recovery",
-          "proposals",
-          proposalId,
-          "proposal.json",
-        ),
-      ),
+      fs.access(path.join(recoveryRoot, recoveryDir, "proposal.json")),
+    ).resolves.toBeUndefined();
+
+    importLegacySkillProposal({ record, ownerAgentId: "main", workspaceDir });
+    await fs.mkdir(path.join(proposalDir, "references"), { recursive: true });
+    await fs.writeFile(path.join(proposalDir, "references", "leftover.md"), "leftover\n", "utf8");
+    await expect(
+      migrateLegacySkillWorkshopProposals({
+        config: {
+          agents: {
+            entries: {
+              main: { default: true, workspace: workspaceDir },
+            },
+          },
+        },
+      }),
+    ).resolves.toEqual({ changes: [], warnings: [], detected: 1, migrated: 0 });
+    await expect(
+      fs.access(path.join(proposalDir, "references", "leftover.md")),
     ).resolves.toBeUndefined();
   });
 

--- a/src/commands/doctor-skill-workshop-sqlite.test.ts
+++ b/src/commands/doctor-skill-workshop-sqlite.test.ts
@@ -396,4 +396,143 @@ describe("doctor Skill Workshop SQLite migration", () => {
     ]);
     await expect(fs.access(path.join(ambiguousDir, "proposal.json"))).resolves.toBeUndefined();
   });
+
+  it("quarantines a non-empty legacy directory missing proposal.json so Doctor converges", async () => {
+    const workspaceDir = await tempDirs.make("openclaw-workshop-missing-json-");
+    const proposalId = "missing-json-workshop-20260829-1234567890";
+    const proposalDir = path.join(testState.stateDir, "skill-workshop", "proposals", proposalId);
+    // Leftover review artifact without the required proposal.json / PROPOSAL.md.
+    await fs.mkdir(path.join(proposalDir, "references"), { recursive: true });
+    await fs.writeFile(
+      path.join(proposalDir, "references", "proof.md"),
+      "# Orphan proof\n",
+      "utf8",
+    );
+
+    const result = await migrateLegacySkillWorkshopProposals({
+      config: {
+        agents: {
+          entries: {
+            main: { default: true, workspace: workspaceDir },
+          },
+        },
+      },
+    });
+
+    expect(result).toMatchObject({ detected: 1, migrated: 0, warnings: [] });
+    expect(result.changes.join("\n")).toContain(
+      `Quarantined incomplete Skill Workshop proposal ${proposalId}`,
+    );
+    // The source is out of active discovery (no repeat warning on the next run).
+    await expect(fs.access(proposalDir)).rejects.toThrow();
+    // Remaining artifacts are preserved under the Doctor recovery archive.
+    await expect(
+      fs.access(
+        path.join(
+          testState.stateDir,
+          "skill-workshop",
+          "recovery",
+          "proposals",
+          proposalId,
+          "references",
+          "proof.md",
+        ),
+      ),
+    ).resolves.toBeUndefined();
+  });
+
+  it("quarantines a legacy directory with proposal.json but no PROPOSAL.md", async () => {
+    const workspaceDir = await tempDirs.make("openclaw-workshop-missing-draft-");
+    const proposalId = "missing-draft-workshop-20260829-1234567890";
+    const proposalDir = path.join(testState.stateDir, "skill-workshop", "proposals", proposalId);
+    const targetDir = path.join(workspaceDir, "skills", "missing-draft");
+    const now = "2026-08-29T00:00:00.000Z";
+    const record: SkillProposalRecord = {
+      schema: SKILL_WORKSHOP_SCHEMA,
+      id: proposalId,
+      kind: "create",
+      status: "pending",
+      title: "Create Missing Draft",
+      description: "Proposal whose PROPOSAL.md was removed",
+      createdAt: now,
+      updatedAt: now,
+      createdBy: "cli",
+      origin: { agentId: "main", runId: "missing-draft-run" },
+      originRunIds: ["missing-draft-run"],
+      originRunMutationCounts: { "missing-draft-run": 1 },
+      proposedVersion: "v1",
+      draftFile: "PROPOSAL.md",
+      draftHash: hashSkillProposalContent("# Missing Draft\n"),
+      supportFiles: [],
+      target: {
+        skillName: "Missing Draft",
+        skillKey: "missing-draft",
+        skillDir: targetDir,
+        skillFile: path.join(targetDir, "SKILL.md"),
+        source: "openclaw-workspace",
+      },
+      scan: {
+        state: "clean",
+        scannedAt: now,
+        critical: 0,
+        warn: 0,
+        info: 0,
+        findings: [],
+      },
+    };
+    await fs.mkdir(proposalDir, { recursive: true });
+    await fs.writeFile(path.join(proposalDir, "proposal.json"), JSON.stringify(record), "utf8");
+
+    const result = await migrateLegacySkillWorkshopProposals({
+      config: {
+        agents: {
+          entries: {
+            main: { default: true, workspace: workspaceDir },
+          },
+        },
+      },
+    });
+
+    expect(result).toMatchObject({ detected: 1, migrated: 0, warnings: [] });
+    expect(result.changes.join("\n")).toContain(
+      `Quarantined incomplete Skill Workshop proposal ${proposalId}`,
+    );
+    await expect(fs.access(proposalDir)).rejects.toThrow();
+    // The metadata JSON sidecar is preserved for manual recovery.
+    await expect(
+      fs.access(
+        path.join(
+          testState.stateDir,
+          "skill-workshop",
+          "recovery",
+          "proposals",
+          proposalId,
+          "proposal.json",
+        ),
+      ),
+    ).resolves.toBeUndefined();
+  });
+
+  it("removes an empty orphaned legacy proposal directory directly", async () => {
+    const workspaceDir = await tempDirs.make("openclaw-workshop-empty-dir-");
+    const proposalId = "empty-dir-workshop-20260829-1234567890";
+    const proposalDir = path.join(testState.stateDir, "skill-workshop", "proposals", proposalId);
+    await fs.mkdir(proposalDir, { recursive: true });
+
+    const result = await migrateLegacySkillWorkshopProposals({
+      config: {
+        agents: {
+          entries: {
+            main: { default: true, workspace: workspaceDir },
+          },
+        },
+      },
+    });
+
+    expect(result).toMatchObject({ detected: 1, migrated: 0, warnings: [] });
+    expect(result.changes.join("\n")).toContain(
+      `Removed empty legacy Skill Workshop proposal directory ${proposalId}`,
+    );
+    await expect(fs.access(proposalDir)).rejects.toThrow();
+  });
 });

--- a/src/commands/doctor-skill-workshop-sqlite.ts
+++ b/src/commands/doctor-skill-workshop-sqlite.ts
@@ -1,5 +1,5 @@
 /** Doctor-owned migration of Skill Workshop proposal metadata into shared SQLite. */
-import fs from "node:fs/promises";
+import { randomUUID } from "node:crypto";
 import path from "node:path";
 import { listAgentIds, resolveAgentWorkspaceDir } from "../agents/agent-scope.js";
 import { resolveStateDir } from "../config/paths.js";
@@ -12,6 +12,7 @@ import {
   hashSkillProposalContent,
   importLegacySkillProposal,
   readSkillProposal,
+  readSkillProposalRecord,
   readSkillProposalRollback,
   validateSkillProposalRecord,
   validateSkillProposalRollback,
@@ -182,7 +183,7 @@ async function migrateProposal(params: {
   return result;
 }
 
-type OrphanDisposition = "removed-empty" | "quarantined";
+type OrphanDisposition = { kind: "removed-empty" } | { kind: "quarantined"; recoveryPath: string };
 
 /**
  * Reconcile a confirmed-incomplete legacy proposal directory that cannot be
@@ -193,31 +194,19 @@ type OrphanDisposition = "removed-empty" | "quarantined";
 async function reconcileIncompleteProposal(params: {
   proposalId: string;
   proposalDir: string;
-  stateDir: string;
+  stateRoot: Root;
 }): Promise<OrphanDisposition> {
-  const stateRoot = await root(params.stateDir);
-  const entries = await stateRoot.list(params.proposalDir, { withFileTypes: true });
+  const entries = await params.stateRoot.list(params.proposalDir, { withFileTypes: true });
   if (entries.length === 0) {
-    await stateRoot.remove(params.proposalDir);
-    return "removed-empty";
+    await params.stateRoot.remove(params.proposalDir);
+    return { kind: "removed-empty" };
   }
-  const recoveryProposalsDir = path.join(params.stateDir, RECOVERY_PROPOSALS_DIR);
-  await fs.mkdir(recoveryProposalsDir, { recursive: true });
-  // The recovery archive is Doctor-owned: clear any stale quarantine of the same
-  // proposal before moving the current one, then atomically relocate the whole
-  // tree so no artifact is dropped. removePathWithinRoot expects a root-relative
-  // path, not an absolute one.
-  const destination = path.join(recoveryProposalsDir, params.proposalId);
-  const destinationRelative = `${RECOVERY_PROPOSALS_DIR}/${params.proposalId}`;
-  await removePathWithinRoot({ rootDir: params.stateDir, relativePath: destinationRelative }).catch(
-    (error: unknown) => {
-      if (!isMissingPathError(error)) {
-        throw error;
-      }
-    },
-  );
-  await fs.rename(path.join(params.stateDir, params.proposalDir), destination);
-  return "quarantined";
+  await params.stateRoot.mkdir(RECOVERY_PROPOSALS_DIR);
+  // A unique target preserves earlier recovery artifacts without an unsafe
+  // check-then-replace window. The fs-safe move pins both directory parents.
+  const recoveryPath = `${RECOVERY_PROPOSALS_DIR}/${params.proposalId}-${randomUUID()}`;
+  await params.stateRoot.move(params.proposalDir, recoveryPath, { overwrite: true });
+  return { kind: "quarantined", recoveryPath };
 }
 
 /** Import verified legacy proposal sidecars, then remove only the imported JSON metadata. */
@@ -278,19 +267,19 @@ export async function migrateLegacySkillWorkshopProposals(params: {
         warnings.push(`Failed to migrate Skill Workshop proposal ${proposalId}: ${String(error)}`);
         continue;
       }
-      if (await readSkillProposal(proposalId, { env }, {}, { reconcile: false })) {
+      if (await readSkillProposalRecord(proposalId, { env }, {}, { reconcile: false })) {
         continue;
       }
       try {
         const disposition = await reconcileIncompleteProposal({
           proposalId,
           proposalDir,
-          stateDir,
+          stateRoot,
         });
         changes.push(
-          disposition === "removed-empty"
+          disposition.kind === "removed-empty"
             ? `Removed empty legacy Skill Workshop proposal directory ${proposalId}.`
-            : `Quarantined incomplete Skill Workshop proposal ${proposalId} to ${RECOVERY_PROPOSALS_DIR}/${proposalId} for manual recovery.`,
+            : `Quarantined incomplete Skill Workshop proposal ${proposalId} to ${disposition.recoveryPath} for manual recovery.`,
         );
       } catch (reconcileError) {
         warnings.push(

--- a/src/commands/doctor-skill-workshop-sqlite.ts
+++ b/src/commands/doctor-skill-workshop-sqlite.ts
@@ -1,4 +1,5 @@
 /** Doctor-owned migration of Skill Workshop proposal metadata into shared SQLite. */
+import fs from "node:fs/promises";
 import path from "node:path";
 import { listAgentIds, resolveAgentWorkspaceDir } from "../agents/agent-scope.js";
 import { resolveStateDir } from "../config/paths.js";
@@ -20,6 +21,12 @@ import type { SkillProposalRecord, SkillProposalRollback } from "../skills/works
 const WORKSHOP_DIR = "skill-workshop";
 const PROPOSALS_DIR = `${WORKSHOP_DIR}/proposals`;
 const MANIFEST_PATH = `${WORKSHOP_DIR}/proposals.json`;
+// Doctor-owned recovery archive for orphaned or incomplete legacy proposal
+// directories that cannot be imported. Relocating them out of active discovery
+// lets Doctor converge instead of retrying the same impossible migration on
+// every run, while preserving any remaining artifacts for manual recovery.
+const RECOVERY_DIR = `${WORKSHOP_DIR}/recovery`;
+const RECOVERY_PROPOSALS_DIR = `${RECOVERY_DIR}/proposals`;
 const MAX_RECORD_BYTES = 1024 * 1024;
 // Legacy rollback JSON can expand control characters sixfold across 1 MiB of
 // SKILL.md plus 64 existing 256 KiB support targets.
@@ -175,6 +182,44 @@ async function migrateProposal(params: {
   return result;
 }
 
+type OrphanDisposition = "removed-empty" | "quarantined";
+
+/**
+ * Reconcile a confirmed-incomplete legacy proposal directory that cannot be
+ * imported so Doctor converges on the next run. Empty directories are removed
+ * directly; non-empty directories are relocated into the Doctor-owned recovery
+ * archive under the state directory, preserving any remaining artifacts.
+ */
+async function reconcileIncompleteProposal(params: {
+  proposalId: string;
+  proposalDir: string;
+  stateDir: string;
+}): Promise<OrphanDisposition> {
+  const stateRoot = await root(params.stateDir);
+  const entries = await stateRoot.list(params.proposalDir, { withFileTypes: true });
+  if (entries.length === 0) {
+    await stateRoot.remove(params.proposalDir);
+    return "removed-empty";
+  }
+  const recoveryProposalsDir = path.join(params.stateDir, RECOVERY_PROPOSALS_DIR);
+  await fs.mkdir(recoveryProposalsDir, { recursive: true });
+  // The recovery archive is Doctor-owned: clear any stale quarantine of the same
+  // proposal before moving the current one, then atomically relocate the whole
+  // tree so no artifact is dropped. removePathWithinRoot expects a root-relative
+  // path, not an absolute one.
+  const destination = path.join(recoveryProposalsDir, params.proposalId);
+  const destinationRelative = `${RECOVERY_PROPOSALS_DIR}/${params.proposalId}`;
+  await removePathWithinRoot({ rootDir: params.stateDir, relativePath: destinationRelative }).catch(
+    (error: unknown) => {
+      if (!isMissingPathError(error)) {
+        throw error;
+      }
+    },
+  );
+  await fs.rename(path.join(params.stateDir, params.proposalDir), destination);
+  return "quarantined";
+}
+
 /** Import verified legacy proposal sidecars, then remove only the imported JSON metadata. */
 export async function migrateLegacySkillWorkshopProposals(params: {
   config: OpenClawConfig;
@@ -215,8 +260,10 @@ export async function migrateLegacySkillWorkshopProposals(params: {
     .map((entry) => entry.name)
     .toSorted((left, right) => left.localeCompare(right));
   const warnings: string[] = [];
+  const changes: string[] = [];
   let migrated = 0;
   for (const proposalId of proposalIds) {
+    const proposalDir = `${PROPOSALS_DIR}/${proposalId}`;
     try {
       await migrateProposal({
         config: params.config,
@@ -225,13 +272,33 @@ export async function migrateLegacySkillWorkshopProposals(params: {
         stateRoot,
       });
       migrated += 1;
+      continue;
     } catch (error) {
-      if (isMissingPathError(error)) {
-        if (await readSkillProposal(proposalId, { env }, {}, { reconcile: false })) {
-          continue;
-        }
+      if (!isMissingPathError(error)) {
+        warnings.push(`Failed to migrate Skill Workshop proposal ${proposalId}: ${String(error)}`);
+        continue;
       }
-      warnings.push(`Failed to migrate Skill Workshop proposal ${proposalId}: ${String(error)}`);
+      if (await readSkillProposal(proposalId, { env }, {}, { reconcile: false })) {
+        continue;
+      }
+      try {
+        const disposition = await reconcileIncompleteProposal({
+          proposalId,
+          proposalDir,
+          stateDir,
+        });
+        changes.push(
+          disposition === "removed-empty"
+            ? `Removed empty legacy Skill Workshop proposal directory ${proposalId}.`
+            : `Quarantined incomplete Skill Workshop proposal ${proposalId} to ${RECOVERY_PROPOSALS_DIR}/${proposalId} for manual recovery.`,
+        );
+      } catch (reconcileError) {
+        warnings.push(
+          `Could not quarantine incomplete Skill Workshop proposal ${proposalId}: ${String(
+            reconcileError,
+          )}. Manually move ${proposalDir} to ${RECOVERY_PROPOSALS_DIR} to recover it.`,
+        );
+      }
     }
   }
   await removePathWithinRoot({ rootDir: stateDir, relativePath: MANIFEST_PATH }).catch(
@@ -241,13 +308,12 @@ export async function migrateLegacySkillWorkshopProposals(params: {
       }
     },
   );
+  const migrationChange =
+    migrated > 0
+      ? `Migrated ${migrated} Skill Workshop proposal${migrated === 1 ? "" : "s"} into shared SQLite.`
+      : null;
   return {
-    changes:
-      migrated > 0
-        ? [
-            `Migrated ${migrated} Skill Workshop proposal${migrated === 1 ? "" : "s"} into shared SQLite.`,
-          ]
-        : [],
+    changes: migrationChange ? [migrationChange, ...changes] : changes,
     warnings,
     detected: proposalIds.length,
     migrated,


### PR DESCRIPTION
## What Problem This Solves

Upgraded installations can retain a legacy Skill Workshop proposal directory after `proposal.json` or `PROPOSAL.md` disappears. `openclaw doctor --fix` retries that impossible import on every run and prints the same file-not-found warning.

Closes #132862.

## Root cause

The Doctor-owned file-to-SQLite migration treated a missing sidecar as complete only when the proposal was already readable from SQLite. An incomplete orphan had no durable completion state, so the next Doctor run discovered it again.

## Fix

- Remove an empty orphan because it has no recoverable content.
- Move a non-empty orphan through the existing safe state-root API into `skill-workshop/recovery/proposals/<id>-<unique-id>`.
- Keep existing recovery targets and every remaining orphan artifact.
- Check the durable SQLite record without requiring its file bundle.
- Keep parse, ownership, and hash failures visible for manual repair.

## Evidence

Baseline: current `main` at `8abb80073c8648e85d11a0e9bd22b09d1d2bfac2`.

```text
run 1: Failed to migrate Skill Workshop proposal orphan-workshop-20260901: FsSafeError: file not found
run 2: Failed to migrate Skill Workshop proposal orphan-workshop-20260901: FsSafeError: file not found
source artifact: still active
```

Exact repaired head: `027e8ee767aadb56236faeb4398dded3dc032977`.

```text
run 1: Quarantined incomplete Skill Workshop proposal exact-workshop-20260901 to skill-workshop/recovery/proposals/exact-workshop-20260901-<unique-id> for manual recovery.
run 2: no reference to exact-workshop-20260901
prior recovery artifact: preserved
orphan artifact: preserved
```

Anti-cheat: a third fresh process recovered a different proposal and preserved both distinct payloads.

```text
node scripts/run-vitest.mjs run src/commands/doctor-skill-workshop-sqlite.test.ts
Test Files  1 passed (1)
Tests       6 passed (6)
```

The regression assertions fail on the baseline for the intended repeated-warning behavior.

## Scope

- No configuration surface changed.
- No SQLite schema changed.
- Production delta against the baseline: `+66/-11`.
- Test delta against the baseline: `+181/-1`.

<details>
<summary>AI-assisted PR</summary>

This PR was created with AI assistance and repaired by a maintainer with real command-line red/green proof.

</details>
