### PR TITLE
test(qa): observe proxy cleanup without rebinding ports

### DIFF
--- a/extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-runtime-e2ee-cli-account.test.ts
+++ b/extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-runtime-e2ee-cli-account.test.ts
@@ -8,10 +8,7 @@ import { startMatrixQaFaultProxy } from "../substrate/fault-proxy.js";
 import type { MatrixQaCliSession } from "./scenario-runtime-cli.js";
 import { runMatrixQaE2eeCliEncryptionSetupBootstrapFailureScenario } from "./scenario-runtime-e2ee-cli-account.js";
 import { MATRIX_QA_ROOM_KEY_BACKUP_VERSION_ENDPOINT } from "./scenario-runtime-e2ee-shared.js";
-import {
-  assertMatrixQaTestPortClosed,
-  createMatrixQaE2eeTestContext,
-} from "./scenario-runtime-e2ee.test-helpers.js";
+import { createMatrixQaE2eeTestContext } from "./scenario-runtime-e2ee.test-helpers.js";
 
 const mocks = vi.hoisted(() => ({ createRuntime: vi.fn() }));
 vi.mock("./scenario-runtime-e2ee-cli-runtime.js", () => ({
@@ -60,10 +57,12 @@ describe("Matrix CLI bootstrap failure evidence and ownership", () => {
     );
     vi.mocked(startMatrixQaFaultProxy).mockImplementation(async (params) => {
       proxy = await actual.startMatrixQaFaultProxy(params);
+      closed = false;
       return {
         ...proxy,
         stop: async () => {
           await beforeProxyStop?.();
+          // Released ports can belong to other tests; observe this proxy's completion.
           stopping = proxy.stop().then(() => {
             closed = true;
           });
@@ -128,7 +127,7 @@ describe("Matrix CLI bootstrap failure evidence and ownership", () => {
     async ({ methods }) => {
       configureCli(methods);
       await expect(run()).rejects.toThrow("did not attempt faulted room-key backup creation");
-      await assertMatrixQaTestPortClosed(proxy.baseUrl);
+      expect(closed).toBe(true);
       expect(dispose).toHaveBeenCalledOnce();
     },
   );
@@ -138,11 +137,10 @@ describe("Matrix CLI bootstrap failure evidence and ownership", () => {
     await expect(run()).resolves.toMatchObject({
       artifacts: { bootstrapSuccess: false, faultHitCount: 2 },
     });
-    await assertMatrixQaTestPortClosed(proxy.baseUrl);
-    closed = false;
+    expect(closed).toBe(true);
     configureCli(["POST"], "unrelated failure");
     await expect(run()).rejects.toThrow("unexpected reason");
-    await assertMatrixQaTestPortClosed(proxy.baseUrl);
+    expect(closed).toBe(true);
   });
 
   it.each([new Error("runtime construction failed"), undefined, "construction rejected"])(
@@ -150,7 +148,7 @@ describe("Matrix CLI bootstrap failure evidence and ownership", () => {
     async (failure) => {
       mocks.createRuntime.mockRejectedValueOnce(failure);
       await expect(run()).rejects.toBe(failure);
-      await assertMatrixQaTestPortClosed(proxy.baseUrl);
+      expect(closed).toBe(true);
     },
   );
 
@@ -163,7 +161,7 @@ describe("Matrix CLI bootstrap failure evidence and ownership", () => {
         cause: failure,
         errors: [failure, proxyCleanupFailure],
       });
-      await assertMatrixQaTestPortClosed(proxy.baseUrl);
+      expect(closed).toBe(true);
     },
   );
 
@@ -173,7 +171,7 @@ describe("Matrix CLI bootstrap failure evidence and ownership", () => {
       configureCli(["POST"]);
       dispose.mockRejectedValueOnce(failure);
       await expect(run()).rejects.toBe(failure);
-      await assertMatrixQaTestPortClosed(proxy.baseUrl);
+      expect(closed).toBe(true);
     },
   );
 
@@ -186,7 +184,7 @@ describe("Matrix CLI bootstrap failure evidence and ownership", () => {
       cause: disposalFailure,
       errors: [disposalFailure, proxyCleanupFailure],
     });
-    await assertMatrixQaTestPortClosed(proxy.baseUrl);
+    expect(closed).toBe(true);
   });
 
   it("joins proxy cleanup before returning a CLI disposal failure", async () => {
@@ -212,6 +210,6 @@ describe("Matrix CLI bootstrap failure evidence and ownership", () => {
       release.resolve();
       expect(await operation).toBe(disposalFailure);
     }
-    await assertMatrixQaTestPortClosed(proxy.baseUrl);
+    expect(closed).toBe(true);
   });
 });

--- a/extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-runtime-e2ee.test-helpers.ts
+++ b/extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-runtime-e2ee.test-helpers.ts
@@ -1,4 +1,3 @@
-import { createServer } from "node:net";
 import type { MatrixVerificationBootstrapResult } from "@openclaw/matrix/test-api.js";
 import type { MatrixQaScenarioContext } from "./scenario-runtime-shared.js";
 
@@ -22,16 +21,6 @@ export function createMatrixQaE2eeTestContext(
     topology: { defaultRoomId: "!room:matrix-qa.test", defaultRoomKey: "main", rooms: [] },
     ...overrides,
   };
-}
-
-export async function assertMatrixQaTestPortClosed(baseUrl: string) {
-  const probe = createServer();
-  await new Promise<void>((resolve, reject) => {
-    probe.once("error", reject);
-    probe.listen(Number(new URL(baseUrl).port), "127.0.0.1", () => {
-      probe.close((error) => (error ? reject(error) : resolve()));
-    });
-  });
 }
 
 export function createMatrixQaBootstrapFailure(): MatrixVerificationBootstrapResult {


### PR DESCRIPTION
## What Problem This Solves

A Matrix QA cleanup test could fail with `EADDRINUSE` after its proxy had shut down correctly. It tried to prove cleanup by opening a second server on the released port. Another parallel test could legitimately claim that port first, causing an unrelated PR to rerun a 3,141-test shard.

This is an AI-assisted, maintainer-requested CI reliability cleanup discovered during a performance campaign.

## Why This Change Was Made

Assert the completion fact the test wrapper already records after the real proxy's `stop()` resolves, and reset that fact on each proxy acquisition. Delete the port-rebinding helper. The proxy owner resolves `stop()` from its own server-close callback, so the assertion follows the correct resource's lifecycle without depending on global port availability.

Production LOC: 0. Test/test-support LOC: +11/-24 (net -13). This removes 14 redundant TCP bind/close probes per suite. No production hooks, retries, larger timeouts, global test serialization, or weakened cleanup-error assertions are added.

## User Impact

No Matrix runtime behavior changes. CI stops treating another test's successful port allocation as a proxy leak. Construction rejection values, POST evidence, error aggregation, disposal counts, and the held-cleanup ordering assertion remain covered.

## Evidence

- Original failure: [CI job for #132940](https://github.com/openclaw/openclaw/actions/runs/33283695026/job/99183161206), one `EADDRINUSE` failure after 3,140 passing tests.
- Deterministic reproduction: start the real fault proxy, await its stop, bind a competing listener to the released port, then invoke the old assertion. It fails with `EADDRINUSE` while the exact proxy's stop-completion fact is already true. Both owned listeners are cleaned up.
- The focused scenario, real fault-proxy, and room-bootstrap sibling suites passed: 25 tests. Formatting and diff checks also passed.
- Structured Codex review found no actionable issue. Direct source review verified `stop()` awaits the server-close callback, and the existing deferred-cleanup test still proves the scenario waits before returning.
- Hosted exact-head CI will be required before landing. No live Matrix account is needed: this is a test-only local socket lifecycle repair, exercised with the real proxy.

Provenance: the racy helper and its scenario suite were added in [19558a78f649](https://github.com/openclaw/openclaw/commit/19558a78f6497fa62f4b78c164fe65e9fd38bd25), [#132776](https://github.com/openclaw/openclaw/pull/132776), on August 29, 2026. The raw parent and parent-to-commit patch were checked; the helper and scenario suite were absent from that parent. Code/PR author and merger: @steipete; Git committer: GitHub.
