### PR TITLE
fix: include stored session colors in CLI JSON

### DIFF
--- a/docs/cli/sessions.md
+++ b/docs/cli/sessions.md
@@ -51,6 +51,10 @@ for a smaller/larger window or `--limit all` when you intentionally need the
 full store. JSON responses include `totalCount`, `limitApplied`, and `hasMore`
 when callers need to show that more rows exist.
 
+JSON session rows include `color` when a session color is set (for example,
+`"color": "blue"`). Uncolored sessions and sessions whose color was cleared omit
+the field.
+
 RPC clients can pass `configuredAgentsOnly: true` to keep the broad combined
 discovery source but return only rows for agents currently present in config.
 Control UI uses that mode by default so deleted or disk-only agent stores do

--- a/src/commands/sessions-table.ts
+++ b/src/commands/sessions-table.ts
@@ -30,6 +30,7 @@ export type SessionDisplayRow = {
   sessionStartedAt?: number;
   lastInteractionAt?: number;
   label?: string;
+  color?: string;
   status?: SessionEntry["status"];
   visibility?: SessionEntry["visibility"];
   createdActor?: SessionEntry["createdActor"];
@@ -81,6 +82,7 @@ export function toSessionDisplayRow(key: string, entry: SessionEntry): SessionDi
     sessionStartedAt: entry?.sessionStartedAt,
     lastInteractionAt: entry?.lastInteractionAt,
     label: entry?.label,
+    color: entry?.color,
     status: entry?.status,
     visibility: entry?.visibility ?? "shared",
     createdActor: entry?.createdActor,

--- a/src/commands/sessions.test.ts
+++ b/src/commands/sessions.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ExpectedCliError } from "../cli/failure-output.js";
 import {
   assignSessionOwner,
+  patchSessionEntryCore,
   recordSessionParticipant,
 } from "../config/sessions/session-accessor.js";
 import type { SessionEntry } from "../config/sessions/types.js";
@@ -410,7 +411,7 @@ describe("sessionsCommand", () => {
     ]);
   });
 
-  it("exports subagent lineage metadata in JSON output", async () => {
+  it("exports session color and subagent lineage metadata in JSON output", async () => {
     const store = await writeStore({
       "agent:main:child": {
         sessionId: "child-session",
@@ -426,10 +427,22 @@ describe("sessionsCommand", () => {
         sessionStartedAt: Date.now() - 20 * 60_000,
         lastInteractionAt: Date.now() - 5 * 60_000,
         label: "research helper",
+        color: "blue",
         status: "done",
         model: "test:opus",
       },
+      "agent:main:uncolored": { sessionId: "uncolored-session", updatedAt: Date.now() },
+      "agent:main:cleared": {
+        sessionId: "cleared-session",
+        updatedAt: Date.now(),
+        color: "red",
+      },
     });
+    await patchSessionEntryCore(
+      { agentId: "main", sessionKey: "agent:main:cleared", storePath: store },
+      () => ({ color: undefined }),
+      { skipMaintenance: true },
+    );
 
     const payload = await runSessionsJson<{
       sessions?: Array<{
@@ -445,6 +458,7 @@ describe("sessionsCommand", () => {
         sessionStartedAt?: number;
         lastInteractionAt?: number;
         label?: string;
+        color?: string;
         status?: string;
       }>;
     }>(sessionsCommand, store);
@@ -462,9 +476,15 @@ describe("sessionsCommand", () => {
       sessionStartedAt: Date.now() - 20 * 60_000,
       lastInteractionAt: Date.now() - 5 * 60_000,
       label: "research helper",
+      color: "blue",
       status: "done",
     });
     expect(child).not.toHaveProperty("sessionFile");
+    for (const key of ["agent:main:uncolored", "agent:main:cleared"]) {
+      const row = payload.sessions?.find((session) => session.key === key);
+      expect(row).toBeDefined();
+      expect(row).not.toHaveProperty("color");
+    }
   });
 
   it("shows preserved stale totals in JSON output", async () => {


### PR DESCRIPTION
Closes #132961 — CLI session JSON omits stored session colors.
Related: #132570 — per-session colors across clients and imported CLI sessions.

## What Problem This Solves

Fixes an issue where operators listing colored sessions with `openclaw sessions list --json` or `openclaw sessions --json` received no `color` field, even though the stored session and Gateway `sessions.list` response retained it. This prevented CLI consumers from using the colors operators had already set.

## Why This Change Was Made

Carry the existing optional `color` through the shared CLI display-row mapper alongside `label`. The SQLite accessor already preserves color, including its lightweight list projection; the value was discarded only when creating the CLI row. No schema migration, promoted column, extra database read, config option, or new compatibility path is needed.

The repair keeps the explicit public row shape rather than spreading full session entries into JSON. Gateway projection and terminal/cleanup formatting are unchanged.

## User Impact

Colored sessions now include their named color in CLI JSON. Never-colored sessions and sessions whose color was cleared continue to omit the field. Both explicit `sessions list` and shorthand `sessions` use the repaired path. The CLI reference documents that optional-field behavior.

## Evidence

- Extended the existing SQLite-backed CLI metadata regression: it failed before the production change because expected `"color": "blue"` was missing, then passed after the fix. The same case verifies never-colored and cleared rows exist without a color property.
- Focused command, shared-table, and cleanup tests passed: **40 tests across 3 files**.
- Real dist-backed CLI proof used seven synthetic sessions in an isolated home/config/state directory: five named colors plus never-colored and cleared rows. Before: **0 color fields**. After: **5 correct color fields** (`red`, `green`, `yellow`, `blue`, `purple`). All other fields matched except elapsed `ageMs`; both CLI invocation forms matched.
- Independently reran the built CLI and verified all five colors plus omission for the two colorless rows.
- Changed-scope checks passed, including core/test typechecks, lint, formatting, and applicable guards. Codex autoreview completed scoped-clean with no accepted/actionable findings.
- Complete `pnpm build` passed on the baseline; the supported development wrapper rebuilt the changed runtime before candidate CLI proof. No operator Gateway, live state, or credentials were used.

Exact focused commands:

```bash
node scripts/run-vitest.mjs src/commands/sessions.test.ts -t 'exports session color and subagent lineage metadata'
node scripts/run-vitest.mjs src/commands/sessions.test.ts src/commands/sessions-table.test.ts src/commands/sessions-cleanup.test.ts
node scripts/check-changed.mjs -- src/commands/sessions-table.ts src/commands/sessions.test.ts docs/cli/sessions.md
```

Representative JSON excerpt:

```json
{"before":{"label":"Proof blue"},"after":{"label":"Proof blue","color":"blue"}}
```

Production LOC: **+2/-0 (net +2)**; tests: **+21/-1 (net +20)**; docs: **+4/-0**. The two production lines are the field declaration and assignment in the existing mapper; reducing them would require unrelated deletion or broadening the serialized shape.

Provenance: the raw parent-to-commit patch for the original color feature (`a9978c1c6edd570b8bbe34c7276df54aabcf639b`) adds the session field and Gateway projection but does not touch the CLI mapper. This fixes missing CLI wiring on current main, not a demonstrated regression from a published release.

AI-assisted. No new dependencies, config, protocol, or persistence contract changes.

Exact-head hosted CI: [run 33285720816](https://github.com/openclaw/openclaw/actions/runs/33285720816) completed successfully for `30c69a3e3e42d7682d7a7b927f242fa823bab60f`. The repository watcher confirmed `GREEN` using `--completion ci-run`.
