### PR TITLE
test(desktop): make Unix socket fixture support explicit

### DIFF
--- a/src/gateway/desktop/observe-bridge.test.ts
+++ b/src/gateway/desktop/observe-bridge.test.ts
@@ -4,6 +4,7 @@ import net from "node:net";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { WebSocket } from "ws";
+import { createDeferred } from "../../../test/helpers/promise.js";
 import {
   DESKTOP_OBSERVE_PATH,
   handleDesktopObserveUpgrade,
@@ -43,13 +44,10 @@ async function createProxyHarness(
   const root = await fs.mkdtemp(path.join(await fs.realpath("/tmp"), "oc-desktop-observe-"));
   const localSocketPath = path.join(root, "desktop.sock");
   let desktopPeer: net.Socket | undefined;
-  let resolvePeer: (socket: net.Socket) => void = () => {};
-  const peerConnected = new Promise<net.Socket>((resolve) => {
-    resolvePeer = resolve;
-  });
+  const peerConnected = createDeferred<net.Socket>();
   const server = net.createServer((socket) => {
     desktopPeer = socket;
-    resolvePeer(socket);
+    peerConnected.resolve(socket);
   });
   cleanup.push(async () => {
     desktopPeer?.destroy();
@@ -108,7 +106,13 @@ async function createProxyHarness(
     ws.once("open", resolve);
     ws.once("error", reject);
   });
-  return { closeObserver, desktopPeer: await peerConnected, observerUrl: ws.url, release, ws };
+  return {
+    closeObserver,
+    desktopPeer: await peerConnected.promise,
+    observerUrl: ws.url,
+    release,
+    ws,
+  };
 }
 
 function readSocketBytes(socket: net.Socket, byteLength: number): Promise<Buffer> {
@@ -141,7 +145,7 @@ async function expectUnauthorizedObserver(url: string): Promise<void> {
   });
 }
 
-describe("worker desktop observer proxy", () => {
+describe.runIf(process.platform !== "win32")("worker desktop observer proxy", () => {
   it("clears the credential-bearing token timer when the token is consumed", async () => {
     const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
     const clearTimeoutSpy = vi.spyOn(globalThis, "clearTimeout");


### PR DESCRIPTION
Related: #132965

## What Problem This Solves

Direct Windows runs of the desktop observer suite attempt Unix socket fixtures even though Node uses named pipes there. The proxy tests require a Unix socket; the independent token test does not. This is a maintainer-requested follow-up to the socket fixture repair in #132965.

## Why This Change Was Made

Skip only the Unix-dependent proxy describe block on Windows, matching the CUA and OpenShell fixture guards. Replace the mutable no-op resolver with the existing deferred-promise helper. Keep the short socket root, error-observing startup, resource-owned cleanup, and all transport assertions unchanged.

## User Impact

No production behavior change. Direct Windows test runs explicitly skip unsupported Unix proxy fixtures while retaining token coverage. Production LOC: +0/-0; tests: +11/-7.

## Evidence

- `node scripts/run-vitest.mjs src/gateway/desktop/observe-bridge.test.ts`: all 8 tests pass on macOS after the change.
- The broader pre-follow-up fixture run passed 24 tests across desktop observe, CUA MCP transport, and the OpenShell mirror sibling.
- Real occupied Unix socket and HTTP port faults against the revised fixture both surfaced `EADDRINUSE` and removed the fixture root during cleanup.
- Fresh Codex autoreview: no accepted/actionable findings at the configured P0 threshold. Independent manual review also checked cleanup order, fixture helpers, and Windows CI selection.
- `git diff --check` passed.
- Exact-head CI passed for `4e2ee393a8977ec14214e9898b9b9d2a2d287675`: https://github.com/openclaw/openclaw/actions/runs/33285472035.
- Full changed checks passed (exit 0) on Blacksmith Testbox: https://github.com/openclaw/openclaw/actions/runs/33285366861. Its source snapshot includes these exact fixture bytes together with the original socket-path repair. The lease is completed.

Limitations: native Windows execution was not performed; the guard uses the same existing platform condition as adjacent Unix-socket fixtures. The original OpenShell Docker E2E limitation remains documented in #132965; this follow-up does not change that fixture.

AI-assisted maintainer review and cleanup.

Named follow-ups remain outside this change: the production SSH desktop-tunnel path-length analogue recorded in #132965, and OpenShell mirror fixtures under longer ambient `TMPDIR` roots. The unchanged mirror sibling bound successfully at 100 bytes and passed all 13 tests in this review.
