### PR TITLE
test: isolate shared /tmp state in reply, channel, and boot suites

### DIFF
--- a/src/auto-reply/reply.block-streaming.test.ts
+++ b/src/auto-reply/reply.block-streaming.test.ts
@@ -1,12 +1,17 @@
 /** Tests block streaming behavior for auto-reply output delivery. */
-import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import path from "node:path";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { withFastReplyConfig } from "./reply/get-reply-fast-path.test-support.js";
 import { loadGetReplyModuleForTest } from "./reply/get-reply.test-loader.js";
 import { createMockTypingController } from "./reply/reply.test-helpers.js";
 import type { MsgContext } from "./templating.js";
 
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
 const mocks = vi.hoisted(() => ({
+  rootDir: "",
   resolveReplyDirectives: vi.fn(),
   handleInlineActions: vi.fn(),
   initSessionState: vi.fn(),
@@ -19,8 +24,8 @@ vi.mock("../agents/agent-scope.js", async () => {
   );
   return {
     ...actual,
-    resolveAgentDir: vi.fn(() => "/tmp/agent"),
-    resolveAgentWorkspaceDir: vi.fn(() => "/tmp/workspace"),
+    resolveAgentDir: vi.fn(() => path.join(mocks.rootDir, "agent")),
+    resolveAgentWorkspaceDir: vi.fn(() => path.join(mocks.rootDir, "workspace")),
     resolveSessionAgentId: vi.fn(() => "main"),
     resolveAgentSkillsFilter: vi.fn(() => undefined),
   };
@@ -39,7 +44,7 @@ vi.mock("../agents/timeout.js", () => ({
 }));
 vi.mock("../agents/workspace.js", () => ({
   DEFAULT_AGENT_WORKSPACE_DIR: "/tmp/workspace",
-  ensureAgentWorkspace: vi.fn(async () => ({ dir: "/tmp/workspace" })),
+  ensureAgentWorkspace: vi.fn(async () => ({ dir: path.join(mocks.rootDir, "workspace") })),
 }));
 vi.mock("../channels/model-overrides.js", () => ({
   resolveChannelModelOverride: vi.fn(() => undefined),
@@ -109,7 +114,7 @@ function createReplyConfig(streamMode?: "block"): OpenClawConfig {
     agents: {
       defaults: {
         model: { primary: "anthropic/claude-opus-4-6" },
-        workspace: "/tmp/workspace",
+        workspace: path.join(mocks.rootDir, "workspace"),
       },
     },
     channels: {
@@ -118,7 +123,7 @@ function createReplyConfig(streamMode?: "block"): OpenClawConfig {
         ...(streamMode ? { streaming: { mode: streamMode } } : {}),
       },
     },
-    session: { store: "/tmp/sessions.json" },
+    session: { store: path.join(mocks.rootDir, "sessions.json") },
   } as OpenClawConfig);
 }
 
@@ -178,6 +183,7 @@ describe("block streaming", () => {
   });
 
   beforeEach(() => {
+    mocks.rootDir = tempDirs.make("openclaw-block-streaming-");
     vi.stubEnv("OPENCLAW_TEST_FAST", "1");
     mocks.resolveReplyDirectives.mockReset();
     mocks.handleInlineActions.mockReset();
@@ -204,7 +210,7 @@ describe("block streaming", () => {
       resetTriggered: false,
       systemSent: false,
       abortedLastRun: false,
-      storePath: "/tmp/sessions.json",
+      storePath: path.join(mocks.rootDir, "sessions.json"),
       sessionScope: "per-sender",
       groupResolution: undefined,
       isGroup: false,

--- a/src/auto-reply/reply/agent-runner-direct-runtime-config.test.ts
+++ b/src/auto-reply/reply/agent-runner-direct-runtime-config.test.ts
@@ -318,7 +318,7 @@ describe("runReplyAgent runtime config", () => {
     expect(createReplyMediaContextMock).toHaveBeenCalledWith({
       cfg: freshCfg,
       sessionKey: undefined,
-      workspaceDir: "/tmp",
+      workspaceDir: followupRun.run.workspaceDir,
       messageProvider: "telegram",
       accountId: undefined,
       groupId: undefined,

--- a/src/auto-reply/reply/agent-runner-execution-cli-progress.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution-cli-progress.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it, onTestFinished, vi } from "vitest";
+import { createDeferred } from "../../../test/helpers/promise.js";
 import { createCliJsonlStreamingParser } from "../../agents/cli-output-stream.js";
 import type { TemplateContext } from "../templating.js";
 import type { GetReplyOptions } from "../types.js";
@@ -282,6 +283,7 @@ describe("executeAgentTurn: CLI progress bridging", () => {
     const typingSignals = createMockTypingSignaler();
     vi.mocked(typingSignals.signalTextDelta).mockReturnValue(typingPending);
     const callbackOrder: string[] = [];
+    const toolStarted = createDeferred();
     const executeAgentTurn = await getExecuteAgentTurnForTest();
     const followupRun = createFollowupRun();
     followupRun.run.provider = "claude-cli";
@@ -297,6 +299,7 @@ describe("executeAgentTurn: CLI progress bridging", () => {
         },
         onToolStart: () => {
           callbackOrder.push("tool");
+          toolStarted.resolve();
         },
       },
       typingSignals,
@@ -313,11 +316,13 @@ describe("executeAgentTurn: CLI progress bridging", () => {
       getActiveSessionEntry: () => undefined,
       resolvedVerboseLevel: "off",
     });
+    onTestFinished(async () => {
+      releaseTyping?.();
+      await runPromise;
+    });
 
     try {
-      await vi.waitFor(() => {
-        expect(callbackOrder).toContain("tool");
-      });
+      await Promise.race([toolStarted.promise, runPromise]);
       expect(callbackOrder).toEqual([
         "partial:answer before tool",
         "partial:answer before tool 2",
@@ -374,6 +379,7 @@ describe("executeAgentTurn: CLI progress bridging", () => {
     const typingSignals = createMockTypingSignaler();
     vi.mocked(typingSignals.signalToolStart).mockReturnValue(typingPending);
     const callbackOrder: string[] = [];
+    const partialReplyStarted = createDeferred();
     const executeAgentTurn = await getExecuteAgentTurnForTest();
     const followupRun = createFollowupRun();
     followupRun.run.provider = "claude-cli";
@@ -386,6 +392,7 @@ describe("executeAgentTurn: CLI progress bridging", () => {
         preserveProgressCallbackStartOrder: true,
         onPartialReply: (payload) => {
           callbackOrder.push(`partial:${payload.text}`);
+          partialReplyStarted.resolve();
         },
         onToolStart: (payload) => {
           callbackOrder.push(`tool:${payload.phase}`);
@@ -405,11 +412,13 @@ describe("executeAgentTurn: CLI progress bridging", () => {
       getActiveSessionEntry: () => undefined,
       resolvedVerboseLevel: "off",
     });
+    onTestFinished(async () => {
+      releaseTyping?.();
+      await runPromise;
+    });
 
     try {
-      await vi.waitFor(() => {
-        expect(callbackOrder).toContain("partial:answer after tool");
-      });
+      await Promise.race([partialReplyStarted.promise, runPromise]);
       expect(callbackOrder).toEqual(["tool:start", "tool:update", "partial:answer after tool"]);
     } finally {
       releaseTyping?.();

--- a/src/auto-reply/reply/agent-runner-execution.test-support.ts
+++ b/src/auto-reply/reply/agent-runner-execution.test-support.ts
@@ -1,5 +1,7 @@
 // Shared mocks and fixtures for agent-runner execution tests.
-import { afterEach, beforeEach, expect, vi } from "vitest";
+import path from "node:path";
+import { afterEach, beforeEach, expect, onTestFinished, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
 import { testing as cliBackendsTesting } from "../../agents/cli-backends.test-support.js";
 import type { runEmbeddedAgentEntry } from "../../agents/embedded-agent-runner/run-entry.js";
 import type { DeferredEmbeddedRunLifecycleOwner } from "../../agents/embedded-agent-runner/run/deferred-lifecycle-owner.js";
@@ -473,18 +475,19 @@ export function createMockTypingSignaler(): TypingSignaler {
 }
 
 export function createFollowupRun(): FollowupRun {
+  const rootDir = useAutoCleanupTempDirTracker(onTestFinished).make("openclaw-agent-execution-");
   return {
     prompt: "hello",
     summaryLine: "hello",
     enqueuedAt: Date.now(),
     run: {
       agentId: "main",
-      agentDir: "/tmp/agent",
+      agentDir: path.join(rootDir, "agent"),
       sessionId: "session",
       sessionKey: "main",
       messageProvider: "whatsapp",
-      sessionFile: "/tmp/session.jsonl",
-      workspaceDir: "/tmp",
+      sessionFile: path.join(rootDir, "session.jsonl"),
+      workspaceDir: rootDir,
       config: {},
       skillsSnapshot: {},
       provider: "anthropic",

--- a/src/auto-reply/reply/agent-runner.media-paths.test.ts
+++ b/src/auto-reply/reply/agent-runner.media-paths.test.ts
@@ -1,8 +1,8 @@
 // Tests media path handling and sandbox staging inside agent runner inputs.
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
-import os from "node:os";
+import { writeFile } from "node:fs/promises";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
 import type { EmbeddedAgentQueueMessageOutcome } from "../../agents/embedded-agent-runner/runs.js";
 import {
   runInitialModelFallbackAttempt,
@@ -21,6 +21,9 @@ import {
   createMockReplyOperation,
   createMockTypingController,
 } from "./test-helpers.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+let testWorkspaceDir: string;
 
 const runEmbeddedAgentMock = vi.fn();
 const runWithModelFallbackMock = vi.fn();
@@ -304,16 +307,15 @@ function makeRunReplyAgentParams(
 ): Parameters<typeof runReplyAgent>[0] {
   const provider = overrides.provider ?? "whatsapp";
   const prompt = overrides.prompt ?? "generate chart";
-  const workspaceDir = overrides.workspaceDir ?? "/tmp/workspace";
+  const runWorkspaceDir = overrides.workspaceDir ?? testWorkspaceDir;
   const followupRun =
     overrides.followupRun ??
     createMockFollowupRun({
       prompt,
       run: {
         agentId: "main",
-        agentDir: "/tmp/agent",
         messageProvider: provider,
-        workspaceDir,
+        workspaceDir: runWorkspaceDir,
       },
     });
   const replyOperation =
@@ -394,9 +396,8 @@ function makeRunReplyAgentParams(
 }
 
 describe("runReplyAgent media path normalization", () => {
-  const cleanupPaths: string[] = [];
-
   beforeEach(() => {
+    testWorkspaceDir = tempDirs.make("openclaw-agent-media-workspace-");
     runEmbeddedAgentMock.mockReset();
     runWithModelFallbackMock.mockReset();
     abortEmbeddedAgentRunMock.mockReset();
@@ -455,8 +456,6 @@ describe("runReplyAgent media path normalization", () => {
       operation.complete();
     }
     vi.useRealTimers();
-    const paths = cleanupPaths.splice(0);
-    return Promise.all(paths.map((entry) => rm(entry, { recursive: true, force: true })));
   });
 
   it("normalizes final MEDIA replies against the run workspace", async () => {
@@ -483,9 +482,9 @@ describe("runReplyAgent media path normalization", () => {
       mediaUrls: ["/tmp/outbound-media/generated.png"],
     });
     expect(resolveOutboundAttachmentFromUrlMock).toHaveBeenCalledWith(
-      path.join("/tmp/workspace", "out", "generated.png"),
+      path.join(testWorkspaceDir, "out", "generated.png"),
       5 * 1024 * 1024,
-      { mediaAccess: expect.objectContaining({ workspaceDir: "/tmp/workspace" }) },
+      { mediaAccess: expect.objectContaining({ workspaceDir: testWorkspaceDir }) },
     );
     expect(runEmbeddedAgentMock).toHaveBeenCalledOnce();
     expect(createReplyMediaContextRuntimeMock).not.toHaveBeenCalled();
@@ -716,7 +715,7 @@ describe("runReplyAgent media path normalization", () => {
     const mediaContext = createReplyMediaContext({
       cfg: {},
       sessionKey: "main",
-      workspaceDir: "/tmp/workspace",
+      workspaceDir: testWorkspaceDir,
       messageProvider: "telegram",
       accountId: "default",
     });
@@ -762,7 +761,7 @@ describe("runReplyAgent media path normalization", () => {
         run: {
           provider: "ollama",
           model: "gemma4:latest",
-          workspaceDir: "/tmp/workspace",
+          workspaceDir: testWorkspaceDir,
           config: {},
         },
       }),
@@ -818,7 +817,7 @@ describe("runReplyAgent media path normalization", () => {
       run: {
         provider: "anthropic",
         model: "claude",
-        workspaceDir: "/tmp/workspace",
+        workspaceDir: testWorkspaceDir,
         config: {},
       },
     });
@@ -868,8 +867,7 @@ describe("runReplyAgent media path normalization", () => {
   });
 
   it("passes current inbound media paths as native OpenClaw images", async () => {
-    const tmpDir = await mkdtemp(path.join(os.tmpdir(), "openclaw-native-agent-media-"));
-    cleanupPaths.push(tmpDir);
+    const tmpDir = tempDirs.make("openclaw-native-agent-media-");
     const imagePath = path.join(tmpDir, "photo.png");
     await writeFile(
       imagePath,
@@ -918,8 +916,7 @@ describe("runReplyAgent media path normalization", () => {
   });
 
   it("does not pass recent history images as unlabeled native OpenClaw images", async () => {
-    const tmpDir = await mkdtemp(path.join(os.tmpdir(), "openclaw-native-agent-history-"));
-    cleanupPaths.push(tmpDir);
+    const tmpDir = tempDirs.make("openclaw-native-agent-history-");
     const imagePath = path.join(tmpDir, "recent.png");
     await writeFile(
       imagePath,
@@ -972,8 +969,7 @@ describe("runReplyAgent media path normalization", () => {
   });
 
   it("retains resolved current images and skips unresolved attachments", async () => {
-    const tmpDir = await mkdtemp(path.join(os.tmpdir(), "openclaw-native-agent-partial-"));
-    cleanupPaths.push(tmpDir);
+    const tmpDir = tempDirs.make("openclaw-native-agent-partial-");
     const imagePath = path.join(tmpDir, "present.png");
     await writeFile(
       imagePath,

--- a/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
+++ b/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
@@ -1,10 +1,10 @@
 import fs from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
 // Tests miscellaneous run-reply-agent behaviors and artifact output.
 import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createDeferred } from "../../../test/helpers/promise.js";
+import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
 import { testing as cliBackendsTesting } from "../../agents/cli-backends.test-support.js";
 import {
   abortEmbeddedAgentRun,
@@ -51,6 +51,9 @@ import { enqueueFollowupRun, scheduleFollowupDrain } from "./queue.js";
 import { createReplyOperation, replyRunRegistry } from "./reply-run-registry.js";
 import { testing as replyRunRegistryTesting } from "./reply-run-registry.test-support.js";
 import { createMockTypingController } from "./test-helpers.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+let rootDir: string;
 
 function createCliBackendTestConfig() {
   return {};
@@ -300,8 +303,8 @@ function createBaseRun(options: BaseRunOptions = {}) {
       sessionId: "session",
       sessionKey,
       messageProvider,
-      sessionFile: "/tmp/session.jsonl",
-      workspaceDir: "/tmp",
+      sessionFile: path.join(rootDir, "session.jsonl"),
+      workspaceDir: rootDir,
       config: {},
       skillsSnapshot: {},
       provider: "anthropic",
@@ -387,6 +390,7 @@ function firstMockCallArg(mock: MockCallSource, label: string): unknown {
 }
 
 function setupAgentRunnerMocks(): void {
+  rootDir = tempDirs.make("openclaw-run-reply-agent-");
   vi.useRealTimers();
   registerCliBackendsForTest();
   clearRuntimeConfigSnapshot();
@@ -491,7 +495,7 @@ describe("runReplyAgent auto-compaction token update", () => {
     return createBaseRun({
       run: {
         agentId: "main",
-        agentDir: "/tmp/agent",
+        agentDir: path.join(rootDir, "agent"),
         config: options?.config ?? {},
         reasoningLevel: "on",
       },
@@ -511,7 +515,7 @@ describe("runReplyAgent auto-compaction token update", () => {
     tmpPrefix: string;
     workspaceDir?: string;
   }) {
-    const tmp = await fs.mkdtemp(path.join(os.tmpdir(), params.tmpPrefix));
+    const tmp = tempDirs.make(params.tmpPrefix);
     const storePath = path.join(tmp, "sessions.json");
     const sessionKey = "main";
     const sessionEntry = {
@@ -538,10 +542,10 @@ describe("runReplyAgent auto-compaction token update", () => {
     const baseRun = createBaseRun({
       run: {
         agentId: "main",
-        agentDir: "/tmp/agent",
+        agentDir: path.join(rootDir, "agent"),
         config: params.config ?? {},
         reasoningLevel: "on",
-        workspaceDir: params.workspaceDir ?? "/tmp",
+        workspaceDir: params.workspaceDir ?? rootDir,
       },
       reply: {
         sessionEntry,
@@ -578,7 +582,7 @@ describe("runReplyAgent auto-compaction token update", () => {
   }, 180_000);
 
   it("keeps an unarmed preflight drain visible instead of dropping the reply", async () => {
-    const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-preflight-drain-"));
+    const tmp = tempDirs.make("openclaw-preflight-drain-");
     const storePath = path.join(tmp, "sessions.json");
     const sessionKey = "agent:main:main";
     const sessionEntry = {
@@ -592,7 +596,7 @@ describe("runReplyAgent auto-compaction token update", () => {
     compactState.compactEmbeddedAgentSessionMock.mockRejectedValueOnce(new GatewayDrainingError());
 
     const result = await createBaseRun({
-      run: { agentId: "main", agentDir: "/tmp/agent", reasoningLevel: "on" },
+      run: { agentId: "main", agentDir: path.join(rootDir, "agent"), reasoningLevel: "on" },
       reply: {
         queueKey: sessionKey,
         sessionEntry,
@@ -607,7 +611,7 @@ describe("runReplyAgent auto-compaction token update", () => {
   });
 
   it("executes the next user turn in the default 32K early-flush interval without compaction", async () => {
-    const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-early-flush-"));
+    const tmp = tempDirs.make("openclaw-early-flush-");
     const storePath = path.join(tmp, "sessions.json");
     const sessionKey = "agent:main:main";
     const scope = { agentId: "main", sessionId: "session", sessionKey, storePath };
@@ -835,7 +839,7 @@ describe("runReplyAgent auto-compaction token update", () => {
     });
 
     const result = await createBaseRun({
-      run: { agentId: "main", agentDir: "/tmp/agent", reasoningLevel: "on" },
+      run: { agentId: "main", agentDir: path.join(rootDir, "agent"), reasoningLevel: "on" },
       reply: {
         queueKey: sessionKey,
         sessionEntry,
@@ -849,9 +853,7 @@ describe("runReplyAgent auto-compaction token update", () => {
   });
 
   it("loads post-compaction context before starting a queued followup drain", async () => {
-    const workspaceDir = await fs.mkdtemp(
-      path.join(os.tmpdir(), "openclaw-post-compaction-queued-followup-"),
-    );
+    const workspaceDir = tempDirs.make("openclaw-post-compaction-queued-followup-");
     try {
       await fs.writeFile(
         path.join(workspaceDir, "AGENTS.md"),
@@ -879,7 +881,7 @@ describe("runReplyAgent auto-compaction token update", () => {
       const baseRun = createBaseRun({
         run: {
           agentId: "main",
-          agentDir: "/tmp/agent",
+          agentDir: path.join(rootDir, "agent"),
           workspaceDir,
           reasoningLevel: "on",
           config: {
@@ -930,7 +932,7 @@ describe("runReplyAgent auto-compaction token update", () => {
     });
 
     const result = await createBaseRun({
-      run: { agentId: "main", agentDir: "/tmp/agent", reasoningLevel: "on" },
+      run: { agentId: "main", agentDir: path.join(rootDir, "agent"), reasoningLevel: "on" },
       reply: {
         queueKey: sessionKey,
         sessionEntry,
@@ -1002,7 +1004,7 @@ describe("runReplyAgent auto-compaction token update", () => {
       const baseRun = createBaseRun({
         run: {
           agentId: "main",
-          agentDir: "/tmp/agent",
+          agentDir: path.join(rootDir, "agent"),
           sessionKey,
           reasoningLevel: "on",
         },
@@ -1127,9 +1129,7 @@ describe("runReplyAgent auto-compaction token update", () => {
   });
 
   it("does not treat diagnostic compaction metadata as a context-refresh trigger", async () => {
-    const workspaceDir = await fs.mkdtemp(
-      path.join(os.tmpdir(), "openclaw-post-compaction-workspace-"),
-    );
+    const workspaceDir = tempDirs.make("openclaw-post-compaction-workspace-");
     await fs.writeFile(
       path.join(workspaceDir, "AGENTS.md"),
       [
@@ -1319,7 +1319,7 @@ describe("runReplyAgent Active Memory inline debug", () => {
   }
 
   async function runActiveMemoryDebugCase(sessionEntry: SessionEntry) {
-    const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-active-memory-inline-"));
+    const tmp = tempDirs.make("openclaw-active-memory-inline-");
     const storePath = path.join(tmp, "sessions.json");
     const sessionKey = "main";
     await replaceSessionEntry({ storePath, sessionKey }, sessionEntry);
@@ -1441,7 +1441,7 @@ describe("runReplyAgent Active Memory inline debug", () => {
   });
 
   it("appends raw trace payloads when trace raw is enabled", async () => {
-    const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-trace-raw-usage-"));
+    const tmp = tempDirs.make("openclaw-trace-raw-usage-");
     const storePath = path.join(tmp, "sessions.json");
     const sessionFile = path.join(tmp, "session.jsonl");
     const sessionKey = "main";
@@ -1623,7 +1623,7 @@ describe("runReplyAgent Active Memory inline debug", () => {
   });
 
   it("does not emit persisted trace output to an unauthorized sender", async () => {
-    const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-trace-raw-unauthorized-"));
+    const tmp = tempDirs.make("openclaw-trace-raw-unauthorized-");
     const storePath = path.join(tmp, "sessions.json");
     const sessionFile = path.join(tmp, "session.jsonl");
     const sessionKey = "main";
@@ -1666,7 +1666,7 @@ describe("runReplyAgent Active Memory inline debug", () => {
   });
 
   it("shows session and last-turn usage totals without per-call usage blocks", async () => {
-    const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-trace-raw-usage-"));
+    const tmp = tempDirs.make("openclaw-trace-raw-usage-");
     const storePath = path.join(tmp, "sessions.json");
     const sessionFile = path.join(tmp, "session.jsonl");
     const sessionKey = "main";
@@ -1722,7 +1722,7 @@ describe("runReplyAgent Active Memory inline debug", () => {
   });
 
   it("escapes markdown fence delimiters inside raw trace blocks", async () => {
-    const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-trace-raw-fence-"));
+    const tmp = tempDirs.make("openclaw-trace-raw-fence-");
     const storePath = path.join(tmp, "sessions.json");
     const sessionFile = path.join(tmp, "session.jsonl");
     const sessionKey = "main";
@@ -2220,7 +2220,7 @@ describe("runReplyAgent fallback reasoning tags", () => {
     return createBaseRun({
       run: {
         agentId: "main",
-        agentDir: "/tmp/agent",
+        agentDir: path.join(rootDir, "agent"),
         sessionKey,
         config: createCliBackendTestConfig(),
       },
@@ -2309,7 +2309,7 @@ describe("runReplyAgent response usage footer", () => {
     return createBaseRun({
       run: {
         agentId: "main",
-        agentDir: "/tmp/agent",
+        agentDir: path.join(rootDir, "agent"),
         sessionKey: params.sessionKey,
         config: params.config ?? createCliBackendTestConfig(),
         provider: params.provider ?? "anthropic",
@@ -2644,7 +2644,7 @@ describe("runReplyAgent private message_tool_only final warning (#85714)", () =>
     replyOperation?: ReturnType<typeof createReplyOperation>;
     turnAdoptionLifecycle?: FollowupRun["turnAdoptionLifecycle"];
   }) {
-    const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-stranded-"));
+    const tmp = tempDirs.make("openclaw-stranded-");
     const storePath = path.join(tmp, "sessions.json");
     const sessionKey = "stranded";
     const sessionEntry = {
@@ -2705,11 +2705,11 @@ describe("runReplyAgent private message_tool_only final warning (#85714)", () =>
         : {}),
       run: {
         agentId: "main",
-        agentDir: "/tmp/agent",
+        agentDir: path.join(rootDir, "agent"),
         sessionId: "session",
         sessionKey,
         messageProvider: "whatsapp",
-        sessionFile: "/tmp/session.jsonl",
+        sessionFile: path.join(rootDir, "session.jsonl"),
         workspaceDir: tmp,
         // Carry the canonical tool-only run fact and keep downstream policy aligned,
         // so the private final is never eligible for automatic source delivery.

--- a/src/auto-reply/reply/agent-runner.test-fixtures.ts
+++ b/src/auto-reply/reply/agent-runner.test-fixtures.ts
@@ -1,4 +1,7 @@
 // Shared fixtures for agent runner tests and temporary session files.
+import path from "node:path";
+import { onTestFinished } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
 import type { SessionEntry } from "../../config/sessions.js";
 import { replaceSessionEntry } from "../../config/sessions/session-accessor.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
@@ -23,18 +26,19 @@ export function createTestQueueSettings(overrides: Partial<QueueSettings> = {}):
 }
 
 export function createTestFollowupRun(overrides: Partial<FollowupRun["run"]> = {}): FollowupRun {
+  const rootDir = useAutoCleanupTempDirTracker(onTestFinished).make("openclaw-followup-run-");
   return {
     prompt: "hello",
     summaryLine: "hello",
     enqueuedAt: Date.now(),
     run: {
       agentId: "main",
-      agentDir: "/tmp/agent",
+      agentDir: path.join(rootDir, "agent"),
       sessionId: "session",
       sessionKey: "main",
       messageProvider: "whatsapp",
-      sessionFile: "/tmp/session.jsonl",
-      workspaceDir: "/tmp",
+      sessionFile: path.join(rootDir, "session.jsonl"),
+      workspaceDir: rootDir,
       config: {},
       skillsSnapshot: { prompt: "", skills: [] },
       provider: "anthropic",

--- a/src/auto-reply/reply/test-helpers.ts
+++ b/src/auto-reply/reply/test-helpers.ts
@@ -1,5 +1,7 @@
 /** Shared test fixtures for reply queue and typing-controller tests. */
-import { vi } from "vitest";
+import path from "node:path";
+import { onTestFinished, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
 import type { FollowupRun } from "./queue.js";
 import type { ReplyOperation } from "./reply-run-registry.js";
 import type { TypingController } from "./typing.js";
@@ -109,6 +111,7 @@ export function createMockTypingController(
 export function createMockFollowupRun(
   overrides: Partial<Omit<FollowupRun, "run">> & { run?: Partial<FollowupRun["run"]> } = {},
 ): FollowupRun {
+  const rootDir = useAutoCleanupTempDirTracker(onTestFinished).make("openclaw-mock-followup-");
   const skipProviderRuntimeHints = process.env.OPENCLAW_TEST_FAST === "1";
   const base: FollowupRun = {
     prompt: "hello",
@@ -117,13 +120,13 @@ export function createMockFollowupRun(
     originatingTo: "channel:C1",
     run: {
       agentId: "main",
-      agentDir: "/tmp/agent",
+      agentDir: path.join(rootDir, "agent"),
       sessionId: "session",
       sessionKey: "main",
       messageProvider: "whatsapp",
       agentAccountId: "primary",
-      sessionFile: "/tmp/session.jsonl",
-      workspaceDir: "/tmp",
+      sessionFile: path.join(rootDir, "session.jsonl"),
+      workspaceDir: rootDir,
       config: {},
       skillsSnapshot: {
         prompt: "",

--- a/src/channels/inbound-event/session-transcript-context.runtime.test.ts
+++ b/src/channels/inbound-event/session-transcript-context.runtime.test.ts
@@ -1,4 +1,6 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
 import type { FinalizedMsgContext } from "../../auto-reply/templating.js";
 import { readRecentUserAssistantTextForSession } from "../../config/sessions/transcript.js";
 import { runPreparedChannelTurn } from "../turn/execution.js";
@@ -28,6 +30,8 @@ function context(overrides: Partial<FinalizedMsgContext> = {}): FinalizedMsgCont
 }
 
 describe("session transcript inbound context", () => {
+  const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
   beforeEach(() => {
     readRecent.mockReset();
   });
@@ -42,7 +46,7 @@ describe("session transcript inbound context", () => {
     await runPreparedChannelTurn({
       channel: "slack",
       routeSessionKey: ctx.SessionKey!,
-      storePath: "/tmp/sessions.json",
+      storePath: path.join(tempDirs.make("openclaw-session-transcript-context-"), "sessions.json"),
       ctxPayload: ctx,
       recordInboundSession: vi.fn(async () => undefined),
       runDispatch: vi.fn(async () => ({ queuedFinal: false })),

--- a/src/channels/turn/run-channel-turn.finalize.test.ts
+++ b/src/channels/turn/run-channel-turn.finalize.test.ts
@@ -1,6 +1,8 @@
 // Channel turn finalize tests cover orchestration, dispatch, and completion behavior.
+import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { bindTestChannelParticipantAdmissionEvidence } from "../../../test/helpers/channel-admission-evidence.js";
+import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
 import type { HistoryEntry } from "../../auto-reply/reply/history.types.js";
 import type { DispatchReplyWithBufferedBlockDispatcher } from "../../auto-reply/reply/provider-dispatcher.types.js";
 import type { FinalizedMsgContext } from "../../auto-reply/templating.js";
@@ -91,6 +93,8 @@ vi.mock("../../config/sessions/transcript.js", () => ({
 }));
 
 const cfg = {} as OpenClawConfig;
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+let storePath: string;
 
 function createCtx(overrides: Partial<FinalizedMsgContext> = {}): FinalizedMsgContext {
   return {
@@ -149,7 +153,7 @@ function dispatchTestAssembledTurn(
   return dispatchAssembledChannelTurn({
     cfg,
     agentId: "main",
-    storePath: "/tmp/sessions.json",
+    storePath,
     ...overrides,
   });
 }
@@ -200,6 +204,7 @@ function loggedEvents(log: ReturnType<typeof vi.fn>): TurnLogEvent[] {
 
 describe("channel turn finalize", () => {
   beforeEach(() => {
+    storePath = path.join(tempDirs.make("openclaw-channel-turn-finalize-"), "sessions.json");
     vi.clearAllMocks();
     recordInboundSessionCore.mockResolvedValue(undefined);
     dispatchReplyWithBufferedBlockDispatcherCore.mockImplementation(createDispatch());
@@ -249,7 +254,7 @@ describe("channel turn finalize", () => {
     const first = await runPreparedChannelTurn({
       channel: "test",
       routeSessionKey: "agent:main:test:peer",
-      storePath: "/tmp/sessions.json",
+      storePath,
       ctxPayload: createCtx(),
       recordInboundSession,
       runDispatch,
@@ -262,7 +267,7 @@ describe("channel turn finalize", () => {
     const second = await runPreparedChannelTurn({
       channel: "test",
       routeSessionKey: "agent:main:test:peer",
-      storePath: "/tmp/sessions.json",
+      storePath,
       ctxPayload: createCtx(),
       recordInboundSession,
       runDispatch,
@@ -374,7 +379,7 @@ describe("channel turn finalize", () => {
     const result = await runPreparedChannelTurn({
       channel: "test",
       routeSessionKey: "agent:observer:test:peer",
-      storePath: "/tmp/sessions.json",
+      storePath,
       ctxPayload: createCtx({ SessionKey: "agent:observer:test:peer" }),
       recordInboundSession,
       runDispatch,
@@ -407,7 +412,7 @@ describe("channel turn finalize", () => {
       channel: "test",
       agentId: "observer",
       routeSessionKey: "agent:observer:test:peer",
-      storePath: "/tmp/sessions.json",
+      storePath,
       ctxPayload: createCtx({ SessionKey: "agent:observer:test:peer" }),
       recordInboundSession: createRecordInboundSession(events),
       dispatchReplyWithBufferedBlockDispatcher: createDispatch(events),
@@ -435,7 +440,7 @@ describe("channel turn finalize", () => {
     await runPreparedChannelTurn({
       channel: "test",
       routeSessionKey: "agent:main:test:group:room-1",
-      storePath: "/tmp/sessions.json",
+      storePath,
       ctxPayload: createCtx(),
       recordInboundSession: createRecordInboundSession(),
       runDispatch: vi.fn(async () => ({
@@ -456,7 +461,7 @@ describe("channel turn finalize", () => {
       runPreparedChannelTurn({
         channel: "test",
         routeSessionKey: "agent:main:test:peer",
-        storePath: "/tmp/sessions.json",
+        storePath,
         ctxPayload: createCtx(),
         recordInboundSession: createRecordInboundSession(),
         runDispatch,
@@ -479,7 +484,7 @@ describe("channel turn finalize", () => {
       runPreparedChannelTurn({
         channel: "test",
         routeSessionKey: "agent:main:test:peer",
-        storePath: "/tmp/sessions.json",
+        storePath,
         ctxPayload: createCtx({
           AgentId: "main",
           SessionTranscriptContext: { historyLimit: 1 },
@@ -512,7 +517,7 @@ describe("channel turn finalize", () => {
       runPreparedChannelTurn({
         channel: "test",
         routeSessionKey: "agent:main:test:peer",
-        storePath: "/tmp/sessions.json",
+        storePath,
         ctxPayload: createCtx(),
         recordInboundSession,
         onPreDispatchFailure,
@@ -544,7 +549,7 @@ describe("channel turn finalize", () => {
       runPreparedChannelTurn({
         channel: "test",
         routeSessionKey: "agent:main:test:peer",
-        storePath: "/tmp/sessions.json",
+        storePath,
         ctxPayload: createCtx(),
         recordInboundSession,
         runDispatch: vi.fn(async () => {
@@ -563,7 +568,7 @@ describe("channel turn finalize", () => {
     await runPreparedChannelTurn({
       channel: "test",
       routeSessionKey: "agent:main:test:peer",
-      storePath: "/tmp/sessions.json",
+      storePath,
       ctxPayload: createCtx(),
       recordInboundSession: createRecordInboundSession(events),
       afterRecord: vi.fn(async () => {
@@ -628,7 +633,7 @@ describe("channel turn finalize", () => {
       runPreparedChannelTurn({
         channel: "test",
         routeSessionKey: "agent:main:test:peer",
-        storePath: "/tmp/sessions.json",
+        storePath,
         ctxPayload: createCtx(),
         recordInboundSession: vi.fn(async () => {
           throw recordError;

--- a/src/channels/turn/run-channel-turn.pipeline.test.ts
+++ b/src/channels/turn/run-channel-turn.pipeline.test.ts
@@ -1,5 +1,7 @@
 // Channel turn pipeline tests cover orchestration, dispatch, and completion behavior.
+import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
 import type { ReplyPayload } from "../../auto-reply/reply-payload.js";
 import { noteDispatchProcessedOutcome } from "../../auto-reply/reply/dispatch-processed-outcome.js";
 import type { DispatchReplyWithBufferedBlockDispatcher } from "../../auto-reply/reply/provider-dispatcher.types.js";
@@ -115,6 +117,8 @@ vi.mock("../../config/sessions/transcript.js", () => ({
 }));
 
 const cfg = {} as OpenClawConfig;
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+let storePath: string;
 const visibleFinalReceipt = {
   counts: {
     tool: {
@@ -186,7 +190,7 @@ function dispatchTestAssembledTurn(
   return dispatchAssembledChannelTurn({
     cfg,
     agentId: "main",
-    storePath: "/tmp/sessions.json",
+    storePath,
     ...overrides,
   });
 }
@@ -197,7 +201,7 @@ function runTestPreparedChannelTurn<TDispatchResult>(
   return runPreparedChannelTurn({
     channel: "test",
     routeSessionKey: "agent:main:test:peer",
-    storePath: "/tmp/sessions.json",
+    storePath,
     ctxPayload: createCtx(),
     recordInboundSession: createRecordInboundSession(),
     record: { onRecordError: vi.fn() },
@@ -238,6 +242,7 @@ function loggedEvents(log: ReturnType<typeof vi.fn>): TurnLogEvent[] {
 
 describe("channel turn pipeline", () => {
   beforeEach(() => {
+    storePath = path.join(tempDirs.make("openclaw-channel-turn-pipeline-"), "sessions.json");
     vi.clearAllMocks();
     recordInboundSessionCore.mockResolvedValue(undefined);
     dispatchReplyWithBufferedBlockDispatcherCore.mockImplementation(createDispatch());
@@ -708,7 +713,7 @@ describe("channel turn pipeline", () => {
     const [recordRequest] = (recordInboundSession as unknown as ReturnType<typeof vi.fn>).mock
       .calls[0] as unknown as [{ sessionKey?: string; storePath?: string }];
     expect(recordRequest.sessionKey).toBe("agent:main:test:peer");
-    expect(recordRequest.storePath).toBe("/tmp/sessions.json");
+    expect(recordRequest.storePath).toBe(storePath);
     expect(deliver).toHaveBeenCalledWith({ text: "reply" }, { kind: "final" });
   });
 
@@ -745,7 +750,7 @@ describe("channel turn pipeline", () => {
       expect.objectContaining({
         agentId: "main",
         sessionKey: targetSessionKey,
-        storePath: "/tmp/sessions.json",
+        storePath,
       }),
     );
     const recordEvents = log.mock.calls
@@ -811,7 +816,7 @@ describe("channel turn pipeline", () => {
     const result = await runPreparedChannelTurn({
       channel: "test",
       routeSessionKey: "agent:main:test:peer",
-      storePath: "/tmp/sessions.json",
+      storePath,
       ctxPayload: createCtx(),
       recordInboundSession,
       runDispatch,
@@ -915,7 +920,7 @@ describe("channel turn pipeline", () => {
       await runPreparedChannelTurn({
         channel: "slack",
         routeSessionKey: "agent:main:slack:channel:c1",
-        storePath: "/tmp/sessions.json",
+        storePath,
         ctxPayload: createCtx({ SessionKey: "agent:main:slack:channel:c1" }),
         recordInboundSession,
         runDispatch,

--- a/src/channels/turn/run-channel-turn.prepared-lifecycle.test.ts
+++ b/src/channels/turn/run-channel-turn.prepared-lifecycle.test.ts
@@ -1,4 +1,6 @@
-import { describe, expect, it, vi } from "vitest";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
 import type { FinalizedMsgContext } from "../../auto-reply/templating.js";
 import type { RecordInboundSession } from "../session.types.js";
 import { hasFinalChannelTurnDispatch } from "./dispatch-result.js";
@@ -43,6 +45,16 @@ function finalizeResult(value: unknown): FinalizeResult {
 }
 
 describe("prepared channel turn lifecycle", () => {
+  const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+  let storePath: string;
+
+  beforeEach(() => {
+    storePath = path.join(
+      tempDirs.make("openclaw-channel-turn-prepared-lifecycle-"),
+      "sessions.json",
+    );
+  });
+
   it("runs custom prepared dispatch from a full turn adapter", async () => {
     const events: string[] = [];
     const result = await runChannelTurn({
@@ -53,7 +65,7 @@ describe("prepared channel turn lifecycle", () => {
         resolveTurn: () => ({
           channel: "test",
           routeSessionKey: "agent:main:test:peer",
-          storePath: "/tmp/sessions.json",
+          storePath,
           ctxPayload: createCtx(),
           recordInboundSession: createRecordInboundSession(events),
           runDispatch: async () => {
@@ -94,7 +106,7 @@ describe("prepared channel turn lifecycle", () => {
             ({
               channel: "test",
               routeSessionKey: "agent:main:test:peer",
-              storePath: "/tmp/sessions.json",
+              storePath,
               ctxPayload: createCtx(),
               recordInboundSession,
               runDispatch,
@@ -126,7 +138,7 @@ describe("prepared channel turn lifecycle", () => {
           resolveTurn: () => ({
             channel: "test",
             routeSessionKey: "agent:main:test:peer",
-            storePath: "/tmp/sessions.json",
+            storePath,
             ctxPayload: createCtx(),
             recordInboundSession,
             runDispatch,
@@ -166,7 +178,7 @@ describe("prepared channel turn lifecycle", () => {
         resolveTurn: () => ({
           channel: "test",
           routeSessionKey: "agent:main:test:peer",
-          storePath: "/tmp/sessions.json",
+          storePath,
           ctxPayload: createCtx(),
           recordInboundSession: createRecordInboundSession(),
           runDispatch,
@@ -209,7 +221,7 @@ describe("prepared channel turn lifecycle", () => {
           resolveTurn: () => ({
             channel: "test",
             routeSessionKey: "agent:observer:test:peer",
-            storePath: "/tmp/sessions.json",
+            storePath,
             ctxPayload: createCtx({ SessionKey: "agent:observer:test:peer" }),
             recordInboundSession: createRecordInboundSession(events),
             runDispatch,

--- a/src/infra/gateway-boot-lifecycle.test.ts
+++ b/src/infra/gateway-boot-lifecycle.test.ts
@@ -1,9 +1,7 @@
 // Gateway boot lifecycle tests cover restart-loop breaker accounting.
-import fs from "node:fs";
-import os from "node:os";
-import path from "node:path";
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { createTempDirTracker } from "../../test/helpers/temp-dir.js";
 import {
   formatLegacyAgentMediaMigrationRequiredMessage,
   GATEWAY_AGENT_MEDIA_MIGRATION_REQUIRED_REASON,
@@ -33,13 +31,16 @@ const GATEWAY_BOOT_LOOP_UNCLEAN_THRESHOLD = 3;
 const GATEWAY_BOOT_LOOP_WINDOW_MS = 5 * 60_000;
 const GATEWAY_BOOT_LIFECYCLE_RETENTION_MS = 24 * 60 * 60_000;
 
+const tempDirs = createTempDirTracker();
+
 afterEach(() => {
   closeOpenClawStateDatabaseForTest();
+  tempDirs.cleanup();
   vi.unstubAllEnvs();
 });
 
 function createLifecycleDb() {
-  const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-gateway-boot-"));
+  const stateDir = tempDirs.make("openclaw-gateway-boot-");
   const env = { OPENCLAW_STATE_DIR: stateDir } as NodeJS.ProcessEnv;
   const { db } = openOpenClawStateDatabase({ env });
   const kysely = getNodeSqliteKysely<GatewayBootLifecycleTestDatabase>(db);

--- a/src/plugin-sdk/inbound-reply-dispatch.test.ts
+++ b/src/plugin-sdk/inbound-reply-dispatch.test.ts
@@ -1,4 +1,6 @@
-import { describe, expect, expectTypeOf, it, vi } from "vitest";
+import path from "node:path";
+import { afterEach, describe, expect, expectTypeOf, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import type { DispatchReplyWithBufferedBlockDispatcher } from "../auto-reply/reply/provider-dispatcher.types.js";
 import type { FinalizedMsgContext } from "../auto-reply/templating.js";
 import type { RecordInboundSession } from "../channels/session.types.js";
@@ -38,6 +40,8 @@ import {
 } from "./inbound-reply-dispatch.js";
 
 describe("inbound reply dispatch compatibility", () => {
+  const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
   it("keeps the deprecated package subpath compatibility exports", () => {
     const callableExports = [
       ["hasFinalInboundReplyDispatch", hasFinalInboundReplyDispatch],
@@ -116,7 +120,7 @@ describe("inbound reply dispatch compatibility", () => {
       channel: "test",
       accountId: "default",
       route: { agentId: "main", sessionKey: "agent:main:test:peer" },
-      storePath: "/tmp/sessions.json",
+      storePath: path.join(tempDirs.make("openclaw-inbound-reply-dispatch-"), "sessions.json"),
       ctxPayload,
       core: {
         channel: {


### PR DESCRIPTION
## What Problem This Solves

Several test fixtures handed real session-store, agent, transcript, and workspace
paths under the shared, machine-wide `/tmp` — `/tmp/agent`, `/tmp/session.jsonl`,
`/tmp/sessions.json`, and `/tmp` itself as a workspace directory. Mocking recording
or model execution did not intercept every filesystem consumer: channel execution
calls `deliverPendingDeliveryNotice`, which reads the session through the real
SQLite accessor and validates its schema.

The result is that unrelated state left on a developer or CI machine silently
changes test outcomes. A stale `/tmp/openclaw-agent.sqlite` at an older schema
version made suites fail with a migration error that has nothing to do with the
code under test, and passing runs only proved that nobody had left such a file
behind yet.

## Why This Change Was Made

Route those fixtures through the existing `test/helpers/temp-dir.ts` tracker,
which creates unique directories under the canonical system temp root (including
macOS `/var` symlink handling). Shared fixture factories register cleanup on the
current test via `onTestFinished` on each invocation, rather than import-time
hooks that could attach only to the first suite under `isolate: false`.

No new helper, production seam, schema, configuration, or dependency was added,
and no repository-wide `/tmp` replacement was performed — inert literals that
terminate in mocked readers were deliberately left alone.

Fresh isolated fixtures then exposed two CLI progress tests whose one-second
`vi.waitFor` polling deadline was racing real startup. They now wait on the actual
callback through the existing deferred helper, keep their exact ordering
assertions, and release/drain the run on failure. No timeout was raised, assertion
weakened, mock broadened, retry added, or test skipped.

## User Impact

None at runtime. Production LOC is unchanged (+0/-0); every changed line is test
or test-support code. The change removes a class of false failures that cost
maintainers time to diagnose.

## Evidence

Failing-first, in the original execution order: with a synthetic
`/tmp/openclaw-agent.sqlite` at `user_version=17` present, `run-channel-turn.finalize`
failed **5/19** on unmodified source with the schema-17 migration error raised at
`src/state/openclaw-agent-db-schema-helpers.ts:265`, through the read-only session
accessor and pending-delivery notice. With the same stale database present, the
repaired suite passed **19/19**. The operator's real database was preserved by
rename and restored with SHA-256 and inode verification.

Blast radius: all 29 call sites of the three changed fixture factories were
enumerated, including two integration suites in `src/agents` that the original
lane runs did not cover. Re-validated on the rebased head:

    node scripts/run-vitest.mjs <14 changed files + uncovered callers>
    Test Files  2 failed | 26 passed (28)
    Tests  2 failed | 583 passed (585)

The two failures were the first-case tests in
`agent-runner-execution-cli-commentary.test.ts` and
`agent-runner-execution-cli-progress.test.ts`. Subsequent review reproduced them
in a fresh two-suite process and traced them to missing model-input metadata in
the execution fixture, which triggered real provider catalog discovery. The
progress case uses mocked CLI events; the commentary case invokes a real local
scripted JSONL subprocess. Warm reruns and the earlier clean A/B did not establish
host load as the root cause.

The fixture correction is tracked separately in #132988 because this PR merged
while the extended verification was running. With that correction, a new empty
Vitest module cache passed 18/18 CLI tests; all 40 affected files passed 723 tests.
See the [corrected review evidence](https://github.com/openclaw/openclaw/pull/132960#issuecomment-5465928906).

Per-suite validation with the stale database deliberately present passed 310 tests
across all 14 changed suites plus `test/helpers/temp-dir.test.ts`. Fresh
`$autoreview` on the final edit reported no accepted or actionable findings.

