### PR TITLE
fix(backup): declare external managed-skill symlink targets as backup assets

### DIFF
--- a/src/commands/backup-shared.ts
+++ b/src/commands/backup-shared.ts
@@ -1,4 +1,5 @@
 // Backup planning helpers for archive naming, payload paths, and deduplicated asset selection.
+import type { Dirent } from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { listAgentIds, resolveAgentDir } from "../agents/agent-scope-config.js";
@@ -55,7 +56,7 @@ export function resolveRequiredBackupPath(
   return resolveUserPath(trimmed);
 }
 
-type BackupAssetKind = "state" | "config" | "credentials" | "workspace" | "agent";
+type BackupAssetKind = "state" | "config" | "credentials" | "workspace" | "agent" | "skill-link";
 type BackupSkipReason = "covered" | "missing" | "regenerable" | "unresolved";
 
 export type BackupAsset = {
@@ -102,6 +103,8 @@ function backupAssetPriority(kind: BackupAssetKind): number {
       return 3;
     case "agent":
       return 4;
+    case "skill-link":
+      return 5;
   }
   throw new Error("Unsupported backup asset kind");
 }
@@ -249,6 +252,10 @@ async function resolveBackupPlanFromPaths(params: {
       sourcePath: path.resolve(workspaceDir),
     })),
     ...agentRoots.map((root) => ({ kind: "agent" as const, sourcePath: root.sourcePath })),
+    ...(await resolveManagedSkillSymlinkTargetCandidates(stateDir)).map((sourcePath) => ({
+      kind: "skill-link" as const,
+      sourcePath,
+    })),
   ];
 
   const candidates: BackupAssetCandidate[] = await Promise.all(
@@ -375,6 +382,33 @@ function compareCandidates(left: BackupAssetCandidate, right: BackupAssetCandida
     return priorityDelta;
   }
   return left.canonicalPath.localeCompare(right.canonicalPath);
+}
+
+// Managed skill roots deliberately accept directory symlinks resolving outside
+// the root (the `skills` CLI symlink-mode layout), while the archive guard is
+// fail-closed on any link whose target is not a declared asset. Declaring each
+// accepted external target as its own asset keeps such layouts self-contained
+// instead of aborting the archive write.
+async function resolveManagedSkillSymlinkTargetCandidates(stateDir: string): Promise<string[]> {
+  const managedSkillsDir = path.join(stateDir, "skills");
+  let entries: Dirent[];
+  try {
+    entries = await fs.readdir(managedSkillsDir, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+  const canonicalStateDir = await canonicalizePathForContainment(stateDir);
+  const targets: string[] = [];
+  for (const entry of entries) {
+    if (!entry.isSymbolicLink()) {
+      continue;
+    }
+    const targetPath = await canonicalizeExistingPath(path.join(managedSkillsDir, entry.name));
+    if (!isPathWithin(targetPath, canonicalStateDir)) {
+      targets.push(targetPath);
+    }
+  }
+  return targets;
 }
 
 async function canonicalizeExistingPath(targetPath: string): Promise<string> {

--- a/src/commands/backup-shared.ts
+++ b/src/commands/backup-shared.ts
@@ -386,9 +386,9 @@ function compareCandidates(left: BackupAssetCandidate, right: BackupAssetCandida
 
 // Managed skill roots deliberately accept directory symlinks resolving outside
 // the root (the `skills` CLI symlink-mode layout), while the archive guard is
-// fail-closed on any link whose target is not a declared asset. Declaring each
-// accepted external target as its own asset keeps such layouts self-contained
-// instead of aborting the archive write.
+// fail-closed on any link whose target is not a declared asset. Declare only
+// bounded skill targets: a link to a state ancestor or any broad directory
+// would otherwise promote that whole tree to an archive root.
 async function resolveManagedSkillSymlinkTargetCandidates(stateDir: string): Promise<string[]> {
   const managedSkillsDir = path.join(stateDir, "skills");
   let entries: Dirent[];
@@ -403,10 +403,29 @@ async function resolveManagedSkillSymlinkTargetCandidates(stateDir: string): Pro
     if (!entry.isSymbolicLink()) {
       continue;
     }
-    const targetPath = await canonicalizeExistingPath(path.join(managedSkillsDir, entry.name));
-    if (!isPathWithin(targetPath, canonicalStateDir)) {
-      targets.push(targetPath);
+    const linkPath = path.join(managedSkillsDir, entry.name);
+    const targetPath = await canonicalizeExistingPath(linkPath);
+    // Neither side may contain the other: an external target that holds the
+    // state asset would swallow it (and everything else) via covered dedupe.
+    if (
+      isPathWithin(targetPath, canonicalStateDir) ||
+      isPathWithin(canonicalStateDir, targetPath)
+    ) {
+      continue;
     }
+    try {
+      if (!(await fs.stat(linkPath)).isDirectory()) {
+        continue;
+      }
+    } catch {
+      continue;
+    }
+    // Skill loaders only admit directories holding a SKILL.md; anything else
+    // in the managed layout is not a skill worth a declared archive root.
+    if (!(await pathExists(path.join(targetPath, "SKILL.md")))) {
+      continue;
+    }
+    targets.push(targetPath);
   }
   return targets;
 }

--- a/src/commands/backup-shared.ts
+++ b/src/commands/backup-shared.ts
@@ -1,5 +1,6 @@
 // Backup planning helpers for archive naming, payload paths, and deduplicated asset selection.
 import type { Dirent } from "node:fs";
+import { closeSync } from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { listAgentIds, resolveAgentDir } from "../agents/agent-scope-config.js";
@@ -10,6 +11,7 @@ import {
   resolveStateDir,
 } from "../config/config.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { openRootFileSync } from "../infra/boundary-file-read.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import {
   resolveActivatedPluginBackupInventory,
@@ -420,11 +422,21 @@ async function resolveManagedSkillSymlinkTargetCandidates(stateDir: string): Pro
     } catch {
       continue;
     }
-    // Skill loaders only admit directories holding a SKILL.md; anything else
-    // in the managed layout is not a skill worth a declared archive root.
-    if (!(await pathExists(path.join(targetPath, "SKILL.md")))) {
+    // Skill loaders admit a directory only when its metadata opens through the
+    // skill-root boundary; a final SKILL.md symlink that escapes the target
+    // would otherwise satisfy existence and declare a broad external target
+    // whose cross-asset link the archive guard accepts.
+    const opened = openRootFileSync({
+      absolutePath: path.join(targetPath, "SKILL.md"),
+      rootPath: targetPath,
+      rootRealPath: targetPath,
+      boundaryLabel: "skill target",
+      rejectSymlinks: false,
+    });
+    if (!opened.ok) {
       continue;
     }
+    closeSync(opened.fd);
     targets.push(targetPath);
   }
   return targets;

--- a/src/commands/backup-shared.ts
+++ b/src/commands/backup-shared.ts
@@ -1,6 +1,4 @@
 // Backup planning helpers for archive naming, payload paths, and deduplicated asset selection.
-import type { Dirent } from "node:fs";
-import { closeSync } from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { listAgentIds, resolveAgentDir } from "../agents/agent-scope-config.js";
@@ -11,13 +9,20 @@ import {
   resolveStateDir,
 } from "../config/config.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import { openRootFileSync } from "../infra/boundary-file-read.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import {
   resolveActivatedPluginBackupInventory,
   type ActivatedPluginBackupInventory,
 } from "../plugins/manifest-backup-resources.js";
 import type { RuntimeEnv } from "../runtime.js";
+import { loadSingleSkillDirectory } from "../skills/loading/local-loader.js";
+import {
+  discoverSkillCandidates,
+  isSymlinkPath,
+  resolveSkillDiscoveryLimits,
+  type ResolvedSkillDiscoveryLimits,
+} from "../skills/loading/skill-root-discovery.js";
+import { tryRealpath } from "../skills/loading/symlink-targets.js";
 import { recordBackupRunOutcome } from "../state/backup-run-records.js";
 import { pathExists, resolveUserPath, shortenHomePath } from "../utils.js";
 import {
@@ -58,7 +63,7 @@ export function resolveRequiredBackupPath(
   return resolveUserPath(trimmed);
 }
 
-type BackupAssetKind = "state" | "config" | "credentials" | "workspace" | "agent" | "skill-link";
+type BackupAssetKind = "state" | "config" | "credentials" | "workspace" | "agent" | "managed skill";
 type BackupSkipReason = "covered" | "missing" | "regenerable" | "unresolved";
 
 export type BackupAsset = {
@@ -105,7 +110,7 @@ function backupAssetPriority(kind: BackupAssetKind): number {
       return 3;
     case "agent":
       return 4;
-    case "skill-link":
+    case "managed skill":
       return 5;
   }
   throw new Error("Unsupported backup asset kind");
@@ -175,6 +180,7 @@ async function resolveBackupPlanFromPaths(params: {
   onlyConfig?: boolean;
   configInsideState?: boolean;
   oauthInsideState?: boolean;
+  skillDiscoveryLimits?: ResolvedSkillDiscoveryLimits;
   nowMs?: number;
 }): Promise<BackupPlan> {
   const includeWorkspace = params.includeWorkspace ?? true;
@@ -254,10 +260,6 @@ async function resolveBackupPlanFromPaths(params: {
       sourcePath: path.resolve(workspaceDir),
     })),
     ...agentRoots.map((root) => ({ kind: "agent" as const, sourcePath: root.sourcePath })),
-    ...(await resolveManagedSkillSymlinkTargetCandidates(stateDir)).map((sourcePath) => ({
-      kind: "skill-link" as const,
-      sourcePath,
-    })),
   ];
 
   const candidates: BackupAssetCandidate[] = await Promise.all(
@@ -271,6 +273,18 @@ async function resolveBackupPlanFromPaths(params: {
       });
     }),
   );
+  for (const sourcePath of resolveManagedSkillSymlinkTargetCandidates({
+    stateDir,
+    ownerRoots: candidates.map((candidate) => candidate.canonicalPath),
+    limits: params.skillDiscoveryLimits ?? resolveSkillDiscoveryLimits(),
+  })) {
+    candidates.push({
+      kind: "managed skill",
+      sourcePath,
+      canonicalPath: sourcePath,
+      exists: true,
+    });
+  }
 
   const uniqueCandidates: BackupAssetCandidate[] = [];
   const seenCanonicalPaths = new Set<string>();
@@ -386,60 +400,66 @@ function compareCandidates(left: BackupAssetCandidate, right: BackupAssetCandida
   return left.canonicalPath.localeCompare(right.canonicalPath);
 }
 
-// Managed skill roots deliberately accept directory symlinks resolving outside
-// the root (the `skills` CLI symlink-mode layout), while the archive guard is
-// fail-closed on any link whose target is not a declared asset. Declare only
-// bounded skill targets: a link to a state ancestor or any broad directory
-// would otherwise promote that whole tree to an archive root.
-async function resolveManagedSkillSymlinkTargetCandidates(stateDir: string): Promise<string[]> {
-  const managedSkillsDir = path.join(stateDir, "skills");
-  let entries: Dirent[];
-  try {
-    entries = await fs.readdir(managedSkillsDir, { withFileTypes: true });
-  } catch {
-    return [];
-  }
-  const canonicalStateDir = await canonicalizePathForContainment(stateDir);
-  const targets: string[] = [];
-  for (const entry of entries) {
-    if (!entry.isSymbolicLink()) {
-      continue;
-    }
-    const linkPath = path.join(managedSkillsDir, entry.name);
-    const targetPath = await canonicalizeExistingPath(linkPath);
-    // Neither side may contain the other: an external target that holds the
-    // state asset would swallow it (and everything else) via covered dedupe.
+// Managed skill roots support operator-created directory links outside the root.
+// The archive guard requires each such target to be a declared asset.
+function resolveManagedSkillSymlinkTargetCandidates(params: {
+  stateDir: string;
+  ownerRoots: readonly string[];
+  limits: ResolvedSkillDiscoveryLimits;
+}): string[] {
+  const managedSkillsDir = path.join(params.stateDir, "skills");
+  const targets = new Set<string>();
+  const discovered = discoverSkillCandidates({
+    dir: managedSkillsDir,
+    source: "openclaw-managed",
+    limits: params.limits,
+    allowedSymlinkTargetRealPaths: [],
+  });
+  for (const candidate of discovered.candidates) {
     if (
-      isPathWithin(targetPath, canonicalStateDir) ||
-      isPathWithin(canonicalStateDir, targetPath)
+      !loadSingleSkillDirectory({
+        skillDir: candidate.skillDir,
+        source: "openclaw-managed",
+        rootRealPath: candidate.skillDirRealPath,
+        maxBytes: params.limits.maxSkillFileBytes,
+      })
     ) {
       continue;
     }
-    try {
-      if (!(await fs.stat(linkPath)).isDirectory()) {
+
+    const relativeSkillDir = path.relative(managedSkillsDir, candidate.skillDir);
+    if (
+      path.isAbsolute(relativeSkillDir) ||
+      relativeSkillDir === ".." ||
+      relativeSkillDir.startsWith(`..${path.sep}`)
+    ) {
+      continue;
+    }
+    // The archive preserves every lexical link component, so each external
+    // ancestor target needs its own asset before the accepted skill can restore.
+    const components = [managedSkillsDir];
+    for (const segment of relativeSkillDir.split(path.sep).filter(Boolean)) {
+      components.push(path.join(components.at(-1) ?? managedSkillsDir, segment));
+    }
+    for (const component of components) {
+      if (!isSymlinkPath(component)) {
         continue;
       }
-    } catch {
-      continue;
+      const targetPath = tryRealpath(component);
+      // A broader target must not swallow another owner root during dedupe.
+      // An inner target is already covered and needs no separate asset.
+      if (
+        !targetPath ||
+        params.ownerRoots.some(
+          (ownerRoot) => isPathWithin(targetPath, ownerRoot) || isPathWithin(ownerRoot, targetPath),
+        )
+      ) {
+        continue;
+      }
+      targets.add(targetPath);
     }
-    // Skill loaders admit a directory only when its metadata opens through the
-    // skill-root boundary; a final SKILL.md symlink that escapes the target
-    // would otherwise satisfy existence and declare a broad external target
-    // whose cross-asset link the archive guard accepts.
-    const opened = openRootFileSync({
-      absolutePath: path.join(targetPath, "SKILL.md"),
-      rootPath: targetPath,
-      rootRealPath: targetPath,
-      boundaryLabel: "skill target",
-      rejectSymlinks: false,
-    });
-    if (!opened.ok) {
-      continue;
-    }
-    closeSync(opened.fd);
-    targets.push(targetPath);
   }
-  return targets;
+  return [...targets];
 }
 
 async function canonicalizeExistingPath(targetPath: string): Promise<string> {
@@ -556,6 +576,7 @@ export async function resolveBackupPlanFromDisk(
     onlyConfig,
     configInsideState: cleanupPlan.configInsideState,
     oauthInsideState: cleanupPlan.oauthInsideState,
+    skillDiscoveryLimits: resolveSkillDiscoveryLimits(discoverySnapshot.config),
     nowMs: params.nowMs,
   });
 }

--- a/src/infra/backup-create.test.ts
+++ b/src/infra/backup-create.test.ts
@@ -687,6 +687,66 @@ describe("createBackupArchive", () => {
     },
   );
 
+  it.runIf(process.platform !== "win32")(
+    "does not promote a managed-skill link to its state ancestor into an archive root",
+    async () => {
+      await withOpenClawTestState(
+        {
+          layout: "state-only",
+          prefix: "openclaw-backup-skill-symlink-ancestor-",
+          scenario: "minimal",
+        },
+        async (state) => {
+          await fs.mkdir(state.statePath("skills"), { recursive: true });
+          // Relative ancestor link: `../..` from <stateDir>/skills resolves to
+          // the directory holding the state asset.
+          await fs.symlink(path.join("..", ".."), state.statePath("skills", "escape"), "dir");
+
+          // An ancestor must not become a declared root: that would let the
+          // covered dedupe swallow the state asset and tar the whole ancestor
+          // tree. The planner declines, so the archive write stays fail-closed.
+          await expect(
+            createBackupArchive({
+              output: state.path("backup.tar.gz"),
+              includeWorkspace: false,
+            }),
+          ).rejects.toThrow(/symbolic link is outside the declared backup assets/iu);
+        },
+      );
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
+    "does not declare an external managed-skill link whose target is not a skill directory",
+    async () => {
+      await withOpenClawTestState(
+        {
+          layout: "state-only",
+          prefix: "openclaw-backup-skill-symlink-unbounded-",
+          scenario: "minimal",
+        },
+        async (state) => {
+          const broadTarget = path.join(await fs.realpath(state.root), "broad");
+          await fs.mkdir(broadTarget, { recursive: true });
+          await fs.writeFile(path.join(broadTarget, "notes.txt"), "not a skill", "utf8");
+          await fs.mkdir(state.statePath("skills"), { recursive: true });
+          await fs.symlink(
+            path.join("..", "..", "broad"),
+            state.statePath("skills", "broad"),
+            "dir",
+          );
+
+          await expect(
+            createBackupArchive({
+              output: state.path("backup.tar.gz"),
+              includeWorkspace: false,
+            }),
+          ).rejects.toThrow(/symbolic link is outside the declared backup assets/iu);
+        },
+      );
+    },
+  );
+
   it("includes a configured external agent directory when workspaces are excluded", async () => {
     await withOpenClawTestState(
       {

--- a/src/infra/backup-create.test.ts
+++ b/src/infra/backup-create.test.ts
@@ -747,6 +747,48 @@ describe("createBackupArchive", () => {
     },
   );
 
+  it.runIf(process.platform !== "win32")(
+    "does not declare an external managed-skill target whose SKILL.md escapes into the state asset",
+    async () => {
+      await withOpenClawTestState(
+        {
+          layout: "state-only",
+          prefix: "openclaw-backup-skill-metadata-escape-",
+          scenario: "minimal",
+        },
+        async (state) => {
+          const skillTarget = path.join(await fs.realpath(state.root), "agents-skills", "escaped");
+          await fs.mkdir(skillTarget, { recursive: true });
+          await fs.writeFile(state.statePath("payload.md"), "state payload\n", "utf8");
+          // Final metadata symlink, relative like the `skills` CLI writes: an
+          // existence check that follows it would admit the broad external
+          // target, and the archive guard accepts the cross-asset link because
+          // both ends resolve to declared assets.
+          await fs.symlink(
+            path.relative(skillTarget, state.statePath("payload.md")),
+            path.join(skillTarget, "SKILL.md"),
+            "file",
+          );
+          await fs.mkdir(state.statePath("skills"), { recursive: true });
+          await fs.symlink(
+            path.join("..", "..", "agents-skills", "escaped"),
+            state.statePath("skills", "escaped"),
+            "dir",
+          );
+
+          // The planner declines the escaping metadata, so the state asset's
+          // external link has no declared target and the write stays fail-closed.
+          await expect(
+            createBackupArchive({
+              output: state.path("backup.tar.gz"),
+              includeWorkspace: false,
+            }),
+          ).rejects.toThrow(/symbolic link is outside the declared backup assets/iu);
+        },
+      );
+    },
+  );
+
   it("includes a configured external agent directory when workspaces are excluded", async () => {
     await withOpenClawTestState(
       {

--- a/src/infra/backup-create.test.ts
+++ b/src/infra/backup-create.test.ts
@@ -8,7 +8,7 @@ import * as tar from "tar";
 import { describe, expect, it, vi } from "vitest";
 import { saveAuthProfileStore } from "../agents/auth-profiles/store.js";
 import { backupRestoreCommand } from "../commands/backup-restore.js";
-import { backupVerifyCommand } from "../commands/backup-verify.js";
+import { backupVerifyCommand, verifyBackupArchive } from "../commands/backup-verify.js";
 import { CONFIG_AUDIT_MAX_ENTRIES, CONFIG_AUDIT_SCOPE } from "../config/io.audit.js";
 import { resolveGatewayLockDir } from "../config/paths.js";
 import type { RuntimeEnv } from "../runtime.js";
@@ -606,6 +606,87 @@ describe("createBackupVolatileStatCache", () => {
 });
 
 describe("createBackupArchive", () => {
+  it.runIf(process.platform !== "win32")(
+    "archives an external managed-skill symlink target as a declared skill-link asset",
+    async () => {
+      await withOpenClawTestState(
+        {
+          layout: "state-only",
+          prefix: "openclaw-backup-skill-symlink-",
+          scenario: "minimal",
+        },
+        async (state) => {
+          const skillTarget = path.join(await fs.realpath(state.root), "agents-skills", "demo");
+          await fs.mkdir(skillTarget, { recursive: true });
+          await fs.writeFile(
+            path.join(skillTarget, "SKILL.md"),
+            "---\nname: demo\ndescription: Symlinked managed skill\n---\n",
+            "utf8",
+          );
+          await fs.mkdir(state.statePath("skills"), { recursive: true });
+          // Relative target, the exact shape the `skills` CLI symlink mode writes.
+          await fs.symlink(
+            path.join("..", "..", "agents-skills", "demo"),
+            state.statePath("skills", "demo"),
+            "dir",
+          );
+
+          const archive = await createBackupArchive({
+            output: state.path("backup.tar.gz"),
+            includeWorkspace: false,
+          });
+          expect(archive.assets).toEqual(
+            expect.arrayContaining([
+              expect.objectContaining({ kind: "skill-link", sourcePath: skillTarget }),
+            ]),
+          );
+          const entries = await listArchiveEntries(archive.archivePath);
+          expect(entries.some((entry) => entry.endsWith("/agents-skills/demo/SKILL.md"))).toBe(
+            true,
+          );
+
+          await expect(verifyBackupArchive(archive.archivePath)).resolves.toMatchObject({
+            ok: true,
+          });
+        },
+      );
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
+    "keeps managed-skill symlinks resolving inside the state asset undeclared",
+    async () => {
+      await withOpenClawTestState(
+        {
+          layout: "state-only",
+          prefix: "openclaw-backup-skill-symlink-internal-",
+          scenario: "minimal",
+        },
+        async (state) => {
+          const skillTarget = state.statePath("skill-sources", "demo");
+          await fs.mkdir(skillTarget, { recursive: true });
+          await fs.writeFile(path.join(skillTarget, "SKILL.md"), "---\nname: demo\n---\n", "utf8");
+          await fs.mkdir(state.statePath("skills"), { recursive: true });
+          await fs.symlink(
+            path.join("..", "skill-sources", "demo"),
+            state.statePath("skills", "demo"),
+            "dir",
+          );
+
+          const archive = await createBackupArchive({
+            output: state.path("backup.tar.gz"),
+            includeWorkspace: false,
+          });
+          expect(archive.assets.some((asset) => asset.kind === "skill-link")).toBe(false);
+          const entries = await listArchiveEntries(archive.archivePath);
+          expect(entries.some((entry) => entry.endsWith("/skill-sources/demo/SKILL.md"))).toBe(
+            true,
+          );
+        },
+      );
+    },
+  );
+
   it("includes a configured external agent directory when workspaces are excluded", async () => {
     await withOpenClawTestState(
       {

--- a/src/infra/backup-create.test.ts
+++ b/src/infra/backup-create.test.ts
@@ -606,9 +606,28 @@ describe("createBackupVolatileStatCache", () => {
 });
 
 describe("createBackupArchive", () => {
-  it.runIf(process.platform !== "win32")(
-    "archives an external managed-skill symlink target as a declared skill-link asset",
-    async () => {
+  it.runIf(process.platform !== "win32").each([
+    {
+      layout: "direct",
+      linkSegments: ["demo"],
+      linkTargetSegments: ["demo"],
+      skillSegments: ["demo"],
+    },
+    {
+      layout: "grouped",
+      linkSegments: ["team", "demo"],
+      linkTargetSegments: ["demo"],
+      skillSegments: ["demo"],
+    },
+    {
+      layout: "group link",
+      linkSegments: ["team"],
+      linkTargetSegments: ["team"],
+      skillSegments: ["team", "demo"],
+    },
+  ])(
+    "archives a $layout external managed-skill target and verifies its payload",
+    async ({ linkSegments, linkTargetSegments, skillSegments }) => {
       await withOpenClawTestState(
         {
           layout: "state-only",
@@ -616,72 +635,39 @@ describe("createBackupArchive", () => {
           scenario: "minimal",
         },
         async (state) => {
-          const skillTarget = path.join(await fs.realpath(state.root), "agents-skills", "demo");
+          const externalRoot = path.join(await fs.realpath(state.root), "agents-skills");
+          const skillTarget = path.join(externalRoot, ...skillSegments);
           await fs.mkdir(skillTarget, { recursive: true });
           await fs.writeFile(
             path.join(skillTarget, "SKILL.md"),
             "---\nname: demo\ndescription: Symlinked managed skill\n---\n",
             "utf8",
           );
-          await fs.mkdir(state.statePath("skills"), { recursive: true });
-          // Relative target, the exact shape the `skills` CLI symlink mode writes.
-          await fs.symlink(
-            path.join("..", "..", "agents-skills", "demo"),
-            state.statePath("skills", "demo"),
-            "dir",
-          );
+          await fs.writeFile(path.join(skillTarget, "operator-data.txt"), "keep me\n", "utf8");
+          const linkPath = state.statePath("skills", ...linkSegments);
+          const linkTarget = path.join(externalRoot, ...linkTargetSegments);
+          await fs.mkdir(path.dirname(linkPath), { recursive: true });
+          // Operator-managed roots support relative directory links outside the state root.
+          await fs.symlink(path.relative(path.dirname(linkPath), linkTarget), linkPath, "dir");
 
           const archive = await createBackupArchive({
             output: state.path("backup.tar.gz"),
             includeWorkspace: false,
           });
-          expect(archive.assets).toEqual(
-            expect.arrayContaining([
-              expect.objectContaining({ kind: "skill-link", sourcePath: skillTarget }),
-            ]),
-          );
           const entries = await listArchiveEntries(archive.archivePath);
-          expect(entries.some((entry) => entry.endsWith("/agents-skills/demo/SKILL.md"))).toBe(
-            true,
-          );
+          const skillSuffix = path.posix.join("/agents-skills", ...skillSegments, "SKILL.md");
+          expect(entries.some((entry) => entry.endsWith(skillSuffix))).toBe(true);
+          expect(
+            entries.some((entry) =>
+              entry.endsWith(
+                path.posix.join("/agents-skills", ...skillSegments, "operator-data.txt"),
+              ),
+            ),
+          ).toBe(true);
 
           await expect(verifyBackupArchive(archive.archivePath)).resolves.toMatchObject({
             ok: true,
           });
-        },
-      );
-    },
-  );
-
-  it.runIf(process.platform !== "win32")(
-    "keeps managed-skill symlinks resolving inside the state asset undeclared",
-    async () => {
-      await withOpenClawTestState(
-        {
-          layout: "state-only",
-          prefix: "openclaw-backup-skill-symlink-internal-",
-          scenario: "minimal",
-        },
-        async (state) => {
-          const skillTarget = state.statePath("skill-sources", "demo");
-          await fs.mkdir(skillTarget, { recursive: true });
-          await fs.writeFile(path.join(skillTarget, "SKILL.md"), "---\nname: demo\n---\n", "utf8");
-          await fs.mkdir(state.statePath("skills"), { recursive: true });
-          await fs.symlink(
-            path.join("..", "skill-sources", "demo"),
-            state.statePath("skills", "demo"),
-            "dir",
-          );
-
-          const archive = await createBackupArchive({
-            output: state.path("backup.tar.gz"),
-            includeWorkspace: false,
-          });
-          expect(archive.assets.some((asset) => asset.kind === "skill-link")).toBe(false);
-          const entries = await listArchiveEntries(archive.archivePath);
-          expect(entries.some((entry) => entry.endsWith("/skill-sources/demo/SKILL.md"))).toBe(
-            true,
-          );
         },
       );
     },
@@ -697,6 +683,11 @@ describe("createBackupArchive", () => {
           scenario: "minimal",
         },
         async (state) => {
+          await fs.writeFile(
+            path.join(await fs.realpath(state.root), "SKILL.md"),
+            "---\nname: broad\ndescription: Broad target\n---\n",
+            "utf8",
+          );
           await fs.mkdir(state.statePath("skills"), { recursive: true });
           // Relative ancestor link: `../..` from <stateDir>/skills resolves to
           // the directory holding the state asset.
@@ -717,7 +708,46 @@ describe("createBackupArchive", () => {
   );
 
   it.runIf(process.platform !== "win32")(
-    "does not declare an external managed-skill link whose target is not a skill directory",
+    "does not promote a managed-skill target containing another backup owner",
+    async () => {
+      await withOpenClawTestState(
+        {
+          layout: "state-only",
+          prefix: "openclaw-backup-skill-owner-ancestor-",
+          scenario: "minimal",
+        },
+        async (state) => {
+          const broadTarget = path.join(await fs.realpath(state.root), "broad-skill");
+          const configPath = path.join(broadTarget, "openclaw.json");
+          state.envVars.OPENCLAW_CONFIG_PATH = configPath;
+          state.applyEnv();
+          await fs.mkdir(broadTarget, { recursive: true });
+          await fs.writeFile(
+            path.join(broadTarget, "SKILL.md"),
+            "---\nname: broad\ndescription: Broad target\n---\n",
+            "utf8",
+          );
+          await fs.writeFile(configPath, "{}\n", "utf8");
+          await fs.mkdir(state.statePath("skills"), { recursive: true });
+          await fs.symlink(
+            path.join("..", "..", "broad-skill"),
+            state.statePath("skills", "broad"),
+            "dir",
+          );
+
+          await expect(
+            createBackupArchive({
+              output: state.path("backup.tar.gz"),
+              includeWorkspace: false,
+            }),
+          ).rejects.toThrow(/symbolic link is outside the declared backup assets/iu);
+        },
+      );
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
+    "does not declare an external managed-skill target with incomplete metadata",
     async () => {
       await withOpenClawTestState(
         {
@@ -728,7 +758,8 @@ describe("createBackupArchive", () => {
         async (state) => {
           const broadTarget = path.join(await fs.realpath(state.root), "broad");
           await fs.mkdir(broadTarget, { recursive: true });
-          await fs.writeFile(path.join(broadTarget, "notes.txt"), "not a skill", "utf8");
+          await fs.writeFile(path.join(broadTarget, "SKILL.md"), "---\nname: broad\n---\n", "utf8");
+          await fs.writeFile(path.join(broadTarget, "unrelated.txt"), "do not archive\n", "utf8");
           await fs.mkdir(state.statePath("skills"), { recursive: true });
           await fs.symlink(
             path.join("..", "..", "broad"),
@@ -760,8 +791,8 @@ describe("createBackupArchive", () => {
           const skillTarget = path.join(await fs.realpath(state.root), "agents-skills", "escaped");
           await fs.mkdir(skillTarget, { recursive: true });
           await fs.writeFile(state.statePath("payload.md"), "state payload\n", "utf8");
-          // Final metadata symlink, relative like the `skills` CLI writes: an
-          // existence check that follows it would admit the broad external
+          // A final metadata symlink is not a valid managed skill: an existence
+          // check that follows it would admit the broad external
           // target, and the archive guard accepts the cross-asset link because
           // both ends resolve to declared assets.
           await fs.symlink(

--- a/src/skills/loading/local-loader.ts
+++ b/src/skills/loading/local-loader.ts
@@ -14,7 +14,7 @@ import {
   type Skill,
 } from "./skill-contract.js";
 
-type LoadedLocalSkill = {
+export type LoadedLocalSkill = {
   skill: Skill;
   frontmatter: ParsedSkillFrontmatter;
 };
@@ -65,7 +65,7 @@ function readSkillFileSync(params: {
   }
 }
 
-function loadSingleSkillDirectory(params: {
+export function loadSingleSkillDirectory(params: {
   skillDir: string;
   source: string;
   rootRealPath: string;

--- a/src/skills/loading/skill-root-discovery.ts
+++ b/src/skills/loading/skill-root-discovery.ts
@@ -223,7 +223,7 @@ function hasCandidateSymlinkChild(
   return false;
 }
 
-function isSymlinkPath(filePath: string): boolean {
+export function isSymlinkPath(filePath: string): boolean {
   try {
     return fs.lstatSync(filePath).isSymbolicLink();
   } catch {


### PR DESCRIPTION
## What Problem This Solves

Fixes #132865.

Operator-managed skills can use a directory symlink under `state/skills/` that points to a skill outside the state directory. Full backup planning declared the state directory but omitted that external target. The archive writer does not follow symlinks and correctly rejects links outside declared assets, so `openclaw backup create` failed and published no recovery artifact.

## Root cause

`src/commands/backup-shared.ts` owns the source inventory. It only produced state, config, credentials, workspace, and agent candidates. The external managed-skill target never became an explicit archive input.

## Fix

- Reuse bounded managed-skill discovery so direct and grouped symlinked skill directories follow the same candidate limits as loading.
- Accept a target only when the existing exact-directory skill loader validates its contained `SKILL.md`, parses its frontmatter, finds required fields, and applies the configured file-size limit.
- Retain each external symlink component that leads to an accepted skill, including a symlinked grouping directory.
- Require each new target to be disjoint from every canonical state, config, credentials, workspace, and agent owner root.
- Declare each accepted target as a `managed skill` asset without weakening archive, verify, or restore link guards.

The all-owner overlap check prevents a broad skill target from swallowing a narrower config, credentials, workspace, or agent asset during candidate deduplication.

## Evidence

Exact current main at reproduction: `a6446347b12af1014f42b72ede507d825cdf11b8`.

Fixture: `<state>/skills/demo -> ../../external/demo`, with a valid `SKILL.md` and a distinct `operator-payload.txt` under the external target.

```text
openclaw backup create --output <archive> --no-include-workspace --json
exit 1: Archive symbolic link is outside the declared backup assets

openclaw backup verify <archive> --json
exit 1: Archive does not exist
```

Exact repaired head: `9de774372732d8a54a3f065263027dc6ea0dfb42`.

```text
openclaw backup create --output <archive> --no-include-workspace --json
exit 0: state and managed skill assets declared

openclaw backup verify <archive> --json
exit 0: ok=true, assetCount=2, entryCount=7, symlinkCount=1
```

Archive inspection found the original relative symlink, the external `SKILL.md`, and the distinct external payload marker.

The grouped-leaf layout `<state>/skills/team/demo -> ../../../external/demo` and grouped-root layout `<state>/skills/team -> ../../external/team` also passed create and verify. Each archive reported two assets, eight entries, one symlink, and its distinct external payload marker.

## Safety and tests

- The new all-owner regression failed on the prior candidate because the broad skill target was archived and the configured path was reported as covered.
- The same regression passes after the repair and the unsafe link stays fail-closed.
- The incomplete-metadata regression failed before full skill validation because a directory missing the required description was archived; it now stays fail-closed.
- `node scripts/run-vitest.mjs src/infra/backup-create.test.ts`: 89 passed.
- Skill discovery and containment suites: 41 passed.
- Focused format, Oxlint, import-cycle, dead-export, dependency, database, and repository ratchet checks passed.
- Hosted CI owns TypeScript checks for this host.

## Change size

- Production: +90/-4, net +86.
- Tests: +215/-1, net +214.

The production growth is required to discover, validate, and explicitly archive an external owner path. A verify-only, restore-only, or generic link-guard change cannot add the missing payload without weakening the existing safety boundary.
