### PR TITLE
fix(ci): route Android-only changed checks to Kotlin lint

### DIFF
--- a/docs/reference/test.md
+++ b/docs/reference/test.md
@@ -100,6 +100,12 @@ Test wrapper runs end with a short `[test] passed|failed|skipped ... in ...` sum
 | `pnpm changed:lanes`                              | Shows the architectural lanes triggered by the diff against `origin/main`.                                                                                                                                                                                                                                                                            |
 | `pnpm check:changed`                              | Runs the local changed formatting/typecheck/lint/guard plan, including targeted Vitest owner tests for selected paths. Use `pnpm test:changed` or `pnpm test <target>` for additional test proof matching the touched contract.                                                                                                                       |
 
+For native app changes, `pnpm check:changed` uses platform scope to select lint:
+Android selects `pnpm android:lint` (the Gradle ktlint checks), while Apple app
+changes retain Swift lint. Android-only changes do not select Swift lint or its
+missing-tool notice. Android framework/resource lint and runtime tests remain
+separate checks; Kotlin lint does not replace them.
+
 Remote filesystem fixtures that execute GNU `stat` and `readlink` run locally
 only on Linux. The shared leading-`@` file-tool scenario
 also runs against a portable remote-only bridge on every platform. Native

--- a/scripts/check-changed.mts
+++ b/scripts/check-changed.mts
@@ -20,7 +20,7 @@ import {
   listStagedChangedPaths,
 } from "./changed-lanes.mts";
 import type { ChangedLaneResult } from "./changed-lanes.mts";
-import { isMacosToolingPath } from "./ci-changed-scope.mjs";
+import { detectChangedScope, isMacosToolingPath } from "./ci-changed-scope.mjs";
 import {
   booleanFlag,
   isOpenEndedTruthyValue,
@@ -824,18 +824,34 @@ export function createChangedCheckPlan(
       addLint("raw HTTP/2 import guard", ["lint:tmp:no-raw-http2-imports"]);
     }
   }
-  if (lanes.apps && shouldSkipAppLintForMissingSwiftlint({ ...options, env: baseEnv })) {
-    addCommand(
-      "lint apps (swiftlint unavailable on this host)",
-      "node",
-      [
-        "-e",
-        "console.error('[check:changed] Swift app lint skipped: swiftlint is unavailable on this non-macOS host; macOS CI owns SwiftLint coverage.')",
-      ],
-      baseEnv,
-    );
-  } else if (lanes.apps) {
-    addLint("lint apps", ["lint:apps"]);
+  if (lanes.apps) {
+    const appScopes = result.paths
+      .filter((changedPath) => getChangedPathFacts(changedPath).surface === "app")
+      .map((changedPath) => detectChangedScope([changedPath]));
+    // Shared Apple sources select Android consumer CI, but Gradle ktlint owns
+    // only Android-exclusive app paths. Classify each path so mixed diffs retain both.
+    if (
+      appScopes.some(
+        ({ runAndroid, runMacos, runIosBuild }) => runAndroid && !runMacos && !runIosBuild,
+      )
+    ) {
+      addLint("lint Android", ["android:lint"]);
+    }
+    if (appScopes.some(({ runMacos, runIosBuild }) => runMacos || runIosBuild)) {
+      if (shouldSkipAppLintForMissingSwiftlint({ ...options, env: baseEnv })) {
+        addCommand(
+          "lint apps (swiftlint unavailable on this host)",
+          "node",
+          [
+            "-e",
+            "console.error('[check:changed] Swift app lint skipped: swiftlint is unavailable on this non-macOS host; macOS CI owns SwiftLint coverage.')",
+          ],
+          baseEnv,
+        );
+      } else {
+        addLint("lint apps", ["lint:apps"]);
+      }
+    }
   }
   if (hasMacosAppCiPath(result.paths)) {
     add("macOS app CI tests", ["test:macos:ci"], baseEnv);

--- a/test/scripts/changed-lanes.test.ts
+++ b/test/scripts/changed-lanes.test.ts
@@ -2052,6 +2052,7 @@ describe("scripts/changed-lanes", () => {
     for (const changedPath of [
       "apps/macos/Sources/OpenClawMac/AppDelegate.swift",
       "apps/macos-mlx-tts/Sources/OpenClawMLXTTS/main.swift",
+      "apps/shared/OpenClawKit/Sources/OpenClawKit/Client.swift",
       "apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift",
       "apps/swabble/Sources/SwabbleKit/WakeWordGate.swift",
       "Swabble/Sources/SwabbleKit/WakeWordGate.swift",
@@ -2064,6 +2065,7 @@ describe("scripts/changed-lanes", () => {
       });
 
       expect(plan.commands.map((command) => command.args[0])).not.toContain("lint:apps");
+      expect(plan.commands.map((command) => command.args[0])).not.toContain("android:lint");
       expect(plan.commands).toContainEqual(
         expect.objectContaining({
           name: "lint apps (swiftlint unavailable on this host)",
@@ -2199,38 +2201,110 @@ describe("scripts/changed-lanes", () => {
     expect(plan.commands.map((command) => command.name)).not.toContain("macOS app CI tests");
   });
 
-  it("runs app lint when SwiftLint is available in Testbox", () => {
-    const result = detectChangedLanes([
-      "apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift",
-    ]);
-    const plan = createChangedCheckPlan(result, {
-      env: { CI: "1", PATH: "/usr/bin" },
-      platform: "linux",
-      swiftlintAvailable: true,
-    });
+  it.each<[string, NodeJS.Platform, boolean, boolean]>([
+    ["apps/ios/Sources/RootTabs.swift", "darwin", true, false],
+    ["apps/macos/Sources/OpenClawMac/AppDelegate.swift", "darwin", false, true],
+    ["apps/shared/OpenClawKit/Sources/OpenClawKit/Client.swift", "linux", true, true],
+    ["apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift", "linux", true, true],
+  ])(
+    "preserves Swift lint for %s on %s with SwiftLint=%s",
+    (changedPath, platform, swiftlintAvailable, macosCi) => {
+      const plan = createChangedCheckPlan(detectChangedLanes([changedPath]), {
+        env: { CI: "1", PATH: "/usr/bin" },
+        platform,
+        swiftlintAvailable,
+      });
+      const commands = plan.commands.map((command) => command.args[0]);
 
-    expect(plan.commands.map((command) => command.args[0])).toContain("lint:apps");
-    expect(plan.commands).toContainEqual(
-      expect.objectContaining({
-        name: "macOS app CI tests",
-        args: ["test:macos:ci"],
-      }),
-    );
+      expect(commands).toContain("lint:apps");
+      expect(commands).not.toContain("android:lint");
+      expect(commands.includes("test:macos:ci")).toBe(macosCi);
+    },
+  );
+
+  it.each<[string, NodeJS.Platform, boolean]>([
+    [
+      "apps/android/app/src/test/java/ai/openclaw/app/gateway/GatewaySessionReconnectTest.kt",
+      "darwin",
+      true,
+    ],
+    [
+      "apps/android/app/src/test/java/ai/openclaw/app/gateway/GatewaySessionReconnectTest.kt",
+      "linux",
+      false,
+    ],
+    ["apps/android/app/src/main/java/ai/openclaw/app/MainActivity.kt", "darwin", false],
+    ["apps/android/app/src/main/AndroidManifest.xml", "linux", true],
+    ["apps/android/app/build.gradle.kts", "linux", false],
+    ["apps/android/settings.gradle.kts", "darwin", true],
+  ])(
+    "selects only Android lint for %s on %s with SwiftLint=%s",
+    (changedPath, platform, swiftlintAvailable) => {
+      const result = detectChangedLanes([changedPath]);
+      const plan = createChangedCheckPlan(result, {
+        env: { CI: "1", PATH: "/usr/bin" },
+        platform,
+        swiftlintAvailable,
+      });
+
+      expectLanes(result.lanes, { apps: true });
+      expect
+        .soft(plan.commands)
+        .toContainEqual(expect.objectContaining({ args: ["android:lint"] }));
+      expect.soft(plan.commands.map((command) => command.args[0])).not.toContain("lint:apps");
+      expect
+        .soft(plan.commands.map((command) => command.name))
+        .not.toContain("lint apps (swiftlint unavailable on this host)");
+      expect(plan.commands.map((command) => command.args[0])).not.toContain("test:macos:ci");
+    },
+  );
+
+  it.each([false, true])("preserves mixed native lint with SwiftLint=%s", (swiftlintAvailable) => {
+    for (const { paths, androidLint, macosCi } of [
+      { paths: ["apps/ios/Sources/RootTabs.swift"], androidLint: false, macosCi: false },
+      {
+        paths: [
+          "apps/android/app/src/main/AndroidManifest.xml",
+          "apps/ios/Sources/RootTabs.swift",
+          "apps/shared/OpenClawKit/Sources/OpenClawKit/Client.swift",
+        ],
+        androidLint: true,
+        macosCi: true,
+      },
+    ]) {
+      const plan = createChangedCheckPlan(detectChangedLanes(paths), {
+        env: { CI: "1", PATH: "/usr/bin" },
+        platform: "linux",
+        swiftlintAvailable,
+      });
+      const commands = plan.commands.map((command) => command.args[0]);
+
+      expect(commands.includes("android:lint")).toBe(androidLint);
+      expect(commands.includes("lint:apps")).toBe(swiftlintAvailable);
+      expect(commands.includes("test:macos:ci")).toBe(macosCi);
+      expect(
+        plan.commands.some(
+          (command) => command.name === "lint apps (swiftlint unavailable on this host)",
+        ),
+      ).toBe(!swiftlintAvailable);
+    }
   });
 
-  it("keeps macOS app CI tests out of Android-only app changes", () => {
-    const result = detectChangedLanes(["apps/android/app/src/main/AndroidManifest.xml"]);
-    const plan = createChangedCheckPlan(result, {
-      env: { CI: "1", PATH: "/usr/bin" },
-      platform: "linux",
-      swiftlintAvailable: true,
-    });
+  it.each(["apps/.i18n/native-source.json", "apps/web/index.ts", "appcast.xml"])(
+    "keeps non-native app assets out of native lint: %s",
+    (changedPath) => {
+      const plan = createChangedCheckPlan(detectChangedLanes([changedPath]), {
+        platform: "linux",
+        swiftlintAvailable: false,
+      });
 
-    expectLanes(result.lanes, {
-      apps: true,
-    });
-    expect(plan.commands.map((command) => command.name)).not.toContain("macOS app CI tests");
-  });
+      expect(plan.commands.map((command) => command.args[0])).not.toContain("android:lint");
+      expect(plan.commands.map((command) => command.args[0])).not.toContain("lint:apps");
+      expect(plan.commands.map((command) => command.name)).not.toContain(
+        "lint apps (swiftlint unavailable on this host)",
+      );
+    },
+  );
 
   it("routes A2UI bundle source changes as extension changes", () => {
     const result = detectChangedLanes([


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

This PR uses a same-repository branch so maintainers can update it.

</details>

## What Problem This Solves

Fixes an issue where developers checking Android-only changes would run unrelated Swift lint and receive no Kotlin lint validation. For example, checking `apps/android/app/src/test/java/ai/openclaw/app/gateway/GatewaySessionReconnectTest.kt` selected `lint:apps`, which invokes only Swift lint. On a non-macOS host without SwiftLint, the same Android change instead produced an irrelevant Swift skip notice.

## Why This Change Was Made

The changed-check planner now consumes the existing CI platform classifier per app path and selects the existing `android:lint` Gradle ktlint command for Android-exclusive paths. Per-path classification keeps mixed Android/Apple diffs covered without treating shared Apple sources as Kotlin lint inputs. No path regexes, Gradle task lists, package commands, or CI platform policies are duplicated or changed.

Apple Swift lint, its existing missing-tool behavior, macOS CI selection, and docs/release-metadata/root-all short-circuits are preserved. Non-native app metadata also stops selecting unrelated Swift lint. The Android source and test fixtures are unchanged.

Tooling LOC: +29/-13 (net +16), needed to select the existing Android validation and separate it from Swift. Tests: +102/-28 (net +74). Documentation: +6. No product runtime code changes.

AI-assisted; implementation and owning paths were reviewed.

## User Impact

Android-only changed checks now run the repository-owned ktlint checks across the phone, benchmark, Wear, and Wear-shared modules without requiring SwiftLint. Apple-only and mixed-platform validation retain their intended coverage. Android framework/resource lint and runtime tests remain separate; this change does not claim that Kotlin lint replaces them.

The [testing reference](https://docs.openclaw.ai/reference/test) documents the distinction.

## Evidence

- Reproduced the original executable dry-run: Android-only selection included `pnpm lint:apps` and no `pnpm android:lint`.
- Added regression coverage first: 11 cases failed against the old planner for missing Android lint or unrelated Swift selection; 5 passed in that focused run.
- Owner and sibling proof passed: 294 tests across changed-lanes, changed-path-facts, and CI changed-scope.
- Executable dry-run matrix passed for 22 scenarios, including Android Kotlin tests/source, manifest and Gradle files, iOS/macOS/shared/generated Swift, mixed platforms, metadata, and empty changes.
- Actual changed-check execution for the reconnect-test path passed and ran `android:lint`, with no Swift lint or Swift skip notice.
- `pnpm android:lint --offline` passed with 36 actionable tasks executed across all four Android modules. The inspected Gradle task graph and pinned ktlint-gradle 14.2.0 source contain lint/report tasks, not Android runtime tests.
- Scoped changed checks passed, including script and root-test typechecking, targeted lint, formatting, and guards. Fresh independent autoreview reported no accepted/actionable findings.

Exact local proof commands:

```bash
node scripts/run-vitest.mjs test/scripts/changed-lanes.test.ts test/scripts/changed-path-facts.test.ts src/scripts/ci-changed-scope.test.ts
```

```bash
node scripts/check-changed.mjs -- scripts/check-changed.mts test/scripts/changed-lanes.test.ts docs/reference/test.md
```

```bash
node scripts/check-changed.mjs --dry-run -- apps/android/app/src/test/java/ai/openclaw/app/gateway/GatewaySessionReconnectTest.kt
```

```bash
node scripts/check-changed.mjs -- apps/android/app/src/test/java/ai/openclaw/app/gateway/GatewaySessionReconnectTest.kt
```

```bash
pnpm android:lint --offline --dry-run
```

```bash
pnpm android:lint --offline
```

```bash
git diff --check
```

Proof scope: static tooling and command routing. No Android runtime tests, app launches, or operator Gateway access were performed. `GatewayBootstrapAuthTest.kt` and `GatewaySessionReconnectTest.kt` were verified byte-identical before and after the repair. Hosted exact-head CI will be linked in the landing proof.
