### PR TITLE
refactor(agents): reuse errno predicate

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -1722,7 +1722,6 @@ src/agents/cli-runner/cli-run-transcript.ts	3
 src/agents/cli-runner/delivery-evidence.ts	2
 src/agents/cli-runner/execute-node-claude.ts	5
 src/agents/cli-runner/execute.ts	3
-src/agents/cli-runner/helpers.ts	1
 src/agents/cli-runner/prepare.ts	5
 src/agents/cli-runner/session-history.ts	3
 src/agents/code-mode-namespaces.ts	5

--- a/src/agents/cli-runner/helpers.ts
+++ b/src/agents/cli-runner/helpers.ts
@@ -18,6 +18,7 @@ import type { SourceReplyDeliveryMode } from "../../auto-reply/get-reply-options
 import type { ThinkLevel } from "../../auto-reply/thinking.js";
 import type { ChatType } from "../../channels/chat-type.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { hasErrnoCode } from "../../infra/errno.js";
 import { resolveRuntimeOsLabel } from "../../infra/os-summary.js";
 import { privateFileStore } from "../../infra/private-file-store.js";
 import { tempWorkspace } from "../../infra/private-temp-workspace.js";
@@ -276,15 +277,6 @@ function resolveCliImageRoot(params: { backend: CliBackendConfig; workspaceDir: 
   return path.join(resolvePreferredOpenClawTmpDir(), "openclaw-cli-images");
 }
 
-function isFileNotFoundError(error: unknown): boolean {
-  return Boolean(
-    error &&
-    typeof error === "object" &&
-    "code" in error &&
-    (error as { code?: unknown }).code === "ENOENT",
-  );
-}
-
 async function sweepCliImageRoot(imageRoot: string): Promise<void> {
   if (sweptCliImageRoots.has(imageRoot)) {
     return;
@@ -299,7 +291,7 @@ async function sweepCliImageRoot(imageRoot: string): Promise<void> {
       }
       const entryPath = path.join(imageRoot, entry.name);
       const stat = await fs.stat(entryPath).catch((error: unknown) => {
-        if (isFileNotFoundError(error)) {
+        if (hasErrnoCode(error, "ENOENT")) {
           return undefined;
         }
         throw error;
@@ -313,7 +305,7 @@ async function sweepCliImageRoot(imageRoot: string): Promise<void> {
       try {
         await fs.rm(entryPath, { force: true });
       } catch (error) {
-        if (!isFileNotFoundError(error)) {
+        if (!hasErrnoCode(error, "ENOENT")) {
           throw error;
         }
       }


### PR DESCRIPTION
## What Problem This Solves

CLI image-cache cleanup maintained a local copy of the shared exact errno-code predicate. The duplicate predated the canonical infra helper, so future error-shape changes could drift between this cleanup path and other filesystem owners.

## Why This Change Was Made

The two stale-image race checks now call `hasErrnoCode(error, "ENOENT")` directly from the dependency-free errno module. The duplicate local helper is removed.

This is the best fix because the shared helper implements the exact inherited `code === "ENOENT"` contract. The broader missing-path predicate is intentionally not used because it also accepts `ENOTDIR` and `not-found`.

Removing the local type assertion also drops the file's assertion-safety count from 1 to 0, so the matching stale baseline entry is removed.

## User Impact

No user-visible behavior changes. Missing files raced away during `stat` or `rm` remain ignored, while every non-`ENOENT` failure follows the existing error path.

## Evidence

- Production LOC: +3/-11 (net -8). Assertion baseline: +0/-1. Tests: +0/-0.
- Current `main` source confirmed the removed predicate and `hasErrnoCode` accept the same errno-shaped values.
- `node scripts/run-vitest.mjs src/agents/cli-runner.helpers.test.ts src/infra/errors.test.ts`: 63 passed.
- `pnpm exec oxfmt --check src/agents/cli-runner/helpers.ts`: passed.
- `pnpm exec oxlint src/agents/cli-runner/helpers.ts`: passed.
- `pnpm tsgo:core`: passed.
- `pnpm check:assertion-safety --base origin/main`: passed, 4176 files / 12938 grandfathered assertions.
- Mandatory local autoreview with `gpt-5.6-sol` at high reasoning: clean, patch correctness confidence 0.99.
