### PR TITLE
test(release): refresh Codex security scan layout

### DIFF
--- a/src/plugins/npm-install-security-scan.release.test.ts
+++ b/src/plugins/npm-install-security-scan.release.test.ts
@@ -51,7 +51,8 @@ const CODEX_LEGACY_SOURCE_FINDING_COUNTS = new Map<string, number>([
 ]);
 const CODEX_CURRENT_SOURCE_FINDING_COUNTS = new Map<string, number>([
   ["@openclaw/codex:dangerous-exec:src/app-server/sandbox-exec-server/sandbox-child.ts", 1],
-  ["@openclaw/codex:dangerous-exec:src/app-server/transport-process-containment.ts", 1],
+  ["@openclaw/codex:dangerous-exec:src/app-server/transport-orphan.test-helper.ts", 1],
+  ["@openclaw/codex:dangerous-exec:src/app-server/transport-process-snapshot.ts", 1],
 ]);
 
 // Generated chunks can contain multiple reviewed execution sites. Counts are
@@ -748,7 +749,7 @@ describe("publishable plugin npm package install security scan", () => {
       "duplicate occurrence",
       [
         ...expandReviewedFindingCounts(CODEX_CURRENT_SOURCE_FINDING_COUNTS),
-        "@openclaw/codex:dangerous-exec:src/app-server/transport-process-containment.ts",
+        "@openclaw/codex:dangerous-exec:src/app-server/transport-process-snapshot.ts",
       ],
     ],
   ];


### PR DESCRIPTION
## What Problem This Solves

Plugin prerelease validation rejected the current `@openclaw/codex` package because the reviewed process-execution inventory still described the pre-orphan-reaping source layout.

Failed release job: https://github.com/openclaw/openclaw/actions/runs/33278891625/job/99170635452

## Why This Change Was Made

Merged #132610 moved process inspection out of `transport-process-containment.ts` and introduced two narrower execution owners:

- `transport-orphan.test-helper.ts` starts the real subprocess tree used by the crash/reconnect regression.
- `transport-process-snapshot.ts` invokes bounded native `ps` inspection on non-Linux POSIX hosts.

The release scanner intentionally requires an exact complete Codex source layout. This change replaces the retired containment finding with those two current findings and updates the duplicate-occurrence negative case to duplicate a current key. Unknown, partial, mixed, relocated, and duplicate layouts remain rejected.

## Dependency Contract

Direct sibling Codex inspection at `../codex` head `bf2aee99c58362d3f588d98432dcbc7adc371c73` confirmed:

- `codex-rs/app-server-transport/src/transport/stdio.rs:24-100` owns stdin EOF and connection-close signaling.
- `codex-rs/app-server/src/message_processor.rs:782-808` drains connection RPC and command/process execution on connection close.
- `codex-rs/app-server/src/message_processor.rs:1563-1586` routes `command/exec` and `process/spawn` through their process owners.
- `codex-rs/app-server-protocol/src/protocol/v2/command_exec.rs:21-108` defines the streamed, optionally timeout-disabled native command contract used by the real orphan fixture.

This PR changes no Codex runtime, process policy, package contents, or dependency.

## Evidence

- Before: exact release scan reported the two current files as unexpected critical findings.
- After: `node scripts/run-vitest.mjs src/plugins/npm-install-security-scan.release.test.ts` — 103 passed.
- `node scripts/check-changed.mjs -- src/plugins/npm-install-security-scan.release.test.ts` — all guards passed through core-test typecheck; the final typecheck was blocked only by the shared checkout's unrelated missing `pako` declaration.
- Structured autoreview: clean, correctness 0.98.
- `git diff --check` — passed.

## Scope

Production LOC: 0. Test/release-policy inventory: +3/-2 (net +1).
