### PR TITLE
fix(ui): show plan usage only for the session provider

### DIFF
--- a/ui/src/e2e/chat-quota-pill-93041.e2e.test.ts
+++ b/ui/src/e2e/chat-quota-pill-93041.e2e.test.ts
@@ -26,12 +26,22 @@ const authStatusWithUsage = {
         windows: [{ label: "Week", usedPercent: 71, resetAt: Date.now() + 4 * 86_400_000 }],
       },
     },
+    {
+      provider: "github-copilot",
+      displayName: "Copilot",
+      status: "ok",
+      profiles: [{ profileId: "github-copilot", type: "token", status: "ok" }],
+      usage: {
+        providerId: "github-copilot",
+        windows: [{ label: "Day", usedPercent: 41 }],
+      },
+    },
   ],
 };
 
 const gatewayInjectedSessions = {
   count: 1,
-  defaults: { contextTokens: 200_000, model: "gateway-injected", modelProvider: "openclaw" },
+  defaults: { contextTokens: 200_000, model: "gateway-injected", modelProvider: "openai" },
   path: "",
   sessions: [
     {
@@ -42,7 +52,7 @@ const gatewayInjectedSessions = {
       kind: "direct",
       label: "Main",
       model: "gateway-injected",
-      modelProvider: "openclaw",
+      modelProvider: "openai",
       status: "done",
       totalTokens: 46_000,
       totalTokensFresh: true,
@@ -181,7 +191,8 @@ suite.define(() => {
     const { page } = fixture;
     try {
       const contextRing = page.locator(".context-ring");
-      const usageLink = page.locator('[data-chat-provider-usage="true"]');
+      const usageLinks = page.locator('[data-chat-provider-usage="true"]');
+      const usageLink = usageLinks.first();
       await contextRing.waitFor({ state: "visible" });
       expect(await usageLink.isVisible()).toBe(false);
       await contextRing.click();
@@ -191,11 +202,15 @@ suite.define(() => {
         path: path.join(artifactDir, "02-context-usage-popover.png"),
       });
 
+      expect(await usageLinks.count()).toBe(1);
       expect(await usageLink.getAttribute("href")).toBe("/usage");
       const rows = await page.locator(".context-usage__limit").allTextContents();
       const normalized = rows.map((row) => row.replace(/\s+/g, " ").trim());
       expect(normalized).toHaveLength(1);
       expect(normalized[0]).toMatch(/^Weekly Resets .+ 71%$/);
+      expect((await page.locator(".context-usage__popover").textContent()) ?? "").not.toContain(
+        "Copilot",
+      );
       expect(
         (await page.locator('[data-chat-usage-provider="true"]').textContent())
           ?.replace(/\s+/g, " ")

--- a/ui/src/pages/chat/chat-composer-context.test.ts
+++ b/ui/src/pages/chat/chat-composer-context.test.ts
@@ -14,7 +14,7 @@ afterEach(async () => {
 });
 
 describe("renderChatComposer context usage", () => {
-  it("renders session context and plan usage through the full composer", () => {
+  it("renders only the current session provider's plan usage", () => {
     vi.useFakeTimers();
     vi.setSystemTime(1_700_000_000_000);
     const container = renderComposer({
@@ -27,7 +27,7 @@ describe("renderChatComposer context usage", () => {
             totalTokens: 46_000,
             contextTokens: 200_000,
             model: "gateway-injected",
-            modelProvider: "openclaw",
+            modelProvider: "openai",
           },
         ],
         defaults: { contextTokens: 200_000 },
@@ -47,6 +47,16 @@ describe("renderChatComposer context usage", () => {
                 windows: [
                   { label: "Week", usedPercent: 72, resetAt: 1_700_000_000_000 + 3 * 3_600_000 },
                 ],
+              },
+            },
+            {
+              provider: "github-copilot",
+              displayName: "Copilot",
+              status: "ok",
+              profiles: [{ profileId: "github-copilot", type: "token", status: "ok" }],
+              usage: {
+                providerId: "github-copilot",
+                windows: [{ label: "Day", usedPercent: 41 }],
               },
             },
           ],
@@ -70,6 +80,7 @@ describe("renderChatComposer context usage", () => {
         ?.textContent?.replace(/\s+/g, " ")
         .trim(),
     ).toBe("Provider: OpenAI");
+    expect(container.querySelectorAll(".context-usage__plan-header")).toHaveLength(1);
     const popoverText = container.querySelector(".context-usage__popover")?.textContent ?? "";
     expect(popoverText).not.toContain("openclaw");
     expect(popoverText).not.toContain("gateway-injected");
@@ -79,6 +90,7 @@ describe("renderChatComposer context usage", () => {
   it("renders plan usage before session metrics arrive", () => {
     const container = renderComposer({
       sessions: null,
+      messages: [{ role: "assistant", content: "hello", provider: "openai" }],
       providerUsage: {
         basePath: "/control",
         modelAuthStatusResult: {
@@ -238,15 +250,58 @@ describe("renderChatComposer context usage", () => {
 
     const container = renderComposer(composerProps as never);
 
-    expect(providerNames(container)).toEqual(["Provider: Claude", "Provider: OpenAI"]);
+    expect(providerNames(container)).toEqual([]);
     expect(container.textContent).toContain("Cost by Type");
     expect(container.textContent).not.toContain("Model:");
 
     session.modelProvider = undefined;
-    expect(providerNames(renderComposer(composerProps as never))).toEqual([
-      "Provider: OpenAI",
-      "Provider: Claude",
-    ]);
+    expect(providerNames(renderComposer(composerProps as never))).toEqual(["Provider: OpenAI"]);
+  });
+
+  it("keeps context, token, and cost details when only unrelated plan usage exists", () => {
+    const container = renderComposer({
+      sessions: {
+        sessions: [
+          {
+            key: "main",
+            kind: "direct",
+            updatedAt: null,
+            inputTokens: 800,
+            outputTokens: 200,
+            totalTokens: 46_000,
+            contextTokens: 200_000,
+            estimatedCostUsd: 0.03,
+            modelProvider: "openai",
+          },
+        ],
+        defaults: { contextTokens: 200_000 },
+      } as never,
+      providerUsage: {
+        modelAuthStatusResult: {
+          ts: Date.now(),
+          providers: [
+            {
+              provider: "github-copilot",
+              displayName: "Copilot",
+              status: "ok",
+              profiles: [{ profileId: "github-copilot", type: "token", status: "ok" }],
+              usage: {
+                providerId: "github-copilot",
+                windows: [{ label: "Day", usedPercent: 41 }],
+              },
+            },
+          ],
+        },
+      },
+    });
+
+    const popoverText = container.querySelector(".context-usage__popover")?.textContent ?? "";
+    expect(container.querySelector(".context-usage__plan-header")).toBeNull();
+    expect(popoverText).not.toContain("Copilot");
+    expect(popoverText).toContain("Context window");
+    expect(popoverText).toContain("Latest run tokens");
+    expect(popoverText).toContain("Est. cost");
+    expect(popoverText).toContain("$0.03");
   });
 
   it("omits the cost-by-type section when every recorded cost is zero", () => {
@@ -345,12 +400,12 @@ describe("renderChatComposer context usage", () => {
       [...container.querySelectorAll(".context-usage__limit")].map((row) =>
         row.textContent?.replace(/\s+/g, " ").trim(),
       ),
-    ).toEqual(["Weekly 25%", "Weekly 72%"]);
+    ).toEqual(["Weekly 25%"]);
     expect(
       [...container.querySelectorAll("[data-chat-usage-provider='true']")].map((row) =>
         row.textContent?.replace(/\s+/g, " ").trim(),
       ),
-    ).toEqual(["Provider: Claude", "Provider: OpenAI"]);
+    ).toEqual(["Provider: Claude"]);
     expect(container.textContent).not.toContain("Model:");
   });
 

--- a/ui/src/pages/chat/components/chat-composer-context.ts
+++ b/ui/src/pages/chat/components/chat-composer-context.ts
@@ -30,7 +30,6 @@ type ProviderCostStats = {
   output?: number;
   cacheRead?: number;
   cacheWrite?: number;
-  provider: string | null;
 };
 
 function readCostValue(
@@ -41,11 +40,8 @@ function readCostValue(
 }
 
 function latestProviderCostStats(messages: unknown[] | undefined): ProviderCostStats | null {
-  if (!messages?.length) {
-    return null;
-  }
-  for (let index = messages.length - 1; index >= 0; index -= 1) {
-    const message = readCostRecord(messages[index]);
+  for (let index = (messages?.length ?? 0) - 1; index >= 0; index -= 1) {
+    const message = readCostRecord(messages?.[index]);
     if (message?.role === "user") {
       return null;
     }
@@ -54,9 +50,7 @@ function latestProviderCostStats(messages: unknown[] | undefined): ProviderCostS
     }
     const directCost = readCostRecord(message.cost);
     const usageCost = readCostRecord(readCostRecord(message.usage)?.cost);
-    const stats: ProviderCostStats = {
-      provider: typeof message.provider === "string" ? message.provider.trim() || null : null,
-    };
+    const stats: ProviderCostStats = {};
     for (const key of ["input", "output", "cacheRead", "cacheWrite"] as const) {
       const cost = readCostValue(directCost, key) ?? readCostValue(usageCost, key);
       if (cost !== undefined) {
@@ -68,6 +62,17 @@ function latestProviderCostStats(messages: unknown[] | undefined): ProviderCostS
     ) {
       return stats;
     }
+  }
+  return null;
+}
+
+function latestAssistantProvider(messages: unknown[] | undefined): string | null {
+  for (let index = (messages?.length ?? 0) - 1; index >= 0; index -= 1) {
+    const message = readCostRecord(messages?.[index]);
+    if (message?.role !== "assistant" || isTranscriptOnlyOpenClawAssistantMessage(message)) {
+      continue;
+    }
+    return typeof message.provider === "string" ? message.provider.trim() || null : null;
   }
   return null;
 }
@@ -319,7 +324,15 @@ export function renderContextNotice(
         isMonitoredAuthProvider,
       )
     : [];
-  if (!model && quotaGroups.length === 0) {
+  const currentProvider =
+    session?.modelProvider?.trim() || latestAssistantProvider(options.messages);
+  const normalizedProvider = currentProvider?.toLowerCase();
+  const currentGroup = normalizedProvider
+    ? quotaGroups.find((group) =>
+        group.providers.some((id) => id.trim().toLowerCase() === normalizedProvider),
+      )
+    : undefined;
+  if (!model && !currentGroup) {
     return nothing;
   }
   const summary = model
@@ -332,18 +345,6 @@ export function renderContextNotice(
   const percentage = model ? `${model.approximate ? "~" : ""}${model.pct}%` : null;
   const dashOffset = model ? RING_CIRCUMFERENCE * (1 - model.pct / 100) : RING_CIRCUMFERENCE;
   const providerCosts = model ? latestProviderCostStats(options.messages) : null;
-  const findQuotaGroup = (provider: string | null | undefined) => {
-    const normalizedProvider = provider?.trim().toLowerCase();
-    return normalizedProvider
-      ? quotaGroups.find((group) =>
-          group.providers.some((id) => id.trim().toLowerCase() === normalizedProvider),
-        )
-      : undefined;
-  };
-  const currentGroup = findQuotaGroup(session?.modelProvider?.trim() || providerCosts?.provider);
-  const planGroups = currentGroup
-    ? [currentGroup, ...quotaGroups.filter((group) => group !== currentGroup)]
-    : quotaGroups;
   // Plan-billed sessions hide dollar estimates: subscription usage is bounded
   // by the plan windows below, and per-token math would misread as real spend.
   // Billing mode is provider-level: session rows do not record which auth
@@ -459,7 +460,7 @@ export function renderContextNotice(
                 </dl>
               `
             : nothing}
-          ${planGroups.map((group) => renderQuotaGroup(group, usageHref))}
+          ${currentGroup ? renderQuotaGroup(currentGroup, usageHref) : nothing}
         </section>
       </details>
     </div>


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users opening the chat context-usage popover could see plan usage from unrelated configured providers. For example, an OpenAI session with both OpenAI and Copilot usage snapshots rendered both plans, while a session with only a Copilot snapshot presented Copilot usage as if it applied to the OpenAI session.

## Why This Change Was Made

The popover now determines the current provider from the session model provider, falling back only to the latest real assistant message when the session provider is absent. It renders one matching plan-usage group or no Plan Usage section, without changing the existing context-window, latest-run token, and estimated-cost details.

## User Impact

The context wheel no longer attributes another provider's subscription plan to the current session. Sessions without a matching plan snapshot still show their context and cost details.

## Evidence

### Before

The regression fixture has an OpenAI session and both OpenAI and Copilot plan snapshots. Before the source fix, the browser assertion found two provider-usage links and the popover displayed both plans.

![Before: OpenAI and unrelated Copilot plan usage are both shown](https://github.com/user-attachments/assets/252c5871-a95c-4a35-9519-ef40bb02ac82)

### After

The same fixture now displays only the matching OpenAI plan. The context window and latest-run token details remain visible.

![After: only matching OpenAI plan usage is shown](https://github.com/user-attachments/assets/0c40b4a2-d9a2-4199-b6a3-42bc5bb09fa9)

### Verification

- `pnpm test ui/src/pages/chat/chat-composer-context.test.ts`: 8 passed
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/chat-quota-pill-93041.e2e.test.ts`: 5 passed
- `pnpm check:changed`: passed
- `pnpm test:changed`: 797 UI files, 3 isolated files, and 1 E2E file passed; 11,958 tests passed and 86 skipped across the three shards
- `pnpm ui:build`: passed, including Control UI performance limits and 796 finalized sidecars
- Autoreview against `origin/main`: no accepted or actionable findings

The first full changed-test run hit two transient layout assertions in an unrelated responsive browser test. Its isolated rerun passed 111 tests, and the complete changed-test rerun then passed.

AI-assisted: yes. I reviewed the repository instructions, source history, tests, browser output, and final diff.
