### PR TITLE
fix(test): preserve shutdown fixture cancellation outcomes

### DIFF
--- a/test/fixtures/vitest-fork-shutdown.mjs
+++ b/test/fixtures/vitest-fork-shutdown.mjs
@@ -3,8 +3,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { PassThrough } from "node:stream";
 import { fileURLToPath, pathToFileURL } from "node:url";
-import { spawnOwnedVitestProcess } from "../../scripts/lib/vitest-process.mts";
-import { installVitestProcessGroupCleanup } from "../../scripts/vitest-process-group.mts";
+import { runVitestShutdownCommand } from "../helpers/vitest-shutdown-command.ts";
 
 const [root, rawOptions] = process.argv.slice(2);
 const { scenario, setup, fail } = JSON.parse(rawOptions);
@@ -146,7 +145,7 @@ if (scenario === "forced") {
     `
 if (process.send) {
   process.on("SIGTERM", () => {});
-  fs.writeFileSync(${JSON.stringify(ready)}, "ready");
+  fs.writeFileSync(${JSON.stringify(ready)}, String(process.pid));
 }
 `,
   );
@@ -172,7 +171,13 @@ if (process.send) {
   } finally {
     await worker.stop();
   }
-  console.log(JSON.stringify({ ...(await exited), stopped: true }));
+  console.log(
+    JSON.stringify({
+      ...(await exited),
+      workerPid: Number(fs.readFileSync(ready, "utf8")),
+      stopped: true,
+    }),
+  );
 } else {
   const setupFiles =
     setup === "raw"
@@ -284,63 +289,61 @@ it("completes the test before worker shutdown", () => {
       `--execArgv=--heap-prof-dir=${profiles}`,
     );
   }
-  const { child, completion } = spawnOwnedVitestProcess({
-    command: process.execPath,
+  const { code, stdout, stderr } = await runVitestShutdownCommand({
     args,
-    options: { cwd: root, env, stdio: "pipe" },
+    cwd: root,
+    env,
   });
-  const detachCleanup = installVitestProcessGroupCleanup({ child, forceSignal: "SIGKILL" });
-  let output = "";
-  child.stdout.on("data", (chunk) => {
-    output += chunk;
-  });
-  child.stderr.on("data", (chunk) => {
-    output += chunk;
-  });
-  const { code } = await completion.finally(detachCleanup);
-  assert.ok(
-    fs.existsSync(receipt),
-    `Vitest exited before the fixture test (code ${code}):\n${output}`,
-  );
-  const state = JSON.parse(fs.readFileSync(receipt, "utf8"));
-  let workerStopped = false;
-  try {
-    process.kill(state.pid, 0);
-  } catch (error) {
-    if (error.code === "ESRCH") {
-      workerStopped = true;
-    } else {
-      throw error;
+  const output = stdout + stderr;
+  // Scenario failures are data; cancellation of this supervisor is an execution failure.
+  if (code > 1) {
+    console.error(`Shutdown fixture ${root} failed with exit code ${code}:\n${output}`);
+    process.exitCode = code;
+  } else {
+    assert.ok(
+      fs.existsSync(receipt),
+      `Vitest exited before the fixture test (code ${code}):\n${output}`,
+    );
+    const state = JSON.parse(fs.readFileSync(receipt, "utf8"));
+    let workerStopped = false;
+    try {
+      process.kill(state.pid, 0);
+    } catch (error) {
+      if (error.code === "ESRCH") {
+        workerStopped = true;
+      } else {
+        throw error;
+      }
     }
+    const counts = { cpu: 0, heap: 0 };
+    for (const file of fs.readdirSync(profiles)) {
+      // Native profile names contain PID/thread ID. A launcher profile cannot
+      // establish that the worker's exit-time writes completed.
+      const [pid, workerThreadId] = file.split(".").slice(3, 5);
+      if (pid !== String(state.pid) || workerThreadId !== String(state.threadId)) {
+        continue;
+      }
+      const profile = JSON.parse(fs.readFileSync(path.join(profiles, file), "utf8"));
+      if (file.endsWith(".cpuprofile") && profile.nodes?.length) {
+        counts.cpu++;
+      }
+      if (file.endsWith(".heapprofile") && profile.head) {
+        counts.heap++;
+      }
+    }
+    console.log(
+      JSON.stringify({
+        code,
+        output,
+        worker: { pid: state.pid, threadId: state.threadId },
+        workerStopped,
+        profiles: counts,
+        homeRemoved: !fs.existsSync(state.home),
+        callerPreserved: fs.readFileSync(path.join(root, "home", "caller"), "utf8") === "keep",
+        events: fs.existsSync(events)
+          ? fs.readFileSync(events, "utf8").trim().split("\n").filter(Boolean).map(JSON.parse)
+          : [],
+      }),
+    );
   }
-  const counts = { cpu: 0, heap: 0 };
-  for (const file of fs.readdirSync(profiles)) {
-    // Native profile names contain PID/thread ID. A launcher profile cannot
-    // establish that the worker's exit-time writes completed.
-    const [, , , pid, workerThreadId] = file.split(".");
-    if (pid !== String(state.pid) || workerThreadId !== String(state.threadId)) {
-      continue;
-    }
-    const profile = JSON.parse(fs.readFileSync(path.join(profiles, file), "utf8"));
-    if (file.endsWith(".cpuprofile") && profile.nodes?.length) {
-      counts.cpu++;
-    }
-    if (file.endsWith(".heapprofile") && profile.head) {
-      counts.heap++;
-    }
-  }
-  console.log(
-    JSON.stringify({
-      code,
-      output,
-      worker: { pid: state.pid, threadId: state.threadId },
-      workerStopped,
-      profiles: counts,
-      homeRemoved: !fs.existsSync(state.home),
-      callerPreserved: fs.readFileSync(path.join(root, "home", "caller"), "utf8") === "keep",
-      events: fs.existsSync(events)
-        ? fs.readFileSync(events, "utf8").trim().split("\n").filter(Boolean).map(JSON.parse)
-        : [],
-    }),
-  );
 }

--- a/test/fixtures/vitest-shutdown-cancellation.mjs
+++ b/test/fixtures/vitest-shutdown-cancellation.mjs
@@ -1,0 +1,54 @@
+import childProcess from "node:child_process";
+import fs from "node:fs";
+import { syncBuiltinESMExports } from "node:module";
+import path from "node:path";
+
+const root = new URL(import.meta.url).searchParams.get("root");
+const file = (name) => path.join(root, name);
+const publish = (name, value) => {
+  fs.writeFileSync(file(`${name}.tmp`), String(value));
+  fs.renameSync(file(`${name}.tmp`), file(name));
+};
+
+if (process.argv[2] === root) {
+  const spawn = childProcess.spawn;
+  childProcess.spawn = (command, args, options) => {
+    const child = spawn(command, args, {
+      ...options,
+      env: {
+        ...options.env,
+        NODE_OPTIONS: `${options.env.NODE_OPTIONS} --import=${JSON.stringify(import.meta.url)}`,
+      },
+    });
+    publish("shim.pid", child.pid);
+    return child;
+  };
+  // Release after every TERM listener and its microtasks run. An immediate KILL
+  // loses the paused forwarding shim; a graceful owner lets it forward first.
+  process.on("SIGTERM", () => {
+    publish("term-received", process.pid);
+    setImmediate(() => {
+      for (const name of ["shim.pid", "worker.pid"]) {
+        try {
+          process.kill(Number(fs.readFileSync(file(name), "utf8")), "SIGCONT");
+        } catch (error) {
+          if (error.code !== "ESRCH") {
+            throw error;
+          }
+        }
+      }
+    });
+  });
+} else {
+  const write = fs.writeFileSync;
+  fs.writeFileSync = (target, ...args) => {
+    const result = write(target, ...args);
+    if (target === file("receipt.json")) {
+      // Stop at the actual worker receipt, before any test result or teardown.
+      publish("worker.pid", process.pid);
+      process.kill(process.pid, "SIGSTOP");
+    }
+    return result;
+  };
+}
+syncBuiltinESMExports();

--- a/test/helpers/vitest-shutdown-command.ts
+++ b/test/helpers/vitest-shutdown-command.ts
@@ -1,0 +1,54 @@
+import { runManagedCommand } from "../../scripts/lib/managed-child-process.mts";
+import { createBoundedChildOutput } from "./bounded-child-output.ts";
+
+/** Capture fixture diagnostics without losing the managed cancellation outcome. */
+export async function runVitestShutdownCommand(
+  options: Pick<
+    Parameters<typeof runManagedCommand>[0],
+    "args" | "cwd" | "env" | "timeoutMs" | "onReady"
+  >,
+) {
+  const maxBytes = 2 * 1024 * 1024;
+  const stdout = createBoundedChildOutput(maxBytes);
+  const stderr = createBoundedChildOutput(maxBytes);
+  const controller = new AbortController();
+  let overflow: Error | undefined;
+  try {
+    const code = await runManagedCommand({
+      ...options,
+      bin: process.execPath,
+      shell: false,
+      stdio: ["ignore", "pipe", "pipe"],
+      requireProcessTreeExit: process.platform !== "win32",
+      signal: controller.signal,
+      onReady(child) {
+        for (const [pipe, output] of [
+          [child.stdout, stdout],
+          [child.stderr, stderr],
+        ] as const) {
+          let bytes = 0;
+          pipe!.on("data", (chunk: Buffer) => {
+            output.append(chunk);
+            bytes += chunk.byteLength;
+            if (bytes > maxBytes && !overflow) {
+              overflow = Object.assign(new Error("Shutdown fixture output exceeded 2 MiB"), {
+                code: "ERR_CHILD_PROCESS_STDIO_MAXBUFFER",
+              });
+              controller.abort();
+            }
+          });
+        }
+        options.onReady?.(child);
+      },
+    });
+    return { code, stdout: stdout.text(), stderr: stderr.text() };
+  } catch (cause) {
+    // Cleanup failures remain primary; overflowing output must not conceal live writers.
+    const aborted = cause instanceof Error && "code" in cause && cause.code === "ABORT_ERR";
+    const error = aborted && overflow ? overflow : cause;
+    throw Object.assign(error instanceof Error ? error : new Error(String(error)), {
+      stdout: stdout.text(),
+      stderr: stderr.text(),
+    });
+  }
+}

--- a/test/scripts/vitest-fork-shutdown.test.ts
+++ b/test/scripts/vitest-fork-shutdown.test.ts
@@ -1,12 +1,53 @@
-import { execFile } from "node:child_process";
+import { execFileSync, type ChildProcess } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { promisify } from "node:util";
-import { afterEach, expect, it } from "vitest";
-import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
+import { expect, it } from "vitest";
+import { isProcessAlive, waitForDead, waitForFile } from "../helpers/process-wait.js";
+import { createTempDirTracker } from "../helpers/temp-dir.js";
+import { runVitestShutdownCommand } from "../helpers/vitest-shutdown-command.js";
 
-const execFileAsync = promisify(execFile);
-const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 const fixture = fileURLToPath(new URL("../fixtures/vitest-fork-shutdown.mjs", import.meta.url));
+// Outside the enclosing Vitest TMPDIR: its owner must not erase retained writers.
+const fixtureRoots = fileURLToPath(
+  new URL("../../.artifacts/vitest-fork-shutdown/", import.meta.url),
+);
+fs.mkdirSync(fixtureRoots, { recursive: true });
+
+function expectReleasedNamespace(root: string) {
+  if (process.platform !== "win32") {
+    expect(
+      fs.readdirSync(path.join(root, "tmp")),
+      `Vitest retained temporary files in ${root}`,
+    ).toEqual([]);
+  }
+}
+
+async function runFixture(
+  root: string,
+  options: { scenario: string; setup: string; fail: boolean },
+  nodeArgs: string[] = [],
+  onReady?: (child: ChildProcess) => void,
+) {
+  try {
+    const result = await runVitestShutdownCommand({
+      args: [...nodeArgs, fixture, root, JSON.stringify(options)],
+      timeoutMs: 20_000,
+      onReady,
+    });
+    if (result.code !== 0) {
+      throw Object.assign(new Error(`Shutdown fixture exited with code ${result.code}`), result);
+    }
+    return result;
+  } catch (error) {
+    if (error instanceof Error) {
+      const stdout = "stdout" in error ? String(error.stdout) : "";
+      const stderr = "stderr" in error ? String(error.stderr) : "";
+      error.message += `; retained fixture ${root}\n${stdout}\n${stderr}`;
+    }
+    throw error;
+  }
+}
 
 it.each([
   { scenario: "slow-exit", setup: "shared", fail: false },
@@ -22,21 +63,19 @@ it.each([
   { scenario: "bad-exit", setup: "shared", fail: false },
   { scenario: "forced", setup: "raw", fail: false },
 ])("joins $scenario shutdown with $setup setup (test failure: $fail)", async (options) => {
-  const root = tempDirs.make("vitest-fork-shutdown-");
-  const { stdout } = await execFileAsync(
-    process.execPath,
-    [fixture, root, JSON.stringify(options)],
-    {
-      timeout: 20_000,
-      maxBuffer: 2 * 1024 * 1024,
-    },
-  );
+  const tempDirs = createTempDirTracker();
+  const root = tempDirs.make("vitest-fork-shutdown-", fixtureRoots);
+  const { stdout } = await runFixture(root, options);
   const result = JSON.parse(stdout);
+  console.log(JSON.stringify({ root, options, ...result, output: undefined }));
   const { scenario, setup, fail } = options;
   if (scenario === "forced") {
     // Node uses TerminateProcess for TERM on Windows; POSIX exercises escalation.
     expect(result.signal).toBe(process.platform === "win32" ? "SIGTERM" : "SIGKILL");
     expect(result.stopped).toBe(true);
+    expect(isProcessAlive(result.workerPid)).toBe(false);
+    expectReleasedNamespace(root);
+    tempDirs.cleanup();
     return;
   }
   const brokenShutdown = scenario.startsWith("hung-") || scenario === "bad-exit";
@@ -52,7 +91,7 @@ it.each([
   }
   if (setup !== "raw") {
     // Windows has no wrapper-owned group cleanup after a forced termination.
-    // Its unfinished home remains inside this test's auto-cleaned fixture root.
+    // Its unfinished home is released after this test verifies the worker stopped.
     expect(result.homeRemoved).toBe(!(process.platform === "win32" && scenario === "hung-cleanup"));
   }
   expect(result.callerPreserved).toBe(true);
@@ -83,4 +122,124 @@ it.each([
       expect(result.events).toContainEqual({ event: "home-removed" });
     }
   }
+  // Only release after execution and shutdown assertions certify completion.
+  expectReleasedNamespace(root);
+  tempDirs.cleanup();
 });
+
+it.runIf(process.platform !== "win32").each(["signal", "timeout"])(
+  "rejects fixture cancellation by %s and joins descendants",
+  async (mode) => {
+    const ownedDirs = createTempDirTracker();
+    const root = ownedDirs.make("vitest-fork-cancellation-", fixtureRoots);
+    const control = new URL("../fixtures/vitest-shutdown-cancellation.mjs", import.meta.url);
+    control.searchParams.set("root", root);
+    let watcher: fs.FSWatcher;
+    const ready = new Promise<{ shim: number; worker: number }>((resolve) => {
+      watcher = fs.watch(root, () => {
+        if (!fs.existsSync(path.join(root, "worker.pid"))) {
+          return;
+        }
+        resolve({
+          shim: Number(fs.readFileSync(path.join(root, "shim.pid"), "utf8")),
+          worker: Number(fs.readFileSync(path.join(root, "worker.pid"), "utf8")),
+        });
+      });
+    });
+    let child!: ChildProcess;
+    const invocation = runFixture(
+      root,
+      { scenario: "slow-exit", setup: "shared", fail: false },
+      ["--import", control.href],
+      (owned) => {
+        child = owned;
+      },
+    );
+    const outcome = invocation.then(
+      (result) => ({ result, error: undefined }),
+      (error: unknown) => ({ result: undefined, error }),
+    );
+    const pids: number[] = [];
+    try {
+      const { worker, shim } = await Promise.race([
+        ready,
+        outcome.then((result) => {
+          throw new Error(`Fixture exited before worker receipt: ${JSON.stringify(result)}`, {
+            cause: result.error,
+          });
+        }),
+      ]);
+      pids.push(shim, worker);
+      process.kill(shim, "SIGSTOP");
+      for (const pid of pids) {
+        await expect
+          .poll(() =>
+            execFileSync("ps", ["-o", "stat=", "-p", String(pid)], {
+              encoding: "utf8",
+              timeout: 1_000,
+            }).trim(),
+          )
+          .toMatch(/^T/);
+      }
+      const rows = execFileSync("ps", ["-axo", "pid=,ppid=,pgid="], {
+        encoding: "utf8",
+        timeout: 1_000,
+      })
+        .trim()
+        .split("\n")
+        .map((row) => {
+          const [pid, ppid, pgid] = row.trim().split(/\s+/).map(Number);
+          return { pid: pid!, ppid: ppid!, pgid: pgid! };
+        });
+      const owned = new Set([child.pid!]);
+      for (let previous = 0; previous !== owned.size;) {
+        previous = owned.size;
+        for (const row of rows) {
+          if (owned.has(row.ppid)) {
+            owned.add(row.pid);
+          }
+        }
+      }
+      expect(owned.has(shim) && owned.has(worker)).toBe(true);
+      pids.splice(0, pids.length, ...owned);
+      if (mode === "signal") {
+        child.kill("SIGTERM");
+      }
+      const result = await outcome;
+      await waitForFile(path.join(root, "term-received"), 1_000);
+      console.log(
+        JSON.stringify({
+          mode,
+          root,
+          fixture: child.pid,
+          pids,
+          processes: rows.filter((row) => owned.has(row.pid)),
+          exitCode: child.exitCode,
+          signalCode: child.signalCode,
+          ...result,
+        }),
+      );
+      expect(result.error).toMatchObject({ code: mode === "timeout" ? "ETIMEDOUT" : 143 });
+      expect(result.error).toMatchObject({
+        stderr: expect.stringContaining("exit code 143"),
+      });
+      expect(pids.filter(isProcessAlive)).toEqual([]);
+      expectReleasedNamespace(root);
+      ownedDirs.cleanup();
+    } finally {
+      watcher!.close();
+      for (const pid of pids) {
+        if (isProcessAlive(pid)) {
+          process.kill(pid, "SIGCONT");
+        }
+      }
+      if (child.exitCode === null && child.signalCode === null) {
+        child.kill("SIGTERM");
+      }
+      await outcome;
+      for (const pid of pids) {
+        await waitForDead(pid, 5_000);
+      }
+    }
+  },
+);


### PR DESCRIPTION
Related: #132815 (fresh transcript ordering; its production repair is unchanged). Preserves #132820 (native worker PID/thread profile proof) and #132824 (consumed custom stop acknowledgement).

## What Problem This Solves

Resolves a problem where maintainers running the Vitest shutdown fixture could see `Unexpected end of JSON input` instead of the actual timeout, and fixture cancellation could outlive its deadline while detached descendants still held output pipes open.

The unchanged fixture consumed `SIGTERM`, immediately killed its forwarding wrapper, discarded the child's signal, and could exit zero. Node's `execFile` deadline destroyed the capture pipes but still accepted that eventual zero exit as success. Real macOS fault injection reproduced both successful `code: null` JSON after a signal and successful empty stdout after the 20-second timeout.

## Why This Change Was Made

Both fixture launch boundaries now use the existing managed-command owner through one bounded test-output capture helper. This removes the fixture's bespoke immediate-KILL forwarding and redundant temporary-namespace supervisor, keeps cancellation authoritative over eventual child success, and retains useful diagnostics. The real test wrapper still owns its own namespace; failed or unverified fixtures retain their exact root outside the enclosing test runner's temporary namespace.

The execution deadline remains 20 seconds and each output stream remains capped at 2 MiB. Expected worker-scenario failures remain JSON data; cancellation of the fixture supervisor is failed execution. Existing shared supervisor code, dependency patches, gateway behavior, and transcript-ordering code are unchanged. This is a maintainer-requested, bounded test-support repair, not a general process-supervisor rewrite.

## User Impact

No application/runtime behavior change. Developers get an actionable timeout or cancellation failure instead of an empty-JSON parse error, and fixture directories are not removed while completion remains unverified.

This fixes the independently reproduced cancellation defect. It does not claim to explain or eliminate the original machine's deadline overruns.

## Evidence

Real native proof used macOS 27.0, Node v24.20.0, and Vitest 4.1.11 after a pinned install; all six installed Vitest/runner patch targets matched their required Git blobs. No installed dependency was manually modified.

| Boundary | Unchanged baseline | Candidate |
| --- | --- | --- |
| Fixture `SIGTERM` after an actual worker receipt | Execution resolved successfully, fixture exit 0, JSON `code: null` | Execution fails with code 143 and retained wrapper diagnostics |
| Existing 20,000 ms deadline | Execution resolved successfully with empty stdout | Execution fails with `ETIMEDOUT`; final native case completed in 20,237 ms including cleanup |
| Descendant/namespace completion | Immediate wrapper termination could leave separate descendant groups running | Every recorded descendant is stopped at settlement; all 14 successful fixture roots removed |

The regression uses actual worker receipts, atomic readiness files, verified POSIX STOP states, and a signal acknowledgement before releasing fixture-owned processes. It does not assume startup duration or fake the worker result. Both new cases failed against the exact unchanged fixture blob before repair. Only the two new POSIX signal-injection cases are platform-gated; all twelve original scenarios/pools and their order remain intact.

Final lead-owned native proof: **57 tests passed** across the 14-case shutdown matrix, five bounded-output tests, and 38 process-group tests:

```bash
node scripts/run-vitest.mjs test/scripts/vitest-fork-shutdown.test.ts test/helpers/bounded-child-output.test.ts test/scripts/vitest-process-group.test.ts
```

Nine selected managed-command lifecycle siblings also passed, including nested resistant cleanup, termination of descendant groups, and the Windows taskkill-failure contract:

```bash
node scripts/run-vitest.mjs test/scripts/managed-child-process.test.ts -t 'joins nested|kills managed child process group descendants|fails closed when Windows taskkill'
```

Formatting, `git diff --check`, and the complete changed-surface gate pass, including root test typechecking, script lint, and dependency/architecture guards:

```bash
node scripts/check-changed.mjs -- test/fixtures/vitest-fork-shutdown.mjs test/fixtures/vitest-shutdown-cancellation.mjs test/helpers/vitest-shutdown-command.ts test/scripts/vitest-fork-shutdown.test.ts
```

Independent Codex autoreview completed **scoped-clean**, with no accepted/actionable findings at its default P0 threshold. The lead separately reviewed the owner, dependency, cleanup, and sibling contracts.

Production/tooling LOC: **+0 / -0**. Tests and test support: **+344 / -74 (net +270)**, including the shared bounded capture and two previously missing real cancellation regressions. The fixture's supervision replacement is +20/-17 when indentation-only changes are discounted.

Proof limits: native Windows execution has not been run locally; the explicit platform contract was tested on macOS, and CI supplies its selected platform coverage. The historical slowdown trigger remains unknown. An initial over-broad lint invocation entered unrelated plugin-declaration preparation and was stopped; its owned processes and retained artifact lock were verified before recovery, then corrected source-only lint passed. An intermediate regression draft's separate readiness deadline was removed in favor of file-event readiness racing the unchanged execution deadline.

AI-assisted implementation and review.
