### PR TITLE
fix(android): stop hiding reconnect fixture teardown failures

### DIFF
--- a/apps/android/app/src/test/java/ai/openclaw/app/gateway/GatewaySessionReconnectTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/gateway/GatewaySessionReconnectTest.kt
@@ -18,6 +18,7 @@ import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
+import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.Response
 import okhttp3.WebSocket
@@ -144,17 +145,76 @@ private data class ReconnectServer(
     get() = server.requestCount
 
   fun shutdown() {
-    sockets.forEach { runCatching { it.cancel() } }
-    runCatching { server.shutdown() }
-      .onFailure { err ->
-        if (err.message != "Gave up waiting for queue to shut down") throw err
-      }
+    server.shutdown()
   }
 }
 
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [34])
 class GatewaySessionReconnectTest {
+  @Test
+  fun serverAcknowledgesPeerCloseBeforeTeardown() =
+    runBlocking {
+      val opened = CompletableDeferred<Unit>()
+      val peerClosed = CompletableDeferred<Pair<Int, String>>()
+      val serverClosed = CompletableDeferred<Unit>()
+      val terminalCallbacks = AtomicInteger()
+      val server =
+        startGatewayServer(
+          json = Json,
+          onClosed = {
+            terminalCallbacks.incrementAndGet()
+            serverClosed.complete(Unit)
+          },
+        ) { _, _, _ -> }
+      val client = OkHttpClient()
+      val socket =
+        client.newWebSocket(
+          Request.Builder().url("ws://127.0.0.1:${server.port}/").build(),
+          object : WebSocketListener() {
+            override fun onOpen(
+              webSocket: WebSocket,
+              response: Response,
+            ) {
+              opened.complete(Unit)
+            }
+
+            override fun onClosed(
+              webSocket: WebSocket,
+              code: Int,
+              reason: String,
+            ) {
+              peerClosed.complete(code to reason)
+            }
+
+            override fun onFailure(
+              webSocket: WebSocket,
+              t: Throwable,
+              response: Response?,
+            ) {
+              opened.completeExceptionally(t)
+              peerClosed.completeExceptionally(t)
+            }
+          },
+        )
+
+      try {
+        withTimeout(LIFECYCLE_TEST_TIMEOUT_MS) { opened.await() }
+        assertTrue(socket.close(1000, "test complete"))
+        assertEquals(1000 to "test complete", withTimeout(LIFECYCLE_TEST_TIMEOUT_MS) { peerClosed.await() })
+        withTimeout(LIFECYCLE_TEST_TIMEOUT_MS) { serverClosed.await() }
+        server.shutdown()
+        assertEquals(1, terminalCallbacks.get())
+      } finally {
+        // A missing acknowledgment must fail the test without leaving the server writer open.
+        server.sockets.forEach { it.close(1000, "test complete") }
+        socket.cancel()
+        client.dispatcher.executorService.shutdown()
+        client.connectionPool.evictAll()
+        server.shutdown()
+      }
+    }
+
   @Test
   fun sequenceGapSignalsRecoveryBeforeAdmittingTheNextEvent() =
     runBlocking {
@@ -495,12 +555,8 @@ class GatewaySessionReconnectTest {
         connectNodeSession(harness.session, server.port)
         withTimeout(LIFECYCLE_TEST_TIMEOUT_MS) { connected.await() }
         val connection = readField<Any>(harness.session, "currentConnection")
-        val listener = readField<WebSocketListener>(connection, "listener")
         val socket = readField<WebSocket>(connection, "socket")
-        val failure =
-          launch(Dispatchers.IO) {
-            listener.onFailure(socket, IOException("test failure"), null)
-          }
+        socket.cancel()
         assertTrue(
           terminalCallbackStarted.await(LIFECYCLE_TEST_TIMEOUT_MS, TimeUnit.MILLISECONDS),
         )
@@ -511,7 +567,6 @@ class GatewaySessionReconnectTest {
 
         allowTerminalCallback.countDown()
         withTimeout(LIFECYCLE_TEST_TIMEOUT_MS) { disconnect.await() }
-        failure.join()
       } finally {
         allowTerminalCallback.countDown()
         shutdownReconnectHarness(harness, server)
@@ -608,6 +663,7 @@ class GatewaySessionReconnectTest {
       val terminalCallback = CompletableDeferred<TerminalCallbackObservation>()
       val allowTerminalCallback = CountDownLatch(1)
       val retiredInvokeCount = AtomicInteger()
+      var clientSocket: WebSocket? = null
       val server =
         startGatewayServer(json = json) { _, id, method ->
           if (method == "connect") connectRequestId.complete(id)
@@ -647,7 +703,7 @@ class GatewaySessionReconnectTest {
         val requestId = withTimeout(LIFECYCLE_TEST_TIMEOUT_MS) { connectRequestId.await() }
         val connection = readField<Any>(harness.session, "currentConnection")
         val listener = readField<WebSocketListener>(connection, "listener")
-        val socket = readField<WebSocket>(connection, "socket")
+        val socket = readField<WebSocket>(connection, "socket").also { clientSocket = it }
         listener.onMessage(socket, """{"type":"event","event":"block","payload":{}}""")
         assertTrue(blockEventStarted.await(LIFECYCLE_TEST_TIMEOUT_MS, TimeUnit.MILLISECONDS))
         listener.onMessage(
@@ -676,6 +732,8 @@ class GatewaySessionReconnectTest {
       } finally {
         allowBlockEvent.countDown()
         allowTerminalCallback.countDown()
+        // The synthetic failure bypasses OkHttp cleanup and lets the session forget this socket.
+        clientSocket?.cancel()
         shutdownReconnectHarness(harness, server)
       }
     }
@@ -1320,9 +1378,16 @@ class GatewaySessionReconnectTest {
     harness: ReconnectHarness,
     vararg servers: ReconnectServer,
   ) {
-    harness.session.disconnect()
-    harness.sessionJob.cancelAndJoin()
-    servers.forEach { it.shutdown() }
+    val failures = mutableListOf<Throwable>()
+    runCatching { harness.session.disconnectAndJoin() }.exceptionOrNull()?.let(failures::add)
+    runCatching { harness.sessionJob.cancelAndJoin() }.exceptionOrNull()?.let(failures::add)
+    servers.forEach { server ->
+      runCatching { server.shutdown() }.exceptionOrNull()?.let(failures::add)
+    }
+    failures.firstOrNull()?.let { failure ->
+      failures.drop(1).forEach(failure::addSuppressed)
+      throw failure
+    }
   }
 
   private fun connectResponseFrame(
@@ -1375,7 +1440,8 @@ class GatewaySessionReconnectTest {
                     code: Int,
                     reason: String,
                   ) {
-                    onClosed()
+                    // Acknowledge the peer so MockWebServer can close both streams and drain its queue.
+                    webSocket.close(code, reason)
                   }
 
                   override fun onClosed(


### PR DESCRIPTION
Related: https://github.com/openclaw/openclaw/pull/132915 — the separately scoped Bootstrap-auth endpoint-isolation repair. This PR does not change that fixture or its runtime cleanup helper.

## What Problem This Solves

Resolves a problem where Android reconnect tests could silently accept incomplete MockWebServer teardown. The fixture suppressed the exact queue-shutdown assertion after trying to cancel server-created WebSockets, and treated receipt of a close frame as completed transport termination.

The current 29-test baseline passes because production retirement now cancels its client transport. A real peer-initiated graceful close still exposes the fixture defect deterministically; this is not a claim of historical operator Gateway contact or a new production reconnect failure.

## Why This Change Was Made

The fixture now acknowledges peer close frames with the public WebSocket close API, reports terminal observation only from `onClosed` or `onFailure`, and lets MockWebServer shutdown failures propagate. Session cleanup is joined before its parent scope is cancelled, and every server cleanup is attempted before collected errors are rethrown.

The natural-failure callback test now uses real client transport cancellation. The accepted-frame/token-persistence ordering test retains its controlled callback injection, but explicitly owns and cancels the physical client socket that synthetic finalization can make the session forget. No production seam, dependency patch, timeout increase, weaker assertion, or retry was added.

History: the suppression was introduced with the reconnect fixture in `f1f92b8656a897da376efa9b803caace22a3df67`, when production used graceful retirement. The later immediate-cancellation repair left that suppression in place.

## User Impact

No shipped application behavior changes. Android reconnect test failures now remain visible, and the fixture completes its WebSocket and coroutine teardown instead of hiding incomplete cleanup.

Production LOC: **+0/−0**. Tests and test support: **+82/−16**, net **+66**.

## Evidence

- Direct source inspection of pinned MockWebServer/OkHttp **5.5.0** verified that server-created `RealWebSocket.cancel()` dereferences a missing client call. `MockWebServer.close()` throws the queue assertion after five seconds, before shutting down its backend.
- A real-socket dependency reproduction deterministically threw `AssertionError: Gave up waiting for queue to shut down` after **5.001 seconds**. The worker was blocked in `MockWebServerSocket.awaitClosed()`; acknowledging the peer close let the same shutdown complete in approximately **0.001 seconds**.
- The new Robolectric `serverAcknowledgesPeerCloseBeforeTeardown` regression **failed against the original fixture** while waiting for the peer-close acknowledgment, then passed with the repair. Its failure cleanup uses the public close API rather than private dependency cleanup.
- Independent final local verification passed **66 tests in each flavor**: Reconnect (30), Invoke (29), and CustomHeaders (7), for **132 passing cases**, zero failures/errors. Only these three classes were selected; Bootstrap-auth was not executed by this work.
- File-scoped Kotlin lint and `git diff --check` passed. The changed-check dry run routes Android-only changes through unrelated Swift lint; that routing gap is tracked separately rather than widening this patch.
- Fresh pre-commit Codex autoreview reported no findings at its default P0 threshold. Lower-priority findings were outside that review threshold.

All local runtime proof used a verified macOS OS fence denying outbound `*:18789`. The rule was validated only against separately owned ephemeral IPv4 and IPv6 listeners: controls connected, and equivalent deny rules returned `EPERM`. No operator Gateway was probed, bound, inspected, restarted, or mutated. Gradle used a fresh single-use daemon and in-process Kotlin compilation.

With JDK 21 and the Android SDK configured, the final scoped command was:

```bash
/usr/bin/sandbox-exec -f "$NETWORK_FENCE" apps/android/gradlew -p apps/android --no-daemon --console=plain -Pkotlin.compiler.execution.strategy=in-process :app:testPlayDebugUnitTest --tests ai.openclaw.app.gateway.GatewaySessionReconnectTest --tests ai.openclaw.app.gateway.GatewaySessionInvokeTest --tests ai.openclaw.app.gateway.GatewaySessionCustomHeadersTest :app:testThirdPartyDebugUnitTest --tests ai.openclaw.app.gateway.GatewaySessionReconnectTest --tests ai.openclaw.app.gateway.GatewaySessionInvokeTest --tests ai.openclaw.app.gateway.GatewaySessionCustomHeadersTest
```

The temporary fence profile contained:

```scheme
(version 1)
(allow default)
(deny network-outbound (remote ip "*:18789"))
```

Test-only fixture repair: no app UI changes or live operator Gateway proof is claimed or required. AI-assisted; owner, caller, sibling, history, and dependency contracts were reviewed before repair.
