### PR TITLE
test: batch boundary guard lint fixtures

### DIFF
--- a/test/scripts/oxlint-boundary-guards.test.ts
+++ b/test/scripts/oxlint-boundary-guards.test.ts
@@ -1,5 +1,5 @@
 import { spawnSync } from "node:child_process";
-import { describe, expect, it } from "vitest";
+import { beforeAll, describe, expect, it } from "vitest";
 
 const FIXTURES = "test/fixtures/oxlint-boundary-guards";
 const cases = [
@@ -25,27 +25,42 @@ const cases = [
   },
 ];
 
-function runGuard(target: string) {
-  return spawnSync(
-    process.execPath,
-    [
-      "scripts/run-oxlint.mjs",
-      "--openclaw-focused-config",
-      "--config",
-      "config/oxlint/boundary-guards.json",
-      target,
-    ],
-    { encoding: "utf8" },
-  );
-}
-
 describe("oxlint boundary guards", () => {
+  let diagnostics: Array<{ filename: string; code: string; severity: string }>;
+
+  beforeAll(() => {
+    const violation = spawnSync(
+      process.execPath,
+      [
+        "scripts/run-oxlint.mjs",
+        "--openclaw-focused-config",
+        "--config",
+        "config/oxlint/boundary-guards.json",
+        "--format",
+        "json",
+        ...cases.map((testCase) => testCase.violation),
+      ],
+      { encoding: "utf8" },
+    );
+    expect(violation.error).toBeUndefined();
+    expect(violation.status, violation.stderr).toBe(1);
+    const report = JSON.parse(violation.stdout) as {
+      diagnostics: typeof diagnostics;
+      number_of_files: number;
+    };
+    expect(report.number_of_files).toBe(cases.length);
+    diagnostics = report.diagnostics;
+  });
+
   it.each(cases)("reports expected violations for $rule", (testCase) => {
-    const violation = runGuard(testCase.violation);
-    const output = `${violation.stdout}${violation.stderr}`;
-    expect(violation.status).toBe(1);
-    expect(output.split(`${testCase.rule.replace("/", "(")})`)).toHaveLength(
-      testCase.violations + 1,
+    // A fixture can trigger sibling rules; match both its file and its owning rule.
+    const matching = diagnostics.filter(
+      (diagnostic) =>
+        diagnostic.filename.replaceAll("\\", "/") === testCase.violation &&
+        diagnostic.code === `${testCase.rule.replace("/", "(")})`,
+    );
+    expect(matching.map((diagnostic) => diagnostic.severity)).toEqual(
+      Array(testCase.violations).fill("error"),
     );
   });
 });


### PR DESCRIPTION
## What Problem This Solves

The boundary guard fixture suite starts the real Oxlint wrapper and native linter four times, once per file. Repeated process startup dominates these small tests.

## Why This Change Was Made

Run the same four fixtures through one native batch in `beforeAll`, using the existing focused configuration and JSON output. Keep all four named tests and their exact violation counts; match both filename and rule, and require error severity. Check process errors, exit status, and the complete fixture count before evaluating diagnostics. Remove the one-use subprocess helper.

This follows the existing batched JSON approach in the neighboring Oxlint configuration tests. The installed Oxlint 1.79.0 implementation resets file state and diagnostics and creates ordinary rule visitors separately for each file. No rule, fixture, dependency, sharding, worker, or concurrency change. Production LOC: 0; test LOC: +35/-20.

## User Impact

Faster developer tests, with no product behavior change. This is a maintainer-requested, AI-assisted performance improvement.

## Evidence

Alternating runs with the pinned Oxlint 1.79.0, Node 26.5.0/macOS, same four tests and routing:

| Run | Before | After |
| --- | --- | --- |
| A | 2.83s | 678ms |
| B | 2.04s | 626ms |

These are complete Vitest test phases, including `beforeAll`: 69–76% less execution time. Per-case JSON timing excludes the shared setup and is deliberately not used. This is a focused result, not a whole-suite wall-time claim.

- Separate native runs and the batch produced identical complete diagnostic objects: 15 diagnostics, including messages, rule codes, severities, labels, and spans.
- Temporarily disabling the HTTP-call rule and the widening rule independently caused exactly one corresponding named test to fail in each run; the other three passed.
- Temporarily omitting one fixture failed the setup assertion with three files instead of four. All temporary mutations were removed.
- Boundary fixtures and neighboring Oxlint configuration tests pass together (17 tests). An initial sibling failure exposed an outdated local Oxlint 1.78 installation; refreshing the existing pinned dependencies fixed it without changing any source or test expectation.
- Independent Codex autoreview found no actionable findings. Full changed-file validation covers formatting, typechecking, scripts lint, and repository guards.
