### PR TITLE
improve(test): reduce sandbox fixture startup work

### DIFF
--- a/src/agents/sandbox/docker.config-hash-recreate.test.ts
+++ b/src/agents/sandbox/docker.config-hash-recreate.test.ts
@@ -3,7 +3,7 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
 import {
   computeSandboxConfigHash,
@@ -171,7 +171,7 @@ let ensureSandboxContainer: typeof import("./docker.js").ensureSandboxContainer;
 let resolveDockerEnvPolicyEpoch: typeof import("./docker.js").resolveDockerEnvPolicyEpoch;
 let PODMAN_SANDBOX_ENGINE: typeof import("./docker.js").PODMAN_SANDBOX_ENGINE;
 
-async function loadFreshDockerModuleForTest() {
+beforeAll(async () => {
   vi.resetModules();
   vi.doMock("./registry.js", () => ({
     readRegistryEntry: registryMocks.readRegistryEntry,
@@ -184,7 +184,14 @@ async function loadFreshDockerModuleForTest() {
   }));
   ({ ensureSandboxContainer, resolveDockerEnvPolicyEpoch, PODMAN_SANDBOX_ENGINE } =
     await import("./docker.js"));
-}
+});
+
+afterAll(() => {
+  vi.doUnmock("./registry.js");
+  vi.doUnmock("../../process/exec.js");
+  vi.doUnmock("../../runtime.js");
+  vi.resetModules();
+});
 
 function createSandboxConfig(
   dns: string[],
@@ -263,7 +270,7 @@ async function ensureSandboxCreateCallForTest(params: {
 }
 
 describe("ensureSandboxContainer config-hash recreation", () => {
-  beforeEach(async () => {
+  beforeEach(() => {
     spawnState.calls.length = 0;
     spawnState.containerExists = true;
     spawnState.inspectRunning = true;
@@ -278,7 +285,6 @@ describe("ensureSandboxContainer config-hash recreation", () => {
     registryMocks.updateRegistry.mockClear();
     registryMocks.updateRegistry.mockResolvedValue(undefined);
     runtimeMocks.log.mockClear();
-    await loadFreshDockerModuleForTest();
   });
 
   it("serializes concurrent provisioning for one container", async () => {

--- a/src/agents/sandbox/docker.config-hash-recreate.test.ts
+++ b/src/agents/sandbox/docker.config-hash-recreate.test.ts
@@ -3,7 +3,7 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
 import {
   computeSandboxConfigHash,
@@ -184,13 +184,6 @@ beforeAll(async () => {
   }));
   ({ ensureSandboxContainer, resolveDockerEnvPolicyEpoch, PODMAN_SANDBOX_ENGINE } =
     await import("./docker.js"));
-});
-
-afterAll(() => {
-  vi.doUnmock("./registry.js");
-  vi.doUnmock("../../process/exec.js");
-  vi.doUnmock("../../runtime.js");
-  vi.resetModules();
 });
 
 function createSandboxConfig(

--- a/src/agents/sandbox/docker.test.ts
+++ b/src/agents/sandbox/docker.test.ts
@@ -1,6 +1,6 @@
 // Docker image tests cover sandbox image inspection and actionable setup errors
 // without invoking a real Docker daemon.
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { withEnvAsync } from "../../test-utils/env.js";
 import { DEFAULT_SANDBOX_IMAGE, SANDBOX_COMMAND_MAX_BUFFER_BYTES } from "./constants.js";
 
@@ -101,7 +101,7 @@ let podmanSandboxEngine: typeof import("./docker.js").PODMAN_SANDBOX_ENGINE;
 let resolvePodmanSandboxRuntimeInfo: typeof import("./docker.js").resolvePodmanSandboxRuntimeInfo;
 let validateSandboxContainerEngineTarget: typeof import("./docker.js").validateSandboxContainerEngineTarget;
 
-async function loadFreshDockerModuleForTest() {
+beforeAll(async () => {
   vi.resetModules();
   vi.doMock("../../process/exec.js", async (importOriginal) => ({
     ...(await importOriginal<typeof import("../../process/exec.js")>()),
@@ -112,16 +112,33 @@ async function loadFreshDockerModuleForTest() {
   resolvePodmanSandboxRuntimeInfo = dockerModule.resolvePodmanSandboxRuntimeInfo;
   validateSandboxContainerEngineTarget = dockerModule.validateSandboxContainerEngineTarget;
   podmanSandboxEngine = dockerModule.PODMAN_SANDBOX_ENGINE;
-}
+});
+
+afterAll(() => {
+  vi.doUnmock("../../process/exec.js");
+  vi.resetModules();
+});
+
+beforeEach(() => {
+  // Hoisted fault state survives module resets and must not reach the next case.
+  spawnState.calls.length = 0;
+  spawnState.imageExists = true;
+  spawnState.inspectError = "";
+  spawnState.infoAvailable.docker = false;
+  spawnState.infoAvailable.podman = false;
+  spawnState.podmanConnections = "[]\n";
+  spawnState.podmanInfo = "true\tfalse\t\t5.0.0\n";
+  spawnState.podmanMachines = "[]\n";
+  spawnState.lastOptions = undefined;
+  spawnState.executionError = undefined;
+  spawnState.transportFailure = false;
+  spawnState.transportExitCode = 0;
+  spawnState.plainExitWithoutStderr = false;
+});
 
 describe("resolvePodmanSandboxRuntimeInfo", () => {
-  beforeEach(async () => {
-    spawnState.calls.length = 0;
+  beforeEach(() => {
     spawnState.infoAvailable.podman = true;
-    spawnState.podmanConnections = "[]\n";
-    spawnState.podmanInfo = "true\tfalse\t\t5.0.0\n";
-    spawnState.podmanMachines = "[]\n";
-    await loadFreshDockerModuleForTest();
   });
 
   it("rejects an arbitrary remote Podman connection", async () => {
@@ -376,18 +393,6 @@ describe("resolvePodmanSandboxRuntimeInfo", () => {
 });
 
 describe("ensureDockerImage", () => {
-  beforeEach(async () => {
-    spawnState.calls.length = 0;
-    spawnState.imageExists = true;
-    spawnState.inspectError = "";
-    spawnState.lastOptions = undefined;
-    spawnState.executionError = undefined;
-    spawnState.transportFailure = false;
-    spawnState.transportExitCode = 0;
-    spawnState.plainExitWithoutStderr = false;
-    await loadFreshDockerModuleForTest();
-  });
-
   it("returns when the configured image already exists", async () => {
     await ensureDockerImage(DEFAULT_SANDBOX_IMAGE);
 
@@ -474,17 +479,6 @@ describe("ensureDockerImage", () => {
 });
 
 describe("execDockerRaw", () => {
-  beforeEach(async () => {
-    spawnState.calls.length = 0;
-    spawnState.imageExists = true;
-    spawnState.inspectError = "";
-    spawnState.lastOptions = undefined;
-    spawnState.executionError = undefined;
-    spawnState.transportFailure = false;
-    spawnState.transportExitCode = 0;
-    await loadFreshDockerModuleForTest();
-  });
-
   it("preserves canonical wrapper execution errors", async () => {
     spawnState.executionError = new Error("docker execution failed");
 

--- a/src/agents/sandbox/docker.test.ts
+++ b/src/agents/sandbox/docker.test.ts
@@ -1,6 +1,6 @@
 // Docker image tests cover sandbox image inspection and actionable setup errors
 // without invoking a real Docker daemon.
-import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { withEnvAsync } from "../../test-utils/env.js";
 import { DEFAULT_SANDBOX_IMAGE, SANDBOX_COMMAND_MAX_BUFFER_BYTES } from "./constants.js";
 
@@ -112,11 +112,6 @@ beforeAll(async () => {
   resolvePodmanSandboxRuntimeInfo = dockerModule.resolvePodmanSandboxRuntimeInfo;
   validateSandboxContainerEngineTarget = dockerModule.validateSandboxContainerEngineTarget;
   podmanSandboxEngine = dockerModule.PODMAN_SANDBOX_ENGINE;
-});
-
-afterAll(() => {
-  vi.doUnmock("../../process/exec.js");
-  vi.resetModules();
 });
 
 beforeEach(() => {


### PR DESCRIPTION
## What Problem This Solves

Sandbox tests repeatedly evaluate the same Docker/Podman module graph across 61 cases. The fixture also leaks a hoisted execution-error flag between suites: shuffling the existing cases with seed 17 makes ten Podman cases fail.

## Why This Change Was Made

Load one fresh module graph per file, retain every per-case scenario reset, and leave cross-file cleanup with the existing Vitest runner. Consolidate all spawn-state resets in the image/engine test so fault flags cannot leak between suites. This removes 59 redundant graph evaluations without changing case bodies or assertions.

The production provisioning queue already removes settled and rejected tasks, and every provisioning call remains awaited. Real environment-file creation, reads and deletion, bind validation, concurrent provisioning and rejection behavior stay covered. No production, dependency, sharding, worker-count or timeout change. Production LOC delta: zero; test delta: +25/-37.

## User Impact

Faster developer test execution and order-independent sandbox fixtures. There is no runtime behavior change.

## Evidence

Two final alternating warm before/after pairs passed the same 61 expanded cases. Complete Vitest test phase, including setup hooks: 6.75 → 5.28 seconds and 6.60 → 5.28 seconds (20–22% faster). Earlier samples had larger cold-start/host-load effects; these final figures are the conservative focused local result, not a whole-CI speed claim.

The unchanged image/engine tests with `--sequence.shuffle --sequence.seed=17` failed 10/21 on the baseline and passed 21/21 after the complete hoisted-state reset. No new mock boundary or production test API was introduced. Codex autoreview found no blocking findings.

The same 158 changed-and-sibling tests passed in normal order and shuffled with seed 17, using one worker to check cross-file isolation. All existing assertions remain intact.

The initial local changed-file gate caught the recreation test exceeding its lint limit by three lines. Removing redundant newly-added teardown keeps cleanup at `OpenClawNonIsolatedRunner.onAfterRunFiles`, which drains pending mocks and clears modules/registries even after collection failure. Both changed-file lint commands passed; no lint-limit change or suppression.
