### PR TITLE
refactor(plugins): decouple tool metadata from runtime loading

### DIFF
--- a/scripts/test-built-plugin-singleton.mts
+++ b/scripts/test-built-plugin-singleton.mts
@@ -212,4 +212,51 @@ assert.equal(match.args, "now");
 const result = await match.command.handler({ args: match.args });
 assert.deepEqual(result, { text: "paired:now" });
 
+// Keep these imports after the cold native checks so they cannot prewarm the loader.
+const { buildBundleMcpToolsFromCatalog } = await import(
+  pathToFileURL(path.join(repoRoot, "dist", "agents", "agent-bundle-mcp-materialize.js")).href
+);
+const { getPluginToolMeta } = await import(
+  pathToFileURL(path.join(repoRoot, "dist", "plugins", "tool-metadata.js")).href
+);
+const { getPluginToolMeta: getSdkPluginToolMeta } = await import(
+  pathToFileURL(path.join(repoRoot, "dist", "plugin-sdk", "agent-harness-runtime.js")).href
+);
+const [mcpTool] = buildBundleMcpToolsFromCatalog({
+  catalog: {
+    version: 1,
+    generatedAt: 0,
+    servers: {
+      "build-smoke-mcp": {
+        serverName: "build-smoke-mcp",
+        safeServerName: "build-smoke-mcp",
+        launchSummary: "build smoke inventory fixture",
+        toolCount: 1,
+      },
+    },
+    tools: [
+      {
+        serverName: "build-smoke-mcp",
+        safeServerName: "build-smoke-mcp",
+        toolName: "lookup",
+        inputSchema: { type: "object", properties: {} },
+        fallbackDescription: "Look up a build smoke inventory item",
+      },
+    ],
+  },
+});
+assert.ok(mcpTool, "compiled MCP materializer did not produce a tool");
+const mcpMetadata = getPluginToolMeta(mcpTool);
+assert.ok(mcpMetadata, "canonical built metadata owner did not receive MCP tool metadata");
+assert.equal(mcpMetadata.pluginId, "bundle-mcp");
+assert.equal(mcpMetadata.mcp?.serverName, "build-smoke-mcp");
+assert.equal(mcpMetadata.mcp?.safeServerName, "build-smoke-mcp");
+assert.equal(mcpMetadata.mcp?.toolName, "lookup");
+assert.equal(mcpMetadata.mcp?.operation, "tool");
+assert.strictEqual(
+  getSdkPluginToolMeta(mcpTool),
+  mcpMetadata,
+  "public agent-harness-runtime SDK did not read the canonical MCP metadata record",
+);
+
 process.stdout.write("[build-smoke] built plugin singleton smoke passed\n");

--- a/src/agents/agent-bundle-lsp-runtime.ts
+++ b/src/agents/agent-bundle-lsp-runtime.ts
@@ -5,7 +5,7 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { createAbortError } from "../infra/abort-signal.js";
 import { logDebug, logWarn } from "../logger.js";
 import type { PluginManifestRegistry } from "../plugins/manifest-registry.js";
-import { setPluginToolMeta } from "../plugins/tools.js";
+import { setPluginToolMeta } from "../plugins/tool-metadata.js";
 import { createPendingRequestRegistry } from "../shared/pending-request-registry.js";
 import {
   defaultBundleLspRuntimeDependencies,

--- a/src/agents/agent-bundle-mcp-harness.ts
+++ b/src/agents/agent-bundle-mcp-harness.ts
@@ -2,7 +2,7 @@
 import type { SessionToolOverrides } from "../config/sessions/types.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { PluginManifestRegistry } from "../plugins/manifest-registry.js";
-import { getPluginToolMeta } from "../plugins/tools.js";
+import { getPluginToolMeta } from "../plugins/tool-metadata.js";
 import {
   buildBundleMcpToolsFromCatalog,
   materializeBundleMcpToolsForRun,

--- a/src/agents/agent-bundle-mcp-materialize.ts
+++ b/src/agents/agent-bundle-mcp-materialize.ts
@@ -6,7 +6,11 @@ import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { logWarn } from "../logger.js";
-import { getPluginToolMeta, setPluginToolMeta, type PluginToolMcpMeta } from "../plugins/tools.js";
+import {
+  getPluginToolMeta,
+  setPluginToolMeta,
+  type PluginToolMcpMeta,
+} from "../plugins/tool-metadata.js";
 import {
   buildSafeToolName,
   normalizeReservedToolNames,

--- a/src/agents/agent-bundle-mcp-runtime.agent-bundle.test.ts
+++ b/src/agents/agent-bundle-mcp-runtime.agent-bundle.test.ts
@@ -8,7 +8,7 @@ import { afterEach, expect, it } from "vitest";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { loadEnabledBundleMcpConfig } from "../plugins/bundle-mcp.js";
 import { clearPluginMetadataLifecycleCaches } from "../plugins/plugin-metadata-lifecycle.js";
-import { getPluginToolMeta } from "../plugins/tools.js";
+import { getPluginToolMeta } from "../plugins/tool-metadata.js";
 import { withEnvAsync } from "../test-utils/env.js";
 import {
   disposeAllSessionMcpRuntimes,

--- a/src/agents/agent-bundle-mcp-runtime.test.ts
+++ b/src/agents/agent-bundle-mcp-runtime.test.ts
@@ -33,15 +33,6 @@ import type { SessionMcpRuntime } from "./agent-bundle-mcp-types.js";
 import { writeExecutable } from "./bundle-mcp-shared.test-harness.js";
 import { updateMcpAppModelContext } from "./mcp-app-model-context.js";
 
-const pluginToolMetadata = vi.hoisted(() => new WeakMap<object, unknown>());
-
-vi.mock("../plugins/tools.js", () => ({
-  getPluginToolMeta: (tool: object) => pluginToolMetadata.get(tool),
-  setPluginToolMeta: (tool: object, metadata: unknown) => {
-    pluginToolMetadata.set(tool, metadata);
-  },
-}));
-
 vi.mock("./embedded-agent-mcp.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("./embedded-agent-mcp.js")>();
   return {

--- a/src/agents/agent-bundle-mcp-tools.materialize.test.ts
+++ b/src/agents/agent-bundle-mcp-tools.materialize.test.ts
@@ -4,7 +4,7 @@ import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { expectDefined } from "@openclaw/normalization-core";
 import { validateToolArguments } from "openclaw/plugin-sdk/llm";
 import { afterEach, describe, expect, it } from "vitest";
-import { getPluginToolMeta } from "../plugins/tools.js";
+import { getPluginToolMeta } from "../plugins/tool-metadata.js";
 import {
   buildBundleMcpToolsFromCatalog,
   createBundleMcpToolRuntime,

--- a/src/agents/agent-tool-metadata.ts
+++ b/src/agents/agent-tool-metadata.ts
@@ -1,4 +1,4 @@
-import { copyPluginToolMeta, getPluginToolMeta } from "../plugins/tools.js";
+import { copyPluginToolMeta, getPluginToolMeta } from "../plugins/tool-metadata.js";
 import type { AnyAgentTool } from "./agent-tools.types.js";
 import { copyBeforeToolCallHookMarker } from "./before-tool-call-metadata.js";
 import { copyChannelAgentToolMeta } from "./channel-tool-metadata.js";

--- a/src/agents/agent-tools.before-tool-call.decision.test.ts
+++ b/src/agents/agent-tools.before-tool-call.decision.test.ts
@@ -11,7 +11,7 @@ import {
 import { addTestHook } from "../plugins/hooks.test-fixtures.js";
 import { createEmptyPluginRegistry } from "../plugins/registry.js";
 import { setActivePluginRegistry } from "../plugins/runtime.js";
-import { setPluginToolMeta } from "../plugins/tools.js";
+import { setPluginToolMeta } from "../plugins/tool-metadata.js";
 import type { PluginHookRegistration } from "../plugins/types.js";
 import { toToolDefinitions } from "./agent-tool-definition-adapter.js";
 import {

--- a/src/agents/agent-tools.before-tool-call.diagnostics.ts
+++ b/src/agents/agent-tools.before-tool-call.diagnostics.ts
@@ -29,7 +29,7 @@ import { pruneMapToMaxSize } from "../infra/map-size.js";
 import type { SessionState } from "../logging/diagnostic-session-state.js";
 import { redactToolDetail } from "../logging/redact.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
-import { getPluginToolMeta } from "../plugins/tools.js";
+import { getPluginToolMeta } from "../plugins/tool-metadata.js";
 import { createLazyRuntimeSurface } from "../shared/lazy-runtime.js";
 import {
   resolveSkillTelemetrySource,

--- a/src/agents/agent-tools.before-tool-call.e2e.test.ts
+++ b/src/agents/agent-tools.before-tool-call.e2e.test.ts
@@ -38,7 +38,7 @@ import { getGlobalHookRunner } from "../plugins/hook-runner-global.js";
 import { createHookRunner, type HookRunner } from "../plugins/hooks.js";
 import { createEmptyPluginRegistry } from "../plugins/registry-empty.js";
 import { setActivePluginRegistry } from "../plugins/runtime.js";
-import { setPluginToolMeta } from "../plugins/tools.js";
+import { setPluginToolMeta } from "../plugins/tool-metadata.js";
 import { consumeRunSkillUsage } from "../skills/runtime/run-usage.js";
 import { createCanonicalFixtureSkill } from "../skills/test-support/test-helpers.js";
 import { createChannelTestPluginBase, createTestRegistry } from "../test-utils/channel-plugins.js";

--- a/src/agents/agent-tools.before-tool-call.integration.e2e.test.ts
+++ b/src/agents/agent-tools.before-tool-call.integration.e2e.test.ts
@@ -28,7 +28,7 @@ import { addTestHook, createMockPluginRegistry } from "../plugins/hooks.test-fix
 import { patchPluginSessionExtension } from "../plugins/host-hook-state.js";
 import { createEmptyPluginRegistry } from "../plugins/registry.js";
 import { setActivePluginRegistry } from "../plugins/runtime.js";
-import { setPluginToolMeta } from "../plugins/tools.js";
+import { setPluginToolMeta } from "../plugins/tool-metadata.js";
 import type { PluginHookRegistration } from "../plugins/types.js";
 import {
   authorizeClientVoiceConfirmation,

--- a/src/agents/agent-tools.before-tool-call.wrapper.ts
+++ b/src/agents/agent-tools.before-tool-call.wrapper.ts
@@ -13,7 +13,7 @@ import {
   freezeDiagnosticTraceContext,
 } from "../infra/diagnostic-trace-context.js";
 import { pruneMapToMaxSize } from "../infra/map-size.js";
-import { getPluginToolMeta } from "../plugins/tools.js";
+import { getPluginToolMeta } from "../plugins/tool-metadata.js";
 import { recordRunSkillUsage } from "../skills/runtime/run-usage.js";
 import { copyBeforeToolCallWrapperMetadata } from "./agent-tool-metadata.js";
 import {

--- a/src/agents/agent-tools.deferred-followup-guidance.test.ts
+++ b/src/agents/agent-tools.deferred-followup-guidance.test.ts
@@ -1,7 +1,7 @@
 /** Tests model-facing descriptions selected from the final authorized tool set. */
 import { expectDefined } from "@openclaw/normalization-core";
 import { describe, expect, it } from "vitest";
-import { getPluginToolMeta, setPluginToolMeta } from "../plugins/tools.js";
+import { getPluginToolMeta, setPluginToolMeta } from "../plugins/tool-metadata.js";
 import { withMockedPlatform } from "../test-utils/vitest-spies.js";
 import { applyToolAvailabilityDescriptions } from "./agent-tools.deferred-followup.js";
 import type { AnyAgentTool } from "./agent-tools.types.js";

--- a/src/agents/agent-tools.safe-bins.test.ts
+++ b/src/agents/agent-tools.safe-bins.test.ts
@@ -141,9 +141,7 @@ vi.mock("./bash-tools.exec-host-shared.js", async () => {
 });
 
 vi.mock("../plugins/tools.js", () => ({
-  copyPluginToolMeta: vi.fn((_from, to) => to),
   resolvePluginTools: () => [],
-  getPluginToolMeta: () => undefined,
 }));
 
 vi.mock("openclaw/plugin-sdk/agent-sessions", () => ({

--- a/src/agents/agent-tools.ts
+++ b/src/agents/agent-tools.ts
@@ -24,7 +24,7 @@ import type {
   PluginHookToolRequesterContext,
 } from "../plugins/hook-types.js";
 import { appendRuntimePluginToolGrant } from "../plugins/tool-grant-allowlist.js";
-import { getPluginToolMeta } from "../plugins/tools.js";
+import { getPluginToolMeta } from "../plugins/tool-metadata.js";
 import { getActiveSecretsRuntimeConfigSnapshot } from "../secrets/runtime-state.js";
 import { GATEWAY_OWNER_ONLY_CORE_TOOLS } from "../security/dangerous-tools.js";
 import type { InputProvenance } from "../sessions/input-provenance.js";

--- a/src/agents/code-mode-mcp-api.ts
+++ b/src/agents/code-mode-mcp-api.ts
@@ -1,5 +1,5 @@
 import { isRecord } from "../../packages/normalization-core/src/record-coerce.js";
-import type { PluginToolMcpMeta } from "../plugins/tools.js";
+import type { PluginToolMcpMeta } from "../plugins/tool-metadata.js";
 
 type McpApiParamDoc = {
   name: string;

--- a/src/agents/code-mode-namespaces.ts
+++ b/src/agents/code-mode-namespaces.ts
@@ -6,7 +6,7 @@
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { tokTypes } from "acorn";
 import { isRecord } from "../../packages/normalization-core/src/record-coerce.js";
-import type { PluginToolMcpMeta } from "../plugins/tools.js";
+import type { PluginToolMcpMeta } from "../plugins/tool-metadata.js";
 import { sanitizeNodeIdFragment } from "./agent-bundle-mcp-names.js";
 import { toCodeModeJsonSafe } from "./code-mode-json.js";
 import {

--- a/src/agents/code-mode.agent-loop.test.ts
+++ b/src/agents/code-mode.agent-loop.test.ts
@@ -9,7 +9,7 @@ import {
 } from "openclaw/plugin-sdk/llm";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createDeferred } from "../../test/helpers/promise.js";
-import { setPluginToolMeta } from "../plugins/tools.js";
+import { setPluginToolMeta } from "../plugins/tool-metadata.js";
 import { consumeRepairableCodeModeFailure } from "./code-mode-repair-provenance.js";
 import type { CodeModeSkill } from "./code-mode-skills.js";
 import { createSubscribedCodeModeHarness } from "./code-mode.bridge.lifecycle.test-support.js";

--- a/src/agents/code-mode.replay.test.ts
+++ b/src/agents/code-mode.replay.test.ts
@@ -3,7 +3,7 @@
 import { expectDefined } from "@openclaw/normalization-core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createDeferred } from "../../test/helpers/promise.js";
-import { setPluginToolMeta } from "../plugins/tools.js";
+import { setPluginToolMeta } from "../plugins/tool-metadata.js";
 import { applyCodeModeCatalog } from "./code-mode.js";
 import {
   resetCodeModeTestState,

--- a/src/agents/code-mode.test-support.ts
+++ b/src/agents/code-mode.test-support.ts
@@ -1,5 +1,5 @@
 import { expect, vi } from "vitest";
-import { setPluginToolMeta } from "../plugins/tools.js";
+import { setPluginToolMeta } from "../plugins/tool-metadata.js";
 import { codeModeReplayIdForToolCall } from "./code-mode-bridge.js";
 import { resolveCodeModeHeadlessConfig } from "./code-mode-runtime.js";
 import type { CodeModeSkill } from "./code-mode-skills.js";

--- a/src/agents/embedded-agent-runner/effective-tool-policy.test.ts
+++ b/src/agents/embedded-agent-runner/effective-tool-policy.test.ts
@@ -5,7 +5,7 @@ import { describe, expect, it } from "vitest";
 import { replaceSessionEntry } from "../../config/sessions/session-accessor.js";
 import type { SessionEntry } from "../../config/sessions/types.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
-import { setPluginToolMeta } from "../../plugins/tools.js";
+import { setPluginToolMeta } from "../../plugins/tool-metadata.js";
 import { resolveConversationCapabilityProfile } from "../conversation-capability-profile.js";
 import type { AnyAgentTool } from "../tools/common.js";
 import { applyFinalEffectiveToolPolicy } from "./effective-tool-policy.js";

--- a/src/agents/embedded-agent-runner/effective-tool-policy.ts
+++ b/src/agents/embedded-agent-runner/effective-tool-policy.ts
@@ -3,7 +3,7 @@
  */
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { PluginMetadataSnapshot } from "../../plugins/plugin-metadata-snapshot.types.js";
-import { getPluginToolMeta } from "../../plugins/tools.js";
+import { getPluginToolMeta } from "../../plugins/tool-metadata.js";
 import type { ResolvedConversationCapabilityProfile } from "../conversation-capability-profile.js";
 import {
   buildConversationToolPolicyPipelineSteps,

--- a/src/agents/embedded-agent-runner/prepared-compaction-runtime.ts
+++ b/src/agents/embedded-agent-runner/prepared-compaction-runtime.ts
@@ -17,7 +17,7 @@ import { listRegisteredPluginAgentPromptGuidance } from "../../plugins/command-r
 import { extractModelCompat } from "../../plugins/provider-model-compat.js";
 import type { ProviderRuntimeModel } from "../../plugins/provider-runtime-model.types.js";
 import { transformProviderSystemPrompt } from "../../plugins/provider-runtime.js";
-import { getPluginToolMeta } from "../../plugins/tools.js";
+import { getPluginToolMeta } from "../../plugins/tool-metadata.js";
 import { resolveSkillsPrompt } from "../../skills/loading/workspace-skill-prompt.js";
 import { resolveEmbeddedRunSkillEntries } from "../../skills/runtime/embedded-run-entries.js";
 import {

--- a/src/agents/embedded-agent-runner/run/attempt-bundle-tools.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-bundle-tools.test.ts
@@ -3,7 +3,7 @@ import {
   createPluginMetadataSnapshot,
   makeRegistry,
 } from "../../../config/plugin-auto-enable.test-helpers.js";
-import { setPluginToolMeta } from "../../../plugins/tools.js";
+import { setPluginToolMeta } from "../../../plugins/tool-metadata.js";
 import { attachToolAllowlistIntersection } from "../../tool-policy.js";
 
 const mocks = vi.hoisted(() => ({

--- a/src/agents/embedded-agent-runner/run/attempt-bundle-tools.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-bundle-tools.ts
@@ -1,4 +1,4 @@
-import { getPluginToolMeta } from "../../../plugins/tools.js";
+import { getPluginToolMeta } from "../../../plugins/tool-metadata.js";
 import { createBundleLspToolRuntime } from "../../agent-bundle-lsp-runtime.js";
 import { assignSafeServerNames, TOOL_NAME_SEPARATOR } from "../../agent-bundle-mcp-names.js";
 import { loadSessionMcpConfig } from "../../agent-bundle-mcp-runtime-config.js";

--- a/src/agents/embedded-agent-runner/run/attempt-client-tools.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-client-tools.test.ts
@@ -1,7 +1,7 @@
 import { Type } from "typebox";
 import { describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
-import { setPluginToolMeta } from "../../../plugins/tools.js";
+import { setPluginToolMeta } from "../../../plugins/tool-metadata.js";
 import { setChannelAgentToolMeta } from "../../channel-tool-metadata.js";
 import { createCodeModeCatalogProjection } from "../../code-mode-catalog.js";
 import { markCodeModeControlTool } from "../../code-mode-control-tools.js";

--- a/src/agents/embedded-agent-runner/run/attempt-client-tools.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-client-tools.ts
@@ -1,4 +1,7 @@
-import { getPluginToolMeta, getPluginToolSideEffectOwnerKey } from "../../../plugins/tools.js";
+import {
+  getPluginToolMeta,
+  getPluginToolSideEffectOwnerKey,
+} from "../../../plugins/tool-metadata.js";
 import {
   createClientToolNameConflictError,
   findClientToolNameConflicts,

--- a/src/agents/embedded-agent-runner/run/attempt-prompt-tool-policy.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-prompt-tool-policy.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { setPluginToolMeta } from "../../../plugins/tools.js";
+import { setPluginToolMeta } from "../../../plugins/tool-metadata.js";
 import type { ToolSearchCatalogEntry, ToolSearchCatalogRef } from "../../tool-search.js";
 import type { AnyAgentTool } from "../../tools/common.js";
 import {

--- a/src/agents/embedded-agent-runner/run/attempt-tool-prepare.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-tool-prepare.ts
@@ -9,7 +9,7 @@ import {
   logCodeModeDiagnostic,
 } from "../../../logging/code-mode-diagnostic.js";
 import { extractModelCompat } from "../../../plugins/provider-model-compat.js";
-import { getPluginToolMeta } from "../../../plugins/tools.js";
+import { getPluginToolMeta } from "../../../plugins/tool-metadata.js";
 import { isSubagentSessionKey } from "../../../routing/session-key.js";
 import type { NestedToolActivity } from "../../../sessions/nested-tool-activity.js";
 import { createOpenClawCodingTools } from "../../agent-tools.js";

--- a/src/agents/embedded-agent-runner/run/attempt-tool-search-run-plan.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-tool-search-run-plan.ts
@@ -1,7 +1,7 @@
 /**
  * Builds tool-search execution plans from allowlists and available controls.
  */
-import { getPluginToolMeta } from "../../../plugins/tools.js";
+import { getPluginToolMeta } from "../../../plugins/tool-metadata.js";
 import { createToolPolicyMatcher } from "../../tool-policy-match.js";
 import { normalizeToolPolicyName } from "../../tool-policy.js";
 import {

--- a/src/agents/embedded-agent-runner/run/attempt.tool-search-run-plan.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.tool-search-run-plan.test.ts
@@ -1,6 +1,6 @@
 // Coverage for Tool Search control planning and allowlist accounting.
 import { describe, expect, it } from "vitest";
-import { setPluginToolMeta } from "../../../plugins/tools.js";
+import { setPluginToolMeta } from "../../../plugins/tool-metadata.js";
 import { buildToolSearchRunPlan } from "./attempt-tool-search-run-plan.js";
 
 describe("buildToolSearchRunPlan", () => {

--- a/src/agents/embedded-agent-runner/run/tool-activity-heartbeat.test.ts
+++ b/src/agents/embedded-agent-runner/run/tool-activity-heartbeat.test.ts
@@ -1,6 +1,6 @@
 import { expectDefined } from "@openclaw/normalization-core";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { getPluginToolMeta, setPluginToolMeta } from "../../../plugins/tools.js";
+import { getPluginToolMeta, setPluginToolMeta } from "../../../plugins/tool-metadata.js";
 import {
   BEFORE_TOOL_CALL_SOURCE_TOOL,
   BEFORE_TOOL_CALL_WRAPPED,

--- a/src/agents/harness/prompt-tool-policy.ts
+++ b/src/agents/harness/prompt-tool-policy.ts
@@ -1,5 +1,5 @@
 import { normalizeUniqueStringEntries } from "@openclaw/normalization-core/string-normalization";
-import { getPluginToolMeta } from "../../plugins/tools.js";
+import { getPluginToolMeta } from "../../plugins/tool-metadata.js";
 import { CODE_MODE_EXEC_TOOL_NAME, CODE_MODE_WAIT_TOOL_NAME } from "../code-mode-control-tools.js";
 import {
   applyEmbeddedAttemptToolsAllow,

--- a/src/agents/node-plugin-tools.test.ts
+++ b/src/agents/node-plugin-tools.test.ts
@@ -8,7 +8,7 @@ import {
   removeConnectedNodePluginTools,
   replaceConnectedNodePluginTools,
 } from "../gateway/node-plugin-tool-snapshot.js";
-import { getPluginToolMeta, setPluginToolMeta } from "../plugins/tools.js";
+import { getPluginToolMeta, setPluginToolMeta } from "../plugins/tool-metadata.js";
 import { applyCodeModeCatalog, createCodeModeTools } from "./code-mode.js";
 import { testing } from "./code-mode.test-support.js";
 import { createNodePluginTools } from "./node-plugin-tools.js";

--- a/src/agents/node-plugin-tools.ts
+++ b/src/agents/node-plugin-tools.ts
@@ -8,7 +8,7 @@ import {
   NODE_PLUGIN_TOOL_CALL_GATEWAY_TIMEOUT_MS,
   NODE_PLUGIN_TOOL_CALL_TIMEOUT_MS,
 } from "../infra/node-commands.js";
-import { setPluginToolMeta } from "../plugins/tools.js";
+import { setPluginToolMeta } from "../plugins/tool-metadata.js";
 import { sanitizeNodeIdFragment, sanitizeServerName } from "./agent-bundle-mcp-names.js";
 import { compileGlobPatterns, matchesAnyGlobPattern } from "./glob-pattern.js";
 import {

--- a/src/agents/runtime-plan/tools.test.ts
+++ b/src/agents/runtime-plan/tools.test.ts
@@ -10,7 +10,7 @@ import {
 } from "openclaw/plugin-sdk/agent-runtime-test-contracts";
 import { Type } from "typebox";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { getPluginToolMeta, setPluginToolMeta } from "../../plugins/tools.js";
+import { getPluginToolMeta, setPluginToolMeta } from "../../plugins/tool-metadata.js";
 import {
   isToolWrappedWithBeforeToolCallHook,
   wrapToolWithBeforeToolCallHook,
@@ -223,16 +223,27 @@ describe("AgentRuntimePlan tool policy helpers", () => {
     // Provider normalization may clone tool objects; plugin metadata has to move
     // with the clone so later dispatch still knows the owning plugin/MCP server.
     const tool = createParameterFreeTool("fixture__lookup_note") as AgentTool;
-    setPluginToolMeta(tool, {
+    const metadata: Parameters<typeof setPluginToolMeta>[1] = {
       pluginId: "bundle-mcp",
-      optional: false,
+      kind: "memory",
+      optional: true,
+      replaySafe: true,
+      sideEffecting: true,
+      trustedLocalMedia: false,
       mcp: {
         serverName: "fixture",
         safeServerName: "fixture",
         toolName: "lookup_note",
         operation: "tool",
+        deniedBySession: true,
+        codexApproval: {
+          mode: "prompt",
+          annotations: { readOnlyHint: false, destructiveHint: true, openWorldHint: true },
+        },
+        node: { id: "fixture-node", displayName: "Fixture node" },
       },
-    });
+    };
+    setPluginToolMeta(tool, metadata);
     const normalized = {
       ...tool,
       parameters: normalizedParameterFreeSchema(),
@@ -245,13 +256,7 @@ describe("AgentRuntimePlan tool policy helpers", () => {
     });
 
     expect(result[0]).toBe(normalized);
-    expect(getPluginToolMeta(expectDefined(result[0], "result[0] test invariant"))).toMatchObject({
-      pluginId: "bundle-mcp",
-      mcp: {
-        serverName: "fixture",
-        toolName: "lookup_note",
-      },
-    });
+    expect(getPluginToolMeta(expectDefined(result[0], "result[0] test invariant"))).toBe(metadata);
   });
 
   it("preserves declared output schemas when runtime normalization clones tools", () => {

--- a/src/agents/test-helpers/fast-tool-stubs.ts
+++ b/src/agents/test-helpers/fast-tool-stubs.ts
@@ -38,9 +38,5 @@ vi.mock("../tools/web-tools.js", () => ({
 }));
 
 vi.mock("../../plugins/tools.js", () => ({
-  buildPluginToolMetadataKey: (pluginId: string, toolName: string) =>
-    JSON.stringify([pluginId, toolName]),
-  copyPluginToolMeta: (_from: unknown, to: unknown) => to,
-  getPluginToolMeta: () => undefined,
   resolvePluginTools: () => [],
 }));

--- a/src/agents/tool-schema-quarantine.ts
+++ b/src/agents/tool-schema-quarantine.ts
@@ -6,7 +6,7 @@
  */
 import { emitTrustedDiagnosticEvent } from "../infra/diagnostic-events.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
-import { getPluginToolMeta } from "../plugins/tools.js";
+import { getPluginToolMeta } from "../plugins/tool-metadata.js";
 import type { RuntimeToolSchemaDiagnostic } from "./tool-schema-projection.js";
 import {
   clearRecoveredPersistedRuntimeToolSchemaQuarantines,

--- a/src/agents/tool-search-catalog.ts
+++ b/src/agents/tool-search-catalog.ts
@@ -1,7 +1,7 @@
 import { stableStringify } from "@openclaw/normalization-core";
 import { pruneMapToMaxSize } from "../infra/map-size.js";
 import { generateSecureToken } from "../infra/secure-random.js";
-import { getPluginToolMeta, type PluginToolMcpMeta } from "../plugins/tools.js";
+import { getPluginToolMeta, type PluginToolMcpMeta } from "../plugins/tool-metadata.js";
 import type { HookContext } from "./agent-tools.before-tool-call.js";
 import {
   isToolWrappedWithBeforeToolCallHook,

--- a/src/agents/tool-search-runtime.ts
+++ b/src/agents/tool-search-runtime.ts
@@ -3,7 +3,7 @@ import {
   normalizeStringEntries,
   uniqueStrings,
 } from "@openclaw/normalization-core/string-normalization";
-import { getPluginToolMeta } from "../plugins/tools.js";
+import { getPluginToolMeta } from "../plugins/tool-metadata.js";
 import { levenshteinDistance } from "../shared/levenshtein-distance.js";
 import {
   getBeforeToolCallFailureDisposition,

--- a/src/agents/tool-search-types.ts
+++ b/src/agents/tool-search-types.ts
@@ -1,7 +1,7 @@
 import type { Result } from "@openclaw/normalization-core/result";
 import type { TSchema } from "typebox";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import type { PluginToolMcpMeta } from "../plugins/tools.js";
+import type { PluginToolMcpMeta } from "../plugins/tool-metadata.js";
 import type { HookContext } from "./agent-tools.before-tool-call.js";
 import type { CodeModeSkill } from "./code-mode-skills.js";
 import type { AgentToolResult, AgentToolUpdateCallback } from "./runtime/index.js";

--- a/src/agents/tool-search.test.ts
+++ b/src/agents/tool-search.test.ts
@@ -10,7 +10,7 @@ import {
   resetGlobalHookRunner,
 } from "../plugins/hook-runner-global.js";
 import { createMockPluginRegistry } from "../plugins/hooks.test-fixtures.js";
-import { setPluginToolMeta } from "../plugins/tools.js";
+import { setPluginToolMeta } from "../plugins/tool-metadata.js";
 import { materializeBundleMcpToolsForRun } from "./agent-bundle-mcp-materialize.js";
 import type { McpToolCatalog, SessionMcpRuntime } from "./agent-bundle-mcp-types.js";
 import { toToolDefinitions } from "./agent-tool-definition-adapter.js";

--- a/src/agents/tools-effective-inventory-build.ts
+++ b/src/agents/tools-effective-inventory-build.ts
@@ -7,7 +7,7 @@ import { normalizeOptionalString } from "@openclaw/normalization-core/string-coe
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { ProviderRuntimeModel } from "../plugins/provider-runtime-model.types.js";
 import { getActivePluginRegistry } from "../plugins/runtime.js";
-import { buildPluginToolMetadataKey, getPluginToolMeta } from "../plugins/tools.js";
+import { buildPluginToolMetadataKey, getPluginToolMeta } from "../plugins/tool-metadata.js";
 import { getChannelAgentToolMeta } from "./channel-tools.js";
 import { normalizeAgentRuntimeTools } from "./runtime-plan/tools.js";
 import {

--- a/src/agents/tools-effective-inventory.test.ts
+++ b/src/agents/tools-effective-inventory.test.ts
@@ -6,13 +6,9 @@ import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ProviderRuntimeModel } from "../plugins/provider-runtime-model.types.js";
 import { createEmptyPluginRegistry } from "../plugins/registry-empty.js";
 import { setActivePluginRegistry } from "../plugins/runtime.js";
+import { setPluginToolMeta } from "../plugins/tool-metadata.js";
 import type { createOpenClawCodingTools } from "./agent-tools.js";
 import type { AnyAgentTool } from "./tools/common.js";
-
-type TestPluginMeta = Record<
-  string,
-  { pluginId: string; mcp?: { serverName: string } } | undefined
->;
 
 function mockTool(params: {
   name: string;
@@ -20,14 +16,20 @@ function mockTool(params: {
   description: string;
   displaySummary?: string;
   parameters?: unknown;
+  pluginMeta?: Parameters<typeof setPluginToolMeta>[1];
 }): AnyAgentTool {
-  return {
-    ...params,
+  const { pluginMeta, ...toolParams } = params;
+  const tool = {
+    ...toolParams,
     parameters: Object.hasOwn(params, "parameters")
       ? params.parameters
       : { type: "object", properties: {} },
     execute: async () => ({ text: params.description }),
   } as unknown as AnyAgentTool;
+  if (pluginMeta) {
+    setPluginToolMeta(tool, pluginMeta);
+  }
+  return tool;
 }
 
 const effectiveInventoryState = vi.hoisted(() => ({
@@ -35,7 +37,6 @@ const effectiveInventoryState = vi.hoisted(() => ({
     mockTool({ name: "exec", label: "Exec", description: "Run shell commands" }),
     mockTool({ name: "docs_lookup", label: "Docs Lookup", description: "Search docs" }),
   ] as AnyAgentTool[],
-  pluginMeta: {} as TestPluginMeta,
   channelMeta: {} as Record<string, { channelId: string } | undefined>,
   effectivePolicy: {} as { profile?: string; providerProfile?: string },
   normalizeToolsMock: vi.fn((options: { tools: AnyAgentTool[] }) => options.tools),
@@ -63,13 +64,6 @@ vi.mock("./agent-scope.js", async () => {
 vi.mock("./agent-tools.js", () => ({
   createOpenClawCodingTools: (options?: Parameters<typeof createOpenClawCodingTools>[0]) =>
     effectiveInventoryState.createToolsMock(options),
-}));
-
-vi.mock("../plugins/tools.js", () => ({
-  copyPluginToolMeta: vi.fn(),
-  getPluginToolMeta: (tool: { name: string }) => effectiveInventoryState.pluginMeta[tool.name],
-  buildPluginToolMetadataKey: (pluginId: string, toolName: string) =>
-    JSON.stringify([pluginId, toolName]),
 }));
 
 vi.mock("./channel-tools.js", () => ({
@@ -106,7 +100,6 @@ let resolveEffectiveToolInventory: typeof import("./tools-effective-inventory.js
 async function loadHarness(options?: {
   tools?: AnyAgentTool[];
   createToolsMock?: typeof effectiveInventoryState.createToolsMock;
-  pluginMeta?: TestPluginMeta;
   channelMeta?: Record<string, { channelId: string } | undefined>;
   effectivePolicy?: { profile?: string; providerProfile?: string };
   normalizeToolsMock?: typeof effectiveInventoryState.normalizeToolsMock;
@@ -115,7 +108,6 @@ async function loadHarness(options?: {
     mockTool({ name: "exec", label: "Exec", description: "Run shell commands" }),
     mockTool({ name: "docs_lookup", label: "Docs Lookup", description: "Search docs" }),
   ];
-  effectiveInventoryState.pluginMeta = options?.pluginMeta ?? {};
   effectiveInventoryState.channelMeta = options?.channelMeta ?? {};
   effectiveInventoryState.effectivePolicy = options?.effectivePolicy ?? {};
   effectiveInventoryState.normalizeToolsMock =
@@ -141,7 +133,6 @@ describe("resolveEffectiveToolInventory", () => {
       mockTool({ name: "exec", label: "Exec", description: "Run shell commands" }),
       mockTool({ name: "docs_lookup", label: "Docs Lookup", description: "Search docs" }),
     ];
-    effectiveInventoryState.pluginMeta = {};
     effectiveInventoryState.channelMeta = {};
     effectiveInventoryState.effectivePolicy = {};
     effectiveInventoryState.normalizeToolsMock = vi.fn((options) => options.tools);
@@ -158,14 +149,18 @@ describe("resolveEffectiveToolInventory", () => {
       await loadHarness({
         tools: [
           mockTool({ name: "exec", label: "Exec", description: "Run shell commands" }),
-          mockTool({ name: "docs_lookup", label: "Docs Lookup", description: "Search docs" }),
+          mockTool({
+            name: "docs_lookup",
+            label: "Docs Lookup",
+            description: "Search docs",
+            pluginMeta: { pluginId: "docs", optional: false },
+          }),
           mockTool({
             name: "message_actions",
             label: "Message Actions",
             description: "Act on messages",
           }),
         ],
-        pluginMeta: { docs_lookup: { pluginId: "docs" } },
         channelMeta: { message_actions: { channelId: "telegram" } },
       });
 
@@ -227,9 +222,13 @@ describe("resolveEffectiveToolInventory", () => {
     const { resolveEffectiveToolInventory: resolveEffectiveToolInventoryLocal10 } =
       await loadHarness({
         tools: [
-          mockTool({ name: "reproProbe__probe_tool", label: "Probe", description: "Probe MCP" }),
+          mockTool({
+            name: "reproProbe__probe_tool",
+            label: "Probe",
+            description: "Probe MCP",
+            pluginMeta: { pluginId: "bundle-mcp", optional: false },
+          }),
         ],
-        pluginMeta: { reproProbe__probe_tool: { pluginId: "bundle-mcp" } },
       });
 
     const result = resolveEffectiveToolInventoryLocal10({ cfg: {} });
@@ -257,14 +256,22 @@ describe("resolveEffectiveToolInventory", () => {
     const { resolveEffectiveToolInventory: resolveEffectiveToolInventoryLocal11 } =
       await loadHarness({
         tools: [
-          mockTool({ name: "remote_echo", label: "Remote Echo", description: "Probe node MCP" }),
+          mockTool({
+            name: "remote_echo",
+            label: "Remote Echo",
+            description: "Probe node MCP",
+            pluginMeta: {
+              pluginId: "remote-demo",
+              optional: false,
+              mcp: {
+                serverName: "remote-demo",
+                safeServerName: "remote-demo",
+                toolName: "echo",
+                operation: "tool",
+              },
+            },
+          }),
         ],
-        pluginMeta: {
-          remote_echo: {
-            pluginId: "remote-demo",
-            mcp: { serverName: "remote-demo" },
-          },
-        },
       });
 
     const result = resolveEffectiveToolInventoryLocal11({ cfg: {} });
@@ -292,13 +299,19 @@ describe("resolveEffectiveToolInventory", () => {
     const { resolveEffectiveToolInventory: resolveEffectiveToolInventoryLocal9 } =
       await loadHarness({
         tools: [
-          mockTool({ name: "docs_lookup", label: "Lookup", description: "Search docs" }),
-          mockTool({ name: "jira_lookup", label: "Lookup", description: "Search Jira" }),
+          mockTool({
+            name: "docs_lookup",
+            label: "Lookup",
+            description: "Search docs",
+            pluginMeta: { pluginId: "docs", optional: false },
+          }),
+          mockTool({
+            name: "jira_lookup",
+            label: "Lookup",
+            description: "Search Jira",
+            pluginMeta: { pluginId: "jira", optional: false },
+          }),
         ],
-        pluginMeta: {
-          docs_lookup: { pluginId: "docs" },
-          jira_lookup: { pluginId: "jira" },
-        },
       });
 
     const result = resolveEffectiveToolInventoryLocal9({ cfg: {} });
@@ -326,8 +339,14 @@ describe("resolveEffectiveToolInventory", () => {
     setActivePluginRegistry(registry);
     const { resolveEffectiveToolInventory: resolveEffectiveToolInventoryLocal8 } =
       await loadHarness({
-        tools: [mockTool({ name: "docs_lookup", label: "Lookup", description: "Search docs" })],
-        pluginMeta: { docs_lookup: { pluginId: "docs" } },
+        tools: [
+          mockTool({
+            name: "docs_lookup",
+            label: "Lookup",
+            description: "Search docs",
+            pluginMeta: { pluginId: "docs", optional: false },
+          }),
+        ],
       });
 
     const result = resolveEffectiveToolInventoryLocal8({ cfg: {} });
@@ -353,6 +372,7 @@ describe("resolveEffectiveToolInventory", () => {
             name: "fuzzplugin_move_angles",
             label: "Fuzzplugin Move Angles",
             description: "Move robot joints",
+            pluginMeta: { pluginId: "fuzzplugin", optional: false },
             parameters: {
               type: "object",
               properties: {
@@ -361,7 +381,6 @@ describe("resolveEffectiveToolInventory", () => {
             },
           }),
         ],
-        pluginMeta: { fuzzplugin_move_angles: { pluginId: "fuzzplugin" } },
       });
 
     const result = resolveEffectiveToolInventoryLocal7({ cfg: {} });
@@ -386,10 +405,10 @@ describe("resolveEffectiveToolInventory", () => {
             name: "fuzzplugin_move_angles",
             label: "Fuzzplugin Move Angles",
             description: "Move fixture joints",
+            pluginMeta: { pluginId: "fuzzplugin", optional: false },
             parameters: { type: "array", items: { type: "number" } },
           }),
         ],
-        pluginMeta: { fuzzplugin_move_angles: { pluginId: "fuzzplugin" } },
       });
 
     const result = resolveEffectiveToolInventoryLocal12({ cfg: {} });
@@ -461,9 +480,9 @@ describe("resolveEffectiveToolInventory", () => {
             label: "Parameter Free",
             description: "Runtime-normalized tool",
             parameters: undefined,
+            pluginMeta: { pluginId: "normalized-plugin", optional: false },
           }),
         ],
-        pluginMeta: { parameter_free: { pluginId: "normalized-plugin" } },
         normalizeToolsMock,
       });
 
@@ -788,9 +807,9 @@ describe("resolveEffectiveToolInventory", () => {
             label: "Parameter Free",
             description: "Runtime-normalized tool",
             parameters: undefined,
+            pluginMeta: { pluginId: "normalized-plugin", optional: false },
           }),
         ],
-        pluginMeta: { parameter_free: { pluginId: "normalized-plugin" } },
         normalizeToolsMock,
       },
     );
@@ -852,8 +871,14 @@ describe("resolveEffectiveToolInventory", () => {
     setActivePluginRegistry(registry);
     const { resolveEffectiveToolInventory: resolveEffectiveToolInventoryScoped } =
       await loadHarness({
-        tools: [mockTool({ name: "docs_lookup", label: "Lookup", description: "Search docs" })],
-        pluginMeta: { docs_lookup: { pluginId: "docs" } },
+        tools: [
+          mockTool({
+            name: "docs_lookup",
+            label: "Lookup",
+            description: "Search docs",
+            pluginMeta: { pluginId: "docs", optional: false },
+          }),
+        ],
       });
 
     const result = resolveEffectiveToolInventoryScoped({ cfg: {} });

--- a/src/agents/tools-effective-mcp-inventory.ts
+++ b/src/agents/tools-effective-mcp-inventory.ts
@@ -5,7 +5,7 @@
  */
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { ProviderRuntimeModel } from "../plugins/provider-runtime-model.types.js";
-import { getPluginToolMeta } from "../plugins/tools.js";
+import { getPluginToolMeta } from "../plugins/tool-metadata.js";
 import { normalizeAgentRuntimeTools } from "./runtime-plan/tools.js";
 import {
   filterRuntimeCompatibleTools,

--- a/src/agents/tools/gateway-caller-context.test.ts
+++ b/src/agents/tools/gateway-caller-context.test.ts
@@ -3,7 +3,7 @@ import { Type } from "typebox";
 import { describe, expect, it, vi } from "vitest";
 import { createExecutionIdentityAdmissionToken } from "../../audit/execution-identity-admission.js";
 import type { GatewayRequestContext } from "../../gateway/server-methods/types.js";
-import { getPluginToolMeta, setPluginToolMeta } from "../../plugins/tools.js";
+import { getPluginToolMeta, setPluginToolMeta } from "../../plugins/tool-metadata.js";
 import {
   isToolWrappedWithBeforeToolCallHook,
   wrapToolWithBeforeToolCallHook,

--- a/src/cli/mcp-cli.import-boundary.test.ts
+++ b/src/cli/mcp-cli.import-boundary.test.ts
@@ -1,15 +1,116 @@
-import { Command } from "commander";
-import { expect, it, vi } from "vitest";
+import { expect, it } from "vitest";
+import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
+import { formatCliProcessFailure, runCliProcessChild } from "./cli-process-child.test-helpers.js";
 
-vi.mock("../mcp/channel-server.js", () => {
-  throw new Error("MCP client commands must not load the channel-serving runtime");
+async function runImportBoundaryChild(forbidden: RegExp, workload: string) {
+  return withOpenClawTestState(
+    {
+      prefix: "openclaw-mcp-import-boundary-",
+      scenario: "minimal",
+      applyEnv: false,
+    },
+    async (state) => {
+      // A fresh child keeps Vitest's shared module cache from bypassing the guard.
+      // Register after TSX and before dynamic imports so the guard sees original specifiers.
+      const script = String.raw`
+        import assert from "node:assert/strict";
+        import { registerHooks } from "node:module";
+
+        const forbidden = ${forbidden};
+        function assertAllowedImport(url, parentURL) {
+          if (forbidden.test(url)) {
+            throw new Error("MCP import boundary denied " + url +
+              " (importer: " + (parentURL ?? "unknown") + ")");
+          }
+        }
+        registerHooks({
+          resolve(specifier, context, nextResolve) {
+            const requested = specifier.startsWith(".")
+              ? new URL(specifier, context.parentURL ?? import.meta.url).href
+              : specifier;
+            assertAllowedImport(requested, context.parentURL);
+            const resolved = nextResolve(specifier, context);
+            assertAllowedImport(resolved.url, context.parentURL);
+            return resolved;
+          },
+        });
+
+        ${workload}
+        console.log("MCP_IMPORT_BOUNDARY_OK");
+      `;
+      const result = await runCliProcessChild({
+        nodeArgs: ["--import", "tsx", "--input-type=module", "--eval", script],
+        // state.env inherits Vitest and operator flags; only fixture paths cross this boundary.
+        env: {
+          PATH: process.env.PATH,
+          ...state.envVars,
+          TMPDIR: state.root,
+          TMP: state.root,
+          TEMP: state.root,
+        },
+        timeoutMs: 30_000,
+      });
+      const failure = formatCliProcessFailure({
+        reason: "MCP import boundary child failed",
+        ...result,
+      });
+
+      expect(result.signal, failure).toBeNull();
+      expect(result.code, failure).toBe(0);
+      expect(result.stdout, failure).toContain("MCP_IMPORT_BOUNDARY_OK");
+      return result.stdout;
+    },
+  );
+}
+
+it("keeps MCP client and catalog paths free of plugin tool construction and channel serving", async () => {
+  const stdout = await runImportBoundaryChild(
+    /\/src\/(?:plugins\/tools|mcp\/channel-server)\.(?:ts|js)(?:[?#].*)?$/u,
+    String.raw`
+      const { Command } = await import("commander");
+      const { registerMcpCli } = await import(${JSON.stringify(new URL("./mcp-cli.ts", import.meta.url).href)});
+      const program = new Command();
+      program.exitOverride();
+      registerMcpCli(program);
+      assert.equal(await program.parseAsync(["mcp", "reload"], { from: "user" }), program);
+
+      const { buildBundleMcpToolsFromCatalog } = await import(${JSON.stringify(new URL("../agents/agent-bundle-mcp-materialize.ts", import.meta.url).href)});
+      const tools = buildBundleMcpToolsFromCatalog({
+        catalog: {
+          version: 1,
+          generatedAt: 0,
+          servers: {
+            inventory: {
+              serverName: "inventory",
+              safeServerName: "inventory",
+              launchSummary: "inventory fixture",
+              toolCount: 1,
+            },
+          },
+          tools: [{
+            serverName: "inventory",
+            safeServerName: "inventory",
+            toolName: "lookup",
+            inputSchema: { type: "object", properties: {} },
+            fallbackDescription: "Look up an inventory item",
+          }],
+        },
+      });
+      assert.deepEqual(tools.map((tool) => tool.name), ["inventory__lookup"]);
+      await assert.rejects(tools[0].execute("inventory-only", {}, undefined, undefined), {
+        message: "bundle-mcp catalog projection cannot execute tools",
+      });
+    `,
+  );
+  expect(stdout).toContain("Disposed cached MCP runtimes.");
 });
 
-it("registers MCP commands and reloads client runtimes without channel serving", async () => {
-  const { registerMcpCli } = await import("./mcp-cli.js");
-  const program = new Command();
-  program.exitOverride();
-  registerMcpCli(program);
-
-  await expect(program.parseAsync(["mcp", "reload"], { from: "user" })).resolves.toBe(program);
+it("keeps the metadata owner independent of plugin loading and channel serving", async () => {
+  await runImportBoundaryChild(
+    /\/src\/(?:plugins\/(?:tools|loader)|mcp\/channel-server)\.(?:ts|js)(?:[?#].*)?$/u,
+    String.raw`
+      const { getPluginToolMeta } = await import(${JSON.stringify(new URL("../plugins/tool-metadata.ts", import.meta.url).href)});
+      assert.equal(getPluginToolMeta({}), undefined);
+    `,
+  );
 });

--- a/src/commands/doctor/shared/active-tool-schema-warnings.test.ts
+++ b/src/commands/doctor/shared/active-tool-schema-warnings.test.ts
@@ -2,10 +2,10 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { createOpenClawCodingTools } from "../../../agents/agent-tools.js";
 import type { AnyAgentTool } from "../../../agents/tools/common.js";
+import { setPluginToolMeta } from "../../../plugins/tool-metadata.js";
 
 const toolState = vi.hoisted(() => ({
   tools: [] as AnyAgentTool[],
-  pluginIds: {} as Record<string, string | undefined>,
   throwError: null as Error | null,
   runtimeModel: null as {
     id: string;
@@ -37,13 +37,6 @@ vi.mock("../../../agents/agent-tools.js", () => ({
   },
 }));
 
-vi.mock("../../../plugins/tools.js", () => ({
-  getPluginToolMeta: (toolLocal: { name: string }) => {
-    const pluginId = toolState.pluginIds[toolLocal.name];
-    return pluginId ? { pluginId, optional: false } : undefined;
-  },
-}));
-
 vi.mock("../../../agents/runtime-plan/tools.js", () => ({
   normalizeAgentRuntimeTools: (options: { tools: AnyAgentTool[] }) =>
     toolState.normalizeTools(options),
@@ -52,20 +45,23 @@ vi.mock("../../../agents/runtime-plan/tools.js", () => ({
 const { collectActiveToolSchemaProjectionWarnings } =
   await import("./active-tool-schema-warnings.js");
 
-function tool(name: string, parameters: unknown): AnyAgentTool {
-  return {
+function tool(name: string, parameters: unknown, pluginId?: string): AnyAgentTool {
+  const result = {
     name,
     label: name,
     description: name,
     parameters,
     execute: async () => ({ text: "ok" }),
   } as unknown as AnyAgentTool;
+  if (pluginId) {
+    setPluginToolMeta(result, { pluginId, optional: false });
+  }
+  return result;
 }
 
 describe("active tool schema doctor warnings", () => {
   beforeEach(() => {
     toolState.tools = [];
-    toolState.pluginIds = {};
     toolState.throwError = null;
     toolState.runtimeModel = null;
     toolState.resolveModelError = null;
@@ -86,9 +82,8 @@ describe("active tool schema doctor warnings", () => {
   it("warns with plugin ownership for active tools blocked by runtime projection", async () => {
     toolState.tools = [
       tool("message", { type: "object", properties: {} }),
-      tool("fuzzplugin_move_angles", { type: "array", items: { type: "number" } }),
+      tool("fuzzplugin_move_angles", { type: "array", items: { type: "number" } }, "fuzzplugin"),
     ];
-    toolState.pluginIds = { fuzzplugin_move_angles: "fuzzplugin" };
 
     expect(
       await collectActiveToolSchemaProjectionWarnings({
@@ -135,9 +130,8 @@ describe("active tool schema doctor warnings", () => {
 
   it("does not validate disabled plugin mode", async () => {
     toolState.tools = [
-      tool("fuzzplugin_move_angles", { type: "array", items: { type: "number" } }),
+      tool("fuzzplugin_move_angles", { type: "array", items: { type: "number" } }, "fuzzplugin"),
     ];
-    toolState.pluginIds = { fuzzplugin_move_angles: "fuzzplugin" };
 
     expect(
       await collectActiveToolSchemaProjectionWarnings({
@@ -194,7 +188,11 @@ describe("active tool schema doctor warnings", () => {
 
   it("validates provider-normalized runtime schemas before reporting doctor health", async () => {
     const healthyTool = tool("message", { type: "object", properties: {} });
-    const dynamicTool = tool("fuzzplugin_move_angles", { type: "object", properties: {} });
+    const dynamicTool = tool(
+      "fuzzplugin_move_angles",
+      { type: "object", properties: {} },
+      "fuzzplugin",
+    );
     toolState.runtimeModel = {
       id: "gpt-5.5",
       name: "GPT-5.5",
@@ -204,7 +202,6 @@ describe("active tool schema doctor warnings", () => {
       compat: { unsupportedToolSchemaKeywords: ["$dynamicRef"] },
     };
     toolState.tools = [healthyTool, dynamicTool];
-    toolState.pluginIds = { fuzzplugin_move_angles: "fuzzplugin" };
     toolState.normalizeTools.mockImplementation(({ tools, modelApi, model }) => {
       if (
         modelApi !== "openai-responses" ||

--- a/src/commands/doctor/shared/active-tool-schema-warnings.ts
+++ b/src/commands/doctor/shared/active-tool-schema-warnings.ts
@@ -20,7 +20,7 @@ import { formatErrorMessage } from "../../../infra/errors.js";
 import type { PluginMetadataSnapshotScopeRunner } from "../../../plugins/current-plugin-metadata-snapshot.js";
 import { extractModelCompat } from "../../../plugins/provider-model-compat.js";
 import type { ProviderRuntimeModel } from "../../../plugins/provider-runtime-model.types.js";
-import { getPluginToolMeta } from "../../../plugins/tools.js";
+import { getPluginToolMeta } from "../../../plugins/tool-metadata.js";
 import { resolveDoctorPrimaryModelRef } from "./primary-model-ref.js";
 
 type RuntimeModelContext = {

--- a/src/cron/trigger-script.ts
+++ b/src/cron/trigger-script.ts
@@ -46,7 +46,7 @@ import { formatErrorMessageWithCode } from "../infra/errors.js";
 import { pruneMapToMaxSize } from "../infra/map-size.js";
 import type { PluginRegistry } from "../plugins/registry-types.js";
 import { withPluginRuntimeRegistryScope } from "../plugins/runtime/gateway-request-scope.js";
-import { getPluginToolMeta } from "../plugins/tools.js";
+import { getPluginToolMeta } from "../plugins/tool-metadata.js";
 import { normalizeAgentId } from "../routing/session-key.js";
 import {
   resolveCronActiveRuntimeConfig,

--- a/src/flows/doctor-core-checks.runtime-errors.test.ts
+++ b/src/flows/doctor-core-checks.runtime-errors.test.ts
@@ -1,7 +1,7 @@
 // Doctor runtime error tests cover error handling in core runtime checks.
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { AnyAgentTool } from "../agents/tools/common.js";
-import { setPluginToolMeta } from "../plugins/tools.js";
+import { setPluginToolMeta } from "../plugins/tool-metadata.js";
 
 const mocks = vi.hoisted(() => ({
   createBundleMcpToolRuntime: vi.fn(),

--- a/src/flows/doctor-core-checks.runtime.test.ts
+++ b/src/flows/doctor-core-checks.runtime.test.ts
@@ -4,7 +4,7 @@ import { GatewayClientRequestError } from "../../packages/gateway-client/src/ind
 import type { AnyAgentTool } from "../agents/tools/common.js";
 import { GATEWAY_HEALTH_RATE_LIMITED_MESSAGE } from "../commands/gateway-health-auth-diagnostic.js";
 import { GatewaySecretRefUnavailableError } from "../gateway/credentials.js";
-import { setPluginToolMeta } from "../plugins/tools.js";
+import { setPluginToolMeta } from "../plugins/tool-metadata.js";
 
 const mocks = vi.hoisted(() => ({
   createBundleMcpToolRuntime: vi.fn(),

--- a/src/flows/doctor-core-checks.runtime.ts
+++ b/src/flows/doctor-core-checks.runtime.ts
@@ -55,7 +55,7 @@ import {
 } from "../media-understanding/local-audio.js";
 import type { PluginMetadataSnapshotScopeRunner } from "../plugins/current-plugin-metadata-snapshot.js";
 import type { ProviderRuntimeModel } from "../plugins/provider-runtime-model.types.js";
-import { getPluginToolMeta, setPluginToolMeta } from "../plugins/tools.js";
+import { getPluginToolMeta, setPluginToolMeta } from "../plugins/tool-metadata.js";
 import type { ProviderCatalogOrder, ProviderPlugin } from "../plugins/types.js";
 import { normalizeAgentId } from "../routing/session-key.js";
 import { buildWorkspaceSkillStatus } from "../skills/discovery/status.js";

--- a/src/gateway/mcp-http.runtime.test.ts
+++ b/src/gateway/mcp-http.runtime.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import { setPluginToolMeta } from "../plugins/tools.js";
+import { setPluginToolMeta } from "../plugins/tool-metadata.js";
 import {
   McpLoopbackToolCache,
   resolveMcpLoopbackPolicyTools,

--- a/src/gateway/mcp-http.runtime.ts
+++ b/src/gateway/mcp-http.runtime.ts
@@ -5,7 +5,7 @@ import { applyEmbeddedAttemptToolsAllow } from "../agents/embedded-agent-runner/
 import { normalizeToolPolicyName } from "../agents/tool-policy.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { DirectoryCache } from "../infra/outbound/directory-cache.js";
-import { getPluginToolMeta } from "../plugins/tools.js";
+import { getPluginToolMeta } from "../plugins/tool-metadata.js";
 import type { McpLoopbackRequestContext } from "./mcp-grant-store.js";
 import {
   buildMcpToolSchema,

--- a/src/gateway/server-methods/tools-catalog.test.ts
+++ b/src/gateway/server-methods/tools-catalog.test.ts
@@ -3,9 +3,11 @@
  */
 
 import { expectDefined } from "@openclaw/normalization-core";
+import { Type } from "typebox";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ErrorCodes } from "../../../packages/gateway-protocol/src/index.js";
 import { createEmptyPluginRegistry } from "../../plugins/registry-empty.js";
+import { setPluginToolMeta } from "../../plugins/tool-metadata.js";
 import {
   ensureStandalonePluginToolRegistryLoaded,
   resolvePluginTools,
@@ -24,22 +26,9 @@ vi.mock("../../config/config.js", () => ({
   getRuntimeConfig: vi.fn(() => ({})),
 }));
 
-const pluginToolMetaState = new Map<string, { pluginId: string; optional: boolean }>();
-
 vi.mock("../../plugins/tools.js", () => ({
-  buildPluginToolMetadataKey: (pluginId: string, toolName: string) =>
-    JSON.stringify([pluginId, toolName]),
   ensureStandalonePluginToolRegistryLoaded: vi.fn(),
-  resolvePluginTools: vi.fn(() => [
-    { name: "voice_call", label: "voice_call", description: "Plugin calling tool" },
-    {
-      name: "matrix_room",
-      label: "matrix_room",
-      displaySummary: "Summarized Matrix room helper.",
-      description: "Matrix room helper\n\nACTIONS:\n- join\n- leave",
-    },
-  ]),
-  getPluginToolMeta: vi.fn((tool: { name: string }) => pluginToolMetaState.get(tool.name)),
+  resolvePluginTools: vi.fn(),
 }));
 
 const getActivePluginRegistryMock = vi.hoisted(() => vi.fn<() => unknown>(() => null));
@@ -125,9 +114,24 @@ function expectCatalogPayload(respond: ReturnType<typeof vi.fn>): CatalogPayload
 
 describe("tools.catalog handler", () => {
   beforeEach(() => {
-    pluginToolMetaState.clear();
-    pluginToolMetaState.set("voice_call", { pluginId: "voice-call", optional: true });
-    pluginToolMetaState.set("matrix_room", { pluginId: "matrix", optional: false });
+    const voiceCall = {
+      name: "voice_call",
+      label: "voice_call",
+      description: "Plugin calling tool",
+      parameters: Type.Object({}),
+      execute: async () => ({ content: [], details: {} }),
+    };
+    const matrixRoom = {
+      name: "matrix_room",
+      label: "matrix_room",
+      displaySummary: "Summarized Matrix room helper.",
+      description: "Matrix room helper\n\nACTIONS:\n- join\n- leave",
+      parameters: Type.Object({}),
+      execute: async () => ({ content: [], details: {} }),
+    };
+    setPluginToolMeta(voiceCall, { pluginId: "voice-call", optional: true });
+    setPluginToolMeta(matrixRoom, { pluginId: "matrix", optional: false });
+    vi.mocked(resolvePluginTools).mockReturnValue([voiceCall, matrixRoom]);
     getActivePluginRegistryMock.mockReturnValue(null);
     vi.mocked(ensureStandalonePluginToolRegistryLoaded).mockReturnValue(undefined);
   });

--- a/src/gateway/server-methods/tools-catalog.ts
+++ b/src/gateway/server-methods/tools-catalog.ts
@@ -15,10 +15,9 @@ import { summarizeToolDescriptionText } from "../../agents/tool-description-summ
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { PluginRegistry } from "../../plugins/registry-types.js";
 import { getActivePluginRegistry } from "../../plugins/runtime.js";
+import { buildPluginToolMetadataKey, getPluginToolMeta } from "../../plugins/tool-metadata.js";
 import {
-  buildPluginToolMetadataKey,
   ensureStandalonePluginToolRegistryLoaded,
-  getPluginToolMeta,
   resolvePluginTools,
 } from "../../plugins/tools.js";
 import { resolveAgentIdOrRespondError } from "./agent-id-shared.js";

--- a/src/gateway/server-methods/tools-effective.test.ts
+++ b/src/gateway/server-methods/tools-effective.test.ts
@@ -5,7 +5,7 @@ import { expectDefined } from "@openclaw/normalization-core";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ErrorCodes } from "../../../packages/gateway-protocol/src/index.js";
 import type { McpToolCatalog } from "../../agents/agent-bundle-mcp-types.js";
-import { setPluginToolMeta } from "../../plugins/tools.js";
+import { setPluginToolMeta } from "../../plugins/tool-metadata.js";
 import { createToolsEffectiveHandlers, testing } from "./tools-effective.js";
 
 type ToolsEffectiveDependencies = NonNullable<Parameters<typeof createToolsEffectiveHandlers>[0]>;

--- a/src/gateway/tool-resolution.ts
+++ b/src/gateway/tool-resolution.ts
@@ -50,7 +50,7 @@ import { resolveEventSessionRoutingPolicy } from "../infra/event-session-routing
 import type { ExecMode } from "../infra/exec-approvals.js";
 import { logWarn } from "../logger.js";
 import type { PluginHookChannelContext } from "../plugins/hook-types.js";
-import { getPluginToolMeta } from "../plugins/tools.js";
+import { getPluginToolMeta } from "../plugins/tool-metadata.js";
 import {
   DEFAULT_GATEWAY_HTTP_TOOL_DENY,
   GATEWAY_OWNER_ONLY_CORE_TOOLS,

--- a/src/gateway/tools-invoke-http.cron-regression.test.ts
+++ b/src/gateway/tools-invoke-http.cron-regression.test.ts
@@ -14,7 +14,6 @@ const runBeforeToolCallHook = async (args: { params: unknown }) => ({
 let cfg: Record<string, unknown> = {};
 const alwaysAuthorized = async () => ({ ok: true as const });
 const disableDefaultMemorySlot = () => false;
-const noPluginToolMeta = () => undefined;
 const noWarnLog = () => {};
 
 vi.mock("../config/config.js", () => ({
@@ -56,10 +55,6 @@ vi.mock("../plugins/config-state.js", async (importOriginal) => {
     isTestDefaultMemorySlotDisabled: disableDefaultMemorySlot,
   };
 });
-
-vi.mock("../plugins/tools.js", () => ({
-  getPluginToolMeta: noPluginToolMeta,
-}));
 
 vi.mock("../agents/openclaw-tools.js", () => {
   const tools = [

--- a/src/gateway/tools-invoke-http.test.ts
+++ b/src/gateway/tools-invoke-http.test.ts
@@ -3,6 +3,7 @@
 import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
 import type { AddressInfo } from "node:net";
 import { expectDefined } from "@openclaw/normalization-core";
+import { Type } from "typebox";
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   GATEWAY_CLIENT_MODES,
@@ -25,10 +26,6 @@ import {
 type RunBeforeToolCallHook = typeof runBeforeToolCallHookType;
 type RunBeforeToolCallHookArgs = Parameters<RunBeforeToolCallHook>[0];
 type RunBeforeToolCallHookResult = Awaited<ReturnType<RunBeforeToolCallHook>>;
-
-const pluginToolMetaState = vi.hoisted(
-  () => new Map<string, { pluginId: string; optional: boolean }>(),
-);
 
 const hookMocks = vi.hoisted(() => ({
   resolveToolLoopDetectionConfig: vi.fn(() => ({ warnAt: 3 })),
@@ -102,16 +99,11 @@ vi.mock("../plugins/config-state.js", async (importOriginal) => {
   };
 });
 
-vi.mock("../plugins/tools.js", () => ({
-  copyPluginToolMeta: () => {},
-  getPluginToolMeta: (tool: { name?: string }) =>
-    typeof tool?.name === "string" ? pluginToolMetaState.get(tool.name) : undefined,
-}));
-
 // Perf: the real tool factory instantiates many tools per request; for these HTTP
 // routing/policy tests we only need a small set of tool names.
 vi.mock("../agents/openclaw-tools.js", async () => {
   const { createTerminalTool } = await import("../agents/tools/terminal-tool.js");
+  const { setPluginToolMeta } = await import("../plugins/tool-metadata.js");
   const toolInputError = (message: string) => {
     const err = new Error(message);
     err.name = "ToolInputError";
@@ -124,6 +116,14 @@ vi.mock("../agents/openclaw-tools.js", async () => {
     return err;
   };
 
+  const pluginDoctor = {
+    name: "plugin_doctor",
+    label: "Plugin doctor",
+    description: "Fixture plugin permission flow",
+    parameters: Type.Object({}),
+    execute: async () => ({ content: [], details: {}, ok: true, permissionFlow: true }),
+  };
+  setPluginToolMeta(pluginDoctor, { pluginId: "test-plugin", optional: true });
   const tools = [
     {
       name: "session_status",
@@ -184,11 +184,7 @@ vi.mock("../agents/openclaw-tools.js", async () => {
       parameters: { type: "object", properties: {} },
       execute: async () => ({ ok: true, result: "browser" }),
     },
-    {
-      name: "plugin_doctor",
-      parameters: { type: "object", properties: {} },
-      execute: async () => ({ ok: true, permissionFlow: true }),
-    },
+    pluginDoctor,
     {
       name: "write_scoped_test",
       parameters: { type: "object", properties: {} },
@@ -329,9 +325,7 @@ beforeEach(() => {
   pluginHttpHandlers = [];
   cfg = {};
   lastCreateOpenClawToolsContext = undefined;
-  pluginToolMetaState.clear();
   sessionEntries.clear();
-  pluginToolMetaState.set("plugin_doctor", { pluginId: "test-plugin", optional: true });
   hookMocks.resolveToolLoopDetectionConfig.mockClear();
   hookMocks.resolveToolLoopDetectionConfig.mockImplementation(() => ({ warnAt: 3 }));
   hookMocks.runBeforeToolCallHook.mockClear();

--- a/src/gateway/tools-invoke-shared.ts
+++ b/src/gateway/tools-invoke-shared.ts
@@ -22,7 +22,7 @@ import { formatErrorMessage } from "../infra/errors.js";
 import { logWarn } from "../logger.js";
 import { isTestDefaultMemorySlotDisabled } from "../plugins/config-state.js";
 import { defaultSlotIdForKey } from "../plugins/slots.js";
-import { getPluginToolMeta } from "../plugins/tools.js";
+import { getPluginToolMeta } from "../plugins/tool-metadata.js";
 import {
   AGENT_HARNESS_SESSION_KEY_RESERVED_MESSAGE,
   isAgentHarnessSessionKey,

--- a/src/plugin-sdk/agent-harness-runtime.ts
+++ b/src/plugin-sdk/agent-harness-runtime.ts
@@ -289,7 +289,7 @@ export {
   applyEmbeddedAttemptToolsAllow,
   resolveEmbeddedAttemptToolConstructionPlan,
 } from "../agents/embedded-agent-runner/run/attempt-tool-construction-plan.js";
-export { getPluginToolMeta, getPluginToolSideEffectOwnerKey } from "../plugins/tools.js";
+export { getPluginToolMeta, getPluginToolSideEffectOwnerKey } from "../plugins/tool-metadata.js";
 export {
   attachModelProviderRequestTransport,
   getModelProviderRequestTransport,

--- a/src/plugin-sdk/codex-mcp-projection.ts
+++ b/src/plugin-sdk/codex-mcp-projection.ts
@@ -13,6 +13,7 @@ import type {
   CronCreatorToolAllowlistEntry,
   CronToolsAllowCaptureRef,
 } from "../agents/tools/cron-tool.types.js";
+import { getPluginToolMeta } from "../plugins/tool-metadata.js";
 
 export { pinExecToolTarget };
 export type CodexScheduledToolProjectionFactory = AgentHarnessScheduledToolProjectionFactory;
@@ -54,7 +55,7 @@ export async function captureFinalCodexCronCreatorToolAllowlist(
   captureRef: CronToolsAllowCaptureRef,
   tools: readonly AnyAgentTool[],
 ) {
-  const [{ captureFinalEffectiveCronCreatorToolAllowlist: capture }, { getPluginToolMeta }] =
-    await Promise.all([import("../agents/tools/cron-tool.js"), import("../plugins/tools.js")]);
+  const { captureFinalEffectiveCronCreatorToolAllowlist: capture } =
+    await import("../agents/tools/cron-tool.js");
   return capture(target, captureRef, tools, (tool) => getPluginToolMeta(tool));
 }

--- a/src/plugin-sdk/test-helpers/agents/openclaw-owned-tool-runtime-contract.ts
+++ b/src/plugin-sdk/test-helpers/agents/openclaw-owned-tool-runtime-contract.ts
@@ -19,7 +19,7 @@ import {
   resetPluginRuntimeStateForTest,
   setActivePluginRegistry,
 } from "../../../plugins/runtime.js";
-import { setPluginToolMeta } from "../../../plugins/tools.js";
+import { setPluginToolMeta } from "../../../plugins/tool-metadata.js";
 
 export function textToolResult(
   text: string,

--- a/src/plugins/tool-metadata.ts
+++ b/src/plugins/tool-metadata.ts
@@ -1,0 +1,68 @@
+/** Dependency-light ownership metadata for plugin-contributed agent tools. */
+import type { McpCodexToolAnnotations } from "../agents/mcp-codex-tool-approval.js";
+import { normalizeToolPolicyName } from "../agents/tool-policy-shared.js";
+import type { AnyAgentTool } from "../agents/tools/common.js";
+import type { McpCodexToolApprovalMode } from "../config/types.mcp.js";
+import type { PluginManifestRecord } from "./manifest-registry.js";
+
+/** MCP bridge metadata attached to plugin tools surfaced through agent tool lists. */
+export type PluginToolMcpMeta = {
+  serverName: string;
+  safeServerName: string;
+  toolName: string;
+  operation: "tool" | "resources_list" | "resources_read" | "prompts_list" | "prompts_get";
+  deniedBySession?: true;
+  codexApproval?: {
+    mode: McpCodexToolApprovalMode;
+    annotations?: McpCodexToolAnnotations;
+  };
+  node?: {
+    id: string;
+    displayName?: string;
+  };
+};
+
+/** Runtime metadata used to trace an agent tool back to its owning plugin registration. */
+type PluginToolMeta = {
+  pluginId: string;
+  kind?: PluginManifestRecord["kind"];
+  optional: boolean;
+  replaySafe?: boolean;
+  sideEffecting?: boolean;
+  trustedLocalMedia?: boolean;
+  mcp?: PluginToolMcpMeta;
+};
+
+const pluginToolMeta = new WeakMap<AnyAgentTool, PluginToolMeta>();
+
+/** Attaches plugin ownership metadata to a concrete agent tool instance. */
+export function setPluginToolMeta(tool: AnyAgentTool, meta: PluginToolMeta): void {
+  pluginToolMeta.set(tool, meta);
+}
+
+/** Reads plugin ownership metadata for a concrete agent tool instance. */
+export function getPluginToolMeta(tool: AnyAgentTool): PluginToolMeta | undefined {
+  return pluginToolMeta.get(tool);
+}
+
+/** Copies plugin ownership metadata when wrappers replace a tool object. */
+export function copyPluginToolMeta(source: AnyAgentTool, target: AnyAgentTool): void {
+  const meta = pluginToolMeta.get(source);
+  if (meta) {
+    pluginToolMeta.set(target, meta);
+  }
+}
+
+/** Builds a collision-proof key for plugin-owned tool metadata lookups. */
+export function buildPluginToolMetadataKey(pluginId: string, toolName: string): string {
+  return JSON.stringify([pluginId, toolName]);
+}
+
+/** Binds a side-effect declaration to the concrete plugin tool that owns it. */
+export function getPluginToolSideEffectOwnerKey(tool: AnyAgentTool): string | undefined {
+  const meta = getPluginToolMeta(tool);
+  const toolName = normalizeToolPolicyName(tool.name);
+  return meta?.sideEffecting && toolName
+    ? buildPluginToolMetadataKey(meta.pluginId, toolName)
+    : undefined;
+}

--- a/src/plugins/tools.optional.test.ts
+++ b/src/plugins/tools.optional.test.ts
@@ -55,8 +55,8 @@ vi.mock("./runtime/load-context.resolve.js", async (importOriginal) => {
 
 let resolvePluginTools: typeof import("./tools.js").resolvePluginTools;
 let ensureStandalonePluginToolRegistryLoaded: typeof import("./tools.js").ensureStandalonePluginToolRegistryLoaded;
-let buildPluginToolMetadataKey: typeof import("./tools.js").buildPluginToolMetadataKey;
-let getPluginToolMeta: typeof import("./tools.js").getPluginToolMeta;
+let buildPluginToolMetadataKey: typeof import("./tool-metadata.js").buildPluginToolMetadataKey;
+let getPluginToolMeta: typeof import("./tool-metadata.js").getPluginToolMeta;
 let resetPluginToolDescriptorCacheForTest: typeof import("./tools.test-fixtures.js").resetPluginToolDescriptorCacheForTest;
 let getActivePluginRegistry: typeof import("./runtime.js").getActivePluginRegistry;
 let resetPluginRuntimeStateForTest: typeof import("./runtime.js").resetPluginRuntimeStateForTest;
@@ -541,12 +541,8 @@ function expectConflictingCoreNameResolution(params: {
 
 describe("resolvePluginTools optional tools", () => {
   beforeAll(async () => {
-    ({
-      buildPluginToolMetadataKey,
-      ensureStandalonePluginToolRegistryLoaded,
-      getPluginToolMeta,
-      resolvePluginTools,
-    } = await import("./tools.js"));
+    ({ ensureStandalonePluginToolRegistryLoaded, resolvePluginTools } = await import("./tools.js"));
+    ({ buildPluginToolMetadataKey, getPluginToolMeta } = await import("./tool-metadata.js"));
     ({ getActivePluginRegistry, resetPluginRuntimeStateForTest, setActivePluginRegistry } =
       await import("./runtime.js"));
     ({ getPluginRuntimeGatewayRequestScope, withPluginRuntimeGatewayRequestScope } =
@@ -3408,7 +3404,7 @@ describe("resolvePluginTools optional tools", () => {
 
 describe("buildPluginToolMetadataKey", () => {
   beforeAll(async () => {
-    ({ buildPluginToolMetadataKey } = await import("./tools.js"));
+    ({ buildPluginToolMetadataKey } = await import("./tool-metadata.js"));
   });
 
   it("does not collide when ids or names contain separator-like characters", () => {

--- a/src/plugins/tools.ts
+++ b/src/plugins/tools.ts
@@ -5,14 +5,12 @@ import {
   uniqueStrings,
 } from "@openclaw/normalization-core/string-normalization";
 import { compileGlobPatterns, matchesAnyGlobPattern } from "../agents/glob-pattern.js";
-import type { McpCodexToolAnnotations } from "../agents/mcp-codex-tool-approval.js";
 import {
   DEFAULT_PLUGIN_TOOLS_ALLOWLIST_ENTRY,
   normalizeToolPolicyName,
 } from "../agents/tool-policy.js";
 import type { AnyAgentTool } from "../agents/tools/common.js";
 import { normalizeConversationReadInvocationOrigin } from "../channels/plugins/conversation-read-origin.js";
-import type { McpCodexToolApprovalMode } from "../config/types.mcp.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import {
   getLoadedRuntimePluginRegistry,
@@ -52,35 +50,8 @@ import {
   writeCachedPluginToolDescriptors,
 } from "./tool-descriptor-cache.js";
 import { isPluginToolAllowed } from "./tool-grant-allowlist.js";
+import { copyPluginToolMeta, setPluginToolMeta } from "./tool-metadata.js";
 import type { OpenClawPluginToolContext } from "./types.js";
-
-/** MCP bridge metadata attached to plugin tools surfaced through agent tool lists. */
-export type PluginToolMcpMeta = {
-  serverName: string;
-  safeServerName: string;
-  toolName: string;
-  operation: "tool" | "resources_list" | "resources_read" | "prompts_list" | "prompts_get";
-  deniedBySession?: true;
-  codexApproval?: {
-    mode: McpCodexToolApprovalMode;
-    annotations?: McpCodexToolAnnotations;
-  };
-  node?: {
-    id: string;
-    displayName?: string;
-  };
-};
-
-/** Runtime metadata used to trace an agent tool back to its owning plugin registration. */
-type PluginToolMeta = {
-  pluginId: string;
-  kind?: PluginManifestRecord["kind"];
-  optional: boolean;
-  replaySafe?: boolean;
-  sideEffecting?: boolean;
-  trustedLocalMedia?: boolean;
-  mcp?: PluginToolMcpMeta;
-};
 
 type PluginToolFactoryTimingResult = "array" | "error" | "null" | "single";
 
@@ -101,28 +72,9 @@ const PLUGIN_TOOL_FACTORY_WARN_TOTAL_MS = 5_000;
 const PLUGIN_TOOL_FACTORY_WARN_FACTORY_MS = 1_000;
 const PLUGIN_TOOL_FACTORY_SUMMARY_LIMIT = 20;
 
-const pluginToolMeta = new WeakMap<AnyAgentTool, PluginToolMeta>();
 const scopedPluginTools = new WeakMap<AnyAgentTool, Map<string, AnyAgentTool>>();
 const pluginRegistryScopeIds = new WeakMap<PluginRegistry, number>();
 let nextPluginRegistryScopeId = 1;
-
-/** Attaches plugin ownership metadata to a concrete agent tool instance. */
-export function setPluginToolMeta(tool: AnyAgentTool, meta: PluginToolMeta): void {
-  pluginToolMeta.set(tool, meta);
-}
-
-/** Reads plugin ownership metadata for a concrete agent tool instance. */
-export function getPluginToolMeta(tool: AnyAgentTool): PluginToolMeta | undefined {
-  return pluginToolMeta.get(tool);
-}
-
-/** Copies plugin ownership metadata when wrappers replace a tool object. */
-export function copyPluginToolMeta(source: AnyAgentTool, target: AnyAgentTool): void {
-  const meta = pluginToolMeta.get(source);
-  if (meta) {
-    pluginToolMeta.set(target, meta);
-  }
-}
 
 function pluginToolScopeKey(
   entry: PluginToolRegistration,
@@ -290,22 +242,6 @@ function blocksHostRestrictedConversationReadRegistration(params: {
       ctx: params.ctx,
     })
   );
-}
-
-/**
- * Builds a collision-proof key for plugin-owned tool metadata lookups.
- */
-export function buildPluginToolMetadataKey(pluginId: string, toolName: string): string {
-  return JSON.stringify([pluginId, toolName]);
-}
-
-/** Binds a side-effect declaration to the concrete plugin tool that owns it. */
-export function getPluginToolSideEffectOwnerKey(tool: AnyAgentTool): string | undefined {
-  const meta = getPluginToolMeta(tool);
-  const toolName = normalizeToolPolicyName(tool.name);
-  return meta?.sideEffecting && toolName
-    ? buildPluginToolMetadataKey(meta.pluginId, toolName)
-    : undefined;
 }
 
 function normalizeAllowlist(list?: string[]) {
@@ -1553,7 +1489,7 @@ export function resolvePluginTools(params: {
         manifestPlugin,
         toolName: tool.name,
       });
-      pluginToolMeta.set(tool, {
+      setPluginToolMeta(tool, {
         pluginId: entry.pluginId,
         ...(manifestPlugin?.kind ? { kind: manifestPlugin.kind } : {}),
         optional,

--- a/src/skills/runtime/tool-dispatch.ts
+++ b/src/skills/runtime/tool-dispatch.ts
@@ -26,7 +26,7 @@ import {
 import type { SessionEntry } from "../../config/sessions.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { logVerbose } from "../../globals.js";
-import { getPluginToolMeta } from "../../plugins/tools.js";
+import { getPluginToolMeta } from "../../plugins/tool-metadata.js";
 import { GATEWAY_OWNER_ONLY_CORE_TOOLS } from "../../security/dangerous-tools.js";
 import { resolveGatewayMessageChannel } from "../../utils/message-channel.js";
 import type { SkillCommandSpec } from "../types.js";

--- a/test/e2e/qa-lab/runtime/agent-bundle-mcp-tools-docker-client.ts
+++ b/test/e2e/qa-lab/runtime/agent-bundle-mcp-tools-docker-client.ts
@@ -14,7 +14,7 @@ import { resolveConversationCapabilityProfile } from "../../../../dist/agents/co
 import { applyFinalEffectiveToolPolicy } from "../../../../dist/agents/embedded-agent-runner/effective-tool-policy.js";
 import { splitSdkTools } from "../../../../dist/agents/embedded-agent-runner/tool-split.js";
 import type { OpenClawConfig } from "../../../../dist/config/types.openclaw.js";
-import { getPluginToolMeta } from "../../../../dist/plugins/tools.js";
+import { getPluginToolMeta } from "../../../../dist/plugins/tool-metadata.js";
 import { createE2eStateDir } from "../../../../scripts/e2e/lib/temp-state-dir.ts";
 
 const require = createRequire(import.meta.url);

--- a/test/vitest/vitest.cli-process-paths.mjs
+++ b/test/vitest/vitest.cli-process-paths.mjs
@@ -7,6 +7,7 @@ export const cliProcessTestFiles = [
   "src/cli/gateway-cli/shutdown-hard-exit.process.test.ts",
   "src/cli/help-exit.process.test.ts",
   "src/cli/hooks-cli.process.test.ts",
+  "src/cli/mcp-cli.import-boundary.test.ts",
   "src/cli/gateway-cli/run-loop.direct-stop-active-work.process.test.ts",
 ];
 

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -462,7 +462,7 @@ function buildDockerE2eHarnessEntries(): Record<string, string> {
     "infra/errors": "src/infra/errors.ts",
     "infra/ws": "src/infra/ws.ts",
     "plugin-sdk/provider-onboard": "src/plugin-sdk/provider-onboard.ts",
-    "plugins/tools": "src/plugins/tools.ts",
+    "plugins/tool-metadata": "src/plugins/tool-metadata.ts",
     "normalization-core/string-coerce": "packages/normalization-core/src/string-coerce.ts",
   };
 }


### PR DESCRIPTION
Related: https://github.com/openclaw/openclaw/pull/131503 — avoid repeated plugin preparation at startup.

## What Problem This Solves

MCP command registration and catalog inspection still imported the plugin tool-construction runtime solely to read or attach tool metadata. The confirmed edge was `mcp-cli.ts` → `agent-bundle-mcp-materialize.ts` → `plugins/tools.ts`, where metadata accessors shared a module with loader imports. This is the separately scoped metadata-owner follow-up left out of the startup-preparation change above.

## Why This Change Was Made

Move the existing metadata types, one WeakMap, and five helpers into a dependency-light canonical owner. Fresh/cached tool producers, wrapper copying, and metadata readers use that same owner. Plugin loading, registry/scope caches, optional grants, replay safety, local-media trust, side-effect policy, and approval decisions remain with their existing owners and retain their implementations.

Keep the shipped agent-harness SDK exports, retargeted directly to the new owner. Replace the old internal build-harness entry and migrate its MCP consumer; do not retain an unneeded compatibility barrel. Tests that previously used name-indexed metadata or a second WeakMap now tag concrete fixture tools through the actual owner, and clone-boundary coverage asserts preservation of the exact full metadata record. Extend the existing compiled-plugin singleton smoke to check that the public SDK reads the materializer's exact metadata record, after—not before—its existing cold-native loader assertions.

## User Impact

No tool, permission, approval, configuration, or default changes. MCP metadata access no longer requires the plugin tool-construction module. The entire MCP CLI is **not** claimed to be loader-free: an independent transport/auth/provider import route remains a separate follow-up. This change does not claim an isolated startup-speed improvement or a fix for previously observed 30-second process timeouts.

Production LOC: **+112/-101 (net +11)**. Tests/support: **+319/-169 (net +150)**. Build tooling: **+1/-1 (net 0)**. The small production increase is module/type-import scaffolding and split imports for the new ownership boundary, not a second store or new runtime policy.

## Evidence

The branch was refreshed onto `e7f6aaa2c3bb3651e13d79aa1e6989718fedd18b` after GitHub reported conflicts. Current head is `30c5d9829c20c37e8c181acb73c0c359fe8eb980`, tree `cc347a81d3b3091004bd5488f3072b59b575aa40`. The latest resolution preserves main's prepared tool-policy matcher and narrow provider-schema mock, while removing the obsolete metadata mock so the real normalizer/copier remain active. The earlier shared result renderer is also preserved. The metadata owner, helper/type bodies, and import-denial/materialization/native assertion sources are unchanged. Fresh review of the resolved full patch returned scoped-clean with no actionable P0 findings.

[Current-head CI run 33294630435](https://github.com/openclaw/openclaw/actions/runs/33294630435) passed, including the required `openclaw/ci-gate` from GitHub Actions on this exact head. The preceding head passed [CI run 33288039766](https://github.com/openclaw/openclaw/actions/runs/33288039766). The local/build/native evidence below belongs to the original pre-rebase candidate and is not represented as execution proof for this latest tree; current-head CI remains required before merge.

- A real fresh Node/TSX import-denial regression failed on original production source at the materializer-to-`plugins/tools` edge, then passed on the restored candidate. It performs actual CLI registration/reload, projects a nonempty catalog, and checks inventory-only execution rejection. A separate metadata-leaf case forbids tool construction, loader imports, and channel serving. Both retain their 30-second child bounds; neither mocks the loader.
- Initial metadata/materialization/runtime-plan/installed-bundle selection: **124 passed**, including a real installed bundle and stdio tool. Actual loader suite: **183 passed**, separately from mocked resolver tests.
- Controlled original-source/candidate plugin-pair replay: **111 passed on each**, in the same optional-tools-before-runtime-registry order with unchanged 120-second limits. Earlier two timeouts and a stopped broader run are retained as prior failures; the recovery does not establish their cause or a timeout fix.
- Final hook/bridge selection: **176 before-call E2E**, **153 Codex dynamic-tool**, and **94 Copilot bridge** tests passed (**423 total**), after the standard private E2E prerequisite build.
- Normal build and all selected changed checks passed, including SDK exports/declarations/surface, core/UI/extension/script/test typechecks, lint, and the runtime import-cycle guard. No ineffective dynamic-import diagnostic was observed.
- The existing compiled MCP harness passed against the normal local build with real stdio execution, metadata lookup across emitted entries, MCP App preview, final policy filtering, and custom-tools projection. Coding/messaging counts were 3/3; minimal/deny counts were 0/0. This was local built-output proof, not Docker or an installed npm tarball.

Commands used for the principal build/check and owner/bridge proofs:

```bash
pnpm build
```

```bash
node scripts/check-changed.mjs --base HEAD
```

```bash
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/plugins/tools.optional.test.ts src/plugins/loader.runtime-registry.test.ts
```

```bash
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/agents/agent-tools.before-tool-call.e2e.test.ts src/agents/agent-tools.before-tool-call.integration.e2e.test.ts extensions/codex/src/app-server/dynamic-tools.test.ts extensions/copilot/src/tool-bridge.test.ts
```

Fresh pre-commit Codex autoreview returned **scoped-clean**, with no actionable P0 findings.

Clean Linux native proof also passed on [Blacksmith Testbox run 33281891979](https://github.com/openclaw/openclaw/actions/runs/33281891979), lease `tbx_01m17yw2gkwa4scmt39748qjf3`: exact base `b3362142c72bcde6dae141e649826de10da0c000` and source tree `9cf9ed7549b680a792ff117290e9a61ab581d2ea` were verified before execution and remained unchanged. Node **24.19.0**, pnpm **12.0.0**, frozen install, normal build, targeted script/tooling checks, and the existing native singleton smoke including the new SDK metadata-record assertion all passed. The command used isolated environment/HOME/state paths on a prepared CI machine; it was not a secretless-machine claim. The one-shot lease was stopped and its completed state verified. Its backing Actions lifecycle may show cancellation during Testbox cleanup; the command exit, exact source/success markers, and completed lease are the proof, not a PR-head CI gate.

The earlier broad native probes did not complete inside their task-local 30-second observation bounds. They remain failed observations; the canonical native smoke has no such per-command deadline, and no limit was changed. One pre-warmed Testbox attempt expired during local source preparation before any build/test ran; the supported one-shot flow corrected allocation ordering without extending a deadline. Timings were non-exclusive and do not isolate this edge's cost. No loader mock, test-mode flag, schema, or dependency workaround was added. Exact PR-head CI remains required before merge.

AI-assisted implementation and independent review.
