### PR TITLE
fix: recreate agent database after explicit close

### DIFF
--- a/src/state/openclaw-agent-db.test.ts
+++ b/src/state/openclaw-agent-db.test.ts
@@ -2913,6 +2913,31 @@ describe("openclaw agent database", () => {
     expect(second.db.isOpen).toBe(true);
   });
 
+  it("initializes a fresh schema after explicit close and file recreation", () => {
+    const stateDir = createTempStateDir();
+    const env = { OPENCLAW_STATE_DIR: stateDir };
+    const original = openOpenClawAgentDatabase({ agentId: "worker-1", env });
+    const databasePath = original.path;
+
+    expect(closeOpenClawAgentDatabaseByPath(databasePath)).toBe(true);
+    for (const suffix of ["", "-wal", "-shm"]) {
+      fs.rmSync(`${databasePath}${suffix}`, { force: true });
+    }
+
+    const recreated = openOpenClawAgentDatabase({ agentId: "worker-1", env });
+    expect(recreated.db.isOpen).toBe(true);
+    expect(collectSqliteSchemaShape(recreated.db)).toEqual(
+      createSqliteSchemaShapeFromSql(new URL("./openclaw-agent-schema.sql", import.meta.url)),
+    );
+    expect(
+      recreated.db
+        .prepare(
+          "SELECT name FROM sqlite_schema WHERE type = 'table' AND name = 'session_key_contract'",
+        )
+        .get(),
+    ).toEqual({ name: "session_key_contract" });
+  });
+
   it("retains its durable lease when closing the handle fails", () => {
     const stateDir = createTempStateDir();
     const env = { OPENCLAW_STATE_DIR: stateDir };

--- a/src/state/openclaw-agent-db.ts
+++ b/src/state/openclaw-agent-db.ts
@@ -1,7 +1,8 @@
 // OpenClaw agent database stores agent-scoped persisted runtime state.
-import { existsSync } from "node:fs";
+import { existsSync, statSync, type BigIntStats } from "node:fs";
 import path from "node:path";
 import type { DatabaseSync } from "node:sqlite";
+import { sameFileIdentity } from "../infra/fs-safe-advanced.js";
 import { enableNodeSqliteKyselyStatementCache } from "../infra/kysely-sync.js";
 import { openNodeSqliteDatabase } from "../infra/node-sqlite.js";
 import type { SqliteFileGeneration } from "../infra/sqlite-file-generation.js";
@@ -128,8 +129,29 @@ const cachedDatabaseLeases = new Map<
   { leaseId: string; env: NodeJS.ProcessEnv | undefined }
 >();
 // External schema changes under a live process are unsupported: doctor migrations
-// require restart, so successful owner/schema validation is process-stable.
-const validatedAgentDatabasePaths = new Map<string, string>();
+// require restart, so successful owner/schema validation is process-stable. Keep
+// filesystem identity so deletion/recreation revokes trust without making an
+// unchanged explicit close pay the write-capable schema path again.
+type AgentDatabaseFileIdentity = Pick<BigIntStats, "birthtimeNs" | "dev" | "ino">;
+const validatedAgentDatabasePaths = new Map<
+  string,
+  { agentId: string; identity: AgentDatabaseFileIdentity }
+>();
+
+function readAgentDatabaseFileIdentity(pathname: string): AgentDatabaseFileIdentity {
+  const stat = statSync(pathname, { bigint: true });
+  if (!stat.isFile()) {
+    throw new Error(`OpenClaw agent database is not a regular file: ${pathname}`);
+  }
+  return { birthtimeNs: stat.birthtimeNs, dev: stat.dev, ino: stat.ino };
+}
+
+function isSameAgentDatabaseFileIdentity(
+  left: AgentDatabaseFileIdentity,
+  right: AgentDatabaseFileIdentity,
+): boolean {
+  return sameFileIdentity(left, right) && left.birthtimeNs === right.birthtimeNs;
+}
 const terminalOpenLatch = createSqliteTerminalOpenLatch({
   closeByPath: closeOpenClawAgentDatabaseByPath,
 });
@@ -327,7 +349,13 @@ export function openOpenClawAgentDatabase(
     openedDb = db;
     // Eviction churn must avoid migration/convergence and registry busy waits.
     // Version and owner can change while evicted, so their read-only gates run on every open.
-    let isValidatedReopen = validatedAgentDatabasePaths.get(pathname) === agentId;
+    const validatedDatabase = validatedAgentDatabasePaths.get(pathname);
+    let isValidatedReopen =
+      validatedDatabase?.agentId === agentId &&
+      isSameAgentDatabaseFileIdentity(
+        validatedDatabase.identity,
+        readAgentDatabaseFileIdentity(pathname),
+      );
     const walMaintenance = (() => {
       let maintenance: OpenClawAgentDatabase["walMaintenance"] | undefined;
       try {
@@ -381,7 +409,10 @@ export function openOpenClawAgentDatabase(
     openedDatabase = database;
     if (!isValidatedReopen) {
       registerOpenClawAgentDatabase({ agentId, path: pathname, env: options.env });
-      validatedAgentDatabasePaths.set(pathname, agentId);
+      validatedAgentDatabasePaths.set(pathname, {
+        agentId,
+        identity: readAgentDatabaseFileIdentity(pathname),
+      });
     }
     terminalOpenLatch.clear(pathname);
     // Safety net for processes that end without an orderly close: agent DBs have


### PR DESCRIPTION
Related: #129185
Related: #131331

## What Problem This Solves

Fixes an issue where users reopening an agent database after an explicit close could get an uninitialized replacement database when the original SQLite file had been deleted or recreated during the same process.

## Why This Change Was Made

Successful schema validation is now retained only while the pathname still identifies the same filesystem object. An unchanged database keeps the fast read-only reopen path, while a replaced or recreated file falls back to full owner/schema initialization. The identity check uses the repository's canonical filesystem identity helper plus birth time to distinguish rapid inode reuse. This does not change the database schema.

## User Impact

Agents can recover correctly when their database is explicitly closed and then replaced or recreated, without regressing prompt reopen behavior for an unchanged WAL database with another writer active.

## Evidence

- Added a regression test that explicitly closes the database, removes the database/WAL/SHM files, reopens it, and verifies the complete canonical schema including `session_key_contract`.
- Focused test: `src/state/openclaw-agent-db.test.ts` — 121 passed, 4 skipped.
- `scripts/check-changed.mjs -- src/state/openclaw-agent-db.ts src/state/openclaw-agent-db.test.ts` passed, including formatting, lint, core/test typechecks, import-cycle checks, and database guards.
- Full `pnpm build` passed under Node 24.15.0.
- Exact-head CI passed, including `openclaw/ci-gate` and `check-sqlite-session-lifecycle`.
- `git diff --check` passed.
- Direct SQLite lifecycle reproduction is the relevant live proof; no UI or channel surface changes.

### Direct runtime proof

Executed against this PR's production database opener under Node 24.15.0 using an isolated temporary `OPENCLAW_STATE_DIR`. The script opened and explicitly closed an agent database, removed its database/WAL/SHM files, reopened it, and queried the resulting live SQLite schema. It then explicitly closed and reopened the unchanged file while an independent connection held a WAL `BEGIN IMMEDIATE` writer:

```json
{
  "explicitCloseSucceeded": true,
  "recreatedSchema": {
    "open": true,
    "userVersion": 19,
    "tableCount": 49,
    "sessionKeyContract": {
      "name": "session_key_contract"
    }
  },
  "unchangedWalResult": {
    "open": true,
    "elapsedUnderOneSecond": true,
    "elapsedMs": 13.8
  }
}
```

Production code grows to retain and compare a bounded filesystem identity. That state is required to distinguish replacement from an unchanged explicit reopen without forcing every reopen through the write-capable schema path.

AI assistance disclosure: OpenClaw-managed Codex was used for review and identified the unchanged-WAL reopen regression, which is covered on current `main`. The repository's standalone `autoreview` helper was unavailable because it uses separate CLI authentication; submission was explicitly authorized with that limitation.
