### PR TITLE
refactor(doctor): share Claude directory problem formatting

### DIFF
--- a/src/commands/doctor-claude-cli.ts
+++ b/src/commands/doctor-claude-cli.ts
@@ -75,32 +75,12 @@ function probeDirectoryHealth(dirPath: string): ClaudeCliDirHealth {
   return "present";
 }
 
-function formatWorkspaceProblemLine(
-  workspaceDir: string,
+function formatDirectoryProblemLine(
+  dirPath: string,
   health: ClaudeCliDirHealth,
-  agentId?: string,
+  label: string,
 ): string | null {
-  const label = agentId ? `Agent ${agentId} workspace` : "Workspace";
-  const display = shortenHomePath(workspaceDir);
-  if (health === "present" || health === "missing") {
-    return null;
-  }
-  if (health === "not_directory") {
-    return `- ${label}: ${display} exists but is not a directory.`;
-  }
-  if (health === "unreadable") {
-    return `- ${label}: ${display} is not readable by this user.`;
-  }
-  return `- ${label}: ${display} is not writable by this user.`;
-}
-
-function formatProjectDirProblemLine(
-  projectDir: string,
-  health: ClaudeCliDirHealth,
-  agentId?: string,
-): string | null {
-  const label = agentId ? `Agent ${agentId} Claude project dir` : "Claude project dir";
-  const display = shortenHomePath(projectDir);
+  const display = shortenHomePath(dirPath);
   if (health === "present" || health === "missing") {
     return null;
   }
@@ -235,10 +215,10 @@ export function noteClaudeCliHealth(
 
   for (const target of workspaceTargets) {
     const agentLabel = showAgentLabels ? target.agentId : undefined;
-    const workspaceProblem = formatWorkspaceProblemLine(
+    const workspaceProblem = formatDirectoryProblemLine(
       target.workspaceDir,
       target.workspaceHealth,
-      agentLabel,
+      agentLabel ? `Agent ${agentLabel} workspace` : "Workspace",
     );
     if (workspaceProblem) {
       lines.push(workspaceProblem);
@@ -255,10 +235,10 @@ export function noteClaudeCliHealth(
       );
     }
 
-    const projectDirProblem = formatProjectDirProblemLine(
+    const projectDirProblem = formatDirectoryProblemLine(
       target.projectDir,
       target.projectDirHealth,
-      agentLabel,
+      agentLabel ? `Agent ${agentLabel} Claude project dir` : "Claude project dir",
     );
     if (projectDirProblem) {
       lines.push(projectDirProblem);


### PR DESCRIPTION
## What Problem This Solves

Claude CLI doctor diagnostics had two copies of the same directory-problem formatting policy. Keeping workspace and project-directory wording in separate implementations made future drift possible.

## Why This Change Was Made

The doctor command now uses one private directory-problem formatter while each call site continues to own its exact label. Healthy/missing suppression, path shortening, diagnostic ordering, and fix-hint behavior are unchanged.

The canonical owner remains `src/commands/doctor-claude-cli.ts`; no shared utility, public API, config, persistence, or compatibility surface is introduced.

## User Impact

No user-visible behavior change. Claude CLI doctor output remains byte-for-byte equivalent for the affected directory health states.

## Evidence

- Focused `src/commands/doctor-claude-cli.test.ts`: 8/8 passed.
- `oxfmt --check`: passed.
- `pnpm tsgo:core`: passed.
- `git diff --check`: passed.
- Mandatory local Sol autoreview: clean, correctness 0.99.
- Production delta: +8/-28, net -20; tests +0/-0.
- `check-changed` passed its applicable ratchets, then its dead-export scan could not load tracked UI config files omitted by the sparse worktree. This draft will remain unready until the hydrated native review lane resolves that environment-only gap.

Root cause: duplicated presentation policy inside the Claude CLI doctor owner.

Canonical fix: one private formatter parameterized by directory path, health, and caller-owned label.

Removed paths: the separate workspace and Claude project-directory formatter implementations.

Sibling coverage: both workspace and project-directory call sites use the canonical formatter; their distinct fix-hint policies remain untouched.
