### PR TITLE
perf(web): reuse published config cache keys

### DIFF
--- a/src/web-fetch/runtime.test.ts
+++ b/src/web-fetch/runtime.test.ts
@@ -1,5 +1,6 @@
 /** Tests web_fetch runtime provider selection, credential discovery, and sandbox filtering. */
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { setRuntimeConfigSnapshot } from "../config/runtime-snapshot.js";
 import type { OpenClawConfig } from "../config/types.js";
 import type { PluginWebFetchProviderEntry } from "../plugins/types.js";
 import type { RuntimeWebFetchMetadata } from "../secrets/runtime-web-tools.types.js";
@@ -286,26 +287,38 @@ describe("web fetch runtime", () => {
     expect(resolvePluginWebFetchProvidersMock).toHaveBeenCalledTimes(2);
   });
 
-  it("invalidates provider discovery when the same config object changes", () => {
-    const firecrawl = createFirecrawlProvider({
-      getConfiguredCredentialValue: () => "firecrawl-key",
-    });
-    const external = createThirdPartyFetchProvider();
-    resolvePluginWebFetchProvidersMock
-      .mockReturnValueOnce([firecrawl])
-      .mockReturnValueOnce([external]);
-    const config = {
-      tools: { web: { fetch: { provider: "firecrawl" } } },
-    } as OpenClawConfig & { tools: { web: { fetch: { provider: string } } } };
+  it.each(["detached", "published"])(
+    "invalidates provider discovery when the same %s config object changes",
+    (mode) => {
+      const firecrawl = createFirecrawlProvider({
+        getConfiguredCredentialValue: () => "firecrawl-key",
+      });
+      const external = createThirdPartyFetchProvider();
+      resolvePluginWebFetchProvidersMock
+        .mockReturnValueOnce([firecrawl])
+        .mockReturnValueOnce([external]);
+      const config = {
+        tools: { web: { fetch: { provider: "firecrawl" } } },
+      } as OpenClawConfig & { tools: { web: { fetch: { provider: string } } } };
+      const resolveProvider = () =>
+        requireResolvedWebFetch(resolveWebFetchDefinition({ config })).provider.id;
 
-    const first = requireResolvedWebFetch(resolveWebFetchDefinition({ config }));
-    config.tools.web.fetch.provider = "thirdparty";
-    const second = requireResolvedWebFetch(resolveWebFetchDefinition({ config }));
+      if (mode === "published") {
+        setRuntimeConfigSnapshot(config);
+      }
+      expect(resolveProvider()).toBe("firecrawl");
+      expect(resolveProvider()).toBe("firecrawl");
+      expect(resolvePluginWebFetchProvidersMock).toHaveBeenCalledTimes(1);
 
-    expect(first.provider.id).toBe("firecrawl");
-    expect(second.provider.id).toBe("thirdparty");
-    expect(resolvePluginWebFetchProvidersMock).toHaveBeenCalledTimes(2);
-  });
+      config.tools.web.fetch.provider = "thirdparty";
+      if (mode === "published") {
+        setRuntimeConfigSnapshot(config);
+      }
+      expect(resolveProvider()).toBe("thirdparty");
+      expect(resolveProvider()).toBe("thirdparty");
+      expect(resolvePluginWebFetchProvidersMock).toHaveBeenCalledTimes(2);
+    },
+  );
 
   it("evicts superseded provider discovery cache entries", () => {
     const firstFirecrawl = createFirecrawlProvider({

--- a/src/web-fetch/runtime.ts
+++ b/src/web-fetch/runtime.ts
@@ -1,6 +1,6 @@
 /** Runtime provider selection and tool construction for the `web_fetch` tool. */
-import { createHash } from "node:crypto";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
+import { resolveRuntimeConfigCacheKey } from "../config/runtime-snapshot.js";
 import type { OpenClawConfig } from "../config/types.js";
 import { logVerbose } from "../globals.js";
 import { getActivePluginRegistryVersion } from "../plugins/runtime.js";
@@ -201,10 +201,6 @@ function resolveWebFetchProviderCacheKey(
   ]);
 }
 
-function createWebFetchProviderConfigFingerprint(config: OpenClawConfig): string {
-  return createHash("sha256").update(JSON.stringify(config)).digest("hex");
-}
-
 function resolveCachedWebFetchProviders(params: {
   cacheKey: string;
   config: OpenClawConfig;
@@ -233,13 +229,6 @@ export function clearWebFetchRuntimeCachesForTest(): void {
   webFetchProviderCache = new WeakMap();
 }
 
-/** Resolves the executable web_fetch provider tool definition. */
-export function resolveWebFetchDefinition(
-  options?: ResolveWebFetchDefinitionParams,
-): WebFetchDefinitionResolution {
-  return resolveWebFetchDefinitionUncached(options);
-}
-
 function resolveWebFetchProvidersForOptions(
   options?: ResolveWebFetchDefinitionParams,
 ): PluginWebFetchProviderEntry[] {
@@ -262,14 +251,15 @@ function resolveWebFetchProvidersForOptions(
     return resolveCachedWebFetchProviders({
       config: options.config,
       cacheKey: resolveWebFetchProviderCacheKey(options),
-      configFingerprint: createWebFetchProviderConfigFingerprint(options.config),
+      configFingerprint: resolveRuntimeConfigCacheKey(options.config),
       load,
     });
   }
   return load();
 }
 
-function resolveWebFetchDefinitionUncached(
+/** Resolves the executable web_fetch provider tool definition. */
+export function resolveWebFetchDefinition(
   options?: ResolveWebFetchDefinitionParams,
 ): WebFetchDefinitionResolution {
   const fetch = resolveWebProviderConfig(options?.config, "fetch") as


### PR DESCRIPTION
## Why

The web-fetch provider cache serializes and hashes the entire config on every lookup, even when the config is the active published runtime snapshot whose revision and fingerprint are already known.

## Change

Use the canonical runtime-config cache key and remove the passthrough uncached resolver wrapper. Keep the config WeakMap, registry/sandbox/runtime-preference dimensions, empty-result retries and per-call tool construction. Detached mutable configs still content-hash; active configs invalidate through their publication owner, including republication of the same object.

Production +4/-14 (net -10), tests +33/-20 (net +13, extending the existing mutation case into a detached/published table). No new setting, cache policy, schema or provider contract. Release-note context: avoid redundant config hashing during web-fetch provider resolution.

## Verification

- 54 existing/extended runtime-selection, runtime-snapshot, provider-discovery and fallback tests passed. The lifecycle test verifies real snapshot republication, provider selection changes and cache reuse on both sides.
- For a 210,475-byte synthetic config, active-key computation dropped from 0.206 ms to below 0.001 ms. This is key-only CPU evidence, not network/tool/Gateway latency; no detached-path speedup claim.
- Complete config publication/clear/preparer owners, web-fetch caller/fallback, provider ordering and web-search sibling reviewed. Independent source review and structured Codex review are clean; format/lint/diff checks pass.
- Full build passed in 2m45.6s; exact-head CI is green.
- Real isolated before/candidate fallback fetches both return 19,803 characters with identical normalized payloads and full spill bytes (SHA-256 `a261b8cb963501a4d6b814691573dd0e78f4927972ba01f58cd1da716efbbdd6`). Only measured duration/fetchedAt, paired outer untrusted-content IDs and task spill path/footer are excluded; page text and every other field remain compared. Both private spill files were readable.
- A real OpenAI turn completed one successful web-fetch call and answered PerformanceObserver. The disabled readability plugin makes this HTML flow reach provider fallback resolution before basic extraction. No network/model latency claim.

The automated stored-data classifier is not applicable: this is a process-local WeakMap key, with no persisted format, schema version, migration or upgrade-data change. The review's build/live/CI Rank-up move is complete.
