### PR TITLE
refactor(plugins): simplify web provider resolution

### DIFF
--- a/src/plugins/web-fetch-providers.runtime.ts
+++ b/src/plugins/web-fetch-providers.runtime.ts
@@ -15,10 +15,7 @@ import {
   mapRegistryProviders,
   resolveManifestDeclaredWebProviderCandidatePluginIds,
 } from "./web-provider-resolution-shared.js";
-import {
-  resolvePluginWebProviders,
-  resolveRuntimeWebProviders,
-} from "./web-provider-runtime-shared.js";
+import { resolvePluginWebProviders } from "./web-provider-runtime-shared.js";
 
 function resolveWebFetchCandidatePluginIds(params: {
   config?: PluginLoadOptions["config"];
@@ -85,7 +82,7 @@ export function resolveRuntimeWebFetchProviders(params: {
   origin?: PluginManifestRecord["origin"];
   manifestRecords?: readonly PluginManifestRecord[];
 }): PluginWebFetchProviderEntry[] {
-  return resolveRuntimeWebProviders(params, {
+  return resolvePluginWebProviders(params, {
     resolveBundledResolutionConfig: resolveBundledWebFetchResolutionConfig,
     resolveCandidatePluginIds: resolveWebFetchCandidatePluginIds,
     mapRegistryProviders: mapRegistryWebFetchProviders,

--- a/src/plugins/web-provider-runtime-shared.test.ts
+++ b/src/plugins/web-provider-runtime-shared.test.ts
@@ -48,7 +48,6 @@ vi.mock("./runtime/load-context.js", () => ({
 }));
 
 let resolvePluginWebProviders: typeof import("./web-provider-runtime-shared.js").resolvePluginWebProviders;
-let resolveRuntimeWebProviders: typeof import("./web-provider-runtime-shared.js").resolveRuntimeWebProviders;
 
 const requireRecord = createRequireRecord("record", "expected-non-array-record");
 
@@ -58,8 +57,7 @@ function mockArg(mock: ReturnType<typeof vi.fn>, callIndex = 0): Record<string, 
 
 describe("web-provider-runtime-shared", () => {
   beforeAll(async () => {
-    ({ resolvePluginWebProviders, resolveRuntimeWebProviders } =
-      await import("./web-provider-runtime-shared.js"));
+    ({ resolvePluginWebProviders } = await import("./web-provider-runtime-shared.js"));
   });
 
   beforeEach(() => {
@@ -87,10 +85,11 @@ describe("web-provider-runtime-shared", () => {
   });
 
   it("preserves explicit empty scopes in runtime-compatible web provider loads", () => {
+    const activeRegistry = { source: "active" };
     const mapRegistryProviders = vi.fn(() => []);
-    mocks.getLoadedRuntimePluginRegistry.mockReturnValue({} as never);
+    mocks.getLoadedRuntimePluginRegistry.mockReturnValue(activeRegistry as never);
 
-    resolvePluginWebProviders(
+    const result = resolvePluginWebProviders(
       {
         config: {},
         onlyPluginIds: [],
@@ -107,38 +106,19 @@ describe("web-provider-runtime-shared", () => {
     );
 
     expect(mockArg(mocks.getLoadedRuntimePluginRegistry).requiredPluginIds).toEqual([]);
-    expect(mockArg(mapRegistryProviders).onlyPluginIds).toEqual([]);
-  });
-
-  it("preserves explicit empty scopes in direct runtime web provider resolution", () => {
-    const mapRegistryProviders = vi.fn(() => []);
-    mocks.getLoadedRuntimePluginRegistry.mockReturnValue({} as never);
-
-    resolveRuntimeWebProviders(
-      {
-        config: {},
-        onlyPluginIds: [],
-      },
-      {
-        resolveBundledResolutionConfig: () => ({
-          config: {},
-          activationSourceConfig: {},
-          autoEnabledReasons: {},
-        }),
-        resolveCandidatePluginIds: () => [],
-        mapRegistryProviders,
-      },
-    );
-
-    expect(mockArg(mocks.getLoadedRuntimePluginRegistry).requiredPluginIds).toEqual([]);
-    expect(mockArg(mapRegistryProviders).onlyPluginIds).toEqual([]);
+    expect(mapRegistryProviders).toHaveBeenCalledWith({
+      registry: activeRegistry,
+      onlyPluginIds: [],
+    });
+    expect(result).toStrictEqual([]);
+    expect(mocks.loadOpenClawPlugins).not.toHaveBeenCalled();
   });
 
   it("preserves explicit scopes when config is omitted in direct runtime resolution", () => {
     const mapRegistryProviders = vi.fn(() => []);
     mocks.getLoadedRuntimePluginRegistry.mockReturnValue({} as never);
 
-    resolveRuntimeWebProviders(
+    resolvePluginWebProviders(
       {
         onlyPluginIds: ["alpha"],
       },
@@ -205,34 +185,6 @@ describe("web-provider-runtime-shared", () => {
     expect(mockArg(mocks.buildPluginRuntimeLoadOptionsFromValues).manifestRegistry).toEqual({
       plugins: manifestRecords,
       diagnostics: [],
-    });
-    expect(mocks.loadOpenClawPlugins).not.toHaveBeenCalled();
-  });
-
-  it("preserves explicit empty candidate scopes when reusing the active registry", () => {
-    const activeRegistry = { source: "active" };
-    const mapRegistryProviders = vi.fn(() => []);
-    mocks.getLoadedRuntimePluginRegistry.mockReturnValue(activeRegistry);
-
-    resolvePluginWebProviders(
-      {
-        config: {},
-        onlyPluginIds: [],
-      },
-      {
-        resolveBundledResolutionConfig: () => ({
-          config: {},
-          activationSourceConfig: {},
-          autoEnabledReasons: {},
-        }),
-        resolveCandidatePluginIds: () => [],
-        mapRegistryProviders,
-      },
-    );
-
-    expect(mapRegistryProviders).toHaveBeenCalledWith({
-      registry: activeRegistry,
-      onlyPluginIds: [],
     });
     expect(mocks.loadOpenClawPlugins).not.toHaveBeenCalled();
   });
@@ -436,31 +388,6 @@ describe("web-provider-runtime-shared", () => {
     expect(mapRegistryProviders).toHaveBeenCalledTimes(2);
   });
 
-  it("does not fall back when the active runtime registry returns empty under an explicit empty scope", () => {
-    const activeRegistry = { source: "active" };
-    const mapRegistryProviders = vi.fn(() => []);
-    mocks.getLoadedRuntimePluginRegistry.mockReturnValue(activeRegistry as never);
-
-    const result = resolvePluginWebProviders(
-      {
-        config: {},
-        onlyPluginIds: [],
-      },
-      {
-        resolveBundledResolutionConfig: () => ({
-          config: {},
-          activationSourceConfig: {},
-          autoEnabledReasons: {},
-        }),
-        resolveCandidatePluginIds: () => [],
-        mapRegistryProviders,
-      },
-    );
-
-    expect(result).toStrictEqual([]);
-    expect(mocks.loadOpenClawPlugins).not.toHaveBeenCalled();
-  });
-
   it("does not treat an active registry missing declared candidates as authoritative", () => {
     // Regression: an active registry with SOME web providers used to win even when a
     // manifest-declared candidate (npm-installed Brave with BRAVE_API_KEY set) was
@@ -481,7 +408,7 @@ describe("web-provider-runtime-shared", () => {
     });
     mocks.loadOpenClawPlugins.mockReturnValue(scopedRegistry as never);
 
-    const result = resolveRuntimeWebProviders(
+    const result = resolvePluginWebProviders(
       {
         config: {},
         env: { BRAVE_API_KEY: "key" } as never,
@@ -499,66 +426,6 @@ describe("web-provider-runtime-shared", () => {
 
     expect(result).toEqual(["brave", "grok"]);
     expect(mocks.loadOpenClawPlugins).toHaveBeenCalledTimes(1);
-  });
-
-  it("falls back when the direct runtime registry has no web providers", () => {
-    const activeRegistry = { source: "active" };
-    const fallbackRegistry = { source: "fallback" };
-    const mapRegistryProviders = vi.fn(({ registry }) =>
-      registry === fallbackRegistry ? ["brave"] : [],
-    );
-    mocks.getLoadedRuntimePluginRegistry.mockImplementation((args: unknown) => {
-      const requiredPluginIds = (args as { requiredPluginIds?: readonly string[] })
-        ?.requiredPluginIds;
-      if (requiredPluginIds === undefined) {
-        return activeRegistry as never;
-      }
-      return undefined;
-    });
-    mocks.loadOpenClawPlugins.mockReturnValue(fallbackRegistry as never);
-
-    const result = resolveRuntimeWebProviders(
-      {
-        config: {},
-      },
-      {
-        resolveBundledResolutionConfig: () => ({
-          config: {},
-          activationSourceConfig: {},
-          autoEnabledReasons: {},
-        }),
-        resolveCandidatePluginIds: () => undefined,
-        mapRegistryProviders,
-      },
-    );
-
-    expect(result).toEqual(["brave"]);
-    expect(mocks.loadOpenClawPlugins).toHaveBeenCalledTimes(1);
-  });
-
-  it("does not fall back when direct runtime registry returns empty under an explicit empty scope", () => {
-    const activeRegistry = { source: "active" };
-    const mapRegistryProviders = vi.fn(() => []);
-    mocks.getLoadedRuntimePluginRegistry.mockReturnValue(activeRegistry as never);
-
-    const result = resolveRuntimeWebProviders(
-      {
-        config: {},
-        onlyPluginIds: [],
-      },
-      {
-        resolveBundledResolutionConfig: () => ({
-          config: {},
-          activationSourceConfig: {},
-          autoEnabledReasons: {},
-        }),
-        resolveCandidatePluginIds: () => [],
-        mapRegistryProviders,
-      },
-    );
-
-    expect(result).toStrictEqual([]);
-    expect(mocks.loadOpenClawPlugins).not.toHaveBeenCalled();
   });
 
   it("keeps explicit setup web provider cache opt-outs", () => {

--- a/src/plugins/web-provider-runtime-shared.ts
+++ b/src/plugins/web-provider-runtime-shared.ts
@@ -80,11 +80,6 @@ type WebProviderRuntimeContext = {
   onlyPluginIds?: string[];
 };
 
-type RuntimeRegistryWebProviderResolution<TEntry> = {
-  providers: TEntry[];
-  shouldReturn: boolean;
-};
-
 function resolveWebProviderRuntimeContext<TEntry>(
   params: ResolvePluginWebProvidersParams,
   deps: ResolveWebProviderRuntimeDeps<TEntry>,
@@ -164,25 +159,6 @@ function resolveWebProviderLoadOptions(
   );
 }
 
-function resolveRuntimeRegistryWebProviders<TEntry>(params: {
-  hasExplicitEmptyScope: boolean;
-  mapRegistryProviders: ResolveWebProviderRuntimeDeps<TEntry>["mapRegistryProviders"];
-  onlyPluginIds?: readonly string[];
-  registry: PluginRegistry | undefined;
-}): RuntimeRegistryWebProviderResolution<TEntry> | undefined {
-  if (!params.registry) {
-    return undefined;
-  }
-  const providers = params.mapRegistryProviders({
-    registry: params.registry,
-    onlyPluginIds: params.onlyPluginIds,
-  });
-  return {
-    providers,
-    shouldReturn: providers.length > 0 || params.hasExplicitEmptyScope,
-  };
-}
-
 /** Resolves plugin web providers from setup, active runtime, or a scoped load. */
 export function resolvePluginWebProviders<TEntry>(
   params: ResolvePluginWebProvidersParams,
@@ -250,24 +226,18 @@ export function resolvePluginWebProviders<TEntry>(
     workspaceDir: context.workspaceDir,
     requiredPluginIds: context.loadPluginIds,
   });
-  const scopedPluginIds = context.onlyPluginIds;
-  const hasExplicitEmptyScope = scopedPluginIds !== undefined && scopedPluginIds.length === 0;
-  const compatibleProviders = resolveRuntimeRegistryWebProviders({
-    hasExplicitEmptyScope,
-    mapRegistryProviders: deps.mapRegistryProviders,
-    onlyPluginIds: context.onlyPluginIds,
-    registry: compatible,
-  });
-  if (compatibleProviders?.shouldReturn) {
-    return compatibleProviders.providers;
-  }
-  if (compatibleProviders) {
-    // The active gateway plugin registry may be otherwise compatible with this
-    // config while contributing zero web providers (for example when channels,
-    // memory, harnesses, and sidecars are loaded but Brave/web providers are
-    // not). Do not treat that empty active registry as authoritative: fall
-    // through to a scoped provider load below so first-class assistant tools
-    // still see the configured provider.
+  const hasExplicitEmptyScope =
+    context.onlyPluginIds !== undefined && context.onlyPluginIds.length === 0;
+  // Candidate coverage is checked before reuse. An empty compatible registry is
+  // authoritative only for an explicit empty scope; otherwise load below.
+  if (compatible) {
+    const providers = deps.mapRegistryProviders({
+      registry: compatible,
+      onlyPluginIds: context.onlyPluginIds,
+    });
+    if (providers.length > 0 || hasExplicitEmptyScope) {
+      return providers;
+    }
   }
   if (isPluginRegistryLoadInFlight(loadOptions)) {
     return [];
@@ -296,18 +266,4 @@ export function resolvePluginWebProviders<TEntry>(
     registry,
     onlyPluginIds: context.onlyPluginIds,
   });
-}
-
-/** Resolves web providers from the active runtime registry before falling back to plugin loading. */
-export function resolveRuntimeWebProviders<TEntry>(
-  params: Omit<ResolvePluginWebProvidersParams, "activate" | "cache" | "mode">,
-  deps: ResolveWebProviderRuntimeDeps<TEntry>,
-): TEntry[] {
-  // Do not treat the active registry's provider set as authoritative here: it can
-  // be non-empty while still missing manifest-declared candidates that never load
-  // at startup (for example an npm-installed Brave plugin with BRAVE_API_KEY set,
-  // whose manifest uses activation.onStartup=false). resolvePluginWebProviders
-  // reuses the active registry only when it covers every declared candidate, and
-  // otherwise runs the same scoped load the explicitly-configured path uses.
-  return resolvePluginWebProviders(params, deps);
 }

--- a/src/plugins/web-search-providers.runtime.ts
+++ b/src/plugins/web-search-providers.runtime.ts
@@ -8,10 +8,7 @@ import {
   mapRegistryProviders,
   resolveManifestDeclaredWebProviderCandidatePluginIds,
 } from "./web-provider-resolution-shared.js";
-import {
-  resolvePluginWebProviders,
-  resolveRuntimeWebProviders,
-} from "./web-provider-runtime-shared.js";
+import { resolvePluginWebProviders } from "./web-provider-runtime-shared.js";
 import {
   resolveBundledWebSearchResolutionConfig,
   sortWebSearchProviders,
@@ -75,7 +72,7 @@ export function resolveRuntimeWebSearchProviders(params: {
   origin?: PluginManifestRecord["origin"];
   manifestRecords?: readonly PluginManifestRecord[];
 }): PluginWebSearchProviderEntry[] {
-  return resolveRuntimeWebProviders(params, {
+  return resolvePluginWebProviders(params, {
     resolveBundledResolutionConfig: resolveBundledWebSearchResolutionConfig,
     resolveCandidatePluginIds: resolveWebSearchCandidatePluginIds,
     mapRegistryProviders: mapRegistryWebSearchProviders,


### PR DESCRIPTION
## What Problem This Solves

This maintainer-requested, AI-assisted cleanup simplifies web search and web fetch provider discovery. It carried an internal forwarding function and a single-use result wrapper around the same resolver. That duplication made the active-registry coverage and empty-scope rules harder to follow and led to repeated tests of the identical path.

## Why This Change Was Made

Both typed family entry points now call the existing canonical resolver directly. Its compatible-registry decision is expressed in place, without constructing an intermediate result. Candidate coverage is still checked before reuse; an empty compatible registry is authoritative only for an explicit empty scope. In-flight protection, artifact discovery, scoped loading, setup activation and cache behavior remain in the same order.

The internal forwarder and private result type/helper are removed. Five duplicate shared tests are consolidated into existing cases, retaining their meaningful assertions and the regression for an active registry that lacks a declared provider. Public entry points and plugin SDK contracts are unchanged.

## User Impact

No intended user-visible behavior, configuration, provider policy, credential policy, or persistence change. This is maintenance cleanup, not a claim of improved network or startup performance.

Production: +16/-66 (50 removed). Tests: +12/-145 (133 removed). Whole change: +28/-211 (183 removed).

## Evidence

- Unchanged baseline: 98 tests across the six shared/family/active-registry and web-fetch/web-search runtime suites passed.
- Candidate: the same six suites passed 93 tests. The five-case difference is the reviewed duplicate consolidation; the other 81 cases are unchanged and the shared suite retains 12 cases. No skips, test retries or timeout changes.
- Targeted formatting and diff checks passed. All 29 stages of the normal changed-scope gate passed, including the complete core/core-test typechecks, typed lint, dead-export scans, import cycles, and storage/security guards. The normal managed precommit review completed with no blocking findings.
- Source inspection covers both family callers, scope/manifest resolution, active registry coverage, cache/in-flight ownership, loader and public-artifact paths. History is shallow, so no originating-commit rationale is asserted.

Both test runs used Node 24.19 and the normal repository runner:

```sh
node scripts/run-vitest.mjs src/plugins/web-provider-runtime-shared.test.ts src/plugins/web-fetch-providers.runtime.test.ts src/plugins/web-search-providers.runtime.test.ts src/plugins/active-runtime-registry.test.ts src/web-fetch/runtime.test.ts src/web-search/runtime.test.ts
node scripts/check-changed.mjs -- src/plugins/web-fetch-providers.runtime.ts src/plugins/web-provider-runtime-shared.test.ts src/plugins/web-provider-runtime-shared.ts src/plugins/web-search-providers.runtime.ts
```

These are local, mocked owner/sibling tests, not authenticated live-provider or packaged end-to-end evidence. The change does not modify external API calls. Hosted exact-head CI, completed public review, current-main composition and normal native preparation remain required before landing.
