### PR TITLE
improve(test): speed up Teams parent-context tests

### DIFF
--- a/extensions/msteams/src/thread-parent-context.test.ts
+++ b/extensions/msteams/src/thread-parent-context.test.ts
@@ -1,5 +1,5 @@
 // Msteams tests cover thread parent context plugin behavior.
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { GraphThreadMessage } from "./graph-thread.js";
 
 let fetchParentMessageCached: typeof import("./thread-parent-context.js").fetchParentMessageCached;
@@ -8,7 +8,7 @@ let markParentContextInjected: typeof import("./thread-parent-context.js").markP
 let shouldInjectParentContext: typeof import("./thread-parent-context.js").shouldInjectParentContext;
 let summarizeParentMessage: typeof import("./thread-parent-context.js").summarizeParentMessage;
 
-beforeEach(async () => {
+async function loadParentContextModule() {
   vi.resetModules();
   ({
     fetchParentMessageCached,
@@ -17,7 +17,10 @@ beforeEach(async () => {
     shouldInjectParentContext,
     summarizeParentMessage,
   } = await import("./thread-parent-context.js"));
-});
+}
+
+// Formatting is stateless; only the cache and dedupe suites need per-case imports.
+beforeAll(loadParentContextModule);
 
 // Matches an unpaired UTF-16 surrogate (lone high or lone low), without relying
 // on the ES2024 String.prototype.isWellFormed() runtime API.
@@ -120,6 +123,8 @@ describe("formatParentContextEvent", () => {
 });
 
 describe("fetchParentMessageCached", () => {
+  beforeEach(loadParentContextModule);
+
   afterEach(() => {
     vi.useRealTimers();
   });
@@ -238,6 +243,8 @@ describe("fetchParentMessageCached", () => {
 });
 
 describe("shouldInjectParentContext / markParentContextInjected", () => {
+  beforeEach(loadParentContextModule);
+
   it("returns true for first observation", () => {
     expect(shouldInjectParentContext("session-1", "parent-1")).toBe(true);
   });


### PR DESCRIPTION
## What Problem This Solves

The Teams parent-context tests reload their full module graph before all 21 cases, including ten stateless formatting and summarization cases.

## Why This Change Was Made

Keep a fresh module for every cache and deduplication case, while sharing one initial import for the pure formatting cases. The complete file performs 12 graph evaluations instead of 21. This restores the isolation scope used before removal of the production-only-for-tests cache reset helper, without reintroducing that API.

All case bodies, assertions, fake-timer cleanup and stateful reloads are unchanged. No production, mock boundary, dependency, sharding, concurrency or timeout change. Production LOC delta: zero; test delta: +10/-3.

## User Impact

Faster execution of the complete Teams parent-context test file, with no runtime behavior change. A narrowly filtered single stateful case can incur one extra initial import; the improvement is measured on the unchanged full file.

## Evidence

Two final alternating warm local pairs passed the same 21 expanded cases. Complete Vitest test phase, including setup hooks: 3.40 → 2.53 seconds and 3.05 → 2.61 seconds (14–26% faster). Earlier samples had larger cold-start/host-load effects; these final figures are the conservative focused local result, not a whole-CI speed claim.

History was verified against the raw parent and patch of 6d3eff97a0d555ee2d00af08eae6a12c0716a2e3: the old reset helper was scoped to the two stateful suites before the replacement import hook became file-global. Codex autoreview found no blocking findings.

The same 55 changed-and-sibling tests passed in normal order and shuffled with seed 83, using one worker to check cross-file isolation. All existing assertions remain intact.

All 23 changed-file checks passed, including core/plugin test type checks, lint, formatting and boundary guards.
