### PR TITLE
refactor(agents): reuse usage predicate

### DIFF
--- a/src/agents/embedded-agent-runner/usage-accumulator.ts
+++ b/src/agents/embedded-agent-runner/usage-accumulator.ts
@@ -1,6 +1,7 @@
 /**
  * Accumulates and normalizes per-call token usage across embedded runs.
  */
+import { hasNonzeroUsage } from "../usage.js";
 import type { NormalizedUsage } from "../usage.js";
 
 export type UsageAccumulator = {
@@ -37,29 +38,11 @@ export const createUsageAccumulator = (): UsageAccumulator => ({
   assistantTurns: 0,
 });
 
-type MaybeUsage = NormalizedUsage | undefined;
-
-const hasUsageValues = (usage: MaybeUsage): usage is NormalizedUsage => {
-  if (!usage) {
-    return false;
-  }
-  return (
-    [
-      usage.input,
-      usage.output,
-      usage.cacheRead,
-      usage.cacheWrite,
-      usage.contextUsage?.state === "available" ? usage.contextUsage.promptTokens : undefined,
-      usage.contextUsage?.state === "available" ? usage.contextUsage.totalTokens : undefined,
-      usage.reasoningTokens,
-      usage.total,
-    ].some((value) => typeof value === "number" && Number.isFinite(value) && value > 0) ||
-    usage.contextUsage?.state === "unavailable"
-  );
-};
-
-export const mergeUsageIntoAccumulator = (target: UsageAccumulator, usage: MaybeUsage) => {
-  if (!hasUsageValues(usage)) {
+export const mergeUsageIntoAccumulator = (
+  target: UsageAccumulator,
+  usage: NormalizedUsage | undefined,
+) => {
+  if (!hasNonzeroUsage(usage)) {
     return;
   }
   const callTotal =


### PR DESCRIPTION
## What Problem This Solves

Embedded-run usage accumulation maintained a local copy of the canonical normalized-usage presence predicate. The two copies had already required the same context-usage update, leaving token-accounting policy vulnerable to future drift.

## Why This Change Was Made

`mergeUsageIntoAccumulator` now calls `hasNonzeroUsage` from the usage normalization owner. The duplicate predicate and its one-use type alias are removed.

This is the best fix because the shared predicate preserves the exact existing contract: any finite positive usage bucket is meaningful, and an explicit unavailable context snapshot remains meaningful without adding token deltas. The adjacent subscription projection retains different derived-total behavior and is intentionally unchanged.

## User Impact

No user-visible behavior changes. Embedded runs retain the same billing accumulation, zero-only filtering, and unavailable-context handling through one canonical policy owner.

## Evidence

- Production LOC: +6/-23 (net -17). Tests: +0/-0.
- Current `main` source and history confirm the removed predicate and `hasNonzeroUsage` are semantically identical; the July context-usage repair changed both copies in parallel.
- Sibling Codex usage accounting was inspected directly. It uses concrete integer buckets and has no equivalent optional unavailable-context sentinel, so this remains OpenClaw-owned normalization policy.
- `node scripts/run-vitest.mjs src/agents/usage.test.ts src/agents/usage.normalization.test.ts src/agents/embedded-agent-runner/usage-accumulator.test.ts src/agents/embedded-agent-runner/run/helpers.test.ts src/agents/embedded-agent-runner/run.attempt-normalization.direct.test.ts`: 101 passed.
- `pnpm exec oxfmt --check src/agents/embedded-agent-runner/usage-accumulator.ts`: passed.
- `pnpm exec oxlint src/agents/embedded-agent-runner/usage-accumulator.ts`: passed.
- `pnpm tsgo:core`: passed.
- `pnpm check:import-cycles`: passed with 0 runtime value cycles.
- `git diff --check origin/main...HEAD`: passed.
- Mandatory local autoreview with `gpt-5.6-sol` at high reasoning: clean, patch correctness confidence 0.98.
- `pnpm build` completed compilation, package bundling, plugin distribution, and CLI bootstrap checks. Runtime postbuild then hit unrelated stale exports because the task worktree's shared `node_modules/@openclaw/ai` resolves the intentionally stale root checkout; hosted exact-head CI remains the clean-build gate.
