### PR TITLE
test(tasks): skip empty writes when selecting durable fixtures

### DIFF
--- a/src/tasks/task-registry.test.ts
+++ b/src/tasks/task-registry.test.ts
@@ -1130,7 +1130,7 @@ describe("task-registry", () => {
   it("clears terminal errors when explicitly updated without an error", async () => {
     await withTaskRegistryTempDir(async (root) => {
       process.env.OPENCLAW_STATE_DIR = root;
-      resetTaskRegistryForTests();
+      resetTaskRegistryForTests({ persist: false });
 
       const task = createTaskFixture("cron", {
         ownerKey: "system:cron:test",
@@ -2117,7 +2117,7 @@ describe("task-registry", () => {
   ])("delivers delegated ACP completion directly to a $name thread origin", async (origin) => {
     await withTaskRegistryTempDir(async (root) => {
       process.env.OPENCLAW_STATE_DIR = root;
-      resetTaskRegistryForTests();
+      resetTaskRegistryForTests({ persist: false });
       const runId = `run-${origin.channel}-thread-terminal`;
       hoisted.sendMessageMock.mockResolvedValue({
         channel: origin.channel,
@@ -2176,7 +2176,7 @@ describe("task-registry", () => {
   it("keeps delegated ACP completion queued when the transport does not declare thread delivery", async () => {
     await withTaskRegistryTempDir(async (root) => {
       process.env.OPENCLAW_STATE_DIR = root;
-      resetTaskRegistryForTests();
+      resetTaskRegistryForTests({ persist: false });
       const runId = "run-guildchat-thread-terminal";
       // guildchat is deliverable but declares no thread capability, so a thread-shaped
       // origin must keep routing through the parent session instead of direct delivery.
@@ -2227,7 +2227,7 @@ describe("task-registry", () => {
   it("keeps delegated ACP completion queued when the requester origin has no thread", async () => {
     await withTaskRegistryTempDir(async (root) => {
       process.env.OPENCLAW_STATE_DIR = root;
-      resetTaskRegistryForTests();
+      resetTaskRegistryForTests({ persist: false });
       const runId = "run-root-discord-terminal";
       const requesterOrigin = {
         channel: "discord",
@@ -2305,7 +2305,7 @@ describe("task-registry", () => {
     },
   ])("routes $name ACP completion through the parent session", async ({ id, ownerKey, target }) => {
     await withTaskRegistryTempDir(async () => {
-      resetTaskRegistryForTests();
+      resetTaskRegistryForTests({ persist: false });
       const runId = `run-group-terminal-${id}`;
       hoisted.sendMessageMock.mockResolvedValue({
         channel: "guildchat",
@@ -2959,7 +2959,7 @@ describe("task-registry", () => {
   it("restores persisted tasks from disk on the next lookup", async () => {
     await withTaskRegistryTempDir(
       async () => {
-        resetTaskRegistryForTests();
+        resetTaskRegistryForTests({ persist: false });
 
         const task = createTaskFixture("subagent", {
           childSessionKey: "agent:main:subagent:child",
@@ -3243,7 +3243,7 @@ describe("task-registry", () => {
     },
   ])("$name", async ({ taskKind, sourceId, task: taskName, ageMinutes, reconciled, error }) => {
     await withTaskRegistryTempDir(async () => {
-      resetTaskRegistryForTests();
+      resetTaskRegistryForTests({ persist: false });
       const now = Date.now();
       const lastEventAt = now - ageMinutes * 60_000;
       const task = createTaskFixture("subagent", {
@@ -3270,7 +3270,7 @@ describe("task-registry", () => {
 
   it("uses normal reconcile grace for OpenClaw-owned subagent tasks", async () => {
     await withTaskRegistryTempDir(async () => {
-      resetTaskRegistryForTests();
+      resetTaskRegistryForTests({ persist: false });
       const now = Date.now();
       const task = createTaskFixture("subagent", {
         childSessionKey: "agent:main:subagent:missing",
@@ -5321,7 +5321,7 @@ describe("task-registry", () => {
     },
   ])("$name", async ({ taskKind, sourceId, task: taskName, cancellable }) => {
     await withTaskRegistryTempDir(async () => {
-      resetTaskRegistryForTests();
+      resetTaskRegistryForTests({ persist: false });
       const task = createTaskFixture("subagent", {
         taskKind,
         sourceId,


### PR DESCRIPTION
## What Problem This Solves

Sixteen task-registry cases initialize and close an empty SQLite database during setup, then reopen it for the first real task write. This adds test execution cost without exercising additional persistence behavior.

## Why This Change Was Made

Pass the existing `persist: false` option to nine initial reset calls inside fresh temporary-directory fixtures. Keep every reset: eight deliberately switch from the fixture's in-memory task store to the real default SQLite backend, and one belongs to an explicit durable-store case. The change skips only the empty snapshot write, preserving state/listener/timer reset, store selection, handle closure, actual task writes, and mid-case reloads.

This follows the earlier fixture work in #132913; these remaining calls could not be deleted because they select the backend. Production LOC: 0; tests +9/-9. No schema, production storage, sharding, concurrency, mock, or assertion changes.

## User Impact

Faster developer tests, with no product behavior change. Maintainer-requested, AI-assisted test performance work.

## Evidence

On Node 26.5.0/macOS, two alternating full-file comparisons kept all 135 cases passing. Aggregate execution of the 16 affected cases fell from 4.04s to 1.70s and from 3.49s to 2.91s. A separate run selecting 14 of those 16 cases reduced the complete test phase from 3.61s to 2.39s (34%), including setup and cleanup.

The entire file varied from 9.41s to 5.04s and 8.17s to 7.87s; unchanged cases also varied, so these measurements do not establish a stable whole-file or CI wall-time gain.

- Temporary mechanism probe: asserting the SQLite file is absent immediately after the initial reset fails before the change and passes after it. The same candidate probe verifies the first task creation creates the SQLite file. Probe edits removed.
- All 307 tests in the owning task lane passed, including durable restore, task-flow store behavior, delivery, cancellation, maintenance, and process-state cases.
- Existing reset and closure assertions remain; actual real SQLite writes and the disk-reload case remain unchanged.
- Full `check-changed` passed: formatting, all core test typechecks, lint, unused-export scans, and repository architecture/fixture guards.
- Independent Codex autoreview found no actionable findings. Refreshed main has identical affected test, fixture, and persistence-owner source to the measured baseline.

