### PR TITLE
fix(doctor): preserve health repairs during stable upgrades

### DIFF
--- a/docs/plugins/manifest.md
+++ b/docs/plugins/manifest.md
@@ -167,6 +167,7 @@ See [Plugins](/tools/plugin) for the full plugin system guide, and [Capability m
 | `backupResources`                    | No       | `object[]`                   | Manifest-owned durable or regenerable state- or agent-relative backup resources. Applied only for effectively activated, loadable plugins without executing their runtime. See [backupResources reference](#backupresources-reference).                                                                                                                                                          |
 | `setup`                              | No       | `object`                     | Cheap setup/onboarding descriptors that discovery and setup surfaces can inspect without loading plugin runtime.                                                                                                                                                                                                                                                                                 |
 | `doctorContract`                     | No       | `object`                     | Declares which dynamic doctor-contract surfaces the plugin artifact exports so doctor loads only relevant modules.                                                                                                                                                                                                                                                                               |
+| `doctorHealthChecks`                 | No       | `boolean`                    | Declares health-check registration in the selected plugin's public API. Currently used for the Codex health API.                                                                                                                                                                                                                                                                                 |
 | `sessionRouteStateOwners`            | No       | `object[]`                   | Static session-route ownership for doctor cleanup. Each entry declares an `id`, `label`, and optional `providerIds`, `runtimeIds`, `cliSessionKeys`, and `authProfilePrefixes`.                                                                                                                                                                                                                  |
 | `qaRunners`                          | No       | `object[]`                   | Cheap QA runner descriptors used by the shared `openclaw qa` host before plugin runtime loads.                                                                                                                                                                                                                                                                                                   |
 | `dashboard`                          | No       | `object`                     | Dashboard widget data bindings and action verbs. Each entry is validated against a Gateway method registered by this plugin with the required read or write scope. See [dashboard reference](#dashboard-reference).                                                                                                                                                                              |
@@ -198,6 +199,13 @@ migration window.
 Set `doctorContract.configRepair: true` when the doctor-contract module exports
 non-empty `legacyConfigRules`, a `normalizeCompatibilityConfig` function, or
 both. One declaration covers the complete config-repair artifact.
+
+The Codex plugin sets `doctorHealthChecks: true` when its public API exports
+health-check registration. Doctor checks the selected plugin's trust before
+loading this surface. Older installed versions without the declaration skip
+Codex health registration without preventing other checks; a declared but
+missing or broken API remains an error. This does not grant plugin capabilities
+or replace upgrade consent.
 
 Channel plugins maintained in the OpenClaw source tree also expose these config
 exports through a pure `config-doctor-api.ts` entrypoint. The core package retains

--- a/extensions/codex/openclaw.plugin.json
+++ b/extensions/codex/openclaw.plugin.json
@@ -21,6 +21,7 @@
     "configRepair": true,
     "stateMigrations": true
   },
+  "doctorHealthChecks": true,
   "sessionRouteStateOwners": [
     {
       "id": "codex",

--- a/src/flows/bundled-health-checks.test.ts
+++ b/src/flows/bundled-health-checks.test.ts
@@ -6,6 +6,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { MissingPublicSurfaceError } from "../plugin-sdk/facade-loader.js";
 import type { PluginManifestRegistry } from "../plugins/manifest-registry.js";
+import { loadPluginManifest } from "../plugins/manifest.js";
 import type { ProviderPolicySurface } from "../plugins/provider-policy-surface.js";
 import {
   registerBundledHealthChecks,
@@ -374,14 +375,32 @@ describe("registerBundledHealthChecks", () => {
     },
   };
 
-  function codexRecord(origin: "bundled" | "global", trustedOfficialInstall?: boolean) {
+  function codexRecord(
+    origin: "bundled" | "global",
+    trustedOfficialInstall?: boolean,
+    healthChecks = true,
+  ) {
+    const manifestPath = join(workspaceDir, "openclaw.plugin.json");
+    writeFileSync(
+      manifestPath,
+      JSON.stringify({
+        id: "codex",
+        configSchema: {},
+        ...(healthChecks ? { doctorHealthChecks: true } : {}),
+      }),
+    );
+    const loaded = loadPluginManifest(workspaceDir);
+    if (!loaded.ok) {
+      throw new Error(loaded.error);
+    }
     return {
       id: "codex",
       origin,
       trustedOfficialInstall,
       rootDir: workspaceDir,
       source: join(workspaceDir, "index.js"),
-      manifestPath: join(workspaceDir, "openclaw.plugin.json"),
+      manifestPath,
+      doctorHealthChecks: loaded.manifest.doctorHealthChecks,
       channels: [],
       providers: [],
       cliBackends: [],
@@ -390,6 +409,24 @@ describe("registerBundledHealthChecks", () => {
       contracts: {},
     } satisfies PluginManifestRegistry["plugins"][number];
   }
+
+  it("continues other health checks for a retained stable Codex without a health API", () => {
+    // Published @openclaw/codex@2026.7.1-1 has neither a health declaration nor api.js.
+    mocks.loadPluginManifestRegistryForPluginRegistry.mockReturnValue({
+      plugins: [codexRecord("global", true, false)],
+      diagnostics: [],
+    });
+
+    registerBundledHealthChecks({
+      cfg: { ...codexConfig, plugins: { entries: { policy: { enabled: true } } } },
+      cwd: workspaceDir,
+    });
+
+    expect(mocks.registerMemoryCoreDoctorChecks).toHaveBeenCalledOnce();
+    expect(mocks.registerPolicyDoctorChecks).toHaveBeenCalledOnce();
+    expect(getHealthCheck("codex/managed-app-server")).toBeUndefined();
+    expect(mocks.registerCodexManagedAppServerDoctorChecks).not.toHaveBeenCalled();
+  });
 
   it.each(["bundled", "global"] as const)(
     "registers and runs health from the selected %s Codex public artifact",
@@ -439,36 +476,43 @@ describe("registerBundledHealthChecks", () => {
     },
   );
 
-  it.each(["missing", "untrusted", "missing-api", "missing-export", "broken-api"])(
-    "fails visibly for a selected Codex install with %s state",
-    (state) => {
-      mocks.loadPluginManifestRegistryForPluginRegistry.mockReturnValue({
-        plugins: state === "missing" ? [] : [codexRecord("global", state !== "untrusted")],
-        diagnostics: [],
-      });
-      if (state === "untrusted") {
-        writeFileSync(
-          join(workspaceDir, "api.js"),
-          'throw new Error("untrusted artifact executed");',
-        );
-      }
-      if (state === "missing-export") {
-        writeFileSync(join(workspaceDir, "api.js"), "module.exports = {};");
-      }
-      if (state === "broken-api") {
-        writeFileSync(join(workspaceDir, "api.js"), 'throw new Error("selected artifact failed");');
-      }
-      expect(() => registerBundledHealthChecks({ cfg: codexConfig, cwd: workspaceDir })).toThrow(
-        state === "broken-api"
-          ? "selected artifact failed"
-          : state === "missing-export"
-            ? TypeError
-            : MissingPublicSurfaceError,
+  it.each([
+    "missing",
+    "untrusted",
+    "untrusted-legacy",
+    "missing-api",
+    "missing-export",
+    "broken-api",
+  ])("fails visibly for a selected Codex install with %s state", (state) => {
+    mocks.loadPluginManifestRegistryForPluginRegistry.mockReturnValue({
+      plugins:
+        state === "missing"
+          ? []
+          : [codexRecord("global", !state.startsWith("untrusted"), state !== "untrusted-legacy")],
+      diagnostics: [],
+    });
+    if (state === "untrusted") {
+      writeFileSync(
+        join(workspaceDir, "api.js"),
+        'throw new Error("untrusted artifact executed");',
       );
-      expect(getHealthCheck("codex/managed-app-server")).toBeUndefined();
-      expect(mocks.registerCodexManagedAppServerDoctorChecks).not.toHaveBeenCalled();
-    },
-  );
+    }
+    if (state === "missing-export") {
+      writeFileSync(join(workspaceDir, "api.js"), "module.exports = {};");
+    }
+    if (state === "broken-api") {
+      writeFileSync(join(workspaceDir, "api.js"), 'throw new Error("selected artifact failed");');
+    }
+    expect(() => registerBundledHealthChecks({ cfg: codexConfig, cwd: workspaceDir })).toThrow(
+      state === "broken-api"
+        ? "selected artifact failed"
+        : state === "missing-export"
+          ? TypeError
+          : MissingPublicSurfaceError,
+    );
+    expect(getHealthCheck("codex/managed-app-server")).toBeUndefined();
+    expect(mocks.registerCodexManagedAppServerDoctorChecks).not.toHaveBeenCalled();
+  });
 
   it.each([
     { enabled: false },

--- a/src/flows/bundled-health-checks.ts
+++ b/src/flows/bundled-health-checks.ts
@@ -142,13 +142,17 @@ export function registerBundledHealthChecks(params: {
         "Unable to resolve Codex doctor health API: install the official Codex plugin with openclaw plugins install @openclaw/codex",
       );
     }
-    loadPluginPublicArtifactModuleSync<
-      Required<Pick<BundledHealthApi, "registerCodexManagedAppServerDoctorChecks">>
-    >({
-      pluginRoot: owner.rootDir,
-      artifactBasename: "api.js",
-      origin: owner.origin === "bundled" ? "bundled" : "global",
-    }).registerCodexManagedAppServerDoctorChecks({ getHealthCheck, registerHealthCheck });
+    // Retained stable plugins can predate health APIs while an upgrade awaits capability consent.
+    // Only load an advertised surface; a broken declaration must still fail visibly.
+    if (owner.doctorHealthChecks === true) {
+      loadPluginPublicArtifactModuleSync<
+        Required<Pick<BundledHealthApi, "registerCodexManagedAppServerDoctorChecks">>
+      >({
+        pluginRoot: owner.rootDir,
+        artifactBasename: "api.js",
+        origin: owner.origin === "bundled" ? "bundled" : "global",
+      }).registerCodexManagedAppServerDoctorChecks({ getHealthCheck, registerHealthCheck });
+    }
   }
   if (shouldRegisterPolicyHealth(params)) {
     loadBundledPluginPublicArtifactModuleSync<BundledHealthApi>({

--- a/src/plugins/manifest-registry.ts
+++ b/src/plugins/manifest-registry.ts
@@ -428,6 +428,7 @@ function buildRecord(params: {
     id: pluginId,
     backupResources: params.manifest.backupResources,
     doctorContract: params.manifest.doctorContract,
+    doctorHealthChecks: params.manifest.doctorHealthChecks,
     sessionRouteStateOwners: params.manifest.sessionRouteStateOwners,
     name: normalizeOptionalString(params.manifest.name) ?? params.candidate.packageName,
     description:

--- a/src/plugins/manifest-registry.types.ts
+++ b/src/plugins/manifest-registry.types.ts
@@ -98,6 +98,7 @@ export type PluginManifestRecord = {
   activation?: PluginManifestActivation;
   setup?: PluginManifestSetup;
   doctorContract?: PluginManifestDoctorContract;
+  doctorHealthChecks?: boolean;
   sessionRouteStateOwners?: DoctorSessionRouteStateOwner[];
   packageManifest?: OpenClawPackageManifest;
   packageDependencies?: PluginDependencySpecMap;

--- a/src/plugins/manifest-types.ts
+++ b/src/plugins/manifest-types.ts
@@ -418,6 +418,8 @@ export type PluginManifest = {
   setup?: PluginManifestSetup;
   /** Doctor contract surfaces available without loading the plugin artifact. */
   doctorContract?: PluginManifestDoctorContract;
+  /** Whether the plugin public API registers structured health checks. */
+  doctorHealthChecks?: boolean;
   /** Static ownership metadata for doctor session-route state repairs. */
   sessionRouteStateOwners?: DoctorSessionRouteStateOwner[];
   /** Cheap QA runner metadata exposed before plugin runtime loads. */

--- a/src/plugins/manifest.ts
+++ b/src/plugins/manifest.ts
@@ -252,6 +252,7 @@ export function loadPluginManifest(
     activation: setupNormalizers.normalizeManifestActivation(raw.activation),
     setup: setupNormalizers.normalizeManifestSetup(raw.setup),
     doctorContract,
+    doctorHealthChecks: raw.doctorHealthChecks === true ? true : undefined,
     sessionRouteStateOwners:
       raw.sessionRouteStateOwners === undefined
         ? undefined


### PR DESCRIPTION
Closes #132930

## What Problem This Solves

Fixes an issue where users upgrading from stable would lose structured doctor health repairs when the usable stable Codex plugin was retained pending explicit consent for new capabilities. Core updates and agent replies could succeed while doctor failed before running unrelated checks.

## Why This Change Was Made

The selected plugin now declares whether its public API supports health registration. Doctor verifies selected-owner trust, then loads only an advertised health API. Stable `@openclaw/codex@2026.7.1-1` never shipped that surface; a current plugin that declares it but has a missing export, missing file, or broken module still fails visibly.

The declaration is separate from `doctorContract`, whose exports belong to a different public module. It passes through the existing manifest parser and registry producer; no alternate owner lookup, bundled fallback, version heuristic, catch-all suppression, or consent bypass is added.

## User Impact

Doctor continues other health checks during a stable-to-main upgrade even before the operator accepts the candidate plugin's expanded capabilities. Matching current Codex plugins retain their managed-app-server health check. Plugin trust, upgrade consent, configuration defaults, database schemas, dependencies, and upstream protocol behavior are unchanged.

## Evidence

- Real Parallels Ubuntu 26.04 and macOS 26.5 stable `2026.7.1-2` to packaged main `6907e94161700e1161e68282f91384d2fe338358` updates reproduced the structured-health failure. The published stable Codex tarball was independently inspected and has no health `api.js`.
- The new retained-stable regression failed before the fix with `MissingPublicSurfaceError`, then all 38 owner tests passed. They cover selected bundled/official external owners, current API execution, legacy absence, unrelated policy checks, owner trust, hardlinks, missing/broken advertised APIs, and non-Codex routes.
- Another 48 focused manifest-registry/public-loader/doctor-declaration/closure tests passed. Formatting and `git diff --check` passed. Fresh independent Codex autoreview reported no actionable findings.
- Packaged head `9a8d59ff76c8abac2bc25fbea89dc6b6977535bd` and matching Codex artifact passed a new Ubuntu Parallels stable-to-fixed update: core swap, Gateway RPC, and exact `OK` live response. No `doctor:structured-health-repairs` failure was present. Core tarball SHA-256: `79a0226183d1e330587eadce7e1de90972a04325ab977e26011ff0a25e50e063`; companion: `3cd42e75c00a8207db9eb826490982f5928b85fd48b62dbdaaa12920826690fc`.
- With the real retained `2026.7.1-1` plugin selected for Codex routing, `openclaw doctor --lint --only core/doctor/final-config-validation --json` returned `{"ok":true,"checksRun":1,"checksSkipped":58,"findings":[]}`. After the documented `openclaw update repair --accept-capabilities --json`, targeted `codex/managed-app-server` doctor returned `{"ok":true,"checksRun":1,"checksSkipped":1,"findings":[]}`. A fresh explicit Codex agent session then returned exact `OK`, `fallbackUsed: false`.
- [Exact-head CI run 33283142204](https://github.com/openclaw/openclaw/actions/runs/33283142204) completed successfully. The complete commit check inventory contained 244 checks: 192 success, 51 skipped, 1 neutral, no failures or pending checks. The broader three-OS matrix separately records Parallels transport/setup interruptions; Gateway smoke uses direct/manual processes where guest service managers are unavailable.

Production LOC: +17/-7 (net +10). Tests: +75/-31 (net +44). Docs: +8/-0. The production growth is the optional shipped-artifact capability plus its canonical declaration/propagation; it avoids a version-specific compatibility branch or exception suppression.

Provenance: #129276 (`ddf5b5a5882c44335e168f2a7a874c803663a4a6`, 2026-08-29) corrected installed-plugin ownership but assumed all selected versions exposed health APIs. Code/PR author @Finn763; merger @steipete. This repair preserves that owner/trust correction.

Direct dependency inspection: Codex `rust-v0.150.1`, `codex-rs/model-provider-info/src/lib.rs:64` onward (Responses API, environment key and OpenAI auth contract). The changed boundary is OpenClaw manifest/doctor dispatch, not Codex protocol or model behavior.

## Landing state

The maintainer explicitly authorized direct GitHub CLI routing for this landing. The native review workflow now initializes and validates the exact-head artifacts successfully; native prepare/merge retains its hosted CI and head-identity gates. Live repository rules require `openclaw/ci-gate`, with no enforced approval requirement. No admin merge bypass is used.

ClawSweeper rank-up disposition: completed. Its reviewed-head request for packaged legacy/current artifact proof is covered by the stable-to-fixed VM update, retained-stable core doctor result, consented current-plugin native doctor result, and fresh live Codex turn above. The review reported no actionable correctness or security findings. No behavior changed after that reviewed head, so another review request is unnecessary.

The original pinned-main Parallels matrix is complete: macOS 26.5, Ubuntu 26.04, and Windows 11 each passed fresh installation and real stable-to-main update through Gateway RPC and exact live `OK` responses without fallback. Windows's final fresh-shell readback confirms the original `6907e94161700e1161e68282f91384d2fe338358` artifact, despite the coordinator's checkout advancing to the fix commit during the run. This matrix tests installation/update plus Gateway/model behavior, not reboot persistence or GUI interaction.

