### PR TITLE
chore(ai): remove ineffective Anthropic ordering tests

### DIFF
--- a/packages/ai/src/providers/anthropic.test.ts
+++ b/packages/ai/src/providers/anthropic.test.ts
@@ -2428,53 +2428,6 @@ describe("Anthropic provider", () => {
     expect(messages[1]?.content).toBe("volatile current-turn metadata");
   });
 
-  it("emits start event only after message_start so pre-stream SSE errors arrive before any non-error event", async () => {
-    function createSseEventResponse(lines: string): Response {
-      return new Response(lines, {
-        status: 200,
-        headers: { "content-type": "text/event-stream" },
-      });
-    }
-
-    const client = {
-      messages: {
-        create: vi.fn(() => ({
-          asResponse: () =>
-            Promise.resolve(
-              createSseEventResponse(
-                "event: message_start\ndata: " +
-                  JSON.stringify({
-                    type: "message_start",
-                    message: { id: "msg_1", usage: { input_tokens: 1, output_tokens: 0 } },
-                  }) +
-                  "\n\nevent: message_stop\ndata: " +
-                  JSON.stringify({ type: "message_stop" }) +
-                  "\n\n",
-              ),
-            ),
-        })),
-      },
-    };
-
-    const stream = streamAnthropic(
-      makeAnthropicModel(),
-      { messages: [{ role: "user", content: "hi", timestamp: 0 }] },
-      { apiKey: "sk-ant-key", client: client as never },
-    );
-
-    const eventTypes: string[] = [];
-    for await (const event of stream as AsyncIterable<{ type: string }>) {
-      eventTypes.push(event.type);
-    }
-
-    // start must come after message_start processing, not before the loop
-    const startIndex = eventTypes.indexOf("start");
-    expect(startIndex).toBeGreaterThanOrEqual(0);
-    // No error before start — the start event should be first non-error event
-    const errorBeforeStart = eventTypes.slice(0, startIndex).some((t) => t === "error");
-    expect(errorBeforeStart).toBe(false);
-  });
-
   it("emits error without a preceding start event when SSE error arrives before message_start", async () => {
     function createSseEventResponse(lines: string): Response {
       return new Response(lines, {

--- a/packages/ai/src/transports/anthropic-transport-stream.test.ts
+++ b/packages/ai/src/transports/anthropic-transport-stream.test.ts
@@ -4270,45 +4270,6 @@ describe("anthropic transport stream", () => {
     expect(payload.output_config).toEqual({ effort: "high" });
   });
 
-  it("emits start event only after message_start so pre-stream SSE errors arrive before any non-error event", async () => {
-    guardedFetchMock.mockResolvedValueOnce(
-      createSseResponse([
-        anthropicMessageStart({ id: "msg_1", usage: { input_tokens: 1, output_tokens: 0 } }),
-        anthropicMessageDelta({ stop_reason: "end_turn" }, { input_tokens: 1, output_tokens: 1 }),
-      ]),
-    );
-    const streamFn = createAnthropicMessagesTransportStreamFn();
-    const acceptanceObserver = vi.fn();
-    const onResponse = vi.fn();
-    const options = withProviderAcceptanceObserver(
-      { apiKey: "sk-ant-api", onResponse } as AnthropicStreamOptions,
-      acceptanceObserver,
-    );
-    const stream = streamFn(
-      makeAnthropicTransportModel(),
-      { messages: [{ role: "user", content: "hi" }] } as AnthropicStreamContext,
-      options,
-    );
-
-    const eventTypes: string[] = [];
-    for await (const event of stream as AsyncIterable<{ type: string }>) {
-      eventTypes.push(event.type);
-    }
-
-    const startIndex = eventTypes.indexOf("start");
-    expect(startIndex).toBeGreaterThanOrEqual(0);
-    expect(eventTypes.slice(0, startIndex).some((t) => t === "error")).toBe(false);
-    expect(acceptanceObserver).toHaveBeenCalledWith({
-      kind: "http_response",
-      status: 200,
-      headers: { "content-type": "text/event-stream" },
-    });
-    expect(onResponse).toHaveBeenCalledWith(
-      { status: 200, headers: { "content-type": "text/event-stream" } },
-      expect.objectContaining({ provider: "anthropic" }),
-    );
-  });
-
   it("emits error without a preceding start event when SSE error arrives before message_start", async () => {
     guardedFetchMock.mockResolvedValueOnce(
       createRawSseResponse(


### PR DESCRIPTION
Related: #132462

## What Problem This Solves

Removes two Anthropic stream tests that claimed to verify `start` was emitted only after `message_start`, but could not distinguish that ordering from the pre-fix behavior.

## Why This Change Was Made

Both tests only observed emitted OpenClaw event types. Because `message_start` is not itself emitted, their assertions also passed when `start` was pushed before the SSE loop. The adjacent provider and managed-transport regressions that feed an SSE error before `message_start` remain; those tests fail if `start` is emitted early and therefore own the recovery invariant.

The separate Fable fallback and interleaved-block regressions remain in both suites because the provider and managed transport implement those behaviors independently.

Production LOC: +0/-0 (net 0) | Tests: +0/-86

## User Impact

No user-visible behavior changes. Contributors retain the effective Anthropic recovery regressions without maintaining assertions that passed on the broken implementation.

## Evidence

- Historical pre-fix source from #90697 emitted `start` before entering the SSE loop; both removed positive tests would still pass because they only required `start` to exist with no earlier emitted error.
- `node scripts/run-vitest.mjs packages/ai/src/providers/anthropic.test.ts packages/ai/src/transports/anthropic-transport-stream.test.ts` — 2 files passed, 225 tests passed.
- The retained pre-`message_start` error tests pass in both suites; the transport case also retains HTTP acceptance-observer and `onResponse` coverage.
- `node scripts/check-changed.mjs -- ...` — all checks through the core-test typecheck passed; typecheck stopped on the checkout's existing missing `pako` declaration at `ui/vite.config.ts:9` (TS7016), unrelated to this test-only deletion.
- `git diff --check` — passed.
- Structured autoreview — clean; patch correct (0.99), no accepted/actionable findings.
