### PR TITLE
perf(time): reuse explicit timezone formatters

### DIFF
--- a/src/auto-reply/envelope.ts
+++ b/src/auto-reply/envelope.ts
@@ -127,35 +127,23 @@ export function formatAgentEnvelopeTimestamp(
     return undefined;
   }
   const zone = resolveEnvelopeTimezone(resolved);
-  // Include a weekday prefix so models do not need to derive DOW from the date
-  // (small models are notoriously unreliable at that).
-  const weekday = (() => {
-    try {
-      if (zone.mode === "utc") {
-        return new Intl.DateTimeFormat("en-US", { timeZone: "UTC", weekday: "short" }).format(date);
-      }
-      if (zone.mode === "local") {
-        return new Intl.DateTimeFormat("en-US", { weekday: "short" }).format(date);
-      }
-      return new Intl.DateTimeFormat("en-US", { timeZone: zone.timeZone, weekday: "short" }).format(
-        date,
-      );
-    } catch {
-      return undefined;
-    }
-  })();
-
-  const formatted =
-    zone.mode === "utc"
-      ? formatUtcTimestamp(date, { displaySeconds: true })
-      : zone.mode === "local"
-        ? formatZonedTimestamp(date, { displaySeconds: true })
-        : formatZonedTimestamp(date, { timeZone: zone.timeZone, displaySeconds: true });
-
-  if (!formatted) {
-    return undefined;
+  // Include the weekday so models do not need to derive it from the date.
+  if (zone.mode !== "utc") {
+    return formatZonedTimestamp(date, {
+      timeZone: zone.mode === "iana" ? zone.timeZone : undefined,
+      displaySeconds: true,
+      displayWeekday: true,
+    });
   }
-  return weekday ? `${weekday} ${formatted}` : formatted;
+  const formatted = formatUtcTimestamp(date, { displaySeconds: true });
+  try {
+    const weekday = new Intl.DateTimeFormat("en-US", { timeZone: "UTC", weekday: "short" }).format(
+      date,
+    );
+    return `${weekday} ${formatted}`;
+  } catch {
+    return formatted;
+  }
 }
 
 function resolveDirectEnvelopeBodyLabel(from: string | undefined): string {

--- a/src/gateway/server-methods/agent-timestamp.ts
+++ b/src/gateway/server-methods/agent-timestamp.ts
@@ -39,17 +39,12 @@ export function buildTimestampPrefix(
   date: Date,
   opts?: Pick<TimestampInjectionOptions, "timezone">,
 ): string | undefined {
-  const timezone = opts?.timezone ?? "UTC";
-  const formatted = formatZonedTimestamp(date, { timeZone: timezone });
-  if (!formatted) {
-    return undefined;
-  }
-  // 3-letter DOW: small models (8B) can't reliably derive day-of-week from
-  // a date, and may treat a bare "Wed" as a typo. Costs ~1 token.
-  const dow = new Intl.DateTimeFormat("en-US", { timeZone: timezone, weekday: "short" }).format(
-    date,
-  );
-  return `[${dow} ${formatted}] `;
+  // The weekday keeps date reasoning reliable without another Intl formatter.
+  const formatted = formatZonedTimestamp(date, {
+    timeZone: opts?.timezone ?? "UTC",
+    displayWeekday: true,
+  });
+  return formatted ? `[${formatted}] ` : undefined;
 }
 
 /**

--- a/src/infra/format-time/format-datetime.ts
+++ b/src/infra/format-time/format-datetime.ts
@@ -76,7 +76,11 @@ type FormatTimestampOptions = {
 type FormatZonedTimestampOptions = FormatTimestampOptions & {
   /** IANA timezone string (e.g., 'America/New_York'). Default: system timezone */
   timeZone?: string;
+  /** Include an abbreviated weekday before the date. Default: false */
+  displayWeekday?: boolean;
 };
+
+let zonedTimestampFormatter: { key: string; formatter: Intl.DateTimeFormat } | undefined;
 
 /**
  * Format a Date as a UTC timestamp string.
@@ -110,38 +114,42 @@ export function formatZonedTimestamp(
   options?: FormatZonedTimestampOptions,
 ): string | undefined {
   try {
-    const intlOptions: Intl.DateTimeFormatOptions = {
-      timeZone: options?.timeZone,
-      year: "numeric",
-      month: "2-digit",
-      day: "2-digit",
-      hour: "2-digit",
-      minute: "2-digit",
-      hourCycle: "h23",
-      timeZoneName: "short",
-    };
-    if (options?.displaySeconds) {
-      intlOptions.second = "2-digit";
+    const { timeZone, displaySeconds = false, displayWeekday = false } = options ?? {};
+    const key = `${timeZone}|${displaySeconds}|${displayWeekday}`;
+    // Keep only the most recent explicit-zone formatter. An omitted zone must
+    // follow the current host timezone, which Intl captures at construction.
+    let formatter =
+      timeZone !== undefined && zonedTimestampFormatter?.key === key
+        ? zonedTimestampFormatter.formatter
+        : undefined;
+    if (!formatter) {
+      formatter = new Intl.DateTimeFormat("en-US", {
+        timeZone,
+        year: "numeric",
+        month: "2-digit",
+        day: "2-digit",
+        hour: "2-digit",
+        minute: "2-digit",
+        hourCycle: "h23",
+        timeZoneName: "short",
+        second: displaySeconds ? "2-digit" : undefined,
+        weekday: displayWeekday ? "short" : undefined,
+      });
+      if (timeZone !== undefined) {
+        zonedTimestampFormatter = { key, formatter };
+      }
     }
-    const parts = new Intl.DateTimeFormat("en-US", intlOptions).formatToParts(date);
-    const pick = (type: string) => parts.find((part) => part.type === type)?.value;
-    const yyyy = pick("year");
-    const mm = pick("month");
-    const dd = pick("day");
-    const hh = pick("hour");
-    const min = pick("minute");
-    const sec = options?.displaySeconds ? pick("second") : undefined;
-    const tz = [...parts]
-      .toReversed()
-      .find((part) => part.type === "timeZoneName")
-      ?.value?.trim();
-    if (!yyyy || !mm || !dd || !hh || !min) {
+    const parts = Object.fromEntries(
+      formatter.formatToParts(date).map(({ type, value }) => [type, value]),
+    );
+    const { year, month, day, hour, minute, second, weekday } = parts;
+    const tz = parts.timeZoneName?.trim();
+    if (!year || !month || !day || !hour || !minute || (displayWeekday && !weekday)) {
       return undefined;
     }
-    if (options?.displaySeconds && sec) {
-      return `${yyyy}-${mm}-${dd} ${hh}:${min}:${sec}${tz ? ` ${tz}` : ""}`;
-    }
-    return `${yyyy}-${mm}-${dd} ${hh}:${min}${tz ? ` ${tz}` : ""}`;
+    const seconds = displaySeconds && second ? `:${second}` : "";
+    const prefix = displayWeekday ? `${weekday} ` : "";
+    return `${prefix}${year}-${month}-${day} ${hour}:${minute}${seconds}${tz ? ` ${tz}` : ""}`;
   } catch {
     return undefined;
   }

--- a/src/infra/format-time/format-time.test.ts
+++ b/src/infra/format-time/format-time.test.ts
@@ -1,5 +1,6 @@
 // Covers duration, UTC/zoned timestamp, timezone, and relative time formatting.
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { withEnv } from "../../test-utils/env.js";
 import {
   createTimeZoneDayKeyFormatter,
   formatUtcTimestamp,
@@ -185,26 +186,37 @@ describe("format-datetime", () => {
         options: { timeZone: "UTC", displaySeconds: true },
         expected: /2024-01-15 14:30:45/,
       },
+      {
+        date: new Date("2024-01-15T14:30:45.000Z"),
+        options: { timeZone: "UTC", displayWeekday: true },
+        expected: /^Mon 2024-01-15 14:30 UTC$/,
+      },
     ] as const)("formats zoned timestamp", ({ date, options, expected }) => {
       const result = formatZonedTimestamp(date, options);
       expect(result).toMatch(expected);
     });
 
-    it("returns undefined when required Intl parts are missing", () => {
-      function MissingPartsDateTimeFormat() {
-        return {
-          formatToParts: () => [
-            { type: "month", value: "01" },
-            { type: "day", value: "15" },
-            { type: "hour", value: "14" },
-            { type: "minute", value: "30" },
-          ],
-        } as Intl.DateTimeFormat;
+    it("follows host timezone changes while keeping explicit zones fixed", () => {
+      const date = new Date("2024-01-15T14:30:00.000Z");
+      for (const [timezone, expected] of [
+        ["UTC", "2024-01-15 14:30 UTC"],
+        ["America/New_York", "2024-01-15 09:30 EST"],
+        ["UTC", "2024-01-15 14:30 UTC"],
+      ]) {
+        withEnv({ TZ: timezone }, () => {
+          expect(formatZonedTimestamp(date)).toBe(expected);
+          expect(formatZonedTimestamp(date, { timeZone: "UTC" })).toBe("2024-01-15 14:30 UTC");
+        });
       }
+    });
 
-      vi.spyOn(Intl, "DateTimeFormat").mockImplementation(
-        MissingPartsDateTimeFormat as unknown as typeof Intl.DateTimeFormat,
-      );
+    it("returns undefined when required Intl parts are missing", () => {
+      vi.spyOn(Intl.DateTimeFormat.prototype, "formatToParts").mockReturnValue([
+        { type: "month", value: "01" },
+        { type: "day", value: "15" },
+        { type: "hour", value: "14" },
+        { type: "minute", value: "30" },
+      ]);
 
       expect(formatZonedTimestamp(new Date("2024-01-15T14:30:00.000Z"), { timeZone: "UTC" })).toBe(
         undefined,
@@ -212,17 +224,9 @@ describe("format-datetime", () => {
     });
 
     it("returns undefined when Intl formatting throws", () => {
-      function ThrowingDateTimeFormat() {
-        return {
-          formatToParts: () => {
-            throw new Error("boom");
-          },
-        } as unknown as Intl.DateTimeFormat;
-      }
-
-      vi.spyOn(Intl, "DateTimeFormat").mockImplementation(
-        ThrowingDateTimeFormat as unknown as typeof Intl.DateTimeFormat,
-      );
+      vi.spyOn(Intl.DateTimeFormat.prototype, "formatToParts").mockImplementation(() => {
+        throw new Error("boom");
+      });
 
       expect(formatZonedTimestamp(new Date("2024-01-15T14:30:00.000Z"), { timeZone: "UTC" })).toBe(
         undefined,


### PR DESCRIPTION
## Why

Replaying each bare user message constructs two Intl.DateTimeFormat objects to recreate its immutable timestamp prefix. The inbound envelope path repeats the weekday conversion as well. These constructors dominate formatting cost on longer histories.

## Change

Fold weekday rendering into the shared timestamp formatter and retain only the most recent explicit-zone formatter, keyed by timezone and display options. Omitted-zone calls remain uncached because Intl captures the host timezone at construction. Each date is still formatted independently, so DST and historical arrival timestamps remain correct. UTC envelopes keep their existing ISO/Z format and weekday fallback.

Production +59/-68 (net -9); tests +28/-24 (net +4). Existing failure tests now fault the actual formatToParts boundary instead of replacing the constructor with fake objects. No config or cache-reset test seam was added. Release-note context: lower CPU and native allocation overhead when stamping agent history, with unchanged prompt bytes.

## Proof

- 384 existing/extended formatting, envelope, gateway timestamp, cron, LLM-boundary and provider prompt-cache stability tests passed.
- 46,128 native-runtime differential cases passed across425 zones and27 instants, DST, date extremes, BCE, invalid values, display-option transitions and host TZ changes.
- Two fresh-process benchmark orders: New York agent prefixes55.0→3.12 microseconds, explicit-zone seconds31.5→3.17, non-UTC envelopes85.4→28.6. Replaying1,000 same-zone user messages constructs one formatter instead of2,000. Alternating zones still improves about56→31 microseconds. Host-default timestamps and UTC envelopes are unchanged within noise; no end-to-end model latency claim.
- Independent source review clean, structured Codex review scoped-clean, formatting/lint passed. Full build and live OpenAI replay-prefix proof passed: an existing message sent on the baseline and replayed after restart on the candidate retained exactly the same model-visible timestamp/content bytes. Whole diagnostic objects contain different historical metadata, so only the model-visible content is claimed identical. Exact-head CI remains required.

The formatter follows ECMA-402: omitted timezones resolve at construction, while explicit-zone offsets are calculated from each input instant. Reviewed shared callers, envelope/cron/system-event siblings and the native Codex plain-text boundary; no protocol or timestamp-injection policy changes.
