### PR TITLE
fix(gateway): stop heap growth across in-process restarts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Gateway restart memory: release retired plugin registries and their captured cache generations during shutdown and replacement, preventing heap growth across repeated in-process restarts. (#132914)
 - **Browser extension relay:** route Runtime binding callbacks only to registered clients and preserve shared bindings during client cleanup, preventing raw callback payloads from reaching unrelated Playwright sessions.
 - **Control UI media playback:** restore inline audio and video rendition loading so readiness checks reach the Gateway instead of silently falling back to download cards. (#132832)
 - **Grok web search startup:** avoid loading the full agent runtime before the first search, while preserving agent-scoped credentials and OAuth fallback behavior.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,7 +70,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- Gateway restart memory: release retired plugin registries and their captured cache generations during shutdown and replacement, preventing heap growth across repeated in-process restarts. (#132914)
 - **Browser extension relay:** route Runtime binding callbacks only to registered clients and preserve shared bindings during client cleanup, preventing raw callback payloads from reaching unrelated Playwright sessions.
 - **Control UI media playback:** restore inline audio and video rendition loading so readiness checks reach the Gateway instead of silently falling back to download cards. (#132832)
 - **Grok web search startup:** avoid loading the full agent runtime before the first search, while preserving agent-scoped credentials and OAuth fallback behavior.

--- a/src/plugins/loader-cache-state.ts
+++ b/src/plugins/loader-cache-state.ts
@@ -42,6 +42,10 @@ export class PluginLoaderCacheState<T> {
     this.#registryCache.set(cacheKey, state);
   }
 
+  deleteValue(state: T): void {
+    this.#registryCache.deleteValue(state);
+  }
+
   isLoadInFlight(cacheKey: string): boolean {
     return this.#inFlightLoads.has(cacheKey);
   }

--- a/src/plugins/loader-cache.ts
+++ b/src/plugins/loader-cache.ts
@@ -1,26 +1,7 @@
-import { PluginLoaderCacheState } from "./loader-cache-state.js";
 import { resolvePluginLoadCacheContext } from "./loader-load-context.js";
 import type { PluginLoadOptions } from "./loader-types.js";
 import { clearPluginRuntimeArtifactResolutionMemo } from "./plugin-runtime-artifact-resolution.js";
-import { isPluginRegistryRetired } from "./registry-lifecycle.js";
-import type { PluginRegistry } from "./registry-types.js";
-
-const MAX_PLUGIN_REGISTRY_CACHE_ENTRIES = 128;
-
-export const pluginLoaderCacheState = new PluginLoaderCacheState<PluginRegistry>(
-  MAX_PLUGIN_REGISTRY_CACHE_ENTRIES,
-);
-
-export function setCachedPluginRegistry(cacheKey: string, registry: PluginRegistry): void {
-  pluginLoaderCacheState.set(cacheKey, registry);
-}
-
-export function getReusableCachedPluginRegistry(cacheKey: string): PluginRegistry | undefined {
-  const registry = pluginLoaderCacheState.get(cacheKey);
-  // Both replacement and terminal cleanup retire registrations. Never reactivate
-  // their closed resources from a cache hit; the loader must register fresh ones.
-  return registry && !isPluginRegistryRetired(registry) ? registry : undefined;
-}
+import { pluginLoaderCacheState } from "./registry-lifecycle.js";
 
 /** Registry reuse is off for explicit opt-outs and for raw env-substituted config loads. */
 export function isPluginRegistryCacheEnabled(options: PluginLoadOptions): boolean {

--- a/src/plugins/loader-cli-registry.ts
+++ b/src/plugins/loader-cli-registry.ts
@@ -11,11 +11,7 @@ import {
 } from "./config-state.js";
 import { isPluginEnabledByDefaultForPlatform } from "./default-enablement.js";
 import { shouldRejectHardlinkedPluginFiles } from "./hardlink-policy.js";
-import {
-  getReusableCachedPluginRegistry,
-  isPluginRegistryCacheEnabled,
-  setCachedPluginRegistry,
-} from "./loader-cache.js";
+import { isPluginRegistryCacheEnabled } from "./loader-cache.js";
 import { resolvePluginLoadDiscovery } from "./loader-discovery.js";
 import { resolvePluginLoadCacheContext } from "./loader-load-context.js";
 import {
@@ -45,6 +41,7 @@ import type { PluginLoadOptions } from "./loader-types.js";
 import { withProfile } from "./plugin-load-profile.js";
 import { normalizePluginPolicyId } from "./plugin-policy-id.js";
 import { createPluginIdScopeSet } from "./plugin-scope.js";
+import { pluginLoaderCacheState } from "./registry-lifecycle.js";
 import { createPluginRegistry, type PluginRecord, type PluginRegistry } from "./registry.js";
 import { hasKind, kindsEqual } from "./slots.js";
 import type { OpenClawPluginModule } from "./types.js";
@@ -61,7 +58,7 @@ export async function loadOpenClawPluginCliRegistry(
   const cacheKey = `cli-metadata::${context.cacheKey}`;
   const cacheEnabled = isPluginRegistryCacheEnabled(options);
   if (cacheEnabled) {
-    const cached = getReusableCachedPluginRegistry(cacheKey);
+    const cached = pluginLoaderCacheState.get(cacheKey);
     if (cached) {
       return cached;
     }
@@ -366,7 +363,7 @@ export async function loadOpenClawPluginCliRegistry(
     }
   }
   if (cacheEnabled) {
-    setCachedPluginRegistry(cacheKey, registry);
+    pluginLoaderCacheState.set(cacheKey, registry);
   }
   return registry;
 }

--- a/src/plugins/loader-discovery.ts
+++ b/src/plugins/loader-discovery.ts
@@ -3,7 +3,6 @@ import {
   type PluginCandidate,
   type PluginDiscoveryResult,
 } from "./discovery.js";
-import { pluginLoaderCacheState } from "./loader-cache.js";
 import type { PluginLoadCacheContext } from "./loader-load-context.js";
 import { buildProvenanceIndex, warnWhenAllowlistIsOpen } from "./loader-provenance.js";
 import { createPluginCandidatesFromManifestRegistry, pushDiagnostics } from "./loader-shared.js";
@@ -14,6 +13,7 @@ import {
   type PluginManifestRegistry,
 } from "./manifest-registry.js";
 import type { PluginDiagnostic } from "./manifest-types.js";
+import { pluginLoaderCacheState } from "./registry-lifecycle.js";
 import type { PluginLogger } from "./types.js";
 
 type ResolvedPluginLoadDiscovery = {

--- a/src/plugins/loader-runtime-load.ts
+++ b/src/plugins/loader-runtime-load.ts
@@ -6,12 +6,7 @@ import {
 } from "./candidate-install-owner.js";
 import { resolveEffectivePluginActivationState } from "./config-state.js";
 import { isPluginEnabledByDefaultForPlatform } from "./default-enablement.js";
-import {
-  getReusableCachedPluginRegistry,
-  isPluginRegistryCacheEnabled,
-  pluginLoaderCacheState,
-  setCachedPluginRegistry,
-} from "./loader-cache.js";
+import { isPluginRegistryCacheEnabled } from "./loader-cache.js";
 import { resolvePluginLoadDiscovery } from "./loader-discovery.js";
 import {
   resolvePluginLoadCacheContext,
@@ -33,6 +28,7 @@ import {
 import type { PluginLoadOptions } from "./loader-types.js";
 import { createPluginIdScopeSet, normalizePluginIdScope } from "./plugin-scope.js";
 import { createEmptyPluginRegistry } from "./registry-empty.js";
+import { pluginLoaderCacheState } from "./registry-lifecycle.js";
 import { getPluginRegistryRuntime } from "./registry-runtime-binding.js";
 import { createPluginRegistry, type PluginRegistry } from "./registry.js";
 import { getActivePluginRegistry } from "./runtime.js";
@@ -102,7 +98,7 @@ function loadOpenClawPluginsInternal(
   const onlyPluginIdSet = createPluginIdScopeSet(context.onlyPluginIds);
   const cacheEnabled = isPluginRegistryCacheEnabled(options);
   if (cacheEnabled) {
-    const cached = getReusableCachedPluginRegistry(context.cacheKey);
+    const cached = pluginLoaderCacheState.get(context.cacheKey);
     if (cached) {
       maybeThrowOnPluginLoadError(cached, options.throwOnLoadError);
       if (context.shouldActivate) {
@@ -296,7 +292,7 @@ function loadOpenClawPluginsInternal(
     // Publish only complete registries: failed activation restores the prior runtime selection,
     // then the catch below can discard this builder without poisoning a reusable cache value.
     if (cacheEnabled) {
-      setCachedPluginRegistry(context.cacheKey, registry);
+      pluginLoaderCacheState.set(context.cacheKey, registry);
     }
     return registry;
   } catch (error) {

--- a/src/plugins/loader.runtime-registry.test.ts
+++ b/src/plugins/loader.runtime-registry.test.ts
@@ -37,11 +37,15 @@ import {
 } from "./loader.test-fixtures.js";
 import { buildMemoryPromptSection, registerMemoryCapability } from "./memory-state.js";
 import { clearPluginMetadataLifecycleCaches } from "./plugin-metadata-lifecycle.js";
+import { pluginLoaderCacheState } from "./registry-lifecycle.js";
 import { getPluginRegistryRuntime } from "./registry-runtime-binding.js";
 import { createEmptyPluginRegistry } from "./registry.js";
 import {
+  captureActivePluginRegistrySnapshot,
   clearActivePluginRegistry,
+  commitStagedPluginRegistry,
   getActivePluginRegistry,
+  rollbackStagedPluginRegistry,
   setActivePluginRegistry,
   stageActivePluginRegistry,
 } from "./runtime.js";
@@ -548,6 +552,41 @@ describe("resolveRuntimePluginRegistry", () => {
 });
 
 describe("clearPluginRegistryLoadCache", () => {
+  it.each(["commit", "rollback"])(
+    "releases only the retired cache aliases after staged %s",
+    (action) => {
+      const original = createEmptyPluginRegistry();
+      const candidate = createEmptyPluginRegistry();
+      pluginLoaderCacheState.set("original", original);
+      pluginLoaderCacheState.set("original-alias", original);
+      pluginLoaderCacheState.set("candidate", candidate);
+      pluginLoaderCacheState.set("candidate-alias", candidate);
+      setActivePluginRegistry(original, "original");
+      const snapshot = captureActivePluginRegistrySnapshot();
+
+      stageActivePluginRegistry(candidate, "candidate", "default");
+      expect(pluginLoaderCacheState.get("original") === original).toBe(true);
+      expect(pluginLoaderCacheState.get("candidate") === candidate).toBe(true);
+      // Reusing a key must not let the old value's retirement evict its successor.
+      pluginLoaderCacheState.set("reused-key", original);
+      pluginLoaderCacheState.set("reused-key", candidate);
+
+      if (action === "commit") {
+        commitStagedPluginRegistry(original, candidate);
+      } else {
+        rollbackStagedPluginRegistry(snapshot);
+      }
+
+      const committed = action === "commit";
+      for (const key of ["original", "original-alias"]) {
+        expect(pluginLoaderCacheState.get(key) === original).toBe(!committed);
+      }
+      for (const key of ["candidate", "candidate-alias", "reused-key"]) {
+        expect(pluginLoaderCacheState.get(key) === candidate).toBe(committed);
+      }
+    },
+  );
+
   it.each(["clear", "replacement"])(
     "rebuilds plugin registrations after runtime %s with unchanged load options",
     async (retirement) => {
@@ -592,6 +631,7 @@ describe("clearPluginRegistryLoadCache", () => {
         return await tool.execute("probe", {});
       };
       const original = loadOpenClawPlugins(options);
+      const originalKey = resolvePluginLoadCacheContext(options).cacheKey;
       expect(loadOpenClawPlugins(options)).toBe(original);
       expect(await read(original)).toMatchObject({ content: [{ text: "live" }] });
 
@@ -606,8 +646,12 @@ describe("clearPluginRegistryLoadCache", () => {
           expect(await read(original)).toMatchObject({ content: [{ text: "closed" }] });
         });
         expect(loadOpenClawPlugins(replacementOptions)).toBe(replacement);
+        expect(
+          pluginLoaderCacheState.get(resolvePluginLoadCacheContext(replacementOptions).cacheKey),
+        ).toBe(replacement);
       }
 
+      expect(pluginLoaderCacheState.get(originalKey) === undefined).toBe(true);
       expect(await read(original)).toMatchObject({ content: [{ text: "closed" }] });
       const reloaded = loadOpenClawPlugins(options);
       expect(await read(reloaded)).toMatchObject({ content: [{ text: "live" }] });

--- a/src/plugins/loader.test-fixtures.ts
+++ b/src/plugins/loader.test-fixtures.ts
@@ -4,8 +4,8 @@ import os from "node:os";
 import path from "node:path";
 import { resetDiagnosticEventsForTest } from "../infra/diagnostic-events.js";
 import { withEnv } from "../test-utils/env.js";
-import { pluginLoaderCacheState } from "./loader-cache.js";
 import { loadOpenClawPlugins } from "./loader.js";
+import { pluginLoaderCacheState } from "./registry-lifecycle.js";
 import { resetPluginRuntimeStateForTest } from "./runtime.js";
 
 export { loadOpenClawPlugins };

--- a/src/plugins/native-module-require.test.ts
+++ b/src/plugins/native-module-require.test.ts
@@ -234,6 +234,45 @@ describe("tryNativeRequireJavaScriptModule", () => {
       moduleExport: { marker: "after" },
     });
   });
+
+  it("releases retired native module graphs, including local cycles", () => {
+    const dir = tempDirs.make("openclaw-native-retirement-");
+    const modulePath = path.join(dir, "plugin.cjs");
+    const probePath = path.join(dir, "probe.mjs");
+    fs.writeFileSync(modulePath, 'exports.helper = require("./helper.cjs");\n');
+    fs.writeFileSync(path.join(dir, "helper.cjs"), 'exports.entry = require("./plugin.cjs");\n');
+    const ownerUrl = pathToFileURL(path.resolve("src/plugins/native-module-require.ts")).href;
+    fs.writeFileSync(
+      probePath,
+      `import assert from "node:assert/strict";
+import { setImmediate } from "node:timers/promises";
+import { clearPluginModuleRequireCache, tryNativeRequireJavaScriptModule } from ${JSON.stringify(ownerUrl)};
+const modulePath = ${JSON.stringify(modulePath)};
+function loadAndRetire() {
+  const result = tryNativeRequireJavaScriptModule(modulePath, { allowWindows: true });
+  assert.equal(result.ok, true);
+  assert.equal(result.moduleExport.helper.entry, result.moduleExport);
+  const ref = new WeakRef(result.moduleExport);
+  clearPluginModuleRequireCache(modulePath);
+  return ref;
+}
+const retired = Array.from({ length: 12 }, loadAndRetire);
+await setImmediate();
+for (let index = 0; index < 5; index++) {
+  global.gc();
+  await setImmediate();
+}
+assert.equal(retired.filter(ref => ref.deref() !== undefined).length, 0);
+`,
+    );
+    const result = spawnSync(process.execPath, ["--expose-gc", "--import", "tsx", probePath], {
+      cwd: process.cwd(),
+      encoding: "utf8",
+      timeout: 30_000,
+    });
+
+    expect(result.status, result.stderr).toBe(0);
+  });
 });
 
 describe("isJavaScriptModulePath", () => {

--- a/src/plugins/native-module-require.ts
+++ b/src/plugins/native-module-require.ts
@@ -140,7 +140,9 @@ function requireWithOptionalAliases(
   modulePath: string,
   aliasMap: Record<string, string> | ((specifier: string) => string | undefined) | undefined,
 ): unknown {
-  return withNativeRequireAliases(aliasMap, () => nodeRequire(modulePath));
+  // A process-wide require retains evicted modules through its synthetic parent's children.
+  // Keep that parent scoped to this load so retired graphs can be collected.
+  return withNativeRequireAliases(aliasMap, () => createRequire(import.meta.url)(modulePath));
 }
 
 /** Runs a native require block with temporary CJS/ESM alias hooks and restores both afterward. */

--- a/src/plugins/plugin-cache-primitives.ts
+++ b/src/plugins/plugin-cache-primitives.ts
@@ -23,6 +23,14 @@ export class PluginLruCache<T> {
     this.#entries.clear();
   }
 
+  deleteValue(value: T): void {
+    for (const [key, entry] of this.#entries) {
+      if (entry === value) {
+        this.#entries.delete(key);
+      }
+    }
+  }
+
   /** Returns a cached value and refreshes its recency when present. */
   get(cacheKey: string): T | undefined {
     const cached = this.getResult(cacheKey);

--- a/src/plugins/registry-lifecycle.ts
+++ b/src/plugins/registry-lifecycle.ts
@@ -1,5 +1,12 @@
 /** Tracks active and retired plugin registries so stale runtime calls can be rejected. */
+import { PluginLoaderCacheState } from "./loader-cache-state.js";
 import type { PluginRecord, PluginRegistry } from "./registry-types.js";
+
+const MAX_PLUGIN_REGISTRY_CACHE_ENTRIES = 128;
+
+export const pluginLoaderCacheState = new PluginLoaderCacheState<PluginRegistry>(
+  MAX_PLUGIN_REGISTRY_CACHE_ENTRIES,
+);
 
 const retiredRegistries = new WeakSet<PluginRegistry>();
 const activatedRegistries = new WeakSet<PluginRegistry>();
@@ -15,6 +22,9 @@ export function markPluginRegistryRetired(registry: PluginRegistry | null | unde
   if (registry) {
     retiredRegistries.add(registry);
     registryEpochs.delete(registry);
+    // Retired registrations cannot be reused and retain their Gateway/cache generation.
+    // Release every cache key now, including keys that will never be looked up again.
+    pluginLoaderCacheState.deleteValue(registry);
   }
 }
 


### PR DESCRIPTION
Closes #132914

## What Problem This Solves

Fixes an issue where operators repeatedly restarting a Gateway in the same process would accumulate old plugin generations and heap memory, even without channel traffic or model inference.

## Why This Change Was Made

Heap snapshots identified two strong retention paths. The registry LRU rejected retired entries on lookup but retained them under obsolete runtime-binding keys. Separately, the process-wide native `require` retained evicted module graphs through its synthetic parent's children.

The registry lifecycle now owns the cache and evicts every alias of an exact registry at retirement. This covers shutdown, replacement, and failed staged activation while preserving the live or rollback generation. Native loads receive a fresh `createRequire` parent with unchanged resolution and alias behavior, allowing retired graphs to be collected without changing Node's private module bookkeeping. Redundant cache read/write wrappers and the consumer-only retired lookup guard are removed.

## User Impact

Repeated in-process restarts release obsolete plugin registrations and native loader graphs. No new settings, environment variables, dependencies, database changes, or protocol changes are introduced. Shared dependency exports remain cached according to Node's contract.

## Evidence

- Both regressions fail before the fix: real registry shutdown/replacement leaves the original entry in the raw cache; a subprocess GC probe retains all 12 retired native module exports, including local cycles.
- 151 focused tests pass across registry retirement, staged commit/rollback, alias replacement, CLI metadata reuse, cache bounds, native loading, ESM aliases, source transforms, and runtime boundaries.
- Node 24 and 26 diagnostic probes: 30 retired CJS/cyclic/native ESM module graphs remain reachable before the native fix and are collectible afterward. An intentionally shared cached dependency preserves its first caller under Node's parent contract; the patch does not mutate foreign parents or private Node fields.
- Built Gateway baseline on main `145b0717295`: restart 5 to 25 grows from 7 to 27 cached registries and 6 to 26 captured cache generations; one native parent grows from 170 to 730 children. Post-GC heap grows from 274.47 to 426.97 MiB. These are same-process snapshots with explicit strong retainer paths, not an RSS-only diagnosis.
- Rebuilt Gateway after the fix, same 25-cycle snapshot command: registry/cache-generation counts remain **2/2** at restarts 5 and 25 and the final additional GC snapshot. The accumulating native parent is absent. Post-GC heap is 253.72 MiB at restart 5, 270.46 MiB at restart 25, and 256.94 MiB after the additional collection (baseline final additional collection: 427.82 MiB).
- Linux Testbox with the patch synced into its prepared checkout: **60 ordinary + 60 GC-assisted restarts completed**, no failed restart. GC-assisted ready heap changed from 283.9 to 313.9 MiB, versus 283.6 to 768.4 MiB before. GC-assisted readiness p95 was 731.79 ms. Ready-time samples include in-flight startup work; these are bounded-run observations, not a claim that all allocations disappear or that every sample is GC-synchronized. The heap retainer comparison is the ownership proof.
- Linux source scope: all 11 changed plugin production/test files match PR head `bb171e88d1f97f4b5750d986f8b02af0f2bca67d`. The prepared checkout differs from that head in eight unrelated Codex app-inventory files, so the Linux run is supporting cross-platform evidence, not exact-head CI. The local build, focused tests, changed checks, and before/after snapshots use the candidate patch. A Linux rerun of both modified regression files also passed all 41 tests.
- `pnpm build` and the full `node scripts/check-changed.mjs` plan passed, including core/test typechecks, lint, dead exports, and zero runtime import cycles. [Linux Testbox environment](https://github.com/openclaw/openclaw/actions/runs/33282978820); the measurements come from the separately executed Testbox command, not assertions in that workflow's CI jobs.

Focused command:

```sh
node scripts/run-vitest.mjs src/plugins/loader.runtime-registry.test.ts src/plugins/loader-cache-state.test.ts src/plugins/plugin-cache-primitives.test.ts src/plugins/runtime.test.ts src/plugins/native-module-require.test.ts src/plugins/plugin-module-loader-cache.test.ts src/plugins/loader.lazy-alias.test.ts src/plugins/loader.cli-metadata.test.ts src/plugins/active-runtime-registry.test.ts src/plugins/runtime-registry-boundary.test.ts
```

The snapshot producer wraps the unchanged built entry with diagnostic GC and V8 snapshots, then uses the maintained benchmark:

```sh
node --import ./scripts/tsx.mjs scripts/bench-gateway-restart.ts --entry <diagnostic-entry.mjs> --case skipChannels --runs 1 --warmup 0 --restarts 25 --post-ready-delay-ms 11000 --timeout-ms 90000 --output <evidence.json>
```

The ordinary Linux command is the same benchmark with its default built entry, `--restarts 60`, and default timings. No GC, increased timeout, or restart workaround is added to production.
- Production delta: 35 added / 37 removed (net -2); tests add 83 lines, with one test-support import moved. Fresh Codex autoreview reports no actionable P0 findings; independent lifecycle review reports no actionable findings.

AI-assisted with Codex. Heap snapshots and raw diagnostic captures remain private local artifacts; no provider credentials or operator state were used.


## Review Follow-through and Landing

Completed built-Gateway and Linux restart measurements are recorded above. The latest ClawSweeper findings were checked against the actual Node dependency contract and independent probes:

- **Shared dependency parent retention:** the observation is real, but does not establish continued restart growth. On Node 24.20.0 and 26.8.1, an out-of-root shared dependency retained all 10/30 generations before this patch; afterward it retained only generation 1 after both 10 and 30 iterations, including local cycles. Reloaded plugin exports stay fresh and the external dependency keeps its cache/export identity. This is bounded first-caller ownership for a fixed dependency graph. Node also records a private last-parent reference, so clearing the public parent is neither a complete ownership repair nor an unchanged dependency contract. The requested foreign/private parent-link surgery and zero-retention assertion are deliberately skipped. This patch removes the two demonstrated accumulating owners while preserving shared dependencies.
- **Changelog removal:** applied to satisfy the native release-owned changelog gate; the operator-facing explanation remains in this PR body. Production code is unchanged by this cleanup.
- **Stored-data-model notice:** false positive; these are process-local in-memory caches, with no SQLite schema, durable storage, or migration change.

The final ClawSweeper review reported no actionable findings. [Final-head CI](https://github.com/openclaw/openclaw/actions/runs/33284691540) passed for `a6203e63094a77f4b00fa56e8009667f7c8286c3`; native review, preparation, and merge completed. Landed as `3d12ee7cdc5b4ead9f2a00da4e64e5c955f56e53`, closing #132914. The final cleanup commit only removes the root changelog line; all production code matches the measured candidate.
