### PR TITLE
fix: keep Code Mode results and read cursors intact at model limits

### DIFF
--- a/docs/tools/code-mode.md
+++ b/docs/tools/code-mode.md
@@ -1029,6 +1029,24 @@ output is delivered incrementally. An unchanged cumulative summary is not repeat
 new output or a changed final-value/error reservation can produce a replacement
 summary of that same original output.
 
+Model-facing `exec` and `wait` results also fit the effective model's per-result
+context and persistence limits. OpenClaw reserves the complete result envelope,
+including status, continuation, diagnostics, telemetry, and JSON formatting,
+before projecting output from its retained original source. Network-derived
+results retain the untrusted-content wrapper and its smaller content limit.
+These limits do not reduce the nested tool's byte allowance. Headless execution
+and low-level controls without model context retain their byte-only allowance
+(with the existing security wrapper limit for network-derived control output).
+
+This protects fresh results; it is not an archival JSON guarantee. Later
+aggregate reduction, cache-TTL pruning, and replay into a smaller model may
+still shorten or replace historical tool text. Already-sent results stay
+unchanged during ordinary continuation. Conventional tools keep their own text
+and image formats: a declared output schema describes `details`, not model-visible
+text. The file-read producer reserves its exact paging footer within the same
+model limits, and oversized skill instructions are refused rather than silently
+served in part.
+
 ## Tool catalog
 
 The hidden catalog includes tools after effective policy filtering, in this

--- a/extensions/copilot/src/tool-bridge.test.ts
+++ b/extensions/copilot/src/tool-bridge.test.ts
@@ -1120,27 +1120,31 @@ describe("createCopilotToolBridge", () => {
       expect(getOpts().sessionKey).toBe("fallback-key");
     });
 
-    it("computes modelApi, modelContextWindowTokens, modelCompat, and modelHasVision from attemptParams.model", async () => {
-      const { createOpenClawCodingTools, getOpts } = captureCall();
+    it.each([undefined, 8000])(
+      "uses the effective read context (%s) with prepared model capabilities",
+      async (contextTokenBudget) => {
+        const { createOpenClawCodingTools, getOpts } = captureCall();
 
-      await createCopilotToolBridge({
-        attemptParams: {
-          model: {
-            api: "openai-responses",
-            contextWindow: 200_000,
-            input: ["text", "image"],
-            compat: { some: "shape" },
-          },
-        } as never,
-        createOpenClawCodingTools,
-      });
+        await createCopilotToolBridge({
+          attemptParams: {
+            contextTokenBudget,
+            model: {
+              api: "openai-responses",
+              contextWindow: 200_000,
+              input: ["text", "image"],
+              compat: { some: "shape" },
+            },
+          } as never,
+          createOpenClawCodingTools,
+        });
 
-      const opts = getOpts();
-      expect(opts.modelApi).toBe("openai-responses");
-      expect(opts.modelContextWindowTokens).toBe(200_000);
-      expect(opts.modelHasVision).toBe(true);
-      expect(opts.modelCompat).toEqual({ some: "shape" });
-    });
+        const opts = getOpts();
+        expect(opts.modelApi).toBe("openai-responses");
+        expect(opts.modelContextWindowTokens).toBe(contextTokenBudget ?? 200_000);
+        expect(opts.modelHasVision).toBe(true);
+        expect(opts.modelCompat).toEqual({ some: "shape" });
+      },
+    );
 
     it("modelHasVision is false when model.input does not include 'image'", async () => {
       const { createOpenClawCodingTools, getOpts } = captureCall();

--- a/extensions/copilot/src/tool-bridge.ts
+++ b/extensions/copilot/src/tool-bridge.ts
@@ -206,6 +206,7 @@ export async function createCopilotToolBridge(
     isRawModelRun: isRawCopilotModelRun(attemptParams),
     // Carries catalog compat so `tools.codeMode.enabled: "auto"` can resolve per model.
     model: attemptParams.model,
+    contextTokenBudget: attemptParams.contextTokenBudget,
     modelId: input.modelId,
     modelProvider: input.modelProvider,
     modelToolsEnabled: true,
@@ -438,7 +439,7 @@ function buildOpenClawCodingToolsOptions(
     toolConstructionPlan: toolPlan.codingToolConstructionPlan,
     modelCompat,
     modelApi: model?.api,
-    modelContextWindowTokens: model?.contextWindow,
+    modelContextWindowTokens: a.contextTokenBudget ?? model?.contextWindow,
     delegationCapability: a.delegationCapability,
     modelAuthMode: resolveModelAuthMode(input.modelProvider, a.config, undefined, {
       workspaceDir,

--- a/scripts/prepare-extension-package-boundary-artifacts.mts
+++ b/scripts/prepare-extension-package-boundary-artifacts.mts
@@ -238,11 +238,12 @@ async function prepareExtensionPackageBoundaryArtifacts(argv: string[] = process
       return { ...unit, outputRoot: fs.realpathSync(resolve(repoRoot, unit.outDir)) };
     }),
   );
-  let before = new BoundaryInputSnapshot(repoRoot);
   for (const batch of batches) {
     if (!batch.length) {
       continue;
     }
+    // Upstream pruning changes consumer topology; snapshot after the preceding batch's cleanup.
+    const before = new BoundaryInputSnapshot(repoRoot);
     const pending = batch
       .map((unit) => {
         const recordPath = resolve(repoRoot, BOUNDARY_CACHE_ROOT, `${unit.id}.json`);
@@ -344,7 +345,6 @@ async function prepareExtensionPackageBoundaryArtifacts(argv: string[] = process
       writeArtifactRecord(unit.recordPath, unit.record);
       process.stdout.write(`[${unit.id} boundary dts] emitted ${unit.outputs.size} files\n`);
     }
-    before = after;
   }
 }
 

--- a/src/agents/agent-tools.read.ts
+++ b/src/agents/agent-tools.read.ts
@@ -6,7 +6,6 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { URL } from "node:url";
 import { detectMime } from "@openclaw/media-core/mime";
-import { formatByteSize } from "@openclaw/normalization-core";
 import type { Static, TSchema } from "typebox";
 import { Value } from "typebox/value";
 import { isWindowsDrivePath } from "../infra/archive-path.js";
@@ -54,12 +53,20 @@ import {
   type ReadToolTruncationDetails,
 } from "./sessions/tools/index.js";
 import { expandOsHomePrefix, resolveToCwd } from "./sessions/tools/path-utils.js";
-import { createBoundedReadTextPage, formatReadContinuationNotice } from "./sessions/tools/read.js";
+import {
+  createBoundedReadTextPage,
+  formatReadContinuationNotice,
+} from "./sessions/tools/read-page.js";
 import {
   ReadToolContinuationSchema,
   type ReadToolContinuation,
 } from "./sessions/tools/tool-contracts.js";
 import { sanitizeToolResultImages } from "./tool-images.js";
+import {
+  resolveToolResultBudget,
+  toolResultFitsBudget,
+  type ToolResultBudget,
+} from "./tool-result-limits.js";
 
 // NOTE(steipete): Upstream read now does file-magic MIME detection; we keep the wrapper
 // to sanitize oversized images before they hit providers.
@@ -141,15 +148,6 @@ export function resolveAdaptiveReadMaxBytes(options?: OpenClawReadToolOptions): 
 
 function malformedXmlArgValuePathError(key: string): Error {
   return new Error(`Malformed path parameter: ${key}. Supply correct parameters before retrying.`);
-}
-
-function formatBytes(bytes: number): string {
-  return formatByteSize(bytes, {
-    style: "legacy-binary",
-    maxUnit: "mega",
-    separator: "",
-    fractionDigits: (_value, unit) => (unit === "byte" ? null : unit === "kilo" ? 0 : 1),
-  });
 }
 
 function getToolResultText(result: AgentToolResult<unknown>): string | undefined {
@@ -310,6 +308,7 @@ async function executeReadWithAdaptivePaging(params: {
   args: Record<string, unknown>;
   signal?: AbortSignal;
   maxBytes: number;
+  modelBudget?: ToolResultBudget;
 }): Promise<AgentToolResult<unknown>> {
   const userLimit = params.args.limit;
   const hasExplicitLimit =
@@ -360,7 +359,13 @@ async function executeReadWithAdaptivePaging(params: {
       ? formatReadContinuationNotice(pageContinuation, params.maxBytes)
       : "";
 
-    if (candidateBytes + Buffer.byteLength(continuationNotice, "utf8") > params.maxBytes) {
+    if (
+      candidateBytes + Buffer.byteLength(continuationNotice, "utf8") > params.maxBytes ||
+      !toolResultFitsBudget(
+        `${aggregatedText}${delimiter}${pageText}${continuationNotice}`,
+        params.modelBudget,
+      )
+    ) {
       if (aggregatedText) {
         return withReadContinuation(
           firstResult,
@@ -379,6 +384,7 @@ async function executeReadWithAdaptivePaging(params: {
         ...(next.kind === "cursor" ? { cursor: next.cursor } : {}),
         limit: next.limit,
         maxBytes: params.maxBytes,
+        modelBudget: params.modelBudget,
         adaptive: true,
       });
       if (bounded.kind === "text") {
@@ -969,6 +975,7 @@ export function createSandboxedReadTool(
     (params.createTool ?? createReadTool)(params.root, {
       operations: createSandboxReadOperations(params),
       maxBytes: resolveAdaptiveReadMaxBytes(params),
+      modelBudget: resolveToolResultBudget(params.modelContextWindowTokens),
       modelHasVision: params.modelHasVision,
     }),
   );
@@ -1045,6 +1052,7 @@ export function createOpenClawReadTool(
   base: AnyAgentTool,
   options?: OpenClawReadToolOptions,
 ): AnyAgentTool {
+  const modelBudget = resolveToolResultBudget(options?.modelContextWindowTokens);
   return {
     ...base,
     execute: async (toolCallId, params, signal) => {
@@ -1069,6 +1077,7 @@ export function createOpenClawReadTool(
           : (normalizedRecord ?? {}),
         signal,
         maxBytes: resolveAdaptiveReadMaxBytes(options),
+        modelBudget,
       });
       const strippedDetailsResult = stripReadTruncationContentDetails(result);
       const normalizedResult = await normalizeReadImageResult(strippedDetailsResult, filePath);
@@ -1189,6 +1198,7 @@ export function wrapReadToolWithSkillContent(
               eraseSessionFileTool(
                 createReadTool("/", {
                   maxBytes: resolveAdaptiveReadMaxBytes(options),
+                  modelBudget: resolveToolResultBudget(options?.modelContextWindowTokens),
                   operations: {
                     resolvePath: (filePath) => filePath,
                     access: async (filePath) => void readContent(filePath),
@@ -1217,7 +1227,8 @@ export function wrapReadToolWithSkillContent(
             : undefined;
         if (detailsKind === "truncated") {
           resetDelivery();
-          const text = `Skill instructions cannot be partially served: the whole document exceeds the ${formatBytes(resolveAdaptiveReadMaxBytes(options))} read budget. Ask the operator to reduce the document or increase the model context.`;
+          const text =
+            "Skill instructions cannot be partially served: the whole document exceeds this call's read or model-context budget. Ask the operator to reduce the document or increase the model context.";
           return {
             content: [{ type: "text", text }],
             details: { kind: "text", content: text },

--- a/src/agents/code-mode-execution.ts
+++ b/src/agents/code-mode-execution.ts
@@ -56,6 +56,7 @@ import {
 import { normalizeCodeModeWorkerResult, runCodeModeWorker } from "./code-mode-worker.js";
 import type { AgentToolUpdateCallback } from "./runtime/index.js";
 import { resolveSwarmConfig } from "./subagents/swarm/swarm-config.js";
+import type { ToolResultBudget } from "./tool-result-limits.js";
 import { ToolSearchRuntime } from "./tool-search-runtime.js";
 import type { ToolSearchToolContext } from "./tool-search-types.js";
 import { ToolInputError } from "./tools/common.js";
@@ -64,6 +65,7 @@ export async function runCodeModeExec(params: {
   toolCallId: string;
   ctx: ToolSearchToolContext;
   config: CodeModeConfig;
+  resultBudget?: ToolResultBudget;
   code: string;
   assistantTurnId?: string;
   language?: CodeModeLanguage;
@@ -100,7 +102,7 @@ export async function runCodeModeExec(params: {
   const approvalWait = observeAgentRunApprovalWait(params.ctx);
   const owner = createCodeModeRunOwner(params.ctx);
   const signal = owner.bindCall(params.signal);
-  const output = new CodeModeOutputState(config.maxOutputBytes);
+  const output = new CodeModeOutputState(config.maxOutputBytes, params.resultBudget);
   try {
     const source = await awaitCodeModeDeadline({
       operation: () => prepareSource({ code: params.code, language: params.language, config }),
@@ -150,21 +152,22 @@ export async function runCodeModeExec(params: {
     });
   } catch (error) {
     const code = signal.aborted ? ("aborted" as const) : codeModeFailureCode(error);
-    return {
-      status: "failed" as const,
-      ...output.take({
-        error: signal.aborted ? "code mode execution aborted" : codeModeFailureMessage(error),
-      }),
-      code,
-      failurePhase: bridgeDispatch.started
-        ? ("bridge" as const)
-        : code === "invalid_input"
-          ? ("input" as const)
-          : ("host" as const),
-      bridgeDispatchStarted: bridgeDispatch.started,
-      replaySafe: params.restartSafe,
-      telemetry: telemetry(runtime),
-    };
+    return output.takeResult(
+      {
+        status: "failed" as const,
+        code,
+        failurePhase: bridgeDispatch.started
+          ? ("bridge" as const)
+          : code === "invalid_input"
+            ? ("input" as const)
+            : ("host" as const),
+        bridgeDispatchStarted: bridgeDispatch.started,
+        replaySafe: params.restartSafe,
+        telemetry: telemetry(runtime),
+      },
+      { error: signal.aborted ? "code mode execution aborted" : codeModeFailureMessage(error) },
+      runtime.hasNetworkContent(),
+    );
   } finally {
     approvalWait.dispose();
     if (!activeRuns.has(owner.runId)) {
@@ -427,19 +430,22 @@ async function settleCodeModeResult(params: {
     );
     if (params.replaySafe && !pendingReplaySafe) {
       cancelPendingBridgeStates(pending);
-      return {
-        status: "failed" as const,
-        ...output.take({
+      return output.takeResult(
+        {
+          status: "failed" as const,
+          code: "invalid_input" as const,
+          failurePhase: params.bridgeDispatch.started ? ("bridge" as const) : ("input" as const),
+          bridgeDispatchStarted: params.bridgeDispatch.started,
+          replaySafe: true,
+          telemetry: telemetry(params.runtime),
+        },
+        {
           error: result.pendingRequests.every((request) => request.method === "namespace")
             ? "restart-safe code mode cannot call namespace tools."
             : "restart-safe code mode cannot call tool surfaces that are not proven replay-safe; recovery runs must use audited read, grep, or find tools.",
-        }),
-        code: "invalid_input" as const,
-        failurePhase: params.bridgeDispatch.started ? ("bridge" as const) : ("input" as const),
-        bridgeDispatchStarted: params.bridgeDispatch.started,
-        replaySafe: true,
-        telemetry: telemetry(params.runtime),
-      };
+        },
+        params.runtime.hasNetworkContent(),
+      );
     }
     let releaseReservation: (() => void) | undefined;
     try {
@@ -501,24 +507,23 @@ async function settleCodeModeResult(params: {
   // Defensive cleanup covers aborts or terminal failures; successful runs have
   // already drained every dispatched call before releasing their snapshot.
   cancelPendingBridgeStates(pending);
-  const bounded = output.take({
+  const channels = {
     ...(result.status === "completed" ? { value: result.value } : {}),
     ...(result.status === "failed" ? { error: result.error } : {}),
-  });
-  const finalized = {
-    ...result,
-    ...(bounded.error !== undefined ? { error: bounded.error } : {}),
-    ...(result.status === "completed" ? { value: bounded.value } : {}),
+  };
+  const metadata = {
     ...(result.status === "failed"
       ? {
+          status: result.status,
+          code: result.code,
           failurePhase: params.bridgeDispatch.started ? ("bridge" as const) : result.failurePhase,
           bridgeDispatchStarted: params.bridgeDispatch.started,
         }
-      : {}),
-    output: bounded.output,
+      : { status: result.status }),
     replaySafe: params.replaySafe,
     telemetry: telemetry(params.runtime),
   };
+  const finalized = output.takeResult(metadata, channels, params.runtime.hasNetworkContent());
   if (finalized.status === "failed" && isCodeModeBridgeRepairEligible(params.bridgeDispatch)) {
     registerRepairableCodeModeFailure(finalized);
   }
@@ -585,15 +590,18 @@ export async function runWait(params: {
       // so the next wait can resume with a fresh deadline instead of losing
       // the run to a restore-only interrupt timeout.
       const pending = state.pending.filter((entry) => !entry.settled);
-      return {
-        status: "waiting" as const,
-        runId: state.runId,
-        reason: codeModeWaitingReason(pending.length > 0 ? pending : state.pending),
-        pendingToolCalls: pendingToolCalls(pending.length > 0 ? pending : state.pending),
-        replaySafe: state.replaySafe,
-        output: state.output.take().output,
-        telemetry: telemetry(state.runtime),
-      };
+      return state.output.takeResult(
+        {
+          status: "waiting" as const,
+          runId: state.runId,
+          reason: codeModeWaitingReason(pending.length > 0 ? pending : state.pending),
+          pendingToolCalls: pendingToolCalls(pending.length > 0 ? pending : state.pending),
+          replaySafe: state.replaySafe,
+          telemetry: telemetry(state.runtime),
+        },
+        {},
+        state.runtime.hasNetworkContent(),
+      );
     }
 
     const settledRequests: SettledBridgeRequest[] = settledBridgeRequestsInCompletionOrder(
@@ -647,17 +655,18 @@ export async function runWait(params: {
     const aborted = signal.aborted;
     state.owner.close();
     cancelPendingBridgeStates(state.pending);
-    return {
-      status: "failed" as const,
-      ...state.output.take({
-        error: aborted ? "code mode execution aborted" : codeModeFailureMessage(error),
-      }),
-      code: aborted ? ("aborted" as const) : codeModeFailureCode(error),
-      failurePhase: "bridge" as const,
-      bridgeDispatchStarted: state.bridgeDispatch.started,
-      replaySafe: state.replaySafe,
-      telemetry: telemetry(state.runtime),
-    };
+    return state.output.takeResult(
+      {
+        status: "failed" as const,
+        code: aborted ? ("aborted" as const) : codeModeFailureCode(error),
+        failurePhase: "bridge" as const,
+        bridgeDispatchStarted: state.bridgeDispatch.started,
+        replaySafe: state.replaySafe,
+        telemetry: telemetry(state.runtime),
+      },
+      { error: aborted ? "code mode execution aborted" : codeModeFailureMessage(error) },
+      state.runtime.hasNetworkContent(),
+    );
   } finally {
     approvalWait.dispose();
     releaseActiveRunSlot?.();

--- a/src/agents/code-mode-json.ts
+++ b/src/agents/code-mode-json.ts
@@ -1,5 +1,7 @@
 import { jsonUtf8Bytes } from "../infra/json-utf8-bytes.js";
 import { truncateUtf8Prefix } from "../utils/utf8-truncate.js";
+import { toolResultFitsBudget, type ToolResultBudget } from "./tool-result-limits.js";
+import { renderToolSearchControlText } from "./tool-search-control-result.js";
 
 export function toCodeModeJsonSafe(value: unknown): unknown {
   if (value === undefined) {
@@ -131,7 +133,10 @@ export class CodeModeOutputState {
   source: CodeModeOutputSource = EMPTY_CODE_MODE_OUTPUT;
   private delivered: DeliveryReceipt = { kind: "entries", count: 0 };
 
-  constructor(private readonly maxBytes: number) {}
+  constructor(
+    private readonly maxBytes: number,
+    private readonly modelBudget?: ToolResultBudget,
+  ) {}
 
   append(leg: CodeModeOutputSource): void {
     if (leg.count === 0) {
@@ -158,6 +163,73 @@ export class CodeModeOutputState {
   take(params: TerminalChannels & { error: string }): DeliveredChannels & { error: string };
   take(params?: TerminalChannels): DeliveredChannels;
   take(params: TerminalChannels = {}): DeliveredChannels {
+    return this.takeResult({}, params);
+  }
+
+  takeResult<T extends object>(
+    metadata: T,
+    params: TerminalChannels & { error: string },
+    networkContent?: boolean,
+  ): T & DeliveredChannels & { error: string };
+  takeResult<T extends object>(
+    metadata: T,
+    params?: TerminalChannels,
+    networkContent?: boolean,
+  ): T & DeliveredChannels;
+  takeResult<T extends object>(
+    metadata: T,
+    params: TerminalChannels = {},
+    networkContent = false,
+  ): T & DeliveredChannels {
+    const fits = (candidate: ReturnType<CodeModeOutputState["project"]>) => {
+      const rendered = renderToolSearchControlText(
+        JSON.stringify({ ...metadata, ...candidate.channels }, null, 2),
+        networkContent,
+      );
+      return !rendered.truncated && toolResultFitsBudget(rendered.text, this.modelBudget);
+    };
+    let projection = this.project(params, this.maxBytes);
+    if ((this.modelBudget || networkContent) && !fits(projection)) {
+      let low = 0;
+      let high = this.maxBytes - 1;
+      let best: typeof projection | undefined;
+      while (low <= high) {
+        const middle = Math.floor((low + high) / 2);
+        const candidate = this.project(params, middle);
+        if (fits(candidate)) {
+          best = candidate;
+          low = middle + 1;
+        } else {
+          high = middle - 1;
+        }
+      }
+      if (!best) {
+        throw new Error(
+          "Model tool-result budget cannot fit Code Mode status; use a larger model context.",
+        );
+      }
+      projection = best;
+    }
+    const prior = this.delivered;
+    const { channels, receipt } = projection;
+    // Trial projections never acknowledge delivery. Charge the cumulative output
+    // before suppressing earlier entries or an unchanged replacement summary.
+    this.delivered = receipt;
+    const output =
+      receipt.kind === "entries"
+        ? channels.output.slice(prior.kind === "entries" ? prior.count : 0)
+        : prior.kind === "summary" &&
+            prior.originalBytes === receipt.originalBytes &&
+            prior.prefixBytes === receipt.prefixBytes
+          ? []
+          : channels.output;
+    return { ...metadata, ...channels, output };
+  }
+
+  private project(
+    params: TerminalChannels,
+    maxBytes: number,
+  ): { channels: DeliveredChannels; receipt: DeliveryReceipt } {
     const { count, source } = this.source;
     const outputBytes = count === 0 ? 0 : sourceBytes(source);
     const valueBytes = params.value === undefined ? 0 : sourceBytes(params.value);
@@ -167,39 +239,36 @@ export class CodeModeOutputState {
         ? undefined
         : boundCodeModeError(
             params.error,
-            this.maxBytes - Math.min(outputBytes + valueBytes, Math.floor(this.maxBytes / 2)),
+            maxBytes - Math.min(outputBytes + valueBytes, Math.floor(maxBytes / 2)),
           );
-    const remaining = this.maxBytes - (error === undefined ? 0 : jsonUtf8Bytes(error));
+    const remaining = maxBytes - (error === undefined ? 0 : jsonUtf8Bytes(error));
     const outputAllowance = remaining - Math.min(valueBytes, Math.floor(remaining / 2));
     let output: unknown[];
     let chargedOutputBytes: number;
+    let receipt: DeliveryReceipt;
     if (outputBytes <= outputAllowance) {
       // A retained prefix has originalBytes > maxBytes and cannot fit this allowance.
       // SAFETY: Complete output sources encode normalized arrays, never guest metadata.
       const entries = JSON.parse(source.json) as unknown[];
-      output = entries.slice(this.delivered.kind === "entries" ? this.delivered.count : count);
+      output = entries;
       chargedOutputBytes = outputBytes;
-      this.delivered = { kind: "entries", count };
+      receipt = { kind: "entries", count };
     } else {
       const marker = truncationMarker(source, outputAllowance - 2);
       const prefixBytes = Buffer.byteLength(marker.prefix, "utf8");
-      const prior = this.delivered;
-      output =
-        prior.kind === "summary" &&
-        prior.originalBytes === outputBytes &&
-        prior.prefixBytes === prefixBytes
-          ? []
-          : [marker];
+      output = [marker];
       chargedOutputBytes = jsonUtf8Bytes([marker]);
-      this.delivered = { kind: "summary", originalBytes: outputBytes, prefixBytes };
+      receipt = { kind: "summary", originalBytes: outputBytes, prefixBytes };
     }
-    // Allocate from the full cumulative projection before suppressing prior delivery.
     return {
-      output,
-      ...(params.value === undefined
-        ? {}
-        : { value: projectValue(params.value, remaining - chargedOutputBytes) }),
-      ...(error === undefined ? {} : { error }),
+      receipt,
+      channels: {
+        output,
+        ...(params.value === undefined
+          ? {}
+          : { value: projectValue(params.value, remaining - chargedOutputBytes) }),
+        ...(error === undefined ? {} : { error }),
+      },
     };
   }
 }

--- a/src/agents/code-mode-state.ts
+++ b/src/agents/code-mode-state.ts
@@ -503,17 +503,22 @@ export function storeSnapshotState(params: {
     bridgeDispatch: params.bridgeDispatch,
     owner: params.owner,
   };
+  const result = params.output.takeResult(
+    {
+      status: "waiting" as const,
+      runId,
+      reason: codeModeWaitingReason(params.pending),
+      pendingToolCalls: pendingToolCalls(params.pending),
+      replaySafe: params.replaySafe,
+      telemetry: telemetry(params.runtime),
+    },
+    {},
+    params.runtime.hasNetworkContent(),
+  );
+  // A result that cannot expose its continuation must not leave an unreachable parked cell.
   activeRuns.set(runId, state);
   scheduleActiveRunExpiry();
-  return {
-    status: "waiting" as const,
-    runId,
-    reason: codeModeWaitingReason(params.pending),
-    pendingToolCalls: pendingToolCalls(params.pending),
-    replaySafe: params.replaySafe,
-    output: params.output.take().output,
-    telemetry: telemetry(params.runtime),
-  };
+  return result;
 }
 
 export function codeModeAbortedResult(params: {
@@ -522,15 +527,18 @@ export function codeModeAbortedResult(params: {
   replaySafe: boolean;
   runtime: ToolSearchRuntime;
 }) {
-  return {
-    status: "failed" as const,
-    ...params.output.take({ error: "code mode execution aborted" }),
-    code: "aborted" as const,
-    failurePhase: params.bridgeDispatch.started ? ("bridge" as const) : ("host" as const),
-    bridgeDispatchStarted: params.bridgeDispatch.started,
-    replaySafe: params.replaySafe,
-    telemetry: telemetry(params.runtime),
-  };
+  return params.output.takeResult(
+    {
+      status: "failed" as const,
+      code: "aborted" as const,
+      failurePhase: params.bridgeDispatch.started ? ("bridge" as const) : ("host" as const),
+      bridgeDispatchStarted: params.bridgeDispatch.started,
+      replaySafe: params.replaySafe,
+      telemetry: telemetry(params.runtime),
+    },
+    { error: "code mode execution aborted" },
+    params.runtime.hasNetworkContent(),
+  );
 }
 
 export function codeModeWaitingReason(

--- a/src/agents/code-mode.result-budget.test.ts
+++ b/src/agents/code-mode.result-budget.test.ts
@@ -1,0 +1,449 @@
+import { writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { createAssistantMessageEventStream, type Model } from "openclaw/plugin-sdk/llm";
+import { afterEach, describe, expect, it } from "vitest";
+import { upsertSessionEntryCore } from "../config/sessions/session-accessor.js";
+import { createOpenClawTestState } from "../test-utils/openclaw-test-state.js";
+import {
+  createOpenClawReadTool,
+  createSandboxedReadTool,
+  wrapReadToolWithSkillContent,
+} from "./agent-tools.read.js";
+import {
+  expectCodeModeSharedBudget,
+  expectOriginalCodeModeMarker,
+  fakeTool,
+  resetCodeModeTestState,
+  resultDetails,
+} from "./code-mode.test-support.js";
+import { submitEmbeddedAttemptPrompt } from "./embedded-agent-runner/run/attempt-prompt-submit.js";
+import {
+  clearEmbeddedSessionPromptStates,
+  getEmbeddedSessionPromptState,
+} from "./embedded-agent-runner/session-prompt-state.js";
+import { installToolResultContextGuard } from "./embedded-agent-runner/tool-result-context-guard.js";
+import { estimateToolResultTextChars } from "./embedded-agent-runner/tool-result-text-budget.js";
+import { truncateOversizedToolResultsInMessages } from "./embedded-agent-runner/tool-result-truncation.js";
+import { createAgentHarnessToolSurfaceRuntimeCore } from "./harness/tool-surface-bridge.js";
+import { projectMcpCallToolResult } from "./mcp-content.js";
+import { Agent, type AgentMessage, type AgentToolResult } from "./runtime/index.js";
+import { installSessionToolResultGuard } from "./session-tool-result-guard.js";
+import { SessionManager } from "./sessions/session-manager.js";
+import { createReadTool } from "./sessions/tools/read.js";
+import type { ReadToolContinuation } from "./sessions/tools/tool-contracts.js";
+import { createHostSandboxFsBridge } from "./test-helpers/host-sandbox-fs-bridge.js";
+import { resolveLiveToolResultMaxChars } from "./tool-result-limits.js";
+
+const sessionId = "result-budget-boundary";
+const model = {
+  id: "budget-fixture",
+  name: "Budget fixture",
+  provider: "test-provider",
+  api: "openai-responses",
+  baseUrl: "https://example.test",
+  reasoning: false,
+  input: ["text"],
+  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+  contextWindow: 128_000,
+  maxTokens: 1_000,
+  compat: {},
+} satisfies Model;
+
+type ToolResultMessage = Extract<AgentMessage, { role: "toolResult" }>;
+
+function message(
+  result: AgentToolResult<unknown>,
+  toolName: string,
+  toolCallId = toolName,
+): ToolResultMessage {
+  return {
+    ...result,
+    role: "toolResult",
+    toolName,
+    toolCallId,
+    isError: false,
+    timestamp: 1,
+  };
+}
+
+function text(result: { content: AgentToolResult<unknown>["content"] }): string {
+  return result.content
+    .filter((block) => block.type === "text")
+    .map((block) => block.text)
+    .join("\n");
+}
+
+function toolResult(messages: AgentMessage[], index: number): ToolResultMessage {
+  const result = messages[index];
+  if (result?.role !== "toolResult") {
+    throw new Error("Expected a tool result at the model boundary");
+  }
+  return result;
+}
+
+async function dispatch(
+  messages: AgentMessage[],
+  contextWindowTokens = model.contextWindow,
+): Promise<AgentMessage[]> {
+  let sent: AgentMessage[] = [];
+  const agent = new Agent({
+    initialState: { model, messages },
+    streamFn: (_model, context) => {
+      sent = context.messages;
+      return createAssistantMessageEventStream();
+    },
+  });
+  const cleanup = installToolResultContextGuard({
+    agent,
+    contextWindowTokens,
+  });
+  const activeSession = {
+    agent,
+    get messages() {
+      return agent.state.messages;
+    },
+  };
+  const sessionPromptState = getEmbeddedSessionPromptState(sessionId);
+  try {
+    await submitEmbeddedAttemptPrompt({
+      attempt: { sessionId },
+      activeSession,
+      contextTokenBudget: contextWindowTokens,
+      images: [],
+      modelPrompt: "",
+      transcriptPrompt: "",
+      systemPrompt: "",
+      runtimeOnly: true,
+      sessionPromptState,
+      toolResultMaxChars: resolveLiveToolResultMaxChars({
+        contextWindowTokens,
+      }),
+      toolResultAggregateMaxChars: 128_000,
+      toolResultPromptProjectionState: sessionPromptState.toolResults,
+      trajectoryRecorder: null,
+      transcriptLeafId: null,
+      onFinalPromptText: () => {},
+      onSteeringAcknowledged: () => {},
+      promptActiveSession: async () => {
+        const context = await agent.transformContext!(messages, new AbortController().signal);
+        await agent.streamFn(model, { messages: await agent.convertToLlm(context) });
+      },
+    });
+    return sent;
+  } finally {
+    cleanup();
+  }
+}
+
+afterEach(() => {
+  resetCodeModeTestState();
+  clearEmbeddedSessionPromptStates([sessionId]);
+});
+
+describe("fresh producer results through persistence and model guards", () => {
+  it.each([
+    { name: "default accented", first: "🦞".repeat(9000), last: "é".repeat(18000) },
+    { name: "ASCII", first: "a".repeat(40_000), last: "b".repeat(40_000) },
+    { name: "equal-byte Euro control", first: "🦞".repeat(9000), last: "€".repeat(12_000) },
+    { name: "CJK", first: "中".repeat(9000), last: "界".repeat(9000) },
+    { name: "JSON escaping", first: '\u0001"\\\n'.repeat(4000), last: '\t"\\'.repeat(4000) },
+    {
+      name: "large final value",
+      first: "é".repeat(15_000),
+      last: "",
+      value: { text: "🦞".repeat(12_000) },
+    },
+    { name: "long failure", first: "x".repeat(35_000), last: "é".repeat(9000), fail: true },
+    { name: "small byte cap", first: "🦞".repeat(140), last: "é".repeat(240), cap: 1024 },
+    {
+      name: "effective raw-weight context",
+      first: "é".repeat(6000),
+      last: "é".repeat(6000),
+      context: 8000,
+    },
+    { name: "ordinary incremental", first: "first", last: "second" },
+  ])(
+    "keeps $name Code Mode output complete after yield and provider dispatch",
+    async (scenario) => {
+      const { first: firstText, last: lastText } = scenario;
+      const cap = "cap" in scenario ? scenario.cap! : 65536;
+      const context = "context" in scenario ? scenario.context! : model.contextWindow;
+      const fail = "fail" in scenario && scenario.fail;
+      const value = "value" in scenario ? scenario.value : true;
+      const state = await createOpenClawTestState({ label: "code-mode-result-budget" });
+      const runtime = createAgentHarnessToolSurfaceRuntimeCore({
+        config: { tools: { codeMode: { enabled: true, maxOutputBytes: cap } } },
+        model,
+        contextTokenBudget: context,
+        modelToolsEnabled: true,
+        sessionId,
+        executeTool: async () => {
+          throw new Error("This fixture has no catalog tools");
+        },
+      });
+      try {
+        const tools = runtime.compactTools([]).tools;
+        const first = message(
+          await tools[0]!.execute("first", {
+            code: `text(${JSON.stringify(firstText)}); await yield_control(); await yield_control(); ${lastText ? `text(${JSON.stringify(lastText)});` : ""} ${fail ? 'throw new Error("DIAGNOSTIC" + "é".repeat(40000));' : `return ${JSON.stringify(value)};`}`,
+          }),
+          "exec",
+        );
+        const firstSent = await dispatch([first], context);
+        expect(JSON.parse(text(toolResult(firstSent, 0)))).toMatchObject({
+          status: "waiting",
+          runId: resultDetails(first).runId,
+        });
+        const empty = message(
+          await tools[1]!.execute("empty", { runId: resultDetails(first).runId }),
+          "wait",
+          "empty",
+        );
+        expect(resultDetails(empty)).toMatchObject({ status: "waiting", output: [] });
+        const final = message(
+          await tools[1]!.execute("second", { runId: resultDetails(first).runId }),
+          "wait",
+        );
+        const sent = await dispatch([first, empty, final], context);
+        expect(text(toolResult(sent, 0))).toBe(text(toolResult(firstSent, 0)));
+        const finalText = text(toolResult(sent, 2));
+        expect(() => JSON.parse(finalText)).not.toThrow();
+        expect(JSON.parse(finalText)).toMatchObject({ status: fail ? "failed" : "completed" });
+        const original = [
+          { type: "text", text: firstText },
+          ...(lastText ? [{ type: "text", text: lastText }] : []),
+        ];
+        const details = resultDetails(final);
+        const output = details.output as unknown[];
+        if (scenario.name === "ordinary incremental") {
+          expect(output).toEqual([original[1]]);
+        } else if (output.length > 0) {
+          expectOriginalCodeModeMarker(output[0], original);
+        } else {
+          expect(lastText).toBe("");
+          expect(
+            Buffer.byteLength(JSON.stringify(original)) +
+              Buffer.byteLength(JSON.stringify(details.value)),
+          ).toBeLessThanOrEqual(cap);
+        }
+        if (fail) {
+          expect(details).toMatchObject({
+            code: "internal_error",
+            failurePhase: "bridge",
+            bridgeDispatchStarted: true,
+            error: expect.stringMatching(/^Error: DIAGNOSTIC.*\[error truncated\]$/s),
+          });
+        } else if (value === true) {
+          expect(details.value).toBe(true);
+        } else {
+          expectOriginalCodeModeMarker(details.value, value);
+        }
+
+        const scope = {
+          agentId: "main",
+          sessionId,
+          sessionKey: "agent:main:result-budget",
+          storePath: join(state.sessionsDir(), "sessions.json"),
+        };
+        await upsertSessionEntryCore(scope, { sessionId, updatedAt: 1 });
+        const manager = SessionManager.open(scope, state.workspaceDir);
+        const maxChars = resolveLiveToolResultMaxChars({ contextWindowTokens: context });
+        installSessionToolResultGuard(manager, { maxToolResultChars: maxChars });
+        for (const [index, frame] of [first, empty, final].entries()) {
+          expect(
+            text(toolResult(sent, index)) === text(frame),
+            "fresh producer text must pass unchanged",
+          ).toBe(true);
+          expect(estimateToolResultTextChars(text(frame))).toBeLessThanOrEqual(maxChars);
+          expect(
+            estimateToolResultTextChars(text(frame), { minimumRawWeight: 2 }),
+          ).toBeLessThanOrEqual(context);
+          expectCodeModeSharedBudget(resultDetails(frame), cap);
+          manager.appendMessage(frame);
+        }
+        manager.flushPendingPersistence();
+        const reloaded = SessionManager.open(scope, state.workspaceDir).buildSessionContext()
+          .messages;
+        expect(text(toolResult(reloaded, 2))).toBe(finalText);
+        expect(text(toolResult(await dispatch(reloaded, context), 2))).toBe(finalText);
+      } finally {
+        runtime.cleanup();
+        await state.cleanup();
+      }
+    },
+  );
+
+  it.each([
+    { name: "host ASCII", sandbox: false, source: "0123456789".repeat(12_000), context: 128_000 },
+    { name: "sandbox Unicode", sandbox: true, source: "中é🦞".repeat(18_000), context: 128_000 },
+    {
+      name: "sandbox resolved filename",
+      sandbox: true,
+      source: "x".repeat(60_000),
+      context: 128_000,
+    },
+    {
+      name: "effective raw-weight context",
+      sandbox: false,
+      source: "é".repeat(16_000),
+      context: 8000,
+    },
+  ])(
+    "keeps the read owner's exact cursor through the downstream result guard: $name",
+    async ({ name, sandbox, source, context }) => {
+      const state = await createOpenClawTestState({ label: "read-result-budget" });
+      try {
+        const resolved = name === "sandbox resolved filename";
+        const file = join(state.workspaceDir, resolved ? "notes 3.04 PM.txt" : "long-line.txt");
+        await writeFile(resolved ? file.replace(" PM", "\u202fPM") : file, source);
+        const read = sandbox
+          ? createSandboxedReadTool({
+              root: state.workspaceDir,
+              bridge: createHostSandboxFsBridge(state.workspaceDir),
+              modelContextWindowTokens: context,
+            })
+          : createOpenClawReadTool(createReadTool(state.workspaceDir), {
+              modelContextWindowTokens: context,
+              cwd: state.workspaceDir,
+            });
+        let collected = "";
+        let continuation: ReadToolContinuation | undefined;
+        for (let index = 0; index < 16; index++) {
+          const page = message(
+            await read.execute(`read-${index}`, { path: file, ...continuation }),
+            "read",
+            `read-${index}`,
+          );
+          const sent = toolResult(await dispatch([page], context), 0);
+          expect(
+            text(sent) === text(page),
+            "no later clipping may discard already-advanced read bytes",
+          ).toBe(true);
+          continuation = resultDetails(page).continuation as ReadToolContinuation | undefined;
+          const pageText = resolved ? text(sent).slice(text(sent).indexOf("\n") + 1) : text(sent);
+          if (!continuation) {
+            collected += pageText;
+            break;
+          }
+          expect(continuation.kind).toBe("cursor");
+          const chunk = pageText.slice(0, pageText.lastIndexOf("\n\n["));
+          expect(chunk.length).toBeGreaterThan(0);
+          collected += chunk;
+          expect(text(sent)).toContain(`cursor=${collected.length}`);
+          expect(collected).toBe(source.slice(0, collected.length));
+        }
+        expect(collected).toBe(source);
+      } finally {
+        await state.cleanup();
+      }
+    },
+  );
+
+  it.each([false, true])(
+    "preserves wrapped network result structure and terminal batches (failed=%s)",
+    async (fail) => {
+      const network = fakeTool("network_fixture", "Read a network fixture");
+      network.resultContentSource = "network";
+      network.execute = async () => ({
+        content: [{ type: "text", text: "received" }],
+        details: "received",
+        terminate: true,
+      });
+      const runtime = createAgentHarnessToolSurfaceRuntimeCore({
+        config: { tools: { codeMode: true } },
+        model,
+        modelToolsEnabled: true,
+        sessionId,
+        executeTool: async ({ toolCallId, input }) => network.execute(toolCallId, input),
+      });
+      try {
+        const [exec, wait] = runtime.compactTools([network]).tools;
+        const first = await exec!.execute("network", {
+          code: `await network_fixture({}); text('<s>'.repeat(20000)); await yield_control(); ${fail ? 'throw new Error("network diagnostic".repeat(5000));' : 'return "é".repeat(20000);'}`,
+        });
+        expect(first.terminate).not.toBe(true);
+        const final = await wait!.execute("network-wait", { runId: resultDetails(first).runId });
+        expect(final.terminate).toBe(true);
+        for (const result of [first, final]) {
+          const rendered = text(result);
+          expect(rendered).toContain("SECURITY NOTICE");
+          expect(rendered).not.toContain("\n[truncated]");
+          const body = rendered
+            .split("\n---\n")[1]
+            ?.split("\n<<<END_EXTERNAL_UNTRUSTED_CONTENT")[0];
+          expect(() => JSON.parse(body!)).not.toThrow();
+          expect(body!.length).toBeLessThanOrEqual(20_000);
+          expect(JSON.parse(body!)).toMatchObject({ status: resultDetails(result).status });
+          expect(text(toolResult(await dispatch([message(result, "exec")]), 0))).toBe(rendered);
+        }
+      } finally {
+        runtime.cleanup();
+      }
+    },
+  );
+
+  it("preserves conventional plain text and mixed MCP content without inferring JSON", async () => {
+    const plain = message(
+      {
+        content: [{ type: "text", text: '{"unfinished": shell output' }],
+        details: { kind: "text" },
+      },
+      "shell",
+    );
+    const mcp = message(
+      projectMcpCallToolResult({
+        structuredContent: { ok: false },
+        isError: true,
+        content: [
+          { type: "text", text: "Retry with a narrower query." },
+          { type: "image", data: "aW1hZ2U=", mimeType: "image/png" },
+        ],
+      }),
+      "mcp",
+    );
+    const sent = await dispatch([plain, mcp]);
+    expect(toolResult(sent, 0).content).toEqual(plain.content);
+    expect(toolResult(sent, 1).content).toEqual(mcp.content);
+    expect(text(mcp)).toContain("structuredContent:\n");
+    expect(text(mcp)).toContain("Retry with a narrower query.");
+  });
+
+  it("allows explicitly lossy aggregate reduction and smaller-context replay", () => {
+    const original = message(
+      {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify({ status: "completed", value: "x".repeat(20_000) }),
+          },
+        ],
+        details: {},
+      },
+      "exec",
+    );
+    const aggregate = truncateOversizedToolResultsInMessages(
+      [original, { ...original, toolCallId: "second" }],
+      128_000,
+      32_000,
+      32_000,
+    );
+    expect(aggregate.aggregateTruncatedCount).toBe(1);
+    expect(text(toolResult(aggregate.messages, 0))).not.toBe(text(original));
+    const smaller = truncateOversizedToolResultsInMessages([original], 8000);
+    expect(() => JSON.parse(text(toolResult(smaller.messages, 0)))).toThrow();
+    expect(() => JSON.parse(text(original))).not.toThrow();
+  });
+
+  it("refuses a whole skill that fits the byte cap but exceeds the model text budget", async () => {
+    const locator = "node://fixture/skills/whole/SKILL.md";
+    const base = fakeTool("read", "Read a file");
+    const read = wrapReadToolWithSkillContent(
+      base,
+      [{ filePath: locator, readContent: "INSTRUCTIONS" + "中".repeat(9000) }],
+      { modelContextWindowTokens: model.contextWindow },
+    );
+    const result = await read.execute("skill", { path: locator, offset: 2, limit: 1 });
+    expect(text(result)).toContain("cannot be partially served");
+    expect(text(result)).not.toContain("INSTRUCTIONS");
+  });
+});

--- a/src/agents/code-mode.ts
+++ b/src/agents/code-mode.ts
@@ -39,6 +39,7 @@ import type { AgentToolUpdateCallback } from "./runtime/index.js";
 import { optionalStringEnum } from "./schema/typebox.js";
 import type { ToolDefinition } from "./sessions/index.js";
 import { resolveSwarmConfig } from "./subagents/swarm/swarm-config.js";
+import { resolveToolResultBudget } from "./tool-result-limits.js";
 import {
   addClientToolsToToolCatalog,
   applyToolCatalogCompaction,
@@ -67,7 +68,7 @@ export {
 };
 export type { CodeModeFailureCode, CodeModeHeadlessResult } from "./code-mode-runtime.js";
 
-type CodeModeToolContext = ToolSearchToolContext;
+type CodeModeToolContext = ToolSearchToolContext & { modelContextWindowTokens?: number };
 
 const MAX_CODE_MODE_CATALOG_INDEX_CHARS = 8_000;
 
@@ -178,7 +179,7 @@ function createCodeModeExecDescription(
     : undefined;
   const catalogIndex = projection ? formatCodeModeCatalogIndex(projection.bindings) : "";
   return (
-    `Run JavaScript or TypeScript in OpenClaw code mode. Enabled tools are async global functions listed in the quick index. Await dependent calls in order; independent calls may run with Promise.all. Declared output fields may feed later calls in the same program; do not spend another \`exec\` merely inspecting them. Return the final value; otherwise the result is \`null\`. \`-> ?\` means unknown output: do not feed it into guessed field-dependent logic in the same program. Return the raw value first, observe it, then use a later \`exec\` for dependent composition. If a tool is omitted from the bounded index, use \`catalog.search(query)\`; results are callable: \`const [tool] = await catalog.search("..."); return await tool({...});\`. Handles expose \`describe()\` when a schema is needed. \`setTimeout\` and \`clearTimeout\` work. Nested calls enforce normal tool policy and approvals. Tool failures are catchable JavaScript errors; otherwise, use a safe failed result to correct your code or choose another tool. If an action may have started, inspect its outcome without repeating mutations. Never replay actions that already ran. Each nested result is bounded separately to ${maxOutputBytes} bytes. Cumulative output and the final value or error share ${maxOutputBytes} bytes across waits. Output/value truncation reports a prefix and omitted bytes of the original normalized JSON; rerun with narrower args. Ordinary output is incremental; unchanged summaries are suppressed, changed cumulative summaries replace earlier ones. Node.js modules and \`require\`/\`import\` are NOT available; use enabled globals for shell, file, network, or external actions.` +
+    `Run JavaScript or TypeScript in OpenClaw code mode. Enabled tools are async global functions listed in the quick index. Await dependent calls in order; independent calls may run with Promise.all. Declared output fields may feed later calls in the same program; do not spend another \`exec\` merely inspecting them. Return the final value; otherwise the result is \`null\`. \`-> ?\` means unknown output: do not feed it into guessed field-dependent logic in the same program. Return the raw value first, observe it, then use a later \`exec\` for dependent composition. If a tool is omitted from the bounded index, use \`catalog.search(query)\`; results are callable: \`const [tool] = await catalog.search("..."); return await tool({...});\`. Handles expose \`describe()\` when a schema is needed. \`setTimeout\` and \`clearTimeout\` work. Nested calls enforce normal tool policy and approvals. Tool failures are catchable JavaScript errors; otherwise, use a safe failed result to correct your code or choose another tool. If an action may have started, inspect its outcome without repeating mutations. Never replay actions that already ran. Each nested result is bounded separately to ${maxOutputBytes} bytes. Cumulative output and the final value or error share ${maxOutputBytes} bytes across waits. Model-facing results may use a smaller allowance to preserve complete status and continuation within model context limits. Output/value truncation reports a prefix and omitted bytes of the original normalized JSON; rerun with narrower args. Ordinary output is incremental; unchanged summaries are suppressed, changed cumulative summaries replace earlier ones. Node.js modules and \`require\`/\`import\` are NOT available; use enabled globals for shell, file, network, or external actions.` +
     apiGuidance +
     mcpGuidance +
     swarmGuidance +
@@ -196,6 +197,7 @@ export function createCodeModeTools(ctx: CodeModeToolContext): AnyAgentTool[] {
   // The surface planner owns activation. Capture limits once so an admitted
   // control remains executable during model overrides and restart recovery.
   const config = resolveCodeModeConfig(ctx.runtimeConfig ?? ctx.config, ctx.agentId);
+  const resultBudget = resolveToolResultBudget(ctx.modelContextWindowTokens);
   const execTool = markCodeModeControlTool({
     name: CODE_MODE_EXEC_TOOL_NAME,
     label: "exec",
@@ -232,6 +234,7 @@ export function createCodeModeTools(ctx: CodeModeToolContext): AnyAgentTool[] {
           toolCallId,
           ctx,
           config,
+          resultBudget,
           code: input.code,
           assistantTurnId:
             executionContext?.assistantMessage.responseId?.trim() ||

--- a/src/agents/core-coding-tools.ts
+++ b/src/agents/core-coding-tools.ts
@@ -30,6 +30,7 @@ import type {
   createWriteTool,
 } from "./sessions/tools/index.js";
 import { createReadTool } from "./sessions/tools/read.js";
+import { resolveToolResultBudget } from "./tool-result-limits.js";
 
 function sandboxReadMounts(
   sandbox: SandboxContext,
@@ -135,6 +136,7 @@ export function createCoreCodingTools(options: CoreCodingToolsOptions): AnyAgent
           })
         : (options.baseToolFactories?.createReadTool ?? createReadTool)(options.codingRoot, {
             maxBytes: resolveAdaptiveReadMaxBytes(options),
+            modelBudget: resolveToolResultBudget(options.modelContextWindowTokens),
             modelHasVision: options.modelHasVision,
           });
       const guarded = options.workspaceOnly

--- a/src/agents/embedded-agent-runner/run/attempt-tool-catalog.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-tool-catalog.ts
@@ -93,6 +93,7 @@ export function prepareEmbeddedAttemptToolCatalog(input: {
     ? createCodeModeTools({
         config: attempt.config,
         runtimeConfig: attempt.config,
+        modelContextWindowTokens: attempt.contextTokenBudget ?? attempt.model.contextWindow,
         agentId: input.sessionAgentId,
         sessionKey: input.sandboxSessionKey,
         sessionId: attempt.sessionId,

--- a/src/agents/embedded-agent-runner/tool-result-context-guard.ts
+++ b/src/agents/embedded-agent-runner/tool-result-context-guard.ts
@@ -8,6 +8,7 @@ import type {
   ContextEngineSessionTarget,
 } from "../../context-engine/types.js";
 import type { AgentMessage } from "../runtime/index.js";
+import { resolveToolResultContextMaxChars } from "../tool-result-limits.js";
 import { formatContextLimitTruncationNotice } from "./context-truncation-notice.js";
 import { log } from "./logger.js";
 import { MidTurnPrecheckSignal, type MidTurnPrecheckRequest } from "./run/midturn-precheck.js";
@@ -25,7 +26,6 @@ import {
 } from "./tool-result-char-estimator.js";
 import { truncateToolResultMessage, truncateToolResultText } from "./tool-result-truncation.js";
 
-const SINGLE_TOOL_RESULT_CONTEXT_SHARE = 0.5;
 const TRANSCRIPT_PROMPT_TEXT_KEY = "__openclawTranscriptPromptText";
 
 type GuardableTransformContext = (
@@ -457,13 +457,7 @@ export function installToolResultContextGuard(params: {
   contextWindowTokens: number;
   midTurnPrecheck?: MidTurnPrecheckOptions;
 }): () => void {
-  const contextWindowTokens = Math.max(1, Math.floor(params.contextWindowTokens));
-  const maxSingleToolResultChars = Math.max(
-    1_024,
-    Math.floor(
-      contextWindowTokens * TOOL_RESULT_CHARS_PER_TOKEN_ESTIMATE * SINGLE_TOOL_RESULT_CONTEXT_SHARE,
-    ),
-  );
+  const maxSingleToolResultChars = resolveToolResultContextMaxChars(params.contextWindowTokens);
 
   // Agent.transformContext is private in session runtime, so access it via a
   // narrow runtime view to keep callsites type-safe while preserving behavior.

--- a/src/agents/harness/tool-surface-bridge.ts
+++ b/src/agents/harness/tool-surface-bridge.ts
@@ -62,7 +62,8 @@ export function createAgentHarnessToolSurfaceRuntimeCore(params: {
   forceMessageTool?: boolean;
   isRawModelRun?: boolean;
   /** Prepared model row carrying catalog compat; required for `"auto"` code-mode resolution. */
-  model?: { compat?: unknown };
+  model?: { compat?: unknown; contextWindow?: number };
+  contextTokenBudget?: number;
   modelId?: string;
   modelProvider?: string;
   codeModeOverride?: boolean | "auto";
@@ -147,6 +148,7 @@ export function createAgentHarnessToolSurfaceRuntimeCore(params: {
       ? createCodeModeTools({
           config: params.config,
           runtimeConfig: params.config,
+          modelContextWindowTokens: params.contextTokenBudget ?? params.model?.contextWindow,
           agentId: params.agentId,
           sessionKey: params.sessionKey,
           sessionId: params.sessionId,

--- a/src/agents/sessions/tools/read-page.ts
+++ b/src/agents/sessions/tools/read-page.ts
@@ -1,0 +1,139 @@
+import { truncateUtf8Prefix } from "../../../utils/utf8-truncate.js";
+import {
+  estimateToolResultTextChars,
+  sliceToolResultTextToBudget,
+} from "../../embedded-agent-runner/tool-result-text-budget.js";
+import { toolResultFitsBudget, type ToolResultBudget } from "../../tool-result-limits.js";
+import type { ReadToolContinuation, ReadToolDetails } from "./tool-contracts.js";
+import { DEFAULT_MAX_BYTES, DEFAULT_MAX_LINES, formatSize, truncateHead } from "./truncate.js";
+
+type BoundedReadTextPage = Extract<ReadToolDetails, { kind: "text" | "truncated" }>;
+
+/** Format model-visible pagination guidance from its exact structured continuation. */
+export function formatReadContinuationNotice(
+  continuation: ReadToolContinuation,
+  maxBytes: number,
+  range?: { startLine: number; totalLines: number },
+): string {
+  const cursor = continuation.kind === "cursor" ? `, cursor=${continuation.cursor}` : "";
+  const limit = continuation.limit === undefined ? "" : `, limit=${continuation.limit}`;
+  if (!range) {
+    const budget = formatSize(maxBytes).replace(/\.0(?=KB)/, "");
+    return `\n\n[Read output capped at ${budget} for this call. Use offset=${continuation.offset}${cursor}${limit} to continue.]`;
+  }
+  const label =
+    continuation.kind === "cursor"
+      ? `part of line ${range.startLine}`
+      : `lines ${range.startLine}-${continuation.offset - 1} of ${range.totalLines}`;
+  const action = continuation.kind === "cursor" ? "Use read with" : "Use";
+  return `\n\n[Showing ${label} (${formatSize(maxBytes)} limit). ${action} offset=${continuation.offset}${cursor}${limit} to continue.]`;
+}
+
+/** Bound a selected text page once; legacy injected readers reuse this owner decision. */
+export function createBoundedReadTextPage(params: {
+  content: string;
+  startLine: number;
+  endLine: number;
+  totalLines: number;
+  cursor?: number;
+  limit?: number;
+  maxBytes: number;
+  pageMaxBytes?: number;
+  modelBudget?: ToolResultBudget;
+  /** Caller-owned framing already reserved in pageMaxBytes, never file/cursor content. */
+  prefix?: string;
+  adaptive?: boolean;
+}): BoundedReadTextPage {
+  const maxBytes = params.pageMaxBytes ?? Math.min(DEFAULT_MAX_BYTES, params.maxBytes);
+  const remainingLines = params.totalLines - params.endLine;
+  const limitNotice =
+    params.limit !== undefined && remainingLines > 0
+      ? `\n\n[${remainingLines} more lines in file. Use offset=${params.endLine + 1} to continue.]`
+      : "";
+  const contentBytes = Buffer.byteLength(params.content, "utf8");
+  const resultPrefix = params.prefix ?? "";
+  if (
+    params.endLine - params.startLine < DEFAULT_MAX_LINES &&
+    contentBytes + Buffer.byteLength(limitNotice, "utf8") <= maxBytes &&
+    toolResultFitsBudget(`${resultPrefix}${params.content}${limitNotice}`, params.modelBudget)
+  ) {
+    return { kind: "text", content: `${params.content}${limitNotice}` };
+  }
+
+  const range = params.adaptive
+    ? undefined
+    : { startLine: params.startLine, totalLines: params.totalLines };
+  const boundedLimit = params.limit === undefined ? {} : { limit: params.limit };
+  const firstLine = params.content.split("\n", 1)[0] ?? "";
+  const cursorEstimate: ReadToolContinuation = {
+    kind: "cursor",
+    offset: params.startLine,
+    cursor: (params.cursor ?? 0) + firstLine.length,
+    ...boundedLimit,
+  };
+  const lineEstimate: ReadToolContinuation = {
+    kind: "line",
+    offset: params.totalLines + 1,
+    ...boundedLimit,
+  };
+  const reservedBytes = Math.max(
+    Buffer.byteLength(formatReadContinuationNotice(cursorEstimate, params.maxBytes, range), "utf8"),
+    Buffer.byteLength(formatReadContinuationNotice(lineEstimate, params.maxBytes, range), "utf8"),
+  );
+  let prefix = truncateUtf8Prefix(params.content, Math.max(0, maxBytes - reservedBytes));
+  if (params.modelBudget) {
+    prefix = sliceToolResultTextToBudget(
+      prefix,
+      params.modelBudget.maxChars - reservedBytes - estimateToolResultTextChars(resultPrefix),
+    );
+    prefix = sliceToolResultTextToBudget(
+      prefix,
+      params.modelBudget.maxContextChars -
+        reservedBytes * 2 -
+        estimateToolResultTextChars(resultPrefix, { minimumRawWeight: 2 }),
+      { minimumRawWeight: 2 },
+    );
+  }
+  // Convert the fitted prefix back to a byte allowance for the existing line/cursor owner.
+  // The cursor advances only over text that survives both model limits and its real footer.
+  const contentBudgetBytes = Buffer.byteLength(prefix, "utf8");
+  const truncation = truncateHead(params.content, { maxBytes: contentBudgetBytes });
+  if (!truncation.truncated) {
+    return { kind: "text", content: `${truncation.content}${limitNotice}` };
+  }
+
+  let continuation: ReadToolContinuation;
+  let content = truncation.content;
+  if (truncation.firstLineExceedsLimit) {
+    content = truncateUtf8Prefix(firstLine, contentBudgetBytes);
+    continuation = {
+      kind: "cursor",
+      offset: params.startLine,
+      cursor: (params.cursor ?? 0) + content.length,
+      ...boundedLimit,
+    };
+  } else {
+    const nextOffset = params.startLine + truncation.outputLines;
+    continuation = {
+      kind: "line",
+      offset: nextOffset,
+      ...(params.limit === undefined
+        ? {}
+        : { limit: Math.max(1, params.endLine - nextOffset + 1) }),
+    };
+  }
+
+  const { content: _content, ...truncationDetails } = truncation;
+  return {
+    kind: "truncated",
+    content: `${content}${formatReadContinuationNotice(continuation, params.maxBytes, range)}`,
+    truncation: {
+      ...truncationDetails,
+      outputBytes: Buffer.byteLength(content, "utf8"),
+      firstLineExceedsLimit: false,
+      lastLinePartial: continuation.kind === "cursor",
+      totalLines: params.totalLines,
+    },
+    continuation,
+  };
+}

--- a/src/agents/sessions/tools/read.ts
+++ b/src/agents/sessions/tools/read.ts
@@ -18,7 +18,6 @@ import {
  */
 import { normalizeNativePathSeparators } from "../../../shared/ignore-rules.js";
 import { levenshteinDistance } from "../../../shared/levenshtein-distance.js";
-import { truncateUtf8Prefix } from "../../../utils/utf8-truncate.js";
 import { getReadmePath } from "../../config.js";
 import { keyHint, keyText } from "../../modes/interactive/components/keybinding-hints.js";
 import {
@@ -27,6 +26,7 @@ import {
   type Theme,
 } from "../../modes/interactive/theme/theme.js";
 import type { AgentTool } from "../../runtime/index.js";
+import type { ToolResultBudget } from "../../tool-result-limits.js";
 import { processImage } from "../../utils/image-resize.js";
 import { detectSupportedImageMimeType } from "../../utils/mime.js";
 import { formatPathRelativeToCwdOrAbsolute } from "../../utils/paths.js";
@@ -37,15 +37,16 @@ import {
 } from "./file-mutation-queue.js";
 import { normalizePositiveLimit } from "./limits.js";
 import { getReadPathVariants, getReadQueuePaths, resolveToCwd } from "./path-utils.js";
+import { createBoundedReadTextPage } from "./read-page.js";
 import {
   createReadToolDetails,
   readToolInputSchema,
   readToolOutputSchema,
 } from "./read-tool-contract.js";
 import { getTextOutput, invalidArgText, replaceTabs, shortenPath, str } from "./render-utils.js";
-import type { ReadToolContinuation, ReadToolDetails } from "./tool-contracts.js";
+import type { ReadToolDetails } from "./tool-contracts.js";
 import { wrapToolDefinition } from "./tool-definition-wrapper.js";
-import { DEFAULT_MAX_BYTES, DEFAULT_MAX_LINES, formatSize, truncateHead } from "./truncate.js";
+import { DEFAULT_MAX_BYTES, DEFAULT_MAX_LINES, formatSize } from "./truncate.js";
 
 function normalizeReadError(error: unknown, filePath: string): Error {
   if (hasErrnoCode(error, "EISDIR")) {
@@ -147,6 +148,8 @@ export interface ReadToolOptions {
   operations?: ReadOperations;
   /** Complete model-visible call budget; individual pages never exceed the session ceiling. */
   maxBytes?: number;
+  /** Prepared text budget; standalone readers retain their byte-only allowance. */
+  modelBudget?: ToolResultBudget;
   /** Prepared capability for embedded calls, which carry no extension model context. */
   modelHasVision?: boolean;
 }
@@ -362,115 +365,6 @@ function formatReadResult(
     }
   }
   return text;
-}
-
-type BoundedReadTextPage = Extract<ReadToolDetails, { kind: "text" | "truncated" }>;
-
-/** Format model-visible pagination guidance from its exact structured continuation. */
-export function formatReadContinuationNotice(
-  continuation: ReadToolContinuation,
-  maxBytes: number,
-  range?: { startLine: number; totalLines: number },
-): string {
-  const cursor = continuation.kind === "cursor" ? `, cursor=${continuation.cursor}` : "";
-  const limit = continuation.limit === undefined ? "" : `, limit=${continuation.limit}`;
-  if (!range) {
-    const budget = formatSize(maxBytes).replace(/\.0(?=KB)/, "");
-    return `\n\n[Read output capped at ${budget} for this call. Use offset=${continuation.offset}${cursor}${limit} to continue.]`;
-  }
-  const label =
-    continuation.kind === "cursor"
-      ? `part of line ${range.startLine}`
-      : `lines ${range.startLine}-${continuation.offset - 1} of ${range.totalLines}`;
-  const action = continuation.kind === "cursor" ? "Use read with" : "Use";
-  return `\n\n[Showing ${label} (${formatSize(maxBytes)} limit). ${action} offset=${continuation.offset}${cursor}${limit} to continue.]`;
-}
-
-/** Bound a selected text page once; legacy injected readers reuse this owner decision. */
-export function createBoundedReadTextPage(params: {
-  content: string;
-  startLine: number;
-  endLine: number;
-  totalLines: number;
-  cursor?: number;
-  limit?: number;
-  maxBytes: number;
-  pageMaxBytes?: number;
-  adaptive?: boolean;
-}): BoundedReadTextPage {
-  const maxBytes = params.pageMaxBytes ?? Math.min(DEFAULT_MAX_BYTES, params.maxBytes);
-  const remainingLines = params.totalLines - params.endLine;
-  const limitNotice =
-    params.limit !== undefined && remainingLines > 0
-      ? `\n\n[${remainingLines} more lines in file. Use offset=${params.endLine + 1} to continue.]`
-      : "";
-  const contentBytes = Buffer.byteLength(params.content, "utf8");
-  if (
-    params.endLine - params.startLine < DEFAULT_MAX_LINES &&
-    contentBytes + Buffer.byteLength(limitNotice, "utf8") <= maxBytes
-  ) {
-    return { kind: "text", content: `${params.content}${limitNotice}` };
-  }
-
-  const range = params.adaptive
-    ? undefined
-    : { startLine: params.startLine, totalLines: params.totalLines };
-  const boundedLimit = params.limit === undefined ? {} : { limit: params.limit };
-  const firstLine = params.content.split("\n", 1)[0] ?? "";
-  const cursorEstimate: ReadToolContinuation = {
-    kind: "cursor",
-    offset: params.startLine,
-    cursor: (params.cursor ?? 0) + firstLine.length,
-    ...boundedLimit,
-  };
-  const lineEstimate: ReadToolContinuation = {
-    kind: "line",
-    offset: params.totalLines + 1,
-    ...boundedLimit,
-  };
-  const reservedBytes = Math.max(
-    Buffer.byteLength(formatReadContinuationNotice(cursorEstimate, params.maxBytes, range), "utf8"),
-    Buffer.byteLength(formatReadContinuationNotice(lineEstimate, params.maxBytes, range), "utf8"),
-  );
-  const truncation = truncateHead(params.content, { maxBytes: maxBytes - reservedBytes });
-  if (!truncation.truncated) {
-    return { kind: "text", content: `${truncation.content}${limitNotice}` };
-  }
-
-  let continuation: ReadToolContinuation;
-  let content = truncation.content;
-  if (truncation.firstLineExceedsLimit) {
-    content = truncateUtf8Prefix(firstLine, maxBytes - reservedBytes);
-    continuation = {
-      kind: "cursor",
-      offset: params.startLine,
-      cursor: (params.cursor ?? 0) + content.length,
-      ...boundedLimit,
-    };
-  } else {
-    const nextOffset = params.startLine + truncation.outputLines;
-    continuation = {
-      kind: "line",
-      offset: nextOffset,
-      ...(params.limit === undefined
-        ? {}
-        : { limit: Math.max(1, params.endLine - nextOffset + 1) }),
-    };
-  }
-
-  const { content: _content, ...truncationDetails } = truncation;
-  return {
-    kind: "truncated",
-    content: `${content}${formatReadContinuationNotice(continuation, params.maxBytes, range)}`,
-    truncation: {
-      ...truncationDetails,
-      outputBytes: Buffer.byteLength(content, "utf8"),
-      firstLineExceedsLimit: false,
-      lastLinePartial: continuation.kind === "cursor",
-      totalLines: params.totalLines,
-    },
-    continuation,
-  };
 }
 
 export function createReadToolDefinition(
@@ -689,6 +583,8 @@ export function createReadToolDefinition(
                     cursor,
                     limit: userLimitedLines,
                     maxBytes,
+                    modelBudget: options?.modelBudget,
+                    prefix: note ? `${note}\n` : undefined,
                     pageMaxBytes: Math.min(DEFAULT_MAX_BYTES, maxBytes) - noteBytes,
                     adaptive: options?.maxBytes !== undefined,
                   });

--- a/src/agents/tool-result-limits.ts
+++ b/src/agents/tool-result-limits.ts
@@ -1,4 +1,5 @@
 /** Automatic live tool-result caps derived from the effective model context. */
+import { estimateToolResultTextChars } from "./embedded-agent-runner/tool-result-text-budget.js";
 
 const MAX_TOOL_RESULT_CONTEXT_SHARE = 0.3;
 
@@ -35,5 +36,36 @@ export function resolveLiveToolResultMaxChars(params: { contextWindowTokens: num
   return calculateMaxToolResultCharsWithCap(
     params.contextWindowTokens,
     resolveAutoLiveToolResultMaxChars(params.contextWindowTokens),
+  );
+}
+
+/** Fresh producer text must fit persistence/dispatch and the raw-weight context guard. */
+export type ToolResultBudget = { maxChars: number; maxContextChars: number };
+
+export function resolveToolResultContextMaxChars(contextWindowTokens: number): number {
+  return Math.max(1_024, Math.floor(Math.max(1, Math.floor(contextWindowTokens)) * 2 * 0.5));
+}
+
+export function resolveToolResultBudget(
+  contextWindowTokens?: number,
+): ToolResultBudget | undefined {
+  if (
+    contextWindowTokens === undefined ||
+    !Number.isFinite(contextWindowTokens) ||
+    contextWindowTokens <= 0
+  ) {
+    return undefined;
+  }
+  return {
+    maxChars: resolveLiveToolResultMaxChars({ contextWindowTokens }),
+    maxContextChars: resolveToolResultContextMaxChars(contextWindowTokens),
+  };
+}
+
+export function toolResultFitsBudget(text: string, budget?: ToolResultBudget): boolean {
+  return (
+    budget === undefined ||
+    (estimateToolResultTextChars(text) <= budget.maxChars &&
+      estimateToolResultTextChars(text, { minimumRawWeight: 2 }) <= budget.maxContextChars)
   );
 }

--- a/src/agents/tool-search-control-result.ts
+++ b/src/agents/tool-search-control-result.ts
@@ -1,0 +1,16 @@
+import {
+  truncateSanitizedExternalContent,
+  wrapExternalContent,
+} from "../security/external-content.js";
+
+/** Shared by the source projector and final formatter; no terminal receipts are consumed here. */
+export function renderToolSearchControlText(text: string, networkContent: boolean) {
+  if (!networkContent) {
+    return { text, truncated: false };
+  }
+  const bounded = truncateSanitizedExternalContent(text, 20_000);
+  const modelText = bounded.truncated
+    ? `${truncateSanitizedExternalContent(text, 19_988).text}\n[truncated]`
+    : bounded.text;
+  return { text: wrapExternalContent(modelText, { source: "api" }), truncated: bounded.truncated };
+}

--- a/src/agents/tool-search-runtime.ts
+++ b/src/agents/tool-search-runtime.ts
@@ -4,10 +4,6 @@ import {
   uniqueStrings,
 } from "@openclaw/normalization-core/string-normalization";
 import { getPluginToolMeta } from "../plugins/tools.js";
-import {
-  truncateSanitizedExternalContent,
-  wrapExternalContent,
-} from "../security/external-content.js";
 import { levenshteinDistance } from "../shared/levenshtein-distance.js";
 import {
   getBeforeToolCallFailureDisposition,
@@ -29,6 +25,7 @@ import {
   resolveCatalog,
   visibleCatalogEntries,
 } from "./tool-search-catalog.js";
+import { renderToolSearchControlText } from "./tool-search-control-result.js";
 import {
   buildLexicalIndex,
   readParameterText,
@@ -714,11 +711,7 @@ export function formatToolSearchControlResult<T>(
   let result: AgentToolResult<T> = jsonResult(payload);
   const content = result.content[0];
   if (runtime?.hasNetworkContent(parentToolCallId) && content?.type === "text") {
-    const bounded = truncateSanitizedExternalContent(content.text, 20_000);
-    const modelText = bounded.truncated
-      ? `${truncateSanitizedExternalContent(content.text, 19_988).text}\n[truncated]`
-      : bounded.text;
-    const text = wrapExternalContent(modelText, { source: "api" });
+    const { text } = renderToolSearchControlText(content.text, true);
     result = { ...result, content: [{ ...content, text }] };
   }
   const terminal =

--- a/test/scripts/prepare-extension-package-boundary-artifacts.test.ts
+++ b/test/scripts/prepare-extension-package-boundary-artifacts.test.ts
@@ -8,6 +8,7 @@ import { pathToFileURL } from "node:url";
 import { MAX_TIMER_TIMEOUT_MS } from "@openclaw/normalization-core/number-coercion";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { readArtifactRecord } from "../../scripts/lib/build-artifact-cache.mts";
+import { BOUNDARY_PLUGIN_UNITS } from "../../scripts/lib/extension-boundary-inputs.mts";
 import {
   createPrefixedOutputWriter,
   parseMode,
@@ -83,100 +84,126 @@ async function waitForProcessExit(
 }
 
 describe("prepare-extension-package-boundary-artifacts", () => {
-  it("prunes only obsolete native declarations after success and repairs a failed partial emit", async () => {
-    const root = fs.realpathSync(makeTempDir(tempRoots, "native-preparer-"));
-    const write = (file: string, text: string) => {
-      const target = path.join(root, file);
-      fs.mkdirSync(path.dirname(target), { recursive: true });
-      fs.writeFileSync(target, text);
-    };
-    write("package.json", '{"name":"openclaw","type":"module"}');
-    write("pnpm-workspace.yaml", "packages: []\n");
-    write(
-      "tsconfig.json",
-      JSON.stringify({
-        compilerOptions: {
-          target: "es2023",
-          module: "nodenext",
-          skipLibCheck: true,
-        },
-      }),
-    );
-    write(
-      "packages/plugin-sdk/tsconfig.json",
-      JSON.stringify({
-        extends: "../../tsconfig.json",
-        include: ["../../src/**/*.ts"],
-      }),
-    );
-    write("src/plugin-sdk/core.ts", 'export { value } from "../nested.js";');
-    write("src/nested.ts", "export const value = 1;");
-    write("scripts/lib/plugin-sdk-entrypoints.json", '["core"]');
-    const copy = (file: string) => {
-      const target = path.join(root, file);
-      fs.mkdirSync(path.dirname(target), { recursive: true });
-      fs.copyFileSync(path.resolve(file), target);
-    };
-    copy("scripts/prepare-extension-package-boundary-artifacts.mts");
-    copy("scripts/lib/plugin-sdk-entries.mts");
-    fs.cpSync(path.resolve("scripts/lib"), path.join(root, "scripts/lib"), { recursive: true });
-    write("scripts/lib/plugin-sdk-entrypoints.json", '["core"]');
-    for (const file of [
-      "scripts/run-tsgo.mjs",
-      "scripts/run-tsgo.mts",
-      "scripts/tsx.mjs",
-      "scripts/windows-cmd-helpers.mjs",
-    ]) {
-      copy(file);
-    }
-    for (const name of ["tsx", "typescript", "@typescript", "@openclaw/fs-safe", ".bin/tsgo"]) {
-      const target = path.join(root, "node_modules", name);
-      fs.mkdirSync(path.dirname(target), { recursive: true });
-      fs.symlinkSync(path.resolve("node_modules", name), target);
-    }
-    fs.symlinkSync(
-      path.resolve("packages/normalization-core"),
-      path.join(root, "packages/normalization-core"),
-      process.platform === "win32" ? "junction" : undefined,
-    );
-    const recordPath = path.join(root, ".artifacts/extension-package-boundary/plugin-sdk.json");
-    const output = "packages/plugin-sdk/dist";
-    const run = () =>
-      runNodeStep(
-        "native-fixture",
-        [
-          path.join(root, "scripts/prepare-extension-package-boundary-artifacts.mts"),
-          "--mode=package-boundary",
-        ],
-        30_000,
+  it.each(["package-boundary", "all"])(
+    "prunes only obsolete native declarations after success and repairs a failed partial emit (%s)",
+    async (mode) => {
+      const root = fs.realpathSync(makeTempDir(tempRoots, "native-preparer-"));
+      const write = (file: string, text: string) => {
+        const target = path.join(root, file);
+        fs.mkdirSync(path.dirname(target), { recursive: true });
+        fs.writeFileSync(target, text);
+      };
+      write("package.json", '{"name":"openclaw","type":"module"}');
+      write("pnpm-workspace.yaml", "packages: []\n");
+      write(
+        "tsconfig.json",
+        JSON.stringify({
+          compilerOptions: {
+            target: "es2023",
+            module: "nodenext",
+            skipLibCheck: true,
+          },
+        }),
       );
-    await run();
-    const first = readArtifactRecord(recordPath)!;
-    expect(first.outputs[`${output}/src/nested.d.ts`]).toBeDefined();
-    write("src/plugin-sdk/core.ts", 'export { value } from "../renamed.js";');
-    fs.renameSync(path.join(root, "src/nested.ts"), path.join(root, "src/renamed.ts"));
-    write("src/renamed.ts", 'export const value: number = "error";');
-    write(`${output}/orphan.d.ts`, "export {};");
-    write(`${output}/operator-note.txt`, "unowned");
-    await expect(run()).rejects.toThrow("failed with exit code 1");
-    expect(fs.existsSync(recordPath)).toBe(false);
-    expect(fs.existsSync(path.join(root, output, "src/renamed.d.ts"))).toBe(true);
-    expect(fs.existsSync(path.join(root, output, "src/nested.d.ts"))).toBe(true);
-    write("src/renamed.ts", "export const value = 2;");
-    await run();
-    const repaired = readArtifactRecord(recordPath)!;
-    expect(repaired.outputs[`${output}/src/renamed.d.ts`]).toBeDefined();
-    expect(repaired.outputs[`${output}/src/nested.d.ts`]).toBeUndefined();
-    expect(fs.existsSync(path.join(root, output, "src/nested.d.ts"))).toBe(false);
-    expect(fs.existsSync(path.join(root, output, "orphan.d.ts"))).toBe(false);
-    expect(fs.readFileSync(path.join(root, output, "operator-note.txt"), "utf8")).toBe("unowned");
-    fs.rmSync(path.join(root, output, "src/renamed.d.ts"));
-    await run();
-    expect(readArtifactRecord(recordPath)?.outputs).toEqual(repaired.outputs);
-    const unchanged = fs.statSync(path.join(root, output, "src/renamed.d.ts")).mtimeMs;
-    await run();
-    expect(fs.statSync(path.join(root, output, "src/renamed.d.ts")).mtimeMs).toBe(unchanged);
-  }, 30_000);
+      write(
+        "packages/plugin-sdk/tsconfig.json",
+        JSON.stringify({
+          extends: "../../tsconfig.json",
+          include: ["../../src/**/*.ts"],
+        }),
+      );
+      write("src/plugin-sdk/core.ts", 'export { value } from "../nested.js";');
+      write("src/nested.ts", "export const value = 1;");
+      write("scripts/lib/plugin-sdk-entrypoints.json", '["core"]');
+      const copy = (file: string) => {
+        const target = path.join(root, file);
+        fs.mkdirSync(path.dirname(target), { recursive: true });
+        fs.copyFileSync(path.resolve(file), target);
+      };
+      copy("scripts/prepare-extension-package-boundary-artifacts.mts");
+      copy("scripts/lib/plugin-sdk-entries.mts");
+      fs.cpSync(path.resolve("scripts/lib"), path.join(root, "scripts/lib"), { recursive: true });
+      write("scripts/lib/plugin-sdk-entrypoints.json", '["core"]');
+      for (const file of [
+        "scripts/run-tsgo.mjs",
+        "scripts/run-tsgo.mts",
+        "scripts/tsx.mjs",
+        "scripts/windows-cmd-helpers.mjs",
+      ]) {
+        copy(file);
+      }
+      for (const name of ["tsx", "typescript", "@typescript", "@openclaw/fs-safe", ".bin/tsgo"]) {
+        const target = path.join(root, "node_modules", name);
+        fs.mkdirSync(path.dirname(target), { recursive: true });
+        fs.symlinkSync(path.resolve("node_modules", name), target);
+      }
+      fs.symlinkSync(
+        path.resolve("packages/normalization-core"),
+        path.join(root, "packages/normalization-core"),
+        process.platform === "win32" ? "junction" : undefined,
+      );
+      write(
+        "packages/plugin-sdk/package.json",
+        '{"name":"fixture-sdk","type":"module","types":"./dist/src/plugin-sdk/core.d.ts"}',
+      );
+      fs.symlinkSync("../packages/plugin-sdk", path.join(root, "node_modules/fixture-sdk"), "dir");
+      const plugins = mode === "all" ? BOUNDARY_PLUGIN_UNITS : [];
+      for (const [id, entry] of plugins) {
+        write(
+          `extensions/${id}/tsconfig.json`,
+          JSON.stringify({ extends: "../../tsconfig.json", files: [`${entry}.ts`] }),
+        );
+        write(`extensions/${id}/${entry}.ts`, 'export { value } from "fixture-sdk";');
+      }
+      const recordPath = path.join(root, ".artifacts/extension-package-boundary/plugin-sdk.json");
+      const output = "packages/plugin-sdk/dist";
+      const run = () =>
+        runNodeStep(
+          "native-fixture",
+          [
+            path.join(root, "scripts/prepare-extension-package-boundary-artifacts.mts"),
+            `--mode=${mode}`,
+          ],
+          30_000,
+        );
+      await run();
+      const first = readArtifactRecord(recordPath)!;
+      expect(first.outputs[`${output}/src/nested.d.ts`]).toBeDefined();
+      write("src/plugin-sdk/core.ts", 'export { value } from "../renamed.js";');
+      fs.renameSync(path.join(root, "src/nested.ts"), path.join(root, "src/renamed.ts"));
+      write("src/renamed.ts", 'export const value: number = "error";');
+      write(`${output}/orphan.d.ts`, "export {};");
+      write(`${output}/operator-note.txt`, "unowned");
+      await expect(run()).rejects.toThrow("failed with exit code 1");
+      expect(fs.existsSync(recordPath)).toBe(false);
+      expect(fs.existsSync(path.join(root, output, "src/renamed.d.ts"))).toBe(true);
+      expect(fs.existsSync(path.join(root, output, "src/nested.d.ts"))).toBe(true);
+      write("src/renamed.ts", "export const value = 2;");
+      await run();
+      const repaired = readArtifactRecord(recordPath)!;
+      expect(repaired.outputs[`${output}/src/renamed.d.ts`]).toBeDefined();
+      expect(repaired.outputs[`${output}/src/nested.d.ts`]).toBeUndefined();
+      expect(fs.existsSync(path.join(root, output, "src/nested.d.ts"))).toBe(false);
+      expect(fs.existsSync(path.join(root, output, "orphan.d.ts"))).toBe(false);
+      expect(fs.readFileSync(path.join(root, output, "operator-note.txt"), "utf8")).toBe("unowned");
+      for (const [id, entry] of plugins) {
+        const record = readArtifactRecord(
+          path.join(root, `.artifacts/extension-package-boundary/${id}.json`),
+        )!;
+        expect(record.inputs).toContain(`${output}/src/renamed.d.ts`);
+        expect(
+          record.outputs[`.artifacts/extension-package-boundary/plugins/${id}/${entry}.d.ts`],
+        ).toBeDefined();
+      }
+      fs.rmSync(path.join(root, output, "src/renamed.d.ts"));
+      await run();
+      expect(readArtifactRecord(recordPath)?.outputs).toEqual(repaired.outputs);
+      const unchanged = fs.statSync(path.join(root, output, "src/renamed.d.ts")).mtimeMs;
+      await run();
+      expect(fs.statSync(path.join(root, output, "src/renamed.d.ts")).mtimeMs).toBe(unchanged);
+    },
+    30_000,
+  );
   it("prefixes each completed line and flushes the trailing partial line", () => {
     let output = "";
     const writer = createPrefixedOutputWriter("boundary", {


### PR DESCRIPTION
Closes #132926 — fresh tool results clipped after production, breaking Code Mode JSON and read continuations.
Related: #132850 — original-output provenance, whose arithmetic this follow-up preserves.

<details>
<summary>Additional instructions</summary>

Maintainer-owned branch in this repository; editable by maintainers. AI-assisted investigation, implementation and verification, published by Peter Steinberger (@steipete).

</details>

## What Problem This Solves

Fixes an issue where users running Code Mode with large output would receive malformed fresh control-result JSON when the model-context text allowance was smaller than the producer's byte allowance. The same mismatch could remove a conventional file read's continuation footer after its cursor had already advanced over the larger page.

The original accented fixture fits the normal 65,536-byte Code Mode allowance but is clipped by the later 32,000-weighted-text-unit limit at a 128k model context. This is a presentation/projection failure, not evidence of duplicate execution. Current-base regressions fail before repair on JSON parsing and the missing true read cursor. Stable-release reachability and the original introduction of the cross-budget mismatch are not established; shallow blame boundaries are not attributed as introducers.

## Why This Change Was Made

Pass the effective model allowance to semantic producers, then fit Code Mode's complete rendered envelope from retained original source before acknowledging delivery; reserve file-read continuation and filename framing before advancing the cursor. This preserves one canonical budget calculation, ordinary downstream guards, nested byte limits and existing authority/lifecycle boundaries instead of raising limits or trying to repair already-chopped JSON.

Conventional tool content is not universally JSON: shell/read text, mixed MCP content, images and structured `details` retain their existing contracts. Copilot now passes the effective attempt context rather than only the larger catalog window. Headless controls without a model budget retain their byte contract; aggregate history reduction, cache-TTL pruning and replay into smaller contexts remain intentionally lossy.

Validation also exposed a declaration-cache lifecycle defect: a pre-pruning SDK topology snapshot was reused by the next plugin compiler batch. A fresh snapshot after the preceding batch's cleanup fixes it without weakening topology/config/toolchain/ctime/inventory guards. This is isolated in the second commit and covered by the existing fixture extended to all seven plugin consumers.

## User Impact

Fresh Code Mode results retain complete status and usable continuation within existing limits, with omission counts still derived from original normalized output. Host and sandbox reads deliver the text their cursor claims and preserve the next cursor. Whole skill instructions remain whole-or-refused. No new configuration, environment option, schema, storage format, dependency, public protocol, or authority surface.

[Output contract documentation](https://docs.openclaw.ai/tools/code-mode#output-api).

## Evidence

### Source and independent review

The original verified candidate was built on `24ea93c8c642cc1c68ef38465ff713988a7f2d9c`; its 20 committed file contents matched the tested source hashes exactly. Rebased onto `45d9badf62c1bf122d6289bbf71703031d56ea4d` only after detecting actual conflicts with #132802's lazy-runtime import migration. Range-diff shows import-context changes only; the tooling commit is patch-identical. Candidate head: `148a06bb8a05b15c4616560f7815a94e6d063020`.

Two independent Codex autoreviews were clean at P0 scope, the second after the tooling repair; reviewers did not execute tests. This is not an all-priority clearance. Parent/worker read the producer, caller, persistence/context guards, lifecycle, conventional tool and sibling runtime paths.

Direct Codex OSS source/test-contract comparison at `6478a751fde8884b2fdc76486fe23175a8e795d4`: [exec raw-output projection and metadata reservation](https://github.com/openai/codex/blob/6478a751fde8884b2fdc76486fe23175a8e795d4/codex-rs/core/src/tools/context.rs#L345-L541), [generic history clipping](https://github.com/openai/codex/blob/6478a751fde8884b2fdc76486fe23175a8e795d4/codex-rs/core/src/context_manager/history.rs#L186-L212), and [Code Mode status framing](https://github.com/openai/codex/blob/6478a751fde8884b2fdc76486fe23175a8e795d4/codex-rs/core/src/tools/code_mode/mod.rs#L250-L342). No Rust tests or latest-remote claim. The useful pattern is producer-owned framing from original source, not a universal JSON guarantee.

### Failure-first and local verification

Original owner tests failed before the production edits on malformed accented Code Mode JSON and missing read cursors. Further regressions failed on Copilot forwarding 200,000 instead of effective 8,000 context, and filename-note framing being counted as file content. Actual QuickJS, file reads, ordinary context/provider transforms and SQLite transcript reload are exercised; the budget owners are not mocked.

Before rebase: 581 focused tests across 15 files; parent final selection 201 across six files; declaration/cache owners 44 across two files. These selections overlap and are not summed. Full changed checks and a fresh normal build passed. The first isolated check omitted the installed Corepack path; that environment was corrected without changing runtime. The next check found the real declaration-cache bug repaired here; the final full check passed.

After the conflict-only rebase, **243 tests passed across eight files/five shards in 126 seconds**, including the same budget/read/Copilot boundaries and lazy bridge/swarm siblings. A fresh normal build also passed in 417 seconds, with unchanged source/dependencies/HEAD and cleaned isolated temporary state. The fresh-build binding digest is `eba4c782165f7556e3085ee5a7a9758f6234dde33b755ec4e49756f3b0152a0b`; it binds candidate head `148a06bb8a05b15c4616560f7815a94e6d063020` and the complete built distribution. Exact local commands are recorded below.

Runtime: Node 26.8.1, QuickJS-WASI 3.5.0, AIMock 1.39.0, Playwright 1.62.1. Trusted tests/builds used isolated HOME/config/state/temp roots and the repository wrappers. No operator Gateway/state, live credentials, auth/SSRF/context bypass, output-limit increase, or dependency patch.

### Real Gateway / QuickJS / Control UI

The three-case real-flow proof passed again on the rebased head in **104 seconds**, using its freshly built distribution (`candidate-002`, `handoff-002`). All 15 original screenshots and three full-duration 2fps video timelines were inspected alongside full-resolution states; durations 6.84s, 5.44s and 6.08s. This is sampled-timeline inspection, not an every-frame claim. Source/dist/dependency/driver bindings stayed unchanged; no input mutations were observed. The runner exited naturally with code 0, all recorded descendants/groups and sockets were gone, isolated roots were removed, and the health-only controller was stopped.

Normal New Session → Start → compiled Gateway → actual QuickJS → normal persistence/provider projection → deterministic AIMock Responses endpoint. Exactly one exec and one wait per case; exact arguments and issued/public/replay IDs correlated. Earlier exec replay remains unchanged; provider/history/full-message result text is byte-identical, and normal side-panel JSON matches. Callback/HTTP/journal accounting is checked after owner drain, with no unknown/retry/fallback rows accepted.

| Case | Original bytes | Prefix bytes | Exact omitted | Output + value bytes | Complete provider text units |
| --- | ---: | ---: | ---: | ---: | ---: |
| Original 1 KiB accented | 1,093 | 896 | 197 | 1,023 / 1,024 | 1,008 / 32,000 |
| Original default accented | 72,053 | 62,878 | 9,175 | 63,006 / 65,536 | 32,000 / 32,000 |
| Equal-byte Euro control | 72,053 | 65,408 | 6,645 | 65,536 / 65,536 | 28,372 / 32,000 |

All three complete results parse, finish with `value: true`, and match independently constructed original-source prefix/omission arithmetic. Whole default-accented text is 63,414 UTF-8 bytes; outer framing is distinct from the byte-channel charge. For this closed fixture alphabet, the weighted estimate equals UTF-16 length, not tokenizer accuracy. The Euro control alone does not prove the original accented case.

The normal GitHub client now accepts the ready transition and approved attachment upload route; no policy/client configuration was changed or bypassed. The previously blocked inspected media is attached below. These are the **deterministic AIMock** runs described above, not authenticated-provider evidence.

Historical v7 before, UI at the provider JSON parse failure:

![Historical accented-case UI before producer budgeting](https://github.com/user-attachments/assets/956ae315-0a07-43a9-8750-b4e724bc84d7)

Rebased candidate after, original accented case with exact independently verified omission counts:

![Rebased accented-case UI after producer budgeting](https://github.com/user-attachments/assets/9d123230-f67e-4933-baf7-cb8b5389419f)

Inspected rebased normal UI flow:

https://github.com/user-attachments/assets/a7eeb503-1593-4bf5-b41e-98d8ed8ed6a9

Local source/receipt root: `.artifacts/qa-e2e/code-mode-repair-b4970f/result-budget-followup/gateway-proof-v1/`; historical before remains under `output-provenance/gateway-proof-v7/candidate-001/default/`.

Historical before is the retained v7 accented failure: 63,285 bytes, exactly 32,000 text units, invalid JSON. It is not relabeled as a new baseline run. The before screenshot shows UI state at the provider parse failure, not every malformed payload byte. New failure-first tests separately establish the defect on the implementation base.

This is real local Gateway/QuickJS/UI proof with deterministic provider responses, not authenticated-provider or uncoached-model behavior. Conventional read proof is at the real filesystem/guard/persistence boundary, not a separate live UI read recording. Images cannot prove all payload bytes; public-API/provider equality and independent arithmetic do. Final UI disconnection is intentional teardown of the owned Gateway. No raw agent transcripts or private runtime data are published.

### Size and design tradeoff

20 files: production **+413/-237 (net +176)**; tooling **+2/-2 (net 0)**; tests **+592/-112 (net +480)**; docs **+18**. Paging moves cancel in the net. Growth supplies the missing producer-budget handoff and complete-envelope/framing allocation; old per-call envelope assembly was replaced and unnecessary internal re-exports removed. Raising limits, generic JSON detection/salvage, and a persisted reconstruction framework were rejected because they violate the existing limit or content contracts. No fallback stack or test-only production seam was added.

<details>
<summary>Exact local commands</summary>

### Exact local command record

Rebased owner/sibling tests: **243 passed / 8 files / 5 shards**, 126 seconds including the isolated wrapper.

```bash
node scripts/run-vitest.mjs src/agents/code-mode.result-budget.test.ts src/agents/code-mode.output.test.ts src/agents/code-mode.catalog-lifetime.test.ts src/agents/sessions/tools/read.test.ts src/agents/harness/tool-surface-bridge.test.ts extensions/copilot/src/tool-bridge.test.ts src/agents/code-mode.bridge.lifecycle.test.ts src/agents/code-mode-swarm.test.ts
```

Declaration/cache owner proof before the import-only rebase: **44 passed / 2 files**; this commit is patch-identical after rebase.

```bash
node scripts/run-vitest.mjs test/scripts/prepare-extension-package-boundary-artifacts.test.ts test/scripts/build-artifact-cache.test.ts
```

Full changed gate before rebase: **passed**, 766 seconds. The explicit paths below include all 20 task files, including then-untracked additions.

```bash
node scripts/check-changed.mjs --base 24ea93c8c642cc1c68ef38465ff713988a7f2d9c -- docs/tools/code-mode.md extensions/copilot/src/tool-bridge.test.ts extensions/copilot/src/tool-bridge.ts scripts/prepare-extension-package-boundary-artifacts.mts src/agents/agent-tools.read.ts src/agents/code-mode-execution.ts src/agents/code-mode-json.ts src/agents/code-mode-state.ts src/agents/code-mode.result-budget.test.ts src/agents/code-mode.ts src/agents/core-coding-tools.ts src/agents/embedded-agent-runner/run/attempt-tool-catalog.ts src/agents/embedded-agent-runner/tool-result-context-guard.ts src/agents/harness/tool-surface-bridge.ts src/agents/sessions/tools/read-page.ts src/agents/sessions/tools/read.ts src/agents/tool-result-limits.ts src/agents/tool-search-control-result.ts src/agents/tool-search-runtime.ts test/scripts/prepare-extension-package-boundary-artifacts.test.ts
```

Normal build command, before rebase and repeated for the rebased candidate:

```bash
pnpm build
```

Each test/check/build command ran with Node 26.8.1 first on PATH, `CI=1`, an isolated HOME/config/state/temp root, and `OPENCLAW_VITEST_MAX_WORKERS=1`. Source/dependency/HEAD stability and cleanup were recorded separately. Runtime/provider secrets were not used. The compiled Gateway proof uses the existing QA child owner, actual QuickJS and the normal Control UI, with a sealed fresh-build binding and a strict deterministic AIMock oracle. It is not authenticated-provider or uncoached-model evidence.

</details>
