### PR TITLE
fix(ci): Telegram QA fails after successful channel run

### DIFF
--- a/.github/workflows/openclaw-release-telegram-qa.yml
+++ b/.github/workflows/openclaw-release-telegram-qa.yml
@@ -1425,6 +1425,11 @@ jobs:
             exec sudo -n -- "$0" --root-terminate-uid
           fi
 
+          if [[ "${1:-}" == "--release-temp-root" ]]; then
+            shift
+            exec sudo -n -- "$0" --root-release-temp-root "$@"
+          fi
+
           if [[ "${1:-}" == "--verify" ]]; then
             shift
             exec sudo -n -- "$0" --root-verify "$@"
@@ -1493,6 +1498,29 @@ jobs:
             [[ "$EUID" == "0" ]]
             source /etc/openclaw-telegram-sut.conf
             terminate_sut_uid
+            exit 0
+          fi
+
+          if [[ "${1:-}" == "--root-release-temp-root" ]]; then
+            [[ "$EUID" == "0" ]]
+            source /etc/openclaw-telegram-sut.conf
+            shift
+            requested_temp_root="$(readlink -f -- "${1:?}")"
+            case "$requested_temp_root" in
+              "$RUNTIME_ROOT"/tmp/openclaw-qa-suite-*|"$RUNTIME_ROOT"/tmp/openclaw-"$RUNNER_UID"/openclaw-qa-suite-*) ;;
+              *) echo "Refusing Telegram SUT temp-root release outside the runtime root." >&2; exit 1 ;;
+            esac
+            [[ -d "$requested_temp_root" && ! -L "$requested_temp_root" ]]
+            # Revalidate the authoritative UID at the privileged use itself;
+            # earlier process-group settlement is not a transferable claim.
+            for _ in 1 2; do
+              if sut_uid_processes_alive; then
+                echo "Refusing Telegram SUT temp-root release while its UID is alive." >&2
+                exit 1
+              fi
+              sleep 1
+            done
+            chown -R -h -- "$RUNNER_UID:$RUNNER_GID" "$requested_temp_root"
             exit 0
           fi
 
@@ -1906,9 +1934,6 @@ jobs:
                     exec "$runtime_node_bin" "${runtime_node_args[@]}"
                   '\'' openclaw-sut "$@"
             ' openclaw-sut "$@"
-          # The isolated runtime owns its private state only while it is alive.
-          # Return deletion authority before the trusted lifecycle observes exit.
-          chown -R -h -- "$RUNNER_UID:$RUNNER_GID" "$temp_root"
           LAUNCHER
           sudo chown root:root "$launcher"
           sudo chmod 0755 "$launcher"

--- a/.github/workflows/openclaw-release-telegram-qa.yml
+++ b/.github/workflows/openclaw-release-telegram-qa.yml
@@ -1906,6 +1906,9 @@ jobs:
                     exec "$runtime_node_bin" "${runtime_node_args[@]}"
                   '\'' openclaw-sut "$@"
             ' openclaw-sut "$@"
+          # The isolated runtime owns its private state only while it is alive.
+          # Return deletion authority before the trusted lifecycle observes exit.
+          chown -R -h -- "$RUNNER_UID:$RUNNER_GID" "$temp_root"
           LAUNCHER
           sudo chown root:root "$launcher"
           sudo chmod 0755 "$launcher"

--- a/.github/workflows/openclaw-release-telegram-qa.yml
+++ b/.github/workflows/openclaw-release-telegram-qa.yml
@@ -1940,26 +1940,26 @@ jobs:
 
           # Exercise the real sudo boundary before credentials or channel work:
           # a live isolated UID must block handoff, then quiescence must permit it.
-          release_proof_root="${RUNTIME_ROOT}/tmp/openclaw-qa-suite-release-proof"
+          release_proof_root="${runtime_root}/tmp/openclaw-qa-suite-release-proof"
           mkdir -p "$release_proof_root/state"
-          sudo chown -R "$SUT_UID:$SUT_GID" "$release_proof_root/state"
+          sudo chown -R "$sut_uid:$sut_gid" "$release_proof_root/state"
           sudo chmod 0700 "$release_proof_root/state"
-          sudo -u "$SUT_USER" -- setsid sleep 30 &
+          sudo -u "$sut_user" -- setsid sleep 30 &
           release_proof_pid=$!
           for _ in $(seq 1 20); do
-            pgrep -U "$SUT_UID" >/dev/null 2>&1 && break
+            pgrep -U "$sut_uid" >/dev/null 2>&1 && break
             sleep 0.1
           done
-          pgrep -U "$SUT_UID" >/dev/null 2>&1
+          pgrep -U "$sut_uid" >/dev/null 2>&1
           if "$launcher" --release-temp-root "$release_proof_root"; then
             echo "Telegram SUT temp-root release accepted a live isolated UID." >&2
             exit 1
           fi
-          [[ "$(stat -c '%u:%g' "$release_proof_root/state")" == "$SUT_UID:$SUT_GID" ]]
+          [[ "$(stat -c '%u:%g' "$release_proof_root/state")" == "$sut_uid:$sut_gid" ]]
           "$launcher" --terminate-uid
           wait "$release_proof_pid" 2>/dev/null || true
           "$launcher" --release-temp-root "$release_proof_root"
-          [[ "$(stat -c '%u:%g' "$release_proof_root/state")" == "$RUNNER_UID:$RUNNER_GID" ]]
+          [[ "$(stat -c '%u:%g' "$release_proof_root/state")" == "$runner_uid:$runner_gid" ]]
           rm -rf -- "$release_proof_root"
           echo "Telegram SUT privileged temp-root release proof passed."
 

--- a/.github/workflows/openclaw-release-telegram-qa.yml
+++ b/.github/workflows/openclaw-release-telegram-qa.yml
@@ -1938,6 +1938,31 @@ jobs:
           sudo chown root:root "$launcher"
           sudo chmod 0755 "$launcher"
 
+          # Exercise the real sudo boundary before credentials or channel work:
+          # a live isolated UID must block handoff, then quiescence must permit it.
+          release_proof_root="${RUNTIME_ROOT}/tmp/openclaw-qa-suite-release-proof"
+          mkdir -p "$release_proof_root/state"
+          sudo chown -R "$SUT_UID:$SUT_GID" "$release_proof_root/state"
+          sudo chmod 0700 "$release_proof_root/state"
+          sudo -u "$SUT_USER" -- setsid sleep 30 &
+          release_proof_pid=$!
+          for _ in $(seq 1 20); do
+            pgrep -U "$SUT_UID" >/dev/null 2>&1 && break
+            sleep 0.1
+          done
+          pgrep -U "$SUT_UID" >/dev/null 2>&1
+          if "$launcher" --release-temp-root "$release_proof_root"; then
+            echo "Telegram SUT temp-root release accepted a live isolated UID." >&2
+            exit 1
+          fi
+          [[ "$(stat -c '%u:%g' "$release_proof_root/state")" == "$SUT_UID:$SUT_GID" ]]
+          "$launcher" --terminate-uid
+          wait "$release_proof_pid" 2>/dev/null || true
+          "$launcher" --release-temp-root "$release_proof_root"
+          [[ "$(stat -c '%u:%g' "$release_proof_root/state")" == "$RUNNER_UID:$RUNNER_GID" ]]
+          rm -rf -- "$release_proof_root"
+          echo "Telegram SUT privileged temp-root release proof passed."
+
           forwarded_env_keys="$(
             sed -n '/^transport_keys=(/,/^)/p' "$launcher" |
               sed -n '2,$p' |

--- a/extensions/qa-lab/src/gateway-child-lifecycle.test.ts
+++ b/extensions/qa-lab/src/gateway-child-lifecycle.test.ts
@@ -202,6 +202,7 @@ describe.skipIf(process.platform === "win32")("QA gateway lifetime ownership", (
       abort: async () => {
         throw diagnostic;
       },
+      releaseTempRoot: async () => {},
     });
     const owner = own({
       ...params,
@@ -449,6 +450,74 @@ describe.skipIf(process.platform === "win32")("QA gateway lifetime ownership", (
     expect(log).toContain("QA_DESCENDANT_FINAL_OUTPUT");
     expect(pids().every((pid) => !isQaPosixProcessGroupAlive(pid))).toBe(true);
   });
+
+  it.runIf(process.platform === "linux")(
+    "returns cleanup authority only after a lingering descendant settles",
+    async () => {
+      const { params, pids } = await fixture("descendant");
+      let protectedState = "";
+      const releaseTempRoot = vi.fn(async () => {
+        expect(pids().every((pid) => !isQaPosixProcessGroupAlive(pid))).toBe(true);
+        await fs.chmod(protectedState, 0o700);
+      });
+      boundary.create.mockResolvedValue({
+        prepare: async ({ env }: { env: NodeJS.ProcessEnv }) => ({ env }),
+        accept: async ({ child }: { child: { pid: number } }) => {
+          groups.push(child.pid);
+          return {};
+        },
+        abort: async () => {},
+        signal: async () => {},
+        markReady: async () => {},
+        markExited: async () => {},
+        releaseTempRoot,
+      });
+      const owner = own({
+        ...params,
+        command: {
+          ...params.command,
+          processBoundary: {
+            kind: "linux-proc-v1",
+            evidenceDir: params.command.tempParentDir,
+            expectedGid: 1,
+            expectedUid: 1,
+            forwardedEnvKeys: [],
+            runtimeArgsPrefix: [],
+            runtimeExecutablePath: process.execPath,
+            terminationRetryTimeoutMs: 45_000,
+          },
+        },
+      });
+      const gateway = await owner.start();
+      protectedState = path.join(gateway.tempRoot, "state");
+      await fs.mkdir(protectedState);
+      await fs.writeFile(path.join(protectedState, "owned"), "sut");
+      await fs.chmod(protectedState, 0o000);
+      const realKill = process.kill.bind(process);
+      const signalFault = vi.spyOn(process, "kill").mockImplementation((pid, signal) => {
+        const replacement = pids()[1];
+        if (replacement && pid === -replacement && (signal === "SIGTERM" || signal === "SIGKILL")) {
+          throw Object.assign(new Error("owned replacement signal denied"), { code: "EPERM" });
+        }
+        return realKill(pid, signal);
+      });
+      try {
+        await expect(gateway.restartAfterStateMutation(async () => {})).rejects.toBeInstanceOf(
+          AggregateError,
+        );
+        await expect(owner.stop()).resolves.toMatchObject({ process: "unconfirmed" });
+        expect(isQaPosixProcessGroupAlive(pids()[1]!)).toBe(true);
+        await expect(fs.readdir(protectedState)).rejects.toMatchObject({ code: "EACCES" });
+        expect(releaseTempRoot).not.toHaveBeenCalled();
+      } finally {
+        signalFault.mockRestore();
+      }
+
+      await expect(owner.stop()).resolves.toEqual({ process: "confirmed-stopped", errors: [] });
+      expect(releaseTempRoot).toHaveBeenCalledOnce();
+      await expect(fs.stat(gateway.tempRoot)).rejects.toMatchObject({ code: "ENOENT" });
+    },
+  );
 
   it("does not spawn a replacement after stop closes an awaited mutation", async () => {
     const { params, pids } = await fixture();

--- a/extensions/qa-lab/src/gateway-child-lifecycle.test.ts
+++ b/extensions/qa-lab/src/gateway-child-lifecycle.test.ts
@@ -489,7 +489,7 @@ describe.skipIf(process.platform === "win32")("QA gateway lifetime ownership", (
         },
       });
       const gateway = await owner.start();
-      protectedState = path.join(gateway.tempRoot, "state");
+      protectedState = path.join(gateway.tempRoot, "state", "sut-owned");
       await fs.mkdir(protectedState);
       await fs.writeFile(path.join(protectedState, "owned"), "sut");
       await fs.chmod(protectedState, 0o000);

--- a/extensions/qa-lab/src/gateway-child-lifecycle.ts
+++ b/extensions/qa-lab/src/gateway-child-lifecycle.ts
@@ -244,6 +244,17 @@ export class QaGatewayChildLifecycle {
     await attempt(async () => this.current?.checkFailure());
     const tempRoot = this.tempRoot;
     const keepTemp = opts?.keepTemp ?? this.keepTemp;
+    let cleanupAuthorized = true;
+    if (tempRoot && this.controller && stopped.process !== "unconfirmed" && !keepTemp) {
+      try {
+        // The privileged boundary revalidates UID quiescence at ownership handoff.
+        // Cleanup must never race a descendant that still owns private state.
+        await this.controller.releaseTempRoot();
+      } catch (error) {
+        cleanupAuthorized = false;
+        errors.push(error);
+      }
+    }
     let artifactsPreserved = true;
     if (tempRoot && opts?.preserveToDir && !keepTemp && !this.artifactsFinalized) {
       try {
@@ -263,7 +274,13 @@ export class QaGatewayChildLifecycle {
         );
       }
     }
-    if (tempRoot && stopped.process !== "unconfirmed" && artifactsPreserved && !keepTemp) {
+    if (
+      tempRoot &&
+      stopped.process !== "unconfirmed" &&
+      cleanupAuthorized &&
+      artifactsPreserved &&
+      !keepTemp
+    ) {
       // Finalize artifact policy before cleanup can delete its log sources.
       // Unconfirmed stops must keep refreshing their still-writable snapshots.
       this.artifactsFinalized = true;

--- a/extensions/qa-lab/src/gateway-process-boundary.ts
+++ b/extensions/qa-lab/src/gateway-process-boundary.ts
@@ -364,6 +364,15 @@ async function runBoundaryTermination(params: { launcherPath: string; identityFi
   });
 }
 
+async function runBoundaryTempRootRelease(params: { launcherPath: string; tempRoot: string }) {
+  await runBoundaryLauncherCommand({
+    args: ["--release-temp-root", params.tempRoot],
+    label: "temporary-root release",
+    launcherPath: params.launcherPath,
+    timeoutMs: PROCESS_BOUNDARY_CONTROL_TIMEOUT_MS,
+  });
+}
+
 async function runBoundaryUidTermination(launcherPath: string) {
   await runBoundaryLauncherCommand({
     args: ["--terminate-uid"],
@@ -771,6 +780,13 @@ export async function createQaGatewayProcessBoundaryController(params: {
     await clearCredentialLeaseRetention();
   };
 
+  const releaseTempRoot = async () => {
+    await runBoundaryTempRootRelease({
+      launcherPath: params.launcherPath,
+      tempRoot,
+    });
+  };
+
   return {
     prepare,
     accept,
@@ -778,6 +794,7 @@ export async function createQaGatewayProcessBoundaryController(params: {
     signal,
     markReady,
     markExited,
+    releaseTempRoot,
     evidencePath,
     retainCredentialLeasePath,
     retainCredentialLease,

--- a/test/scripts/openclaw-release-telegram-qa-workflow.test.ts
+++ b/test/scripts/openclaw-release-telegram-qa-workflow.test.ts
@@ -941,6 +941,10 @@ describe("release Telegram QA workflow", () => {
     expect(quiescenceCheck).toBeGreaterThan(-1);
     expect(ownershipReturn).toBeGreaterThan(quiescenceCheck);
     expect(launcher).not.toContain('chown -R -h -- "$RUNNER_UID:$RUNNER_GID" "$temp_root"');
+    expect(createSut).toContain(
+      'echo "Telegram SUT temp-root release accepted a live isolated UID." >&2',
+    );
+    expect(createSut).toContain('echo "Telegram SUT privileged temp-root release proof passed."');
   });
 
   it("lets the SUT create suite locks without exposing the runner-owned config", () => {

--- a/test/scripts/openclaw-release-telegram-qa-workflow.test.ts
+++ b/test/scripts/openclaw-release-telegram-qa-workflow.test.ts
@@ -926,19 +926,21 @@ describe("release Telegram QA workflow", () => {
     );
   });
 
-  it("returns the stopped SUT tree to the trusted cleanup owner", () => {
+  it("returns the settled SUT tree to the trusted cleanup owner", () => {
     const createSut = requireRun(
       "run_telegram",
       "Create isolated Telegram SUT identity and launcher",
     );
     const launcher = extractHereDocument(createSut, "LAUNCHER");
-    const runtimeExit = launcher.lastIndexOf('\' openclaw-sut "$@"');
+    expect(launcher).toContain('exec sudo -n -- "$0" --root-release-temp-root "$@"');
+    expect(launcher).toContain('if [[ "${1:-}" == "--root-release-temp-root" ]]; then');
+    const quiescenceCheck = launcher.indexOf("if sut_uid_processes_alive; then");
     const ownershipReturn = launcher.indexOf(
-      'chown -R -h -- "$RUNNER_UID:$RUNNER_GID" "$temp_root"',
+      'chown -R -h -- "$RUNNER_UID:$RUNNER_GID" "$requested_temp_root"',
     );
-
-    expect(runtimeExit).toBeGreaterThan(-1);
-    expect(ownershipReturn).toBeGreaterThan(runtimeExit);
+    expect(quiescenceCheck).toBeGreaterThan(-1);
+    expect(ownershipReturn).toBeGreaterThan(quiescenceCheck);
+    expect(launcher).not.toContain('chown -R -h -- "$RUNNER_UID:$RUNNER_GID" "$temp_root"');
   });
 
   it("lets the SUT create suite locks without exposing the runner-owned config", () => {

--- a/test/scripts/openclaw-release-telegram-qa-workflow.test.ts
+++ b/test/scripts/openclaw-release-telegram-qa-workflow.test.ts
@@ -926,6 +926,21 @@ describe("release Telegram QA workflow", () => {
     );
   });
 
+  it("returns the stopped SUT tree to the trusted cleanup owner", () => {
+    const createSut = requireRun(
+      "run_telegram",
+      "Create isolated Telegram SUT identity and launcher",
+    );
+    const launcher = extractHereDocument(createSut, "LAUNCHER");
+    const runtimeExit = launcher.lastIndexOf('\' openclaw-sut "$@"');
+    const ownershipReturn = launcher.indexOf(
+      'chown -R -h -- "$RUNNER_UID:$RUNNER_GID" "$temp_root"',
+    );
+
+    expect(runtimeExit).toBeGreaterThan(-1);
+    expect(ownershipReturn).toBeGreaterThan(runtimeExit);
+  });
+
   it("lets the SUT create suite locks without exposing the runner-owned config", () => {
     const createSut = requireRun(
       "run_telegram",


### PR DESCRIPTION
Related: #132836

## What Problem This Solves

Fixes release Telegram QA passing channel scenarios but failing runner cleanup with EACCES on isolated Gateway state.

## Root Cause and Canonical Fix

The privileged SUT launcher makes runtime state UID-owned while cleanup remains runner-owned. Direct launcher exit does not prove descendant settlement.

The QA lifecycle now waits for every owned process tree to settle, then calls one privileged temp-root release. The launcher canonicalizes and allowlists the suite root, independently requires two empty isolated-UID probes, and only then returns ownership. Cleanup stays disabled after an unconfirmed stop or failed release. The old post-unshare ownership return is removed.

## Evidence

- Original failure: https://github.com/openclaw/openclaw/actions/runs/33278941146/job/99171190227
- Focused suite: 33 passed, 3 platform-skipped locally.
- Exact-head Linux regression deliberately retains a descendant, proves unconfirmed stop plus runner EACCES and no release call, then proves settlement, release, and deletion.
- Real privileged proof: tooling head 3feedc9060f run https://github.com/openclaw/openclaw/actions/runs/33286746057 job 99191729676 logged `Refusing Telegram SUT temp-root release while its UID is alive.` and, after verified UID termination, `Telegram SUT privileged temp-root release proof passed.`
- The following current-main candidate canary reproduced the original cleanup EACCES because that candidate intentionally lacks this PR runtime fix.
- Changed checks passed locally after dependency installation.
- Codex autoreview through P1: scoped-clean, patch correct (0.94).

Production/tooling LOC establishes the missing privileged ownership-release boundary and its fail-closed lifecycle integration. No authenticated secret is logged.

## User Impact

Release Telegram QA can clean isolated state after successful runs without exposing it to the runner while any SUT process remains alive.
