### PR TITLE
test: avoid cold CLI fixture catalog discovery

### DIFF
--- a/src/auto-reply/reply/agent-runner-execution.test-support.ts
+++ b/src/auto-reply/reply/agent-runner-execution.test-support.ts
@@ -492,12 +492,18 @@ export function createFollowupRun(): FollowupRun {
       skillsSnapshot: {},
       provider: "anthropic",
       model: "claude",
+      // Missing fixture modalities trigger real provider catalog discovery during execution.
       thinkingCatalog: [
         { provider: "anthropic", id: "claude", input: ["text"] },
+        { provider: "anthropic", id: "claude-opus-4-7", input: ["text", "image"] },
+        { provider: "claude-cli", id: "sonnet-4.6", input: ["text", "image"] },
         { provider: "claude-cli", id: "claude-sonnet-4-6", input: ["text", "image"] },
+        { provider: "claude-cli", id: "claude-opus-4-6", input: ["text", "image"] },
+        { provider: "claude-cli", id: "claude-opus-4-7", input: ["text", "image"] },
         { provider: "claude-cli", id: "claude-opus-5", input: ["text", "image"] },
         { provider: "claude-cli", id: "claude-opus-4-8", input: ["text", "image"] },
         { provider: "codex-cli", id: "gpt-5.4", input: ["text", "image"] },
+        { provider: "codex-cli", id: "gpt-5.5", input: ["text", "image"] },
       ],
       verboseLevel: "off",
       elevatedLevel: "off",


### PR DESCRIPTION
Related: #132960

## What Problem This Solves

Resolves cold-start timeouts in the CLI progress and commentary tests. Their shared execution fixture omitted model input metadata for routes the tests select, causing normal vision-capability lookup to load the real provider catalog during the first turn.

## Why This Change Was Made

Complete the existing prepared fixture catalog for the five affected routes. Keep modality facts with their fixture producer, preserving the dynamic execution getter, real execution paths, ordering assertions, and deadlines. No new mock, preload, retry, helper, or production branch is needed.

This follow-up carries the review improvement after #132960 merged while verification was running.

## User Impact

More reliable test execution; no application behavior changes. Production LOC +0/-0; test-support LOC +6/-0. No configuration, schema, dependency, or public-contract changes.

## Evidence

At #132960's original head, a fresh process running the progress and commentary suites failed 2/18 tests: both first cases exceeded their 120-second deadlines (about 139 seconds observed). The progress case uses mocked CLI events; commentary invokes a real local scripted JSONL subprocess.

After completing model metadata, a new empty Vitest module-cache directory produced 18/18 passing tests in 51.57 seconds, with the first cases completing in 32.59 and 34.66 seconds. No deadline or assertion changed.

```sh
node scripts/run-vitest.mjs src/auto-reply/reply/agent-runner-execution-cli-commentary.test.ts src/auto-reply/reply/agent-runner-execution-cli-progress.test.ts
```

The completed fixture passed all 40 affected test files (723 tests), covering all 31 shared-factory consumer suites, module-reset integration, session handoff, channel behavior, boot lifecycle, and temp-directory cleanup. Changed-file checks passed. Fresh Codex autoreview found no actionable findings within its configured review scope; independent source review also checked the sibling routes and cleanup ordering.

The final six-line patch is unchanged when applied to current main; the fixture and affected execution/cold-test modules are identical to the tested baseline. Exact-head hosted CI will gate landing.
