### PR TITLE
fix(codex): keep shutdown diagnostics best effort

### DIFF
--- a/extensions/codex/src/app-server/run-attempt.turn-watches.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.turn-watches.test.ts
@@ -32,6 +32,7 @@ import type { CodexServerNotification, JsonObject } from "./protocol.js";
 import { itemNotification, rawItemCompleted, turnCompleted } from "./protocol.test-helpers.js";
 import { readRecentCodexRateLimits } from "./rate-limit-cache.js";
 import {
+  bindProductionHarnessHostCapabilitiesForTest,
   createParams,
   createTestParams,
   createResumeHarness,
@@ -3606,6 +3607,23 @@ describe("runCodexAppServerAttempt turn watches", () => {
         transportError:
           'codex app-server exited: code=137 signal=SIGKILL stderr="worker exhausted"',
       },
+    });
+  });
+
+  it("settles a client-close route after the host trajectory capability closes", async () => {
+    const harness = createStartedThreadHarness();
+    const params = Object.assign(createTestParams(), {
+      trajectoryRecorder: { recordEvent: vi.fn(), flush: vi.fn() },
+    });
+    const closeHost = await bindProductionHarnessHostCapabilitiesForTest(params);
+    const run = runCodexAppServerAttempt(params, { turnTerminalIdleTimeoutMs: 60_000 });
+
+    await harness.waitForMethod("turn/start");
+    closeHost();
+    harness.close();
+
+    await expect(run).resolves.toMatchObject({
+      codexAppServerFailure: { kind: "client_closed_before_turn_completed" },
     });
   });
 

--- a/extensions/codex/src/app-server/trajectory.ts
+++ b/extensions/codex/src/app-server/trajectory.ts
@@ -28,7 +28,14 @@ export function createCodexTrajectoryRecorder(
   const trajectory = params.trajectory;
 
   return {
-    recordEvent: trajectory.recordEvent,
+    recordEvent: (type, data) => {
+      try {
+        trajectory.recordEvent(type, data);
+      } catch {
+        // Host authority can close before transport callbacks finish during shutdown.
+        // Optional diagnostics must not interrupt the owning run lifecycle.
+      }
+    },
     flush: trajectory.flush,
   };
 }


### PR DESCRIPTION
## What problem this solves

Full Release Validation run 33278798215 exposed an unhandled Codex shutdown error after every selected gateway-core live test had passed. Gateway teardown revoked the admitted host capability, then closing the shared Codex app-server client aborted its still-active route. The route's optional trajectory event called the revoked host sink, throwing `agent harness host capability is no longer active` from the abort callback and preventing normal turn settlement.

## Root cause and fix

The Codex trajectory adapter retained a closure-bound host event sink as though it were an infallible local recorder. Transport callbacks and attempt cleanup can legitimately outlive that diagnostic authority during Gateway shutdown. The adapter now treats synchronous event-recording failure as best-effort diagnostic loss; the host capability itself remains fail-closed, and trajectory flushing retains its existing error reporting through the cleanup owner.

This owns the invariant once for route-close, cleanup, projector, and terminal trajectory events instead of guarding only the reported callback.

## Codex contract proof

Directly inspected sibling Codex at `bf2aee99c58362d3f588d98432dcbc7adc371c73`:

- `codex-rs/app-server/README.md:214` and `codex-rs/app-server/README.md:1157` document that `turn/interrupt` requests cancellation and terminal state arrives later through `turn/completed`.
- `codex-rs/app-server/src/bespoke_event_handling.rs:1114` handles `TurnAborted`, resolves pending interrupt work, then dispatches interrupted-turn handling.
- `codex-rs/app-server/src/bespoke_event_handling.rs:1518` emits the terminal `turn/completed` notification with `TurnStatus::Interrupted`.

That asynchronous terminal contract makes client/Gateway teardown racing an active turn a valid lifecycle state, not malformed provider behavior.

## Evidence

The added owner-boundary regression uses a real admitted production host capability and the real Codex route/client callback. Before the fix it hung because the abort callback threw; a route-only catch then exposed the same retained sink failing from cleanup. With the adapter repair it settles as the existing `client_closed_before_turn_completed` outcome.

- Focused regression: 1 passed.
- Full trajectory + turn-watch owner set: 103 passed.
- `check-changed` for both files: passed, including extension production/test typechecks, lint, formatting, plugin boundaries, dead exports, database-first and import-cycle guards.
- Codex autoreview: scoped clean, no actionable findings.

Production LOC: +8/-1. Tests: +18/-0. The production growth is the owner-boundary guard and its lifecycle invariant comment; no config, protocol, persistence, dependency, or public API surface changes.

No duplicate issue or open PR was found for the exact error or lifecycle race.
