### PR TITLE
fix(qa): prevent runtime directories reappearing after cleanup

### DIFF
--- a/docs/concepts/qa-e2e-automation.md
+++ b/docs/concepts/qa-e2e-automation.md
@@ -1135,10 +1135,14 @@ requires adapters to use the two cleanup phases; it does not change broker TTLs
 or provide a durable guarantee after the QA parent or host is lost.
 
 Temporary runtime and staged-plugin directories are removed independently, and
-removal failures are reported with redacted diagnostics. A cleanup error can
+cleanup failures are reported with redacted diagnostics. Before removing the
+runtime, the QA parent closes that root's auth readers and agent databases,
+releases their leases while shared state is still open, then closes the shared
+database. Other QA roots remain untouched. A close failure retains the runtime
+for retry while staged-plugin removal is still attempted. A cleanup error can
 therefore leave isolated runtime or auth state on disk even when process
-termination is confirmed. Correct the filesystem problem and retry `stop()` on
-the retained lifecycle owner; confirmed termination still permits after-stop
+termination is confirmed. Correct the reported problem and retry `stop()` on the
+retained lifecycle owner; confirmed termination still permits after-stop
 credential cleanup.
 
 Payload shapes the broker validates on `admin/add`:

--- a/extensions/qa-lab/src/gateway-child-artifacts.test.ts
+++ b/extensions/qa-lab/src/gateway-child-artifacts.test.ts
@@ -1,17 +1,156 @@
 import fs from "node:fs/promises";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { inspect } from "node:util";
+import {
+  openOpenClawAgentDatabase,
+  openOpenClawStateDatabase,
+} from "openclaw/plugin-sdk/sqlite-runtime-testing";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { cleanupQaGatewayTempRoots } from "./gateway-child-artifacts.js";
+import { readQaAuthProfiles, writeQaAuthProfiles } from "./providers/shared/auth-store.js";
 import { createTempDirHarness } from "./temp-dir.test-helper.js";
+import { runQaScenarioCommandLifecycle } from "./test-file-scenario-command-lifecycle.js";
 
 const dirs = createTempDirHarness();
+const runtimeRoots: string[] = [];
 afterEach(async () => {
   vi.restoreAllMocks();
+  for (const tempRoot of runtimeRoots.splice(0)) {
+    await cleanupQaGatewayTempRoots({ tempRoot });
+  }
   await dirs.cleanup();
 });
 
 describe("cleanupQaGatewayTempRoots", () => {
+  it("does not recreate disposed state at natural parent exit or close sibling stores", async () => {
+    const root = await fs.realpath(await dirs.makeTempDir("qa-cleanup-parent-stores-"));
+    const tempRoot = path.join(root, "runtime");
+    const stagedBundledPluginsRoot = path.join(root, "plugins");
+    const home = path.join(root, "home");
+    const tmp = path.join(root, "tmp");
+    await Promise.all([home, tmp, stagedBundledPluginsRoot].map((dir) => fs.mkdir(dir)));
+    const repoRoot = fileURLToPath(new URL("../../../", import.meta.url));
+    const source = `
+      import assert from "node:assert/strict";
+      import fs from "node:fs";
+      import path from "node:path";
+      import { openOpenClawAgentDatabase, openOpenClawStateDatabase } from "openclaw/plugin-sdk/sqlite-runtime-testing";
+      import { stageQaLiveApiKeyProfiles } from ${JSON.stringify(new URL("./providers/live-frontier/auth.ts", import.meta.url).href)};
+      import { readQaAuthProfiles } from ${JSON.stringify(new URL("./providers/shared/auth-store.ts", import.meta.url).href)};
+      import { cleanupQaGatewayTempRoots } from ${JSON.stringify(new URL("./gateway-child-artifacts.ts", import.meta.url).href)};
+      const tempRoot = ${JSON.stringify(tempRoot)};
+      const roots = [tempRoot, tempRoot + "-sibling"];
+      await Promise.all(roots.map(root => stageQaLiveApiKeyProfiles({
+        cfg: {}, stateDir: path.join(root, "state"), providerIds: ["openai"],
+        env: { OPENAI_API_KEY: "qa-fake-not-a-real-key" },
+      })));
+      const stores = roots.map(root => {
+        const stateDir = path.join(root, "state");
+        const agentDir = path.join(stateDir, "agents", "qa", "agent");
+        const env = { OPENCLAW_STATE_DIR: stateDir };
+        return {
+          agentDir,
+          agent: openOpenClawAgentDatabase({ agentId: "qa", env, path: path.join(agentDir, "openclaw-agent.sqlite") }),
+          shared: openOpenClawStateDatabase({ env }),
+          profiles: readQaAuthProfiles(agentDir),
+        };
+      });
+      const sibling = stores[1];
+      const leases = () => sibling.shared.db.prepare("SELECT * FROM agent_database_leases ORDER BY lease_id").all();
+      const beforeLeases = leases();
+      await cleanupQaGatewayTempRoots({ tempRoot, stagedBundledPluginsRoot: ${JSON.stringify(stagedBundledPluginsRoot)} });
+      assert.equal(fs.existsSync(tempRoot), false);
+      assert.equal(sibling.agent.db.isOpen, true);
+      assert.equal(sibling.shared.db.isOpen, true);
+      assert.deepEqual(readQaAuthProfiles(sibling.agentDir), sibling.profiles);
+      assert.deepEqual(leases(), beforeLeases);
+      process.stdout.write(JSON.stringify({
+        targetClosed: !stores[0].agent.db.isOpen && !stores[0].shared.db.isOpen,
+        siblingUsable: true,
+      }));
+    `;
+    const result = await runQaScenarioCommandLifecycle({
+      command: process.execPath,
+      args: ["--import", "tsx", "--input-type=module", "--eval", source],
+      cwd: repoRoot,
+      env: {
+        PATH: process.env.PATH,
+        SystemRoot: process.env.SystemRoot,
+        HOME: home,
+        USERPROFILE: home,
+        OPENCLAW_HOME: home,
+        OPENCLAW_STATE_DIR: path.join(home, "state"),
+        XDG_CONFIG_HOME: path.join(home, "config"),
+        XDG_CACHE_HOME: path.join(home, "cache"),
+        XDG_DATA_HOME: path.join(home, "data"),
+        XDG_STATE_HOME: path.join(home, "xdg-state"),
+        TMPDIR: tmp,
+        TMP: tmp,
+        TEMP: tmp,
+        TSX_DISABLE_CACHE: "1",
+        TSX_TSCONFIG_PATH: path.join(repoRoot, "tsconfig.json"),
+      },
+      timeoutMs: 90_000,
+    });
+    expect(result).toMatchObject({ exitCode: 0, stderr: "" });
+    expect(result.failureMessage).toBeUndefined();
+    // Check from outside the process: SQLite exit hooks run after cleanup returns.
+    await expect(fs.stat(tempRoot)).rejects.toMatchObject({ code: "ENOENT" });
+    await expect(fs.stat(stagedBundledPluginsRoot)).rejects.toMatchObject({ code: "ENOENT" });
+    expect(JSON.parse(result.stdout)).toEqual({ targetClosed: true, siblingUsable: true });
+  }, 120_000);
+
+  it.each(["agent", "shared"] as const)(
+    "retains runtime on %s close failure, removes staging, and permits cleanup retry",
+    async (failedStore) => {
+      const tempRoot = await dirs.makeTempDir("qa-cleanup-store-failure-");
+      runtimeRoots.push(tempRoot);
+      const stagedBundledPluginsRoot = await dirs.makeTempDir("qa-cleanup-store-plugins-");
+      const stateDir = path.join(tempRoot, "state");
+      const agentDir = path.join(stateDir, "agents", "qa", "agent");
+      const env = { OPENCLAW_STATE_DIR: stateDir };
+      await writeQaAuthProfiles({
+        agentId: "qa",
+        stateDir,
+        profiles: { fake: { type: "api_key", provider: "openai", key: "qa-synthetic" } },
+      });
+      readQaAuthProfiles(agentDir);
+      const agent = openOpenClawAgentDatabase({
+        agentId: "qa",
+        env,
+        path: path.join(agentDir, "openclaw-agent.sqlite"),
+      });
+      const shared = openOpenClawStateDatabase({ env });
+      const failed = failedStore === "agent" ? agent : shared;
+      const close = vi.spyOn(failed.db, "close").mockImplementationOnce(() => {
+        throw new Error("close failed apiKey=synthetic-close-secret", {
+          cause: new Error("synthetic-close-cause"),
+        });
+      });
+
+      const outcome = await cleanupQaGatewayTempRoots({
+        tempRoot,
+        stagedBundledPluginsRoot,
+      }).catch((error: unknown) => error);
+      expect(outcome).toBeInstanceOf(AggregateError);
+      expect(inspect(outcome, { depth: null })).toContain("tempRoot: close failed");
+      expect(inspect(outcome, { depth: null })).not.toMatch(
+        /synthetic-close-secret|synthetic-close-cause/,
+      );
+      expect(failed.db.isOpen).toBe(true);
+      expect(shared.db.isOpen).toBe(true);
+      await expect(fs.stat(tempRoot)).resolves.toBeDefined();
+      await expect(fs.stat(stagedBundledPluginsRoot)).rejects.toMatchObject({ code: "ENOENT" });
+
+      close.mockRestore();
+      await cleanupQaGatewayTempRoots({ tempRoot, stagedBundledPluginsRoot });
+      expect(agent.db.isOpen).toBe(false);
+      expect(shared.db.isOpen).toBe(false);
+      await expect(fs.stat(tempRoot)).rejects.toMatchObject({ code: "ENOENT" });
+    },
+  );
+
   // Short messages expose cause leaks that padding could hide behind truncation.
   it.each([
     { failedRoots: ["tempRoot"], padding: "" },

--- a/extensions/qa-lab/src/gateway-child-artifacts.ts
+++ b/extensions/qa-lab/src/gateway-child-artifacts.ts
@@ -2,6 +2,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { coerceErrorMessage } from "openclaw/plugin-sdk/error-runtime";
+import { closeQaRuntimeStores } from "openclaw/plugin-sdk/qa-runtime";
 import { sliceUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import { ensureRepoBoundDirectory } from "./cli-paths.js";
 import { redactQaGatewayDebugText } from "./gateway-log-redaction.js";
@@ -35,6 +36,9 @@ export async function cleanupQaGatewayTempRoots(params: {
       continue;
     }
     try {
+      if (label === "tempRoot") {
+        await closeQaRuntimeStores(root);
+      }
       await fs.rm(root, { recursive: true, force: true });
     } catch (error) {
       // Attempt both roots. Read only the top-level message before redaction;

--- a/src/agents/auth-profiles.sqlite-store.test.ts
+++ b/src/agents/auth-profiles.sqlite-store.test.ts
@@ -31,6 +31,7 @@ import {
   replaceRuntimeAuthProfileStoreSnapshots,
 } from "./auth-profiles/runtime-snapshots.js";
 import {
+  closeAuthProfileReadPool,
   inspectPersistedAuthProfileStateRaw,
   inspectPersistedAuthProfileStoreRaw,
   resolveAuthProfileDatabasePath,
@@ -569,6 +570,45 @@ describe("auth profile sqlite store", () => {
       } finally {
         statementCacheSpy.mockRestore();
         openSpy.mockRestore();
+      }
+    });
+  });
+
+  it("retains scoped readers for a retry when native close fails", async () => {
+    await withAgentDirEnv("openclaw-auth-reader-close-", (agentDir) => {
+      const siblingAgentDir = `${agentDir}-sibling`;
+      saveAuthProfileStore(apiKeyStore("qa-synthetic"), agentDir);
+      saveAuthProfileStore(apiKeyStore("qa-sibling"), siblingAgentDir);
+      clearRuntimeAuthProfileStoreSnapshots();
+      const openSpy = vi.spyOn(nodeSqlite, "openNodeSqliteDatabase");
+      let reader: DatabaseSync | undefined;
+      try {
+        expect(loadPersistedAuthProfileStore(agentDir)).not.toBeNull();
+        reader = openSpy.mock.results[0]?.value as DatabaseSync;
+        expect(loadPersistedAuthProfileStore(siblingAgentDir)).not.toBeNull();
+        const siblingReader = openSpy.mock.results[1]?.value as DatabaseSync;
+        const close = vi.spyOn(reader, "close").mockImplementationOnce(() => {
+          throw new Error("native close failed");
+        });
+        try {
+          expect(() => closeAuthProfileReadPool({ kind: "root", rootPath: agentDir })).toThrow(
+            "native close failed",
+          );
+          expect(reader.isOpen).toBe(true);
+          closeAuthProfileReadPool({ kind: "root", rootPath: agentDir });
+          expect(reader.isOpen).toBe(false);
+          expect(siblingReader.isOpen).toBe(true);
+          expect(loadPersistedAuthProfileStore(siblingAgentDir)).toMatchObject(
+            apiKeyStore("qa-sibling"),
+          );
+        } finally {
+          close.mockRestore();
+        }
+      } finally {
+        openSpy.mockRestore();
+        if (reader?.isOpen) {
+          reader.close();
+        }
       }
     });
   });

--- a/src/agents/auth-profiles/sqlite.ts
+++ b/src/agents/auth-profiles/sqlite.ts
@@ -335,11 +335,12 @@ function closeAuthProfileReadDatabase(databasePath: string): void {
   if (!db) {
     return;
   }
-  authProfileReadDatabases.delete(pathname);
   clearNodeSqliteKyselyCacheForDatabase(db);
   if (db.isOpen) {
     db.close();
   }
+  // Failed closes remain owned so scoped disposal can retain the root and retry.
+  authProfileReadDatabases.delete(pathname);
   if (authProfileReadDatabases.size === 0) {
     unregisterReadHandleExitClose?.();
     unregisterReadHandleExitClose = null;

--- a/src/plugin-sdk/qa-runtime.ts
+++ b/src/plugin-sdk/qa-runtime.ts
@@ -1,4 +1,5 @@
 import { createServer } from "node:net";
+import path from "node:path";
 // QA runtime helpers register and execute plugin QA scenarios from local files.
 import { runExec } from "./process-runtime.js";
 import { loadQaRuntimeModule as loadQaRunnerRuntimeModule } from "./qa-runner-runtime.js";
@@ -18,6 +19,23 @@ export type {
   LiveTransportQaCredentialCliOptions,
   LiveTransportQaSuiteCommandOptions,
 } from "./qa-runner-runtime.js";
+
+/** Release only this QA root's parent stores before its files are removed. */
+export async function closeQaRuntimeStores(tempRoot: string): Promise<void> {
+  const [auth, agents, state, paths] = await Promise.all([
+    import("../agents/auth-profiles/sqlite.js"),
+    import("../state/openclaw-agent-db.js"),
+    import("../state/openclaw-state-db.js"),
+    import("../state/openclaw-state-db.paths.js"),
+  ]);
+  // Agent close releases leases through shared state. Keep that owner alive
+  // until every scoped handle closes, or exit-time release can recreate the root.
+  auth.closeAuthProfileReadPool({ kind: "root", rootPath: tempRoot });
+  agents.closeOpenClawAgentDatabases(tempRoot);
+  state.closeOpenClawStateDatabaseByPath(
+    paths.resolveOpenClawStateSqlitePath({ OPENCLAW_STATE_DIR: path.join(tempRoot, "state") }),
+  );
+}
 
 type QaRuntimeSurface = {
   acquireQaCredentialLease: <TPayload>(options: {

--- a/src/state/openclaw-agent-db.ts
+++ b/src/state/openclaw-agent-db.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import type { DatabaseSync } from "node:sqlite";
 import { enableNodeSqliteKyselyStatementCache } from "../infra/kysely-sync.js";
 import { openNodeSqliteDatabase } from "../infra/node-sqlite.js";
+import { isPathInside } from "../infra/path-guards.js";
 import type { SqliteFileGeneration } from "../infra/sqlite-file-generation.js";
 import { quarantineOrphanedSqliteSidecars } from "../infra/sqlite-files.js";
 import {
@@ -654,20 +655,12 @@ export function disposeOpenClawAgentDatabaseByPath(
   return true;
 }
 
-/** Close all cached agent database handles. */
-export function closeOpenClawAgentDatabases(): void {
-  unregisterExitClose?.();
-  unregisterExitClose = null;
-  const removedIncognito = [...cachedDatabases.values()].some(
-    (database) => database.db.isOpen && incognitoDatabases.has(database),
-  );
-  for (const database of cachedDatabases.values()) {
-    closeCachedOpenClawAgentDatabase(database);
-  }
-  cachedDatabases.clear();
-  cachedDatabaseOpenFailures.clear();
-  if (removedIncognito) {
-    incognitoDatabaseGeneration += 1;
+/** Close cached agent handles, optionally restricted to one runtime root. */
+export function closeOpenClawAgentDatabases(rootPath?: string): void {
+  for (const pathname of cachedDatabases.keys()) {
+    if (rootPath === undefined || isPathInside(rootPath, pathname)) {
+      closeOpenClawAgentDatabaseByPath(pathname);
+    }
   }
 }
 


### PR DESCRIPTION
Closes #132957

<details>
<summary>Additional instructions</summary>

Maintainer-owned same-repository branch; maintainers can update it.

</details>

## What Problem This Solves

Resolves a problem where QA Lab reports successful Gateway cleanup but empty `state/` and `state/state/` directories reappear when its Node driver exits. This was independently reproduced through the built QA API in both live-frontier and mock-provider modes, without model inference or real credentials.

## Why This Change Was Made

QA's parent process retained SQLite handles after auth staging. Natural process exit closed the agent handles and released their leases through shared state, whose permission hardening recreated the already-removed runtime directory. QA now closes only its own auth readers and agent handles, releases leases while shared state still exists, then closes that exact shared database before removing files.

The change reuses canonical scoped/exact-path close mechanisms. Other QA roots remain open and unchanged. A failed native close retains ownership and the runtime for retry, while staged-plugin cleanup is still attempted independently. Process-group confirmation, unconfirmed-stop retention, keep-temp, artifact export, and error redaction remain intact. No delays, cleanup polling, operator-state changes, schema/config changes, dependency changes, or directive-whitespace repair are included.

Production LOC: +31/-15 (net +16). Tests: +179/-0. Docs: +7/-3. The small production increase adds the missing scoped disposal boundary; the existing all-agent close loop is simplified to reuse exact-path closure.

AI-assisted implementation and independent review. No agent transcripts are included.

## User Impact

Source-checkout QA runs now remain clean after the driver exits. Successful shutdown no longer leaves the reproduced empty runtime residue. Cleanup failures remain visible and retryable rather than deleting files still held by the parent. No operator migration or configuration change is required.

## Evidence

The fresh-subprocess regression failed before the production patch because the runtime root existed after natural parent exit. The repaired test also verifies that a prefix-sharing sibling root keeps its open handles, auth data, and leases. Fault tests cover auth-reader, agent, and shared-database close failures, retention, retry, and redacted diagnostics.

Built-API before/after proof used fresh allowlisted HOME/state/XDG environments and the real `createQaLiveLaneGateway` lifecycle with `forcedRuntime: "openclaw"`. Live-frontier used a synthetic key; mock-openai used the managed local provider. Both modes produced the same results:

| Observation | Before | After |
| --- | --- | --- |
| Stop result | `confirmed-stopped`, no errors | `confirmed-stopped`, no errors |
| Driver exit | 0 | 0 |
| Runtime absent before driver exit | yes | yes |
| Runtime absent after natural driver exit | no | yes |
| Remaining entries | empty `state`, `state/state` | none |
| Gateway PID, group, listener absent | yes | yes |

The repaired runs also independently verified that the staged-plugin root was absent.

This is real ephemeral Gateway startup/shutdown and parent-exit proof, not authenticated inference. No model turn is needed for the defect; no real key or operator Gateway/state was used. It is not a UI or channel-message change.

216 focused owner/sibling tests passed; 4 existing platform/filesystem-gated cases were skipped on macOS. Commands:

```bash
node scripts/run-vitest.mjs extensions/qa-lab/src/gateway-child-artifacts.test.ts src/agents/auth-profiles.sqlite-store.test.ts src/state/openclaw-agent-db.incognito.test.ts src/plugin-sdk/qa-runtime.test.ts extensions/qa-lab/src/gateway-child-lifecycle.test.ts extensions/qa-lab/src/live-transports/shared/live-gateway.runtime.test.ts
```

```bash
node scripts/run-vitest.mjs extensions/qa-lab/src/providers/shared/auth-store.test.ts src/state/openclaw-agent-db.test.ts src/state/openclaw-agent-db.cache-eviction.test.ts
```

```bash
node scripts/check-changed.mjs -- docs/concepts/qa-e2e-automation.md extensions/qa-lab/src/gateway-child-artifacts.test.ts extensions/qa-lab/src/gateway-child-artifacts.ts src/agents/auth-profiles.sqlite-store.test.ts src/agents/auth-profiles/sqlite.ts src/plugin-sdk/qa-runtime.ts src/state/openclaw-agent-db.ts
```

```bash
OPENCLAW_BUILD_PRIVATE_QA=1 pnpm build
```

All selected changed-scope gates and the private QA build passed, including core/plugin production/test typechecks, format/lint, SDK exports/surface, dead exports, state-schema guard, and import cycles. Fresh isolated autoreview is scoped-clean at its default P0 threshold. Introducing-commit attribution remains unknown at the available shallow-history boundary; no introduction claim is made from blame alone.

### Review disposition

[ClawSweeper reviewed this exact head](https://github.com/openclaw/openclaw/pull/132958#issuecomment-5465894687) at 2026-08-30 01:02 UTC and found no actionable code or security defects. Its two before-merge items are handled as follows: the justified +16 production lines remain confined to the QA disposal boundary and the canonical scoped/exact-path close owners, with no additional lifecycle path; exact-head CI and the native maintainer prepare flow are required before the parent lead makes the final merge decision. There is no separate Rank-up moves list or discrete fixup request. The current root-scoped order and subprocess/retry coverage are retained as the review's recommended mitigation.
