### PR TITLE
refactor(cli): share precomputed help output

### DIFF
--- a/src/cli/root-help-metadata.ts
+++ b/src/cli/root-help-metadata.ts
@@ -49,6 +49,19 @@ function loadPrecomputedHelpText(
   return null;
 }
 
+function outputPrecomputedHelpText(
+  key: PrecomputedHelpTextKey,
+  cache: string | null | undefined,
+  setCache: (value: string | null) => void,
+): boolean {
+  const helpText = loadPrecomputedHelpText(key, cache, setCache);
+  if (!helpText) {
+    return false;
+  }
+  process.stdout.write(helpText);
+  return true;
+}
+
 function loadPrecomputedSubcommandHelpText(commandName: string): string | null {
   if (!isPrecomputedSubcommandHelpName(commandName)) {
     return null;
@@ -75,59 +88,27 @@ function loadPrecomputedSubcommandHelpText(commandName: string): string | null {
 }
 
 export function outputPrecomputedRootHelpText(): boolean {
-  const rootHelpText = loadPrecomputedHelpText("rootHelpText", precomputedRootHelpText, (value) => {
+  return outputPrecomputedHelpText("rootHelpText", precomputedRootHelpText, (value) => {
     precomputedRootHelpText = value;
   });
-  if (!rootHelpText) {
-    return false;
-  }
-  process.stdout.write(rootHelpText);
-  return true;
 }
 
 export function outputPrecomputedBrowserHelpText(): boolean {
-  const browserHelpText = loadPrecomputedHelpText(
-    "browserHelpText",
-    precomputedBrowserHelpText,
-    (value) => {
-      precomputedBrowserHelpText = value;
-    },
-  );
-  if (!browserHelpText) {
-    return false;
-  }
-  process.stdout.write(browserHelpText);
-  return true;
+  return outputPrecomputedHelpText("browserHelpText", precomputedBrowserHelpText, (value) => {
+    precomputedBrowserHelpText = value;
+  });
 }
 
 export function outputPrecomputedSecretsHelpText(): boolean {
-  const secretsHelpText = loadPrecomputedHelpText(
-    "secretsHelpText",
-    precomputedSecretsHelpText,
-    (value) => {
-      precomputedSecretsHelpText = value;
-    },
-  );
-  if (!secretsHelpText) {
-    return false;
-  }
-  process.stdout.write(secretsHelpText);
-  return true;
+  return outputPrecomputedHelpText("secretsHelpText", precomputedSecretsHelpText, (value) => {
+    precomputedSecretsHelpText = value;
+  });
 }
 
 export function outputPrecomputedNodesHelpText(): boolean {
-  const nodesHelpText = loadPrecomputedHelpText(
-    "nodesHelpText",
-    precomputedNodesHelpText,
-    (value) => {
-      precomputedNodesHelpText = value;
-    },
-  );
-  if (!nodesHelpText) {
-    return false;
-  }
-  process.stdout.write(nodesHelpText);
-  return true;
+  return outputPrecomputedHelpText("nodesHelpText", precomputedNodesHelpText, (value) => {
+    precomputedNodesHelpText = value;
+  });
 }
 
 export function outputPrecomputedSubcommandHelpText(commandName: string): boolean {


### PR DESCRIPTION
## What Problem This Solves

Stable root, browser, secrets, and nodes help output each maintained the same loading, missing-text, stdout write, and handled-result policy. The copied wrappers could drift independently as precomputed help expands.

## Why This Change Was Made

The four stable-help wrappers now delegate to one private `outputPrecomputedHelpText` helper. It reuses the existing keyed loader, returns `false` when no text exists, writes exactly once when text exists, discards stdout backpressure state, and returns literal `true`.

Subcommand help remains separate because it has a different keyed cache and loader contract. Exports, signatures, cache values, lazy reads, output bytes, and caller behavior are unchanged.

## User Impact

No user-visible behavior changes. Precomputed CLI help keeps the same fast-path output and fallback behavior through one internal implementation.

## Evidence

- Production LOC: +23/-42 (net -19). Tests: +0/-0.
- Current `main` source and history confirm the four wrappers differ only by metadata key, cache, and setter.
- Sibling Codex CLI ownership was inspected directly. Codex renders help independently through Rust/Clap and has no shared runtime contract with this helper.
- `node scripts/run-vitest.mjs src/entry.root-help-fast-path.test.ts src/cli/precomputed-help.test.ts src/cli/run-main.exit.test.ts`: 257 passed.
- `node_modules/.bin/oxfmt --check src/cli/root-help-metadata.ts`: passed.
- `pnpm tsgo:core`: passed.
- `git diff --check origin/main...HEAD`: passed.
- Mandatory local autoreview with `gpt-5.6-sol` at high reasoning: clean, patch correctness confidence 0.99.
- `node scripts/check-changed.mjs -- src/cli/root-help-metadata.ts` stopped before changed-file checks because the sparse task worktree could not resolve the unrelated generated UI locale module.
- The targeted launcher E2E setup stopped before tests because shared task-worktree dependencies exposed a stale unrelated `@openclaw/ai/internal/anthropic` export. Native review and hosted exact-head CI remain the authoritative hydrated-worktree gates.
