### PR TITLE
test(mattermost): reuse slash handler imports with isolated state

### DIFF
--- a/extensions/mattermost/src/mattermost/slash-http.send-config.test.ts
+++ b/extensions/mattermost/src/mattermost/slash-http.send-config.test.ts
@@ -3,7 +3,7 @@ import { ServerResponse, type IncomingMessage } from "node:http";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/core";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime";
 import { createMockIncomingRequest } from "openclaw/plugin-sdk/test-env";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ResolvedMattermostAccount } from "./accounts.js";
 
 const mockState = vi.hoisted(() => ({
@@ -144,6 +144,7 @@ vi.mock("./slash-commands.js", () => ({
 }));
 
 let createSlashCommandHttpHandler: typeof import("./slash-http.js").createSlashCommandHttpHandler;
+let clearMattermostSlashCommandValidationCacheForAccount: typeof import("./slash-http.js").clearMattermostSlashCommandValidationCacheForAccount;
 const callbackUrlFixture = "https://gateway.example.com/slash";
 
 function createRequest(body = "token=valid-token"): IncomingMessage {
@@ -211,22 +212,21 @@ const accountFixture: ResolvedMattermostAccount = {
 };
 
 describe("slash-http cfg threading", () => {
-  beforeEach(async () => {
+  beforeAll(async () => {
     vi.resetModules();
-    mockState.readRequestBodyWithLimit.mockClear();
-    mockState.parseSlashCommandPayload.mockClear();
-    mockState.resolveCommandText.mockClear();
-    mockState.buildPreparedModelsProviderData.mockClear();
-    mockState.resolveMattermostModelPickerEntry.mockClear();
-    mockState.authorizeMattermostCommandInvocation.mockClear();
-    mockState.createMattermostClient.mockClear();
-    mockState.fetchMattermostChannel.mockClear();
-    mockState.sendMessageMattermost.mockClear();
-    mockState.normalizeMattermostAllowList.mockClear();
-    mockState.getMattermostCommand.mockClear();
-    mockState.listMattermostCommands.mockClear();
-    mockState.dispatchInbound.mockClear();
-    ({ createSlashCommandHttpHandler } = await import("./slash-http.js"));
+    ({ createSlashCommandHttpHandler, clearMattermostSlashCommandValidationCacheForAccount } =
+      await import("./slash-http.js"));
+  });
+
+  afterEach(() => {
+    clearMattermostSlashCommandValidationCacheForAccount(accountFixture.accountId);
+  });
+
+  beforeEach(() => {
+    // Rejected-before-lookup cases can leave one-shot responses unconsumed.
+    for (const mock of Object.values(mockState)) {
+      mock.mockReset();
+    }
   });
 
   it("passes cfg through the no-models slash reply send path", async () => {


### PR DESCRIPTION
## What Problem This Solves

The slash-command configuration tests rebuild the same module graph before every case. That repeated setup slows execution even though each test uses the same mocks and account. Their mock cleanup also leaves unused one-shot responses queued, causing an existing valid-request test to fail if the rejected-before-lookup case runs first.

## Why This Change Was Made

Import the handler once after a fresh module reset in `beforeAll`. Release the account's validation state after each case through the existing cleanup API used by slash-command shutdown. Reset this fixture's own mocks to their initial implementations before each case, including queued one-shot responses, instead of manually clearing only call history.

All five cases and their assertions remain, with the same real handler and existing mocks. No production, API, dependency, schema, sharding, concurrency, or test-order change. The initial module reset remains so this suite starts fresh in the non-isolated runner.

## User Impact

Faster developer tests and reliable fixture isolation. No product behavior change. Maintainer-requested, AI-assisted test performance work.

## Evidence

Two alternating comparisons of the final fixture on the same baseline and current pinned dependencies, Node 26.5.0/macOS:

| Run | Before | After |
| --- | --- | --- |
| A | 7.20s | 5.20s |
| B | 7.93s | 5.63s |

These measure the complete Vitest test phase, including the shared import in `beforeAll`: 28–29% less execution time in these runs. Host/import variation exists; earlier import-only trials showed smaller gains. No whole-suite or CI wall-time claim.

- All 35 tests passed across this suite, the HTTP handler suite, and slash-command state suite.
- Cache isolation fault probe: run the invalid-current-token case before a valid request. Omitting account cleanup makes the valid request fail with 401; restoring cleanup passes all five cases.
- Mock isolation regression: moving the rejected-before-lookup case ahead of the valid request fails on the original file because an unused one-shot response survives `mockClear`. The candidate passes the same order because `mockReset` clears that queue and restores the original mock implementations.
- All temporary reorders and fault mutations were removed. No permanent extra test or broader mock was added.
- Direct source inspection confirms the existing cleanup covers all three account-keyed maps; installed Vitest 4.1.11 restores initial `vi.fn` implementations on reset and still runs `afterEach` after a test failure.
- Full changed-file gate passed, including extension test typechecking, type-aware lint, unused-export scans, formatting, and repository guards.
- Independent Codex autoreview found no actionable findings. Production LOC: 0; test LOC: +16/-16.

This draft still needs exact-head hosted CI and the native landing workflow. Those operations are currently blocked by the maintainer CLI's protected-command support; local validation is not being represented as hosted CI or merge completion.
