### PR TITLE
perf(web): reuse basic HTML extraction work

### DIFF
--- a/src/agents/tools/web-fetch-utils.ts
+++ b/src/agents/tools/web-fetch-utils.ts
@@ -597,10 +597,6 @@ function htmlFragmentToMarkdown(html: string): { text: string; title?: string } 
   };
 }
 
-function stripTags(value: string): string {
-  return htmlFragmentToMarkdown(value).text;
-}
-
 /** Collapses display whitespace while preserving paragraph breaks. */
 export function normalizeWhitespace(value: string): string {
   return value
@@ -671,7 +667,7 @@ export async function extractBasicHtmlContent(params: {
     const text =
       stripInvisibleUnicode(markdownToText(rendered.text)) ||
       stripInvisibleUnicode(rendered.title ?? "") ||
-      stripInvisibleUnicode(normalizeWhitespace(stripTags(cleanHtml)));
+      stripInvisibleUnicode(rendered.text);
     return text ? { text, title: rendered.title } : null;
   }
   const text = stripInvisibleUnicode(rendered.text) || stripInvisibleUnicode(rendered.title ?? "");

--- a/src/agents/tools/web-fetch-visibility.test.ts
+++ b/src/agents/tools/web-fetch-visibility.test.ts
@@ -5,7 +5,7 @@ import { stripInvisibleUnicode } from "../../infra/unicode-visibility.js";
 import { sanitizeHtml } from "./web-fetch-visibility.js";
 
 describe("sanitizeHtml", () => {
-  it("reuses compiled CSS property matchers across styled elements", async () => {
+  it("reuses compiled visibility matchers across styled elements", async () => {
     const styledElements = 256;
     const html = Array.from(
       { length: styledElements },
@@ -21,13 +21,9 @@ describe("sanitizeHtml", () => {
 
     try {
       const result = await sanitizeHtml(html);
-      const perElementStyleMatchers = regexpConstructor.mock.calls.filter(
-        ([pattern]) => typeof pattern === "string" && pattern.startsWith("(?:^|;)\\s*"),
-      );
-
       expect(result).toContain("Visible 0");
       expect(result).toContain(`Visible ${styledElements - 1}`);
-      expect(perElementStyleMatchers).toHaveLength(0);
+      expect(regexpConstructor).not.toHaveBeenCalled();
     } finally {
       regexpConstructor.mockRestore();
     }

--- a/src/agents/tools/web-fetch-visibility.ts
+++ b/src/agents/tools/web-fetch-visibility.ts
@@ -119,9 +119,9 @@ function isStyleHidden(style: string): boolean {
 }
 
 // The fixed visibility attributes share one grammar; each reader compiles it once per process.
-function createAttributeReader(name: "aria-hidden" | "class" | "hidden" | "style" | "type") {
+function createAttributeReader(attribute: "aria-hidden" | "class" | "hidden" | "style" | "type") {
   const pattern = new RegExp(
-    `(?:^|\\s)${name}(?:\\s*=\\s*(?:"([^"]*)"|'([^']*)'|([^\\s"'=<>\`]+)))?`,
+    `(?:^|\\s)${attribute}(?:\\s*=\\s*(?:"([^"]*)"|'([^']*)'|([^\\s"'=<>\`]+)))?`,
     "i",
   );
   return (attrs: string): string | undefined => {

--- a/src/agents/tools/web-fetch-visibility.ts
+++ b/src/agents/tools/web-fetch-visibility.ts
@@ -118,24 +118,23 @@ function isStyleHidden(style: string): boolean {
   return false;
 }
 
-function readAttribute(attrs: string, name: string): string | undefined {
-  const escapedName = name.replace(/[-/\\^$*+?.()|[\]{}]/g, "\\$&");
-  const unquotedAttributeValue = "[^\\s\"'=<>`]+";
-  const match = attrs.match(
-    new RegExp(
-      `(?:^|\\s)${escapedName}(?:\\s*=\\s*(?:"([^"]*)"|'([^']*)'|(${unquotedAttributeValue})))?`,
-      "i",
-    ),
+// The fixed visibility attributes share one grammar; each reader compiles it once per process.
+function createAttributeReader(name: "aria-hidden" | "class" | "hidden" | "style" | "type") {
+  const pattern = new RegExp(
+    `(?:^|\\s)${name}(?:\\s*=\\s*(?:"([^"]*)"|'([^']*)'|([^\\s"'=<>\`]+)))?`,
+    "i",
   );
-  if (!match) {
-    return undefined;
-  }
-  return match[1] ?? match[2] ?? match[3] ?? "";
+  return (attrs: string): string | undefined => {
+    const match = attrs.match(pattern);
+    return match ? (match[1] ?? match[2] ?? match[3] ?? "") : undefined;
+  };
 }
 
-function hasAttribute(attrs: string, name: string): boolean {
-  return readAttribute(attrs, name) !== undefined;
-}
+const readType = createAttributeReader("type");
+const readAriaHidden = createAttributeReader("aria-hidden");
+const readHidden = createAttributeReader("hidden");
+const readClass = createAttributeReader("class");
+const readStyle = createAttributeReader("style");
 
 function shouldRemoveElement(tagNameRaw: string, attrs: string): boolean {
   const tagName = normalizeLowercaseStringOrEmpty(tagNameRaw);
@@ -144,27 +143,24 @@ function shouldRemoveElement(tagNameRaw: string, attrs: string): boolean {
     return true;
   }
 
-  if (
-    tagName === "input" &&
-    normalizeOptionalLowercaseString(readAttribute(attrs, "type")) === "hidden"
-  ) {
+  if (tagName === "input" && normalizeOptionalLowercaseString(readType(attrs)) === "hidden") {
     return true;
   }
 
-  if (normalizeOptionalLowercaseString(readAttribute(attrs, "aria-hidden")) === "true") {
+  if (normalizeOptionalLowercaseString(readAriaHidden(attrs)) === "true") {
     return true;
   }
 
-  if (hasAttribute(attrs, "hidden")) {
+  if (readHidden(attrs) !== undefined) {
     return true;
   }
 
-  const className = readAttribute(attrs, "class") ?? "";
+  const className = readClass(attrs) ?? "";
   if (hasHiddenClass(className)) {
     return true;
   }
 
-  const style = readAttribute(attrs, "style") ?? "";
+  const style = readStyle(attrs) ?? "";
   if (style && isStyleHidden(style)) {
     return true;
   }


### PR DESCRIPTION
## What Problem This Solves

The basic HTML fallback in `web_fetch` rebuilt the same attribute matchers for every element. Pages with thousands of elements spent avoidable CPU on that work. The plain-text fallback could also parse the same sanitized HTML twice.

This is an AI-assisted, maintainer-requested performance cleanup.

## Why This Change Was Made

Create five private attribute readers once, using one shared grammar, and reuse the already rendered text instead of parsing it again. The attribute names are a closed set; matching flags, precedence, hidden-content policy, malformed-HTML behavior, and extraction fallback order stay unchanged.

Production LOC: +20/-28 (net -8). Tests: +2/-6 (net -4). No dependencies, configuration options, schema changes, or compatibility paths were added.

## User Impact

Basic HTML extraction uses less CPU and allocates fewer temporary matchers. This affects the `raw-html` fallback; it does not change the default Readability path, which remains preferred when available. Extracted content and tool presentation are unchanged.

## Evidence

- Extended the existing sanitizer allocation regression instead of adding another test. It fails against the pre-change implementation with 1,024 dynamic RegExp constructions for 256 styled elements, then passes with zero per-call constructions after the change.
- `pnpm test src/agents/tools/web-fetch-visibility.test.ts src/agents/tools/web-fetch-utils.test.ts src/agents/tools/web-fetch.test.ts`: 99 tests passed.
- Standalone comparison: 4,742 HTML fixtures produced identical sanitizer output, including attribute case, quotes, duplicate attributes, malformed markup, and nested hidden elements. Eighteen additional serialized text/markdown fallback results stayed identical after removing the redundant parse.
- Two independent source reviews and structured Codex review found no actionable issues.
- `pnpm build` and `node scripts/check-changed.mjs -- src/agents/tools/web-fetch-visibility.ts src/agents/tools/web-fetch-visibility.test.ts src/agents/tools/web-fetch-utils.ts` passed, including formatting, lint, core and core-test typechecks, and architecture guards.

Quiet repeated measurements on Node 26.8.1/macOS, 3,000-element pages (median per sanitizer call):

| Input | Before | After |
| --- | ---: | ---: |
| Plain elements | 3.05 ms | 0.469 ms |
| Styled elements | 4.90 ms | 2.25 ms |
| Mixed visibility | 3.62 ms | 1.74 ms |

These are sanitizer measurements, not whole-turn latency claims. Dynamic matcher constructions for the plain/styled page dropped from 12,004 to zero per call; RSS varied with GC, so no universal memory reduction is claimed.

Live proof used a session-owned, isolated dev gateway and a real OpenAI API key. Short turns, model-driven `web_fetch`, and native OpenAI web search succeeded. For the changed path, the optional Readability plugin was explicitly disabled through its existing plugin setting: before and after requests to the official Node.js performance-hooks documentation both returned HTTP 200, `extractor: raw-html`, and 19,803-character tool results. Only the per-fetch untrusted-content marker and spill-file path differed. A subsequent model-driven fetch on the rebuilt candidate also completed successfully. Single network timings are deliberately not used as a speedup claim.

Follow-up identified during review: the existing visibility attribute grammar can misclassify attribute-name prefixes or attribute-looking text inside quoted values. This patch preserves that behavior; a tokenizer/policy repair needs separate behavior evidence.

CI follow-up: the tool-display source scanner interpreted the factory parameter named `name` as a tool declaration. The parameter now says `attribute`; the unchanged tool-display guard passes. A fresh structured Codex review found no actionable issue in that rename.
