### PR TITLE
[BACKPORT] fix(codex): Fix codex apps disappear when plugin is in read-only or prompt mode

### DIFF
--- a/extensions/codex/src/app-server/app-inventory-cache.test.ts
+++ b/extensions/codex/src/app-server/app-inventory-cache.test.ts
@@ -36,6 +36,7 @@ describe("Codex app inventory cache", () => {
     expect(request).toHaveBeenNthCalledWith(1, "app/installed", { forceRefresh: true });
     expect(request).toHaveBeenNthCalledWith(2, "app/read", {
       appIds: ["app-1", "app-2"],
+      includeTools: true,
     });
 
     const fresh = cache.read({ key, request, nowMs: 50 });
@@ -82,6 +83,7 @@ describe("Codex app inventory cache", () => {
     expect(request).toHaveBeenNthCalledWith(1, "app/installed", { forceRefresh: true });
     expect(request).toHaveBeenNthCalledWith(2, "app/read", {
       appIds: ["google-calendar-app"],
+      includeTools: true,
     });
   });
 
@@ -123,8 +125,8 @@ describe("Codex app inventory cache", () => {
       ["app/installed", { forceRefresh: false }],
     ]);
     expect(request.mock.calls.filter(([method]) => method === "app/read")).toEqual([
-      ["app/read", { appIds: ["google-calendar-app"] }],
-      ["app/read", { appIds: ["google-calendar-app", "unrelated-slack-app"] }],
+      ["app/read", { appIds: ["google-calendar-app"], includeTools: true }],
+      ["app/read", { appIds: ["google-calendar-app", "unrelated-slack-app"], includeTools: true }],
     ]);
   });
 
@@ -184,12 +186,15 @@ describe("Codex app inventory cache", () => {
     expect(request).toHaveBeenCalledTimes(4);
     expect(request).toHaveBeenNthCalledWith(2, "app/read", {
       appIds: apps.slice(0, 100).map((entry) => entry.id),
+      includeTools: true,
     });
     expect(request).toHaveBeenNthCalledWith(3, "app/read", {
       appIds: apps.slice(100, 200).map((entry) => entry.id),
+      includeTools: true,
     });
     expect(request).toHaveBeenNthCalledWith(4, "app/read", {
       appIds: apps.slice(200).map((entry) => entry.id),
+      includeTools: true,
     });
   });
 
@@ -221,6 +226,7 @@ describe("Codex app inventory cache", () => {
     expect(snapshot.apps).toEqual([]);
     expect(request).toHaveBeenNthCalledWith(2, "app/read", {
       appIds: ["policy-disabled-app"],
+      includeTools: true,
     });
   });
 
@@ -420,7 +426,10 @@ describe("Codex app inventory cache", () => {
 
     await expect(cache.refreshNow({ key: "runtime", request })).rejects.toThrow("Method not found");
     expect(request).toHaveBeenNthCalledWith(1, "app/installed", { forceRefresh: true });
-    expect(request).toHaveBeenNthCalledWith(2, "app/read", { appIds: ["current-app"] });
+    expect(request).toHaveBeenNthCalledWith(2, "app/read", {
+      appIds: ["current-app"],
+      includeTools: true,
+    });
     expect(cache.read({ key: "runtime", request, suppressRefresh: true }).snapshot).toBeUndefined();
   });
 

--- a/extensions/codex/src/app-server/app-inventory-cache.ts
+++ b/extensions/codex/src/app-server/app-inventory-cache.ts
@@ -486,6 +486,7 @@ async function readInstalledApps(
         appIds: apps
           .slice(index * CODEX_APP_READ_BATCH_LIMIT, (index + 1) * CODEX_APP_READ_BATCH_LIMIT)
           .map((app) => app.id),
+        includeTools: true,
       }),
     ),
   );
@@ -519,6 +520,7 @@ async function readInstalledApps(
           isAccessible: true,
           isEnabled: installedApp.enabled,
           pluginDisplayNames: metadata.pluginDisplayNames,
+          ...(metadata.toolSummaries ? { toolSummaries: metadata.toolSummaries } : {}),
         },
       ];
     }),

--- a/extensions/codex/src/app-server/app-inventory.test-helpers.ts
+++ b/extensions/codex/src/app-server/app-inventory.test-helpers.ts
@@ -20,7 +20,8 @@ export function codexAppInventoryResponse<Method extends CodexAppInventoryMethod
     } as CodexAppServerRequestResult<Method>;
   }
 
-  const requestedIds = (params as CodexAppServerRequestParams<"app/read"> | undefined)?.appIds;
+  const readParams = params as CodexAppServerRequestParams<"app/read"> | undefined;
+  const requestedIds = readParams?.appIds;
   const requestedIdSet = requestedIds ? new Set(requestedIds) : undefined;
   const matchingApps = apps.filter(
     (app) => app.isAccessible && (!requestedIdSet || requestedIdSet.has(app.id)),
@@ -37,6 +38,7 @@ export function codexAppInventoryResponse<Method extends CodexAppInventoryMethod
       distributionChannel: app.distributionChannel,
       installUrl: app.installUrl,
       pluginDisplayNames: app.pluginDisplayNames,
+      toolSummaries: readParams?.includeTools ? (app.toolSummaries ?? null) : null,
     })),
     missingAppIds: requestedIds?.filter((id) => !returnedIds.has(id)) ?? [],
   } as CodexAppServerRequestResult<Method>;

--- a/extensions/codex/src/app-server/plugin-inventory.ts
+++ b/extensions/codex/src/app-server/plugin-inventory.ts
@@ -66,6 +66,8 @@ export type CodexPluginOwnedApp = {
   accessible: boolean;
   enabled: boolean;
   needsAuth: boolean;
+  /** Tool config keys Codex explicitly classifies as read-only. */
+  readOnlyToolConfigKeys?: readonly string[];
 };
 
 /** Inventory record for one configured Codex plugin policy. */
@@ -521,17 +523,57 @@ function resolveOwnedApps(params: {
           needsAuth: true,
         };
       }
-      return {
-        id: app.id,
-        name: app.name,
-        accessible: info.isAccessible,
-        enabled: info.isEnabled,
-        // Modern plugin summaries carry no auth bit; account-authorized
-        // app/read metadata is the canonical connector access proof.
-        needsAuth: !info.isAccessible,
-      };
+      return Object.assign(
+        {
+          id: app.id,
+          name: app.name,
+          accessible: info.isAccessible,
+          enabled: info.isEnabled,
+          // Modern plugin summaries carry no auth bit; account-authorized
+          // app/read metadata is the canonical connector access proof.
+          needsAuth: !info.isAccessible,
+        },
+        resolveOwnedAppReadOnlyToolConfigKeys(info),
+      );
     })
     .toSorted((left, right) => left.id.localeCompare(right.id));
+}
+
+/** Returns the config keys that Codex metadata proves belong to read-only tools. */
+export function resolveOwnedAppReadOnlyToolConfigKeys(
+  app: v2.AppInfo,
+): Pick<CodexPluginOwnedApp, "readOnlyToolConfigKeys"> {
+  const appName = app.name.trim();
+  const appNameLower = appName.toLowerCase();
+  const tools = app.toolSummaries ?? [];
+  const writableToolConfigKeys = new Set(
+    tools
+      .filter((tool) => !tool.isReadOnly)
+      .flatMap((tool) => resolveAppToolConfigKeys({ appName, appNameLower, tool })),
+  );
+  const keys = tools
+    .filter((tool) => tool.isReadOnly)
+    .flatMap((tool) => resolveAppToolConfigKeys({ appName, appNameLower, tool }))
+    .filter((key) => !writableToolConfigKeys.has(key));
+  return keys.length > 0 ? { readOnlyToolConfigKeys: Array.from(new Set(keys)).toSorted() } : {};
+}
+
+function resolveAppToolConfigKeys(params: {
+  appName: string;
+  appNameLower: string;
+  tool: { name: string; title?: string | null };
+}): string[] {
+  const keys = [params.tool.name];
+  if (params.tool.title) {
+    keys.push(params.tool.title);
+  }
+  if (params.appName) {
+    keys.push(`${params.appName}_${params.tool.name}`);
+  }
+  if (params.appNameLower && params.appNameLower !== params.appName) {
+    keys.push(`${params.appNameLower}_${params.tool.name}`);
+  }
+  return keys;
 }
 
 function findPluginSummary(

--- a/extensions/codex/src/app-server/plugin-thread-app-admission.ts
+++ b/extensions/codex/src/app-server/plugin-thread-app-admission.ts
@@ -6,11 +6,12 @@ import {
   type CodexAppInventorySnapshot,
 } from "./app-inventory-cache.js";
 import type { ResolvedCodexPluginsPolicy } from "./config.js";
-import type {
-  CodexPluginInventory,
-  CodexPluginInventoryRecord,
-  CodexPluginOwnedApp,
-  CodexPluginRuntimeRequest,
+import {
+  resolveOwnedAppReadOnlyToolConfigKeys,
+  type CodexPluginInventory,
+  type CodexPluginInventoryRecord,
+  type CodexPluginOwnedApp,
+  type CodexPluginRuntimeRequest,
 } from "./plugin-inventory.js";
 import type { CodexAppServerRequestResult } from "./protocol.js";
 import { isJsonObject, type JsonObject, type v2 } from "./protocol.js";
@@ -163,6 +164,7 @@ export function toCodexPluginOwnedAccountApp(app: v2.AppInfo): CodexPluginOwnedA
     accessible: app.isAccessible,
     enabled: app.isEnabled,
     needsAuth: !app.isAccessible,
+    ...resolveOwnedAppReadOnlyToolConfigKeys(app),
   };
 }
 

--- a/extensions/codex/src/app-server/plugin-thread-config.test.ts
+++ b/extensions/codex/src/app-server/plugin-thread-config.test.ts
@@ -6,7 +6,10 @@ import {
   CODEX_PLUGINS_MARKETPLACE_NAME,
   CODEX_PLUGINS_WORKSPACE_MARKETPLACE_NAME,
 } from "./config.js";
-import { resolveRecoverableCodexPluginConfigKeys } from "./plugin-inventory.js";
+import {
+  resolveOwnedAppReadOnlyToolConfigKeys,
+  resolveRecoverableCodexPluginConfigKeys,
+} from "./plugin-inventory.js";
 import { CodexPluginMetadataCache } from "./plugin-metadata-cache.js";
 import { createCodexPluginThreadConfigStartupProvider } from "./plugin-thread-config-deadline.js";
 import {
@@ -23,6 +26,34 @@ import type { CodexAppServerRequestParams, JsonObject, v2 } from "./protocol.js"
 describe("Codex plugin thread config", () => {
   beforeEach(() => {
     defaultCodexAppInventoryCache.clear();
+  });
+
+  it("does not classify keys shared with writable tools as read-only", () => {
+    const app: v2.AppInfo = {
+      ...appInfo("linear", true),
+      toolSummaries: [
+        {
+          name: "fetch",
+          title: "Fetch",
+          description: "Fetch a Linear issue.",
+          isEnabled: true,
+          disabledReason: null,
+          isReadOnly: true,
+        },
+        {
+          name: "linear_fetch",
+          title: "Save issue",
+          description: "Create or update a Linear issue.",
+          isEnabled: true,
+          disabledReason: null,
+          isReadOnly: false,
+        },
+      ],
+    };
+
+    expect(resolveOwnedAppReadOnlyToolConfigKeys(app)).toStrictEqual({
+      readOnlyToolConfigKeys: ["Fetch", "fetch"],
+    });
   });
 
   it("defaults destructive app access on for accessible migrated plugin apps", async () => {
@@ -668,13 +699,120 @@ describe("Codex plugin thread config", () => {
     expect(configPatch).not.toHaveProperty("approvals_reviewer");
   });
 
-  it("omits ask policy apps when cwd effective approval overrides remain after cleanup", async () => {
+  it("keeps ask policy apps when managed approval overrides cover only read-only tools", async () => {
     const appCache = new CodexAppInventoryCache();
+    const linearApp: v2.AppInfo = {
+      ...appInfo("linear", true),
+      toolSummaries: [
+        {
+          name: "fetch",
+          title: "Fetch",
+          description: "Fetch a Linear issue.",
+          isEnabled: true,
+          disabledReason: null,
+          isReadOnly: true,
+        },
+        {
+          name: "save_issue",
+          title: "linear/save_issue",
+          description: "Create or update a Linear issue.",
+          isEnabled: true,
+          disabledReason: null,
+          isReadOnly: false,
+        },
+      ],
+    };
     await appCache.refreshNow({
       key: "runtime",
       nowMs: 0,
-      request: async (method, params) =>
-        codexAppInventoryResponse(method, [appInfo("google-calendar-app", true)], params),
+      request: async (method, params) => codexAppInventoryResponse(method, [linearApp], params),
+    });
+    const request = vi.fn(async (method: string, params?: unknown) => {
+      if (method === "plugin/installed" || method === "plugin/list") {
+        return pluginList([pluginSummary("linear", { installed: true, enabled: true })]);
+      }
+      if (method === "plugin/read") {
+        return pluginDetail("linear", [appSummary("linear")], ["linear"]);
+      }
+      if (method === "config/read") {
+        expect(params).toEqual({ includeLayers: true, cwd: "/repo/project" });
+        return {
+          config: {
+            apps: {
+              linear: {
+                tools: {
+                  linear_fetch: { approval_mode: "approve" },
+                },
+              },
+            },
+          },
+          layers: [],
+        };
+      }
+      throw new Error(`unexpected request ${method}`);
+    });
+
+    const config = await buildCodexPluginThreadConfig({
+      pluginConfig: {
+        codexPlugins: {
+          enabled: true,
+          allow_destructive_actions: "ask",
+          plugins: {
+            linear: {
+              marketplaceName: CODEX_PLUGINS_MARKETPLACE_NAME,
+              pluginName: "linear",
+            },
+          },
+        },
+      },
+      appCache,
+      appCacheKey: "runtime",
+      configCwd: "/repo/project",
+      nowMs: 1,
+      request,
+    });
+
+    expect(config.configPatch).toEqual({
+      apps: {
+        _default: {
+          enabled: false,
+          destructive_enabled: false,
+          open_world_enabled: false,
+        },
+        linear: {
+          enabled: true,
+          approvals_reviewer: "user",
+          destructive_enabled: true,
+          open_world_enabled: true,
+          default_tools_approval_mode: "auto",
+        },
+      },
+    });
+    expect(config.provisionalAppIds).toEqual(["linear"]);
+    expect(config.diagnostics).toStrictEqual([]);
+    expect(request.mock.calls.filter(([method]) => method === "config/read")).toHaveLength(1);
+    expect(request.mock.calls.map(([method]) => method)).not.toContain("config/batchWrite");
+  });
+
+  it("omits ask policy apps when cwd effective approval overrides remain after cleanup", async () => {
+    const appCache = new CodexAppInventoryCache();
+    const calendarApp: v2.AppInfo = {
+      ...appInfo("google-calendar-app", true),
+      toolSummaries: [
+        {
+          name: "calendar/create",
+          title: null,
+          description: "Create a calendar event.",
+          isEnabled: true,
+          disabledReason: null,
+          isReadOnly: false,
+        },
+      ],
+    };
+    await appCache.refreshNow({
+      key: "runtime",
+      nowMs: 0,
+      request: async (method, params) => codexAppInventoryResponse(method, [calendarApp], params),
     });
     let configReadCount = 0;
     const request = vi.fn(async (method: string, params?: unknown) => {
@@ -2537,7 +2675,7 @@ describe("Codex plugin thread config", () => {
       ["app/installed", { forceRefresh: true }],
     ]);
     expect(request.mock.calls.filter(([method]) => method === "app/read")).toEqual([
-      ["app/read", { appIds: ["calendar-app", "meetings-app"] }],
+      ["app/read", { appIds: ["calendar-app", "meetings-app"], includeTools: true }],
     ]);
     expect(request.mock.calls.filter(([method]) => method === "config/read")).toHaveLength(1);
   });

--- a/extensions/codex/src/app-server/plugin-thread-config.ts
+++ b/extensions/codex/src/app-server/plugin-thread-config.ts
@@ -659,6 +659,7 @@ function readPersistedAppToolApprovalOverrideNames(
     return [];
   }
   return Object.entries(tools)
+    .filter(([toolName]) => !app.readOnlyToolConfigKeys?.includes(toolName))
     .filter(([, value]) => hasPersistedToolApprovalOverride(value))
     .map(([toolName]) => toolName)
     .toSorted();

--- a/extensions/codex/src/app-server/protocol-control-plane.ts
+++ b/extensions/codex/src/app-server/protocol-control-plane.ts
@@ -106,6 +106,8 @@ export type CodexAppInfo = {
   isAccessible: boolean;
   isEnabled: boolean;
   pluginDisplayNames: string[];
+  /** Present when app/read was requested with includeTools. */
+  toolSummaries?: CodexAppToolSummary[];
 };
 
 export type CodexAppsListParams = {


### PR DESCRIPTION
## Why

Carry the merged Codex app-inventory fix onto the current OpenClaw release line so apps remain available when read-only tools are pre-approved and write tools remain approval-gated.

## Evidence

- Applied the authoritative merged source commit as one release commit.
- Preserved the release line's existing app-server protocol import boundary.
- Focused Codex app-server validation passed: 2 files, 107 tests.
- Formatting passed for all 8 changed files.
- `git diff --check` passed.

Backport-Of: #130394
Release-Target: sjf_openclaw_2026-07-31