### PR TITLE
docs: remove AI-assistance disclosure requirement for PRs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -128,18 +128,16 @@ build tooling to support standard decorators.
 
 ## AI/Vibe-Coded PRs Welcome! 🤖
 
-Built with Codex, Claude, or other AI tools? **Awesome - just mark it!**
+Built with Codex, Claude, or other AI tools? **Welcome!** No AI-assistance label or disclosure is required.
 
 Please include in your PR:
 
-- [ ] Mark as AI-assisted in the PR title or description
 - [ ] Include a concise **Evidence** section with the most useful validation. Reviewers will inspect the code, tests, and CI rather than relying on the PR body alone.
-- [ ] Include prompts or session logs if possible (super helpful!)
 - [ ] Confirm you understand what the code does
 - [ ] Run the `autoreview` skill when available and address accepted/actionable findings
 - [ ] Follow the [pull request review flow](https://docs.openclaw.ai/reference/pull-request-review-flow) after Barnacle, ClawSweeper, or maintainer feedback
 
-AI PRs are first-class citizens here. We just want transparency so reviewers know what to look for.
+AI PRs are first-class citizens here and follow the same quality and review standards as any other PR.
 
 ## Current Focus & Roadmap 🗺
 


### PR DESCRIPTION
## What Problem This Solves

The contribution guide asks contributors to mark AI-assisted PRs in the title or description and encourages sharing prompts or session logs. This adds a tool-disclosure requirement that is no longer part of the contribution policy.

## Why This Change Was Made

Requested by @steipete: remove the AI-assistance disclosure requirement. The AI PR section now explicitly says no label or disclosure is required, removes the prompt/session-log request, and makes clear that the same quality and review standards apply to every PR.

The evidence checklist, responsibility to understand the code, autoreview guidance, and review follow-up requirements remain unchanged. The PR template and review-flow documentation already impose no AI-disclosure requirement. Historical changelog entries and unrelated product references are untouched.

## User Impact

Contributors can submit PRs without identifying which AI tools they used or sharing prompts or session logs. This is a contribution-policy documentation change only; no runtime or test behavior changes.

## Evidence

- `pnpm docs:list` — passed.
- `git diff --check` — passed.
- `./node_modules/.bin/oxfmt --check CONTRIBUTING.md` — passed.
- Searched tracked Markdown and GitHub configuration for AI-assistance marking/disclosure language; the requirement lives only in this section of `CONTRIBUTING.md`.
- Reviewed the full contribution guide, PR template, README contribution wording, and https://docs.openclaw.ai/reference/pull-request-review-flow for consistency.
- Production LOC: +0/-0. Test LOC: +0/-0. Documentation: +2/-4 in one file.
- No new tests, runtime build, browser proof, or independent autoreview: this is a small documentation-only policy edit, covered by the repository's docs-only validation exception.
