### PR TITLE
refactor(agents): reuse auth profile listing

### DIFF
--- a/src/agents/models-config.providers.secret-helpers.ts
+++ b/src/agents/models-config.providers.secret-helpers.ts
@@ -5,6 +5,7 @@ import { normalizeOptionalString } from "@openclaw/normalization-core/string-coe
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { coerceSecretRef, resolveSecretInputRef } from "../config/types.secrets.js";
 import { normalizeOptionalSecretInput } from "../utils/normalize-secret-input.js";
+import { listProfilesForProvider } from "./auth-profiles/profile-list.js";
 import type { AuthProfileStore } from "./auth-profiles/types.js";
 import { resolveEnvApiKey, type EnvApiKeyLookupOptions } from "./model-auth-env.js";
 import {
@@ -14,7 +15,6 @@ import {
   resolveNonEnvSecretRefHeaderValueMarker,
 } from "./model-auth-markers.js";
 import { resolveAwsSdkEnvVarName } from "./model-auth-runtime-shared.js";
-import { resolveProviderIdForAuth } from "./provider-auth-aliases.js";
 
 /**
  * Secret-aware provider config helpers.
@@ -201,21 +201,13 @@ export function resolveApiKeyFromCredential(
   return undefined;
 }
 
-/** Lists auth profile ids whose provider aliases match the requested provider. */
-export function listAuthProfilesForProvider(store: AuthProfileStore, provider: string): string[] {
-  const providerKey = resolveProviderIdForAuth(provider);
-  return Object.entries(store.profiles)
-    .filter(([, cred]) => resolveProviderIdForAuth(cred.provider) === providerKey)
-    .map(([id]) => id);
-}
-
 /** Resolves the first usable API key from matching auth profiles. */
 export function resolveApiKeyFromProfiles(params: {
   provider: string;
   store: AuthProfileStore;
   env?: NodeJS.ProcessEnv;
 }): ProfileApiKeyResolution | undefined {
-  const ids = listAuthProfilesForProvider(params.store, params.provider);
+  const ids = listProfilesForProvider(params.store, params.provider);
   for (const id of ids) {
     const resolved = resolveApiKeyFromCredential(params.store.profiles[id], params.env);
     if (resolved) {

--- a/src/agents/models-config.providers.secrets.ts
+++ b/src/agents/models-config.providers.secrets.ts
@@ -8,6 +8,7 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { resolveSecretInputRef } from "../config/types.secrets.js";
 import { resolveProviderSyntheticAuthWithPlugin } from "../plugins/provider-runtime.js";
 import type { ProviderAuthEvidence } from "../secrets/provider-env-vars.js";
+import { listProfilesForProvider } from "./auth-profiles/profile-list.js";
 import type { AuthProfileStore } from "./auth-profiles/types.js";
 import { resolveProviderEnvAuthLookupMaps } from "./model-auth-env-vars.js";
 import {
@@ -17,7 +18,6 @@ import {
   resolveNonEnvSecretRefApiKeyMarker,
 } from "./model-auth-markers.js";
 import {
-  listAuthProfilesForProvider,
   normalizeApiKeyConfig,
   resolveApiKeyFromCredential,
   resolveApiKeyFromProfiles,
@@ -191,7 +191,7 @@ export function createProviderAuthResolver(
     const lookupCaches = getLookupCaches();
     const authProvider = resolveProviderIdForAuthFromCaches(provider, lookupCaches);
     const authStore = resolveAuthProfileStoreInput(authStoreInput);
-    const ids = listAuthProfilesForProvider(authStore, authProvider);
+    const ids = listProfilesForProvider(authStore, authProvider);
 
     let oauthCandidate:
       | {


### PR DESCRIPTION
## What Problem This Solves

Provider auth resolution maintained a second copy of the canonical provider-profile enumeration logic. The implementations were identical, so future alias or ordering changes could drift between model-config secret resolution and the shared auth-profile owner.

## Why This Change Was Made

Both model-config consumers now import the lightweight canonical `listProfilesForProvider` helper directly. The duplicate exported helper and its unused alias resolver import are removed; the specialized auth ordering path remains unchanged.

This is the best fix because `auth-profiles/profile-list.ts` already owns the exact side-effect-free invariant. Keeping an alias or another wrapper would preserve duplicate policy without a compatibility requirement.

## User Impact

No user-visible behavior changes. Provider aliases and profile insertion order resolve exactly as before, with one canonical implementation instead of two.

## Evidence

- Production LOC: +4/-12 (net -8). Tests: +0/-0.
- Direct comparison on current `main` confirmed the removed helper was byte-identical apart from its name.
- `node scripts/run-vitest.mjs src/agents/models-config.providers.auth-provenance.test.ts src/agents/models-config.providers.normalize-keys.test.ts src/agents/provider-auth-aliases.test.ts src/agents/auth-profiles/order.test.ts`: 67 passed.
- `pnpm exec oxfmt --check` on both changed files: passed.
- `pnpm exec oxlint` on both changed files: passed.
- `pnpm tsgo:core`: passed.
- Mandatory local autoreview with `gpt-5.6-sol` at high reasoning: clean, patch correctness confidence 0.98.
