### PR TITLE
test(qa): observe lease heartbeat event order

### DIFF
--- a/extensions/qa-lab/src/gateway-startup-lease.integration.test.ts
+++ b/extensions/qa-lab/src/gateway-startup-lease.integration.test.ts
@@ -441,14 +441,13 @@ describe.skipIf(process.platform === "win32")(
           (event) => event.kind === "transport-after-gateway-stop",
         );
         const rejected = result.events.findIndex((event) => event.kind === "suite-rejected");
+        expect(rejected).toBeGreaterThan(-1);
         if (denyGroupSignals) {
           expect(afterCleanup).toBe(-1);
           expect(result.releases).toEqual([]);
           expect(
-            result.events.some(
-              (event) => event.kind === "lease-heartbeat" && event.at > result.events[rejected]!.at,
-            ),
-          ).toBe(true);
+            result.events.findLastIndex((event) => event.kind === "lease-heartbeat"),
+          ).toBeGreaterThan(rejected);
         } else {
           expect(result.releases.length).toBeGreaterThan(0);
           expect(result.releases.every((release) => !release.groupAlive)).toBe(true);


### PR DESCRIPTION
## Why

The real-process startup lease test already waits for a heartbeat appended after suite rejection, but its final assertion also requires that heartbeat's wall-clock timestamp to be greater. Ordered events can share a millisecond, and wall clocks can move. This redundant oracle falsely failed an otherwise completed QA shard in [this job](https://github.com/openclaw/openclaw/actions/runs/33285125485/job/99186983079).

## Change

Require the rejection event to exist, then compare the last heartbeat's event index with the rejection index, matching the test's other lifecycle-order assertions. Keep the real process groups, heartbeat-count barrier, zero release after denied shutdown, descendant checks, final cleanup and all existing timeouts unchanged.

Production delta0; tests+3/-4 (net-1). This removes a false failure that wastes a whole shard rerun; no throughput claim or production behavior change.

## Proof

All four existing real-process Gateway/bootstrap and permitted/denied shutdown cases passed (28.81 seconds including imports). Structured Codex review was scoped-clean; independent investigation and parent source review verified the producer and cleanup ownership. Formatting/diff checks pass.

The original job reports3140 passing tests and this one final assertion failure. Its earlier post-rejection heartbeat-count barrier had passed, proving a later append existed. The exact same-millisecond versus clock-adjustment cause cannot be distinguished without the job's unuploaded events artifact; no claim is made to have observed those timestamps. The original assertion was verified in raw parent-to-commit history for6e6a0e59fde and remains on current main.
