### PR TITLE
test: bind fixture unix sockets under a path the platform can hold

### DIFF
--- a/extensions/cua-computer/src/mcp-driver-client.test.ts
+++ b/extensions/cua-computer/src/mcp-driver-client.test.ts
@@ -1,6 +1,5 @@
 import fs from "node:fs/promises";
 import net from "node:net";
-import os from "node:os";
 import path from "node:path";
 import { describe, expect, it, onTestFinished, vi } from "vitest";
 import { ClickButton, EscalationReason } from "./driver-client.js";
@@ -24,7 +23,10 @@ type FakeEndpoint = {
 async function createFakeEndpoint(
   handle: (request: RpcRequest, endpoint: FakeEndpoint) => void,
 ): Promise<FakeEndpoint> {
-  const directory = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-cua-mcp-test-"));
+  // macOS sockaddr_un cannot hold the test runner's nested temporary path.
+  const directory = await fs.mkdtemp(path.join(await fs.realpath("/tmp"), "oc-cua-mcp-"));
+  // Registered before the bind so a failed listen still removes the root.
+  onTestFinished(async () => await fs.rm(directory, { recursive: true, force: true }));
   const socketPath = path.join(directory, "daemon.sock");
   const binaryPath = path.join(directory, "cua-driver");
   await fs.writeFile(
@@ -100,7 +102,6 @@ socket.on("close", () => process.exit(0));
           resolve();
         });
       });
-      await fs.rm(directory, { recursive: true, force: true });
     },
   });
   // Register first so later driver hooks dispose before socket cleanup, even when a test fails.

--- a/extensions/openshell/src/backend.e2e.test.ts
+++ b/extensions/openshell/src/backend.e2e.test.ts
@@ -1,7 +1,6 @@
 // Openshell tests cover backend plugin behavior.
 import fs from "node:fs/promises";
 import net from "node:net";
-import os from "node:os";
 import path from "node:path";
 import {
   createSandboxTestContext,
@@ -339,7 +338,9 @@ describe("openshell sandbox backend e2e", () => {
         throw new Error("OpenShell E2E requires an active local registered gateway");
       }
 
-      const rootDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-openshell-e2e-"));
+      // macOS sockaddr_un cannot hold the test runner's nested temporary path, and the
+      // mirror socket under this root would exceed it.
+      const rootDir = await fs.mkdtemp(path.join(await fs.realpath("/tmp"), "oc-osh-e2e-"));
       const env = openshellEnv(rootDir);
       const previousHome = process.env.HOME;
       const previousXdgConfigHome = process.env.XDG_CONFIG_HOME;

--- a/src/gateway/desktop/observe-bridge.test.ts
+++ b/src/gateway/desktop/observe-bridge.test.ts
@@ -1,7 +1,6 @@
 import fs from "node:fs/promises";
 import http from "node:http";
 import net from "node:net";
-import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { WebSocket } from "ws";
@@ -40,25 +39,38 @@ async function createProxyHarness(
     preauth?: RfbPreauthDescriptor;
   } = {},
 ) {
-  const root = await fs.mkdtemp(path.join(await fs.realpath(os.tmpdir()), "desktop-observe-"));
+  // macOS sockaddr_un cannot hold the test runner's nested temporary path.
+  const root = await fs.mkdtemp(path.join(await fs.realpath("/tmp"), "oc-desktop-observe-"));
   const localSocketPath = path.join(root, "desktop.sock");
   let desktopPeer: net.Socket | undefined;
+  let resolvePeer: (socket: net.Socket) => void = () => {};
   const peerConnected = new Promise<net.Socket>((resolve) => {
-    const server = net.createServer((socket) => {
-      desktopPeer = socket;
-      resolve(socket);
+    resolvePeer = resolve;
+  });
+  const server = net.createServer((socket) => {
+    desktopPeer = socket;
+    resolvePeer(socket);
+  });
+  cleanup.push(async () => {
+    desktopPeer?.destroy();
+    await new Promise<void>((resolveClose) => {
+      server.close(() => resolveClose());
     });
-    server.listen(localSocketPath);
-    cleanup.push(
-      async () =>
-        await new Promise<void>((resolveClose) => {
-          server.close(() => resolveClose());
-        }),
-    );
+    await fs.rm(root, { recursive: true, force: true });
+  });
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(localSocketPath, resolve);
   });
   const release = vi.fn();
   const closeObserver = vi.fn();
   const httpServer = http.createServer();
+  cleanup.push(
+    async () =>
+      await new Promise<void>((resolveClose) => {
+        httpServer.close(() => resolveClose());
+      }),
+  );
   httpServer.on("upgrade", (req, socket, head) => {
     handleDesktopObserveUpgrade(req, socket, head, {
       registry: {
@@ -73,20 +85,14 @@ async function createProxyHarness(
       ...(params.getBufferedAmount ? { getBufferedAmount: () => params.getBufferedAmount!() } : {}),
     });
   });
-  await new Promise<void>((resolve) => {
+  await new Promise<void>((resolve, reject) => {
+    httpServer.once("error", reject);
     httpServer.listen(0, "127.0.0.1", resolve);
   });
   const address = httpServer.address();
   if (!address || typeof address === "string") {
     throw new Error("expected TCP test server address");
   }
-  cleanup.push(async () => {
-    desktopPeer?.destroy();
-    await new Promise<void>((resolveClose) => {
-      httpServer.close(() => resolveClose());
-    });
-    await fs.rm(root, { recursive: true, force: true });
-  });
   const minted = mintDesktopObserverToken({
     sourceKey: "worker:pump",
     ownerEpoch: 2,


### PR DESCRIPTION
## What Problem This Solves

`scripts/lib/vitest-process.mts:22` creates an `oc-vt-XXXXXX` namespace below the
ambient temporary directory and assigns it to `TMPDIR`/`TMP`/`TEMP`. Any fixture
that then builds a Unix socket path from `os.tmpdir()` inherits that extra depth,
and on macOS the result can exceed the 104-byte `sockaddr_un.sun_path` limit.
`listen` fails with `EINVAL`.

Three fixtures were affected, with very different symptoms:

- `src/gateway/desktop/observe-bridge.test.ts` produced a **105-byte** path and
  never observed the server's `error` event. The bind failure was therefore
  completely invisible: the harness's `peerConnected` promise stayed pending and
  **seven tests waited out their full 120-second timeout** — roughly 14 minutes of
  dead wall-clock per run — reporting "Test timed out" instead of the real cause.
  This is the repo's worst bug class: an action that ends in no visible outcome and
  no recorded reason.
- `extensions/cua-computer/src/mcp-driver-client.test.ts` produced a **110-byte**
  path and **fails 3/3 on current `main`**. It does await its bind with an error
  handler, so it fails loudly rather than hanging.
- `extensions/openshell/src/backend.e2e.test.ts` produces a **116-byte** mirror
  socket path (`.../mirror/host.sock`). Opt-in Docker E2E, so it is not part of a
  normal run.

## Why This Change Was Made

`src/infra/jsonl-socket.test.ts:16` already carries the exact comment "macOS
sockaddr_un cannot hold the test runner's nested temporary path" and binds under an
explicit short root. That constraint was solved locally once and never applied to
the sibling fixtures. This change applies it consistently.

There is no universal Unix-socket fixture helper to reuse here, and adopting one
would be wrong: `withTestDir` and `createSuiteTempRootTracker` both default to
`os.tmpdir()` (`src/test-helpers/temp-dir.ts:46`, `:154`) and so do not fix the
budget without an explicit short `parentDir`. `withTestDir`'s callback scope would
additionally tear down the observe harness's live server, socket, and WebSocket,
which tests use until `afterEach`. The canonical constraint is an explicitly short
parent plus resource-owned cleanup, which is what each fixture now does.

Two lifecycle defects were repaired alongside the paths, because a bind that can
now fail loudly must not leak: every resource's cleanup is registered **before** the
operation that can fail. Previously `observe-bridge` registered its temp-root
removal and `httpServer` close only after a successful Unix bind, and
`cua-computer` registered its directory cleanup only after a successful listen.
`observe-bridge`'s HTTP startup is now error-observing too.

## User Impact

None at runtime. Production LOC is unchanged (+0/-0); all three files are tests.
Maintainers get a red extensions lane back to green, ~14 minutes of wall-clock back
per full run, and a bind failure that names itself instead of masquerading as a
timeout.

## Evidence

Root cause, measured on this host (69-byte runner namespace) with a live Node
v26.5.0 / libuv 1.52.1 probe using real `mkdtemp` and `net.Server.listen`:

| Path                     | Bytes | Bind result                |
| ------------------------ | ----: | -------------------------- |
| Original observe fixture |   105 | `EINVAL`, syscall `listen` |
| Revised observe fixture  |    51 | Success                    |
| Boundary control         |   104 | Success                    |
| Boundary control         |   105 | `EINVAL`                   |

Observed failure before the change, reproduced directly:

    listen EINVAL: invalid argument
      /private/var/folders/.../T/oc-vt-LzgRGk/openclaw-cua-mcp-test-OcGDa3/daemon.sock

Results:

    node scripts/run-vitest.mjs src/gateway/desktop/observe-bridge.test.ts
      before: 7 failed (120s timeouts each) — after: 8 passed, 156ms
    node scripts/run-vitest.mjs extensions/cua-computer
      before: 3 failed (EINVAL), exit 1 — after: 12 files, 98 passed, exit 0
    node scripts/run-vitest.mjs extensions/openshell
      7 files, 180 passed, exit 0
    node scripts/check-changed.mjs -- <all three files>   exit 0
    git diff --check                                       exit 0

Lifecycle repairs were proven with real faults, not mocked bind results: an
occupied socket pathname (`EADDRINUSE`) left the short root present before the fix
and absent after it; an occupied TCP port exercised the HTTP path the same way.

Sibling inventory. Every other real Unix-bind fixture was measured; all fit, and
those already using an explicit short root are listed for contrast:
`src/infra/jsonl-socket.test.ts`, `src/infra/exec-host.socket.test.ts`,
`src/node-host/invoke-system-run.socket.test.ts` and
`extensions/codex/src/app-server/transport-websocket.test.ts` already choose `/tmp`;
`src/worker/worker.runtime.test.ts` (95), `extensions/openshell/src/mirror.test.ts`
(100), and `src/gateway/server.plugin-node-capability-auth.test.ts` (94) fit under
the current one-level namespace. `src/secrets/egress-proxy/proxy-server.test.ts`,
`src/proxy-capture/proxy-server.test.ts` and the Mattermost monitor bind TCP, not
Unix sockets.

**Limitation:** `extensions/openshell/src/backend.e2e.test.ts` requires Docker and a
registered local gateway and was not executed here. Its change is a strictly
shortening root swap (116 → 47 bytes) with no assertion on the path prefix, covered
by typecheck, lint and format.

## Named follow-up (not in this PR)

`src/gateway/worker-environments/desktop-tunnel.ts:138` derives `desktop.sock` from
a root created under unrestricted `os.tmpdir()` in
`src/gateway/worker-environments/ssh.ts:153`, so the `-L` forward argument can
exceed the same budget — 113 bytes under this namespace, and real
`ssh -G -F none -L <path>:127.0.0.1:5900` exits 255 with "Bad local forwarding
specification". It is deliberately excluded here: it is production, it fails loudly
rather than silently (`ExitOnForwardFailure=yes`, with rejection and captured
diagnostics in `tunnel-ssh-runner.ts:77`), and `git log --follow` places its
introducing commit outside every available stable tag, so it is a current-`main`
analogue rather than a shipped regression. The fix belongs with the desktop-tunnel
lifecycle owner, as a short private socket directory independent of the credential
temporary directory.
