### PR TITLE
perf(agents): trim history without temporary arrays

### DIFF
--- a/src/agents/embedded-agent-runner/history.ts
+++ b/src/agents/embedded-agent-runner/history.ts
@@ -57,14 +57,9 @@ export function limitHistoryTurns(
     conversationStart++;
   }
 
-  const tail = messages.slice(conversationStart);
-  if (tail.length === 0) {
-    return messages;
-  }
-
   let userCount = 0;
-  for (const message of tail) {
-    if (message.role === "user") {
+  for (let i = conversationStart; i < messages.length; i++) {
+    if (messages[i]?.role === "user") {
       userCount++;
     }
   }
@@ -80,13 +75,13 @@ export function limitHistoryTurns(
   const userTurnsToKeep = targetUserTurns + ((userCount - targetUserTurns) % evictionBatchSize);
 
   userCount = 0;
-  let lastUserIndex = tail.length;
+  let lastUserIndex = messages.length;
 
-  for (const [i, message] of Array.from(tail.entries()).toReversed()) {
-    if (message.role === "user") {
+  for (let i = messages.length - 1; i >= conversationStart; i--) {
+    if (messages[i]?.role === "user") {
       userCount++;
       if (userCount > userTurnsToKeep) {
-        return [...messages.slice(0, conversationStart), ...tail.slice(lastUserIndex)];
+        return [...messages.slice(0, conversationStart), ...messages.slice(lastUserIndex)];
       }
       lastUserIndex = i;
     }


### PR DESCRIPTION
## What Problem This Solves

The embedded history limiter copied the whole conversation tail even when no cut was needed. When trimming, it also built all index/message pairs and reversed them, just to locate the retained suffix. Large histories therefore generated avoidable CPU work and temporary arrays on turn preparation and compaction.

This is an AI-assisted, maintainer-requested performance cleanup.

## Why This Change Was Made

Scan the original message array directly and allocate a result only when a cut is needed. Keep the existing 50% cushion and batch-eviction formula, leading compaction/reset preludes, message order, retained object identities, and unchanged-array identity. Provider replay preservation and tool-call/result repair remain at their existing caller boundaries.

Production LOC: +6/-11 (net -5). Tests unchanged: the existing limiter and channel-policy suites already exercise the behavior; another test mirroring indexed loops would add little value. No dependencies, public options, schema changes, or compatibility paths were added.

## User Impact

Configured history limiting does less allocation work, especially for long transcripts that need trimming. Retained content and prompt-cache boundaries are unchanged. This owner belongs to the built-in OpenClaw harness; native Codex history management is unaffected.

## Evidence

- `pnpm test src/agents/embedded-agent-runner.limithistoryturns.test.ts src/agents/embedded-agent-runner/history.test.ts packages/ai/src/transports/provider-compaction-replay.test.ts`: 72 tests passed.
- 15,461 before/after comparisons passed for exact serialized bytes, retained message-object identity, unchanged-array identity, and frozen source arrays/messages. Cases include repeated cushion cycles, fractional/disabled limits, summaries and marked preludes, tool-call/result rounds, and large histories.
- Independent source review traced normal turns and compaction through the shared limiter, provider replay window preservation, and post-limit tool pairing. Structured Codex review found no actionable issues.
- Formatting, targeted lint, `pnpm build`, and exact-head hosted CI passed. The required `openclaw/ci-gate` is green.

Quiet repeated measurements on Node 26.8.1/macOS (separate processes, 200 warmups, five batches):

| Workload | Before | After |
| --- | ---: | ---: |
| 164 messages, limit 8, trimming | 2.406 µs | 0.370 µs |
| 4,004 messages, limit 20, trimming | 54.714 µs | 6.458 µs |
| 40,004 messages, limit 20, trimming | 620.532 µs | 50.245 µs |
| 4,004 messages, limit 800, inside cushion | 4.798 µs | 5.393 µs |

The inside-cushion case is about 0.59 µs slower while avoiding the tail allocation. For the 40,004-message process, maximum RSS fell from 277,616 to 85,488 KiB. These are local helper measurements, not whole-turn latency or universal memory claims.

## Review Scope

Owner: `src/agents/embedded-agent-runner/history.ts`. Callers: `run/attempt-history.ts` and `compaction-session-execution.ts`. Related contracts: `packages/ai/src/transports/provider-compaction-replay.ts`, `src/agents/session-transcript-repair.ts`, and the existing history suites. Upstream Codex context normalization was inspected directly; its separate history flow is unchanged.

Live proof: 14 real OpenAI turns (seven before and seven after), using the built-in OpenClaw harness and the existing DM history limit of 2. Both sequences retained 0,1,2,3,2,3,2 historical user turns; the cuts were 8→4, 12→8, and14→6 messages, including a real web-fetch tool-call/result pair. Cache-trace message fingerprints prove every retained message matches its source exactly. The same cuts and role ordering occurred before and after.

The isolated test gateway kept Telegram disabled and used no external delivery. The initial benchmark setup used the existing skip-channels environment flag, which intentionally removes channel configuration (including history limits); those untrimmed runs were discarded as trimming evidence. The corrected setup retained configuration while leaving the channel disabled. Full trace payloads have diagnostic size caps, so the equality check uses the canonical per-message fingerprints rather than comparing redacted payload copies.

Maintainer review is complete under the requested autonomous landing workflow. The latest ClawSweeper review reports no actionable findings; its remaining maintainer-decision note is satisfied by this requested work. No additional GitHub approval rule is enforced for this change.
