### PR TITLE
fix(test): report interrupted shutdown fixtures as failures

### DIFF
--- a/test/fixtures/vitest-fork-shutdown.mjs
+++ b/test/fixtures/vitest-fork-shutdown.mjs
@@ -3,6 +3,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { PassThrough } from "node:stream";
 import { fileURLToPath, pathToFileURL } from "node:url";
+import { signalExitCode } from "../../scripts/lib/managed-child-process.mts";
 import { spawnOwnedVitestProcess } from "../../scripts/lib/vitest-process.mts";
 import { installVitestProcessGroupCleanup } from "../../scripts/vitest-process-group.mts";
 
@@ -11,6 +12,7 @@ const { scenario, setup, fail } = JSON.parse(rawOptions);
 const repo = fileURLToPath(new URL("../../", import.meta.url));
 const events = path.join(root, "events.jsonl");
 const ready = path.join(root, "ready");
+const interrupted = path.join(root, "interrupted");
 const receipt = path.join(root, "receipt.json");
 const profiles = path.join(root, "profiles");
 const preload = path.join(root, "preload.mjs");
@@ -179,7 +181,7 @@ if (process.send) {
       ? []
       : [path.join(repo, setup === "env" ? "test/setup.env.ts" : "test/setup.ts")];
   let runner = path.join(repo, "test/non-isolated-runner.ts");
-  if (scenario === "hung-cleanup") {
+  if (scenario === "hung-cleanup" || scenario === "interrupted") {
     runner = path.join(root, "runner.ts");
     fs.writeFileSync(
       runner,
@@ -190,8 +192,19 @@ export default class extends Runner {
   constructor(config) {
     super(config);
     this.onCleanupWorkerContext(() => {
+      ${scenario === "interrupted" ? `if (!fs.existsSync(${JSON.stringify(receipt)})) return;` : ""}
       fs.writeFileSync(${JSON.stringify(ready)}, "cleanup");
-      return new Promise(() => {});
+      ${
+        scenario === "interrupted"
+          ? `return new Promise((resolve) => {
+        const poll = setInterval(() => {
+          if (!fs.existsSync(${JSON.stringify(interrupted)})) return;
+          clearInterval(poll);
+          resolve();
+        }, 5);
+      });`
+          : "return new Promise(() => {});"
+      }
     });
   }
 }
@@ -289,7 +302,18 @@ it("completes the test before worker shutdown", () => {
     args,
     options: { cwd: root, env, stdio: "pipe" },
   });
-  const detachCleanup = installVitestProcessGroupCleanup({ child, forceSignal: "SIGKILL" });
+  let forwardedSignal;
+  const detachCleanup = installVitestProcessGroupCleanup({
+    child,
+    forceSignal: "SIGKILL",
+    onSignal(signal) {
+      forwardedSignal ??= signal;
+      if (scenario === "interrupted") {
+        // Release cleanup only after the fixture observes the outer signal.
+        fs.writeFileSync(interrupted, forwardedSignal);
+      }
+    },
+  });
   let output = "";
   child.stdout.on("data", (chunk) => {
     output += chunk;
@@ -298,6 +322,10 @@ it("completes the test before worker shutdown", () => {
     output += chunk;
   });
   const { code } = await completion.finally(detachCleanup);
+  // Joining cleanup must not turn parent interruption into successful fixture completion.
+  if (forwardedSignal) {
+    process.exitCode = signalExitCode(forwardedSignal);
+  }
   assert.ok(
     fs.existsSync(receipt),
     `Vitest exited before the fixture test (code ${code}):\n${output}`,

--- a/test/scripts/vitest-fork-shutdown.test.ts
+++ b/test/scripts/vitest-fork-shutdown.test.ts
@@ -1,7 +1,10 @@
 import { execFile } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { promisify } from "node:util";
 import { afterEach, expect, it } from "vitest";
+import { isProcessAlive, waitForFile } from "../helpers/process-wait.js";
 import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
 
 const execFileAsync = promisify(execFile);
@@ -82,5 +85,51 @@ it.each([
     if (scenario === "slow-exit") {
       expect(result.events).toContainEqual({ event: "home-removed" });
     }
+  }
+});
+
+// Windows termination cannot invoke the fixture's POSIX signal handlers.
+it.skipIf(process.platform === "win32").each([
+  { signal: "SIGINT", code: 130 },
+  { signal: "SIGTERM", code: 143 },
+] as const)("rejects forwarded $signal after joining fixture cleanup", async ({ signal, code }) => {
+  const root = tempDirs.make("vitest-fork-shutdown-");
+  const invocation = execFileAsync(
+    process.execPath,
+    [fixture, root, JSON.stringify({ scenario: "interrupted", setup: "shared", fail: false })],
+    { timeout: 20_000, maxBuffer: 2 * 1024 * 1024 },
+  );
+  // Handle early rejection while waiting for readiness; join before afterEach removes the root.
+  const settled = invocation.then(
+    () => undefined,
+    () => undefined,
+  );
+  try {
+    await waitForFile(path.join(root, "ready"), 10_000);
+    const receipt = JSON.parse(fs.readFileSync(path.join(root, "receipt.json"), "utf8"));
+    expect(isProcessAlive(receipt.pid)).toBe(true);
+    expect(fs.existsSync(receipt.home)).toBe(true);
+    expect(fs.readdirSync(path.join(root, "tmp"))).not.toEqual([]);
+
+    expect(invocation.child.kill(signal)).toBe(true);
+    await expect(invocation).rejects.toMatchObject({ code, killed: true, signal: null });
+    const { stdout } = await invocation.catch((error: { stdout: string }) => error);
+    expect(stdout).not.toBe("");
+    expect(JSON.parse(stdout)).toMatchObject({
+      worker: { pid: receipt.pid },
+      workerStopped: true,
+      homeRemoved: true,
+      callerPreserved: true,
+    });
+
+    expect(isProcessAlive(receipt.pid)).toBe(false);
+    expect(fs.existsSync(receipt.home)).toBe(false);
+    expect(fs.readdirSync(path.join(root, "tmp"))).toEqual([]);
+    expect(fs.readFileSync(path.join(root, "home", "caller"), "utf8")).toBe("keep");
+  } finally {
+    if (invocation.child.exitCode === null && invocation.child.signalCode === null) {
+      invocation.child.kill("SIGTERM");
+    }
+    await settled;
   }
 });


### PR DESCRIPTION
Related: [cloud-workspace transfer cleanup #132821](https://github.com/openclaw/openclaw/pull/132821), [native-worker shutdown profiling #132820](https://github.com/openclaw/openclaw/pull/132820), and [custom-worker shutdown synchronization #132824](https://github.com/openclaw/openclaw/pull/132824).

## What Problem This Solves

Resolves a problem where developers running the fork-shutdown suite can receive `Unexpected end of JSON input` instead of a failed subprocess outcome when the fixture is interrupted. The fixture forwards termination and joins cleanup, but previously returned success afterward.

A controlled macOS Node 24.20.0 reproduction confirmed the diagnostic trap: `execFile` destroyed stdout/stderr and successfully sent SIGTERM at its unchanged 20-second timeout; the fixture then exited with code 0 and no signal, allowing the promisified call to resolve empty output. This establishes the failure mode, not the cause of the five historical local failures or a causal connection to the cloud-transfer cleanup.

## Why This Change Was Made

Keep interruption ownership in the fixture: retain the first forwarded signal through the existing cleanup callback and use the existing `signalExitCode` helper only after child, process-group, and output completion. No JSON fallback, new subprocess abstraction, dependency patch, retry, or timeout increase is introduced.

Add readiness-synchronized SIGINT/SIGTERM regressions at the real fixture-process boundary. The new fixture-only cleanup gate releases when the outer signal is actually observed; both regressions require rejection, an intact JSON report, worker death, owned temporary/home cleanup, and preservation of the caller's file. They do not rely on startup sleeps or a second timeout to complete.

## User Impact

No product runtime or configuration changes. Interrupted test fixtures fail as interrupted subprocesses rather than misleading JSON parse errors. The original 12-case test block is byte-for-byte unchanged, including the 20-second deadline, 2 MiB buffer limit, native worker PID/threadId profile checks, and custom-worker stopped-response handshake.

Production/tooling LOC: 0. Tests/test support: +80/-3, net +77.

## Evidence

Validated on macOS with Node 24.20.0 and the repository's already-declared Vitest patches. The initial local install lacked those patches; a normal `pnpm install` corrected the install without changing dependency files or patch definitions.

- Both new regressions failed before the exit-code repair because the promises resolved instead of rejecting. The final gate-based regression retained full reports in this RED run.
- The same regressions passed after the repair with exit codes 130/143, `killed: true`, intact JSON, dead workers, removed owned temporary namespaces/homes, and preserved caller files.
- Final focused proof: 14 shutdown tests (all original 12 plus the 2 regressions) and 38 process-group tests passed, 52 total.
- Replayed the controlled 20-second timeout with monotonic spawn/kill/exit/close receipts. Before: accepted SIGTERM, both pipes destroyed, `killed=true`, exit/close `0/null`, empty output resolved. After: the timeout's `delayedKill` call was observed, accepted SIGTERM, both pipes destroyed, `killed=true`, exit/close `143/null`, and empty output rejected. The owned process group was verified stopped.
- Changed-scope formatting, root test typecheck, script lint, dependency/patch guards, and `git diff --check` passed.
- Independent Codex autoreview passed at its default P0 scope; the fresh pre-commit review also returned scoped-clean with no findings.

```bash
node scripts/run-vitest.mjs test/scripts/vitest-fork-shutdown.test.ts test/scripts/vitest-process-group.test.ts --reporter=verbose
```

```bash
node scripts/check-changed.mjs -- test/scripts/vitest-fork-shutdown.test.ts test/fixtures/vitest-fork-shutdown.mjs
```

```bash
git diff --check
```

The new signal-handler cases are POSIX-only because Windows termination does not invoke these handlers; the original 12 scenarios retain their existing cross-platform coverage. No fresh Windows or Linux run is claimed by the local proof. No screenshots are applicable to this test-only change. Diagnostic artifacts remain local and are not committed.

AI-assisted; code, dependency behavior, regression evidence, and cleanup ownership were reviewed.
