### PR TITLE
perf(agents): bound weighted tool result searches

### DIFF
--- a/src/agents/embedded-agent-runner/tool-result-text-budget.ts
+++ b/src/agents/embedded-agent-runner/tool-result-text-budget.ts
@@ -32,26 +32,27 @@ export function estimateToolResultTextChars(
   return chars;
 }
 
-export function sliceToolResultTextToBudget(
+function sliceToolResultTextBudget(
   text: string,
   maxChars: number,
-  options: ToolResultTextBudgetOptions = {},
+  options: ToolResultTextBudgetOptions,
+  fromEnd: boolean,
 ): string {
   const budget = Math.max(0, Math.floor(maxChars));
-  if (estimateToolResultTextChars(text, options) <= budget) {
+  if (text.length <= budget && estimateToolResultTextChars(text, options) <= budget) {
     return text;
   }
-
   let best = "";
   let low = 0;
-  let high = text.length;
+  // Every UTF-16 unit costs at least one budget unit, so longer candidates cannot fit.
+  let high = Math.min(text.length, budget);
   while (low <= high) {
     const midpoint = Math.floor((low + high) / 2);
-    const candidate = sliceUtf16Safe(text, 0, midpoint);
+    const candidate = fromEnd
+      ? sliceUtf16Safe(text, text.length - midpoint)
+      : sliceUtf16Safe(text, 0, midpoint);
     if (estimateToolResultTextChars(candidate, options) <= budget) {
-      if (candidate.length > best.length) {
-        best = candidate;
-      }
+      best = candidate;
       low = midpoint + 1;
     } else {
       high = midpoint - 1;
@@ -60,30 +61,18 @@ export function sliceToolResultTextToBudget(
   return best;
 }
 
+export function sliceToolResultTextToBudget(
+  text: string,
+  maxChars: number,
+  options: ToolResultTextBudgetOptions = {},
+): string {
+  return sliceToolResultTextBudget(text, maxChars, options, false);
+}
+
 export function sliceToolResultTextTailToBudget(
   text: string,
   maxChars: number,
   options: ToolResultTextBudgetOptions = {},
 ): string {
-  const budget = Math.max(0, Math.floor(maxChars));
-  if (estimateToolResultTextChars(text, options) <= budget) {
-    return text;
-  }
-
-  let best = "";
-  let low = 0;
-  let high = text.length;
-  while (low <= high) {
-    const midpoint = Math.floor((low + high) / 2);
-    const candidate = sliceUtf16Safe(text, midpoint);
-    if (estimateToolResultTextChars(candidate, options) <= budget) {
-      if (candidate.length > best.length) {
-        best = candidate;
-      }
-      high = midpoint - 1;
-    } else {
-      low = midpoint + 1;
-    }
-  }
-  return best;
+  return sliceToolResultTextBudget(text, maxChars, options, true);
 }

--- a/src/agents/embedded-agent-runner/tool-result-truncation.ts
+++ b/src/agents/embedded-agent-runner/tool-result-truncation.ts
@@ -369,7 +369,7 @@ export function truncateToolResultText(
     suffixFactory,
     minimumRawWeight: options.minimumRawWeight,
   });
-  if (estimateToolResultTextChars(text, budgetOptions) <= maxChars) {
+  if (text.length <= maxChars && estimateToolResultTextChars(text, budgetOptions) <= maxChars) {
     return text;
   }
   const initialKeptText = sliceToolResultTextToBudget(text, maxChars, budgetOptions);
@@ -501,6 +501,7 @@ export function truncateToolResultMessage(
     (block, index) =>
       (blockTextChars[index] ?? 0) > 0 &&
       isToolResultTextBlock(block) &&
+      block.text.length <= minKeepChars &&
       estimateToolResultTextChars(block.text) <= minKeepChars,
   );
   const blockNoticeChars = content.map((block, index) =>


### PR DESCRIPTION
## Why

Large tool results spend unnecessary CPU repeatedly estimating text that cannot fit the available character budget. The head and diagnostic-tail cutters also duplicate the same binary-search policy.

## Change

Use one directional cutter and cap its search at the budget's UTF-16 lower bound. Skip full-text estimates when raw length already proves overflow, and apply that same lower bound at the owning truncation caller. Existing weighted CJK accounting, fractional weights, surrogate-safe boundaries, diagnostic tails, omission notices, and unchanged-message identity are preserved.

Production +21/-31 (net -10); no test changes. No config, storage, provider API, or model-context policy change. Release-note context: less CPU spent bounding large web/tool results, with the same retained output.

## Verification

- 155 existing budget, full-message truncation, context-guard, and image regressions passed.
- 195,000 leaf differential cases and 4,080 full-owner cases preserved exact output and object identity, including Unicode boundaries, fractional weights, non-finite budgets, multiple blocks, and diagnostic tails.
- Full-message benchmark: 250,029 CJK characters bounded to 16,000 budget units took 192.785 ms before and 33.813 ms after with minimumRawWeight=2; weight=1 took 26.907 ms and 3.812 ms. Mixed text and ASCII also improved. These are local CPU microbenchmarks, not end-to-end model latency claims.
- Real OpenAI dev Gateway baseline fetched the Chinese Wikipedia mathematics page through web_fetch with the existing fetch cap raised only in the isolated test config. The stored tool result recorded 55,584 omitted characters, and the model completed the turn. The full candidate build and matching live flow passed. Before and after both retained 46,973 text characters and the same 55,584-character omission notice; text hashes matched after normalizing only fetch timestamps/duration and random wrapper/spill identifiers. Both model replies were Mathematics. One additional candidate run used text extraction and also completed; it is excluded from the matching markdown comparison.
- Independent source review found no actionable issue; structured Codex autoreview was scoped-clean. Formatting and targeted lint passed.

Owner and sibling review covered the text budget, full truncation allocator, context guard, image handling, recovery/persistence, and provider boundary. Native Codex protocol InputText handling and tool-output truncation were inspected directly; their separate policy is unchanged.

CI follow-up: one unrelated startup-lease heartbeat assertion failed in the original QA shard; only failed jobs were rerun and the exact-head CI gate is now green. Its root-cause test-oracle cleanup is tracked in #132985. No code or timeout was changed to pass this PR.
