### PR TITLE
fix: keep reply tests inside owned state

### DIFF
--- a/src/auto-reply/reply.block-streaming.test.ts
+++ b/src/auto-reply/reply.block-streaming.test.ts
@@ -1,20 +1,20 @@
 /** Tests block streaming behavior for auto-reply output delivery. */
 import path from "node:path";
-import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
-import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { expectDefined } from "@openclaw/normalization-core";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
+import { resolveUnsuffixedSqliteTargetFromSessionStorePath } from "../config/sessions/session-sqlite-target.js";
+import { isPathInside } from "../infra/path-guards.js";
+import {
+  withOpenClawTestState,
+  type OpenClawTestState,
+} from "../test-utils/openclaw-test-state.js";
 import { withFastReplyConfig } from "./reply/get-reply-fast-path.test-support.js";
 import { loadGetReplyModuleForTest } from "./reply/get-reply.test-loader.js";
 import { createMockTypingController } from "./reply/reply.test-helpers.js";
 import type { MsgContext } from "./templating.js";
 
-const tempDirs = useAutoCleanupTempDirTracker(afterEach);
-
 const mocks = vi.hoisted(() => ({
-  rootDir: "",
-  resolveReplyDirectives: vi.fn(),
-  handleInlineActions: vi.fn(),
-  initSessionState: vi.fn(),
   runPreparedReply: vi.fn(),
 }));
 
@@ -24,8 +24,6 @@ vi.mock("../agents/agent-scope.js", async () => {
   );
   return {
     ...actual,
-    resolveAgentDir: vi.fn(() => path.join(mocks.rootDir, "agent")),
-    resolveAgentWorkspaceDir: vi.fn(() => path.join(mocks.rootDir, "workspace")),
     resolveSessionAgentId: vi.fn(() => "main"),
     resolveAgentSkillsFilter: vi.fn(() => undefined),
   };
@@ -42,10 +40,6 @@ vi.mock("../agents/model-selection.js", async () => {
 vi.mock("../agents/timeout.js", () => ({
   resolveAgentTimeoutMs: vi.fn(() => 60_000),
 }));
-vi.mock("../agents/workspace.js", () => ({
-  DEFAULT_AGENT_WORKSPACE_DIR: "/tmp/workspace",
-  ensureAgentWorkspace: vi.fn(async () => ({ dir: path.join(mocks.rootDir, "workspace") })),
-}));
 vi.mock("../channels/model-overrides.js", () => ({
   resolveChannelModelOverride: vi.fn(() => undefined),
 }));
@@ -53,7 +47,7 @@ vi.mock("../config/config.js", () => ({
   getRuntimeConfig: vi.fn(() => ({})),
 }));
 vi.mock("../runtime.js", () => ({
-  defaultRuntime: { log: vi.fn(), error: vi.fn(), warn: vi.fn(), info: vi.fn() },
+  defaultRuntime: { log: vi.fn(), error: vi.fn(), warn: vi.fn() },
 }));
 vi.mock("./command-auth.js", () => ({
   resolveCommandAuthorization: vi.fn(() => ({ isAuthorizedSender: true })),
@@ -78,23 +72,17 @@ vi.mock("./reply/typing.js", () => ({
   createTypingController: vi.fn(() => createMockTypingController()),
 }));
 
-vi.mock("./reply/get-reply-directives.js", () => ({
-  resolveReplyDirectives: (...args: unknown[]) => mocks.resolveReplyDirectives(...args),
-}));
-vi.mock("./reply/get-reply-inline-actions.js", () => ({
-  handleInlineActions: (...args: unknown[]) => mocks.handleInlineActions(...args),
-}));
-vi.mock("./reply/session.js", () => ({
-  initSessionState: (...args: unknown[]) => mocks.initSessionState(...args),
-}));
 vi.mock("./reply/get-reply-run.js", () => ({
   runPreparedReply: (...args: unknown[]) => mocks.runPreparedReply(...args),
 }));
 
 let getReplyFromConfig: typeof import("./reply/get-reply.js").getReplyFromConfig;
+let resolveAgentWorkspaceDirMock: typeof import("../agents/agent-scope.js").resolveAgentWorkspaceDir;
 
 async function loadFreshGetReplyModuleForTest() {
   ({ getReplyFromConfig } = await loadGetReplyModuleForTest({ cacheKey: import.meta.url }));
+  ({ resolveAgentWorkspaceDir: resolveAgentWorkspaceDirMock } =
+    await import("../agents/agent-scope.js"));
 }
 
 function createTelegramMessage(messageSid: string): MsgContext {
@@ -109,12 +97,12 @@ function createTelegramMessage(messageSid: string): MsgContext {
   };
 }
 
-function createReplyConfig(streamMode?: "block"): OpenClawConfig {
+function createReplyConfig(state: OpenClawTestState, streamMode?: "block"): OpenClawConfig {
   return withFastReplyConfig({
     agents: {
       defaults: {
         model: { primary: "anthropic/claude-opus-4-6" },
-        workspace: path.join(mocks.rootDir, "workspace"),
+        workspace: state.workspaceDir,
       },
     },
     channels: {
@@ -123,58 +111,8 @@ function createReplyConfig(streamMode?: "block"): OpenClawConfig {
         ...(streamMode ? { streaming: { mode: streamMode } } : {}),
       },
     },
-    session: { store: path.join(mocks.rootDir, "sessions.json") },
-  } as OpenClawConfig);
-}
-
-function createContinueDirectivesResult() {
-  return {
-    kind: "continue" as const,
-    result: {
-      commandSource: undefined,
-      command: {
-        surface: "telegram",
-        channel: "telegram",
-        channelId: "+2000",
-        ownerList: [],
-        senderIsOwner: true,
-        isAuthorizedSender: true,
-        senderId: "+1004",
-        abortKey: "telegram:+2000",
-        rawBodyNormalized: "ping",
-        commandBodyNormalized: "ping",
-        from: "+1004",
-        to: "+2000",
-        resetHookTriggered: false,
-      },
-      allowTextCommands: true,
-      skillCommands: [],
-      directives: {},
-      cleanedBody: "ping",
-      elevatedEnabled: false,
-      elevatedAllowed: false,
-      elevatedFailures: [],
-      defaultActivation: "always",
-      resolvedThinkLevel: undefined,
-      resolvedVerboseLevel: "off",
-      resolvedReasoningLevel: "off",
-      resolvedElevatedLevel: "off",
-      execOverrides: undefined,
-      blockStreamingEnabled: true,
-      blockReplyChunking: undefined,
-      resolvedBlockStreamingBreak: "message_end",
-      provider: "anthropic",
-      model: "claude-opus-4-6",
-      modelState: {
-        resolveDefaultThinkingLevel: async () => undefined,
-      },
-      contextTokens: 0,
-      inlineStatusRequested: false,
-      directiveAck: undefined,
-      perMessageQueueMode: undefined,
-      perMessageQueueOptions: undefined,
-    },
-  };
+    session: { store: path.join(state.sessionsDir("main"), "sessions.json") },
+  } satisfies OpenClawConfig);
 }
 
 describe("block streaming", () => {
@@ -183,80 +121,63 @@ describe("block streaming", () => {
   });
 
   beforeEach(() => {
-    mocks.rootDir = tempDirs.make("openclaw-block-streaming-");
-    vi.stubEnv("OPENCLAW_TEST_FAST", "1");
-    mocks.resolveReplyDirectives.mockReset();
-    mocks.handleInlineActions.mockReset();
-    mocks.initSessionState.mockReset();
     mocks.runPreparedReply.mockReset();
-
-    mocks.resolveReplyDirectives.mockResolvedValue(createContinueDirectivesResult());
-    mocks.handleInlineActions.mockImplementation(async (params) => ({
-      kind: "continue",
-      directives: params.directives,
-      abortedLastRun: false,
-    }));
-    mocks.initSessionState.mockImplementation(async ({ ctx }: { ctx: MsgContext }) => ({
-      sessionCtx: {
-        ...ctx,
-        CommandAuthorized: true,
-      },
-      sessionEntry: {},
-      previousSessionEntry: {},
-      sessionStore: {},
-      sessionKey: "agent:main:telegram:direct:+1004",
-      sessionId: "session-1",
-      isNewSession: true,
-      resetTriggered: false,
-      systemSent: false,
-      abortedLastRun: false,
-      storePath: path.join(mocks.rootDir, "sessions.json"),
-      sessionScope: "per-sender",
-      groupResolution: undefined,
-      isGroup: false,
-      triggerBodyNormalized: "ping",
-      bodyStripped: "ping",
-    }));
   });
 
   it("handles ordering, timeout fallback, and telegram streamMode block", async () => {
-    const onReplyStart = vi.fn().mockResolvedValue(undefined);
-    const onBlockReply = vi.fn().mockResolvedValue(undefined);
+    await withOpenClawTestState(
+      { label: "reply-block-streaming", env: { OPENCLAW_TEST_FAST: "1" } },
+      async (state) => {
+        const cfg = createReplyConfig(state);
+        const streamModeCfg = createReplyConfig(state, "block");
 
-    mocks.runPreparedReply.mockImplementationOnce(async (params) => {
-      await params.opts?.onReplyStart?.();
-      await params.opts?.onBlockReply?.({ text: "first\n\nsecond" });
-      return undefined;
-    });
+        // Check both configs with pure resolvers before either reply can mkdir or probe SQLite.
+        for (const config of [cfg, streamModeCfg]) {
+          const storePath = expectDefined(config.session?.store, "block-streaming session store");
+          const sqliteTarget = resolveUnsuffixedSqliteTargetFromSessionStorePath(storePath);
+          expect(isPathInside(state.root, sqliteTarget.path)).toBe(true);
+          expect(isPathInside(state.root, resolveAgentWorkspaceDirMock(config, "main"))).toBe(true);
+        }
 
-    const res = await getReplyFromConfig(
-      createTelegramMessage("msg-123"),
-      {
-        onReplyStart,
-        onBlockReply,
-        disableBlockStreaming: false,
+        const onReplyStart = vi.fn().mockResolvedValue(undefined);
+        const onBlockReply = vi.fn().mockResolvedValue(undefined);
+
+        mocks.runPreparedReply.mockImplementationOnce(async (params) => {
+          await params.opts?.onReplyStart?.();
+          await params.opts?.onBlockReply?.({ text: "first\n\nsecond" });
+          return undefined;
+        });
+
+        const res = await getReplyFromConfig(
+          createTelegramMessage("msg-123"),
+          {
+            onReplyStart,
+            onBlockReply,
+            disableBlockStreaming: false,
+          },
+          cfg,
+        );
+
+        expect(res).toBeUndefined();
+        expect(mocks.runPreparedReply).toHaveBeenCalledTimes(1);
+        expect(onReplyStart).toHaveBeenCalledTimes(1);
+        expect(onBlockReply).toHaveBeenCalledWith({ text: "first\n\nsecond" });
+
+        const onBlockReplyStreamMode = vi.fn().mockResolvedValue(undefined);
+        mocks.runPreparedReply.mockImplementationOnce(async () => [{ text: "final" }]);
+
+        const resStreamMode = await getReplyFromConfig(
+          createTelegramMessage("msg-127"),
+          {
+            onBlockReply: onBlockReplyStreamMode,
+          },
+          streamModeCfg,
+        );
+
+        const streamPayload = Array.isArray(resStreamMode) ? resStreamMode[0] : resStreamMode;
+        expect(streamPayload?.text).toBe("final");
+        expect(onBlockReplyStreamMode).not.toHaveBeenCalled();
       },
-      createReplyConfig(),
     );
-
-    expect(res).toBeUndefined();
-    expect(mocks.runPreparedReply).toHaveBeenCalledTimes(1);
-    expect(onReplyStart).toHaveBeenCalledTimes(1);
-    expect(onBlockReply).toHaveBeenCalledWith({ text: "first\n\nsecond" });
-
-    const onBlockReplyStreamMode = vi.fn().mockResolvedValue(undefined);
-    mocks.runPreparedReply.mockImplementationOnce(async () => [{ text: "final" }]);
-
-    const resStreamMode = await getReplyFromConfig(
-      createTelegramMessage("msg-127"),
-      {
-        onBlockReply: onBlockReplyStreamMode,
-      },
-      createReplyConfig("block"),
-    );
-
-    const streamPayload = Array.isArray(resStreamMode) ? resStreamMode[0] : resStreamMode;
-    expect(streamPayload?.text).toBe("final");
-    expect(onBlockReplyStreamMode).not.toHaveBeenCalled();
   });
 });

--- a/src/auto-reply/reply/get-reply.fast-path.test.ts
+++ b/src/auto-reply/reply/get-reply.fast-path.test.ts
@@ -1,22 +1,24 @@
 // Tests get-reply fast-path command handling before full agent dispatch.
-import fs from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
 import { expectDefined } from "@openclaw/normalization-core";
-import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { testing as cliBackendsTesting } from "../../agents/cli-backends.test-support.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import type { SessionEntry } from "../../config/sessions.js";
 import { loadSessionEntry, replaceSessionEntry } from "../../config/sessions/session-accessor.js";
+import { resolveUnsuffixedSqliteTargetFromSessionStorePath } from "../../config/sessions/session-sqlite-target.js";
+import { isPathInside } from "../../infra/path-guards.js";
 import { setActivePluginRegistry } from "../../plugins/runtime.js";
 import {
   MODEL_SELECTION_LOCKED_RESET_MESSAGE,
   ModelSelectionLockedError,
 } from "../../sessions/model-overrides.js";
 import { listSessionStateEventsSince } from "../../sessions/session-state-events.js";
-import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db.js";
-import { createSuiteTempRootTracker } from "../../test-helpers/temp-dir.js";
 import { createTestRegistry } from "../../test-utils/channel-plugins.js";
+import {
+  createOpenClawTestState,
+  type OpenClawTestState,
+} from "../../test-utils/openclaw-test-state.js";
 import { getReplyPayloadMetadata } from "../reply-payload.js";
 import { handleGoalCommand } from "./commands-goal.js";
 import { buildFastReplyCommandContext, initFastReplySessionState } from "./get-reply-fast-path.js";
@@ -82,6 +84,7 @@ vi.mock("../../agents/workspace.js", () => ({
 registerGetReplyRuntimeOverrides(mocks);
 
 let getReplyFromConfig: typeof import("./get-reply.js").getReplyFromConfig;
+let resolveAgentWorkspaceDirMock: typeof import("../../agents/agent-scope.js").resolveAgentWorkspaceDir;
 let resolveDefaultModelMock: typeof import("./directive-handling.defaults.js").resolveDefaultModel;
 let resolveModelRefFromStringMock: typeof import("../../agents/model-selection.js").resolveModelRefFromString;
 let loadConfigMock: typeof import("../../config/config.js").getRuntimeConfig;
@@ -89,6 +92,8 @@ let runPreparedReplyMock: typeof import("./get-reply-run.js").runPreparedReply;
 
 async function loadGetReplyRuntimeForTest() {
   ({ getReplyFromConfig } = await loadGetReplyModuleForTest({ cacheKey: import.meta.url }));
+  ({ resolveAgentWorkspaceDir: resolveAgentWorkspaceDirMock } =
+    await import("../../agents/agent-scope.js"));
   ({ resolveDefaultModel: resolveDefaultModelMock } =
     await import("./directive-handling.defaults.js"));
   ({ resolveModelRefFromString: resolveModelRefFromStringMock } =
@@ -134,19 +139,21 @@ function readFastPathSessionEntry(storePath: string, sessionKey: string): Sessio
 }
 
 describe("getReplyFromConfig fast test bootstrap", () => {
-  const tempDirs = createSuiteTempRootTracker({ prefix: "openclaw-fast-reply-store-" });
+  let state: OpenClawTestState;
   let isolatedStorePath: string;
 
   beforeAll(async () => {
-    await tempDirs.setup();
     await loadGetReplyRuntimeForTest();
   });
 
-  afterAll(() => tempDirs.cleanup());
-
   beforeEach(async () => {
-    isolatedStorePath = path.join(await tempDirs.make(), "sessions.json");
-    vi.stubEnv("OPENCLAW_TEST_FAST", "1");
+    state = await createOpenClawTestState({
+      label: "fast-reply",
+      env: { OPENCLAW_TEST_FAST: "1" },
+    });
+    isolatedStorePath = path.join(state.sessionsDir("main"), "sessions.json");
+    const sqliteTarget = resolveUnsuffixedSqliteTargetFromSessionStorePath(isolatedStorePath);
+    expect(isPathInside(state.root, sqliteTarget.path)).toBe(true);
     cliBackendsTesting.setDepsForTest({
       resolvePluginSetupRegistry: () => ({
         providers: [],
@@ -214,8 +221,8 @@ describe("getReplyFromConfig fast test bootstrap", () => {
     mocks.initSessionState.mockResolvedValue(createGetReplySessionState());
   });
 
-  afterEach(() => {
-    closeOpenClawStateDatabaseForTest();
+  afterEach(async () => {
+    await state.cleanup();
     setActivePluginRegistry(createTestRegistry([]));
     cliBackendsTesting.resetDepsForTest();
     vi.unstubAllEnvs();
@@ -229,17 +236,19 @@ describe("getReplyFromConfig fast test bootstrap", () => {
   });
 
   it("skips getRuntimeConfig, workspace bootstrap, and session bootstrap for marked test configs", async () => {
-    const home = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-fast-reply-"));
     const cfg = markCompleteReplyConfig({
       agents: {
         defaults: {
           model: "anthropic/claude-opus-4-6",
-          workspace: path.join(home, "openclaw"),
+          workspace: state.workspaceDir,
         },
       },
       channels: { telegram: { allowFrom: ["*"] } },
-      session: { store: path.join(home, "sessions.json") },
+      session: { store: isolatedStorePath },
     } as OpenClawConfig);
+
+    // Check the mocked runtime resolver before fast bootstrap can create its workspace.
+    expect(isPathInside(state.root, resolveAgentWorkspaceDirMock(cfg, "main"))).toBe(true);
 
     await expect(getReplyFromConfig(buildGetReplyCtx(), undefined, cfg)).resolves.toEqual({
       text: "ok",
@@ -329,7 +338,10 @@ describe("getReplyFromConfig fast test bootstrap", () => {
   });
 
   it("marks configs through withFastReplyConfig()", async () => {
-    const cfg = withFastReplyConfig({ session: { store: isolatedStorePath } } as OpenClawConfig);
+    const cfg = withFastReplyConfig({
+      agents: { defaults: { workspace: state.workspaceDir } },
+      session: { store: isolatedStorePath },
+    } satisfies OpenClawConfig);
 
     await expect(getReplyFromConfig(buildGetReplyCtx(), undefined, cfg)).resolves.toEqual({
       text: "ok",
@@ -340,8 +352,7 @@ describe("getReplyFromConfig fast test bootstrap", () => {
   });
 
   it("clears stale ack-only heartbeat pending delivery before running heartbeat", async () => {
-    const home = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-heartbeat-pending-clear-"));
-    const storePath = path.join(home, "sessions.json");
+    const storePath = isolatedStorePath;
     const sessionKey = "agent:main:telegram:123";
     await seedFastPathSessionStore(storePath, {
       [sessionKey]: {
@@ -359,7 +370,7 @@ describe("getReplyFromConfig fast test bootstrap", () => {
       agents: {
         defaults: {
           model: "openai/gpt-5.5",
-          workspace: home,
+          workspace: state.workspaceDir,
           heartbeat: {},
         },
       },
@@ -375,8 +386,7 @@ describe("getReplyFromConfig fast test bootstrap", () => {
   });
 
   it("clears short heartbeat pending delivery under the fixed ack policy", async () => {
-    const home = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-heartbeat-pending-replay-"));
-    const storePath = path.join(home, "sessions.json");
+    const storePath = isolatedStorePath;
     const sessionKey = "agent:main:telegram:123";
     await seedFastPathSessionStore(storePath, {
       [sessionKey]: {
@@ -393,7 +403,7 @@ describe("getReplyFromConfig fast test bootstrap", () => {
       agents: {
         defaults: {
           model: "openai/gpt-5.5",
-          workspace: home,
+          workspace: state.workspaceDir,
           heartbeat: {},
         },
       },
@@ -409,8 +419,7 @@ describe("getReplyFromConfig fast test bootstrap", () => {
   });
 
   it("does not replay stale heartbeat pending delivery", async () => {
-    const home = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-heartbeat-pending-suppress-"));
-    const storePath = path.join(home, "sessions.json");
+    const storePath = isolatedStorePath;
     const sessionKey = "agent:main:telegram:123";
     await seedFastPathSessionStore(storePath, {
       [sessionKey]: {
@@ -427,7 +436,7 @@ describe("getReplyFromConfig fast test bootstrap", () => {
       agents: {
         defaults: {
           model: "openai/gpt-5.5",
-          workspace: home,
+          workspace: state.workspaceDir,
           heartbeat: {},
         },
       },
@@ -448,16 +457,15 @@ describe("getReplyFromConfig fast test bootstrap", () => {
   });
 
   it("handles native /status before workspace bootstrap", async () => {
-    const home = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-native-status-fast-"));
     const targetSessionKey = "agent:main:telegram:123";
     const cfg = markCompleteReplyConfig({
       agents: {
         defaults: {
           model: "openai/gpt-5.5",
-          workspace: path.join(home, "workspace"),
+          workspace: state.workspaceDir,
         },
       },
-      session: { store: path.join(home, "sessions.json") },
+      session: { store: isolatedStorePath },
     } as OpenClawConfig);
     vi.mocked(resolveDefaultModelMock).mockReturnValueOnce({
       defaultProvider: "openai",
@@ -489,11 +497,11 @@ describe("getReplyFromConfig fast test bootstrap", () => {
       expect.objectContaining({
         config: cfg,
         agentId: "main",
-        agentDir: expect.any(String),
+        agentDir: state.agentDir("main"),
       }),
     );
     expect(mocks.loadModelCatalog.mock.calls[0]?.[0]).toMatchObject({
-      workspaceDir: "/tmp/workspace",
+      workspaceDir: state.workspaceDir,
     });
     expect(mocks.ensureAgentWorkspace).not.toHaveBeenCalled();
     expect(mocks.initSessionState).not.toHaveBeenCalled();
@@ -502,13 +510,12 @@ describe("getReplyFromConfig fast test bootstrap", () => {
   });
 
   it("uses configured agent thinking defaults for native /status", async () => {
-    const home = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-native-status-agent-think-"));
     const targetSessionKey = "agent:main:telegram:123";
     const cfg = markCompleteReplyConfig({
       agents: {
         defaults: {
           model: "openai/gpt-5.5",
-          workspace: path.join(home, "workspace"),
+          workspace: state.workspaceDir,
           thinkingDefault: "low",
         },
         list: [
@@ -518,7 +525,7 @@ describe("getReplyFromConfig fast test bootstrap", () => {
           },
         ],
       },
-      session: { store: path.join(home, "sessions.json") },
+      session: { store: isolatedStorePath },
     } as OpenClawConfig);
     vi.mocked(resolveDefaultModelMock).mockReturnValueOnce({
       defaultProvider: "openai",
@@ -549,8 +556,8 @@ describe("getReplyFromConfig fast test bootstrap", () => {
     expect(mocks.loadModelCatalog).toHaveBeenCalledExactlyOnceWith({
       config: cfg,
       agentId: "main",
-      agentDir: "/tmp/agent",
-      workspaceDir: "/tmp/workspace",
+      agentDir: state.agentDir("main"),
+      workspaceDir: state.workspaceDir,
       readOnly: true,
     });
     expect(mocks.ensureAgentWorkspace).not.toHaveBeenCalled();
@@ -560,8 +567,7 @@ describe("getReplyFromConfig fast test bootstrap", () => {
   });
 
   it("uses the target session thinking override for native /status", async () => {
-    const home = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-native-status-think-"));
-    const storePath = path.join(home, "sessions.json");
+    const storePath = isolatedStorePath;
     const targetSessionKey = "agent:main:telegram:123";
     await seedFastPathSessionStore(storePath, {
       [targetSessionKey]: {
@@ -574,7 +580,7 @@ describe("getReplyFromConfig fast test bootstrap", () => {
       agents: {
         defaults: {
           model: "openai/gpt-5.5",
-          workspace: path.join(home, "workspace"),
+          workspace: state.workspaceDir,
         },
       },
       session: { store: storePath },
@@ -609,8 +615,8 @@ describe("getReplyFromConfig fast test bootstrap", () => {
     expect(mocks.loadModelCatalog).toHaveBeenCalledExactlyOnceWith({
       config: cfg,
       agentId: "main",
-      agentDir: "/tmp/agent",
-      workspaceDir: "/tmp/workspace",
+      agentDir: state.agentDir("main"),
+      workspaceDir: state.workspaceDir,
       readOnly: true,
     });
     expect(mocks.ensureAgentWorkspace).not.toHaveBeenCalled();
@@ -620,17 +626,15 @@ describe("getReplyFromConfig fast test bootstrap", () => {
   });
 
   it("handles native slash directives before workspace bootstrap", async () => {
-    const home = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-native-slash-fast-"));
     const targetSessionKey = "agent:main:telegram:123";
-    vi.stubEnv("OPENCLAW_STATE_DIR", path.join(home, "state"));
     const cfg = markCompleteReplyConfig({
       agents: {
         defaults: {
           model: "anthropic/claude-opus-4-6",
-          workspace: path.join(home, "workspace"),
+          workspace: state.workspaceDir,
         },
       },
-      session: { store: path.join(home, "sessions.json") },
+      session: { store: isolatedStorePath },
     } as OpenClawConfig);
     mocks.resolveReplyDirectives.mockResolvedValueOnce({
       kind: "reply",
@@ -676,18 +680,17 @@ describe("getReplyFromConfig fast test bootstrap", () => {
     );
     const directiveParams = requireDirectiveParams();
     expect(directiveParams.sessionKey).toBe(targetSessionKey);
-    expect(directiveParams.workspaceDir).toBe("/tmp/workspace");
+    expect(directiveParams.workspaceDir).toBe(state.workspaceDir);
   });
 
   it("continues native slash goal starts with the rewritten command-safe prompt", async () => {
-    const home = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-native-goal-fast-"));
     const targetSessionKey = "agent:main:telegram:123";
-    const storePath = path.join(home, "sessions.json");
+    const storePath = isolatedStorePath;
     const cfg = markCompleteReplyConfig({
       agents: {
         defaults: {
           model: "anthropic/claude-opus-4-6",
-          workspace: path.join(home, "workspace"),
+          workspace: state.workspaceDir,
         },
       },
       session: { store: storePath },
@@ -804,8 +807,7 @@ describe("getReplyFromConfig fast test bootstrap", () => {
   });
 
   it("preserves usage footer mode during fast reset bootstrap", async () => {
-    const home = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-fast-reset-usage-"));
-    const storePath = path.join(home, "sessions.json");
+    const storePath = isolatedStorePath;
     const sessionKey = "agent:main:telegram:123";
     await seedFastPathSessionStore(storePath, {
       [sessionKey]: {
@@ -825,7 +827,7 @@ describe("getReplyFromConfig fast test bootstrap", () => {
       cfg: { session: { store: storePath } } as OpenClawConfig,
       agentId: "main",
       commandAuthorized: true,
-      workspaceDir: home,
+      workspaceDir: state.workspaceDir,
     });
 
     expect(result.resetTriggered).toBe(true);
@@ -875,8 +877,7 @@ describe("getReplyFromConfig fast test bootstrap", () => {
   });
 
   it("preserves node provenance and lineage during fast reset bootstrap", async () => {
-    const home = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-fast-reset-lineage-"));
-    const storePath = path.join(home, "sessions.json");
+    const storePath = isolatedStorePath;
     const sessionKey = "agent:main:telegram:lineage";
     const lineage = {
       spawnedBy: "agent:main:main",
@@ -910,7 +911,7 @@ describe("getReplyFromConfig fast test bootstrap", () => {
       cfg: { session: { store: storePath } } as OpenClawConfig,
       agentId: "main",
       commandAuthorized: true,
-      workspaceDir: home,
+      workspaceDir: state.workspaceDir,
     });
 
     expect(result.sessionEntry).toMatchObject({
@@ -920,8 +921,7 @@ describe("getReplyFromConfig fast test bootstrap", () => {
   });
 
   it("rejects a fast reset bootstrap for a model-locked session", async () => {
-    const home = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-fast-reset-locked-"));
-    const storePath = path.join(home, "sessions.json");
+    const storePath = isolatedStorePath;
     const sessionKey = "agent:main:telegram:123";
     await seedFastPathSessionStore(storePath, {
       [sessionKey]: {
@@ -943,7 +943,7 @@ describe("getReplyFromConfig fast test bootstrap", () => {
         cfg: { session: { store: storePath } } as OpenClawConfig,
         agentId: "main",
         commandAuthorized: true,
-        workspaceDir: home,
+        workspaceDir: state.workspaceDir,
       }),
     ).toThrow(MODEL_SELECTION_LOCKED_RESET_MESSAGE);
     expect(readFastPathSessionEntry(storePath, sessionKey)).toMatchObject({
@@ -954,8 +954,7 @@ describe("getReplyFromConfig fast test bootstrap", () => {
   });
 
   it("captures the initial SQLite session entry during fast bootstrap", async () => {
-    const home = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-fast-initial-entry-"));
-    const storePath = path.join(home, "sessions.json");
+    const storePath = isolatedStorePath;
     const sessionKey = "agent:main:telegram:123";
     await seedFastPathSessionStore(storePath, {
       [sessionKey]: {
@@ -975,7 +974,7 @@ describe("getReplyFromConfig fast test bootstrap", () => {
       cfg: { session: { store: storePath } } as OpenClawConfig,
       agentId: "main",
       commandAuthorized: true,
-      workspaceDir: home,
+      workspaceDir: state.workspaceDir,
     });
 
     expect(result.initialSessionEntry?.sessionId).toBe("existing-fast-initial");
@@ -1025,8 +1024,7 @@ describe("getReplyFromConfig fast test bootstrap", () => {
   });
 
   it("keeps the existing session for /reset newline soft during fast bootstrap", async () => {
-    const home = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-fast-reset-newline-soft-"));
-    const storePath = path.join(home, "sessions.json");
+    const storePath = isolatedStorePath;
     const sessionKey = "agent:main:telegram:123";
     await seedFastPathSessionStore(storePath, {
       [sessionKey]: {
@@ -1045,7 +1043,7 @@ describe("getReplyFromConfig fast test bootstrap", () => {
       cfg: { session: { store: storePath } } as OpenClawConfig,
       agentId: "main",
       commandAuthorized: true,
-      workspaceDir: home,
+      workspaceDir: state.workspaceDir,
     });
 
     expect(result.resetTriggered).toBe(false);
@@ -1054,8 +1052,7 @@ describe("getReplyFromConfig fast test bootstrap", () => {
   });
 
   it("keeps the existing session for /reset: soft during fast bootstrap", async () => {
-    const home = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-fast-reset-colon-soft-"));
-    const storePath = path.join(home, "sessions.json");
+    const storePath = isolatedStorePath;
     const sessionKey = "agent:main:telegram:123";
     await seedFastPathSessionStore(storePath, {
       [sessionKey]: {
@@ -1074,7 +1071,7 @@ describe("getReplyFromConfig fast test bootstrap", () => {
       cfg: { session: { store: storePath } } as OpenClawConfig,
       agentId: "main",
       commandAuthorized: true,
-      workspaceDir: home,
+      workspaceDir: state.workspaceDir,
     });
 
     expect(result.resetTriggered).toBe(false);

--- a/src/auto-reply/reply/get-reply.message-hooks.test.ts
+++ b/src/auto-reply/reply/get-reply.message-hooks.test.ts
@@ -1,9 +1,13 @@
 // Tests get-reply message hooks before and after agent execution.
+import path from "node:path";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { resolveUnsuffixedSqliteTargetFromSessionStorePath } from "../../config/sessions/session-sqlite-target.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { logVerbose } from "../../globals.js";
+import { isPathInside } from "../../infra/path-guards.js";
 import type { ApplyMediaUnderstandingResult } from "../../media-understanding/apply.js";
 import { AGENT_HARNESS_SESSION_KEY_RESERVED_MESSAGE } from "../../sessions/agent-harness-session-key.js";
+import { withOpenClawTestState } from "../../test-utils/openclaw-test-state.js";
 import type { MsgContext } from "../templating.js";
 import { withFastReplyConfig } from "./get-reply-fast-path.test-support.js";
 import {
@@ -38,30 +42,24 @@ vi.mock("../../hooks/internal-hooks.js", () => ({
   createInternalHookEvent: mocks.createInternalHookEvent,
   triggerInternalHook: mocks.triggerInternalHook,
 }));
-vi.mock("../../link-understanding/apply.js", () => ({
-  applyLinkUnderstanding: mocks.applyLinkUnderstanding,
-}));
 vi.mock("../../link-understanding/apply.runtime.js", () => ({
   applyLinkUnderstanding: mocks.applyLinkUnderstanding,
-}));
-vi.mock("../../media-understanding/apply.js", () => ({
-  applyMediaUnderstanding: mocks.applyMediaUnderstanding,
 }));
 vi.mock("../../media-understanding/apply.runtime.js", () => ({
   applyMediaUnderstanding: mocks.applyMediaUnderstanding,
 }));
-vi.mock("./commands-core.js", () => ({
-  emitResetCommandHooks: vi.fn(async () => undefined),
-}));
 registerGetReplyRuntimeOverrides(mocks);
 
 let getReplyFromConfig: typeof import("./get-reply.js").getReplyFromConfig;
+let resolveAgentWorkspaceDirMock: typeof import("../../agents/agent-scope.js").resolveAgentWorkspaceDir;
 let resolveDefaultModelMock: typeof import("./directive-handling.defaults.js").resolveDefaultModel;
 let runPreparedReplyMock: typeof import("./get-reply-run.js").runPreparedReply;
 let stageSandboxMediaMock: typeof import("./stage-sandbox-media.runtime.js").stageSandboxMedia;
 
 async function loadGetReplyRuntimeForTest() {
   ({ getReplyFromConfig } = await loadGetReplyModuleForTest({ cacheKey: import.meta.url }));
+  ({ resolveAgentWorkspaceDir: resolveAgentWorkspaceDirMock } =
+    await import("../../agents/agent-scope.js"));
   ({ resolveDefaultModel: resolveDefaultModelMock } =
     await import("./directive-handling.defaults.js"));
   ({ runPreparedReply: runPreparedReplyMock } = await import("./get-reply-run.js"));
@@ -841,66 +839,68 @@ describe("getReplyFromConfig message hooks", () => {
   });
 
   it("stages remaining remote iMessage media in a mixed staged context", async () => {
-    const order: string[] = [];
-    const alreadyStagedPath = "/tmp/already-staged.jpg";
-    const remotePath = "/Users/demo/Library/Messages/Attachments/ab/cd/photo.jpg";
-    const stagedPath = "/tmp/openclaw-remote-cache/photo.jpg";
-    vi.mocked(stageSandboxMediaMock).mockImplementationOnce(async (params) => {
-      order.push("stage");
-      const stagedFacts = [
-        { path: alreadyStagedPath, contentType: "image/jpeg", workspaceDir: "/tmp" },
-        { path: stagedPath, contentType: "image/jpeg", workspaceDir: "/tmp" },
-      ];
-      params.ctx.media = stagedFacts;
-      params.sessionCtx.media = stagedFacts;
-      return { staged: new Map([[1, stagedPath]]) };
-    });
-    mocks.applyMediaUnderstanding.mockImplementationOnce(async (...args: unknown[]) => {
-      order.push("understand");
-      const { ctx } = args[0] as { ctx: MsgContext };
-      expect(ctx.media).toEqual([
-        { path: alreadyStagedPath, contentType: "image/jpeg", workspaceDir: "/tmp" },
-        { path: stagedPath, contentType: "image/jpeg", workspaceDir: "/tmp" },
-      ]);
-    });
+    await withOpenClawTestState({ label: "reply-message-hooks-mixed-media" }, async (state) => {
+      const order: string[] = [];
+      const alreadyStagedPath = "/tmp/already-staged.jpg";
+      const remotePath = "/Users/demo/Library/Messages/Attachments/ab/cd/photo.jpg";
+      const stagedPath = "/tmp/openclaw-remote-cache/photo.jpg";
+      vi.mocked(stageSandboxMediaMock).mockImplementationOnce(async (params) => {
+        order.push("stage");
+        const stagedFacts = [
+          { path: alreadyStagedPath, contentType: "image/jpeg", workspaceDir: "/tmp" },
+          { path: stagedPath, contentType: "image/jpeg", workspaceDir: "/tmp" },
+        ];
+        params.ctx.media = stagedFacts;
+        params.sessionCtx.media = stagedFacts;
+        return { staged: new Map([[1, stagedPath]]) };
+      });
+      mocks.applyMediaUnderstanding.mockImplementationOnce(async (...args: unknown[]) => {
+        order.push("understand");
+        const { ctx } = args[0] as { ctx: MsgContext };
+        expect(ctx.media).toEqual([
+          { path: alreadyStagedPath, contentType: "image/jpeg", workspaceDir: "/tmp" },
+          { path: stagedPath, contentType: "image/jpeg", workspaceDir: "/tmp" },
+        ]);
+      });
 
-    await getReplyFromConfig(
-      buildCtx({
-        Provider: "imessage",
-        Surface: "imessage",
-        OriginatingChannel: "imessage",
-        OriginatingTo: "imessage:chat:abc",
-        ChatType: "direct",
-        Body: "please describe this",
-        BodyForAgent: "please describe this",
-        RawBody: "please describe this",
-        CommandBody: "please describe this",
-        BodyForCommands: "please describe this",
-        SessionKey: "agent:main:imessage:direct:user",
-        From: "imessage:user",
-        To: "imessage:chat:abc",
-        media: [
-          {
-            path: alreadyStagedPath,
-            contentType: "image/jpeg",
-            workspaceDir: "/tmp",
-          },
-          { path: remotePath, url: remotePath, contentType: "image/jpeg" },
-        ],
-        MediaRemoteHost: "user@gateway-host",
-      }),
-      undefined,
-      withFastReplyConfig({}),
-    );
+      await getReplyFromConfig(
+        buildCtx({
+          Provider: "imessage",
+          Surface: "imessage",
+          OriginatingChannel: "imessage",
+          OriginatingTo: "imessage:chat:abc",
+          ChatType: "direct",
+          Body: "please describe this",
+          BodyForAgent: "please describe this",
+          RawBody: "please describe this",
+          CommandBody: "please describe this",
+          BodyForCommands: "please describe this",
+          SessionKey: "agent:main:imessage:direct:user",
+          From: "imessage:user",
+          To: "imessage:chat:abc",
+          media: [
+            {
+              path: alreadyStagedPath,
+              contentType: "image/jpeg",
+              workspaceDir: "/tmp",
+            },
+            { path: remotePath, url: remotePath, contentType: "image/jpeg" },
+          ],
+          MediaRemoteHost: "user@gateway-host",
+        }),
+        undefined,
+        withFastReplyConfig({ agents: { defaults: { workspace: state.workspaceDir } } }),
+      );
 
-    expect(order).toEqual(["stage", "understand"]);
-    expect(stageSandboxMediaMock).toHaveBeenCalledTimes(1);
-    expect(stageSandboxMediaMock).toHaveBeenCalledWith(
-      expect.objectContaining({
-        sessionKey: "agent:main:imessage:direct:user",
-        workspaceDir: "/tmp/workspace",
-      }),
-    );
+      expect(order).toEqual(["stage", "understand"]);
+      expect(stageSandboxMediaMock).toHaveBeenCalledTimes(1);
+      expect(stageSandboxMediaMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sessionKey: "agent:main:imessage:direct:user",
+          workspaceDir: state.workspaceDir,
+        }),
+      );
+    });
   });
 
   it("emits only preprocessed when no transcript is produced", async () => {
@@ -922,14 +922,26 @@ describe("getReplyFromConfig message hooks", () => {
   });
 
   it("skips message hooks in fast test mode", async () => {
-    process.env.OPENCLAW_TEST_FAST = "1";
+    await withOpenClawTestState(
+      { label: "reply-message-hooks-fast", env: { OPENCLAW_TEST_FAST: "1" } },
+      async (state) => {
+        const storePath = path.join(state.sessionsDir("main"), "sessions.json");
+        const cfg = withFastReplyConfig({
+          agents: { defaults: { workspace: state.workspaceDir } },
+          session: { store: storePath },
+        });
+        const sqliteTarget = resolveUnsuffixedSqliteTargetFromSessionStorePath(cfg.session.store);
+        expect(isPathInside(state.root, sqliteTarget.path)).toBe(true);
+        expect(isPathInside(state.root, resolveAgentWorkspaceDirMock(cfg, "main"))).toBe(true);
 
-    await getReplyFromConfig(buildCtx(), undefined, withFastReplyConfig({}));
+        await getReplyFromConfig(buildCtx(), undefined, cfg);
 
-    expect(mocks.applyMediaUnderstanding).not.toHaveBeenCalled();
-    expect(mocks.applyLinkUnderstanding).not.toHaveBeenCalled();
-    expect(mocks.createInternalHookEvent).not.toHaveBeenCalled();
-    expect(mocks.triggerInternalHook).not.toHaveBeenCalled();
+        expect(mocks.applyMediaUnderstanding).not.toHaveBeenCalled();
+        expect(mocks.applyLinkUnderstanding).not.toHaveBeenCalled();
+        expect(mocks.createInternalHookEvent).not.toHaveBeenCalled();
+        expect(mocks.triggerInternalHook).not.toHaveBeenCalled();
+      },
+    );
   });
 
   it("skips message hooks when SessionKey is unavailable", async () => {

--- a/src/auto-reply/reply/get-reply.test-mocks.ts
+++ b/src/auto-reply/reply/get-reply.test-mocks.ts
@@ -8,8 +8,6 @@ vi.mock("../../agents/agent-scope.js", async () => {
   );
   return {
     ...actual,
-    resolveAgentDir: vi.fn(() => "/tmp/agent"),
-    resolveAgentWorkspaceDir: vi.fn(() => "/tmp/workspace"),
     resolveSessionAgentId: vi.fn(() => "main"),
     resolveAgentSkillsFilter: vi.fn(() => undefined),
   };

--- a/src/auto-reply/reply/get-reply.turn-model-selection-differential.test.ts
+++ b/src/auto-reply/reply/get-reply.turn-model-selection-differential.test.ts
@@ -1,10 +1,15 @@
 import path from "node:path";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
-import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
 import type { ModelRef } from "../../agents/model-ref-shared.js";
 import { replaceSessionEntrySync } from "../../config/sessions/session-accessor.js";
+import { resolveUnsuffixedSqliteTargetFromSessionStorePath } from "../../config/sessions/session-sqlite-target.js";
 import type { SessionEntry } from "../../config/sessions/types.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { isPathInside } from "../../infra/path-guards.js";
+import {
+  createOpenClawTestState,
+  type OpenClawTestState,
+} from "../../test-utils/openclaw-test-state.js";
 import {
   TURN_MODEL_CHANNEL_REF,
   TURN_MODEL_DEFAULT_REF,
@@ -41,9 +46,10 @@ const mocks = vi.hoisted(() => ({
 registerGetReplyBaselineBypass();
 registerGetReplyRuntimeOverrides(mocks);
 
-const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+let state: OpenClawTestState;
 
 let getReplyFromConfig: typeof import("./get-reply.js").getReplyFromConfig;
+let resolveAgentWorkspaceDirMock: typeof import("../../agents/agent-scope.js").resolveAgentWorkspaceDir;
 let resolveDefaultModelMock: typeof import("./directive-handling.defaults.js").resolveDefaultModel;
 let resolveChannelModelOverrideMock: typeof import("../../channels/model-overrides.js").resolveChannelModelOverride;
 let resolveModelRefFromStringMock: typeof import("../../agents/model-selection.js").resolveModelRefFromString;
@@ -51,6 +57,7 @@ let runPreparedReplyMock: typeof import("./get-reply-run.js").runPreparedReply;
 
 function createConfig(params: {
   storePath: string;
+  workspaceDir: string;
   modelByChannel?: Record<string, Record<string, string>>;
 }): OpenClawConfig {
   return markCompleteReplyConfig({
@@ -59,6 +66,7 @@ function createConfig(params: {
       defaults: {
         model: { primary: turnModelRefLabel(TURN_MODEL_DEFAULT_REF) },
         modelPolicy: { allow: ["*/*"] },
+        workspace: params.workspaceDir,
       },
     },
     channels: params.modelByChannel ? { modelByChannel: params.modelByChannel } : undefined,
@@ -70,6 +78,8 @@ async function seedFixtureStore(
   sessionKey: string,
   fixture: Pick<TurnModelDifferentialFixture, "child" | "parent">,
 ): Promise<Record<string, SessionEntry>> {
+  const sqliteTarget = resolveUnsuffixedSqliteTargetFromSessionStorePath(storePath);
+  expect(isPathInside(state.root, sqliteTarget.path)).toBe(true);
   const store: Record<string, SessionEntry> = { [sessionKey]: fixture.child };
   replaceSessionEntrySync({ storePath, sessionKey }, fixture.child);
   if (fixture.parent) {
@@ -104,6 +114,8 @@ async function observeReplySelection(params: {
     }),
   );
   vi.mocked(runPreparedReplyMock).mockClear();
+  // Use the same module as getReply so a shared resolver override cannot escape this fixture.
+  expect(isPathInside(state.root, resolveAgentWorkspaceDirMock(cfg, "main"))).toBe(true);
   await getReplyFromConfig(
     buildGetReplyCtx({ SessionKey: sessionKey, ...fixture.ctx }),
     fixture.heartbeat
@@ -126,6 +138,8 @@ async function observeReplySelection(params: {
 
 beforeAll(async () => {
   ({ getReplyFromConfig } = await loadGetReplyModuleForTest({ cacheKey: import.meta.url }));
+  ({ resolveAgentWorkspaceDir: resolveAgentWorkspaceDirMock } =
+    await import("../../agents/agent-scope.js"));
   ({ resolveDefaultModel: resolveDefaultModelMock } =
     await import("./directive-handling.defaults.js"));
   ({ resolveChannelModelOverride: resolveChannelModelOverrideMock } =
@@ -136,7 +150,10 @@ beforeAll(async () => {
 });
 
 beforeEach(async () => {
-  vi.stubEnv("OPENCLAW_TEST_FAST", "1");
+  state = await createOpenClawTestState({
+    label: "turn-model-reply",
+    env: { OPENCLAW_TEST_FAST: "1" },
+  });
   const actualChannelModel = await vi.importActual<
     typeof import("../../channels/model-overrides.js")
   >("../../channels/model-overrides.js");
@@ -189,8 +206,8 @@ beforeEach(async () => {
   vi.mocked(runPreparedReplyMock).mockResolvedValue({ text: "ok" });
 });
 
-afterEach(() => {
-  vi.unstubAllEnvs();
+afterEach(async () => {
+  await state.cleanup();
 });
 
 describe("getReplyFromConfig channel model input boundary", () => {
@@ -243,7 +260,7 @@ describe("getReplyFromConfig channel model input boundary", () => {
   ];
 
   it.each(matrix)("selects $name", async (testCase) => {
-    const storePath = path.join(tempDirs.make("turn-model-reply-matrix-"), "sessions.json");
+    const storePath = path.join(state.sessionsDir("main"), "sessions.json");
     const sessionKey = "agent:main:telegram:group:room";
     const child = createTurnModelEntry({
       channel: testCase.omitPersistedChannel ? undefined : "discord",
@@ -280,7 +297,11 @@ describe("getReplyFromConfig channel model input boundary", () => {
       expected: {} as Record<TurnModelSelectionPath, TurnModelSelectionVerdict>,
     };
     const sessionStore = await seedFixtureStore(storePath, sessionKey, fixture);
-    const cfg = createConfig({ storePath, modelByChannel: fixture.modelByChannel });
+    const cfg = createConfig({
+      storePath,
+      workspaceDir: state.workspaceDir,
+      modelByChannel: fixture.modelByChannel,
+    });
     await expect(
       observeReplySelection({ fixture, cfg, sessionKey, sessionStore }),
     ).resolves.toEqual(turnModelVerdict(testCase.expected));
@@ -289,10 +310,14 @@ describe("getReplyFromConfig channel model input boundary", () => {
 
 describe("turn model selection reply-path differential", () => {
   it.each(TURN_MODEL_DIFFERENTIAL_FIXTURES)("pins observed $name behavior", async (fixture) => {
-    const storePath = path.join(tempDirs.make("turn-model-differential-"), "sessions.json");
+    const storePath = path.join(state.sessionsDir("main"), "sessions.json");
     const sessionKey = "agent:main:telegram:group:selection";
     const sessionStore = await seedFixtureStore(storePath, sessionKey, fixture);
-    const cfg = createConfig({ storePath, modelByChannel: fixture.modelByChannel });
+    const cfg = createConfig({
+      storePath,
+      workspaceDir: state.workspaceDir,
+      modelByChannel: fixture.modelByChannel,
+    });
 
     await expect(
       observeReplySelection({ fixture, cfg, sessionKey, sessionStore }),


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

This is a same-repository branch so maintainers can update it directly.

</details>

## What Problem This Solves

Resolves a problem where developers running auto-reply tests could read or create shared temporary session and workspace state instead of using the test's owned fixtures. This made the affected tests depend on other runs and could contaminate shared temporary directories.

## Why This Change Was Made

Remove the hardcoded agent/workspace resolver overrides and let the tests exercise canonical path resolution. Real-I/O cases now use the existing owned-state fixture and its cleanup lifecycle, while keeping fast mode and real SQLite accessors intact.

Containment assertions check the actual resolved workspace and SQLite destination before reply execution. Obsolete full-initializer data and superseded direct-module mocks are removed rather than maintaining parallel mock paths. Production behavior, configuration, schemas, dependencies, timeouts, and cache policies are unchanged by this PR.

The earlier conflict repair incorporates #132960 (shared-temporary-state test isolation). Its block-streaming safety outcome is preserved through the canonical OpenClaw test-state helper instead of maintaining a second temporary-directory lifecycle. The shared resolver overrides and the remaining real-I/O fixtures still needed this repair.

## User Impact

No user-facing runtime change from this PR. The affected reply tests use private, lifecycle-owned state while retaining their callback, final-payload, model-selection, native-status, and full/prepared-runtime expectations.

## Evidence

Current head: `9ba6eee2c80ddd87974a7a63103815198ca03e98`, mechanically rebased onto `be5e79ca4713c33a11ccd56b2d728c19f0779f3d`. All five changed file blobs and the complete patch are byte-identical to the previously reviewed repair at `4acf1fe5d37f32f45714040023376f8452bc23d4`.

### Fresh current-head proof

- **119 passed, 0 failed, 0 skipped across 9 files** in 67.717 seconds: the original 91-test reply neighborhood, plus 15 existing Code Mode recovery cases and 13 existing client-tool cases. These were executed on this head, not borrowed from another PR's proof.
- Node 24.15.0, pinned pnpm 12.1.0, process-lifetime private state, and a clean-whitelist environment. The inherited recovery tests use fake tools/in-memory state; captured skill content avoids fixture-file reads, and the real guest worker uses installed assets and its normal cleanup.
- Focused core typecheck passed in 9.118 seconds. Formatting of all five changed files and `git diff --check` passed. Source identity remained unchanged throughout proof.
- Production LOC: **+0/-0**. Tests and test support: **+254/-301 (net -47)**. The native classifier treats `get-reply.test-mocks.ts` as runtime by filename, but it is test support; its actual consumer behavior is covered.

### Retained proof and CI recovery

- Historical guarded RED proof is retained from the original pre-repair base: the block fixture failed its SQLite containment assertion and the shared fast-path fixture failed its actual workspace-resolver containment assertion, both before reply execution. Both then passed after the ownership repair; this does not claim the subsequently repaired upstream block fixture still fails.
- The complete classified `core` and `coreTests` aggregate passed on `4acf1fe5d37f32f45714040023376f8452bc23d4` in 451.498 seconds. That full aggregate remains prior-head evidence; the current head has the fresh focused proof above and requires new exact-head CI for integration.
- The clean isolated Codex P0 review applies to the exact unchanged patch, SHA256 `35c56e886b43c4f19e0150f8dcf635b40c874b1a4fd439197cc5f02ea2b73d45`. No semantic edits were made during this rebase.
- [CI run 33298729154, attempt 1](https://github.com/openclaw/openclaw/actions/runs/33298729154) failed while building the old head's merge with newer `main`. The upstream metadata extraction had moved `getPluginToolSideEffectOwnerKey` but missed the import in `code-mode-reconciliation.ts`; build, lint, type, and package-boundary jobs failed with the same missing export. All failed-job logs and original proof are retained.
- The canonical repair is #133155 (Code Mode metadata import), by @edenfunf, merged as `be5e79ca4713c33a11ccd56b2d728c19f0779f3d`. This PR inherits that landed fix rather than duplicating it. The rebase was triggered by failed merge-ref CI, not merely moving `main`; the old immutable failed run was not retried.
- The latest completed ClawSweeper review found no introduced code or security defect. Its remaining rank-up action—confirm current-head required checks—remains a landing gate, along with normal maintainer handling. No duplicate clean review was requested merely for the mechanical rebase.

Executed current-head behavior command:

```sh
node --import ./scripts/tsx.mjs scripts/test-projects-serial.mts \
  src/auto-reply/reply.block-streaming.test.ts \
  src/auto-reply/reply/get-reply.fast-path.test.ts \
  src/auto-reply/reply/get-reply.turn-model-selection-differential.test.ts \
  src/auto-reply/reply/get-reply.message-hooks.test.ts \
  src/auto-reply/reply/get-reply.auto-fallback.test.ts \
  src/auto-reply/reply/get-reply.reset-hooks-fallback.test.ts \
  src/auto-reply/reply/get-reply.config-override.test.ts \
  src/agents/embedded-agent-runner/run/code-mode-reconciliation.test.ts \
  src/agents/embedded-agent-runner/run/attempt-client-tools.test.ts \
  -- --passWithNoTests=false --reporter=default --reporter=json
```

Executed current-head typecheck:

```sh
node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental \
  --tsBuildInfoFile .artifacts/tsgo-cache/core.tsbuildinfo
```

This is test-only proof; no live provider, channel, or UI verification is claimed. AI-assisted implementation and review.
