### PR TITLE
fix(release): audit tool dependencies and preserve Sandbox failures

### DIFF
--- a/.github/release/vercel-cli/package-lock.json
+++ b/.github/release/vercel-cli/package-lock.json
@@ -8,6 +8,7 @@
       "name": "openclaw-release-vercel-cli",
       "version": "1.0.0",
       "dependencies": {
+        "sandbox": "4.0.0",
         "vercel": "59.3.0"
       }
     },
@@ -513,36 +514,6 @@
       ],
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/@fastify/busboy": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
-      "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=14"
-      }
-    },
-    "node_modules/@isaacs/balanced-match": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@isaacs/balanced-match/-/balanced-match-4.0.1.tgz",
-      "integrity": "sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==",
-      "license": "MIT",
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
-    "node_modules/@isaacs/brace-expansion": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@isaacs/brace-expansion/-/brace-expansion-5.0.1.tgz",
-      "integrity": "sha512-WMz71T1JS624nWj2n2fnYAuPovhv7EUhk69R6i9dsVyzxt5eM3bjwvgk9L+APE1TRscGysAVMANkB0jh0LQZrQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@isaacs/balanced-match": "^4.0.1"
-      },
-      "engines": {
-        "node": "20 || >=22"
       }
     },
     "node_modules/@isaacs/fs-minipass": {
@@ -1486,9 +1457,9 @@
       "license": "MIT"
     },
     "node_modules/@tootallnate/once": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
-      "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.1.tgz",
+      "integrity": "sha512-HqmEUIGRJ5fSXchkVgR5F7qn48bDBzv0kWj/Kfu5e6uci4UlEeng4331LnBkWffb++Ei3FOVLxo8JJWMFBDMeQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 10"
@@ -1609,15 +1580,6 @@
       },
       "engines": {
         "node": ">= 20"
-      }
-    },
-    "node_modules/@vercel/blob/node_modules/undici": {
-      "version": "6.28.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.28.0.tgz",
-      "integrity": "sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18.17"
       }
     },
     "node_modules/@vercel/build-utils": {
@@ -1827,15 +1789,6 @@
       "integrity": "sha512-CcEtRh/oc9Jc4uWeUwdpG/+Mb2YUHKmdaTf0gUr7Wa+bfp4xx70HOb3RuSTJMvqKNB1TkdTfjLdrcz2X4rkkZA==",
       "license": "MIT"
     },
-    "node_modules/@vercel/fun/node_modules/path-to-regexp": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.2.0.tgz",
-      "integrity": "sha512-TdrF7fW9Rphjq4RjrW0Kp2AW0Ahwu9sRGTkS6bvDi0SCwZlEZYmcfDbEsTz8RVk0EHIS/Vd1bv3JhG+1xZuAyQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=16"
-      }
-    },
     "node_modules/@vercel/fun/node_modules/xdg-app-paths": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/xdg-app-paths/-/xdg-app-paths-5.1.0.tgz",
@@ -2032,22 +1985,10 @@
       }
     },
     "node_modules/@vercel/node/node_modules/path-to-regexp": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.1.0.tgz",
-      "integrity": "sha512-h9DqehX3zZZDCEm+xbfU0ZmwCGFCAAraPJWMXJ4+v32NjZJilVg3k1TcKsRgIb8IQ/izZSaydDc1OhJCZvs2Dw==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
       "license": "MIT"
-    },
-    "node_modules/@vercel/node/node_modules/undici": {
-      "version": "5.28.4",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.28.4.tgz",
-      "integrity": "sha512-72RFADWFqKmUb2hmmvNODKL3p9hcB6Gt2DOQMis1SEBaV6a4MH8soBvzg+95CYhCKPFedut2JY9bMfrDl9D23g==",
-      "license": "MIT",
-      "dependencies": {
-        "@fastify/busboy": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=14.0"
-      }
     },
     "node_modules/@vercel/oidc": {
       "version": "3.2.0",
@@ -2147,9 +2088,9 @@
       }
     },
     "node_modules/@vercel/remix-builder/node_modules/path-to-regexp": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.1.0.tgz",
-      "integrity": "sha512-h9DqehX3zZZDCEm+xbfU0ZmwCGFCAAraPJWMXJ4+v32NjZJilVg3k1TcKsRgIb8IQ/izZSaydDc1OhJCZvs2Dw==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
       "license": "MIT"
     },
     "node_modules/@vercel/ruby": {
@@ -2401,15 +2342,15 @@
       }
     },
     "node_modules/ajv": {
-      "version": "8.6.3",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.6.3.tgz",
-      "integrity": "sha512-SMJOdDP6LqTkD0Uq8qLi+gMwSt0imXLSV080qFVwJCpH9U6Mb+SUGHAXM0KNbcBPguytWyvFxcHgMLe2D2XSpw==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "license": "MIT",
       "dependencies": {
-        "fast-deep-equal": "^3.1.1",
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
         "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2",
-        "uri-js": "^4.2.2"
+        "require-from-string": "^2.0.2"
       },
       "funding": {
         "type": "github",
@@ -2847,6 +2788,22 @@
         "node": ">=8.6.0"
       }
     },
+    "node_modules/fast-uri": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/fastq": {
       "version": "1.20.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
@@ -2986,42 +2943,6 @@
       },
       "engines": {
         "node": ">= 6"
-      }
-    },
-    "node_modules/glob/node_modules/balanced-match": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-      "license": "MIT",
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/glob/node_modules/brace-expansion": {
-      "version": "5.0.9",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
-      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
-    "node_modules/glob/node_modules/minimatch": {
-      "version": "10.2.6",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
-      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "brace-expansion": "^5.0.8"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/graceful-fs": {
@@ -3200,9 +3121,19 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -3357,18 +3288,39 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.1.1.tgz",
-      "integrity": "sha512-enIvLvRAFZYXJzkCYG5RKmPfrFArdLv+R+lbQ53BmIMLIry74bjKzX6iHAm8WYamJkhSSEabrWN5D97XnKObjQ==",
+      "version": "10.2.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "@isaacs/brace-expansion": "^5.0.0"
+        "brace-expansion": "^5.0.8"
       },
       "engines": {
-        "node": "20 || >=22"
+        "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minimatch/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/minimatch/node_modules/brace-expansion": {
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/minipass": {
@@ -3611,9 +3563,9 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
-      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.0.tgz",
+      "integrity": "sha512-PuseHIvAnz3bjrM2rGJtSgo1zjgxapTLZ7x2pjhzWwlp4SJQgK3f3iZIQwkpEnBaKz6seKBADpM4B4ySkuYypg==",
       "license": "MIT",
       "funding": {
         "type": "opencollective",
@@ -3680,15 +3632,6 @@
       "dependencies": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
-      }
-    },
-    "node_modules/punycode": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
-      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/queue-microtask": {
@@ -3967,9 +3910,9 @@
       }
     },
     "node_modules/smol-toml": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.5.2.tgz",
-      "integrity": "sha512-QlaZEqcAH3/RtNyet1IPIYPsEWAaYyXXv1Krsi+1L/QHppjX4Ifm8MQsBISz9vE8cHicIq3clogsheili5vhaQ==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.6.1.tgz",
+      "integrity": "sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg==",
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">= 18"
@@ -4065,10 +4008,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.7",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.7.tgz",
-      "integrity": "sha512-fov56fJiRuThVFXD6o6/Q354S7pnWMJIVlDBYijsTNx6jKSE4pvrDTs6lUnmGvNyfJwFQQwWy3owKz1ucIhveQ==",
-      "deprecated": "Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "version": "7.5.22",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.22.tgz",
+      "integrity": "sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",
@@ -4232,15 +4174,12 @@
       "license": "MIT"
     },
     "node_modules/undici": {
-      "version": "5.29.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
-      "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
+      "version": "6.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.28.0.tgz",
+      "integrity": "sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==",
       "license": "MIT",
-      "dependencies": {
-        "@fastify/busboy": "^2.0.0"
-      },
       "engines": {
-        "node": ">=14.0"
+        "node": ">=18.17"
       }
     },
     "node_modules/undici-types": {
@@ -4265,15 +4204,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/uri-js": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
-      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "punycode": "^2.1.0"
       }
     },
     "node_modules/uuid": {

--- a/.github/release/vercel-cli/package.json
+++ b/.github/release/vercel-cli/package.json
@@ -3,6 +3,18 @@
   "private": true,
   "version": "1.0.0",
   "dependencies": {
+    "sandbox": "4.0.0",
     "vercel": "59.3.0"
+  },
+  "overrides": {
+    "@tootallnate/once@2.0.0": "2.0.1",
+    "ajv@8.6.3": "8.18.0",
+    "js-yaml@4.1.1": "4.3.1",
+    "minimatch@10.1.1": "10.2.6",
+    "path-to-regexp@6.1.0": "6.3.0",
+    "path-to-regexp@8.2.0 || 8.3.0": "8.4.0",
+    "smol-toml@1.5.2": "1.6.1",
+    "tar@7.5.7": "7.5.22",
+    "undici@5.28.4 || 5.29.0": "6.28.0"
   }
 }

--- a/.github/workflows/vercel-container-registry-publish.yml
+++ b/.github/workflows/vercel-container-registry-publish.yml
@@ -173,8 +173,8 @@ jobs:
       - name: Run custom-image Sandbox smoke
         id: sandbox_smoke
         env:
+          SANDBOX_CLI: ${{ steps.vercel_cli.outputs.sandbox_cli }}
           VERCEL_AUTH_TOKEN: ${{ secrets.VERCEL_TOKEN }}
-          VERCEL_CLI: ${{ steps.vercel_cli.outputs.cli }}
           VERCEL_PROJECT_ID: ${{ vars.VERCEL_PROJECT_ID }}
           VERCEL_SCOPE: ${{ vars.VERCEL_SCOPE }}
           VERCEL_VCR_IMAGE: ${{ vars.VERCEL_VCR_IMAGE }}
@@ -187,7 +187,7 @@ jobs:
           while true; do
             set +e
             output="$(
-              "${VERCEL_CLI}" sandbox run \
+              "${SANDBOX_CLI}" run \
                 --silent \
                 --rm \
                 --non-persistent \

--- a/docs/gateway/security/dependency-locking.md
+++ b/docs/gateway/security/dependency-locking.md
@@ -11,7 +11,13 @@ OpenClaw uses `pnpm-lock.yaml` as its committed product dependency review bounda
 
 OpenClaw does not commit npm-format locks for product packages or publish them in package tarballs. [npm 12 removed shrinkwrap support](https://github.com/npm/cli/releases/tag/v12.0.0), including the `npm shrinkwrap` command and loading `npm-shrinkwrap.json` from package roots or dependency tarballs.
 
-The trusted ClawHub release toolchain is a separate exception: `.github/release/clawhub-cli/package-lock.json` is a committed npm 12 project lock used by release automation. It is not shipped in an OpenClaw package.
+The trusted ClawHub and Vercel release toolchains are separate exceptions: `.github/release/clawhub-cli/package-lock.json` and `.github/release/vercel-cli/package-lock.json` are committed npm project locks used by release automation. Neither is shipped in an OpenClaw package.
+
+These projects do not inherit root pnpm overrides. The Vercel project uses approved, version-scoped npm overrides for vulnerable upstream pins; remove each override when its owning dependency accepts a fixed version. Lock audits cover resolved package identities, not code already bundled into upstream CLI artifacts.
+
+`pnpm deps:vuln:gate` audits the product pnpm lock and both release-tool locks independently against npm advisory data. Within each lockfile, known malware and critical advisories block anywhere, and high advisories block in the production/runtime graph. Dev-only high advisories and moderate or lower non-malware advisories are reported without blocking. Reports retain the source lockfile, so a release-tool finding does not imply product runtime exposure. Missing or invalid expected locks fail the gate.
+
+Release dependency evidence runs this gate. Ordinary CI's `security-fast` job and the production audit pre-commit hook still audit only the product production graph.
 
 ## Published package behavior
 

--- a/scripts/dependency-vulnerability-gate.mts
+++ b/scripts/dependency-vulnerability-gate.mts
@@ -4,6 +4,7 @@
 import { readFile } from "node:fs/promises";
 import path from "node:path";
 import process from "node:process";
+import { isRecord } from "../packages/normalization-core/src/record-coerce.ts";
 import { parseReportCliArgs, writeReportArtifact } from "./lib/report-cli-helpers.mts";
 import {
   collectAllResolvedPackagesFromLockfile,
@@ -26,7 +27,11 @@ type Advisory = Partial<
 type Graph = "all" | "production";
 type AdvisoryMap = Record<string, Advisory[]>;
 type AdvisoryPayload = Record<string, string[]>;
-type AdvisorySets = { allAdvisories: AdvisoryMap; productionAdvisories: AdvisoryMap };
+type AdvisorySets = {
+  lockfile: string;
+  allAdvisories: AdvisoryMap;
+  productionAdvisories: AdvisoryMap;
+};
 
 function isSeverity(severity: string): severity is keyof typeof SEVERITY_RANK {
   return severity in SEVERITY_RANK;
@@ -44,8 +49,14 @@ function isMalwareAdvisory(advisory: Advisory) {
   return fields.some((field) => /\bmalware\b/iu.test(field));
 }
 
-function findingFromAdvisory(packageName: string, advisory: Advisory, graph: Graph) {
+function findingFromAdvisory(
+  packageName: string,
+  advisory: Advisory,
+  graph: Graph,
+  lockfile: string,
+) {
   return {
+    lockfile,
     graph,
     packageName,
     id: advisory.id ?? "unknown",
@@ -59,18 +70,11 @@ function findingFromAdvisory(packageName: string, advisory: Advisory, graph: Gra
 
 type Finding = ReturnType<typeof findingFromAdvisory>;
 
-function chunkEntries<T>(entries: T[], size: number) {
-  const chunks: T[][] = [];
-  for (let index = 0; index < entries.length; index += size) {
-    chunks.push(entries.slice(index, index + size));
-  }
-  return chunks;
-}
-
 async function fetchBulkAdvisoriesForPayload(payload: AdvisoryPayload, fetchImpl: typeof fetch) {
   const advisoryResults: AdvisoryMap = {};
-  for (const payloadChunk of chunkEntries(Object.entries(payload), 400)) {
-    const chunkPayload = Object.fromEntries(payloadChunk);
+  const entries = Object.entries(payload);
+  for (let index = 0; index < entries.length; index += 400) {
+    const chunkPayload = Object.fromEntries(entries.slice(index, index + 400));
     Object.assign(
       advisoryResults,
       await fetchBulkAdvisories({
@@ -82,7 +86,7 @@ async function fetchBulkAdvisoriesForPayload(payload: AdvisoryPayload, fetchImpl
   return advisoryResults;
 }
 
-function flattenAdvisories(advisoriesByPackage: AdvisoryMap, graphName: Graph) {
+function flattenAdvisories(advisoriesByPackage: AdvisoryMap, graphName: Graph, lockfile: string) {
   const findings: Finding[] = [];
   for (const [packageName, advisories] of Object.entries(advisoriesByPackage ?? {})) {
     if (!Array.isArray(advisories)) {
@@ -92,7 +96,7 @@ function flattenAdvisories(advisoriesByPackage: AdvisoryMap, graphName: Graph) {
       if (!advisory || typeof advisory !== "object") {
         continue;
       }
-      findings.push(findingFromAdvisory(packageName, advisory, graphName));
+      findings.push(findingFromAdvisory(packageName, advisory, graphName, lockfile));
     }
   }
   return findings;
@@ -100,6 +104,7 @@ function flattenAdvisories(advisoriesByPackage: AdvisoryMap, graphName: Graph) {
 
 function findingKey(finding: Finding) {
   return [
+    finding.lockfile,
     finding.packageName,
     String(finding.id),
     finding.severity,
@@ -136,35 +141,33 @@ function sortFindings(findings: Finding[]) {
     if (left.packageName !== right.packageName) {
       return left.packageName.localeCompare(right.packageName);
     }
-    return String(left.id).localeCompare(String(right.id));
+    return (
+      String(left.id).localeCompare(String(right.id)) || left.lockfile.localeCompare(right.lockfile)
+    );
   });
 }
 
 /**
  * Classifies npm advisory findings into report-only findings and hard blockers.
  */
-export function classifyVulnerabilityFindings({
+function classifyVulnerabilityFindings({
+  lockfile,
   allAdvisories,
   productionAdvisories,
 }: AdvisorySets) {
-  const allFindings = flattenAdvisories(allAdvisories, "all");
-  const productionFindings = flattenAdvisories(productionAdvisories, "production");
-  const blockers: Finding[] = [];
-
-  for (const finding of allFindings) {
-    if (finding.malware || finding.severity === "critical") {
-      blockers.push(finding);
-    }
-  }
-  for (const finding of productionFindings) {
-    if (finding.severity === "high" || finding.severity === "critical" || finding.malware) {
-      blockers.push(finding);
-    }
-  }
-
+  const findings = [
+    ...flattenAdvisories(allAdvisories, "all", lockfile),
+    ...flattenAdvisories(productionAdvisories, "production", lockfile),
+  ];
+  const blockers = findings.filter(
+    (finding) =>
+      finding.malware ||
+      finding.severity === "critical" ||
+      (finding.graph === "production" && finding.severity === "high"),
+  );
   return {
     blockers: sortFindings(dedupeFindings(blockers)),
-    findings: sortFindings(dedupeFindings([...allFindings, ...productionFindings])),
+    findings: sortFindings(dedupeFindings(findings)),
   };
 }
 
@@ -172,26 +175,115 @@ function countPayloadVersions(payload: AdvisoryPayload) {
   return Object.values(payload).reduce((sum, versions) => sum + versions.length, 0);
 }
 
+function collectNpmLockPackages(text: string) {
+  const lock: unknown = JSON.parse(text);
+  if (
+    !isRecord(lock) ||
+    lock.lockfileVersion !== 3 ||
+    !isRecord(lock.packages) ||
+    !isRecord(lock.packages[""])
+  ) {
+    throw new Error("Expected an npm v3 lockfile with a packages map and root entry.");
+  }
+  const all = new Map<string, Set<string>>();
+  const production = new Map<string, Set<string>>();
+  for (const [location, metadata] of Object.entries(lock.packages)) {
+    if (location === "") {
+      continue;
+    }
+    if (!isRecord(metadata)) {
+      throw new Error(`Invalid package entry: ${location}`);
+    }
+    if (metadata.link === true) {
+      continue;
+    }
+    // npm records alias targets in name; nested paths retain scoped package names.
+    const name =
+      metadata.name ?? location.match(/(?:^|\/)node_modules\/((?:@[^/]+\/)?[^/]+)$/u)?.[1];
+    if (
+      typeof name !== "string" ||
+      !name ||
+      typeof metadata.version !== "string" ||
+      !metadata.version
+    ) {
+      throw new Error(`Missing package name or version: ${location}`);
+    }
+    // Only dev-only entries are excluded. Optional and devOptional can run in production.
+    for (const graph of metadata.dev === true ? [all] : [all, production]) {
+      const versions = graph.get(name) ?? new Set<string>();
+      versions.add(metadata.version);
+      graph.set(name, versions);
+    }
+  }
+  if (all.size === 0) {
+    throw new Error("Expected resolved dependencies in the release-tool lockfile.");
+  }
+  return { all, production };
+}
+
 /**
- * Runs the dependency vulnerability gate against pnpm-lock.yaml.
+ * Audits product and committed release-tool locks without merging their runtime graphs.
  */
 export async function runDependencyVulnerabilityGate({
   rootDir = process.cwd(),
   fetchImpl = fetch,
 }: { rootDir?: string; fetchImpl?: typeof fetch } = {}) {
-  const lockfileText = await readFile(path.join(rootDir, "pnpm-lock.yaml"), "utf8");
-  const allPayload = createBulkAdvisoryPayload(
-    collectAllResolvedPackagesFromLockfile(lockfileText),
+  const lockfiles = await Promise.all(
+    [
+      "pnpm-lock.yaml",
+      ".github/release/clawhub-cli/package-lock.json",
+      ".github/release/vercel-cli/package-lock.json",
+    ].map(async (lockfile) => {
+      try {
+        const text = await readFile(path.join(rootDir, lockfile), "utf8");
+        const packages =
+          lockfile === "pnpm-lock.yaml"
+            ? {
+                all: collectAllResolvedPackagesFromLockfile(text),
+                production: collectProdResolvedPackagesFromLockfile(text),
+              }
+            : collectNpmLockPackages(text);
+        return {
+          lockfile,
+          allPayload: createBulkAdvisoryPayload(packages.all),
+          productionPayload: createBulkAdvisoryPayload(packages.production),
+        };
+      } catch (error) {
+        throw new Error(`${lockfile}: ${error instanceof Error ? error.message : String(error)}`, {
+          cause: error,
+        });
+      }
+    }),
   );
-  const productionPayload = createBulkAdvisoryPayload(
-    collectProdResolvedPackagesFromLockfile(lockfileText),
+  // Query each source independently: a vulnerable tool version must not taint a safe product version.
+  const sources = await Promise.all(
+    lockfiles.map(async ({ lockfile, allPayload, productionPayload }) => {
+      const [allAdvisories, productionAdvisories] = await Promise.all([
+        fetchBulkAdvisoriesForPayload(allPayload, fetchImpl),
+        fetchBulkAdvisoriesForPayload(productionPayload, fetchImpl),
+      ]);
+      const classified = classifyVulnerabilityFindings({
+        lockfile,
+        allAdvisories,
+        productionAdvisories,
+      });
+      return {
+        graphs: {
+          lockfile,
+          all: {
+            packages: Object.keys(allPayload).length,
+            packageVersions: countPayloadVersions(allPayload),
+          },
+          production: {
+            packages: Object.keys(productionPayload).length,
+            packageVersions: countPayloadVersions(productionPayload),
+          },
+        },
+        blockers: classified.blockers,
+        findings: classified.findings,
+      };
+    }),
   );
-
-  const [allAdvisories, productionAdvisories] = await Promise.all([
-    fetchBulkAdvisoriesForPayload(allPayload, fetchImpl),
-    fetchBulkAdvisoriesForPayload(productionPayload, fetchImpl),
-  ]);
-  const classified = classifyVulnerabilityFindings({ allAdvisories, productionAdvisories });
   return {
     generatedAt: new Date().toISOString(),
     policy: {
@@ -206,17 +298,9 @@ export async function runDependencyVulnerabilityGate({
       ],
       vulnerabilityExceptions: false,
     },
-    graphs: {
-      all: {
-        packages: Object.keys(allPayload).length,
-        packageVersions: countPayloadVersions(allPayload),
-      },
-      production: {
-        packages: Object.keys(productionPayload).length,
-        packageVersions: countPayloadVersions(productionPayload),
-      },
-    },
-    ...classified,
+    graphs: sources.map((source) => source.graphs),
+    blockers: sortFindings(sources.flatMap((source) => source.blockers)),
+    findings: sortFindings(sources.flatMap((source) => source.findings)),
   };
 }
 
@@ -233,17 +317,22 @@ export function renderDependencyVulnerabilityGateMarkdownReport(
     "",
     "## Scope",
     "",
-    "This gate checks resolved package versions from pnpm-lock.yaml against npm advisory data. It includes transitive dependencies. It blocks known malware anywhere, critical advisories anywhere, and high advisories in the production/runtime graph.",
+    "This gate checks resolved package versions from pnpm-lock.yaml and the committed ClawHub and Vercel release-tool npm locks against npm advisory data. It includes transitive dependencies. Each lockfile is audited independently: known malware and critical advisories block anywhere; high advisories block in that source's production/runtime graph. Release-tool findings do not imply product runtime exposure.",
     "",
     "## Summary",
     "",
-    `- All graph packages: ${report.graphs.all.packages}`,
-    `- All graph package versions: ${report.graphs.all.packageVersions}`,
-    `- Production graph packages: ${report.graphs.production.packages}`,
-    `- Production graph package versions: ${report.graphs.production.packageVersions}`,
     `- Hard blockers: ${report.blockers.length}`,
     `- Total findings: ${report.findings.length}`,
     "",
+    ...report.graphs.flatMap((graph) => [
+      `### ${graph.lockfile}`,
+      "",
+      `- All graph packages: ${graph.all.packages}`,
+      `- All graph package versions: ${graph.all.packageVersions}`,
+      `- Production graph packages: ${graph.production.packages}`,
+      `- Production graph package versions: ${graph.production.packageVersions}`,
+      "",
+    ]),
     "## Policy",
     "",
     ...report.policy.blocks.map((block) => `- Block: ${block}`),
@@ -252,24 +341,17 @@ export function renderDependencyVulnerabilityGateMarkdownReport(
     "",
   ];
 
-  if (report.blockers.length > 0) {
-    lines.push("## Hard Blockers", "");
-    for (const finding of report.blockers) {
-      lines.push(
-        `- ${finding.severity.toUpperCase()} ${finding.packageName} (${finding.graph}) ` +
-          `id=${finding.id} range=${finding.vulnerableVersions ?? "unknown"} ` +
-          `${finding.malware ? "[malware] " : ""}${finding.url ?? ""}`,
-      );
-      lines.push(`  - ${finding.title}`);
+  for (const [title, findings] of [
+    ["Hard Blockers", report.blockers],
+    ["Findings", report.findings],
+  ] as const) {
+    if (findings.length === 0) {
+      continue;
     }
-    lines.push("");
-  }
-
-  if (report.findings.length > 0) {
-    lines.push("## Findings", "");
-    for (const finding of report.findings) {
+    lines.push(`## ${title}`, "");
+    for (const finding of findings) {
       lines.push(
-        `- ${finding.severity.toUpperCase()} ${finding.packageName} (${finding.graph}) ` +
+        `- ${finding.severity.toUpperCase()} ${finding.packageName} (${finding.lockfile}; ${finding.graph}) ` +
           `id=${finding.id} range=${finding.vulnerableVersions ?? "unknown"} ` +
           `${finding.malware ? "[malware] " : ""}${finding.url ?? ""}`,
       );
@@ -295,10 +377,13 @@ export async function main(argv = process.argv.slice(2)) {
   );
 
   if (report.blockers.length === 0) {
-    const packageVersions = report.graphs.all.packageVersions;
+    const packageVersions = report.graphs.reduce(
+      (sum, graph) => sum + graph.all.packageVersions,
+      0,
+    );
     process.stdout.write(
       `PASS npm advisory vulnerability gate: checked ${packageVersions} resolved ` +
-        `package versions across the lockfile graph; 0 hard blockers, ` +
+        `package versions across ${report.graphs.length} separate lockfile graphs; 0 hard blockers, ` +
         `${report.findings.length} total advisories.\n`,
     );
     return 0;
@@ -310,7 +395,7 @@ export async function main(argv = process.argv.slice(2)) {
   );
   for (const blocker of report.blockers.slice(0, 25)) {
     process.stderr.write(
-      `- ${blocker.severity.toUpperCase()} ${blocker.packageName} (${blocker.graph}) ` +
+      `- ${blocker.severity.toUpperCase()} ${blocker.packageName} (${blocker.lockfile}; ${blocker.graph}) ` +
         `id=${blocker.id} title=${blocker.title}\n`,
     );
   }

--- a/scripts/materialize-vercel-cli.sh
+++ b/scripts/materialize-vercel-cli.sh
@@ -8,7 +8,7 @@ github_output="${3:-}"
 
 package_json="${source_root}/package.json"
 package_lock="${source_root}/package-lock.json"
-expected_lock_sha256="4cea63abc4e89d659902aae28dd3e88973fdff9cdd2d2f5e234315d3a3bb680e"
+expected_lock_sha256="85e611c2d409f9ce91f2f85bdfbdf02fdaaead2e2e4ba7dfaaac9c7220d6b021"
 expected_vercel_integrity="sha512-Bj/SN1qln/9guMcIz4gEGn+Ij+amGtkT2kqxwUAFgrLU2Hr0zYk4kX4QfxmZEs6WhheAaMlblVw2VUF2JFP5fA=="
 test -f "${package_json}"
 test -f "${package_lock}"
@@ -59,11 +59,15 @@ vercel_version="$(
 }
 test -x "${destination}/node_modules/.bin/vercel"
 vercel_cli="${destination}/node_modules/.bin/vercel"
+# Use Sandbox directly: Vercel's sandbox wrapper overwrites failed remote exits.
+test -x "${destination}/node_modules/.bin/sandbox"
+sandbox_cli="${destination}/node_modules/.bin/sandbox"
 
 echo "Materialized vercel@${vercel_version} from lock ${lock_sha256}."
 if [[ -n "${github_output}" ]]; then
   {
     echo "cli=${vercel_cli}"
+    echo "sandbox_cli=${sandbox_cli}"
     echo "integrity=${vercel_integrity}"
     echo "lock_sha256=${lock_sha256}"
     echo "version=${vercel_version}"

--- a/test/scripts/dependency-vulnerability-gate.test.ts
+++ b/test/scripts/dependency-vulnerability-gate.test.ts
@@ -1,56 +1,51 @@
 // Dependency Vulnerability Gate tests cover dependency vulnerability gate script behavior.
 import { spawnSync } from "node:child_process";
-import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
-  classifyVulnerabilityFindings,
+  main,
   renderDependencyVulnerabilityGateMarkdownReport,
   runDependencyVulnerabilityGate,
 } from "../../scripts/dependency-vulnerability-gate.mts";
 
-function runCli(...args: string[]) {
-  return spawnSync(
-    process.execPath,
-    ["--import", "tsx", "scripts/dependency-vulnerability-gate.mts", ...args],
-    {
-      cwd: path.resolve("."),
-      encoding: "utf8",
-    },
-  );
-}
+const releaseLocks = [
+  ".github/release/clawhub-cli/package-lock.json",
+  ".github/release/vercel-cli/package-lock.json",
+] as const;
 
-function expectNoNodeStack(stderr: string) {
-  expect(stderr).not.toContain("Node.js");
-  expect(stderr).not.toContain("\n    at ");
-}
-
-function advisory({
-  id,
-  severity,
-  title,
-  vulnerableVersions = "<=1.0.0",
-}: {
-  id: string;
-  severity: string;
-  title: string;
-  vulnerableVersions?: string;
-}) {
+function advisory(severity: string, title = "Fixture vulnerability") {
   return {
-    id,
+    id: "GHSA-fixture",
     severity,
     title,
-    vulnerable_versions: vulnerableVersions,
-    url: `https://github.com/advisories/${id}`,
+    vulnerable_versions: "<1.0.0",
+    url: "https://github.com/advisories/GHSA-fixture",
   };
 }
 
-async function writeLockfile(rootDir: string) {
+async function writeNpmLock(
+  rootDir: string,
+  lockfile: string,
+  packages: Record<string, unknown> = { "node_modules/fixture-tool": { version: "2.0.0" } },
+) {
+  await mkdir(path.dirname(path.join(rootDir, lockfile)), { recursive: true });
   await writeFile(
-    path.join(rootDir, "pnpm-lock.yaml"),
-    `lockfileVersion: '9.0'
+    path.join(rootDir, lockfile),
+    JSON.stringify({
+      lockfileVersion: 3,
+      packages: { "": { name: "fixture", version: "1.0.0" }, ...packages },
+    }),
+  );
+}
 
+async function withLockfiles(run: (rootDir: string) => Promise<void>) {
+  const rootDir = await mkdtemp(path.join(tmpdir(), "openclaw-vuln-gate-"));
+  try {
+    await writeFile(
+      path.join(rootDir, "pnpm-lock.yaml"),
+      `lockfileVersion: '9.0'
 importers:
   .:
     dependencies:
@@ -59,74 +54,49 @@ importers:
     devDependencies:
       dev-high:
         version: 1.0.0
-
 snapshots:
   runtime-high@1.0.0: {}
   dev-high@1.0.0: {}
   transitive-critical@1.0.0: {}
 `,
-    "utf8",
-  );
+    );
+    for (const lockfile of releaseLocks) {
+      await writeNpmLock(rootDir, lockfile);
+    }
+    await run(rootDir);
+  } finally {
+    await rm(rootDir, { force: true, recursive: true });
+  }
+}
+
+function requestPayload(init: RequestInit | undefined): Record<string, string[]> {
+  if (typeof init?.body !== "string") {
+    throw new Error("expected a JSON request body");
+  }
+  return JSON.parse(init.body);
 }
 
 describe("dependency-vulnerability-gate", () => {
   it("reports CLI argument errors without a Node stack trace", () => {
-    const unknownArg = runCli("--wat");
-    expect(unknownArg.status).toBe(1);
-    expect(unknownArg.stdout).toBe("");
-    expect(unknownArg.stderr.trim()).toBe("Unsupported argument: --wat");
-    expectNoNodeStack(unknownArg.stderr);
-  });
-
-  it("blocks critical advisories anywhere and high advisories in the production graph", () => {
-    const result = classifyVulnerabilityFindings({
-      allAdvisories: {
-        "dev-high": [advisory({ id: "GHSA-dev-high", severity: "high", title: "dev high" })],
-        "transitive-critical": [
-          advisory({ id: "GHSA-critical", severity: "critical", title: "critical issue" }),
-        ],
-      },
-      productionAdvisories: {
-        "runtime-high": [
-          advisory({ id: "GHSA-runtime-high", severity: "high", title: "runtime high" }),
-        ],
-      },
-    });
-
-    expect(result.blockers.map((finding) => finding.id)).toEqual([
-      "GHSA-critical",
-      "GHSA-runtime-high",
-    ]);
-    expect(result.findings.map((finding) => finding.id)).toEqual([
-      "GHSA-critical",
-      "GHSA-dev-high",
-      "GHSA-runtime-high",
-    ]);
-  });
-
-  it("blocks malware advisories regardless of severity or graph", () => {
-    const result = classifyVulnerabilityFindings({
-      allAdvisories: {
-        dev: [advisory({ id: "GHSA-malware", severity: "low", title: "Malware in dev" })],
-      },
-      productionAdvisories: {},
-    });
-
-    expect(result.blockers).toMatchObject([
+    const result = spawnSync(
+      process.execPath,
+      ["--import", "tsx", "scripts/dependency-vulnerability-gate.mts", "--wat"],
       {
-        id: "GHSA-malware",
-        malware: true,
-        severity: "low",
+        cwd: path.resolve("."),
+        encoding: "utf8",
       },
-    ]);
+    );
+    expect(result.status).toBe(1);
+    expect(result.stdout).toBe("");
+    expect(result.stderr.trim()).toBe("Unsupported argument: --wat");
+    expect(result.stderr).not.toContain("Node.js");
+    expect(result.stderr).not.toContain("\n    at ");
   });
 
   it.each([false, true])(
-    "queries toolchain and production graphs separately (metadata %s)",
+    "keeps pnpm toolchain and production graphs separate (metadata %s)",
     async (withToolchain) => {
-      const rootDir = await mkdtemp(path.join(tmpdir(), "openclaw-vuln-gate-"));
-      try {
-        await writeLockfile(rootDir);
+      await withLockfiles(async (rootDir) => {
         if (withToolchain) {
           const lockPath = path.join(rootDir, "pnpm-lock.yaml");
           await writeFile(
@@ -136,90 +106,293 @@ describe("dependency-vulnerability-gate", () => {
           );
         }
         const payloads: Record<string, string[]>[] = [];
-
         const report = await runDependencyVulnerabilityGate({
           rootDir,
           fetchImpl: async (_url, init) => {
-            if (typeof init?.body !== "string") {
-              throw new Error("expected a JSON request body");
-            }
-            const payload = JSON.parse(init.body);
+            const payload = requestPayload(init);
             payloads.push(payload);
-            const packages = Object.keys(payload);
-            const body: Record<string, unknown[]> = {};
-            if (packages.includes("runtime-high")) {
-              body["runtime-high"] = [
-                advisory({ id: "GHSA-runtime-high", severity: "high", title: "runtime high" }),
-              ];
-            }
-            if (packages.includes("toolchain")) {
-              body.toolchain = [
-                advisory({ id: "GHSA-toolchain", severity: "low", title: "Malware in toolchain" }),
-              ];
-            }
-            if (packages.includes("dev-high")) {
-              body["dev-high"] = [
-                advisory({ id: "GHSA-dev-high", severity: "high", title: "dev high" }),
-              ];
-            }
-            return new Response(JSON.stringify(body), {
-              status: 200,
-              headers: { "content-type": "application/json" },
-            });
+            const advisories = {
+              "runtime-high": advisory("high"),
+              "dev-high": advisory("high"),
+              "transitive-critical": advisory("critical"),
+              toolchain: advisory("low", "Malware in toolchain"),
+            };
+            const body = Object.fromEntries(
+              Object.entries(advisories)
+                .filter(([name]) => payload[name]?.includes("1.0.0"))
+                .map(([name, finding]) => [name, [{ ...finding, vulnerable_versions: "<=1.0.0" }]]),
+            );
+            return new Response(JSON.stringify(body));
           },
         });
-
-        expect(payloads).toHaveLength(2);
-        expect(payloads[0]).toEqual({
-          "dev-high": ["1.0.0"],
-          "runtime-high": ["1.0.0"],
-          "transitive-critical": ["1.0.0"],
-          ...(withToolchain ? { toolchain: ["1.0.0"] } : {}),
-        });
-        expect(payloads[1]).toEqual({
-          "runtime-high": ["1.0.0"],
-        });
-        expect(report.blockers.map((finding) => finding.id)).toEqual([
-          "GHSA-runtime-high",
-          ...(withToolchain ? ["GHSA-toolchain"] : []),
+        expect(payloads.filter((payload) => "runtime-high" in payload)).toEqual([
+          {
+            "dev-high": ["1.0.0"],
+            "runtime-high": ["1.0.0"],
+            "transitive-critical": ["1.0.0"],
+            ...(withToolchain ? { toolchain: ["1.0.0"] } : {}),
+          },
+          { "runtime-high": ["1.0.0"] },
         ]);
-        expect(report.findings.map((finding) => finding.id)).toEqual([
-          "GHSA-dev-high",
-          "GHSA-runtime-high",
-          ...(withToolchain ? ["GHSA-toolchain"] : []),
+        expect(report.blockers.map(({ packageName }) => packageName)).toEqual([
+          "transitive-critical",
+          "runtime-high",
+          ...(withToolchain ? ["toolchain"] : []),
         ]);
-      } finally {
-        await rm(rootDir, { force: true, recursive: true });
-      }
+        expect(report.findings.every(({ lockfile }) => lockfile === "pnpm-lock.yaml")).toBe(true);
+        expect(report.graphs).toContainEqual({
+          lockfile: "pnpm-lock.yaml",
+          all: { packages: withToolchain ? 4 : 3, packageVersions: withToolchain ? 4 : 3 },
+          production: { packages: 1, packageVersions: 1 },
+        });
+      });
     },
   );
 
-  it("documents the resolved transitive dependency graph scope in Markdown", () => {
-    const markdown = renderDependencyVulnerabilityGateMarkdownReport({
-      generatedAt: "2026-05-12T00:00:00.000Z",
-      policy: {
-        blocks: [
-          "known malware advisories anywhere in the installed graph",
-          "critical advisories anywhere in the installed graph",
-          "high advisories in the production/runtime graph",
-        ],
-        reports: [
-          "moderate and lower advisories",
-          "high advisories outside production/runtime graph",
-        ],
-        vulnerabilityExceptions: false,
-      },
-      graphs: {
-        all: { packages: 2, packageVersions: 2 },
-        production: { packages: 1, packageVersions: 1 },
-      },
-      blockers: [],
-      findings: [],
-    });
+  const npmCases = [
+    {
+      name: "runtime high",
+      location: "node_modules/runtime-high",
+      metadata: {},
+      severity: "high",
+      graph: "production",
+      blocks: true,
+    },
+    {
+      name: "nested scoped alias",
+      location: "node_modules/@scope/parent/node_modules/@scope/alias",
+      metadata: { name: "runtime-high" },
+      severity: "high",
+      graph: "production",
+      blocks: true,
+    },
+    {
+      name: "dev-only high",
+      location: "node_modules/runtime-high",
+      metadata: { dev: true },
+      severity: "high",
+      graph: "all",
+      blocks: false,
+    },
+    {
+      name: "optional runtime high",
+      location: "node_modules/runtime-high",
+      metadata: { optional: true },
+      severity: "high",
+      graph: "production",
+      blocks: true,
+    },
+    {
+      name: "dev and optional high",
+      location: "node_modules/runtime-high",
+      metadata: { dev: true, optional: true },
+      severity: "high",
+      graph: "all",
+      blocks: false,
+    },
+    {
+      name: "shared devOptional high",
+      location: "node_modules/runtime-high",
+      metadata: { devOptional: true },
+      severity: "high",
+      graph: "production",
+      blocks: true,
+    },
+    {
+      name: "dev-only critical",
+      location: "node_modules/runtime-high",
+      metadata: { dev: true },
+      severity: "critical",
+      graph: "all",
+      blocks: true,
+    },
+    {
+      name: "dev-only malware",
+      location: "node_modules/runtime-high",
+      metadata: { dev: true },
+      severity: "low",
+      title: "Malware in dependency",
+      graph: "all",
+      blocks: true,
+    },
+    {
+      name: "runtime moderate",
+      location: "node_modules/runtime-high",
+      metadata: {},
+      severity: "moderate",
+      graph: "production",
+      blocks: false,
+    },
+  ];
+  it.each(releaseLocks.flatMap((lockfile) => npmCases.map((entry) => ({ lockfile, ...entry }))))(
+    "$lockfile: $name stays isolated from the safe product version",
+    async ({ lockfile, location, metadata, severity, title, graph, blocks }) => {
+      await withLockfiles(async (rootDir) => {
+        await writeNpmLock(rootDir, lockfile, { [location]: { version: "0.9.0", ...metadata } });
+        const report = await runDependencyVulnerabilityGate({
+          rootDir,
+          fetchImpl: async (_url, init) =>
+            new Response(
+              JSON.stringify(
+                requestPayload(init)["runtime-high"]?.includes("0.9.0")
+                  ? { "runtime-high": [advisory(severity, title)] }
+                  : {},
+              ),
+            ),
+        });
+        expect(report.findings).toMatchObject([
+          { lockfile, packageName: "runtime-high", graph, severity },
+        ]);
+        expect(report.findings).toHaveLength(1);
+        expect(report.blockers).toEqual(blocks ? report.findings : []);
+        const markdown = renderDependencyVulnerabilityGateMarkdownReport(report);
+        expect(markdown).toContain(`runtime-high (${lockfile}; ${graph})`);
+        expect(markdown).not.toContain("runtime-high (pnpm-lock.yaml;");
+      });
+    },
+  );
 
-    expect(markdown).toContain("# npm Advisory Vulnerability Gate: Resolved Dependency Graph");
-    expect(markdown).toContain("## Scope");
-    expect(markdown).toContain("resolved package versions from pnpm-lock.yaml");
-    expect(markdown).toContain("It includes transitive dependencies.");
+  it("retains nested versions and findings in both release locks without auditing the root or links", async () => {
+    await withLockfiles(async (rootDir) => {
+      for (const lockfile of releaseLocks) {
+        await writeNpmLock(rootDir, lockfile, {
+          "": { name: "root-only", version: "0.9.0" },
+          "node_modules/@scope/leaf": { version: "0.8.0" },
+          "node_modules/parent/node_modules/@scope/leaf": { version: "0.9.0" },
+          "node_modules/other/node_modules/@scope/leaf": { version: "0.9.0" },
+          "node_modules/link-only": { link: true, resolved: "../local" },
+        });
+      }
+      const payloads: Record<string, string[]>[] = [];
+      const report = await runDependencyVulnerabilityGate({
+        rootDir,
+        fetchImpl: async (_url, init) => {
+          const payload = requestPayload(init);
+          payloads.push(payload);
+          return new Response(
+            JSON.stringify(payload["@scope/leaf"] ? { "@scope/leaf": [advisory("high")] } : {}),
+          );
+        },
+      });
+      expect(payloads.filter((payload) => "@scope/leaf" in payload)).toEqual(
+        Array.from({ length: 4 }, () => ({ "@scope/leaf": ["0.8.0", "0.9.0"] })),
+      );
+      expect(
+        payloads.every((payload) => !("root-only" in payload) && !("link-only" in payload)),
+      ).toBe(true);
+      expect(report.blockers.map(({ lockfile }) => lockfile)).toEqual(releaseLocks);
+      expect(report.findings).toHaveLength(2);
+      for (const lockfile of releaseLocks) {
+        expect(report.graphs).toContainEqual({
+          lockfile,
+          all: { packages: 1, packageVersions: 2 },
+          production: { packages: 1, packageVersions: 2 },
+        });
+      }
+    });
   });
+
+  it.each(
+    releaseLocks.flatMap((lockfile) => [
+      { lockfile, name: "missing", contents: null },
+      { lockfile, name: "invalid JSON", contents: "{" },
+      { lockfile, name: "missing packages", contents: '{"lockfileVersion":3}' },
+      {
+        lockfile,
+        name: "empty dependency graph",
+        contents: '{"lockfileVersion":3,"packages":{"":{}}}',
+      },
+      {
+        lockfile,
+        name: "invalid package entry",
+        contents: '{"lockfileVersion":3,"packages":{"":{},"node_modules/broken":{}}}',
+      },
+    ]),
+  )("rejects $name lock $lockfile before requesting advisories", async ({ lockfile, contents }) => {
+    await withLockfiles(async (rootDir) => {
+      if (contents === null) {
+        await rm(path.join(rootDir, lockfile));
+      } else {
+        await writeFile(path.join(rootDir, lockfile), contents);
+      }
+      const fetchImpl = vi.fn(async () => new Response("{}"));
+      await expect(runDependencyVulnerabilityGate({ rootDir, fetchImpl })).rejects.toThrow(
+        lockfile,
+      );
+      expect(fetchImpl).not.toHaveBeenCalled();
+    });
+  });
+
+  it("propagates release-tool advisory transport failures", async () => {
+    await withLockfiles(async (rootDir) => {
+      await writeNpmLock(rootDir, releaseLocks[0], {
+        "node_modules/tool-only": { version: "1.0.0" },
+      });
+      await expect(
+        runDependencyVulnerabilityGate({
+          rootDir,
+          fetchImpl: async (_url, init) =>
+            requestPayload(init)["tool-only"]
+              ? new Response("fixture unavailable", { status: 503 })
+              : new Response("{}"),
+        }),
+      ).rejects.toThrow("Bulk advisory request failed (503");
+    });
+  });
+
+  it.each([false, true])(
+    "writes attributed CLI artifacts and the gate exit code (tool blocker %s)",
+    async (blocked) => {
+      await withLockfiles(async (rootDir) => {
+        const lockfile = ".github/release/vercel-cli/package-lock.json";
+        await writeNpmLock(rootDir, lockfile, {
+          "node_modules/runtime-high": { version: "0.9.0" },
+        });
+        const fetchSpy = vi
+          .spyOn(globalThis, "fetch")
+          .mockImplementation(
+            async (_url, init) =>
+              new Response(
+                JSON.stringify(
+                  blocked && requestPayload(init)["runtime-high"]?.includes("0.9.0")
+                    ? { "runtime-high": [advisory("critical")] }
+                    : {},
+                ),
+              ),
+          );
+        const stderr = vi.spyOn(process.stderr, "write").mockReturnValue(true);
+        const stdout = vi.spyOn(process.stdout, "write").mockReturnValue(true);
+        try {
+          const jsonPath = path.join(rootDir, "report.json");
+          const markdownPath = path.join(rootDir, "report.md");
+          expect(
+            await main(["--root", rootDir, "--json", jsonPath, "--markdown", markdownPath]),
+          ).toBe(blocked ? 1 : 0);
+          const report = JSON.parse(await readFile(jsonPath, "utf8"));
+          expect(report.blockers).toHaveLength(blocked ? 1 : 0);
+          const markdown = await readFile(markdownPath, "utf8");
+          expect(markdown).toContain("### pnpm-lock.yaml");
+          expect(markdown).toContain("### .github/release/clawhub-cli/package-lock.json");
+          if (blocked) {
+            expect(report.blockers).toMatchObject([{ lockfile }]);
+            expect(markdown).toContain(
+              "runtime-high (.github/release/vercel-cli/package-lock.json; production)",
+            );
+            expect(stderr.mock.calls.flat().join("")).toContain(lockfile);
+            expect(stdout).not.toHaveBeenCalled();
+          } else {
+            expect(markdown).toContain("No advisories found.");
+            expect(stdout.mock.calls.flat().join("")).toContain(
+              "checked 5 resolved package versions across 3 separate lockfile graphs; 0 hard blockers",
+            );
+            expect(stderr).not.toHaveBeenCalled();
+          }
+        } finally {
+          fetchSpy.mockRestore();
+          stderr.mockRestore();
+          stdout.mockRestore();
+        }
+      });
+    },
+  );
 });

--- a/test/scripts/generate-dependency-release-evidence.test.ts
+++ b/test/scripts/generate-dependency-release-evidence.test.ts
@@ -258,8 +258,15 @@ describe("generate-dependency-release-evidence", () => {
     const dir = await mkdtemp(path.join(tmpdir(), "openclaw-release-dependency-evidence-test-"));
     try {
       await writeJson(dir, "dependency-vulnerability-gate.json", {
-        blockers: [{ id: "GHSA-blocker" }],
-        findings: [{ id: "GHSA-blocker" }, { id: "GHSA-report" }],
+        blockers: [
+          { id: "GHSA-blocker", lockfile: "pnpm-lock.yaml" },
+          { id: "GHSA-blocker", lockfile: ".github/release/vercel-cli/package-lock.json" },
+        ],
+        findings: [
+          { id: "GHSA-blocker", lockfile: "pnpm-lock.yaml" },
+          { id: "GHSA-blocker", lockfile: ".github/release/vercel-cli/package-lock.json" },
+          { id: "GHSA-report", lockfile: ".github/release/clawhub-cli/package-lock.json" },
+        ],
       });
       await writeJson(dir, "transitive-manifest-risk-report.json", {
         findingCount: 17,
@@ -283,8 +290,8 @@ describe("generate-dependency-release-evidence", () => {
 
       const counts = await collectDependencyEvidenceSummaryCounts(dir);
       expect(counts).toEqual({
-        vulnerabilityBlockers: 1,
-        vulnerabilityFindings: 2,
+        vulnerabilityBlockers: 2,
+        vulnerabilityFindings: 3,
         transitiveRiskSignals: 17,
         workspaceExcludedTransitiveSignals: 3,
         transitiveMetadataFailures: 1,
@@ -302,7 +309,7 @@ describe("generate-dependency-release-evidence", () => {
         baseRef: "v2026.5.1",
         counts,
       });
-      expect(summary).toContain("- npm advisory vulnerability hard blockers: 1");
+      expect(summary).toContain("- npm advisory vulnerability hard blockers: 2");
       expect(summary).toContain("- Transitive manifest reported risk signals: 17");
       expect(summary).toContain("- Dependency change baseline: `v2026.5.1`");
       expect(summary).toContain("- Resolved package changes: +5 -6 changed 7");
@@ -315,7 +322,7 @@ describe("generate-dependency-release-evidence", () => {
       expect(stepSummary).toContain(
         "- Evidence artifact: `openclaw-release-dependency-evidence-v2026.5.13`",
       );
-      expect(stepSummary).toContain("- npm advisory vulnerability hard blockers: `1`");
+      expect(stepSummary).toContain("- npm advisory vulnerability hard blockers: `2`");
 
       await expect(
         readFile(path.join(dir, "dependency-vulnerability-gate.json"), "utf8"),

--- a/test/scripts/vercel-container-registry-publish.test.ts
+++ b/test/scripts/vercel-container-registry-publish.test.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import { readFileSync, readdirSync } from "node:fs";
 import { describe, expect, it, vi } from "vitest";
 import { parse } from "yaml";
@@ -617,8 +618,10 @@ describe("Vercel Container Registry publishing", () => {
     expect(copyIndex).toBeGreaterThan(-1);
     expect(smokeIndex).toBeGreaterThan(copyIndex ?? -1);
     expect(promoteIndex).toBeGreaterThan(smokeIndex ?? -1);
-    const smokeRun = reusablePublish.steps?.[smokeIndex ?? -1]?.run ?? "";
-    expect(smokeRun).toContain("sandbox run \\\n");
+    const smokeStep = reusablePublish.steps?.[smokeIndex ?? -1];
+    expect(smokeStep?.env?.SANDBOX_CLI).toBe("${{ steps.vercel_cli.outputs.sandbox_cli }}");
+    const smokeRun = smokeStep?.run ?? "";
+    expect(smokeRun).toContain('"${SANDBOX_CLI}" run \\\n');
     expect(smokeRun).toContain("image_not_ready");
     expect(smokeRun).toContain("retry_deadline");
   });
@@ -627,25 +630,31 @@ describe("Vercel Container Registry publishing", () => {
     const packageJson = JSON.parse(
       readFileSync(".github/release/vercel-cli/package.json", "utf8"),
     ) as { dependencies?: Record<string, string> };
-    const packageLock = JSON.parse(
-      readFileSync(".github/release/vercel-cli/package-lock.json", "utf8"),
-    ) as {
+    const packageLockBytes = readFileSync(".github/release/vercel-cli/package-lock.json");
+    const packageLock = JSON.parse(packageLockBytes.toString("utf8")) as {
       lockfileVersion?: number;
       packages?: Record<string, { integrity?: string; version?: string }>;
     };
     const materialize = readFileSync("scripts/materialize-vercel-cli.sh", "utf8");
 
-    expect(packageJson.dependencies).toEqual({ vercel: "59.3.0" });
+    expect(packageJson.dependencies).toEqual({ sandbox: "4.0.0", vercel: "59.3.0" });
     expect(packageLock.lockfileVersion).toBe(3);
     expect(packageLock.packages?.["node_modules/vercel"]).toMatchObject({
       integrity:
         "sha512-Bj/SN1qln/9guMcIz4gEGn+Ij+amGtkT2kqxwUAFgrLU2Hr0zYk4kX4QfxmZEs6WhheAaMlblVw2VUF2JFP5fA==",
       version: "59.3.0",
     });
-    expect(materialize).toContain(
-      'expected_lock_sha256="4cea63abc4e89d659902aae28dd3e88973fdff9cdd2d2f5e234315d3a3bb680e"',
-    );
+    expect(packageLock.packages?.["node_modules/sandbox"]).toMatchObject({
+      bin: { sandbox: "bin/sandbox.mjs" },
+      integrity:
+        "sha512-3fNfxSmRJpoCGF3wBncPjxypKYmgtleaAYgyhMrowBpp83388gIELSQ4evIPt1sP+fa6gnn0wRr8CBnUneFzRQ==",
+      version: "4.0.0",
+    });
+    const lockSha256 = createHash("sha256").update(packageLockBytes).digest("hex");
+    expect(materialize).toContain(`expected_lock_sha256="${lockSha256}"`);
     expect(materialize).toContain("npm ci \\\n");
     expect(materialize).toContain("--ignore-scripts");
+    expect(materialize).toContain('sandbox_cli="${destination}/node_modules/.bin/sandbox"');
+    expect(materialize).toContain('echo "sandbox_cli=${sandbox_cli}"');
   });
 });


### PR DESCRIPTION
Closes https://github.com/openclaw/openclaw/issues/132967 — the dependency gate omits committed release-tool locks.

## What Problem This Solves

Resolves a problem where release dependency checks reported success while the separately installed Vercel toolchain retained 35 public npm advisories. The gate audited pnpm only; the root pnpm overrides did not apply to the committed Vercel npm project.

Installed-tool validation also found an existing false success in the same release path: `vercel sandbox run` returned zero when the remote smoke command exited 17, allowing the workflow to treat a failed smoke command as successful.

These are release-tooling defects, not a claim of exploit reachability or a product-runtime vulnerability. The product pnpm graph and the separate ClawHub release-tool graph independently had zero advisories.

## Why This Change Was Made

Keep Vercel at **59.3.0**. Ordinary cooled resolutions of 59.3.0 and 59.4.0 retained exactly the same 35 advisory IDs; 59.4.0 additionally changed builder majors. The maintainer explicitly approved affected-version-scoped npm overrides after that owning-parent route was proven insufficient. The overrides cover eight package families, including tar **7.5.7 → 7.5.22** and the affected Undici 5.x copies → **6.28.0**, while preserving safe existing majors and npm aliases.

The materializer retains the original Vercel tarball integrity and binds the refreshed complete lock by SHA-256. The dependency gate now audits pnpm, ClawHub and Vercel independently, preserves the source lockfile on every finding, and applies its existing severity policy within each source. Missing/corrupt expected tool locks fail visibly. No new audit dependency, configuration, exception mechanism, or fallback path is introduced.

For Sandbox, consume its already-locked **4.0.0** executable directly instead of the Vercel wrapper that overwrites its exit status. Declare that existing package as a direct release-tool dependency and expose its validated absolute binary path from the materializer. No additional package/version enters the closure. Auth bindings, smoke arguments, cleanup, image copying/promotion and retry policy are otherwise unchanged.

## User Impact

Release maintainers get accurate dependency findings and a smoke-check failure when the remote command fails. Normal OpenClaw runtime dependencies, the ClawHub lock, and the separate SDK update are unchanged; neither release-tool lock is shipped in product packages.

Ordinary CI's `security-fast` job and the production pre-commit audit remain product-only. Extending those enforcement/reporting paths is a separately flagged follow-up, not an implicit policy change here.

AI-assisted implementation and validation. The scoped dependency overrides were explicitly approved by the maintainer.

## Evidence

### Advisory and integrity proof

Fresh full bulk advisory queries and `npm audit --package-lock-only --ignore-scripts --json` report **zero advisories** for the candidate Vercel lock. All 355 non-root lock locations / 343 distinct package-version pairs meet the frozen **2026-08-22T22:23:31Z** cutoff, and registry integrity was independently checked for every entry. The final direct Sandbox declaration changes only root metadata, not that resolved closure.

| Independently audited graph | Distinct package/version pairs | Advisories |
| --- | ---: | ---: |
| Product pnpm, including toolchain metadata | 1606 | 0 |
| ClawHub release tool | 47 | 0 |
| Vercel release tool | 343 | 0 |

Final Vercel lock SHA-256: `85e611c2d409f9ce91f2f85bdfbdf02fdaaead2e2e4ba7dfaaac9c7220d6b021`.

The gate boundary reproduction fails before repair: safe product tar plus vulnerable tar only in the Vercel lock produces no blocker. After repair it produces a blocker attributed only to that tool lock. Tests cover both tool locks, aliases, nested versions, dev/optional classification, missing/corrupt inputs, transport failures, and CLI artifacts/exits.

### Focused source validation

**95 tests passed**:

```bash
node scripts/run-vitest.mjs test/scripts/dependency-vulnerability-gate.test.ts test/scripts/generate-dependency-release-evidence.test.ts test/scripts/pnpm-audit-prod.test.ts test/scripts/vercel-container-registry-publish.test.ts test/scripts/plugin-clawhub-new-workflow.test.ts
```

The final selected-file `node scripts/check-changed.mjs -- ...` plan passed formatting, script/root-test type checks, lint and all selected guards. The initial no-map-spread lint finding was fixed before the passing run. Repository-native workflow sanity passed with compatible installed Python 3.14.7; system Python 3.9.6 could not install the existing pre-commit pin, which requires Python >=3.10. No tool pin was changed.

```bash
node --import ./scripts/tsx.mjs scripts/dependency-vulnerability-gate.mts
```

```bash
node --import ./scripts/tsx.mjs scripts/check-workflows.mts
```

Independent isolated Codex autoreview is clean at its P0 threshold. Exact-head CI and final native landing evidence will be recorded before merge.

### Isolated installed-tool proof

Fresh secretless AWS proof used Node **24.19.0** / npm **11.17.0**, public networking, no Tailscale or Actions hydration, and an IMDSv2 check proving no instance-role credentials. Processes used fresh homes and synthetic Vercel tokens; real Vercel services and Docker registries were not contacted. The lease has been released.

- **14/14 installed CLI/process-boundary cases pass**: real materialization with lifecycle scripts disabled, tamper refusal before npm, existing-destination refusal, published tarball-byte verification, VCR success/denials, Sandbox success/nonzero/API-denial/malformed responses, cleanup, and fail-closed unknown transport.
- **10/10 additional installed caller/API contracts pass** across the eight override families, including real Vercel direct/proxy dispatchers and Undici request/stream/abort/reuse/shutdown, actual Fun request lifecycle, both tar extraction patterns, YAML/TOML, minimatch, both route matcher majors, and the actual static-config/Ajv validator.
- Baseline: remote Sandbox exit **17 → process 0**. Repaired direct CLI: **17 → 17**, with DELETE cleanup retained. Installed package bytes remain unchanged throughout the probes.

Baseline run: `run_9029ce52b029`. Candidate CLI proof: `run_b88b8f6b9ea8` (all CLI cases passed; the supplementary leaf harness still needed corrections). Completed leaf proof and evidence retrieval: `run_50a915b0bba1`. The leaf harness corrections followed inspected Node/Undici contracts; they changed no dependency or production bytes.

This is real installed code against strict mock API/loopback fixtures, **not live authenticated service or full-builder certification**. Zero lock advisories does not certify code already embedded in upstream CLI bundles. No production publishing, deployment, real Vercel credentials, operator-service changes, dependency patches, or vendoring were used.

### Size and ownership

Product runtime source delta: **0**. Tooling code: **+169/-80 (net +89)** for the missing npm-lock/provenance boundary and validated direct Sandbox output. Manifest: **+12** for approved selectors/direct ownership. Workflow: **+2/-2**. Tests: **+361/-172 (net +189)**. Generated lock: **net -70**. Duplicate gate classification/rendering paths and the classifier's test-only export were removed.
